### PR TITLE
Support conversion from scipy.sparse matrix to cupy.sparse

### DIFF
--- a/cupy/sparse/compressed.py
+++ b/cupy/sparse/compressed.py
@@ -1,4 +1,9 @@
 import numpy
+try:
+    import scipy.sparse
+    scipy_available = True
+except ImportError:
+    scipy_available = False
 
 import cupy
 from cupy.creation import basic
@@ -37,6 +42,17 @@ class _compressed_sparse_matrix(sparse_data._data_matrix):
             # shape and copy argument is ignored
             shape = (m, n)
             copy = False
+
+        elif scipy_available and scipy.sparse.issparse(arg1):
+            # Convert scipy.sparse to cupy.sparse
+            x = arg1.asformat(self.format)
+            data = cupy.array(x.data)
+            indices = cupy.array(x.indices, dtype='i')
+            indptr = cupy.array(x.indptr, dtype='i')
+            copy = False
+
+            if shape is None:
+                shape = arg1.shape
 
         elif isinstance(arg1, tuple) and len(arg1) == 3:
             data, indices, indptr = arg1

--- a/tests/cupy_tests/sparse_tests/test_csc.py
+++ b/tests/cupy_tests/sparse_tests/test_csc.py
@@ -91,6 +91,30 @@ class TestCscMatrix(unittest.TestCase):
         cupy.testing.assert_array_equal(n.indptr, self.m.indptr)
         self.assertEqual(n.shape, self.m.shape)
 
+    @unittest.skipUnless(scipy_available, 'requires scipy')
+    def test_init_copy_scipy_sparse(self):
+        m = _make(numpy, scipy.sparse, self.dtype)
+        n = cupy.sparse.csc_matrix(m)
+        self.assertIsInstance(n.data, cupy.ndarray)
+        self.assertIsInstance(n.indices, cupy.ndarray)
+        self.assertIsInstance(n.indptr, cupy.ndarray)
+        cupy.testing.assert_array_equal(n.data, m.data)
+        cupy.testing.assert_array_equal(n.indices, m.indices)
+        cupy.testing.assert_array_equal(n.indptr, m.indptr)
+        self.assertEqual(n.shape, m.shape)
+
+    @unittest.skipUnless(scipy_available, 'requires scipy')
+    def test_init_copy_other_scipy_sparse(self):
+        m = _make(numpy, scipy.sparse, self.dtype)
+        n = cupy.sparse.csc_matrix(m.tocsr())
+        self.assertIsInstance(n.data, cupy.ndarray)
+        self.assertIsInstance(n.indices, cupy.ndarray)
+        self.assertIsInstance(n.indptr, cupy.ndarray)
+        cupy.testing.assert_array_equal(n.data, m.data)
+        cupy.testing.assert_array_equal(n.indices, m.indices)
+        cupy.testing.assert_array_equal(n.indptr, m.indptr)
+        self.assertEqual(n.shape, m.shape)
+
     def test_copy(self):
         n = self.m.copy()
         self.assertIsInstance(n, cupy.sparse.csc_matrix)

--- a/tests/cupy_tests/sparse_tests/test_csr.py
+++ b/tests/cupy_tests/sparse_tests/test_csr.py
@@ -94,6 +94,30 @@ class TestCsrMatrix(unittest.TestCase):
         cupy.testing.assert_array_equal(n.indptr, self.m.indptr)
         self.assertEqual(n.shape, self.m.shape)
 
+    @unittest.skipUnless(scipy_available, 'requires scipy')
+    def test_init_copy_scipy_sparse(self):
+        m = _make(numpy, scipy.sparse, self.dtype)
+        n = cupy.sparse.csr_matrix(m)
+        self.assertIsInstance(n.data, cupy.ndarray)
+        self.assertIsInstance(n.indices, cupy.ndarray)
+        self.assertIsInstance(n.indptr, cupy.ndarray)
+        cupy.testing.assert_array_equal(n.data, m.data)
+        cupy.testing.assert_array_equal(n.indices, m.indices)
+        cupy.testing.assert_array_equal(n.indptr, m.indptr)
+        self.assertEqual(n.shape, m.shape)
+
+    @unittest.skipUnless(scipy_available, 'requires scipy')
+    def test_init_copy_other_scipy_sparse(self):
+        m = _make(numpy, scipy.sparse, self.dtype)
+        n = cupy.sparse.csr_matrix(m.tocsc())
+        self.assertIsInstance(n.data, cupy.ndarray)
+        self.assertIsInstance(n.indices, cupy.ndarray)
+        self.assertIsInstance(n.indptr, cupy.ndarray)
+        cupy.testing.assert_array_equal(n.data, m.data)
+        cupy.testing.assert_array_equal(n.indices, m.indices)
+        cupy.testing.assert_array_equal(n.indptr, m.indptr)
+        self.assertEqual(n.shape, m.shape)
+
     def test_copy(self):
         n = self.m.copy()
         self.assertIsInstance(n, cupy.sparse.csr_matrix)


### PR DESCRIPTION
csr_matrix and csc_matrix support conversion from scipy.spmatrix with this patch.
related to #36 