### PR TITLE
Reset cuda runtime error

### DIFF
--- a/cupy/cuda/cupy_cuda.h
+++ b/cupy/cuda/cupy_cuda.h
@@ -250,6 +250,10 @@ const char* cudaGetErrorString(...) {
     return NULL;
 }
 
+cudaError_t cudaGetLastError() {
+    return cudaSuccess;
+}
+
 
 // Initialization
 cudaError_t cudaDriverGetVersion(...) {

--- a/cupy/cuda/runtime.pyx
+++ b/cupy/cuda/runtime.pyx
@@ -50,6 +50,7 @@ cdef extern from "cupy_cuda.h" nogil:
     # Error handling
     const char* cudaGetErrorName(Error error)
     const char* cudaGetErrorString(Error error)
+    int cudaGetLastError()
 
     # Initialization
     int cudaDriverGetVersion(int* driverVersion)
@@ -131,6 +132,8 @@ class CUDARuntimeError(RuntimeError):
 @cython.profile(False)
 cpdef inline check_status(int status):
     if status != 0:
+        # to reset error status
+        cudaGetLastError()
         raise CUDARuntimeError(status)
 
 


### PR DESCRIPTION
Fix #1574

Thrust uses `cudaGetLastError`. This PR resets it.
