### PR TITLE
Enhance error messages of elementwise operation in fusion mode

### DIFF
--- a/cupy/core/fusion.pyx
+++ b/cupy/core/fusion.pyx
@@ -598,7 +598,7 @@ class _FusionHistory(object):
         out_vars = var_list[nin:]
         if 'out' in kwargs:
             out = kwargs.pop('out')
-            if len(out_vars) > 0:
+            if out_vars:
                 raise ValueError('cannot specify \'out\' as both a positional '
                                  'and keyword argument')
             if isinstance(out, _FusionVarArray):


### PR DESCRIPTION
This PR also fixes a bug of cast mentioned in #1983, but this bug will not be reproduced until `cupy.copyto` is introduced in this repository.
