### PR TITLE
Use xorshift128 to reduce global memory access

### DIFF
--- a/cupy/random/generator.py
+++ b/cupy/random/generator.py
@@ -323,7 +323,7 @@ class RandomState(object):
         curand.setPseudoRandomGeneratorSeed(self._generator, seed)
         curand.setGeneratorOffset(self._generator, 0)
 
-        self.rk_seed = numpy.uint32(seed)
+        self.rk_seed = numpy.uint64(seed)
 
     def standard_normal(self, size=None, dtype=float):
         """Returns samples drawn from the standard normal distribution.


### PR DESCRIPTION
[The test code](https://github.com/okuta/cupy-bench)

before
```
% python test_random.py
beta_cupy     , 32768, 2.584322, 0.115615
binomial_cupy , 32768, 0.494043, 0.117940
beta_numpy    , 32768, 8.867222, 8.865142
binomial_numpy, 32768, 2.167342, 2.165002
```

after
```
% python test_random.py
beta_cupy     , 32768, 0.190274, 0.114515
binomial_cupy , 32768, 0.129215, 0.115728
beta_numpy    , 32768, 7.926788, 7.924813
binomial_numpy, 32768, 1.830270, 1.828578
```
