### PR TITLE
Fix memory allocator docs

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -554,28 +554,30 @@ cuda.set_pinned_memory_allocator(_default_pinned_memory_pool.malloc)
 
 
 def get_default_memory_pool():
-    """Returns CuPy default memory pool.
+    """Returns CuPy default memory pool for GPU memory.
 
     Returns:
-        cupy.cuda.MemoryPool: it is memory pool object.
+        cupy.cuda.MemoryPool: The memory pool object.
 
     .. note::
        If you want to disable memory pool, please use the following code.
-       >>> cupy.cuda.set_allocator()
+
+       >>> cupy.cuda.set_allocator(None)
 
     """
     return _default_memory_pool
 
 
 def get_default_pinned_memory_pool():
-    """Returns CuPy default memory pool.
+    """Returns CuPy default memory pool for pinned memory.
 
     Returns:
-        cupy.cuda.MemoryPool: it is memory pool object.
+        cupy.cuda.PinnedMemoryPool: The memory pool object.
 
     .. note::
        If you want to disable memory pool, please use the following code.
-       >>> cupy.cuda.set_pinned_memory_allocator()
+
+       >>> cupy.cuda.set_pinned_memory_allocator(None)
 
     """
     return _default_pinned_memory_pool

--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -440,7 +440,7 @@ cpdef MemoryPointer alloc(Py_ssize_t size):
 
 
 cpdef set_allocator(allocator=None):
-    """Sets the current allocator.
+    """Sets the current allocator for GPU memory.
 
     Args:
         allocator (function): CuPy memory allocator. It must have the same
@@ -883,7 +883,7 @@ cdef class SingleDeviceMemoryPool:
 
 cdef class MemoryPool(object):
 
-    """Memory pool for all devices on the machine.
+    """Memory pool for all GPU devices on the host.
 
     A memory pool preserves any allocations even if they are freed by the user.
     Freed memory buffers are held by the memory pool as *free blocks*, and they

--- a/cupy/cuda/pinned_memory.pyx
+++ b/cupy/cuda/pinned_memory.pyx
@@ -212,11 +212,11 @@ cpdef PinnedMemoryPointer alloc_pinned_memory(Py_ssize_t size):
 
 
 cpdef set_pinned_memory_allocator(allocator=None):
-    """Sets the current allocator.
+    """Sets the current allocator for the pinned memory.
 
     Args:
         allocator (function): CuPy pinned memory allocator. It must have the
-            same interface as the :func:`cupy.cuda.alloc_alloc_pinned_memory`
+            same interface as the :func:`cupy.cuda.alloc_pinned_memory`
             function, which takes the buffer size as an argument and returns
             the device buffer of that size. When ``None`` is specified, raw
             memory allocator is used (i.e., memory pool is disabled).
@@ -260,7 +260,7 @@ class PooledPinnedMemory(PinnedMemory):
 
 cdef class PinnedMemoryPool:
 
-    """Memory pool on the host.
+    """Memory pool for pinned memory on the host.
 
     Note that it preserves all allocated memory buffers even if the user
     explicitly release the one. Those released memory buffers are held by the

--- a/docs/source/reference/cuda.rst
+++ b/docs/source/reference/cuda.rst
@@ -18,11 +18,15 @@ Memory management
    :toctree: generated/
    :nosignatures:
 
+   cupy.get_default_memory_pool
+   cupy.get_default_pinned_memory_pool
    cupy.cuda.Memory
    cupy.cuda.MemoryPointer
    cupy.cuda.alloc
    cupy.cuda.set_allocator
+   cupy.cuda.set_pinned_memory_allocator
    cupy.cuda.MemoryPool
+   cupy.cuda.PinnedMemoryPool
 
 
 Memory hook


### PR DESCRIPTION
This PR exposes some useful memory allocator APIs to documents.
Also includes fixes for some typos.

~~This PR assumes https://github.com/cupy/cupy/pull/885 will be merged.~~ (done)