### PR TITLE
Fix eliminate zeros

### DIFF
--- a/cupy/sparse/coo.py
+++ b/cupy/sparse/coo.py
@@ -146,7 +146,6 @@ class coo_matrix(sparse_data._data_matrix):
 
     def eliminate_zeros(self):
         """Removes zero entories in place."""
-        self.sum_duplicates()
         ind = self.data != 0
         self.data = self.data[ind]
         self.row = self.row[ind]

--- a/cupy/sparse/csr.py
+++ b/cupy/sparse/csr.py
@@ -137,7 +137,6 @@ class csr_matrix(compressed._compressed_sparse_matrix):
 
     def eliminate_zeros(self):
         """Removes zero entories in place."""
-        self.sum_duplicates()
         if cupy.cuda.runtime.runtimeGetVersion() >= 8000:
             compress = cusparse.csr2csr_compress(self, 0)
         else:

--- a/tests/cupy_tests/sparse_tests/test_coo.py
+++ b/tests/cupy_tests/sparse_tests/test_coo.py
@@ -750,12 +750,11 @@ class TestCooMatrixScipyComparison(unittest.TestCase):
         m = _make(xp, sp, self.dtype)
         m.transpose(axes=0)
 
-    @testing.numpy_cupy_allclose(sp_name='sp')
+    @testing.numpy_cupy_equal(sp_name='sp')
     def test_eliminate_zeros(self, xp, sp):
-        m = _make(xp, sp, self.dtype)
+        m = self.make(xp, sp, self.dtype)
         m.eliminate_zeros()
-        self.assertEqual(m.nnz, 3)
-        return m.toarray()
+        return m.nnz
 
 
 @testing.parameterize(*testing.product({


### PR DESCRIPTION
NumPy does not call `sum_duplicates` in `eliminate_zeros`. I removed this call.
related to #834 