### PR TITLE
Fix simple reduction

### DIFF
--- a/cupy/core/reduction.pxi
+++ b/cupy/core/reduction.pxi
@@ -202,36 +202,38 @@ class simple_reduction_function(object):
         self._output_expr = 'type_out0_raw &out0 = _raw_out0[_out_ind.get()];'
         self._routine_cache = {}
 
-    def __call__(self, a, axis=None, dtype=None, out=None, keepdims=False):
-        if not isinstance(a, ndarray):
-            raise TypeError('Input type must be cupy.ndarray')
-        if self.identity is None and 0 in a.shape:
-            raise ValueError(('zero-size array to reduction operation'
-                              ' %s which has no identity') % self.name)
+    def __call__(self, ndarray a, axis=None, dtype=None, ndarray out=None,
+                 bint keepdims=False):
+        cdef list in_args, out_args
+        cdef tuple in_sahpe, laxis, raxis
+        cdef Py_ssize_t ndim
         if dtype is not None:
             dtype = numpy.dtype(dtype).type
 
         in_args = [a]
+        a_shape = a.shape
         if out is None:
-            a = _preprocess_args((a,))[0]
+            _preprocess_args((a,))
             out_args = []
         else:
-            a, out = _preprocess_args((a, out))
+            _preprocess_args((a, out))
             out_args = [out]
 
         in_types, out_types, routine = _guess_routine(
             self.name, self._routine_cache, self._ops, in_args, dtype)
 
-        axis, raxis = _get_axis(axis, a.ndim)
-        out_shape = _get_out_shape(a.shape, axis, raxis, keepdims)
+        ndim = a._shape.size()
+        laxis, raxis = _get_axis(axis, ndim)
+        del axis  # to avoid bug
+        out_shape = _get_out_shape(a_shape, laxis, raxis, keepdims)
         out_args = _get_out_args(out_args, out_types, out_shape, 'unsafe')
-        if 0 in out_shape:
+        if a.size == 0:
             if len(out_args) == 1:
                 return out_args[0]
             return tuple(out_args)
 
         in_args, in_shape = _get_trans_args(
-            in_args, axis + raxis, in_args[0].shape, None)
+            in_args, laxis + raxis, a_shape, None)
 
         block_size = self._block_size
         in_indexer = Indexer(in_shape)

--- a/cupy/logic/truth.py
+++ b/cupy/logic/truth.py
@@ -1,8 +1,11 @@
+import cupy
+
+
 def all(a, axis=None, out=None, keepdims=False):
-    # TODO(okuta): check type
+    assert isinstance(a, cupy.ndarray)
     return a.all(axis=axis, out=out, keepdims=keepdims)
 
 
 def any(a, axis=None, out=None, keepdims=False):
-    # TODO(okuta): check type
+    assert isinstance(a, cupy.ndarray)
     return a.any(axis=axis, out=out, keepdims=keepdims)

--- a/tests/cupy_tests/logic_tests/test_truth.py
+++ b/tests/cupy_tests/logic_tests/test_truth.py
@@ -29,7 +29,9 @@ def _calc_out_shape(shape, axis, keepdims):
         {'f': ['all', 'any'],
          'x': [numpy.arange(24).reshape(2, 3, 4) - 10,
                numpy.zeros((2, 3, 4)),
-               numpy.ones((2, 3, 4))],
+               numpy.ones((2, 3, 4)),
+               numpy.zeros((0, 3, 4)),
+               numpy.ones((0, 3, 4))],
          'axis': [None, (0, 1, 2), 0, 1, 2, (0, 1)],
          'keepdims': [False, True]}))
 @testing.gpu

--- a/tests/cupy_tests/sorting_tests/test_search.py
+++ b/tests/cupy_tests/sorting_tests/test_search.py
@@ -59,6 +59,24 @@ class TestSearch(unittest.TestCase):
         return a.argmax(axis=2)
 
     @testing.for_all_dtypes(no_complex=True)
+    @testing.numpy_cupy_raises(accept_error=ValueError)
+    def test_argmax_zero_size(self, xp, dtype):
+        a = testing.shaped_random((0, 1), xp, dtype)
+        return a.argmax()
+
+    @testing.for_all_dtypes(no_complex=True)
+    @testing.numpy_cupy_raises(accept_error=ValueError)
+    def test_argmax_zero_size_axis0(self, xp, dtype):
+        a = testing.shaped_random((0, 1), xp, dtype)
+        return a.argmax(axis=0)
+
+    @testing.for_all_dtypes(no_complex=True)
+    @testing.numpy_cupy_allclose()
+    def test_argmax_zero_size_axis1(self, xp, dtype):
+        a = testing.shaped_random((0, 1), xp, dtype)
+        return a.argmax(axis=1)
+
+    @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose()
     def test_argmin_all(self, xp, dtype):
         a = testing.shaped_random((2, 3), xp, dtype)
@@ -105,6 +123,24 @@ class TestSearch(unittest.TestCase):
     def test_argmin_axis2(self, xp, dtype):
         a = testing.shaped_random((2, 3, 4), xp, dtype)
         return a.argmin(axis=2)
+
+    @testing.for_all_dtypes(no_complex=True)
+    @testing.numpy_cupy_raises(accept_error=ValueError)
+    def test_argmin_zero_size(self, xp, dtype):
+        a = testing.shaped_random((0, 1), xp, dtype)
+        return a.argmin()
+
+    @testing.for_all_dtypes(no_complex=True)
+    @testing.numpy_cupy_raises(accept_error=ValueError)
+    def test_argmin_zero_size_axis0(self, xp, dtype):
+        a = testing.shaped_random((0, 1), xp, dtype)
+        return a.argmin(axis=0)
+
+    @testing.for_all_dtypes(no_complex=True)
+    @testing.numpy_cupy_allclose()
+    def test_argmin_zero_size_axis1(self, xp, dtype):
+        a = testing.shaped_random((0, 1), xp, dtype)
+        return a.argmin(axis=1)
 
 
 @testing.parameterize(


### PR DESCRIPTION
Fix #266
`simple_reduction_function` returns zero-sized array, even if `self.identity == None`.