### PR TITLE
remove platform-dependent dtype

### DIFF
--- a/tests/cupy_tests/linalg_tests/test_einsum.py
+++ b/tests/cupy_tests/linalg_tests/test_einsum.py
@@ -244,8 +244,7 @@ class TestEinSumBinaryOperationWithScalar(unittest.TestCase):
 
 
 def _target_dtype(dtype):
-    if (dtype == numpy.complex64 or dtype == numpy.complex128 or
-            dtype == numpy.complex256):
+    if (dtype == numpy.complex64 or dtype == numpy.complex128):
         return numpy.complex64
     else:
         return numpy.float32


### PR DESCRIPTION
Tests will fail in some environments (e.g., Windows) that does not support `complex256`.
`testing.for_all_dtypes` does not emit `complex256` test case, so this condition is not needed.