### PR TITLE
Support NumPy 1.13

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -611,8 +611,9 @@ cdef class ndarray:
                 if _axis < 0:
                     _axis += ndim
                 if _axis < 0 or _axis >= ndim:
-                    msg = "'axis' entry %d is out of bounds [-%d, %d)"
-                    raise ValueError(msg % (axis_orig, ndim, ndim))
+                    raise numpy.AxisError(
+                        "'axis' entry %d is out of bounds [-%d, %d)" %
+                        (axis_orig, ndim, ndim))
                 if axis_flags[_axis] == 1:
                     raise ValueError("duplicate value in 'axis'")
                 axis_flags[_axis] = 1
@@ -627,8 +628,9 @@ cdef class ndarray:
                 pass
             else:
                 if _axis < 0 or _axis >= ndim:
-                    msg = "'axis' entry %d is out of bounds [-%d, %d)"
-                    raise ValueError(msg % (axis_orig, ndim, ndim))
+                    raise numpy.AxisError(
+                        "'axis' entry %d is out of bounds [-%d, %d)" %
+                        (axis_orig, ndim, ndim))
                 axis_flags[_axis] = 1
 
         # Verify that the axes requested are all of size one
@@ -2235,7 +2237,7 @@ cpdef ndarray concatenate_method(tup, int axis):
             if axis < 0:
                 axis += ndim
             if axis < 0 or axis >= ndim:
-                raise IndexError(
+                raise numpy.AxisError(
                     'axis {} out of bounds [0, {})'.format(axis, ndim))
             dtype = a.dtype
             continue
@@ -2611,7 +2613,7 @@ cpdef ndarray _take(ndarray a, indices, li=None, ri=None, ndarray out=None):
         index_range = a.size
     else:
         if not (-a.ndim <= li < a.ndim and -a.ndim <= ri < a.ndim):
-            raise ValueError('Axis overrun')
+            raise numpy.AxisError('Axis overrun')
         if a.ndim != 0:
             li %= a.ndim
             ri %= a.ndim

--- a/cupy/manipulation/join.py
+++ b/cupy/manipulation/join.py
@@ -1,3 +1,5 @@
+import numpy
+
 import cupy
 from cupy import core
 
@@ -128,5 +130,6 @@ def _get_positive_axis(ndim, axis):
     if a < 0:
         a += ndim
     if a < 0 or a >= ndim:
-        raise IndexError('axis {} out of bounds [0, {})'.format(axis, ndim))
+        raise numpy.AxisError(
+            'axis {} out of bounds [0, {})'.format(axis, ndim))
     return a

--- a/cupy/manipulation/rearrange.py
+++ b/cupy/manipulation/rearrange.py
@@ -1,3 +1,5 @@
+import numpy
+
 import cupy
 
 
@@ -23,7 +25,8 @@ def flip(a, axis):
 
     axis = int(axis)
     if not -a_ndim <= axis < a_ndim:
-        raise ValueError('axis must be >= %d and < %d' % (-a_ndim, a_ndim))
+        raise ValueError(
+            'axis must be >= %d and < %d' % (-a_ndim, a_ndim))
 
     return _flip(a, axis)
 
@@ -99,7 +102,8 @@ def roll(a, shift, axis=None):
         if axis < 0:
             axis += a.ndim
         if not 0 <= axis < a.ndim:
-            raise ValueError('axis must be >= %d and < %d' % (-a.ndim, a.ndim))
+            raise numpy.AxisError(
+                'axis must be >= %d and < %d' % (-a.ndim, a.ndim))
         size = a.shape[axis]
         if size == 0:
             return a

--- a/cupy/math/sumprod.py
+++ b/cupy/math/sumprod.py
@@ -125,7 +125,7 @@ def cumsum(a, axis=None, dtype=None, out=None):
     if axis is None:
         out = out.ravel()
     elif not (-a.ndim <= axis < a.ndim):
-        raise ValueError('axis(={}) out of bounds'.format(axis))
+        raise numpy.AxisError('axis(={}) out of bounds'.format(axis))
     else:
         return _proc_as_batch(_cumsum_batch, out, axis=axis)
 
@@ -203,7 +203,7 @@ def cumprod(a, axis=None, dtype=None, out=None):
     if axis is None:
         out = out.ravel()
     elif not (-a.ndim <= axis < a.ndim):
-        raise ValueError('axis(={}) out of bounds'.format(axis))
+        raise numpy.AxisError('axis(={}) out of bounds'.format(axis))
     else:
         return _proc_as_batch(_cumprod_batch, out, axis=axis)
 

--- a/cupy/statistics/histogram.py
+++ b/cupy/statistics/histogram.py
@@ -40,7 +40,7 @@ def bincount(x, weights=None, minlength=None):
         raise ValueError('The weights and list don\'t have the same length.')
     if minlength is not None:
         minlength = int(minlength)
-        if minlength <= 0:
+        if minlength < 0:
             raise ValueError('minlength must be positive')
 
     size = int(cupy.max(x)) + 1

--- a/tests/cupy_tests/core_tests/test_fusion.py
+++ b/tests/cupy_tests/core_tests/test_fusion.py
@@ -949,7 +949,7 @@ class TestFusionFuse(unittest.TestCase):
 
         return g(a, b, c)
 
-    @testing.for_all_dtypes()
+    @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_array_equal()
     def test_fuse3(self, xp, dtype):
         a = xp.array([2, 2, 2, 2, 3, 3, 3, 3], dtype=dtype)

--- a/tests/cupy_tests/core_tests/test_ndarray.py
+++ b/tests/cupy_tests/core_tests/test_ndarray.py
@@ -217,6 +217,7 @@ class TestScalaNdarrayTakeWithIntWithOutParam(unittest.TestCase):
 class TestNdarrayTakeErrorAxisOverRun(unittest.TestCase):
 
     @testing.for_all_dtypes()
+    @testing.with_requires('numpy>=1.13')
     @testing.numpy_cupy_raises()
     def test_axis_overrun(self, xp, dtype):
         a = testing.shaped_arange(self.shape, xp, dtype)

--- a/tests/cupy_tests/core_tests/test_ndarray_unary_op.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_unary_op.py
@@ -51,8 +51,11 @@ class TestArrayUnaryOp(unittest.TestCase):
         a = testing.shaped_arange((2, 3), xp, dtype)
         return op(a)
 
-    def test_neg_array(self):
-        self.check_array_op(operator.neg)
+    @testing.for_all_dtypes(no_bool=True)
+    @testing.numpy_cupy_allclose()
+    def test_neg_array(self, xp, dtype):
+        a = testing.shaped_arange((2, 3), xp, dtype)
+        return operator.neg(a)
 
     def test_pos_array(self):
         self.check_array_op(operator.pos)
@@ -66,8 +69,11 @@ class TestArrayUnaryOp(unittest.TestCase):
         a = xp.array(-2, dtype)
         return op(a)
 
-    def test_neg_zerodim(self):
-        self.check_zerodim_op(operator.neg)
+    @testing.for_all_dtypes(no_bool=True)
+    @testing.numpy_cupy_allclose()
+    def test_neg_zerodim(self, xp, dtype):
+        a = xp.array(-2, dtype)
+        return operator.neg(a)
 
     def test_pos_zerodim(self):
         self.check_zerodim_op(operator.pos)

--- a/tests/cupy_tests/manipulation_tests/test_dims.py
+++ b/tests/cupy_tests/manipulation_tests/test_dims.py
@@ -161,6 +161,7 @@ class TestDims(unittest.TestCase):
         a = testing.shaped_arange((1, 2, 1, 3, 1, 1, 4, 1), xp)
         return a.squeeze(axis=-3)
 
+    @testing.with_requires('numpy>=1.13')
     @testing.numpy_cupy_raises()
     def test_squeze_int_axis_failure(self, xp):
         a = testing.shaped_arange((1, 2, 1, 3, 1, 1, 4, 1), xp)
@@ -186,6 +187,7 @@ class TestDims(unittest.TestCase):
         a = testing.shaped_arange((1, 2, 1, 3, 1, 1, 4, 1), xp)
         return a.squeeze(axis=())
 
+    @testing.with_requires('numpy>=1.13')
     @testing.numpy_cupy_raises()
     def test_squeze_tuple_axis_failure1(self, xp):
         a = testing.shaped_arange((1, 2, 1, 3, 1, 1, 4, 1), xp)
@@ -206,11 +208,13 @@ class TestDims(unittest.TestCase):
         a = testing.shaped_arange((), xp)
         return a.squeeze(axis=-1)
 
+    @testing.with_requires('numpy>=1.13')
     @testing.numpy_cupy_raises()
     def test_squeeze_scalar_failure1(self, xp):
         a = testing.shaped_arange((), xp)
         a.squeeze(axis=-2)
 
+    @testing.with_requires('numpy>=1.13')
     @testing.numpy_cupy_raises()
     def test_squeeze_scalar_failure2(self, xp):
         a = testing.shaped_arange((), xp)

--- a/tests/cupy_tests/manipulation_tests/test_join.py
+++ b/tests/cupy_tests/manipulation_tests/test_join.py
@@ -206,7 +206,7 @@ class TestJoin(unittest.TestCase):
         b = testing.shaped_arange((2, 4), xp)
         return xp.stack([a, b])
 
-    @testing.with_requires('numpy>=1.10')
+    @testing.with_requires('numpy>=1.13')
     @testing.numpy_cupy_raises()
     def test_stack_out_of_bounds(self, xp):
         a = testing.shaped_arange((2, 3), xp)

--- a/tests/cupy_tests/manipulation_tests/test_rearrange.py
+++ b/tests/cupy_tests/manipulation_tests/test_rearrange.py
@@ -57,12 +57,14 @@ class TestRoll(unittest.TestCase):
         return xp.roll(x, 5)
 
     @testing.for_all_dtypes()
+    @testing.with_requires('numpy>=1.13')
     @testing.numpy_cupy_raises()
     def test_roll_invalid_axis(self, xp, dtype):
         x = testing.shaped_arange((5, 2), xp, dtype)
         return xp.roll(x, 1, axis=2)
 
     @testing.for_all_dtypes()
+    @testing.with_requires('numpy>=1.13')
     @testing.numpy_cupy_raises()
     def test_roll_invalid_negative_axis(self, xp, dtype):
         x = testing.shaped_arange((5, 2), xp, dtype)

--- a/tests/cupy_tests/math_tests/test_sumprod.py
+++ b/tests/cupy_tests/math_tests/test_sumprod.py
@@ -188,12 +188,14 @@ class TestCumsum(unittest.TestCase):
         return xp.cumsum(a, axis=self.axis)
 
     @testing.for_all_dtypes()
+    @testing.with_requires('numpy>=1.13')
     @testing.numpy_cupy_raises()
     def test_invalid_axis_lower(self, xp, dtype):
         a = testing.shaped_arange((4, 5), xp, dtype)
         return xp.cumsum(a, axis=-a.ndim - 1)
 
     @testing.for_all_dtypes()
+    @testing.with_requires('numpy>=1.13')
     @testing.numpy_cupy_raises()
     def test_invalid_axis_upper(self, xp, dtype):
         a = testing.shaped_arange((4, 5), xp, dtype)
@@ -230,12 +232,14 @@ class TestCumprod(unittest.TestCase):
         return xp.cumprod(a)
 
     @testing.for_all_dtypes()
+    @testing.with_requires('numpy>=1.13')
     @testing.numpy_cupy_raises()
     def test_invalid_axis_lower(self, xp, dtype):
         a = testing.shaped_arange((4, 5), xp, dtype)
         return xp.cumprod(a, axis=-a.ndim - 1)
 
     @testing.for_all_dtypes()
+    @testing.with_requires('numpy>=1.13')
     @testing.numpy_cupy_raises()
     def test_invalid_axis_upper(self, xp, dtype):
         a = testing.shaped_arange((4, 5), xp, dtype)

--- a/tests/cupy_tests/statics_tests/test_histogram.py
+++ b/tests/cupy_tests/statics_tests/test_histogram.py
@@ -94,4 +94,4 @@ class TestHistogram(unittest.TestCase):
     @testing.numpy_cupy_raises()
     def test_bincount_zero_minlength(self, xp, dtype):
         x = testing.shaped_arange((3,), xp, dtype)
-        return xp.bincount(x, minlength=0)
+        return xp.bincount(x, minlength=-1)

--- a/tests/cupy_tests/statics_tests/test_histogram.py
+++ b/tests/cupy_tests/statics_tests/test_histogram.py
@@ -91,7 +91,14 @@ class TestHistogram(unittest.TestCase):
         return xp.bincount(x)
 
     @for_all_dtypes_bincount()
+    @testing.with_requires('numpy>=1.13')
+    @testing.numpy_cupy_allclose(accept_error=TypeError)
+    def test_bincount_zero(self, xp, dtype):
+        x = testing.shaped_arange((3,), xp, dtype)
+        return xp.bincount(x, minlength=0)
+
+    @for_all_dtypes_bincount()
     @testing.numpy_cupy_raises()
-    def test_bincount_zero_minlength(self, xp, dtype):
+    def test_bincount_too_small_minlength(self, xp, dtype):
         x = testing.shaped_arange((3,), xp, dtype)
         return xp.bincount(x, minlength=-1)


### PR DESCRIPTION
Fix #137 
- Use `numpy.AxisError`.
- Skip bool test case.