### PR TITLE
Show NVRTC error code

### DIFF
--- a/cupy/cuda/nvrtc.pyx
+++ b/cupy/cuda/nvrtc.pyx
@@ -43,7 +43,8 @@ class NVRTCError(RuntimeError):
     def __init__(self, status):
         self.status = status
         cdef bytes msg = nvrtcGetErrorString(<Result>status)
-        super(NVRTCError, self).__init__('{} ({})'.format(msg.decode(), status))
+        super(NVRTCError, self).__init__(
+            '{} ({})'.format(msg.decode(), status))
 
 
 @cython.profile(False)

--- a/cupy/cuda/nvrtc.pyx
+++ b/cupy/cuda/nvrtc.pyx
@@ -43,7 +43,7 @@ class NVRTCError(RuntimeError):
     def __init__(self, status):
         self.status = status
         cdef bytes msg = nvrtcGetErrorString(<Result>status)
-        super(NVRTCError, self).__init__(msg.decode())
+        super(NVRTCError, self).__init__('{} ({})'.format(msg.decode(), status))
 
 
 @cython.profile(False)


### PR DESCRIPTION
Error code is useful for debugging (especially when you get `NVRTC_ERROR unknown`).