### PR TITLE
Fix error in typecast from fp16 to complex dtype in `cupy.fuse`

### DIFF
--- a/cupy/core/fusion.py
+++ b/cupy/core/fusion.py
@@ -167,12 +167,15 @@ class FusionOp(object):
     def code(self):
         args_sub = ['v{}_{}'.format(self.index, i)
                     for i in six.moves.range(len(self.args))]
-        args_list = list(zip(self.args, args_sub))
+        ctypes = [_dtype_to_ctype[t] for t in self.dtypes]
+        args_list = list(zip(self.args, args_sub, ctypes))
         code = '// op  # {}\n'.format(self.index)
-        code += ''.join('{} = v{};\n'.format(s, v.index) for v, s in args_list)
+        code += ''.join('{} = static_cast< {} >(v{});\n'.format(s, t, v.index)
+                        for v, s, t in args_list)
         code += self.submodule.fcall(args_sub)
-        code += ''.join('v{} = {};\n'.format(v.index, s)
-                        for v, s in args_list[len(self.submodule.in_params):])
+        code += ''.join('v{} = static_cast< {} >({});\n'.format(v.index, t, s)
+                        for v, s, t in
+                        args_list[len(self.submodule.in_params):])
         return code
 
 

--- a/cupy/core/fusion.py
+++ b/cupy/core/fusion.py
@@ -173,9 +173,10 @@ class FusionOp(object):
         code += ''.join('{} = static_cast< {} >(v{});\n'.format(s, t, v.index)
                         for v, s, t in args_list)
         code += self.submodule.fcall(args_sub)
-        code += ''.join('v{} = static_cast< {} >({});\n'.format(v.index, t, s)
-                        for v, s, t in
-                        args_list[len(self.submodule.in_params):])
+        code += ''.join('v{} = static_cast< {} >({});\n'.format(
+            v.index, _dtype_to_ctype[v.dtype], s)
+            for v, s, _ in
+            args_list[len(self.submodule.in_params):])
         return code
 
 

--- a/tests/cupy_tests/core_tests/test_fusion.py
+++ b/tests/cupy_tests/core_tests/test_fusion.py
@@ -10,11 +10,11 @@ from cupy import testing
 
 def fusion_default_array_equal():
     def deco(func):
-        def wrapper(self_x, name, xp, dtype):
+        def wrapper(self_x, name, xp, **dtypes):
             @cupy.fuse()
             def f(*args):
                 return getattr(xp, name)(*args)
-            args = func(self_x, name, xp, dtype)
+            args = func(self_x, name, xp, **dtypes)
             return f(*args)
         return wrapper
     return deco
@@ -60,12 +60,13 @@ class TestFusionElementwise(unittest.TestCase):
 @testing.gpu
 class TestFusionComparison(unittest.TestCase):
 
-    @testing.for_all_dtypes(no_complex=True)
+    @testing.for_all_dtypes_combination(
+        no_complex=True, names=['dtype1', 'dtype2'])
     @testing.numpy_cupy_allclose(atol=1e-5)
     @fusion_default_array_equal()
-    def check_binary(self, name, xp, dtype):
-        a = testing.shaped_arange((2, 3), xp, dtype)
-        b = testing.shaped_reverse_arange((2, 3), xp, dtype)
+    def check_binary(self, name, xp, dtype1, dtype2):
+        a = testing.shaped_arange((2, 3), xp, dtype1)
+        b = testing.shaped_reverse_arange((2, 3), xp, dtype2)
         return a, b
 
     def test_greater(self):
@@ -127,12 +128,13 @@ class TestFusionOps(unittest.TestCase):
         a = testing.shaped_arange((2, 3), xp, dtype)
         return (a,)
 
-    @testing.for_all_dtypes(no_complex=True)
+    @testing.for_all_dtypes_combination(
+        no_complex=True, names=['dtype1', 'dtype2'])
     @testing.numpy_cupy_allclose(atol=1e-5)
     @fusion_default_array_equal()
-    def check_binary(self, name, xp, dtype):
-        a = testing.shaped_arange((2, 3), xp, dtype)
-        b = testing.shaped_reverse_arange((2, 3), xp, dtype)
+    def check_binary(self, name, xp, dtype1, dtype2):
+        a = testing.shaped_arange((2, 3), xp, dtype1)
+        b = testing.shaped_reverse_arange((2, 3), xp, dtype2)
         return a, b
 
     def test_logical_and(self):
@@ -158,12 +160,13 @@ class TestFusionTrigonometric(unittest.TestCase):
         a = testing.shaped_arange((2, 3), xp, dtype)
         return (a,)
 
-    @testing.for_all_dtypes(no_complex=True)
+    @testing.for_all_dtypes_combination(
+        no_complex=True, names=['dtype1', 'dtype2'])
     @testing.numpy_cupy_allclose(atol=1e-5)
     @fusion_default_array_equal()
-    def check_binary(self, name, xp, dtype):
-        a = testing.shaped_arange((2, 3), xp, dtype)
-        b = testing.shaped_reverse_arange((2, 3), xp, dtype)
+    def check_binary(self, name, xp, dtype1, dtype2):
+        a = testing.shaped_arange((2, 3), xp, dtype1)
+        b = testing.shaped_reverse_arange((2, 3), xp, dtype2)
         return a, b
 
     @testing.for_dtypes(['e', 'f', 'd'])
@@ -293,12 +296,13 @@ class TestFusionExplog(unittest.TestCase):
         a = testing.shaped_arange((2, 3), xp, dtype)
         return (a,)
 
-    @testing.for_all_dtypes(no_complex=True)
+    @testing.for_all_dtypes_combination(
+        no_complex=True, names=['dtype1', 'dtype2'])
     @testing.numpy_cupy_allclose(atol=1e-5)
     @fusion_default_array_equal()
-    def check_binary(self, name, xp, dtype):
-        a = testing.shaped_arange((2, 3), xp, dtype)
-        b = testing.shaped_reverse_arange((2, 3), xp, dtype)
+    def check_binary(self, name, xp, dtype1, dtype2):
+        a = testing.shaped_arange((2, 3), xp, dtype1)
+        b = testing.shaped_reverse_arange((2, 3), xp, dtype2)
         return a, b
 
     def test_exp(self):
@@ -342,12 +346,13 @@ class TestFusionFloating(unittest.TestCase):
         a = testing.shaped_arange((2, 3), xp, dtype)
         return (a,)
 
-    @testing.for_all_dtypes(no_complex=True)
+    @testing.for_all_dtypes_combination(
+        no_complex=True, names=['dtype1', 'dtype2'])
     @testing.numpy_cupy_allclose(atol=1e-5)
     @fusion_default_array_equal()
-    def check_binary(self, name, xp, dtype):
-        a = testing.shaped_arange((2, 3), xp, dtype)
-        b = testing.shaped_reverse_arange((2, 3), xp, dtype)
+    def check_binary(self, name, xp, dtype1, dtype2):
+        a = testing.shaped_arange((2, 3), xp, dtype1)
+        b = testing.shaped_reverse_arange((2, 3), xp, dtype2)
         return a, b
 
     @testing.for_float_dtypes(name='ftype')
@@ -401,28 +406,30 @@ class TestFusionArithmetic(unittest.TestCase):
         a = testing.shaped_arange((2, 3), xp, dtype)
         return (a,)
 
-    @testing.for_all_dtypes()
+    @testing.for_all_dtypes_combination(names=['dtype1', 'dtype2'])
     @testing.numpy_cupy_allclose(atol=1e-5)
     @fusion_default_array_equal()
-    def check_binary(self, name, xp, dtype):
-        a = testing.shaped_arange((2, 3), xp, dtype)
-        b = testing.shaped_reverse_arange((2, 3), xp, dtype)
+    def check_binary(self, name, xp, dtype1, dtype2):
+        a = testing.shaped_arange((2, 3), xp, dtype1)
+        b = testing.shaped_reverse_arange((2, 3), xp, dtype2)
         return a, b
 
-    @testing.for_all_dtypes(no_complex=True)
+    @testing.for_all_dtypes_combination(
+        no_complex=True, names=['dtype1', 'dtype2'])
     @testing.numpy_cupy_allclose(atol=1e-5)
     @fusion_default_array_equal()
-    def check_binary_without_complex(self, name, xp, dtype):
-        a = testing.shaped_arange((2, 3), xp, dtype)
-        b = testing.shaped_reverse_arange((2, 3), xp, dtype)
+    def check_binary_without_complex(self, name, xp, dtype1, dtype2):
+        a = testing.shaped_arange((2, 3), xp, dtype1)
+        b = testing.shaped_reverse_arange((2, 3), xp, dtype2)
         return a, b
 
-    @testing.for_all_dtypes(no_bool=True)
+    @testing.for_all_dtypes_combination(
+        no_bool=True, names=['dtype1', 'dtype2'])
     @testing.numpy_cupy_allclose(atol=1e-5)
     @fusion_default_array_equal()
-    def check_binary_without_bool(self, name, xp, dtype):
-        a = testing.shaped_arange((2, 3), xp, dtype)
-        b = testing.shaped_reverse_arange((2, 3), xp, dtype)
+    def check_binary_without_bool(self, name, xp, dtype1, dtype2):
+        a = testing.shaped_arange((2, 3), xp, dtype1)
+        b = testing.shaped_reverse_arange((2, 3), xp, dtype2)
         return a, b
 
     @testing.for_dtypes(['?', 'b', 'h', 'i', 'q', 'e', 'f', 'd'])
@@ -432,20 +439,22 @@ class TestFusionArithmetic(unittest.TestCase):
         a = xp.array([-3, -2, -1, 1, 2, 3], dtype=dtype)
         return (a,)
 
-    @testing.for_dtypes(['?', 'b', 'h', 'i', 'q', 'e', 'f', 'd'])
+    @testing.for_dtypes_combination(
+        ['?', 'b', 'h', 'i', 'q', 'e', 'f', 'd'], names=['dtype1', 'dtype2'])
     @testing.numpy_cupy_allclose(atol=1e-5)
     @fusion_default_array_equal()
-    def check_binary_negative(self, name, xp, dtype):
-        a = xp.array([-3, -2, -1, 1, 2, 3], dtype=dtype)
-        b = xp.array([4, 3, 2, 1, -1, -2], dtype=dtype)
+    def check_binary_negative(self, name, xp, dtype1, dtype2):
+        a = xp.array([-3, -2, -1, 1, 2, 3], dtype=dtype1)
+        b = xp.array([4, 3, 2, 1, -1, -2], dtype=dtype2)
         return a, b
 
-    @testing.for_dtypes(['e', 'f', 'd'])
+    @testing.for_dtypes_combination(
+        ['e', 'f', 'd'], names=['dtype1', 'dtype2'])
     @testing.numpy_cupy_allclose(atol=1e-5)
     @fusion_default_array_equal()
-    def check_binary_negative_float(self, name, xp, dtype):
-        a = xp.array([-3, -2, -1, 1, 2, 3], dtype=dtype)
-        b = xp.array([4, 3, 2, 1, -1, -2], dtype=dtype)
+    def check_binary_negative_float(self, name, xp, dtype1, dtype2):
+        a = xp.array([-3, -2, -1, 1, 2, 3], dtype=dtype1)
+        b = xp.array([4, 3, 2, 1, -1, -2], dtype=dtype2)
         return a, b
 
     def test_add(self):

--- a/tests/cupy_tests/core_tests/test_fusion.py
+++ b/tests/cupy_tests/core_tests/test_fusion.py
@@ -469,7 +469,7 @@ class TestFusionArithmetic(unittest.TestCase):
 
     def test_divide(self):
         with testing.NumpyError(divide='ignore'):
-            self.check_binary('divide')
+            self.check_binary_without_bool('divide')
 
     def test_divide_negative(self):
         with testing.NumpyError(divide='ignore'):
@@ -484,7 +484,7 @@ class TestFusionArithmetic(unittest.TestCase):
 
     def test_true_divide(self):
         with testing.NumpyError(divide='ignore'):
-            self.check_binary('true_divide')
+            self.check_binary_without_bool('true_divide')
 
     def test_true_divide_negative(self):
         with testing.NumpyError(divide='ignore'):

--- a/tests/cupy_tests/core_tests/test_fusion.py
+++ b/tests/cupy_tests/core_tests/test_fusion.py
@@ -415,10 +415,10 @@ class TestFusionArithmetic(unittest.TestCase):
         return a, b
 
     @testing.for_all_dtypes_combination(
-        no_complex=True, names=['dtype1', 'dtype2'])
+        no_bool=True, no_complex=True, names=['dtype1', 'dtype2'])
     @testing.numpy_cupy_allclose(atol=1e-5)
     @fusion_default_array_equal()
-    def check_binary_without_complex(self, name, xp, dtype1, dtype2):
+    def check_binary_without_complex_bool(self, name, xp, dtype1, dtype2):
         a = testing.shaped_arange((2, 3), xp, dtype1)
         b = testing.shaped_reverse_arange((2, 3), xp, dtype2)
         return a, b
@@ -492,7 +492,7 @@ class TestFusionArithmetic(unittest.TestCase):
 
     def test_floor_divide(self):
         with testing.NumpyError(divide='ignore'):
-            self.check_binary_without_complex('floor_divide')
+            self.check_binary_without_complex_bool('floor_divide')
 
     def test_floor_divide_negative(self):
         with testing.NumpyError(divide='ignore'):
@@ -500,7 +500,7 @@ class TestFusionArithmetic(unittest.TestCase):
 
     def test_fmod(self):
         with testing.NumpyError(divide='ignore'):
-            self.check_binary_without_complex('fmod')
+            self.check_binary_without_complex_bool('fmod')
 
     def test_fmod_negative(self):
         with testing.NumpyError(divide='ignore'):
@@ -523,7 +523,7 @@ class TestFusionArithmetic(unittest.TestCase):
 
     def test_remainder(self):
         with testing.NumpyError(divide='ignore'):
-            self.check_binary_without_complex('remainder')
+            self.check_binary_without_complex_bool('remainder')
 
     def test_remainder_negative(self):
         with testing.NumpyError(divide='ignore'):


### PR DESCRIPTION
Fixed the following error.
```
>>> import cupy
>>> @cupy.fuse()
... def f(x, y):
...     return x + y
...
>>> x = cupy.arange(10).astype('e')
>>> y = cupy.arange(10).astype('F')
>>> f(x, y)
Traceback (most recent call last):
  File "/home/imanishi/cupy/cupy/cuda/compiler.py", line 241, in compile
    nvrtc.compileProgram(self.ptr, options)
  File "cupy/cuda/nvrtc.pyx", line 98, in cupy.cuda.nvrtc.compileProgram
    cpdef compileProgram(size_t prog, options):
  File "cupy/cuda/nvrtc.pyx", line 108, in cupy.cuda.nvrtc.compileProgram
    check_status(status)
  File "cupy/cuda/nvrtc.pyx", line 53, in cupy.cuda.nvrtc.check_status
    raise NVRTCError(status)
cupy.cuda.nvrtc.NVRTCError: NVRTC_ERROR_COMPILATION (6)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/imanishi/cupy/cupy/core/fusion.py", line 775, in __call__
    return func(*args, **kwargs)
  File "cupy/core/_kernel.pyx", line 568, in cupy.core._kernel.ElementwiseKernel.__call__
    kern = self._get_elementwise_kernel(args_info, types)
  File "cupy/core/_kernel.pyx", line 589, in cupy.core._kernel.ElementwiseKernel._get_elementwise_kernel
    kern = _get_elementwise_kernel(
  File "cupy/core/_kernel.pyx", line 397, in cupy.core._kernel._get_elementwise_kernel
    return _get_simple_elementwise_kernel(
  File "cupy/core/_kernel.pyx", line 31, in cupy.core._kernel._get_simple_elementwise_kernel
    cpdef _get_simple_elementwise_kernel(
  File "cupy/core/_kernel.pyx", line 51, in cupy.core._kernel._get_simple_elementwise_kernel
    module = compile_with_cache(module_code, options)
  File "cupy/core/carray.pxi", line 148, in cupy.core.core.compile_with_cache
    return cuda.compile_with_cache(source, options, arch, cachd_dir,
  File "/home/imanishi/cupy/cupy/cuda/compiler.py", line 164, in compile_with_cache
    ptx = compile_using_nvrtc(source, options, arch)
  File "/home/imanishi/cupy/cupy/cuda/compiler.py", line 82, in compile_using_nvrtc
    ptx = prog.compile(options)
  File "/home/imanishi/cupy/cupy/cuda/compiler.py", line 245, in compile
    raise CompileException(log, self.src, self.name, options)
cupy.cuda.compiler.CompileException: /home/imanishi/cupy/cupy/core/include/cupy/carray.cuh(281): warning: statement is unreachable
          detected during instantiation of "void CIndexer<_ndim>::set(ptrdiff_t) [with _ndim=1]"
/tmp/tmpd7s5v0r9/kern.cu(19): here

/tmp/tmpd7s5v0r9/kern.cu(27): error: no operator "=" matches these operands
            operand types are: thrust::complex<float> = const float16

1 error detected in the compilation of "/tmp/tmpd7s5v0r9/kern.cu".
```