### PR TITLE
Fix README image to use URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<div align="center"><img src="docs/image/cupy_logo_1000px.png" width="400"/></div>
+<div align="center"><img src="https://raw.githubusercontent.com/cupy/cupy/master/docs/image/cupy_logo_1000px.png" width="400"/></div>
 
 # CuPy : NumPy-like API accelerated with CUDA
 


### PR DESCRIPTION
This is needed for DockerHub to render README correctly.

https://hub.docker.com/r/cupy/cupy