### PR TITLE
Fix temporary variables which are used when input_num is given

### DIFF
--- a/cupy/core/fusion.py
+++ b/cupy/core/fusion.py
@@ -503,7 +503,9 @@ def _get_fusion(func, nin, reduce, post_map, identity, input_types, name):
     out_vars = [_normalize_arg(copy(_), mem) for _ in out_refs]
     nout = len(out_vars)
     op_list = mem.op_list
-    tmpvars = mem.var_list[nin:-nout] if nout > 0 else mem.var_list[nin:]
+    tmpvars = mem.var_list[len(in_vars):]
+    if nout > 0:
+        tmpvars = tmpvars[:-nout]
 
     in_params = ', '.join(_get_params(in_vars[:nin]))
     out_params = ', '.join(_get_params(out_vars))

--- a/tests/cupy_tests/core_tests/test_fusion.py
+++ b/tests/cupy_tests/core_tests/test_fusion.py
@@ -1355,3 +1355,15 @@ class TestFusionKernelName(unittest.TestCase):
             return func_a1(a, b, c)
 
         return self.check(xp, func, 'abc', False)
+
+
+@testing.gpu
+class TestFusionInputNum(unittest.TestCase):
+
+    def test_no_result(self):
+        @cupy.fuse(input_num=0)
+        def f(x):
+            pass
+
+        f(testing.shaped_arange((1,), numpy, 'f'))
+        f(testing.shaped_arange((1,), cupy, 'f'))


### PR DESCRIPTION
`tmpvars` is a set of variables that are defined in a given function. `mem.var_list[0:len(in_vars)]` is `in_vars`. We need to skip all these variables.
fix #1019 