### PR TITLE
[backport] Fix `ndarray.__iter__`

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1583,8 +1583,7 @@ cdef class ndarray:
     def __iter__(self):
         if self._shape.size() == 0:
             raise TypeError('iteration over a 0-d array')
-        for i in six.moves.range(self._shape[0]):
-            yield self[i]
+        return (self[i] for i in six.moves.range(self._shape[0]))
 
     def __len__(self):
         if self._shape.size() == 0:

--- a/tests/cupy_tests/core_tests/test_iter.py
+++ b/tests/cupy_tests/core_tests/test_iter.py
@@ -27,9 +27,9 @@ class TestIterInvalid(unittest.TestCase):
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_raises()
-    def test_list(self, xp, dtype):
+    def test_iter(self, xp, dtype):
         x = testing.shaped_arange((), xp, dtype)
-        list(x)
+        iter(x)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_raises()


### PR DESCRIPTION
Backport of #1697