### PR TITLE
[backport] Fix to preserve dtype of input array in cupy.linalg.norm

### DIFF
--- a/cupy/linalg/norms.py
+++ b/cupy/linalg/norms.py
@@ -69,17 +69,14 @@ def norm(x, ord=None, axis=None, keepdims=False):
         elif ord == 0:
             # Zero norm
             # Convert to Python float in accordance with NumPy
-            return (x != 0).sum(axis=axis, keepdims=keepdims, dtype='d')
+            return (x != 0).astype(x.real.dtype).sum(
+                axis=axis, keepdims=keepdims)
         elif ord == 1:
             # special case for speedup
             return abs(x).sum(axis=axis, keepdims=keepdims)
         elif ord is None or ord == 2:
             # special case for speedup
-            if issubclass(x.dtype.type, numpy.complexfloating):
-                s = abs(x)
-                s *= s
-            else:
-                s = x ** 2
+            s = (x.conj() * x).real
             return cupy.sqrt(s.sum(axis=axis, keepdims=keepdims))
         else:
             try:
@@ -87,18 +84,10 @@ def norm(x, ord=None, axis=None, keepdims=False):
             except TypeError:
                 raise ValueError("Invalid norm order for vectors.")
 
-            # Mirror Numpy behavior of casting to double for non-complex
-            # dtypes, and to float32 or float64 for complex dtypes and
-            # no reduction over all axes.
-            cast_dtype = 'd'
-            if issubclass(x.dtype.type, numpy.complexfloating):
-                if keepdims or tuple(sorted(axis)) != tuple(range(nd)):
-                    cast_dtype = x.dtype.char.lower()  # 'D'->'d' and 'F'->'f'
-
-            absx = abs(x).astype(cast_dtype)
+            absx = abs(x)
             absx **= ord
             ret = absx.sum(axis=axis, keepdims=keepdims)
-            ret **= (1.0 / ord)
+            ret **= cupy.reciprocal(ord, dtype=ret.dtype)
             return ret
     elif len(axis) == 2:
         row_axis, col_axis = axis

--- a/tests/cupy_tests/linalg_tests/test_norms.py
+++ b/tests/cupy_tests/linalg_tests/test_norms.py
@@ -49,8 +49,11 @@ class TestTrace(unittest.TestCase):
 @testing.with_requires('numpy>=1.11.2')  # The old version dtype is strange
 class TestNorm(unittest.TestCase):
 
+    # TODO(kmaehashi) Currently dtypes returned from CuPy is not compatible
+    # with NumPy. We should remove `type_check=False` once NumPy is fixed.
+    # See https://github.com/cupy/cupy/pull/875 for details.
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-4)
+    @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-4, type_check=False)
     def test_norm(self, xp, dtype):
         a = testing.shaped_arange(self.shape, xp, dtype)
         with testing.NumpyError(divide='ignore'):


### PR DESCRIPTION
Backport of #875