### PR TITLE
Reduce GPU device object

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -408,7 +408,7 @@ cdef class ndarray:
             return self.astype(self.dtype, copy=True, order=order)
 
         dev_id = device.get_device_id()
-        if self.data.device_id == device.get_device_id():
+        if self.data.device_id == dev_id:
             return self.astype(self.dtype, copy=True, order=order)
 
         # It need to make a contiguous copy for copying from another device

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -371,7 +371,10 @@ cdef class ndarray:
         else:
             newarray = ndarray(self.shape, dtype=dtype, order=chr(order_char))
 
-        if self.dtype.kind == 'c' and newarray.dtype.kind == 'b':
+        if self.size == 0:
+            # skip copy
+            pass
+        elif self.dtype.kind == 'c' and newarray.dtype.kind == 'b':
             cupy.not_equal(self, 0j, out=newarray)
         elif self.dtype.kind == 'c' and newarray.dtype.kind != 'c':
             warnings.warn(

--- a/cupy/core/dlpack.pyx
+++ b/cupy/core/dlpack.pyx
@@ -1,5 +1,4 @@
 cimport cpython  # NOQA
-from cpython cimport pycapsule
 
 from libc cimport stdlib
 from libc.stdint cimport uint8_t

--- a/cupy/core/dlpack.pyx
+++ b/cupy/core/dlpack.pyx
@@ -1,4 +1,5 @@
 cimport cpython  # NOQA
+from cpython cimport pycapsule
 
 from libc cimport stdlib
 from libc.stdint cimport uint8_t
@@ -100,7 +101,7 @@ cpdef object toDlpack(ndarray array) except +:
 
     cdef DLContext* ctx = &dl_tensor.ctx
     ctx.device_type = DLDeviceType.kDLGPU
-    ctx.device_id = array.device.id
+    ctx.device_id = array.data.device_id
 
     cdef DLDataType* dtype = &dl_tensor.dtype
     if array.dtype.kind == 'u':
@@ -136,7 +137,7 @@ cdef class DLPackMemory(memory.Memory):
         self.dltensor = dltensor
         self.dlm_tensor = <DLManagedTensor *>cpython.PyCapsule_GetPointer(
             dltensor, 'dltensor')
-        self.device = cupy.cuda.Device(self.dlm_tensor.dl_tensor.ctx.device_id)
+        self.device_id = self.dlm_tensor.dl_tensor.ctx.device_id
         self.ptr = self.dlm_tensor.dl_tensor.data
         cdef int n = 0
         cdef int ndim = self.dlm_tensor.dl_tensor.ndim

--- a/cupy/core/elementwise.pxi
+++ b/cupy/core/elementwise.pxi
@@ -56,12 +56,12 @@ cpdef list _preprocess_args(args, bint use_c_scalar=False):
     for arg in args:
         typ = type(arg)
         if typ is ndarray:
-            arr_dev = (<ndarray?>arg).data.device
-            if arr_dev is not None and arr_dev.id != dev_id:
+            arr_dev_id = (<ndarray?>arg).data.device_id
+            if arr_dev_id != dev_id:
                 raise ValueError(
                     'Array device must be same as the current '
                     'device: array device = %d while current = %d'
-                    % (arr_dev.id, dev_id))
+                    % (arr_dev_id, dev_id))
         else:
             arg = _scalar.convert_scalar(arg, use_c_scalar)
             if arg is None:

--- a/cupy/cuda/memory.pxd
+++ b/cupy/cuda/memory.pxd
@@ -12,14 +12,14 @@ cdef class Memory:
     cdef:
         public size_t ptr
         public Py_ssize_t size
-        readonly device.Device device
+        public int device_id
 
 
 cdef class MemoryPointer:
 
     cdef:
         readonly size_t ptr
-        readonly device.Device device
+        readonly int device_id
         readonly Memory mem
 
     cpdef copy_from_device(self, MemoryPointer src, Py_ssize_t size)

--- a/tests/cupy_tests/creation_tests/test_from_data.py
+++ b/tests/cupy_tests/creation_tests/test_from_data.py
@@ -108,8 +108,8 @@ class TestFromData(unittest.TestCase):
             y = cupy.array(x)
         self.assertIsInstance(y, cupy.ndarray)
         self.assertIsNot(x, y)  # Do copy
-        self.assertIsNone(x.device)
-        self.assertIsNone(y.device)
+        assert x.device.id == 0
+        assert y.device.id == 1
         testing.assert_array_equal(x, y)
 
     @testing.for_all_dtypes()

--- a/tests/cupy_tests/cuda_tests/test_memory.py
+++ b/tests/cupy_tests/cuda_tests/test_memory.py
@@ -16,6 +16,7 @@ class MockMemory(memory.Memory):
         self.ptr = MockMemory.cur_ptr
         MockMemory.cur_ptr += size
         self.size = size
+        self.device_id = 0
 
     def __del__(self):
         self.ptr = 0

--- a/tests/cupy_tests/cuda_tests/test_pinned_memory.py
+++ b/tests/cupy_tests/cuda_tests/test_pinned_memory.py
@@ -11,7 +11,6 @@ class MockMemory(pinned_memory.PinnedMemory):
         self.ptr = MockMemory.cur_ptr
         MockMemory.cur_ptr += size
         self.size = size
-        self.device = None
 
     def __del__(self):
         self.ptr = 0


### PR DESCRIPTION
This PR reduce GPU device object. In most cases it is less expensive to keep the GPU device id.

No compatible point.
- `ndarray.device` will not be `None`. So far it is `None` when the array size is 0.


