### PR TITLE
Add upgrade guide for cupyx namespaces

### DIFF
--- a/docs/source/upgrade.rst
+++ b/docs/source/upgrade.rst
@@ -8,6 +8,15 @@ This is a list of changes introduced in each release that users should be aware 
 Most changes are carefully designed not to break existing code; however changes that may possibly break them are highlighted with a box.
 
 
+CuPy v5
+=======
+
+``cupyx.scipy`` Namespace
+-------------------------
+
+:mod:`cupyx.scipy` namespace has been introduced to provide CUDA-enabled SciPy functions.
+:mod:`cupy.sparse` module has been renamed to :mod:`cupyx.scipy.sparse`; :mod:`cupy.sparse` will be kept as an alias for backward compatibility.
+
 CuPy v4
 =======
 
@@ -74,6 +83,15 @@ As CUDA Stream is fully supported in CuPy v4, ``cupy.cuda.RandomState.set_stream
 Please use :func:`cupy.cuda.Stream.use` instead.
 
 See the discussion in `#306 <https://github.com/cupy/cupy/pull/306>`_ for more details.
+
+``cupyx`` Namespace
+-------------------
+
+``cupyx`` namespace has been introduced to provide features specific to CuPy (i.e., features not provided in NumPy) while avoiding collision in future.
+See :doc:`reference/ext` for the list of such functions.
+
+For this rule, :func:`cupy.scatter_add` has been moved to :func:`cupyx.scatter_add`.
+:func:`cupy.scatter_add` is still available as an alias, but it is encouraged to use :func:`cupyx.scatter_add` instead.
 
 Update of Docker Images
 -----------------------


### PR DESCRIPTION
Blocked by #1451.

to-be-backported for v4 part.