### PR TITLE
emit DeprecationWarning instead of error for new null stream

### DIFF
--- a/tests/cupy_tests/cuda_tests/test_stream.py
+++ b/tests/cupy_tests/cuda_tests/test_stream.py
@@ -7,6 +7,17 @@ from cupy.testing import attr
 
 
 class TestStream(unittest.TestCase):
+
+    @attr.gpu
+    def test_eq(self):
+        null0 = cuda.Stream.null
+        with testing.assert_warns(DeprecationWarning):
+            null1 = cuda.Stream(True)
+            null2 = cuda.Stream(True)
+
+        self.assertEqual(null0, null1)
+        self.assertEqual(null1, null2)
+
     @attr.gpu
     def test_del(self):
         stream = cuda.Stream().use()


### PR DESCRIPTION
During the discussion with @niboshi san and @sonots san, we concluded that it is better to keep backward compatibility for null Stream creation, as null Stream is used in some of the user code.

After mergin this PR, creation of new null stream emits DeprecationWarning, instead of raising error.

This issue was first intorduced in https://github.com/cupy/cupy/pull/306 (no backport needed)