### PR TITLE
exclude Cython files from sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
-recursive-include cupy *.pyx *.pxd *.pxi *.h
+recursive-include cupy *.h
+recursive-exclude cupy *.pyx *.pxd *.pxi
 include cupy_setup_build.py
 recursive-include install *.py

--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -160,8 +160,15 @@ def module_extension_name(file):
 
 def module_extension_sources(file, use_cython, no_cuda):
     pyx, others = ensure_module_file(file)
-    ext = '.pyx' if use_cython else '.cpp'
-    pyx = path.join(*pyx.split('.')) + ext
+    base = path.join(*pyx.split('.'))
+    if use_cython:
+        pyx = base + '.pyx'
+        if not os.path.exists(pyx):
+            use_cython = False
+            print(
+                'NOTICE: Skipping cythonize as {} does not exist.'.format(pyx))
+    if not use_cython:
+        pyx = base + '.cpp'
 
     # If CUDA SDK is not available, remove CUDA C files from extension sources
     # and use stubs defined in header files.


### PR DESCRIPTION
This PR fixes #906.

* Exclude Cython source files from sdist distribution (on PyPI).
* If Cython source is missing on installation, fallback to use `*.cpp`.