### PR TITLE
Add float16 support for scatter_add

### DIFF
--- a/cupy/core/carray.pxi
+++ b/cupy/core/carray.pxi
@@ -136,13 +136,14 @@ cpdef function.Module compile_with_cache(
     if _cuda_runtime_version is None:
         _cuda_runtime_version = runtime.runtimeGetVersion()
 
-    cuda_path = cuda.get_cuda_path()
-    if cuda_path is None:
-        warnings.warn('Please set the CUDA path ' +
-                      'to environment variable `CUDA_PATH`')
-    else:
-        path = os.path.join(cuda_path, 'include')
-        options += ('-I ' + path,)
+    if _cuda_runtime_version >= 9000:
+        cuda_path = cuda.get_cuda_path()
+        if cuda_path is None:
+            warnings.warn('Please set the CUDA path ' +
+                          'to environment variable `CUDA_PATH`')
+        else:
+            path = os.path.join(cuda_path, 'include')
+            options += ('-I ' + path,)
 
     return cuda.compile_with_cache(source, options, arch, cachd_dir,
                                    extra_source)

--- a/cupy/core/carray.pxi
+++ b/cupy/core/carray.pxi
@@ -136,14 +136,13 @@ cpdef function.Module compile_with_cache(
     if _cuda_runtime_version is None:
         _cuda_runtime_version = runtime.runtimeGetVersion()
 
-    if _cuda_runtime_version >= 9000:
-        cuda_path = cuda.get_cuda_path()
-        if cuda_path is None:
-            warnings.warn('Please set the CUDA path ' +
-                          'to environment variable `CUDA_PATH`')
-        else:
-            path = os.path.join(cuda_path, 'include')
-            options += ('-I ' + path,)
+    cuda_path = cuda.get_cuda_path()
+    if cuda_path is None:
+        warnings.warn('Please set the CUDA path ' +
+                      'to environment variable `CUDA_PATH`')
+    else:
+        path = os.path.join(cuda_path, 'include')
+        options += ('-I ' + path,)
 
     return cuda.compile_with_cache(source, options, arch, cachd_dir,
                                    extra_source)

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -3439,8 +3439,9 @@ cpdef _scatter_op_single(ndarray a, ndarray indices, v,
     elif op == 'add':
         # There is constraints on types because atomicAdd() in CUDA 7.5
         # only supports int32, uint32, uint64, and float32.
-        if not issubclass(v.dtype.type, (numpy.int32, numpy.float16, numpy.float32,
-                numpy.uint32, numpy.uint64, numpy.ulonglong)):
+        if not issubclass(v.dtype.type, (numpy.int32, numpy.float16,
+                                         numpy.float32, numpy.uint32,
+                                         numpy.uint64, numpy.ulonglong)):
             raise TypeError(
                 'scatter_add only supports int32, float16, float32, uint32, '
                 'uint64, as data type')

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -3439,17 +3439,11 @@ cpdef _scatter_op_single(ndarray a, ndarray indices, v,
     elif op == 'add':
         # There is constraints on types because atomicAdd() in CUDA 7.5
         # only supports int32, uint32, uint64, and float32.
-        supported_types = (numpy.int32, numpy.float32,
-                           numpy.uint32, numpy.uint64, numpy.ulonglong)
-        global _cuda_runtime_version
-        if _cuda_runtime_version is None:
-            _cuda_runtime_version = runtime.runtimeGetVersion()
-        if _cuda_runtime_version >= 9000:
-            supported_types += (numpy.float16,)
-        if not issubclass(v.dtype.type, supported_types):
+        if not issubclass(v.dtype.type, (numpy.int32, numpy.float16, numpy.float32,
+                numpy.uint32, numpy.uint64, numpy.ulonglong)):
             raise TypeError(
-                'scatter_add only supports int32, float32, uint32, uint64, '
-                'float16 (CUDA >= 9.0) as data type')
+                'scatter_add only supports int32, float16, float32, uint32, '
+                'uint64, as data type')
         _scatter_add_kernel(
             v, indices, cdim, rdim, adim, a.reduced_view())
     else:

--- a/cupy/core/include/cupy/atomics.cuh
+++ b/cupy/core/include/cupy/atomics.cuh
@@ -16,3 +16,24 @@ __device__ double atomicAdd(double *address, double val)
 }
 
 #endif
+
+#if __CUDACC_VER_MAJOR__ >= 9
+
+__device__ float16 atomicAdd(float16* address, float16 val) {
+  unsigned int *aligned = (unsigned int*)((size_t)address - ((size_t)address & 2));
+  unsigned int old = *aligned;
+  unsigned int assumed;
+  do {
+    assumed = old;
+    unsigned short old_as_us = (unsigned short)((size_t)address & 2 ? old >> 16 : old & 0xffff);
+    __half sum = __ushort_as_half(old_as_us) + __float2half((float)val);
+    unsigned short sum_as_us = __half_as_ushort(sum);
+    unsigned int sum_as_ui = (size_t)address & 2 ? (sum_as_us << 16) | (old & 0xffff)
+                                                 : (old & 0xffff0000) | sum_as_us;
+    old = atomicCAS(aligned, assumed, sum_as_ui);
+  } while(assumed != old);
+  unsigned short old_as_us = (unsigned short)((size_t)address & 2 ? old >> 16 : old & 0xffff);
+  return float16((__half_raw)__ushort_as_half(old_as_us));
+}
+
+#endif  // #if __CUDACC_VER_MAJOR__ >= 9

--- a/cupy/core/include/cupy/atomics.cuh
+++ b/cupy/core/include/cupy/atomics.cuh
@@ -25,9 +25,10 @@ __device__ float16 atomicAdd(float16* address, float16 val) {
   unsigned int *aligned = (unsigned int*)((size_t)address - ((size_t)address & 2));
   unsigned int old = *aligned;
   unsigned int assumed;
+  unsigned short old_as_us;
   do {
     assumed = old;
-    unsigned short old_as_us = (unsigned short)((size_t)address & 2 ? old >> 16 : old & 0xffff);
+    old_as_us = (unsigned short)((size_t)address & 2 ? old >> 16 : old & 0xffff);
 #if __CUDACC_VER_MAJOR__ >= 9
     unsigned short sum_as_us = __nv_float2half_rn(__nv_half2float(old_as_us) + float(val));
 #else

--- a/cupy/core/include/cupy/atomics.cuh
+++ b/cupy/core/include/cupy/atomics.cuh
@@ -35,5 +35,6 @@ __device__ float16 atomicAdd(float16* address, float16 val) {
                                                  : (old & 0xffff0000) | sum_as_us;
     old = atomicCAS(aligned, assumed, sum_as_ui);
   } while(assumed != old);
-  return float16(old_as_us);
-}
+  __half_raw raw = {old_as_us};
+  return float16(half(raw));
+};

--- a/cupy/core/include/cupy/atomics.cuh
+++ b/cupy/core/include/cupy/atomics.cuh
@@ -37,6 +37,5 @@ __device__ float16 atomicAdd(float16* address, float16 val) {
                                                  : (old & 0xffff0000) | sum_as_us;
     old = atomicCAS(aligned, assumed, sum_as_ui);
   } while(assumed != old);
-  unsigned short old_as_us = (unsigned short)((size_t)address & 2 ? old >> 16 : old & 0xffff);
   return float16(old_as_us);
 }

--- a/cupy/core/include/cupy/atomics.cuh
+++ b/cupy/core/include/cupy/atomics.cuh
@@ -26,7 +26,7 @@ __device__ float16 atomicAdd(float16* address, float16 val) {
     assumed = old;
     old_as_us = (unsigned short)((size_t)address & 2 ? old >> 16 : old & 0xffff);
 #if __CUDACC_VER_MAJOR__ >= 9
-    half sum = __ushort_as_half(old_as_us) + half(float(val));
+    half sum = __float2half_rn(__half2float(__ushort_as_half(old_as_us)) + float(val));
     unsigned short sum_as_us = __half_as_ushort(sum);
 #else
     unsigned short sum_as_us = __float2half_rn(__half2float(old_as_us) + float(val));

--- a/cupy/core/include/cupy/atomics.cuh
+++ b/cupy/core/include/cupy/atomics.cuh
@@ -17,10 +17,6 @@ __device__ double atomicAdd(double *address, double val)
 
 #endif
 
-#if __CUDACC_VER_MAJOR__ >= 9
-#include <device_functions_decls.h>
-#endif
-
 __device__ float16 atomicAdd(float16* address, float16 val) {
   unsigned int *aligned = (unsigned int*)((size_t)address - ((size_t)address & 2));
   unsigned int old = *aligned;
@@ -30,7 +26,8 @@ __device__ float16 atomicAdd(float16* address, float16 val) {
     assumed = old;
     old_as_us = (unsigned short)((size_t)address & 2 ? old >> 16 : old & 0xffff);
 #if __CUDACC_VER_MAJOR__ >= 9
-    unsigned short sum_as_us = __nv_float2half_rn(__nv_half2float(old_as_us) + float(val));
+    half sum = __ushort_as_half(old_as_us) + half(float(val));
+    unsigned short sum_as_us = __half_as_ushort(sum);
 #else
     unsigned short sum_as_us = __float2half_rn(__half2float(old_as_us) + float(val));
 #endif

--- a/cupy/core/include/cupy/atomics.cuh
+++ b/cupy/core/include/cupy/atomics.cuh
@@ -17,7 +17,9 @@ __device__ double atomicAdd(double *address, double val)
 
 #endif
 
+#if __CUDACC_VER_MAJOR__ >= 9
 #include <device_functions_decls.h>
+#endif
 
 __device__ float16 atomicAdd(float16* address, float16 val) {
   unsigned int *aligned = (unsigned int*)((size_t)address - ((size_t)address & 2));
@@ -26,7 +28,11 @@ __device__ float16 atomicAdd(float16* address, float16 val) {
   do {
     assumed = old;
     unsigned short old_as_us = (unsigned short)((size_t)address & 2 ? old >> 16 : old & 0xffff);
+#if __CUDACC_VER_MAJOR__ >= 9
     unsigned short sum_as_us = __nv_float2half_rn(__nv_half2float(old_as_us) + float(val));
+#else
+    unsigned short sum_as_us = __float2half_rn(__half2float(old_as_us) + float(val));
+#endif
     unsigned int sum_as_ui = (size_t)address & 2 ? (sum_as_us << 16) | (old & 0xffff)
                                                  : (old & 0xffff0000) | sum_as_us;
     old = atomicCAS(aligned, assumed, sum_as_ui);

--- a/tests/cupy_tests/core_tests/test_ndarray_scatter.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_scatter.py
@@ -4,7 +4,6 @@ import numpy
 
 import cupy
 from cupy import testing
-import pytest
 
 
 @testing.parameterize(

--- a/tests/cupy_tests/core_tests/test_ndarray_scatter.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_scatter.py
@@ -116,9 +116,6 @@ class TestScatterAddParametrized(unittest.TestCase):
                          numpy.uint64, numpy.ulonglong, numpy.float16])
     @testing.numpy_cupy_array_equal()
     def test_scatter_add(self, xp, dtype):
-        if (cupy.cuda.runtime.runtimeGetVersion() < 9000 and
-                dtype == numpy.float16):
-            pytest.skip()
         a = xp.zeros(self.shape, dtype)
         if xp is cupy:
             a.scatter_add(self.slices, self.value)
@@ -133,9 +130,6 @@ class TestScatterAdd(unittest.TestCase):
     @testing.for_dtypes([numpy.float32, numpy.int32, numpy.uint32,
                          numpy.uint64, numpy.ulonglong, numpy.float16])
     def test_scatter_add_cupy_arguments(self, dtype):
-        if (cupy.cuda.runtime.runtimeGetVersion() < 9000 and
-                dtype == numpy.float16):
-            pytest.skip()
         shape = (2, 3)
         a = cupy.zeros(shape, dtype)
         slices = (cupy.array([1, 1]), slice(None))
@@ -146,9 +140,6 @@ class TestScatterAdd(unittest.TestCase):
     @testing.for_dtypes([numpy.float32, numpy.int32, numpy.uint32,
                          numpy.uint64, numpy.ulonglong, numpy.float16])
     def test_scatter_add_cupy_arguments_mask(self, dtype):
-        if (cupy.cuda.runtime.runtimeGetVersion() < 9000 and
-                dtype == numpy.float16):
-            pytest.skip()
         shape = (2, 3)
         a = cupy.zeros(shape, dtype)
         slices = (cupy.array([True, False]), slice(None))
@@ -160,9 +151,6 @@ class TestScatterAdd(unittest.TestCase):
         [numpy.float32, numpy.int32, numpy.uint32, numpy.uint64,
          numpy.ulonglong, numpy.float16], names=['src_dtype', 'dst_dtype'])
     def test_scatter_add_differnt_dtypes(self, src_dtype, dst_dtype):
-        if (cupy.cuda.runtime.runtimeGetVersion() < 9000 and
-                numpy.float16 in (src_dtype, dst_dtype)):
-            pytest.skip()
         shape = (2, 3)
         a = cupy.zeros(shape, dtype=src_dtype)
         value = cupy.array(1, dtype=dst_dtype)
@@ -177,9 +165,6 @@ class TestScatterAdd(unittest.TestCase):
         [numpy.float32, numpy.int32, numpy.uint32, numpy.uint64,
          numpy.ulonglong, numpy.float16], names=['src_dtype', 'dst_dtype'])
     def test_scatter_add_differnt_dtypes_mask(self, src_dtype, dst_dtype):
-        if (cupy.cuda.runtime.runtimeGetVersion() < 9000 and
-                numpy.float16 in (src_dtype, dst_dtype)):
-            pytest.skip()
         shape = (2, 3)
         a = cupy.zeros(shape, dtype=src_dtype)
         value = cupy.array(1, dtype=dst_dtype)

--- a/tests/cupy_tests/core_tests/test_ndarray_scatter.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_scatter.py
@@ -4,6 +4,7 @@ import numpy
 
 import cupy
 from cupy import testing
+import pytest
 
 
 @testing.parameterize(
@@ -112,9 +113,12 @@ from cupy import testing
 class TestScatterAddParametrized(unittest.TestCase):
 
     @testing.for_dtypes([numpy.float32, numpy.int32, numpy.uint32,
-                         numpy.uint64, numpy.ulonglong])
+                         numpy.uint64, numpy.ulonglong, numpy.float16])
     @testing.numpy_cupy_array_equal()
     def test_scatter_add(self, xp, dtype):
+        if (cupy.cuda.runtime.runtimeGetVersion() < 9000 and
+                dtype == numpy.float16):
+            pytest.skip()
         a = xp.zeros(self.shape, dtype)
         if xp is cupy:
             a.scatter_add(self.slices, self.value)
@@ -127,8 +131,11 @@ class TestScatterAddParametrized(unittest.TestCase):
 class TestScatterAdd(unittest.TestCase):
 
     @testing.for_dtypes([numpy.float32, numpy.int32, numpy.uint32,
-                         numpy.uint64, numpy.ulonglong])
+                         numpy.uint64, numpy.ulonglong, numpy.float16])
     def test_scatter_add_cupy_arguments(self, dtype):
+        if (cupy.cuda.runtime.runtimeGetVersion() < 9000 and
+                dtype == numpy.float16):
+            pytest.skip()
         shape = (2, 3)
         a = cupy.zeros(shape, dtype)
         slices = (cupy.array([1, 1]), slice(None))
@@ -137,8 +144,11 @@ class TestScatterAdd(unittest.TestCase):
             a, cupy.array([[0., 0., 0.], [2., 2., 2.]], dtype))
 
     @testing.for_dtypes([numpy.float32, numpy.int32, numpy.uint32,
-                         numpy.uint64, numpy.ulonglong])
+                         numpy.uint64, numpy.ulonglong, numpy.float16])
     def test_scatter_add_cupy_arguments_mask(self, dtype):
+        if (cupy.cuda.runtime.runtimeGetVersion() < 9000 and
+                dtype == numpy.float16):
+            pytest.skip()
         shape = (2, 3)
         a = cupy.zeros(shape, dtype)
         slices = (cupy.array([True, False]), slice(None))
@@ -148,8 +158,11 @@ class TestScatterAdd(unittest.TestCase):
 
     @testing.for_dtypes_combination(
         [numpy.float32, numpy.int32, numpy.uint32, numpy.uint64,
-         numpy.ulonglong], names=['src_dtype', 'dst_dtype'])
+         numpy.ulonglong, numpy.float16], names=['src_dtype', 'dst_dtype'])
     def test_scatter_add_differnt_dtypes(self, src_dtype, dst_dtype):
+        if (cupy.cuda.runtime.runtimeGetVersion() < 9000 and
+                numpy.float16 in (src_dtype, dst_dtype)):
+            pytest.skip()
         shape = (2, 3)
         a = cupy.zeros(shape, dtype=src_dtype)
         value = cupy.array(1, dtype=dst_dtype)
@@ -162,8 +175,11 @@ class TestScatterAdd(unittest.TestCase):
 
     @testing.for_dtypes_combination(
         [numpy.float32, numpy.int32, numpy.uint32, numpy.uint64,
-         numpy.ulonglong], names=['src_dtype', 'dst_dtype'])
+         numpy.ulonglong, numpy.float16], names=['src_dtype', 'dst_dtype'])
     def test_scatter_add_differnt_dtypes_mask(self, src_dtype, dst_dtype):
+        if (cupy.cuda.runtime.runtimeGetVersion() < 9000 and
+                numpy.float16 in (src_dtype, dst_dtype)):
+            pytest.skip()
         shape = (2, 3)
         a = cupy.zeros(shape, dtype=src_dtype)
         value = cupy.array(1, dtype=dst_dtype)


### PR DESCRIPTION
This pull request adds float16 support for `scatter_add` by implementing float16 version of `atomicAdd()` (`atomicCAS` with 32bit memory alignment) and works with CUDA 9.0 and later.

[In CUDA 10, 16bit __half floating point version of `atomicAdd()` is introduced](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#atomicadd), and maybe its faster than this implementation, but this works on more devices for now.
