### PR TITLE
 Handle errors in cupy.show_config()

### DIFF
--- a/cupyx/runtime.py
+++ b/cupyx/runtime.py
@@ -13,6 +13,16 @@ except ImportError:
     nccl = None
 
 
+def _eval_or_error(func, errors):
+    # Evaluates `func` and return the result.
+    # If an error specified by `errors` occured, it returns a string
+    # representing the error.
+    try:
+        return func()
+    except errors as e:
+        return repr(e)
+
+
 class _RuntimeInfo(object):
 
     cupy_version = None
@@ -29,8 +39,12 @@ class _RuntimeInfo(object):
 
         self.cuda_path = cupy.cuda.get_cuda_path()
         self.cuda_build_version = cupy.cuda.driver.get_build_version()
-        self.cuda_driver_version = cupy.cuda.runtime.driverGetVersion()
-        self.cuda_runtime_version = cupy.cuda.runtime.runtimeGetVersion()
+        self.cuda_driver_version = _eval_or_error(
+            cupy.cuda.runtime.driverGetVersion,
+            cupy.cuda.runtime.CUDARuntimeError)
+        self.cuda_runtime_version = _eval_or_error(
+            cupy.cuda.runtime.runtimeGetVersion,
+            cupy.cuda.runtime.CUDARuntimeError)
 
         if cudnn is not None:
             self.cudnn_build_version = cudnn.get_build_version()


### PR DESCRIPTION
Functions like `cupy.cuda.runtime.runtimeGetVersion()` could cause an error and `cupy.show_config()` does not handle it.

Previously:
```
>>> cupy.show_config()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/data2/work/w/repos/cupy/cupy/__init__.py", line 691, in show_config
    sys.stdout.write(str(cupyx.get_runtime_info()))
  File "/data2/work/w/repos/cupy/cupyx/runtime.py", line 63, in get_runtime_info
    return _RuntimeInfo()
  File "/data2/work/w/repos/cupy/cupyx/runtime.py", line 33, in __init__
    self.cuda_runtime_version = cupy.cuda.runtime.runtimeGetVersion()
  File "cupy/cuda/runtime.pyx", line 150, in cupy.cuda.runtime.runtimeGetVersion
    cpdef int runtimeGetVersion() except *:
  File "cupy/cuda/runtime.pyx", line 153, in cupy.cuda.runtime.runtimeGetVersion
    check_status(status)
  File "cupy/cuda/runtime.pyx", line 136, in cupy.cuda.runtime.check_status
    raise CUDARuntimeError(status)
cupy.cuda.runtime.CUDARuntimeError: cudaErrorUnknown: unknown error
```

This PR:
```
>>> cupy.show_config()
CuPy Version          : 4.0.0rc1
CUDA Root             : /usr/local/cuda
CUDA Build Version    : 9000
CUDA Driver Version   : 9010
CUDA Runtime Version  : CUDARuntimeError('cudaErrorUnknown: unknown error',)
cuDNN Build Version   : None
cuDNN Version         : None
NCCL Build Version    : 2104
```