### PR TITLE
define __dealloc__ instead of __del__ for cdef-classes to fix memory leak

### DIFF
--- a/cupy/cudnn.pyx
+++ b/cupy/cudnn.pyx
@@ -87,7 +87,7 @@ cdef class Descriptor:
         self.value = descriptor
         self.destroy = destroyer
 
-    def __del__(self):
+    def __dealloc__(self):
         if self.value:
             self.destroy(self.value)
             self.value = 0
@@ -532,7 +532,7 @@ cdef class _DescriptorArray:
     def __init__(self, destroyer):
         self._destroy = destroyer
 
-    def __del__(self):
+    def __dealloc__(self):
         for desc in self._value:
             self._destroy(desc)
 


### PR DESCRIPTION
It seems that PR #1659 introduced a memory leak, and this PR fixes the problem.

When I ran a program that repeatedly train a network that contains batch normalization, memory consumption increased continuously. The problem happens with the following combinations of Chainer and CuPy. (I’m using python 3.5.2, cuda 8.0 and cudnn 5.1)

* Chainer
  * v5.0.0
  * v5.1.0
  * revisions between v5.1.0 and https://github.com/chainer/chainer/commit/511f3cb5c3888c00df70f85b1d65fcf54e689d6f.
* CuPy
  * revisions between https://github.com/cupy/cupy/commit/769c4a5ec4e846a1a4e9e503481572d5a5c3c23e and  v5.1.0.
  * v5.1.0
  * v5.2.0

The commit https://github.com/cupy/cupy/commit/769c4a5ec4e846a1a4e9e503481572d5a5c3c23e is a backport of PR #1659 and it changes `Descriptor` from `class` to `cdef class` while keeping `__del__` as is. But according to the [Cython documentation](https://cython.readthedocs.io/en/stable/src/userguide/special_methods.html#finalization-method-dealloc) "there is no `__del__()` method for extension types", and it seems that we need to define `__dealloc__` instead of `__del__`.