### PR TITLE
fix array iteration index overflow

### DIFF
--- a/cupy/core/include/cupy/carray.cuh
+++ b/cupy/core/include/cupy/carray.cuh
@@ -278,9 +278,10 @@ __device__ int signbit(float16 x) {return x.signbit();}
 
 // CArray
 #define CUPY_FOR(i, n) \
-    for (ptrdiff_t i = blockIdx.x * blockDim.x + threadIdx.x; \
+    for (ptrdiff_t i = \
+            static_cast<ptrdiff_t>(blockIdx.x) * blockDim.x + threadIdx.x; \
          i < (n); \
-         i += blockDim.x * gridDim.x)
+         i += static_cast<ptrdiff_t>(blockDim.x) * gridDim.x)
 
 template <typename T, int _ndim>
 class CArray {

--- a/tests/cupy_tests/core_tests/test_carray.py
+++ b/tests/cupy_tests/core_tests/test_carray.py
@@ -57,6 +57,9 @@ class TestCArray(unittest.TestCase):
 )
 @testing.slow
 class TestCArray32BitBoundary(unittest.TestCase):
+    # This test case is intended to confirm CArray indexing work correctly
+    # with arrays whose size is so large that it crosses the 32-bit boundary.
+    # See https://github.com/cupy/cupy/pull/882 for detailed discussions.
     def test(self):
         # Elementwise
         a = cupy.ones(self.size, dtype='b')

--- a/tests/cupy_tests/core_tests/test_carray.py
+++ b/tests/cupy_tests/core_tests/test_carray.py
@@ -45,3 +45,21 @@ class TestCArray(unittest.TestCase):
             'test_carray_getitem_idx',
         )(x, y)
         testing.assert_array_equal(y, x)
+
+
+@testing.parameterize(
+    {"size": 2 ** 32 + 1024},
+    {"size": 2 ** 32},
+    {"size": 2 ** 32 - 1024},
+    {"size": 2 ** 31 + 1024},
+    {"size": 2 ** 31},
+    {"size": 2 ** 31 - 1024},
+)
+@testing.slow
+class TestCArray32BitBoundary(unittest.TestCase):
+    def test(self):
+        # Elementwise
+        a = cupy.ones(self.size, dtype='b')
+        # Reduction
+        result = a.sum()
+        self.assertEqual(self.size, result)


### PR DESCRIPTION
This fixes #854.

The minimum code to reproduce this issue is:

```py
# This is the minimum number of elements to reproduce this issue, since block_max_size == 128
size = 2 ** 32 - 127

a = cupy.ndarray((size,), dtype='b')
f = cupy.core.create_ufunc('test', ('b->b',), 'out0 = in0;')

# This triggers infinite-loop on GPU.
out = f(a)
```

The computation `blockDim.x * gridDim.x` (both are typed as `unsigned int`) overflows and becomes 0, which makes CUPY_FOR run forever.