### PR TITLE
[backport] Fix typo in docstring for cupy.linalg.slogdet

### DIFF
--- a/cupy/linalg/norms.py
+++ b/cupy/linalg/norms.py
@@ -180,9 +180,9 @@ def matrix_rank(M, tol=None):
 
 
 def slogdet(a):
-    """Returns sign and logarithm of the determinat of an array.
+    """Returns sign and logarithm of the determinant of an array.
 
-    It calculates the natural logarithm of the deteminant of a given value.
+    It calculates the natural logarithm of the determinant of a given value.
 
     Args:
         a (cupy.ndarray): The input matrix with dimension ``(..., N, N)``.
@@ -190,10 +190,10 @@ def slogdet(a):
     Returns:
         tuple of :class:`~cupy.ndarray`:
             It returns a tuple ``(sign, logdet)``. ``sign`` represents each
-            sign of the deteminant as a real number ``0``, ``1`` or ``-1``.
+            sign of the determinant as a real number ``0``, ``1`` or ``-1``.
             'logdet' represents the natural logarithm of the absolute of the
-            deteminant.
-            If the deteninant is zero, ``sign`` will be ``0`` and ``logdet``
+            determinant.
+            If the determinant is zero, ``sign`` will be ``0`` and ``logdet``
             will be ``-inf``.
             The shapes of both ``sign`` and ``logdet`` are equal to
             ``a.shape[:-2]``.


### PR DESCRIPTION
Backport of #1667