### PR TITLE
Test linalg.cholesky with more stable inputs

### DIFF
--- a/tests/cupy_tests/linalg_tests/test_decomposition.py
+++ b/tests/cupy_tests/linalg_tests/test_decomposition.py
@@ -22,6 +22,9 @@ def random_matrix(shape, dtype, scale, sym=False):
         low_s += err
         high_s -= err
         if dtype.kind in 'u':
+            assert sym, (
+                'generating nonsymmetric matrix with uint cells is not'
+                ' supported')
             # (singular value of numpy.ones((m, n))) <= \sqrt{mn}
             high_s = bias = high_s / (1 + numpy.sqrt(m * n))
     assert low_s <= high_s

--- a/tests/cupy_tests/linalg_tests/test_decomposition.py
+++ b/tests/cupy_tests/linalg_tests/test_decomposition.py
@@ -23,7 +23,7 @@ class TestCholeskyDecomposition(unittest.TestCase):
         return xp.linalg.cholesky(a)
 
     def test_decomposition(self):
-        # A normal positive definite matrix
+        # A positive semidefinite matrix
         a0 = numpy.random.randint(0, 100, size=(5, 5))
         a1 = numpy.random.randint(0, 100, size=(5, 5))
         A = a0.dot(a0.T) + a1.dot(a1.T)

--- a/tests/cupy_tests/linalg_tests/test_decomposition.py
+++ b/tests/cupy_tests/linalg_tests/test_decomposition.py
@@ -24,8 +24,9 @@ class TestCholeskyDecomposition(unittest.TestCase):
 
     def test_decomposition(self):
         # A normal positive definite matrix
-        A = numpy.random.randint(0, 100, size=(5, 5))
-        A = numpy.dot(A, A.transpose())
+        a0 = numpy.random.randint(0, 100, size=(5, 5))
+        a1 = numpy.random.randint(0, 100, size=(5, 5))
+        A = a0.dot(a0.T) + a1.dot(a1.T)
         self.check_L(A)
         # np.linalg.cholesky only uses a lower triangle of an array
         self.check_L(numpy.array([[1, 2], [1, 9]]))

--- a/tests/cupy_tests/linalg_tests/test_decomposition.py
+++ b/tests/cupy_tests/linalg_tests/test_decomposition.py
@@ -23,10 +23,10 @@ class TestCholeskyDecomposition(unittest.TestCase):
         return xp.linalg.cholesky(a)
 
     def test_decomposition(self):
-        # A positive semidefinite matrix
+        # A positive definite matrix
         a0 = numpy.random.randint(0, 100, size=(5, 5))
         a1 = numpy.random.randint(0, 100, size=(5, 5))
-        A = a0.dot(a0.T) + a1.dot(a1.T)
+        A = a0.dot(a0.T) + a1.dot(a1.T) + numpy.identity(n=5, dtype=int)
         self.check_L(A)
         # np.linalg.cholesky only uses a lower triangle of an array
         self.check_L(numpy.array([[1, 2], [1, 9]]))


### PR DESCRIPTION
Generating a positive (semi-)definite matrix by `A = X.dot(X.T)` may give `A` too small eigenvalues by chance.  This fix reduces the chance to pick such unstable inputs.

Close #2083.