### PR TITLE
[backport] Fix PendingDeprecationWarning when running test against NumPy 1.15

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,13 +8,21 @@ exclude = .eggs,*.egg,build,.git
 filterwarnings= ignore::FutureWarning
                 ignore::UserWarning
                 error::DeprecationWarning
+                error::PendingDeprecationWarning
                 error::numpy.ComplexWarning
                 # importing old SciPy is warned because it tries to
                 # import nose via numpy.testing
-                ignore::DeprecationWarning:scipy._lib._numpy_compat
+                ignore::DeprecationWarning:scipy\._lib\._numpy_compat
                 # importing stats from old SciPy is warned because it tries to
                 # import numpy.testing.decorators
-                ignore::DeprecationWarning:scipy.stats.morestats
+                ignore::DeprecationWarning:scipy\.stats\.morestats
+                # Using `scipy.sparse` against NumPy 1.15+ raises warning
+                # as it uses `np.matrix` which is pending deprecation.
+                # Also exclude `numpy.matrixlib.defmatrix` as SciPy and our
+                # test code uses `np.asmatrix`, which internally calls
+                # `np.matrix`.
+                ignore::PendingDeprecationWarning:scipy\.sparse\.\w+
+                ignore::PendingDeprecationWarning:numpy\.matrixlib\.defmatrix
 
 [metadata]
 license_file = docs/source/license.rst


### PR DESCRIPTION
Backport of #1755