### PR TITLE
Revert "Support compile-time constants in Fusion"

### DIFF
--- a/cupy/core/fusion.py
+++ b/cupy/core/fusion.py
@@ -651,7 +651,7 @@ class _FusionHistory(object):
             operation=operation)
         return module_code
 
-    def get_fusion(self, func, in_dtypes, name, const_params):
+    def get_fusion(self, func, in_dtypes, name):
         """This generates CUDA kernel from the given function and dtypes.
 
         This function generates ElementwiseKernel or ReductioKernel from the
@@ -668,7 +668,7 @@ class _FusionHistory(object):
         """
         in_params = [self._fresh_premap_param(t) for t in in_dtypes]
         in_pvars = [FusionVarPython(_, False) for _ in in_params]
-        return_value = func(*in_pvars, **const_params)
+        return_value = func(*in_pvars)
 
         if isinstance(return_value, tuple):
             return_tuple = True
@@ -764,24 +764,35 @@ class Fusion(object):
         name (str): The name of the function.
     """
 
-    def __init__(self, func, name=None, const_params=None):
+    def __init__(self, func, name=None):
         self.func = func
         self.name = name or func.__name__
         self._memo = {}
-        self._const_params = {} if const_params is None else const_params
 
     def __repr__(self):
         return '<Fusion \'{}\'>'.format(self.name)
 
-    def _is_cupy_data(self, a):
-        return isinstance(a, (core.ndarray, numpy.generic))
+    def __call__(self, *args, **kwargs):
+        if not hasattr(_thread_local, 'history'):
+            func, kw = self._compile(*args, **kwargs)
+            kwargs = dict(kwargs, **kw)
+            return func(*args, **kwargs)
+        else:
+            return self.func(*args, **kwargs)
 
-    def __call__(self, *args):
-        # Inner function of composition of multiple fused functions.
-        if hasattr(_thread_local, 'history'):
-            return self.func(*args, **self._const_params)
+    def _compile_from_dtypes(self, *dtypes):
+        assert not hasattr(_thread_local, 'history')
+        _thread_local.history = _FusionHistory()
+        try:
+            key = tuple(dtypes)
+            if key not in self._memo:
+                self._memo[key] = _thread_local.history.get_fusion(
+                    self.func, dtypes, self.name)
+            return self._memo[key]
+        finally:
+            del _thread_local.history
 
-        # Invalid argument types
+    def _compile(self, *args, **kwargs):
         if builtins.any(
                 not isinstance(_, (core.ndarray, numpy.ndarray, numpy.generic))
                 for _ in args):
@@ -789,25 +800,18 @@ class Fusion(object):
                 self.name,
                 ', '.join(repr(type(_)) for _ in args)))
 
-        # Fail to fuse
-        if not builtins.all(self._is_cupy_data(_) for _ in args):
-            # Arguments include some CuPy ndarrays
+        def is_cupy_data(a):
+            return isinstance(a, (core.ndarray, numpy.generic))
+        if builtins.all(is_cupy_data(_) for _ in args):
+            dtypes = [_.dtype for _ in args]
+            return self._compile_from_dtypes(*dtypes)
+        else:
             if builtins.any(type(_) is core.ndarray for _ in args):
                 types_str = '.'.join(repr(type(_)) for _ in args)
                 message = 'Can\'t fuse \n {}({})'.format(self.name, types_str)
                 warnings.warn(message)
-            return self.func(*args, **self._const_params)
-
-        dtypes = tuple(_.dtype for _ in args)
-        if dtypes not in self._memo:
-            try:
-                _thread_local.history = _FusionHistory()
-                self._memo[dtypes] = _thread_local.history.get_fusion(
-                    self.func, dtypes, self.name, self._const_params)
-            finally:
-                del _thread_local.history
-        kernel, kwargs = self._memo[dtypes]
-        return kernel(*args, **kwargs)
+            else:
+                return self.func, {}
 
     def clear_cache(self):
         self._memo = {}
@@ -824,7 +828,6 @@ def fuse(*args, **kwargs):
     Args:
         kernel_name (str): Name of the fused kernel function.
             If omitted, the name of the decorated function is used.
-        const_params (dict): Compile time constants in kernel function.
 
     .. note::
        This API is currently experimental and the interface may be changed in
@@ -832,11 +835,11 @@ def fuse(*args, **kwargs):
 
     """
 
-    def wrapper(f, kernel_name=None, const_params=None):
-        return Fusion(f, kernel_name, const_params)
+    def wrapper(f, kernel_name=None):
+        return Fusion(f, kernel_name)
 
-    if len(args) >= 1 and callable(args[0]):
-        return functools.update_wrapper(wrapper(*args, **kwargs), args[0])
+    if len(args) == 1 and len(kwargs) == 0 and callable(args[0]):
+        return functools.update_wrapper(wrapper(args[0]), args[0])
     else:
         return lambda f: functools.update_wrapper(
             wrapper(f, *args, **kwargs), f)

--- a/tests/cupy_tests/core_tests/test_fusion.py
+++ b/tests/cupy_tests/core_tests/test_fusion.py
@@ -1556,6 +1556,18 @@ class TestFusionCompile(unittest.TestCase):
 
     @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_array_equal()
+    def test_compile_from_dtypes(self, xp, dtype):
+        @cupy.fuse()
+        def f(x, y):
+            return x - y * 2
+
+        x = testing.shaped_arange((3, 3), xp, dtype)
+        y = testing.shaped_arange((3, 3), xp, dtype)
+        f._compile_from_dtypes(x.dtype, y.dtype)
+        return f(x, y)
+
+    @testing.for_all_dtypes(no_bool=True)
+    @testing.numpy_cupy_array_equal()
     def test_clear_cache(self, xp, dtype):
         @cupy.fuse()
         def f(x, y):
@@ -1606,7 +1618,6 @@ class TestFusionThread(unittest.TestCase):
 
     @testing.numpy_cupy_array_equal()
     def test_thread_multiple_dtypes(self, xp):
-        # A fusion class set thread_local for each dtypes of input parameters.
         x1 = testing.shaped_arange((3, 3), xp, xp.int64)
         y1 = testing.shaped_arange((3, 3), xp, xp.int64)
         x2 = x1.astype(xp.float64)
@@ -1671,67 +1682,3 @@ class TestBroadcast(unittest.TestCase):
         x = testing.shaped_arange((3, 4), xp, xp.int64)
         y = testing.shaped_arange((2, 3, 4), xp, xp.int64)
         return f(x, y)
-
-
-class TestFusionConstParams(unittest.TestCase):
-
-    @testing.for_all_dtypes()
-    @testing.numpy_cupy_array_equal()
-    def test_const_params(self, xp, dtype):
-
-        @cupy.fuse(const_params={'const_x': 1, 'xp': xp})
-        def f(x, const_x, xp):
-            return xp.square(x + const_x)
-
-        x = testing.shaped_arange((3, 4), xp, dtype)
-        return f(x)
-
-    @testing.for_all_dtypes()
-    @testing.numpy_cupy_array_equal()
-    def test_const_params_multiple_kernels(self, xp, dtype):
-
-        def f(x, const_x, xp):
-            return xp.square(x + const_x)
-
-        f1 = cupy.fuse(f, const_params={'const_x': 1, 'xp': xp})
-        f2 = cupy.fuse(f, const_params={'const_x': 20, 'xp': xp})
-
-        x = testing.shaped_arange((3, 4), xp, dtype)
-        return f1(x) + f2(x)
-
-    @testing.for_all_dtypes()
-    @testing.numpy_cupy_array_equal()
-    def test_const_params_composition(self, xp, dtype):
-
-        @cupy.fuse(const_params={'const_x': 1, 'xp': xp})
-        def f(x, const_x, xp):
-            return xp.square(x + const_x)
-
-        @cupy.fuse(const_params={'const_x': 1, 'xp': xp})
-        def g(x, const_x, xp):
-            return xp.square(f(x) + const_x)
-
-        x = testing.shaped_arange((3, 4), xp, dtype)
-        return g(x)
-
-    @testing.for_all_dtypes()
-    @testing.numpy_cupy_raises()
-    def test_const_params_extra(self, xp, dtype):
-
-        @cupy.fuse(const_params={'const_x': 1, 'xp': xp, 'extra': 1})
-        def f(x, const_x, xp):
-            return xp.square(x + const_x)
-
-        x = testing.shaped_arange((3, 4), xp, dtype)
-        return f(x)
-
-    @testing.for_all_dtypes()
-    @testing.numpy_cupy_raises()
-    def test_const_params_lack(self, xp, dtype):
-
-        @cupy.fuse(const_params={'const_x': 1})
-        def f(x, const_x, xp):
-            return xp.square(x + const_x)
-
-        x = testing.shaped_arange((3, 4), xp, dtype)
-        return f(x)


### PR DESCRIPTION
Reverts cupy/cupy#1594
I mistook.