### PR TITLE
Support cublas<t>tpttr and cublas<t>trttp

### DIFF
--- a/cupy/cuda/cublas.pxd
+++ b/cupy/cuda/cublas.pxd
@@ -224,3 +224,9 @@ cpdef gemmEx(size_t handle, int transa, int transb, int m, int n, int k,
              size_t alpha, size_t A, int Atype, int lda, size_t B,
              int Btype, int ldb, size_t beta, size_t C, int Ctype,
              int ldc, int computeType, int algo)
+
+cpdef stpttr(size_t handle, int uplo, int n, size_t AP, size_t A, int lda)
+cpdef dtpttr(size_t handle, int uplo, int n, size_t AP, size_t A, int lda)
+
+cpdef strttp(size_t handle, int uplo, int n, size_t A, int lda, size_t AP)
+cpdef dtrttp(size_t handle, int uplo, int n, size_t A, int lda, size_t AP)

--- a/cupy/cuda/cublas.pyx
+++ b/cupy/cuda/cublas.pyx
@@ -217,6 +217,14 @@ cdef extern from 'cupy_cuda.h' nogil:
         const void *beta,
         void *C, runtime.DataType Ctype, int ldc,
         runtime.DataType computetype, GemmAlgo algo)
+    int cublasStpttr(
+        Handle handle, FillMode uplo, int n, float *AP, float *A, int lda)
+    int cublasDtpttr(
+        Handle handle, FillMode uplo, int n, double *AP, double *A, int lda)
+    int cublasStrttp(
+        Handle handle, FillMode uplo, int n, float *A, int lda, float *AP)
+    int cublasDtrttp(
+        Handle handle, FillMode uplo, int n, double *A, int lda, double *AP)
 
 ###############################################################################
 # Util
@@ -896,4 +904,36 @@ cpdef gemmEx(
             <const void*>beta,
             <void*>C, <runtime.DataType>Ctype, ldc,
             <runtime.DataType>computeType, <GemmAlgo>algo)
+    check_status(status)
+
+
+cpdef stpttr(size_t handle, int uplo, int n, size_t AP, size_t A, int lda):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cublasStpttr(
+            <Handle>handle, <FillMode>uplo, n, <const float*>AP, <float*>A, lda)
+    check_status(status)
+
+
+cpdef dtpttr(size_t handle, int uplo, int n, size_t AP, size_t A, int lda):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cublasDtpttr(
+            <Handle>handle, <FillMode>uplo, n, <const double*>AP, <double*>A, lda)
+    check_status(status)
+
+
+cpdef strttp(size_t handle, int uplo, int n, size_t A, int lda, size_t AP):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cublasStrttp(
+            <Handle>handle, <FillMode>uplo, n, <const float*>A, lda, <float*>AP)
+    check_status(status)
+
+
+cpdef dtrttp(size_t handle, int uplo, int n, size_t A, int lda, size_t AP):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cublasDtrttp(
+            <Handle>handle, <FillMode>uplo, n, <const double*>A, lda, <double*>AP)
     check_status(status)

--- a/cupy/cuda/cupy_cuda.h
+++ b/cupy/cuda/cupy_cuda.h
@@ -658,6 +658,21 @@ cublasStatus_t cublasSgetriBatched(...) {
     return CUBLAS_STATUS_SUCCESS;
 }
 
+cublasStatus_t cublasStrttp(...) {
+    return CUBLAS_STATUS_SUCCESS;
+}
+
+cublasStatus_t cublasDtrttp(...) {
+    return CUBLAS_STATUS_SUCCESS;
+}
+
+cublasStatus_t cublasStpttr(...) {
+    return CUBLAS_STATUS_SUCCESS;
+}
+
+cublasStatus_t cublasDprttr(...) {
+    return CUBLAS_STATUS_SUCCESS;
+}
 
 ///////////////////////////////////////////////////////////////////////////////
 // curand.h


### PR DESCRIPTION
This PR aims to allow users to use cublas[SD]tpttr and cublas[SD]trttp, those are useful for matrix format conversion from triangular packed format to triangular format and vice versa. Please refer to  https://docs.nvidia.com/cuda/cublas/index.html#cublas-trttp for details about the APIs.