### PR TITLE
Fix RPATH not set correctly

### DIFF
--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -415,6 +415,7 @@ def make_extensions(options, compiler, use_cython):
                 compile_args.append('/openmp')
 
         for f in module['file']:
+            s = s.copy()
             name = module_extension_name(f)
 
             rpath = []
@@ -438,8 +439,7 @@ def make_extensions(options, compiler, use_cython):
                 ldflag = '-Wl,'
                 if PLATFORM_LINUX:
                     ldflag += '--disable-new-dtags,'
-                ldflag += ','.join('-rpath,' + p
-                                   for p in s['library_dirs'])
+                ldflag += ','.join('-rpath,' + p for p in rpath)
                 args = s.setdefault('extra_link_args', [])
                 args.append(ldflag)
                 if PLATFORM_DARWIN:

--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -414,19 +414,6 @@ def make_extensions(options, compiler, use_cython):
             elif compiler.compiler_type == 'msvc':
                 compile_args.append('/openmp')
 
-        if (PLATFORM_LINUX and s['library_dirs']) or PLATFORM_DARWIN:
-            ldflag = '-Wl,'
-            if PLATFORM_LINUX:
-                ldflag += '--disable-new-dtags,'
-            ldflag += ','.join('-rpath,' + p
-                               for p in s['library_dirs'])
-            args = s.setdefault('extra_link_args', [])
-            args.append(ldflag)
-            if PLATFORM_DARWIN:
-                # -rpath is only supported when targetting Mac OS X 10.5 or
-                # later
-                args.append('-mmacosx-version-min=10.5')
-
         for f in module['file']:
             name = module_extension_name(f)
 
@@ -447,6 +434,18 @@ def make_extensions(options, compiler, use_cython):
 
             if not PLATFORM_WIN32 and not PLATFORM_LINUX:
                 s['runtime_library_dirs'] = rpath
+            if (PLATFORM_LINUX and s['library_dirs']) or PLATFORM_DARWIN:
+                ldflag = '-Wl,'
+                if PLATFORM_LINUX:
+                    ldflag += '--disable-new-dtags,'
+                ldflag += ','.join('-rpath,' + p
+                                   for p in s['library_dirs'])
+                args = s.setdefault('extra_link_args', [])
+                args.append(ldflag)
+                if PLATFORM_DARWIN:
+                    # -rpath is only supported when targetting Mac OS X 10.5 or
+                    # later
+                    args.append('-mmacosx-version-min=10.5')
 
             sources = module_extension_sources(f, use_cython, no_cuda)
             extension = setuptools.Extension(name, sources, **s)


### PR DESCRIPTION
This PR fixes issues introduced in #2014.

* RPATH needs to be calculated for each file, not module.
* RPATH to `library_dirs` should not be set if `--cupy-no-rpath` is given.

This fix is needed to build wheels for release.