### PR TITLE
Fix cupy.copyto ignore where argument when src is scalar

### DIFF
--- a/cupy/manipulation/basic.py
+++ b/cupy/manipulation/basic.py
@@ -39,7 +39,7 @@ def copyto(dst, src, casting='same_kind', where=None):
     if dst.size == 0:
         return
 
-    if src_is_python_scalar:
+    if src_is_python_scalar and where is None:
         dst.fill(src)
         return
 

--- a/tests/cupy_tests/manipulation_tests/test_basic.py
+++ b/tests/cupy_tests/manipulation_tests/test_basic.py
@@ -108,7 +108,7 @@ class TestBasic(unittest.TestCase):
 
 @testing.parameterize(
     *testing.product(
-        {'src': [float(3.2), int(0), int(4), int(-4), True, False],
+        {'src': [float(3.2), int(0), int(4), int(-4), True, False, 1+1j],
          'dst_shape': [(), (0,), (1,), (1, 1), (2, 2)]}))
 @testing.gpu
 class TestCopytoFromScalar(unittest.TestCase):

--- a/tests/cupy_tests/manipulation_tests/test_basic.py
+++ b/tests/cupy_tests/manipulation_tests/test_basic.py
@@ -119,3 +119,12 @@ class TestCopytoFromScalar(unittest.TestCase):
         dst = xp.ones(self.dst_shape, dtype=dtype)
         xp.copyto(dst, self.src)
         return dst
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose(accept_error=TypeError)
+    def test_copyto_where(self, xp, dtype):
+        dst = xp.ones(self.dst_shape, dtype=dtype)
+        mask = (testing.shaped_arange(
+            self.dst_shape, xp, dtype) % 2).astype(xp.bool_)
+        xp.copyto(dst, self.src, where=mask)
+        return dst


### PR DESCRIPTION
Fixes #872