### PR TITLE
improve performance of reduction on outer axis

### DIFF
--- a/cupy/core/reduction.pxi
+++ b/cupy/core/reduction.pxi
@@ -51,20 +51,17 @@ extern "C" __global__ void ${name}(${params}) {
       _type_reduce _a = static_cast<_type_reduce>(${pre_map_expr});
       _s = REDUCE(_s, _a);
     }
-    if (_block_stride < ${block_size}) {
-      _sdata[_tid] = _s;
-      __syncthreads();
-      for (unsigned int _block = ${block_size} / 2;
-           _block >= _block_stride; _block >>= 1) {
-        if (_tid < _block) {
-          _REDUCE(_block);
-        }
-        __syncthreads();
-      }
-      if (_tid < _block_stride) {
-        _s = _sdata[_tid];
+    _sdata[_tid] = _s;
+    __syncthreads();
+    for (unsigned int _block = ${block_size} / 2;
+         _block >= _block_stride; _block >>= 1) {
+      if (_tid < _block) {
+        _REDUCE(_block);
       }
       __syncthreads();
+    }
+    if (_tid < _block_stride) {
+      _s = _sdata[_tid];
     }
     if (_tid < _block_stride && _i < _out_ind.size()) {
       _out_ind.set(static_cast<ptrdiff_t>(_i));

--- a/cupy/core/reduction.pxi
+++ b/cupy/core/reduction.pxi
@@ -114,29 +114,43 @@ cpdef tuple _get_out_shape(
 
 
 cpdef tuple _get_permuted_args(
-        list args, tuple axis_permutes, tuple shape, tuple params):
+        list args, tuple axis_permutes, tuple shape, tuple params,
+        Py_ssize_t out_ndim):
     cdef ParameterInfo p
-    if axis_permutes == tuple(range(len(shape))):
-        return args, shape
-    if params is not None:
-        for p in params:
-            if p.raw:
-                raise NotImplementedError('Illegal conditions')
-    args = [a.transpose(axis_permutes) if isinstance(a, ndarray) else a
-            for a in args]
-    shape = tuple([shape[i] for i in axis_permutes])
+    cdef Py_ssize_t contiguous_size, tmp_contiguous_size, itemsize
 
-    return args, shape
+    if axis_permutes != tuple(range(len(shape))):
+        if params is not None:
+            for p in params:
+                if p.raw:
+                    raise NotImplementedError('Illegal conditions')
+        args = [a.transpose(axis_permutes) if isinstance(a, ndarray) else a
+                for a in args]
+        shape = tuple([shape[i] for i in axis_permutes])
+
+    contiguous_size = 1
+    for a in args:
+        if not isinstance(a, ndarray):
+            continue
+        tmp_contiguous_size = 1
+        itemsize = a.dtype.itemsize
+        for i in range(out_ndim):
+            if a.strides[-i-1] != tmp_contiguous_size * itemsize:
+                break
+            tmp_contiguous_size *= a.shape[-i-1]
+        contiguous_size = max(contiguous_size, tmp_contiguous_size)
+    return args, shape, contiguous_size
 
 
 cpdef (Py_ssize_t, Py_ssize_t, Py_ssize_t) _get_block_specs(  # NOQA
-        Indexer in_indexer, Indexer out_indexer):
+        Indexer in_indexer, Indexer out_indexer, Py_ssize_t contiguous_size):
     cdef Py_ssize_t block_size, reduce_block_size, block_stride, out_block_num
     block_size = 512
 
-    reduce_block_size = max(
-        1, internal.clp2(in_indexer.size // out_indexer.size))
-    block_stride = max(1, block_size // reduce_block_size)
+    reduce_block_size = max(1, in_indexer.size // out_indexer.size)
+    contiguous_size = min(contiguous_size, 32)
+    block_stride = max(contiguous_size, block_size // reduce_block_size)
+    block_stride = internal.clp2(block_stride // 2 + 1)  # floor
     out_block_num = (out_indexer.size + block_stride - 1) // block_stride
 
     return block_size, block_stride, out_block_num
@@ -200,6 +214,7 @@ class simple_reduction_function(object):
                  bint keepdims=False):
         cdef list in_args, out_args
         cdef tuple in_sahpe, reduce_axis, out_axis
+        cdef Py_ssize_t contiguous_size
         cdef Py_ssize_t block_size, block_stride, out_block_num
         if dtype is not None:
             dtype = get_dtype(dtype).type
@@ -227,13 +242,13 @@ class simple_reduction_function(object):
             raise ValueError(('zero-size array to reduction operation'
                               ' %s which has no identity') % self.name)
 
-        in_args, in_shape = _get_permuted_args(
-            in_args, reduce_axis + out_axis, a_shape, None)
+        in_args, in_shape, contiguous_size = _get_permuted_args(
+            in_args, reduce_axis + out_axis, a_shape, None, len(out_axis))
 
         in_indexer = Indexer(in_shape)
         out_indexer = Indexer(out_shape)
         block_size, block_stride, out_block_num = _get_block_specs(
-            in_indexer, out_indexer)
+            in_indexer, out_indexer, contiguous_size)
 
         inout_args = _get_inout_args(
             in_args, out_args, in_indexer, out_indexer, block_stride,
@@ -360,6 +375,7 @@ class ReductionKernel(object):
             ``__init__`` method.
 
         """
+        cdef Py_ssize_t contiguous_size
         cdef Py_ssize_t block_size, block_stride, out_block_num
 
         out = kwargs.pop('out', None)
@@ -412,13 +428,14 @@ class ReductionKernel(object):
         in_args = [x if isinstance(x, ndarray) else
                    _scalar.get_scalar_from_numpy(x, t)
                    for x, t in zip(in_args, in_types)]
-        in_args, in_shape = _get_permuted_args(
-            in_args, reduce_axis + out_axis, broad_shape, self.in_params)
+        in_args, in_shape, contiguous_size = _get_permuted_args(
+            in_args, reduce_axis + out_axis, broad_shape, self.in_params,
+            len(out_axis))
 
         in_indexer = Indexer(in_shape)
         out_indexer = Indexer(out_shape)
         block_size, block_stride, out_block_num = _get_block_specs(
-            in_indexer, out_indexer)
+            in_indexer, out_indexer, contiguous_size)
 
         inout_args = _get_inout_args(
             in_args, out_args, in_indexer, out_indexer, block_stride,

--- a/tests/cupy_tests/core_tests/test_reduction.py
+++ b/tests/cupy_tests/core_tests/test_reduction.py
@@ -49,7 +49,8 @@ class SimpleReductionFunction(unittest.TestCase):
         self.check_int8_sum((512 + 1, 256 * 256 + 1), axis=1)
 
     def test_shape5(self):
-        size = ((2 << 32) // self.my_int8_sum._block_size)
+        block_size = 512
+        size = ((2 << 32) // block_size)
         self.check_int8_sum((size, 1), axis=1)
         self.check_int8_sum((size, 1), axis=0)
 


### PR DESCRIPTION
Reduction on a outer axis of a large tensor has been small, due to bad memory access pattern. This PR aim to mitigate the issue by allocating up to 32 contiguous items to `_block_stride`. By doing this, coalesced memory access is achieved.

Increasing `_block_stride` can hurt parallelism, so performance degradation can occur depending on workload. I think the speed-up will outweigh the possible degradation, but more benchmarks are welcomed.

The following is the benchmark I conducted.

```python
# nvprof --print-gpu-trace python spam.py
import cupy


x = cupy.random.normal(0.0, 1.0, (16, 512, 8, 8), dtype=cupy.float32)
y = cupy.random.normal(0.0, 1.0, (16, 512, 8, 8), dtype=cupy.float32)
kern = cupy.ReductionKernel(
    'T x, T y', 'T z',
    'x * y', 'a + b', 'z = a', '0', 'sample_dot')

for i in range(10):
    z = cupy.sum(x, axis=1)

for i in range(10):
    z = kern(x, y, axis=1)

for i in range(10):
    z = kern(x[:, :, None], y[:, None, :], axis=1)

for i in range(10):
    z = kern(x[:, :, None], y[:, None, :], axis=(1, 2))
```

About 4x speed up is observed on the first 3 samples. A little degradation is observed on the last sample, due to decreased parallelism. I run the benchmark on a Linux laptop, CUDA 10.0 installed and GTX 1080 mobile equipped.

Before:

```
==18176== Profiling result:
   Start  Duration            Grid Size      Block Size     Regs*    SSMem*    DSMem*           Device   Context    Stream  Name
290.45ms  3.6917ms             (64 1 1)        (64 1 1)        48        0B        0B  GeForce GTX 108         1         7  generate_seed_pseudo(__int64, __int64, __int64, curandOrdering, curandStateXORWOW*, unsigned int*) [217]
294.25ms  21.504us             (64 1 1)        (64 1 1)        24        0B        0B  GeForce GTX 108         1         7  void gen_sequenced<curandStateXORWOW, float2, normal_args_st, __operator_&__(float2 curand_normal_scaled2<curandStateXORWOW>(curandStateXORWOW*, normal_args_st))>(curandStateXORWOW*, float2*, u
nsigned long, unsigned long, normal_args_st) [222]                                                                                                                                                                                                                                                                           360.60ms  18.432us           (4096 1 1)       (128 1 1)        18        0B        0B  GeForce GTX 108         1         7  cupy_multiply [236]
361.11ms  15.328us           (4096 1 1)       (128 1 1)        18        0B        0B  GeForce GTX 108         1         7  cupy_add [243]
361.31ms  22.880us             (64 1 1)        (64 1 1)        24        0B        0B  GeForce GTX 108         1         7  void gen_sequenced<curandStateXORWOW, float2, normal_args_st, __operator_&__(float2 curand_normal_scaled2<curandStateXORWOW>(curandStateXORWOW*, normal_args_st))>(curandStateXORWOW*, float2*, u
nsigned long, unsigned long, normal_args_st) [249]                                                                                                                                                                                                                                                                           361.37ms  19.233us           (4096 1 1)       (128 1 1)        18        0B        0B  GeForce GTX 108         1         7  cupy_multiply [254]
361.42ms  14.912us           (4096 1 1)       (128 1 1)        18        0B        0B  GeForce GTX 108         1         7  cupy_add [258]
362.01ms  93.088us           (1024 1 1)       (512 1 1)        54  2.0000KB        0B  GeForce GTX 108         1         7  cupy_sum [267]
362.11ms  89.089us           (1024 1 1)       (512 1 1)        54  2.0000KB        0B  GeForce GTX 108         1         7  cupy_sum [273]
362.20ms  88.896us           (1024 1 1)       (512 1 1)        54  2.0000KB        0B  GeForce GTX 108         1         7  cupy_sum [277]
362.29ms  89.057us           (1024 1 1)       (512 1 1)        54  2.0000KB        0B  GeForce GTX 108         1         7  cupy_sum [281]
362.38ms  88.448us           (1024 1 1)       (512 1 1)        54  2.0000KB        0B  GeForce GTX 108         1         7  cupy_sum [285]
362.46ms  88.961us           (1024 1 1)       (512 1 1)        54  2.0000KB        0B  GeForce GTX 108         1         7  cupy_sum [289]
362.55ms  88.961us           (1024 1 1)       (512 1 1)        54  2.0000KB        0B  GeForce GTX 108         1         7  cupy_sum [293]
362.64ms  88.864us           (1024 1 1)       (512 1 1)        54  2.0000KB        0B  GeForce GTX 108         1         7  cupy_sum [297]
362.73ms  89.057us           (1024 1 1)       (512 1 1)        54  2.0000KB        0B  GeForce GTX 108         1         7  cupy_sum [301]
362.82ms  89.568us           (1024 1 1)       (512 1 1)        54  2.0000KB        0B  GeForce GTX 108         1         7  cupy_sum [305]
363.29ms  106.75us           (1024 1 1)       (512 1 1)        54  2.0000KB        0B  GeForce GTX 108         1         7  sample_dot [313]
363.40ms  105.47us           (1024 1 1)       (512 1 1)        54  2.0000KB        0B  GeForce GTX 108         1         7  sample_dot [318]
363.51ms  105.57us           (1024 1 1)       (512 1 1)        54  2.0000KB        0B  GeForce GTX 108         1         7  sample_dot [323]
363.61ms  104.99us           (1024 1 1)       (512 1 1)        54  2.0000KB        0B  GeForce GTX 108         1         7  sample_dot [328]
363.72ms  105.38us           (1024 1 1)       (512 1 1)        54  2.0000KB        0B  GeForce GTX 108         1         7  sample_dot [333]
363.82ms  105.12us           (1024 1 1)       (512 1 1)        54  2.0000KB        0B  GeForce GTX 108         1         7  sample_dot [338]
363.93ms  105.15us           (1024 1 1)       (512 1 1)        54  2.0000KB        0B  GeForce GTX 108         1         7  sample_dot [343]
364.03ms  105.09us           (1024 1 1)       (512 1 1)        54  2.0000KB        0B  GeForce GTX 108         1         7  sample_dot [348]
364.14ms  105.41us           (1024 1 1)       (512 1 1)        54  2.0000KB        0B  GeForce GTX 108         1         7  sample_dot [353]
364.25ms  105.38us           (1024 1 1)       (512 1 1)        54  2.0000KB        0B  GeForce GTX 108         1         7  sample_dot [358]
364.87ms  50.431ms         (524288 1 1)       (512 1 1)        64  2.0000KB        0B  GeForce GTX 108         1         7  sample_dot [368]
415.30ms  50.428ms         (524288 1 1)       (512 1 1)        64  2.0000KB        0B  GeForce GTX 108         1         7  sample_dot [375]
465.73ms  49.509ms         (524288 1 1)       (512 1 1)        64  2.0000KB        0B  GeForce GTX 108         1         7  sample_dot [380]
515.24ms  45.686ms         (524288 1 1)       (512 1 1)        64  2.0000KB        0B  GeForce GTX 108         1         7  sample_dot [385]
560.92ms  45.684ms         (524288 1 1)       (512 1 1)        64  2.0000KB        0B  GeForce GTX 108         1         7  sample_dot [390]
606.61ms  45.045ms         (524288 1 1)       (512 1 1)        64  2.0000KB        0B  GeForce GTX 108         1         7  sample_dot [395]
651.65ms  43.153ms         (524288 1 1)       (512 1 1)        64  2.0000KB        0B  GeForce GTX 108         1         7  sample_dot [400]
694.81ms  41.327ms         (524288 1 1)       (512 1 1)        64  2.0000KB        0B  GeForce GTX 108         1         7  sample_dot [405]
736.13ms  41.295ms         (524288 1 1)       (512 1 1)        64  2.0000KB        0B  GeForce GTX 108         1         7  sample_dot [410]
777.43ms  40.895ms         (524288 1 1)       (512 1 1)        64  2.0000KB        0B  GeForce GTX 108         1         7  sample_dot [415]
818.32ms  12.040ms           (1024 1 1)       (512 1 1)        64  2.0000KB        0B  GeForce GTX 108         1         7  sample_dot [420]
830.36ms  12.016ms           (1024 1 1)       (512 1 1)        64  2.0000KB        0B  GeForce GTX 108         1         7  sample_dot [425]
842.38ms  11.830ms           (1024 1 1)       (512 1 1)        64  2.0000KB        0B  GeForce GTX 108         1         7  sample_dot [430]
854.21ms  12.157ms           (1024 1 1)       (512 1 1)        64  2.0000KB        0B  GeForce GTX 108         1         7  sample_dot [435]
866.37ms  12.291ms           (1024 1 1)       (512 1 1)        64  2.0000KB        0B  GeForce GTX 108         1         7  sample_dot [440]
878.66ms  12.557ms           (1024 1 1)       (512 1 1)        64  2.0000KB        0B  GeForce GTX 108         1         7  sample_dot [445]
891.22ms  12.571ms           (1024 1 1)       (512 1 1)        64  2.0000KB        0B  GeForce GTX 108         1         7  sample_dot [450]
903.79ms  12.569ms           (1024 1 1)       (512 1 1)        64  2.0000KB        0B  GeForce GTX 108         1         7  sample_dot [455]
916.36ms  12.554ms           (1024 1 1)       (512 1 1)        64  2.0000KB        0B  GeForce GTX 108         1         7  sample_dot [460]
928.91ms  12.557ms           (1024 1 1)       (512 1 1)        64  2.0000KB        0B  GeForce GTX 108         1         7  sample_dot [465]
```

After:

```
==18216== Profiling result:
   Start  Duration            Grid Size      Block Size     Regs*    SSMem*    DSMem*           Device   Context    Stream  Name
319.26ms  2.7971ms             (64 1 1)        (64 1 1)        48        0B        0B  GeForce GTX 108         1         7  generate_seed_pseudo(__int64, __int64, __int64, curandOrdering, curandStateXORWOW*, unsigned int*) [217]
322.16ms  16.576us             (64 1 1)        (64 1 1)        24        0B        0B  GeForce GTX 108         1         7  void gen_sequenced<curandStateXORWOW, float2, normal_args_st, __operator_&__(float2 curand_normal_scaled2<curandStateXORWOW>(curandStateXORWOW*, normal_args_st))>(curandStateXORWOW*, float2*, unsigned long, unsigned long, normal_args_st) [222]
388.91ms  17.696us           (4096 1 1)       (128 1 1)        18        0B        0B  GeForce GTX 108         1         7  cupy_multiply [236]
389.48ms  12.064us           (4096 1 1)       (128 1 1)        18        0B        0B  GeForce GTX 108         1         7  cupy_add [243]
389.68ms  17.537us             (64 1 1)        (64 1 1)        24        0B        0B  GeForce GTX 108         1         7  void gen_sequenced<curandStateXORWOW, float2, normal_args_st, __operator_&__(float2 curand_normal_scaled2<curandStateXORWOW>(curandStateXORWOW*, normal_args_st))>(curandStateXORWOW*, float2*, unsigned long, unsigned long, normal_args_st) [249]
389.74ms  18.752us           (4096 1 1)       (128 1 1)        18        0B        0B  GeForce GTX 108         1         7  cupy_multiply [254]
389.79ms  11.648us           (4096 1 1)       (128 1 1)        18        0B        0B  GeForce GTX 108         1         7  cupy_add [258]
390.39ms  21.760us             (32 1 1)       (512 1 1)        54  2.0000KB        0B  GeForce GTX 108         1         7  cupy_sum [267]
390.49ms  20.032us             (32 1 1)       (512 1 1)        54  2.0000KB        0B  GeForce GTX 108         1         7  cupy_sum [273]
390.58ms  17.120us             (32 1 1)       (512 1 1)        54  2.0000KB        0B  GeForce GTX 108         1         7  cupy_sum [277]
390.73ms  17.056us             (32 1 1)       (512 1 1)        54  2.0000KB        0B  GeForce GTX 108         1         7  cupy_sum [281]
390.80ms  17.216us             (32 1 1)       (512 1 1)        54  2.0000KB        0B  GeForce GTX 108         1         7  cupy_sum [285]
390.89ms  16.960us             (32 1 1)       (512 1 1)        54  2.0000KB        0B  GeForce GTX 108         1         7  cupy_sum [289]
390.96ms  17.152us             (32 1 1)       (512 1 1)        54  2.0000KB        0B  GeForce GTX 108         1         7  cupy_sum [293]
391.04ms  17.216us             (32 1 1)       (512 1 1)        54  2.0000KB        0B  GeForce GTX 108         1         7  cupy_sum [297]
391.12ms  17.312us             (32 1 1)       (512 1 1)        54  2.0000KB        0B  GeForce GTX 108         1         7  cupy_sum [301]
391.19ms  17.440us             (32 1 1)       (512 1 1)        54  2.0000KB        0B  GeForce GTX 108         1         7  cupy_sum [305]
391.76ms  30.048us             (32 1 1)       (512 1 1)        54  2.0000KB        0B  GeForce GTX 108         1         7  sample_dot [313]
391.88ms  29.185us             (32 1 1)       (512 1 1)        54  2.0000KB        0B  GeForce GTX 108         1         7  sample_dot [318]
391.98ms  27.520us             (32 1 1)       (512 1 1)        54  2.0000KB        0B  GeForce GTX 108         1         7  sample_dot [323]
392.08ms  29.024us             (32 1 1)       (512 1 1)        54  2.0000KB        0B  GeForce GTX 108         1         7  sample_dot [328]
392.18ms  28.929us             (32 1 1)       (512 1 1)        54  2.0000KB        0B  GeForce GTX 108         1         7  sample_dot [333]
392.28ms  29.120us             (32 1 1)       (512 1 1)        54  2.0000KB        0B  GeForce GTX 108         1         7  sample_dot [338]
392.38ms  28.928us             (32 1 1)       (512 1 1)        54  2.0000KB        0B  GeForce GTX 108         1         7  sample_dot [343]
392.48ms  28.449us             (32 1 1)       (512 1 1)        54  2.0000KB        0B  GeForce GTX 108         1         7  sample_dot [348]
392.57ms  28.704us             (32 1 1)       (512 1 1)        54  2.0000KB        0B  GeForce GTX 108         1         7  sample_dot [353]
392.67ms  28.800us             (32 1 1)       (512 1 1)        54  2.0000KB        0B  GeForce GTX 108         1         7  sample_dot [358]
393.37ms  11.704ms          (16384 1 1)       (512 1 1)        64  2.0000KB        0B  GeForce GTX 108         1         7  sample_dot [368]
405.07ms  11.700ms          (16384 1 1)       (512 1 1)        64  2.0000KB        0B  GeForce GTX 108         1         7  sample_dot [375]
416.77ms  11.699ms          (16384 1 1)       (512 1 1)        64  2.0000KB        0B  GeForce GTX 108         1         7  sample_dot [380]
428.47ms  11.699ms          (16384 1 1)       (512 1 1)        64  2.0000KB        0B  GeForce GTX 108         1         7  sample_dot [385]
440.17ms  11.701ms          (16384 1 1)       (512 1 1)        64  2.0000KB        0B  GeForce GTX 108         1         7  sample_dot [390]
451.87ms  11.702ms          (16384 1 1)       (512 1 1)        64  2.0000KB        0B  GeForce GTX 108         1         7  sample_dot [395]
463.58ms  11.700ms          (16384 1 1)       (512 1 1)        64  2.0000KB        0B  GeForce GTX 108         1         7  sample_dot [400]
475.28ms  11.700ms          (16384 1 1)       (512 1 1)        64  2.0000KB        0B  GeForce GTX 108         1         7  sample_dot [405]
486.98ms  11.703ms          (16384 1 1)       (512 1 1)        64  2.0000KB        0B  GeForce GTX 108         1         7  sample_dot [410]
498.68ms  11.702ms          (16384 1 1)       (512 1 1)        64  2.0000KB        0B  GeForce GTX 108         1         7  sample_dot [415]
510.39ms  13.880ms             (32 1 1)       (512 1 1)        64  2.0000KB        0B  GeForce GTX 108         1         7  sample_dot [420]
524.27ms  13.885ms             (32 1 1)       (512 1 1)        64  2.0000KB        0B  GeForce GTX 108         1         7  sample_dot [425]
538.15ms  13.881ms             (32 1 1)       (512 1 1)        64  2.0000KB        0B  GeForce GTX 108         1         7  sample_dot [430]
552.03ms  13.884ms             (32 1 1)       (512 1 1)        64  2.0000KB        0B  GeForce GTX 108         1         7  sample_dot [435]
565.92ms  13.882ms             (32 1 1)       (512 1 1)        64  2.0000KB        0B  GeForce GTX 108         1         7  sample_dot [440]
579.80ms  13.890ms             (32 1 1)       (512 1 1)        64  2.0000KB        0B  GeForce GTX 108         1         7  sample_dot [445]
593.69ms  13.880ms             (32 1 1)       (512 1 1)        64  2.0000KB        0B  GeForce GTX 108         1         7  sample_dot [450]
607.57ms  13.883ms             (32 1 1)       (512 1 1)        64  2.0000KB        0B  GeForce GTX 108         1         7  sample_dot [455]
621.45ms  13.882ms             (32 1 1)       (512 1 1)        64  2.0000KB        0B  GeForce GTX 108         1         7  sample_dot [460]
635.34ms  13.786ms             (32 1 1)       (512 1 1)        64  2.0000KB        0B  GeForce GTX 108         1         7  sample_dot [465]
```