### PR TITLE
[backport] fix typo in test_generate.py

### DIFF
--- a/tests/cupy_tests/indexing_tests/test_generate.py
+++ b/tests/cupy_tests/indexing_tests/test_generate.py
@@ -140,7 +140,7 @@ class TestC_(unittest.TestCase):
 @testing.gpu
 class TestAxisConcatenator(unittest.TestCase):
 
-    _multiprocesGs_can_split_ = True
+    _multiprocess_can_split_ = True
 
     def test_AxisConcatenator_init1(self):
         with self.assertRaises(TypeError):


### PR DESCRIPTION
Backport of #631