### PR TITLE
Add `cupyx.rsqrt`

### DIFF
--- a/cupyx/__init__.py
+++ b/cupyx/__init__.py
@@ -1,3 +1,3 @@
 # "NOQA" to suppress flake8 warning
-from cupyx.scatter import scatter_add  # NOQA
 from cupyx.rsqrt import rsqrt  # NOQA
+from cupyx.scatter import scatter_add  # NOQA

--- a/cupyx/__init__.py
+++ b/cupyx/__init__.py
@@ -1,2 +1,3 @@
 # "NOQA" to suppress flake8 warning
 from cupyx.scatter import scatter_add  # NOQA
+from cupyx.rsqrt import rsqrt  # NOQA

--- a/cupyx/rsqrt.py
+++ b/cupyx/rsqrt.py
@@ -1,0 +1,7 @@
+from cupy.core.core import create_ufunc
+
+rsqrt = create_ufunc(
+    'cupy_rsqrt',
+    ('e->e', 'f->f', 'd->d', 'F->F', 'D->D'),
+    'out0 = rsqrt(in0)',
+    doc='''Returns the reciprocal square root.''')

--- a/docs/source/reference/ext.rst
+++ b/docs/source/reference/ext.rst
@@ -7,4 +7,5 @@ CuPy-specific functions are placed under ``cupyx`` namespace.
    :toctree: generated/
    :nosignatures:
 
+   cupyx.rsqrt
    cupyx.scatter_add

--- a/tests/cupyx_tests/test_rsqrt.py
+++ b/tests/cupyx_tests/test_rsqrt.py
@@ -4,6 +4,7 @@ import numpy
 
 import cupy
 from cupy import testing
+import cupyx
 
 
 @testing.gpu
@@ -14,6 +15,6 @@ class TestRsqrt(unittest.TestCase):
     def test_rsqrt(self, dtype):
         # Adding 1.0 to avoid division by zero.
         a = testing.shaped_arange((2, 3), numpy, dtype) + 1.0
-        out = cupy.ext.rsqrt(cupy.array(a))
+        out = cupyx.rsqrt(cupy.array(a))
         # numpy.sqrt is broken in numpy<1.11.2
         testing.assert_allclose(out, 1.0 / numpy.sqrt(a))

--- a/tests/cupyx_tests/test_rsqrt.py
+++ b/tests/cupyx_tests/test_rsqrt.py
@@ -1,0 +1,19 @@
+import unittest
+
+import numpy
+
+import cupy
+from cupy import testing
+
+
+@testing.gpu
+class TestRsqrt(unittest.TestCase):
+
+    @testing.for_all_dtypes(no_complex=True)
+    @testing.with_requires('numpy>=1.11.2')
+    def test_rsqrt(self, dtype):
+        # Adding 1.0 to avoid division by zero.
+        a = testing.shaped_arange((2, 3), numpy, dtype) + 1.0
+        out = cupy.ext.rsqrt(cupy.array(a))
+        # numpy.sqrt is broken in numpy<1.11.2
+        testing.assert_allclose(out, 1.0 / numpy.sqrt(a))


### PR DESCRIPTION
This PR implements `cupy.rsqrt` as discussed in https://github.com/chainer/chainer/issues/4092.