### PR TITLE
Avoid PyInt in linear_launch

### DIFF
--- a/cupy/cuda/function.pyx
+++ b/cupy/cuda/function.pyx
@@ -147,12 +147,9 @@ cdef class Function:
     cpdef linear_launch(self, size_t size, args, size_t shared_mem=0,
                         size_t block_max_size=128, stream=None):
         # TODO(beam2d): Tune it
-        gridx = (size + block_max_size - 1) // block_max_size
-        if gridx > 2 ** 31 - 1:
-            gridx = 2 ** 31 - 1
-        blockx = size
-        if blockx > block_max_size:
-            blockx = block_max_size
+        cdef size_t gridx = min(
+            0x7fffffffUL, (size + block_max_size - 1) // block_max_size)
+        cdef size_t blockx = min(block_max_size, size)
         s = _get_stream(stream)
         _launch(self.ptr,
                 gridx, 1, 1, blockx, 1, 1, args, shared_mem, s)


### PR DESCRIPTION
This PR avoids PyInt in `linear_launch`.