### PR TITLE
fix OutOfMemoryError raised even when there are sufficient large freeable chunks

### DIFF
--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -797,6 +797,11 @@ cdef class SingleDeviceMemoryPool:
                     _compact_index(self, stream_ptr, False)
                 break
         finally:
+            # clear references to chunks from local variables
+            # so that errorMemoryAllocation cases in the following section
+            # can cudaFree() the chunks by gc.collect().
+            arena = None
+            free_list = None
             rlock.unlock_fastrlock(self._free_lock)
 
         if chunk is not None:


### PR DESCRIPTION
CuPy sometimes raises `OutOfMemoryError` even if there are sufficient large freeable chunks.
A code to reproduce the problem is at the bottom.


`SingleDeviceMemoryPool._malloc()` tries to `cudaFree()` unused freeable chunks using `free_all_blocks()` and `gc.collect()` in some cases.  But because there are some local variables referencing the freeable chunks, they can't be reclaimed and remains until `_malloc()` ends (unfortunately, by `OutOfMemoryError`).
This PR fixes the problem by clearing such local variables.


The following code reproduces the problem:
```
import cupy

# assume that almost all memory is available
free, total = cupy.cuda.runtime.memGetInfo()
assert free > total*0.97

blob_30pct_1 = cupy.empty(int(0.3*free), dtype=cupy.uint8)
blob_30pct_2 = cupy.empty(int(0.3*free), dtype=cupy.uint8)
# now, 60% is in use and ~40% is free.

del blob_30pct_2
# now, 30% is in use and ~70% is free

blob_60pct_1 = None
try:
  # this is expected to success; 90% will be in use and ~10% will be free
  blob_60pct_1 = cupy.empty(int(0.6*free), dtype=cupy.uint8)
except cupy.cuda.memory.OutOfMemoryError:
  # ... but actually the allocation fails (unexpected behavior #1)
  pass
del blob_60pct_1

blob_60pct_2 = None
try:
  # if the allocation above failed, this will also expected to be failed
  blob_60pct_2 = cupy.empty(int(0.6*free), dtype=cupy.uint8)
  # ... but actually this allocation succeeds (unexpected behavior #2)
except cupy.cuda.memory.OutOfMemoryError:
  pass
del blob_60pct_2
```