### PR TITLE
Add destroy method to NcclCommunicator

### DIFF
--- a/cupy/cuda/nccl.pyx
+++ b/cupy/cuda/nccl.pyx
@@ -129,7 +129,7 @@ cdef class NcclCommunicator:
     def __dealloc__(self):
         self.destroy()
 
-    def destroy(self):
+    cpdef destroy(self):
         if self._comm:
             ncclCommDestroy(self._comm)
             self._comm = <ncclComm_t>0

--- a/cupy/cuda/nccl.pyx
+++ b/cupy/cuda/nccl.pyx
@@ -127,8 +127,12 @@ cdef class NcclCommunicator:
         check_status(status)
 
     def __dealloc__(self):
+        self.destroy()
+
+    def destroy(self):
         if self._comm:
             ncclCommDestroy(self._comm)
+            self._comm = <ncclComm_t>0
 
     def device_id(self):
         cdef int device_id


### PR DESCRIPTION
TL; DR: this pull request is for fault tolerance in ChainerMN.

To continue distributed training in ChainerMN, the training cluster must endure process failure and also the communicator must be reconstructed. The simplest way to enable reconstruction is to add explicit `destroy()` method, rather than reconstruction method. This change enables reconstruction like this:

```python
  comm = nccl.NcclCommunicator(8, comm_id, 3)
  ...(node failure detected)...
  comm.destroy()
  new_rank = renew_rank()
  comm = nccl.NcclCommunicator(7, comm_id, new_rank)
  ...(resume computation)...
```

See [another example](https://gist.github.com/kuenishi/370df96974051b2dc6159366a8f62d7d) for working code. Maybe I could add null-checking code for all other methods than `destroy()`, but don't want to mess up current code more than this before basic discussion.