### PR TITLE
Refactor cyclic imports

### DIFF
--- a/cupy/core/_kernel.pyx
+++ b/cupy/core/_kernel.pyx
@@ -1,5 +1,6 @@
 from __future__ import division
 import string
+import threading
 
 import numpy
 
@@ -23,9 +24,7 @@ from cupy.core.core cimport ndarray
 from cupy.core cimport internal
 
 
-# We can't directly import cupy.core.fusion at module level due to cyclic
-# imports. Importing it every time at the point of use is too slow.
-_fusion_module = None
+_thread_local = threading.local()
 
 
 cpdef _get_simple_elementwise_kernel(
@@ -766,13 +765,8 @@ class ufunc(object):
             Output array or a tuple of output arrays.
 
         """
-        global _fusion_module
-        if _fusion_module is None:
-            from cupy.core import fusion as _fusion_module
-
-        thread_local = _fusion_module._thread_local
-        if hasattr(thread_local, 'history'):
-            return thread_local.history.call_ufunc(self, args, kwargs)
+        if hasattr(_thread_local, 'history'):
+            return _thread_local.history.call_ufunc(self, args, kwargs)
 
         cdef function.Function kern
 

--- a/cupy/core/fusion.pyx
+++ b/cupy/core/fusion.pyx
@@ -771,7 +771,7 @@ class _FusionHistory(object):
         if self.reduce_op is None:
             operation += ' '.join('{} = {};'.format(t, s)
                                   for s, t in zip(out_cvars, out_params))
-            kernel = core.ElementwiseKernel(
+            kernel = _kernel.ElementwiseKernel(
                 in_params_code, out_params_code, operation,
                 preamble=submodule_code,
                 return_tuple=return_tuple,
@@ -806,7 +806,7 @@ class _FusionHistory(object):
                 reduce_ctype, postmap_dtype, postmap_cast_code)
             submodule_code += self._emit_postmap_code(out_params, postmap_code)
 
-            kernel = core.ReductionKernel(
+            kernel = _kernel.ReductionKernel(
                 in_params_code,
                 out_params_code,
                 '_pre_map({})'.format(', '.join([repr(p) for p in in_params])),

--- a/cupy/core/fusion.pyx
+++ b/cupy/core/fusion.pyx
@@ -1,17 +1,17 @@
 import functools
 import six
 import string
-import threading
 import warnings
 
 import numpy
 
 import cupy
 from cupy.core._dtype import get_dtype
+from cupy.core import _kernel
 from cupy.core import core
 
 
-_thread_local = threading.local()
+_thread_local = _kernel._thread_local
 
 cdef dict _kind_score = {
     'b': 0,

--- a/tests/cupy_tests/core_tests/test_fusion.py
+++ b/tests/cupy_tests/core_tests/test_fusion.py
@@ -1359,8 +1359,8 @@ class TestFusionKernelName(unittest.TestCase):
         # Test kernel name (with mock)
         if xp is cupy:
             target = (
-                'cupy.core.core.ElementwiseKernel' if is_elementwise
-                else 'cupy.core.core.ReductionKernel')
+                'cupy.core._kernel.ElementwiseKernel' if is_elementwise
+                else 'cupy.core._kernel.ReductionKernel')
 
             with mock.patch(target) as Kernel:
                 func(a, b, c)


### PR DESCRIPTION
Moved the declaration of `_thread_local` to `_kernel.pyx`.