### PR TITLE
Fix the difference between six.MAXSIZE and max of cupy.int_

### DIFF
--- a/cupy/random/generator.py
+++ b/cupy/random/generator.py
@@ -277,7 +277,7 @@ class RandomState(object):
             self._generator, sample.data.ptr, sample.size * size_in_int)
 
         # Disable sign bit
-        sample &= six.MAXSIZE
+        sample &= cupy.iinfo(cupy.int_).max
         return sample
 
     def uniform(self, low=0.0, high=1.0, size=None, dtype=float):

--- a/tests/cupy_tests/random_tests/test_generator.py
+++ b/tests/cupy_tests/random_tests/test_generator.py
@@ -279,19 +279,19 @@ class TestTomaxint(unittest.TestCase):
         x = self.rs.tomaxint()
         self.assertEqual(x.shape, ())
         self.assertTrue((0 <= x).all())
-        self.assertTrue((x <= six.MAXSIZE).all())
+        self.assertTrue((x <= cupy.iinfo(cupy.int_).max).all())
 
     def test_tomaxint_int(self):
         x = self.rs.tomaxint(3)
         self.assertEqual(x.shape, (3,))
         self.assertTrue((0 <= x).all())
-        self.assertTrue((x <= six.MAXSIZE).all())
+        self.assertTrue((x <= cupy.iinfo(cupy.int_).max).all())
 
     def test_tomaxint_tuple(self):
         x = self.rs.tomaxint((2, 3))
         self.assertEqual(x.shape, (2, 3))
         self.assertTrue((0 <= x).all())
-        self.assertTrue((x <= six.MAXSIZE).all())
+        self.assertTrue((x <= cupy.iinfo(cupy.int_).max).all())
 
 
 @testing.parameterize(


### PR DESCRIPTION
On Windows x64, cupy.int_ is int32 but six.MAXSIZE is 64bit.