### PR TITLE
Fix `__cuda_array_interface__` data pointer for sliced arrays

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -141,7 +141,7 @@ cdef class ndarray:
             'shape': self.shape,
             'typestr': self.dtype.str,
             'descr': self.dtype.descr,
-            'data': (self.data.mem.ptr, False),
+            'data': (self.data.ptr, False),
             'version': 0,
         }
         if not self._c_contiguous:

--- a/tests/cupy_tests/core_tests/test_ndarray_cuda_array_interface.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_cuda_array_interface.py
@@ -127,13 +127,13 @@ class TestReductionKernel(unittest.TestCase):
 
 
 @testing.parameterize(
-        {'shape': (10,), 'slices': (slice(0, None),)},
-        {'shape': (10,), 'slices': (slice(2, None),)},
-        {'shape': (10, 10), 'slices': (slice(0, None), slice(0, None))},
-        {'shape': (10, 10), 'slices': (slice(0, None), slice(2, None))},
-        {'shape': (10, 10), 'slices': (slice(2, None), slice(0, None))},
-        {'shape': (10, 10), 'slices': (slice(2, None), slice(2, None))},
-        {'shape': (10, 10), 'slices': (slice(2, None), slice(4, None))},
+    {'shape': (10,), 'slices': (slice(0, None),)},
+    {'shape': (10,), 'slices': (slice(2, None),)},
+    {'shape': (10, 10), 'slices': (slice(0, None), slice(0, None))},
+    {'shape': (10, 10), 'slices': (slice(0, None), slice(2, None))},
+    {'shape': (10, 10), 'slices': (slice(2, None), slice(0, None))},
+    {'shape': (10, 10), 'slices': (slice(2, None), slice(2, None))},
+    {'shape': (10, 10), 'slices': (slice(2, None), slice(4, None))},
 )
 @testing.gpu
 class TestSlicingMemoryPointer(unittest.TestCase):

--- a/tests/cupy_tests/core_tests/test_ndarray_cuda_array_interface.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_cuda_array_interface.py
@@ -145,16 +145,14 @@ class TestSlicingMemoryPointer(unittest.TestCase):
 
         start = [x.start for x in self.slices]
         itemsize = cupy.dtype(dtype).itemsize
-        if order == 'C':
-            if len(self.shape) == 1:
-                offset = start[0] * itemsize
-            elif len(self.shape) == 2:
-                offset = self.shape[0] * start[0] * itemsize + start[1] * itemsize
+        dimsize = [x * itemsize for x in start]
+        if len(self.shape) == 1:
+            offset = start[0] * itemsize
         else:
-            if len(self.shape) == 1:
-                offset = start[0] * itemsize
-            elif len(self.shape) == 2:
-                offset = self.shape[0] * start[1] * itemsize + start[0] * itemsize
+            if order == 'C':
+                offset = self.shape[0] * dimsize[0] + dimsize[1]
+            else:
+                offset = self.shape[0] * dimsize[1] + dimsize[0]
 
         cai_ptr, _ = x.__cuda_array_interface__['data']
         slice_cai_ptr, _ = x[self.slices].__cuda_array_interface__['data']

--- a/tests/cupy_tests/core_tests/test_ndarray_cuda_array_interface.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_cuda_array_interface.py
@@ -143,9 +143,9 @@ class TestSlicingMemoryPointer(unittest.TestCase):
     def test_shape_with_strides(self, dtype, order):
         x = cupy.zeros(self.shape, dtype=dtype, order=order)
 
-        start = [x.start for x in self.slices]
+        start = [s.start for s in self.slices]
         itemsize = cupy.dtype(dtype).itemsize
-        dimsize = [x * itemsize for x in start]
+        dimsize = [s * itemsize for s in start]
         if len(self.shape) == 1:
             offset = start[0] * itemsize
         else:


### PR DESCRIPTION
Solves #2128.

According to what I understand from the `cupy.cuda.MemoryPointer` [documentation](https://docs-cupy.chainer.org/en/stable/reference/generated/cupy.cuda.MemoryPointer.html), the `mem.ptr` attribute pointer points to the base of the memory buffer, whereas `ptr` points to the _place within the buffer_, which I understand as base+slice offset.

Feel free to correct me if my understanding is wrong and the fix is not correct for all situations (e.g., we may need to point to some other attribute from `self.data.mem`). In my tests, also for the example I provided in #2128, this suffices to fix the issue.