### PR TITLE
Support order option in astype method

### DIFF
--- a/cupy/core/core.pxd
+++ b/cupy/core/core.pxd
@@ -19,7 +19,7 @@ cdef class ndarray:
     cpdef tofile(self, fid, sep=*, format=*)
     cpdef dump(self, file)
     cpdef dumps(self)
-    cpdef ndarray astype(self, dtype, copy=*)
+    cpdef ndarray astype(self, dtype, order=*, casting=*, subok=*, copy=*)
     cpdef ndarray copy(self, order=*)
     cpdef ndarray view(self, dtype=*)
     cpdef fill(self, value)

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -261,7 +261,7 @@ cdef class ndarray:
         return six.moves.cPickle.dumps(self, -1)
 
     cpdef ndarray astype(
-        self, dtype, order='K', casting=None, subok=None, copy=True):
+            self, dtype, order='K', casting=None, subok=None, copy=True):
         """Casts the array to given data type.
 
         Args:

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -272,7 +272,6 @@ cdef class ndarray:
                 uses `C` otherwise.
                 And when `order` is 'K', it keeps strides as closely as
                 possible.
-                This function currently does not support order 'K'.
             copy (bool): If it is False and no cast happens, then this method
                 returns the array itself. Otherwise, a copy is returned.
 

--- a/tests/cupy_tests/core_tests/test_ndarray_copy_and_view.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_copy_and_view.py
@@ -63,27 +63,67 @@ class TestArrayCopyAndView(unittest.TestCase):
         b.fill(1)
         return b
 
+    @testing.for_orders('CFAK')
     @testing.for_all_dtypes(name='src_dtype')
     @testing.for_all_dtypes(name='dst_dtype')
     @testing.numpy_cupy_array_equal()
-    def test_astype(self, xp, src_dtype, dst_dtype):
+    def test_astype(self, xp, src_dtype, dst_dtype, order):
         a = testing.shaped_arange((2, 3, 4), xp, src_dtype)
-        return a.astype(dst_dtype)
+        return a.astype(dst_dtype, order=order)
+
+    @testing.for_orders('CFAK')
+    @testing.for_all_dtypes(name='src_dtype')
+    @testing.for_all_dtypes(name='dst_dtype')
+    def test_astype_type(self, src_dtype, dst_dtype, order):
+        a = testing.shaped_arange((2, 3, 4), cupy, src_dtype)
+        b = a.astype(dst_dtype, order=order)
+        a_cpu = testing.shaped_arange((2, 3, 4), numpy, src_dtype)
+        b_cpu = a_cpu.astype(dst_dtype, order=order)
+        self.assertEqual(b.dtype.type, b_cpu.dtype.type)
+
+    @testing.for_orders('CAK')
+    @testing.for_all_dtypes()
+    def test_astype_type_c_contiguous_no_copy(self, dtype, order):
+        a = testing.shaped_arange((2, 3, 4), cupy, dtype)
+        b = a.astype(dtype, order=order, copy=False)
+        self.assertTrue(b is a)
+
+    @testing.for_orders('FAK')
+    @testing.for_all_dtypes()
+    def test_astype_type_f_contiguous_no_copy(self, dtype, order):
+        a = testing.shaped_arange((2, 3, 4), cupy, dtype)
+        a = cupy.asfortranarray(a)
+        b = a.astype(dtype, order=order, copy=False)
+        self.assertTrue(b is a)
 
     @testing.for_all_dtypes(name='src_dtype')
     @testing.for_all_dtypes(name='dst_dtype')
-    def test_astype_type(self, src_dtype, dst_dtype):
-        a = testing.shaped_arange((2, 3, 4), cupy, src_dtype)
-        b = a.astype(dst_dtype)
-        a_cpu = testing.shaped_arange((2, 3, 4), numpy, src_dtype)
-        b_cpu = a_cpu.astype(dst_dtype)
-        self.assertEqual(b.dtype.type, b_cpu.dtype.type)
+    @testing.numpy_cupy_array_equal()
+    def test_astype_strides(self, xp, src_dtype, dst_dtype):
+        src = xp.empty((1, 2, 3), dtype=src_dtype)
+        return numpy.array(src.astype(dst_dtype, order='K').strides)
 
-    @testing.for_all_dtypes()
-    def test_astype_type_no_copy(self, dtype):
-        a = testing.shaped_arange((2, 3, 4), cupy, dtype)
-        b = a.astype(dtype, copy=False)
-        self.assertTrue(b is a)
+    @testing.for_all_dtypes(name='src_dtype')
+    @testing.for_all_dtypes(name='dst_dtype')
+    @testing.numpy_cupy_array_equal()
+    def test_astype_strides_negative(self, xp, src_dtype, dst_dtype):
+        src = xp.empty((2, 3), dtype=src_dtype)[::-1, :]
+        return numpy.array(src.astype(dst_dtype, order='K').strides)
+
+    @testing.for_all_dtypes(name='src_dtype')
+    @testing.for_all_dtypes(name='dst_dtype')
+    @testing.numpy_cupy_array_equal()
+    def test_astype_strides_swapped(self, xp, src_dtype, dst_dtype):
+        src = xp.swapaxes(xp.empty((2, 3, 4), dtype=src_dtype), 1, 0)
+        return numpy.array(src.astype(dst_dtype, order='K').strides)
+
+    @testing.for_all_dtypes(name='src_dtype')
+    @testing.for_all_dtypes(name='dst_dtype')
+    @testing.numpy_cupy_array_equal()
+    def test_astype_strides_broadcast(self, xp, src_dtype, dst_dtype):
+        src, _ = xp.broadcast_arrays(xp.empty((2,), dtype=src_dtype),
+                                     xp.empty((2, 3, 2), dtype=src_dtype))
+        return numpy.array(src.astype(dst_dtype, order='K').strides)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()


### PR DESCRIPTION
I implemented order option support in `astype` method.
It uses `elementwise_copy`. Is it better to use `ndarray.copy_from_device`?