### PR TITLE
Fix Numpy VisibleDeprecationWarning in indexing tests

### DIFF
--- a/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
@@ -79,7 +79,7 @@ class TestArrayAdvancedIndexingGetitemPerm(unittest.TestCase):
     {'shape': (2, 3, 4), 'indexes': numpy.array([], dtype=numpy.bool)},
     {'shape': (2, 3, 4),
      'indexes': (slice(None), numpy.array([], dtype=numpy.bool))},
-    {'shape': (2, 3, 4), 'indexes': numpy.array([[]], dtype=numpy.bool)},
+    {'shape': (2, 3, 4), 'indexes': numpy.array([[], []], dtype=numpy.bool)},
     # list indexes
     {'shape': (2, 3, 4), 'indexes': [1]},
     {'shape': (2, 3, 4), 'indexes': [1, 1]},
@@ -262,7 +262,7 @@ class TestArrayInvalidIndexAdvGetitem(unittest.TestCase):
     {'shape': (2, 3, 4),
      'indexes': (slice(None), numpy.array([], dtype=numpy.bool)),
      'value': 1},
-    {'shape': (2, 3, 4), 'indexes': numpy.array([[]], dtype=numpy.bool),
+    {'shape': (2, 3, 4), 'indexes': numpy.array([[], []], dtype=numpy.bool),
      'value': numpy.random.uniform(size=(4,))},
     # list indexes
     {'shape': (2, 3, 4), 'indexes': [1, 0], 'value': 1},

--- a/tests/cupy_tests/core_tests/test_ndarray_scatter.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_scatter.py
@@ -95,7 +95,7 @@ from cupy import testing
     {'shape': (2, 3, 4),
      'slices': (slice(None), numpy.array([], dtype=numpy.bool)),
      'value': 1},
-    {'shape': (2, 3, 4), 'slices': numpy.array([[]], dtype=numpy.bool),
+    {'shape': (2, 3, 4), 'slices': numpy.array([[], []], dtype=numpy.bool),
      'value': numpy.random.uniform(size=(4,))},
     # list indexes
     {'shape': (2, 3, 4), 'slices': [1], 'value': 1},


### PR DESCRIPTION
NumPy is emitting `VisibleDeprecationWarning` in these tests because of dimension mismatch with boolean index.

```
/home/niboshi/w/repos/cupy/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py:283: VisibleDeprecationWarning: boolean index did not match indexed array along dimension 0; dimension is 2 but corresponding boolean dimension is 1
  a[self.indexes] = self.value
```
