### PR TITLE
[WIP] Avoid cimport-ing driver

### DIFF
--- a/cupy/cuda/__init__.py
+++ b/cupy/cuda/__init__.py
@@ -3,8 +3,11 @@ import os
 
 from cupy.cuda import compiler  # NOQA
 from cupy.cuda import device  # NOQA
-from cupy.cuda import driver  # NOQA
-from cupy.cuda import function  # NOQA
+try:
+    from cupy.cuda import driver  # NOQA
+    from cupy.cuda import function  # NOQA
+except ImportError:
+    pass
 from cupy.cuda import memory  # NOQA
 from cupy.cuda import memory_hook  # NOQA
 from cupy.cuda import memory_hooks  # NOQA
@@ -18,11 +21,8 @@ _available = None
 _cuda_path = None
 
 
-if driver.get_build_version() >= 8000:
-    from cupy.cuda import cusolver  # NOQA
-    cusolver_enabled = True
-else:
-    cusolver_enabled = False
+from cupy.cuda import cusolver  # NOQA
+cusolver_enabled = True
 
 try:
     from cupy.cuda import nvtx  # NOQA

--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -8,9 +8,13 @@ import tempfile
 
 import six
 
-from cupy.cuda import device
-from cupy.cuda import function
-from cupy.cuda import nvrtc
+try:
+    from cupy.cuda import device
+    from cupy.cuda import function
+    from cupy.cuda import nvrtc
+except ImportError:
+    pass
+
 
 _nvrtc_version = None
 _nvrtc_max_compute_capability = None

--- a/cupy/cuda/cublas.pyx
+++ b/cupy/cuda/cublas.pyx
@@ -4,7 +4,7 @@
 
 cimport cython  # NOQA
 
-from cupy.cuda cimport driver
+from cupy.cuda cimport driver_types as driver
 from cupy.cuda cimport runtime
 from cupy.cuda cimport stream as stream_module
 

--- a/cupy/cuda/cudnn.pyx
+++ b/cupy/cuda/cudnn.pyx
@@ -5,7 +5,7 @@
 cimport cython  # NOQA
 from libcpp cimport vector
 
-from cupy.cuda cimport driver
+from cupy.cuda cimport driver_types as driver
 from cupy.cuda cimport stream as stream_module
 
 ###############################################################################

--- a/cupy/cuda/cufft.pyx
+++ b/cupy/cuda/cufft.pyx
@@ -2,7 +2,7 @@ cimport cython  # NOQA
 import numpy
 
 import cupy
-from cupy.cuda cimport driver
+from cupy.cuda cimport driver_types as driver
 from cupy.cuda cimport memory
 from cupy.cuda cimport stream as stream_module
 

--- a/cupy/cuda/curand.pyx
+++ b/cupy/cuda/curand.pyx
@@ -3,7 +3,7 @@
 """Thin wrapper of cuRAND."""
 cimport cython  # NOQA
 
-from cupy.cuda cimport driver
+from cupy.cuda cimport driver_types as driver
 from cupy.cuda cimport stream as stream_module
 
 ###############################################################################

--- a/cupy/cuda/cusolver.pxd
+++ b/cupy/cuda/cusolver.pxd
@@ -5,7 +5,7 @@
 # Types
 ###############################################################################
 
-from cupy.cuda.driver cimport Stream
+from cupy.cuda.driver_types cimport Stream
 
 cdef extern from *:
     ctypedef void* Handle 'cusolverDnHandle_t'

--- a/cupy/cuda/cusolver.pyx
+++ b/cupy/cuda/cusolver.pyx
@@ -2,7 +2,7 @@
 
 cimport cython  # NOQA
 
-from cupy.cuda cimport driver
+from cupy.cuda cimport driver_types as driver
 from cupy.cuda cimport stream as stream_module
 
 ###############################################################################

--- a/cupy/cuda/cusparse.pyx
+++ b/cupy/cuda/cusparse.pyx
@@ -1,6 +1,6 @@
 cimport cython  # NOQA
 
-from cupy.cuda cimport driver
+from cupy.cuda cimport driver_types as driver
 from cupy.cuda cimport stream as stream_module
 
 cdef extern from "cupy_cuComplex.h":

--- a/cupy/cuda/driver.pxd
+++ b/cupy/cuda/driver.pxd
@@ -1,21 +1,9 @@
+from cupy.cuda.driver_types cimport Device
+
+
 ###############################################################################
 # Types
 ###############################################################################
-
-cdef extern from *:
-    ctypedef int Device 'CUdevice'
-    ctypedef int Result 'CUresult'
-
-    ctypedef void* Context 'CUcontext'
-    ctypedef void* Deviceptr 'CUdeviceptr'
-    ctypedef void* Event 'struct CUevent_st*'
-    ctypedef void* Function 'struct CUfunc_st*'
-    ctypedef void* Module 'struct CUmod_st*'
-    ctypedef void* Stream 'struct CUstream_st*'
-    ctypedef void* LinkState 'CUlinkState'
-
-    ctypedef int CUjit_option 'CUjit_option'
-    ctypedef int CUjitInputType 'CUjitInputType'
 
 cpdef enum:
     CU_JIT_INPUT_CUBIN = 0

--- a/cupy/cuda/driver.pyx
+++ b/cupy/cuda/driver.pyx
@@ -13,6 +13,8 @@ There are four differences compared to the original C API.
 """
 cimport cython  # NOQA
 
+from cupy.cuda.driver_types cimport *
+
 
 ###############################################################################
 # Extern

--- a/cupy/cuda/driver_types.pxd
+++ b/cupy/cuda/driver_types.pxd
@@ -1,0 +1,18 @@
+###############################################################################
+# Types
+###############################################################################
+
+cdef extern from *:
+    ctypedef int Device 'CUdevice'
+    ctypedef int Result 'CUresult'
+
+    ctypedef void* Context 'CUcontext'
+    ctypedef void* Deviceptr 'CUdeviceptr'
+    ctypedef void* Event 'struct CUevent_st*'
+    ctypedef void* Function 'struct CUfunc_st*'
+    ctypedef void* Module 'struct CUmod_st*'
+    ctypedef void* Stream 'struct CUstream_st*'
+    ctypedef void* LinkState 'CUlinkState'
+
+    ctypedef int CUjit_option 'CUjit_option'
+    ctypedef int CUjitInputType 'CUjitInputType'

--- a/cupy/cuda/nccl.pyx
+++ b/cupy/cuda/nccl.pyx
@@ -5,7 +5,7 @@ Wrapper for NCCL: Optimized primiteive for collective multi-GPU communication
 """
 cimport cython  # NOQA
 
-from cupy.cuda cimport driver
+from cupy.cuda cimport driver_types as driver
 
 cdef extern from "cupy_nccl.h":
     ctypedef struct ncclComm:

--- a/cupy/cuda/runtime.pyx
+++ b/cupy/cuda/runtime.pyx
@@ -12,7 +12,7 @@ There are four differences compared to the original C API.
 cimport cpython  # NOQA
 cimport cython  # NOQA
 
-from cupy.cuda cimport driver
+from cupy.cuda cimport driver_types as driver
 
 cdef class PointerAttributes:
 


### PR DESCRIPTION
This fix is to support environment which doesn't have CUDA Driver installed.
It is better to avoid depending on CUDA driver shared library during `import cupy` (c.f. https://github.com/cupy/cupy/issues/1073#issuecomment-436229508, #1790).

This makes possible to import CuPy without try-except block in environment without driver, e.g. in the following environment:

- Windows environment without CUDA GPU
- Linux Docker environment running without `nvidia-docker`

(Note: in both case CUDA Runtime must be installed separately unless using anaconda cupy package)

TODOs:

- [ ] avoid `except ImportError: pass`
- [ ] avoid `cimport driver_types as driver`
- [ ] avoid `cimport *`
- [ ] support cupy.show_config() to work without driver

This PR depends on #1780.