### PR TITLE
Fix PendingDeprecationWarning when running test against NumPy 1.15

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,10 +12,10 @@ filterwarnings= ignore::FutureWarning
                 error::numpy.ComplexWarning
                 # importing old SciPy is warned because it tries to
                 # import nose via numpy.testing
-                ignore::DeprecationWarning:scipy._lib._numpy_compat
+                ignore::DeprecationWarning:scipy\._lib\._numpy_compat
                 # importing stats from old SciPy is warned because it tries to
                 # import numpy.testing.decorators
-                ignore::DeprecationWarning:scipy.stats.morestats
+                ignore::DeprecationWarning:scipy\.stats\.morestats
                 # Using `scipy.sparse` against NumPy 1.15+ raises warning
                 # as it uses `np.matrix` which is pending deprecation.
                 # Also exclude `numpy.matrixlib.defmatrix` as SciPy and our

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,6 +8,7 @@ exclude = .eggs,*.egg,build,.git
 filterwarnings= ignore::FutureWarning
                 ignore::UserWarning
                 error::DeprecationWarning
+                error::PendingDeprecationWarning
                 error::numpy.ComplexWarning
                 # importing old SciPy is warned because it tries to
                 # import nose via numpy.testing
@@ -15,6 +16,13 @@ filterwarnings= ignore::FutureWarning
                 # importing stats from old SciPy is warned because it tries to
                 # import numpy.testing.decorators
                 ignore::DeprecationWarning:scipy.stats.morestats
+                # Using `scipy.sparse` against NumPy 1.15+ raises warning
+                # as it uses `np.matrix` which is pending deprecation.
+                # Also exclude `numpy.matrixlib.defmatrix` as SciPy and our
+                # test code uses `np.asmatrix`, which internally calls
+                # `np.matrix`.
+                ignore::PendingDeprecationWarning:scipy\.sparse\.\w+
+                ignore::PendingDeprecationWarning:numpy\.matrixlib\.defmatrix
 
 [metadata]
 license_file = docs/source/license.rst


### PR DESCRIPTION
In NumPy 1.15, `np.matrix` has been deprecated. https://github.com/numpy/numpy/pull/10142
However, `scipy.sparse` is still using it (and seems to continue using it for a while).

Note: SciPy 1.2 will set their own warning filter to ignore this warning. https://github.com/scipy/scipy/pull/8887