### PR TITLE
Support dtype argument in random.randint

### DIFF
--- a/tests/cupy_tests/random_tests/test_sample.py
+++ b/tests/cupy_tests/random_tests/test_sample.py
@@ -13,38 +13,11 @@ from cupy.testing import hypothesis
 
 @testing.gpu
 class TestRandint(unittest.TestCase):
-
     _multiprocess_can_split_ = True
 
-    def setUp(self):
-        self.rs_tmp = random.generator._random_states
-        device_id = cuda.Device().id
-        self.m = mock.Mock()
-        self.m.interval.return_value = 0
-        random.generator._random_states = {device_id: self.m}
-
-    def tearDown(self):
-        random.generator._random_states = self.rs_tmp
-
-    def test_value_error(self):
+    def test_lo_hi_reversed(self):
         with self.assertRaises(ValueError):
             random.randint(100, 1)
-
-    def test_high_and_size_are_none(self):
-        random.randint(3)
-        self.m.interval.assert_called_with(2, None)
-
-    def test_size_is_none(self):
-        random.randint(3, 5)
-        self.m.interval.assert_called_with(1, None)
-
-    def test_high_is_none(self):
-        random.randint(3, None, (1, 2, 3))
-        self.m.interval.assert_called_with(2, (1, 2, 3))
-
-    def test_no_none(self):
-        random.randint(3, 5, (1, 2, 3))
-        self.m.interval.assert_called_with(1, (1, 2, 3))
 
 
 @testing.fix_random()
@@ -98,20 +71,29 @@ class TestRandintDtype(unittest.TestCase):
         self.assertLessEqual(low, min(x))
         self.assertLessEqual(max(x), high)
 
-    @testing.for_dtypes([numpy.uint32, numpy.int64, numpy.uint64])
+    @testing.for_int_dtypes(no_bool=True)
     def test_dtype2(self, dtype):
-        size = (1,)
-        low = numpy.iinfo(dtype).min
-        high = low + numpy.iinfo(numpy.int32).max + 1
-        x = random.randint(low, high, size, dtype)
-        self.assertLessEqual(low, min(x))
-        self.assertLessEqual(max(x), high)
+        dtype = numpy.dtype(dtype)
 
-        high = numpy.iinfo(dtype).max + 1
-        low = high - numpy.iinfo(numpy.int32).max - 1
-        x = random.randint(low, high, size, dtype)
-        self.assertLessEqual(low, int(min(x)))
-        self.assertLessEqual(int(max(x)), high)
+        # randint does not support 64 bit integers
+        if dtype in (numpy.int64, numpy.uint64):
+            return
+
+        iinfo = numpy.iinfo(dtype)
+        size = (10000,)
+
+        x = random.randint(iinfo.min, iinfo.max + 1, size, dtype)
+        self.assertEqual(x.dtype, dtype)
+        self.assertLessEqual(iinfo.min, min(x))
+        self.assertLessEqual(max(x), iinfo.max)
+
+        # Lower bound check
+        with self.assertRaises(ValueError):
+            random.randint(iinfo.min - 1, iinfo.min + 10, size, dtype)
+
+        # Upper bound check
+        with self.assertRaises(ValueError):
+            random.randint(iinfo.max - 10, iinfo.max + 2, size, dtype)
 
 
 @testing.gpu

--- a/tests/cupy_tests/random_tests/test_sample.py
+++ b/tests/cupy_tests/random_tests/test_sample.py
@@ -86,6 +86,35 @@ class TestRandint2(unittest.TestCase):
 
 
 @testing.gpu
+class TestRandintDtype(unittest.TestCase):
+
+    @testing.for_dtypes([
+        numpy.int8, numpy.uint8, numpy.int16, numpy.uint16, numpy.int32])
+    def test_dtype(self, dtype):
+        size = (1000,)
+        low = numpy.iinfo(dtype).min
+        high = numpy.iinfo(dtype).max + 1
+        x = random.randint(low, high, size, dtype)
+        self.assertLessEqual(low, min(x))
+        self.assertLessEqual(max(x), high)
+
+    @testing.for_dtypes([numpy.uint32, numpy.int64, numpy.uint64])
+    def test_dtype2(self, dtype):
+        size = (1,)
+        low = numpy.iinfo(dtype).min
+        high = low + numpy.iinfo(numpy.int32).max + 1
+        x = random.randint(low, high, size, dtype)
+        self.assertLessEqual(low, min(x))
+        self.assertLessEqual(max(x), high)
+
+        high = numpy.iinfo(dtype).max + 1
+        low = high - numpy.iinfo(numpy.int32).max - 1
+        x = random.randint(low, high, size, dtype)
+        self.assertLessEqual(low, int(min(x)))
+        self.assertLessEqual(int(max(x)), high)
+
+
+@testing.gpu
 class TestRandomIntegers(unittest.TestCase):
 
     _multiprocess_can_split_ = True


### PR DESCRIPTION
Limitation:
* `high - low <= 0x7fffffff` must be met

Merge after #564.