### PR TITLE
Set default memory allocator

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -526,3 +526,11 @@ def get_array_module(*args):
 fuse = fusion.fuse
 
 disable_experimental_feature_warning = False
+
+
+# set default allocator
+default_memory_pool = cuda.MemoryPool()
+default_pinned_memory_pool = cuda.PinnedMemoryPool()
+
+cuda.set_allocator(default_memory_pool.malloc)
+cuda.set_pinned_memory_allocator(default_pinned_memory_pool.malloc)

--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -529,8 +529,36 @@ disable_experimental_feature_warning = False
 
 
 # set default allocator
-default_memory_pool = cuda.MemoryPool()
-default_pinned_memory_pool = cuda.PinnedMemoryPool()
+_default_memory_pool = cuda.MemoryPool()
+_default_pinned_memory_pool = cuda.PinnedMemoryPool()
 
-cuda.set_allocator(default_memory_pool.malloc)
-cuda.set_pinned_memory_allocator(default_pinned_memory_pool.malloc)
+cuda.set_allocator(_default_memory_pool.malloc)
+cuda.set_pinned_memory_allocator(_default_pinned_memory_pool.malloc)
+
+
+def get_default_memory_pool():
+    """Returns CuPy default memory pool.
+
+    Returns:
+        cupy.cuda.MemoryPool: it is memory pool object.
+
+    .. note::
+       If you want to disable memory pool, please use the following code.
+       >>> cupy.cuda.set_allocator()
+
+    """
+    return _default_memory_pool
+
+
+def get_default_pinned_memory_pool():
+    """Returns CuPy default memory pool.
+
+    Returns:
+        cupy.cuda.MemoryPool: it is memory pool object.
+
+    .. note::
+       If you want to disable memory pool, please use the following code.
+       >>> cupy.cuda.set_pinned_memory_allocator()
+
+    """
+    return _default_pinned_memory_pool

--- a/tests/cupy_tests/test_init.py
+++ b/tests/cupy_tests/test_init.py
@@ -7,6 +7,7 @@ import tempfile
 import unittest
 
 
+import cupy
 from cupy import testing
 
 
@@ -79,6 +80,17 @@ class TestNotAvailable(unittest.TestCase):
         os.environ['CUDA_VISIBLE_DEVICES'] = '-1'
         available = _test_cupy_available(self)
         self.assertFalse(available)
+
+
+class TestMemoryPool(unittest.TestCase):
+
+    def test_get_default_memory_pool(self):
+        p = cupy.get_default_memory_pool()
+        self.assertIsInstance(p, cupy.cuda.memory.MemoryPool)
+
+    def test_get_default_pinned_memory_pool(self):
+        p = cupy.get_default_pinned_memory_pool()
+        self.assertIsInstance(p, cupy.cuda.pinned_memory.PinnedMemoryPool)
 
 
 # This is copied from chainer/testing/__init__.py, so should be replaced in


### PR DESCRIPTION
We improved memory allocator #168.
So, CuPy should use memory pool by default.
