### PR TITLE
Update agnostic code tutorial

### DIFF
--- a/docs/source/tutorial/basic.rst
+++ b/docs/source/tutorial/basic.rst
@@ -186,3 +186,21 @@ A CPU/GPU generic function is defined using it like follows:
    >>> def softplus(x):
    ...     xp = cp.get_array_module(x)
    ...     return xp.maximum(0, x) + xp.log1p(xp.exp(-abs(x)))
+
+Sometimes, an explicit conversion to a host or device array may be required.
+:func:`cupy.asarray` and :func:`cupy.asnumpy` can be used in agnostic implementations
+to get host or device arrays from either CuPy or NumPy arrays.
+
+.. doctest::
+
+   >>> np.allclose(x_cpu, [1, 2, 3])
+   True
+   >>> np.allclose(x_gpu, [1, 2, 3])
+   Traceback (most recent call last):
+   ...
+   ValueError: object __array__ method not producing an array
+   >>> np.allclose(cp.asnumpy(x_cpu), [1, 2, 3])
+   True
+   >>> np.allclose(cp.asnumpy(x_gpu), [1, 2, 3])
+   True
+


### PR DESCRIPTION
Proposal: add a hint to the agnostic code tutorial that `cupy.asarray` and `cupy.asnumpy` can be used for explicit conversions from generic arrays.

Calling out to code that requires a NumPy array and that fails when given a CuPy array is, I think, a common operation, e.g. when plotting. I think it would be helpful to beginners to mention that `cupy.asarray` and `cupy.asnumpy` are agnostic functions, and to provide a best practice example. These functions are only used in their intended directions in the tutorial, at least to me it was not obvious that they are actually agnostic.

I put in an example that throws `ValueError: object __array__ method not producing an array` to have this example turn up in a page for someone who runs into this issue.