### PR TITLE
Hide source link for alien objects

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -394,6 +394,13 @@ def linkcode_resolve(domain, info):
     # Import the object from module path
     obj = _import_object_from_name(info['module'], info['fullname'])
 
+    # If it's not defined in the internal module, return None.
+    mod = inspect.getmodule(obj)
+    if mod is None:
+        return None
+    if not (mod.__name__ == 'cupy' or mod.__name__.startswith('cupy.')):
+        return None
+
     # Get the source file name and line number at which obj is defined.
     try:
         filename = inspect.getsourcefile(obj)


### PR DESCRIPTION
I found the [source] link does not work for an object which is an alias of an external module (e.g. `cupy.isscalar` = `numpy.isscalar`. See https://docs-cupy.chainer.org/en/v1.0.2/reference/generated/cupy.isscalar.html).

In these cases the link should be hidden.

TODO: Port to Chainer