### PR TITLE
Add `fnc` and `forc` to `core.flags.Flags`

### DIFF
--- a/cupy/core/flags.pyx
+++ b/cupy/core/flags.pyx
@@ -8,6 +8,14 @@ class Flags(object):
         self.f_contiguous = f_contiguous
         self.owndata = owndata
 
+    @property
+    def fnc(self):
+        return self.f_contiguous and not self.c_contiguous
+
+    @property
+    def forc(self):
+        return self.f_contiguous or self.c_contiguous
+
     def __getitem__(self, name):
         if name == 'C_CONTIGUOUS':
             return self.c_contiguous

--- a/tests/cupy_tests/core_tests/test_flags.py
+++ b/tests/cupy_tests/core_tests/test_flags.py
@@ -1,6 +1,8 @@
 import unittest
 
+import cupy
 from cupy.core import flags
+from cupy import testing
 
 
 class TestFlags(unittest.TestCase):
@@ -25,3 +27,23 @@ class TestFlags(unittest.TestCase):
         self.assertEqual('''  C_CONTIGUOUS : 1
   F_CONTIGUOUS : 2
   OWNDATA : 3''', repr(self.flags))
+
+    def test_fnc(self):
+        a_1d_c = testing.shaped_random((4, ), cupy)
+        a_2d_c = testing.shaped_random((4, 4), cupy)
+        a_2d_f = cupy.asfortranarray(testing.shaped_random((4, 4), cupy))
+        a_2d_noncontig = testing.shaped_random((4, 8), cupy)[:, ::2]
+        assert a_1d_c.flags.fnc is False
+        assert a_2d_c.flags.fnc is False
+        assert a_2d_f.flags.fnc is True
+        assert a_2d_noncontig.flags.fnc is False
+
+    def test_forc(self):
+        a_1d_c = testing.shaped_random((4, ), cupy)
+        a_2d_c = testing.shaped_random((4, 4), cupy)
+        a_2d_f = cupy.asfortranarray(testing.shaped_random((4, 4), cupy))
+        a_2d_noncontig = testing.shaped_random((4, 8), cupy)[:, ::2]
+        assert a_1d_c.flags.forc is True
+        assert a_2d_c.flags.forc is True
+        assert a_2d_f.flags.forc is True
+        assert a_2d_noncontig.flags.forc is False


### PR DESCRIPTION
This adds the properties `forc` and `fnc` to the ndarray's `flags`.  These behave the same as in NumPy.

`forc` is True if the array is either Fortran or C contiguous
`fnc` is True if the array is Fortran contiguous, but not C contiguous
