### PR TITLE
[backport] Support Python scalars in `iscomplexobj`

### DIFF
--- a/cupy/logic/type_test.py
+++ b/cupy/logic/type_test.py
@@ -24,7 +24,11 @@ def iscomplex(x):
     array([ True, False, False, False, False,  True])
 
     """
-    if issubclass(x.dtype.type, numpy.complexfloating):
+    if numpy.isscalar(x):
+        return numpy.iscomplex(x)
+    if not isinstance(x, cupy.ndarray):
+        return cupy.asarray(numpy.iscomplex(x))
+    if x.dtype.kind == 'c':
         return x.imag != 0
     return cupy.zeros(x.shape, bool)
 
@@ -53,7 +57,9 @@ def iscomplexobj(x):
     False
 
     """
-    return issubclass(x.dtype.type, numpy.complexfloating)
+    if not isinstance(x, cupy.ndarray):
+        return numpy.iscomplexobj(x)
+    return x.dtype.kind == 'c'
 
 
 def isfortran(a):
@@ -139,7 +145,13 @@ def isreal(x):
     array([False,  True,  True,  True,  True, False])
 
     """
-    return x.imag == 0
+    if numpy.isscalar(x):
+        return numpy.isreal(x)
+    if not isinstance(x, cupy.ndarray):
+        return cupy.asarray(numpy.isreal(x))
+    if x.dtype.kind == 'c':
+        return x.imag == 0
+    return cupy.ones(x.shape, bool)
 
 
 def isrealobj(x):
@@ -166,4 +178,6 @@ def isrealobj(x):
     True
 
     """
-    return not iscomplexobj(x)
+    if not isinstance(x, cupy.ndarray):
+        return numpy.isrealobj(x)
+    return x.dtype.kind != 'c'

--- a/tests/cupy_tests/logic_tests/test_type_test.py
+++ b/tests/cupy_tests/logic_tests/test_type_test.py
@@ -57,6 +57,17 @@ class TestTypeTestingFunctions(unittest.TestCase):
     def test(self, xp, dtype):
         return getattr(xp, self.func)(xp.ones(5, dtype=dtype))
 
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_equal()
+    def test_scalar(self, xp, dtype):
+        return getattr(xp, self.func)(dtype(3))
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_list(self, xp, dtype):
+        return getattr(xp, self.func)(
+            testing.shaped_arange((2, 3), xp, dtype).tolist())
+
 
 @testing.parameterize(
     {'func': 'iscomplexobj'},
@@ -68,3 +79,14 @@ class TestTypeTestingObjFunctions(unittest.TestCase):
     @testing.numpy_cupy_equal()
     def test(self, xp, dtype):
         return getattr(xp, self.func)(xp.ones(5, dtype=dtype))
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_equal()
+    def test_scalar(self, xp, dtype):
+        return getattr(xp, self.func)(dtype(3))
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_equal()
+    def test_list(self, xp, dtype):
+        return getattr(xp, self.func)(
+            testing.shaped_arange((2, 3), xp, dtype).tolist())


### PR DESCRIPTION
Backport of #1991