### PR TITLE
Include cu files in --cupy-no-cuda mode

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,10 @@ setup(
               'cupy.statistics',
               'cupy.testing'],
     package_data={
-        'cupy': ['core/carray.cuh'],
+        'cupy': [
+            'core/carray.cuh',
+            'cupy/cuda/cupy_thrust.cu',
+        ],
     },
     zip_safe=False,
     setup_requires=setup_requires,


### PR DESCRIPTION
This PR provides correct pip archive file by `python setup.py sdist --cupy--no-cuda` command.
