### PR TITLE
Add `ndarray.item` method

### DIFF
--- a/cupy/core/core.pxd
+++ b/cupy/core/core.pxd
@@ -18,6 +18,7 @@ cdef class ndarray:
         # underlying memory is UnownedMemory.
         readonly ndarray base
 
+    cpdef item(self)
     cpdef tolist(self)
     cpdef tofile(self, fid, sep=*, format=*)
     cpdef dump(self, file)

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -290,7 +290,19 @@ cdef class ndarray:
     # -------------------------------------------------------------------------
     # Array conversion
     # -------------------------------------------------------------------------
-    # TODO(okuta): Implement item
+    cpdef item(self):
+        """Converts the array with one element to a Python scalar
+
+        Returns:
+            int or float or complex: The element of the array.
+
+        .. seealso:: :meth:`numpy.ndarray.item`
+
+        """
+        if self.size != 1:
+            raise ValueError(
+                'can only convert an array of size 1 to a Python scalar')
+        return self.get().item()
 
     cpdef tolist(self):
         """Converts the array to a (possibly nested) Python list.

--- a/tests/cupy_tests/core_tests/test_ndarray_conversion.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_conversion.py
@@ -1,0 +1,30 @@
+import unittest
+
+from cupy import testing
+
+
+@testing.parameterize(
+    {"shape": ()},
+    {"shape": (1,)},
+    {"shape": (1, 1, 1)},
+)
+class TestNdarrayItem(unittest.TestCase):
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_equal()
+    def test_item(self, xp, dtype):
+        a = xp.full(self.shape, 3, dtype)
+        return a.item()
+
+
+@testing.parameterize(
+    {"shape": (0,)},
+    {"shape": (2, 3)},
+    {"shape": (1, 0, 1)},
+)
+class TestNdarrayItemRaise(unittest.TestCase):
+
+    @testing.numpy_cupy_raises()
+    def test_item(self, xp):
+        a = testing.shaped_arange(self.shape, xp, xp.float32)
+        a.item()


### PR DESCRIPTION
The `numpy.ndarray.item` method converts an array to a Python scalar (`int`, `float`, or `complex`).
I believe it's reasonable for `cupy.ndarray.item` to return a Python scalar, which is on CPU, too.