### PR TITLE
fix potential error at the stride for loop over the j-axis in RedutionKernel

### DIFF
--- a/cupy/core/reduction.pxi
+++ b/cupy/core/reduction.pxi
@@ -31,8 +31,8 @@ cpdef _get_simple_reduction_kernel(
 
       int _J_offset = _tid / _block_stride;
       int _j_offset = _J_offset * _out_ind.size();
-      int _J_stride = ${block_size};
-      long long _j_stride = ${block_size}LL * _out_ind.size();
+      int _J_stride = ${block_size} / _block_stride;
+      long long _j_stride = (long long)_J_stride * _out_ind.size();
 
       for (int _i_base = blockIdx.x * _block_stride;
            _i_base < _out_ind.size();


### PR DESCRIPTION
The j-stride of the loop should be `block_size / block_stride` instead of `block_size`,  where `block_stride` is the length of a block for the direction of i-axis.

Currently this error hasn't caused bug, because the current blocking strategy is to minimize `block_stride` and avoid the loop over j-axis. So if the loop is still required, `block_stride` has been always 1.

But it causes bug if the blocking strategy is changed. Furthermore, it is very confusing for those who read the code. I believe the error is very harmful for maintainability.