### PR TITLE
Support Unified Memory and Memory Trace options　

### DIFF
--- a/cupy/cuda/memory.pxd
+++ b/cupy/cuda/memory.pxd
@@ -1,17 +1,23 @@
-from cupy.cuda cimport device
+from cupy.cuda cimport device as device_mod
 
 cdef class Memory:
 
     cdef:
-        public device.Device device
+        public device_mod.Device device
         public size_t ptr
         public Py_ssize_t size
+
+
+cdef class ManagedMemory(Memory):
+
+    cpdef prefetch(self, stream)
+    cpdef advise(self, int advice, device_mod.Device device)
 
 
 cdef class MemoryPointer:
 
     cdef:
-        readonly device.Device device
+        readonly device_mod.Device device
         readonly object mem
         readonly size_t ptr
 

--- a/cupy/cuda/runtime.pxd
+++ b/cupy/cuda/runtime.pxd
@@ -30,6 +30,10 @@ cpdef enum:
     cudaMemoryTypeHost = 1
     cudaMemoryTypeDevice = 2
 
+    cudaMemAttachGlobal = 1
+    cudaMemAttachHost = 2
+    cudaMemAttachSingle = 4
+
     hostAllocDefault = 0
     hostAllocPortable = 1
     hostAllocMapped = 2

--- a/cupy/cuda/runtime.pyx
+++ b/cupy/cuda/runtime.pyx
@@ -70,6 +70,7 @@ cdef extern from "cupy_cuda.h":
 
     # Memory management
     int cudaMalloc(void** devPtr, size_t size) nogil
+    int cudaMallocManaged(void** devPtr, size_t size, unsigned int flags) nogil
     int cudaHostAlloc(void** ptr, size_t size, unsigned int flags) nogil
     int cudaFree(void* devPtr) nogil
     int cudaFreeHost(void* ptr) nogil
@@ -204,6 +205,15 @@ cpdef size_t malloc(size_t size) except *:
     cdef void* ptr
     with nogil:
         status = cudaMalloc(&ptr, size)
+    check_status(status)
+    return <size_t>ptr
+
+
+cpdef size_t mallocManaged(size_t size,
+                           unsigned int flags=cudaMemAttachGlobal) except *:
+    cdef void* ptr
+    with nogil:
+        status = cudaMallocManaged(&ptr, size, flags)
     check_status(status)
     return <size_t>ptr
 


### PR DESCRIPTION
This PR supports Unified Memory and Memory Trace options in cupy.
You can use these options with Chainer V2.

The code for Unified Memory support comes from https://github.com/pfnet/chainer/tree/unified-memory by @okuta.

(1) To enable Unified Memory 
    Insert the following two lines into your code as same as the original one.
    memory_pool = cupy.cuda.MemoryPool(cupy.cuda.memory._mallocManaged)
    cupy.cuda.memory.set_allocator(memory_pool.malloc)
(2) To enable Memory Trace options.
    Insert the following one into your code.
    cupy.cuda.memory.set_options(memtrace=args.memtrace)

