### PR TITLE
Allow cupy.copyto from python scalar

### DIFF
--- a/cupy/manipulation/basic.py
+++ b/cupy/manipulation/basic.py
@@ -1,4 +1,5 @@
 import numpy
+import six
 
 from cupy import core
 
@@ -21,10 +22,25 @@ def copyto(dst, src, casting='same_kind', where=None):
     .. seealso:: :func:`numpy.copyto`
 
     """
-    if not numpy.can_cast(src.dtype, dst.dtype, casting):
+
+    src_type = type(src)
+    src_is_python_scalar = (src_type in six.integer_types or
+                            src_type in (bool, float, complex))
+    if src_is_python_scalar:
+        src_dtype = numpy.dtype(type(src))
+        can_cast = numpy.can_cast(src, dst.dtype, casting)
+    else:
+        src_dtype = src.dtype
+        can_cast = numpy.can_cast(src_dtype, dst.dtype, casting)
+
+    if not can_cast:
         raise TypeError('Cannot cast %s to %s in %s casting mode' %
-                        (src.dtype, dst.dtype, casting))
+                        (src_dtype, dst.dtype, casting))
     if dst.size == 0:
+        return
+
+    if src_is_python_scalar:
+        dst[...] = src
         return
 
     if where is None:

--- a/cupy/manipulation/basic.py
+++ b/cupy/manipulation/basic.py
@@ -40,7 +40,7 @@ def copyto(dst, src, casting='same_kind', where=None):
         return
 
     if src_is_python_scalar:
-        dst[...] = src
+        dst.fill(src)
         return
 
     if where is None:

--- a/tests/cupy_tests/manipulation_tests/test_basic.py
+++ b/tests/cupy_tests/manipulation_tests/test_basic.py
@@ -59,30 +59,13 @@ class TestBasic(unittest.TestCase):
 @testing.parameterize(
     *testing.product(
         {'src': [float(3.2), int(0), int(4), int(-4), True, False],
-         'dst_shape': [(), (0,), (1,), (1, 1), (2, 2)],
-         'dst_dtype': testing.helper._make_all_dtypes(False, False)}))
+         'dst_shape': [(), (0,), (1,), (1, 1), (2, 2)]}))
 @testing.gpu
 class TestCopytoFromScalar(unittest.TestCase):
 
-    def _do_copyto(self, xp):
-        dst = xp.ones(self.dst_shape, dtype=self.dst_dtype)
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose(accept_error=TypeError)
+    def test_copyto(self, xp, dtype):
+        dst = xp.ones(self.dst_shape, dtype=dtype)
         xp.copyto(dst, self.src)
         return dst
-
-    def test_copyto(self):
-        try:
-            dst_expected = self._do_copyto(numpy)
-            success_expected = True
-        except TypeError:
-            dst_expected = None
-            success_expected = False
-
-        if success_expected:
-            # Numpy succeeds; expected to succeed
-            testing.array.assert_array_equal(
-                dst_expected,
-                self._do_copyto(cupy))
-        else:
-            # Numpy fails; expected to fail
-            with self.assertRaises(TypeError):
-                self._do_copyto(cupy)

--- a/tests/cupy_tests/manipulation_tests/test_basic.py
+++ b/tests/cupy_tests/manipulation_tests/test_basic.py
@@ -59,7 +59,7 @@ class TestBasic(unittest.TestCase):
 @testing.parameterize(
     *testing.product(
         {'src': [float(3.2), int(0), int(4), int(-4), True, False],
-         'dst_shape': [(), (0,), (1,), (1,1), (2,2), ],
+         'dst_shape': [(), (0,), (1,), (1, 1), (2, 2)],
          'dst_dtype': testing.helper._make_all_dtypes(False, False)}))
 @testing.gpu
 class TestCopytoFromScalar(unittest.TestCase):


### PR DESCRIPTION
Fixes https://github.com/pfnet/chainer/issues/720