### PR TITLE
Avoid memory error

### DIFF
--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -515,7 +515,10 @@ cdef class PooledMemory(Memory):
         if ptr == 0:
             return
         self.ptr = 0
-        pool = self.pool()
+        pool = self.pool
+        if pool is None:
+            return
+        pool = pool()
         if pool is None:
             return
 


### PR DESCRIPTION
I found memory error with Python3.7.
```
tests/cupy_tests/linalg_tests/test_einsum.py::TestEinSumError::test_invalid_diagonal1 Traceback (most recent call last):
  File "cupy/cuda/memory.pyx", line 521, in cupy.cuda.memory.PooledMemory.free
    pool = pool()
TypeError: 'NoneType' object is not callable
Exception ignored in: 'cupy.cuda.memory.PooledMemory.__dealloc__'
Traceback (most recent call last):
  File "cupy/cuda/memory.pyx", line 521, in cupy.cuda.memory.PooledMemory.free
    pool = pool()
TypeError: 'NoneType' object is not callable
```

This PR fixes it.