### PR TITLE
Allow derived errors to pass equality tests

### DIFF
--- a/cupy/testing/helper.py
+++ b/cupy/testing/helper.py
@@ -59,7 +59,8 @@ numpy
 %s
 ''' % (cupy_tb, numpy_tb)
         self.fail(msg)
-    elif not isinstance(cupy_error, accept_error):
+    elif not (isinstance(cupy_error, accept_error) and
+              isinstance(numpy_error, accept_error)):
         msg = '''Both cupy and numpy raise exceptions
 
 cupy

--- a/cupy/testing/helper.py
+++ b/cupy/testing/helper.py
@@ -49,8 +49,11 @@ def _check_cupy_numpy_error(self, cupy_error, cupy_tb, numpy_error,
         self.fail('Only numpy raises error\n\n' + numpy_tb)
     elif numpy_error is None:
         self.fail('Only cupy raises error\n\n' + cupy_tb)
-    elif not (isinstance(cupy_error, type(numpy_error)) or
-              isinstance(numpy_error, type(cupy_error))):
+    elif not isinstance(cupy_error, type(numpy_error)):
+        # CuPy errors should always be more explicit than NumPy errors, i.e.
+        # allow CuPy errors to derive from NumPy errors but not the opposite.
+        # This ensures that try/except blocks that catch NumPy errors also
+        # catch CuPy errors.
         msg = '''Different types of errors occurred
 
 cupy

--- a/cupy/testing/helper.py
+++ b/cupy/testing/helper.py
@@ -49,7 +49,8 @@ def _check_cupy_numpy_error(self, cupy_error, cupy_tb, numpy_error,
         self.fail('Only numpy raises error\n\n' + numpy_tb)
     elif numpy_error is None:
         self.fail('Only cupy raises error\n\n' + cupy_tb)
-    elif type(cupy_error) is not type(numpy_error):
+    elif not (isinstance(cupy_error, type(numpy_error)) or
+              isinstance(numpy_error, type(cupy_error))):
         msg = '''Different types of errors occurred
 
 cupy

--- a/cupy/testing/helper.py
+++ b/cupy/testing/helper.py
@@ -50,7 +50,7 @@ def _check_cupy_numpy_error(self, cupy_error, cupy_tb, numpy_error,
     elif numpy_error is None:
         self.fail('Only cupy raises error\n\n' + cupy_tb)
     elif not isinstance(cupy_error, type(numpy_error)):
-        # CuPy errors should always be more explicit than NumPy errors, i.e.
+        # CuPy errors should be at least as explicit as the NumPy errors, i.e.
         # allow CuPy errors to derive from NumPy errors but not the opposite.
         # This ensures that try/except blocks that catch NumPy errors also
         # catch CuPy errors.

--- a/tests/cupy_tests/testing_tests/test_helper.py
+++ b/tests/cupy_tests/testing_tests/test_helper.py
@@ -71,6 +71,52 @@ class TestCheckCupyNumpyError(unittest.TestCase):
                                        numpy_error, numpy_tb,
                                        accept_error=Exception)
 
+    def test_cupy_derived_error(self):
+        cupy_error = ValueError()
+        cupy_tb = 'xxxx'
+        numpy_error = Exception()
+        numpy_tb = 'yyyy'
+        # Nothing happens
+        helper._check_cupy_numpy_error(self, cupy_error, cupy_tb,
+                                       numpy_error, numpy_tb,
+                                       accept_error=Exception)
+
+    def test_numpy_derived_error(self):
+        cupy_error = Exception()
+        cupy_tb = 'xxxx'
+        numpy_error = IndexError()
+        numpy_tb = 'yyyy'
+        # Nothing happens
+        helper._check_cupy_numpy_error(self, cupy_error, cupy_tb,
+                                       numpy_error, numpy_tb,
+                                       accept_error=Exception)
+
+    def test_cupy_derived_unaccept_error(self):
+        cupy_error = IndexError()
+        cupy_tb = 'xxxx'
+        numpy_error = Exception()
+        numpy_tb = 'yyyy'
+        pattern = re.compile(cupy_tb + '.*' + numpy_tb, re.S)
+        with six.assertRaisesRegex(self, AssertionError, pattern):
+            # Neither `IndexError` nor `Exception` is derived from
+            # `ValueError`, therefore expect an error
+            helper._check_cupy_numpy_error(self, cupy_error, cupy_tb,
+                                           numpy_error, numpy_tb,
+                                           accept_error=ValueError)
+
+    def test_numpy_derived_unaccept_error(self):
+        cupy_error = Exception()
+        cupy_tb = 'xxxx'
+        numpy_error = ValueError()
+        numpy_tb = 'yyyy'
+        pattern = re.compile(cupy_tb + '.*' + numpy_tb, re.S)
+        with six.assertRaisesRegex(self, AssertionError, pattern):
+            # `Exception` is not derived from `ValueError`, therefore except an
+            # error
+            helper._check_cupy_numpy_error(self, cupy_error, cupy_tb,
+                                           numpy_error, numpy_tb,
+                                           accept_error=ValueError)
+
     def test_forbidden_error(self):
         cupy_error = Exception()
         cupy_tb = 'xxxx'

--- a/tests/cupy_tests/testing_tests/test_helper.py
+++ b/tests/cupy_tests/testing_tests/test_helper.py
@@ -32,104 +32,122 @@ class TestContainsSignedAndUnsigned(unittest.TestCase):
 
 class TestCheckCupyNumpyError(unittest.TestCase):
 
+    tbs = {
+        cupy: 'xxxx',
+        numpy: 'yyyy'
+    }
+
     def test_both_success(self):
+        @testing.helper.numpy_cupy_raises()
+        def dummy_both_success(self, xp):
+            pass
+
         with self.assertRaises(AssertionError):
-            helper._check_cupy_numpy_error(self, None, None, None, None)
+            dummy_both_success(self)
 
     def test_cupy_error(self):
-        cupy_error = Exception()
-        cupy_tb = 'xxxx'
-        with six.assertRaisesRegex(self, AssertionError, cupy_tb):
-            helper._check_cupy_numpy_error(self, cupy_error, cupy_tb,
-                                           None, None)
+        @testing.helper.numpy_cupy_raises()
+        def dummy_cupy_error(self, xp):
+            if xp is cupy:
+                raise Exception(self.tbs.get(cupy))
+
+        with six.assertRaisesRegex(self, AssertionError, self.tbs.get(cupy)):
+            dummy_cupy_error(self)
 
     def test_numpy_error(self):
-        numpy_error = Exception()
-        numpy_tb = 'yyyy'
-        with six.assertRaisesRegex(self, AssertionError, numpy_tb):
-            helper._check_cupy_numpy_error(self, None, None,
-                                           numpy_error, numpy_tb)
+        @testing.helper.numpy_cupy_raises()
+        def dummy_numpy_error(self, xp):
+            if xp is numpy:
+                raise Exception(self.tbs.get(numpy))
+
+        with six.assertRaisesRegex(self, AssertionError, self.tbs.get(numpy)):
+            dummy_numpy_error(self)
 
     def test_cupy_numpy_different_error(self):
-        cupy_error = TypeError()
-        cupy_tb = 'xxxx'
-        numpy_error = ValueError()
-        numpy_tb = 'yyyy'
-        # Use re.S mode to ignore new line characters
-        pattern = re.compile(cupy_tb + '.*' + numpy_tb, re.S)
-        with six.assertRaisesRegex(self, AssertionError, pattern):
-            helper._check_cupy_numpy_error(self, cupy_error, cupy_tb,
-                                           numpy_error, numpy_tb)
+        @testing.helper.numpy_cupy_raises()
+        def dummy_cupy_numpy_different_error(self, xp):
+            if xp is cupy:
+                raise TypeError(self.tbs.get(cupy))
+            elif xp is numpy:
+                raise ValueError(self.tbs.get(numpy))
 
-    def test_same_error(self):
-        cupy_error = Exception()
-        cupy_tb = 'xxxx'
-        numpy_error = Exception()
-        numpy_tb = 'yyyy'
-        # Nothing happens
-        helper._check_cupy_numpy_error(self, cupy_error, cupy_tb,
-                                       numpy_error, numpy_tb,
-                                       accept_error=Exception)
+        # Use re.S mode to ignore new line characters
+        pattern = re.compile(
+            self.tbs.get(cupy) + '.*' + self.tbs.get(numpy), re.S)
+        with six.assertRaisesRegex(self, AssertionError, pattern):
+            dummy_cupy_numpy_different_error(self)
 
     def test_cupy_derived_error(self):
-        cupy_error = ValueError()
-        cupy_tb = 'xxxx'
-        numpy_error = Exception()
-        numpy_tb = 'yyyy'
-        # Nothing happens, CuPy errors may derive from NumPy errors
-        helper._check_cupy_numpy_error(self, cupy_error, cupy_tb,
-                                       numpy_error, numpy_tb,
-                                       accept_error=Exception)
+        @testing.helper.numpy_cupy_raises()
+        def dummy_cupy_derived_error(self, xp):
+            if xp is cupy:
+                raise ValueError(self.tbs.get(cupy))
+            elif xp is numpy:
+                raise Exception(self.tbs.get(numpy))
+
+        dummy_cupy_derived_error(self)  # Assert no exceptions
 
     def test_numpy_derived_error(self):
-        cupy_error = Exception()
-        cupy_tb = 'xxxx'
-        numpy_error = IndexError()
-        numpy_tb = 'yyyy'
+        @testing.helper.numpy_cupy_raises()
+        def dummy_numpy_derived_error(self, xp):
+            if xp is cupy:
+                raise Exception(self.tbs.get(cupy))
+            elif xp is numpy:
+                raise IndexError(self.tbs.get(numpy))
+
         # NumPy errors may not derive from CuPy errors, i.e. CuPy errors should
-        # always be more explicit
-        pattern = re.compile(cupy_tb + '.*' + numpy_tb, re.S)
+        # be at least as explicit as the NumPy error
+        pattern = re.compile(
+            self.tbs.get(cupy) + '.*' + self.tbs.get(numpy), re.S)
         with six.assertRaisesRegex(self, AssertionError, pattern):
-            helper._check_cupy_numpy_error(self, cupy_error, cupy_tb,
-                                           numpy_error, numpy_tb)
+            dummy_numpy_derived_error(self)
+
+    def test_same_error(self):
+        @testing.helper.numpy_cupy_raises(accept_error=Exception)
+        def dummy_same_error(self, xp):
+            raise Exception(self.tbs.get(xp))
+
+        dummy_same_error(self)
 
     def test_cupy_derived_unaccept_error(self):
-        cupy_error = IndexError()
-        cupy_tb = 'xxxx'
-        numpy_error = Exception()
-        numpy_tb = 'yyyy'
-        pattern = re.compile(cupy_tb + '.*' + numpy_tb, re.S)
+        @testing.helper.numpy_cupy_raises(accept_error=ValueError)
+        def dummy_cupy_derived_unaccept_error(self, xp):
+            if xp is cupy:
+                raise IndexError(self.tbs.get(cupy))
+            elif xp is numpy:
+                raise Exception(self.tbs.get(numpy))
+
+        # Neither `IndexError` nor `Exception` is derived from `ValueError`,
+        # therefore expect an error
+        pattern = re.compile(
+            self.tbs.get(cupy) + '.*' + self.tbs.get(numpy), re.S)
         with six.assertRaisesRegex(self, AssertionError, pattern):
-            # Neither `IndexError` nor `Exception` is derived from
-            # `ValueError`, therefore expect an error
-            helper._check_cupy_numpy_error(self, cupy_error, cupy_tb,
-                                           numpy_error, numpy_tb,
-                                           accept_error=ValueError)
+            dummy_cupy_derived_unaccept_error(self)
 
     def test_numpy_derived_unaccept_error(self):
-        cupy_error = Exception()
-        cupy_tb = 'xxxx'
-        numpy_error = ValueError()
-        numpy_tb = 'yyyy'
-        pattern = re.compile(cupy_tb + '.*' + numpy_tb, re.S)
+        @testing.helper.numpy_cupy_raises(accept_error=ValueError)
+        def dummy_numpy_derived_unaccept_error(self, xp):
+            if xp is cupy:
+                raise Exception(self.tbs.get(cupy))
+            elif xp is numpy:
+                raise ValueError(self.tbs.get(numpy))
+
+        # `Exception` is not derived from `ValueError`, therefore expect an
+        # error
+        pattern = re.compile(
+            self.tbs.get(cupy) + '.*' + self.tbs.get(numpy), re.S)
         with six.assertRaisesRegex(self, AssertionError, pattern):
-            # `Exception` is not derived from `ValueError`, therefore except an
-            # error
-            helper._check_cupy_numpy_error(self, cupy_error, cupy_tb,
-                                           numpy_error, numpy_tb,
-                                           accept_error=ValueError)
+            dummy_numpy_derived_unaccept_error(self)
 
     def test_forbidden_error(self):
-        cupy_error = Exception()
-        cupy_tb = 'xxxx'
-        numpy_error = Exception()
-        numpy_tb = 'yyyy'
-        # Use re.S mode to ignore new line characters
-        pattern = re.compile(cupy_tb + '.*' + numpy_tb, re.S)
+        @testing.helper.numpy_cupy_raises(accept_error=False)
+        def dummy_forbidden_error(self, xp):
+            raise Exception(self.tbs.get(xp))
+
+        pattern = re.compile(
+            self.tbs.get(cupy) + '.*' + self.tbs.get(numpy), re.S)
         with six.assertRaisesRegex(self, AssertionError, pattern):
-            helper._check_cupy_numpy_error(
-                self, cupy_error, cupy_tb,
-                numpy_error, numpy_tb, accept_error=False)
+            dummy_forbidden_error(self)
 
 
 class NumPyCuPyDecoratorBase(object):

--- a/tests/cupy_tests/testing_tests/test_helper.py
+++ b/tests/cupy_tests/testing_tests/test_helper.py
@@ -76,7 +76,7 @@ class TestCheckCupyNumpyError(unittest.TestCase):
         cupy_tb = 'xxxx'
         numpy_error = Exception()
         numpy_tb = 'yyyy'
-        # Nothing happens
+        # Nothing happens, CuPy errors may derive from NumPy errors
         helper._check_cupy_numpy_error(self, cupy_error, cupy_tb,
                                        numpy_error, numpy_tb,
                                        accept_error=Exception)
@@ -86,10 +86,12 @@ class TestCheckCupyNumpyError(unittest.TestCase):
         cupy_tb = 'xxxx'
         numpy_error = IndexError()
         numpy_tb = 'yyyy'
-        # Nothing happens
-        helper._check_cupy_numpy_error(self, cupy_error, cupy_tb,
-                                       numpy_error, numpy_tb,
-                                       accept_error=Exception)
+        # NumPy errors may not derive from CuPy errors, i.e. CuPy errors should
+        # always be more explicit
+        pattern = re.compile(cupy_tb + '.*' + numpy_tb, re.S)
+        with six.assertRaisesRegex(self, AssertionError, pattern):
+            helper._check_cupy_numpy_error(self, cupy_error, cupy_tb,
+                                           numpy_error, numpy_tb)
 
     def test_cupy_derived_unaccept_error(self):
         cupy_error = IndexError()


### PR DESCRIPTION
For tests that assert errors to be thrown, allow derived errors to be treated as equal errors and pass the tests. I am not sure if this goes agains the design but it makes sense as these errors can be caught by the same try/except.

A concrete example is `cupy.stack` throwing `IndexOrValueError` which is an error defined by CuPy meaning that it won't pass the equality test with any NumPy error. This PR would allow it to pass.