### PR TITLE
Improve _tril() and _triu() with an ElementwiseKernel

### DIFF
--- a/cupy/linalg/util.py
+++ b/cupy/linalg/util.py
@@ -26,18 +26,16 @@ def _assert_nd_squareness(*arrays):
 
 
 def _tril(x, k=0):
-    m, n = x.shape
-    u = cupy.arange(m).reshape(m, 1)
-    v = cupy.arange(n).reshape(1, n)
-    mask = v - u <= k
-    x *= mask
+    cupy.ElementwiseKernel(
+        'int64 k', 'S x',
+        'x = (_ind.get()[1] - _ind.get()[0] <= k) ? x : 0',
+        reduce_dims=False)(k, x)
     return x
 
 
 def _triu(x, k=0):
-    m, n = x.shape
-    u = cupy.arange(m).reshape(m, 1)
-    v = cupy.arange(n).reshape(1, n)
-    mask = v - u >= k
-    x *= mask
+    cupy.ElementwiseKernel(
+        'int64 k', 'S x',
+        'x = (_ind.get()[1] - _ind.get()[0] >= k) ? x : 0',
+        reduce_dims=False)(k, x)
     return x

--- a/cupy/linalg/util.py
+++ b/cupy/linalg/util.py
@@ -1,6 +1,7 @@
 from numpy import linalg
 
 import cupy
+from cupy import core
 
 
 def _assert_cupy_array(*arrays):
@@ -25,17 +26,27 @@ def _assert_nd_squareness(*arrays):
                 'Last 2 dimensions of the array must be square')
 
 
+_tril_kernel = core.ElementwiseKernel(
+    'int64 k', 'S x',
+    'x = (_ind.get()[1] - _ind.get()[0] <= k) ? x : 0',
+    'tril_kernel',
+    reduce_dims=False
+)
+
+
 def _tril(x, k=0):
-    cupy.ElementwiseKernel(
-        'int64 k', 'S x',
-        'x = (_ind.get()[1] - _ind.get()[0] <= k) ? x : 0',
-        reduce_dims=False)(k, x)
+    _tril_kernel(k, x)
     return x
 
 
+_triu_kernel = core.ElementwiseKernel(
+    'int64 k', 'S x',
+    'x = (_ind.get()[1] - _ind.get()[0] >= k) ? x : 0',
+    'triu_kernel',
+    reduce_dims=False
+)
+
+
 def _triu(x, k=0):
-    cupy.ElementwiseKernel(
-        'int64 k', 'S x',
-        'x = (_ind.get()[1] - _ind.get()[0] >= k) ? x : 0',
-        reduce_dims=False)(k, x)
+    _triu_kernel(k, x)
     return x


### PR DESCRIPTION
This small PR speedups `_tril()` and `_triu()` in `cupy/linalg/util.py` with the ElementwiseKernel.