### PR TITLE
Better support cuda-gdb

### DIFF
--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -64,15 +64,14 @@ def _get_bool_env_variable(name, default):
         return False
 
 
-def compile_using_nvrtc(source, options=(), arch=None):
+def compile_using_nvrtc(source, options=(), arch=None, filename='kern.cu'):
     if not arch:
         arch = _get_arch()
 
     options += ('-arch={}'.format(arch),)
 
     with TemporaryDirectory() as root_dir:
-        path = os.path.join(root_dir, 'kern')
-        cu_path = '%s.cu' % path
+        cu_path = os.path.join(root_dir, filename)
 
         with open(cu_path, 'w') as cu_file:
             cu_file.write(source)
@@ -127,6 +126,8 @@ def compile_with_cache(source, options=(), arch=None, cache_dir=None,
         arch = _get_arch()
 
     options += ('-ftz=true',)
+    if _get_bool_env_variable('CUPY_CUDA_COMPILE_WITH_DEBUG', False):
+        options += ('--device-debug', '--generate-line-info')
 
     env = (arch, options, _get_nvrtc_version())
     base = _empty_file_preprocess_cache.get(env, None)
@@ -161,7 +162,7 @@ def compile_with_cache(source, options=(), arch=None, cache_dir=None,
                 mod.load(cubin)
                 return mod
 
-    ptx = compile_using_nvrtc(source, options, arch)
+    ptx = compile_using_nvrtc(source, options, arch, name + '.cu')
     ls = function.LinkState()
     ls.add_ptr_data(ptx, six.u('cupy.ptx'))
     cubin = ls.complete()

--- a/docs/source/reference/environment.rst
+++ b/docs/source/reference/environment.rst
@@ -19,6 +19,11 @@ Here are the environment variables CuPy uses.
 |                                    | CuPy dumps CUDA kernel code to standard error.     |
 |                                    | It is disabled by default.                         |
 +------------------------------------+----------------------------------------------------+
+| ``CUPY_CUDA_COMPILE_WITH_DEBUG``   | If set to 1, CUDA kernel will be compiled with     |
+|                                    | debug information (``--device-debug`` and          |
+|                                    | ``--generate-line-info``).                         |
+|                                    | It is disabled by default.                         |
++------------------------------------+----------------------------------------------------+
 
 
 For install


### PR DESCRIPTION
This makes use of `cuda-gdb` against CuPy kernels easier by:

- Introducing `CUPY_CUDA_COMPILE_WITH_DEBUG` environment variable which enables embedding of debug information to cubin.
- Using the same filename for both compilation-time temporary source file and cached source file, so that users can easily see the code in `cuda-gdb` session (i.e., `list` command) by using `CUPY_CACHE_SAVE_CUDA_SOURCE=1`, `CUPY_CUDA_COMPILE_WITH_DEBUG=1` and `directory ~/.cupy/kernel_cache` in cuda-gdb.

This feature is becoming important as `RawKernel` is introduced.