### PR TITLE
cumsum, cumprod: support array-like input

### DIFF
--- a/cupy/math/sumprod.py
+++ b/cupy/math/sumprod.py
@@ -25,6 +25,7 @@ def sum(a, axis=None, dtype=None, out=None, keepdims=False):
 
     """
     # TODO(okuta): check type
+    a = cupy.asarray(a)
     return a.sum(axis, dtype, out, keepdims)
 
 
@@ -47,6 +48,7 @@ def prod(a, axis=None, dtype=None, out=None, keepdims=False):
 
     """
     # TODO(okuta): check type
+    a = cupy.asarray(a)
     return a.prod(axis, dtype, out, keepdims)
 
 
@@ -80,6 +82,7 @@ def _proc_as_batch(proc, x, axis):
 
 
 def _cum_core(a, axis, dtype, out, kern, batch_kern):
+    a = cupy.asarray(a)
     if out is None:
         if dtype is None:
             kind = a.dtype.kind

--- a/cupy/math/sumprod.py
+++ b/cupy/math/sumprod.py
@@ -25,7 +25,6 @@ def sum(a, axis=None, dtype=None, out=None, keepdims=False):
 
     """
     # TODO(okuta): check type
-    a = cupy.asarray(a)
     return a.sum(axis, dtype, out, keepdims)
 
 
@@ -48,7 +47,6 @@ def prod(a, axis=None, dtype=None, out=None, keepdims=False):
 
     """
     # TODO(okuta): check type
-    a = cupy.asarray(a)
     return a.prod(axis, dtype, out, keepdims)
 
 

--- a/tests/cupy_tests/math_tests/test_sumprod.py
+++ b/tests/cupy_tests/math_tests/test_sumprod.py
@@ -27,6 +27,10 @@ class TestSumprod(unittest.TestCase):
         a = testing.shaped_arange((2, 3, 4), xp, dtype)
         return xp.sum(a)
 
+    @testing.numpy_cupy_allclose()
+    def test_external_sum_arraylike(self, xp):
+        return xp.sum((1, 2, 3))
+
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_sum_all2(self, xp, dtype):
@@ -157,6 +161,10 @@ class TestSumprod(unittest.TestCase):
         a = testing.shaped_arange((2, 3), xp, dtype)
         return xp.prod(a)
 
+    @testing.numpy_cupy_allclose()
+    def test_external_prod_arraylike(self, xp):
+        return xp.sum((1, 2, 3))
+
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_prod_axis(self, xp, dtype):
@@ -244,6 +252,10 @@ class TestCumsum(unittest.TestCase):
         with self.assertRaises(cupy.core.core._AxisError):
             return cupy.cumsum(a, axis=a.ndim + 1)
 
+    @testing.numpy_cupy_allclose()
+    def test_cumsum_arraylike(self, xp):
+        return xp.cumsum((1, 2, 3))
+
 
 @testing.gpu
 class TestCumprod(unittest.TestCase):
@@ -310,3 +322,7 @@ class TestCumprod(unittest.TestCase):
         a = testing.shaped_arange((4, 5), cupy, dtype)
         with self.assertRaises(cupy.core.core._AxisError):
             return cupy.cumprod(a, axis=a.ndim)
+
+    @testing.numpy_cupy_allclose()
+    def test_cumprod_arraylike(self, xp):
+        return xp.cumprod((1, 2, 3))

--- a/tests/cupy_tests/math_tests/test_sumprod.py
+++ b/tests/cupy_tests/math_tests/test_sumprod.py
@@ -27,10 +27,6 @@ class TestSumprod(unittest.TestCase):
         a = testing.shaped_arange((2, 3, 4), xp, dtype)
         return xp.sum(a)
 
-    @testing.numpy_cupy_allclose()
-    def test_external_sum_arraylike(self, xp):
-        return xp.sum((1, 2, 3))
-
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_sum_all2(self, xp, dtype):
@@ -160,10 +156,6 @@ class TestSumprod(unittest.TestCase):
     def test_external_prod_all(self, xp, dtype):
         a = testing.shaped_arange((2, 3), xp, dtype)
         return xp.prod(a)
-
-    @testing.numpy_cupy_allclose()
-    def test_external_prod_arraylike(self, xp):
-        return xp.sum((1, 2, 3))
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()

--- a/tests/cupy_tests/math_tests/test_sumprod.py
+++ b/tests/cupy_tests/math_tests/test_sumprod.py
@@ -248,6 +248,12 @@ class TestCumsum(unittest.TestCase):
     def test_cumsum_arraylike(self, xp):
         return xp.cumsum((1, 2, 3))
 
+    @testing.for_float_dtypes()
+    @testing.numpy_cupy_allclose()
+    def test_cumsum_numpy_array(self, xp, dtype):
+        a_numpy = numpy.arange(8, dtype=dtype)
+        return xp.cumsum(a_numpy)
+
 
 @testing.gpu
 class TestCumprod(unittest.TestCase):
@@ -318,3 +324,9 @@ class TestCumprod(unittest.TestCase):
     @testing.numpy_cupy_allclose()
     def test_cumprod_arraylike(self, xp):
         return xp.cumprod((1, 2, 3))
+
+    @testing.for_float_dtypes()
+    @testing.numpy_cupy_allclose()
+    def test_cumprod_numpy_array(self, xp, dtype):
+        a_numpy = numpy.arange(1, 6, dtype=dtype)
+        return xp.cumprod(a_numpy)


### PR DESCRIPTION
This is a minimal PR adding a call to `asarray` so `cumsum` and `cumprod` work on numpy.ndarray, tuple and list inputs (as supported in NumPy).

Omit commit a6eed90 if it is desired to also do the conversion for `cupy.sum` and `cupy.prod`
I wasn't sure in that case because it could potentially cause backwards compatibility issues:

The current behavior of `sum` and `prod` on numpy.ndarray inputs (e.g. ``cupy.sum(numpy.arange(16))``) returns a scalar rather than a 0-dimensional cupy array.  This is because the `numpy.ndarray.sum` method when the input is a numpy array.  I wasn't sure whether or not this was intended? 

