### PR TITLE
Support ccache with CUDA_PATH

### DIFF
--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -435,7 +435,13 @@ class _UnixCCompiler(unixccompiler.UnixCCompiler):
         try:
             nvcc_path = build.get_nvcc_path()
             base_opts = build.get_compiler_base_options()
-            self.set_executable('compiler_so', nvcc_path)
+            use_ccache = bool(int(os.environ.get('CUPY_BUILD_USE_CCACHE',
+                                                 '0')))
+            if use_ccache:
+                self.set_executable('compiler_so', 'ccache ')
+                base_opts = [nvcc_path] + base_opts
+            else:
+                self.set_executable('compiler_so', nvcc_path)
 
             cuda_version = build.get_cuda_version()
             postargs = _nvcc_gencode_options(cuda_version) + [

--- a/docs/source/contribution.rst
+++ b/docs/source/contribution.rst
@@ -164,6 +164,8 @@ In order to run unit tests at the repository root, you first have to build Cytho
 .. note::
 
   It's not officially supported, but you can use `ccache <https://ccache.samba.org/>`_ to reduce compilation time.
+  Please set environment variable `CUPY_BUILD_USE_CCACHE=1`, when you want to use ccache for nvcc.
+
   On Ubuntu 16.04, you can set up as follows::
 
     $ sudo apt-get install ccache

--- a/docs/source/contribution.rst
+++ b/docs/source/contribution.rst
@@ -164,14 +164,15 @@ In order to run unit tests at the repository root, you first have to build Cytho
 .. note::
 
   It's not officially supported, but you can use `ccache <https://ccache.samba.org/>`_ to reduce compilation time.
-  Please set environment variable `CUPY_BUILD_USE_CCACHE=1`, when you want to use ccache for nvcc.
-
   On Ubuntu 16.04, you can set up as follows::
 
     $ sudo apt-get install ccache
     $ export PATH=/usr/lib/ccache:$PATH
 
   See `ccache <https://ccache.samba.org/>`_ for details.
+
+  If you want to use ccache for nvcc, please install ccache v3.3 and later.
+  And, please set environment variable `CUPY_BUILD_USE_CCACHE=1`.
 
 Once the Cython modules are built, you can run unit tests simply by running ``nosetests`` command at the repository root::
 

--- a/install/build.py
+++ b/install/build.py
@@ -18,7 +18,6 @@ maximum_cudnn_version = 7999
 minimum_cusolver_cuda_version = 8000
 
 _cuda_path = 'NOT_INITIALIZED'
-_nvcc_path = 'NOT_INITIALIZED'
 _compiler_base_options = None
 
 
@@ -32,7 +31,7 @@ def _tempdir():
 
 
 def get_cuda_path():
-    global _cuda_path, _nvcc_path
+    global _cuda_path
 
     # Use a magic word to represent the cache not filled because None is a
     # valid return value.
@@ -49,10 +48,7 @@ def get_cuda_path():
     else:
         cuda_path_default = os.path.normpath(
             os.path.join(os.path.dirname(_nvcc_path), '..'))
-        real_path = os.path.realpath(_nvcc_path)
-        print(real_path)
-        if (len(cuda_path) > 0 and cuda_path != cuda_path_default and
-                os.path.split(real_path)[1] != 'ccache'):
+        if len(cuda_path) > 0 and cuda_path != cuda_path_default:
             utils.print_warning(
                 'nvcc path != CUDA_PATH',
                 'nvcc path: %s' % cuda_path_default,
@@ -71,9 +67,6 @@ def get_cuda_path():
 
 
 def get_nvcc_path():
-    if _nvcc_path is not None:
-        return _nvcc_path
-
     cuda_path = get_cuda_path()
     if cuda_path is None:
         return None

--- a/install/build.py
+++ b/install/build.py
@@ -38,21 +38,21 @@ def get_cuda_path():
     if _cuda_path is not 'NOT_INITIALIZED':
         return _cuda_path
 
-    cuda_path = os.environ.get('CUDA_PATH', '')  # Nvidia default on Windows
-
-    _nvcc_path = utils.search_on_path(('nvcc', 'nvcc.exe'))
+    nvcc_path = utils.search_on_path(('nvcc', 'nvcc.exe'))
     cuda_path_default = None
-    if _nvcc_path is None:
+    if nvcc_path is None:
         utils.print_warning('nvcc not in path.',
                             'Please set path to nvcc.')
     else:
         cuda_path_default = os.path.normpath(
-            os.path.join(os.path.dirname(_nvcc_path), '..'))
-        if len(cuda_path) > 0 and cuda_path != cuda_path_default:
-            utils.print_warning(
-                'nvcc path != CUDA_PATH',
-                'nvcc path: %s' % cuda_path_default,
-                'CUDA_PATH: %s' % cuda_path)
+            os.path.join(os.path.dirname(nvcc_path), '..'))
+
+    cuda_path = os.environ.get('CUDA_PATH', '')  # Nvidia default on Windows
+    if len(cuda_path) > 0 and cuda_path != cuda_path_default:
+        utils.print_warning(
+            'nvcc path != CUDA_PATH',
+            'nvcc path: %s' % cuda_path_default,
+            'CUDA_PATH: %s' % cuda_path)
 
     if os.path.exists(cuda_path):
         _cuda_path = cuda_path


### PR DESCRIPTION
CuPy installer use `CUDA_PATH/bin/nvcc` when `CUDA_PATH` is set.
In this case, `PATH` is ignored. Also `ccache` is ignored. 
