### PR TITLE
accept None in set_allocator and set_pinned_memory_allocator

### DIFF
--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -439,17 +439,20 @@ cpdef MemoryPointer alloc(Py_ssize_t size):
     return _current_allocator(size)
 
 
-cpdef set_allocator(allocator=_malloc):
+cpdef set_allocator(allocator=None):
     """Sets the current allocator.
 
     Args:
         allocator (function): CuPy memory allocator. It must have the same
             interface as the :func:`cupy.cuda.alloc` function, which takes the
             buffer size as an argument and returns the device buffer of that
-            size.
+            size. When ``None`` is specified, the default memory allocator
+            is used (i.e., memory pool is disabled).
 
     """
     global _current_allocator
+    if allocator is None:
+        allocator = _malloc
     _current_allocator = allocator
 
 

--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -446,8 +446,8 @@ cpdef set_allocator(allocator=None):
         allocator (function): CuPy memory allocator. It must have the same
             interface as the :func:`cupy.cuda.alloc` function, which takes the
             buffer size as an argument and returns the device buffer of that
-            size. When ``None`` is specified, the default memory allocator
-            is used (i.e., memory pool is disabled).
+            size. When ``None`` is specified, raw memory allocator will be
+            used (i.e., memory pool is disabled).
 
     """
     global _current_allocator

--- a/cupy/cuda/pinned_memory.pyx
+++ b/cupy/cuda/pinned_memory.pyx
@@ -211,17 +211,20 @@ cpdef PinnedMemoryPointer alloc_pinned_memory(Py_ssize_t size):
     return _current_allocator(size)
 
 
-cpdef set_pinned_memory_allocator(allocator=_malloc):
+cpdef set_pinned_memory_allocator(allocator=None):
     """Sets the current allocator.
 
     Args:
         allocator (function): CuPy pinned memory allocator. It must have the
             same interface as the :func:`cupy.cuda.alloc_alloc_pinned_memory`
             function, which takes the buffer size as an argument and returns
-            the device buffer of that size.
+            the device buffer of that size. When ``None`` is specified, the
+            default memory allocator is used (i.e., memory pool is disabled).
 
     """
     global _current_allocator
+    if allocator is None:
+        allocator = _malloc
     _current_allocator = allocator
 
 

--- a/cupy/cuda/pinned_memory.pyx
+++ b/cupy/cuda/pinned_memory.pyx
@@ -218,8 +218,8 @@ cpdef set_pinned_memory_allocator(allocator=None):
         allocator (function): CuPy pinned memory allocator. It must have the
             same interface as the :func:`cupy.cuda.alloc_alloc_pinned_memory`
             function, which takes the buffer size as an argument and returns
-            the device buffer of that size. When ``None`` is specified, the
-            default memory allocator is used (i.e., memory pool is disabled).
+            the device buffer of that size. When ``None`` is specified, raw
+            memory allocator is used (i.e., memory pool is disabled).
 
     """
     global _current_allocator

--- a/tests/cupy_tests/cuda_tests/test_memory.py
+++ b/tests/cupy_tests/cuda_tests/test_memory.py
@@ -518,6 +518,7 @@ class TestAllocatorDefault(unittest.TestCase):
         with cupy.cuda.Device(0):
             arr = cupy.arange(128, dtype=cupy.int64)
             self.assertEqual(0, self.pool.used_bytes() - used_bytes)
+            del arr
 
     def test(self):
         memory.set_allocator()

--- a/tests/cupy_tests/cuda_tests/test_memory.py
+++ b/tests/cupy_tests/cuda_tests/test_memory.py
@@ -502,3 +502,27 @@ class TestAllocator(unittest.TestCase):
             t.start()
             t.join()
         self.assertFalse(self._error)
+
+
+@testing.gpu
+class TestAllocatorDefault(unittest.TestCase):
+
+    def setUp(self):
+        self.pool = cupy.get_default_memory_pool()
+
+    def tearDown(self):
+        memory.set_allocator(self.pool.malloc)
+
+    def _check_pool_not_used(self):
+        used_bytes = self.pool.used_bytes()
+        with cupy.cuda.Device(0):
+            arr = cupy.arange(128, dtype=cupy.int64)
+            self.assertEqual(0, self.pool.used_bytes() - used_bytes)
+
+    def test(self):
+        memory.set_allocator()
+        self._check_pool_not_used()
+
+    def test_none(self):
+        memory.set_allocator(None)
+        self._check_pool_not_used()


### PR DESCRIPTION
This changes these two methods to accept `None` as an argument.
When `None` is specified, it uses the default allocator (i.e., no memory pool.)

During the discussion with @sonots san, we found that `set_allocator()` sounds like resetting the memory allocator to the "default" one.
As CuPy v4 introduced default memory pool, I want to make this API more explicit.
After merging this PR, users can disable the memory pool using `set_allocator(None)`, which is more explicit and easy to understand than `set_allocator()` for users.

For backward compatibility, `set_allocator()` is still kept.