### PR TITLE
Fix format to pass autopep8

### DIFF
--- a/cupy/sorting/count.py
+++ b/cupy/sorting/count.py
@@ -14,6 +14,7 @@ def count_nonzero(x):
 
     return int(_count_nonzero(x))
 
+
 _count_nonzero = core.create_reduction_func(
     'cupy_count_nonzero',
     ('?->l', 'B->l', 'h->l', 'H->l', 'i->l', 'I->l', 'l->l', 'L->l',

--- a/cupy/sorting/search.py
+++ b/cupy/sorting/search.py
@@ -118,6 +118,7 @@ def where(condition, x=None, y=None):
 
     return _where_ufunc(condition.astype('?'), x, y)
 
+
 _where_ufunc = core.create_ufunc(
     'cupy_where',
     ('???->?', '?bb->b', '?BB->B', '?hh->h', '?HH->H', '?ii->i', '?II->I',

--- a/tests/cupy_tests/test_init.py
+++ b/tests/cupy_tests/test_init.py
@@ -10,6 +10,7 @@ class TestImportError(unittest.TestCase):
         except Exception as e:
             self.assertIsInstance(e, RuntimeError)
 
+
 # This is copied from chainer/testing/__init__.py, so should be replaced in
 # some way.
 if __name__ == '__main__':


### PR DESCRIPTION
This PR fixes the format of some code in CuPy, which has [autopep8 failure in Travis](https://travis-ci.org/cupy/cupy/jobs/210055674).