### PR TITLE
fix test failure in cuDNN v5 which does not support CUDNN_ACTIVATION_ELU

### DIFF
--- a/tests/cupy_tests/test_cudnn.py
+++ b/tests/cupy_tests/test_cudnn.py
@@ -13,8 +13,10 @@ try:
     ]
     coef_modes = [
         libcudnn.CUDNN_ACTIVATION_CLIPPED_RELU,
-        libcudnn.CUDNN_ACTIVATION_ELU,
     ]
+    if libcudnn.getVersion() >= 6000:
+        coef_modes.append(libcudnn.CUDNN_ACTIVATION_ELU)
+
     import cupy.cudnn
 except ImportError:
     cudnn_enabled = False


### PR DESCRIPTION
`CUDNN_ACTIVATION_ELU` is a feature introduced in cuDNN v6.

https://developer.nvidia.com/compute/machine-learning/cudnn/secure/v6/prod/Doc/cuDNN_v6.0_ReleaseNotes-pdf