### PR TITLE
[backport] Support Numpy arrays as seeds in RandomState

### DIFF
--- a/cupy/random/generator.py
+++ b/cupy/random/generator.py
@@ -1,6 +1,7 @@
 import atexit
 import binascii
 import functools
+import hashlib
 import operator
 import os
 import time
@@ -468,6 +469,8 @@ class RandomState(object):
             except NotImplementedError:
                 seed = numpy.uint64(time.clock() * 1000000)
         else:
+            if isinstance(seed, numpy.ndarray):
+                seed = int(hashlib.md5(seed).hexdigest()[:16], 16)
             seed = numpy.asarray(seed).astype(numpy.uint64, casting='safe')
 
         curand.setPseudoRandomGeneratorSeed(self._generator, seed)

--- a/docs/source/reference/difference.rst
+++ b/docs/source/reference/difference.rst
@@ -155,3 +155,17 @@ They do not accept other objects (e.g., lists or :class:`numpy.ndarray`).
   Traceback (most recent call last):
     File "<stdin>", line 1, in <module>
   TypeError: Unsupported type <class 'list'>
+
+
+Random seed arrays are hashed to scalars
+----------------------------------------
+
+Like Numpy, CuPy's RandomState objects accept seeds either as numbers or as
+full numpy arrays.
+
+  >>> seed = np.array([1, 2, 3, 4, 5])
+  >>> rs = cupy.random.RandomState(seed=seed)
+
+However, unlike Numpy, array seeds will be hashed down to a single number and
+so may not communicate as much entropy to the underlying random number
+generator.

--- a/tests/cupy_tests/random_tests/test_generator.py
+++ b/tests/cupy_tests/random_tests/test_generator.py
@@ -101,6 +101,9 @@ class TestRandomState(unittest.TestCase):
         with self.assertRaises(TypeError):
             self.rs.seed(dtype(0))
 
+    def test_array_seed(self):
+        self.check_seed(numpy.random.randint(0, 2**32, size=40))
+
 
 @testing.parameterize(
     {'a': 1.0, 'b': 3.0},


### PR DESCRIPTION
Backport of #1689