### PR TITLE
Fusion kernel name

### DIFF
--- a/cupy/core/fusion.py
+++ b/cupy/core/fusion.py
@@ -37,12 +37,6 @@ class FusionOp(object):
         return "<FusionOp, name={}, types=[{}]>".format(
             self.name, ', '.join(_.name for _ in self.types))
 
-    def build_kernel_name(self):
-        return self.name + '_' + '_'.join([
-            'IN_' + '_'.join(build_kernel_name(_) for _ in self.in_vars),
-            'OUT_' + '_'.join(build_kernel_name(_) for _ in self.out_vars),
-        ])
-
 
 class _FusionVar(object):
 
@@ -54,9 +48,6 @@ class _FusionVar(object):
     def __repr__(self):
         return "<_FusionVar, num={}, ty={}, const={}>".format(
             self.num, self.ty, self.const)
-
-    def build_kernel_name(self):
-        return self.ty.name + '_at' + str(self.num)
 
 
 class _FusionMem(object):
@@ -93,9 +84,6 @@ class _FusionRef(object):
 
     def __repr__(self):
         return "<_FusionRef, dtype=%s>" % self.dtype
-
-    def build_kernel_name(self):
-        return build_kernel_name(self._var)
 
     def __neg__(self):
         return negative(self)
@@ -498,7 +486,7 @@ def _get_fix_code(data_type, fixed_type, operation):
     return module_code
 
 
-def _get_fusion(func, nin, reduce, post_map, identity, input_types, name=None):
+def _get_fusion(func, nin, reduce, post_map, identity, input_types, name):
     in_vars = [_FusionVar(i, t) for i, t in enumerate(input_types)]
     mem = _FusionMem(in_vars)
     in_refs = [_FusionRef(_, mem) for _ in in_vars]
@@ -516,9 +504,6 @@ def _get_fusion(func, nin, reduce, post_map, identity, input_types, name=None):
     operation = ''.join(_get_declaration_from_var(_) for _ in tmpvars)
     operation += ''.join(_get_declaration_from_op(_) for _ in op_list)
     operation += '\n'.join(_get_operation_code(_) for _ in op_list)
-
-    if name is None:
-        name = 'fusion__' + '__'.join(build_kernel_name(_) for _ in op_list)
 
     if reduce is None:
         if not out_params:
@@ -633,7 +618,7 @@ class Fusion(object):
                 else:
                     nin = len(args)
                 f = _get_fusion(self.func, nin, self.reduce,
-                                self.post_map, self.identity, types)
+                                self.post_map, self.identity, types, self.name)
                 self._memo[key] = f
             f = self._memo[key]
             if self.reduce is None:
@@ -678,17 +663,6 @@ def fuse(*args, **kwargs):
     else:
         return lambda f: functools.update_wrapper(
             wrapper(f, *args, **kwargs), f)
-
-
-def build_kernel_name(entity):
-    if isinstance(entity, FusionOp):
-        return entity.build_kernel_name()
-    elif isinstance(entity, _FusionVar):
-        return entity.build_kernel_name()
-    elif isinstance(entity, _FusionRef):
-        return entity.build_kernel_name()
-    else:
-        assert False, type(entity)
 
 
 class ufunc(core.ufunc):

--- a/cupy/core/fusion.py
+++ b/cupy/core/fusion.py
@@ -559,6 +559,7 @@ def _get_fusion(func, nin, reduce, post_map, identity, input_types, name):
                                     reduce_code,
                                     'res = _post_map(_post_fix(a))',
                                     identity,
+                                    name=name,
                                     reduce_type=post_type,
                                     preamble=submodule_code)
 

--- a/cupy/core/fusion.py
+++ b/cupy/core/fusion.py
@@ -577,9 +577,9 @@ class Fusion(object):
         post_map (function): Mapping function for reduced values.
     """
 
-    def __init__(self, func, input_num, reduce, post_map):
+    def __init__(self, func, input_num, reduce, post_map, name=None):
         self.func = func
-        self.name = func.__name__
+        self.name = name or func.__name__
         self.input_num = input_num
         self.reduce = reduce
         self.post_map = post_map
@@ -655,8 +655,10 @@ def fuse(*args, **kwargs):
     """
     util.experimental('cupy.core.fusion')
 
-    def wrapper(f, input_num=None, reduce=None, post_map=lambda x: x):
-        return Fusion(f, input_num, reduce, post_map)
+    def wrapper(
+            f, input_num=None, reduce=None, post_map=lambda x: x,
+            kernel_name=None):
+        return Fusion(f, input_num, reduce, post_map, kernel_name)
 
     if len(args) == 1 and len(kwargs) == 0 and callable(args[0]):
         return functools.update_wrapper(wrapper(args[0]), args[0])

--- a/cupy/core/fusion.py
+++ b/cupy/core/fusion.py
@@ -653,6 +653,8 @@ def fuse(*args, **kwargs):
             pre-mapping step. If not assigned, reduction step is skipped.
         post_map (function): Mapping function for reduced values.
             If not assigned, post_map step is skipped.
+        kernel_name (str): Name of the fused kernel function.
+            If omitted, the name of the decorated function is used.
     """
     util.experimental('cupy.core.fusion')
 


### PR DESCRIPTION
* Use target function name as the kernel name by default
* Add `kernel_name` option to `fuse` to override the kernel name