### PR TITLE
[backport] Support weak reference to CuPy array

### DIFF
--- a/cupy/core/core.pxd
+++ b/cupy/core/core.pxd
@@ -6,6 +6,7 @@ from cupy.cuda.function cimport CPointer
 
 cdef class ndarray:
     cdef:
+        object __weakref__
         readonly Py_ssize_t size
         public vector.vector[Py_ssize_t] _shape
         public vector.vector[Py_ssize_t] _strides


### PR DESCRIPTION
Backport of #1355