### PR TITLE
Fix bug about stream deletion

### DIFF
--- a/tests/cupy_tests/cuda_tests/test_stream.py
+++ b/tests/cupy_tests/cuda_tests/test_stream.py
@@ -25,6 +25,7 @@ class TestStream(unittest.TestCase):
         stream_ptr = stream.ptr
         x = from_data.array([1, 2, 3])
         del stream
+        self.assertEqual(cuda.Stream.null, cuda.get_current_stream())
         # Want to test cudaStreamDestory is issued, but
         # runtime.streamQuery(stream_ptr) causes SEGV. We cannot test...
         del stream_ptr


### PR DESCRIPTION
In now, `get_current_stream_ptr` does not detect stream deletion.
