### PR TITLE
[backport] skip int8.max test on Windows due to NumPy bug

### DIFF
--- a/cupy/testing/__init__.py
+++ b/cupy/testing/__init__.py
@@ -38,6 +38,7 @@ from cupy.testing.helper import numpy_cupy_array_list_equal  # NOQA
 from cupy.testing.helper import numpy_cupy_array_max_ulp  # NOQA
 from cupy.testing.helper import numpy_cupy_equal  # NOQA
 from cupy.testing.helper import numpy_cupy_raises  # NOQA
+from cupy.testing.helper import numpy_satisfies  # NOQA
 from cupy.testing.helper import NumpyAliasBasicTestBase  # NOQA
 from cupy.testing.helper import NumpyAliasValuesTestBase  # NOQA
 from cupy.testing.helper import NumpyError  # NOQA

--- a/cupy/testing/helper.py
+++ b/cupy/testing/helper.py
@@ -910,6 +910,20 @@ def with_requires(*requirements):
     return unittest.skipIf(skip, msg)
 
 
+def numpy_satisfies(version_range):
+    """Returns True if numpy version satisfies the specified criteria.
+
+    Args:
+        version_range: A version specifier (e.g., `>=1.13.0`).
+    """
+    spec = 'numpy{}'.format(version_range)
+    try:
+        pkg_resources.require(spec)
+    except pkg_resources.VersionConflict:
+        return False
+    return True
+
+
 def shaped_arange(shape, xp=cupy, dtype=numpy.float32):
     """Returns an array with given shape, array module, and dtype.
 

--- a/tests/cupy_tests/core_tests/test_elementwise.py
+++ b/tests/cupy_tests/core_tests/test_elementwise.py
@@ -1,3 +1,4 @@
+import sys
 import unittest
 
 import numpy
@@ -75,6 +76,11 @@ class TestElementwiseInvalidArgument(unittest.TestCase):
 @testing.gpu
 class TestElementwiseType(unittest.TestCase):
 
+    # Skip this test due to NumPy bug on Windows (fixed in NumPy 1.14.0).
+    # https://github.com/numpy/numpy/pull/9778
+    @unittest.skipIf(
+        sys.platform == 'win32' and testing.numpy_satisfies('<1.14'),
+        'This test requires 1.14.0 when running on Windows.')
     @testing.for_int_dtypes(no_bool=True)
     @testing.numpy_cupy_array_equal()
     def test_large_int_upper_1(self, xp, dtype):

--- a/tests/cupy_tests/math_tests/test_arithmetic.py
+++ b/tests/cupy_tests/math_tests/test_arithmetic.py
@@ -1,20 +1,9 @@
 import itertools
 import numpy
-import pkg_resources
 import unittest
 
 import cupy
 from cupy import testing
-
-
-def numpy_satisfies(version_range):
-    """Returns True if numpy version satisfies the specified criteria."""
-    spec = 'numpy{}'.format(version_range)
-    try:
-        pkg_resources.require(spec)
-    except pkg_resources.VersionConflict:
-        return False
-    return True
 
 
 float_types = [numpy.float16, numpy.float32, numpy.float64]
@@ -86,7 +75,7 @@ class TestArithmeticUnary(unittest.TestCase):
             arg1 = xp.asarray(arg1)
         y = getattr(xp, self.name)(arg1)
 
-        if (numpy_satisfies('>=1.13.0')
+        if (testing.numpy_satisfies('>=1.13.0')
                 and self.name in ('real', 'imag')):
 
             # From NumPy>=1.13, some functions return Python scalars for Python
@@ -190,7 +179,7 @@ class TestArithmeticBinary(unittest.TestCase):
         # NumPy>=1.13.0 does not support subtraction between booleans
         # TODO(niboshi): Write a separate test to check both NumPy and CuPy
         # raise TypeError.
-        if (numpy_satisfies('>=1.13.0')
+        if (testing.numpy_satisfies('>=1.13.0')
                 and self.name == 'subtract'
                 and xp.asarray(arg1).dtype == numpy.bool_
                 and xp.asarray(arg2).dtype == numpy.bool_):

--- a/tests/cupy_tests/math_tests/test_misc.py
+++ b/tests/cupy_tests/math_tests/test_misc.py
@@ -1,10 +1,9 @@
+import sys
 import unittest
 
 import numpy
 
 from cupy import testing
-
-import os
 
 
 @testing.gpu
@@ -47,7 +46,7 @@ class TestMisc(unittest.TestCase):
         return getattr(xp, name)(a, b)
 
     @unittest.skipIf(
-        os.sys.platform == 'win32', 'dtype problem on Windows')
+        sys.platform == 'win32', 'dtype problem on Windows')
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_array_equal()
     def test_clip1(self, xp, dtype):
@@ -66,6 +65,11 @@ class TestMisc(unittest.TestCase):
         a = testing.shaped_arange((2, 3, 4), xp, dtype)
         return a.clip(None, 3)
 
+    # Skip this test due to NumPy bug on Windows (fixed in NumPy 1.14.0).
+    # https://github.com/numpy/numpy/pull/9778
+    @unittest.skipIf(
+        sys.platform == 'win32' and testing.numpy_satisfies('<1.14'),
+        'This test requires 1.14.0 when running on Windows.')
     @testing.for_all_dtypes(no_bool=True, no_complex=True)
     @testing.numpy_cupy_array_equal()
     def test_clip_max_none(self, xp, dtype):
@@ -79,7 +83,7 @@ class TestMisc(unittest.TestCase):
         return a.clip(None, None)
 
     @unittest.skipIf(
-        os.sys.platform == 'win32', 'dtype problem on Windows')
+        sys.platform == 'win32', 'dtype problem on Windows')
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_array_equal()
     def test_external_clip1(self, xp, dtype):


### PR DESCRIPTION
Backport of #1171