### PR TITLE
Support float64 in scatter_add

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -3438,9 +3438,10 @@ cpdef _scatter_op_single(ndarray a, ndarray indices, v,
     elif op == 'add':
         # There is constraints on types because atomicAdd() in CUDA 7.5
         # only supports int32, uint32, uint64, and float32.
-        if not issubclass(v.dtype.type, (numpy.int32, numpy.float16,
-                                         numpy.float32, numpy.float64, numpy.uint32,
-                                         numpy.uint64, numpy.ulonglong)):
+        if not issubclass(v.dtype.type,
+                          (numpy.int32, numpy.float16, numpy.float32,
+                           numpy.float64, numpy.uint32, numpy.uint64,
+                           numpy.ulonglong)):
             raise TypeError(
                 'scatter_add only supports int32, float16, float32, float64, '
                 'uint32, uint64, as data type')

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -3439,11 +3439,11 @@ cpdef _scatter_op_single(ndarray a, ndarray indices, v,
         # There is constraints on types because atomicAdd() in CUDA 7.5
         # only supports int32, uint32, uint64, and float32.
         if not issubclass(v.dtype.type, (numpy.int32, numpy.float16,
-                                         numpy.float32, numpy.uint32,
+                                         numpy.float32, numpy.float64, numpy.uint32,
                                          numpy.uint64, numpy.ulonglong)):
             raise TypeError(
-                'scatter_add only supports int32, float16, float32, uint32, '
-                'uint64, as data type')
+                'scatter_add only supports int32, float16, float32, float64, '
+                'uint32, uint64, as data type')
         _scatter_add_kernel(
             v, indices, cdim, rdim, adim, a.reduced_view())
     else:

--- a/tests/cupy_tests/core_tests/test_ndarray_scatter.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_scatter.py
@@ -112,7 +112,8 @@ from cupy import testing
 class TestScatterAddParametrized(unittest.TestCase):
 
     @testing.for_dtypes([numpy.float32, numpy.int32, numpy.uint32,
-                         numpy.uint64, numpy.ulonglong, numpy.float16])
+                         numpy.uint64, numpy.ulonglong, numpy.float16,
+                         numpy.float64])
     @testing.numpy_cupy_array_equal()
     def test_scatter_add(self, xp, dtype):
         a = xp.zeros(self.shape, dtype)
@@ -127,7 +128,8 @@ class TestScatterAddParametrized(unittest.TestCase):
 class TestScatterAdd(unittest.TestCase):
 
     @testing.for_dtypes([numpy.float32, numpy.int32, numpy.uint32,
-                         numpy.uint64, numpy.ulonglong, numpy.float16])
+                         numpy.uint64, numpy.ulonglong, numpy.float16,
+                         numpy.float64])
     def test_scatter_add_cupy_arguments(self, dtype):
         shape = (2, 3)
         a = cupy.zeros(shape, dtype)
@@ -137,7 +139,8 @@ class TestScatterAdd(unittest.TestCase):
             a, cupy.array([[0., 0., 0.], [2., 2., 2.]], dtype))
 
     @testing.for_dtypes([numpy.float32, numpy.int32, numpy.uint32,
-                         numpy.uint64, numpy.ulonglong, numpy.float16])
+                         numpy.uint64, numpy.ulonglong, numpy.float16,
+                         numpy.float64])
     def test_scatter_add_cupy_arguments_mask(self, dtype):
         shape = (2, 3)
         a = cupy.zeros(shape, dtype)
@@ -148,7 +151,8 @@ class TestScatterAdd(unittest.TestCase):
 
     @testing.for_dtypes_combination(
         [numpy.float32, numpy.int32, numpy.uint32, numpy.uint64,
-         numpy.ulonglong, numpy.float16], names=['src_dtype', 'dst_dtype'])
+         numpy.ulonglong, numpy.float16, numpy.float64],
+        names=['src_dtype', 'dst_dtype'])
     def test_scatter_add_differnt_dtypes(self, src_dtype, dst_dtype):
         shape = (2, 3)
         a = cupy.zeros(shape, dtype=src_dtype)
@@ -162,7 +166,8 @@ class TestScatterAdd(unittest.TestCase):
 
     @testing.for_dtypes_combination(
         [numpy.float32, numpy.int32, numpy.uint32, numpy.uint64,
-         numpy.ulonglong, numpy.float16], names=['src_dtype', 'dst_dtype'])
+         numpy.ulonglong, numpy.float16, numpy.float64],
+        names=['src_dtype', 'dst_dtype'])
     def test_scatter_add_differnt_dtypes_mask(self, src_dtype, dst_dtype):
         shape = (2, 3)
         a = cupy.zeros(shape, dtype=src_dtype)


### PR DESCRIPTION
This PR add support for FP64 in `scatter_add`.