### PR TITLE
add cupyx.scipy.sparse.diags

### DIFF
--- a/cupyx/scipy/sparse/__init__.py
+++ b/cupyx/scipy/sparse/__init__.py
@@ -15,6 +15,7 @@ from cupyx.scipy.sparse.construct import identity  # NOQA
 from cupyx.scipy.sparse.construct import rand  # NOQA
 from cupyx.scipy.sparse.construct import random  # NOQA
 from cupyx.scipy.sparse.construct import spdiags  # NOQA
+from cupyx.scipy.sparse.construct import diags  # NOQA
 
 # TODO(unno): implement bsr_matrix
 # TODO(unno): implement dok_matrix

--- a/cupyx/scipy/sparse/construct.py
+++ b/cupyx/scipy/sparse/construct.py
@@ -1,8 +1,10 @@
+import numpy
 import cupy
 from cupyx.scipy.sparse import coo
 from cupyx.scipy.sparse import csc
 from cupyx.scipy.sparse import csr
 from cupyx.scipy.sparse import dia
+from cupyx.scipy.sparse.sputils import isscalarlike
 
 
 def eye(m, n=None, k=0, dtype='d', format=None):
@@ -168,3 +170,96 @@ def rand(m, n, density=0.01, format='coo', dtype=None, random_state=None):
 
     """
     return random(m, n, density, format, dtype, random_state)
+
+
+def diags(diagonals, offsets=0, shape=None, format=None, dtype=None):
+    """Construct a sparse matrix from diagonals.
+
+    Args:
+        diagonals (sequence of array_like):
+            Sequence of arrays containing the matrix diagonals, corresponding
+            to `offsets`.
+        offsets (sequence of int or an int):
+            Diagonals to set:
+                - k = 0  the main diagonal (default)
+                - k > 0  the k-th upper diagonal
+                - k < 0  the k-th lower diagonal
+        shape (tuple of int):
+            Shape of the result. If omitted, a square matrix large enough
+            to contain the diagonals is returned.
+        format ({"dia", "csr", "csc", "lil", ...}):
+            Matrix format of the result.  By default (format=None) an
+            appropriate sparse matrix format is returned.  This choice is
+            subject to change.
+        dtype (dtype): Data type of the matrix.
+
+    Returns:
+        cupyx.scipy.sparse.spmatrix: Generated matrix.
+
+    Notes:
+        This function differs from `spdiags` in the way it handles
+        off-diagonals.
+
+        The result from `diags` is the sparse equivalent of::
+
+            cupy.diag(diagonals[0], offsets[0])
+            + ...
+            + cupy.diag(diagonals[k], offsets[k])
+
+        Repeated diagonal offsets are disallowed.
+    """
+    # if offsets is not a sequence, assume that there's only one diagonal
+    if isscalarlike(offsets):
+        # now check that there's actually only one diagonal
+        if len(diagonals) == 0 or isscalarlike(diagonals[0]):
+            diagonals = [cupy.atleast_1d(diagonals)]
+        else:
+            raise ValueError("Different number of diagonals and offsets.")
+    else:
+        diagonals = list(map(cupy.atleast_1d, diagonals))
+
+    if isinstance(offsets, cupy.ndarray):
+        offsets = offsets.get()
+    offsets = numpy.atleast_1d(offsets)
+
+    # Basic check
+    if len(diagonals) != len(offsets):
+        raise ValueError("Different number of diagonals and offsets.")
+
+    # Determine shape, if omitted
+    if shape is None:
+        m = len(diagonals[0]) + abs(int(offsets[0]))
+        shape = (m, m)
+
+    # Determine data type, if omitted
+    if dtype is None:
+        dtype = cupy.common_type(*diagonals)
+
+    # Construct data array
+    m, n = shape
+
+    M = max([min(m + offset, n - offset) + max(0, offset)
+             for offset in offsets])
+    M = max(0, M)
+    data_arr = cupy.zeros((len(offsets), M), dtype=dtype)
+
+    K = min(m, n)
+
+    for j, diagonal in enumerate(diagonals):
+        offset = offsets[j]
+        k = max(0, offset)
+        length = min(m + offset, n - offset, K)
+        if length < 0:
+            raise ValueError(
+                "Offset %d (index %d) out of bounds" % (offset, j))
+        try:
+            data_arr[j, k:k+length] = diagonal[..., :length]
+        except ValueError:
+            if len(diagonal) != length and len(diagonal) != 1:
+                raise ValueError(
+                    "Diagonal length (index %d: %d at offset %d) does not "
+                    "agree with matrix size (%d, %d)." % (
+                        j, len(diagonal), offset, m, n))
+            raise
+
+    return dia.dia_matrix((data_arr, offsets), shape=(m, n)).asformat(format)

--- a/cupyx/scipy/sparse/sputils.py
+++ b/cupyx/scipy/sparse/sputils.py
@@ -1,0 +1,10 @@
+import cupy
+
+
+def isdense(x):
+    return isinstance(x, cupy.ndarray)
+
+
+def isscalarlike(x):
+    """Is x either a scalar, an array scalar, or a 0-dim array?"""
+    return cupy.isscalar(x) or (isdense(x) and x.ndim == 0)

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_construct.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_construct.py
@@ -136,3 +136,57 @@ class TestRandomInvalidArgument(unittest.TestCase):
     @testing.numpy_cupy_raises(sp_name='sp', accept_error=NotImplementedError)
     def test_invalid_dtype(self, xp, sp):
         sp.random(3, 4, dtype='i')
+
+
+@testing.parameterize(*testing.product({
+    'dtype': [numpy.float32, numpy.float64, numpy.complex64, numpy.complex128],
+    'format': ['dia', 'csr', 'csc', 'coo'],
+}))
+@testing.with_requires('scipy')
+class TestDiags(unittest.TestCase):
+
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_diags_scalar_offset(self, xp, sp):
+        x = sp.diags(
+            xp.arange(16), offsets=0, dtype=self.dtype, format=self.format)
+        self.assertIsInstance(x, sp.spmatrix)
+        self.assertEqual(x.format, self.format)
+        return x
+
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_diags_single_element_lists(self, xp, sp):
+        x = sp.diags(
+            [xp.arange(16)], offsets=[0], dtype=self.dtype, format=self.format)
+        self.assertIsInstance(x, sp.spmatrix)
+        self.assertEqual(x.format, self.format)
+        return x
+
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_diags_multiple(self, xp, sp):
+        x = sp.diags(
+            [xp.arange(15), xp.arange(16), xp.arange(15), xp.arange(13)],
+            offsets=[-1, 0, 1, 3],
+            dtype=self.dtype, format=self.format)
+        self.assertIsInstance(x, sp.spmatrix)
+        self.assertEqual(x.format, self.format)
+        return x
+
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_diags_offsets_as_array(self, xp, sp):
+        x = sp.diags(
+            [xp.arange(15), xp.arange(16), xp.arange(15), xp.arange(13)],
+            offsets=xp.array([-1, 0, 1, 3]),
+            dtype=self.dtype, format=self.format)
+        self.assertIsInstance(x, sp.spmatrix)
+        self.assertEqual(x.format, self.format)
+        return x
+
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_diags_non_square(self, xp, sp):
+        x = sp.diags(
+            [xp.arange(5), xp.arange(3)],
+            offsets=[0, -2], shape=(5, 10),
+            dtype=self.dtype, format=self.format)
+        self.assertIsInstance(x, sp.spmatrix)
+        self.assertEqual(x.format, self.format)
+        return x


### PR DESCRIPTION
This PR adds a CuPy implementation of `scipy.sparse.diags`. The implementation is identical to SciPy's aside from replacing some NumPy calls with their CuPy equivalents.

The new file `sputils.py` has only the subset of the functions that were used in the `diags` implementation. These are not part of the public API, so I have not added tests for these, but they are tested indirectly via the diags tests.
