### PR TITLE
Fix cupy.random.hypergeometric

### DIFF
--- a/cupy/random/_kernels.py
+++ b/cupy/random/_kernels.py
@@ -626,6 +626,7 @@ __device__ long rk_geometric(rk_state *state, double p) {
 }
 '''
 
+# min and max for the long type are not defined in cuda75
 long_min_max_definition = '''
 __device__ long long_min(long a, long b)
 {

--- a/cupy/random/_kernels.py
+++ b/cupy/random/_kernels.py
@@ -627,12 +627,12 @@ __device__ long rk_geometric(rk_state *state, double p) {
 '''
 
 long_min_max_definition = '''
-__device__ long min(long a, long b)
+__device__ long long_min(long a, long b)
 {
     return a < b ? a : b;
 }
 
-__device__ long max(long a, long b)
+__device__ long long_max(long a, long b)
 {
     return a > b ? a : b;
 }
@@ -646,7 +646,7 @@ __device__ long rk_hypergeometric_hyp(
     double d2, U, Y;
 
     d1 = bad + good - sample;
-    d2 = (double)min(bad, good);
+    d2 = (double)long_min(bad, good);
 
     Y = d2;
     K = sample;
@@ -674,10 +674,10 @@ __device__ long rk_hypergeometric_hrua(
     long Z;
     double T, W, X, Y;
 
-    mingoodbad = min(good, bad);
+    mingoodbad = long_min(good, bad);
     popsize = good + bad;
-    maxgoodbad = max(good, bad);
-    m = min(sample, popsize - sample);
+    maxgoodbad = long_max(good, bad);
+    m = long_min(sample, popsize - sample);
     d4 = ((double)mingoodbad) / popsize;
     d5 = 1.0 - d4;
     d6 = m*d4 + 0.5;
@@ -686,7 +686,7 @@ __device__ long rk_hypergeometric_hrua(
     d9 = (long)floor((double)(m + 1) * (mingoodbad + 1) / (popsize + 2));
     d10 = (loggam(d9+1) + loggam(mingoodbad-d9+1) + loggam(m-d9+1) +
            loggam(maxgoodbad-m+d9+1));
-    d11 = min(min(m, mingoodbad)+1.0, floor(d6+16*d7));
+    d11 = min(long_min(m, mingoodbad)+1.0, floor(d6+16*d7));
     /* 16 for 16-decimal-digit precision in D1 and D2 */
 
     while (1)

--- a/cupy/random/_kernels.py
+++ b/cupy/random/_kernels.py
@@ -626,7 +626,7 @@ __device__ long rk_geometric(rk_state *state, double p) {
 }
 '''
 
-# min and max for the long type are not defined in cuda75
+# min and max for the long type are not defined in cuda90 but in cuda75.
 long_min_max_definition = '''
 __device__ long long_min(long a, long b)
 {

--- a/cupy/random/_kernels.py
+++ b/cupy/random/_kernels.py
@@ -626,18 +626,6 @@ __device__ long rk_geometric(rk_state *state, double p) {
 }
 '''
 
-long_min_max_definition = '''
-__device__ long min(long a, long b)
-{
-    return a < b ? a : b;
-}
-
-__device__ long max(long a, long b)
-{
-    return a > b ? a : b;
-}
-'''
-
 rk_hypergeometric_definition = '''
 __device__ long rk_hypergeometric_hyp(
     rk_state *state, long good, long bad, long sample)
@@ -646,7 +634,7 @@ __device__ long rk_hypergeometric_hyp(
     double d2, U, Y;
 
     d1 = bad + good - sample;
-    d2 = (double)min(bad, good);
+    d2 = (double)(bad < good ? bad : good);  // min(bad, good);
 
     Y = d2;
     K = sample;
@@ -674,9 +662,9 @@ __device__ long rk_hypergeometric_hrua(
     long Z;
     double T, W, X, Y;
 
-    mingoodbad = min(good, bad);
+    mingoodbad = good < bad ? good : bad;
     popsize = good + bad;
-    maxgoodbad = max(good, bad);
+    maxgoodbad = good > bad ? good : bad;
     m = min(sample, popsize - sample);
     d4 = ((double)mingoodbad) / popsize;
     d5 = 1.0 - d4;
@@ -893,7 +881,7 @@ geometric_kernel = core.ElementwiseKernel(
 )
 
 definitions = \
-    [rk_basic_definition, loggam_definition, long_min_max_definition,
+    [rk_basic_definition, loggam_definition,
      rk_hypergeometric_definition]
 hypergeometric_kernel = core.ElementwiseKernel(
     'S good, T bad, U sample, uint32 seed', 'Y y',

--- a/cupy/random/_kernels.py
+++ b/cupy/random/_kernels.py
@@ -626,6 +626,18 @@ __device__ long rk_geometric(rk_state *state, double p) {
 }
 '''
 
+long_min_max_definition = '''
+__device__ long min(long a, long b)
+{
+    return a < b ? a : b;
+}
+
+__device__ long max(long a, long b)
+{
+    return a > b ? a : b;
+}
+'''
+
 rk_hypergeometric_definition = '''
 __device__ long rk_hypergeometric_hyp(
     rk_state *state, long good, long bad, long sample)
@@ -634,7 +646,7 @@ __device__ long rk_hypergeometric_hyp(
     double d2, U, Y;
 
     d1 = bad + good - sample;
-    d2 = (double)(bad < good ? bad : good);  // min(bad, good);
+    d2 = (double)min(bad, good);
 
     Y = d2;
     K = sample;
@@ -662,9 +674,9 @@ __device__ long rk_hypergeometric_hrua(
     long Z;
     double T, W, X, Y;
 
-    mingoodbad = good < bad ? good : bad;
+    mingoodbad = min(good, bad);
     popsize = good + bad;
-    maxgoodbad = good > bad ? good : bad;
+    maxgoodbad = max(good, bad);
     m = min(sample, popsize - sample);
     d4 = ((double)mingoodbad) / popsize;
     d5 = 1.0 - d4;
@@ -881,7 +893,7 @@ geometric_kernel = core.ElementwiseKernel(
 )
 
 definitions = \
-    [rk_basic_definition, loggam_definition,
+    [rk_basic_definition, loggam_definition, long_min_max_definition,
      rk_hypergeometric_definition]
 hypergeometric_kernel = core.ElementwiseKernel(
     'S good, T bad, U sample, uint32 seed', 'Y y',


### PR DESCRIPTION
This PR fixes the nvrtc error:
```
link error: Linking globals named '_Z3minll': symbol multiply defined!
```

See the results of the daily tests on Jenkins.