### PR TITLE
Fix result dtypes of special functions

### DIFF
--- a/cupyx/scipy/special/bessel.py
+++ b/cupyx/scipy/special/bessel.py
@@ -1,65 +1,65 @@
+from cupy import core
 import cupy.core.fusion
-from cupy.math import ufunc
 
 
-_j0 = ufunc.create_math_ufunc(
-    'j0', 1, 'cupyx_scipy_j0',
-    '''Bessel function of the first kind of order 0.
+_j0 = core.create_ufunc(
+    'cupyx_scipy_j0', ('f->f', 'd->d'),
+    'out0 = j0(in0)',
+    doc='''Bessel function of the first kind of order 0.
 
     .. seealso:: :meth:`scipy.special.j0`
 
-    ''',
-    support_complex=False)
+    ''')
 
 
-_j1 = ufunc.create_math_ufunc(
-    'j1', 1, 'cupyx_scipy_j1',
-    '''Bessel function of the first kind of order 1.
+_j1 = core.create_ufunc(
+    'cupyx_scipy_j1', ('f->f', 'd->d'),
+    'out0 = j1(in0)',
+    doc='''Bessel function of the first kind of order 1.
 
     .. seealso:: :meth:`scipy.special.j1`
 
-    ''',
-    support_complex=False)
+    ''')
 
 
-_y0 = ufunc.create_math_ufunc(
-    'y0', 1, 'cupyx_scipy_y0',
-    '''Bessel function of the second kind of order 0.
+_y0 = core.create_ufunc(
+    'cupyx_scipy_y0', ('f->f', 'd->d'),
+    'out0 = y0(in0)',
+    doc='''Bessel function of the second kind of order 0.
 
     .. seealso:: :meth:`scipy.special.y0`
 
-    ''',
-    support_complex=False)
+    ''')
 
 
-_y1 = ufunc.create_math_ufunc(
-    'y1', 1, 'cupyx_scipy_y1',
-    '''Bessel function of the second kind of order 1.
+_y1 = core.create_ufunc(
+    'cupyx_scipy_y1', ('f->f', 'd->d'),
+    'out0 = y1(in0)',
+    doc='''Bessel function of the second kind of order 1.
 
     .. seealso:: :meth:`scipy.special.y1`
 
-    ''',
-    support_complex=False)
+    ''')
 
 
-_i0 = ufunc.create_math_ufunc(
-    'cyl_bessel_i0', 1, 'cupyx_scipy_i0',
-    '''Modified Bessel function of order 0.
+_i0 = core.create_ufunc(
+    'cupyx_scipy_i0', ('f->f', 'd->d'),
+    'out0 = cyl_bessel_i0(in0)',
+    doc='''Modified Bessel function of order 0.
 
     .. seealso:: :meth:`scipy.special.i0`
 
-    ''',
-    support_complex=False)
+    ''')
 
 
-_i1 = ufunc.create_math_ufunc(
-    'cyl_bessel_i1', 1, 'cupyx_scipy_i1',
-    '''Modified Bessel function of order 1.
+_i1 = core.create_ufunc(
+    'cupyx_scipy_i1', ('f->f', 'd->d'),
+    'out0 = cyl_bessel_i1(in0)',
+    doc='''Modified Bessel function of order 1.
 
     .. seealso:: :meth:`scipy.special.i1`
 
-    ''',
-    support_complex=False)
+    ''')
 
 
 j0 = cupy.core.fusion.ufunc(_j0)

--- a/cupyx/scipy/special/erf.py
+++ b/cupyx/scipy/special/erf.py
@@ -1,35 +1,35 @@
+from cupy import core
 import cupy.core.fusion
-from cupy.math import ufunc
 
 
-_erf = ufunc.create_math_ufunc(
-    'erf', 1, 'cupyx_scipy_erf',
-    '''Error function.
+_erf = core.create_ufunc(
+    'cupyx_scipy_erf', ('f->f', 'd->d'),
+    'out0 = erf(in0)',
+    doc='''Error function.
 
     .. seealso:: :meth:`scipy.special.erf`
 
-    ''',
-    support_complex=False)
+    ''')
 
 
-_erfc = ufunc.create_math_ufunc(
-    'erfc', 1, 'cupyx_scipy_erfc',
-    '''Complementary error function.
+_erfc = core.create_ufunc(
+    'cupyx_scipy_erfc', ('f->f', 'd->d'),
+    'out0 = erfc(in0)',
+    doc='''Complementary error function.
 
     .. seealso:: :meth:`scipy.special.erfc`
 
-    ''',
-    support_complex=False)
+    ''')
 
 
-_erfcx = ufunc.create_math_ufunc(
-    'erfcx', 1, 'cupyx_scipy_erfcx',
-    '''Scaled complementary error function.
+_erfcx = core.create_ufunc(
+    'cupyx_scipy_erfcx', ('f->f', 'd->d'),
+    'out0 = erfcx(in0)',
+    doc='''Scaled complementary error function.
 
     .. seealso:: :meth:`scipy.special.erfcx`
 
-    ''',
-    support_complex=False)
+    ''')
 
 
 erf = cupy.core.fusion.ufunc(_erf)

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_bessel.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_bessel.py
@@ -8,7 +8,7 @@ from cupy import testing
 @testing.with_requires('scipy')
 class TestSpecial(unittest.TestCase):
 
-    @testing.for_dtypes(['f', 'd'])
+    @testing.for_dtypes(['e', 'f', 'd'])
     @testing.numpy_cupy_allclose(atol=1e-5, scipy_name='scp')
     def check_unary(self, name, xp, scp, dtype):
         a = testing.shaped_arange((2, 3), xp, dtype)
@@ -37,7 +37,7 @@ class TestSpecial(unittest.TestCase):
 @testing.with_requires('scipy')
 class TestFusionSpecial(unittest.TestCase):
 
-    @testing.for_dtypes(['f', 'd'])
+    @testing.for_dtypes(['e', 'f', 'd'])
     @testing.numpy_cupy_allclose(atol=1e-5, scipy_name='scp')
     def check_unary(self, name, xp, scp, dtype):
         a = testing.shaped_arange((2, 3), xp, dtype)

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_erf.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_erf.py
@@ -21,7 +21,7 @@ class _TestBase(object):
 @testing.with_requires('scipy')
 class TestSpecial(unittest.TestCase, _TestBase):
 
-    @testing.for_dtypes(['f', 'd'])
+    @testing.for_dtypes(['e', 'f', 'd'])
     @testing.numpy_cupy_allclose(atol=1e-5, scipy_name='scp')
     def check_unary(self, name, xp, scp, dtype):
         import scipy.special  # NOQA
@@ -34,7 +34,7 @@ class TestSpecial(unittest.TestCase, _TestBase):
 @testing.with_requires('scipy')
 class TestFusionSpecial(unittest.TestCase, _TestBase):
 
-    @testing.for_dtypes(['f', 'd'])
+    @testing.for_dtypes(['e', 'f', 'd'])
     @testing.numpy_cupy_allclose(atol=1e-5, scipy_name='scp')
     def check_unary(self, name, xp, scp, dtype):
         import scipy.special  # NOQA


### PR DESCRIPTION
It seems that `scipy.special` converts `float16` to `float32`.

```python
>>> scipy.special.j0(numpy.ones((2,), dtype=numpy.float16))
array([0.7651977, 0.7651977], dtype=float32)
```
