### PR TITLE
Fix errors on 0-sized inputs

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2324,6 +2324,8 @@ def array_split(ndarray ary, indices_or_sections, Py_ssize_t axis):
     prev = 0
     ret = []
     stride = ary._strides[axis]
+    if ary.size == 0:
+        stride = 0
     for index in indices:
         shape[axis] = index - prev
         v = ary.view()

--- a/cupy/math/sumprod.py
+++ b/cupy/math/sumprod.py
@@ -1,6 +1,7 @@
 import numpy
 import six
 
+import cupy
 from cupy import core
 
 
@@ -60,6 +61,8 @@ def _axis_to_first(x, axis):
 
 
 def _proc_as_batch(proc, x, axis):
+    if x.shape[axis] == 0:
+        return cupy.empty_like(x)
     trans, revert = _axis_to_first(x, axis)
     t = x.transpose(trans)
     s = t.shape

--- a/tests/cupy_tests/manipulation_tests/test_split.py
+++ b/tests/cupy_tests/manipulation_tests/test_split.py
@@ -18,6 +18,7 @@ class TestSplit(unittest.TestCase):
         split = xp.array_split(a, 4, -1)
         return xp.concatenate(split, -1)
 
+    @testing.with_requires('numpy>=1.11')
     @testing.numpy_cupy_array_equal()
     def test_array_split_empty_array(self, xp):
         a = testing.shaped_arange((5, 0), xp)

--- a/tests/cupy_tests/manipulation_tests/test_split.py
+++ b/tests/cupy_tests/manipulation_tests/test_split.py
@@ -19,10 +19,16 @@ class TestSplit(unittest.TestCase):
         return xp.concatenate(split, -1)
 
     @testing.numpy_cupy_array_equal()
-    def test_array_spliti_empty(self, xp):
+    def test_array_split_empty_array(self, xp):
+        a = testing.shaped_arange((5, 0), xp)
+        split = xp.array_split(a, [2, 4], 0)
+        return xp.concatenate(split, 0)
+
+    @testing.numpy_cupy_array_equal()
+    def test_array_split_empty_sections(self, xp):
         a = testing.shaped_arange((3, 11), xp)
         split = xp.array_split(a, [])
-        return xp.concatenate(split, -1)
+        return xp.concatenate(split, 0)
 
     @testing.numpy_cupy_array_equal()
     def test_dsplit(self, xp):

--- a/tests/cupy_tests/math_tests/test_sumprod.py
+++ b/tests/cupy_tests/math_tests/test_sumprod.py
@@ -205,6 +205,13 @@ class TestCumsum(unittest.TestCase):
         return xp.cumsum(a, axis=self.axis)
 
     @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose()
+    def test_cumsum_axis_empty(self, xp, dtype):
+        n = len(axes)
+        a = testing.shaped_arange(tuple(six.moves.range(0, n)), xp, dtype)
+        return xp.cumsum(a, axis=self.axis)
+
+    @testing.for_all_dtypes()
     @testing.with_requires('numpy>=1.13')
     @testing.numpy_cupy_raises()
     def test_invalid_axis_lower1(self, xp, dtype):


### PR DESCRIPTION
This PR make the following functions support 0-sized input arrays.
- `cupy.cumsum`, `cupy.cumprod` (fix #1455)
- `cupy.split`, `cupy.array_split` (fix #1458)