### PR TITLE
Fix incompatibility between cupy.random.permutation and numpy.random.permutation .

### DIFF
--- a/cupy/random/permutations.py
+++ b/cupy/random/permutations.py
@@ -16,7 +16,18 @@ def shuffle(a):
 
 
 def permutation(a):
-    """Returns a permuted range or shuffles an array."""
+    """Returns a permuted range or a permutation of an array.
+
+    Args:
+        a (int or cupy.ndarray): The range or the array to be shuffled.
+
+    Returns:
+        cupy.ndarray: If `a` is an integer, it is permutation range between 0
+        and `a` - 1.
+        Otherwise, it is a permutation of `a`.
+
+    .. seealso:: :func:`numpy.random.permutation`
+    """
     rs = generator.get_random_state()
     if isinstance(a, six.integer_types):
         return rs.permutation(a)

--- a/cupy/random/permutations.py
+++ b/cupy/random/permutations.py
@@ -17,8 +17,8 @@ def shuffle(a):
 
 def permutation(a):
     """Returns a permuted range or shuffles an array."""
+    rs = generator.get_random_state()
     if isinstance(a, six.integer_types):
-        rs = generator.get_random_state()
         return rs.permutation(a)
     else:
-        return shuffle(a)
+        return a[rs.permutation(len(a))]

--- a/docs/source/reference/random.rst
+++ b/docs/source/reference/random.rst
@@ -64,3 +64,4 @@ Permutations
    :nosignatures:
 
    cupy.random.shuffle
+   cupy.random.permutation

--- a/tests/cupy_tests/random_tests/test_permutations.py
+++ b/tests/cupy_tests/random_tests/test_permutations.py
@@ -25,15 +25,17 @@ class TestPermutations(unittest.TestCase):
     def test_permutation_sort_1dim(self, dtype):
         a = cupy.arange(10, dtype=dtype)
         b = cupy.copy(a)
-        cupy.random.permutation(a)
-        testing.assert_allclose(cupy.sort(a), b)
+        c = cupy.random.permutation(a)
+        testing.assert_allclose(a, b)
+        testing.assert_allclose(b, cupy.sort(c))
 
     @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
     def test_permutation_sort_ndim(self, dtype):
         a = cupy.arange(15, dtype=dtype).reshape(5, 3)
         b = cupy.copy(a)
-        cupy.random.permutation(a)
-        testing.assert_allclose(cupy.sort(a, axis=0), b)
+        c = cupy.random.permutation(a)
+        testing.assert_allclose(a, b)
+        testing.assert_allclose(b, cupy.sort(c, axis=0))
 
     # Test seed
 
@@ -42,10 +44,10 @@ class TestPermutations(unittest.TestCase):
         a = testing.shaped_random((10,), cupy, dtype)
         b = cupy.copy(a)
         cupy.random.seed(0)
-        cupy.random.permutation(a)
+        pa = cupy.random.permutation(a)
         cupy.random.seed(0)
-        cupy.random.permutation(b)
-        testing.assert_allclose(a, b)
+        pb = cupy.random.permutation(b)
+        testing.assert_allclose(pa, pb)
 
 
 @testing.gpu

--- a/tests/cupy_tests/random_tests/test_permutations.py
+++ b/tests/cupy_tests/random_tests/test_permutations.py
@@ -12,6 +12,41 @@ class TestPermutations(unittest.TestCase):
 
     _multiprocess_can_split_ = True
 
+    # Test ranks
+
+    @testing.numpy_cupy_raises()
+    def test_permutation_zero_dim(self, xp):
+        a = testing.shaped_random((), xp)
+        xp.random.permutation(a)
+
+    # Test same values
+
+    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
+    def test_permutation_sort_1dim(self, dtype):
+        a = cupy.arange(10, dtype=dtype)
+        b = cupy.copy(a)
+        cupy.random.permutation(a)
+        testing.assert_allclose(cupy.sort(a), b)
+
+    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
+    def test_permutation_sort_ndim(self, dtype):
+        a = cupy.arange(15, dtype=dtype).reshape(5, 3)
+        b = cupy.copy(a)
+        cupy.random.permutation(a)
+        testing.assert_allclose(cupy.sort(a, axis=0), b)
+
+    # Test seed
+
+    @testing.for_all_dtypes()
+    def test_permutation_seed1(self, dtype):
+        a = testing.shaped_random((10,), cupy, dtype)
+        b = cupy.copy(a)
+        cupy.random.seed(0)
+        cupy.random.permutation(a)
+        cupy.random.seed(0)
+        cupy.random.permutation(b)
+        testing.assert_allclose(a, b)
+
 
 @testing.gpu
 class TestShuffle(unittest.TestCase):


### PR DESCRIPTION
Fixed #1137.