### PR TITLE
[backport] Use randint instead of random_integer that is deprecated

### DIFF
--- a/tests/cupy_tests/testing_tests/test_array.py
+++ b/tests/cupy_tests/testing_tests/test_array.py
@@ -41,7 +41,7 @@ def _convert_array(xs, array_module):
     elif array_module == 'all_cupy':
         return cupy.asarray(xs)
     else:
-        return [cupy.asarray(x) if numpy.random.random_integers(0, 1)
+        return [cupy.asarray(x) if numpy.random.randint(0, 2)
                 else x for x in xs]
 
 


### PR DESCRIPTION
This PR is backport of #425.