### PR TITLE
Fix linalg.matrix_rank casting for Windows

### DIFF
--- a/cupy/linalg/norms.py
+++ b/cupy/linalg/norms.py
@@ -176,7 +176,7 @@ def matrix_rank(M, tol=None):
     if tol is None:
         tol = (S.max(axis=-1, keepdims=True) * max(M.shape[-2:]) *
                numpy.finfo(S.dtype).eps)
-    return (S > tol).sum(axis=-1).astype(numpy.intp)
+    return (S > tol).sum(axis=-1, dtype=numpy.intp)
 
 
 def slogdet(a):

--- a/cupy/linalg/norms.py
+++ b/cupy/linalg/norms.py
@@ -182,12 +182,12 @@ def matrix_rank(M, tol=None):
     .. seealso:: :func:`numpy.linalg.matrix_rank`
     """
     if M.ndim < 2:
-        return (M != 0).any().astype('l')
+        return (M != 0).any().astype(int)
     S = decomposition.svd(M, compute_uv=False)
     if tol is None:
         tol = (S.max(axis=-1, keepdims=True) * max(M.shape[-2:]) *
                numpy.finfo(S.dtype).eps)
-    return (S > tol).sum(axis=-1)
+    return (S > tol).sum(axis=-1).astype(numpy.intp)
 
 
 def slogdet(a):

--- a/tests/cupy_tests/linalg_tests/test_norms.py
+++ b/tests/cupy_tests/linalg_tests/test_norms.py
@@ -79,17 +79,21 @@ class TestMatrixRank(unittest.TestCase):
 
     _multiprocess_can_split_ = True
 
+    # matrix_rank of CuPy returns in dtype compatible with NumPy 1.14.
+    type_check = testing.numpy_satisfies('>=1.14')
+
     @testing.for_all_dtypes(no_float16=True, no_complex=True)
-    @testing.numpy_cupy_array_equal()
+    @testing.numpy_cupy_array_equal(type_check=type_check)
     def test_matrix_rank(self, xp, dtype):
         a = xp.array(self.array, dtype=dtype)
         y = xp.linalg.matrix_rank(a, tol=self.tol)
         if xp is cupy:
-            # Note numpy returns int
             self.assertIsInstance(y, cupy.ndarray)
-            self.assertEqual(y.dtype, 'l')
             self.assertEqual(y.shape, ())
-        return xp.array(y)
+        else:
+            # Note numpy returns numpy scalar or python int
+            y = xp.array(y)
+        return y
 
 
 @unittest.skipUnless(


### PR DESCRIPTION
Fix for NumPy 1.14 on Windows.
In NumPy 1.14, `matrix_rank` has been rewritten to use `count_nonzero` (which results in `int64`) instead of `sum` reduction (which results in `int32` on Windows).