### PR TITLE
[backport] fix test to pass with numpy 1.9

### DIFF
--- a/tests/cupy_tests/manipulation_tests/test_join.py
+++ b/tests/cupy_tests/manipulation_tests/test_join.py
@@ -183,6 +183,7 @@ class TestJoin(unittest.TestCase):
         a = testing.shaped_arange((2, 3), xp)
         return xp.stack((a, a), axis=2)
 
+    @testing.with_requires('numpy>=1.10')
     @testing.numpy_cupy_raises()
     def test_stack_with_axis_over(self, xp):
         a = testing.shaped_arange((2, 3), xp)


### PR DESCRIPTION
Backport of #803