### PR TITLE
[backport] Fix return type of linalg.norm for complex input

### DIFF
--- a/tests/cupy_tests/linalg_tests/test_norms.py
+++ b/tests/cupy_tests/linalg_tests/test_norms.py
@@ -53,7 +53,7 @@ class TestNorm(unittest.TestCase):
 
     _multiprocess_can_split_ = True
 
-    @testing.for_all_dtypes(no_complex=True)
+    @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-4)
     def test_norm(self, xp, dtype):
         a = testing.shaped_arange(self.shape, xp, dtype)


### PR DESCRIPTION
Backport of #781