### PR TITLE
sum_duplicates for compressed matrices

### DIFF
--- a/cupy/sparse/compressed.py
+++ b/cupy/sparse/compressed.py
@@ -55,6 +55,7 @@ class _compressed_sparse_matrix(sparse_data._data_matrix):
 
             if shape is None:
                 shape = arg1.shape
+            has_canonical_format = x.has_canonical_format
 
         elif isinstance(arg1, tuple) and len(arg1) == 3:
             data, indices, indptr = arg1

--- a/cupy/sparse/csc.py
+++ b/cupy/sparse/csc.py
@@ -106,7 +106,7 @@ class csc_matrix(compressed._compressed_sparse_matrix):
 
         if self.nnz == 0:
             return cupy.zeros(shape=self.shape, dtype=self.dtype, order=order)
-        
+
         self.sum_duplicates()
         # csc2dense and csr2dense returns F-contiguous array.
         if order == 'C':

--- a/cupy/sparse/csr.py
+++ b/cupy/sparse/csr.py
@@ -72,6 +72,8 @@ class csr_matrix(compressed._compressed_sparse_matrix):
     # TODO(unno): Implement __getitem__
 
     def _add_sparse(self, other, alpha, beta):
+        self.sum_duplicates()
+        other.sum_duplicates()
         return cusparse.csrgeam(self, other.tocsr(), alpha, beta)
 
     def __eq__(self, other):
@@ -158,8 +160,6 @@ class csr_matrix(compressed._compressed_sparse_matrix):
         """Sorts the indices of the matrix in place."""
         cusparse.csrsort(self)
 
-    # TODO(unno): Implement sum_duplicates
-
     def toarray(self, order=None, out=None):
         """Returns a dense matrix representing the same value.
 
@@ -180,6 +180,7 @@ class csr_matrix(compressed._compressed_sparse_matrix):
         if self.nnz == 0:
             return cupy.zeros(shape=self.shape, dtype=self.dtype, order=order)
 
+        self.sum_duplicates()
         # csr2dense returns F-contiguous array.
         if order == 'C':
             # To return C-contiguous array, it uses transpose.

--- a/tests/cupy_tests/sparse_tests/test_csr.py
+++ b/tests/cupy_tests/sparse_tests/test_csr.py
@@ -53,6 +53,16 @@ def _make_unordered(xp, sp, dtype):
     return sp.csr_matrix((data, indices, indptr), shape=(3, 4))
 
 
+def _make_duplicate(xp, sp, dtype):
+    data = xp.array([0, 1, 3, 2, 4, 5], dtype)
+    indices = xp.array([0, 0, 0, 2, 0, 2], 'i')
+    indptr = xp.array([0, 3, 6, 6], 'i')
+    # 4, 0, 0, 0
+    # 4, 0, 7, 0
+    # 0, 0, 0, 0
+    return sp.csr_matrix((data, indices, indptr), shape=(3, 4))
+
+
 def _make_square(xp, sp, dtype):
     data = xp.array([0, 1, 2, 3], dtype)
     indices = xp.array([0, 1, 0, 2], 'i')
@@ -722,6 +732,14 @@ class TestCsrMatrixScipyComparison(unittest.TestCase):
     def test_sort_indices(self, xp, sp):
         m = _make_unordered(xp, sp, self.dtype)
         m.sort_indices()
+        return m.toarray()
+
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_sum_duplicates(self, xp, sp):
+        m = _make_duplicate(xp, sp, self.dtype)
+        self.assertFalse(m.has_canonical_format)
+        m.sum_duplicates()
+        self.assertTrue(m.has_canonical_format)
         return m.toarray()
 
     @testing.numpy_cupy_allclose(sp_name='sp')


### PR DESCRIPTION
I implemented `sum_duplicates` method for csr and csc. It uses `coo_matrix.sum_duplicates`.
It depends on #326 and #328 
related to #36 