### PR TITLE
CuPy external memory pool with memory pool and function pointers

### DIFF
--- a/cupy/cuda/memory.pxd
+++ b/cupy/cuda/memory.pxd
@@ -73,5 +73,6 @@ cdef class ExternalAllocator:
         intptr_t _param
         intptr_t _malloc_func
         intptr_t _free_func
+        object _owner
 
     cpdef MemoryPointer malloc(self, Py_ssize_t size)

--- a/cupy/cuda/memory.pxd
+++ b/cupy/cuda/memory.pxd
@@ -1,5 +1,6 @@
 cimport cython  # NOQA
 
+from libc.stdint cimport intptr_t
 from libcpp cimport vector
 from libcpp cimport map
 
@@ -56,3 +57,21 @@ cdef class MemoryPool:
     cpdef used_bytes(self)
     cpdef free_bytes(self)
     cpdef total_bytes(self)
+
+
+@cython.no_gc
+cdef class ExternalMemoryPoolMemory(BaseMemory):
+
+    cdef:
+        intptr_t _memory_pool
+        intptr_t _free
+
+
+cdef class ExternalMemoryPool:
+
+    cdef:
+        object _memory_pools
+        intptr_t _malloc
+        intptr_t _free
+
+    cpdef MemoryPointer malloc(self, Py_ssize_t size)

--- a/cupy/cuda/memory.pxd
+++ b/cupy/cuda/memory.pxd
@@ -63,15 +63,15 @@ cdef class MemoryPool:
 cdef class ExternalAllocatorMemory(BaseMemory):
 
     cdef:
-        intptr_t _param_ptr
-        intptr_t _free_ptr
+        intptr_t _param
+        intptr_t _free_func
 
 
 cdef class ExternalAllocator:
 
     cdef:
-        intptr_t _param_ptr
-        intptr_t _malloc_ptr
-        intptr_t _free_ptr
+        intptr_t _param
+        intptr_t _malloc_func
+        intptr_t _free_func
 
     cpdef MemoryPointer malloc(self, Py_ssize_t size)

--- a/cupy/cuda/memory.pxd
+++ b/cupy/cuda/memory.pxd
@@ -60,18 +60,18 @@ cdef class MemoryPool:
 
 
 @cython.no_gc
-cdef class ExternalMemoryPoolMemory(BaseMemory):
+cdef class ExternalAllocatorMemory(BaseMemory):
 
     cdef:
-        intptr_t _memory_pool
-        intptr_t _free
+        intptr_t _param_ptr
+        intptr_t _free_ptr
 
 
-cdef class ExternalMemoryPool:
+cdef class ExternalAllocator:
 
     cdef:
-        object _memory_pools
-        intptr_t _malloc
-        intptr_t _free
+        intptr_t _param_ptr
+        intptr_t _malloc_ptr
+        intptr_t _free_ptr
 
     cpdef MemoryPointer malloc(self, Py_ssize_t size)

--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -1140,7 +1140,6 @@ cdef class MemoryPool(object):
         return mp.total_bytes()
 
 
-
 ctypedef void*(*malloc_func)(void*, size_t, int)
 ctypedef void(*free_func)(void*, void*, int)
 

--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -1159,16 +1159,14 @@ cpdef void _call_free(intptr_t param_ptr, intptr_t free_ptr, intptr_t ptr,
 @cython.no_gc
 cdef class ExternalAllocatorMemory(BaseMemory):
 
-    def __init__(
-            self, Py_ssize_t size, intptr_t param_ptr, intptr_t malloc_ptr,
-            intptr_t free_ptr, int device_id):
+    def __init__(self, Py_ssize_t size, intptr_t param_ptr,
+                 intptr_t malloc_ptr, intptr_t free_ptr, int device_id):
         self._param_ptr = param_ptr
         self._free_ptr = free_ptr
         self.device_id = device_id
         self.ptr = 0
         if size > 0:
             self.ptr = _call_malloc(param_ptr, malloc_ptr, size, device_id)
-
 
     def __dealloc__(self):
         if self.ptr:

--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -1196,13 +1196,17 @@ cdef class ExternalAllocator:
         param (int): Address of *param*.
         malloc_func (int): Address of *malloc*.
         free_func (int): Address of *free*.
+        owner (object): Reference to the owner object to keep the param and
+            the functions alive.
 
     """
 
-    def __init__(self, param, malloc_func, free_func):
+    def __init__(self, intptr_t param, intptr_t malloc_func,
+                 intptr_t free_func, object owner):
         self._param = param
         self._malloc_func = malloc_func
         self._free_func = free_func
+        self._owner = owner
 
     cpdef MemoryPointer malloc(self, Py_ssize_t size):
         mem = ExternalAllocatorMemory(size, self._param, self._malloc_func,


### PR DESCRIPTION
Allow setting external allocators to CuPy via raw pointers. See the docs for its interface. https://github.com/cupy/cupy/pull/1904/files#diff-0cb5dfa3212da5a58c698548f2df2f68R1179 .