### PR TITLE
Use CUDA version to decide if it import cusolver or not

### DIFF
--- a/cupy/cuda/__init__.py
+++ b/cupy/cuda/__init__.py
@@ -2,6 +2,7 @@ import contextlib
 
 from cupy.cuda import compiler  # NOQA
 from cupy.cuda import device  # NOQA
+from cupy.cuda import driver  # NOQA
 from cupy.cuda import function  # NOQA
 from cupy.cuda import memory  # NOQA
 from cupy.cuda import memory_hook  # NOQA
@@ -15,7 +16,7 @@ from cupy.cuda import stream  # NOQA
 _available = None
 
 
-if runtime.runtimeGetVersion() >= 8000:
+if driver.get_build_version() >= 8000:
     from cupy.cuda import cusolver  # NOQA
     cusolver_enabled = True
 else:

--- a/cupy/cuda/__init__.py
+++ b/cupy/cuda/__init__.py
@@ -15,10 +15,10 @@ from cupy.cuda import stream  # NOQA
 _available = None
 
 
-try:
+if runtime.runtimeGetVersion() >= 8000:
     from cupy.cuda import cusolver  # NOQA
     cusolver_enabled = True
-except ImportError:
+else:
     cusolver_enabled = False
 
 try:


### PR DESCRIPTION
When cusolver has a bug and cupy fails to import cusolver, the error is ignored and reports wrong error. It is better to check CUDA version.