### PR TITLE
[backport] Fix invalid memory access during reduction whose output is large to exceed 32-bit

### DIFF
--- a/cupy/core/reduction.pxi
+++ b/cupy/core/reduction.pxi
@@ -32,17 +32,18 @@ extern "C" __global__ void ${name}(${params}) {
   unsigned int _tid = threadIdx.x;
 
   int _J_offset = _tid >> __popc(_block_stride - 1);  // _tid / _block_stride
-  int _j_offset = _J_offset * _out_ind.size();
+  ptrdiff_t _j_offset = (ptrdiff_t)_J_offset * _out_ind.size();
   int _J_stride = ${block_size} >> __popc(_block_stride - 1);
-  long long _j_stride = (long long)_J_stride * _out_ind.size();
+  ptrdiff_t _j_stride = (ptrdiff_t)_J_stride * _out_ind.size();
 
-  for (int _i_base = blockIdx.x * _block_stride;
+  for (ptrdiff_t _i_base = (ptrdiff_t)blockIdx.x * _block_stride;
        _i_base < _out_ind.size();
-       _i_base += gridDim.x * _block_stride) {
+       _i_base += (ptrdiff_t)gridDim.x * _block_stride) {
     _type_reduce _s = _type_reduce(${identity});
-    int _i = _i_base + (_tid & (_block_stride - 1));  // _tid % _block_stride
+    ptrdiff_t _i =
+        _i_base + (_tid & (_block_stride - 1));  // _tid % _block_stride
     int _J = _J_offset;
-    for (long long _j = _i + _j_offset; _j < _in_ind.size();
+    for (ptrdiff_t _j = _i + _j_offset; _j < _in_ind.size();
          _j += _j_stride, _J += _J_stride) {
       _in_ind.set(_j);
       ${input_expr}

--- a/tests/cupy_tests/core_tests/test_carray.py
+++ b/tests/cupy_tests/core_tests/test_carray.py
@@ -48,27 +48,28 @@ class TestCArray(unittest.TestCase):
 
 
 @testing.parameterize(
-    {"size": 2 ** 32 + 1024},
-    {"size": 2 ** 32},
-    {"size": 2 ** 32 - 1024},
-    {"size": 2 ** 31 + 1024},
-    {"size": 2 ** 31},
     {"size": 2 ** 31 - 1024},
+    {"size": 2 ** 31},
+    {"size": 2 ** 31 + 1024},
+    {"size": 2 ** 32 - 1024},
+    {"size": 2 ** 32},
+    {"size": 2 ** 32 + 1024},
 )
 @testing.slow
 class TestCArray32BitBoundary(unittest.TestCase):
     # This test case is intended to confirm CArray indexing work correctly
-    # with arrays whose size is so large that it crosses the 32-bit boundary.
+    # with input/output arrays whose size is so large that it crosses the
+    # 32-bit boundary (in terms of both number of elements and size in bytes).
+    # This test requires approx. 8 GiB GPU memory to run.
     # See https://github.com/cupy/cupy/pull/882 for detailed discussions.
 
     def tearDown(self):
         # Free huge memory for slow test
         cupy.get_default_memory_pool().free_all_blocks()
 
-    @testing.numpy_cupy_equal()
-    def test(self, xp):
+    def test(self):
         # Elementwise
-        a = xp.ones(self.size, dtype='b')
+        a = cupy.full((1, self.size), 7, dtype=cupy.int8)
         # Reduction
-        result = a.sum()
-        return result
+        result = a.sum(axis=0, dtype=cupy.int8)
+        assert result.sum() == self.size * 7


### PR DESCRIPTION
Backport of #1774