### PR TITLE
Exclude a test case which contains undefined result

### DIFF
--- a/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
@@ -507,8 +507,6 @@ class TestArrayAdvancedIndexingSetitemScalarValueIndexError(unittest.TestCase):
      'value': numpy.array([1, 2, 3, 4])},
     {'shape': (2, 3, 4), 'indexes': (slice(None), [0, -1]),
      'value': numpy.arange(2 * 2 * 4).reshape(2, 2, 4)},
-    {'shape': (2, 3, 4), 'indexes': (slice(None), [[0, 1], [2, 0]]),
-     'value': numpy.arange(2 * 2 * 2 * 4).reshape(2, 2, 2, 4)},
     # mask
     {'shape': (2, 3, 4), 'indexes': numpy.random.choice([False, True], (2, 3)),
      'value': numpy.arange(4)},


### PR DESCRIPTION
Hi,
as [reference/difference.html](https://docs-cupy.chainer.org/en/stable/reference/difference.html#duplicate-values-in-indices) says, in advanced indexing, assignment through duplicated indices causes undefined results.

I guess this testing parameter contains that behavior:
https://github.com/cupy/cupy/blob/78018afd826d9892bfae8a9ffa0e4e5697a658a9/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py#L510-L511

Because of it, on my environment, `test_ndarray_adv_indexing.py` fails with this single parameter.
```
# A part of stdout from  $ pytest test_ndarray_adv_indexing.py
x = array([[[ 0.,  1.,  2.,  3.],
        [ 4.,  5.,  6.,  7.],
        [ 8.,  9., 10., 11.]],

       [[16., 17., 18., 19.],
        [20., 21., 22., 23.],
        [24., 25., 26., 27.]]])
y = array([[[12., 13., 14., 15.],
        [ 4.,  5.,  6.,  7.],
        [ 8.,  9., 10., 11.]],

       [[28., 29., 30., 31.],
        [20., 21., 22., 23.],
        [24., 25., 26., 27.]]])

(omitted)
== 1 failed, 265 passed in 86.21 seconds ==
```
I suggest that this case is removed or replaced by a correct one.

My environment's spec here.
```
OS: Ubuntu 16.04.4 LTS
CPU: Core i9-7900X
GPU: NVIDIA TITAN V
SDK: CUDA 9.2
```

Sincerely