### PR TITLE
Add interface to use cudnnGetTensor4dDescriptor

### DIFF
--- a/cupy/cuda/cudnn.pyx
+++ b/cupy/cuda/cudnn.pyx
@@ -454,19 +454,12 @@ cpdef setTensor4dDescriptorEx(size_t tensorDesc, int dataType,
 
 cpdef getTensor4dDescriptor(size_t tensorDesc):
     cdef DataType dataType
-    cdef int n
-    cdef int c
-    cdef int h
-    cdef int w
-    cdef int nStride
-    cdef int cStride
-    cdef int hStride
-    cdef int wStride
+    cdef int n, c, h, w, nStride, cStride, hStride, wStride
     status = cudnnGetTensor4dDescriptor(
         <TensorDescriptor>tensorDesc, &dataType,
         &n, &c, &h, &w, &nStride, &cStride, &hStride, &wStride)
     check_status(status)
-    return(dataType, n, c, h, w, nStride, cStride, hStride, wStride)
+    return dataType, n, c, h, w, nStride, cStride, hStride, wStride
 
 
 cpdef setTensorNdDescriptor(size_t tensorDesc, int dataType, int nbDims,

--- a/cupy/cuda/cudnn.pyx
+++ b/cupy/cuda/cudnn.pyx
@@ -452,6 +452,23 @@ cpdef setTensor4dDescriptorEx(size_t tensorDesc, int dataType,
     check_status(status)
 
 
+cpdef getTensor4dDescriptor(size_t tensorDesc):
+    cdef DataType dataType
+    cdef int n
+    cdef int c
+    cdef int h
+    cdef int w
+    cdef int nStride
+    cdef int cStride
+    cdef int hStride
+    cdef int wStride
+    status = cudnnGetTensor4dDescriptor(
+        <TensorDescriptor>tensorDesc, &dataType,
+        &n, &c, &h, &w, &nStride, &cStride, &hStride, &wStride)
+    check_status(status)
+    return(dataType, n, c, h, w, nStride, cStride, hStride, wStride)
+
+
 cpdef setTensorNdDescriptor(size_t tensorDesc, int dataType, int nbDims,
                             size_t dimA, size_t strideA):
     status = cudnnSetTensorNdDescriptor(

--- a/cupy/cuda/cupy_cudnn.h
+++ b/cupy/cuda/cupy_cudnn.h
@@ -79,6 +79,10 @@ cudnnStatus_t cudnnSetTensor4dDescriptorEx(...) {
     return CUDNN_STATUS_SUCCESS;
 }
 
+cudnnStatus_t cudnnGetTensor4dDescriptor(...) {
+    return CUDNN_STATUS_SUCCESS;
+}
+
 cudnnStatus_t cudnnSetTensorNdDescriptor(...) {
     return CUDNN_STATUS_SUCCESS;
 }


### PR DESCRIPTION
This PR adds an interface to use a function `cudnnGetTensor4dDescriptor` in cuDNN library.