### PR TITLE
Fix indexing 0-dim array with boolean mask

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1383,14 +1383,12 @@ cdef class ndarray:
 
         slices += noneslices * (ndim - <Py_ssize_t>len(slices) + n_newaxes)
 
-        if len(slices) > self.ndim + n_newaxes:
-            raise IndexError('too many indices for array')
-
         # Check if advanced is true,
         # and convert list/NumPy arrays to cupy.ndarray
         advanced = False
         mask_exists = False
         for i, s in enumerate(slices):
+            is_list = False
             if isinstance(s, (list, numpy.ndarray)):
                 is_list = isinstance(s, list)
                 s = array(s)
@@ -1402,11 +1400,14 @@ cdef class ndarray:
                 if issubclass(s.dtype.type, numpy.integer):
                     advanced = True
                 elif issubclass(s.dtype.type, numpy.bool_):
-                    mask_exists = True
+                    mask_exists = not is_list
                 else:
                     raise IndexError(
                         'arrays used as indices must be of integer or boolean '
                         'type. (actual: {})'.format(s.dtype.type))
+
+        if not mask_exists and len(slices) > self.ndim + n_newaxes:
+            raise IndexError('too many indices for array')
 
         if mask_exists:
             n_not_slice_none = 0
@@ -2934,14 +2935,12 @@ cpdef _scatter_op(ndarray a, slices, value, op):
 
     slices += noneslices * (ndim - <Py_ssize_t>len(slices) + n_newaxes)
 
-    if len(slices) > a.ndim + n_newaxes:
-        raise IndexError('too many indices for array')
-
     # Check if advanced is true,
     # and convert list/NumPy arrays to cupy.ndarray
     advanced = False
     mask_exists = False
     for i, s in enumerate(slices):
+        is_list = False
         if isinstance(s, (list, numpy.ndarray)):
             is_list = isinstance(s, list)
             s = array(s)
@@ -2953,11 +2952,14 @@ cpdef _scatter_op(ndarray a, slices, value, op):
             if issubclass(s.dtype.type, numpy.integer):
                 advanced = True
             elif issubclass(s.dtype.type, numpy.bool_):
-                mask_exists = True
+                mask_exists = not is_list
             else:
                 raise IndexError(
                     'arrays used as indices must be of integer or boolean '
                     'type. (actual: {})'.format(s.dtype.type))
+
+    if not mask_exists and len(slices) > a.ndim + n_newaxes:
+        raise IndexError('too many indices for array')
 
     if mask_exists:
         n_not_slice_none = 0

--- a/cupy/cuda/function.pyx
+++ b/cupy/cuda/function.pyx
@@ -140,7 +140,8 @@ cdef class Function:
         s = _get_stream(stream)
         _launch(
             self.ptr,
-            grid[0], grid[1], grid[2], block[0], block[1], block[2],
+            max(1, grid[0]), max(1, grid[1]), max(1, grid[2]),
+            max(1, block[0]), max(1, block[1]), max(1, block[2]),
             args, shared_mem, s)
 
     cpdef linear_launch(self, size_t size, args, size_t shared_mem=0,

--- a/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
@@ -99,7 +99,8 @@ class TestArrayAdvancedIndexingGetitemPerm(unittest.TestCase):
     # {'shape': (), 'indexes': (False, True, True)},
     # {'shape': (), 'indexes': numpy.array([True])},
     # {'shape': (), 'indexes': numpy.array([False, True, True])},
-    # {'shape': (), 'indexes': numpy.empty((), dtype=numpy.bool_)},
+    {'shape': (), 'indexes': numpy.ones((), dtype=numpy.bool_)},
+    {'shape': (), 'indexes': numpy.zeros((), dtype=numpy.bool_)},
     {'shape': (0,), 'indexes': None},
     {'shape': (0,), 'indexes': ()},
     # TODO(niboshi): pass the following commented out tests
@@ -108,7 +109,8 @@ class TestArrayAdvancedIndexingGetitemPerm(unittest.TestCase):
     # {'shape': (0,), 'indexes': (False, True, True)},
     # {'shape': (0,), 'indexes': numpy.array([True])},
     # {'shape': (0,), 'indexes': numpy.array([False, True, True])},
-    # {'shape': (0,), 'indexes': numpy.empty((), dtype=numpy.bool_)},
+    {'shape': (0,), 'indexes': numpy.ones((), dtype=numpy.bool_)},
+    {'shape': (0,), 'indexes': numpy.zeros((), dtype=numpy.bool_)},
 )
 @testing.gpu
 class TestArrayAdvancedIndexingGetitemParametrized(unittest.TestCase):

--- a/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
@@ -309,6 +309,28 @@ class TestArrayInvalidIndexAdvGetitem(unittest.TestCase):
     {'shape': (2, 3, 4), 'indexes': [[1, 0], 2], 'value': 1},
     {'shape': (2, 3, 4), 'indexes': [[1], slice(1, 2)], 'value': 1},
     {'shape': (2, 3, 4), 'indexes': [[[1]], slice(1, 2)], 'value': 1},
+    # zero-dim and zero-sized arrays
+    {'shape': (), 'indexes': Ellipsis, 'value': 1},
+    {'shape': (), 'indexes': (), 'value': 1},
+    {'shape': (), 'indexes': None, 'value': 1},
+    # TODO(niboshi): pass the following commented out tests
+    # {'shape': (), 'indexes': True, 'value': 1},
+    # {'shape': (), 'indexes': (True,), 'value': 1},
+    # {'shape': (), 'indexes': (False, True, True), 'value': 1},
+    # {'shape': (), 'indexes': numpy.array([True]), 'value': 1},
+    # {'shape': (), 'indexes': numpy.array([False, True, True]), 'value': 1},
+    {'shape': (), 'indexes': numpy.ones((), dtype=numpy.bool_), 'value': 1},
+    {'shape': (), 'indexes': numpy.zeros((), dtype=numpy.bool_), 'value': 1},
+    {'shape': (0,), 'indexes': None, 'value': 1},
+    {'shape': (0,), 'indexes': (), 'value': 1},
+    # TODO(niboshi): pass the following commented out tests
+    # {'shape': (0,), 'indexes': True, 'value': 1},
+    # {'shape': (0,), 'indexes': (True,), 'value': 1},
+    # {'shape': (0,), 'indexes': (False, True, True), 'value': 1},
+    # {'shape': (0,), 'indexes': numpy.array([True]), 'value': 1},
+    # {'shape': (0,), 'indexes': numpy.array([False, True, True]), 'value': 1},
+    {'shape': (0,), 'indexes': numpy.ones((), dtype=numpy.bool_), 'value': 1},
+    {'shape': (0,), 'indexes': numpy.zeros((), dtype=numpy.bool_), 'value': 1},
 )
 @testing.gpu
 class TestArrayAdvancedIndexingSetitemScalarValue(unittest.TestCase):

--- a/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
@@ -109,8 +109,8 @@ class TestArrayAdvancedIndexingGetitemPerm(unittest.TestCase):
     # {'shape': (0,), 'indexes': (False, True, True)},
     # {'shape': (0,), 'indexes': numpy.array([True])},
     # {'shape': (0,), 'indexes': numpy.array([False, True, True])},
-    {'shape': (0,), 'indexes': numpy.ones((), dtype=numpy.bool_)},
-    {'shape': (0,), 'indexes': numpy.zeros((), dtype=numpy.bool_)},
+    # {'shape': (0,), 'indexes': numpy.ones((), dtype=numpy.bool_)},
+    # {'shape': (0,), 'indexes': numpy.zeros((), dtype=numpy.bool_)},
 )
 @testing.gpu
 class TestArrayAdvancedIndexingGetitemParametrized(unittest.TestCase):
@@ -329,8 +329,10 @@ class TestArrayInvalidIndexAdvGetitem(unittest.TestCase):
     # {'shape': (0,), 'indexes': (False, True, True), 'value': 1},
     # {'shape': (0,), 'indexes': numpy.array([True]), 'value': 1},
     # {'shape': (0,), 'indexes': numpy.array([False, True, True]), 'value': 1},
-    {'shape': (0,), 'indexes': numpy.ones((), dtype=numpy.bool_), 'value': 1},
-    {'shape': (0,), 'indexes': numpy.zeros((), dtype=numpy.bool_), 'value': 1},
+    # {'shape': (0,), 'indexes': numpy.ones((), dtype=numpy.bool_),
+    #  'value': 1},
+    # {'shape': (0,), 'indexes': numpy.zeros((), dtype=numpy.bool_),
+    #  'value': 1},
 )
 @testing.gpu
 class TestArrayAdvancedIndexingSetitemScalarValue(unittest.TestCase):


### PR DESCRIPTION
Fixes a part of #503.

This allows boolean mask on a 0-dim array:
```
a = cupy.ones(())
a[a != 0]
```