### PR TITLE
Implement sum_duplicates

### DIFF
--- a/cupy/sparse/coo.py
+++ b/cupy/sparse/coo.py
@@ -279,6 +279,7 @@ class coo_matrix(sparse_data._data_matrix):
         """
         if self.nnz == 0:
             return csr.csr_matrix(self.shape, dtype=self.dtype)
+        self.sum_duplicates()
         # copy is ignored because coosort method breaks an original.
         x = self.copy()
         cusparse.coosort(x)

--- a/cupy/sparse/coo.py
+++ b/cupy/sparse/coo.py
@@ -54,6 +54,7 @@ class coo_matrix(sparse_data._data_matrix):
             # shape and copy argument is ignored
             shape = (m, n)
             copy = False
+            has_canonical_format = True
 
         elif isinstance(arg1, tuple) and len(arg1) == 2:
             try:

--- a/cupy/sparse/coo.py
+++ b/cupy/sparse/coo.py
@@ -171,6 +171,9 @@ class coo_matrix(sparse_data._data_matrix):
         """
         if self._has_canonical_format:
             return
+        if self.data.size == 0:
+            self._has_canonical_format = True
+            return
         keys = cupy.stack([self.row, self.col])
         order = cupy.lexsort(keys)
         src_data = self.data[order]

--- a/cupy/sparse/coo.py
+++ b/cupy/sparse/coo.py
@@ -212,7 +212,8 @@ class coo_matrix(sparse_data._data_matrix):
                 row[index] = src_row;
                 col[index] = src_col;
                 ''',
-                'sum_duplicates_assign'
+                'sum_duplicates_assign',
+                preamble=util._preamble_atomic_add
             )(src_data, src_row, src_col, index, data, row, col)
 
         self.data = data

--- a/cupy/sparse/coo.py
+++ b/cupy/sparse/coo.py
@@ -117,11 +117,15 @@ class coo_matrix(sparse_data._data_matrix):
         self.row = row
         self.col = col
         self._shape = shape
-        self.has_canonical_format = has_canonical_format
+        self._has_canonical_format = has_canonical_format
 
     def _with_data(self, data):
         return coo_matrix(
             (data, (self.row.copy(), self.col.copy())), shape=self.shape)
+
+    @property
+    def has_canonical_format(self):
+        return self._has_canonical_format
 
     def get_shape(self):
         """Returns the shape of the matrix.
@@ -159,7 +163,7 @@ class coo_matrix(sparse_data._data_matrix):
             (data, (row, col)), shape=self.shape)
 
     def sum_duplicates(self):
-        if self.has_canonical_format:
+        if self._has_canonical_format:
             return
         keys = cupy.stack([self.row, self.col])
         order = cupy.lexsort(keys)
@@ -198,7 +202,7 @@ class coo_matrix(sparse_data._data_matrix):
         self.data = data
         self.row = row
         self.col = col
-        self.has_canonical_format = True
+        self._has_canonical_format = True
 
     def toarray(self, order=None, out=None):
         """Returns a dense matrix representing the same value.

--- a/cupy/sparse/coo.py
+++ b/cupy/sparse/coo.py
@@ -163,6 +163,12 @@ class coo_matrix(sparse_data._data_matrix):
             (data, (row, col)), shape=self.shape)
 
     def sum_duplicates(self):
+        """Eliminate duplicate matrix entries by adding them together.
+
+        .. see::
+           :func:`scipy.sparse.coo_matrix.sum_duplicates`
+
+        """
         if self._has_canonical_format:
             return
         keys = cupy.stack([self.row, self.col])

--- a/cupy/sparse/util.py
+++ b/cupy/sparse/util.py
@@ -1,6 +1,24 @@
 import cupy
 
 
+_preamble_atomic_add = '''
+#if __CUDA_ARCH__ < 600
+__device__ double atomicAdd(double* address, double val) {
+    unsigned long long int* address_as_ull =
+                                          (unsigned long long int*)address;
+    unsigned long long int old = *address_as_ull, assumed;
+    do {
+        assumed = old;
+        old = atomicCAS(address_as_ull, assumed,
+                        __double_as_longlong(val +
+                        __longlong_as_double(assumed)));
+    } while (assumed != old);
+    return __longlong_as_double(old);
+}
+#endif
+'''
+
+
 def isintlike(x):
     try:
         return bool(int(x) == x)

--- a/tests/cupy_tests/sparse_tests/test_coo.py
+++ b/tests/cupy_tests/sparse_tests/test_coo.py
@@ -264,7 +264,9 @@ class TestCooMatrixInit(unittest.TestCase):
 
 
 @testing.parameterize(*testing.product({
-    'make_method': ['_make', '_make_unordered', '_make_empty', '_make_shape'],
+    'make_method': [
+        '_make', '_make_unordered', '_make_empty', '_make_duplicate',
+        '_make_shape'],
     'dtype': [numpy.float32, numpy.float64],
 }))
 @unittest.skipUnless(scipy_available, 'requires scipy')
@@ -303,6 +305,13 @@ class TestCooMatrixScipyComparison(unittest.TestCase):
     def test_transpose(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
         return m.transpose().toarray()
+
+
+@testing.parameterize(*testing.product({
+    'dtype': [numpy.float32, numpy.float64],
+}))
+@unittest.skipUnless(scipy_available, 'requires scipy')
+class TestCooMatrixSumDuplicates(unittest.TestCase):
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_sum_duplicates(self, xp, sp):

--- a/tests/cupy_tests/sparse_tests/test_coo.py
+++ b/tests/cupy_tests/sparse_tests/test_coo.py
@@ -341,8 +341,7 @@ class TestCooMatrixSumDuplicates(unittest.TestCase):
         m.sum_duplicates()
         self.assertTrue(m.has_canonical_format)
         self.assertEqual(m.nnz, 0)
-        a = m.toarray()
-        return a
+        return m.toarray()
 
 
 @testing.parameterize(*testing.product({


### PR DESCRIPTION
I implemented `sum_duplicates` for `coo_matrix`. Its bottleneck is `cumsum`, but we can make more efficient implementation:
http://people.cs.vt.edu/yongcao/teaching/cs5234/spring2013/slides/Lecture10.pdf
merge #328 first.
related to #36 