### PR TITLE
Expose context management API in driver

### DIFF
--- a/cupy/cuda/cupy_cuda.h
+++ b/cupy/cuda/cupy_cuda.h
@@ -137,6 +137,10 @@ typedef struct CUmod_st* CUmodule;
 typedef struct CUstream_st* cudaStream_t;
 typedef struct CUlinkState_st* CUlinkState;
 
+// Initialization
+CUresult cuInit(...) {
+    return CUDA_SUCCESS;
+}
 
 // Error handling
 CUresult cuGetErrorName(...) {
@@ -147,9 +151,41 @@ CUresult cuGetErrorString(...) {
     return CUDA_SUCCESS;
 }
 
+// Primary context management
+CUresult cuDevicePrimaryCtxGetState(...) {
+    return CUDA_SUCCESS;
+}
+
+CUresult cuDevicePrimaryCtxSetFlags(...) {
+    return CUDA_SUCCESS;
+}
+
+CUresult cuDevicePrimaryCtxRelease(...) {
+    return CUDA_SUCCESS;
+}
+
+CUresult cuDevicePrimaryCtxReset(...) {
+    return CUDA_SUCCESS;
+}
+
+CUresult cuDevicePrimaryCtxRetain(...) {
+    return CUDA_SUCCESS;
+}
 
 // Context management
 CUresult cuCtxGetCurrent(...) {
+    return CUDA_SUCCESS;
+}
+
+CUresult cuCtxSetCurrent(...) {
+    return CUDA_SUCCESS;
+}
+
+CUresult cuCtxCreate(...) {
+    return CUDA_SUCCESS;
+}
+
+CUresult cuCtxDestroy(...) {
     return CUDA_SUCCESS;
 }
 

--- a/cupy/cuda/cupy_cuda.h
+++ b/cupy/cuda/cupy_cuda.h
@@ -137,11 +137,6 @@ typedef struct CUmod_st* CUmodule;
 typedef struct CUstream_st* cudaStream_t;
 typedef struct CUlinkState_st* CUlinkState;
 
-// Initialization
-CUresult cuInit(...) {
-    return CUDA_SUCCESS;
-}
-
 // Error handling
 CUresult cuGetErrorName(...) {
     return CUDA_SUCCESS;
@@ -152,23 +147,7 @@ CUresult cuGetErrorString(...) {
 }
 
 // Primary context management
-CUresult cuDevicePrimaryCtxGetState(...) {
-    return CUDA_SUCCESS;
-}
-
-CUresult cuDevicePrimaryCtxSetFlags(...) {
-    return CUDA_SUCCESS;
-}
-
 CUresult cuDevicePrimaryCtxRelease(...) {
-    return CUDA_SUCCESS;
-}
-
-CUresult cuDevicePrimaryCtxReset(...) {
-    return CUDA_SUCCESS;
-}
-
-CUresult cuDevicePrimaryCtxRetain(...) {
     return CUDA_SUCCESS;
 }
 

--- a/cupy/cuda/driver.pxd
+++ b/cupy/cuda/driver.pxd
@@ -29,16 +29,16 @@ cpdef enum:
 # Primary context management
 ###############################################################################
 
-cpdef void devicePrimaryCtxRelease(Device dev) except *
+cpdef devicePrimaryCtxRelease(Device dev)
 
 ###############################################################################
 # Context management
 ###############################################################################
 
 cpdef size_t ctxGetCurrent() except *
-cpdef void ctxSetCurrent(size_t ctx) except *
+cpdef ctxSetCurrent(size_t ctx)
 cpdef size_t ctxCreate(Device dev) except *
-cpdef void ctxDestroy(size_t ctx) except *
+cpdef ctxDestroy(size_t ctx)
 
 ###############################################################################
 # Module load and kernel execution

--- a/cupy/cuda/driver.pxd
+++ b/cupy/cuda/driver.pxd
@@ -26,10 +26,29 @@ cpdef enum:
 
 
 ###############################################################################
+# Initialization
+###############################################################################
+
+cpdef void init() except *
+
+###############################################################################
+# Primary context management
+###############################################################################
+
+# def tuple devicePrimaryCtxGetState(Device dev)
+cpdef void devicePrimaryCtxSetFlags(Device dev, unsigned int flags) except *
+cpdef void devicePrimaryCtxRelease(Device dev) except *
+cpdef void devicePrimaryCtxReset(Device dev) except *
+cpdef size_t devicePrimaryCtxRetain(Device dev) except *
+
+###############################################################################
 # Context management
 ###############################################################################
 
 cpdef size_t ctxGetCurrent() except *
+cpdef void ctxSetCurrent(size_t ctx) except *
+cpdef size_t ctxCreate(Device dev) except *
+cpdef void ctxDestroy(size_t ctx) except *
 
 ###############################################################################
 # Module load and kernel execution

--- a/cupy/cuda/driver.pxd
+++ b/cupy/cuda/driver.pxd
@@ -26,20 +26,10 @@ cpdef enum:
 
 
 ###############################################################################
-# Initialization
-###############################################################################
-
-cpdef void init() except *
-
-###############################################################################
 # Primary context management
 ###############################################################################
 
-# def tuple devicePrimaryCtxGetState(Device dev)
-cpdef void devicePrimaryCtxSetFlags(Device dev, unsigned int flags) except *
 cpdef void devicePrimaryCtxRelease(Device dev) except *
-cpdef void devicePrimaryCtxReset(Device dev) except *
-cpdef size_t devicePrimaryCtxRetain(Device dev) except *
 
 ###############################################################################
 # Context management

--- a/cupy/cuda/driver.pyx
+++ b/cupy/cuda/driver.pyx
@@ -93,7 +93,7 @@ def get_build_version():
 # Primary context management
 ###############################################################################
 
-cpdef void devicePrimaryCtxRelease(Device dev) except *:
+cpdef devicePrimaryCtxRelease(Device dev):
     with nogil:
         status = cuDevicePrimaryCtxRelease(dev)
     check_status(status)
@@ -109,7 +109,7 @@ cpdef size_t ctxGetCurrent() except *:
     check_status(status)
     return <size_t>ctx
 
-cpdef void ctxSetCurrent(size_t ctx) except *:
+cpdef ctxSetCurrent(size_t ctx):
     with nogil:
         status = cuCtxSetCurrent(<Context>ctx)
     check_status(status)
@@ -122,7 +122,7 @@ cpdef size_t ctxCreate(Device dev) except *:
     check_status(status)
     return <size_t>ctx
 
-cpdef void ctxDestroy(size_t ctx) except *:
+cpdef ctxDestroy(size_t ctx):
     with nogil:
         status = cuCtxDestroy(<Context>ctx)
     check_status(status)

--- a/cupy/cuda/driver.pyx
+++ b/cupy/cuda/driver.pyx
@@ -23,16 +23,8 @@ cdef extern from "cupy_cuda.h" nogil:
     int cuGetErrorName(Result error, const char** pStr)
     int cuGetErrorString(Result error, const char** pStr)
 
-    # Initialization
-    int cuInit(unsigned int flags)
-
     # Primary context management
-    int cuDevicePrimaryCtxGetState(Device dev, unsigned int* flags,
-                                   int* active)
-    int cuDevicePrimaryCtxSetFlags(Device dev, unsigned int flags)
     int cuDevicePrimaryCtxRelease(Device dev)
-    int cuDevicePrimaryCtxReset(Device dev)
-    int cuDevicePrimaryCtxRetain(Context* pctx, Device dev)
 
     # Context management
     int cuCtxGetCurrent(Context* pctx)
@@ -98,50 +90,13 @@ def get_build_version():
 
 
 ###############################################################################
-# Initialization
-###############################################################################
-
-cpdef void init() except *:
-    cdef unsigned int flags = 0
-    with nogil:
-        status = cuInit(flags)
-    check_status(status)
-
-
-###############################################################################
 # Primary context management
 ###############################################################################
-
-def devicePrimaryCtxGetState(Device dev):
-    cdef unsigned int flags
-    cdef int active
-    with nogil:
-        status = cuDevicePrimaryCtxGetState(dev, &flags, &active)
-    check_status(status)
-    return flags, active
-
-cpdef void devicePrimaryCtxSetFlags(Device dev, unsigned int flags) except *:
-    with nogil:
-        status = cuDevicePrimaryCtxSetFlags(dev, flags)
-    check_status(status)
 
 cpdef void devicePrimaryCtxRelease(Device dev) except *:
     with nogil:
         status = cuDevicePrimaryCtxRelease(dev)
     check_status(status)
-
-cpdef void devicePrimaryCtxReset(Device dev) except *:
-    with nogil:
-        status = cuDevicePrimaryCtxReset(dev)
-    check_status(status)
-
-cpdef size_t devicePrimaryCtxRetain(Device dev) except *:
-    cdef Context ctx
-    with nogil:
-        status = cuDevicePrimaryCtxRetain(&ctx, dev)
-    check_status(status)
-    return <size_t>ctx
-
 
 ###############################################################################
 # Context management


### PR DESCRIPTION
This PR exposes low-level CUDA functions for manually modifying the CUDA context. I found it useful when using `cupy` with the `multiprocessing` module, as it will create superfluous CUDA contexts that need to be removed manually.

One design issue is that only `devicePrimaryCtxGetState` is a Python function, since it returns a tuple, while the other functions are defined with `cpdef`. Do you have any opinion on whether this function should also be exposed to the Cython side with `cpdef`?