### PR TITLE
Improve usability of special functions

### DIFF
--- a/cupyx/scipy/special/gamma.py
+++ b/cupyx/scipy/special/gamma.py
@@ -1,33 +1,19 @@
-import cupy
 from cupy import core
+import cupy.core.fusion
 
 
-_gamma_kernel = None
-
-
-def _get_gamma_kernel():
-    global _gamma_kernel
-    if _gamma_kernel is None:
-        _gamma_kernel = core.ElementwiseKernel(
-            'T x', 'T y',
-            """
-            if(isinf(x) && x < 0){
-                y = - 1.0 / 0.0;
-                return;
-            }
-            if(x < 0. && x == floor(x)){
-                y = 1.0 / 0.0;
-                return;
-            }
-            y = tgamma(x);
-            """,
-            'gamma_kernel'
-        )
-    return _gamma_kernel
-
-
-def gamma(z):
-    """Gamma function.
+_gamma = core.create_ufunc(
+    'cupyx_scipy_gamma', ('f->f', 'd->d'),
+    '''
+    if (isinf(in0) && in0 < 0) {
+        out0 = -1.0 / 0.0;
+    } else if (in0 < 0. && in0 == floor(in0)) {
+        out0 = 1.0 / 0.0;
+    } else {
+        out0 = tgamma(in0);
+    }
+    ''',
+    doc="""Gamma function.
 
     Args:
         z (cupy.ndarray): The input of gamma function.
@@ -37,11 +23,7 @@ def gamma(z):
 
     .. seealso:: :data:`scipy.special.gamma`
 
-    """
-    if z.dtype.char in '?ebBhH':
-        z = z.astype(cupy.float32)
-    elif z.dtype.char in 'iIlLqQ':
-        z = z.astype(cupy.float64)
-    y = cupy.zeros_like(z)
-    _get_gamma_kernel()(z, y)
-    return y
+    """)
+
+
+gamma = cupy.core.fusion.ufunc(_gamma)

--- a/cupyx/scipy/special/gammaln.py
+++ b/cupyx/scipy/special/gammaln.py
@@ -1,29 +1,17 @@
-import cupy
 from cupy import core
+import cupy.core.fusion
 
 
-_gammaln_kernel = None
-
-
-def _get_gammaln_kernel():
-    global _gammaln_kernel
-    if _gammaln_kernel is None:
-        _gammaln_kernel = core.ElementwiseKernel(
-            'T x', 'T y',
-            """
-            if(isinf(x) && x < 0){
-                y = - 1.0 / 0.0;
-                return;
-            }
-            y = lgamma(x);
-            """,
-            'gammaln_kernel'
-        )
-    return _gammaln_kernel
-
-
-def gammaln(x):
-    """Logarithm of the absolute value of the Gamma function.
+_gammaln = core.create_ufunc(
+    'cupyx_scipy_gammaln', ('f->f', 'd->d'),
+    '''
+    if (isinf(in0) && in0 < 0) {
+        out0 = -1.0 / 0.0;
+    } else {
+        out0 = lgamma(in0);
+    }
+    ''',
+    doc="""Logarithm of the absolute value of the Gamma function.
 
     Args:
         x (cupy.ndarray): Values on the real line at which to compute
@@ -34,11 +22,7 @@ def gammaln(x):
 
     .. seealso:: :data:`scipy.special.gammaln`
 
-    """
-    if x.dtype.char in '?ebBhH':
-        x = x.astype(cupy.float32)
-    elif x.dtype.char in 'iIlLqQ':
-        x = x.astype(cupy.float64)
-    y = cupy.zeros_like(x)
-    _get_gammaln_kernel()(x, y)
-    return y
+    """)
+
+
+gammaln = cupy.core.fusion.ufunc(_gammaln)

--- a/cupyx/scipy/special/zeta.py
+++ b/cupyx/scipy/special/zeta.py
@@ -8,11 +8,8 @@
 
 # TODO(YoshikawaMasashi): float implementation of zeta function
 
-import cupy
 from cupy import core
-
-
-_zeta_kernel = None
+import cupy.core.fusion
 
 
 zeta_definition = '''
@@ -115,22 +112,11 @@ double __device__ zeta(double x, double q)
 '''
 
 
-def _get_zeta_kernel():
-    global _zeta_kernel
-    if _zeta_kernel is None:
-        _zeta_kernel = core.ElementwiseKernel(
-            'T x, T q', 'T y',
-            """
-            y = zeta(x, q)
-            """,
-            'zeta_kernel',
-            preamble=zeta_definition
-        )
-    return _zeta_kernel
-
-
-def zeta(x, q):
-    """Hurwitz zeta function.
+_zeta = core.create_ufunc(
+    'cupyx_scipy_zeta', ('ff->f', 'dd->d'),
+    'out0 = zeta(in0, in1)',
+    preamble=zeta_definition,
+    doc="""Hurwitz zeta function.
 
     Args:
         x (cupy.ndarray): Input data, must be real.
@@ -141,13 +127,7 @@ def zeta(x, q):
 
     .. seealso:: :data:`scipy.special.zeta`
 
-    """
-    if x.dtype.char in '?ebBhH':
-        x = x.astype(cupy.float32)
-    elif x.dtype.char in 'iIlLqQ':
-        x = x.astype(cupy.float64)
-    q = q.astype(x.dtype)
-    x, q = cupy.broadcast_arrays(x, q)
-    y = cupy.zeros_like(x)
-    _get_zeta_kernel()(x, q, y)
-    return y
+    """)
+
+
+zeta = cupy.core.fusion.ufunc(_zeta)


### PR DESCRIPTION
Resolve the problem like following:

```python
>>> cupyx.scipy.special.gamma(1)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/user/work/chainer/cupy/cupyx/scipy/special/gamma.py", line 41, in gamma
```
