### PR TITLE
Fix int types

### DIFF
--- a/cupy/cuda/driver.pxd
+++ b/cupy/cuda/driver.pxd
@@ -1,3 +1,6 @@
+from libc.stdint cimport intptr_t
+
+
 ###############################################################################
 # Types
 ###############################################################################
@@ -54,8 +57,8 @@ cpdef moduleUnload(size_t module)
 cpdef size_t moduleGetFunction(size_t module, str funcname) except? 0
 cpdef size_t moduleGetGlobal(size_t module, str varname) except? 0
 cpdef launchKernel(
-    size_t f, unsigned int grid_dim_x, unsigned int grid_dim_y,
+    intptr_t f, unsigned int grid_dim_x, unsigned int grid_dim_y,
     unsigned int grid_dim_z, unsigned int block_dim_x,
     unsigned int block_dim_y, unsigned int block_dim_z,
-    unsigned int shared_mem_bytes, size_t stream, size_t kernel_params,
-    size_t extra)
+    unsigned int shared_mem_bytes, size_t stream, intptr_t kernel_params,
+    intptr_t extra)

--- a/cupy/cuda/driver.pyx
+++ b/cupy/cuda/driver.pyx
@@ -12,6 +12,7 @@ There are four differences compared to the original C API.
 
 """
 cimport cython  # NOQA
+from libc.stdint cimport intptr_t
 
 
 ###############################################################################
@@ -214,11 +215,11 @@ cpdef size_t moduleGetGlobal(size_t module, str varname) except? 0:
 
 
 cpdef launchKernel(
-        size_t f, unsigned int grid_dim_x, unsigned int grid_dim_y,
+        intptr_t f, unsigned int grid_dim_x, unsigned int grid_dim_y,
         unsigned int grid_dim_z, unsigned int block_dim_x,
         unsigned int block_dim_y, unsigned int block_dim_z,
-        unsigned int shared_mem_bytes, size_t stream, size_t kernel_params,
-        size_t extra):
+        unsigned int shared_mem_bytes, size_t stream, intptr_t kernel_params,
+        intptr_t extra):
     with nogil:
         status = cuLaunchKernel(
             <Function>f, grid_dim_x, grid_dim_y, grid_dim_z,

--- a/cupy/cuda/function.pxd
+++ b/cupy/cuda/function.pxd
@@ -1,3 +1,6 @@
+from libc.stdint cimport intptr_t
+
+
 cdef class CPointer:
     cdef void* ptr
 
@@ -6,7 +9,7 @@ cdef class Function:
 
     cdef:
         public Module module
-        public size_t ptr
+        public intptr_t ptr
 
     cpdef linear_launch(self, size_t size, args, size_t shared_mem=*,
                         size_t block_max_size=*, stream=*)
@@ -15,7 +18,7 @@ cdef class Function:
 cdef class Module:
 
     cdef:
-        public size_t ptr
+        public intptr_t ptr
 
     cpdef load_file(self, filename)
     cpdef load(self, bytes cubin)
@@ -26,7 +29,7 @@ cdef class Module:
 cdef class LinkState:
 
     cdef:
-        public size_t ptr
+        public intptr_t ptr
 
     cpdef add_ptr_data(self, unicode data, unicode name)
     cpdef bytes complete(self)

--- a/cupy/cuda/function.pyx
+++ b/cupy/cuda/function.pyx
@@ -8,6 +8,7 @@ from libc.stdint cimport int8_t
 from libc.stdint cimport int16_t
 from libc.stdint cimport int32_t
 from libc.stdint cimport int64_t
+from libc.stdint cimport intptr_t
 from libcpp cimport vector
 
 
@@ -114,7 +115,7 @@ cdef inline size_t _get_stream(stream) except *:
         return stream.ptr
 
 
-cdef _launch(size_t func, Py_ssize_t grid0, int grid1, int grid2,
+cdef _launch(intptr_t func, Py_ssize_t grid0, int grid1, int grid2,
              Py_ssize_t block0, int block1, int block2,
              args, Py_ssize_t shared_mem, size_t stream):
     cdef list pargs = []
@@ -129,7 +130,7 @@ cdef _launch(size_t func, Py_ssize_t grid0, int grid1, int grid2,
     runtime._ensure_context()
     driver.launchKernel(
         func, <int>grid0, grid1, grid2, <int>block0, block1, block2,
-        <int>shared_mem, stream, <size_t>&(kargs[0]), <size_t>0)
+        <int>shared_mem, stream, <intptr_t>&(kargs[0]), <intptr_t>0)
 
 
 cdef class Function:

--- a/cupy/cuda/memory.pxd
+++ b/cupy/cuda/memory.pxd
@@ -11,8 +11,8 @@ from cupy.cuda cimport device
 cdef class BaseMemory:
 
     cdef:
-        public size_t ptr
-        public Py_ssize_t size
+        public intptr_t ptr
+        public size_t size
         public int device_id
 
 
@@ -20,13 +20,13 @@ cdef class BaseMemory:
 cdef class MemoryPointer:
 
     cdef:
-        readonly size_t ptr
+        readonly intptr_t ptr
         readonly int device_id
         readonly BaseMemory mem
 
-    cdef _init(self, BaseMemory mem, Py_ssize_t offset)
+    cdef _init(self, BaseMemory mem, ptrdiff_t offset)
 
-    cpdef copy_from_device(self, MemoryPointer src, Py_ssize_t size)
+    cpdef copy_from_device(self, MemoryPointer src, size_t size)
     cpdef copy_from_device_async(self, MemoryPointer src, size_t size,
                                  stream=?)
     cpdef copy_from_host(self, mem, size_t size)
@@ -50,13 +50,13 @@ cdef class MemoryPool:
     cdef:
         object _pools
 
-    cpdef MemoryPointer malloc(self, Py_ssize_t size)
+    cpdef MemoryPointer malloc(self, size_t size)
     cpdef free_all_blocks(self, stream=?)
     cpdef free_all_free(self)
-    cpdef n_free_blocks(self)
-    cpdef used_bytes(self)
-    cpdef free_bytes(self)
-    cpdef total_bytes(self)
+    cpdef size_t n_free_blocks(self)
+    cpdef size_t used_bytes(self)
+    cpdef size_t free_bytes(self)
+    cpdef size_t total_bytes(self)
 
 
 @cython.no_gc
@@ -75,4 +75,4 @@ cdef class CFunctionAllocator:
         intptr_t _free_func
         object _owner
 
-    cpdef MemoryPointer malloc(self, Py_ssize_t size)
+    cpdef MemoryPointer malloc(self, size_t size)

--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -70,7 +70,7 @@ cdef class Memory(BaseMemory):
         size (int): Size of the memory allocation in bytes.
     """
 
-    def __init__(self, Py_ssize_t size):
+    def __init__(self, size_t size):
         self.size = size
         self.device_id = device.get_device_id()
         self.ptr = 0
@@ -97,7 +97,7 @@ cdef class UnownedMemory(BaseMemory):
     cdef:
         readonly object _owner
 
-    def __init__(self, size_t ptr, Py_ssize_t size, object owner,
+    def __init__(self, intptr_t ptr, size_t size, object owner,
                  int device_id=-1):
         cdef runtime.PointerAttributes ptr_attrs
         if device_id < 0:
@@ -121,7 +121,7 @@ cdef class ManagedMemory(BaseMemory):
 
     """
 
-    def __init__(self, Py_ssize_t size):
+    def __init__(self, size_t size):
         self.size = size
         self.device_id = device.get_device_id()
         self.ptr = 0
@@ -186,18 +186,18 @@ cdef class _Chunk:
 
     Attributes:
         mem (Memory): The device memory buffer.
-        ptr (size_t): Memory address.
+        ptr (int): Memory address.
         offset (int): An offset bytes from the head of the buffer.
         size (int): Chunk size in bytes.
         prev (Chunk): prev memory pointer if split from a larger allocation
         next (Chunk): next memory pointer if split from a larger allocation
-        stream_ptr (size_t): Raw stream handle of cupy.cuda.Stream
+        stream_ptr (int): Raw stream handle of cupy.cuda.Stream
     """
 
     cdef:
         readonly BaseMemory mem
-        readonly Py_ssize_t offset
-        readonly Py_ssize_t size
+        readonly ptrdiff_t offset
+        readonly size_t size
         readonly size_t stream_ptr
         public _Chunk prev
         public _Chunk next
@@ -207,18 +207,18 @@ cdef class _Chunk:
         mem, offset, size, stream_ptr = args
         self._init(mem, offset, size, stream_ptr)
 
-    cdef _init(self, BaseMemory mem, Py_ssize_t offset,
-               Py_ssize_t size, Py_ssize_t stream_ptr):
-        assert mem.ptr > 0 or offset == 0
+    cdef _init(self, BaseMemory mem, ptrdiff_t offset,
+               size_t size, Py_ssize_t stream_ptr):
+        assert mem.ptr != 0 or offset == 0
         self.mem = mem
         self.offset = offset
         self.size = size
         self.stream_ptr = stream_ptr
 
-    cpdef size_t ptr(self):
+    cpdef intptr_t ptr(self):
         return self.mem.ptr + self.offset
 
-    cpdef _Chunk split(self, Py_ssize_t size):
+    cpdef _Chunk split(self, size_t size):
         """Split contiguous block of a larger allocation"""
         cdef _Chunk remaining
         assert self.size >= size
@@ -260,14 +260,14 @@ cdef class MemoryPointer:
         ~MemoryPointer.device (~cupy.cuda.Device): Device whose memory the
             pointer refers to.
         ~MemoryPointer.mem (~cupy.cuda.BaseMemory): The device memory buffer.
-        ~MemoryPointer.ptr (size_t): Pointer to the place within the buffer.
+        ~MemoryPointer.ptr (int): Pointer to the place within the buffer.
     """
 
-    def __init__(self, BaseMemory mem, Py_ssize_t offset):
+    def __init__(self, BaseMemory mem, ptrdiff_t offset):
         self._init(mem, offset)
 
-    cdef _init(self, BaseMemory mem, Py_ssize_t offset):
-        assert mem.ptr > 0 or offset == 0
+    cdef _init(self, BaseMemory mem, ptrdiff_t offset):
+        assert mem.ptr != 0 or offset == 0
         self.ptr = mem.ptr + offset
         self.device_id = mem.device_id
         self.mem = mem
@@ -283,20 +283,20 @@ cdef class MemoryPointer:
     def __add__(x, y):
         """Adds an offset to the pointer."""
         cdef MemoryPointer self
-        cdef Py_ssize_t offset
+        cdef ptrdiff_t offset
         if isinstance(x, MemoryPointer):
             self = x
-            offset = <Py_ssize_t?>y
+            offset = <ptrdiff_t?>y
         else:
             self = <MemoryPointer?>y
-            offset = <Py_ssize_t?>x
+            offset = <ptrdiff_t?>x
         assert self.ptr > 0 or offset == 0
         return MemoryPointer(self.mem,
                              self.ptr - self.mem.ptr + offset)
 
-    def __iadd__(self, Py_ssize_t offset):
+    def __iadd__(self, ptrdiff_t offset):
         """Adds an offset to the pointer in place."""
-        assert self.ptr > 0 or offset == 0
+        assert self.ptr != 0 or offset == 0
         self.ptr += offset
         return self
 
@@ -304,11 +304,11 @@ cdef class MemoryPointer:
         """Subtracts an offset from the pointer."""
         return self + -offset
 
-    def __isub__(self, Py_ssize_t offset):
+    def __isub__(self, ptrdiff_t offset):
         """Subtracts an offset from the pointer in place."""
         return self.__iadd__(-offset)
 
-    cpdef copy_from_device(self, MemoryPointer src, Py_ssize_t size):
+    cpdef copy_from_device(self, MemoryPointer src, size_t size):
         """Copies a memory sequence from a (possibly different) device.
 
         Args:
@@ -470,12 +470,12 @@ cdef class MemoryPointer:
             runtime.memsetAsync(self.ptr, value, size, stream_ptr)
 
 
-cpdef MemoryPointer _malloc(Py_ssize_t size):
+cpdef MemoryPointer _malloc(size_t size):
     mem = Memory(size)
     return MemoryPointer(mem, 0)
 
 
-cpdef MemoryPointer malloc_managed(Py_ssize_t size):
+cpdef MemoryPointer malloc_managed(size_t size):
     """Allocate managed memory (unified memory).
 
     This method can be used as a CuPy memory allocator. The simplest way to
@@ -562,7 +562,7 @@ cdef class PooledMemory(BaseMemory):
         buffer to the memory pool for reuse.
 
         """
-        cdef size_t ptr
+        cdef intptr_t ptr
         ptr = self.ptr
         if ptr == 0:
             return
@@ -609,8 +609,8 @@ cdef _compact_index(SingleDeviceMemoryPool pool, size_t stream_ptr, bint free):
     # need self._free_lock
     cdef list arena, new_arena
     cdef set free_list, keep_list
-    cdef vector.vector[int]* arena_index
-    cdef vector.vector[int] new_index
+    cdef vector.vector[size_t]* arena_index
+    cdef vector.vector[size_t] new_index
     cdef size_t index
 
     if stream_ptr not in pool._free:
@@ -642,18 +642,19 @@ cdef _compact_index(SingleDeviceMemoryPool pool, size_t stream_ptr, bint free):
         pool._arena_flag(stream_ptr).assign(new_index.size(), <int8_t>1)
 
 
-cdef object _get_chunk(SingleDeviceMemoryPool pool, Py_ssize_t size,
+cdef object _get_chunk(SingleDeviceMemoryPool pool, size_t size,
                        size_t stream_ptr):
     # need self._free_lock
     cdef set free_list
-    cdef int i, index, length
+    cdef size_t i, index, length
     cdef _Chunk chunk
-    cdef int bin_index = _bin_index_from_size(size)
+    cdef size_t bin_index = _bin_index_from_size(size)
     cdef list arena = pool._arena(stream_ptr)
     a_index = pool._arena_index(stream_ptr)
     a_flag = pool._arena_flag(stream_ptr)
-    index = algorithm.lower_bound(
-        a_index.begin(), a_index.end(), bin_index) - a_index.begin()
+    index = <size_t>(
+        algorithm.lower_bound(a_index.begin(), a_index.end(), bin_index)
+        - a_index.begin())
     length = a_index.size()
     for i in range(index, length):
         if a_flag.at(i) == 0:
@@ -673,7 +674,7 @@ cdef object _get_chunk(SingleDeviceMemoryPool pool, Py_ssize_t size,
     return None
 
 
-cdef BaseMemory _try_malloc(SingleDeviceMemoryPool pool, Py_ssize_t size):
+cdef BaseMemory _try_malloc(SingleDeviceMemoryPool pool, size_t size):
     try:
         return pool._alloc(size).mem
     except runtime.CUDARuntimeError as e:
@@ -695,15 +696,16 @@ cdef BaseMemory _try_malloc(SingleDeviceMemoryPool pool, Py_ssize_t size):
     raise OutOfMemoryError(size, total)
 
 
-cdef _append_to_free_list(list arena, vector.vector[int]* a_index,
+cdef _append_to_free_list(list arena, vector.vector[size_t]* a_index,
                           vector.vector[int8_t]* a_flag, _Chunk chunk):
     # need self._free_lock
-    cdef int index, bin_index
+    cdef size_t index, bin_index
     cdef set free_list
     bin_index = _bin_index_from_size(chunk.size)
-    index = algorithm.lower_bound(
-        a_index.begin(), a_index.end(), bin_index) - a_index.begin()
-    if index < <int>a_index.size() and a_index.at(index) == bin_index:
+    index = <size_t>(
+        algorithm.lower_bound(a_index.begin(), a_index.end(), bin_index)
+        - a_index.begin())
+    if index < a_index.size() and a_index.at(index) == bin_index:
         free_list = arena[index]
         if free_list is None:
             arena[index] = free_list = set()
@@ -716,7 +718,7 @@ cdef _append_to_free_list(list arena, vector.vector[int]* a_index,
     dereference(a_flag)[index] = 1
 
 
-cdef bint _remove_from_free_list(list arena, vector.vector[int]* a_index,
+cdef bint _remove_from_free_list(list arena, vector.vector[size_t]* a_index,
                                  vector.vector[int8_t]* a_flag,
                                  _Chunk chunk) except *:
     """Removes the chunk from the free list (need self._free_lock).
@@ -727,14 +729,15 @@ cdef bint _remove_from_free_list(list arena, vector.vector[int]* a_index,
             be found in the free list as the chunk is allocated.)
     """
 
-    cdef int index, bin_index
+    cdef size_t index, bin_index
     cdef set free_list
 
     bin_index = _bin_index_from_size(chunk.size)
     if a_index.size() == 0:
         return False
-    index = algorithm.lower_bound(
-        a_index.begin(), a_index.end(), bin_index) - a_index.begin()
+    index = <size_t>(
+        algorithm.lower_bound(a_index.begin(), a_index.end(), bin_index)
+        - a_index.begin())
     if index == a_index.size():
         # Bin does not exist for the given chunk size.
         return False
@@ -757,13 +760,13 @@ DEF ALLOCATION_UNIT_SIZE = 512
 _allocation_unit_size = ALLOCATION_UNIT_SIZE
 
 
-cpdef Py_ssize_t _round_size(Py_ssize_t size):
+cpdef size_t _round_size(size_t size):
     """Rounds up the memory size to fit memory alignment of cudaMalloc."""
     # avoid 0 div checking
     size = (size + ALLOCATION_UNIT_SIZE - 1) // ALLOCATION_UNIT_SIZE
     return size * ALLOCATION_UNIT_SIZE
 
-cpdef int _bin_index_from_size(Py_ssize_t size):
+cpdef size_t _bin_index_from_size(size_t size):
     """Returns appropriate bins index from the memory size."""
     # avoid 0 div checking
     return (size - 1) // ALLOCATION_UNIT_SIZE
@@ -802,7 +805,7 @@ cdef class SingleDeviceMemoryPool:
 
         # Map from stream pointer to its arena index.
         # `_free_lock` must be acquired to access.
-        map.map[size_t, vector.vector[int]] _index
+        map.map[size_t, vector.vector[size_t]] _index
         map.map[size_t, vector.vector[int8_t]] _flag
 
     def __init__(self, allocator=_malloc):
@@ -826,7 +829,7 @@ cdef class SingleDeviceMemoryPool:
             self._free[stream_ptr] = ret = []
         return ret
 
-    cdef inline vector.vector[int]* _arena_index(self, size_t stream_ptr):
+    cdef inline vector.vector[size_t]* _arena_index(self, size_t stream_ptr):
         """Returns appropriate arena sparse index of a given stream.
 
         Each element of the returned vector is an index value of the arena
@@ -868,7 +871,7 @@ cdef class SingleDeviceMemoryPool:
                 return memptr
         return self._allocator(rounded_size)
 
-    cpdef MemoryPointer malloc(self, Py_ssize_t size):
+    cpdef MemoryPointer malloc(self, size_t size):
         rounded_size = _round_size(size)
         if memory_hook._has_memory_hooks():
             hooks = memory_hook.get_memory_hooks()
@@ -899,7 +902,7 @@ cdef class SingleDeviceMemoryPool:
                 return memptr
         return self._malloc(rounded_size)
 
-    cpdef MemoryPointer _malloc(self, Py_ssize_t size):
+    cpdef MemoryPointer _malloc(self, size_t size):
         cdef _Chunk chunk
         cdef long current_thread
         cdef BaseMemory mem
@@ -931,7 +934,7 @@ cdef class SingleDeviceMemoryPool:
         pmem = PooledMemory(chunk, self._weakref)
         return MemoryPointer(pmem, 0)
 
-    cpdef free(self, size_t ptr, Py_ssize_t size):
+    cpdef free(self, intptr_t ptr, size_t size):
         cdef _Chunk chunk, c
         cdef long current_thread = pythread.PyThread_get_thread_ident()
 
@@ -986,8 +989,8 @@ cdef class SingleDeviceMemoryPool:
             DeprecationWarning)
         self.free_all_blocks()
 
-    cpdef n_free_blocks(self):
-        cdef Py_ssize_t n = 0
+    cpdef size_t n_free_blocks(self):
+        cdef size_t n = 0
         cdef set free_list
         rlock.lock_fastrlock(self._free_lock, -1, True)
         try:
@@ -999,8 +1002,8 @@ cdef class SingleDeviceMemoryPool:
             rlock.unlock_fastrlock(self._free_lock)
         return n
 
-    cpdef used_bytes(self):
-        cdef Py_ssize_t size = 0
+    cpdef size_t used_bytes(self):
+        cdef size_t size = 0
         cdef _Chunk chunk
         rlock.lock_fastrlock(self._in_use_lock, -1, True)
         try:
@@ -1010,8 +1013,8 @@ cdef class SingleDeviceMemoryPool:
             rlock.unlock_fastrlock(self._in_use_lock)
         return size
 
-    cpdef free_bytes(self):
-        cdef Py_ssize_t size = 0
+    cpdef size_t free_bytes(self):
+        cdef size_t size = 0
         cdef set free_list
         cdef _Chunk chunk
         rlock.lock_fastrlock(self._free_lock, -1, True)
@@ -1026,7 +1029,7 @@ cdef class SingleDeviceMemoryPool:
             rlock.unlock_fastrlock(self._free_lock)
         return size
 
-    cpdef total_bytes(self):
+    cpdef size_t total_bytes(self):
         return self.used_bytes() + self.free_bytes()
 
 
@@ -1062,7 +1065,7 @@ cdef class MemoryPool(object):
         self._pools = collections.defaultdict(
             lambda: SingleDeviceMemoryPool(allocator))
 
-    cpdef MemoryPointer malloc(self, Py_ssize_t size):
+    cpdef MemoryPointer malloc(self, size_t size):
         """Allocates the memory, from the pool if possible.
 
         This method can be used as a CuPy memory allocator. The simplest way to
@@ -1103,7 +1106,7 @@ cdef class MemoryPool(object):
             DeprecationWarning)
         self.free_all_blocks()
 
-    cpdef n_free_blocks(self):
+    cpdef size_t n_free_blocks(self):
         """Count the total number of free blocks.
 
         Returns:
@@ -1112,7 +1115,7 @@ cdef class MemoryPool(object):
         mp = <SingleDeviceMemoryPool>self._pools[device.get_device_id()]
         return mp.n_free_blocks()
 
-    cpdef used_bytes(self):
+    cpdef size_t used_bytes(self):
         """Get the total number of bytes used.
 
         Returns:
@@ -1121,7 +1124,7 @@ cdef class MemoryPool(object):
         mp = <SingleDeviceMemoryPool>self._pools[device.get_device_id()]
         return mp.used_bytes()
 
-    cpdef free_bytes(self):
+    cpdef size_t free_bytes(self):
         """Get the total number of bytes acquired but not used in the pool.
 
         Returns:
@@ -1130,7 +1133,7 @@ cdef class MemoryPool(object):
         mp = <SingleDeviceMemoryPool>self._pools[device.get_device_id()]
         return mp.free_bytes()
 
-    cpdef total_bytes(self):
+    cpdef size_t total_bytes(self):
         """Get the total number of bytes acquired in the pool.
 
         Returns:
@@ -1158,7 +1161,7 @@ cpdef void _call_free(intptr_t param, intptr_t free_func, intptr_t ptr,
 @cython.no_gc
 cdef class CFunctionAllocatorMemory(BaseMemory):
 
-    def __init__(self, Py_ssize_t size, intptr_t param,
+    def __init__(self, size_t size, intptr_t param,
                  intptr_t malloc_func, intptr_t free_func,
                  int device_id):
         self._param = param
@@ -1209,7 +1212,7 @@ cdef class CFunctionAllocator:
         self._free_func = free_func
         self._owner = owner
 
-    cpdef MemoryPointer malloc(self, Py_ssize_t size):
+    cpdef MemoryPointer malloc(self, size_t size):
         mem = CFunctionAllocatorMemory(size, self._param, self._malloc_func,
                                        self._free_func, device.get_device_id())
         return MemoryPointer(mem, 0)

--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -290,7 +290,7 @@ cdef class MemoryPointer:
         else:
             self = <MemoryPointer?>y
             offset = <ptrdiff_t?>x
-        assert self.ptr > 0 or offset == 0
+         assert self.ptr != 0 or offset == 0
         return MemoryPointer(self.mem,
                              self.ptr - self.mem.ptr + offset)
 

--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -290,7 +290,7 @@ cdef class MemoryPointer:
         else:
             self = <MemoryPointer?>y
             offset = <ptrdiff_t?>x
-         assert self.ptr != 0 or offset == 0
+        assert self.ptr != 0 or offset == 0
         return MemoryPointer(self.mem,
                              self.ptr - self.mem.ptr + offset)
 

--- a/cupy/cuda/pinned_memory.pxd
+++ b/cupy/cuda/pinned_memory.pxd
@@ -1,19 +1,21 @@
+from libc.stdint cimport intptr_t
+
 
 cdef class PinnedMemoryPointer:
 
     cdef:
         readonly object mem
-        readonly size_t ptr
+        readonly intptr_t ptr
         Py_ssize_t _shape[1]
         Py_ssize_t _strides[1]
 
-    cpdef Py_ssize_t size(self)
+    cpdef size_t size(self)
 
 
 cpdef _add_to_watch_list(event, obj)
 
 
-cpdef PinnedMemoryPointer alloc_pinned_memory(Py_ssize_t size)
+cpdef PinnedMemoryPointer alloc_pinned_memory(size_t size)
 
 
 cpdef set_pinned_memory_allocator(allocator=*)
@@ -28,9 +30,9 @@ cdef class PinnedMemoryPool:
         object __weakref__
         object _weakref
         object _lock
-        Py_ssize_t _allocation_unit_size
+        size_t _allocation_unit_size
 
-    cpdef PinnedMemoryPointer malloc(self, Py_ssize_t size)
-    cpdef free(self, size_t ptr, Py_ssize_t size)
+    cpdef PinnedMemoryPointer malloc(self, size_t size)
+    cpdef free(self, intptr_t ptr, size_t size)
     cpdef free_all_blocks(self)
     cpdef n_free_blocks(self)

--- a/cupy/cuda/runtime.pxd
+++ b/cupy/cuda/runtime.pxd
@@ -1,3 +1,6 @@
+from libc.stdint cimport intptr_t
+
+
 ###############################################################################
 # Types
 ###############################################################################
@@ -202,26 +205,26 @@ cpdef deviceEnablePeerAccess(int peerDevice)
 # Memory management
 ###############################################################################
 
-cpdef size_t malloc(size_t size) except? 0
-cpdef size_t mallocManaged(size_t size, unsigned int flags=*) except? 0
-cpdef size_t hostAlloc(size_t size, unsigned int flags) except? 0
-cpdef free(size_t ptr)
-cpdef freeHost(size_t ptr)
+cpdef intptr_t malloc(size_t size) except? 0
+cpdef intptr_t mallocManaged(size_t size, unsigned int flags=*) except? 0
+cpdef intptr_t hostAlloc(size_t size, unsigned int flags) except? 0
+cpdef free(intptr_t ptr)
+cpdef freeHost(intptr_t ptr)
 cpdef memGetInfo()
-cpdef memcpy(size_t dst, size_t src, size_t size, int kind)
-cpdef memcpyAsync(size_t dst, size_t src, size_t size, int kind,
+cpdef memcpy(intptr_t dst, intptr_t src, size_t size, int kind)
+cpdef memcpyAsync(intptr_t dst, intptr_t src, size_t size, int kind,
                   size_t stream)
-cpdef memcpyPeer(size_t dst, int dstDevice, size_t src, int srcDevice,
+cpdef memcpyPeer(intptr_t dst, int dstDevice, intptr_t src, int srcDevice,
                  size_t size)
-cpdef memcpyPeerAsync(size_t dst, int dstDevice,
-                      size_t src, int srcDevice,
+cpdef memcpyPeerAsync(intptr_t dst, int dstDevice,
+                      intptr_t src, int srcDevice,
                       size_t size, size_t stream)
-cpdef memset(size_t ptr, int value, size_t size)
-cpdef memsetAsync(size_t ptr, int value, size_t size, size_t stream)
-cpdef memPrefetchAsync(size_t devPtr, size_t count, int dstDevice,
+cpdef memset(intptr_t ptr, int value, size_t size)
+cpdef memsetAsync(intptr_t ptr, int value, size_t size, size_t stream)
+cpdef memPrefetchAsync(intptr_t devPtr, size_t count, int dstDevice,
                        size_t stream)
-cpdef memAdvise(size_t devPtr, int count, int advice, int device)
-cpdef PointerAttributes pointerGetAttributes(size_t ptr)
+cpdef memAdvise(intptr_t devPtr, size_t count, int advice, int device)
+cpdef PointerAttributes pointerGetAttributes(intptr_t ptr)
 
 
 ###############################################################################
@@ -232,7 +235,7 @@ cpdef size_t streamCreate() except? 0
 cpdef size_t streamCreateWithFlags(unsigned int flags) except? 0
 cpdef streamDestroy(size_t stream)
 cpdef streamSynchronize(size_t stream)
-cpdef streamAddCallback(size_t stream, callback, size_t arg,
+cpdef streamAddCallback(size_t stream, callback, intptr_t arg,
                         unsigned int flags=*)
 cpdef streamQuery(size_t stream)
 cpdef streamWaitEvent(size_t stream, size_t event, unsigned int flags=*)


### PR DESCRIPTION
Fixes #1913

The added benefit is that Cython now checks negative size for malloc:
```
>>> a = cupy.cuda.memory.alloc(-1)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "cupy/cuda/memory.pyx", line 506, in cupy.cuda.memory.alloc
    cpdef MemoryPointer alloc(size):
  File "cupy/cuda/memory.pyx", line 518, in cupy.cuda.memory.alloc
    return _current_allocator(size)
  File "cupy/cuda/memory.pyx", line 1068, in cupy.cuda.memory.MemoryPool.malloc
    cpdef MemoryPointer malloc(self, size_t size):
OverflowError: can't convert negative value to size_t
```