### PR TITLE
[backport] Support coo matrix initialization with other types of sparse matrices

### DIFF
--- a/cupy/sparse/coo.py
+++ b/cupy/sparse/coo.py
@@ -19,6 +19,9 @@ class coo_matrix(sparse_data._data_matrix):
 
     Now it has only one initializer format below:
 
+    ``coo_matrix(S)``
+        ``S`` is another sparse matrix. It is equivalent to ``S.tocoo()``.
+
     ``coo_matrix((M, N), [dtype])``
         It constructs an empty matrix whose shape is ``(M, N)``. Default dtype
         is float64.
@@ -45,7 +48,22 @@ class coo_matrix(sparse_data._data_matrix):
             raise ValueError(
                 'Only two-dimensional sparse arrays are supported.')
 
-        if util.isshape(arg1):
+        if base.issparse(arg1):
+            x = arg1.asformat(self.format)
+            data = x.data
+            row = x.row
+            col = x.col
+
+            if arg1.format != self.format:
+                # When formats are differnent, all arrays are already copied
+                copy = False
+
+            if shape is None:
+                shape = arg1.shape
+
+            has_canonical_format = x.has_canonical_format
+
+        elif util.isshape(arg1):
             m, n = arg1
             m, n = int(m), int(n)
             data = cupy.zeros(0, dtype if dtype else 'd')
@@ -71,16 +89,6 @@ class coo_matrix(sparse_data._data_matrix):
                     'row, column, and data array must all be the same length')
 
             has_canonical_format = False
-
-        elif isspmatrix_coo(arg1):
-            data = arg1.data
-            row = arg1.row
-            col = arg1.col
-
-            if shape is None:
-                shape = arg1.shape
-
-            has_canonical_format = arg1.has_canonical_format
 
         else:
             raise ValueError(

--- a/tests/cupy_tests/sparse_tests/test_coo.py
+++ b/tests/cupy_tests/sparse_tests/test_coo.py
@@ -110,6 +110,15 @@ class TestCooMatrix(unittest.TestCase):
         testing.assert_array_equal(
             self.m.col, cupy.array([0, 1, 3, 2], self.dtype))
 
+    def test_init_copy(self):
+        n = cupy.sparse.coo_matrix(self.m)
+        self.assertIsNot(n, self.m)
+        cupy.testing.assert_array_equal(n.toarray(), self.m.toarray())
+
+    def test_init_copy_other_sparse(self):
+        n = cupy.sparse.coo_matrix(self.m.tocsr())
+        cupy.testing.assert_array_equal(n.toarray(), self.m.toarray())
+
     def test_shape(self):
         self.assertEqual(self.m.shape, (3, 4))
 


### PR DESCRIPTION
The backport of #573.