### PR TITLE
Add `lu_factor` and `lu_solve` to `cupyx.scipy.linalg`

### DIFF
--- a/cupyx/scipy/linalg/__init__.py
+++ b/cupyx/scipy/linalg/__init__.py
@@ -1,1 +1,2 @@
 from cupyx.scipy.linalg.solve_triangular import solve_triangular  # NOQA
+from cupyx.scipy.linalg.decomp_lu import lu_factor, lu_solve  # NOQA

--- a/cupyx/scipy/linalg/decomp_lu.py
+++ b/cupyx/scipy/linalg/decomp_lu.py
@@ -42,7 +42,7 @@ def lu_factor(a, overwrite_a=False, check_finite=True):
     if not cuda.cusolver_enabled:
         raise RuntimeError('Current cupy only supports cusolver in CUDA 8.0')
 
-    util._assert_cupy_array(a)
+    a = cupy.asarray(a)
     util._assert_rank2(a)
     util._assert_nd_squareness(a)
 

--- a/cupyx/scipy/linalg/decomp_lu.py
+++ b/cupyx/scipy/linalg/decomp_lu.py
@@ -74,7 +74,7 @@ Singular matrix.
 
     dtype = a.dtype
 
-    if dtype == 'f':
+    if dtype.char == 'f':
         getrf = cusolver.sgetrf
         getrf_bufferSize = cusolver.sgetrf_bufferSize
     elif dtype.char == 'd':
@@ -162,7 +162,7 @@ def lu_solve(lu_and_piv, b, trans=0, overwrite_b=False, check_finite=True):
         raise ValueError('incompatible dimensions.')
 
     dtype = lu.dtype
-    if dtype == 'f':
+    if dtype.char == 'f':
         getrs = cusolver.sgetrs
     elif dtype.char == 'd':
         getrs = cusolver.dgetrs

--- a/cupyx/scipy/linalg/decomp_lu.py
+++ b/cupyx/scipy/linalg/decomp_lu.py
@@ -19,7 +19,8 @@ def lu_factor(a, overwrite_a=False, check_finite=True):
     where ``P`` is a permutation matrix,  ``L`` lower-triangular with
     unit diagonal elements, and ``U`` upper-triangular matrix.
     Note that in the current implementation ``a`` must be
-    a real matrix, and only float32 and float64 are supported.
+    a real matrix, and only :class:`numpy.float32` and :class:`numpy.float64`
+    are supported.
 
     Args:
         a (cupy.ndarray): The input matrix with dimension ``(N, N)``

--- a/cupyx/scipy/linalg/decomp_lu.py
+++ b/cupyx/scipy/linalg/decomp_lu.py
@@ -39,6 +39,30 @@ def lu_factor(a, overwrite_a=False, check_finite=True):
             permutation matrix ``P``.
 
     .. seealso:: :func:`scipy.linalg.lu_factor`
+
+    .. note::
+
+        Current implementation returns result different from SciPy when the
+        matrix singular. SciPy returns an array containing ``0.`` while the
+        current implementation returns an array containing ``nan``.
+
+        >>> import numpy as np
+        >>> import scipy.linalg
+        >>> scipy.linalg.lu_factor(np.array([[0, 1], [0, 0]], \
+dtype=np.float32))
+        __main__:1: LinAlgWarning: Diagonal number 1 is exactly zero. \
+Singular matrix.
+        (array([[0., 1.],
+               [0., 0.]], dtype=float32), array([0, 1], dtype=int32))
+
+        >>> import cupy as cp
+        >>> import cupyx.scipy.linalg
+        >>> cupyx.scipy.linalg.lu_factor(cp.array([[0, 1], [0, 0]], \
+dtype=cp.float32))
+        __main__:1: RuntimeWarning: Diagonal number 1 is exactly zero. \
+Singular matrix.
+        (array([[ 0.,  1.],
+               [nan, nan]], dtype=float32), array([0, 1], dtype=int32))
     """
 
     if not cuda.cusolver_enabled:

--- a/cupyx/scipy/linalg/decomp_lu.py
+++ b/cupyx/scipy/linalg/decomp_lu.py
@@ -187,7 +187,10 @@ def lu_solve(lu_and_piv, b, trans=0, overwrite_b=False, check_finite=True):
     if check_finite:
         if lu.dtype.kind == 'f' and not cupy.isfinite(lu).all():
             raise ValueError(
-                'array must not contain infs or NaNs')
+                'array must not contain infs or NaNs.\n'
+                'Note that when a singular matrix is given, unlike '
+                'scipy.linalg.lu_factor, cupyx.scipy.linalg.lu_factor '
+                'returns an array containing NaN.')
         if b.dtype.kind == 'f' and not cupy.isfinite(b).all():
             raise ValueError(
                 'array must not contain infs or NaNs')

--- a/cupyx/scipy/linalg/decomp_lu.py
+++ b/cupyx/scipy/linalg/decomp_lu.py
@@ -1,3 +1,5 @@
+from warnings import warn
+
 import numpy
 
 import cupy
@@ -77,6 +79,13 @@ def lu_factor(a, overwrite_a=False, check_finite=True):
     # LU factorization
     getrf(cusolver_handle, m, m, a.data.ptr, m, workspace.data.ptr,
           ipiv.data.ptr, dev_info.data.ptr)
+
+    if dev_info[0] < 0:
+        raise ValueError('illegal value in %d-th argument of '
+                         'internal getrf (lu_factor)' % -dev_info[0])
+    elif dev_info[0] > 0:
+        warn("Diagonal number %d is exactly zero. Singular matrix."
+             % dev_info[0], RuntimeWarning, stacklevel=2)
 
     # cuSolver uses 1-origin while SciPy uses 0-origin
     ipiv -= 1
@@ -167,5 +176,9 @@ def lu_solve(lu_and_piv, b, trans=0, overwrite_b=False, check_finite=True):
           trans,
           m, n, lu.data.ptr, m, ipiv.data.ptr, b.data.ptr,
           m, dev_info.data.ptr)
+
+    if dev_info[0] < 0:
+        raise ValueError('illegal value in %d-th argument of '
+                         'internal getrs (lu_solve)' % -dev_info[0])
 
     return b

--- a/cupyx/scipy/linalg/decomp_lu.py
+++ b/cupyx/scipy/linalg/decomp_lu.py
@@ -126,6 +126,7 @@ def lu_solve(lu_and_piv, b, trans=0, overwrite_b=False, check_finite=True):
         b (cupy.ndarray): The matrix with dimension ``(M,)`` or
             ``(M, N)``.
         trans ({0, 1, 2}): Type of system to solve:
+
             ========  =========
             trans     system
             ========  =========

--- a/cupyx/scipy/linalg/decomp_lu.py
+++ b/cupyx/scipy/linalg/decomp_lu.py
@@ -140,7 +140,7 @@ def lu_solve(lu_and_piv, b, trans=0, overwrite_b=False, check_finite=True):
     elif trans == 1:
         trans = cublas.CUBLAS_OP_T
     elif trans == 2:
-        trans = cublas.CUBLAS_OP_H
+        trans = cublas.CUBLAS_OP_C
     else:
         raise ValueError("unknown trans")
 

--- a/cupyx/scipy/linalg/decomp_lu.py
+++ b/cupyx/scipy/linalg/decomp_lu.py
@@ -88,7 +88,7 @@ Singular matrix.
     if check_finite:
         if a.dtype.kind == 'f' and not cupy.isfinite(a).all():
             raise ValueError(
-                "array must not contain infs or NaNs")
+                'array must not contain infs or NaNs')
 
     cusolver_handle = device.get_cusolver_handle()
     dev_info = cupy.empty(1, dtype=numpy.intc)
@@ -108,7 +108,7 @@ Singular matrix.
         raise ValueError('illegal value in %d-th argument of '
                          'internal getrf (lu_factor)' % -dev_info[0])
     elif dev_info[0] > 0:
-        warn("Diagonal number %d is exactly zero. Singular matrix."
+        warn('Diagonal number %d is exactly zero. Singular matrix.'
              % dev_info[0], RuntimeWarning, stacklevel=2)
 
     # cuSolver uses 1-origin while SciPy uses 0-origin
@@ -159,7 +159,7 @@ def lu_solve(lu_and_piv, b, trans=0, overwrite_b=False, check_finite=True):
 
     m = lu.shape[0]
     if m != b.shape[0]:
-        raise ValueError("incompatible dimensions.")
+        raise ValueError('incompatible dimensions.')
 
     dtype = lu.dtype
     if dtype == 'f':
@@ -176,7 +176,7 @@ def lu_solve(lu_and_piv, b, trans=0, overwrite_b=False, check_finite=True):
     elif trans == 2:
         trans = cublas.CUBLAS_OP_C
     else:
-        raise ValueError("unknown trans")
+        raise ValueError('unknown trans')
 
     lu = lu.astype(dtype, order='F', copy=False)
     ipiv = ipiv.astype(ipiv.dtype, order='F', copy=True)
@@ -187,10 +187,10 @@ def lu_solve(lu_and_piv, b, trans=0, overwrite_b=False, check_finite=True):
     if check_finite:
         if lu.dtype.kind == 'f' and not cupy.isfinite(lu).all():
             raise ValueError(
-                "array must not contain infs or NaNs")
+                'array must not contain infs or NaNs')
         if b.dtype.kind == 'f' and not cupy.isfinite(b).all():
             raise ValueError(
-                "array must not contain infs or NaNs")
+                'array must not contain infs or NaNs')
 
     n = 1 if b.ndim == 1 else b.shape[1]
     cusolver_handle = device.get_cusolver_handle()

--- a/cupyx/scipy/linalg/decomp_lu.py
+++ b/cupyx/scipy/linalg/decomp_lu.py
@@ -1,0 +1,174 @@
+import numpy
+
+import cupy
+from cupy import cuda
+from cupy.cuda import cublas
+from cupy.cuda import device
+from cupy.linalg import util
+
+if cuda.cusolver_enabled:
+    from cupy.cuda import cusolver
+
+
+def lu_factor(a, overwrite_a=False, check_finite=True):
+    """LU decomposition.
+
+    Decompose a given two-dimensional square matrix into ``P * L * U``,
+    where ``P`` is a permutation matrix,  ``L`` lower-triangular with
+    unit diagonal elements, and ``U`` upper-triangular matrix.
+    Note that in the current implementation ``a`` must be
+    a real matrix, and only float32 and float64 are supported.
+
+    Args:
+        a (cupy.ndarray): The input matrix with dimension ``(N, N)``
+        overwrite_a (bool): Allow overwriting data in ``a`` (may enhance
+            performance)
+        check_finite (bool): Whether to check that the input matrices contain
+            only finite numbers. Disabling may give a performance gain, but may
+            result in problems (crashes, non-termination) if the inputs do
+            contain infinities or NaNs.
+
+    Returns:
+        tuple:
+            ``(lu, piv)`` where ``lu`` is a :class:`cupy.ndarray`
+            storing ``U`` in its upper triangle, and ``L`` without
+            unit diagonal elements in its lower triangle, and `piv` is
+            a :class:`cupy.ndarray` storing pivot indices representing
+            permutation matrix ``P``.
+
+    .. seealso:: :func:`scipy.linalg.lu_factor`
+    """
+
+    if not cuda.cusolver_enabled:
+        raise RuntimeError('Current cupy only supports cusolver in CUDA 8.0')
+
+    util._assert_cupy_array(a)
+    util._assert_rank2(a)
+    util._assert_nd_squareness(a)
+
+    if a.dtype.char == 'f' or a.dtype.char == 'd':
+        dtype = a.dtype.char
+    else:
+        dtype = numpy.find_common_type((a.dtype.char, 'f'), ()).char
+
+    a = a.astype(dtype, order='F', copy=(not overwrite_a))
+
+    if check_finite:
+        if a.dtype.kind == 'f' and not cupy.isfinite(a).all():
+            raise ValueError(
+                "array must not contain infs or NaNs")
+
+    cusolver_handle = device.get_cusolver_handle()
+    dev_info = cupy.empty(1, dtype=numpy.intc)
+
+    ipiv = cupy.empty((a.shape[0],), dtype=numpy.intc)
+
+    if dtype == 'f':
+        getrf = cusolver.sgetrf
+        getrf_bufferSize = cusolver.sgetrf_bufferSize
+    else:  # dtype == 'd'
+        getrf = cusolver.dgetrf
+        getrf_bufferSize = cusolver.dgetrf_bufferSize
+
+    m = a.shape[0]
+
+    buffersize = getrf_bufferSize(cusolver_handle, m, m, a.data.ptr, m)
+    workspace = cupy.empty(buffersize, dtype=dtype)
+
+    # LU factorization
+    getrf(cusolver_handle, m, m, a.data.ptr, m, workspace.data.ptr,
+          ipiv.data.ptr, dev_info.data.ptr)
+
+    # cuSolver uses 1-origin while SciPy uses 0-origin
+    ipiv -= 1
+
+    return (a, ipiv)
+
+
+def lu_solve(lu_and_piv, b, trans=0, overwrite_b=False, check_finite=True):
+    """Solve an equation system, ``a * x = b``, given the LU factorization of ``a``
+
+    Args:
+        lu_and_piv (tuple): LU factorization of matrix ``a`` (``(M, N)``)
+            together with pivot indices.
+        b (cupy.ndarray): The matrix with dimension ``(M,)`` or
+            ``(M, N)``.
+        trans ({0, 1, 2}): Type of system to solve:
+            ========  =========
+            trans     system
+            ========  =========
+            0         a x  = b
+            1         a^T x = b
+            2         a^H x = b
+            ========  =========
+        overwrite_b (bool): Allow overwriting data in b (may enhance
+            performance)
+        check_finite (bool): Whether to check that the input matrices contain
+            only finite numbers. Disabling may give a performance gain, but may
+            result in problems (crashes, non-termination) if the inputs do
+            contain infinities or NaNs.
+
+    Returns:
+        cupy.ndarray:
+            The matrix with dimension ``(M,)`` or ``(M, N)``.
+
+    .. seealso:: :func:`scipy.linalg.lu_solve`
+    """
+
+    if not cuda.cusolver_enabled:
+        raise RuntimeError('Current cupy only supports cusolver in CUDA 8.0')
+
+    (lu, ipiv) = lu_and_piv
+
+    util._assert_cupy_array(lu)
+    util._assert_rank2(lu)
+    util._assert_nd_squareness(lu)
+
+    m = lu.shape[0]
+    if m != b.shape[0]:
+        raise ValueError("incompatible dimensions.")
+
+    if lu.dtype.char == 'f' or lu.dtype.char == 'd':
+        dtype = lu.dtype.char
+    else:
+        dtype = numpy.find_common_type((lu.dtype.char, 'f'), ()).char
+
+    if trans == 0:
+        trans = cublas.CUBLAS_OP_N
+    elif trans == 1:
+        trans = cublas.CUBLAS_OP_T
+    elif trans == 2:
+        trans = cublas.CUBLAS_OP_H
+    else:
+        raise ValueError("unknown trans")
+
+    lu = lu.astype(dtype, order='F', copy=False)
+    ipiv = ipiv.astype(ipiv.dtype, order='F', copy=True)
+    # cuSolver uses 1-origin while SciPy uses 0-origin
+    ipiv += 1
+    b = b.astype(dtype, order='F', copy=(not overwrite_b))
+
+    if check_finite:
+        if lu.dtype.kind == 'f' and not cupy.isfinite(lu).all():
+            raise ValueError(
+                "array must not contain infs or NaNs")
+        if b.dtype.kind == 'f' and not cupy.isfinite(b).all():
+            raise ValueError(
+                "array must not contain infs or NaNs")
+
+    n = 1 if b.ndim == 1 else b.shape[1]
+    cusolver_handle = device.get_cusolver_handle()
+    dev_info = cupy.empty(1, dtype=numpy.intc)
+
+    if dtype == 'f':
+        getrs = cusolver.sgetrs
+    else:  # dtype == 'd'
+        getrs = cusolver.dgetrs
+
+    # solve for the inverse
+    getrs(cusolver_handle,
+          trans,
+          m, n, lu.data.ptr, m, ipiv.data.ptr, b.data.ptr,
+          m, dev_info.data.ptr)
+
+    return b

--- a/cupyx/scipy/linalg/decomp_lu.py
+++ b/cupyx/scipy/linalg/decomp_lu.py
@@ -51,8 +51,6 @@ def lu_factor(a, overwrite_a=False, check_finite=True):
         >>> import scipy.linalg
         >>> scipy.linalg.lu_factor(np.array([[0, 1], [0, 0]], \
 dtype=np.float32))
-        __main__:1: LinAlgWarning: Diagonal number 1 is exactly zero. \
-Singular matrix.
         (array([[0., 1.],
                [0., 0.]], dtype=float32), array([0, 1], dtype=int32))
 
@@ -60,8 +58,6 @@ Singular matrix.
         >>> import cupyx.scipy.linalg
         >>> cupyx.scipy.linalg.lu_factor(cp.array([[0, 1], [0, 0]], \
 dtype=cp.float32))
-        __main__:1: RuntimeWarning: Diagonal number 1 is exactly zero. \
-Singular matrix.
         (array([[ 0.,  1.],
                [nan, nan]], dtype=float32), array([0, 1], dtype=int32))
     """

--- a/docs/source/reference/linalg.rst
+++ b/docs/source/reference/linalg.rst
@@ -68,4 +68,6 @@ Solving linear equations
    cupy.linalg.pinv
    cupy.linalg.tensorinv
 
+   cupyx.scipy.linalg.lu_factor
+   cupyx.scipy.linalg.lu_solve
    cupyx.scipy.linalg.solve_triangular

--- a/tests/cupyx_tests/scipy_tests/linalg_tests/test_decomp_lu.py
+++ b/tests/cupyx_tests/scipy_tests/linalg_tests/test_decomp_lu.py
@@ -18,6 +18,9 @@ import cupyx.scipy.linalg
     cuda.cusolver_enabled, 'Only cusolver in CUDA 8.0 is supported')
 @unittest.skipUnless(scipy_available, 'requires scipy')
 @testing.gpu
+@testing.parameterize(*testing.product({
+    'shape': [(1, 1), (2, 2), (3, 3), (5, 5)],
+}))
 @testing.fix_random()
 class TestLUFactor(unittest.TestCase):
 
@@ -34,10 +37,7 @@ class TestLUFactor(unittest.TestCase):
         cupy.testing.assert_array_equal(result_cpu[1], result_gpu[1])
 
     def test_lu_factor(self):
-        self.check_x(numpy.random.randn(1, 1))
-        self.check_x(numpy.random.randn(2, 2))
-        self.check_x(numpy.random.randn(3, 3))
-        self.check_x(numpy.random.randn(5, 5))
+        self.check_x(numpy.random.randn(*self.shape))
 
 
 @unittest.skipUnless(

--- a/tests/cupyx_tests/scipy_tests/linalg_tests/test_decomp_lu.py
+++ b/tests/cupyx_tests/scipy_tests/linalg_tests/test_decomp_lu.py
@@ -27,6 +27,7 @@ class TestLUFactor(unittest.TestCase):
         a_gpu = cupy.asarray(array, dtype=dtype)
         result_cpu = scipy.linalg.lu_factor(a_cpu)
         result_gpu = cupyx.scipy.linalg.lu_factor(a_gpu)
+        self.assertEqual(len(result_cpu), len(result_gpu))
         self.assertEqual(result_cpu[0].dtype, result_gpu[0].dtype)
         self.assertEqual(result_cpu[1].dtype, result_gpu[1].dtype)
         cupy.testing.assert_allclose(result_cpu[0], result_gpu[0], atol=1e-5)

--- a/tests/cupyx_tests/scipy_tests/linalg_tests/test_decomp_lu.py
+++ b/tests/cupyx_tests/scipy_tests/linalg_tests/test_decomp_lu.py
@@ -25,7 +25,8 @@ import cupyx.scipy.linalg
 class TestLUFactor(unittest.TestCase):
 
     @testing.for_float_dtypes(no_float16=True)
-    def check_x(self, array, dtype):
+    def test_lu_factor(self, dtype):
+        array = numpy.random.randn(*self.shape)
         a_cpu = numpy.asarray(array, dtype=dtype)
         a_gpu = cupy.asarray(array, dtype=dtype)
         result_cpu = scipy.linalg.lu_factor(a_cpu)
@@ -35,9 +36,6 @@ class TestLUFactor(unittest.TestCase):
         self.assertEqual(result_cpu[1].dtype, result_gpu[1].dtype)
         cupy.testing.assert_allclose(result_cpu[0], result_gpu[0], atol=1e-5)
         cupy.testing.assert_array_equal(result_cpu[1], result_gpu[1])
-
-    def test_lu_factor(self):
-        self.check_x(numpy.random.randn(*self.shape))
 
 
 @unittest.skipUnless(
@@ -53,7 +51,7 @@ class TestLUSolve(unittest.TestCase):
 
     @testing.for_float_dtypes(no_float16=True)
     @testing.numpy_cupy_allclose(atol=1e-5, scipy_name='scp')
-    def test_solve(self, xp, scp, dtype):
+    def test_lu_solve(self, xp, scp, dtype):
         a_shape, b_shape = self.shapes
         A = testing.shaped_random(a_shape, xp, dtype=dtype)
         b = testing.shaped_random(b_shape, xp, dtype=dtype)

--- a/tests/cupyx_tests/scipy_tests/linalg_tests/test_decomp_lu.py
+++ b/tests/cupyx_tests/scipy_tests/linalg_tests/test_decomp_lu.py
@@ -1,0 +1,63 @@
+import unittest
+
+import numpy
+try:
+    import scipy.linalg
+
+    scipy_available = True
+except ImportError:
+    scipy_available = False
+
+import cupy
+from cupy import cuda
+from cupy import testing
+import cupyx.scipy.linalg
+
+
+@unittest.skipUnless(
+    cuda.cusolver_enabled, 'Only cusolver in CUDA 8.0 is supported')
+@unittest.skipUnless(scipy_available, 'requires scipy')
+@testing.gpu
+@testing.fix_random()
+class TestLUFactor(unittest.TestCase):
+
+    @testing.for_float_dtypes(no_float16=True)
+    def check_x(self, array, dtype):
+        a_cpu = numpy.asarray(array, dtype=dtype)
+        a_gpu = cupy.asarray(array, dtype=dtype)
+        result_cpu = scipy.linalg.lu_factor(a_cpu)
+        result_gpu = cupyx.scipy.linalg.lu_factor(a_gpu)
+        self.assertEqual(result_cpu[0].dtype, result_gpu[0].dtype)
+        self.assertEqual(result_cpu[1].dtype, result_gpu[1].dtype)
+        cupy.testing.assert_allclose(result_cpu[0], result_gpu[0], atol=1e-5)
+        cupy.testing.assert_array_equal(result_cpu[1], result_gpu[1])
+
+    def test_lu_factor(self):
+        self.check_x(numpy.random.randn(1, 1))
+        self.check_x(numpy.random.randn(2, 2))
+        self.check_x(numpy.random.randn(3, 3))
+        self.check_x(numpy.random.randn(5, 5))
+
+
+@unittest.skipUnless(
+    cuda.cusolver_enabled, 'Only cusolver in CUDA 8.0 is supported')
+@unittest.skipUnless(scipy_available, 'requires scipy')
+@testing.gpu
+@testing.parameterize(
+    {'trans': 0},
+    {'trans': 1},
+)
+@testing.fix_random()
+class TestLUSolve(unittest.TestCase):
+
+    @testing.for_float_dtypes(no_float16=True)
+    @testing.numpy_cupy_allclose(atol=1e-5, scipy_name='scp')
+    def check_x(self, a_shape, b_shape, trans, xp, scp, dtype):
+        A = testing.shaped_random(a_shape, xp, dtype=dtype)
+        b = testing.shaped_random(b_shape, xp, dtype=dtype)
+        lu = scp.linalg.lu_factor(A)
+        return scp.linalg.lu_solve(lu, b, trans=trans)
+
+    def test_solve(self):
+        self.check_x((4, 4), (4,), trans=self.trans)
+        self.check_x((5, 5), (5, 2), trans=self.trans)

--- a/tests/cupyx_tests/scipy_tests/linalg_tests/test_decomp_lu.py
+++ b/tests/cupyx_tests/scipy_tests/linalg_tests/test_decomp_lu.py
@@ -14,13 +14,13 @@ from cupy import testing
 import cupyx.scipy.linalg
 
 
-@unittest.skipUnless(
-    cuda.cusolver_enabled, 'Only cusolver in CUDA 8.0 is supported')
 @testing.gpu
 @testing.parameterize(*testing.product({
     'shape': [(1, 1), (2, 2), (3, 3), (5, 5)],
 }))
 @testing.fix_random()
+@unittest.skipUnless(
+    cuda.cusolver_enabled, 'Only cusolver in CUDA 8.0 is supported')
 @testing.with_requires('scipy')
 class TestLUFactor(unittest.TestCase):
 
@@ -38,14 +38,14 @@ class TestLUFactor(unittest.TestCase):
         cupy.testing.assert_array_equal(result_cpu[1], result_gpu[1])
 
 
-@unittest.skipUnless(
-    cuda.cusolver_enabled, 'Only cusolver in CUDA 8.0 is supported')
 @testing.gpu
 @testing.parameterize(*testing.product({
     'trans': [0, 1, 2],
     'shapes': [((4, 4), (4,)), ((5, 5), (5, 2))],
 }))
 @testing.fix_random()
+@unittest.skipUnless(
+    cuda.cusolver_enabled, 'Only cusolver in CUDA 8.0 is supported')
 @testing.with_requires('scipy')
 class TestLUSolve(unittest.TestCase):
 

--- a/tests/cupyx_tests/scipy_tests/linalg_tests/test_decomp_lu.py
+++ b/tests/cupyx_tests/scipy_tests/linalg_tests/test_decomp_lu.py
@@ -16,12 +16,12 @@ import cupyx.scipy.linalg
 
 @unittest.skipUnless(
     cuda.cusolver_enabled, 'Only cusolver in CUDA 8.0 is supported')
-@unittest.skipUnless(scipy_available, 'requires scipy')
 @testing.gpu
 @testing.parameterize(*testing.product({
     'shape': [(1, 1), (2, 2), (3, 3), (5, 5)],
 }))
 @testing.fix_random()
+@testing.with_requires('scipy')
 class TestLUFactor(unittest.TestCase):
 
     @testing.for_float_dtypes(no_float16=True)
@@ -40,13 +40,13 @@ class TestLUFactor(unittest.TestCase):
 
 @unittest.skipUnless(
     cuda.cusolver_enabled, 'Only cusolver in CUDA 8.0 is supported')
-@unittest.skipUnless(scipy_available, 'requires scipy')
 @testing.gpu
 @testing.parameterize(*testing.product({
     'trans': [0, 1, 2],
     'shapes': [((4, 4), (4,)), ((5, 5), (5, 2))],
 }))
 @testing.fix_random()
+@testing.with_requires('scipy')
 class TestLUSolve(unittest.TestCase):
 
     @testing.for_float_dtypes(no_float16=True)

--- a/tests/cupyx_tests/scipy_tests/linalg_tests/test_decomp_lu.py
+++ b/tests/cupyx_tests/scipy_tests/linalg_tests/test_decomp_lu.py
@@ -1,17 +1,12 @@
 import unittest
 
 import numpy
-try:
-    import scipy.linalg
-
-    scipy_available = True
-except ImportError:
-    scipy_available = False
-
 import cupy
 from cupy import cuda
 from cupy import testing
 import cupyx.scipy.linalg
+if cupyx.scipy._scipy_available:
+    import scipy.linalg
 
 
 @testing.gpu

--- a/tests/cupyx_tests/scipy_tests/linalg_tests/test_decomp_lu.py
+++ b/tests/cupyx_tests/scipy_tests/linalg_tests/test_decomp_lu.py
@@ -47,6 +47,7 @@ class TestLUFactor(unittest.TestCase):
 @testing.parameterize(
     {'trans': 0},
     {'trans': 1},
+    {'trans': 2},
 )
 @testing.fix_random()
 class TestLUSolve(unittest.TestCase):


### PR DESCRIPTION
This PR adds `lu_factor` and `lu_solve` to `cupyx.scipy.linalg` that correspond to `scipy.linalg.lu_factor` and `scipy.linalg.lu_solve`.

I want those functions to port https://github.com/locuslab/qpth/ from PyTorch to Chainer/CuPy.