### PR TITLE
Use bit operation when the divisor is a power of 2 on GPU

### DIFF
--- a/cupy/core/include/cupy/carray.cuh
+++ b/cupy/core/include/cupy/carray.cuh
@@ -283,16 +283,28 @@ public:
       size_t a = static_cast<size_t>(i);
       for (int dim = ndim; --dim > 0; ) {
         size_t s = static_cast<size_t>(shape_[dim]);
-        index_[dim] = a % s;
-        a /= s;
+        if (s & (s - 1)) {
+          size_t t = a / s;
+          index_[dim] = a - t * s;
+          a = t;
+        } else { // exp of 2
+          index_[dim] = a & (s - 1);
+          a >>= __popcll(s - 1);
+        }
       }
       index_[0] = a;
     } else {
       unsigned int a = static_cast<unsigned int>(i);
       for (int dim = ndim; --dim > 0; ) {
         unsigned int s = static_cast<unsigned int>(shape_[dim]);
-        index_[dim] = a % s;
-        a /= s;
+        if (s & (s - 1)) {
+          unsigned int t = a / s;
+          index_[dim] = a - t * s;
+          a = t;
+        } else { // exp of 2
+          index_[dim] = a & (s - 1);
+          a >>= __popc(s - 1);
+        }
       }
       index_[0] = a;
     }


### PR DESCRIPTION
`/' and `%` are very slow on GPU.
The new version uses bit operation when the divisor is a power of 2.
