### PR TITLE
Skip some tests when using old numpy

### DIFF
--- a/tests/cupy_tests/linalg_tests/test_product.py
+++ b/tests/cupy_tests/linalg_tests/test_product.py
@@ -203,6 +203,7 @@ class TestProduct(unittest.TestCase):
         return xp.inner(a, b)
 
     @testing.for_all_dtypes()
+    @testing.with_requires('numpy>=1.10.2')
     @testing.numpy_cupy_allclose()
     def test_reversed_inner(self, xp, dtype):
         a = testing.shaped_arange((5,), xp, dtype)[::-1]

--- a/tests/cupy_tests/statics_tests/test_order.py
+++ b/tests/cupy_tests/statics_tests/test_order.py
@@ -47,6 +47,7 @@ class TestOrder(unittest.TestCase):
 
     @for_all_interpolations()
     @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
+    @testing.with_requires('numpy>=1.10.0')
     @testing.numpy_cupy_allclose(rtol=1e-6)
     def test_percentile_tuple_axis(self, xp, dtype, interpolation):
         a = testing.shaped_random((1, 6, 3, 2), xp, dtype)


### PR DESCRIPTION
These tests fails when using old numpy. They make CI unstable.