### PR TITLE
Add keyword argument

### DIFF
--- a/tests/cupy_tests/linalg_tests/test_norms.py
+++ b/tests/cupy_tests/linalg_tests/test_norms.py
@@ -127,6 +127,7 @@ class TestSlogdet(unittest.TestCase):
         sign, logdet = xp.linalg.slogdet(a)
         return xp.array([sign, logdet], dtype)
 
+    @testing.for_float_dtypes(no_float16=True)
     @testing.numpy_cupy_raises(accept_error=numpy.linalg.LinAlgError)
     def test_slogdet_one_dim(self, xp, dtype):
         a = testing.shaped_arange((2,), xp, dtype)

--- a/tests/cupy_tests/linalg_tests/test_norms.py
+++ b/tests/cupy_tests/linalg_tests/test_norms.py
@@ -127,7 +127,7 @@ class TestSlogdet(unittest.TestCase):
         sign, logdet = xp.linalg.slogdet(a)
         return xp.array([sign, logdet], dtype)
 
-    @testing.numpy_cupy_raises(numpy.linalg.LinAlgError)
+    @testing.numpy_cupy_raises(accept_error=numpy.linalg.LinAlgError)
     def test_slogdet_one_dim(self, xp, dtype):
         a = testing.shaped_arange((2,), xp, dtype)
         xp.linalg.slogdet(a)


### PR DESCRIPTION
I found that `numpy_cupy_raises` requires keyword argument.