### PR TITLE
Fix `cupy.random.randint` fail with size zero

### DIFF
--- a/cupy/random/generator.py
+++ b/cupy/random/generator.py
@@ -556,6 +556,8 @@ class RandomState(object):
         """  # NOQA
         if size is None:
             return self._interval(mx, 1).reshape(())
+        elif size == 0:
+            return cupy.array(())
         elif isinstance(size, int):
             size = (size, )
 

--- a/tests/cupy_tests/random_tests/test_generator.py
+++ b/tests/cupy_tests/random_tests/test_generator.py
@@ -1190,6 +1190,9 @@ class TestRandint(RandomGeneratorTestCase):
     def test_randint_2(self):
         self.generate(3, 4, size=(3, 2))
 
+    def test_randint_3(self):
+        self.generate(3, 10, size=0)
+
 
 @testing.gpu
 @testing.fix_random()


### PR DESCRIPTION
This fixes the following error:

```py
>>> cupy.random.randint(3, 10, size=0)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/kenichi/Development/cupy/cupy/random/sample.py", line 112, in randint
    return rs.randint(low, high, size, dtype)
  File "/home/kenichi/Development/cupy/cupy/random/generator.py", line 1030, in randint
    x = self._interval(diff, size).astype(dtype, copy=False)
  File "/home/kenichi/Development/cupy/cupy/random/generator.py", line 607, in _interval
    return ret.reshape(size)
AttributeError: 'NoneType' object has no attribute 'reshape'
```