### PR TITLE
Implement isclose

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -316,6 +316,8 @@ from cupy.linalg.norms import trace  # NOQA
 # -----------------------------------------------------------------------------
 # Logic functions
 # -----------------------------------------------------------------------------
+from cupy.logic.comparison import isclose
+
 from cupy.core.fusion import isfinite  # NOQA
 from cupy.core.fusion import isinf  # NOQA
 from cupy.core.fusion import isnan  # NOQA

--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -316,7 +316,7 @@ from cupy.linalg.norms import trace  # NOQA
 # -----------------------------------------------------------------------------
 # Logic functions
 # -----------------------------------------------------------------------------
-from cupy.logic.comparison import isclose
+from cupy.logic.comparison import isclose  # NOQA
 
 from cupy.core.fusion import isfinite  # NOQA
 from cupy.core.fusion import isinf  # NOQA

--- a/cupy/logic/comparison.py
+++ b/cupy/logic/comparison.py
@@ -1,10 +1,57 @@
+import cupy
 from cupy import core
 
 
 # TODO(okuta): Implement allclose
 
 
-# TODO(okuta): Implement isclose
+def isclose(a, b, rtol=1.e-5, atol=1.e-8, equal_nan=False):
+    """Returns a boolean array where two arrays are equal within a tolerance.
+
+    Two values in ``a`` and ``b`` are  considiered equal when the following
+    equation is satisfied.
+
+    .. math::
+
+       |a - b| \le \mathrm{atol} + \mathrm{rtol} |b|
+
+    Args:
+        a (cupy.ndarray): Input array to compare.
+        b (cupy.ndarray): Input array to compare.
+        rtol (float): The relative tolerance.
+        atol (float): The absolute tolerance.
+        equal_nan (bool): If ``True``, NaN's in ``a`` will be considered equal
+            to NaN's in ``b``.
+
+    Returns:
+        cupy.ndarray: A boolean array storing where ``a`` and ``b`` are equal.
+
+    .. seealso:: :func:`numpy.isclose`
+
+    """
+    def within_tol(x, y):
+        return abs(x - y) <= atol + rtol * abs(y)
+
+    # When we use integer type, abs(MIN_INT) causes overflow.
+    x = cupy.asarray(a, dtype='d')
+    y = cupy.asarray(b, dtype='d')
+
+    xfin = cupy.isfinite(x)
+    yfin = cupy.isfinite(y)
+    if all(xfin) and all(yfin):
+        cond = within_tol(x, y)
+    else:
+        finite = xfin & yfin
+        cond = cupy.zeros_like(finite)
+        # For boolean indexing, we need to broadcast arrays.
+        x, y = cupy.broadcast_arrays(x, y)
+        cond[finite] = within_tol(x[finite], y[finite])
+        cond[~finite] = (x[~finite] == y[~finite])
+        if equal_nan:
+            both_nan = cupy.isnan(x) & cupy.isnan(y)
+            cond[both_nan] = both_nan[both_nan]
+
+    return cond
 
 
 # TODO(okuta): Implement array_equal

--- a/tests/cupy_tests/logic_tests/test_comparison.py
+++ b/tests/cupy_tests/logic_tests/test_comparison.py
@@ -39,16 +39,20 @@ class TestComparison(unittest.TestCase):
 
 class TestIsclose(unittest.TestCase):
 
+    @testing.with_requires('numpy>=1.10')
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_array_equal()
     def test_is_close_finite(self, xp, dtype):
+        # In numpy<1.10 this test fails when dtype is bool
         a = xp.array([0.9e-5, 1.1e-5, 1000 + 1e-4, 1000 - 1e-4], dtype=dtype)
         b = xp.array([0, 0, 1000, 1000], dtype=dtype)
         return xp.isclose(a, b)
 
+    @testing.with_requires('numpy>=1.10')
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_array_equal()
     def test_is_close_min_int(self, xp, dtype):
+        # In numpy<1.10 this test fails when dtype is bool
         a = xp.array([0], dtype=dtype)
         b = xp.array([numpy.iinfo('i').min], dtype=dtype)
         return xp.isclose(a, b)


### PR DESCRIPTION
I implemented isclose.
I want to discuss its specification for scalar values. When input values are scalars, numpy returns `bool` object. But in cupy, we need to transfer the data. I use `cupy.ndarray` in such case in this PR same as `cupy.sum`. How do you think about this problem?