### PR TITLE
Fix test failure of binomial distribution in Windows

### DIFF
--- a/tests/cupy_tests/random_tests/test_distributions.py
+++ b/tests/cupy_tests/random_tests/test_distributions.py
@@ -59,6 +59,8 @@ class TestDistributionsBinomial(RandomDistributionsTestCase):
     @cupy.testing.for_signed_dtypes('n_dtype')
     @cupy.testing.for_float_dtypes('p_dtype')
     def test_binomial(self, n_dtype, p_dtype):
+        if (numpy.dtype('l') == numpy.int32 and n_dtype == numpy.int64):
+            self.skipTest('n must be able to cast to long')
         n = numpy.full(self.n_shape, 5, dtype=n_dtype)
         p = numpy.full(self.p_shape, 0.5, dtype=p_dtype)
         self.check_distribution('binomial',

--- a/tests/cupy_tests/random_tests/test_distributions.py
+++ b/tests/cupy_tests/random_tests/test_distributions.py
@@ -59,7 +59,7 @@ class TestDistributionsBinomial(RandomDistributionsTestCase):
     @cupy.testing.for_signed_dtypes('n_dtype')
     @cupy.testing.for_float_dtypes('p_dtype')
     def test_binomial(self, n_dtype, p_dtype):
-        if (numpy.dtype('l') == numpy.int32 and n_dtype == numpy.int64):
+        if numpy.dtype('l') == numpy.int32 and n_dtype == numpy.int64:
             self.skipTest('n must be able to cast to long')
         n = numpy.full(self.n_shape, 5, dtype=n_dtype)
         p = numpy.full(self.p_shape, 0.5, dtype=p_dtype)


### PR DESCRIPTION
`numpy.random.binomial` requires `n` to be able to cast to long.
https://github.com/numpy/numpy/blob/v1.15.0/numpy/random/mtrand/mtrand.pyx#L3786

This PR depends on #1757.