### PR TITLE
cupy.argsort for arrays of rank two or more

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -786,7 +786,7 @@ cdef class ndarray:
             raise ValueError('Axis out of range')
 
         if axis == ndim - 1:
-            data = data.copy(order='C')
+            data = data.copy()
         else:
             data = cupy.ascontiguousarray(cupy.rollaxis(data, axis, ndim))
 

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -745,13 +745,15 @@ cdef class ndarray:
         thrust.sort(self.dtype, self.data.ptr, self._shape)
 
     def argsort(self, axis=-1):
-        """Return the indices that would sort an array with stable sorting
+        """Returns the indices that would sort an array with stable sorting
 
-        .. note::
-            For its implementation reason, ``ndarray.argsort`` currently
-            supports only arrays with their rank of one, and does not support
-            ``axis``, ``kind`` and ``order`` parameters that
-            ``numpy.ndarray.argsort`` supports.
+        Args:
+            axis (int or None): Axis along which to sort. Default is -1, which
+                means sort along the last axis. If None is supplied, the array
+                is flattened before sorting.
+
+        Returns:
+            cupy.ndarray: Array of indices that sort the array.
 
         .. seealso::
             :func:`cupy.argsort` for full documentation,

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -805,7 +805,7 @@ cdef class ndarray:
         if axis == ndim - 1:
             return idx_array
         else:
-            return cupy.ascontiguousarray(cupy.rollaxis(idx_array, -1, axis))
+            return cupy.rollaxis(idx_array, -1, axis)
 
     # TODO(okuta): Implement partition
     # TODO(okuta): Implement argpartition

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -772,15 +772,21 @@ cdef class ndarray:
             raise ValueError('Sorting arrays with the rank of zero is not '
                              'supported')  # as numpy.argsort() raises
 
+        if axis is None:
+            data = self.reshape(self.size)
+            axis = -1
+        else:
+            data = self
+
         if axis < 0:
             axis += ndim
         if not (0 <= axis < ndim):
             raise ValueError('Axis out of range')
 
         if axis == ndim - 1:
-            data = self.copy(order='C')
+            data = data.copy(order='C')
         else:
-            data = cupy.ascontiguousarray(cupy.rollaxis(self, axis, ndim))
+            data = cupy.ascontiguousarray(cupy.rollaxis(data, axis, ndim))
 
         idx_array = ndarray(data.shape, dtype=numpy.intp)
 

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -788,7 +788,7 @@ cdef class ndarray:
         if axis == ndim - 1:
             data = data.copy()
         else:
-            data = cupy.ascontiguousarray(cupy.rollaxis(data, axis, ndim))
+            data = cupy.rollaxis(data, axis, ndim).copy()
 
         idx_array = ndarray(data.shape, dtype=numpy.intp)
 

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -797,10 +797,8 @@ cdef class ndarray:
                            data._shape)
         else:
             keys_array = ndarray(data._shape, dtype=numpy.intp)
-            buff_array = ndarray(data._shape, dtype=self.dtype)
             thrust.argsort(self.dtype, idx_array.data.ptr, data.data.ptr,
-                           keys_array.data.ptr, buff_array.data.ptr,
-                           data._shape)
+                           keys_array.data.ptr, data._shape)
 
         if axis == ndim - 1:
             return idx_array

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -793,7 +793,7 @@ cdef class ndarray:
         idx_array = ndarray(data.shape, dtype=numpy.intp)
 
         if ndim == 1:
-            thrust.argsort(self.dtype, idx_array.data.ptr, data.data.ptr, 0, 0,
+            thrust.argsort(self.dtype, idx_array.data.ptr, data.data.ptr, 0,
                            data._shape)
         else:
             keys_array = ndarray(data._shape, dtype=numpy.intp)

--- a/cupy/cuda/cupy_thrust.cu
+++ b/cupy/cuda/cupy_thrust.cu
@@ -159,16 +159,12 @@ void cupy::thrust::_argsort(size_t *idx_start, void *data_start, void *keys_star
                   dp_keys_first,
                   divides<size_t>());
 
-        // Copy data to the buffer.
-        dp_buff_first = device_pointer_cast(static_cast<T*>(buff_start));
-        dp_buff_last  = device_pointer_cast(static_cast<T*>(buff_start) + size);
-        copy(dp_data_first, dp_data_last, dp_buff_first);
-
         // Sorting with back-to-back approach.
 
         stable_sort_by_key(dp_data_first,
                            dp_data_last,
-                           make_zip_iterator(make_tuple(dp_idx_first, dp_keys_first)),
+                           make_zip_iterator(make_tuple(dp_idx_first,
+                                                        dp_keys_first)),
                            less<T>());
 
         stable_sort_by_key(dp_keys_first,

--- a/cupy/cuda/cupy_thrust.cu
+++ b/cupy/cuda/cupy_thrust.cu
@@ -118,7 +118,7 @@ public:
         T1 i1 = get<1>(i), j1 = get<1>(j);
         return i0 < j0 || i0 == j0 && i1 < j1;
     }
-}
+};
 
 template <typename T>
 void cupy::thrust::_argsort(size_t *idx_start, void *data_start, void *keys_start, const std::vector<ptrdiff_t>& shape) {

--- a/cupy/cuda/cupy_thrust.cu
+++ b/cupy/cuda/cupy_thrust.cu
@@ -111,7 +111,7 @@ template void cupy::thrust::_lexsort<cpy_double>(size_t *, void *, size_t, size_
  */
 
 template <typename T>
-void cupy::thrust::_argsort(size_t *idx_start, void *data_start, void *keys_start, void *buff_start, const std::vector<ptrdiff_t>& shape) {
+void cupy::thrust::_argsort(size_t *idx_start, void *data_start, void *keys_start, const std::vector<ptrdiff_t>& shape) {
     /* idx_start is the beggining of the output array where the indexes that
        would sort the data will be placed. The original contents of idx_start
        will be destroyed. */
@@ -122,7 +122,6 @@ void cupy::thrust::_argsort(size_t *idx_start, void *data_start, void *keys_star
     device_ptr<size_t> dp_idx_first, dp_idx_last;
     device_ptr<T> dp_data_first, dp_data_last;
     device_ptr<size_t> dp_keys_first, dp_keys_last;
-    device_ptr<T> dp_buff_first, dp_buff_last;
 
     // Compute the total size of the data array.
     size = shape[0];
@@ -174,13 +173,13 @@ void cupy::thrust::_argsort(size_t *idx_start, void *data_start, void *keys_star
     }
 }
 
-template void cupy::thrust::_argsort<cpy_byte>(size_t *, void *, void *, void *, const std::vector<ptrdiff_t>& shape);
-template void cupy::thrust::_argsort<cpy_ubyte>(size_t *, void *, void *, void *, const std::vector<ptrdiff_t>& shape);
-template void cupy::thrust::_argsort<cpy_short>(size_t *, void *, void *, void *, const std::vector<ptrdiff_t>& shape);
-template void cupy::thrust::_argsort<cpy_ushort>(size_t *, void *, void *, void *, const std::vector<ptrdiff_t>& shape);
-template void cupy::thrust::_argsort<cpy_int>(size_t *, void *, void *, void *, const std::vector<ptrdiff_t>& shape);
-template void cupy::thrust::_argsort<cpy_uint>(size_t *, void *, void *, void *, const std::vector<ptrdiff_t>& shape);
-template void cupy::thrust::_argsort<cpy_long>(size_t *, void *, void *, void *, const std::vector<ptrdiff_t>& shape);
-template void cupy::thrust::_argsort<cpy_ulong>(size_t *, void *, void *, void *, const std::vector<ptrdiff_t>& shape);
-template void cupy::thrust::_argsort<cpy_float>(size_t *, void *, void *, void *, const std::vector<ptrdiff_t>& shape);
-template void cupy::thrust::_argsort<cpy_double>(size_t *, void *, void *, void *, const std::vector<ptrdiff_t>& shape);
+template void cupy::thrust::_argsort<cpy_byte>(size_t *, void *, void *, const std::vector<ptrdiff_t>& shape);
+template void cupy::thrust::_argsort<cpy_ubyte>(size_t *, void *, void *, const std::vector<ptrdiff_t>& shape);
+template void cupy::thrust::_argsort<cpy_short>(size_t *, void *, void *, const std::vector<ptrdiff_t>& shape);
+template void cupy::thrust::_argsort<cpy_ushort>(size_t *, void *, void *, const std::vector<ptrdiff_t>& shape);
+template void cupy::thrust::_argsort<cpy_int>(size_t *, void *, void *, const std::vector<ptrdiff_t>& shape);
+template void cupy::thrust::_argsort<cpy_uint>(size_t *, void *, void *, const std::vector<ptrdiff_t>& shape);
+template void cupy::thrust::_argsort<cpy_long>(size_t *, void *, void *, const std::vector<ptrdiff_t>& shape);
+template void cupy::thrust::_argsort<cpy_ulong>(size_t *, void *, void *, const std::vector<ptrdiff_t>& shape);
+template void cupy::thrust::_argsort<cpy_float>(size_t *, void *, void *, const std::vector<ptrdiff_t>& shape);
+template void cupy::thrust::_argsort<cpy_double>(size_t *, void *, void *, const std::vector<ptrdiff_t>& shape);

--- a/cupy/cuda/cupy_thrust.cu
+++ b/cupy/cuda/cupy_thrust.cu
@@ -168,8 +168,6 @@ void cupy::thrust::_argsort(size_t *idx_start, void *data_start, void *keys_star
                   dp_keys_first,
                   divides<size_t>());
 
-        // Sorting with back-to-back approach.
-
         stable_sort_by_key(
             make_zip_iterator(make_tuple(dp_keys_first, dp_data_first)),
             make_zip_iterator(make_tuple(dp_keys_last, dp_data_last)),

--- a/cupy/cuda/cupy_thrust.cu
+++ b/cupy/cuda/cupy_thrust.cu
@@ -1,9 +1,9 @@
 #include <thrust/device_ptr.h>
 #include <thrust/device_vector.h>
+#include <thrust/iterator/zip_iterator.h>
 #include <thrust/sequence.h>
 #include <thrust/sort.h>
 #include <thrust/tuple.h>
-#include <thrust/zip_iterator.h>
 #include "cupy_common.h"
 #include "cupy_thrust.h"
 

--- a/cupy/cuda/cupy_thrust.cu
+++ b/cupy/cuda/cupy_thrust.cu
@@ -2,6 +2,8 @@
 #include <thrust/device_vector.h>
 #include <thrust/sequence.h>
 #include <thrust/sort.h>
+#include <thrust/tuple.h>
+#include <thrust/zip_iterator.h>
 #include "cupy_common.h"
 #include "cupy_thrust.h"
 
@@ -164,14 +166,9 @@ void cupy::thrust::_argsort(size_t *idx_start, void *data_start, void *keys_star
 
         // Sorting with back-to-back approach.
 
-        stable_sort_by_key(dp_buff_first,
-                           dp_buff_last,
-                           dp_keys_first,
-                           less<T>());
-
         stable_sort_by_key(dp_data_first,
                            dp_data_last,
-                           dp_idx_first,
+                           make_zip_iterator(make_tuple(dp_idx_first, dp_keys_first)),
                            less<T>());
 
         stable_sort_by_key(dp_keys_first,

--- a/cupy/cuda/cupy_thrust.h
+++ b/cupy/cuda/cupy_thrust.h
@@ -10,8 +10,8 @@ namespace thrust {
 template <typename T> void _sort(void *, const std::vector<ptrdiff_t>&);
 
 template <typename T> void _lexsort(size_t *, void *, size_t, size_t);
-   
-template <typename T> void _argsort(size_t *, void *, size_t);
+
+template <typename T> void _argsort(size_t *, void *, void *, void *, const std::vector<ptrdiff_t>&);
 
 } // namespace thrust
 
@@ -29,7 +29,7 @@ template <typename T> void _sort(void *, const std::vector<ptrdiff_t>&) { return
 
 template <typename T> void _lexsort(size_t *, void *, size_t, size_t) { return; }
 
-template <typename T> void _argsort(size_t *, void *, size_t) { return; }
+template <typename T> void _argsort(size_t *, void *, void *, void *, const std::vector<ptrdiff_t>&) { return; }
 
 } // namespace thrust
 

--- a/cupy/cuda/cupy_thrust.h
+++ b/cupy/cuda/cupy_thrust.h
@@ -11,7 +11,7 @@ template <typename T> void _sort(void *, const std::vector<ptrdiff_t>&);
 
 template <typename T> void _lexsort(size_t *, void *, size_t, size_t);
 
-template <typename T> void _argsort(size_t *, void *, void *, void *, const std::vector<ptrdiff_t>&);
+template <typename T> void _argsort(size_t *, void *, void *, const std::vector<ptrdiff_t>&);
 
 } // namespace thrust
 
@@ -29,7 +29,7 @@ template <typename T> void _sort(void *, const std::vector<ptrdiff_t>&) { return
 
 template <typename T> void _lexsort(size_t *, void *, size_t, size_t) { return; }
 
-template <typename T> void _argsort(size_t *, void *, void *, void *, const std::vector<ptrdiff_t>&) { return; }
+template <typename T> void _argsort(size_t *, void *, void *, const std::vector<ptrdiff_t>&) { return; }
 
 } // namespace thrust
 

--- a/cupy/cuda/thrust.pyx
+++ b/cupy/cuda/thrust.pyx
@@ -16,7 +16,8 @@ from cupy.cuda cimport common
 cdef extern from "../cuda/cupy_thrust.h" namespace "cupy::thrust":
     void _sort[T](void *, const vector.vector[ptrdiff_t]&)
     void _lexsort[T](size_t *, void *, size_t, size_t)
-    void _argsort[T](size_t *, void *, size_t)
+    void _argsort[T](size_t *, void *, void *, void *,
+                     const vector.vector[ptrdiff_t]&)
 
 
 ###############################################################################
@@ -85,36 +86,47 @@ cpdef lexsort(dtype, size_t idx_start, size_t keys_start, size_t k, size_t n):
                         'supported'.format(dtype))
 
 
-cpdef argsort(dtype, size_t idx_start, size_t data_start, size_t num):
-    cdef size_t *idx_ptr
-    cdef void *data_ptr
-    cdef size_t n
+cpdef argsort(dtype, size_t idx_start, size_t data_start, size_t keys_start,
+              size_t buff_start, vector.vector[ptrdiff_t]& shape):
+    cdef size_t *_idx_start, *_keys_start
+    cdef void *_data_start, *_buff_start
 
-    idx_ptr = <size_t *>idx_start
-    data_ptr = <void *>data_start
-    n = <size_t>num
+    _idx_start = <size_t *>idx_start
+    _data_start = <void *>data_start
+    _keys_start = <size_t *>keys_start
+    _buff_start = <void *>buff_start
 
     # TODO(takagi): Support float16 and bool
     if dtype == numpy.int8:
-        _argsort[common.cpy_byte](idx_ptr, data_ptr, n)
+        _argsort[common.cpy_byte](
+            _idx_start, _data_start, _keys_start, _buff_start, shape)
     elif dtype == numpy.uint8:
-        _argsort[common.cpy_ubyte](idx_ptr, data_ptr, n)
+        _argsort[common.cpy_ubyte](
+            _idx_start, _data_start, _keys_start, _buff_start, shape)
     elif dtype == numpy.int16:
-        _argsort[common.cpy_short](idx_ptr, data_ptr, n)
+        _argsort[common.cpy_short](
+            _idx_start, _data_start, _keys_start, _buff_start, shape)
     elif dtype == numpy.uint16:
-        _argsort[common.cpy_ushort](idx_ptr, data_ptr, n)
+        _argsort[common.cpy_ushort](
+            _idx_start, _data_start, _keys_start, _buff_start, shape)
     elif dtype == numpy.int32:
-        _argsort[common.cpy_int](idx_ptr, data_ptr, n)
+        _argsort[common.cpy_int](
+            _idx_start, _data_start, _keys_start, _buff_start, shape)
     elif dtype == numpy.uint32:
-        _argsort[common.cpy_uint](idx_ptr, data_ptr, n)
+        _argsort[common.cpy_uint](
+            _idx_start, _data_start, _keys_start, _buff_start, shape)
     elif dtype == numpy.int64:
-        _argsort[common.cpy_long](idx_ptr, data_ptr, n)
+        _argsort[common.cpy_long](
+            _idx_start, _data_start, _keys_start, _buff_start, shape)
     elif dtype == numpy.uint64:
-        _argsort[common.cpy_ulong](idx_ptr, data_ptr, n)
+        _argsort[common.cpy_ulong](
+            _idx_start, _data_start, _keys_start, _buff_start, shape)
     elif dtype == numpy.float32:
-        _argsort[common.cpy_float](idx_ptr, data_ptr, n)
+        _argsort[common.cpy_float](
+            _idx_start, _data_start, _keys_start, _buff_start, shape)
     elif dtype == numpy.float64:
-        _argsort[common.cpy_double](idx_ptr, data_ptr, n)
+        _argsort[common.cpy_double](
+            _idx_start, _data_start, _keys_start, _buff_start, shape)
     else:
         raise NotImplementedError('Sorting arrays with dtype \'{}\' is not '
                                   'supported'.format(dtype))

--- a/cupy/cuda/thrust.pyx
+++ b/cupy/cuda/thrust.pyx
@@ -16,8 +16,7 @@ from cupy.cuda cimport common
 cdef extern from "../cuda/cupy_thrust.h" namespace "cupy::thrust":
     void _sort[T](void *, const vector.vector[ptrdiff_t]&)
     void _lexsort[T](size_t *, void *, size_t, size_t)
-    void _argsort[T](size_t *, void *, void *, void *,
-                     const vector.vector[ptrdiff_t]&)
+    void _argsort[T](size_t *, void *, void *, const vector.vector[ptrdiff_t]&)
 
 
 ###############################################################################
@@ -87,46 +86,37 @@ cpdef lexsort(dtype, size_t idx_start, size_t keys_start, size_t k, size_t n):
 
 
 cpdef argsort(dtype, size_t idx_start, size_t data_start, size_t keys_start,
-              size_t buff_start, vector.vector[ptrdiff_t]& shape):
+              vector.vector[ptrdiff_t]& shape):
     cdef size_t *_idx_start, *_keys_start
-    cdef void *_data_start, *_buff_start
+    cdef void *_data_start
 
     _idx_start = <size_t *>idx_start
     _data_start = <void *>data_start
     _keys_start = <size_t *>keys_start
-    _buff_start = <void *>buff_start
 
     # TODO(takagi): Support float16 and bool
     if dtype == numpy.int8:
-        _argsort[common.cpy_byte](
-            _idx_start, _data_start, _keys_start, _buff_start, shape)
+        _argsort[common.cpy_byte](_idx_start, _data_start, _keys_start, shape)
     elif dtype == numpy.uint8:
-        _argsort[common.cpy_ubyte](
-            _idx_start, _data_start, _keys_start, _buff_start, shape)
+        _argsort[common.cpy_ubyte](_idx_start, _data_start, _keys_start, shape)
     elif dtype == numpy.int16:
-        _argsort[common.cpy_short](
-            _idx_start, _data_start, _keys_start, _buff_start, shape)
+        _argsort[common.cpy_short](_idx_start, _data_start, _keys_start, shape)
     elif dtype == numpy.uint16:
         _argsort[common.cpy_ushort](
-            _idx_start, _data_start, _keys_start, _buff_start, shape)
+            _idx_start, _data_start, _keys_start, shape)
     elif dtype == numpy.int32:
-        _argsort[common.cpy_int](
-            _idx_start, _data_start, _keys_start, _buff_start, shape)
+        _argsort[common.cpy_int](_idx_start, _data_start, _keys_start, shape)
     elif dtype == numpy.uint32:
-        _argsort[common.cpy_uint](
-            _idx_start, _data_start, _keys_start, _buff_start, shape)
+        _argsort[common.cpy_uint](_idx_start, _data_start, _keys_start, shape)
     elif dtype == numpy.int64:
-        _argsort[common.cpy_long](
-            _idx_start, _data_start, _keys_start, _buff_start, shape)
+        _argsort[common.cpy_long](_idx_start, _data_start, _keys_start, shape)
     elif dtype == numpy.uint64:
-        _argsort[common.cpy_ulong](
-            _idx_start, _data_start, _keys_start, _buff_start, shape)
+        _argsort[common.cpy_ulong](_idx_start, _data_start, _keys_start, shape)
     elif dtype == numpy.float32:
-        _argsort[common.cpy_float](
-            _idx_start, _data_start, _keys_start, _buff_start, shape)
+        _argsort[common.cpy_float](_idx_start, _data_start, _keys_start, shape)
     elif dtype == numpy.float64:
         _argsort[common.cpy_double](
-            _idx_start, _data_start, _keys_start, _buff_start, shape)
+            _idx_start, _data_start, _keys_start, shape)
     else:
         raise NotImplementedError('Sorting arrays with dtype \'{}\' is not '
                                   'supported'.format(dtype))

--- a/cupy/sorting/sort.py
+++ b/cupy/sorting/sort.py
@@ -74,7 +74,7 @@ def lexsort(keys):
     return idx_array
 
 
-def argsort(a):
+def argsort(a, axis=-1):
     """Return the indices that would sort an array with a stable sorting.
 
     Args:
@@ -91,7 +91,7 @@ def argsort(a):
     .. seealso:: :func:`numpy.argsort`
 
     """
-    return a.argsort()
+    return a.argsort(axis=axis)
 
 
 def msort(a):

--- a/cupy/sorting/sort.py
+++ b/cupy/sorting/sort.py
@@ -75,18 +75,20 @@ def lexsort(keys):
 
 
 def argsort(a, axis=-1):
-    """Return the indices that would sort an array with a stable sorting.
+    """Returns the indices that would sort an array with a stable sorting.
 
     Args:
         a (cupy.ndarray): Array to sort.
+        axis (int or None): Axis along which to sort. Default is -1, which
+            means sort along the last axis. If None is supplied, the array is
+            flattened before sorting.
 
     Returns:
         cupy.ndarray: Array of indices that sort ``a``.
 
     .. note::
-       For its implementation reason, ``cupy.argsort`` currently supports only
-       arrays with their rank of one and does not support ``axis``, ``kind``
-       and ``order`` parameters that ``numpy.argsort`` supports.
+        For its implementation reason, ``cupy.argsort`` does not support
+        ``kind`` and ``order`` parameters.
 
     .. seealso:: :func:`numpy.argsort`
 


### PR DESCRIPTION
Merge #285 first.

This PR makes `cupy.argsort` support sort multi rank arrays which are of rank two or more. It also supports sort along axes but last.
