### PR TITLE
Avoid decoding nvcc output with UTF-8

### DIFF
--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -93,9 +93,8 @@ def preprocess(source, options=()):
         cmd.append(cu_path)
         pp_src = _run_nvcc(cmd, root_dir)
 
-        if isinstance(pp_src, six.binary_type):
-            pp_src = pp_src.decode('utf-8')
-        return re.sub('(?m)^#.*$', '', pp_src)
+        assert isinstance(pp_src, six.binary_type)
+        return re.sub(b'(?m)^#.*$', b'', pp_src)
 
 
 _default_cache_dir = os.path.expanduser('~/.cupy/kernel_cache')


### PR DESCRIPTION
Fixes #378 by avoiding decoding nvcc output.

Notes:
- The result of this function (`preprocess`) is only used to generate md5 digest. So there's no need to decode it.
- The result (`bytes`) is used in `str` formatting (https://github.com/cupy/cupy/blob/accf3ad237f6cf63710852df2d5d7d37f05830ee/cupy/cuda/compiler.py#L126), but the type difference doesn't matter; different values of `preprocess(...)` will result in  different `pp_src`, even if it's `bytes`. It's enough as a key to generate hash digest.