### PR TITLE
Fix fromDlpack memory management

### DIFF
--- a/cupy/core/dlpack.pyx
+++ b/cupy/core/dlpack.pyx
@@ -154,6 +154,7 @@ cdef class DLPackMemory(memory.Memory):
     def __dealloc__(self):
         # DLPack tensor should be managed by the original creator
         self.ptr = 0
+        self.dlm_tensor.deleter(self.dlm_tensor)
 
 
 # The name of this function is following the framwork integration guide of

--- a/cupy/core/dlpack.pyx
+++ b/cupy/core/dlpack.pyx
@@ -64,6 +64,7 @@ cdef void pycapsule_deleter(object dltensor):
     try:
         dlm_tensor = <DLManagedTensor *>pycapsule.PyCapsule_GetPointer(
             dltensor, 'used_dltensor')
+        return             # we do not call a used capsule's deleter
     except Exception:
         dlm_tensor = <DLManagedTensor *>pycapsule.PyCapsule_GetPointer(
             dltensor, 'dltensor')


### PR DESCRIPTION
Thank you for CuPy!

The DLManagedTensor interface has a "deleter" function that
is used to signal the creator of the DLManagedTensor that
the consumer does not need the memory anymore.

This tiny patch calls the deleter when the DLPackMemory
created by fromDlpack is destroyed.

This fixes #1443, the memory leak when consuming DLPacks created by PyTorch.

This is my first PR to CuPy. I did run the test_dlpack tests.
