### PR TITLE
Add cumsum and cumprod to ndarray

### DIFF
--- a/cupy/core/core.pxd
+++ b/cupy/core/core.pxd
@@ -44,6 +44,7 @@ cdef class ndarray:
     cpdef ndarray trace(self, offset=*, axis1=*, axis2=*, dtype=*,
                         out=*)
     cpdef ndarray sum(self, axis=*, dtype=*, out=*, keepdims=*)
+    cpdef ndarray cumsum(self, axis=*, dtype=*, out=*)
 
     cpdef ndarray mean(self, axis=*, dtype=*, out=*, keepdims=*)
     cpdef ndarray var(self, axis=*, dtype=*, out=*, ddof=*,
@@ -51,6 +52,8 @@ cdef class ndarray:
     cpdef ndarray std(self, axis=*, dtype=*, out=*, ddof=*,
                       keepdims=*)
     cpdef ndarray prod(self, axis=*, dtype=*, out=*, keepdims=*)
+    cpdef ndarray cumprod(a, axis=*, dtype=*, out=*)
+
     cpdef ndarray all(self, axis=*, out=*, keepdims=*)
     cpdef ndarray any(self, axis=*, out=*, keepdims=*)
     cpdef ndarray conj(self)

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1187,7 +1187,15 @@ cdef class ndarray:
         else:
             return _sum_keep_dtype(self, axis, dtype, out, keepdims)
 
-    # TODO(okuta): Implement cumsum
+    cpdef ndarray cumsum(self, axis=None, dtype=None, out=None):
+        """Returns the cumulative sum of an array along a given axis.
+
+        .. seealso::
+           :func:`cupy.cumsum` for full documentation,
+           :meth:`numpy.ndarray.cumsum`
+
+        """
+        return cupy.cumsum(self, axis, dtype, out)
 
     cpdef ndarray mean(self, axis=None, dtype=None, out=None, keepdims=False):
         """Returns the mean along a given axis.
@@ -1236,7 +1244,15 @@ cdef class ndarray:
         else:
             return _prod_keep_dtype(self, axis, dtype, out, keepdims)
 
-    # TODO(okuta): Implement cumprod
+    cpdef ndarray cumprod(a, axis=None, dtype=None, out=None):
+        """Returns the cumulative product of an array along a given axis.
+
+        .. seealso::
+           :func:`cupy.cumprod` for full documentation,
+           :meth:`numpy.ndarray.cumprod`
+
+        """
+        return cupy.cumprod(a, axis, dtype, out)
 
     cpdef ndarray all(self, axis=None, out=None, keepdims=False):
         return _all(self, axis=axis, out=out, keepdims=keepdims)

--- a/tests/cupy_tests/math_tests/test_sumprod.py
+++ b/tests/cupy_tests/math_tests/test_sumprod.py
@@ -205,6 +205,13 @@ class TestCumsum(unittest.TestCase):
         return xp.cumsum(a, axis=self.axis)
 
     @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
+    def test_ndarray_cumsum_axis(self, xp, dtype):
+        n = len(axes)
+        a = testing.shaped_arange(tuple(six.moves.range(4, 4 + n)), xp, dtype)
+        return a.cumsum(axis=self.axis)
+
+    @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_cumsum_axis_empty(self, xp, dtype):
         n = len(axes)
@@ -258,6 +265,12 @@ class TestCumprod(unittest.TestCase):
     def test_cumprod_2dim_with_axis(self, xp, dtype):
         a = testing.shaped_arange((4, 5), xp, dtype)
         return xp.cumprod(a, axis=1)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose()
+    def test_ndarray_cumprod_2dim_with_axis(self, xp, dtype):
+        a = testing.shaped_arange((4, 5), xp, dtype)
+        return a.cumprod(axis=1)
 
     @testing.slow
     def test_cumprod_huge_array(self):


### PR DESCRIPTION
`cumsum` and `cumprod` are already implemented.
But, `ndarray` does not have them. I will add them by this PR.