### PR TITLE
Support comparison operators for complex numbers

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -4147,9 +4147,14 @@ cpdef inline tuple _to_cublas_vector(ndarray a, Py_ssize_t rundim):
 
 cpdef create_comparison(name, op, doc='', require_sortable_dtype=True):
 
-    ops = ('??->?', 'bb->?', 'BB->?', 'hh->?', 'HH->?', 'ii->?', 'II->?',
-           'll->?', 'LL->?', 'qq->?', 'QQ->?', 'ee->?', 'ff->?', 'dd->?',
-           'FF->?', 'DD->?')
+    if require_sortable_dtype:
+        ops = ('??->?', 'bb->?', 'BB->?', 'hh->?', 'HH->?', 'ii->?', 'II->?',
+               'll->?', 'LL->?', 'qq->?', 'QQ->?', 'ee->?', 'ff->?', 'dd->?')
+    else:
+        ops = ('??->?', 'bb->?', 'BB->?', 'hh->?', 'HH->?', 'ii->?', 'II->?',
+               'll->?', 'LL->?', 'qq->?', 'QQ->?', 'ee->?', 'ff->?', 'dd->?',
+               'FF->?', 'DD->?')
+
     return create_ufunc(
         'cupy_' + name,
         ops,
@@ -4163,7 +4168,8 @@ greater = create_comparison(
 
     .. seealso:: :data:`numpy.greater`
 
-    ''')
+    ''',
+    require_sortable_dtype=False)
 
 
 greater_equal = create_comparison(
@@ -4172,7 +4178,8 @@ greater_equal = create_comparison(
 
     .. seealso:: :data:`numpy.greater_equal`
 
-    ''')
+    ''',
+    require_sortable_dtype=False)
 
 
 less = create_comparison(
@@ -4181,7 +4188,8 @@ less = create_comparison(
 
     .. seealso:: :data:`numpy.less`
 
-    ''')
+    ''',
+    require_sortable_dtype=False)
 
 
 less_equal = create_comparison(
@@ -4190,7 +4198,8 @@ less_equal = create_comparison(
 
     .. seealso:: :data:`numpy.less_equal`
 
-    ''')
+    ''',
+    require_sortable_dtype=False)
 
 
 equal = create_comparison(
@@ -4199,7 +4208,8 @@ equal = create_comparison(
 
     .. seealso:: :data:`numpy.equal`
 
-    ''', False)
+    ''',
+    require_sortable_dtype=False)
 
 
 not_equal = create_comparison(
@@ -4208,7 +4218,8 @@ not_equal = create_comparison(
 
     .. seealso:: :data:`numpy.equal`
 
-    ''', False)
+    ''',
+    require_sortable_dtype=False)
 
 
 _all = create_reduction_func(

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2053,6 +2053,17 @@ __device__ min_max_st<T> my_min_float(
     if (is_nan(b.value)) return b;
     return min_max_st<T>(min(a.value, b.value));
 }
+template <typename T>
+__device__ min_max_st<T> my_min_complex(
+        const min_max_st<T>& a, const min_max_st<T>& b) {
+    if (a.index == -1) return b;
+    if (b.index == -1) return a;
+    if (is_nan(a.value.real())) return a;
+    if (is_nan(a.value.imag())) return a;
+    if (is_nan(b.value.real())) return b;
+    if (is_nan(b.value.imag())) return b;
+    return min_max_st<T>(min(a.value, b.value));
+}
 
 template <typename T>
 __device__ min_max_st<T> my_max(
@@ -2068,6 +2079,17 @@ __device__ min_max_st<T> my_max_float(
     if (b.index == -1) return a;
     if (is_nan(a.value)) return a;
     if (is_nan(b.value)) return b;
+    return min_max_st<T>(max(a.value, b.value));
+}
+template <typename T>
+__device__ min_max_st<T> my_max_complex(
+        const min_max_st<T>& a, const min_max_st<T>& b) {
+    if (a.index == -1) return b;
+    if (b.index == -1) return a;
+    if (is_nan(a.value.real())) return a;
+    if (is_nan(a.value.imag())) return a;
+    if (is_nan(b.value.real())) return b;
+    if (is_nan(b.value.imag())) return b;
     return min_max_st<T>(max(a.value, b.value));
 }
 
@@ -2091,6 +2113,19 @@ __device__ min_max_st<T> my_argmin_float(
     if (is_nan(b.value)) return b;
     return (a.value <= b.value) ? a : b;
 }
+template <typename T>
+__device__ min_max_st<T> my_argmin_complex(
+        const min_max_st<T>& a, const min_max_st<T>& b) {
+    if (a.index == -1) return b;
+    if (b.index == -1) return a;
+    if (a.value == b.value)
+        return min_max_st<T>(a.value, min(a.index, b.index));
+    if (is_nan(a.value.real())) return a;
+    if (is_nan(a.value.imag())) return a;
+    if (is_nan(b.value.real())) return b;
+    if (is_nan(b.value.imag())) return b;
+    return (a.value <= b.value) ? a : b;
+}
 
 template <typename T>
 __device__ min_max_st<T> my_argmax(
@@ -2112,6 +2147,19 @@ __device__ min_max_st<T> my_argmax_float(
     if (is_nan(b.value)) return b;
     return (a.value >= b.value) ? a : b;
 }
+template <typename T>
+__device__ min_max_st<T> my_argmax_complex(
+        const min_max_st<T>& a, const min_max_st<T>& b) {
+    if (a.index == -1) return b;
+    if (b.index == -1) return a;
+    if (a.value == b.value)
+        return min_max_st<T>(a.value, min(a.index, b.index));
+    if (is_nan(a.value.real())) return a;
+    if (is_nan(a.value.imag())) return a;
+    if (is_nan(b.value.real())) return b;
+    if (is_nan(b.value.imag())) return b;
+    return (a.value >= b.value) ? a : b;
+}
 '''
 
 
@@ -2121,7 +2169,9 @@ _amin = create_reduction_func(
      'q->q', 'Q->Q',
      ('e->e', (None, 'my_min_float(a, b)', None, None)),
      ('f->f', (None, 'my_min_float(a, b)', None, None)),
-     ('d->d', (None, 'my_min_float(a, b)', None, None))),
+     ('d->d', (None, 'my_min_float(a, b)', None, None)),
+     ('F->F', (None, 'my_min_complex(a, b)', None, None)),
+     ('D->D', (None, 'my_min_complex(a, b)', None, None))),
     ('min_max_st<type_in0_raw>(in0)', 'my_min(a, b)', 'out0 = a.value',
      'min_max_st<type_in0_raw>'),
     None, _min_max_preamble)
@@ -2133,7 +2183,10 @@ _amax = create_reduction_func(
      'q->q', 'Q->Q',
      ('e->e', (None, 'my_max_float(a, b)', None, None)),
      ('f->f', (None, 'my_max_float(a, b)', None, None)),
-     ('d->d', (None, 'my_max_float(a, b)', None, None))),
+     ('d->d', (None, 'my_max_float(a, b)', None, None)),
+     ('F->F', (None, 'my_max_complex(a, b)', None, None)),
+     ('D->D', (None, 'my_max_complex(a, b)', None, None)),
+     ),
     ('min_max_st<type_in0_raw>(in0)', 'my_max(a, b)', 'out0 = a.value',
      'min_max_st<type_in0_raw>'),
     None, _min_max_preamble)
@@ -2163,7 +2216,9 @@ cdef _argmin = create_reduction_func(
      'q->q', 'Q->q',
      ('e->q', (None, 'my_argmin_float(a, b)', None, None)),
      ('f->q', (None, 'my_argmin_float(a, b)', None, None)),
-     ('d->q', (None, 'my_argmin_float(a, b)', None, None))),
+     ('d->q', (None, 'my_argmin_float(a, b)', None, None)),
+     ('F->q', (None, 'my_argmin_complex(a, b)', None, None)),
+     ('D->q', (None, 'my_argmin_complex(a, b)', None, None))),
     ('min_max_st<type_in0_raw>(in0, _J)', 'my_argmin(a, b)', 'out0 = a.index',
      'min_max_st<type_in0_raw>'),
     None, _min_max_preamble)
@@ -2175,7 +2230,9 @@ cdef _argmax = create_reduction_func(
      'q->q', 'Q->q',
      ('e->q', (None, 'my_argmax_float(a, b)', None, None)),
      ('f->q', (None, 'my_argmax_float(a, b)', None, None)),
-     ('d->q', (None, 'my_argmax_float(a, b)', None, None))),
+     ('d->q', (None, 'my_argmax_float(a, b)', None, None)),
+     ('F->q', (None, 'my_argmax_complex(a, b)', None, None)),
+     ('D->q', (None, 'my_argmax_complex(a, b)', None, None))),
     ('min_max_st<type_in0_raw>(in0, _J)', 'my_argmax(a, b)', 'out0 = a.index',
      'min_max_st<type_in0_raw>'),
     None, _min_max_preamble)

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -4090,13 +4090,9 @@ cpdef inline tuple _to_cublas_vector(ndarray a, Py_ssize_t rundim):
 
 cpdef create_comparison(name, op, doc='', require_sortable_dtype=True):
 
-    if require_sortable_dtype:
-        ops = ('??->?', 'bb->?', 'BB->?', 'hh->?', 'HH->?', 'ii->?', 'II->?',
-               'll->?', 'LL->?', 'qq->?', 'QQ->?', 'ee->?', 'ff->?', 'dd->?')
-    else:
-        ops = ('??->?', 'bb->?', 'BB->?', 'hh->?', 'HH->?', 'ii->?', 'II->?',
-               'll->?', 'LL->?', 'qq->?', 'QQ->?', 'ee->?', 'ff->?', 'dd->?',
-               'FF->?', 'DD->?')
+    ops = ('??->?', 'bb->?', 'BB->?', 'hh->?', 'HH->?', 'ii->?', 'II->?',
+           'll->?', 'LL->?', 'qq->?', 'QQ->?', 'ee->?', 'ff->?', 'dd->?',
+           'FF->?', 'DD->?')
     return create_ufunc(
         'cupy_' + name,
         ops,

--- a/cupy/core/include/cupy/complex/arithmetic.h
+++ b/cupy/core/include/cupy/complex/arithmetic.h
@@ -114,6 +114,114 @@ __device__ inline complex<ValueType> operator/(const ValueType& lhs,
   return complex<ValueType>(lhs) / rhs;
 }
 
+/* --- Unary comparison with Numpy logic. This means that a + bi > c + di if either
+ * a > c or a == c and b > d. --- */
+
+template <typename ValueType>
+__device__ inline bool operator<(const complex<ValueType>& lhs,
+                                 const complex<ValueType>& rhs) {
+  if (lhs == rhs)
+  {
+      return false;
+  } else if (lhs.real() < rhs.real())
+  {
+      return true;
+  } else if (lhs.real() == rhs.real())
+  {
+      return lhs.imag() < rhs.imag();
+  } else
+  {
+      return false;
+  }
+}
+
+template <typename ValueType>
+__device__ inline bool operator<=(const complex<ValueType>& lhs,
+                                  const complex<ValueType>& rhs) {
+  if (lhs == rhs)
+  {
+      return true;
+  } else if (lhs < rhs)
+  {
+      return true;
+  } else
+  {
+      return false;
+  }
+}
+
+template <typename ValueType>
+__device__ inline bool operator>(const complex<ValueType>& lhs,
+                                 const complex<ValueType>& rhs) {
+  if (lhs == rhs)
+  {
+      return false;
+  } else
+  {
+      return !(lhs < rhs);
+  }
+}
+
+template <typename ValueType>
+__device__ inline bool operator>=(const complex<ValueType>& lhs,
+                                  const complex<ValueType>& rhs) {
+  if (lhs == rhs || lhs > rhs)
+  {
+      return true;
+  } else
+  {
+      return false;
+  }
+}
+
+template <typename ValueType>
+__device__ inline bool operator<(const ValueType& lhs,
+                                 const complex<ValueType>& rhs) {
+    return complex<ValueType>(lhs) < rhs;
+}
+
+template <typename ValueType>
+__device__ inline bool operator>(const ValueType& lhs,
+                                 const complex<ValueType>& rhs) {
+    return complex<ValueType>(lhs) > rhs;
+}
+
+template <typename ValueType>
+__device__ inline bool operator<(const complex<ValueType>& lhs,
+                                 const ValueType& rhs) {
+    return lhs < complex<ValueType>(rhs);
+}
+
+template <typename ValueType>
+__device__ inline bool operator>(const complex<ValueType>& lhs,
+                                 const ValueType& rhs) {
+    return lhs > complex<ValueType>(rhs);
+}
+
+template <typename ValueType>
+__device__ inline bool operator<=(const ValueType& lhs,
+                                  const complex<ValueType>& rhs) {
+    return complex<ValueType>(lhs) <= rhs;
+}
+
+template <typename ValueType>
+__device__ inline bool operator>=(const ValueType& lhs,
+                                  const complex<ValueType>& rhs) {
+    return complex<ValueType>(lhs) >= rhs;
+}
+
+template <typename ValueType>
+__device__ inline bool operator<=(const complex<ValueType>& lhs,
+                                  const ValueType& rhs) {
+    return lhs <= complex<ValueType>(rhs);
+}
+
+template <typename ValueType>
+__device__ inline bool operator>=(const complex<ValueType>& lhs,
+                                  const ValueType& rhs) {
+    return lhs >= complex<ValueType>(rhs);
+}
+
 /* --- Unary Arithmetic Operators --- */
 
 template <typename ValueType>

--- a/cupy/logic/ops.py
+++ b/cupy/logic/ops.py
@@ -6,7 +6,8 @@ logical_and = core.create_comparison(
 
     .. seealso:: :data:`numpy.logical_and`
 
-    ''')
+    ''',
+    require_sortable_dtype=False)
 
 
 logical_or = core.create_comparison(
@@ -15,7 +16,8 @@ logical_or = core.create_comparison(
 
     .. seealso:: :data:`numpy.logical_or`
 
-    ''')
+    ''',
+    require_sortable_dtype=False)
 
 
 logical_not = core.create_ufunc(

--- a/cupy/logic/ops.py
+++ b/cupy/logic/ops.py
@@ -7,7 +7,7 @@ logical_and = core.create_comparison(
     .. seealso:: :data:`numpy.logical_and`
 
     ''',
-    require_sortable_dtype=False)
+    require_sortable_dtype=True)
 
 
 logical_or = core.create_comparison(
@@ -17,7 +17,7 @@ logical_or = core.create_comparison(
     .. seealso:: :data:`numpy.logical_or`
 
     ''',
-    require_sortable_dtype=False)
+    require_sortable_dtype=True)
 
 
 logical_not = core.create_ufunc(

--- a/tests/cupy_tests/core_tests/test_ndarray_elementwise_op.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_elementwise_op.py
@@ -141,16 +141,16 @@ class TestArrayElementwiseOp(unittest.TestCase):
                                        no_complex=True)
 
     def test_lt_scalar(self):
-        self.check_array_scalar_op(operator.lt, no_complex=True)
+        self.check_array_scalar_op(operator.lt, no_complex=False)
 
     def test_le_scalar(self):
-        self.check_array_scalar_op(operator.le, no_complex=True)
+        self.check_array_scalar_op(operator.le, no_complex=False)
 
     def test_gt_scalar(self):
-        self.check_array_scalar_op(operator.gt, no_complex=True)
+        self.check_array_scalar_op(operator.gt, no_complex=False)
 
     def test_ge_scalar(self):
-        self.check_array_scalar_op(operator.ge, no_complex=True)
+        self.check_array_scalar_op(operator.ge, no_complex=False)
 
     def test_eq_scalar(self):
         self.check_array_scalar_op(operator.eq)


### PR DESCRIPTION
This adds numpy-style lexicographic ordering for complex numbers. This means, first the real parts are compared (if nan, I'm not sure what's supposed to happen, in this case I return the first number) and if they are equal, the imaginary parts are used.

This enables `>, >=, <=, >, min(), max()` to be used on complex arrays. At least one side-effect is that `svd()` now works with complex.