### PR TITLE
Avoid using pytest attributes during import

### DIFF
--- a/cupy/testing/attr.py
+++ b/cupy/testing/attr.py
@@ -28,8 +28,11 @@ def get_error():
 if _error is None:
     _gpu_limit = int(os.getenv('CUPY_TEST_GPU_LIMIT', '-1'))
 
-    cudnn = pytest.mark.cudnn
-    slow = pytest.mark.slow
+    def cudnn(*args, **kwargs):
+        return pytest.mark.cudnn(*args, **kwargs)
+
+    def slow(*args, **kwargs):
+        return pytest.mark.slow(*args, **kwargs)
 
 else:
     def _dummy_callable(*args, **kwargs):


### PR DESCRIPTION
Closes #1917
Note: chainer has the same issue.