### PR TITLE
Remove device memory allocation out of memory pool

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -752,10 +752,11 @@ cdef class ndarray:
             raise ValueError('Axis out of range')
 
         if axis == ndim - 1:
-            thrust.sort(self.dtype, self.data.ptr, self._shape)
+            thrust.sort(self.dtype, self.data.ptr, 0, self._shape)
         else:
             x = cupy.ascontiguousarray(cupy.rollaxis(self, axis, ndim))
-            thrust.sort(self.dtype, x.data.ptr, x._shape)
+            keys_array = ndarray(x._shape, dtype=numpy.intp)
+            thrust.sort(self.dtype, x.data.ptr, keys_array.data.ptr, x._shape)
             y = cupy.rollaxis(x, -1, axis)
             elementwise_copy(y, self)
 

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -752,13 +752,22 @@ cdef class ndarray:
             raise ValueError('Axis out of range')
 
         if axis == ndim - 1:
-            thrust.sort(self.dtype, self.data.ptr, 0, self._shape)
+            data = self
         else:
-            x = cupy.ascontiguousarray(cupy.rollaxis(self, axis, ndim))
-            keys_array = ndarray(x._shape, dtype=numpy.intp)
-            thrust.sort(self.dtype, x.data.ptr, keys_array.data.ptr, x._shape)
-            y = cupy.rollaxis(x, -1, axis)
-            elementwise_copy(y, self)
+            data = cupy.rollaxis(self, axis, ndim).copy()
+
+        if ndim == 1:
+            thrust.sort(self.dtype, data.data.ptr, 0, self._shape)
+        else:
+            keys_array = ndarray(data._shape, dtype=numpy.intp)
+            thrust.sort(
+                self.dtype, data.data.ptr, keys_array.data.ptr, data._shape)
+
+        if axis == ndim - 1:
+            pass
+        else:
+            data = cupy.rollaxis(data, -1, axis)
+            elementwise_copy(data, self)
 
     def argsort(self):
         """Return the indices that would sort an array with stable sorting

--- a/cupy/cuda/cupy_thrust.cu
+++ b/cupy/cuda/cupy_thrust.cu
@@ -26,8 +26,8 @@ void cupy::thrust::_sort(void *data_start, void *keys_start, const std::vector<p
         size *= shape[i];
     }
 
-    dp_data_first = device_pointer_cast(static_cast<T*>(start));
-    dp_data_last  = device_pointer_cast(static_cast<T*>(start) + size);
+    dp_data_first = device_pointer_cast(static_cast<T*>(data_start));
+    dp_data_last  = device_pointer_cast(static_cast<T*>(data_start) + size);
 
     if (ndim == 1) {
         stable_sort(dp_data_first, dp_data_last);

--- a/cupy/cuda/cupy_thrust.cu
+++ b/cupy/cuda/cupy_thrust.cu
@@ -1,5 +1,6 @@
 #include <thrust/device_ptr.h>
 #include <thrust/device_vector.h>
+#include <thrust/iterator/zip_iterator.h>
 #include <thrust/sequence.h>
 #include <thrust/sort.h>
 #include "cupy_common.h"
@@ -11,6 +12,16 @@ using namespace thrust;
 /*
  * sort
  */
+
+template <typename T0, typename T1>
+class tuple_less {
+public:
+    __device__ bool operator()(tuple<T0, T1> i, tuple<T0, T1> j) {
+        T0 i0 = get<0>(i), j0 = get<0>(j);
+        T1 i1 = get<1>(i), j1 = get<1>(j);
+        return i0 < j0 || i0 == j0 && i1 < j1;
+    }
+};
 
 template <typename T>
 void cupy::thrust::_sort(void *data_start, size_t *keys_start, const std::vector<ptrdiff_t>& shape) {
@@ -41,16 +52,10 @@ void cupy::thrust::_sort(void *data_start, size_t *keys_start, const std::vector
                   dp_keys_first,
                   divides<size_t>());
 
-        // Sorting with back-to-back approach.
-        stable_sort_by_key(dp_data_first,
-                           dp_data_last,
-                           dp_keys_first,
-                           less<T>());
-
-        stable_sort_by_key(dp_keys_first,
-                           dp_keys_last,
-                           dp_data_first,
-                           less<size_t>());
+        stable_sort(
+            make_zip_iterator(make_tuple(dp_keys_first, dp_data_first)),
+            make_zip_iterator(make_tuple(dp_keys_last, dp_data_last)),
+            tuple_less<size_t, T>());
     }
 }
 

--- a/cupy/cuda/cupy_thrust.cu
+++ b/cupy/cuda/cupy_thrust.cu
@@ -13,7 +13,7 @@ using namespace thrust;
  */
 
 template <typename T>
-void cupy::thrust::_sort(void *data_start, void *keys_start, const std::vector<ptrdiff_t>& shape) {
+void cupy::thrust::_sort(void *data_start, size_t *keys_start, const std::vector<ptrdiff_t>& shape) {
 
     size_t ndim = shape.size();
     ptrdiff_t size;
@@ -33,8 +33,8 @@ void cupy::thrust::_sort(void *data_start, void *keys_start, const std::vector<p
         stable_sort(dp_data_first, dp_data_last);
     } else {
         // Generate key indices.
-        dp_keys_first = device_pointer_cast(static_cast<size_t*>(keys_start));
-        dp_keys_last  = device_pointer_cast(static_cast<size_t*>(keys_start) + size);
+        dp_keys_first = device_pointer_cast(keys_start);
+        dp_keys_last  = device_pointer_cast(keys_start + size);
         transform(make_counting_iterator<size_t>(0),
                   make_counting_iterator<size_t>(size),
                   make_constant_iterator<ptrdiff_t>(shape[ndim-1]),
@@ -54,16 +54,16 @@ void cupy::thrust::_sort(void *data_start, void *keys_start, const std::vector<p
     }
 }
 
-template void cupy::thrust::_sort<cpy_byte>(void *, void *, const std::vector<ptrdiff_t>& shape);
-template void cupy::thrust::_sort<cpy_ubyte>(void *, void *, const std::vector<ptrdiff_t>& shape);
-template void cupy::thrust::_sort<cpy_short>(void *, void *, const std::vector<ptrdiff_t>& shape);
-template void cupy::thrust::_sort<cpy_ushort>(void *, void *, const std::vector<ptrdiff_t>& shape);
-template void cupy::thrust::_sort<cpy_int>(void *, void *, const std::vector<ptrdiff_t>& shape);
-template void cupy::thrust::_sort<cpy_uint>(void *, void *, const std::vector<ptrdiff_t>& shape);
-template void cupy::thrust::_sort<cpy_long>(void *, void *, const std::vector<ptrdiff_t>& shape);
-template void cupy::thrust::_sort<cpy_ulong>(void *, void *, const std::vector<ptrdiff_t>& shape);
-template void cupy::thrust::_sort<cpy_float>(void *, void *, const std::vector<ptrdiff_t>& shape);
-template void cupy::thrust::_sort<cpy_double>(void *, void *, const std::vector<ptrdiff_t>& shape);
+template void cupy::thrust::_sort<cpy_byte>(void *, size_t *, const std::vector<ptrdiff_t>& shape);
+template void cupy::thrust::_sort<cpy_ubyte>(void *, size_t *, const std::vector<ptrdiff_t>& shape);
+template void cupy::thrust::_sort<cpy_short>(void *, size_t *, const std::vector<ptrdiff_t>& shape);
+template void cupy::thrust::_sort<cpy_ushort>(void *, size_t *, const std::vector<ptrdiff_t>& shape);
+template void cupy::thrust::_sort<cpy_int>(void *, size_t *, const std::vector<ptrdiff_t>& shape);
+template void cupy::thrust::_sort<cpy_uint>(void *, size_t *, const std::vector<ptrdiff_t>& shape);
+template void cupy::thrust::_sort<cpy_long>(void *, size_t *, const std::vector<ptrdiff_t>& shape);
+template void cupy::thrust::_sort<cpy_ulong>(void *, size_t *, const std::vector<ptrdiff_t>& shape);
+template void cupy::thrust::_sort<cpy_float>(void *, size_t *, const std::vector<ptrdiff_t>& shape);
+template void cupy::thrust::_sort<cpy_double>(void *, size_t *, const std::vector<ptrdiff_t>& shape);
 
 
 /*

--- a/cupy/cuda/cupy_thrust.cu
+++ b/cupy/cuda/cupy_thrust.cu
@@ -13,11 +13,12 @@ using namespace thrust;
  */
 
 template <typename T>
-void cupy::thrust::_sort(void *start, const std::vector<ptrdiff_t>& shape) {
+void cupy::thrust::_sort(void *data_start, void *keys_start, const std::vector<ptrdiff_t>& shape) {
 
     size_t ndim = shape.size();
     ptrdiff_t size;
-    device_ptr<T> dp_first, dp_last;
+    device_ptr<T> dp_data_first, dp_data_last;
+    device_ptr<size_t> dp_keys_first, dp_keys_last;
 
     // Compute the total size of the array.
     size = shape[0];
@@ -25,44 +26,44 @@ void cupy::thrust::_sort(void *start, const std::vector<ptrdiff_t>& shape) {
         size *= shape[i];
     }
 
-    dp_first = device_pointer_cast(static_cast<T*>(start));
-    dp_last  = device_pointer_cast(static_cast<T*>(start) + size);
+    dp_data_first = device_pointer_cast(static_cast<T*>(start));
+    dp_data_last  = device_pointer_cast(static_cast<T*>(start) + size);
 
     if (ndim == 1) {
-        stable_sort(dp_first, dp_last);
+        stable_sort(dp_data_first, dp_data_last);
     } else {
-        device_vector<size_t> d_keys(size);
-
         // Generate key indices.
+        dp_keys_first = device_pointer_cast(static_cast<size_t*>(keys_start));
+        dp_keys_last  = device_pointer_cast(static_cast<size_t*>(keys_start) + size);
         transform(make_counting_iterator<size_t>(0),
                   make_counting_iterator<size_t>(size),
                   make_constant_iterator<ptrdiff_t>(shape[ndim-1]),
-                  d_keys.begin(),
+                  dp_keys_first,
                   divides<size_t>());
 
         // Sorting with back-to-back approach.
-        stable_sort_by_key(dp_first,
-                           dp_last,
-                           d_keys.begin(),
+        stable_sort_by_key(dp_data_first,
+                           dp_data_last,
+                           dp_keys_first,
                            less<T>());
 
-        stable_sort_by_key(d_keys.begin(),
-                           d_keys.end(),
-                           dp_first,
+        stable_sort_by_key(dp_keys_first,
+                           dp_keys_last,
+                           dp_data_first,
                            less<size_t>());
     }
 }
 
-template void cupy::thrust::_sort<cpy_byte>(void *, const std::vector<ptrdiff_t>& shape);
-template void cupy::thrust::_sort<cpy_ubyte>(void *, const std::vector<ptrdiff_t>& shape);
-template void cupy::thrust::_sort<cpy_short>(void *, const std::vector<ptrdiff_t>& shape);
-template void cupy::thrust::_sort<cpy_ushort>(void *, const std::vector<ptrdiff_t>& shape);
-template void cupy::thrust::_sort<cpy_int>(void *, const std::vector<ptrdiff_t>& shape);
-template void cupy::thrust::_sort<cpy_uint>(void *, const std::vector<ptrdiff_t>& shape);
-template void cupy::thrust::_sort<cpy_long>(void *, const std::vector<ptrdiff_t>& shape);
-template void cupy::thrust::_sort<cpy_ulong>(void *, const std::vector<ptrdiff_t>& shape);
-template void cupy::thrust::_sort<cpy_float>(void *, const std::vector<ptrdiff_t>& shape);
-template void cupy::thrust::_sort<cpy_double>(void *, const std::vector<ptrdiff_t>& shape);
+template void cupy::thrust::_sort<cpy_byte>(void *, void *, const std::vector<ptrdiff_t>& shape);
+template void cupy::thrust::_sort<cpy_ubyte>(void *, void *, const std::vector<ptrdiff_t>& shape);
+template void cupy::thrust::_sort<cpy_short>(void *, void *, const std::vector<ptrdiff_t>& shape);
+template void cupy::thrust::_sort<cpy_ushort>(void *, void *, const std::vector<ptrdiff_t>& shape);
+template void cupy::thrust::_sort<cpy_int>(void *, void *, const std::vector<ptrdiff_t>& shape);
+template void cupy::thrust::_sort<cpy_uint>(void *, void *, const std::vector<ptrdiff_t>& shape);
+template void cupy::thrust::_sort<cpy_long>(void *, void *, const std::vector<ptrdiff_t>& shape);
+template void cupy::thrust::_sort<cpy_ulong>(void *, void *, const std::vector<ptrdiff_t>& shape);
+template void cupy::thrust::_sort<cpy_float>(void *, void *, const std::vector<ptrdiff_t>& shape);
+template void cupy::thrust::_sort<cpy_double>(void *, void *, const std::vector<ptrdiff_t>& shape);
 
 
 /*

--- a/cupy/cuda/cupy_thrust.h
+++ b/cupy/cuda/cupy_thrust.h
@@ -7,7 +7,7 @@ namespace cupy {
 
 namespace thrust {
 
-template <typename T> void _sort(void *, const std::vector<ptrdiff_t>&);
+template <typename T> void _sort(void *, void *, const std::vector<ptrdiff_t>&);
 
 template <typename T> void _lexsort(size_t *, void *, size_t, size_t);
    
@@ -25,7 +25,7 @@ namespace cupy {
 
 namespace thrust {
 
-template <typename T> void _sort(void *, const std::vector<ptrdiff_t>&) { return; }
+template <typename T> void _sort(void *, void *, const std::vector<ptrdiff_t>&) { return; }
 
 template <typename T> void _lexsort(size_t *, void *, size_t, size_t) { return; }
 

--- a/cupy/cuda/cupy_thrust.h
+++ b/cupy/cuda/cupy_thrust.h
@@ -7,7 +7,7 @@ namespace cupy {
 
 namespace thrust {
 
-template <typename T> void _sort(void *, void *, const std::vector<ptrdiff_t>&);
+template <typename T> void _sort(void *, size_t *, const std::vector<ptrdiff_t>&);
 
 template <typename T> void _lexsort(size_t *, void *, size_t, size_t);
    
@@ -25,7 +25,7 @@ namespace cupy {
 
 namespace thrust {
 
-template <typename T> void _sort(void *, void *, const std::vector<ptrdiff_t>&) { return; }
+template <typename T> void _sort(void *, size_t *, const std::vector<ptrdiff_t>&) { return; }
 
 template <typename T> void _lexsort(size_t *, void *, size_t, size_t) { return; }
 

--- a/cupy/cuda/thrust.pyx
+++ b/cupy/cuda/thrust.pyx
@@ -14,7 +14,7 @@ from cupy.cuda cimport common
 ###############################################################################
 
 cdef extern from "../cuda/cupy_thrust.h" namespace "cupy::thrust":
-    void _sort[T](void *, void *, const vector.vector[ptrdiff_t]&)
+    void _sort[T](void *, size_t *, const vector.vector[ptrdiff_t]&)
     void _lexsort[T](size_t *, void *, size_t, size_t)
     void _argsort[T](size_t *, void *, size_t)
 

--- a/cupy/cuda/thrust.pyx
+++ b/cupy/cuda/thrust.pyx
@@ -14,7 +14,7 @@ from cupy.cuda cimport common
 ###############################################################################
 
 cdef extern from "../cuda/cupy_thrust.h" namespace "cupy::thrust":
-    void _sort[T](void *, const vector.vector[ptrdiff_t]&)
+    void _sort[T](void *, void *, const vector.vector[ptrdiff_t]&)
     void _lexsort[T](size_t *, void *, size_t, size_t)
     void _argsort[T](size_t *, void *, size_t)
 
@@ -23,32 +23,36 @@ cdef extern from "../cuda/cupy_thrust.h" namespace "cupy::thrust":
 # Python interface
 ###############################################################################
 
-cpdef sort(dtype, size_t start, vector.vector[ptrdiff_t]& shape):
+cpdef sort(dtype, size_t data_start, size_t keys_start,
+           vector.vector[ptrdiff_t]& shape):
 
-    cdef void *_start
-    _start = <void *>start
+    cdef void *_data_start
+    cdef size_t *_keys_start
+
+    _data_start = <void *>data_start
+    _keys_start = <size_t *>keys_start
 
     # TODO(takagi): Support float16 and bool
     if dtype == numpy.int8:
-        _sort[common.cpy_byte](_start, shape)
+        _sort[common.cpy_byte](_data_start, _keys_start, shape)
     elif dtype == numpy.uint8:
-        _sort[common.cpy_ubyte](_start, shape)
+        _sort[common.cpy_ubyte](_data_start, _keys_start, shape)
     elif dtype == numpy.int16:
-        _sort[common.cpy_short](_start, shape)
+        _sort[common.cpy_short](_data_start, _keys_start, shape)
     elif dtype == numpy.uint16:
-        _sort[common.cpy_ushort](_start, shape)
+        _sort[common.cpy_ushort](_data_start, _keys_start, shape)
     elif dtype == numpy.int32:
-        _sort[common.cpy_int](_start, shape)
+        _sort[common.cpy_int](_data_start, _keys_start, shape)
     elif dtype == numpy.uint32:
-        _sort[common.cpy_uint](_start, shape)
+        _sort[common.cpy_uint](_data_start, _keys_start, shape)
     elif dtype == numpy.int64:
-        _sort[common.cpy_long](_start, shape)
+        _sort[common.cpy_long](_data_start, _keys_start, shape)
     elif dtype == numpy.uint64:
-        _sort[common.cpy_ulong](_start, shape)
+        _sort[common.cpy_ulong](_data_start, _keys_start, shape)
     elif dtype == numpy.float32:
-        _sort[common.cpy_float](_start, shape)
+        _sort[common.cpy_float](_data_start, _keys_start, shape)
     elif dtype == numpy.float64:
-        _sort[common.cpy_double](_start, shape)
+        _sort[common.cpy_double](_data_start, _keys_start, shape)
     else:
         raise NotImplementedError('Sorting arrays with dtype \'{}\' is not '
                                   'supported'.format(dtype))


### PR DESCRIPTION
This PR removes device memory allocation out of memory pool form `cupy.sort`.