### PR TITLE
Fix memory pool to correctly detect that memory pool is not established

### DIFF
--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -31,9 +31,7 @@ cdef inline _ensure_context(int device_id):
     if not hasattr(thread_local, 'seen_devices'):
         thread_local.seen_devices = set()
     if device_id not in thread_local.seen_devices:
-        try:
-            driver.ctxGetCurrent()
-        except driver.CUDADriverError:
+        if driver.ctxGetCurrent() == 0:
             # Call Runtime API to establish context on this host thread.
             runtime.memGetInfo()
         thread_local.seen_devices.add(device_id)

--- a/tests/cupy_tests/cuda_tests/test_driver.py
+++ b/tests/cupy_tests/cuda_tests/test_driver.py
@@ -1,3 +1,4 @@
+import threading
 import unittest
 
 import cupy
@@ -9,3 +10,27 @@ class TestDriver(unittest.TestCase):
         # Make sure to create context.
         cupy.arange(1)
         self.assertNotEqual(0, driver.ctxGetCurrent())
+
+    def test_ctxGetCurrent_thread(self):
+        # Make sure to create context in main thread.
+        cupy.arange(1)
+
+        def f(self):
+            self._result0 = driver.ctxGetCurrent()
+            cupy.arange(1)
+            self._result1 = driver.ctxGetCurrent()
+
+        self._result0 = None
+        self._result1 = None
+        t = threading.Thread(target=f, args=(self,))
+        t.daemon = True
+        t.start()
+        t.join()
+
+        # The returned context pointer must be NULL on sub thread
+        # without valid context.
+        self.assertEqual(0, self._result0)
+
+        # After the context is created, it should return the valid
+        # context pointer.
+        self.assertNotEqual(0, self._result1)

--- a/tests/cupy_tests/cuda_tests/test_memory.py
+++ b/tests/cupy_tests/cuda_tests/test_memory.py
@@ -485,11 +485,20 @@ class TestAllocator(unittest.TestCase):
             self.assertEqual(1024, self.pool.used_bytes())
 
     def test_reuse_between_thread(self):
-        def job():
+        def job(self):
             cupy.arange(16)
+            self._error = False
 
+        # Run in main thread.
+        self._error = True
+        job(self)
+        self.assertFalse(self._error)
+
+        # Run in sub thread.
+        self._error = True
         with cupy.cuda.Device(0):
-            t = threading.Thread(target=job)
+            t = threading.Thread(target=job, args=(self,))
+            t.daemon = True
             t.start()
             t.join()
-            job()
+        self.assertFalse(self._error)


### PR DESCRIPTION
When context is initialized in main thread, but not in sub thread, `ctxGetCurrent` returns:
*  valid pointer in main thread
* `0` in sub thread

Related to #72.