### PR TITLE
Add `out` argument to `ndarray.get` for asynchronous device-to-host copy

### DIFF
--- a/cupy/core/core.pxd
+++ b/cupy/core/core.pxd
@@ -65,7 +65,7 @@ cdef class ndarray:
     cpdef ndarray all(self, axis=*, out=*, keepdims=*)
     cpdef ndarray any(self, axis=*, out=*, keepdims=*)
     cpdef ndarray conj(self)
-    cpdef get(self, stream=*, order=*, arr=*)
+    cpdef get(self, stream=*, order=*, out=*)
     cpdef set(self, arr, stream=*)
     cpdef ndarray reduced_view(self, dtype=*)
     cpdef _update_c_contiguity(self)

--- a/cupy/core/core.pxd
+++ b/cupy/core/core.pxd
@@ -65,7 +65,7 @@ cdef class ndarray:
     cpdef ndarray all(self, axis=*, out=*, keepdims=*)
     cpdef ndarray any(self, axis=*, out=*, keepdims=*)
     cpdef ndarray conj(self)
-    cpdef get(self, stream=*, order=*)
+    cpdef get(self, stream=*, order=*, arr=*)
     cpdef set(self, arr, stream=*)
     cpdef ndarray reduced_view(self, dtype=*)
     cpdef _update_c_contiguity(self)

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1650,7 +1650,7 @@ cdef class ndarray:
                 raise TypeError('Only numpy.ndarray can be obtained from'
                                 'cupy.ndarray')
             if self.dtype != arr.dtype:
-                raise TypeError('{} array cannot be got from {} array'.format(
+                raise TypeError('{} array cannot be obtained from {} array'.format(
                     arr.dtype, self.dtype))
             if self.shape != arr.shape:
                 raise ValueError(

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1657,9 +1657,11 @@ cdef class ndarray:
                     'Shape mismatch. Expected shape: {}, actual shape: {}'.format(
                         self.shape, out.shape))
             if self._c_contiguous:
-                out = numpy.ascontiguousarray(out)
+                if not out.flags.c_contiguous:
+                    raise RuntimeError('`out` is not c contiguous array')
             elif self._f_contiguous:
-                out = numpy.asfortranarray(out)
+                if not out.flags.f_contiguous:
+                    raise RuntimeError('`out` is not f contiguous array')
             else:
                 raise RuntimeError('Cannot set to non-contiguous array')
 

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1654,7 +1654,7 @@ cdef class ndarray:
                     arr.dtype, self.dtype))
             if self.shape != arr.shape:
                 raise ValueError(
-                    'Shape mismatch. Old shape: {}, new shape: {}'.format(
+                    'Shape mismatch. Expected shape: {}, actual shape: {}'.format(
                         self.shape, arr.shape))
             if self._c_contiguous:
                 arr = numpy.ascontiguousarray(arr)

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1612,7 +1612,7 @@ cdef class ndarray:
         """CUDA device on which this array resides."""
         return self.data.device
 
-    cpdef get(self, stream=None, order='C', arr=None):
+    cpdef get(self, stream=None, order='C', out=None):
         """Returns a copy of the array on host memory.
 
         Args:
@@ -1645,25 +1645,25 @@ cdef class ndarray:
             else:
                 raise ValueError("unsupported order: {}".format(order))
 
-        if arr is not None:
-            if not isinstance(arr, numpy.ndarray):
+        if out is not None:
+            if not isinstance(out, numpy.ndarray):
                 raise TypeError('Only numpy.ndarray can be obtained from'
                                 'cupy.ndarray')
-            if self.dtype != arr.dtype:
+            if self.dtype != out.dtype:
                 raise TypeError('{} array cannot be obtained from {} array'.format(
-                    arr.dtype, self.dtype))
-            if self.shape != arr.shape:
+                    out.dtype, self.dtype))
+            if self.shape != out.shape:
                 raise ValueError(
                     'Shape mismatch. Expected shape: {}, actual shape: {}'.format(
-                        self.shape, arr.shape))
+                        self.shape, out.shape))
             if self._c_contiguous:
-                arr = numpy.ascontiguousarray(arr)
+                out = numpy.ascontiguousarray(out)
             elif self._f_contiguous:
-                arr = numpy.asfortranarray(arr)
+                out = numpy.asfortranarray(out)
             else:
                 raise RuntimeError('Cannot set to non-contiguous array')
 
-            a_cpu = arr
+            a_cpu = out
         else:
             a_cpu = numpy.empty(self._shape, dtype=self.dtype, order=order)
         ptr = a_cpu.ctypes.get_as_parameter()

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1623,8 +1623,8 @@ cdef class ndarray:
                 array. When ``order`` is 'A', it uses 'F' if the array is
                 fortran-contiguous and 'C' otherwise. The ``order`` will be
                 ignored if ``out`` is specified.
-            out Output array. It should be a pinned memory to enable
-                asynchronous copy
+            out (numpy.ndarray): Output array. In order to enable asynchronous
+                copy, the underlying memory should be a pinned memory.
 
         Returns:
             numpy.ndarray: Copy of the array on host memory.

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1623,7 +1623,7 @@ cdef class ndarray:
                 array. When ``order`` is 'A', it uses 'F' if the array is
                 fortran-contiguous and 'C' otherwise. The ``order`` will be 
                 ignored if ``out`` is specified.
-            out Output array. it should be a pinned memory to enable
+            out Output array. It should be a pinned memory to enable
                 asynchronous copy
 
         Returns:

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1647,7 +1647,7 @@ cdef class ndarray:
 
         if arr is not None:
             if not isinstance(arr, numpy.ndarray):
-                raise TypeError('Only numpy.ndarray can be got from'
+                raise TypeError('Only numpy.ndarray can be obtained from'
                                 'cupy.ndarray')
             if self.dtype != arr.dtype:
                 raise TypeError('{} array cannot be got from {} array'.format(

--- a/tests/cupy_tests/core_tests/test_ndarray_get.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_get.py
@@ -64,3 +64,81 @@ class TestArrayGet(unittest.TestCase):
             dst = src.get()
         expected = testing.shaped_arange((2, 3), numpy, dtype, order)
         np_testing.assert_array_equal(dst, expected)
+
+
+@testing.gpu
+class TestArrayGetWithOut(unittest.TestCase):
+
+    def setUp(self):
+        self.stream = cuda.Stream.null
+
+    def check_get(self, f, out, stream):
+        a_gpu = f(cupy)
+        a_cpu = a_gpu.get(stream, out=out)
+        if stream:
+            stream.synchronize()
+        b_cpu = f(numpy)
+        assert a_cpu is out
+        np_testing.assert_array_equal(a_cpu, b_cpu)
+
+    @testing.for_orders('CF')
+    @testing.for_all_dtypes()
+    def test_contiguous_array(self, dtype, order):
+        def contiguous_array(xp):
+            return testing.shaped_arange((3,), xp, dtype, order)
+        out = numpy.empty((3,), dtype, order)
+        self.check_get(contiguous_array, out, None)
+
+    @testing.for_orders('CF')
+    @testing.for_all_dtypes()
+    def test_contiguous_array_cross(self, dtype, order):
+        def contiguous_array(xp):
+            return testing.shaped_arange((3,), xp, dtype, order)
+        out_order = 'C' if order == 'F' else 'F'
+        out = numpy.empty((3,), dtype, out_order)
+        self.check_get(contiguous_array, out, None)
+
+    @testing.for_orders('CF')
+    @testing.for_all_dtypes()
+    def test_contiguous_array_with_error(self, dtype, order):
+        out = numpy.empty((3, 3), dtype)[0:2, 0:2]
+        with self.assertRaises(RuntimeError):
+            a_gpu = testing.shaped_arange((3, 3), cupy, dtype, order)[0:2, 0:2]
+            a_gpu.get(out=out)
+
+    @testing.for_orders('CF')
+    @testing.for_all_dtypes()
+    def test_non_contiguous_array(self, dtype, order):
+        def non_contiguous_array(xp):
+            return testing.shaped_arange((3, 3), xp, dtype, order)[0::2, 0::2]
+        out = numpy.empty((2, 2), dtype, order)
+        self.check_get(non_contiguous_array, out, None)
+
+    @testing.for_orders('CF')
+    @testing.for_all_dtypes()
+    def test_contiguous_array_stream(self, dtype, order):
+        def contiguous_array(xp):
+            return testing.shaped_arange((3,), xp, dtype, order)
+        out = numpy.empty((3,), dtype, order)
+        self.check_get(contiguous_array, out, self.stream)
+
+    @testing.for_orders('CF')
+    @testing.for_all_dtypes()
+    def test_non_contiguous_array_stream(self, dtype, order):
+        def non_contiguous_array(xp):
+            return testing.shaped_arange((3, 3), xp, dtype, order)[0::2, 0::2]
+        out = numpy.empty((2, 2), dtype, order)
+        self.check_get(non_contiguous_array, out, self.stream)
+
+    @testing.multi_gpu(2)
+    @testing.for_orders('CF')
+    @testing.for_all_dtypes()
+    def test_get_multigpu(self, dtype, order):
+        with cuda.Device(1):
+            src = testing.shaped_arange((2, 3), cupy, dtype, order)
+            src = cupy.asfortranarray(src)
+        with cuda.Device(0):
+            dst = numpy.empty((2, 3), dtype, order)
+            src.get(out=dst)
+        expected = testing.shaped_arange((2, 3), numpy, dtype, order)
+        np_testing.assert_array_equal(dst, expected)


### PR DESCRIPTION
This PR is takeover version of #1955.
- Reduce function call
- Fix flake8 error
- Add tests
