### PR TITLE
Support `nonzero` for complex types 

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1058,7 +1058,8 @@ cdef class ndarray:
             count_nonzero = 0
         else:
             r = self.ravel()
-            scan_index = scan(not_equal(r, 0, ndarray(r.shape, dtype)))
+            nonzero = not_equal(r, 0, ndarray(r.shape, dtype))
+            scan_index = scan(nonzero)
             count_nonzero = int(scan_index[-1])
         ndim = max(self._shape.size(), 1)
         if count_nonzero == 0:
@@ -1066,13 +1067,14 @@ cdef class ndarray:
 
         if ndim <= 1:
             dst = ndarray((count_nonzero,), dtype=dtype)
-            _nonzero_kernel_1d(r, scan_index, dst)
+            _nonzero_kernel_1d(nonzero, scan_index, dst)
             return dst,
         else:
             del r
+            nonzero.shape = self.shape
             scan_index.shape = self.shape
             dst = ndarray((ndim, count_nonzero), dtype=dtype)
-            _nonzero_kernel(self, scan_index, dst)
+            _nonzero_kernel(nonzero, scan_index, dst)
             return tuple([dst[i] for i in range(ndim)])
 
     # TODO(okuta): Implement compress

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1059,6 +1059,7 @@ cdef class ndarray:
         else:
             r = self.ravel()
             nonzero = not_equal(r, 0, ndarray(r.shape, dtype))
+            del r
             scan_index = scan(nonzero)
             count_nonzero = int(scan_index[-1])
         ndim = max(self._shape.size(), 1)
@@ -1070,7 +1071,6 @@ cdef class ndarray:
             _nonzero_kernel_1d(nonzero, scan_index, dst)
             return dst,
         else:
-            del r
             nonzero.shape = self.shape
             scan_index.shape = self.shape
             dst = ndarray((ndim, count_nonzero), dtype=dtype)

--- a/tests/cupy_tests/sorting_tests/test_search.py
+++ b/tests/cupy_tests/sorting_tests/test_search.py
@@ -207,8 +207,9 @@ class TestWhereError(unittest.TestCase):
     {"array": numpy.random.randn(3, 2, 4)},
     {"array": numpy.array(0)},
     {"array": numpy.array(1)},
-    {"array": numpy.zeros((0, 2))},
-    {"array": numpy.zeros((0, 2, 0))},
+    {"array": numpy.empty((0,))},
+    {"array": numpy.empty((0, 2))},
+    {"array": numpy.empty((0, 2, 0))},
 )
 @testing.gpu
 class TestNonzero(unittest.TestCase):
@@ -225,13 +226,14 @@ class TestNonzero(unittest.TestCase):
     {"array": numpy.random.randn(3, 2, 4)},
     {"array": numpy.array(0)},
     {"array": numpy.array(1)},
-    {"array": numpy.zeros((0, 2))},
-    {"array": numpy.zeros((0, 2, 0))},
+    {"array": numpy.empty((0,))},
+    {"array": numpy.empty((0, 2))},
+    {"array": numpy.empty((0, 2, 0))},
 )
 @testing.gpu
 class TestFlatNonzero(unittest.TestCase):
 
-    @testing.for_all_dtypes(no_complex=True)
+    @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_flatnonzero(self, xp, dtype):
         array = xp.array(self.array, dtype=dtype)

--- a/tests/cupy_tests/sorting_tests/test_search.py
+++ b/tests/cupy_tests/sorting_tests/test_search.py
@@ -213,7 +213,7 @@ class TestWhereError(unittest.TestCase):
 @testing.gpu
 class TestNonzero(unittest.TestCase):
 
-    @testing.for_all_dtypes(no_complex=True)
+    @testing.for_all_dtypes()
     @testing.numpy_cupy_array_list_equal()
     def test_nonzero(self, xp, dtype):
         array = xp.array(self.array, dtype=dtype)


### PR DESCRIPTION
numpy supports `nonzero` for complex types.
```
>>> np.array([[1, 0], [2j, 3]]).nonzero()
(array([0, 1, 1]), array([0, 0, 1]))
```

In cupy, the kernel has `!= 0`, which results in the compile error below on complex inputs.
```
E           CompileException: /tmp/tmpq4wq7klq/kern.cu(15): error: no operator "!=" matches these operands
E                       operand types are: T != int
```

Merge #1487 first.