### PR TITLE
[backport] Add NumPy 1.14 to supported versions

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -31,7 +31,7 @@ You need to have the following components to use CuPy.
 * `Python <https://python.org/>`_
     * Supported Versions: 2.7.6+, 3.4.3+, 3.5.1+ and 3.6.0+.
 * `NumPy <http://www.numpy.org/>`_
-    * Supported Versions: 1.9, 1.10, 1.11, 1.12 and 1.13.
+    * Supported Versions: 1.9, 1.10, 1.11, 1.12, 1.13 and 1.14.
     * NumPy will be installed automatically during the installation of CuPy.
 
 Before installing CuPy, we recommend you to upgrade ``setuptools`` and ``pip``::


### PR DESCRIPTION
Backport of #1139