### PR TITLE
Improve performance of batch normalization

### DIFF
--- a/cupy/cuda/cudnn.pxd
+++ b/cupy/cuda/cudnn.pxd
@@ -85,6 +85,7 @@ cpdef enum:
 
     CUDNN_BATCHNORM_PER_ACTIVATION = 0
     CUDNN_BATCHNORM_SPATIAL = 1
+    CUDNN_BATCHNORM_SPATIAL_PERSISTENT = 2
 
     CUDNN_RNN_RELU = 0
     CUDNN_RNN_TANH = 1
@@ -103,11 +104,25 @@ cpdef enum:
 
     CUDNN_SAMPLER_BILINEAR = 0
 
+    CUDNN_STATUS_SUCCESS = 0
+    CUDNN_STATUS_RUNTIME_PREREQUISITE_MISSING = 11
+    CUDNN_STATUS_RUNTIME_IN_PROGRESS = 12
+    CUDNN_STATUS_RUNTIME_FP_OVERFLOW = 13
+
+    CUDNN_ERRQUERY_RAWCODE = 0
+    CUDNN_ERRQUERY_NONBLOCKING = 1
+    CUDNN_ERRQUERY_BLOCKING = 2
+
 ###############################################################################
 # Version
 ###############################################################################
 
 cpdef size_t getVersion() except *
+
+###############################################################################
+# Runtime error checking
+###############################################################################
+cpdef queryRuntimeError(size_t handle, int mode)
 
 ###############################################################################
 # Initialization and CUDA cooperation

--- a/cupy/cuda/cudnn.pyx
+++ b/cupy/cuda/cudnn.pyx
@@ -55,6 +55,8 @@ cdef extern from "cupy_cudnn.h" nogil:
     ctypedef int SoftmaxMode 'cudnnSoftmaxMode_t'
     ctypedef int Status 'cudnnStatus_t'
     ctypedef int TensorFormat 'cudnnTensorFormat_t'
+    ctypedef int ErrQueryMode 'cudnnErrQueryMode_t'
+    ctypedef struct RuntimeTag 'cudnnRuntimeTag_t'
 
     ctypedef void* ActivationDescriptor 'cudnnActivationDescriptor_t'
     ctypedef void* ConvolutionDescriptor 'cudnnConvolutionDescriptor_t'
@@ -74,6 +76,10 @@ cdef extern from "cupy_cudnn.h" nogil:
 
     # Version
     size_t cudnnGetVersion()
+
+    # Runtime error checking
+    int cudnnQueryRuntimeError(Handle handle, Status *rstatus,
+                               ErrQueryMode mode, RuntimeTag *tag)
 
     # Initialization and CUDA cooperation
     int cudnnCreate(Handle* handle)
@@ -475,6 +481,19 @@ def get_build_version():
 
 cpdef size_t getVersion() except *:
     return cudnnGetVersion()
+
+
+###############################################################################
+# Runtime error checking
+###############################################################################
+
+cpdef queryRuntimeError(size_t handle, int mode):
+    cdef Status rstatus
+    with nogil:
+        status = cudnnQueryRuntimeError(<Handle>handle, &rstatus,
+                                        <ErrQueryMode>mode, <RuntimeTag*>0)
+    check_status(status)
+    return rstatus
 
 
 ###############################################################################

--- a/cupy/cuda/cupy_cudnn.h
+++ b/cupy/cuda/cupy_cudnn.h
@@ -29,7 +29,8 @@ typedef enum {} cudnnPoolingMode_t;
 typedef enum {} cudnnSoftmaxAlgorithm_t;
 typedef enum {} cudnnSoftmaxMode_t;
 typedef enum {} cudnnTensorFormat_t;
-
+typedef enum {} cudnnErrQueryMode_t;
+typedef struct cudnnRuntimeTag_t cudnnRuntimeTag_t;
 
 typedef void* cudnnConvolutionDescriptor_t;
 typedef void* cudnnFilterDescriptor_t;
@@ -49,6 +50,10 @@ size_t cudnnGetVersion() {
     return CUDNN_STATUS_SUCCESS;
 }
 
+// Runtime error checking
+cudnnStatus_t cudnnQueryRuntimeError(...) {
+    return CUDNN_STATUS_SUCCESS;
+}
 
 // Initialization and CUDA cooperation
 cudnnStatus_t cudnnCreate(...) {
@@ -594,6 +599,18 @@ cudnnStatus_t cudnnSetConvolution2dDescriptor_v4(...) {
 #define cudnnGetConvolutionBackwardDataAlgorithm_v6 cudnnGetConvolutionBackwardDataAlgorithm
 
 #endif // #if !defined(CUPY_NO_CUDA) && (CUDNN_VERSION < 8000)
+
+
+#if !defined(CUPY_NO_CUDA) && (CUDNN_VERSION < 7000)
+
+typedef enum {} cudnnErrQueryMode_t;
+typedef struct cudnnRuntimeTag_t cudnnRuntimeTag_t;
+
+cudnnStatus_t cudnnQueryRuntimeError(...) {
+    return CUDNN_STATUS_SUCCESS;
+}
+
+#endif // !defined(CUPY_NO_CUDA) && (CUDNN_VERSION < 7000)
 
 } // extern "C"
 


### PR DESCRIPTION
This PR aims to improve performance of batch normalization on GPU.

cuDNN batch normalization may not be so fast sometime specifically when batch size and/or channel size is small and image size is big. The **CUDNN_BATCHNORM_SPATIAL_PERSISTENT** mode that is supported by cuDNN 7.0 or later can improve the performance for that cases. This PR is related to this mode and allows you to use this mode for batch normalization layers in your models.

Please take a look at [here](https://docs.nvidia.com/deeplearning/sdk/cudnn-developer-guide/index.html#cudnnBatchNormMode_t) for details about **CUDNN_BATCHNORM_SPATIAL_PERSISTENT**.