### PR TITLE
WIP: ENH: have ndarray subclass np.ndarray

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -4,6 +4,7 @@ from __future__ import division
 import sys
 
 import numpy
+cimport numpy as np
 import six
 
 import cupy
@@ -50,7 +51,7 @@ except AttributeError:
     _AxisError = IndexOrValueError
 
 
-cdef class ndarray:
+cdef class ndarray(np.ndarray):
 
     """Multi-dimensional array on a CUDA device.
 


### PR DESCRIPTION
I've run into an error with CuPy where it wasn't recognized as a NumPy ndarray. That is, `isinstance(cupy_array, np.ndarray) == False`. This resolves that.

Specifically, I believe this would resolve https://github.com/numba/numba/issues/2786 (though it's untested). This issue happens because numba checks for `isinstance(arg, np.ndarray)` at [deviceufunc.py#L97].

I'm don't see why numba shouldn't work with CuPy. I'm a new user of CuPy, but this seems like it'd help with NumPy integration (but I'm not certain what expense this would come at).

I can devote more time to this, and test, but first I'd like to hear if this is reasonable.

[deviceufunc.py#L97]:https://github.com/numba/numba/blob/d6f3a74f5a56a2d98fd0f1aed69a7686d66bb033/numba/npyufunc/deviceufunc.py#L97