### PR TITLE
Fix regex in einsum to match empty input subscript

### DIFF
--- a/cupy/linalg/einsum.py
+++ b/cupy/linalg/einsum.py
@@ -266,7 +266,7 @@ def einsum(*operands):
         raise ValueError('einstein sum subscripts string contains a \'.\' that'
                          'is not part of an ellipsis (\'...\')')
 
-    match = re.match('^([a-zA-Z@,]+)(->[a-zA-Z@]*)?$', subscripts)
+    match = re.match('^([a-zA-Z@,]*)(->[a-zA-Z@]*)?$', subscripts)
     if not match:
         raise ValueError('einstein sum subscript string does not contain '
                          'proper \'->\' output specified')

--- a/tests/cupy_tests/linalg_tests/test_einsum.py
+++ b/tests/cupy_tests/linalg_tests/test_einsum.py
@@ -150,6 +150,9 @@ class TestEinSumError(unittest.TestCase):
     {'shape_a': (2, 3), 'subscripts': 'ij->...ij'},  # do nothing
     {'shape_a': (2, 3), 'subscripts': 'ij...->ij'},  # do nothing
     {'shape_a': (2, 3), 'subscripts': 'i...j->ij'},  # do nothing
+
+    {'shape_a': (), 'subscripts': ''},  # do nothing
+    {'shape_a': (), 'subscripts': '->'},  # do nothing
 )
 class TestEinSumUnaryOperation(unittest.TestCase):
     # Avoid overflow


### PR DESCRIPTION
Support `cupy.einsum('', x)` and `cupy.einsum('->', x)` for scalar `x`.

Fixes #1179.