### PR TITLE
improve message during installation

### DIFF
--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -198,6 +198,7 @@ def check_library(compiler, includes=(), libraries=(),
                           include_dirs, library_dirs)
     except Exception as e:
         print(e)
+        sys.stdout.flush()
         return False
     return True
 
@@ -238,6 +239,7 @@ def check_installed_modules(compiler, settings):
 
         print('')
         print('-------- Configuring Module: {} --------'.format(module['name']))
+        sys.stdout.flush()
         if not check_library(compiler,
                              includes=module['include'],
                              include_dirs=settings['include_dirs']):

--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -237,7 +237,9 @@ def preconfigure_modules(compiler, settings):
 
     ret = []
     for module in MODULES:
-        (installed, status, errmsg) = (False, 'No', [])
+        installed = False
+        status = 'No'
+        errmsg = []
 
         print('')
         print('-------- Configuring Module: {} --------'.format(

--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -205,7 +205,7 @@ def check_library(compiler, includes=(), libraries=(),
 
 def check_installed_modules(compiler, settings):
     """
-    For each module in MODULES list, this function checks if each module
+    For each module in MODULES list, this function checks if the module
     can be built in the current environment and reports it.
     Returns a list of module names available.
     """
@@ -235,7 +235,7 @@ def check_installed_modules(compiler, settings):
 
     ret = []
     for module in MODULES:
-        (installed, status, msg) = (False, 'No', [])
+        (installed, status, errmsg) = (False, 'No', [])
 
         print('')
         print('-------- Configuring Module: {} --------'.format(module['name']))
@@ -243,21 +243,21 @@ def check_installed_modules(compiler, settings):
         if not check_library(compiler,
                              includes=module['include'],
                              include_dirs=settings['include_dirs']):
-            msg = ['Include files not found: %s' % module['include'],
-                   'Check your CFLAGS environment variable.']
+            errmsg = ['Include files not found: %s' % module['include'],
+                      'Check your CFLAGS environment variable.']
         elif not check_library(compiler,
                                libraries=module['libraries'],
                                library_dirs=settings['library_dirs']):
-            msg = ['Cannot link libraries: %s' % module['libraries'],
-                   'Check your LDFLAGS environment variable.']
+            errmsg = ['Cannot link libraries: %s' % module['libraries'],
+                      'Check your LDFLAGS environment variable.']
         elif 'check_method' in module and not module['check_method'](compiler, settings):
             # Fail on per-library condition check (version requirements etc.)
             installed = True
-            msg = ['Installed library is not supported.']
+            errmsg = ['The library is installed but not supported.']
         elif module['name'] == 'thrust' and nvcc_path is None:
             installed = True
-            msg = ['Cannot find nvcc in PATH.',
-                   'Check your PATH environment variable.']
+            errmsg = ['nvcc command could not be found in PATH.',
+                      'Check your PATH environment variable.']
         else:
             installed = True
             status = 'Yes'
@@ -271,8 +271,8 @@ def check_installed_modules(compiler, settings):
         ]
 
         # If error message exists...
-        if len(msg) != 0:
-            summary += ['    -> {}'.format(m) for m in msg]
+        if len(errmsg) != 0:
+            summary += ['    -> {}'.format(m) for m in errmsg]
 
             # Skip checking other modules when CUDA is unavailable.
             if module['name'] == 'cuda':
@@ -292,7 +292,7 @@ def check_installed_modules(compiler, settings):
             '',
         ] + lines + [
             'Please refer to the Installation Guide for details:',
-            'http://docs.chainer.org/en/stable/install.html',
+            'http://docs-cupy.chainer.org/en/stable/install.html',
             '',
         ]
 

--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -225,8 +225,8 @@ def check_installed_modules(compiler, settings):
         'Environment Variables:',
     ]
 
-    for v in ['CFLAGS', 'LDFLAGS', 'LIBRARY_PATH']:
-        summary += ['  {:<16}: {}'.format(v, os.environ.get(v, '(none)'))]
+    for key in ['CFLAGS', 'LDFLAGS', 'LIBRARY_PATH', 'CUDA_PATH', 'NVCC']:
+        summary += ['  {:<16}: {}'.format(key, os.environ.get(key, '(none)'))]
 
     summary += [
         '',

--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -68,6 +68,7 @@ MODULES = [
             'nvToolsExt',
         ],
         'check_method': build.check_cuda_version,
+        'version_method': build.get_cuda_version,
     },
     {
         'name': 'cudnn',
@@ -82,6 +83,7 @@ MODULES = [
             'cudnn',
         ],
         'check_method': build.check_cudnn_version,
+        'version_method': build.get_cudnn_version,
     },
     {
         'name': 'nccl',
@@ -95,6 +97,7 @@ MODULES = [
             'nccl',
         ],
         'check_method': build.check_nccl_version,
+        'version_method': build.get_nccl_version,
     },
     {
         'name': 'cusolver',
@@ -199,6 +202,107 @@ def check_library(compiler, includes=(), libraries=(),
     return True
 
 
+def check_installed_modules(compiler, settings):
+    """
+    For each module in MODULES list, this function checks if each module
+    can be built in the current environment and reports it.
+    Returns a list of module names available.
+    """
+
+    nvcc_path = build.get_nvcc_path()
+    summary = [
+        '',
+        '************************************************************',
+        '* CuPy Configuration Summary                               *',
+        '************************************************************',
+        '',
+        'Build Environment:',
+        '  Include directories: {}'.format(str(settings['include_dirs'])),
+        '  Library directories: {}'.format(str(settings['library_dirs'])),
+        '  nvcc command       : {}'.format(nvcc_path if nvcc_path else '(not found)'),
+        '',
+        'Environment Variables:',
+    ]
+
+    for v in ['CFLAGS', 'LDFLAGS', 'LIBRARY_PATH']:
+        summary += ['  {:<16}: {}'.format(v, os.environ.get(v, '(none)'))]
+
+    summary += [
+        '',
+        'Modules:',
+    ]
+
+    ret = []
+    for module in MODULES:
+        (installed, status, msg) = (False, 'No', [])
+
+        print('')
+        print('-------- Configuring Module: {} --------'.format(module['name']))
+        if not check_library(compiler,
+                             includes=module['include'],
+                             include_dirs=settings['include_dirs']):
+            msg = ['Include files not found: %s' % module['include'],
+                   'Check your CFLAGS environment variable.']
+        elif not check_library(compiler,
+                               libraries=module['libraries'],
+                               library_dirs=settings['library_dirs']):
+            msg = ['Cannot link libraries: %s' % module['libraries'],
+                   'Check your LDFLAGS environment variable.']
+        elif 'check_method' in module and not module['check_method'](compiler, settings):
+            # Fail on per-library condition check (version requirements etc.)
+            installed = True
+            msg = ['Installed library is not supported.']
+        elif module['name'] == 'thrust' and nvcc_path is None:
+            installed = True
+            msg = ['Cannot find nvcc in PATH.',
+                   'Check your PATH environment variable.']
+        else:
+            installed = True
+            status = 'Yes'
+            ret.append(module['name'])
+
+        if installed and 'version_method' in module:
+            status += ' (version {})'.format(module['version_method'](True))
+
+        summary += [
+            '  {:<10}: {}'.format(module['name'], status)
+        ]
+
+        # If error message exists...
+        if len(msg) != 0:
+            summary += ['    -> {}'.format(m) for m in msg]
+
+            # Skip checking other modules when CUDA is unavailable.
+            if module['name'] == 'cuda':
+                break
+
+    if len(ret) != len(MODULES):
+        if 'cuda' in ret:
+            lines = [
+                'WARNING: Some modules could not be configured.',
+                'CuPy will be installed without these modules.',
+            ]
+        else:
+            lines = [
+                'ERROR: CUDA could not be found on your system.',
+            ]
+        summary += [
+            '',
+        ] + lines + [
+            'Please refer to the Installation Guide for details:',
+            'http://docs.chainer.org/en/stable/install.html',
+            '',
+        ]
+
+    summary += [
+        '************************************************************',
+        '',
+    ]
+
+    print('\n'.join(summary))
+    return ret
+
+
 def make_extensions(options, compiler, use_cython):
     """Produce a list of Extension instances which passed to cythonize()."""
 
@@ -240,40 +344,20 @@ def make_extensions(options, compiler, use_cython):
     if no_cuda:
         settings['define_macros'].append(('CUPY_NO_CUDA', '1'))
 
+
+    available_modules = []
+    if no_cuda:
+        available_modules = [m['name'] for m in MODULES]
+    else:
+        available_modules = check_installed_modules(compiler, settings)
+        if 'cuda' not in available_modules:
+            raise Exception('Your CUDA environment is invalid. '
+                            'Please check above error log.')
+
     ret = []
     for module in MODULES:
-        print('Include directories:', settings['include_dirs'])
-        print('Library directories:', settings['library_dirs'])
-
-        if not no_cuda:
-            err = False
-            if not check_library(compiler,
-                                 includes=module['include'],
-                                 include_dirs=settings['include_dirs']):
-                utils.print_warning(
-                    'Include files not found: %s' % module['include'],
-                    'Skip installing %s support' % module['name'],
-                    'Check your CFLAGS environment variable')
-                err = True
-            elif not check_library(compiler,
-                                   libraries=module['libraries'],
-                                   library_dirs=settings['library_dirs']):
-                utils.print_warning(
-                    'Cannot link libraries: %s' % module['libraries'],
-                    'Skip installing %s support' % module['name'],
-                    'Check your LDFLAGS environment variable')
-                err = True
-            elif('check_method' in module and
-                 not module['check_method'](compiler, settings)):
-                err = True
-
-            if err:
-                if module['name'] == 'cuda':
-                    raise Exception('Your CUDA environment is invalid. '
-                                    'Please check above error log.')
-                else:
-                    # Other modules are optional. They are skipped.
-                    continue
+        if module['name'] not in available_modules:
+            continue
 
         s = settings.copy()
         if not no_cuda:
@@ -289,13 +373,6 @@ def make_extensions(options, compiler, use_cython):
                 link_args.append('-fopenmp')
             elif compiler.compiler_type == 'msvc':
                 compile_args.append('/openmp')
-
-        if not no_cuda and module['name'] == 'thrust':
-            if build.get_nvcc_path() is None:
-                utils.print_warning(
-                    'Cannot find nvcc in PATH.',
-                    'Skip installing thrust support.')
-                continue
 
         for f in module['file']:
             name = module_extension_name(f)

--- a/install/build.py
+++ b/install/build.py
@@ -237,7 +237,7 @@ def get_cuda_version(formatted=False):
     global _cuda_version
     if _cuda_version is None:
         msg = 'check_cuda_version() must be called first.'
-        raise Exception(msg)
+        raise RuntimeError(msg)
     if formatted:
         return _format_cuda_version(_cuda_version)
     return _cuda_version
@@ -278,7 +278,7 @@ def get_cudnn_version(formatted=False):
     global _cudnn_version
     if _cudnn_version is None:
         msg = 'check_cudnn_version() must be called first.'
-        raise Exception(msg)
+        raise RuntimeError(msg)
     if formatted:
         return _format_cuda_version(_cudnn_version)
     return _cudnn_version
@@ -318,7 +318,7 @@ def get_nccl_version(formatted=False):
     global _nccl_version
     if _nccl_version is None:
         msg = 'check_nccl_version() must be called first.'
-        raise Exception(msg)
+        raise RuntimeError(msg)
     if formatted:
         if _nccl_version == 0:
             return '1.x'

--- a/install/build.py
+++ b/install/build.py
@@ -228,7 +228,7 @@ def check_cuda_version(compiler, settings):
 def _format_cuda_version(version):
     major = version // 1000
     minor = (version % 1000) // 100
-    patch = (version % 100)
+    patch = version % 100
     return '{}.{}.{}'.format(major, minor, patch)
 
 

--- a/install/build.py
+++ b/install/build.py
@@ -222,17 +222,25 @@ def check_cuda_version(compiler, settings):
 
     return True
 
+def _format_cuda_version(version):
+    major = version // 1000
+    minor = (version % 1000) // 100
+    patch = (version % 100)
+    return '{}.{}.{}'.format(major, minor, patch)
 
-def get_cuda_version():
+def get_cuda_version(formatted=False):
     """Return CUDA Toolkit version cached in check_cuda_version()."""
     global _cuda_version
     if _cuda_version is None:
         msg = 'check_cuda_version() must be called first.'
         raise Exception(msg)
+    if formatted:
+        return _format_cuda_version(_cuda_version)
     return _cuda_version
 
 
 def check_cudnn_version(compiler, settings):
+    global _cudnn_version
     try:
         out = build_and_run(compiler, '''
         #include <cudnn.h>
@@ -247,26 +255,45 @@ def check_cudnn_version(compiler, settings):
         utils.print_warning('Cannot check cuDNN version\n{0}'.format(e))
         return False
 
-    cudnn_version = int(out)
+    _cudnn_version = int(out)
 
-    if not minimum_cudnn_version <= cudnn_version <= maximum_cudnn_version:
-        min_major = minimum_cudnn_version // 1000
-        max_major = maximum_cudnn_version // 1000
+    if not minimum_cudnn_version <= _cudnn_version <= maximum_cudnn_version:
+        min_major = _format_cuda_version(minimum_cudnn_version)
+        max_major = _format_cuda_version(maximum_cudnn_version)
         utils.print_warning(
-            'Unsupported cuDNN version: %d' % cudnn_version,
-            'cuDNN v%d<= and <=v%d is required' % (min_major, max_major))
+            'Unsupported cuDNN version: %s' % _format_cuda_version(_cudnn_version),
+            'cuDNN v%s= and <=v%s is required' % (min_major, max_major))
         return False
 
     return True
 
+def get_cudnn_version(formatted=False):
+    """Return cuDNN version cached in check_cudnn_version()."""
+    global _cudnn_version
+    if _cudnn_version is None:
+        msg = 'check_cudnn_version() must be called first.'
+        raise Exception(msg)
+    if formatted:
+        return _format_cuda_version(_cudnn_version)
+    return _cudnn_version
+
 
 def check_nccl_version(compiler, settings):
-    # NCCL does not provide version information.
-    # It only check whether there is nccl.h.
+    global _nccl_version
+
+    # NCCL 1.x does not provide version information.
     try:
-        build_and_run(compiler, '''
+        out = build_and_run(compiler, '''
         #include <nccl.h>
+        #include <stdio.h>
+        #ifdef NCCL_MAJOR
+        #  define NCCL_VERSION \
+                (NCCL_MAJOR * 1000 + NCCL_MINOR * 100 + NCCL_PATCH)
+        #else
+        #  define NCCL_VERSION 0
+        #endif
         int main(int argc, char* argv[]) {
+          printf("%d", NCCL_VERSION);
           return 0;
         }
         ''', include_dirs=settings['include_dirs'])
@@ -275,7 +302,22 @@ def check_nccl_version(compiler, settings):
         utils.print_warning('Cannot include NCCL\n{0}'.format(e))
         return False
 
+    _nccl_version = int(out)
+
     return True
+
+
+def get_nccl_version(formatted=False):
+    """Return NCCL version cached in check_nccl_version()."""
+    global _nccl_version
+    if _nccl_version is None:
+        msg = 'check_nccl_version() must be called first.'
+        raise Exception(msg)
+    if formatted:
+        if _nccl_version == 0:
+            return '1.x'
+        return _format_cuda_version(_nccl_version)
+    return _nccl_version
 
 
 def check_cusolver_version(compiler, settings):

--- a/install/build.py
+++ b/install/build.py
@@ -194,6 +194,8 @@ def _get_compiler_base_options():
 
 
 _cuda_version = None
+_cudnn_version = None
+_nccl_version = None
 
 
 def check_cuda_version(compiler, settings):
@@ -222,11 +224,13 @@ def check_cuda_version(compiler, settings):
 
     return True
 
+
 def _format_cuda_version(version):
     major = version // 1000
     minor = (version % 1000) // 100
     patch = (version % 100)
     return '{}.{}.{}'.format(major, minor, patch)
+
 
 def get_cuda_version(formatted=False):
     """Return CUDA Toolkit version cached in check_cuda_version()."""
@@ -261,11 +265,13 @@ def check_cudnn_version(compiler, settings):
         min_major = _format_cuda_version(minimum_cudnn_version)
         max_major = _format_cuda_version(maximum_cudnn_version)
         utils.print_warning(
-            'Unsupported cuDNN version: %s' % _format_cuda_version(_cudnn_version),
-            'cuDNN v%s= and <=v%s is required' % (min_major, max_major))
+            'Unsupported cuDNN version: {}'.format(
+                _format_cuda_version(_cudnn_version)),
+            'cuDNN v{}= and <=v{} is required'.format(min_major, max_major))
         return False
 
     return True
+
 
 def get_cudnn_version(formatted=False):
     """Return cuDNN version cached in check_cudnn_version()."""

--- a/tests/install_tests/test_build.py
+++ b/tests/install_tests/test_build.py
@@ -16,11 +16,19 @@ class TestCheckVersion(unittest.TestCase):
 
     @pytest.mark.gpu
     def test_check_cuda_version(self):
+        with self.assertRaises(Exception):
+            build.get_cuda_version()
         self.assertTrue(build.check_cuda_version(
             self.compiler, self.settings))
+        self.assertIsInstance(build.get_cuda_version(), int)
+        self.assertIsInstance(build.get_cuda_version(True), str)
 
     @pytest.mark.gpu
     @pytest.mark.cudnn
     def test_check_cudnn_version(self):
+        with self.assertRaises(Exception):
+            build.get_cudnn_version()
         self.assertTrue(build.check_cudnn_version(
             self.compiler, self.settings))
+        self.assertIsInstance(build.get_cudnn_version(), int)
+        self.assertIsInstance(build.get_cudnn_version(True), str)

--- a/tests/install_tests/test_build.py
+++ b/tests/install_tests/test_build.py
@@ -16,7 +16,7 @@ class TestCheckVersion(unittest.TestCase):
 
     @pytest.mark.gpu
     def test_check_cuda_version(self):
-        with self.assertRaises(Exception):
+        with self.assertRaises(RuntimeError):
             build.get_cuda_version()
         self.assertTrue(build.check_cuda_version(
             self.compiler, self.settings))
@@ -26,7 +26,7 @@ class TestCheckVersion(unittest.TestCase):
     @pytest.mark.gpu
     @pytest.mark.cudnn
     def test_check_cudnn_version(self):
-        with self.assertRaises(Exception):
+        with self.assertRaises(RuntimeError):
             build.get_cudnn_version()
         self.assertTrue(build.check_cudnn_version(
             self.compiler, self.settings))


### PR DESCRIPTION
This PR tries to fix issue #669.

Currently many users are frequently trapped with installation issues.
I want to mitigate this situation by making messages more friendly.

By applying this PR, the following configuration summary is printed.

```
************************************************************
* CuPy Configuration Summary                               *
************************************************************

Build Environment:
  Include directories: ['/usr/local/cuda/include']   
  Library directories: ['/usr/local/cuda/lib64']
  nvcc command       : ['/usr/local/cuda/bin/nvcc']

Environment Variables:
  CFLAGS          : (none)
  LDFLAGS         : (none)
  LIBRARY_PATH    : /home/kenichi/.nccl/active/cuda/lib64:/home/kenichi/.cudnn/active/cuda/lib64:/home/kenichi/.cudnn/active/cuda/lib64:
  CUDA_PATH       : (none)
  NVCC            : (none)

Modules:
  cuda      : Yes (version 9.0.0)
  cudnn     : Yes (version 7.0.4)
  nccl      : Yes (version 2.1.2)
  cusolver  : Yes
  thrust    : Yes
************************************************************
```

When some of the module is unavailable,

```
************************************************************
* CuPy Configuration Summary                               *
************************************************************

Build Environment:
  Include directories: ['/usr/local/cuda/include']
  Library directories: ['/usr/local/cuda/lib64']
  nvcc command       : ['/usr/local/cuda/bin/nvcc']

Environment Variables:
  CFLAGS          : (none)
  LDFLAGS         : (none)
  LIBRARY_PATH    : /home/kenichi/.nccl/active/cuda/lib64:/home/kenichi/.cudnn/active/cuda/lib64:/home/kenichi/.cudnn/active/cuda/lib64:
  CUDA_PATH       : (none)
  NVCC            : (none)

Modules:
  cuda      : Yes (version 9.0.0)
  cudnn     : No (version 2.0.0)
    -> The library is installed but not supported.
  nccl      : No
    -> Cannot link libraries: ['nccl']
    -> Check your LDFLAGS environment variable.
  cusolver  : Yes
  thrust    : Yes

WARNING: Some modules could not be configured.
CuPy will be installed without these modules.
Please refer to the Installation Guide for details:
http://docs-cupy.chainer.org/en/stable/install.html
************************************************************
```

Full output example is as follows:

https://gist.github.com/kmaehashi/a944c9d1de181d1a398cd2e343eea38a