### PR TITLE
Tell the memory size when cudaErrorMemoryAllocation occurred

### DIFF
--- a/cupy/cuda/memory.pxd
+++ b/cupy/cuda/memory.pxd
@@ -1,9 +1,5 @@
 from cupy.cuda cimport device
 
-
-cdef class OutOfMemoryError(Exception):
-    pass
-
 cdef class Memory:
 
     cdef:

--- a/cupy/cuda/memory.pxd
+++ b/cupy/cuda/memory.pxd
@@ -1,5 +1,9 @@
 from cupy.cuda cimport device
 
+
+cdef class OutOfMemoryError(Exception):
+    pass
+
 cdef class Memory:
 
     cdef:

--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -12,7 +12,7 @@ from cupy.cuda cimport device
 from cupy.cuda cimport runtime
 
 
-cdef class OutOfMemoryError(Exception):
+class OutOfMemoryError(MemoryError):
 
     def __init__(self, size, total):
         msg = 'out of memory to allocate %d bytes ' \


### PR DESCRIPTION
Fix https://github.com/cupy/cupy/issues/185

Error message becomes as following:

    cupy.cuda.memory.OutOfMemoryError: out of memory to allocate XXXX bytes (total YYYY bytes)

instead of:

    cupy.cuda.runtime.CUDARuntimeError: cudaErrorMemoryAllocation: out of memory