### PR TITLE
 Remove unnecessary intermediate data in FP16 atomicAdd

### DIFF
--- a/cupy/core/include/cupy/atomics.cuh
+++ b/cupy/core/include/cupy/atomics.cuh
@@ -36,5 +36,5 @@ __device__ float16 atomicAdd(float16* address, float16 val) {
     old = atomicCAS(aligned, assumed, sum_as_ui);
   } while(assumed != old);
   __half_raw raw = {old_as_us};
-  return float16(half(raw));
+  return float16(raw);
 };


### PR DESCRIPTION
Since `float16` constructor accepts `__half_raw`, we can remove intermediate `half` construction.