### PR TITLE
Fix `real`, `imag` of non-contiguous complex arrays

### DIFF
--- a/cupy/core/core.pxd
+++ b/cupy/core/core.pxd
@@ -62,6 +62,7 @@ cdef class ndarray:
     cpdef _set_shape_and_strides(self, vector.vector[Py_ssize_t]& shape,
                                  vector.vector[Py_ssize_t]& strides,
                                  bint update_c_contiguity=*)
+    cpdef _set_dtype(self, object dtype)
     cdef CPointer get_pointer(self)
     cpdef object toDlpack(self)
 

--- a/cupy/core/core.pxd
+++ b/cupy/core/core.pxd
@@ -62,7 +62,6 @@ cdef class ndarray:
     cpdef _set_shape_and_strides(self, vector.vector[Py_ssize_t]& shape,
                                  vector.vector[Py_ssize_t]& strides,
                                  bint update_c_contiguity=*)
-    cpdef _set_dtype(self, object dtype)
     cdef CPointer get_pointer(self)
     cpdef object toDlpack(self)
 

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1412,11 +1412,8 @@ cdef class ndarray:
     @property
     def real(self):
         if self.dtype.kind == 'c':
-            if self.ndim == 0:
-                # `view` does not work with zero-dim array
-                return self.reshape(1).real[0]
-            view = self.view(self.dtype.char.lower())
-            view._set_shape_and_strides(self.shape, self.strides)
+            view = self.view()
+            view._set_dtype(numpy.dtype(self.dtype.char.lower()))
             return view
         return self
 
@@ -1430,11 +1427,8 @@ cdef class ndarray:
     @property
     def imag(self):
         if self.dtype.kind == 'c':
-            if self.ndim == 0:
-                # `view` does not work with zero-dim array
-                return self.reshape(1).imag[0]
-            view = self.view(self.dtype.char.lower())
-            view._set_shape_and_strides(self.shape, self.strides)
+            view = self.view()
+            view._set_dtype(numpy.dtype(self.dtype.char.lower()))
             view.data = view.data + self.itemsize // 2
             return view
         new_array = ndarray(self.shape, dtype=self.dtype)
@@ -1776,6 +1770,9 @@ cdef class ndarray:
             self._update_contiguity()
         else:
             self._update_f_contiguity()
+
+    cpdef _set_dtype(self, object dtype):
+        self.dtype = dtype
 
     cdef function.CPointer get_pointer(self):
         return CArray(self)
@@ -4123,7 +4120,6 @@ real = create_ufunc(
     .. seealso:: :func:`numpy.real`
 
     ''')
-
 
 _real_setter = create_ufunc(
     'cupy_real_setter',

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -356,7 +356,7 @@ cdef class ndarray:
             warnings.warn(
                 'Casting complex values to real discards the imaginary part',
                 numpy.ComplexWarning)
-            elementwise_copy(ascontiguousarray(self).real, newarray)
+            elementwise_copy(self.real, newarray)
         else:
             elementwise_copy(self, newarray)
         return newarray

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1412,8 +1412,10 @@ cdef class ndarray:
     @property
     def real(self):
         if self.dtype.kind == 'c':
-            view = self.view()
-            view._set_dtype(numpy.dtype(self.dtype.char.lower()))
+            view = ndarray(
+                shape=(), dtype=numpy.dtype(self.dtype.char.lower()),
+                memptr=self.data)
+            view._set_shape_and_strides(self.shape, self.strides)
             return view
         return self
 
@@ -1427,9 +1429,10 @@ cdef class ndarray:
     @property
     def imag(self):
         if self.dtype.kind == 'c':
-            view = self.view()
-            view._set_dtype(numpy.dtype(self.dtype.char.lower()))
-            view.data = view.data + self.itemsize // 2
+            view = ndarray(
+                shape=(), dtype=numpy.dtype(self.dtype.char.lower()),
+                memptr=self.data + self.itemsize // 2)
+            view._set_shape_and_strides(self.shape, self.strides)
             return view
         new_array = ndarray(self.shape, dtype=self.dtype)
         new_array.fill(0)
@@ -1770,9 +1773,6 @@ cdef class ndarray:
             self._update_contiguity()
         else:
             self._update_f_contiguity()
-
-    cpdef _set_dtype(self, object dtype):
-        self.dtype = dtype
 
     cdef function.CPointer get_pointer(self):
         return CArray(self)

--- a/tests/cupy_tests/core_tests/test_ndarray_complex_ops.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_complex_ops.py
@@ -50,6 +50,12 @@ class TestRealImag(unittest.TestCase):
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_almost_equal(accept_error=False)
+    def test_real_non_contiguous(self, xp, dtype):
+        x = testing.shaped_arange((2, 3, 2), xp, dtype).transpose(0, 2, 1)
+        return x.real
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_almost_equal(accept_error=False)
     def test_imag(self, xp, dtype):
         x = testing.shaped_arange((2, 3), xp, dtype)
         return x.imag
@@ -58,6 +64,12 @@ class TestRealImag(unittest.TestCase):
     @testing.numpy_cupy_array_almost_equal(accept_error=False)
     def test_imag_zero_dim(self, xp, dtype):
         x = xp.array(1, dtype=dtype)
+        return x.imag
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_almost_equal(accept_error=False)
+    def test_imag_non_contiguous(self, xp, dtype):
+        x = testing.shaped_arange((2, 3, 2), xp, dtype).transpose(0, 2, 1)
         return x.imag
 
     @testing.for_all_dtypes()
@@ -76,6 +88,13 @@ class TestRealImag(unittest.TestCase):
 
     @testing.for_dtypes('FD')
     @testing.numpy_cupy_array_almost_equal(accept_error=False)
+    def test_real_setter_non_contiguous(self, xp, dtype):
+        x = testing.shaped_arange((2, 3, 2), xp, dtype).transpose(0, 2, 1)
+        x.real = testing.shaped_reverse_arange((2, 2, 3), xp, dtype).real
+        return x
+
+    @testing.for_dtypes('FD')
+    @testing.numpy_cupy_array_almost_equal(accept_error=False)
     def test_imag_setter(self, xp, dtype):
         x = testing.shaped_arange((2, 3), xp, dtype)
         x.imag = testing.shaped_reverse_arange((2, 3), xp, dtype).real
@@ -86,6 +105,13 @@ class TestRealImag(unittest.TestCase):
     def test_imag_setter_zero_dim(self, xp, dtype):
         x = xp.array(1, dtype=dtype)
         x.imag = 2
+        return x
+
+    @testing.for_dtypes('FD')
+    @testing.numpy_cupy_array_almost_equal(accept_error=False)
+    def test_imag_setter_non_contiguous(self, xp, dtype):
+        x = testing.shaped_arange((2, 3, 2), xp, dtype).transpose(0, 2, 1)
+        x.imag = testing.shaped_reverse_arange((2, 2, 3), xp, dtype).real
         return x
 
     @testing.for_all_dtypes(no_complex=True)


### PR DESCRIPTION
Fix `ndarray.real` and `ndarray.imag` that have relied on a numpy-incompatible behavior of `ndarray.view(dtype)`, which was fixed in f1946967ea1cecfed3c7b2e0c4841c6c837458b2.