### PR TITLE
Check if device is None on array method

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1888,7 +1888,8 @@ cpdef ndarray array(obj, dtype=None, bint copy=True, Py_ssize_t ndmin=0):
         src = obj
         if dtype is None:
             dtype = src.dtype
-        if src.data.device.id == device.get_device_id():
+        if (src.data.device is None or
+            src.data.device.id == device.get_device_id()):
             a = src.astype(dtype, copy=copy)
         else:
             a = src.copy().astype(dtype, copy=False)

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1889,7 +1889,7 @@ cpdef ndarray array(obj, dtype=None, bint copy=True, Py_ssize_t ndmin=0):
         if dtype is None:
             dtype = src.dtype
         if (src.data.device is None or
-            src.data.device.id == device.get_device_id()):
+                src.data.device.id == device.get_device_id()):
             a = src.astype(dtype, copy=copy)
         else:
             a = src.copy().astype(dtype, copy=False)


### PR DESCRIPTION
When `src.data.device` is `None`, `src.data.device.id` is `0`. But this behavior is not expected. I fixed this code to check if the device is `None`. 
See #122 