### PR TITLE
Fix test about bool and complex

### DIFF
--- a/tests/cupy_tests/core_tests/test_fusion.py
+++ b/tests/cupy_tests/core_tests/test_fusion.py
@@ -415,17 +415,33 @@ class TestFusionArithmetic(unittest.TestCase):
 
     _multiprocess_can_split_ = True
 
-    @testing.for_all_dtypes(no_complex=True)
+    @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(atol=1e-5)
     @fusion_default_array_equal()
     def check_unary(self, name, xp, dtype):
         a = testing.shaped_arange((2, 3), xp, dtype)
         return (a,)
 
-    @testing.for_all_dtypes(no_complex=True)
+    @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(atol=1e-5)
     @fusion_default_array_equal()
     def check_binary(self, name, xp, dtype):
+        a = testing.shaped_arange((2, 3), xp, dtype)
+        b = testing.shaped_reverse_arange((2, 3), xp, dtype)
+        return a, b
+
+    @testing.for_all_dtypes(no_complex=True)
+    @testing.numpy_cupy_allclose(atol=1e-5)
+    @fusion_default_array_equal()
+    def check_binary_without_complex(self, name, xp, dtype):
+        a = testing.shaped_arange((2, 3), xp, dtype)
+        b = testing.shaped_reverse_arange((2, 3), xp, dtype)
+        return a, b
+
+    @testing.for_all_dtypes(no_bool=True)
+    @testing.numpy_cupy_allclose(atol=1e-5)
+    @fusion_default_array_equal()
+    def check_binary_without_bool(self, name, xp, dtype):
         a = testing.shaped_arange((2, 3), xp, dtype)
         b = testing.shaped_reverse_arange((2, 3), xp, dtype)
         return a, b
@@ -478,7 +494,7 @@ class TestFusionArithmetic(unittest.TestCase):
         self.check_binary_negative_float('power')
 
     def test_subtract(self):
-        self.check_binary('subtract')
+        self.check_binary_without_bool('subtract')
 
     def test_true_divide(self):
         with testing.NumpyError(divide='ignore'):
@@ -490,7 +506,7 @@ class TestFusionArithmetic(unittest.TestCase):
 
     def test_floor_divide(self):
         with testing.NumpyError(divide='ignore'):
-            self.check_binary('floor_divide')
+            self.check_binary_without_complex('floor_divide')
 
     def test_floor_divide_negative(self):
         with testing.NumpyError(divide='ignore'):
@@ -498,7 +514,7 @@ class TestFusionArithmetic(unittest.TestCase):
 
     def test_fmod(self):
         with testing.NumpyError(divide='ignore'):
-            self.check_binary('fmod')
+            self.check_binary_without_complex('fmod')
 
     def test_fmod_negative(self):
         with testing.NumpyError(divide='ignore'):
@@ -521,7 +537,7 @@ class TestFusionArithmetic(unittest.TestCase):
 
     def test_remainder(self):
         with testing.NumpyError(divide='ignore'):
-            self.check_binary('remainder')
+            self.check_binary_without_complex('remainder')
 
     def test_remainder_negative(self):
         with testing.NumpyError(divide='ignore'):


### PR DESCRIPTION
Latest NumPy emits DeprecationWarning.
```
cupy/cupy/core/fusion.py:699: DeprecationWarning: numpy boolean subtract, the `-` operator, is deprecated, use the bitwise_xor, the `^` operator, or the logical_xor function instead.
  return self._numpy_op(*args, **kwargs)
```