### PR TITLE
[backport] Allow `cupy.get_array_module` take fusion parameters

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -652,6 +652,8 @@ def get_array_module(*args):
 
     """
     for arg in args:
+        if isinstance(arg, fusion.FusionVarPython):
+            return fusion
         if isinstance(arg, (ndarray, sparse.spmatrix)):
             return _cupy
     return numpy

--- a/tests/cupy_tests/core_tests/test_fusion.py
+++ b/tests/cupy_tests/core_tests/test_fusion.py
@@ -1538,3 +1538,19 @@ class TestFusionCompile(unittest.TestCase):
         y = testing.shaped_arange((3, 3), xp, dtype)
         f.clear_cache()
         return f(x, y)
+
+
+@testing.gpu
+class TestFusionGetArrayModule(unittest.TestCase):
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_get_array_module(self, xp, dtype):
+
+        @cupy.fuse()
+        def f(x):
+            xp = cupy.get_array_module(x)
+            return xp.square(x)
+
+        x = testing.shaped_arange((3, 4), xp, dtype)
+        return f(x)


### PR DESCRIPTION
Backport of #1446