### PR TITLE
Force displaying known methods which are mis-recognized as attributes by Sphinx

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1530,13 +1530,13 @@ cdef class ndarray:
             reference the same location multiple times.
             In that case, the value that is actually stored is undefined.
 
-            >>> import cupy; import numpy
+            >>> import cupy
             >>> a = cupy.zeros((2,))
             >>> i = cupy.arange(10000) % 2
-            >>> v = cupy.arange(10000).astype(numpy.float)
+            >>> v = cupy.arange(10000).astype(cupy.float)
             >>> a[i] = v
             >>> a  # doctest: +SKIP
-            array([ 9150.,  9151.])
+            array([9150., 9151.])
 
             On the other hand, NumPy stores the value corresponding to the
             last index among the indices referencing duplicate locations.
@@ -1547,7 +1547,7 @@ cdef class ndarray:
             >>> v_cpu = numpy.arange(10000).astype(numpy.float)
             >>> a_cpu[i_cpu] = v_cpu
             >>> a_cpu
-            array([ 9998.,  9999.])
+            array([9998., 9999.])
 
         """
         _scatter_op(self, slices, value, 'update')

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1471,11 +1471,11 @@ cdef class ndarray:
            CuPy handles out-of-bounds indices differently from NumPy.
            NumPy handles them by raising an error, but CuPy wraps around them.
 
-           Examples
-           --------
-           >>> a = cupy.arange(3)
-           >>> a[[1, 3]]
-           array([1, 0])
+        Example:
+
+            >>> a = cupy.arange(3)
+            >>> a[[1, 3]]
+            array([1, 0])
 
         """
         # supports basic indexing (by slices, ints or Ellipsis) and

--- a/docs/source/_templates/autosummary/class.rst
+++ b/docs/source/_templates/autosummary/class.rst
@@ -16,7 +16,7 @@
       Special methods
 
 {% for item in ('__call__', '__enter__', '__exit__', '__getitem__', '__setitem__', '__len__', '__next__', '__iter__', '__copy__') %}
-{% if item in all_methods %}
+{% if item in all_methods or item in all_attributes %}
    .. automethod:: {{ item }}
 {% endif %}
 {%- endfor %}


### PR DESCRIPTION
Some `cpdef` methods in cython `cdef` class seems to become `wrapper_descriptor`:

```py
>>> import cupy
>>> type(cupy.ElementwiseKernel.__call__)  # cdef class
<class 'wrapper_descriptor'>
>>> type(cupy.ReductionKernel.__call__)  # class
<class 'cython_function_or_method'>
```

Sphinx cannot decide if `wrapper_descriptor` is a method or an attribute, and mis-recognize it as an attribute, as attributes have higher priorotiy than methods.

https://github.com/sphinx-doc/sphinx/blob/v1.7.4/sphinx/ext/autodoc/__init__.py#L1325-L1327

This PR changes the template to force render known methods as method even if it is recognized as attributes.

This fixes #458 (`ElementwiseKernel.__call__` is not documented), and also adds docs for some important methods like `cupy.ndarray.__getitem__`.
See https://gist.github.com/kmaehashi/776897de58f0ed2ab2e4e2861efdb4fd for the full difference of generated docs.