### PR TITLE
fix cupy.linalg.inv() breaks its argument

### DIFF
--- a/cupy/linalg/solve.py
+++ b/cupy/linalg/solve.py
@@ -168,6 +168,9 @@ def inv(a):
     if not cuda.cusolver_enabled:
         raise RuntimeError('Current cupy only supports cusolver in CUDA 8.0')
 
+    # to prevent `a` to be overwritten
+    a = a.copy()
+
     util._assert_cupy_array(a)
     util._assert_rank2(a)
     util._assert_nd_squareness(a)

--- a/tests/cupy_tests/linalg_tests/test_solve.py
+++ b/tests/cupy_tests/linalg_tests/test_solve.py
@@ -22,10 +22,14 @@ class TestSolve(unittest.TestCase):
         b_cpu = numpy.random.randint(0, 10, size=b_shape).astype(dtype)
         a_gpu = cupy.asarray(a_cpu)
         b_gpu = cupy.asarray(b_cpu)
+        a_gpu_copy = a_gpu.copy()
+        b_gpu_copy = b_gpu.copy()
         result_cpu = numpy.linalg.solve(a_cpu, b_cpu)
         result_gpu = cupy.linalg.solve(a_gpu, b_gpu)
         self.assertEqual(result_cpu.dtype, result_gpu.dtype)
         cupy.testing.assert_allclose(result_cpu, result_gpu, atol=1e-3)
+        cupy.testing.assert_array_equal(a_gpu_copy, a_gpu)
+        cupy.testing.assert_array_equal(b_gpu_copy, b_gpu)
 
     def test_solve(self):
         self.check_x((4, 4), (4,))
@@ -91,10 +95,12 @@ class TestInv(unittest.TestCase):
     def check_x(self, a_shape, dtype):
         a_cpu = numpy.random.randint(0, 10, size=a_shape).astype(dtype)
         a_gpu = cupy.asarray(a_cpu)
+        a_gpu_copy = a_gpu.copy()
         result_cpu = numpy.linalg.inv(a_cpu)
         result_gpu = cupy.linalg.inv(a_gpu)
         self.assertEqual(result_cpu.dtype, result_gpu.dtype)
         cupy.testing.assert_allclose(result_cpu, result_gpu, atol=1e-3)
+        cupy.testing.assert_array_equal(a_gpu_copy, a_gpu)
 
     def check_shape(self, a_shape):
         a = cupy.random.rand(*a_shape)
@@ -123,11 +129,13 @@ class TestPinv(unittest.TestCase):
     def check_x(self, a_shape, rcond, dtype):
         a_cpu = numpy.random.randint(0, 10, size=a_shape).astype(dtype)
         a_gpu = cupy.asarray(a_cpu)
+        a_gpu_copy = a_gpu.copy()
         result_cpu = numpy.linalg.pinv(a_cpu, rcond=rcond)
         result_gpu = cupy.linalg.pinv(a_gpu, rcond=rcond)
 
         self.assertEqual(result_cpu.dtype, result_gpu.dtype)
         cupy.testing.assert_allclose(result_cpu, result_gpu, atol=1e-3)
+        cupy.testing.assert_array_equal(a_gpu_copy, a_gpu)
 
     def check_shape(self, a_shape, rcond):
         a = cupy.random.rand(*a_shape)
@@ -162,10 +170,12 @@ class TestTensorInv(unittest.TestCase):
     def check_x(self, a_shape, ind, dtype):
         a_cpu = numpy.random.randint(0, 10, size=a_shape).astype(dtype)
         a_gpu = cupy.asarray(a_cpu)
+        a_gpu_copy = a_gpu.copy()
         result_cpu = numpy.linalg.tensorinv(a_cpu, ind=ind)
         result_gpu = cupy.linalg.tensorinv(a_gpu, ind=ind)
         self.assertEqual(result_cpu.dtype, result_gpu.dtype)
         cupy.testing.assert_allclose(result_cpu, result_gpu, atol=1e-3)
+        cupy.testing.assert_array_equal(a_gpu_copy, a_gpu)
 
     def check_shape(self, a_shape, ind):
         a = cupy.random.rand(*a_shape)


### PR DESCRIPTION
I'm using CuPy 4.0.0rc1 with CUDA 9.1 on CentOS 7.4.

`cupy.linalg.inv()` breaks its argument just like #842.
I pasted a code to reproduce the problem at the bottom.

My PR has two problems:
1. The PR is time- and space-consuming because it always copies the given matrix. It might be better to introduce `overwrite_a` as in `scipy.linalg.inv()`.
2. Test is not extensive. I noticed that the problem does not reproduce for some matrices (e.g. lower-triangular matrix in row-major format).  The test should cover such a special/corner cases.

A code to reproduce the problem is as follows:
```
import numpy as np
import scipy as sp
import scipy.linalg
import cupy as cp

ndim = 10
#init_x = np.tril(np.random.random((ndim, ndim)), -1)
init_x = np.triu(np.random.random((ndim, ndim)), +1)
init_x += np.diag(np.arange(ndim)+1)
assert np.linalg.matrix_rank(init_x) == ndim

for xp in (np, sp, cp):
    for order in ('C', 'F'):
        print('{} {}, order={}'.format(xp.__name__, xp.__version__, order))
        x = xp.copy(xp.array(init_x), order=order)
        _ = xp.linalg.inv(x)
        assert (xp.array(init_x) == x).all()
```
and I got:
```
numpy 1.14.2, order=C
numpy 1.14.2, order=F
scipy 0.19.1, order=C
scipy 0.19.1, order=F
cupy 4.0.0rc1, order=C
Traceback (most recent call last):
  File "test.py", line 17, in <module>
    assert (xp.array(init_x) == x).all()
AssertionError
```