### PR TITLE
Use exponential of 2 for stability

### DIFF
--- a/tests/cupy_tests/random_tests/test_generator.py
+++ b/tests/cupy_tests/random_tests/test_generator.py
@@ -337,7 +337,7 @@ class TestChoiceMultinomial(unittest.TestCase):
     @testing.for_float_dtypes()
     @testing.numpy_cupy_allclose(atol=0.02)
     def test_choice_multinomial(self, xp, dtype):
-        p = xp.array([0.2, 0.3, 0.5], dtype)
+        p = xp.array([0.5, 0.25, 0.125, 0.125], dtype)
         trial = 10000
         x = xp.random.choice(len(p), trial, p=p)
         y = xp.bincount(x).astype('f') / trial


### PR DESCRIPTION
I found in numpy 1.9, this test does not work:
```
>>> numpy.random.choice(3, p=numpy.array([.2, .3, .5], 'f'))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "mtrand.pyx", line 1094, in mtrand.RandomState.choice (numpy/random/mtrand/mtrand.c:11476)
ValueError: probabilities do not sum to 1
```

To stabilize the test, I replaced constants with exponential of 2.