### PR TITLE
remove invalid argument description in cupy.tensordot

### DIFF
--- a/cupy/linalg/product.py
+++ b/cupy/linalg/product.py
@@ -146,7 +146,6 @@ def tensordot(a, b, axes=2):
             - If it is a pair of sequences of integers, then these two
               sequences specify the list of axes for ``a`` and ``b``. The
               corresponding axes are paired for sum-product.
-        out (cupy.ndarray): Output array.
 
     Returns:
         cupy.ndarray: The tensor dot product of ``a`` and ``b`` along the


### PR DESCRIPTION
`out` is not available in CuPy nor NumPy.
See https://docs.scipy.org/doc/numpy-1.14.0/reference/generated/numpy.tensordot.html