### PR TITLE
`order` option for `copy`

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -368,7 +368,6 @@ cdef class ndarray:
         else:
             return x
 
-
     cpdef ndarray view(self, dtype=None):
         """Returns a view of the array.
 

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -341,6 +341,10 @@ cdef class ndarray:
     cpdef ndarray copy(self, order='C'):
         """Returns a copy of the array.
 
+        This method makes a copy of a given array in the current device.
+        Even when a given array is located in another device, you can copy it
+        to the current device.
+
         Args:
             order ({'C', 'F', 'A', 'K'}): Row-major (C-style) or column-major
                 (Fortran-style) order.

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -357,7 +357,6 @@ cdef class ndarray:
         """
         return self.astype(self.dtype, copy=True, order=order)
 
-
     cpdef ndarray view(self, dtype=None):
         """Returns a view of the array.
 

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -357,16 +357,16 @@ cdef class ndarray:
         if self.size == 0:
             return self.astype(self.dtype, copy=True, order=order)
 
-        with self.device:
-            x = self.astype(self.dtype, copy=True, order=order)
-
-        if device.Device() != self.device:
+        if device.Device() == self.device:
+            return self.astype(self.dtype, copy=True, order=order)
+        else:
+            # It need to make a contiguous copy for copying from another device
+            with self.device:
+                x = self.astype(self.dtype, copy=False, order=order)
             newarray = ndarray(x.shape, dtype=x.dtype)
             newarray._set_shape_and_strides(x._shape, x._strides)
             newarray.data.copy_from_device(x.data, x.nbytes)
             return newarray
-        else:
-            return x
 
     cpdef ndarray view(self, dtype=None):
         """Returns a view of the array.

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -357,7 +357,8 @@ cdef class ndarray:
         if self.size == 0:
             return self.astype(self.dtype, copy=True, order=order)
 
-        if device.Device() == self.device:
+        if (self.data.device is None or
+                self.data.device.id == device.get_device_id()):
             return self.astype(self.dtype, copy=True, order=order)
         else:
             # It need to make a contiguous copy for copying from another device

--- a/cupy/creation/from_data.py
+++ b/cupy/creation/from_data.py
@@ -89,9 +89,12 @@ def copy(a, order='C'):
 
     Args:
         a (cupy.ndarray): The source array.
-        order ({'C', 'F'}): Row-major (C-style) or column-major
-            (Fortran-style) order. This function currently does not
-            support order 'A' and 'K'.
+        order ({'C', 'F', 'A', 'K'}): Row-major (C-style) or column-major
+            (Fortran-style) order.
+            When `order` is 'A', it uses 'F' if `a` is column-major and
+            uses `C` otherwise.
+            And when `order` is 'K', it keeps strides as closely as
+            possible.
 
     Returns:
         cupy.ndarray: The copy of ``a`` on the current device.
@@ -102,7 +105,6 @@ def copy(a, order='C'):
     # If the current device is different from the device of ``a``, then this
     # function allocates a new array on the current device, and copies the
     # contents over the devices.
-    # TODO(beam2d): Support ordering option 'A' and 'K'
     return a.copy(order=order)
 
 

--- a/tests/cupy_tests/core_tests/test_elementwise.py
+++ b/tests/cupy_tests/core_tests/test_elementwise.py
@@ -32,21 +32,25 @@ class TestElementwise(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.check_copy(dtype, 0, 1)
 
-    @testing.for_CF_orders()
+    @testing.for_orders('CFAK')
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_copy_zero_sized_array1(self, xp, dtype, order):
         src = xp.empty((0,), dtype=dtype)
-        return xp.copy(src, order=order)
+        res = xp.copy(src, order=order)
+        self.assertIsNot(src, res)
+        return res
 
-    @testing.for_CF_orders()
+    @testing.for_orders('CFAK')
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_copy_zero_sized_array2(self, xp, dtype, order):
         src = xp.empty((1, 0, 2), dtype=dtype)
-        return xp.copy(src, order=order)
+        res = xp.copy(src, order=order)
+        self.assertIsNot(src, res)
+        return res
 
-    @testing.for_CF_orders()
+    @testing.for_orders('CFAK')
     def test_copy_orders(self, order):
         a = cupy.empty((2, 3, 4))
         b = cupy.copy(a, order)


### PR DESCRIPTION
I supported order option in `copy` method using `astype`.
merge #111 first