### PR TITLE
Fix __array_function__ bug

### DIFF
--- a/cupy/core/_kernel.pyx
+++ b/cupy/core/_kernel.pyx
@@ -672,7 +672,8 @@ cdef tuple _guess_routine(name, dict cache, list ops, list in_args, dtype):
     if dtype is None:
         use_raw_value = _check_should_use_min_scalar(in_args)
         if use_raw_value:
-            in_types = tuple(in_args)
+            in_types = tuple([i.dtype if isinstance(i, ndarray) else i
+                              for i in in_args])
             op = ()
         else:
             in_types = tuple([i.dtype.type for i in in_args])

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1244,10 +1244,14 @@ cdef class ndarray:
     def __array_function__(self, func, types, args, kwargs):
         if not hasattr(cupy, func.__name__):
             return NotImplemented
+        cupy_func = getattr(cupy, func.__name__)
+        if cupy_func is func:
+            # avoid NumPy func
+            return NotImplemented
         for t in types:
             if t not in _HANDLED_TYPES:
                 return NotImplemented
-        return getattr(cupy, func.__name__)(*args, **kwargs)
+        return cupy_func(*args, **kwargs)
 
     # Conversion:
 


### PR DESCRIPTION
This PR relates #1650 .

Please test with NumPy >= 1.16
```
NUMPY_EXPERIMENTAL_ARRAY_FUNCTION=1 python -c "import numpy, cupy; print(numpy.power(cupy.arange(10), 2))"
```