### PR TITLE
Use numpy.AxisError

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -751,7 +751,7 @@ cdef class ndarray:
         if axis < 0:
             axis += ndim
         if not (0 <= axis < ndim):
-            raise ValueError('Axis out of range')
+            raise numpy.AxisError('Axis out of range')
 
         if axis == ndim - 1:
             thrust.sort(self.dtype, self.data.ptr, self._shape)


### PR DESCRIPTION
Rel: #281
Jenkins is failing

(`tests/cupy_tests/sorting_tests/test_sort.py:TestSort.test_external_sort_invalid_axis`)