### PR TITLE
Introduce cupy.is_available()

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -19,6 +19,14 @@ except ImportError:
 
     six.reraise(ImportError, ImportError(msg), exc_info[2])
 
+
+from cupy import cuda
+
+
+def is_available():
+    return cuda.is_available()
+
+
 __version__ = pkg_resources.get_distribution('cupy').version
 
 

--- a/cupy/cuda/__init__.py
+++ b/cupy/cuda/__init__.py
@@ -39,7 +39,8 @@ def is_available():
         try:
             _available = runtime.getDeviceCount() > 0
         except Exception as e:
-            if e.args[0] != 'cudaErrorNoDevice: no CUDA-capable device is detected':
+            if (e.args[0] !=
+                    'cudaErrorNoDevice: no CUDA-capable device is detected'):
                 raise
     return _available
 

--- a/cupy/cuda/__init__.py
+++ b/cupy/cuda/__init__.py
@@ -6,6 +6,7 @@ from cupy.cuda import function  # NOQA
 from cupy.cuda import memory  # NOQA
 from cupy.cuda import pinned_memory  # NOQA
 from cupy.cuda import profiler  # NOQA
+from cupy.cuda import runtime  # NOQA
 from cupy.cuda import stream  # NOQA
 
 try:
@@ -25,6 +26,16 @@ try:
     thrust_enabled = True
 except ImportError:
     thrust_enabled = False
+
+
+def is_available():
+    n = 0
+    try:
+        n = runtime.getDeviceCount()
+    except runtime.CUDARuntimeError as e:
+        if e.args[0] != 'cudaErrorNoDevice: no CUDA-capable device is detected':
+            raise
+    return n > 0
 
 
 # import class and function

--- a/cupy/cuda/__init__.py
+++ b/cupy/cuda/__init__.py
@@ -9,6 +9,10 @@ from cupy.cuda import profiler  # NOQA
 from cupy.cuda import runtime  # NOQA
 from cupy.cuda import stream  # NOQA
 
+
+_available = None
+
+
 try:
     from cupy.cuda import cusolver  # NOQA
     cusolver_enabled = True
@@ -29,13 +33,15 @@ except ImportError:
 
 
 def is_available():
-    n = 0
-    try:
-        n = runtime.getDeviceCount()
-    except runtime.CUDARuntimeError as e:
-        if e.args[0] != 'cudaErrorNoDevice: no CUDA-capable device is detected':
-            raise
-    return n > 0
+    global _available
+    if _available is None:
+        _available = False
+        try:
+            _available = runtime.getDeviceCount() > 0
+        except Exception as e:
+            if e.args[0] != 'cudaErrorNoDevice: no CUDA-capable device is detected':
+                raise
+    return _available
 
 
 # import class and function

--- a/tests/cupy_tests/test_init.py
+++ b/tests/cupy_tests/test_init.py
@@ -1,14 +1,83 @@
 import nose
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
 import unittest
+
+
+from cupy import testing
+
+
+def _run_script(code):
+    # subprocess is required not to interfere with cupy module imported in top
+    # of this file
+    temp_dir = tempfile.mkdtemp()
+    try:
+        script_path = os.path.join(temp_dir, 'script.py')
+        with open(script_path, 'w') as f:
+            f.write(code)
+        proc = subprocess.Popen(
+            [sys.executable, script_path],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE)
+        stdoutdata, stderrdata = proc.communicate()
+    finally:
+        shutil.rmtree(temp_dir, ignore_errors=True)
+    return proc.returncode, stdoutdata, stderrdata
+
+
+def _test_cupy_available(self):
+    returncode, stdoutdata, stderrdata = _run_script('''
+import cupy
+print(cupy.is_available())''')
+    self.assertEqual(returncode, 0)
+    self.assertIn(stdoutdata, (b'True\n', b'False\n'))
+    return stdoutdata == b'True\n'
 
 
 class TestImportError(unittest.TestCase):
 
     def test_import_error(self):
-        try:
-            import cupy  # noqa
-        except Exception as e:
-            self.assertIsInstance(e, RuntimeError)
+        returncode, stdoutdata, stderrdata = _run_script('''
+try:
+    import cupy
+except Exception as e:
+    print(type(e).__name__)
+''')
+        self.assertEqual(returncode, 0)
+        self.assertIn(stdoutdata, (b'', b'RuntimeError\n'))
+
+
+class TestAvailable(unittest.TestCase):
+
+    @testing.gpu
+    def test_available(self):
+        available = _test_cupy_available(self)
+        self.assertTrue(available)
+
+
+class TestNotAvailable(unittest.TestCase):
+
+    def setUp(self):
+        self.old = os.environ.get('CUDA_VISIBLE_DEVICES')
+
+    def tearDown(self):
+        if self.old is None:
+            os.environ.pop('CUDA_VISIBLE_DEVICES')
+        else:
+            os.environ['CUDA_VISIBLE_DEVICES'] = self.old
+
+    def test_no_device_1(self):
+        os.environ['CUDA_VISIBLE_DEVICES'] = ''
+        available = _test_cupy_available(self)
+        self.assertFalse(available)
+
+    def test_no_device_2(self):
+        os.environ['CUDA_VISIBLE_DEVICES'] = '-1'
+        available = _test_cupy_available(self)
+        self.assertFalse(available)
 
 
 # This is copied from chainer/testing/__init__.py, so should be replaced in

--- a/tests/cupy_tests/test_init.py
+++ b/tests/cupy_tests/test_init.py
@@ -32,7 +32,7 @@ def _test_cupy_available(self):
     returncode, stdoutdata, stderrdata = _run_script('''
 import cupy
 print(cupy.is_available())''')
-    self.assertEqual(returncode, 0)
+    self.assertEqual(returncode, 0, 'stderr: {!r}'.format(stderrdata))
     self.assertIn(stdoutdata, (b'True\n', b'False\n'))
     return stdoutdata == b'True\n'
 
@@ -46,7 +46,7 @@ try:
 except Exception as e:
     print(type(e).__name__)
 ''')
-        self.assertEqual(returncode, 0)
+        self.assertEqual(returncode, 0, 'stderr: {!r}'.format(stderrdata))
         self.assertIn(stdoutdata, (b'', b'RuntimeError\n'))
 
 


### PR DESCRIPTION
Currently, `chainer.cuda.available` is `True` even if there is no available CUDA device (by setting `CUDA_VISIBLE_DEVICES=-1`).
In order to avoid that, this PR introduces ~~`cupy.available`~~ `cupy.is_available()` which takes account of device availability.

(Corresponding issue in PyTorch: https://github.com/pytorch/pytorch/issues/306)