### PR TITLE
Fix test of `assert_array_list_equal`

### DIFF
--- a/tests/cupy_tests/testing_tests/test_array.py
+++ b/tests/cupy_tests/testing_tests/test_array.py
@@ -61,13 +61,13 @@ class TestListEqualityAssertion(unittest.TestCase):
         self.ys = _convert_array(ys, self.array_module_y)
 
     def test_equality_numpy(self):
-        testing.assert_array_equal(self.xs, self.ys)
+        testing.assert_array_list_equal(self.xs, self.ys)
 
     def test_inequality_numpy(self):
         self.xs[0] += 1
         with six.assertRaisesRegex(self, AssertionError,
                                    '^\nArrays are not equal'):
-            testing.assert_array_equal(self.xs, self.ys)
+            testing.assert_array_list_equal(self.xs, self.ys)
 
 
 @testing.parameterize(

--- a/tests/cupy_tests/testing_tests/test_array.py
+++ b/tests/cupy_tests/testing_tests/test_array.py
@@ -39,10 +39,15 @@ def _convert_array(xs, array_module):
     if array_module == 'all_numpy':
         return xs
     elif array_module == 'all_cupy':
-        return cupy.asarray(xs)
+        return [
+            cupy.asarray(x)
+            for x in xs
+        ]
     else:
-        return [cupy.asarray(x) if numpy.random.randint(0, 2)
-                else x for x in xs]
+        return [
+            cupy.asarray(x) if numpy.random.randint(0, 2) else x
+            for x in xs
+        ]
 
 
 @testing.parameterize(


### PR DESCRIPTION
The bug in the test is effective with `numpy>=1.16.1`.