### PR TITLE
Fix `randint` high value in test for Windows

### DIFF
--- a/tests/cupy_tests/random_tests/test_generator.py
+++ b/tests/cupy_tests/random_tests/test_generator.py
@@ -219,7 +219,7 @@ class TestRandomState(unittest.TestCase):
             self.rs.seed(dtype(0))
 
     def test_array_seed(self):
-        self.check_seed(numpy.random.randint(0, 2**32, size=40))
+        self.check_seed(numpy.random.randint(0, 2**31, size=40))
 
 
 @testing.parameterize(


### PR DESCRIPTION
Fix regression (Windows test failure) introduced in #1689.

```_______________________ TestRandomState.test_array_seed _______________________

self = <cupy_tests.random_tests.test_generator.TestRandomState testMethod=test_array_seed>

    def test_array_seed(self):
>       self.check_seed(numpy.random.randint(0, 2**32, size=40))

tests\cupy_tests\random_tests\test_generator.py:222: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

>   ???
E   ValueError: high is out of bounds for int32

mtrand.pyx:991: ValueError
```