### PR TITLE
Change allocation_unit_size from 256 to 512

### DIFF
--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -340,7 +340,9 @@ cdef class SingleDeviceMemoryPool:
         self._free = collections.defaultdict(list)
         self._alloc = allocator
         self._weakref = weakref.ref(self)
-        self._allocation_unit_size = 256
+        # cudaMalloc() is aligned to at least 512 bytes
+        # cf. https://gist.github.com/sonots/41daaa6432b1c8b27ef782cd14064269
+        self._allocation_unit_size = 512
 
     cpdef MemoryPointer malloc(self, Py_ssize_t size):
         cdef list free


### PR DESCRIPTION
I investigated the least alignment of cudaMalloc, and it was 512 bytes, not 256 bytes with GeForce GTX TITAN X and NVIDIA Tesla k80 (AWS p2.xlarge).
See https://gist.github.com/sonots/41daaa6432b1c8b27ef782cd14064269

It is better to change the round size (`allocation_unit_size`) from 256 bytes to 512 bytes.