### PR TITLE
Fix cupy.concatenate to support arrays with >= 2**31 elements

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2467,7 +2467,7 @@ cpdef ndarray concatenate_method(tup, int axis):
 
 cpdef ndarray _concatenate(list arrays, Py_ssize_t axis, tuple shape, dtype):
     cdef ndarray a, ret
-    cdef int i
+    cdef Py_ssize_t i
     cdef bint all_same_type, same_shape_and_contiguous
     cdef Py_ssize_t axis_size
     # If arrays are large, Issuing each copy method is efficient.

--- a/cupy/core/internal.pyx
+++ b/cupy/core/internal.pyx
@@ -143,7 +143,7 @@ cpdef vector.vector[Py_ssize_t] infer_unknown_dimension(
 
 
 @cython.profile(False)
-cpdef inline int _extract_slice_element(x) except *:
+cpdef inline Py_ssize_t _extract_slice_element(x) except *:
     try:
         return x.__index__()
     except AttributeError:

--- a/tests/cupy_tests/manipulation_tests/test_join.py
+++ b/tests/cupy_tests/manipulation_tests/test_join.py
@@ -108,12 +108,16 @@ class TestJoin(unittest.TestCase):
         b = testing.shaped_arange((2, 1), xp, 'f')
         return xp.concatenate((a, b) * 1024, axis=1)
 
-    @testing.numpy_cupy_array_equal()
     @testing.slow
-    def test_concatenate_32bit_boundary(self, xp):
-        a = xp.zeros((2 ** 30,), dtype=xp.int8)
-        b = xp.zeros((2 ** 30,), dtype=xp.int8)
-        return xp.concatenate([a, b])
+    def test_concatenate_32bit_boundary(self):
+        a = cupy.zeros((2 ** 30,), dtype=cupy.int8)
+        b = cupy.zeros((2 ** 30,), dtype=cupy.int8)
+        ret = cupy.concatenate([a, b])
+        del a
+        del b
+        del ret
+        # Free huge memory for slow test
+        cupy.get_default_memory_pool().free_all_blocks()
 
     def test_concatenate_wrong_ndim(self):
         a = cupy.empty((2, 3))

--- a/tests/cupy_tests/manipulation_tests/test_join.py
+++ b/tests/cupy_tests/manipulation_tests/test_join.py
@@ -108,6 +108,13 @@ class TestJoin(unittest.TestCase):
         b = testing.shaped_arange((2, 1), xp, 'f')
         return xp.concatenate((a, b) * 1024, axis=1)
 
+    @testing.numpy_cupy_array_equal()
+    @testing.slow
+    def test_concatenate_32bit_boundary(self, xp):
+        a = xp.zeros((2 ** 30,), dtype=xp.int8)
+        b = xp.zeros((2 ** 30,), dtype=xp.int8)
+        return xp.concatenate([a, b])
+
     def test_concatenate_wrong_ndim(self):
         a = cupy.empty((2, 3))
         b = cupy.empty((2,))


### PR DESCRIPTION
Fix #893.