### PR TITLE
Fix `ndarray.__iter__`

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1583,7 +1583,7 @@ cdef class ndarray:
     def __iter__(self):
         if self._shape.size() == 0:
             raise TypeError('iteration over a 0-d array')
-        return self[i] for i in six.moves.range(self._shape[0])
+        return (self[i] for i in six.moves.range(self._shape[0]))
 
     def __len__(self):
         if self._shape.size() == 0:

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1583,8 +1583,7 @@ cdef class ndarray:
     def __iter__(self):
         if self._shape.size() == 0:
             raise TypeError('iteration over a 0-d array')
-        for i in six.moves.range(self._shape[0]):
-            yield self[i]
+        return self[i] for i in six.moves.range(self._shape[0])
 
     def __len__(self):
         if self._shape.size() == 0:

--- a/tests/cupy_tests/core_tests/test_iter.py
+++ b/tests/cupy_tests/core_tests/test_iter.py
@@ -27,9 +27,9 @@ class TestIterInvalid(unittest.TestCase):
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_raises()
-    def test_list(self, xp, dtype):
+    def test_iter(self, xp, dtype):
         x = testing.shaped_arange((), xp, dtype)
-        list(x)
+        iter(x)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_raises()


### PR DESCRIPTION
`TypeError` should be raised as soon as `__iter__` is called.  Before this PR,
```
=============== FAILURES ===============
______ TestIterInvalid.test_iter _______
cupy/testing/helper.py:587: in test_func
    impl(self, *args, **kw)
cupy/testing/helper.py:564: in test_func
    accept_error=accept_error)
cupy/testing/helper.py:50: in _check_cupy_numpy_error
    self.fail('Only numpy raises error\n\n' + numpy_tb)
E   AssertionError: Only numpy raises error
E
E   Traceback (most recent call last):
E     File "/home/kataoka/cupy/cupy/testing/helper.py", line 555, in test_func
E       impl(self, *args, **kw)
E     File "/home/kataoka/cupy/test_tmp.py", line 32, in test_iter
E       iter(x)
E   TypeError: iteration over a 0-d array
--------- Captured stdout call ---------
dtype is <class 'numpy.float64'>
```

#1449