### PR TITLE
Fix array method on multi GPU

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1883,11 +1883,15 @@ cdef _argmax = create_reduction_func(
 cpdef ndarray array(obj, dtype=None, bint copy=True, Py_ssize_t ndmin=0):
     # TODO(beam2d): Support order and subok options
     cdef Py_ssize_t nvidem
-    cdef ndarray a
+    cdef ndarray a, src
     if isinstance(obj, ndarray):
+        src = obj
         if dtype is None:
-            dtype = obj.dtype
-        a = obj.astype(dtype, copy=copy)
+            dtype = src.dtype
+        if src.data.device.id == device.get_device_id():
+            a = src.astype(dtype, copy=copy)
+        else:
+            a = src.copy().astype(dtype, copy=False)
 
         ndim = a._shape.size()
         if ndmin > ndim:

--- a/tests/cupy_tests/creation_tests/test_from_data.py
+++ b/tests/cupy_tests/creation_tests/test_from_data.py
@@ -45,13 +45,27 @@ class TestFromData(unittest.TestCase):
         return b
 
     @testing.multi_gpu(2)
-    def test_array_multidevice(self):
+    def test_array_multi_device(self):
         with cuda.Device(0):
             x = testing.shaped_arange((2, 3, 4), cupy, dtype='f')
         with cuda.Device(1):
             y = cupy.array(x)
         self.assertIsInstance(y, cupy.ndarray)
         self.assertIsNot(x, y)  # Do copy
+        self.assertEqual(int(x.device), 0)
+        self.assertEqual(int(y.device), 1)
+        testing.assert_array_equal(x, y)
+
+    @testing.multi_gpu(2)
+    def test_array_multi_device_zero_size(self):
+        with cuda.Device(0):
+            x = testing.shaped_arange((0,), cupy, dtype='f')
+        with cuda.Device(1):
+            y = cupy.array(x)
+        self.assertIsInstance(y, cupy.ndarray)
+        self.assertIsNot(x, y)  # Do copy
+        self.assertIsNone(x.device)
+        self.assertIsNone(y.device)
         testing.assert_array_equal(x, y)
 
     @testing.for_all_dtypes()

--- a/tests/cupy_tests/creation_tests/test_from_data.py
+++ b/tests/cupy_tests/creation_tests/test_from_data.py
@@ -44,6 +44,16 @@ class TestFromData(unittest.TestCase):
         a.fill(0)
         return b
 
+    @testing.multi_gpu(2)
+    def test_array_multidevice(self):
+        with cuda.Device(0):
+            x = testing.shaped_arange((2, 3, 4), cupy, dtype='f')
+        with cuda.Device(1):
+            y = cupy.array(x)
+        self.assertIsInstance(y, cupy.ndarray)
+        self.assertIsNot(x, y)  # Do copy
+        testing.assert_array_equal(x, y)
+
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_array_no_copy_ndmin(self, xp, dtype):


### PR DESCRIPTION
Rel #111.
`astype` method raises error when it receives ndarray on other GPU.
