### PR TITLE
__cuda_array_interface__ implementation

### DIFF
--- a/cupy/core/core.pxd
+++ b/cupy/core/core.pxd
@@ -14,6 +14,7 @@ cdef class ndarray:
         readonly object dtype
         readonly memory.MemoryPointer data
         readonly ndarray base
+        readonly object _cuda_array_descr
 
     cpdef tolist(self)
     cpdef tofile(self, fid, sep=*, format=*)

--- a/cupy/core/core.pxd
+++ b/cupy/core/core.pxd
@@ -14,7 +14,6 @@ cdef class ndarray:
         readonly object dtype
         readonly memory.MemoryPointer data
         readonly ndarray base
-        readonly object _cuda_array_descr
 
     cpdef tolist(self)
     cpdef tofile(self, fid, sep=*, format=*)

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -132,6 +132,27 @@ cdef class ndarray:
         else:
             raise TypeError('order not understood. order={}'.format(order))
 
+        self._cuda_array_descr = None
+
+    @property
+    def __cuda_array_interface__(self):
+        if self._cuda_array_descr is None:
+            desc = {
+                'shape': self.shape,
+                'typestr': self.dtype.str,
+                'descr': self.dtype.descr,
+                'data': (self.data.mem.ptr, False),
+                'version': 0,
+            }
+            if not self._c_contiguous:
+                desc['strides'] = self._strides
+
+            self._cuda_array_descr = desc
+        else:
+            desc = self._cuda_array_descr
+
+        return desc
+
     # The definition order of attributes and methods are borrowed from the
     # order of documentation at the following NumPy document.
     # https://docs.scipy.org/doc/numpy/reference/arrays.ndarray.html

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -132,24 +132,17 @@ cdef class ndarray:
         else:
             raise TypeError('order not understood. order={}'.format(order))
 
-        self._cuda_array_descr = None
-
     @property
     def __cuda_array_interface__(self):
-        if self._cuda_array_descr is None:
-            desc = {
-                'shape': self.shape,
-                'typestr': self.dtype.str,
-                'descr': self.dtype.descr,
-                'data': (self.data.mem.ptr, False),
-                'version': 0,
-            }
-            if not self._c_contiguous:
-                desc['strides'] = self._strides
-
-            self._cuda_array_descr = desc
-        else:
-            desc = self._cuda_array_descr
+        desc = {
+            'shape': self.shape,
+            'typestr': self.dtype.str,
+            'descr': self.dtype.descr,
+            'data': (self.data.mem.ptr, False),
+            'version': 0,
+        }
+        if not self._c_contiguous:
+            desc['strides'] = self._strides
 
         return desc
 

--- a/tests/cupy_tests/core_tests/test_ndarray.py
+++ b/tests/cupy_tests/core_tests/test_ndarray.py
@@ -132,6 +132,38 @@ class TestNdarrayShape(unittest.TestCase):
         return xp.array(arr.shape)
 
 
+class TestNdarrayCudaInterface(unittest.TestCase):
+
+    def test_cuda_array_interface(self):
+        arr = cupy.zeros(shape=(2,3), dtype=cupy.float64)
+        iface = arr.__cuda_array_interface__
+        self.assertEqual(set(iface.keys()),
+                         set(['shape', 'typestr', 'data', 'version', 'descr']))
+        self.assertEqual(iface['shape'], (2,3))
+        self.assertEqual(iface['typestr'], '<f8')
+        self.assertIsInstance(iface['data'], tuple)
+        self.assertEqual(len(iface['data']), 2)
+        self.assertEqual(iface['data'][1], False)
+        self.assertEqual(iface['version'], 0)
+        self.assertEqual(iface['descr'], [('', '<f8')])
+
+    def test_cuda_array_interface_view(self):
+        arr = cupy.zeros(shape=(10,20), dtype=cupy.float64)
+        view = arr[::2,::5]
+        iface = view.__cuda_array_interface__
+        self.assertEqual(set(iface.keys()),
+                         set(['shape', 'typestr', 'data', 'version',
+                              'strides', 'descr']))
+        self.assertEqual(iface['shape'], (5,4))
+        self.assertEqual(iface['typestr'], '<f8')
+        self.assertIsInstance(iface['data'], tuple)
+        self.assertEqual(len(iface['data']), 2)
+        self.assertEqual(iface['data'][1], False)
+        self.assertEqual(iface['version'], 0)
+        self.assertEqual(iface['strides'], [320, 40])
+        self.assertEqual(iface['descr'], [('', '<f8')])
+
+
 @testing.parameterize(
     *testing.product({
         'indices_shape': [(2,), (2, 3)],

--- a/tests/cupy_tests/core_tests/test_ndarray.py
+++ b/tests/cupy_tests/core_tests/test_ndarray.py
@@ -135,29 +135,31 @@ class TestNdarrayShape(unittest.TestCase):
 class TestNdarrayCudaInterface(unittest.TestCase):
 
     def test_cuda_array_interface(self):
-        arr = cupy.zeros(shape=(2,3), dtype=cupy.float64)
+        arr = cupy.zeros(shape=(2, 3), dtype=cupy.float64)
         iface = arr.__cuda_array_interface__
         self.assertEqual(set(iface.keys()),
                          set(['shape', 'typestr', 'data', 'version', 'descr']))
-        self.assertEqual(iface['shape'], (2,3))
+        self.assertEqual(iface['shape'], (2, 3))
         self.assertEqual(iface['typestr'], '<f8')
         self.assertIsInstance(iface['data'], tuple)
         self.assertEqual(len(iface['data']), 2)
+        self.assertEqual(iface['data'][0], arr.data.ptr)
         self.assertEqual(iface['data'][1], False)
         self.assertEqual(iface['version'], 0)
         self.assertEqual(iface['descr'], [('', '<f8')])
 
     def test_cuda_array_interface_view(self):
-        arr = cupy.zeros(shape=(10,20), dtype=cupy.float64)
+        arr = cupy.zeros(shape=(10, 20), dtype=cupy.float64)
         view = arr[::2,::5]
         iface = view.__cuda_array_interface__
         self.assertEqual(set(iface.keys()),
                          set(['shape', 'typestr', 'data', 'version',
                               'strides', 'descr']))
-        self.assertEqual(iface['shape'], (5,4))
+        self.assertEqual(iface['shape'], (5, 4))
         self.assertEqual(iface['typestr'], '<f8')
         self.assertIsInstance(iface['data'], tuple)
         self.assertEqual(len(iface['data']), 2)
+        self.assertEqual(iface['data'][0], arr.data.ptr)
         self.assertEqual(iface['data'][1], False)
         self.assertEqual(iface['version'], 0)
         self.assertEqual(iface['strides'], [320, 40])

--- a/tests/cupy_tests/core_tests/test_ndarray.py
+++ b/tests/cupy_tests/core_tests/test_ndarray.py
@@ -150,7 +150,7 @@ class TestNdarrayCudaInterface(unittest.TestCase):
 
     def test_cuda_array_interface_view(self):
         arr = cupy.zeros(shape=(10, 20), dtype=cupy.float64)
-        view = arr[::2,::5]
+        view = arr[::2, ::5]
         iface = view.__cuda_array_interface__
         self.assertEqual(set(iface.keys()),
                          set(['shape', 'typestr', 'data', 'version',


### PR DESCRIPTION
This implements a special CUDA array interface attribute, analogous to the [`__array_interface__`](https://docs.scipy.org/doc/numpy-1.14.0/reference/arrays.interface.html#__array_interface__) attribute on NumPy arrays.  This attribute is specifically for advertising CUDA device-compatible pointers (actual device allocations, or managed memory) and associated metadata.

This allows CuPy arrays to be used with Numba-compiled CUDA functions when combined with numba/numba#2860.