### PR TITLE
MAINT: warning on CUDA toolkit install

### DIFF
--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -5,6 +5,7 @@ import re
 import shutil
 import sys
 import tempfile
+import warnings
 
 import six
 
@@ -230,6 +231,9 @@ class _NVRTCProgram(object):
             return nvrtc.getPTX(self.ptr)
         except nvrtc.NVRTCError:
             log = nvrtc.getProgramLog(self.ptr)
+            warnings.warn('Has the CUDA toolkit been installed? '
+                          'Install details are available at '
+                          'https://developer.nvidia.com/cuda-downloads')
             raise CompileException(log, self.src, self.name, options)
 
 


### PR DESCRIPTION
I ran into a bug related to this. I had an unhelpful error message in #1005. This *might* help resolve that error message. I'm a new user of CuPy, and it's still not working for me.

I'm not sure if this is the right place for this warning. I *think* I got the same warning in #1005 before and after I installed the CUDA toolkit.