### PR TITLE
Fix matrix multiplication when matrixes have duplicated entries

### DIFF
--- a/cupy/cusparse.py
+++ b/cupy/cusparse.py
@@ -178,6 +178,7 @@ def csrmm2(a, b, c=None, alpha=1.0, beta=0.0, transa=False, transb=False):
 
     """
     assert a.ndim == b.ndim == 2
+    assert a.has_canonical_format
     assert b.flags.f_contiguous
     assert c is None or c.flags.f_contiguous
     assert not (transa and transb)
@@ -226,6 +227,8 @@ def csrgeam(a, b, alpha=1, beta=1):
         cupy.sparse.csr_matrix: Result matrix.
 
     """
+    assert a.has_canonical_format
+    assert b.has_canonical_format
     if a.shape != b.shape:
         raise ValueError('inconsistent shapes')
 
@@ -259,7 +262,9 @@ def csrgeam(a, b, alpha=1, beta=1):
         c_descr.descriptor, c_data.data.ptr, c_indptr.data.ptr,
         c_indices.data.ptr)
 
-    return cupy.sparse.csr_matrix((c_data, c_indices, c_indptr), shape=a.shape)
+    c = cupy.sparse.csr_matrix((c_data, c_indices, c_indptr), shape=a.shape)
+    c._has_canonical_format = True
+    return c
 
 
 def csrgemm(a, b, transa=False, transb=False):
@@ -279,6 +284,8 @@ def csrgemm(a, b, transa=False, transb=False):
 
     """
     assert a.ndim == b.ndim == 2
+    assert a.has_canonical_format
+    assert b.has_canonical_format
     a_shape = a.shape if not transa else a.shape[::-1]
     b_shape = b.shape if not transb else b.shape[::-1]
     if a_shape[1] != b_shape[0]:
@@ -320,7 +327,9 @@ def csrgemm(a, b, transa=False, transb=False):
         c_descr.descriptor, c_data.data.ptr, c_indptr.data.ptr,
         c_indices.data.ptr)
 
-    return cupy.sparse.csr_matrix((c_data, c_indices, c_indptr), shape=(m, n))
+    c = cupy.sparse.csr_matrix((c_data, c_indices, c_indptr), shape=(m, n))
+    c._has_canonical_format = True
+    return c
 
 
 def csr2dense(x, out=None):
@@ -545,7 +554,9 @@ def dense2csc(x):
         x.data.ptr, m, nnz_per_col.data.ptr,
         data.data.ptr, indices.data.ptr, indptr.data.ptr)
     # Note that a desciptor is recreated
-    return cupy.sparse.csc_matrix((data, indices, indptr), shape=x.shape)
+    csc = cupy.sparse.csc_matrix((data, indices, indptr), shape=x.shape)
+    csc._has_canonical_format = True
+    return csc
 
 
 def dense2csr(x):
@@ -582,7 +593,9 @@ def dense2csr(x):
         x.data.ptr, m, nnz_per_row.data.ptr,
         data.data.ptr, indptr.data.ptr, indices.data.ptr)
     # Note that a desciptor is recreated
-    return cupy.sparse.csr_matrix((data, indices, indptr), shape=x.shape)
+    csr = cupy.sparse.csr_matrix((data, indices, indptr), shape=x.shape)
+    csr._has_canonical_format = True
+    return csr
 
 
 def csr2csr_compress(x, tol):

--- a/cupy/sparse/csc.py
+++ b/cupy/sparse/csc.py
@@ -72,20 +72,28 @@ class csc_matrix(compressed._compressed_sparse_matrix):
 
     def __mul__(self, other):
         if cupy.isscalar(other):
+            self.sum_duplicates()
             return self._with_data(self.data * other)
         elif cupy.sparse.isspmatrix_csr(other):
+            self.sum_duplicates()
+            other.sum_duplicates()
             return cusparse.csrgemm(self.T, other, transa=True)
         elif isspmatrix_csc(other):
+            self.sum_duplicates()
+            other.sum_duplicates()
             return cusparse.csrgemm(self.T, other.T, transa=True, transb=True)
         elif cupy.sparse.isspmatrix(other):
-            return cusparse.csrgemm(self.T, other.tocsr(), transa=True)
+            return self * other.tocsr()
         elif cupy.sparse.base.isdense(other):
             if other.ndim == 0:
+                self.sum_duplicates()
                 return self._with_data(self.data * other)
             elif other.ndim == 1:
+                self.sum_duplicates()
                 return cusparse.csrmv(
                     self.T, cupy.asfortranarray(other), transa=True)
             elif other.ndim == 2:
+                self.sum_duplicates()
                 return cusparse.csrmm2(
                     self.T, cupy.asfortranarray(other), transa=True)
             else:
@@ -151,8 +159,9 @@ class csc_matrix(compressed._compressed_sparse_matrix):
 
     def _add_sparse(self, other, alpha, beta):
         self.sum_duplicates()
+        other = other.tocsc().T
         other.sum_duplicates()
-        return cusparse.csrgeam(self.T, other.tocsc().T, alpha, beta).T
+        return cusparse.csrgeam(self.T, other, alpha, beta).T
 
     # TODO(unno): Implement tobsr
 
@@ -221,8 +230,10 @@ class csc_matrix(compressed._compressed_sparse_matrix):
                 'swapping dimensions is the only logical permutation.')
 
         shape = self.shape[1], self.shape[0]
-        return cupy.sparse.csr_matrix(
+        trans = cupy.sparse.csr_matrix(
             (self.data, self.indices, self.indptr), shape=shape, copy=copy)
+        trans._has_canonical_format = self._has_canonical_format
+        return trans
 
 
 def isspmatrix_csc(x):

--- a/cupy/sparse/csr.py
+++ b/cupy/sparse/csr.py
@@ -73,8 +73,9 @@ class csr_matrix(compressed._compressed_sparse_matrix):
 
     def _add_sparse(self, other, alpha, beta):
         self.sum_duplicates()
+        other = other.tocsr()
         other.sum_duplicates()
-        return cusparse.csrgeam(self, other.tocsr(), alpha, beta)
+        return cusparse.csrgeam(self, other, alpha, beta)
 
     def __eq__(self, other):
         raise NotImplementedError
@@ -96,19 +97,27 @@ class csr_matrix(compressed._compressed_sparse_matrix):
 
     def __mul__(self, other):
         if cupy.isscalar(other):
+            self.sum_duplicates()
             return self._with_data(self.data * other)
         elif isspmatrix_csr(other):
+            self.sum_duplicates()
+            other.sum_duplicates()
             return cusparse.csrgemm(self, other)
         elif csc.isspmatrix_csc(other):
+            self.sum_duplicates()
+            other.sum_duplicates()
             return cusparse.csrgemm(self, other.T, transb=True)
         elif base.isspmatrix(other):
-            return cusparse.csrgemm(self, other.tocsr())
+            return self * other.tocsr()
         elif base.isdense(other):
             if other.ndim == 0:
+                self.sum_duplicates()
                 return self._with_data(self.data * other)
             elif other.ndim == 1:
+                self.sum_duplicates()
                 return cusparse.csrmv(self, cupy.asfortranarray(other))
             elif other.ndim == 2:
+                self.sum_duplicates()
                 return cusparse.csrmm2(self, cupy.asfortranarray(other))
             else:
                 raise ValueError('could not interpret dimensions')

--- a/cupy/sparse/csr.py
+++ b/cupy/sparse/csr.py
@@ -151,6 +151,7 @@ class csr_matrix(compressed._compressed_sparse_matrix):
         else:
             coo = self.tocoo()
             coo.eliminate_zeros()
+            # Because tocsr sums duplicated entries, it cannot keep nnz
             compress = coo.tocsr()
         self.data = compress.data
         self.indices = compress.indices

--- a/tests/cupy_tests/sparse_tests/test_csc.py
+++ b/tests/cupy_tests/sparse_tests/test_csc.py
@@ -349,7 +349,8 @@ class TestCscMatrixInit(unittest.TestCase):
 
 @testing.parameterize(*testing.product({
     'make_method': [
-        '_make', '_make_unordered', '_make_empty', '_make_shape'],
+        '_make', '_make_unordered', '_make_empty', '_make_duplicate',
+        '_make_shape'],
     'dtype': [numpy.float32, numpy.float64],
 }))
 @unittest.skipUnless(scipy_available, 'requires scipy')

--- a/tests/cupy_tests/sparse_tests/test_csc.py
+++ b/tests/cupy_tests/sparse_tests/test_csc.py
@@ -756,8 +756,17 @@ class TestCscMatrixScipyComparison(unittest.TestCase):
         m = self.make(xp, sp, self.dtype)
         m.transpose(axes=0)
 
-    @testing.numpy_cupy_equal(sp_name='sp')
+    @testing.numpy_cupy_allclose(sp_name='sp')
     def test_eliminate_zeros(self, xp, sp):
+        m = self.make(xp, sp, self.dtype)
+        m.eliminate_zeros()
+        return m.toarray()
+
+    @testing.numpy_cupy_equal(sp_name='sp')
+    @unittest.skipUnless(
+        cupy.cuda.runtime.runtimeGetVersion() < 8000,
+        'CUDA <8 cannot keep number of non-zero entries ')
+    def test_eliminate_zeros_nnz(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
         m.eliminate_zeros()
         return m.nnz

--- a/tests/cupy_tests/sparse_tests/test_csc.py
+++ b/tests/cupy_tests/sparse_tests/test_csc.py
@@ -763,7 +763,7 @@ class TestCscMatrixScipyComparison(unittest.TestCase):
         return m.toarray()
 
     @testing.numpy_cupy_equal(sp_name='sp')
-    @unittest.skipUnless(
+    @unittest.skipIf(
         cupy.cuda.runtime.runtimeGetVersion() < 8000,
         'CUDA <8 cannot keep number of non-zero entries ')
     def test_eliminate_zeros_nnz(self, xp, sp):

--- a/tests/cupy_tests/sparse_tests/test_csr.py
+++ b/tests/cupy_tests/sparse_tests/test_csr.py
@@ -803,8 +803,17 @@ class TestCsrMatrixScipyComparison(unittest.TestCase):
         m = self.make(xp, sp, self.dtype)
         m.transpose(axes=0)
 
-    @testing.numpy_cupy_equal(sp_name='sp')
+    @testing.numpy_cupy_allclose(sp_name='sp')
     def test_eliminate_zeros(self, xp, sp):
+        m = self.make(xp, sp, self.dtype)
+        m.eliminate_zeros()
+        return m.toarray()
+
+    @testing.numpy_cupy_equal(sp_name='sp')
+    @unittest.skipUnless(
+        cupy.cuda.runtime.runtimeGetVersion() < 8000,
+        'CUDA <8 cannot keep number of non-zero entries ')
+    def test_eliminate_zeros_nnz(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
         m.eliminate_zeros()
         return m.nnz

--- a/tests/cupy_tests/sparse_tests/test_csr.py
+++ b/tests/cupy_tests/sparse_tests/test_csr.py
@@ -810,7 +810,7 @@ class TestCsrMatrixScipyComparison(unittest.TestCase):
         return m.toarray()
 
     @testing.numpy_cupy_equal(sp_name='sp')
-    @unittest.skipUnless(
+    @unittest.skipIf(
         cupy.cuda.runtime.runtimeGetVersion() < 8000,
         'CUDA <8 cannot keep number of non-zero entries ')
     def test_eliminate_zeros_nnz(self, xp, sp):

--- a/tests/cupy_tests/sparse_tests/test_csr.py
+++ b/tests/cupy_tests/sparse_tests/test_csr.py
@@ -363,7 +363,8 @@ class TestCsrMatrixInit(unittest.TestCase):
 
 @testing.parameterize(*testing.product({
     'make_method': [
-        '_make', '_make_unordered', '_make_empty', '_make_shape'],
+        '_make', '_make_unordered', '_make_empty', '_make_duplicate',
+        '_make_shape'],
     'dtype': [numpy.float32, numpy.float64],
 }))
 @unittest.skipUnless(scipy_available, 'requires scipy')


### PR DESCRIPTION
When a sparse matrix has duplicated entries, matrix multiplication does not work correctly.
merge #833 first