### PR TITLE
[backport] Fix error in typecast from fp16 to complex dtype in `cupy.fuse`

### DIFF
--- a/cupy/core/fusion.py
+++ b/cupy/core/fusion.py
@@ -159,12 +159,16 @@ class FusionOp(object):
     def code(self):
         args_sub = ['v{}_{}'.format(self.index, i)
                     for i in six.moves.range(len(self.args))]
-        args_list = list(zip(self.args, args_sub))
+        ctypes = [_dtype_to_ctype[t] for t in self.dtypes]
+        args_list = list(zip(self.args, args_sub, ctypes))
         code = '// op  # {}\n'.format(self.index)
-        code += ''.join('{} = v{};\n'.format(s, v.index) for v, s in args_list)
+        code += ''.join('{} = static_cast< {} >(v{});\n'.format(s, t, v.index)
+                        for v, s, t in args_list)
         code += self.submodule.fcall(args_sub)
-        code += ''.join('v{} = {};\n'.format(v.index, s)
-                        for v, s in args_list[len(self.submodule.in_params):])
+        code += ''.join('v{} = static_cast< {} >({});\n'.format(
+            v.index, _dtype_to_ctype[v.dtype], s)
+            for v, s, _ in
+            args_list[len(self.submodule.in_params):])
         return code
 
 

--- a/tests/cupy_tests/core_tests/test_fusion.py
+++ b/tests/cupy_tests/core_tests/test_fusion.py
@@ -10,11 +10,11 @@ from cupy import testing
 
 def fusion_default_array_equal():
     def deco(func):
-        def wrapper(self_x, name, xp, dtype):
+        def wrapper(self_x, name, xp, **dtypes):
             @cupy.fuse()
             def f(*args):
                 return getattr(xp, name)(*args)
-            args = func(self_x, name, xp, dtype)
+            args = func(self_x, name, xp, **dtypes)
             return f(*args)
         return wrapper
     return deco
@@ -60,12 +60,13 @@ class TestFusionElementwise(unittest.TestCase):
 @testing.gpu
 class TestFusionComparison(unittest.TestCase):
 
-    @testing.for_all_dtypes(no_complex=True)
+    @testing.for_all_dtypes_combination(
+        no_complex=True, names=['dtype1', 'dtype2'])
     @testing.numpy_cupy_allclose(atol=1e-5)
     @fusion_default_array_equal()
-    def check_binary(self, name, xp, dtype):
-        a = testing.shaped_arange((2, 3), xp, dtype)
-        b = testing.shaped_reverse_arange((2, 3), xp, dtype)
+    def check_binary(self, name, xp, dtype1, dtype2):
+        a = testing.shaped_arange((2, 3), xp, dtype1)
+        b = testing.shaped_reverse_arange((2, 3), xp, dtype2)
         return a, b
 
     def test_greater(self):
@@ -127,12 +128,13 @@ class TestFusionOps(unittest.TestCase):
         a = testing.shaped_arange((2, 3), xp, dtype)
         return (a,)
 
-    @testing.for_all_dtypes(no_complex=True)
+    @testing.for_all_dtypes_combination(
+        no_complex=True, names=['dtype1', 'dtype2'])
     @testing.numpy_cupy_allclose(atol=1e-5)
     @fusion_default_array_equal()
-    def check_binary(self, name, xp, dtype):
-        a = testing.shaped_arange((2, 3), xp, dtype)
-        b = testing.shaped_reverse_arange((2, 3), xp, dtype)
+    def check_binary(self, name, xp, dtype1, dtype2):
+        a = testing.shaped_arange((2, 3), xp, dtype1)
+        b = testing.shaped_reverse_arange((2, 3), xp, dtype2)
         return a, b
 
     def test_logical_and(self):
@@ -158,12 +160,13 @@ class TestFusionTrigonometric(unittest.TestCase):
         a = testing.shaped_arange((2, 3), xp, dtype)
         return (a,)
 
-    @testing.for_all_dtypes(no_complex=True)
+    @testing.for_all_dtypes_combination(
+        no_complex=True, names=['dtype1', 'dtype2'])
     @testing.numpy_cupy_allclose(atol=1e-5)
     @fusion_default_array_equal()
-    def check_binary(self, name, xp, dtype):
-        a = testing.shaped_arange((2, 3), xp, dtype)
-        b = testing.shaped_reverse_arange((2, 3), xp, dtype)
+    def check_binary(self, name, xp, dtype1, dtype2):
+        a = testing.shaped_arange((2, 3), xp, dtype1)
+        b = testing.shaped_reverse_arange((2, 3), xp, dtype2)
         return a, b
 
     @testing.for_dtypes(['e', 'f', 'd'])
@@ -293,12 +296,13 @@ class TestFusionExplog(unittest.TestCase):
         a = testing.shaped_arange((2, 3), xp, dtype)
         return (a,)
 
-    @testing.for_all_dtypes(no_complex=True)
+    @testing.for_all_dtypes_combination(
+        no_complex=True, names=['dtype1', 'dtype2'])
     @testing.numpy_cupy_allclose(atol=1e-5)
     @fusion_default_array_equal()
-    def check_binary(self, name, xp, dtype):
-        a = testing.shaped_arange((2, 3), xp, dtype)
-        b = testing.shaped_reverse_arange((2, 3), xp, dtype)
+    def check_binary(self, name, xp, dtype1, dtype2):
+        a = testing.shaped_arange((2, 3), xp, dtype1)
+        b = testing.shaped_reverse_arange((2, 3), xp, dtype2)
         return a, b
 
     def test_exp(self):
@@ -342,12 +346,13 @@ class TestFusionFloating(unittest.TestCase):
         a = testing.shaped_arange((2, 3), xp, dtype)
         return (a,)
 
-    @testing.for_all_dtypes(no_complex=True)
+    @testing.for_all_dtypes_combination(
+        no_complex=True, names=['dtype1', 'dtype2'])
     @testing.numpy_cupy_allclose(atol=1e-5)
     @fusion_default_array_equal()
-    def check_binary(self, name, xp, dtype):
-        a = testing.shaped_arange((2, 3), xp, dtype)
-        b = testing.shaped_reverse_arange((2, 3), xp, dtype)
+    def check_binary(self, name, xp, dtype1, dtype2):
+        a = testing.shaped_arange((2, 3), xp, dtype1)
+        b = testing.shaped_reverse_arange((2, 3), xp, dtype2)
         return a, b
 
     @testing.for_float_dtypes(name='ftype')
@@ -401,28 +406,30 @@ class TestFusionArithmetic(unittest.TestCase):
         a = testing.shaped_arange((2, 3), xp, dtype)
         return (a,)
 
-    @testing.for_all_dtypes()
+    @testing.for_all_dtypes_combination(names=['dtype1', 'dtype2'])
     @testing.numpy_cupy_allclose(atol=1e-5)
     @fusion_default_array_equal()
-    def check_binary(self, name, xp, dtype):
-        a = testing.shaped_arange((2, 3), xp, dtype)
-        b = testing.shaped_reverse_arange((2, 3), xp, dtype)
+    def check_binary(self, name, xp, dtype1, dtype2):
+        a = testing.shaped_arange((2, 3), xp, dtype1)
+        b = testing.shaped_reverse_arange((2, 3), xp, dtype2)
         return a, b
 
-    @testing.for_all_dtypes(no_complex=True)
+    @testing.for_all_dtypes_combination(
+        no_bool=True, no_complex=True, names=['dtype1', 'dtype2'])
     @testing.numpy_cupy_allclose(atol=1e-5)
     @fusion_default_array_equal()
-    def check_binary_without_complex(self, name, xp, dtype):
-        a = testing.shaped_arange((2, 3), xp, dtype)
-        b = testing.shaped_reverse_arange((2, 3), xp, dtype)
+    def check_binary_without_complex_bool(self, name, xp, dtype1, dtype2):
+        a = testing.shaped_arange((2, 3), xp, dtype1)
+        b = testing.shaped_reverse_arange((2, 3), xp, dtype2)
         return a, b
 
-    @testing.for_all_dtypes(no_bool=True)
+    @testing.for_all_dtypes_combination(
+        no_bool=True, names=['dtype1', 'dtype2'])
     @testing.numpy_cupy_allclose(atol=1e-5)
     @fusion_default_array_equal()
-    def check_binary_without_bool(self, name, xp, dtype):
-        a = testing.shaped_arange((2, 3), xp, dtype)
-        b = testing.shaped_reverse_arange((2, 3), xp, dtype)
+    def check_binary_without_bool(self, name, xp, dtype1, dtype2):
+        a = testing.shaped_arange((2, 3), xp, dtype1)
+        b = testing.shaped_reverse_arange((2, 3), xp, dtype2)
         return a, b
 
     @testing.for_dtypes(['?', 'b', 'h', 'i', 'q', 'e', 'f', 'd'])
@@ -432,20 +439,22 @@ class TestFusionArithmetic(unittest.TestCase):
         a = xp.array([-3, -2, -1, 1, 2, 3], dtype=dtype)
         return (a,)
 
-    @testing.for_dtypes(['?', 'b', 'h', 'i', 'q', 'e', 'f', 'd'])
+    @testing.for_dtypes_combination(
+        ['?', 'b', 'h', 'i', 'q', 'e', 'f', 'd'], names=['dtype1', 'dtype2'])
     @testing.numpy_cupy_allclose(atol=1e-5)
     @fusion_default_array_equal()
-    def check_binary_negative(self, name, xp, dtype):
-        a = xp.array([-3, -2, -1, 1, 2, 3], dtype=dtype)
-        b = xp.array([4, 3, 2, 1, -1, -2], dtype=dtype)
+    def check_binary_negative(self, name, xp, dtype1, dtype2):
+        a = xp.array([-3, -2, -1, 1, 2, 3], dtype=dtype1)
+        b = xp.array([4, 3, 2, 1, -1, -2], dtype=dtype2)
         return a, b
 
-    @testing.for_dtypes(['e', 'f', 'd'])
+    @testing.for_dtypes_combination(
+        ['e', 'f', 'd'], names=['dtype1', 'dtype2'])
     @testing.numpy_cupy_allclose(atol=1e-5)
     @fusion_default_array_equal()
-    def check_binary_negative_float(self, name, xp, dtype):
-        a = xp.array([-3, -2, -1, 1, 2, 3], dtype=dtype)
-        b = xp.array([4, 3, 2, 1, -1, -2], dtype=dtype)
+    def check_binary_negative_float(self, name, xp, dtype1, dtype2):
+        a = xp.array([-3, -2, -1, 1, 2, 3], dtype=dtype1)
+        b = xp.array([4, 3, 2, 1, -1, -2], dtype=dtype2)
         return a, b
 
     def test_add(self):
@@ -460,7 +469,7 @@ class TestFusionArithmetic(unittest.TestCase):
 
     def test_divide(self):
         with testing.NumpyError(divide='ignore'):
-            self.check_binary('divide')
+            self.check_binary_without_bool('divide')
 
     def test_divide_negative(self):
         with testing.NumpyError(divide='ignore'):
@@ -475,7 +484,7 @@ class TestFusionArithmetic(unittest.TestCase):
 
     def test_true_divide(self):
         with testing.NumpyError(divide='ignore'):
-            self.check_binary('true_divide')
+            self.check_binary_without_bool('true_divide')
 
     def test_true_divide_negative(self):
         with testing.NumpyError(divide='ignore'):
@@ -483,7 +492,7 @@ class TestFusionArithmetic(unittest.TestCase):
 
     def test_floor_divide(self):
         with testing.NumpyError(divide='ignore'):
-            self.check_binary_without_complex('floor_divide')
+            self.check_binary_without_complex_bool('floor_divide')
 
     def test_floor_divide_negative(self):
         with testing.NumpyError(divide='ignore'):
@@ -491,7 +500,7 @@ class TestFusionArithmetic(unittest.TestCase):
 
     def test_fmod(self):
         with testing.NumpyError(divide='ignore'):
-            self.check_binary_without_complex('fmod')
+            self.check_binary_without_complex_bool('fmod')
 
     def test_fmod_negative(self):
         with testing.NumpyError(divide='ignore'):
@@ -514,7 +523,7 @@ class TestFusionArithmetic(unittest.TestCase):
 
     def test_remainder(self):
         with testing.NumpyError(divide='ignore'):
-            self.check_binary_without_complex('remainder')
+            self.check_binary_without_complex_bool('remainder')
 
     def test_remainder_negative(self):
         with testing.NumpyError(divide='ignore'):


### PR DESCRIPTION
Backport of #1799