### PR TITLE
Save CUDA source with environment variable

### DIFF
--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -161,6 +161,11 @@ def compile_with_cache(source, options=(), arch=None, cache_dir=None):
         temp_path = tf.name
     shutil.move(temp_path, path)
 
+    # Save .cu source file along with .cubin
+    if _get_bool_env_variable('CUPY_CACHE_SAVE_CUDA_SOURCE', False):
+        with open(path + '.cu', 'w') as f:
+            f.write(source)
+
     mod.load(cubin)
     return mod
 

--- a/docs/source/reference/environment.rst
+++ b/docs/source/reference/environment.rst
@@ -9,6 +9,12 @@ Here are the environment variables CuPy uses.
 |                                    | ``$(HOME)/.cupy.kernel_cache`` is used by default. |
 |                                    | See :ref:`overview` for details.                   |
 +------------------------------------+----------------------------------------------------+
+| ``CUPY_CACHE_SAVE_CUDA_SOURCE``    | If set to 1, CUDA source file will be saved along  |
+|                                    | with compiled binary in the cache directory for    |
+|                                    | debug purpose. It is disabled by default.          |
+|                                    | Note: source file will not be saved if the         |
+|                                    | compiled binary is already stored in the cache.    |
++------------------------------------+----------------------------------------------------+
 | ``CUPY_DUMP_CUDA_SOURCE_ON_ERROR`` | If set to 1, when CUDA kernel compilation fails,   |
 |                                    | CuPy dumps CUDA kernel code to standard error.     |
 |                                    | It is disabled by default.                         |


### PR DESCRIPTION
I often insert this code to inspect generated CUDA source.
It would be useful if this can be enabled by an environment variable.