### PR TITLE
[backport] add pytest cache directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ cupy.egg-info/
 dist/
 htmlcov/
 .idea/
+.cache/


### PR DESCRIPTION
Backport of #797