### PR TITLE
Fix unit test errors in NumPy 1.15

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -3364,7 +3364,7 @@ cpdef ndarray _diagonal(ndarray a, Py_ssize_t offset=0, Py_ssize_t axis1=0,
                         Py_ssize_t axis2=1):
     cdef Py_ssize_t ndim = a.ndim
     if not (-ndim <= axis1 < ndim and -ndim <= axis2 < ndim):
-        raise ValueError('axis1(={0}) and axis2(={1}) must be within range '
+        raise _AxisError('axis1(={0}) and axis2(={1}) must be within range '
                          '(ndim={2})'.format(axis1, axis2, ndim))
 
     axis1 %= ndim

--- a/cupy/manipulation/rearrange.py
+++ b/cupy/manipulation/rearrange.py
@@ -20,11 +20,11 @@ def flip(a, axis):
     """
     a_ndim = a.ndim
     if a_ndim < 1:
-        raise ValueError('Input must be >= 1-d')
+        raise core.core._AxisError('Input must be >= 1-d')
 
     axis = int(axis)
     if not -a_ndim <= axis < a_ndim:
-        raise ValueError(
+        raise core.core._AxisError(
             'axis must be >= %d and < %d' % (-a_ndim, a_ndim))
 
     return _flip(a, axis)

--- a/cupy/statistics/histogram.py
+++ b/cupy/statistics/histogram.py
@@ -35,8 +35,6 @@ def histogram(x, bins=10):
             min_value -= 0.5
             max_value += 0.5
         bin_type = cupy.result_type(min_value, max_value, x)
-        if cupy.issubdtype(bin_type, cupy.integer):
-            bin_type = cupy.result_Type(bin_type, float)
         bins = cupy.linspace(min_value, max_value, bins + 1, dtype=bin_type)
     elif isinstance(bins, cupy.ndarray):
         if cupy.any(bins[:-1] > bins[1:]):

--- a/cupy/statistics/histogram.py
+++ b/cupy/statistics/histogram.py
@@ -34,7 +34,10 @@ def histogram(x, bins=10):
         if min_value == max_value:
             min_value -= 0.5
             max_value += 0.5
-        bins = cupy.linspace(min_value, max_value, bins + 1)
+        bin_type = cupy.result_type(min_value, max_value, x)
+        if cupy.issubdtype(bin_type, cupy.integer):
+            bin_type = cupy.result_Type(bin_type, float)
+        bins = cupy.linspace(min_value, max_value, bins + 1, dtype=bin_type)
     elif isinstance(bins, cupy.ndarray):
         if cupy.any(bins[:-1] > bins[1:]):
             raise ValueError('bins must increase monotonically.')

--- a/tests/cupy_tests/statics_tests/test_histogram.py
+++ b/tests/cupy_tests/statics_tests/test_histogram.py
@@ -38,6 +38,7 @@ def for_all_dtypes_combination_bincount(names):
 @testing.gpu
 class TestHistogram(unittest.TestCase):
 
+    @testing.with_requires('numpy>=1.15.0')
     @testing.for_all_dtypes(no_bool=True, no_complex=True)
     @testing.numpy_cupy_array_list_equal()
     def test_histogram(self, xp, dtype):
@@ -45,6 +46,7 @@ class TestHistogram(unittest.TestCase):
         y, bin_edges = xp.histogram(x)
         return y, bin_edges
 
+    @testing.with_requires('numpy>=1.15.0')
     @testing.for_all_dtypes(no_bool=True, no_complex=True)
     @testing.numpy_cupy_array_list_equal()
     def test_histogram_same_value(self, xp, dtype):
@@ -52,6 +54,7 @@ class TestHistogram(unittest.TestCase):
         y, bin_edges = xp.histogram(x, 3)
         return y, bin_edges
 
+    @testing.with_requires('numpy>=1.15.0')
     @testing.for_all_dtypes(no_bool=True, no_complex=True)
     @testing.numpy_cupy_array_list_equal()
     def test_histogram_empty(self, xp, dtype):


### PR DESCRIPTION
* Some exception types has been changed from `ValueError` to `numpy.AxisError` (which inherits from `ValueError`).
* `np.histogram` has been changed to decide dtype for bin edges based on input. (https://github.com/numpy/numpy/pull/10324)