### PR TITLE
Skip cross compile on setup.py develop to build faster

### DIFF
--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -416,7 +416,10 @@ def _nvcc_gencode_options(cuda_version):
             options.append('--generate-code=arch={},code={}'.format(
                 arch, arch))
 
-    return options
+    if sys.argv == ['setup.py', 'develop']:
+        return []
+    else:
+        return options
 
 
 class _UnixCCompiler(unixccompiler.UnixCCompiler):


### PR DESCRIPTION
I am not sure whether this is acceptable, but this patch made the building time of `python setup.py develop` faster from `3:24.88` to `2:30.71` by skipping cross compile. This makes me feel good on development.