### PR TITLE
Support bundling dependent DLLs for Windows wheel support

### DIFF
--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -490,27 +490,31 @@ def get_long_description():
 
 
 def prepare_wheel_libs():
-    """Bundle shared libraries for wheels."""
-    libs = []
-    libdirname = None
+    """Prepare shared libraries for wheels.
 
+    On Windows, DLLs will be placed under `cupy/cuda`.
+    On other platforms, shared libraries are placed under `cupy/_libs` and
+    RUNPATH will be set to this directory later.
+    """
+    libdirname = None
     if sys.platform.startswith('win32'):
         libdirname = 'cuda'
-        libfiles = glob.glob('cupy/{}/*.dll'.format(libdirname))
         # Clean up existing libraries.
+        libfiles = glob.glob('cupy/{}/*.dll'.format(libdirname))
         for libfile in libfiles:
             print("Removing file: {}".format(libfile))
             os.remove(libfile)
     else:
         libdirname = '_lib'
-        libdir = 'cupy/{}'.format(libdirname)
         # Clean up the library directory.
+        libdir = 'cupy/{}'.format(libdirname)
         if os.path.exists(libdir):
             print("Removing directory: {}".format(libdir))
             shutil.rmtree(libdir)
         os.mkdir(libdir)
 
     # Copy specified libraries to the library directory.
+    libs = []
     for lib in cupy_setup_options['wheel_libs']:
         # Note: symlink is resolved by shutil.copy2.
         print("Copying library for wheel: {}".format(lib))

--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -347,7 +347,8 @@ def make_extensions(options, compiler, use_cython):
         x for x in settings['library_dirs'] if path.exists(x)]
 
     # Adjust rpath to use CUDA libraries in `cupy/_lib/*.so`) from CuPy.
-    use_wheel_libs_rpath = 0 < len(options['wheel_libs'])
+    use_wheel_libs_rpath = (
+        0 < len(options['wheel_libs']) and not PLATFORM_WIN32)
 
     # This is a workaround for Anaconda.
     # Anaconda installs libstdc++ from GCC 4.8 and it is not compatible

--- a/install/build.py
+++ b/install/build.py
@@ -10,6 +10,10 @@ import tempfile
 from install import utils
 
 
+PLATFORM_DARWIN = sys.platform.startswith('darwin')
+PLATFORM_LINUX = sys.platform.startswith('linux')
+PLATFORM_WIN32 = sys.platform.startswith('win32')
+
 minimum_cuda_version = 7000
 minimum_cudnn_version = 4000
 maximum_cudnn_version = 7999
@@ -76,7 +80,7 @@ def get_nvcc_path():
     if cuda_path is None:
         return None
 
-    if sys.platform == 'win32':
+    if PLATFORM_WIN32:
         nvcc_bin = 'bin/nvcc.exe'
     else:
         nvcc_bin = 'bin/nvcc'
@@ -97,16 +101,16 @@ def get_compiler_setting():
 
     if cuda_path:
         include_dirs.append(os.path.join(cuda_path, 'include'))
-        if sys.platform == 'win32':
+        if PLATFORM_WIN32:
             library_dirs.append(os.path.join(cuda_path, 'bin'))
             library_dirs.append(os.path.join(cuda_path, 'lib', 'x64'))
         else:
             library_dirs.append(os.path.join(cuda_path, 'lib64'))
             library_dirs.append(os.path.join(cuda_path, 'lib'))
-    if sys.platform == 'darwin':
+    if PLATFORM_DARWIN:
         library_dirs.append('/usr/local/cuda/lib')
 
-    if sys.platform == 'win32':
+    if PLATFORM_WIN32:
         nvtoolsext_path = os.environ.get('NVTOOLSEXT_PATH', '')
         if os.path.exists(nvtoolsext_path):
             include_dirs.append(os.path.join(nvtoolsext_path, 'include'))
@@ -349,7 +353,7 @@ def check_cusolver_version(compiler, settings):
 
 
 def check_nvtx(compiler, settings):
-    if sys.platform == 'win32':
+    if PLATFORM_WIN32:
         path = os.environ.get('NVTOOLSEXT_PATH', None)
         if path is None:
             utils.print_warning(
@@ -378,7 +382,7 @@ def build_shlib(compiler, source, libraries=(),
                                    include_dirs=include_dirs)
 
         try:
-            postargs = ['/MANIFEST'] if sys.platform == 'win32' else []
+            postargs = ['/MANIFEST'] if PLATFORM_WIN32 else []
             compiler.link_shared_lib(objects,
                                      os.path.join(temp_dir, 'a'),
                                      libraries=libraries,
@@ -401,7 +405,7 @@ def build_and_run(compiler, source, libraries=(),
                                    include_dirs=include_dirs)
 
         try:
-            postargs = ['/MANIFEST'] if sys.platform == 'win32' else []
+            postargs = ['/MANIFEST'] if PLATFORM_WIN32 else []
             compiler.link_executable(objects,
                                      os.path.join(temp_dir, 'a'),
                                      libraries=libraries,


### PR DESCRIPTION
This PR enables bundling DLLs into wheels for Windows.

```
python setup.py bdist_wheel \
    --cupy-wheel-lib "C:\Program Files\NVIDIA Corporation\NvToolsExt\bin\x64\nvToolsExt64_1.dll" \
    --cupy-wheel-lib "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v9.1\bin\cudnn64_7.dll"
```