### PR TITLE
Change minimum Cython version

### DIFF
--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -17,7 +17,7 @@ from install import build
 from install import utils
 
 
-required_cython_version = pkg_resources.parse_version('0.26.0')
+required_cython_version = pkg_resources.parse_version('0.26.1')
 
 MODULES = [
     {

--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -17,7 +17,7 @@ from install import build
 from install import utils
 
 
-required_cython_version = pkg_resources.parse_version('0.24.0')
+required_cython_version = pkg_resources.parse_version('0.26.0')
 
 MODULES = [
     {


### PR DESCRIPTION
Ctyhon version 0.26.0 was released. We should use latest Cython.
https://github.com/cython/cython/blob/master/CHANGES.rst