### PR TITLE
Fix ndarray.diagonal to accept appropriate argument of axis2

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -3209,8 +3209,7 @@ cpdef _scatter_op(ndarray a, slices, value, op):
 cpdef ndarray _diagonal(ndarray a, Py_ssize_t offset=0, Py_ssize_t axis1=0,
                         Py_ssize_t axis2=1):
     cdef Py_ssize_t ndim = a.ndim
-    if (axis1 >= ndim or axis2 >= ndim or
-            axis1 < - ndim or axis2 < - ndim):
+    if not (-ndim <= axis1 < ndim and -ndim <= axis2 < ndim):
         raise ValueError('axis1(={0}) and axis2(={1}) must be within range '
                          '(ndim={2})'.format(axis1, axis2, ndim))
 

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -3209,7 +3209,7 @@ cpdef _scatter_op(ndarray a, slices, value, op):
 cpdef ndarray _diagonal(ndarray a, Py_ssize_t offset=0, Py_ssize_t axis1=0,
                         Py_ssize_t axis2=1):
     cdef Py_ssize_t ndim = a.ndim
-    if (axis1 >= ndim or abs(axis2) >= ndim or
+    if (axis1 >= ndim or axis2 >= ndim or
             axis1 < - ndim or axis2 < - ndim):
         raise ValueError('axis1(={0}) and axis2(={1}) must be within range '
                          '(ndim={2})'.format(axis1, axis2, ndim))

--- a/tests/cupy_tests/indexing_tests/test_indexing.py
+++ b/tests/cupy_tests/indexing_tests/test_indexing.py
@@ -61,6 +61,18 @@ class TestIndexing(unittest.TestCase):
         a = testing.shaped_arange((3, 3, 3), xp, dtype)
         return a.diagonal(0, -1, 1)
 
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_diagonal_negative4(self, xp, dtype):
+        a = testing.shaped_arange((3, 3, 3), xp, dtype)
+        return a.diagonal(0, -3, -1)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_diagonal_negative5(self, xp, dtype):
+        a = testing.shaped_arange((3, 3, 3), xp, dtype)
+        return a.diagonal(0, -1, -3)
+
     @testing.numpy_cupy_raises()
     def test_diagonal_invalid1(self, xp):
         a = testing.shaped_arange((3, 3, 3), xp)


### PR DESCRIPTION
In numpy, [`ndarray.diagonal(x, offset, axis1, axis2)`](https://docs.scipy.org/doc/numpy/reference/generated/numpy.ndarray.diagonal.html) accepts negative axis for both axis1 and axis2. The smallest negative axis we can specify is `-x.ndim` (i.e., the range of axis1 and axis2 is `-x.ndim <= axis < x.ndim` ).
However, in cupy, the same method cannot accept `axis2=-x.ndim` (i.e., the range of axis2 is `-x.ndim < axis < x.ndim` ).
This inconsistency between numpy and cupy does not seem to be intended.

This PR allows `axis2` to be `-x.ndim` .

## code for reproduction and its output
```python
import numpy as np
import cupy

x_np = np.arange(16).reshape(4, 4)
y_np21 = x_np.diagonal(axis1=-2, axis2=-1)
print('y_np21 =', y_np21)
y_np12 = x_np.diagonal(axis1=-1, axis2=-2)
print('y_np12 =', y_np12)
np.testing.assert_array_equal(y_np21, y_np12)

x_cp = cupy.asarray(x_np)
y_cp21 = x_cp.diagonal(axis1=-2, axis2=-1)  # no error
print('y_cp21 =', y_cp21)
y_cp12 = x_cp.diagonal(axis1=-1, axis2=-2)  # error
print('y_cp12 =', y_cp12)
```

```python
y_np21 = [ 0  5 10 15]
y_np12 = [ 0  5 10 15]
y_cp21 = [ 0  5 10 15]
Traceback (most recent call last):

  File "<ipython-input-25-67a2b84a9668>", line 1, in <module>
    runfile('C:/Users/sakurai/Google ドライブ/Python/chainer_trace/tmp_debu.py', wdir='C:/Users/sakurai/Google ドライブ/Python/chainer_trace')

  File "C:\Users\sakurai\Anaconda3\lib\site-packages\spyder\utils\site\sitecustomize.py", line 710, in runfile
    execfile(filename, namespace)

  File "C:\Users\sakurai\Anaconda3\lib\site-packages\spyder\utils\site\sitecustomize.py", line 101, in execfile
    exec(compile(f.read(), filename, 'exec'), namespace)

  File "C:/Users/sakurai/Google ドライブ/Python/chainer_trace/tmp_debu.py", line 14, in <module>
    y_cp12 = x_cp.diagonal(axis1=-1, axis2=-2)  # error

  File "cupy/core/core.pyx", line 982, in cupy.core.core.ndarray.diagonal

  File "cupy/core/core.pyx", line 990, in cupy.core.core.ndarray.diagonal

  File "cupy/core/core.pyx", line 3209, in cupy.core.core._diagonal

ValueError: axis1(=-1) and axis2(=-2) must be within range (ndim=2)
```