### PR TITLE
Check if cx is None

### DIFF
--- a/cupy/cudnn.pyx
+++ b/cupy/cudnn.pyx
@@ -593,7 +593,8 @@ def rnn_forward_inference(
         core.ndarray hx, core.ndarray cx, core.ndarray w, core.ndarray xs,
         lengths):
     hx = core.ascontiguousarray(hx)
-    cx = core.ascontiguousarray(cx)
+    if cx is not None:
+        cx = core.ascontiguousarray(cx)
     w = core.ascontiguousarray(w)
     xs = core.ascontiguousarray(xs)
 
@@ -657,7 +658,8 @@ def rnn_forward_training(
         core.ndarray hx, core.ndarray cx, core.ndarray w, core.ndarray xs,
         lengths):
     hx = core.ascontiguousarray(hx)
-    cx = core.ascontiguousarray(cx)
+    if cx is not None:
+        cx = core.ascontiguousarray(cx)
     w = core.ascontiguousarray(w)
     xs = core.ascontiguousarray(xs)
 
@@ -728,12 +730,14 @@ def rnn_backward_data(
         core.ndarray dhy, core.ndarray dcy, core.ndarray dys,
         lengths):
     hx = core.ascontiguousarray(hx)
-    cx = core.ascontiguousarray(cx)
+    if cx is not None:
+        cx = core.ascontiguousarray(cx)
     w = core.ascontiguousarray(w)
     xs = core.ascontiguousarray(xs)
     ys = core.ascontiguousarray(ys)
     dhy = core.ascontiguousarray(dhy)
-    dcy = core.ascontiguousarray(dcy)
+    if dcy is not None:
+        dcy = core.ascontiguousarray(dcy)
     dys = core.ascontiguousarray(dys)
 
     cdef int length = len(lengths)


### PR DESCRIPTION
We need to check if `cx` is `None` because GRU and RNN do not use `cx` and they set `None`.
related to #1659 