### PR TITLE
Fix create_comparison

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -4085,8 +4085,8 @@ cpdef create_comparison(name, op, doc='', require_sortable_dtype=True):
                'll->?', 'LL->?', 'qq->?', 'QQ->?', 'ee->?', 'ff->?', 'dd->?')
     else:
         ops = ('??->?', 'bb->?', 'BB->?', 'hh->?', 'HH->?', 'ii->?', 'II->?',
-               'll->?', 'LL->?', 'qq->?', 'QQ->?', 'ee->?', 'ff->?', 'FF->?',
-               'dd->?', 'DD->?')
+               'll->?', 'LL->?', 'qq->?', 'QQ->?', 'ee->?', 'ff->?', 'dd->?',
+               'FF->?', 'DD->?')
     return create_ufunc(
         'cupy_' + name,
         ops,


### PR DESCRIPTION
NumPy dtype order
```
>>> numpy.equal.types
['??->?',
 'bb->?',
 'BB->?',
 'hh->?',
 'HH->?',
 'ii->?',
 'II->?',
 'll->?',
 'LL->?',
 'qq->?',
 'QQ->?',
 'ee->?',
 'ff->?',
 'dd->?',
 'gg->?',
 'FF->?',
 'DD->?',
 'GG->?',
 'OO->?',
 'MM->?',
 'mm->?',
 'OO->O']
```