### PR TITLE
Memory pool is thread unsafe

### DIFF
--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -384,7 +384,7 @@ cdef class SingleDeviceMemoryPool:
         free.append(mem)
 
     cpdef free_all_blocks(self):
-        self._free = collections.defaultdict(list)
+        self._free.clear()
 
     cpdef free_all_free(self):
         warnings.warn(

--- a/cupy/cuda/pinned_memory.pyx
+++ b/cupy/cuda/pinned_memory.pyx
@@ -259,7 +259,7 @@ cdef class PinnedMemoryPool:
 
     cpdef free_all_blocks(self):
         """Release free all blocks."""
-        self._free = collections.defaultdict(list)
+        self._free.clear()
 
     cpdef n_free_blocks(self):
         """Count the total number of free blocks.


### PR DESCRIPTION
When using CuPy default memory pool from multiple threads simultaneously, sometimes it causes invalid memory access.  I confirmed this issue using the official Docker image with [this code](https://gist.github.com/kmaehashi/ef5931ab758db1fdaa08474596eec5ec).

The issue (generally) occur when the initial trial of `malloc` failed with out-of-memory error and `free_all_blocks` is called.

https://github.com/cupy/cupy/blob/v1.0.0/cupy/cuda/memory.pyx#L359-L364

The code of [`free_all_blocks`](https://github.com/cupy/cupy/blob/v1.0.0/cupy/cuda/memory.pyx#L386-L387) internally does the following (according to the generated Cython source code):

1. Construct new `collections.defaultdict(list)` instance.
2. Decrement ref count for `self._free`, which triggers garbage collection.
3. Set the new `defaultdict` instance to `self._free`.

The point here is that during the GC of memory blocks, their destructor invoke [`cudaFree`](https://github.com/cupy/cupy/blob/v1.0.0/cupy/cuda/runtime.pyx#L219-L222), which releases GIL.  So, other threads can call `malloc` or `free` while `cudaFree` is running, access `self._free` that is BEING destructed, which causes invalid memory access that results in SegV, glibc error or deadlock sometimes.

```
*** Error in `python': corrupted double-linked list: 0x00007f12f0042fc0 ***
```

I fixed the code to use `clear()` instead of just substituting a new instance.  AFAIK CPython's `dict` classes [first clear the dict slots and then decref each item](https://github.com/python/cpython/blob/v3.6.1/Objects/dictobject.c#L1734-L1740), so it should be safe.