### PR TITLE
[backport] Drop support for CUDA 7.0 / 7.5

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -25,7 +25,7 @@ You need to have the following components to use CuPy.
 * `NVIDIA CUDA GPU <https://developer.nvidia.com/cuda-gpus>`_
     * Compute Capability of the GPU must be at least 3.0.
 * `CUDA Toolkit <https://developer.nvidia.com/cuda-zone>`_
-    * Supported Versions: 7.0, 7.5, 8.0, 9.0, 9.1 and 9.2.
+    * Supported Versions: 8.0, 9.0, 9.1 and 9.2.
     * If you have multiple versions of CUDA Toolkit installed, CuPy will choose one of the CUDA installations automatically.
       See :ref:`install_cuda` for details.
 * `Python <https://python.org/>`_
@@ -44,7 +44,7 @@ Optional Libraries
 Some features in CuPy will only be enabled if the corresponding libraries are installed.
 
 * `cuDNN <https://developer.nvidia.com/cudnn>`_ (library to accelerate deep neural network computations)
-    * Supported Versions: v4, v5, v5.1, v6, v7, v7.1 and v7.2.
+    * Supported Versions: v5, v5.1, v6, v7, v7.1 and v7.2.
 * `NCCL <https://developer.nvidia.com/nccl>`_  (library to perform collective multi-GPU / multi-node computations)
     * Supported Versions: v1.3.4, v2, v2.1 and v2.2.
 

--- a/docs/source/upgrade.rst
+++ b/docs/source/upgrade.rst
@@ -28,6 +28,7 @@ Update of Docker Images
 CuPy official Docker images (see :doc:`install` for details) are now updated to use CUDA 9.2 and cuDNN 7.
 
 To use these images, you may need to upgrade the NVIDIA driver on your host.
+See `Requirements of nvidia-docker <https://github.com/NVIDIA/nvidia-docker/wiki/CUDA#requirements>`_ for details.
 
 
 CuPy v4

--- a/docs/source/upgrade.rst
+++ b/docs/source/upgrade.rst
@@ -17,13 +17,17 @@ CuPy v5
 :mod:`cupyx.scipy` namespace has been introduced to provide CUDA-enabled SciPy functions.
 :mod:`cupy.sparse` module has been renamed to :mod:`cupyx.scipy.sparse`; :mod:`cupy.sparse` will be kept as an alias for backward compatibility.
 
+Dropped Support for CUDA 7.0 / 7.5
+----------------------------------
+
+CuPy v5 no longer supports CUDA 7.0 / 7.5.
+
 Update of Docker Images
 -----------------------
 
 CuPy official Docker images (see :doc:`install` for details) are now updated to use CUDA 9.2 and cuDNN 7.
 
 To use these images, you may need to upgrade the NVIDIA driver on your host.
-See `Requirements of nvidia-docker <https://github.com/NVIDIA/nvidia-docker/wiki/CUDA#requirements>`_ for details.
 
 
 CuPy v4


### PR DESCRIPTION
This PR is backport of #1722 