### PR TITLE
Fix RandomState.seed to only accept integer types

### DIFF
--- a/cupy/random/generator.py
+++ b/cupy/random/generator.py
@@ -240,7 +240,7 @@ class RandomState(object):
             except NotImplementedError:
                 seed = numpy.uint64(time.clock() * 1000000)
         else:
-            seed = numpy.uint64(seed)
+            seed = numpy.asarray(seed).astype(numpy.uint64, casting='safe')
 
         curand.setPseudoRandomGeneratorSeed(self._generator, seed)
         curand.setGeneratorOffset(self._generator, 0)

--- a/tests/cupy_tests/random_tests/test_generator.py
+++ b/tests/cupy_tests/random_tests/test_generator.py
@@ -118,10 +118,22 @@ class TestRandomState(unittest.TestCase):
         with FunctionSwitcher(curand.setPseudoRandomGeneratorSeed):
             self.check_seed(curand.setPseudoRandomGeneratorSeed, None)
 
-    @testing.for_all_dtypes()
+    @testing.for_int_dtypes()
     def test_seed_not_none(self, dtype):
         with FunctionSwitcher(curand.setPseudoRandomGeneratorSeed):
             self.check_seed(curand.setPseudoRandomGeneratorSeed, dtype(0))
+
+    @testing.for_dtypes([numpy.complex_])
+    def test_seed_invalid_type_complex(self, dtype):
+        with self.assertRaises(TypeError):
+            with FunctionSwitcher(curand.setPseudoRandomGeneratorSeed):
+                self.check_seed(curand.setPseudoRandomGeneratorSeed, dtype(0))
+
+    @testing.for_float_dtypes()
+    def test_seed_invalid_type_float(self, dtype):
+        with self.assertRaises(TypeError):
+            with FunctionSwitcher(curand.setPseudoRandomGeneratorSeed):
+                self.check_seed(curand.setPseudoRandomGeneratorSeed, dtype(0))
 
 
 @testing.gpu


### PR DESCRIPTION
To align with NumPy, `cupy.random.RandomState.seed` should only accept integer types.

This fix supresses `ComplexWarning` in unit tests:

```
tests/cupy_tests/random_tests/test_generator.py::TestRandomState2::test_seed_not_none
  /work/cupy/cupy/random/generator.py:243: ComplexWarning: Casting complex values to real discards the imaginary part
    seed = numpy.uint64(seed)
```