### PR TITLE
Fix to accept longer order names

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -53,9 +53,8 @@ except AttributeError:
 
 
 cdef int _normalize_order(str order) except? 0:
-    if len(order) != 1:
-        raise TypeError('order not understood')
-    cdef int order_char = ord(order)
+    cdef int order_char
+    order_char = 'C' if len(order) == 0 else ord(order[0])
     if order_char == 'K' or order_char == 'k':
         order_char = 'K'
     elif order_char == 'A' or order_char == 'a':

--- a/tests/cupy_tests/core_tests/test_core.py
+++ b/tests/cupy_tests/core_tests/test_core.py
@@ -1,7 +1,5 @@
 import unittest
 
-import numpy
-
 import cupy
 from cupy.core import core
 from cupy import testing

--- a/tests/cupy_tests/core_tests/test_core.py
+++ b/tests/cupy_tests/core_tests/test_core.py
@@ -1,5 +1,7 @@
 import unittest
 
+import numpy
+
 import cupy
 from cupy.core import core
 from cupy import testing
@@ -51,3 +53,18 @@ class TestSize(unittest.TestCase):
     def test_size_huge(self, xp):
         a = xp.ndarray(2 ** 32, 'b')  # 4 GiB
         return xp.size(a)
+
+
+class TestOrder(unittest.TestCase):
+
+    @testing.for_orders([
+        'C', 'c', 'CONTIGUOUS',
+        'F', 'f', 'FORTRAN',
+        None,
+    ])
+    def test_ndarray(self, order):
+        a = core.ndarray((2, 3), order=order)
+        expect_c = order is None or order[0].upper() == 'C'
+        expect_f = order is not None and order[0].upper() == 'F'
+        assert a.flags.c_contiguous == expect_c
+        assert a.flags.f_contiguous == expect_f


### PR DESCRIPTION
NumPy still supports longer order names (although it emits DeprecationWarning).
Fixes the issue introduced in #1385.