### PR TITLE
Implement size method

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -471,6 +471,11 @@ from cupy.statistics.meanvar import var  # NOQA
 from cupy.statistics.histogram import bincount  # NOQA
 
 # -----------------------------------------------------------------------------
+# Undocumented functions
+# -----------------------------------------------------------------------------
+from cupy.core import size  # NOQA
+
+# -----------------------------------------------------------------------------
 # CuPy specific functions
 # -----------------------------------------------------------------------------
 

--- a/cupy/core/__init__.py
+++ b/cupy/core/__init__.py
@@ -51,6 +51,7 @@ from cupy.core.core import ReductionKernel  # NOQA
 from cupy.core.core import remainder  # NOQA
 from cupy.core.core import right_shift  # NOQA
 from cupy.core.core import rollaxis  # NOQA
+from cupy.core.core import size  # NOQA'
 from cupy.core.core import sqrt  # NOQA
 from cupy.core.core import subtract  # NOQA
 from cupy.core.core import tensordot_core  # NOQA

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2636,6 +2636,29 @@ cdef _concatenate_kernel = ElementwiseKernel(
 )
 
 
+cpdef int size(ndarray a, axis=None) except *:
+    """Returns the number of elements along a given axis.
+
+    Args:
+        a (ndarray): Input data.
+        axis (int or None): Axis along which the elements are counted.
+            When it is ``None``, it returns the total number of elements.
+
+    Returns:
+        int: Number of elements along the given axis.
+
+    """
+    cdef int index
+    if axis is None:
+        return a.size
+    else:
+        index = axis
+        if index < 0:
+            index += a.ndim
+        if not 0 <= index < a.ndim:
+            raise IndexError('index out of range')
+        return a._shape[index]
+
 # -----------------------------------------------------------------------------
 # Binary operations
 # -----------------------------------------------------------------------------

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2648,14 +2648,15 @@ cpdef int size(ndarray a, axis=None) except *:
         int: Number of elements along the given axis.
 
     """
-    cdef int index
+    cdef int index, ndim
     if axis is None:
         return a.size
     else:
         index = axis
+        ndim = a._shape.size()
         if index < 0:
-            index += a.ndim
-        if not 0 <= index < a.ndim:
+            index += ndim
+        if not 0 <= index < ndim:
             raise IndexError('index out of range')
         return a._shape[index]
 

--- a/tests/cupy_tests/core_tests/test_ndarray.py
+++ b/tests/cupy_tests/core_tests/test_ndarray.py
@@ -267,3 +267,42 @@ class TestNdarrayTakeErrorTypeMismatch(unittest.TestCase):
         i = testing.shaped_arange(self.indices, xp, numpy.int32) % 3
         o = testing.shaped_arange(self.out_shape, xp, numpy.float32)
         wrap_take(a, i, out=o)
+
+
+@testing.gpu
+class TestSize(unittest.TestCase):
+
+    @testing.numpy_cupy_equal()
+    def test_size_without_axis(self, xp):
+        x = testing.shaped_arange((3, 4, 5), xp, numpy.int32)
+        return xp.size(x)
+
+    @testing.numpy_cupy_equal()
+    def test_size_with_axis(self, xp):
+        x = testing.shaped_arange((3, 4, 5), xp, numpy.int32)
+        return xp.size(x, 0)
+
+    @testing.numpy_cupy_equal()
+    def test_size_with_negative_axis(self, xp):
+        x = testing.shaped_arange((3, 4, 5), xp, numpy.int32)
+        return xp.size(x, -1)
+
+    @testing.numpy_cupy_equal()
+    def test_size_zero_dim_array(self, xp):
+        x = testing.shaped_arange((), xp, numpy.int32)
+        return xp.size(x)
+
+    @testing.numpy_cupy_raises(accept_error=IndexError)
+    def test_size_axis_too_large(self, xp):
+        x = testing.shaped_arange((3, 4, 5), xp, numpy.int32)
+        return xp.size(x, 3)
+
+    @testing.numpy_cupy_raises(accept_error=IndexError)
+    def test_size_axis_too_small(self, xp):
+        x = testing.shaped_arange((3, 4, 5), xp, numpy.int32)
+        return xp.size(x, -4)
+
+    @testing.numpy_cupy_raises(accept_error=IndexError)
+    def test_size_zero_dim_array_with_axis(self, xp):
+        x = testing.shaped_arange((), xp, numpy.int32)
+        return xp.size(x, 0)


### PR DESCRIPTION
I implemented `cupy.size` method. It does not generate a tuple but only returns `int`.
Note `numpy.size` exists but is not documented.