### PR TITLE
Implement coo initializer for scipy sparse matrix

### DIFF
--- a/cupy/sparse/coo.py
+++ b/cupy/sparse/coo.py
@@ -74,6 +74,18 @@ class coo_matrix(sparse_data._data_matrix):
             copy = False
             has_canonical_format = True
 
+        elif _scipy_available and scipy.sparse.issparse(arg1):
+            # Convert scipy.sparse to cupy.sparse
+            x = arg1.tocoo()
+            data = cupy.array(x.data)
+            row = cupy.array(x.row, dtype='i')
+            col = cupy.array(x.col, dtype='i')
+            copy = False
+
+            if shape is None:
+                shape = arg1.shape
+            has_canonical_format = x.has_canonical_format
+
         elif isinstance(arg1, tuple) and len(arg1) == 2:
             try:
                 data, (row, col) = arg1

--- a/tests/cupy_tests/sparse_tests/test_coo.py
+++ b/tests/cupy_tests/sparse_tests/test_coo.py
@@ -119,6 +119,30 @@ class TestCooMatrix(unittest.TestCase):
         n = cupy.sparse.coo_matrix(self.m.tocsr())
         cupy.testing.assert_array_equal(n.toarray(), self.m.toarray())
 
+    @unittest.skipUnless(scipy_available, 'requires scipy')
+    def test_init_copy_scipy_sparse(self):
+        m = _make(numpy, scipy.sparse, self.dtype)
+        n = cupy.sparse.coo_matrix(m)
+        self.assertIsInstance(n.data, cupy.ndarray)
+        self.assertIsInstance(n.row, cupy.ndarray)
+        self.assertIsInstance(n.col, cupy.ndarray)
+        cupy.testing.assert_array_equal(n.data, m.data)
+        cupy.testing.assert_array_equal(n.row, m.row)
+        cupy.testing.assert_array_equal(n.col, m.col)
+        self.assertEqual(n.shape, m.shape)
+
+    @unittest.skipUnless(scipy_available, 'requires scipy')
+    def test_init_copy_other_scipy_sparse(self):
+        m = _make(numpy, scipy.sparse, self.dtype)
+        n = cupy.sparse.coo_matrix(m.tocsc())
+        self.assertIsInstance(n.data, cupy.ndarray)
+        self.assertIsInstance(n.row, cupy.ndarray)
+        self.assertIsInstance(n.col, cupy.ndarray)
+        cupy.testing.assert_array_equal(n.data, m.data)
+        cupy.testing.assert_array_equal(n.row, m.row)
+        cupy.testing.assert_array_equal(n.col, m.col)
+        self.assertEqual(n.shape, m.shape)
+
     def test_shape(self):
         self.assertEqual(self.m.shape, (3, 4))
 


### PR DESCRIPTION
With this patch, coo matrix supports initializer with scipy sparse matrix.