### PR TITLE
[backport] fix to capture CuDNNError in cupyx.runtime

### DIFF
--- a/cupyx/runtime.py
+++ b/cupyx/runtime.py
@@ -48,7 +48,8 @@ class _RuntimeInfo(object):
 
         if cudnn is not None:
             self.cudnn_build_version = cudnn.get_build_version()
-            self.cudnn_version = cudnn.getVersion()
+            self.cudnn_version = _eval_or_error(
+                cudnn.getVersion, cudnn.CuDNNError)
 
         if nccl is not None:
             self.nccl_build_version = nccl.get_version()

--- a/tests/cupyx_tests/test_runtime.py
+++ b/tests/cupyx_tests/test_runtime.py
@@ -1,7 +1,21 @@
 import unittest
 
+import mock
+
 import cupy
 import cupyx
+
+
+try:
+    import cupy.cuda.cudnn as cudnn
+except ImportError:
+    cudnn = None
+
+
+def _get_error_func(error, *args, **kwargs):
+    def raise_error(*_args, **_kwargs):
+        raise error(*args, **kwargs)
+    return raise_error
 
 
 class TestRuntime(unittest.TestCase):
@@ -9,3 +23,28 @@ class TestRuntime(unittest.TestCase):
         runtime = cupyx.get_runtime_info()
         assert cupy.__version__ == runtime.cupy_version
         assert cupy.__version__ in str(runtime)
+
+    @unittest.skipUnless(cudnn is not None, 'cuDNN is required')
+    def test_error(self):
+        runtime = cupyx.get_runtime_info()
+        assert 'Error' not in str(runtime)
+
+        with mock.patch(
+                'cupy.cuda.runtime.driverGetVersion',
+                side_effect=_get_error_func(
+                    cupy.cuda.runtime.CUDARuntimeError, 0)):
+            runtime = cupyx.get_runtime_info()
+            assert 'CUDARuntimeError' in str(runtime)
+
+        with mock.patch(
+                'cupy.cuda.runtime.runtimeGetVersion',
+                side_effect=_get_error_func(
+                    cupy.cuda.runtime.CUDARuntimeError, 0)):
+            runtime = cupyx.get_runtime_info()
+            assert 'CUDARuntimeError' in str(runtime)
+
+        with mock.patch(
+                'cupy.cuda.cudnn.getVersion',
+                side_effect=_get_error_func(cudnn.CuDNNError, 0)):
+            runtime = cupyx.get_runtime_info()
+            assert 'CuDNNError' in str(runtime)


### PR DESCRIPTION
Backport of #1136