### PR TITLE
Improve readability of reduction kernel (only python)

### DIFF
--- a/cupy/core/reduction.pxi
+++ b/cupy/core/reduction.pxi
@@ -151,7 +151,7 @@ cpdef tuple _get_trans_args(list args, tuple trans, tuple shape, tuple params):
 
 cpdef list _get_inout_args(
         list in_args, list out_args, Indexer in_indexer, Indexer out_indexer,
-        Py_ssize_t out_clp2_size, tuple params, bint reduce_dims):
+        Py_ssize_t out_block_size, tuple params, bint reduce_dims):
     if reduce_dims:
         in_shape = _reduce_dims(in_args, params, in_indexer.shape)
         out_shape = _reduce_dims(
@@ -159,7 +159,7 @@ cpdef list _get_inout_args(
         in_indexer.shape = in_shape
         out_indexer.shape = out_shape
     cdef _scalar.CScalar s = _scalar.CScalar.__new__(_scalar.CScalar)
-    (<int32_t *>s.ptr)[0] = out_clp2_size
+    (<int32_t *>s.ptr)[0] = out_block_size
     s.kind = 'i'
     s.size = 4
     return in_args + out_args + [in_indexer, out_indexer, s]
@@ -209,7 +209,7 @@ class simple_reduction_function(object):
                  bint keepdims=False):
         cdef list in_args, out_args
         cdef tuple in_sahpe, laxis, raxis
-        cdef Py_ssize_t block_size, clp2_count, block_stride
+        cdef Py_ssize_t block_size, reduce_block_size, out_block_size
         if dtype is not None:
             dtype = get_dtype(dtype).type
 
@@ -242,8 +242,8 @@ class simple_reduction_function(object):
         block_size = self._block_size
         in_indexer = Indexer(in_shape)
         out_indexer = Indexer(out_shape)
-        clp2_count = max(1, internal.clp2(in_indexer.size // out_indexer.size))
-        block_stride = max(1, block_size // clp2_count)
+        reduce_block_size = max(1, internal.clp2(in_indexer.size // out_indexer.size))
+        out_block_size = max(1, block_size // reduce_block_size)
 
         inout_args = _get_inout_args(
             in_args, out_args, in_indexer, out_indexer, block_stride,
@@ -371,7 +371,7 @@ class ReductionKernel(object):
             ``__init__`` method.
 
         """
-        cdef Py_ssize_t block_size, clp2_count, block_stride
+        cdef Py_ssize_t block_size, reduce_block_size, out_block_size
 
         out = kwargs.pop('out', None)
         axis = kwargs.pop('axis', None)
@@ -428,8 +428,8 @@ class ReductionKernel(object):
         block_size = 512
         in_indexer = Indexer(in_shape)
         out_indexer = Indexer(out_shape)
-        clp2_count = max(1, internal.clp2(in_indexer.size // out_indexer.size))
-        block_stride = max(1, block_size // clp2_count)
+        reduce_block_size = max(1, internal.clp2(in_indexer.size // out_indexer.size))
+        out_block_size = max(1, block_size // reduce_block_size)
 
         inout_args = _get_inout_args(
             in_args, out_args, in_indexer, out_indexer, block_stride,

--- a/cupy/core/reduction.pxi
+++ b/cupy/core/reduction.pxi
@@ -135,7 +135,8 @@ cpdef tuple _get_out_shape(
     return tuple([shape[i] for i in out_axis])
 
 
-cpdef tuple _get_permuted_args(list args, tuple axis_permutes, tuple shape, tuple params):
+cpdef tuple _get_permuted_args(
+        list args, tuple axis_permutes, tuple shape, tuple params):
     cdef ParameterInfo p
     if axis_permutes == tuple(range(len(shape))):
         return args, shape
@@ -210,7 +211,8 @@ class simple_reduction_function(object):
                  bint keepdims=False):
         cdef list in_args, out_args
         cdef tuple in_sahpe, reduce_axis, out_axis
-        cdef Py_ssize_t block_size, reduce_block_size, out_block_size, out_block_num
+        cdef Py_ssize_t block_size, reduce_block_size, out_block_size
+        cdef Py_ssize_t out_block_num
         if dtype is not None:
             dtype = get_dtype(dtype).type
 
@@ -243,7 +245,8 @@ class simple_reduction_function(object):
         block_size = self._block_size
         in_indexer = Indexer(in_shape)
         out_indexer = Indexer(out_shape)
-        reduce_block_size = max(1, internal.clp2(in_indexer.size // out_indexer.size))
+        reduce_block_size = max(
+            1, internal.clp2(in_indexer.size // out_indexer.size))
         out_block_size = max(1, block_size // reduce_block_size)
 
         inout_args = _get_inout_args(
@@ -259,7 +262,8 @@ class simple_reduction_function(object):
 
         # TODO(okuta) set actual size
         shared_mem = 32 * block_size
-        out_block_num = (out_indexer.size + out_block_size - 1) // out_block_size
+        out_block_num = (
+            out_indexer.size + out_block_size - 1) // out_block_size
 
         kern.linear_launch(
             out_block_num * block_size,
@@ -372,7 +376,8 @@ class ReductionKernel(object):
             ``__init__`` method.
 
         """
-        cdef Py_ssize_t block_size, reduce_block_size, out_block_size, out_block_num
+        cdef Py_ssize_t block_size, reduce_block_size, out_block_size
+        cdef Py_ssize_t out_block_num
 
         out = kwargs.pop('out', None)
         axis = kwargs.pop('axis', None)
@@ -413,7 +418,8 @@ class ReductionKernel(object):
             in_ndarray_types, out_ndarray_types)
 
         reduce_axis, out_axis = _get_axis(axis, len(broad_shape))
-        out_shape = _get_out_shape(broad_shape, reduce_axis, out_axis, keepdims)
+        out_shape = _get_out_shape(
+            broad_shape, reduce_axis, out_axis, keepdims)
         out_args = _get_out_args_with_params(
             out_args, out_types, out_shape, self.out_params, False)
         ret = out_args[0]
@@ -429,7 +435,8 @@ class ReductionKernel(object):
         block_size = 512
         in_indexer = Indexer(in_shape)
         out_indexer = Indexer(out_shape)
-        reduce_block_size = max(1, internal.clp2(in_indexer.size // out_indexer.size))
+        reduce_block_size = max(
+            1, internal.clp2(in_indexer.size // out_indexer.size))
         out_block_size = max(1, block_size // reduce_block_size)
 
         inout_args = _get_inout_args(
@@ -445,7 +452,8 @@ class ReductionKernel(object):
 
         # TODO(okuta) set actual size
         shared_mem = 32 * block_size
-        out_block_num = (out_indexer.size + out_block_size - 1) // out_block_size
+        out_block_num = (
+            out_indexer.size + out_block_size - 1) // out_block_size
 
         kern.linear_launch(
             out_block_num * block_size,

--- a/cupy/core/reduction.pxi
+++ b/cupy/core/reduction.pxi
@@ -135,17 +135,18 @@ cpdef tuple _get_out_shape(
     return tuple([shape[i] for i in raxis])
 
 
-cpdef tuple _get_trans_args(list args, tuple trans, tuple shape, tuple params):
+cpdef tuple _get_permuted_args(list args, tuple axis_permutes, tuple shape, tuple params):
     cdef ParameterInfo p
-    if trans == tuple(range(len(shape))):
+    if axis_permutes == tuple(range(len(shape))):
         return args, shape
     if params is not None:
         for p in params:
             if p.raw:
                 raise NotImplementedError('Illegal conditions')
-    args = [a.transpose(trans) if isinstance(a, ndarray) else a
+    args = [a.transpose(axis_permutes) if isinstance(a, ndarray) else a
             for a in args]
-    shape = tuple([shape[i] for i in trans])
+    shape = tuple([shape[i] for i in axis_permutes])
+
     return args, shape
 
 
@@ -236,7 +237,7 @@ class simple_reduction_function(object):
             raise ValueError(('zero-size array to reduction operation'
                               ' %s which has no identity') % self.name)
 
-        in_args, in_shape = _get_trans_args(
+        in_args, in_shape = _get_permuted_args(
             in_args, laxis + raxis, a_shape, None)
 
         block_size = self._block_size
@@ -422,7 +423,7 @@ class ReductionKernel(object):
         in_args = [x if isinstance(x, ndarray) else
                    _scalar.get_scalar_from_numpy(x, t)
                    for x, t in zip(in_args, in_types)]
-        in_args, in_shape = _get_trans_args(
+        in_args, in_shape = _get_permuted_args(
             in_args, axis + raxis, broad_shape, self.in_params)
 
         block_size = 512

--- a/cupy/core/reduction.pxi
+++ b/cupy/core/reduction.pxi
@@ -120,19 +120,19 @@ cpdef tuple _get_axis(object axis, Py_ssize_t ndim):
     for dim in axis:
         if dim < -ndim or dim >= ndim:
             raise ValueError('Axis overrun')
-    axis = tuple(sorted([dim % ndim for dim in axis]))
-    raxis = tuple([dim for dim in range(ndim) if dim not in axis])
-    return axis, raxis
+    reduce_axis = tuple(sorted([dim % ndim for dim in axis]))
+    out_axis = tuple([dim for dim in range(ndim) if dim not in reduce_axis])
+    return reduce_axis, out_axis
 
 
 cpdef tuple _get_out_shape(
-        tuple shape, tuple axis, tuple raxis, bint keepdims):
+        tuple shape, tuple reduce_axis, tuple out_axis, bint keepdims):
     if keepdims:
         out_shape = list(shape)
-        for i in axis:
+        for i in reduce_axis:
             out_shape[i] = 1
         return tuple(out_shape)
-    return tuple([shape[i] for i in raxis])
+    return tuple([shape[i] for i in out_axis])
 
 
 cpdef tuple _get_permuted_args(list args, tuple axis_permutes, tuple shape, tuple params):
@@ -209,7 +209,7 @@ class simple_reduction_function(object):
     def __call__(self, ndarray a, axis=None, dtype=None, ndarray out=None,
                  bint keepdims=False):
         cdef list in_args, out_args
-        cdef tuple in_sahpe, laxis, raxis
+        cdef tuple in_sahpe, reduce_axis, out_axis
         cdef Py_ssize_t block_size, reduce_block_size, out_block_size, out_block_num
         if dtype is not None:
             dtype = get_dtype(dtype).type
@@ -226,9 +226,9 @@ class simple_reduction_function(object):
         in_types, out_types, routine = _guess_routine(
             self.name, self._routine_cache, self._ops, in_args, dtype)
 
-        laxis, raxis = _get_axis(axis, a._shape.size())
+        reduce_axis, out_axis = _get_axis(axis, a._shape.size())
         del axis  # to avoid bug
-        out_shape = _get_out_shape(a_shape, laxis, raxis, keepdims)
+        out_shape = _get_out_shape(a_shape, reduce_axis, out_axis, keepdims)
         out_args = _get_out_args(out_args, out_types, out_shape, 'unsafe')
         ret = out_args[0] if len(out_args) == 1 else tuple(out_args)
         if (<ndarray>out_args[0]).size == 0:
@@ -238,7 +238,7 @@ class simple_reduction_function(object):
                               ' %s which has no identity') % self.name)
 
         in_args, in_shape = _get_permuted_args(
-            in_args, laxis + raxis, a_shape, None)
+            in_args, reduce_axis + out_axis, a_shape, None)
 
         block_size = self._block_size
         in_indexer = Indexer(in_shape)
@@ -412,8 +412,8 @@ class ReductionKernel(object):
             self.in_params, self.out_params,
             in_ndarray_types, out_ndarray_types)
 
-        axis, raxis = _get_axis(axis, len(broad_shape))
-        out_shape = _get_out_shape(broad_shape, axis, raxis, keepdims)
+        reduce_axis, out_axis = _get_axis(axis, len(broad_shape))
+        out_shape = _get_out_shape(broad_shape, reduce_axis, out_axis, keepdims)
         out_args = _get_out_args_with_params(
             out_args, out_types, out_shape, self.out_params, False)
         ret = out_args[0]
@@ -424,7 +424,7 @@ class ReductionKernel(object):
                    _scalar.get_scalar_from_numpy(x, t)
                    for x, t in zip(in_args, in_types)]
         in_args, in_shape = _get_permuted_args(
-            in_args, axis + raxis, broad_shape, self.in_params)
+            in_args, reduce_axis + out_axis, broad_shape, self.in_params)
 
         block_size = 512
         in_indexer = Indexer(in_shape)


### PR DESCRIPTION
This PR is a collection of partial commits from https://github.com/cupy/cupy/pull/1520.
Since we noticed that https://github.com/cupy/cupy/pull/1520 introduces backward compatibility, I cherry-picked patches only in python layer.

Changes:

* out_clp2_size ~~=> out_block_size~~ => block_stride
* clp2_count => reduce_block_size
* get_trans_args => get_permuted_args
* laxis => reduce_axis
* raxis => out_axis
* out_block_ num = (out_indexer.size + out_block_size - 1) // out_block_size

