### PR TITLE
Support array conversion from numba to cupy w/o memcpy

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2312,12 +2312,6 @@ cpdef ndarray array(obj, dtype=None, bint copy=True, str order='K',
                 # When `copy` is False, `a` is same as `obj`.
                 a = a.view()
             a.shape = (1,) * (ndmin - ndim) + a.shape
-    elif (hasattr(obj, '__cuda_array_interface__') and
-          obj.__cuda_array_interface__['version'] <= 0):
-        desc = obj.__cuda_array_interface__
-        a = ndarray(desc['shape'], dtype=numpy.dtype(desc['typestr']))
-        runtime.memcpy(a.data.ptr, desc['data'][0], a.nbytes,
-                       runtime.memcpyDefault)
     else:
         if order is not None and len(order) >= 1 and order[0] in 'KAka':
             if isinstance(obj, numpy.ndarray) and obj.flags.f_contiguous:

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2312,6 +2312,12 @@ cpdef ndarray array(obj, dtype=None, bint copy=True, str order='K',
                 # When `copy` is False, `a` is same as `obj`.
                 a = a.view()
             a.shape = (1,) * (ndmin - ndim) + a.shape
+    elif (hasattr(obj, '__cuda_array_interface__') and
+          obj.__cuda_array_interface__['version'] <= 0):
+        desc = obj.__cuda_array_interface__
+        a = ndarray(desc['shape'], dtype=numpy.dtype(desc['typestr']))
+        runtime.memcpy(a.data.ptr, desc['data'][0], a.nbytes,
+                       runtime.memcpyDefault)
     else:
         if order is not None and len(order) >= 1 and order[0] in 'KAka':
             if isinstance(obj, numpy.ndarray) and obj.flags.f_contiguous:

--- a/cupy/creation/from_data.py
+++ b/cupy/creation/from_data.py
@@ -1,8 +1,9 @@
+import numpy
+
 from cupy import core
 from cupy.core import fusion
 from cupy.core import ndarray
 from cupy.cuda import memory
-import numpy
 
 
 def array(obj, dtype=None, copy=True, order='K', subok=False, ndmin=0):
@@ -48,13 +49,15 @@ def _convert_object_with_cuda_array_interface(a):
     desc = a.__cuda_array_interface__
     shape = desc['shape']
     dtype = numpy.dtype(desc['typestr'])
-    nbytes = numpy.prod(shape) * dtype.itemsize
-    mem = memory.UnownedMemory(desc['data'][0], nbytes, a)
-    memptr = memory.MemoryPointer(mem, 0)
     if 'strides' in desc:
         strides = desc['strides']
+        # this should be fixed.
+        nbytes = numpy.max(numpy.array(shape) * numpy.array(strides))
     else:
         strides = None
+        nbytes = numpy.prod(shape) * dtype.itemsize
+    mem = memory.UnownedMemory(desc['data'][0], nbytes, a)
+    memptr = memory.MemoryPointer(mem, 0)
     return ndarray(shape, dtype=dtype, memptr=memptr, strides=strides)
 
 

--- a/cupy/creation/from_data.py
+++ b/cupy/creation/from_data.py
@@ -51,7 +51,11 @@ def _convert_object_with_cuda_array_interface(a):
     nbytes = numpy.prod(shape) * dtype.itemsize
     mem = memory.UnownedMemory(desc['data'][0], nbytes, a)
     memptr = memory.MemoryPointer(mem, 0)
-    return ndarray(shape, dtype=dtype, memptr=memptr, strides=desc['strides'])
+    if 'strides' in desc:
+        strides = desc['strides']
+    else:
+        strides = None
+    return ndarray(shape, dtype=dtype, memptr=memptr, strides=strides)
 
 
 def asarray(a, dtype=None):

--- a/cupy/creation/from_data.py
+++ b/cupy/creation/from_data.py
@@ -4,7 +4,6 @@ from cupy import core
 from cupy.core import fusion
 from cupy.core import ndarray
 from cupy.cuda import memory
-from cupy.cuda import runtime
 
 
 def array(obj, dtype=None, copy=True, order='K', subok=False, ndmin=0):
@@ -56,10 +55,7 @@ def _convert_object_with_cuda_array_interface(a):
     else:
         strides = None
         nbytes = numpy.prod(shape) * dtype.itemsize
-    dataptr = desc['data'][0]
-    attrs = runtime.pointerGetAttributes(dataptr)
-    runtime.setDevice(attrs.device)
-    mem = memory.UnownedMemory(dataptr, nbytes, a)
+    mem = memory.UnownedMemory(desc['data'][0], nbytes, a)
     memptr = memory.MemoryPointer(mem, 0)
     return ndarray(shape, dtype=dtype, memptr=memptr, strides=strides)
 


### PR DESCRIPTION
This PR aims to improve an interoperability between CuPy and Numba. With this PR, you can convert a numba array to a cupy array w/o D2H/H2D by cupy.asarray() as below.

    x = numpy.arange(10)    # type: numpy.ndarray
    x_numba = numba.cuda.to_device(x)    # type: numba.cuda.cudadrv.devicearray.DeviceNDArray
    x_cupy = cupy.asarray(x_numba)    # type: cupy.core.core.ndarray

Note that still D2D is performed at array conversion.
(*) this is related to #1720. 