### PR TITLE
[backport] Fix incorrect cast in element-wise op for float array and complex scalar

### DIFF
--- a/cupy/core/_kernel.pyx
+++ b/cupy/core/_kernel.pyx
@@ -52,7 +52,7 @@ cdef dict _kind_score = {
     'u': 1,
     'i': 1,
     'f': 2,
-    'c': 3,
+    'c': 2,
 }
 
 

--- a/cupy/core/fusion.py
+++ b/cupy/core/fusion.py
@@ -19,7 +19,7 @@ _kind_score = {
     'u': 1,
     'i': 1,
     'f': 2,
-    'c': 3,
+    'c': 2,
 }
 
 _dtype_to_ctype = {

--- a/tests/cupy_tests/core_tests/test_fusion.py
+++ b/tests/cupy_tests/core_tests/test_fusion.py
@@ -1435,23 +1435,23 @@ class TestFusionKernelName(unittest.TestCase):
 @testing.gpu
 class TestFusionPythonConstant(unittest.TestCase):
 
-    @testing.for_all_dtypes()
+    @testing.for_all_dtypes_combination(names=['dtype1', 'dtype2'])
     @testing.numpy_cupy_array_equal()
-    def test_python_scalar(self, xp, dtype):
+    def test_python_scalar(self, xp, dtype1, dtype2):
 
         @cupy.fuse()
         def f(x):
-            return x * numpy.asscalar(dtype(1))
-        return f(testing.shaped_arange((1,), xp, dtype))
+            return x * numpy.asscalar(dtype2(1))
+        return f(testing.shaped_arange((1,), xp, dtype1))
 
-    @testing.for_all_dtypes()
+    @testing.for_all_dtypes_combination(names=['dtype1', 'dtype2'])
     @testing.numpy_cupy_array_equal()
-    def test_numpy_scalar(self, xp, dtype):
+    def test_numpy_scalar(self, xp, dtype1, dtype2):
 
         @cupy.fuse()
         def f(x):
-            return x * dtype(1)
-        return f(testing.shaped_arange((1,), xp, dtype))
+            return x * dtype2(1)
+        return f(testing.shaped_arange((1,), xp, dtype1))
 
 
 @testing.gpu

--- a/tests/cupy_tests/core_tests/test_ndarray_elementwise_op.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_elementwise_op.py
@@ -11,8 +11,7 @@ from cupy import testing
 @testing.gpu
 class TestArrayElementwiseOp(unittest.TestCase):
 
-    @testing.for_all_dtypes_combination(names=['x_type', 'y_type'],
-                                        no_complex=True)
+    @testing.for_all_dtypes_combination(names=['x_type', 'y_type'])
     @testing.numpy_cupy_allclose(rtol=1e-6, accept_error=TypeError)
     def check_array_scalar_op(self, op, xp, x_type, y_type, swap=False,
                               no_bool=False, no_complex=False):


### PR DESCRIPTION
Backport of #1795