### PR TITLE
remove cudnn STATUS dict

### DIFF
--- a/cupy/cuda/cudnn.pyx
+++ b/cupy/cuda/cudnn.pyx
@@ -432,27 +432,12 @@ cdef extern from "cupy_cudnn.h" nogil:
 # Error handling
 ###############################################################################
 
-cdef dict STATUS = {
-    0: 'CUDNN_STATUS_SUCCESS',
-    1: 'CUDNN_STATUS_NOT_INITIALIZED',
-    2: 'CUDNN_STATUS_ALLOC_FAILED',
-    3: 'CUDNN_STATUS_BAD_PARAM',
-    4: 'CUDNN_STATUS_INTERNAL_ERROR',
-    5: 'CUDNN_STATUS_INVALID_VALUE',
-    6: 'CUDNN_STATUS_ARCH_MISMATCH',
-    7: 'CUDNN_STATUS_MAPPING_ERROR',
-    8: 'CUDNN_STATUS_EXECUTION_FAILED',
-    9: 'CUDNN_STATUS_NOT_SUPPORTED',
-    10: 'CUDNN_STATUS_LICENSE_ERROR',
-}
-
-
 class CuDNNError(RuntimeError):
 
     def __init__(self, int status):
         self.status = status
         msg = cudnnGetErrorString(<Status>status)
-        super(CuDNNError, self).__init__('%s: %s' % (STATUS[status], msg))
+        super(CuDNNError, self).__init__(msg.decode())
 
 
 @cython.profile(False)


### PR DESCRIPTION
cuDNN v7 adds following new status values:

```
CUDNN_STATUS_RUNTIME_PREREQUISITE_MISSING = 11,
CUDNN_STATUS_RUNTIME_IN_PROGRESS          = 12,
CUDNN_STATUS_RUNTIME_FP_OVERFLOW          = 13,
```

However they haven't added in the dictionary.

As `cudnnGetErrorString` returns the string version of the status (e.g., `CUDNN_STATUS_SUCCESS`), current error message is redundant. I think we don't have to manage the dict.