### PR TITLE
Add total_bytes(), free_bytes(), and used_bytes() methods to memory pool

### DIFF
--- a/cupy/cuda/memory.pxd
+++ b/cupy/cuda/memory.pxd
@@ -56,6 +56,9 @@ cdef class SingleDeviceMemoryPool:
     cpdef free_all_blocks(self)
     cpdef free_all_free(self)
     cpdef n_free_blocks(self)
+    cpdef used_bytes(self)
+    cpdef free_bytes(self)
+    cpdef total_bytes(self)
 
 
 cdef class MemoryPool:
@@ -67,3 +70,6 @@ cdef class MemoryPool:
     cpdef free_all_blocks(self)
     cpdef free_all_free(self)
     cpdef n_free_blocks(self)
+    cpdef used_bytes(self)
+    cpdef free_bytes(self)
+    cpdef total_bytes(self)

--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -404,6 +404,22 @@ cdef class SingleDeviceMemoryPool:
             n += len(v)
         return n
 
+    cpdef used_bytes(self):
+        cdef Py_ssize_t size = 0
+        for mem in six.itervalues(self._in_use):
+            size += mem.size
+        return size
+
+    cpdef free_bytes(self):
+        cdef Py_ssize_t size = 0
+        for free_list in six.itervalues(self._free):
+            for mem in free_list:
+                size += mem.size
+        return size
+
+    cpdef total_bytes(self):
+        return self.used_bytes() + self.free_bytes()
+
 
 cdef class MemoryPool(object):
 
@@ -475,3 +491,30 @@ cdef class MemoryPool(object):
         """
         mp = <SingleDeviceMemoryPool>self._pools[device.get_device_id()]
         return mp.n_free_blocks()
+
+    cpdef used_bytes(self):
+        """Get the total number of bytes used.
+
+        Returns:
+            int: The total number of bytes used.
+        """
+        mp = <SingleDeviceMemoryPool>self._pools[device.get_device_id()]
+        return mp.used_bytes()
+
+    cpdef free_bytes(self):
+        """Get the total number of bytes acquired but not used in the pool.
+
+        Returns:
+            int: The total number of bytes acquired but not used in the pool.
+        """
+        mp = <SingleDeviceMemoryPool>self._pools[device.get_device_id()]
+        return mp.free_bytes()
+
+    cpdef total_bytes(self):
+        """Get the total number of bytes acquired in the pool.
+
+        Returns:
+            int: The total number of bytes acquired in the pool.
+        """
+        mp = <SingleDeviceMemoryPool>self._pools[device.get_device_id()]
+        return mp.total_bytes()

--- a/tests/cupy_tests/cuda_tests/test_memory.py
+++ b/tests/cupy_tests/cuda_tests/test_memory.py
@@ -149,6 +149,8 @@ class TestSingleDeviceMemoryPool(unittest.TestCase):
         self.assertEqual(1024, self.pool.used_bytes())
         p2 = self.pool.malloc(2000)
         self.assertEqual(3072, self.pool.used_bytes())
+        del p1
+        del p2
 
     def test_free_bytes(self):
         p1 = self.pool.malloc(1000)

--- a/tests/cupy_tests/cuda_tests/test_memory.py
+++ b/tests/cupy_tests/cuda_tests/test_memory.py
@@ -144,6 +144,29 @@ class TestSingleDeviceMemoryPool(unittest.TestCase):
         p2 = self.pool.malloc(1000)
         self.assertNotEqual(ptr1, p2.ptr)
 
+    def test_used_bytes(self):
+        p1 = self.pool.malloc(1000)
+        self.assertEqual(1024, self.pool.used_bytes())
+        p2 = self.pool.malloc(2000)
+        self.assertEqual(3072, self.pool.used_bytes())
+
+    def test_free_bytes(self):
+        p1 = self.pool.malloc(1000)
+        del p1
+        self.assertEqual(1024, self.pool.free_bytes())
+        p2 = self.pool.malloc(2000)
+        del p2
+        self.assertEqual(3072, self.pool.free_bytes())
+
+    def test_total_bytes(self):
+        p1 = self.pool.malloc(1000)
+        self.assertEqual(1024, self.pool.total_bytes())
+        p2 = self.pool.malloc(2000)
+        del p1
+        self.assertEqual(3072, self.pool.total_bytes())
+        del p2
+        self.assertEqual(3072, self.pool.total_bytes())
+
 
 @testing.gpu
 class TestMemoryPool(unittest.TestCase):
@@ -201,3 +224,15 @@ class TestMemoryPool(unittest.TestCase):
         with cupy.cuda.Device(0):
             # call directly without malloc/free_all_free.
             self.assertEqual(self.pool.n_free_blocks(), 0)
+
+    def test_used_bytes(self):
+        with cupy.cuda.Device(0):
+            self.assertEqual(0, self.pool.used_bytes())
+
+    def test_free_bytes(self):
+        with cupy.cuda.Device(0):
+            self.assertEqual(0, self.pool.free_bytes())
+
+    def test_total_bytes(self):
+        with cupy.cuda.Device(0):
+            self.assertEqual(0, self.pool.total_bytes())


### PR DESCRIPTION
I propose to add API to get total bytes, free bytes, and bytes used in the MemoryPool.

With this API, users of chainer will be able to examine memory usage as:

```
from chainer.cuda import memory_pool

print(memory_pool.total_bytes())
```

Note that `free_bytes()` does not mean free bytes in the GPU, but means that memory acquired to the pool, but not used. 
