### PR TITLE
Implement multi-dimensional image processing

### DIFF
--- a/cupyx/__init__.py
+++ b/cupyx/__init__.py
@@ -1,3 +1,5 @@
 # "NOQA" to suppress flake8 warning
 from cupyx.rsqrt import rsqrt  # NOQA
 from cupyx.scatter import scatter_add  # NOQA
+
+from cupyx import scipy  # NOQA

--- a/cupyx/scipy/ndimage/__init__.py
+++ b/cupyx/scipy/ndimage/__init__.py
@@ -1,0 +1,5 @@
+from cupyx.scipy.ndimage.interpolation import affine_transform  # NOQA
+from cupyx.scipy.ndimage.interpolation import map_coordinates  # NOQA
+from cupyx.scipy.ndimage.interpolation import rotate  # NOQA
+from cupyx.scipy.ndimage.interpolation import shift  # NOQA
+from cupyx.scipy.ndimage.interpolation import zoom  # NOQA

--- a/cupyx/scipy/ndimage/interpolation.py
+++ b/cupyx/scipy/ndimage/interpolation.py
@@ -22,7 +22,7 @@ def _get_output(output, input, shape=None):
     elif type(output) in [type(type), type(cupy.zeros((4,)).dtype)]:
         output = cupy.zeros(shape, dtype=output)
         return_value = output
-    elif type(output) is string_type:
+    elif isinstance(output, string_type):
         output = numpy.typeDict[output]
         output = cupy.zeros(shape, dtype=output)
         return_value = output

--- a/cupyx/scipy/ndimage/interpolation.py
+++ b/cupyx/scipy/ndimage/interpolation.py
@@ -101,8 +101,8 @@ def map_coordinates(input, coordinates, output=None, order=None,
                 coordinates[i] = 0
             else:
                 coordinates[i] = cupy.remainder(coordinates[i], 2 * length)
-                coordinates[i] = 2 * cupy.clip(
-                    coordinates[i], None, length) - coordinates[i]
+                coordinates[i] = 2 * cupy.minimum(
+                    coordinates[i], length) - coordinates[i]
 
     if cupy.issubdtype(input.dtype, cupy.integer):
         input = input.astype(cupy.float32)

--- a/cupyx/scipy/ndimage/interpolation.py
+++ b/cupyx/scipy/ndimage/interpolation.py
@@ -311,6 +311,7 @@ def rotate(input, angle, axes=(1, 0), reshape=True, output=None, order=None,
     if mode == 'opencv':
         mode = '_opencv_edge'
 
+    axes = list(axes)
     if axes[0] < 0:
         axes[0] += input.ndim
     if axes[1] < 0:

--- a/cupyx/scipy/ndimage/interpolation.py
+++ b/cupyx/scipy/ndimage/interpolation.py
@@ -13,7 +13,7 @@ def _get_output(output, input, shape=None):
         output = input.dtype
     if isinstance(output, cupy.ndarray):
         if output.shape != tuple(shape):
-            raise RuntimeError("output shape not correct")
+            raise RuntimeError("output shape is not correct")
         return_value = None
     else:
         output = cupy.zeros(shape, dtype=output)
@@ -27,12 +27,12 @@ def _check_parameter(func_name, order, mode):
                       'It is different from scipy.ndimage and can change in '
                       'the future.'.format(func_name))
     elif order < 0 or 5 < order:
-        raise RuntimeError('spline order not supported')
+        raise RuntimeError('spline order is not supported')
     elif 1 < order:
         # SciPy supports order 0-5, but CuPy supports only order 0 and 1. Other
         # orders will be implemented, therefore it raises NotImplementedError
         # instead of RuntimeError.
-        raise NotImplementedError('spline order not supported')
+        raise NotImplementedError('spline order is not supported')
 
     if mode in ('reflect', 'wrap'):
         raise NotImplementedError('\'{}\' mode is not supported. See '
@@ -40,7 +40,7 @@ def _check_parameter(func_name, order, mode):
                                   .format(mode))
     elif mode not in ('constant', 'nearest', 'mirror', 'opencv',
                       '_opencv_edge'):
-        raise RuntimeError('boundary mode not supported')
+        raise RuntimeError('boundary mode is not supported')
 
 
 def map_coordinates(input, coordinates, output=None, order=None,

--- a/cupyx/scipy/ndimage/interpolation.py
+++ b/cupyx/scipy/ndimage/interpolation.py
@@ -1,35 +1,23 @@
 import itertools
 import math
-import sys
 import warnings
 
 import cupy
-import numpy
 import six
 
 
 def _get_output(output, input, shape=None):
-    if sys.version_info[0] == 3:
-        string_type = str
-    else:
-        string_type = basestring  # NOQA
-
     if shape is None:
         shape = input.shape
     if output is None:
-        output = cupy.zeros(shape, dtype=input.dtype.name)
-        return_value = output
-    elif type(output) in [type(type), type(cupy.zeros((4,)).dtype)]:
-        output = cupy.zeros(shape, dtype=output)
-        return_value = output
-    elif isinstance(output, string_type):
-        output = numpy.typeDict[output]
-        output = cupy.zeros(shape, dtype=output)
-        return_value = output
-    else:
-        if list(output.shape) != list(shape):
+        output = input.dtype
+    if isinstance(output, cupy.ndarray):
+        if output.shape != tuple(shape):
             raise RuntimeError("output shape not correct")
         return_value = None
+    else:
+        output = cupy.zeros(shape, dtype=output)
+        return_value = output
     return output, return_value
 
 

--- a/cupyx/scipy/ndimage/interpolation.py
+++ b/cupyx/scipy/ndimage/interpolation.py
@@ -306,7 +306,7 @@ def rotate(input, angle, axes=(1, 0), reshape=True, output=None, order=None,
     .. seealso:: :func:`scipy.ndimage.rotate`
     """
 
-    _check_parameter('affine_transform', order, mode)
+    _check_parameter('rotate', order, mode)
 
     if mode == 'opencv':
         mode = '_opencv_edge'
@@ -399,7 +399,7 @@ def shift(input, shift, output=None, order=None, mode='constant', cval=0.0,
     .. seealso:: :func:`scipy.ndimage.shift`
     """
 
-    _check_parameter('affine_transform', order, mode)
+    _check_parameter('shift', order, mode)
 
     if mode == 'opencv':
         mode = '_opencv_edge'
@@ -444,7 +444,7 @@ def zoom(input, zoom, output=None, order=None, mode='constant', cval=0.0,
     .. seealso:: :func:`scipy.ndimage.zoom`
     """
 
-    _check_parameter('affine_transform', order, mode)
+    _check_parameter('zoom', order, mode)
 
     if not hasattr(zoom, '__iter__') and type(zoom) is not cupy.ndarray:
         zoom = [zoom] * input.ndim

--- a/cupyx/scipy/ndimage/interpolation.py
+++ b/cupyx/scipy/ndimage/interpolation.py
@@ -35,9 +35,9 @@ def _get_output(output, input, shape=None):
 
 def _check_parameter(func_name, order, mode):
     if order is None:
-        warnings.warn('In the current feature the default order of {} is 1. It'
-                      'is different from scipy.ndimage and can change in the'
-                      'future'.format(func_name))
+        warnings.warn('In the current feature the default order of {} is 1. '
+                      'It is different from scipy.ndimage and can change in '
+                      'the future.'.format(func_name))
     elif order < 0 or 5 < order:
         raise RuntimeError('spline order not supported')
     elif 1 < order:

--- a/cupyx/scipy/ndimage/interpolation.py
+++ b/cupyx/scipy/ndimage/interpolation.py
@@ -1,0 +1,476 @@
+import itertools
+import math
+import sys
+import warnings
+
+import cupy
+import numpy
+import six
+
+
+def _get_output(output, input, shape=None):
+    if sys.version_info[0] == 3:
+        string_type = str
+    else:
+        string_type = basestring  # NOQA
+
+    if shape is None:
+        shape = input.shape
+    if output is None:
+        output = cupy.zeros(shape, dtype=input.dtype.name)
+        return_value = output
+    elif type(output) in [type(type), type(cupy.zeros((4,)).dtype)]:
+        output = cupy.zeros(shape, dtype=output)
+        return_value = output
+    elif type(output) is string_type:
+        output = numpy.typeDict[output]
+        output = cupy.zeros(shape, dtype=output)
+        return_value = output
+    else:
+        if list(output.shape) != list(shape):
+            raise RuntimeError("output shape not correct")
+        return_value = None
+    return output, return_value
+
+
+def _check_parameter(func_name, order, mode):
+    if order is None:
+        warnings.warn('In the current feature the default order of {} is 1. It'
+                      'is different from scipy.ndimage and can change in the'
+                      'future'.format(func_name))
+    elif order < 0 or 5 < order:
+        raise RuntimeError('spline order not supported')
+    elif 1 < order:
+        # SciPy supports order 0-5, but CuPy supports only order 0 and 1. Other
+        # orders will be implemented, therefore it raises NotImplementedError
+        # instead of RuntimeError.
+        raise NotImplementedError('spline order not supported')
+
+    if mode in ('reflect', 'wrap'):
+        raise NotImplementedError('\'{}\' mode is not supported. See '
+                                  'https://github.com/scipy/scipy/issues/8465'
+                                  .format(mode))
+    elif mode not in ('constant', 'nearest', 'mirror', 'opencv',
+                      '_opencv_edge'):
+        raise RuntimeError('boundary mode not supported')
+
+
+def map_coordinates(input, coordinates, output=None, order=None,
+                    mode='constant', cval=0.0, prefilter=True):
+    """Map the input array to new coordinates by interpolation.
+
+    The array of coordinates is used to find, for each point in the output, the
+    corresponding coordinates in the input. The value of the input at those
+    coordinates is determined by spline interpolation of the requested order.
+
+    The shape of the output is derived from that of the coordinate array by
+    dropping the first axis. The values of the array along the first axis are
+    the coordinates in the input array at which the output value is found.
+
+    Args:
+        input (cupy.ndarray): The input array.
+        coordinates (array_like): The coordinates at which ``input`` is
+            evaluated.
+        output (cupy.ndarray or dtype): The array in which to place the output,
+            or the dtype of the returned array.
+        order (int): The order of the spline interpolation. If it is not given,
+            order 1 is used. It is different from :mod:`scipy.ndimage` and can
+            change in the future. Currently it supports only order 0 and 1.
+        mode (str): Points outside the boundaries of the input are filled
+            according to the given mode (``'constant'``, ``'nearest'``,
+            ``'mirror'`` or ``'opencv'``). Default is ``'constant'``.
+        cval (scalar): Value used for points outside the boundaries of
+            the input if ``mode='constant'`` or ``mode='opencv'``. Default is
+            0.0
+        prefilter (bool): It is not used yet. It just exists for compatibility
+            with :mod:`scipy.ndimage`.
+
+    Returns:
+        cupy.ndarray:
+            The result of transforming the input. The shape of the output is
+            derived from that of ``coordinates`` by dropping the first axis.
+
+    .. seealso:: :func:`scipy.ndimage.map_coordinates`
+    """
+
+    _check_parameter('map_coordinates', order, mode)
+
+    if mode == 'opencv' or mode == '_opencv_edge':
+        input = cupy.pad(input, [[1, 1]] * input.ndim, 'constant',
+                         constant_values=cval)
+        coordinates = cupy.add(coordinates, 1)
+        mode = 'constant'
+
+    output, return_value = _get_output(output, input, coordinates.shape[1:])
+
+    if mode == 'nearest':
+        for i in six.moves.range(input.ndim):
+            coordinates[i] = coordinates[i].clip(0, input.shape[i] - 1)
+    elif mode == 'mirror':
+        for i in six.moves.range(input.ndim):
+            length = input.shape[i] - 1
+            if length == 0:
+                coordinates[i] = 0
+            else:
+                coordinates[i] = cupy.remainder(coordinates[i], 2 * length)
+                coordinates[i] = 2 * cupy.clip(
+                    coordinates[i], None, length) - coordinates[i]
+
+    if cupy.issubdtype(input.dtype, cupy.integer):
+        input = input.astype(cupy.float64)
+
+    if order == 0:
+        out = input[list(cupy.rint(coordinates).astype(cupy.int64))]
+    else:
+        coordinates_floor = cupy.floor(coordinates).astype(cupy.int64)
+        coordinates_ceil = coordinates_floor + 1
+
+        sides = []
+        for i in six.moves.range(input.ndim):
+            # TODO(mizuno): Use array_equal after it is implemented
+            if cupy.all(coordinates[i] == coordinates_floor[i]):
+                sides.append([0])
+            else:
+                sides.append([0, 1])
+
+        if cupy.issubdtype(input.dtype, numpy.complexfloating):
+            out = cupy.zeros(coordinates.shape[1], dtype=input.dtype)
+        else:
+            out = cupy.zeros(coordinates.shape[1])
+        for side in itertools.product(*sides):
+            ind = []
+            weight = cupy.ones(coordinates.shape[1])
+            for i in six.moves.range(input.ndim):
+                if side[i] == 0:
+                    ind.append(coordinates_floor[i])
+                    weight *= coordinates_ceil[i] - coordinates[i]
+                else:
+                    ind.append(coordinates_ceil[i])
+                    weight *= coordinates[i] - coordinates_floor[i]
+            out += input[ind] * weight
+
+    if mode == 'constant':
+        mask = cupy.ones(coordinates.shape[1])
+        for i in six.moves.range(input.ndim):
+            mask *= 0 <= coordinates[i]
+            mask *= coordinates[i] <= input.shape[i] - 1
+        c = (cupy.ones_like(mask) - mask) * cval
+        out *= mask
+        out += c
+
+    if cupy.issubdtype(output.dtype, cupy.integer):
+        out = cupy.rint(out)
+
+    cupy.copyto(output, out.astype(output.dtype))
+    return return_value
+
+
+def affine_transform(input, matrix, offset=0.0, output_shape=None, output=None,
+                     order=None, mode='constant', cval=0.0, prefilter=True):
+    """Apply an affine transformation.
+
+    Given an output image pixel index vector ``o``, the pixel value is
+    determined from the input image at position
+    ``cupy.dot(matrix, o) + offset``.
+
+    Args:
+        input (cupy.ndarray): The input array.
+        matrix (cupy.ndarray): The inverse coordinate transformation matrix,
+            mapping output coordinates to input coordinates. If ``ndim`` is the
+            number of dimensions of ``input``, the given matrix must have one
+            of the following shapes:
+
+                - ``(ndim, ndim)``: the linear transformation matrix for each
+                  output coordinate.
+                - ``(ndim,)``: assume that the 2D transformation matrix is
+                  diagonal, with the diagonal specified by the given value.
+                - ``(ndim + 1, ndim + 1)``: assume that the transformation is
+                  specified using homogeneous coordinates. In this case, any
+                  value passed to ``offset`` is ignored.
+                - ``(ndim, ndim + 1)``: as above, but the bottom row of a
+                  homogeneous transformation matrix is always
+                  ``[0, 0, ..., 1]``, and may be omitted.
+
+        offset (float or sequence): The offset into the array where the
+            transform is applied. If a float, ``offset`` is the same for each
+            axis. If a sequence, ``offset`` should contain one value for each
+            axis.
+        output_shape (tuple of ints): Shape tuple.
+        output (cupy.ndarray or dtype): The array in which to place the output,
+            or the dtype of the returned array.
+        order (int): The order of the spline interpolation. If it is not given,
+            order 1 is used. It is different from :mod:`scipy.ndimage` and can
+            change in the future. Currently it supports only order 0 and 1.
+        mode (str): Points outside the boundaries of the input are filled
+            according to the given mode (``'constant'``, ``'nearest'``,
+            ``'mirror'`` or ``'opencv'``). Default is ``'constant'``.
+        cval (scalar): Value used for points outside the boundaries of
+            the input if ``mode='constant'`` or ``mode='opencv'``. Default is
+            0.0
+        prefilter (bool): It is not used yet. It just exists for compatibility
+            with :mod:`scipy.ndimage`.
+
+    Returns:
+        cupy.ndarray or None:
+            The transformed input. If ``output`` is given as a parameter,
+            ``None`` is returned.
+
+    .. seealso:: :func:`scipy.ndimage.affine_transform`
+    """
+
+    _check_parameter('affine_transform', order, mode)
+
+    output, return_value = _get_output(output, input, output_shape)
+
+    if not hasattr(offset, '__iter__') and type(offset) is not cupy.ndarray:
+        offset = [offset] * input.ndim
+
+    if matrix.ndim == 1:
+        # TODO(mizuno): Implement zoom_shift
+        matrix = cupy.diag(matrix)
+    elif matrix.shape[0] == matrix.shape[1] - 1:
+        offset = matrix[:, -1]
+        matrix = matrix[:, :-1]
+    elif matrix.shape[0] == input.ndim + 1:
+        offset = matrix[:-1, -1]
+        matrix = matrix[:-1, :-1]
+
+    if output_shape is None:
+        output_shape = input.shape
+
+    if mode == 'opencv':
+        m = cupy.zeros((input.ndim + 1, input.ndim + 1))
+        m[:-1, :-1] = matrix
+        m[:-1, -1] = offset
+        m[-1, -1] = 1
+        m = cupy.linalg.inv(m)
+        m[:2] = cupy.roll(m[:2], 1, axis=0)
+        m[:2, :2] = cupy.roll(m[:2, :2], 1, axis=1)
+        matrix = m[:-1, :-1]
+        offset = m[:-1, -1]
+
+    coordinates = cupy.indices(output_shape, dtype=cupy.float64)
+    coordinates = cupy.dot(matrix, coordinates.reshape((input.ndim, -1)))
+    coordinates += cupy.expand_dims(cupy.asarray(offset), -1)
+    out = map_coordinates(input, coordinates, output.dtype, order, mode, cval,
+                          prefilter)
+    cupy.copyto(output, out.astype(output.dtype))
+    return return_value
+
+
+def _minmax(coor, minc, maxc):
+    if coor[0] < minc[0]:
+        minc[0] = coor[0]
+    if coor[0] > maxc[0]:
+        maxc[0] = coor[0]
+    if coor[1] < minc[1]:
+        minc[1] = coor[1]
+    if coor[1] > maxc[1]:
+        maxc[1] = coor[1]
+    return minc, maxc
+
+
+def rotate(input, angle, axes=(1, 0), reshape=True, output=None, order=None,
+           mode='constant', cval=0.0, prefilter=True):
+    """Rotate an array.
+
+    The array is rotated in the plane defined by the two axes given by the
+    ``axes`` parameter using spline interpolation of the requested order.
+
+    Args:
+        input (cupy.ndarray): The input array.
+        angle (float): The rotation angle in degrees.
+        axes (tuple of 2 ints): The two axes that define the plane of rotation.
+            Default is the first two axes.
+        reshape (bool): If ``reshape`` is True, the output shape is adapted so
+            that the input array is contained completely in the output. Default
+            is True.
+        output (cupy.ndarray or dtype): The array in which to place the output,
+            or the dtype of the returned array.
+        order (int): The order of the spline interpolation. If it is not given,
+            order 1 is used. It is different from :mod:`scipy.ndimage` and can
+            change in the future. Currently it supports only order 0 and 1.
+        mode (str): Points outside the boundaries of the input are filled
+            according to the given mode (``'constant'``, ``'nearest'``,
+            ``'mirror'`` or ``'opencv'``). Default is ``'constant'``.
+        cval (scalar): Value used for points outside the boundaries of
+            the input if ``mode='constant'`` or ``mode='opencv'``. Default is
+            0.0
+        prefilter (bool): It is not used yet. It just exists for compatibility
+            with :mod:`scipy.ndimage`.
+
+    Returns:
+        cupy.ndarray or None
+            The rotated input.
+
+    .. seealso:: :func:`scipy.ndimage.rotate`
+    """
+
+    _check_parameter('affine_transform', order, mode)
+
+    if mode == 'opencv':
+        mode = '_opencv_edge'
+
+    if axes[0] < 0:
+        axes[0] += input.ndim
+    if axes[1] < 0:
+        axes[1] += input.ndim
+    if axes[0] > axes[1]:
+        axes = axes[1], axes[0]
+    if axes[0] < 0 or input.ndim <= axes[1]:
+        raise IndexError
+
+    rad = cupy.deg2rad(angle)
+    sin = math.sin(rad)
+    cos = math.cos(rad)
+
+    matrix = cupy.identity(input.ndim)
+    matrix[axes[0], axes[0]] = cos
+    matrix[axes[0], axes[1]] = sin
+    matrix[axes[1], axes[0]] = -sin
+    matrix[axes[1], axes[1]] = cos
+
+    iy = input.shape[axes[0]]
+    ix = input.shape[axes[1]]
+    if reshape:
+        mtrx = cupy.array([[cos, sin], [-sin, cos]])
+        minc = [0, 0]
+        maxc = [0, 0]
+        coor = cupy.dot(mtrx, cupy.array([0, ix]))
+        minc, maxc = _minmax(coor, minc, maxc)
+        coor = cupy.dot(mtrx, cupy.array([iy, 0]))
+        minc, maxc = _minmax(coor, minc, maxc)
+        coor = cupy.dot(mtrx, cupy.array([iy, ix]))
+        minc, maxc = _minmax(coor, minc, maxc)
+        oy = int(maxc[0] - minc[0] + 0.5)
+        ox = int(maxc[1] - minc[1] + 0.5)
+    else:
+        oy = input.shape[axes[0]]
+        ox = input.shape[axes[1]]
+
+    offset = cupy.zeros(input.ndim)
+    offset[axes[0]] = oy / 2.0 - 0.5
+    offset[axes[1]] = ox / 2.0 - 0.5
+    offset = cupy.dot(matrix, offset)
+    tmp = cupy.zeros(input.ndim)
+    tmp[axes[0]] = iy / 2.0 - 0.5
+    tmp[axes[1]] = ix / 2.0 - 0.5
+    offset = tmp - offset
+
+    output_shape = list(input.shape)
+    output_shape[axes[0]] = oy
+    output_shape[axes[1]] = ox
+
+    return affine_transform(input, matrix, offset, output_shape, output, order,
+                            mode, cval, prefilter)
+
+
+def shift(input, shift, output=None, order=None, mode='constant', cval=0.0,
+          prefilter=True):
+    """Shift an array.
+
+    The array is shifted using spline interpolation of the requested order.
+    Points outside the boundaries of the input are filled according to the
+    given mode.
+
+    Args:
+        input (cupy.ndarray): The input array.
+        shift (float or sequence): The shift along the axes. If a float,
+            ``shift`` is the same for each axis. If a sequence, ``shift``
+            should contain one value for each axis.
+        output (cupy.ndarray or dtype): The array in which to place the output,
+            or the dtype of the returned array.
+        order (int): The order of the spline interpolation. If it is not given,
+            order 1 is used. It is different from :mod:`scipy.ndimage` and can
+            change in the future. Currently it supports only order 0 and 1.
+        mode (str): Points outside the boundaries of the input are filled
+            according to the given mode (``'constant'``, ``'nearest'``,
+            ``'mirror'`` or ``'opencv'``). Default is ``'constant'``.
+        cval (scalar): Value used for points outside the boundaries of
+            the input if ``mode='constant'`` or ``mode='opencv'``. Default is
+            0.0
+        prefilter (bool): It is not used yet. It just exists for compatibility
+            with :mod:`scipy.ndimage`.
+
+    Returns:
+        cupy.ndarray or None:
+            The shifted input.
+
+    .. seealso:: :func:`scipy.ndimage.shift`
+    """
+
+    _check_parameter('affine_transform', order, mode)
+
+    if mode == 'opencv':
+        mode = '_opencv_edge'
+
+    if not hasattr(shift, '__iter__') and type(shift) is not cupy.ndarray:
+        shift = [shift] * input.ndim
+
+    return affine_transform(input, cupy.ones(input.ndim),
+                            cupy.negative(cupy.asarray(shift)), None, output,
+                            order, mode, cval, prefilter)
+
+
+def zoom(input, zoom, output=None, order=None, mode='constant', cval=0.0,
+         prefilter=True):
+    """Zoom an array.
+
+    The array is zoomed using spline interpolation of the requested order.
+
+    Args:
+        input (cupy.ndarray): The input array.
+        zoom (float or sequence): The zoom factor along the axes. If a float,
+            ``zoom`` is the same for each axis. If a sequence, ``zoom`` should
+            contain one value for each axis.
+        output (cupy.ndarray or dtype): The array in which to place the output,
+            or the dtype of the returned array.
+        order (int): The order of the spline interpolation. If it is not given,
+            order 1 is used. It is different from :mod:`scipy.ndimage` and can
+            change in the future. Currently it supports only order 0 and 1.
+        mode (str): Points outside the boundaries of the input are filled
+            according to the given mode (``'constant'``, ``'nearest'``,
+            ``'mirror'`` or ``'opencv'``). Default is ``'constant'``.
+        cval (scalar): Value used for points outside the boundaries of
+            the input if ``mode='constant'`` or ``mode='opencv'``. Default is
+            0.0
+        prefilter (bool): It is not used yet. It just exists for compatibility
+            with :mod:`scipy.ndimage`.
+
+    Returns:
+        zoom : cupy.ndarray or None
+            The zoomed input.
+
+    .. seealso:: :func:`scipy.ndimage.zoom`
+    """
+
+    _check_parameter('affine_transform', order, mode)
+
+    if not hasattr(zoom, '__iter__') and type(zoom) is not cupy.ndarray:
+        zoom = [zoom] * input.ndim
+    output_shape = []
+    for s, z in zip(input.shape, zoom):
+        output_shape.append(int(round(s * z)))
+
+    if mode == 'opencv':
+        zoom = []
+        offset = []
+        for in_size, out_size in zip(input.shape, output_shape):
+            if out_size > 1:
+                zoom.append(float(in_size) / out_size)
+                offset.append((zoom[-1] - 1) / 2.0)
+            else:
+                zoom.append(0)
+                offset.append(0)
+        mode = 'nearest'
+    else:
+        zoom = []
+        for in_size, out_size in zip(input.shape, output_shape):
+            if out_size > 1:
+                zoom.append(float(in_size - 1) / (out_size - 1))
+            else:
+                zoom.append(0)
+        offset = 0.0
+
+    return affine_transform(input, cupy.asarray(zoom), offset, output_shape,
+                            output, order, mode, cval, prefilter)

--- a/cupyx/scipy/ndimage/interpolation.py
+++ b/cupyx/scipy/ndimage/interpolation.py
@@ -71,8 +71,8 @@ def map_coordinates(input, coordinates, output=None, order=None,
         input (cupy.ndarray): The input array.
         coordinates (array_like): The coordinates at which ``input`` is
             evaluated.
-        output (cupy.ndarray or dtype): The array in which to place the output,
-            or the dtype of the returned array.
+        output (cupy.ndarray or ~cupy.dtype): The array in which to place the
+            output, or the dtype of the returned array.
         order (int): The order of the spline interpolation. If it is not given,
             order 1 is used. It is different from :mod:`scipy.ndimage` and can
             change in the future. Currently it supports only order 0 and 1.
@@ -196,8 +196,8 @@ def affine_transform(input, matrix, offset=0.0, output_shape=None, output=None,
             axis. If a sequence, ``offset`` should contain one value for each
             axis.
         output_shape (tuple of ints): Shape tuple.
-        output (cupy.ndarray or dtype): The array in which to place the output,
-            or the dtype of the returned array.
+        output (cupy.ndarray or ~cupy.dtype): The array in which to place the
+            output, or the dtype of the returned array.
         order (int): The order of the spline interpolation. If it is not given,
             order 1 is used. It is different from :mod:`scipy.ndimage` and can
             change in the future. Currently it supports only order 0 and 1.
@@ -285,8 +285,8 @@ def rotate(input, angle, axes=(1, 0), reshape=True, output=None, order=None,
         reshape (bool): If ``reshape`` is True, the output shape is adapted so
             that the input array is contained completely in the output. Default
             is True.
-        output (cupy.ndarray or dtype): The array in which to place the output,
-            or the dtype of the returned array.
+        output (cupy.ndarray or ~cupy.dtype): The array in which to place the
+            output, or the dtype of the returned array.
         order (int): The order of the spline interpolation. If it is not given,
             order 1 is used. It is different from :mod:`scipy.ndimage` and can
             change in the future. Currently it supports only order 0 and 1.
@@ -378,8 +378,8 @@ def shift(input, shift, output=None, order=None, mode='constant', cval=0.0,
         shift (float or sequence): The shift along the axes. If a float,
             ``shift`` is the same for each axis. If a sequence, ``shift``
             should contain one value for each axis.
-        output (cupy.ndarray or dtype): The array in which to place the output,
-            or the dtype of the returned array.
+        output (cupy.ndarray or ~cupy.dtype): The array in which to place the
+            output, or the dtype of the returned array.
         order (int): The order of the spline interpolation. If it is not given,
             order 1 is used. It is different from :mod:`scipy.ndimage` and can
             change in the future. Currently it supports only order 0 and 1.
@@ -423,8 +423,8 @@ def zoom(input, zoom, output=None, order=None, mode='constant', cval=0.0,
         zoom (float or sequence): The zoom factor along the axes. If a float,
             ``zoom`` is the same for each axis. If a sequence, ``zoom`` should
             contain one value for each axis.
-        output (cupy.ndarray or dtype): The array in which to place the output,
-            or the dtype of the returned array.
+        output (cupy.ndarray or ~cupy.dtype): The array in which to place the
+            output, or the dtype of the returned array.
         order (int): The order of the spline interpolation. If it is not given,
             order 1 is used. It is different from :mod:`scipy.ndimage` and can
             change in the future. Currently it supports only order 0 and 1.

--- a/cupyx/scipy/ndimage/interpolation.py
+++ b/cupyx/scipy/ndimage/interpolation.py
@@ -13,7 +13,7 @@ def _get_output(output, input, shape=None):
         output = input.dtype
     if isinstance(output, cupy.ndarray):
         if output.shape != tuple(shape):
-            raise RuntimeError("output shape is not correct")
+            raise ValueError("output shape is not correct")
         return_value = None
     else:
         output = cupy.zeros(shape, dtype=output)
@@ -27,11 +27,11 @@ def _check_parameter(func_name, order, mode):
                       'It is different from scipy.ndimage and can change in '
                       'the future.'.format(func_name))
     elif order < 0 or 5 < order:
-        raise RuntimeError('spline order is not supported')
+        raise ValueError('spline order is not supported')
     elif 1 < order:
         # SciPy supports order 0-5, but CuPy supports only order 0 and 1. Other
         # orders will be implemented, therefore it raises NotImplementedError
-        # instead of RuntimeError.
+        # instead of ValueError.
         raise NotImplementedError('spline order is not supported')
 
     if mode in ('reflect', 'wrap'):
@@ -40,7 +40,7 @@ def _check_parameter(func_name, order, mode):
                                   .format(mode))
     elif mode not in ('constant', 'nearest', 'mirror', 'opencv',
                       '_opencv_edge'):
-        raise RuntimeError('boundary mode is not supported')
+        raise ValueError('boundary mode is not supported')
 
 
 def map_coordinates(input, coordinates, output=None, order=None,

--- a/cupyx/scipy/ndimage/interpolation.py
+++ b/cupyx/scipy/ndimage/interpolation.py
@@ -84,7 +84,7 @@ def map_coordinates(input, coordinates, output=None, order=None,
     _check_parameter('map_coordinates', order, mode)
 
     if mode == 'opencv' or mode == '_opencv_edge':
-        input = cupy.pad(input, [[1, 1]] * input.ndim, 'constant',
+        input = cupy.pad(input, [(1, 1)] * input.ndim, 'constant',
                          constant_values=cval)
         coordinates = cupy.add(coordinates, 1)
         mode = 'constant'
@@ -108,7 +108,7 @@ def map_coordinates(input, coordinates, output=None, order=None,
         input = input.astype(cupy.float32)
 
     if order == 0:
-        out = input[list(cupy.rint(coordinates).astype(cupy.int32))]
+        out = input[tuple(cupy.rint(coordinates).astype(cupy.int32))]
     else:
         coordinates_floor = cupy.floor(coordinates).astype(cupy.int32)
         coordinates_ceil = coordinates_floor + 1

--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -19,7 +19,8 @@ This is the official reference of CuPy, a multi-dimensional array on CUDA with a
    ndarray
    ufunc
    routines
-   sparse           
+   sparse
+   ndimage
    generic
    cuda
    memoize

--- a/docs/source/reference/ndimage.rst
+++ b/docs/source/reference/ndimage.rst
@@ -1,0 +1,28 @@
+----------------------------------
+Multi-dimensional image processing
+----------------------------------
+
+CuPy provides multi-dimensional image processing functions.
+It supports a subset of :mod:`scipy.ndimage` interface.
+
+.. module:: cupyx.scipy.ndimage
+
+
+Interpolation
+-------------
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+
+   cupyx.scipy.ndimage.affine_transform
+   cupyx.scipy.ndimage.map_coordinates
+   cupyx.scipy.ndimage.rotate
+   cupyx.scipy.ndimage.shift
+   cupyx.scipy.ndimage.zoom
+
+
+OpenCV mode
+-----------
+:mod:`cupyx.scipy.ndimage` supports additional mode, ``opencv``.
+If it is given, the function performs like `cv2.warpAffine <https://docs.opencv.org/master/da/d54/group__imgproc__transform.html#ga0203d9ee5fcd28d40dbc4a1ea4451983>`_ or `cv2.resize <https://docs.opencv.org/master/da/d54/group__imgproc__transform.html#ga47a974309e9102f5f08231edc7e7529d>`_.

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,4 +3,5 @@ exclude = .eggs,*.egg,build,caffe_pb2.py,caffe_pb3.py,docs,.git
 
 [tool:pytest]
 filterwarnings= ignore::FutureWarning
+                ignore::UserWarning
                 error::DeprecationWarning

--- a/setup.py
+++ b/setup.py
@@ -102,6 +102,7 @@ setup(
         'cupy.statistics',
         'cupy.testing',
         'cupyx',
+        'cupyx.scipy',
         'cupyx.scipy.ndimage',
     ],
     package_data=package_data,

--- a/setup.py
+++ b/setup.py
@@ -102,6 +102,7 @@ setup(
         'cupy.statistics',
         'cupy.testing',
         'cupyx',
+        'cupyx.scipy.ndimage',
     ],
     package_data=package_data,
     zip_safe=False,

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
@@ -309,7 +309,7 @@ class TestShiftOpenCV(unittest.TestCase):
 
 @testing.parameterize(*testing.product({
     'zoom': [0.1, 10, (0.1, 10)],
-    'output': [None, numpy.float64, 'f', float, 'empty'],
+    'output': [None, numpy.float64, 'empty'],
     'order': [0, 1],
     'mode': ['constant', 'nearest', 'mirror'],
     'cval': [1.0],

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
@@ -56,6 +56,12 @@ class TestMapCoordinates(unittest.TestCase):
     @testing.for_int_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose()
     def test_map_coordinates_int(self, xp, dtype):
+        if numpy.lib.NumpyVersion(scipy.__version__) < '1.0.0':
+            if dtype in (numpy.dtype('l'), numpy.dtype('q')):
+                dtype = numpy.int64
+            elif dtype in (numpy.dtype('L'), numpy.dtype('Q')):
+                dtype = numpy.uint64
+
         a = testing.shaped_random((100, 100), xp, dtype)
         coordinates = testing.shaped_random((a.ndim, 100), xp, dtype)
         out = self._map_coordinates(xp, a, coordinates)
@@ -83,6 +89,10 @@ class TestAffineTransform(unittest.TestCase):
     _multiprocess_can_split = True
 
     def _affine_transform(self, xp, a, matrix):
+        if (numpy.lib.NumpyVersion(scipy.__version__) < '1.0.0'
+                and matrix.ndim == 2 and matrix.shape[1] == 3):
+            return xp.empty(0)
+
         if matrix.shape == (3, 3):
             matrix[-1, 0:-1] = 0
             matrix[-1, -1] = 1
@@ -113,6 +123,12 @@ class TestAffineTransform(unittest.TestCase):
     @testing.for_int_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose()
     def test_affine_transform_int(self, xp, dtype):
+        if numpy.lib.NumpyVersion(scipy.__version__) < '1.0.0':
+            if dtype in (numpy.dtype('l'), numpy.dtype('q')):
+                dtype = numpy.int64
+            elif dtype in (numpy.dtype('L'), numpy.dtype('Q')):
+                dtype = numpy.uint64
+
         a = testing.shaped_random((100, 100), xp, dtype)
         matrix = testing.shaped_random(self.matrix_shape, xp, dtype)
         out = self._affine_transform(xp, a, matrix)
@@ -188,6 +204,12 @@ class TestRotate(unittest.TestCase):
     @testing.for_int_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose()
     def test_rotate_int(self, xp, dtype):
+        if numpy.lib.NumpyVersion(scipy.__version__) < '1.0.0':
+            if dtype in (numpy.dtype('l'), numpy.dtype('q')):
+                dtype = numpy.int64
+            elif dtype in (numpy.dtype('L'), numpy.dtype('Q')):
+                dtype = numpy.uint64
+
         a = testing.shaped_random(self.shape, xp, dtype)
         out = self._rotate(xp, a)
         float_out = self._rotate(xp, a.astype(xp.float64)) % 1
@@ -252,6 +274,12 @@ class TestShift(unittest.TestCase):
     @testing.for_int_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose()
     def test_shift_int(self, xp, dtype):
+        if numpy.lib.NumpyVersion(scipy.__version__) < '1.0.0':
+            if dtype in (numpy.dtype('l'), numpy.dtype('q')):
+                dtype = numpy.int64
+            elif dtype in (numpy.dtype('L'), numpy.dtype('Q')):
+                dtype = numpy.uint64
+
         a = testing.shaped_random((100, 100), xp, dtype)
         out = self._shift(xp, a)
         float_out = self._shift(xp, a.astype(xp.float64)) % 1
@@ -318,6 +346,12 @@ class TestZoom(unittest.TestCase):
     @testing.for_int_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose()
     def test_zoom_int(self, xp, dtype):
+        if numpy.lib.NumpyVersion(scipy.__version__) < '1.0.0':
+            if dtype in (numpy.dtype('l'), numpy.dtype('q')):
+                dtype = numpy.int64
+            elif dtype in (numpy.dtype('L'), numpy.dtype('Q')):
+                dtype = numpy.uint64
+
         a = testing.shaped_random((100, 100), xp, dtype)
         out = self._zoom(xp, a)
         float_out = self._zoom(xp, a.astype(xp.float64)) % 1

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
@@ -1,0 +1,348 @@
+import unittest
+
+import numpy
+
+import cupy
+from cupy import testing
+import cupyx.scipy.ndimage
+
+try:
+    import scipy.ndimage
+except ImportError:
+    pass
+
+try:
+    import cv2
+except ImportError:
+    pass
+
+
+@testing.parameterize(*testing.product({
+    'output': [None, numpy.float64, 'f', float, 'empty'],
+    'order': [0, 1],
+    'mode': ['constant', 'nearest', 'mirror'],
+    'cval': [1.0],
+    'prefilter': [True],
+}))
+@testing.gpu
+@testing.with_requires('scipy')
+class TestMapCoordinates(unittest.TestCase):
+
+    _multiprocess_can_split = True
+
+    def _map_coordinates(self, xp, a, coordinates):
+        if xp == cupy:
+            map_coordinates = cupyx.scipy.ndimage.map_coordinates
+        else:
+            map_coordinates = scipy.ndimage.map_coordinates
+        if self.output == 'empty':
+            output = xp.empty(coordinates.shape[1], dtype=a.dtype)
+            return_value = map_coordinates(a, coordinates, output, self.order,
+                                           self.mode, self.cval,
+                                           self.prefilter)
+            self.assertTrue(return_value is None)
+            return output
+        else:
+            return map_coordinates(a, coordinates, self.output, self.order,
+                                   self.mode, self.cval, self.prefilter)
+
+    @testing.for_float_dtypes(no_float16=True)
+    @testing.numpy_cupy_allclose()
+    def test_map_coordinates_float(self, xp, dtype):
+        a = testing.shaped_random((100, 100), xp, dtype)
+        coordinates = testing.shaped_random((a.ndim, 100), xp, dtype)
+        return self._map_coordinates(xp, a, coordinates)
+
+    @testing.for_int_dtypes(no_bool=True)
+    @testing.numpy_cupy_allclose()
+    def test_map_coordinates_int(self, xp, dtype):
+        a = testing.shaped_random((100, 100), xp, dtype)
+        coordinates = testing.shaped_random((a.ndim, 100), xp, dtype)
+        out = self._map_coordinates(xp, a, coordinates)
+        float_out = self._map_coordinates(xp, a.astype(xp.float64),
+                                          coordinates) % 1
+        half = xp.full_like(float_out, 0.5)
+        out[xp.isclose(float_out, half, atol=1e-5)] = 0
+        return out
+
+
+@testing.parameterize(*testing.product({
+    'matrix_shape': [(2,), (2, 2), (2, 3), (3, 3)],
+    'offset': [0.3, [-1.3, 1.3]],
+    'output_shape': [None],
+    'output': [None, numpy.float64, 'empty'],
+    'order': [0, 1],
+    'mode': ['constant', 'nearest', 'mirror'],
+    'cval': [1.0],
+    'prefilter': [True],
+}))
+@testing.gpu
+@testing.with_requires('scipy')
+class TestAffineTransform(unittest.TestCase):
+
+    _multiprocess_can_split = True
+
+    def _affine_transform(self, xp, a, matrix):
+        if matrix.shape == (3, 3):
+            matrix[-1, 0:-1] = 0
+            matrix[-1, -1] = 1
+        if xp == cupy:
+            affine_transform = cupyx.scipy.ndimage.affine_transform
+        else:
+            affine_transform = scipy.ndimage.affine_transform
+        if self.output == 'empty':
+            output = xp.empty_like(a)
+            return_value = affine_transform(a, matrix, self.offset,
+                                            self.output_shape, output,
+                                            self.order, self.mode, self.cval,
+                                            self.prefilter)
+            self.assertTrue(return_value is None)
+            return output
+        else:
+            return affine_transform(a, matrix, self.offset, self.output_shape,
+                                    self.output, self.order, self.mode,
+                                    self.cval, self.prefilter)
+
+    @testing.for_float_dtypes(no_float16=True)
+    @testing.numpy_cupy_allclose()
+    def test_affine_transform_float(self, xp, dtype):
+        a = testing.shaped_random((100, 100), xp, dtype)
+        matrix = testing.shaped_random(self.matrix_shape, xp, dtype)
+        return self._affine_transform(xp, a, matrix)
+
+    @testing.for_int_dtypes(no_bool=True)
+    @testing.numpy_cupy_allclose()
+    def test_affine_transform_int(self, xp, dtype):
+        a = testing.shaped_random((100, 100), xp, dtype)
+        matrix = testing.shaped_random(self.matrix_shape, xp, dtype)
+        out = self._affine_transform(xp, a, matrix)
+        float_out = self._affine_transform(xp, a.astype(xp.float64),
+                                           matrix) % 1
+        half = xp.full_like(float_out, 0.5)
+        out[xp.isclose(float_out, half, atol=1e-5)] = 0
+        return out
+
+
+@testing.gpu
+@testing.with_requires('opencv-python')
+class TestAffineTransformOpenCV(unittest.TestCase):
+
+    _multiprocess_can_split = True
+
+    @testing.for_float_dtypes(no_float16=True)
+    # The precision of cv2.warpAffine is not good because it uses fixed-point
+    # arithmetic.
+    @testing.numpy_cupy_allclose(atol=0.2)
+    def test_affine_transform_opencv(self, xp, dtype):
+        a = testing.shaped_random((100, 100), xp, dtype)
+        matrix = testing.shaped_random((2, 3), xp, dtype)
+        if xp == cupy:
+            return cupyx.scipy.ndimage.affine_transform(a, matrix, order=1,
+                                                        mode='opencv')
+        else:
+            return cv2.warpAffine(a, matrix, (a.shape[1], a.shape[0]))
+
+
+@testing.parameterize(*testing.product({
+    'shape': [(10, 100), (99, 9), (9, 10, 11)],
+    'angle': [-10, 1000],
+    'axes': [(1, 0)],
+    'reshape': [False, True],
+    'output': [None, numpy.float64, 'empty'],
+    'order': [0, 1],
+    'mode': ['constant', 'nearest', 'mirror'],
+    'cval': [1.0],
+    'prefilter': [True],
+}))
+@testing.gpu
+@testing.with_requires('scipy')
+class TestRotate(unittest.TestCase):
+
+    _multiprocess_can_split = True
+
+    def _rotate(self, xp, a):
+        if xp == cupy:
+            rotate = cupyx.scipy.ndimage.rotate
+        else:
+            rotate = scipy.ndimage.rotate
+        if self.output == 'empty':
+            output = rotate(a, self.angle, self.axes,
+                            self.reshape, None, self.order,
+                            self.mode, self.cval, self.prefilter)
+            return_value = rotate(a, self.angle, self.axes,
+                                  self.reshape, output, self.order,
+                                  self.mode, self.cval, self.prefilter)
+            self.assertTrue(return_value is None)
+            return output
+        else:
+            return rotate(a, self.angle, self.axes,
+                          self.reshape, self.output, self.order,
+                          self.mode, self.cval, self.prefilter)
+
+    @testing.for_float_dtypes(no_float16=True)
+    @testing.numpy_cupy_allclose()
+    def test_rotate_float(self, xp, dtype):
+        a = testing.shaped_random(self.shape, xp, dtype)
+        return self._rotate(xp, a)
+
+    @testing.for_int_dtypes(no_bool=True)
+    @testing.numpy_cupy_allclose()
+    def test_rotate_int(self, xp, dtype):
+        a = testing.shaped_random(self.shape, xp, dtype)
+        out = self._rotate(xp, a)
+        float_out = self._rotate(xp, a.astype(xp.float64)) % 1
+        half = xp.full_like(float_out, 0.5)
+        out[xp.isclose(float_out, half, atol=1e-5)] = 0
+        return out
+
+
+@testing.gpu
+@testing.with_requires('opencv-python')
+class TestRotateOpenCV(unittest.TestCase):
+
+    _multiprocess_can_split = True
+
+    @testing.for_float_dtypes(no_float16=True)
+    @testing.numpy_cupy_allclose(atol=0.3)
+    def test_rotate_opencv(self, xp, dtype):
+        a = testing.shaped_random((100, 100), xp, dtype)
+        if xp == cupy:
+            return cupyx.scipy.ndimage.rotate(a, 10, reshape=False,
+                                              order=1, mode='opencv')
+        else:
+            matrix = cv2.getRotationMatrix2D((49.5, 49.5), 10, 1)
+            return cv2.warpAffine(a, matrix, (a.shape[1], a.shape[0]))
+
+
+@testing.parameterize(*testing.product({
+    'shift': [0.1, -10, (5, -5)],
+    'output': [None, numpy.float64, 'empty'],
+    'order': [0, 1],
+    'mode': ['constant', 'nearest', 'mirror'],
+    'cval': [1.0],
+    'prefilter': [True],
+}))
+@testing.gpu
+@testing.with_requires('scipy')
+class TestShift(unittest.TestCase):
+
+    _multiprocess_can_split = True
+
+    def _shift(self, xp, a):
+        if xp == cupy:
+            shift = cupyx.scipy.ndimage.shift
+        else:
+            shift = scipy.ndimage.shift
+        if self.output == 'empty':
+            output = xp.empty_like(a)
+            return_value = shift(a, self.shift, output, self.order,
+                                 self.mode, self.cval, self.prefilter)
+            self.assertTrue(return_value is None)
+            return output
+        else:
+            return shift(a, self.shift, self.output, self.order,
+                         self.mode, self.cval, self.prefilter)
+
+    @testing.for_float_dtypes(no_float16=True)
+    @testing.numpy_cupy_allclose()
+    def test_shift_float(self, xp, dtype):
+        a = testing.shaped_random((100, 100), xp, dtype)
+        return self._shift(xp, a)
+
+    @testing.for_int_dtypes(no_bool=True)
+    @testing.numpy_cupy_allclose()
+    def test_shift_int(self, xp, dtype):
+        a = testing.shaped_random((100, 100), xp, dtype)
+        out = self._shift(xp, a)
+        float_out = self._shift(xp, a.astype(xp.float64)) % 1
+        half = xp.full_like(float_out, 0.5)
+        out[xp.isclose(float_out, half, atol=1e-5)] = 0
+        return out
+
+
+@testing.gpu
+@testing.with_requires('opencv-python')
+class TestShiftOpenCV(unittest.TestCase):
+
+    _multiprocess_can_split = True
+
+    @testing.for_float_dtypes(no_float16=True)
+    @testing.numpy_cupy_allclose(atol=0.2)
+    def test_shift_opencv(self, xp, dtype):
+        a = testing.shaped_random((100, 100), xp, dtype)
+        shift = testing.shaped_random((2,), xp, dtype)
+        if xp == cupy:
+            return cupyx.scipy.ndimage.shift(a, shift, order=1,
+                                             mode='opencv')
+        else:
+            matrix = numpy.array([[1, 0, shift[1]], [0, 1, shift[0]]])
+            return cv2.warpAffine(a, matrix, (a.shape[1], a.shape[0]))
+
+
+@testing.parameterize(*testing.product({
+    'zoom': [0.1, 10, (0.1, 10)],
+    'output': [None, numpy.float64, 'f', float, 'empty'],
+    'order': [0, 1],
+    'mode': ['constant', 'nearest', 'mirror'],
+    'cval': [1.0],
+    'prefilter': [True],
+}))
+@testing.gpu
+@testing.with_requires('scipy')
+class TestZoom(unittest.TestCase):
+
+    _multiprocess_can_split = True
+
+    def _zoom(self, xp, a):
+        if xp == cupy:
+            zoom = cupyx.scipy.ndimage.zoom
+        else:
+            zoom = scipy.ndimage.zoom
+        if self.output == 'empty':
+            output = zoom(a, self.zoom, None, self.order,
+                          self.mode, self.cval, self.prefilter)
+            return_value = zoom(a, self.zoom, output, self.order,
+                                self.mode, self.cval, self.prefilter)
+            self.assertTrue(return_value is None)
+            return output
+        else:
+            return zoom(a, self.zoom, self.output, self.order,
+                        self.mode, self.cval, self.prefilter)
+
+    @testing.for_float_dtypes(no_float16=True)
+    @testing.numpy_cupy_allclose()
+    def test_zoom_float(self, xp, dtype):
+        a = testing.shaped_random((100, 100), xp, dtype)
+        return self._zoom(xp, a)
+
+    @testing.for_int_dtypes(no_bool=True)
+    @testing.numpy_cupy_allclose()
+    def test_zoom_int(self, xp, dtype):
+        a = testing.shaped_random((100, 100), xp, dtype)
+        out = self._zoom(xp, a)
+        float_out = self._zoom(xp, a.astype(xp.float64)) % 1
+        half = xp.full_like(float_out, 0.5)
+        out[xp.isclose(float_out, half, atol=1e-5)] = 0
+        return out
+
+
+@testing.parameterize(
+    {'zoom': 3},
+    {'zoom': 0.3},
+)
+@testing.gpu
+@testing.with_requires('opencv-python')
+class TestZoomOpenCV(unittest.TestCase):
+
+    _multiprocess_can_split = True
+
+    @testing.for_float_dtypes(no_float16=True)
+    @testing.numpy_cupy_allclose(atol=1e-4)
+    def test_zoom_opencv(self, xp, dtype):
+        a = testing.shaped_random((100, 100), xp, dtype)
+        if xp == cupy:
+            return cupyx.scipy.ndimage.zoom(a, self.zoom, order=1,
+                                            mode='opencv')
+        else:
+            output_shape = numpy.rint(numpy.multiply(a.shape, self.zoom))
+            return cv2.resize(a, tuple(output_shape.astype(int)))

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
@@ -33,7 +33,7 @@ class TestMapCoordinates(unittest.TestCase):
 
     def _map_coordinates(self, xp, a, coordinates):
         # scipy.ndimage has bug with Python2
-        if (sys.version_info[0] == 2 and self.output == 'f'):
+        if sys.version_info[0] == 2 and self.output == 'f':
             return xp.empty(0)
 
         if xp == cupy:

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
@@ -1,3 +1,4 @@
+import sys
 import unittest
 
 import numpy
@@ -31,6 +32,10 @@ class TestMapCoordinates(unittest.TestCase):
     _multiprocess_can_split = True
 
     def _map_coordinates(self, xp, a, coordinates):
+        # scipy.ndimage has bug with Python2
+        if (sys.version_info[0] == 2 and self.output == 'f'):
+            return xp.empty(0)
+
         if xp == cupy:
             map_coordinates = cupyx.scipy.ndimage.map_coordinates
         else:

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
@@ -52,14 +52,14 @@ class TestMapCoordinates(unittest.TestCase):
                                    self.mode, self.cval, self.prefilter)
 
     @testing.for_float_dtypes(no_float16=True)
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(atol=1e-5)
     def test_map_coordinates_float(self, xp, dtype):
         a = testing.shaped_random((100, 100), xp, dtype)
         coordinates = testing.shaped_random((a.ndim, 100), xp, dtype)
         return self._map_coordinates(xp, a, coordinates)
 
     @testing.for_int_dtypes(no_bool=True)
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(atol=1e-5)
     def test_map_coordinates_int(self, xp, dtype):
         if numpy.lib.NumpyVersion(scipy.__version__) < '1.0.0':
             if dtype in (numpy.dtype('l'), numpy.dtype('q')):
@@ -119,14 +119,14 @@ class TestAffineTransform(unittest.TestCase):
                                     self.cval, self.prefilter)
 
     @testing.for_float_dtypes(no_float16=True)
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(atol=1e-5)
     def test_affine_transform_float(self, xp, dtype):
         a = testing.shaped_random((100, 100), xp, dtype)
         matrix = testing.shaped_random(self.matrix_shape, xp, dtype)
         return self._affine_transform(xp, a, matrix)
 
     @testing.for_int_dtypes(no_bool=True)
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(atol=1e-5)
     def test_affine_transform_int(self, xp, dtype):
         if numpy.lib.NumpyVersion(scipy.__version__) < '1.0.0':
             if dtype in (numpy.dtype('l'), numpy.dtype('q')):
@@ -200,13 +200,13 @@ class TestRotate(unittest.TestCase):
                           self.mode, self.cval, self.prefilter)
 
     @testing.for_float_dtypes(no_float16=True)
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(atol=1e-5)
     def test_rotate_float(self, xp, dtype):
         a = testing.shaped_random((10, 10), xp, dtype)
         return self._rotate(xp, a)
 
     @testing.for_int_dtypes(no_bool=True)
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(atol=1e-5)
     def test_rotate_int(self, xp, dtype):
         if numpy.lib.NumpyVersion(scipy.__version__) < '1.0.0':
             if dtype in (numpy.dtype('l'), numpy.dtype('q')):
@@ -235,7 +235,7 @@ class TestRotateAxes(unittest.TestCase):
     _multiprocess_can_split = True
 
     @testing.for_float_dtypes(no_float16=True)
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(1e-5)
     def test_rotate_axes(self, xp, dtype):
         a = testing.shaped_random((10, 10, 10), xp, dtype)
         if xp == cupy:
@@ -293,13 +293,13 @@ class TestShift(unittest.TestCase):
                          self.mode, self.cval, self.prefilter)
 
     @testing.for_float_dtypes(no_float16=True)
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(atol=1e-5)
     def test_shift_float(self, xp, dtype):
         a = testing.shaped_random((100, 100), xp, dtype)
         return self._shift(xp, a)
 
     @testing.for_int_dtypes(no_bool=True)
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(1e-5)
     def test_shift_int(self, xp, dtype):
         if numpy.lib.NumpyVersion(scipy.__version__) < '1.0.0':
             if dtype in (numpy.dtype('l'), numpy.dtype('q')):
@@ -365,13 +365,13 @@ class TestZoom(unittest.TestCase):
                         self.mode, self.cval, self.prefilter)
 
     @testing.for_float_dtypes(no_float16=True)
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(atol=1e-5)
     def test_zoom_float(self, xp, dtype):
         a = testing.shaped_random((100, 100), xp, dtype)
         return self._zoom(xp, a)
 
     @testing.for_int_dtypes(no_bool=True)
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(atol=1e-5)
     def test_zoom_int(self, xp, dtype):
         if numpy.lib.NumpyVersion(scipy.__version__) < '1.0.0':
             if dtype in (numpy.dtype('l'), numpy.dtype('q')):


### PR DESCRIPTION
I implement multi-dimensional image processing as `cupyx.scipy.ndimage`. This is a subset of `scipy.ndimage` interface. Some options for parameters are not supported and it has two differential features.
- Support additional mode, `opencv`. If it is given, the function performs like the behavior of OpenCV's functions.
- Change default order from 3 to 1. If `order` option is not given, it outputs a warning. It may change in the future, but it is not decided. Therefore I think `FutureWarning` is not necessary.