### PR TITLE
ensure that sparse matrix shapes are always a tuple of int

### DIFF
--- a/cupyx/scipy/sparse/compressed.py
+++ b/cupyx/scipy/sparse/compressed.py
@@ -130,7 +130,9 @@ class _compressed_sparse_matrix(sparse_data._data_matrix):
                              % (len(indptr), major + 1))
 
         self._descr = cusparse.MatDescriptor.create()
-        self._shape = shape
+        if not util.isshape(shape):
+            raise ValueError('invalid shape (must be a 2-tuple of int)')
+        self._shape = int(shape[0]), int(shape[1])
         self._has_canonical_format = has_canonical_format
 
     def _with_data(self, data, copy=True):

--- a/cupyx/scipy/sparse/compressed.py
+++ b/cupyx/scipy/sparse/compressed.py
@@ -33,9 +33,10 @@ class _compressed_sparse_matrix(sparse_data._data_matrix):
         'compress_getitem_complex')
 
     def __init__(self, arg1, shape=None, dtype=None, copy=False):
-        if shape is not None and len(shape) != 2:
-            raise ValueError(
-                'Only two-dimensional sparse arrays are supported.')
+        if shape is not None:
+            if not util.isshape(shape):
+                raise ValueError('invalid shape (must be a 2-tuple of int)')
+            shape = int(shape[0]), int(shape[1])
 
         if base.issparse(arg1):
             x = arg1.asformat(self.format)
@@ -130,9 +131,7 @@ class _compressed_sparse_matrix(sparse_data._data_matrix):
                              % (len(indptr), major + 1))
 
         self._descr = cusparse.MatDescriptor.create()
-        if not util.isshape(shape):
-            raise ValueError('invalid shape (must be a 2-tuple of int)')
-        self._shape = int(shape[0]), int(shape[1])
+        self._shape = shape
         self._has_canonical_format = has_canonical_format
 
     def _with_data(self, data, copy=True):

--- a/cupyx/scipy/sparse/coo.py
+++ b/cupyx/scipy/sparse/coo.py
@@ -139,7 +139,9 @@ class coo_matrix(sparse_data._data_matrix):
         sparse_data._data_matrix.__init__(self, data)
         self.row = row
         self.col = col
-        self._shape = shape
+        if not util.isshape(shape):
+            raise ValueError('invalid shape (must be a 2-tuple of int)')
+        self._shape = int(shape[0]), int(shape[1])
         self._has_canonical_format = has_canonical_format
 
     def _with_data(self, data, copy=True):

--- a/cupyx/scipy/sparse/dia.py
+++ b/cupyx/scipy/sparse/dia.py
@@ -8,6 +8,7 @@ import cupy
 from cupy import core
 from cupyx.scipy.sparse import csc
 from cupyx.scipy.sparse import data
+from cupyx.scipy.sparse import util
 
 
 class dia_matrix(data._data_matrix):
@@ -64,7 +65,9 @@ class dia_matrix(data._data_matrix):
 
         self.data = data
         self.offsets = offsets
-        self._shape = shape
+        if not util.isshape(shape):
+            raise ValueError('invalid shape (must be a 2-tuple of int)')
+        self._shape = int(shape[0]), int(shape[1])
 
     def _with_data(self, data, copy=True):
         """Returns a matrix with the same sparsity structure as self,

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_coo.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_coo.py
@@ -252,6 +252,15 @@ class TestCooMatrixInit(unittest.TestCase):
         sp.coo_matrix(
             (self.data(xp), self.row(xp)), shape=self.shape)
 
+    @testing.numpy_cupy_allclose(sp_name='sp', atol=1e-5)
+    def test_intlike_shape(self, xp, sp):
+        s = sp.coo_matrix((self.data(xp), (self.row(xp), self.col(xp))),
+                          shape=(xp.array(self.shape[0]),
+                                 xp.int32(self.shape[1])))
+        assert isinstance(s.shape[0], int)
+        assert isinstance(s.shape[1], int)
+        return s
+
     @testing.numpy_cupy_raises(sp_name='sp')
     def test_shape_invalid(self, xp, sp):
         sp.coo_matrix(

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
@@ -314,6 +314,15 @@ class TestCscMatrixInit(unittest.TestCase):
         self.assertEqual(s.size, 0)
         return s
 
+    @testing.numpy_cupy_allclose(sp_name='sp', atol=1e-5)
+    def test_intlike_shape(self, xp, sp):
+        s = sp.csc_matrix((self.data(xp), self.indices(xp), self.indptr(xp)),
+                          shape=(xp.array(self.shape[0]),
+                                 xp.int32(self.shape[1])))
+        assert isinstance(s.shape[0], int)
+        assert isinstance(s.shape[1], int)
+        return s
+
     @testing.numpy_cupy_raises(sp_name='sp')
     def test_shape_invalid(self, xp, sp):
         sp.csc_matrix(

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -328,6 +328,15 @@ class TestCsrMatrixInit(unittest.TestCase):
         self.assertEqual(s.size, 0)
         return s
 
+    @testing.numpy_cupy_allclose(sp_name='sp', atol=1e-5)
+    def test_intlike_shape(self, xp, sp):
+        s = sp.csr_matrix((self.data(xp), self.indices(xp), self.indptr(xp)),
+                          shape=(xp.array(self.shape[0]),
+                                 xp.int32(self.shape[1])))
+        assert isinstance(s.shape[0], int)
+        assert isinstance(s.shape[1], int)
+        return s
+
     @testing.numpy_cupy_raises(sp_name='sp')
     def test_shape_invalid(self, xp, sp):
         sp.csr_matrix(

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_dia.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_dia.py
@@ -122,6 +122,15 @@ class TestDiaMatrixInit(unittest.TestCase):
         sp.dia_matrix(
             (self.data(xp), self.offsets(xp)), shape=None)
 
+    @testing.numpy_cupy_allclose(sp_name='sp', atol=1e-5)
+    def test_intlike_shape(self, xp, sp):
+        s = sp.dia_matrix((self.data(xp), self.offsets(xp)),
+                          shape=(xp.array(self.shape[0]),
+                                 xp.int32(self.shape[1])))
+        assert isinstance(s.shape[0], int)
+        assert isinstance(s.shape[1], int)
+        return s
+
     @testing.numpy_cupy_raises(sp_name='sp', accept_error=ValueError)
     def test_large_rank_offset(self, xp, sp):
         sp.dia_matrix(


### PR DESCRIPTION
It is currently possible to pass non-integers as the elements of the `shape` input to the sparse matrix creation routines.  When this is done, the `__init__` method should make sure these get converted to proper Python `int`.  This conversion to `int` is already done if the first argument is a shape, but was missing when `shape` was instead supplied via the keyword argument.

A remaining difference is that the existing `util.isshape` function still allows a shape such as `(3.0, 4.0)` to be converted to `(3, 4)` while SciPy would raise the following error:
`TypeError: 'float' object cannot be interpreted as an integer`
