### PR TITLE
Do not "accept error" if bad kwarg is passed to test itself

### DIFF
--- a/cupy/testing/helper.py
+++ b/cupy/testing/helper.py
@@ -7,6 +7,7 @@ import inspect
 import os
 import pkg_resources
 import random
+import sys
 import traceback
 import unittest
 import warnings
@@ -27,16 +28,17 @@ def _call_func(self, impl, args, kw):
         result = impl(self, *args, **kw)
         self.assertIsNotNone(result)
         error = None
-        tb = None
+        tb_str = None
     except Exception as e:
-        if e.__traceback__.tb_next is None:
+        _, _, tb = sys.exc_info()  # e.__traceback__ is py3 only
+        if tb.tb_next is None:
             # failed before impl is called, e.g. invalid kw
             raise e
         result = None
         error = e
-        tb = traceback.format_exc()
+        tb_str = traceback.format_exc()
 
-    return result, error, tb
+    return result, error, tb_str
 
 
 def _check_cupy_numpy_error(self, cupy_error, cupy_tb, numpy_error,

--- a/cupy/testing/helper.py
+++ b/cupy/testing/helper.py
@@ -29,6 +29,9 @@ def _call_func(self, impl, args, kw):
         error = None
         tb = None
     except Exception as e:
+        if e.__traceback__.tb_next is None:
+            # failed before impl is called, e.g. invalid kw
+            raise e
         result = None
         error = e
         tb = traceback.format_exc()

--- a/tests/cupy_tests/core_tests/test_ndarray_elementwise_op.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_elementwise_op.py
@@ -159,7 +159,12 @@ class TestArrayElementwiseOp(unittest.TestCase):
 
     @testing.for_all_dtypes_combination(names=['x_type', 'y_type'])
     @testing.numpy_cupy_allclose(accept_error=TypeError)
-    def check_array_array_op(self, op, xp, x_type, y_type, no_bool=False):
+    def check_array_array_op(self, op, xp, x_type, y_type,
+                             no_complex=False, no_bool=False):
+        if no_complex:
+            if numpy.dtype(x_type).kind == 'c' \
+                    or numpy.dtype(y_type).kind == 'c':
+                return xp.array(True)
         if no_bool and (numpy.dtype(x_type) == '?' and
                         numpy.dtype(y_type) == '?'):
             return xp.array(True)

--- a/tests/cupy_tests/core_tests/test_ndarray_elementwise_op.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_elementwise_op.py
@@ -161,10 +161,9 @@ class TestArrayElementwiseOp(unittest.TestCase):
     @testing.numpy_cupy_allclose(accept_error=TypeError)
     def check_array_array_op(self, op, xp, x_type, y_type,
                              no_complex=False, no_bool=False):
-        if no_complex:
-            if numpy.dtype(x_type).kind == 'c' \
-                    or numpy.dtype(y_type).kind == 'c':
-                return xp.array(True)
+        if no_complex and (numpy.dtype(x_type).kind == 'c' or
+                           numpy.dtype(y_type).kind == 'c'):
+            return xp.array(True)
         if no_bool and (numpy.dtype(x_type) == '?' and
                         numpy.dtype(y_type) == '?'):
             return xp.array(True)
@@ -268,10 +267,9 @@ class TestArrayElementwiseOp(unittest.TestCase):
     @testing.numpy_cupy_allclose(accept_error=TypeError)
     def check_array_broadcasted_op(self, op, xp, x_type, y_type,
                                    no_complex=False, no_bool=False):
-        if no_complex:
-            if numpy.dtype(x_type).kind == 'c' \
-                    or numpy.dtype(y_type).kind == 'c':
-                return xp.array(True)
+        if no_complex and (numpy.dtype(x_type).kind == 'c' or
+                           numpy.dtype(y_type).kind == 'c'):
+            return xp.array(True)
         if no_bool and (numpy.dtype(x_type) == '?' and
                         numpy.dtype(y_type) == '?'):
             return xp.array(True)
@@ -381,10 +379,9 @@ class TestArrayElementwiseOp(unittest.TestCase):
     @testing.numpy_cupy_allclose()
     def check_array_doubly_broadcasted_op(self, op, xp, x_type, y_type,
                                           no_complex=False, no_bool=False):
-        if no_complex:
-            if numpy.dtype(x_type).kind == 'c' \
-                    or numpy.dtype(y_type).kind == 'c':
-                return x_type(True)
+        if no_complex and (numpy.dtype(x_type).kind == 'c' or
+                           numpy.dtype(y_type).kind == 'c'):
+            return x_type(True)
         if no_bool and (numpy.dtype(x_type) == '?' and
                         numpy.dtype(y_type) == '?'):
             return x_type(True)

--- a/tests/cupy_tests/core_tests/test_ndarray_elementwise_op.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_elementwise_op.py
@@ -160,12 +160,12 @@ class TestArrayElementwiseOp(unittest.TestCase):
     @testing.for_all_dtypes_combination(names=['x_type', 'y_type'])
     @testing.numpy_cupy_allclose(accept_error=TypeError)
     def check_array_array_op(self, op, xp, x_type, y_type,
-                             no_complex=False, no_bool=False):
-        if no_complex and (numpy.dtype(x_type).kind == 'c' or
-                           numpy.dtype(y_type).kind == 'c'):
+                             no_bool=False, no_complex=False):
+        x_dtype = numpy.dtype(x_type)
+        y_dtype = numpy.dtype(y_type)
+        if no_bool and x_dtype == '?' and y_dtype == '?':
             return xp.array(True)
-        if no_bool and (numpy.dtype(x_type) == '?' and
-                        numpy.dtype(y_type) == '?'):
+        if no_complex and (x_dtype.kind == 'c' or y_dtype.kind == 'c'):
             return xp.array(True)
         a = xp.array([[1, 2, 3], [4, 5, 6]], x_type)
         b = xp.array([[6, 5, 4], [3, 2, 1]], y_type)
@@ -266,12 +266,12 @@ class TestArrayElementwiseOp(unittest.TestCase):
     @testing.for_all_dtypes_combination(names=['x_type', 'y_type'])
     @testing.numpy_cupy_allclose(accept_error=TypeError)
     def check_array_broadcasted_op(self, op, xp, x_type, y_type,
-                                   no_complex=False, no_bool=False):
-        if no_complex and (numpy.dtype(x_type).kind == 'c' or
-                           numpy.dtype(y_type).kind == 'c'):
+                                   no_bool=False, no_complex=False):
+        x_dtype = numpy.dtype(x_type)
+        y_dtype = numpy.dtype(y_type)
+        if no_bool and x_dtype == '?' and y_dtype == '?':
             return xp.array(True)
-        if no_bool and (numpy.dtype(x_type) == '?' and
-                        numpy.dtype(y_type) == '?'):
+        if no_complex and (x_dtype.kind == 'c' or y_dtype.kind == 'c'):
             return xp.array(True)
         a = xp.array([[1, 2, 3], [4, 5, 6]], x_type)
         b = xp.array([[1], [2]], y_type)
@@ -378,13 +378,13 @@ class TestArrayElementwiseOp(unittest.TestCase):
     @testing.for_all_dtypes_combination(names=['x_type', 'y_type'])
     @testing.numpy_cupy_allclose()
     def check_array_doubly_broadcasted_op(self, op, xp, x_type, y_type,
-                                          no_complex=False, no_bool=False):
-        if no_complex and (numpy.dtype(x_type).kind == 'c' or
-                           numpy.dtype(y_type).kind == 'c'):
-            return x_type(True)
-        if no_bool and (numpy.dtype(x_type) == '?' and
-                        numpy.dtype(y_type) == '?'):
-            return x_type(True)
+                                          no_bool=False, no_complex=False):
+        x_dtype = numpy.dtype(x_type)
+        y_dtype = numpy.dtype(y_type)
+        if no_bool and x_dtype == '?' and y_dtype == '?':
+            return xp.array(True)
+        if no_complex and (x_dtype.kind == 'c' or y_dtype.kind == 'c'):
+            return xp.array(True)
         a = xp.array([[[1, 2, 3]], [[4, 5, 6]]], x_type)
         b = xp.array([[1], [2], [3]], y_type)
         return op(a, b)


### PR DESCRIPTION
`accept_error` feature catches errors in test codes.

https://github.com/cupy/cupy/blob/7ea8df6127b7a2bf1d8c0b77f3a3050217fd926f/tests/cupy_tests/core_tests/test_ndarray_elementwise_op.py#L160-L168
is called by
https://github.com/cupy/cupy/blob/7ea8df6127b7a2bf1d8c0b77f3a3050217fd926f/tests/cupy_tests/core_tests/test_ndarray_elementwise_op.py#L213-L215
, which should fail with `TypeError: ... got an unexpected keyword argument 'no_complex'`.