### PR TITLE
Unified memory

### DIFF
--- a/cupy/cuda/__init__.py
+++ b/cupy/cuda/__init__.py
@@ -53,6 +53,8 @@ from cupy.cuda.device import get_device_id  # NOQA
 from cupy.cuda.function import Function  # NOQA
 from cupy.cuda.function import Module  # NOQA
 from cupy.cuda.memory import alloc  # NOQA
+from cupy.cuda.memory import malloc_managed  # NOQA
+from cupy.cuda.memory import ManagedMemory  # NOQA
 from cupy.cuda.memory import Memory  # NOQA
 from cupy.cuda.memory import MemoryPointer  # NOQA
 from cupy.cuda.memory import MemoryPool  # NOQA

--- a/cupy/cuda/cupy_cuda.h
+++ b/cupy/cuda/cupy_cuda.h
@@ -39,15 +39,36 @@ typedef enum cudaDataType_t cudaDataType;
 #endif // #if CUDA_VERSION >= 7050
 #endif // #if CUDA_VERSION < 8000
 
+
 #if CUDA_VERSION < 7050
 cublasStatus_t cublasSgemmEx(...) {
     return CUBLAS_STATUS_NOT_SUPPORTED;
 }
+
 #endif // #if CUDA_VERSION < 7050
+
+
+#if CUDA_VERSION < 8000
+
+enum cudaMemoryAdvise {};
+
+cudaError_t cudaMemPrefetchAsync(const void *devPtr, size_t count,
+                                 int dstDevice, cudaStream_t stream) {
+    return cudaErrorUnknown;
+}
+
+cudaError_t cudaMemAdvise(const void *devPtr, size_t count,
+                          enum cudaMemoryAdvise advice, int device) {
+    return cudaErrorUnknown;
+}
+
+#endif // #if CUDA_VERSION < 8000
 
 } // extern "C"
 
 #else // #ifndef CUPY_NO_CUDA
+
+
 
 extern "C" {
 
@@ -139,6 +160,7 @@ typedef enum {
 } cudaError_t;
 typedef enum {} cudaDataType;
 enum cudaDeviceAttr {};
+enum cudaMemoryAdvise {};
 enum cudaMemcpyKind {};
 
 
@@ -218,6 +240,10 @@ cudaError_t cudaHostAlloc(...) {
     return cudaSuccess;
 }
 
+cudaError_t cudaMallocManaged(...) {
+    return cudaSuccess;
+}
+
 int cudaFree(...) {
     return cudaSuccess;
 }
@@ -253,6 +279,15 @@ cudaError_t cudaMemset(...) {
 cudaError_t cudaMemsetAsync(...) {
     return cudaSuccess;
 }
+
+cudaError_t cudaMemAdvise(...) {
+    return cudaSuccess;
+}
+
+cudaError_t cudaMemPrefetchAsync(...) {
+    return cudaSuccess;
+}
+
 
 cudaError_t cudaPointerGetAttributes(...) {
     return cudaSuccess;

--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -14,9 +14,6 @@ from cupy.cuda cimport device
 from cupy.cuda cimport runtime
 
 
-_cuda_version = runtime.runtimeGetVersion()
-
-
 class OutOfMemoryError(MemoryError):
 
     def __init__(self, size, total):

--- a/cupy/cuda/runtime.pxd
+++ b/cupy/cuda/runtime.pxd
@@ -30,10 +30,21 @@ cpdef enum:
     cudaMemoryTypeHost = 1
     cudaMemoryTypeDevice = 2
 
+    cudaMemAttachGlobal = 1
+    cudaMemAttachHost = 2
+    cudaMemAttachSingle = 4
+
     hostAllocDefault = 0
     hostAllocPortable = 1
     hostAllocMapped = 2
     hostAllocWriteCombined = 4
+
+    cudaMemAdviseSetReadMostly = 1
+    cudaMemAdviseUnsetReadMostly = 2
+    cudaMemAdviseSetPreferredLocation = 3
+    cudaMemAdviseUnsetPreferredLocation = 4
+    cudaMemAdviseSetAccessedBy = 5
+    cudaMemAdviseUnsetAccessedBy = 6
 
     streamDefault = 0
     streamNonBlocking = 1
@@ -91,6 +102,7 @@ cpdef deviceEnablePeerAccess(int peerDevice)
 ###############################################################################
 
 cpdef size_t malloc(size_t size) except *
+cpdef size_t mallocManaged(size_t size, unsigned int flags=*) except *
 cpdef size_t hostAlloc(size_t size, unsigned int flags) except *
 cpdef free(size_t ptr)
 cpdef freeHost(size_t ptr)
@@ -105,6 +117,9 @@ cpdef memcpyPeerAsync(size_t dst, int dstDevice,
                       size_t size, size_t stream)
 cpdef memset(size_t ptr, int value, size_t size)
 cpdef memsetAsync(size_t ptr, int value, size_t size, size_t stream)
+cpdef memPrefetchAsync(size_t devPtr, size_t count, int dstDevice,
+                       size_t stream)
+cpdef memAdvise(size_t devPtr, int count, int advice, int device)
 cpdef PointerAttributes pointerGetAttributes(size_t ptr)
 
 

--- a/cupy/cuda/runtime.pyx
+++ b/cupy/cuda/runtime.pyx
@@ -298,12 +298,13 @@ cpdef memPrefetchAsync(size_t devPtr, size_t count, int dstDevice,
                        size_t stream):
     with nogil:
         status = cudaMemPrefetchAsync(<void*>devPtr, count, dstDevice,
-                                  <driver.Stream> stream)
+                                      <driver.Stream> stream)
     check_status(status)
 
 cpdef memAdvise(size_t devPtr, int count, int advice, int device):
     with nogil:
-        status = cudaMemAdvise(<void*>devPtr, count, <MemoryAdvise>advice, device)
+        status = cudaMemAdvise(<void*>devPtr, count,
+                               <MemoryAdvise>advice, device)
     check_status(status)
 
 

--- a/tests/cupy_tests/cuda_tests/test_memory.py
+++ b/tests/cupy_tests/cuda_tests/test_memory.py
@@ -99,7 +99,6 @@ class TestMemoryPointer(unittest.TestCase):
 # -----------------------------------------------------------------------------
 # Memory pool
 
-
 @testing.gpu
 class TestSingleDeviceMemoryPool(unittest.TestCase):
 
@@ -310,11 +309,14 @@ class TestSingleDeviceMemoryPool(unittest.TestCase):
         del p3
 
 
+@testing.parameterize(*testing.product({
+    'allocator': [memory._malloc, memory.malloc_managed],
+}))
 @testing.gpu
 class TestMemoryPool(unittest.TestCase):
 
     def setUp(self):
-        self.pool = memory.MemoryPool()
+        self.pool = memory.MemoryPool(self.allocator)
 
     def test_zero_size_alloc(self):
         with cupy.cuda.Device(0):


### PR DESCRIPTION
follow-up: https://github.com/cupy/cupy/pull/163

The advantage using unified memory in CuPy is that device memory
oversubscription is possible for GPUs that have a non-zero value for the
device attribute cudaDevAttrConcurrentManagedAccess.
CUDA >= 8.0 with GPUs later than or equal to Pascal is preferrable.

Read more at: http://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__MEMORY.html#axzz4qygc1Ry1

## How to change the allocator

Without memory pool:

```
set_allocator(malloc_managed)
```

With memory pool:

```
set_allocator(MemoryPool(malloc_managed).malloc)
```

## What not supported

* Using unified memory, we should be able to eliminate CPU <=> GPU memory transfer codes. But, it is not supported in this PR.
* We've added `ManagedMemory.prefetch` and `ManagedMemory.advice` API, but we still do not have easy interfaces to call them for cupy ndarray.
