### PR TITLE
Improve readability of reduction kernel

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2120,7 +2120,7 @@ cdef _argmin = create_reduction_func(
      ('e->q', (None, 'my_argmin_float(a, b)', None, None)),
      ('f->q', (None, 'my_argmin_float(a, b)', None, None)),
      ('d->q', (None, 'my_argmin_float(a, b)', None, None))),
-    ('min_max_st<type_in0_raw>(in0, _J)', 'my_argmin(a, b)', 'out0 = a.index',
+    ('min_max_st<type_in0_raw>(in0, _i_reduce)', 'my_argmin(a, b)', 'out0 = a.index',
      'min_max_st<type_in0_raw>'),
     None, _min_max_preamble)
 
@@ -2132,7 +2132,7 @@ cdef _argmax = create_reduction_func(
      ('e->q', (None, 'my_argmax_float(a, b)', None, None)),
      ('f->q', (None, 'my_argmax_float(a, b)', None, None)),
      ('d->q', (None, 'my_argmax_float(a, b)', None, None))),
-    ('min_max_st<type_in0_raw>(in0, _J)', 'my_argmax(a, b)', 'out0 = a.index',
+    ('min_max_st<type_in0_raw>(in0, _i_reduce)', 'my_argmax(a, b)', 'out0 = a.index',
      'min_max_st<type_in0_raw>'),
     None, _min_max_preamble)
 

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2120,8 +2120,8 @@ cdef _argmin = create_reduction_func(
      ('e->q', (None, 'my_argmin_float(a, b)', None, None)),
      ('f->q', (None, 'my_argmin_float(a, b)', None, None)),
      ('d->q', (None, 'my_argmin_float(a, b)', None, None))),
-    ('min_max_st<type_in0_raw>(in0, _i_reduce)', 'my_argmin(a, b)', 'out0 = a.index',
-     'min_max_st<type_in0_raw>'),
+    ('min_max_st<type_in0_raw>(in0, _i_reduce)', 'my_argmin(a, b)',
+     'out0 = a.index', 'min_max_st<type_in0_raw>'),
     None, _min_max_preamble)
 
 
@@ -2132,8 +2132,8 @@ cdef _argmax = create_reduction_func(
      ('e->q', (None, 'my_argmax_float(a, b)', None, None)),
      ('f->q', (None, 'my_argmax_float(a, b)', None, None)),
      ('d->q', (None, 'my_argmax_float(a, b)', None, None))),
-    ('min_max_st<type_in0_raw>(in0, _i_reduce)', 'my_argmax(a, b)', 'out0 = a.index',
-     'min_max_st<type_in0_raw>'),
+    ('min_max_st<type_in0_raw>(in0, _i_reduce)', 'my_argmax(a, b)',
+     'out0 = a.index', 'min_max_st<type_in0_raw>'),
     None, _min_max_preamble)
 
 

--- a/cupy/core/reduction.pxi
+++ b/cupy/core/reduction.pxi
@@ -44,8 +44,10 @@ cpdef _get_simple_reduction_kernel(
            _i_out_base < _out_ind.size(); _i_out_base += _out_stride) {
         _type_reduce _s = _type_reduce(${identity});
         int _i_out = _i_out_base + _out_offset;
+        int _i_reduce = _reduce_block_offset;
         for (long long _i_in = _i_out + _reduce_offset;
-             _i_in < _in_ind.size(); _i_in += _reduce_stride) {
+             _i_in < _in_ind.size();
+             _i_in += _reduce_stride, _i_reduce += _reduce_block_size) {
           _in_ind.set(_i_in);
           ${input_expr}
           _type_reduce _a = static_cast<_type_reduce>(${pre_map_expr});

--- a/cupy/core/reduction.pxi
+++ b/cupy/core/reduction.pxi
@@ -36,13 +36,15 @@ cpdef _get_simple_reduction_kernel(
       int _reduce_block_size = ${block_size} / _out_block_size;
       long long _reduce_stride = (long long)_reduce_block_size * _out_ind.size();
 
+      int _out_offset = _tid % _out_block_size;
+      int _out_stride = gridDim.x * _out_block_size;
+
       for (int _i_out_base = blockIdx.x * _out_block_size;
-           _i_out_base < _out_ind.size();
-           _i_out_base += gridDim.x * _out_block_size) {
+           _i_out_base < _out_ind.size(); _i_out_base += _out_stride) {
         _type_reduce _s = _type_reduce(${identity});
-        int _i_out = _i_out_base + _tid % _out_block_size;
-        for (long long _i_in = _i_out + _reduce_offset; _i_in < _in_ind.size();
-             _i_in += _reduce_stride) {
+        int _i_out = _i_out_base + _out_offset;
+        for (long long _i_in = _i_out + _reduce_offset;
+             _i_in < _in_ind.size(); _i_in += _reduce_stride) {
           _in_ind.set(_i_in);
           ${input_expr}
           _type_reduce _a = static_cast<_type_reduce>(${pre_map_expr});

--- a/cupy/core/reduction.pxi
+++ b/cupy/core/reduction.pxi
@@ -34,7 +34,8 @@ cpdef _get_simple_reduction_kernel(
       int _reduce_block_offset = _tid / _out_block_size;
       int _reduce_offset = _reduce_block_offset * _out_ind.size();
       int _reduce_block_size = ${block_size} / _out_block_size;
-      long long _reduce_stride = (long long)_reduce_block_size * _out_ind.size();
+      long long _reduce_stride =
+        (long long)_reduce_block_size * _out_ind.size();
 
       int _out_offset = _tid % _out_block_size;
       int _out_stride = gridDim.x * _out_block_size;
@@ -136,7 +137,8 @@ cpdef tuple _get_out_shape(
     return tuple([shape[i] for i in out_axis])
 
 
-cpdef tuple _get_permuted_args(list args, tuple axis_permutes, tuple shape, tuple params):
+cpdef tuple _get_permuted_args(
+        list args, tuple axis_permutes, tuple shape, tuple params):
     cdef ParameterInfo p
     if axis_permutes == tuple(range(len(shape))):
         return args, shape
@@ -211,7 +213,8 @@ class simple_reduction_function(object):
                  bint keepdims=False):
         cdef list in_args, out_args
         cdef tuple in_sahpe, reduce_axis, out_axis
-        cdef Py_ssize_t block_size, reduce_block_size, out_block_size, out_block_num
+        cdef Py_ssize_t block_size, reduce_block_size, out_block_size
+        cdef Py_ssize_t out_block_num
         if dtype is not None:
             dtype = get_dtype(dtype).type
 
@@ -244,7 +247,8 @@ class simple_reduction_function(object):
         block_size = self._block_size
         in_indexer = Indexer(in_shape)
         out_indexer = Indexer(out_shape)
-        reduce_block_size = max(1, internal.clp2(in_indexer.size // out_indexer.size))
+        reduce_block_size = max(
+            1, internal.clp2(in_indexer.size // out_indexer.size))
         out_block_size = max(1, block_size // reduce_block_size)
 
         inout_args = _get_inout_args(
@@ -260,7 +264,8 @@ class simple_reduction_function(object):
 
         # TODO(okuta) set actual size
         shared_mem = 32 * block_size
-        out_block_num = (out_indexer.size + out_block_size - 1) // out_block_size
+        out_block_num = (
+            out_indexer.size + out_block_size - 1) // out_block_size
 
         kern.linear_launch(
             out_block_num * block_size,
@@ -373,7 +378,8 @@ class ReductionKernel(object):
             ``__init__`` method.
 
         """
-        cdef Py_ssize_t block_size, reduce_block_size, out_block_size, out_block_num
+        cdef Py_ssize_t block_size, reduce_block_size, out_block_size
+        cdef Py_ssize_t out_block_num
 
         out = kwargs.pop('out', None)
         axis = kwargs.pop('axis', None)
@@ -414,7 +420,8 @@ class ReductionKernel(object):
             in_ndarray_types, out_ndarray_types)
 
         reduce_axis, out_axis = _get_axis(axis, len(broad_shape))
-        out_shape = _get_out_shape(broad_shape, reduce_axis, out_axis, keepdims)
+        out_shape = _get_out_shape(
+            broad_shape, reduce_axis, out_axis, keepdims)
         out_args = _get_out_args_with_params(
             out_args, out_types, out_shape, self.out_params, False)
         ret = out_args[0]
@@ -430,7 +437,8 @@ class ReductionKernel(object):
         block_size = 512
         in_indexer = Indexer(in_shape)
         out_indexer = Indexer(out_shape)
-        reduce_block_size = max(1, internal.clp2(in_indexer.size // out_indexer.size))
+        reduce_block_size = max(
+            1, internal.clp2(in_indexer.size // out_indexer.size))
         out_block_size = max(1, block_size // reduce_block_size)
 
         inout_args = _get_inout_args(
@@ -446,7 +454,8 @@ class ReductionKernel(object):
 
         # TODO(okuta) set actual size
         shared_mem = 32 * block_size
-        out_block_num = (out_indexer.size + out_block_size - 1) // out_block_size
+        out_block_num = (
+            out_indexer.size + out_block_size - 1) // out_block_size
 
         kern.linear_launch(
             out_block_num * block_size,

--- a/cupy/core/reduction.pxi
+++ b/cupy/core/reduction.pxi
@@ -150,7 +150,7 @@ cpdef tuple _get_trans_args(list args, tuple trans, tuple shape, tuple params):
 
 cpdef list _get_inout_args(
         list in_args, list out_args, Indexer in_indexer, Indexer out_indexer,
-        Py_ssize_t out_clp2_size, tuple params, bint reduce_dims):
+        Py_ssize_t out_block_size, tuple params, bint reduce_dims):
     if reduce_dims:
         in_shape = _reduce_dims(in_args, params, in_indexer.shape)
         out_shape = _reduce_dims(
@@ -158,7 +158,7 @@ cpdef list _get_inout_args(
         in_indexer.shape = in_shape
         out_indexer.shape = out_shape
     cdef _scalar.CScalar s = _scalar.CScalar.__new__(_scalar.CScalar)
-    (<int32_t *>s.ptr)[0] = out_clp2_size
+    (<int32_t *>s.ptr)[0] = out_block_size
     s.kind = 'i'
     s.size = 4
     return in_args + out_args + [in_indexer, out_indexer, s]
@@ -208,7 +208,7 @@ class simple_reduction_function(object):
                  bint keepdims=False):
         cdef list in_args, out_args
         cdef tuple in_sahpe, laxis, raxis
-        cdef Py_ssize_t block_size, clp2_count, out_block_size
+        cdef Py_ssize_t block_size, reduce_block_size, out_block_size
         if dtype is not None:
             dtype = get_dtype(dtype).type
 
@@ -241,8 +241,8 @@ class simple_reduction_function(object):
         block_size = self._block_size
         in_indexer = Indexer(in_shape)
         out_indexer = Indexer(out_shape)
-        clp2_count = max(1, internal.clp2(in_indexer.size // out_indexer.size))
-        out_block_size = max(1, block_size // clp2_count)
+        reduce_block_size = max(1, internal.clp2(in_indexer.size // out_indexer.size))
+        out_block_size = max(1, block_size // reduce_block_size)
 
         inout_args = _get_inout_args(
             in_args, out_args, in_indexer, out_indexer, out_block_size,
@@ -370,7 +370,7 @@ class ReductionKernel(object):
             ``__init__`` method.
 
         """
-        cdef Py_ssize_t block_size, clp2_count, out_block_size
+        cdef Py_ssize_t block_size, reduce_block_size, out_block_size
 
         out = kwargs.pop('out', None)
         axis = kwargs.pop('axis', None)
@@ -427,8 +427,8 @@ class ReductionKernel(object):
         block_size = 512
         in_indexer = Indexer(in_shape)
         out_indexer = Indexer(out_shape)
-        clp2_count = max(1, internal.clp2(in_indexer.size // out_indexer.size))
-        out_block_size = max(1, block_size // clp2_count)
+        reduce_block_size = max(1, internal.clp2(in_indexer.size // out_indexer.size))
+        out_block_size = max(1, block_size // reduce_block_size)
 
         inout_args = _get_inout_args(
             in_args, out_args, in_indexer, out_indexer, out_block_size,

--- a/cupy/core/reduction.pxi
+++ b/cupy/core/reduction.pxi
@@ -209,7 +209,7 @@ class simple_reduction_function(object):
                  bint keepdims=False):
         cdef list in_args, out_args
         cdef tuple in_sahpe, laxis, raxis
-        cdef Py_ssize_t block_size, reduce_block_size, out_block_size
+        cdef Py_ssize_t block_size, reduce_block_size, out_block_size, out_block_num
         if dtype is not None:
             dtype = get_dtype(dtype).type
 
@@ -258,11 +258,11 @@ class simple_reduction_function(object):
 
         # TODO(okuta) set actual size
         shared_mem = 32 * block_size
+        out_block_num = (out_indexer.size + out_block_size - 1) // out_block_size
 
         kern.linear_launch(
-            (out_indexer.size + out_block_size - 1) // out_block_size * block_size,
+            out_block_num * block_size,
             inout_args, shared_mem, block_size)
-
         return ret
 
 
@@ -371,7 +371,7 @@ class ReductionKernel(object):
             ``__init__`` method.
 
         """
-        cdef Py_ssize_t block_size, reduce_block_size, out_block_size
+        cdef Py_ssize_t block_size, reduce_block_size, out_block_size, out_block_num
 
         out = kwargs.pop('out', None)
         axis = kwargs.pop('axis', None)
@@ -444,9 +444,10 @@ class ReductionKernel(object):
 
         # TODO(okuta) set actual size
         shared_mem = 32 * block_size
+        out_block_num = (out_indexer.size + out_block_size - 1) // out_block_size
 
         kern.linear_launch(
-            (out_indexer.size + out_block_size - 1) // out_block_size * block_size,
+            out_block_num * block_size,
             inout_args, shared_mem, block_size, stream)
         return ret
 


### PR DESCRIPTION
This PR only changes variable and function names to improve readability, and does not change any behaviors.

Concerns:  This requires JIT compilation again because texts of kernel codes are changed. Is it okay? (Personally thinking, I feel it is okay).

![image](https://user-images.githubusercontent.com/2290461/44244657-eed5d380-a20f-11e8-8f93-447705a90633.png)



Changes:

* J_offset => reduce_block_offset
* j_offset => reduce_offset
* J_stride => reduce_block_size
* j_stride => reduce_stride
* i => i_out
* j => i_in
* J => i_reduce
* block_stride => out_block_size
* out_clp2_size => out_block_size
* clp2_count => reduce_block_size
* get_trans_args => get_permuted_args
* laxis => reduce_axis
* raxis => out_axis
* out_offset  =_tid % _out_block_size
* out_stride = gridDim.x * _out_block_size
* out_block_ num = (out_indexer.size + out_block_size - 1) // out_block_size

