### PR TITLE
Use skip_dtypes properly in test_einsum

### DIFF
--- a/tests/cupy_tests/linalg_tests/test_einsum.py
+++ b/tests/cupy_tests/linalg_tests/test_einsum.py
@@ -158,6 +158,8 @@ class TestEinSumUnaryOperation(unittest.TestCase):
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_einsum_unary(self, xp, dtype):
+        if dtype in self.skip_dtypes:
+            return xp.array([])
         a = testing.shaped_arange(self.shape_a, xp, dtype)
         return xp.einsum(self.subscripts, a)
 


### PR DESCRIPTION
This PR fixes test with numpy 1.9.