### PR TITLE
Support order argument in toarray method of csc and csr

### DIFF
--- a/cupy/sparse/csc.py
+++ b/cupy/sparse/csc.py
@@ -83,7 +83,8 @@ class csc_matrix(compressed._compressed_sparse_matrix):
         """Returns a dense matrix representing the same value.
 
         Args:
-            order: Not supported.
+            order ({'C', 'F', None}): Whether to store data in C (row-major)
+                order or F (column-major) order. Default is C-order.
             out: Not supported.
 
         Returns:
@@ -92,9 +93,17 @@ class csc_matrix(compressed._compressed_sparse_matrix):
         .. seealso:: :func:`cupy.sparse.csc_array.toarray`
 
         """
-        # csc2dense returns F-contiguous array.
-        # To return C-contiguous array, it uses transpose.
-        return cusparse.csr2dense(self.T).T
+        if order is None:
+            order = 'C'
+
+        # csc2dense and csr2dense returns F-contiguous array.
+        if order == 'C':
+            # To return C-contiguous array, it uses transpose.
+            return cusparse.csr2dense(self.T).T
+        elif order == 'F':
+            return cusparse.csc2dense(self)
+        else:
+            raise TypeError('order not understood')
 
     # TODO(unno): Implement tobsr
 

--- a/cupy/sparse/csr.py
+++ b/cupy/sparse/csr.py
@@ -83,7 +83,8 @@ class csr_matrix(compressed._compressed_sparse_matrix):
         """Returns a dense matrix representing the same value.
 
         Args:
-            order (str): Not supported.
+            order ({'C', 'F', None}): Whether to store data in C (row-major)
+                order or F (column-major) order. Default is C-order.
             out: Not supported.
 
         Returns:
@@ -92,9 +93,17 @@ class csr_matrix(compressed._compressed_sparse_matrix):
         .. seealso:: :func:`cupy.sparse.csr_array.toarray`
 
         """
+        if order is None:
+            order = 'C'
+
         # csr2dense returns F-contiguous array.
-        # To return C-contiguous array, it uses transpose.
-        return cusparse.csc2dense(self.T).T
+        if order == 'C':
+            # To return C-contiguous array, it uses transpose.
+            return cusparse.csc2dense(self.T).T
+        elif order == 'F':
+            return cusparse.csr2dense(self)
+        else:
+            raise TypeError('order not understood')
 
     # TODO(unno): Implement tobsr
 

--- a/tests/cupy_tests/sparse_tests/test_csc.py
+++ b/tests/cupy_tests/sparse_tests/test_csc.py
@@ -211,6 +211,25 @@ class TestCscMatrixScipyComparison(unittest.TestCase):
         return a
 
     @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_toarray_c_order(self, xp, sp):
+        m = _make(xp, sp, self.dtype)
+        a = m.toarray(order='C')
+        self.assertTrue(a.flags.c_contiguous)
+        return a
+
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_toarray_f_order(self, xp, sp):
+        m = _make(xp, sp, self.dtype)
+        a = m.toarray(order='F')
+        self.assertTrue(a.flags.f_contiguous)
+        return a
+
+    @testing.numpy_cupy_raises(sp_name='sp', accept_error=TypeError)
+    def test_toarray_unknown_order(self, xp, sp):
+        m = _make(xp, sp, self.dtype)
+        m.toarray(order='unknown')
+
+    @testing.numpy_cupy_allclose(sp_name='sp')
     def test_tocoo(self, xp, sp):
         m = _make(xp, sp, self.dtype)
         return m.tocoo().toarray()

--- a/tests/cupy_tests/sparse_tests/test_csr.py
+++ b/tests/cupy_tests/sparse_tests/test_csr.py
@@ -214,6 +214,25 @@ class TestCsrMatrixScipyComparison(unittest.TestCase):
         return a
 
     @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_toarray_c_order(self, xp, sp):
+        m = _make(xp, sp, self.dtype)
+        a = m.toarray(order='C')
+        self.assertTrue(a.flags.c_contiguous)
+        return a
+
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_toarray_f_order(self, xp, sp):
+        m = _make(xp, sp, self.dtype)
+        a = m.toarray(order='F')
+        self.assertTrue(a.flags.f_contiguous)
+        return a
+
+    @testing.numpy_cupy_raises(sp_name='sp', accept_error=TypeError)
+    def test_toarray_unknown_order(self, xp, sp):
+        m = _make(xp, sp, self.dtype)
+        m.toarray(order='unknown')
+
+    @testing.numpy_cupy_allclose(sp_name='sp')
     def test_tocoo(self, xp, sp):
         m = _make(xp, sp, self.dtype)
         return m.tocoo().toarray()


### PR DESCRIPTION
It supports `order` argument in `toarray` method of sparse matrixes.