### PR TITLE
Fix multi-threaded application fail when memory pool is enabled

### DIFF
--- a/cupy/cuda/cupy_cuda.h
+++ b/cupy/cuda/cupy_cuda.h
@@ -130,6 +130,12 @@ CUresult cuGetErrorString(...) {
 }
 
 
+// Context management
+CUresult cuCtxGetCurrent(...) {
+    return CUDA_SUCCESS;
+}
+
+
 // Module load and kernel execution
 CUresult cuLinkCreate (...) {
     return CUDA_SUCCESS;

--- a/cupy/cuda/cupy_cuda.h
+++ b/cupy/cuda/cupy_cuda.h
@@ -106,6 +106,7 @@ enum CUjitInputType {};
 
 
 typedef void* CUdeviceptr;
+struct CUctx_st;
 struct CUevent_st;
 struct CUfunc_st;
 struct CUmod_st;
@@ -113,6 +114,7 @@ struct CUstream_st;
 struct CUlinkState_st;
 
 
+typedef struct CUctx_st* CUcontext;
 typedef struct CUevent_st* cudaEvent_t;
 typedef struct CUfunc_st* CUfunction;
 typedef struct CUmod_st* CUmodule;

--- a/cupy/cuda/driver.pxd
+++ b/cupy/cuda/driver.pxd
@@ -6,6 +6,7 @@ cdef extern from *:
     ctypedef int Device 'CUdevice'
     ctypedef int Result 'CUresult'
 
+    ctypedef void* Context 'CUcontext'
     ctypedef void* Deviceptr 'CUdeviceptr'
     ctypedef void* Event 'struct CUevent_st*'
     ctypedef void* Function 'struct CUfunc_st*'
@@ -23,6 +24,12 @@ cpdef enum:
     CU_JIT_INPUT_OBJECT = 3
     CU_JIT_INPUT_LIBRARY = 4
 
+
+###############################################################################
+# Context management
+###############################################################################
+
+cpdef size_t ctxGetCurrent() except *
 
 ###############################################################################
 # Module load and kernel execution

--- a/cupy/cuda/driver.pyx
+++ b/cupy/cuda/driver.pyx
@@ -23,6 +23,9 @@ cdef extern from "cupy_cuda.h" nogil:
     int cuGetErrorName(Result error, const char** pStr)
     int cuGetErrorString(Result error, const char** pStr)
 
+    # Context management
+    int cuCtxGetCurrent(Context* pctx)
+
     # Module load and kernel execution
     int cuLinkCreate(unsigned int numOptions, CUjit_option* options,
                      void** optionValues, LinkState* stateOut)
@@ -67,6 +70,18 @@ class CUDADriverError(RuntimeError):
 cpdef inline check_status(int status):
     if status != 0:
         raise CUDADriverError(status)
+
+
+###############################################################################
+# Context management
+###############################################################################
+
+cpdef size_t ctxGetCurrent() except *:
+    cdef Context* ctx
+    with nogil:
+        status = cuCtxGetCurrent(ctx)
+    check_status(status)
+    return <size_t>ctx
 
 
 ###############################################################################

--- a/tests/cupy_tests/cuda_tests/test_memory.py
+++ b/tests/cupy_tests/cuda_tests/test_memory.py
@@ -400,6 +400,7 @@ class TestAllocator(unittest.TestCase):
         with cupy.cuda.Device(0):
             self.assertEqual(0, self.pool.used_bytes())
             arr = cupy.arange(128, dtype=cupy.int64)
+            self.assertEqual(1024, arr.data.size)
             self.assertEqual(1024, self.pool.used_bytes())
 
     def test_reuse_between_thread(self):

--- a/tests/cupy_tests/cuda_tests/test_memory.py
+++ b/tests/cupy_tests/cuda_tests/test_memory.py
@@ -400,7 +400,7 @@ class TestAllocator(unittest.TestCase):
         with cupy.cuda.Device(0):
             self.assertEqual(0, self.pool.used_bytes())
             arr = cupy.arange(128, dtype=cupy.int64)
-            self.assertEqual(1024, arr.data.size)
+            self.assertEqual(1024, arr.data.mem.size)
             self.assertEqual(1024, self.pool.used_bytes())
 
     def test_reuse_between_thread(self):


### PR DESCRIPTION
This fixes #72.

I use `memGetInfo()` Runtime API, which seems to be most harmless, to explicitly bind the context to the current thread.
(I first tried `getDevice()`, but seems that it does not create a context)