### PR TITLE
Use mock.patch instead of directly replacing function with Mock

### DIFF
--- a/tests/cupy_tests/random_tests/test_sample.py
+++ b/tests/cupy_tests/random_tests/test_sample.py
@@ -90,24 +90,20 @@ class TestRandomIntegers(unittest.TestCase):
 
     _multiprocess_can_split_ = True
 
-    def setUp(self):
-        self.randint_tmp = random.sample_.randint
-        random.sample_.randint = mock.Mock()
-
-    def tearDown(self):
-        random.sample_.randint = self.randint_tmp
-
     def test_normal(self):
-        random.random_integers(3, 5)
-        random.sample_.randint.assert_called_with(3, 6, None)
+        with mock.patch('cupy.random.sample_.randint') as m:
+            random.random_integers(3, 5)
+        m.assert_called_with(3, 6, None)
 
     def test_high_is_none(self):
-        random.random_integers(3, None)
-        random.sample_.randint.assert_called_with(1, 4, None)
+        with mock.patch('cupy.random.sample_.randint') as m:
+            random.random_integers(3, None)
+        m.assert_called_with(1, 4, None)
 
     def test_size_is_not_none(self):
-        random.random_integers(3, 5, (1, 2, 3))
-        random.sample_.randint.assert_called_with(3, 6, (1, 2, 3))
+        with mock.patch('cupy.random.sample_.randint') as m:
+            random.random_integers(3, 5, (1, 2, 3))
+        m.assert_called_with(3, 6, (1, 2, 3))
 
 
 @testing.fix_random()
@@ -202,15 +198,15 @@ class TestChoice(unittest.TestCase):
 class TestRandomSample(unittest.TestCase):
 
     def test_rand(self):
-        random.sample_.random_sample = mock.Mock()
-        random.rand(1, 2, 3, dtype=numpy.float32)
-        random.sample_.random_sample.assert_called_once_with(
+        with mock.patch('cupy.random.sample_.random_sample') as m:
+            random.rand(1, 2, 3, dtype=numpy.float32)
+        m.assert_called_once_with(
             size=(1, 2, 3), dtype=numpy.float32)
 
     def test_rand_default_dtype(self):
-        random.sample_.random_sample = mock.Mock()
-        random.rand(1, 2, 3)
-        random.sample_.random_sample.assert_called_once_with(
+        with mock.patch('cupy.random.sample_.random_sample') as m:
+            random.rand(1, 2, 3)
+        m.assert_called_once_with(
             size=(1, 2, 3), dtype=float)
 
     def test_rand_invalid_argument(self):
@@ -218,15 +214,15 @@ class TestRandomSample(unittest.TestCase):
             random.rand(1, 2, 3, unnecessary='unnecessary_argument')
 
     def test_randn(self):
-        random.distributions.normal = mock.Mock()
-        random.randn(1, 2, 3, dtype=numpy.float32)
-        random.distributions.normal.assert_called_once_with(
+        with mock.patch('cupy.random.distributions.normal') as m:
+            random.randn(1, 2, 3, dtype=numpy.float32)
+        m.assert_called_once_with(
             size=(1, 2, 3), dtype=numpy.float32)
 
     def test_randn_default_dtype(self):
-        random.distributions.normal = mock.Mock()
-        random.randn(1, 2, 3)
-        random.distributions.normal.assert_called_once_with(
+        with mock.patch('cupy.random.distributions.normal') as m:
+            random.randn(1, 2, 3)
+        m.assert_called_once_with(
             size=(1, 2, 3), dtype=float)
 
     def test_randn_invalid_argument(self):


### PR DESCRIPTION
I replaced `Mock` with `mock.patch` where functions are directly replaced with `Mock`. It causes a critical bug. After replacing them other tests also uses these Mocks. Always we need to use `mock.patch` to replace functions.