### PR TITLE
Stop using itervalue

### DIFF
--- a/cupy/cuda/pinned_memory.pyx
+++ b/cupy/cuda/pinned_memory.pyx
@@ -319,6 +319,6 @@ cdef class PinnedMemoryPool:
             int: The total number of free blocks.
         """
         cdef Py_ssize_t n = 0
-        for v in self._free.itervalues():
+        for v in self._free.values():
             n += len(v)
         return n


### PR DESCRIPTION
`itervalues` does not exist in Python 3. I replaced it.