### PR TITLE
[backport] Define `__dealloc__` instead of `__del__` for cdef-classes to fix memory leak

### DIFF
--- a/cupy/cudnn.pyx
+++ b/cupy/cudnn.pyx
@@ -85,7 +85,7 @@ cdef class Descriptor:
         self.value = descriptor
         self.destroy = destroyer
 
-    def __del__(self):
+    def __dealloc__(self):
         if self.value:
             self.destroy(self.value)
             self.value = 0
@@ -528,7 +528,7 @@ cdef class _DescriptorArray:
     def __init__(self, destroyer):
         self._destroy = destroyer
 
-    def __del__(self):
+    def __dealloc__(self):
         for desc in self._value:
             self._destroy(desc)
 


### PR DESCRIPTION
Backport of #1995