### PR TITLE
Ignore scipy<1.0 is warned by using deprecated feature of numpy>=1.15 

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,9 @@ filterwarnings= ignore::FutureWarning
                 # importing old SciPy is warned because it tries to
                 # import nose via numpy.testing
                 ignore::DeprecationWarning:scipy._lib._numpy_compat
+                # importing stats from old SciPy is warned because it tries to
+                # import numpy.testing.decorators
+                ignore::DeprecationWarning:scipy.stats.morestats
 
 [metadata]
 license_file = docs/source/license.rst

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,9 @@ filterwarnings= ignore::FutureWarning
                 ignore::UserWarning
                 error::DeprecationWarning
                 error::numpy.ComplexWarning
+                # importing old SciPy is warned because it tries to
+                # import nose via numpy.testing
+                ignore::DeprecationWarning:scipy._lib._numpy_compat
 
 [metadata]
 license_file = docs/source/license.rst


### PR DESCRIPTION
To support NumPy 1.15