### PR TITLE
fix duplicate delcaration of cudaError_t

### DIFF
--- a/cupy/cuda/runtime.pyx
+++ b/cupy/cuda/runtime.pyx
@@ -30,7 +30,6 @@ cdef class PointerAttributes:
 # Extern
 ###############################################################################
 cdef extern from *:
-    ctypedef int Error 'cudaError_t'
     ctypedef int DeviceAttr 'enum cudaDeviceAttr'
     ctypedef int MemoryAdvise 'enum cudaMemoryAdvise'
     ctypedef int MemoryKind 'enum cudaMemcpyKind'


### PR DESCRIPTION
`Error` is already declared in `runtime.pxd`: https://github.com/cupy/cupy/blob/v4.0.0rc1/cupy/cuda/runtime.pxd#L15, to share `Error` declaration with  `profile.pyx`.

This fixes the warning message during installation.

```
    warning: cupy/cuda/runtime.pyx:33:4: 'Error' redeclared
```