### PR TITLE
[RFC] Support array construction from list or tuple containing CuPy arrays

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2019,7 +2019,7 @@ cpdef ndarray array(obj, dtype=None, bint copy=True, str order='K',
             a.shape = (1,) * (ndmin - ndim) + a.shape
     else:
         concat_shape = _discover_dimensions(obj)
-        if concat_shape is not None:
+        if concat_shape is not None and concat_shape[-1] != 0:
             return concatenate_method(
                 _flatten_list(obj), 0).reshape(concat_shape)
 
@@ -2065,7 +2065,10 @@ cpdef tuple _discover_dimensions(obj):
         if shape2 is None or shape != shape2:
             return None
 
-    return (len(obj),) + shape
+    final_shape = (len(obj),)
+    if shape is not None:
+        final_shape += shape
+    return final_shape
 
 
 cpdef list _flatten_list(obj):

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2055,7 +2055,7 @@ cpdef tuple _discover_dimensions(obj):
     shape = None
     for elem in obj:
         shape2 = (elem.shape if isinstance(elem, ndarray) else
-            _discover_dimensions(elem))
+                  _discover_dimensions(elem))
 
         # Use shape of the first element as the common shape.
         if shape is None:

--- a/tests/cupy_tests/creation_tests/test_from_data.py
+++ b/tests/cupy_tests/creation_tests/test_from_data.py
@@ -116,6 +116,22 @@ class TestFromData(unittest.TestCase):
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
+    def test_array_from_tuple(self, xp, dtype):
+        a = testing.shaped_arange((2, 3, 4), xp, dtype)
+        b = xp.array((a, a, a, a, a))
+        self.assertEqual(b.shape, (5, 2, 3, 4))
+        return b
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_array_from_list(self, xp, dtype):
+        a = testing.shaped_arange((2, 3, 4), xp, dtype)
+        b = xp.array([[a, a, a], [a, a, a]])
+        self.assertEqual(b.shape, (2, 3, 2, 3, 4))
+        return b
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
     def test_asarray(self, xp, dtype):
         a = testing.shaped_arange((2, 3, 4), xp, dtype)
         return xp.asarray(a)

--- a/tests/cupy_tests/creation_tests/test_from_data.py
+++ b/tests/cupy_tests/creation_tests/test_from_data.py
@@ -130,6 +130,14 @@ class TestFromData(unittest.TestCase):
         self.assertEqual(b.shape, (2, 3, 2, 3, 4))
         return b
 
+    @testing.numpy_cupy_array_equal()
+    def test_array_from_empty_list(self, xp):
+        b = xp.array([[[], []],
+                      [[], []],
+                      [[], []]])
+        self.assertEqual(b.shape, (3, 2, 0))
+        return b
+
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_asarray(self, xp, dtype):


### PR DESCRIPTION
This PR mitigates the situation of #409.

I think handling a list of CuPy array is a common situation for users. For example, users may want to preprocess images one by one, then concatenate them into a single array to process them as one batch. In such case, users have to manually concatenate the list instead of calling `xp.asarray`, which is a step not needed in NumPy.