### PR TITLE
Fix performance of async D2H copy

### DIFF
--- a/cupy/core/core.pxd
+++ b/cupy/core/core.pxd
@@ -65,7 +65,7 @@ cdef class ndarray:
     cpdef ndarray all(self, axis=*, out=*, keepdims=*)
     cpdef ndarray any(self, axis=*, out=*, keepdims=*)
     cpdef ndarray conj(self)
-    cpdef get(self, stream=*, order=*, arr=*)
+    cpdef get(self, stream=*, order=*, out=*)
     cpdef set(self, arr, stream=*)
     cpdef ndarray reduced_view(self, dtype=*)
     cpdef _update_c_contiguity(self)

--- a/cupy/core/core.pxd
+++ b/cupy/core/core.pxd
@@ -65,7 +65,7 @@ cdef class ndarray:
     cpdef ndarray all(self, axis=*, out=*, keepdims=*)
     cpdef ndarray any(self, axis=*, out=*, keepdims=*)
     cpdef ndarray conj(self)
-    cpdef get(self, stream=*, order=*)
+    cpdef get(self, stream=*, order=*, arr=*)
     cpdef set(self, arr, stream=*)
     cpdef ndarray reduced_view(self, dtype=*)
     cpdef _update_c_contiguity(self)

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1650,7 +1650,7 @@ cdef class ndarray:
                 raise TypeError('Only numpy.ndarray can be obtained from'
                                 'cupy.ndarray')
             if self.dtype != arr.dtype:
-                raise TypeError('{} array cannot be got from {} array'.format(
+                raise TypeError('{} array cannot be obtained from {} array'.format(
                     arr.dtype, self.dtype))
             if self.shape != arr.shape:
                 raise ValueError(

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1657,9 +1657,11 @@ cdef class ndarray:
                     'Shape mismatch. Expected shape: {}, actual shape: {}'.format(
                         self.shape, out.shape))
             if self._c_contiguous:
-                out = numpy.ascontiguousarray(out)
+                if not out.flags.c_contiguous:
+                    raise RuntimeError('`out` is not c contiguous array')
             elif self._f_contiguous:
-                out = numpy.asfortranarray(out)
+                if not out.flags.f_contiguous:
+                    raise RuntimeError('`out` is not f contiguous array')
             else:
                 raise RuntimeError('Cannot set to non-contiguous array')
 

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1654,7 +1654,7 @@ cdef class ndarray:
                     arr.dtype, self.dtype))
             if self.shape != arr.shape:
                 raise ValueError(
-                    'Shape mismatch. Old shape: {}, new shape: {}'.format(
+                    'Shape mismatch. Expected shape: {}, actual shape: {}'.format(
                         self.shape, arr.shape))
             if self._c_contiguous:
                 arr = numpy.ascontiguousarray(arr)

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1612,7 +1612,7 @@ cdef class ndarray:
         """CUDA device on which this array resides."""
         return self.data.device
 
-    cpdef get(self, stream=None, order='C', arr=None):
+    cpdef get(self, stream=None, order='C', out=None):
         """Returns a copy of the array on host memory.
 
         Args:
@@ -1645,25 +1645,25 @@ cdef class ndarray:
             else:
                 raise ValueError("unsupported order: {}".format(order))
 
-        if arr is not None:
-            if not isinstance(arr, numpy.ndarray):
+        if out is not None:
+            if not isinstance(out, numpy.ndarray):
                 raise TypeError('Only numpy.ndarray can be obtained from'
                                 'cupy.ndarray')
-            if self.dtype != arr.dtype:
+            if self.dtype != out.dtype:
                 raise TypeError('{} array cannot be obtained from {} array'.format(
-                    arr.dtype, self.dtype))
-            if self.shape != arr.shape:
+                    out.dtype, self.dtype))
+            if self.shape != out.shape:
                 raise ValueError(
                     'Shape mismatch. Expected shape: {}, actual shape: {}'.format(
-                        self.shape, arr.shape))
+                        self.shape, out.shape))
             if self._c_contiguous:
-                arr = numpy.ascontiguousarray(arr)
+                out = numpy.ascontiguousarray(out)
             elif self._f_contiguous:
-                arr = numpy.asfortranarray(arr)
+                out = numpy.asfortranarray(out)
             else:
                 raise RuntimeError('Cannot set to non-contiguous array')
 
-            a_cpu = arr
+            a_cpu = out
         else:
             a_cpu = numpy.empty(self._shape, dtype=self.dtype, order=order)
         ptr = a_cpu.ctypes.get_as_parameter()

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1623,7 +1623,7 @@ cdef class ndarray:
                 array. When ``order`` is 'A', it uses 'F' if the array is
                 fortran-contiguous and 'C' otherwise. The ``order`` will be 
                 ignored if ``out`` is specified.
-            out Output array. it should be a pinned memory to enable
+            out Output array. It should be a pinned memory to enable
                 asynchronous copy
 
         Returns:

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1647,7 +1647,7 @@ cdef class ndarray:
 
         if arr is not None:
             if not isinstance(arr, numpy.ndarray):
-                raise TypeError('Only numpy.ndarray can be got from'
+                raise TypeError('Only numpy.ndarray can be obtained from'
                                 'cupy.ndarray')
             if self.dtype != arr.dtype:
                 raise TypeError('{} array cannot be got from {} array'.format(


### PR DESCRIPTION
In `cupy.core.ndarray.get`, it internally creates a page-able buffer as destination
which causes asynchronous copy from device to host has lower bandwidth and
overlapping of GPU kernel execution and data transfer is impossible.

In order to solve this issue, add new argument as destination to `get` API.
User must allocate a pinned buffer as destination first to get speedup.
Otherwise, CuPy will go back to original behavior.

Regarding issues are #1937 and #1938