### PR TITLE
fix exception handling fail on Windows with Python 3.x

### DIFF
--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -666,7 +666,7 @@ class _MSVCCompiler(msvccompiler.MSVCCompiler):
             try:
                 self.spawn(compiler_so + cc_args + [src, '-o', obj] + postargs)
             except errors.DistutilsExecError as e:
-                raise errors.CompileError(e.message)
+                raise errors.CompileError(str(e))
 
         return objects
 


### PR DESCRIPTION
Exception message was not printed correctly during Windows build failure.