### PR TITLE
Fix a.real and a.imag to return view

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1389,7 +1389,9 @@ cdef class ndarray:
     @property
     def real(self):
         if self.dtype.kind == 'c':
-            return real(self)
+            view = self.view(self.dtype.char.lower())
+            view._set_shape_and_strides(self.shape, self.strides)
+            return view
         return self
 
     @real.setter
@@ -1402,7 +1404,10 @@ cdef class ndarray:
     @property
     def imag(self):
         if self.dtype.kind == 'c':
-            return imag(self)
+            view = self.view(self.dtype.char.lower())
+            view._set_shape_and_strides(self.shape, self.strides)
+            view.data = view.data + self.itemsize // 2
+            return view
         new_array = ndarray(self.shape, dtype=self.dtype)
         new_array.fill(0)
         return new_array

--- a/tests/cupy_tests/core_tests/test_ndarray_complex_ops.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_complex_ops.py
@@ -75,6 +75,25 @@ class TestRealImag(unittest.TestCase):
         x.imag = testing.shaped_reverse_arange((2, 3), xp, dtype)
         return x
 
+    @testing.for_all_dtypes()
+    def test_real_inplace(self, dtype):
+        x = cupy.zeros((2, 3), dtype=dtype)
+        x.real[:] = 1
+        expected = cupy.ones((2, 3), dtype=dtype)
+        assert cupy.all(x == expected)
+
+    @testing.for_all_dtypes()
+    def test_imag_inplace(self, dtype):
+        x = cupy.zeros((2, 3), dtype=dtype)
+
+        # TODO(kmaehashi) The following line should raise error for real
+        # dtypes, but currently ignored silently.
+        x.imag[:] = 1
+
+        expected = cupy.zeros((2, 3), dtype=dtype) + (
+            1j if x.dtype.kind == 'c' else 0)
+        assert cupy.all(x == expected)
+
 
 @testing.gpu
 class TestScalarConversion(unittest.TestCase):


### PR DESCRIPTION
This PR fixes the issue #799 that in-place modification of `real` and `imag` does not work.

~~TODO: add test.~~ (done)