### PR TITLE
Use fmin and fmax for HIP environment

### DIFF
--- a/cupy/core/include/cupy/carray.cuh
+++ b/cupy/core/include/cupy/carray.cuh
@@ -150,6 +150,12 @@ __device__ float16 min(float16 x, float16 y) {
 __device__ float16 max(float16 x, float16 y) {
   return float16(max(float(x), float(y)));
 }
+__device__ float16 fmin(float16 x, float16 y) {
+  return float16(fmin(float(x), float(y)));
+}
+__device__ float16 fmax(float16 x, float16 y) {
+  return float16(fmax(float(x), float(y)));
+}
 __device__ int iszero(float16 x) {return x.iszero();}
 __device__ int isnan(float16 x) {return x.isnan();}
 __device__ int isinf(float16 x) {return x.isinf();}

--- a/cupy/math/misc.py
+++ b/cupy/math/misc.py
@@ -76,8 +76,7 @@ sign = core.create_ufunc(
     ''')
 
 
-_float_maximum = \
-    'out0 = isnan(in0) ? in0 : isnan(in1) ? in1 : max(in0, in1)'
+_float_maximum = 'out0 = isnan(in0) ? in0 : isnan(in1) ? in1 : max(in0, in1)'
 maximum = core.create_ufunc(
     'cupy_maximum',
     ('??->?', 'bb->b', 'BB->B', 'hh->h', 'HH->H', 'ii->i', 'II->I', 'll->l',
@@ -97,8 +96,7 @@ maximum = core.create_ufunc(
     ''')
 
 
-_float_minimum = \
-    'out0 = isnan(in0) ? in0 : isnan(in1) ? in1 : min(in0, in1)'
+_float_minimum = 'out0 = isnan(in0) ? in0 : isnan(in1) ? in1 : min(in0, in1)'
 minimum = core.create_ufunc(
     'cupy_minimum',
     ('??->?', 'bb->b', 'BB->B', 'hh->h', 'HH->H', 'ii->i', 'II->I', 'll->l',
@@ -121,7 +119,11 @@ minimum = core.create_ufunc(
 fmax = core.create_ufunc(
     'cupy_fmax',
     ('??->?', 'bb->b', 'BB->B', 'hh->h', 'HH->H', 'ii->i', 'II->I', 'll->l',
-     'LL->L', 'qq->q', 'QQ->Q', 'ee->e', 'ff->f', 'dd->d', 'FF->F', 'DD->D'),
+     'LL->L', 'qq->q', 'QQ->Q',
+     ('ee->e', 'out0 = fmax(in0, in1)'),
+     ('ff->f', 'out0 = fmax(in0, in1)'),
+     ('dd->d', 'out0 = fmax(in0, in1)'),
+     'FF->F', 'DD->D'),
     'out0 = max(in0, in1)',
     doc='''Takes the maximum of two arrays elementwise.
 
@@ -135,7 +137,11 @@ fmax = core.create_ufunc(
 fmin = core.create_ufunc(
     'cupy_fmin',
     ('??->?', 'bb->b', 'BB->B', 'hh->h', 'HH->H', 'ii->i', 'II->I', 'll->l',
-     'LL->L', 'qq->q', 'QQ->Q', 'ee->e', 'ff->f', 'dd->d', 'FF->F', 'DD->D'),
+     'LL->L', 'qq->q', 'QQ->Q',
+     ('ee->e', 'out0 = fmin(in0, in1)'),
+     ('ff->f', 'out0 = fmin(in0, in1)'),
+     ('dd->d', 'out0 = fmin(in0, in1)'),
+     'FF->F', 'DD->D'),
     'out0 = min(in0, in1)',
     doc='''Takes the minimum of two arrays elementwise.
 


### PR DESCRIPTION
This PR is related to #1094 and #1117 .


`numpy.fmax` complies with std c `fmax` function. But, `min` behaves same as `fmin` in CUDA. It is a little strange.

HIP doesn't have such behavior. So, this PR fix it.