### PR TITLE
Fix cupy-thrust packaging

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
     package_data={
         'cupy': [
             'core/carray.cuh',
-            'cupy/cuda/cupy_thrust.cu',
+            'cuda/cupy_thrust.cu',
         ],
     },
     zip_safe=False,


### PR DESCRIPTION
This is a fix over #76 (I missed this point on reviewing, sorry).