### PR TITLE
Implement __setitem__ in fusion function

### DIFF
--- a/cupy/core/fusion.py
+++ b/cupy/core/fusion.py
@@ -228,6 +228,13 @@ class _FusionRef(object):
     def __bool__(self):
         raise Exception("Can't cast to bool")
 
+    def __setitem__(self, slices, value):
+        if slices is Ellipsis or (isinstance(slices, slice) and
+                                  slices == slice(None)):
+            copy(value, self)
+        else:
+            raise ValueError('The fusion supports `[...]` or `[:]`.')
+
     def copy(self):
         return copy(self)
 

--- a/tests/cupy_tests/core_tests/test_fusion.py
+++ b/tests/cupy_tests/core_tests/test_fusion.py
@@ -667,6 +667,38 @@ class TestFusionUfunc(unittest.TestCase):
         ret1 = f(*data)  # Fused
         numpy.testing.assert_array_almost_equal(ret0.get(), ret1.get())
 
+    def test_setitem_ellipsis(self):
+        def func(x, y):
+            y[...] = x
+            return y
+
+        ret = self._check(
+            func, 2, self.random_int, ((2, 3),) * 2,
+            True, error_types=(TypeError,))
+        is_err, (arrs_n, arrs_f) = ret
+
+        if not is_err:
+            # The returned array must equal to z
+            ret, x, y = arrs_f
+            testing.assert_array_equal(x, ret)
+            testing.assert_array_equal(x, y)
+
+    def test_setitem_none_slice(self):
+        def func(x, y):
+            y[:] = x
+            return y
+
+        ret = self._check(
+            func, 2, self.random_int, ((2, 3),) * 2,
+            True, error_types=(TypeError,))
+        is_err, (arrs_n, arrs_f) = ret
+
+        if not is_err:
+            # The returned array must equal to z
+            ret, x, y = arrs_f
+            testing.assert_array_equal(x, ret)
+            testing.assert_array_equal(x, y)
+
     @testing.for_all_dtypes_combination(
         names=['src_dtype', 'dst_dtype'], full=True, no_complex=True)
     def test_out_arg(self, src_dtype, dst_dtype):


### PR DESCRIPTION
We want to use following code.
```
@cuda.fuse(input_num=None)
def hoge(x, y, z):
    z[...] = x + y
    return z
```
This feature is requested in chainer/chainer#4162 .