### PR TITLE
Use NVRTC instead of NVCC to compile kernels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ build
 .eggs/
 _readthedocs_build
 chainer.egg-info/
+cupy.egg-info/
 dist/
 htmlcov/
 .idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,7 @@ install:
   - pip install dist/*.tar.gz
   - pip install nose hacking mock
   - pip install autopep8
+  - pip install pynvrtc
 
 script:
   - flake8 --config=.flake8.cython

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Minimum requirements:
 
 Requirements for some features:
 - CUDA support
-  - CUDA 6.5, 7.0, 7.5, 8.0
+  - CUDA 7.0, 7.5, 8.0
   - filelock
   - g++ 4.8.4+
 - cuDNN support

--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -83,12 +83,7 @@ def compile_with_cache(source, options=(), arch=None, cache_dir=None):
     if arch is None:
         arch = _get_arch()
 
-    # if 'win32' == sys.platform:
-    #     options += ('-Xcompiler', '/wd 4819')
-    #     if sys.maxsize == 9223372036854775807:
-    #         options += '-m64',
-    #     elif sys.maxsize == 2147483647:
-    #         options += '-m32',
+    options += ('-ftz=true')
 
     env = (arch, options, _get_nvrtc_version())
     if '#include' in source:

--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -5,28 +5,29 @@ import subprocess
 import sys
 import tempfile
 
-import filelock
 import six
 
+import filelock
 from cupy.cuda import device
 from cupy.cuda import function
+from pynvrtc.compiler import NVRTCInterface
+from pynvrtc.compiler import Program
+
+_nvrtc_version = None
 
 
-_nvcc_version = None
+def _get_nvrtc_version():
+    global _nvrtc_version
+    if _nvrtc_version is None:
+        interface = NVRTCInterface()
+        _nvrtc_version = interface.nvrtcVersion()
 
-
-def _get_nvcc_version():
-    global _nvcc_version
-    if _nvcc_version is None:
-        cmd = ['nvcc', '--version']
-        _nvcc_version = _run_nvcc(cmd, '.')
-
-    return _nvcc_version
+    return _nvrtc_version
 
 
 def _get_arch():
     cc = device.Device().compute_capability
-    return 'sm_%s' % cc
+    return 'compute_%s' % cc
 
 
 class TemporaryDirectory(object):
@@ -44,55 +45,27 @@ class TemporaryDirectory(object):
         os.rmdir(self.path)
 
 
-def _run_nvcc(cmd, cwd):
-    try:
-        return subprocess.check_output(cmd, cwd=cwd, stderr=subprocess.STDOUT)
-    except subprocess.CalledProcessError as e:
-        msg = ('`nvcc` command returns non-zero exit status. \n'
-               'command: {0}\n'
-               'return-code: {1}\n'
-               'stdout/stderr: \n'
-               '{2}'.format(e.cmd, e.returncode, e.output))
-        raise RuntimeError(msg)
-    except OSError as e:
-        msg = 'Failed to run `nvcc` command. ' \
-              'Check PATH environment variable: ' \
-              + str(e)
-        raise OSError(msg)
-
-
-def nvcc(source, options=(), arch=None):
+def nvrtc(source, options=(), arch=None):
     if not arch:
         arch = _get_arch()
-    cmd = ['nvcc', '--cubin', '-arch', arch] + list(options)
 
     with TemporaryDirectory() as root_dir:
         path = os.path.join(root_dir, 'kern')
         cu_path = '%s.cu' % path
-        cubin_path = '%s.cubin' % path
+        ptx_path = '%s.ptx' % path
 
         with open(cu_path, 'w') as cu_file:
             cu_file.write(source)
 
-        cmd.append(cu_path)
-        _run_nvcc(cmd, root_dir)
+        prog = Program(six.b(source), six.b(os.path.basename(cu_path)))
+        ptx = prog.compile([six.b('-arch={}'.format(arch))])
 
-        with open(cubin_path, 'rb') as bin_file:
-            return bin_file.read()
+        return six.b(ptx)
 
 
 def preprocess(source, options=()):
-    cmd = ['nvcc', '--preprocess'] + list(options)
     with TemporaryDirectory() as root_dir:
-        path = os.path.join(root_dir, 'kern')
-        cu_path = '%s.cu' % path
-
-        with open(cu_path, 'w') as cu_file:
-            cu_file.write(source)
-
-        cmd.append(cu_path)
-        pp_src = _run_nvcc(cmd, root_dir)
-
+        pp_src = Program(six.b(source), six.b('')).compile()
         if isinstance(pp_src, six.binary_type):
             pp_src = pp_src.decode('utf-8')
         return re.sub('(?m)^#.*$', '', pp_src)
@@ -115,14 +88,14 @@ def compile_with_cache(source, options=(), arch=None, cache_dir=None):
     if arch is None:
         arch = _get_arch()
 
-    if 'win32' == sys.platform:
-        options += ('-Xcompiler', '/wd 4819')
-        if sys.maxsize == 9223372036854775807:
-            options += '-m64',
-        elif sys.maxsize == 2147483647:
-            options += '-m32',
+    # if 'win32' == sys.platform:
+    #     options += ('-Xcompiler', '/wd 4819')
+    #     if sys.maxsize == 9223372036854775807:
+    #         options += '-m64',
+    #     elif sys.maxsize == 2147483647:
+    #         options += '-m32',
 
-    env = (arch, options, _get_nvcc_version())
+    env = (arch, options, _get_nvrtc_version())
     if '#include' in source:
         pp_src = '%s %s' % (env, preprocess(source, options))
     else:
@@ -153,7 +126,7 @@ def compile_with_cache(source, options=(), arch=None, cache_dir=None):
                 cubin = file.read()
         else:
             lock.release()
-            cubin = nvcc(source, options, arch)
+            cubin = nvrtc(source, options, arch)
             lock.acquire()
             with open(path, 'wb') as cubin_file:
                 cubin_file.write(cubin)

--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -46,6 +46,8 @@ def nvrtc(source, options=(), arch=None):
     if not arch:
         arch = _get_arch()
 
+    options += ('-arch{}'.format(arch),)
+
     with TemporaryDirectory() as root_dir:
         path = os.path.join(root_dir, 'kern')
         cu_path = '%s.cu' % path
@@ -54,8 +56,8 @@ def nvrtc(source, options=(), arch=None):
             cu_file.write(source)
 
         prog = Program(six.b(source), six.b(os.path.basename(cu_path)))
-        ptx = prog.compile([six.b('-arch={}'.format(arch))])
-
+        ptx = prog.compile([six.b(o) for o in options])
+                                        
         return six.b(ptx)
 
 
@@ -83,7 +85,7 @@ def compile_with_cache(source, options=(), arch=None, cache_dir=None):
     if arch is None:
         arch = _get_arch()
 
-    options += ('-ftz=true')
+    options += ('-ftz=true',)
 
     env = (arch, options, _get_nvrtc_version())
     if '#include' in source:

--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -1,13 +1,11 @@
 import hashlib
 import os
 import re
-import subprocess
-import sys
 import tempfile
 
+import filelock
 import six
 
-import filelock
 from cupy.cuda import device
 from cupy.cuda import function
 from pynvrtc.compiler import NVRTCInterface
@@ -31,7 +29,6 @@ def _get_arch():
 
 
 class TemporaryDirectory(object):
-
     def __enter__(self):
         self.path = tempfile.mkdtemp()
         return self.path
@@ -52,7 +49,6 @@ def nvrtc(source, options=(), arch=None):
     with TemporaryDirectory() as root_dir:
         path = os.path.join(root_dir, 'kern')
         cu_path = '%s.cu' % path
-        ptx_path = '%s.ptx' % path
 
         with open(cu_path, 'w') as cu_file:
             cu_file.write(source)
@@ -64,11 +60,10 @@ def nvrtc(source, options=(), arch=None):
 
 
 def preprocess(source, options=()):
-    with TemporaryDirectory() as root_dir:
-        pp_src = Program(six.b(source), six.b('')).compile()
-        if isinstance(pp_src, six.binary_type):
-            pp_src = pp_src.decode('utf-8')
-        return re.sub('(?m)^#.*$', '', pp_src)
+    pp_src = Program(six.b(source), six.b('')).compile()
+    if isinstance(pp_src, six.binary_type):
+        pp_src = pp_src.decode('utf-8')
+    return re.sub('(?m)^#.*$', '', pp_src)
 
 
 _default_cache_dir = os.path.expanduser('~/.cupy/kernel_cache')

--- a/cupy/testing/helper.py
+++ b/cupy/testing/helper.py
@@ -420,7 +420,7 @@ _regular_dtypes = _regular_float_dtypes + _int_bool_dtypes
 _dtypes = _float_dtypes + _int_bool_dtypes
 
 
-def _make_all_dtypes(no_float16, no_bool):
+def _make_all_dtypes(no_float16, no_bool, excludes=False):
     if no_float16:
         if no_bool:
             return _regular_float_dtypes + _int_dtypes
@@ -430,10 +430,14 @@ def _make_all_dtypes(no_float16, no_bool):
         if no_bool:
             return _float_dtypes + _int_dtypes
         else:
-            return _dtypes
+            if excludes:
+                return (t for t in _dtypes if t not in excludes)
+            else:
+                return _dtypes
 
 
-def for_all_dtypes(name='dtype', no_float16=False, no_bool=False):
+def for_all_dtypes(name='dtype', no_float16=False, no_bool=False,
+                   excludes=False):
     """Decorator that checks the fixture with all dtypes.
 
     Args:
@@ -442,6 +446,8 @@ def for_all_dtypes(name='dtype', no_float16=False, no_bool=False):
              omitted from candidate dtypes.
          no_bool(bool): If, True, ``numpy.bool_`` is
              omitted from candidate dtypes.
+         excludes(list of dtypes): A list of dtypes that will be excluded from
+             the returned dtypes.
 
     dtypes to be tested: ``numpy.float16`` (optional), ``numpy.float32``,
     ``numpy.float64``, ``numpy.dtype('b')``, ``numpy.dtype('h')``,
@@ -484,7 +490,8 @@ def for_all_dtypes(name='dtype', no_float16=False, no_bool=False):
 
     .. seealso:: :func:`cupy.testing.for_dtypes`
     """
-    return for_dtypes(_make_all_dtypes(no_float16, no_bool), name=name)
+    return for_dtypes(_make_all_dtypes(no_float16, no_bool, excludes),
+                      name=name)
 
 
 def for_float_dtypes(name='dtype', no_float16=False):

--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -47,6 +47,7 @@ MODULES = [
             'cudart',
             'curand',
             'nvToolsExt',
+            'nvrtc',
         ],
         'check_method': build.check_cuda_version,
     },

--- a/install/build.py
+++ b/install/build.py
@@ -7,7 +7,7 @@ import tempfile
 from install import utils
 
 
-minimum_cuda_version = 6050
+minimum_cuda_version = 7000
 minimum_cudnn_version = 2000
 # Although cuda 7.0 includes cusolver,
 # we tentatively support cusolver in cuda 8.0 only because

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ install_requires = [
     'nose',
     'numpy>=1.9.0',
     'six>=1.9.0',
+    'pynvrtc>=7.0',
 ]
 
 ext_modules = cupy_setup_build.get_ext_modules()

--- a/tests/cupy_tests/linalg_tests/test_product.py
+++ b/tests/cupy_tests/linalg_tests/test_product.py
@@ -1,8 +1,9 @@
 import unittest
 
+import numpy as np
+
 from cupy import testing
 
-import numpy as np
 
 @testing.parameterize(*testing.product({
     'shape': [

--- a/tests/cupy_tests/linalg_tests/test_product.py
+++ b/tests/cupy_tests/linalg_tests/test_product.py
@@ -1,6 +1,6 @@
 import unittest
 
-import numpy as np
+import numpy
 
 from cupy import testing
 
@@ -258,14 +258,16 @@ class TestProduct(unittest.TestCase):
         b = testing.shaped_arange((4, 3, 2), xp, dtype).transpose(2, 0, 1)
         return xp.tensordot(a, b)
 
-    @testing.for_all_dtypes(excludes=(np.uint8, np.int8, np.uint16, np.int16))
+    @testing.for_all_dtypes(excludes=(numpy.uint8, numpy.int8, numpy.uint16,
+                                      numpy.int16))
     @testing.numpy_cupy_allclose()
     def test_tensordot_with_int_axes(self, xp, dtype):
         a = testing.shaped_arange((2, 3, 4, 5), xp, dtype)
         b = testing.shaped_arange((3, 4, 5, 2), xp, dtype)
         return xp.tensordot(a, b, axes=3)
 
-    @testing.for_all_dtypes(excludes=(np.uint8, np.int8, np.uint16, np.int16))
+    @testing.for_all_dtypes(excludes=(numpy.uint8, numpy.int8, numpy.uint16,
+                                      numpy.int16))
     @testing.numpy_cupy_allclose()
     def test_transposed_tensordot_with_int_axes(self, xp, dtype):
         a = testing.shaped_arange(
@@ -274,14 +276,16 @@ class TestProduct(unittest.TestCase):
             (5, 4, 3, 2), xp, dtype).transpose(3, 0, 2, 1)
         return xp.tensordot(a, b, axes=3)
 
-    @testing.for_all_dtypes(excludes=(np.uint8, np.int8, np.uint16, np.int16))
+    @testing.for_all_dtypes(excludes=(numpy.uint8, numpy.int8, numpy.uint16,
+                                      numpy.int16))
     @testing.numpy_cupy_allclose()
     def test_tensordot_with_list_axes(self, xp, dtype):
         a = testing.shaped_arange((2, 3, 4, 5), xp, dtype)
         b = testing.shaped_arange((3, 5, 4, 2), xp, dtype)
         return xp.tensordot(a, b, axes=([3, 2, 1], [1, 2, 0]))
 
-    @testing.for_all_dtypes(excludes=(np.uint8, np.int8, np.uint16, np.int16))
+    @testing.for_all_dtypes(excludes=(numpy.uint8, numpy.int8, numpy.uint16,
+                                      numpy.int16))
     @testing.numpy_cupy_allclose()
     def test_transposed_tensordot_with_list_axes(self, xp, dtype):
         a = testing.shaped_arange(

--- a/tests/cupy_tests/linalg_tests/test_product.py
+++ b/tests/cupy_tests/linalg_tests/test_product.py
@@ -2,6 +2,7 @@ import unittest
 
 from cupy import testing
 
+import numpy as np
 
 @testing.parameterize(*testing.product({
     'shape': [
@@ -256,14 +257,14 @@ class TestProduct(unittest.TestCase):
         b = testing.shaped_arange((4, 3, 2), xp, dtype).transpose(2, 0, 1)
         return xp.tensordot(a, b)
 
-    @testing.for_all_dtypes()
+    @testing.for_all_dtypes(excludes=(np.uint8, np.int8, np.uint16, np.int16))
     @testing.numpy_cupy_allclose()
     def test_tensordot_with_int_axes(self, xp, dtype):
         a = testing.shaped_arange((2, 3, 4, 5), xp, dtype)
         b = testing.shaped_arange((3, 4, 5, 2), xp, dtype)
         return xp.tensordot(a, b, axes=3)
 
-    @testing.for_all_dtypes()
+    @testing.for_all_dtypes(excludes=(np.uint8, np.int8, np.uint16, np.int16))
     @testing.numpy_cupy_allclose()
     def test_transposed_tensordot_with_int_axes(self, xp, dtype):
         a = testing.shaped_arange(
@@ -272,14 +273,14 @@ class TestProduct(unittest.TestCase):
             (5, 4, 3, 2), xp, dtype).transpose(3, 0, 2, 1)
         return xp.tensordot(a, b, axes=3)
 
-    @testing.for_all_dtypes()
+    @testing.for_all_dtypes(excludes=(np.uint8, np.int8, np.uint16, np.int16))
     @testing.numpy_cupy_allclose()
     def test_tensordot_with_list_axes(self, xp, dtype):
         a = testing.shaped_arange((2, 3, 4, 5), xp, dtype)
         b = testing.shaped_arange((3, 5, 4, 2), xp, dtype)
         return xp.tensordot(a, b, axes=([3, 2, 1], [1, 2, 0]))
 
-    @testing.for_all_dtypes()
+    @testing.for_all_dtypes(excludes=(np.uint8, np.int8, np.uint16, np.int16))
     @testing.numpy_cupy_allclose()
     def test_transposed_tensordot_with_list_axes(self, xp, dtype):
         a = testing.shaped_arange(


### PR DESCRIPTION
It fixes https://github.com/pfnet/chainer/issues/1918.

- NVRTC doesn't support any 32-bit system