### PR TITLE
rewrite installation guide

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -314,8 +314,8 @@ Also see :ref:`install_cuda`.
 
 If you are installing CuPy on Anaconda environment, also make sure that the following packages are not installed.
 
-* `cudatoolkit <https://anaconda.org/anaconda/cudatoolkit>`_
-* `cudnn <https://anaconda.org/anaconda/cudnn>`_
-* `nccl <https://anaconda.org/anaconda/nccl>`_
+* `cudatoolkit <https://anaconda.org/anaconda/cudatoolkit>`__
+* `cudnn <https://anaconda.org/anaconda/cudnn>`__
+* `nccl <https://anaconda.org/anaconda/nccl>`__
 
 Use ``conda uninstall cudatoolkit cudnn nccl`` to remove these package.

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -14,7 +14,7 @@ We recommend the following Linux distributions.
 .. note::
 
    We are automatically testing CuPy on all the recommended environments above.
-   We cannot guarantee that CuPy works on other environments including Windows and macOS, even if CuPy looks running correctly.
+   We cannot guarantee that CuPy works on other environments including Windows and macOS, even if CuPy may seem to be running correctly.
 
 
 Requirements
@@ -26,10 +26,10 @@ You need to have the following components to use CuPy.
     * Compute Capability of the GPU must be at least 3.0.
 * `CUDA Toolkit <https://developer.nvidia.com/cuda-zone>`_
     * Supported Versions: 7.0, 7.5, 8.0, 9.0 and 9.1.
-    * If you have multiple versions of CUDA Toolkit installed, CuPy will choose one of the CUDA installation automatically.
+    * If you have multiple versions of CUDA Toolkit installed, CuPy will choose one of the CUDA installations automatically.
       See :ref:`install_cuda` for details.
 * `Python <https://python.org/>`_
-    * Supported Versions: 2.7.6+, 3.4.3+, 3.5.1+, and 3.6.0+.
+    * Supported Versions: 2.7.6+, 3.4.3+, 3.5.1+ and 3.6.0+.
 * `NumPy <http://www.numpy.org/>`_
     * Supported Versions: 1.9, 1.10, 1.11, 1.12 and 1.13.
     * NumPy will be installed automatically during the installation of CuPy.
@@ -138,7 +138,7 @@ Use pip to uninstall CuPy::
 
 .. note::
 
-   When you upgrade Chainer, ``pip`` sometimes install the new version without removing the old one in ``site-packages``.
+   When you upgrade Chainer, ``pip`` sometimes installs the new version without removing the old one in ``site-packages``.
    In this case, ``pip uninstall`` only removes the latest one.
    To ensure that CuPy is completely removed, run the above command repeatedly until ``pip`` returns an error.
 
@@ -291,13 +291,13 @@ If you are hacking CuPy source code, we recommend you to use ``pip`` with ``-e``
   $ cd /path/to/cupy/source
   $ pip install -e .
 
-Please note that even with ``-e``, you will have to rerun ``pip install -e .`` to regenerate C++ sources using Cython if you modified Cython source files (e.g., ``*.pyx`` files)
+Please note that even with ``-e``, you will have to rerun ``pip install -e .`` to regenerate C++ sources using Cython if you modified Cython source files (e.g., ``*.pyx`` files).
 
 CuPy always raises ``cupy.cuda.compiler.CompileException``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If CuPy does not work at all with ``CompileException``, it is possible that CuPy cannot detect CUDA installed on your system correctly.
-The followings are error messages commonly observed in such case.
+The followings are error messages commonly observed in such cases.
 
 * ``nvrtc: error: failed to load builtins``
 * ``catastrophic error: cannot open source file "cuda_fp16.h"``

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -303,6 +303,7 @@ If CuPy does not work at all with ``CompileException``, it is possible that CuPy
 The followings are error messages commonly observed in such case.
 
 * ``nvrtc: error: failed to load builtins``
+* ``catastrophic error: cannot open source file "cuda_fp16.h"``
 * ``error: cannot overload functions distinguished by return type alone``
 * ``error: identifier "__half_raw" is undefined``
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -6,28 +6,15 @@ Installation Guide
 Recommended Environments
 ------------------------
 
-We recommend these Linux distributions.
+We recommend the following Linux distributions.
 
-* `Ubuntu <https://www.ubuntu.com/>`_ 14.04/16.04 LTS 64bit
-* `CentOS <https://www.centos.org/>`_ 7 64bit
-
-The following versions of Python can be used: 2.7.6+, 3.4.3+, 3.5.1+, and 3.6.0+.
-
-.. warning::
-
-   If you are using certain versions of conda, it may fail to build CuPy with error
-   ``g++: error: unrecognized command line option ‘-R’``.
-   This is due to a bug in conda (see `conda/conda#6030 <https://github.com/conda/conda/issues/6030>`_ for details).
-   If you encounter this problem, please downgrade or upgrade it.
+* `Ubuntu <https://www.ubuntu.com/>`_ 14.04 / 16.04 LTS (64-bit)
+* `CentOS <https://www.centos.org/>`_ 7 (64-bit)
 
 .. note::
 
-   We are testing CuPy automatically with Jenkins, where all the *recommended* environments above are tested.
+   We are automatically testing CuPy on all the recommended environments above.
    We cannot guarantee that CuPy works on other environments including Windows and macOS, even if CuPy looks running correctly.
-
-Before installing CuPy, we recommend you to upgrade ``setuptools`` and ``pip``::
-
-  $ pip install -U setuptools pip
 
 
 Requirements
@@ -41,9 +28,15 @@ You need to have the following components to use CuPy.
     * Supported Versions: 7.0, 7.5, 8.0, 9.0 and 9.1.
     * If you have multiple versions of CUDA Toolkit installed, CuPy will choose one of the CUDA installation automatically.
       See :ref:`install_cuda` for details.
+* `Python <https://python.org/>`_
+    * Supported Versions: 2.7.6+, 3.4.3+, 3.5.1+, and 3.6.0+.
 * `NumPy <http://www.numpy.org/>`_
     * Supported Versions: 1.9, 1.10, 1.11, 1.12 and 1.13.
     * NumPy will be installed automatically during the installation of CuPy.
+
+Before installing CuPy, we recommend you to upgrade ``setuptools`` and ``pip``::
+
+  $ pip install -U setuptools pip
 
 Optional Libraries
 ~~~~~~~~~~~~~~~~~~
@@ -226,6 +219,10 @@ If you are using ``sudo`` to install CuPy, note that ``sudo`` command does not p
 If you need to pass environment variable (e.g., ``CUDA_PATH``), you need to specify them inside ``sudo`` like this::
 
   $ sudo CUDA_PATH=/opt/nvidia/cuda pip install cupy
+
+If you are using certain versions of conda, it may fail to build CuPy with error ``g++: error: unrecognized command line option ‘-R’``.
+This is due to a bug in conda (see `conda/conda#6030 <https://github.com/conda/conda/issues/6030>`_ for details).
+If you encounter this problem, please downgrade or upgrade it.
 
 .. _install_cudnn:
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -311,3 +311,11 @@ For example, if you have CUDA installed at ``/usr/local/cuda-9.0``::
   export LD_LIBRARY_PATH=$CUDA_PATH/lib64:$LD_LIBRARY_PATH
 
 Also see :ref:`install_cuda`.
+
+If you are installing CuPy on Anaconda environment, also make sure that the following packages are not installed.
+
+* `cudatoolkit <https://anaconda.org/anaconda/cudatoolkit>`_
+* `cudnn <https://anaconda.org/anaconda/cudnn>`_
+* `nccl <https://anaconda.org/anaconda/nccl>`_
+
+Use ``conda uninstall cudatoolkit cudnn nccl`` to remove these package.

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -295,3 +295,21 @@ If you are hacking CuPy source code, we recommend you to use ``pip`` with ``-e``
   $ pip install -e .
 
 Please note that even with ``-e``, you will have to rerun ``pip install -e .`` to regenerate C++ sources using Cython if you modified Cython source files (e.g., ``*.pyx`` files)
+
+CuPy always raises ``cupy.cuda.compiler.CompileException``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If CuPy does not work at all with ``CompileException``, it is possible that CuPy cannot detect CUDA installed on your system correctly.
+The followings are error messages commonly observed in such case.
+
+* ``nvrtc: error: failed to load builtins``
+* ``error: cannot overload functions distinguished by return type alone``
+* ``error: identifier "__half_raw" is undefined``
+
+Please try setting ``LD_LIBRARY_PATH`` and ``CUDA_PATH`` environment variable.
+For example, if you have CUDA installed at ``/usr/local/cuda-9.0``::
+
+  export CUDA_PATH=/usr/local/cuda-9.0
+  export LD_LIBRARY_PATH=$CUDA_PATH/lib64:$LD_LIBRARY_PATH
+
+Also see :ref:`install_cuda`.

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -22,71 +22,47 @@ The following versions of Python can be used: 2.7.6+, 3.4.3+, 3.5.1+, and 3.6.0+
 
 .. note::
 
-   We are testing CuPy automatically with Jenkins, where all the above *recommended* environments are tested.
+   We are testing CuPy automatically with Jenkins, where all the *recommended* environments above are tested.
    We cannot guarantee that CuPy works on other environments including Windows and macOS, even if CuPy looks running correctly.
 
-CuPy uses C++ compiler such as g++.
-You need to install it before installing CuPy.
-This is typical installation method for each platform::
+Before installing CuPy, we recommend you to upgrade ``setuptools`` and ``pip``::
 
-  # Ubuntu 14.04
-  $ apt-get install g++
-
-  # CentOS 7
-  $ yum install gcc-c++
-
-If you use old ``setuptools``, upgrade it::
-
-  $ pip install -U setuptools
+  $ pip install -U setuptools pip
 
 
-Dependencies
+Requirements
 ------------
 
-Before installing CuPy, we recommend to upgrade ``setuptools`` if you are using an old one::
+You need to have the following components to use CuPy.
 
-  $ pip install -U setuptools
-
-The following Python packages are required to install CuPy.
-The latest version of each package will automatically be installed if missing.
-
-* `NumPy <http://www.numpy.org/>`_ 1.9, 1.10, 1.11, 1.12, 1.13
-* `Six <https://pythonhosted.org/six/>`_ 1.9+
-
-In addition, you need to install `CUDA <https://developer.nvidia.com/cuda-zone>`_.
-The following versions of CUDA can be used: 7.0, 7.5, 8.0, 9.0 and 9.1.
-You need a GPU with Compute Capability of at least 3.0.
+* `NVIDIA CUDA GPU <https://developer.nvidia.com/cuda-gpus>`_
+    * Compute Capability of the GPU must be at least 3.0.
+* `CUDA Toolkit <https://developer.nvidia.com/cuda-zone>`_
+    * Supported Versions: 7.0, 7.5, 8.0, 9.0 and 9.1.
+    * If you have multiple versions of CUDA Toolkit installed, CuPy will choose one of the CUDA installation automatically.
+      See :ref:`install_cuda` for details.
+* `NumPy <http://www.numpy.org/>`_
+    * Supported Versions: 1.9, 1.10, 1.11, 1.12 and 1.13.
+    * NumPy will be installed automatically during the installation of CuPy.
 
 Optional Libraries
 ~~~~~~~~~~~~~~~~~~
 
-The following libraries are optional dependencies.
-CuPy will enable these features only if they are installed.
+Some features in CuPy will only be enabled if the corresponding libraries are installed.
 
-* `cuDNN <https://developer.nvidia.com/cudnn>`_ v4, v5, v5.1, v6, v7
-* `NCCL <https://github.com/NVIDIA/nccl>`_ v1.3+
+* `cuDNN <https://developer.nvidia.com/cudnn>`_ (library to accelerate deep neural network computations)
+    * Supported Versions: v4, v5, v5.1, v6, v7
+* `NCCL <https://developer.nvidia.com/nccl>`_  (library to perform collective multi-GPU / multi-node computations)
+    * Supported Versions: v1.3.4, v2
+
 
 Install CuPy
 ------------
 
-Install CuPy via pip
-~~~~~~~~~~~~~~~~~~~~
+Wheels (precompiled binary packages) are available for the recommended environments above.
+Package names are different depending on the CUDA version you have installed on your host.
 
-We recommend to install CuPy via pip::
-
-  $ pip install cupy
-
-.. note::
-
-   All optional CUDA related libraries, cuDNN and NCCL, need to be installed before installing CuPy.
-   After you update these libraries, please reinstall CuPy because you need to compile and link to the newer version of them.
-
-
-Install CuPy using wheel
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-We are experimentally providing wheels (precompiled binary packages) for Linux (x86_64) environment.
-Package names are different depending on the CUDA version you have installed on your host::
+::
 
   (For CUDA 8.0)
   $ pip install cupy-cuda80
@@ -97,16 +73,55 @@ Package names are different depending on the CUDA version you have installed on 
   (For CUDA 9.1)
   $ pip install cupy-cuda91
 
+.. note::
+
+   The latest version of cuDNN and NCCL libraries are included in these wheels.
+   You don't have to install them manually.
+
 When using wheels, please be careful not to install multiple CuPy packages at the same time.
-These packages and ``cupy`` package conflict to each other.
+Any of these packages and ``cupy`` package (source installation) conflict with each other.
+Please make sure that only one CuPy package (``cupy`` or ``cupy-cudaXX`` where XX is a CUDA version) is installed::
+
+  $ pip freeze | grep cupy
+
+
+Install CuPy from Source
+------------------------
+
+It is recommended to use wheels whenever possible.
+However, if wheels cannot meet your requirements (e.g., you are running non-Linux environment or want to use a version of CUDA / cuDNN / NCCL not supported by wheels), you can also build CuPy from source.
+
+When installing from source, C++ compiler such as ``g++`` is required.
+You need to install it before installing CuPy.
+This is typical installation method for each platform::
+
+  # Ubuntu 14.04
+  $ apt-get install g++
+
+  # CentOS 7
+  $ yum install gcc-c++
 
 .. note::
 
-   The latest version of cuDNN and NCCL are included in these wheels.
+   When installing CuPy from source, features provided by optional libraries (cuDNN and NCCL) will be disabled if these libraries are not available at the time of installation.
+   See :ref:`install_cudnn` for the instructions.
 
+.. note::
 
-Install CuPy from source
-~~~~~~~~~~~~~~~~~~~~~~~~
+   If you upgrade or downgrade the version of CUDA Toolkit, cuDNN or NCCL, you may need to reinstall CuPy.
+   See :ref:`install_reinstall` for details.
+
+Using pip
+~~~~~~~~~
+
+You can install `CuPy package <https://pypi.python.org/pypi/cupy>`_ via ``pip``.
+
+::
+
+  $ pip install cupy
+
+Using Tarball
+~~~~~~~~~~~~~
 
 The tarball of the source tree is available via ``pip download cupy`` or from `the release notes page <https://github.com/cupy/cupy/releases>`_.
 You can install CuPy from the tarball::
@@ -119,103 +134,7 @@ You can also install the development version of CuPy from a cloned Git repositor
   $ cd cupy
   $ pip install .
 
-
-.. _install_error:
-
-When an error occurs...
-~~~~~~~~~~~~~~~~~~~~~~~
-
-Use ``-vvvv`` option with ``pip`` command.
-That shows all logs of installation.
-It may help you::
-
-  $ pip install cupy -vvvv
-
-If you are using wheel, make sure that you don't have multiple CuPy packages installed.
-Only one cupy package (``cupy`` or ``cupy-cudaXX`` where XX is a CUDA version) can be installed::
-
-  $ pip freeze | grep cupy
-
-.. _install_cuda:
-
-Install CuPy with CUDA
-~~~~~~~~~~~~~~~~~~~~~~
-
-You need to install CUDA Toolkit before installing CuPy.
-If you have CUDA in a default directory or set ``CUDA_PATH`` correctly, CuPy installer finds CUDA automatically::
-
-  $ pip install cupy
-
-
-.. note::
-
-   CuPy installer looks up ``CUDA_PATH`` environment variable first.
-   If it is empty, the installer looks for ``nvcc`` command from ``PATH`` environment variable and use its parent directory as the root directory of CUDA installation.
-   If ``nvcc`` command is also not found, the installer tries to use the default directory for Ubuntu ``/usr/local/cuda``.
-
-
-If you installed CUDA into a non-default directory, you need to specify the directory with ``CUDA_PATH`` environment variable::
-
-  $ CUDA_PATH=/opt/nvidia/cuda pip install cupy
-
-
-If you want to use a custom ``nvcc`` compiler (For example, to use ``ccache`` ), please set ``NVCC`` environment variables before installing CuPy::
-
-  export NVCC='ccache nvcc'
-
-
-.. warning::
-
-   If you want to use ``sudo`` to install CuPy, note that ``sudo`` command initializes all environment variables.
-   Please specify ``CUDA_PATH`` environment variable inside ``sudo`` like this::
-
-      $ sudo CUDA_PATH=/opt/nvidia/cuda pip install cupy
-
-
-.. _install_cudnn:
-
-Install CuPy with cuDNN and NCCL
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-cuDNN is a library for Deep Neural Networks that NVIDIA provides.
-NCCL is a library for collective multi-GPU communication.
-CuPy can use cuDNN and NCCL.
-If you want to enable these libraries, install them before installing CuPy.
-We recommend you to install developer library of deb package of cuDNN and NCCL.
-
-If you want to install tar-gz version of cuDNN, we recommend you to install it to CUDA directory.
-For example if you uses Ubuntu Linux, copy ``.h`` files to ``include`` directory and ``.so`` files to ``lib64`` directory::
-
-  $ cp /path/to/cudnn.h $CUDA_PATH/include
-  $ cp /path/to/libcudnn.so* $CUDA_PATH/lib64
-
-The destination directories depend on your environment.
-
-If you want to use cuDNN or NCCL installed in other directory, please use ``CFLAGS``, ``LDFLAGS`` and ``LD_LIBRARY_PATH`` environment variables before installing CuPy::
-
-  export CFLAGS=-I/path/to/cudnn/include
-  export LDFLAGS=-L/path/to/cudnn/lib
-  export LD_LIBRARY_PATH=/path/to/cudnn/lib:$LD_LIBRARY_PATH
-
-.. note::
-
-   Use full paths for the environment variables.
-   ``distutils`` that is used in the setup script does not parse the home directory mark ``~``.
-
-
-Install CuPy for developers
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-CuPy uses Cython (>=0.26.1).
-Developers need to use Cython to regenerate C++ sources from ``pyx`` files.
-We recommend to use ``pip`` with ``-e`` option for editable mode::
-
-  $ pip install -U cython
-  $ cd /path/to/cupy/source
-  $ pip install -e .
-
-Users need not to install Cython as a distribution package of CuPy only contains generated sources.
-
+If you are using source tree downloaded from GitHub, you need to install Cython 0.26.1 or later (``pip install cython``).
 
 Uninstall CuPy
 --------------
@@ -228,37 +147,45 @@ Use pip to uninstall CuPy::
 
    When you upgrade Chainer, ``pip`` sometimes install the new version without removing the old one in ``site-packages``.
    In this case, ``pip uninstall`` only removes the latest one.
-   To ensure that Chainer is completely removed, run the above command repeatedly until ``pip`` returns an error.
+   To ensure that CuPy is completely removed, run the above command repeatedly until ``pip`` returns an error.
 
 .. note::
 
-   If you installed CuPy using wheel, use ``pip uninstall cupy-cudaXX`` (where XX is a CUDA version number) instead.
+   If you are using a wheel, ``cupy`` shall be replaced with ``cupy-cudaXX`` (where XX is a CUDA version number).
+
 
 Upgrade CuPy
 ------------
 
-Just use ``pip`` with ``-U`` option::
+Just use ``pip install`` with ``-U`` option::
 
   $ pip install -U cupy
 
+.. note::
+
+   If you are using a wheel, ``cupy`` shall be replaced with ``cupy-cudaXX`` (where XX is a CUDA version number).
+
+
+.. _install_reinstall:
 
 Reinstall CuPy
 --------------
 
 If you want to reinstall CuPy, please uninstall CuPy and then install it.
-We recommend to use ``--no-cache-dir`` option as ``pip`` sometimes uses cache::
+When reinstalling CuPy, we recommend to use ``--no-cache-dir`` option as ``pip`` caches the previously built binaries::
 
   $ pip uninstall cupy
   $ pip install cupy --no-cache-dir
 
-When you install CuPy without CUDA, and after that you want to use CUDA, please reinstall CuPy.
-You need to reinstall CuPy when you want to upgrade CUDA.
+.. note::
+
+   If you are using a wheel, ``cupy`` shall be replaced with ``cupy-cudaXX`` (where XX is a CUDA version number).
 
 
 Run CuPy with Docker
 --------------------
 
-We are providing the official Docker image.
+We are providing the `official Docker image <https://hub.docker.com/r/cupy/cupy/>`_.
 Use `nvidia-docker <https://github.com/NVIDIA/nvidia-docker>`_ command to run CuPy image with GPU.
 You can login to the environment with bash, and run the Python interpreter::
 
@@ -272,11 +199,99 @@ Or run the interpreter directly::
 FAQ
 ---
 
-Warning message "cuDNN is not enabled" appears
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Warning message "cuDNN is not enabled" appears when using Chainer
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You failed to build CuPy with cuDNN.
 If you don't need cuDNN, ignore this message.
 Otherwise, retry to install CuPy with cuDNN.
-``-vvvv`` option helps you.
-See :ref:`install_cudnn`.
+
+See :ref:`install_cudnn` and :ref:`install_error` for details.
+
+.. _install_error:
+
+``pip`` fails to install CuPy
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Please make sure that you are using the latest ``setuptools`` and ``pip``::
+
+  $ pip install -U setuptools pip
+
+Use ``-vvvv`` option with ``pip`` command.
+This will display all logs of installation::
+
+  $ pip install cupy -vvvv
+
+If you are using ``sudo`` to install CuPy, note that ``sudo`` command does not propagate environment variables.
+If you need to pass environment variable (e.g., ``CUDA_PATH``), you need to specify them inside ``sudo`` like this::
+
+  $ sudo CUDA_PATH=/opt/nvidia/cuda pip install cupy
+
+.. _install_cudnn:
+
+Installing cuDNN and NCCL
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+We recommend installing cuDNN and NCCL using binary packages (i.e., using ``apt`` or ``yum``) provided by NVIDIA.
+
+If you want to install tar-gz version of cuDNN and NCCL, we recommend you to install it under CUDA directory.
+For example, if you are using Ubuntu, copy ``*.h`` files to ``include`` directory and ``*.so*`` files to ``lib64`` directory::
+
+  $ cp /path/to/cudnn.h $CUDA_PATH/include
+  $ cp /path/to/libcudnn.so* $CUDA_PATH/lib64
+
+The destination directories depend on your environment.
+
+If you want to use cuDNN or NCCL installed in another directory, please use ``CFLAGS``, ``LDFLAGS`` and ``LD_LIBRARY_PATH`` environment variables before installing CuPy::
+
+  export CFLAGS=-I/path/to/cudnn/include
+  export LDFLAGS=-L/path/to/cudnn/lib
+  export LD_LIBRARY_PATH=/path/to/cudnn/lib:$LD_LIBRARY_PATH
+
+.. note::
+
+   Use full paths for the environment variables.
+   ``distutils`` that is used in the setup script does not expand the home directory mark ``~``.
+
+.. _install_cuda:
+
+Working with Custom CUDA Installation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you have installed CUDA on the non-default directory or have multiple CUDA versions installed, you may need to manually specify the CUDA installation directory to be used by CuPy.
+
+CuPy uses the first CUDA installation directory found by the following order.
+
+#. ``CUDA_PATH`` environment variable.
+#. The parent directory of ``nvcc`` command. CuPy looks for ``nvcc`` command in each directory set in ``PATH`` environment variable.
+#. ``/usr/local/cuda``
+
+For example, you can tell CuPy to use non-default CUDA directory by ``CUDA_PATH`` environment variable::
+
+  $ CUDA_PATH=/opt/nvidia/cuda pip install cupy
+
+.. note::
+
+   CUDA installation discovery is also performed at runtime using the rule above.
+   Depending on your system configuration, you may also need to set ``LD_LIBRARY_PATH`` environment variable to ``$CUDA_PATH/lib64`` at runtime.
+
+Using custom ``nvcc`` command during installation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you want to use a custom ``nvcc`` compiler (for example, to use ``ccache`` ), please set ``NVCC`` environment variables before installing CuPy::
+
+  export NVCC='ccache nvcc'
+
+.. note::
+
+   Setting ``NVCC`` environment variable does not affect at runtime, as CuPy does not use ``nvcc`` command at runtime.
+
+Installation for Developers
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you are hacking CuPy source code, we recommend you to use ``pip`` with ``-e`` option for editable mode::
+
+  $ cd /path/to/cupy/source
+  $ pip install -e .
+
+Please note that even with ``-e``, you will have to rerun ``pip install -e .`` to regenerate C++ sources using Cython if you modified Cython source files (e.g., ``*.pyx`` files)

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -275,13 +275,13 @@ For example, you can tell CuPy to use non-default CUDA directory by ``CUDA_PATH`
 Using custom ``nvcc`` command during installation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you want to use a custom ``nvcc`` compiler (for example, to use ``ccache`` ), please set ``NVCC`` environment variables before installing CuPy::
+If you want to use a custom ``nvcc`` compiler (for example, to use ``ccache``) to build CuPy, please set ``NVCC`` environment variables before installing CuPy::
 
   export NVCC='ccache nvcc'
 
 .. note::
 
-   Setting ``NVCC`` environment variable does not affect at runtime, as CuPy does not use ``nvcc`` command at runtime.
+   During runtime, you don't need to set this environment variable since CuPy doesn't use the nvcc command.
 
 Installation for Developers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
As many users are reporting installation failures, I reorganized the Installation Guide.
Major changes compared to the current one is to recommend use of wheels as the first choice.