### PR TITLE
[backport] Workaround for test failure when Python 3.4 + SciPy 0.x + NumPy 0.15

### DIFF
--- a/tests/cupyx_tests/__init__.py
+++ b/tests/cupyx_tests/__init__.py
@@ -1,0 +1,18 @@
+# TODO(kmaehashi) this is to avoid DeprecationWarning raised during import
+# not being filtered in Python 3.4. Remove this when we drop Python 3.4.
+
+import sys
+import warnings
+
+
+ver = sys.version_info
+if ver.major == 3 and ver.minor == 4:
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+
+        # This imports `numpy.testing.*` module, which emits
+        # DeprecationWarning during import (in NumPy 1.15+).
+        try:
+            from scipy import stats  # NOQA
+        except ImportError:
+            pass


### PR DESCRIPTION
Backport of #1732