### PR TITLE
improve matrix inverse speed using LU decomposition

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1092,7 +1092,8 @@ cdef class ndarray:
            :meth:`numpy.ndarray.var`
 
         """
-        return _var(self, axis=axis, dtype=dtype, out=out, keepdims=keepdims)
+        return _var(self, axis=axis, dtype=dtype, out=out, ddof=ddof,
+                    keepdims=keepdims)
 
     cpdef ndarray std(self, axis=None, dtype=None, out=None, ddof=0,
                       keepdims=False):
@@ -1103,7 +1104,8 @@ cdef class ndarray:
            :meth:`numpy.ndarray.std`
 
         """
-        return _std(self, axis=axis, dtype=dtype, out=out, keepdims=keepdims)
+        return _std(self, axis=axis, dtype=dtype, out=out, ddof=ddof,
+                    keepdims=keepdims)
 
     cpdef ndarray prod(self, axis=None, dtype=None, out=None, keepdims=None):
         """Returns the product along a given axis.

--- a/cupy/linalg/solve.py
+++ b/cupy/linalg/solve.py
@@ -189,7 +189,7 @@ def inv(a):
     workspace = cupy.empty(buffersize, dtype=dtype)
 
     # LU factorization
-    getrf(cusolver_handle, m, m, a.data.ptr, m, workspace.data.ptr, 
+    getrf(cusolver_handle, m, m, a.data.ptr, m, workspace.data.ptr,
           ipiv.data.ptr, dev_info.data.ptr)
 
     b = cupy.eye(m, dtype=dtype)

--- a/cupy/linalg/solve.py
+++ b/cupy/linalg/solve.py
@@ -156,15 +156,51 @@ def inv(a):
 
     .. seealso:: :func:`numpy.linalg.inv`
     '''
-    if not cuda.cusolver_enabled:
-        raise RuntimeError('Current cupy only supports cusolver in CUDA 8.0')
 
     util._assert_cupy_array(a)
     util._assert_rank2(a)
     util._assert_nd_squareness(a)
 
-    b = cupy.eye(len(a), dtype=a.dtype)
-    return solve(a, b)
+    if not cuda.cusolver_enabled:
+        raise RuntimeError('Current cupy only supports cusolver in CUDA 8.0')
+    
+    if a.dtype.char == 'f' or a.dtype.char == 'd':
+        dtype = a.dtype.char
+    else:
+        dtype = numpy.find_common_type((a.dtype.char, 'f'), ()).char
+
+    cusolver_handle = device.get_cusolver_handle()
+    cublas_handle = device.get_cublas_handle()
+    dev_info = cupy.empty(1, dtype=dtype)
+    
+    ipiv = cupy.empty((a.shape[0], 1), dtype=dtype)
+
+    if dtype == 'f':
+        #geqrf = cusolver.sgeqrf
+        getrf = cusolver.sgetrf
+        getrf_bufferSize = cusolver.sgetrf_bufferSize
+        getrs = cusolver.sgetrs
+    else:  # dtype == 'd'
+        getrf = cusolver.dgetrf
+        getrf_bufferSize = cusolver.dgetrf_bufferSize
+        getrs = cusolver.dgetrs
+
+    m = a.shape[0]
+        
+    buffersize = getrf_bufferSize(cusolver_handle, m, m, a.data.ptr, m)
+    workspace = cupy.empty(buffersize, dtype=dtype)
+    
+    # LU factorization
+    getrf(cusolver_handle, m, m, a.data.ptr, m, workspace.data.ptr, 
+          ipiv.data.ptr, dev_info.data.ptr)
+    
+    b = cupy.eye(m, dtype=dtype)
+    
+    # solve for the inverse
+    getrs(cusolver_handle, 0, m, m, a.data.ptr, m, ipiv.data.ptr, b.data.ptr,
+          m, dev_info.data.ptr)
+        
+    return b
 
 
 def pinv(a, rcond=1e-15):

--- a/cupy/statistics/meanvar.py
+++ b/cupy/statistics/meanvar.py
@@ -45,7 +45,8 @@ def var(a, axis=None, dtype=None, out=None, ddof=0, keepdims=False):
 
     """
     # TODO(okuta): check type
-    return a.var(axis=axis, dtype=dtype, out=out, keepdims=keepdims)
+    return a.var(axis=axis, dtype=dtype, out=out, ddof=ddof,
+                 keepdims=keepdims)
 
 
 def std(a, axis=None, dtype=None, out=None, ddof=0, keepdims=False):
@@ -67,7 +68,8 @@ def std(a, axis=None, dtype=None, out=None, ddof=0, keepdims=False):
 
     """
     # TODO(okuta): check type
-    return a.std(axis=axis, dtype=dtype, out=out, keepdims=keepdims)
+    return a.std(axis=axis, dtype=dtype, out=out, ddof=ddof,
+                 keepdims=keepdims)
 
 
 # TODO(okuta): Implement nanmean

--- a/tests/cupy_tests/statics_tests/test_meanvar.py
+++ b/tests/cupy_tests/statics_tests/test_meanvar.py
@@ -43,6 +43,18 @@ class TestMeanVar(unittest.TestCase):
     def test_external_var_all(self, xp, dtype):
         a = testing.shaped_arange((2, 3), xp, dtype)
         return xp.var(a)
+        
+    @testing.for_all_dtypes(no_complex=True)
+    @testing.numpy_cupy_allclose()
+    def test_var_all_ddof(self, xp, dtype):
+        a = testing.shaped_arange((2, 3), xp, dtype)
+        return a.var(ddof=1)
+
+    @testing.for_all_dtypes(no_complex=True)
+    @testing.numpy_cupy_allclose()
+    def test_external_var_all_ddof(self, xp, dtype):
+        a = testing.shaped_arange((2, 3), xp, dtype)
+        return xp.var(a, ddof=1)
 
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose()
@@ -58,6 +70,18 @@ class TestMeanVar(unittest.TestCase):
 
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose()
+    def test_var_axis_ddof(self, xp, dtype):
+        a = testing.shaped_arange((2, 3, 4), xp, dtype)
+        return a.var(axis=1, ddof=1)
+
+    @testing.for_all_dtypes(no_complex=True)
+    @testing.numpy_cupy_allclose()
+    def test_external_var_axis_ddof(self, xp, dtype):
+        a = testing.shaped_arange((2, 3, 4), xp, dtype)
+        return xp.var(a, axis=1, ddof=1)
+        
+    @testing.for_all_dtypes(no_complex=True)
+    @testing.numpy_cupy_allclose()
     def test_std_all(self, xp, dtype):
         a = testing.shaped_arange((2, 3), xp, dtype)
         return a.std()
@@ -67,6 +91,18 @@ class TestMeanVar(unittest.TestCase):
     def test_external_std_all(self, xp, dtype):
         a = testing.shaped_arange((2, 3), xp, dtype)
         return xp.std(a)
+        
+    @testing.for_all_dtypes(no_complex=True)
+    @testing.numpy_cupy_allclose()
+    def test_std_all_ddof(self, xp, dtype):
+        a = testing.shaped_arange((2, 3), xp, dtype)
+        return a.std(ddof=1)
+
+    @testing.for_all_dtypes(no_complex=True)
+    @testing.numpy_cupy_allclose()
+    def test_external_std_all_ddof(self, xp, dtype):
+        a = testing.shaped_arange((2, 3), xp, dtype)
+        return xp.std(a, ddof=1)
 
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose()
@@ -79,3 +115,15 @@ class TestMeanVar(unittest.TestCase):
     def test_external_std_axis(self, xp, dtype):
         a = testing.shaped_arange((2, 3, 4), xp, dtype)
         return xp.std(a, axis=1)
+
+    @testing.for_all_dtypes(no_complex=True)
+    @testing.numpy_cupy_allclose()
+    def test_std_axis_ddof(self, xp, dtype):
+        a = testing.shaped_arange((2, 3, 4), xp, dtype)
+        return a.std(axis=1, ddof=1)
+
+    @testing.for_all_dtypes(no_complex=True)
+    @testing.numpy_cupy_allclose()
+    def test_external_std_axis_ddof(self, xp, dtype):
+        a = testing.shaped_arange((2, 3, 4), xp, dtype)
+        return xp.std(a, axis=1, ddof=1)

--- a/tests/cupy_tests/statics_tests/test_meanvar.py
+++ b/tests/cupy_tests/statics_tests/test_meanvar.py
@@ -43,7 +43,7 @@ class TestMeanVar(unittest.TestCase):
     def test_external_var_all(self, xp, dtype):
         a = testing.shaped_arange((2, 3), xp, dtype)
         return xp.var(a)
-        
+
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose()
     def test_var_all_ddof(self, xp, dtype):
@@ -79,7 +79,7 @@ class TestMeanVar(unittest.TestCase):
     def test_external_var_axis_ddof(self, xp, dtype):
         a = testing.shaped_arange((2, 3, 4), xp, dtype)
         return xp.var(a, axis=1, ddof=1)
-        
+
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose()
     def test_std_all(self, xp, dtype):
@@ -91,7 +91,7 @@ class TestMeanVar(unittest.TestCase):
     def test_external_std_all(self, xp, dtype):
         a = testing.shaped_arange((2, 3), xp, dtype)
         return xp.std(a)
-        
+
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose()
     def test_std_all_ddof(self, xp, dtype):


### PR DESCRIPTION
Currently `cupy.linalg.inv` computes the matrix inverse by calling `solve` with an identity matrix. This can be accomplished more quickly by instead using LU factorization and calls to CUDA's `getrf` and `getrs` functions.

I use the following code to test speed:

```
import numpy as np
import cupy as cp
np.random.seed(0)
samples = np.random.random(size=(2000, 2000)).astype(np.float64)
%timeit cp.linalg.inv(cp.array(samples))
```

Current `master` produces:

`874 ms ± 11.2 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)`

With this PR, the output is:

`224 ms ± 1.25 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)`

Finally, in comparing the output of the original function to the output of the modified function, `np.allclose(inv_LU, inv_QR)` returns `True`.

This PR includes the fixes to `ddof` passing in PR #693.

