### PR TITLE
[WIP] Improve performance of cupyx.scipy.ndimage

### DIFF
--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
@@ -163,6 +163,23 @@ class TestAffineTransformOpenCV(unittest.TestCase):
         else:
             return cv2.warpAffine(a, matrix, (a.shape[1], a.shape[0]))
 
+    @testing.for_float_dtypes(no_float16=True)
+    @testing.numpy_cupy_allclose(atol=0.3)
+    def test_affine_transform_opencv_eye(self, xp, dtype):
+        a = testing.shaped_random((100, 100), xp, dtype)
+        matrix = testing.shaped_random((2,), xp, dtype)
+        offset = testing.shaped_random((2,), xp, dtype)
+        if xp == cupy:
+            return cupyx.scipy.ndimage.affine_transform(
+                a, matrix, offset, order=1, mode='opencv')
+        else:
+            m = numpy.zeros((2, 3))
+            m[0, 0] = matrix[0]
+            m[1, 1] = matrix[1]
+            m[0, 2] = offset[0]
+            m[1, 2] = offset[1]
+            return cv2.warpAffine(a, m, (a.shape[1], a.shape[0]))
+
 
 @testing.parameterize(*testing.product({
     'angle': [-10, 1000],


### PR DESCRIPTION
I'm working to improve the performance of `cupyx.scipy.ndimage`. The current implementation is about 2 times faster than master. Following tables are generated by https://github.com/not522/cupy-perf/tree/ndimage.

master
```
affine              :  9515.110 us   +/-419.642 us   9560.473 us   +/-420.991 us
rotate              :  6595.603 us   +/-68.038 us   6637.013 us   +/-72.040 us
zoomin              : 23640.229 us   +/-99.898 us  23947.574 us   +/-100.035 us
zoomout             :  3112.422 us   +/-44.781 us   3118.226 us   +/-44.791 us
```
This PR
```
affine              :  3153.761 us   +/-40.126 us   3202.805 us   +/-52.124 us
rotate              :  3233.512 us   +/-46.167 us   3276.836 us   +/-52.382 us
zoomin              :  9057.006 us   +/-68.345 us   9365.274 us   +/-67.907 us
zoomout             :  1975.992 us   +/-72.311 us   1982.033 us   +/-72.444 us
```