### PR TITLE
Fix where tests

### DIFF
--- a/tests/cupy_tests/core_tests/test_fusion.py
+++ b/tests/cupy_tests/core_tests/test_fusion.py
@@ -534,22 +534,25 @@ class TestFusionUfunc(unittest.TestCase):
     def sample_function(x, y, z):
         return cupy.square(cupy.add(x, y))
 
-    def random_bool(self):
+    def random_bool(self, seed=0):
         return testing.shaped_random((3, 3),
                                      xp=cupy,
-                                     dtype=numpy.bool_)
+                                     dtype=numpy.bool_,
+                                     seed=seed)
 
-    def random_int(self, lower=-1000, higher=1000):
+    def random_int(self, lower=-1000, higher=1000, seed=0):
         return testing.shaped_random((3, 3),
                                      xp=cupy,
                                      dtype=numpy.int64,
-                                     scale=(higher - lower)) + lower
+                                     scale=(higher - lower),
+                                     seed=seed) + lower
 
-    def random_real(self, lower=-1000, higher=1000):
+    def random_real(self, lower=-1000, higher=1000, seed=0):
         return testing.shaped_random((3, 3),
                                      xp=cupy,
                                      dtype=numpy.float64,
-                                     scale=(higher - lower)) + lower
+                                     scale=(higher - lower),
+                                     seed=seed) + lower
 
     def check(self, func, n, gen, args=None):
         if args is None:
@@ -789,10 +792,14 @@ class TestFusionUfunc(unittest.TestCase):
 
     def test_special(self):
         self.check(cupy.where, 3,
-                   (self.random_bool, self.random_int, self.random_int),
+                   (self.random_bool,
+                    lambda *args: self.random_int(*args, seed=0),
+                    lambda *args: self.random_int(*args, seed=1)),
                    ((), (0, 100), (0, 100)))
         self.check(cupy.clip, 3,
-                   (self.random_real, self.random_real, self.random_real),
+                   (lambda *args: self.random_real(*args, seed=0),
+                    lambda *args: self.random_real(*args, seed=1),
+                    lambda *args: self.random_real(*args, seed=2)),
                    ((0, 1000), (0, 500), (500, 1000)))
 
     def test_reduce(self):

--- a/tests/cupy_tests/sorting_tests/test_search.py
+++ b/tests/cupy_tests/sorting_tests/test_search.py
@@ -160,8 +160,8 @@ class TestWhereTwoArrays(unittest.TestCase):
         # Almost all values of a matrix `shaped_random` makes are not zero.
         # To make a sparse matrix, we need multiply `m`.
         cond = testing.shaped_random(self.cond_shape, xp, cond_type) * m
-        x = testing.shaped_random(self.x_shape, xp, x_type)
-        y = testing.shaped_random(self.y_shape, xp, y_type)
+        x = testing.shaped_random(self.x_shape, xp, x_type, seed=0)
+        y = testing.shaped_random(self.y_shape, xp, y_type, seed=1)
         return xp.where(cond, x, y)
 
 


### PR DESCRIPTION
As mentioned in #698, we need to set seeds to avoid unintended correlation between arrays in thses tests.