### PR TITLE
Support ellipsis in __getitem__ for sparse matrix

### DIFF
--- a/cupy/sparse/compressed.py
+++ b/cupy/sparse/compressed.py
@@ -155,6 +155,18 @@ class _compressed_sparse_matrix(sparse_data._data_matrix):
         else:
             slices = [slices]
 
+        ellipsis = -1
+        n_ellipsis = 0
+        for i, s in enumerate(slices):
+            if s is None:
+                raise IndexError('newaxis is not supported')
+            elif s is Ellipsis:
+                ellipsis = i
+                n_ellipsis += 1
+        if n_ellipsis > 0:
+            ellipsis_size = self.ndim - (len(slices) - 1)
+            slices[ellipsis:ellipsis + 1] = [slice(None)] * ellipsis_size
+
         if len(slices) == 2:
             row, col = slices
         elif len(slices) == 1:

--- a/tests/cupy_tests/sparse_tests/test_csr.py
+++ b/tests/cupy_tests/sparse_tests/test_csr.py
@@ -869,3 +869,11 @@ class TestCsrMatrixGetitem(unittest.TestCase):
     def test_getitem_slice_step_2(self):
         with self.assertRaises(ValueError):
             _make(cupy, cupy.sparse, self.dtype)[0::2]
+
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_getitem_ellipsis(self, xp, sp):
+        return _make(xp, sp, self.dtype)[...].toarray()
+
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_getitem_int_ellipsis(self, xp, sp):
+        return _make(xp, sp, self.dtype)[1, ...].toarray()


### PR DESCRIPTION
It supports ellipsis in __getitem__ for sparse matrix.
Please merge #301 first.
related to #36 