### PR TITLE
Allow passing `None` as parameters of `Fusion.__call__`

### DIFF
--- a/tests/cupy_tests/core_tests/test_fusion.py
+++ b/tests/cupy_tests/core_tests/test_fusion.py
@@ -1537,6 +1537,25 @@ class TestFusionScalar(unittest.TestCase):
 
 
 @testing.gpu
+class TestFusionNone(unittest.TestCase):
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_python_none_parameter(self, xp, dtype):
+
+        @cupy.fuse()
+        def f(x, y, z):
+            if y is None:
+                return x * z
+            return x + y + z
+
+        x = testing.shaped_arange((10,), xp, dtype)
+        y = testing.shaped_arange((10,), xp, dtype)
+        z = testing.shaped_arange((10,), xp, dtype)
+        return f(x, None, z) + f(x, y, z)
+
+
+@testing.gpu
 class TestFusionReturnsConstantValue(unittest.TestCase):
 
     @testing.for_all_dtypes()


### PR DESCRIPTION
```
>>> import cupy
>>>
>>> @cupy.fuse()
... def f(x, y):
...     if y is None:
...         x[:] = -x
...     else:
...         x += y
...
>>> x = cupy.array([1, 2, 3])
>>> x
array([1, 2, 3])
>>> f(x, 1)
>>> x
array([2, 3, 4])
>>> f(x, None)
>>> x
array([-2, -3, -4])
```