### PR TITLE
Add strides to docstring of ndarray

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -70,6 +70,7 @@ cdef class ndarray:
         shape (tuple of ints): Length of axes.
         dtype: Data type. It must be an argument of :class:`numpy.dtype`.
         memptr (cupy.cuda.MemoryPointer): Pointer to the array content head.
+        strides (tuple of ints or None): Strides of data in memory.
         order ({'C', 'F'}): Row-major (C-style) or column-major
             (Fortran-style) order.
 


### PR DESCRIPTION
Current docstring of ndarray does not cover `strides` argument which is supported in #1611.