### PR TITLE
Simplify __getitem__ and __setitem__

### DIFF
--- a/cupy/core/internal.pxd
+++ b/cupy/core/internal.pxd
@@ -27,3 +27,4 @@ cpdef vector.vector[Py_ssize_t] infer_unknown_dimension(
     vector.vector[Py_ssize_t]& shape, Py_ssize_t size) except *
 
 cpdef slice complete_slice(slice slc, Py_ssize_t dim)
+cpdef tuple complete_slice_list(list slice_list, Py_ssize_t ndim)

--- a/cupy/core/internal.pxd
+++ b/cupy/core/internal.pxd
@@ -27,4 +27,5 @@ cpdef vector.vector[Py_ssize_t] infer_unknown_dimension(
     vector.vector[Py_ssize_t]& shape, Py_ssize_t size) except *
 
 cpdef slice complete_slice(slice slc, Py_ssize_t dim)
+
 cpdef tuple complete_slice_list(list slice_list, Py_ssize_t ndim)


### PR DESCRIPTION
~Please merge #747 first.~
This PR refactor `__getitem__` and `__setitem__` .
These have same code. So, I create new helper functions.
And, this PR contains some small  fixing.
