### PR TITLE
use continuous copies for concatenate if arrays are not contiguous on axis

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2409,6 +2409,7 @@ cpdef ndarray concatenate(tup, axis, shape, dtype):
     all_same_type = True
     all_one_and_contiguous = True
     any_contiguous_on_axis = False
+    total_bytes = 0
     dtype = tup[0].dtype
     for a in tup:
         all_same_type = all_same_type and (a.dtype == dtype)
@@ -2418,8 +2419,10 @@ cpdef ndarray concatenate(tup, axis, shape, dtype):
         any_contiguous_on_axis = (
             any_contiguous_on_axis or
             a._strides[axis] == a.itemsize)
+        total_bytes += a.size * a.itemsize
 
-    if not all_same_type or not any_contiguous_on_axis:
+    if ((not all_same_type or not any_contiguous_on_axis) and
+            (len(tup) < 256 or total_bytes / len(tup) > 524288)):
         skip = (slice(None),) * axis
         i = 0
         for a in tup:

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2406,47 +2406,48 @@ cpdef ndarray concatenate(tup, axis, shape, dtype):
 
     ret = ndarray(shape, dtype=dtype)
 
-    if len(tup) > 3:
-        all_same_type = True
-        all_one_and_contiguous = True
-        dtype = tup[0].dtype
-        for a in tup:
-            all_same_type = all_same_type and (a.dtype == dtype)
-            all_one_and_contiguous = (
-                all_one_and_contiguous and a._c_contiguous and
-                a._shape[axis] == 1)
-
-        if all_same_type:
-            ptrs = numpy.ndarray(len(tup), numpy.int64)
-            for i, a in enumerate(tup):
-                ptrs[i] = a.data.ptr
-            x = array(ptrs)
-
-            if all_one_and_contiguous:
-                base = <int>internal.prod_ssize_t(shape[axis + 1:])
-                _concatenate_kernel_one(x, base, ret)
-            else:
-                ndim = tup[0].ndim
-                x_strides = numpy.ndarray((len(tup), ndim), numpy.int32)
-                cum_sizes = numpy.ndarray(len(tup), numpy.int32)
-                cum = 0
-                for i, a in enumerate(tup):
-                    for j in range(ndim):
-                        x_strides[i, j] = <int>a._strides[j]
-                    cum_sizes[i] = cum
-                    cum += <int>a._shape[axis]
-
-                _concatenate_kernel(
-                    x, axis, array(cum_sizes), array(x_strides), ret)
-            return ret
-
-    skip = (slice(None),) * axis
-    i = 0
+    all_same_type = True
+    all_one_and_contiguous = True
+    any_contiguous_on_axis = False
+    dtype = tup[0].dtype
     for a in tup:
-        aw = a._shape[axis]
-        ret[skip + (slice(i, i + aw),)] = a
-        i += aw
+        all_same_type = all_same_type and (a.dtype == dtype)
+        all_one_and_contiguous = (
+            all_one_and_contiguous and a._c_contiguous and
+            a._shape[axis] == 1)
+        any_contiguous_on_axis = (
+            any_contiguous_on_axis or
+            a._strides[axis] == a.itemsize)
 
+    if not all_same_type or not any_contiguous_on_axis:
+        skip = (slice(None),) * axis
+        i = 0
+        for a in tup:
+            aw = a._shape[axis]
+            ret[skip + (slice(i, i + aw),)] = a
+            i += aw
+    else:
+        ptrs = numpy.ndarray(len(tup), numpy.int64)
+        for i, a in enumerate(tup):
+            ptrs[i] = a.data.ptr
+        x = array(ptrs)
+
+        if all_one_and_contiguous:
+            base = <int>internal.prod_ssize_t(shape[axis + 1:])
+            _concatenate_kernel_one(x, base, ret)
+        else:
+            ndim = tup[0].ndim
+            x_strides = numpy.ndarray((len(tup), ndim), numpy.int32)
+            cum_sizes = numpy.ndarray(len(tup), numpy.int32)
+            cum = 0
+            for i, a in enumerate(tup):
+                for j in range(ndim):
+                    x_strides[i, j] = <int>a._strides[j]
+                cum_sizes[i] = cum
+                cum += <int>a._shape[axis]
+
+            _concatenate_kernel(
+                x, axis, array(cum_sizes), array(x_strides), ret)
     return ret
 
 cdef _concatenate_kernel_one = ElementwiseKernel(


### PR DESCRIPTION
For #419 

benchmark code:
```
from itertools import product

import cupy as xp
from cupy import cuda

cnt = 1000
xs = xp.random.rand(256, 256, 256)

for axis, order, transpose in product([0, -1], ['C', 'F'], [True, False]):
    arr = [x.copy() if order is 'C' else xp.asfortranarray(x.copy()) for x in xs]
    tup = [a.T if transpose else a for a in arr]
    stream = cuda.Stream.null
    start = stream.record()
    for _ in range(cnt):
        _ = xp.concatenate(tup, axis=axis)
    end = stream.record()
    end.synchronize()
    elapsed = xp.cuda.get_elapsed_time(start, end) / cnt
    print("axis: {}, order: {}, T: {}, elapsed: {}".format(axis, order, transpose, elapsed))
```

This pull request:
```
axis: 0, order: C, T: True, elapsed: 7.17641357421875
axis: 0, order: C, T: False, elapsed: 2.462125732421875
axis: 0, order: F, T: True, elapsed: 2.475766845703125
axis: 0, order: F, T: False, elapsed: 6.72791455078125
axis: -1, order: C, T: True, elapsed: 4.633283203125
axis: -1, order: C, T: False, elapsed: 6.23294873046875
axis: -1, order: F, T: True, elapsed: 6.19220849609375
axis: -1, order: F, T: False, elapsed: 4.65268212890625
```

master
```
axis: 0, order: C, T: True, elapsed: 7.17486572265625
axis: 0, order: C, T: False, elapsed: 6.489275390625
axis: 0, order: F, T: True, elapsed: 6.13665966796875
axis: 0, order: F, T: False, elapsed: 6.7003427734375
axis: -1, order: C, T: True, elapsed: 12.597591796875
axis: -1, order: C, T: False, elapsed: 6.2214814453125
axis: -1, order: F, T: True, elapsed: 6.1746484375
axis: -1, order: F, T: False, elapsed: 12.63175390625
```