### PR TITLE
Add scipy_name to testing helper functions

### DIFF
--- a/cupy/testing/helper.py
+++ b/cupy/testing/helper.py
@@ -19,6 +19,7 @@ from cupy import internal
 import cupy.sparse
 from cupy.testing import array
 from cupy.testing import parameterized
+import cupyx
 
 
 def _call_func(self, impl, args, kw):
@@ -88,12 +89,15 @@ def _contains_signed_and_unsigned(kw):
         any(d in vs for d in _float_dtypes + _signed_dtypes)
 
 
-def _make_decorator(check_func, name, type_check, accept_error, sp_name=None):
+def _make_decorator(check_func, name, type_check, accept_error, sp_name=None,
+                    scipy_name=None):
     def decorator(impl):
         @functools.wraps(impl)
         def test_func(self, *args, **kw):
             if sp_name:
                 kw[sp_name] = cupy.sparse
+            if scipy_name:
+                kw[scipy_name] = cupyx.scipy
             kw[name] = cupy
             cupy_result, cupy_error, cupy_tb = _call_func(self, impl, args, kw)
 
@@ -101,6 +105,9 @@ def _make_decorator(check_func, name, type_check, accept_error, sp_name=None):
             if sp_name:
                 import scipy.sparse
                 kw[sp_name] = scipy.sparse
+            if scipy_name:
+                import scipy
+                kw[scipy_name] = scipy
             numpy_result, numpy_error, numpy_tb = \
                 _call_func(self, impl, args, kw)
 
@@ -138,7 +145,7 @@ def _make_decorator(check_func, name, type_check, accept_error, sp_name=None):
 
 def numpy_cupy_allclose(rtol=1e-7, atol=0, err_msg='', verbose=True,
                         name='xp', type_check=True, accept_error=False,
-                        sp_name=None, contiguous_check=True):
+                        sp_name=None, scipy_name=None, contiguous_check=True):
     """Decorator that checks NumPy results and CuPy ones are close.
 
     Args:
@@ -159,6 +166,9 @@ def numpy_cupy_allclose(rtol=1e-7, atol=0, err_msg='', verbose=True,
          sp_name(str or None): Argument name whose value is either
              ``scipy.sparse`` or ``cupy.sparse`` module. If ``None``, no
              argument is given for the modules.
+         scipy_name(str or None): Argument name whose value is either ``scipy``
+             or ``cupyx.scipy`` module. If ``None``, no argument is given for
+             the modules.
          contiguous_check(bool): If ``True``, consistency of contiguity is
              also checked.
 
@@ -198,12 +208,14 @@ def numpy_cupy_allclose(rtol=1e-7, atol=0, err_msg='', verbose=True,
                     'The state of f_contiguous flag is false. '
                     '(cupy_result:{} numpy_result:{})'.format(
                         c.flags.f_contiguous, n.flags.f_contiguous))
-    return _make_decorator(check_func, name, type_check, accept_error, sp_name)
+    return _make_decorator(check_func, name, type_check, accept_error, sp_name,
+                           scipy_name)
 
 
 def numpy_cupy_array_almost_equal(decimal=6, err_msg='', verbose=True,
                                   name='xp', type_check=True,
-                                  accept_error=False, sp_name=None):
+                                  accept_error=False, sp_name=None,
+                                  scipy_name=None):
     """Decorator that checks NumPy results and CuPy ones are almost equal.
 
     Args:
@@ -223,6 +235,9 @@ def numpy_cupy_array_almost_equal(decimal=6, err_msg='', verbose=True,
          sp_name(str or None): Argument name whose value is either
              ``scipy.sparse`` or ``cupy.sparse`` module. If ``None``, no
              argument is given for the modules.
+         scipy_name(str or None): Argument name whose value is either ``scipy``
+             or ``cupyx.scipy`` module. If ``None``, no argument is given for
+             the modules.
 
     Decorated test fixture is required to return the same arrays
     in the sense of :func:`cupy.testing.assert_array_almost_equal`
@@ -233,11 +248,13 @@ def numpy_cupy_array_almost_equal(decimal=6, err_msg='', verbose=True,
     def check_func(x, y):
         array.assert_array_almost_equal(
             x, y, decimal, err_msg, verbose)
-    return _make_decorator(check_func, name, type_check, accept_error, sp_name)
+    return _make_decorator(check_func, name, type_check, accept_error, sp_name,
+                           scipy_name)
 
 
 def numpy_cupy_array_almost_equal_nulp(nulp=1, name='xp', type_check=True,
-                                       accept_error=False, sp_name=None):
+                                       accept_error=False, sp_name=None,
+                                       scipy_name=None):
     """Decorator that checks results of NumPy and CuPy are equal w.r.t. spacing.
 
     Args:
@@ -254,6 +271,9 @@ def numpy_cupy_array_almost_equal_nulp(nulp=1, name='xp', type_check=True,
          sp_name(str or None): Argument name whose value is either
              ``scipy.sparse`` or ``cupy.sparse`` module. If ``None``, no
              argument is given for the modules.
+         scipy_name(str or None): Argument name whose value is either ``scipy``
+             or ``cupyx.scipy`` module. If ``None``, no argument is given for
+             the modules.
 
     Decorated test fixture is required to return the same arrays
     in the sense of :func:`cupy.testing.assert_array_almost_equal_nulp`
@@ -263,11 +283,13 @@ def numpy_cupy_array_almost_equal_nulp(nulp=1, name='xp', type_check=True,
     """
     def check_func(x, y):
         array.assert_array_almost_equal_nulp(x, y, nulp)
-    return _make_decorator(check_func, name, type_check, accept_error, sp_name)
+    return _make_decorator(check_func, name, type_check, accept_error, sp_name,
+                           scipy_name=None)
 
 
 def numpy_cupy_array_max_ulp(maxulp=1, dtype=None, name='xp', type_check=True,
-                             accept_error=False, sp_name=None):
+                             accept_error=False, sp_name=None,
+                             scipy_name=None):
     """Decorator that checks results of NumPy and CuPy ones are equal w.r.t. ulp.
 
     Args:
@@ -287,6 +309,9 @@ def numpy_cupy_array_max_ulp(maxulp=1, dtype=None, name='xp', type_check=True,
          sp_name(str or None): Argument name whose value is either
              ``scipy.sparse`` or ``cupy.sparse`` module. If ``None``, no
              argument is given for the modules.
+         scipy_name(str or None): Argument name whose value is either ``scipy``
+             or ``cupyx.scipy`` module. If ``None``, no argument is given for
+             the modules.
 
     Decorated test fixture is required to return the same arrays
     in the sense of :func:`assert_array_max_ulp`
@@ -297,11 +322,13 @@ def numpy_cupy_array_max_ulp(maxulp=1, dtype=None, name='xp', type_check=True,
     """
     def check_func(x, y):
         array.assert_array_max_ulp(x, y, maxulp, dtype)
-    return _make_decorator(check_func, name, type_check, accept_error, sp_name)
+    return _make_decorator(check_func, name, type_check, accept_error, sp_name,
+                           scipy_name)
 
 
 def numpy_cupy_array_equal(err_msg='', verbose=True, name='xp',
-                           type_check=True, accept_error=False, sp_name=None):
+                           type_check=True, accept_error=False, sp_name=None,
+                           scipy_name=None):
     """Decorator that checks NumPy results and CuPy ones are equal.
 
     Args:
@@ -320,6 +347,9 @@ def numpy_cupy_array_equal(err_msg='', verbose=True, name='xp',
          sp_name(str or None): Argument name whose value is either
              ``scipy.sparse`` or ``cupy.sparse`` module. If ``None``, no
              argument is given for the modules.
+         scipy_name(str or None): Argument name whose value is either ``scipy``
+             or ``cupyx.scipy`` module. If ``None``, no argument is given for
+             the modules.
 
     Decorated test fixture is required to return the same arrays
     in the sense of :func:`numpy_cupy_array_equal`
@@ -330,11 +360,12 @@ def numpy_cupy_array_equal(err_msg='', verbose=True, name='xp',
     def check_func(x, y):
         array.assert_array_equal(x, y, err_msg, verbose)
 
-    return _make_decorator(check_func, name, type_check, accept_error, sp_name)
+    return _make_decorator(check_func, name, type_check, accept_error, sp_name,
+                           scipy_name)
 
 
 def numpy_cupy_array_list_equal(
-        err_msg='', verbose=True, name='xp', sp_name=None):
+        err_msg='', verbose=True, name='xp', sp_name=None, scipy_name=None):
     """Decorator that checks the resulting lists of NumPy and CuPy's one are equal.
 
     Args:
@@ -346,6 +377,9 @@ def numpy_cupy_array_list_equal(
          sp_name(str or None): Argument name whose value is either
              ``scipy.sparse`` or ``cupy.sparse`` module. If ``None``, no
              argument is given for the modules.
+         scipy_name(str or None): Argument name whose value is either ``scipy``
+             or ``cupyx.scipy`` module. If ``None``, no argument is given for
+             the modules.
 
     Decorated test fixture is required to return the same list of arrays
     (except the type of array module) even if ``xp`` is ``numpy`` or ``cupy``.
@@ -357,12 +391,17 @@ def numpy_cupy_array_list_equal(
         def test_func(self, *args, **kw):
             if sp_name:
                 kw[sp_name] = cupy.sparse
+            if scipy_name:
+                kw[scipy_name] = cupyx.scipy
             kw[name] = cupy
             x = impl(self, *args, **kw)
 
             if sp_name:
                 import scipy.sparse
                 kw[sp_name] = scipy.sparse
+            if scipy_name:
+                import scipy
+                kw[scipy_name] = scipy
             kw[name] = numpy
             y = impl(self, *args, **kw)
             self.assertIsNotNone(x)
@@ -373,7 +412,8 @@ def numpy_cupy_array_list_equal(
 
 
 def numpy_cupy_array_less(err_msg='', verbose=True, name='xp',
-                          type_check=True, accept_error=False, sp_name=None):
+                          type_check=True, accept_error=False, sp_name=None,
+                          scipy_name=None):
     """Decorator that checks the CuPy result is less than NumPy result.
 
     Args:
@@ -392,6 +432,9 @@ def numpy_cupy_array_less(err_msg='', verbose=True, name='xp',
          sp_name(str or None): Argument name whose value is either
              ``scipy.sparse`` or ``cupy.sparse`` module. If ``None``, no
              argument is given for the modules.
+         scipy_name(str or None): Argument name whose value is either ``scipy``
+             or ``cupyx.scipy`` module. If ``None``, no argument is given for
+             the modules.
 
     Decorated test fixture is required to return the smaller array
     when ``xp`` is ``cupy`` than the one when ``xp`` is ``numpy``.
@@ -400,10 +443,11 @@ def numpy_cupy_array_less(err_msg='', verbose=True, name='xp',
     """
     def check_func(x, y):
         array.assert_array_less(x, y, err_msg, verbose)
-    return _make_decorator(check_func, name, type_check, accept_error, sp_name)
+    return _make_decorator(check_func, name, type_check, accept_error, sp_name,
+                           scipy_name)
 
 
-def numpy_cupy_equal(name='xp', sp_name=None):
+def numpy_cupy_equal(name='xp', sp_name=None, scipy_name=None):
     """Decorator that checks NumPy results are equal to CuPy ones.
 
     Args:
@@ -412,6 +456,9 @@ def numpy_cupy_equal(name='xp', sp_name=None):
          sp_name(str or None): Argument name whose value is either
              ``scipy.sparse`` or ``cupy.sparse`` module. If ``None``, no
              argument is given for the modules.
+         scipy_name(str or None): Argument name whose value is either ``scipy``
+             or ``cupyx.scipy`` module. If ``None``, no argument is given for
+             the modules.
 
     Decorated test fixture is required to return the same results
     even if ``xp`` is ``numpy`` or ``cupy``.
@@ -421,12 +468,17 @@ def numpy_cupy_equal(name='xp', sp_name=None):
         def test_func(self, *args, **kw):
             if sp_name:
                 kw[sp_name] = cupy.sparse
+            if scipy_name:
+                kw[scipy_name] = cupyx.scipy
             kw[name] = cupy
             cupy_result = impl(self, *args, **kw)
 
             if sp_name:
                 import scipy.sparse
                 kw[sp_name] = scipy.sparse
+            if scipy_name:
+                import scipy
+                kw[scipy_name] = scipy
             kw[name] = numpy
             numpy_result = impl(self, *args, **kw)
 
@@ -439,7 +491,8 @@ numpy: %s''' % (str(cupy_result), str(numpy_result))
     return decorator
 
 
-def numpy_cupy_raises(name='xp', sp_name=None, accept_error=Exception):
+def numpy_cupy_raises(name='xp', sp_name=None, scipy_name=None,
+                      accept_error=Exception):
     """Decorator that checks the NumPy and CuPy throw same errors.
 
     Args:
@@ -448,6 +501,9 @@ def numpy_cupy_raises(name='xp', sp_name=None, accept_error=Exception):
          sp_name(str or None): Argument name whose value is either
              ``scipy.sparse`` or ``cupy.sparse`` module. If ``None``, no
              argument is given for the modules.
+         scipy_name(str or None): Argument name whose value is either ``scipy``
+             or ``cupyx.scipy`` module. If ``None``, no argument is given for
+             the modules.
          accept_error(bool, Exception or tuple of Exception): Specify
              acceptable errors. When both NumPy test and CuPy test raises the
              same type of errors, and the type of the errors is specified with
@@ -464,6 +520,8 @@ def numpy_cupy_raises(name='xp', sp_name=None, accept_error=Exception):
         def test_func(self, *args, **kw):
             if sp_name:
                 kw[sp_name] = cupy.sparse
+            if scipy_name:
+                kw[scipy_name] = cupyx.scipy
             kw[name] = cupy
             try:
                 impl(self, *args, **kw)
@@ -476,6 +534,9 @@ def numpy_cupy_raises(name='xp', sp_name=None, accept_error=Exception):
             if sp_name:
                 import scipy.sparse
                 kw[sp_name] = scipy.sparse
+            if scipy_name:
+                import scipy
+                kw[scipy_name] = scipy
             kw[name] = numpy
             try:
                 impl(self, *args, **kw)

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
@@ -31,15 +31,12 @@ class TestMapCoordinates(unittest.TestCase):
 
     _multiprocess_can_split = True
 
-    def _map_coordinates(self, xp, a, coordinates):
+    def _map_coordinates(self, xp, scp, a, coordinates):
         # scipy.ndimage has bug with Python2
         if sys.version_info[0] == 2 and self.output == 'f':
             return xp.empty(0)
 
-        if xp == cupy:
-            map_coordinates = cupyx.scipy.ndimage.map_coordinates
-        else:
-            map_coordinates = scipy.ndimage.map_coordinates
+        map_coordinates = scp.ndimage.map_coordinates
         if self.output == 'empty':
             output = xp.empty(coordinates.shape[1], dtype=a.dtype)
             return_value = map_coordinates(a, coordinates, output, self.order,
@@ -52,15 +49,15 @@ class TestMapCoordinates(unittest.TestCase):
                                    self.mode, self.cval, self.prefilter)
 
     @testing.for_float_dtypes(no_float16=True)
-    @testing.numpy_cupy_allclose(atol=1e-5)
-    def test_map_coordinates_float(self, xp, dtype):
+    @testing.numpy_cupy_allclose(atol=1e-5, scipy_name='scp')
+    def test_map_coordinates_float(self, xp, scp, dtype):
         a = testing.shaped_random((100, 100), xp, dtype)
         coordinates = testing.shaped_random((a.ndim, 100), xp, dtype)
-        return self._map_coordinates(xp, a, coordinates)
+        return self._map_coordinates(xp, scp, a, coordinates)
 
     @testing.for_int_dtypes(no_bool=True)
-    @testing.numpy_cupy_allclose(atol=1e-5)
-    def test_map_coordinates_int(self, xp, dtype):
+    @testing.numpy_cupy_allclose(atol=1e-5, scipy_name='scp')
+    def test_map_coordinates_int(self, xp, scp, dtype):
         if numpy.lib.NumpyVersion(scipy.__version__) < '1.0.0':
             if dtype in (numpy.dtype('l'), numpy.dtype('q')):
                 dtype = numpy.int64
@@ -69,8 +66,8 @@ class TestMapCoordinates(unittest.TestCase):
 
         a = testing.shaped_random((100, 100), xp, dtype)
         coordinates = testing.shaped_random((a.ndim, 100), xp, dtype)
-        out = self._map_coordinates(xp, a, coordinates)
-        float_out = self._map_coordinates(xp, a.astype(xp.float64),
+        out = self._map_coordinates(xp, scp, a, coordinates)
+        float_out = self._map_coordinates(xp, scp, a.astype(xp.float64),
                                           coordinates) % 1
         half = xp.full_like(float_out, 0.5)
         out[xp.isclose(float_out, half, atol=1e-5)] = 0
@@ -93,7 +90,7 @@ class TestAffineTransform(unittest.TestCase):
 
     _multiprocess_can_split = True
 
-    def _affine_transform(self, xp, a, matrix):
+    def _affine_transform(self, xp, scp, a, matrix):
         if (numpy.lib.NumpyVersion(scipy.__version__) < '1.0.0'
                 and matrix.ndim == 2 and matrix.shape[1] == 3):
             return xp.empty(0)
@@ -101,10 +98,7 @@ class TestAffineTransform(unittest.TestCase):
         if matrix.shape == (3, 3):
             matrix[-1, 0:-1] = 0
             matrix[-1, -1] = 1
-        if xp == cupy:
-            affine_transform = cupyx.scipy.ndimage.affine_transform
-        else:
-            affine_transform = scipy.ndimage.affine_transform
+        affine_transform = scp.ndimage.affine_transform
         if self.output == 'empty':
             output = xp.empty_like(a)
             return_value = affine_transform(a, matrix, self.offset,
@@ -119,15 +113,15 @@ class TestAffineTransform(unittest.TestCase):
                                     self.cval, self.prefilter)
 
     @testing.for_float_dtypes(no_float16=True)
-    @testing.numpy_cupy_allclose(atol=1e-5)
-    def test_affine_transform_float(self, xp, dtype):
+    @testing.numpy_cupy_allclose(atol=1e-5, scipy_name='scp')
+    def test_affine_transform_float(self, xp, scp, dtype):
         a = testing.shaped_random((100, 100), xp, dtype)
         matrix = testing.shaped_random(self.matrix_shape, xp, dtype)
-        return self._affine_transform(xp, a, matrix)
+        return self._affine_transform(xp, scp, a, matrix)
 
     @testing.for_int_dtypes(no_bool=True)
-    @testing.numpy_cupy_allclose(atol=1e-5)
-    def test_affine_transform_int(self, xp, dtype):
+    @testing.numpy_cupy_allclose(atol=1e-5, scipy_name='scp')
+    def test_affine_transform_int(self, xp, scp, dtype):
         if numpy.lib.NumpyVersion(scipy.__version__) < '1.0.0':
             if dtype in (numpy.dtype('l'), numpy.dtype('q')):
                 dtype = numpy.int64
@@ -136,8 +130,8 @@ class TestAffineTransform(unittest.TestCase):
 
         a = testing.shaped_random((100, 100), xp, dtype)
         matrix = testing.shaped_random(self.matrix_shape, xp, dtype)
-        out = self._affine_transform(xp, a, matrix)
-        float_out = self._affine_transform(xp, a.astype(xp.float64),
+        out = self._affine_transform(xp, scp, a, matrix)
+        float_out = self._affine_transform(xp, scp, a.astype(xp.float64),
                                            matrix) % 1
         half = xp.full_like(float_out, 0.5)
         out[xp.isclose(float_out, half, atol=1e-5)] = 0
@@ -180,11 +174,8 @@ class TestRotate(unittest.TestCase):
 
     _multiprocess_can_split = True
 
-    def _rotate(self, xp, a):
-        if xp == cupy:
-            rotate = cupyx.scipy.ndimage.rotate
-        else:
-            rotate = scipy.ndimage.rotate
+    def _rotate(self, xp, scp, a):
+        rotate = scp.ndimage.rotate
         if self.output == 'empty':
             output = rotate(a, self.angle, self.axes,
                             self.reshape, None, self.order,
@@ -200,14 +191,14 @@ class TestRotate(unittest.TestCase):
                           self.mode, self.cval, self.prefilter)
 
     @testing.for_float_dtypes(no_float16=True)
-    @testing.numpy_cupy_allclose(atol=1e-5)
-    def test_rotate_float(self, xp, dtype):
+    @testing.numpy_cupy_allclose(atol=1e-5, scipy_name='scp')
+    def test_rotate_float(self, xp, scp, dtype):
         a = testing.shaped_random((10, 10), xp, dtype)
-        return self._rotate(xp, a)
+        return self._rotate(xp, scp, a)
 
     @testing.for_int_dtypes(no_bool=True)
-    @testing.numpy_cupy_allclose(atol=1e-5)
-    def test_rotate_int(self, xp, dtype):
+    @testing.numpy_cupy_allclose(atol=1e-5, scipy_name='scp')
+    def test_rotate_int(self, xp, scp, dtype):
         if numpy.lib.NumpyVersion(scipy.__version__) < '1.0.0':
             if dtype in (numpy.dtype('l'), numpy.dtype('q')):
                 dtype = numpy.int64
@@ -215,8 +206,8 @@ class TestRotate(unittest.TestCase):
                 dtype = numpy.uint64
 
         a = testing.shaped_random((10, 10), xp, dtype)
-        out = self._rotate(xp, a)
-        float_out = self._rotate(xp, a.astype(xp.float64)) % 1
+        out = self._rotate(xp, scp, a)
+        float_out = self._rotate(xp, scp, a.astype(xp.float64)) % 1
         half = xp.full_like(float_out, 0.5)
         out[xp.isclose(float_out, half, atol=1e-5)] = 0
         return out
@@ -235,13 +226,10 @@ class TestRotateAxes(unittest.TestCase):
     _multiprocess_can_split = True
 
     @testing.for_float_dtypes(no_float16=True)
-    @testing.numpy_cupy_allclose(1e-5)
-    def test_rotate_axes(self, xp, dtype):
+    @testing.numpy_cupy_allclose(atol=1e-5, scipy_name='scp')
+    def test_rotate_axes(self, xp, scp, dtype):
         a = testing.shaped_random((10, 10, 10), xp, dtype)
-        if xp == cupy:
-            rotate = cupyx.scipy.ndimage.rotate
-        else:
-            rotate = scipy.ndimage.rotate
+        rotate = scp.ndimage.rotate
         return rotate(a, 1, self.axes, order=1)
 
 
@@ -277,11 +265,8 @@ class TestShift(unittest.TestCase):
 
     _multiprocess_can_split = True
 
-    def _shift(self, xp, a):
-        if xp == cupy:
-            shift = cupyx.scipy.ndimage.shift
-        else:
-            shift = scipy.ndimage.shift
+    def _shift(self, xp, scp, a):
+        shift = scp.ndimage.shift
         if self.output == 'empty':
             output = xp.empty_like(a)
             return_value = shift(a, self.shift, output, self.order,
@@ -293,14 +278,14 @@ class TestShift(unittest.TestCase):
                          self.mode, self.cval, self.prefilter)
 
     @testing.for_float_dtypes(no_float16=True)
-    @testing.numpy_cupy_allclose(atol=1e-5)
-    def test_shift_float(self, xp, dtype):
+    @testing.numpy_cupy_allclose(atol=1e-5, scipy_name='scp')
+    def test_shift_float(self, xp, scp, dtype):
         a = testing.shaped_random((100, 100), xp, dtype)
-        return self._shift(xp, a)
+        return self._shift(xp, scp, a)
 
     @testing.for_int_dtypes(no_bool=True)
-    @testing.numpy_cupy_allclose(1e-5)
-    def test_shift_int(self, xp, dtype):
+    @testing.numpy_cupy_allclose(atol=1e-5, scipy_name='scp')
+    def test_shift_int(self, xp, scp, dtype):
         if numpy.lib.NumpyVersion(scipy.__version__) < '1.0.0':
             if dtype in (numpy.dtype('l'), numpy.dtype('q')):
                 dtype = numpy.int64
@@ -308,8 +293,8 @@ class TestShift(unittest.TestCase):
                 dtype = numpy.uint64
 
         a = testing.shaped_random((100, 100), xp, dtype)
-        out = self._shift(xp, a)
-        float_out = self._shift(xp, a.astype(xp.float64)) % 1
+        out = self._shift(xp, scp, a)
+        float_out = self._shift(xp, scp, a.astype(xp.float64)) % 1
         half = xp.full_like(float_out, 0.5)
         out[xp.isclose(float_out, half, atol=1e-5)] = 0
         return out
@@ -348,11 +333,8 @@ class TestZoom(unittest.TestCase):
 
     _multiprocess_can_split = True
 
-    def _zoom(self, xp, a):
-        if xp == cupy:
-            zoom = cupyx.scipy.ndimage.zoom
-        else:
-            zoom = scipy.ndimage.zoom
+    def _zoom(self, xp, scp, a):
+        zoom = scp.ndimage.zoom
         if self.output == 'empty':
             output = zoom(a, self.zoom, None, self.order,
                           self.mode, self.cval, self.prefilter)
@@ -365,14 +347,14 @@ class TestZoom(unittest.TestCase):
                         self.mode, self.cval, self.prefilter)
 
     @testing.for_float_dtypes(no_float16=True)
-    @testing.numpy_cupy_allclose(atol=1e-5)
-    def test_zoom_float(self, xp, dtype):
+    @testing.numpy_cupy_allclose(atol=1e-5, scipy_name='scp')
+    def test_zoom_float(self, xp, scp, dtype):
         a = testing.shaped_random((100, 100), xp, dtype)
-        return self._zoom(xp, a)
+        return self._zoom(xp, scp, a)
 
     @testing.for_int_dtypes(no_bool=True)
-    @testing.numpy_cupy_allclose(atol=1e-5)
-    def test_zoom_int(self, xp, dtype):
+    @testing.numpy_cupy_allclose(atol=1e-5, scipy_name='scp')
+    def test_zoom_int(self, xp, scp, dtype):
         if numpy.lib.NumpyVersion(scipy.__version__) < '1.0.0':
             if dtype in (numpy.dtype('l'), numpy.dtype('q')):
                 dtype = numpy.int64
@@ -380,8 +362,8 @@ class TestZoom(unittest.TestCase):
                 dtype = numpy.uint64
 
         a = testing.shaped_random((100, 100), xp, dtype)
-        out = self._zoom(xp, a)
-        float_out = self._zoom(xp, a.astype(xp.float64)) % 1
+        out = self._zoom(xp, scp, a)
+        float_out = self._zoom(xp, scp, a.astype(xp.float64)) % 1
         half = xp.full_like(float_out, 0.5)
         out[xp.isclose(float_out, half, atol=1e-5)] = 0
         return out


### PR DESCRIPTION
We introduced `cupyx.scipy` namespace and have been adding functions. This PR adds `scipy_name` to simplify the testing of those functions.