### PR TITLE
Add test for transpose when axes is not none

### DIFF
--- a/tests/cupy_tests/sparse_tests/test_coo.py
+++ b/tests/cupy_tests/sparse_tests/test_coo.py
@@ -664,6 +664,11 @@ class TestCooMatrixScipyComparison(unittest.TestCase):
         m = self.make(xp, sp, self.dtype)
         return m.transpose().toarray()
 
+    @testing.numpy_cupy_raises(sp_name='sp', accept_error=ValueError)
+    def test_transpose_axes_int(self, xp, sp):
+        m = _make(xp, sp, self.dtype)
+        m.transpose(axes=0)
+
 
 @testing.parameterize(*testing.product({
     'dtype': [numpy.float32, numpy.float64],

--- a/tests/cupy_tests/sparse_tests/test_csc.py
+++ b/tests/cupy_tests/sparse_tests/test_csc.py
@@ -626,6 +626,11 @@ class TestCscMatrixScipyComparison(unittest.TestCase):
         m = _make(xp, sp, self.dtype)
         return m.transpose().toarray()
 
+    @testing.numpy_cupy_raises(sp_name='sp', accept_error=ValueError)
+    def test_transpose_axes_int(self, xp, sp):
+        m = _make(xp, sp, self.dtype)
+        m.transpose(axes=0)
+
 
 @testing.parameterize(*testing.product({
     'dtype': [numpy.float32, numpy.float64],

--- a/tests/cupy_tests/sparse_tests/test_csr.py
+++ b/tests/cupy_tests/sparse_tests/test_csr.py
@@ -683,6 +683,11 @@ class TestCsrMatrixScipyComparison(unittest.TestCase):
         m = _make(xp, sp, self.dtype)
         return m.transpose().toarray()
 
+    @testing.numpy_cupy_raises(sp_name='sp', accept_error=ValueError)
+    def test_transpose_axes_int(self, xp, sp):
+        m = _make(xp, sp, self.dtype)
+        m.transpose(axes=0)
+
 
 @testing.parameterize(*testing.product({
     'dtype': [numpy.float32, numpy.float64],


### PR DESCRIPTION
I added a test case when `axes` argument is not `None`. It causes `ValueError`.