### PR TITLE
Fix scatter_add docs

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1551,7 +1551,7 @@ cdef class ndarray:
         """Adds given values to specified elements of an array.
 
         .. seealso::
-            :func:`cupy.scatter_add` for full documentation.
+            :func:`cupyx.scatter_add` for full documentation.
 
         """
         _scatter_op(self, slices, value, 'add')

--- a/docs/source/reference/ufunc.rst
+++ b/docs/source/reference/ufunc.rst
@@ -148,4 +148,4 @@ ufunc.at
 --------
 
 Currently, CuPy does not support ``at`` for ufuncs in general.
-However, :func:`cupy.scatter_add` can substitute ``add.at`` as both behave identically.
+However, :func:`cupyx.scatter_add` can substitute ``add.at`` as both behave identically.


### PR DESCRIPTION
`cupy.scatter_add` is deprecated. #894
This PR fixes to use `cupyx.scatter_add`.