### PR TITLE
Fix csrmm2 to support transa

### DIFF
--- a/tests/cupy_tests/test_cusparse.py
+++ b/tests/cupy_tests/test_cusparse.py
@@ -33,7 +33,7 @@ class TestCsrmm(unittest.TestCase):
         a = cupy.sparse.csr_matrix(self.a)
         b = cupy.array(self.b, order='f')
         y = cupy.cusparse.csrmm(a, b, alpha=self.alpha, transa=self.transa)
-        expect = self.alpha * (self.op_a.dot(self.b))
+        expect = self.alpha * self.op_a.dot(self.b)
         testing.assert_array_almost_equal(y, expect)
 
     def test_csrmm_with_c(self):
@@ -42,7 +42,7 @@ class TestCsrmm(unittest.TestCase):
         c = cupy.array(self.c, order='f')
         y = cupy.cusparse.csrmm(
             a, b, c=c, alpha=self.alpha, beta=self.beta, transa=self.transa)
-        expect = self.alpha * (self.op_a.dot(self.b)) + self.beta * self.c
+        expect = self.alpha * self.op_a.dot(self.b) + self.beta * self.c
         self.assertIs(y, c)
         testing.assert_array_almost_equal(y, expect)
 
@@ -76,7 +76,7 @@ class TestCsrmm2(unittest.TestCase):
         b = cupy.array(self.b, order='f')
         y = cupy.cusparse.csrmm2(
             a, b, alpha=self.alpha, transa=self.transa, transb=self.transb)
-        expect = self.alpha * (self.op_a.dot(self.op_b))
+        expect = self.alpha * self.op_a.dot(self.op_b)
         testing.assert_array_almost_equal(y, expect)
 
     def test_csrmm2_with_c(self):
@@ -86,6 +86,6 @@ class TestCsrmm2(unittest.TestCase):
         y = cupy.cusparse.csrmm2(
             a, b, c=c, alpha=self.alpha, beta=self.beta,
             transa=self.transa, transb=self.transb)
-        expect = self.alpha * (self.op_a.dot(self.op_b)) + self.beta * self.c
+        expect = self.alpha * self.op_a.dot(self.op_b) + self.beta * self.c
         self.assertIs(y, c)
         testing.assert_array_almost_equal(y, expect)

--- a/tests/cupy_tests/test_cusparse.py
+++ b/tests/cupy_tests/test_cusparse.py
@@ -69,7 +69,7 @@ class TestCsrmm2(unittest.TestCase):
             self.b = self.op_b.T
         else:
             self.b = self.op_b
-        self.c = numpy.zeros((2, 4)).astype(self.dtype)
+        self.c = numpy.random.uniform(-1, 1, (2, 4)).astype(self.dtype)
 
     def test_csrmm2(self):
         a = cupy.sparse.csr_matrix(self.a)

--- a/tests/cupy_tests/test_cusparse.py
+++ b/tests/cupy_tests/test_cusparse.py
@@ -49,7 +49,7 @@ class TestCsrmm(unittest.TestCase):
 
 
 @testing.parameterize(*testing.product({
-    'dtype': [numpy.float64],
+    'dtype': [numpy.float32, numpy.float64],
     'trans': [(False, False), (True, False), (False, True)],
 }))
 @testing.with_requires('scipy')

--- a/tests/cupy_tests/test_cusparse.py
+++ b/tests/cupy_tests/test_cusparse.py
@@ -1,0 +1,92 @@
+import unittest
+
+import numpy
+try:
+    import scipy.sparse
+    scipy_available = True
+except ImportError:
+    scipy_available = False
+
+import cupy
+from cupy import testing
+
+
+@testing.parameterize(*testing.product({
+    'dtype': [numpy.float32, numpy.float64],
+    'transa': [True, False],
+}))
+@testing.with_requires('scipy')
+class TestCsrmm(unittest.TestCase):
+
+    alpha = 0.5
+    beta = 0.25
+
+    def setUp(self):
+        self.op_a = scipy.sparse.random(2, 3, density=0.5, dtype=self.dtype)
+        if self.transa:
+            self.a = self.op_a.T
+        else:
+            self.a = self.op_a
+        self.b = numpy.random.uniform(-1, 1, (3, 4)).astype(self.dtype)
+        self.c = numpy.random.uniform(-1, 1, (2, 4)).astype(self.dtype)
+
+    def test_csrmm(self):
+        a = cupy.sparse.csr_matrix(self.a)
+        b = cupy.array(self.b, order='f')
+        y = cupy.cusparse.csrmm(a, b, alpha=self.alpha, transa=self.transa)
+        expect = self.alpha * (self.op_a.dot(self.b))
+        testing.assert_array_almost_equal(y, expect)
+
+    def test_csrmm_with_c(self):
+        a = cupy.sparse.csr_matrix(self.a)
+        b = cupy.array(self.b, order='f')
+        c = cupy.array(self.c, order='f')
+        y = cupy.cusparse.csrmm(
+            a, b, c=c, alpha=self.alpha, beta=self.beta, transa=self.transa)
+        expect = self.alpha * (self.op_a.dot(self.b)) + self.beta * self.c
+        self.assertIs(y, c)
+        testing.assert_array_almost_equal(y, expect)
+
+
+@testing.parameterize(*testing.product({
+    'dtype': [numpy.float64],
+    'trans': [(False, False), (True, False), (False, True)],
+}))
+@testing.with_requires('scipy')
+class TestCsrmm2(unittest.TestCase):
+
+    alpha = 0.5
+    beta = 0.25
+
+    def setUp(self):
+        self.transa, self.transb = self.trans
+        self.op_a = scipy.sparse.random(2, 3, density=0.5, dtype=self.dtype)
+        if self.transa:
+            self.a = self.op_a.T
+        else:
+            self.a = self.op_a
+        self.op_b = numpy.random.uniform(-1, 1, (3, 4)).astype(self.dtype)
+        if self.transb:
+            self.b = self.op_b.T
+        else:
+            self.b = self.op_b
+        self.c = numpy.zeros((2, 4)).astype(self.dtype)
+
+    def test_csrmm2(self):
+        a = cupy.sparse.csr_matrix(self.a)
+        b = cupy.array(self.b, order='f')
+        y = cupy.cusparse.csrmm2(
+            a, b, alpha=self.alpha, transa=self.transa, transb=self.transb)
+        expect = self.alpha * (self.op_a.dot(self.op_b))
+        testing.assert_array_almost_equal(y, expect)
+
+    def test_csrmm2_with_c(self):
+        a = cupy.sparse.csr_matrix(self.a)
+        b = cupy.array(self.b, order='f')
+        c = cupy.array(self.c, order='f')
+        y = cupy.cusparse.csrmm2(
+            a, b, c=c, alpha=self.alpha, beta=self.beta,
+            transa=self.transa, transb=self.transb)
+        expect = self.alpha * (self.op_a.dot(self.op_b)) + self.beta * self.c
+        self.assertIs(y, c)
+        testing.assert_array_almost_equal(y, expect)

--- a/tests/cupy_tests/test_cusparse.py
+++ b/tests/cupy_tests/test_cusparse.py
@@ -3,9 +3,8 @@ import unittest
 import numpy
 try:
     import scipy.sparse
-    scipy_available = True
 except ImportError:
-    scipy_available = False
+    pass
 
 import cupy
 from cupy import testing


### PR DESCRIPTION
I noticed that I misunderstood arguments `m` and `n` in `csrmm2` especially when `transa=True`.
fix #552 