### PR TITLE
Support Python scalars in `iscomplexobj`

### DIFF
--- a/cupy/logic/type_test.py
+++ b/cupy/logic/type_test.py
@@ -24,7 +24,11 @@ def iscomplex(x):
     array([ True, False, False, False, False,  True])
 
     """
-    if issubclass(x.dtype.type, numpy.complexfloating):
+    try:
+        ty = x.dtype.type
+    except AttributeError:
+        return complex(x).imag != 0
+    if issubclass(ty, numpy.complexfloating):
         return x.imag != 0
     return cupy.zeros(x.shape, bool)
 
@@ -53,7 +57,11 @@ def iscomplexobj(x):
     False
 
     """
-    return issubclass(x.dtype.type, numpy.complexfloating)
+    try:
+        ty = x.dtype.type
+    except AttributeError:
+        ty = numpy.asarray(x).dtype.type
+    return issubclass(ty, numpy.complexfloating)
 
 
 def isfortran(a):
@@ -139,7 +147,13 @@ def isreal(x):
     array([False,  True,  True,  True,  True, False])
 
     """
-    return x.imag == 0
+    try:
+        ty = x.dtype.type
+    except AttributeError:
+        return complex(x).imag == 0
+    if issubclass(ty, numpy.complexfloating):
+        return x.imag == 0
+    return cupy.ones(x.shape, bool)
 
 
 def isrealobj(x):

--- a/tests/cupy_tests/logic_tests/test_type_test.py
+++ b/tests/cupy_tests/logic_tests/test_type_test.py
@@ -57,6 +57,11 @@ class TestTypeTestingFunctions(unittest.TestCase):
     def test(self, xp, dtype):
         return getattr(xp, self.func)(xp.ones(5, dtype=dtype))
 
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_equal()
+    def test_scalar(self, xp, dtype):
+        return getattr(xp, self.func)(dtype(3))
+
 
 @testing.parameterize(
     {'func': 'iscomplexobj'},
@@ -68,3 +73,8 @@ class TestTypeTestingObjFunctions(unittest.TestCase):
     @testing.numpy_cupy_equal()
     def test(self, xp, dtype):
         return getattr(xp, self.func)(xp.ones(5, dtype=dtype))
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_equal()
+    def test_scalar(self, xp, dtype):
+        return getattr(xp, self.func)(dtype(3))


### PR DESCRIPTION
Close #1990.

This PR fixes
- `cupy.iscomplexobj`
- `cupy.isrealobj`
- `cupy.iscomplex`
- `cupy.isreal`.