### PR TITLE
Fix random.exponential

### DIFF
--- a/cupy/random/generator.py
+++ b/cupy/random/generator.py
@@ -142,8 +142,12 @@ class RandomState(object):
             :func:`cupy.random.exponential` for full documentation,
             :meth:`numpy.random.RandomState.exponential`
         """
+        scale = cupy.asarray(scale, dtype)
+        if size is None:
+            size = scale.shape
         x = self.standard_exponential(size, dtype)
-        return cupy.multiply(scale, x, out=x)
+        x *= scale
+        return x
 
     def f(self, dfnum, dfden, size=None, dtype=float):
         """Returns an array of samples drawn from the f distribution.

--- a/cupy/random/generator.py
+++ b/cupy/random/generator.py
@@ -143,6 +143,8 @@ class RandomState(object):
             :meth:`numpy.random.RandomState.exponential`
         """
         scale = cupy.asarray(scale, dtype)
+        if (scale < 0).any():
+            raise ValueError('scale < 0')
         if size is None:
             size = scale.shape
         x = self.standard_exponential(size, dtype)

--- a/tests/cupy_tests/random_tests/test_distributions.py
+++ b/tests/cupy_tests/random_tests/test_distributions.py
@@ -116,6 +116,15 @@ class TestDistributionsExponential(RandomDistributionsTestCase):
                                 {'scale': scale}, dtype)
 
 
+@testing.gpu
+class TestDistributionsExponentialError(RandomDistributionsTestCase):
+
+    def test_negative_scale(self):
+        scale = cupy.array([2, -1, 3], dtype=numpy.float32)
+        with self.assertRaises(ValueError):
+            cupy.random.exponential(scale)
+
+
 @testing.parameterize(*testing.product({
     'shape': [(4, 3, 2), (3, 2)],
     'dfnum_shape': [(), (3, 2)],

--- a/tests/cupy_tests/random_tests/test_distributions.py
+++ b/tests/cupy_tests/random_tests/test_distributions.py
@@ -17,8 +17,9 @@ _int_dtypes = _signed_dtypes + _unsigned_dtypes
 class RandomDistributionsTestCase(unittest.TestCase):
     def check_distribution(self, dist_name, params, dtype):
         cp_params = {k: cupy.asarray(params[k]) for k in params}
-        np_out = getattr(numpy.random, dist_name)(
-            size=self.shape, **params).astype(dtype)
+        np_out = numpy.asarray(
+            getattr(numpy.random, dist_name)(size=self.shape, **params),
+            dtype)
         cp_out = getattr(distributions, dist_name)(
             size=self.shape, dtype=dtype, **cp_params)
         self.assertEqual(cp_out.shape, np_out.shape)
@@ -100,7 +101,7 @@ class TestDistributionsDirichlet(RandomDistributionsTestCase):
 
 
 @testing.parameterize(*testing.product({
-    'shape': [(4, 3, 2), (3, 2)],
+    'shape': [(4, 3, 2), (3, 2), None],
     'scale_shape': [(), (3, 2)],
 })
 )


### PR DESCRIPTION
#1624.

- Check `scale >= 0`
- Fix the distribution about #1644
- Fix `test_distributions.py` for the cases numpy outputs Python `float`.