### PR TITLE
Make count_nonzero to return array

### DIFF
--- a/cupy/sorting/count.py
+++ b/cupy/sorting/count.py
@@ -4,21 +4,24 @@ from cupy import core
 def count_nonzero(a, axis=None):
     """Counts the number of non-zero values in the array.
 
+    .. note::
+
+       :func:`numpy.count_nonzero` returns `int` value when `axis=None`,
+       but :func:`cupy.count_nonzero` returns zero-dimensional array to reduce
+       CPU-GPU synchronization.
+
     Args:
         a (cupy.ndarray): The array for which to count non-zeros.
         axis (int or tuple, optional): Axis or tuple of axes along which to
             count non-zeros. Default is None, meaning that non-zeros will be
             counted along a flattened version of ``a``
     Returns:
-        int or cupy.ndarray of int: Number of non-zero values in the array
+        cupy.ndarray of int: Number of non-zero values in the array
             along a given axis. Otherwise, the total number of non-zero values
             in the array is returned.
     """
 
-    if axis is None:
-        return int(_count_nonzero(a))
-    else:
-        return _count_nonzero(a, axis=axis)
+    return _count_nonzero(a, axis=axis)
 
 
 _count_nonzero = core.create_reduction_func(

--- a/tests/cupy_tests/sorting_tests/test_count.py
+++ b/tests/cupy_tests/sorting_tests/test_count.py
@@ -18,8 +18,7 @@ class TestCount(unittest.TestCase):
             m = testing.shaped_random((2, 3), xp, xp.bool_)
             a = testing.shaped_random((2, 3), xp, dtype) * m
             c = xp.count_nonzero(a)
-            self.assertIsInstance(c, int)
-            return c
+            return int(c)
         self.assertEqual(func(numpy), func(cupy))
 
     @testing.for_all_dtypes()
@@ -27,8 +26,7 @@ class TestCount(unittest.TestCase):
         def func(xp):
             a = xp.array(1.0, dtype=dtype)
             c = xp.count_nonzero(a)
-            self.assertIsInstance(c, int)
-            return c
+            return int(c)
         self.assertEqual(func(numpy), func(cupy))
 
     @testing.with_requires('numpy>=1.12')

--- a/tests/cupy_tests/sorting_tests/test_count.py
+++ b/tests/cupy_tests/sorting_tests/test_count.py
@@ -26,6 +26,12 @@ class TestCount(unittest.TestCase):
         def func(xp):
             a = xp.array(1.0, dtype=dtype)
             c = xp.count_nonzero(a)
+            if xp is cupy:
+                # CuPy returns zero-dimensional array instead of
+                # returning a scalar value
+                self.assertIsInstance(c, xp.ndarray)
+                self.assertEqual(c.dtype, 'l')
+                self.assertEqual(c.shape, ())
             return int(c)
         self.assertEqual(func(numpy), func(cupy))
 

--- a/tests/cupy_tests/sorting_tests/test_count.py
+++ b/tests/cupy_tests/sorting_tests/test_count.py
@@ -18,6 +18,12 @@ class TestCount(unittest.TestCase):
             m = testing.shaped_random((2, 3), xp, xp.bool_)
             a = testing.shaped_random((2, 3), xp, dtype) * m
             c = xp.count_nonzero(a)
+            if xp is cupy:
+                # CuPy returns zero-dimensional array instead of
+                # returning a scalar value
+                self.assertIsInstance(c, xp.ndarray)
+                self.assertEqual(c.dtype, 'l')
+                self.assertEqual(c.shape, ())
             return int(c)
         self.assertEqual(func(numpy), func(cupy))
 


### PR DESCRIPTION
I fixed `count_nonzero` to return `ndarray` instead of `int`. It is faster because there is not synchronization between CPU and GPU.
see also #95 