### PR TITLE
Fix multi thread problem in PooledMemory

### DIFF
--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -430,24 +430,19 @@ class PooledMemory(Memory):
         ptr = self.ptr
         if ptr == 0:
             return
-        pool = self.pool()
-        size = self.size
-        device = self.device
-
         self.ptr = 0
-        self.size = 0
-        self.device = None
-        self.pool = None
+        pool = self.pool()
         if pool is None:
             return
 
         hooks = None
+        # to avoid error at exit
         mh = memory_hook
         if mh is not None:
-            hooks = memory_hook.get_memory_hooks()
-
+            hooks = mh.get_memory_hooks()
+        size = self.size
         if hooks:
-            device_id = device.id
+            device_id = self.device.id
             pmem_id = id(self)
             hooks_values = hooks.values()  # avoid six for performance
             for hook in hooks_values:

--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -441,7 +441,11 @@ class PooledMemory(Memory):
         if pool is None:
             return
 
-        hooks = memory_hook.get_memory_hooks()
+        hooks = None
+        mh = memory_hook
+        if mh is not None:
+            hooks = memory_hook.get_memory_hooks()
+
         if hooks:
             device_id = device.id
             pmem_id = id(self)

--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -438,7 +438,7 @@ class PooledMemory(Memory):
         hooks = None
         # to avoid error at exit
         mh = memory_hook
-        if mh is not None:
+        if mh is not None and mh.get_memory_hooks is not None:
             hooks = mh.get_memory_hooks()
         size = self.size
         if hooks:


### PR DESCRIPTION
Sometimes, we get following error.
`Exception TypeError: "'NoneType' object is not callable" in <bound method PooledMemory.__del__ of <cupy.cuda.memory.PooledMemory object at 0x7f397a991c90>> ignored`

This PR will fix that error.
