### PR TITLE
Use v6 RNN API with cuDNN7

### DIFF
--- a/cupy/cuda/cudnn.pxd
+++ b/cupy/cuda/cudnn.pxd
@@ -93,6 +93,10 @@ cpdef enum:
     CUDNN_UNIDIRECTIONAL = 0
     CUDNN_BIDIRECTIONAL = 1
 
+    CUDNN_RNN_ALGO_STANDARD = 0
+    CUDNN_RNN_ALGO_PERSIST_STATIC = 1
+    CUDNN_RNN_ALGO_PERSIST_DYNAMIC = 2
+
     CUDNN_LINEAR_INPUT = 0
     CUDNN_SKIP_INPUT = 1
 
@@ -336,6 +340,10 @@ cpdef setRNNDescriptor_v5(
     size_t rnnDesc, int hiddenSize, int numLayers,
     size_t dropoutDesc, int inputMode, int direction, int mode,
     int dataType)
+cpdef setRNNDescriptor_v6(
+    size_t handle, size_t rnnDesc, int hiddenSize, int numLayers,
+    size_t dropoutDesc, int inputMode, int direction, int mode,
+    int algo, int dataType)
 cpdef getRNNWorkspaceSize(
     size_t handle, size_t rnnDesc, int seqLength, size_t xDesc)
 cpdef getRNNTrainingReserveSize(

--- a/cupy/cuda/cudnn.pyx
+++ b/cupy/cuda/cudnn.pyx
@@ -1190,6 +1190,18 @@ cpdef setRNNDescriptor_v5(
     check_status(status)
 
 
+cpdef setRNNDescriptor_v6(
+        size_t handle, size_t rnnDesc, int hiddenSize, int numLayers,
+        size_t dropoutDesc, int inputMode, int direction, int mode,
+        int algo, int dataType):
+    status = cudnnSetRNNDescriptor_v6(
+        <Handle>handle, <RNNDescriptor>rnnDesc, hiddenSize, numLayers,
+        <DropoutDescriptor>dropoutDesc, <RNNInputMode>inputMode,
+        <DirectionMode>direction, <RNNMode>mode, <RNNAlgo>algo,
+        <DataType>dataType)
+    check_status(status)
+
+
 cpdef getRNNWorkspaceSize(
         size_t handle, size_t rnnDesc, int seqLength, size_t xDesc):
     cdef size_t sizeInBytes

--- a/cupy/cuda/cupy_cudnn.h
+++ b/cupy/cuda/cupy_cudnn.h
@@ -454,6 +454,8 @@ cudnnStatus_t cudnnSpatialTfSamplerBackward(...) {
 
 #if defined(CUPY_NO_CUDA) || (CUDNN_VERSION < 6000)
 
+typedef enum {} cudnnRNNAlgo_t;
+
 cudnnStatus_t cudnnSetRNNDescriptor_v6(...) {
     return CUDNN_STATUS_NOT_SUPPORTED;
 }

--- a/cupy/cudnn.py
+++ b/cupy/cudnn.py
@@ -274,9 +274,16 @@ def create_rnn_descriptor(hidden_size, num_layers, dropout_desc,
                           input_mode, direction, mode, data_type):
     desc = Descriptor(cudnn.createRNNDescriptor(),
                       cudnn.destroyRNNDescriptor)
-    cudnn.setRNNDescriptor_v5(
-        desc.value, hidden_size, num_layers, dropout_desc.value,
-        input_mode, direction, mode, data_type)
+    if _cudnn_version >= 7000:
+        _handle = get_handle()
+        _algo = cudnn.CUDNN_RNN_ALGO_STANDARD
+        cudnn.setRNNDescriptor_v6(
+            _handle, desc.value, hidden_size, num_layers, dropout_desc.value,
+            input_mode, direction, mode, _algo, data_type)
+    else:
+        cudnn.setRNNDescriptor_v5(
+            desc.value, hidden_size, num_layers, dropout_desc.value,
+            input_mode, direction, mode, data_type)
     return desc
 
 


### PR DESCRIPTION
This is a work-around for an issue in cuDNN7's `cudnnSetRNNDescriptor_v5`. We found there is potential issue in `cudnnSetRNNDescriptor_v5` of cuDNN7. Our proposal for this issue is to use `cudnnSetRNNDescriptor_v6` instead, which is a new API introduced in cuDNN6 and is the default in cuDNN7. 

With this PR, when cuDNN version is 7.0 or newer, `cudnnSetRNNDescritpor_v6` is automatically used. No modification to Chainer is necessary since there is no change in terms of user APIs.

We've confirmed that this PR works correctly with following combinations.
 * CUDA 9 and cuDNN 7.0
 * CUDA 8 and cuDNN 6.0
 * CUDA 8 and cuDNN 5.1