### PR TITLE
Add a sync option to time_range

### DIFF
--- a/cupy/prof/time_range.py
+++ b/cupy/prof/time_range.py
@@ -19,7 +19,8 @@ def time_range(message, color_id=None, argb_color=None, sync=False):
         color_id: range color ID
         argb_color: range color in ARGB (e.g. 0xFF00FF00 for green)
         sync (bool): If ``True``, waits for completion of all outstanding
-            processings on GPU before calling RangePush() or RangePop()
+            processing on GPU before calling :func:`cupy.cuda.nvtx.RangePush()`
+            or :func:`cupy.cuda.nvtx.RangePop()`
 
     .. seealso:: :func:`cupy.cuda.nvtx.RangePush`
         :func:`cupy.cuda.nvtx.RangePop`
@@ -61,7 +62,8 @@ class TimeRangeDecorator(object):
         color_id: range color ID
         argb_color: range color in ARGB (e.g. 0xFF00FF00 for green)
         sync (bool): If ``True``, waits for completion of all outstanding
-            processings on GPU before calling RangePush() or RangePop()
+            processing on GPU before calling :func:`cupy.cuda.nvtx.RangePush()`
+            or :func:`cupy.cuda.nvtx.RangePop()`
 
     .. seealso:: :func:`cupy.nvtx.range`
         :func:`cupy.cuda.nvtx.RangePush`

--- a/cupy/prof/time_range.py
+++ b/cupy/prof/time_range.py
@@ -18,6 +18,8 @@ def time_range(message, color_id=None, argb_color=None, sync=False):
         message: Name of a range.
         color_id: range color ID
         argb_color: range color in ARGB (e.g. 0xFF00FF00 for green)
+        sync (bool): If ``True``, waits for completion of all outstanding
+            processings on GPU before calling RangePush() or RangePop()
 
     .. seealso:: :func:`cupy.cuda.nvtx.RangePush`
         :func:`cupy.cuda.nvtx.RangePop`
@@ -58,6 +60,8 @@ class TimeRangeDecorator(object):
         message (str): Name of a range, default use ``func.__name__``.
         color_id: range color ID
         argb_color: range color in ARGB (e.g. 0xFF00FF00 for green)
+        sync (bool): If ``True``, waits for completion of all outstanding
+            processings on GPU before calling RangePush() or RangePop()
 
     .. seealso:: :func:`cupy.nvtx.range`
         :func:`cupy.cuda.nvtx.RangePush`


### PR DESCRIPTION
This PR makes performance and behavior analysis using a `time_range` method a little convenient.

Using the `time_range` method makes it easier to analyze when some processing of interest were run on CPU and the corresponding GPU kernels were launched on NVVP. However it is not so easy to identify exactly which GPU kernels are corresponding to the processing and when they are executed. That is mainly because kernels are usually launched non-blocking way and they are not executed in sync with the launch.

With this PR, by just adding `sync=True` to the `time_range` method, the marked range is extended until the completion of the kernels that are launched with in the range.