### PR TITLE
Use std::map instead of std::unordered_map to avoid c++11

### DIFF
--- a/cupy/cuda/memory.pxd
+++ b/cupy/cuda/memory.pxd
@@ -1,5 +1,5 @@
 from libcpp cimport vector
-from libcpp cimport unordered_map
+from libcpp cimport map
 
 from cupy.cuda cimport device
 
@@ -54,7 +54,7 @@ cdef class SingleDeviceMemoryPool:
         object _in_use_lock
         readonly Py_ssize_t _allocation_unit_size
         readonly int _device_id
-        unordered_map.unordered_map[size_t, vector.vector[int]] _index
+        map.map[size_t, vector.vector[int]] _index
 
     cpdef MemoryPointer _alloc(self, Py_ssize_t size)
     cpdef MemoryPointer malloc(self, Py_ssize_t size)

--- a/install/build.py
+++ b/install/build.py
@@ -119,7 +119,6 @@ def get_compiler_setting():
         'library_dirs': library_dirs,
         'define_macros': define_macros,
         'language': 'c++',
-        'extra_compile_args': ['-std=c++11'],
     }
 
 


### PR DESCRIPTION
follow-up: https://github.com/cupy/cupy/pull/306

But, note that std::map is slower than std::unordered_map