### PR TITLE
Remove superfluous type check for Python scalars

### DIFF
--- a/cupy/cuda/function.pyx
+++ b/cupy/cuda/function.pyx
@@ -1,7 +1,6 @@
 # distutils: language = c++
 
 import numpy
-import six
 
 cimport cpython
 from libcpp cimport vector

--- a/cupy/cuda/function.pyx
+++ b/cupy/cuda/function.pyx
@@ -70,16 +70,6 @@ cdef inline CPointer _pointer(x):
     if isinstance(x, core.Indexer):
         return (<core.Indexer>x).get_pointer()
 
-    if type(x) not in _pointer_numpy_types:
-        if isinstance(x, six.integer_types):
-            x = numpy.int64(x)
-        elif isinstance(x, float):
-            x = numpy.float64(x)
-        elif isinstance(x, bool):
-            x = numpy.bool_(x)
-        else:
-            raise TypeError('Unsupported type %s' % type(x))
-
     itemsize = x.itemsize
     if itemsize == 1:
         return CInt8(x.view(numpy.int8))


### PR DESCRIPTION
I think this check is not needed because Python scalars should have been converted to NumPy scalars.