### PR TITLE
catch C++ exceptions from Thrust

### DIFF
--- a/cupy/cuda/thrust.pyx
+++ b/cupy/cuda/thrust.pyx
@@ -26,7 +26,7 @@ cdef extern from "../cuda/cupy_thrust.h" namespace "cupy::thrust":
 ###############################################################################
 
 cpdef sort(dtype, size_t data_start, size_t keys_start,
-           vector.vector[ptrdiff_t]& shape):
+           vector.vector[ptrdiff_t]& shape) except +:
 
     cdef void *_data_start
     cdef size_t *_keys_start
@@ -62,7 +62,8 @@ cpdef sort(dtype, size_t data_start, size_t keys_start,
                                   'supported'.format(dtype))
 
 
-cpdef lexsort(dtype, size_t idx_start, size_t keys_start, size_t k, size_t n):
+cpdef lexsort(
+    dtype, size_t idx_start, size_t keys_start, size_t k, size_t n) except +:
 
     cdef size_t _strm
 
@@ -97,7 +98,7 @@ cpdef lexsort(dtype, size_t idx_start, size_t keys_start, size_t k, size_t n):
 
 
 cpdef argsort(dtype, size_t idx_start, size_t data_start, size_t keys_start,
-              vector.vector[ptrdiff_t]& shape):
+              vector.vector[ptrdiff_t]& shape) except +:
     cdef size_t *_idx_start
     cdef size_t *_keys_start
     cdef void *_data_start

--- a/cupy/cuda/thrust.pyx
+++ b/cupy/cuda/thrust.pyx
@@ -62,8 +62,8 @@ cpdef sort(dtype, size_t data_start, size_t keys_start,
                                   'supported'.format(dtype))
 
 
-cpdef lexsort(
-    dtype, size_t idx_start, size_t keys_start, size_t k, size_t n) except +:
+cpdef lexsort(dtype, size_t idx_start, size_t keys_start,
+              size_t k, size_t n) except +:
 
     cdef size_t _strm
 


### PR DESCRIPTION
Thrust may raise C++ exceptions.
We should translate it, otherwise python process will abort when exception is thrown.

```
Traceback (most recent call last):
  File "test.py", line 11, in test
    cupy.unique(arr, return_inverse=True)
  File "/home/kenichi/Development/cupy/cupy/manipulation/add_remove.py", line 65, in unique
    perm = ar.argsort()
  File "cupy/core/core.pyx", line 844, in cupy.core.core.ndarray.argsort
    thrust.argsort(self.dtype, idx_array.data.ptr, data.data.ptr, 0,
  File "cupy/cuda/thrust.pyx", line 100, in cupy.cuda.thrust.argsort
    cpdef argsort(dtype, size_t idx_start, size_t data_start, size_t keys_start,
RuntimeError: radix_sort: failed to get memory buffer: out of memory
```