### PR TITLE
Fix argsort for non-contiguous arrays

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -776,13 +776,15 @@ cdef class ndarray:
             raise NotImplementedError('Sorting arrays with the rank of two or '
                                       'more is not supported')
 
+        data = cupy.ascontiguousarray(self)
+
         # Assuming that Py_ssize_t can be represented with numpy.int64.
         assert cython.sizeof(Py_ssize_t) == 8
 
         idx_array = ndarray(self.shape, dtype=numpy.int64)
 
         thrust.argsort(
-            self.dtype, idx_array.data.ptr, self.data.ptr, self._shape[0])
+            self.dtype, idx_array.data.ptr, data.data.ptr, self._shape[0])
 
         return idx_array
 

--- a/tests/cupy_tests/sorting_tests/test_sort.py
+++ b/tests/cupy_tests/sorting_tests/test_sort.py
@@ -128,6 +128,16 @@ class TestLexsort(unittest.TestCase):
             return cupy.lexsort(a)
 
 
+def _argsort(xp, external, a):
+    if external:
+        return xp.argsort(a)
+    else:
+        return a.argsort()
+
+
+@testing.parameterize(*testing.product({
+    'external': [False, True],
+}))
 @testing.gpu
 class TestArgsort(unittest.TestCase):
 
@@ -138,22 +148,12 @@ class TestArgsort(unittest.TestCase):
     @testing.numpy_cupy_raises()
     def test_argsort_zero_dim(self, xp):
         a = testing.shaped_random((), xp)
-        return a.argsort()
-
-    @testing.numpy_cupy_raises()
-    def test_external_argsort_zero_dim(self, xp):
-        a = testing.shaped_random((), xp)
-        return xp.argsort(a)
+        return _argsort(xp, self.external, a)
 
     def test_argsort_two_or_more_dim(self):
         a = testing.shaped_random((2, 3), cupy)
         with self.assertRaises(NotImplementedError):
-            return a.argsort()
-
-    def test_external_argsort_two_or_more_dim(self):
-        a = testing.shaped_random((2, 3), cupy)
-        with self.assertRaises(NotImplementedError):
-            return cupy.argsort(a)
+            return _argsort(cupy, self.external, a)
 
     # Test dtypes
 
@@ -161,30 +161,20 @@ class TestArgsort(unittest.TestCase):
     @testing.numpy_cupy_allclose()
     def test_argsort_dtype(self, xp, dtype):
         a = testing.shaped_random((10,), xp, dtype)
-        return a.argsort()
-
-    @testing.for_all_dtypes(no_float16=True, no_bool=True)
-    @testing.numpy_cupy_allclose()
-    def test_external_argsort_dtype(self, xp, dtype):
-        a = testing.shaped_random((10,), xp, dtype)
-        return xp.argsort(a)
+        return _argsort(xp, self.external, a)
 
     @testing.for_dtypes([numpy.float16, numpy.bool_])
     def test_argsort_unsupported_dtype(self, dtype):
         a = testing.shaped_random((10,), cupy, dtype)
         with self.assertRaises(NotImplementedError):
-            return a.argsort()
+            return _argsort(cupy, self.external, a)
 
-    @testing.for_dtypes([numpy.float16, numpy.bool_])
-    def test_external_argsort_unsupported_dtype(self, dtype):
-        a = testing.shaped_random((10,), cupy, dtype)
-        with self.assertRaises(NotImplementedError):
-            return cupy.argsort(a)
+    # Misc tests
 
-    def test_argsort_keep_original_array(self):
+    def test_argsort_original_array_not_modified(self):
         a = testing.shaped_random((10,), cupy)
         b = cupy.array(a)
-        a.argsort()
+        _argsort(cupy, self.external, a)
         testing.assert_allclose(a, b)
 
 

--- a/tests/cupy_tests/sorting_tests/test_sort.py
+++ b/tests/cupy_tests/sorting_tests/test_sort.py
@@ -163,6 +163,11 @@ class TestArgsort(unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             return self.argsort(a)
 
+    @testing.numpy_cupy_array_equal()
+    def test_argsort_no_contiguous_array(self, xp):
+        a = xp.array([1, 0, 2, 3])[::2]
+        return self.argsort(a)
+
     # Test unsupported dtype
 
     @testing.for_dtypes([numpy.float16, numpy.bool_])

--- a/tests/cupy_tests/sorting_tests/test_sort.py
+++ b/tests/cupy_tests/sorting_tests/test_sort.py
@@ -143,29 +143,31 @@ class TestArgsort(unittest.TestCase):
 
     _multiprocess_can_split_ = True
 
-    # Test ranks
-
-    @testing.numpy_cupy_raises()
-    def test_argsort_zero_dim(self, xp):
-        a = testing.shaped_random((), xp)
-        return _argsort(xp, self.external, a)
-
-    def test_argsort_two_or_more_dim(self):
-        a = testing.shaped_random((2, 3), cupy)
-        with self.assertRaises(NotImplementedError):
-            return _argsort(cupy, self.external, a)
-
-    # Test dtypes
+    # Test base cases
 
     @testing.for_all_dtypes(no_float16=True, no_bool=True)
-    @testing.numpy_cupy_allclose()
-    def test_argsort_dtype(self, xp, dtype):
+    @testing.numpy_cupy_raises()
+    def test_argsort_zero_dim(self, xp, dtype):
+        a = testing.shaped_random((), xp, dtype)
+        return _argsort(xp, self.external, a)
+
+    @testing.for_all_dtypes(no_float16=True, no_bool=True)
+    @testing.numpy_cupy_equal()
+    def test_argsort_one_dim(self, xp, dtype):
         a = testing.shaped_random((10,), xp, dtype)
         return _argsort(xp, self.external, a)
 
+    @testing.for_all_dtypes(no_float16=True, no_bool=True)
+    def test_argsort_multi_dim(self, dtype):
+        a = testing.shaped_random((10,), cupy, dtype)
+        with self.assertRaises(NotImplementedError):
+            return _argsort(cupy, self.external, a)
+
+    # Test unsupported dtype
+
     @testing.for_dtypes([numpy.float16, numpy.bool_])
     def test_argsort_unsupported_dtype(self, dtype):
-        a = testing.shaped_random((10,), cupy, dtype)
+        a = testing.shaped_random((2, 3), cupy, dtype)
         with self.assertRaises(NotImplementedError):
             return _argsort(cupy, self.external, a)
 

--- a/tests/cupy_tests/sorting_tests/test_sort.py
+++ b/tests/cupy_tests/sorting_tests/test_sort.py
@@ -159,7 +159,7 @@ class TestArgsort(unittest.TestCase):
 
     @testing.for_all_dtypes(no_float16=True, no_bool=True)
     def test_argsort_multi_dim(self, dtype):
-        a = testing.shaped_random((10,), cupy, dtype)
+        a = testing.shaped_random((2, 3), cupy, dtype)
         with self.assertRaises(NotImplementedError):
             return _argsort(cupy, self.external, a)
 
@@ -167,7 +167,7 @@ class TestArgsort(unittest.TestCase):
 
     @testing.for_dtypes([numpy.float16, numpy.bool_])
     def test_argsort_unsupported_dtype(self, dtype):
-        a = testing.shaped_random((2, 3), cupy, dtype)
+        a = testing.shaped_random((10,), cupy, dtype)
         with self.assertRaises(NotImplementedError):
             return _argsort(cupy, self.external, a)
 

--- a/tests/cupy_tests/sorting_tests/test_sort.py
+++ b/tests/cupy_tests/sorting_tests/test_sort.py
@@ -128,13 +128,6 @@ class TestLexsort(unittest.TestCase):
             return cupy.lexsort(a)
 
 
-def _argsort(xp, external, a):
-    if external:
-        return xp.argsort(a)
-    else:
-        return a.argsort()
-
-
 @testing.parameterize(*testing.product({
     'external': [False, True],
 }))
@@ -143,25 +136,32 @@ class TestArgsort(unittest.TestCase):
 
     _multiprocess_can_split_ = True
 
+    def argsort(self, a):
+        if self.external:
+            xp = cupy.get_array_module(a)
+            return xp.argsort(a)
+        else:
+            return a.argsort()
+
     # Test base cases
 
     @testing.for_all_dtypes(no_float16=True, no_bool=True)
     @testing.numpy_cupy_raises()
     def test_argsort_zero_dim(self, xp, dtype):
         a = testing.shaped_random((), xp, dtype)
-        return _argsort(xp, self.external, a)
+        return self.argsort(a)
 
     @testing.for_all_dtypes(no_float16=True, no_bool=True)
     @testing.numpy_cupy_equal()
     def test_argsort_one_dim(self, xp, dtype):
         a = testing.shaped_random((10,), xp, dtype)
-        return _argsort(xp, self.external, a)
+        return self.argsort(a)
 
     @testing.for_all_dtypes(no_float16=True, no_bool=True)
     def test_argsort_multi_dim(self, dtype):
         a = testing.shaped_random((2, 3), cupy, dtype)
         with self.assertRaises(NotImplementedError):
-            return _argsort(cupy, self.external, a)
+            return self.argsort(a)
 
     # Test unsupported dtype
 
@@ -169,14 +169,14 @@ class TestArgsort(unittest.TestCase):
     def test_argsort_unsupported_dtype(self, dtype):
         a = testing.shaped_random((10,), cupy, dtype)
         with self.assertRaises(NotImplementedError):
-            return _argsort(cupy, self.external, a)
+            return self.argsort(a)
 
     # Misc tests
 
     def test_argsort_original_array_not_modified(self):
         a = testing.shaped_random((10,), cupy)
         b = cupy.array(a)
-        _argsort(cupy, self.external, a)
+        self.argsort(a)
         testing.assert_allclose(a, b)
 
 

--- a/tests/cupy_tests/sorting_tests/test_sort.py
+++ b/tests/cupy_tests/sorting_tests/test_sort.py
@@ -164,7 +164,7 @@ class TestArgsort(unittest.TestCase):
             return self.argsort(a)
 
     @testing.numpy_cupy_array_equal()
-    def test_argsort_no_contiguous_array(self, xp):
+    def test_argsort_non_contiguous(self, xp):
         a = xp.array([1, 0, 2, 3])[::2]
         return self.argsort(a)
 

--- a/tests/cupy_tests/sorting_tests/test_sort.py
+++ b/tests/cupy_tests/sorting_tests/test_sort.py
@@ -152,7 +152,7 @@ class TestArgsort(unittest.TestCase):
         return self.argsort(a)
 
     @testing.for_all_dtypes(no_float16=True, no_bool=True)
-    @testing.numpy_cupy_equal()
+    @testing.numpy_cupy_array_equal()
     def test_argsort_one_dim(self, xp, dtype):
         a = testing.shaped_random((10,), xp, dtype)
         return self.argsort(a)


### PR DESCRIPTION
Merge #282 first.

This PR fixes `cupy.argsort` for non-contiguous arrays. Arrays need to be C contiguous when using Thrust sorting operations.

```Python
>>> a = cupy.array([1, 0, 2, 3])[::2]
>>> a.argsort()
[1, 0]  # should be [0, 1]
```

This PR does not need to backport to v1 because `cupy.argsort` is introduced at v2.0.0.a1.