### PR TITLE
Add cupy.cublas.dgetriBatched

### DIFF
--- a/cupy/cuda/cublas.pxd
+++ b/cupy/cuda/cublas.pxd
@@ -227,6 +227,9 @@ cpdef dgetrfBatched(size_t handle, int n, size_t Aarray, int lda,
 cpdef sgetriBatched(size_t handle, int n, size_t Aarray, int lda,
                     size_t PivotArray, size_t Carray, int ldc,
                     size_t infoArray, int batchSize)
+cpdef dgetriBatched(size_t handle, int n, size_t Aarray, int lda,
+                    size_t PivotArray, size_t Carray, int ldc,
+                    size_t infoArray, int batchSize)
 cpdef gemmEx(size_t handle, int transa, int transb, int m, int n, int k,
              size_t alpha, size_t A, int Atype, int lda, size_t B,
              int Btype, int ldb, size_t beta, size_t C, int Ctype,

--- a/cupy/cuda/cublas.pyx
+++ b/cupy/cuda/cublas.pyx
@@ -211,6 +211,10 @@ cdef extern from 'cupy_cuda.h' nogil:
         Handle handle, int n, const float **Aarray, int lda,
         int *PivotArray, float *Carray[], int ldc, int *infoArray,
         int batchSize)
+    int cublasDgetriBatched(
+        Handle handle, int n, const double **Aarray, int lda,
+        int *PivotArray, double *Carray[], int ldc, int *infoArray,
+        int batchSize)
     int cublasGemmEx(
         Handle handle, Operation transa, Operation transb,
         int m, int n, int k,
@@ -903,6 +907,17 @@ cpdef sgetriBatched(
         status = cublasSgetriBatched(
             <Handle>handle, n, <const float**>Aarray, lda, <int*>PivotArray,
             <float**>Carray, ldc, <int*>infoArray, batchSize)
+    check_status(status)
+
+
+cpdef dgetriBatched(
+        size_t handle, int n, size_t Aarray, int lda, size_t PivotArray,
+        size_t Carray, int ldc, size_t infoArray, int batchSize):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cublasDgetriBatched(
+            <Handle>handle, n, <const double**>Aarray, lda, <int*>PivotArray,
+            <double**>Carray, ldc, <int*>infoArray, batchSize)
     check_status(status)
 
 

--- a/cupy/cuda/cupy_cuda.h
+++ b/cupy/cuda/cupy_cuda.h
@@ -666,6 +666,10 @@ cublasStatus_t cublasSgetriBatched(...) {
     return CUBLAS_STATUS_SUCCESS;
 }
 
+cublasStatus_t cublasDgetriBatched(...) {
+    return CUBLAS_STATUS_SUCCESS;
+}
+
 cublasStatus_t cublasStrttp(...) {
     return CUBLAS_STATUS_SUCCESS;
 }


### PR DESCRIPTION
This PR adds `cupy.cublas.dgetriBatched` which I need to make `chainer.functions.inv` work in double.