### PR TITLE
Reduce support environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ Minimum requirements:
 
 Requirements for some features:
 - CUDA support
-  - CUDA 6.5, 7.0, 7.5, 8.0
+  - CUDA 7.0, 7.5, 8.0
   - filelock
   - g++ 4.8.4+
 - cuDNN support
-  - cuDNN v2, v3, v4, v5, v5.1, v6
+  - cuDNN v4, v5, v5.1, v6
 - Testing utilities
   - Mock
   - Nose

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -32,17 +32,17 @@ Install CuPy
 
 CuPy depends on these Python packages:
 
-* `NumPy <http://www.numpy.org/>`_ 1.9, 1.10, 1.11
+* `NumPy <http://www.numpy.org/>`_ 1.9, 1.10, 1.11, 1.12
 * `Six <https://pythonhosted.org/six/>`_ 1.9
 
 CUDA support
 
-* `CUDA <https://developer.nvidia.com/cuda-zone>`_ 6.5, 7.0, 7.5, 8.0
+* `CUDA <https://developer.nvidia.com/cuda-zone>`_ 7.0, 7.5, 8.0
 * `filelock <https://filelock.readthedocs.org>`_
 
 cuDNN support
 
-* `cuDNN <https://developer.nvidia.com/cudnn>`_ v2, v3, v4, v5, v5.1, v6
+* `cuDNN <https://developer.nvidia.com/cudnn>`_ v4, v5, v5.1, v6
 
 All these libraries are automatically installed with ``pip`` or ``setup.py``.
 


### PR DESCRIPTION
This PR reduce support environment. 
CUDA 6.5: This SDK does not have NVRTC.
cuDNN v2, v3: These library is too old. And, some API does not have API compatibility.