### PR TITLE
Fix default dtype of full

### DIFF
--- a/cupy/creation/basic.py
+++ b/cupy/creation/basic.py
@@ -1,4 +1,5 @@
 import cupy
+import numpy
 
 
 def empty(shape, dtype=float, order='C'):
@@ -189,7 +190,10 @@ def full(shape, fill_value, dtype=None):
     """
     # TODO(beam2d): Support ordering option
     if dtype is None:
-        dtype = cupy.array(fill_value).dtype
+        if isinstance(fill_value, cupy.ndarray):
+            dtype = fill_value.dtype
+        else:
+            dtype = numpy.array(fill_value).dtype
     a = cupy.ndarray(shape, dtype=dtype)
     a.fill(fill_value)
     return a

--- a/cupy/creation/basic.py
+++ b/cupy/creation/basic.py
@@ -188,6 +188,8 @@ def full(shape, fill_value, dtype=None):
 
     """
     # TODO(beam2d): Support ordering option
+    if dtype is None:
+        dtype = cupy.array(fill_value).dtype
     a = cupy.ndarray(shape, dtype=dtype)
     a.fill(fill_value)
     return a

--- a/tests/cupy_tests/creation_tests/test_basic.py
+++ b/tests/cupy_tests/creation_tests/test_basic.py
@@ -143,6 +143,11 @@ class TestBasic(unittest.TestCase):
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
+    def test_full_default_dtype(self, xp, dtype):
+        return xp.full((2, 3, 4), xp.array(1, dtype=dtype))
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
     def test_full_like(self, xp, dtype):
         a = xp.ndarray((2, 3, 4), dtype=dtype)
         return xp.full_like(a, 1)

--- a/tests/cupy_tests/creation_tests/test_basic.py
+++ b/tests/cupy_tests/creation_tests/test_basic.py
@@ -149,6 +149,12 @@ class TestBasic(unittest.TestCase):
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
+    @testing.with_requires('numpy>=1.12.0')
+    def test_full_default_dtype_cpu_input(self, xp, dtype):
+        return xp.full((2, 3, 4), numpy.array(1, dtype=dtype))
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
     def test_full_like(self, xp, dtype):
         a = xp.ndarray((2, 3, 4), dtype=dtype)
         return xp.full_like(a, 1)

--- a/tests/cupy_tests/creation_tests/test_basic.py
+++ b/tests/cupy_tests/creation_tests/test_basic.py
@@ -143,6 +143,7 @@ class TestBasic(unittest.TestCase):
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
+    @testing.with_requires('numpy>=1.12.0')
     def test_full_default_dtype(self, xp, dtype):
         return xp.full((2, 3, 4), xp.array(1, dtype=dtype))
 


### PR DESCRIPTION
This PR fixes #1203. The default `dtype` of `cupy.full` should be determined by `fill_value`.