### PR TITLE
fix RecursionError bug in conj method of sparse matrix classes

### DIFF
--- a/cupyx/scipy/sparse/base.py
+++ b/cupyx/scipy/sparse/base.py
@@ -268,7 +268,7 @@ class spmatrix(object):
             cupyx.scipy.sparse.spmatrix : The element-wise complex conjugate.
 
         """
-        if cupy.issubdtype(self.dtype, cupy.complexfloating):
+        if self.dtype.kind == 'c':
             return self.tocsr(copy=copy).conj(copy=False)
         elif copy:
             return self.copy()

--- a/cupyx/scipy/sparse/base.py
+++ b/cupyx/scipy/sparse/base.py
@@ -260,14 +260,12 @@ class spmatrix(object):
         If the matrix is of non-complex data type and `copy` is False,
         this method does nothing and the data is not copied.
 
-        Parameters
-        ----------
-        copy : bool, optional
-            If True, the result is guaranteed to not share data with self.
+        Args:
+            copy (bool):
+                If True, the result is guaranteed to not share data with self.
 
-        Returns
-        -------
-        A : The element-wise complex conjugate.
+        Returns:
+            cupyx.scipy.sparse.spmatrix : The element-wise complex conjugate.
 
         """
         if cupy.issubdtype(self.dtype, cupy.complexfloating):

--- a/cupyx/scipy/sparse/base.py
+++ b/cupyx/scipy/sparse/base.py
@@ -254,14 +254,40 @@ class spmatrix(object):
         """
         return self.tocsr().astype(t).asformat(self.format)
 
-    def conj(self):
-        return self.tocsr().conj()
+    def conj(self, copy=True):
+        """Element-wise complex conjugation.
 
-    def conjugate(self):
-        return self.conj()
+        If the matrix is of non-complex data type and `copy` is False,
+        this method does nothing and the data is not copied.
+
+        Parameters
+        ----------
+        copy : bool, optional
+            If True, the result is guaranteed to not share data with self.
+
+        Returns
+        -------
+        A : The element-wise complex conjugate.
+
+        """
+        if cupy.issubdtype(self.dtype, cupy.complexfloating):
+            return self.tocsr(copy=copy).conj(copy=False)
+        elif copy:
+            return self.copy()
+        else:
+            return self
+
+    def conjugate(self, copy=True):
+        return self.conj(copy=copy)
+
+    conjugate.__doc__ = conj.__doc__
 
     def copy(self):
-        """Returns a copy of this matrix."""
+        """Returns a copy of this matrix.
+
+        No data/indices will be shared between the returned value and current
+        matrix.
+        """
         return self.__class__(self, copy=True)
 
     def count_nonzero(self):

--- a/cupyx/scipy/sparse/compressed.py
+++ b/cupyx/scipy/sparse/compressed.py
@@ -133,9 +133,17 @@ class _compressed_sparse_matrix(sparse_data._data_matrix):
         self._shape = shape
         self._has_canonical_format = has_canonical_format
 
-    def _with_data(self, data):
-        return self.__class__(
-            (data, self.indices.copy(), self.indptr.copy()), shape=self.shape)
+    def _with_data(self, data, copy=True):
+        if copy:
+            return self.__class__(
+                (data, self.indices.copy(), self.indptr.copy()),
+                shape=self.shape,
+                dtype=data.dtype)
+        else:
+            return self.__class__(
+                (data, self.indices, self.indptr),
+                shape=self.shape,
+                dtype=data.dtype)
 
     def _convert_dense(self, x):
         raise NotImplementedError

--- a/cupyx/scipy/sparse/coo.py
+++ b/cupyx/scipy/sparse/coo.py
@@ -142,9 +142,19 @@ class coo_matrix(sparse_data._data_matrix):
         self._shape = shape
         self._has_canonical_format = has_canonical_format
 
-    def _with_data(self, data):
-        return coo_matrix(
-            (data, (self.row.copy(), self.col.copy())), shape=self.shape)
+    def _with_data(self, data, copy=True):
+        """Returns a matrix with the same sparsity structure as self,
+        but with different data.  By default the index arrays
+        (i.e. .row and .col) are copied.
+        """
+        if copy:
+            return coo_matrix(
+                (data, (self.row.copy(), self.col.copy())),
+                shape=self.shape, dtype=data.dtype)
+        else:
+            return coo_matrix(
+                (data, (self.row, self.col)), shape=self.shape,
+                dtype=data.dtype)
 
     def eliminate_zeros(self):
         """Removes zero entories in place."""

--- a/cupyx/scipy/sparse/data.py
+++ b/cupyx/scipy/sparse/data.py
@@ -19,7 +19,7 @@ class _data_matrix(base.spmatrix):
         """Data type of the matrix."""
         return self.data.dtype
 
-    def _with_data(self, data):
+    def _with_data(self, data, copy=True):
         raise NotImplementedError
 
     def __abs__(self):
@@ -41,6 +41,21 @@ class _data_matrix(base.spmatrix):
 
         """
         return self._with_data(self.data.astype(t))
+
+    def conj(self, copy=True):
+        if cupy.issubdtype(self.dtype, cupy.complexfloating):
+            return self._with_data(self.data.conj(), copy=copy)
+        elif copy:
+            return self.copy()
+        else:
+            return self
+
+    conj.__doc__ = base.spmatrix.conj.__doc__
+
+    def copy(self):
+        return self._with_data(self.data.copy(), copy=True)
+
+    copy.__doc__ = base.spmatrix.copy.__doc__
 
     def count_nonzero(self):
         """Returns number of non-zero entries.

--- a/cupyx/scipy/sparse/dia.py
+++ b/cupyx/scipy/sparse/dia.py
@@ -66,8 +66,14 @@ class dia_matrix(data._data_matrix):
         self.offsets = offsets
         self._shape = shape
 
-    def _with_data(self, data):
-        return dia_matrix((data, self.offsets), shape=self.shape)
+    def _with_data(self, data, copy=True):
+        """Returns a matrix with the same sparsity structure as self,
+        but with different data.  By default the structure arrays are copied.
+        """
+        if copy:
+            return dia_matrix((data, self.offsets.copy()), shape=self.shape)
+        else:
+            return dia_matrix((data, self.offsets), shape=self.shape)
 
     def get(self, stream=None):
         """Returns a copy of the array on host memory.

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_coo.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_coo.py
@@ -22,6 +22,18 @@ def _make(xp, sp, dtype):
     return sp.coo_matrix((data, (row, col)), shape=(3, 4))
 
 
+def _make_complex(xp, sp, dtype):
+    data = xp.array([0, 1, 2, 3], dtype)
+    if dtype in [numpy.complex64, numpy.complex128]:
+        data = data - 1j
+    row = xp.array([0, 0, 1, 2], 'i')
+    col = xp.array([0, 1, 3, 2], 'i')
+    # 0, 1 - 1j, 0, 0
+    # 0, 0, 0, 2 - 1j
+    # 0, 0, 3 - 1j, 0
+    return sp.coo_matrix((data, (row, col)), shape=(3, 4))
+
+
 def _make2(xp, sp, dtype):
     data = xp.array([1, 2, 3, 4], dtype)
     row = xp.array([0, 1, 1, 2], 'i')
@@ -150,6 +162,10 @@ class TestCooMatrix(unittest.TestCase):
 
     def test_nnz(self):
         self.assertEqual(self.m.nnz, 4)
+
+    def test_conj(self):
+        n = _make_complex(cupy, sparse, self.dtype)
+        cupy.testing.assert_array_equal(n.conj().data, n.data.conj())
 
     def test_has_canonical_format(self):
         self.assertFalse(self.m.has_canonical_format)
@@ -331,6 +347,11 @@ class TestCooMatrixInit(unittest.TestCase):
             sparse.coo_matrix(
                 (self.data(cupy), (self.row(cupy), self.col(cupy))),
                 shape=self.shape, dtype='i')
+
+    @testing.numpy_cupy_equal(sp_name='sp')
+    def test_conj(self, xp, sp):
+        n = _make_complex(xp, sp, self.dtype)
+        cupy.testing.assert_array_equal(n.conj().data, n.data.conj())
 
 
 @testing.parameterize(*testing.product({

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -23,6 +23,18 @@ def _make(xp, sp, dtype):
     return sp.csr_matrix((data, indices, indptr), shape=(3, 4))
 
 
+def _make_complex(xp, sp, dtype):
+    data = xp.array([0, 1, 2, 3], dtype)
+    if dtype in [numpy.complex64, numpy.complex128]:
+        data = data - 1j
+    indices = xp.array([0, 1, 3, 2], 'i')
+    indptr = xp.array([0, 2, 3, 4], 'i')
+    # 0, 1 - 1j, 0, 0
+    # 0, 0, 0, 2 - 1j
+    # 0, 0, 3 - 1j, 0
+    return sp.csr_matrix((data, indices, indptr), shape=(3, 4))
+
+
 def _make2(xp, sp, dtype):
     data = xp.array([1, 2, 3, 4], dtype)
     indices = xp.array([2, 1, 2, 2], 'i')
@@ -217,6 +229,10 @@ class TestCsrMatrix(unittest.TestCase):
     def test_nnz(self):
         self.assertEqual(self.m.nnz, 4)
 
+    def test_conj(self):
+        n = _make_complex(cupy, sparse, self.dtype)
+        cupy.testing.assert_array_equal(n.conj().data, n.data.conj())
+
     @unittest.skipUnless(scipy_available, 'requires scipy')
     def test_get(self):
         m = self.m.get()
@@ -367,6 +383,11 @@ class TestCsrMatrixInit(unittest.TestCase):
             sparse.csr_matrix(
                 (self.data(cupy), self.indices(cupy), self.indptr(cupy)),
                 shape=self.shape, dtype='i')
+
+    @testing.numpy_cupy_equal(sp_name='sp')
+    def test_conj(self, xp, sp):
+        n = _make_complex(xp, sp, self.dtype)
+        cupy.testing.assert_array_equal(n.conj().data, n.data.conj())
 
 
 @testing.parameterize(*testing.product({

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_dia.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_dia.py
@@ -73,6 +73,10 @@ class TestDiaMatrix(unittest.TestCase):
         n = _make_complex(cupy, sparse, self.dtype)
         cupy.testing.assert_array_equal(n.conj().data, n.data.conj())
 
+    def test_conjugate(self):
+        n = _make_complex(cupy, sparse, self.dtype)
+        cupy.testing.assert_array_equal(n.conjugate().data, n.data.conj())
+
     @unittest.skipUnless(scipy_available, 'requires scipy')
     def test_str(self):
         if numpy.dtype(self.dtype).kind == 'f':


### PR DESCRIPTION
A `conj` method is defined for the sparse matrix classes in current master, but results in infinite recursion when used.

Here is a minimal example to reproduce the bug (run on the current master branch):

```Python
import cupy
cupy.cupyx.scipy.sparse.eye(5).conj()
```

which results in an error ending in:
```
  File "/media/Data1/cupy/cupyx/scipy/sparse/base.py", line 258, in conj
    return self.tocsr().conj()

RecursionError: maximum recursion depth exceeded
```

The `conj` method of the `cupyx.scipy.sparse.spmatrix` classes for COO, CSR, CSC and DIA is implemented in this PR.

The docstrings and implementation closely follow those for the corresponding methods in `scipy.sparse`.
