### PR TITLE
Use current stream in array method

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2037,7 +2037,7 @@ cpdef ndarray array(obj, dtype=None, bint copy=True, str order='K',
         src_cpu = numpy.frombuffer(mem, a_cpu.dtype,
                                    a_cpu.size).reshape(a_cpu.shape)
         src_cpu[...] = a_cpu
-        stream = cuda.Stream.null
+        stream = stream_module.get_current_stream()
         a.set(src_cpu, stream)
         pinned_memory._add_to_watch_list(stream.record(), mem)
     return a

--- a/cupy/cuda/stream.pxd
+++ b/cupy/cuda/stream.pxd
@@ -1,1 +1,2 @@
 cdef size_t get_current_stream_ptr()
+cpdef get_current_stream()

--- a/cupy/cuda/stream.pyx
+++ b/cupy/cuda/stream.pyx
@@ -19,7 +19,7 @@ cdef size_t get_current_stream_ptr():
     return <size_t>pythread.PyThread_get_key_value(_current_stream_key)
 
 
-def get_current_stream():
+cpdef get_current_stream():
     """Gets current CUDA stream.
 
     Returns:


### PR DESCRIPTION
Currently, we provides `set_default_stream` method.
I want to use default stream in `array` method.