### PR TITLE
[backport] Support `astype` in fused functions

### DIFF
--- a/cupy/core/fusion.py
+++ b/cupy/core/fusion.py
@@ -8,6 +8,7 @@ import warnings
 import numpy
 
 import cupy
+from cupy.core._dtype import get_dtype
 from cupy.core import core
 
 
@@ -339,6 +340,18 @@ class FusionVarPython(object):
 
     def copy(self):
         return cupy.copy(self)
+
+    def astype(self, dtype, order=None, casting=None, subok=None, copy=True):
+        dtype = get_dtype(dtype)
+        if order is not None:
+            raise TypeError('order is not supported yet')
+        if casting is not None:
+            raise TypeError('casting is not supported yet')
+        if subok is not None:
+            raise TypeError('subok is not supported yet')
+        if not copy and self.dtype == dtype:
+            return self
+        return _dtype_to_astype[dtype](self)
 
 
 class _FusionHistory(object):
@@ -848,3 +861,15 @@ def _reduction_wrapper(fusion_op):
                 True)
         return functools.update_wrapper(call, f)
     return func
+
+
+def _create_astype_ufunc(dtype):
+    name = 'astype_{}'.format(dtype)
+    rules = tuple(['{}->{}'.format(cast_from.char, dtype.char)
+                   for cast_from in _dtype_list])
+    command = 'out0 = static_cast<{}>(in0)'.format(_dtype_to_ctype[dtype])
+    return core.create_ufunc(name, rules, command)
+
+
+_dtype_to_astype = dict([(dtype, _create_astype_ufunc(dtype))
+                         for dtype in _dtype_list])

--- a/tests/cupy_tests/core_tests/test_fusion.py
+++ b/tests/cupy_tests/core_tests/test_fusion.py
@@ -990,6 +990,18 @@ class TestFusionMisc(unittest.TestCase):
     def test_fmin_nan(self):
         self.check_binary_nan('fmin')
 
+    @testing.for_all_dtypes_combination(
+        names=['src_dtype', 'dst_dtype'], no_complex=True)
+    @testing.numpy_cupy_array_equal()
+    def test_astype_class(self, xp, src_dtype, dst_dtype):
+
+        @cupy.fuse()
+        def f(x):
+            return x.astype(dst_dtype)
+
+        x = xp.arange(6).astype(src_dtype).reshape(2, 3)
+        return f(x)
+
 
 @testing.gpu
 class TestFusionFuse(unittest.TestCase):


### PR DESCRIPTION
Backport of #1586