### PR TITLE
[backport] fix docs to use NumPy 1.14 textual representation

### DIFF
--- a/cupy/ext/scatter.py
+++ b/cupy/ext/scatter.py
@@ -24,7 +24,7 @@ def scatter_add(a, slices, value):
     >>> v = cupy.array([1., 1., 1.])
     >>> cupy.scatter_add(a, i, v);
     >>> a
-    array([ 1.,  2.,  0.,  0.,  0.,  0.], dtype=float32)
+    array([1., 2., 0., 0., 0., 0.], dtype=float32)
 
     Args:
         a (ndarray): An array that gets added.

--- a/docs/source/reference/difference.rst
+++ b/docs/source/reference/difference.rst
@@ -77,7 +77,7 @@ last element among elements referencing duplicate locations.
   >>> v_cpu = np.arange(10000).astype(np.float)
   >>> a_cpu[i_cpu] = v_cpu
   >>> a_cpu
-  array([ 9998.,  9999.])
+  array([9998., 9999.])
 
 
 Reduction methods return zero-dimensional array

--- a/docs/source/tutorial/kernel.rst
+++ b/docs/source/tutorial/kernel.rst
@@ -38,11 +38,11 @@ The above kernel can be called on either scalars or arrays with broadcasting:
    >>> x = cp.arange(10, dtype=np.float32).reshape(2, 5)
    >>> y = cp.arange(5, dtype=np.float32)
    >>> squared_diff(x, y)
-   array([[  0.,   0.,   0.,   0.,   0.],
-          [ 25.,  25.,  25.,  25.,  25.]], dtype=float32)
+   array([[ 0.,  0.,  0.,  0.,  0.],
+          [25., 25., 25., 25., 25.]], dtype=float32)
    >>> squared_diff(x, 5)
-   array([[ 25.,  16.,   9.,   4.,   1.],
-          [  0.,   1.,   4.,   9.,  16.]], dtype=float32)
+   array([[25., 16.,  9.,  4.,  1.],
+          [ 0.,  1.,  4.,  9., 16.]], dtype=float32)
 
 Output arguments can be explicitly specified (next to the input arguments):
 
@@ -50,8 +50,8 @@ Output arguments can be explicitly specified (next to the input arguments):
 
    >>> z = cp.empty((2, 5), dtype=np.float32)
    >>> squared_diff(x, y, z)
-   array([[  0.,   0.,   0.,   0.,   0.],
-          [ 25.,  25.,  25.,  25.,  25.]], dtype=float32)
+   array([[ 0.,  0.,  0.,  0.,  0.],
+          [25., 25., 25., 25., 25.]], dtype=float32)
 
 
 Type-generic kernels
@@ -161,7 +161,7 @@ For example, L2 norm along specified axes can be written as follows:
    ... )
    >>> x = cp.arange(10, dtype='f').reshape(2, 5)
    >>> l2norm_kernel(x, axis=1)
-   array([  5.47722578,  15.96871948], dtype=float32)
+   array([ 5.477226 , 15.9687195], dtype=float32)
 
 .. note::
    ``raw`` specifier is restricted for usages that the axes to be reduced are put at the head of the shape.


### PR DESCRIPTION
Backport of #876