### PR TITLE
Improve asynchronous host to device copy

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1904,8 +1904,6 @@ cpdef ndarray array(obj, dtype=None, bint copy=True, Py_ssize_t ndmin=0):
         dtype = a_cpu.dtype
         if dtype.char not in '?bhilqBHILQefd':
             raise ValueError('Unsupported dtype %s' % dtype)
-        if a_cpu.ndim > 0:
-            a_cpu = numpy.ascontiguousarray(a_cpu)
         a = ndarray(a_cpu.shape, dtype=dtype)
         mem = pinned_memory.alloc_pinned_memory(a.nbytes)
         src = numpy.frombuffer(mem, a_cpu.dtype,

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1906,11 +1906,11 @@ cpdef ndarray array(obj, dtype=None, bint copy=True, Py_ssize_t ndmin=0):
             raise ValueError('Unsupported dtype %s' % dtype)
         a = ndarray(a_cpu.shape, dtype=dtype)
         mem = pinned_memory.alloc_pinned_memory(a.nbytes)
-        src = numpy.frombuffer(mem, a_cpu.dtype,
-                               a_cpu.size).reshape(a_cpu.shape)
-        src[...] = a_cpu
+        src_cpu = numpy.frombuffer(mem, a_cpu.dtype,
+                                   a_cpu.size).reshape(a_cpu.shape)
+        src_cpu[...] = a_cpu
         stream = cuda.Stream.null
-        a.set(src, stream)
+        a.set(src_cpu, stream)
         pinned_memory._add_to_watch_list(stream.record(), mem)
     return a
 

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1911,7 +1911,7 @@ cpdef ndarray array(obj, dtype=None, bint copy=True, Py_ssize_t ndmin=0):
         src[...] = a_cpu
         stream = cuda.Stream.null
         a.set(src, stream)
-        pinned_memory._add_to_watch_lsit(stream.record(), mem)
+        pinned_memory._add_to_watch_list(stream.record(), mem)
     return a
 
 

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1887,8 +1887,8 @@ cpdef ndarray array(obj, dtype=None, bint copy=True, Py_ssize_t ndmin=0):
         src = obj
         if dtype is None:
             dtype = src.dtype
-        if (src.data.device is None or
-                src.data.device.id == device.get_device_id()):
+        dev = src.data.device
+        if dev is None or dev.id == device.get_device_id():
             a = src.astype(dtype, copy=copy)
         else:
             a = src.copy().astype(dtype, copy=False)

--- a/cupy/cuda/pinned_memory.pxd
+++ b/cupy/cuda/pinned_memory.pxd
@@ -17,6 +17,9 @@ cdef class PinnedMemoryPointer:
     cpdef Py_ssize_t size(self)
 
 
+cpdef _add_to_watch_lsit(event, obj)
+
+
 cpdef PinnedMemoryPointer alloc_pinned_memory(Py_ssize_t size)
 
 

--- a/cupy/cuda/pinned_memory.pxd
+++ b/cupy/cuda/pinned_memory.pxd
@@ -17,7 +17,7 @@ cdef class PinnedMemoryPointer:
     cpdef Py_ssize_t size(self)
 
 
-cpdef _add_to_watch_lsit(event, obj)
+cpdef _add_to_watch_list(event, obj)
 
 
 cpdef PinnedMemoryPointer alloc_pinned_memory(Py_ssize_t size)

--- a/cupy/cuda/pinned_memory.pyx
+++ b/cupy/cuda/pinned_memory.pyx
@@ -158,13 +158,13 @@ cdef class _EventWatcher:
         """ Check and release completed events.
 
         """
-        if len(self.events) == 0:
+        if not self.events:
             return
         with self.lock:
             self._check_and_release_without_lock()
 
     cpdef _check_and_release_without_lock(self):
-        while len(self.events) != 0 and self.events[0][0].done:
+        while self.events and self.events[0][0].done:
             del self.events[0]
 
 

--- a/cupy/cuda/pinned_memory.pyx
+++ b/cupy/cuda/pinned_memory.pyx
@@ -174,7 +174,7 @@ cdef object _current_allocator = _malloc
 cdef _EventWatcher _watcher = _EventWatcher()
 
 
-cpdef _add_to_watch_lsit(event, obj):
+cpdef _add_to_watch_list(event, obj):
     """ Add event to be monitored.
 
     The ``obj`` are automatically released when the event done.


### PR DESCRIPTION
This PR implement asynchronous copy to `cupy.array`.
Please see also chainer/chainer#2238.