### PR TITLE
Support skipping tests decorated by condition or parametize

### DIFF
--- a/cupy/testing/condition.py
+++ b/cupy/testing/condition.py
@@ -63,7 +63,13 @@ def repeat_with_success_at_least(times, min_success):
                         tearDown=ins.tearDown))
 
                 result = QuietTestRunner().run(suite)
-                if result.wasSuccessful():
+                if len(result.skipped) == 1:
+                    # "Skipped" is a special case of "Successful".
+                    # When the test has been skipped, immedeately quit the
+                    # test regardleess of `times` and `min_success` by raising
+                    # SkipTest exception using the original reason.
+                    instance.skipTest(result.skipped[0][1])
+                elif result.wasSuccessful():
                     success_counter += 1
                 else:
                     results.append(result)

--- a/cupy/testing/helper.py
+++ b/cupy/testing/helper.py
@@ -585,6 +585,8 @@ def for_dtypes(dtypes, name='dtype'):
                 try:
                     kw[name] = numpy.dtype(dtype).type
                     impl(self, *args, **kw)
+                except unittest.SkipTest as e:
+                    print('skipped: {} = {} ({})'.format(name, dtype, e))
                 except Exception:
                     print(name, 'is', dtype)
                     raise

--- a/cupy/testing/parameterized.py
+++ b/cupy/testing/parameterized.py
@@ -41,6 +41,8 @@ def _gen_case(base, module, i, param):
         def wrap(*args, **kwargs):
             try:
                 return method(*args, **kwargs)
+            except unittest.SkipTest:
+                raise
             except Exception as e:
                 s = six.StringIO()
                 s.write('Parameterized test failed.\n\n')

--- a/tests/cupy_tests/testing_tests/test_parameterized.py
+++ b/tests/cupy_tests/testing_tests/test_parameterized.py
@@ -3,6 +3,12 @@ import unittest
 from cupy import testing
 
 
+class TestParameterize(unittest.TestCase):
+    def test_skip(self):
+        # Skipping the test case should not report error.
+        self.skipTest('skip')
+
+
 @testing.parameterize(
     {'actual': {'a': [1, 2], 'b': [3, 4, 5]},
      'expect': [{'a': 1, 'b': 3}, {'a': 1, 'b': 4}, {'a': 1, 'b': 5},


### PR DESCRIPTION
Support `self.skipTest` in unittest as done in Chainer.
https://github.com/chainer/chainer/pull/4685

CuPy specific fixes (difference from above PR): `for_dtypes` loops inside one test case with different parameters. In this case we can't just raise the exception, as it will skip the all parameters.