### PR TITLE
[HIGH] Introduce clp2 to improve pinned_memory

### DIFF
--- a/cupy/core/internal.pxd
+++ b/cupy/core/internal.pxd
@@ -30,4 +30,4 @@ cpdef slice complete_slice(slice slc, Py_ssize_t dim)
 
 cpdef tuple complete_slice_list(list slice_list, Py_ssize_t ndim)
 
-cpdef int clp2(size_t x)
+cpdef size_t clp2(size_t x)

--- a/cupy/core/internal.pxd
+++ b/cupy/core/internal.pxd
@@ -29,3 +29,5 @@ cpdef vector.vector[Py_ssize_t] infer_unknown_dimension(
 cpdef slice complete_slice(slice slc, Py_ssize_t dim)
 
 cpdef tuple complete_slice_list(list slice_list, Py_ssize_t ndim)
+
+cpdef int clp2(size_t x)

--- a/cupy/core/internal.pyx
+++ b/cupy/core/internal.pyx
@@ -225,7 +225,7 @@ cpdef tuple complete_slice_list(list slice_list, Py_ssize_t ndim):
 
 
 @cython.profile(False)
-cpdef int clp2(size_t x):
+cpdef size_t clp2(size_t x):
     x -= 1
     x |= x >> 1
     x |= x >> 2

--- a/cupy/core/internal.pyx
+++ b/cupy/core/internal.pyx
@@ -222,3 +222,15 @@ cpdef tuple complete_slice_list(list slice_list, Py_ssize_t ndim):
     elif n > 0:
         slice_list += [slice(None)] * n
     return slice_list, n_newaxes
+
+
+@cython.profile(False)
+cpdef int clp2(size_t x):
+    x -= 1
+    x |= x >> 1
+    x |= x >> 2
+    x |= x >> 4
+    x |= x >> 8
+    x |= x >> 16
+    x |= x >> 32
+    return x + 1

--- a/tests/cupy_tests/core_tests/test_internal.py
+++ b/tests/cupy_tests/core_tests/test_internal.py
@@ -203,6 +203,9 @@ class TestCompleteSliceError(unittest.TestCase):
     {'x': 2 ** 10,     'expect': 2 ** 10},
     {'x': 2 ** 10 - 1, 'expect': 2 ** 10},
     {'x': 2 ** 10 + 1, 'expect': 2 ** 11},
+    {'x': 2 ** 40,     'expect': 2 ** 40},
+    {'x': 2 ** 40 - 1, 'expect': 2 ** 40},
+    {'x': 2 ** 40 + 1, 'expect': 2 ** 41},
 )
 class TestClp2(unittest.TestCase):
 

--- a/tests/cupy_tests/core_tests/test_internal.py
+++ b/tests/cupy_tests/core_tests/test_internal.py
@@ -193,3 +193,18 @@ class TestCompleteSliceError(unittest.TestCase):
             internal.complete_slice(slice((1, 2), 1, 1), 1)
         with self.assertRaises(TypeError):
             internal.complete_slice(slice((1, 2), 1, -1), 1)
+
+
+@testing.parameterize(
+    {'x': 0, 'expect': 0},
+    {'x': 1, 'expect': 1},
+    {'x': 2, 'expect': 2},
+    {'x': 3, 'expect': 4},
+    {'x': 2 ** 10,     'expect': 2 ** 10},
+    {'x': 2 ** 10 - 1, 'expect': 2 ** 10},
+    {'x': 2 ** 10 + 1, 'expect': 2 ** 11},
+)
+class TestClp2(unittest.TestCase):
+
+    def test_clp2(self):
+        assert internal.clp2(self.x) == self.expect


### PR DESCRIPTION
This PR can reduce usage of pinned_memory when user copies arrays of multiple sizes.