### PR TITLE
Fix conversion from float16 to complex

### DIFF
--- a/cupy/core/reduction.pxi
+++ b/cupy/core/reduction.pxi
@@ -44,7 +44,7 @@ cpdef _get_simple_reduction_kernel(
              _j += _j_stride, _J += _J_stride) {
           _in_ind.set(_j);
           ${input_expr}
-          _type_reduce _a = ${pre_map_expr};
+          _type_reduce _a = static_cast<_type_reduce>(${pre_map_expr});
           _s = REDUCE(_s, _a);
         }
         if (_block_stride < ${block_size}) {


### PR DESCRIPTION
Fix a compilation error like following found by @toslunar. The cause is that there are no implicit conversions from `float16` to `complex<float>` and from `float16` to `complex<double>`.

```
>>> cupy.sum(cupy.arange(3).astype(cupy.float16), dtype=cupy.complex64)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/user/local/miniconda3/envs/chainer2/lib/python2.7/site-packages/cupy/core/fusion.py", line 833, in __call__
    return self._cupy_op(*args, **kwargs)
  File "/home/user/local/miniconda3/envs/chainer2/lib/python2.7/site-packages/cupy/math/sumprod.py", line 25, in sum
    return a.sum(axis, dtype, out, keepdims)
  File "cupy/core/core.pyx", line 1139, in cupy.core.core.ndarray.sum
  File "cupy/core/core.pyx", line 1147, in cupy.core.core.ndarray.sum
  File "cupy/core/reduction.pxi", line 254, in cupy.core.core.simple_reduction_function.__call__
  File "cupy/util.pyx", line 39, in cupy.util.memoize.decorator.ret
  File "cupy/core/reduction.pxi", line 178, in cupy.core.core._get_simple_reduction_function
  File "cupy/core/reduction.pxi", line 105, in cupy.core.core._get_simple_reduction_kernel
  File "cupy/core/carray.pxi", line 146, in cupy.core.core.compile_with_cache
  File "/home/user/local/miniconda3/envs/chainer2/lib/python2.7/site-packages/cupy/cuda/compiler.py", line 164, in compile_with_cache
    ptx = compile_using_nvrtc(source, options, arch)
  File "/home/user/local/miniconda3/envs/chainer2/lib/python2.7/site-packages/cupy/cuda/compiler.py", line 82, in compile_using_nvrtc
    ptx = prog.compile(options)
  File "/home/user/local/miniconda3/envs/chainer2/lib/python2.7/site-packages/cupy/cuda/compiler.py", line 245, in compile
    raise CompileException(log, self.src, self.name, options)
cupy.cuda.compiler.CompileException: /home/user/local/miniconda3/envs/chainer2/lib/python2.7/site-packages/cupy/core/include/cupy/carray.cuh(275): warning: statement is unreachable
          detected during instantiation of "void CIndexer<_ndim>::set(ptrdiff_t) [with _ndim=1]" 
/tmp/tmpVaFY2x/kern.cu(30): here

/tmp/tmpVaFY2x/kern.cu(32): error: no suitable user-defined conversion from "const type_in0_raw" to "_type_reduce" exists
```