### PR TITLE
[backport] Fix `cupy.random.randint` fail with size zero

### DIFF
--- a/cupy/random/generator.py
+++ b/cupy/random/generator.py
@@ -404,6 +404,8 @@ class RandomState(object):
         """  # NOQA
         if size is None:
             return self._interval(mx, 1).reshape(())
+        elif size == 0:
+            return cupy.array(())
         elif isinstance(size, int):
             size = (size, )
 

--- a/tests/cupy_tests/random_tests/test_generator.py
+++ b/tests/cupy_tests/random_tests/test_generator.py
@@ -809,6 +809,9 @@ class TestRandint(RandomGeneratorTestCase):
     def test_randint_2(self):
         self.generate(3, 4, size=(3, 2))
 
+    def test_randint_3(self):
+        self.generate(3, 10, size=0)
+
 
 @testing.gpu
 @testing.fix_random()


### PR DESCRIPTION
Backport of #1967