### PR TITLE
fix to correctly display filename of CUDA dump

### DIFF
--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -196,7 +196,7 @@ class CompileException(Exception):
         linum_fmt = '{{:0{}d}} '.format(digits)
         f.write('NVRTC compilation error: {}\n'.format(self))
         f.write('-----\n')
-        f.write('Name: {}\n'.format(' '.join(self.name)))
+        f.write('Name: {}\n'.format(self.name))
         f.write('Options: {}\n'.format(' '.join(self.options)))
         f.write('CUDA source:\n')
         for i, line in enumerate(lines):


### PR DESCRIPTION
File name of CUDA dump (shown when `CUPY_DUMP_CUDA_SOURCE_ON_ERROR=1` is set) is broken.

```
Name: / t m p / t m p 3 8 0 z 2 j 8 a / k e r n . c u
Options: -I/home/kenichi/.pyenv/versions/local-3.6.3/lib/python3.6/site-packages/cupy/core/include -I /usr/local/cuda/include -ftz=true -arch=compute_52
CUDA source:
... snip ...
```

This PR fixes the issue.