### PR TITLE
Add include option for covreage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,6 @@
 [run]
 plugins = Cython.Coverage
+include = cupy/*,examples/*
 
 [report]
 exclude_lines =


### PR DESCRIPTION
I added include option in covreagerc. It prevents to include lines of system libraries to coverage result.