### PR TITLE
fix cupyx.scipy.get_array_module's docstring

### DIFF
--- a/cupyx/scipy/__init__.py
+++ b/cupyx/scipy/__init__.py
@@ -18,7 +18,7 @@ def get_array_module(*args):
     """Returns the array module for arguments.
 
     This function is used to implement CPU/GPU generic code. If at least one of
-    the arguments is a :class:`cupy.ndarray` object, the :mod:`cupy` module is
+    the arguments is a :class:`cupy.ndarray` object, the :mod:`cupyx.scipy` module is
     returned.
 
     Args:

--- a/cupyx/scipy/__init__.py
+++ b/cupyx/scipy/__init__.py
@@ -18,8 +18,8 @@ def get_array_module(*args):
     """Returns the array module for arguments.
 
     This function is used to implement CPU/GPU generic code. If at least one of
-    the arguments is a :class:`cupy.ndarray` object, the :mod:`cupyx.scipy` module is
-    returned.
+    the arguments is a :class:`cupy.ndarray` object, the :mod:`cupyx.scipy`
+    module is returned.
 
     Args:
         args: Values to determine whether NumPy or CuPy should be used.


### PR DESCRIPTION
It says that the function returns `cupy` module, but in fact it returns `cupyx.scipy` module.