### PR TITLE
Expose mem info

### DIFF
--- a/cupy/cuda/device.pyx
+++ b/cupy/cuda/device.pyx
@@ -212,6 +212,17 @@ cdef class Device:
             _cusparse_handles[self.id] = handle
             return handle
 
+    @property
+    def mem_info(self):
+        """The device memory info.
+
+        Returns:
+            free: The amount of free memory, in bytes.
+            total: The total amount of memory, in bytes.
+        """
+        with self:
+            return runtime.memGetInfo()
+
     def __richcmp__(Device self, Device other, int op):
         if op == 0:
             return self.id < other.id

--- a/tests/cupy_tests/cuda_tests/test_memory.py
+++ b/tests/cupy_tests/cuda_tests/test_memory.py
@@ -540,3 +540,15 @@ class TestAllocatorDefault(unittest.TestCase):
     def test_none(self):
         memory.set_allocator(None)
         self._check_pool_not_used()
+
+
+@testing.gpu
+class TestMemInfo(unittest.TestCase):
+
+    def test_mem_info(self):
+        d = cupy.cuda.Device()
+        mem_info = d.mem_info
+        assert isinstance(mem_info, tuple)
+        assert len(mem_info) == 2
+        assert all(isinstance(m, int) for m in mem_info)
+        assert all(m > 0 for m in mem_info)


### PR DESCRIPTION
I'm migrating from `PyCUDA` to `cupy` and I didn't (easily) find a public-facing equivalent in `cupy` of `PyCUDA` of `mem_get_info`, which simply calls `cuMemGetInfo` under the hood. I've added it as a `@property` of `Device`. For example on my system with two GPUs I get:
```
>>> cupy.cuda.Device(0).mem_info
(11900223488, 11996954624)
>>> cupy.cuda.Device(1).mem_info
(1545011200, 2087714816)
```
I added a test to `tests/cupy_testls/cuda_tests/test_memory.py`.

Now that I've completed this PR, I realize that I can just do:
```
with cupy.cuda.Device(0):
    cupy.cuda.runtime.memGetInfo()
```
... so I understand if this is not valuable enough to add. Let me know if these things should live somewhere else, or if I (and others) should just go with the `runtime` option.