### PR TITLE
Fix incorrect `dtype` for `ipiv` buffer in `cupy.linalg.inv`

### DIFF
--- a/cupy/linalg/solve.py
+++ b/cupy/linalg/solve.py
@@ -201,7 +201,7 @@ def inv(a):
     cusolver_handle = device.get_cusolver_handle()
     dev_info = cupy.empty(1, dtype=dtype)
 
-    ipiv = cupy.empty((a.shape[0], 1), dtype=dtype)
+    ipiv = cupy.empty((a.shape[0], 1), dtype=numpy.intc)
 
     if dtype == 'f':
         getrf = cusolver.sgetrf


### PR DESCRIPTION
The `ipiv` parameter of `sgetrf`/`dgetrf` function is declared to be a pointer to int array, but the current implementation allocates a buffer ndarray with `'f'` or `'d'` dtype.

It is safe on all platforms supported by CUDA, because `sizeof(int) <= sizeof(float)` on those platforms. But allocated buffer is larger than necessary in the `dgetrf` case on those platforms, since `sizeof(double)` is larger than `sizeof(int)`.

I'm not sure which of `numpy.intc` or `numpy.int32` is more appropriate for the purpose.