### PR TITLE
Support CUDA stream on FFT

### DIFF
--- a/cupy/cuda/cupy_cufft.h
+++ b/cupy/cuda/cupy_cufft.h
@@ -61,6 +61,11 @@ cufftResult_t cufftSetWorkArea(...) {
     return CUFFT_SUCCESS;
 }
 
+// cuFFT Stream Function
+cufftResult_t cufftSetStream(...) {
+    return CUFFT_SUCCESS;
+}
+
 // cuFFT Plan Function
 cufftResult_t cufftMakePlan1d(...) {
     return CUFFT_SUCCESS;

--- a/examples/stream/cufft.py
+++ b/examples/stream/cufft.py
@@ -1,0 +1,18 @@
+# nvprof --print-gpu-trace python examples/stream/cufft.py
+import cupy
+
+x = cupy.array([1, 0, 3, 0, 5, 0, 7, 0, 9], dtype=float)
+expected_f = cupy.fft.fft(x)
+cupy.cuda.Device().synchronize()
+
+stream = cupy.cuda.stream.Stream()
+with stream:
+    f = cupy.fft.fft(x)
+stream.synchronize()
+cupy.testing.assert_array_equal(f, expected_f)
+
+stream = cupy.cuda.stream.Stream()
+stream.use()
+f = cupy.fft.fft(x)
+stream.synchronize()
+cupy.testing.assert_array_equal(f, expected_f)


### PR DESCRIPTION
Support CUDA stream on `cupy.cuda.cufft`.
I verified by running `nvprof --print-gpu-trace python examples/stream/cufft.py`.