### PR TITLE
[backport] Fix English in ndarray.nbytes documentation

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -242,7 +242,7 @@ cdef class ndarray:
 
     @property
     def nbytes(self):
-        """Size of whole elements in bytes.
+        """Total size of all elements in bytes.
 
         It does not count skips between elements.
 


### PR DESCRIPTION
Backport of #1797