### PR TITLE
[backport] Fix invalid escape sequence warnings in Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ script:
   - flake8 --config=.flake8.cython
   - autopep8 -r . --global-config .pep8 --diff | tee check_autopep8
   - test ! -s check_autopep8
+  - python -Werror::DeprecationWarning -m compileall -f -q cupy cupyx examples tests docs
   - READTHEDOCS=True python setup.py develop
 
 sudo: false

--- a/cupy/logic/comparison.py
+++ b/cupy/logic/comparison.py
@@ -28,7 +28,7 @@ def isclose(a, b, rtol=1.e-5, atol=1.e-8, equal_nan=False):
 
     .. math::
 
-       |a - b| \le \mathrm{atol} + \mathrm{rtol} |b|
+       |a - b| \\le \\mathrm{atol} + \\mathrm{rtol} |b|
 
     Args:
         a (cupy.ndarray): Input array to compare.


### PR DESCRIPTION
Backport of #1619