### PR TITLE
Convert cupy.sparse to cupyx.scipy.sparse in docstrings

### DIFF
--- a/cupy/cusparse.py
+++ b/cupy/cusparse.py
@@ -113,7 +113,7 @@ def csrmm(a, b, c=None, alpha=1, beta=0, transa=False):
     is an identity function otherwise.
 
     Args:
-        a (cupy.sparse.csr): Sparse matrix A.
+        a (cupyx.scipy.sparse.csr): Sparse matrix A.
         b (cupy.ndarray): Dense matrix B. It must be F-contiguous.
         c (cupy.ndarray or None): Dense matrix C. It must be F-contiguous.
         alpha (float): Coefficient for AB.
@@ -169,7 +169,7 @@ def csrmm2(a, b, c=None, alpha=1.0, beta=0.0, transa=False, transb=False):
     cuSPARSE specification.
 
     Args:
-        a (cupy.sparse.csr): Sparse matrix A.
+        a (cupyx.scipy.sparse.csr): Sparse matrix A.
         b (cupy.ndarray): Dense matrix B. It must be F-contiguous.
         c (cupy.ndarray or None): Dense matrix C. It must be F-contiguous.
         alpha (float): Coefficient for AB.
@@ -222,13 +222,13 @@ def csrgeam(a, b, alpha=1, beta=1):
         C = \\alpha A + \\beta B
 
     Args:
-        a (cupy.sparse.csr_matrix): Sparse matrix A.
-        b (cupy.sparse.csr_matrix): Sparse matrix B.
+        a (cupyx.scipy.sparse.csr_matrix): Sparse matrix A.
+        b (cupyx.scipy.sparse.csr_matrix): Sparse matrix B.
         alpha (float): Coefficient for A.
         beta (float): Coefficient for B.
 
     Returns:
-        cupy.sparse.csr_matrix: Result matrix.
+        cupyx.scipy.sparse.csr_matrix: Result matrix.
 
     """
     assert a.has_canonical_format
@@ -278,13 +278,13 @@ def csrgemm(a, b, transa=False, transb=False):
        C = op(A) op(B),
 
     Args:
-        a (cupy.sparse.csr_matrix): Sparse matrix A.
-        b (cupy.sparse.csr_matrix): Sparse matrix B.
+        a (cupyx.scipy.sparse.csr_matrix): Sparse matrix A.
+        b (cupyx.scipy.sparse.csr_matrix): Sparse matrix B.
         transa (bool): If ``True``, transpose of A is used.
         transb (bool): If ``True``, transpose of B is used.
 
     Returns:
-        cupy.sparse.csr_matrix: Calculated C.
+        cupyx.scipy.sparse.csr_matrix: Calculated C.
 
     """
     assert a.ndim == b.ndim == 2
@@ -340,7 +340,7 @@ def csr2dense(x, out=None):
     """Converts CSR-matrix to a dense matrix.
 
     Args:
-        x (cupy.sparse.csr_matrix): A sparse matrix to convert.
+        x (cupyx.scipy.sparse.csr_matrix): A sparse matrix to convert.
         out (cupy.ndarray or None): A dense metrix to store the result.
             It must be F-contiguous.
 
@@ -369,7 +369,7 @@ def csc2dense(x, out=None):
     """Converts CSC-matrix to a dense matrix.
 
     Args:
-        x (cupy.sparse.csc_matrix): A sparse matrix to convert.
+        x (cupyx.scipy.sparse.csc_matrix): A sparse matrix to convert.
         out (cupy.ndarray or None): A dense metrix to store the result.
             It must be F-contiguous.
 
@@ -398,7 +398,7 @@ def csrsort(x):
     """Sorts indices of CSR-matrix in place.
 
     Args:
-        x (cupy.sparse.csr_matrix): A sparse matrix to sort.
+        x (cupyx.scipy.sparse.csr_matrix): A sparse matrix to sort.
 
     """
     nnz = x.nnz
@@ -426,7 +426,7 @@ def cscsort(x):
     """Sorts indices of CSC-matrix in place.
 
     Args:
-        x (cupy.sparse.csc_matrix): A sparse matrix to sort.
+        x (cupyx.scipy.sparse.csc_matrix): A sparse matrix to sort.
 
     """
     nnz = x.nnz
@@ -486,12 +486,12 @@ def csr2coo(x, data, indices):
     """Converts a CSR-matrix to COO format.
 
     Args:
-        x (cupy.sparse.csr_matrix): A matrix to be converted.
+        x (cupyx.scipy.sparse.csr_matrix): A matrix to be converted.
         data (cupy.ndarray): A data array for converted data.
         indices (cupy.ndarray): An index array for converted data.
 
     Returns:
-        cupy.sparse.coo_matrix: A converted matrix.
+        cupyx.scipy.sparse.coo_matrix: A converted matrix.
 
     """
     handle = device.get_cusparse_handle()
@@ -531,7 +531,7 @@ def dense2csc(x):
         x (cupy.ndarray): A matrix to be converted.
 
     Returns:
-        cupy.sparse.csc_matrix: A converted matrix.
+        cupyx.scipy.sparse.csc_matrix: A converted matrix.
 
     """
     assert x.ndim == 2
@@ -570,7 +570,7 @@ def dense2csr(x):
         x (cupy.ndarray): A matrix to be converted.
 
     Returns:
-        cupy.sparse.csr_matrix: A converted matrix.
+        cupyx.scipy.sparse.csr_matrix: A converted matrix.
 
     """
     assert x.ndim == 2

--- a/cupy/sparse/base.py
+++ b/cupy/sparse/base.py
@@ -147,8 +147,8 @@ class spmatrix(object):
             other (int): Exponent.
 
         Returns:
-            cupy.sparse.spmatrix: A sparse matrix representing n-th power of
-                this matrix.
+            cupyx.scipy.sparse.spmatrix: A sparse matrix representing n-th
+                power of this matrix.
 
         """
         m, n = self.shape
@@ -179,8 +179,8 @@ class spmatrix(object):
     def A(self):
         """Dense ndarray representation of this matrix.
 
-        This property is equivalent to :meth:`~cupy.sparse.spmatrix.toarray`
-        method.
+        This property is equivalent to
+        :meth:`~cupyx.scipy.sparse.spmatrix.toarray` method.
 
         """
         return self.toarray()
@@ -231,7 +231,7 @@ class spmatrix(object):
         Otherwise it makes a copy with floating point type and the same format.
 
         Returns:
-            cupy.sparse.spmatrix: A matrix with float type.
+            cupyx.scipy.sparse.spmatrix: A matrix with float type.
 
         """
         if self.dtype.kind == 'f':
@@ -247,7 +247,7 @@ class spmatrix(object):
             t: Type specifier.
 
         Returns:
-            cupy.sparse.spmatrix:
+            cupyx.scipy.sparse.spmatrix:
                 A copy of the array with the given type and the same format.
 
         """
@@ -413,8 +413,8 @@ def issparse(x):
     """Checks if a given matrix is a sparse matrix.
 
     Returns:
-        bool: Returns if ``x`` is :class:`cupy.sparse.spmatrix` that is a base
-            class of all sparse matrix classes.
+        bool: Returns if ``x`` is :class:`cupyx.scipy.sparse.spmatrix` that is
+            a base class of all sparse matrix classes.
 
     """
     return isinstance(x, spmatrix)

--- a/cupy/sparse/compressed.py
+++ b/cupy/sparse/compressed.py
@@ -63,7 +63,7 @@ class _compressed_sparse_matrix(sparse_data._data_matrix):
             has_canonical_format = True
 
         elif scipy_available and scipy.sparse.issparse(arg1):
-            # Convert scipy.sparse to cupy.sparse
+            # Convert scipy.sparse to cupyx.scipy.sparse
             x = arg1.asformat(self.format)
             data = cupy.array(x.data)
             indices = cupy.array(x.indices, dtype='i')

--- a/cupy/sparse/construct.py
+++ b/cupy/sparse/construct.py
@@ -13,7 +13,7 @@ def eye(m, n=None, k=0, dtype='d', format=None):
         format (str or None): Format of the result, e.g. ``format="csr"``.
 
     Returns:
-        cupy.sparse.spmatrix: Created sparse matrix.
+        cupyx.scipy.sparse.spmatrix: Created sparse matrix.
 
     .. seealso:: :func:`scipy.sparse.eye`
 
@@ -55,7 +55,7 @@ def identity(n, dtype='d', format=None):
         format (str or None): Format of the result, e.g. ``format="csr"``.
 
     Returns:
-        cupy.sparse.spmatrix: Created identity matrix.
+        cupyx.scipy.sparse.spmatrix: Created identity matrix.
 
     .. seealso:: :func:`scipy.sparse.identity`
 
@@ -74,7 +74,7 @@ def spdiags(data, diags, m, n, format=None):
         format (str or None): Sparse format, e.g. ``format="csr"``.
 
     Returns:
-        cupy.sparse.spmatrix: Created sparse matrix.
+        cupyx.scipy.sparse.spmatrix: Created sparse matrix.
 
     .. seealso:: :func:`scipy.sparse.spdiags`
 
@@ -107,7 +107,7 @@ def random(m, n, density=0.01, format='coo', dtype=None,
             If it is not given, `random_state.rand` is used.
 
     Returns:
-        cupy.sparse.spmatrix: Generated matrix.
+        cupyx.scipy.sparse.spmatrix: Generated matrix.
 
     .. seealso:: :func:`scipy.sparse.random`
 
@@ -141,7 +141,7 @@ def random(m, n, density=0.01, format='coo', dtype=None,
 def rand(m, n, density=0.01, format='coo', dtype=None, random_state=None):
     """Generates a random sparse matrix.
 
-    See :func:`cupy.sparse.random` for detail.
+    See :func:`cupyx.scipy.sparse.random` for detail.
 
     Args:
         m (int): Number of rows.
@@ -157,10 +157,10 @@ def rand(m, n, density=0.01, format='coo', dtype=None, random_state=None):
             This state is used to generate random indexes for nonzero entries.
 
     Returns:
-        cupy.sparse.spmatrix: Generated matrix.
+        cupyx.scipy.sparse.spmatrix: Generated matrix.
 
     .. seealso:: :func:`scipy.sparse.rand`
-    .. seealso:: :func:`cupy.sparse.random`
+    .. seealso:: :func:`cupyx.scipy.sparse.random`
 
     """
     return random(m, n, density, format, dtype, random_state)

--- a/cupy/sparse/coo.py
+++ b/cupy/sparse/coo.py
@@ -75,7 +75,7 @@ class coo_matrix(sparse_data._data_matrix):
             has_canonical_format = True
 
         elif _scipy_available and scipy.sparse.issparse(arg1):
-            # Convert scipy.sparse to cupy.sparse
+            # Convert scipy.sparse to cupyx.scipy.sparse
             x = arg1.tocoo()
             data = cupy.array(x.data)
             row = cupy.array(x.row, dtype='i')
@@ -288,7 +288,7 @@ class coo_matrix(sparse_data._data_matrix):
                 possible.
 
         Returns:
-            cupy.sparse.coo_matrix: Converted matrix.
+            cupyx.scipy.sparse.coo_matrix: Converted matrix.
 
         """
         if copy:
@@ -305,7 +305,7 @@ class coo_matrix(sparse_data._data_matrix):
                 arrays in a matrix cannot be shared in coo to csc conversion.
 
         Returns:
-            cupy.sparse.csc_matrix: Converted matrix.
+            cupyx.scipy.sparse.csc_matrix: Converted matrix.
 
         """
         return self.T.tocsr().T
@@ -319,7 +319,7 @@ class coo_matrix(sparse_data._data_matrix):
                 arrays in a matrix cannot be shared in coo to csr conversion.
 
         Returns:
-            cupy.sparse.csr_matrix: Converted matrix.
+            cupyx.scipy.sparse.csr_matrix: Converted matrix.
 
         """
         if self.nnz == 0:
@@ -339,7 +339,7 @@ class coo_matrix(sparse_data._data_matrix):
                 Otherwise, it shared data arrays as much as possible.
 
         Returns:
-            cupy.sparse.spmatrix: Transpose matrix.
+            cupyx.scipy.sparse.spmatrix: Transpose matrix.
 
         """
         if axes is not None:
@@ -355,7 +355,7 @@ def isspmatrix_coo(x):
     """Checks if a given matrix is of COO format.
 
     Returns:
-        bool: Returns if ``x`` is :class:`cupy.sparse.coo_matrix`.
+        bool: Returns if ``x`` is :class:`cupyx.scipy.sparse.coo_matrix`.
 
     """
     return isinstance(x, coo_matrix)

--- a/cupy/sparse/csc.py
+++ b/cupy/sparse/csc.py
@@ -173,7 +173,7 @@ class csc_matrix(compressed._compressed_sparse_matrix):
                 possible.
 
         Returns:
-            cupy.sparse.coo_matrix: Converted matrix.
+            cupyx.scipy.sparse.coo_matrix: Converted matrix.
 
         """
         return self.T.tocoo(copy).T
@@ -186,7 +186,7 @@ class csc_matrix(compressed._compressed_sparse_matrix):
                 Otherwise it makes a copy of the matrix.
 
         Returns:
-            cupy.sparse.csc_matrix: Converted matrix.
+            cupyx.scipy.sparse.csc_matrix: Converted matrix.
 
         """
         if copy:
@@ -203,7 +203,7 @@ class csc_matrix(compressed._compressed_sparse_matrix):
                 arrays in a matrix cannot be shared in csr to csc conversion.
 
         Returns:
-            cupy.sparse.csr_matrix: Converted matrix.
+            cupyx.scipy.sparse.csr_matrix: Converted matrix.
 
         """
         return self.T.tocsc(copy=False).T
@@ -221,7 +221,7 @@ class csc_matrix(compressed._compressed_sparse_matrix):
                 Otherwise, it shared data arrays as much as possible.
 
         Returns:
-            cupy.sparse.spmatrix: Transpose matrix.
+            cupyx.scipy.sparse.spmatrix: Transpose matrix.
 
         """
         if axes is not None:
@@ -240,7 +240,7 @@ def isspmatrix_csc(x):
     """Checks if a given matrix is of CSC format.
 
     Returns:
-        bool: Returns if ``x`` is :class:`cupy.sparse.csc_matrix`.
+        bool: Returns if ``x`` is :class:`cupyx.scipy.sparse.csc_matrix`.
 
     """
     return isinstance(x, csc_matrix)

--- a/cupy/sparse/csr.py
+++ b/cupy/sparse/csr.py
@@ -222,7 +222,7 @@ class csr_matrix(compressed._compressed_sparse_matrix):
                 possible.
 
         Returns:
-            cupy.sparse.coo_matrix: Converted matrix.
+            cupyx.scipy.sparse.coo_matrix: Converted matrix.
 
         """
         if copy:
@@ -243,7 +243,7 @@ class csr_matrix(compressed._compressed_sparse_matrix):
                 arrays in a matrix cannot be shared in csr to csc conversion.
 
         Returns:
-            cupy.sparse.csc_matrix: Converted matrix.
+            cupyx.scipy.sparse.csc_matrix: Converted matrix.
 
         """
         # copy is ignored
@@ -257,7 +257,7 @@ class csr_matrix(compressed._compressed_sparse_matrix):
                 Otherwise it makes a copy of the matrix.
 
         Returns:
-            cupy.sparse.csr_matrix: Converted matrix.
+            cupyx.scipy.sparse.csr_matrix: Converted matrix.
 
         """
         if copy:
@@ -286,7 +286,7 @@ class csr_matrix(compressed._compressed_sparse_matrix):
                 Otherwise, it shared data arrays as much as possible.
 
         Returns:
-            cupy.sparse.spmatrix: Transpose matrix.
+            cupyx.scipy.sparse.spmatrix: Transpose matrix.
 
         """
         if axes is not None:
@@ -303,7 +303,7 @@ def isspmatrix_csr(x):
     """Checks if a given matrix is of CSR format.
 
     Returns:
-        bool: Returns if ``x`` is :class:`cupy.sparse.csr_matrix`.
+        bool: Returns if ``x`` is :class:`cupyx.scipy.sparse.csr_matrix`.
 
     """
     return isinstance(x, csr_matrix)

--- a/cupy/sparse/dia.py
+++ b/cupy/sparse/dia.py
@@ -128,7 +128,7 @@ class dia_matrix(data._data_matrix):
                 arrays in a matrix cannot be shared in dia to csc conversion.
 
         Returns:
-            cupy.sparse.csc_matrix: Converted matrix.
+            cupyx.scipy.sparse.csc_matrix: Converted matrix.
 
         """
         if self.data.size == 0:
@@ -166,7 +166,7 @@ class dia_matrix(data._data_matrix):
                 arrays in a matrix cannot be shared in dia to csr conversion.
 
         Returns:
-            cupy.sparse.csc_matrix: Converted matrix.
+            cupyx.scipy.sparse.csc_matrix: Converted matrix.
 
         """
         return self.tocsc().tocsr()
@@ -176,7 +176,7 @@ def isspmatrix_dia(x):
     """Checks if a given matrix is of DIA format.
 
     Returns:
-        bool: Returns if ``x`` is :class:`cupy.sparse.dia_matrix`.
+        bool: Returns if ``x`` is :class:`cupyx.scipy.sparse.dia_matrix`.
 
     """
     return isinstance(x, dia_matrix)

--- a/cupy/sparse/linalg/solve.py
+++ b/cupy/sparse/linalg/solve.py
@@ -19,8 +19,8 @@ def lsqr(A, b):
     decomposed into ``Q * R``.
 
     Args:
-        A (cupy.ndarray or cupy.sparse.csr_matrix): The input matrix with
-            dimension ``(N, N)``
+        A (cupy.ndarray or cupyx.scipy.sparse.csr_matrix): The input matrix
+            with dimension ``(N, N)``
         b (cupy.ndarray): Right-hand side vector.
 
     Returns:

--- a/cupy/testing/helper.py
+++ b/cupy/testing/helper.py
@@ -164,7 +164,7 @@ def numpy_cupy_allclose(rtol=1e-7, atol=0, err_msg='', verbose=True,
              If it is ``True`` all error types are acceptable.
              If it is ``False`` no error is acceptable.
          sp_name(str or None): Argument name whose value is either
-             ``scipy.sparse`` or ``cupy.sparse`` module. If ``None``, no
+             ``scipy.sparse`` or ``cupyx.scipy.sparse`` module. If ``None``, no
              argument is given for the modules.
          scipy_name(str or None): Argument name whose value is either ``scipy``
              or ``cupyx.scipy`` module. If ``None``, no argument is given for
@@ -233,7 +233,7 @@ def numpy_cupy_array_almost_equal(decimal=6, err_msg='', verbose=True,
              If it is ``True`` all error types are acceptable.
              If it is ``False`` no error is acceptable.
          sp_name(str or None): Argument name whose value is either
-             ``scipy.sparse`` or ``cupy.sparse`` module. If ``None``, no
+             ``scipy.sparse`` or ``cupyx.scipy.sparse`` module. If ``None``, no
              argument is given for the modules.
          scipy_name(str or None): Argument name whose value is either ``scipy``
              or ``cupyx.scipy`` module. If ``None``, no argument is given for
@@ -269,7 +269,7 @@ def numpy_cupy_array_almost_equal_nulp(nulp=1, name='xp', type_check=True,
              If it is ``True``, all error types are acceptable.
              If it is ``False``, no error is acceptable.
          sp_name(str or None): Argument name whose value is either
-             ``scipy.sparse`` or ``cupy.sparse`` module. If ``None``, no
+             ``scipy.sparse`` or ``cupyx.scipy.sparse`` module. If ``None``, no
              argument is given for the modules.
          scipy_name(str or None): Argument name whose value is either ``scipy``
              or ``cupyx.scipy`` module. If ``None``, no argument is given for
@@ -307,7 +307,7 @@ def numpy_cupy_array_max_ulp(maxulp=1, dtype=None, name='xp', type_check=True,
              If it is ``True`` all error types are acceptable.
              If it is ``False`` no error is acceptable.
          sp_name(str or None): Argument name whose value is either
-             ``scipy.sparse`` or ``cupy.sparse`` module. If ``None``, no
+             ``scipy.sparse`` or ``cupyx.scipy.sparse`` module. If ``None``, no
              argument is given for the modules.
          scipy_name(str or None): Argument name whose value is either ``scipy``
              or ``cupyx.scipy`` module. If ``None``, no argument is given for
@@ -345,7 +345,7 @@ def numpy_cupy_array_equal(err_msg='', verbose=True, name='xp',
              If it is ``True`` all error types are acceptable.
              If it is ``False`` no error is acceptable.
          sp_name(str or None): Argument name whose value is either
-             ``scipy.sparse`` or ``cupy.sparse`` module. If ``None``, no
+             ``scipy.sparse`` or ``cupyx.scipy.sparse`` module. If ``None``, no
              argument is given for the modules.
          scipy_name(str or None): Argument name whose value is either ``scipy``
              or ``cupyx.scipy`` module. If ``None``, no argument is given for
@@ -375,7 +375,7 @@ def numpy_cupy_array_list_equal(
          name(str): Argument name whose value is either
              ``numpy`` or ``cupy`` module.
          sp_name(str or None): Argument name whose value is either
-             ``scipy.sparse`` or ``cupy.sparse`` module. If ``None``, no
+             ``scipy.sparse`` or ``cupyx.scipy.sparse`` module. If ``None``, no
              argument is given for the modules.
          scipy_name(str or None): Argument name whose value is either ``scipy``
              or ``cupyx.scipy`` module. If ``None``, no argument is given for
@@ -430,7 +430,7 @@ def numpy_cupy_array_less(err_msg='', verbose=True, name='xp',
              If it is ``True`` all error types are acceptable.
              If it is ``False`` no error is acceptable.
          sp_name(str or None): Argument name whose value is either
-             ``scipy.sparse`` or ``cupy.sparse`` module. If ``None``, no
+             ``scipy.sparse`` or ``cupyx.scipy.sparse`` module. If ``None``, no
              argument is given for the modules.
          scipy_name(str or None): Argument name whose value is either ``scipy``
              or ``cupyx.scipy`` module. If ``None``, no argument is given for
@@ -454,7 +454,7 @@ def numpy_cupy_equal(name='xp', sp_name=None, scipy_name=None):
          name(str): Argument name whose value is either
              ``numpy`` or ``cupy`` module.
          sp_name(str or None): Argument name whose value is either
-             ``scipy.sparse`` or ``cupy.sparse`` module. If ``None``, no
+             ``scipy.sparse`` or ``cupyx.sciyp.sparse`` module. If ``None``, no
              argument is given for the modules.
          scipy_name(str or None): Argument name whose value is either ``scipy``
              or ``cupyx.scipy`` module. If ``None``, no argument is given for
@@ -499,7 +499,7 @@ def numpy_cupy_raises(name='xp', sp_name=None, scipy_name=None,
          name(str): Argument name whose value is either
              ``numpy`` or ``cupy`` module.
          sp_name(str or None): Argument name whose value is either
-             ``scipy.sparse`` or ``cupy.sparse`` module. If ``None``, no
+             ``scipy.sparse`` or ``cupyx.scipy.sparse`` module. If ``None``, no
              argument is given for the modules.
          scipy_name(str or None): Argument name whose value is either ``scipy``
              or ``cupyx.scipy`` module. If ``None``, no argument is given for


### PR DESCRIPTION
I converted `cupy.sparse` in docstrings. All links are now broken.
related to #1079 