### PR TITLE
Support wheel build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ dist/
 htmlcov/
 .idea/
 .cache/
+cupy/_lib/

--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -9,7 +9,6 @@ from distutils import unixccompiler
 import os
 from os import path
 import shutil
-import subprocess
 import sys
 
 import pkg_resources

--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -8,6 +8,8 @@ from distutils import sysconfig
 from distutils import unixccompiler
 import os
 from os import path
+import shutil
+import subprocess
 import sys
 
 import pkg_resources
@@ -320,6 +322,15 @@ def preconfigure_modules(compiler, settings):
     return ret
 
 
+def _rpath_base():
+    if sys.platform.startswith('linux'):
+        return '$ORIGIN'
+    elif sys.platform.startswith('darwin'):
+        return '@loader_path'
+    else:
+        raise Exception('not supported on this platform')
+
+
 def make_extensions(options, compiler, use_cython):
     """Produce a list of Extension instances which passed to cythonize()."""
 
@@ -332,15 +343,9 @@ def make_extensions(options, compiler, use_cython):
         x for x in include_dirs if path.exists(x)]
     settings['library_dirs'] = [
         x for x in settings['library_dirs'] if path.exists(x)]
-    if sys.platform != 'win32':
-        settings['runtime_library_dirs'] = settings['library_dirs']
-    if sys.platform == 'darwin':
-        args = settings.setdefault('extra_link_args', [])
-        args.append(
-            '-Wl,' + ','.join('-rpath,' + p
-                              for p in settings['library_dirs']))
-        # -rpath is only supported when targetting Mac OS X 10.5 or later
-        args.append('-mmacosx-version-min=10.5')
+
+    # Adjust rpath to use CUDA libraries in `cupy/_lib/*.so`) from CuPy.
+    use_wheel_libs_rpath = 'wheel_libs' in options
 
     # This is a workaround for Anaconda.
     # Anaconda installs libstdc++ from GCC 4.8 and it is not compatible
@@ -391,6 +396,23 @@ def make_extensions(options, compiler, use_cython):
                 compile_args.append('/openmp')
 
         for f in module['file']:
+            rpath = list(s['library_dirs'])  # copy
+            if use_wheel_libs_rpath:
+                modname = f[0] if isinstance(f, tuple) else f
+                depth = modname.count('.') - 1
+                rpath.append('{}{}/_lib'.format(_rpath_base(), '/..' * depth))
+
+            if sys.platform != 'win32':
+                s['runtime_library_dirs'] = rpath
+            if sys.platform == 'darwin':
+                args = s.setdefault('extra_link_args', [])
+                args.append(
+                    '-Wl,' + ','.join('-rpath,' + p
+                                      for p in s['library_dirs']))
+                # -rpath is only supported when targetting Mac OS X 10.5 or
+                # later
+                args.append('-mmacosx-version-min=10.5')
+
             name = module_extension_name(f)
             sources = module_extension_sources(f, use_cython, no_cuda)
             extension = setuptools.Extension(name, sources, **s)
@@ -402,6 +424,13 @@ def make_extensions(options, compiler, use_cython):
 def parse_args():
     parser = argparse.ArgumentParser(add_help=False)
 
+    parser.add_argument(
+        '--cupy-package-name', type=str, default='cupy',
+        help='alternate package name')
+    parser.add_argument(
+        '--cupy-wheel-lib', type=str, action='append', default=[],
+        help='shared library to copy into the wheel '
+             '(can be specified for multiple times)')
     parser.add_argument(
         '--cupy-profile', action='store_true', default=False,
         help='enable profiling for Cython code')
@@ -415,6 +444,8 @@ def parse_args():
     opts, sys.argv = parser.parse_known_args(sys.argv)
 
     arg_options = {
+        'package_name': opts.cupy_package_name,
+        'wheel_libs': opts.cupy_wheel_lib,  # list
         'profile': opts.cupy_profile,
         'linetrace': opts.cupy_coverage,
         'annotate': opts.cupy_coverage,
@@ -427,6 +458,32 @@ def parse_args():
 
 cupy_setup_options = parse_args()
 print('Options:', cupy_setup_options)
+
+
+def get_package_name():
+    return cupy_setup_options['package_name']
+
+
+def prepare_wheel_libs():
+    libs = []
+    libdir = 'cupy/_lib'
+
+    # Clean up the library directory.
+    if os.path.exists(libdir):
+        print("Removing directory: {}".format(libdir))
+        shutil.rmtree(libdir)
+    os.mkdir(libdir)
+
+    # Copy specified libraries to the library directory.
+    for lib in cupy_setup_options['wheel_libs']:
+        # Note: symlink is resolved by shutil.copy2.
+        print("Copying library for wheel: {}".format(lib))
+        libname = path.basename(lib)
+        libpath = '{}/{}'.format(libdir, libname)
+        shutil.copy2(lib, libpath)
+        libs.append('_lib/{}'.format(libname))
+    return libs
+
 
 try:
     import Cython

--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -1,4 +1,6 @@
 from __future__ import print_function
+
+import argparse
 from distutils import ccompiler
 from distutils import errors
 from distutils import msvccompiler
@@ -398,21 +400,25 @@ def make_extensions(options, compiler, use_cython):
 
 
 def parse_args():
-    cupy_profile = '--cupy-profile' in sys.argv
-    if cupy_profile:
-        sys.argv.remove('--cupy-profile')
-    cupy_coverage = '--cupy-coverage' in sys.argv
-    if cupy_coverage:
-        sys.argv.remove('--cupy-coverage')
-    no_cuda = '--cupy-no-cuda' in sys.argv
-    if no_cuda:
-        sys.argv.remove('--cupy-no-cuda')
+    parser = argparse.ArgumentParser(add_help=False)
+
+    parser.add_argument(
+        '--cupy-profile', action='store_true', default=False,
+        help='enable profiling for Cython code')
+    parser.add_argument(
+        '--cupy-coverage', action='store_true', default=False,
+        help='enable coverage for Cython code')
+    parser.add_argument(
+        '--cupy-no-cuda', action='store_true', default=False,
+        help='build CuPy with stub header file')
+
+    opts, sys.argv = parser.parse_known_args(sys.argv)
 
     arg_options = {
-        'profile': cupy_profile,
-        'linetrace': cupy_coverage,
-        'annotate': cupy_coverage,
-        'no_cuda': no_cuda,
+        'profile': opts.cupy_profile,
+        'linetrace': opts.cupy_coverage,
+        'annotate': opts.cupy_coverage,
+        'no_cuda': opts.cupy_no_cuda,
     }
     if check_readthedocs_environment():
         arg_options['no_cuda'] = True

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,37 @@ install_requires = [
     'fastrlock>=0.3',
 ]
 
+package_data = {
+    'cupy': [
+        'core/include/cupy/complex/arithmetic.h',
+        'core/include/cupy/complex/catrig.h',
+        'core/include/cupy/complex/catrigf.h',
+        'core/include/cupy/complex/ccosh.h',
+        'core/include/cupy/complex/ccoshf.h',
+        'core/include/cupy/complex/cexp.h',
+        'core/include/cupy/complex/cexpf.h',
+        'core/include/cupy/complex/clog.h',
+        'core/include/cupy/complex/clogf.h',
+        'core/include/cupy/complex/complex.h',
+        'core/include/cupy/complex/complex_inl.h',
+        'core/include/cupy/complex/cpow.h',
+        'core/include/cupy/complex/cproj.h',
+        'core/include/cupy/complex/csinh.h',
+        'core/include/cupy/complex/csinhf.h',
+        'core/include/cupy/complex/csqrt.h',
+        'core/include/cupy/complex/csqrtf.h',
+        'core/include/cupy/complex/ctanh.h',
+        'core/include/cupy/complex/ctanhf.h',
+        'core/include/cupy/complex/math_private.h',
+        'core/include/cupy/carray.cuh',
+        'core/include/cupy/complex.cuh',
+        'cuda/cupy_thrust.cu',
+    ],
+}
+
+package_data['cupy'] += cupy_setup_build.prepare_wheel_libs()
+
+package_name = cupy_setup_build.get_package_name()
 ext_modules = cupy_setup_build.get_ext_modules()
 build_ext = cupy_setup_build.custom_build_ext
 sdist = cupy_setup_build.sdist_with_cython
@@ -38,7 +69,7 @@ __version__ = imp.load_source(
     '_version', os.path.join(here, 'cupy', '_version.py')).__version__
 
 setup(
-    name='cupy',
+    name=package_name,
     version=__version__,
     description='CuPy: NumPy-like API accelerated with CUDA',
     author='Seiya Tokui',
@@ -67,33 +98,7 @@ setup(
               'cupy.sparse.linalg',
               'cupy.statistics',
               'cupy.testing'],
-    package_data={
-        'cupy': [
-            'core/include/cupy/complex/arithmetic.h',
-            'core/include/cupy/complex/catrig.h',
-            'core/include/cupy/complex/catrigf.h',
-            'core/include/cupy/complex/ccosh.h',
-            'core/include/cupy/complex/ccoshf.h',
-            'core/include/cupy/complex/cexp.h',
-            'core/include/cupy/complex/cexpf.h',
-            'core/include/cupy/complex/clog.h',
-            'core/include/cupy/complex/clogf.h',
-            'core/include/cupy/complex/complex.h',
-            'core/include/cupy/complex/complex_inl.h',
-            'core/include/cupy/complex/cpow.h',
-            'core/include/cupy/complex/cproj.h',
-            'core/include/cupy/complex/csinh.h',
-            'core/include/cupy/complex/csinhf.h',
-            'core/include/cupy/complex/csqrt.h',
-            'core/include/cupy/complex/csqrtf.h',
-            'core/include/cupy/complex/ctanh.h',
-            'core/include/cupy/complex/ctanhf.h',
-            'core/include/cupy/complex/math_private.h',
-            'core/include/cupy/carray.cuh',
-            'core/include/cupy/complex.cuh',
-            'cuda/cupy_thrust.cu',
-        ],
-    },
+    package_data=package_data,
     zip_safe=False,
     setup_requires=setup_requires,
     install_requires=install_requires,


### PR DESCRIPTION
This PR implements #768.  ~~Depends on #762.~~ (done)
The usage is as follows:

```
pip install wheel
python setup.py bdist_wheel \
  --cupy-package-name cupy-cuda90                                          \
  --cupy-wheel-lib ~/.cudnn/versions/v7.0.4-cuda9/cuda/lib64/libcudnn.so.7 \
  --cupy-wheel-lib ~/.nccl/versions/v2.1-cuda9/cuda/lib64/libnccl.so.2     \
```

* Wheel packages are named `cupy-cuda{70,75,80,90}`.
  `cupy` package remains as is (i.e., source install).
* cuDNN/NCCL shared library binaries are copied into the wheel.
  The package size become approx. 50 (CUDA 7.0) to 250 MB (CUDA 9.0)
* CUDA shared library binaries are not copied into the wheel.
  This is because CuPy depends on some non-redistributable CUDA files (e.g., headers and `libnvrtc-builtins.so`), so it is mandatory to have the same version of CUDA library being installed on the host.
* If a user specifies `LD_LIBRARY_PATH` and the matching cuDNN / NCCL shared library is available, the library file included in `_lib/` will not be used.  (this behavior cannot be overridden)

We need to automate the release process. This includes:

* Build --- Create wheels for each Python version & CUDA version.
* Veirfy --- Confirm that the built wheels:
    * can be installed without CUDA/cuDNN/NCCL dependency
    * pass the unit tests
    * does not contain shared libraries linking to absolute-path RUNPATH
* Publish --- Upload the wheels to PyPI.

Currently it does not work on macOS.