### PR TITLE
[backport] Add .pytest_cache/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,5 @@ dist/
 htmlcov/
 .idea/
 .cache/
+.pytest_cache/
 cupy/_lib/


### PR DESCRIPTION
Backport of #1526