### PR TITLE
Free pooled memory when cufftMakePlan1d cannot allocate memory

### DIFF
--- a/cupy/cuda/cufft.pyx
+++ b/cupy/cuda/cufft.pyx
@@ -87,6 +87,15 @@ class Plan1d(object):
             if result == 0:
                 result = cufftMakePlan1d(plan, nx, <Type>fft_type, batch,
                                          &workSize)
+
+        # cufftMakePlan1d uses large memory when nx has large divisor.
+        # See https://github.com/cupy/cupy/issues/1063
+        if result == 2:
+            cupy.get_default_memory_pool().free_all_blocks()
+            with nogil:
+                result = cufftMakePlan1d(plan, nx, <Type>fft_type, batch,
+                                         &workSize)
+
         check_result(result)
         workArea = memory.alloc(workSize)
         with nogil:


### PR DESCRIPTION
This PR adds a workaround about `CUFFT_ALLOC_FAILED` (#1063). Even after it is merged, the reported error at #1063 is not resolved because memory compaction has not been introduced (#536).