### PR TITLE
Support CUDA stream with stream memory pool

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -443,7 +443,7 @@ cdef class ndarray:
             value = value.item()
 
         if value == 0 and self._c_contiguous:
-            self.data.memset_async(0, self.nbytes, stream.Stream(True))
+            self.data.memset_async(0, self.nbytes, stream.Stream.null)
         else:
             elementwise_copy(value, self, dtype=self.dtype)
 

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -443,7 +443,8 @@ cdef class ndarray:
             value = value.item()
 
         if value == 0 and self._c_contiguous:
-            self.data.memset_async(0, self.nbytes, stream.Stream.null)
+            stream = cuda.get_current_stream()
+            self.data.memset_async(0, self.nbytes, stream)
         else:
             elementwise_copy(value, self, dtype=self.dtype)
 
@@ -3423,7 +3424,8 @@ cpdef ndarray matmul(ndarray a, ndarray b, ndarray out=None):
     b = view
 
     out = ndarray(out_shape, dtype=dtype)
-    out.data.memset(0, out.nbytes)
+    stream = cuda.get_current_stream()
+    out.data.memset_async(0, out.nbytes, stream)
 
     out_view = out.view()
     out_view_shape = out.shape

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1680,6 +1680,7 @@ cdef class ndarray:
         Args:
             stream (cupy.cuda.Stream): CUDA stream object. If it is given, the
                 copy runs asynchronously. Otherwise, the copy is synchronous.
+                The default uses CUDA stream object of the current context.
 
         Returns:
             numpy.ndarray: Copy of the array on host memory.
@@ -1692,7 +1693,8 @@ cdef class ndarray:
             a_gpu = ascontiguousarray(self)
         a_cpu = numpy.empty(self._shape, dtype=self.dtype)
         ptr = a_cpu.ctypes.get_as_parameter()
-        if stream is None:
+        stream = cuda.get_current_stream() if stream is None else stream
+        if stream == cuda.Stream.null:
             a_gpu.data.copy_to_host(ptr, a_gpu.nbytes)
         else:
             a_gpu.data.copy_to_host_async(ptr, a_gpu.nbytes, stream)
@@ -1705,6 +1707,7 @@ cdef class ndarray:
             arr (numpy.ndarray): The source array on the host memory.
             stream (cupy.cuda.Stream): CUDA stream object. If it is given, the
                 copy runs asynchronously. Otherwise, the copy is synchronous.
+                The default uses CUDA stream object of the current context.
 
         """
         if not isinstance(arr, numpy.ndarray):
@@ -1724,7 +1727,8 @@ cdef class ndarray:
             raise RuntimeError('Cannot set to non-contiguous array')
 
         ptr = arr.ctypes.get_as_parameter()
-        if stream is None:
+        stream = cuda.get_current_stream() if stream is None else stream
+        if stream == cuda.Stream.null:
             self.data.copy_from_host(ptr, self.nbytes)
         else:
             self.data.copy_from_host_async(ptr, self.nbytes, stream)

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -443,8 +443,7 @@ cdef class ndarray:
             value = value.item()
 
         if value == 0 and self._c_contiguous:
-            stream = cuda.get_current_stream()
-            self.data.memset_async(0, self.nbytes, stream)
+            self.data.memset_async(0, self.nbytes)
         else:
             elementwise_copy(value, self, dtype=self.dtype)
 
@@ -1694,7 +1693,8 @@ cdef class ndarray:
             a_gpu = ascontiguousarray(self)
         a_cpu = numpy.empty(self._shape, dtype=self.dtype)
         ptr = a_cpu.ctypes.get_as_parameter()
-        stream = cuda.get_current_stream() if stream is None else stream
+        if stream is None:
+            stream = cuda.get_current_stream()
         if stream == cuda.Stream.null:
             a_gpu.data.copy_to_host(ptr, a_gpu.nbytes)
         else:
@@ -1728,7 +1728,8 @@ cdef class ndarray:
             raise RuntimeError('Cannot set to non-contiguous array')
 
         ptr = arr.ctypes.get_as_parameter()
-        stream = cuda.get_current_stream() if stream is None else stream
+        if stream is None:
+            stream = cuda.get_current_stream()
         if stream == cuda.Stream.null:
             self.data.copy_from_host(ptr, self.nbytes)
         else:
@@ -3424,8 +3425,7 @@ cpdef ndarray matmul(ndarray a, ndarray b, ndarray out=None):
     b = view
 
     out = ndarray(out_shape, dtype=dtype)
-    stream = cuda.get_current_stream()
-    out.data.memset_async(0, out.nbytes, stream)
+    out.data.memset_async(0, out.nbytes)
 
     out_view = out.view()
     out_view_shape = out.shape

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -26,6 +26,7 @@ from cupy.cuda cimport function
 from cupy.cuda cimport pinned_memory
 from cupy.cuda cimport runtime
 from cupy.cuda cimport memory
+from cupy.cuda cimport stream as stream_module
 
 DEF MAX_NDIM = 25
 
@@ -1694,8 +1695,10 @@ cdef class ndarray:
         a_cpu = numpy.empty(self._shape, dtype=self.dtype)
         ptr = a_cpu.ctypes.get_as_parameter()
         if stream is None:
-            stream = cuda.get_current_stream()
-        if stream == cuda.Stream.null:
+            stream_ptr = stream_module.get_current_stream_ptr()
+        else:
+            stream_ptr = stream.ptr
+        if stream_ptr == 0:
             a_gpu.data.copy_to_host(ptr, a_gpu.nbytes)
         else:
             a_gpu.data.copy_to_host_async(ptr, a_gpu.nbytes, stream)
@@ -1729,8 +1732,10 @@ cdef class ndarray:
 
         ptr = arr.ctypes.get_as_parameter()
         if stream is None:
-            stream = cuda.get_current_stream()
-        if stream == cuda.Stream.null:
+            stream_ptr = stream_module.get_current_stream_ptr()
+        else:
+            stream_ptr = stream.ptr
+        if stream_ptr == 0:
             self.data.copy_from_host(ptr, self.nbytes)
         else:
             self.data.copy_from_host_async(ptr, self.nbytes, stream)

--- a/cupy/creation/basic.py
+++ b/cupy/creation/basic.py
@@ -1,4 +1,5 @@
 import cupy
+from cupy.cuda import stream as stream_module
 
 
 def empty(shape, dtype=float, order='C'):
@@ -144,7 +145,8 @@ def zeros(shape, dtype=float, order='C'):
 
     """
     a = cupy.ndarray(shape, dtype, order=order)
-    a.data.memset(0, a.nbytes)
+    stream = stream_module.get_current_stream()
+    a.data.memset_async(0, a.nbytes, stream)
     return a
 
 
@@ -167,7 +169,8 @@ def zeros_like(a, dtype=None):
     if dtype is None:
         dtype = a.dtype
     a = cupy.ndarray(a.shape, dtype)
-    a.data.memset(0, a.nbytes)
+    stream = stream_module.get_current_stream()
+    a.data.memset_async(0, a.nbytes, stream)
     return a
 
 

--- a/cupy/creation/basic.py
+++ b/cupy/creation/basic.py
@@ -1,5 +1,4 @@
 import cupy
-from cupy.cuda import stream as stream_module
 
 
 def empty(shape, dtype=float, order='C'):
@@ -145,8 +144,7 @@ def zeros(shape, dtype=float, order='C'):
 
     """
     a = cupy.ndarray(shape, dtype, order=order)
-    stream = stream_module.get_current_stream()
-    a.data.memset_async(0, a.nbytes, stream)
+    a.data.memset_async(0, a.nbytes)
     return a
 
 
@@ -169,8 +167,7 @@ def zeros_like(a, dtype=None):
     if dtype is None:
         dtype = a.dtype
     a = cupy.ndarray(a.shape, dtype)
-    stream = stream_module.get_current_stream()
-    a.data.memset_async(0, a.nbytes, stream)
+    a.data.memset_async(0, a.nbytes)
     return a
 
 

--- a/cupy/cuda/__init__.py
+++ b/cupy/cuda/__init__.py
@@ -68,6 +68,7 @@ from cupy.cuda.pinned_memory import PinnedMemoryPointer  # NOQA
 from cupy.cuda.pinned_memory import PinnedMemoryPool  # NOQA
 from cupy.cuda.pinned_memory import set_pinned_memory_allocator  # NOQA
 from cupy.cuda.stream import Event  # NOQA
+from cupy.cuda.stream import get_current_stream  # NOQA
 from cupy.cuda.stream import get_elapsed_time  # NOQA
 from cupy.cuda.stream import Stream  # NOQA
 

--- a/cupy/cuda/cublas.pyx
+++ b/cupy/cuda/cublas.pyx
@@ -5,6 +5,7 @@ cimport cython
 
 from cupy.cuda cimport driver
 from cupy.cuda cimport runtime
+from cupy.cuda import stream as stream_module
 
 
 ###############################################################################
@@ -320,6 +321,7 @@ cpdef int getMathMode(size_t handle) except *:
 
 cpdef int isamax(size_t handle, int n, size_t x, int incx) except *:
     cdef int result
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cublasIsamax(
             <Handle>handle, n, <float*>x, incx, &result)
@@ -329,6 +331,7 @@ cpdef int isamax(size_t handle, int n, size_t x, int incx) except *:
 
 cpdef int isamin(size_t handle, int n, size_t x, int incx) except *:
     cdef int result
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cublasIsamin(
             <Handle>handle, n, <float*>x, incx, &result)
@@ -338,6 +341,7 @@ cpdef int isamin(size_t handle, int n, size_t x, int incx) except *:
 
 cpdef float sasum(size_t handle, int n, size_t x, int incx) except *:
     cdef float result
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cublasSasum(
             <Handle>handle, n, <float*>x, incx, &result)
@@ -347,6 +351,7 @@ cpdef float sasum(size_t handle, int n, size_t x, int incx) except *:
 
 cpdef saxpy(size_t handle, int n, float alpha, size_t x, int incx, size_t y,
             int incy):
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cublasSaxpy(
             <Handle>handle, n, &alpha, <float*>x, incx, <float*>y, incy)
@@ -355,6 +360,7 @@ cpdef saxpy(size_t handle, int n, float alpha, size_t x, int incx, size_t y,
 
 cpdef daxpy(size_t handle, int n, double alpha, size_t x, int incx, size_t y,
             int incy):
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cublasDaxpy(
             <Handle>handle, n, &alpha, <double*>x, incx, <double*>y, incy)
@@ -363,6 +369,7 @@ cpdef daxpy(size_t handle, int n, double alpha, size_t x, int incx, size_t y,
 
 cpdef sdot(size_t handle, int n, size_t x, int incx, size_t y, int incy,
            size_t result):
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cublasSdot(
             <Handle>handle, n, <float*>x, incx, <float*>y, incy,
@@ -372,6 +379,7 @@ cpdef sdot(size_t handle, int n, size_t x, int incx, size_t y, int incy,
 
 cpdef ddot(size_t handle, int n, size_t x, int incx, size_t y, int incy,
            size_t result):
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cublasDdot(
             <Handle>handle, n, <double*>x, incx, <double*>y, incy,
@@ -417,6 +425,7 @@ cpdef zdotc(size_t handle, int n, size_t x, int incx, size_t y, int incy,
 
 cpdef float snrm2(size_t handle, int n, size_t x, int incx) except *:
     cdef float result
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cublasSnrm2(<Handle>handle, n, <float*>x, incx, &result)
     check_status(status)
@@ -424,6 +433,7 @@ cpdef float snrm2(size_t handle, int n, size_t x, int incx) except *:
 
 
 cpdef sscal(size_t handle, int n, float alpha, size_t x, int incx):
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cublasSscal(<Handle>handle, n, &alpha, <float*>x, incx)
     check_status(status)
@@ -435,6 +445,7 @@ cpdef sscal(size_t handle, int n, float alpha, size_t x, int incx):
 
 cpdef sgemv(size_t handle, int trans, int m, int n, float alpha, size_t A,
             int lda, size_t x, int incx, float beta, size_t y, int incy):
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cublasSgemv(
             <Handle>handle, <Operation>trans, m, n, &alpha,
@@ -444,6 +455,7 @@ cpdef sgemv(size_t handle, int trans, int m, int n, float alpha, size_t A,
 
 cpdef dgemv(size_t handle, int trans, int m, int n, double alpha, size_t A,
             int lda, size_t x, int incx, double beta, size_t y, int incy):
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cublasDgemv(
             <Handle>handle, <Operation>trans, m, n, &alpha,
@@ -477,6 +489,7 @@ cpdef zgemv(size_t handle, int trans, int m, int n, double complex alpha,
 
 cpdef sger(size_t handle, int m, int n, float alpha, size_t x, int incx,
            size_t y, int incy, size_t A, int lda):
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cublasSger(
             <Handle>handle, m, n, &alpha, <float*>x, incx, <float*>y, incy,
@@ -486,6 +499,7 @@ cpdef sger(size_t handle, int m, int n, float alpha, size_t x, int incx,
 
 cpdef dger(size_t handle, int m, int n, double alpha, size_t x, int incx,
            size_t y, int incy, size_t A, int lda):
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cublasDger(
             <Handle>handle, m, n, &alpha, <double*>x, incx, <double*>y, incy,
@@ -542,6 +556,7 @@ cpdef zgerc(size_t handle, int m, int n, double complex alpha, size_t x,
 cpdef sgemm(size_t handle, int transa, int transb,
             int m, int n, int k, float alpha, size_t A, int lda,
             size_t B, int ldb, float beta, size_t C, int ldc):
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cublasSgemm(
             <Handle>handle, <Operation>transa, <Operation>transb, m, n, k,
@@ -552,6 +567,7 @@ cpdef sgemm(size_t handle, int transa, int transb,
 cpdef dgemm(size_t handle, int transa, int transb,
             int m, int n, int k, double alpha, size_t A, int lda,
             size_t B, int ldb, double beta, size_t C, int ldc):
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cublasDgemm(
             <Handle>handle, <Operation>transa, <Operation>transb, m, n, k,
@@ -590,6 +606,7 @@ cpdef sgemmBatched(
         size_t handle, int transa, int transb, int m, int n, int k,
         float alpha, size_t Aarray, int lda, size_t Barray, int ldb,
         float beta, size_t Carray, int ldc, int batchCount):
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cublasSgemmBatched(
             <Handle>handle, <Operation>transa, <Operation>transb, m, n, k,
@@ -602,6 +619,7 @@ cpdef dgemmBatched(
         size_t handle, int transa, int transb, int m, int n, int k,
         double alpha, size_t Aarray, int lda, size_t Barray, int ldb,
         double beta, size_t Carray, int ldc, int batchCount):
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cublasDgemmBatched(
             <Handle>handle, <Operation>transa, <Operation>transb, m, n, k,
@@ -669,6 +687,7 @@ cpdef dtrsm(
 cpdef sgeam(size_t handle, int transa, int transb, int m, int n,
             float alpha, size_t A, int lda, float beta, size_t B, int ldb,
             size_t C, int ldc):
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cublasSgeam(
             <Handle>handle, <Operation>transa, <Operation>transb, m, n,
@@ -680,6 +699,7 @@ cpdef sgeam(size_t handle, int transa, int transb, int m, int n,
 cpdef dgeam(size_t handle, int transa, int transb, int m, int n,
             double alpha, size_t A, int lda, double beta, size_t B, int ldb,
             size_t C, int ldc):
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cublasDgeam(
             <Handle>handle, <Operation>transa, <Operation>transb, m, n,
@@ -690,6 +710,7 @@ cpdef dgeam(size_t handle, int transa, int transb, int m, int n,
 
 cpdef sdgmm(size_t handle, int mode, int m, int n, size_t A, int lda,
             size_t x, int incx, size_t C, int ldc):
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cublasSdgmm(
             <Handle>handle, <SideMode>mode, m, n, <float*>A, lda, <float*>x,
@@ -702,6 +723,7 @@ cpdef sgemmEx(
         float alpha, size_t A, int Atype, int lda, size_t B,
         int Btype, int ldb, float beta, size_t C, int Ctype,
         int ldc):
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cublasSgemmEx(
             <Handle>handle, <Operation>transa, <Operation>transb, m, n, k,
@@ -713,6 +735,7 @@ cpdef sgemmEx(
 
 cpdef sgetrfBatched(size_t handle, int n, size_t Aarray, int lda,
                     size_t PivotArray, size_t infoArray, int batchSize):
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cublasSgetrfBatched(
             <Handle>handle, n, <float**>Aarray, lda, <int*>PivotArray,
@@ -723,6 +746,7 @@ cpdef sgetrfBatched(size_t handle, int n, size_t Aarray, int lda,
 cpdef sgetriBatched(
         size_t handle, int n, size_t Aarray, int lda, size_t PivotArray,
         size_t Carray, int ldc, size_t infoArray, int batchSize):
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cublasSgetriBatched(
             <Handle>handle, n, <const float**>Aarray, lda, <int*>PivotArray,

--- a/cupy/cuda/cublas.pyx
+++ b/cupy/cuda/cublas.pyx
@@ -5,7 +5,7 @@ cimport cython
 
 from cupy.cuda cimport driver
 from cupy.cuda cimport runtime
-from cupy.cuda import stream as stream_module
+from cupy.cuda cimport stream as stream_module
 
 
 ###############################################################################
@@ -321,7 +321,7 @@ cpdef int getMathMode(size_t handle) except *:
 
 cpdef int isamax(size_t handle, int n, size_t x, int incx) except *:
     cdef int result
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cublasIsamax(
             <Handle>handle, n, <float*>x, incx, &result)
@@ -331,7 +331,7 @@ cpdef int isamax(size_t handle, int n, size_t x, int incx) except *:
 
 cpdef int isamin(size_t handle, int n, size_t x, int incx) except *:
     cdef int result
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cublasIsamin(
             <Handle>handle, n, <float*>x, incx, &result)
@@ -341,7 +341,7 @@ cpdef int isamin(size_t handle, int n, size_t x, int incx) except *:
 
 cpdef float sasum(size_t handle, int n, size_t x, int incx) except *:
     cdef float result
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cublasSasum(
             <Handle>handle, n, <float*>x, incx, &result)
@@ -351,7 +351,7 @@ cpdef float sasum(size_t handle, int n, size_t x, int incx) except *:
 
 cpdef saxpy(size_t handle, int n, float alpha, size_t x, int incx, size_t y,
             int incy):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cublasSaxpy(
             <Handle>handle, n, &alpha, <float*>x, incx, <float*>y, incy)
@@ -360,7 +360,7 @@ cpdef saxpy(size_t handle, int n, float alpha, size_t x, int incx, size_t y,
 
 cpdef daxpy(size_t handle, int n, double alpha, size_t x, int incx, size_t y,
             int incy):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cublasDaxpy(
             <Handle>handle, n, &alpha, <double*>x, incx, <double*>y, incy)
@@ -369,7 +369,7 @@ cpdef daxpy(size_t handle, int n, double alpha, size_t x, int incx, size_t y,
 
 cpdef sdot(size_t handle, int n, size_t x, int incx, size_t y, int incy,
            size_t result):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cublasSdot(
             <Handle>handle, n, <float*>x, incx, <float*>y, incy,
@@ -379,7 +379,7 @@ cpdef sdot(size_t handle, int n, size_t x, int incx, size_t y, int incy,
 
 cpdef ddot(size_t handle, int n, size_t x, int incx, size_t y, int incy,
            size_t result):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cublasDdot(
             <Handle>handle, n, <double*>x, incx, <double*>y, incy,
@@ -425,7 +425,7 @@ cpdef zdotc(size_t handle, int n, size_t x, int incx, size_t y, int incy,
 
 cpdef float snrm2(size_t handle, int n, size_t x, int incx) except *:
     cdef float result
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cublasSnrm2(<Handle>handle, n, <float*>x, incx, &result)
     check_status(status)
@@ -433,7 +433,7 @@ cpdef float snrm2(size_t handle, int n, size_t x, int incx) except *:
 
 
 cpdef sscal(size_t handle, int n, float alpha, size_t x, int incx):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cublasSscal(<Handle>handle, n, &alpha, <float*>x, incx)
     check_status(status)
@@ -445,7 +445,7 @@ cpdef sscal(size_t handle, int n, float alpha, size_t x, int incx):
 
 cpdef sgemv(size_t handle, int trans, int m, int n, float alpha, size_t A,
             int lda, size_t x, int incx, float beta, size_t y, int incy):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cublasSgemv(
             <Handle>handle, <Operation>trans, m, n, &alpha,
@@ -455,7 +455,7 @@ cpdef sgemv(size_t handle, int trans, int m, int n, float alpha, size_t A,
 
 cpdef dgemv(size_t handle, int trans, int m, int n, double alpha, size_t A,
             int lda, size_t x, int incx, double beta, size_t y, int incy):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cublasDgemv(
             <Handle>handle, <Operation>trans, m, n, &alpha,
@@ -489,7 +489,7 @@ cpdef zgemv(size_t handle, int trans, int m, int n, double complex alpha,
 
 cpdef sger(size_t handle, int m, int n, float alpha, size_t x, int incx,
            size_t y, int incy, size_t A, int lda):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cublasSger(
             <Handle>handle, m, n, &alpha, <float*>x, incx, <float*>y, incy,
@@ -499,7 +499,7 @@ cpdef sger(size_t handle, int m, int n, float alpha, size_t x, int incx,
 
 cpdef dger(size_t handle, int m, int n, double alpha, size_t x, int incx,
            size_t y, int incy, size_t A, int lda):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cublasDger(
             <Handle>handle, m, n, &alpha, <double*>x, incx, <double*>y, incy,
@@ -556,7 +556,7 @@ cpdef zgerc(size_t handle, int m, int n, double complex alpha, size_t x,
 cpdef sgemm(size_t handle, int transa, int transb,
             int m, int n, int k, float alpha, size_t A, int lda,
             size_t B, int ldb, float beta, size_t C, int ldc):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cublasSgemm(
             <Handle>handle, <Operation>transa, <Operation>transb, m, n, k,
@@ -567,7 +567,7 @@ cpdef sgemm(size_t handle, int transa, int transb,
 cpdef dgemm(size_t handle, int transa, int transb,
             int m, int n, int k, double alpha, size_t A, int lda,
             size_t B, int ldb, double beta, size_t C, int ldc):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cublasDgemm(
             <Handle>handle, <Operation>transa, <Operation>transb, m, n, k,
@@ -606,7 +606,7 @@ cpdef sgemmBatched(
         size_t handle, int transa, int transb, int m, int n, int k,
         float alpha, size_t Aarray, int lda, size_t Barray, int ldb,
         float beta, size_t Carray, int ldc, int batchCount):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cublasSgemmBatched(
             <Handle>handle, <Operation>transa, <Operation>transb, m, n, k,
@@ -619,7 +619,7 @@ cpdef dgemmBatched(
         size_t handle, int transa, int transb, int m, int n, int k,
         double alpha, size_t Aarray, int lda, size_t Barray, int ldb,
         double beta, size_t Carray, int ldc, int batchCount):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cublasDgemmBatched(
             <Handle>handle, <Operation>transa, <Operation>transb, m, n, k,
@@ -687,7 +687,7 @@ cpdef dtrsm(
 cpdef sgeam(size_t handle, int transa, int transb, int m, int n,
             float alpha, size_t A, int lda, float beta, size_t B, int ldb,
             size_t C, int ldc):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cublasSgeam(
             <Handle>handle, <Operation>transa, <Operation>transb, m, n,
@@ -699,7 +699,7 @@ cpdef sgeam(size_t handle, int transa, int transb, int m, int n,
 cpdef dgeam(size_t handle, int transa, int transb, int m, int n,
             double alpha, size_t A, int lda, double beta, size_t B, int ldb,
             size_t C, int ldc):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cublasDgeam(
             <Handle>handle, <Operation>transa, <Operation>transb, m, n,
@@ -710,7 +710,7 @@ cpdef dgeam(size_t handle, int transa, int transb, int m, int n,
 
 cpdef sdgmm(size_t handle, int mode, int m, int n, size_t A, int lda,
             size_t x, int incx, size_t C, int ldc):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cublasSdgmm(
             <Handle>handle, <SideMode>mode, m, n, <float*>A, lda, <float*>x,
@@ -723,7 +723,7 @@ cpdef sgemmEx(
         float alpha, size_t A, int Atype, int lda, size_t B,
         int Btype, int ldb, float beta, size_t C, int Ctype,
         int ldc):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cublasSgemmEx(
             <Handle>handle, <Operation>transa, <Operation>transb, m, n, k,
@@ -735,7 +735,7 @@ cpdef sgemmEx(
 
 cpdef sgetrfBatched(size_t handle, int n, size_t Aarray, int lda,
                     size_t PivotArray, size_t infoArray, int batchSize):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cublasSgetrfBatched(
             <Handle>handle, n, <float**>Aarray, lda, <int*>PivotArray,
@@ -746,7 +746,7 @@ cpdef sgetrfBatched(size_t handle, int n, size_t Aarray, int lda,
 cpdef sgetriBatched(
         size_t handle, int n, size_t Aarray, int lda, size_t PivotArray,
         size_t Carray, int ldc, size_t infoArray, int batchSize):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cublasSgetriBatched(
             <Handle>handle, n, <const float**>Aarray, lda, <int*>PivotArray,

--- a/cupy/cuda/cudnn.pyx
+++ b/cupy/cuda/cudnn.pyx
@@ -6,7 +6,7 @@ cimport cython
 from libcpp cimport vector
 
 from cupy.cuda cimport driver
-
+from cupy.cuda import stream as stream_module
 
 ###############################################################################
 # Extern
@@ -536,6 +536,7 @@ cpdef destroyTensorDescriptor(size_t tensorDesc):
 
 cpdef addTensor_v3(size_t handle, size_t alpha, size_t bDesc,
                    size_t b, size_t beta, size_t yDesc, size_t y):
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cudnnAddTensor_v3(
             <Handle>handle, <void*>alpha, <TensorDescriptor>bDesc,
@@ -712,6 +713,7 @@ cpdef convolutionForward(
         size_t filterDesc, size_t filterData, size_t convDesc, int algo,
         size_t workSpace, size_t workSpaceSizeInBytes, size_t beta,
         size_t destDesc, size_t destData):
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cudnnConvolutionForward(
             <Handle>handle, <void*>alpha,
@@ -726,6 +728,7 @@ cpdef convolutionForward(
 cpdef convolutionBackwardBias(
         size_t handle, size_t alpha, size_t srcDesc, size_t srcData,
         size_t beta, size_t destDesc, size_t destData):
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cudnnConvolutionBackwardBias(
             <Handle>handle, <void*>alpha,
@@ -799,6 +802,7 @@ cpdef convolutionBackwardFilter_v3(
         size_t diffDesc, size_t diffData, size_t convDesc, int algo,
         size_t workSpace, size_t workSpaceSizeInBytes, size_t beta,
         size_t gradDesc, size_t gradData):
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cudnnConvolutionBackwardFilter_v3(
             <Handle>handle, <void*>alpha,
@@ -875,6 +879,7 @@ cpdef convolutionBackwardData_v3(
         size_t diffDesc, size_t diffData, size_t convDesc, int algo,
         size_t workSpace, size_t workSpaceSizeInBytes, size_t beta,
         size_t gradDesc, size_t gradData):
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cudnnConvolutionBackwardData_v3(
             <Handle>handle, <void*>alpha,
@@ -925,6 +930,7 @@ cpdef destroyPoolingDescriptor(size_t poolingDesc):
 cpdef poolingForward(
         size_t handle, size_t poolingDesc, size_t alpha, size_t srcDesc,
         size_t srcData, size_t beta, size_t dstDesc, size_t dstData):
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cudnnPoolingForward(
             <Handle>handle, <PoolingDescriptor>poolingDesc, <void*>alpha,
@@ -938,6 +944,7 @@ cpdef poolingBackward(
         size_t srcData, size_t srcDiffDesc, size_t srcDiffData,
         size_t destDesc, size_t destData, size_t beta, size_t destDiffDesc,
         size_t destDiffData):
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cudnnPoolingBackward(
             <Handle>handle, <PoolingDescriptor>poolingDesc, <void*>alpha,
@@ -967,6 +974,7 @@ cpdef batchNormalizationForwardTraining(
         size_t bnBias, double exponentialAverageFactor,
         size_t resultRunningMean, size_t resultRunningVariance,
         double epsilon, size_t resultSaveMean, size_t resultSaveInvVariance):
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cudnnBatchNormalizationForwardTraining(
             <Handle>handle, <BatchNormMode> mode,
@@ -986,6 +994,7 @@ cpdef batchNormalizationForwardInference(
         size_t bnScaleBiasMeanVarDesc, size_t bnScale,
         size_t bnBias, size_t estimatedMean, size_t estimatedVariance,
         double epsilon):
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cudnnBatchNormalizationForwardInference(
             <Handle>handle, <BatchNormMode> mode,
@@ -1006,6 +1015,7 @@ cpdef batchNormalizationBackward(
         size_t dBnScaleBiasDesc, size_t bnScale,
         size_t dBnScaleResult, size_t dBnBiasResult,
         double epsilon, size_t savedMean, size_t savedInvVariance):
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cudnnBatchNormalizationBackward(
             <Handle>handle, <BatchNormMode>mode,
@@ -1047,6 +1057,7 @@ cpdef destroyActivationDescriptor(size_t activationDesc):
 cpdef softmaxForward(
         size_t handle, int algorithm, int mode, size_t alpha, size_t srcDesc,
         size_t srcData, size_t beta, size_t dstDesc, size_t dstData):
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cudnnSoftmaxForward(
             <Handle>handle, <SoftmaxAlgorithm>algorithm, <SoftmaxMode>mode,
@@ -1059,6 +1070,7 @@ cpdef softmaxBackward(
         size_t handle, int algorithm, int mode, size_t alpha, size_t srcDesc,
         size_t srcData, size_t srcDiffDesc, size_t srcDiffData, size_t beta,
         size_t destDiffDesc, size_t destDiffData):
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cudnnSoftmaxBackward(
             <Handle>handle, <SoftmaxAlgorithm>algorithm, <SoftmaxMode>mode,
@@ -1071,6 +1083,7 @@ cpdef softmaxBackward(
 cpdef activationForward_v4(
         size_t handle, size_t activationDesc, size_t alpha, size_t srcDesc,
         size_t srcData, size_t beta, size_t dstDesc, size_t dstData):
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cudnnActivationForward_v4(
             <Handle>handle, <ActivationDescriptor>activationDesc, <void*>alpha,
@@ -1084,6 +1097,7 @@ cpdef activationBackward_v4(
         size_t srcData, size_t srcDiffDesc, size_t srcDiffData,
         size_t destDesc, size_t destData, size_t beta, size_t destDiffDesc,
         size_t destDiffData):
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cudnnActivationBackward_v4(
             <Handle>handle, <ActivationDescriptor>activationDesc, <void*>alpha,
@@ -1247,6 +1261,7 @@ cpdef RNNForwardInference(
         size_t cx, size_t wDesc, size_t w, size_t yDesc,
         size_t y, size_t hyDesc, size_t hy, size_t cyDesc,
         size_t cy, size_t workspace, size_t workSpaceSizeInBytes):
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cudnnRNNForwardInference(
             <Handle>handle, <RNNDescriptor>rnnDesc, seqLength,
@@ -1268,6 +1283,7 @@ cpdef RNNForwardTraining(
         size_t hyDesc, size_t hy, size_t cyDesc, size_t cy,
         size_t workspace, size_t workSpaceSizeInBytes, size_t reserveSpace,
         size_t reserveSpaceSizeInBytes):
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cudnnRNNForwardTraining(
             <Handle>handle, <RNNDescriptor>rnnDesc, seqLength,
@@ -1292,6 +1308,7 @@ cpdef RNNBackwardData(
         size_t dcxDesc, size_t dcx, size_t workspace,
         size_t workSpaceSizeInBytes, size_t reserveSpace,
         size_t reserveSpaceSizeInBytes):
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cudnnRNNBackwardData(
             <Handle>handle, <RNNDescriptor>rnnDesc, seqLength,
@@ -1315,6 +1332,7 @@ cpdef RNNBackwardWeights(
         size_t hxDesc, size_t hx, size_t yDesc, size_t y,
         size_t workspace, size_t workSpaceSizeInBytes, size_t dwDesc,
         size_t dw, size_t reserveSpace, size_t reserveSpaceSizeInBytes):
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cudnnRNNBackwardWeights(
             <Handle>handle, <RNNDescriptor>rnnDesc, seqLength,
@@ -1355,6 +1373,7 @@ cpdef setSpatialTransformerDescriptor(
 
 cpdef spatialTfGridGeneratorForward(
         size_t handle, size_t stDesc, size_t theta, size_t grid):
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cudnnSpatialTfGridGeneratorForward(
             <Handle>handle, <SpatialTransformerDescriptor> stDesc,
@@ -1364,6 +1383,7 @@ cpdef spatialTfGridGeneratorForward(
 
 cpdef spatialTfGridGeneratorBackward(
         size_t handle, size_t stDesc, size_t dgrid, size_t dtheta):
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cudnnSpatialTfGridGeneratorBackward(
             <Handle>handle, <SpatialTransformerDescriptor>stDesc,
@@ -1374,6 +1394,7 @@ cpdef spatialTfGridGeneratorBackward(
 cpdef spatialTfSamplerForward(
         size_t handle, size_t stDesc, size_t alpha, size_t xDesc,
         size_t x, size_t grid, size_t beta, size_t yDesc, size_t y):
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cudnnSpatialTfSamplerForward(
             <Handle>handle, <SpatialTransformerDescriptor>stDesc,
@@ -1386,6 +1407,7 @@ cpdef spatialTfSamplerBackward(
         size_t handle, size_t stDesc, size_t alpha, size_t xDesc,
         size_t x, size_t beta, size_t dxDesc, size_t dx, size_t alphaDgrid,
         size_t dyDesc, size_t dy, size_t grid, size_t betaDgrid, size_t dgrid):
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cudnnSpatialTfSamplerBackward(
             <Handle>handle, <SpatialTransformerDescriptor>stDesc,

--- a/cupy/cuda/cudnn.pyx
+++ b/cupy/cuda/cudnn.pyx
@@ -6,7 +6,7 @@ cimport cython
 from libcpp cimport vector
 
 from cupy.cuda cimport driver
-from cupy.cuda import stream as stream_module
+from cupy.cuda cimport stream as stream_module
 
 ###############################################################################
 # Extern
@@ -536,7 +536,7 @@ cpdef destroyTensorDescriptor(size_t tensorDesc):
 
 cpdef addTensor_v3(size_t handle, size_t alpha, size_t bDesc,
                    size_t b, size_t beta, size_t yDesc, size_t y):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cudnnAddTensor_v3(
             <Handle>handle, <void*>alpha, <TensorDescriptor>bDesc,
@@ -713,7 +713,7 @@ cpdef convolutionForward(
         size_t filterDesc, size_t filterData, size_t convDesc, int algo,
         size_t workSpace, size_t workSpaceSizeInBytes, size_t beta,
         size_t destDesc, size_t destData):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cudnnConvolutionForward(
             <Handle>handle, <void*>alpha,
@@ -728,7 +728,7 @@ cpdef convolutionForward(
 cpdef convolutionBackwardBias(
         size_t handle, size_t alpha, size_t srcDesc, size_t srcData,
         size_t beta, size_t destDesc, size_t destData):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cudnnConvolutionBackwardBias(
             <Handle>handle, <void*>alpha,
@@ -802,7 +802,7 @@ cpdef convolutionBackwardFilter_v3(
         size_t diffDesc, size_t diffData, size_t convDesc, int algo,
         size_t workSpace, size_t workSpaceSizeInBytes, size_t beta,
         size_t gradDesc, size_t gradData):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cudnnConvolutionBackwardFilter_v3(
             <Handle>handle, <void*>alpha,
@@ -879,7 +879,7 @@ cpdef convolutionBackwardData_v3(
         size_t diffDesc, size_t diffData, size_t convDesc, int algo,
         size_t workSpace, size_t workSpaceSizeInBytes, size_t beta,
         size_t gradDesc, size_t gradData):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cudnnConvolutionBackwardData_v3(
             <Handle>handle, <void*>alpha,
@@ -930,7 +930,7 @@ cpdef destroyPoolingDescriptor(size_t poolingDesc):
 cpdef poolingForward(
         size_t handle, size_t poolingDesc, size_t alpha, size_t srcDesc,
         size_t srcData, size_t beta, size_t dstDesc, size_t dstData):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cudnnPoolingForward(
             <Handle>handle, <PoolingDescriptor>poolingDesc, <void*>alpha,
@@ -944,7 +944,7 @@ cpdef poolingBackward(
         size_t srcData, size_t srcDiffDesc, size_t srcDiffData,
         size_t destDesc, size_t destData, size_t beta, size_t destDiffDesc,
         size_t destDiffData):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cudnnPoolingBackward(
             <Handle>handle, <PoolingDescriptor>poolingDesc, <void*>alpha,
@@ -974,7 +974,7 @@ cpdef batchNormalizationForwardTraining(
         size_t bnBias, double exponentialAverageFactor,
         size_t resultRunningMean, size_t resultRunningVariance,
         double epsilon, size_t resultSaveMean, size_t resultSaveInvVariance):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cudnnBatchNormalizationForwardTraining(
             <Handle>handle, <BatchNormMode> mode,
@@ -994,7 +994,7 @@ cpdef batchNormalizationForwardInference(
         size_t bnScaleBiasMeanVarDesc, size_t bnScale,
         size_t bnBias, size_t estimatedMean, size_t estimatedVariance,
         double epsilon):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cudnnBatchNormalizationForwardInference(
             <Handle>handle, <BatchNormMode> mode,
@@ -1015,7 +1015,7 @@ cpdef batchNormalizationBackward(
         size_t dBnScaleBiasDesc, size_t bnScale,
         size_t dBnScaleResult, size_t dBnBiasResult,
         double epsilon, size_t savedMean, size_t savedInvVariance):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cudnnBatchNormalizationBackward(
             <Handle>handle, <BatchNormMode>mode,
@@ -1057,7 +1057,7 @@ cpdef destroyActivationDescriptor(size_t activationDesc):
 cpdef softmaxForward(
         size_t handle, int algorithm, int mode, size_t alpha, size_t srcDesc,
         size_t srcData, size_t beta, size_t dstDesc, size_t dstData):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cudnnSoftmaxForward(
             <Handle>handle, <SoftmaxAlgorithm>algorithm, <SoftmaxMode>mode,
@@ -1070,7 +1070,7 @@ cpdef softmaxBackward(
         size_t handle, int algorithm, int mode, size_t alpha, size_t srcDesc,
         size_t srcData, size_t srcDiffDesc, size_t srcDiffData, size_t beta,
         size_t destDiffDesc, size_t destDiffData):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cudnnSoftmaxBackward(
             <Handle>handle, <SoftmaxAlgorithm>algorithm, <SoftmaxMode>mode,
@@ -1083,7 +1083,7 @@ cpdef softmaxBackward(
 cpdef activationForward_v4(
         size_t handle, size_t activationDesc, size_t alpha, size_t srcDesc,
         size_t srcData, size_t beta, size_t dstDesc, size_t dstData):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cudnnActivationForward_v4(
             <Handle>handle, <ActivationDescriptor>activationDesc, <void*>alpha,
@@ -1097,7 +1097,7 @@ cpdef activationBackward_v4(
         size_t srcData, size_t srcDiffDesc, size_t srcDiffData,
         size_t destDesc, size_t destData, size_t beta, size_t destDiffDesc,
         size_t destDiffData):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cudnnActivationBackward_v4(
             <Handle>handle, <ActivationDescriptor>activationDesc, <void*>alpha,
@@ -1261,7 +1261,7 @@ cpdef RNNForwardInference(
         size_t cx, size_t wDesc, size_t w, size_t yDesc,
         size_t y, size_t hyDesc, size_t hy, size_t cyDesc,
         size_t cy, size_t workspace, size_t workSpaceSizeInBytes):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cudnnRNNForwardInference(
             <Handle>handle, <RNNDescriptor>rnnDesc, seqLength,
@@ -1283,7 +1283,7 @@ cpdef RNNForwardTraining(
         size_t hyDesc, size_t hy, size_t cyDesc, size_t cy,
         size_t workspace, size_t workSpaceSizeInBytes, size_t reserveSpace,
         size_t reserveSpaceSizeInBytes):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cudnnRNNForwardTraining(
             <Handle>handle, <RNNDescriptor>rnnDesc, seqLength,
@@ -1308,7 +1308,7 @@ cpdef RNNBackwardData(
         size_t dcxDesc, size_t dcx, size_t workspace,
         size_t workSpaceSizeInBytes, size_t reserveSpace,
         size_t reserveSpaceSizeInBytes):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cudnnRNNBackwardData(
             <Handle>handle, <RNNDescriptor>rnnDesc, seqLength,
@@ -1332,7 +1332,7 @@ cpdef RNNBackwardWeights(
         size_t hxDesc, size_t hx, size_t yDesc, size_t y,
         size_t workspace, size_t workSpaceSizeInBytes, size_t dwDesc,
         size_t dw, size_t reserveSpace, size_t reserveSpaceSizeInBytes):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cudnnRNNBackwardWeights(
             <Handle>handle, <RNNDescriptor>rnnDesc, seqLength,
@@ -1373,7 +1373,7 @@ cpdef setSpatialTransformerDescriptor(
 
 cpdef spatialTfGridGeneratorForward(
         size_t handle, size_t stDesc, size_t theta, size_t grid):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cudnnSpatialTfGridGeneratorForward(
             <Handle>handle, <SpatialTransformerDescriptor> stDesc,
@@ -1383,7 +1383,7 @@ cpdef spatialTfGridGeneratorForward(
 
 cpdef spatialTfGridGeneratorBackward(
         size_t handle, size_t stDesc, size_t dgrid, size_t dtheta):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cudnnSpatialTfGridGeneratorBackward(
             <Handle>handle, <SpatialTransformerDescriptor>stDesc,
@@ -1394,7 +1394,7 @@ cpdef spatialTfGridGeneratorBackward(
 cpdef spatialTfSamplerForward(
         size_t handle, size_t stDesc, size_t alpha, size_t xDesc,
         size_t x, size_t grid, size_t beta, size_t yDesc, size_t y):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cudnnSpatialTfSamplerForward(
             <Handle>handle, <SpatialTransformerDescriptor>stDesc,
@@ -1407,7 +1407,7 @@ cpdef spatialTfSamplerBackward(
         size_t handle, size_t stDesc, size_t alpha, size_t xDesc,
         size_t x, size_t beta, size_t dxDesc, size_t dx, size_t alphaDgrid,
         size_t dyDesc, size_t dy, size_t grid, size_t betaDgrid, size_t dgrid):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cudnnSpatialTfSamplerBackward(
             <Handle>handle, <SpatialTransformerDescriptor>stDesc,

--- a/cupy/cuda/cupy_cusparse.h
+++ b/cupy/cuda/cupy_cusparse.h
@@ -52,6 +52,14 @@ cusparseStatus_t cusparseSetPointerMode(...) {
   return CUSPARSE_STATUS_SUCCESS;
 }
 
+// Stream
+cusparseStatus_t cusparseSetStream(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseGetStream(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
 
 // cuSPARSE Level1 Function
 cusparseStatus_t cusparseSgthr(...) {

--- a/cupy/cuda/cupy_cusparse.h
+++ b/cupy/cuda/cupy_cusparse.h
@@ -57,9 +57,10 @@ cusparseStatus_t cusparseSetStream(...) {
   return CUSPARSE_STATUS_SUCCESS;
 }
 
-cusparseStatus_t cusparseGetStream(...) {
-  return CUSPARSE_STATUS_SUCCESS;
-}
+// cusparseGetStream is only available from CUDA 8.0
+// cusparseStatus_t cusparseGetStream(...) {
+//   return CUSPARSE_STATUS_SUCCESS;
+// }
 
 // cuSPARSE Level1 Function
 cusparseStatus_t cusparseSgthr(...) {

--- a/cupy/cuda/cupy_thrust.cu
+++ b/cupy/cuda/cupy_thrust.cu
@@ -89,7 +89,7 @@ void cupy::thrust::_lexsort(size_t *idx_start, void *keys_start, size_t k, size_
     sequence(cuda::par.on(stream_), dp_first, dp_last);
     for (size_t i = 0; i < k; ++i) {
         T *key_start = static_cast<T*>(keys_start) + i * n;
-        stable_sort< system::cuda::detail::execute_on_stream, device_ptr<size_t> >(
+        stable_sort(
             cuda::par.on(stream_),
             dp_first,
             dp_last,

--- a/cupy/cuda/cupy_thrust.cu
+++ b/cupy/cuda/cupy_thrust.cu
@@ -4,6 +4,7 @@
 #include <thrust/sequence.h>
 #include <thrust/sort.h>
 #include <thrust/tuple.h>
+#include <thrust/execution_policy.h>
 #include "cupy_common.h"
 #include "cupy_thrust.h"
 
@@ -15,12 +16,13 @@ using namespace thrust;
  */
 
 template <typename T>
-void cupy::thrust::_sort(void *data_start, size_t *keys_start, const std::vector<ptrdiff_t>& shape) {
+void cupy::thrust::_sort(void *data_start, size_t *keys_start, const std::vector<ptrdiff_t>& shape, size_t stream) {
 
     size_t ndim = shape.size();
     ptrdiff_t size;
     device_ptr<T> dp_data_first, dp_data_last;
     device_ptr<size_t> dp_keys_first, dp_keys_last;
+    cudaStream_t stream_ = (cudaStream_t)stream;
 
     // Compute the total size of the array.
     size = shape[0];
@@ -32,33 +34,35 @@ void cupy::thrust::_sort(void *data_start, size_t *keys_start, const std::vector
     dp_data_last  = device_pointer_cast(static_cast<T*>(data_start) + size);
 
     if (ndim == 1) {
-        stable_sort(dp_data_first, dp_data_last);
+        stable_sort(cuda::par.on(stream_), dp_data_first, dp_data_last);
     } else {
         // Generate key indices.
         dp_keys_first = device_pointer_cast(keys_start);
         dp_keys_last  = device_pointer_cast(keys_start + size);
-        transform(make_counting_iterator<size_t>(0),
+        transform(cuda::par.on(stream_),
+                  make_counting_iterator<size_t>(0),
                   make_counting_iterator<size_t>(size),
                   make_constant_iterator<ptrdiff_t>(shape[ndim-1]),
                   dp_keys_first,
                   divides<size_t>());
 
         stable_sort(
+            cuda::par.on(stream_),
             make_zip_iterator(make_tuple(dp_keys_first, dp_data_first)),
             make_zip_iterator(make_tuple(dp_keys_last, dp_data_last)));
     }
 }
 
-template void cupy::thrust::_sort<cpy_byte>(void *, size_t *, const std::vector<ptrdiff_t>& shape);
-template void cupy::thrust::_sort<cpy_ubyte>(void *, size_t *, const std::vector<ptrdiff_t>& shape);
-template void cupy::thrust::_sort<cpy_short>(void *, size_t *, const std::vector<ptrdiff_t>& shape);
-template void cupy::thrust::_sort<cpy_ushort>(void *, size_t *, const std::vector<ptrdiff_t>& shape);
-template void cupy::thrust::_sort<cpy_int>(void *, size_t *, const std::vector<ptrdiff_t>& shape);
-template void cupy::thrust::_sort<cpy_uint>(void *, size_t *, const std::vector<ptrdiff_t>& shape);
-template void cupy::thrust::_sort<cpy_long>(void *, size_t *, const std::vector<ptrdiff_t>& shape);
-template void cupy::thrust::_sort<cpy_ulong>(void *, size_t *, const std::vector<ptrdiff_t>& shape);
-template void cupy::thrust::_sort<cpy_float>(void *, size_t *, const std::vector<ptrdiff_t>& shape);
-template void cupy::thrust::_sort<cpy_double>(void *, size_t *, const std::vector<ptrdiff_t>& shape);
+template void cupy::thrust::_sort<cpy_byte>(void *, size_t *, const std::vector<ptrdiff_t>& shape, size_t);
+template void cupy::thrust::_sort<cpy_ubyte>(void *, size_t *, const std::vector<ptrdiff_t>& shape, size_t);
+template void cupy::thrust::_sort<cpy_short>(void *, size_t *, const std::vector<ptrdiff_t>& shape, size_t);
+template void cupy::thrust::_sort<cpy_ushort>(void *, size_t *, const std::vector<ptrdiff_t>& shape, size_t);
+template void cupy::thrust::_sort<cpy_int>(void *, size_t *, const std::vector<ptrdiff_t>& shape, size_t);
+template void cupy::thrust::_sort<cpy_uint>(void *, size_t *, const std::vector<ptrdiff_t>& shape, size_t);
+template void cupy::thrust::_sort<cpy_long>(void *, size_t *, const std::vector<ptrdiff_t>& shape, size_t);
+template void cupy::thrust::_sort<cpy_ulong>(void *, size_t *, const std::vector<ptrdiff_t>& shape, size_t);
+template void cupy::thrust::_sort<cpy_float>(void *, size_t *, const std::vector<ptrdiff_t>& shape, size_t);
+template void cupy::thrust::_sort<cpy_double>(void *, size_t *, const std::vector<ptrdiff_t>& shape, size_t);
 
 
 /*
@@ -75,29 +79,35 @@ private:
 };
 
 template <typename T>
-void cupy::thrust::_lexsort(size_t *idx_start, void *keys_start, size_t k, size_t n) {
+void cupy::thrust::_lexsort(size_t *idx_start, void *keys_start, size_t k, size_t n, size_t stream) {
     /* idx_start is the beginning of the output array where the indexes that
        would sort the data will be placed. The original contents of idx_start
        will be destroyed. */
     device_ptr<size_t> dp_first = device_pointer_cast(idx_start);
     device_ptr<size_t> dp_last  = device_pointer_cast(idx_start + n);
-    sequence(dp_first, dp_last);
+    cudaStream_t stream_ = (cudaStream_t)stream;
+    sequence(cuda::par.on(stream_), dp_first, dp_last);
     for (size_t i = 0; i < k; ++i) {
         T *key_start = static_cast<T*>(keys_start) + i * n;
-        stable_sort< device_ptr<size_t> >(dp_first, dp_last, elem_less<T>(key_start));
+        stable_sort< system::cuda::detail::execute_on_stream, device_ptr<size_t> >(
+            cuda::par.on(stream_),
+            dp_first,
+            dp_last,
+            elem_less<T>(key_start)
+        );
     }
 }
 
-template void cupy::thrust::_lexsort<cpy_byte>(size_t *, void *, size_t, size_t);
-template void cupy::thrust::_lexsort<cpy_ubyte>(size_t *, void *, size_t, size_t);
-template void cupy::thrust::_lexsort<cpy_short>(size_t *, void *, size_t, size_t);
-template void cupy::thrust::_lexsort<cpy_ushort>(size_t *, void *, size_t, size_t);
-template void cupy::thrust::_lexsort<cpy_int>(size_t *, void *, size_t, size_t);
-template void cupy::thrust::_lexsort<cpy_uint>(size_t *, void *, size_t, size_t);
-template void cupy::thrust::_lexsort<cpy_long>(size_t *, void *, size_t, size_t);
-template void cupy::thrust::_lexsort<cpy_ulong>(size_t *, void *, size_t, size_t);
-template void cupy::thrust::_lexsort<cpy_float>(size_t *, void *, size_t, size_t);
-template void cupy::thrust::_lexsort<cpy_double>(size_t *, void *, size_t, size_t);
+template void cupy::thrust::_lexsort<cpy_byte>(size_t *, void *, size_t, size_t, size_t);
+template void cupy::thrust::_lexsort<cpy_ubyte>(size_t *, void *, size_t, size_t, size_t);
+template void cupy::thrust::_lexsort<cpy_short>(size_t *, void *, size_t, size_t, size_t);
+template void cupy::thrust::_lexsort<cpy_ushort>(size_t *, void *, size_t, size_t, size_t);
+template void cupy::thrust::_lexsort<cpy_int>(size_t *, void *, size_t, size_t, size_t);
+template void cupy::thrust::_lexsort<cpy_uint>(size_t *, void *, size_t, size_t, size_t);
+template void cupy::thrust::_lexsort<cpy_long>(size_t *, void *, size_t, size_t, size_t);
+template void cupy::thrust::_lexsort<cpy_ulong>(size_t *, void *, size_t, size_t, size_t);
+template void cupy::thrust::_lexsort<cpy_float>(size_t *, void *, size_t, size_t, size_t);
+template void cupy::thrust::_lexsort<cpy_double>(size_t *, void *, size_t, size_t, size_t);
 
 
 /*
@@ -105,13 +115,14 @@ template void cupy::thrust::_lexsort<cpy_double>(size_t *, void *, size_t, size_
  */
 
 template <typename T>
-void cupy::thrust::_argsort(size_t *idx_start, void *data_start, void *keys_start, const std::vector<ptrdiff_t>& shape) {
+void cupy::thrust::_argsort(size_t *idx_start, void *data_start, void *keys_start, const std::vector<ptrdiff_t>& shape, size_t stream) {
     /* idx_start is the beggining of the output array where the indexes that
        would sort the data will be placed. The original contents of idx_start
        will be destroyed. */
 
     size_t ndim = shape.size();
     ptrdiff_t size;
+    cudaStream_t stream_ = (cudaStream_t)stream;
 
     device_ptr<size_t> dp_idx_first, dp_idx_last;
     device_ptr<T> dp_data_first, dp_data_last;
@@ -130,7 +141,8 @@ void cupy::thrust::_argsort(size_t *idx_start, void *data_start, void *keys_star
     // Generate an index sequence.
     dp_idx_first = device_pointer_cast(static_cast<size_t*>(idx_start));
     dp_idx_last  = device_pointer_cast(static_cast<size_t*>(idx_start) + size);
-    transform(make_counting_iterator<size_t>(0),
+    transform(cuda::par.on(stream_),
+              make_counting_iterator<size_t>(0),
               make_counting_iterator<size_t>(size),
               make_constant_iterator<ptrdiff_t>(shape[ndim-1]),
               dp_idx_first,
@@ -138,33 +150,36 @@ void cupy::thrust::_argsort(size_t *idx_start, void *data_start, void *keys_star
 
     if (ndim == 1) {
         // Sort the index sequence by data.
-        stable_sort_by_key(dp_data_first,
+        stable_sort_by_key(cuda::par.on(stream_),
+                           dp_data_first,
                            dp_data_last,
                            dp_idx_first);
     } else {
         // Generate key indices.
         dp_keys_first = device_pointer_cast(static_cast<size_t*>(keys_start));
         dp_keys_last  = device_pointer_cast(static_cast<size_t*>(keys_start) + size);
-        transform(make_counting_iterator<size_t>(0),
+        transform(cuda::par.on(stream_),
+                  make_counting_iterator<size_t>(0),
                   make_counting_iterator<size_t>(size),
                   make_constant_iterator<ptrdiff_t>(shape[ndim-1]),
                   dp_keys_first,
                   divides<size_t>());
 
         stable_sort_by_key(
+            cuda::par.on(stream_),
             make_zip_iterator(make_tuple(dp_keys_first, dp_data_first)),
             make_zip_iterator(make_tuple(dp_keys_last, dp_data_last)),
             dp_idx_first);
     }
 }
 
-template void cupy::thrust::_argsort<cpy_byte>(size_t *, void *, void *, const std::vector<ptrdiff_t>& shape);
-template void cupy::thrust::_argsort<cpy_ubyte>(size_t *, void *, void *, const std::vector<ptrdiff_t>& shape);
-template void cupy::thrust::_argsort<cpy_short>(size_t *, void *, void *, const std::vector<ptrdiff_t>& shape);
-template void cupy::thrust::_argsort<cpy_ushort>(size_t *, void *, void *, const std::vector<ptrdiff_t>& shape);
-template void cupy::thrust::_argsort<cpy_int>(size_t *, void *, void *, const std::vector<ptrdiff_t>& shape);
-template void cupy::thrust::_argsort<cpy_uint>(size_t *, void *, void *, const std::vector<ptrdiff_t>& shape);
-template void cupy::thrust::_argsort<cpy_long>(size_t *, void *, void *, const std::vector<ptrdiff_t>& shape);
-template void cupy::thrust::_argsort<cpy_ulong>(size_t *, void *, void *, const std::vector<ptrdiff_t>& shape);
-template void cupy::thrust::_argsort<cpy_float>(size_t *, void *, void *, const std::vector<ptrdiff_t>& shape);
-template void cupy::thrust::_argsort<cpy_double>(size_t *, void *, void *, const std::vector<ptrdiff_t>& shape);
+template void cupy::thrust::_argsort<cpy_byte>(size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, size_t);
+template void cupy::thrust::_argsort<cpy_ubyte>(size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, size_t);
+template void cupy::thrust::_argsort<cpy_short>(size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, size_t);
+template void cupy::thrust::_argsort<cpy_ushort>(size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, size_t);
+template void cupy::thrust::_argsort<cpy_int>(size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, size_t);
+template void cupy::thrust::_argsort<cpy_uint>(size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, size_t);
+template void cupy::thrust::_argsort<cpy_long>(size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, size_t);
+template void cupy::thrust::_argsort<cpy_ulong>(size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, size_t);
+template void cupy::thrust::_argsort<cpy_float>(size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, size_t);
+template void cupy::thrust::_argsort<cpy_double>(size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, size_t);

--- a/cupy/cuda/cupy_thrust.h
+++ b/cupy/cuda/cupy_thrust.h
@@ -7,11 +7,11 @@ namespace cupy {
 
 namespace thrust {
 
-template <typename T> void _sort(void *, size_t *, const std::vector<ptrdiff_t>&);
+template <typename T> void _sort(void *, size_t *, const std::vector<ptrdiff_t>&, size_t stream=0);
 
-template <typename T> void _lexsort(size_t *, void *, size_t, size_t);
+template <typename T> void _lexsort(size_t *, void *, size_t, size_t, size_t stream=0);
 
-template <typename T> void _argsort(size_t *, void *, void *, const std::vector<ptrdiff_t>&);
+template <typename T> void _argsort(size_t *, void *, void *, const std::vector<ptrdiff_t>&, size_t stream=0);
 
 } // namespace thrust
 
@@ -25,11 +25,11 @@ namespace cupy {
 
 namespace thrust {
 
-template <typename T> void _sort(void *, size_t *, const std::vector<ptrdiff_t>&) { return; }
+template <typename T> void _sort(void *, size_t *, const std::vector<ptrdiff_t>&, size_t stream=0) { return; }
 
-template <typename T> void _lexsort(size_t *, void *, size_t, size_t) { return; }
+template <typename T> void _lexsort(size_t *, void *, size_t, size_t, size_t stream=0) { return; }
 
-template <typename T> void _argsort(size_t *, void *, void *, const std::vector<ptrdiff_t>&) { return; }
+template <typename T> void _argsort(size_t *, void *, void *, const std::vector<ptrdiff_t>&, size_t stream=0) { return; }
 
 } // namespace thrust
 

--- a/cupy/cuda/curand.pyx
+++ b/cupy/cuda/curand.pyx
@@ -4,7 +4,7 @@
 cimport cython
 
 from cupy.cuda cimport driver
-
+from cupy.cuda import stream as stream_module
 
 ###############################################################################
 # Extern
@@ -132,24 +132,28 @@ cpdef setGeneratorOrdering(size_t generator, int order):
 ###############################################################################
 
 cpdef generate(size_t generator, size_t outputPtr, size_t num):
+    setStream(generator, stream_module.get_current_stream().ptr)
     status = curandGenerate(
         <Generator>generator, <unsigned int*>outputPtr, num)
     check_status(status)
 
 
 cpdef generateLongLong(size_t generator, size_t outputPtr, size_t num):
+    setStream(generator, stream_module.get_current_stream().ptr)
     status = curandGenerateLongLong(
         <Generator>generator, <unsigned long long*>outputPtr, num)
     check_status(status)
 
 
 cpdef generateUniform(size_t generator, size_t outputPtr, size_t num):
+    setStream(generator, stream_module.get_current_stream().ptr)
     status = curandGenerateUniform(
         <Generator>generator, <float*>outputPtr, num)
     check_status(status)
 
 
 cpdef generateUniformDouble(size_t generator, size_t outputPtr, size_t num):
+    setStream(generator, stream_module.get_current_stream().ptr)
     status = curandGenerateUniformDouble(
         <Generator>generator, <double*>outputPtr, num)
     check_status(status)
@@ -161,6 +165,7 @@ cpdef generateNormal(size_t generator, size_t outputPtr, size_t n,
         msg = ('curandGenerateNormal can only generate even number of '
                'random variables simultaneously. See issue #390 for detail.')
         raise ValueError(msg)
+    setStream(generator, stream_module.get_current_stream().ptr)
     status = curandGenerateNormal(
         <Generator>generator, <float*>outputPtr, n, mean, stddev)
     check_status(status)
@@ -172,6 +177,7 @@ cpdef generateNormalDouble(size_t generator, size_t outputPtr, size_t n,
         msg = ('curandGenerateNormalDouble can only generate even number of '
                'random variables simultaneously. See issue #390 for detail.')
         raise ValueError(msg)
+    setStream(generator, stream_module.get_current_stream().ptr)
     status = curandGenerateNormalDouble(
         <Generator>generator, <double*>outputPtr, n, mean, stddev)
     check_status(status)
@@ -183,6 +189,7 @@ def generateLogNormal(size_t generator, size_t outputPtr, size_t n,
         msg = ('curandGenerateLogNormal can only generate even number of '
                'random variables simultaneously. See issue #390 for detail.')
         raise ValueError(msg)
+    setStream(generator, stream_module.get_current_stream().ptr)
     status = curandGenerateLogNormal(
         <Generator>generator, <float*>outputPtr, n, mean, stddev)
     check_status(status)
@@ -195,6 +202,7 @@ cpdef generateLogNormalDouble(size_t generator, size_t outputPtr, size_t n,
                'of random variables simultaneously. See issue #390 for '
                'detail.')
         raise ValueError(msg)
+    setStream(generator, stream_module.get_current_stream().ptr)
     status = curandGenerateLogNormalDouble(
         <Generator>generator, <double*>outputPtr, n, mean, stddev)
     check_status(status)
@@ -202,6 +210,7 @@ cpdef generateLogNormalDouble(size_t generator, size_t outputPtr, size_t n,
 
 cpdef generatePoisson(size_t generator, size_t outputPtr, size_t n,
                       double lam):
+    setStream(generator, stream_module.get_current_stream().ptr)
     status = curandGeneratePoisson(
         <Generator>generator, <unsigned int*>outputPtr, n, lam)
     check_status(status)

--- a/cupy/cuda/curand.pyx
+++ b/cupy/cuda/curand.pyx
@@ -4,7 +4,7 @@
 cimport cython
 
 from cupy.cuda cimport driver
-from cupy.cuda import stream as stream_module
+from cupy.cuda cimport stream as stream_module
 
 ###############################################################################
 # Extern
@@ -132,28 +132,28 @@ cpdef setGeneratorOrdering(size_t generator, int order):
 ###############################################################################
 
 cpdef generate(size_t generator, size_t outputPtr, size_t num):
-    setStream(generator, stream_module.get_current_stream().ptr)
+    setStream(generator, stream_module.get_current_stream_ptr())
     status = curandGenerate(
         <Generator>generator, <unsigned int*>outputPtr, num)
     check_status(status)
 
 
 cpdef generateLongLong(size_t generator, size_t outputPtr, size_t num):
-    setStream(generator, stream_module.get_current_stream().ptr)
+    setStream(generator, stream_module.get_current_stream_ptr())
     status = curandGenerateLongLong(
         <Generator>generator, <unsigned long long*>outputPtr, num)
     check_status(status)
 
 
 cpdef generateUniform(size_t generator, size_t outputPtr, size_t num):
-    setStream(generator, stream_module.get_current_stream().ptr)
+    setStream(generator, stream_module.get_current_stream_ptr())
     status = curandGenerateUniform(
         <Generator>generator, <float*>outputPtr, num)
     check_status(status)
 
 
 cpdef generateUniformDouble(size_t generator, size_t outputPtr, size_t num):
-    setStream(generator, stream_module.get_current_stream().ptr)
+    setStream(generator, stream_module.get_current_stream_ptr())
     status = curandGenerateUniformDouble(
         <Generator>generator, <double*>outputPtr, num)
     check_status(status)
@@ -165,7 +165,7 @@ cpdef generateNormal(size_t generator, size_t outputPtr, size_t n,
         msg = ('curandGenerateNormal can only generate even number of '
                'random variables simultaneously. See issue #390 for detail.')
         raise ValueError(msg)
-    setStream(generator, stream_module.get_current_stream().ptr)
+    setStream(generator, stream_module.get_current_stream_ptr())
     status = curandGenerateNormal(
         <Generator>generator, <float*>outputPtr, n, mean, stddev)
     check_status(status)
@@ -177,7 +177,7 @@ cpdef generateNormalDouble(size_t generator, size_t outputPtr, size_t n,
         msg = ('curandGenerateNormalDouble can only generate even number of '
                'random variables simultaneously. See issue #390 for detail.')
         raise ValueError(msg)
-    setStream(generator, stream_module.get_current_stream().ptr)
+    setStream(generator, stream_module.get_current_stream_ptr())
     status = curandGenerateNormalDouble(
         <Generator>generator, <double*>outputPtr, n, mean, stddev)
     check_status(status)
@@ -189,7 +189,7 @@ def generateLogNormal(size_t generator, size_t outputPtr, size_t n,
         msg = ('curandGenerateLogNormal can only generate even number of '
                'random variables simultaneously. See issue #390 for detail.')
         raise ValueError(msg)
-    setStream(generator, stream_module.get_current_stream().ptr)
+    setStream(generator, stream_module.get_current_stream_ptr())
     status = curandGenerateLogNormal(
         <Generator>generator, <float*>outputPtr, n, mean, stddev)
     check_status(status)
@@ -202,7 +202,7 @@ cpdef generateLogNormalDouble(size_t generator, size_t outputPtr, size_t n,
                'of random variables simultaneously. See issue #390 for '
                'detail.')
         raise ValueError(msg)
-    setStream(generator, stream_module.get_current_stream().ptr)
+    setStream(generator, stream_module.get_current_stream_ptr())
     status = curandGenerateLogNormalDouble(
         <Generator>generator, <double*>outputPtr, n, mean, stddev)
     check_status(status)
@@ -210,7 +210,7 @@ cpdef generateLogNormalDouble(size_t generator, size_t outputPtr, size_t n,
 
 cpdef generatePoisson(size_t generator, size_t outputPtr, size_t n,
                       double lam):
-    setStream(generator, stream_module.get_current_stream().ptr)
+    setStream(generator, stream_module.get_current_stream_ptr())
     status = curandGeneratePoisson(
         <Generator>generator, <unsigned int*>outputPtr, n, lam)
     check_status(status)

--- a/cupy/cuda/cusolver.pyx
+++ b/cupy/cuda/cusolver.pyx
@@ -3,7 +3,7 @@ cimport cython
 
 from cupy.cuda cimport driver
 from cupy.cuda cimport runtime
-from cupy.cuda import stream as stream_module
+from cupy.cuda cimport stream as stream_module
 
 ###############################################################################
 # Extern
@@ -203,7 +203,7 @@ cpdef size_t getStream(size_t handle) except *:
 cpdef int spotrf_bufferSize(size_t handle, int uplo,
                             int n, size_t A, int lda) except *:
     cdef int lwork
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cusolverDnSpotrf_bufferSize(
             <Handle>handle, <FillMode>uplo, n, <float*>A, <int>lda, &lwork)
@@ -213,7 +213,7 @@ cpdef int spotrf_bufferSize(size_t handle, int uplo,
 cpdef int dpotrf_bufferSize(size_t handle, int uplo,
                             int n, size_t A, int lda) except *:
     cdef int lwork
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cusolverDnDpotrf_bufferSize(
             <Handle>handle, <FillMode>uplo, n, <double*>A, <int>lda, &lwork)
@@ -222,7 +222,7 @@ cpdef int dpotrf_bufferSize(size_t handle, int uplo,
 
 cpdef spotrf(size_t handle, int uplo, int n, size_t A, int lda,
              size_t work, int lwork, size_t devInfo):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cusolverDnSpotrf(
             <Handle>handle, <FillMode>uplo, n, <float*>A,
@@ -231,7 +231,7 @@ cpdef spotrf(size_t handle, int uplo, int n, size_t A, int lda,
 
 cpdef dpotrf(size_t handle, int uplo, int n, size_t A, int lda,
              size_t work, int lwork, size_t devInfo):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cusolverDnDpotrf(
             <Handle>handle, <FillMode>uplo, n, <double*>A,
@@ -240,7 +240,7 @@ cpdef dpotrf(size_t handle, int uplo, int n, size_t A, int lda,
 
 cpdef spotrs(size_t handle, int uplo, int n, int nrhs,
              size_t A, int lda, size_t B, int ldb, size_t devInfo):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cusolverDnSpotrs(
             <Handle>handle, <FillMode>uplo, n, nrhs,
@@ -249,7 +249,7 @@ cpdef spotrs(size_t handle, int uplo, int n, int nrhs,
 
 cpdef dpotrs(size_t handle, int uplo, int n, int nrhs,
              size_t A, int lda, size_t B, int ldb, size_t devInfo):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cusolverDnDpotrs(
             <Handle>handle, <FillMode>uplo, n, nrhs,
@@ -258,7 +258,7 @@ cpdef dpotrs(size_t handle, int uplo, int n, int nrhs,
 
 cpdef sgetrf(size_t handle, int m, int n, size_t A, int lda,
              size_t work, size_t devIpiv, size_t devInfo):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cusolverDnSgetrf(
             <Handle>handle, m, n, <float*>A, lda,
@@ -267,7 +267,7 @@ cpdef sgetrf(size_t handle, int m, int n, size_t A, int lda,
 
 cpdef dgetrf(size_t handle, int m, int n, size_t A, int lda,
              size_t work, size_t devIpiv, size_t devInfo):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cusolverDnDgetrf(
             <Handle>handle, m, n, <double*>A, lda,
@@ -277,7 +277,7 @@ cpdef dgetrf(size_t handle, int m, int n, size_t A, int lda,
 cpdef sgetrs(size_t handle, int trans, int n, int nrhs,
              size_t A, int lda, size_t devIpiv,
              size_t B, int ldb, size_t devInfo):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cusolverDnSgetrs(
             <Handle>handle, <Operation>trans, n, nrhs,
@@ -288,7 +288,7 @@ cpdef sgetrs(size_t handle, int trans, int n, int nrhs,
 cpdef dgetrs(size_t handle, int trans, int n, int nrhs,
              size_t A, int lda, size_t devIpiv,
              size_t B, int ldb, size_t devInfo):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cusolverDnDgetrs(
             <Handle>handle, <Operation>trans, n, nrhs,
@@ -299,7 +299,7 @@ cpdef dgetrs(size_t handle, int trans, int n, int nrhs,
 cpdef int sgetrf_bufferSize(size_t handle, int m, int n,
                             size_t A, int lda) except *:
     cdef int lwork
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cusolverDnSgetrf_bufferSize(
             <Handle>handle, m, n, <float*>A, lda, &lwork)
@@ -309,7 +309,7 @@ cpdef int sgetrf_bufferSize(size_t handle, int m, int n,
 cpdef int dgetrf_bufferSize(size_t handle, int m, int n,
                             size_t A, int lda) except *:
     cdef int lwork
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cusolverDnDgetrf_bufferSize(
             <Handle>handle, m, n, <double*>A, lda, &lwork)
@@ -319,7 +319,7 @@ cpdef int dgetrf_bufferSize(size_t handle, int m, int n,
 cpdef int sgeqrf_bufferSize(size_t handle, int m, int n,
                             size_t A, int lda) except *:
     cdef int lwork
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cusolverDnSgeqrf_bufferSize(
             <Handle>handle, m, n, <float*>A, lda, &lwork)
@@ -329,7 +329,7 @@ cpdef int sgeqrf_bufferSize(size_t handle, int m, int n,
 cpdef int dgeqrf_bufferSize(size_t handle, int m, int n,
                             size_t A, int lda) except *:
     cdef int lwork
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cusolverDnDgeqrf_bufferSize(
             <Handle>handle, m, n, <double*>A, lda, &lwork)
@@ -338,7 +338,7 @@ cpdef int dgeqrf_bufferSize(size_t handle, int m, int n,
 
 cpdef sgeqrf(size_t handle, int m, int n, size_t A, int lda,
              size_t tau, size_t work, int lwork, size_t devInfo):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cusolverDnSgeqrf(
             <Handle>handle, m, n, <float*>A, lda,
@@ -347,7 +347,7 @@ cpdef sgeqrf(size_t handle, int m, int n, size_t A, int lda,
 
 cpdef dgeqrf(size_t handle, int m, int n, size_t A, int lda,
              size_t tau, size_t work, int lwork, size_t devInfo):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cusolverDnDgeqrf(
             <Handle>handle, m, n, <double*>A, lda,
@@ -357,7 +357,7 @@ cpdef dgeqrf(size_t handle, int m, int n, size_t A, int lda,
 cpdef int sorgqr_bufferSize(size_t handle, int m, int n, int k,
                             size_t A, int lda, size_t tau) except *:
     cdef int lwork
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cusolverDnSorgqr_bufferSize(
             <Handle>handle, m, n, k, <const float*>A, lda,
@@ -368,7 +368,7 @@ cpdef int sorgqr_bufferSize(size_t handle, int m, int n, int k,
 cpdef int dorgqr_bufferSize(size_t handle, int m, int n, int k,
                             size_t A, int lda, size_t tau) except *:
     cdef int lwork
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cusolverDnDorgqr_bufferSize(
             <Handle>handle, m, n, k, <double*>A, lda,
@@ -378,7 +378,7 @@ cpdef int dorgqr_bufferSize(size_t handle, int m, int n, int k,
 
 cpdef sorgqr(size_t handle, int m, int n, int k, size_t A, int lda,
              size_t tau, size_t work, int lwork, size_t devInfo):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cusolverDnSorgqr(
             <Handle>handle, m, n, k, <float*>A, lda,
@@ -387,7 +387,7 @@ cpdef sorgqr(size_t handle, int m, int n, int k, size_t A, int lda,
 
 cpdef dorgqr(size_t handle, int m, int n, int k, size_t A, int lda,
              size_t tau, size_t work, int lwork, size_t devInfo):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cusolverDnDorgqr(
             <Handle>handle, m, n, k, <double*>A, lda,
@@ -397,7 +397,7 @@ cpdef dorgqr(size_t handle, int m, int n, int k, size_t A, int lda,
 cpdef sormqr(size_t handle, int side, int trans,
              int m, int n, int k, size_t A, int lda, size_t tau,
              size_t C, int ldc, size_t work, int lwork, size_t devInfo):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cusolverDnSormqr(
             <Handle>handle, <SideMode>side, <Operation>trans, m, n, k,
@@ -408,7 +408,7 @@ cpdef sormqr(size_t handle, int side, int trans,
 cpdef dormqr(size_t handle, int side, int trans,
              int m, int n, int k, size_t A, int lda, size_t tau,
              size_t C, int ldc, size_t work, int lwork, size_t devInfo):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cusolverDnDormqr(
             <Handle>handle, <SideMode>side, <Operation>trans, m, n, k,
@@ -418,7 +418,7 @@ cpdef dormqr(size_t handle, int side, int trans,
 
 cpdef ssytrf(size_t handle, int uplo, int n, size_t A, int lda,
              size_t ipiv, size_t work, int lwork, size_t devInfo):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cusolverDnSsytrf(
             <Handle>handle, <FillMode>uplo, n, <float*>A, lda,
@@ -427,7 +427,7 @@ cpdef ssytrf(size_t handle, int uplo, int n, size_t A, int lda,
 
 cpdef dsytrf(size_t handle, int uplo, int n, size_t A, int lda,
              size_t ipiv, size_t work, int lwork, size_t devInfo):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cusolverDnDsytrf(
             <Handle>handle, <FillMode>uplo, n, <double*>A, lda,
@@ -437,7 +437,7 @@ cpdef dsytrf(size_t handle, int uplo, int n, size_t A, int lda,
 cpdef sgebrd(size_t handle, int m, int n, size_t A, int lda,
              size_t D, size_t E, size_t tauQ, size_t tauP,
              size_t Work, int lwork, size_t devInfo):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cusolverDnSgebrd(
             <Handle>handle, m, n, <float*>A, lda,
@@ -448,7 +448,7 @@ cpdef sgebrd(size_t handle, int m, int n, size_t A, int lda,
 cpdef dgebrd(size_t handle, int m, int n, size_t A, int lda,
              size_t D, size_t E, size_t tauQ, size_t tauP,
              size_t Work, int lwork, size_t devInfo):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cusolverDnDgebrd(
             <Handle>handle, m, n, <double*>A, lda,
@@ -458,7 +458,7 @@ cpdef dgebrd(size_t handle, int m, int n, size_t A, int lda,
 
 cpdef int sgesvd_bufferSize(size_t handle, int m, int n) except *:
     cdef int lwork
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cusolverDnSgesvd_bufferSize(<Handle>handle, m, n, &lwork)
     check_status(status)
@@ -466,7 +466,7 @@ cpdef int sgesvd_bufferSize(size_t handle, int m, int n) except *:
 
 cpdef int dgesvd_bufferSize(size_t handle, int m, int n) except *:
     cdef int lwork
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cusolverDnDgesvd_bufferSize(<Handle>handle, m, n, &lwork)
     check_status(status)
@@ -475,7 +475,7 @@ cpdef int dgesvd_bufferSize(size_t handle, int m, int n) except *:
 cpdef sgesvd(size_t handle, char jobu, char jobvt, int m, int n, size_t A,
              int lda, size_t S, size_t U, int ldu, size_t VT, int ldvt,
              size_t Work, int lwork, size_t rwork, size_t devInfo):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cusolverDnSgesvd(
             <Handle>handle, jobu, jobvt, m, n, <float*>A,
@@ -486,7 +486,7 @@ cpdef sgesvd(size_t handle, char jobu, char jobvt, int m, int n, size_t A,
 cpdef dgesvd(size_t handle, char jobu, char jobvt, int m, int n, size_t A,
              int lda, size_t S, size_t U, int ldu, size_t VT, int ldvt,
              size_t Work, int lwork, size_t rwork, size_t devInfo):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cusolverDnDgesvd(
             <Handle>handle, jobu, jobvt, m, n, <double*>A,
@@ -497,7 +497,7 @@ cpdef dgesvd(size_t handle, char jobu, char jobvt, int m, int n, size_t A,
 cpdef int ssyevd_bufferSize(size_t handle, int jobz, int uplo, int n,
                             size_t A, int lda, size_t W):
     cdef int lwork, status
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cusolverDnSsyevd_bufferSize(
             <Handle>handle, <EigMode>jobz, <FillMode>uplo, n, <const float*>A,
@@ -508,7 +508,7 @@ cpdef int ssyevd_bufferSize(size_t handle, int jobz, int uplo, int n,
 cpdef int dsyevd_bufferSize(size_t handle, int jobz, int uplo, int n,
                             size_t A, int lda, size_t W):
     cdef int lwork, status
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cusolverDnDsyevd_bufferSize(
             <Handle>handle, <EigMode>jobz, <FillMode>uplo, n, <const double*>A,
@@ -519,7 +519,7 @@ cpdef int dsyevd_bufferSize(size_t handle, int jobz, int uplo, int n,
 cpdef ssyevd(size_t handle, int jobz, int uplo, int n, size_t A, int lda,
              size_t W, size_t work, int lwork, size_t info):
     cdef int status
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cusolverDnSsyevd(
             <Handle>handle, <EigMode>jobz, <FillMode>uplo, n, <float*>A, lda,
@@ -529,7 +529,7 @@ cpdef ssyevd(size_t handle, int jobz, int uplo, int n, size_t A, int lda,
 cpdef dsyevd(size_t handle, int jobz, int uplo, int n, size_t A, int lda,
              size_t W, size_t work, int lwork, size_t info):
     cdef int status
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cusolverDnDsyevd(
             <Handle>handle, <EigMode>jobz, <FillMode>uplo, n, <double*>A, lda,

--- a/cupy/cuda/cusolver.pyx
+++ b/cupy/cuda/cusolver.pyx
@@ -3,7 +3,7 @@ cimport cython
 
 from cupy.cuda cimport driver
 from cupy.cuda cimport runtime
-
+from cupy.cuda import stream as stream_module
 
 ###############################################################################
 # Extern
@@ -185,7 +185,7 @@ cpdef void destroy(size_t handle) except *:
 
 cpdef setStream(size_t handle, size_t stream):
     with nogil:
-        status = cusolverDnSetStream(<Handle>handle, <Stream>stream)
+        status = cusolverDnSetStream(<Handle>handle, <driver.Stream>stream)
     check_status(status)
 
 
@@ -203,6 +203,7 @@ cpdef size_t getStream(size_t handle) except *:
 cpdef int spotrf_bufferSize(size_t handle, int uplo,
                             int n, size_t A, int lda) except *:
     cdef int lwork
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cusolverDnSpotrf_bufferSize(
             <Handle>handle, <FillMode>uplo, n, <float*>A, <int>lda, &lwork)
@@ -212,6 +213,7 @@ cpdef int spotrf_bufferSize(size_t handle, int uplo,
 cpdef int dpotrf_bufferSize(size_t handle, int uplo,
                             int n, size_t A, int lda) except *:
     cdef int lwork
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cusolverDnDpotrf_bufferSize(
             <Handle>handle, <FillMode>uplo, n, <double*>A, <int>lda, &lwork)
@@ -220,6 +222,7 @@ cpdef int dpotrf_bufferSize(size_t handle, int uplo,
 
 cpdef spotrf(size_t handle, int uplo, int n, size_t A, int lda,
              size_t work, int lwork, size_t devInfo):
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cusolverDnSpotrf(
             <Handle>handle, <FillMode>uplo, n, <float*>A,
@@ -228,6 +231,7 @@ cpdef spotrf(size_t handle, int uplo, int n, size_t A, int lda,
 
 cpdef dpotrf(size_t handle, int uplo, int n, size_t A, int lda,
              size_t work, int lwork, size_t devInfo):
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cusolverDnDpotrf(
             <Handle>handle, <FillMode>uplo, n, <double*>A,
@@ -236,6 +240,7 @@ cpdef dpotrf(size_t handle, int uplo, int n, size_t A, int lda,
 
 cpdef spotrs(size_t handle, int uplo, int n, int nrhs,
              size_t A, int lda, size_t B, int ldb, size_t devInfo):
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cusolverDnSpotrs(
             <Handle>handle, <FillMode>uplo, n, nrhs,
@@ -244,6 +249,7 @@ cpdef spotrs(size_t handle, int uplo, int n, int nrhs,
 
 cpdef dpotrs(size_t handle, int uplo, int n, int nrhs,
              size_t A, int lda, size_t B, int ldb, size_t devInfo):
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cusolverDnDpotrs(
             <Handle>handle, <FillMode>uplo, n, nrhs,
@@ -252,6 +258,7 @@ cpdef dpotrs(size_t handle, int uplo, int n, int nrhs,
 
 cpdef sgetrf(size_t handle, int m, int n, size_t A, int lda,
              size_t work, size_t devIpiv, size_t devInfo):
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cusolverDnSgetrf(
             <Handle>handle, m, n, <float*>A, lda,
@@ -260,6 +267,7 @@ cpdef sgetrf(size_t handle, int m, int n, size_t A, int lda,
 
 cpdef dgetrf(size_t handle, int m, int n, size_t A, int lda,
              size_t work, size_t devIpiv, size_t devInfo):
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cusolverDnDgetrf(
             <Handle>handle, m, n, <double*>A, lda,
@@ -269,6 +277,7 @@ cpdef dgetrf(size_t handle, int m, int n, size_t A, int lda,
 cpdef sgetrs(size_t handle, int trans, int n, int nrhs,
              size_t A, int lda, size_t devIpiv,
              size_t B, int ldb, size_t devInfo):
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cusolverDnSgetrs(
             <Handle>handle, <Operation>trans, n, nrhs,
@@ -279,6 +288,7 @@ cpdef sgetrs(size_t handle, int trans, int n, int nrhs,
 cpdef dgetrs(size_t handle, int trans, int n, int nrhs,
              size_t A, int lda, size_t devIpiv,
              size_t B, int ldb, size_t devInfo):
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cusolverDnDgetrs(
             <Handle>handle, <Operation>trans, n, nrhs,
@@ -289,6 +299,7 @@ cpdef dgetrs(size_t handle, int trans, int n, int nrhs,
 cpdef int sgetrf_bufferSize(size_t handle, int m, int n,
                             size_t A, int lda) except *:
     cdef int lwork
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cusolverDnSgetrf_bufferSize(
             <Handle>handle, m, n, <float*>A, lda, &lwork)
@@ -298,6 +309,7 @@ cpdef int sgetrf_bufferSize(size_t handle, int m, int n,
 cpdef int dgetrf_bufferSize(size_t handle, int m, int n,
                             size_t A, int lda) except *:
     cdef int lwork
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cusolverDnDgetrf_bufferSize(
             <Handle>handle, m, n, <double*>A, lda, &lwork)
@@ -307,6 +319,7 @@ cpdef int dgetrf_bufferSize(size_t handle, int m, int n,
 cpdef int sgeqrf_bufferSize(size_t handle, int m, int n,
                             size_t A, int lda) except *:
     cdef int lwork
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cusolverDnSgeqrf_bufferSize(
             <Handle>handle, m, n, <float*>A, lda, &lwork)
@@ -316,6 +329,7 @@ cpdef int sgeqrf_bufferSize(size_t handle, int m, int n,
 cpdef int dgeqrf_bufferSize(size_t handle, int m, int n,
                             size_t A, int lda) except *:
     cdef int lwork
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cusolverDnDgeqrf_bufferSize(
             <Handle>handle, m, n, <double*>A, lda, &lwork)
@@ -324,6 +338,7 @@ cpdef int dgeqrf_bufferSize(size_t handle, int m, int n,
 
 cpdef sgeqrf(size_t handle, int m, int n, size_t A, int lda,
              size_t tau, size_t work, int lwork, size_t devInfo):
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cusolverDnSgeqrf(
             <Handle>handle, m, n, <float*>A, lda,
@@ -332,6 +347,7 @@ cpdef sgeqrf(size_t handle, int m, int n, size_t A, int lda,
 
 cpdef dgeqrf(size_t handle, int m, int n, size_t A, int lda,
              size_t tau, size_t work, int lwork, size_t devInfo):
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cusolverDnDgeqrf(
             <Handle>handle, m, n, <double*>A, lda,
@@ -341,6 +357,7 @@ cpdef dgeqrf(size_t handle, int m, int n, size_t A, int lda,
 cpdef int sorgqr_bufferSize(size_t handle, int m, int n, int k,
                             size_t A, int lda, size_t tau) except *:
     cdef int lwork
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cusolverDnSorgqr_bufferSize(
             <Handle>handle, m, n, k, <const float*>A, lda,
@@ -351,6 +368,7 @@ cpdef int sorgqr_bufferSize(size_t handle, int m, int n, int k,
 cpdef int dorgqr_bufferSize(size_t handle, int m, int n, int k,
                             size_t A, int lda, size_t tau) except *:
     cdef int lwork
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cusolverDnDorgqr_bufferSize(
             <Handle>handle, m, n, k, <double*>A, lda,
@@ -360,6 +378,7 @@ cpdef int dorgqr_bufferSize(size_t handle, int m, int n, int k,
 
 cpdef sorgqr(size_t handle, int m, int n, int k, size_t A, int lda,
              size_t tau, size_t work, int lwork, size_t devInfo):
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cusolverDnSorgqr(
             <Handle>handle, m, n, k, <float*>A, lda,
@@ -368,6 +387,7 @@ cpdef sorgqr(size_t handle, int m, int n, int k, size_t A, int lda,
 
 cpdef dorgqr(size_t handle, int m, int n, int k, size_t A, int lda,
              size_t tau, size_t work, int lwork, size_t devInfo):
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cusolverDnDorgqr(
             <Handle>handle, m, n, k, <double*>A, lda,
@@ -377,6 +397,7 @@ cpdef dorgqr(size_t handle, int m, int n, int k, size_t A, int lda,
 cpdef sormqr(size_t handle, int side, int trans,
              int m, int n, int k, size_t A, int lda, size_t tau,
              size_t C, int ldc, size_t work, int lwork, size_t devInfo):
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cusolverDnSormqr(
             <Handle>handle, <SideMode>side, <Operation>trans, m, n, k,
@@ -387,6 +408,7 @@ cpdef sormqr(size_t handle, int side, int trans,
 cpdef dormqr(size_t handle, int side, int trans,
              int m, int n, int k, size_t A, int lda, size_t tau,
              size_t C, int ldc, size_t work, int lwork, size_t devInfo):
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cusolverDnDormqr(
             <Handle>handle, <SideMode>side, <Operation>trans, m, n, k,
@@ -396,6 +418,7 @@ cpdef dormqr(size_t handle, int side, int trans,
 
 cpdef ssytrf(size_t handle, int uplo, int n, size_t A, int lda,
              size_t ipiv, size_t work, int lwork, size_t devInfo):
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cusolverDnSsytrf(
             <Handle>handle, <FillMode>uplo, n, <float*>A, lda,
@@ -404,6 +427,7 @@ cpdef ssytrf(size_t handle, int uplo, int n, size_t A, int lda,
 
 cpdef dsytrf(size_t handle, int uplo, int n, size_t A, int lda,
              size_t ipiv, size_t work, int lwork, size_t devInfo):
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cusolverDnDsytrf(
             <Handle>handle, <FillMode>uplo, n, <double*>A, lda,
@@ -413,6 +437,7 @@ cpdef dsytrf(size_t handle, int uplo, int n, size_t A, int lda,
 cpdef sgebrd(size_t handle, int m, int n, size_t A, int lda,
              size_t D, size_t E, size_t tauQ, size_t tauP,
              size_t Work, int lwork, size_t devInfo):
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cusolverDnSgebrd(
             <Handle>handle, m, n, <float*>A, lda,
@@ -423,6 +448,7 @@ cpdef sgebrd(size_t handle, int m, int n, size_t A, int lda,
 cpdef dgebrd(size_t handle, int m, int n, size_t A, int lda,
              size_t D, size_t E, size_t tauQ, size_t tauP,
              size_t Work, int lwork, size_t devInfo):
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cusolverDnDgebrd(
             <Handle>handle, m, n, <double*>A, lda,
@@ -432,6 +458,7 @@ cpdef dgebrd(size_t handle, int m, int n, size_t A, int lda,
 
 cpdef int sgesvd_bufferSize(size_t handle, int m, int n) except *:
     cdef int lwork
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cusolverDnSgesvd_bufferSize(<Handle>handle, m, n, &lwork)
     check_status(status)
@@ -439,6 +466,7 @@ cpdef int sgesvd_bufferSize(size_t handle, int m, int n) except *:
 
 cpdef int dgesvd_bufferSize(size_t handle, int m, int n) except *:
     cdef int lwork
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cusolverDnDgesvd_bufferSize(<Handle>handle, m, n, &lwork)
     check_status(status)
@@ -447,6 +475,7 @@ cpdef int dgesvd_bufferSize(size_t handle, int m, int n) except *:
 cpdef sgesvd(size_t handle, char jobu, char jobvt, int m, int n, size_t A,
              int lda, size_t S, size_t U, int ldu, size_t VT, int ldvt,
              size_t Work, int lwork, size_t rwork, size_t devInfo):
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cusolverDnSgesvd(
             <Handle>handle, jobu, jobvt, m, n, <float*>A,
@@ -457,6 +486,7 @@ cpdef sgesvd(size_t handle, char jobu, char jobvt, int m, int n, size_t A,
 cpdef dgesvd(size_t handle, char jobu, char jobvt, int m, int n, size_t A,
              int lda, size_t S, size_t U, int ldu, size_t VT, int ldvt,
              size_t Work, int lwork, size_t rwork, size_t devInfo):
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cusolverDnDgesvd(
             <Handle>handle, jobu, jobvt, m, n, <double*>A,
@@ -467,6 +497,7 @@ cpdef dgesvd(size_t handle, char jobu, char jobvt, int m, int n, size_t A,
 cpdef int ssyevd_bufferSize(size_t handle, int jobz, int uplo, int n,
                             size_t A, int lda, size_t W):
     cdef int lwork, status
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cusolverDnSsyevd_bufferSize(
             <Handle>handle, <EigMode>jobz, <FillMode>uplo, n, <const float*>A,
@@ -477,6 +508,7 @@ cpdef int ssyevd_bufferSize(size_t handle, int jobz, int uplo, int n,
 cpdef int dsyevd_bufferSize(size_t handle, int jobz, int uplo, int n,
                             size_t A, int lda, size_t W):
     cdef int lwork, status
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cusolverDnDsyevd_bufferSize(
             <Handle>handle, <EigMode>jobz, <FillMode>uplo, n, <const double*>A,
@@ -487,6 +519,7 @@ cpdef int dsyevd_bufferSize(size_t handle, int jobz, int uplo, int n,
 cpdef ssyevd(size_t handle, int jobz, int uplo, int n, size_t A, int lda,
              size_t W, size_t work, int lwork, size_t info):
     cdef int status
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cusolverDnSsyevd(
             <Handle>handle, <EigMode>jobz, <FillMode>uplo, n, <float*>A, lda,
@@ -496,6 +529,7 @@ cpdef ssyevd(size_t handle, int jobz, int uplo, int n, size_t A, int lda,
 cpdef dsyevd(size_t handle, int jobz, int uplo, int n, size_t A, int lda,
              size_t W, size_t work, int lwork, size_t info):
     cdef int status
+    setStream(handle, stream_module.get_current_stream().ptr)
     with nogil:
         status = cusolverDnDsyevd(
             <Handle>handle, <EigMode>jobz, <FillMode>uplo, n, <double*>A, lda,

--- a/cupy/cuda/cusparse.pyx
+++ b/cupy/cuda/cusparse.pyx
@@ -16,7 +16,8 @@ cdef extern from "cupy_cusparse.h":
 
     # Stream
     Status cusparseSetStream(Handle handle, driver.Stream streamId)
-    Status cusparseGetStream(Handle handle, driver.Stream* streamId)
+    # cusparseGetStream is only available from CUDA 8.0
+    # Status cusparseGetStream(Handle handle, driver.Stream* streamId)
 
     # cuSPARSE Level1 Function
     Status cusparseSgthr(
@@ -285,11 +286,12 @@ cpdef setStream(size_t handle, size_t stream):
     check_status(status)
 
 
-cpdef size_t getStream(size_t handle) except *:
-    cdef driver.Stream stream
-    status = cusparseGetStream(<Handle>handle, &stream)
-    check_status(status)
-    return <size_t>stream
+# cusparseGetStream is only available from CUDA 8.0
+# cpdef size_t getStream(size_t handle) except *:
+#     cdef driver.Stream stream
+#     status = cusparseGetStream(<Handle>handle, &stream)
+#     check_status(status)
+#     return <size_t>stream
 
 
 ########################################

--- a/cupy/cuda/cusparse.pyx
+++ b/cupy/cuda/cusparse.pyx
@@ -1,7 +1,7 @@
 cimport cython
 
 from cupy.cuda cimport driver
-from cupy.cuda import stream as stream_module
+from cupy.cuda cimport stream as stream_module
 
 cdef extern from "cupy_cusparse.h":
 
@@ -299,7 +299,7 @@ cpdef setStream(size_t handle, size_t stream):
 
 cpdef sgthr(size_t handle, int nnz, size_t y, size_t xVal, size_t xInd,
             int idxBase):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     status = cusparseSgthr(
         <Handle>handle, nnz, <const float *>y, <float *>xVal,
         <const int *>xInd, <IndexBase>idxBase)
@@ -307,7 +307,7 @@ cpdef sgthr(size_t handle, int nnz, size_t y, size_t xVal, size_t xInd,
 
 cpdef dgthr(size_t handle, int nnz, size_t y, size_t xVal, size_t xInd,
             int idxBase):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     status = cusparseDgthr(
         <Handle>handle, nnz, <const double *>y, <double *>xVal,
         <const int *>xInd, <IndexBase>idxBase)
@@ -322,7 +322,7 @@ cpdef scsrmv(
         size_t alpha, size_t descrA, size_t csrSortedValA,
         size_t csrSortedRowPtrA, size_t csrSortedColIndA,
         size_t x, size_t beta, size_t y):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     status = cusparseScsrmv(
         <Handle>handle, <Operation>transA, m, n, nnz,
         <const float *>alpha, <MatDescr>descrA, <const float *>csrSortedValA,
@@ -335,7 +335,7 @@ cpdef dcsrmv(
         size_t alpha, size_t descrA, size_t csrSortedValA,
         size_t csrSortedRowPtrA, size_t csrSortedColIndA,
         size_t x, size_t beta, size_t y):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     status = cusparseDcsrmv(
         <Handle>handle, <Operation>transA, m, n, nnz,
         <const double *>alpha, <MatDescr>descrA, <const double *>csrSortedValA,
@@ -352,7 +352,7 @@ cpdef scsrmm(
         size_t alpha, size_t descrA, size_t csrSortedValA,
         size_t csrSortedRowPtrA, size_t csrSortedColIndA,
         size_t B, int ldb, size_t beta, size_t C, int ldc):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     status = cusparseScsrmm(
         <Handle>handle, <Operation>transA, m, n, k, nnz,
         <const float *>alpha, <MatDescr>descrA, <const float *>csrSortedValA,
@@ -365,7 +365,7 @@ cpdef dcsrmm(
         size_t alpha, size_t descrA, size_t csrSortedValA,
         size_t csrSortedRowPtrA, size_t csrSortedColIndA,
         size_t B, int ldb, size_t beta, size_t C, int ldc):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     status = cusparseDcsrmm(
         <Handle>handle, <Operation>transA, m, n, k, nnz,
         <const double *>alpha, <MatDescr>descrA, <const double *>csrSortedValA,
@@ -378,7 +378,7 @@ cpdef scsrmm2(
         size_t alpha, size_t descrA, size_t csrValA,
         size_t csrRowPtrA, size_t csrColIndA,
         size_t B, int ldb, size_t beta, size_t C, int ldc):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     status = cusparseScsrmm2(
         <Handle>handle, <Operation>transA, <Operation>transB, m, n, k, nnz,
         <const float *>alpha, <MatDescr>descrA, <const float *>csrValA,
@@ -391,7 +391,7 @@ cpdef dcsrmm2(
         size_t alpha, size_t descrA, size_t csrValA,
         size_t csrRowPtrA, size_t csrColIndA,
         size_t B, int ldb, size_t beta, size_t C, int ldc):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     status = cusparseDcsrmm2(
         <Handle>handle, <Operation>transA, <Operation>transB, m, n, k, nnz,
         <const double *>alpha, <MatDescr>descrA, <const double *>csrValA,
@@ -408,7 +408,7 @@ cpdef xcsrgeamNnz(
         size_t csrRowPtrA, size_t csrColIndA, size_t descrB,
         int nnzB, size_t csrRowPtrB, size_t csrColIndB,
         size_t descrC, size_t csrRowPtrC, size_t nnzTotalDevHostPtr):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     status = cusparseXcsrgeamNnz(
         <Handle>handle, m, n, <const MatDescr>descrA, nnzA,
         <const int *>csrRowPtrA, <const int *>csrColIndA,
@@ -424,7 +424,7 @@ cpdef scsrgeam(
         int nnzB, size_t csrValB, size_t csrRowPtrB,
         size_t csrColIndB, size_t descrC, size_t csrValC,
         size_t csrRowPtrC, size_t csrColIndC):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     status = cusparseScsrgeam(
         <Handle>handle, m, n, <const float *>alpha,
         <const MatDescr>descrA, nnzA, <const float *>csrValA,
@@ -443,7 +443,7 @@ cpdef dcsrgeam(
         int nnzB, size_t csrValB, size_t csrRowPtrB,
         size_t csrColIndB, size_t descrC, size_t csrValC,
         size_t csrRowPtrC, size_t csrColIndC):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     status = cusparseDcsrgeam(
         <Handle>handle, m, n, <const double *>alpha,
         <const MatDescr>descrA, nnzA, <const double *>csrValA,
@@ -461,7 +461,7 @@ cpdef xcsrgemmNnz(
         size_t csrColIndA, size_t descrB, int nnzB,
         size_t csrRowPtrB, size_t csrColIndB,
         size_t descrC, size_t csrRowPtrC, size_t nnzTotalDevHostPtr):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     status = cusparseXcsrgemmNnz(
         <Handle>handle, <Operation>transA, <Operation>transB, m, n, k,
         <const MatDescr>descrA, nnzA, <const int *>csrRowPtrA,
@@ -478,7 +478,7 @@ cpdef scsrgemm(
         const int nnzB, size_t csrValB, size_t csrRowPtrB,
         size_t csrColIndB, size_t descrC, size_t csrValC,
         size_t csrRowPtrC, size_t csrColIndC):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     status = cusparseScsrgemm(
         <Handle>handle, <Operation>transA, <Operation>transB, m, n, k,
         <const MatDescr>descrA, nnzA, <const float *>csrValA,
@@ -497,7 +497,7 @@ cpdef dcsrgemm(
         const int nnzB, size_t csrValB, size_t csrRowPtrB,
         size_t csrColIndB, size_t descrC, size_t csrValC,
         size_t csrRowPtrC, size_t csrColIndC):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     status = cusparseDcsrgemm(
         <Handle>handle, <Operation>transA, <Operation>transB, m, n, k,
         <const MatDescr>descrA, nnzA, <const double *>csrValA,
@@ -515,7 +515,7 @@ cpdef dcsrgemm(
 cpdef xcoo2csr(
         size_t handle, size_t cooRowInd, int nnz, int m, size_t csrRowPtr,
         int idxBase):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     status = cusparseXcoo2csr(
         <Handle>handle, <const int *>cooRowInd, nnz, m, <int *>csrRowPtr,
         <IndexBase>idxBase)
@@ -547,7 +547,7 @@ cpdef dcsc2dense(
 cpdef xcsr2coo(
         size_t handle, size_t csrRowPtr, int nnz, int m, size_t cooRowInd,
         int idxBase):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     status = cusparseXcsr2coo(
         <Handle>handle, <const int *>csrRowPtr, nnz, m, <int *>cooRowInd,
         <IndexBase>idxBase)
@@ -558,7 +558,7 @@ cpdef scsr2csc(
         size_t handle, int m, int n, int nnz, size_t csrVal,
         size_t csrRowPtr, size_t csrColInd, size_t cscVal,
         size_t cscRowInd, size_t cscColPtr, int copyValues, int idxBase):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     status = cusparseScsr2csc(
         <Handle>handle, m, n, nnz, <const float *>csrVal,
         <const int *>csrRowPtr, <const int *>csrColInd, <float *>cscVal,
@@ -571,7 +571,7 @@ cpdef dcsr2csc(
         size_t handle, int m, int n, int nnz, size_t csrVal,
         size_t csrRowPtr, size_t csrColInd, size_t cscVal,
         size_t cscRowInd, size_t cscColPtr, int copyValues, int idxBase):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     status = cusparseDcsr2csc(
         <Handle>handle, m, n, nnz, <const double *>csrVal,
         <const int *>csrRowPtr, <const int *>csrColInd, <double *>cscVal,
@@ -584,7 +584,7 @@ cpdef scsr2dense(
         size_t handle, int m, int n, size_t descrA,
         size_t csrSortedValA, size_t csrSortedRowPtrA,
         size_t csrSortedColIndA, size_t A, int lda):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     status = cusparseScsr2dense(
         <Handle>handle, m, n, <MatDescr>descrA,
         <const float *>csrSortedValA, <const int *>csrSortedRowPtrA,
@@ -596,7 +596,7 @@ cpdef dcsr2dense(
         size_t handle, int m, int n, size_t descrA,
         size_t csrSortedValA, size_t csrSortedRowPtrA,
         size_t csrSortedColIndA, size_t A, int lda):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     status = cusparseDcsr2dense(
         <Handle>handle, m, n, <MatDescr>descrA,
         <const double *>csrSortedValA, <const int *>csrSortedRowPtrA,
@@ -670,7 +670,7 @@ cpdef dnnz(
 
 cpdef createIdentityPermutation(
         size_t handle, int n, size_t p):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     status = cusparseCreateIdentityPermutation(
         <Handle>handle, n, <int *>p)
     check_status(status)
@@ -680,7 +680,7 @@ cpdef size_t xcoosort_bufferSizeExt(
         size_t handle, int m, int n, int nnz, size_t cooRows,
         size_t cooCols):
     cdef size_t bufferSizeInBytes
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     status = cusparseXcoosort_bufferSizeExt(
         <Handle>handle, m, n, nnz, <const int *>cooRows,
         <const int *>cooCols, &bufferSizeInBytes)
@@ -691,7 +691,7 @@ cpdef size_t xcoosort_bufferSizeExt(
 cpdef xcoosortByRow(
         size_t handle, int m, int n, int nnz, size_t cooRows, size_t cooCols,
         size_t P, size_t pBuffer):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     status = cusparseXcoosortByRow(
         <Handle>handle, m, n, nnz, <int *>cooRows, <int *>cooCols,
         <int *>P, <void *>pBuffer)
@@ -702,7 +702,7 @@ cpdef size_t xcsrsort_bufferSizeExt(
         size_t handle, int m, int n, int nnz, size_t csrRowPtr,
         size_t csrColInd):
     cdef size_t bufferSizeInBytes
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     status = cusparseXcsrsort_bufferSizeExt(
         <Handle>handle, m, n, nnz, <const int *>csrRowPtr,
         <const int *>csrColInd, &bufferSizeInBytes)
@@ -713,7 +713,7 @@ cpdef size_t xcsrsort_bufferSizeExt(
 cpdef xcsrsort(
         size_t handle, int m, int n, int nnz, size_t descrA,
         size_t csrRowPtr, size_t csrColInd, size_t P, size_t pBuffer):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     status = cusparseXcsrsort(
         <Handle>handle, m, n, nnz, <const MatDescr>descrA,
         <const int *>csrRowPtr, <int *>csrColInd, <int *>P, <void *>pBuffer)
@@ -724,7 +724,7 @@ cpdef size_t xcscsort_bufferSizeExt(
         size_t handle, int m, int n, int nnz, size_t cscColPtr,
         size_t cscRowInd):
     cdef size_t bufferSizeInBytes
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     status = cusparseXcscsort_bufferSizeExt(
         <Handle>handle, m, n, nnz, <const int *>cscColPtr,
         <const int *>cscRowInd, &bufferSizeInBytes)
@@ -735,7 +735,7 @@ cpdef size_t xcscsort_bufferSizeExt(
 cpdef xcscsort(
         size_t handle, int m, int n, int nnz, size_t descrA,
         size_t cscColPtr, size_t cscRowInd, size_t P, size_t pBuffer):
-    setStream(handle, stream_module.get_current_stream().ptr)
+    setStream(handle, stream_module.get_current_stream_ptr())
     status = cusparseXcscsort(
         <Handle>handle, m, n, nnz, <const MatDescr>descrA,
         <const int *>cscColPtr, <int *>cscRowInd, <int *>P, <void *>pBuffer)

--- a/cupy/cuda/function.pyx
+++ b/cupy/cuda/function.pyx
@@ -8,7 +8,7 @@ from libcpp cimport vector
 
 from cupy.cuda cimport driver
 from cupy.core cimport core
-from cupy.cuda import stream as stream_module
+from cupy.cuda cimport stream as stream_module
 
 
 cdef extern from "cupy_stdint.h" nogil:
@@ -107,7 +107,7 @@ cdef inline CPointer _pointer(x):
 
 cdef inline size_t _get_stream(stream) except *:
     if stream is None:
-        return stream_module.get_current_stream().ptr
+        return stream_module.get_current_stream_ptr()
     else:
         return stream.ptr
 

--- a/cupy/cuda/function.pyx
+++ b/cupy/cuda/function.pyx
@@ -8,6 +8,7 @@ from libcpp cimport vector
 
 from cupy.cuda cimport driver
 from cupy.core cimport core
+from cupy.cuda import stream as stream_module
 
 
 cdef extern from "cupy_stdint.h" nogil:
@@ -104,8 +105,11 @@ cdef inline CPointer _pointer(x):
     raise TypeError('Unsupported type %s. (size=%d)', type(x), itemsize)
 
 
-cdef inline size_t _get_stream(strm) except *:
-    return 0 if strm is None else strm.ptr
+cdef inline size_t _get_stream(stream) except *:
+    if stream is None:
+        return stream_module.get_current_stream().ptr
+    else:
+        return stream.ptr
 
 
 cdef void _launch(size_t func, Py_ssize_t grid0, int grid1, int grid2,

--- a/cupy/cuda/memory.pxd
+++ b/cupy/cuda/memory.pxd
@@ -60,7 +60,7 @@ cdef class SingleDeviceMemoryPool:
     cpdef MemoryPointer malloc(self, Py_ssize_t size)
     cpdef MemoryPointer _malloc(self, Py_ssize_t size)
     cpdef free(self, size_t ptr, Py_ssize_t size)
-    cpdef free_all_blocks(self)
+    cpdef free_all_blocks(self, stream=?, stream_ptr=?)
     cpdef free_all_free(self)
     cpdef n_free_blocks(self)
     cpdef used_bytes(self)
@@ -82,7 +82,7 @@ cdef class MemoryPool:
         object _pools
 
     cpdef MemoryPointer malloc(self, Py_ssize_t size)
-    cpdef free_all_blocks(self)
+    cpdef free_all_blocks(self, stream=?, stream_ptr=?)
     cpdef free_all_free(self)
     cpdef n_free_blocks(self)
     cpdef used_bytes(self)

--- a/cupy/cuda/memory.pxd
+++ b/cupy/cuda/memory.pxd
@@ -1,4 +1,5 @@
 from libcpp cimport vector
+from libcpp cimport unordered_map
 
 from cupy.cuda cimport device
 
@@ -11,6 +12,7 @@ cdef class Chunk:
         readonly size_t ptr
         readonly Py_ssize_t offset
         readonly Py_ssize_t size
+        public object stream_ptr
         public Chunk prev
         public Chunk next
 
@@ -22,15 +24,16 @@ cdef class MemoryPointer:
         readonly size_t ptr
 
     cpdef copy_from_device(self, MemoryPointer src, Py_ssize_t size)
-    cpdef copy_from_device_async(self, MemoryPointer src, size_t size, stream)
+    cpdef copy_from_device_async(self, MemoryPointer src, size_t size,
+                                 stream=?)
     cpdef copy_from_host(self, mem, size_t size)
-    cpdef copy_from_host_async(self, mem, size_t size, stream)
+    cpdef copy_from_host_async(self, mem, size_t size, stream=?)
     cpdef copy_from(self, mem, size_t size)
-    cpdef copy_from_async(self, mem, size_t size, stream)
+    cpdef copy_from_async(self, mem, size_t size, stream=?)
     cpdef copy_to_host(self, mem, size_t size)
-    cpdef copy_to_host_async(self, mem, size_t size, stream)
+    cpdef copy_to_host_async(self, mem, size_t size, stream=?)
     cpdef memset(self, int value, size_t size)
-    cpdef memset_async(self, int value, size_t size, stream)
+    cpdef memset_async(self, int value, size_t size, stream=?)
 
 
 cpdef MemoryPointer alloc(Py_ssize_t size)
@@ -44,14 +47,14 @@ cdef class SingleDeviceMemoryPool:
     cdef:
         object _allocator
         dict _in_use
-        list _free
+        dict _free
         object __weakref__
         object _weakref
         object _free_lock
         object _in_use_lock
         readonly Py_ssize_t _allocation_unit_size
         readonly int _device_id
-        vector.vector[int] _index
+        unordered_map.unordered_map[size_t, vector.vector[int]] _index
 
     cpdef MemoryPointer _alloc(self, Py_ssize_t size)
     cpdef MemoryPointer malloc(self, Py_ssize_t size)
@@ -65,8 +68,11 @@ cdef class SingleDeviceMemoryPool:
     cpdef total_bytes(self)
     cpdef Py_ssize_t _round_size(self, Py_ssize_t size)
     cpdef int _bin_index_from_size(self, Py_ssize_t size)
-    cpdef _append_to_free_list(self, Py_ssize_t size, chunk)
-    cpdef bint _remove_from_free_list(self, Py_ssize_t size, chunk) except *
+    cpdef list _arena(self, size_t stream_ptr)
+    cdef vector.vector[int]* _arena_index(self, size_t stream_ptr)
+    cpdef _append_to_free_list(self, Py_ssize_t size, chunk, size_t stream_ptr)
+    cpdef bint _remove_from_free_list(self, Py_ssize_t size,
+                                      chunk, size_t stream_ptr) except *
     cpdef tuple _split(self, Chunk chunk, Py_ssize_t size)
     cpdef Chunk _merge(self, Chunk head, Chunk remaining)
 

--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -10,6 +10,7 @@ from libcpp cimport algorithm
 
 from cupy.cuda import memory_hook
 from cupy.cuda import runtime
+from cupy.cuda import stream as stream_module
 
 from cupy.cuda cimport device
 from cupy.cuda cimport runtime
@@ -126,24 +127,27 @@ cdef class Chunk:
         mem (Memory): The device memory buffer.
         offset (int): An offset bytes from the head of the buffer.
         size (int): Chunk size in bytes.
+        stream_ptr (size_t): Raw stream handle of cupy.cuda.Stream
 
     Attributes:
         device (cupy.cuda.Device): Device whose memory the pointer refers to.
         mem (Memory): The device memory buffer.
-        ptr (int): Memory address.
+        ptr (size_t): Memory address.
         offset (int): An offset bytes from the head of the buffer.
         size (int): Chunk size in bytes.
         prev (Chunk): prev memory pointer if split from a larger allocation
         next (Chunk): next memory pointer if split from a larger allocation
+        stream_ptr (size_t): Raw stream handle of cupy.cuda.Stream
     """
 
-    def __init__(self, mem, Py_ssize_t offset, Py_ssize_t size):
+    def __init__(self, mem, Py_ssize_t offset, Py_ssize_t size, stream_ptr):
         assert mem.ptr > 0 or offset == 0
         self.mem = mem
         self.device = mem.device
         self.ptr = mem.ptr + offset
         self.offset = offset
         self.size = size
+        self.stream_ptr = stream_ptr
         self.prev = None
         self.next = None
 
@@ -163,7 +167,7 @@ cdef class MemoryPointer:
         ~MemoryPointer.device (cupy.cuda.Device): Device whose memory the
             pointer refers to.
         mem (Memory): The device memory buffer.
-        ptr (int): Pointer to the place within the buffer.
+        ptr (size_t): Pointer to the place within the buffer.
     """
 
     def __init__(self, mem, Py_ssize_t offset):
@@ -217,15 +221,19 @@ cdef class MemoryPointer:
             runtime.memcpy(self.ptr, src.ptr, size,
                            runtime.memcpyDefault)
 
-    cpdef copy_from_device_async(self, MemoryPointer src, size_t size, stream):
+    cpdef copy_from_device_async(self, MemoryPointer src, size_t size,
+                                 stream=None):
         """Copies a memory from a (possibly different) device asynchronously.
 
         Args:
             src (cupy.cuda.MemoryPointer): Source memory pointer.
             size (int): Size of the sequence in bytes.
             stream (cupy.cuda.Stream): CUDA stream.
+                The default uses CUDA stream of the current context.
 
         """
+        if stream is None:
+            stream = stream_module.get_current_stream()
         if size > 0:
             _set_peer_access(src.device.id, self.device.id)
             runtime.memcpyAsync(self.ptr, src.ptr, size,
@@ -243,7 +251,7 @@ cdef class MemoryPointer:
             runtime.memcpy(self.ptr, mem.value, size,
                            runtime.memcpyHostToDevice)
 
-    cpdef copy_from_host_async(self, mem, size_t size, stream):
+    cpdef copy_from_host_async(self, mem, size_t size, stream=None):
         """Copies a memory sequence from the host memory asynchronously.
 
         Args:
@@ -251,8 +259,11 @@ cdef class MemoryPointer:
                 memory.
             size (int): Size of the sequence in bytes.
             stream (cupy.cuda.Stream): CUDA stream.
+                The default uses CUDA stream of the current context.
 
         """
+        if stream is None:
+            stream = stream_module.get_current_stream()
         if size > 0:
             runtime.memcpyAsync(self.ptr, mem.value, size,
                                 runtime.memcpyHostToDevice, stream.ptr)
@@ -275,7 +286,7 @@ cdef class MemoryPointer:
         else:
             self.copy_from_host(mem, size)
 
-    cpdef copy_from_async(self, mem, size_t size, stream):
+    cpdef copy_from_async(self, mem, size_t size, stream=None):
         """Copies a memory sequence from an arbitrary place asynchronously.
 
         This function is a useful interface that selects appropriate one from
@@ -287,8 +298,11 @@ cdef class MemoryPointer:
                 pointer.
             size (int): Size of the sequence in bytes.
             stream (cupy.cuda.Stream): CUDA stream.
+                The default uses CUDA stream of the current context.
 
         """
+        if stream is None:
+            stream = stream_module.get_current_stream()
         if isinstance(mem, MemoryPointer):
             self.copy_from_device_async(mem, size, stream)
         else:
@@ -306,7 +320,7 @@ cdef class MemoryPointer:
             runtime.memcpy(mem.value, self.ptr, size,
                            runtime.memcpyDeviceToHost)
 
-    cpdef copy_to_host_async(self, mem, size_t size, stream):
+    cpdef copy_to_host_async(self, mem, size_t size, stream=None):
         """Copies a memory sequence to the host memory asynchronously.
 
         Args:
@@ -314,8 +328,11 @@ cdef class MemoryPointer:
                 memory.
             size (int): Size of the sequence in bytes.
             stream (cupy.cuda.Stream): CUDA stream.
+                The default uses CUDA stream of the current context.
 
         """
+        if stream is None:
+            stream = stream_module.get_current_stream()
         if size > 0:
             runtime.memcpyAsync(mem.value, self.ptr, size,
                                 runtime.memcpyDeviceToHost, stream.ptr)
@@ -331,15 +348,18 @@ cdef class MemoryPointer:
         if size > 0:
             runtime.memset(self.ptr, value, size)
 
-    cpdef memset_async(self, int value, size_t size, stream):
+    cpdef memset_async(self, int value, size_t size, stream=None):
         """Fills a memory sequence by constant byte value asynchronously.
 
         Args:
             value (int): Value to fill.
             size (int): Size of the sequence in bytes.
             stream (cupy.cuda.Stream): CUDA stream.
+                The default uses CUDA stream of the current context.
 
         """
+        if stream is None:
+            stream = stream_module.get_current_stream()
         if size > 0:
             runtime.memsetAsync(self.ptr, value, size, stream.ptr)
 
@@ -482,7 +502,7 @@ cdef class SingleDeviceMemoryPool:
         # cf. https://gist.github.com/sonots/41daaa6432b1c8b27ef782cd14064269
         self._allocation_unit_size = 512
         self._in_use = {}
-        self._free = []
+        self._free = {}
         self._allocator = allocator
         self._weakref = weakref.ref(self)
         self._device_id = device.get_device_id()
@@ -499,38 +519,62 @@ cdef class SingleDeviceMemoryPool:
         unit = self._allocation_unit_size
         return (size - 1) // unit
 
-    cpdef _append_to_free_list(self, Py_ssize_t size, chunk):
+    cpdef list _arena(self, size_t stream_ptr):
+        """Get appropriate arena (list of bins) of a given stream"""
+        if stream_ptr not in self._free:
+            self._free[stream_ptr] = []
+        return self._free[stream_ptr]
+
+    cdef vector.vector[int]* _arena_index(self, size_t stream_ptr):
+        """Get appropriate arena sparse index of a given stream"""
+        if self._index.count(stream_ptr) == 0:
+            self._index[stream_ptr] = vector.vector[int]()
+        return &self._index[stream_ptr]
+
+    cpdef _append_to_free_list(self, Py_ssize_t size, chunk,
+                               size_t stream_ptr):
         cdef int index, bin_index
+        cdef list arena
         cdef set free_list
+        cdef vector.vector[int]* arena_index
+
         bin_index = self._bin_index_from_size(size)
         rlock.lock_fastrlock(self._free_lock, -1, True)
         try:
+            arena = self._arena(stream_ptr)
+            arena_index = self._arena_index(stream_ptr)
             index = algorithm.lower_bound(
-                self._index.begin(), self._index.end(),
-                bin_index) - self._index.begin()
-            if index < self._index.size() and self._index[index] == bin_index:
-                free_list = self._free[index]
+                arena_index.begin(), arena_index.end(),
+                bin_index) - arena_index.begin()
+            size = <int>arena_index.size()
+            if index < size and arena_index.at(index) == bin_index:
+                free_list = arena[index]
             else:
                 free_list = set()
-                self._index.insert(
-                    self._index.begin() + index, bin_index)
-                self._free.insert(index, free_list)
+                arena_index.insert(arena_index.begin() + index, bin_index)
+                arena.insert(index, free_list)
             free_list.add(chunk)
         finally:
             rlock.unlock_fastrlock(self._free_lock)
 
-    cpdef bint _remove_from_free_list(self, Py_ssize_t size, chunk) except *:
+    cpdef bint _remove_from_free_list(self, Py_ssize_t size, chunk,
+                                      size_t stream_ptr) except *:
         cdef int index, bin_index
+        cdef list arena
         cdef set free_list
+        cdef vector.vector[int]* arena_index
+
         bin_index = self._bin_index_from_size(size)
         rlock.lock_fastrlock(self._free_lock, -1, True)
         try:
+            arena = self._arena(stream_ptr)
+            arena_index = self._arena_index(stream_ptr)
             index = algorithm.lower_bound(
-                self._index.begin(), self._index.end(),
-                bin_index) - self._index.begin()
-            if self._index[index] != bin_index:
+                arena_index.begin(), arena_index.end(),
+                bin_index) - arena_index.begin()
+            if arena_index.at(index) != bin_index:
                 return False
-            free_list = self._free[index]
+            free_list = arena[index]
             if chunk in free_list:
                 free_list.remove(chunk)
                 return True
@@ -545,8 +589,9 @@ cdef class SingleDeviceMemoryPool:
         assert chunk.size >= size
         if chunk.size == size:
             return chunk, None
-        head = Chunk(chunk.mem, chunk.offset, size)
-        remaining = Chunk(chunk.mem, chunk.offset + size, chunk.size - size)
+        head = Chunk(chunk.mem, chunk.offset, size, chunk.stream_ptr)
+        remaining = Chunk(chunk.mem, chunk.offset + size, chunk.size - size,
+                          chunk.stream_ptr)
         if chunk.prev is not None:
             head.prev = chunk.prev
             chunk.prev.next = head
@@ -559,9 +604,10 @@ cdef class SingleDeviceMemoryPool:
 
     cpdef Chunk _merge(self, Chunk head, Chunk remaining):
         """Merge previously splitted block (chunk)"""
+        assert head.stream_ptr == remaining.stream_ptr
         cdef Chunk merged
         size = head.size + remaining.size
-        merged = Chunk(head.mem, head.offset, size)
+        merged = Chunk(head.mem, head.offset, size, head.stream_ptr)
         if head.prev is not None:
             merged.prev = head.prev
             merged.prev.next = merged
@@ -630,16 +676,20 @@ cdef class SingleDeviceMemoryPool:
         if size == 0:
             return MemoryPointer(Memory(0), 0)
 
+        stream_ptr = stream_module.get_current_stream().ptr
+
+        bin_index = self._bin_index_from_size(size)
         # find best-fit, or a smallest larger allocation
         rlock.lock_fastrlock(self._free_lock, -1, True)
-        bin_index = self._bin_index_from_size(size)
         try:
+            arena = self._arena(stream_ptr)
+            arena_index = self._arena_index(stream_ptr)
             index = algorithm.lower_bound(
-                self._index.begin(), self._index.end(),
-                bin_index) - self._index.begin()
-            length = self._index.size()
+                arena_index.begin(), arena_index.end(),
+                bin_index) - arena_index.begin()
+            length = arena_index.size()
             for i in range(index, length):
-                free_list = self._free[i]
+                free_list = arena[i]
                 if free_list:
                     chunk = free_list.pop()
                     break
@@ -670,15 +720,16 @@ cdef class SingleDeviceMemoryPool:
                         else:
                             total = size + self.total_bytes()
                             raise OutOfMemoryError(size, total)
-            chunk = Chunk(mem, 0, size)
+            chunk = Chunk(mem, 0, size, stream_ptr)
 
+        assert chunk.stream_ptr == stream_ptr
         rlock.lock_fastrlock(self._in_use_lock, -1, True)
         try:
             self._in_use[chunk.ptr] = chunk
         finally:
             rlock.unlock_fastrlock(self._in_use_lock)
         if remaining is not None:
-            self._append_to_free_list(remaining.size, remaining)
+            self._append_to_free_list(remaining.size, remaining, stream_ptr)
         pmem = PooledMemory(chunk, self._weakref)
         return MemoryPointer(pmem, 0)
 
@@ -693,16 +744,19 @@ cdef class SingleDeviceMemoryPool:
             rlock.unlock_fastrlock(self._in_use_lock)
         if chunk is None:
             raise RuntimeError('Cannot free out-of-pool memory')
+        stream_ptr = chunk.stream_ptr
 
         if chunk.next is not None:
-            if self._remove_from_free_list(chunk.next.size, chunk.next):
+            if self._remove_from_free_list(chunk.next.size, chunk.next,
+                                           stream_ptr):
                 chunk = self._merge(chunk, chunk.next)
 
         if chunk.prev is not None:
-            if self._remove_from_free_list(chunk.prev.size, chunk.prev):
+            if self._remove_from_free_list(chunk.prev.size, chunk.prev,
+                                           stream_ptr):
                 chunk = self._merge(chunk.prev, chunk)
 
-        self._append_to_free_list(chunk.size, chunk)
+        self._append_to_free_list(chunk.size, chunk, stream_ptr)
 
     cpdef free_all_blocks(self):
         cdef set free_list, keep_list
@@ -710,13 +764,14 @@ cdef class SingleDeviceMemoryPool:
         # Free all **non-split** chunks
         rlock.lock_fastrlock(self._free_lock, -1, True)
         try:
-            for i in range(len(self._free)):
-                free_list = self._free[i]
-                keep_list = set()
-                for chunk in free_list:
-                    if chunk.prev is not None or chunk.next is not None:
-                        keep_list.add(chunk)
-                self._free[i] = keep_list
+            for arena in self._free.itervalues():
+                for i in range(len(arena)):
+                    free_list = arena[i]
+                    keep_list = set()
+                    for chunk in free_list:
+                        if chunk.prev is not None or chunk.next is not None:
+                            keep_list.add(chunk)
+                    arena[i] = keep_list
         finally:
             rlock.unlock_fastrlock(self._free_lock)
 
@@ -731,8 +786,9 @@ cdef class SingleDeviceMemoryPool:
         cdef set free_list
         rlock.lock_fastrlock(self._free_lock, -1, True)
         try:
-            for free_list in self._free:
-                n += len(free_list)
+            for arena in self._free.itervalues():
+                for v in arena:
+                    n += len(v)
         finally:
             rlock.unlock_fastrlock(self._free_lock)
         return n
@@ -754,9 +810,10 @@ cdef class SingleDeviceMemoryPool:
         cdef Chunk chunk
         rlock.lock_fastrlock(self._free_lock, -1, True)
         try:
-            for free_list in self._free:
-                for chunk in free_list:
-                    size += chunk.size
+            for arena in self._free.itervalues():
+                for free_list in arena:
+                    for chunk in free_list:
+                        size += chunk.size
         finally:
             rlock.unlock_fastrlock(self._free_lock)
         return size

--- a/cupy/cuda/stream.pxd
+++ b/cupy/cuda/stream.pxd
@@ -1,0 +1,1 @@
+cdef size_t get_current_stream_ptr()

--- a/cupy/cuda/stream.py
+++ b/cupy/cuda/stream.py
@@ -62,7 +62,7 @@ class Event(object):
 
         """
         if stream is None:
-            stream = Stream.null
+            stream = get_current_stream()
         runtime.eventRecord(self.ptr, stream.ptr)
 
     def synchronize(self):

--- a/cupy/cuda/stream.py
+++ b/cupy/cuda/stream.py
@@ -107,6 +107,7 @@ class Stream(object):
     Attributes:
         ptr (cupy.cuda.runtime.Stream): Raw stream handle. It can be passed to
             the CUDA Runtime API via ctypes.
+        device (int): CUDA Device ID
 
     """
 
@@ -119,10 +120,13 @@ class Stream(object):
                              'a new cupy.cuda.Stream(null=True) object')
         if null:
             self.ptr = 0
+            self.device = None  # any devices
         elif non_blocking:
             self.ptr = runtime.streamCreateWithFlags(runtime.streamNonBlocking)
+            self.device = runtime.getDevice()
         else:
             self.ptr = runtime.streamCreate()
+            self.device = runtime.getDevice()
 
     def __del__(self):
         if self.ptr:

--- a/cupy/cuda/stream.py
+++ b/cupy/cuda/stream.py
@@ -116,7 +116,6 @@ class Stream(object):
     Attributes:
         ptr (size_t): Raw stream handle. It can be passed to
             the CUDA Runtime API via ctypes.
-        device (int): CUDA Device ID
 
     """
 
@@ -129,13 +128,10 @@ class Stream(object):
                              'a new cupy.cuda.Stream(null=True) object')
         if null:
             self.ptr = 0
-            self.device = None  # any devices
         elif non_blocking:
             self.ptr = runtime.streamCreateWithFlags(runtime.streamNonBlocking)
-            self.device = runtime.getDevice()
         else:
             self.ptr = runtime.streamCreate()
-            self.device = runtime.getDevice()
 
     def __del__(self):
         if self.ptr:

--- a/cupy/cuda/stream.py
+++ b/cupy/cuda/stream.py
@@ -1,4 +1,14 @@
 from cupy.cuda import runtime
+import threading
+
+
+thread_local = threading.local()
+
+
+def get_current_stream():
+    if not hasattr(thread_local, 'current_stream'):
+        thread_local.current_stream = Stream.null
+    return thread_local.current_stream
 
 
 class Event(object):
@@ -112,6 +122,24 @@ class Stream(object):
     def __del__(self):
         if self.ptr:
             runtime.streamDestroy(self.ptr)
+
+    def __enter__(self):
+        if not hasattr(thread_local, 'prev_stream_stack'):
+            thread_local.prev_stream_stack = []
+        thread_local.prev_stream_stack.append(get_current_stream())
+        thread_local.current_stream = self
+        return self
+
+    def __exit__(self, *args):
+        thread_local.current_stream = thread_local.prev_stream_stack.pop()
+
+    def use(self):
+        """Makes this stream current.
+
+        If you want to switch a stream temporarily, use the *with* statement.
+        """
+        thread_local.current_stream = self
+        return self
 
     @property
     def done(self):

--- a/cupy/cuda/stream.py
+++ b/cupy/cuda/stream.py
@@ -136,7 +136,9 @@ class Stream(object):
 
     def __del__(self):
         if self.ptr:
-            runtime.streamDestroy(self.ptr)
+            # https://stackoverflow.com/questions/8590238/unable-to-reference-an-imported-module-in-del
+            if runtime:
+                runtime.streamDestroy(self.ptr)
 
     def __enter__(self):
         if not hasattr(thread_local, 'prev_stream_stack'):

--- a/cupy/cuda/stream.py
+++ b/cupy/cuda/stream.py
@@ -99,7 +99,8 @@ class Stream(object):
     Args:
         null (bool): If ``True``, the stream is a null stream (i.e. the default
             stream that synchronizes with all streams). Otherwise, a plain new
-            stream is created.
+            stream is created. Users must not use this parameter, instead, use
+            ``Stream.null`` object to use the default stream.
         non_blocking (bool): If ``True``, the stream does not synchronize with
             the NULL stream.
 
@@ -112,6 +113,10 @@ class Stream(object):
     null = None
 
     def __init__(self, null=False, non_blocking=False):
+        if null and Stream.null:
+            self.ptr = 0  # to avoid AttributeError on __del__
+            raise ValueError('Use cupy.cuda.Stream.null instead of creating '
+                             'a new cupy.cuda.Stream(null=True) object')
         if null:
             self.ptr = 0
         elif non_blocking:

--- a/cupy/cuda/stream.py
+++ b/cupy/cuda/stream.py
@@ -17,11 +17,6 @@ def get_current_stream():
     stream = thread_local.current_stream_ref()
     if stream is None:
         stream = Stream.null
-    device = runtime.getDevice()
-    if stream != Stream.null and stream.device != device:
-        raise ValueError('Current stream device (%d) is different '
-                         'with the current device (%d)' %
-                         (stream.device, device))
     return stream
 
 

--- a/cupy/cuda/stream.py
+++ b/cupy/cuda/stream.py
@@ -8,7 +8,13 @@ thread_local = threading.local()
 def get_current_stream():
     if not hasattr(thread_local, 'current_stream'):
         thread_local.current_stream = Stream.null
-    return thread_local.current_stream
+    stream = thread_local.current_stream
+    device = runtime.getDevice()
+    if stream != Stream.null and stream.device != device:
+        raise ValueError('Current stream device (%d) is different '
+                         'with the current device (%d)' %
+                         (stream.device, device))
+    return stream
 
 
 class Event(object):

--- a/cupy/cuda/stream.pyx
+++ b/cupy/cuda/stream.pyx
@@ -41,6 +41,7 @@ cpdef _set_current_stream(stream):
     if stream is None:
         stream = Stream.null
     cdef size_t stream_ptr = stream.ptr
+    pythread.PyThread_delete_key_value(_current_stream_key)
     pythread.PyThread_set_key_value(_current_stream_key, <void *>stream_ptr)
     _thread_local.current_stream_ref = weakref.ref(stream)
 

--- a/cupy/cuda/thrust.pyx
+++ b/cupy/cuda/thrust.pyx
@@ -7,6 +7,7 @@ import numpy
 from libcpp.vector cimport vector
 
 from cupy.cuda cimport common
+from cupy.cuda import stream as stream_module
 
 
 ###############################################################################
@@ -14,9 +15,10 @@ from cupy.cuda cimport common
 ###############################################################################
 
 cdef extern from "../cuda/cupy_thrust.h" namespace "cupy::thrust":
-    void _sort[T](void *, size_t *, const vector.vector[ptrdiff_t]&)
-    void _lexsort[T](size_t *, void *, size_t, size_t)
-    void _argsort[T](size_t *, void *, void *, const vector.vector[ptrdiff_t]&)
+    void _sort[T](void *, size_t *, const vector.vector[ptrdiff_t]&, size_t)
+    void _lexsort[T](size_t *, void *, size_t, size_t, size_t)
+    void _argsort[T](size_t *, void *, void *, const vector.vector[ptrdiff_t]&,
+                     size_t)
 
 
 ###############################################################################
@@ -28,31 +30,33 @@ cpdef sort(dtype, size_t data_start, size_t keys_start,
 
     cdef void *_data_start
     cdef size_t *_keys_start
+    cdef size_t _strm
 
     _data_start = <void *>data_start
     _keys_start = <size_t *>keys_start
+    _strm = <size_t>(stream_module.get_current_stream().ptr)
 
     # TODO(takagi): Support float16 and bool
     if dtype == numpy.int8:
-        _sort[common.cpy_byte](_data_start, _keys_start, shape)
+        _sort[common.cpy_byte](_data_start, _keys_start, shape, _strm)
     elif dtype == numpy.uint8:
-        _sort[common.cpy_ubyte](_data_start, _keys_start, shape)
+        _sort[common.cpy_ubyte](_data_start, _keys_start, shape, _strm)
     elif dtype == numpy.int16:
-        _sort[common.cpy_short](_data_start, _keys_start, shape)
+        _sort[common.cpy_short](_data_start, _keys_start, shape, _strm)
     elif dtype == numpy.uint16:
-        _sort[common.cpy_ushort](_data_start, _keys_start, shape)
+        _sort[common.cpy_ushort](_data_start, _keys_start, shape, _strm)
     elif dtype == numpy.int32:
-        _sort[common.cpy_int](_data_start, _keys_start, shape)
+        _sort[common.cpy_int](_data_start, _keys_start, shape, _strm)
     elif dtype == numpy.uint32:
-        _sort[common.cpy_uint](_data_start, _keys_start, shape)
+        _sort[common.cpy_uint](_data_start, _keys_start, shape, _strm)
     elif dtype == numpy.int64:
-        _sort[common.cpy_long](_data_start, _keys_start, shape)
+        _sort[common.cpy_long](_data_start, _keys_start, shape, _strm)
     elif dtype == numpy.uint64:
-        _sort[common.cpy_ulong](_data_start, _keys_start, shape)
+        _sort[common.cpy_ulong](_data_start, _keys_start, shape, _strm)
     elif dtype == numpy.float32:
-        _sort[common.cpy_float](_data_start, _keys_start, shape)
+        _sort[common.cpy_float](_data_start, _keys_start, shape, _strm)
     elif dtype == numpy.float64:
-        _sort[common.cpy_double](_data_start, _keys_start, shape)
+        _sort[common.cpy_double](_data_start, _keys_start, shape, _strm)
     else:
         raise NotImplementedError('Sorting arrays with dtype \'{}\' is not '
                                   'supported'.format(dtype))
@@ -60,30 +64,33 @@ cpdef sort(dtype, size_t data_start, size_t keys_start,
 
 cpdef lexsort(dtype, size_t idx_start, size_t keys_start, size_t k, size_t n):
 
+    cdef size_t _strm
+
     idx_ptr = <size_t *>idx_start
     keys_ptr = <void *>keys_start
+    _strm = <size_t>(stream_module.get_current_stream().ptr)
 
     # TODO(takagi): Support float16 and bool
     if dtype == numpy.int8:
-        _lexsort[common.cpy_byte](idx_ptr, keys_ptr, k, n)
+        _lexsort[common.cpy_byte](idx_ptr, keys_ptr, k, n, _strm)
     elif dtype == numpy.uint8:
-        _lexsort[common.cpy_ubyte](idx_ptr, keys_ptr, k, n)
+        _lexsort[common.cpy_ubyte](idx_ptr, keys_ptr, k, n, _strm)
     elif dtype == numpy.int16:
-        _lexsort[common.cpy_short](idx_ptr, keys_ptr, k, n)
+        _lexsort[common.cpy_short](idx_ptr, keys_ptr, k, n, _strm)
     elif dtype == numpy.uint16:
-        _lexsort[common.cpy_ushort](idx_ptr, keys_ptr, k, n)
+        _lexsort[common.cpy_ushort](idx_ptr, keys_ptr, k, n, _strm)
     elif dtype == numpy.int32:
-        _lexsort[common.cpy_int](idx_ptr, keys_ptr, k, n)
+        _lexsort[common.cpy_int](idx_ptr, keys_ptr, k, n, _strm)
     elif dtype == numpy.uint32:
-        _lexsort[common.cpy_uint](idx_ptr, keys_ptr, k, n)
+        _lexsort[common.cpy_uint](idx_ptr, keys_ptr, k, n, _strm)
     elif dtype == numpy.int64:
-        _lexsort[common.cpy_long](idx_ptr, keys_ptr, k, n)
+        _lexsort[common.cpy_long](idx_ptr, keys_ptr, k, n, _strm)
     elif dtype == numpy.uint64:
-        _lexsort[common.cpy_ulong](idx_ptr, keys_ptr, k, n)
+        _lexsort[common.cpy_ulong](idx_ptr, keys_ptr, k, n, _strm)
     elif dtype == numpy.float32:
-        _lexsort[common.cpy_float](idx_ptr, keys_ptr, k, n)
+        _lexsort[common.cpy_float](idx_ptr, keys_ptr, k, n, _strm)
     elif dtype == numpy.float64:
-        _lexsort[common.cpy_double](idx_ptr, keys_ptr, k, n)
+        _lexsort[common.cpy_double](idx_ptr, keys_ptr, k, n, _strm)
     else:
         raise TypeError('Sorting keys with dtype \'{}\' is not '
                         'supported'.format(dtype))
@@ -94,34 +101,44 @@ cpdef argsort(dtype, size_t idx_start, size_t data_start, size_t keys_start,
     cdef size_t *_idx_start
     cdef size_t *_keys_start
     cdef void *_data_start
+    cdef size_t _strm
 
     _idx_start = <size_t *>idx_start
     _data_start = <void *>data_start
     _keys_start = <size_t *>keys_start
+    _strm = <size_t>(stream_module.get_current_stream().ptr)
 
     # TODO(takagi): Support float16 and bool
     if dtype == numpy.int8:
-        _argsort[common.cpy_byte](_idx_start, _data_start, _keys_start, shape)
+        _argsort[common.cpy_byte](
+            _idx_start, _data_start, _keys_start, shape, _strm)
     elif dtype == numpy.uint8:
-        _argsort[common.cpy_ubyte](_idx_start, _data_start, _keys_start, shape)
+        _argsort[common.cpy_ubyte](
+            _idx_start, _data_start, _keys_start, shape, _strm)
     elif dtype == numpy.int16:
-        _argsort[common.cpy_short](_idx_start, _data_start, _keys_start, shape)
+        _argsort[common.cpy_short](
+            _idx_start, _data_start, _keys_start, shape, _strm)
     elif dtype == numpy.uint16:
         _argsort[common.cpy_ushort](
-            _idx_start, _data_start, _keys_start, shape)
+            _idx_start, _data_start, _keys_start, shape, _strm)
     elif dtype == numpy.int32:
-        _argsort[common.cpy_int](_idx_start, _data_start, _keys_start, shape)
+        _argsort[common.cpy_int](
+            _idx_start, _data_start, _keys_start, shape, _strm)
     elif dtype == numpy.uint32:
-        _argsort[common.cpy_uint](_idx_start, _data_start, _keys_start, shape)
+        _argsort[common.cpy_uint](
+            _idx_start, _data_start, _keys_start, shape, _strm)
     elif dtype == numpy.int64:
-        _argsort[common.cpy_long](_idx_start, _data_start, _keys_start, shape)
+        _argsort[common.cpy_long](
+            _idx_start, _data_start, _keys_start, shape, _strm)
     elif dtype == numpy.uint64:
-        _argsort[common.cpy_ulong](_idx_start, _data_start, _keys_start, shape)
+        _argsort[common.cpy_ulong](
+            _idx_start, _data_start, _keys_start, shape, _strm)
     elif dtype == numpy.float32:
-        _argsort[common.cpy_float](_idx_start, _data_start, _keys_start, shape)
+        _argsort[common.cpy_float](
+            _idx_start, _data_start, _keys_start, shape, _strm)
     elif dtype == numpy.float64:
         _argsort[common.cpy_double](
-            _idx_start, _data_start, _keys_start, shape)
+            _idx_start, _data_start, _keys_start, shape, _strm)
     else:
         raise NotImplementedError('Sorting arrays with dtype \'{}\' is not '
                                   'supported'.format(dtype))

--- a/cupy/cuda/thrust.pyx
+++ b/cupy/cuda/thrust.pyx
@@ -7,7 +7,7 @@ import numpy
 from libcpp.vector cimport vector
 
 from cupy.cuda cimport common
-from cupy.cuda import stream as stream_module
+from cupy.cuda cimport stream as stream_module
 
 
 ###############################################################################
@@ -34,7 +34,7 @@ cpdef sort(dtype, size_t data_start, size_t keys_start,
 
     _data_start = <void *>data_start
     _keys_start = <size_t *>keys_start
-    _strm = <size_t>(stream_module.get_current_stream().ptr)
+    _strm = <size_t>(stream_module.get_current_stream_ptr())
 
     # TODO(takagi): Support float16 and bool
     if dtype == numpy.int8:
@@ -68,7 +68,7 @@ cpdef lexsort(dtype, size_t idx_start, size_t keys_start, size_t k, size_t n):
 
     idx_ptr = <size_t *>idx_start
     keys_ptr = <void *>keys_start
-    _strm = <size_t>(stream_module.get_current_stream().ptr)
+    _strm = <size_t>(stream_module.get_current_stream_ptr())
 
     # TODO(takagi): Support float16 and bool
     if dtype == numpy.int8:
@@ -106,7 +106,7 @@ cpdef argsort(dtype, size_t idx_start, size_t data_start, size_t keys_start,
     _idx_start = <size_t *>idx_start
     _data_start = <void *>data_start
     _keys_start = <size_t *>keys_start
-    _strm = <size_t>(stream_module.get_current_stream().ptr)
+    _strm = <size_t>(stream_module.get_current_stream_ptr())
 
     # TODO(takagi): Support float16 and bool
     if dtype == numpy.int8:

--- a/cupy/random/generator.py
+++ b/cupy/random/generator.py
@@ -51,11 +51,6 @@ class RandomState(object):
         if hasattr(self, '_generator'):
             curand.destroyGenerator(self._generator)
 
-    def set_stream(self, stream=None):
-        if stream is None:
-            stream = cuda.Stream()
-        curand.setStream(self._generator, stream.ptr)
-
     def _generate_normal(self, func, size, dtype, *args):
         # curand functions below don't support odd size.
         # * curand.generateNormal

--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -40,6 +40,7 @@ MODULES = [
             'cupy.cuda.profiler',
             'cupy.cuda.nvtx',
             'cupy.cuda.function',
+            'cupy.cuda.stream',
             'cupy.cuda.runtime',
             'cupy.util',
         ],

--- a/docs/source/reference/cuda.rst
+++ b/docs/source/reference/cuda.rst
@@ -44,6 +44,7 @@ Streams and events
    :nosignatures:
 
    cupy.cuda.Stream
+   cupy.cuda.get_current_stream
    cupy.cuda.Event
    cupy.cuda.get_elapsed_time
 

--- a/examples/stream/cublas.py
+++ b/examples/stream/cublas.py
@@ -3,10 +3,17 @@ import cupy
 
 x = cupy.array([1, 2, 3])
 y = cupy.array([[1], [2], [3]])
+expected = cupy.matmul(x, y)
+cupy.cuda.Device().synchronize()
 
-with cupy.cuda.stream.Stream():
+stream = cupy.cuda.stream.Stream()
+with stream:
     z = cupy.matmul(x, y)
+stream.synchronize()
+cupy.testing.assert_array_equal(z, expected)
 
 stream = cupy.cuda.stream.Stream()
 stream.use()
 z = cupy.matmul(x, y)
+stream.synchronize()
+cupy.testing.assert_array_equal(z, expected)

--- a/examples/stream/cublas.py
+++ b/examples/stream/cublas.py
@@ -1,0 +1,12 @@
+# nvprof --print-gpu-trace python examples/stream/cublas.py
+import cupy
+
+x = cupy.array([1, 2, 3])
+y = cupy.array([[1], [2], [3]])
+
+with cupy.cuda.stream.Stream():
+    z = cupy.matmul(x, y)
+
+stream = cupy.cuda.stream.Stream()
+stream.use()
+z = cupy.matmul(x, y)

--- a/examples/stream/cudnn.py
+++ b/examples/stream/cudnn.py
@@ -1,0 +1,13 @@
+# nvprof --print-gpu-trace python examples/stream/cudnn.py
+import cupy
+import cupy.cudnn
+
+x = cupy.array([1.0, 2.0, 3.0])
+mode = cupy.cuda.cudnn.CUDNN_ACTIVATION_RELU
+
+with cupy.cuda.stream.Stream():
+    y = cupy.cudnn.activation_forward(x, mode)
+
+stream = cupy.cuda.stream.Stream()
+stream.use()
+y = cupy.cudnn.activation_forward(x, mode)

--- a/examples/stream/cudnn.py
+++ b/examples/stream/cudnn.py
@@ -4,10 +4,17 @@ import cupy.cudnn
 
 x = cupy.array([1.0, 2.0, 3.0])
 mode = cupy.cuda.cudnn.CUDNN_ACTIVATION_RELU
+expected = cupy.cudnn.activation_forward(x, mode)
+cupy.cuda.Device().synchronize()
 
-with cupy.cuda.stream.Stream():
+stream = cupy.cuda.stream.Stream()
+with stream:
     y = cupy.cudnn.activation_forward(x, mode)
+stream.synchronize()
+cupy.testing.assert_array_equal(y, expected)
 
 stream = cupy.cuda.stream.Stream()
 stream.use()
 y = cupy.cudnn.activation_forward(x, mode)
+stream.synchronize()
+cupy.testing.assert_array_equal(y, expected)

--- a/examples/stream/cupy_event.py
+++ b/examples/stream/cupy_event.py
@@ -16,9 +16,17 @@ def _norm_with_elapsed_time(x):
     return y
 
 
-with cupy.cuda.stream.Stream():
+expected = _norm_with_elapsed_time(x)
+cupy.cuda.Device().synchronize()
+
+stream = cupy.cuda.stream.Stream()
+with stream:
     y = _norm_with_elapsed_time(x)
+stream.synchronize()
+cupy.testing.assert_array_equal(y, expected)
 
 stream = cupy.cuda.stream.Stream()
 stream.use()
 y = _norm_with_elapsed_time(x)
+stream.synchronize()
+cupy.testing.assert_array_equal(y, expected)

--- a/examples/stream/cupy_event.py
+++ b/examples/stream/cupy_event.py
@@ -1,0 +1,24 @@
+# nvprof --print-gpu-trace python examples/stream/cupy_event.py
+import cupy
+
+x = cupy.array([1, 2, 3])
+
+start_event = cupy.cuda.stream.Event()
+stop_event = cupy.cuda.stream.Event()
+
+
+def _norm_with_elapsed_time(x):
+    start_event.record()
+    y = cupy.linalg.norm(x)
+    stop_event.record()
+    stop_event.synchronize()
+    print(cupy.cuda.get_elapsed_time(start_event, stop_event))
+    return y
+
+
+with cupy.cuda.stream.Stream():
+    y = _norm_with_elapsed_time(x)
+
+stream = cupy.cuda.stream.Stream()
+stream.use()
+y = _norm_with_elapsed_time(x)

--- a/examples/stream/cupy_kernel.py
+++ b/examples/stream/cupy_kernel.py
@@ -2,10 +2,17 @@
 import cupy
 
 x = cupy.array([1, 2, 3])
+expected = cupy.linalg.norm(x)
+cupy.cuda.Device().synchronize()
 
-with cupy.cuda.stream.Stream():
+stream = cupy.cuda.stream.Stream()
+with stream:
     y = cupy.linalg.norm(x)
+stream.synchronize()
+cupy.testing.assert_array_equal(y, expected)
 
 stream = cupy.cuda.stream.Stream()
 stream.use()
 y = cupy.linalg.norm(x)
+stream.synchronize()
+cupy.testing.assert_array_equal(y, expected)

--- a/examples/stream/cupy_kernel.py
+++ b/examples/stream/cupy_kernel.py
@@ -1,0 +1,11 @@
+# nvprof --print-gpu-trace python examples/stream/cupy_kernel.py
+import cupy
+
+x = cupy.array([1, 2, 3])
+
+with cupy.cuda.stream.Stream():
+    y = cupy.linalg.norm(x)
+
+stream = cupy.cuda.stream.Stream()
+stream.use()
+y = cupy.linalg.norm(x)

--- a/examples/stream/cupy_memcpy.py
+++ b/examples/stream/cupy_memcpy.py
@@ -1,0 +1,24 @@
+# nvprof --print-gpu-trace python examples/stream/cupy_memcpy.py
+import cupy
+import numpy
+
+pinned_memory_pool = cupy.cuda.PinnedMemoryPool()
+cupy.cuda.set_pinned_memory_allocator(pinned_memory_pool.malloc)
+
+
+def _pin_memory(array):
+    mem = cupy.cuda.alloc_pinned_memory(array.nbytes)
+    ret = numpy.frombuffer(mem, array.dtype, array.size).reshape(array.shape)
+    ret[...] = array
+    return ret
+
+
+x_cpu = numpy.array([1, 2, 3], dtype=numpy.float32)
+x_pinned_cpu = _pin_memory(x_cpu)
+x_gpu = cupy.core.ndarray((3,), dtype=numpy.float32)
+with cupy.cuda.stream.Stream():
+    x_gpu.set(x_pinned_cpu)
+
+stream = cupy.cuda.stream.Stream()
+stream.use()
+x_pinned_cpu = x_gpu.get()

--- a/examples/stream/curand.py
+++ b/examples/stream/curand.py
@@ -1,10 +1,10 @@
 # nvprof --print-gpu-trace python examples/stream/curand.py
 import cupy
 
-x = cupy.array([1, 2, 3])
 rand = cupy.random.generator.RandomState()
 
-with cupy.cuda.stream.Stream():
+stream = cupy.cuda.stream.Stream()
+with stream:
     y = rand.lognormal(size=(1, 3))
 
 stream = cupy.cuda.stream.Stream()

--- a/examples/stream/curand.py
+++ b/examples/stream/curand.py
@@ -1,0 +1,12 @@
+# nvprof --print-gpu-trace python examples/stream/curand.py
+import cupy
+
+x = cupy.array([1, 2, 3])
+rand = cupy.random.generator.RandomState()
+
+with cupy.cuda.stream.Stream():
+    y = rand.lognormal(size=(1, 3))
+
+stream = cupy.cuda.stream.Stream()
+stream.use()
+y = rand.lognormal(size=(1, 3))

--- a/examples/stream/cusolver.py
+++ b/examples/stream/cusolver.py
@@ -1,0 +1,11 @@
+# nvprof --print-gpu-trace python examples/stream/cusolver.py
+import cupy
+
+x = cupy.array([[1, 0, 3], [0, 5, 0], [7, 0, 9]], float)
+
+with cupy.cuda.stream.Stream():
+    w, v = cupy.linalg.eigh(x, UPLO='U')
+
+stream = cupy.cuda.stream.Stream()
+stream.use()
+w, v = cupy.linalg.eigh(x, UPLO='U')

--- a/examples/stream/cusolver.py
+++ b/examples/stream/cusolver.py
@@ -2,10 +2,19 @@
 import cupy
 
 x = cupy.array([[1, 0, 3], [0, 5, 0], [7, 0, 9]], float)
+expected_w, expected_v = cupy.linalg.eigh(x, UPLO='U')
+cupy.cuda.Device().synchronize()
 
-with cupy.cuda.stream.Stream():
+stream = cupy.cuda.stream.Stream()
+with stream:
     w, v = cupy.linalg.eigh(x, UPLO='U')
+stream.synchronize()
+cupy.testing.assert_array_equal(w, expected_w)
+cupy.testing.assert_array_equal(v, expected_v)
 
 stream = cupy.cuda.stream.Stream()
 stream.use()
 w, v = cupy.linalg.eigh(x, UPLO='U')
+stream.synchronize()
+cupy.testing.assert_array_equal(w, expected_w)
+cupy.testing.assert_array_equal(v, expected_v)

--- a/examples/stream/cusparse.py
+++ b/examples/stream/cusparse.py
@@ -13,10 +13,17 @@ def _make(xp, sp, dtype):
 
 
 x = _make(cupy, cupy.sparse, float)
+expected = cupy.cusparse.cscsort(x)
+cupy.cuda.Device().synchronize()
 
-with cupy.cuda.stream.Stream():
+stream = cupy.cuda.stream.Stream()
+with stream:
     y = cupy.cusparse.cscsort(x)
+stream.synchronize()
+cupy.testing.assert_array_equal(y, expected)
 
 stream = cupy.cuda.stream.Stream()
 stream.use()
 y = cupy.cusparse.cscsort(x)
+stream.synchronize()
+cupy.testing.assert_array_equal(y, expected)

--- a/examples/stream/cusparse.py
+++ b/examples/stream/cusparse.py
@@ -1,0 +1,22 @@
+# nvprof --print-gpu-trace python examples/stream/cusparse.py
+import cupy
+
+
+def _make(xp, sp, dtype):
+    data = xp.array([0, 1, 3, 2], dtype)
+    indices = xp.array([0, 0, 2, 1], 'i')
+    indptr = xp.array([0, 1, 2, 3, 4], 'i')
+    # 0, 1, 0, 0
+    # 0, 0, 0, 2
+    # 0, 0, 3, 0
+    return sp.csc_matrix((data, indices, indptr), shape=(3, 4))
+
+
+x = _make(cupy, cupy.sparse, float)
+
+with cupy.cuda.stream.Stream():
+    y = cupy.cusparse.cscsort(x)
+
+stream = cupy.cuda.stream.Stream()
+stream.use()
+y = cupy.cusparse.cscsort(x)

--- a/examples/stream/map_reduce.py
+++ b/examples/stream/map_reduce.py
@@ -1,0 +1,47 @@
+import cupy
+import time
+
+device = cupy.cuda.Device()
+memory_pool = cupy.cuda.MemoryPool()
+cupy.cuda.set_allocator(memory_pool.malloc)
+rand = cupy.random.generator.RandomState(seed=1)
+
+n = 10
+zs = []
+map_streams = []
+stop_events = []
+reduce_stream = cupy.cuda.stream.Stream()
+for i in range(n):
+    map_streams.append(cupy.cuda.stream.Stream())
+
+start_time = time.time()
+
+# Map
+for stream in map_streams:
+    with stream:
+        x = rand.normal(size=(1, 1024 * 256))
+        y = rand.normal(size=(1024 * 256, 1))
+        z = cupy.matmul(x, y)
+        zs.append(z)
+    stop_event = stream.record()
+    stop_events.append(stop_event)
+
+# Block the `reduce_stream` until all events occur. This does not block host.
+# This is not required when reduction is performed in the default (Stream.null)
+# stream unless streams are created with `non_blocking=True` flag.
+for i in range(n):
+    reduce_stream.wait_event(stop_events[i])
+
+# Reduce
+with reduce_stream:
+    z = sum(zs)
+
+device.synchronize()
+elapsed_time = time.time() - start_time
+print('elapsed time', elapsed_time)
+print('total bytes', memory_pool.total_bytes())
+
+# Free all blocks in the memory pool of streams
+for stream in map_streams:
+    memory_pool.free_all_blocks(stream=stream)
+print('total bytes', memory_pool.total_bytes())

--- a/examples/stream/thrust.py
+++ b/examples/stream/thrust.py
@@ -1,0 +1,11 @@
+# nvprof --print-gpu-trace python examples/stream/thrust.py
+import cupy
+
+x = cupy.array([1, 2, 3])
+
+with cupy.cuda.stream.Stream():
+    y = x.sort()
+
+stream = cupy.cuda.stream.Stream()
+stream.use()
+y = x.sort()

--- a/examples/stream/thrust.py
+++ b/examples/stream/thrust.py
@@ -1,11 +1,18 @@
 # nvprof --print-gpu-trace python examples/stream/thrust.py
 import cupy
 
-x = cupy.array([1, 2, 3])
+x = cupy.array([1, 3, 2])
+expected = x.sort()
+cupy.cuda.Device().synchronize()
 
-with cupy.cuda.stream.Stream():
+stream = cupy.cuda.stream.Stream()
+with stream:
     y = x.sort()
+stream.synchronize()
+cupy.testing.assert_array_equal(y, expected)
 
 stream = cupy.cuda.stream.Stream()
 stream.use()
 y = x.sort()
+stream.synchronize()
+cupy.testing.assert_array_equal(y, expected)

--- a/install/build.py
+++ b/install/build.py
@@ -119,6 +119,7 @@ def get_compiler_setting():
         'library_dirs': library_dirs,
         'define_macros': define_macros,
         'language': 'c++',
+        'extra_compile_args': ['-std=c++11'],
     }
 
 

--- a/tests/cupy_tests/cuda_tests/test_memory.py
+++ b/tests/cupy_tests/cuda_tests/test_memory.py
@@ -291,6 +291,23 @@ class TestSingleDeviceMemoryPool(unittest.TestCase):
             p2 = self.pool.malloc(self.unit * 4)
             ptr2 = p2.ptr
             del p2
+        self.pool.free_all_blocks(stream=stream_module.Stream.null)
+        p3 = self.pool.malloc(self.unit * 4)
+        self.assertNotEqual(ptr1, p3.ptr)
+        self.assertNotEqual(ptr2, p3.ptr)
+        with self.stream:
+            p4 = self.pool.malloc(self.unit * 4)
+            self.assertNotEqual(ptr1, p4.ptr)
+            self.assertEqual(ptr2, p4.ptr)
+
+    def test_free_all_blocks_all_streams(self):
+        p1 = self.pool.malloc(self.unit * 4)
+        ptr1 = p1.ptr
+        del p1
+        with self.stream:
+            p2 = self.pool.malloc(self.unit * 4)
+            ptr2 = p2.ptr
+            del p2
         self.pool.free_all_blocks()
         p3 = self.pool.malloc(self.unit * 4)
         self.assertNotEqual(ptr1, p3.ptr)

--- a/tests/cupy_tests/cuda_tests/test_stream.py
+++ b/tests/cupy_tests/cuda_tests/test_stream.py
@@ -1,5 +1,6 @@
 import unittest
 
+from cupy.creation import from_data
 from cupy import cuda
 from cupy import testing
 from cupy.testing import attr
@@ -15,6 +16,17 @@ class TestStream(unittest.TestCase):
         with cuda.Device():
             stream = cuda.Stream()
             self.assertEqual(0, stream.device)
+
+    @attr.gpu
+    def test_del(self):
+        stream = cuda.Stream().use()
+        stream_ptr = stream.ptr
+        x = from_data.array([1, 2, 3])
+        del stream
+        # Want to test cudaStreamDestory is issued, but
+        # runtime.streamQuery(stream_ptr) causes SEGV. We cannot test...
+        del stream_ptr
+        del x
 
     @attr.gpu
     def test_get_and_add_callback(self):

--- a/tests/cupy_tests/cuda_tests/test_stream.py
+++ b/tests/cupy_tests/cuda_tests/test_stream.py
@@ -11,6 +11,11 @@ class TestStream(unittest.TestCase):
         with self.assertRaises(ValueError):
             cuda.Stream(null=True)
 
+        self.assertEqual(None, cuda.Stream.null.device)
+        with cuda.Device():
+            stream = cuda.Stream()
+            self.assertEqual(0, stream.device)
+
     @attr.gpu
     def test_get_and_add_callback(self):
         N = 100

--- a/tests/cupy_tests/cuda_tests/test_stream.py
+++ b/tests/cupy_tests/cuda_tests/test_stream.py
@@ -7,16 +7,6 @@ from cupy.testing import attr
 
 
 class TestStream(unittest.TestCase):
-
-    def test_init(self):
-        with self.assertRaises(ValueError):
-            cuda.Stream(null=True)
-
-        self.assertEqual(None, cuda.Stream.null.device)
-        with cuda.Device():
-            stream = cuda.Stream()
-            self.assertEqual(0, stream.device)
-
     @attr.gpu
     def test_del(self):
         stream = cuda.Stream().use()
@@ -62,16 +52,3 @@ class TestStream(unittest.TestCase):
         self.assertEqual(stream1, cuda.get_current_stream())
         cuda.Stream.null.use()
         self.assertEqual(cuda.Stream.null, cuda.get_current_stream())
-
-    @testing.multi_gpu(2)
-    def test_get_current_stream_on_another_device(self):
-        with cuda.Device(0):
-            stream0 = cuda.Stream()
-            stream0.use()
-        with self.assertRaises(ValueError):
-            with cuda.Device(1):
-                cuda.get_current_stream()
-        # Stream.null is available on all devices
-        cuda.Stream.null.use()
-        with cuda.Device(1):
-            cuda.get_current_stream()

--- a/tests/cupy_tests/cuda_tests/test_stream.py
+++ b/tests/cupy_tests/cuda_tests/test_stream.py
@@ -50,3 +50,16 @@ class TestStream(unittest.TestCase):
         self.assertEqual(stream1, cuda.get_current_stream())
         cuda.Stream.null.use()
         self.assertEqual(cuda.Stream.null, cuda.get_current_stream())
+
+    @testing.multi_gpu(2)
+    def test_get_current_stream_on_another_device(self):
+        with cuda.Device(0):
+            stream0 = cuda.Stream()
+            stream0.use()
+        with self.assertRaises(ValueError):
+            with cuda.Device(1):
+                cuda.get_current_stream()
+        # Stream.null is available on all devices
+        cuda.Stream.null.use()
+        with cuda.Device(1):
+            cuda.get_current_stream()

--- a/tests/cupy_tests/cuda_tests/test_stream.py
+++ b/tests/cupy_tests/cuda_tests/test_stream.py
@@ -22,3 +22,22 @@ class TestStream(unittest.TestCase):
 
         stream.synchronize()
         self.assertEqual(out, list(range(N)))
+
+    @attr.gpu
+    def test_with_statement(self):
+        stream1 = cuda.Stream()
+        stream2 = cuda.Stream()
+        self.assertEqual(cuda.Stream.null, cuda.get_current_stream())
+        with stream1:
+            self.assertEqual(stream1, cuda.get_current_stream())
+            with stream2:
+                self.assertEqual(stream2, cuda.get_current_stream())
+            self.assertEqual(stream1, cuda.get_current_stream())
+        self.assertEqual(cuda.Stream.null, cuda.get_current_stream())
+
+    @attr.gpu
+    def test_use(self):
+        stream1 = cuda.Stream().use()
+        self.assertEqual(stream1, cuda.get_current_stream())
+        cuda.Stream.null.use()
+        self.assertEqual(cuda.Stream.null, cuda.get_current_stream())

--- a/tests/cupy_tests/cuda_tests/test_stream.py
+++ b/tests/cupy_tests/cuda_tests/test_stream.py
@@ -7,6 +7,10 @@ from cupy.testing import attr
 
 class TestStream(unittest.TestCase):
 
+    def test_init(self):
+        with self.assertRaises(ValueError):
+            cuda.Stream(null=True)
+
     @attr.gpu
     def test_get_and_add_callback(self):
         N = 100


### PR DESCRIPTION
Fix https://github.com/cupy/cupy/issues/225

Support CUDA stream. `stream` can be specified with `with` statement or `use()` method as:

```python
import cupy as cp

x_gpu = cp.array([1, 2, 3])

with cp.cuda.stream.Stream():
   y_gpu = cp.linalg.norm(x_gpu)

stream = cp.cuda.stream.Stream()
stream.use()
y_gpu = cp.linalg.norm(x_gpu)
```

`nvprof --print-gpu-trace python ~/test_cupy.py` shows cupy kernels are executed in another stream.

To support CUDA stream, this PR changes memory pool, too.
A memory pool is created for **each stream** separately so that parallel computations among streams do not touch memory used in another stream.

Note that cudaMalloc is issued on default stream always.

## Incompatibility changes:

* `cupy.cuda.generator.RandomState`: `setStream()` method was removed
* `cupy.cuda.stream.Stream(null=True)` is prohibited to assure `cupy.cuda.stream.Stream.null` object is always used to specify the default stream.