### PR TITLE
Small fixes for cupy.sort

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -733,7 +733,8 @@ cdef class ndarray:
 
         # TODO(takagi): Support sorting views
         if not self._c_contiguous:
-            raise ValueError('Sorting non-contiguous array is not supported.')
+            raise NotImplementedError('Sorting non-contiguous array is not '
+                                      'supported.')
 
         # TODO(takagi): Support float16 and bool
         try:

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -736,9 +736,8 @@ cdef class ndarray:
             raise ValueError('Sorting non-contiguous array is not supported.')
 
         # TODO(takagi): Support float16 and bool
-        c_shape = numpy.array(self.shape, dtype=numpy.intp).ctypes
         try:
-            thrust.sort(self.dtype, self.data.ptr, self.ndim, c_shape.data)
+            thrust.sort(self.dtype, self.data.ptr, self._shape)
         except NameError:
             msg = ('Thrust is needed to use cupy.sort. Please install CUDA '
                    'Toolkit with Thrust then reinstall CuPy after '

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -729,7 +729,7 @@ cdef class ndarray:
 
         if self.ndim == 0:
             raise ValueError('Sorting arrays with the rank of zero is not '
-                             'supported')
+                             'supported')  # as numpy.sort() raises
 
         # TODO(takagi): Support sorting views
         if not self._c_contiguous:

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -728,8 +728,8 @@ cdef class ndarray:
         # TODO(takagi): Support kind argument.
 
         if self.ndim == 0:
-            msg = 'Sorting arrays with the rank of zero is not supported'
-            raise ValueError(msg)
+            raise ValueError('Sorting arrays with the rank of zero is not '
+                             'supported')
 
         # TODO(takagi): Support sorting views
         if not self._c_contiguous:
@@ -739,10 +739,9 @@ cdef class ndarray:
         try:
             thrust.sort(self.dtype, self.data.ptr, self._shape)
         except NameError:
-            msg = ('Thrust is needed to use cupy.sort. Please install CUDA '
-                   'Toolkit with Thrust then reinstall CuPy after '
-                   'uninstalling it.')
-            raise RuntimeError(msg)
+            raise RuntimeError('Thrust is needed to use cupy.sort. Please '
+                               'install CUDA Toolkit with Thrust then '
+                               'reinstall CuPy after uninstalling it.')
 
     def argsort(self):
         """Return the indices that would sort an array with stable sorting

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -736,7 +736,7 @@ cdef class ndarray:
             raise ValueError('Sorting non-contiguous array is not supported.')
 
         # TODO(takagi): Support float16 and bool
-        c_shape = numpy.array(self.shape, dtype=numpy.int64).ctypes
+        c_shape = numpy.array(self.shape, dtype=numpy.intp).ctypes
         try:
             thrust.sort(self.dtype, self.data.ptr, self.ndim, c_shape.data)
         except NameError:

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -736,7 +736,6 @@ cdef class ndarray:
             raise NotImplementedError('Sorting non-contiguous array is not '
                                       'supported.')
 
-        # TODO(takagi): Support float16 and bool
         try:
             thrust.sort(self.dtype, self.data.ptr, self._shape)
         except NameError:

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -714,9 +714,9 @@ cdef class ndarray:
 
         .. note::
            For its implementation reason, ``ndarray.sort`` currently supports
-           only arrays with their rank of one and their own data, and does not
-           support ``axis``, ``kind`` and ``order`` parameters that
-           ``numpy.ndarray.sort`` does support.
+           only arrays with their own data, and does not support ``axis``,
+           ``kind`` and ``order`` parameters that ``numpy.ndarray.sort``
+           does support.
 
         .. seealso::
             :func:`cupy.sort` for full documentation,
@@ -731,19 +731,14 @@ cdef class ndarray:
             msg = 'Sorting arrays with the rank of zero is not supported'
             raise ValueError(msg)
 
-        # TODO(takagi): Support ranks of two or more
-        if self.ndim > 1:
-            msg = ('Sorting arrays with the rank of two or more is '
-                   'not supported')
-            raise ValueError(msg)
-
         # TODO(takagi): Support sorting views
         if not self._c_contiguous:
             raise ValueError('Sorting non-contiguous array is not supported.')
 
         # TODO(takagi): Support float16 and bool
+        c_shape = numpy.array(self.shape, dtype=numpy.int64).ctypes
         try:
-            thrust.sort(self.dtype, self.data.ptr, self._shape[0])
+            thrust.sort(self.dtype, self.data.ptr, self.ndim, c_shape.data)
         except NameError:
             msg = ('Thrust is needed to use cupy.sort. Please install CUDA '
                    'Toolkit with Thrust then reinstall CuPy after '

--- a/cupy/cuda/cupy_thrust.cu
+++ b/cupy/cuda/cupy_thrust.cu
@@ -13,9 +13,10 @@ using namespace thrust;
  */
 
 template <typename T>
-void cupy::thrust::_sort(void *start, size_t ndim, size_t *shape) {
+void cupy::thrust::_sort(void *start, std::vector<ptrdiff_t>& shape) {
 
-    size_t size;
+    size_t ndim = shape.size();
+    ptrdiff_t size;
     device_ptr<T> dp_first, dp_last;
 
     // Compute the total size of the array.
@@ -35,7 +36,7 @@ void cupy::thrust::_sort(void *start, size_t ndim, size_t *shape) {
         // Generate key indices.
         transform(make_counting_iterator<size_t>(0),
                   make_counting_iterator<size_t>(size),
-                  make_constant_iterator<size_t>(shape[ndim-1]),
+                  make_constant_iterator<ptrdiff_t>(shape[ndim-1]),
                   d_keys.begin(),
                   divides<size_t>());
 
@@ -52,16 +53,16 @@ void cupy::thrust::_sort(void *start, size_t ndim, size_t *shape) {
     }
 }
 
-template void cupy::thrust::_sort<cpy_byte>(void *, size_t, size_t *);
-template void cupy::thrust::_sort<cpy_ubyte>(void *, size_t, size_t *);
-template void cupy::thrust::_sort<cpy_short>(void *, size_t, size_t *);
-template void cupy::thrust::_sort<cpy_ushort>(void *, size_t, size_t *);
-template void cupy::thrust::_sort<cpy_int>(void *, size_t, size_t *);
-template void cupy::thrust::_sort<cpy_uint>(void *, size_t, size_t *);
-template void cupy::thrust::_sort<cpy_long>(void *, size_t, size_t *);
-template void cupy::thrust::_sort<cpy_ulong>(void *, size_t, size_t *);
-template void cupy::thrust::_sort<cpy_float>(void *, size_t, size_t *);
-template void cupy::thrust::_sort<cpy_double>(void *, size_t, size_t *);
+template void cupy::thrust::_sort<cpy_byte>(void *, std::vector<ptrdiff_t>& shape);
+template void cupy::thrust::_sort<cpy_ubyte>(void *, std::vector<ptrdiff_t>& shape);
+template void cupy::thrust::_sort<cpy_short>(void *, std::vector<ptrdiff_t>& shape);
+template void cupy::thrust::_sort<cpy_ushort>(void *, std::vector<ptrdiff_t>& shape);
+template void cupy::thrust::_sort<cpy_int>(void *, std::vector<ptrdiff_t>& shape);
+template void cupy::thrust::_sort<cpy_uint>(void *, std::vector<ptrdiff_t>& shape);
+template void cupy::thrust::_sort<cpy_long>(void *, std::vector<ptrdiff_t>& shape);
+template void cupy::thrust::_sort<cpy_ulong>(void *, std::vector<ptrdiff_t>& shape);
+template void cupy::thrust::_sort<cpy_float>(void *, std::vector<ptrdiff_t>& shape);
+template void cupy::thrust::_sort<cpy_double>(void *, std::vector<ptrdiff_t>& shape);
 
 
 /*

--- a/cupy/cuda/cupy_thrust.cu
+++ b/cupy/cuda/cupy_thrust.cu
@@ -24,8 +24,8 @@ void cupy::thrust::_sort(void *start, size_t ndim, size_t *shape) {
         size *= shape[i];
     }
 
-    dp_first = device_pointer_cast((T *)start);
-    dp_last  = device_pointer_cast((T *)start + size);
+    dp_first = device_pointer_cast(static_cast<T*>(start));
+    dp_last  = device_pointer_cast(static_cast<T*>(start) + size);
 
     if (ndim == 1) {
         stable_sort(dp_first, dp_last);

--- a/cupy/cuda/cupy_thrust.cu
+++ b/cupy/cuda/cupy_thrust.cu
@@ -13,7 +13,7 @@ using namespace thrust;
  */
 
 template <typename T>
-void cupy::thrust::_sort(void *start, std::vector<ptrdiff_t>& shape) {
+void cupy::thrust::_sort(void *start, const std::vector<ptrdiff_t>& shape) {
 
     size_t ndim = shape.size();
     ptrdiff_t size;
@@ -53,16 +53,16 @@ void cupy::thrust::_sort(void *start, std::vector<ptrdiff_t>& shape) {
     }
 }
 
-template void cupy::thrust::_sort<cpy_byte>(void *, std::vector<ptrdiff_t>& shape);
-template void cupy::thrust::_sort<cpy_ubyte>(void *, std::vector<ptrdiff_t>& shape);
-template void cupy::thrust::_sort<cpy_short>(void *, std::vector<ptrdiff_t>& shape);
-template void cupy::thrust::_sort<cpy_ushort>(void *, std::vector<ptrdiff_t>& shape);
-template void cupy::thrust::_sort<cpy_int>(void *, std::vector<ptrdiff_t>& shape);
-template void cupy::thrust::_sort<cpy_uint>(void *, std::vector<ptrdiff_t>& shape);
-template void cupy::thrust::_sort<cpy_long>(void *, std::vector<ptrdiff_t>& shape);
-template void cupy::thrust::_sort<cpy_ulong>(void *, std::vector<ptrdiff_t>& shape);
-template void cupy::thrust::_sort<cpy_float>(void *, std::vector<ptrdiff_t>& shape);
-template void cupy::thrust::_sort<cpy_double>(void *, std::vector<ptrdiff_t>& shape);
+template void cupy::thrust::_sort<cpy_byte>(void *, const std::vector<ptrdiff_t>& shape);
+template void cupy::thrust::_sort<cpy_ubyte>(void *, const std::vector<ptrdiff_t>& shape);
+template void cupy::thrust::_sort<cpy_short>(void *, const std::vector<ptrdiff_t>& shape);
+template void cupy::thrust::_sort<cpy_ushort>(void *, const std::vector<ptrdiff_t>& shape);
+template void cupy::thrust::_sort<cpy_int>(void *, const std::vector<ptrdiff_t>& shape);
+template void cupy::thrust::_sort<cpy_uint>(void *, const std::vector<ptrdiff_t>& shape);
+template void cupy::thrust::_sort<cpy_long>(void *, const std::vector<ptrdiff_t>& shape);
+template void cupy::thrust::_sort<cpy_ulong>(void *, const std::vector<ptrdiff_t>& shape);
+template void cupy::thrust::_sort<cpy_float>(void *, const std::vector<ptrdiff_t>& shape);
+template void cupy::thrust::_sort<cpy_double>(void *, const std::vector<ptrdiff_t>& shape);
 
 
 /*

--- a/cupy/cuda/cupy_thrust.cu
+++ b/cupy/cuda/cupy_thrust.cu
@@ -1,4 +1,5 @@
 #include <thrust/device_ptr.h>
+#include <thrust/device_vector.h>
 #include <thrust/sequence.h>
 #include <thrust/sort.h>
 #include "cupy_common.h"
@@ -12,22 +13,55 @@ using namespace thrust;
  */
 
 template <typename T>
-void cupy::thrust::_sort(void *start, ptrdiff_t num) {
-    device_ptr<T> dp_first = device_pointer_cast((T *)start);
-    device_ptr<T> dp_last  = device_pointer_cast((T *)start + num);
-    stable_sort< device_ptr<T> >(dp_first, dp_last);
+void cupy::thrust::_sort(void *start, size_t ndim, size_t *shape) {
+
+    size_t size;
+    device_ptr<T> dp_first, dp_last;
+
+    // Compute the total size of the array.
+    size = shape[0];
+    for (size_t i = 1; i < ndim; ++i) {
+        size *= shape[i];
+    }
+
+    dp_first = device_pointer_cast((T *)start);
+    dp_last  = device_pointer_cast((T *)start + size);
+
+    if (ndim == 1) {
+        stable_sort(dp_first, dp_last);
+    } else {
+        device_vector<size_t> d_keys(size);
+
+        // Generate key indices.
+        transform(make_counting_iterator<size_t>(0),
+                  make_counting_iterator<size_t>(size),
+                  make_constant_iterator<size_t>(shape[ndim-1]),
+                  d_keys.begin(),
+                  divides<size_t>());
+
+        // Sorting with back-to-back approach.
+        stable_sort_by_key(dp_first,
+                           dp_last,
+                           d_keys.begin(),
+                           less<T>());
+
+        stable_sort_by_key(d_keys.begin(),
+                           d_keys.end(),
+                           dp_first,
+                           less<size_t>());
+    }
 }
 
-template void cupy::thrust::_sort<cpy_byte>(void *, ptrdiff_t);
-template void cupy::thrust::_sort<cpy_ubyte>(void *, ptrdiff_t);
-template void cupy::thrust::_sort<cpy_short>(void *, ptrdiff_t);
-template void cupy::thrust::_sort<cpy_ushort>(void *, ptrdiff_t);
-template void cupy::thrust::_sort<cpy_int>(void *, ptrdiff_t);
-template void cupy::thrust::_sort<cpy_uint>(void *, ptrdiff_t);
-template void cupy::thrust::_sort<cpy_long>(void *, ptrdiff_t);
-template void cupy::thrust::_sort<cpy_ulong>(void *, ptrdiff_t);
-template void cupy::thrust::_sort<cpy_float>(void *, ptrdiff_t);
-template void cupy::thrust::_sort<cpy_double>(void *, ptrdiff_t);
+template void cupy::thrust::_sort<cpy_byte>(void *, size_t, size_t *);
+template void cupy::thrust::_sort<cpy_ubyte>(void *, size_t, size_t *);
+template void cupy::thrust::_sort<cpy_short>(void *, size_t, size_t *);
+template void cupy::thrust::_sort<cpy_ushort>(void *, size_t, size_t *);
+template void cupy::thrust::_sort<cpy_int>(void *, size_t, size_t *);
+template void cupy::thrust::_sort<cpy_uint>(void *, size_t, size_t *);
+template void cupy::thrust::_sort<cpy_long>(void *, size_t, size_t *);
+template void cupy::thrust::_sort<cpy_ulong>(void *, size_t, size_t *);
+template void cupy::thrust::_sort<cpy_float>(void *, size_t, size_t *);
+template void cupy::thrust::_sort<cpy_double>(void *, size_t, size_t *);
 
 
 /*

--- a/cupy/cuda/cupy_thrust.h
+++ b/cupy/cuda/cupy_thrust.h
@@ -7,7 +7,7 @@ namespace cupy {
 
 namespace thrust {
 
-template <typename T> void _sort(void *, ptrdiff_t);
+template <typename T> void _sort(void *, size_t, size_t *);
 
 template <typename T> void _lexsort(size_t *, void *, size_t, size_t);
    
@@ -25,7 +25,7 @@ namespace cupy {
 
 namespace thrust {
 
-template <typename T> void _sort(void *, ptrdiff_t) { return; }
+template <typename T> void _sort(void *, size_t, size_t *) { return; }
 
 template <typename T> void _lexsort(size_t *, void *, size_t, size_t) { return; }
 

--- a/cupy/cuda/cupy_thrust.h
+++ b/cupy/cuda/cupy_thrust.h
@@ -7,7 +7,7 @@ namespace cupy {
 
 namespace thrust {
 
-template <typename T> void _sort(void *, std::vector<ptrdiff_t>&);
+template <typename T> void _sort(void *, const std::vector<ptrdiff_t>&);
 
 template <typename T> void _lexsort(size_t *, void *, size_t, size_t);
    
@@ -25,7 +25,7 @@ namespace cupy {
 
 namespace thrust {
 
-template <typename T> void _sort(void *, std::vector<ptrdiff_t>&) { return; }
+template <typename T> void _sort(void *, const std::vector<ptrdiff_t>&) { return; }
 
 template <typename T> void _lexsort(size_t *, void *, size_t, size_t) { return; }
 

--- a/cupy/cuda/cupy_thrust.h
+++ b/cupy/cuda/cupy_thrust.h
@@ -7,7 +7,7 @@ namespace cupy {
 
 namespace thrust {
 
-template <typename T> void _sort(void *, size_t, size_t *);
+template <typename T> void _sort(void *, std::vector<ptrdiff_t>&);
 
 template <typename T> void _lexsort(size_t *, void *, size_t, size_t);
    
@@ -25,7 +25,7 @@ namespace cupy {
 
 namespace thrust {
 
-template <typename T> void _sort(void *, size_t, size_t *) { return; }
+template <typename T> void _sort(void *, std::vector<ptrdiff_t>&) { return; }
 
 template <typename T> void _lexsort(size_t *, void *, size_t, size_t) { return; }
 

--- a/cupy/cuda/thrust.pyx
+++ b/cupy/cuda/thrust.pyx
@@ -4,6 +4,7 @@
 
 cimport cython
 import numpy
+from libcpp.vector cimport vector
 
 from cupy.cuda cimport common
 
@@ -13,7 +14,7 @@ from cupy.cuda cimport common
 ###############################################################################
 
 cdef extern from "../cuda/cupy_thrust.h" namespace "cupy::thrust":
-    void _sort[T](void *start, size_t ndim, size_t *shape)
+    void _sort[T](void *start, vector.vector[ptrdiff_t]&)
     void _lexsort[T](size_t *idx_start, void *keys_start, size_t k, size_t n)
     void _argsort[T](size_t *idx_start, void *data_start, size_t num)
 
@@ -22,36 +23,32 @@ cdef extern from "../cuda/cupy_thrust.h" namespace "cupy::thrust":
 # Python interface
 ###############################################################################
 
-cpdef sort(dtype, size_t start, size_t ndim, size_t shape):
-    cdef void *_start
-    cdef size_t _ndim
-    cdef size_t *_shape
+cpdef sort(dtype, size_t start, vector.vector[ptrdiff_t]& shape):
 
+    cdef void *_start
     _start = <void *>start
-    _ndim = <size_t>ndim
-    _shape = <size_t *>shape
 
     # TODO(takagi): Support float16 and bool
     if dtype == numpy.int8:
-        _sort[common.cpy_byte](_start, _ndim, _shape)
+        _sort[common.cpy_byte](_start, shape)
     elif dtype == numpy.uint8:
-        _sort[common.cpy_ubyte](_start, _ndim, _shape)
+        _sort[common.cpy_ubyte](_start, shape)
     elif dtype == numpy.int16:
-        _sort[common.cpy_short](_start, _ndim, _shape)
+        _sort[common.cpy_short](_start, shape)
     elif dtype == numpy.uint16:
-        _sort[common.cpy_ushort](_start, _ndim, _shape)
+        _sort[common.cpy_ushort](_start, shape)
     elif dtype == numpy.int32:
-        _sort[common.cpy_int](_start, _ndim, _shape)
+        _sort[common.cpy_int](_start, shape)
     elif dtype == numpy.uint32:
-        _sort[common.cpy_uint](_start, _ndim, _shape)
+        _sort[common.cpy_uint](_start, shape)
     elif dtype == numpy.int64:
-        _sort[common.cpy_long](_start, _ndim, _shape)
+        _sort[common.cpy_long](_start, shape)
     elif dtype == numpy.uint64:
-        _sort[common.cpy_ulong](_start, _ndim, _shape)
+        _sort[common.cpy_ulong](_start, shape)
     elif dtype == numpy.float32:
-        _sort[common.cpy_float](_start, _ndim, _shape)
+        _sort[common.cpy_float](_start, shape)
     elif dtype == numpy.float64:
-        _sort[common.cpy_double](_start, _ndim, _shape)
+        _sort[common.cpy_double](_start, shape)
     else:
         msg = "Sorting arrays with dtype '{}' is not supported"
         raise TypeError(msg.format(dtype))

--- a/cupy/cuda/thrust.pyx
+++ b/cupy/cuda/thrust.pyx
@@ -50,8 +50,8 @@ cpdef sort(dtype, size_t start, vector.vector[ptrdiff_t]& shape):
     elif dtype == numpy.float64:
         _sort[common.cpy_double](_start, shape)
     else:
-        raise TypeError('Sorting arrays with dtype \'{}\' is not '
-                        'supported'.format(dtype))
+        raise NotImplementedError('Sorting arrays with dtype \'{}\' is not '
+                                  'supported'.format(dtype))
 
 
 cpdef lexsort(dtype, size_t idx_start, size_t keys_start, size_t k, size_t n):

--- a/cupy/cuda/thrust.pyx
+++ b/cupy/cuda/thrust.pyx
@@ -50,8 +50,8 @@ cpdef sort(dtype, size_t start, vector.vector[ptrdiff_t]& shape):
     elif dtype == numpy.float64:
         _sort[common.cpy_double](_start, shape)
     else:
-        msg = "Sorting arrays with dtype '{}' is not supported"
-        raise TypeError(msg.format(dtype))
+        raise TypeError('Sorting arrays with dtype \'{}\' is not '
+                        'supported'.format(dtype))
 
 
 cpdef lexsort(dtype, size_t idx_start, size_t keys_start, size_t k, size_t n):

--- a/cupy/cuda/thrust.pyx
+++ b/cupy/cuda/thrust.pyx
@@ -14,7 +14,7 @@ from cupy.cuda cimport common
 ###############################################################################
 
 cdef extern from "../cuda/cupy_thrust.h" namespace "cupy::thrust":
-    void _sort[T](void *start, vector.vector[ptrdiff_t]&)
+    void _sort[T](void *start, const vector.vector[ptrdiff_t]&)
     void _lexsort[T](size_t *idx_start, void *keys_start, size_t k, size_t n)
     void _argsort[T](size_t *idx_start, void *data_start, size_t num)
 

--- a/cupy/cuda/thrust.pyx
+++ b/cupy/cuda/thrust.pyx
@@ -13,7 +13,7 @@ from cupy.cuda cimport common
 ###############################################################################
 
 cdef extern from "../cuda/cupy_thrust.h" namespace "cupy::thrust":
-    void _sort[T](void *start, ptrdiff_t num)
+    void _sort[T](void *start, size_t ndim, size_t *shape)
     void _lexsort[T](size_t *idx_start, void *keys_start, size_t k, size_t n)
     void _argsort[T](size_t *idx_start, void *data_start, size_t num)
 
@@ -22,34 +22,36 @@ cdef extern from "../cuda/cupy_thrust.h" namespace "cupy::thrust":
 # Python interface
 ###############################################################################
 
-cpdef sort(dtype, size_t start, size_t num):
-    cdef void* ptr
-    cdef Py_ssize_t n
+cpdef sort(dtype, size_t start, size_t ndim, size_t shape):
+    cdef void *_start
+    cdef size_t _ndim
+    cdef size_t *_shape
 
-    ptr = <void *>start
-    n = <Py_ssize_t> num
+    _start = <void *>start
+    _ndim = <size_t>ndim
+    _shape = <size_t *>shape
 
     # TODO(takagi): Support float16 and bool
     if dtype == numpy.int8:
-        _sort[common.cpy_byte](ptr, n)
+        _sort[common.cpy_byte](_start, _ndim, _shape)
     elif dtype == numpy.uint8:
-        _sort[common.cpy_ubyte](ptr, n)
+        _sort[common.cpy_ubyte](_start, _ndim, _shape)
     elif dtype == numpy.int16:
-        _sort[common.cpy_short](ptr, n)
+        _sort[common.cpy_short](_start, _ndim, _shape)
     elif dtype == numpy.uint16:
-        _sort[common.cpy_ushort](ptr, n)
+        _sort[common.cpy_ushort](_start, _ndim, _shape)
     elif dtype == numpy.int32:
-        _sort[common.cpy_int](ptr, n)
+        _sort[common.cpy_int](_start, _ndim, _shape)
     elif dtype == numpy.uint32:
-        _sort[common.cpy_uint](ptr, n)
+        _sort[common.cpy_uint](_start, _ndim, _shape)
     elif dtype == numpy.int64:
-        _sort[common.cpy_long](ptr, n)
+        _sort[common.cpy_long](_start, _ndim, _shape)
     elif dtype == numpy.uint64:
-        _sort[common.cpy_ulong](ptr, n)
+        _sort[common.cpy_ulong](_start, _ndim, _shape)
     elif dtype == numpy.float32:
-        _sort[common.cpy_float](ptr, n)
+        _sort[common.cpy_float](_start, _ndim, _shape)
     elif dtype == numpy.float64:
-        _sort[common.cpy_double](ptr, n)
+        _sort[common.cpy_double](_start, _ndim, _shape)
     else:
         msg = "Sorting arrays with dtype '{}' is not supported"
         raise TypeError(msg.format(dtype))

--- a/cupy/sorting/sort.py
+++ b/cupy/sorting/sort.py
@@ -15,9 +15,9 @@ def sort(a):
         cupy.ndarray: Array of the same type and shape as ``a``.
 
     .. note::
-       For its implementation reason, ``cupy.sort`` currently supports only
-       arrays with their rank of one and does not support ``axis``, ``kind``
-       and ``order`` parameters that ``numpy.sort`` does support.
+       For its implementation reason, ``cupy.sort`` currently does not support
+       ``axis``, ``kind`` and ``order`` parameters that ``numpy.sort`` does
+       support.
 
     .. seealso:: :func:`numpy.sort`
 

--- a/tests/cupy_tests/sorting_tests/test_sort.py
+++ b/tests/cupy_tests/sorting_tests/test_sort.py
@@ -54,13 +54,13 @@ class TestSort(unittest.TestCase):
     @testing.for_dtypes([numpy.float16, numpy.bool_])
     def test_sort_unsupported_dtype(self, dtype):
         a = testing.shaped_random((10,), cupy, dtype)
-        with self.assertRaises(TypeError):
+        with self.assertRaises(NotImplementedError):
             a.sort()
 
     @testing.for_dtypes([numpy.float16, numpy.bool_])
     def test_external_sort_unsupported_dtype(self, dtype):
         a = testing.shaped_random((10,), cupy, dtype)
-        with self.assertRaises(TypeError):
+        with self.assertRaises(NotImplementedError):
             return cupy.sort(a)
 
     # Test contiguous arrays
@@ -73,7 +73,7 @@ class TestSort(unittest.TestCase):
 
     def test_sort_non_contiguous(self):
         a = testing.shaped_random((10,), cupy)[::2]  # Non contiguous view
-        with self.assertRaises(ValueError):
+        with self.assertRaises(NotImplementedError):
             a.sort()
 
     @testing.numpy_cupy_allclose()

--- a/tests/cupy_tests/sorting_tests/test_sort.py
+++ b/tests/cupy_tests/sorting_tests/test_sort.py
@@ -23,15 +23,16 @@ class TestSort(unittest.TestCase):
         a = testing.shaped_random((), xp)
         return xp.sort(a)
 
-    def test_sort_two_or_more_dim(self):
-        a = testing.shaped_random((2, 3), cupy)
-        with self.assertRaises(ValueError):
-            a.sort()
+    @testing.numpy_cupy_array_equal()
+    def test_sort_two_or_more_dim(self, xp):
+        a = testing.shaped_random((2, 3, 3), xp)
+        a.sort()
+        return a
 
-    def test_external_sort_two_or_more_dim(self):
-        a = testing.shaped_random((2, 3), cupy)
-        with self.assertRaises(ValueError):
-            return cupy.sort(a)
+    @testing.numpy_cupy_array_equal()
+    def test_external_sort_two_or_more_dim(self, xp):
+        a = testing.shaped_random((2, 3, 3), xp)
+        return xp.sort(a)
 
     # Test dtypes
 


### PR DESCRIPTION
Follows #186. This PR is a set of small fixes for `cupy.sort`.