### PR TITLE
Fix cupy.size overflow in 32-bit

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2654,7 +2654,7 @@ cdef _concatenate_kernel = ElementwiseKernel(
 )
 
 
-cpdef int size(ndarray a, axis=None) except *:
+cpdef Py_ssize_t size(ndarray a, axis=None) except *:
     """Returns the number of elements along a given axis.
 
     Args:

--- a/tests/cupy_tests/core_tests/test_core.py
+++ b/tests/cupy_tests/core_tests/test_core.py
@@ -2,6 +2,7 @@ import unittest
 
 import cupy
 from cupy.core import core
+from cupy import testing
 
 
 class TestGetStridesForNocopyReshape(unittest.TestCase):
@@ -19,3 +20,30 @@ class TestGetStridesForNocopyReshape(unittest.TestCase):
     def test_normal(self):
         # TODO(nno): write test for normal case
         pass
+
+
+class TestSize(unittest.TestCase):
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_equal()
+    def test_size(self, xp, dtype):
+        a = xp.ndarray((2, 3), dtype=dtype)
+        return xp.size(a)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_equal()
+    def test_size_axis(self, xp, dtype):
+        a = xp.ndarray((2, 3), dtype=dtype)
+        return xp.size(a, axis=1)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_raises()
+    def test_size_axis_error(self, xp, dtype):
+        a = xp.ndarray((2, 3), dtype=dtype)
+        return xp.size(a, axis=3)
+
+    @testing.numpy_cupy_equal()
+    @testing.slow
+    def test_size_huge(self, xp):
+        a = xp.ndarray(2 ** 32, 'b')  # 4 GiB
+        return xp.size(a)


### PR DESCRIPTION
This fixes the overflow in `cupy.size`.

```py
>>> a = cupy.ndarray(2 ** 32, 'b')  # 4 GiB
>>> cupy.size(a)
0
```