### PR TITLE
Tensor-Core support (cuBLAS)

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -3,7 +3,6 @@
 from __future__ import division
 import sys
 
-import ctypes
 import numpy
 import six
 

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -8,8 +8,8 @@ import six
 
 import cupy
 from cupy.core import flags
-from cupy.cuda import stream
 from cupy.cuda import device
+from cupy.cuda import stream
 try:
     from cupy.cuda import thrust
 except ImportError:

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -30,6 +30,7 @@ from cupy.cuda cimport memory
 
 DEF MAX_NDIM = 25
 
+
 @cython.profile(False)
 cdef inline _should_use_rop(x, y):
     xp = getattr(x, '__array_priority__', 0)

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -3544,6 +3544,7 @@ cpdef ndarray tensordot_core(
     if use_tensor_core:
         one_ptr = ctypes.cast(ctypes.byref(_one_fp32), ctypes.c_void_p)
         zero_ptr = ctypes.cast(ctypes.byref(_zero_fp32), ctypes.c_void_p)
+        cublas.setMathMode(handle, cublas.CUBLAS_TENSOR_OP_MATH)
         cublas.gemmEx(
             handle, <int>transb, <int> transa, <int>m, <int>n, <int>k,
             one_ptr.value,
@@ -3552,6 +3553,7 @@ cpdef ndarray tensordot_core(
             zero_ptr.value,
             c.data.ptr, runtime.CUDA_R_16F, <int>m,
             runtime.CUDA_R_32F, cublas.CUBLAS_GEMM_DFALT_TENSOR_OP)
+        cublas.setMathMode(handle, cublas.CUBLAS_DEFAULT_MATH)
     elif use_sgemmEx:
         Ctype = runtime.CUDA_R_16F if c.dtype == 'e' else runtime.CUDA_R_32F
         cublas.sgemmEx(

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -9,6 +9,7 @@ import six
 import cupy
 from cupy.core import flags
 from cupy.cuda import stream
+from cupy.cuda import device
 try:
     from cupy.cuda import thrust
 except ImportError:
@@ -21,7 +22,6 @@ from libcpp cimport vector
 
 from cupy.core cimport internal
 from cupy.cuda cimport cublas
-from cupy.cuda cimport device
 from cupy.cuda cimport function
 from cupy.cuda cimport pinned_memory
 from cupy.cuda cimport runtime

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -3446,7 +3446,6 @@ cpdef ndarray matmul(ndarray a, ndarray b, ndarray out=None):
 
 
 cdef _cuda_runtime_version = None
-cdef _compute_capability = None
 cdef _tensordot_core_mul_sum = ReductionKernel(
     'S x, T y', 'U out',
     'static_cast<U>(x) * static_cast<U>(y)',
@@ -3472,10 +3471,6 @@ cpdef ndarray tensordot_core(
         out.fill(0)
         return out
 
-    global _compute_capability
-    if _compute_capability is None:
-        _compute_capability = int(device.Device().compute_capability)
-
     global _cuda_runtime_version
     if _cuda_runtime_version is None:
         _cuda_runtime_version = runtime.runtimeGetVersion()
@@ -3485,7 +3480,7 @@ cpdef ndarray tensordot_core(
                    (ret_dtype == 'e' or ret_dtype == 'f'))
     use_tensor_core = (use_sgemmEx and
                        _cuda_runtime_version >= 9000 and
-                       _compute_capability == 70)
+                       int(device.get_compute_capability()) == 70)
 
     if use_sgemmEx or ret_dtype in 'fdFD':
         dtype = ret_dtype

--- a/cupy/cuda/cublas.pxd
+++ b/cupy/cuda/cublas.pxd
@@ -193,6 +193,6 @@ cpdef sgetriBatched(size_t handle, int n, size_t Aarray, int lda,
                     size_t PivotArray, size_t Carray, int ldc,
                     size_t infoArray, int batchSize)
 cpdef gemmEx(size_t handle, int transa, int transb, int m, int n, int k,
-              size_t alpha, size_t A, int Atype, int lda, size_t B,
-              int Btype, int ldb, size_t beta, size_t C, int Ctype,
-              int ldc, int computeType, int algo)
+             size_t alpha, size_t A, int Atype, int lda, size_t B,
+             int Btype, int ldb, size_t beta, size_t C, int Ctype,
+             int ldc, int computeType, int algo)

--- a/cupy/cuda/cublas.pxd
+++ b/cupy/cuda/cublas.pxd
@@ -19,6 +19,7 @@ cdef extern from *:
     ctypedef int PointerMode 'cublasPointerMode_t'
     ctypedef int SideMode 'cublasSideMode_t'
     ctypedef int GemmAlgo 'cublasGemmAlgo_t'
+    ctypedef int Math 'cublasMath_t'
 
 
 ###############################################################################
@@ -45,6 +46,9 @@ cpdef enum:
     CUBLAS_GEMM_DFALT = -1
     CUBLAS_GEMM_DFALT_TENSOR_OP = 99
 
+    CUBLAS_DEFAULT_MATH = 0
+    CUBLAS_TENSOR_OP_MATH = 1
+
 ###############################################################################
 # Context
 ###############################################################################
@@ -62,6 +66,14 @@ cpdef setPointerMode(size_t handle, int mode)
 
 cpdef setStream(size_t handle, size_t stream)
 cpdef size_t getStream(size_t handle) except *
+
+
+###############################################################################
+# Math Mode
+###############################################################################
+
+cpdef setMathMode(size_t handle, int mode)
+cpdef int getMathMode(size_t handle) except *
 
 
 ###############################################################################

--- a/cupy/cuda/cublas.pxd
+++ b/cupy/cuda/cublas.pxd
@@ -42,6 +42,8 @@ cpdef enum:
     CUBLAS_DIAG_NON_UNIT = 0
     CUBLAS_DIAG_UNIT = 1
 
+    CUBLAS_GEMM_DFALT = -1
+    CUBLAS_GEMM_DFALT_TENSOR_OP = 99
 
 ###############################################################################
 # Context
@@ -178,3 +180,7 @@ cpdef sgetrfBatched(size_t handle, int n, size_t Aarray, int lda,
 cpdef sgetriBatched(size_t handle, int n, size_t Aarray, int lda,
                     size_t PivotArray, size_t Carray, int ldc,
                     size_t infoArray, int batchSize)
+cpdef gemmEx(size_t handle, int transa, int transb, int m, int n, int k,
+              size_t alpha, size_t A, int Atype, int lda, size_t B,
+              int Btype, int ldb, size_t beta, size_t C, int Ctype,
+              int ldc, int computeType, int algo)

--- a/cupy/cuda/cublas.pxd
+++ b/cupy/cuda/cublas.pxd
@@ -18,6 +18,7 @@ cdef extern from *:
     ctypedef int Operation 'cublasOperation_t'
     ctypedef int PointerMode 'cublasPointerMode_t'
     ctypedef int SideMode 'cublasSideMode_t'
+    ctypedef int GemmAlgo 'cublasGemmAlgo_t'
 
 
 ###############################################################################

--- a/cupy/cuda/cublas.pyx
+++ b/cupy/cuda/cublas.pyx
@@ -178,13 +178,12 @@ cdef extern from 'cupy_cuda.h' nogil:
     int cublasGemmEx(
         Handle handle, Operation transa, Operation transb,
         int m, int n, int k,
-        const float *alpha,
+        const void *alpha,
         const void *A, runtime.DataType Atype, int lda,
         const void *B, runtime.DataType Btype, int ldb,
-        const float *beta,
+        const void *beta,
         void *C, runtime.DataType Ctype, int ldc,
         runtime.DataType computetype, GemmAlgo algo)
-)
 
 ###############################################################################
 # Util
@@ -722,5 +721,5 @@ cpdef gemmEx(
             <const void*>B, <runtime.DataType>Btype, ldb,
             <const void*>beta,
             <void*>C, <runtime.DataType>Ctype, ldc,
-            <runtime.DateType>computeType, <GemmAlgo>algo)
+            <runtime.DataType>computeType, <GemmAlgo>algo)
     check_status(status)

--- a/cupy/cuda/cublas.pyx
+++ b/cupy/cuda/cublas.pyx
@@ -175,7 +175,16 @@ cdef extern from 'cupy_cuda.h' nogil:
         Handle handle, int n, const float **Aarray, int lda,
         int *PivotArray, float *Carray[], int ldc, int *infoArray,
         int batchSize)
-
+    int cublasGemmEx(
+        Handle handle, Operation transa, Operation transb,
+        int m, int n, int k,
+        const float *alpha,
+        const void *A, runtime.DataType Atype, int lda,
+        const void *B, runtime.DataType Btype, int ldb,
+        const float *beta,
+        void *C, runtime.DataType Ctype, int ldc,
+        runtime.DataType computetype, GemmAlgo algo)
+)
 
 ###############################################################################
 # Util
@@ -697,4 +706,21 @@ cpdef sgetriBatched(
         status = cublasSgetriBatched(
             <Handle>handle, n, <const float**>Aarray, lda, <int*>PivotArray,
             <float**>Carray, ldc, <int*>infoArray, batchSize)
+    check_status(status)
+
+
+cpdef gemmEx(
+        size_t handle, int transa, int transb, int m, int n, int k,
+        size_t alpha, size_t A, int Atype, int lda, size_t B,
+        int Btype, int ldb, size_t beta, size_t C, int Ctype,
+        int ldc, int computeType, int algo):
+    with nogil:
+        status = cublasGemmEx(
+            <Handle>handle, <Operation>transa, <Operation>transb, m, n, k,
+            <const void*>alpha,
+            <const void*>A, <runtime.DataType>Atype, lda,
+            <const void*>B, <runtime.DataType>Btype, ldb,
+            <const void*>beta,
+            <void*>C, <runtime.DataType>Ctype, ldc,
+            <runtime.DateType>computeType, <GemmAlgo>algo)
     check_status(status)

--- a/cupy/cuda/cublas.pyx
+++ b/cupy/cuda/cublas.pyx
@@ -30,6 +30,10 @@ cdef extern from 'cupy_cuda.h' nogil:
     int cublasSetStream(Handle handle, driver.Stream streamId)
     int cublasGetStream(Handle handle, driver.Stream* streamId)
 
+    # Math Mode
+    int cublasSetMathMode(Handle handle, Math mode)
+    int cublasGetMathMode(Handle handle, Math* mode)
+
     # BLAS Level 1
     int cublasIsamax(Handle handle, int n, float* x, int incx,
                      int* result)
@@ -290,6 +294,24 @@ cpdef size_t getStream(size_t handle) except *:
         status = cublasGetStream(<Handle>handle, &stream)
     check_status(status)
     return <size_t>stream
+
+
+###############################################################################
+# Math Mode
+###############################################################################
+
+cpdef setMathMode(size_t handle, int mode):
+    with nogil:
+        status = cublasSetMathMode(<Handle>handle, <Math>mode)
+    check_status(status)
+
+
+cpdef int getMathMode(size_t handle) except *:
+    cdef Math mode
+    with nogil:
+        status = cublasGetMathMode(<Handle>handle, &mode)
+    check_status(status)
+    return <int>mode
 
 
 ###############################################################################

--- a/cupy/cuda/cupy_cuda.h
+++ b/cupy/cuda/cupy_cuda.h
@@ -368,6 +368,7 @@ typedef enum {} cublasFillMode_t;
 typedef enum {} cublasOperation_t;
 typedef enum {} cublasPointerMode_t;
 typedef enum {} cublasSideMode_t;
+typedef enum {} cublasGemmAlgo_t;
 typedef enum {
     CUBLAS_STATUS_SUCCESS=0,
 } cublasStatus_t;

--- a/cupy/cuda/cupy_cuda.h
+++ b/cupy/cuda/cupy_cuda.h
@@ -62,7 +62,28 @@ cudaError_t cudaMemAdvise(const void *devPtr, size_t count,
     return cudaErrorUnknown;
 }
 
+typedef enum {} cublasGemmAlgo_t;
+
+cublasStatus_t cublasGemmEx(...) {
+    return CUBLAS_STATUS_NOT_SUPPORTED;
+}
+
 #endif // #if CUDA_VERSION < 8000
+
+
+#if CUDA_VERSION < 9000
+
+typedef enum {} cublasMath_t;
+
+cublasStatus_t cublasSetMathMode(...) {
+    return CUBLAS_STATUS_NOT_SUPPORTED;
+}
+
+cublasStatus_t cublasGetMathMode(...) {
+    return CUBLAS_STATUS_NOT_SUPPORTED;
+}
+
+#endif // #if CUDA_VERSION < 9000
 
 } // extern "C"
 
@@ -545,6 +566,10 @@ cublasStatus_t cublasZgemmBatched(...) {
 }
 
 cublasStatus_t cublasSgemmEx(...) {
+    return CUBLAS_STATUS_SUCCESS;
+}
+
+cublasStatus_t cublasGemmEx(...) {
     return CUBLAS_STATUS_SUCCESS;
 }
 

--- a/cupy/cuda/cupy_cuda.h
+++ b/cupy/cuda/cupy_cuda.h
@@ -369,6 +369,7 @@ typedef enum {} cublasOperation_t;
 typedef enum {} cublasPointerMode_t;
 typedef enum {} cublasSideMode_t;
 typedef enum {} cublasGemmAlgo_t;
+typedef enum {} cublasMath_t;
 typedef enum {
     CUBLAS_STATUS_SUCCESS=0,
 } cublasStatus_t;
@@ -401,6 +402,15 @@ cublasStatus_t cublasSetStream(...) {
 }
 
 cublasStatus_t cublasGetStream(...) {
+    return CUBLAS_STATUS_SUCCESS;
+}
+
+// Math Mode
+cublasStatus_t cublasSetMathMode(...) {
+    return CUBLAS_STATUS_SUCCESS;
+}
+
+cublasStatus_t cublasGetMathMode(...) {
     return CUBLAS_STATUS_SUCCESS;
 }
 


### PR DESCRIPTION
The aim of this PR is to enable use of Tensor-Core via cuBLAS. The following modifications are mainly included in this PR.
- Add interfaces to use `cublasSetMathMode()`, `cublasGetMathMode()` and `cublasGemmEx()` in cuBLAS.
- Use `cublasGemmEx()` with Tensor-Core configs instead of `cublasSgemmEx()` when Tensor-Core is available.