### PR TITLE
Use csc2dense to convert csr-matrix to dense

### DIFF
--- a/cupy/cuda/cupy_cusparse.h
+++ b/cupy/cuda/cupy_cusparse.h
@@ -120,6 +120,14 @@ cusparseStatus_t cusparseXcoo2csr(...) {
   return CUSPARSE_STATUS_SUCCESS;
 }
 
+cusparseStatus_t cusparseScsc2dense(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDcsc2dense(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
 cusparseStatus_t cusparseXcsr2coo(...) {
   return CUSPARSE_STATUS_SUCCESS;
 }

--- a/cupy/cuda/cusparse.pyx
+++ b/cupy/cuda/cusparse.pyx
@@ -111,6 +111,16 @@ cdef extern from "cupy_cusparse.h":
         Handle handle, const int *cooRowInd, int nnz, int m, int *csrRowPtr,
         IndexBase idxBase)
 
+    Status cusparseScsc2dense(
+        Handle handle, int m, int n, const MatDescr descrA,  
+        const float *cscSortedValA, const int *cscSortedRowIndA, 
+        const int *cscSortedColPtrA, float *A, int lda);
+
+    Status cusparseDcsc2dense(
+        Handle handle, int m, int n, const MatDescr descrA,
+        const double *cscSortedValA, const int *cscSortedRowIndA,
+        const int *cscSortedColPtrA, double *A, int lda)
+
     Status cusparseXcsr2coo(
         Handle handle, const int *csrRowPtr, int nnz, int m, int *cooRowInd,
         IndexBase idxBase)
@@ -442,6 +452,28 @@ cpdef xcoo2csr(
     status = cusparseXcoo2csr(
         <Handle>handle, <const int *>cooRowInd, nnz, m, <int *>csrRowPtr,
         <IndexBase>idxBase)
+    check_status(status)
+
+
+cpdef scsc2dense(
+        size_t handle, int m, int n, size_t descrA,
+        size_t cscSortedValA, size_t cscSortedRowIndA,
+        size_t cscSortedColPtrA, size_t A, int lda):
+    status = cusparseScsc2dense(
+        <Handle>handle, m, n, <MatDescr>descrA,
+        <const float *>cscSortedValA, <const int *>cscSortedRowIndA,
+        <const int *>cscSortedColPtrA, <float *>A, lda)
+    check_status(status)
+
+
+cpdef dcsc2dense(
+        size_t handle, int m, int n, size_t descrA,
+        size_t cscSortedValA, size_t cscSortedRowIndA,
+        size_t cscSortedColPtrA, size_t A, int lda):
+    status = cusparseDcsc2dense(
+        <Handle>handle, m, n, <MatDescr>descrA,
+        <const double *>cscSortedValA, <const int *>cscSortedRowIndA,
+        <const int *>cscSortedColPtrA, <double *>A, lda)
     check_status(status)
 
 

--- a/cupy/cuda/cusparse.pyx
+++ b/cupy/cuda/cusparse.pyx
@@ -112,9 +112,9 @@ cdef extern from "cupy_cusparse.h":
         IndexBase idxBase)
 
     Status cusparseScsc2dense(
-        Handle handle, int m, int n, const MatDescr descrA,  
-        const float *cscSortedValA, const int *cscSortedRowIndA, 
-        const int *cscSortedColPtrA, float *A, int lda);
+        Handle handle, int m, int n, const MatDescr descrA,
+        const float *cscSortedValA, const int *cscSortedRowIndA,
+        const int *cscSortedColPtrA, float *A, int lda)
 
     Status cusparseDcsc2dense(
         Handle handle, int m, int n, const MatDescr descrA,

--- a/cupy/cusparse.py
+++ b/cupy/cusparse.py
@@ -65,6 +65,35 @@ def csr2dense(x, out=None):
     return out
 
 
+def csc2dense(x, out=None):
+    """Converts CSC-matrix to a dense matrix.
+
+    Args:
+        x (cupy.sparse.csc_matrix): A sparse matrix to convert.
+        out (cupy.ndarray or None): A dense metrix to store the result.
+            It must be F-contiguous.
+
+    Returns:
+        cupy.ndarray: Converted result.
+
+    """
+    dtype = x.dtype
+    assert dtype == 'f' or dtype == 'd'
+    if out is None:
+        out = cupy.empty(x.shape, dtype=dtype, order='F')
+    else:
+        assert out.flags.f_contiguous
+
+    handle = device.get_cusparse_handle()
+    _call_cusparse(
+        'csc2dense', x.dtype,
+        handle, x.shape[0], x.shape[1], x._descr.descriptor,
+        x.data.data.ptr, x.indices.data.ptr, x.indptr.data.ptr,
+        out.data.ptr, x.shape[0])
+
+    return out
+
+
 def csrsort(x):
     """Sorts indices of CSR-matrix in place.
 

--- a/cupy/sparse/csc.py
+++ b/cupy/sparse/csc.py
@@ -92,6 +92,8 @@ class csc_matrix(compressed._compressed_sparse_matrix):
         .. seealso:: :func:`cupy.sparse.csc_array.toarray`
 
         """
+        # csc2dense returns F-contiguous array.
+        # To return C-contiguous array, it uses transpose.
         return cusparse.csr2dense(self.T).T
 
     # TODO(unno): Implement tobsr

--- a/cupy/sparse/csr.py
+++ b/cupy/sparse/csr.py
@@ -93,7 +93,9 @@ class csr_matrix(compressed._compressed_sparse_matrix):
         .. seealso:: :func:`cupy.sparse.csr_array.toarray`
 
         """
-        return cupy.ascontiguousarray(cusparse.csr2dense(self))
+        # csr2dense returns F-contiguous array.
+        # To return C-contiguous array, it uses transpose.
+        return cusparse.csc2dense(self.T).T
 
     # TODO(unno): Implement tobsr
     # TODO(unno): Implement tocoo

--- a/cupy/sparse/csr.py
+++ b/cupy/sparse/csr.py
@@ -4,7 +4,6 @@ try:
 except ImportError:
     _scipy_available = False
 
-import cupy
 from cupy import cusparse
 from cupy.sparse import compressed
 from cupy.sparse import csc


### PR DESCRIPTION
I found `cusparseScsc2dense` API, that can convert csc matrix to f-contiguous array. I fixed `csr_matrix.toarray` with this method to return c-contiguous array.