### PR TITLE
Suppress `UserWarning` in cupy/random/generator.py

### DIFF
--- a/cupy/random/generator.py
+++ b/cupy/random/generator.py
@@ -87,7 +87,8 @@ class RandomState(object):
             size = cupy.broadcast(a, b).shape
         y = cupy.empty(shape=size, dtype=dtype)
         _kernels.beta_kernel(a, b, self.rk_seed, y)
-        self.rk_seed += numpy.prod(y.size, dtype=self.rk_seed.dtype)
+        with numpy.errstate(over='ignore'):
+            self.rk_seed += numpy.prod(y.size, dtype=self.rk_seed.dtype)
         return y
 
     def binomial(self, n, p, size=None, dtype=int):
@@ -102,7 +103,8 @@ class RandomState(object):
             size = cupy.broadcast(n, p).shape
         y = cupy.empty(shape=size, dtype=dtype)
         _kernels.binomial_kernel(n, p, self.rk_seed, y)
-        self.rk_seed += numpy.prod(y.size, dtype=self.rk_seed.dtype)
+        with numpy.errstate(over='ignore'):
+            self.rk_seed += numpy.prod(y.size, dtype=self.rk_seed.dtype)
         return y
 
     def chisquare(self, df, size=None, dtype=float):
@@ -117,7 +119,8 @@ class RandomState(object):
             size = df.shape
         y = cupy.empty(shape=size, dtype=dtype)
         _kernels.chisquare_kernel(df, self.rk_seed, y)
-        self.rk_seed += numpy.prod(size, dtype=self.rk_seed.dtype)
+        with numpy.errstate(over='ignore'):
+            self.rk_seed += numpy.prod(size, dtype=self.rk_seed.dtype)
         return y
 
     def dirichlet(self, alpha, size=None, dtype=float):
@@ -135,7 +138,8 @@ class RandomState(object):
         y = cupy.empty(shape=size, dtype=dtype)
         _kernels.standard_gamma_kernel(alpha, self.rk_seed, y)
         y /= y.sum(axis=-1, keepdims=True)
-        self.rk_seed += numpy.prod(size, dtype=self.rk_seed.dtype)
+        with numpy.errstate(over='ignore'):
+            self.rk_seed += numpy.prod(size, dtype=self.rk_seed.dtype)
         return y
 
     def exponential(self, scale=1.0, size=None, dtype=float):
@@ -166,7 +170,8 @@ class RandomState(object):
             size = cupy.broadcast(dfnum, dfden).shape
         y = cupy.empty(shape=size, dtype=dtype)
         _kernels.f_kernel(dfnum, dfden, self.rk_seed, y)
-        self.rk_seed += numpy.prod(size, dtype=self.rk_seed.dtype)
+        with numpy.errstate(over='ignore'):
+            self.rk_seed += numpy.prod(size, dtype=self.rk_seed.dtype)
         return y
 
     def gamma(self, shape, scale=1.0, size=None, dtype=float):
@@ -182,7 +187,8 @@ class RandomState(object):
         y = cupy.empty(shape=size, dtype=dtype)
         _kernels.standard_gamma_kernel(shape, self.rk_seed, y)
         y *= scale
-        self.rk_seed += numpy.prod(size, dtype=self.rk_seed.dtype)
+        with numpy.errstate(over='ignore'):
+            self.rk_seed += numpy.prod(size, dtype=self.rk_seed.dtype)
         return y
 
     def geometric(self, p, size=None, dtype=int):
@@ -197,7 +203,8 @@ class RandomState(object):
             size = p.shape
         y = cupy.empty(shape=size, dtype=dtype)
         _kernels.geometric_kernel(p, self.rk_seed, y)
-        self.rk_seed += numpy.prod(size, dtype=self.rk_seed.dtype)
+        with numpy.errstate(over='ignore'):
+            self.rk_seed += numpy.prod(size, dtype=self.rk_seed.dtype)
         return y
 
     def hypergeometric(self, ngood, nbad, nsample, size=None, dtype=int):
@@ -213,7 +220,8 @@ class RandomState(object):
             size = cupy.broadcast(ngood, nbad, nsample).shape
         y = cupy.empty(shape=size, dtype=dtype)
         _kernels.hypergeometric_kernel(ngood, nbad, nsample, self.rk_seed, y)
-        self.rk_seed += numpy.prod(size, dtype=self.rk_seed.dtype)
+        with numpy.errstate(over='ignore'):
+            self.rk_seed += numpy.prod(size, dtype=self.rk_seed.dtype)
         return y
 
     _laplace_kernel = core.ElementwiseKernel(
@@ -248,7 +256,8 @@ class RandomState(object):
             size = cupy.broadcast(loc, scale).shape
         x = cupy.empty(shape=size, dtype=dtype)
         _kernels.open_uniform_kernel(self.rk_seed, x)
-        self.rk_seed += numpy.prod(size, dtype=self.rk_seed.dtype)
+        with numpy.errstate(over='ignore'):
+            self.rk_seed += numpy.prod(size, dtype=self.rk_seed.dtype)
         x = (1.0 - x) / x
         cupy.log(x, out=x)
         cupy.multiply(x, scale, out=x)
@@ -287,7 +296,8 @@ class RandomState(object):
             size = p.shape
         y = cupy.empty(shape=size, dtype=dtype)
         _kernels.logseries_kernel(p, self.rk_seed, y)
-        self.rk_seed += numpy.prod(size, dtype=self.rk_seed.dtype)
+        with numpy.errstate(over='ignore'):
+            self.rk_seed += numpy.prod(size, dtype=self.rk_seed.dtype)
         return y
 
     def multivariate_normal(self, mean, cov, size=None, check_valid='ignore',
@@ -405,7 +415,8 @@ class RandomState(object):
             size = cupy.broadcast(df, nonc).shape
         y = cupy.empty(shape=size, dtype=dtype)
         _kernels.noncentral_chisquare_kernel(df, nonc, self.rk_seed, y)
-        self.rk_seed += numpy.prod(size, dtype=self.rk_seed.dtype)
+        with numpy.errstate(over='ignore'):
+            self.rk_seed += numpy.prod(size, dtype=self.rk_seed.dtype)
         return y
 
     def noncentral_f(self, dfnum, dfden, nonc, size=None, dtype=float):
@@ -427,7 +438,8 @@ class RandomState(object):
             size = cupy.broadcast(dfnum, dfden, nonc).shape
         y = cupy.empty(shape=size, dtype=dtype)
         _kernels.noncentral_f_kernel(dfnum, dfden, nonc, self.rk_seed, y)
-        self.rk_seed += numpy.prod(size, dtype=self.rk_seed.dtype)
+        with numpy.errstate(over='ignore'):
+            self.rk_seed += numpy.prod(size, dtype=self.rk_seed.dtype)
         return y
 
     def poisson(self, lam=1.0, size=None, dtype=int):
@@ -442,7 +454,8 @@ class RandomState(object):
             size = lam.shape
         y = cupy.empty(shape=size, dtype=dtype)
         _kernels.poisson_kernel(lam, self.rk_seed, y)
-        self.rk_seed += numpy.prod(size, dtype=self.rk_seed.dtype)
+        with numpy.errstate(over='ignore'):
+            self.rk_seed += numpy.prod(size, dtype=self.rk_seed.dtype)
         return y
 
     def power(self, a, size=None, dtype=float):
@@ -664,7 +677,8 @@ class RandomState(object):
             size = shape.shape
         y = cupy.empty(shape=size, dtype=dtype)
         _kernels.standard_gamma_kernel(shape, self.rk_seed, y)
-        self.rk_seed += numpy.prod(size, dtype=self.rk_seed.dtype)
+        with numpy.errstate(over='ignore'):
+            self.rk_seed += numpy.prod(size, dtype=self.rk_seed.dtype)
         return y
 
     def standard_normal(self, size=None, dtype=float):
@@ -689,7 +703,8 @@ class RandomState(object):
             size = df.shape
         y = cupy.empty(shape=size, dtype=dtype)
         _kernels.standard_t_kernel(df, self.rk_seed, y)
-        self.rk_seed += numpy.prod(size, dtype=self.rk_seed.dtype)
+        with numpy.errstate(over='ignore'):
+            self.rk_seed += numpy.prod(size, dtype=self.rk_seed.dtype)
         return y
 
     def tomaxint(self, size=None):
@@ -792,7 +807,8 @@ class RandomState(object):
             size = cupy.broadcast(mu, kappa).shape
         y = cupy.empty(shape=size, dtype=dtype)
         _kernels.vonmises_kernel(mu, kappa, self.rk_seed, y)
-        self.rk_seed += numpy.prod(size, dtype=self.rk_seed.dtype)
+        with numpy.errstate(over='ignore'):
+            self.rk_seed += numpy.prod(size, dtype=self.rk_seed.dtype)
         return y
 
     _wald_kernel = core.ElementwiseKernel(
@@ -853,7 +869,8 @@ class RandomState(object):
             size = a.shape
         y = cupy.empty(shape=size, dtype=dtype)
         _kernels.zipf_kernel(a, self.rk_seed, y)
-        self.rk_seed += numpy.prod(size, dtype=self.rk_seed.dtype)
+        with numpy.errstate(over='ignore'):
+            self.rk_seed += numpy.prod(size, dtype=self.rk_seed.dtype)
         return y
 
     def choice(self, a, size=None, replace=True, p=None):


### PR DESCRIPTION
Fix #2042

Before:
```before.py
>>> import numpy, cupy
>>> cupy.random.seed(numpy.uint64(numpy.iinfo(numpy.uint64).max))
>>> cupy.random.gamma(1, 1)
/home/hashimoto/.local/source/cupy/cupy/random/generator.py:185: RuntimeWarning: overflow encountered in ulong_scalars
  self.rk_seed += numpy.prod(size, dtype=self.rk_seed.dtype)
array(1.89141704)
```

After:
```after.py
>>> import numpy, cupy
>>> cupy.random.seed(numpy.uint64(numpy.iinfo(numpy.uint64).max))
>>> cupy.random.gamma(1, 1)
array(1.89141704)
```