### PR TITLE
Support SciPy1.0+

### DIFF
--- a/cupy/testing/helper.py
+++ b/cupy/testing/helper.py
@@ -193,10 +193,16 @@ def numpy_cupy_allclose(rtol=1e-7, atol=0, err_msg='', verbose=True,
 
     .. seealso:: :func:`cupy.testing.assert_allclose`
     """
-    def check_func(cupy_result, numpy_result):
-        c = cupy_result
-        n = numpy_result
-        array.assert_allclose(c, n, rtol, atol, err_msg, verbose)
+    def check_func(c, n):
+        c_array = c
+        n_array = n
+        if sp_name is not None:
+            import scipy.sparse
+            if cupyx.scipy.sparse.issparse(c):
+                c_array = c.A
+            if scipy.sparse.issparse(n):
+                n_array = n.A
+        array.assert_allclose(c_array, n_array, rtol, atol, err_msg, verbose)
         if contiguous_check and isinstance(n, numpy.ndarray):
             if n.flags.c_contiguous and not c.flags.c_contiguous:
                 raise AssertionError(
@@ -358,6 +364,13 @@ def numpy_cupy_array_equal(err_msg='', verbose=True, name='xp',
     .. seealso:: :func:`cupy.testing.assert_array_equal`
     """
     def check_func(x, y):
+        if sp_name is not None:
+            import scipy.sparse
+            if cupyx.scipy.sparse.issparse(x):
+                x = x.A
+            if scipy.sparse.issparse(y):
+                y = y.A
+
         array.assert_array_equal(x, y, err_msg, verbose)
 
     return _make_decorator(check_func, name, type_check, accept_error, sp_name,

--- a/cupyx/scipy/sparse/compressed.py
+++ b/cupyx/scipy/sparse/compressed.py
@@ -269,13 +269,13 @@ class _compressed_sparse_matrix(sparse_data._data_matrix):
             major_start += major_size
         if major_stop < 0:
             major_stop += major_size
+        major_start = max(min(major_start, major_size), 0)
+        major_stop = max(min(major_stop, major_size), 0)
 
         if major_step != 1:
             raise ValueError('slicing with step != 1 not supported')
 
-        if not (0 <= major_start <= major_size and
-                0 <= major_stop <= major_size and
-                major_start <= major_stop):
+        if not (major_start <= major_stop):
             raise IndexError('index out of bounds')
 
         start = self.indptr[major_start]

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_construct.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_construct.py
@@ -25,7 +25,7 @@ class TestEye(unittest.TestCase):
             self.m, n=self.n, k=self.k, dtype=self.dtype, format=self.format)
         self.assertIsInstance(x, sp.spmatrix)
         self.assertEqual(x.format, self.format)
-        return x.toarray()
+        return x
 
 
 @testing.parameterize(*testing.product({
@@ -40,7 +40,7 @@ class TestIdentity(unittest.TestCase):
         x = sp.identity(3, dtype=self.dtype, format=self.format)
         self.assertIsInstance(x, sp.spmatrix)
         self.assertEqual(x.format, self.format)
-        return x.toarray()
+        return x
 
 
 @testing.parameterize(*testing.product({
@@ -54,7 +54,7 @@ class TestSpdiags(unittest.TestCase):
         data = xp.arange(12, dtype=self.dtype).reshape(3, 4)
         diags = xp.array([0, -1, 2], dtype='i')
         x = sp.spdiags(data, diags, 3, 4)
-        return x.toarray()
+        return x
 
 
 @testing.parameterize(*testing.product({

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_coo.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_coo.py
@@ -132,16 +132,15 @@ class TestCooMatrix(unittest.TestCase):
         self.assertEqual(n.shape, m.shape)
 
     @unittest.skipUnless(scipy_available, 'requires scipy')
-    def test_init_copy_other_scipy_sparse(self):
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_init_copy_other_scipy_sparse(self, xp, sp):
         m = _make(numpy, scipy.sparse, self.dtype)
-        n = sparse.coo_matrix(m.tocsc())
-        self.assertIsInstance(n.data, cupy.ndarray)
-        self.assertIsInstance(n.row, cupy.ndarray)
-        self.assertIsInstance(n.col, cupy.ndarray)
-        cupy.testing.assert_array_equal(n.data, m.data)
-        cupy.testing.assert_array_equal(n.row, m.row)
-        cupy.testing.assert_array_equal(n.col, m.col)
-        self.assertEqual(n.shape, m.shape)
+        n = sp.coo_matrix(m.tocsc())
+        assert len(n.data) == len(m.data)
+        assert len(n.row) == len(m.row)
+        assert len(n.col) == len(m.col)
+        assert n.shape == m.shape
+        return n
 
     def test_shape(self):
         self.assertEqual(self.m.shape, (3, 4))
@@ -360,7 +359,7 @@ class TestCooMatrixScipyComparison(unittest.TestCase):
     @testing.numpy_cupy_array_equal(sp_name='sp')
     def test_asfptype(self, xp, sp):
         m = _make(xp, sp, self.dtype)
-        return m.asfptype().toarray()
+        return m.asfptype()
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_toarray(self, xp, sp):
@@ -375,7 +374,7 @@ class TestCooMatrixScipyComparison(unittest.TestCase):
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_tocoo(self, xp, sp):
         m = _make(xp, sp, self.dtype)
-        return m.tocoo().toarray()
+        return m.tocoo()
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_tocoo_copy(self, xp, sp):
@@ -384,48 +383,48 @@ class TestCooMatrixScipyComparison(unittest.TestCase):
         self.assertIsNot(m.data, n.data)
         self.assertIsNot(m.row, n.row)
         self.assertIsNot(m.col, n.col)
-        return n.toarray()
+        return n
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_tocsc(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
-        return m.tocsc().toarray()
+        return m.tocsc()
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_tocsc_copy(self, xp, sp):
         m = _make(xp, sp, self.dtype)
         n = m.tocsc(copy=True)
         self.assertIsNot(m.data, n.data)
-        return n.toarray()
+        return n
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_tocsr(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
-        return m.tocsr().toarray()
+        return m.tocsr()
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_tocsr_copy(self, xp, sp):
         m = _make(xp, sp, self.dtype)
         n = m.tocsr(copy=True)
         self.assertIsNot(m.data, n.data)
-        return n.toarray()
+        return n
 
     # dot
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_dot_scalar(self, xp, sp):
         m = _make(xp, sp, self.dtype)
-        return m.dot(2.0).toarray()
+        return m.dot(2.0)
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_dot_numpy_scalar(self, xp, sp):
         m = _make(xp, sp, self.dtype)
-        return m.dot(numpy.dtype(self.dtype).type(2.0)).toarray()
+        return m.dot(numpy.dtype(self.dtype).type(2.0))
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_dot_csr(self, xp, sp):
         m = _make(xp, sp, self.dtype)
         x = _make3(xp, sp, self.dtype)
-        return m.dot(x).toarray()
+        return m.dot(x)
 
     @testing.numpy_cupy_raises(sp_name='sp', accept_error=ValueError)
     def test_dot_csr_invalid_shape(self, xp, sp):
@@ -437,19 +436,19 @@ class TestCooMatrixScipyComparison(unittest.TestCase):
     def test_dot_csc(self, xp, sp):
         m = _make(xp, sp, self.dtype)
         x = _make3(xp, sp, self.dtype).tocsc()
-        return m.dot(x).toarray()
+        return m.dot(x)
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_dot_sparse(self, xp, sp):
         m = _make(xp, sp, self.dtype)
         x = _make3(xp, sp, self.dtype).tocoo()
-        return m.dot(x).toarray()
+        return m.dot(x)
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_dot_zero_dim(self, xp, sp):
         m = _make(xp, sp, self.dtype)
         x = xp.array(2, dtype=self.dtype)
-        return m.dot(x).toarray()
+        return m.dot(x)
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_dot_dense_vector(self, xp, sp):
@@ -490,7 +489,7 @@ class TestCooMatrixScipyComparison(unittest.TestCase):
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_add_zero(self, xp, sp):
         m = _make(xp, sp, self.dtype)
-        return (m + 0).toarray()
+        return m + 0
 
     @testing.numpy_cupy_raises(sp_name='sp')
     def test_add_scalar(self, xp, sp):
@@ -501,13 +500,13 @@ class TestCooMatrixScipyComparison(unittest.TestCase):
     def test_add_csr(self, xp, sp):
         m = _make(xp, sp, self.dtype)
         n = _make2(xp, sp, self.dtype)
-        return (m + n).toarray()
+        return m + n
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_add_coo(self, xp, sp):
         m = _make(xp, sp, self.dtype)
         n = _make2(xp, sp, self.dtype).tocoo()
-        return (m + n).toarray()
+        return m + n
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_add_dense(self, xp, sp):
@@ -519,7 +518,7 @@ class TestCooMatrixScipyComparison(unittest.TestCase):
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_radd_zero(self, xp, sp):
         m = _make(xp, sp, self.dtype)
-        return (0 + m).toarray()
+        return 0 + m
 
     @testing.numpy_cupy_raises(sp_name='sp')
     def test_radd_scalar(self, xp, sp):
@@ -536,7 +535,7 @@ class TestCooMatrixScipyComparison(unittest.TestCase):
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_sub_zero(self, xp, sp):
         m = _make(xp, sp, self.dtype)
-        return (m - 0).toarray()
+        return m - 0
 
     @testing.numpy_cupy_raises(sp_name='sp')
     def test_sub_scalar(self, xp, sp):
@@ -547,13 +546,13 @@ class TestCooMatrixScipyComparison(unittest.TestCase):
     def test_sub_csr(self, xp, sp):
         m = _make(xp, sp, self.dtype)
         n = _make2(xp, sp, self.dtype)
-        return (m - n).toarray()
+        return m - n
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_sub_coo(self, xp, sp):
         m = _make(xp, sp, self.dtype)
         n = _make2(xp, sp, self.dtype).tocoo()
-        return (m - n).toarray()
+        return m - n
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_sub_dense(self, xp, sp):
@@ -565,7 +564,7 @@ class TestCooMatrixScipyComparison(unittest.TestCase):
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_rsub_zero(self, xp, sp):
         m = _make(xp, sp, self.dtype)
-        return (0 - m).toarray()
+        return 0 - m
 
     @testing.numpy_cupy_raises(sp_name='sp')
     def test_rsub_scalar(self, xp, sp):
@@ -582,18 +581,18 @@ class TestCooMatrixScipyComparison(unittest.TestCase):
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_mul_scalar(self, xp, sp):
         m = _make(xp, sp, self.dtype)
-        return (m * 2.0).toarray()
+        return m * 2.0
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_mul_numpy_scalar(self, xp, sp):
         m = _make(xp, sp, self.dtype)
-        return (m * numpy.dtype(self.dtype).type(2.0)).toarray()
+        return m * numpy.dtype(self.dtype).type(2.0)
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_mul_csr(self, xp, sp):
         m = _make(xp, sp, self.dtype)
         x = _make3(xp, sp, self.dtype)
-        return (m * x).toarray()
+        return m * x
 
     @testing.numpy_cupy_raises(sp_name='sp', accept_error=ValueError)
     def test_mul_csr_invalid_shape(self, xp, sp):
@@ -605,19 +604,19 @@ class TestCooMatrixScipyComparison(unittest.TestCase):
     def test_mul_csc(self, xp, sp):
         m = _make(xp, sp, self.dtype)
         x = _make3(xp, sp, self.dtype).tocsc()
-        return (m * x).toarray()
+        return m * x
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_mul_sparse(self, xp, sp):
         m = _make(xp, sp, self.dtype)
         x = _make3(xp, sp, self.dtype).tocoo()
-        return (m * x).toarray()
+        return m * x
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_mul_zero_dim(self, xp, sp):
         m = _make(xp, sp, self.dtype)
         x = xp.array(2, dtype=self.dtype)
-        return (m * x).toarray()
+        return m * x
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_mul_dense_vector(self, xp, sp):
@@ -635,7 +634,7 @@ class TestCooMatrixScipyComparison(unittest.TestCase):
     def test_mul_dense_matrix(self, xp, sp):
         m = _make(xp, sp, self.dtype)
         x = xp.arange(8).reshape(4, 2).astype(self.dtype)
-        return (m * x)
+        return m * x
 
     @testing.numpy_cupy_raises(sp_name='sp', accept_error=ValueError)
     def test_mul_dense_matrix_invalid_shape(self, xp, sp):
@@ -658,36 +657,36 @@ class TestCooMatrixScipyComparison(unittest.TestCase):
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_rmul_scalar(self, xp, sp):
         m = _make(xp, sp, self.dtype)
-        return (2.0 * m).toarray()
+        return 2.0 * m
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_rmul_numpy_scalar(self, xp, sp):
         m = _make(xp, sp, self.dtype)
-        return (numpy.dtype(self.dtype).type(2.0) * m).toarray()
+        return numpy.dtype(self.dtype).type(2.0) * m
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_rmul_csr(self, xp, sp):
         m = _make(xp, sp, self.dtype)
         x = _make3(xp, sp, self.dtype)
-        return (x * m).toarray()
+        return x * m
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_rmul_csc(self, xp, sp):
         m = _make(xp, sp, self.dtype)
         x = _make3(xp, sp, self.dtype).tocsc()
-        return (x * m).toarray()
+        return x * m
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_rmul_sparse(self, xp, sp):
         m = _make(xp, sp, self.dtype)
         x = _make3(xp, sp, self.dtype).tocoo()
-        return (x * m).toarray()
+        return x * m
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_rmul_zero_dim(self, xp, sp):
         m = _make(xp, sp, self.dtype)
         x = xp.array(2, dtype=self.dtype)
-        return (x * m).toarray()
+        return x * m
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_rmul_dense_matrix(self, xp, sp):
@@ -710,22 +709,22 @@ class TestCooMatrixScipyComparison(unittest.TestCase):
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_pow_0(self, xp, sp):
         m = _make_square(xp, sp, self.dtype)
-        return (m ** 0).toarray()
+        return m ** 0
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_pow_1(self, xp, sp):
         m = _make_square(xp, sp, self.dtype)
-        return (m ** 1).toarray()
+        return m ** 1
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_pow_2(self, xp, sp):
         m = _make_square(xp, sp, self.dtype)
-        return (m ** 2).toarray()
+        return m ** 2
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_pow_3(self, xp, sp):
         m = _make_square(xp, sp, self.dtype)
-        return (m ** 3).toarray()
+        return m ** 3
 
     @testing.numpy_cupy_raises(sp_name='sp', accept_error=ValueError)
     def test_pow_neg(self, xp, sp):
@@ -750,7 +749,7 @@ class TestCooMatrixScipyComparison(unittest.TestCase):
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_transpose(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
-        return m.transpose().toarray()
+        return m.transpose()
 
     @testing.numpy_cupy_raises(sp_name='sp', accept_error=ValueError)
     def test_transpose_axes_int(self, xp, sp):
@@ -810,7 +809,7 @@ class TestCooMatrixSumDuplicates(unittest.TestCase):
 
         m.sum_duplicates()
         self.assertTrue(m.has_canonical_format)
-        return m.toarray()
+        return m
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_sum_duplicates_canonical(self, xp, sp):
@@ -819,7 +818,7 @@ class TestCooMatrixSumDuplicates(unittest.TestCase):
         m.sum_duplicates()
         self.assertTrue(m.has_canonical_format)
         self.assertEqual(m.nnz, 4)
-        return m.toarray()
+        return m
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_sum_duplicates_empty(self, xp, sp):
@@ -828,7 +827,7 @@ class TestCooMatrixSumDuplicates(unittest.TestCase):
         m.sum_duplicates()
         self.assertTrue(m.has_canonical_format)
         self.assertEqual(m.nnz, 0)
-        return m.toarray()
+        return m
 
 
 @testing.parameterize(*testing.product({
@@ -854,7 +853,7 @@ class TestUfunc(unittest.TestCase):
                 func()
             return numpy.array(0)
         else:
-            return func().toarray()
+            return func()
 
 
 class TestIsspmatrixCoo(unittest.TestCase):

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
@@ -288,7 +288,7 @@ class TestCscMatrixInit(unittest.TestCase):
         self.assertEqual(s.shape, self.shape)
         self.assertEqual(s.dtype, 'd')
         self.assertEqual(s.size, 0)
-        return s.toarray()
+        return s
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_init_with_shape_and_dtype(self, xp, sp):
@@ -296,7 +296,7 @@ class TestCscMatrixInit(unittest.TestCase):
         self.assertEqual(s.shape, self.shape)
         self.assertEqual(s.dtype, self.dtype)
         self.assertEqual(s.size, 0)
-        return s.toarray()
+        return s
 
     @testing.numpy_cupy_raises(sp_name='sp')
     def test_shape_invalid(self, xp, sp):
@@ -376,13 +376,14 @@ class TestCscMatrixScipyComparison(unittest.TestCase):
     @testing.numpy_cupy_array_equal(sp_name='sp')
     def test_asfptype(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
-        return m.asfptype().toarray()
+        return m.asfptype()
 
-    @testing.numpy_cupy_allclose(sp_name='sp')
+    @testing.numpy_cupy_allclose(sp_name='sp', contiguous_check=False)
     def test_toarray(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
         a = m.toarray()
-        self.assertTrue(a.flags.c_contiguous)
+        if sp is sparse:
+            self.assertTrue(a.flags.c_contiguous)
         return a
 
     @testing.numpy_cupy_allclose(sp_name='sp')
@@ -404,7 +405,7 @@ class TestCscMatrixScipyComparison(unittest.TestCase):
         m = self.make(xp, sp, self.dtype)
         m.toarray(order='#')
 
-    @testing.numpy_cupy_allclose(sp_name='sp')
+    @testing.numpy_cupy_allclose(sp_name='sp', contiguous_check=False)
     def test_A(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
         return m.A
@@ -412,19 +413,19 @@ class TestCscMatrixScipyComparison(unittest.TestCase):
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_tocoo(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
-        return m.tocoo().toarray()
+        return m.tocoo()
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_tocoo_copy(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
         n = m.tocoo(copy=True)
         self.assertIsNot(m.data, n.data)
-        return n.toarray()
+        return n
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_tocsc(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
-        return m.tocsc().toarray()
+        return m.tocsc()
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_tocsc_copy(self, xp, sp):
@@ -433,12 +434,12 @@ class TestCscMatrixScipyComparison(unittest.TestCase):
         self.assertIsNot(m.data, n.data)
         self.assertIsNot(m.indices, n.indices)
         self.assertIsNot(m.indptr, n.indptr)
-        return n.toarray()
+        return n
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_tocsr(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
-        return m.tocsr().toarray()
+        return m.tocsr()
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_tocsr_copy(self, xp, sp):
@@ -447,24 +448,24 @@ class TestCscMatrixScipyComparison(unittest.TestCase):
         self.assertIsNot(m.data, n.data)
         self.assertIsNot(m.indices, n.indices)
         self.assertIsNot(m.indptr, n.indptr)
-        return n.toarray()
+        return n
 
     # dot
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_dot_scalar(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
-        return m.dot(2.0).toarray()
+        return m.dot(2.0)
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_dot_numpy_scalar(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
-        return m.dot(numpy.dtype(self.dtype).type(2.0)).toarray()
+        return m.dot(numpy.dtype(self.dtype).type(2.0))
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_dot_csr(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
         x = _make3(xp, sp, self.dtype)
-        return m.dot(x).toarray()
+        return m.dot(x)
 
     @testing.numpy_cupy_raises(sp_name='sp', accept_error=ValueError)
     def test_dot_csr_invalid_shape(self, xp, sp):
@@ -476,19 +477,19 @@ class TestCscMatrixScipyComparison(unittest.TestCase):
     def test_dot_csc(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
         x = _make3(xp, sp, self.dtype).tocsc()
-        return m.dot(x).toarray()
+        return m.dot(x)
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_dot_sparse(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
         x = _make3(xp, sp, self.dtype).tocoo()
-        return m.dot(x).toarray()
+        return m.dot(x)
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_dot_zero_dim(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
         x = xp.array(2, dtype=self.dtype)
-        return m.dot(x).toarray()
+        return m.dot(x)
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_dot_dense_vector(self, xp, sp):
@@ -529,7 +530,7 @@ class TestCscMatrixScipyComparison(unittest.TestCase):
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_add_zero(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
-        return (m + 0).toarray()
+        return m + 0
 
     @testing.numpy_cupy_raises(sp_name='sp')
     def test_add_scalar(self, xp, sp):
@@ -540,15 +541,15 @@ class TestCscMatrixScipyComparison(unittest.TestCase):
     def test_add_csr(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
         n = _make2(xp, sp, self.dtype)
-        return (m + n).toarray()
+        return m + n
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_add_coo(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
         n = _make2(xp, sp, self.dtype).tocoo()
-        return (m + n).toarray()
+        return m + n
 
-    @testing.numpy_cupy_allclose(sp_name='sp')
+    @testing.numpy_cupy_allclose(sp_name='sp', contiguous_check=False)
     def test_add_dense(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
         n = xp.arange(12).reshape(3, 4)
@@ -558,14 +559,14 @@ class TestCscMatrixScipyComparison(unittest.TestCase):
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_radd_zero(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
-        return (0 + m).toarray()
+        return 0 + m
 
     @testing.numpy_cupy_raises(sp_name='sp')
     def test_radd_scalar(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
         1 + m
 
-    @testing.numpy_cupy_allclose(sp_name='sp')
+    @testing.numpy_cupy_allclose(sp_name='sp', contiguous_check=False)
     def test_radd_dense(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
         n = xp.arange(12).reshape(3, 4)
@@ -575,7 +576,7 @@ class TestCscMatrixScipyComparison(unittest.TestCase):
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_sub_zero(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
-        return (m - 0).toarray()
+        return m - 0
 
     @testing.numpy_cupy_raises(sp_name='sp')
     def test_sub_scalar(self, xp, sp):
@@ -586,13 +587,13 @@ class TestCscMatrixScipyComparison(unittest.TestCase):
     def test_sub_csr(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
         n = _make2(xp, sp, self.dtype)
-        return (m - n).toarray()
+        return m - n
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_sub_coo(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
         n = _make2(xp, sp, self.dtype).tocoo()
-        return (m - n).toarray()
+        return m - n
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_sub_dense(self, xp, sp):
@@ -604,7 +605,7 @@ class TestCscMatrixScipyComparison(unittest.TestCase):
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_rsub_zero(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
-        return (0 - m).toarray()
+        return 0 - m
 
     @testing.numpy_cupy_raises(sp_name='sp')
     def test_rsub_scalar(self, xp, sp):
@@ -621,36 +622,36 @@ class TestCscMatrixScipyComparison(unittest.TestCase):
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_mul_scalar(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
-        return (m * 2.0).toarray()
+        return m * 2.0
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_mul_numpy_scalar(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
-        return (m * numpy.dtype(self.dtype).type(2.0)).toarray()
+        return m * numpy.dtype(self.dtype).type(2.0)
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_mul_csr(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
         x = _make3(xp, sp, self.dtype)
-        return (m * x).toarray()
+        return m * x
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_mul_csc(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
         x = _make3(xp, sp, self.dtype).tocsc()
-        return (m * x).toarray()
+        return m * x
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_mul_sparse(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
         x = _make3(xp, sp, self.dtype).tocoo()
-        return (m * x).toarray()
+        return m * x
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_mul_zero_dim(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
         x = xp.array(2, dtype=self.dtype)
-        return (m * x).toarray()
+        return m * x
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_mul_dense_vector(self, xp, sp):
@@ -679,36 +680,36 @@ class TestCscMatrixScipyComparison(unittest.TestCase):
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_rmul_scalar(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
-        return (2.0 * m).toarray()
+        return 2.0 * m
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_rmul_numpy_scalar(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
-        return (numpy.dtype(self.dtype).type(2.0) * m).toarray()
+        return numpy.dtype(self.dtype).type(2.0) * m
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_rmul_csr(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
         x = _make3(xp, sp, self.dtype)
-        return (x * m).toarray()
+        return x * m
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_rmul_csc(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
         x = _make3(xp, sp, self.dtype).tocsc()
-        return (x * m).toarray()
+        return x * m
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_rmul_sparse(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
         x = _make3(xp, sp, self.dtype).tocoo()
-        return (x * m).toarray()
+        return x * m
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_rmul_zero_dim(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
         x = xp.array(2, dtype=self.dtype)
-        return (x * m).toarray()
+        return x * m
 
     @testing.numpy_cupy_allclose(sp_name='sp', contiguous_check=False)
     def test_rmul_dense_matrix(self, xp, sp):
@@ -735,7 +736,7 @@ class TestCscMatrixScipyComparison(unittest.TestCase):
     def test_sort_indices(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
         m.sort_indices()
-        return m.toarray()
+        return m
 
     @testing.numpy_cupy_raises(sp_name='sp')
     def test_sum_tuple_axis(self, xp, sp):
@@ -752,12 +753,12 @@ class TestCscMatrixScipyComparison(unittest.TestCase):
         m = self.make(xp, sp, self.dtype)
         m.sum_duplicates()
         self.assertTrue(m.has_canonical_format)
-        return m.toarray()
+        return m
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_transpose(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
-        return m.transpose().toarray()
+        return m.transpose()
 
     @testing.numpy_cupy_raises(sp_name='sp', accept_error=ValueError)
     def test_transpose_axes_int(self, xp, sp):
@@ -768,7 +769,7 @@ class TestCscMatrixScipyComparison(unittest.TestCase):
     def test_eliminate_zeros(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
         m.eliminate_zeros()
-        return m.toarray()
+        return m
 
     @testing.numpy_cupy_equal(sp_name='sp')
     @unittest.skipIf(
@@ -838,12 +839,12 @@ class TestCscMatrixData(unittest.TestCase):
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_abs(self, xp, sp):
         m = _make(xp, sp, self.dtype)
-        return abs(m).toarray()
+        return abs(m)
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_neg(self, xp, sp):
         m = _make(xp, sp, self.dtype)
-        return (-m).toarray()
+        return (-m)
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_astype(self, xp, sp):
@@ -852,7 +853,7 @@ class TestCscMatrixData(unittest.TestCase):
             t = 'D'
         else:
             t = 'd'
-        return m.astype(t).toarray()
+        return m.astype(t)
 
     @testing.numpy_cupy_equal(sp_name='sp')
     def test_count_nonzero(self, xp, sp):
@@ -862,7 +863,7 @@ class TestCscMatrixData(unittest.TestCase):
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_power(self, xp, sp):
         m = _make(xp, sp, self.dtype)
-        return m.power(2).toarray()
+        return m.power(2)
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_power_with_dtype(self, xp, sp):
@@ -871,7 +872,7 @@ class TestCscMatrixData(unittest.TestCase):
             t = 'D'
         else:
             t = 'd'
-        return m.power(2, t).toarray()
+        return m.power(2, t)
 
 
 @testing.parameterize(*testing.product({
@@ -897,7 +898,7 @@ class TestUfunc(unittest.TestCase):
                 func()
             return numpy.array(0)
         else:
-            return func().toarray()
+            return func()
 
 
 class TestIsspmatrixCsc(unittest.TestCase):
@@ -955,11 +956,11 @@ class TestCsrMatrixGetitem(unittest.TestCase):
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_getitem_int(self, xp, sp):
-        return _make(xp, sp, self.dtype)[:, 1].toarray()
+        return _make(xp, sp, self.dtype)[:, 1]
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_getitem_negative_int(self, xp, sp):
-        return _make(xp, sp, self.dtype)[:, -1].toarray()
+        return _make(xp, sp, self.dtype)[:, -1]
 
     @testing.numpy_cupy_raises(sp_name='sp', accept_error=IndexError)
     def test_getitem_int_too_small(self, xp, sp):
@@ -971,27 +972,11 @@ class TestCsrMatrixGetitem(unittest.TestCase):
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_getitem_slice(self, xp, sp):
-        return _make(xp, sp, self.dtype)[:, 1:3].toarray()
+        return _make(xp, sp, self.dtype)[:, 1:3]
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_getitem_slice_negative(self, xp, sp):
-        return _make(xp, sp, self.dtype)[:, -2:-1].toarray()
-
-    @testing.numpy_cupy_raises(sp_name='sp', accept_error=IndexError)
-    def test_getitem_slice_start_too_small(self, xp, sp):
-        _make(xp, sp, self.dtype)[:, -5:None]
-
-    @testing.numpy_cupy_raises(sp_name='sp', accept_error=IndexError)
-    def test_getitem_slice_start_too_large(self, xp, sp):
-        _make(xp, sp, self.dtype)[:, 5:None]
-
-    @testing.numpy_cupy_raises(sp_name='sp', accept_error=IndexError)
-    def test_getitem_slice_stop_too_small(self, xp, sp):
-        _make(xp, sp, self.dtype)[:, None:-5]
-
-    @testing.numpy_cupy_raises(sp_name='sp', accept_error=IndexError)
-    def test_getitem_slice_stop_too_large(self, xp, sp):
-        _make(xp, sp, self.dtype)[:, None:5]
+        return _make(xp, sp, self.dtype)[:, -2:-1]
 
     @testing.numpy_cupy_raises(sp_name='sp', accept_error=IndexError)
     def test_getitem_slice_start_larger_than_stop(self, xp, sp):
@@ -1000,3 +985,26 @@ class TestCsrMatrixGetitem(unittest.TestCase):
     def test_getitem_slice_step_2(self):
         with self.assertRaises(ValueError):
             _make(cupy, sparse, self.dtype)[:, 0::2]
+
+
+@testing.parameterize(*testing.product({
+    'dtype': [numpy.float32, numpy.float64, numpy.complex64, numpy.complex128],
+}))
+@testing.with_requires('scipy>=1.0')
+class TestCsrMatrixGetitem2(unittest.TestCase):
+
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_getitem_slice_start_too_small(self, xp, sp):
+        return _make(xp, sp, self.dtype)[:, -5:None]
+
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_getitem_slice_start_too_large(self, xp, sp):
+        return _make(xp, sp, self.dtype)[:, 5:None]
+
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_getitem_slice_stop_too_small(self, xp, sp):
+        return _make(xp, sp, self.dtype)[:, None:-5]
+
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_getitem_slice_stop_too_large(self, xp, sp):
+        return _make(xp, sp, self.dtype)[:, None:5]

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -302,7 +302,7 @@ class TestCsrMatrixInit(unittest.TestCase):
         self.assertEqual(s.shape, self.shape)
         self.assertEqual(s.dtype, 'd')
         self.assertEqual(s.size, 0)
-        return s.toarray()
+        return s
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_init_with_shape_and_dtype(self, xp, sp):
@@ -310,7 +310,7 @@ class TestCsrMatrixInit(unittest.TestCase):
         self.assertEqual(s.shape, self.shape)
         self.assertEqual(s.dtype, self.dtype)
         self.assertEqual(s.size, 0)
-        return s.toarray()
+        return s
 
     @testing.numpy_cupy_raises(sp_name='sp')
     def test_shape_invalid(self, xp, sp):
@@ -436,19 +436,19 @@ class TestCsrMatrixScipyComparison(unittest.TestCase):
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_tocoo(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
-        return m.tocoo().toarray()
+        return m.tocoo()
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_tocoo_copy(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
         n = m.tocoo(copy=True)
         self.assertIsNot(m.data, n.data)
-        return n.toarray()
+        return n
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_tocsc(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
-        return m.tocsc().toarray()
+        return m.tocsc()
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_tocsc_copy(self, xp, sp):
@@ -457,12 +457,12 @@ class TestCsrMatrixScipyComparison(unittest.TestCase):
         self.assertIsNot(m.data, n.data)
         self.assertIsNot(m.indices, n.indices)
         self.assertIsNot(m.indptr, n.indptr)
-        return n.toarray()
+        return n
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_tocsr(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
-        return m.tocsr().toarray()
+        return m.tocsr()
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_tocsr_copy(self, xp, sp):
@@ -471,13 +471,13 @@ class TestCsrMatrixScipyComparison(unittest.TestCase):
         self.assertIsNot(m.data, n.data)
         self.assertIsNot(m.indices, n.indices)
         self.assertIsNot(m.indptr, n.indptr)
-        return n.toarray()
+        return n
 
     # dot
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_dot_scalar(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
-        return m.dot(2.0).toarray()
+        return m.dot(2.0)
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_dot_numpy_scalar(self, xp, sp):
@@ -488,7 +488,7 @@ class TestCsrMatrixScipyComparison(unittest.TestCase):
     def test_dot_csr(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
         x = _make3(xp, sp, self.dtype)
-        return m.dot(x).toarray()
+        return m.dot(x)
 
     @testing.numpy_cupy_raises(sp_name='sp', accept_error=ValueError)
     def test_dot_csr_invalid_shape(self, xp, sp):
@@ -500,19 +500,19 @@ class TestCsrMatrixScipyComparison(unittest.TestCase):
     def test_dot_csc(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
         x = _make3(xp, sp, self.dtype).tocsc()
-        return m.dot(x).toarray()
+        return m.dot(x)
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_dot_sparse(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
         x = _make3(xp, sp, self.dtype).tocoo()
-        return m.dot(x).toarray()
+        return m.dot(x)
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_dot_zero_dim(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
         x = xp.array(2, dtype=self.dtype)
-        return m.dot(x).toarray()
+        return m.dot(x)
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_dot_dense_vector(self, xp, sp):
@@ -553,7 +553,7 @@ class TestCsrMatrixScipyComparison(unittest.TestCase):
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_add_zero(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
-        return (m + 0).toarray()
+        return m + 0
 
     @testing.numpy_cupy_raises(sp_name='sp')
     def test_add_scalar(self, xp, sp):
@@ -564,13 +564,13 @@ class TestCsrMatrixScipyComparison(unittest.TestCase):
     def test_add_csr(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
         n = _make2(xp, sp, self.dtype)
-        return (m + n).toarray()
+        return m + n
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_add_coo(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
         n = _make2(xp, sp, self.dtype).tocoo()
-        return (m + n).toarray()
+        return m + n
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_add_dense(self, xp, sp):
@@ -616,7 +616,7 @@ class TestCsrMatrixScipyComparison(unittest.TestCase):
     def test_sub_coo(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
         n = _make2(xp, sp, self.dtype).tocoo()
-        return (m - n).toarray()
+        return m - n
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_sub_dense(self, xp, sp):
@@ -628,7 +628,7 @@ class TestCsrMatrixScipyComparison(unittest.TestCase):
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_rsub_zero(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
-        return (0 - m).toarray()
+        return 0 - m
 
     @testing.numpy_cupy_raises(sp_name='sp')
     def test_rsub_scalar(self, xp, sp):
@@ -645,18 +645,18 @@ class TestCsrMatrixScipyComparison(unittest.TestCase):
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_mul_scalar(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
-        return (m * 2.0).toarray()
+        return m * 2.0
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_mul_numpy_scalar(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
-        return (m * numpy.dtype(self.dtype).type(2.0)).toarray()
+        return m * numpy.dtype(self.dtype).type(2.0)
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_mul_csr(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
         x = _make3(xp, sp, self.dtype)
-        return (m * x).toarray()
+        return m * x
 
     @testing.numpy_cupy_raises(sp_name='sp', accept_error=ValueError)
     def test_mul_csr_invalid_shape(self, xp, sp):
@@ -668,19 +668,19 @@ class TestCsrMatrixScipyComparison(unittest.TestCase):
     def test_mul_csc(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
         x = _make3(xp, sp, self.dtype).tocsc()
-        return (m * x).toarray()
+        return m * x
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_mul_sparse(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
         x = _make3(xp, sp, self.dtype).tocoo()
-        return (m * x).toarray()
+        return m * x
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_mul_zero_dim(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
         x = xp.array(2, dtype=self.dtype)
-        return (m * x).toarray()
+        return m * x
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_mul_dense_vector(self, xp, sp):
@@ -698,7 +698,7 @@ class TestCsrMatrixScipyComparison(unittest.TestCase):
     def test_mul_dense_matrix(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
         x = xp.arange(8).reshape(4, 2).astype(self.dtype)
-        return (m * x)
+        return m * x
 
     @testing.numpy_cupy_raises(sp_name='sp', accept_error=ValueError)
     def test_mul_dense_matrix_invalid_shape(self, xp, sp):
@@ -721,36 +721,36 @@ class TestCsrMatrixScipyComparison(unittest.TestCase):
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_rmul_scalar(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
-        return (2.0 * m).toarray()
+        return 2.0 * m
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_rmul_numpy_scalar(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
-        return (numpy.dtype(self.dtype).type(2.0) * m).toarray()
+        return numpy.dtype(self.dtype).type(2.0) * m
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_rmul_csr(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
         x = _make3(xp, sp, self.dtype)
-        return (x * m).toarray()
+        return x * m
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_rmul_csc(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
         x = _make3(xp, sp, self.dtype).tocsc()
-        return (x * m).toarray()
+        return x * m
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_rmul_sparse(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
         x = _make3(xp, sp, self.dtype).tocoo()
-        return (x * m).toarray()
+        return x * m
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_rmul_zero_dim(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
         x = xp.array(2, dtype=self.dtype)
-        return (x * m).toarray()
+        return x * m
 
     @testing.numpy_cupy_allclose(sp_name='sp', contiguous_check=False)
     def test_rmul_dense_matrix(self, xp, sp):
@@ -777,7 +777,7 @@ class TestCsrMatrixScipyComparison(unittest.TestCase):
     def test_sort_indices(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
         m.sort_indices()
-        return m.toarray()
+        return m
 
     @testing.numpy_cupy_raises(sp_name='sp')
     def test_sum_tuple_axis(self, xp, sp):
@@ -799,12 +799,12 @@ class TestCsrMatrixScipyComparison(unittest.TestCase):
         m = self.make(xp, sp, self.dtype)
         m.sum_duplicates()
         self.assertTrue(m.has_canonical_format)
-        return m.toarray()
+        return m
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_transpose(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
-        return m.transpose().toarray()
+        return m.transpose()
 
     @testing.numpy_cupy_raises(sp_name='sp', accept_error=ValueError)
     def test_transpose_axes_int(self, xp, sp):
@@ -815,7 +815,7 @@ class TestCsrMatrixScipyComparison(unittest.TestCase):
     def test_eliminate_zeros(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
         m.eliminate_zeros()
-        return m.toarray()
+        return m
 
     @testing.numpy_cupy_equal(sp_name='sp')
     @unittest.skipIf(
@@ -836,22 +836,23 @@ class TestCsrMatrixPowScipyComparison(unittest.TestCase):
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_pow_0(self, xp, sp):
         m = _make_square(xp, sp, self.dtype)
-        return (m ** 0).toarray()
+        return m ** 0
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_pow_1(self, xp, sp):
         m = _make_square(xp, sp, self.dtype)
-        return (m ** 1).toarray()
+        return m ** 1
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_pow_2(self, xp, sp):
         m = _make_square(xp, sp, self.dtype)
-        return (m ** 2).toarray()
+        return m ** 2
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_pow_3(self, xp, sp):
         m = _make_square(xp, sp, self.dtype)
-        return (m ** 3).toarray()
+        return m ** 3
+        return m ** 3
 
     @testing.numpy_cupy_raises(sp_name='sp', accept_error=ValueError)
     def test_pow_neg(self, xp, sp):
@@ -932,12 +933,12 @@ class TestCsrMatrixData(unittest.TestCase):
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_abs(self, xp, sp):
         m = _make(xp, sp, self.dtype)
-        return abs(m).toarray()
+        return abs(m)
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_neg(self, xp, sp):
         m = _make(xp, sp, self.dtype)
-        return (-m).toarray()
+        return -m
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_astype(self, xp, sp):
@@ -946,7 +947,7 @@ class TestCsrMatrixData(unittest.TestCase):
             t = 'D'
         else:
             t = 'd'
-        return m.astype(t).toarray()
+        return m.astype(t)
 
     @testing.numpy_cupy_equal(sp_name='sp')
     def test_count_nonzero(self, xp, sp):
@@ -956,7 +957,7 @@ class TestCsrMatrixData(unittest.TestCase):
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_power(self, xp, sp):
         m = _make(xp, sp, self.dtype)
-        return m.power(2).toarray()
+        return m.power(2)
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_power_with_dtype(self, xp, sp):
@@ -965,7 +966,7 @@ class TestCsrMatrixData(unittest.TestCase):
             t = 'D'
         else:
             t = 'd'
-        return m.power(2, t).toarray()
+        return m.power(2, t)
 
 
 @testing.parameterize(*testing.product({
@@ -991,7 +992,7 @@ class TestUfunc(unittest.TestCase):
                 func()
             return numpy.array(0)
         else:
-            return func().toarray()
+            return func()
 
 
 class TestIsspmatrixCsr(unittest.TestCase):
@@ -1049,11 +1050,11 @@ class TestCsrMatrixGetitem(unittest.TestCase):
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_getitem_int(self, xp, sp):
-        return _make(xp, sp, self.dtype)[1].toarray()
+        return _make(xp, sp, self.dtype)[1]
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_getitem_int_negative(self, xp, sp):
-        return _make(xp, sp, self.dtype)[-1].toarray()
+        return _make(xp, sp, self.dtype)[-1]
 
     @testing.numpy_cupy_raises(sp_name='sp', accept_error=IndexError)
     def test_getitem_int_to_small(self, xp, sp):
@@ -1065,11 +1066,11 @@ class TestCsrMatrixGetitem(unittest.TestCase):
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_getitem_int_none_slice(self, xp, sp):
-        return _make(xp, sp, self.dtype)[1, :].toarray()
+        return _make(xp, sp, self.dtype)[1, :]
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_getitem_negative_int_none_slice(self, xp, sp):
-        return _make(xp, sp, self.dtype)[-1, :].toarray()
+        return _make(xp, sp, self.dtype)[-1, :]
 
     @testing.numpy_cupy_raises(sp_name='sp', accept_error=IndexError)
     def test_getitem_int_too_small_none_slice(self, xp, sp):
@@ -1081,27 +1082,11 @@ class TestCsrMatrixGetitem(unittest.TestCase):
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_getitem_slice(self, xp, sp):
-        return _make(xp, sp, self.dtype)[1:3].toarray()
+        return _make(xp, sp, self.dtype)[1:3]
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_getitem_slice_negative(self, xp, sp):
-        return _make(xp, sp, self.dtype)[-2:-1].toarray()
-
-    @testing.numpy_cupy_raises(sp_name='sp', accept_error=IndexError)
-    def test_getitem_slice_start_too_small(self, xp, sp):
-        _make(xp, sp, self.dtype)[-4:None]
-
-    @testing.numpy_cupy_raises(sp_name='sp', accept_error=IndexError)
-    def test_getitem_slice_start_too_large(self, xp, sp):
-        _make(xp, sp, self.dtype)[4:None]
-
-    @testing.numpy_cupy_raises(sp_name='sp', accept_error=IndexError)
-    def test_getitem_slice_stop_too_small(self, xp, sp):
-        _make(xp, sp, self.dtype)[None:-4]
-
-    @testing.numpy_cupy_raises(sp_name='sp', accept_error=IndexError)
-    def test_getitem_slice_stop_too_large(self, xp, sp):
-        _make(xp, sp, self.dtype)[None:4]
+        return _make(xp, sp, self.dtype)[-2:-1]
 
     @testing.numpy_cupy_raises(sp_name='sp', accept_error=IndexError)
     def test_getitem_slice_start_larger_than_stop(self, xp, sp):
@@ -1113,8 +1098,31 @@ class TestCsrMatrixGetitem(unittest.TestCase):
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_getitem_ellipsis(self, xp, sp):
-        return _make(xp, sp, self.dtype)[...].toarray()
+        return _make(xp, sp, self.dtype)[...]
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_getitem_int_ellipsis(self, xp, sp):
-        return _make(xp, sp, self.dtype)[1, ...].toarray()
+        return _make(xp, sp, self.dtype)[1, ...]
+
+
+@testing.parameterize(*testing.product({
+    'dtype': [numpy.float32, numpy.float64, cupy.complex64, cupy.complex128],
+}))
+@testing.with_requires('scipy>=1.0')
+class TestCsrMatrixGetitem2(unittest.TestCase):
+
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_getitem_slice_start_too_small(self, xp, sp):
+        return _make(xp, sp, self.dtype)[-4:None]
+
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_getitem_slice_start_too_large(self, xp, sp):
+        return _make(xp, sp, self.dtype)[4:None]
+
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_getitem_slice_stop_too_small(self, xp, sp):
+        return _make(xp, sp, self.dtype)[None:-4]
+
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_getitem_slice_stop_too_large(self, xp, sp):
+        return _make(xp, sp, self.dtype)[None:4]

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_dia.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_dia.py
@@ -175,43 +175,43 @@ class TestDiaMatrixScipyComparison(unittest.TestCase):
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_tocoo(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
-        return m.tocoo().toarray()
+        return m.tocoo()
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_tocoo_copy(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
         n = m.tocoo(copy=True)
         self.assertIsNot(m.data, n.data)
-        return n.toarray()
+        return n
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_tocsc(self, xp, sp):
         m = _make(xp, sp, self.dtype)
-        return m.tocsc().toarray()
+        return m.tocsc()
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_tocsc_copy(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
         n = m.tocsc(copy=True)
         self.assertIsNot(m.data, n.data)
-        return n.toarray()
+        return n
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_tocsr(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
-        return m.tocsr().toarray()
+        return m.tocsr()
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_tocsr_copy(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
         n = m.tocsr(copy=True)
         self.assertIsNot(m.data, n.data)
-        return n.toarray()
+        return n
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_transpose(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
-        return m.transpose().toarray()
+        return m.transpose()
 
 
 @testing.parameterize(*testing.product({


### PR DESCRIPTION
This PR supports old and new SciPy. Fix #680 .
- Accept sparse matrix in `numpy_cupy_allclose` and `numpy_cupy_array_equal`.
- Relax slicing restrictions
- Fix test to use new style test functions