### PR TITLE
Add link to CuPy repository

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -2,7 +2,7 @@
 CuPy -- NumPy-like API accelerated with CUDA
 ============================================
 
-This is the CuPy documentation.
+This is the `CuPy <https://github.com/cupy/cupy>`_ documentation.
 
 .. module:: cupy
 


### PR DESCRIPTION
This PR adds the link to the official repository to the top page of the readthedocs