### PR TITLE
Keep backward compatibility on cupy.cudnn.batch_normalization_forward_training

### DIFF
--- a/cupy/cudnn.pyx
+++ b/cupy/cudnn.pyx
@@ -1572,6 +1572,12 @@ def batch_normalization_forward_training(
         core.ndarray running_mean, core.ndarray running_var,
         mean, inv_std, double eps, double decay,
         bint is_for_conv2d, int cudnn_mode, bint debug):
+    # Usually supply None to mean and inv_std, which are left for backward
+    # compatibility. See cupy#2060 and cupy#2070.
+    if (mean is None and inv_std is not None or
+        inv_std is None and mean is not None):
+        raise ValueError('Both mean and inv_std must be None if one is.')
+
     x = core.ascontiguousarray(x)
     dtype = x.dtype
     y = core.ndarray(x._shape, dtype)

--- a/cupy/cudnn.pyx
+++ b/cupy/cudnn.pyx
@@ -1574,8 +1574,7 @@ def batch_normalization_forward_training(
         bint is_for_conv2d, int cudnn_mode, bint debug):
     # Usually supply None to mean and inv_std, which are left for backward
     # compatibility. See cupy#2060 and cupy#2070.
-    if (mean is None and inv_std is not None or
-            inv_std is None and mean is not None):
+    if (mean is None) != (inv_std is None):
         raise ValueError('Both mean and inv_std must be None if one is.')
 
     x = core.ascontiguousarray(x)

--- a/cupy/cudnn.pyx
+++ b/cupy/cudnn.pyx
@@ -1575,7 +1575,7 @@ def batch_normalization_forward_training(
     # Usually supply None to mean and inv_std, which are left for backward
     # compatibility. See cupy#2060 and cupy#2070.
     if (mean is None and inv_std is not None or
-        inv_std is None and mean is not None):
+            inv_std is None and mean is not None):
         raise ValueError('Both mean and inv_std must be None if one is.')
 
     x = core.ascontiguousarray(x)

--- a/cupy/cudnn.pyx
+++ b/cupy/cudnn.pyx
@@ -1570,7 +1570,7 @@ cdef _get_dtype_of_tensor_descriptor(size_t desc):
 def batch_normalization_forward_training(
         core.ndarray x, core.ndarray gamma, core.ndarray beta,
         core.ndarray running_mean, core.ndarray running_var,
-        mean, inv_std, codouble eps, double decay,
+        mean, inv_std, double eps, double decay,
         bint is_for_conv2d, int cudnn_mode, bint debug):
     x = core.ascontiguousarray(x)
     dtype = x.dtype


### PR DESCRIPTION
This PR follows #2060 to make it keep backward compatibility.