### PR TITLE
limit arch to the maximum value allowed in each NVRTC version

### DIFF
--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -13,6 +13,7 @@ from cupy.cuda import function
 from cupy.cuda import nvrtc
 
 _nvrtc_version = None
+_nvrtc_max_compute_capability = None
 
 
 def _get_nvrtc_version():
@@ -24,7 +25,18 @@ def _get_nvrtc_version():
 
 
 def _get_arch():
-    cc = device.Device().compute_capability
+    global _nvrtc_max_compute_capability
+    if _nvrtc_max_compute_capability is None:
+        # See Supported Compile Options section of NVRTC User Guide for
+        # the maximum value allowed for `--gpu-architecture`.
+        major, minor = _get_nvrtc_version()
+        if major < 9:
+            # CUDA 7.0 / 7.5 / 8.0
+            _nvrtc_max_compute_capability = '53'
+        else:
+            # CUDA 9.0 / 9.1
+            _nvrtc_max_compute_capability = '72'
+    cc = min(device.Device().compute_capability, _nvrtc_max_compute_capability)
     return 'compute_%s' % cc
 
 

--- a/tests/cupy_tests/cuda_tests/test_compiler.py
+++ b/tests/cupy_tests/cuda_tests/test_compiler.py
@@ -44,10 +44,12 @@ class TestNvrtcArch(unittest.TestCase):
         self._compile('compute_52')
 
         # It should fail.
+        # (`compute_60` and `compute_61` are not supported by NVRTC in CUDA 8
+        #  but it does not raise error when used.)
         self.assertRaises(
             compiler.CompileException, self._compile, 'compute_54')
         self.assertRaises(
-            compiler.CompileException, self._compile, 'compute_60')
+            compiler.CompileException, self._compile, 'compute_70')
 
     @unittest.skipUnless(9000 <= cuda_version(), 'Requires CUDA 9.0 or later')
     def test_compile_cuda9(self):

--- a/tests/cupy_tests/cuda_tests/test_compiler.py
+++ b/tests/cupy_tests/cuda_tests/test_compiler.py
@@ -40,12 +40,8 @@ class TestNvrtcArch(unittest.TestCase):
         # This test is intended to detect specification change in NVRTC API.
 
         # It should not fail.
+        # (Do not test `compute_53` as it is for Tegra.)
         self._compile('compute_52')
-
-        # It should not fail (`compute_53` is valid according to the API
-        # Reference), but actually it fails.
-        self.assertRaises(
-            compiler.CompileException, self._compile, 'compute_53')
 
         # It should fail.
         self.assertRaises(
@@ -58,12 +54,8 @@ class TestNvrtcArch(unittest.TestCase):
         # This test is intended to detect specification change in NVRTC API.
 
         # It should not fail.
+        # (Do not test `compute_72` as it is for Tegra.)
         self._compile('compute_70')
-
-        # It should not fail (`compute_72` is valid according to the API
-        # Reference), but actually it fails.
-        self.assertRaises(
-            compiler.CompileException, self._compile, 'compute_72')
 
         # It should fail.
         self.assertRaises(

--- a/tests/cupy_tests/cuda_tests/test_compiler.py
+++ b/tests/cupy_tests/cuda_tests/test_compiler.py
@@ -1,9 +1,68 @@
 import unittest
 
+import mock
 import six
 
+import cupy
 from cupy.cuda import compiler
 from cupy import testing
+
+
+def cuda_version():
+    return cupy.cuda.runtime.runtimeGetVersion()
+
+
+@testing.gpu
+class TestNvrtcArch(unittest.TestCase):
+
+    def _check_get_arch(self, device_cc, expected_arch):
+        with mock.patch('cupy.cuda.device.Device') as device_class:
+            device_class.return_value.compute_capability = device_cc
+            assert compiler._get_arch() == expected_arch
+
+    @unittest.skipUnless(cuda_version() < 9000, 'Requires CUDA 8.x or earlier')
+    def test_get_arch_cuda8(self):
+        self._check_get_arch('52', 'compute_52')
+        self._check_get_arch('53', 'compute_53')
+        self._check_get_arch('54', 'compute_53')
+
+    @unittest.skipUnless(9000 <= cuda_version(), 'Requires CUDA 9.x or later')
+    def test_get_arch_cuda9(self):
+        self._check_get_arch('71', 'compute_71')
+        self._check_get_arch('72', 'compute_72')
+        self._check_get_arch('73', 'compute_72')
+
+    def _compile(self, arch):
+        compiler.compile_using_nvrtc('', arch=arch)
+
+    @unittest.skipUnless(cuda_version() < 9000, 'Requires CUDA 8.x or earlier')
+    def test_compile_cuda8(self):
+        # This test is intended to detect specification change in NVRTC API.
+
+        # It should not fail.
+        self._compile('compute_53')
+
+        # It should fail.
+        self.assertRaises(
+            compiler.CompileException, self._compile, 'compute_54')
+        self.assertRaises(
+            compiler.CompileException, self._compile, 'compute_60')
+
+    @unittest.skipUnless(9000 <= cuda_version(), 'Requires CUDA 9.0 or later')
+    def test_compile_cuda9(self):
+        # This test is intended to detect specification change in NVRTC API.
+
+        # It should not fail.
+        self._compile('compute_70')
+
+        # It should not fail (`compute_72` is valid according to the API
+        # Reference), but actually it fails.
+        self.assertRaises(
+            compiler.CompileException, self._compile, 'compute_72')
+
+        # It should fail.
+        self.assertRaises(
+            compiler.CompileException, self._compile, 'compute_73')
 
 
 @testing.gpu

--- a/tests/cupy_tests/cuda_tests/test_compiler.py
+++ b/tests/cupy_tests/cuda_tests/test_compiler.py
@@ -40,7 +40,12 @@ class TestNvrtcArch(unittest.TestCase):
         # This test is intended to detect specification change in NVRTC API.
 
         # It should not fail.
-        self._compile('compute_53')
+        self._compile('compute_52')
+
+        # It should not fail (`compute_53` is valid according to the API
+        # Reference), but actually it fails.
+        self.assertRaises(
+            compiler.CompileException, self._compile, 'compute_53')
 
         # It should fail.
         self.assertRaises(


### PR DESCRIPTION
Fixes #1048.
See also: http://docs.nvidia.com/cuda/nvrtc/index.html#group__options