### PR TITLE
Fix bug about empty coo_matrix

### DIFF
--- a/cupy/cusparse.py
+++ b/cupy/cusparse.py
@@ -427,9 +427,11 @@ def cscsort(x):
 
 
 def coosort(x):
+    nnz = x.nnz
+    if nnz == 0:
+        return
     handle = device.get_cusparse_handle()
     m, n = x.shape
-    nnz = x.nnz
 
     buffer_size = cusparse.xcoosort_bufferSizeExt(
         handle, m, n, nnz, x.row.data.ptr, x.col.data.ptr)

--- a/cupy/sparse/coo.py
+++ b/cupy/sparse/coo.py
@@ -82,14 +82,15 @@ class coo_matrix(sparse_data._data_matrix):
                     'cannot infer dimensions from zero sized index arrays')
             shape = (int(row.max()) + 1, int(col.max()) + 1)
 
-        if row.max() >= shape[0]:
-            raise ValueError('row index exceeds matrix dimensions')
-        if col.max() >= shape[1]:
-            raise ValueError('column index exceeds matrix dimensions')
-        if row.min() < 0:
-            raise ValueError('negative row index found')
-        if col.min() < 0:
-            raise ValueError('negative column index found')
+        if len(data) > 0:
+            if row.max() >= shape[0]:
+                raise ValueError('row index exceeds matrix dimensions')
+            if col.max() >= shape[1]:
+                raise ValueError('column index exceeds matrix dimensions')
+            if row.min() < 0:
+                raise ValueError('negative row index found')
+            if col.min() < 0:
+                raise ValueError('negative column index found')
 
         sparse_data._data_matrix.__init__(self, data)
         self.row = row

--- a/cupy/sparse/coo.py
+++ b/cupy/sparse/coo.py
@@ -7,6 +7,7 @@ except ImportError:
 
 from cupy import cusparse
 from cupy.sparse import base
+from cupy.sparse import csr
 from cupy.sparse import data as sparse_data
 
 
@@ -193,6 +194,8 @@ class coo_matrix(sparse_data._data_matrix):
             cupy.sparse.csr_matrix: Converted matrix.
 
         """
+        if self.nnz == 0:
+            return csr.csr_matrix(self.shape, dtype=self.dtype)
         # copy is ignored because coosort method breaks an original.
         x = self.copy()
         cusparse.coosort(x)

--- a/cupy/sparse/csr.py
+++ b/cupy/sparse/csr.py
@@ -172,6 +172,9 @@ class csr_matrix(compressed._compressed_sparse_matrix):
         if order is None:
             order = 'C'
 
+        if self.nnz == 0:
+            return cupy.zeros(shape=self.shape, dtype=self.dtype, order=order)
+
         # csr2dense returns F-contiguous array.
         if order == 'C':
             # To return C-contiguous array, it uses transpose.


### PR DESCRIPTION
I found a bug about coo_matrix. It does not work correctly when it is empty.
merge #316 first