### PR TITLE
Support None as an argument for clip method

### DIFF
--- a/cupy/core/core.pxd
+++ b/cupy/core/core.pxd
@@ -39,7 +39,7 @@ cdef class ndarray:
     cpdef ndarray min(self, axis=*, out=*, dtype=*, keepdims=*)
     cpdef ndarray argmin(self, axis=*, out=*, dtype=*,
                          keepdims=*)
-    cpdef ndarray clip(self, a_min, a_max, out=*)
+    cpdef ndarray clip(self, a_min=*, a_max=*, out=*)
 
     cpdef ndarray trace(self, offset=*, axis1=*, axis2=*, dtype=*,
                         out=*)

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1040,7 +1040,7 @@ cdef class ndarray:
 
     # TODO(okuta): Implement ptp
 
-    cpdef ndarray clip(self, a_min, a_max, out=None):
+    cpdef ndarray clip(self, a_min=None, a_max=None, out=None):
         """Returns an array with values limited to [a_min, a_max].
 
         .. seealso::
@@ -1048,6 +1048,16 @@ cdef class ndarray:
            :meth:`numpy.ndarray.clip`
 
         """
+        if a_min is None:
+            if issubclass(self.dtype.type, numpy.floating):
+                a_min = self.dtype.type('-inf')
+            elif issubclass(self.dtype.type, numpy.integer):
+                a_min = numpy.iinfo(self.dtype.type).min
+        if a_max is None:
+            if issubclass(self.dtype.type, numpy.floating):
+                a_max = self.dtype.type('inf')
+            elif issubclass(self.dtype.type, numpy.integer):
+                a_max = numpy.iinfo(self.dtype.type).max
         return _clip(self, a_min, a_max, out=out)
 
     # TODO(okuta): Implement round

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1048,6 +1048,8 @@ cdef class ndarray:
            :meth:`numpy.ndarray.clip`
 
         """
+        if a_min is None and a_max is None:
+            raise ValueError('array_clip: must set either max or min')
         if a_min is None:
             if issubclass(self.dtype.type, numpy.floating):
                 a_min = self.dtype.type('-inf')

--- a/cupy/math/misc.py
+++ b/cupy/math/misc.py
@@ -4,7 +4,7 @@ from cupy import core
 # TODO(okuta): Implement convolve
 
 
-def clip(a, a_min, a_max, out=None):
+def clip(a, a_min=None, a_max=None, out=None):
     """Clips the values of an array to a given interval.
 
     This is equivalent to ``maximum(minimum(a, a_max), a_min)``, while this
@@ -12,8 +12,10 @@ def clip(a, a_min, a_max, out=None):
 
     Args:
         a (cupy.ndarray): The source array.
-        a_min (scalar or cupy.ndarray): The left side of the interval.
-        a_max (scalar or cupy.ndarray): The right side of the interval.
+        a_min (scalar, cupy.ndarray or None): The left side of the interval.
+            When it is ``None``, it is ignored.
+        a_max (scalar, cupy.ndarray or None): The right side of the interval.
+            When it is ``None``, it is ignored.
         out (cupy.ndarray): Output array.
 
     Returns:

--- a/tests/cupy_tests/math_tests/test_misc.py
+++ b/tests/cupy_tests/math_tests/test_misc.py
@@ -60,6 +60,18 @@ class TestMisc(unittest.TestCase):
         a = testing.shaped_arange((2, 3, 4), xp, dtype)
         return a.clip(3, 13)
 
+    @testing.for_all_dtypes(no_bool=True, no_complex=True)
+    @testing.numpy_cupy_array_equal()
+    def test_clip_min_none(self, xp, dtype):
+        a = testing.shaped_arange((2, 3, 4), xp, dtype)
+        return a.clip(None, 3)
+
+    @testing.for_all_dtypes(no_bool=True, no_complex=True)
+    @testing.numpy_cupy_array_equal()
+    def test_clip_max_none(self, xp, dtype):
+        a = testing.shaped_arange((2, 3, 4), xp, dtype)
+        return a.clip(3, None)
+
     @unittest.skipIf(
         os.sys.platform == 'win32', 'dtype problem on Windows')
     @testing.for_all_dtypes(no_complex=True)

--- a/tests/cupy_tests/math_tests/test_misc.py
+++ b/tests/cupy_tests/math_tests/test_misc.py
@@ -72,6 +72,12 @@ class TestMisc(unittest.TestCase):
         a = testing.shaped_arange((2, 3, 4), xp, dtype)
         return a.clip(3, None)
 
+    @testing.for_all_dtypes(no_bool=True, no_complex=True)
+    @testing.numpy_cupy_raises(accept_error=ValueError)
+    def test_clip_min_max_none(self, xp, dtype):
+        a = testing.shaped_arange((2, 3, 4), xp, dtype)
+        return a.clip(None, None)
+
     @unittest.skipIf(
         os.sys.platform == 'win32', 'dtype problem on Windows')
     @testing.for_all_dtypes(no_complex=True)


### PR DESCRIPTION
The default argument for `a_min` and `a_max` in `clip` is ``None``. This patch supports it.