### PR TITLE
Fix race-condition on memory pool

### DIFF
--- a/cupy/cuda/memory.pxd
+++ b/cupy/cuda/memory.pxd
@@ -45,6 +45,8 @@ cdef class SingleDeviceMemoryPool:
         object _free
         object __weakref__
         object _weakref
+        object _free_lock
+        object _in_use_lock
         readonly Py_ssize_t _allocation_unit_size
         readonly Py_ssize_t _initial_bins_size
 

--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -563,7 +563,6 @@ cdef class SingleDeviceMemoryPool:
                 for chunk in self._free[i]:
                     if chunk.prev or chunk.next:
                         keep_list.add(chunk)
-                self._free[i].clear()
                 self._free[i] = keep_list
         finally:
             rlock.unlock_fastrlock(self._free_lock)

--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -3,6 +3,7 @@
 import collections
 import ctypes
 import gc
+import threading
 import warnings
 import weakref
 
@@ -90,7 +91,6 @@ cdef class Chunk:
         size (int): Chunk size in bytes.
         prev (Chunk): prev memory pointer if split from a larger allocation
         next (Chunk): next memory pointer if split from a larger allocation
-        in_use (boolen): in_use flag
     """
 
     def __init__(self, mem, Py_ssize_t offset, Py_ssize_t size):
@@ -102,7 +102,6 @@ cdef class Chunk:
         self.size = size
         self.prev = None
         self.next = None
-        self.in_use = False
 
 cdef class MemoryPointer:
 
@@ -388,9 +387,11 @@ cdef class SingleDeviceMemoryPool:
         self._allocation_unit_size = 512
         self._initial_bins_size = 1024
         self._in_use = {}
-        self._free = [[] for i in range(self._initial_bins_size)]
+        self._free = [set() for i in range(self._initial_bins_size)]
         self._alloc = allocator
         self._weakref = weakref.ref(self)
+        self._free_lock = threading.Lock()
+        self._in_use_lock = threading.Lock()
 
     cpdef Py_ssize_t _round_size(self, Py_ssize_t size):
         """Round up the memory size to fit memory alignment of cudaMalloc."""
@@ -408,18 +409,17 @@ cdef class SingleDeviceMemoryPool:
         if current_size >= size:
             return
         growth_size = size - current_size
-        growth = [[] for i in range(growth_size)]
+        growth = [set() for i in range(growth_size)]
         self._free.extend(growth)
 
     cpdef tuple _split(self, Chunk chunk, Py_ssize_t size):
         """Split contiguous block of a larger allocation"""
-        assert not chunk.in_use
+        assert chunk.ptr not in self._in_use
         assert chunk.size >= size
         if chunk.size == size:
             return (chunk, None)
         cdef Chunk head
         cdef Chunk remaining
-        cdef int index
         head = Chunk(chunk.mem, chunk.offset, size)
         remaining = Chunk(chunk.mem, chunk.offset + size, chunk.size - size)
         if chunk.prev is not None:
@@ -430,14 +430,12 @@ cdef class SingleDeviceMemoryPool:
             chunk.next.prev = remaining
         head.next = remaining
         remaining.prev = head
-        index = self._bin_index_from_size(remaining.size)
-        self._free[index].append(remaining)
         return (head, remaining)
 
     cpdef Chunk _merge(self, Chunk head, Chunk remaining):
         """Merge previously splitted block (chunk)"""
-        assert not head.in_use
-        assert not remaining.in_use
+        assert head.ptr not in self._in_use
+        assert remaining.ptr not in self._in_use
         cdef Chunk merged
         size = head.size + remaining.size
         merged = Chunk(head.mem, head.offset, size)
@@ -450,9 +448,9 @@ cdef class SingleDeviceMemoryPool:
         return merged
 
     cpdef MemoryPointer malloc(self, Py_ssize_t size):
-        cdef list free_list = None
+        cdef set free_list = None
         cdef Chunk chunk = None
-        cdef MemoryPointer memptr
+        cdef Chunk remaining = None
 
         if size == 0:
             return MemoryPointer(Memory(0), 0)
@@ -462,14 +460,16 @@ cdef class SingleDeviceMemoryPool:
         # find best-fit, or a smallest larger allocation
         length = len(self._free)
         for i in range(index, length):
-            free_list = self._free[i]
-            if free_list:
-                chunk = free_list.pop()
-                chunk, _remaining = self._split(chunk, size)
-                break
+            with self._free_lock:
+                free_list = self._free[i]
+                if free_list:
+                    chunk = free_list.pop()
+                    break
 
-        # cudaMalloc if not found
-        if chunk is None:
+        if chunk:
+            chunk, remaining = self._split(chunk, size)
+        else:
+            # cudaMalloc if a cache is not found
             try:
                 mem = self._alloc(size).mem
             except runtime.CUDARuntimeError as e:
@@ -492,8 +492,12 @@ cdef class SingleDeviceMemoryPool:
                             raise OutOfMemoryError(size, total)
             chunk = Chunk(mem, 0, size)
 
-        chunk.in_use = True
-        self._in_use[chunk.ptr] = chunk
+        with self._in_use_lock:
+            self._in_use[chunk.ptr] = chunk
+        if remaining:
+            remaining_index = self._bin_index_from_size(remaining.size)
+            with self._free_lock:
+                self._free[remaining_index].add(remaining)
         pmem = PooledMemory(chunk, self._weakref)
         return MemoryPointer(pmem, 0)
 
@@ -501,33 +505,46 @@ cdef class SingleDeviceMemoryPool:
         cdef Chunk chunk
         cdef int index
 
-        chunk = self._in_use.pop(ptr, None)
+        with self._in_use_lock:
+            chunk = self._in_use.pop(ptr, None)
         if chunk is None:
             raise RuntimeError('Cannot free out-of-pool memory')
 
-        chunk.in_use = False
-        if chunk.next and not chunk.next.in_use:
+        if chunk.next:
+            chunk_next = None
             index = self._bin_index_from_size(chunk.next.size)
-            self._free[index].remove(chunk.next)
-            chunk = self._merge(chunk, chunk.next)
+            with self._free_lock:
+                if chunk.next in self._free[index]:
+                    self._free[index].remove(chunk.next)
+                    chunk_next = chunk.next
+            if chunk_next:
+                chunk = self._merge(chunk, chunk_next)
 
-        if chunk.prev and not chunk.prev.in_use:
+        if chunk.prev:
+            chunk_prev = None
             index = self._bin_index_from_size(chunk.prev.size)
-            self._free[index].remove(chunk.prev)
-            chunk = self._merge(chunk.prev, chunk)
+            with self._free_lock:
+                if chunk.prev in self._free[index]:
+                    self._free[index].remove(chunk.prev)
+                    chunk_prev = chunk.prev
+            if chunk_prev:
+                chunk = self._merge(chunk_prev, chunk)
 
         index = self._bin_index_from_size(chunk.size)
         self._grow_free_if_necessary(index + 1)
-        self._free[index].append(chunk)
+        with self._free_lock:
+            self._free[index].add(chunk)
 
     cpdef free_all_blocks(self):
         # Free all **non-split** chunks
-        cdef list free_list
-        cdef Chunk chunk
-        for free_list in self._free:
-            for chunk in free_list:
-                if not chunk.prev and not chunk.next:
-                    free_list.remove(chunk)
+        with self._free_lock:
+            for i in range(len(self._free)):
+                keep_list = set()
+                for chunk in self._free[i]:
+                    if chunk.prev or chunk.next:
+                        keep_list.add(chunk)
+                self._free[i].clear()
+                self._free[i] = keep_list
 
     cpdef free_all_free(self):
         warnings.warn(
@@ -537,21 +554,24 @@ cdef class SingleDeviceMemoryPool:
 
     cpdef n_free_blocks(self):
         cdef Py_ssize_t n = 0
-        for v in self._free:
-            n += len(v)
+        with self._free_lock:
+            for v in self._free:
+                n += len(v)
         return n
 
     cpdef used_bytes(self):
         cdef Py_ssize_t size = 0
-        for chunk in self._in_use.itervalues():
-            size += chunk.size
+        with self._in_use_lock:
+            for chunk in self._in_use.itervalues():
+                size += chunk.size
         return size
 
     cpdef free_bytes(self):
         cdef Py_ssize_t size = 0
-        for free_list in self._free:
-            for chunk in free_list:
-                size += chunk.size
+        with self._free_lock:
+            for free_list in self._free:
+                for chunk in free_list:
+                    size += chunk.size
         return size
 
     cpdef total_bytes(self):

--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -3,9 +3,9 @@
 import collections
 import ctypes
 import gc
-import threading
 import warnings
 import weakref
+from fastrlock import rlock
 
 from cupy.cuda import runtime
 
@@ -390,8 +390,8 @@ cdef class SingleDeviceMemoryPool:
         self._free = [set() for i in range(self._initial_bins_size)]
         self._alloc = allocator
         self._weakref = weakref.ref(self)
-        self._free_lock = threading.Lock()
-        self._in_use_lock = threading.Lock()
+        self._free_lock = rlock.FastRLock()
+        self._in_use_lock = rlock.FastRLock()
 
     cpdef Py_ssize_t _round_size(self, Py_ssize_t size):
         """Round up the memory size to fit memory alignment of cudaMalloc."""

--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -458,14 +458,15 @@ cdef class SingleDeviceMemoryPool:
         # find best-fit, or a smallest larger allocation
         length = len(self._free)
         for i in range(index, length):
-            try:
-                rlock.lock_fastrlock(self._free_lock, -1, True)
-                free_list = self._free[i]
-                if free_list:
-                    chunk = free_list.pop()
-                    break
-            finally:
-                rlock.unlock_fastrlock(self._free_lock)
+            if self._free[i]:
+                try:
+                    rlock.lock_fastrlock(self._free_lock, -1, True)
+                    free_list = self._free[i]
+                    if free_list:
+                        chunk = free_list.pop()
+                        break
+                finally:
+                    rlock.unlock_fastrlock(self._free_lock)
 
         if chunk:
             chunk, remaining = self._split(chunk, size)

--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -414,7 +414,6 @@ cdef class SingleDeviceMemoryPool:
 
     cpdef tuple _split(self, Chunk chunk, Py_ssize_t size):
         """Split contiguous block of a larger allocation"""
-        assert chunk.ptr not in self._in_use
         assert chunk.size >= size
         if chunk.size == size:
             return (chunk, None)
@@ -434,8 +433,6 @@ cdef class SingleDeviceMemoryPool:
 
     cpdef Chunk _merge(self, Chunk head, Chunk remaining):
         """Merge previously splitted block (chunk)"""
-        assert head.ptr not in self._in_use
-        assert remaining.ptr not in self._in_use
         cdef Chunk merged
         size = head.size + remaining.size
         merged = Chunk(head.mem, head.offset, size)

--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -354,7 +354,7 @@ def check_extensions(extensions):
                 raise RuntimeError(msg)
 
 
-def get_ext_modules():
+def get_ext_modules(use_cython=False):
     arg_options = parse_args()
     print('Options:', arg_options)
 
@@ -364,13 +364,11 @@ def get_ext_modules():
     compiler = ccompiler.new_compiler()
     sysconfig.customize_compiler(compiler)
 
-    use_cython = check_cython_version()
     extensions = make_extensions(arg_options, compiler, use_cython)
 
     if use_cython:
         extensions = cythonize(extensions, arg_options)
 
-    check_extensions(extensions)
     return extensions
 
 
@@ -529,4 +527,7 @@ class custom_build_ext(build_ext.build_ext):
             # Intentionally causes DistutilsPlatformError in
             # ccompiler.new_compiler() function to hook.
             self.compiler = 'nvidia'
+        use_cython = check_cython_version()
+        extensions = get_ext_modules(use_cython)
+        check_extensions(extensions)
         build_ext.build_ext.run(self)

--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -527,7 +527,7 @@ class custom_build_ext(build_ext.build_ext):
             # Intentionally causes DistutilsPlatformError in
             # ccompiler.new_compiler() function to hook.
             self.compiler = 'nvidia'
-        use_cython = check_cython_version()
-        extensions = get_ext_modules(use_cython)
-        check_extensions(extensions)
+        if check_cython_version():
+            get_ext_modules(True)  # convert Cython files to cpp files
+        check_extensions(self.extensions)
         build_ext.build_ext.run(self)

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ install_requires = [
     'nose',
     'numpy>=1.9.0',
     'six>=1.9.0',
+    'fastrlock>=0.2',
 ]
 
 ext_modules = cupy_setup_build.get_ext_modules()

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,9 @@ set 1 to CUPY_PYTHON_350_FORCE environment variable."""
         sys.exit(1)
 
 
-setup_requires = []
+setup_requires = [
+    'fastrlock>=0.3',
+]
 install_requires = [
     'nose',
     'numpy>=1.9.0',

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ install_requires = [
     'nose',
     'numpy>=1.9.0',
     'six>=1.9.0',
-    'fastrlock>=0.2',
+    'fastrlock>=0.3',
 ]
 
 ext_modules = cupy_setup_build.get_ext_modules()


### PR DESCRIPTION
For https://github.com/cupy/cupy/issues/317#issuecomment-317614730

1. Remove in_use flag to avoid race-condition
2. Change free list from `list` to `set` so that we can find a free block fast without in_use flag
3. Add _free_lock and _in_use_lock to avoid race-condition with free_all_blocks, n_free_blocks(), used_bytes(), free_bytes(), and total_bytes().
    * Operations on `set` or `dict` are atomic in python, but locks are required for these functions which iterate set or dict.