### PR TITLE
Changed order argument for unknown order test as SciPy causes DeprecationWarning

### DIFF
--- a/tests/cupy_tests/sparse_tests/test_csc.py
+++ b/tests/cupy_tests/sparse_tests/test_csc.py
@@ -315,7 +315,7 @@ class TestCscMatrixScipyComparison(unittest.TestCase):
     @testing.numpy_cupy_raises(sp_name='sp', accept_error=TypeError)
     def test_toarray_unknown_order(self, xp, sp):
         m = _make(xp, sp, self.dtype)
-        m.toarray(order='unknown')
+        m.toarray(order='#')
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_A(self, xp, sp):

--- a/tests/cupy_tests/sparse_tests/test_csr.py
+++ b/tests/cupy_tests/sparse_tests/test_csr.py
@@ -328,7 +328,7 @@ class TestCsrMatrixScipyComparison(unittest.TestCase):
     @testing.numpy_cupy_raises(sp_name='sp', accept_error=TypeError)
     def test_toarray_unknown_order(self, xp, sp):
         m = _make(xp, sp, self.dtype)
-        m.toarray(order='unknown')
+        m.toarray(order='#')
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_A(self, xp, sp):


### PR DESCRIPTION
SciPy causes DeprecationWarning when order argument has more than two characters before it raises an actual error. To prevent it, I changed the test argument.