### PR TITLE
Align with the latest numpy docs

### DIFF
--- a/docs/source/reference/binary.rst
+++ b/docs/source/reference/binary.rst
@@ -1,6 +1,8 @@
 Binary Operations
 =================
 
+.. https://docs.scipy.org/doc/numpy/reference/routines.bitwise.html
+
 Elementwise bit operations
 --------------------------
 

--- a/docs/source/reference/creation.rst
+++ b/docs/source/reference/creation.rst
@@ -1,6 +1,8 @@
 Array Creation Routines
 =======================
 
+.. https://docs.scipy.org/doc/numpy/reference/routines.array-creation.html
+
 Basic creation routines
 -----------------------
 

--- a/docs/source/reference/fft.rst
+++ b/docs/source/reference/fft.rst
@@ -3,6 +3,7 @@
 FFT Functions
 =============
 
+.. https://docs.scipy.org/doc/numpy/reference/routines.fft.html
 
 Standard FFTs
 -------------

--- a/docs/source/reference/indexing.rst
+++ b/docs/source/reference/indexing.rst
@@ -1,6 +1,8 @@
 Indexing Routines
 =================
 
+.. https://docs.scipy.org/doc/numpy/reference/routines.indexing.html
+
 .. autosummary::
    :toctree: generated/
    :nosignatures:

--- a/docs/source/reference/io.rst
+++ b/docs/source/reference/io.rst
@@ -1,8 +1,10 @@
 Input and Output
 ================
 
-NPZ files
----------
+.. https://docs.scipy.org/doc/numpy/reference/routines.io.html
+
+NumPy binary files (NPY, NPZ)
+-----------------------------
 
 .. autosummary::
    :toctree: generated/

--- a/docs/source/reference/linalg.rst
+++ b/docs/source/reference/linalg.rst
@@ -1,6 +1,8 @@
 Linear Algebra
 ==============
 
+.. https://docs.scipy.org/doc/numpy/reference/routines.linalg.html
+
 Matrix and vector products
 --------------------------
 
@@ -15,6 +17,7 @@ Matrix and vector products
    cupy.matmul
    cupy.tensordot
    cupy.einsum
+   cupy.linalg.matrix_power
    cupy.kron
 
 Decompositions
@@ -64,5 +67,5 @@ Solving linear equations
    cupy.linalg.inv
    cupy.linalg.pinv
    cupy.linalg.tensorinv
-   
+
    cupyx.scipy.linalg.solve_triangular

--- a/docs/source/reference/logic.rst
+++ b/docs/source/reference/logic.rst
@@ -1,6 +1,8 @@
 Logic Functions
 ===============
 
+.. https://docs.scipy.org/doc/numpy/reference/routines.logic.html
+
 Truth value testing
 -------------------
 
@@ -31,12 +33,12 @@ Array type testing
    :toctree: generated/
    :nosignatures:
 
-   cupy.isscalar
    cupy.iscomplex
    cupy.iscomplexobj
    cupy.isfortran
    cupy.isreal
    cupy.isrealobj
+   cupy.isscalar
 
 
 Logic operations
@@ -52,8 +54,8 @@ Logic operations
    cupy.logical_xor
 
 
-Comparison operations
----------------------
+Comparison
+----------
 
 .. autosummary::
    :toctree: generated/

--- a/docs/source/reference/manipulation.rst
+++ b/docs/source/reference/manipulation.rst
@@ -1,8 +1,10 @@
 Array Manipulation Routines
 ===========================
 
-Basic manipulations
--------------------
+.. https://docs.scipy.org/doc/numpy/reference/routines.array-manipulation.html
+
+Basic operations
+----------------
 
 .. autosummary::
    :toctree: generated/
@@ -11,8 +13,8 @@ Basic manipulations
    cupy.copyto
 
 
-Shape manipulation
-------------------
+Changing array shape
+--------------------
 
 .. autosummary::
    :toctree: generated/
@@ -22,8 +24,8 @@ Shape manipulation
    cupy.ravel
 
 
-Transposition
--------------
+Transpose-like operations
+-------------------------
 
 .. autosummary::
    :toctree: generated/
@@ -32,10 +34,11 @@ Transposition
    cupy.moveaxis
    cupy.rollaxis
    cupy.swapaxes
+   cupy.ndarray.T
    cupy.transpose
 
 
-Edit dimensionalities
+Changing number of dimensions
 ---------------------
 
 .. autosummary::
@@ -46,8 +49,8 @@ Edit dimensionalities
    cupy.atleast_2d
    cupy.atleast_3d
    cupy.broadcast
-   cupy.broadcast_arrays
    cupy.broadcast_to
+   cupy.broadcast_arrays
    cupy.expand_dims
    cupy.squeeze
 
@@ -65,8 +68,8 @@ Changing kind of array
    cupy.ascontiguousarray
 
 
-Joining arrays along axis
--------------------------
+Joining arrays
+--------------
 
 .. autosummary::
    :toctree: generated/
@@ -80,8 +83,8 @@ Joining arrays along axis
    cupy.vstack
 
 
-Splitting arrays along axis
----------------------------
+Splitting arrays
+----------------
 
 .. autosummary::
    :toctree: generated/
@@ -94,7 +97,7 @@ Splitting arrays along axis
    cupy.vsplit
 
 
-Repeating part of arrays along axis
+Tiling arrays
 -----------------------------------
 
 .. autosummary::

--- a/docs/source/reference/math.rst
+++ b/docs/source/reference/math.rst
@@ -1,6 +1,8 @@
 Mathematical Functions
 ======================
 
+.. https://docs.scipy.org/doc/numpy/reference/routines.math.html
+
 Trigonometric functions
 -----------------------
 
@@ -16,10 +18,10 @@ Trigonometric functions
    cupy.arctan
    cupy.hypot
    cupy.arctan2
-   cupy.deg2rad
-   cupy.rad2deg
    cupy.degrees
    cupy.radians
+   cupy.deg2rad
+   cupy.rad2deg
 
 
 Hyperbolic functions
@@ -47,27 +49,27 @@ Rounding
    cupy.around
    cupy.round_
    cupy.rint
+   cupy.fix
    cupy.floor
    cupy.ceil
    cupy.trunc
-   cupy.fix
 
 
-Sums and products
------------------
+Sums, products, differences
+---------------------------
 
 .. autosummary::
    :toctree: generated/
    :nosignatures:
 
-   cupy.sum
    cupy.prod
-   cupy.cumsum
+   cupy.sum
    cupy.cumprod
+   cupy.cumsum
 
 
-Exponential and logarithm functions
------------------------------------
+Exponents and logarithms
+------------------------
 
 .. autosummary::
    :toctree: generated/
@@ -95,8 +97,8 @@ Other special functions
    cupy.sinc
 
 
-Floating point manipulations
-----------------------------
+Floating point routines
+-----------------------
 
 .. autosummary::
    :toctree: generated/
@@ -104,8 +106,8 @@ Floating point manipulations
 
    cupy.signbit
    cupy.copysign
-   cupy.ldexp
    cupy.frexp
+   cupy.ldexp
    cupy.nextafter
 
 
@@ -116,19 +118,20 @@ Arithmetic operations
    :toctree: generated/
    :nosignatures:
 
-   cupy.negative
    cupy.add
-   cupy.subtract
+   cupy.reciprocal
+   cupy.negative
    cupy.multiply
    cupy.divide
+   cupy.power
+   cupy.subtract
    cupy.true_divide
    cupy.floor_divide
-   cupy.power
    cupy.fmod
    cupy.mod
-   cupy.remainder
    cupy.modf
-   cupy.reciprocal
+   cupy.remainder
+   cupy.divmod
 
 
 Handling complex numbers
@@ -153,6 +156,7 @@ Miscellaneous
 
    cupy.clip
    cupy.sqrt
+   cupy.cbrt
    cupy.square
    cupy.absolute
    cupy.sign

--- a/docs/source/reference/ndimage.rst
+++ b/docs/source/reference/ndimage.rst
@@ -7,6 +7,7 @@ It supports a subset of :mod:`scipy.ndimage` interface.
 
 .. module:: cupyx.scipy.ndimage
 
+.. https://docs.scipy.org/doc/scipy/reference/ndimage.html
 
 Interpolation
 -------------

--- a/docs/source/reference/pad.rst
+++ b/docs/source/reference/pad.rst
@@ -1,6 +1,8 @@
 Padding
 ================================
 
+.. https://docs.scipy.org/doc/numpy/reference/routines.padding.html
+
 .. autosummary::
    :toctree: generated/
    :nosignatures:

--- a/docs/source/reference/random.rst
+++ b/docs/source/reference/random.rst
@@ -3,6 +3,8 @@
 Random Sampling (``cupy.random``)
 =================================
 
+.. https://docs.scipy.org/doc/numpy/reference/routines.random.html
+
 The big difference of :mod:`cupy.random` from :mod:`numpy.random` is that :mod:`cupy.random` supports ``dtype`` option for most functions.
 This option enables us to generate float32 values directly without any space overhead.
 
@@ -17,7 +19,6 @@ Sample random data
    :toctree: generated/
    :nosignatures:
 
-   cupy.random.choice
    cupy.random.rand
    cupy.random.randn
    cupy.random.randint
@@ -26,6 +27,7 @@ Sample random data
    cupy.random.random
    cupy.random.ranf
    cupy.random.sample
+   cupy.random.choice
    cupy.random.bytes
 
 
@@ -73,17 +75,17 @@ Distributions
    cupy.random.zipf
 
 
-Random number generator
------------------------
+Random generator
+----------------
 
 .. autosummary::
    :toctree: generated/
    :nosignatures:
 
+   cupy.random.RandomState
    cupy.random.seed
    cupy.random.get_random_state
    cupy.random.set_random_state
-   cupy.random.RandomState
 
 
 Permutations

--- a/docs/source/reference/scipy.rst
+++ b/docs/source/reference/scipy.rst
@@ -4,7 +4,7 @@ SciPy-compatible Routines
 
 The following pages describe SciPy-compatible routines.
 These functions cover a subset of
-`SciPy routines <https://docs.scipy.org/doc/scipy/reference/routines.html#api-reference>`_.
+`SciPy routines <https://docs.scipy.org/doc/scipy/reference/#api-reference>`_.
 
 
 .. module:: cupyx.scipy

--- a/docs/source/reference/sorting.rst
+++ b/docs/source/reference/sorting.rst
@@ -1,6 +1,11 @@
 Sorting, Searching, and Counting
 ================================
 
+.. https://docs.scipy.org/doc/numpy/reference/routines.sort.html
+
+Sorting
+-------
+
 .. autosummary::
    :toctree: generated/
    :nosignatures:
@@ -8,12 +13,29 @@ Sorting, Searching, and Counting
    cupy.sort
    cupy.lexsort
    cupy.argsort
+   cupy.ndarray.sort
    cupy.msort
-   cupy.argmax
-   cupy.argmin
    cupy.partition
    cupy.argpartition
-   cupy.count_nonzero
+
+Searching
+---------
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+
+   cupy.argmax
+   cupy.argmin
    cupy.nonzero
    cupy.flatnonzero
    cupy.where
+
+Counting
+--------
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+
+   cupy.count_nonzero

--- a/docs/source/reference/sparse.rst
+++ b/docs/source/reference/sparse.rst
@@ -2,6 +2,8 @@
 Sparse matrices
 ---------------
 
+.. https://docs.scipy.org/doc/scipy/reference/sparse.html
+
 CuPy supports sparse matrices using `cuSPARSE <https://developer.nvidia.com/cusparse>`_.
 These matrices have the same interfaces of `SciPy's sparse matrices <https://docs.scipy.org/doc/scipy/reference/sparse.html>`_.
 
@@ -10,7 +12,7 @@ These matrices have the same interfaces of `SciPy's sparse matrices <https://doc
 Conversion to/from SciPy sparse matrices
 ----------------------------------------
 
-``cupyx.scipy.sparse.*_matrix`` and ``cupyx.scipy.sparse.*_matrix`` are not implicitly convertible to each other.
+``cupyx.scipy.sparse.*_matrix`` and ``scipy.sparse.*_matrix`` are not implicitly convertible to each other.
 That means, SciPy functions cannot take ``cupyx.scipy.sparse.*_matrix`` objects as inputs, and vice versa.
 
 - To convert SciPy sparse matrices to CuPy, pass it to the constructor of each CuPy sparse matrix class.
@@ -27,8 +29,8 @@ Sparse matrix classes
    :nosignatures:
 
    cupyx.scipy.sparse.coo_matrix
-   cupyx.scipy.sparse.csr_matrix
    cupyx.scipy.sparse.csc_matrix
+   cupyx.scipy.sparse.csr_matrix
    cupyx.scipy.sparse.dia_matrix
    cupyx.scipy.sparse.spmatrix
 
@@ -67,6 +69,8 @@ Identifying sparse matrices
 
 Linear Algebra
 ~~~~~~~~~~~~~~
+
+.. https://docs.scipy.org/doc/scipy/reference/sparse.linalg.html
 
 .. autosummary::
    :toctree: generated/

--- a/docs/source/reference/special.rst
+++ b/docs/source/reference/special.rst
@@ -1,8 +1,10 @@
 Special Functions
 =================
 
-Faster versions of common Bessel Functions
-------------------------------------------
+.. https://docs.scipy.org/doc/scipy/reference/special.html
+
+Bessel Functions
+----------------
 
 .. autosummary::
    :toctree: generated/
@@ -22,11 +24,21 @@ Gamma and Related Functions
 .. autosummary::
    :toctree: generated/
    :nosignatures:
-   
+
    cupyx.scipy.special.gamma
    cupyx.scipy.special.gammaln
-   cupyx.scipy.special.digamma
    cupyx.scipy.special.polygamma
+   cupyx.scipy.special.digamma
+
+
+Raw Statistical Functions
+-------------------------
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+
+   cupyx.scipy.special.ndtr
 
 
 Error Function
@@ -41,16 +53,6 @@ Error Function
    cupyx.scipy.special.erfcx
    cupyx.scipy.special.erfinv
    cupyx.scipy.special.erfcinv
-
-
-Raw Statistical Functions
--------------------------
-
-.. autosummary::
-   :toctree: generated/
-   :nosignatures:
-
-   cupyx.scipy.special.ndtr
 
 
 Other Special Functions

--- a/docs/source/reference/statistics.rst
+++ b/docs/source/reference/statistics.rst
@@ -1,5 +1,7 @@
-Statistics
-==========
+Statistical Functions
+=====================
+
+.. https://docs.scipy.org/doc/scipy/reference/stats.html
 
 Order statistics
 ----------------

--- a/docs/source/reference/ufunc.rst
+++ b/docs/source/reference/ufunc.rst
@@ -1,6 +1,8 @@
 Universal Functions (ufunc)
 ===========================
 
+.. https://docs.scipy.org/doc/numpy/reference/ufuncs.html
+
 CuPy provides universal functions (a.k.a. ufuncs) to support various elementwise operations.
 CuPy's ufunc supports following features of NumPy's one:
 
@@ -122,8 +124,8 @@ Comparison functions
    cupy.fmin
 
 
-Floating point values
-~~~~~~~~~~~~~~~~~~~~~
+Floating functions
+~~~~~~~~~~~~~~~~~~
 
 .. autosummary::
    :toctree: generated/


### PR DESCRIPTION
* Align order of functions and headings to the latest NumPy reference.
* Fix `cupy.divmod` and `cupy.cbrt` are undocumented.
* Fix dead link to SciPy routines.