### PR TITLE
Fix order=None of unravel_index

### DIFF
--- a/cupy/indexing/generate.py
+++ b/cupy/indexing/generate.py
@@ -275,7 +275,10 @@ def unravel_index(indices, dims, order='C'):
     .. seealso:: :func:`numpy.unravel_index`
 
     """
-    if order in ('C', None):
+    if order is None:
+        order = 'C'
+
+    if order == 'C':
         dims = reversed(dims)
     elif order == 'F':
         pass

--- a/tests/cupy_tests/indexing_tests/test_generate.py
+++ b/tests/cupy_tests/indexing_tests/test_generate.py
@@ -156,26 +156,13 @@ class TestUnravelIndex(unittest.TestCase):
 
     _multiprocess_can_split_ = True
 
+    @testing.for_orders(['C', 'F', None])
     @testing.for_int_dtypes()
     @testing.numpy_cupy_array_list_equal()
-    def test_C(self, xp, dtype):
+    def test(self, xp, order, dtype):
         a = testing.shaped_arange((4, 3, 2), xp, dtype)
         a = xp.minimum(a, 6 * 4 - 1)
-        return xp.unravel_index(a, (6, 4))
-
-    @testing.for_int_dtypes()
-    @testing.numpy_cupy_array_list_equal()
-    def test_F(self, xp, dtype):
-        a = testing.shaped_arange((4, 3, 2), xp, dtype)
-        a = xp.minimum(a, 6 * 4 - 1)
-        return xp.unravel_index(a, (6, 4), order='F')
-
-    @testing.for_int_dtypes()
-    @testing.numpy_cupy_array_list_equal()
-    def test_none(self, xp, dtype):
-        a = testing.shaped_arange((4, 3, 2), xp, dtype)
-        a = xp.minimum(a, 6 * 4 - 1)
-        return xp.unravel_index(a, (6, 4), order=None)
+        return xp.unravel_index(a, (6, 4), order=order)
 
     @testing.for_int_dtypes()
     @testing.numpy_cupy_raises(accept_error=TypeError)
@@ -183,14 +170,16 @@ class TestUnravelIndex(unittest.TestCase):
         a = testing.shaped_arange((4, 3, 2), xp, dtype)
         xp.unravel_index(a, (6, 4), order='V')
 
+    @testing.for_orders(['C', 'F', None])
     @testing.for_int_dtypes(no_bool=True)
     @testing.numpy_cupy_raises(accept_error=ValueError)
-    def test_invalid_index(self, xp, dtype):
+    def test_invalid_index(self, xp, order, dtype):
         a = testing.shaped_arange((4, 3, 2), xp, dtype)
-        xp.unravel_index(a, (6, 4))
+        xp.unravel_index(a, (6, 4), order=order)
 
+    @testing.for_orders(['C', 'F', None])
     @testing.for_float_dtypes()
     @testing.numpy_cupy_raises(accept_error=TypeError)
-    def test_invalid_dtype(self, xp, dtype):
+    def test_invalid_dtype(self, xp, order, dtype):
         a = testing.shaped_arange((4, 3, 2), xp, dtype)
-        xp.unravel_index(a, (6, 4))
+        xp.unravel_index(a, (6, 4), order=order)

--- a/tests/cupy_tests/indexing_tests/test_generate.py
+++ b/tests/cupy_tests/indexing_tests/test_generate.py
@@ -171,6 +171,13 @@ class TestUnravelIndex(unittest.TestCase):
         return xp.unravel_index(a, (6, 4), order='F')
 
     @testing.for_int_dtypes()
+    @testing.numpy_cupy_array_list_equal()
+    def test_none(self, xp, dtype):
+        a = testing.shaped_arange((4, 3, 2), xp, dtype)
+        a = xp.minimum(a, 6 * 4 - 1)
+        return xp.unravel_index(a, (6, 4), order=None)
+
+    @testing.for_int_dtypes()
     @testing.numpy_cupy_raises(accept_error=TypeError)
     def test_invalid_order(self, xp, dtype):
         a = testing.shaped_arange((4, 3, 2), xp, dtype)


### PR DESCRIPTION
`order=None` is supported in #764. However, the behaviour is different from numpy.

```python
np.unravel_index((4, 6), (4, 3), order=None)
# (array([1, 2]), array([1, 0]))
cupy.unravel_index(cupy.array((4, 6)), (4, 3), order=None)
# (array([1, 0]), array([1, 2]))
```

In the case of `order='C'`,
```python
np.unravel_index((4, 6), (4, 3), order='C')
# (array([1, 2]), array([1, 0]))
cupy.unravel_index(cupy.array((4, 6)), (4, 3), order='C')
# (array([1, 2]), array([1, 0]))
```

