### PR TITLE
Support rounding for complex types

### DIFF
--- a/cupy/core/include/cupy/complex.cuh
+++ b/cupy/core/include/cupy/complex.cuh
@@ -76,6 +76,10 @@ template<typename T> __device__ complex<T> max(complex<T> x, complex<T> y) {
     } else {
         return x;
     }
+
+template<typename T> __device__ complex<T> rint(complex<T> x) {
+    return complex<T>(rint(x.real()), rint(x.imag()));
+}
 }
 
 // ToDo: assignment operator for complex<T> = T2 for T2 all types

--- a/cupy/math/rounding.py
+++ b/cupy/math/rounding.py
@@ -23,7 +23,7 @@ floor = ufunc.create_math_ufunc(
 
     .. seealso:: :data:`numpy.floor`
 
-    ''')
+    ''', support_complex=False)
 
 
 ceil = ufunc.create_math_ufunc(
@@ -32,7 +32,7 @@ ceil = ufunc.create_math_ufunc(
 
     .. seealso:: :data:`numpy.ceil`
 
-    ''')
+    ''', support_complex=False)
 
 
 trunc = ufunc.create_math_ufunc(
@@ -41,7 +41,7 @@ trunc = ufunc.create_math_ufunc(
 
     .. seealso:: :data:`numpy.trunc`
 
-    ''')
+    ''', support_complex=False)
 
 
 fix = core.create_ufunc(
@@ -52,4 +52,4 @@ fix = core.create_ufunc(
 
     .. seealso:: :func:`numpy.fix`
 
-    ''')
+    ''', support_complex=False)

--- a/cupy/math/rounding.py
+++ b/cupy/math/rounding.py
@@ -52,4 +52,4 @@ fix = core.create_ufunc(
 
     .. seealso:: :func:`numpy.fix`
 
-    ''', support_complex=False)
+    ''')

--- a/cupy/math/ufunc.py
+++ b/cupy/math/ufunc.py
@@ -1,13 +1,17 @@
 from cupy import core
 
 
-def create_math_ufunc(math_name, nargs, name, doc):
+def create_math_ufunc(math_name, nargs, name, doc, support_complex=True):
     assert 1 <= nargs <= 2
     if nargs == 1:
+        types = ('e->e', 'f->f', 'd->d')
+        if support_complex:
+            types += ('F->F', 'D->D')
         return core.create_ufunc(
-            name, ('e->e', 'f->f', 'd->d', 'F->F', 'D->D'),
-            'out0 = %s(in0)' % math_name, doc=doc)
+            name, types, 'out0 = %s(in0)' % math_name, doc=doc)
     else:
+        types = ('ee->e', 'ff->f', 'dd->d')
+        if support_complex:
+            types += ('FF->F', 'DD->D')
         return core.create_ufunc(
-            name, ('ee->e', 'ff->f', 'dd->d', 'FF->F', 'DD->D'),
-            'out0 = %s(in0, in1)' % math_name, doc=doc)
+            name, types, 'out0 = %s(in0, in1)' % math_name, doc=doc)

--- a/tests/cupy_tests/math_tests/test_rounding.py
+++ b/tests/cupy_tests/math_tests/test_rounding.py
@@ -12,26 +12,50 @@ class TestRounding(unittest.TestCase):
         a = testing.shaped_arange((2, 3), xp, dtype)
         return getattr(xp, name)(a)
 
+    @testing.for_complex_dtypes()
+    @testing.numpy_cupy_allclose(atol=1e-5)
+    def check_unary_complex(self, name, xp, dtype):
+        a = testing.shaped_arange((2, 3), xp, dtype)
+        return getattr(xp, name)(a)
+
+    @testing.for_complex_dtypes()
+    @testing.numpy_cupy_raises(TypeError)
+    def check_unary_complex_unsupported(self, name, xp, dtype):
+        a = testing.shaped_arange((2, 3), xp, dtype)
+        getattr(xp, name)(a)
+
     @testing.for_dtypes(['?', 'b', 'h', 'i', 'q', 'e', 'f', 'd'])
     @testing.numpy_cupy_allclose(atol=1e-5)
     def check_unary_negative(self, name, xp, dtype):
         a = xp.array([-3, -2, -1, 1, 2, 3], dtype=dtype)
         return getattr(xp, name)(a)
 
+    @testing.for_complex_dtypes()
+    @testing.numpy_cupy_allclose(atol=1e-5)
+    def check_unary_negative_complex(self, name, xp, dtype):
+        a = xp.array([-3-3j, -2-2j, -1-1j, 1+1j, 2+2j, 3+3j], dtype=dtype)
+        return getattr(xp, name)(a)
+
     def test_rint(self):
         self.check_unary('rint')
+        self.check_unary_complex('rint')
 
     def test_rint_negative(self):
         self.check_unary_negative('rint')
+        self.check_unary_negative_complex('rint')
 
     def test_floor(self):
         self.check_unary('floor')
+        self.check_unary_complex_unsupported('floor')
 
     def test_ceil(self):
         self.check_unary('ceil')
+        self.check_unary_complex_unsupported('ceil')
 
     def test_trunc(self):
         self.check_unary('trunc')
+        self.check_unary_complex_unsupported('trunc')
 
     def test_fix(self):
         self.check_unary('fix')
+        self.check_unary_complex_unsupported('fix')


### PR DESCRIPTION
`rint` is applied to both real and imag.
related to #1281 