### PR TITLE
Improve the document of rand/randn with examples

### DIFF
--- a/cupy/random/sample.py
+++ b/cupy/random/sample.py
@@ -14,7 +14,7 @@ def rand(*size, **kwarg):
     distributed (i.i.d.).
 
     Args:
-        size (tuple of ints): The shape of the array.
+        size (ints): The shape of the array.
         dtype: Data type specifier. Only :class:`numpy.float32` and
             :class:`numpy.float64` types are allowed. The default is
             :class:`numpy.float64`.
@@ -23,6 +23,18 @@ def rand(*size, **kwarg):
         cupy.ndarray: A random array.
 
     .. seealso:: :func:`numpy.random.rand`
+
+    .. admonition:: Example
+
+       >>> cupy.random.rand(3, 2)
+       array([[0.86476479, 0.05633727],   # random
+              [0.27283185, 0.38255354],   # random
+              [0.16592278, 0.75150313]])  # random
+
+       >>> cupy.random.rand(3, 2, dtype=cupy.float32)
+       array([[0.9672306 , 0.9590486 ],                  # random
+              [0.6851264 , 0.70457625],                  # random
+              [0.22382522, 0.36055237]], dtype=float32)  # random
 
     """
     dtype = kwarg.pop('dtype', float)
@@ -40,7 +52,7 @@ def randn(*size, **kwarg):
     (i.i.d.).
 
     Args:
-        size (tuple of ints): The shape of the array.
+        size (ints): The shape of the array.
         dtype: Data type specifier. Only :class:`numpy.float32` and
             :class:`numpy.float64` types are allowed.
             The default is :class:`numpy.float64`.
@@ -49,6 +61,18 @@ def randn(*size, **kwarg):
         cupy.ndarray: An array of standard normal random values.
 
     .. seealso:: :func:`numpy.random.randn`
+
+    .. admonition:: Example
+
+       >>> cupy.random.randn(3, 2)
+       array([[0.41193321, 1.59579542],   # random
+              [0.47904589, 0.18566376],   # random
+              [0.59748424, 2.32602829]])  # random
+
+       >>> cupy.random.randn(3, 2, dtype=cupy.float32)
+       array([[ 0.1373886 ,  2.403238  ],                  # random
+              [ 0.84020025,  1.5089266 ],                  # random
+              [-1.2268474 , -0.48219103]], dtype=float32)  # random
 
     """
     dtype = kwarg.pop('dtype', float)

--- a/cupy/random/sample.py
+++ b/cupy/random/sample.py
@@ -26,15 +26,17 @@ def rand(*size, **kwarg):
 
     .. admonition:: Example
 
-       >>> cupy.random.rand(3, 2)
-       array([[0.86476479, 0.05633727],   # random
-              [0.27283185, 0.38255354],   # random
-              [0.16592278, 0.75150313]])  # random
+       .. code-block:: python
 
-       >>> cupy.random.rand(3, 2, dtype=cupy.float32)
-       array([[0.9672306 , 0.9590486 ],                  # random
-              [0.6851264 , 0.70457625],                  # random
-              [0.22382522, 0.36055237]], dtype=float32)  # random
+          >>> cupy.random.rand(3, 2)
+          array([[0.86476479, 0.05633727],   # random
+                 [0.27283185, 0.38255354],   # random
+                 [0.16592278, 0.75150313]])  # random
+
+          >>> cupy.random.rand(3, 2, dtype=cupy.float32)
+          array([[0.9672306 , 0.9590486 ],                  # random
+                 [0.6851264 , 0.70457625],                  # random
+                 [0.22382522, 0.36055237]], dtype=float32)  # random
 
     """
     dtype = kwarg.pop('dtype', float)
@@ -64,15 +66,17 @@ def randn(*size, **kwarg):
 
     .. admonition:: Example
 
-       >>> cupy.random.randn(3, 2)
-       array([[0.41193321, 1.59579542],   # random
-              [0.47904589, 0.18566376],   # random
-              [0.59748424, 2.32602829]])  # random
+       .. code-block:: python
 
-       >>> cupy.random.randn(3, 2, dtype=cupy.float32)
-       array([[ 0.1373886 ,  2.403238  ],                  # random
-              [ 0.84020025,  1.5089266 ],                  # random
-              [-1.2268474 , -0.48219103]], dtype=float32)  # random
+          >>> cupy.random.randn(3, 2)
+          array([[0.41193321, 1.59579542],   # random
+                 [0.47904589, 0.18566376],   # random
+                 [0.59748424, 2.32602829]])  # random
+
+          >>> cupy.random.randn(3, 2, dtype=cupy.float32)
+          array([[ 0.1373886 ,  2.403238  ],                  # random
+                 [ 0.84020025,  1.5089266 ],                  # random
+                 [-1.2268474 , -0.48219103]], dtype=float32)  # random
 
     """
     dtype = kwarg.pop('dtype', float)


### PR DESCRIPTION
The current document is misleading so that users may be confused with `cupy.random.rand((2, 3))` which causes an error. I slightly fixed the document and added examples.