### PR TITLE
Extract moveaxis and normalize_axis_tuple from einsum.

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -166,6 +166,7 @@ from cupy.manipulation.basic import copyto  # NOQA
 from cupy.manipulation.shape import ravel  # NOQA
 from cupy.manipulation.shape import reshape  # NOQA
 
+from cupy.manipulation.transpose import moveaxis  # NOQA
 from cupy.manipulation.transpose import rollaxis  # NOQA
 from cupy.manipulation.transpose import swapaxes  # NOQA
 from cupy.manipulation.transpose import transpose  # NOQA

--- a/cupy/core/__init__.py
+++ b/cupy/core/__init__.py
@@ -37,11 +37,13 @@ from cupy.core.core import left_shift  # NOQA
 from cupy.core.core import less  # NOQA
 from cupy.core.core import less_equal  # NOQA
 from cupy.core.core import matmul  # NOQA
+from cupy.core.core import moveaxis  # NOQA
 from cupy.core.core import multiply  # NOQA
 from cupy.core.core import nanmax  # NOQA
 from cupy.core.core import nanmin  # NOQA
 from cupy.core.core import ndarray  # NOQA
 from cupy.core.core import negative  # NOQA
+from cupy.core.core import normalize_axis_tuple  # NOQA
 from cupy.core.core import not_equal  # NOQA
 from cupy.core.core import power  # NOQA
 from cupy.core.core import real  # NOQA

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2173,7 +2173,8 @@ def _has_element(vector.vector[Py_ssize_t] source, Py_ssize_t n):
     return False
 
 
-def normalize_axis_tuple(axis, Py_ssize_t ndim):
+cpdef vector.vector[Py_ssize_t] normalize_axis_tuple(axis, Py_ssize_t ndim) \
+      except *:
     """Normalizes an axis argument into a tuple of non-negative integer axes.
 
     """

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2174,7 +2174,7 @@ def _has_element(vector.vector[Py_ssize_t] source, Py_ssize_t n):
 
 
 cpdef vector.vector[Py_ssize_t] normalize_axis_tuple(axis, Py_ssize_t ndim) \
-      except *:
+        except *:
     """Normalizes an axis argument into a tuple of non-negative integer axes.
 
     """

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2166,7 +2166,7 @@ cpdef ndarray asfortranarray(ndarray a, dtype=None):
 # Array manipulation routines
 # -----------------------------------------------------------------------------
 
-def has_element(vector.vector[Py_ssize_t] source, Py_ssize_t n):
+def _has_element(vector.vector[Py_ssize_t] source, Py_ssize_t n):
     for elem in source:
         if elem == n:
             return True
@@ -2198,7 +2198,7 @@ cpdef ndarray moveaxis(ndarray a, vector.vector[Py_ssize_t] source,
     cdef Py_ssize_t n = 0
     for i in range(a.ndim):
         n = <Py_ssize_t>i
-        if not has_element(source, n):
+        if not _has_element(source, n):
             order.push_back(n)
 
     for i in range(len(source)):

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2179,8 +2179,8 @@ def normalize_axis_tuple(vector.vector[Py_ssize_t] axis, ndim):
     """
     for ax in axis:
         if ax >= ndim or ax < -ndim:
-            raise numpy.AxisError('axis {} is out of bounds for array of '
-                                  'dimension {}'.format(ax, ndim))
+            raise _AxisError('axis {} is out of bounds for array of '
+                             'dimension {}'.format(ax, ndim))
     return tuple((ax % ndim) for ax in axis)
 
 

--- a/cupy/manipulation/transpose.py
+++ b/cupy/manipulation/transpose.py
@@ -56,7 +56,7 @@ def moveaxis(a, source, destination):
     .. seealso:: :func:`numpy.moveaxis`
 
     """
-    # TODO(okuta): check type
+    # TODO(fukatani): check type
     return core.moveaxis(a, source, destination)
 
 

--- a/cupy/manipulation/transpose.py
+++ b/cupy/manipulation/transpose.py
@@ -38,15 +38,16 @@ def swapaxes(a, axis1, axis2):
 
 def moveaxis(a, source, destination):
     """Moves axes of an array to new positions.
+
     Other axes remain in their original order.
 
     Args:
-    a (cupy.ndarray): Array whose axes should be reordered.
-    source (int or sequence of int):
-        Original positions of the axes to move. These must be unique.
-    destination (int or sequence of int):
-        Destination positions for each of the original axes. These must also be
-        unique.
+        a (cupy.ndarray): Array whose axes should be reordered.
+        source (int or sequence of int):
+            Original positions of the axes to move. These must be unique.
+        destination (int or sequence of int):
+            Destination positions for each of the original axes. These must
+            also be unique.
 
     Returns:
         cupy.ndarray:

--- a/cupy/manipulation/transpose.py
+++ b/cupy/manipulation/transpose.py
@@ -36,6 +36,29 @@ def swapaxes(a, axis1, axis2):
     return a.swapaxes(axis1, axis2)
 
 
+def moveaxis(a, source, destination):
+    """Moves axes of an array to new positions.
+    Other axes remain in their original order.
+
+    Args:
+    a (cupy.ndarray): Array whose axes should be reordered.
+    source (int or sequence of int):
+        Original positions of the axes to move. These must be unique.
+    destination (int or sequence of int):
+        Destination positions for each of the original axes. These must also be
+        unique.
+
+    Returns:
+        cupy.ndarray:
+        Array with moved axes. This array is a view of the input array.
+
+    .. seealso:: :func:`numpy.moveaxis`
+
+    """
+    # TODO(okuta): check type
+    return core.moveaxis(a, source, destination)
+
+
 def transpose(a, axes=None):
     """Permutes the dimensions of an array.
 

--- a/docs/source/reference/manipulation.rst
+++ b/docs/source/reference/manipulation.rst
@@ -29,6 +29,7 @@ Transposition
    :toctree: generated/
    :nosignatures:
 
+   cupy.moveaxis
    cupy.rollaxis
    cupy.swapaxes
    cupy.transpose

--- a/tests/cupy_tests/manipulation_tests/test_transpose.py
+++ b/tests/cupy_tests/manipulation_tests/test_transpose.py
@@ -10,11 +10,13 @@ class TestTranspose(unittest.TestCase):
     _multiprocess_can_split_ = True
 
     @testing.numpy_cupy_array_equal()
+    @testing.with_requires('numpy>=1.11')
     def test_moveaxis(self, xp):
         a = testing.shaped_arange((2, 3, 4), xp)
         return xp.moveaxis(a, [0, 1], [1, 2])
 
     @testing.numpy_cupy_raises()
+    @testing.with_requires('numpy>=1.11')
     def test_moveaxis_failure(self, xp):
         a = testing.shaped_arange((2, 3, 4), xp)
         return xp.moveaxis(a, [0, 1], [1, 3])

--- a/tests/cupy_tests/manipulation_tests/test_transpose.py
+++ b/tests/cupy_tests/manipulation_tests/test_transpose.py
@@ -23,17 +23,27 @@ class TestTranspose(unittest.TestCase):
 
     # dim is too large
     @testing.numpy_cupy_raises()
-    @testing.with_requires('numpy>=1.11')
-    def test_moveaxis_invalid1(self, xp):
+    @testing.with_requires('numpy>=1.13')
+    def test_moveaxis_invalid1_1(self, xp):
         a = testing.shaped_arange((2, 3, 4), xp)
         return xp.moveaxis(a, [0, 1], [1, 3])
 
+    def test_moveaxis_invalid1_2(self):
+        a = testing.shaped_arange((2, 3, 4), cupy)
+        with self.assertRaises(cupy.core.core._AxisError):
+            return cupy.moveaxis(a, [0, 1], [1, 3])
+
     # dim is too small
     @testing.numpy_cupy_raises()
-    @testing.with_requires('numpy>=1.11')
-    def test_moveaxis_invalid2(self, xp):
+    @testing.with_requires('numpy>=1.13')
+    def test_moveaxis_invalid2_1(self, xp):
         a = testing.shaped_arange((2, 3, 4), xp)
         return xp.moveaxis(a, [0, -4], [1, 2])
+
+    def test_moveaxis_invalid2_2(self):
+        a = testing.shaped_arange((2, 3, 4), cupy)
+        with self.assertRaises(cupy.core.core._AxisError):
+            return cupy.moveaxis(a, [0, -4], [1, 2])
 
     # len(source) != len(destination)
     @testing.numpy_cupy_raises()

--- a/tests/cupy_tests/manipulation_tests/test_transpose.py
+++ b/tests/cupy_tests/manipulation_tests/test_transpose.py
@@ -11,9 +11,15 @@ class TestTranspose(unittest.TestCase):
 
     @testing.numpy_cupy_array_equal()
     @testing.with_requires('numpy>=1.11')
-    def test_moveaxis(self, xp):
+    def test_moveaxis1(self, xp):
         a = testing.shaped_arange((2, 3, 4), xp)
         return xp.moveaxis(a, [0, 1], [1, 2])
+
+    @testing.numpy_cupy_array_equal()
+    @testing.with_requires('numpy>=1.11')
+    def test_moveaxis2(self, xp):
+        a = testing.shaped_arange((2, 3, 4), xp)
+        return xp.moveaxis(a, 1, -1)
 
     # dim is too large
     @testing.numpy_cupy_raises()
@@ -27,7 +33,7 @@ class TestTranspose(unittest.TestCase):
     @testing.with_requires('numpy>=1.11')
     def test_moveaxis_invalid2(self, xp):
         a = testing.shaped_arange((2, 3, 4), xp)
-        return xp.moveaxis(a, [0, -3], [1, 2])
+        return xp.moveaxis(a, [0, -4], [1, 2])
 
     # len(source) != len(destination)
     @testing.numpy_cupy_raises()

--- a/tests/cupy_tests/manipulation_tests/test_transpose.py
+++ b/tests/cupy_tests/manipulation_tests/test_transpose.py
@@ -14,6 +14,11 @@ class TestTranspose(unittest.TestCase):
         a = testing.shaped_arange((2, 3, 4), xp)
         return xp.moveaxis(a, [0, 1], [1, 2])
 
+    @testing.numpy_cupy_raises()
+    def test_moveaxis_failure(self, xp):
+        a = testing.shaped_arange((2, 3, 4), xp)
+        return xp.moveaxis(a, [0, 1], [1, 3])
+
     @testing.numpy_cupy_array_equal()
     def test_rollaxis(self, xp):
         a = testing.shaped_arange((2, 3, 4), xp)

--- a/tests/cupy_tests/manipulation_tests/test_transpose.py
+++ b/tests/cupy_tests/manipulation_tests/test_transpose.py
@@ -10,6 +10,11 @@ class TestTranspose(unittest.TestCase):
     _multiprocess_can_split_ = True
 
     @testing.numpy_cupy_array_equal()
+    def test_moveaxis(self, xp):
+        a = testing.shaped_arange((2, 3, 4), xp)
+        return xp.moveaxis(a, [0, 1], [1, 2])
+
+    @testing.numpy_cupy_array_equal()
     def test_rollaxis(self, xp):
         a = testing.shaped_arange((2, 3, 4), xp)
         return xp.rollaxis(a, 2)

--- a/tests/cupy_tests/manipulation_tests/test_transpose.py
+++ b/tests/cupy_tests/manipulation_tests/test_transpose.py
@@ -15,11 +15,33 @@ class TestTranspose(unittest.TestCase):
         a = testing.shaped_arange((2, 3, 4), xp)
         return xp.moveaxis(a, [0, 1], [1, 2])
 
+    # dim is too large
     @testing.numpy_cupy_raises()
     @testing.with_requires('numpy>=1.11')
-    def test_moveaxis_failure(self, xp):
+    def test_moveaxis_invalid1(self, xp):
         a = testing.shaped_arange((2, 3, 4), xp)
         return xp.moveaxis(a, [0, 1], [1, 3])
+
+    # dim is too small
+    @testing.numpy_cupy_raises()
+    @testing.with_requires('numpy>=1.11')
+    def test_moveaxis_invalid2(self, xp):
+        a = testing.shaped_arange((2, 3, 4), xp)
+        return xp.moveaxis(a, [0, -3], [1, 2])
+
+    # len(source) != len(destination)
+    @testing.numpy_cupy_raises()
+    @testing.with_requires('numpy>=1.11')
+    def test_moveaxis_invalid3(self, xp):
+        a = testing.shaped_arange((2, 3, 4), xp)
+        return xp.moveaxis(a, [0, 1, 2], [1, 2])
+
+    # len(source) != len(destination)
+    @testing.numpy_cupy_raises()
+    @testing.with_requires('numpy>=1.11')
+    def test_moveaxis_invalid4(self, xp):
+        a = testing.shaped_arange((2, 3, 4), xp)
+        return xp.moveaxis(a, [0, 1], [1, 2, 0])
 
     @testing.numpy_cupy_array_equal()
     def test_rollaxis(self, xp):


### PR DESCRIPTION
Extracted `moveaxis` as numpy>=1.11 API.
Also I want to use `normalize_axis_tuple` in `moveaxis` and `einsum`, I transport it to `cupy.core`.