### PR TITLE
Fix deepcopy with multiple devices

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1165,7 +1165,11 @@ cdef class ndarray:
         return self.copy()
 
     def __deepcopy__(self, memo):
-        return self.copy()
+        if self.device is not None:
+            with self.device:
+                return self.copy()
+        else:
+            return self.copy()
 
     def __reduce__(self):
         return array, (self.get(),)


### PR DESCRIPTION
Fixes `ndarray` deepcopy issue reported in https://github.com/chainer/chainer/issues/2972.