### PR TITLE
do not use platform-specific CC

### DIFF
--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -32,10 +32,10 @@ def _get_arch():
         major, minor = _get_nvrtc_version()
         if major < 9:
             # CUDA 7.0 / 7.5 / 8.0
-            _nvrtc_max_compute_capability = '53'
+            _nvrtc_max_compute_capability = '50'
         else:
             # CUDA 9.0 / 9.1
-            _nvrtc_max_compute_capability = '72'
+            _nvrtc_max_compute_capability = '70'
     cc = min(device.Device().compute_capability, _nvrtc_max_compute_capability)
     return 'compute_%s' % cc
 

--- a/tests/cupy_tests/cuda_tests/test_compiler.py
+++ b/tests/cupy_tests/cuda_tests/test_compiler.py
@@ -22,15 +22,15 @@ class TestNvrtcArch(unittest.TestCase):
 
     @unittest.skipUnless(cuda_version() < 9000, 'Requires CUDA 8.x or earlier')
     def test_get_arch_cuda8(self):
-        self._check_get_arch('52', 'compute_52')
-        self._check_get_arch('53', 'compute_53')
-        self._check_get_arch('54', 'compute_53')
+        self._check_get_arch('37', 'compute_37')
+        self._check_get_arch('50', 'compute_50')
+        self._check_get_arch('52', 'compute_50')
 
     @unittest.skipUnless(9000 <= cuda_version(), 'Requires CUDA 9.x or later')
     def test_get_arch_cuda9(self):
-        self._check_get_arch('71', 'compute_71')
-        self._check_get_arch('72', 'compute_72')
-        self._check_get_arch('73', 'compute_72')
+        self._check_get_arch('62', 'compute_62')
+        self._check_get_arch('70', 'compute_70')
+        self._check_get_arch('72', 'compute_70')
 
     def _compile(self, arch):
         compiler.compile_using_nvrtc('', arch=arch)


### PR DESCRIPTION
The maximum value should not be a platform-specific CC.