### PR TITLE
Deny numpy arrays in ufunc outside fuse decorator

### DIFF
--- a/cupy/core/fusion.py
+++ b/cupy/core/fusion.py
@@ -1,6 +1,7 @@
 import six
 from six.moves import builtins
 import string
+import threading
 import warnings
 
 import numpy
@@ -12,6 +13,9 @@ from cupy import math
 from cupy import sorting
 from cupy import statistics
 from cupy import util
+
+
+_thread_local = threading.local()
 
 
 class FusionOp(object):
@@ -592,6 +596,13 @@ class Fusion(object):
         return "<Fusion '%s'>" % self.name
 
     def __call__(self, *args, **kwargs):
+        _thread_local.in_fusion = True
+        try:
+            return self._call(*args, **kwargs)
+        finally:
+            _thread_local.in_fusion = False
+
+    def _call(self, *args, **kwargs):
         axis = kwargs['axis'] if 'axis' in kwargs else None
         if len(args) == 0:
             raise Exception('number of arguments must be more than 0')
@@ -684,12 +695,14 @@ class ufunc(core.ufunc):
         return repr(self._cupy_op)
 
     def __call__(self, *args, **kwargs):
-        if builtins.any(type(_) is _FusionRef for _ in args):
-            return _convert(self._fusion_op)(*args, **kwargs)
-        elif builtins.any(type(_) is numpy.ndarray for _ in args):
-            return self._numpy_op(*args, **kwargs)
-        else:
-            return self._cupy_op(*args, **kwargs)
+        in_fusion = getattr(_thread_local, 'in_fusion', False)
+        if in_fusion:
+            if builtins.any(isinstance(_, _FusionRef) for _ in args):
+                return _convert(self._fusion_op)(*args, **kwargs)
+            elif builtins.any(isinstance(_, numpy.ndarray) for _ in args):
+                return self._numpy_op(*args, **kwargs)
+
+        return self._cupy_op(*args, **kwargs)
 
     __doc__ = core.ufunc.__doc__
     __call__.__doc__ = core.ufunc.__call__.__doc__

--- a/tests/cupy_tests/core_tests/test_fusion.py
+++ b/tests/cupy_tests/core_tests/test_fusion.py
@@ -560,8 +560,10 @@ class TestFusionUfunc(unittest.TestCase):
 
         ret0 = func(*data)  # Non-fused
         ret1 = f(*data)  # Fused
-        ret0 = list(ret0) if isinstance(ret0, tuple) else [ret0]
-        ret1 = list(ret1) if isinstance(ret1, tuple) else [ret1]
+        if not isinstance(ret0, tuple):
+            ret0 = [ret0]
+        if not isinstance(ret1, tuple):
+            ret1 = [ret1]
         for nf, f in zip(ret0, ret1):
             numpy.testing.assert_array_almost_equal(nf.get(), f.get())
 

--- a/tests/cupy_tests/math_tests/test_arithmetic.py
+++ b/tests/cupy_tests/math_tests/test_arithmetic.py
@@ -1,5 +1,8 @@
+import itertools
+import numpy
 import unittest
 
+import cupy
 from cupy import testing
 
 
@@ -41,19 +44,34 @@ class TestArithmetic(unittest.TestCase):
         b = xp.array([4, 3, 2, 1, -1, -2], dtype=dtype)
         return getattr(xp, name)(a, b)
 
+    def check_raises_with_numpy_input(self, nargs, name):
+        # Check TypeError is raised if numpy.ndarray is given as input
+        func = getattr(cupy, name)
+        for input_xp_list in itertools.product(*[[numpy, cupy]] * nargs):
+            if all(xp is cupy for xp in input_xp_list):
+                # We don't test all-cupy-array inputs here
+                continue
+            arys = [xp.array([2, -3]) for xp in input_xp_list]
+            with self.assertRaises(TypeError):
+                func(*arys)
+
     def test_add(self):
         self.check_binary('add')
+        self.check_raises_with_numpy_input(2, 'add')
 
     def test_reciprocal(self):
         with testing.NumpyError(divide='ignore', invalid='ignore'):
             self.check_unary('reciprocal')
+        self.check_raises_with_numpy_input(1, 'reciprocal')
 
     def test_multiply(self):
         self.check_binary('multiply')
+        self.check_raises_with_numpy_input(2, 'multiply')
 
     def test_divide(self):
         with testing.NumpyError(divide='ignore'):
             self.check_binary('divide')
+        self.check_raises_with_numpy_input(2, 'divide')
 
     def test_divide_negative(self):
         with testing.NumpyError(divide='ignore'):
@@ -61,16 +79,19 @@ class TestArithmetic(unittest.TestCase):
 
     def test_power(self):
         self.check_binary('power')
+        self.check_raises_with_numpy_input(2, 'power')
 
     def test_power_negative(self):
         self.check_binary_negative_float('power')
 
     def test_subtract(self):
         self.check_binary('subtract')
+        self.check_raises_with_numpy_input(2, 'subtract')
 
     def test_true_divide(self):
         with testing.NumpyError(divide='ignore'):
             self.check_binary('true_divide')
+        self.check_raises_with_numpy_input(2, 'true_divide')
 
     def test_true_divide_negative(self):
         with testing.NumpyError(divide='ignore'):
@@ -79,6 +100,7 @@ class TestArithmetic(unittest.TestCase):
     def test_floor_divide(self):
         with testing.NumpyError(divide='ignore'):
             self.check_binary('floor_divide')
+        self.check_raises_with_numpy_input(2, 'floor_divide')
 
     def test_floor_divide_negative(self):
         with testing.NumpyError(divide='ignore'):
@@ -87,6 +109,7 @@ class TestArithmetic(unittest.TestCase):
     def test_fmod(self):
         with testing.NumpyError(divide='ignore'):
             self.check_binary('fmod')
+        self.check_raises_with_numpy_input(2, 'fmod')
 
     def test_fmod_negative(self):
         with testing.NumpyError(divide='ignore'):
@@ -105,6 +128,7 @@ class TestArithmetic(unittest.TestCase):
     def test_remainder(self):
         with testing.NumpyError(divide='ignore'):
             self.check_binary('remainder')
+        self.check_raises_with_numpy_input(2, 'remainder')
 
     def test_remainder_negative(self):
         with testing.NumpyError(divide='ignore'):


### PR DESCRIPTION
Fixes #147 

(Additional notes)
I removed all numpy-cupy comparison tests in `test_fusion.py`.
Instead, equality is tested between non-fused cupy computation and fused cupy computation.