### PR TITLE
Allow more natural fusion notation

### DIFF
--- a/cupy/core/fusion.py
+++ b/cupy/core/fusion.py
@@ -49,16 +49,17 @@ _dtype_list = [numpy.dtype(_) for _ in '?bhilqBHILQefdFD']
 class Submodule(object):
     """Submodule class.
 
-    ufunc or elementwise kernel with types
+    Ufunc or elementwise kernel with types.
 
     Attributes:
-       ufunc (cupy.fusion.ufunc): The ufunc.
+       name (str): The name of submodule
        in_params (list of tuples of dtype and str):
          The tuple of dtype and name of input parameters.
        out_params (list of tuples of dtype and str):
          The tuple of dtype and name of output parameters.
-       op (str): The string of operation code.
-       type (list of dtypes): The list of types of parameters.
+       op (str): The operation code.
+       preamble (str): The preamble code.
+       type (list of dtypes): The list of types of the parameters.
     """
 
     def __init__(self, ufunc, in_params, out_params, op):
@@ -100,11 +101,11 @@ class _FusionVarCUDA(object):
 
     """_FusionVarCUDA class.
 
-    TODO
+    Local variable in CUDA program.
 
     Attributes:
-        index (int): The name of variable located in GPU.
-        ty (dtype): The type in CUDA.
+        index (int): The name of the variable.
+        ty (dtype): The type of the variable.
         const (any of types): The constant value (or None)
     """
 
@@ -142,13 +143,13 @@ class FusionOp(object):
 
     """FusionOp class.
 
-    TODO
+    Function call with arguments in CUDA program.
 
     Attributes:
-        index (int): index of this op.
-        func (submodule): submodule.
-        args (list of _FusionVarCUDA): the arguments.
-        types (list of dtype): the types of parameters.
+        index (int): The index of this operation.
+        func (submodule): The submodules called in this operation.
+        args (list of _FusionVarCUDA): The arguments.
+        types (list of dtype): The types of parameters.
     """
 
     def __init__(self, index, func, args):
@@ -182,12 +183,12 @@ class _FusionHistory(object):
 
     """_FusionHistory class.
 
-    TODO
+    History of operation exectuted in the target function of fusion.
 
     Attributes:
         op_list (list of FusionOp): The list of operations.
-        param_list (list of _FusionVarCUDA): The list of parameters
-        local_list (list of _FusionVarCUDA): The list of variables.
+        param_list (list of _FusionVarCUDA): The list of parameters.
+        local_list (list of _FusionVarCUDA): The list of local variables.
         submodules (dictionary from str to submodule): submodules.
     """
 
@@ -263,12 +264,12 @@ class FusionVarPython(object):
 
     """FusionVarPython class.
 
-    TODO
+    The values of variables in target function of fusion.
 
     Attributes:
         dtype (dtype): The data type.
-        shape (tuple of ints): !! not supported !!
     """
+    #   shape (tuple of ints): !! not supported !!
 
     def __init__(self, var, history):
         self._var = var
@@ -434,18 +435,18 @@ class FusionVarPython(object):
 
 
 class ReducedVarPython(FusionVarPython):
+    """ReducedVarPython class.
 
-    """_ReducedVarPython class
-
-    TODO
+    The value of variables after the reduction phase.
 
     Attributes:
-        dtype (dtpe): The data type.
+        dtype (dtype): The data type.
     """
+    #   shape (tuple of ints): !! not supported !!
 
 
 def _normalize_arg(arg, mem, is_postmap):
-    """TODO
+    """This converts `arg` to _FusionVarCUDA data.
 
     Args:
        arg (FusionVarPython or a primitive type)

--- a/cupy/core/fusion.py
+++ b/cupy/core/fusion.py
@@ -495,6 +495,8 @@ class _FusionHistory(object):
         nin = ufunc.nin
         nout = ufunc.nout
 
+        # Corresponds to _check_should_use_min_scalar in elementwise.pxi
+        # This function decides which typecast rule to use.
         def _should_use_min_scalar(in_args):
             max_array_kind = -2
             max_scalar_kind = -1

--- a/cupy/core/fusion.py
+++ b/cupy/core/fusion.py
@@ -175,11 +175,12 @@ class FusionVarPython(object):
 
     """The values of variables in target function of fusion.
 
+    Args:
+        var (_FusionVarCUDA)
+
     Attributes:
         dtype (dtype): The data type.
     """
-    # shape (tuple of ints): !! not supported !!
-    # _var (_FusionVarCUDA)
 
     def __init__(self, var, is_postmap):
         self._var = var

--- a/cupy/core/fusion.py
+++ b/cupy/core/fusion.py
@@ -168,13 +168,12 @@ class FusionOp(object):
     def code(self):
         args_sub = ["v{}_{}".format(self.index, i)
                     for i in six.moves.range(len(self.args))]
+        args_list = list(zip(self.args, args_sub))
         code = "// op  # {}\n".format(self.index)
-        code += ''.join("{} = v{};\n".format(s, v.index)
-                        for v, s in zip(self.args, args_sub))
+        code += ''.join("{} = v{};\n".format(s, v.index) for v, s in args_list)
         code += self.func.fcall(args_sub)
         code += ''.join("v{} = {};\n".format(v.index, s)
-                        for v, s in zip(self.args, args_sub)
-                        if v.const is None)
+                        for v, s in args_list[len(self.func.in_params):])
         return code
 
 

--- a/cupy/core/fusion.py
+++ b/cupy/core/fusion.py
@@ -468,7 +468,7 @@ class _FusionHistory(object):
         """
         arg_type = type(arg)
         if arg_type is FusionVarPython:
-            if arg._is_postmap is self.has_reduction():
+            if arg._is_postmap == self.has_reduction():
                 return arg._var
             else:
                 # Map operation between pre-map variable and post-map variable
@@ -657,7 +657,7 @@ def _get_fusion_from_types(func, in_dtypes, name):
             in_params_code, out_params_code, operation,
             preamble=submodules,
             name=name)
-        return (kernel, {})
+        return kernel, {}
     else:
         op = history.reduce_op
         _, (fixed_type,), (_, reduce_code, fix_code, reduce_ctype) = op
@@ -693,7 +693,7 @@ def _get_fusion_from_types(func, in_dtypes, name):
             name=name,
             reduce_type=reduce_ctype,
             preamble=submodules)
-        return (kernel, history.reduce_kwargs)
+        return kernel, history.reduce_kwargs
 
 
 class Fusion(object):
@@ -748,7 +748,7 @@ class Fusion(object):
                 message = 'Can\'t fuse \n {}({})'.format(self.name, types_str)
                 warnings.warn(message)
             else:
-                return (self.func, {})
+                return self.func, {}
 
     def _call(self, *args, **kwargs):
         func, kw = self.compile(*args, **kwargs)

--- a/cupy/core/fusion.py
+++ b/cupy/core/fusion.py
@@ -555,7 +555,8 @@ class _FusionHistory(object):
             ufunc.name, in_dtypes, out_dtypes))
 
     def call_elementwise(self, f, args, kwargs):
-        raise NotImplementedError()
+        raise NotImplementedError(
+            'Fusion for elementwise-kernel is not implemented yet')
 
     def call(self, f, args, kwargs):
         if type(f) is core.ufunc:
@@ -959,9 +960,11 @@ class reduction(object):
         if isinstance(arg, FusionVarPython):
             if arg._is_postmap:
                 # Multiple reduction
-                raise NotImplementedError()
+                raise NotImplementedError(
+                    'Multiple reduction is not implemented yet')
             if len(args) != 1:
-                raise Exception('Can\'t reduce a tuple')
+                mes = '{}() takes 1 positional argument but {} were given'
+                raise TypeError(mes.format(self._raw._ops.name, len(args)))
             dtype = arg.dtype
             history = _thread_local.history
             for op in self._raw._ops:

--- a/cupy/core/fusion.py
+++ b/cupy/core/fusion.py
@@ -480,18 +480,17 @@ class _FusionHistory(object):
 
         Return value: _FusionVarCUDA
         """
-        arg_type = type(arg)
-        if arg_type is FusionVarPython:
+        if isinstance(arg, FusionVarPython):
             if arg._is_postmap == self._has_reduction():
                 return arg._var
             else:
                 # Map operation between pre-map variable and post-map variable
                 raise Exception('Shape mismatch')
-        is_scalar = arg_type in six.integer_types + (float, bool, complex)
+        is_scalar = isinstance(arg, six.integer_types + (float, bool, complex))
         is_ndarray = hasattr(arg, 'dtype') and arg.dtype in _dtype_list
         if is_scalar or is_ndarray:
-            return self._fresh_local(numpy.dtype(arg_type), const=arg)
-        raise Exception('Unsupported type {}'.format(arg_type))
+            return self._fresh_local(numpy.dtype(type(arg)), const=arg)
+        raise Exception('Unsupported type {}'.format(type(type)))
 
     def call_ufunc(self, ufunc, args, kwargs):
         nin = ufunc.nin

--- a/tests/cupy_tests/core_tests/test_fusion.py
+++ b/tests/cupy_tests/core_tests/test_fusion.py
@@ -652,7 +652,6 @@ class TestFusionUfunc(unittest.TestCase):
         if args is None:
             args = ((),) * n
         self._check_reduce(func, n, reduce_f, gen, args)
-        self._check_reduce(func, n, reduce_f, gen, args)
 
     def _check_reduce(self, func, n, reduce_f, gen, args):
         @cupy.fuse()
@@ -1212,7 +1211,7 @@ class TestFusionFuse(unittest.TestCase):
 
         @cupy.fuse()
         def g(x, y, z):
-            return cupy.sum(x * y + z)
+            return xp.sum(x * y + z)
 
         return g(a, b, c)
 
@@ -1225,7 +1224,7 @@ class TestFusionFuse(unittest.TestCase):
 
         @cupy.fuse()
         def g(x, y, z):
-            return cupy.sum(x * y + z, axis=0)
+            return xp.sum(x * y + z, axis=0)
 
         return g(a, b, c)
 
@@ -1238,7 +1237,7 @@ class TestFusionFuse(unittest.TestCase):
 
         @cupy.fuse()
         def g(x, y, z):
-            return cupy.sum(x * y + z, axis=1)
+            return xp.sum(x * y + z, axis=1)
 
         return g(a, b, c)
 
@@ -1249,7 +1248,7 @@ class TestFusionFuse(unittest.TestCase):
 
         @cupy.fuse()
         def g(x):
-            return cupy.prod(x)
+            return xp.prod(x)
 
         return g(a)
 
@@ -1260,7 +1259,7 @@ class TestFusionFuse(unittest.TestCase):
 
         @cupy.fuse()
         def g(x):
-            return cupy.max(x, axis=0)
+            return xp.max(x, axis=0)
 
         return g(a)
 
@@ -1271,7 +1270,7 @@ class TestFusionFuse(unittest.TestCase):
 
         @cupy.fuse()
         def g(x):
-            return cupy.min(x, axis=0)
+            return xp.min(x, axis=0)
 
         return g(a)
 

--- a/tests/cupy_tests/core_tests/test_fusion.py
+++ b/tests/cupy_tests/core_tests/test_fusion.py
@@ -1175,6 +1175,20 @@ class TestFusionFuse(unittest.TestCase):
 
         g(a, b)
 
+    @testing.for_all_dtypes(no_bool=True)
+    @testing.numpy_cupy_array_equal()
+    def test_different_type_same_ufunc(self, xp, dtype):
+        a = xp.array([2, 2, 2, 2, 3, 3, 3, 3], dtype=dtype)
+        b = xp.array([2, 2, 3, 3, 2, 2, 3, 3], dtype=numpy.int32)
+        c = xp.array([2, 3, 2, 3, 2, 3, 2, 3], dtype=numpy.float32)
+
+        @cupy.fuse()
+        def g(x, y, z):
+            return (x + y, y + z, z + x)
+
+        s, t, u = g(a, b, c)
+        return s
+
     @unittest.skipUnless(six.PY2, 'Only for py2')
     @testing.for_int_dtypes(no_bool=True)
     @testing.numpy_cupy_array_equal()

--- a/tests/cupy_tests/core_tests/test_fusion.py
+++ b/tests/cupy_tests/core_tests/test_fusion.py
@@ -1308,9 +1308,9 @@ class TestFusionDecorator(unittest.TestCase):
 class TestFusionKernelName(unittest.TestCase):
 
     def check(self, xp, func, expected_name, is_elementwise):
-        a = xp.array([2, 3], 'f')
-        b = xp.array([2, 3], 'f')
-        c = xp.array([2, 3], 'f')
+        a = xp.arange(0, 12, dtype='d').reshape(3, 4)
+        b = xp.arange(5, 17, dtype='d').reshape(3, 4)
+        c = xp.arange(13, 25, dtype='d').reshape(3, 4)
 
         # Test kernel name (with mock)
         if xp is cupy:
@@ -1326,7 +1326,7 @@ class TestFusionKernelName(unittest.TestCase):
         # Test there's no error in computation (without mock)
         return func(a, b, c)
 
-    @testing.numpy_cupy_array_equal()
+    @testing.numpy_cupy_allclose(atol=1e-5)
     def test_elementwise(self, xp):
         def func(a, b, c):
             @cupy.fuse()
@@ -1337,7 +1337,7 @@ class TestFusionKernelName(unittest.TestCase):
 
         return self.check(xp, func, 'func_a1', True)
 
-    @testing.numpy_cupy_array_equal()
+    @testing.numpy_cupy_allclose(atol=1e-5)
     def test_elementwise_with_name(self, xp):
         def func(a, b, c):
             @cupy.fuse(kernel_name='abc')
@@ -1348,8 +1348,8 @@ class TestFusionKernelName(unittest.TestCase):
 
         return self.check(xp, func, 'abc', True)
 
-    @testing.numpy_cupy_array_equal()
-    def test_reduction(self, xp):
+    @testing.numpy_cupy_allclose(atol=1e-5)
+    def test_reduction_premap(self, xp):
         def func(a, b, c):
             @cupy.fuse()
             def func_a1(x, y, z):
@@ -1359,7 +1359,7 @@ class TestFusionKernelName(unittest.TestCase):
 
         return self.check(xp, func, 'func_a1', False)
 
-    @testing.numpy_cupy_array_equal()
+    @testing.numpy_cupy_allclose(atol=1e-5)
     def test_reduction_with_name(self, xp):
         def func(a, b, c):
             @cupy.fuse(kernel_name='abc')

--- a/tests/cupy_tests/core_tests/test_fusion.py
+++ b/tests/cupy_tests/core_tests/test_fusion.py
@@ -1360,6 +1360,28 @@ class TestFusionKernelName(unittest.TestCase):
         return self.check(xp, func, 'func_a1', False)
 
     @testing.numpy_cupy_allclose(atol=1e-5)
+    def test_reduction_postmap(self, xp):
+        def func(a, b, c):
+            @cupy.fuse()
+            def func_a1(x):
+                return cupy.sqrt(cupy.sum(x) + 10)
+
+            return func_a1(a)
+
+        return self.check(xp, func, 'func_a1', False)
+
+    @testing.numpy_cupy_allclose(atol=1e-5)
+    def test_reduction_01(self, xp):
+        def func(a, b, c):
+            @cupy.fuse()
+            def func_a1(x, y, z):
+                return cupy.sqrt(cupy.prod(x + y * z, axis=1) + 10)
+
+            return func_a1(a, b, c)
+
+        return self.check(xp, func, 'func_a1', False)
+
+    @testing.numpy_cupy_allclose(atol=1e-5)
     def test_reduction_with_name(self, xp):
         def func(a, b, c):
             @cupy.fuse(kernel_name='abc')


### PR DESCRIPTION
Improved fusion notation by allowing direct reduction.  This PR resolves #141.

### Example

```
@cupy.fuse()
def sample2(x, y):
    return cupy.sum(x + y, axis=0) * 2

for xp in (numpy, cupy):
    a = xp.array([[3, 1, 4, 1, 5], [9, 2, 6, 5, 3]], 'f')
    b = xp.array([[2, 7, 1, 8, 2], [8, 1, 8, 2, 8]], 'f')
    print(sample2(a, b))
```

```
[ 44.  22.  38.  32.  36.]
[ 44.  22.  38.  32.  36.]
```
