### PR TITLE
Add the `order` kwarg to `cupy.reshape` and the underlying `ndarray` method

### DIFF
--- a/cupy/core/core.pxd
+++ b/cupy/core/core.pxd
@@ -31,7 +31,7 @@ cdef class ndarray:
     cpdef ndarray _transpose(self, vector.vector[Py_ssize_t] axes)
     cpdef ndarray swapaxes(self, Py_ssize_t axis1, Py_ssize_t axis2)
     cpdef ndarray flatten(self)
-    cpdef ndarray ravel(self)
+    cpdef ndarray ravel(self, order=*)
     cpdef ndarray squeeze(self, axis=*)
     cpdef ndarray take(self, indices, axis=*, out=*)
     cpdef repeat(self, repeats, axis=*)

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -689,7 +689,7 @@ cdef class ndarray:
         newarray._f_contiguous = True
         return newarray
 
-    cpdef ndarray ravel(self):
+    cpdef ndarray ravel(self, order='C'):
         """Returns an array flattened into one dimension.
 
         .. seealso::
@@ -697,10 +697,24 @@ cdef class ndarray:
            :meth:`numpy.ndarray.ravel`
 
         """
-        # TODO(beam2d): Support ordering option
+        # TODO(beam2d): Support K ordering option
+        cdef int order_char
         cdef vector.vector[Py_ssize_t] shape
         shape.push_back(self.size)
-        return self._reshape(shape)
+
+        order_char = _normalize_order(order, True)
+        if order_char == 'A':
+            if self._f_contiguous:
+                order_char = 'F'
+            else:
+                order_char = 'C'
+        if order_char == 'C':
+            return self._reshape(shape)
+        elif order_char == 'F':
+            return self.transpose()._reshape(shape)
+        elif order_char == 'K':
+            raise NotImplementedError(
+                "ravel with order='K' not yet implemented.")
 
     cpdef ndarray squeeze(self, axis=None):
         """Returns a view with size-one axes removed.

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -566,7 +566,7 @@ cdef class ndarray:
             shape = shape[0]
 
         if order_char == 'A':
-            if self._f_contiguous:
+            if if self._f_contiguous and not self._c_contiguous:
                 order_char = 'F'
             else:
                 order_char = 'C'
@@ -701,7 +701,7 @@ cdef class ndarray:
 
         order_char = _normalize_order(order, True)
         if order_char == 'A':
-            if self._f_contiguous:
+            if self._f_contiguous and not self._c_contiguous
                 order_char = 'F'
             else:
                 order_char = 'C'

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -566,7 +566,7 @@ cdef class ndarray:
             shape = shape[0]
 
         if order_char == 'A':
-            if if self._f_contiguous and not self._c_contiguous:
+            if self._f_contiguous and not self._c_contiguous:
                 order_char = 'F'
             else:
                 order_char = 'C'
@@ -701,7 +701,7 @@ cdef class ndarray:
 
         order_char = _normalize_order(order, True)
         if order_char == 'A':
-            if self._f_contiguous and not self._c_contiguous
+            if self._f_contiguous and not self._c_contiguous:
                 order_char = 'F'
             else:
                 order_char = 'C'

--- a/cupy/manipulation/shape.py
+++ b/cupy/manipulation/shape.py
@@ -1,9 +1,7 @@
-def reshape(a, newshape):
+def reshape(a, newshape, order='C'):
     """Returns an array with new shape and same elements.
 
     It tries to return a view if possible, otherwise returns a copy.
-
-    This function currently does not support ``order`` option.
 
     Args:
         a (cupy.ndarray): Array to be reshaped.
@@ -12,6 +10,18 @@ def reshape(a, newshape):
             It should be compatible with ``a.size``. One of the elements can be
             -1, which is automatically replaced with the appropriate value to
             make the shape compatible with ``a.size``.
+        order ({'C', 'F', 'A'}):
+            Read the elements of ``a`` using this index order, and place the
+            elements into the reshaped array using this index order.
+            'C' means to read / write the elements using C-like index order,
+            with the last axis index changing fastest, back to the first axis
+            index changing slowest. 'F' means to read / write the elements
+            using Fortran-like index order, with the first index changing
+            fastest, and the last index changing slowest. Note that the 'C'
+            and 'F' options take no account of the memory layout of the
+            underlying array, and only refer to the order of indexing. 'A'
+            means to read / write the elements in Fortran-like index order if
+            a is Fortran contiguous in memory, C-like order otherwise.
 
     Returns:
         cupy.ndarray: A reshaped view of ``a`` if possible, otherwise a copy.
@@ -19,9 +29,8 @@ def reshape(a, newshape):
     .. seealso:: :func:`numpy.reshape`
 
     """
-    # TODO(beam2d): Support ordering option
     # TODO(okuta): check type
-    return a.reshape(newshape)
+    return a.reshape(newshape, order=order)
 
 
 def ravel(a):

--- a/cupy/manipulation/shape.py
+++ b/cupy/manipulation/shape.py
@@ -33,15 +33,27 @@ def reshape(a, newshape, order='C'):
     return a.reshape(newshape, order=order)
 
 
-def ravel(a):
+def ravel(a, order='C'):
     """Returns a flattened array.
 
     It tries to return a view if possible, otherwise returns a copy.
 
-    This function currently does not support ``order`` option.
+    This function currently does not support the ``order = 'K'`` option.
 
     Args:
         a (cupy.ndarray): Array to be flattened.
+        order ({'C', 'F', 'A'}):
+            Read the elements of ``a`` using this index order, and place the
+            elements into the reshaped array using this index order.
+            'C' means to read / write the elements using C-like index order,
+            with the last axis index changing fastest, back to the first axis
+            index changing slowest. 'F' means to read / write the elements
+            using Fortran-like index order, with the first index changing
+            fastest, and the last index changing slowest. Note that the 'C'
+            and 'F' options take no account of the memory layout of the
+            underlying array, and only refer to the order of indexing. 'A'
+            means to read / write the elements in Fortran-like index order if
+            a is Fortran contiguous in memory, C-like order otherwise.
 
     Returns:
         cupy.ndarray: A flattened view of ``a`` if possible, otherwise a copy.
@@ -49,6 +61,6 @@ def ravel(a):
     .. seealso:: :func:`numpy.ravel`
 
     """
-    # TODO(beam2d): Support ordering option
+    # TODO(beam2d): Support ordering option K
     # TODO(okuta): check type
-    return a.ravel()
+    return a.ravel(order)

--- a/cupy/manipulation/shape.py
+++ b/cupy/manipulation/shape.py
@@ -61,6 +61,6 @@ def ravel(a, order='C'):
     .. seealso:: :func:`numpy.ravel`
 
     """
-    # TODO(beam2d): Support ordering option K
+    # TODO(beam2d, grlee77): Support ordering option K
     # TODO(okuta): check type
     return a.ravel(order)

--- a/tests/cupy_tests/manipulation_tests/test_shape.py
+++ b/tests/cupy_tests/manipulation_tests/test_shape.py
@@ -88,6 +88,11 @@ class TestShape(unittest.TestCase):
         return xp.reshape(a, (1, 1, 1, 4, 1, 2))
 
     @testing.numpy_cupy_array_equal()
+    def test_external_reshape_F_order(self, xp):
+        a = xp.zeros((8,), dtype=xp.float32)
+        return xp.reshape(a, (1, 1, 1, 4, 1, 2), order='F')
+
+    @testing.numpy_cupy_array_equal()
     def test_ravel(self, xp):
         a = testing.shaped_arange((2, 3, 4), xp)
         a = a.transpose(2, 0, 1)

--- a/tests/cupy_tests/manipulation_tests/test_shape.py
+++ b/tests/cupy_tests/manipulation_tests/test_shape.py
@@ -61,6 +61,11 @@ class TestShape(unittest.TestCase):
         return a.reshape(4, 6, order='A')
 
     @testing.numpy_cupy_array_equal()
+    def test_transposed_reshape_lowercase_order(self, xp):
+        a = testing.shaped_arange((2, 3, 4), xp).T
+        return a.reshape(4, 6, order='a')
+
+    @testing.numpy_cupy_array_equal()
     def test_transposed_reshape2(self, xp):
         a = testing.shaped_arange((2, 3, 4), xp).transpose(2, 0, 1)
         return a.reshape(2, 3, 4)

--- a/tests/cupy_tests/manipulation_tests/test_shape.py
+++ b/tests/cupy_tests/manipulation_tests/test_shape.py
@@ -37,6 +37,14 @@ class TestShape(unittest.TestCase):
         b[1] = 1
         return a
 
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_nocopy_reshape_A_order(self, xp, dtype):
+        a = xp.zeros((2, 3, 4), dtype=dtype)
+        b = a.reshape(4, 3, 2, order='A')
+        b[1] = 1
+        return a
+
     @testing.numpy_cupy_array_equal()
     def test_transposed_reshape(self, xp):
         a = testing.shaped_arange((2, 3, 4), xp).T
@@ -46,6 +54,11 @@ class TestShape(unittest.TestCase):
     def test_transposed_reshape_F_order(self, xp):
         a = testing.shaped_arange((2, 3, 4), xp).T
         return a.reshape(4, 6, order='F')
+
+    @testing.numpy_cupy_array_equal()
+    def test_transposed_reshape_A_order(self, xp):
+        a = testing.shaped_arange((2, 3, 4), xp).T
+        return a.reshape(4, 6, order='A')
 
     @testing.numpy_cupy_array_equal()
     def test_transposed_reshape2(self, xp):

--- a/tests/cupy_tests/manipulation_tests/test_shape.py
+++ b/tests/cupy_tests/manipulation_tests/test_shape.py
@@ -21,69 +21,35 @@ class TestShape(unittest.TestCase):
             return a.reshape((1, 1, 1, 4, 1, 2)).strides
         self.assertEqual(func(numpy), func(cupy))
 
+    @testing.for_orders('CFA')
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
-    def test_nocopy_reshape(self, xp, dtype):
+    def test_nocopy_reshape(self, xp, dtype, order):
         a = xp.zeros((2, 3, 4), dtype=dtype)
-        b = a.reshape(4, 3, 2)
+        b = a.reshape(4, 3, 2, order=order)
         b[1] = 1
         return a
 
+    @testing.for_orders('CFA')
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
-    def test_nocopy_reshape_F_order(self, xp, dtype):
+    def test_nocopy_reshape_with_order(self, xp, dtype, order):
         a = xp.zeros((2, 3, 4), dtype=dtype)
-        b = a.reshape(4, 3, 2, order='F')
+        b = a.reshape(4, 3, 2, order=order)
         b[1] = 1
         return a
 
-    @testing.for_all_dtypes()
+    @testing.for_orders('CFA')
     @testing.numpy_cupy_array_equal()
-    def test_nocopy_reshape_A_order(self, xp, dtype):
-        a = xp.zeros((2, 3, 4), dtype=dtype)
-        b = a.reshape(4, 3, 2, order='A')
-        b[1] = 1
-        return a
-
-    @testing.numpy_cupy_array_equal()
-    def test_transposed_reshape(self, xp):
-        a = testing.shaped_arange((2, 3, 4), xp).T
-        return a.reshape(4, 6)
-
-    @testing.numpy_cupy_array_equal()
-    def test_transposed_reshape_F_order(self, xp):
-        a = testing.shaped_arange((2, 3, 4), xp).T
-        return a.reshape(4, 6, order='F')
-
-    @testing.numpy_cupy_array_equal()
-    def test_transposed_reshape_A_order(self, xp):
-        a = testing.shaped_arange((2, 3, 4), xp).T
-        return a.reshape(4, 6, order='A')
-
-    @testing.numpy_cupy_array_equal()
-    def test_transposed_reshape_lowercase_order(self, xp):
-        a = testing.shaped_arange((2, 3, 4), xp).T
-        return a.reshape(4, 6, order='a')
-
-    @testing.numpy_cupy_array_equal()
-    def test_transposed_reshape2(self, xp):
+    def test_transposed_reshape2(self, xp, order):
         a = testing.shaped_arange((2, 3, 4), xp).transpose(2, 0, 1)
-        return a.reshape(2, 3, 4)
+        return a.reshape(2, 3, 4, order=order)
 
+    @testing.for_orders('CFA')
     @testing.numpy_cupy_array_equal()
-    def test_transposed_reshape2_F_order(self, xp):
-        a = testing.shaped_arange((2, 3, 4), xp).transpose(2, 0, 1)
-        return a.reshape(2, 3, 4, order='F')
-
-    @testing.numpy_cupy_array_equal()
-    def test_reshape_with_unknown_dimension(self, xp):
+    def test_reshape_with_unknown_dimension(self, xp, order):
         a = testing.shaped_arange((2, 3, 4), xp)
-        return a.reshape(3, -1)
-
-    @testing.numpy_cupy_array_equal()
-    def test_reshape_with_unknown_dimension_F_order(self, xp):
-        a = testing.shaped_arange((2, 3, 4), xp)
-        return a.reshape(3, -1, order='F')
+        return a.reshape(3, -1, order=order)
 
     @testing.numpy_cupy_raises()
     def test_reshape_with_multiple_unknown_dimensions(self):
@@ -100,15 +66,11 @@ class TestShape(unittest.TestCase):
         a = testing.shaped_arange((2, 3, 4))
         a.reshape(2, 4, 4, order='K')
 
+    @testing.for_orders('CFA')
     @testing.numpy_cupy_array_equal()
-    def test_external_reshape(self, xp):
+    def test_external_reshape(self, xp, order):
         a = xp.zeros((8,), dtype=xp.float32)
-        return xp.reshape(a, (1, 1, 1, 4, 1, 2))
-
-    @testing.numpy_cupy_array_equal()
-    def test_external_reshape_F_order(self, xp):
-        a = xp.zeros((8,), dtype=xp.float32)
-        return xp.reshape(a, (1, 1, 1, 4, 1, 2), order='F')
+        return xp.reshape(a, (1, 1, 1, 4, 1, 2), order=order)
 
     @testing.numpy_cupy_array_equal()
     def test_ravel(self, xp):

--- a/tests/cupy_tests/manipulation_tests/test_shape.py
+++ b/tests/cupy_tests/manipulation_tests/test_shape.py
@@ -72,11 +72,25 @@ class TestShape(unittest.TestCase):
         a = xp.zeros((8,), dtype=xp.float32)
         return xp.reshape(a, (1, 1, 1, 4, 1, 2), order=order)
 
+    @testing.for_orders('CFA')
     @testing.numpy_cupy_array_equal()
-    def test_ravel(self, xp):
+    def test_ravel(self, xp, order):
         a = testing.shaped_arange((2, 3, 4), xp)
         a = a.transpose(2, 0, 1)
-        return a.ravel()
+        return a.ravel(order)
+
+    @testing.for_orders('CFA')
+    @testing.numpy_cupy_array_equal()
+    def test_ravel2(self, xp, order):
+        a = testing.shaped_arange((2, 3, 4), xp)
+        return a.ravel(order)
+
+    @testing.for_orders('CFA')
+    @testing.numpy_cupy_array_equal()
+    def test_ravel3(self, xp, order):
+        a = testing.shaped_arange((2, 3, 4), xp)
+        a = xp.asfortranarray(a)
+        return a.ravel(order)
 
     @testing.numpy_cupy_array_equal()
     def test_external_ravel(self, xp):

--- a/tests/cupy_tests/manipulation_tests/test_shape.py
+++ b/tests/cupy_tests/manipulation_tests/test_shape.py
@@ -109,6 +109,7 @@ class TestShape(unittest.TestCase):
 @testing.gpu
 class TestReshapeOrder(unittest.TestCase):
 
+    @testing.with_requires('numpy>=1.12')
     def test_reshape_contiguity(self):
         shape_init, shape_final = self.shape_in_out
 


### PR DESCRIPTION
This PR implements a simple means to support the `order` kwarg in ndarray's `reshape` method.

namely, the trick used here is that:
```Python
x.reshape(newshape, order='F')
```

is equivalent to:
```Python
x.transpose().reshape(newshape[::-1]).transpose()
```
Various reshape test cases were duplicated for Fortran order to verify that this is indeed the case.

This transpose-based implementation probably has slight overhead vs. a lower-level implementation, but is considerably simpler and seems to have fairly small overhead. This is probably because transpose is fast as it returns a view rather than a copy. 
