### PR TITLE
Fix requirements of numpy in `test_einsum.py`

### DIFF
--- a/tests/cupy_tests/linalg_tests/test_einsum.py
+++ b/tests/cupy_tests/linalg_tests/test_einsum.py
@@ -6,11 +6,9 @@ import numpy
 from cupy import testing
 
 
-_wrong_bool_einsum, _wrong_float16_einsum = [
-    numpy.lib.NumpyVersion(numpy.__version__) <= v for v in [
-        '1.9.99',  # before numpy PR #5946
-        '1.14.99',  # before numpy PR #10911
-    ]]
+_np_version = numpy.lib.NumpyVersion(numpy.__version__)
+_wrong_bool_einsum = _np_version <= '1.9.99'  # before numpy PR #5946
+_wrong_float16_einsum = _np_version <= '1.14.99'  # before numpy PR #10911
 
 
 def _dec_shape(shape, dec):

--- a/tests/cupy_tests/linalg_tests/test_einsum.py
+++ b/tests/cupy_tests/linalg_tests/test_einsum.py
@@ -285,7 +285,6 @@ class TestEinSumUnaryOperation(unittest.TestCase):
             testing.assert_allclose(optimized_out, out)
         return out
 
-    @testing.with_requires('numpy>=1.10')
     @testing.for_all_dtypes(no_bool=not _bool_ok)
     @testing.numpy_cupy_equal()
     def test_einsum_unary_views(self, xp, dtype):

--- a/tests/cupy_tests/linalg_tests/test_einsum.py
+++ b/tests/cupy_tests/linalg_tests/test_einsum.py
@@ -6,6 +6,11 @@ import numpy
 from cupy import testing
 
 
+_wrong_bool_einsum = \
+    numpy.lib.NumpyVersion(numpy.__version__) < '1.10.0'
+    # before numpy PR #5946
+
+
 def _dec_shape(shape, dec):
     # Test smaller shape
     return tuple(1 if s == 1 else max(0, s - dec) for s in shape)
@@ -271,8 +276,7 @@ class TestListArgEinSumError(unittest.TestCase):
 @testing.with_requires('numpy!=1.14.0')
 class TestEinSumUnaryOperation(unittest.TestCase):
 
-    @testing.with_requires('numpy>=1.10')
-    @testing.for_all_dtypes()
+    @testing.for_all_dtypes(no_bool=_wrong_bool_einsum)
     @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_einsum_unary(self, xp, dtype):
         a = testing.shaped_arange(self.shape_a, xp, dtype)
@@ -283,7 +287,7 @@ class TestEinSumUnaryOperation(unittest.TestCase):
         return out
 
     @testing.with_requires('numpy>=1.10')
-    @testing.for_all_dtypes()
+    @testing.for_all_dtypes(no_bool=_wrong_bool_einsum)
     @testing.numpy_cupy_equal()
     def test_einsum_unary_views(self, xp, dtype):
         a = testing.shaped_arange(self.shape_a, xp, dtype)
@@ -293,6 +297,7 @@ class TestEinSumUnaryOperation(unittest.TestCase):
 
     @testing.for_all_dtypes_combination(
         ['dtype_a', 'dtype_out'],
+        no_bool=_wrong_bool_einsum,
         no_complex=True)  # avoid ComplexWarning
     @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_einsum_unary_dtype(self, xp, dtype_a, dtype_out):
@@ -371,6 +376,7 @@ class TestEinSumUnaryOperationWithScalar(unittest.TestCase):
 class TestEinSumBinaryOperation(unittest.TestCase):
     @testing.for_all_dtypes_combination(
         ['dtype_a', 'dtype_b'],
+        no_bool=_wrong_bool_einsum,
         no_float16=True)  # Avoid numpy issue #10899
     @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_einsum_binary(self, xp, dtype_a, dtype_b):
@@ -417,6 +423,7 @@ class TestEinSumBinaryOperationWithScalar(unittest.TestCase):
 class TestEinSumTernaryOperation(unittest.TestCase):
     @testing.for_all_dtypes_combination(
         ['dtype_a', 'dtype_b', 'dtype_c'],
+        no_bool=_wrong_bool_einsum,
         no_float16=True)  # Avoid numpy issue #10899
     @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_einsum_ternary(self, xp, dtype_a, dtype_b, dtype_c):

--- a/tests/cupy_tests/linalg_tests/test_einsum.py
+++ b/tests/cupy_tests/linalg_tests/test_einsum.py
@@ -6,9 +6,11 @@ import numpy
 from cupy import testing
 
 
-_wrong_bool_einsum = \
-    numpy.lib.NumpyVersion(numpy.__version__) < '1.10.0'
-    # before numpy PR #5946
+_wrong_bool_einsum, _wrong_float16_einsum = [
+    numpy.lib.NumpyVersion(numpy.__version__) <= v for v in [
+        '1.9.99',  # before numpy PR #5946
+        '1.14.99',  # before numpy PR #10911
+    ]]
 
 
 def _dec_shape(shape, dec):
@@ -377,7 +379,7 @@ class TestEinSumBinaryOperation(unittest.TestCase):
     @testing.for_all_dtypes_combination(
         ['dtype_a', 'dtype_b'],
         no_bool=_wrong_bool_einsum,
-        no_float16=True)  # Avoid numpy issue #10899
+        no_float16=_wrong_float16_einsum)
     @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_einsum_binary(self, xp, dtype_a, dtype_b):
         a = testing.shaped_arange(self.shape_a, xp, dtype_a)
@@ -424,7 +426,7 @@ class TestEinSumTernaryOperation(unittest.TestCase):
     @testing.for_all_dtypes_combination(
         ['dtype_a', 'dtype_b', 'dtype_c'],
         no_bool=_wrong_bool_einsum,
-        no_float16=True)  # Avoid numpy issue #10899
+        no_float16=_wrong_float16_einsum)
     @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_einsum_ternary(self, xp, dtype_a, dtype_b, dtype_c):
         a = testing.shaped_arange(self.shape_a, xp, dtype_a)

--- a/tests/cupy_tests/linalg_tests/test_einsum.py
+++ b/tests/cupy_tests/linalg_tests/test_einsum.py
@@ -6,9 +6,8 @@ import numpy
 from cupy import testing
 
 
-_wrong_bool_einsum = testing.numpy_satisfies('<1.10')  # before numpy PR #5946
-_wrong_float16_einsum = \
-    testing.numpy_satisfies('<1.15')  # before numpy PR #10911
+_bool_ok = testing.numpy_satisfies('>=1.10')  # after numpy PR #5946
+_float16_ok = testing.numpy_satisfies('>=1.15')  # after numpy PR #10911
 
 
 def _dec_shape(shape, dec):
@@ -276,7 +275,7 @@ class TestListArgEinSumError(unittest.TestCase):
 @testing.with_requires('numpy!=1.14.0')
 class TestEinSumUnaryOperation(unittest.TestCase):
 
-    @testing.for_all_dtypes(no_bool=_wrong_bool_einsum)
+    @testing.for_all_dtypes(no_bool=not _bool_ok)
     @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_einsum_unary(self, xp, dtype):
         a = testing.shaped_arange(self.shape_a, xp, dtype)
@@ -287,7 +286,7 @@ class TestEinSumUnaryOperation(unittest.TestCase):
         return out
 
     @testing.with_requires('numpy>=1.10')
-    @testing.for_all_dtypes(no_bool=_wrong_bool_einsum)
+    @testing.for_all_dtypes(no_bool=not _bool_ok)
     @testing.numpy_cupy_equal()
     def test_einsum_unary_views(self, xp, dtype):
         a = testing.shaped_arange(self.shape_a, xp, dtype)
@@ -297,7 +296,7 @@ class TestEinSumUnaryOperation(unittest.TestCase):
 
     @testing.for_all_dtypes_combination(
         ['dtype_a', 'dtype_out'],
-        no_bool=_wrong_bool_einsum,
+        no_bool=not _bool_ok,
         no_complex=True)  # avoid ComplexWarning
     @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_einsum_unary_dtype(self, xp, dtype_a, dtype_out):
@@ -376,8 +375,8 @@ class TestEinSumUnaryOperationWithScalar(unittest.TestCase):
 class TestEinSumBinaryOperation(unittest.TestCase):
     @testing.for_all_dtypes_combination(
         ['dtype_a', 'dtype_b'],
-        no_bool=_wrong_bool_einsum,
-        no_float16=_wrong_float16_einsum)
+        no_bool=not _bool_ok,
+        no_float16=not _float16_ok)
     @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_einsum_binary(self, xp, dtype_a, dtype_b):
         a = testing.shaped_arange(self.shape_a, xp, dtype_a)
@@ -423,8 +422,8 @@ class TestEinSumBinaryOperationWithScalar(unittest.TestCase):
 class TestEinSumTernaryOperation(unittest.TestCase):
     @testing.for_all_dtypes_combination(
         ['dtype_a', 'dtype_b', 'dtype_c'],
-        no_bool=_wrong_bool_einsum,
-        no_float16=_wrong_float16_einsum)
+        no_bool=not _bool_ok,
+        no_float16=not _float16_ok)
     @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_einsum_ternary(self, xp, dtype_a, dtype_b, dtype_c):
         a = testing.shaped_arange(self.shape_a, xp, dtype_a)

--- a/tests/cupy_tests/linalg_tests/test_einsum.py
+++ b/tests/cupy_tests/linalg_tests/test_einsum.py
@@ -6,9 +6,9 @@ import numpy
 from cupy import testing
 
 
-_np_version = numpy.lib.NumpyVersion(numpy.__version__)
-_wrong_bool_einsum = _np_version <= '1.9.99'  # before numpy PR #5946
-_wrong_float16_einsum = _np_version <= '1.14.99'  # before numpy PR #10911
+_wrong_bool_einsum = testing.numpy_satisfies('<1.10')  # before numpy PR #5946
+_wrong_float16_einsum = \
+    testing.numpy_satisfies('<1.15')  # before numpy PR #10911
 
 
 def _dec_shape(shape, dec):


### PR DESCRIPTION
The PR #1334 was partial:
- The memory bug in old `np.einsum` is caused by wrong pointer increment.  Return value can be wrong whether or not einsum crashes.
- `@testing.for_all_dtypes_combination(full=False)` rarely contains `{'dtype_a': <class 'numpy.bool_'>, 'dtype_b': <class 'numpy.bool_'>, 'dtype_c': <class 'numpy.bool_'>}`.
