### PR TITLE
Check if gc module is still available

### DIFF
--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -788,7 +788,12 @@ cdef class LockAndNoGc:
 
     def __enter__(self):
         rlock.lock_fastrlock(self._lock, -1, True)
-        if gc.isenabled():
+
+        # This method may be called from the context of finalizer
+        # (e.g., `__dealloc__` of PooledMemory class).
+        # If the process is going to be terminated, the module itself may
+        # already been unavailable.
+        if gc is not None and gc.isenabled():
             self._gc = True
             gc.disable()
 


### PR DESCRIPTION
Follow-up of #2103.

https://jenkins.preferred.jp/job/chainer/job/chainer_pr/34/TEST=CHAINERX_chainer-py3,sakura11=sakura11/console
```
20:33:56 Traceback (most recent call last):
20:33:56   File "cupy/cuda/memory.pyx", line 597, in cupy.cuda.memory.PooledMemory.free
20:33:56   File "cupy/cuda/memory.pyx", line 969, in cupy.cuda.memory.SingleDeviceMemoryPool.free
20:33:56   File "cupy/cuda/memory.pyx", line 791, in cupy.cuda.memory.LockAndNoGc.__enter__
20:33:56 AttributeError: 'NoneType' object has no attribute 'isenabled'
20:33:56 Exception ignored in: 'cupy.cuda.memory.PooledMemory.__dealloc__'
```