### PR TITLE
Implement memory pool index compaction

### DIFF
--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -136,6 +136,7 @@ cpdef _set_peer_access(int device, int peer):
     finally:
         runtime.setDevice(current)
 
+
 cdef class Chunk:
 
     """A chunk points to a device memory.
@@ -171,6 +172,7 @@ cdef class Chunk:
         self.stream_ptr = stream_ptr
         self.prev = None
         self.next = None
+
 
 cdef class MemoryPointer:
 
@@ -514,6 +516,40 @@ class PooledMemory(Memory):
     __del__ = free
 
 
+cdef int _compaction_threshold = 512
+
+
+cdef _compaction(SingleDeviceMemoryPool pool, size_t stream_ptr, bint free):
+    # need self._free_lock
+    cdef list arena, new_arena
+    cdef set free_list, keep_list
+    cdef vector.vector[int]* arena_index
+    cdef vector.vector[int] new_index
+    cdef size_t index
+
+    new_arena = []
+    arena = pool._free[stream_ptr]
+    arena_index = &pool._index[stream_ptr]
+    for index in range(len(arena)):
+        free_list = arena[index]
+        if not free_list:
+            continue
+        if free:
+            keep_list = set()
+            for chunk in free_list:
+                if chunk.prev is not None or chunk.next is not None:
+                    keep_list.add(chunk)
+            if len(keep_list) == 0:
+                continue
+            free_list = keep_list
+
+        new_index.push_back(arena_index.at(index))
+        new_arena.append(free_list)
+    arena_index.swap(new_index)
+    arena[:] = new_arena
+
+
+
 cdef class SingleDeviceMemoryPool:
     """Memory pool implementation for single device.
 
@@ -575,6 +611,8 @@ cdef class SingleDeviceMemoryPool:
             size = <int>arena_index.size()
             if index < size and arena_index.at(index) == bin_index:
                 free_list = arena[index]
+                if free_list is None:
+                    arena[index] = free_list = set()
             else:
                 free_list = set()
                 arena_index.insert(arena_index.begin() + index, bin_index)
@@ -601,8 +639,10 @@ cdef class SingleDeviceMemoryPool:
             if arena_index.at(index) != bin_index:
                 return False
             free_list = arena[index]
-            if chunk in free_list:
+            if free_list and chunk in free_list:
                 free_list.remove(chunk)
+                if len(free_list) == 0:
+                    arena[index] = None
                 return True
         finally:
             rlock.unlock_fastrlock(self._free_lock)
@@ -716,9 +756,15 @@ cdef class SingleDeviceMemoryPool:
             length = arena_index.size()
             for i in range(index, length):
                 free_list = arena[i]
-                if free_list:
-                    chunk = free_list.pop()
-                    break
+                if free_list is None:
+                    continue
+                assert len(free_list) > 0
+                chunk = free_list.pop()
+                if len(free_list) == 0:
+                    arena[i] = None
+                if i - index >= _compaction_threshold:
+                    _compaction(self, stream_ptr, False)
+                break
         finally:
             rlock.unlock_fastrlock(self._free_lock)
 
@@ -815,19 +861,8 @@ cdef class SingleDeviceMemoryPool:
         try:
             if _stream_ptr not in self._free:
                 return
+            _compaction(self, _stream_ptr, True)
             arena = self._free[_stream_ptr]
-            arena_index = &self._index[_stream_ptr]
-            for index in range(len(arena) -1, -1, -1):
-                free_list = arena[index]
-                keep_list = set()
-                for chunk in free_list:
-                    if chunk.prev is not None or chunk.next is not None:
-                        keep_list.add(chunk)
-                if len(keep_list) > 0:
-                    arena[index] = keep_list
-                else:
-                    arena_index.erase(arena_index.begin() + index)
-                    del arena[index]
             if len(arena) == 0:
                 self._index.erase(_stream_ptr)
                 del self._free[_stream_ptr]
@@ -847,7 +882,8 @@ cdef class SingleDeviceMemoryPool:
         try:
             for arena in self._free.itervalues():
                 for v in arena:
-                    n += len(v)
+                    if v is not None:
+                        n += len(v)
         finally:
             rlock.unlock_fastrlock(self._free_lock)
         return n
@@ -871,6 +907,8 @@ cdef class SingleDeviceMemoryPool:
         try:
             for arena in self._free.itervalues():
                 for free_list in arena:
+                    if free_list is None:
+                        continue
                     for chunk in free_list:
                         size += chunk.size
         finally:


### PR DESCRIPTION
The size of `SingleDeviceMemoryPool._free` increases in some case. Sometimes it may exceed 100000.
Therefore malloc gets slower when we use CuPy long time. Especially in Chainer's workload there is a huge performance degradation.

In this PR, I suggest using None instead of empty `set` object and compressing `_free` arrays.