### PR TITLE
Fix broken link to numpy.sum

### DIFF
--- a/docs/source/reference/ndarray.rst
+++ b/docs/source/reference/ndarray.rst
@@ -20,8 +20,8 @@ Code compatibility features
 
 :class:`cupy.ndarray` is designed to be interchangeable with :class:`numpy.ndarray` in terms of code compatibility as much as possible.
 But occasionally, you will need to know whether the arrays you're handling are :class:`cupy.ndarray` or :class:`numpy.ndarray`.
-One example is when invoking module-level functions such as :meth:`cupy.sum` or :meth:`numpy.sum`.
-In such situations, :meth:`cupy.get_array_module` can be used.
+One example is when invoking module-level functions such as :func:`cupy.sum` or :func:`numpy.sum`.
+In such situations, :func:`cupy.get_array_module` can be used.
 
 .. autosummary::
    :toctree: generated/
@@ -36,8 +36,8 @@ Conversion to/from NumPy arrays
 :class:`cupy.ndarray` and :class:`numpy.ndarray` are not implicitly convertible to each other.
 That means, NumPy functions cannot take :class:`cupy.ndarray`\s as inputs, and vice versa.
 
-- To convert :class:`numpy.ndarray` to :class:`cupy.ndarray`, use :meth:`cupy.array` or :meth:`cupy.asarray`.
-- To convert :class:`cupy.ndarray` to :class:`numpy.ndarray`, use :meth:`cupy.asnumpy` or :meth:`cupy.ndarray.get`.
+- To convert :class:`numpy.ndarray` to :class:`cupy.ndarray`, use :func:`cupy.array` or :func:`cupy.asarray`.
+- To convert :class:`cupy.ndarray` to :class:`numpy.ndarray`, use :func:`cupy.asnumpy` or :meth:`cupy.ndarray.get`.
 
 Note that converting between :class:`cupy.ndarray` and :class:`numpy.ndarray` incurs data transfer between
 the host (CPU) device and the GPU device, which is costly in terms of performance.


### PR DESCRIPTION
This PR fixes to use `:func:` instead of `:meth:`.