### PR TITLE
Fix float16 nextafter

### DIFF
--- a/cupy/core/include/cupy/carray.cuh
+++ b/cupy/core/include/cupy/carray.cuh
@@ -122,7 +122,7 @@ public:
     } else if (x.iszero()) {
       ret_raw_.x = (y_raw_.x & 0x8000u) + 1;
     } else if (!(x_raw_.x & 0x8000u)) {
-      if (x_raw_.x > y_raw_.x) {
+      if (static_cast<signed short>(x_raw_.x) > static_cast<signed short>(y_raw_.x)) {
         ret_raw_.x = x_raw_.x - 1;
       } else {
         ret_raw_.x = x_raw_.x + 1;


### PR DESCRIPTION
I found a bug in nextafter and fixed it.
The bug happens if x>0 and y<0.

in 3788136df8f499e6b2c8643e3d4478c59e4193a6 (master)
```shell
$ python nextafter.py 
numpy 2.998
cupy 3.002
```

in f1f00b593d94e2d5081efe57ef93c729cde2eb10 (fix-float16-nextafter)
```shell
$ python nextafter.py 
numpy 2.998
cupy 2.998
```

This is nextafter.py.
```
import cupy
import numpy

a = numpy.asarray(3.0, dtype='float16')
b = numpy.asarray(-1.0, dtype='float16')

print("numpy", numpy.nextafter(a, b))

cpa = cupy.array(a)
cpb = cupy.array(b)

print("cupy", cupy.nextafter(cpa, cpb))
```