### PR TITLE
Allow multi-axis `roll` as in numpy 1.12+

### DIFF
--- a/cupy/core/reduction.pxi
+++ b/cupy/core/reduction.pxi
@@ -99,7 +99,11 @@ cpdef tuple _get_axis(object axis, Py_ssize_t ndim):
 
     for dim in axis:
         if dim < -ndim or dim >= ndim:
-            raise ValueError('Axis overrun')
+            try:
+                raise numpy.AxisError('Axis overrun')
+            except AttributeError:
+                # AxisError didn't exist prior to numpy 1.13
+                raise ValueError('Axis overrun')
     reduce_axis = tuple(sorted([dim % ndim for dim in axis]))
     out_axis = tuple([dim for dim in range(ndim) if dim not in reduce_axis])
     return reduce_axis, out_axis

--- a/cupy/core/reduction.pxi
+++ b/cupy/core/reduction.pxi
@@ -99,11 +99,8 @@ cpdef tuple _get_axis(object axis, Py_ssize_t ndim):
 
     for dim in axis:
         if dim < -ndim or dim >= ndim:
-            try:
-                raise numpy.AxisError('Axis overrun')
-            except AttributeError:
-                # AxisError didn't exist prior to numpy 1.13
-                raise ValueError('Axis overrun')
+            from cupy.core.core import _AxisError
+            raise _AxisError('Axis overrun')
     reduce_axis = tuple(sorted([dim % ndim for dim in axis]))
     out_axis = tuple([dim for dim in range(ndim) if dim not in reduce_axis])
     return reduce_axis, out_axis

--- a/cupy/manipulation/rearrange.py
+++ b/cupy/manipulation/rearrange.py
@@ -73,12 +73,18 @@ def flipud(a):
 def roll(a, shift, axis=None):
     """Roll array elements along a given axis.
 
+    Elements that roll beyond the last position are re-introduced at the first.
+
     Args:
         a (~cupy.ndarray): Array to be rolled.
-        shift (int): The number of places by which elements are shifted.
-        axis (int or None): The axis along which elements are shifted.
-            If ``axis`` is ``None``, the array is flattened before shifting,
-            and after that it is reshaped to the original shape.
+        shift (int or tuple of int): The number of places by which elements are
+            shifted. If a tuple, then `axis` must be a tuple of the same size,
+            and each of the given axes is shifted by the corresponding number.
+            If an int while `axis` is a tuple of ints, then the same value is
+            used for all given axes.
+        axis (int or tuple of int or None): The axis along which elements are
+            shifted. By default, the array is flattened before shifting, after
+            which the original shape is restored.
 
     Returns:
         ~cupy.ndarray: Output array.
@@ -86,40 +92,34 @@ def roll(a, shift, axis=None):
     .. seealso:: :func:`numpy.roll`
 
     """
+    a = asanyarray(a)
     if axis is None:
-        if a.size == 0:
-            return a
-        size = a.size
-        ra = a.ravel()
-        shift %= size
-        res = cupy.empty((size,), a.dtype)
-        res[:shift] = ra[size - shift:]
-        res[shift:] = ra[:size - shift]
-        return res.reshape(a.shape)
+        return roll(a.ravel(), shift, 0).reshape(a.shape)
+
     else:
-        axis = int(axis)
-        if axis < 0:
-            axis += a.ndim
-        if not 0 <= axis < a.ndim:
-            raise core.core._AxisError(
-                'axis must be >= %d and < %d' % (-a.ndim, a.ndim))
-        size = a.shape[axis]
-        if size == 0:
-            return a
-        shift %= size
-        prev = (slice(None),) * axis
-        rest = (slice(None),) * (a.ndim - axis - 1)
-        # Roll only the dimensiont at the given axis
-        # ind1 is [:, ..., size-shift:, ..., :]
-        # ind2 is [:, ..., :size-shift, ..., :]
-        ind1 = prev + (slice(size - shift, None, None),) + rest
-        ind2 = prev + (slice(None, size - shift, None),) + rest
-        r_ind1 = prev + (slice(None, shift, None),) + rest
-        r_ind2 = prev + (slice(shift, None, None),) + rest
-        res = cupy.empty_like(a)
-        res[r_ind1] = a[ind1]
-        res[r_ind2] = a[ind2]
-        return res
+        axis = normalize_axis_tuple(axis, a.ndim, allow_duplicate=True)
+        broadcasted = broadcast(shift, axis)
+        if broadcasted.ndim > 1:
+            raise ValueError(
+                "'shift' and 'axis' should be scalars or 1D sequences")
+        shifts = {ax: 0 for ax in range(a.ndim)}
+        for sh, ax in broadcasted:
+            shifts[ax] += sh
+
+        rolls = [((slice(None), slice(None)),)] * a.ndim
+        for ax, offset in shifts.items():
+            offset %= a.shape[ax] or 1  # If `a` is empty, nothing matters.
+            if offset:
+                # (original, result), (original, result)
+                rolls[ax] = ((slice(None, -offset), slice(offset, None)),
+                             (slice(-offset, None), slice(None, offset)))
+
+        result = empty_like(a)
+        for indices in itertools.product(*rolls):
+            arr_index, res_index = zip(*indices)
+            result[res_index] = a[arr_index]
+
+        return result
 
 
 def rot90(a, k=1, axes=(0, 1)):

--- a/cupy/manipulation/rearrange.py
+++ b/cupy/manipulation/rearrange.py
@@ -103,7 +103,7 @@ def roll(a, shift, axis=None):
         axis = _get_axis(axis, a.ndim)[0]
 
         broadcasted = numpy.broadcast(shift, axis)
-        if broadcasted.ndim > 1:
+        if broadcasted.nd > 1:
             raise ValueError(
                 "'shift' and 'axis' should be scalars or 1D sequences")
         shifts = {ax: 0 for ax in range(a.ndim)}

--- a/cupy/manipulation/rearrange.py
+++ b/cupy/manipulation/rearrange.py
@@ -10,7 +10,6 @@ try:
 except ImportError:
     # TODO: remove this copy once minimum supported is numpy >= 1.13.
 
-
     def normalize_axis_tuple(axis, ndim, argname=None, allow_duplicate=False):
         """
         Normalizes an axis argument into a tuple of non-negative integer axes.

--- a/cupy/manipulation/rearrange.py
+++ b/cupy/manipulation/rearrange.py
@@ -1,9 +1,76 @@
 import itertools
 import numpy
-from numpy.core.numeric import normalize_axis_tuple
+
 
 import cupy
 from cupy import core
+
+try:
+    from numpy.core.numeric import normalize_axis_tuple
+except ImportError:
+    # TODO: remove this copy once minimum supported is numpy >= 1.13.
+
+
+    def normalize_axis_tuple(axis, ndim, argname=None, allow_duplicate=False):
+        """
+        Normalizes an axis argument into a tuple of non-negative integer axes.
+
+        This handles shorthands such as ``1`` and converts them to ``(1,)``,
+        as well as performing the handling of negative indices covered by
+        `normalize_axis_index`.
+
+        By default, this forbids axes from being specified multiple times.
+
+        Used internally by multi-axis-checking logic.
+
+        .. versionadded:: 1.13.0
+
+        Parameters
+        ----------
+        axis : int, iterable of int
+            The un-normalized index or indices of the axis.
+        ndim : int
+            The number of dimensions of the array that `axis` should be
+            normalized against.
+        argname : str, optional
+            A prefix to put before the error message, typically the name of the
+            argument.
+        allow_duplicate : bool, optional
+            If False, the default, disallow an axis from being specified twice.
+
+        Returns
+        -------
+        normalized_axes : tuple of int
+            The normalized axis index, such that `0 <= normalized_axis < ndim`
+
+        Raises
+        ------
+        AxisError
+            If any axis provided is out of range
+        ValueError
+            If an axis is repeated
+
+        See also
+        --------
+        normalize_axis_index : normalizing a single scalar axis
+        """
+        import operator
+        from numpy.core.multiarray import normalize_axis_index
+        # Optimization to speed-up the most common cases.
+        if type(axis) not in (tuple, list):
+            try:
+                axis = [operator.index(axis)]
+            except TypeError:
+                pass
+        # Going via an iterator directly is slower than via list comprehension.
+        axis = tuple([normalize_axis_index(ax, ndim, argname) for ax in axis])
+        if not allow_duplicate and len(set(axis)) != len(axis):
+            if argname:
+                raise ValueError(
+                    'repeated axis in `{}` argument'.format(argname))
+            else:
+                raise ValueError('repeated axis')
+        return axis
 
 
 def flip(a, axis):

--- a/cupy/manipulation/rearrange.py
+++ b/cupy/manipulation/rearrange.py
@@ -1,6 +1,6 @@
 import itertools
-import numpy
 
+import numpy
 
 import cupy
 from cupy import core

--- a/cupy/manipulation/rearrange.py
+++ b/cupy/manipulation/rearrange.py
@@ -1,3 +1,7 @@
+import itertools
+import numpy
+from numpy.core.numeric import normalize_axis_tuple
+
 import cupy
 from cupy import core
 
@@ -92,13 +96,12 @@ def roll(a, shift, axis=None):
     .. seealso:: :func:`numpy.roll`
 
     """
-    a = asanyarray(a)
     if axis is None:
         return roll(a.ravel(), shift, 0).reshape(a.shape)
 
     else:
         axis = normalize_axis_tuple(axis, a.ndim, allow_duplicate=True)
-        broadcasted = broadcast(shift, axis)
+        broadcasted = numpy.broadcast(shift, axis)
         if broadcasted.ndim > 1:
             raise ValueError(
                 "'shift' and 'axis' should be scalars or 1D sequences")
@@ -114,7 +117,7 @@ def roll(a, shift, axis=None):
                 rolls[ax] = ((slice(None, -offset), slice(offset, None)),
                              (slice(-offset, None), slice(None, offset)))
 
-        result = empty_like(a)
+        result = cupy.empty_like(a)
         for indices in itertools.product(*rolls):
             arr_index, res_index = zip(*indices)
             result[res_index] = a[arr_index]

--- a/cupy/manipulation/rearrange.py
+++ b/cupy/manipulation/rearrange.py
@@ -4,72 +4,7 @@ import numpy
 
 import cupy
 from cupy import core
-
-try:
-    from numpy.core.numeric import normalize_axis_tuple
-except ImportError:
-    # TODO: remove this copy once minimum supported is numpy >= 1.13.
-
-    def normalize_axis_tuple(axis, ndim, argname=None, allow_duplicate=False):
-        """
-        Normalizes an axis argument into a tuple of non-negative integer axes.
-
-        This handles shorthands such as ``1`` and converts them to ``(1,)``,
-        as well as performing the handling of negative indices covered by
-        `normalize_axis_index`.
-
-        By default, this forbids axes from being specified multiple times.
-
-        Used internally by multi-axis-checking logic.
-
-        .. versionadded:: 1.13.0
-
-        Parameters
-        ----------
-        axis : int, iterable of int
-            The un-normalized index or indices of the axis.
-        ndim : int
-            The number of dimensions of the array that `axis` should be
-            normalized against.
-        argname : str, optional
-            A prefix to put before the error message, typically the name of the
-            argument.
-        allow_duplicate : bool, optional
-            If False, the default, disallow an axis from being specified twice.
-
-        Returns
-        -------
-        normalized_axes : tuple of int
-            The normalized axis index, such that `0 <= normalized_axis < ndim`
-
-        Raises
-        ------
-        AxisError
-            If any axis provided is out of range
-        ValueError
-            If an axis is repeated
-
-        See also
-        --------
-        normalize_axis_index : normalizing a single scalar axis
-        """
-        import operator
-        from numpy.core.multiarray import normalize_axis_index
-        # Optimization to speed-up the most common cases.
-        if type(axis) not in (tuple, list):
-            try:
-                axis = [operator.index(axis)]
-            except TypeError:
-                pass
-        # Going via an iterator directly is slower than via list comprehension.
-        axis = tuple([normalize_axis_index(ax, ndim, argname) for ax in axis])
-        if not allow_duplicate and len(set(axis)) != len(axis):
-            if argname:
-                raise ValueError(
-                    'repeated axis in `{}` argument'.format(argname))
-            else:
-                raise ValueError('repeated axis')
-        return axis
+from cupy.core._kernel import _get_axis
 
 
 def flip(a, axis):
@@ -164,9 +99,9 @@ def roll(a, shift, axis=None):
     """
     if axis is None:
         return roll(a.ravel(), shift, 0).reshape(a.shape)
-
     else:
-        axis = normalize_axis_tuple(axis, a.ndim, allow_duplicate=True)
+        axis = _get_axis(axis, a.ndim)[0]
+
         broadcasted = numpy.broadcast(shift, axis)
         if broadcasted.ndim > 1:
             raise ValueError(

--- a/tests/cupy_tests/manipulation_tests/test_rearrange.py
+++ b/tests/cupy_tests/manipulation_tests/test_rearrange.py
@@ -1,6 +1,7 @@
 import unittest
 
 import numpy
+
 import cupy
 from cupy import testing
 

--- a/tests/cupy_tests/manipulation_tests/test_rearrange.py
+++ b/tests/cupy_tests/manipulation_tests/test_rearrange.py
@@ -105,21 +105,6 @@ class TestRoll(unittest.TestCase):
         x = testing.shaped_arange((5, 2), xp, dtype)
         return xp.roll(x, (2, 1, 3), axis=None)
 
-    @testing.numpy_cupy_raises(accept_error=numpy.AxisError)
-    def test_roll_invalid_axis1(self, xp):
-        x = testing.shaped_arange((5, 2), xp)
-        return xp.roll(x, 2, axis=(1, 2))
-
-    @testing.numpy_cupy_raises(accept_error=numpy.AxisError)
-    def test_roll_invalid_axis2(self, xp):
-        x = testing.shaped_arange((5, 2), xp)
-        return xp.roll(x, 2, axis=-2)
-
-    @testing.numpy_cupy_raises(accept_error=TypeError)
-    def test_roll_invalid_axis3(self, xp):
-        x = testing.shaped_arange((5, 2), xp)
-        return xp.roll(x, 2, axis='0')
-
     @testing.numpy_cupy_raises(accept_error=TypeError)
     def test_roll_invalid_shift(self, xp):
         x = testing.shaped_arange((5, 2), xp)
@@ -130,25 +115,28 @@ class TestRoll(unittest.TestCase):
         x = testing.shaped_arange((5, 2, 3), xp)
         return xp.roll(x, (2, 2, 2), axis=(0, 1))
 
-    @testing.for_all_dtypes()
     @testing.with_requires('numpy>=1.13')
-    @testing.numpy_cupy_raises()
+    @testing.numpy_cupy_raises(accept_error=numpy.AxisError)
     def test_roll_invalid_axis1(self, xp, dtype):
-        x = testing.shaped_arange((5, 2), xp, dtype)
+        x = testing.shaped_arange((5, 2), xp)
         return xp.roll(x, 1, axis=2)
 
-    @testing.for_all_dtypes()
-    def test_roll_invalid_axis2(self, dtype):
-        x = testing.shaped_arange((5, 2), cupy, dtype)
-        with self.assertRaises(cupy.core.core._AxisError):
-            return cupy.roll(x, 1, axis=2)
+    @testing.with_requires('numpy>=1.13')
+    @testing.numpy_cupy_raises(accept_error=numpy.AxisError)
+    def test_roll_invalid_axis2(self, xp):
+        x = testing.shaped_arange((5, 2), xp)
+        return xp.roll(x, 1, axis=-3)
 
-    @testing.for_all_dtypes()
     @testing.with_requires('numpy>=1.12')
-    def test_roll_invalid_axis3(self, dtype):
-        x = testing.shaped_arange((5, 2, 2), cupy, dtype)
-        with self.assertRaises(ValueError):
-            return cupy.roll(x, shift=(1, 0), axis=(0, 1, 2))
+    @testing.numpy_cupy_raises(accept_error=ValueError)
+    def test_roll_invalid_axis_length(self, xp):
+        x = testing.shaped_arange((5, 2, 2), xp)
+        return cupy.roll(x, shift=(1, 0), axis=(0, 1, 2))
+
+    @testing.numpy_cupy_raises(accept_error=TypeError)
+    def test_roll_invalid_axis_type(self, xp):
+        x = testing.shaped_arange((5, 2), xp)
+        return xp.roll(x, 2, axis='0')
 
     @testing.for_all_dtypes()
     @testing.with_requires('numpy>=1.13')

--- a/tests/cupy_tests/manipulation_tests/test_rearrange.py
+++ b/tests/cupy_tests/manipulation_tests/test_rearrange.py
@@ -113,47 +113,45 @@ class TestRoll(unittest.TestCase):
         x = testing.shaped_arange((5, 2), xp, dtype)
         return xp.roll(x, (2, 1, 3), axis=None)
 
-    @testing.numpy_cupy_raises(accept_error=TypeError)
+    @testing.numpy_cupy_raises()
     def test_roll_invalid_shift(self, xp):
         x = testing.shaped_arange((5, 2), xp)
         return xp.roll(x, '0', axis=0)
 
-    @testing.numpy_cupy_raises(accept_error=ValueError)
+    @testing.with_requires('numpy>=1.12')
+    @testing.numpy_cupy_raises()
     def test_roll_shape_mismatch(self, xp):
         x = testing.shaped_arange((5, 2, 3), xp)
         return xp.roll(x, (2, 2, 2), axis=(0, 1))
 
-    @testing.with_requires('numpy>=1.13')
-    @testing.numpy_cupy_raises(accept_error=numpy.AxisError)
+    @testing.numpy_cupy_raises()
     def test_roll_invalid_axis1(self, xp):
         x = testing.shaped_arange((5, 2), xp)
         return xp.roll(x, 1, axis=2)
 
-    @testing.with_requires('numpy>=1.13')
-    @testing.numpy_cupy_raises(accept_error=numpy.AxisError)
+    @testing.numpy_cupy_raises()
     def test_roll_invalid_axis2(self, xp):
         x = testing.shaped_arange((5, 2), xp)
         return xp.roll(x, 1, axis=-3)
 
     @testing.with_requires('numpy>=1.12')
-    @testing.numpy_cupy_raises(accept_error=ValueError)
+    @testing.numpy_cupy_raises()
     def test_roll_invalid_axis_length(self, xp):
         x = testing.shaped_arange((5, 2, 2), xp)
         return cupy.roll(x, shift=(1, 0), axis=(0, 1, 2))
 
-    @testing.numpy_cupy_raises(accept_error=TypeError)
+    @testing.numpy_cupy_raises()
     def test_roll_invalid_axis_type(self, xp):
         x = testing.shaped_arange((5, 2), xp)
         return xp.roll(x, 2, axis='0')
 
-    @testing.with_requires('numpy>=1.13')
-    @testing.numpy_cupy_raises(accept_error=numpy.AxisError)
+    @testing.numpy_cupy_raises()
     def test_roll_invalid_negative_axis1(self, xp):
         x = testing.shaped_arange((5, 2), xp)
         return xp.roll(x, 1, axis=-3)
 
-    @testing.with_requires('numpy>=1.13')
-    @testing.numpy_cupy_raises(accept_error=numpy.AxisError)
+    @testing.with_requires('numpy>=1.12')
+    @testing.numpy_cupy_raises()
     def test_roll_invalid_negative_axis2(self, xp):
         x = testing.shaped_arange((5, 2), xp)
         return xp.roll(x, 1, axis=(1, -3))

--- a/tests/cupy_tests/manipulation_tests/test_rearrange.py
+++ b/tests/cupy_tests/manipulation_tests/test_rearrange.py
@@ -56,6 +56,20 @@ class TestRoll(unittest.TestCase):
         return xp.roll(x, 5)
 
     @testing.for_all_dtypes()
+    @testing.with_requires('numpy>=1.12')
+    @testing.numpy_cupy_array_equal()
+    def test_roll_scalar_shift_multi_axis(self, xp, dtype):
+        x = testing.shaped_arange((5, 2), xp, dtype)
+        return xp.roll(x, 1, axis=(0, 1))
+
+    @testing.for_all_dtypes()
+    @testing.with_requires('numpy>=1.12')
+    @testing.numpy_cupy_array_equal()
+    def test_roll_multi_shift_multi_axis(self, xp, dtype):
+        x = testing.shaped_arange((5, 2), xp, dtype)
+        return xp.roll(x, (2, 1), axis=(0, 1))
+
+    @testing.for_all_dtypes()
     @testing.with_requires('numpy>=1.13')
     @testing.numpy_cupy_raises()
     def test_roll_invalid_axis1(self, xp, dtype):
@@ -67,6 +81,13 @@ class TestRoll(unittest.TestCase):
         x = testing.shaped_arange((5, 2), cupy, dtype)
         with self.assertRaises(cupy.core.core._AxisError):
             return cupy.roll(x, 1, axis=2)
+
+    @testing.for_all_dtypes()
+    @testing.with_requires('numpy>=1.12')
+    def test_roll_invalid_axis3(self, dtype):
+        x = testing.shaped_arange((5, 2, 2), cupy, dtype)
+        with self.assertRaises(ValueError):
+            return cupy.roll(x, shift=(1, 0), axis=(0, 1, 2))
 
     @testing.for_all_dtypes()
     @testing.with_requires('numpy>=1.13')

--- a/tests/cupy_tests/manipulation_tests/test_rearrange.py
+++ b/tests/cupy_tests/manipulation_tests/test_rearrange.py
@@ -67,6 +67,13 @@ class TestRoll(unittest.TestCase):
     @testing.for_all_dtypes()
     @testing.with_requires('numpy>=1.12')
     @testing.numpy_cupy_array_equal()
+    def test_roll_scalar_shift_duplicate_axis(self, xp, dtype):
+        x = testing.shaped_arange((5, 2), xp, dtype)
+        return xp.roll(x, 1, axis=(0, 0))
+
+    @testing.for_all_dtypes()
+    @testing.with_requires('numpy>=1.12')
+    @testing.numpy_cupy_array_equal()
     def test_roll_large_shift(self, xp, dtype):
         x = testing.shaped_arange((5, 2), xp, dtype)
         return xp.roll(x, 50, axis=0)

--- a/tests/cupy_tests/manipulation_tests/test_rearrange.py
+++ b/tests/cupy_tests/manipulation_tests/test_rearrange.py
@@ -1,7 +1,5 @@
 import unittest
 
-import numpy
-
 import cupy
 from cupy import testing
 

--- a/tests/cupy_tests/manipulation_tests/test_rearrange.py
+++ b/tests/cupy_tests/manipulation_tests/test_rearrange.py
@@ -1,5 +1,6 @@
 import unittest
 
+import numpy
 import cupy
 from cupy import testing
 
@@ -65,9 +66,69 @@ class TestRoll(unittest.TestCase):
     @testing.for_all_dtypes()
     @testing.with_requires('numpy>=1.12')
     @testing.numpy_cupy_array_equal()
+    def test_roll_large_shift(self, xp, dtype):
+        x = testing.shaped_arange((5, 2), xp, dtype)
+        return xp.roll(x, 50, axis=0)
+
+    @testing.for_all_dtypes()
+    @testing.with_requires('numpy>=1.12')
+    @testing.numpy_cupy_array_equal()
     def test_roll_multi_shift_multi_axis(self, xp, dtype):
         x = testing.shaped_arange((5, 2), xp, dtype)
         return xp.roll(x, (2, 1), axis=(0, 1))
+
+    @testing.for_all_dtypes()
+    @testing.with_requires('numpy>=1.12')
+    @testing.numpy_cupy_array_equal()
+    def test_roll_multi_shift_multi_axis2(self, xp, dtype):
+        x = testing.shaped_arange((5, 2), xp, dtype)
+        return xp.roll(x, (2, 1), axis=(0, -1))
+
+    @testing.for_all_dtypes()
+    @testing.with_requires('numpy>=1.12')
+    @testing.numpy_cupy_array_equal()
+    def test_roll_multi_shift_multi_axis3(self, xp, dtype):
+        x = testing.shaped_arange((5, 2), xp, dtype)
+        return xp.roll(x, (2, 1), axis=(1, -1))
+
+    @testing.for_all_dtypes()
+    @testing.with_requires('numpy>=1.12')
+    @testing.numpy_cupy_array_equal()
+    def test_roll_multi_shift_scalar_axis(self, xp, dtype):
+        x = testing.shaped_arange((5, 2), xp, dtype)
+        return xp.roll(x, (2, 1, 3), axis=0)
+
+    @testing.for_all_dtypes()
+    @testing.with_requires('numpy>=1.12')
+    @testing.numpy_cupy_array_equal()
+    def test_roll_multi_shift_axis_none(self, xp, dtype):
+        x = testing.shaped_arange((5, 2), xp, dtype)
+        return xp.roll(x, (2, 1, 3), axis=None)
+
+    @testing.numpy_cupy_raises(accept_error=numpy.AxisError)
+    def test_roll_invalid_axis1(self, xp):
+        x = testing.shaped_arange((5, 2), xp)
+        return xp.roll(x, 2, axis=(1, 2))
+
+    @testing.numpy_cupy_raises(accept_error=numpy.AxisError)
+    def test_roll_invalid_axis2(self, xp):
+        x = testing.shaped_arange((5, 2), xp)
+        return xp.roll(x, 2, axis=-2)
+
+    @testing.numpy_cupy_raises(accept_error=TypeError)
+    def test_roll_invalid_axis3(self, xp):
+        x = testing.shaped_arange((5, 2), xp)
+        return xp.roll(x, 2, axis='0')
+
+    @testing.numpy_cupy_raises(accept_error=TypeError)
+    def test_roll_invalid_shift(self, xp):
+        x = testing.shaped_arange((5, 2), xp)
+        return xp.roll(x, '0', axis=0)
+
+    @testing.numpy_cupy_raises(accept_error=ValueError)
+    def test_roll_shape_mismatch(self, xp):
+        x = testing.shaped_arange((5, 2, 3), xp)
+        return xp.roll(x, (2, 2, 2), axis=(0, 1))
 
     @testing.for_all_dtypes()
     @testing.with_requires('numpy>=1.13')

--- a/tests/cupy_tests/manipulation_tests/test_rearrange.py
+++ b/tests/cupy_tests/manipulation_tests/test_rearrange.py
@@ -117,7 +117,7 @@ class TestRoll(unittest.TestCase):
 
     @testing.with_requires('numpy>=1.13')
     @testing.numpy_cupy_raises(accept_error=numpy.AxisError)
-    def test_roll_invalid_axis1(self, xp, dtype):
+    def test_roll_invalid_axis1(self, xp):
         x = testing.shaped_arange((5, 2), xp)
         return xp.roll(x, 1, axis=2)
 
@@ -138,18 +138,17 @@ class TestRoll(unittest.TestCase):
         x = testing.shaped_arange((5, 2), xp)
         return xp.roll(x, 2, axis='0')
 
-    @testing.for_all_dtypes()
     @testing.with_requires('numpy>=1.13')
-    @testing.numpy_cupy_raises()
-    def test_roll_invalid_negative_axis1(self, xp, dtype):
-        x = testing.shaped_arange((5, 2), xp, dtype)
+    @testing.numpy_cupy_raises(accept_error=numpy.AxisError)
+    def test_roll_invalid_negative_axis1(self, xp):
+        x = testing.shaped_arange((5, 2), xp)
         return xp.roll(x, 1, axis=-3)
 
-    @testing.for_all_dtypes()
-    def test_roll_invalid_negative_axis2(self, dtype):
-        x = testing.shaped_arange((5, 2), cupy, dtype)
-        with self.assertRaises(cupy.core.core._AxisError):
-            return cupy.roll(x, 1, axis=-3)
+    @testing.with_requires('numpy>=1.13')
+    @testing.numpy_cupy_raises(accept_error=numpy.AxisError)
+    def test_roll_invalid_negative_axis2(self, xp):
+        x = testing.shaped_arange((5, 2), xp)
+        return xp.roll(x, 1, axis=(1, -3))
 
 
 @testing.gpu


### PR DESCRIPTION
For ease of review, the body of `numpy.roll` function is reproduced exactly in the first commit here.
The minimal changes needed for `cupy` are in the second commit.

