### PR TITLE
Put the value of copy option of cupy.array appropriately to ndarray.astype

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1887,7 +1887,7 @@ cpdef ndarray array(obj, dtype=None, bint copy=True, Py_ssize_t ndmin=0):
     if isinstance(obj, ndarray):
         if dtype is None:
             dtype = obj.dtype
-        a = obj.astype(dtype, copy)
+        a = obj.astype(dtype, copy=copy)
 
         ndim = a._shape.size()
         if ndmin > ndim:

--- a/tests/cupy_tests/core_tests/test_core.py
+++ b/tests/cupy_tests/core_tests/test_core.py
@@ -2,8 +2,6 @@ import unittest
 
 import cupy
 from cupy.core import core
-from cupy import testing
-import numpy
 
 
 class TestGetStridesForNocopyReshape(unittest.TestCase):
@@ -21,68 +19,3 @@ class TestGetStridesForNocopyReshape(unittest.TestCase):
     def test_normal(self):
         # TODO(nno): write test for normal case
         pass
-
-
-@testing.parameterize(*[
-    {'xp': numpy},
-    {'xp': cupy}
-])
-class TestArrayDtype(unittest.TestCase):
-
-    @testing.for_all_dtypes()
-    def test_cupy_ndarray(self, dtype):
-        a = self.xp.random.randint(0, 3, (2, 3))
-        b = cupy.array(a, dtype)
-        self.assertEqual(dtype, b.dtype)
-        a = a.astype(b.dtype)
-        testing.assert_array_equal(a, b)
-
-    def test_cupy_ndarray_dtype_is_none(self):
-        a = self.xp.random.randint(0, 3, (2, 3))
-        b = cupy.array(a, None)
-        testing.assert_array_equal(a, b)
-
-
-class TestArrayCopy(unittest.TestCase):
-
-    def test_copy(self):
-        a = cupy.random.randint(0, 3, (2, 3))
-        b = cupy.array(a, copy=False)
-        self.assertIs(a, b)
-
-
-@testing.parameterize(
-    *testing.product({
-        'ndmin': [0, 1, 2, 3],
-        'copy': [True, False],
-        'xp': [numpy, cupy]
-    })
-)
-class TestArrayNdmin(unittest.TestCase):
-
-    def test_cupy_ndarray_ndmin(self):
-        shape = 2, 3
-        a = self.xp.arange(6).reshape(*shape)
-        ndim = a.ndim
-        actual = cupy.array(a, copy=self.copy, ndmin=self.ndmin)
-
-        # Check if cupy.ndarray does not alter
-        # the shape of the original array.
-        self.assertEqual(a.shape, shape)
-
-        expected = a
-        if ndim < self.ndmin:
-            expected_shape = (1,) * (self.ndmin - ndim) + a.shape
-            expected = a.reshape(expected_shape)
-        testing.assert_array_equal(expected, actual)
-
-        if (self.xp is cupy) and not self.copy:
-            self.assertTrue((a is actual) or (actual.base is a.base))
-
-
-class TestArrayInvalidObject(unittest.TestCase):
-
-    def test_invalid_type(self):
-        a = numpy.array([1, 2, 3], dtype=object)
-        with self.assertRaises(ValueError):
-            cupy.array(a)

--- a/tests/cupy_tests/core_tests/test_core.py
+++ b/tests/cupy_tests/core_tests/test_core.py
@@ -2,6 +2,8 @@ import unittest
 
 import cupy
 from cupy.core import core
+from cupy import testing
+import numpy
 
 
 class TestGetStridesForNocopyReshape(unittest.TestCase):
@@ -19,3 +21,68 @@ class TestGetStridesForNocopyReshape(unittest.TestCase):
     def test_normal(self):
         # TODO(nno): write test for normal case
         pass
+
+
+@testing.parameterize(*[
+    {'xp': numpy},
+    {'xp': cupy}
+])
+class TestArrayDtype(unittest.TestCase):
+
+    @testing.for_all_dtypes()
+    def test_cupy_ndarray(self, dtype):
+        a = self.xp.random.randint(0, 3, (2, 3))
+        b = cupy.array(a, dtype)
+        self.assertEqual(dtype, b.dtype)
+        a = a.astype(b.dtype)
+        testing.assert_array_equal(a, b)
+
+    def test_cupy_ndarray_dtype_is_none(self):
+        a = self.xp.random.randint(0, 3, (2, 3))
+        b = cupy.array(a, None)
+        testing.assert_array_equal(a, b)
+
+
+class TestArrayCopy(unittest.TestCase):
+
+    def test_copy(self):
+        a = cupy.random.randint(0, 3, (2, 3))
+        b = cupy.array(a, copy=False)
+        self.assertIs(a, b)
+
+
+@testing.parameterize(
+    *testing.product({
+        'ndmin': [0, 1, 2, 3],
+        'copy': [True, False],
+        'xp': [numpy, cupy]
+    })
+)
+class TestArrayNdmin(unittest.TestCase):
+
+    def test_cupy_ndarray_ndmin(self):
+        shape = 2, 3
+        a = self.xp.arange(6).reshape(*shape)
+        ndim = a.ndim
+        actual = cupy.array(a, copy=self.copy, ndmin=self.ndmin)
+
+        # Check if cupy.ndarray does not alter
+        # the shape of the original array.
+        self.assertEqual(a.shape, shape)
+
+        expected = a
+        if ndim < self.ndmin:
+            expected_shape = (1,) * (self.ndmin - ndim) + a.shape
+            expected = a.reshape(expected_shape)
+        testing.assert_array_equal(expected, actual)
+
+        if (self.xp is cupy) and not self.copy:
+            self.assertTrue((a is actual) or (actual.base is a.base))
+
+
+class TestArrayInvalidObject(unittest.TestCase):
+
+    def test_invalid_type(self):
+        a = numpy.array([1, 2, 3], dtype=object)
+        with self.assertRaises(ValueError):
+            cupy.array(a)


### PR DESCRIPTION
Fixes #119 

This PR also adds unit tests of `cupy.array`.