### PR TITLE
Fix DropoutStates interface to avoid using cuDNN handle

### DIFF
--- a/cupy/cudnn.pyx
+++ b/cupy/cudnn.pyx
@@ -508,6 +508,10 @@ class DropoutStates(object):
             cudnn_handle, 0., self._states.ptr,
             state_size, seed)
 
+    def set_dropout_ratio(self, dropout_ratio):
+        cudnn_handle = get_handle()
+        set_dropout_descriptor(self._desc, cudnn_handle, dropout_ratio)
+
     def forward(self, handle, core.ndarray x, dropout_ratio):
         cdef core.ndarray y, reserve_space
         cdef size_t cudnn_handle

--- a/cupy/cudnn.pyx
+++ b/cupy/cudnn.pyx
@@ -497,15 +497,25 @@ cpdef bint is_tensor_core_available(dtype) except *:
 class DropoutStates(object):
 
     def __init__(self, handle, seed):
-        state_size = cudnn.dropoutGetStatesSize(handle)
+        cdef size_t cudnn_handle
+        if handle is None:
+            cudnn_handle = get_handle()
+        else:
+            cudnn_handle = handle
+        state_size = cudnn.dropoutGetStatesSize(cudnn_handle)
         self._states = memory.alloc(state_size)
         self._desc = create_dropout_descriptor(
-            handle, 0., self._states.ptr,
+            cudnn_handle, 0., self._states.ptr,
             state_size, seed)
 
     def forward(self, handle, core.ndarray x, dropout_ratio):
         cdef core.ndarray y, reserve_space
-        set_dropout_descriptor(self._desc, handle, dropout_ratio)
+        cdef size_t cudnn_handle
+        if handle is None:
+            cudnn_handle = get_handle()
+        else:
+            cudnn_handle = handle
+        set_dropout_descriptor(self._desc, cudnn_handle, dropout_ratio)
 
         x = core.ascontiguousarray(x)
         y = core.ndarray(x._shape, x.dtype)
@@ -516,7 +526,7 @@ class DropoutStates(object):
             reserve_size = cudnn.getDropoutReserveSpaceSize(x_desc)
             reserve_space = core.ndarray((reserve_size,), 'b')
 
-            cudnn.dropoutForward(handle, self._desc.value,
+            cudnn.dropoutForward(cudnn_handle, self._desc.value,
                                  x_desc, x.data.ptr, x_desc, y.data.ptr,
                                  reserve_space.data.ptr, reserve_size)
         finally:
@@ -526,7 +536,12 @@ class DropoutStates(object):
     def backward(self, handle, core.ndarray dy, dropout_ratio,
                  core.ndarray reserve_space):
         cdef core.ndarray dx
-        set_dropout_descriptor(self._desc, handle, dropout_ratio)
+        cdef size_t cudnn_handle
+        if handle is None:
+            cudnn_handle = get_handle()
+        else:
+            cudnn_handle = handle
+        set_dropout_descriptor(self._desc, cudnn_handle, dropout_ratio)
 
         dy = core.ascontiguousarray(dy)
         dx = core.ndarray(dy._shape, dy.dtype)
@@ -534,7 +549,7 @@ class DropoutStates(object):
         dy_desc = cudnn.createTensorDescriptor()
         try:
             _create_tensor_descriptor_as4darray(dy_desc, dy)
-            cudnn.dropoutBackward(handle, self._desc.value,
+            cudnn.dropoutBackward(cudnn_handle, self._desc.value,
                                   dy_desc, dy.data.ptr,
                                   dy_desc, dx.data.ptr,
                                   reserve_space.data.ptr,

--- a/tests/cupy_tests/test_cudnn.py
+++ b/tests/cupy_tests/test_cudnn.py
@@ -80,19 +80,19 @@ class TestCudnnDropout(unittest.TestCase):
     def setUp(self):
         self.x = testing.shaped_arange((3, 4), cupy, self.dtype)
         self.gy = testing.shaped_arange((3, 4), cupy, self.dtype)
-        self.states = cudnn.DropoutStates(cudnn.get_handle(), self.seed)
+        self.states = cudnn.DropoutStates(None, self.seed)
 
     def test_dropout_forward(self):
-        _, y = self.states.forward(cudnn.get_handle(), self.x, self.ratio)
+        _, y = self.states.forward(None, self.x, self.ratio)
         if self.ratio == 0:
             self.assertTrue(cupy.all(self.x == y))
         else:
             self.assertTrue(cupy.all(self.x != y))
 
     def test_dropout_backward(self):
-        rspace, y = self.states.forward(cudnn.get_handle(), self.x, self.ratio)
+        rspace, y = self.states.forward(None, self.x, self.ratio)
         gx = self.states.backward(
-            cudnn.get_handle(), self.gy, self.ratio, rspace)
+            None, self.gy, self.ratio, rspace)
 
         forward_mask = y / self.x
         backward_mask = gx / self.gy
@@ -101,18 +101,16 @@ class TestCudnnDropout(unittest.TestCase):
         self.assertTrue(cupy.all(forward_mask == backward_mask))
 
     def test_dropout_seed(self):
-        handle = cudnn.get_handle()
-
         # initialize Dropoutstates with the same seed
-        states2 = cudnn.DropoutStates(handle, self.seed)
+        states2 = cudnn.DropoutStates(None, self.seed)
 
-        rspace, y = self.states.forward(handle, self.x, self.ratio)
-        rspace2, y2 = states2.forward(handle, self.x, self.ratio)
+        rspace, y = self.states.forward(None, self.x, self.ratio)
+        rspace2, y2 = states2.forward(None, self.x, self.ratio)
         # forward results must be the same
         self.assertTrue(cupy.all(y == y2))
 
-        gx = self.states.backward(handle, self.gy, self.ratio, rspace)
-        gx2 = states2.backward(handle, self.gy, self.ratio, rspace2)
+        gx = self.states.backward(None, self.gy, self.ratio, rspace)
+        gx2 = states2.backward(None, self.gy, self.ratio, rspace2)
         # backward results must be the same
         self.assertTrue(cupy.all(gx == gx2))
 


### PR DESCRIPTION
- Support None as handle in `DropoutStates`
- Add `sed_dropout_ratio interface` to avoid using cuDNN handle