### PR TITLE
Improve cupy.argsort efficiency in time

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -776,16 +776,16 @@ cdef class ndarray:
             raise NotImplementedError('Sorting arrays with the rank of two or '
                                       'more is not supported')
 
-        data = cupy.ascontiguousarray(self)
+        data = self.copy()
 
         # Assuming that Py_ssize_t can be represented with numpy.int64.
         assert cython.sizeof(Py_ssize_t) == 8
 
         idx_array = ndarray(self.shape, dtype=numpy.int64)
 
-        buf_array = ndarray(self.shape, dtype=data.dtype)
-        thrust.argsort(self.dtype, idx_array.data.ptr, data.data.ptr,
-                       buf_array.data.ptr, self._shape[0])
+        thrust.argsort(
+            self.dtype, idx_array.data.ptr, data.data.ptr, self._shape[0])
+
 
         return idx_array
 

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -786,7 +786,6 @@ cdef class ndarray:
         thrust.argsort(
             self.dtype, idx_array.data.ptr, data.data.ptr, self._shape[0])
 
-
         return idx_array
 
     # TODO(okuta): Implement partition

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -783,8 +783,9 @@ cdef class ndarray:
 
         idx_array = ndarray(self.shape, dtype=numpy.int64)
 
-        thrust.argsort(
-            self.dtype, idx_array.data.ptr, data.data.ptr, self._shape[0])
+        buf_array = ndarray(self.shape, dtype=data.dtype)
+        thrust.argsort(self.dtype, idx_array.data.ptr, data.data.ptr,
+                       buf_array.data.ptr, self._shape[0])
 
         return idx_array
 

--- a/cupy/cuda/cupy_thrust.cu
+++ b/cupy/cuda/cupy_thrust.cu
@@ -109,42 +109,43 @@ template void cupy::thrust::_lexsort<cpy_double>(size_t *, void *, size_t, size_
  */
 
 template <typename T>
-void cupy::thrust::_argsort(size_t *idx_start, void *data_start, size_t num) {
+void cupy::thrust::_argsort(size_t *idx_start, void *data_start, void *buff_start, size_t num) {
     /* idx_start is the beggining of the output array where the indexes that
        would sort the data will be placed. The original contents of idx_start
        will be destroyed. */
 
-    device_ptr<T> dp_data_first, dp_data_last;
+    device_ptr<T> dp_data_first, dp_data_last, dp_buff_first, dp_buff_last;
     device_ptr<size_t> dp_idx_first, dp_idx_last;
-    device_vector<T> d_vals0, d_vals;
 
-    // Make a data vector from the data pointer.
+    // Make a buffer vector object.
+    dp_buff_first = device_pointer_cast(static_cast<T*>(buff_start));
+    dp_buff_last  = device_pointer_cast(static_cast<T*>(buff_start) + num);
+    device_vector<T> d_buff(dp_buff_first, dp_buff_last);
+
+    // Copy to the buffer vector to keep the original data as it is.
     dp_data_first = device_pointer_cast(static_cast<T*>(data_start));
     dp_data_last  = device_pointer_cast(static_cast<T*>(data_start) + num);
-    d_vals0(dp_data_first, dp_data_last);
+    d_buff.assign(dp_data_first, dp_data_last);
 
-    // Copy the data vector to keep the original data as it is.
-    d_vals = d_vals0;
-
-    // Make an index sequence.
+    // Generate an index sequence.
     dp_idx_first = device_pointer_cast(static_cast<size_t*>(idx_start));
     dp_idx_last  = device_pointer_cast(static_cast<size_t*>(idx_start) + num);
     sequence(dp_idx_first, dp_idx_last);
 
-    // Sort the index sequence by the data vector.
-    stable_sort_by_key(d_vals.begin(),
-                       d_vals.end(),
+    // Sort the index sequence by the values.
+    stable_sort_by_key(d_buff.begin(),
+                       d_buff.end(),
                        dp_idx_first,
                        less<T>());
 }
 
-template void cupy::thrust::_argsort<cpy_byte>(size_t *, void *, size_t);
-template void cupy::thrust::_argsort<cpy_ubyte>(size_t *, void *, size_t);
-template void cupy::thrust::_argsort<cpy_short>(size_t *, void *, size_t);
-template void cupy::thrust::_argsort<cpy_ushort>(size_t *, void *, size_t);
-template void cupy::thrust::_argsort<cpy_int>(size_t *, void *, size_t);
-template void cupy::thrust::_argsort<cpy_uint>(size_t *, void *, size_t);
-template void cupy::thrust::_argsort<cpy_long>(size_t *, void *, size_t);
-template void cupy::thrust::_argsort<cpy_ulong>(size_t *, void *, size_t);
-template void cupy::thrust::_argsort<cpy_float>(size_t *, void *, size_t);
-template void cupy::thrust::_argsort<cpy_double>(size_t *, void *, size_t);
+template void cupy::thrust::_argsort<cpy_byte>(size_t *, void *, void *, size_t);
+template void cupy::thrust::_argsort<cpy_ubyte>(size_t *, void *, void *, size_t);
+template void cupy::thrust::_argsort<cpy_short>(size_t *, void *, void *, size_t);
+template void cupy::thrust::_argsort<cpy_ushort>(size_t *, void *, void *, size_t);
+template void cupy::thrust::_argsort<cpy_int>(size_t *, void *, void *, size_t);
+template void cupy::thrust::_argsort<cpy_uint>(size_t *, void *, void *, size_t);
+template void cupy::thrust::_argsort<cpy_long>(size_t *, void *, void *, size_t);
+template void cupy::thrust::_argsort<cpy_ulong>(size_t *, void *, void *, size_t);
+template void cupy::thrust::_argsort<cpy_float>(size_t *, void *, void *, size_t);
+template void cupy::thrust::_argsort<cpy_double>(size_t *, void *, void *, size_t);

--- a/cupy/cuda/cupy_thrust.cu
+++ b/cupy/cuda/cupy_thrust.cu
@@ -109,43 +109,37 @@ template void cupy::thrust::_lexsort<cpy_double>(size_t *, void *, size_t, size_
  */
 
 template <typename T>
-void cupy::thrust::_argsort(size_t *idx_start, void *data_start, void *buff_start, size_t num) {
+void cupy::thrust::_argsort(size_t *idx_start, void *data_start, size_t num) {
     /* idx_start is the beggining of the output array where the indexes that
        would sort the data will be placed. The original contents of idx_start
        will be destroyed. */
 
-    device_ptr<T> dp_data_first, dp_data_last, dp_buff_first, dp_buff_last;
+    device_ptr<T> dp_data_first, dp_data_last;
     device_ptr<size_t> dp_idx_first, dp_idx_last;
 
-    // Make a buffer vector object.
-    dp_buff_first = device_pointer_cast(static_cast<T*>(buff_start));
-    dp_buff_last  = device_pointer_cast(static_cast<T*>(buff_start) + num);
-    device_vector<T> d_buff(dp_buff_first, dp_buff_last);
-
-    // Copy to the buffer vector to keep the original data as it is.
+    // Cast device pointers of data.
     dp_data_first = device_pointer_cast(static_cast<T*>(data_start));
     dp_data_last  = device_pointer_cast(static_cast<T*>(data_start) + num);
-    d_buff.assign(dp_data_first, dp_data_last);
 
     // Generate an index sequence.
     dp_idx_first = device_pointer_cast(static_cast<size_t*>(idx_start));
     dp_idx_last  = device_pointer_cast(static_cast<size_t*>(idx_start) + num);
     sequence(dp_idx_first, dp_idx_last);
 
-    // Sort the index sequence by the values.
-    stable_sort_by_key(d_buff.begin(),
-                       d_buff.end(),
+    // Sort the index sequence by data.
+    stable_sort_by_key(dp_data_first,
+                       dp_data_last,
                        dp_idx_first,
                        less<T>());
 }
 
-template void cupy::thrust::_argsort<cpy_byte>(size_t *, void *, void *, size_t);
-template void cupy::thrust::_argsort<cpy_ubyte>(size_t *, void *, void *, size_t);
-template void cupy::thrust::_argsort<cpy_short>(size_t *, void *, void *, size_t);
-template void cupy::thrust::_argsort<cpy_ushort>(size_t *, void *, void *, size_t);
-template void cupy::thrust::_argsort<cpy_int>(size_t *, void *, void *, size_t);
-template void cupy::thrust::_argsort<cpy_uint>(size_t *, void *, void *, size_t);
-template void cupy::thrust::_argsort<cpy_long>(size_t *, void *, void *, size_t);
-template void cupy::thrust::_argsort<cpy_ulong>(size_t *, void *, void *, size_t);
-template void cupy::thrust::_argsort<cpy_float>(size_t *, void *, void *, size_t);
-template void cupy::thrust::_argsort<cpy_double>(size_t *, void *, void *, size_t);
+template void cupy::thrust::_argsort<cpy_byte>(size_t *, void *, size_t);
+template void cupy::thrust::_argsort<cpy_ubyte>(size_t *, void *, size_t);
+template void cupy::thrust::_argsort<cpy_short>(size_t *, void *, size_t);
+template void cupy::thrust::_argsort<cpy_ushort>(size_t *, void *, size_t);
+template void cupy::thrust::_argsort<cpy_int>(size_t *, void *, size_t);
+template void cupy::thrust::_argsort<cpy_uint>(size_t *, void *, size_t);
+template void cupy::thrust::_argsort<cpy_long>(size_t *, void *, size_t);
+template void cupy::thrust::_argsort<cpy_ulong>(size_t *, void *, size_t);
+template void cupy::thrust::_argsort<cpy_float>(size_t *, void *, size_t);
+template void cupy::thrust::_argsort<cpy_double>(size_t *, void *, size_t);

--- a/cupy/cuda/cupy_thrust.h
+++ b/cupy/cuda/cupy_thrust.h
@@ -11,7 +11,7 @@ template <typename T> void _sort(void *, const std::vector<ptrdiff_t>&);
 
 template <typename T> void _lexsort(size_t *, void *, size_t, size_t);
    
-template <typename T> void _argsort(size_t *, void *, void *, size_t);
+template <typename T> void _argsort(size_t *, void *, size_t);
 
 } // namespace thrust
 
@@ -29,7 +29,7 @@ template <typename T> void _sort(void *, const std::vector<ptrdiff_t>&) { return
 
 template <typename T> void _lexsort(size_t *, void *, size_t, size_t) { return; }
 
-template <typename T> void _argsort(size_t *, void *, void *, size_t) { return; }
+template <typename T> void _argsort(size_t *, void *, size_t) { return; }
 
 } // namespace thrust
 

--- a/cupy/cuda/cupy_thrust.h
+++ b/cupy/cuda/cupy_thrust.h
@@ -11,7 +11,7 @@ template <typename T> void _sort(void *, const std::vector<ptrdiff_t>&);
 
 template <typename T> void _lexsort(size_t *, void *, size_t, size_t);
    
-template <typename T> void _argsort(size_t *, void *, size_t);
+template <typename T> void _argsort(size_t *, void *, void *, size_t);
 
 } // namespace thrust
 
@@ -29,7 +29,7 @@ template <typename T> void _sort(void *, const std::vector<ptrdiff_t>&) { return
 
 template <typename T> void _lexsort(size_t *, void *, size_t, size_t) { return; }
 
-template <typename T> void _argsort(size_t *, void *, size_t) { return; }
+template <typename T> void _argsort(size_t *, void *, void *, size_t) { return; }
 
 } // namespace thrust
 

--- a/cupy/cuda/thrust.pyx
+++ b/cupy/cuda/thrust.pyx
@@ -14,9 +14,9 @@ from cupy.cuda cimport common
 ###############################################################################
 
 cdef extern from "../cuda/cupy_thrust.h" namespace "cupy::thrust":
-    void _sort[T](void *start, const vector.vector[ptrdiff_t]&)
-    void _lexsort[T](size_t *idx_start, void *keys_start, size_t k, size_t n)
-    void _argsort[T](size_t *idx_start, void *data_start, void *buff_start, size_t num)
+    void _sort[T](void *, const vector.vector[ptrdiff_t]&)
+    void _lexsort[T](size_t *, void *, size_t, size_t)
+    void _argsort[T](size_t *, void *, void *, size_t)
 
 
 ###############################################################################

--- a/cupy/cuda/thrust.pyx
+++ b/cupy/cuda/thrust.pyx
@@ -16,7 +16,7 @@ from cupy.cuda cimport common
 cdef extern from "../cuda/cupy_thrust.h" namespace "cupy::thrust":
     void _sort[T](void *start, const vector.vector[ptrdiff_t]&)
     void _lexsort[T](size_t *idx_start, void *keys_start, size_t k, size_t n)
-    void _argsort[T](size_t *idx_start, void *data_start, size_t num)
+    void _argsort[T](size_t *idx_start, void *data_start, void *buff_start, size_t num)
 
 
 ###############################################################################
@@ -85,36 +85,38 @@ cpdef lexsort(dtype, size_t idx_start, size_t keys_start, size_t k, size_t n):
                         'supported'.format(dtype))
 
 
-cpdef argsort(dtype, size_t idx_start, size_t data_start, size_t num):
+cpdef argsort(dtype, size_t idx_start, size_t data_start, size_t buff_start, size_t num):
     cdef size_t *idx_ptr
     cdef void *data_ptr
+    cdef void *buff_ptr
     cdef size_t n
 
     idx_ptr = <size_t *>idx_start
     data_ptr = <void *>data_start
+    buff_ptr = <void *>buff_start
     n = <size_t>num
 
     # TODO(takagi): Support float16 and bool
     if dtype == numpy.int8:
-        _argsort[common.cpy_byte](idx_ptr, data_ptr, n)
+        _argsort[common.cpy_byte](idx_ptr, data_ptr, buff_ptr, n)
     elif dtype == numpy.uint8:
-        _argsort[common.cpy_ubyte](idx_ptr, data_ptr, n)
+        _argsort[common.cpy_ubyte](idx_ptr, data_ptr, buff_ptr, n)
     elif dtype == numpy.int16:
-        _argsort[common.cpy_short](idx_ptr, data_ptr, n)
+        _argsort[common.cpy_short](idx_ptr, data_ptr, buff_ptr, n)
     elif dtype == numpy.uint16:
-        _argsort[common.cpy_ushort](idx_ptr, data_ptr, n)
+        _argsort[common.cpy_ushort](idx_ptr, data_ptr, buff_ptr, n)
     elif dtype == numpy.int32:
-        _argsort[common.cpy_int](idx_ptr, data_ptr, n)
+        _argsort[common.cpy_int](idx_ptr, data_ptr, buff_ptr, n)
     elif dtype == numpy.uint32:
-        _argsort[common.cpy_uint](idx_ptr, data_ptr, n)
+        _argsort[common.cpy_uint](idx_ptr, data_ptr, buff_ptr, n)
     elif dtype == numpy.int64:
-        _argsort[common.cpy_long](idx_ptr, data_ptr, n)
+        _argsort[common.cpy_long](idx_ptr, data_ptr, buff_ptr, n)
     elif dtype == numpy.uint64:
-        _argsort[common.cpy_ulong](idx_ptr, data_ptr, n)
+        _argsort[common.cpy_ulong](idx_ptr, data_ptr, buff_ptr, n)
     elif dtype == numpy.float32:
-        _argsort[common.cpy_float](idx_ptr, data_ptr, n)
+        _argsort[common.cpy_float](idx_ptr, data_ptr, buff_ptr, n)
     elif dtype == numpy.float64:
-        _argsort[common.cpy_double](idx_ptr, data_ptr, n)
+        _argsort[common.cpy_double](idx_ptr, data_ptr, buff_ptr, n)
     else:
         raise NotImplementedError('Sorting arrays with dtype \'{}\' is not '
                                   'supported'.format(dtype))

--- a/cupy/cuda/thrust.pyx
+++ b/cupy/cuda/thrust.pyx
@@ -16,7 +16,7 @@ from cupy.cuda cimport common
 cdef extern from "../cuda/cupy_thrust.h" namespace "cupy::thrust":
     void _sort[T](void *, const vector.vector[ptrdiff_t]&)
     void _lexsort[T](size_t *, void *, size_t, size_t)
-    void _argsort[T](size_t *, void *, void *, size_t)
+    void _argsort[T](size_t *, void *, size_t)
 
 
 ###############################################################################
@@ -85,39 +85,36 @@ cpdef lexsort(dtype, size_t idx_start, size_t keys_start, size_t k, size_t n):
                         'supported'.format(dtype))
 
 
-cpdef argsort(dtype, size_t idx_start, size_t data_start, size_t buff_start,
-              size_t num):
+cpdef argsort(dtype, size_t idx_start, size_t data_start, size_t num):
     cdef size_t *idx_ptr
     cdef void *data_ptr
-    cdef void *buff_ptr
     cdef size_t n
 
     idx_ptr = <size_t *>idx_start
     data_ptr = <void *>data_start
-    buff_ptr = <void *>buff_start
     n = <size_t>num
 
     # TODO(takagi): Support float16 and bool
     if dtype == numpy.int8:
-        _argsort[common.cpy_byte](idx_ptr, data_ptr, buff_ptr, n)
+        _argsort[common.cpy_byte](idx_ptr, data_ptr, n)
     elif dtype == numpy.uint8:
-        _argsort[common.cpy_ubyte](idx_ptr, data_ptr, buff_ptr, n)
+        _argsort[common.cpy_ubyte](idx_ptr, data_ptr, n)
     elif dtype == numpy.int16:
-        _argsort[common.cpy_short](idx_ptr, data_ptr, buff_ptr, n)
+        _argsort[common.cpy_short](idx_ptr, data_ptr, n)
     elif dtype == numpy.uint16:
-        _argsort[common.cpy_ushort](idx_ptr, data_ptr, buff_ptr, n)
+        _argsort[common.cpy_ushort](idx_ptr, data_ptr, n)
     elif dtype == numpy.int32:
-        _argsort[common.cpy_int](idx_ptr, data_ptr, buff_ptr, n)
+        _argsort[common.cpy_int](idx_ptr, data_ptr, n)
     elif dtype == numpy.uint32:
-        _argsort[common.cpy_uint](idx_ptr, data_ptr, buff_ptr, n)
+        _argsort[common.cpy_uint](idx_ptr, data_ptr, n)
     elif dtype == numpy.int64:
-        _argsort[common.cpy_long](idx_ptr, data_ptr, buff_ptr, n)
+        _argsort[common.cpy_long](idx_ptr, data_ptr, n)
     elif dtype == numpy.uint64:
-        _argsort[common.cpy_ulong](idx_ptr, data_ptr, buff_ptr, n)
+        _argsort[common.cpy_ulong](idx_ptr, data_ptr, n)
     elif dtype == numpy.float32:
-        _argsort[common.cpy_float](idx_ptr, data_ptr, buff_ptr, n)
+        _argsort[common.cpy_float](idx_ptr, data_ptr, n)
     elif dtype == numpy.float64:
-        _argsort[common.cpy_double](idx_ptr, data_ptr, buff_ptr, n)
+        _argsort[common.cpy_double](idx_ptr, data_ptr, n)
     else:
         raise NotImplementedError('Sorting arrays with dtype \'{}\' is not '
                                   'supported'.format(dtype))

--- a/cupy/cuda/thrust.pyx
+++ b/cupy/cuda/thrust.pyx
@@ -85,7 +85,8 @@ cpdef lexsort(dtype, size_t idx_start, size_t keys_start, size_t k, size_t n):
                         'supported'.format(dtype))
 
 
-cpdef argsort(dtype, size_t idx_start, size_t data_start, size_t buff_start, size_t num):
+cpdef argsort(dtype, size_t idx_start, size_t data_start, size_t buff_start,
+              size_t num):
     cdef size_t *idx_ptr
     cdef void *data_ptr
     cdef void *buff_ptr


### PR DESCRIPTION
Merge #284 first.

This PR replaces `cupy.argsort` implementation employing `thrust::sort_by_key` to make significant improvement in time efficiency.

It does not need backport to v1 because `cupy.argsort` is introduced at v2.0.0a1.