### PR TITLE
Expose signatures to Reference

### DIFF
--- a/cupy/core/elementwise.pxi
+++ b/cupy/core/elementwise.pxi
@@ -742,9 +742,7 @@ class ufunc(object):
         return types
 
     def __call__(self, *args, **kwargs):
-        """__call__(*args, **kwargs)
-
-        Applies the universal function to arguments elementwise.
+        """Applies the universal function to arguments elementwise.
 
         Args:
             args: Input arguments. Each of them can be a :class:`cupy.ndarray`

--- a/cupy/core/reduction.pxi
+++ b/cupy/core/reduction.pxi
@@ -355,9 +355,7 @@ class ReductionKernel(object):
         self.preamble = preamble
 
     def __call__(self, *args, **kwargs):
-        """__call__(*args, **kwargs)
-
-        Compiles and invokes the reduction kernel.
+        """Compiles and invokes the reduction kernel.
 
         The compilation runs only if the kernel is not cached. Note that the
         kernels with different argument dtypes, ndims, or axis are not

--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -346,6 +346,9 @@ def cythonize(extensions, arg_options):
     directive_keys = ('linetrace', 'profile')
     directives = {key: arg_options[key] for key in directive_keys}
 
+    # Embed signatures for Sphinx documentation.
+    directives['embedsignature'] = True
+
     cythonize_option_keys = ('annotate',)
     cythonize_options = {key: arg_options[key]
                          for key in cythonize_option_keys}


### PR DESCRIPTION
Added `embedsignature` cython compile option to show signatures of methods in API reference generated by Sphinx.
http://cython.readthedocs.io/en/latest/src/reference/compilation.html

I also removed existing explicit signatures, because internally it becames duplicate declaration of signature and raise warning.