### PR TITLE
Implement cupy.show_config and cupyx.get_runtime_info

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -621,3 +621,4 @@ def get_default_pinned_memory_pool():
 def show_config():
     """Prints the current runtime configuration to standard output."""
     sys.stdout.write(str(cupyx.get_runtime_info()))
+    sys.stdout.flush()

--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -520,6 +520,8 @@ from cupy.core import ReductionKernel  # NOQA
 # New CuPy specific routines should reside in cupyx package.
 from cupy.ext.scatter import scatter_add  # NOQA
 
+import cupyx
+
 
 def asnumpy(a, stream=None):
     """Returns an array on the host memory from an arbitrary source array.
@@ -614,3 +616,8 @@ def get_default_pinned_memory_pool():
 
     """
     return _default_pinned_memory_pool
+
+
+def show_config():
+    """Prints the current runtime configuration to standard output."""
+    sys.stdout.write(str(cupyx.get_runtime_info()))

--- a/cupy/core/carray.pxi
+++ b/cupy/core/carray.pxi
@@ -121,31 +121,6 @@ cpdef str _get_header_source():
     return _header_source
 
 
-cdef str _cuda_path = None
-
-cpdef str _get_cuda_path():
-    global _cuda_path
-    if _cuda_path is None:
-        _cuda_path = os.getenv('CUDA_PATH', None)
-        if _cuda_path is not None:
-            return _cuda_path
-
-        for p in os.getenv('PATH', '').split(os.pathsep):
-            for cmd in ('nvcc', 'nvcc.exe'):
-                nvcc_path = os.path.join(p, cmd)
-                if not os.path.exists(nvcc_path):
-                    continue
-                nvcc_dir = os.path.dirname(
-                    os.path.abspath(nvcc_path))
-                _cuda_path = os.path.normpath(
-                    os.path.join(nvcc_dir, '..'))
-                return _cuda_path
-
-        if os.path.exists('/usr/local/cuda'):
-            _cuda_path = '/usr/local/cuda'
-
-    return _cuda_path
-
 cpdef function.Module compile_with_cache(
         str source, tuple options=(), arch=None, cachd_dir=None):
     source = _cupy_header + source
@@ -159,7 +134,7 @@ cpdef function.Module compile_with_cache(
         _cuda_runtime_version = runtime.runtimeGetVersion()
 
     if _cuda_runtime_version >= 9000:
-        cuda_path = _get_cuda_path()
+        cuda_path = cuda.get_cuda_path()
         if cuda_path is None:
             warnings.warn('Please set the CUDA path ' +
                           'to environment variable `CUDA_PATH`')

--- a/cupy/cuda/__init__.py
+++ b/cupy/cuda/__init__.py
@@ -1,4 +1,5 @@
 import contextlib
+import os
 
 from cupy.cuda import compiler  # NOQA
 from cupy.cuda import device  # NOQA
@@ -14,6 +15,7 @@ from cupy.cuda import stream  # NOQA
 
 
 _available = None
+_cuda_path = None
 
 
 if driver.get_build_version() >= 8000:
@@ -46,6 +48,28 @@ def is_available():
                     'cudaErrorNoDevice: no CUDA-capable device is detected'):
                 raise
     return _available
+
+
+def get_cuda_path():
+    global _cuda_path
+    if _cuda_path is None:
+        _cuda_path = os.getenv('CUDA_PATH', None)
+        if _cuda_path is not None:
+            return _cuda_path
+
+        for p in os.getenv('PATH', '').split(os.pathsep):
+            for cmd in ('nvcc', 'nvcc.exe'):
+                nvcc_path = os.path.join(p, cmd)
+                if not os.path.exists(nvcc_path):
+                    continue
+                nvcc_dir = os.path.dirname(os.path.abspath(nvcc_path))
+                _cuda_path = os.path.normpath(os.path.join(nvcc_dir, '..'))
+                return _cuda_path
+
+        if os.path.exists('/usr/local/cuda'):
+            _cuda_path = '/usr/local/cuda'
+
+    return _cuda_path
 
 
 # import class and function

--- a/cupyx/__init__.py
+++ b/cupyx/__init__.py
@@ -1,4 +1,4 @@
 # "NOQA" to suppress flake8 warning
-from cupyx.runtime import get_runtime_info  # NOQA
 from cupyx.rsqrt import rsqrt  # NOQA
+from cupyx.runtime import get_runtime_info  # NOQA
 from cupyx.scatter import scatter_add  # NOQA

--- a/cupyx/__init__.py
+++ b/cupyx/__init__.py
@@ -1,3 +1,4 @@
 # "NOQA" to suppress flake8 warning
+from cupyx.runtime import get_runtime_info  # NOQA
 from cupyx.rsqrt import rsqrt  # NOQA
 from cupyx.scatter import scatter_add  # NOQA

--- a/cupyx/runtime.py
+++ b/cupyx/runtime.py
@@ -53,8 +53,8 @@ class _RuntimeInfo(object):
         width = max([len(r[0]) for r in records]) + 2
         fmt = '{:' + str(width) + '}: {}\n'
         s = six.StringIO()
-        for r in records:
-            s.write(fmt.format(*r))
+        for k, v in records:
+            s.write(fmt.format(k, v))
 
         return s.getvalue()
 

--- a/cupyx/runtime.py
+++ b/cupyx/runtime.py
@@ -1,0 +1,63 @@
+import six
+
+import cupy
+
+try:
+    import cupy.cuda.cudnn as cudnn
+except ImportError:
+    cudnn = None
+
+try:
+    import cupy.cuda.nccl as nccl
+except ImportError:
+    nccl = None
+
+
+class _RuntimeInfo(object):
+
+    cupy_version = None
+    cuda_path = None
+    cuda_build_version = None
+    cuda_driver_version = None
+    cuda_runtime_version = None
+    cudnn_build_version = None
+    cudnn_version = None
+    nccl_build_version = None
+
+    def __init__(self):
+        self.cupy_version = cupy.__version__
+
+        self.cuda_path = cupy.cuda.get_cuda_path()
+        self.cuda_build_version = cupy.cuda.driver.get_build_version()
+        self.cuda_driver_version = cupy.cuda.runtime.driverGetVersion()
+        self.cuda_runtime_version = cupy.cuda.runtime.runtimeGetVersion()
+
+        if cudnn is not None:
+            self.cudnn_build_version = cudnn.get_build_version()
+            self.cudnn_version = cudnn.getVersion()
+
+        if nccl is not None:
+            self.nccl_build_version = nccl.get_version()
+
+    def __str__(self):
+        records = [
+            ('CuPy Version', self.cupy_version),
+            ('CUDA Root', self.cuda_path),
+            ('CUDA Build Version', self.cuda_build_version),
+            ('CUDA Driver Version', self.cuda_driver_version),
+            ('CUDA Runtime Version', self.cuda_runtime_version),
+            ('cuDNN Build Version', self.cudnn_build_version),
+            ('cuDNN Version', self.cudnn_version),
+            ('NCCL Build Version', self.nccl_build_version),
+        ]
+        width = max([len(r[0]) for r in records]) + 2
+        fmt = '{:' + str(width) + '}: {}\n'
+        s = six.StringIO()
+        for r in records:
+            s.write(fmt.format(*r))
+
+        return s.getvalue()
+
+
+def get_runtime_info():
+    return _RuntimeInfo()

--- a/tests/cupy_tests/test_init.py
+++ b/tests/cupy_tests/test_init.py
@@ -101,6 +101,7 @@ class TestShowConfig(unittest.TestCase):
             cupy.show_config()
         write_func.assert_called_once_with(str(cupyx.get_runtime_info()))
 
+
 # This is copied from chainer/testing/__init__.py, so should be replaced in
 # some way.
 if __name__ == '__main__':

--- a/tests/cupy_tests/test_init.py
+++ b/tests/cupy_tests/test_init.py
@@ -5,9 +5,11 @@ import sys
 import tempfile
 import unittest
 
+import mock
 
 import cupy
 from cupy import testing
+import cupyx
 
 
 def _run_script(code):
@@ -95,7 +97,9 @@ class TestMemoryPool(unittest.TestCase):
 class TestShowConfig(unittest.TestCase):
 
     def test_show_config(self):
-        cupy.show_config()
+        with mock.patch('sys.stdout.write') as write_func:
+            cupy.show_config()
+        write_func.assert_called_once_with(str(cupyx.get_runtime_info()))
 
 # This is copied from chainer/testing/__init__.py, so should be replaced in
 # some way.

--- a/tests/cupy_tests/test_init.py
+++ b/tests/cupy_tests/test_init.py
@@ -92,6 +92,11 @@ class TestMemoryPool(unittest.TestCase):
         self.assertIsInstance(p, cupy.cuda.pinned_memory.PinnedMemoryPool)
 
 
+class TestShowConfig(unittest.TestCase):
+
+    def test_show_config(self):
+        cupy.show_config()
+
 # This is copied from chainer/testing/__init__.py, so should be replaced in
 # some way.
 if __name__ == '__main__':

--- a/tests/cupyx_tests/test_runtime.py
+++ b/tests/cupyx_tests/test_runtime.py
@@ -8,4 +8,4 @@ class TestRuntime(unittest.TestCase):
     def test_runtime(self):
         runtime = cupyx.get_runtime_info()
         assert cupy.__version__ == runtime.cupy_version
-        assert cupy.__version__ in str(runtime.cupy_version)
+        assert cupy.__version__ in str(runtime)

--- a/tests/cupyx_tests/test_runtime.py
+++ b/tests/cupyx_tests/test_runtime.py
@@ -1,0 +1,11 @@
+import unittest
+
+import cupy
+import cupyx
+
+
+class TestRuntime(unittest.TestCase):
+    def test_runtime(self):
+        runtime = cupyx.get_runtime_info()
+        assert cupy.__version__ == runtime.cupy_version
+        assert cupy.__version__ in str(runtime.cupy_version)


### PR DESCRIPTION
* `cupy.show_config` is a counterpart for `numpy.show_config` that prints configuration information to stdout.
  Note that `cupy.show_config` prints both compile-time and runtime info, whereas `numpy.show_config` only prints compile-time info.
* `cupyx.get_runtime_info` is a hidden API to be used in Chainer (see PR https://github.com/chainer/chainer/pull/4298)