### PR TITLE
Fix concatenate bug and improve performance

### DIFF
--- a/cupy/core/__init__.py
+++ b/cupy/core/__init__.py
@@ -15,7 +15,6 @@ from cupy.core.core import bitwise_or  # NOQA
 from cupy.core.core import bitwise_xor  # NOQA
 from cupy.core.core import broadcast  # NOQA
 from cupy.core.core import broadcast_to  # NOQA
-from cupy.core.core import concatenate  # NOQA
 from cupy.core.core import concatenate_method  # NOQA
 from cupy.core.core import conj  # NOQA
 from cupy.core.core import create_comparison  # NOQA

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2440,7 +2440,8 @@ cpdef ndarray concatenate_method(tup, int axis):
     ndim = -1
     dtype = None
     have_same_types = True
-    for o in tup:
+    arrays = list(tup)
+    for o in arrays:
         if not isinstance(o, ndarray):
             raise TypeError('Only cupy arrays can be concatenated')
         a = o
@@ -2472,92 +2473,107 @@ cpdef ndarray concatenate_method(tup, int axis):
         raise ValueError('Cannot concatenate from empty tuple')
 
     if not have_same_types:
-        dtype = numpy.find_common_type([a.dtype for a in tup], [])
-    return concatenate(tup, axis, shape, dtype)
+        dtype = numpy.find_common_type([a.dtype for a in arrays], [])
+    return _concatenate(arrays, axis, tuple(shape), dtype)
 
 
-cpdef ndarray concatenate(tup, axis, shape, dtype):
-    cdef ndarray a, x, ret
-    cdef int i, j, base, cum, ndim
-    cdef bint all_same_type, all_one_and_contiguous
-    cdef Py_ssize_t[:] ptrs
-    cdef int[:] cum_sizes
-    cdef int[:, :] x_strides
+cpdef ndarray _concatenate(list arrays, Py_ssize_t axis, tuple shape, dtype):
+    cdef ndarray a, ret
+    cdef int i
+    cdef bint all_same_type, same_shape_and_contiguous
+    cdef Py_ssize_t axis_size
+    cdef Py_ssize_t threshold_size = 2 * 1024 * 1024
+
+    if len(arrays) > 8:
+        all_same_type = True
+        same_shape_and_contiguous = True
+        axis_size = shape[axis] // len(arrays)
+        total_bytes = 0
+        for a in arrays:
+            if a.dtype != dtype:
+                all_same_type = False
+                break
+            if same_shape_and_contiguous:
+                same_shape_and_contiguous = (
+                    a._c_contiguous and a._shape[axis] == axis_size)
+            total_bytes += a.size * a.dtype.itemsize
+
+        if all_same_type and total_bytes < threshold_size * len(arrays):
+            return _concatenate_single_kernel(
+                arrays, axis, shape, dtype, same_shape_and_contiguous)
 
     ret = ndarray(shape, dtype=dtype)
-
-    all_same_type = True
-    all_one_and_contiguous = True
-    any_contiguous_on_axis = False
-    total_bytes = 0
-    dtype = tup[0].dtype
-    for a in tup:
-        all_same_type = all_same_type and (a.dtype == dtype)
-        all_one_and_contiguous = (
-            all_one_and_contiguous and a._c_contiguous and
-            a._shape[axis] == 1)
-        any_contiguous_on_axis = (
-            any_contiguous_on_axis or
-            a._strides[axis] == a.itemsize)
-        total_bytes += a.size * a.itemsize
-
-    if ((not all_same_type or not any_contiguous_on_axis) and
-            (len(tup) < 256 or total_bytes / len(tup) > 524288)):
-        skip = (slice(None),) * axis
-        i = 0
-        for a in tup:
-            aw = a._shape[axis]
-            ret[skip + (slice(i, i + aw),)] = a
-            i += aw
-    else:
-        ptrs = numpy.ndarray(len(tup), numpy.int64)
-        for i, a in enumerate(tup):
-            ptrs[i] = a.data.ptr
-        x = array(ptrs)
-
-        if all_one_and_contiguous:
-            base = <int>internal.prod_ssize_t(shape[axis + 1:])
-            _concatenate_kernel_one(x, base, ret)
-        else:
-            ndim = tup[0].ndim
-            x_strides = numpy.ndarray((len(tup), ndim), numpy.int32)
-            cum_sizes = numpy.ndarray(len(tup), numpy.int32)
-            cum = 0
-            for i, a in enumerate(tup):
-                for j in range(ndim):
-                    x_strides[i, j] = <int>a._strides[j]
-                cum_sizes[i] = cum
-                cum += <int>a._shape[axis]
-
-            _concatenate_kernel(
-                x, axis, array(cum_sizes), array(x_strides), ret)
+    i = 0
+    slice_list = [slice(None)] * len(shape)
+    for a in arrays:
+        aw = a._shape[axis]
+        slice_list[axis] = slice(i, i + aw)
+        elementwise_copy(a, ret[tuple(slice_list)])
+        i += aw
     return ret
 
-cdef _concatenate_kernel_one = ElementwiseKernel(
-    'raw P x, int32 base',
+
+cpdef ndarray _concatenate_single_kernel(
+        list arrays, Py_ssize_t axis, tuple shape, dtype,
+        bint same_shape_and_contiguous):
+    cdef ndarray a, x, ret
+    cdef Py_ssize_t base, cum, ndim
+    cdef int i, j
+    cdef Py_ssize_t[:] ptrs
+    cdef Py_ssize_t[:] cum_sizes
+    cdef Py_ssize_t[:, :] x_strides
+
+    ptrs = numpy.ndarray(len(arrays), numpy.int64)
+    for i, a in enumerate(arrays):
+        ptrs[i] = a.data.ptr
+    x = array(ptrs)
+
+    ret = ndarray(shape, dtype=dtype)
+    if same_shape_and_contiguous:
+        base = internal.prod_ssize_t(shape[axis:]) // len(arrays)
+        _concatenate_kernel_same_size(x, base, ret)
+        return ret
+
+    ndim = len(shape)
+    x_strides = numpy.ndarray((len(arrays), ndim), numpy.int64)
+    cum_sizes = numpy.ndarray(len(arrays), numpy.int64)
+    cum = 0
+    for i, a in enumerate(arrays):
+        for j in range(ndim):
+            x_strides[i, j] = <int>a._strides[j]
+        cum_sizes[i] = cum
+        cum += <int>a._shape[axis]
+
+    _concatenate_kernel(
+        x, axis, array(cum_sizes), array(x_strides), ret)
+    return ret
+
+
+cdef _concatenate_kernel_same_size = ElementwiseKernel(
+    'raw P x, int64 base',
     'T y',
     '''
-    int middle = i / base;
-    int top = middle / x.size();
-    int array_ind = middle - top * x.size();
-    int offset = i + (top - middle) * base;
+    ptrdiff_t middle = i / base;
+    ptrdiff_t top = middle / x.size();
+    ptrdiff_t array_ind = middle - top * x.size();
+    ptrdiff_t offset = i + (top - middle) * base;
     y = reinterpret_cast<T*>(x[array_ind])[offset];
     ''',
-    'cupy_concatenate_one'
+    'cupy_concatenate_same_size'
 )
 
 
 cdef _concatenate_kernel = ElementwiseKernel(
-    '''raw P x, int32 axis, raw int32 cum_sizes,
-    raw int32 x_strides''',
+    '''raw P x, int32 axis, raw int64 cum_sizes,
+    raw int64 x_strides''',
     'T y',
     '''
-    int axis_ind = _ind.get()[axis];
-    int left = 0;
-    int right = cum_sizes.size();
+    ptrdiff_t axis_ind = _ind.get()[axis];
+    ptrdiff_t left = 0;
+    ptrdiff_t right = cum_sizes.size();
 
     while (left < right - 1) {
-      int m = (left + right) / 2;
+      ptrdiff_t m = (left + right) / 2;
       if (axis_ind < cum_sizes[m]) {
         right = m;
       } else {
@@ -2565,7 +2581,7 @@ cdef _concatenate_kernel = ElementwiseKernel(
       }
     }
 
-    int array_ind = left;
+    ptrdiff_t array_ind = left;
     axis_ind -= cum_sizes[left];
     char* ptr = reinterpret_cast<char*>(x[array_ind]);
     for (int j = _ind.ndim - 1; j >= 0; --j) {
@@ -3207,7 +3223,7 @@ cpdef _prepare_multiple_array_indexing(ndarray a, list slices):
 
     # do stack: flattened_indexes = stack(flattened_indexes, axis=0)
     concat_shape = (len(flattened_indexes),) + br.shape
-    flattened_indexes = concatenate(
+    flattened_indexes = _concatenate(
         [index._reshape((1,) + index.shape) for index in flattened_indexes],
         axis=0, shape=concat_shape, dtype=flattened_indexes[0].dtype)
 

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2482,6 +2482,7 @@ cpdef ndarray _concatenate(list arrays, Py_ssize_t axis, tuple shape, dtype):
     cdef int i
     cdef bint all_same_type, same_shape_and_contiguous
     cdef Py_ssize_t axis_size
+    # If arrays are large, Issuing each copy method is efficient.
     cdef Py_ssize_t threshold_size = 2 * 1024 * 1024
 
     if len(arrays) > 8:

--- a/tests/cupy_tests/manipulation_tests/test_join.py
+++ b/tests/cupy_tests/manipulation_tests/test_join.py
@@ -81,6 +81,12 @@ class TestJoin(unittest.TestCase):
         e = testing.shaped_arange((2, 3, 2), xp, dtype)
         return xp.concatenate((a, b, c, d, e), axis=-1)
 
+    @testing.numpy_cupy_array_equal()
+    def test_concatenate_many_multi_dptye(self, xp):
+        a = testing.shaped_arange((2, 1), xp, 'i')
+        b = testing.shaped_arange((2, 1), xp, 'f')
+        return xp.concatenate((a, b) * 1024, axis=1)
+
     def test_concatenate_wrong_ndim(self):
         a = cupy.empty((2, 3))
         b = cupy.empty((2,))

--- a/tests/cupy_tests/manipulation_tests/test_join.py
+++ b/tests/cupy_tests/manipulation_tests/test_join.py
@@ -61,7 +61,28 @@ class TestJoin(unittest.TestCase):
         c = testing.shaped_arange((2, 3, 3), xp, dtype)
         d = testing.shaped_arange((2, 3, 5), xp, dtype)
         e = testing.shaped_arange((2, 3, 2), xp, dtype)
-        return xp.concatenate((a, b, c, d, e), axis=-1)
+        return xp.concatenate((a, b, c, d, e) * 2, axis=-1)
+
+    @testing.for_all_dtypes(name='dtype')
+    @testing.numpy_cupy_array_equal()
+    def test_concatenate_large_3(self, xp, dtype):
+        a = testing.shaped_arange((2, 3, 1), xp, dtype)
+        b = testing.shaped_reverse_arange((2, 3, 1), xp, dtype)
+        return xp.concatenate((a, b) * 10, axis=-1)
+
+    @testing.for_all_dtypes(name='dtype')
+    @testing.numpy_cupy_array_equal()
+    def test_concatenate_large_4(self, xp, dtype):
+        a = testing.shaped_arange((2, 3, 4), xp, dtype)
+        b = testing.shaped_reverse_arange((2, 3, 4), xp, dtype)
+        return xp.concatenate((a, b) * 10, axis=-1)
+
+    @testing.for_all_dtypes(name='dtype')
+    @testing.numpy_cupy_array_equal()
+    def test_concatenate_large_5(self, xp, dtype):
+        a = testing.shaped_arange((2, 3, 4), xp, dtype)
+        b = testing.shaped_reverse_arange((2, 3, 4), xp, 'i')
+        return xp.concatenate((a, b) * 10, axis=-1)
 
     @testing.for_all_dtypes(name='dtype')
     @testing.numpy_cupy_array_equal()


### PR DESCRIPTION
This bug is from #452.
`concatenate` crash when it gets mixed dtype array.

And, this PR improve performance. The test code is [here](https://gist.github.com/okuta/ea732a251feea32ab80226ab6fa5ffe3)
```
# This PR #######################################################
shape: (256, 256, 256), axis: 0, order: C, elapsed: 16.1625622559
shape: (256, 256, 256), axis: 0, order: F, elapsed: 131.348251953
shape: (256, 256, 256), axis: 1, order: C, elapsed: 16.1895678711
shape: (256, 256, 256), axis: 1, order: F, elapsed: 130.555195312
shape: (256, 256, 256), axis: 2, order: C, elapsed: 16.4942749023
shape: (256, 256, 256), axis: 2, order: F, elapsed: 131.340351562

shape: (128, 128, 128), axis: 0, order: C, elapsed: 2.06588348389
shape: (128, 128, 128), axis: 0, order: F, elapsed: 10.6780529785
shape: (128, 128, 128), axis: 1, order: C, elapsed: 2.08701797485
shape: (128, 128, 128), axis: 1, order: F, elapsed: 9.83940124512
shape: (128, 128, 128), axis: 2, order: C, elapsed: 2.1305078125
shape: (128, 128, 128), axis: 2, order: F, elapsed: 9.80235351563

shape: (64, 64, 64), axis: 0, order: C, elapsed: 0.328061103821
shape: (64, 64, 64), axis: 0, order: F, elapsed: 0.5101404953
shape: (64, 64, 64), axis: 1, order: C, elapsed: 0.356145591736
shape: (64, 64, 64), axis: 1, order: F, elapsed: 0.518843193054
shape: (64, 64, 64), axis: 2, order: C, elapsed: 0.355208320618
shape: (64, 64, 64), axis: 2, order: F, elapsed: 0.549785270691

shape: (32, 32, 32), axis: 0, order: C, elapsed: 0.138884162903
shape: (32, 32, 32), axis: 0, order: F, elapsed: 0.371274871826
shape: (32, 32, 32), axis: 1, order: C, elapsed: 0.114077119827
shape: (32, 32, 32), axis: 1, order: F, elapsed: 0.483764801025
shape: (32, 32, 32), axis: 2, order: C, elapsed: 0.11232000351
shape: (32, 32, 32), axis: 2, order: F, elapsed: 0.501377601624


# master branch #################################################
shape: (256, 256, 256), axis: 0, order: C, elapsed: 16.3996728516
shape: (256, 256, 256), axis: 0, order: F, elapsed: 218.83328125
shape: (256, 256, 256), axis: 1, order: C, elapsed: 16.1702990723
shape: (256, 256, 256), axis: 1, order: F, elapsed: 130.665185547
shape: (256, 256, 256), axis: 2, order: C, elapsed: 79.9679003906
shape: (256, 256, 256), axis: 2, order: F, elapsed: 131.264052734

shape: (128, 128, 128), axis: 0, order: C, elapsed: 2.10899291992
shape: (128, 128, 128), axis: 0, order: F, elapsed: 24.5056542969
shape: (128, 128, 128), axis: 1, order: C, elapsed: 2.08578781128
shape: (128, 128, 128), axis: 1, order: F, elapsed: 9.82618713379
shape: (128, 128, 128), axis: 2, order: C, elapsed: 9.98044372559
shape: (128, 128, 128), axis: 2, order: F, elapsed: 9.78024780273

shape: (64, 64, 64), axis: 0, order: C, elapsed: 0.316738872528
shape: (64, 64, 64), axis: 0, order: F, elapsed: 1.84249404907
shape: (64, 64, 64), axis: 1, order: C, elapsed: 0.397792015076
shape: (64, 64, 64), axis: 1, order: F, elapsed: 0.517691841125
shape: (64, 64, 64), axis: 2, order: C, elapsed: 1.40936187744
shape: (64, 64, 64), axis: 2, order: F, elapsed: 0.560832328796

shape: (32, 32, 32), axis: 0, order: C, elapsed: 0.23242816925
shape: (32, 32, 32), axis: 0, order: F, elapsed: 0.361150093079
shape: (32, 32, 32), axis: 1, order: C, elapsed: 0.412528953552
shape: (32, 32, 32), axis: 1, order: F, elapsed: 0.380282897949
shape: (32, 32, 32), axis: 2, order: C, elapsed: 0.341022720337
shape: (32, 32, 32), axis: 2, order: F, elapsed: 0.382827835083

# v2 branch ######################################################
shape: (256, 256, 256), axis: 0, order: C, elapsed: 82.4052929688
shape: (256, 256, 256), axis: 0, order: F, elapsed: 261.209726563
shape: (256, 256, 256), axis: 1, order: C, elapsed: 82.3436035156
shape: (256, 256, 256), axis: 1, order: F, elapsed: 167.829375
shape: (256, 256, 256), axis: 2, order: C, elapsed: 83.3973535156
shape: (256, 256, 256), axis: 2, order: F, elapsed: 302.420722656

shape: (128, 128, 128), axis: 0, order: C, elapsed: 15.1660290527
shape: (128, 128, 128), axis: 0, order: F, elapsed: 22.8101855469
shape: (128, 128, 128), axis: 1, order: C, elapsed: 14.8621643066
shape: (128, 128, 128), axis: 1, order: F, elapsed: 22.6841137695
shape: (128, 128, 128), axis: 2, order: C, elapsed: 14.8460644531
shape: (128, 128, 128), axis: 2, order: F, elapsed: 23.0372827148

shape: (64, 64, 64), axis: 0, order: C, elapsed: 1.42650680542
shape: (64, 64, 64), axis: 0, order: F, elapsed: 1.70116027832
shape: (64, 64, 64), axis: 1, order: C, elapsed: 1.42875076294
shape: (64, 64, 64), axis: 1, order: F, elapsed: 3.27464080811
shape: (64, 64, 64), axis: 2, order: C, elapsed: 1.42323074341
shape: (64, 64, 64), axis: 2, order: F, elapsed: 3.39681365967

shape: (32, 32, 32), axis: 0, order: C, elapsed: 1.17972061157
shape: (32, 32, 32), axis: 0, order: F, elapsed: 0.228332805634
shape: (32, 32, 32), axis: 1, order: C, elapsed: 1.17656227112
shape: (32, 32, 32), axis: 1, order: F, elapsed: 0.34329536438
shape: (32, 32, 32), axis: 2, order: C, elapsed: 1.18050048828
shape: (32, 32, 32), axis: 2, order: F, elapsed: 0.355680656433
```