### PR TITLE
fix downcast of size in CArray and CIndexer

### DIFF
--- a/cupy/core/include/cupy/carray.cuh
+++ b/cupy/core/include/cupy/carray.cuh
@@ -293,7 +293,7 @@ private:
   ptrdiff_t strides_[ndim];
 
 public:
-  __device__ int size() const {
+  __device__ ptrdiff_t size() const {
     return size_;
   }
 
@@ -346,7 +346,7 @@ private:
 public:
   static const int ndim = 0;
 
-  __device__ int size() const {
+  __device__ ptrdiff_t size() const {
     return size_;
   }
 
@@ -424,7 +424,7 @@ private:
 public:
   static const int ndim = 0;
 
-  __device__ int size() const {
+  __device__ ptrdiff_t size() const {
     return size_;
   }
 


### PR DESCRIPTION
This PR fixes unintended downcast of `size()` from `ptrdiff_t` to `int`.
This affects some functions when processing array with number of elements >= 2^31.

For example, before applying this PR:

```py
>>> import cupy as cp
>>> a = cp.ones(2**31, dtype='b')
>>> cp.core.core.scan(a)
array([0, 0, 0, ..., 0, 0, 0], dtype=int8)
```

After applying this PR, the above code should work as expected:

```py
array([ 1,  2,  3, ..., -2, -1,  0], dtype=int8)
```