### PR TITLE
Remove duplicated build option in setup script.

### DIFF
--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -211,14 +211,6 @@ def make_extensions(options, compiler, use_cython):
         # -rpath is only supported when targetting Mac OS X 10.5 or later
         args.append('-mmacosx-version-min=10.5')
 
-    if compiler.compiler_type == 'unix' and sys.platform != 'darwin':
-        # clang does not have this option.
-        args = settings.setdefault('extra_compile_args', [])
-        args.append('-fopenmp')
-    elif compiler.compiler_type == 'msvc':
-        args = settings.setdefault('extra_compile_args', [])
-        args.append('/openmp')
-
     # This is a workaround for Anaconda.
     # Anaconda installs libstdc++ from GCC 4.8 and it is not compatible
     # with GCC 5's new ABI.


### PR DESCRIPTION
The setup script has duplicated codes to add OpenMP build option passed to the compiler.

- https://github.com/cupy/cupy/blob/master/cupy_setup_build.py#L214
- https://github.com/cupy/cupy/blob/master/cupy_setup_build.py#L280

I guess the option is intended for cusolver, so the first section would be unnecessary.

This change does not need backporting because the change is included at v2.0.0a1 (https://github.com/cupy/cupy/pull/46).