### PR TITLE
Added test for __iter__

### DIFF
--- a/tests/cupy_tests/sparse_tests/test_csr.py
+++ b/tests/cupy_tests/sparse_tests/test_csr.py
@@ -361,6 +361,16 @@ class TestCsrMatrixScipyComparison(unittest.TestCase):
         len(m)
 
     @testing.numpy_cupy_array_equal(sp_name='sp')
+    def test_iter(self, xp, sp):
+        m = _make(xp, sp, self.dtype)
+        rows = []
+        for r in m:
+            rows.append(r)
+            self.assertIsInstance(r, sp.spmatrix)
+        self.assertEqual(len(rows), 3)
+        return xp.concatenate([r.toarray() for r in rows])
+
+    @testing.numpy_cupy_array_equal(sp_name='sp')
     def test_asfptype(self, xp, sp):
         m = _make(xp, sp, self.dtype)
         return m.asfptype().toarray()


### PR DESCRIPTION
I wrote test for `__iter__`. Note that this method uses `__getitem__` and int index is only supported in csr_matrix.