### PR TITLE
Support double precision atomicAdd on Maxwell or older GPUs

### DIFF
--- a/cupy/core/carray.pxi
+++ b/cupy/core/carray.pxi
@@ -66,6 +66,7 @@ cdef class Indexer:
 cdef list _cupy_header_list = [
     'cupy/complex.cuh',
     'cupy/carray.cuh',
+    'cupy/atomics.cuh',
 ]
 cdef str _cupy_header = ''.join(
     ['#include <%s>\n' % i for i in _cupy_header_list])

--- a/cupy/core/include/cupy/atomics.cuh
+++ b/cupy/core/include/cupy/atomics.cuh
@@ -1,0 +1,18 @@
+#pragma once
+
+#if __CUDA_ARCH__ < 600
+
+__device__ double atomicAdd(double *address, double val)
+{
+    unsigned long long int* address_as_ull = (unsigned long long int*)address;
+    unsigned long long int old = *address_as_ull;
+    unsigned long long int assumed;
+    do {
+	assumed = old;
+	old = atomicCAS(address_as_ull, assumed,
+			__double_as_longlong(val + __longlong_as_double(assumed)));
+    } while (assumed != old);
+    return __longlong_as_double(old);
+}
+
+#endif

--- a/cupy/sparse/compressed.py
+++ b/cupy/sparse/compressed.py
@@ -19,7 +19,7 @@ class _compressed_sparse_matrix(sparse_data._data_matrix):
     _compress_getitem_kern = core.ElementwiseKernel(
         'T d, S ind, int32 minor', 'raw T answer',
         'if (ind == minor) atomicAdd(&answer[0], d);',
-        'compress_getitem', preamble=util._preamble_atomic_add)
+        'compress_getitem')
 
     def __init__(self, arg1, shape=None, dtype=None, copy=False):
         if shape is not None and len(shape) != 2:

--- a/cupy/sparse/coo.py
+++ b/cupy/sparse/coo.py
@@ -240,8 +240,7 @@ class coo_matrix(sparse_data._data_matrix):
                 row[index] = src_row;
                 col[index] = src_col;
                 ''',
-                'sum_duplicates_assign',
-                preamble=util._preamble_atomic_add
+                'sum_duplicates_assign'
             )(src_data, src_row, src_col, index, data, row, col)
 
         self.data = data

--- a/cupy/sparse/util.py
+++ b/cupy/sparse/util.py
@@ -2,24 +2,6 @@ import cupy
 import cupy.sparse.base
 
 
-_preamble_atomic_add = '''
-#if __CUDA_ARCH__ < 600
-__device__ double atomicAdd(double* address, double val) {
-    unsigned long long* address_as_ull =
-                                          (unsigned long long*)address;
-    unsigned long long old = *address_as_ull, assumed;
-    do {
-        assumed = old;
-        old = atomicCAS(address_as_ull, assumed,
-                        __double_as_longlong(val +
-                        __longlong_as_double(assumed)));
-    } while (assumed != old);
-    return __longlong_as_double(old);
-}
-#endif
-'''
-
-
 def isintlike(x):
     try:
         return bool(int(x) == x)

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ package_data = {
         'core/include/cupy/complex/math_private.h',
         'core/include/cupy/carray.cuh',
         'core/include/cupy/complex.cuh',
+        'core/include/cupy/atomics.cuh',
         'cuda/cupy_thrust.cu',
     ],
 }


### PR DESCRIPTION
This PR aims to support double precision `atomicAdd` on Maxwell or older GPUs. This is related to chainer/chainer#4397.