### PR TITLE
add missing chainer interreference

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -324,6 +324,7 @@ intersphinx_mapping = {
     'python': ('https://docs.python.org/3/', None),
     'numpy': ('http://docs.scipy.org/doc/numpy/', None),
     'scipy': ('http://docs.scipy.org/doc/scipy/reference/', None),
+    'chainer': ('https://docs.chainer.org/en/latest/', None),
 }
 
 doctest_global_setup = '''


### PR DESCRIPTION
to_cpu, to_gpu link is dead.
https://docs-cupy.chainer.org/en/stable/tutorial/basic.html#move-array-from-a-device-to-the-host