### PR TITLE
Use cuDNN v7 APIs to get conv algos for TensorCore

### DIFF
--- a/cupy/cuda/cudnn.pxd
+++ b/cupy/cuda/cudnn.pxd
@@ -177,7 +177,7 @@ cpdef findConvolutionForwardAlgorithmEx(
     size_t handle, size_t xDesc, size_t x, size_t wDesc, size_t w,
     size_t convDesc, size_t yDesc, size_t y, int requestedAlgoCount,
     size_t workSpace, size_t workSpaceSizeInBytes)
-cpdef int getConvolutionForwardAlgorithm(
+cpdef int getConvolutionForwardAlgorithm_v6(
     size_t handle, size_t srcDesc, size_t filterDesc, size_t convDesc,
     size_t destDesc, int preference, size_t memoryLimitInbytes) except *
 cpdef getConvolutionForwardAlgorithm_v7(
@@ -201,7 +201,7 @@ cpdef findConvolutionBackwardFilterAlgorithmEx(
     size_t handle, size_t xDesc, size_t x, size_t dyDesc, size_t dy,
     size_t convDesc, size_t dwDesc, size_t dw, int requestedAlgoCount,
     size_t workSpace, size_t workSpaceSizeInBytes)
-cpdef int getConvolutionBackwardFilterAlgorithm(
+cpdef int getConvolutionBackwardFilterAlgorithm_v6(
     size_t handle, size_t srcDesc, size_t diffDesc, size_t convDesc,
     size_t filterDesc, int preference, size_t memoryLimitInbytes) except *
 cpdef getConvolutionBackwardFilterAlgorithm_v7(
@@ -222,7 +222,7 @@ cpdef findConvolutionBackwardDataAlgorithmEx(
     size_t handle, size_t wDesc, size_t w, size_t dyDesc, size_t dy,
     size_t convDesc, size_t dxDesc, size_t dx,
     int requestedAlgoCount, size_t workSpace, size_t workSpaceSizeInBytes)
-cpdef int getConvolutionBackwardDataAlgorithm(
+cpdef int getConvolutionBackwardDataAlgorithm_v6(
     size_t handle, size_t filterDesc, size_t diffDesc, size_t convDesc,
     size_t gradDesc, size_t preference,
     size_t memoryLimitInbytes) except *

--- a/cupy/cuda/cudnn.pxd
+++ b/cupy/cuda/cudnn.pxd
@@ -180,6 +180,9 @@ cpdef findConvolutionForwardAlgorithmEx(
 cpdef int getConvolutionForwardAlgorithm(
     size_t handle, size_t srcDesc, size_t filterDesc, size_t convDesc,
     size_t destDesc, int preference, size_t memoryLimitInbytes) except *
+cpdef getConvolutionForwardAlgorithm_v7(
+    size_t handle, size_t srcDesc, size_t filterDesc, size_t convDesc,
+    size_t destDesc, int requestedAlgoCount)
 cpdef size_t getConvolutionForwardWorkspaceSize(
     size_t handle, size_t srcDesc, size_t filterDesc, size_t convDesc,
     size_t destDesc, int algo) except *
@@ -201,6 +204,9 @@ cpdef findConvolutionBackwardFilterAlgorithmEx(
 cpdef int getConvolutionBackwardFilterAlgorithm(
     size_t handle, size_t srcDesc, size_t diffDesc, size_t convDesc,
     size_t filterDesc, int preference, size_t memoryLimitInbytes) except *
+cpdef getConvolutionBackwardFilterAlgorithm_v7(
+    size_t handle, size_t srcDesc, size_t diffDesc, size_t convDesc,
+    size_t gradDesc, int requestedAlgoCount)
 cpdef size_t getConvolutionBackwardFilterWorkspaceSize(
     size_t handle, size_t srcDesc, size_t diffDesc, size_t convDesc,
     size_t filterDesc, int algo) except *
@@ -220,6 +226,9 @@ cpdef int getConvolutionBackwardDataAlgorithm(
     size_t handle, size_t filterDesc, size_t diffDesc, size_t convDesc,
     size_t gradDesc, size_t preference,
     size_t memoryLimitInbytes) except *
+cpdef getConvolutionBackwardDataAlgorithm_v7(
+    size_t handle, size_t filterDesc, size_t diffDesc, size_t convDesc,
+    size_t gradDesc, int requestedAlgoCount)
 cpdef size_t getConvolutionBackwardDataWorkspaceSize(
     size_t handle, size_t filterDesc, size_t diffDesc, size_t convDesc,
     size_t gradDesc, int algo) except *

--- a/cupy/cuda/cudnn.pyx
+++ b/cupy/cuda/cudnn.pyx
@@ -151,7 +151,7 @@ cdef extern from "cupy_cudnn.h" nogil:
         TensorDescriptor yDesc, void* y, int requestedAlgoCount,
         int* returnedAlgoCount, ConvolutionFwdAlgoPerf* perfResults,
         void* workSpace, size_t workSpaceSizeInBytes)
-    int cudnnGetConvolutionForwardAlgorithm(
+    int cudnnGetConvolutionForwardAlgorithm_v6(
         Handle handle, TensorDescriptor srcDesc,
         FilterDescriptor filterDesc, ConvolutionDescriptor convDesc,
         TensorDescriptor destDesc, ConvolutionFwdPreference preference,
@@ -187,7 +187,7 @@ cdef extern from "cupy_cudnn.h" nogil:
         FilterDescriptor dwDesc, void* dw, int requestedAlgoCount,
         int* returnedAlgoCount, ConvolutionBwdFilterAlgoPerf* perfResults,
         void* workSpace, size_t workSpaceSizeInBytes)
-    int cudnnGetConvolutionBackwardFilterAlgorithm(
+    int cudnnGetConvolutionBackwardFilterAlgorithm_v6(
         Handle handle, TensorDescriptor srcDesc, TensorDescriptor diffDesc,
         ConvolutionDescriptor convDesc, FilterDescriptor filterDesc,
         ConvolutionBwdFilterPreference preference,
@@ -208,7 +208,7 @@ cdef extern from "cupy_cudnn.h" nogil:
         ConvolutionDescriptor convDesc, ConvolutionBwdFilterAlgo algo,
         void* workSpace, size_t workSpaceSizeInBytes, void* beta,
         FilterDescriptor gradDesc, void* gradData)
-    int cudnnGetConvolutionBackwardDataAlgorithm(
+    int cudnnGetConvolutionBackwardDataAlgorithm_v6(
         Handle handle, FilterDescriptor filterDesc,
         TensorDescriptor diffDesc,
         ConvolutionDescriptor convDesc, TensorDescriptor gradDesc,
@@ -723,11 +723,11 @@ cpdef findConvolutionForwardAlgorithmEx(
     return perfResults
 
 
-cpdef int getConvolutionForwardAlgorithm(
+cpdef int getConvolutionForwardAlgorithm_v6(
         size_t handle, size_t srcDesc, size_t filterDesc, size_t convDesc,
         size_t destDesc, int preference, size_t memoryLimitInbytes) except *:
     cdef ConvolutionFwdAlgo algo
-    status = cudnnGetConvolutionForwardAlgorithm(
+    status = cudnnGetConvolutionForwardAlgorithm_v6(
         <Handle>handle, <TensorDescriptor>srcDesc,
         <FilterDescriptor>filterDesc, <ConvolutionDescriptor>convDesc,
         <TensorDescriptor>destDesc, <ConvolutionFwdPreference>preference,
@@ -826,11 +826,11 @@ cpdef findConvolutionBackwardFilterAlgorithmEx(
     return perfResults
 
 
-cpdef int getConvolutionBackwardFilterAlgorithm(
+cpdef int getConvolutionBackwardFilterAlgorithm_v6(
         size_t handle, size_t srcDesc, size_t diffDesc, size_t convDesc,
         size_t filterDesc, int preference, size_t memoryLimitInbytes) except *:
     cdef ConvolutionBwdFilterAlgo algo
-    status = cudnnGetConvolutionBackwardFilterAlgorithm(
+    status = cudnnGetConvolutionBackwardFilterAlgorithm_v6(
         <Handle>handle, <TensorDescriptor>srcDesc,
         <TensorDescriptor>diffDesc, <ConvolutionDescriptor>convDesc,
         <FilterDescriptor>filterDesc,
@@ -918,12 +918,12 @@ cpdef findConvolutionBackwardDataAlgorithmEx(
     return perfResults
 
 
-cpdef int getConvolutionBackwardDataAlgorithm(
+cpdef int getConvolutionBackwardDataAlgorithm_v6(
         size_t handle, size_t filterDesc, size_t diffDesc, size_t convDesc,
         size_t gradDesc, size_t preference,
         size_t memoryLimitInbytes) except *:
     cdef ConvolutionBwdDataAlgo algo
-    status = cudnnGetConvolutionBackwardDataAlgorithm(
+    status = cudnnGetConvolutionBackwardDataAlgorithm_v6(
         <Handle>handle, <FilterDescriptor>filterDesc,
         <TensorDescriptor>diffDesc, <ConvolutionDescriptor>convDesc,
         <TensorDescriptor>gradDesc, <ConvolutionBwdDataPreference>preference,

--- a/cupy/cuda/cudnn.pyx
+++ b/cupy/cuda/cudnn.pyx
@@ -26,7 +26,6 @@ cdef extern from "cupy_cudnn.h" nogil:
         int status
         float time
         size_t memory
-        int determinism
     ctypedef int ConvolutionBwdFilterAlgo 'cudnnConvolutionBwdFilterAlgo_t'
     ctypedef int ConvolutionBwdFilterPreference \
         'cudnnConvolutionBwdFilterPreference_t'
@@ -36,7 +35,6 @@ cdef extern from "cupy_cudnn.h" nogil:
         int status
         float time
         size_t memory
-        int determinism
     ctypedef int ConvolutionFwdAlgo 'cudnnConvolutionFwdAlgo_t'
     ctypedef int ConvolutionFwdPreference 'cudnnConvolutionFwdPreference_t'
     ctypedef struct ConvolutionFwdAlgoPerf 'cudnnConvolutionFwdAlgoPerf_t':
@@ -44,7 +42,6 @@ cdef extern from "cupy_cudnn.h" nogil:
         int status
         float time
         size_t memory
-        int determinism
     ctypedef int ConvolutionMode 'cudnnConvolutionMode_t'
     ctypedef int DataType 'cudnnDataType_t'
     ctypedef int MathType 'cudnnMathType_t'

--- a/cupy/cuda/cupy_cudnn.h
+++ b/cupy/cuda/cupy_cudnn.h
@@ -117,7 +117,7 @@ cudnnStatus_t cudnnDestroyConvolutionDescriptor(...) {
     return CUDNN_STATUS_SUCCESS;
 }
 
-cudnnStatus_t cudnnGetConvolutionForwardAlgorithm(...) {
+cudnnStatus_t cudnnGetConvolutionForwardAlgorithm_v6(...) {
     return CUDNN_STATUS_SUCCESS;
 }
 
@@ -212,7 +212,7 @@ cudnnStatus_t cudnnFindConvolutionBackwardFilterAlgorithm(...) {
     return CUDNN_STATUS_NOT_SUPPORTED;
 }
 
-cudnnStatus_t cudnnGetConvolutionBackwardFilterAlgorithm(...) {
+cudnnStatus_t cudnnGetConvolutionBackwardFilterAlgorithm_v6(...) {
     return CUDNN_STATUS_NOT_SUPPORTED;
 }
 
@@ -228,7 +228,7 @@ cudnnStatus_t cudnnFindConvolutionBackwardDataAlgorithm(...) {
     return CUDNN_STATUS_NOT_SUPPORTED;
 }
 
-cudnnStatus_t cudnnGetConvolutionBackwardDataAlgorithm(...) {
+cudnnStatus_t cudnnGetConvolutionBackwardDataAlgorithm_v6(...) {
     return CUDNN_STATUS_NOT_SUPPORTED;
 }
 
@@ -588,6 +588,16 @@ cudnnStatus_t cudnnSetConvolution2dDescriptor_v4(...) {
 
 
 #endif // #if !defined(CUPY_NO_CUDA) && (CUDNN_VERSION >= 7000)
+
+
+#if !defined(CUPY_NO_CUDA) && (CUDNN_VERSION < 8000)
+// TODO: check function names when cuDNN 8 is released.
+
+#define cudnnGetConvolutionForwardAlgorithm_v6 cudnnGetConvolutionForwardAlgorithm
+#define cudnnGetConvolutionBackwardFilterAlgorithm_v6 cudnnGetConvolutionBackwardFilterAlgorithm
+#define cudnnGetConvolutionBackwardDataAlgorithm_v6 cudnnGetConvolutionBackwardDataAlgorithm
+
+#endif // #if !defined(CUPY_NO_CUDA) && (CUDNN_VERSION < 8000)
 
 } // extern "C"
 

--- a/cupy/cuda/cupy_cudnn.h
+++ b/cupy/cuda/cupy_cudnn.h
@@ -169,27 +169,23 @@ typedef enum {} cudnnConvolutionBwdDataAlgo_t;
 typedef enum {} cudnnConvolutionBwdDataPreference_t;
 typedef enum {} cudnnConvolutionBwdFilterAlgo_t;
 typedef enum {} cudnnConvolutionBwdFilterPreference_t;
-typedef enum {} cudnnDeterminism_t;
 typedef struct {
   cudnnConvolutionFwdAlgo_t algo;
   cudnnStatus_t status;
   float time;
   size_t memory;
-  cudnnDeterminism_t determinism;
 } cudnnConvolutionFwdAlgoPerf_t;
 typedef struct {
   cudnnConvolutionBwdFilterAlgo_t algo;
   cudnnStatus_t status;
   float time;
   size_t memory;
-  cudnnDeterminism_t determinism;
 } cudnnConvolutionBwdFilterAlgoPerf_t;
 typedef struct {
   cudnnConvolutionBwdDataAlgo_t algo;
   cudnnStatus_t status;
   float time;
   size_t memory;
-  cudnnDeterminism_t determinism;
 } cudnnConvolutionBwdDataAlgoPerf_t;
 
 cudnnStatus_t cudnnAddTensor_v3(...) {

--- a/cupy/cuda/cupy_cudnn.h
+++ b/cupy/cuda/cupy_cudnn.h
@@ -121,6 +121,10 @@ cudnnStatus_t cudnnGetConvolutionForwardAlgorithm(...) {
     return CUDNN_STATUS_SUCCESS;
 }
 
+cudnnStatus_t cudnnGetConvolutionForwardAlgorithm_v7(...) {
+    return CUDNN_STATUS_SUCCESS;
+}
+
 cudnnStatus_t cudnnGetConvolutionForwardWorkspaceSize(...) {
     return CUDNN_STATUS_SUCCESS;
 }
@@ -165,23 +169,27 @@ typedef enum {} cudnnConvolutionBwdDataAlgo_t;
 typedef enum {} cudnnConvolutionBwdDataPreference_t;
 typedef enum {} cudnnConvolutionBwdFilterAlgo_t;
 typedef enum {} cudnnConvolutionBwdFilterPreference_t;
+typedef enum {} cudnnDeterminism_t;
 typedef struct {
   cudnnConvolutionFwdAlgo_t algo;
   cudnnStatus_t status;
   float time;
   size_t memory;
+  cudnnDeterminism_t determinism;
 } cudnnConvolutionFwdAlgoPerf_t;
 typedef struct {
   cudnnConvolutionBwdFilterAlgo_t algo;
   cudnnStatus_t status;
   float time;
   size_t memory;
+  cudnnDeterminism_t determinism;
 } cudnnConvolutionBwdFilterAlgoPerf_t;
 typedef struct {
   cudnnConvolutionBwdDataAlgo_t algo;
   cudnnStatus_t status;
   float time;
   size_t memory;
+  cudnnDeterminism_t determinism;
 } cudnnConvolutionBwdDataAlgoPerf_t;
 
 cudnnStatus_t cudnnAddTensor_v3(...) {
@@ -208,6 +216,10 @@ cudnnStatus_t cudnnGetConvolutionBackwardFilterAlgorithm(...) {
     return CUDNN_STATUS_NOT_SUPPORTED;
 }
 
+cudnnStatus_t cudnnGetConvolutionBackwardFilterAlgorithm_v7(...) {
+    return CUDNN_STATUS_NOT_SUPPORTED;
+}
+
 cudnnStatus_t cudnnConvolutionBackwardData_v3(...) {
     return CUDNN_STATUS_NOT_SUPPORTED;
 }
@@ -217,6 +229,10 @@ cudnnStatus_t cudnnFindConvolutionBackwardDataAlgorithm(...) {
 }
 
 cudnnStatus_t cudnnGetConvolutionBackwardDataAlgorithm(...) {
+    return CUDNN_STATUS_NOT_SUPPORTED;
+}
+
+cudnnStatus_t cudnnGetConvolutionBackwardDataAlgorithm_v7(...) {
     return CUDNN_STATUS_NOT_SUPPORTED;
 }
 
@@ -544,6 +560,18 @@ cudnnStatus_t cudnnSetConvolutionGroupCount(...) {
 }
 
 cudnnStatus_t cudnnGetConvolutionGroupCount(...) {
+    return CUDNN_STATUS_NOT_SUPPORTED;
+}
+
+cudnnStatus_t cudnnGetConvolutionForwardAlgorithm_v7(...) {
+    return CUDNN_STATUS_SUCCESS;
+}
+
+cudnnStatus_t cudnnGetConvolutionBackwardFilterAlgorithm_v7(...) {
+    return CUDNN_STATUS_NOT_SUPPORTED;
+}
+
+cudnnStatus_t cudnnGetConvolutionBackwardDataAlgorithm_v7(...) {
     return CUDNN_STATUS_NOT_SUPPORTED;
 }
 

--- a/cupy/cudnn.pyx
+++ b/cupy/cudnn.pyx
@@ -526,12 +526,10 @@ cpdef tuple _get_algorithm_fwd(
     if use_tensor_core and _cudnn_version >= 7000:
         ret = cudnn.getConvolutionForwardAlgorithm_v7(
             handle, x_desc, filter_desc, conv_desc, y_desc, 10)
-        i = -1
-        for j in range(len(ret)):
-            if ret[j]['memory'] <= max_workspace_size:
-                i = j
+        for i in range(len(ret)):
+            if ret[i]['memory'] <= max_workspace_size:
                 break
-        if i < 0:
+        else:
             raise RuntimeError('No conv fwd algo available with workspace size'
                                ' less equal {}'.format(max_workspace_size))
         if i != 0:
@@ -541,12 +539,12 @@ cpdef tuple _get_algorithm_fwd(
         algo = ret[i]['algo']
         workspace_size = ret[i]['memory']
     else:
-        algo = cudnn.getConvolutionForwardAlgorithm(
+        algo = cudnn.getConvolutionForwardAlgorithm_v6(
             handle, x_desc, filter_desc, conv_desc, y_desc,
             cudnn.CUDNN_CONVOLUTION_FWD_SPECIFY_WORKSPACE_LIMIT,
             max_workspace_size)
         workspace_size = max_workspace_size
-    return (algo, workspace_size)
+    return algo, workspace_size
 
 
 cpdef tuple _find_algorithm_bwd_filter(
@@ -574,15 +572,13 @@ cpdef tuple _get_algorithm_bwd_filter(
     if use_tensor_core and _cudnn_version >= 7000:
         ret = cudnn.getConvolutionBackwardFilterAlgorithm_v7(
             handle, x_desc, gy_desc, conv_desc, filter_desc, 10)
-        i = -1
-        for j in range(len(ret)):
-            if ret[j]['memory'] <= max_workspace_size:
-                i = j
+        for i in range(len(ret)):
+            if ret[i]['memory'] <= max_workspace_size:
                 break
-        if i < 0:
-            raise RuntimeError('No conv bwd filter algo available with '
-                               'workspace size less equal {}'
-                               ''.format(max_workspace_size))
+        else:
+            msg = 'No conv bwd filter algo available with workspace size less '\
+                  'equal {}'.format(max_workspace_size)
+            raise RuntimeError(msg)
         if i != 0:
             msg = 'The best algo of conv bwd filter might not not selected '\
                   'due to lack of workspace size ({})'\
@@ -591,7 +587,7 @@ cpdef tuple _get_algorithm_bwd_filter(
         algo = ret[i]['algo']
         workspace_size = ret[i]['memory']
     else:
-        algo = cudnn.getConvolutionBackwardFilterAlgorithm(
+        algo = cudnn.getConvolutionBackwardFilterAlgorithm_v6(
             handle, x_desc, gy_desc, conv_desc, filter_desc,
             cudnn.CUDNN_CONVOLUTION_BWD_FILTER_SPECIFY_WORKSPACE_LIMIT,
             max_workspace_size)
@@ -624,12 +620,10 @@ cpdef tuple _get_algorithm_bwd_data(
     if use_tensor_core and _cudnn_version >= 7000:
         ret = cudnn.getConvolutionBackwardDataAlgorithm_v7(
             handle, filter_desc, x_desc, conv_desc, y_desc, 10)
-        i = -1
-        for j in range(len(ret)):
-            if ret[j]['memory'] <= max_workspace_size:
-                i = j
+        for i in range(len(ret)):
+            if ret[i]['memory'] <= max_workspace_size:
                 break
-        if i < 0:
+        else:
             msg = 'No conv bwd data algo available with workspace size less '\
                   'equal {}'.format(max_workspace_size)
             raise RuntimeError(msg)
@@ -640,7 +634,7 @@ cpdef tuple _get_algorithm_bwd_data(
         algo = ret[i]['algo']
         workspace_size = ret[i]['memory']
     else:
-        algo = cudnn.getConvolutionBackwardDataAlgorithm(
+        algo = cudnn.getConvolutionBackwardDataAlgorithm_v6(
             handle, filter_desc, x_desc, conv_desc, y_desc,
             cudnn.CUDNN_CONVOLUTION_BWD_DATA_SPECIFY_WORKSPACE_LIMIT,
             max_workspace_size)

--- a/cupy/cudnn.pyx
+++ b/cupy/cudnn.pyx
@@ -501,7 +501,7 @@ cdef dict _algorithm_bwd_filter = {}
 cdef dict _algorithm_bwd_data = {}
 
 
-cpdef tuple _get_algorithm_fwd(
+cpdef tuple _find_algorithm_fwd(
         core.ndarray x, core.ndarray W, core.ndarray y, tuple conv_param,
         size_t handle, size_t x_desc, size_t filter_desc, size_t conv_desc,
         size_t y_desc, size_t max_workspace_size):
@@ -518,7 +518,38 @@ cpdef tuple _get_algorithm_fwd(
     return algo
 
 
-cpdef tuple _get_algorithm_bwd_filter(
+cpdef tuple _get_algorithm_fwd(
+        size_t handle, size_t x_desc, size_t filter_desc, size_t conv_desc,
+        size_t y_desc, size_t max_workspace_size, bint use_tensor_core):
+    cdef int algo
+    cdef workspace_size
+    if use_tensor_core and _cudnn_version >= 7000:
+        ret = cudnn.getConvolutionForwardAlgorithm_v7(
+            handle, x_desc, filter_desc, conv_desc, y_desc, 10)
+        i = -1
+        for j in range(len(ret)):
+            if ret[j]['memory'] <= max_workspace_size:
+                i = j
+                break
+        if i < 0:
+            raise RuntimeError('No conv fwd algo available with workspace size'
+                               ' less equal {}'.format(max_workspace_size))
+        if i != 0:
+            msg = 'The best algo of conv fwd might not be selected due to '\
+                  'lack of workspace size ({})'.format(max_workspace_size)
+            warnings.warn(msg)
+        algo = ret[i]['algo']
+        workspace_size = ret[i]['memory']
+    else:
+        algo = cudnn.getConvolutionForwardAlgorithm(
+            handle, x_desc, filter_desc, conv_desc, y_desc,
+            cudnn.CUDNN_CONVOLUTION_FWD_SPECIFY_WORKSPACE_LIMIT,
+            max_workspace_size)
+        workspace_size = max_workspace_size
+    return (algo, workspace_size)
+
+
+cpdef tuple _find_algorithm_bwd_filter(
         core.ndarray x, core.ndarray dy, core.ndarray dW, tuple conv_param,
         size_t handle, size_t x_desc, size_t dy_desc, size_t conv_desc,
         size_t filter_desc, size_t max_workspace_size):
@@ -535,7 +566,40 @@ cpdef tuple _get_algorithm_bwd_filter(
     return algo
 
 
-cpdef tuple _get_algorithm_bwd_data(
+cpdef tuple _get_algorithm_bwd_filter(
+        size_t handle, size_t x_desc, size_t gy_desc, size_t conv_desc,
+        size_t filter_desc, size_t max_workspace_size, bint use_tensor_core):
+    cdef int algo
+    cdef workspace_size
+    if use_tensor_core and _cudnn_version >= 7000:
+        ret = cudnn.getConvolutionBackwardFilterAlgorithm_v7(
+            handle, x_desc, gy_desc, conv_desc, filter_desc, 10)
+        i = -1
+        for j in range(len(ret)):
+            if ret[j]['memory'] <= max_workspace_size:
+                i = j
+                break
+        if i < 0:
+            raise RuntimeError('No conv bwd filter algo available with '
+                               'workspace size less equal {}'
+                               ''.format(max_workspace_size))
+        if i != 0:
+            msg = 'The best algo of conv bwd filter might not not selected '\
+                  'due to lack of workspace size ({})'\
+                  .format(max_workspace_size)
+            warnings.warn(msg)
+        algo = ret[i]['algo']
+        workspace_size = ret[i]['memory']
+    else:
+        algo = cudnn.getConvolutionBackwardFilterAlgorithm(
+            handle, x_desc, gy_desc, conv_desc, filter_desc,
+            cudnn.CUDNN_CONVOLUTION_BWD_FILTER_SPECIFY_WORKSPACE_LIMIT,
+            max_workspace_size)
+        workspace_size = max_workspace_size
+    return (algo, workspace_size)
+
+
+cpdef tuple _find_algorithm_bwd_data(
         core.ndarray W, core.ndarray x, core.ndarray y, tuple conv_param,
         size_t handle, size_t filter_desc, size_t x_desc, size_t conv_desc,
         size_t y_desc, size_t max_workspace_size):
@@ -550,6 +614,38 @@ cpdef tuple _get_algorithm_bwd_data(
     algo = (ret[0]['algo'], ret[0]['memory'])
     _algorithm_bwd_data[key] = algo
     return algo
+
+
+cpdef tuple _get_algorithm_bwd_data(
+        size_t handle, size_t filter_desc, size_t x_desc, size_t conv_desc,
+        size_t y_desc, size_t max_workspace_size, bint use_tensor_core):
+    cdef int algo
+    cdef workspace_size
+    if use_tensor_core and _cudnn_version >= 7000:
+        ret = cudnn.getConvolutionBackwardDataAlgorithm_v7(
+            handle, filter_desc, x_desc, conv_desc, y_desc, 10)
+        i = -1
+        for j in range(len(ret)):
+            if ret[j]['memory'] <= max_workspace_size:
+                i = j
+                break
+        if i < 0:
+            msg = 'No conv bwd data algo available with workspace size less '\
+                  'equal {}'.format(max_workspace_size)
+            raise RuntimeError(msg)
+        if i != 0:
+            msg = 'The best algo of conv bwd data might not not selected due '\
+                  'to lack of workspace size ({})'.format(max_workspace_size)
+            warnings.warn(msg)
+        algo = ret[i]['algo']
+        workspace_size = ret[i]['memory']
+    else:
+        algo = cudnn.getConvolutionBackwardDataAlgorithm(
+            handle, filter_desc, x_desc, conv_desc, y_desc,
+            cudnn.CUDNN_CONVOLUTION_BWD_DATA_SPECIFY_WORKSPACE_LIMIT,
+            max_workspace_size)
+        workspace_size = max_workspace_size
+    return (algo, workspace_size)
 
 
 cpdef bint _should_use_tensor_core(
@@ -608,7 +704,7 @@ def convolution_forward(
 
     cdef int algo
     cdef size_t max_workspace_size = get_max_workspace_size()
-    cdef size_t workspace_size
+    cdef size_t workspace_size = 0
     try:
         _create_tensor_nd_descriptor(x_desc, x, -1)
         _create_tensor_nd_descriptor(y_desc, y, -1)
@@ -617,30 +713,22 @@ def convolution_forward(
             conv_desc, pad, stride, dilation, groups, x.dtype,
             cudnn.CUDNN_CROSS_CORRELATION, use_tensor_core)
 
-        if use_tensor_core:
-            # Only CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_PRECOMP_GEMM
-            # supports Tensor-Core in cuDNN7.
-            algo = cudnn.CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_PRECOMP_GEMM
-            workspace_size = cudnn.getConvolutionForwardWorkspaceSize(
-                handle, x_desc, filter_desc, conv_desc, y_desc, algo)
-            max_workspace_size = max(max_workspace_size, workspace_size)
-        elif auto_tune and _cudnn_version >= 5000:
-            algo, workspace_size = _get_algorithm_fwd(
+        if auto_tune and _cudnn_version >= 5000:
+            algo, workspace_size = _find_algorithm_fwd(
                 x, W, y, conv_param, handle, x_desc, filter_desc,
                 conv_desc, y_desc, max_workspace_size)
         else:
-            algo = cudnn.getConvolutionForwardAlgorithm(
+            algo, workspace_size = _get_algorithm_fwd(
                 handle, x_desc, filter_desc, conv_desc, y_desc,
-                cudnn.CUDNN_CONVOLUTION_FWD_SPECIFY_WORKSPACE_LIMIT,
-                max_workspace_size)
-            workspace_size = max_workspace_size
+                max_workspace_size, use_tensor_core)
 
+        max_workspace_size = max(max_workspace_size, workspace_size)
         # TODO(okuta): allocate best size memory
         workspace = memory.alloc(max_workspace_size)
 
         cudnn.convolutionForward(
             handle, one, x_desc, x.data.ptr, filter_desc, W.data.ptr,
-            conv_desc, algo, workspace.ptr, workspace_size, zero, y_desc,
+            conv_desc, algo, workspace.ptr, max_workspace_size, zero, y_desc,
             y.data.ptr)
 
         if b is not None:
@@ -691,7 +779,7 @@ def convolution_backward_filter(
 
     cdef int algo
     cdef size_t max_workspace_size = get_max_workspace_size()
-    cdef size_t workspace_size
+    cdef size_t workspace_size = 0
     try:
         _create_tensor_nd_descriptor(x_desc, x, -1)
         _create_tensor_nd_descriptor(gy_desc, gy, -1)
@@ -700,31 +788,28 @@ def convolution_backward_filter(
             conv_desc, pad, stride, dilation, groups, x.dtype,
             cudnn.CUDNN_CROSS_CORRELATION, use_tensor_core)
 
-        if deterministic or use_tensor_core:
-            # Only CUDNN_CONVOLUTION_BWD_FILTER_ALGO_1 supports
-            # Tensor-Core in cuDNN7.
+        if deterministic:
             algo = cudnn.CUDNN_CONVOLUTION_BWD_FILTER_ALGO_1
             workspace_size = cudnn.getConvolutionBackwardFilterWorkspaceSize(
                 handle, x_desc, gy_desc, conv_desc, filter_desc, algo)
-            max_workspace_size = max(max_workspace_size, workspace_size)
             # TODO(okuta): check workspace size
         elif auto_tune and _cudnn_version >= 5000:
-            algo, workspace_size = _get_algorithm_bwd_filter(
+            algo, workspace_size = _find_algorithm_bwd_filter(
                 x, gy, gW, conv_param, handle, x_desc, gy_desc, conv_desc,
                 filter_desc, max_workspace_size)
         else:
-            algo = cudnn.getConvolutionBackwardFilterAlgorithm(
+            algo, workspace_size = _get_algorithm_bwd_filter(
                 handle, x_desc, gy_desc, conv_desc, filter_desc,
-                cudnn.CUDNN_CONVOLUTION_BWD_FILTER_SPECIFY_WORKSPACE_LIMIT,
-                max_workspace_size)
-            workspace_size = max_workspace_size
+                max_workspace_size, use_tensor_core)
+
+        max_workspace_size = max(max_workspace_size, workspace_size)
         # TODO(okuta): allocate best size memory
         workspace = memory.alloc(max_workspace_size)
 
         cudnn.convolutionBackwardFilter_v3(
             handle, one, x_desc, x.data.ptr, gy_desc,
             gy.data.ptr, conv_desc, algo, workspace.ptr,
-            workspace_size, zero, filter_desc, gW.data.ptr)
+            max_workspace_size, zero, filter_desc, gW.data.ptr)
     finally:
         cudnn.destroyTensorDescriptor(x_desc)
         cudnn.destroyTensorDescriptor(gy_desc)
@@ -774,7 +859,7 @@ def convolution_backward_data(
 
     cdef int algo
     cdef size_t max_workspace_size = get_max_workspace_size()
-    cdef size_t workspace_size
+    cdef size_t workspace_size = 0
     try:
         _create_tensor_nd_descriptor(x_desc, x, -1)
         _create_tensor_nd_descriptor(y_desc, y, -1)
@@ -783,31 +868,27 @@ def convolution_backward_data(
             conv_desc, pad, stride, dilation, groups, x.dtype,
             cudnn.CUDNN_CROSS_CORRELATION, use_tensor_core)
 
-        if deterministic or use_tensor_core:
-            # Only CUDNN_CONVOLUTION_BWD_DATA_ALGO_1 supports
-            # Tensor-Core in cuDNN7
+        if deterministic:
             algo = cudnn.CUDNN_CONVOLUTION_BWD_DATA_ALGO_1
             workspace_size = cudnn.getConvolutionBackwardDataWorkspaceSize(
                 handle, filter_desc, x_desc, conv_desc, y_desc, algo)
-            max_workspace_size = max(max_workspace_size, workspace_size)
             # TODO(okuta): check workspace size
         elif auto_tune and _cudnn_version >= 5000:
-            algo, workspace_size = _get_algorithm_bwd_data(
+            algo, workspace_size = _find_algorithm_bwd_data(
                 W, x, y, conv_param, handle, filter_desc, x_desc,
                 conv_desc, y_desc, max_workspace_size)
         else:
-            algo = cudnn.getConvolutionBackwardDataAlgorithm(
+            algo, workspace_size = _get_algorithm_bwd_data(
                 handle, filter_desc, x_desc, conv_desc, y_desc,
-                cudnn.CUDNN_CONVOLUTION_BWD_DATA_SPECIFY_WORKSPACE_LIMIT,
-                max_workspace_size)
-            workspace_size = max_workspace_size
+                max_workspace_size, use_tensor_core)
 
+        max_workspace_size = max(max_workspace_size, workspace_size)
         # TODO(okuta): allocate best size memory
         workspace = memory.alloc(max_workspace_size)
 
         cudnn.convolutionBackwardData_v3(
             handle, one, filter_desc, W.data.ptr, x_desc, x.data.ptr,
-            conv_desc, algo, workspace.ptr, workspace_size, zero, y_desc,
+            conv_desc, algo, workspace.ptr, max_workspace_size, zero, y_desc,
             y.data.ptr)
 
         if b is not None:

--- a/cupy/cudnn.pyx
+++ b/cupy/cudnn.pyx
@@ -592,7 +592,7 @@ cpdef tuple _get_algorithm_bwd_filter(
             cudnn.CUDNN_CONVOLUTION_BWD_FILTER_SPECIFY_WORKSPACE_LIMIT,
             max_workspace_size)
         workspace_size = max_workspace_size
-    return (algo, workspace_size)
+    return algo, workspace_size
 
 
 cpdef tuple _find_algorithm_bwd_data(
@@ -639,7 +639,7 @@ cpdef tuple _get_algorithm_bwd_data(
             cudnn.CUDNN_CONVOLUTION_BWD_DATA_SPECIFY_WORKSPACE_LIMIT,
             max_workspace_size)
         workspace_size = max_workspace_size
-    return (algo, workspace_size)
+    return algo, workspace_size
 
 
 cpdef bint _should_use_tensor_core(


### PR DESCRIPTION
This PR aims to use v7 APIs of cuDNN in order to get appropriate convolution algorithms when TensorCore is available.  This is a split from #890.