### PR TITLE
Fix bad hyperlink in `cupy.around` documentation

### DIFF
--- a/cupy/core/fusion.py
+++ b/cupy/core/fusion.py
@@ -586,8 +586,9 @@ class _FusionHistory(object):
         # Make FusionVar list
         var_list = [self._get_fusion_var(_) for _ in args]
         if 'out' in kwargs:
-            out_var = self._get_fusion_var(kwargs.pop('out'))
-            var_list.append(out_var)
+            out = kwargs.pop('out')
+            if out is not None:
+                var_list.append(self._get_fusion_var(out))
         if kwargs:
             raise TypeError('Wrong arguments {}'.format(kwargs))
 

--- a/cupy/math/rounding.py
+++ b/cupy/math/rounding.py
@@ -4,6 +4,11 @@ from cupy.math import ufunc
 
 
 @fusion._ufunc_wrapper(core.core._round_ufunc)
+def _round(a, decimals, out=None):
+    a = core.array(a, copy=False)
+    return a.round(decimals, out)
+
+
 def around(a, decimals=0, out=None):
     """Rounds to the given number of decimals.
 
@@ -20,14 +25,11 @@ def around(a, decimals=0, out=None):
     .. seealso:: :func:`numpy.around`
 
     """
-    a = core.array(a, copy=False)
-    return a.round(decimals, out)
+    return _round(a, decimals, out=out)
 
 
-@fusion._ufunc_wrapper(core.core._round_ufunc)
 def round_(a, decimals=0, out=None):
-    a = core.array(a, copy=False)
-    return a.round(decimals, out)
+    return _round(a, decimals, out=out)
 
 
 rint = ufunc.create_math_ufunc(


### PR DESCRIPTION
Related to issue #1834 (PR: #1835).

https://docs-cupy.chainer.org/en/latest/reference/generated/cupy.around.html
https://docs-cupy.chainer.org/en/latest/reference/generated/cupy.round_.html