### PR TITLE
allow non-decorator usage of cp.fuse

### DIFF
--- a/cupy/core/fusion.py
+++ b/cupy/core/fusion.py
@@ -673,7 +673,15 @@ def fuse(*args, **kwargs):
        the future version.
 
     """
+    if 'func' in kwargs:
+        pass_kwargs = kwargs.copy()
+        del pass_kwargs['func']
+        return _fuse(kwargs['func'], *args, **pass_kwargs)
+    else:
+        return _fuse
 
+
+def _fuse(*args, **kwargs):
     def wrapper(
             f, input_num=None, reduce=None, post_map=lambda x: x,
             kernel_name=None):


### PR DESCRIPTION
Modifies definition of `cp.fuse` to allow `func` kwarg.  This enables the following usage pattern:

```
import cupy as cp

arr = cp.ones(10)


def test(x):
    return x + x + x


# note this usage
test2 = cp.fuse(func=test)

@cp.fuse()
def test3(x):
    return x + x + x


# test(arr), test2(arr), and test3(arr) return the same values
```

Resolves #1264 

The test suite may need a new entry that tests this behavior.  I do not know the coverage of cp.fuse.