### PR TITLE
Make ElementwiseKernel emit immutable in_params

### DIFF
--- a/cupy/core/elementwise.pxi
+++ b/cupy/core/elementwise.pxi
@@ -206,6 +206,8 @@ cdef class ParameterInfo:
         for i in s[:-2]:
             if i == 'raw':
                 self.raw = True
+            elif i == '_non_const':
+                self.is_const = False
             else:
                 raise Exception('Unknown keyword "%s"' % i)
 

--- a/cupy/core/elementwise.pxi
+++ b/cupy/core/elementwise.pxi
@@ -97,9 +97,11 @@ cpdef str _get_kernel_params(tuple params, tuple args_info):
             t = _get_typename(dtype)
             if is_array:
                 t = 'CArray<%s, %d>' % (t, ndim)
-        ret.append('%s %s%s' % (t,
-                                '_raw_' if is_array and not p.raw else '',
-                                p.name))
+        ret.append('{}{} {}{}'.format(
+            'const ' if p.is_const else '',
+            t,
+            '_raw_' if is_array and not p.raw else '',
+            p.name))
     return ', '.join(ret)
 
 
@@ -364,7 +366,7 @@ cdef function.Function _get_elementwise_kernel(
     for p, a in zip(params, args_info):
         if not p.raw and a[0] == ndarray:
             if p.is_const:
-                fmt = '{t} &{n} = _raw_{n}[_ind.get()];'
+                fmt = 'const {t} &{n} = _raw_{n}[_ind.get()];'
             else:
                 fmt = '{t} &{n} = _raw_{n}[_ind.get()];'
             op.append(fmt.format(t=p.ctype, n=p.name))

--- a/cupy/core/fusion.py
+++ b/cupy/core/fusion.py
@@ -672,7 +672,7 @@ class _FusionHistory(object):
         out_dtypes = [_.dtype for _ in out_pvars]
         out_params = [self._fresh_premap_param(t) for t in out_dtypes]
 
-        in_params_code = ', '.join(var.declaration_param()
+        in_params_code = ', '.join('_non_const ' + var.declaration_param()
                                    for var in in_params)
         out_params_code = ', '.join(var.declaration_param()
                                     for var in out_params)

--- a/cupy/core/reduction.pxi
+++ b/cupy/core/reduction.pxi
@@ -278,8 +278,8 @@ def _get_reduction_kernel(
         'typedef %s %s;' % (_get_typename(v), k)
         for k, v in types)
     input_expr = '\n'.join(
-        ['const {0} {1} = _raw_{1}[_j];'.format(p.ctype, p.name)
-         for p in arrays if p.is_const])
+        [(('const {0} {1}' if p.is_const else '{0}& {1}') +
+          ' = _raw_{1}[_j];').format(p.ctype, p.name) for p in arrays])
     output_expr = '\n'.join(
         ['{0} &{1} = _raw_{1}[_i];'.format(p.ctype, p.name)
          for p in arrays if not p.is_const])

--- a/cupy/random/generator.py
+++ b/cupy/random/generator.py
@@ -499,7 +499,7 @@ class RandomState(object):
                 block_size *= 2
             for j_start in range(0, num, block_size):
                 j_end = j_start + block_size
-                _cupy_permutation()(array, sample, j_start, j_end, size=num)
+                _cupy_permutation()(sample, j_start, j_end, array, size=num)
         else:
             # When num > 32M, argsort is used, because it is faster than
             # custom kernel. See https://github.com/cupy/cupy/pull/603.
@@ -561,8 +561,8 @@ class RandomState(object):
 
 def _cupy_permutation():
     return core.ElementwiseKernel(
-        'raw int32 array, raw int32 sample, int32 j_start, int32 _j_end',
-        '',
+        'raw int32 sample, int32 j_start, int32 _j_end',
+        'raw int32 array',
         '''
             const int invalid = -1;
             const int num = _ind.size();


### PR DESCRIPTION
Merge #1552 and chainer/chainer#5258 first.
ElementwiseKernel should cause CUDA compilation error when trying to mutate `in_params` in the `operation`.