### PR TITLE
Add RawKernel.compile() method

### DIFF
--- a/cupy/core/raw.pyx
+++ b/cupy/core/raw.pyx
@@ -14,9 +14,10 @@ cdef class RawKernel:
     ``$HOME/.cupy/kernel_cache/`` directory with a hashed file name. The cached
     binary is reused by other processes.
 
-    Alternatively, this class can also compile an existing codebase (ex: reading
-    a .cu source file) by the :meth:`~RawKernel.compile` method, which returns a
-    cp.cuda.function.Module instance that contains the kernels in the source.
+    Alternatively, this class can also compile an existing codebase (ex:
+    reading a .cu source file) by the :meth:`~RawKernel.compile` method, which
+    returns a cp.cuda.function.Module instance that contains the kernels in the
+    source.
 
     Args:
         code (str): CUDA source code.

--- a/cupy/core/raw.pyx
+++ b/cupy/core/raw.pyx
@@ -14,6 +14,10 @@ cdef class RawKernel:
     ``$HOME/.cupy/kernel_cache/`` directory with a hashed file name. The cached
     binary is reused by other processes.
 
+    Alternatively, this class can also compile an existing codebase (ex: reading
+    a .cu source file) by the :meth:`~RawKernel.compile` method, which returns a
+    cp.cuda.function.Module instance that contains the kernels in the source.
+
     Args:
         code (str): CUDA source code.
         name (str): Name of the kernel function.
@@ -44,6 +48,25 @@ cdef class RawKernel:
         """
         kern = _get_raw_kernel(self.code, self.name, self.options)
         kern(grid, block, args, **kwargs)
+
+    def compile(self, code=None, options=()):
+        """compile(self, code=None, options=())
+
+        Compiles the kernels in code, and returns a Module instance. If the
+        arguments are not given, the corresponding attributes of the RawKernel
+        instance that were given during initialization are used.
+
+        The compilation runs only if the kernels are not cached.
+        """
+        if code is None:
+            code = self.code
+
+        if options == ():
+            options = self.options
+
+        module = cupy.core.core.compile_with_cache(
+            code, options, prepend_cupy_headers=False)
+        return module
 
 
 @cupy.util.memoize(for_each_device=True)

--- a/cupy/core/raw.pyx
+++ b/cupy/core/raw.pyx
@@ -50,8 +50,8 @@ cdef class RawKernel:
         kern = _get_raw_kernel(self.code, self.name, self.options)
         kern(grid, block, args, **kwargs)
 
-    def compile(self, code=None, options=()):
-        """compile(self, code=None, options=())
+    def compile(self, code=None, options=(), backend='nvrtc'):
+        """compile(self, code=None, options=(), backend='nvrtc')
 
         Compiles the kernels in code, and returns a Module instance. If the
         arguments are not given, the corresponding attributes of the RawKernel
@@ -66,7 +66,8 @@ cdef class RawKernel:
             options = self.options
 
         module = cupy.core.core.compile_with_cache(
-            code, options, prepend_cupy_headers=False)
+            code, options, prepend_cupy_headers=False, backend=backend)
+
         return module
 
 

--- a/docs/source/tutorial/kernel.rst
+++ b/docs/source/tutorial/kernel.rst
@@ -202,40 +202,39 @@ Alternatively, you may load and compile an existing ``.cu`` file, and select the
 .. doctest::
 
    >>> loaded_from_source = r'''
-	... extern "C"{
-	... 
-	... __global__ void test_sum(const float* x1, const float* x2, float* y, \
-	...                          unsigned int N)
-	... {
-	...     unsigned int tid = blockDim.x * blockIdx.x + threadIdx.x;
-	...     if (tid < N)
-	...     {
-	...         y[tid] = x1[tid] + x2[tid];
-	...     }
-	... }
-	... 
-	... __global__ void test_multiply(const float* x1, const float* x2, float* y, \
-	...                               unsigned int N)
-	... {
-	...     unsigned int tid = blockDim.x * blockIdx.x + threadIdx.x;
-	...     if (tid < N)
-	...     {
-	...         y[tid] = x1[tid] * x2[tid];
-	...     }
-	... }
-	... 
-	... }
-	... '''
+   ... extern "C"{
+   ... 
+   ... __global__ void test_sum(const float* x1, const float* x2, float* y, \
+   ...                          unsigned int N)
+   ... {
+   ...     unsigned int tid = blockDim.x * blockIdx.x + threadIdx.x;
+   ...     if (tid < N)
+   ...     {
+   ...         y[tid] = x1[tid] + x2[tid];
+   ...     }
+   ... }
+   ... 
+   ... __global__ void test_multiply(const float* x1, const float* x2, float* y, \
+   ...                               unsigned int N)
+   ... {
+   ...     unsigned int tid = blockDim.x * blockIdx.x + threadIdx.x;
+   ...     if (tid < N)
+   ...     {
+   ...         y[tid] = x1[tid] * x2[tid];
+   ...     }
+   ... }
+   ... 
+   ... }'''
    >>> ker = cupy.RawKernel(loaded_from_source, None)
-	>>> module = ker.compile()
-	>>> ker_sum = module.get_function('test_sum')
-	>>> ker_times = module.get_function('test_multiply')
-	>>> N = 10
-	>>> x1 = cupy.arange(N**2, dtype=cupy.float32).reshape(N, N)
-	>>> x2 = cupy.ones((N, N), dtype=cupy.float32)
-	>>> y = cupy.zeros((N, N), dtype=cupy.float32)
-	>>> ker_sum((N,), (N,), (x1, x2, y, N**2))   # y = x1 + x2
-	>>> ker_times((N,), (N,), (x1, x2, y, N**2)) # y = x1 * x2
+   >>> module = ker.compile()
+   >>> ker_sum = module.get_function('test_sum')
+   >>> ker_times = module.get_function('test_multiply')
+   >>> N = 10
+   >>> x1 = cupy.arange(N**2, dtype=cupy.float32).reshape(N, N)
+   >>> x2 = cupy.ones((N, N), dtype=cupy.float32)
+   >>> y = cupy.zeros((N, N), dtype=cupy.float32)
+   >>> ker_sum((N,), (N,), (x1, x2, y, N**2))   # y = x1 + x2
+   >>> ker_times((N,), (N,), (x1, x2, y, N**2)) # y = x1 * x2
 
 .. note::
     The kernel does not have return values.

--- a/tests/cupy_tests/core_tests/test_raw.py
+++ b/tests/cupy_tests/core_tests/test_raw.py
@@ -15,7 +15,9 @@ void test_sum(const float* x1, const float* x2, float* y) {
 _test_source2 = r'''
 extern "C"{
 
-__global__ void test_sum(const float* x1, const float* x2, float* y, unsigned int N) {
+__global__ void test_sum(const float* x1, const float* x2, float* y, \
+                         unsigned int N)
+{
     unsigned int tid = blockDim.x * blockIdx.x + threadIdx.x;
     if (tid < N)
     {
@@ -23,7 +25,9 @@ __global__ void test_sum(const float* x1, const float* x2, float* y, unsigned in
     }
 }
 
-__global__ void test_multiply(const float* x1, const float* x2, float* y, unsigned int N) {
+__global__ void test_multiply(const float* x1, const float* x2, float* y, \
+                              unsigned int N)
+{
     unsigned int tid = blockDim.x * blockIdx.x + threadIdx.x;
     if (tid < N)
     {
@@ -50,7 +54,9 @@ _test_source3 = r'''
 
 extern "C"{
 
-__global__ void test_sum(const TYPE* x1, const TYPE* x2, TYPE* y, unsigned int N) {
+__global__ void test_sum(const TYPE* x1, const TYPE* x2, TYPE* y, \
+                         unsigned int N)
+{
     unsigned int tid = blockDim.x * blockIdx.x + threadIdx.x;
     if (tid < N)
     {
@@ -58,7 +64,9 @@ __global__ void test_sum(const TYPE* x1, const TYPE* x2, TYPE* y, unsigned int N
     }
 }
 
-__global__ void test_multiply(const TYPE* x1, const TYPE* x2, TYPE* y, unsigned int N) {
+__global__ void test_multiply(const TYPE* x1, const TYPE* x2, TYPE* y, \
+                              unsigned int N)
+{
     unsigned int tid = blockDim.x * blockIdx.x + threadIdx.x;
     if (tid < N)
     {
@@ -79,40 +87,41 @@ class TestRaw(unittest.TestCase):
         kern((10,), (10,), (x1, x2, y))
         assert (y == x1 + x2).all()
 
-    # test compiling using the compile() method and invoking multiple kernels in one single .cubin
+    # test compiling using the compile() method and invoking multiple kernels
+    # in one single .cubin
     def test_multiple(self):
         ker = cupy.RawKernel(_test_source2, None)
-        #module = ker.compile(_test_source2)
+        # module = ker.compile(_test_source2)
         module = ker.compile()
         ker_sum = module.get_function('test_sum')
         ker_times = module.get_function('test_multiply')
-        
+
         N = 10
         x1 = cupy.arange(N**2, dtype=cupy.float32).reshape(N, N)
         x2 = cupy.ones((N, N), dtype=cupy.float32)
         y = cupy.zeros((N, N), dtype=cupy.float32)
-        
+
         ker_sum((N,), (N,), (x1, x2, y, N**2))
         assert (y == x1 + x2).all()
-        
+
         ker_times((N,), (N,), (x1, x2, y, N**2))
         assert (y == x1 * x2).all()
 
     # test setting C macros using compiler options
     def test_macro(self):
         ker = cupy.RawKernel(_test_source3, None, ("-DPRECISION=1",))
-        #module = ker.compile(_test_source3, ("-DPRECISION=1",))
+        # module = ker.compile(_test_source3, ("-DPRECISION=1",))
         module = ker.compile()
         ker_sum = module.get_function('test_sum')
         ker_times = module.get_function('test_multiply')
-        
+
         N = 10
         x1 = cupy.arange(N**2, dtype=cupy.float32).reshape(N, N)
         x2 = cupy.ones((N, N), dtype=cupy.float32)
         y = cupy.zeros((N, N), dtype=cupy.float32)
-        
+
         ker_sum((N,), (N,), (x1, x2, y, N**2))
         assert (y == x1 + x2).all()
-        
+
         ker_times((N,), (N,), (x1, x2, y, N**2))
         assert (y == x1 * x2).all()

--- a/tests/cupy_tests/core_tests/test_raw.py
+++ b/tests/cupy_tests/core_tests/test_raw.py
@@ -11,6 +11,64 @@ void test_sum(const float* x1, const float* x2, float* y) {
 }
 '''
 
+# test compiling and invoking multiple kernels in one single .cubin
+_test_source2 = r'''
+extern "C"{
+
+__global__ void test_sum(const float* x1, const float* x2, float* y, unsigned int N) {
+    unsigned int tid = blockDim.x * blockIdx.x + threadIdx.x;
+    if (tid < N)
+    {
+        y[tid] = x1[tid] + x2[tid];
+    }
+}
+
+__global__ void test_multiply(const float* x1, const float* x2, float* y, unsigned int N) {
+    unsigned int tid = blockDim.x * blockIdx.x + threadIdx.x;
+    if (tid < N)
+    {
+        y[tid] = x1[tid] * x2[tid];
+    }
+}
+
+}
+'''
+
+# test C macros
+_test_source3 = r'''
+#ifndef PRECISION
+    #define PRECISION 2
+#endif
+
+#if PRECISION == 2
+    #define TYPE double
+#elif PRECISION == 1
+    #define TYPE float
+#else
+    #error precision not supported
+#endif
+
+extern "C"{
+
+__global__ void test_sum(const TYPE* x1, const TYPE* x2, TYPE* y, unsigned int N) {
+    unsigned int tid = blockDim.x * blockIdx.x + threadIdx.x;
+    if (tid < N)
+    {
+        y[tid] = x1[tid] + x2[tid];
+    }
+}
+
+__global__ void test_multiply(const TYPE* x1, const TYPE* x2, TYPE* y, unsigned int N) {
+    unsigned int tid = blockDim.x * blockIdx.x + threadIdx.x;
+    if (tid < N)
+    {
+        y[tid] = x1[tid] * x2[tid];
+    }
+}
+
+}
+'''
+
 
 class TestRaw(unittest.TestCase):
     def test_basic(self):
@@ -20,3 +78,41 @@ class TestRaw(unittest.TestCase):
         y = cupy.zeros((10, 10), dtype=cupy.float32)
         kern((10,), (10,), (x1, x2, y))
         assert (y == x1 + x2).all()
+
+    # test compiling using the compile() method and invoking multiple kernels in one single .cubin
+    def test_multiple(self):
+        ker = cupy.RawKernel(_test_source2, None)
+        #module = ker.compile(_test_source2)
+        module = ker.compile()
+        ker_sum = module.get_function('test_sum')
+        ker_times = module.get_function('test_multiply')
+        
+        N = 10
+        x1 = cupy.arange(N**2, dtype=cupy.float32).reshape(N, N)
+        x2 = cupy.ones((N, N), dtype=cupy.float32)
+        y = cupy.zeros((N, N), dtype=cupy.float32)
+        
+        ker_sum((N,), (N,), (x1, x2, y, N**2))
+        assert (y == x1 + x2).all()
+        
+        ker_times((N,), (N,), (x1, x2, y, N**2))
+        assert (y == x1 * x2).all()
+
+    # test setting C macros using compiler options
+    def test_macro(self):
+        ker = cupy.RawKernel(_test_source3, None, ("-DPRECISION=1",))
+        #module = ker.compile(_test_source3, ("-DPRECISION=1",))
+        module = ker.compile()
+        ker_sum = module.get_function('test_sum')
+        ker_times = module.get_function('test_multiply')
+        
+        N = 10
+        x1 = cupy.arange(N**2, dtype=cupy.float32).reshape(N, N)
+        x2 = cupy.ones((N, N), dtype=cupy.float32)
+        y = cupy.zeros((N, N), dtype=cupy.float32)
+        
+        ker_sum((N,), (N,), (x1, x2, y, N**2))
+        assert (y == x1 + x2).all()
+        
+        ker_times((N,), (N,), (x1, x2, y, N**2))
+        assert (y == x1 * x2).all()


### PR DESCRIPTION
As discussed in #1657, a `.compile()` method is desired. I implemented it and added two tests.

A few words on this implementation: while it functions as requested, upon reflection I feel the `compile()` method should belong to the module level instead of the `RawKernel` class. The later implies that a CUDA kernel, instead of a module, is returned and used. However, I don't see any other way to do so without breaking backward compatibility, so this is a design choice I leave for you to worry in the future. Should you have any comments or suggestions, I'm more than happy to discuss and make changes. 

Thanks.