### PR TITLE
Improve exception handling performance in Cython

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2287,8 +2287,8 @@ def _has_element(vector.vector[Py_ssize_t] source, Py_ssize_t n):
     return False
 
 
-cpdef vector.vector[Py_ssize_t] normalize_axis_tuple(axis, Py_ssize_t ndim) \
-        except *:
+cpdef vector.vector[Py_ssize_t] normalize_axis_tuple(
+        axis, Py_ssize_t ndim) except *:
     """Normalizes an axis argument into a tuple of non-negative integer axes.
 
     Arguments `allow_duplicate` and `axis_name` are not supported.
@@ -2778,7 +2778,7 @@ cdef _concatenate_kernel = ElementwiseKernel(
 )
 
 
-cpdef Py_ssize_t size(ndarray a, axis=None) except *:
+cpdef Py_ssize_t size(ndarray a, axis=None) except? -1:
     """Returns the number of elements along a given axis.
 
     Args:

--- a/cupy/core/elementwise.pxi
+++ b/cupy/core/elementwise.pxi
@@ -621,7 +621,7 @@ cdef tuple _guess_routine_from_dtype(list ops, object dtype):
     return None
 
 
-cdef bint _check_should_use_min_scalar(list in_args) except *:
+cdef inline bint _check_should_use_min_scalar(list in_args) except? -1:
     cdef int kind, max_array_kind, max_scalar_kind
     cdef bint all_scalars
     all_scalars = True

--- a/cupy/core/internal.pxd
+++ b/cupy/core/internal.pxd
@@ -2,7 +2,7 @@ from libcpp cimport vector
 from libc.stdint cimport uint16_t
 
 
-cpdef Py_ssize_t prod(args, Py_ssize_t init=*) except *
+cpdef Py_ssize_t prod(args, Py_ssize_t init=*) except? -1
 
 cpdef Py_ssize_t prod_ssize_t(
     vector.vector[Py_ssize_t]& arr, Py_ssize_t init=*)
@@ -19,7 +19,7 @@ cdef void get_reduced_dims(
 
 cpdef vector.vector[Py_ssize_t] get_contiguous_strides(
     vector.vector[Py_ssize_t]& shape, Py_ssize_t itemsize,
-    bint is_c_contiguous) except *
+    bint is_c_contiguous)
 
 cdef set_contiguous_strides(
     vector.vector[Py_ssize_t]& shape, vector.vector[Py_ssize_t]& strides,
@@ -27,7 +27,7 @@ cdef set_contiguous_strides(
 
 cpdef bint get_c_contiguity(
     vector.vector[Py_ssize_t]& shape, vector.vector[Py_ssize_t]& strides,
-    Py_ssize_t itemsize) except *
+    Py_ssize_t itemsize)
 
 cpdef vector.vector[Py_ssize_t] infer_unknown_dimension(
     vector.vector[Py_ssize_t]& shape, Py_ssize_t size) except *

--- a/cupy/core/internal.pyx
+++ b/cupy/core/internal.pyx
@@ -11,7 +11,7 @@ cdef extern from "halffloat.h":
 
 
 @cython.profile(False)
-cpdef inline Py_ssize_t prod(args, Py_ssize_t init=1) except *:
+cpdef inline Py_ssize_t prod(args, Py_ssize_t init=1) except? -1:
     cdef Py_ssize_t arg
     for arg in args:
         init *= arg
@@ -93,7 +93,7 @@ cdef void get_reduced_dims(
 @cython.profile(False)
 cpdef vector.vector[Py_ssize_t] get_contiguous_strides(
         vector.vector[Py_ssize_t]& shape, Py_ssize_t itemsize,
-        bint is_c_contiguous) except *:
+        bint is_c_contiguous):
     cdef vector.vector[Py_ssize_t] strides
     set_contiguous_strides(shape, strides, itemsize, is_c_contiguous)
     return strides
@@ -123,7 +123,7 @@ cdef inline set_contiguous_strides(
 @cython.profile(False)
 cpdef inline bint get_c_contiguity(
         vector.vector[Py_ssize_t]& shape, vector.vector[Py_ssize_t]& strides,
-        Py_ssize_t itemsize) except *:
+        Py_ssize_t itemsize):
     cdef vector.vector[Py_ssize_t] r_shape, r_strides
     cpdef Py_ssize_t ndim
     ndim = strides.size()
@@ -156,7 +156,7 @@ cpdef vector.vector[Py_ssize_t] infer_unknown_dimension(
 
 
 @cython.profile(False)
-cpdef inline Py_ssize_t _extract_slice_element(x) except *:
+cpdef inline Py_ssize_t _extract_slice_element(x) except? 0:
     try:
         return x.__index__()
     except AttributeError:

--- a/cupy/cuda/cublas.pxd
+++ b/cupy/cuda/cublas.pxd
@@ -53,10 +53,10 @@ cpdef enum:
 # Context
 ###############################################################################
 
-cpdef size_t create() except *
-cpdef void destroy(size_t handle) except *
-cpdef int getVersion(size_t handle) except *
-cpdef int getPointerMode(size_t handle) except *
+cpdef size_t create() except? 0
+cpdef destroy(size_t handle)
+cpdef int getVersion(size_t handle) except? -1
+cpdef int getPointerMode(size_t handle) except? -1
 cpdef setPointerMode(size_t handle, int mode)
 
 
@@ -65,7 +65,7 @@ cpdef setPointerMode(size_t handle, int mode)
 ###############################################################################
 
 cpdef setStream(size_t handle, size_t stream)
-cpdef size_t getStream(size_t handle) except *
+cpdef size_t getStream(size_t handle) except? 0
 
 
 ###############################################################################
@@ -73,16 +73,16 @@ cpdef size_t getStream(size_t handle) except *
 ###############################################################################
 
 cpdef setMathMode(size_t handle, int mode)
-cpdef int getMathMode(size_t handle) except *
+cpdef int getMathMode(size_t handle) except? -1
 
 
 ###############################################################################
 # BLAS Level 1
 ###############################################################################
 
-cpdef int isamax(size_t handle, int n, size_t x, int incx) except *
-cpdef int isamin(size_t handle, int n, size_t x, int incx) except *
-cpdef float sasum(size_t handle, int n, size_t x, int incx) except *
+cpdef int isamax(size_t handle, int n, size_t x, int incx) except? 0
+cpdef int isamin(size_t handle, int n, size_t x, int incx) except? 0
+cpdef float sasum(size_t handle, int n, size_t x, int incx) except? 0
 cpdef saxpy(size_t handle, int n, float alpha, size_t x, int incx, size_t y,
             int incy)
 cpdef daxpy(size_t handle, int n, double alpha, size_t x, int incx, size_t y,
@@ -99,7 +99,7 @@ cpdef zdotu(size_t handle, int n, size_t x, int incx, size_t y, int incy,
             size_t result)
 cpdef zdotc(size_t handle, int n, size_t x, int incx, size_t y, int incy,
             size_t result)
-cpdef float snrm2(size_t handle, int n, size_t x, int incx) except *
+cpdef float snrm2(size_t handle, int n, size_t x, int incx) except? 0
 cpdef sscal(size_t handle, int n, float alpha, size_t x, int incx)
 
 

--- a/cupy/cuda/cublas.pyx
+++ b/cupy/cuda/cublas.pyx
@@ -283,7 +283,7 @@ cpdef inline check_status(int status):
 # Context
 ###############################################################################
 
-cpdef size_t create() except *:
+cpdef size_t create() except? 0:
     cdef Handle handle
     with nogil:
         status = cublasCreate(&handle)
@@ -291,13 +291,13 @@ cpdef size_t create() except *:
     return <size_t>handle
 
 
-cpdef void destroy(size_t handle) except *:
+cpdef destroy(size_t handle):
     with nogil:
         status = cublasDestroy(<Handle>handle)
     check_status(status)
 
 
-cpdef int getVersion(size_t handle) except *:
+cpdef int getVersion(size_t handle) except? -1:
     cdef int version
     with nogil:
         status = cublasGetVersion(<Handle>handle, &version)
@@ -305,7 +305,7 @@ cpdef int getVersion(size_t handle) except *:
     return version
 
 
-cpdef int getPointerMode(size_t handle) except *:
+cpdef int getPointerMode(size_t handle) except? -1:
     cdef PointerMode mode
     with nogil:
         status = cublasGetPointerMode(<Handle>handle, &mode)
@@ -329,7 +329,7 @@ cpdef setStream(size_t handle, size_t stream):
     check_status(status)
 
 
-cpdef size_t getStream(size_t handle) except *:
+cpdef size_t getStream(size_t handle) except? 0:
     cdef driver.Stream stream
     with nogil:
         status = cublasGetStream(<Handle>handle, &stream)
@@ -347,7 +347,7 @@ cpdef setMathMode(size_t handle, int mode):
     check_status(status)
 
 
-cpdef int getMathMode(size_t handle) except *:
+cpdef int getMathMode(size_t handle) except? -1:
     cdef Math mode
     with nogil:
         status = cublasGetMathMode(<Handle>handle, &mode)
@@ -359,7 +359,7 @@ cpdef int getMathMode(size_t handle) except *:
 # BLAS Level 1
 ###############################################################################
 
-cpdef int isamax(size_t handle, int n, size_t x, int incx) except *:
+cpdef int isamax(size_t handle, int n, size_t x, int incx) except? 0:
     cdef int result
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -369,7 +369,7 @@ cpdef int isamax(size_t handle, int n, size_t x, int incx) except *:
     return result
 
 
-cpdef int isamin(size_t handle, int n, size_t x, int incx) except *:
+cpdef int isamin(size_t handle, int n, size_t x, int incx) except? 0:
     cdef int result
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -379,7 +379,7 @@ cpdef int isamin(size_t handle, int n, size_t x, int incx) except *:
     return result
 
 
-cpdef float sasum(size_t handle, int n, size_t x, int incx) except *:
+cpdef float sasum(size_t handle, int n, size_t x, int incx) except? 0:
     cdef float result
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -466,7 +466,7 @@ cpdef zdotc(size_t handle, int n, size_t x, int incx, size_t y, int incy,
     check_status(status)
 
 
-cpdef float snrm2(size_t handle, int n, size_t x, int incx) except *:
+cpdef float snrm2(size_t handle, int n, size_t x, int incx) except? 0:
     cdef float result
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:

--- a/cupy/cuda/cudnn.pxd
+++ b/cupy/cuda/cudnn.pxd
@@ -145,7 +145,7 @@ cpdef enum:
 # Version
 ###############################################################################
 
-cpdef size_t getVersion() except *
+cpdef size_t getVersion() except? 0
 
 ###############################################################################
 # Runtime error checking
@@ -156,17 +156,17 @@ cpdef queryRuntimeError(size_t handle, int mode)
 # Initialization and CUDA cooperation
 ###############################################################################
 
-cpdef size_t create() except *
+cpdef size_t create() except? 0
 cpdef destroy(size_t handle)
 cpdef setStream(size_t handle, size_t stream)
-cpdef size_t getStream(size_t handle) except *
+cpdef size_t getStream(size_t handle) except? 0
 
 
 ###############################################################################
 # Tensor manipulation
 ###############################################################################
 
-cpdef size_t createTensorDescriptor() except *
+cpdef size_t createTensorDescriptor() except? 0
 cpdef setTensor4dDescriptor(size_t tensorDesc, int format, int dataType,
                             int n, int c, int h, int w)
 cpdef setTensor4dDescriptorEx(size_t tensorDesc, int dataType,
@@ -223,7 +223,7 @@ cpdef scaleTensor(size_t handle, size_t yDesc, size_t y, size_t alpha)
 # Filter manipulation
 ###############################################################################
 
-cpdef size_t createFilterDescriptor() except *
+cpdef size_t createFilterDescriptor() except? 0
 cpdef setFilter4dDescriptor_v4(
     size_t filterDesc, int dataType, int format, int k, int c, int h, int w)
 cpdef setFilterNdDescriptor_v4(
@@ -236,13 +236,13 @@ cpdef destroyFilterDescriptor(size_t filterDesc)
 # Convolution
 ###############################################################################
 
-cpdef size_t createConvolutionDescriptor() except *
+cpdef size_t createConvolutionDescriptor() except? 0
 cpdef setConvolutionMathType(
     size_t convDesc, size_t mathType)
-cpdef size_t getConvolutionMathType(size_t convDesc) except *
+cpdef size_t getConvolutionMathType(size_t convDesc) except? 0
 cpdef setConvolutionGroupCount(
     size_t convDesc, int groupCount)
-cpdef int getConvolutionGroupCount(size_t convDesc) except *
+cpdef int getConvolutionGroupCount(size_t convDesc) except? -1
 cpdef setConvolution2dDescriptor_v4(
     size_t convDesc, int pad_h, int pad_w, int u, int v, int dilation_h,
     int dilation_w, int mode)
@@ -266,13 +266,13 @@ cpdef findConvolutionForwardAlgorithmEx_v7(
     size_t workSpace, size_t workSpaceSizeInBytes)
 cpdef int getConvolutionForwardAlgorithm_v6(
     size_t handle, size_t srcDesc, size_t filterDesc, size_t convDesc,
-    size_t destDesc, int preference, size_t memoryLimitInbytes) except *
+    size_t destDesc, int preference, size_t memoryLimitInbytes) except? -1
 cpdef getConvolutionForwardAlgorithm_v7(
     size_t handle, size_t srcDesc, size_t filterDesc, size_t convDesc,
     size_t destDesc, int requestedAlgoCount)
-cpdef size_t getConvolutionForwardWorkspaceSize(
+cpdef Py_ssize_t getConvolutionForwardWorkspaceSize(
     size_t handle, size_t srcDesc, size_t filterDesc, size_t convDesc,
-    size_t destDesc, int algo) except *
+    size_t destDesc, int algo) except? -1
 cpdef convolutionForward(
     size_t handle, size_t alpha, size_t srcDesc, size_t srcData,
     size_t filterDesc, size_t filterData, size_t convDesc, int algo,
@@ -294,13 +294,13 @@ cpdef findConvolutionBackwardFilterAlgorithmEx_v7(
     size_t workSpace, size_t workSpaceSizeInBytes)
 cpdef int getConvolutionBackwardFilterAlgorithm_v6(
     size_t handle, size_t srcDesc, size_t diffDesc, size_t convDesc,
-    size_t filterDesc, int preference, size_t memoryLimitInbytes) except *
+    size_t filterDesc, int preference, size_t memoryLimitInbytes) except? -1
 cpdef getConvolutionBackwardFilterAlgorithm_v7(
     size_t handle, size_t srcDesc, size_t diffDesc, size_t convDesc,
     size_t gradDesc, int requestedAlgoCount)
-cpdef size_t getConvolutionBackwardFilterWorkspaceSize(
+cpdef Py_ssize_t getConvolutionBackwardFilterWorkspaceSize(
     size_t handle, size_t srcDesc, size_t diffDesc, size_t convDesc,
-    size_t filterDesc, int algo) except *
+    size_t filterDesc, int algo) except? -1
 cpdef convolutionBackwardFilter_v3(
     size_t handle, size_t alpha, size_t srcDesc, size_t srcData,
     size_t diffDesc, size_t diffData, size_t convDesc, int algo,
@@ -320,13 +320,13 @@ cpdef findConvolutionBackwardDataAlgorithmEx_v7(
 cpdef int getConvolutionBackwardDataAlgorithm_v6(
     size_t handle, size_t filterDesc, size_t diffDesc, size_t convDesc,
     size_t gradDesc, size_t preference,
-    size_t memoryLimitInbytes) except *
+    size_t memoryLimitInbytes) except? -1
 cpdef getConvolutionBackwardDataAlgorithm_v7(
     size_t handle, size_t filterDesc, size_t diffDesc, size_t convDesc,
     size_t gradDesc, int requestedAlgoCount)
-cpdef size_t getConvolutionBackwardDataWorkspaceSize(
+cpdef Py_ssize_t getConvolutionBackwardDataWorkspaceSize(
     size_t handle, size_t filterDesc, size_t diffDesc, size_t convDesc,
-    size_t gradDesc, int algo) except *
+    size_t gradDesc, int algo) except? -1
 cpdef convolutionBackwardData_v3(
     size_t handle, size_t alpha, size_t filterDesc, size_t filterData,
     size_t diffDesc, size_t diffData, size_t convDesc, int algo,
@@ -338,7 +338,7 @@ cpdef convolutionBackwardData_v3(
 # Pooling
 ###############################################################################
 
-cpdef size_t createPoolingDescriptor() except *
+cpdef size_t createPoolingDescriptor() except? 0
 cpdef setPooling2dDescriptor_v4(
     size_t poolingDesc, int mode, int maxpoolingNanOpt, int windowHeight,
     int windowWidth, int verticalPadding, int horizontalPadding,
@@ -395,7 +395,7 @@ cpdef batchNormalizationBackward(
 # Activation
 ###############################################################################
 
-cpdef size_t createActivationDescriptor() except *
+cpdef size_t createActivationDescriptor() except? 0
 cpdef setActivationDescriptor(
     size_t activationDesc, int mode, int reluNanOpt, double reluCeiling)
 cpdef destroyActivationDescriptor(size_t activationDesc)
@@ -419,13 +419,13 @@ cpdef activationBackward_v4(
 ###############################################################################
 # Dropout
 ###############################################################################
-cpdef size_t createDropoutDescriptor() except *
+cpdef size_t createDropoutDescriptor() except? 0
 cpdef destroyDropoutDescriptor(size_t dropoutDesc)
-cpdef size_t dropoutGetStatesSize(size_t handle) except *
+cpdef Py_ssize_t dropoutGetStatesSize(size_t handle) except? -1
 cpdef setDropoutDescriptor(
     size_t dropoutDesc, size_t handle, float dropout,
     size_t states, size_t stateSizeInBytes, unsigned long long seed)
-cpdef size_t getDropoutReserveSpaceSize(size_t xDesc)
+cpdef size_t getDropoutReserveSpaceSize(size_t xDesc) except? 0
 cpdef dropoutForward(
     size_t handle, size_t dropoutDesc,
     size_t srcDesc, size_t srcData,
@@ -442,10 +442,10 @@ cpdef dropoutBackward(
 # RNN
 ###############################################################################
 
-cpdef size_t createRNNDescriptor() except *
+cpdef size_t createRNNDescriptor() except? 0
 cpdef destroyRNNDescriptor(size_t rnnDesc)
 cpdef size_t createPersistentRNNPlan(
-    size_t rnnDesc, int minibatch, int dataType) except *
+    size_t rnnDesc, int minibatch, int dataType) except? 0
 cpdef setPersistentRNNPlan(size_t rnnDesc, size_t plan)
 cpdef destroyPersistentRNNPlan(size_t plan)
 cpdef setRNNDescriptor_v5(
@@ -502,7 +502,7 @@ cpdef RNNBackwardWeights(
 # Spatial Transformer
 ###############################################################################
 
-cpdef size_t createSpatialTransformerDescriptor() except *
+cpdef size_t createSpatialTransformerDescriptor() except? 0
 cpdef destroySpatialTransformerDescriptor(size_t stDesc)
 cpdef setSpatialTransformerDescriptor(
     size_t stDesc, size_t samplerType, int dataType,

--- a/cupy/cuda/cudnn.pyx
+++ b/cupy/cuda/cudnn.pyx
@@ -585,7 +585,7 @@ def get_build_version():
 # Version
 ###############################################################################
 
-cpdef size_t getVersion() except *:
+cpdef size_t getVersion() except? 0:
     return cudnnGetVersion()
 
 
@@ -606,7 +606,7 @@ cpdef queryRuntimeError(size_t handle, int mode):
 # Initialization and CUDA cooperation
 ###############################################################################
 
-cpdef size_t create() except *:
+cpdef size_t create() except? 0:
     cdef Handle handle
     with nogil:
         status = cudnnCreate(&handle)
@@ -625,7 +625,7 @@ cpdef setStream(size_t handle, size_t stream):
     check_status(status)
 
 
-cpdef size_t getStream(size_t handle) except *:
+cpdef size_t getStream(size_t handle) except? 0:
     cdef driver.Stream stream
     status = cudnnGetStream(<Handle>handle, &stream)
     check_status(status)
@@ -636,7 +636,7 @@ cpdef size_t getStream(size_t handle) except *:
 # Tensor manipulation
 ###############################################################################
 
-cpdef size_t createTensorDescriptor() except *:
+cpdef size_t createTensorDescriptor() except? 0:
     cdef TensorDescriptor descriptor
     status = cudnnCreateTensorDescriptor(&descriptor)
     check_status(status)
@@ -840,7 +840,7 @@ cpdef scaleTensor(size_t handle, size_t yDesc, size_t y, size_t alpha):
 # Filter manipulation
 ###############################################################################
 
-cpdef size_t createFilterDescriptor() except *:
+cpdef size_t createFilterDescriptor() except? 0:
     cdef FilterDescriptor desc
     status = cudnnCreateFilterDescriptor(&desc)
     check_status(status)
@@ -888,7 +888,7 @@ cpdef destroyFilterDescriptor(size_t filterDesc):
 # Convolution
 ###############################################################################
 
-cpdef size_t createConvolutionDescriptor() except *:
+cpdef size_t createConvolutionDescriptor() except? 0:
     cdef ConvolutionDescriptor desc
     status = cudnnCreateConvolutionDescriptor(&desc)
     check_status(status)
@@ -901,7 +901,7 @@ cpdef setConvolutionMathType(size_t convDesc, size_t mathType):
     check_status(status)
 
 
-cpdef size_t getConvolutionMathType(size_t convDesc) except *:
+cpdef size_t getConvolutionMathType(size_t convDesc) except? 0:
     cdef MathType mathType
     status = cudnnGetConvolutionMathType(
         <ConvolutionDescriptor>convDesc, &mathType)
@@ -914,7 +914,7 @@ cpdef setConvolutionGroupCount(size_t convDesc, int groupCount):
     check_status(status)
 
 
-cpdef int getConvolutionGroupCount(size_t convDesc) except *:
+cpdef int getConvolutionGroupCount(size_t convDesc) except? -1:
     cdef int groupCount
     status = cudnnGetConvolutionGroupCount(
         <ConvolutionDescriptor>convDesc, &groupCount)
@@ -1012,7 +1012,7 @@ cpdef findConvolutionForwardAlgorithmEx_v7(
 
 cpdef int getConvolutionForwardAlgorithm_v6(
         size_t handle, size_t srcDesc, size_t filterDesc, size_t convDesc,
-        size_t destDesc, int preference, size_t memoryLimitInbytes) except *:
+        size_t destDesc, int preference, size_t memoryLimitInbytes) except? -1:
     cdef ConvolutionFwdAlgo algo
     status = cudnnGetConvolutionForwardAlgorithm_v6(
         <Handle>handle, <TensorDescriptor>srcDesc,
@@ -1043,16 +1043,16 @@ cpdef getConvolutionForwardAlgorithm_v7(
     return ret
 
 
-cpdef size_t getConvolutionForwardWorkspaceSize(
+cpdef Py_ssize_t getConvolutionForwardWorkspaceSize(
         size_t handle, size_t srcDesc, size_t filterDesc, size_t convDesc,
-        size_t destDesc, int algo) except *:
+        size_t destDesc, int algo) except? -1:
     cdef size_t sizeInBytes
     status = cudnnGetConvolutionForwardWorkspaceSize(
         <Handle>handle, <TensorDescriptor>srcDesc,
         <FilterDescriptor>filterDesc, <ConvolutionDescriptor> convDesc,
         <TensorDescriptor>destDesc, <ConvolutionFwdAlgo>algo, &sizeInBytes)
     check_status(status)
-    return sizeInBytes
+    return <Py_ssize_t>sizeInBytes
 
 
 cpdef convolutionForward(
@@ -1141,7 +1141,8 @@ cpdef findConvolutionBackwardFilterAlgorithmEx_v7(
 
 cpdef int getConvolutionBackwardFilterAlgorithm_v6(
         size_t handle, size_t srcDesc, size_t diffDesc, size_t convDesc,
-        size_t filterDesc, int preference, size_t memoryLimitInbytes) except *:
+        size_t filterDesc, int preference,
+        size_t memoryLimitInbytes) except? -1:
     cdef ConvolutionBwdFilterAlgo algo
     status = cudnnGetConvolutionBackwardFilterAlgorithm_v6(
         <Handle>handle, <TensorDescriptor>srcDesc,
@@ -1172,9 +1173,9 @@ cpdef getConvolutionBackwardFilterAlgorithm_v7(
     return ret
 
 
-cpdef size_t getConvolutionBackwardFilterWorkspaceSize(
+cpdef Py_ssize_t getConvolutionBackwardFilterWorkspaceSize(
         size_t handle, size_t srcDesc, size_t diffDesc, size_t convDesc,
-        size_t filterDesc, int algo) except *:
+        size_t filterDesc, int algo) except? -1:
     cdef size_t sizeInBytes
     status = cudnnGetConvolutionBackwardFilterWorkspaceSize(
         <Handle>handle, <TensorDescriptor>srcDesc,
@@ -1182,7 +1183,7 @@ cpdef size_t getConvolutionBackwardFilterWorkspaceSize(
         <FilterDescriptor>filterDesc, <ConvolutionBwdFilterAlgo>algo,
         &sizeInBytes)
     check_status(status)
-    return sizeInBytes
+    return <Py_ssize_t>sizeInBytes
 
 
 cpdef convolutionBackwardFilter_v3(
@@ -1260,7 +1261,7 @@ cpdef findConvolutionBackwardDataAlgorithmEx_v7(
 cpdef int getConvolutionBackwardDataAlgorithm_v6(
         size_t handle, size_t filterDesc, size_t diffDesc, size_t convDesc,
         size_t gradDesc, size_t preference,
-        size_t memoryLimitInbytes) except *:
+        size_t memoryLimitInbytes) except? -1:
     cdef ConvolutionBwdDataAlgo algo
     status = cudnnGetConvolutionBackwardDataAlgorithm_v6(
         <Handle>handle, <FilterDescriptor>filterDesc,
@@ -1291,9 +1292,9 @@ cpdef getConvolutionBackwardDataAlgorithm_v7(
     return ret
 
 
-cpdef size_t getConvolutionBackwardDataWorkspaceSize(
+cpdef Py_ssize_t getConvolutionBackwardDataWorkspaceSize(
         size_t handle, size_t filterDesc, size_t diffDesc, size_t convDesc,
-        size_t gradDesc, int algo) except *:
+        size_t gradDesc, int algo) except? -1:
     cdef size_t sizeInBytes
     status = cudnnGetConvolutionBackwardDataWorkspaceSize(
         <Handle>handle, <FilterDescriptor>filterDesc,
@@ -1301,7 +1302,7 @@ cpdef size_t getConvolutionBackwardDataWorkspaceSize(
         <ConvolutionDescriptor>convDesc, <TensorDescriptor>gradDesc,
         <ConvolutionBwdDataAlgo>algo, &sizeInBytes)
     check_status(status)
-    return sizeInBytes
+    return <Py_ssize_t>sizeInBytes
 
 
 cpdef convolutionBackwardData_v3(
@@ -1324,7 +1325,7 @@ cpdef convolutionBackwardData_v3(
 # Pooling
 ###############################################################################
 
-cpdef size_t createPoolingDescriptor() except *:
+cpdef size_t createPoolingDescriptor() except? 0:
     cdef PoolingDescriptor desc
     status = cudnnCreatePoolingDescriptor(&desc)
     check_status(status)
@@ -1465,7 +1466,7 @@ cpdef batchNormalizationBackward(
 # Activation
 ###############################################################################
 
-cpdef size_t createActivationDescriptor() except *:
+cpdef size_t createActivationDescriptor() except? 0:
     cdef ActivationDescriptor activationDesc
     status = cudnnCreateActivationDescriptor(&activationDesc)
     check_status(status)
@@ -1544,7 +1545,7 @@ cpdef activationBackward_v4(
 # Dropout
 ###############################################################################
 
-cpdef size_t createDropoutDescriptor() except *:
+cpdef size_t createDropoutDescriptor() except? 0:
     cdef DropoutDescriptor desc
     status = cudnnCreateDropoutDescriptor(&desc)
     check_status(status)
@@ -1556,12 +1557,12 @@ cpdef destroyDropoutDescriptor(size_t dropoutDesc):
     check_status(status)
 
 
-cpdef size_t dropoutGetStatesSize(size_t handle) except *:
+cpdef Py_ssize_t dropoutGetStatesSize(size_t handle) except? -1:
     cdef size_t sizeInBytes
     status = cudnnDropoutGetStatesSize(
         <Handle>handle, &sizeInBytes)
     check_status(status)
-    return sizeInBytes
+    return <Py_ssize_t>sizeInBytes
 
 
 cpdef setDropoutDescriptor(
@@ -1573,7 +1574,7 @@ cpdef setDropoutDescriptor(
     check_status(status)
 
 
-cpdef size_t getDropoutReserveSpaceSize(size_t xDesc):
+cpdef size_t getDropoutReserveSpaceSize(size_t xDesc) except? 0:
     cdef size_t sizeInBytes
     status = cudnnDropoutGetReserveSpaceSize(
         <TensorDescriptor>xDesc, &sizeInBytes)
@@ -1615,7 +1616,7 @@ cpdef dropoutBackward(
 # RNN
 ###############################################################################
 
-cpdef size_t createRNNDescriptor() except *:
+cpdef size_t createRNNDescriptor() except? 0:
     cdef RNNDescriptor desc
     status = cudnnCreateRNNDescriptor(&desc)
     check_status(status)
@@ -1628,7 +1629,7 @@ cpdef destroyRNNDescriptor(size_t rnnDesc):
 
 
 cpdef size_t createPersistentRNNPlan(size_t rnnDesc, int minibatch,
-                                     int dataType) except *:
+                                     int dataType) except? 0:
     cdef PersistentRNNPlan plan
     status = cudnnCreatePersistentRNNPlan(
         <RNNDescriptor>rnnDesc,
@@ -1816,7 +1817,7 @@ cpdef RNNBackwardWeights(
 # Spatial Transformer
 ###############################################################################
 
-cpdef size_t createSpatialTransformerDescriptor() except *:
+cpdef size_t createSpatialTransformerDescriptor() except? 0:
     cdef SpatialTransformerDescriptor stDesc
     status = cudnnCreateSpatialTransformerDescriptor(&stDesc)
     check_status(status)

--- a/cupy/cuda/curand.pyx
+++ b/cupy/cuda/curand.pyx
@@ -87,7 +87,7 @@ cpdef inline check_status(int status):
 # Generator
 ###############################################################################
 
-cpdef size_t createGenerator(int rng_type) except *:
+cpdef size_t createGenerator(int rng_type) except? 0:
     cdef Generator generator
     with nogil:
         status = curandCreateGenerator(&generator, <RngType>rng_type)
@@ -100,7 +100,7 @@ cpdef destroyGenerator(size_t generator):
     check_status(status)
 
 
-cpdef int getVersion() except *:
+cpdef int getVersion() except? -1:
     cdef int version
     status = curandGetVersion(&version)
     check_status(status)

--- a/cupy/cuda/cusolver.pxd
+++ b/cupy/cuda/cusolver.pxd
@@ -36,25 +36,25 @@ cpdef enum:
 # Context
 ###############################################################################
 
-cpdef size_t create() except *
-cpdef size_t spCreate() except *
-cpdef void destroy(size_t handle) except *
+cpdef size_t create() except? 0
+cpdef size_t spCreate() except? 0
+cpdef destroy(size_t handle)
 
 ###############################################################################
 # Stream
 ###############################################################################
 
 cpdef setStream(size_t handle, size_t stream)
-cpdef size_t getStream(size_t handle) except *
+cpdef size_t getStream(size_t handle) except? 0
 
 ###############################################################################
 # dense LAPACK Functions
 ###############################################################################
 
 cpdef int spotrf_bufferSize(size_t handle, int uplo,
-                            int n, size_t A, int lda) except *
+                            int n, size_t A, int lda) except? -1
 cpdef int dpotrf_bufferSize(size_t handle, int uplo,
-                            int n, size_t A, int lda) except *
+                            int n, size_t A, int lda) except? -1
 cpdef spotrf(size_t handle, int uplo, int n, size_t A, int lda,
              size_t work, int lwork, size_t devInfo)
 cpdef dpotrf(size_t handle, int uplo, int n, size_t A, int lda,
@@ -78,13 +78,13 @@ cpdef dgetrs(size_t handle, int trans, int n, int nrhs,
              size_t B, int ldb, size_t devInfo)
 
 cpdef int sgeqrf_bufferSize(size_t handle, int m, int n,
-                            size_t A, int lda) except *
+                            size_t A, int lda) except? -1
 cpdef int dgeqrf_bufferSize(size_t handle, int m, int n,
-                            size_t A, int lda) except *
+                            size_t A, int lda) except? -1
 cpdef int sgetrf_bufferSize(size_t handle, int m, int n,
-                            size_t A, int lda) except *
+                            size_t A, int lda) except? -1
 cpdef int dgetrf_bufferSize(size_t handle, int m, int n,
-                            size_t A, int lda) except *
+                            size_t A, int lda) except? -1
 
 cpdef sgeqrf(size_t handle, int m, int n, size_t A, int lda,
              size_t tau, size_t work, int lwork, size_t devInfo)
@@ -92,9 +92,9 @@ cpdef dgeqrf(size_t handle, int m, int n, size_t A, int lda,
              size_t tau, size_t work, int lwork, size_t devInfo)
 
 cpdef int sorgqr_bufferSize(size_t handle, int m, int n, int k,
-                            size_t A, int lda, size_t tau) except *
+                            size_t A, int lda, size_t tau) except? -1
 cpdef int dorgqr_bufferSize(size_t handle, int m, int n, int k,
-                            size_t A, int lda, size_t tau) except *
+                            size_t A, int lda, size_t tau) except? -1
 cpdef sorgqr(size_t handle, int m, int n, int k, size_t A, int lda,
              size_t tau, size_t work, int lwork, size_t devInfo)
 cpdef dorgqr(size_t handle, int m, int n, int k, size_t A, int lda,
@@ -119,8 +119,8 @@ cpdef dgebrd(size_t handle, int m, int n, size_t A, int lda,
              size_t D, size_t E, size_t tauQ, size_t tauP,
              size_t Work, int lwork, size_t devInfo)
 
-cpdef int sgesvd_bufferSize(size_t handle, int m, int n) except *
-cpdef int dgesvd_bufferSize(size_t handle, int m, int n) except *
+cpdef int sgesvd_bufferSize(size_t handle, int m, int n) except? -1
+cpdef int dgesvd_bufferSize(size_t handle, int m, int n) except? -1
 cpdef sgesvd(size_t handle, char jobu, char jobvt, int m, int n, size_t A,
              int lda, size_t S, size_t U, int ldu, size_t VT, int ldvt,
              size_t Work, int lwork, size_t rwork, size_t devInfo)

--- a/cupy/cuda/cusolver.pyx
+++ b/cupy/cuda/cusolver.pyx
@@ -188,7 +188,7 @@ cpdef inline check_status(int status):
 # Context
 ###############################################################################
 
-cpdef size_t create() except *:
+cpdef size_t create() except? 0:
     cdef Handle handle
     with nogil:
         status = cusolverDnCreate(&handle)
@@ -196,7 +196,7 @@ cpdef size_t create() except *:
     return <size_t>handle
 
 
-cpdef size_t spCreate() except *:
+cpdef size_t spCreate() except? 0:
     cdef SpHandle handle
     with nogil:
         status = cusolverSpCreate(&handle)
@@ -204,7 +204,7 @@ cpdef size_t spCreate() except *:
     return <size_t>handle
 
 
-cpdef void destroy(size_t handle) except *:
+cpdef destroy(size_t handle):
     with nogil:
         status = cusolverDnDestroy(<Handle>handle)
     check_status(status)
@@ -219,7 +219,7 @@ cpdef setStream(size_t handle, size_t stream):
     check_status(status)
 
 
-cpdef size_t getStream(size_t handle) except *:
+cpdef size_t getStream(size_t handle) except? 0:
     cdef driver.Stream stream
     with nogil:
         status = cusolverDnGetStream(<Handle>handle, &stream)
@@ -246,7 +246,7 @@ cpdef size_t spGetStream(size_t handle) except *:
 ###############################################################################
 
 cpdef int spotrf_bufferSize(size_t handle, int uplo,
-                            int n, size_t A, int lda) except *:
+                            int n, size_t A, int lda) except? -1:
     cdef int lwork
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -256,7 +256,7 @@ cpdef int spotrf_bufferSize(size_t handle, int uplo,
     return lwork
 
 cpdef int dpotrf_bufferSize(size_t handle, int uplo,
-                            int n, size_t A, int lda) except *:
+                            int n, size_t A, int lda) except? -1:
     cdef int lwork
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -342,7 +342,7 @@ cpdef dgetrs(size_t handle, int trans, int n, int nrhs,
     check_status(status)
 
 cpdef int sgetrf_bufferSize(size_t handle, int m, int n,
-                            size_t A, int lda) except *:
+                            size_t A, int lda) except? -1:
     cdef int lwork
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -352,7 +352,7 @@ cpdef int sgetrf_bufferSize(size_t handle, int m, int n,
     return lwork
 
 cpdef int dgetrf_bufferSize(size_t handle, int m, int n,
-                            size_t A, int lda) except *:
+                            size_t A, int lda) except? -1:
     cdef int lwork
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -362,7 +362,7 @@ cpdef int dgetrf_bufferSize(size_t handle, int m, int n,
     return lwork
 
 cpdef int sgeqrf_bufferSize(size_t handle, int m, int n,
-                            size_t A, int lda) except *:
+                            size_t A, int lda) except? -1:
     cdef int lwork
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -372,7 +372,7 @@ cpdef int sgeqrf_bufferSize(size_t handle, int m, int n,
     return lwork
 
 cpdef int dgeqrf_bufferSize(size_t handle, int m, int n,
-                            size_t A, int lda) except *:
+                            size_t A, int lda) except? -1:
     cdef int lwork
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -400,7 +400,7 @@ cpdef dgeqrf(size_t handle, int m, int n, size_t A, int lda,
     check_status(status)
 
 cpdef int sorgqr_bufferSize(size_t handle, int m, int n, int k,
-                            size_t A, int lda, size_t tau) except *:
+                            size_t A, int lda, size_t tau) except? -1:
     cdef int lwork
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -411,7 +411,7 @@ cpdef int sorgqr_bufferSize(size_t handle, int m, int n, int k,
     return lwork
 
 cpdef int dorgqr_bufferSize(size_t handle, int m, int n, int k,
-                            size_t A, int lda, size_t tau) except *:
+                            size_t A, int lda, size_t tau) except? -1:
     cdef int lwork
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -501,7 +501,7 @@ cpdef dgebrd(size_t handle, int m, int n, size_t A, int lda,
             <double*>Work, lwork, <int*>devInfo)
     check_status(status)
 
-cpdef int sgesvd_bufferSize(size_t handle, int m, int n) except *:
+cpdef int sgesvd_bufferSize(size_t handle, int m, int n) except? -1:
     cdef int lwork
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -509,7 +509,7 @@ cpdef int sgesvd_bufferSize(size_t handle, int m, int n) except *:
     check_status(status)
     return lwork
 
-cpdef int dgesvd_bufferSize(size_t handle, int m, int n) except *:
+cpdef int dgesvd_bufferSize(size_t handle, int m, int n) except? -1:
     cdef int lwork
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:

--- a/cupy/cuda/cusparse.pxd
+++ b/cupy/cuda/cusparse.pxd
@@ -40,5 +40,5 @@ cpdef enum:
     CUSPARSE_DIRECTION_COLUMN = 1
 
 
-cpdef size_t create() except *
-cpdef void destroy(size_t handle)
+cpdef size_t create() except? 0
+cpdef destroy(size_t handle)

--- a/cupy/cuda/cusparse.pyx
+++ b/cupy/cuda/cusparse.pyx
@@ -460,7 +460,7 @@ cdef inline cuDoubleComplex double_complex_to_cuda(double complex value):
 ########################################
 # cuSPARSE Helper Function
 
-cpdef size_t create() except *:
+cpdef size_t create() except? 0:
     cdef Handle handle
     status = cusparseCreate(& handle)
     check_status(status)
@@ -474,17 +474,17 @@ cpdef size_t createMatDescr():
     return <size_t>desc
 
 
-cpdef void destroy(size_t handle):
+cpdef destroy(size_t handle):
     status = cusparseDestroy(<Handle >handle)
     check_status(status)
 
 
-cpdef void destroyMatDescr(size_t descr):
+cpdef destroyMatDescr(size_t descr):
     status = cusparseDestroyMatDescr(<MatDescr>descr)
     check_status(status)
 
 
-cpdef void setMatIndexBase(size_t descr, base):
+cpdef setMatIndexBase(size_t descr, base):
     status = cusparseSetMatIndexBase(<MatDescr>descr, base)
     check_status(status)
 
@@ -507,7 +507,7 @@ cpdef setStream(size_t handle, size_t stream):
 
 
 # cusparseGetStream is only available from CUDA 8.0
-# cpdef size_t getStream(size_t handle) except *:
+# cpdef size_t getStream(size_t handle) except? 0:
 #     cdef driver.Stream stream
 #     status = cusparseGetStream(<Handle>handle, &stream)
 #     check_status(status)

--- a/cupy/cuda/device.pxd
+++ b/cupy/cuda/device.pxd
@@ -1,7 +1,7 @@
-cpdef int get_device_id() except *
-cpdef size_t get_cublas_handle() except *
-cpdef size_t get_cusolver_handle() except *
-cpdef size_t get_cusparse_handle() except *
+cpdef int get_device_id() except? -1
+cpdef size_t get_cublas_handle() except? 0
+cpdef size_t get_cusolver_handle() except? 0
+cpdef size_t get_cusparse_handle() except? 0
 cpdef str get_compute_capability()
 
 cdef class Device:

--- a/cupy/cuda/device.pyx
+++ b/cupy/cuda/device.pyx
@@ -15,7 +15,7 @@ except ImportError:
     cusolver_enabled = False
 
 
-cpdef int get_device_id() except *:
+cpdef int get_device_id() except? -1:
     return runtime.getDevice()
 
 
@@ -26,7 +26,7 @@ cdef dict _cusparse_handles = {}
 cdef dict _compute_capabilities = {}
 
 
-cpdef size_t get_cublas_handle() except *:
+cpdef size_t get_cublas_handle() except? 0:
     dev_id = get_device_id()
     ret = _cublas_handles.get(dev_id, None)
     if ret is not None:
@@ -34,7 +34,7 @@ cpdef size_t get_cublas_handle() except *:
     return Device().cublas_handle
 
 
-cpdef size_t get_cusolver_handle() except *:
+cpdef size_t get_cusolver_handle() except? 0:
     dev_id = get_device_id()
     ret = _cusolver_handles.get(dev_id, None)
     if ret is not None:
@@ -49,7 +49,7 @@ cpdef get_cusolver_sp_handle():
     return Device().cusolver_sp_handle
 
 
-cpdef size_t get_cusparse_handle() except *:
+cpdef size_t get_cusparse_handle() except? 0:
     dev_id = get_device_id()
     ret = _cusparse_handles.get(dev_id, None)
     if ret is not None:

--- a/cupy/cuda/driver.pxd
+++ b/cupy/cuda/driver.pxd
@@ -35,24 +35,24 @@ cpdef devicePrimaryCtxRelease(Device dev)
 # Context management
 ###############################################################################
 
-cpdef size_t ctxGetCurrent() except *
+cpdef size_t ctxGetCurrent() except? 0
 cpdef ctxSetCurrent(size_t ctx)
-cpdef size_t ctxCreate(Device dev) except *
+cpdef size_t ctxCreate(Device dev) except? 0
 cpdef ctxDestroy(size_t ctx)
 
 ###############################################################################
 # Module load and kernel execution
 ###############################################################################
 
-cpdef size_t linkCreate() except *
+cpdef size_t linkCreate() except? 0
 cpdef linkAddData(size_t state, int input_type, bytes data, unicode name)
 cpdef bytes linkComplete(size_t state)
 cpdef linkDestroy(size_t state)
-cpdef size_t moduleLoad(str filename) except *
-cpdef size_t moduleLoadData(bytes image) except *
+cpdef size_t moduleLoad(str filename) except? 0
+cpdef size_t moduleLoadData(bytes image) except? 0
 cpdef moduleUnload(size_t module)
-cpdef size_t moduleGetFunction(size_t module, str funcname) except *
-cpdef size_t moduleGetGlobal(size_t module, str varname) except *
+cpdef size_t moduleGetFunction(size_t module, str funcname) except? 0
+cpdef size_t moduleGetGlobal(size_t module, str varname) except? 0
 cpdef launchKernel(
     size_t f, unsigned int grid_dim_x, unsigned int grid_dim_y,
     unsigned int grid_dim_z, unsigned int block_dim_x,

--- a/cupy/cuda/driver.pyx
+++ b/cupy/cuda/driver.pyx
@@ -102,7 +102,7 @@ cpdef devicePrimaryCtxRelease(Device dev):
 # Context management
 ###############################################################################
 
-cpdef size_t ctxGetCurrent() except *:
+cpdef size_t ctxGetCurrent() except? 0:
     cdef Context ctx
     with nogil:
         status = cuCtxGetCurrent(&ctx)
@@ -114,7 +114,7 @@ cpdef ctxSetCurrent(size_t ctx):
         status = cuCtxSetCurrent(<Context>ctx)
     check_status(status)
 
-cpdef size_t ctxCreate(Device dev) except *:
+cpdef size_t ctxCreate(Device dev) except? 0:
     cdef Context ctx
     cdef unsigned int flags = 0
     with nogil:
@@ -132,7 +132,7 @@ cpdef ctxDestroy(size_t ctx):
 # Module load and kernel execution
 ###############################################################################
 
-cpdef size_t linkCreate() except *:
+cpdef size_t linkCreate() except? 0:
     cpdef LinkState state
     with nogil:
         status = cuLinkCreate(0, <CUjit_option*>0, <void**>0, &state)
@@ -167,7 +167,7 @@ cpdef linkDestroy(size_t state):
     check_status(status)
 
 
-cpdef size_t moduleLoad(str filename) except *:
+cpdef size_t moduleLoad(str filename) except? 0:
     cdef Module module
     cdef bytes b_filename = filename.encode()
     cdef char* b_filename_ptr = b_filename
@@ -177,7 +177,7 @@ cpdef size_t moduleLoad(str filename) except *:
     return <size_t>module
 
 
-cpdef size_t moduleLoadData(bytes image) except *:
+cpdef size_t moduleLoadData(bytes image) except? 0:
     cdef Module module
     cdef char* image_ptr = image
     with nogil:
@@ -192,7 +192,7 @@ cpdef moduleUnload(size_t module):
     check_status(status)
 
 
-cpdef size_t moduleGetFunction(size_t module, str funcname) except *:
+cpdef size_t moduleGetFunction(size_t module, str funcname) except? 0:
     cdef Function func
     cdef bytes b_funcname = funcname.encode()
     cdef char* b_funcname_ptr = b_funcname
@@ -202,7 +202,7 @@ cpdef size_t moduleGetFunction(size_t module, str funcname) except *:
     return <size_t>func
 
 
-cpdef size_t moduleGetGlobal(size_t module, str varname) except *:
+cpdef size_t moduleGetGlobal(size_t module, str varname) except? 0:
     cdef Deviceptr var
     cdef size_t size
     cdef bytes b_varname = varname.encode()

--- a/cupy/cuda/function.pyx
+++ b/cupy/cuda/function.pyx
@@ -114,9 +114,9 @@ cdef inline size_t _get_stream(stream) except *:
         return stream.ptr
 
 
-cdef void _launch(size_t func, Py_ssize_t grid0, int grid1, int grid2,
-                  Py_ssize_t block0, int block1, int block2,
-                  args, Py_ssize_t shared_mem, size_t stream) except *:
+cdef _launch(size_t func, Py_ssize_t grid0, int grid1, int grid2,
+             Py_ssize_t block0, int block1, int block2,
+             args, Py_ssize_t shared_mem, size_t stream):
     cdef list pargs = []
     cdef vector.vector[void*] kargs
     cdef CPointer cp

--- a/cupy/cuda/nvrtc.pxd
+++ b/cupy/cuda/nvrtc.pxd
@@ -18,7 +18,7 @@ cpdef tuple getVersion()
 ###############################################################################
 
 cpdef size_t createProgram(unicode src, unicode name, headers,
-                           include_names) except *
+                           include_names) except? 0
 cpdef destroyProgram(size_t prog)
 cpdef compileProgram(size_t prog, options)
 cpdef unicode getPTX(size_t prog)

--- a/cupy/cuda/nvrtc.pyx
+++ b/cupy/cuda/nvrtc.pyx
@@ -66,7 +66,7 @@ cpdef tuple getVersion():
 ###############################################################################
 
 cpdef size_t createProgram(unicode src, unicode name, headers,
-                           include_names) except *:
+                           include_names) except? 0:
     cdef Program prog
     cdef bytes b_src = src.encode()
     cdef const char* src_ptr = b_src

--- a/cupy/cuda/nvtx.pyx
+++ b/cupy/cuda/nvtx.pyx
@@ -90,7 +90,7 @@ cdef nvtxEventAttributes_t make_event_attributes(str message, color):
     return attrib
 
 
-cpdef void MarkC(str message, uint32_t color=0) except *:
+cpdef MarkC(str message, uint32_t color=0):
     """
     Marks an instantaneous event (marker) in the application.
 
@@ -118,7 +118,7 @@ cpdef void MarkC(str message, uint32_t color=0) except *:
     nvtxMarkEx(&attrib)
 
 
-cpdef void Mark(str message, int id_color=-1) except *:
+cpdef Mark(str message, int id_color=-1):
     """
     Marks an instantaneous event (marker) in the application.
 
@@ -138,7 +138,7 @@ cpdef void Mark(str message, int id_color=-1) except *:
     MarkC(message, color)
 
 
-cpdef void RangePushC(str message, uint32_t color=0) except *:
+cpdef RangePushC(str message, uint32_t color=0):
     """
     Starts a nested range.
 
@@ -167,7 +167,7 @@ cpdef void RangePushC(str message, uint32_t color=0) except *:
     nvtxRangePushEx(&attrib)
 
 
-cpdef void RangePush(str message, int id_color=-1) except *:
+cpdef RangePush(str message, int id_color=-1):
     """
     Starts a nested range.
 
@@ -188,7 +188,7 @@ cpdef void RangePush(str message, int id_color=-1) except *:
     RangePushC(message, color)
 
 
-cpdef void RangePop() except *:
+cpdef RangePop():
     """
     Ends a nested range.
 
@@ -199,10 +199,10 @@ cpdef void RangePop() except *:
     nvtxRangePop()
 
 
-cpdef unsigned long long RangeStart(str message, color) except *:
+cpdef unsigned long long RangeStart(str message, color) except? 0:
     cdef nvtxEventAttributes_t attrib = make_event_attributes(message, color)
     return nvtxRangeStartEx(&attrib)
 
 
-cpdef void RangeEnd(unsigned long long range_id) except *:
+cpdef RangeEnd(unsigned long long range_id):
     nvtxRangeEnd(range_id)

--- a/cupy/cuda/profiler.pxd
+++ b/cupy/cuda/profiler.pxd
@@ -6,7 +6,6 @@ cpdef enum:
     cudaKeyValuePair = 0
     cudaCSV = 1
 
-cpdef void initialize(
-    str config_file, str output_file, int output_mode) except *
-cpdef void start() except *
-cpdef void stop() except *
+cpdef initialize(str config_file, str output_file, int output_mode)
+cpdef start()
+cpdef stop()

--- a/cupy/cuda/profiler.pyx
+++ b/cupy/cuda/profiler.pyx
@@ -12,9 +12,9 @@ cdef extern from "cupy_cuda.h" nogil:
     runtime.Error cudaProfilerStop()
 
 
-cpdef void initialize(str config_file,
-                      str output_file,
-                      int output_mode) except *:
+cpdef initialize(str config_file,
+                 str output_file,
+                 int output_mode):
     """Initialize the CUDA profiler.
 
     This function initialize the CUDA profiler. See the CUDA document for
@@ -34,7 +34,7 @@ cpdef void initialize(str config_file,
     runtime.check_status(status)
 
 
-cpdef void start() except *:
+cpdef start():
     """Enable profiling.
 
     A user can enable CUDA profiling. When an error occurs, it raises an
@@ -46,7 +46,7 @@ cpdef void start() except *:
     runtime.check_status(status)
 
 
-cpdef void stop() except *:
+cpdef stop():
     """Disable profiling.
 
     A user can disable CUDA profiling. When an error occurs, it raises an

--- a/cupy/cuda/runtime.pxd
+++ b/cupy/cuda/runtime.pxd
@@ -79,21 +79,21 @@ cpdef check_status(int status)
 # Initialization
 ###############################################################################
 
-cpdef int driverGetVersion() except *
-cpdef int runtimeGetVersion() except *
+cpdef int driverGetVersion() except? -1
+cpdef int runtimeGetVersion() except? -1
 
 
 ###############################################################################
 # Device and context operations
 ###############################################################################
 
-cpdef int getDevice() except *
-cpdef int deviceGetAttribute(int attrib, int device) except *
-cpdef int getDeviceCount() except *
+cpdef int getDevice() except? -1
+cpdef int deviceGetAttribute(int attrib, int device) except? -1
+cpdef int getDeviceCount() except? -1
 cpdef setDevice(int device)
 cpdef deviceSynchronize()
 
-cpdef int deviceCanAccessPeer(int device, int peerDevice) except *
+cpdef int deviceCanAccessPeer(int device, int peerDevice) except? -1
 cpdef deviceEnablePeerAccess(int peerDevice)
 
 
@@ -101,9 +101,9 @@ cpdef deviceEnablePeerAccess(int peerDevice)
 # Memory management
 ###############################################################################
 
-cpdef size_t malloc(size_t size) except *
-cpdef size_t mallocManaged(size_t size, unsigned int flags=*) except *
-cpdef size_t hostAlloc(size_t size, unsigned int flags) except *
+cpdef size_t malloc(size_t size) except? 0
+cpdef size_t mallocManaged(size_t size, unsigned int flags=*) except? 0
+cpdef size_t hostAlloc(size_t size, unsigned int flags) except? 0
 cpdef free(size_t ptr)
 cpdef freeHost(size_t ptr)
 cpdef memGetInfo()
@@ -127,18 +127,18 @@ cpdef PointerAttributes pointerGetAttributes(size_t ptr)
 # Stream and Event
 ###############################################################################
 
-cpdef size_t streamCreate() except *
-cpdef size_t streamCreateWithFlags(unsigned int flags) except *
+cpdef size_t streamCreate() except? 0
+cpdef size_t streamCreateWithFlags(unsigned int flags) except? 0
 cpdef streamDestroy(size_t stream)
 cpdef streamSynchronize(size_t stream)
 cpdef streamAddCallback(size_t stream, callback, size_t arg,
                         unsigned int flags=*)
 cpdef streamQuery(size_t stream)
 cpdef streamWaitEvent(size_t stream, size_t event, unsigned int flags=*)
-cpdef size_t eventCreate() except *
-cpdef size_t eventCreateWithFlags(unsigned int flags) except *
+cpdef size_t eventCreate() except? 0
+cpdef size_t eventCreateWithFlags(unsigned int flags) except? 0
 cpdef eventDestroy(size_t event)
-cpdef float eventElapsedTime(size_t start, size_t end) except *
+cpdef float eventElapsedTime(size_t start, size_t end) except? 0
 cpdef eventQuery(size_t event)
 cpdef eventRecord(size_t event, size_t stream)
 cpdef eventSynchronize(size_t event)

--- a/cupy/cuda/runtime.pyx
+++ b/cupy/cuda/runtime.pyx
@@ -138,14 +138,14 @@ cpdef inline check_status(int status):
 # Initialization
 ###############################################################################
 
-cpdef int driverGetVersion() except *:
+cpdef int driverGetVersion() except? -1:
     cdef int version
     status = cudaDriverGetVersion(&version)
     check_status(status)
     return version
 
 
-cpdef int runtimeGetVersion() except *:
+cpdef int runtimeGetVersion() except? -1:
     cdef int version
     status = cudaRuntimeGetVersion(&version)
     check_status(status)
@@ -156,21 +156,21 @@ cpdef int runtimeGetVersion() except *:
 # Device and context operations
 ###############################################################################
 
-cpdef int getDevice() except *:
+cpdef int getDevice() except? -1:
     cdef int device
     status = cudaGetDevice(&device)
     check_status(status)
     return device
 
 
-cpdef int deviceGetAttribute(int attrib, int device) except *:
+cpdef int deviceGetAttribute(int attrib, int device) except? -1:
     cdef int ret
     status = cudaDeviceGetAttribute(&ret, <DeviceAttr>attrib, device)
     check_status(status)
     return ret
 
 
-cpdef int getDeviceCount() except *:
+cpdef int getDeviceCount() except? -1:
     cdef int count
     status = cudaGetDeviceCount(&count)
     check_status(status)
@@ -188,7 +188,7 @@ cpdef deviceSynchronize():
     check_status(status)
 
 
-cpdef int deviceCanAccessPeer(int device, int peerDevice) except *:
+cpdef int deviceCanAccessPeer(int device, int peerDevice) except? -1:
     cpdef int ret
     status = cudaDeviceCanAccessPeer(&ret, device, peerDevice)
     check_status(status)
@@ -204,7 +204,7 @@ cpdef deviceEnablePeerAccess(int peerDevice):
 # Memory management
 ###############################################################################
 
-cpdef size_t malloc(size_t size) except *:
+cpdef size_t malloc(size_t size) except? 0:
     cdef void* ptr
     with nogil:
         status = cudaMalloc(&ptr, size)
@@ -213,7 +213,7 @@ cpdef size_t malloc(size_t size) except *:
 
 
 cpdef size_t mallocManaged(size_t size,
-                           unsigned int flags=cudaMemAttachGlobal) except *:
+                           unsigned int flags=cudaMemAttachGlobal) except? 0:
     cdef void* ptr
     with nogil:
         status = cudaMallocManaged(&ptr, size, flags)
@@ -221,7 +221,7 @@ cpdef size_t mallocManaged(size_t size,
     return <size_t>ptr
 
 
-cpdef size_t hostAlloc(size_t size, unsigned int flags) except *:
+cpdef size_t hostAlloc(size_t size, unsigned int flags) except? 0:
     cdef void* ptr
     with nogil:
         status = cudaHostAlloc(&ptr, size, flags)
@@ -318,14 +318,14 @@ cpdef PointerAttributes pointerGetAttributes(size_t ptr):
 # Stream and Event
 ###############################################################################
 
-cpdef size_t streamCreate() except *:
+cpdef size_t streamCreate() except? 0:
     cdef driver.Stream stream
     status = cudaStreamCreate(&stream)
     check_status(status)
     return <size_t>stream
 
 
-cpdef size_t streamCreateWithFlags(unsigned int flags) except *:
+cpdef size_t streamCreateWithFlags(unsigned int flags) except? 0:
     cdef driver.Stream stream
     status = cudaStreamCreateWithFlags(&stream, flags)
     check_status(status)
@@ -373,13 +373,13 @@ cpdef streamWaitEvent(size_t stream, size_t event, unsigned int flags=0):
     check_status(status)
 
 
-cpdef size_t eventCreate() except *:
+cpdef size_t eventCreate() except? 0:
     cdef driver.Event event
     status = cudaEventCreate(&event)
     check_status(status)
     return <size_t>event
 
-cpdef size_t eventCreateWithFlags(unsigned int flags) except *:
+cpdef size_t eventCreateWithFlags(unsigned int flags) except? 0:
     cdef driver.Event event
     status = cudaEventCreateWithFlags(&event, flags)
     check_status(status)
@@ -391,7 +391,7 @@ cpdef eventDestroy(size_t event):
     check_status(status)
 
 
-cpdef float eventElapsedTime(size_t start, size_t end) except *:
+cpdef float eventElapsedTime(size_t start, size_t end) except? 0:
     cdef float ms
     status = cudaEventElapsedTime(&ms, <driver.Event>start, <driver.Event>end)
     check_status(status)

--- a/cupy/cudnn.pyx
+++ b/cupy/cudnn.pyx
@@ -22,7 +22,7 @@ cdef _thread_local = threading.local()
 cdef vector.vector[size_t] _handles
 
 
-cpdef size_t get_handle() except *:
+cpdef size_t get_handle() except? 0:
     cdef int dev
     dev = device.get_device_id()
     if _handles.size() <= dev:


### PR DESCRIPTION
CuPy uses a lot of `except *`, but there is a better way.
http://cython.readthedocs.io/en/latest/src/userguide/language_basics.html#error-return-values


- Removing `void`. The PR uses `cpdef function(...)` instead of `cpdef void function(...)`.
- Using `except? 0` instead of `except *` when return type is `size_t` and `float`.
- Mostly, using `except? -1` instead of `except *` when return type is `int`, `bint`.
