### PR TITLE
Small fixes for cupy.argsort

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -7,6 +7,7 @@ import sys
 import numpy
 import six
 
+import cupy
 from cupy.core import flags
 from cupy.cuda import stream
 try:

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -762,14 +762,13 @@ cdef class ndarray:
         # TODO(takagi): Support kind argument.
 
         if self.ndim == 0:
-            msg = 'Sorting arrays with the rank of zero is not supported'
-            raise ValueError(msg)
+            raise ValueError('Sorting arrays with the rank of zero is not '
+                             'supported')
 
         # TODO(takagi): Support ranks of two or more
         if self.ndim > 1:
-            msg = ('Sorting arrays with the rank of two or more is '
-                   'not supported')
-            raise ValueError(msg)
+            raise ValueError('Sorting arrays with the rank of two or more is '
+                             'not supported')
 
         # Assuming that Py_ssize_t can be represented with numpy.int64.
         assert cython.sizeof(Py_ssize_t) == 8
@@ -781,10 +780,9 @@ cdef class ndarray:
             thrust.argsort(
                 self.dtype, idx_array.data.ptr, self.data.ptr, self._shape[0])
         except NameError:
-            msg = ('Thrust is needed to use cupy.argsort. Please install CUDA '
-                   'Toolkit with Thrust then reinstall CuPy after '
-                   'uninstalling it.')
-            raise RuntimeError(msg)
+            raise RuntimeError('Thrust is needed to use cupy.argsort. Please '
+                               'install CUDA Toolkit with Thrust then '
+                               'reinstall CuPy after uninstalling it.')
 
         return idx_array
 

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -767,8 +767,8 @@ cdef class ndarray:
 
         # TODO(takagi): Support ranks of two or more
         if self.ndim > 1:
-            raise ValueError('Sorting arrays with the rank of two or more is '
-                             'not supported')
+            raise NotImplementedError('Sorting arrays with the rank of two or '
+                                      'more is not supported')
 
         # Assuming that Py_ssize_t can be represented with numpy.int64.
         assert cython.sizeof(Py_ssize_t) == 8

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -780,7 +780,6 @@ cdef class ndarray:
 
         idx_array = ndarray(self.shape, dtype=numpy.int64)
 
-        # TODO(takagi): Support float16 and bool
         thrust.argsort(
             self.dtype, idx_array.data.ptr, self.data.ptr, self._shape[0])
 

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -763,7 +763,7 @@ cdef class ndarray:
 
         if self.ndim == 0:
             raise ValueError('Sorting arrays with the rank of zero is not '
-                             'supported')
+                             'supported')  # as numpy.argsort() raises
 
         # TODO(takagi): Support ranks of two or more
         if self.ndim > 1:

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -761,6 +761,11 @@ cdef class ndarray:
         # TODO(takagi): Support axis argument.
         # TODO(takagi): Support kind argument.
 
+        if not cupy.cuda.thrust_enabled:
+            raise RuntimeError('Thrust is needed to use cupy.argsort. Please '
+                               'install CUDA Toolkit with Thrust then '
+                               'reinstall CuPy after uninstalling it.')
+
         if self.ndim == 0:
             raise ValueError('Sorting arrays with the rank of zero is not '
                              'supported')  # as numpy.argsort() raises
@@ -776,13 +781,8 @@ cdef class ndarray:
         idx_array = ndarray(self.shape, dtype=numpy.int64)
 
         # TODO(takagi): Support float16 and bool
-        try:
-            thrust.argsort(
-                self.dtype, idx_array.data.ptr, self.data.ptr, self._shape[0])
-        except NameError:
-            raise RuntimeError('Thrust is needed to use cupy.argsort. Please '
-                               'install CUDA Toolkit with Thrust then '
-                               'reinstall CuPy after uninstalling it.')
+        thrust.argsort(
+            self.dtype, idx_array.data.ptr, self.data.ptr, self._shape[0])
 
         return idx_array
 

--- a/cupy/cuda/thrust.pyx
+++ b/cupy/cuda/thrust.pyx
@@ -116,5 +116,5 @@ cpdef argsort(dtype, size_t idx_start, size_t data_start, size_t num):
     elif dtype == numpy.float64:
         _argsort[common.cpy_double](idx_ptr, data_ptr, n)
     else:
-        msg = "Sorting arrays with dtype '{}' is not supported"
+        msg = 'Sorting arrays with dtype \'{}\' is not supported'
         raise TypeError(msg.format(dtype))

--- a/cupy/cuda/thrust.pyx
+++ b/cupy/cuda/thrust.pyx
@@ -116,5 +116,5 @@ cpdef argsort(dtype, size_t idx_start, size_t data_start, size_t num):
     elif dtype == numpy.float64:
         _argsort[common.cpy_double](idx_ptr, data_ptr, n)
     else:
-        msg = 'Sorting arrays with dtype \'{}\' is not supported'
-        raise TypeError(msg.format(dtype))
+        raise TypeError('Sorting arrays with dtype \'{}\' is not '
+                        'supported'.format(dtype))

--- a/cupy/cuda/thrust.pyx
+++ b/cupy/cuda/thrust.pyx
@@ -116,5 +116,5 @@ cpdef argsort(dtype, size_t idx_start, size_t data_start, size_t num):
     elif dtype == numpy.float64:
         _argsort[common.cpy_double](idx_ptr, data_ptr, n)
     else:
-        raise TypeError('Sorting arrays with dtype \'{}\' is not '
-                        'supported'.format(dtype))
+        raise NotImplementedError('Sorting arrays with dtype \'{}\' is not '
+                                  'supported'.format(dtype))

--- a/tests/cupy_tests/sorting_tests/test_sort.py
+++ b/tests/cupy_tests/sorting_tests/test_sort.py
@@ -150,12 +150,12 @@ class TestArgsort(unittest.TestCase):
 
     def test_argsort_two_or_more_dim(self):
         a = testing.shaped_random((2, 3), cupy)
-        with self.assertRaises(ValueError):
+        with self.assertRaises(NotImplementedError):
             return a.argsort()
 
     def test_external_argsort_two_or_more_dim(self):
         a = testing.shaped_random((2, 3), cupy)
-        with self.assertRaises(ValueError):
+        with self.assertRaises(NotImplementedError):
             return cupy.argsort(a)
 
     # Test dtypes
@@ -177,13 +177,13 @@ class TestArgsort(unittest.TestCase):
     @testing.for_dtypes([numpy.float16, numpy.bool_])
     def test_argsort_unsupported_dtype(self, dtype):
         a = testing.shaped_random((10,), cupy, dtype)
-        with self.assertRaises(TypeError):
+        with self.assertRaises(NotImplementedError):
             return a.argsort()
 
     @testing.for_dtypes([numpy.float16, numpy.bool_])
     def test_external_argsort_unsupported_dtype(self, dtype):
         a = testing.shaped_random((10,), cupy, dtype)
-        with self.assertRaises(TypeError):
+        with self.assertRaises(NotImplementedError):
             return cupy.argsort(a)
 
     def test_argsort_keep_original_array(self):


### PR DESCRIPTION
Small fixes for `cupy.argsort`.