### PR TITLE
Fix wrong references of document

### DIFF
--- a/cupy/cuda/__init__.py
+++ b/cupy/cuda/__init__.py
@@ -62,6 +62,7 @@ from cupy.cuda.memory import Memory  # NOQA
 from cupy.cuda.memory import MemoryPointer  # NOQA
 from cupy.cuda.memory import MemoryPool  # NOQA
 from cupy.cuda.memory import set_allocator  # NOQA
+from cupy.cuda.memory import SingleDeviceMemoryPool  # NOQA
 from cupy.cuda.memory_hook import MemoryHook  # NOQA
 from cupy.cuda.pinned_memory import alloc_pinned_memory  # NOQA
 from cupy.cuda.pinned_memory import PinnedMemory  # NOQA

--- a/cupy/cuda/__init__.py
+++ b/cupy/cuda/__init__.py
@@ -62,7 +62,6 @@ from cupy.cuda.memory import Memory  # NOQA
 from cupy.cuda.memory import MemoryPointer  # NOQA
 from cupy.cuda.memory import MemoryPool  # NOQA
 from cupy.cuda.memory import set_allocator  # NOQA
-from cupy.cuda.memory import SingleDeviceMemoryPool  # NOQA
 from cupy.cuda.memory_hook import MemoryHook  # NOQA
 from cupy.cuda.pinned_memory import alloc_pinned_memory  # NOQA
 from cupy.cuda.pinned_memory import PinnedMemory  # NOQA

--- a/cupy/cuda/pinned_memory.pyx
+++ b/cupy/cuda/pinned_memory.pyx
@@ -49,8 +49,8 @@ cdef class PinnedMemoryPointer:
             pointer refers.
 
     Attributes:
-        mem (PinnedMemory): The device memory buffer.
-        ptr (int): Pointer to the place within the buffer.
+        ~PinnedMemoryPointer.mem (PinnedMemory): The device memory buffer.
+        ~PinnedMemoryPointer.ptr (int): Pointer to the place within the buffer.
     """
 
     def __init__(self, mem, Py_ssize_t offset):

--- a/cupy/indexing/generate.py
+++ b/cupy/indexing/generate.py
@@ -108,7 +108,7 @@ Args:
 Returns:
     cupy.ndarray: Joined array.
 
-.. seealso:: :func:`numpy.c_`
+.. seealso:: :obj:`numpy.c_`
 
 Examples
 --------
@@ -147,7 +147,7 @@ Args:
 Returns:
     cupy.ndarray: Joined array.
 
-.. seealso:: :func:`numpy.r_`
+.. seealso:: :obj:`numpy.r_`
 
 Examples
 --------

--- a/cupy/math/rounding.py
+++ b/cupy/math/rounding.py
@@ -49,6 +49,7 @@ fix = core.create_ufunc(
     'out0 = (in0 >= 0.0) ? floor(in0): ceil(in0)',
     doc='''If given value x is positive, it return floor(x).
     Else, it return ceil(x).
-    .. seealso:: :data:`numpy.fix`
+
+    .. seealso:: :func:`numpy.fix`
 
     ''')

--- a/cupy/math/sumprod.py
+++ b/cupy/math/sumprod.py
@@ -134,7 +134,7 @@ def cumsum(a, axis=None, dtype=None, out=None):
     Args:
         a (cupy.ndarray): Input array.
         axis (int): Axis along which the cumulative sum is taken. If it is not
-        specified, the input is flattened.
+            specified, the input is flattened.
         dtype: Data type specifier.
         out (cupy.ndarray): Output array.
 
@@ -177,7 +177,7 @@ def cumprod(a, axis=None, dtype=None, out=None):
     Args:
         a (cupy.ndarray): Input array.
         axis (int): Axis along which the cumulative product is taken. If it is
-        not specified, the input is flattened.
+            not specified, the input is flattened.
         dtype: Data type specifier.
         out (cupy.ndarray): Output array.
 

--- a/cupy/prof/time_range.py
+++ b/cupy/prof/time_range.py
@@ -65,8 +65,7 @@ class TimeRangeDecorator(object):
             processing on GPU before calling :func:`cupy.cuda.nvtx.RangePush()`
             or :func:`cupy.cuda.nvtx.RangePop()`
 
-    .. seealso:: :func:`cupy.nvtx.range`
-        :func:`cupy.cuda.nvtx.RangePush`
+    .. seealso:: :func:`cupy.cuda.nvtx.RangePush`
         :func:`cupy.cuda.nvtx.RangePop`
     """
 

--- a/cupy/random/distributions.py
+++ b/cupy/random/distributions.py
@@ -40,7 +40,7 @@ def gumbel(loc=0.0, scale=1.0, size=None, dtype=float):
         cupy.ndarray: Samples drawn from the Gumbel destribution.
 
     .. seealso::
-        :func:`cupy.RandomState.gumbel`
+        :func:`cupy.random.RandomState.gumbel`
         :func:`numpy.random.gumbel`
     """
     rs = generator.get_random_state()

--- a/cupy/random/generator.py
+++ b/cupy/random/generator.py
@@ -307,7 +307,7 @@ class RandomState(object):
 
         .. seealso::
             :func:`cupy.random.choice` for full document,
-            :meth:`numpy.random.choice`
+            :func:`numpy.random.choice`
 
         """
         if a is None:
@@ -384,7 +384,7 @@ class RandomState(object):
 
         .. seealso::
             :func:`cupy.random.shuffle` for full document,
-            :meth:`numpy.random.shuffle`
+            :func:`numpy.random.shuffle`
 
         """
         if not isinstance(a, cupy.ndarray):

--- a/cupy/sparse/base.py
+++ b/cupy/sparse/base.py
@@ -336,7 +336,7 @@ class spmatrix(object):
             cupy.ndarray: Summed array.
 
         .. seealso::
-           :func:`scipy.sparse.spmatrix.sum`
+           :meth:`scipy.sparse.spmatrix.sum`
 
         """
         util.validateaxis(axis)

--- a/cupy/sparse/coo.py
+++ b/cupy/sparse/coo.py
@@ -194,7 +194,7 @@ class coo_matrix(sparse_data._data_matrix):
         """Eliminate duplicate matrix entries by adding them together.
 
         .. seealso::
-           :func:`scipy.sparse.coo_matrix.sum_duplicates`
+           :meth:`scipy.sparse.coo_matrix.sum_duplicates`
 
         """
         if self._has_canonical_format:
@@ -259,7 +259,7 @@ class coo_matrix(sparse_data._data_matrix):
         Returns:
             cupy.ndarray: Dense array representing the same value.
 
-        .. seealso:: :func:`cupy.sparse.coo_array.toarray`
+        .. seealso:: :meth:`cupy.sparse.coo_matrix.toarray`
 
         """
         return self.tocsr().toarray(order=order, out=out)

--- a/cupy/sparse/coo.py
+++ b/cupy/sparse/coo.py
@@ -259,7 +259,7 @@ class coo_matrix(sparse_data._data_matrix):
         Returns:
             cupy.ndarray: Dense array representing the same value.
 
-        .. seealso:: :meth:`cupy.sparse.coo_matrix.toarray`
+        .. seealso:: :meth:`scipy.sparse.coo_matrix.toarray`
 
         """
         return self.tocsr().toarray(order=order, out=out)

--- a/cupy/sparse/csc.py
+++ b/cupy/sparse/csc.py
@@ -138,7 +138,7 @@ class csc_matrix(compressed._compressed_sparse_matrix):
         Returns:
             cupy.ndarray: Dense array representing the same matrix.
 
-        .. seealso:: :func:`cupy.sparse.csc_array.toarray`
+        .. seealso:: :meth:`scipy.sparse.csc_matrix.toarray`
 
         """
         if order is None:

--- a/cupy/sparse/csr.py
+++ b/cupy/sparse/csr.py
@@ -191,7 +191,7 @@ class csr_matrix(compressed._compressed_sparse_matrix):
         Returns:
             cupy.ndarray: Dense array representing the same matrix.
 
-        .. seealso:: :func:`cupy.sparse.csr_array.toarray`
+        .. seealso:: :meth:`scipy.sparse.csr_matrix.toarray`
 
         """
         if order is None:

--- a/cupy/sparse/linalg/solve.py
+++ b/cupy/sparse/linalg/solve.py
@@ -24,7 +24,8 @@ def lsqr(A, b):
         b (cupy.ndarray): Right-hand side vector.
 
     Returns:
-        ret (tuple): Its length must be ten. It has same type elements
+        tuple:
+            Its length must be ten. It has same type elements
             as SciPy. Only the first element, the solution vector ``x``, is
             available and other elements are expressed as ``None`` because
             the implementation of cuSOLVER is different from the one of SciPy.

--- a/cupyx/scatter.py
+++ b/cupyx/scatter.py
@@ -50,7 +50,7 @@ def scatter_add(a, slices, value):
         package.
         ``cupy.scatter_add`` is still available for backward compatibility.
 
-    .. seealso:: :func:`numpy.add.at`.
+    .. seealso:: :meth:`numpy.ufunc.at`.
 
     """
     a.scatter_add(slices, value)

--- a/docs/source/reference/cuda.rst
+++ b/docs/source/reference/cuda.rst
@@ -21,12 +21,16 @@ Memory management
    cupy.get_default_memory_pool
    cupy.get_default_pinned_memory_pool
    cupy.cuda.Memory
+   cupy.cuda.PinnedMemory
    cupy.cuda.MemoryPointer
+   cupy.cuda.PinnedMemoryPointer
    cupy.cuda.alloc
+   cupy.cuda.alloc_pinned_memory
    cupy.cuda.set_allocator
    cupy.cuda.set_pinned_memory_allocator
    cupy.cuda.MemoryPool
    cupy.cuda.PinnedMemoryPool
+   cupy.cuda.SingleDeviceMemoryPool
 
 
 Memory hook

--- a/docs/source/reference/cuda.rst
+++ b/docs/source/reference/cuda.rst
@@ -30,7 +30,6 @@ Memory management
    cupy.cuda.set_pinned_memory_allocator
    cupy.cuda.MemoryPool
    cupy.cuda.PinnedMemoryPool
-   cupy.cuda.SingleDeviceMemoryPool
 
 
 Memory hook

--- a/docs/source/reference/fft.rst
+++ b/docs/source/reference/fft.rst
@@ -1,3 +1,5 @@
+.. module:: cupy.fft
+
 FFT Functions
 =============
 

--- a/docs/source/reference/sorting.rst
+++ b/docs/source/reference/sorting.rst
@@ -8,9 +8,11 @@ Sorting, Searching, and Counting
    cupy.sort
    cupy.lexsort
    cupy.argsort
+   cupy.msort
    cupy.argmax
    cupy.argmin
    cupy.partition
+   cupy.argpartition
    cupy.count_nonzero
    cupy.nonzero
    cupy.flatnonzero


### PR DESCRIPTION
I fix wrong references using nitpicky mode of Sphinx.
Enable nitpicky mode is suggested (#657), but it is a bit difficult to fix all warnings.
Therefore, I first write PR about fixing easy errors.