### PR TITLE
avoid emitting DeprecationWarning when creating a new null stream object

### DIFF
--- a/cupy/cuda/stream.pyx
+++ b/cupy/cuda/stream.pyx
@@ -137,8 +137,8 @@ class Stream(object):
     Args:
         null (bool): If ``True``, the stream is a null stream (i.e. the default
             stream that synchronizes with all streams). Otherwise, a plain new
-            stream is created. Users must not use this parameter, instead, use
-            ``Stream.null`` object to use the default stream.
+            stream is created. Note that you can also use ``Stream.null``
+            singleton object instead of creating new null stream object.
         non_blocking (bool): If ``True``, the stream does not synchronize with
             the NULL stream.
 
@@ -151,11 +151,6 @@ class Stream(object):
     null = None
 
     def __init__(self, null=False, non_blocking=False):
-        if null and Stream.null:
-            warnings.warn(
-                'Creation of new null stream object is deprecated. '
-                'Use cupy.cuda.Stream.null instead.',
-                DeprecationWarning)
         if null:
             self.ptr = 0
         elif non_blocking:

--- a/tests/cupy_tests/cuda_tests/test_stream.py
+++ b/tests/cupy_tests/cuda_tests/test_stream.py
@@ -11,9 +11,8 @@ class TestStream(unittest.TestCase):
     @attr.gpu
     def test_eq(self):
         null0 = cuda.Stream.null
-        with testing.assert_warns(DeprecationWarning):
-            null1 = cuda.Stream(True)
-            null2 = cuda.Stream(True)
+        null1 = cuda.Stream(True)
+        null2 = cuda.Stream(True)
 
         self.assertEqual(null0, null1)
         self.assertEqual(null1, null2)

--- a/tests/cupy_tests/cuda_tests/test_stream.py
+++ b/tests/cupy_tests/cuda_tests/test_stream.py
@@ -13,9 +13,11 @@ class TestStream(unittest.TestCase):
         null0 = cuda.Stream.null
         null1 = cuda.Stream(True)
         null2 = cuda.Stream(True)
+        null3 = cuda.Stream()
 
         self.assertEqual(null0, null1)
         self.assertEqual(null1, null2)
+        self.assertNotEqual(null2, null3)
 
     @attr.gpu
     def test_del(self):


### PR DESCRIPTION
As we discussed in https://github.com/cupy/cupy/pull/888, Stream(null=True) should not emit warnings.