### PR TITLE
Fix moveaxis bug

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2143,7 +2143,7 @@ cpdef ndarray moveaxis(ndarray a, source, destination):
             order.push_back(n)
 
     cdef Py_ssize_t d, s
-    for d, s in sorted(six.moves.zip(dest, src)):
+    for d, s in sorted(zip(dest, src)):
         order.insert(order.begin() + d, s)
 
     return a.transpose(order)

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2137,9 +2137,8 @@ cpdef ndarray moveaxis(ndarray a, source, destination):
         if not _has_element(src, n):
             order.push_back(n)
 
-    for i in range(len(src)):
-        n = <Py_ssize_t>i
-        order.insert(order.begin() + dest[n], src[n])
+    for d, s in sorted(zip(dest, src)):
+        order.insert(order.begin() + <Py_ssize_t>d, <Py_ssize_t>s)
 
     return a.transpose(order)
 

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2142,8 +2142,9 @@ cpdef ndarray moveaxis(ndarray a, source, destination):
         if not _has_element(src, n):
             order.push_back(n)
 
-    for d, s in sorted(zip(dest, src)):
-        order.insert(order.begin() + <Py_ssize_t>d, <Py_ssize_t>s)
+    cdef Py_ssize_t d, s
+    for d, s in sorted(six.moves.zip(dest, src)):
+        order.insert(order.begin() + d, s)
 
     return a.transpose(order)
 

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2108,6 +2108,8 @@ cpdef vector.vector[Py_ssize_t] normalize_axis_tuple(axis, Py_ssize_t ndim) \
         except *:
     """Normalizes an axis argument into a tuple of non-negative integer axes.
 
+    Arguments `allow_duplicate` and `axis_name` are not supported.
+
     """
     if numpy.isscalar(axis):
         axis = (axis,)
@@ -2117,7 +2119,10 @@ cpdef vector.vector[Py_ssize_t] normalize_axis_tuple(axis, Py_ssize_t ndim) \
         if ax >= ndim or ax < -ndim:
             raise _AxisError('axis {} is out of bounds for array of '
                              'dimension {}'.format(ax, ndim))
+        if _has_element(ret, ax):
+            raise _AxisError('repeated axis')
         ret.push_back(ax % ndim)
+
     return ret
 
 

--- a/tests/cupy_tests/manipulation_tests/test_transpose.py
+++ b/tests/cupy_tests/manipulation_tests/test_transpose.py
@@ -21,6 +21,24 @@ class TestTranspose(unittest.TestCase):
         a = testing.shaped_arange((2, 3, 4), xp)
         return xp.moveaxis(a, 1, -1)
 
+    @testing.numpy_cupy_array_equal()
+    @testing.with_requires('numpy>=1.11')
+    def test_moveaxis3(self, xp):
+        a = testing.shaped_arange((2, 3, 4), xp)
+        return xp.moveaxis(a, [0, 2], [1, 0])
+
+    @testing.numpy_cupy_array_equal()
+    @testing.with_requires('numpy>=1.11')
+    def test_moveaxis4(self, xp):
+        a = testing.shaped_arange((2, 3, 4), xp)
+        return xp.moveaxis(a, [2, 0], [1, 0])
+
+    @testing.numpy_cupy_array_equal()
+    @testing.with_requires('numpy>=1.11')
+    def test_moveaxis5(self, xp):
+        a = testing.shaped_arange((2, 3, 4), xp)
+        return xp.moveaxis(a, [2, 0], [0, 1])
+
     # dim is too large
     @testing.numpy_cupy_raises()
     @testing.with_requires('numpy>=1.13')

--- a/tests/cupy_tests/manipulation_tests/test_transpose.py
+++ b/tests/cupy_tests/manipulation_tests/test_transpose.py
@@ -39,6 +39,12 @@ class TestTranspose(unittest.TestCase):
         a = testing.shaped_arange((2, 3, 4), xp)
         return xp.moveaxis(a, [2, 0], [0, 1])
 
+    @testing.numpy_cupy_array_equal()
+    @testing.with_requires('numpy>=1.11')
+    def test_moveaxis5(self, xp):
+        a = testing.shaped_arange((2, 3, 4, 5, 6), xp)
+        return xp.moveaxis(a, [0, 2, 1], [3, 4, 0])
+
     # dim is too large
     @testing.numpy_cupy_raises()
     @testing.with_requires('numpy>=1.13')

--- a/tests/cupy_tests/manipulation_tests/test_transpose.py
+++ b/tests/cupy_tests/manipulation_tests/test_transpose.py
@@ -83,6 +83,22 @@ class TestTranspose(unittest.TestCase):
         a = testing.shaped_arange((2, 3, 4), xp)
         return xp.moveaxis(a, [0, 1], [1, 2, 0])
 
+    # Use the same axis twice
+    def test_moveaxis_invalid5_1(self):
+        a = testing.shaped_arange((2, 3, 4), cupy)
+        with self.assertRaises(cupy.core.core._AxisError):
+            return cupy.moveaxis(a, [1, -1], [1, 3])
+
+    def test_moveaxis_invalid5_2(self):
+        a = testing.shaped_arange((2, 3, 4), cupy)
+        with self.assertRaises(cupy.core.core._AxisError):
+            return cupy.moveaxis(a, [0, 1], [-1, 2])
+
+    def test_moveaxis_invalid5_3(self):
+        a = testing.shaped_arange((2, 3, 4), cupy)
+        with self.assertRaises(cupy.core.core._AxisError):
+            return cupy.moveaxis(a, [0, 1], [1, 1])
+
     @testing.numpy_cupy_array_equal()
     def test_rollaxis(self, xp):
         a = testing.shaped_arange((2, 3, 4), xp)

--- a/tests/cupy_tests/manipulation_tests/test_transpose.py
+++ b/tests/cupy_tests/manipulation_tests/test_transpose.py
@@ -41,7 +41,7 @@ class TestTranspose(unittest.TestCase):
 
     @testing.numpy_cupy_array_equal()
     @testing.with_requires('numpy>=1.11')
-    def test_moveaxis5(self, xp):
+    def test_moveaxis6(self, xp):
         a = testing.shaped_arange((2, 3, 4, 5, 6), xp)
         return xp.moveaxis(a, [0, 2, 1], [3, 4, 0])
 


### PR DESCRIPTION
Embarrasingly, my cupy.moveaxis behavior is different from numpy if destination is not ascending order.
I fixed it and added tests.