### PR TITLE
fix cupy.diag() fails for array_likes other than CuPy arrays

### DIFF
--- a/cupy/creation/matrix.py
+++ b/cupy/creation/matrix.py
@@ -25,12 +25,21 @@ def diag(v, k=0):
     if numpy.isscalar(v):
         return cupy.array(numpy.diag(v, k))
 
-    if v.ndim == 1:
+    if isinstance(v, cupy.ndarray):
+        ndim = v.ndim
+    else:
+        ndim = numpy.ndim(v)
+        # to save bandwidth, don't copy non-diag elements to GPU
+        xp = cupy if ndim == 1 else numpy
+        v = xp.array(v)
+
+    if ndim == 1:
         size = v.size + abs(k)
         ret = cupy.zeros((size, size), dtype=v.dtype)
         ret.diagonal(k)[:] = v
         return ret
     else:
+        # its okay to cupy.diag(numpy.eye(2)) returns NumPy instead of CuPy?
         return v.diagonal(k)
 
 

--- a/cupy/creation/matrix.py
+++ b/cupy/creation/matrix.py
@@ -39,8 +39,7 @@ def diag(v, k=0):
         ret.diagonal(k)[:] = v
         return ret
     else:
-        # its okay to cupy.diag(numpy.eye(2)) returns NumPy instead of CuPy?
-        return v.diagonal(k)
+        return cupy.array(v.diagonal(k))
 
 
 def diagflat(v, k=0):

--- a/tests/cupy_tests/creation_tests/test_matrix.py
+++ b/tests/cupy_tests/creation_tests/test_matrix.py
@@ -24,6 +24,41 @@ class TestMatrix(unittest.TestCase):
         return xp.diag(a, -2)
 
     @testing.numpy_cupy_array_equal()
+    def test_diag_extraction_from_nested_list(self, xp):
+        a = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+        r = xp.diag(a, 1)
+        # self.assertIsInstance(r, xp.ndarray)
+        return r
+
+    @testing.numpy_cupy_array_equal()
+    def test_diag_extraction_from_nested_tuple(self, xp):
+        a = ((1, 2, 3), (4, 5, 6), (7, 8, 9))
+        r = xp.diag(a, -1)
+        # self.assertIsInstance(r, xp.ndarray)
+        return r
+
+    @testing.numpy_cupy_array_equal()
+    def test_diag_construction(self, xp):
+        a = testing.shaped_arange((3,), xp)
+        r = xp.diag(a)
+        self.assertIsInstance(r, xp.ndarray)
+        return r
+
+    @testing.numpy_cupy_array_equal()
+    def test_diag_construction_from_list(self, xp):
+        a = [1, 2, 3]
+        r = xp.diag(a)
+        self.assertIsInstance(r, xp.ndarray)
+        return r
+
+    @testing.numpy_cupy_array_equal()
+    def test_diag_construction_from_tuple(self, xp):
+        a = (1, 2, 3)
+        r = xp.diag(a)
+        self.assertIsInstance(r, xp.ndarray)
+        return r
+
+    @testing.numpy_cupy_array_equal()
     def test_diagflat1(self, xp):
         a = testing.shaped_arange((3, 3), xp)
         return xp.diagflat(a)

--- a/tests/cupy_tests/creation_tests/test_matrix.py
+++ b/tests/cupy_tests/creation_tests/test_matrix.py
@@ -27,14 +27,14 @@ class TestMatrix(unittest.TestCase):
     def test_diag_extraction_from_nested_list(self, xp):
         a = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
         r = xp.diag(a, 1)
-        # self.assertIsInstance(r, xp.ndarray)
+        self.assertIsInstance(r, xp.ndarray)
         return r
 
     @testing.numpy_cupy_array_equal()
     def test_diag_extraction_from_nested_tuple(self, xp):
         a = ((1, 2, 3), (4, 5, 6), (7, 8, 9))
         r = xp.diag(a, -1)
-        # self.assertIsInstance(r, xp.ndarray)
+        self.assertIsInstance(r, xp.ndarray)
         return r
 
     @testing.numpy_cupy_array_equal()


### PR DESCRIPTION
By using the latest GitHub master, `cupy.diag()` fails when a list or a tuple is given.

It reproduces as follows:
```
$ python
...
>>> import cupy
>>> cupy.diag((1,2,3))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File ".../cupy/cupy/creation/matrix.py", line 28, in diag
    if v.ndim == 1:
AttributeError: 'tuple' object has no attribute 'ndim'
```