### PR TITLE
Add `hostRegister` and `hostUnregister`

### DIFF
--- a/cupy/cuda/cupy_cuda.h
+++ b/cupy/cuda/cupy_cuda.h
@@ -237,6 +237,14 @@ cudaError_t cudaHostAlloc(...) {
     return cudaSuccess;
 }
 
+cudaError_t cudaHostRegister(...) {
+    return cudaSuccess;
+}
+
+cudaError_t cudaHostUnregister(...) {
+    return cudaSuccess;
+}
+
 cudaError_t cudaMallocManaged(...) {
     return cudaSuccess;
 }

--- a/cupy/cuda/runtime.pxd
+++ b/cupy/cuda/runtime.pxd
@@ -208,6 +208,8 @@ cpdef deviceEnablePeerAccess(int peerDevice)
 cpdef intptr_t malloc(size_t size) except? 0
 cpdef intptr_t mallocManaged(size_t size, unsigned int flags=*) except? 0
 cpdef intptr_t hostAlloc(size_t size, unsigned int flags) except? 0
+cpdef hostRegister(intptr_t ptr, size_t size, unsigned int flags)
+cpdef hostUnregister(intptr_t ptr)
 cpdef free(intptr_t ptr)
 cpdef freeHost(intptr_t ptr)
 cpdef memGetInfo()

--- a/cupy/cuda/runtime.pyx
+++ b/cupy/cuda/runtime.pyx
@@ -71,6 +71,8 @@ cdef extern from 'cupy_cuda.h' nogil:
     int cudaMalloc(void** devPtr, size_t size)
     int cudaMallocManaged(void** devPtr, size_t size, unsigned int flags)
     int cudaHostAlloc(void** ptr, size_t size, unsigned int flags)
+    int cudaHostRegister(void *ptr, size_t size, unsigned int flags)
+    int cudaHostUnregister(void *ptr)
     int cudaFree(void* devPtr)
     int cudaFreeHost(void* ptr)
     int cudaMemGetInfo(size_t* free, size_t* total)
@@ -229,6 +231,18 @@ cpdef intptr_t hostAlloc(size_t size, unsigned int flags) except? 0:
         status = cudaHostAlloc(&ptr, size, flags)
     check_status(status)
     return <intptr_t>ptr
+
+
+cpdef hostRegister(intptr_t ptr, size_t size, unsigned int flags):
+    with nogil:
+        status = cudaHostRegister(<void*>ptr, size, flags)
+    check_status(status)
+
+
+cpdef hostUnregister(intptr_t ptr):
+    with nogil:
+        status = cudaHostUnregister(<void*>ptr)
+    check_status(status)
 
 
 cpdef free(intptr_t ptr):


### PR DESCRIPTION
Add wrappers for `cudaHostRegister` and `cudaHostUnregister` in CUDA Runtime API. It can *pin* (page-lock) a memory which is allocated by methods other than `cudaHostAlloc`.