### PR TITLE
ensure the input to the CUFFT Plan1D class is C contiguous

### DIFF
--- a/cupy/fft/fft.py
+++ b/cupy/fft/fft.py
@@ -76,7 +76,7 @@ def _exec_fft(a, direction, value_type, norm, axis, overwrite_x,
     if axis % a.ndim != a.ndim - 1:
         a = a.swapaxes(axis, -1)
 
-    if a.base is not None:
+    if a.base is not None or not a.flags.c_contiguous:
         a = a.copy()
 
     if out_size is None:

--- a/tests/cupy_tests/fft_tests/test_fft.py
+++ b/tests/cupy_tests/fft_tests/test_fft.py
@@ -84,6 +84,45 @@ class TestFft(unittest.TestCase):
         return out
 
 
+@testing.parameterize(*testing.product({
+    'shape': [(10, 10), (10, 5, 10)],
+    'data_order': ['F', 'C'],
+    'axis': [0, 1, -1],
+}))
+@testing.gpu
+@testing.with_requires('numpy>=1.10.0')
+class TestFftOrder(unittest.TestCase):
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
+                                 contiguous_check=False)
+    def test_fft(self, xp, dtype):
+        a = testing.shaped_random(self.shape, xp, dtype)
+        if self.data_order == 'F':
+            a = xp.asfortranarray(a)
+        out = xp.fft.fft(a, axis=self.axis)
+
+        # np.fft.fft alway returns np.complex128
+        if xp == np and dtype in [np.float16, np.float32, np.complex64]:
+            out = out.astype(np.complex64)
+
+        return out
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
+                                 contiguous_check=False)
+    def test_ifft(self, xp, dtype):
+        a = testing.shaped_random(self.shape, xp, dtype)
+        if self.data_order == 'F':
+            a = xp.asfortranarray(a)
+        out = xp.fft.ifft(a, axis=self.axis)
+
+        if xp == np and dtype in [np.float16, np.float32, np.complex64]:
+            out = out.astype(np.complex64)
+
+        return out
+
+
 @testing.gpu
 class TestDefaultPlanType(unittest.TestCase):
 


### PR DESCRIPTION
Plan1D requires C contiguous data, but `_exec_fft` did not always ensure this. Specifically if the array was F-contiguous and the last axis was transformed, no copy was made, leading to an incorrect output.

closes #1934

@leofang, can you run your test cases using this small patch and verify that this fixes it for you?

