### PR TITLE
Fix test for tensorsolve

### DIFF
--- a/tests/cupy_tests/linalg_tests/test_solve.py
+++ b/tests/cupy_tests/linalg_tests/test_solve.py
@@ -43,8 +43,6 @@ class TestSolve(unittest.TestCase):
         self.check_shape((3, 3, 4), (3,))
 
 
-@unittest.skipUnless(
-    cuda.cusolver_enabled, 'Only cusolver in CUDA 8.0 is supported')
 @testing.parameterize(*testing.product({
     'a_shape': [(2, 3, 6), (3, 4, 4, 3)],
     'dtype': [numpy.float32, numpy.float64],
@@ -52,6 +50,8 @@ class TestSolve(unittest.TestCase):
 }))
 @testing.fix_random()
 @testing.gpu
+@unittest.skipUnless(
+    cuda.cusolver_enabled, 'Only cusolver in CUDA 8.0 is supported')
 class TestTensorSolve(unittest.TestCase):
 
     _multiprocess_can_split_ = True

--- a/tests/cupy_tests/linalg_tests/test_solve.py
+++ b/tests/cupy_tests/linalg_tests/test_solve.py
@@ -62,9 +62,8 @@ class TestTensorSolve(unittest.TestCase):
         self.b = numpy.random.randint(
             0, 10, size=self.a_shape[:2]).astype(self.dtype)
 
-    @testing.for_float_dtypes(no_float16=True)
     @testing.numpy_cupy_allclose(atol=0.02)
-    def test_tensorsolve(self, xp, dtype):
+    def test_tensorsolve(self, xp):
         a = xp.array(self.a)
         b = xp.array(self.b)
         return xp.linalg.tensorsolve(a, b, axes=self.axes)


### PR DESCRIPTION
I found `axes` argument in `tensorsolve` is not tested.