### PR TITLE
Fix shaped_random for complex number

### DIFF
--- a/cupy/testing/__init__.py
+++ b/cupy/testing/__init__.py
@@ -18,6 +18,7 @@ from cupy.testing.helper import assert_warns  # NOQA
 from cupy.testing.helper import for_all_dtypes  # NOQA
 from cupy.testing.helper import for_all_dtypes_combination  # NOQA
 from cupy.testing.helper import for_CF_orders  # NOQA
+from cupy.testing.helper import for_complex_dtypes  # NOQA
 from cupy.testing.helper import for_dtypes  # NOQA
 from cupy.testing.helper import for_dtypes_combination  # NOQA
 from cupy.testing.helper import for_float_dtypes  # NOQA

--- a/cupy/testing/helper.py
+++ b/cupy/testing/helper.py
@@ -680,6 +680,20 @@ def for_int_dtypes(name='dtype', no_bool=False):
         return for_dtypes(_int_bool_dtypes, name=name)
 
 
+def for_complex_dtypes(name='dtype'):
+    """Decorator that checks the fixture with all complex dtypes.
+
+    Args:
+         name(str): Argument name to which specified dtypes are passed.
+
+    dtypes to be tested are ``numpy.complex64`` and ``numpy.complex128``.
+
+    .. seealso:: :func:`cupy.testing.for_dtypes`,
+        :func:`cupy.testing.for_all_dtypes`
+    """
+    return for_dtypes(_complex_dtypes, name=name)
+
+
 def for_dtypes_combination(types, names=('dtype',), full=None):
     """Decorator that checks the fixture with a product set of dtypes.
 

--- a/cupy/testing/helper.py
+++ b/cupy/testing/helper.py
@@ -971,8 +971,12 @@ def shaped_random(shape, xp=cupy, dtype=numpy.float32, scale=10, seed=0):
     with specified dtype.
     """
     numpy.random.seed(seed)
-    if numpy.dtype(dtype).type == numpy.bool_:
+    dtype = numpy.dtype(dtype)
+    if dtype == '?':
         return xp.asarray(numpy.random.randint(2, size=shape).astype(dtype))
+    elif dtype.kind == 'c':
+        a = numpy.random.rand(*shape) + 1j * numpy.random.rand(*shape)
+        return xp.asarray((a * scale).astype(dtype))
     else:
         return xp.asarray((numpy.random.rand(*shape) * scale).astype(dtype))
 

--- a/docs/source/reference/testing.rst
+++ b/docs/source/reference/testing.rst
@@ -65,6 +65,7 @@ combination of dtype(s).
    cupy.testing.for_signed_dtypes
    cupy.testing.for_unsigned_dtypes
    cupy.testing.for_int_dtypes
+   cupy.testing.for_complex_dtypes
    cupy.testing.for_dtypes_combination
    cupy.testing.for_all_dtypes_combination
    cupy.testing.for_signed_dtypes_combination

--- a/tests/cupy_tests/testing_tests/test_helper.py
+++ b/tests/cupy_tests/testing_tests/test_helper.py
@@ -313,3 +313,38 @@ class TestIgnoreOfNegativeValueDifferenceOnCpuAndGpu(unittest.TestCase):
             return xp.array(-1, dtype=dtype1)
         else:
             return xp.array(-2, dtype=dtype1)
+
+
+@testing.parameterize(
+    {'xp': numpy},
+    {'xp': cupy},
+)
+@testing.gpu
+class TestShapedRandom(unittest.TestCase):
+
+    _multiprocess_can_split_ = True
+
+    @testing.for_all_dtypes()
+    def test_shape_and_dtype(self, dtype):
+        a = testing.shaped_random((2, 3), self.xp, dtype)
+        self.assertTrue(a.shape == (2, 3))
+        self.assertTrue(a.dtype == dtype)
+
+    @testing.for_all_dtypes(no_bool=True, no_complex=True)
+    def test_value_range(self, dtype):
+        a = testing.shaped_random((2, 3), self.xp, dtype)
+        self.assertTrue(self.xp.all(0 <= a))
+        self.assertTrue(self.xp.all(a < 10))
+
+    def test_bool(self):
+        a = testing.shaped_random(10000, self.xp, numpy.bool_)
+        self.assertTrue(4000 < self.xp.sum(a) < 6000)
+
+    @testing.for_complex_dtypes()
+    def test_complex(self, dtype):
+        a = testing.shaped_random((2, 3), self.xp, dtype)
+        self.assertTrue(self.xp.all(0 <= a.real))
+        self.assertTrue(self.xp.all(a.real < 10))
+        self.assertTrue(self.xp.all(0 <= a.imag))
+        self.assertTrue(self.xp.all(a.imag < 10))
+        self.assertTrue(self.xp.any(a.imag))


### PR DESCRIPTION
The original implementation of shaped_random always generates real number even if `dtype` indicates complex number.