### PR TITLE
Add documents of cupy.linalg

### DIFF
--- a/cupy/linalg/decomposition.py
+++ b/cupy/linalg/decomposition.py
@@ -81,15 +81,15 @@ def qr(a, mode='reduced'):
         a (cupy.ndarray): The input matrix.
         mode (str): The mode of decomposition. Currently 'reduced',
             'complete', 'r', and 'raw' modes are supported. The default mode
-            is 'reduced', and decompose a matrix ``A = (M, N)`` into ``Q``,
-            ``R`` with dimensions ``(M, K)``, ``(K, N)``, where
+            is 'reduced', in which matrix ``A = (M, N)`` is decomposed into
+            ``Q``, ``R`` with dimensions ``(M, K)``, ``(K, N)``, where
             ``K = min(M, N)``.
 
     Returns:
-        cupy.ndarray, or tuple of :class:`~cupy.ndarray`:
-            Although the type of returned objects depends on the mode,
+        cupy.ndarray, or tuple of ndarray:
+            Although the type of returned object depends on the mode,
             it returns a tuple of ``(Q, R)`` by default.
-            For details, please see the document of ``numpy.linalg.qr``.
+            For details, please see the document of :func:`numpy.linalg.qr`.
 
     .. seealso:: :func:`numpy.linalg.qr`
     '''
@@ -183,7 +183,7 @@ def qr(a, mode='reduced'):
 def svd(a, full_matrices=True, compute_uv=True):
     '''Singular Value Decomposition.
 
-    Factorizes the matrix ``a`` as ``U * np.diag(S) * v``, where ``u`` and
+    Factorizes the matrix ``a`` as ``u * np.diag(s) * v``, where ``u`` and
     ``v`` are unitary and ``s`` is an one-dimensional array of ``a``'s
     singular values.
 
@@ -196,7 +196,7 @@ def svd(a, full_matrices=True, compute_uv=True):
         compute_uv (bool): If True, it only returns singular values.
 
     Returns:
-        tuple of :class:`~cupy.ndarray`:
+        tuple of :class:`cupy.ndarray`:
             A tuple of ``(u, s, v)`` such that ``a = u * np.diag(s) * v``.
 
     .. seealso:: :func:`numpy.linalg.svd`

--- a/cupy/linalg/decomposition.py
+++ b/cupy/linalg/decomposition.py
@@ -22,6 +22,9 @@ def cholesky(a):
     Args:
         a (cupy.ndarray): The input matrix with dimension ``(N, N)``
 
+    Returns:
+        cupy.ndarray: The lower-triangular matrix.
+
     .. seealso:: :func:`numpy.linalg.cholesky`
     '''
     if not cuda.cusolver_enabled:
@@ -81,6 +84,12 @@ def qr(a, mode='reduced'):
             is 'reduced', and decompose a matrix ``A = (M, N)`` into ``Q``,
             ``R`` with dimensions ``(M, K)``, ``(K, N)``, where
             ``K = min(M, N)``.
+
+    Returns:
+        cupy.ndarray, or tuple of :class:`~cupy.ndarray`:
+            Although the type of returned objects depends on the mode,
+            it returns a tuple of ``(Q, R)`` by default.
+            For details, please see the document of ``numpy.linalg.qr``.
 
     .. seealso:: :func:`numpy.linalg.qr`
     '''
@@ -174,17 +183,21 @@ def qr(a, mode='reduced'):
 def svd(a, full_matrices=True, compute_uv=True):
     '''Singular Value Decomposition.
 
-    Factorizes the matrix ``a`` as ``u * np.diag(s) * v``, where ``u`` and
+    Factorizes the matrix ``a`` as ``U * np.diag(S) * v``, where ``u`` and
     ``v`` are unitary and ``s`` is an one-dimensional array of ``a``'s
     singular values.
 
     Args:
         a (cupy.ndarray): The input matrix with dimension ``(M, N)``.
-        full_matrices (bool): If True, it returns U and V with dimensions
-            ``(M, M)`` and ``(N, N)``. Otherwise, the dimensions of U and V
+        full_matrices (bool): If True, it returns u and v with dimensions
+            ``(M, M)`` and ``(N, N)``. Otherwise, the dimensions of u and v
             are respectively ``(M, K)`` and ``(K, N)``, where
             ``K = min(M, N)``.
         compute_uv (bool): If True, it only returns singular values.
+
+    Returns:
+        tuple of :class:`~cupy.ndarray`:
+            A tuple of ``(u, s, v)`` such that ``a = u * np.diag(s) * v``.
 
     .. seealso:: :func:`numpy.linalg.svd`
     '''

--- a/cupy/linalg/solve.py
+++ b/cupy/linalg/solve.py
@@ -23,6 +23,10 @@ def solve(a, b):
         b (cupy.ndarray): The vector with ``M`` elements, or
             the matrix with dimension ``(M, K)``
 
+    Returns:
+        cupy.ndarray: The vector with ``M`` elements, or
+            the matrix with dimension ``(M, K)``.
+
     .. seealso:: :func:`numpy.linalg.solve`
     '''
     # NOTE: Since cusolver in CUDA 8.0 does not support gesv,
@@ -109,6 +113,10 @@ def tensorsolve(a, b, axes=None):
         b (cupy.ndarray): The tensor with ``len(shape) >= 1``
         axes (tuple of ints): Axes in ``a`` to reorder to the right
             before inversion.
+
+    Returns:
+        cupy.ndarray: The tensor with shape ``Q`` such that
+            ``b.shape + Q == a.shape``.
 
     .. seealso:: :func:`numpy.linalg.tensorsolve`
     '''

--- a/cupy/linalg/solve.py
+++ b/cupy/linalg/solve.py
@@ -24,8 +24,9 @@ def solve(a, b):
             the matrix with dimension ``(M, K)``
 
     Returns:
-        cupy.ndarray: The vector with ``M`` elements, or
-            the matrix with dimension ``(M, K)``.
+        cupy.ndarray:
+            The vector with ``M`` elements, or the matrix with dimension
+            ``(M, K)``.
 
     .. seealso:: :func:`numpy.linalg.solve`
     '''
@@ -115,8 +116,8 @@ def tensorsolve(a, b, axes=None):
             before inversion.
 
     Returns:
-        cupy.ndarray: The tensor with shape ``Q`` such that
-            ``b.shape + Q == a.shape``.
+        cupy.ndarray:
+            The tensor with shape ``Q`` such that ``b.shape + Q == a.shape``.
 
     .. seealso:: :func:`numpy.linalg.tensorsolve`
     '''


### PR DESCRIPTION
This PR adds ``Returns:`` sections to ``cupy.linalg`` functions.