### PR TITLE
Revert "Fix document about numpy version"

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ CuPy is tested on Ubuntu 14.04 and CentOS 7. We recommend them to use CuPy, thou
 
 Minimum requirements:
 - Python 2.7.6+, 3.4.3+, 3.5.1+, 3.6.0+
-- NumPy 1.9, 1.10, 1.11, 1.12, 1.13
+- NumPy 1.9, 1.10, 1.11, 1.12
 - Six 1.9
 
 Requirements for some features:

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -44,7 +44,7 @@ Before installing CuPy, we recommend to upgrade ``setuptools`` if you are using 
 The following Python packages are required to install CuPy.
 The latest version of each package will automatically be installed if missing.
 
-* `NumPy <http://www.numpy.org/>`_ 1.9, 1.10, 1.11, 1.12, 1.13
+* `NumPy <http://www.numpy.org/>`_ 1.9, 1.10, 1.11, 1.12
 * `Six <https://pythonhosted.org/six/>`_ 1.9+
 
 CUDA support


### PR DESCRIPTION
Reverts cupy/cupy#336

We will revert https://github.com/cupy/cupy/pull/281, so we also have to revert https://github.com/cupy/cupy/pull/336