### PR TITLE
add --cupy-long-description option to inject long description for wheels

### DIFF
--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -427,6 +427,9 @@ def parse_args():
         '--cupy-package-name', type=str, default='cupy',
         help='alternate package name')
     parser.add_argument(
+        '--cupy-long-description', type=str, default=None,
+        help='path to the long description file')
+    parser.add_argument(
         '--cupy-wheel-lib', type=str, action='append', default=[],
         help='shared library to copy into the wheel '
              '(can be specified for multiple times)')
@@ -444,6 +447,7 @@ def parse_args():
 
     arg_options = {
         'package_name': opts.cupy_package_name,
+        'long_description': opts.cupy_long_description,
         'wheel_libs': opts.cupy_wheel_lib,  # list
         'profile': opts.cupy_profile,
         'linetrace': opts.cupy_coverage,
@@ -461,6 +465,14 @@ print('Options:', cupy_setup_options)
 
 def get_package_name():
     return cupy_setup_options['package_name']
+
+
+def get_long_description():
+    path = cupy_setup_options['long_description']
+    if path is None:
+        return None
+    with open(path) as f:
+        return f.read()
 
 
 def prepare_wheel_libs():

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ package_data = {
 package_data['cupy'] += cupy_setup_build.prepare_wheel_libs()
 
 package_name = cupy_setup_build.get_package_name()
+long_description = cupy_setup_build.get_long_description()
 ext_modules = cupy_setup_build.get_ext_modules()
 build_ext = cupy_setup_build.custom_build_ext
 sdist = cupy_setup_build.sdist_with_cython
@@ -72,6 +73,7 @@ setup(
     name=package_name,
     version=__version__,
     description='CuPy: NumPy-like API accelerated with CUDA',
+    long_description=long_description,
     author='Seiya Tokui',
     author_email='tokui@preferred.jp',
     url='https://docs-cupy.chainer.org/',


### PR DESCRIPTION
This PR adds the option to inject long description from file, so that we can insert additional information for each wheel (like below) to be shown on each PyPI package page.

```
This wheel package requires CUDA 9.0.
Please see `Installation Guide <https://docs-cupy.chainer.org/en/latest/install.html>`_ for wheels for other CUDA versions or installation from source.
```