### PR TITLE
cupy.msort supporting multi rank arrays.

### DIFF
--- a/cupy/sorting/sort.py
+++ b/cupy/sorting/sort.py
@@ -112,21 +112,14 @@ def msort(a):
 
     .. note:
         ``cupy.msort(a)``, the CuPy counterpart of ``numpy.msort(a)``, is
-        equivalent to ``cupy.sort(a, axis=0)``. For its implementation reason,
-        ``cupy.sort`` currently supports only sorting an array with its rank of
-        one, so ``cupy.msort(a)`` is actually the same as ``cupy.sort(a)`` for
-        now.
+        equivalent to ``cupy.sort(a, axis=0)``.
 
     .. seealso:: :func:`numpy.msort`
 
     """
 
-    if a.ndim > 1:
-        raise ValueError('Sorting arrays with the rank of two or more is not '
-                         'Supported')
-
     # TODO(takagi): Support float16 and bool.
-    return sort(a)
+    return sort(a, axis=0)
 
 
 # TODO(okuta): Implement sort_complex

--- a/tests/cupy_tests/sorting_tests/test_sort.py
+++ b/tests/cupy_tests/sorting_tests/test_sort.py
@@ -239,7 +239,7 @@ class TestMsort(unittest.TestCase):
 
     _multiprocess_can_split_ = True
 
-    # Test ranks
+    # Test base cases
 
     @testing.numpy_cupy_raises()
     def test_msort_zero_dim(self, xp):
@@ -248,17 +248,17 @@ class TestMsort(unittest.TestCase):
 
     @testing.for_all_dtypes(no_float16=True, no_bool=True)
     @testing.numpy_cupy_array_equal()
+    def test_msort_one_dim(self, xp, dtype):
+        a = testing.shaped_random((10,), xp, dtype)
+        return xp.msort(a)
+
+    @testing.for_all_dtypes(no_float16=True, no_bool=True)
+    @testing.numpy_cupy_array_equal()
     def test_msort_multi_dim(self, xp, dtype):
         a = testing.shaped_random((2, 3), xp, dtype)
         return xp.msort(a)
 
-    # Test dtypes
-
-    @testing.for_all_dtypes(no_float16=True, no_bool=True)
-    @testing.numpy_cupy_allclose()
-    def test_msort_dtype(self, xp, dtype):
-        a = testing.shaped_random((10,), xp, dtype)
-        return xp.msort(a)
+    # Test unsupported dtype
 
     @testing.for_dtypes([numpy.float16, numpy.bool_])
     def test_msort_unsupported_dtype(self, dtype):

--- a/tests/cupy_tests/sorting_tests/test_sort.py
+++ b/tests/cupy_tests/sorting_tests/test_sort.py
@@ -246,10 +246,11 @@ class TestMsort(unittest.TestCase):
         a = testing.shaped_random((), xp)
         return xp.msort(a)
 
-    def test_msort_two_or_more_dim(self):
-        a = testing.shaped_random((2, 3), cupy)
-        with self.assertRaises(ValueError):
-            return cupy.msort(a)
+    @testing.for_all_dtypes(no_float16=True, no_bool=True)
+    @testing.numpy_cupy_array_equal()
+    def test_msort_multi_dim(self, xp, dtype):
+        a = testing.shaped_random((2, 3), xp, dtype)
+        return xp.msort(a)
 
     # Test dtypes
 


### PR DESCRIPTION
This PR fixes `cupy.msort` so that it can sort multi rank arrays, along the first axis.
