### PR TITLE
Make a copy when SVD is calculated

### DIFF
--- a/cupy/linalg/decomposition.py
+++ b/cupy/linalg/decomposition.py
@@ -219,12 +219,14 @@ def svd(a, full_matrices=True, compute_uv=True):
     # Remark 3: gesvd returns matrix U and V^H
     # Remark 4: Remark 2 is removed since cuda 8.0 (new!)
     n, m = a.shape
+
+    # `a` must be copied because xgesvd destroys the matrix
     if m >= n:
-        x = a.astype(dtype, order='C', copy=False)
+        x = a.astype(dtype, order='C', copy=True)
         trans_flag = False
     else:
         m, n = a.shape
-        x = a.transpose().astype(dtype, order='C', copy=False)
+        x = a.transpose().astype(dtype, order='C', copy=True)
         trans_flag = True
     mn = min(m, n)
 

--- a/tests/cupy_tests/linalg_tests/test_decomposition.py
+++ b/tests/cupy_tests/linalg_tests/test_decomposition.py
@@ -92,8 +92,11 @@ class TestSVD(unittest.TestCase):
     @testing.numpy_cupy_allclose(atol=1e-4)
     def check_singular(self, array, xp, dtype):
         a = xp.asarray(array, dtype=dtype)
+        a_copy = a.copy()
         result = xp.linalg.svd(
             a, full_matrices=self.full_matrices, compute_uv=False)
+        # Check if the input matrix is not broken
+        assert (a == a_copy).all()
         return result
 
     def check_rank2(self, array):


### PR DESCRIPTION
Input matrixes are destroyed in SVD method of cuSOLVER.
fix #842