### PR TITLE
Remove _multiprocess_can_split_

### DIFF
--- a/tests/cupy_tests/binary_tests/test_elementwise.py
+++ b/tests/cupy_tests/binary_tests/test_elementwise.py
@@ -6,8 +6,6 @@ from cupy import testing
 @testing.gpu
 class TestElementwise(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.for_int_dtypes()
     @testing.numpy_cupy_array_equal()
     def check_unary_int(self, name, xp, dtype):

--- a/tests/cupy_tests/binary_tests/test_packing.py
+++ b/tests/cupy_tests/binary_tests/test_packing.py
@@ -7,8 +7,6 @@ from cupy import testing
 @testing.gpu
 class TestPacking(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.with_requires('numpy>=1.10')
     @testing.for_int_dtypes()
     @testing.numpy_cupy_array_equal()

--- a/tests/cupy_tests/core_tests/test_elementwise.py
+++ b/tests/cupy_tests/core_tests/test_elementwise.py
@@ -13,8 +13,6 @@ from cupy import testing
 @testing.gpu
 class TestElementwise(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     def check_copy(self, dtype, src_id, dst_id):
         with cuda.Device(src_id):
             src = testing.shaped_arange((2, 3, 4), dtype=dtype)
@@ -65,8 +63,6 @@ class TestElementwise(unittest.TestCase):
 
 @testing.gpu
 class TestElementwiseInvalidArgument(unittest.TestCase):
-
-    _multiprocess_can_split_ = True
 
     def test_invalid_kernel_name(self):
         with six.assertRaisesRegex(self, ValueError, 'Invalid kernel name'):

--- a/tests/cupy_tests/core_tests/test_fusion.py
+++ b/tests/cupy_tests/core_tests/test_fusion.py
@@ -25,8 +25,6 @@ def fusion_default_array_equal():
 @testing.gpu
 class TestFusionElementwise(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.for_int_dtypes()
     @testing.numpy_cupy_array_equal()
     @fusion_default_array_equal()
@@ -64,8 +62,6 @@ class TestFusionElementwise(unittest.TestCase):
 @testing.gpu
 class TestFusionComparison(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose(atol=1e-5)
     @fusion_default_array_equal()
@@ -95,8 +91,6 @@ class TestFusionComparison(unittest.TestCase):
 
 @testing.gpu
 class TestFusionContent(unittest.TestCase):
-
-    _multiprocess_can_split_ = True
 
     @testing.for_float_dtypes()
     @testing.numpy_cupy_array_equal()
@@ -128,8 +122,6 @@ class TestFusionContent(unittest.TestCase):
 @testing.gpu
 class TestFusionOps(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose(atol=1e-5)
     @fusion_default_array_equal()
@@ -160,8 +152,6 @@ class TestFusionOps(unittest.TestCase):
 
 @testing.gpu
 class TestFusionTrigonometric(unittest.TestCase):
-
-    _multiprocess_can_split_ = True
 
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose(atol=1e-5)
@@ -219,8 +209,6 @@ class TestFusionTrigonometric(unittest.TestCase):
 @testing.gpu
 class TestFusionHyperbolic(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose(atol=1e-5)
     @fusion_default_array_equal()
@@ -264,8 +252,6 @@ class TestFusionHyperbolic(unittest.TestCase):
 @testing.gpu
 class TestFusionRounding(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose(atol=1e-5)
     @fusion_default_array_equal()
@@ -301,8 +287,6 @@ class TestFusionRounding(unittest.TestCase):
 
 @testing.gpu
 class TestFusionExplog(unittest.TestCase):
-
-    _multiprocess_can_split_ = True
 
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose(atol=1e-5)
@@ -352,8 +336,6 @@ class TestFusionExplog(unittest.TestCase):
 
 @testing.gpu
 class TestFusionFloating(unittest.TestCase):
-
-    _multiprocess_can_split_ = True
 
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose(atol=1e-5)
@@ -412,8 +394,6 @@ class TestFusionFloating(unittest.TestCase):
 
 @testing.gpu
 class TestFusionArithmetic(unittest.TestCase):
-
-    _multiprocess_can_split_ = True
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(atol=1e-5)
@@ -895,8 +875,6 @@ class TestFusionUfunc(unittest.TestCase):
 @testing.gpu
 class TestFusionMisc(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose(atol=1e-5)
     def check_unary(self, name, xp, dtype, no_bool=False):
@@ -1005,8 +983,6 @@ class TestFusionMisc(unittest.TestCase):
 
 @testing.gpu
 class TestFusionFuse(unittest.TestCase):
-
-    _multiprocess_can_split_ = True
 
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_array_equal()

--- a/tests/cupy_tests/core_tests/test_ndarray_complex_ops.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_complex_ops.py
@@ -8,8 +8,6 @@ from cupy import testing
 @testing.gpu
 class TestConj(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_almost_equal()
     def test_conj(self, xp, dtype):
@@ -28,8 +26,6 @@ class TestConj(unittest.TestCase):
 @testing.gpu
 class TestAngle(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_almost_equal()
     def test_angle(self, xp, dtype):
@@ -39,8 +35,6 @@ class TestAngle(unittest.TestCase):
 
 @testing.gpu
 class TestRealImag(unittest.TestCase):
-
-    _multiprocess_can_split_ = True
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_almost_equal(accept_error=False)
@@ -97,8 +91,6 @@ class TestRealImag(unittest.TestCase):
 
 @testing.gpu
 class TestScalarConversion(unittest.TestCase):
-
-    _multiprocess_can_split_ = True
 
     @testing.for_all_dtypes()
     @testing.with_requires('numpy>=1.12.0')

--- a/tests/cupy_tests/core_tests/test_ndarray_contiguity.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_contiguity.py
@@ -6,8 +6,6 @@ from cupy import testing
 @testing.gpu
 class TestArrayContiguity(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     def test_is_contiguous(self):
         a = testing.shaped_arange((2, 3, 4))
         self.assertTrue(a.flags.c_contiguous)

--- a/tests/cupy_tests/core_tests/test_ndarray_copy_and_view.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_copy_and_view.py
@@ -9,8 +9,6 @@ from cupy import testing
 @testing.gpu
 class TestArrayCopyAndView(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.numpy_cupy_array_equal()
     def test_view(self, xp):
         a = testing.shaped_arange((4,), xp, dtype=numpy.float32)

--- a/tests/cupy_tests/core_tests/test_ndarray_elementwise_op.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_elementwise_op.py
@@ -11,8 +11,6 @@ from cupy import testing
 @testing.gpu
 class TestArrayElementwiseOp(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.for_all_dtypes_combination(names=['x_type', 'y_type'],
                                         no_complex=True)
     @testing.numpy_cupy_allclose(rtol=1e-6, accept_error=TypeError)
@@ -516,8 +514,6 @@ class TestArrayElementwiseOp(unittest.TestCase):
 
 @testing.gpu
 class TestArrayIntElementwiseOp(unittest.TestCase):
-
-    _multiprocess_can_split_ = True
 
     @testing.for_all_dtypes_combination(names=['x_type', 'y_type'])
     @testing.numpy_cupy_allclose(accept_error=TypeError)

--- a/tests/cupy_tests/core_tests/test_ndarray_get.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_get.py
@@ -10,8 +10,6 @@ from numpy import testing as np_testing
 @testing.gpu
 class TestArrayGet(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     def setUp(self):
         self.stream = cuda.Stream.null
 

--- a/tests/cupy_tests/core_tests/test_ndarray_indexing.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_indexing.py
@@ -73,8 +73,6 @@ from cupy import testing
 @testing.gpu
 class TestArrayIndexingParameterized(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_getitem(self, xp, dtype):
@@ -116,8 +114,6 @@ class TestArrayInvalidIndex(unittest.TestCase):
 
 @testing.gpu
 class TestArrayIndex(unittest.TestCase):
-
-    _multiprocess_can_split_ = True
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()

--- a/tests/cupy_tests/core_tests/test_ndarray_owndata.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_owndata.py
@@ -7,8 +7,6 @@ from cupy import testing
 @testing.gpu
 class TestArrayOwndata(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     def setUp(self):
         self.a = core.ndarray(())
 

--- a/tests/cupy_tests/core_tests/test_ndarray_reduction.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_reduction.py
@@ -6,8 +6,6 @@ from cupy import testing
 @testing.gpu
 class TestArrayReduction(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose()
     def test_max_all(self, xp, dtype):

--- a/tests/cupy_tests/core_tests/test_ndarray_unary_op.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_unary_op.py
@@ -10,8 +10,6 @@ from cupy import testing
 @testing.gpu
 class TestArrayBoolOp(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.for_all_dtypes()
     def test_bool_empty(self, dtype):
         self.assertFalse(bool(cupy.array((), dtype=dtype)))
@@ -42,8 +40,6 @@ class TestArrayBoolOp(unittest.TestCase):
 
 @testing.gpu
 class TestArrayUnaryOp(unittest.TestCase):
-
-    _multiprocess_can_split_ = True
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
@@ -84,8 +80,6 @@ class TestArrayUnaryOp(unittest.TestCase):
 
 @testing.gpu
 class TestArrayIntUnaryOp(unittest.TestCase):
-
-    _multiprocess_can_split_ = True
 
     @testing.for_int_dtypes()
     @testing.numpy_cupy_allclose()

--- a/tests/cupy_tests/core_tests/test_reduction.py
+++ b/tests/cupy_tests/core_tests/test_reduction.py
@@ -10,8 +10,6 @@ from cupy import testing
 @testing.gpu
 class SimpleReductionFunction(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     def setUp(self):
         self.my_int8_sum = core.create_reduction_func(
             'my_sum', ('b->b',), ('in0', 'a + b', 'out0 = a', None))
@@ -60,8 +58,6 @@ class SimpleReductionFunction(unittest.TestCase):
 @testing.gpu
 class TestReductionKernel(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     def setUp(self):
         self.my_sum = core.ReductionKernel(
             'T x', 'T out', 'x', 'a + b', 'out = a', '0', 'my_sum')
@@ -102,8 +98,6 @@ class TestReductionKernel(unittest.TestCase):
 
 @testing.gpu
 class TestReductionKernelInvalidArgument(unittest.TestCase):
-
-    _multiprocess_can_split_ = True
 
     def test_invalid_kernel_name(self):
         with six.assertRaisesRegex(self, ValueError, 'Invalid kernel name'):

--- a/tests/cupy_tests/creation_tests/test_basic.py
+++ b/tests/cupy_tests/creation_tests/test_basic.py
@@ -9,8 +9,6 @@ from cupy import testing
 @testing.gpu
 class TestBasic(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.for_CF_orders()
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()

--- a/tests/cupy_tests/creation_tests/test_from_data.py
+++ b/tests/cupy_tests/creation_tests/test_from_data.py
@@ -9,8 +9,6 @@ import numpy
 @testing.gpu
 class TestFromData(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.for_orders('CFAK')
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()

--- a/tests/cupy_tests/creation_tests/test_matrix.py
+++ b/tests/cupy_tests/creation_tests/test_matrix.py
@@ -6,8 +6,6 @@ from cupy import testing
 @testing.gpu
 class TestMatrix(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.numpy_cupy_array_equal()
     def test_diag1(self, xp):
         a = testing.shaped_arange((3, 3), xp)

--- a/tests/cupy_tests/creation_tests/test_ranges.py
+++ b/tests/cupy_tests/creation_tests/test_ranges.py
@@ -9,8 +9,6 @@ from cupy import testing
 @testing.gpu
 class TestRanges(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_array_equal()
     def test_arange(self, xp, dtype):

--- a/tests/cupy_tests/fft_tests/test_fft.py
+++ b/tests/cupy_tests/fft_tests/test_fft.py
@@ -14,8 +14,6 @@ from cupy import testing
 @testing.with_requires('numpy>=1.10.0')
 class TestFft(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
                                  contiguous_check=False)
@@ -64,8 +62,6 @@ class TestFft(unittest.TestCase):
 @testing.with_requires('numpy>=1.10.0')
 class TestFft2(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
                                  contiguous_check=False)
@@ -113,8 +109,6 @@ class TestFft2(unittest.TestCase):
 @testing.with_requires('numpy>=1.10.0')
 class TestFftn(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
                                  contiguous_check=False)
@@ -148,8 +142,6 @@ class TestFftn(unittest.TestCase):
 @testing.gpu
 @testing.with_requires('numpy>=1.10.0')
 class TestRfft(unittest.TestCase):
-
-    _multiprocess_can_split_ = True
 
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, contiguous_check=False)
@@ -201,8 +193,6 @@ class TestRfft(unittest.TestCase):
 @testing.with_requires('numpy>=1.10.0')
 class TestRfft2(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
                                  contiguous_check=False)
@@ -253,8 +243,6 @@ class TestRfft2(unittest.TestCase):
 @testing.with_requires('numpy>=1.10.0')
 class TestRfftn(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
                                  contiguous_check=False)
@@ -289,8 +277,6 @@ class TestRfftn(unittest.TestCase):
 @testing.with_requires('numpy>=1.10.0')
 class TestHfft(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, contiguous_check=False)
     def test_hfft(self, xp, dtype):
@@ -323,8 +309,6 @@ class TestHfft(unittest.TestCase):
 @testing.with_requires('numpy>=1.10.0')
 class TestFftfreq(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, contiguous_check=False)
     def test_fftfreq(self, xp, dtype):
@@ -352,8 +336,6 @@ class TestFftfreq(unittest.TestCase):
 @testing.gpu
 @testing.with_requires('numpy>=1.10.0')
 class TestFftshift(unittest.TestCase):
-
-    _multiprocess_can_split_ = True
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, contiguous_check=False)

--- a/tests/cupy_tests/indexing_tests/test_generate.py
+++ b/tests/cupy_tests/indexing_tests/test_generate.py
@@ -8,8 +8,6 @@ from cupy import testing
 @testing.gpu
 class TestIndices(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_indices_list0(self, xp, dtype):
@@ -33,8 +31,6 @@ class TestIndices(unittest.TestCase):
 @testing.gpu
 class TestIX_(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.numpy_cupy_array_list_equal()
     def test_ix_list(self, xp):
         return xp.ix_([0, 1], [2, 4])
@@ -55,8 +51,6 @@ class TestIX_(unittest.TestCase):
 
 @testing.gpu
 class TestR_(unittest.TestCase):
-
-    _multiprocess_can_split_ = True
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
@@ -112,8 +106,6 @@ class TestR_(unittest.TestCase):
 @testing.gpu
 class TestC_(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_c_1(self, xp, dtype):
@@ -140,8 +132,6 @@ class TestC_(unittest.TestCase):
 @testing.gpu
 class TestAxisConcatenator(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     def test_AxisConcatenator_init1(self):
         with self.assertRaises(TypeError):
             cupy.indexing.generate.AxisConcatenator.__init__()
@@ -153,8 +143,6 @@ class TestAxisConcatenator(unittest.TestCase):
 
 @testing.gpu
 class TestUnravelIndex(unittest.TestCase):
-
-    _multiprocess_can_split_ = True
 
     @testing.for_orders(['C', 'F', None])
     @testing.for_int_dtypes()

--- a/tests/cupy_tests/indexing_tests/test_indexing.py
+++ b/tests/cupy_tests/indexing_tests/test_indexing.py
@@ -7,8 +7,6 @@ from cupy import testing
 @testing.gpu
 class TestIndexing(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.numpy_cupy_array_equal()
     def test_take_by_scalar(self, xp):
         a = testing.shaped_arange((2, 4, 3), xp)
@@ -86,8 +84,6 @@ class TestIndexing(unittest.TestCase):
 
 @testing.gpu
 class TestChoose(unittest.TestCase):
-
-    _multiprocess_can_split_ = True
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()

--- a/tests/cupy_tests/indexing_tests/test_insert.py
+++ b/tests/cupy_tests/indexing_tests/test_insert.py
@@ -11,8 +11,6 @@ from cupy import testing
 @testing.gpu
 class TestInsert(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_fill_diagonal(self, xp, dtype):

--- a/tests/cupy_tests/io_tests/test_formatting.py
+++ b/tests/cupy_tests/io_tests/test_formatting.py
@@ -9,8 +9,6 @@ from cupy import testing
 @testing.gpu
 class TestFormatting(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     def test_array_repr(self):
         a = testing.shaped_arange((2, 3, 4), cupy)
         b = testing.shaped_arange((2, 3, 4), numpy)

--- a/tests/cupy_tests/io_tests/test_npz.py
+++ b/tests/cupy_tests/io_tests/test_npz.py
@@ -9,8 +9,6 @@ from cupy import testing
 @testing.gpu
 class TestNpz(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.for_all_dtypes()
     def test_save_load(self, dtype):
         a = testing.shaped_arange((2, 3, 4), dtype=dtype)

--- a/tests/cupy_tests/io_tests/test_rawfile.py
+++ b/tests/cupy_tests/io_tests/test_rawfile.py
@@ -6,4 +6,4 @@ from cupy import testing
 @testing.gpu
 class TestRawfile(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
+    pass

--- a/tests/cupy_tests/io_tests/test_text.py
+++ b/tests/cupy_tests/io_tests/test_text.py
@@ -6,4 +6,4 @@ from cupy import testing
 @testing.gpu
 class TestText(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
+    pass

--- a/tests/cupy_tests/linalg_tests/test_decomposition.py
+++ b/tests/cupy_tests/linalg_tests/test_decomposition.py
@@ -14,8 +14,6 @@ from cupy.testing import condition
 @testing.gpu
 class TestCholeskyDecomposition(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.for_dtypes([
         numpy.int32, numpy.int64, numpy.uint32, numpy.uint64,
         numpy.float32, numpy.float64])
@@ -40,8 +38,6 @@ class TestCholeskyDecomposition(unittest.TestCase):
     cuda.cusolver_enabled, 'Only cusolver in CUDA 8.0 is supported')
 @testing.gpu
 class TestQRDecomposition(unittest.TestCase):
-
-    _multiprocess_can_split_ = True
 
     @testing.for_float_dtypes(no_float16=True)
     def check_mode(self, array, mode, dtype):
@@ -73,8 +69,6 @@ class TestQRDecomposition(unittest.TestCase):
     cuda.cusolver_enabled, 'Only cusolver in CUDA 8.0 is supported')
 @testing.gpu
 class TestSVD(unittest.TestCase):
-
-    _multiprocess_can_split_ = True
 
     @testing.for_float_dtypes(no_float16=True)
     def check_usv(self, array, dtype):

--- a/tests/cupy_tests/linalg_tests/test_eigenvalue.py
+++ b/tests/cupy_tests/linalg_tests/test_eigenvalue.py
@@ -15,8 +15,6 @@ from cupy import testing
 @testing.gpu
 class TestEigenvalue(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.for_all_dtypes(no_float16=True, no_complex=True)
     @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-4)
     def test_eigh(self, xp, dtype):

--- a/tests/cupy_tests/linalg_tests/test_norms.py
+++ b/tests/cupy_tests/linalg_tests/test_norms.py
@@ -10,8 +10,6 @@ from cupy import testing
 @testing.gpu
 class TestTrace(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_trace(self, xp, dtype):
@@ -51,8 +49,6 @@ class TestTrace(unittest.TestCase):
 @testing.with_requires('numpy>=1.11.2')  # The old version dtype is strange
 class TestNorm(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-4)
     def test_norm(self, xp, dtype):
@@ -77,8 +73,6 @@ class TestNorm(unittest.TestCase):
 @testing.gpu
 class TestMatrixRank(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.for_all_dtypes(no_float16=True, no_complex=True)
     @testing.numpy_cupy_array_equal()
     def test_matrix_rank(self, xp, dtype):
@@ -96,8 +90,6 @@ class TestMatrixRank(unittest.TestCase):
     cuda.cusolver_enabled, 'Only cusolver in CUDA 8.0 is supported')
 @testing.gpu
 class TestDet(unittest.TestCase):
-
-    _multiprocess_can_split_ = True
 
     @testing.for_float_dtypes(no_float16=True)
     @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-4)
@@ -140,8 +132,6 @@ class TestDet(unittest.TestCase):
     cuda.cusolver_enabled, 'Only cusolver in CUDA 8.0 is supported')
 @testing.gpu
 class TestSlogdet(unittest.TestCase):
-
-    _multiprocess_can_split_ = True
 
     @testing.for_float_dtypes(no_float16=True)
     @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-4)

--- a/tests/cupy_tests/linalg_tests/test_product.py
+++ b/tests/cupy_tests/linalg_tests/test_product.py
@@ -32,8 +32,6 @@ from cupy import testing
 @testing.gpu
 class TestDot(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.for_all_dtypes_combination(['dtype_a', 'dtype_b'])
     @testing.numpy_cupy_allclose()
     def test_dot(self, xp, dtype_a, dtype_b):
@@ -84,8 +82,6 @@ class TestDot(unittest.TestCase):
 @testing.gpu
 class TestDotFor0Dim(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.for_all_dtypes_combination(['dtype_a', 'dtype_b'])
     @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_dot(self, xp, dtype_a, dtype_b):
@@ -103,8 +99,6 @@ class TestDotFor0Dim(unittest.TestCase):
 
 @testing.gpu
 class TestProduct(unittest.TestCase):
-
-    _multiprocess_can_split_ = True
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()

--- a/tests/cupy_tests/linalg_tests/test_solve.py
+++ b/tests/cupy_tests/linalg_tests/test_solve.py
@@ -13,8 +13,6 @@ from cupy.testing import condition
 @testing.gpu
 class TestSolve(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.for_float_dtypes(no_float16=True)
     @condition.retry(10)
     def check_x(self, a_shape, b_shape, dtype):
@@ -68,8 +66,6 @@ class TestSolve(unittest.TestCase):
     cuda.cusolver_enabled, 'Only cusolver in CUDA 8.0 is supported')
 class TestTensorSolve(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     def setUp(self):
         self.a = numpy.random.randint(
             0, 10, size=self.a_shape).astype(self.dtype)
@@ -87,8 +83,6 @@ class TestTensorSolve(unittest.TestCase):
     cuda.cusolver_enabled, 'Only cusolver in CUDA 8.0 is supported')
 @testing.gpu
 class TestInv(unittest.TestCase):
-
-    _multiprocess_can_split_ = True
 
     @testing.for_float_dtypes(no_float16=True)
     @condition.retry(10)
@@ -121,8 +115,6 @@ class TestInv(unittest.TestCase):
     cuda.cusolver_enabled, 'Only cusolver in CUDA 8.0 is supported')
 @testing.gpu
 class TestPinv(unittest.TestCase):
-
-    _multiprocess_can_split_ = True
 
     @testing.for_float_dtypes(no_float16=True)
     @condition.retry(10)
@@ -162,8 +154,6 @@ class TestPinv(unittest.TestCase):
     cuda.cusolver_enabled, 'Only cusolver in CUDA 8.0 is supported')
 @testing.gpu
 class TestTensorInv(unittest.TestCase):
-
-    _multiprocess_can_split_ = True
 
     @testing.for_float_dtypes(no_float16=True)
     @condition.retry(10)

--- a/tests/cupy_tests/logic_tests/test_comparison.py
+++ b/tests/cupy_tests/logic_tests/test_comparison.py
@@ -9,8 +9,6 @@ from cupy import testing
 @testing.gpu
 class TestComparison(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose(atol=1e-5)
     def check_binary(self, name, xp, dtype):

--- a/tests/cupy_tests/logic_tests/test_content.py
+++ b/tests/cupy_tests/logic_tests/test_content.py
@@ -8,8 +8,6 @@ from cupy import testing
 @testing.gpu
 class TestContent(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.for_dtypes('efFdD')
     @testing.numpy_cupy_array_equal()
     def check_unary_inf(self, name, xp, dtype):

--- a/tests/cupy_tests/logic_tests/test_ops.py
+++ b/tests/cupy_tests/logic_tests/test_ops.py
@@ -6,8 +6,6 @@ from cupy import testing
 @testing.gpu
 class TestOps(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose(atol=1e-5)
     def check_unary(self, name, xp, dtype):

--- a/tests/cupy_tests/logic_tests/test_truth.py
+++ b/tests/cupy_tests/logic_tests/test_truth.py
@@ -37,8 +37,6 @@ def _calc_out_shape(shape, axis, keepdims):
 @testing.gpu
 class TestAllAny(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_without_out(self, xp, dtype):
@@ -66,8 +64,6 @@ class TestAllAny(unittest.TestCase):
          'keepdims': [False, True]}))
 @testing.gpu
 class TestAllAnyWithNaN(unittest.TestCase):
-
-    _multiprocess_can_split_ = True
 
     @testing.for_dtypes(
         (numpy.float64, numpy.float32, numpy.float16, numpy.bool_))

--- a/tests/cupy_tests/manipulation_tests/test_add_remove.py
+++ b/tests/cupy_tests/manipulation_tests/test_add_remove.py
@@ -6,4 +6,4 @@ from cupy import testing
 @testing.gpu
 class TestAddRemove(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
+    pass

--- a/tests/cupy_tests/manipulation_tests/test_basic.py
+++ b/tests/cupy_tests/manipulation_tests/test_basic.py
@@ -12,8 +12,6 @@ from cupy import testing
 @testing.gpu
 class TestBasic(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_copyto(self, xp, dtype):

--- a/tests/cupy_tests/manipulation_tests/test_dims.py
+++ b/tests/cupy_tests/manipulation_tests/test_dims.py
@@ -8,8 +8,6 @@ from cupy import testing
 @testing.gpu
 class TestDims(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     def check_atleast(self, func, xp):
         a = testing.shaped_arange((), xp)
         b = testing.shaped_arange((2,), xp)

--- a/tests/cupy_tests/manipulation_tests/test_join.py
+++ b/tests/cupy_tests/manipulation_tests/test_join.py
@@ -8,8 +8,6 @@ from cupy import testing
 @testing.gpu
 class TestJoin(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.for_all_dtypes(name='dtype1')
     @testing.for_all_dtypes(name='dtype2')
     @testing.numpy_cupy_array_equal()

--- a/tests/cupy_tests/manipulation_tests/test_kind.py
+++ b/tests/cupy_tests/manipulation_tests/test_kind.py
@@ -9,8 +9,6 @@ from cupy import testing
 @testing.gpu
 class TestKind(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.for_all_dtypes()
     def test_asfortranarray1(self, dtype):
         def func(xp):

--- a/tests/cupy_tests/manipulation_tests/test_rearrange.py
+++ b/tests/cupy_tests/manipulation_tests/test_rearrange.py
@@ -7,8 +7,6 @@ from cupy import testing
 @testing.gpu
 class TestRoll(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal(accept_error=TypeError)
     def test_roll(self, xp, dtype):
@@ -87,8 +85,6 @@ class TestRoll(unittest.TestCase):
 @testing.gpu
 class TestFliplr(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_fliplr_2(self, xp, dtype):
@@ -110,8 +106,6 @@ class TestFliplr(unittest.TestCase):
 
 @testing.gpu
 class TestFlipud(unittest.TestCase):
-
-    _multiprocess_can_split_ = True
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
@@ -135,8 +129,6 @@ class TestFlipud(unittest.TestCase):
 @testing.gpu
 @testing.with_requires('numpy>=1.12')
 class TestFlip(unittest.TestCase):
-
-    _multiprocess_can_split_ = True
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
@@ -195,8 +187,6 @@ class TestFlip(unittest.TestCase):
 
 @testing.gpu
 class TestRot90(unittest.TestCase):
-
-    _multiprocess_can_split_ = True
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()

--- a/tests/cupy_tests/manipulation_tests/test_shape.py
+++ b/tests/cupy_tests/manipulation_tests/test_shape.py
@@ -9,8 +9,6 @@ from cupy import testing
 @testing.gpu
 class TestShape(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     def test_reshape_strides(self):
         def func(xp):
             a = testing.shaped_arange((1, 1, 1, 2, 2), xp)

--- a/tests/cupy_tests/manipulation_tests/test_split.py
+++ b/tests/cupy_tests/manipulation_tests/test_split.py
@@ -6,8 +6,6 @@ from cupy import testing
 @testing.gpu
 class TestSplit(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.numpy_cupy_array_equal()
     def test_array_split1(self, xp):
         a = testing.shaped_arange((3, 11), xp)

--- a/tests/cupy_tests/manipulation_tests/test_tiling.py
+++ b/tests/cupy_tests/manipulation_tests/test_tiling.py
@@ -15,8 +15,6 @@ from cupy import testing
 @testing.gpu
 class TestRepeat(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.numpy_cupy_array_equal()
     def test_array_repeat(self, xp):
         x = testing.shaped_arange((2, 3, 4), xp)
@@ -85,8 +83,6 @@ class TestRepeat1DListBroadcast(unittest.TestCase):
 @testing.gpu
 class TestRepeatFailure(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.numpy_cupy_raises()
     def test_repeat_failure(self, xp):
         x = testing.shaped_arange((2, 3, 4), xp)
@@ -104,8 +100,6 @@ class TestRepeatFailure(unittest.TestCase):
 @testing.gpu
 class TestTile(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.numpy_cupy_array_equal()
     def test_array_tile(self, xp):
         x = testing.shaped_arange((2, 3, 4), xp)
@@ -118,8 +112,6 @@ class TestTile(unittest.TestCase):
 )
 @testing.gpu
 class TestTileFailure(unittest.TestCase):
-
-    _multiprocess_can_split_ = True
 
     @testing.numpy_cupy_raises()
     def test_tile_failure(self, xp):

--- a/tests/cupy_tests/manipulation_tests/test_transpose.py
+++ b/tests/cupy_tests/manipulation_tests/test_transpose.py
@@ -7,8 +7,6 @@ from cupy import testing
 @testing.gpu
 class TestTranspose(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.numpy_cupy_array_equal()
     @testing.with_requires('numpy>=1.11')
     def test_moveaxis1(self, xp):

--- a/tests/cupy_tests/math_tests/test_explog.py
+++ b/tests/cupy_tests/math_tests/test_explog.py
@@ -8,8 +8,6 @@ from cupy import testing
 @testing.gpu
 class TestExplog(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(atol=1e-5)
     def check_unary(self, name, xp, dtype, no_complex=False):

--- a/tests/cupy_tests/math_tests/test_floating.py
+++ b/tests/cupy_tests/math_tests/test_floating.py
@@ -9,8 +9,6 @@ from cupy import testing
 @testing.gpu
 class TestFloating(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(atol=1e-5)
     def check_unary(self, name, xp, dtype, no_complex=False):

--- a/tests/cupy_tests/math_tests/test_hyperbolic.py
+++ b/tests/cupy_tests/math_tests/test_hyperbolic.py
@@ -6,8 +6,6 @@ from cupy import testing
 @testing.gpu
 class TestHyperbolic(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(atol=1e-5)
     def check_unary(self, name, xp, dtype):

--- a/tests/cupy_tests/math_tests/test_matmul.py
+++ b/tests/cupy_tests/math_tests/test_matmul.py
@@ -26,8 +26,6 @@ from cupy import testing
 @testing.gpu
 class TestMatmul(unittest.TestCase):
 
-    # _multiprocess_can_split_ = True
-
     @unittest.skipUnless(sys.version_info >= (3, 5),
                          'Only for Python3.5 or higher')
     @testing.with_requires('numpy>=1.10')
@@ -67,8 +65,6 @@ class TestMatmul(unittest.TestCase):
     }))
 @testing.gpu
 class TestMatmulLarge(unittest.TestCase):
-
-    # _multiprocess_can_split_ = True
 
     # Avoid overflow
     skip_dtypes = {

--- a/tests/cupy_tests/math_tests/test_misc.py
+++ b/tests/cupy_tests/math_tests/test_misc.py
@@ -9,8 +9,6 @@ from cupy import testing
 @testing.gpu
 class TestMisc(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose(atol=1e-5)
     def check_unary(self, name, xp, dtype, no_bool=False):

--- a/tests/cupy_tests/math_tests/test_rounding.py
+++ b/tests/cupy_tests/math_tests/test_rounding.py
@@ -6,8 +6,6 @@ from cupy import testing
 @testing.gpu
 class TestRounding(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose(atol=1e-5)
     def check_unary(self, name, xp, dtype):

--- a/tests/cupy_tests/math_tests/test_special.py
+++ b/tests/cupy_tests/math_tests/test_special.py
@@ -6,4 +6,4 @@ from cupy import testing
 @testing.gpu
 class TestSpecial(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
+    pass

--- a/tests/cupy_tests/math_tests/test_sumprod.py
+++ b/tests/cupy_tests/math_tests/test_sumprod.py
@@ -10,8 +10,6 @@ from cupy import testing
 @testing.gpu
 class TestSumprod(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     def tearDown(self):
         # Free huge memory for slow test
         cupy.get_default_memory_pool().free_all_blocks()
@@ -171,8 +169,6 @@ axes = [0, 1, 2]
 @testing.gpu
 class TestCumsum(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_cumsum(self, xp, dtype):
@@ -221,8 +217,6 @@ class TestCumsum(unittest.TestCase):
 
 @testing.gpu
 class TestCumprod(unittest.TestCase):
-
-    _multiprocess_can_split_ = True
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()

--- a/tests/cupy_tests/math_tests/test_trigonometric.py
+++ b/tests/cupy_tests/math_tests/test_trigonometric.py
@@ -6,8 +6,6 @@ from cupy import testing
 @testing.gpu
 class TestTrigonometric(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose(atol=1e-5)
     def check_unary(self, name, xp, dtype):

--- a/tests/cupy_tests/math_tests/test_window.py
+++ b/tests/cupy_tests/math_tests/test_window.py
@@ -11,8 +11,6 @@ from cupy import testing
 )
 class TestWindow(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.numpy_cupy_allclose(atol=1e-5)
     def test_window(self, xp):
         return getattr(xp, self.name)(self.m)

--- a/tests/cupy_tests/padding_tests/test_pad.py
+++ b/tests/cupy_tests/padding_tests/test_pad.py
@@ -16,8 +16,6 @@ from cupy import testing
 @testing.gpu
 class TestPadDefault(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_array_equal()
     def test_pad_default(self, xp, dtype):
@@ -59,8 +57,6 @@ class TestPadDefault(unittest.TestCase):
 @testing.with_requires('numpy>=1.11.1')
 class TestPad(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_array_equal()
     def test_pad(self, xp, dtype):
@@ -85,8 +81,6 @@ class TestPad(unittest.TestCase):
 
 @testing.gpu
 class TestPadNumpybug(unittest.TestCase):
-
-    _multiprocess_can_split_ = True
 
     @testing.with_requires('numpy>=1.11.2')
     @testing.for_all_dtypes(no_bool=True, no_complex=True)
@@ -119,8 +113,6 @@ class TestPadNumpybug(unittest.TestCase):
 )
 @testing.gpu
 class TestPadSpecial(unittest.TestCase):
-
-    _multiprocess_can_split_ = True
 
     @testing.numpy_cupy_array_equal()
     def test_pad_special(self, xp):
@@ -159,8 +151,6 @@ class TestPadSpecial(unittest.TestCase):
 @testing.gpu
 @testing.with_requires('numpy>=1.11.1')  # Old numpy fails differently
 class TestPadFailure(unittest.TestCase):
-
-    _multiprocess_can_split_ = True
 
     @testing.numpy_cupy_raises()
     def test_pad_failure(self, xp):

--- a/tests/cupy_tests/random_tests/test_distributions.py
+++ b/tests/cupy_tests/random_tests/test_distributions.py
@@ -14,8 +14,6 @@ from cupy import testing
 @testing.gpu
 class TestDistributions(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     def check_distribution(self, dist_func, loc_dtype, scale_dtype, dtype):
         loc = cupy.ones(self.loc_shape, dtype=loc_dtype)
         scale = cupy.ones(self.scale_shape, dtype=scale_dtype)

--- a/tests/cupy_tests/random_tests/test_permutations.py
+++ b/tests/cupy_tests/random_tests/test_permutations.py
@@ -10,8 +10,6 @@ import numpy
 @testing.gpu
 class TestPermutations(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     # Test ranks
 
     @testing.numpy_cupy_raises()
@@ -52,8 +50,6 @@ class TestPermutations(unittest.TestCase):
 
 @testing.gpu
 class TestShuffle(unittest.TestCase):
-
-    _multiprocess_can_split_ = True
 
     # Test ranks
 
@@ -97,8 +93,6 @@ class TestShuffle(unittest.TestCase):
 @testing.gpu
 class TestPermutationSoundness(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     def setUp(self):
         a = cupy.random.permutation(self.num)
         self.a = a.get()
@@ -118,7 +112,6 @@ class TestPermutationSoundness(unittest.TestCase):
 @testing.gpu
 class TestPermutationRandomness(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
     num = 256
 
     def setUp(self):

--- a/tests/cupy_tests/random_tests/test_sample.py
+++ b/tests/cupy_tests/random_tests/test_sample.py
@@ -13,7 +13,6 @@ from cupy.testing import hypothesis
 
 @testing.gpu
 class TestRandint(unittest.TestCase):
-    _multiprocess_can_split_ = True
 
     def test_lo_hi_reversed(self):
         with self.assertRaises(ValueError):
@@ -99,8 +98,6 @@ class TestRandintDtype(unittest.TestCase):
 @testing.gpu
 class TestRandomIntegers(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     def test_normal(self):
         with mock.patch('cupy.random.sample_.randint') as m:
             random.random_integers(3, 5)
@@ -120,8 +117,6 @@ class TestRandomIntegers(unittest.TestCase):
 @testing.fix_random()
 @testing.gpu
 class TestRandomIntegers2(unittest.TestCase):
-
-    _multiprocess_can_split_ = True
 
     @condition.repeat(3, 10)
     def test_bound_1(self):
@@ -159,8 +154,6 @@ class TestRandomIntegers2(unittest.TestCase):
 
 @testing.gpu
 class TestChoice(unittest.TestCase):
-
-    _multiprocess_can_split_ = True
 
     def setUp(self):
         self.rs_tmp = random.generator._random_states
@@ -251,8 +244,6 @@ class TestRandomSample(unittest.TestCase):
 @testing.fix_random()
 @testing.gpu
 class TestMultinomial(unittest.TestCase):
-
-    _multiprocess_can_split_ = True
 
     @condition.repeat(3, 10)
     @testing.for_float_dtypes()

--- a/tests/cupy_tests/sorting_tests/test_count.py
+++ b/tests/cupy_tests/sorting_tests/test_count.py
@@ -10,8 +10,6 @@ from cupy import testing
 @testing.gpu
 class TestCount(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.for_all_dtypes()
     def test_count_nonzero(self, dtype):
         def func(xp):

--- a/tests/cupy_tests/sorting_tests/test_search.py
+++ b/tests/cupy_tests/sorting_tests/test_search.py
@@ -8,8 +8,6 @@ from cupy import testing
 @testing.gpu
 class TestSearch(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose()
     def test_argmax_all(self, xp, dtype):

--- a/tests/cupy_tests/sorting_tests/test_sort.py
+++ b/tests/cupy_tests/sorting_tests/test_sort.py
@@ -9,8 +9,6 @@ from cupy import testing
 @testing.gpu
 class TestSort(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     # Test ranks
 
     @testing.numpy_cupy_raises()
@@ -161,8 +159,6 @@ class TestSort(unittest.TestCase):
 @testing.gpu
 class TestLexsort(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     # Test ranks
 
     @testing.numpy_cupy_raises()
@@ -206,8 +202,6 @@ class TestLexsort(unittest.TestCase):
 }))
 @testing.gpu
 class TestArgsort(unittest.TestCase):
-
-    _multiprocess_can_split_ = True
 
     def argsort(self, a, axis=-1):
         if self.external:
@@ -306,8 +300,6 @@ class TestArgsort(unittest.TestCase):
 @testing.gpu
 class TestMsort(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     # Test base cases
 
     @testing.numpy_cupy_raises()
@@ -342,8 +334,6 @@ class TestMsort(unittest.TestCase):
 }))
 @testing.gpu
 class TestPartition(unittest.TestCase):
-
-    _multiprocess_can_split_ = True
 
     def partition(self, a, kth, axis=-1):
         if self.external:
@@ -510,8 +500,6 @@ class TestPartition(unittest.TestCase):
 }))
 @testing.gpu
 class TestArgpartition(unittest.TestCase):
-
-    _multiprocess_can_split_ = True
 
     def argpartition(self, a, kth, axis=-1):
         if self.external:

--- a/tests/cupy_tests/statics_tests/test_correlation.py
+++ b/tests/cupy_tests/statics_tests/test_correlation.py
@@ -6,4 +6,4 @@ from cupy import testing
 @testing.gpu
 class TestCorrelation(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
+    pass

--- a/tests/cupy_tests/statics_tests/test_histogram.py
+++ b/tests/cupy_tests/statics_tests/test_histogram.py
@@ -38,8 +38,6 @@ def for_all_dtypes_combination_bincount(names):
 @testing.gpu
 class TestHistogram(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.for_all_dtypes(no_bool=True, no_complex=True)
     @testing.numpy_cupy_array_list_equal()
     def test_histogram(self, xp, dtype):

--- a/tests/cupy_tests/statics_tests/test_meanvar.py
+++ b/tests/cupy_tests/statics_tests/test_meanvar.py
@@ -6,8 +6,6 @@ from cupy import testing
 @testing.gpu
 class TestMeanVar(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_mean_all(self, xp, dtype):

--- a/tests/cupy_tests/statics_tests/test_order.py
+++ b/tests/cupy_tests/statics_tests/test_order.py
@@ -19,8 +19,6 @@ def for_all_interpolations(name='interpolation'):
 @testing.gpu
 class TestOrder(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @for_all_interpolations()
     @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
     @testing.numpy_cupy_allclose()

--- a/tests/cupy_tests/testing_tests/test_helper.py
+++ b/tests/cupy_tests/testing_tests/test_helper.py
@@ -322,8 +322,6 @@ class TestIgnoreOfNegativeValueDifferenceOnCpuAndGpu(unittest.TestCase):
 @testing.gpu
 class TestShapedRandom(unittest.TestCase):
 
-    _multiprocess_can_split_ = True
-
     @testing.for_all_dtypes()
     def test_shape_and_dtype(self, dtype):
         a = testing.shaped_random((2, 3), self.xp, dtype)


### PR DESCRIPTION
We already moved to pytest instead of nose, therefore `_multiprocess_can_split_` has no effect.