### PR TITLE
[backport] Use collections.abc to avoid DeprecationWarning in Python 3.7

### DIFF
--- a/cupy/core/internal.pyx
+++ b/cupy/core/internal.pyx
@@ -43,7 +43,7 @@ cpdef inline tuple get_size(object size):
         return tuple(size)
     if isinstance(size, int):
         return size,
-    raise ValueError('size should be None, collections.Sequence, or int')
+    raise ValueError('size should be None, collections.abc.Sequence, or int')
 
 
 @cython.profile(False)

--- a/cupy/linalg/product.py
+++ b/cupy/linalg/product.py
@@ -1,11 +1,10 @@
-import collections
-
 import numpy
 import six
 
 import cupy
 from cupy import core
 from cupy import internal
+from cupy.util import collections_abc
 
 
 matmul = core.matmul
@@ -161,7 +160,7 @@ def tensordot(a, b, axes=2):
             raise ValueError('An input is zero-dim while axes has dimensions')
         return cupy.multiply(a, b)
 
-    if isinstance(axes, collections.Sequence):
+    if isinstance(axes, collections_abc.Sequence):
         if len(axes) != 2:
             raise ValueError('Axes must consist of two arrays.')
         a_axes, b_axes = axes

--- a/cupy/util.pyx
+++ b/cupy/util.pyx
@@ -1,11 +1,20 @@
 # distutils: language = c++
 
 import atexit
+import collections
 import functools
 import warnings
 
 import cupy
 from cupy.cuda cimport device
+
+
+# TODO(kmaehashi) remove this when `six.moves.collections_abc` is implemented.
+# See: https://github.com/chainer/chainer/issues/5097
+try:
+    collections_abc = collections.abc
+except AttributeError:  # python <3.3
+    collections_abc = collections
 
 
 cdef list _memos = []


### PR DESCRIPTION
Backport of #1515