### PR TITLE
Use version interface in NCCL 2.3.4

### DIFF
--- a/cupy/cuda/cupy_nccl.h
+++ b/cupy/cuda/cupy_nccl.h
@@ -101,16 +101,18 @@ typedef struct CUstream_st *cudaStream_t;
 #define NCCL_PATCH 0
 #endif
 
-#define NCCL_VERSION  (NCCL_MAJOR * 1000 + NCCL_MINOR * 100 + NCCL_PATCH)
+#ifndef NCCL_VERSION_CODE
+#define NCCL_VERSION_CODE (NCCL_MAJOR * 1000 + NCCL_MINOR * 100 + NCCL_PATCH)
+#endif
 
 
-#if (NCCL_VERSION >= 2000)
+#if (NCCL_VERSION_CODE >= 2000)
 
 ncclDataType_t _get_proper_datatype(ncclDataType_t datatype) {
     return datatype;
 }
 
-#else // #if (NCCL_VERSION >= 2000)
+#else // #if (NCCL_VERSION_CODE >= 2000)
 
 #define NCCL_CHAR_V1 ncclChar
 #define NCCL_INT_V1 ncclInt
@@ -137,7 +139,16 @@ ncclDataType_t _get_proper_datatype(ncclDataType_t datatype) {
     return TYPE2TYPE_V1[datatype];
 }
 
-#endif // #if (NCCL_VERSION < 2000)
+#endif // #if (NCCL_VERSION_CODE < 2000)
+
+#if (NCCL_VERSION_CODE < 2304)
+
+ncclResult_t ncclGetVersion(int *version) {
+    version = 0;
+    return ncclSuccess;
+}
+
+#endif // #if (NCCL_VERSION_CODE < 2304)
 
 
 ncclResult_t _ncclAllReduce(const void* sendbuff, void* recvbuff, size_t count,
@@ -175,12 +186,11 @@ ncclResult_t _ncclAllGather(const void* sendbuff, void* recvbuff, size_t sendcou
                             ncclDataType_t datatype, ncclComm_t comm,
                             cudaStream_t stream) {
     ncclDataType_t _datatype = _get_proper_datatype(datatype);
-#if (NCCL_VERSION >= 2000)
+#if (NCCL_VERSION_CODE >= 2000)
     return ncclAllGather(sendbuff, recvbuff, sendcount, _datatype, comm, stream);
 #else
     return ncclAllGather(sendbuff, sendcount, _datatype, recvbuff, comm, stream);
-#endif // #if (NCCL_VERSION < 2000)
+#endif // #if (NCCL_VERSION_CODE < 2000)
 }
-
 
 #endif // #ifndef INCLUDE_GUARD_CUPY_NCCL_H

--- a/cupy/cuda/nccl.pyx
+++ b/cupy/cuda/nccl.pyx
@@ -105,6 +105,11 @@ def get_build_version():
 
 
 def get_version():
+    """Returns the runtime version of NCCL.
+
+    This function will return 0 when built with NCCL version earlier than
+    2.3.4, which does not support ``ncclGetVersion`` API.
+    """
     cdef int version
     status = ncclGetVersion(&version)
     check_status(status)

--- a/cupyx/runtime.py
+++ b/cupyx/runtime.py
@@ -54,7 +54,10 @@ class _RuntimeInfo(object):
 
         if nccl is not None:
             self.nccl_build_version = nccl.get_build_version()
-            self.nccl_runtime_version = nccl.get_version()
+            nccl_runtime_version = nccl.get_version()
+            if nccl_runtime_version == 0:
+                nccl_runtime_version = '(unknown)'
+            self.nccl_runtime_version = nccl_runtime_version
 
     def __str__(self):
         records = [

--- a/cupyx/runtime.py
+++ b/cupyx/runtime.py
@@ -33,6 +33,7 @@ class _RuntimeInfo(object):
     cudnn_build_version = None
     cudnn_version = None
     nccl_build_version = None
+    nccl_runtime_version = None
 
     def __init__(self):
         self.cupy_version = cupy.__version__
@@ -52,7 +53,8 @@ class _RuntimeInfo(object):
                 cudnn.getVersion, cudnn.CuDNNError)
 
         if nccl is not None:
-            self.nccl_build_version = nccl.get_version()
+            self.nccl_build_version = nccl.get_build_version()
+            self.nccl_runtime_version = nccl.get_version()
 
     def __str__(self):
         records = [
@@ -64,6 +66,7 @@ class _RuntimeInfo(object):
             ('cuDNN Build Version', self.cudnn_build_version),
             ('cuDNN Version', self.cudnn_version),
             ('NCCL Build Version', self.nccl_build_version),
+            ('NCCL Runtime Version', self.nccl_runtime_version),
         ]
         width = max([len(r[0]) for r in records]) + 2
         fmt = '{:' + str(width) + '}: {}\n'

--- a/install/build.py
+++ b/install/build.py
@@ -290,13 +290,15 @@ def check_nccl_version(compiler, settings):
         #include <nccl.h>
         #include <stdio.h>
         #ifdef NCCL_MAJOR
-        #  define NCCL_VERSION \
+        #ifndef NCCL_VERSION_CODE
+        #  define NCCL_VERSION_CODE \
                 (NCCL_MAJOR * 1000 + NCCL_MINOR * 100 + NCCL_PATCH)
+        #endif
         #else
-        #  define NCCL_VERSION 0
+        #  define NCCL_VERSION_CODE 0
         #endif
         int main(int argc, char* argv[]) {
-          printf("%d", NCCL_VERSION);
+          printf("%d", NCCL_VERSION_CODE);
           return 0;
         }
         ''', include_dirs=settings['include_dirs'])


### PR DESCRIPTION
`ncclGetVersion` function, `NCCL_VERSION` macro and `NCCL_VERSION_CODE` macro has been introduced in NCCL v2.3.4.
Use them to report runtime version in `cupy.show_config()` and also avoid redeclaration warning:

```
/tmp/tmpfdjuddmz/a.cpp:5:0: warning: "NCCL_VERSION" redefined
         #  define NCCL_VERSION                 (NCCL_MAJOR * 1000 + NCCL_MINOR * 100 + NCCL_PATCH)
 ^
In file included from /tmp/tmpfdjuddmz/a.cpp:2:0:
/home/kenichi/.nccl/active/cuda/include/nccl.h:19:0: note: this is the location of the previous definition
 #define NCCL_VERSION(X,Y,Z) ((X) * 1000 + (Y) * 100 + (Z))
 ^