### PR TITLE
Fix invalid escape sequence warnings in Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ script:
   - flake8 --config=.flake8.cython
   - autopep8 -r . --global-config .pep8 --diff | tee check_autopep8
   - test ! -s check_autopep8
-  - python -Werror::DeprecationWarning -m compileall -f -q cupy cupyx examples tests
+  - python -Werror::DeprecationWarning -m compileall -f -q cupy cupyx examples tests docs
   - READTHEDOCS=True python setup.py develop
 
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ script:
   - flake8 --config=.flake8.cython
   - autopep8 -r . --global-config .pep8 --diff | tee check_autopep8
   - test ! -s check_autopep8
+  - python -Werror::DeprecationWarning -m compileall -f -q cupy cupyx examples tests
   - READTHEDOCS=True python setup.py develop
 
 sudo: false

--- a/docs/source/_comparison_generator.py
+++ b/docs/source/_comparison_generator.py
@@ -37,10 +37,10 @@ def _generate_comparison_rst(base_obj, cupy_obj, base_type):
     ]
     for f in sorted(base_funcs):
         if f in cp_funcs:
-            line = '   :obj:`{0}.{1}`, :obj:`{2}.{1}`'.format(
+            line = r'   :obj:`{0}.{1}`, :obj:`{2}.{1}`'.format(
                 base_obj, f, cupy_obj)
         else:
-            line = '   :obj:`{0}.{1}`, \-'.format(base_obj, f)
+            line = r'   :obj:`{0}.{1}`, \-'.format(base_obj, f)
         buf.append(line)
 
     buf += [


### PR DESCRIPTION
CuPy version of https://github.com/chainer/chainer/pull/5317.