### PR TITLE
Remove nose dependency

### DIFF
--- a/tests/cupy_tests/testing_tests/test_helper.py
+++ b/tests/cupy_tests/testing_tests/test_helper.py
@@ -297,8 +297,8 @@ class TestIgnoreOfNegativeValueDifferenceOnCpuAndGpu(unittest.TestCase):
             return xp.array(-2, dtype=numpy.float32)
 
     def test_correct_failure(self):
-        numpy.testing.assert_raises_regex(
-            AssertionError, 'mismatch 100.0%', self.correct_failure)
+        with six.assertRaisesRegex(self, AssertionError, 'mismatch 100.0%'):
+            self.correct_failure()
 
     @helper.for_unsigned_dtypes('dtype1')
     @helper.for_signed_dtypes('dtype2')


### PR DESCRIPTION
I use `six.assertRaisesRegex` instead of `numpy.testing.assert_raises_regex`. `numpy.testing.assert_raises_regex` depends on nose. (Note that it's fixed in the master branch.)
https://github.com/numpy/numpy/blob/v1.14.0/numpy/testing/nose_tools/utils.py#L1194-L1223