### PR TITLE
Support uint32 sampling in random.RandomState.interval

### DIFF
--- a/cupy/random/generator.py
+++ b/cupy/random/generator.py
@@ -166,16 +166,30 @@ class RandomState(object):
             If ``int``, 1-D array of length size is returned.
             If ``tuple``, multi-dimensional array with shape
             ``size`` is returned.
-            Currently, each element of the array is ``numpy.int32``.
+            Currently, only 32 bit integers can be sampled.
+            If 0 :math:`\\leq` ``mx`` :math:`\\leq` 0x7fffffff,
+            a ``numpy.int32`` array is returned.
+            If 0x80000000 :math:`\\leq` ``mx`` :math:`\\leq` 0xffffffff,
+            a ``numpy.uint32`` array is returned.
         """
-        dtype = numpy.int32
         if size is None:
             return self.interval(mx, 1).reshape(())
         elif isinstance(size, int):
             size = (size, )
 
         if mx == 0:
-            return cupy.zeros(size, dtype=dtype)
+            return cupy.zeros(size, dtype=numpy.int32)
+
+        if mx < 0:
+            raise ValueError(
+                'mx must be non-negative (actual: {})'.format(mx))
+        elif mx <= 0x7fffffff:
+            dtype = numpy.int32
+        elif mx <= 0xffffffff:
+            dtype = numpy.uint32
+        else:
+            raise ValueError(
+                'mx must be within uint32 range (actual: {})'.format(mx))
 
         mask = (1 << mx.bit_length()) - 1
         mask = cupy.array(mask, dtype=dtype)

--- a/tests/cupy_tests/random_tests/test_generator.py
+++ b/tests/cupy_tests/random_tests/test_generator.py
@@ -211,18 +211,32 @@ class TestInterval(unittest.TestCase):
 
     def test_shape_zero(self):
         v = self.rs.interval(10, None)
-        self.assertEqual(v.dtype, 'i')
+        self.assertEqual(v.dtype, numpy.int32)
         self.assertEqual(v.shape, ())
 
     def test_shape_one_dim(self):
         v = self.rs.interval(10, 10)
-        self.assertEqual(v.dtype, 'i')
+        self.assertEqual(v.dtype, numpy.int32)
         self.assertEqual(v.shape, (10,))
 
     def test_shape_multi_dim(self):
         v = self.rs.interval(10, (1, 2))
-        self.assertEqual(v.dtype, 'i')
+        self.assertEqual(v.dtype, numpy.int32)
         self.assertEqual(v.shape, (1, 2))
+
+    def test_int32_range(self):
+        v = self.rs.interval(0x00000000, 2)
+        self.assertEqual(v.dtype, numpy.int32)
+
+        v = self.rs.interval(0x7fffffff, 2)
+        self.assertEqual(v.dtype, numpy.int32)
+
+    def test_uint32_range(self):
+        v = self.rs.interval(0x80000000, 2)
+        self.assertEqual(v.dtype, numpy.uint32)
+
+        v = self.rs.interval(0xffffffff, 2)
+        self.assertEqual(v.dtype, numpy.uint32)
 
     @condition.repeat(3, 10)
     def test_bound_1(self):


### PR DESCRIPTION
In this PR, `random.RandomState.interval` supports sampling up to `0xffffffff`.
It returns `numpy.int32` array if `mx` <= 0x7fffffff for backward compatibility.
Otherwise it returns `numpy.uint32`.