### PR TITLE
Use item instead of asscalar to support NumPy 1.16

### DIFF
--- a/cupy/core/fusion.py
+++ b/cupy/core/fusion.py
@@ -114,7 +114,7 @@ class _FusionVarCUDA(object):
 
     def declaration(self):
         c = self.const
-        val = numpy.asscalar(c) if hasattr(c, 'dtype') else c
+        val = c.item() if hasattr(c, 'dtype') else c
         ctype = _dtype_to_ctype[self.dtype]
 
         if self.const is None:

--- a/cupy/manipulation/kind.py
+++ b/cupy/manipulation/kind.py
@@ -24,7 +24,4 @@ def asfortranarray(a, dtype=None):
 # TODO(okuta): Implement asarray_chkfinite
 
 
-# TODO(okuta): Implement asscalar
-
-
 # TODO(okuta): Implement require

--- a/tests/cupy_tests/core_tests/test_fusion.py
+++ b/tests/cupy_tests/core_tests/test_fusion.py
@@ -1446,7 +1446,7 @@ class TestFusionScalar(unittest.TestCase):
 
         @cupy.fuse()
         def f(x):
-            return x * numpy.asscalar(dtype2(1))
+            return x * dtype2(1).item()
         return f(testing.shaped_arange((1,), xp, dtype1))
 
     @testing.for_all_dtypes_combination(names=['dtype1', 'dtype2'])
@@ -1466,7 +1466,7 @@ class TestFusionScalar(unittest.TestCase):
         def f(x, y):
             return x + y
         x = testing.shaped_arange((10,), xp, dtype1)
-        y = numpy.asscalar(dtype2(1))
+        y = dtype2(1).item()
         return f(x, y)
 
     @testing.for_all_dtypes_combination(names=('dtype1', 'dtype2'))


### PR DESCRIPTION
This PR is to support NumPy 1.16
#1881 