### PR TITLE
use --no-cache-dir in Dockerfile

### DIFF
--- a/docker/python2/Dockerfile
+++ b/docker/python2/Dockerfile
@@ -8,4 +8,4 @@ RUN apt-get update -y && \
     python-setuptools && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
-RUN pip install cupy-cuda80==4.0.0rc1
+RUN pip install --no-cache-dir cupy-cuda80==4.0.0rc1

--- a/docker/python3/Dockerfile
+++ b/docker/python3/Dockerfile
@@ -8,4 +8,4 @@ RUN apt-get update -y && \
     python3-setuptools && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
-RUN pip3 install cupy-cuda80==4.0.0rc1
+RUN pip3 install --no-cache-dir cupy-cuda80==4.0.0rc1


### PR DESCRIPTION
I found that Docker build for Python 2.x is failing with `MemoryError` on Docker Hub.

https://hub.docker.com/r/cupy/cupy/builds/bkjms5j4pjhdw4vwynzjf7v/

It seems it hits the memory limit while downloading wheels.
I confirmed that `--no-cache-dir` reduces the memory usage and succeed to build.
It also improves the footprint of the image size.