### PR TITLE
update to CUDA 8.0 and use CuPy wheels in Dockerfiles

### DIFF
--- a/docker/python2/Dockerfile
+++ b/docker/python2/Dockerfile
@@ -1,9 +1,11 @@
-FROM nvidia/cuda:7.5-cudnn5-devel
+FROM nvidia/cuda:8.0-cudnn6-devel
 
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
     python-dev \
-    python-pip && \
+    python-pip \
+    python-wheel \
+    python-setuptools && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
-RUN pip install cupy==4.0.0b4
+RUN pip install cupy-cuda80==4.0.0b4

--- a/docker/python3/Dockerfile
+++ b/docker/python3/Dockerfile
@@ -1,9 +1,11 @@
-FROM nvidia/cuda:7.5-cudnn5-devel
+FROM nvidia/cuda:8.0-cudnn6-devel
 
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
     python3-dev \
-    python3-pip && \
+    python3-pip \
+    python3-wheel \
+    python3-setuptools && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
-RUN pip3 install cupy==4.0.0b4
+RUN pip3 install cupy-cuda80==4.0.0b4


### PR DESCRIPTION
This PR changes the base Docker image from CUDA 7.5 to 8.0 (as done in Chainer https://github.com/chainer/chainer/pull/3902), and use CuPy wheel for installation.