### PR TITLE
Fix invalid memory access during reduction whose output is large to exceed 32-bit

### DIFF
--- a/cupy/core/reduction.pxi
+++ b/cupy/core/reduction.pxi
@@ -32,18 +32,18 @@ extern "C" __global__ void ${name}(${params}) {
   unsigned int _tid = threadIdx.x;
 
   int _J_offset = _tid >> __popc(_block_stride - 1);  // _tid / _block_stride
-  long long _j_offset = (long long)_J_offset * _out_ind.size();
+  ptrdiff_t _j_offset = (ptrdiff_t)_J_offset * _out_ind.size();
   int _J_stride = ${block_size} >> __popc(_block_stride - 1);
-  long long _j_stride = (long long)_J_stride * _out_ind.size();
+  ptrdiff_t _j_stride = (ptrdiff_t)_J_stride * _out_ind.size();
 
-  for (long long _i_base = (long long)blockIdx.x * _block_stride;
+  for (ptrdiff_t _i_base = (ptrdiff_t)blockIdx.x * _block_stride;
        _i_base < _out_ind.size();
-       _i_base += (long long)gridDim.x * _block_stride) {
+       _i_base += (ptrdiff_t)gridDim.x * _block_stride) {
     _type_reduce _s = _type_reduce(${identity});
-    long long _i =
+    ptrdiff_t _i =
         _i_base + (_tid & (_block_stride - 1));  // _tid % _block_stride
     int _J = _J_offset;
-    for (long long _j = _i + _j_offset; _j < _in_ind.size();
+    for (ptrdiff_t _j = _i + _j_offset; _j < _in_ind.size();
          _j += _j_stride, _J += _J_stride) {
       _in_ind.set(_j);
       ${input_expr}

--- a/cupy/core/reduction.pxi
+++ b/cupy/core/reduction.pxi
@@ -32,15 +32,16 @@ extern "C" __global__ void ${name}(${params}) {
   unsigned int _tid = threadIdx.x;
 
   int _J_offset = _tid >> __popc(_block_stride - 1);  // _tid / _block_stride
-  int _j_offset = _J_offset * _out_ind.size();
+  long long _j_offset = (long long)_J_offset * _out_ind.size();
   int _J_stride = ${block_size} >> __popc(_block_stride - 1);
   long long _j_stride = (long long)_J_stride * _out_ind.size();
 
-  for (int _i_base = blockIdx.x * _block_stride;
+  for (long long _i_base = (long long)blockIdx.x * _block_stride;
        _i_base < _out_ind.size();
-       _i_base += gridDim.x * _block_stride) {
+       _i_base += (long long)gridDim.x * _block_stride) {
     _type_reduce _s = _type_reduce(${identity});
-    int _i = _i_base + (_tid & (_block_stride - 1));  // _tid % _block_stride
+    long long _i =
+        _i_base + (_tid & (_block_stride - 1));  // _tid % _block_stride
     int _J = _J_offset;
     for (long long _j = _i + _j_offset; _j < _in_ind.size();
          _j += _j_stride, _J += _J_stride) {

--- a/tests/cupy_tests/core_tests/test_carray.py
+++ b/tests/cupy_tests/core_tests/test_carray.py
@@ -69,7 +69,7 @@ class TestCArray32BitBoundary(unittest.TestCase):
 
     def test(self):
         # Elementwise
-        a = cupy.ones((1, self.size), dtype=cupy.int8)
+        a = cupy.full((1, self.size), 7, dtype=cupy.int8)
         # Reduction
         result = a.sum(axis=0, dtype=cupy.int8)
-        assert result.sum() == self.size
+        assert result.sum() == self.size * 7

--- a/tests/cupy_tests/core_tests/test_carray.py
+++ b/tests/cupy_tests/core_tests/test_carray.py
@@ -67,10 +67,9 @@ class TestCArray32BitBoundary(unittest.TestCase):
         # Free huge memory for slow test
         cupy.get_default_memory_pool().free_all_blocks()
 
-    @testing.numpy_cupy_allclose()
-    def test(self, xp):
+    def test(self):
         # Elementwise
-        a = xp.ones((1, self.size), dtype=xp.int8)
+        a = cupy.ones((1, self.size), dtype=cupy.int8)
         # Reduction
-        result = a.sum(axis=0, dtype=xp.int8)
-        return result
+        result = a.sum(axis=0, dtype=cupy.int8)
+        assert result.sum() == self.size

--- a/tests/cupy_tests/core_tests/test_carray.py
+++ b/tests/cupy_tests/core_tests/test_carray.py
@@ -58,17 +58,19 @@ class TestCArray(unittest.TestCase):
 @testing.slow
 class TestCArray32BitBoundary(unittest.TestCase):
     # This test case is intended to confirm CArray indexing work correctly
-    # with arrays whose size is so large that it crosses the 32-bit boundary.
+    # with input/output arrays whose size is so large that it crosses the
+    # 32-bit boundary (in terms of both number of elements and size in bytes).
+    # This test requires approx. 8 GiB GPU memory to run.
     # See https://github.com/cupy/cupy/pull/882 for detailed discussions.
 
     def tearDown(self):
         # Free huge memory for slow test
         cupy.get_default_memory_pool().free_all_blocks()
 
-    @testing.numpy_cupy_equal()
+    @testing.numpy_cupy_allclose()
     def test(self, xp):
         # Elementwise
-        a = xp.ones(self.size, dtype='b')
+        a = xp.ones((1, self.size), dtype=xp.int8)
         # Reduction
-        result = a.sum()
+        result = a.sum(axis=0, dtype=xp.int8)
         return result

--- a/tests/cupy_tests/core_tests/test_carray.py
+++ b/tests/cupy_tests/core_tests/test_carray.py
@@ -48,12 +48,12 @@ class TestCArray(unittest.TestCase):
 
 
 @testing.parameterize(
-    {"size": 2 ** 32 + 1024},
-    {"size": 2 ** 32},
-    {"size": 2 ** 32 - 1024},
-    {"size": 2 ** 31 + 1024},
-    {"size": 2 ** 31},
     {"size": 2 ** 31 - 1024},
+    {"size": 2 ** 31},
+    {"size": 2 ** 31 + 1024},
+    {"size": 2 ** 32 - 1024},
+    {"size": 2 ** 32},
+    {"size": 2 ** 32 + 1024},
 )
 @testing.slow
 class TestCArray32BitBoundary(unittest.TestCase):


### PR DESCRIPTION
Fix #1766.

* `_J_offset` can be up to `2^9` and `_out_ind.size.size()` (size_t) can be up to `2^64` (capped at max GPU memory).  Thus `_j_offset` should be typed as  `long long`.
* `gridDim.x` (unsigned int) can be up to `2^31` and `_block_stride` (int) can be up to `2^9`. Thus `_i_base` and `_i` should be typed as `long long`.