### PR TITLE
Fix .coveragerc

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,6 @@
 [run]
 plugins = Cython.Coverage
-include = cupy/*,examples/*
+include = cupy/*,cupyx/*,examples/*
 
 [report]
 exclude_lines =


### PR DESCRIPTION
This PR fixes the bug which the coverage of `cupyx` has not been measured.