### PR TITLE
Accept `out` argument specified as a tuple, and support it in fusion

### DIFF
--- a/tests/cupy_tests/math_tests/test_arithmetic.py
+++ b/tests/cupy_tests/math_tests/test_arithmetic.py
@@ -250,3 +250,15 @@ class TestArithmeticModf(unittest.TestCase):
         d[0] = b
         d[1] = c
         return d
+
+    @testing.for_float_dtypes()
+    @testing.numpy_cupy_allclose()
+    def test_modf_out(self, xp, dtype):
+        a = xp.array([-2.5, -1.5, -0.5, 0, 0.5, 1.5, 2.5], dtype=dtype)
+        b = xp.empty(7, dtype=dtype)
+        c = xp.empty(7, dtype=dtype)
+        xp.modf(a, out=(b, c))
+        d = xp.empty((2, 7), dtype=dtype)
+        d[0] = b
+        d[1] = c
+        return d


### PR DESCRIPTION
Currently CuPy doesn't allows a tuple for `'out'` argument. Furthermore fusion has no `out` support. This PR implements those.

For some popular tasks, including bounding box calculation and color conversion, it is very beneficial to pass multiple output views to a fusion function. The following example illustrates the use case. It converts bounding box format with a single CUDA call.

```python
import cupy

@cupy.fuse
def xywh_to_ltrb(x, y, w, h):
    l = x - 0.5 * w
    t = y - 0.5 * h
    r = x + 0.5 * w
    b = y + 0.5 * h
    return l, t, r, b

xywh = cupy.asarray([[10, 20, 2, 4], [30, 40, 6, 8]], dtype=cupy.float32)
ltrb = cupy.empty_like(xywh)

xywh_to_ltrb(xywh[:, 0], xywh[:, 1], xywh[:, 2], xywh[:, 3],
             out=(ltrb[:, 0], ltrb[:, 1], ltrb[:, 2], ltrb[:, 3]))
print(ltrb)  # [[9, 18, 11, 12], [27, 36, 33, 44]]
```
