### PR TITLE
Clean up `internal.pyx` (`prod`)

### DIFF
--- a/cupy/core/_routines_manipulation.pyx
+++ b/cupy/core/_routines_manipulation.pyx
@@ -72,7 +72,7 @@ cdef class broadcast:
 
         shape.assign(r_shape.rbegin(), r_shape.rend())
         self.shape = tuple(shape)
-        self.size = internal.prod_ssize_t(shape)
+        self.size = internal.prod(shape)
 
         broadcasted = []
         for x in arrays:
@@ -681,7 +681,7 @@ cdef vector.vector[Py_ssize_t] _get_strides_for_nocopy_reshape(
     cdef vector.vector[Py_ssize_t] newstrides
     cdef Py_ssize_t size, itemsize, ndim, dim, last_stride
     size = a.size
-    if size != internal.prod_ssize_t(newshape):
+    if size != internal.prod(newshape):
         return newstrides
 
     itemsize = a.itemsize
@@ -752,7 +752,7 @@ cdef ndarray _concatenate_single_kernel(
 
     ret = core.ndarray(shape, dtype=dtype)
     if same_shape_and_contiguous:
-        base = internal.prod_ssize_t(shape[axis:]) // len(arrays)
+        base = internal.prod(shape[axis:]) // len(arrays)
         _concatenate_kernel_same_size(x, base, ret)
         return ret
 

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1755,7 +1755,7 @@ cdef class ndarray:
             raise ValueError('len(shape) != len(strides)')
         self._shape = shape
         self._strides = strides
-        self.size = internal.prod_ssize_t(shape)
+        self.size = internal.prod(shape)
         if update_c_contiguity:
             self._update_c_contiguity()
         if update_f_contiguity:

--- a/cupy/core/internal.pxd
+++ b/cupy/core/internal.pxd
@@ -3,10 +3,7 @@ from libcpp cimport vector
 from libc.stdint cimport uint16_t
 
 
-cpdef Py_ssize_t prod(args, Py_ssize_t init=*) except? -1
-
-cpdef Py_ssize_t prod_ssize_t(
-    vector.vector[Py_ssize_t]& arr, Py_ssize_t init=*)
+cpdef Py_ssize_t prod(const vector.vector[Py_ssize_t]& args)
 
 cpdef tuple get_size(object size)
 

--- a/cupy/core/internal.pyx
+++ b/cupy/core/internal.pyx
@@ -12,20 +12,11 @@ cdef extern from "halffloat.h":
 
 
 @cython.profile(False)
-cpdef inline Py_ssize_t prod(args, Py_ssize_t init=1) except? -1:
-    cdef Py_ssize_t arg
-    for arg in args:
-        init *= arg
-    return init
-
-
-@cython.profile(False)
-cpdef inline Py_ssize_t prod_ssize_t(
-        vector.vector[Py_ssize_t]& arr, Py_ssize_t init=1):
-    cdef Py_ssize_t a
-    for a in arr:
-        init *= a
-    return init
+cpdef inline Py_ssize_t prod(const vector.vector[Py_ssize_t]& args):
+    cdef Py_ssize_t n = 1
+    for i in range(args.size()):
+        n *= args[i]
+    return n
 
 
 @cython.profile(False)


### PR DESCRIPTION
* Removed the untyped variant, as it seems the typed one is sufficient.
* Removed `init` argument - it's never used.