### PR TITLE
[backport] cython 0.27.1 is released. revert .travis.yml to use the latest cython

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ python:
 
 install:
   - pip install -U pip wheel
-  - pip install cython==0.26.1
+  - pip install cython
   - python setup.py sdist --cupy-no-cuda
   - pip install autopep8 hacking
 


### PR DESCRIPTION
Backport of #597