### PR TITLE
Fix memory leak (mempool tries to find out-of-bounds bin when freeing chunk)

### DIFF
--- a/cupy/cuda/memory.pxd
+++ b/cupy/cuda/memory.pxd
@@ -42,14 +42,26 @@ cdef class SingleDeviceMemoryPool:
 
     cdef:
         object _allocator
+
+        # Map from memory pointer of the chunk (size_t) to the corresponding
+        # Chunk object. All chunks currently allocated to the application from
+        # this pool are stored.
+        # `_in_use_lock` must be acquired to access.
         dict _in_use
+
+        # Map from stream pointer (int) to its arena (list) for the stream.
+        # `_free_lock` must be acquired to access.
         dict _free
+
         object __weakref__
         object _weakref
         object _free_lock
         object _in_use_lock
         readonly Py_ssize_t _allocation_unit_size
         readonly int _device_id
+
+        # Map from stream pointer to its arena index.
+        # `_free_lock` must be acquired to access.
         map.map[size_t, vector.vector[int]] _index
 
     cpdef MemoryPointer _alloc(self, Py_ssize_t size)

--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -612,23 +612,37 @@ cdef class SingleDeviceMemoryPool:
         self._in_use_lock = rlock.create_fastrlock()
 
     cpdef Py_ssize_t _round_size(self, Py_ssize_t size):
-        """Round up the memory size to fit memory alignment of cudaMalloc."""
+        """Rounds up the memory size to fit memory alignment of cudaMalloc."""
         unit = self._allocation_unit_size
         return ((size + unit - 1) // unit) * unit
 
     cpdef int _bin_index_from_size(self, Py_ssize_t size):
-        """Get appropriate bins index from the memory size"""
+        """Returns appropriate bins index from the memory size."""
         unit = self._allocation_unit_size
         return (size - 1) // unit
 
     cpdef list _arena(self, size_t stream_ptr):
-        """Get appropriate arena (list of bins) of a given stream"""
+        """Returns appropriate arena (list of bins) of a given stream.
+
+        All free chunks in the stream belong to one of the bin in the arena.
+
+        Caller is responsible to acquire `_free_lock`.
+        """
         if stream_ptr not in self._free:
             self._free[stream_ptr] = []
         return self._free[stream_ptr]
 
     cdef vector.vector[int]* _arena_index(self, size_t stream_ptr):
-        """Get appropriate arena sparse index of a given stream"""
+        """Returns appropriate arena sparse index of a given stream.
+
+        Each element of the returned vector is an index value of the arena
+        for the stream. The k-th element of the arena index is the bin index
+        of the arena. For example, when the arena index is `[1, 3]`, it means
+        that the arena has 2 bins, and `arena[0]` is for bin index 1 and
+        `arena[1]` is for bin index 3.
+
+        Caller is responsible to acquire `_free_lock`.
+        """
         return &self._index[stream_ptr]
 
     cpdef _append_to_free_list(self, Py_ssize_t size, chunk,
@@ -661,6 +675,14 @@ cdef class SingleDeviceMemoryPool:
 
     cpdef bint _remove_from_free_list(self, Py_ssize_t size, chunk,
                                       size_t stream_ptr) except *:
+        """Removes the chunk from the free list.
+
+        Returns:
+            bool: ``True`` if the chunk can successfully be removed from
+                the free list. ``False`` otherwise (e.g., the chunk could not
+                be found in the free list as the chunk is allocated.)
+        """
+
         cdef int index, bin_index
         cdef list arena
         cdef set free_list

--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -698,6 +698,9 @@ cdef class SingleDeviceMemoryPool:
             index = algorithm.lower_bound(
                 arena_index.begin(), arena_index.end(),
                 bin_index) - arena_index.begin()
+            if index == arena_index.size():
+                # Bin does not exist for the given chunk size.
+                return False
             if arena_index.at(index) != bin_index:
                 return False
             free_list = arena[index]


### PR DESCRIPTION
(This PR consists of two parts: bug fix and comment improvements. Please review commit-by-commit.)

Under the following circumstances, an exception is raised during freeing chunk.
As a result, it will leak memory as the chunk being freed does not go back to arena of the memory pool.

Here is a code to reproduce the issue:

```py
import cupy

def malloc(x):
    return cupy.zeros(x, dtype=cupy.int8)

def make_garbages():
    garbages = []
    for i in range(1024):  # 1024 = compaction_threshold * 2
        garbages.append(malloc(512 * (i + 1)))  # 512 = alloc_unit
    return garbages

### Comments show the contents of the arena for the null stream.
### First, fill the arena with empty bins.

# []  # length = 0
garbages = make_garbages()
del garbages
# [ [], [512], [1024], ... [512*1024] ]  # length = 1024
garbages = make_garbages()
# [ [], [], [], ..., [] ]  # length = 1024

### Then, do malloc, split and run compaction

m1 = malloc(512*2048)
del m1
# [ [], [], [], ..., [], [512*2048] ]  # length = 1025
m2 = malloc(512*1024)  #  split
# [ [], [], [], ..., [512*1024], [] ]  # length = 1025
m3 = malloc(1024)  # trigger compaction
# [ [511*1024] ]  # length = 1

### Free m3; however, bin suitable for size 1024 no longer exists.
print("-- exception --")
del m3
print("-- end --")
```

You will see this error:

```
-- exception --
Traceback (most recent call last):
  File "cupy/cuda/memory.pyx", line 544, in cupy.cuda.memory.PooledMemory.free
    pool.free(ptr, size)
  File "cupy/cuda/memory.pyx", line 816, in cupy.cuda.memory.SingleDeviceMemoryPool.free
    mem = self._alloc(size).mem
  File "cupy/cuda/memory.pyx", line 835, in cupy.cuda.memory.SingleDeviceMemoryPool.free
    self._in_use[chunk.ptr] = chunk
  File "cupy/cuda/memory.pyx", line 679, in cupy.cuda.memory.SingleDeviceMemoryPool._remove_from_free_list
    
IndexError: vector::_M_range_check: __n (which is 1) >= this->size() (which is 1)
Exception IndexError: 'vector::_M_range_check: __n (which is 1) >= this->size() (which is 1)' in 'cupy.cuda.memory.PooledMemory.__dealloc__' ignored
-- end --
Traceback (most recent call last):
  File "cupy/cuda/memory.pyx", line 544, in cupy.cuda.memory.PooledMemory.free
    pool.free(ptr, size)
  File "cupy/cuda/memory.pyx", line 816, in cupy.cuda.memory.SingleDeviceMemoryPool.free
    mem = self._alloc(size).mem
  File "cupy/cuda/memory.pyx", line 830, in cupy.cuda.memory.SingleDeviceMemoryPool.free
    chunk._init(mem, 0, size, stream_ptr)
  File "cupy/cuda/memory.pyx", line 679, in cupy.cuda.memory.SingleDeviceMemoryPool._remove_from_free_list
    
IndexError: vector::_M_range_check: __n (which is 1) >= this->size() (which is 1)
Exception IndexError: 'vector::_M_range_check: __n (which is 1) >= this->size() (which is 1)' in 'cupy.cuda.memory.PooledMemory.__dealloc__' ignored
```

This issue was originally reported by @jinjiren san on Slack. (Thanks!)
Not confirmed but I guess this issue was introduced in #912 (v4.0.0b4).