### PR TITLE
Add license file to wheel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,6 @@ filterwarnings= ignore::FutureWarning
                 ignore::UserWarning
                 error::DeprecationWarning
                 error::numpy.ComplexWarning
+
+[metadata]
+license_file = docs/source/license.rst


### PR DESCRIPTION
Include license file to wheel distribution.
`license.rst` will be installed under `.../site-packages/cupy-5.0.0b1.dist-info/LICENSE.txt`.

Note: currently wheel does not support adding multiple license files.
https://wheel.readthedocs.io/en/stable/#including-the-license-in-the-generated-wheel-file

Related to #1330