### PR TITLE
Fix gitignore to exclude pyd files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.pyo
 *.cpp
 *.so
+*.pyd
 build
 \#*\#
 .\#*

--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,9 @@
 *.egg/
 *.pyc
 *.pyo
+*.pyd
 *.cpp
 *.so
-*.pyd
 build
 \#*\#
 .\#*


### PR DESCRIPTION
pyd files are generated while building Windows DLL (Python modules).