### PR TITLE
Fix repeat behave differently with numpy

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2434,7 +2434,7 @@ cpdef ndarray _repeat(ndarray a, repeats, axis=None):
 
     # Scalar and size 1 'repeat' arrays broadcast to any shape, for all
     # other inputs the dimension must match exactly.
-    broadcast = False
+    cdef bint broadcast = False
     if isinstance(repeats, int):
         if repeats < 0:
             raise ValueError(

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2463,6 +2463,10 @@ cpdef ndarray _repeat(ndarray a, repeats, axis=None):
         else:
             a = a.ravel()
             axis = 0
+    elif not (-a.ndim <= axis < a.ndim):
+        raise _AxisError(
+            'axis {} is out of bounds for array of dimension {}'.format(
+                axis, a.ndim))
 
     if broadcast:
         repeats = repeats * a._shape[axis % a._shape.size()]

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2440,6 +2440,7 @@ cpdef ndarray _repeat(ndarray a, repeats, axis=None):
             raise ValueError(
                 "'repeats' should not be negative: {}".format(repeats))
         broadcast = True
+        repeats = [repeats]
     elif cpython.PySequence_Check(repeats):
         for rep in repeats:
             if rep < 0:
@@ -2447,7 +2448,6 @@ cpdef ndarray _repeat(ndarray a, repeats, axis=None):
                     "all elements of 'repeats' should not be negative: {}"
                     .format(repeats))
         if len(repeats) == 1:
-            repeats = repeats[0]
             broadcast = True
     else:
         raise ValueError(
@@ -2456,7 +2456,7 @@ cpdef ndarray _repeat(ndarray a, repeats, axis=None):
     if axis is None:
         if broadcast:
             a = a.reshape((-1, 1))
-            ret = ndarray((a.size, repeats), dtype=a.dtype)
+            ret = ndarray((a.size, repeats[0]), dtype=a.dtype)
             if ret.size:
                 ret[...] = a
             return ret.ravel()
@@ -2465,7 +2465,7 @@ cpdef ndarray _repeat(ndarray a, repeats, axis=None):
             axis = 0
 
     if broadcast:
-        repeats = [repeats] * a._shape[axis % a._shape.size()]
+        repeats = repeats * a._shape[axis % a._shape.size()]
     elif a.shape[axis] != len(repeats):
         raise ValueError(
             "'repeats' and 'axis' of 'a' should be same length: {} != {}"

--- a/tests/cupy_tests/manipulation_tests/test_tiling.py
+++ b/tests/cupy_tests/manipulation_tests/test_tiling.py
@@ -59,7 +59,7 @@ class TestRepeatFailure(unittest.TestCase):
     @testing.numpy_cupy_raises()
     def test_repeat_failure(self, xp):
         x = testing.shaped_arange((2, 3, 4), xp)
-        xp.repeat(x, -3)
+        xp.repeat(x, self.repeats, self.axis)
 
 
 @testing.parameterize(

--- a/tests/cupy_tests/manipulation_tests/test_tiling.py
+++ b/tests/cupy_tests/manipulation_tests/test_tiling.py
@@ -8,8 +8,6 @@ from cupy import testing
     {'repeats': 2, 'axis': None},
     {'repeats': 2, 'axis': 1},
     {'repeats': 2, 'axis': -1},
-    {'repeats': [2], 'axis': None},
-    {'repeats': [2], 'axis': 1},
     {'repeats': [0, 0, 0], 'axis': 1},
     {'repeats': [1, 2, 3], 'axis': 1},
     {'repeats': [1, 2, 3], 'axis': -2},
@@ -26,16 +24,49 @@ class TestRepeat(unittest.TestCase):
 
 
 @testing.parameterize(
+    {'repeats': [2], 'axis': None},
+    {'repeats': [2], 'axis': 1},
+)
+@testing.gpu
+@testing.with_requires('numpy>=1.10')
+class TestRepeatListBroadcast(unittest.TestCase):
+
+    """Test for `repeats` argument using single element list.
+
+    This feature is only supported in NumPy 1.10 or later.
+    """
+
+    @testing.numpy_cupy_array_equal()
+    def test_array_repeat(self, xp):
+        x = testing.shaped_arange((2, 3, 4), xp)
+        return xp.repeat(x, self.repeats, self.axis)
+
+
+@testing.parameterize(
     {'repeats': 0, 'axis': None},
     {'repeats': 2, 'axis': None},
     {'repeats': 2, 'axis': 0},
-    {'repeats': [2], 'axis': None},
-    {'repeats': [2], 'axis': 0},
     {'repeats': [1, 2, 3, 4], 'axis': None},
     {'repeats': [1, 2, 3, 4], 'axis': 0},
 )
 @testing.gpu
 class TestRepeat1D(unittest.TestCase):
+
+    @testing.numpy_cupy_array_equal()
+    def test_array_repeat(self, xp):
+        x = testing.shaped_arange((4,), xp)
+        return xp.repeat(x, self.repeats, self.axis)
+
+
+@testing.parameterize(
+    {'repeats': [2], 'axis': None},
+    {'repeats': [2], 'axis': 0},
+)
+@testing.gpu
+@testing.with_requires('numpy>=1.10')
+class TestRepeat1DListBroadcast(unittest.TestCase):
+
+    """See comment in TestRepeatListBroadcast class."""
 
     @testing.numpy_cupy_array_equal()
     def test_array_repeat(self, xp):

--- a/tests/cupy_tests/manipulation_tests/test_tiling.py
+++ b/tests/cupy_tests/manipulation_tests/test_tiling.py
@@ -8,6 +8,8 @@ from cupy import testing
     {'repeats': 2, 'axis': None},
     {'repeats': 2, 'axis': 1},
     {'repeats': 2, 'axis': -1},
+    {'repeats': [2], 'axis': None},
+    {'repeats': [2], 'axis': 1},
     {'repeats': [0, 0, 0], 'axis': 1},
     {'repeats': [1, 2, 3], 'axis': 1},
     {'repeats': [1, 2, 3], 'axis': -2},
@@ -20,6 +22,23 @@ class TestRepeat(unittest.TestCase):
     @testing.numpy_cupy_array_equal()
     def test_array_repeat(self, xp):
         x = testing.shaped_arange((2, 3, 4), xp)
+        return xp.repeat(x, self.repeats, self.axis)
+
+@testing.parameterize(
+    {'repeats': 0, 'axis': None},
+    {'repeats': 2, 'axis': None},
+    {'repeats': 2, 'axis': 0},
+    {'repeats': [2], 'axis': None},
+    {'repeats': [2], 'axis': 0},
+    {'repeats': [1, 2, 3, 4], 'axis': None},
+    {'repeats': [1, 2, 3, 4], 'axis': 0},
+)
+@testing.gpu
+class TestRepeat1D(unittest.TestCase):
+
+    @testing.numpy_cupy_array_equal()
+    def test_array_repeat(self, xp):
+        x = testing.shaped_arange((4,), xp)
         return xp.repeat(x, self.repeats, self.axis)
 
 

--- a/tests/cupy_tests/manipulation_tests/test_tiling.py
+++ b/tests/cupy_tests/manipulation_tests/test_tiling.py
@@ -48,6 +48,8 @@ class TestRepeat1D(unittest.TestCase):
     {'repeats': [-3, -3], 'axis': 0},
     {'repeats': [1, 2, 3], 'axis': None},
     {'repeats': [1, 2], 'axis': 1},
+    {'repeats': 2, 'axis': -4},
+    {'repeats': 2, 'axis': 3},
 )
 @testing.gpu
 class TestRepeatFailure(unittest.TestCase):

--- a/tests/cupy_tests/manipulation_tests/test_tiling.py
+++ b/tests/cupy_tests/manipulation_tests/test_tiling.py
@@ -24,6 +24,7 @@ class TestRepeat(unittest.TestCase):
         x = testing.shaped_arange((2, 3, 4), xp)
         return xp.repeat(x, self.repeats, self.axis)
 
+
 @testing.parameterize(
     {'repeats': 0, 'axis': None},
     {'repeats': 2, 'axis': None},


### PR DESCRIPTION
Issue 1: NumPy works with `len(repeats) == 1`, while CuPy does not.

```
>>> import numpy as np
>>> import cupy as cp
>>> np.array([1,2,3]).repeat((2,))
array([1, 1, 2, 2, 3, 3])
>>> cp.array([1,2,3]).repeat((2,))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "cupy/core/core.pyx", line 691, in cupy.core.core.ndarray.repeat
  File "cupy/core/core.pyx", line 699, in cupy.core.core.ndarray.repeat
  File "cupy/core/core.pyx", line 2392, in cupy.core.core._repeat
ValueError: 'axis' should be specified if 'repeats' is sequence
```

Issue 2: NumPy works with `isinstance(repeats, list) == True` and `axis is None`, while CuPy does not.

```
>>> np.array([1,2,3]).repeat((2,2,2))
array([1, 1, 2, 2, 3, 3])
>>> cp.array([1,2,3]).repeat((2,2,2))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "cupy/core/core.pyx", line 691, in cupy.core.core.ndarray.repeat
  File "cupy/core/core.pyx", line 699, in cupy.core.core.ndarray.repeat
  File "cupy/core/core.pyx", line 2392, in cupy.core.core._repeat
ValueError: 'axis' should be specified if 'repeats' is sequence
```

This PR fixes the two issues above.

The corresponding NumPy code is around here:
https://github.com/numpy/numpy/blob/v1.13.0/numpy/core/src/multiarray/item_selection.c#L559-L565