### PR TITLE
fix cupy.random.dirichlet to behave same as numpy.random.dirichlet

### DIFF
--- a/cupy/random/generator.py
+++ b/cupy/random/generator.py
@@ -118,6 +118,8 @@ class RandomState(object):
         alpha = cupy.asarray(alpha)
         if size is None:
             size = alpha.shape
+        else:
+            size += alpha.shape
         y = cupy.zeros(shape=size, dtype=dtype)
         _kernels.standard_gamma_kernel(alpha, self.rk_seed, y)
         y /= y.sum(axis=-1, keepdims=True)

--- a/tests/cupy_tests/random_tests/test_distributions.py
+++ b/tests/cupy_tests/random_tests/test_distributions.py
@@ -14,6 +14,17 @@ _unsigned_dtypes = tuple(numpy.dtype(i).type for i in 'BHILQ')
 _int_dtypes = _signed_dtypes + _unsigned_dtypes
 
 
+class RandomDistributionsTestCase(unittest.TestCase):
+    def check_distribution(self, dist_name, params, dtype):
+        cp_params = {k: cupy.asarray(params[k]) for k in params}
+        np_out = numpy.random.__dict__[dist_name](
+            size=self.shape, **params).astype(dtype)
+        cp_out = distributions.__dict__[dist_name](
+            size=self.shape, dtype=dtype, **cp_params)
+        self.assertEqual(cp_out.shape, np_out.shape)
+        self.assertEqual(cp_out.dtype, np_out.dtype)
+
+
 @testing.parameterize(*testing.product({
     'shape': [(4, 3, 2), (3, 2)],
     'a_shape': [(), (3, 2)],
@@ -22,20 +33,15 @@ _int_dtypes = _signed_dtypes + _unsigned_dtypes
 })
 )
 @testing.gpu
-class TestDistributionsBeta(unittest.TestCase):
-
-    def check_distribution(self, dist_func, a_dtype, b_dtype, dtype):
-        a = 3. * cupy.ones(self.a_shape, dtype=a_dtype)
-        b = 3. * cupy.ones(self.b_shape, dtype=b_dtype)
-        out = dist_func(a, b, self.shape, dtype)
-        self.assertEqual(self.shape, out.shape)
-        self.assertEqual(out.dtype, dtype)
+class TestDistributionsBeta(RandomDistributionsTestCase):
 
     @cupy.testing.for_float_dtypes('a_dtype')
     @cupy.testing.for_float_dtypes('b_dtype')
     def test_beta(self, a_dtype, b_dtype):
-        self.check_distribution(distributions.beta,
-                                a_dtype, b_dtype, self.dtype)
+        a = 3. * numpy.ones(self.a_shape, dtype=a_dtype)
+        b = 3. * numpy.ones(self.b_shape, dtype=b_dtype)
+        self.check_distribution('beta',
+                                {'a': a, 'b': b}, self.dtype)
 
 
 @testing.parameterize(*testing.product({
@@ -46,41 +52,31 @@ class TestDistributionsBeta(unittest.TestCase):
 })
 )
 @testing.gpu
-class TestDistributionsBinomial(unittest.TestCase):
+class TestDistributionsBinomial(RandomDistributionsTestCase):
 
-    def check_distribution(self, dist_func, n_dtype, p_dtype, dtype):
-        n = 5 * cupy.ones(self.n_shape, dtype=n_dtype)
-        p = 0.5 * cupy.ones(self.p_shape, dtype=p_dtype)
-        out = dist_func(n, p, self.shape, dtype)
-        self.assertEqual(self.shape, out.shape)
-        self.assertEqual(out.dtype, dtype)
-
-    @cupy.testing.for_int_dtypes('n_dtype')
+    @cupy.testing.for_signed_dtypes('n_dtype')
     @cupy.testing.for_float_dtypes('p_dtype')
     def test_binomial(self, n_dtype, p_dtype):
-        self.check_distribution(distributions.binomial,
-                                n_dtype, p_dtype, self.dtype)
+        n = 5 * numpy.ones(self.n_shape, dtype=n_dtype)
+        p = 0.5 * numpy.ones(self.p_shape, dtype=p_dtype)
+        self.check_distribution('binomial',
+                                {'n': n, 'p': p}, self.dtype)
 
 
 @testing.parameterize(*testing.product({
     'shape': [(4, 3, 2, 3), (3, 2, 3)],
-    'alpha_shape': [(3,), (3, 2, 3)],
+    'alpha_shape': [(3,)],
 })
 )
 @testing.gpu
-class TestDistributionsDirichlet(unittest.TestCase):
-
-    def check_distribution(self, dist_func, alpha_dtype, dtype):
-        alpha = cupy.ones(self.alpha_shape, dtype=alpha_dtype)
-        out = dist_func(alpha, self.shape, dtype)
-        self.assertEqual(self.shape, out.shape)
-        self.assertEqual(out.dtype, dtype)
+class TestDistributionsDirichlet(RandomDistributionsTestCase):
 
     @cupy.testing.for_float_dtypes('alpha_dtype')
     @cupy.testing.for_float_dtypes('dtype')
     def test_dirichlet(self, alpha_dtype, dtype):
-        self.check_distribution(distributions.dirichlet,
-                                alpha_dtype, dtype)
+        alpha = numpy.ones(self.alpha_shape, dtype=alpha_dtype)
+        self.check_distribution('dirichlet',
+                                {'alpha': alpha}, dtype)
 
 
 @testing.parameterize(*testing.product({
@@ -90,21 +86,16 @@ class TestDistributionsDirichlet(unittest.TestCase):
 })
 )
 @testing.gpu
-class TestDistributionsGumbel(unittest.TestCase):
-
-    def check_distribution(self, dist_func, loc_dtype, scale_dtype, dtype):
-        loc = cupy.ones(self.loc_shape, dtype=loc_dtype)
-        scale = cupy.ones(self.scale_shape, dtype=scale_dtype)
-        out = dist_func(loc, scale, self.shape, dtype)
-        self.assertEqual(self.shape, out.shape)
-        self.assertEqual(out.dtype, dtype)
+class TestDistributionsGumbel(RandomDistributionsTestCase):
 
     @cupy.testing.for_float_dtypes('dtype', no_float16=True)
     @cupy.testing.for_float_dtypes('loc_dtype')
     @cupy.testing.for_float_dtypes('scale_dtype')
     def test_gumbel(self, loc_dtype, scale_dtype, dtype):
-        self.check_distribution(distributions.gumbel,
-                                loc_dtype, scale_dtype, dtype)
+        loc = numpy.ones(self.loc_shape, dtype=loc_dtype)
+        scale = numpy.ones(self.scale_shape, dtype=scale_dtype)
+        self.check_distribution('gumbel',
+                                {'loc': loc, 'scale': scale}, dtype)
 
 
 @testing.parameterize(*testing.product({
@@ -114,21 +105,16 @@ class TestDistributionsGumbel(unittest.TestCase):
 })
 )
 @testing.gpu
-class TestDistributionsLaplace(unittest.TestCase):
-
-    def check_distribution(self, dist_func, loc_dtype, scale_dtype, dtype):
-        loc = cupy.ones(self.loc_shape, dtype=loc_dtype)
-        scale = cupy.ones(self.scale_shape, dtype=scale_dtype)
-        out = dist_func(loc, scale, self.shape, dtype)
-        self.assertEqual(self.shape, out.shape)
-        self.assertEqual(out.dtype, dtype)
+class TestDistributionsLaplace(RandomDistributionsTestCase):
 
     @cupy.testing.for_float_dtypes('dtype', no_float16=True)
     @cupy.testing.for_float_dtypes('loc_dtype')
     @cupy.testing.for_float_dtypes('scale_dtype')
     def test_laplace(self, loc_dtype, scale_dtype, dtype):
-        self.check_distribution(distributions.laplace,
-                                loc_dtype, scale_dtype, dtype)
+        loc = numpy.ones(self.loc_shape, dtype=loc_dtype)
+        scale = numpy.ones(self.scale_shape, dtype=scale_dtype)
+        self.check_distribution('laplace',
+                                {'loc': loc, 'scale': scale}, dtype)
 
 
 @testing.parameterize(*testing.product({
@@ -138,21 +124,16 @@ class TestDistributionsLaplace(unittest.TestCase):
 })
 )
 @testing.gpu
-class TestDistributionsLognormal(unittest.TestCase):
-
-    def check_distribution(self, dist_func, mean_dtype, sigma_dtype, dtype):
-        mean = cupy.ones(self.mean_shape, dtype=mean_dtype)
-        sigma = cupy.ones(self.sigma_shape, dtype=sigma_dtype)
-        out = dist_func(mean, sigma, self.shape, dtype)
-        self.assertEqual(self.shape, out.shape)
-        self.assertEqual(out.dtype, dtype)
+class TestDistributionsLognormal(RandomDistributionsTestCase):
 
     @cupy.testing.for_float_dtypes('dtype', no_float16=True)
     @cupy.testing.for_float_dtypes('mean_dtype')
     @cupy.testing.for_float_dtypes('sigma_dtype')
     def test_lognormal(self, mean_dtype, sigma_dtype, dtype):
-        self.check_distribution(distributions.lognormal,
-                                mean_dtype, sigma_dtype, dtype)
+        mean = numpy.ones(self.mean_shape, dtype=mean_dtype)
+        sigma = numpy.ones(self.sigma_shape, dtype=sigma_dtype)
+        self.check_distribution('lognormal',
+                                {'mean': mean, 'sigma': sigma}, dtype)
 
 
 @testing.parameterize(*testing.product({
@@ -162,21 +143,16 @@ class TestDistributionsLognormal(unittest.TestCase):
 })
 )
 @testing.gpu
-class TestDistributionsNormal(unittest.TestCase):
-
-    def check_distribution(self, dist_func, loc_dtype, scale_dtype, dtype):
-        loc = cupy.ones(self.loc_shape, dtype=loc_dtype)
-        scale = cupy.ones(self.scale_shape, dtype=scale_dtype)
-        out = dist_func(loc, scale, self.shape, dtype)
-        self.assertEqual(self.shape, out.shape)
-        self.assertEqual(out.dtype, dtype)
+class TestDistributionsNormal(RandomDistributionsTestCase):
 
     @cupy.testing.for_float_dtypes('dtype', no_float16=True)
     @cupy.testing.for_float_dtypes('loc_dtype')
     @cupy.testing.for_float_dtypes('scale_dtype')
     def test_normal(self, loc_dtype, scale_dtype, dtype):
-        self.check_distribution(distributions.normal,
-                                loc_dtype, scale_dtype, dtype)
+        loc = numpy.ones(self.loc_shape, dtype=loc_dtype)
+        scale = numpy.ones(self.scale_shape, dtype=scale_dtype)
+        self.check_distribution('normal',
+                                {'loc': loc, 'scale': scale}, dtype)
 
 
 @testing.parameterize(*testing.product({
@@ -184,16 +160,11 @@ class TestDistributionsNormal(unittest.TestCase):
 })
 )
 @testing.gpu
-class TestDistributionsStandardNormal(unittest.TestCase):
-
-    def check_distribution(self, dist_func, dtype):
-        out = dist_func(self.shape, dtype)
-        self.assertEqual(self.shape, out.shape)
-        self.assertEqual(out.dtype, dtype)
+class TestDistributionsStandardNormal(RandomDistributionsTestCase):
 
     @cupy.testing.for_float_dtypes('dtype', no_float16=True)
     def test_standardnormal(self, dtype):
-        self.check_distribution(distributions.standard_normal, dtype)
+        self.check_distribution('standard_normal', {}, dtype)
 
 
 @testing.parameterize(*testing.product({
@@ -203,18 +174,13 @@ class TestDistributionsStandardNormal(unittest.TestCase):
 })
 )
 @testing.gpu
-class TestDistributionsUniform(unittest.TestCase):
-
-    def check_distribution(self, dist_func, low_dtype, high_dtype, dtype):
-        low = cupy.ones(self.low_shape, dtype=low_dtype)
-        high = cupy.ones(self.high_shape, dtype=high_dtype) * 2.
-        out = dist_func(low, high, self.shape, dtype)
-        self.assertEqual(self.shape, out.shape)
-        self.assertEqual(out.dtype, dtype)
+class TestDistributionsUniform(RandomDistributionsTestCase):
 
     @cupy.testing.for_float_dtypes('dtype', no_float16=True)
     @cupy.testing.for_float_dtypes('low_dtype')
     @cupy.testing.for_float_dtypes('high_dtype')
     def test_uniform(self, low_dtype, high_dtype, dtype):
-        self.check_distribution(distributions.uniform,
-                                low_dtype, high_dtype, dtype)
+        low = numpy.ones(self.low_shape, dtype=low_dtype)
+        high = numpy.ones(self.high_shape, dtype=high_dtype) * 2.
+        self.check_distribution('uniform',
+                                {'low': low, 'high': high}, dtype)

--- a/tests/cupy_tests/random_tests/test_distributions.py
+++ b/tests/cupy_tests/random_tests/test_distributions.py
@@ -17,9 +17,9 @@ _int_dtypes = _signed_dtypes + _unsigned_dtypes
 class RandomDistributionsTestCase(unittest.TestCase):
     def check_distribution(self, dist_name, params, dtype):
         cp_params = {k: cupy.asarray(params[k]) for k in params}
-        np_out = numpy.random.__dict__[dist_name](
+        np_out = getattr(numpy.random, dist_name)(
             size=self.shape, **params).astype(dtype)
-        cp_out = distributions.__dict__[dist_name](
+        cp_out = getattr(distributions, dist_name)(
             size=self.shape, dtype=dtype, **cp_params)
         self.assertEqual(cp_out.shape, np_out.shape)
         self.assertEqual(cp_out.dtype, np_out.dtype)


### PR DESCRIPTION
for now
```
>>> import numpy
>>> import cupy
>>> numpy.random.dirichlet([1,1,1], (100,3)).shape
(100, 3, 3)
>>> cupy.random.dirichlet([1,1,1], (100,3)).shape
(100, 3)
```

I fixed this.