### PR TITLE
Add retry to unit tests of decomposition functions

### DIFF
--- a/tests/cupy_tests/linalg_tests/test_decomposition.py
+++ b/tests/cupy_tests/linalg_tests/test_decomposition.py
@@ -6,6 +6,7 @@ import six
 import cupy
 from cupy import cuda
 from cupy import testing
+from cupy.testing import condition
 
 
 @unittest.skipUnless(
@@ -56,6 +57,7 @@ class TestQRDecomposition(unittest.TestCase):
             self.assertEqual(result_cpu.dtype, result_gpu.dtype)
             cupy.testing.assert_allclose(result_cpu, result_gpu, atol=1e-4)
 
+    @condition.retry(10)
     def test_mode(self):
         self.check_mode(numpy.random.randn(2, 4), mode=self.mode)
         self.check_mode(numpy.random.randn(3, 3), mode=self.mode)
@@ -96,16 +98,19 @@ class TestSVD(unittest.TestCase):
         with self.assertRaises(numpy.linalg.LinAlgError):
             cupy.linalg.svd(array, full_matrices=self.full_matrices)
 
+    @condition.retry(10)
     def test_svd(self):
         self.check_usv(numpy.random.randn(2, 3))
         self.check_usv(numpy.random.randn(2, 2))
         self.check_usv(numpy.random.randn(3, 2))
 
+    @condition.retry(10)
     def test_svd_no_uv(self):
         self.check_singular(numpy.random.randn(2, 3))
         self.check_singular(numpy.random.randn(2, 2))
         self.check_singular(numpy.random.randn(3, 2))
 
+    @condition.retry(10)
     def test_rank2(self):
         self.check_rank2(cupy.random.randn(2, 3, 4).astype(numpy.float32))
         self.check_rank2(cupy.random.randn(1, 2, 3, 4).astype(numpy.float64))


### PR DESCRIPTION
This PR as `condition.retry` decorator to decomposition functions (`xp.linalg.svd` and `xp.linalg.qr`) as they are numerically-unstable.