### PR TITLE
Support NVCC environment variable

### DIFF
--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -463,7 +463,7 @@ class _MSVCCompiler(msvccompiler.MSVCCompiler):
             self._setup_compile(output_dir, macros, include_dirs, sources,
                                 depends, extra_postargs)
 
-        compiler_so = [build.get_nvcc_path()]
+        compiler_so = build.get_nvcc_path()
         cc_args = self._get_cc_args(pp_opts, debug, extra_preargs)
         cuda_version = build.get_cuda_version()
         postargs = _nvcc_gencode_options(cuda_version) + ['-O2']

--- a/docs/source/contribution.rst
+++ b/docs/source/contribution.rst
@@ -171,7 +171,7 @@ In order to run unit tests at the repository root, you first have to build Cytho
 
   See `ccache <https://ccache.samba.org/>`_ for details.
 
-  If you want to use ccache for nvcc, please install ccache v3.3 and later.
+  If you want to use ccache for nvcc, please install ccache v3.3 or later.
   And, please set environment variable `NVCC=/path/to/nvcc_with_ccache`.
 
 Once the Cython modules are built, you can run unit tests simply by running ``nosetests`` command at the repository root::

--- a/docs/source/contribution.rst
+++ b/docs/source/contribution.rst
@@ -172,7 +172,7 @@ In order to run unit tests at the repository root, you first have to build Cytho
   See `ccache <https://ccache.samba.org/>`_ for details.
 
   If you want to use ccache for nvcc, please install ccache v3.3 or later.
-  You also need to set environment variable ``NVCC=/path/to/nvcc_with_ccache``.
+  You also need to set environment variable ``NVCC='ccache nvcc'``.
 
 Once the Cython modules are built, you can run unit tests simply by running ``nosetests`` command at the repository root::
 

--- a/docs/source/contribution.rst
+++ b/docs/source/contribution.rst
@@ -172,7 +172,7 @@ In order to run unit tests at the repository root, you first have to build Cytho
   See `ccache <https://ccache.samba.org/>`_ for details.
 
   If you want to use ccache for nvcc, please install ccache v3.3 or later.
-  And, please set environment variable `NVCC=/path/to/nvcc_with_ccache`.
+  You also need to set environment variable `NVCC=/path/to/nvcc_with_ccache`.
 
 Once the Cython modules are built, you can run unit tests simply by running ``nosetests`` command at the repository root::
 

--- a/docs/source/contribution.rst
+++ b/docs/source/contribution.rst
@@ -171,6 +171,9 @@ In order to run unit tests at the repository root, you first have to build Cytho
 
   See `ccache <https://ccache.samba.org/>`_ for details.
 
+  If you want to use ccache for nvcc, please install ccache v3.3 and later.
+  And, please set environment variable `NVCC=/path/to/nvcc_with_ccache`.
+
 Once the Cython modules are built, you can run unit tests simply by running ``nosetests`` command at the repository root::
 
   $ nosetests

--- a/docs/source/contribution.rst
+++ b/docs/source/contribution.rst
@@ -172,7 +172,7 @@ In order to run unit tests at the repository root, you first have to build Cytho
   See `ccache <https://ccache.samba.org/>`_ for details.
 
   If you want to use ccache for nvcc, please install ccache v3.3 or later.
-  You also need to set environment variable `NVCC=/path/to/nvcc_with_ccache`.
+  You also need to set environment variable ``NVCC=/path/to/nvcc_with_ccache``.
 
 Once the Cython modules are built, you can run unit tests simply by running ``nosetests`` command at the repository root::
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -127,7 +127,7 @@ If you installed CUDA into a non-default directory, you need to specify the dire
   $ CUDA_PATH=/opt/nvidia/cuda pip install cupy
 
 
-If you want to use custom ``nvcc`` compiler (For example, to use ```ccache`` ), please use ``NVCC`` environment variables before installing CuPy::
+If you want to use a custom ``nvcc`` compiler (For example, to use ``ccache`` ), please set ``NVCC`` environment variables before installing CuPy::
 
   export NVCC='ccache nvcc'
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -127,6 +127,11 @@ If you installed CUDA into a non-default directory, you need to specify the dire
   $ CUDA_PATH=/opt/nvidia/cuda pip install cupy
 
 
+If you want to use custom ``nvcc`` compiler (For example, to use ```ccache`` ), please use ``NVCC`` environment variables before installing CuPy::
+
+  export NVCC='ccache nvcc'
+
+
 .. warning::
 
    If you want to use ``sudo`` to install CuPy, note that ``sudo`` command initializes all environment variables.
@@ -162,7 +167,7 @@ If you want to use cuDNN or NCCL installed in other directory, please use ``CFLA
 
 
 Install CuPy for developers
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 CuPy uses Cython (>=0.24).
 Developers need to use Cython to regenerate C++ sources from ``pyx`` files.
@@ -190,7 +195,7 @@ Use pip to uninstall CuPy::
 
 
 Upgrade CuPy
----------------
+------------
 
 Just use ``pip`` with ``-U`` option::
 
@@ -198,7 +203,7 @@ Just use ``pip`` with ``-U`` option::
 
 
 Reinstall CuPy
----------------
+--------------
 
 If you want to reinstall CuPy, please uninstall CuPy and then install it.
 We recommend to use ``--no-cache-dir`` option as ``pip`` sometimes uses cache::
@@ -211,7 +216,7 @@ You need to reinstall CuPy when you want to upgrade CUDA.
 
 
 Run CuPy with Docker
------------------------
+--------------------
 
 We are providing the official Docker image.
 Use `nvidia-docker <https://github.com/NVIDIA/nvidia-docker>`_ command to run CuPy image with GPU.

--- a/docs/source/reference/environment.rst
+++ b/docs/source/reference/environment.rst
@@ -32,5 +32,5 @@ These environment variables are only used during installation.
 |               | When ``nvcc`` is not found, ``/usr/local/cuda`` is used.            |
 |               | See :ref:`install_cuda` for details.                                |
 +---------------+---------------------------------------------------------------------+
-| ``NVCC``      | Define the compiler to use when compiling CUDA files                |
+| ``NVCC``      | Define the compiler to use when compiling CUDA files.               |
 +---------------+---------------------------------------------------------------------+

--- a/docs/source/reference/environment.rst
+++ b/docs/source/reference/environment.rst
@@ -32,3 +32,5 @@ These environment variables are only used during installation.
 |               | When ``nvcc`` is not found, ``/usr/local/cuda`` is used.            |
 |               | See :ref:`install_cuda` for details.                                |
 +---------------+---------------------------------------------------------------------+
+| ``NVCC``      | Define the compiler to use when compiling CUDA files                |
++---------------+---------------------------------------------------------------------+

--- a/install/build.py
+++ b/install/build.py
@@ -67,6 +67,10 @@ def get_cuda_path():
 
 
 def get_nvcc_path():
+    nvcc = os.environ.get('NVCC', '')
+    if os.path.exists(nvcc):
+        return nvcc
+
     cuda_path = get_cuda_path()
     if cuda_path is None:
         return None

--- a/install/build.py
+++ b/install/build.py
@@ -1,4 +1,5 @@
 import contextlib
+import distutils.util
 import os
 import re
 import shutil
@@ -68,8 +69,8 @@ def get_cuda_path():
 
 def get_nvcc_path():
     nvcc = os.environ.get('NVCC', None)
-    if nvcc is not None and os.path.exists(nvcc):
-        return nvcc
+    if nvcc is not None:
+        return distutils.util.split_quoted(nvcc)
 
     cuda_path = get_cuda_path()
     if cuda_path is None:
@@ -82,7 +83,7 @@ def get_nvcc_path():
 
     nvcc_path = os.path.join(cuda_path, nvcc_bin)
     if os.path.exists(nvcc_path):
-        return nvcc_path
+        return [nvcc_path]
     else:
         return None
 
@@ -164,7 +165,7 @@ def _get_compiler_base_options():
         with open(test_cu_path, 'w') as f:
             f.write('int main() { return 0; }')
         proc = subprocess.Popen(
-            [nvcc_path, '-o', test_out_path, test_cu_path],
+            nvcc_path + ['-o', test_out_path, test_cu_path],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE)
         stdoutdata, stderrdata = proc.communicate()

--- a/install/build.py
+++ b/install/build.py
@@ -67,8 +67,8 @@ def get_cuda_path():
 
 
 def get_nvcc_path():
-    nvcc = os.environ.get('NVCC', '')
-    if os.path.exists(nvcc):
+    nvcc = os.environ.get('NVCC', None)
+    if nvcc is not None and os.path.exists(nvcc):
         return nvcc
 
     cuda_path = get_cuda_path()

--- a/install/build.py
+++ b/install/build.py
@@ -69,7 +69,7 @@ def get_cuda_path():
 
 def get_nvcc_path():
     nvcc = os.environ.get('NVCC', None)
-    if nvcc is not None:
+    if nvcc:
         return distutils.util.split_quoted(nvcc)
 
     cuda_path = get_cuda_path()


### PR DESCRIPTION
CuPy installer use CUDA_PATH/bin/nvcc when CUDA_PATH is set.
In this case, PATH is ignored. Also ccache is ignored.