### PR TITLE
Improve GPU memory usage by reallocating

### DIFF
--- a/cupy/cuda/memory.pxd
+++ b/cupy/cuda/memory.pxd
@@ -14,7 +14,9 @@ cdef class MemoryPointer:
         readonly device.Device device
         readonly object mem
         readonly size_t ptr
+        object __weakref__
 
+    cpdef set_ptr(self, size_t ptr)
     cpdef copy_from_device(self, MemoryPointer src, Py_ssize_t size)
     cpdef copy_from_device_async(self, MemoryPointer src, size_t size, stream)
     cpdef copy_from_host(self, mem, size_t size)
@@ -46,6 +48,7 @@ cdef class SingleDeviceMemoryPool:
     cdef:
         object _alloc
         dict _in_use
+        dict _in_use_memptr
         object _free
         object __weakref__
         object _weakref
@@ -56,6 +59,8 @@ cdef class SingleDeviceMemoryPool:
     cpdef free_all_blocks(self)
     cpdef free_all_free(self)
     cpdef n_free_blocks(self)
+    cpdef size_t realloc(self, size_t ptr, Py_ssize_t size)
+    cpdef realloc_all(self)
     cpdef used_bytes(self)
     cpdef free_bytes(self)
     cpdef total_bytes(self)

--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -380,7 +380,8 @@ cdef class SingleDeviceMemoryPool:
                     if e.status != runtime.errorMemoryAllocation:
                         raise
                     if _debug:
-                        print('# memory.pyx: total_bytes:{}, size:{}'.format(self.total_bytes(), size))
+                        print('# memory.pyx: total_bytes:{}, size:{}'
+                              .format(self.total_bytes(), size))
                         print('# memory.pyx: realloc_all() is called.')
                     self.realloc_all()
                     gc.collect()
@@ -429,7 +430,8 @@ cdef class SingleDeviceMemoryPool:
         # memory copy
         cur_mem = self._in_use.pop(ptr, None)
         _size = min(cur_size, new_size)
-        runtime.memcpy(new_mem.ptr, cur_mem.ptr, _size, runtime.memcpyDeviceToDevice)
+        runtime.memcpy(new_mem.ptr, cur_mem.ptr, _size,
+                       runtime.memcpyDeviceToDevice)
         runtime.deviceSynchronize()
         del cur_mem
         # update info


### PR DESCRIPTION
This PR is to improve GPU memory usage and adds two methods, `realloc()` and `realloc_all()`, to the class `SingleDeviceMemoryPool`.

In the current design, when GPU memory allocation is failed in the class `SingleDeviceMemoryPool`, whole memory blocks pooled in the `memory pool` are released by calling the method `free_all_blocks()`, then 2nd memory allocation is attempted. In principle, the 2nd memory allocation is to succeed when allocation size is smaller than total amount of free GPU memory. However, it sometimes fail even when allocation size is sufficiently smaller than total amount of free GPU memory. The cause of this issue is considered to be related to memory fragmentation.

The obvious solution is to do de-fragmentation, but complete de-fragmentation is time consuming and not easy to implement (specifically in user level..). Instead of complete de-fragmentation, I'd propose to reallocate whole in-use memory blocks in the `memory pool` when 2nd memory allocation fails. This approach does not solve the memory fragmentation completely but can mitigate the effect of the issue.

Actually, in case of the googlenet in Chainer's example/imagenet, you cannot train it at the batch size of >300 on GPU with 16GB memory, but this patch allows you to train it with up-to 420 batch size on it.