### PR TITLE
Ignore W503 and W504

### DIFF
--- a/.flake8.cython
+++ b/.flake8.cython
@@ -1,4 +1,4 @@
 [flake8]
 filename = *.pyx,*.px*
 exclude = .eggs,*.egg,build,docs,.git
-ignore = E225,E226,E227,E999
+ignore = W503,W504,E225,E226,E227,E999


### PR DESCRIPTION
We do not enforce either, so let's ignore them.

* Line break occurred before a binary operator (W503)
* Line break occurred after a binary operator (W504)

https://lintlyci.github.io/Flake8Rules/rules/W503.html
https://lintlyci.github.io/Flake8Rules/rules/W504.html