### PR TITLE
csr and csc matrixes' initializers support shape

### DIFF
--- a/cupy/sparse/compressed.py
+++ b/cupy/sparse/compressed.py
@@ -1,9 +1,11 @@
 import numpy
 
 import cupy
+from cupy.creation import basic
 from cupy import cusparse
 from cupy.sparse import base
 from cupy.sparse import data as sparse_data
+from cupy.sparse import util
 
 
 class _compressed_sparse_matrix(sparse_data._data_matrix):
@@ -25,6 +27,16 @@ class _compressed_sparse_matrix(sparse_data._data_matrix):
 
             if shape is None:
                 shape = arg1.shape
+
+        elif util.isshape(arg1):
+            m, n = arg1
+            m, n = int(m), int(n)
+            data = basic.zeros(0, dtype if dtype else 'd')
+            indices = basic.zeros(0, 'i')
+            indptr = basic.zeros(self._swap(m, n)[0] + 1, dtype='i')
+            # shape and copy argument is ignored
+            shape = (m, n)
+            copy = False
 
         elif isinstance(arg1, tuple) and len(arg1) == 3:
             data, indices, indptr = arg1

--- a/cupy/sparse/csc.py
+++ b/cupy/sparse/csc.py
@@ -17,6 +17,9 @@ class csc_matrix(compressed._compressed_sparse_matrix):
 
     ``csc_matrix(S)``
         ``S`` is another sparse matrix. It is equivalent to ``S.tocsc()``.
+    ``csc_matrix((M, N), [dtype])``
+        It constructs an empty matrix whose shape is ``(M, N)``. Default dtype
+        is flat64.
     ``csc_matrix((data, indices, indptr))``
         All ``data``, ``indices`` and ``indptr`` are one-dimenaional
         :class:`cupy.ndarray`.

--- a/cupy/sparse/csr.py
+++ b/cupy/sparse/csr.py
@@ -17,6 +17,9 @@ class csr_matrix(compressed._compressed_sparse_matrix):
 
     ``csr_matrix(S)``
         ``S`` is another sparse matrix. It is equivalent to ``S.tocsr()``.
+    ``csr_matrix((M, N), [dtype])``
+        It constructs an empty matrix whose shape is ``(M, N)``. Default dtype
+        is flat64.
     ``csr_matrix((data, indices, indptr))``
         All ``data``, ``indices`` and ``indptr`` are one-dimenaional
         :class:`cupy.ndarray`.

--- a/cupy/sparse/util.py
+++ b/cupy/sparse/util.py
@@ -1,0 +1,5 @@
+def isshape(x):
+    if not isinstance(x, tuple) or len(x) != 2:
+        return False
+    m, n = x
+    return int(m) == m and int(n) == n

--- a/tests/cupy_tests/sparse_tests/test_csc.py
+++ b/tests/cupy_tests/sparse_tests/test_csc.py
@@ -172,6 +172,22 @@ class TestCscMatrixInit(unittest.TestCase):
         self.assertIsNot(indices, x.indices)
         self.assertIsNot(indptr, x.indptr)
 
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_init_with_shape(self, xp, sp):
+        s = sp.csc_matrix(self.shape)
+        self.assertEqual(s.shape, self.shape)
+        self.assertEqual(s.dtype, 'd')
+        self.assertEqual(s.size, 0)
+        return s.toarray()
+
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_init_with_shape_and_dtype(self, xp, sp):
+        s = sp.csc_matrix(self.shape, dtype=self.dtype)
+        self.assertEqual(s.shape, self.shape)
+        self.assertEqual(s.dtype, self.dtype)
+        self.assertEqual(s.size, 0)
+        return s.toarray()
+
     @testing.numpy_cupy_raises(sp_name='sp')
     def test_shape_invalid(self, xp, sp):
         sp.csc_matrix(

--- a/tests/cupy_tests/sparse_tests/test_csr.py
+++ b/tests/cupy_tests/sparse_tests/test_csr.py
@@ -175,6 +175,22 @@ class TestCsrMatrixInit(unittest.TestCase):
         self.assertIsNot(indices, x.indices)
         self.assertIsNot(indptr, x.indptr)
 
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_init_with_shape(self, xp, sp):
+        s = sp.csr_matrix(self.shape)
+        self.assertEqual(s.shape, self.shape)
+        self.assertEqual(s.dtype, 'd')
+        self.assertEqual(s.size, 0)
+        return s.toarray()
+
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_init_with_shape_and_dtype(self, xp, sp):
+        s = sp.csr_matrix(self.shape, dtype=self.dtype)
+        self.assertEqual(s.shape, self.shape)
+        self.assertEqual(s.dtype, self.dtype)
+        self.assertEqual(s.size, 0)
+        return s.toarray()
+
     @testing.numpy_cupy_raises(sp_name='sp')
     def test_shape_invalid(self, xp, sp):
         sp.csr_matrix(


### PR DESCRIPTION
It support this type of initializer: `csc_matrix((m, n))`
merge #236 first