### PR TITLE
Prefer pip in documentation

### DIFF
--- a/docs/source/contribution.rst
+++ b/docs/source/contribution.rst
@@ -158,7 +158,7 @@ In order to run unit tests at the repository root, you first have to build Cytho
 
 .. note::
 
-  When you modify ``*.pxd`` files, before running ``pip install .``, you must clean ``*.cpp`` and ``*.so`` files once with the following command, because Cython does not automatically rebuild those files nicely::
+  When you modify ``*.pxd`` files, before running ``pip install -e .``, you must clean ``*.cpp`` and ``*.so`` files once with the following command, because Cython does not automatically rebuild those files nicely::
 
     $ git clean -fdx
 

--- a/docs/source/contribution.rst
+++ b/docs/source/contribution.rst
@@ -154,11 +154,11 @@ Note that we are using pytest and mock package for testing, so install them befo
 
 In order to run unit tests at the repository root, you first have to build Cython files in place by running the following command::
 
-  $ python setup.py develop
+  $ pip install .
 
 .. note::
 
-  When you modify ``*.pxd`` files, before running ``python setup.py develop``, you must clean ``*.cpp`` and ``*.so`` files once with the following command, because Cython does not automatically rebuild those files nicely::
+  When you modify ``*.pxd`` files, before running ``pip install .``, you must clean ``*.cpp`` and ``*.so`` files once with the following command, because Cython does not automatically rebuild those files nicely::
 
     $ git clean -fdx
 

--- a/docs/source/contribution.rst
+++ b/docs/source/contribution.rst
@@ -154,7 +154,7 @@ Note that we are using pytest and mock package for testing, so install them befo
 
 In order to run unit tests at the repository root, you first have to build Cython files in place by running the following command::
 
-  $ pip install .
+  $ pip install -e .
 
 .. note::
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -106,17 +106,15 @@ Install CuPy from source
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 The tarball of the source tree is available via ``pip download cupy`` or from `the release notes page <https://github.com/cupy/cupy/releases>`_.
-You can use ``setup.py`` to install CuPy from the tarball::
+You can install CuPy from the tarball::
 
-  $ tar zxf cupy-x.x.x.tar.gz
-  $ cd cupy-x.x.x
-  $ python setup.py install
+  $ pip install cupy-x.x.x.tar.gz
 
 You can also install the development version of CuPy from a cloned Git repository::
 
   $ git clone https://github.com/cupy/cupy.git
   $ cd cupy
-  $ python setup.py install
+  $ pip install .
 
 
 .. _install_error:


### PR DESCRIPTION
We should encourage pip. Corresponding to https://github.com/chainer/chainer/pull/4366.