### PR TITLE
Call free_all_blocks to free CUDA memory

### DIFF
--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -687,6 +687,7 @@ cdef BaseMemory _try_malloc(SingleDeviceMemoryPool pool, size_t size):
             if e.status != runtime.errorMemoryAllocation:
                 raise
             gc.collect()
+            pool.free_all_blocks()
             try:
                 return pool._alloc(size).mem
             except runtime.CUDARuntimeError as e:


### PR DESCRIPTION
This fixing is for Python 2.

Please check chainer/chainer#5621 and [forum(ja)](https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/chainer-jp/7HVJiVHYgtU/n2PGkYI6FQAJ)