### PR TITLE
Add cuDNN support for dropout.

### DIFF
--- a/cupy/cuda/cudnn.pxd
+++ b/cupy/cuda/cudnn.pxd
@@ -313,6 +313,17 @@ cpdef size_t dropoutGetStatesSize(size_t handle) except *
 cpdef setDropoutDescriptor(
     size_t dropoutDesc, size_t handle, float dropout,
     size_t states, size_t stateSizeInBytes, unsigned long long seed)
+cpdef size_t getDropoutReserveSpaceSize(size_t xDesc)
+cpdef dropoutForward(
+        size_t handle, size_t dropoutDesc,
+        size_t srcDesc, size_t srcData,
+        size_t dstDesc, size_t dstData,
+        size_t reserveSpace, size_t reserveSpaceSizeInBytes)
+cpdef dropoutBackward(
+        size_t handle, size_t dropoutDesc,
+        size_t dyDesc, size_t dyData,
+        size_t dxtDesc, size_t dxData,
+        size_t reserveSpace, size_t reserveSpaceSizeInBytes)
 
 
 ###############################################################################

--- a/cupy/cuda/cudnn.pxd
+++ b/cupy/cuda/cudnn.pxd
@@ -315,15 +315,15 @@ cpdef setDropoutDescriptor(
     size_t states, size_t stateSizeInBytes, unsigned long long seed)
 cpdef size_t getDropoutReserveSpaceSize(size_t xDesc)
 cpdef dropoutForward(
-        size_t handle, size_t dropoutDesc,
-        size_t srcDesc, size_t srcData,
-        size_t dstDesc, size_t dstData,
-        size_t reserveSpace, size_t reserveSpaceSizeInBytes)
+    size_t handle, size_t dropoutDesc,
+    size_t srcDesc, size_t srcData,
+    size_t dstDesc, size_t dstData,
+    size_t reserveSpace, size_t reserveSpaceSizeInBytes)
 cpdef dropoutBackward(
-        size_t handle, size_t dropoutDesc,
-        size_t dyDesc, size_t dyData,
-        size_t dxtDesc, size_t dxData,
-        size_t reserveSpace, size_t reserveSpaceSizeInBytes)
+    size_t handle, size_t dropoutDesc,
+    size_t dyDesc, size_t dyData,
+    size_t dxtDesc, size_t dxData,
+    size_t reserveSpace, size_t reserveSpaceSizeInBytes)
 
 
 ###############################################################################

--- a/cupy/cuda/cudnn.pyx
+++ b/cupy/cuda/cudnn.pyx
@@ -311,6 +311,11 @@ cdef extern from "cupy_cudnn.h" nogil:
     int cudnnSetDropoutDescriptor(
         DropoutDescriptor dropoutDesc, Handle handle, float dropout,
         void* states, size_t stateSizeInBytes, unsigned long long seed)
+    int cudnnDropoutForward(
+        Handle handle, DropoutDescriptor dropoutDesc,
+        TensorDescriptor srcDesc, void* srcData,
+        TensorDescriptor dstDesc, void* dstData,
+        void* reserveSpace, size_t reserveSpaceSizeInBytes)
     int cudnnDropoutBackward(
         Handle handle, DropoutDescriptor dropoutDesc,
         TensorDescriptor dydesc, void* dy, TensorDescriptor dxdesc,
@@ -1119,6 +1124,42 @@ cpdef setDropoutDescriptor(
     status = cudnnSetDropoutDescriptor(
         <DropoutDescriptor>dropoutDesc, <Handle>handle, dropout,
         <void*>states, stateSizeInBytes, seed)
+    check_status(status)
+
+
+cpdef size_t getDropoutReserveSpaceSize(size_t xDesc):
+    cdef size_t sizeInBytes
+    status = cudnnDropoutGetReserveSpaceSize(
+        <TensorDescriptor>xDesc, &sizeInBytes)
+    check_status(status)
+    return sizeInBytes
+
+
+cpdef dropoutForward(
+        size_t handle, size_t dropoutDesc,
+        size_t srcDesc, size_t srcData,
+        size_t dstDesc, size_t dstData,
+        size_t reserveSpace, size_t reserveSpaceSizeInBytes):
+    with nogil:
+        status = cudnnDropoutForward(
+            <Handle>handle, <DropoutDescriptor>dropoutDesc,
+            <TensorDescriptor>srcDesc, <void*>srcData,
+            <TensorDescriptor>dstDesc, <void*>dstData,
+            <void*>reserveSpace, reserveSpaceSizeInBytes)
+    check_status(status)
+
+
+cpdef dropoutBackward(
+        size_t handle, size_t dropoutDesc,
+        size_t dyDesc, size_t dyData,
+        size_t dxDesc, size_t dxData,
+        size_t reserveSpace, size_t reserveSpaceSizeInBytes):
+    with nogil:
+        status = cudnnDropoutBackward(
+            <Handle>handle, <DropoutDescriptor>dropoutDesc,
+            <TensorDescriptor>dyDesc, <void*>dyData,
+            <TensorDescriptor>dxDesc, <void*>dxData,
+            <void*>reserveSpace, reserveSpaceSizeInBytes)
     check_status(status)
 
 

--- a/cupy/cudnn.py
+++ b/cupy/cudnn.py
@@ -10,6 +10,7 @@ from cupy.core import internal
 from cupy import cuda
 from cupy.cuda import cudnn
 from cupy.cuda import device
+from cupy.cuda import memory
 
 
 _cudnn_version = cudnn.getVersion()
@@ -345,16 +346,16 @@ class DropoutStates(object):
 
     def __init__(self, handle, seed):
         state_size = cudnn.dropoutGetStatesSize(handle)
-        self.states = cupy.empty((state_size,), dtype='b')
-        self.desc = create_dropout_descriptor(
-            handle, 0., self.states.data.ptr,
-            self.states.size, seed)
+        self._states = memory.alloc(state_size)
+        self._desc = create_dropout_descriptor(
+            handle, 0., self._states.ptr,
+            state_size, seed)
 
     def forward(self, handle, x, dropout_ratio):
         if not isinstance(x, cupy.ndarray):
             raise TypeError('argument x must be an cupy.ndarray')
 
-        set_dropout_descriptor(self.desc, handle, dropout_ratio)
+        set_dropout_descriptor(self._desc, handle, dropout_ratio)
 
         x = cupy.ascontiguousarray(x)
         y = cupy.empty_like(x)
@@ -363,9 +364,9 @@ class DropoutStates(object):
         x_desc = create_tensor_descriptor(x_mat)
 
         reserve_size = cudnn.getDropoutReserveSpaceSize(x_desc.value)
-        reserve_space = cupy.empty((reserve_size,))
+        reserve_space = cupy.empty((reserve_size,), dtype='b')
 
-        cudnn.dropoutForward(handle, self.desc.value,
+        cudnn.dropoutForward(handle, self._desc.value,
                              x_desc.value, x_mat.data.ptr,
                              x_desc.value, y.data.ptr,
                              reserve_space.data.ptr, reserve_size)
@@ -375,7 +376,7 @@ class DropoutStates(object):
         if not isinstance(dy, cupy.ndarray):
             raise TypeError('argument dy must be an cupy.ndarray')
 
-        set_dropout_descriptor(self.desc, handle, dropout_ratio)
+        set_dropout_descriptor(self._desc, handle, dropout_ratio)
 
         dy = cupy.ascontiguousarray(dy)
         dx = cupy.empty_like(dy)
@@ -383,7 +384,7 @@ class DropoutStates(object):
         dy_mat = _as4darray(dy)
         dy_desc = create_tensor_descriptor(dy_mat)
 
-        cudnn.dropoutBackward(handle, self.desc.value,
+        cudnn.dropoutBackward(handle, self._desc.value,
                               dy_desc.value, dy_mat.data.ptr,
                               dy_desc.value, dx.data.ptr,
                               reserve_space.data.ptr,

--- a/cupy/cudnn.py
+++ b/cupy/cudnn.py
@@ -1,5 +1,6 @@
 import atexit
 import threading
+import warnings
 
 import numpy
 import six
@@ -309,6 +310,9 @@ def get_rnn_lin_layer_bias_params(
 
 
 def create_dropout_states(handle):
+    warnings.warn('create_dropout_states is deprecated.'
+                  'Please use DropoutStates class instead.',
+                  DeprecationWarning)
     state_size = cudnn.dropoutGetStatesSize(handle)
     return cupy.empty((state_size,), dtype='b')
 
@@ -337,10 +341,11 @@ def is_tensor_core_available(dtype):
     return False
 
 
-class DropoutTransaction(object):
+class DropoutStates(object):
 
     def __init__(self, handle, seed):
-        self.states = create_dropout_states(handle)
+        state_size = cudnn.dropoutGetStatesSize(handle)
+        self.states = cupy.empty((state_size,), dtype='b')
         self.desc = create_dropout_descriptor(
             handle, 0., self.states.data.ptr,
             self.states.size, seed)

--- a/tests/cupy_tests/test_cudnn.py
+++ b/tests/cupy_tests/test_cudnn.py
@@ -50,3 +50,56 @@ class TestCudnnActivation(unittest.TestCase):
         with mock.patch(patch) as func:
             cupy.cudnn.activation_backward(self.x, self.y, self.g, self.mode)
             self.assertEqual(func.called, True)
+
+
+@testing.parameterize(*testing.product({
+    'dtype': [numpy.float32, numpy.float64],
+    'ratio': [0.0, 0.1, 0.2, 0.5],
+    'seed': [0, 100]
+}))
+@unittest.skipUnless(
+    cudnn_enabled and libcudnn.getVersion() >= 5000,
+    'cuDNN >= 5.0 is supported')
+class TestCudnnDropout(unittest.TestCase):
+
+    def setUp(self):
+        self.x = testing.shaped_arange((3, 4), cupy, self.dtype)
+        self.gy = testing.shaped_arange((3, 4), cupy, self.dtype)
+        self.states = cupy.cudnn.DropoutStates(
+            cupy.cudnn.get_handle(), self.seed)
+
+    def test_dropout_forward(self):
+        _, y = self.states.forward(
+            cupy.cudnn.get_handle(), self.x, self.ratio)
+        if self.ratio == 0:
+            self.assertTrue(cupy.all(self.x == y))
+        else:
+            self.assertTrue(cupy.all(self.x != y))
+
+    def test_dropout_backward(self):
+        rspace, y = self.states.forward(
+            cupy.cudnn.get_handle(), self.x, self.ratio)
+        gx = self.states.backward(
+            cupy.cudnn.get_handle(), self.gy, self.ratio, rspace)
+
+        forward_mask = y / self.x
+        backward_mask = gx / self.gy
+
+        # backward_mask must be the same as forward_mask
+        self.assertTrue(cupy.all(forward_mask == backward_mask))
+
+    def test_dropout_seed(self):
+        handle = cupy.cudnn.get_handle()
+
+        # initialize Dropoutstates with the same seed
+        states2 = cupy.cudnn.DropoutStates(handle, self.seed)
+
+        rspace, y = self.states.forward(handle, self.x, self.ratio)
+        rspace2, y2 = states2.forward(handle, self.x, self.ratio)
+        # forward results must be the same
+        self.assertTrue(cupy.all(y == y2))
+
+        gx = self.states.backward(handle, self.gy, self.ratio, rspace)
+        gx2 = states2.backward(handle, self.gy, self.ratio, rspace2)
+        # backward results must be the same
+        self.assertTrue(cupy.all(gx == gx2))


### PR DESCRIPTION
I implemented function wrappers for dropout functions which cuDNN provides (cuDNN v5 or later is required).

Some of cuDNN interfaces ( `cudnnDropoutForward` and `cudnnDropoutBackward` ) take the states which indicate the random number generators for creating dropout masks and created dropout masks, so I also implemented the utility class which provides `forward` and `backward` methods to conceal the internal cuDNN states.
