### PR TITLE
Skip bool unary negative test

### DIFF
--- a/tests/cupy_tests/core_tests/test_fusion.py
+++ b/tests/cupy_tests/core_tests/test_fusion.py
@@ -949,7 +949,7 @@ class TestFusionFuse(unittest.TestCase):
 
         return g(a, b, c)
 
-    @testing.for_all_dtypes()
+    @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_array_equal()
     def test_fuse3(self, xp, dtype):
         a = xp.array([2, 2, 2, 2, 3, 3, 3, 3], dtype=dtype)


### PR DESCRIPTION
Rel: #281 
 Jenkins is failing in stable test

(`tests/cupy_tests/core_tests/test_fusion.py:TestFusionFuse.test_fuse3`)