### PR TITLE
[Do not merge] v2 with Cython v0.27

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ python:
 
 install:
   - pip install -U pip wheel
-  - pip install cython==0.26.1
+  - pip install cython==0.27
   - python setup.py sdist --cupy-no-cuda
   - pip install autopep8 hacking
 


### PR DESCRIPTION
Rel #550. Do not merge.

This PR is for checking if Cython v0.27 with Python 3.5 does not work with CuPy v2 as well as #527.

