### PR TITLE
Fix astype for complex dtypes

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -350,7 +350,9 @@ cdef class ndarray:
         else:
             newarray = ndarray(self.shape, dtype=dtype, order=order)
 
-        if self.dtype.kind == 'c' and newarray.dtype.kind != 'c':
+        if self.dtype.kind == 'c' and newarray.dtype.kind == 'b':
+            cupy.not_equal(self, 0j, out=newarray)
+        elif self.dtype.kind == 'c' and newarray.dtype.kind != 'c':
             warnings.warn(
                 'Casting complex values to real discards the imaginary part',
                 numpy.ComplexWarning)

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -356,7 +356,7 @@ cdef class ndarray:
             warnings.warn(
                 'Casting complex values to real discards the imaginary part',
                 numpy.ComplexWarning)
-            elementwise_copy(self.real, newarray)
+            elementwise_copy(ascontiguousarray(self).real, newarray)
         else:
             elementwise_copy(self, newarray)
         return newarray

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -349,7 +349,14 @@ cdef class ndarray:
             newarray._set_shape_and_strides(self._shape, strides)
         else:
             newarray = ndarray(self.shape, dtype=dtype, order=order)
-        elementwise_copy(self, newarray)
+
+        if self.dtype.kind == 'c' and newarray.dtype.kind != 'c':
+            warnings.warn(
+                'Casting complex values to real discards the imaginary part',
+                numpy.ComplexWarning)
+            elementwise_copy(self.real, newarray)
+        else:
+            elementwise_copy(self, newarray)
         return newarray
 
     # TODO(okuta): Implement byteswap

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,3 +5,4 @@ exclude = .eggs,*.egg,build,caffe_pb2.py,caffe_pb3.py,docs,.git
 filterwarnings= ignore::FutureWarning
                 ignore::UserWarning
                 error::DeprecationWarning
+                error::numpy.ComplexWarning

--- a/tests/cupy_tests/core_tests/test_ndarray_copy_and_view.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_copy_and_view.py
@@ -87,8 +87,7 @@ class TestArrayCopyAndView(unittest.TestCase):
         return b
 
     @testing.for_orders(['C', 'F', 'A', 'K', None])
-    @testing.for_all_dtypes(name='src_dtype')
-    @testing.for_all_dtypes(name='dst_dtype')
+    @testing.for_all_dtypes_combination(('src_dtype', 'dst_dtype'))
     @testing.numpy_cupy_array_equal()
     def test_astype(self, xp, src_dtype, dst_dtype, order):
         a = testing.shaped_arange((2, 3, 4), xp, src_dtype)

--- a/tests/cupy_tests/core_tests/test_ndarray_copy_and_view.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_copy_and_view.py
@@ -6,6 +6,15 @@ import cupy
 from cupy import testing
 
 
+def astype_without_warning(x, dtype, *args, **kwargs):
+    if (numpy.dtype(x.dtype).kind == 'c' and
+            numpy.dtype(dtype).kind not in ['b', 'c']):
+        with testing.assert_warns(numpy.ComplexWarning):
+            return x.astype(dtype, *args, **kwargs)
+    else:
+        return x.astype(dtype, *args, **kwargs)
+
+
 @testing.gpu
 class TestArrayCopyAndView(unittest.TestCase):
 
@@ -91,32 +100,15 @@ class TestArrayCopyAndView(unittest.TestCase):
     @testing.numpy_cupy_array_equal()
     def test_astype(self, xp, src_dtype, dst_dtype, order):
         a = testing.shaped_arange((2, 3, 4), xp, src_dtype)
-        if (numpy.dtype(src_dtype).kind == 'c' and
-                numpy.dtype(dst_dtype).kind not in ['b', 'c']):
-            with testing.assert_warns(numpy.ComplexWarning):
-                return a.astype(dst_dtype, order=order)
-        else:
-            return a.astype(dst_dtype, order=order)
+        return astype_without_warning(a, dst_dtype, order=order)
 
     @testing.for_orders('CFAK')
     @testing.for_all_dtypes_combination(('src_dtype', 'dst_dtype'))
     def test_astype_type(self, src_dtype, dst_dtype, order):
-        complex_warning = (numpy.dtype(src_dtype).kind == 'c' and
-                           numpy.dtype(dst_dtype).kind not in ['b', 'c'])
-
         a = testing.shaped_arange((2, 3, 4), cupy, src_dtype)
-        if complex_warning:
-            with testing.assert_warns(numpy.ComplexWarning):
-                b = a.astype(dst_dtype, order=order)
-        else:
-            b = a.astype(dst_dtype, order=order)
-
+        b = astype_without_warning(a, dst_dtype, order=order)
         a_cpu = testing.shaped_arange((2, 3, 4), numpy, src_dtype)
-        if complex_warning:
-            with testing.assert_warns(numpy.ComplexWarning):
-                b_cpu = a_cpu.astype(dst_dtype, order=order)
-        else:
-            b_cpu = a_cpu.astype(dst_dtype, order=order)
+        b_cpu = astype_without_warning(a_cpu, dst_dtype, order=order)
         self.assertEqual(b.dtype.type, b_cpu.dtype.type)
 
     @testing.for_orders('CAK')
@@ -134,34 +126,34 @@ class TestArrayCopyAndView(unittest.TestCase):
         b = a.astype(dtype, order=order, copy=False)
         self.assertTrue(b is a)
 
-    @testing.for_all_dtypes(name='src_dtype', no_complex=True)
-    @testing.for_all_dtypes(name='dst_dtype')
+    @testing.for_all_dtypes_combination(('src_dtype', 'dst_dtype'))
     @testing.numpy_cupy_array_equal()
     def test_astype_strides(self, xp, src_dtype, dst_dtype):
         src = xp.empty((1, 2, 3), dtype=src_dtype)
-        return numpy.array(src.astype(dst_dtype, order='K').strides)
+        return numpy.array(
+            astype_without_warning(src, dst_dtype, order='K').strides)
 
-    @testing.for_all_dtypes(name='src_dtype', no_complex=True)
-    @testing.for_all_dtypes(name='dst_dtype')
+    @testing.for_all_dtypes_combination(('src_dtype', 'dst_dtype'))
     @testing.numpy_cupy_array_equal()
     def test_astype_strides_negative(self, xp, src_dtype, dst_dtype):
         src = xp.empty((2, 3), dtype=src_dtype)[::-1, :]
-        return numpy.array(src.astype(dst_dtype, order='K').strides)
+        return numpy.array(
+            astype_without_warning(src, dst_dtype, order='K').strides)
 
-    @testing.for_all_dtypes(name='src_dtype', no_complex=True)
-    @testing.for_all_dtypes(name='dst_dtype')
+    @testing.for_all_dtypes_combination(('src_dtype', 'dst_dtype'))
     @testing.numpy_cupy_array_equal()
     def test_astype_strides_swapped(self, xp, src_dtype, dst_dtype):
         src = xp.swapaxes(xp.empty((2, 3, 4), dtype=src_dtype), 1, 0)
-        return numpy.array(src.astype(dst_dtype, order='K').strides)
+        return numpy.array(
+            astype_without_warning(src, dst_dtype, order='K').strides)
 
-    @testing.for_all_dtypes(name='src_dtype', no_complex=True)
-    @testing.for_all_dtypes(name='dst_dtype')
+    @testing.for_all_dtypes_combination(('src_dtype', 'dst_dtype'))
     @testing.numpy_cupy_array_equal()
     def test_astype_strides_broadcast(self, xp, src_dtype, dst_dtype):
         src, _ = xp.broadcast_arrays(xp.empty((2,), dtype=src_dtype),
                                      xp.empty((2, 3, 2), dtype=src_dtype))
-        return numpy.array(src.astype(dst_dtype, order='K').strides)
+        return numpy.array(
+            astype_without_warning(src, dst_dtype, order='K').strides)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()

--- a/tests/cupy_tests/core_tests/test_ndarray_copy_and_view.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_copy_and_view.py
@@ -99,13 +99,24 @@ class TestArrayCopyAndView(unittest.TestCase):
             return a.astype(dst_dtype, order=order)
 
     @testing.for_orders('CFAK')
-    @testing.for_all_dtypes(name='src_dtype', no_complex=True)
-    @testing.for_all_dtypes(name='dst_dtype')
+    @testing.for_all_dtypes_combination(('src_dtype', 'dst_dtype'))
     def test_astype_type(self, src_dtype, dst_dtype, order):
+        complex_warning = (numpy.dtype(src_dtype).kind == 'c' and
+                           numpy.dtype(dst_dtype).kind not in ['b', 'c'])
+
         a = testing.shaped_arange((2, 3, 4), cupy, src_dtype)
-        b = a.astype(dst_dtype, order=order)
+        if complex_warning:
+            with testing.assert_warns(numpy.ComplexWarning):
+                b = a.astype(dst_dtype, order=order)
+        else:
+            b = a.astype(dst_dtype, order=order)
+
         a_cpu = testing.shaped_arange((2, 3, 4), numpy, src_dtype)
-        b_cpu = a_cpu.astype(dst_dtype, order=order)
+        if complex_warning:
+            with testing.assert_warns(numpy.ComplexWarning):
+                b_cpu = a_cpu.astype(dst_dtype, order=order)
+        else:
+            b_cpu = a_cpu.astype(dst_dtype, order=order)
         self.assertEqual(b.dtype.type, b_cpu.dtype.type)
 
     @testing.for_orders('CAK')

--- a/tests/cupy_tests/core_tests/test_ndarray_copy_and_view.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_copy_and_view.py
@@ -87,12 +87,17 @@ class TestArrayCopyAndView(unittest.TestCase):
         return b
 
     @testing.for_orders(['C', 'F', 'A', 'K', None])
-    @testing.for_all_dtypes(name='src_dtype', no_complex=True)
+    @testing.for_all_dtypes(name='src_dtype')
     @testing.for_all_dtypes(name='dst_dtype')
     @testing.numpy_cupy_array_equal()
     def test_astype(self, xp, src_dtype, dst_dtype, order):
         a = testing.shaped_arange((2, 3, 4), xp, src_dtype)
-        return a.astype(dst_dtype, order=order)
+        if (numpy.dtype(src_dtype).kind == 'c' and
+                numpy.dtype(dst_dtype).kind not in ['b', 'c']):
+            with testing.assert_warns(numpy.ComplexWarning):
+                return a.astype(dst_dtype, order=order)
+        else:
+            return a.astype(dst_dtype, order=order)
 
     @testing.for_orders('CFAK')
     @testing.for_all_dtypes(name='src_dtype', no_complex=True)

--- a/tests/cupy_tests/core_tests/test_ndarray_copy_and_view.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_copy_and_view.py
@@ -7,8 +7,8 @@ from cupy import testing
 
 
 def astype_without_warning(x, dtype, *args, **kwargs):
-    if (numpy.dtype(x.dtype).kind == 'c' and
-            numpy.dtype(dtype).kind not in ['b', 'c']):
+    dtype = numpy.dtype(dtype)
+    if x.dtype.kind == 'c' and dtype.kind not in ['b', 'c']:
         with testing.assert_warns(numpy.ComplexWarning):
             return x.astype(dtype, *args, **kwargs)
     else:


### PR DESCRIPTION
- complex to bool checks if each element is non-zero
- complex to int and complex to float uses real part

```
>>> numpy.array([0+1j]).astype('?')
array([ True], dtype=bool)
>>> numpy.array([0+1j]).astype('i')
__main__:1: ComplexWarning: Casting complex values to real discards the imaginary part
array([0], dtype=int32)
>>> numpy.array([0+1j]).astype('f')
array([ 0.], dtype=float32)
```

fix #1276