### PR TITLE
Use AxisError with numpy compat.

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -826,7 +826,7 @@ cdef class ndarray:
         if axis < 0:
             axis += ndim
         if not (0 <= axis < ndim):
-            raise ValueError('Axis out of range')
+            raise _AxisError('Axis out of range')
 
         if axis == ndim - 1:
             data = data.copy()

--- a/tests/cupy_tests/sorting_tests/test_sort.py
+++ b/tests/cupy_tests/sorting_tests/test_sort.py
@@ -242,15 +242,27 @@ class TestArgsort(unittest.TestCase):
         a = testing.shaped_random((2, 3, 3), xp)
         return self.argsort(a, axis=None)
 
+    @testing.with_requires('numpy>=1.13')
     @testing.numpy_cupy_raises()
-    def test_argsort_invalid_axis(self, xp):
+    def test_argsort_invalid_axis1(self, xp):
         a = testing.shaped_random((2, 3, 3), xp)
         return self.argsort(a, axis=3)
 
+    def test_argsort_invalid_axis2(self):
+        a = testing.shaped_random((2, 3, 3), cupy)
+        with self.assertRaises(cupy.core.core._AxisError):
+            return self.argsort(a, axis=3)
+
+    @testing.with_requires('numpy>=1.13')
     @testing.numpy_cupy_raises()
-    def test_argsort_invalid_negative_axis(self, xp):
+    def test_argsort_invalid_negative_axis1(self, xp):
         a = testing.shaped_random((2, 3, 3), xp)
         return self.argsort(a, axis=-4)
+
+    def test_argsort_invalid_negative_axis2(self):
+        a = testing.shaped_random((2, 3, 3), cupy)
+        with self.assertRaises(cupy.core.core._AxisError):
+            return self.argsort(a, axis=-4)
 
     # Misc tests
 


### PR DESCRIPTION
Rel #347.

This PR fixes argsort to raise `AxisError` on numpy >= 1.13.