### PR TITLE
Add `plan` argument to 1D FFT functions in `cupyx.scipy.fftpack`

### DIFF
--- a/cupy/cuda/cufft.pyx
+++ b/cupy/cuda/cufft.pyx
@@ -108,6 +108,7 @@ class Plan1d(object):
         self.fft_type = fft_type
         self.plan = plan
         self.work_area = work_area
+        self.batch = batch
 
     def __del__(self):
         cdef Handle plan = self.plan
@@ -236,6 +237,7 @@ class PlanNd(object):
         self.fft_type = fft_type
         self.plan = plan
         self.work_area = work_area
+        self.batch = batch
 
     def __del__(self):
         cdef Handle plan = self.plan

--- a/cupy/cuda/cufft.pyx
+++ b/cupy/cuda/cufft.pyx
@@ -237,7 +237,6 @@ class PlanNd(object):
         self.fft_type = fft_type
         self.plan = plan
         self.work_area = work_area
-        self.batch = batch
 
     def __del__(self):
         cdef Handle plan = self.plan

--- a/cupy/fft/fft.py
+++ b/cupy/fft/fft.py
@@ -92,9 +92,9 @@ def _exec_fft(a, direction, value_type, norm, axis, overwrite_x,
         if fft_type != plan.fft_type:
             raise ValueError("CUFFT plan dtype mismatch.")
         if out_size != plan.nx:
-            raise ValueError("Target array size mismatches the plan.")
+            raise ValueError("Target array size does not match the plan.")
         if batch != plan.batch:
-            raise ValueError("Batch size mismatches the plan.")
+            raise ValueError("Batch size does not match the plan.")
 
     if overwrite_x and value_type == 'C2C':
         out = a

--- a/cupy/fft/fft.py
+++ b/cupy/fft/fft.py
@@ -121,7 +121,7 @@ def _exec_fft(a, direction, value_type, norm, axis, overwrite_x,
     return out
 
 
-def _fft_c2c(a, direction, norm, axes, overwrite_x, plan):
+def _fft_c2c(a, direction, norm, axes, overwrite_x, plan=None):
     for axis in axes:
         a = _exec_fft(a, direction, 'C2C', norm, axis, overwrite_x, plan=plan)
     return a

--- a/cupyx/scipy/fftpack/fft.py
+++ b/cupyx/scipy/fftpack/fft.py
@@ -1,4 +1,5 @@
 from numpy import prod
+
 import cupy
 from cupy.cuda import cufft
 from cupy.fft.fft import (_fft, _default_fft_func, _convert_fft_type,
@@ -52,9 +53,8 @@ def get_fft_plan(a, shape=None, axes=None, value_type='C2C'):
         axis1D = axes
         axes = (axes,)
         if axis1D >= a.ndim or axis1D < -a.ndim:
-            raise ValueError("Invalid input: a has dimension {0} but you "
-                             "choose the axis {1} to be transformed."
-                             .format(a.ndim, axis1D))
+            raise ValueError("The chosen axis ({0}) exceeds the number of "
+                             "dimensions of a ({1})".format(axis1D, a.ndim))
     else:  # axes is a tuple
         n = len(axes)
         if n == 1:
@@ -105,7 +105,7 @@ def fft(x, n=None, axis=-1, overwrite_x=False, plan=None):
         axis (int): Axis over which to compute the FFT.
         overwrite_x (bool): If True, the contents of ``x`` can be destroyed.
         plan (cupy.cuda.cufft.Plan1d): a cuFFT plan for transforming ``x``
-            over ``axis``, which can be obtained using
+            over ``axis``, which can be obtained using::
 
                 plan = cupyx.scipy.fftpack.get_fft_plan(x, axis)
 
@@ -134,7 +134,7 @@ def ifft(x, n=None, axis=-1, overwrite_x=False, plan=None):
         axis (int): Axis over which to compute the FFT.
         overwrite_x (bool): If True, the contents of ``x`` can be destroyed.
         plan (cupy.cuda.cufft.Plan1d): a cuFFT plan for transforming ``x``
-            over ``axis``, which can be obtained using
+            over ``axis``, which can be obtained using::
 
                 plan = cupyx.scipy.fftpack.get_fft_plan(x, axis)
 
@@ -163,7 +163,7 @@ def fft2(x, shape=None, axes=(-2, -1), overwrite_x=False, plan=None):
         axes (tuple of ints): Axes over which to compute the FFT.
         overwrite_x (bool): If True, the contents of ``x`` can be destroyed.
         plan (cupy.cuda.cufft.PlanNd): a cuFFT plan for transforming ``x``
-            over ``axes``, which can be obtained using
+            over ``axes``, which can be obtained using::
 
                 plan = cupyx.scipy.fftpack.get_fft_plan(x, axes)
 
@@ -195,7 +195,7 @@ def ifft2(x, shape=None, axes=(-2, -1), overwrite_x=False, plan=None):
         axes (tuple of ints): Axes over which to compute the FFT.
         overwrite_x (bool): If True, the contents of ``x`` can be destroyed.
         plan (cupy.cuda.cufft.PlanNd): a cuFFT plan for transforming ``x``
-            over ``axes``, which can be obtained using
+            over ``axes``, which can be obtained using::
 
                 plan = cupyx.scipy.fftpack.get_fft_plan(x, axes)
 
@@ -227,7 +227,7 @@ def fftn(x, shape=None, axes=None, overwrite_x=False, plan=None):
         axes (tuple of ints): Axes over which to compute the FFT.
         overwrite_x (bool): If True, the contents of ``x`` can be destroyed.
         plan (cupy.cuda.cufft.PlanNd): a cuFFT plan for transforming ``x``
-            over ``axes``, which can be obtained using
+            over ``axes``, which can be obtained using::
 
                 plan = cupyx.scipy.fftpack.get_fft_plan(x, axes)
 
@@ -259,7 +259,7 @@ def ifftn(x, shape=None, axes=None, overwrite_x=False, plan=None):
         axes (tuple of ints): Axes over which to compute the FFT.
         overwrite_x (bool): If True, the contents of ``x`` can be destroyed.
         plan (cupy.cuda.cufft.PlanNd): a cuFFT plan for transforming ``x``
-            over ``axes``, which can be obtained using
+            over ``axes``, which can be obtained using::
 
                 plan = cupyx.scipy.fftpack.get_fft_plan(x, axes)
 

--- a/cupyx/scipy/fftpack/fft.py
+++ b/cupyx/scipy/fftpack/fft.py
@@ -28,11 +28,6 @@ def get_fft_plan(a, shape=None, axes=None, value_type='C2C'):
         plan: a cuFFT plan for either 1D transform (cupy.cuda.cufft.Plan1d)
             or N-D transform (cupy.cuda.cufft.PlanNd).
     """
-    # check value_type
-    fft_type = _convert_fft_type(a, value_type)
-    if fft_type not in [cufft.CUFFT_C2C, cufft.CUFFT_Z2Z]:
-        raise NotImplementedError("Only C2C and Z2Z are supported.")
-
     # check input array
     if a.flags.c_contiguous:
         order = 'C'

--- a/cupyx/scipy/fftpack/fft.py
+++ b/cupyx/scipy/fftpack/fft.py
@@ -1,3 +1,4 @@
+from numpy import prod
 import cupy
 from cupy.cuda import cufft
 from cupy.fft.fft import (_fft, _default_fft_func, _convert_fft_type,
@@ -62,6 +63,8 @@ def get_fft_plan(a, shape=None, axes=None, value_type='C2C'):
             raise ValueError("Only up to three axes is supported")
 
     # check shape
+    if isinstance(shape, int):
+        shape = (shape,)
     if (shape is not None) and len(shape) != n:
         raise ValueError("Shape and axes have different lengths.")
     # Note that "shape" here refers to the shape along trasformed axes, not
@@ -85,7 +88,7 @@ def get_fft_plan(a, shape=None, axes=None, value_type='C2C'):
         plan = _get_cufft_plan_nd(shape, fft_type, axes=axes, order=order)
     else:  # 1D transform
         out_size = shape[axis1D]
-        batch = np.prod(shape) // out_size
+        batch = prod(shape) // out_size
         plan = cufft.Plan1d(out_size, fft_type, batch)
 
     return plan

--- a/cupyx/scipy/fftpack/fft.py
+++ b/cupyx/scipy/fftpack/fft.py
@@ -79,12 +79,12 @@ def get_fft_plan(a, shape=None, axes=None, value_type='C2C'):
 
     # check value_type
     fft_type = _convert_fft_type(a, value_type)
-    if n>1 and fft_type not in [cufft.CUFFT_C2C, cufft.CUFFT_Z2Z]:
+    if n > 1 and fft_type not in [cufft.CUFFT_C2C, cufft.CUFFT_Z2Z]:
         raise NotImplementedError("Only C2C and Z2Z are supported for N-dim"
                                   " transform.")
 
     # generate plan
-    if n>1:  # ND transform
+    if n > 1:  # ND transform
         plan = _get_cufft_plan_nd(shape, fft_type, axes=axes, order=order)
     else:  # 1D transform
         out_size = shape[axis1D]

--- a/cupyx/scipy/fftpack/fft.py
+++ b/cupyx/scipy/fftpack/fft.py
@@ -14,15 +14,23 @@ def get_fft_plan(a, shape=None, axes=None, value_type='C2C'):
             output. If ``shape`` is not given, the lengths of the input along
             the axes specified by ``axes`` are used.
         axes (None or int or tuple of int):  The axes of the array to
-            transform. Currently, these must be a set of up to three adjacent
-            axes and must include either the first or the last axis of the
-            array.  If `None`, it is assumed that all axes are transformed.
+            transform. If `None`, it is assumed that all axes are transformed.
+
+            Currently, for performing N-D transform these must be a set of up
+            to three adjacent axes, and must include either the first or the
+            last axis of the array.
         value_type ('C2C'): The FFT type to perform.
             Currently only complex-to-complex transforms are supported.
 
     Returns:
-        plan (cupy.cuda.cufft.PlanNd): The cuFFT Plan.
+        plan: a cuFFT plan for either 1D transform (cupy.cuda.cufft.Plan1d)
+            or N-D transform (cupy.cuda.cufft.PlanNd).
     """
+    # check value_type
+    fft_type = _convert_fft_type(a, value_type)
+    if fft_type not in [cufft.CUFFT_C2C, cufft.CUFFT_Z2Z]:
+        raise NotImplementedError("Only C2C and Z2Z are supported.")
+
     # check input array
     if a.flags.c_contiguous:
         order = 'C'

--- a/cupyx/scipy/fftpack/fft.py
+++ b/cupyx/scipy/fftpack/fft.py
@@ -6,7 +6,6 @@ from cupy.fft.fft import (_fft, _default_fft_func, _convert_fft_type,
 
 def get_fft_plan(a, shape=None, axes=None, value_type='C2C'):
     """ Generate a CUDA FFT plan for transforming up to three axes.
-        This is a convenient handle to cupy.fft.fft._get_cufft_plan_nd.
 
     Args:
         a (cupy.ndarray): Array to be transform, assumed to be either C- or
@@ -24,10 +23,7 @@ def get_fft_plan(a, shape=None, axes=None, value_type='C2C'):
     Returns:
         plan (cupy.cuda.cufft.PlanNd): The cuFFT Plan.
     """
-    fft_type = _convert_fft_type(a, value_type)
-    if fft_type not in [cufft.CUFFT_C2C, cufft.CUFFT_Z2Z]:
-        raise NotImplementedError("Only C2C and Z2Z are supported.")
-
+    # check input array
     if a.flags.c_contiguous:
         order = 'C'
     elif a.flags.f_contiguous:
@@ -35,32 +31,59 @@ def get_fft_plan(a, shape=None, axes=None, value_type='C2C'):
     else:
         raise ValueError("Input array a must be contiguous")
 
-    if (shape is not None) and (axes is not None) and len(shape) != len(axes):
-        raise ValueError("Shape and axes have different lengths.")
-    if (shape is not None) and (axes is None) and len(shape) != a.ndim:
-        raise ValueError("Shape and axes have different lengths.")
-    if (shape is None) and (axes is not None) and (len(axes) > a.ndim):
-        raise ValueError("The number of axes exceeds a.ndim.")
-    # let _get_cufft_plan_nd() check (shape is None and axes is None)
+    # check axes
+    # n=1: 1d (need axis1D); n>1: Nd
+    if axes is None:
+        n = a.ndim
+        axes = tuple(i for i in range(n))
+        if n == 1:
+            axis1D = 0
+    elif isinstance(axes, int):
+        n = 1
+        axis1D = axes
+        axes = (axes,)
+        if axis1D >= a.ndim or axis1D < -a.ndim:
+            raise ValueError("Invalid input: a has dimension {0} but you "
+                             "choose the axis {1} to be transformed."
+                             .format(a.ndim, axis1D))
+    else:  # axes is a tuple
+        n = len(axes)
+        if n == 1:
+            axis1D = axes[0]
+        elif n > 3:
+            raise ValueError("Only up to three axes is supported")
 
+    # check shape
+    if (shape is not None) and len(shape) != n:
+        raise ValueError("Shape and axes have different lengths.")
     # Note that "shape" here refers to the shape along trasformed axes, not
     # the shape of the output array, and we need to convert it to the latter.
     # The result is as if "a=_cook_shape(a); return a.shape" is called.
     transformed_shape = shape
     shape = list(a.shape)
     if transformed_shape is not None:
-        if axes is None:
-            axes = [i for i in range(a.ndim)]
         for s, axis in zip(transformed_shape, axes):
             shape[axis] = s
     shape = tuple(shape)
 
-    plan = _get_cufft_plan_nd(shape, fft_type, axes=axes, order=order)
+    # check value_type
+    fft_type = _convert_fft_type(a, value_type)
+    if n>1 and fft_type not in [cufft.CUFFT_C2C, cufft.CUFFT_Z2Z]:
+        raise NotImplementedError("Only C2C and Z2Z are supported for N-dim"
+                                  " transform.")
+
+    # generate plan
+    if n>1:  # ND transform
+        plan = _get_cufft_plan_nd(shape, fft_type, axes=axes, order=order)
+    else:  # 1D transform
+        out_size = shape[axis1D]
+        batch = np.prod(shape) // out_size
+        plan = cufft.Plan1d(out_size, fft_type, batch)
 
     return plan
 
 
-def fft(x, n=None, axis=-1, overwrite_x=False):
+def fft(x, n=None, axis=-1, overwrite_x=False, plan=None):
     """Compute the one-dimensional FFT.
 
     Args:
@@ -70,6 +93,13 @@ def fft(x, n=None, axis=-1, overwrite_x=False):
             ``axis`` is used.
         axis (int): Axis over which to compute the FFT.
         overwrite_x (bool): If True, the contents of ``x`` can be destroyed.
+        plan (cupy.cuda.cufft.Plan1d): a cuFFT plan for transforming ``x``
+            over ``axis``, which can be obtained using
+
+                plan = cupyx.scipy.fftpack.get_fft_plan(x, axis)
+
+            Note that `plan` is defaulted to None, meaning CuPy will use an
+            auto-generated plan behind the scene.
 
     Returns:
         cupy.ndarray:
@@ -79,10 +109,10 @@ def fft(x, n=None, axis=-1, overwrite_x=False):
     .. seealso:: :func:`scipy.fftpack.fft`
     """
     return _fft(x, (n,), (axis,), None, cufft.CUFFT_FORWARD,
-                overwrite_x=overwrite_x)
+                overwrite_x=overwrite_x, plan=plan)
 
 
-def ifft(x, n=None, axis=-1, overwrite_x=False):
+def ifft(x, n=None, axis=-1, overwrite_x=False, plan=None):
     """Compute the one-dimensional inverse FFT.
 
     Args:
@@ -92,6 +122,13 @@ def ifft(x, n=None, axis=-1, overwrite_x=False):
             ``axis`` is used.
         axis (int): Axis over which to compute the FFT.
         overwrite_x (bool): If True, the contents of ``x`` can be destroyed.
+        plan (cupy.cuda.cufft.Plan1d): a cuFFT plan for transforming ``x``
+            over ``axis``, which can be obtained using
+
+                plan = cupyx.scipy.fftpack.get_fft_plan(x, axis)
+
+            Note that `plan` is defaulted to None, meaning CuPy will use an
+            auto-generated plan behind the scene.
 
     Returns:
         cupy.ndarray:
@@ -101,7 +138,7 @@ def ifft(x, n=None, axis=-1, overwrite_x=False):
     .. seealso:: :func:`scipy.fftpack.ifft`
     """
     return _fft(x, (n,), (axis,), None, cufft.CUFFT_INVERSE,
-                overwrite_x=overwrite_x)
+                overwrite_x=overwrite_x, plan=plan)
 
 
 def fft2(x, shape=None, axes=(-2, -1), overwrite_x=False, plan=None):

--- a/cupyx/scipy/fftpack/fft.py
+++ b/cupyx/scipy/fftpack/fft.py
@@ -112,6 +112,10 @@ def fft(x, n=None, axis=-1, overwrite_x=False, plan=None):
             The transformed array which shape is specified by ``n`` and type
             will convert to complex if that of the input is another.
 
+    .. note::
+       The argument `plan` is currently experimental and the interface may be
+       changed in the future version.
+
     .. seealso:: :func:`scipy.fftpack.fft`
     """
     return _fft(x, (n,), (axis,), None, cufft.CUFFT_FORWARD,
@@ -140,6 +144,10 @@ def ifft(x, n=None, axis=-1, overwrite_x=False, plan=None):
         cupy.ndarray:
             The transformed array which shape is specified by ``n`` and type
             will convert to complex if that of the input is another.
+
+    .. note::
+       The argument `plan` is currently experimental and the interface may be
+       changed in the future version.
 
     .. seealso:: :func:`scipy.fftpack.ifft`
     """

--- a/tests/cupyx_tests/scipy_tests/fftpack_tests/test_fftpack.py
+++ b/tests/cupyx_tests/scipy_tests/fftpack_tests/test_fftpack.py
@@ -118,10 +118,10 @@ class TestFft(unittest.TestCase):
         if scp is cupyx.scipy:
             plan = scp.fftpack.get_fft_plan(x, shape=self.n, axes=self.axis)
             x = scp.fftpack.ifft(x, n=self.n, axis=self.axis,
-                             overwrite_x=True, plan=plan)
+                                 overwrite_x=True, plan=plan)
         else:  # scipy
             x = scp.fftpack.ifft(x, n=self.n, axis=self.axis,
-                             overwrite_x=True)
+                                 overwrite_x=True)
         return x
 
 

--- a/tests/cupyx_tests/scipy_tests/fftpack_tests/test_fftpack.py
+++ b/tests/cupyx_tests/scipy_tests/fftpack_tests/test_fftpack.py
@@ -34,6 +34,34 @@ class TestFft(unittest.TestCase):
         return scp.fftpack.fft(x, n=self.n, axis=self.axis,
                                overwrite_x=True)
 
+    @testing.for_complex_dtypes()
+    @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
+                                 contiguous_check=False, scipy_name='scp')
+    def test_fft_plan(self, xp, scp, dtype):
+        x = testing.shaped_random(self.shape, xp, dtype)
+        x_orig = x.copy()
+        if isinstance(scp, cupyx.scipy):
+            plan = scp.fftpack.get_fft_plan(x)
+            out = scp.fftpack.fft(x, shape=self.s, axes=self.axes, plan=plan)
+        else:  # scipy
+            out = scp.fftpack.fft(x, shape=self.s, axes=self.axes)
+        testing.assert_array_equal(x, x_orig)
+        return out
+
+    @testing.for_complex_dtypes()
+    @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
+                                 contiguous_check=False, scipy_name='scp')
+    def test_fft_overwrite_plan(self, xp, scp, dtype):
+        x = testing.shaped_random(self.shape, xp, dtype)
+        if isinstance(scp, cupyx.scipy):
+            plan = scp.fftpack.get_fft_plan(x)
+            scp.fftpack.fft(x, shape=self.s, axes=self.axes,
+                             overwrite_x=True, plan=plan)
+        else:  # scipy
+            scp.fftpack.fft(x, shape=self.s, axes=self.axes,
+                             overwrite_x=True)
+        return x
+
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
                                  contiguous_check=False, scipy_name='scp')
@@ -51,6 +79,34 @@ class TestFft(unittest.TestCase):
         x = testing.shaped_random(self.shape, xp, dtype)
         return scp.fftpack.ifft(x, n=self.n, axis=self.axis,
                                 overwrite_x=True)
+
+    @testing.for_complex_dtypes()
+    @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
+                                 contiguous_check=False, scipy_name='scp')
+    def test_ifft_plan(self, xp, scp, dtype):
+        x = testing.shaped_random(self.shape, xp, dtype)
+        x_orig = x.copy()
+        if isinstance(scp, cupyx.scipy):
+            plan = scp.fftpack.get_fft_plan(x)
+            out = scp.fftpack.ifft(x, shape=self.s, axes=self.axes, plan=plan)
+        else:  # scipy
+            out = scp.fftpack.ifft(x, shape=self.s, axes=self.axes)
+        testing.assert_array_equal(x, x_orig)
+        return out
+
+    @testing.for_complex_dtypes()
+    @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
+                                 contiguous_check=False, scipy_name='scp')
+    def test_ifft_overwrite_plan(self, xp, scp, dtype):
+        x = testing.shaped_random(self.shape, xp, dtype)
+        if isinstance(scp, cupyx.scipy):
+            plan = scp.fftpack.get_fft_plan(x)
+            scp.fftpack.ifft(x, shape=self.s, axes=self.axes,
+                             overwrite_x=True, plan=plan)
+        else:  # scipy
+            scp.fftpack.ifft(x, shape=self.s, axes=self.axes,
+                             overwrite_x=True)
+        return x
 
 
 @testing.parameterize(

--- a/tests/cupyx_tests/scipy_tests/fftpack_tests/test_fftpack.py
+++ b/tests/cupyx_tests/scipy_tests/fftpack_tests/test_fftpack.py
@@ -39,12 +39,16 @@ class TestFft(unittest.TestCase):
                                  contiguous_check=False, scipy_name='scp')
     def test_fft_plan(self, xp, scp, dtype):
         x = testing.shaped_random(self.shape, xp, dtype)
+        # hack: avoid testing the cases when the output array is of size 0
+        # because cuFFT and numpy raise different kinds of exceptions
+        if self.n == 0:
+            return x
         x_orig = x.copy()
-        if isinstance(scp, cupyx.scipy):
-            plan = scp.fftpack.get_fft_plan(x)
-            out = scp.fftpack.fft(x, shape=self.s, axes=self.axes, plan=plan)
+        if scp is cupyx.scipy:
+            plan = scp.fftpack.get_fft_plan(x, shape=self.n, axes=self.axis)
+            out = scp.fftpack.fft(x, n=self.n, axis=self.axis, plan=plan)
         else:  # scipy
-            out = scp.fftpack.fft(x, shape=self.s, axes=self.axes)
+            out = scp.fftpack.fft(x, n=self.n, axis=self.axis)
         testing.assert_array_equal(x, x_orig)
         return out
 
@@ -53,13 +57,17 @@ class TestFft(unittest.TestCase):
                                  contiguous_check=False, scipy_name='scp')
     def test_fft_overwrite_plan(self, xp, scp, dtype):
         x = testing.shaped_random(self.shape, xp, dtype)
-        if isinstance(scp, cupyx.scipy):
-            plan = scp.fftpack.get_fft_plan(x)
-            scp.fftpack.fft(x, shape=self.s, axes=self.axes,
-                             overwrite_x=True, plan=plan)
+        # hack: avoid testing the cases when the output array is of size 0
+        # because cuFFT and numpy raise different kinds of exceptions
+        if self.n == 0:
+            return x
+        if scp is cupyx.scipy:
+            plan = scp.fftpack.get_fft_plan(x, shape=self.n, axes=self.axis)
+            x = scp.fftpack.fft(x, n=self.n, axis=self.axis,
+                                overwrite_x=True, plan=plan)
         else:  # scipy
-            scp.fftpack.fft(x, shape=self.s, axes=self.axes,
-                             overwrite_x=True)
+            x = scp.fftpack.fft(x, n=self.n, axis=self.axis,
+                                overwrite_x=True)
         return x
 
     @testing.for_all_dtypes()
@@ -85,12 +93,16 @@ class TestFft(unittest.TestCase):
                                  contiguous_check=False, scipy_name='scp')
     def test_ifft_plan(self, xp, scp, dtype):
         x = testing.shaped_random(self.shape, xp, dtype)
+        # hack: avoid testing the cases when the output array is of size 0
+        # because cuFFT and numpy raise different kinds of exceptions
+        if self.n == 0:
+            return x
         x_orig = x.copy()
-        if isinstance(scp, cupyx.scipy):
-            plan = scp.fftpack.get_fft_plan(x)
-            out = scp.fftpack.ifft(x, shape=self.s, axes=self.axes, plan=plan)
+        if scp is cupyx.scipy:
+            plan = scp.fftpack.get_fft_plan(x, shape=self.n, axes=self.axis)
+            out = scp.fftpack.ifft(x, n=self.n, axis=self.axis, plan=plan)
         else:  # scipy
-            out = scp.fftpack.ifft(x, shape=self.s, axes=self.axes)
+            out = scp.fftpack.ifft(x, n=self.n, axis=self.axis)
         testing.assert_array_equal(x, x_orig)
         return out
 
@@ -99,12 +111,16 @@ class TestFft(unittest.TestCase):
                                  contiguous_check=False, scipy_name='scp')
     def test_ifft_overwrite_plan(self, xp, scp, dtype):
         x = testing.shaped_random(self.shape, xp, dtype)
-        if isinstance(scp, cupyx.scipy):
-            plan = scp.fftpack.get_fft_plan(x)
-            scp.fftpack.ifft(x, shape=self.s, axes=self.axes,
+        # hack: avoid testing the cases when the output array is of size 0
+        # because cuFFT and numpy raise different kinds of exceptions
+        if self.n == 0:
+            return x
+        if scp is cupyx.scipy:
+            plan = scp.fftpack.get_fft_plan(x, shape=self.n, axes=self.axis)
+            x = scp.fftpack.ifft(x, n=self.n, axis=self.axis,
                              overwrite_x=True, plan=plan)
         else:  # scipy
-            scp.fftpack.ifft(x, shape=self.s, axes=self.axes,
+            x = scp.fftpack.ifft(x, n=self.n, axis=self.axis,
                              overwrite_x=True)
         return x
 


### PR DESCRIPTION
This is an accompanying PR with #1942 to address the performance issue discussed in #1669. In this PR I changed the signatures for the following functions:

* `cupyx.scipy.fftpack.fft`
* `cupyx.scipy.fftpack.ifft`

so that they accept a `plan` argument (defaulted to `None`). Another change is made to `cupyx.scipy.fftpack.get_fft_plan`, introduced #1942, so that it can return either a cuFFT `Plan1d` or `PlanNd` --- this is a design choice that I'd like to have feedbacks from @grlee77 and perhaps @asi1024. Thanks.