### PR TITLE
Set arch option when calling `_preprocess`, as the option is necesary on some modern GPUs (e.g. Drive PX 2)

### DIFF
--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -78,10 +78,7 @@ def compile_using_nvrtc(source, options=(), arch=None):
         return ptx
 
 
-def _preprocess(source, options=(), arch=None):
-    if not arch:
-        arch = _get_arch()
-
+def _preprocess(source, options, arch):
     options += ('-arch={}'.format(arch),)
 
     prog = _NVRTCProgram(source, '')

--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -78,7 +78,12 @@ def compile_using_nvrtc(source, options=(), arch=None):
         return ptx
 
 
-def _preprocess(source, options=()):
+def _preprocess(source, options=(), arch=None):
+    if not arch:
+        arch = _get_arch()
+
+    options += ('-arch={}'.format(arch),)
+
     prog = _NVRTCProgram(source, '')
     try:
         result = prog.compile(options)
@@ -118,7 +123,8 @@ def compile_with_cache(source, options=(), arch=None, cache_dir=None,
     base = _empty_file_preprocess_cache.get(env, None)
     if base is None:
         # This is checking of NVRTC compiler internal version
-        base = _empty_file_preprocess_cache[env] = _preprocess('', options)
+        base = _preprocess('', options, arch)
+        _empty_file_preprocess_cache[env] = base
     key_src = '%s %s %s %s' % (env, base, source, extra_source)
 
     key_src = key_src.encode('utf-8')


### PR DESCRIPTION
Passing `arch` option to nvrtc is necessary on some modern GPUs (e.g. one on Drive PX 2), even when compiling the empty program. This PR makes `_preprocess` method to pass the `arch` option.

Without the patch, the following error occurred when executing `./train_mnist.py -g 0` (with cupy 2.0.0).

I note that a similar issue also exists on MXNet <https://github.com/apache/incubator-mxnet/issues/8387>.

```
Exception in main training loop: nvrtc: error: failed to load builtins
Traceback (most recent call last):
  File "/home/nvidia/.virtualenvs/bench/lib/python3.5/site-packages/chainer/training/trainer.py", line 299, in run
    update()
  File "/home/nvidia/.virtualenvs/bench/lib/python3.5/site-packages/chainer/training/updater.py", line 223, in update
    self.update_core()
  File "/home/nvidia/.virtualenvs/bench/lib/python3.5/site-packages/chainer/training/updater.py", line 234, in update_core
    optimizer.update(loss_func, *in_arrays)
  File "/home/nvidia/.virtualenvs/bench/lib/python3.5/site-packages/chainer/optimizer.py", line 528, in update
    loss = lossfun(*args, **kwds)
  File "/home/nvidia/.virtualenvs/bench/lib/python3.5/site-packages/chainer/links/model/classifier.py", line 114, in __call__
    self.y = self.predictor(*args, **kwargs)
  File "./train_mnist.py", line 26, in __call__
    h1 = F.relu(self.l1(x))
  File "/home/nvidia/.virtualenvs/bench/lib/python3.5/site-packages/chainer/links/connection/linear.py", line 126, in __call__
    self._initialize_params(x.size // x.shape[0])
  File "/home/nvidia/.virtualenvs/bench/lib/python3.5/site-packages/chainer/links/connection/linear.py", line 113, in _initialize_params
    self.W.initialize((self.out_size, in_size))
  File "/home/nvidia/.virtualenvs/bench/lib/python3.5/site-packages/chainer/variable.py", line 1222, in initialize
    data = initializers.generate_array(self.initializer, shape, xp)
  File "/home/nvidia/.virtualenvs/bench/lib/python3.5/site-packages/chainer/initializers/__init__.py", line 46, in generate_array
    initializer(array)
  File "/home/nvidia/.virtualenvs/bench/lib/python3.5/site-packages/chainer/initializers/normal.py", line 68, in __call__
    Normal(s)(array)
  File "/home/nvidia/.virtualenvs/bench/lib/python3.5/site-packages/chainer/initializers/normal.py", line 36, in __call__
    array[...] = xp.random.normal(**args)
  File "/home/nvidia/.virtualenvs/bench/lib/python3.5/site-packages/cupy/random/distributions.py", line 94, in normal
    cupy.multiply(x, scale, out=x)
  File "/home/nvidia/.virtualenvs/bench/lib/python3.5/site-packages/cupy/core/fusion.py", line 701, in __call__
    return self._cupy_op(*args, **kwargs)
  File "cupy/core/elementwise.pxi", line 810, in cupy.core.core.ufunc.__call__
  File "cupy/util.pyx", line 39, in cupy.util.memoize.decorator.ret
  File "cupy/core/elementwise.pxi", line 613, in cupy.core.core._get_ufunc_kernel
  File "cupy/core/elementwise.pxi", line 33, in cupy.core.core._get_simple_elementwise_kernel
  File "cupy/core/carray.pxi", line 170, in cupy.core.core.compile_with_cache
  File "/home/nvidia/.virtualenvs/bench/lib/python3.5/site-packages/cupy/cuda/compiler.py", line 121, in compile_with_cache
    base = _empty_file_preprocess_cache[env] = _preprocess('', options)
  File "/home/nvidia/.virtualenvs/bench/lib/python3.5/site-packages/cupy/cuda/compiler.py", line 84, in _preprocess
    result = prog.compile(options)
  File "/home/nvidia/.virtualenvs/bench/lib/python3.5/site-packages/cupy/cuda/compiler.py", line 230, in compile
    raise CompileException(log, self.src, self.name, options)
Will finalize trainer extensions and updater before reraising the exception.
Traceback (most recent call last):
  File "/home/nvidia/.virtualenvs/bench/lib/python3.5/site-packages/cupy/cuda/compiler.py", line 226, in compile
    nvrtc.compileProgram(self.ptr, options)
  File "cupy/cuda/nvrtc.pyx", line 98, in cupy.cuda.nvrtc.compileProgram
  File "cupy/cuda/nvrtc.pyx", line 108, in cupy.cuda.nvrtc.compileProgram
  File "cupy/cuda/nvrtc.pyx", line 53, in cupy.cuda.nvrtc.check_status
cupy.cuda.nvrtc.NVRTCError: NVRTC_ERROR unknown (7)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "./train_mnist.py", line 124, in <module>
    main()
  File "./train_mnist.py", line 120, in main
    trainer.run()
  File "/home/nvidia/.virtualenvs/bench/lib/python3.5/site-packages/chainer/training/trainer.py", line 313, in run
    six.reraise(*sys.exc_info())
  File "/home/nvidia/.virtualenvs/bench/lib/python3.5/site-packages/six.py", line 693, in reraise
    raise value
  File "/home/nvidia/.virtualenvs/bench/lib/python3.5/site-packages/chainer/training/trainer.py", line 299, in run
    update()
  File "/home/nvidia/.virtualenvs/bench/lib/python3.5/site-packages/chainer/training/updater.py", line 223, in update
    self.update_core()
  File "/home/nvidia/.virtualenvs/bench/lib/python3.5/site-packages/chainer/training/updater.py", line 234, in update_core
    optimizer.update(loss_func, *in_arrays)
  File "/home/nvidia/.virtualenvs/bench/lib/python3.5/site-packages/chainer/optimizer.py", line 528, in update
    loss = lossfun(*args, **kwds)
  File "/home/nvidia/.virtualenvs/bench/lib/python3.5/site-packages/chainer/links/model/classifier.py", line 114, in __call__
    self.y = self.predictor(*args, **kwargs)
  File "./train_mnist.py", line 26, in __call__
    h1 = F.relu(self.l1(x))
  File "/home/nvidia/.virtualenvs/bench/lib/python3.5/site-packages/chainer/links/connection/linear.py", line 126, in __call__
    self._initialize_params(x.size // x.shape[0])
  File "/home/nvidia/.virtualenvs/bench/lib/python3.5/site-packages/chainer/links/connection/linear.py", line 113, in _initialize_params
    self.W.initialize((self.out_size, in_size))
  File "/home/nvidia/.virtualenvs/bench/lib/python3.5/site-packages/chainer/variable.py", line 1222, in initialize
    data = initializers.generate_array(self.initializer, shape, xp)
  File "/home/nvidia/.virtualenvs/bench/lib/python3.5/site-packages/chainer/initializers/__init__.py", line 46, in generate_array
    initializer(array)
  File "/home/nvidia/.virtualenvs/bench/lib/python3.5/site-packages/chainer/initializers/normal.py", line 68, in __call__
    Normal(s)(array)
  File "/home/nvidia/.virtualenvs/bench/lib/python3.5/site-packages/chainer/initializers/normal.py", line 36, in __call__
    array[...] = xp.random.normal(**args)
  File "/home/nvidia/.virtualenvs/bench/lib/python3.5/site-packages/cupy/random/distributions.py", line 94, in normal
    cupy.multiply(x, scale, out=x)
  File "/home/nvidia/.virtualenvs/bench/lib/python3.5/site-packages/cupy/core/fusion.py", line 701, in __call__
    return self._cupy_op(*args, **kwargs)
  File "cupy/core/elementwise.pxi", line 810, in cupy.core.core.ufunc.__call__
  File "cupy/util.pyx", line 39, in cupy.util.memoize.decorator.ret
  File "cupy/core/elementwise.pxi", line 613, in cupy.core.core._get_ufunc_kernel
  File "cupy/core/elementwise.pxi", line 33, in cupy.core.core._get_simple_elementwise_kernel
  File "cupy/core/carray.pxi", line 170, in cupy.core.core.compile_with_cache
  File "/home/nvidia/.virtualenvs/bench/lib/python3.5/site-packages/cupy/cuda/compiler.py", line 121, in compile_with_cache
    base = _empty_file_preprocess_cache[env] = _preprocess('', options)
  File "/home/nvidia/.virtualenvs/bench/lib/python3.5/site-packages/cupy/cuda/compiler.py", line 84, in _preprocess
    result = prog.compile(options)
  File "/home/nvidia/.virtualenvs/bench/lib/python3.5/site-packages/cupy/cuda/compiler.py", line 230, in compile
    raise CompileException(log, self.src, self.name, options)
cupy.cuda.compiler.CompileException: nvrtc: error: failed to load builtins
```