### PR TITLE
Improve `_comparison_generator`

### DIFF
--- a/docs/source/_comparison_generator.py
+++ b/docs/source/_comparison_generator.py
@@ -1,16 +1,4 @@
-import numpy
-
-import scipy
-import scipy.linalg
-import scipy.special
-import scipy.ndimage
-
-import cupy
-
-import cupyx.scipy
-import cupyx.scipy.linalg
-import cupyx.scipy.ndimage
-import cupyx.scipy.special
+import importlib
 
 
 def _get_functions(obj):
@@ -26,8 +14,8 @@ def _get_functions(obj):
 
 
 def _generate_comparison_rst(base_obj, cupy_obj, base_type):
-    base_funcs = _get_functions(eval(base_obj))
-    cp_funcs = _get_functions(eval(cupy_obj))
+    base_funcs = _get_functions(importlib.import_module(base_obj))
+    cp_funcs = _get_functions(importlib.import_module(cupy_obj))
 
     buf = []
     buf += [

--- a/docs/source/_comparison_generator.py
+++ b/docs/source/_comparison_generator.py
@@ -19,7 +19,8 @@ def _import(mod, klass):
         obj = getattr(obj, klass)
         return obj, ':meth:`{}.{}.{{}}`'.format(mod, klass)
     else:
-        return obj, ':func:`{}.{{}}`'.format(mod)
+        # ufunc is not a function
+        return obj, ':obj:`{}.{{}}`'.format(mod)
 
 
 def _generate_comparison_rst(

--- a/docs/source/_comparison_generator.py
+++ b/docs/source/_comparison_generator.py
@@ -22,11 +22,18 @@ def _import(mod, klass):
         return obj, ':func:`{}.{{}}`'.format(mod)
 
 
-def _generate_comparison_rst(base_mod, cupy_mod, base_type, klass):
+def _generate_comparison_rst(
+        base_mod, cupy_mod, base_type, klass, exclude_mod):
     base_obj, base_fmt = _import(base_mod, klass)
     base_funcs = _get_functions(base_obj)
     cp_obj, cp_fmt = _import(cupy_mod, klass)
     cp_funcs = _get_functions(cp_obj)
+
+    if exclude_mod:
+        exclude_obj, _ = _import(exclude_mod, klass)
+        exclude_funcs = _get_functions(exclude_obj)
+        base_funcs -= exclude_funcs
+        cp_funcs -= exclude_funcs
 
     buf = []
     buf += [
@@ -53,12 +60,16 @@ def _generate_comparison_rst(base_mod, cupy_mod, base_type, klass):
     return buf
 
 
-def _section(header, base_mod, cupy_mod, base_type='NumPy', klass=None):
+def _section(
+        header, base_mod, cupy_mod,
+        base_type='NumPy', klass=None, exclude=None):
     return [
         header,
         '~' * len(header),
         '',
-    ] + _generate_comparison_rst(base_mod, cupy_mod, base_type, klass) + [
+    ] + _generate_comparison_rst(
+        base_mod, cupy_mod, base_type, klass, exclude
+    ) + [
         '',
     ]
 
@@ -97,7 +108,10 @@ def generate():
         'scipy.sparse', 'cupyx.scipy.sparse', 'SciPy')
     buf += _section(
         'Sparse Linear Algebra',
-        'scipy.linalg', 'cupyx.scipy.linalg', 'SciPy')
+        'scipy.sparse.linalg', 'cupyx.scipy.sparse.linalg', 'SciPy')
+    buf += _section(
+        'Advanced Linear Algebra',
+        'scipy.linalg', 'cupyx.scipy.linalg', 'SciPy', exclude='numpy.linalg')
     buf += _section(
         'Multidimensional Image Processing',
         'scipy.ndimage', 'cupyx.scipy.ndimage', 'SciPy')

--- a/docs/source/_comparison_generator.py
+++ b/docs/source/_comparison_generator.py
@@ -13,9 +13,20 @@ def _get_functions(obj):
     ])
 
 
-def _generate_comparison_rst(base_obj, cupy_obj, base_type):
-    base_funcs = _get_functions(importlib.import_module(base_obj))
-    cp_funcs = _get_functions(importlib.import_module(cupy_obj))
+def _import(mod, klass):
+    obj = importlib.import_module(mod)
+    if klass:
+        obj = getattr(obj, klass)
+        return obj, ':meth:`{}.{}.{{}}`'.format(mod, klass)
+    else:
+        return obj, ':func:`{}.{{}}`'.format(mod)
+
+
+def _generate_comparison_rst(base_mod, cupy_mod, base_type, klass):
+    base_obj, base_fmt = _import(base_mod, klass)
+    base_funcs = _get_functions(base_obj)
+    cp_obj, cp_fmt = _import(cupy_mod, klass)
+    cp_funcs = _get_functions(cp_obj)
 
     buf = []
     buf += [
@@ -24,11 +35,9 @@ def _generate_comparison_rst(base_obj, cupy_obj, base_type):
         '',
     ]
     for f in sorted(base_funcs):
-        if f in cp_funcs:
-            line = r'   :obj:`{0}.{1}`, :obj:`{2}.{1}`'.format(
-                base_obj, f, cupy_obj)
-        else:
-            line = r'   :obj:`{0}.{1}`, \-'.format(base_obj, f)
+        base_cell = base_fmt.format(f)
+        cp_cell = cp_fmt.format(f) if f in cp_funcs else r'\-'
+        line = '   {}, {}'.format(base_cell, cp_cell)
         buf.append(line)
 
     buf += [
@@ -44,12 +53,12 @@ def _generate_comparison_rst(base_obj, cupy_obj, base_type):
     return buf
 
 
-def _section(header, base_obj, cupy_obj, base_type='NumPy'):
+def _section(header, base_mod, cupy_mod, base_type='NumPy', klass=None):
     return [
         header,
         '~' * len(header),
         '',
-    ] + _generate_comparison_rst(base_obj, cupy_obj, base_type) + [
+    ] + _generate_comparison_rst(base_mod, cupy_mod, base_type, klass) + [
         '',
     ]
 
@@ -67,7 +76,7 @@ def generate():
         'numpy', 'cupy')
     buf += _section(
         'Multi-Dimensional Array',
-        'numpy.ndarray', 'cupy.ndarray')
+        'numpy', 'cupy', klass='ndarray')
     buf += _section(
         'Linear Algebra',
         'numpy.linalg', 'cupy.linalg')


### PR DESCRIPTION
- Fix `scipy.linalg` table
  - Fix caption
  - Exclude `numpy.linalg` reexports
- Add `scipy.sparse.linalg` table
- Use ~`:func:`~ `:obj:` and `:meth:`