### PR TITLE
Use __dealloc__ in memory object

### DIFF
--- a/cupy/cuda/memory.pxd
+++ b/cupy/cuda/memory.pxd
@@ -4,6 +4,14 @@ from libcpp cimport map
 from cupy.cuda cimport device
 
 
+cdef class Memory:
+
+    cdef:
+        public size_t ptr
+        public Py_ssize_t size
+        readonly device.Device device
+
+
 cdef class Chunk:
 
     cdef:
@@ -19,9 +27,9 @@ cdef class Chunk:
 cdef class MemoryPointer:
 
     cdef:
-        readonly device.Device device
-        readonly object mem
         readonly size_t ptr
+        readonly device.Device device
+        readonly Memory mem
 
     cpdef copy_from_device(self, MemoryPointer src, Py_ssize_t size)
     cpdef copy_from_device_async(self, MemoryPointer src, size_t size,

--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -32,7 +32,6 @@ thread_local = threading.local()
 
 
 cdef inline _ensure_context(int device_id):
-
     """Ensure that CUcontext bound to the calling host thread exists.
 
     See discussion on https://github.com/cupy/cupy/issues/72 for details.
@@ -56,7 +55,6 @@ class OutOfMemoryError(MemoryError):
 
 
 cdef class Memory:
-
     """Memory allocation on a CUDA device.
 
     This class provides an RAII interface of the CUDA memory allocation.
@@ -65,15 +63,11 @@ cdef class Memory:
         size (int): Size of the memory allocation in bytes.
 
     Attributes:
-        ptr (int): Pointer to the place within the buffer.
-        size (int): Size of the memory allocation in bytes.
-        device (~cupy.cuda.Device): Device whose memory the pointer refers to.
+        ~Memory.ptr (int): Pointer to the place within the buffer.
+        ~Memory.size (int): Size of the memory allocation in bytes.
+        ~Memory.device (~cupy.cuda.Device): Device whose memory the pointer
+            refers to.
     """
-
-    cdef:
-        public size_t ptr
-        public Py_ssize_t size
-        readonly device_mod.Device device
 
     def __init__(self, Py_ssize_t size):
         self.size = size
@@ -93,7 +87,6 @@ cdef class Memory:
 
 
 cdef class ManagedMemory(Memory):
-
     """Managed memory (Unified memory) allocation on a CUDA device.
 
     This class provides an RAII interface of the CUDA managed memory
@@ -162,14 +155,14 @@ cdef class Chunk:
     sorted by base address that must be contiguous.
 
     Args:
-        mem (Memory): The device memory buffer.
+        mem (~cupy.cuda.Memory): The device memory buffer.
         offset (int): An offset bytes from the head of the buffer.
         size (int): Chunk size in bytes.
         stream_ptr (size_t): Raw stream handle of cupy.cuda.Stream
 
     Attributes:
-        device (cupy.cuda.Device): Device whose memory the pointer refers to.
-        mem (Memory): The device memory buffer.
+        device (~cupy.cuda.Device): Device whose memory the pointer refers to.
+        mem (~cupy.cuda.Memory): The device memory buffer.
         ptr (size_t): Memory address.
         offset (int): An offset bytes from the head of the buffer.
         size (int): Chunk size in bytes.
@@ -178,7 +171,8 @@ cdef class Chunk:
         stream_ptr (size_t): Raw stream handle of cupy.cuda.Stream
     """
 
-    def __init__(self, mem, Py_ssize_t offset, Py_ssize_t size, stream_ptr):
+    def __init__(self, Memory mem, Py_ssize_t offset,
+                 Py_ssize_t size, stream_ptr):
         assert mem.ptr > 0 or offset == 0
         self.mem = mem
         self.device = mem.device
@@ -191,7 +185,6 @@ cdef class Chunk:
 
 
 cdef class MemoryPointer:
-
     """Pointer to a point on a device memory.
 
     An instance of this class holds a reference to the original memory buffer
@@ -205,8 +198,8 @@ cdef class MemoryPointer:
     Attributes:
         ~MemoryPointer.device (~cupy.cuda.Device): Device whose memory the
             pointer refers to.
-        mem (~cupy.cuda.Memory): The device memory buffer.
-        ptr (size_t): Pointer to the place within the buffer.
+        ~MemoryPointer.mem (~cupy.cuda.Memory): The device memory buffer.
+        ~MemoryPointer.ptr (size_t): Pointer to the place within the buffer.
     """
 
     def __init__(self, Memory mem, Py_ssize_t offset):
@@ -536,6 +529,7 @@ cdef class PooledMemory(Memory):
         if _exit_mode:
             return  # To avoid error at exit
         self.free()
+
 
 cdef int _index_compaction_threshold = 512
 

--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -62,15 +62,18 @@ cdef class Memory:
     This class provides an RAII interface of the CUDA memory allocation.
 
     Args:
-        ~Memory.device (cupy.cuda.Device): Device whose memory the pointer
-            refers to.
-        ~Memory.size (int): Size of the memory allocation in bytes.
+        size (int): Size of the memory allocation in bytes.
 
+    Attributes:
+        ptr (int): Pointer to the place within the buffer.
+        size (int): Size of the memory allocation in bytes.
+        device (~cupy.cuda.Device): Device whose memory the pointer refers to.
     """
+
     cdef:
         public size_t ptr
         public Py_ssize_t size
-        public device.Device device
+        readonly device_mod.Device device
 
     def __init__(self, Py_ssize_t size):
         self.size = size
@@ -97,7 +100,6 @@ cdef class ManagedMemory(Memory):
     allocation.
 
     Args:
-        device (cupy.cuda.Device): Device whose memory the pointer refers to.
         size (int): Size of the memory allocation in bytes.
 
     """
@@ -196,18 +198,18 @@ cdef class MemoryPointer:
     and a pointer to a place within this buffer.
 
     Args:
-        mem (Memory): The device memory buffer.
+        mem (~cupy.cuda.Memory): The device memory buffer.
         offset (int): An offset from the head of the buffer to the place this
             pointer refers.
 
     Attributes:
-        ~MemoryPointer.device (cupy.cuda.Device): Device whose memory the
+        ~MemoryPointer.device (~cupy.cuda.Device): Device whose memory the
             pointer refers to.
-        mem (Memory): The device memory buffer.
+        mem (~cupy.cuda.Memory): The device memory buffer.
         ptr (size_t): Pointer to the place within the buffer.
     """
 
-    def __init__(self, mem, Py_ssize_t offset):
+    def __init__(self, Memory mem, Py_ssize_t offset):
         assert mem.ptr > 0 or offset == 0
         self.mem = mem
         self.device = mem.device
@@ -480,8 +482,9 @@ cdef class PooledMemory(Memory):
     should not instantiate it by hand.
 
     """
+
     cdef:
-        public object pool
+        readonly object pool
 
     def __init__(self, Chunk chunk, pool):
         self.device = chunk.device

--- a/cupy/cuda/stream.pyx
+++ b/cupy/cuda/stream.pyx
@@ -63,7 +63,7 @@ class Event(object):
             processes.
 
     Attributes:
-        ptr (cupy.cuda.runtime.Stream): Raw stream handle. It can be passed to
+        ~Event.ptr (size_t): Raw stream handle. It can be passed to
             the CUDA Runtime API via ctypes.
 
     """
@@ -143,7 +143,7 @@ class Stream(object):
             the NULL stream.
 
     Attributes:
-        ptr (size_t): Raw stream handle. It can be passed to
+        ~Stream.ptr (size_t): Raw stream handle. It can be passed to
             the CUDA Runtime API via ctypes.
 
     """

--- a/tests/cupy_tests/cuda_tests/test_memory.py
+++ b/tests/cupy_tests/cuda_tests/test_memory.py
@@ -15,7 +15,6 @@ class MockMemory(memory.Memory):
         self.ptr = MockMemory.cur_ptr
         MockMemory.cur_ptr += size
         self.size = size
-        self.device = None
 
     def __del__(self):
         self.ptr = 0


### PR DESCRIPTION
I checked generated code by Cython. If object has no cycle reference, __dealloc__ is safe IMO.
Please see also #381.

And, this PR uses `atexit` to avoid error at exit.
