### PR TITLE
[backport] Fix `randint` high value in test for Windows

### DIFF
--- a/tests/cupy_tests/random_tests/test_generator.py
+++ b/tests/cupy_tests/random_tests/test_generator.py
@@ -102,7 +102,7 @@ class TestRandomState(unittest.TestCase):
             self.rs.seed(dtype(0))
 
     def test_array_seed(self):
-        self.check_seed(numpy.random.randint(0, 2**32, size=40))
+        self.check_seed(numpy.random.randint(0, 2**31, size=40))
 
 
 @testing.parameterize(


### PR DESCRIPTION
Backport of #1892