### PR TITLE
Make compilation error readable

### DIFF
--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -52,7 +52,9 @@ def _run_nvcc(cmd, cwd):
                'command: {0}\n'
                'return-code: {1}\n'
                'stdout/stderr: \n'
-               '{2}'.format(e.cmd, e.returncode, e.output))
+               '{2}'.format(e.cmd,
+                            e.returncode,
+                            e.output.decode(encoding='UTF-8')))
         raise RuntimeError(msg)
     except OSError as e:
         msg = 'Failed to run `nvcc` command. ' \

--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -54,7 +54,8 @@ def _run_nvcc(cmd, cwd):
                'stdout/stderr: \n'
                '{2}'.format(e.cmd,
                             e.returncode,
-                            e.output.decode(encoding='UTF-8')))
+                            e.output.decode(encoding='UTF-8',
+                                            errors='replace')))
         raise RuntimeError(msg)
     except OSError as e:
         msg = 'Failed to run `nvcc` command. ' \


### PR DESCRIPTION
Python 3 prints a line feed in bytes as `\n` and `e.output` is `bytes`, so `e.output` should be converted to `str` for readability.