### PR TITLE
Clear doctest warnings

### DIFF
--- a/cupy/core/elementwise.pxi
+++ b/cupy/core/elementwise.pxi
@@ -730,7 +730,9 @@ class ufunc(object):
         return types
 
     def __call__(self, *args, **kwargs):
-        """Applies the universal function to arguments elementwise.
+        """__call__(*args, **kwargs)
+
+        Applies the universal function to arguments elementwise.
 
         Args:
             args: Input arguments. Each of them can be a :class:`cupy.ndarray`

--- a/cupy/core/reduction.pxi
+++ b/cupy/core/reduction.pxi
@@ -347,7 +347,9 @@ class ReductionKernel(object):
         self.preamble = preamble
 
     def __call__(self, *args, **kwargs):
-        """Compiles and invokes the reduction kernel.
+        """__call__(*args, **kwargs)
+
+        Compiles and invokes the reduction kernel.
 
         The compilation runs only if the kernel is not cached. Note that the
         kernels with different argument dtypes, ndims, or axis are not


### PR DESCRIPTION
Clear warnings in doctest.
This is needed before merging https://github.com/cupy/cupy/pull/442 .