### PR TITLE
Add erf, erfc, and erfcx to cupyx

### DIFF
--- a/cupyx/scipy/special/__init__.py
+++ b/cupyx/scipy/special/__init__.py
@@ -11,3 +11,7 @@ from cupyx.scipy.special.digamma import digamma  # NOQA
 from cupyx.scipy.special.gamma import gamma  # NOQA
 from cupyx.scipy.special.gammaln import gammaln  # NOQA
 from cupyx.scipy.special.zeta import zeta  # NOQA
+
+from cupyx.scipy.special.erf import erf  # NOQA
+from cupyx.scipy.special.erf import erfc  # NOQA
+from cupyx.scipy.special.erf import erfcx  # NOQA

--- a/cupyx/scipy/special/erf.py
+++ b/cupyx/scipy/special/erf.py
@@ -1,0 +1,37 @@
+import cupy.core.fusion
+from cupy.math import ufunc
+
+
+_erf = ufunc.create_math_ufunc(
+    'erf', 1, 'cupyx_scipy_erf',
+    '''Error function.
+
+    .. seealso:: :meth: scipy.special.erf
+
+    ''',
+    support_complex=False)
+
+
+_erfc = ufunc.create_math_ufunc(
+    'erfc', 1, 'cupyx_scipy_erfc',
+    '''Complementary error function.
+
+    .. seealso:: :meth: scipy.special.erfc
+
+    ''',
+    support_complex=False)
+
+
+_erfcx = ufunc.create_math_ufunc(
+    'erfcx', 1, 'cupyx_scipy_erfcx',
+    '''Scaled complementary error function.
+
+    .. seealso:: :meth: scipy.special.erfcx
+
+    ''',
+    support_complex=False)
+
+
+erf = cupy.core.fusion.ufunc(_erf)
+erfc = cupy.core.fusion.ufunc(_erfc)
+erfcx = cupy.core.fusion.ufunc(_erfcx)

--- a/cupyx/scipy/special/erf.py
+++ b/cupyx/scipy/special/erf.py
@@ -6,7 +6,7 @@ _erf = ufunc.create_math_ufunc(
     'erf', 1, 'cupyx_scipy_erf',
     '''Error function.
 
-    .. seealso:: :meth: scipy.special.erf
+    .. seealso:: :meth:`scipy.special.erf`
 
     ''',
     support_complex=False)
@@ -16,7 +16,7 @@ _erfc = ufunc.create_math_ufunc(
     'erfc', 1, 'cupyx_scipy_erfc',
     '''Complementary error function.
 
-    .. seealso:: :meth: scipy.special.erfc
+    .. seealso:: :meth:`scipy.special.erfc`
 
     ''',
     support_complex=False)
@@ -26,7 +26,7 @@ _erfcx = ufunc.create_math_ufunc(
     'erfcx', 1, 'cupyx_scipy_erfcx',
     '''Scaled complementary error function.
 
-    .. seealso:: :meth: scipy.special.erfcx
+    .. seealso:: :meth:`scipy.special.erfcx`
 
     ''',
     support_complex=False)

--- a/docs/source/reference/special.rst
+++ b/docs/source/reference/special.rst
@@ -29,6 +29,18 @@ Gamma and Related Functions
    cupyx.scipy.special.polygamma
 
 
+Error Function
+--------------
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+
+   cupyx.scipy.special.erf
+   cupyx.scipy.special.erfc
+   cupyx.scipy.special.erfcx
+
+
 Other Special Functions
 -----------------------
 

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_erf.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_erf.py
@@ -1,0 +1,48 @@
+import unittest
+
+import cupy
+from cupy import testing
+import cupyx.scipy.special  # NOQA
+
+
+class _TestBase(object):
+
+    def test_erf(self):
+        self.check_unary('erf')
+
+    def test_erfc(self):
+        self.check_unary('erfc')
+
+    def test_erfcx(self):
+        self.check_unary('erfcx')
+
+
+@testing.gpu
+@testing.with_requires('scipy')
+class TestSpecial(unittest.TestCase, _TestBase):
+
+    @testing.for_dtypes(['f', 'd'])
+    @testing.numpy_cupy_allclose(atol=1e-5, scipy_name='scp')
+    def check_unary(self, name, xp, scp, dtype):
+        import scipy.special  # NOQA
+
+        a = testing.shaped_arange((2, 3), xp, dtype)
+        return getattr(scp.special, name)(a)
+
+
+@testing.gpu
+@testing.with_requires('scipy')
+class TestFusionSpecial(unittest.TestCase, _TestBase):
+
+    @testing.for_dtypes(['f', 'd'])
+    @testing.numpy_cupy_allclose(atol=1e-5, scipy_name='scp')
+    def check_unary(self, name, xp, scp, dtype):
+        import scipy.special  # NOQA
+
+        a = testing.shaped_arange((2, 3), xp, dtype)
+
+        @cupy.fuse()
+        def f(x):
+            return getattr(scp.special, name)(x)
+
+        return f(a)


### PR DESCRIPTION
`erfinv` and `erfcinv` are not included because different behavior of SciPy and CUDA. They will be implemented later.