### PR TITLE
pass ddof from var/std to _var/_std

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1092,7 +1092,8 @@ cdef class ndarray:
            :meth:`numpy.ndarray.var`
 
         """
-        return _var(self, axis=axis, dtype=dtype, out=out, keepdims=keepdims)
+        return _var(self, axis=axis, dtype=dtype, out=out, ddof=ddof,
+                    keepdims=keepdims)
 
     cpdef ndarray std(self, axis=None, dtype=None, out=None, ddof=0,
                       keepdims=False):
@@ -1103,7 +1104,8 @@ cdef class ndarray:
            :meth:`numpy.ndarray.std`
 
         """
-        return _std(self, axis=axis, dtype=dtype, out=out, keepdims=keepdims)
+        return _std(self, axis=axis, dtype=dtype, out=out, ddof=ddof,
+                    keepdims=keepdims)
 
     cpdef ndarray prod(self, axis=None, dtype=None, out=None, keepdims=None):
         """Returns the product along a given axis.

--- a/cupy/statistics/meanvar.py
+++ b/cupy/statistics/meanvar.py
@@ -45,7 +45,8 @@ def var(a, axis=None, dtype=None, out=None, ddof=0, keepdims=False):
 
     """
     # TODO(okuta): check type
-    return a.var(axis=axis, dtype=dtype, out=out, keepdims=keepdims)
+    return a.var(axis=axis, dtype=dtype, out=out, ddof=ddof,
+                 keepdims=keepdims)
 
 
 def std(a, axis=None, dtype=None, out=None, ddof=0, keepdims=False):
@@ -67,7 +68,8 @@ def std(a, axis=None, dtype=None, out=None, ddof=0, keepdims=False):
 
     """
     # TODO(okuta): check type
-    return a.std(axis=axis, dtype=dtype, out=out, keepdims=keepdims)
+    return a.std(axis=axis, dtype=dtype, out=out, ddof=ddof,
+                 keepdims=keepdims)
 
 
 # TODO(okuta): Implement nanmean

--- a/tests/cupy_tests/statics_tests/test_meanvar.py
+++ b/tests/cupy_tests/statics_tests/test_meanvar.py
@@ -43,6 +43,18 @@ class TestMeanVar(unittest.TestCase):
     def test_external_var_all(self, xp, dtype):
         a = testing.shaped_arange((2, 3), xp, dtype)
         return xp.var(a)
+        
+    @testing.for_all_dtypes(no_complex=True)
+    @testing.numpy_cupy_allclose()
+    def test_var_all_ddof(self, xp, dtype):
+        a = testing.shaped_arange((2, 3), xp, dtype)
+        return a.var(ddof=1)
+
+    @testing.for_all_dtypes(no_complex=True)
+    @testing.numpy_cupy_allclose()
+    def test_external_var_all_ddof(self, xp, dtype):
+        a = testing.shaped_arange((2, 3), xp, dtype)
+        return xp.var(a, ddof=1)
 
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose()
@@ -58,6 +70,18 @@ class TestMeanVar(unittest.TestCase):
 
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose()
+    def test_var_axis_ddof(self, xp, dtype):
+        a = testing.shaped_arange((2, 3, 4), xp, dtype)
+        return a.var(axis=1, ddof=1)
+
+    @testing.for_all_dtypes(no_complex=True)
+    @testing.numpy_cupy_allclose()
+    def test_external_var_axis_ddof(self, xp, dtype):
+        a = testing.shaped_arange((2, 3, 4), xp, dtype)
+        return xp.var(a, axis=1, ddof=1)
+        
+    @testing.for_all_dtypes(no_complex=True)
+    @testing.numpy_cupy_allclose()
     def test_std_all(self, xp, dtype):
         a = testing.shaped_arange((2, 3), xp, dtype)
         return a.std()
@@ -67,6 +91,18 @@ class TestMeanVar(unittest.TestCase):
     def test_external_std_all(self, xp, dtype):
         a = testing.shaped_arange((2, 3), xp, dtype)
         return xp.std(a)
+        
+    @testing.for_all_dtypes(no_complex=True)
+    @testing.numpy_cupy_allclose()
+    def test_std_all_ddof(self, xp, dtype):
+        a = testing.shaped_arange((2, 3), xp, dtype)
+        return a.std(ddof=1)
+
+    @testing.for_all_dtypes(no_complex=True)
+    @testing.numpy_cupy_allclose()
+    def test_external_std_all_ddof(self, xp, dtype):
+        a = testing.shaped_arange((2, 3), xp, dtype)
+        return xp.std(a, ddof=1)
 
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose()
@@ -79,3 +115,15 @@ class TestMeanVar(unittest.TestCase):
     def test_external_std_axis(self, xp, dtype):
         a = testing.shaped_arange((2, 3, 4), xp, dtype)
         return xp.std(a, axis=1)
+
+    @testing.for_all_dtypes(no_complex=True)
+    @testing.numpy_cupy_allclose()
+    def test_std_axis_ddof(self, xp, dtype):
+        a = testing.shaped_arange((2, 3, 4), xp, dtype)
+        return a.std(axis=1, ddof=1)
+
+    @testing.for_all_dtypes(no_complex=True)
+    @testing.numpy_cupy_allclose()
+    def test_external_std_axis_ddof(self, xp, dtype):
+        a = testing.shaped_arange((2, 3, 4), xp, dtype)
+        return xp.std(a, axis=1, ddof=1)

--- a/tests/cupy_tests/statics_tests/test_meanvar.py
+++ b/tests/cupy_tests/statics_tests/test_meanvar.py
@@ -43,7 +43,7 @@ class TestMeanVar(unittest.TestCase):
     def test_external_var_all(self, xp, dtype):
         a = testing.shaped_arange((2, 3), xp, dtype)
         return xp.var(a)
-        
+
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose()
     def test_var_all_ddof(self, xp, dtype):
@@ -79,7 +79,7 @@ class TestMeanVar(unittest.TestCase):
     def test_external_var_axis_ddof(self, xp, dtype):
         a = testing.shaped_arange((2, 3, 4), xp, dtype)
         return xp.var(a, axis=1, ddof=1)
-        
+
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose()
     def test_std_all(self, xp, dtype):
@@ -91,7 +91,7 @@ class TestMeanVar(unittest.TestCase):
     def test_external_std_all(self, xp, dtype):
         a = testing.shaped_arange((2, 3), xp, dtype)
         return xp.std(a)
-        
+
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose()
     def test_std_all_ddof(self, xp, dtype):


### PR DESCRIPTION
The `ddof` parameter is not currently passed from `std` and `var` to `_std` and `_var` respectively, though the code for ddof is implemented in both `_std` and `_var`. The follow code illustrates the problem:

```
import cupy as cp
np.random.seed(0)
samples = np.random.random(size=(20,)).astype(np.float64)
for i in range(5):
    print('with ddof=%d:' % i)
    print('np:', np.var(samples, ddof=i, axis=0))
    print('cp:', cp.array(samples).var(ddof=i, axis=0))
    print(' ')
```

With the current `master`, the output is:

```
with ddof=0:
np: 0.0761292085833
cp: 0.07612920858325248
 
with ddof=1:
np: 0.080136009035
cp: 0.07612920858325248
 
with ddof=2:
np: 0.0845880095369
cp: 0.07612920858325248
 
with ddof=3:
np: 0.0895637748038
cp: 0.07612920858325248
 
with ddof=4:
np: 0.0951615107291
cp: 0.07612920858325248
```

With the changes in this PR, the output is:

```
with ddof=0:
np: 0.0761292085833
cp: 0.07612920858325248
 
with ddof=1:
np: 0.080136009035
cp: 0.08013600903500259
 
with ddof=2:
np: 0.0845880095369
cp: 0.08458800953694719
 
with ddof=3:
np: 0.0895637748038
cp: 0.08956377480382643
 
with ddof=4:
np: 0.0951615107291
cp: 0.09516151072906559
```