### PR TITLE
add some distribution to cupy.random

### DIFF
--- a/cupy/random/__init__.py
+++ b/cupy/random/__init__.py
@@ -18,6 +18,7 @@ from cupy.random import sample as sample_  # NOQA
 # import class and function
 from cupy.random.distributions import gumbel  # NOQA
 from cupy.random.distributions import lognormal  # NOQA
+from cupy.random.distributions import multivariate_normal  # NOQA
 from cupy.random.distributions import normal  # NOQA
 from cupy.random.distributions import standard_normal  # NOQA
 from cupy.random.distributions import uniform  # NOQA

--- a/cupy/random/__init__.py
+++ b/cupy/random/__init__.py
@@ -22,6 +22,7 @@ from cupy.random.distributions import chisquare  # NOQA
 from cupy.random.distributions import dirichlet  # NOQA
 from cupy.random.distributions import f  # NOQA
 from cupy.random.distributions import gamma  # NOQA
+from cupy.random.distributions import geometric  # NOQA
 from cupy.random.distributions import gumbel  # NOQA
 from cupy.random.distributions import laplace  # NOQA
 from cupy.random.distributions import lognormal  # NOQA

--- a/cupy/random/__init__.py
+++ b/cupy/random/__init__.py
@@ -16,6 +16,7 @@ from cupy.random import sample as sample_  # NOQA
 
 
 # import class and function
+from cupy.random.distributions import binomial  # NOQA
 from cupy.random.distributions import gumbel  # NOQA
 from cupy.random.distributions import laplace  # NOQA
 from cupy.random.distributions import lognormal  # NOQA

--- a/cupy/random/__init__.py
+++ b/cupy/random/__init__.py
@@ -28,6 +28,7 @@ from cupy.random.distributions import laplace  # NOQA
 from cupy.random.distributions import lognormal  # NOQA
 from cupy.random.distributions import multivariate_normal  # NOQA
 from cupy.random.distributions import normal  # NOQA
+from cupy.random.distributions import pareto  # NOQA
 from cupy.random.distributions import poisson  # NOQA
 from cupy.random.distributions import standard_cauchy  # NOQA
 from cupy.random.distributions import standard_exponential  # NOQA

--- a/cupy/random/__init__.py
+++ b/cupy/random/__init__.py
@@ -27,6 +27,7 @@ from cupy.random.distributions import lognormal  # NOQA
 from cupy.random.distributions import multivariate_normal  # NOQA
 from cupy.random.distributions import normal  # NOQA
 from cupy.random.distributions import standard_normal  # NOQA
+from cupy.random.distributions import standard_t  # NOQA
 from cupy.random.distributions import uniform  # NOQA
 from cupy.random.generator import get_random_state  # NOQA
 from cupy.random.generator import RandomState  # NOQA

--- a/cupy/random/__init__.py
+++ b/cupy/random/__init__.py
@@ -27,6 +27,7 @@ from cupy.random.distributions import lognormal  # NOQA
 from cupy.random.distributions import multivariate_normal  # NOQA
 from cupy.random.distributions import normal  # NOQA
 from cupy.random.distributions import poisson  # NOQA
+from cupy.random.distributions import standard_cauchy  # NOQA
 from cupy.random.distributions import standard_normal  # NOQA
 from cupy.random.distributions import standard_t  # NOQA
 from cupy.random.distributions import uniform  # NOQA

--- a/cupy/random/__init__.py
+++ b/cupy/random/__init__.py
@@ -20,6 +20,7 @@ from cupy.random.distributions import beta  # NOQA
 from cupy.random.distributions import binomial  # NOQA
 from cupy.random.distributions import chisquare  # NOQA
 from cupy.random.distributions import dirichlet  # NOQA
+from cupy.random.distributions import f  # NOQA
 from cupy.random.distributions import gamma  # NOQA
 from cupy.random.distributions import gumbel  # NOQA
 from cupy.random.distributions import laplace  # NOQA

--- a/cupy/random/__init__.py
+++ b/cupy/random/__init__.py
@@ -17,6 +17,7 @@ from cupy.random import sample as sample_  # NOQA
 
 # import class and function
 from cupy.random.distributions import gumbel  # NOQA
+from cupy.random.distributions import laplace  # NOQA
 from cupy.random.distributions import lognormal  # NOQA
 from cupy.random.distributions import multivariate_normal  # NOQA
 from cupy.random.distributions import normal  # NOQA

--- a/cupy/random/__init__.py
+++ b/cupy/random/__init__.py
@@ -19,6 +19,7 @@ from cupy.random import sample as sample_  # NOQA
 from cupy.random.distributions import beta  # NOQA
 from cupy.random.distributions import binomial  # NOQA
 from cupy.random.distributions import chisquare  # NOQA
+from cupy.random.distributions import dirichlet  # NOQA
 from cupy.random.distributions import gumbel  # NOQA
 from cupy.random.distributions import laplace  # NOQA
 from cupy.random.distributions import lognormal  # NOQA

--- a/cupy/random/__init__.py
+++ b/cupy/random/__init__.py
@@ -20,6 +20,7 @@ from cupy.random.distributions import beta  # NOQA
 from cupy.random.distributions import binomial  # NOQA
 from cupy.random.distributions import chisquare  # NOQA
 from cupy.random.distributions import dirichlet  # NOQA
+from cupy.random.distributions import gamma  # NOQA
 from cupy.random.distributions import gumbel  # NOQA
 from cupy.random.distributions import laplace  # NOQA
 from cupy.random.distributions import lognormal  # NOQA

--- a/cupy/random/__init__.py
+++ b/cupy/random/__init__.py
@@ -18,6 +18,7 @@ from cupy.random import sample as sample_  # NOQA
 # import class and function
 from cupy.random.distributions import beta  # NOQA
 from cupy.random.distributions import binomial  # NOQA
+from cupy.random.distributions import chisquare  # NOQA
 from cupy.random.distributions import gumbel  # NOQA
 from cupy.random.distributions import laplace  # NOQA
 from cupy.random.distributions import lognormal  # NOQA

--- a/cupy/random/__init__.py
+++ b/cupy/random/__init__.py
@@ -28,6 +28,7 @@ from cupy.random.distributions import multivariate_normal  # NOQA
 from cupy.random.distributions import normal  # NOQA
 from cupy.random.distributions import poisson  # NOQA
 from cupy.random.distributions import standard_cauchy  # NOQA
+from cupy.random.distributions import standard_exponential  # NOQA
 from cupy.random.distributions import standard_normal  # NOQA
 from cupy.random.distributions import standard_t  # NOQA
 from cupy.random.distributions import uniform  # NOQA

--- a/cupy/random/__init__.py
+++ b/cupy/random/__init__.py
@@ -16,6 +16,7 @@ from cupy.random import sample as sample_  # NOQA
 
 
 # import class and function
+from cupy.random.distributions import beta  # NOQA
 from cupy.random.distributions import binomial  # NOQA
 from cupy.random.distributions import gumbel  # NOQA
 from cupy.random.distributions import laplace  # NOQA

--- a/cupy/random/__init__.py
+++ b/cupy/random/__init__.py
@@ -26,6 +26,7 @@ from cupy.random.distributions import laplace  # NOQA
 from cupy.random.distributions import lognormal  # NOQA
 from cupy.random.distributions import multivariate_normal  # NOQA
 from cupy.random.distributions import normal  # NOQA
+from cupy.random.distributions import poisson  # NOQA
 from cupy.random.distributions import standard_normal  # NOQA
 from cupy.random.distributions import standard_t  # NOQA
 from cupy.random.distributions import uniform  # NOQA

--- a/cupy/random/distributions.py
+++ b/cupy/random/distributions.py
@@ -71,6 +71,36 @@ def lognormal(mean=0.0, sigma=1.0, size=None, dtype=float):
     return rs.lognormal(mean, sigma, size=size, dtype=dtype)
 
 
+def multivariate_normal(mean, cov, size=None, check_valid='warn', tol=1e-8,
+                        dtype=float):
+    """Returns an array of multivariate nomally distributed samples.
+
+    Args:
+        mean (1-D array_like, of length N): Mean of the multivariate normal
+            distribution.
+        cov (2-D array_like, of shape (N, N)): Covariance matrix of the
+            multivariate normal distribution. It must be symmetric and
+            positive-semidefinite for proper sampling.
+        size (int or tuple of ints): The shape of the array. If ``None``, a
+            zero-dimensional array is generated.
+        check_valid (‘warn’, ‘raise’, ‘ignore’): Behavior when the covariance
+            matrix is not positive semidefinite.
+        tol (float): Tolerance when checking the singular values in
+            covariance matrix.
+        dtype: Data type specifier. Only :class:`numpy.float32` and
+            :class:`numpy.float64` types are allowed.
+
+    Returns:
+        cupy.ndarray: Multivariate normally distributed samples.
+
+    .. seealso:: :func:`numpy.random.normal`
+
+    """
+    rs = generator.get_random_state()
+    x = rs.multivariate_normal(mean, cov, size, check_valid, tol, dtype)
+    return x
+
+
 def normal(loc=0.0, scale=1.0, size=None, dtype=float):
     """Returns an array of normally distributed samples.
 

--- a/cupy/random/distributions.py
+++ b/cupy/random/distributions.py
@@ -62,22 +62,23 @@ def binomial(n, p, size=None, dtype=int):
 
 
 def chisquare(df, size=None, dtype=float):
-    """Returns an array of samples drawn from a Chi-Squared distribution.
+    """Chi-square distribution.
 
-    Its probability density function is defined as
+    Returns an array of samples drawn from the chi-square distribution. Its
+    probability density function is defined as
 
     .. math::
-       f(x) = \\frac{(1/2)^{k/2}}{\\Gamma(k/2)}x^{k/2-1}\mathrm{e}^{-x/2}
+       f(x) = \\frac{(1/2)^{k/2}}{\\Gamma(k/2)}x^{k/2-1}e^{-x/2}
 
     Args:
-        df (int): Degree of freedom.
+        df (int): Degree of freedom :math:`k`.
         size (int or tuple of ints): The shape of the array. If ``None``, a
             zero-dimensional array is generated.
         dtype: Data type specifier. Only :class:`numpy.float32` and
             :class:`numpy.float64` types are allowed.
 
     Returns:
-        cupy.ndarray: Samples drawn from the Chi-Squared destribution.
+        cupy.ndarray: Samples drawn from the chi-square distribution.
 
     .. seealso::
         :func:`cupy.random.RandomState.chisquare`

--- a/cupy/random/distributions.py
+++ b/cupy/random/distributions.py
@@ -298,6 +298,26 @@ def poisson(lam=1.0, size=None, dtype=int):
     return x
 
 
+def standard_cauchy(size=None, dtype=float):
+    """Returns an array of samples drawn from the standard cauchy distribution.
+
+    Args:
+        size (int or tuple of ints): The shape of the array. If ``None``, a
+            zero-dimensional array is generated.
+        dtype: Data type specifier. Only :class:`numpy.float32` and
+            :class:`numpy.float64` types are allowed.
+
+    Returns:
+        cupy.ndarray: Samples drawn from the standard cauchy distribution.
+
+    .. seealso:: :func:`numpy.random.standard_cauchy`
+
+    """
+    rs = generator.get_random_state()
+    x = rs.standard_cauchy(size, dtype)
+    return x
+
+
 def standard_normal(size=None, dtype=float):
     """Returns an array of samples drawn from the standard normal distribution.
 

--- a/cupy/random/distributions.py
+++ b/cupy/random/distributions.py
@@ -449,14 +449,18 @@ def standard_normal(size=None, dtype=float):
 
 
 def standard_t(df, size=None, dtype=float):
-    """Returns an array of samples drawn from a standard Student's t distribution.
+    """Standard Student's t distribution.
 
-    Its probability density function is defined as
+    Returns an array of samples drawn from the standard Student's t
+    distribution. Its probability density function is defined as
 
     .. math::
+        f(x) = \\frac{\\Gamma(\\frac{\\nu+1}{2})} \
+            {\\sqrt{\\nu\\pi}\\Gamma(\\frac{\\nu}{2})} \
+            \\left(1 + \\frac{x^2}{\\nu} \\right)^{-(\\frac{\\nu+1}{2})}
 
     Args:
-        df (float):
+        df (float): Degree of freedom :math:`\\nu`.
         size (int or tuple of ints): The shape of the array. If ``None``, a
             zero-dimensional array is generated.
         dtype: Data type specifier. Only :class:`numpy.float32` and

--- a/cupy/random/distributions.py
+++ b/cupy/random/distributions.py
@@ -393,7 +393,13 @@ def poisson(lam=1.0, size=None, dtype=int):
 
 
 def standard_cauchy(size=None, dtype=float):
-    """Returns an array of samples drawn from the standard cauchy distribution.
+    """Standard cauchy distribution.
+
+    Returns an array of samples drawn from the standard cauchy distribution.
+    Its probability density function is defined as
+
+      .. math::
+         f(x) = \\frac{1}{\\pi(1+x^2)},
 
     Args:
         size (int or tuple of ints): The shape of the array. If ``None``, a

--- a/cupy/random/distributions.py
+++ b/cupy/random/distributions.py
@@ -216,27 +216,24 @@ def gumbel(loc=0.0, scale=1.0, size=None, dtype=float):
 
 
 def laplace(loc=0.0, scale=1.0, size=None, dtype=float):
-    """Returns an array of samples drawn from a Laplace distribution.
+    """Laplace distribution.
 
-    The samples are drawn from a Laplace distribution with location ``loc``
-    and scale ``scale``.
-    Its probability density function is defined as
+    Returns an array of samples drawn from the laplace distribution. Its
+    probability density function is defined as
 
     .. math::
        f(x) = \\frac{1}{2b}\\exp\\left(-\\frac{|x-\\mu|}{b}\\right),
 
-    where :math:`\\mu` is ``loc`` and :math:`\\b` is ``scale``.
-
     Args:
         loc (float): The location of the mode :math:`\\mu`.
-        scale (float): The scale parameter :math:`\\eta`.
+        scale (float): The scale parameter :math:`b`.
         size (int or tuple of ints): The shape of the array. If ``None``, a
             zero-dimensional array is generated.
         dtype: Data type specifier. Only :class:`numpy.float32` and
             :class:`numpy.float64` types are allowed.
 
     Returns:
-        cupy.ndarray: Samples drawn from the Laplace destribution.
+        cupy.ndarray: Samples drawn from the laplace destribution.
 
     .. seealso::
         :func:`cupy.random.RandomState.laplace`

--- a/cupy/random/distributions.py
+++ b/cupy/random/distributions.py
@@ -355,17 +355,23 @@ def normal(loc=0.0, scale=1.0, size=None, dtype=float):
 
 
 def pareto(a, size=None, dtype=float):
-    """Returns an array of samples drawn from a pareto distribution.
+    """Pareto II or Lomax distribution.
+
+    Returns an array of samples drawn from the pareto II distribution. Its
+    probability density function is defined as
+
+    .. math::
+        f(x) = \\alpha(1+x)^{-(\\alpha+1)},
 
     Args:
-        a (float):
+        a (float): Parameter of the gamma distribution :math:`\\alpha`.
         size (int or tuple of ints): The shape of the array. If ``None``, a
             zero-dimensional array is generated.
         dtype: Data type specifier. Only :class:`numpy.float32` and
             :class:`numpy.float64` types are allowed.
 
     Returns:
-        cupy.ndarray: Samples drawn from the pareto distribution.
+        cupy.ndarray: Samples drawn from the pareto II distribution.
 
     .. seealso:: :func:`numpy.random.pareto`
 

--- a/cupy/random/distributions.py
+++ b/cupy/random/distributions.py
@@ -12,7 +12,7 @@ def beta(a, b, size=None, dtype=float):
     probability density function is defined as
 
     .. math::
-       f(x) = \\frac{x^{\\alpha-1}(1-x)^{\\beta-1}}{B(\\alpha,\\beta)}
+       f(x) = \\frac{x^{\\alpha-1}(1-x)^{\\beta-1}}{B(\\alpha,\\beta)},
 
     Args:
         a (float): Parameter of the beta distribution :math:`\\alpha`.
@@ -40,7 +40,7 @@ def binomial(n, p, size=None, dtype=int):
     probability mass function is defined as
 
     .. math::
-        f(x) = \\binom{n}{x}p^x(1-p)^{n-x}
+        f(x) = \\binom{n}{x}p^x(1-p)^{n-x},
 
     Args:
         n (int): Trial number of the binomial distribution.
@@ -68,7 +68,7 @@ def chisquare(df, size=None, dtype=float):
     probability density function is defined as
 
     .. math::
-       f(x) = \\frac{(1/2)^{k/2}}{\\Gamma(k/2)}x^{k/2-1}e^{-x/2}
+       f(x) = \\frac{(1/2)^{k/2}}{\\Gamma(k/2)}x^{k/2-1}e^{-x/2},
 
     Args:
         df (int): Degree of freedom :math:`k`.
@@ -97,7 +97,7 @@ def dirichlet(alpha, size=None, dtype=float):
     .. math::
         f(x) = \\frac{\\Gamma(\\sum_{i=1}^K\\alpha_i)} \
             {\\prod_{i=1}^{K}\\Gamma(\\alpha_i)} \
-            \\prod_{i=1}^Kx_i^{\\alpha_i-1}
+            \\prod_{i=1}^Kx_i^{\\alpha_i-1},
 
     Args:
         alpha (array): Parameters of the dirichlet distribution
@@ -149,7 +149,7 @@ def gamma(shape, scale=1.0, size=None, dtype=float):
     probability density function is defined as
 
     .. math::
-       f(x) = \\frac{1}{\\Gamma(k)\\theta^k}x^{k-1}e^{-x/\\theta}
+       f(x) = \\frac{1}{\\Gamma(k)\\theta^k}x^{k-1}e^{-x/\\theta},
 
     Args:
         shape (float): Parameter of the gamma distribution :math:`k`.
@@ -366,14 +366,20 @@ def pareto(a, size=None, dtype=float):
 
 
 def poisson(lam=1.0, size=None, dtype=int):
-    """Returns an array of samples drawn from a poisson distribution.
+    """Poisson distribution.
+
+    Returns an array of samples drawn from the poisson distribution. Its
+    probability mass function is defined as
+
+    .. math::
+        f(x) = \\frac{\\lambda^xe^{-\\lambda}}{k!},
 
     Args:
-        lam (float):
+        lam (float): Parameter of the poisson distribution :math:`\\lambda`.
         size (int or tuple of ints): The shape of the array. If ``None``, a
             zero-dimensional array is generated.
-        dtype: Data type specifier. Only :class:`numpy.float32` and
-            :class:`numpy.float64` types are allowed.
+        dtype: Data type specifier. Only :class:`numpy.int32` and
+            :class:`numpy.int64` types are allowed.
 
     Returns:
         cupy.ndarray: Samples drawn from the poisson distribution.
@@ -457,7 +463,7 @@ def standard_t(df, size=None, dtype=float):
     .. math::
         f(x) = \\frac{\\Gamma(\\frac{\\nu+1}{2})} \
             {\\sqrt{\\nu\\pi}\\Gamma(\\frac{\\nu}{2})} \
-            \\left(1 + \\frac{x^2}{\\nu} \\right)^{-(\\frac{\\nu+1}{2})}
+            \\left(1 + \\frac{x^2}{\\nu} \\right)^{-(\\frac{\\nu+1}{2})},
 
     Args:
         df (float): Degree of freedom :math:`\\nu`.

--- a/cupy/random/distributions.py
+++ b/cupy/random/distributions.py
@@ -81,29 +81,52 @@ def chisquare(df, size=None, dtype=float):
 
 
 def dirichlet(alpha, size=None, dtype=float):
-    """Returns an array of samples drawn from a Chi-Squared distribution.
+    """Returns an array of samples drawn from a Dirichlet distribution.
 
     Its probability density function is defined as
 
     .. math::
-       f(x) = \\frac{(1/2)^{k/2}}{\\Gamma(k/2)}x^{k/2-1}\mathrm{e}^{-x/2}
 
     Args:
-        df (int): Degree of freedom.
+        alpha (int):
         size (int or tuple of ints): The shape of the array. If ``None``, a
             zero-dimensional array is generated.
         dtype: Data type specifier. Only :class:`numpy.float32` and
             :class:`numpy.float64` types are allowed.
 
     Returns:
-        cupy.ndarray: Samples drawn from the Chi-Squared destribution.
+        cupy.ndarray: Samples drawn from the Dirichret destribution.
 
     .. seealso::
-        :func:`cupy.random.RandomState.chisquare`
-        :func:`numpy.random.chisquare`
+        :func:`cupy.random.RandomState.dirichlet`
+        :func:`numpy.random.dirichlet`
     """
     rs = generator.get_random_state()
     return rs.dirichlet(alpha, size, dtype)
+
+
+def f(dfnum, dfden, size=None, dtype=float):
+    """Returns an array of samples drawn from the F distribution.
+
+    Its probability density function is defined as
+
+    .. math::
+
+    Args:
+        size (int or tuple of ints): The shape of the array. If ``None``, a
+            zero-dimensional array is generated.
+        dtype: Data type specifier. Only :class:`numpy.float32` and
+            :class:`numpy.float64` types are allowed.
+
+    Returns:
+        cupy.ndarray: Samples drawn from the F destribution.
+
+    .. seealso::
+        :func:`cupy.random.RandomState.f`
+        :func:`numpy.random.f`
+    """
+    rs = generator.get_random_state()
+    return rs.f(dfnum, dfden, size, dtype)
 
 
 def gamma(shape, scale=1.0, size=None, dtype=float):

--- a/cupy/random/distributions.py
+++ b/cupy/random/distributions.py
@@ -106,6 +106,33 @@ def dirichlet(alpha, size=None, dtype=float):
     return rs.dirichlet(alpha, size, dtype)
 
 
+def gamma(shape, scale=1.0, size=None, dtype=float):
+    """Returns an array of samples drawn from a Gamma distribution.
+
+    Its probability density function is defined as
+
+    .. math::
+       f(x) = \\frac{1}{\\Gamma(k)\\theta^k}x^{k-1}\\mathrm{e}^{-x/\\theta}
+
+    Args:
+        shape (float):
+        scale (float):
+        size (int or tuple of ints): The shape of the array. If ``None``, a
+            zero-dimensional array is generated.
+        dtype: Data type specifier. Only :class:`numpy.float32` and
+            :class:`numpy.float64` types are allowed.
+
+    Returns:
+        cupy.ndarray: Samples drawn from the Chi-Squared destribution.
+
+    .. seealso::
+        :func:`cupy.random.RandomState.chisquare`
+        :func:`numpy.random.chisquare`
+    """
+    rs = generator.get_random_state()
+    return rs.gamma(shape, scale, size, dtype)
+
+
 def gumbel(loc=0.0, scale=1.0, size=None, dtype=float):
     """Returns an array of samples drawn from a Gumbel distribution.
 

--- a/cupy/random/distributions.py
+++ b/cupy/random/distributions.py
@@ -296,6 +296,31 @@ def standard_normal(size=None, dtype=float):
     return normal(size=size, dtype=dtype)
 
 
+def standard_t(df, size=None, dtype=float):
+    """Returns an array of samples drawn from a standard Student's t distribution.
+
+    Its probability density function is defined as
+
+    .. math::
+
+    Args:
+        df (float):
+        size (int or tuple of ints): The shape of the array. If ``None``, a
+            zero-dimensional array is generated.
+        dtype: Data type specifier. Only :class:`numpy.float32` and
+            :class:`numpy.float64` types are allowed.
+
+    Returns:
+        cupy.ndarray: Samples drawn from the standard Student's t destribution.
+
+    .. seealso::
+        :func:`cupy.random.RandomState.standard_t`
+        :func:`numpy.random.standard_t`
+    """
+    rs = generator.get_random_state()
+    return rs.standard_t(df, size, dtype)
+
+
 def uniform(low=0.0, high=1.0, size=None, dtype=float):
     """Returns an array of uniformly-distributed samples over an interval.
 

--- a/cupy/random/distributions.py
+++ b/cupy/random/distributions.py
@@ -388,7 +388,9 @@ def standard_cauchy(size=None, dtype=float):
 
 
 def standard_exponential(size=None, dtype=float):
-    """Returns an array of samples drawn from the standard exponential
+    """Standard Exponential
+
+    Returns an array of samples drawn from the standard exponential
     distribution.
 
     Args:

--- a/cupy/random/distributions.py
+++ b/cupy/random/distributions.py
@@ -6,12 +6,13 @@ from cupy.random import generator
 
 
 def beta(a, b, size=None, dtype=float):
-    """Returns an array of samples drawn from a Beta distribution.
+    """Beta distribution.
 
-    Its probability density function is defined as
+    Returns an array of samples drawn from the beta distribution. Its
+    probability density function is defined as
 
     .. math::
-       f(x) = \\frac{x^{\\alpha-1}(1-x)§{\\beta-1}}{B(\\alpha,\\beta)}
+       f(x) = \\frac{x^{\\alpha-1}(1-x)^{\\beta-1}}{B(\\alpha,\\beta)}
 
     Args:
         a (float): Parameter of the beta distribution :math:`\\alpha`.
@@ -22,7 +23,7 @@ def beta(a, b, size=None, dtype=float):
             :class:`numpy.float64` types are allowed.
 
     Returns:
-        cupy.ndarray: Samples drawn from the Beta destribution.
+        cupy.ndarray: Samples drawn from the beta destribution.
 
     .. seealso::
         :func:`cupy.random.RandomState.beta`
@@ -39,7 +40,7 @@ def binomial(n, p, size=None, dtype=int):
     probability mass function is defined as
 
     .. math::
-     f(x) = \\binom{n}{x}p^x(1-p)^{n-x}
+        f(x) = \\binom{n}{x}p^x(1-p)^{n-x}
 
     Args:
         n (int): Trial number of the binomial distribution.

--- a/cupy/random/distributions.py
+++ b/cupy/random/distributions.py
@@ -179,21 +179,23 @@ def gamma(shape, scale=1.0, size=None, dtype=float):
 
 
 def geometric(p, size=None, dtype=int):
-    """Returns an array of samples drawn from a Geometric distribution.
+    """Geometric distribution.
 
-    Its probability mass function is defined as
+    Returns an array of samples drawn from the geometric distribution. Its
+    probability mass function is defined as
 
     .. math::
+        f(x) = p(1-p)^{k-1},
 
     Args:
-        p (float):
+        p (float): Success probability of the geometric distribution.
         size (int or tuple of ints): The shape of the array. If ``None``, a
             zero-dimensional array is generated.
-        dtype: Data type specifier. Only :class:`numpy.float32` and
-            :class:`numpy.float64` types are allowed.
+        dtype: Data type specifier. Only :class:`numpy.int32` and
+            :class:`numpy.int64` types are allowed.
 
     Returns:
-        cupy.ndarray: Samples drawn from the Geometric destribution.
+        cupy.ndarray: Samples drawn from the geometric distribution.
 
     .. seealso::
         :func:`cupy.random.RandomState.geometric`

--- a/cupy/random/distributions.py
+++ b/cupy/random/distributions.py
@@ -325,6 +325,27 @@ def normal(loc=0.0, scale=1.0, size=None, dtype=float):
     return x
 
 
+def pareto(a, size=None, dtype=float):
+    """Returns an array of samples drawn from a pareto distribution.
+
+    Args:
+        a (float):
+        size (int or tuple of ints): The shape of the array. If ``None``, a
+            zero-dimensional array is generated.
+        dtype: Data type specifier. Only :class:`numpy.float32` and
+            :class:`numpy.float64` types are allowed.
+
+    Returns:
+        cupy.ndarray: Samples drawn from the pareto distribution.
+
+    .. seealso:: :func:`numpy.random.pareto`
+
+    """
+    rs = generator.get_random_state()
+    x = rs.pareto(a, size, dtype)
+    return x
+
+
 def poisson(lam=1.0, size=None, dtype=int):
     """Returns an array of samples drawn from a poisson distribution.
 

--- a/cupy/random/distributions.py
+++ b/cupy/random/distributions.py
@@ -272,14 +272,22 @@ def lognormal(mean=0.0, sigma=1.0, size=None, dtype=float):
 
 def multivariate_normal(mean, cov, size=None, check_valid='warn', tol=1e-8,
                         dtype=float):
-    """Returns an array of multivariate nomally distributed samples.
+    """Multivariate normal distribution.
+
+    Returns an array of samples drawn from the multivariate normal
+    distribution. Its probability density function is defined as
+
+    .. math::
+       f(x) = \\frac{1}{(2\\pi|\\Sigma|)^(n/2)} \
+           \\exp\\left(-\\frac{1}{2} \
+           (x-\\mu)^{\\top}\\Sigma^{-1}(x-\\mu)\\right),
 
     Args:
         mean (1-D array_like, of length N): Mean of the multivariate normal
-            distribution.
+            distribution :math:`\\mu`.
         cov (2-D array_like, of shape (N, N)): Covariance matrix of the
             multivariate normal distribution. It must be symmetric and
-            positive-semidefinite for proper sampling.
+            positive-semidefinite for proper sampling :math:`\\Sigma`.
         size (int or tuple of ints): The shape of the array. If ``None``, a
             zero-dimensional array is generated.
         check_valid (‘warn’, ‘raise’, ‘ignore’): Behavior when the covariance
@@ -290,9 +298,9 @@ def multivariate_normal(mean, cov, size=None, check_valid='warn', tol=1e-8,
             :class:`numpy.float64` types are allowed.
 
     Returns:
-        cupy.ndarray: Multivariate normally distributed samples.
+        cupy.ndarray: Samples drawn from the multivariate normal distribution.
 
-    .. seealso:: :func:`numpy.random.normal`
+    .. seealso:: :func:`numpy.random.multivariate_normal`
 
     """
     rs = generator.get_random_state()

--- a/cupy/random/distributions.py
+++ b/cupy/random/distributions.py
@@ -318,6 +318,27 @@ def standard_cauchy(size=None, dtype=float):
     return x
 
 
+def standard_exponential(size=None, dtype=float):
+    """Returns an array of samples drawn from the standard exponential
+    distribution.
+
+    Args:
+        size (int or tuple of ints): The shape of the array. If ``None``, a
+            zero-dimensional array is generated.
+        dtype: Data type specifier. Only :class:`numpy.float32` and
+            :class:`numpy.float64` types are allowed.
+
+    Returns:
+        cupy.ndarray: Samples drawn from the standard exponential distribution.
+
+    .. seealso:: :func:`numpy.random.standard_exponential`
+
+    """
+    rs = generator.get_random_state()
+    x = rs.standard_exponential(size, dtype)
+    return x
+
+
 def standard_normal(size=None, dtype=float):
     """Returns an array of samples drawn from the standard normal distribution.
 

--- a/cupy/random/distributions.py
+++ b/cupy/random/distributions.py
@@ -12,11 +12,27 @@ _gumbel_kernel = core.ElementwiseKernel(
     'gumbel_kernel'
 )
 
-_laplace_kernel = core.ElementwiseKernel(
-    'T x, T loc, T scale', 'T y',
-    'y = (x < 0.5)? loc + scale * log(x + x): loc - scale * log(2.0 - x - x)',
-    'laplace_kernel'
-)
+
+def binomial(n, p, size=None, dtype=float):
+    """Returns an array of samples drawn from a Binomial distribution.
+
+    Args:
+        n (int): Trial number of the binomial distribution.
+        p (float): Success probability of the binomial distribution.
+        size (int or tuple of ints): The shape of the array. If ``None``, a
+            zero-dimensional array is generated.
+        dtype: Data type specifier. Only :class:`numpy.float32` and
+            :class:`numpy.float64` types are allowed.
+
+    Returns:
+        cupy.ndarray: Samples drawn from the Binomial destribution.
+
+    .. seealso::
+        :func:`cupy.random.RandomState.binomial`
+        :func:`numpy.random.binomial`
+    """
+    rs = generator.get_random_state()
+    return rs.binomial(n, p, size, dtype)
 
 
 def gumbel(loc=0.0, scale=1.0, size=None, dtype=float):

--- a/cupy/random/distributions.py
+++ b/cupy/random/distributions.py
@@ -119,20 +119,28 @@ def dirichlet(alpha, size=None, dtype=float):
 
 
 def f(dfnum, dfden, size=None, dtype=float):
-    """Returns an array of samples drawn from the F distribution.
+    """F distribution.
 
-    Its probability density function is defined as
+    Returns an array of samples drawn from the f distribution. Its probability
+    density function is defined as
 
     .. math::
+        f(x) = \\frac{1}{B(\\frac{d_1}{2},\\frac{d_2}{2})} \
+            \\left(\\frac{d_1}{d_2}\\right)^{\\frac{d_1}{2}} \
+            x^{\\frac{d_1}{2}-1} \
+            \\left(1+\\frac{d_1}{d_2}x\\right) \
+            ^{-\\frac{d_1+d_2}{2}},
 
     Args:
+        dfnum (float): Parameter of the f distribution :math:`d_1`.
+        dfden (float): Parameter of the f distribution :math:`d_2`.
         size (int or tuple of ints): The shape of the array. If ``None``, a
             zero-dimensional array is generated.
         dtype: Data type specifier. Only :class:`numpy.float32` and
             :class:`numpy.float64` types are allowed.
 
     Returns:
-        cupy.ndarray: Samples drawn from the F destribution.
+        cupy.ndarray: Samples drawn from the f destribution.
 
     .. seealso::
         :func:`cupy.random.RandomState.f`

--- a/cupy/random/distributions.py
+++ b/cupy/random/distributions.py
@@ -89,21 +89,26 @@ def chisquare(df, size=None, dtype=float):
 
 
 def dirichlet(alpha, size=None, dtype=float):
-    """Returns an array of samples drawn from a Dirichlet distribution.
+    """Dirichlet distribution.
 
-    Its probability density function is defined as
+    Returns an array of samples drawn from the dirichlet distribution. Its
+    probability density function is defined as
 
     .. math::
+        f(x) = \\frac{\\Gamma(\\sum_{i=1}^K\\alpha_i)} \
+            {\\prod_{i=1}^{K}\\Gamma(\\alpha_i)} \
+            \\prod_{i=1}^Kx_i^{\\alpha_i-1}
 
     Args:
-        alpha (int):
+        alpha (array): Parameters of the dirichlet distribution
+        :math:`\\alpha`.
         size (int or tuple of ints): The shape of the array. If ``None``, a
             zero-dimensional array is generated.
         dtype: Data type specifier. Only :class:`numpy.float32` and
             :class:`numpy.float64` types are allowed.
 
     Returns:
-        cupy.ndarray: Samples drawn from the Dirichret destribution.
+        cupy.ndarray: Samples drawn from the dirichret destribution.
 
     .. seealso::
         :func:`cupy.random.RandomState.dirichlet`

--- a/cupy/random/distributions.py
+++ b/cupy/random/distributions.py
@@ -80,6 +80,32 @@ def chisquare(df, size=None, dtype=float):
     return rs.chisquare(df, size, dtype)
 
 
+def dirichlet(alpha, size=None, dtype=float):
+    """Returns an array of samples drawn from a Chi-Squared distribution.
+
+    Its probability density function is defined as
+
+    .. math::
+       f(x) = \\frac{(1/2)^{k/2}}{\\Gamma(k/2)}x^{k/2-1}\mathrm{e}^{-x/2}
+
+    Args:
+        df (int): Degree of freedom.
+        size (int or tuple of ints): The shape of the array. If ``None``, a
+            zero-dimensional array is generated.
+        dtype: Data type specifier. Only :class:`numpy.float32` and
+            :class:`numpy.float64` types are allowed.
+
+    Returns:
+        cupy.ndarray: Samples drawn from the Chi-Squared destribution.
+
+    .. seealso::
+        :func:`cupy.random.RandomState.chisquare`
+        :func:`numpy.random.chisquare`
+    """
+    rs = generator.get_random_state()
+    return rs.dirichlet(alpha, size, dtype)
+
+
 def gumbel(loc=0.0, scale=1.0, size=None, dtype=float):
     """Returns an array of samples drawn from a Gumbel distribution.
 

--- a/cupy/random/distributions.py
+++ b/cupy/random/distributions.py
@@ -12,6 +12,12 @@ _gumbel_kernel = core.ElementwiseKernel(
     'gumbel_kernel'
 )
 
+_laplace_kernel = core.ElementwiseKernel(
+    'T x, T loc, T scale', 'T y',
+    'y = (x < 0.5)? loc + scale * log(x + x): loc - scale * log(2.0 - x - x)',
+    'laplace_kernel'
+)
+
 
 def gumbel(loc=0.0, scale=1.0, size=None, dtype=float):
     """Returns an array of samples drawn from a Gumbel distribution.
@@ -45,6 +51,37 @@ def gumbel(loc=0.0, scale=1.0, size=None, dtype=float):
     """
     rs = generator.get_random_state()
     return rs.gumbel(loc, scale, size, dtype)
+
+
+def laplace(loc=0.0, scale=1.0, size=None, dtype=float):
+    """Returns an array of samples drawn from a Laplace distribution.
+
+    The samples are drawn from a Laplace distribution with location ``loc``
+    and scale ``scale``.
+    Its probability density function is defined as
+
+    .. math::
+       f(x) = \\frac{1}{2b}\\exp\\left(-\\frac{|x-\\mu|}{b}\\right),
+
+    where :math:`\\mu` is ``loc`` and :math:`\\b` is ``scale``.
+
+    Args:
+        loc (float): The location of the mode :math:`\\mu`.
+        scale (float): The scale parameter :math:`\\eta`.
+        size (int or tuple of ints): The shape of the array. If ``None``, a
+            zero-dimensional array is generated.
+        dtype: Data type specifier. Only :class:`numpy.float32` and
+            :class:`numpy.float64` types are allowed.
+
+    Returns:
+        cupy.ndarray: Samples drawn from the Laplace destribution.
+
+    .. seealso::
+        :func:`cupy.random.RandomState.laplace`
+        :func:`numpy.random.laplace`
+    """
+    rs = generator.get_random_state()
+    return rs.laplace(loc, scale, size, dtype)
 
 
 def lognormal(mean=0.0, sigma=1.0, size=None, dtype=float):

--- a/cupy/random/distributions.py
+++ b/cupy/random/distributions.py
@@ -1,16 +1,35 @@
 import cupy
-from cupy import core
 from cupy.random import generator
 
 
 # TODO(beam2d): Implement many distributions
 
 
-_gumbel_kernel = core.ElementwiseKernel(
-    'T x, T loc, T scale', 'T y',
-    'y = loc - log(-log(1 - x)) * scale',
-    'gumbel_kernel'
-)
+def beta(a, b, size=None, dtype=float):
+    """Returns an array of samples drawn from a Beta distribution.
+
+    Its probability density function is defined as
+
+    .. math::
+       f(x) = \\frac{x^{\\alpha-1}(1-x)§{\\beta-1}}{B(\\alpha,\\beta)}
+
+    Args:
+        a (float): Parameter of the beta distribution :math:`\\alpha`.
+        b (float): Parameter of the beta distribution :math:`\\beta`.
+        size (int or tuple of ints): The shape of the array. If ``None``, a
+            zero-dimensional array is generated.
+        dtype: Data type specifier. Only :class:`numpy.float32` and
+            :class:`numpy.float64` types are allowed.
+
+    Returns:
+        cupy.ndarray: Samples drawn from the Beta destribution.
+
+    .. seealso::
+        :func:`cupy.random.RandomState.beta`
+        :func:`numpy.random.beta`
+    """
+    rs = generator.get_random_state()
+    return rs.beta(a, b, size, dtype)
 
 
 def binomial(n, p, size=None, dtype=float):

--- a/cupy/random/distributions.py
+++ b/cupy/random/distributions.py
@@ -146,14 +146,39 @@ def gamma(shape, scale=1.0, size=None, dtype=float):
             :class:`numpy.float64` types are allowed.
 
     Returns:
-        cupy.ndarray: Samples drawn from the Chi-Squared destribution.
+        cupy.ndarray: Samples drawn from the Gamma destribution.
 
     .. seealso::
-        :func:`cupy.random.RandomState.chisquare`
-        :func:`numpy.random.chisquare`
+        :func:`cupy.random.RandomState.gamma`
+        :func:`numpy.random.gamma`
     """
     rs = generator.get_random_state()
     return rs.gamma(shape, scale, size, dtype)
+
+
+def geometric(p, size=None, dtype=int):
+    """Returns an array of samples drawn from a Geometric distribution.
+
+    Its probability mass function is defined as
+
+    .. math::
+
+    Args:
+        p (float):
+        size (int or tuple of ints): The shape of the array. If ``None``, a
+            zero-dimensional array is generated.
+        dtype: Data type specifier. Only :class:`numpy.float32` and
+            :class:`numpy.float64` types are allowed.
+
+    Returns:
+        cupy.ndarray: Samples drawn from the Geometric destribution.
+
+    .. seealso::
+        :func:`cupy.random.RandomState.geometric`
+        :func:`numpy.random.geometric`
+    """
+    rs = generator.get_random_state()
+    return rs.geometric(p, size, dtype)
 
 
 def gumbel(loc=0.0, scale=1.0, size=None, dtype=float):

--- a/cupy/random/distributions.py
+++ b/cupy/random/distributions.py
@@ -143,23 +143,24 @@ def f(dfnum, dfden, size=None, dtype=float):
 
 
 def gamma(shape, scale=1.0, size=None, dtype=float):
-    """Returns an array of samples drawn from a Gamma distribution.
+    """Gamma distribution.
 
-    Its probability density function is defined as
+    Returns an array of samples drawn from the gamma distribution. Its
+    probability density function is defined as
 
     .. math::
-       f(x) = \\frac{1}{\\Gamma(k)\\theta^k}x^{k-1}\\mathrm{e}^{-x/\\theta}
+       f(x) = \\frac{1}{\\Gamma(k)\\theta^k}x^{k-1}e^{-x/\\theta}
 
     Args:
-        shape (float):
-        scale (float):
+        shape (float): Parameter of the gamma distribution :math:`k`.
+        scale (float): Parameter of the gamma distribution :math:`\\theta`
         size (int or tuple of ints): The shape of the array. If ``None``, a
             zero-dimensional array is generated.
         dtype: Data type specifier. Only :class:`numpy.float32` and
             :class:`numpy.float64` types are allowed.
 
     Returns:
-        cupy.ndarray: Samples drawn from the Gamma destribution.
+        cupy.ndarray: Samples drawn from the gamma destribution.
 
     .. seealso::
         :func:`cupy.random.RandomState.gamma`

--- a/cupy/random/distributions.py
+++ b/cupy/random/distributions.py
@@ -277,6 +277,27 @@ def normal(loc=0.0, scale=1.0, size=None, dtype=float):
     return x
 
 
+def poisson(lam=1.0, size=None, dtype=int):
+    """Returns an array of samples drawn from a poisson distribution.
+
+    Args:
+        lam (float):
+        size (int or tuple of ints): The shape of the array. If ``None``, a
+            zero-dimensional array is generated.
+        dtype: Data type specifier. Only :class:`numpy.float32` and
+            :class:`numpy.float64` types are allowed.
+
+    Returns:
+        cupy.ndarray: Samples drawn from the poisson distribution.
+
+    .. seealso:: :func:`numpy.random.poisson`
+
+    """
+    rs = generator.get_random_state()
+    x = rs.poisson(lam, size, dtype)
+    return x
+
+
 def standard_normal(size=None, dtype=float):
     """Returns an array of samples drawn from the standard normal distribution.
 

--- a/cupy/random/distributions.py
+++ b/cupy/random/distributions.py
@@ -32,19 +32,25 @@ def beta(a, b, size=None, dtype=float):
     return rs.beta(a, b, size, dtype)
 
 
-def binomial(n, p, size=None, dtype=float):
-    """Returns an array of samples drawn from a Binomial distribution.
+def binomial(n, p, size=None, dtype=int):
+    """Binomial distribution.
+
+    Returns an array of samples drawn from the binomial distribution. Its
+    probability mass function is defined as
+
+    .. math::
+     f(x) = \\binom{n}{x}p^x(1-p)^{n-x}
 
     Args:
         n (int): Trial number of the binomial distribution.
         p (float): Success probability of the binomial distribution.
         size (int or tuple of ints): The shape of the array. If ``None``, a
             zero-dimensional array is generated.
-        dtype: Data type specifier. Only :class:`numpy.float32` and
-            :class:`numpy.float64` types are allowed.
+        dtype: Data type specifier. Only :class:`numpy.int32` and
+            :class:`numpy.int64` types are allowed.
 
     Returns:
-        cupy.ndarray: Samples drawn from the Binomial destribution.
+        cupy.ndarray: Samples drawn from the binomial destribution.
 
     .. seealso::
         :func:`cupy.random.RandomState.binomial`

--- a/cupy/random/distributions.py
+++ b/cupy/random/distributions.py
@@ -54,6 +54,32 @@ def binomial(n, p, size=None, dtype=float):
     return rs.binomial(n, p, size, dtype)
 
 
+def chisquare(df, size=None, dtype=float):
+    """Returns an array of samples drawn from a Chi-Squared distribution.
+
+    Its probability density function is defined as
+
+    .. math::
+       f(x) = \\frac{(1/2)^{k/2}}{\\Gamma(k/2)}x^{k/2-1}\mathrm{e}^{-x/2}
+
+    Args:
+        df (int): Degree of freedom.
+        size (int or tuple of ints): The shape of the array. If ``None``, a
+            zero-dimensional array is generated.
+        dtype: Data type specifier. Only :class:`numpy.float32` and
+            :class:`numpy.float64` types are allowed.
+
+    Returns:
+        cupy.ndarray: Samples drawn from the Chi-Squared destribution.
+
+    .. seealso::
+        :func:`cupy.random.RandomState.chisquare`
+        :func:`numpy.random.chisquare`
+    """
+    rs = generator.get_random_state()
+    return rs.chisquare(df, size, dtype)
+
+
 def gumbel(loc=0.0, scale=1.0, size=None, dtype=float):
     """Returns an array of samples drawn from a Gumbel distribution.
 

--- a/cupy/random/distributions.py
+++ b/cupy/random/distributions.py
@@ -419,10 +419,13 @@ def standard_cauchy(size=None, dtype=float):
 
 
 def standard_exponential(size=None, dtype=float):
-    """Standard Exponential
+    """Standard exponential distribution.
 
     Returns an array of samples drawn from the standard exponential
-    distribution.
+    distribution. Its probability density function is defined as
+
+      .. math::
+         f(x) = e^{-x},
 
     Args:
         size (int or tuple of ints): The shape of the array. If ``None``, a

--- a/cupy/random/generator.py
+++ b/cupy/random/generator.py
@@ -437,7 +437,7 @@ class RandomState(object):
         return self._generate_normal(func, size, dtype, loc, scale)
 
     def pareto(self, a, size=None, dtype=float):
-        """Returns an array of samples drawn from a Pareto distribution.
+        """Returns an array of samples drawn from the pareto II distribution.
 
         .. seealso::
             :func:`cupy.random.pareto_kernel` for full documentation,

--- a/cupy/random/generator.py
+++ b/cupy/random/generator.py
@@ -560,6 +560,21 @@ class RandomState(object):
             self.rk_seed += numpy.prod(size)
         return y
 
+    def geometric(self, p, size=None, dtype=int):
+        """Returns an array of samples drawn from a Geometric distribution.
+
+        .. seealso::
+            :func:`cupy.random.geometric` for full documentation,
+            :meth:`numpy.random.RandomState.geometric`
+        """
+        y = cupy.zeros(shape=size, dtype=int)
+        kernels._get_geometric_kernel()(p, self.rk_seed, y)
+        if size is None:
+            self.rk_seed += 1
+        else:
+            self.rk_seed += numpy.prod(size)
+        return y
+
     def gumbel(self, loc=0.0, scale=1.0, size=None, dtype=float):
         """Returns an array of samples drawn from a Gumbel distribution.
 

--- a/cupy/random/generator.py
+++ b/cupy/random/generator.py
@@ -21,7 +21,7 @@ _laplace_kernel = None
 _binomial_kernel = None
 
 
-# TODO: implementation of BTPE same as numpy
+# TODO(YoshikawaMasashi): implementation of BTPE same as numpy
 def _get_binomial_kernel():
     global _binomial_kernel
     if _binomial_kernel is None:

--- a/cupy/random/generator.py
+++ b/cupy/random/generator.py
@@ -21,8 +21,58 @@ _binomial_kernel = None
 _chisquare_kernel = None
 _gumbel_kernel = None
 _laplace_kernel = None
+_poisson_kernel = None
 _standard_gamma_kernel = None
 _standard_t_kernel = None
+
+
+loggam_difinition = '''
+/*
+ * log-gamma function to support some of these distributions. The
+ * algorithm comes from SPECFUN by Shanjie Zhang and Jianming Jin and their
+ * book "Computation of Special Functions", 1996, John Wiley & Sons, Inc.
+ */
+static __device__ double loggam(double x)
+{
+    double x0, x2, xp, gl, gl0;
+    long k, n;
+
+    static double a[10] = {8.333333333333333e-02,-2.777777777777778e-03,
+         7.936507936507937e-04,-5.952380952380952e-04,
+         8.417508417508418e-04,-1.917526917526918e-03,
+         6.410256410256410e-03,-2.955065359477124e-02,
+         1.796443723688307e-01,-1.39243221690590e+00};
+    x0 = x;
+    n = 0;
+    if ((x == 1.0) || (x == 2.0))
+    {
+        return 0.0;
+    }
+    else if (x <= 7.0)
+    {
+        n = (long)(7 - x);
+        x0 = x + n;
+    }
+    x2 = 1.0/(x0*x0);
+    xp = 2*M_PI;
+    gl0 = a[9];
+    for (k=8; k>=0; k--)
+    {
+        gl0 *= x2;
+        gl0 += a[k];
+    }
+    gl = gl0/x0 + 0.5*log(xp) + (x0-0.5)*log(x0) - x0;
+    if (x <= 7.0)
+    {
+        for (k=1; k<=n; k++)
+        {
+            gl -= log(x0-1.0);
+            x0 -= 1.0;
+        }
+    }
+    return gl;
+}
+'''
 
 
 rk_state_difinition = '''
@@ -301,6 +351,99 @@ __device__ double rk_standard_t(rk_state *state, double df)
 '''
 
 
+rk_poisson_mult_definition = '''
+__device__ long rk_poisson_mult(rk_state *state, double lam)
+{
+    long X;
+    double prod, U, enlam;
+
+    enlam = exp(-lam);
+    X = 0;
+    prod = 1.0;
+    while (1)
+    {
+        U = rk_double(state);
+        prod *= U;
+        if (prod > enlam)
+        {
+            X += 1;
+        }
+        else
+        {
+            return X;
+        }
+    }
+}
+'''
+
+
+rk_poisson_ptrs_definition = '''
+/*
+ * The transformed rejection method for generating Poisson random variables
+ * W. Hoermann
+ * Insurance: Mathematics and Economics 12, 39-45 (1993)
+ */
+#define LS2PI 0.91893853320467267
+#define TWELFTH 0.083333333333333333333333
+__device__ long rk_poisson_ptrs(rk_state *state, double lam)
+{
+    long k;
+    double U, V, slam, loglam, a, b, invalpha, vr, us;
+
+    slam = sqrt(lam);
+    loglam = log(lam);
+    b = 0.931 + 2.53*slam;
+    a = -0.059 + 0.02483*b;
+    invalpha = 1.1239 + 1.1328/(b-3.4);
+    vr = 0.9277 - 3.6224/(b-2);
+
+    while (1)
+    {
+        U = rk_double(state) - 0.5;
+        V = rk_double(state);
+        us = 0.5 - fabs(U);
+        k = (long)floor((2*a/us + b)*U + lam + 0.43);
+        if ((us >= 0.07) && (V <= vr))
+        {
+            return k;
+        }
+        if ((k < 0) ||
+            ((us < 0.013) && (V > us)))
+        {
+            continue;
+        }
+        if ((log(V) + log(invalpha) - log(a/(us*us)+b)) <=
+            (-lam + k*loglam - loggam(k+1)))
+        {
+            return k;
+        }
+
+
+    }
+
+}
+'''
+
+
+rk_poisson_definition = '''
+__device__ long rk_poisson(rk_state *state, double lam)
+{
+    if (lam >= 10)
+    {
+        return rk_poisson_ptrs(state, lam);
+    }
+    else if (lam == 0)
+    {
+        return 0;
+    }
+    else
+    {
+        return rk_poisson_mult(state, lam);
+    }
+}
+'''
+
+
 def _get_beta_kernel():
     global _beta_kernel
     if _beta_kernel is None:
@@ -384,6 +527,27 @@ def _get_laplace_kernel():
             'laplace_kernel'
         )
     return _laplace_kernel
+
+
+def _get_poisson_kernel():
+    global _poisson_kernel
+    if _poisson_kernel is None:
+        definitions = \
+            [rk_state_difinition, rk_seed_definition, rk_random_definition,
+             rk_double_definition, loggam_difinition,
+             rk_poisson_mult_definition, rk_poisson_ptrs_definition,
+             rk_poisson_definition]
+        _poisson_kernel = core.ElementwiseKernel(
+            'T lam, T seed', 'T y',
+            '''
+            rk_seed(seed + i, &internal_state);
+            y = rk_poisson(&internal_state, lam);
+            ''',
+            'poisson_kernel',
+            preamble=''.join(definitions),
+            loop_prep="rk_state internal_state;"
+        )
+    return _poisson_kernel
 
 
 def _get_standard_gamma_kernel():
@@ -978,6 +1142,21 @@ class RandomState(object):
         x = self.uniform(size=size, dtype=dtype)
         _get_laplace_kernel()(x, loc, scale, x)
         return x
+
+    def poisson(self, lam=1.0, size=None, dtype=int):
+        """Returns an array of samples drawn from a Poisson distribution.
+
+        .. seealso::
+            :func:`cupy.random.poisson` for full documentation,
+            :meth:`numpy.random.RandomState.poisson`
+        """
+        y = cupy.zeros(shape=size, dtype=dtype)
+        _get_poisson_kernel()(lam, self.rk_seed, y)
+        if size is None:
+            self.rk_seed += 1
+        else:
+            self.rk_seed += numpy.prod(size)
+        return y
 
     def standard_t(self, df, size=None, dtype=float):
         """Returns an array of samples drawn from a Standard Student’s t distribution.

--- a/cupy/random/generator.py
+++ b/cupy/random/generator.py
@@ -484,7 +484,7 @@ class RandomState(object):
         return array
 
     def poisson(self, lam=1.0, size=None, dtype=int):
-        """Returns an array of samples drawn from a Poisson distribution.
+        """Returns an array of samples drawn from the poisson distribution.
 
         .. seealso::
             :func:`cupy.random.poisson` for full documentation,

--- a/cupy/random/generator.py
+++ b/cupy/random/generator.py
@@ -636,7 +636,7 @@ class RandomState(object):
         return self.normal(size=size, dtype=dtype)
 
     def standard_t(self, df, size=None, dtype=float):
-        """Returns an array of samples drawn from a Standard Student’s t distribution.
+        """Returns an array of samples drawn from the standard t distribution.
 
         .. seealso::
             :func:`cupy.random.standard_t` for full documentation,

--- a/cupy/random/generator.py
+++ b/cupy/random/generator.py
@@ -710,7 +710,6 @@ class RandomState(object):
         return x
 
 
-# TODO(YoshikawaMasashi): move to kernels.py
 def _cupy_permutation():
     return core.ElementwiseKernel(
         'raw int32 array, raw int32 sample, int32 j_start, int32 _j_end',

--- a/cupy/random/generator.py
+++ b/cupy/random/generator.py
@@ -196,7 +196,7 @@ class RandomState(object):
         return a[index]
 
     def dirichlet(self, alpha, size=None, dtype=float):
-        """Returns an array of samples drawn from a Dirichlet distribution.
+        """Returns an array of samples drawn from the dirichlet distribution.
 
         .. seealso::
             :func:`cupy.random.dirichlet` for full documentation,

--- a/cupy/random/generator.py
+++ b/cupy/random/generator.py
@@ -596,7 +596,7 @@ class RandomState(object):
         a[:] = a[self.permutation(len(a))]
 
     def standard_cauchy(self, size=None, dtype=float):
-        """Returns an array of samples drawn from a Standard Cauchy distribution.
+        """Returns an array of samples drawn from the standard cauchy distribution.
 
         .. seealso::
             :func:`cupy.random.standard_cauchy` for full documentation,

--- a/cupy/random/generator.py
+++ b/cupy/random/generator.py
@@ -529,6 +529,21 @@ class RandomState(object):
             self.rk_seed += numpy.prod(size)
         return y
 
+    def f(self, dfnum, dfden, size=None, dtype=float):
+        """Returns an array of samples drawn from the F distribution.
+
+        .. seealso::
+            :func:`cupy.random.f` for full documentation,
+            :meth:`numpy.random.RandomState.f`
+        """
+        y = cupy.zeros(shape=size, dtype=dtype)
+        kernels._get_f_kernel()(dfnum, dfden, self.rk_seed, y)
+        if size is None:
+            self.rk_seed += 1
+        else:
+            self.rk_seed += numpy.prod(size)
+        return y
+
     def gamma(self, shape, scale=1.0, size=None, dtype=float):
         """Returns an array of samples drawn from a Gamma distribution.
 

--- a/cupy/random/generator.py
+++ b/cupy/random/generator.py
@@ -19,6 +19,288 @@ from cupy.cuda import device
 _gumbel_kernel = None
 _laplace_kernel = None
 _binomial_kernel = None
+_beta_kernel = None
+
+
+rk_state_difinition = '''
+#define RK_STATE_LEN 624
+
+typedef struct rk_state_
+{
+    unsigned long key[RK_STATE_LEN];
+    int pos;
+    int has_gauss; /* !=0: gauss contains a gaussian deviate */
+    double gauss;
+
+    /* The rk_state structure has been extended to store the following
+     * information for the binomial generator. If the input values of n or p
+     * are different than nsave and psave, then the other parameters will be
+     * recomputed. RTK 2005-09-02 */
+
+    int has_binomial; /* !=0: following parameters initialized for
+                              binomial */
+    double psave;
+    long nsave;
+    double r;
+    double q;
+    double fm;
+    long m;
+    double p1;
+    double xm;
+    double xl;
+    double xr;
+    double c;
+    double laml;
+    double lamr;
+    double p2;
+    double p3;
+    double p4;
+
+}
+rk_state;
+'''
+
+
+rk_seed_definition = '''
+__device__ void
+rk_seed(unsigned long seed, rk_state *state)
+{
+    int pos;
+    seed &= 0xffffffffUL;
+
+    /* Knuth's PRNG as used in the Mersenne Twister reference implementation */
+    for (pos = 0; pos < RK_STATE_LEN; pos++) {
+        state->key[pos] = seed;
+        seed = (1812433253UL * (seed ^ (seed >> 30)) + pos + 1) & 0xffffffffUL;
+    }
+    state->pos = RK_STATE_LEN;
+    state->gauss = 0;
+    state->has_gauss = 0;
+    state->has_binomial = 0;
+}
+'''
+
+
+rk_random_definition = '''
+/* Magic Mersenne Twister constants */
+#define N 624
+#define M 397
+#define MATRIX_A 0x9908b0dfUL
+#define UPPER_MASK 0x80000000UL
+#define LOWER_MASK 0x7fffffffUL
+
+/*
+ * Slightly optimised reference implementation of the Mersenne Twister
+ * Note that regardless of the precision of long, only 32 bit random
+ * integers are produced
+ */
+__device__ unsigned long
+rk_random(rk_state *state)
+{
+    unsigned long y;
+
+    if (state->pos == RK_STATE_LEN) {
+        int i;
+
+        for (i = 0; i < N - M; i++) {
+            y = (state->key[i] & UPPER_MASK) | (state->key[i+1] & LOWER_MASK);
+            state->key[i] = state->key[i+M] ^ (y>>1) ^ (-(y & 1) & MATRIX_A);
+        }
+        for (; i < N - 1; i++) {
+            y = (state->key[i] & UPPER_MASK) | (state->key[i+1] & LOWER_MASK);
+            state->key[i] = state->key[i+(M-N)] ^ (y>>1) ^ (-(y & 1) & MATRIX_A);
+        }
+        y = (state->key[N - 1] & UPPER_MASK) | (state->key[0] & LOWER_MASK);
+        state->key[N - 1] = state->key[M - 1] ^ (y >> 1) ^ (-(y & 1) & MATRIX_A);
+
+        state->pos = 0;
+    }
+    y = state->key[state->pos++];
+
+    /* Tempering */
+    y ^= (y >> 11);
+    y ^= (y << 7) & 0x9d2c5680UL;
+    y ^= (y << 15) & 0xefc60000UL;
+    y ^= (y >> 18);
+
+    return y;
+}
+'''
+
+
+rk_double_definition = '''
+__device__ double
+rk_double(rk_state *state)
+{
+    /* shifts : 67108864 = 0x4000000, 9007199254740992 = 0x20000000000000 */
+    long a = rk_random(state) >> 5, b = rk_random(state) >> 6;
+    return (a * 67108864.0 + b) / 9007199254740992.0;
+}
+'''
+
+
+rk_gauss_definition = '''
+__device__ double
+rk_gauss(rk_state *state)
+{
+    if (state->has_gauss) {
+        const double tmp = state->gauss;
+        state->gauss = 0;
+        state->has_gauss = 0;
+        return tmp;
+    }
+    else {
+        double f, x1, x2, r2;
+
+        do {
+            x1 = 2.0*rk_double(state) - 1.0;
+            x2 = 2.0*rk_double(state) - 1.0;
+            r2 = x1*x1 + x2*x2;
+        }
+        while (r2 >= 1.0 || r2 == 0.0);
+
+        /* Box-Muller transform */
+        f = sqrt(-2.0*log(r2)/r2);
+        /* Keep for next call */
+        state->gauss = f*x1;
+        state->has_gauss = 1;
+        return f*x2;
+    }
+}
+'''
+
+
+rk_standard_exponential_definition = '''
+__device__ double rk_standard_exponential(rk_state *state)
+{
+    /* We use -log(1-U) since U is [0, 1) */
+    return -log(1.0 - rk_double(state));
+}
+'''
+
+
+rk_standard_gamma_definition = '''
+__device__ double rk_standard_gamma(rk_state *state, double shape)
+{
+    double b, c;
+    double U, V, X, Y;
+
+    if (shape == 1.0)
+    {
+        return rk_standard_exponential(state);
+    }
+    else if (shape < 1.0)
+    {
+        for (;;)
+        {
+            U = rk_double(state);
+            V = rk_standard_exponential(state);
+            if (U <= 1.0 - shape)
+            {
+                X = pow(U, 1./shape);
+                if (X <= V)
+                {
+                    return X;
+                }
+            }
+            else
+            {
+                Y = -log((1-U)/shape);
+                X = pow(1.0 - shape + shape*Y, 1./shape);
+                if (X <= (V + Y))
+                {
+                    return X;
+                }
+            }
+        }
+    }
+    else
+    {
+        b = shape - 1./3.;
+        c = 1./sqrt(9*b);
+        for (;;)
+        {
+            do
+            {
+                X = rk_gauss(state);
+                V = 1.0 + c*X;
+            } while (V <= 0.0);
+
+            V = V*V*V;
+            U = rk_double(state);
+            if (U < 1.0 - 0.0331*(X*X)*(X*X)) return (b*V);
+            if (log(U) < 0.5*X*X + b*(1. - V + log(V))) return (b*V);
+        }
+    }
+}
+'''
+
+
+rk_beta_definition = '''
+__device__ double rk_beta(rk_state *state, double a, double b)
+{
+    double Ga, Gb;
+
+    if ((a <= 1.0) && (b <= 1.0))
+    {
+        double U, V, X, Y;
+        /* Use Johnk's algorithm */
+
+        while (1)
+        {
+            U = rk_double(state);
+            V = rk_double(state);
+            X = pow(U, 1.0/a);
+            Y = pow(V, 1.0/b);
+
+            if ((X + Y) <= 1.0)
+            {
+                if (X +Y > 0)
+                {
+                    return X / (X + Y);
+                }
+                else
+                {
+                    double logX = log(U) / a;
+                    double logY = log(V) / b;
+                    double logM = logX > logY ? logX : logY;
+                    logX -= logM;
+                    logY -= logM;
+
+                    return exp(logX - log(exp(logX) + exp(logY)));
+                }
+            }
+        }
+    }
+    else
+    {
+        Ga = rk_standard_gamma(state, a);
+        Gb = rk_standard_gamma(state, b);
+        return Ga/(Ga + Gb);
+    }
+}
+'''
+
+
+def _get_beta_kernel():
+    global _beta_kernel
+    if _beta_kernel is None:
+        definitions = \
+            [rk_state_difinition, rk_seed_definition, rk_random_definition,
+             rk_double_definition, rk_gauss_definition,
+             rk_standard_exponential_definition, rk_standard_gamma_definition,
+             rk_beta_definition]
+        _beta_kernel = core.ElementwiseKernel(
+            'T a, T b, T seed', 'T y',
+            '''
+            rk_seed(seed + i, &internal_state);
+            y = rk_beta(&internal_state, a, b);
+            ''',
+            'beta_kernel',
+            preamble=''.join(definitions),
+            loop_prep="rk_state internal_state;"
+        )
+    return _beta_kernel
 
 
 # TODO(YoshikawaMasashi): implementation of BTPE same as numpy
@@ -344,6 +626,8 @@ class RandomState(object):
         curand.setPseudoRandomGeneratorSeed(self._generator, seed)
         curand.setGeneratorOffset(self._generator, 0)
 
+        self.rk_seed = numpy.uint32(seed)
+
     def standard_normal(self, size=None, dtype=float):
         """Returns samples drawn from the standard normal distribution.
 
@@ -526,6 +810,21 @@ class RandomState(object):
         x = self.uniform(size=size, dtype=dtype)
         y = cupy.zeros_like(x, dtype=dtype)
         _get_binomial_kernel()(x, n, p, y)
+        return y
+
+    def beta(self, a, b, size=None, dtype=float):
+        """Returns an array of samples drawn from a Beta distribution.
+
+        .. seealso::
+            :func:`cupy.random.beta` for full documentation,
+            :meth:`numpy.random.RandomState.beta`
+        """
+        y = cupy.zeros(shape=size, dtype=dtype)
+        _get_beta_kernel()(a, b, self.rk_seed, y)
+        if size is None:
+            self.rk_seed += 1
+        else:
+            self.rk_seed += numpy.prod(size)
         return y
 
     def gumbel(self, loc=0.0, scale=1.0, size=None, dtype=float):

--- a/cupy/random/generator.py
+++ b/cupy/random/generator.py
@@ -14,581 +14,7 @@ from cupy import core
 from cupy import cuda
 from cupy.cuda import curand
 from cupy.cuda import device
-
-
-_beta_kernel = None
-_binomial_kernel = None
-_chisquare_kernel = None
-_gumbel_kernel = None
-_laplace_kernel = None
-_poisson_kernel = None
-_standard_gamma_kernel = None
-_standard_t_kernel = None
-
-
-loggam_difinition = '''
-/*
- * log-gamma function to support some of these distributions. The
- * algorithm comes from SPECFUN by Shanjie Zhang and Jianming Jin and their
- * book "Computation of Special Functions", 1996, John Wiley & Sons, Inc.
- */
-static __device__ double loggam(double x)
-{
-    double x0, x2, xp, gl, gl0;
-    long k, n;
-
-    static double a[10] = {8.333333333333333e-02,-2.777777777777778e-03,
-         7.936507936507937e-04,-5.952380952380952e-04,
-         8.417508417508418e-04,-1.917526917526918e-03,
-         6.410256410256410e-03,-2.955065359477124e-02,
-         1.796443723688307e-01,-1.39243221690590e+00};
-    x0 = x;
-    n = 0;
-    if ((x == 1.0) || (x == 2.0))
-    {
-        return 0.0;
-    }
-    else if (x <= 7.0)
-    {
-        n = (long)(7 - x);
-        x0 = x + n;
-    }
-    x2 = 1.0/(x0*x0);
-    xp = 2*M_PI;
-    gl0 = a[9];
-    for (k=8; k>=0; k--)
-    {
-        gl0 *= x2;
-        gl0 += a[k];
-    }
-    gl = gl0/x0 + 0.5*log(xp) + (x0-0.5)*log(x0) - x0;
-    if (x <= 7.0)
-    {
-        for (k=1; k<=n; k++)
-        {
-            gl -= log(x0-1.0);
-            x0 -= 1.0;
-        }
-    }
-    return gl;
-}
-'''
-
-
-rk_state_difinition = '''
-#define RK_STATE_LEN 624
-
-typedef struct rk_state_
-{
-    unsigned long key[RK_STATE_LEN];
-    int pos;
-    int has_gauss; /* !=0: gauss contains a gaussian deviate */
-    double gauss;
-
-    /* The rk_state structure has been extended to store the following
-     * information for the binomial generator. If the input values of n or p
-     * are different than nsave and psave, then the other parameters will be
-     * recomputed. RTK 2005-09-02 */
-
-    int has_binomial; /* !=0: following parameters initialized for
-                              binomial */
-    double psave;
-    long nsave;
-    double r;
-    double q;
-    double fm;
-    long m;
-    double p1;
-    double xm;
-    double xl;
-    double xr;
-    double c;
-    double laml;
-    double lamr;
-    double p2;
-    double p3;
-    double p4;
-
-}
-rk_state;
-'''
-
-
-rk_seed_definition = '''
-__device__ void
-rk_seed(unsigned long seed, rk_state *state)
-{
-    int pos;
-    seed &= 0xffffffffUL;
-
-    /* Knuth's PRNG as used in the Mersenne Twister reference implementation */
-    for (pos = 0; pos < RK_STATE_LEN; pos++) {
-        state->key[pos] = seed;
-        seed = (1812433253UL * (seed ^ (seed >> 30)) + pos + 1) & 0xffffffffUL;
-    }
-    state->pos = RK_STATE_LEN;
-    state->gauss = 0;
-    state->has_gauss = 0;
-    state->has_binomial = 0;
-}
-'''
-
-
-rk_random_definition = '''
-/* Magic Mersenne Twister constants */
-#define N 624
-#define M 397
-#define MATRIX_A 0x9908b0dfUL
-#define UPPER_MASK 0x80000000UL
-#define LOWER_MASK 0x7fffffffUL
-
-/*
- * Slightly optimised reference implementation of the Mersenne Twister
- * Note that regardless of the precision of long, only 32 bit random
- * integers are produced
- */
-__device__ unsigned long
-rk_random(rk_state *state)
-{
-    unsigned long y;
-
-    if (state->pos == RK_STATE_LEN) {
-        int i;
-
-        for (i = 0; i < N - M; i++) {
-            y = (state->key[i] & UPPER_MASK) | (state->key[i+1] & LOWER_MASK);
-            state->key[i] = state->key[i+M] ^ (y>>1) ^ (-(y & 1) & MATRIX_A);
-        }
-        for (; i < N - 1; i++) {
-            y = (state->key[i] & UPPER_MASK) | (state->key[i+1] & LOWER_MASK);
-            state->key[i]
-                = state->key[i+(M-N)] ^ (y>>1) ^ (-(y & 1) & MATRIX_A);
-        }
-        y = (state->key[N - 1] & UPPER_MASK) | (state->key[0] & LOWER_MASK);
-        state->key[N - 1]
-            = state->key[M - 1] ^ (y >> 1) ^ (-(y & 1) & MATRIX_A);
-
-        state->pos = 0;
-    }
-    y = state->key[state->pos++];
-
-    /* Tempering */
-    y ^= (y >> 11);
-    y ^= (y << 7) & 0x9d2c5680UL;
-    y ^= (y << 15) & 0xefc60000UL;
-    y ^= (y >> 18);
-
-    return y;
-}
-'''
-
-
-rk_double_definition = '''
-__device__ double
-rk_double(rk_state *state)
-{
-    /* shifts : 67108864 = 0x4000000, 9007199254740992 = 0x20000000000000 */
-    long a = rk_random(state) >> 5, b = rk_random(state) >> 6;
-    return (a * 67108864.0 + b) / 9007199254740992.0;
-}
-'''
-
-
-rk_gauss_definition = '''
-__device__ double
-rk_gauss(rk_state *state)
-{
-    if (state->has_gauss) {
-        const double tmp = state->gauss;
-        state->gauss = 0;
-        state->has_gauss = 0;
-        return tmp;
-    }
-    else {
-        double f, x1, x2, r2;
-
-        do {
-            x1 = 2.0*rk_double(state) - 1.0;
-            x2 = 2.0*rk_double(state) - 1.0;
-            r2 = x1*x1 + x2*x2;
-        }
-        while (r2 >= 1.0 || r2 == 0.0);
-
-        /* Box-Muller transform */
-        f = sqrt(-2.0*log(r2)/r2);
-        /* Keep for next call */
-        state->gauss = f*x1;
-        state->has_gauss = 1;
-        return f*x2;
-    }
-}
-'''
-
-
-rk_standard_exponential_definition = '''
-__device__ double rk_standard_exponential(rk_state *state)
-{
-    /* We use -log(1-U) since U is [0, 1) */
-    return -log(1.0 - rk_double(state));
-}
-'''
-
-
-rk_standard_gamma_definition = '''
-__device__ double rk_standard_gamma(rk_state *state, double shape)
-{
-    double b, c;
-    double U, V, X, Y;
-
-    if (shape == 1.0)
-    {
-        return rk_standard_exponential(state);
-    }
-    else if (shape < 1.0)
-    {
-        for (;;)
-        {
-            U = rk_double(state);
-            V = rk_standard_exponential(state);
-            if (U <= 1.0 - shape)
-            {
-                X = pow(U, 1./shape);
-                if (X <= V)
-                {
-                    return X;
-                }
-            }
-            else
-            {
-                Y = -log((1-U)/shape);
-                X = pow(1.0 - shape + shape*Y, 1./shape);
-                if (X <= (V + Y))
-                {
-                    return X;
-                }
-            }
-        }
-    }
-    else
-    {
-        b = shape - 1./3.;
-        c = 1./sqrt(9*b);
-        for (;;)
-        {
-            do
-            {
-                X = rk_gauss(state);
-                V = 1.0 + c*X;
-            } while (V <= 0.0);
-
-            V = V*V*V;
-            U = rk_double(state);
-            if (U < 1.0 - 0.0331*(X*X)*(X*X)) return (b*V);
-            if (log(U) < 0.5*X*X + b*(1. - V + log(V))) return (b*V);
-        }
-    }
-}
-'''
-
-
-rk_beta_definition = '''
-__device__ double rk_beta(rk_state *state, double a, double b)
-{
-    double Ga, Gb;
-
-    if ((a <= 1.0) && (b <= 1.0))
-    {
-        double U, V, X, Y;
-        /* Use Johnk's algorithm */
-
-        while (1)
-        {
-            U = rk_double(state);
-            V = rk_double(state);
-            X = pow(U, 1.0/a);
-            Y = pow(V, 1.0/b);
-
-            if ((X + Y) <= 1.0)
-            {
-                if (X +Y > 0)
-                {
-                    return X / (X + Y);
-                }
-                else
-                {
-                    double logX = log(U) / a;
-                    double logY = log(V) / b;
-                    double logM = logX > logY ? logX : logY;
-                    logX -= logM;
-                    logY -= logM;
-
-                    return exp(logX - log(exp(logX) + exp(logY)));
-                }
-            }
-        }
-    }
-    else
-    {
-        Ga = rk_standard_gamma(state, a);
-        Gb = rk_standard_gamma(state, b);
-        return Ga/(Ga + Gb);
-    }
-}
-'''
-
-rk_chisquare_definition = '''
-__device__ double rk_chisquare(rk_state *state, double df)
-{
-    return 2.0*rk_standard_gamma(state, df/2.0);
-}
-'''
-
-rk_standard_t_definition = '''
-__device__ double rk_standard_t(rk_state *state, double df)
-{
-    return sqrt(df/2)*rk_gauss(state)/sqrt(rk_standard_gamma(state, df/2));
-}
-'''
-
-
-rk_poisson_mult_definition = '''
-__device__ long rk_poisson_mult(rk_state *state, double lam)
-{
-    long X;
-    double prod, U, enlam;
-
-    enlam = exp(-lam);
-    X = 0;
-    prod = 1.0;
-    while (1)
-    {
-        U = rk_double(state);
-        prod *= U;
-        if (prod > enlam)
-        {
-            X += 1;
-        }
-        else
-        {
-            return X;
-        }
-    }
-}
-'''
-
-
-rk_poisson_ptrs_definition = '''
-/*
- * The transformed rejection method for generating Poisson random variables
- * W. Hoermann
- * Insurance: Mathematics and Economics 12, 39-45 (1993)
- */
-#define LS2PI 0.91893853320467267
-#define TWELFTH 0.083333333333333333333333
-__device__ long rk_poisson_ptrs(rk_state *state, double lam)
-{
-    long k;
-    double U, V, slam, loglam, a, b, invalpha, vr, us;
-
-    slam = sqrt(lam);
-    loglam = log(lam);
-    b = 0.931 + 2.53*slam;
-    a = -0.059 + 0.02483*b;
-    invalpha = 1.1239 + 1.1328/(b-3.4);
-    vr = 0.9277 - 3.6224/(b-2);
-
-    while (1)
-    {
-        U = rk_double(state) - 0.5;
-        V = rk_double(state);
-        us = 0.5 - fabs(U);
-        k = (long)floor((2*a/us + b)*U + lam + 0.43);
-        if ((us >= 0.07) && (V <= vr))
-        {
-            return k;
-        }
-        if ((k < 0) ||
-            ((us < 0.013) && (V > us)))
-        {
-            continue;
-        }
-        if ((log(V) + log(invalpha) - log(a/(us*us)+b)) <=
-            (-lam + k*loglam - loggam(k+1)))
-        {
-            return k;
-        }
-
-
-    }
-
-}
-'''
-
-
-rk_poisson_definition = '''
-__device__ long rk_poisson(rk_state *state, double lam)
-{
-    if (lam >= 10)
-    {
-        return rk_poisson_ptrs(state, lam);
-    }
-    else if (lam == 0)
-    {
-        return 0;
-    }
-    else
-    {
-        return rk_poisson_mult(state, lam);
-    }
-}
-'''
-
-
-def _get_beta_kernel():
-    global _beta_kernel
-    if _beta_kernel is None:
-        definitions = \
-            [rk_state_difinition, rk_seed_definition, rk_random_definition,
-             rk_double_definition, rk_gauss_definition,
-             rk_standard_exponential_definition, rk_standard_gamma_definition,
-             rk_beta_definition]
-        _beta_kernel = core.ElementwiseKernel(
-            'T a, T b, T seed', 'T y',
-            '''
-            rk_seed(seed + i, &internal_state);
-            y = rk_beta(&internal_state, a, b);
-            ''',
-            'beta_kernel',
-            preamble=''.join(definitions),
-            loop_prep="rk_state internal_state;"
-        )
-    return _beta_kernel
-
-
-# TODO(YoshikawaMasashi): implementation of BTPE same as numpy
-def _get_binomial_kernel():
-    global _binomial_kernel
-    if _binomial_kernel is None:
-        _binomial_kernel = core.ElementwiseKernel(
-            'T x, T n, T p', 'T y',
-            '''
-            y = 0.;
-            T px = exp(n * log(1-p));
-            while(x > px){
-                y += 1.;
-                x -= px;
-                px = ((n-y+1) * p * px)/(y*(1-p));
-            }
-            ''',
-            'binomial_kernel'
-        )
-    return _binomial_kernel
-
-
-def _get_chisquare_kernel():
-    global _chisquare_kernel
-    if _chisquare_kernel is None:
-        definitions = \
-            [rk_state_difinition, rk_seed_definition, rk_random_definition,
-             rk_double_definition, rk_gauss_definition,
-             rk_standard_exponential_definition, rk_standard_gamma_definition,
-             rk_chisquare_definition]
-        _chisquare_kernel = core.ElementwiseKernel(
-            'T df, T seed', 'T y',
-            '''
-            rk_seed(seed + i, &internal_state);
-            y = rk_chisquare(&internal_state, df);
-            ''',
-            'beta_kernel',
-            preamble=''.join(definitions),
-            loop_prep="rk_state internal_state;"
-        )
-    return _chisquare_kernel
-
-
-def _get_gumbel_kernel():
-    global _gumbel_kernel
-    if _gumbel_kernel is None:
-        _gumbel_kernel = core.ElementwiseKernel(
-            'T x, T loc, T scale', 'T y',
-            'y = loc - log(-log(1 - x)) * scale',
-            'gumbel_kernel'
-        )
-    return _gumbel_kernel
-
-
-def _get_laplace_kernel():
-    global _laplace_kernel
-    if _laplace_kernel is None:
-        _laplace_kernel = core.ElementwiseKernel(
-            'T x, T loc, T scale', 'T y',
-            'y = (x < 0.5)? loc + scale * log(x + x):'
-            ' loc - scale * log(2.0 - x - x)',
-            'laplace_kernel'
-        )
-    return _laplace_kernel
-
-
-def _get_poisson_kernel():
-    global _poisson_kernel
-    if _poisson_kernel is None:
-        definitions = \
-            [rk_state_difinition, rk_seed_definition, rk_random_definition,
-             rk_double_definition, loggam_difinition,
-             rk_poisson_mult_definition, rk_poisson_ptrs_definition,
-             rk_poisson_definition]
-        _poisson_kernel = core.ElementwiseKernel(
-            'T lam, T seed', 'T y',
-            '''
-            rk_seed(seed + i, &internal_state);
-            y = rk_poisson(&internal_state, lam);
-            ''',
-            'poisson_kernel',
-            preamble=''.join(definitions),
-            loop_prep="rk_state internal_state;"
-        )
-    return _poisson_kernel
-
-
-def _get_standard_gamma_kernel():
-    global _standard_gamma_kernel
-    if _standard_gamma_kernel is None:
-        definitions = \
-            [rk_state_difinition, rk_seed_definition, rk_random_definition,
-             rk_double_definition, rk_gauss_definition,
-             rk_standard_exponential_definition, rk_standard_gamma_definition]
-        _standard_gamma_kernel = core.ElementwiseKernel(
-            'T shape, T seed', 'T y',
-            '''
-            rk_seed(seed + i, &internal_state);
-            y = rk_standard_gamma(&internal_state, shape);
-            ''',
-            'standard_gamma_kernel',
-            preamble=''.join(definitions),
-            loop_prep="rk_state internal_state;"
-        )
-    return _standard_gamma_kernel
-
-
-def _get_standard_t_kernel():
-    global _standard_t_kernel
-    if _standard_t_kernel is None:
-        definitions = \
-            [rk_state_difinition, rk_seed_definition, rk_random_definition,
-             rk_double_definition, rk_gauss_definition,
-             rk_standard_exponential_definition, rk_standard_gamma_definition,
-             rk_standard_t_definition]
-        _standard_t_kernel = core.ElementwiseKernel(
-            'T df, T seed', 'T y',
-            '''
-            rk_seed(seed + i, &internal_state);
-            y = rk_standard_t(&internal_state, df);
-            ''',
-            'standard_t_kernel',
-            preamble=''.join(definitions),
-            loop_prep="rk_state internal_state;"
-        )
-    return _standard_t_kernel
+from cupy.random import kernels
 
 
 class RandomState(object):
@@ -1054,7 +480,7 @@ class RandomState(object):
         """
         x = self.uniform(size=size, dtype=dtype)
         y = cupy.zeros_like(x, dtype=dtype)
-        _get_binomial_kernel()(x, n, p, y)
+        kernels._get_binomial_kernel()(x, n, p, y)
         return y
 
     def beta(self, a, b, size=None, dtype=float):
@@ -1065,7 +491,7 @@ class RandomState(object):
             :meth:`numpy.random.RandomState.beta`
         """
         y = cupy.zeros(shape=size, dtype=dtype)
-        _get_beta_kernel()(a, b, self.rk_seed, y)
+        kernels._get_beta_kernel()(a, b, self.rk_seed, y)
         if size is None:
             self.rk_seed += 1
         else:
@@ -1080,7 +506,7 @@ class RandomState(object):
             :meth:`numpy.random.RandomState.chisquare`
         """
         y = cupy.zeros(shape=size, dtype=dtype)
-        _get_chisquare_kernel()(df, self.rk_seed, y)
+        kernels._get_chisquare_kernel()(df, self.rk_seed, y)
         if size is None:
             self.rk_seed += 1
         else:
@@ -1095,7 +521,7 @@ class RandomState(object):
             :meth:`numpy.random.RandomState.dirichlet`
         """
         y = cupy.zeros(shape=size, dtype=dtype)
-        _get_standard_gamma_kernel()(alpha, self.rk_seed, y)
+        kernels._get_standard_gamma_kernel()(alpha, self.rk_seed, y)
         y /= cupy.expand_dims(y.sum(axis=-1), axis=-1)
         if size is None:
             self.rk_seed += 1
@@ -1111,7 +537,7 @@ class RandomState(object):
             :meth:`numpy.random.RandomState.gamma`
         """
         y = cupy.zeros(shape=size, dtype=dtype)
-        _get_standard_gamma_kernel()(shape, self.rk_seed, y)
+        kernels._get_standard_gamma_kernel()(shape, self.rk_seed, y)
         y *= scale
         if size is None:
             self.rk_seed += 1
@@ -1129,7 +555,7 @@ class RandomState(object):
         x = self.uniform(size=size, dtype=dtype)
         # We use `1 - x` as input of `log` method to prevent overflow.
         # It obeys numpy implementation.
-        _get_gumbel_kernel()(x, loc, scale, x)
+        kernels._get_gumbel_kernel()(x, loc, scale, x)
         return x
 
     def laplace(self, loc=0.0, scale=1.0, size=None, dtype=float):
@@ -1140,7 +566,7 @@ class RandomState(object):
             :meth:`numpy.random.RandomState.laplace`
         """
         x = self.uniform(size=size, dtype=dtype)
-        _get_laplace_kernel()(x, loc, scale, x)
+        kernels._get_laplace_kernel()(x, loc, scale, x)
         return x
 
     def poisson(self, lam=1.0, size=None, dtype=int):
@@ -1151,7 +577,7 @@ class RandomState(object):
             :meth:`numpy.random.RandomState.poisson`
         """
         y = cupy.zeros(shape=size, dtype=dtype)
-        _get_poisson_kernel()(lam, self.rk_seed, y)
+        kernels._get_poisson_kernel()(lam, self.rk_seed, y)
         if size is None:
             self.rk_seed += 1
         else:
@@ -1166,7 +592,7 @@ class RandomState(object):
             :meth:`numpy.random.RandomState.standard_t`
         """
         y = cupy.zeros(shape=size, dtype=dtype)
-        _get_standard_t_kernel()(df, self.rk_seed, y)
+        kernels._get_standard_t_kernel()(df, self.rk_seed, y)
         if size is None:
             self.rk_seed += 1
         else:

--- a/cupy/random/generator.py
+++ b/cupy/random/generator.py
@@ -227,7 +227,7 @@ class RandomState(object):
         return y
 
     def gamma(self, shape, scale=1.0, size=None, dtype=float):
-        """Returns an array of samples drawn from a Gamma distribution.
+        """Returns an array of samples drawn from a gamma distribution.
 
         .. seealso::
             :func:`cupy.random.gamma` for full documentation,

--- a/cupy/random/generator.py
+++ b/cupy/random/generator.py
@@ -243,7 +243,7 @@ class RandomState(object):
         return y
 
     def geometric(self, p, size=None, dtype=int):
-        """Returns an array of samples drawn from a Geometric distribution.
+        """Returns an array of samples drawn from the geometric distribution.
 
         .. seealso::
             :func:`cupy.random.geometric` for full documentation,

--- a/cupy/random/generator.py
+++ b/cupy/random/generator.py
@@ -599,6 +599,21 @@ class RandomState(object):
             self.rk_seed += numpy.prod(size)
         return y
 
+    def standard_exponential(self, size=None, dtype=float):
+        """Returns an array of samples drawn from a Standard Exponential distribution.
+
+        .. seealso::
+            :func:`cupy.random.standard_exponential` for full documentation,
+            :meth:`numpy.random.RandomState.standard_exponential`
+        """
+        y = cupy.zeros(shape=size, dtype=dtype)
+        kernels._get_standard_exponential_kernel()(self.rk_seed, y)
+        if size is None:
+            self.rk_seed += 1
+        else:
+            self.rk_seed += numpy.prod(size)
+        return y
+
     def standard_t(self, df, size=None, dtype=float):
         """Returns an array of samples drawn from a Standard Student’s t distribution.
 

--- a/cupy/random/generator.py
+++ b/cupy/random/generator.py
@@ -342,7 +342,7 @@ class RandomState(object):
         return ret.reshape(size)
 
     def laplace(self, loc=0.0, scale=1.0, size=None, dtype=float):
-        """Returns an array of samples drawn from a Laplace distribution.
+        """Returns an array of samples drawn from the Laplace distribution.
 
         .. seealso::
             :func:`cupy.random.laplace` for full documentation,

--- a/cupy/random/generator.py
+++ b/cupy/random/generator.py
@@ -104,7 +104,7 @@ class RandomState(object):
         return y
 
     def chisquare(self, df, size=None, dtype=float):
-        """Returns an array of samples drawn from a Chisquare distribution.
+        """Returns an array of samples drawn from the chi-square distribution.
 
         .. seealso::
             :func:`cupy.random.chisquare` for full documentation,

--- a/cupy/random/generator.py
+++ b/cupy/random/generator.py
@@ -910,6 +910,22 @@ class RandomState(object):
             self.rk_seed += numpy.prod(size)
         return y
 
+    def gamma(self, shape, scale=1.0, size=None, dtype=float):
+        """Returns an array of samples drawn from a Gamma distribution.
+
+        .. seealso::
+            :func:`cupy.random.gamma` for full documentation,
+            :meth:`numpy.random.RandomState.gamma`
+        """
+        y = cupy.zeros(shape=size, dtype=dtype)
+        _get_standard_gamma_kernel()(shape, self.rk_seed, y)
+        y *= scale
+        if size is None:
+            self.rk_seed += 1
+        else:
+            self.rk_seed += numpy.prod(size)
+        return y
+
     def gumbel(self, loc=0.0, scale=1.0, size=None, dtype=float):
         """Returns an array of samples drawn from a Gumbel distribution.
 

--- a/cupy/random/generator.py
+++ b/cupy/random/generator.py
@@ -369,7 +369,7 @@ class RandomState(object):
 
     def multivariate_normal(self, mean, cov, size=None, check_valid='warn',
                             tol=1e-8, dtype=float):
-        """Returns an array of multivariate nomally distributed samples.
+        """Returns an array of samples drawn from the multivariate normal distribution.
 
         .. seealso::
             :func:`cupy.random.multivariate_normal` for full documentation,

--- a/cupy/random/generator.py
+++ b/cupy/random/generator.py
@@ -611,7 +611,7 @@ class RandomState(object):
         return y
 
     def standard_exponential(self, size=None, dtype=float):
-        """Returns an array of samples drawn from a Standard Exponential distribution.
+        """Returns an array of samples drawn from the standard exp distribution.
 
         .. seealso::
             :func:`cupy.random.standard_exponential` for full documentation,

--- a/cupy/random/generator.py
+++ b/cupy/random/generator.py
@@ -108,10 +108,12 @@ rk_random(rk_state *state)
         }
         for (; i < N - 1; i++) {
             y = (state->key[i] & UPPER_MASK) | (state->key[i+1] & LOWER_MASK);
-            state->key[i] = state->key[i+(M-N)] ^ (y>>1) ^ (-(y & 1) & MATRIX_A);
+            state->key[i]
+                = state->key[i+(M-N)] ^ (y>>1) ^ (-(y & 1) & MATRIX_A);
         }
         y = (state->key[N - 1] & UPPER_MASK) | (state->key[0] & LOWER_MASK);
-        state->key[N - 1] = state->key[M - 1] ^ (y >> 1) ^ (-(y & 1) & MATRIX_A);
+        state->key[N - 1]
+            = state->key[M - 1] ^ (y >> 1) ^ (-(y & 1) & MATRIX_A);
 
         state->pos = 0;
     }

--- a/cupy/random/generator.py
+++ b/cupy/random/generator.py
@@ -89,7 +89,7 @@ class RandomState(object):
         return y
 
     def binomial(self, n, p, size=None, dtype=int):
-        """Returns an array of samples drawn from a Binomial distribution.
+        """Returns an array of samples drawn from a binomial distribution.
 
         .. seealso::
             :func:`cupy.random.binomial` for full documentation,
@@ -342,7 +342,7 @@ class RandomState(object):
         return ret.reshape(size)
 
     def laplace(self, loc=0.0, scale=1.0, size=None, dtype=float):
-        """Returns an array of samples drawn from the Laplace distribution.
+        """Returns an array of samples drawn from the laplace distribution.
 
         .. seealso::
             :func:`cupy.random.laplace` for full documentation,

--- a/cupy/random/generator.py
+++ b/cupy/random/generator.py
@@ -599,6 +599,21 @@ class RandomState(object):
         kernels._get_laplace_kernel()(x, loc, scale, x)
         return x
 
+    def pareto(self, a, size=None, dtype=float):
+        """Returns an array of samples drawn from a Pareto distribution.
+
+        .. seealso::
+            :func:`cupy.random.pareto_kernel` for full documentation,
+            :meth:`numpy.random.RandomState.pareto`
+        """
+        y = cupy.zeros(shape=size, dtype=dtype)
+        kernels._get_pareto_kernel()(a, self.rk_seed, y)
+        if size is None:
+            self.rk_seed += 1
+        else:
+            self.rk_seed += numpy.prod(size)
+        return y
+
     def poisson(self, lam=1.0, size=None, dtype=int):
         """Returns an array of samples drawn from a Poisson distribution.
 

--- a/cupy/random/generator.py
+++ b/cupy/random/generator.py
@@ -471,16 +471,19 @@ class RandomState(object):
             array = cupy.argsort(sample)
         return array
 
-    def binomial(self, n, p, size=None, dtype=float):
+    def binomial(self, n, p, size=None, dtype=int):
         """Returns an array of samples drawn from a Binomial distribution.
 
         .. seealso::
             :func:`cupy.random.binomial` for full documentation,
             :meth:`numpy.random.RandomState.binomial`
         """
-        x = self.uniform(size=size, dtype=dtype)
-        y = cupy.zeros_like(x, dtype=dtype)
-        kernels._get_binomial_kernel()(x, n, p, y)
+        y = cupy.zeros(shape=size, dtype=dtype)
+        kernels._get_binomial_kernel()(n, p, self.rk_seed, y)
+        if size is None:
+            self.rk_seed += 1
+        else:
+            self.rk_seed += numpy.prod(size)
         return y
 
     def beta(self, a, b, size=None, dtype=float):

--- a/cupy/random/generator.py
+++ b/cupy/random/generator.py
@@ -74,7 +74,7 @@ class RandomState(object):
     # NumPy compatible functions
 
     def beta(self, a, b, size=None, dtype=float):
-        """Returns an array of samples drawn from a Beta distribution.
+        """Returns an array of samples drawn from the beta distribution.
 
         .. seealso::
             :func:`cupy.random.beta` for full documentation,
@@ -89,7 +89,7 @@ class RandomState(object):
         return y
 
     def binomial(self, n, p, size=None, dtype=int):
-        """Returns an array of samples drawn from a binomial distribution.
+        """Returns an array of samples drawn from the binomial distribution.
 
         .. seealso::
             :func:`cupy.random.binomial` for full documentation,

--- a/cupy/random/generator.py
+++ b/cupy/random/generator.py
@@ -707,7 +707,7 @@ class RandomState(object):
         return x
 
 
-# TODO: move to kernels.py
+# TODO(YoshikawaMasashi): move to kernels.py
 def _cupy_permutation():
     return core.ElementwiseKernel(
         'raw int32 array, raw int32 sample, int32 j_start, int32 _j_end',

--- a/cupy/random/generator.py
+++ b/cupy/random/generator.py
@@ -212,7 +212,7 @@ class RandomState(object):
         return y
 
     def f(self, dfnum, dfden, size=None, dtype=float):
-        """Returns an array of samples drawn from the F distribution.
+        """Returns an array of samples drawn from the f distribution.
 
         .. seealso::
             :func:`cupy.random.f` for full documentation,

--- a/cupy/random/generator.py
+++ b/cupy/random/generator.py
@@ -584,6 +584,21 @@ class RandomState(object):
             self.rk_seed += numpy.prod(size)
         return y
 
+    def standard_cauchy(self, size=None, dtype=float):
+        """Returns an array of samples drawn from a Standard Cauchy distribution.
+
+        .. seealso::
+            :func:`cupy.random.standard_cauchy` for full documentation,
+            :meth:`numpy.random.RandomState.standard_cauchy`
+        """
+        y = cupy.zeros(shape=size, dtype=dtype)
+        kernels._get_standard_cauchy_kernel()(self.rk_seed, y)
+        if size is None:
+            self.rk_seed += 1
+        else:
+            self.rk_seed += numpy.prod(size)
+        return y
+
     def standard_t(self, df, size=None, dtype=float):
         """Returns an array of samples drawn from a Standard Student’s t distribution.
 
@@ -632,6 +647,7 @@ class RandomState(object):
         return x
 
 
+# TODO: move to kernels.py
 def _cupy_permutation():
     return core.ElementwiseKernel(
         'raw int32 array, raw int32 sample, int32 j_start, int32 _j_end',

--- a/cupy/random/kernels.py
+++ b/cupy/random/kernels.py
@@ -500,6 +500,223 @@ __device__ double rk_pareto(rk_state *state, double a)
 }
 '''
 
+rk_binomial_btpe_definition = '''
+__device__ long rk_binomial_btpe(rk_state *state, long n, double p)
+{
+    double r,q,fm,p1,xm,xl,xr,c,laml,lamr,p2,p3,p4;
+    double a,u,v,s,F,rho,t,A,nrq,x1,x2,f1,f2,z,z2,w,w2,x;
+    long m,y,k,i;
+
+    if (!(state->has_binomial) ||
+         (state->nsave != n) ||
+         (state->psave != p))
+    {
+        /* initialize */
+        state->nsave = n;
+        state->psave = p;
+        state->has_binomial = 1;
+        state->r = r = min(p, 1.0-p);
+        state->q = q = 1.0 - r;
+        state->fm = fm = n*r+r;
+        state->m = m = (long)floor(state->fm);
+        state->p1 = p1 = floor(2.195*sqrt(n*r*q)-4.6*q) + 0.5;
+        state->xm = xm = m + 0.5;
+        state->xl = xl = xm - p1;
+        state->xr = xr = xm + p1;
+        state->c = c = 0.134 + 20.5/(15.3 + m);
+        a = (fm - xl)/(fm-xl*r);
+        state->laml = laml = a*(1.0 + a/2.0);
+        a = (xr - fm)/(xr*q);
+        state->lamr = lamr = a*(1.0 + a/2.0);
+        state->p2 = p2 = p1*(1.0 + 2.0*c);
+        state->p3 = p3 = p2 + c/laml;
+        state->p4 = p4 = p3 + c/lamr;
+    }
+    else
+    {
+        r = state->r;
+        q = state->q;
+        fm = state->fm;
+        m = state->m;
+        p1 = state->p1;
+        xm = state->xm;
+        xl = state->xl;
+        xr = state->xr;
+        c = state->c;
+        laml = state->laml;
+        lamr = state->lamr;
+        p2 = state->p2;
+        p3 = state->p3;
+        p4 = state->p4;
+    }
+
+  /* sigh ... */
+  Step10:
+    nrq = n*r*q;
+    u = rk_double(state)*p4;
+    v = rk_double(state);
+    if (u > p1) goto Step20;
+    y = (long)floor(xm - p1*v + u);
+    goto Step60;
+
+  Step20:
+    if (u > p2) goto Step30;
+    x = xl + (u - p1)/c;
+    v = v*c + 1.0 - fabs(m - x + 0.5)/p1;
+    if (v > 1.0) goto Step10;
+    y = (long)floor(x);
+    goto Step50;
+
+  Step30:
+    if (u > p3) goto Step40;
+    y = (long)floor(xl + log(v)/laml);
+    if (y < 0) goto Step10;
+    v = v*(u-p2)*laml;
+    goto Step50;
+
+  Step40:
+    y = (long)floor(xr - log(v)/lamr);
+    if (y > n) goto Step10;
+    v = v*(u-p3)*lamr;
+
+  Step50:
+    k = labs(y - m);
+    if ((k > 20) && (k < ((nrq)/2.0 - 1))) goto Step52;
+
+    s = r/q;
+    a = s*(n+1);
+    F = 1.0;
+    if (m < y)
+    {
+        for (i=m+1; i<=y; i++)
+        {
+            F *= (a/i - s);
+        }
+    }
+    else if (m > y)
+    {
+        for (i=y+1; i<=m; i++)
+        {
+            F /= (a/i - s);
+        }
+    }
+    if (v > F) goto Step10;
+    goto Step60;
+
+    Step52:
+    rho = (k/(nrq))*((k*(k/3.0 + 0.625) + 0.16666666666666666)/nrq + 0.5);
+    t = -k*k/(2*nrq);
+    A = log(v);
+    if (A < (t - rho)) goto Step60;
+    if (A > (t + rho)) goto Step10;
+
+    x1 = y+1;
+    f1 = m+1;
+    z = n+1-m;
+    w = n-y+1;
+    x2 = x1*x1;
+    f2 = f1*f1;
+    z2 = z*z;
+    w2 = w*w;
+    if (A > (xm*log(f1/x1)
+           + (n-m+0.5)*log(z/w)
+           + (y-m)*log(w*r/(x1*q))
+           + (13680.-(462.-(132.-(99.-140./f2)/f2)/f2)/f2)/f1/166320.
+           + (13680.-(462.-(132.-(99.-140./z2)/z2)/z2)/z2)/z/166320.
+           + (13680.-(462.-(132.-(99.-140./x2)/x2)/x2)/x2)/x1/166320.
+           + (13680.-(462.-(132.-(99.-140./w2)/w2)/w2)/w2)/w/166320.))
+    {
+        goto Step10;
+    }
+
+  Step60:
+    if (p > 0.5)
+    {
+        y = n - y;
+    }
+
+    return y;
+}
+'''
+
+
+rk_binomial_inversion_definition = '''
+__device__ long rk_binomial_inversion(rk_state *state, long n, double p)
+{
+    double q, qn, np, px, U;
+    long X, bound;
+
+    if (!(state->has_binomial) ||
+         (state->nsave != n) ||
+         (state->psave != p))
+    {
+        state->nsave = n;
+        state->psave = p;
+        state->has_binomial = 1;
+        state->q = q = 1.0 - p;
+        state->r = qn = exp(n * log(q));
+        state->c = np = n*p;
+        state->m = bound = min((double)n, np + 10.0*sqrt(np*q + 1));
+    } else
+    {
+        q = state->q;
+        qn = state->r;
+        np = state->c;
+        bound = state->m;
+    }
+    X = 0;
+    px = qn;
+    U = rk_double(state);
+    while (U > px)
+    {
+        X++;
+        if (X > bound)
+        {
+            X = 0;
+            px = qn;
+            U = rk_double(state);
+        } else
+        {
+            U -= px;
+            px  = ((n-X+1) * p * px)/(X*q);
+        }
+    }
+    return X;
+}
+'''
+
+rk_binomial_definition = '''
+__device__ long rk_binomial(rk_state *state, long n, double p)
+{
+    double q;
+
+    if (p <= 0.5)
+    {
+        if (p*n <= 30.0)
+        {
+            return rk_binomial_inversion(state, n, p);
+        }
+        else
+        {
+            return rk_binomial_btpe(state, n, p);
+        }
+    }
+    else
+    {
+        q = 1.0-p;
+        if (q*n <= 30.0)
+        {
+            return n - rk_binomial_inversion(state, n, q);
+        }
+        else
+        {
+            return n - rk_binomial_btpe(state, n, q);
+        }
+    }
+
+}
+'''
+
 
 def _get_beta_kernel():
     global _beta_kernel
@@ -522,22 +739,22 @@ def _get_beta_kernel():
     return _beta_kernel
 
 
-# TODO(YoshikawaMasashi): implementation of BTPE same as numpy
 def _get_binomial_kernel():
     global _binomial_kernel
     if _binomial_kernel is None:
+        definitions = \
+            [rk_state_difinition, rk_seed_definition, rk_random_definition,
+             rk_double_definition, rk_binomial_btpe_definition,
+             rk_binomial_inversion_definition, rk_binomial_definition]
         _binomial_kernel = core.ElementwiseKernel(
-            'T x, T n, T p', 'T y',
+            'T n, T p, T seed', 'T y',
             '''
-            y = 0.;
-            T px = exp(n * log(1-p));
-            while(x > px){
-                y += 1.;
-                x -= px;
-                px = ((n-y+1) * p * px)/(y*(1-p));
-            }
+            rk_seed(seed + i, &internal_state);
+            y = rk_binomial(&internal_state, n, p);
             ''',
-            'binomial_kernel'
+            'binomial_kernel',
+            preamble=''.join(definitions),
+            loop_prep="rk_state internal_state;"
         )
     return _binomial_kernel
 

--- a/cupy/random/kernels.py
+++ b/cupy/random/kernels.py
@@ -7,6 +7,7 @@ _gumbel_kernel = None
 _laplace_kernel = None
 _poisson_kernel = None
 _standard_cauchy_kernel = None
+_standard_exponential_kernel = None
 _standard_gamma_kernel = None
 _standard_t_kernel = None
 
@@ -561,6 +562,25 @@ def _get_standard_cauchy_kernel():
             loop_prep="rk_state internal_state;"
         )
     return _standard_cauchy_kernel
+
+
+def _get_standard_exponential_kernel():
+    global _standard_exponential_kernel
+    if _standard_exponential_kernel is None:
+        definitions = \
+            [rk_state_difinition, rk_seed_definition, rk_random_definition,
+             rk_double_definition, rk_standard_exponential_definition]
+        _standard_exponential_kernel = core.ElementwiseKernel(
+            'T seed', 'T y',
+            '''
+            rk_seed(seed + i, &internal_state);
+            y = rk_standard_exponential(&internal_state);
+            ''',
+            'standard_exponential_kernel',
+            preamble=''.join(definitions),
+            loop_prep="rk_state internal_state;"
+        )
+    return _standard_exponential_kernel
 
 
 def _get_standard_gamma_kernel():

--- a/cupy/random/kernels.py
+++ b/cupy/random/kernels.py
@@ -747,7 +747,7 @@ def _get_binomial_kernel():
              rk_double_definition, rk_binomial_btpe_definition,
              rk_binomial_inversion_definition, rk_binomial_definition]
         _binomial_kernel = core.ElementwiseKernel(
-            'T n, T p, T seed', 'T y',
+            'T n, float64 p, T seed', 'T y',
             '''
             rk_seed(seed + i, &internal_state);
             y = rk_binomial(&internal_state, n, p);

--- a/cupy/random/kernels.py
+++ b/cupy/random/kernels.py
@@ -1,0 +1,575 @@
+from cupy import core
+
+_beta_kernel = None
+_binomial_kernel = None
+_chisquare_kernel = None
+_gumbel_kernel = None
+_laplace_kernel = None
+_poisson_kernel = None
+_standard_gamma_kernel = None
+_standard_t_kernel = None
+
+
+loggam_difinition = '''
+/*
+ * log-gamma function to support some of these distributions. The
+ * algorithm comes from SPECFUN by Shanjie Zhang and Jianming Jin and their
+ * book "Computation of Special Functions", 1996, John Wiley & Sons, Inc.
+ */
+static __device__ double loggam(double x)
+{
+    double x0, x2, xp, gl, gl0;
+    long k, n;
+
+    static double a[10] = {8.333333333333333e-02,-2.777777777777778e-03,
+         7.936507936507937e-04,-5.952380952380952e-04,
+         8.417508417508418e-04,-1.917526917526918e-03,
+         6.410256410256410e-03,-2.955065359477124e-02,
+         1.796443723688307e-01,-1.39243221690590e+00};
+    x0 = x;
+    n = 0;
+    if ((x == 1.0) || (x == 2.0))
+    {
+        return 0.0;
+    }
+    else if (x <= 7.0)
+    {
+        n = (long)(7 - x);
+        x0 = x + n;
+    }
+    x2 = 1.0/(x0*x0);
+    xp = 2*M_PI;
+    gl0 = a[9];
+    for (k=8; k>=0; k--)
+    {
+        gl0 *= x2;
+        gl0 += a[k];
+    }
+    gl = gl0/x0 + 0.5*log(xp) + (x0-0.5)*log(x0) - x0;
+    if (x <= 7.0)
+    {
+        for (k=1; k<=n; k++)
+        {
+            gl -= log(x0-1.0);
+            x0 -= 1.0;
+        }
+    }
+    return gl;
+}
+'''
+
+
+rk_state_difinition = '''
+#define RK_STATE_LEN 624
+
+typedef struct rk_state_
+{
+    unsigned long key[RK_STATE_LEN];
+    int pos;
+    int has_gauss; /* !=0: gauss contains a gaussian deviate */
+    double gauss;
+
+    /* The rk_state structure has been extended to store the following
+     * information for the binomial generator. If the input values of n or p
+     * are different than nsave and psave, then the other parameters will be
+     * recomputed. RTK 2005-09-02 */
+
+    int has_binomial; /* !=0: following parameters initialized for
+                              binomial */
+    double psave;
+    long nsave;
+    double r;
+    double q;
+    double fm;
+    long m;
+    double p1;
+    double xm;
+    double xl;
+    double xr;
+    double c;
+    double laml;
+    double lamr;
+    double p2;
+    double p3;
+    double p4;
+
+}
+rk_state;
+'''
+
+
+rk_seed_definition = '''
+__device__ void
+rk_seed(unsigned long seed, rk_state *state)
+{
+    int pos;
+    seed &= 0xffffffffUL;
+
+    /* Knuth's PRNG as used in the Mersenne Twister reference implementation */
+    for (pos = 0; pos < RK_STATE_LEN; pos++) {
+        state->key[pos] = seed;
+        seed = (1812433253UL * (seed ^ (seed >> 30)) + pos + 1) & 0xffffffffUL;
+    }
+    state->pos = RK_STATE_LEN;
+    state->gauss = 0;
+    state->has_gauss = 0;
+    state->has_binomial = 0;
+}
+'''
+
+
+rk_random_definition = '''
+/* Magic Mersenne Twister constants */
+#define N 624
+#define M 397
+#define MATRIX_A 0x9908b0dfUL
+#define UPPER_MASK 0x80000000UL
+#define LOWER_MASK 0x7fffffffUL
+
+/*
+ * Slightly optimised reference implementation of the Mersenne Twister
+ * Note that regardless of the precision of long, only 32 bit random
+ * integers are produced
+ */
+__device__ unsigned long
+rk_random(rk_state *state)
+{
+    unsigned long y;
+
+    if (state->pos == RK_STATE_LEN) {
+        int i;
+
+        for (i = 0; i < N - M; i++) {
+            y = (state->key[i] & UPPER_MASK) | (state->key[i+1] & LOWER_MASK);
+            state->key[i] = state->key[i+M] ^ (y>>1) ^ (-(y & 1) & MATRIX_A);
+        }
+        for (; i < N - 1; i++) {
+            y = (state->key[i] & UPPER_MASK) | (state->key[i+1] & LOWER_MASK);
+            state->key[i]
+                = state->key[i+(M-N)] ^ (y>>1) ^ (-(y & 1) & MATRIX_A);
+        }
+        y = (state->key[N - 1] & UPPER_MASK) | (state->key[0] & LOWER_MASK);
+        state->key[N - 1]
+            = state->key[M - 1] ^ (y >> 1) ^ (-(y & 1) & MATRIX_A);
+
+        state->pos = 0;
+    }
+    y = state->key[state->pos++];
+
+    /* Tempering */
+    y ^= (y >> 11);
+    y ^= (y << 7) & 0x9d2c5680UL;
+    y ^= (y << 15) & 0xefc60000UL;
+    y ^= (y >> 18);
+
+    return y;
+}
+'''
+
+
+rk_double_definition = '''
+__device__ double
+rk_double(rk_state *state)
+{
+    /* shifts : 67108864 = 0x4000000, 9007199254740992 = 0x20000000000000 */
+    long a = rk_random(state) >> 5, b = rk_random(state) >> 6;
+    return (a * 67108864.0 + b) / 9007199254740992.0;
+}
+'''
+
+
+rk_gauss_definition = '''
+__device__ double
+rk_gauss(rk_state *state)
+{
+    if (state->has_gauss) {
+        const double tmp = state->gauss;
+        state->gauss = 0;
+        state->has_gauss = 0;
+        return tmp;
+    }
+    else {
+        double f, x1, x2, r2;
+
+        do {
+            x1 = 2.0*rk_double(state) - 1.0;
+            x2 = 2.0*rk_double(state) - 1.0;
+            r2 = x1*x1 + x2*x2;
+        }
+        while (r2 >= 1.0 || r2 == 0.0);
+
+        /* Box-Muller transform */
+        f = sqrt(-2.0*log(r2)/r2);
+        /* Keep for next call */
+        state->gauss = f*x1;
+        state->has_gauss = 1;
+        return f*x2;
+    }
+}
+'''
+
+
+rk_standard_exponential_definition = '''
+__device__ double rk_standard_exponential(rk_state *state)
+{
+    /* We use -log(1-U) since U is [0, 1) */
+    return -log(1.0 - rk_double(state));
+}
+'''
+
+
+rk_standard_gamma_definition = '''
+__device__ double rk_standard_gamma(rk_state *state, double shape)
+{
+    double b, c;
+    double U, V, X, Y;
+
+    if (shape == 1.0)
+    {
+        return rk_standard_exponential(state);
+    }
+    else if (shape < 1.0)
+    {
+        for (;;)
+        {
+            U = rk_double(state);
+            V = rk_standard_exponential(state);
+            if (U <= 1.0 - shape)
+            {
+                X = pow(U, 1./shape);
+                if (X <= V)
+                {
+                    return X;
+                }
+            }
+            else
+            {
+                Y = -log((1-U)/shape);
+                X = pow(1.0 - shape + shape*Y, 1./shape);
+                if (X <= (V + Y))
+                {
+                    return X;
+                }
+            }
+        }
+    }
+    else
+    {
+        b = shape - 1./3.;
+        c = 1./sqrt(9*b);
+        for (;;)
+        {
+            do
+            {
+                X = rk_gauss(state);
+                V = 1.0 + c*X;
+            } while (V <= 0.0);
+
+            V = V*V*V;
+            U = rk_double(state);
+            if (U < 1.0 - 0.0331*(X*X)*(X*X)) return (b*V);
+            if (log(U) < 0.5*X*X + b*(1. - V + log(V))) return (b*V);
+        }
+    }
+}
+'''
+
+
+rk_beta_definition = '''
+__device__ double rk_beta(rk_state *state, double a, double b)
+{
+    double Ga, Gb;
+
+    if ((a <= 1.0) && (b <= 1.0))
+    {
+        double U, V, X, Y;
+        /* Use Johnk's algorithm */
+
+        while (1)
+        {
+            U = rk_double(state);
+            V = rk_double(state);
+            X = pow(U, 1.0/a);
+            Y = pow(V, 1.0/b);
+
+            if ((X + Y) <= 1.0)
+            {
+                if (X +Y > 0)
+                {
+                    return X / (X + Y);
+                }
+                else
+                {
+                    double logX = log(U) / a;
+                    double logY = log(V) / b;
+                    double logM = logX > logY ? logX : logY;
+                    logX -= logM;
+                    logY -= logM;
+
+                    return exp(logX - log(exp(logX) + exp(logY)));
+                }
+            }
+        }
+    }
+    else
+    {
+        Ga = rk_standard_gamma(state, a);
+        Gb = rk_standard_gamma(state, b);
+        return Ga/(Ga + Gb);
+    }
+}
+'''
+
+rk_chisquare_definition = '''
+__device__ double rk_chisquare(rk_state *state, double df)
+{
+    return 2.0*rk_standard_gamma(state, df/2.0);
+}
+'''
+
+rk_standard_t_definition = '''
+__device__ double rk_standard_t(rk_state *state, double df)
+{
+    return sqrt(df/2)*rk_gauss(state)/sqrt(rk_standard_gamma(state, df/2));
+}
+'''
+
+
+rk_poisson_mult_definition = '''
+__device__ long rk_poisson_mult(rk_state *state, double lam)
+{
+    long X;
+    double prod, U, enlam;
+
+    enlam = exp(-lam);
+    X = 0;
+    prod = 1.0;
+    while (1)
+    {
+        U = rk_double(state);
+        prod *= U;
+        if (prod > enlam)
+        {
+            X += 1;
+        }
+        else
+        {
+            return X;
+        }
+    }
+}
+'''
+
+
+rk_poisson_ptrs_definition = '''
+/*
+ * The transformed rejection method for generating Poisson random variables
+ * W. Hoermann
+ * Insurance: Mathematics and Economics 12, 39-45 (1993)
+ */
+#define LS2PI 0.91893853320467267
+#define TWELFTH 0.083333333333333333333333
+__device__ long rk_poisson_ptrs(rk_state *state, double lam)
+{
+    long k;
+    double U, V, slam, loglam, a, b, invalpha, vr, us;
+
+    slam = sqrt(lam);
+    loglam = log(lam);
+    b = 0.931 + 2.53*slam;
+    a = -0.059 + 0.02483*b;
+    invalpha = 1.1239 + 1.1328/(b-3.4);
+    vr = 0.9277 - 3.6224/(b-2);
+
+    while (1)
+    {
+        U = rk_double(state) - 0.5;
+        V = rk_double(state);
+        us = 0.5 - fabs(U);
+        k = (long)floor((2*a/us + b)*U + lam + 0.43);
+        if ((us >= 0.07) && (V <= vr))
+        {
+            return k;
+        }
+        if ((k < 0) ||
+            ((us < 0.013) && (V > us)))
+        {
+            continue;
+        }
+        if ((log(V) + log(invalpha) - log(a/(us*us)+b)) <=
+            (-lam + k*loglam - loggam(k+1)))
+        {
+            return k;
+        }
+
+
+    }
+
+}
+'''
+
+
+rk_poisson_definition = '''
+__device__ long rk_poisson(rk_state *state, double lam)
+{
+    if (lam >= 10)
+    {
+        return rk_poisson_ptrs(state, lam);
+    }
+    else if (lam == 0)
+    {
+        return 0;
+    }
+    else
+    {
+        return rk_poisson_mult(state, lam);
+    }
+}
+'''
+
+
+def _get_beta_kernel():
+    global _beta_kernel
+    if _beta_kernel is None:
+        definitions = \
+            [rk_state_difinition, rk_seed_definition, rk_random_definition,
+             rk_double_definition, rk_gauss_definition,
+             rk_standard_exponential_definition, rk_standard_gamma_definition,
+             rk_beta_definition]
+        _beta_kernel = core.ElementwiseKernel(
+            'T a, T b, T seed', 'T y',
+            '''
+            rk_seed(seed + i, &internal_state);
+            y = rk_beta(&internal_state, a, b);
+            ''',
+            'beta_kernel',
+            preamble=''.join(definitions),
+            loop_prep="rk_state internal_state;"
+        )
+    return _beta_kernel
+
+
+# TODO(YoshikawaMasashi): implementation of BTPE same as numpy
+def _get_binomial_kernel():
+    global _binomial_kernel
+    if _binomial_kernel is None:
+        _binomial_kernel = core.ElementwiseKernel(
+            'T x, T n, T p', 'T y',
+            '''
+            y = 0.;
+            T px = exp(n * log(1-p));
+            while(x > px){
+                y += 1.;
+                x -= px;
+                px = ((n-y+1) * p * px)/(y*(1-p));
+            }
+            ''',
+            'binomial_kernel'
+        )
+    return _binomial_kernel
+
+
+def _get_chisquare_kernel():
+    global _chisquare_kernel
+    if _chisquare_kernel is None:
+        definitions = \
+            [rk_state_difinition, rk_seed_definition, rk_random_definition,
+             rk_double_definition, rk_gauss_definition,
+             rk_standard_exponential_definition, rk_standard_gamma_definition,
+             rk_chisquare_definition]
+        _chisquare_kernel = core.ElementwiseKernel(
+            'T df, T seed', 'T y',
+            '''
+            rk_seed(seed + i, &internal_state);
+            y = rk_chisquare(&internal_state, df);
+            ''',
+            'beta_kernel',
+            preamble=''.join(definitions),
+            loop_prep="rk_state internal_state;"
+        )
+    return _chisquare_kernel
+
+
+def _get_gumbel_kernel():
+    global _gumbel_kernel
+    if _gumbel_kernel is None:
+        _gumbel_kernel = core.ElementwiseKernel(
+            'T x, T loc, T scale', 'T y',
+            'y = loc - log(-log(1 - x)) * scale',
+            'gumbel_kernel'
+        )
+    return _gumbel_kernel
+
+
+def _get_laplace_kernel():
+    global _laplace_kernel
+    if _laplace_kernel is None:
+        _laplace_kernel = core.ElementwiseKernel(
+            'T x, T loc, T scale', 'T y',
+            'y = (x < 0.5)? loc + scale * log(x + x):'
+            ' loc - scale * log(2.0 - x - x)',
+            'laplace_kernel'
+        )
+    return _laplace_kernel
+
+
+def _get_poisson_kernel():
+    global _poisson_kernel
+    if _poisson_kernel is None:
+        definitions = \
+            [rk_state_difinition, rk_seed_definition, rk_random_definition,
+             rk_double_definition, loggam_difinition,
+             rk_poisson_mult_definition, rk_poisson_ptrs_definition,
+             rk_poisson_definition]
+        _poisson_kernel = core.ElementwiseKernel(
+            'T lam, T seed', 'T y',
+            '''
+            rk_seed(seed + i, &internal_state);
+            y = rk_poisson(&internal_state, lam);
+            ''',
+            'poisson_kernel',
+            preamble=''.join(definitions),
+            loop_prep="rk_state internal_state;"
+        )
+    return _poisson_kernel
+
+
+def _get_standard_gamma_kernel():
+    global _standard_gamma_kernel
+    if _standard_gamma_kernel is None:
+        definitions = \
+            [rk_state_difinition, rk_seed_definition, rk_random_definition,
+             rk_double_definition, rk_gauss_definition,
+             rk_standard_exponential_definition, rk_standard_gamma_definition]
+        _standard_gamma_kernel = core.ElementwiseKernel(
+            'T shape, T seed', 'T y',
+            '''
+            rk_seed(seed + i, &internal_state);
+            y = rk_standard_gamma(&internal_state, shape);
+            ''',
+            'standard_gamma_kernel',
+            preamble=''.join(definitions),
+            loop_prep="rk_state internal_state;"
+        )
+    return _standard_gamma_kernel
+
+
+def _get_standard_t_kernel():
+    global _standard_t_kernel
+    if _standard_t_kernel is None:
+        definitions = \
+            [rk_state_difinition, rk_seed_definition, rk_random_definition,
+             rk_double_definition, rk_gauss_definition,
+             rk_standard_exponential_definition, rk_standard_gamma_definition,
+             rk_standard_t_definition]
+        _standard_t_kernel = core.ElementwiseKernel(
+            'T df, T seed', 'T y',
+            '''
+            rk_seed(seed + i, &internal_state);
+            y = rk_standard_t(&internal_state, df);
+            ''',
+            'standard_t_kernel',
+            preamble=''.join(definitions),
+            loop_prep="rk_state internal_state;"
+        )
+    return _standard_t_kernel

--- a/cupy/random/kernels.py
+++ b/cupy/random/kernels.py
@@ -6,6 +6,7 @@ _chisquare_kernel = None
 _gumbel_kernel = None
 _laplace_kernel = None
 _poisson_kernel = None
+_standard_cauchy_kernel = None
 _standard_gamma_kernel = None
 _standard_t_kernel = None
 
@@ -428,6 +429,14 @@ __device__ long rk_poisson(rk_state *state, double lam)
 '''
 
 
+rk_standard_cauchy_definition = '''
+__device__ double rk_standard_cauchy(rk_state *state)
+{
+    return rk_gauss(state) / rk_gauss(state);
+}
+'''
+
+
 def _get_beta_kernel():
     global _beta_kernel
     if _beta_kernel is None:
@@ -532,6 +541,26 @@ def _get_poisson_kernel():
             loop_prep="rk_state internal_state;"
         )
     return _poisson_kernel
+
+
+def _get_standard_cauchy_kernel():
+    global _standard_cauchy_kernel
+    if _standard_cauchy_kernel is None:
+        definitions = \
+            [rk_state_difinition, rk_seed_definition, rk_random_definition,
+             rk_double_definition, rk_gauss_definition,
+             rk_standard_cauchy_definition]
+        _standard_cauchy_kernel = core.ElementwiseKernel(
+            'T seed', 'T y',
+            '''
+            rk_seed(seed + i, &internal_state);
+            y = rk_standard_cauchy(&internal_state);
+            ''',
+            'standard_gamma_kernel',
+            preamble=''.join(definitions),
+            loop_prep="rk_state internal_state;"
+        )
+    return _standard_cauchy_kernel
 
 
 def _get_standard_gamma_kernel():

--- a/cupy/random/kernels.py
+++ b/cupy/random/kernels.py
@@ -7,6 +7,7 @@ _f_kernel = None
 _geometric_kernel = None
 _gumbel_kernel = None
 _laplace_kernel = None
+_pareto_kernel = None
 _poisson_kernel = None
 _standard_cauchy_kernel = None
 _standard_exponential_kernel = None
@@ -492,6 +493,14 @@ __device__ long rk_geometric(rk_state *state, double p)
 '''
 
 
+rk_pareto_definition = '''
+__device__ double rk_pareto(rk_state *state, double a)
+{
+    return exp(rk_standard_exponential(state)/a) - 1;
+}
+'''
+
+
 def _get_beta_kernel():
     global _beta_kernel
     if _beta_kernel is None:
@@ -616,6 +625,26 @@ def _get_laplace_kernel():
             'laplace_kernel'
         )
     return _laplace_kernel
+
+
+def _get_pareto_kernel():
+    global _pareto_kernel
+    if _pareto_kernel is None:
+        definitions = \
+            [rk_state_difinition, rk_seed_definition, rk_random_definition,
+             rk_double_definition, rk_standard_exponential_definition,
+             rk_pareto_definition]
+        _pareto_kernel = core.ElementwiseKernel(
+            'T a, T seed', 'T y',
+            '''
+            rk_seed(seed + i, &internal_state);
+            y = rk_pareto(&internal_state, a);
+            ''',
+            'pareto_kernel',
+            preamble=''.join(definitions),
+            loop_prep="rk_state internal_state;"
+        )
+    return _pareto_kernel
 
 
 def _get_poisson_kernel():

--- a/tests/cupy_tests/random_tests/test_generator.py
+++ b/tests/cupy_tests/random_tests/test_generator.py
@@ -583,6 +583,83 @@ class TestBeta(RandomGeneratorTestCase):
         self.generate(a=self.a, b=self.b, size=(3, 2))
 
 
+@testing.parameterize(
+    {'df': 1.0},
+    {'df': 3.0},
+    {'df': 10.0},
+)
+@testing.gpu
+@testing.fix_random()
+class TestChisquare(RandomGeneratorTestCase):
+
+    target_method = 'chisquare'
+
+    def test_chisquare(self):
+        self.generate(df=self.df, size=(3, 2))
+
+
+@testing.gpu
+@testing.parameterize(
+    {'alpha': cupy.array([1.0, 1.0, 1.0])},
+    {'alpha': cupy.array([1.0, 3.0, 5.0])},
+)
+@testing.fix_random()
+class TestDirichlet(RandomGeneratorTestCase):
+
+    target_method = 'dirichlet'
+
+    def test_dirichlet(self):
+        self.generate(alpha=self.alpha, size=(3, 2, 3))
+
+
+@testing.parameterize(
+    {'dfnum': 1.0, 'dfden': 3.0},
+    {'dfnum': 3.0, 'dfden': 3.0},
+    {'dfnum': 3.0, 'dfden': 1.0},
+)
+@testing.gpu
+@testing.fix_random()
+class TestF(RandomGeneratorTestCase):
+
+    target_method = 'f'
+
+    def test_f(self):
+        self.generate(dfnum=self.dfnum, dfden=self.dfden, size=(3, 2))
+
+
+@testing.parameterize(
+    {'shape': 1.0, 'scale': 3.0},
+    {'shape': 3.0, 'scale': 3.0},
+    {'shape': 3.0, 'scale': 1.0},
+)
+@testing.gpu
+@testing.fix_random()
+class TestGamma(RandomGeneratorTestCase):
+
+    target_method = 'gamma'
+
+    def test_gamma_1(self):
+        self.generate(shape=self.shape, scale=self.scale, size=(3, 2))
+
+    def test_gamma_2(self):
+        self.generate(shape=self.shape, size=(3, 2))
+
+
+@testing.parameterize(
+    {'p': 0.5},
+    {'p': 0.1},
+    {'p': 1.0},
+)
+@testing.gpu
+@testing.fix_random()
+class TestGeometric(RandomGeneratorTestCase):
+
+    target_method = 'geometric'
+
+    def test_geometric(self):
+        self.generate(p=self.p, size=(3, 2))
+
+
 @testing.gpu
 @testing.fix_random()
 class TestGumbel(RandomGeneratorTestCase):
@@ -615,6 +692,36 @@ class TestLaplace(RandomGeneratorTestCase):
         self.generate(0.0, 1.0, size=(3, 2))
 
 
+@testing.parameterize(
+    {'a': 1.0},
+    {'a': 3.0},
+    {'a': 10.0},
+)
+@testing.gpu
+@testing.fix_random()
+class TestPareto(RandomGeneratorTestCase):
+
+    target_method = 'pareto'
+
+    def test_pareto(self):
+        self.generate(a=self.a, size=(3, 2))
+
+
+@testing.parameterize(
+    {'lam': 1.0},
+    {'lam': 3.0},
+    {'lam': 10.0},
+)
+@testing.gpu
+@testing.fix_random()
+class TestPoisson(RandomGeneratorTestCase):
+
+    target_method = 'poisson'
+
+    def test_poisson(self):
+        self.generate(lam=self.lam, size=(3, 2))
+
+
 @testing.gpu
 @testing.fix_random()
 class TestRandint(RandomGeneratorTestCase):
@@ -629,6 +736,41 @@ class TestRandint(RandomGeneratorTestCase):
 
     def test_randint_2(self):
         self.generate(3, 4, size=(3, 2))
+
+
+@testing.parameterize(
+    {'df': 1.0},
+    {'df': 3.0},
+    {'df': 10.0},
+)
+@testing.gpu
+@testing.fix_random()
+class TestStandardT(RandomGeneratorTestCase):
+
+    target_method = 'standard_t'
+
+    def test_standard_t(self):
+        self.generate(df=self.df, size=(3, 2))
+
+
+@testing.gpu
+@testing.fix_random()
+class TestStandardCauchy(RandomGeneratorTestCase):
+
+    target_method = 'standard_cauchy'
+
+    def test_standard_cauchy(self):
+        self.generate(size=(3, 2))
+
+
+@testing.gpu
+@testing.fix_random()
+class TestStandardExponential(RandomGeneratorTestCase):
+
+    target_method = 'standard_exponential'
+
+    def test_standard_exponential(self):
+        self.generate(size=(3, 2))
 
 
 @testing.gpu

--- a/tests/cupy_tests/random_tests/test_generator.py
+++ b/tests/cupy_tests/random_tests/test_generator.py
@@ -173,6 +173,40 @@ class TestNormal(RandomGeneratorTestCase):
 
 @testing.gpu
 @testing.parameterize(*[
+    {'args': ([0., 0.], [[1., 0.], [0., 1.]]), 'size': None, 'tol': 1e-6},
+    {'args': ([10., 10.], [[20., 10.], [10., 20.]]), 'size': None, 'tol': 1e-6},
+    {'args': ([0., 0.], [[1., 0.], [0., 1.]]), 'size': 10, 'tol': 1e-6},
+    {'args': ([0., 0.], [[1., 0.], [0., 1.]]), 'size': (1, 2, 3), 'tol': 1e-6},
+    {'args': ([0., 0.], [[1., 0.], [0., 1.]]), 'size': 3, 'tol': 1e-6},
+    {'args': ([0., 0.], [[1., 0.], [0., 1.]]), 'size': (3, 3), 'tol': 1e-6},
+    {'args': ([0., 0.], [[1., 0.], [0., 1.]]), 'size': (), 'tol': 1e-6},
+])
+@testing.fix_random()
+class TestMultivariateNormal(RandomGeneratorTestCase):
+
+    target_method = 'multivariate_normal'
+
+    def check_multivariate_normal(self, dtype):
+        vals = self.generate_many(
+            mean=self.args[0], cov=self.args[1], size=self.size, tol=self.tol, 
+            dtype=dtype, _count=10)
+
+        shape = core.get_size(self.size)
+        for val in vals:
+            assert isinstance(val, cupy.ndarray)
+            assert val.dtype == dtype
+            assert val.shape == shape + (2,)
+        # TODO(niboshi): Distribution test
+
+    def test_multivariate_normal_float32(self):
+        self.check_multivariate_normal(numpy.float32)
+
+    def test_multivariate_normal_float64(self):
+        self.check_multivariate_normal(numpy.float64)
+
+
+@testing.gpu
+@testing.parameterize(*[
     {'size': None},
     {'size': 10},
     {'size': (1, 2, 3)},
@@ -529,6 +563,22 @@ class TestGumbel(RandomGeneratorTestCase):
         self.generate()
 
     def test_gumbel_2(self):
+        self.generate(0.0, 1.0, size=(3, 2))
+
+
+@testing.gpu
+@testing.fix_random()
+class TestLaplace(RandomGeneratorTestCase):
+    # TODO(niboshi):
+    #   Test soundness of distribution.
+    #   Currently only reprocibility is checked.
+
+    target_method = 'laplace'
+
+    def test_laplace_1(self):
+        self.generate()
+
+    def test_laplace_2(self):
         self.generate(0.0, 1.0, size=(3, 2))
 
 

--- a/tests/cupy_tests/random_tests/test_generator.py
+++ b/tests/cupy_tests/random_tests/test_generator.py
@@ -174,7 +174,8 @@ class TestNormal(RandomGeneratorTestCase):
 @testing.gpu
 @testing.parameterize(*[
     {'args': ([0., 0.], [[1., 0.], [0., 1.]]), 'size': None, 'tol': 1e-6},
-    {'args': ([10., 10.], [[20., 10.], [10., 20.]]), 'size': None, 'tol': 1e-6},
+    {'args': ([10., 10.], [[20., 10.], [10., 20.]]),
+     'size': None, 'tol': 1e-6},
     {'args': ([0., 0.], [[1., 0.], [0., 1.]]), 'size': 10, 'tol': 1e-6},
     {'args': ([0., 0.], [[1., 0.], [0., 1.]]), 'size': (1, 2, 3), 'tol': 1e-6},
     {'args': ([0., 0.], [[1., 0.], [0., 1.]]), 'size': 3, 'tol': 1e-6},
@@ -188,7 +189,7 @@ class TestMultivariateNormal(RandomGeneratorTestCase):
 
     def check_multivariate_normal(self, dtype):
         vals = self.generate_many(
-            mean=self.args[0], cov=self.args[1], size=self.size, tol=self.tol, 
+            mean=self.args[0], cov=self.args[1], size=self.size, tol=self.tol,
             dtype=dtype, _count=10)
 
         shape = core.get_size(self.size)

--- a/tests/cupy_tests/random_tests/test_generator.py
+++ b/tests/cupy_tests/random_tests/test_generator.py
@@ -551,6 +551,24 @@ class TestChoiceReplaceFalse(RandomGeneratorTestCase):
         self.assertEqual(numpy.unique(val).size, val.size)
 
 
+@testing.parameterize(
+    {'n': 5, 'p': 0.5},
+    {'n': 5, 'p': 0.0},
+    {'n': 5, 'p': 1.0},
+)
+@testing.gpu
+@testing.fix_random()
+class TestBinomial(RandomGeneratorTestCase):
+    # TODO(niboshi):
+    #   Test soundness of distribution.
+    #   Currently only reprocibility is checked.
+
+    target_method = 'binomial'
+
+    def test_laplace(self):
+        self.generate(n=self.n, p=self.p, size=(3, 2))
+
+
 @testing.gpu
 @testing.fix_random()
 class TestGumbel(RandomGeneratorTestCase):

--- a/tests/cupy_tests/random_tests/test_generator.py
+++ b/tests/cupy_tests/random_tests/test_generator.py
@@ -197,7 +197,6 @@ class TestMultivariateNormal(RandomGeneratorTestCase):
             assert isinstance(val, cupy.ndarray)
             assert val.dtype == dtype
             assert val.shape == shape + (2,)
-        # TODO(niboshi): Distribution test
 
     def test_multivariate_normal_float32(self):
         self.check_multivariate_normal(numpy.float32)
@@ -565,8 +564,23 @@ class TestBinomial(RandomGeneratorTestCase):
 
     target_method = 'binomial'
 
-    def test_laplace(self):
+    def test_binomial(self):
         self.generate(n=self.n, p=self.p, size=(3, 2))
+
+
+@testing.parameterize(
+    {'a': 1.0, 'b': 3.0},
+    {'a': 3.0, 'b': 3.0},
+    {'a': 3.0, 'b': 1.0},
+)
+@testing.gpu
+@testing.fix_random()
+class TestBeta(RandomGeneratorTestCase):
+
+    target_method = 'beta'
+
+    def test_beta(self):
+        self.generate(a=self.a, b=self.b, size=(3, 2))
 
 
 @testing.gpu


### PR DESCRIPTION
I am implementing some distribution for `cupy.random`.

I will implement the following distribution.

## The distributions for `Chainer.distributions`
- [x] multivariate_normal
- [x] laplace
- [x] binomial
- [x] beta 
- [x] chisquare
- [x] dirichlet
- [x] gamma
- [x] standard_t
- [x] poisson
- [x] standard_cauchy
- [x] standard_exponential
- [x] f
- [x] geometric
- [x] pareto

## Other distributions
- [x] exponential
- [x] hypergeometric
- [x] logistic
- [x] logseries
- [x] multinomial
- [x] negative_binomial
- [x] noncentral_chisquare
- [x] noncentral_f
- [x] power
- [x] rayleigh
- [x] standard_gamma
- [x] triangular 
- [x] vonmises
- [x] wald
- [x] weibull
- [x] zipf
