### PR TITLE
Move development guides from README to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,55 +98,7 @@ $ nvidia-docker run -it cupy/cupy /bin/bash
 
 ## Development
 
-Build CuPy from the source code as:
-
-```
-python setup.py develop
-```
-
-Run all tests as:
-
-```
-nosetests --processes=4 --process-timeout=10000 --stop -a '!slow'
-```
-
-Run a specific test file, or a specific test method respectively:
-
-```
-python -m unittest tests/cupy_tests/cuda_tests/test_memory.py
-python -m unittest tests.cupy_tests.cuda_tests.test_memory.TestMemoryPointer.test_int
-```
-
-Run doctest as:
-
-```
-( cd docs && make doctest )
-```
-
-### Rebuild pxd files
-
-Currently, we have problems that cython does not rebuild pxd files well with `python setup.py develop`.
-
-Clean `*.cpp` and `*.so` files once with:
-
-```
-git clean -fdx
-```
-
-Then, run `python setup.py develop` again.
-
-### ccache
-
-We do not officially support, but some of the developer members use [ccache](https://ccache.samba.org/) to boost compilation time.
-
-For example, on Ubuntu, set up as followings:
-
-```
-sudo apt-get install ccache
-export PATH=/usr/lib/ccache:$PATH
-```
-
-See [ccache](https://ccache.samba.org/) for details.
+Please see the [For CuPy Developers](https://docs-cupy.chainer.org/en/stable/developers.html) document.
 
 ## More information
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ $ nvidia-docker run -it cupy/cupy /bin/bash
 
 ## Development
 
-Please see the [For CuPy Developers](https://docs-cupy.chainer.org/en/stable/developers.html) document.
+Please see [the documentation for developers](https://docs-cupy.chainer.org/en/stable/developers.html).
 
 ## More information
 

--- a/docs/source/contribution.rst
+++ b/docs/source/contribution.rst
@@ -255,7 +255,7 @@ Note that reviewers will test your code without the option to check CUDA-related
    Some of numerically unstable tests might cause errors irrelevant to your changes.
    In such a case, we ignore the failures and go on to the review process, so do not worry about it.
 
-We leverage doctest as well, you can run doctest by typing ``make doctest`` at the ``docs`` directory::
+We leverage doctest as well. You can run doctest by typing ``make doctest`` at the ``docs`` directory::
 
   $ cd docs
   $ make doctest

--- a/docs/source/contribution.rst
+++ b/docs/source/contribution.rst
@@ -149,19 +149,21 @@ In order to run unit tests at the repository root, you first have to build Cytho
 
   $ python setup.py develop
 
-Please note that when you modify ``*.pxd`` files, you must clean ``*.cpp`` and ``*.so`` files once with::
+.. note::
+
+  When you modify ``*.pxd`` files, before running ``python setup.py develop``, you must clean ``*.cpp`` and ``*.so`` files once with the following command, because Cython does not automatically rebuild those files nicely::
+    
+    $ git clean -fdx
+
+.. note::
+
+  It's not officially supported, but you can use `ccache <https://ccache.samba.org/>`_ to reduce compilation time.
+  On Ubuntu 16.04, you can set up as follows::
   
-  $ git clean -fdx
-
-before running ``python setup.py develop`` because currently, we have problems that Cython does not automatically rebuild modified pxd files well.
-
-We do not officially support, but some of the core developer members use `ccache <https://ccache.samba.org/>`_ to boost compilation time.
-For example, on Ubuntu, set up as followings::
-
-  $ sudo apt-get install ccache
-  $ export PATH=/usr/lib/ccache:$PATH
-
-See `ccache <https://ccache.samba.org/>`_ for details.
+    $ sudo apt-get install ccache
+    $ export PATH=/usr/lib/ccache:$PATH
+  
+  See `ccache <https://ccache.samba.org/>`_ for details.
 
 Testing Guidelines
 ------------------
@@ -256,7 +258,7 @@ Note that reviewers will test your code without the option to check CUDA-related
    Some of numerically unstable tests might cause errors irrelevant to your changes.
    In such a case, we ignore the failures and go on to the review process, so do not worry about it.
 
-We leverage doctest also, you can run doctest by typing ``make doctest`` at the ``docs`` directory::
+We leverage doctest as well, you can run doctest by typing ``make doctest`` at the ``docs`` directory::
 
   $ cd docs
   $ make doctest

--- a/docs/source/contribution.rst
+++ b/docs/source/contribution.rst
@@ -142,29 +142,6 @@ Please note the followings when writing the document.
   the document.
 
 
-Building Guidelines
--------------------
-
-In order to run unit tests at the repository root, you first have to build Cython files in place by running the following command::
-
-  $ python setup.py develop
-
-.. note::
-
-  When you modify ``*.pxd`` files, before running ``python setup.py develop``, you must clean ``*.cpp`` and ``*.so`` files once with the following command, because Cython does not automatically rebuild those files nicely::
-    
-    $ git clean -fdx
-
-.. note::
-
-  It's not officially supported, but you can use `ccache <https://ccache.samba.org/>`_ to reduce compilation time.
-  On Ubuntu 16.04, you can set up as follows::
-  
-    $ sudo apt-get install ccache
-    $ export PATH=/usr/lib/ccache:$PATH
-  
-  See `ccache <https://ccache.samba.org/>`_ for details.
-
 Testing Guidelines
 ------------------
 
@@ -174,7 +151,27 @@ Note that we are using the nose package and the mock package for testing, so ins
 
   $ pip install nose mock
 
-Once the Cython modules are built by ``python setup.py develop``, you can run unit tests simply by running ``nosetests`` command at the repository root::
+In order to run unit tests at the repository root, you first have to build Cython files in place by running the following command::
+
+  $ python setup.py develop
+
+.. note::
+
+  When you modify ``*.pxd`` files, before running ``python setup.py develop``, you must clean ``*.cpp`` and ``*.so`` files once with the following command, because Cython does not automatically rebuild those files nicely::
+
+    $ git clean -fdx
+
+.. note::
+
+  It's not officially supported, but you can use `ccache <https://ccache.samba.org/>`_ to reduce compilation time.
+  On Ubuntu 16.04, you can set up as follows::
+
+    $ sudo apt-get install ccache
+    $ export PATH=/usr/lib/ccache:$PATH
+
+  See `ccache <https://ccache.samba.org/>`_ for details.
+
+Once the Cython modules are built, you can run unit tests simply by running ``nosetests`` command at the repository root::
 
   $ nosetests
 

--- a/docs/source/contribution.rst
+++ b/docs/source/contribution.rst
@@ -142,6 +142,27 @@ Please note the followings when writing the document.
   the document.
 
 
+Building Guidelines
+-------------------
+
+In order to run unit tests at the repository root, you first have to build Cython files in place by running the following command::
+
+  $ python setup.py develop
+
+Please note that when you modify ``*.pxd`` files, you must clean ``*.cpp`` and ``*.so`` files once with::
+  
+  $ git clean -fdx
+
+before running ``python setup.py develop`` because currently, we have problems that Cython does not automatically rebuild modified pxd files well.
+
+We do not officially support, but some of the core developer members use `ccache <https://ccache.samba.org/>`_ to boost compilation time.
+For example, on Ubuntu, set up as followings::
+
+  $ sudo apt-get install ccache
+  $ export PATH=/usr/lib/ccache:$PATH
+
+See `ccache <https://ccache.samba.org/>`_ for details.
+
 Testing Guidelines
 ------------------
 
@@ -151,11 +172,7 @@ Note that we are using the nose package and the mock package for testing, so ins
 
   $ pip install nose mock
 
-In order to run unit tests at the repository root, you first have to build Cython files in place by running the following command::
-
-  $ python setup.py develop
-
-Once the Cython modules are built, you can run unit tests simply by running ``nosetests`` command at the repository root::
+Once the Cython modules are built by ``python setup.py develop``, you can run unit tests simply by running ``nosetests`` command at the repository root::
 
   $ nosetests
 
@@ -238,3 +255,8 @@ Note that reviewers will test your code without the option to check CUDA-related
 .. note::
    Some of numerically unstable tests might cause errors irrelevant to your changes.
    In such a case, we ignore the failures and go on to the review process, so do not worry about it.
+
+We leverage doctest also, you can run doctest by typing ``make doctest`` at the ``docs`` directory::
+
+  $ cd docs
+  $ make doctest


### PR DESCRIPTION
follow-up: https://github.com/cupy/cupy/pull/310