### PR TITLE
[backport] Avoid variable name 'l' to follow pep8

### DIFF
--- a/cupy/linalg/norms.py
+++ b/cupy/linalg/norms.py
@@ -215,9 +215,9 @@ def slogdet(a):
 
     a = a.astype(dtype)
     for index in numpy.ndindex(*shape):
-        s, l = _slogdet_one(a[index])
+        s, logd = _slogdet_one(a[index])
         sign[index] = s
-        logdet[index] = l
+        logdet[index] = logd
     return sign, logdet
 
 


### PR DESCRIPTION
Backport of #1460