### PR TITLE
Verbose broadcast failure message

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2682,7 +2682,11 @@ cdef class broadcast:
                 if a_sh == r_shape[i]:
                     r_strides[i] = a._strides[a_ndim - i - 1]
                 elif a_sh != 1:
-                    raise ValueError('Broadcasting failed')
+                    raise ValueError(
+                        'operands could not be broadcast together with shapes '
+                        '{}'.format(
+                            ', '.join([str(x.shape) if isinstance(x, ndarray)
+                                       else '()' for x in arrays])))
 
             strides.assign(r_strides.rbegin(), r_strides.rend())
             view = a.view()
@@ -2716,7 +2720,9 @@ cpdef ndarray broadcast_to(ndarray array, shape):
         if sh == a_sh:
             strides[j] = array._strides[i]
         elif a_sh != 1:
-            raise ValueError('Broadcasting failed')
+            raise ValueError(
+                'operands could not be broadcast together with shape {} and '
+                'requested shape {}'.format(array.shape, shape))
 
     view = array.view()
     # TODO(niboshi): Confirm update_x_contiguity flags


### PR DESCRIPTION
This PR aligns the error messages of broadcast failures towards numpy, printing the shapes of interest. Although a quite common error to encounter,  the previous error message contained little information. This change should make debugging easier when encountered.

Please close this ticket if it has been discussed before, maybe in terms of performance.