### PR TITLE
cython 0.27.1 is released. revert .travis.yml to use the latest cython

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ python:
 
 install:
   - pip install -U pip wheel
-  - pip install cython==0.26.1
+  - pip install cython
   - python setup.py sdist --cupy-no-cuda
   - pip install autopep8 hacking
 


### PR DESCRIPTION
https://github.com/cython/cython/releases/tag/0.27.1 is released on 9 days ago.

follow-up: https://github.com/cupy/cupy/pull/529

ref. https://github.com/cython/cython/issues/1885