### PR TITLE
Check type in assert_array_list_equal

### DIFF
--- a/cupy/testing/array.py
+++ b/cupy/testing/array.py
@@ -110,6 +110,16 @@ def assert_array_list_equal(xlist, ylist, err_msg='', verbose=True):
 
     .. seealso:: :func:`numpy.testing.assert_array_equal`
     """
+    x_type = type(xlist)
+    y_type = type(ylist)
+    if x_type is not y_type:
+        raise AssertionError(
+            'Matching types of list or tuple are expected, '
+            'but were different types '
+            '(xlist:{} ylist:{})'.format(x_type, y_type))
+    if x_type not in (list, tuple):
+        raise AssertionError(
+            'List or tuple is expected, but was {}'.format(x_type))
     if len(xlist) != len(ylist):
         raise AssertionError('List size is different')
     for x, y in zip(xlist, ylist):

--- a/tests/cupy_tests/creation_tests/test_ranges.py
+++ b/tests/cupy_tests/creation_tests/test_ranges.py
@@ -238,26 +238,26 @@ class TestMgrid(unittest.TestCase):
     def test_mgrid0(self, xp):
         return xp.mgrid[0:]
 
-    @testing.numpy_cupy_array_list_equal()
+    @testing.numpy_cupy_array_equal()
     def test_mgrid1(self, xp):
         return xp.mgrid[-10:10]
 
-    @testing.numpy_cupy_array_list_equal()
+    @testing.numpy_cupy_array_equal()
     def test_mgrid2(self, xp):
         return xp.mgrid[-10:10:10j]
 
-    @testing.numpy_cupy_array_list_equal()
+    @testing.numpy_cupy_array_equal()
     def test_mgrid3(self, xp):
         x = xp.zeros(10)[:, None]
         y = xp.ones(10)[:, None]
         return xp.mgrid[x:y:10j]
 
-    @testing.numpy_cupy_array_list_equal()
+    @testing.numpy_cupy_array_equal()
     def test_mgrid4(self, xp):
         # check len(keys) > 1
         return xp.mgrid[-10:10:10j, -10:10:10j]
 
-    @testing.numpy_cupy_array_list_equal()
+    @testing.numpy_cupy_array_equal()
     def test_mgrid5(self, xp):
         # check len(keys) > 1
         x = xp.zeros(10)[:, None]
@@ -272,15 +272,15 @@ class TestOgrid(unittest.TestCase):
     def test_ogrid0(self, xp):
         return xp.ogrid[0:]
 
-    @testing.numpy_cupy_array_list_equal()
+    @testing.numpy_cupy_array_equal()
     def test_ogrid1(self, xp):
         return xp.ogrid[-10:10]
 
-    @testing.numpy_cupy_array_list_equal()
+    @testing.numpy_cupy_array_equal()
     def test_ogrid2(self, xp):
         return xp.ogrid[-10:10:10j]
 
-    @testing.numpy_cupy_array_list_equal()
+    @testing.numpy_cupy_array_equal()
     def test_ogrid3(self, xp):
         x = xp.zeros(10)[:, None]
         y = xp.ones(10)[:, None]

--- a/tests/cupy_tests/indexing_tests/test_generate.py
+++ b/tests/cupy_tests/indexing_tests/test_generate.py
@@ -11,17 +11,17 @@ class TestIndices(unittest.TestCase):
     _multiprocess_can_split_ = True
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_array_list_equal()
+    @testing.numpy_cupy_array_equal()
     def test_indices_list0(self, xp, dtype):
         return xp.indices((0,), dtype)
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_array_list_equal()
+    @testing.numpy_cupy_array_equal()
     def test_indices_list1(self, xp, dtype):
         return xp.indices((1, 2), dtype)
 
     @testing.for_all_dtypes(no_bool=True)
-    @testing.numpy_cupy_array_list_equal()
+    @testing.numpy_cupy_array_equal()
     def test_indices_list2(self, xp, dtype):
         return xp.indices((1, 2, 3, 4), dtype)
 

--- a/tests/cupy_tests/testing_tests/test_array.py
+++ b/tests/cupy_tests/testing_tests/test_array.py
@@ -61,12 +61,12 @@ class TestListEqualityAssertion(unittest.TestCase):
         self.ys = _convert_array(ys, self.array_module_y)
 
     def test_equality_numpy(self):
-        testing.assert_array_list_equal(self.xs, self.ys)
+        testing.assert_array_equal(self.xs, self.ys)
 
     def test_inequality_numpy(self):
         self.xs[0] += 1
-        with self.assertRaises(AssertionError):
-            testing.assert_array_list_equal(self.xs, self.ys)
+        with self.assertRaisesRegex(AssertionError, '^\nArrays are not equal'):
+            testing.assert_array_equal(self.xs, self.ys)
 
 
 @testing.parameterize(


### PR DESCRIPTION
`assert_array_list_equal` has not checked input types, so it has accepted bare arrays.