### PR TITLE
Fix ufunc performance degradation

### DIFF
--- a/cupy/core/_kernel.pyx
+++ b/cupy/core/_kernel.pyx
@@ -4,6 +4,7 @@ import string
 import numpy
 
 from cupy.cuda import compiler
+from cupy.core import fusion
 from cupy import util
 
 cimport cpython  # NOQA
@@ -756,8 +757,6 @@ class ufunc(object):
             Output array or a tuple of output arrays.
 
         """
-        from cupy.core import fusion
-
         thread_local = fusion._thread_local
         if hasattr(thread_local, 'history'):
             return thread_local.history.call_ufunc(self, args, kwargs)

--- a/cupy/core/fusion.py
+++ b/cupy/core/fusion.py
@@ -878,6 +878,6 @@ def _dtype_to_astype(dtype):
     global _dtype_to_astype_dict
     if _dtype_to_astype_dict is None:
         _dtype_to_astype_dict = dict([
-            (dtype, _create_astype_ufunc(dtype))
-            for dtype in _dtype_list])
+            (dt, _create_astype_ufunc(dt))
+            for dt in _dtype_list])
     return _dtype_to_astype_dict[dtype]

--- a/cupy/core/fusion.py
+++ b/cupy/core/fusion.py
@@ -351,7 +351,7 @@ class FusionVarPython(object):
             raise TypeError('subok is not supported yet')
         if not copy and self.dtype == dtype:
             return self
-        return _dtype_to_astype[dtype](self)
+        return _dtype_to_astype(dtype)(self)
 
 
 class _FusionHistory(object):
@@ -871,5 +871,13 @@ def _create_astype_ufunc(dtype):
     return core.create_ufunc(name, rules, command)
 
 
-_dtype_to_astype = dict([(dtype, _create_astype_ufunc(dtype))
-                         for dtype in _dtype_list])
+_dtype_to_astype_dict = None
+
+
+def _dtype_to_astype(dtype):
+    global _dtype_to_astype_dict
+    if _dtype_to_astype_dict is None:
+        _dtype_to_astype_dict = dict([
+            (dtype, _create_astype_ufunc(dtype))
+            for dtype in _dtype_list])
+    return _dtype_to_astype_dict[dtype]


### PR DESCRIPTION
Fixes degradation introduced in https://github.com/cupy/cupy/commit/860a0c19157b7bb31b2f88a5378f18ab410adcf4#diff-e2a721d3ce2742c7fd3e3e565742b7feR757.

Before this PR
```
empty               :     0.249 us   +/- 0.115 (min:    0.212) us
sum                 :    30.966 us   +/- 1.153 (min:   29.550) us
sum_huge            :    33.688 us   +/-28.630 (min:   27.795) us
add                 :    83.483 us   +/-18.837 (min:   80.957) us
add_out             :    79.505 us   +/- 2.171 (min:   77.337) us
add_out_huge        :    81.218 us   +/- 3.399 (min:   78.210) us
userkernel_create   :     3.873 us   +/- 0.304 (min:    3.694) us
userkenel           :    11.117 us   +/- 0.519 (min:   10.682) us
userkernel_huge     :    12.456 us   +/- 2.327 (min:   10.950) us
```

This PR:
```
empty               :     0.208 us   +/- 0.026 (min:    0.187) us
sum                 :    30.402 us   +/- 1.419 (min:   28.813) us
sum_huge            :    32.036 us   +/-14.739 (min:   28.718) us
add                 :    19.512 us   +/- 1.074 (min:   18.538) us
add_out             :    17.452 us   +/- 1.311 (min:   16.667) us
add_out_huge        :    18.563 us   +/- 1.951 (min:   17.158) us
userkernel_create   :     3.830 us   +/- 0.414 (min:    3.677) us
userkenel           :    16.544 us   +/- 7.608 (min:   11.174) us
userkernel_huge     :    12.706 us   +/- 5.114 (min:   11.339) us
```