### PR TITLE
Avoid to call python methods in __dealloc__(), use __del__() instead.

### DIFF
--- a/cupy/cuda/memory.pxd
+++ b/cupy/cuda/memory.pxd
@@ -1,13 +1,5 @@
 from cupy.cuda cimport device
 
-cdef class Memory:
-
-    cdef:
-        public device.Device device
-        public size_t ptr
-        public Py_ssize_t size
-
-
 cdef class Chunk:
 
     cdef:
@@ -43,14 +35,6 @@ cpdef MemoryPointer alloc(Py_ssize_t size)
 
 
 cpdef set_allocator(allocator=*)
-
-
-cdef class PooledMemory(Memory):
-
-    cdef:
-        object pool
-
-    cpdef free(self)
 
 
 cdef class SingleDeviceMemoryPool:

--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -19,7 +19,8 @@ class OutOfMemoryError(MemoryError):
               '(total %d bytes)' % (size, total)
         super(OutOfMemoryError, self).__init__(msg)
 
-cdef class Memory:
+
+class Memory(object):
 
     """Memory allocation on a CUDA device.
 
@@ -39,7 +40,7 @@ cdef class Memory:
             self.device = device.Device()
             self.ptr = runtime.malloc(size)
 
-    def __dealloc__(self):
+    def __del__(self):
         if self.ptr:
             runtime.free(self.ptr)
 
@@ -336,7 +337,7 @@ cpdef set_allocator(allocator=_malloc):
     _current_allocator = allocator
 
 
-cdef class PooledMemory(Memory):
+class PooledMemory(Memory):
 
     """Memory allocation for a memory pool.
 
@@ -351,11 +352,11 @@ cdef class PooledMemory(Memory):
         self.size = chunk.size
         self.pool = pool
 
-    def __dealloc__(self):
+    def __del__(self):
         if self.ptr != 0:
             self.free()
 
-    cpdef free(self):
+    def free(self):
         """Frees the memory buffer and returns it to the memory pool.
 
         This function actually does not free the buffer. It just returns the
@@ -452,7 +453,6 @@ cdef class SingleDeviceMemoryPool:
         cdef list free_list = None
         cdef Chunk chunk = None
         cdef MemoryPointer memptr
-        cdef Memory mem
 
         if size == 0:
             return MemoryPointer(Memory(0), 0)


### PR DESCRIPTION
For https://github.com/cupy/cupy/issues/317#issue-245007720,

Referring http://cython.readthedocs.io/en/latest/src/userguide/special_methods.html#finalization-method-dealloc,

> You need to be careful what you do in a `__dealloc__()` method. By the
> time your` __dealloc__()` method is called, **the object may already have
> been partially destroyed** and may not be in a valid state as far as
> Python is concerned, so you should avoid invoking any Python
> operations which might touch the object. In particular, don’t call any
> other methods of the object or do anything which might cause the
> object to be resurrected. It’s best if you stick to just deallocating
> C data.

Therefore, the pool object potentially can be None in `__dealloc__()`, and
we should not call any python methods in `__dealloc__()`.