### PR TITLE
remove unnecessary heading from reference

### DIFF
--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -6,15 +6,10 @@ Reference Manual
 
 This is the official reference of CuPy, a multi-dimensional array on CUDA with a subset of NumPy interface.
 
-
-Indices and tables
-==================
-
 * :ref:`genindex`
 * :ref:`modindex`
 
-Reference
-=========
+----
 
 .. module:: cupy
 


### PR DESCRIPTION
Tree in the left pane has a redundant hierarchy and difficult to access.

https://docs-cupy.chainer.org/en/stable/reference/index.html#module-cupy