### PR TITLE
Improve cupy.partition performance

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -851,7 +851,7 @@ cdef class ndarray:
             return cupy.rollaxis(idx_array, -1, axis)
 
     def partition(self, kth, axis=-1):
-        """Partially sorts an array.
+        """Partitions an array.
 
         Args:
             kth (int or sequence of ints): Element index to partition by. If
@@ -860,12 +860,6 @@ cdef class ndarray:
 
             axis (int): Axis along which to sort. Default is -1, which means
                 sort along the last axis.
-
-        .. note::
-           For its implementation reason, :func:`cupy.ndarray.partition` fully
-           sorts the given array as :meth:`cupy.ndarray.sort` does. It also
-           does not support ``kind`` and ``order`` parameters that
-           :func:`numpy.partition` supports.
 
         .. seealso::
             :func:`cupy.partition` for full documentation,

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -903,7 +903,9 @@ cdef class ndarray:
             if max_k < k:
                 max_k = k
 
-        # For simplicity, max_k is round up to the power of 2.
+        # For simplicity, max_k is round up to the power of 2. If max_k is
+        # already the power of 2, it is round up to the next power of 2 because
+        # we need to collect the first max(kth)+1 elements.
         max_k = max(32, 1 << max_k.bit_length())
 
         # The parameter t is the length of the list that stores elements to be

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -867,7 +867,7 @@ cdef class ndarray:
 
         """
 
-        if cupy.issubdtype(self.dtype, complex):
+        if cupy.issubdtype(self.dtype, numpy.complexfloating):
             raise NotImplementedError('Sorting arrays with dtype \'{}\' is '
                                       'not supported'.format(self.dtype))
 

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -4360,7 +4360,11 @@ def _partition_kernel(dtype):
 
             // If at least one thread int the warp has found t values that
             // can be selected, we update the first k elements.
+    #if __CUDACC_VER_MAJOR__ >= 9
             if (__any_sync(0xffffffff, x >= t)) {
+    #else
+            if (__any(x >= t)) {
+    #endif
                 bitonic_sort(a, k + z, 32 * t + k + z, id);
                 merge(a, k, id, z, min(k / 32, t));
                 x = 0;

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -867,10 +867,7 @@ cdef class ndarray:
 
         """
 
-        if self.dtype not in [numpy.int8, numpy.uint8, numpy.int16,
-                              numpy.uint16, numpy.int32, numpy.uint32,
-                              numpy.int64, numpy.uint64, numpy.float32,
-                              numpy.float64]:
+        if cupy.issubdtype(self.dtype, complex):
             raise NotImplementedError('Sorting arrays with dtype \'{}\' is '
                                       'not supported'.format(self.dtype))
 

--- a/cupy/sorting/sort.py
+++ b/cupy/sorting/sort.py
@@ -128,7 +128,7 @@ def msort(a):
 
 
 def partition(a, kth, axis=-1):
-    """Returns a partially sorted copy of an array.
+    """Returns a partitioned copy of an array.
 
     Creates a copy of the array whose elements are rearranged such that the
     value of the element in k-th position would occur in that position in a
@@ -146,11 +146,6 @@ def partition(a, kth, axis=-1):
 
     Returns:
         cupy.ndarray: Array of the same type and shape as ``a``.
-
-    .. note::
-       For its implementation reason, :func:`cupy.partition` fully sorts the
-       given array as :func:`cupy.sort` does. It also does not support
-       ``kind`` and ``order`` parameters that :func:`numpy.partition` supports.
 
     .. seealso:: :func:`numpy.partition`
 

--- a/tests/cupy_tests/sorting_tests/test_sort.py
+++ b/tests/cupy_tests/sorting_tests/test_sort.py
@@ -338,7 +338,7 @@ class TestMsort(unittest.TestCase):
 
 @testing.parameterize(*testing.product({
     'external': [False, True],
-    'length': [10, 10000],
+    'length': [10, 20000],
 }))
 @testing.gpu
 class TestPartition(unittest.TestCase):
@@ -394,7 +394,7 @@ class TestPartition(unittest.TestCase):
 
     @testing.numpy_cupy_equal()
     def test_partition_non_contiguous(self, xp):
-        a = testing.shaped_random((self.length,), xp)[::2]
+        a = testing.shaped_random((self.length,), xp)[::-1]
         kth = 2
         if not self.external:
             if xp is cupy:

--- a/tests/cupy_tests/sorting_tests/test_sort.py
+++ b/tests/cupy_tests/sorting_tests/test_sort.py
@@ -371,6 +371,16 @@ class TestPartition(unittest.TestCase):
         return x[kth]
 
     @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
+    @testing.numpy_cupy_equal()
+    def test_partition_one_dim_large(self, xp, dtype):
+        a = testing.shaped_random((100000,), xp, dtype)
+        kth = 2
+        x = self.partition(a, kth)
+        self.assertTrue(xp.all(x[0:kth] <= x[kth:kth + 1]))
+        self.assertTrue(xp.all(x[kth:kth + 1] <= x[kth + 1:]))
+        return x[kth]
+
+    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
     @testing.numpy_cupy_array_equal()
     def test_partition_multi_dim(self, xp, dtype):
         a = testing.shaped_random((10, 10, 10), xp, dtype)

--- a/tests/cupy_tests/sorting_tests/test_sort.py
+++ b/tests/cupy_tests/sorting_tests/test_sort.py
@@ -390,6 +390,16 @@ class TestPartition(unittest.TestCase):
         self.assertTrue(xp.all(x[:, :, kth:kth + 1] <= x[:, :, kth + 1:]))
         return x[:, :, kth:kth + 1]
 
+    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
+    @testing.numpy_cupy_array_equal()
+    def test_partition_multi_dim_large(self, xp, dtype):
+        a = testing.shaped_random((10, 10, 1000), xp, dtype)
+        kth = 2
+        x = self.partition(a, kth)
+        self.assertTrue(xp.all(x[:, :, 0:kth] <= x[:, :, kth:kth + 1]))
+        self.assertTrue(xp.all(x[:, :, kth:kth + 1] <= x[:, :, kth + 1:]))
+        return x[:, :, kth:kth + 1]
+
     # Test unsupported dtype
 
     @testing.for_dtypes([numpy.float16, numpy.bool_])

--- a/tests/cupy_tests/sorting_tests/test_sort.py
+++ b/tests/cupy_tests/sorting_tests/test_sort.py
@@ -361,9 +361,12 @@ class TestPartition(unittest.TestCase):
         kth = 2
         return self.partition(a, kth)
 
-    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
+    @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_equal()
     def test_partition_one_dim(self, xp, dtype):
+        if self.length == 10 and dtype in [xp.float16, xp.bool_]:
+            return cupy.zeros(1)  # dummy
+
         a = testing.shaped_random((self.length,), xp, dtype)
         kth = 2
         x = self.partition(a, kth)
@@ -371,9 +374,12 @@ class TestPartition(unittest.TestCase):
         self.assertTrue(xp.all(x[kth:kth + 1] <= x[kth + 1:]))
         return x[kth]
 
-    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
+    @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_array_equal()
     def test_partition_multi_dim(self, xp, dtype):
+        if self.length == 10 and dtype in [xp.float16, xp.bool_]:
+            return cupy.zeros(1)  # dummy
+
         a = testing.shaped_random((10, 10, self.length), xp, dtype)
         kth = 2
         x = self.partition(a, kth)
@@ -383,8 +389,12 @@ class TestPartition(unittest.TestCase):
 
     # Test unsupported dtype
 
-    @testing.for_dtypes([numpy.float16, numpy.bool_])
+    @testing.for_dtypes([numpy.float16, numpy.bool_, numpy.complex64,
+                         numpy.complex128])
     def test_partition_unsupported_dtype(self, dtype):
+        if self.length != 10 and not cupy.issubdtype(dtype, complex):
+            return
+
         a = testing.shaped_random((self.length,), cupy, dtype)
         kth = 2
         with self.assertRaises(NotImplementedError):


### PR DESCRIPTION
This PR will improve the performance of cupy.partition and solve #478.
The algorithm is a simplification of [Jhonson et al. 2017](https://arxiv.org/abs/1702.08734).

I have not tuned the parameters yet and use naive selection sort internally.
In addition, in the worst case (the order of the input array is reversed) it will take a very long time.
Therefore, there are still room for improvement.

Now, the speed is several times faster than the naive sorting.
![by_n](https://user-images.githubusercontent.com/1255726/32943960-379246b4-cbd1-11e7-8209-460b0bcfa1b6.png)
![by_k](https://user-images.githubusercontent.com/1255726/32943970-3cc70fca-cbd1-11e7-8ae5-7cc08b43ff64.png)
The benchmark data is [here](https://docs.google.com/spreadsheets/d/1JYoueD-ZoTMI2vlw8Ou64C4yJpgygznRqGSfDyuK6xk/edit?usp=sharing) and the benchmark code is same as #478.