### PR TITLE
remove trailing NULL from values returned from NVRTC

### DIFF
--- a/cupy/cuda/nvrtc.pyx
+++ b/cupy/cuda/nvrtc.pyx
@@ -120,6 +120,9 @@ cpdef unicode getPTX(size_t prog):
     with nogil:
         status = nvrtcGetPTX(<Program>prog, ptx_ptr)
     check_status(status)
+
+    # Strip the trailing NULL.
+    ptx = ptx[:-1]
     return ptx.decode('UTF-8')
 
 
@@ -135,4 +138,7 @@ cpdef unicode getProgramLog(size_t prog):
     with nogil:
         status = nvrtcGetProgramLog(<Program>prog, log_ptr)
     check_status(status)
+
+    # Strip the trailing NULL.
+    log = log[:-1]
     return log.decode('UTF-8')

--- a/cupy/cuda/nvrtc.pyx
+++ b/cupy/cuda/nvrtc.pyx
@@ -122,6 +122,7 @@ cpdef unicode getPTX(size_t prog):
     check_status(status)
 
     # Strip the trailing NULL.
+    assert ptx.endswith(b'\x00')
     ptx = ptx[:-1]
     return ptx.decode('UTF-8')
 
@@ -140,5 +141,6 @@ cpdef unicode getProgramLog(size_t prog):
     check_status(status)
 
     # Strip the trailing NULL.
+    assert log.endswith(b'\x00')
     log = log[:-1]
     return log.decode('UTF-8')


### PR DESCRIPTION
According to the [API reference of NVRTC](http://docs.nvidia.com/cuda/nvrtc/index.html#group__compilation_1gc622d6ffb6fff71e209407da19612c1a), sizes returned by `nvrtcGetPTXSize` and `nvrtcGetProgramLogSize` includes trailing NULL.
As a result, when the error occur, garbage appears at the end.
<img width="749" alt="screen shot 2018-02-09 at 12 41 45" src="https://user-images.githubusercontent.com/939877/36010799-bf4d59b6-0d96-11e8-9138-fd40122ec374.png">
