### PR TITLE
[backport] Fix matmul to raise ValueError on invalid shapes

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -3347,6 +3347,11 @@ cpdef ndarray matmul(ndarray a, ndarray b, ndarray out=None):
     cdef Py_ssize_t batchCount
     cdef ndarray ap, bp, outp
 
+    orig_a_shape = a.shape
+    orig_b_shape = b.shape
+    if len(orig_a_shape) == 0 or len(orig_b_shape) == 0:
+        raise ValueError('Scalar operands are not allowed, use \'*\' instead')
+
     ret_dtype = numpy.result_type(a.dtype, b.dtype)
     dtype = numpy.find_common_type((ret_dtype, 'f'), ())
 
@@ -3432,9 +3437,16 @@ cpdef ndarray matmul(ndarray a, ndarray b, ndarray out=None):
     *la, ka, n = a.shape
     *lb, m, kb = b.shape
 
-    assert ka == kb
+    if ka != kb:
+        raise ValueError(
+            'shapes ({}) and ({}) not aligned'.format(
+                ','.join([str(_) for _ in orig_a_shape]),
+                ','.join([str(_) for _ in orig_b_shape])))
     for la_, lb_ in zip(la, lb):
-        assert la_ == lb_ or la_ == 1 or lb_ == 1
+        if not (la_ == lb_ or la_ == 1 or lb_ == 1):
+            raise ValueError(
+                'operands could not be broadcast together with '
+                'remapped shapes')
 
     batchCount = 1  # batchCount = numpy.prod(la)
     for i in la:

--- a/tests/cupy_tests/math_tests/test_matmul.py
+++ b/tests/cupy_tests/math_tests/test_matmul.py
@@ -104,6 +104,29 @@ class TestMatmulLarge(unittest.TestCase):
         if ((dtype1, dtype2) in self.skip_dtypes or
                 (dtype2, dtype1) in self.skip_dtypes):
             return xp.array([])
-        x1 = testing.shaped_arange(self.shape_pair[0], xp, dtype1)
-        x2 = testing.shaped_arange(self.shape_pair[1], xp, dtype2)
+        shape1, shape2 = self.shape_pair
+        x1 = testing.shaped_arange(shape1, xp, dtype1)
+        x2 = testing.shaped_arange(shape2, xp, dtype2)
         return xp.matmul(x1, x2)
+
+
+@testing.parameterize(
+    *testing.product({
+        'shape_pair': [
+            ((5, 3, 1), (3, 1, 4)),
+            ((3, 2, 3), (3, 2, 4)),
+            ((3, 2), ()),
+            ((), (3, 2)),
+            ((), ()),
+            ((3, 2), (1,)),
+        ],
+    }))
+@testing.gpu
+class TestMatmulInvalidShape(unittest.TestCase):
+
+    @testing.numpy_cupy_raises(accept_error=ValueError)
+    def test_invalid_shape(self, xp):
+        shape1, shape2 = self.shape_pair
+        x1 = testing.shaped_arange(shape1, xp, numpy.float32)
+        x2 = testing.shaped_arange(shape2, xp, numpy.float32)
+        xp.matmul(x1, x2)


### PR DESCRIPTION
Backport of #737