### PR TITLE
Use python 3.5 for doctest

### DIFF
--- a/docs/source/reference/difference.rst
+++ b/docs/source/reference/difference.rst
@@ -90,6 +90,6 @@ If these types were returned, it would be required to synchronize between GPU an
 If you want to use scalar values, cast the returned arrays explicitly.
 
   >>> type(np.sum(np.arange(3)))
-  <type 'numpy.int64'>
+  <class 'numpy.int64'>
   >>> type(cupy.sum(cupy.arange(3)))
-  <type 'cupy.core.core.ndarray'>
+  <class 'cupy.core.core.ndarray'>

--- a/docs/source/reference/difference.rst
+++ b/docs/source/reference/difference.rst
@@ -89,7 +89,7 @@ That is because CuPy scalar values (e.g. :class:`cupy.float32`) are aliases of N
 If these types were returned, it would be required to synchronize between GPU and CPU.
 If you want to use scalar values, cast the returned arrays explicitly.
 
-  >>> type(np.sum(np.arange(3)))
-  <class 'numpy.int64'>
-  >>> type(cupy.sum(cupy.arange(3)))
-  <class 'cupy.core.core.ndarray'>
+  >>> type(np.sum(np.arange(3))) == np.int64
+  True
+  >>> type(cupy.sum(cupy.arange(3))) == cupy.core.core.ndarray
+  True


### PR DESCRIPTION
Related: https://github.com/chainer/chainer-test/pull/342

Fixed doctest to pass with python 3.5.