### PR TITLE
Add diags to documentation

### DIFF
--- a/docs/source/reference/sparse.rst
+++ b/docs/source/reference/sparse.rst
@@ -51,6 +51,7 @@ Building sparse matrices
    :toctree: generated/
    :nosignatures:
 
+   cupyx.scipy.sparse.diags
    cupyx.scipy.sparse.eye
    cupyx.scipy.sparse.identity
    cupyx.scipy.sparse.spdiags


### PR DESCRIPTION
This PR follows #1840 to add `cupyx.scipy.sparse.diags` to the reference.