### PR TITLE
Sort arrays along axes but last

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -710,14 +710,17 @@ cdef class ndarray:
 
         return out
 
-    def sort(self):
+    def sort(self, axis=-1):
         """Sort an array, in-place with a stable sorting algorithm.
+
+        Args:
+            axis (int): Axis along which to sort. Default is -1, which means
+                sort along the last axis.
 
         .. note::
            For its implementation reason, ``ndarray.sort`` currently supports
-           only arrays with their own data, and does not support ``axis``,
-           ``kind`` and ``order`` parameters that ``numpy.ndarray.sort``
-           does support.
+           only arrays with their own data, and does not support ``kind`` and
+           ``order`` parameters that ``numpy.ndarray.sort`` does support.
 
         .. seealso::
             :func:`cupy.sort` for full documentation,
@@ -725,15 +728,16 @@ cdef class ndarray:
 
         """
 
-        # TODO(takagi): Support axis argument.
         # TODO(takagi): Support kind argument.
+
+        cdef Py_ssize_t ndim = self.ndim
 
         if not cupy.cuda.thrust_enabled:
             raise RuntimeError('Thrust is needed to use cupy.sort. Please '
                                'install CUDA Toolkit with Thrust then '
                                'reinstall CuPy after uninstalling it.')
 
-        if self.ndim == 0:
+        if ndim == 0:
             raise ValueError('Sorting arrays with the rank of zero is not '
                              'supported')  # as numpy.sort() raises
 
@@ -742,7 +746,18 @@ cdef class ndarray:
             raise NotImplementedError('Sorting non-contiguous array is not '
                                       'supported.')
 
-        thrust.sort(self.dtype, self.data.ptr, self._shape)
+        if axis < 0:
+            axis += ndim
+        if not (0 <= axis < ndim):
+            raise ValueError('Axis out of range')
+
+        if axis == ndim - 1:
+            thrust.sort(self.dtype, self.data.ptr, self._shape)
+        else:
+            x = cupy.ascontiguousarray(cupy.rollaxis(self, axis, ndim))
+            thrust.sort(self.dtype, x.data.ptr, x._shape)
+            y = cupy.rollaxis(x, -1, axis)
+            elementwise_copy(y, self)
 
     def argsort(self):
         """Return the indices that would sort an array with stable sorting

--- a/cupy/sorting/sort.py
+++ b/cupy/sorting/sort.py
@@ -5,25 +5,27 @@ if cupy.cuda.thrust_enabled:
     from cupy.cuda import thrust
 
 
-def sort(a):
+def sort(a, axis=-1):
     """Returns a sorted copy of an array with a stable sorting algorithm.
 
     Args:
         a (cupy.ndarray): Array to be sorted.
+        axis (int): Axis along which to sort. Default is -1, which means sort
+            along the last axis.
 
     Returns:
         cupy.ndarray: Array of the same type and shape as ``a``.
 
     .. note::
        For its implementation reason, ``cupy.sort`` currently does not support
-       ``axis``, ``kind`` and ``order`` parameters that ``numpy.sort`` does
+       ``kind`` and ``order`` parameters that ``numpy.sort`` does
        support.
 
     .. seealso:: :func:`numpy.sort`
 
     """
     ret = a.copy()
-    ret.sort()
+    ret.sort(axis=axis)
     return ret
 
 

--- a/cupy/sorting/sort.py
+++ b/cupy/sorting/sort.py
@@ -10,8 +10,9 @@ def sort(a, axis=-1):
 
     Args:
         a (cupy.ndarray): Array to be sorted.
-        axis (int): Axis along which to sort. Default is -1, which means sort
-            along the last axis.
+        axis (int or None): Axis along which to sort. Default is -1, which
+            means sort along the last axis. If None is supplied, the array is
+            flattened before sorting.
 
     Returns:
         cupy.ndarray: Array of the same type and shape as ``a``.
@@ -24,7 +25,11 @@ def sort(a, axis=-1):
     .. seealso:: :func:`numpy.sort`
 
     """
-    ret = a.copy()
+    if axis is None:
+        ret = a.flatten()
+        axis = -1
+    else:
+        ret = a.copy()
     ret.sort(axis=axis)
     return ret
 

--- a/tests/cupy_tests/sorting_tests/test_sort.py
+++ b/tests/cupy_tests/sorting_tests/test_sort.py
@@ -108,7 +108,7 @@ class TestSort(unittest.TestCase):
         a = testing.shaped_random((2, 3, 3), xp)
         return xp.sort(a, axis=-2)
 
-    @testing.numpy_cupy_raises()
+    @testing.numpy_cupy_array_equal()
     def test_external_sort_none_axis(self, xp):
         a = testing.shaped_random((2, 3, 3), xp)
         return xp.sort(a, axis=None)

--- a/tests/cupy_tests/sorting_tests/test_sort.py
+++ b/tests/cupy_tests/sorting_tests/test_sort.py
@@ -123,6 +123,16 @@ class TestSort(unittest.TestCase):
         a = testing.shaped_random((2, 3, 3), xp)
         xp.sort(a, axis=3)
 
+    @testing.numpy_cupy_raises()
+    def test_sort_invalid_negative_axis(self, xp):
+        a = testing.shaped_random((2, 3, 3), xp)
+        a.sort(axis=-4)
+
+    @testing.numpy_cupy_raises()
+    def test_external_sort_invalid_negative_axis(self, xp):
+        a = testing.shaped_random((2, 3, 3), xp)
+        xp.sort(a, axis=-4)
+
 
 @testing.gpu
 class TestLexsort(unittest.TestCase):

--- a/tests/cupy_tests/sorting_tests/test_sort.py
+++ b/tests/cupy_tests/sorting_tests/test_sort.py
@@ -97,6 +97,17 @@ class TestSort(unittest.TestCase):
         a = testing.shaped_random((2, 3, 3), xp)
         return xp.sort(a, axis=0)
 
+    @testing.numpy_cupy_array_equal()
+    def test_sort_negative_axis(self, xp):
+        a = testing.shaped_random((2, 3, 3), xp)
+        a.sort(axis=-2)
+        return a
+
+    @testing.numpy_cupy_array_equal()
+    def test_external_sort_negative_axis(self, xp):
+        a = testing.shaped_random((2, 3, 3), xp)
+        return xp.sort(a, axis=-2)
+
     @testing.numpy_cupy_raises()
     def test_sort_invalid_axis(self, xp):
         a = testing.shaped_random((2, 3, 3), xp)

--- a/tests/cupy_tests/sorting_tests/test_sort.py
+++ b/tests/cupy_tests/sorting_tests/test_sort.py
@@ -109,6 +109,11 @@ class TestSort(unittest.TestCase):
         return xp.sort(a, axis=-2)
 
     @testing.numpy_cupy_raises()
+    def test_external_sort_none_axis(self, xp):
+        a = testing.shaped_random((2, 3, 3), xp)
+        return xp.sort(a, axis=None)
+
+    @testing.numpy_cupy_raises()
     def test_sort_invalid_axis(self, xp):
         a = testing.shaped_random((2, 3, 3), xp)
         a.sort(axis=3)

--- a/tests/cupy_tests/sorting_tests/test_sort.py
+++ b/tests/cupy_tests/sorting_tests/test_sort.py
@@ -84,6 +84,29 @@ class TestSort(unittest.TestCase):
         a = testing.shaped_random((10,), xp)[::2]  # Non contiguous view
         return xp.sort(a)
 
+    # Test axis
+
+    @testing.numpy_cupy_array_equal()
+    def test_sort_axis(self, xp):
+        a = testing.shaped_random((2, 3, 3), xp)
+        a.sort(axis=0)
+        return a
+
+    @testing.numpy_cupy_array_equal()
+    def test_external_sort_axis(self, xp):
+        a = testing.shaped_random((2, 3, 3), xp)
+        return xp.sort(a, axis=0)
+
+    @testing.numpy_cupy_raises()
+    def test_sort_invalid_axis(self, xp):
+        a = testing.shaped_random((2, 3, 3), xp)
+        a.sort(axis=3)
+
+    @testing.numpy_cupy_raises()
+    def test_external_sort_invalid_axis(self, xp):
+        a = testing.shaped_random((2, 3, 3), xp)
+        xp.sort(a, axis=3)
+
 
 @testing.gpu
 class TestLexsort(unittest.TestCase):


### PR DESCRIPTION
Please merge #224 first.

Previously, #186 made `cupy.sort` support sorting two or higher rank arrays, but it is only along the last axis.

This PR allows `cupy.sort` to sort such arrays along other axes but last, as well as `axis=None` option that `numpy.sort` has.

Finding no efficient way to operate such sorting on GPU, I have implemented the operation in terms of rolling axes.

