### PR TITLE
Make wheel of master for CI

### DIFF
--- a/.pfnci/config.pbtxt
+++ b/.pfnci/config.pbtxt
@@ -4,7 +4,6 @@ configs {
     requirement {
       cpu: 2
       memory: 12
-      disk: 20
     }
     time_limit {
       seconds: 1800

--- a/.pfnci/config.pbtxt
+++ b/.pfnci/config.pbtxt
@@ -1,0 +1,14 @@
+configs {
+  key: "cupy.wheel.nightly"
+  value {
+    requirement {
+      cpu: 2
+      memory: 12
+      disk: 20
+    }
+    time_limit {
+      seconds: 1800
+    }
+    command: "sh .pfnci/wheel_nightly.sh"
+  }
+}

--- a/.pfnci/docker/devel/Dockerfile
+++ b/.pfnci/docker/devel/Dockerfile
@@ -1,17 +1,15 @@
 FROM nvidia/cuda:9.2-cudnn7-devel-ubuntu18.04
 
-RUN apt-get update -y && apt-get install -y --no-install-recommends \
+ARG PYTHON
+RUN apt-get update -y \
+    && apt-get install -y --no-install-recommends \
     ca-certificates \
     curl \
-    python-dev \
-    python3-dev \
+    python${PYTHON%%.*}-dev \
+    python${PYTHON}-dev \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN curl -LO https://bootstrap.pypa.io/get-pip.py \
-    && python2.7 get-pip.py --no-cache-dir \
-    && python3.6 get-pip.py --no-cache-dir \
-    && rm get-pip.py
-
-RUN pip2.7 install --no-cache-dir cython \
-    && pip3.6 install --no-cache-dir cython
+    && rm -rf /var/lib/apt/lists/* \
+    && curl -LO https://bootstrap.pypa.io/get-pip.py \
+    && python${PYTHON} get-pip.py --no-cache-dir \
+    && rm get-pip.py \
+    && pip${PYTHON} install --no-cache-dir cython

--- a/.pfnci/docker/devel/Dockerfile
+++ b/.pfnci/docker/devel/Dockerfile
@@ -2,6 +2,7 @@ FROM nvidia/cuda:9.2-cudnn7-devel-ubuntu18.04
 
 RUN apt-get update -y && apt-get install -y --no-install-recommends \
     ca-certificates \
+    ccache \
     curl \
     python-dev \
     python3-dev \
@@ -15,3 +16,6 @@ RUN curl -LO https://bootstrap.pypa.io/get-pip.py \
 
 RUN pip2 install --no-cache-dir cython \
     && pip3 install --no-cache-dir cython
+
+ENV PATH=/usr/lib/ccache:${PATH} \
+    NVCC='ccache nvcc'

--- a/.pfnci/docker/devel/Dockerfile
+++ b/.pfnci/docker/devel/Dockerfile
@@ -1,12 +1,11 @@
 FROM nvidia/cuda:9.2-cudnn7-devel-ubuntu18.04
 
 ARG PYTHON
-RUN apt-get update -y \
-    && apt-get install -y --no-install-recommends \
+RUN apt-get update -y && apt-get install -y --no-install-recommends \
     ca-certificates \
     curl \
-    python${PYTHON%%.*}-dev \
     python${PYTHON}-dev \
+    $([ ${PYTHON} = 2.7 ] || echo python${PYTHON}-distutils) \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && curl -LO https://bootstrap.pypa.io/get-pip.py \

--- a/.pfnci/docker/devel/Dockerfile
+++ b/.pfnci/docker/devel/Dockerfile
@@ -2,7 +2,6 @@ FROM nvidia/cuda:9.2-cudnn7-devel-ubuntu18.04
 
 RUN apt-get update -y && apt-get install -y --no-install-recommends \
     ca-certificates \
-    ccache \
     curl \
     python-dev \
     python3-dev \
@@ -16,6 +15,3 @@ RUN curl -LO https://bootstrap.pypa.io/get-pip.py \
 
 RUN pip2 install --no-cache-dir cython \
     && pip3 install --no-cache-dir cython
-
-ENV PATH=/usr/lib/ccache:${PATH} \
-    NVCC='ccache nvcc'

--- a/.pfnci/docker/devel/Dockerfile
+++ b/.pfnci/docker/devel/Dockerfile
@@ -9,9 +9,9 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 RUN curl -LO https://bootstrap.pypa.io/get-pip.py \
-    && python2 get-pip.py --no-cache-dir \
-    && python3 get-pip.py --no-cache-dir \
+    && python2.7 get-pip.py --no-cache-dir \
+    && python3.6 get-pip.py --no-cache-dir \
     && rm get-pip.py
 
-RUN pip2 install --no-cache-dir cython \
-    && pip3 install --no-cache-dir cython
+RUN pip2.7 install --no-cache-dir cython \
+    && pip3.6 install --no-cache-dir cython

--- a/.pfnci/docker/devel/Dockerfile
+++ b/.pfnci/docker/devel/Dockerfile
@@ -1,0 +1,17 @@
+FROM nvidia/cuda:9.2-cudnn7-devel-ubuntu18.04
+
+RUN apt-get update -y && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    python-dev \
+    python3-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -LO https://bootstrap.pypa.io/get-pip.py \
+    && python2 get-pip.py --no-cache-dir \
+    && python3 get-pip.py --no-cache-dir \
+    && rm get-pip.py
+
+RUN pip2 install --no-cache-dir cython \
+    && pip3 install --no-cache-dir cython

--- a/.pfnci/wheel_nightly.sh
+++ b/.pfnci/wheel_nightly.sh
@@ -21,7 +21,7 @@ PID3=$!
 
 wait ${PID2} ${PID3}
 
-if [ -n ${CI_COMMIT_ID:-} ]; then
+if [ -n "${CI_COMMIT_ID:-}" ]; then
     gsutil cp -q ${TEMP2}/dist/* gs://tmp-pfn-public-ci/cupy/wheel/${CI_COMMIT_ID}/
     gsutil cp -q ${TEMP3}/dist/* gs://tmp-pfn-public-ci/cupy/wheel/${CI_COMMIT_ID}/
     echo ${CI_COMMIT_ID} | gsutil cp -q - gs://tmp-pfn-public-ci/cupy/wheel/master

--- a/.pfnci/wheel_nightly.sh
+++ b/.pfnci/wheel_nightly.sh
@@ -5,7 +5,7 @@ systemctl stop docker.service
 mount -t tmpfs tmpfs /var/lib/docker/
 systemctl start docker.service
 
-echo -n 2.7 3.6 | xargs -i -d ' ' -P $(nproc) sh -euxc '
+echo -n 2.7 3.6 | xargs -i -d ' ' -P $(nproc) bash -euxc '
 PYTHON={}
 
 docker build \

--- a/.pfnci/wheel_nightly.sh
+++ b/.pfnci/wheel_nightly.sh
@@ -23,5 +23,5 @@ docker run --rm \
        pip${PYTHON} wheel -e .
 '
 
-gsutil -q cp cupy-*.whl gs://tmp-pfn-public-ci/cupy/wheel/${CI_COMMIT_ID}/cuda92/
+gsutil -q cp cupy-*.whl gs://tmp-pfn-public-ci/cupy/wheel/${CI_COMMIT_ID}/cuda9.2/
 echo ${CI_COMMIT_ID} | gsutil -q cp - gs://tmp-pfn-public-ci/cupy/wheel/master

--- a/.pfnci/wheel_nightly.sh
+++ b/.pfnci/wheel_nightly.sh
@@ -1,0 +1,28 @@
+#! /usr/bin/env sh
+set -eux
+
+docker build -t devel .pfnci/docker/devel/
+
+TEMP2=$(mktemp -d)
+cp -r . ${TEMP2}
+docker run --rm \
+       --volume ${TEMP2}:/cupy/ --workdir /cupy/ \
+       devel \
+       python2 setup.py bdist_wheel &
+PID2=$!
+
+TEMP3=$(mktemp -d)
+cp -r . ${TEMP3}
+docker run --rm \
+       --volume ${TEMP3}:/cupy/ --workdir /cupy/ \
+       devel \
+       python3 setup.py bdist_wheel &
+PID3=$!
+
+wait ${PID2} ${PID3}
+
+if [ -n ${CI_COMMIT_ID:-} ]; then
+    gsutil cp -q ${TEMP2}/dist/* gs://tmp-pfn-public-ci/cupy/nightly/${CI_COMMIT_ID}/
+    gsutil cp -q ${TEMP3}/dist/* gs://tmp-pfn-public-ci/cupy/nightly/${CI_COMMIT_ID}/
+    echo ${CI_COMMIT_ID} | gsutil cp -q - gs://tmp-pfn-public-ci/cupy/nightly/master
+fi

--- a/.pfnci/wheel_nightly.sh
+++ b/.pfnci/wheel_nightly.sh
@@ -10,19 +10,18 @@ mount -t tmpfs tmpfs ${TEMP}/
 cp -a . ${TEMP}/
 cd ${TEMP}/
 
-echo -n 2.7 3.6 | xargs -i -d ' ' -P $(nproc) bash -euxc '
+echo -n 2.7 3.6 | xargs -i -d ' ' -P $(nproc) sh -euxc '
 PYTHON={}
 
 docker build \
        --build-arg PYTHON=${PYTHON} \
-       -t devel:py${PYTHON//.} \
+       -t devel:${PYTHON} \
        .pfnci/docker/devel/
 docker run --rm \
        --volume $(pwd):/cupy/ --workdir /cupy/ \
-       devel:py${PYTHON//.} \
+       devel:${PYTHON} \
        pip${PYTHON} wheel -e .
-gsutil -q cp cupy-*-cp${PYTHON//.}-*.whl \
-       gs://tmp-pfn-public-ci/cupy/wheel/${CI_COMMIT_ID}/cupy-cuda92-py${PYTHON//.}.whl
 '
 
+gsutil -q cp cupy-*.whl gs://tmp-pfn-public-ci/cupy/wheel/${CI_COMMIT_ID}/cuda92/
 echo ${CI_COMMIT_ID} | gsutil -q cp - gs://tmp-pfn-public-ci/cupy/wheel/master

--- a/.pfnci/wheel_nightly.sh
+++ b/.pfnci/wheel_nightly.sh
@@ -21,8 +21,6 @@ PID3=$!
 
 wait ${PID2} ${PID3}
 
-if [ -n "${CI_COMMIT_ID:-}" ]; then
-    gsutil cp -q ${TEMP2}/dist/* gs://tmp-pfn-public-ci/cupy/wheel/${CI_COMMIT_ID}/
-    gsutil cp -q ${TEMP3}/dist/* gs://tmp-pfn-public-ci/cupy/wheel/${CI_COMMIT_ID}/
-    echo ${CI_COMMIT_ID} | gsutil cp -q - gs://tmp-pfn-public-ci/cupy/wheel/master
-fi
+gsutil cp -q ${TEMP2}/dist/* gs://tmp-pfn-public-ci/cupy/wheel/${CI_COMMIT_ID}/
+gsutil cp -q ${TEMP3}/dist/* gs://tmp-pfn-public-ci/cupy/wheel/${CI_COMMIT_ID}/
+echo ${CI_COMMIT_ID} | gsutil cp -q - gs://tmp-pfn-public-ci/cupy/wheel/master

--- a/.pfnci/wheel_nightly.sh
+++ b/.pfnci/wheel_nightly.sh
@@ -6,19 +6,10 @@ mount -t tmpfs tmpfs /var/lib/docker/ -o size=75%
 systemctl start docker.service
 docker build -t devel .pfnci/docker/devel/
 
-CCACHE=$(mktemp -d)
-mount -t tmpfs tmpfs ${CCACHE}/ -o size=75%
-gsutil -q cp gs://tmp-pfn-public-ci/cupy/ccache.tar - | tar -xf - -C ${CCACHE}/ || true
-docker run --rm \
-       --volume ${CCACHE}/:/root/.ccache/ \
-       devel \
-       ccache --max-size=256Mi --set-config=compiler_check=content
-
 TEMP2=$(mktemp -d)
 cp -r . ${TEMP2}/
 docker run --rm \
        --volume ${TEMP2}/:/cupy/ --workdir /cupy/ \
-       --volume ${CCACHE}/:/root/.ccache/ \
        devel \
        python2 setup.py bdist_wheel &
 PID2=$!
@@ -27,14 +18,11 @@ TEMP3=$(mktemp -d)
 cp -r . ${TEMP3}/
 docker run --rm \
        --volume ${TEMP3}/:/cupy/ --workdir /cupy/ \
-       --volume ${CCACHE}/:/root/.ccache/ \
        devel \
        python3 setup.py bdist_wheel &
 PID3=$!
 
 wait ${PID2} ${PID3}
-
-tar -cf - -C ${CCACHE}/ -R . | gsutil -q cp - gs://tmp-pfn-public-ci/cupy/ccache.tar
 
 gsutil -q cp ${TEMP2}/dist/* gs://tmp-pfn-public-ci/cupy/wheel/${CI_COMMIT_ID}/
 gsutil -q cp ${TEMP3}/dist/* gs://tmp-pfn-public-ci/cupy/wheel/${CI_COMMIT_ID}/

--- a/.pfnci/wheel_nightly.sh
+++ b/.pfnci/wheel_nightly.sh
@@ -5,7 +5,7 @@ systemctl stop docker.service
 mount -t tmpfs tmpfs /var/lib/docker/
 systemctl start docker.service
 
-TEMP=$(mktemp -d)
+export TEMP=$(mktemp -d)
 mount -t tmpfs tmpfs ${TEMP}/
 cp -r . ${TEMP}/
 

--- a/.pfnci/wheel_nightly.sh
+++ b/.pfnci/wheel_nightly.sh
@@ -12,7 +12,7 @@ gsutil -q cp gs://tmp-pfn-public-ci/cupy/ccache.tar - | tar -xf - -C ${CCACHE}/ 
 docker run --rm \
        --volume ${CCACHE}/:/root/.ccache/ \
        devel \
-       ccache --max-size=256Mi
+       ccache --max-size=1Gi --set-config=compiler_check=content
 
 TEMP2=$(mktemp -d)
 cp -r . ${TEMP2}/

--- a/.pfnci/wheel_nightly.sh
+++ b/.pfnci/wheel_nightly.sh
@@ -1,12 +1,20 @@
 #! /usr/bin/env sh
 set -eux
 
+systemctl stop docker.service
+mount -t tmpfs tmpfs /var/lib/docker/ -o size=75%
+systemctl start docker.service
 docker build -t devel .pfnci/docker/devel/
+
+CCACHE=$(mktemp -d)
+mount -t tmpfs tmpfs ${CCACHE}/ -o size=75%
+gsutil -q cp gs://tmp-pfn-public-ci/cupy/ccache.tar - | tar -xf - -C ${CCACHE}/ || true
 
 TEMP2=$(mktemp -d)
 cp -r . ${TEMP2}/
 docker run --rm \
        --volume ${TEMP2}/:/cupy/ --workdir /cupy/ \
+       --volume ${CCACHE}/:/root/.ccache/ \
        devel \
        python2 setup.py bdist_wheel &
 PID2=$!
@@ -15,11 +23,14 @@ TEMP3=$(mktemp -d)
 cp -r . ${TEMP3}/
 docker run --rm \
        --volume ${TEMP3}/:/cupy/ --workdir /cupy/ \
+       --volume ${CCACHE}/:/root/.ccache/ \
        devel \
        python3 setup.py bdist_wheel &
 PID3=$!
 
 wait ${PID2} ${PID3}
+
+tar -cf - -C ${CCACHE}/ -R . | gsutil -q cp - gs://tmp-pfn-public-ci/cupy/ccache.tar
 
 gsutil cp -q ${TEMP2}/dist/* gs://tmp-pfn-public-ci/cupy/wheel/${CI_COMMIT_ID}/
 gsutil cp -q ${TEMP3}/dist/* gs://tmp-pfn-public-ci/cupy/wheel/${CI_COMMIT_ID}/

--- a/.pfnci/wheel_nightly.sh
+++ b/.pfnci/wheel_nightly.sh
@@ -12,16 +12,11 @@ docker build \
        --build-arg PYTHON=${PYTHON} \
        -t devel:py${PYTHON//.} \
        .pfnci/docker/devel/
-
-TEMP=$(mktemp -d)
-mount -t tmpfs tmpfs ${TEMP}/
-cp -r . ${TEMP}/
 docker run --rm \
-       --volume ${TEMP}/:/cupy/ --workdir /cupy/ \
+       --volume $(pwd):/cupy/ --workdir /cupy/ \
        devel:py${PYTHON//.} \
-       python${PYTHON} setup.py bdist_wheel
-
-gsutil -q cp ${TEMP}/dist/cupy-*.whl \
+       pip${PYTHON} wheel -e . -b /tmp/
+gsutil -q cp cupy-*-cp${PYTHON//.}-*.whl \
        gs://tmp-pfn-public-ci/cupy/wheel/${CI_COMMIT_ID}/cupy-cuda92-py${PYTHON//.}.whl
 '
 

--- a/.pfnci/wheel_nightly.sh
+++ b/.pfnci/wheel_nightly.sh
@@ -2,11 +2,12 @@
 set -eux
 
 systemctl stop docker.service
-mount -t tmpfs tmpfs /var/lib/docker/ -o size=75%
+mount -t tmpfs tmpfs /var/lib/docker/
 systemctl start docker.service
 docker build -t devel .pfnci/docker/devel/
 
 TEMP2=$(mktemp -d)
+mount -t tmpfs tmpfs ${TEMP2}/
 cp -r . ${TEMP2}/
 docker run --rm \
        --volume ${TEMP2}/:/cupy/ --workdir /cupy/ \
@@ -15,6 +16,7 @@ docker run --rm \
 PID2=$!
 
 TEMP3=$(mktemp -d)
+mount -t tmpfs tmpfs ${TEMP3}/
 cp -r . ${TEMP3}/
 docker run --rm \
        --volume ${TEMP3}/:/cupy/ --workdir /cupy/ \

--- a/.pfnci/wheel_nightly.sh
+++ b/.pfnci/wheel_nightly.sh
@@ -6,26 +6,26 @@ mount -t tmpfs tmpfs /var/lib/docker/
 systemctl start docker.service
 docker build -t devel .pfnci/docker/devel/
 
-TEMP2=$(mktemp -d)
-mount -t tmpfs tmpfs ${TEMP2}/
-cp -r . ${TEMP2}/
+TEMP27=$(mktemp -d)
+mount -t tmpfs tmpfs ${TEMP27}/
+cp -r . ${TEMP27}/
 docker run --rm \
-       --volume ${TEMP2}/:/cupy/ --workdir /cupy/ \
+       --volume ${TEMP27}/:/cupy/ --workdir /cupy/ \
        devel \
-       python2 setup.py bdist_wheel &
-PID2=$!
+       python2.7 setup.py bdist_wheel &
+PID27=$!
 
-TEMP3=$(mktemp -d)
-mount -t tmpfs tmpfs ${TEMP3}/
-cp -r . ${TEMP3}/
+TEMP36=$(mktemp -d)
+mount -t tmpfs tmpfs ${TEMP36}/
+cp -r . ${TEMP36}/
 docker run --rm \
-       --volume ${TEMP3}/:/cupy/ --workdir /cupy/ \
+       --volume ${TEMP36}/:/cupy/ --workdir /cupy/ \
        devel \
-       python3 setup.py bdist_wheel &
-PID3=$!
+       python3.6 setup.py bdist_wheel &
+PID36=$!
 
-wait ${PID2} ${PID3}
+wait ${PID27} ${PID36}
 
-gsutil -q cp ${TEMP2}/dist/* gs://tmp-pfn-public-ci/cupy/wheel/${CI_COMMIT_ID}/
-gsutil -q cp ${TEMP3}/dist/* gs://tmp-pfn-public-ci/cupy/wheel/${CI_COMMIT_ID}/
+gsutil -q cp ${TEMP27}/dist/cupy-*.whl gs://tmp-pfn-public-ci/cupy/wheel/${CI_COMMIT_ID}/cupy-cuda92-py27.whl
+gsutil -q cp ${TEMP36}/dist/cupy-*.whl gs://tmp-pfn-public-ci/cupy/wheel/${CI_COMMIT_ID}/cupy-cuda92-py36.whl
 echo ${CI_COMMIT_ID} | gsutil -q cp - gs://tmp-pfn-public-ci/cupy/wheel/master

--- a/.pfnci/wheel_nightly.sh
+++ b/.pfnci/wheel_nightly.sh
@@ -5,6 +5,10 @@ systemctl stop docker.service
 mount -t tmpfs tmpfs /var/lib/docker/
 systemctl start docker.service
 
+TEMP=$(mktemp -d)
+mount -t tmpfs tmpfs ${TEMP}/
+cp -r . ${TEMP}/
+
 echo -n 2.7 3.6 | xargs -i -d ' ' -P $(nproc) bash -euxc '
 PYTHON={}
 
@@ -13,10 +17,10 @@ docker build \
        -t devel:py${PYTHON//.} \
        .pfnci/docker/devel/
 docker run --rm \
-       --volume $(pwd):/cupy/ --workdir /cupy/ \
+       --volume ${TEMP}/:/cupy/ --workdir /cupy/ \
        devel:py${PYTHON//.} \
-       pip${PYTHON} wheel -e . -b /tmp/
-gsutil -q cp cupy-*-cp${PYTHON//.}-*.whl \
+       pip${PYTHON} wheel -e .
+gsutil -q cp ${TEMP}/cupy-*-cp${PYTHON//.}-*.whl \
        gs://tmp-pfn-public-ci/cupy/wheel/${CI_COMMIT_ID}/cupy-cuda92-py${PYTHON//.}.whl
 '
 

--- a/.pfnci/wheel_nightly.sh
+++ b/.pfnci/wheel_nightly.sh
@@ -5,9 +5,10 @@ systemctl stop docker.service
 mount -t tmpfs tmpfs /var/lib/docker/
 systemctl start docker.service
 
-export TEMP=$(mktemp -d)
+TEMP=$(mktemp -d)
 mount -t tmpfs tmpfs ${TEMP}/
-cp -r . ${TEMP}/
+cp -a . ${TEMP}/
+cd ${TEMP}/
 
 echo -n 2.7 3.6 | xargs -i -d ' ' -P $(nproc) bash -euxc '
 PYTHON={}
@@ -17,10 +18,10 @@ docker build \
        -t devel:py${PYTHON//.} \
        .pfnci/docker/devel/
 docker run --rm \
-       --volume ${TEMP}/:/cupy/ --workdir /cupy/ \
+       --volume $(pwd):/cupy/ --workdir /cupy/ \
        devel:py${PYTHON//.} \
        pip${PYTHON} wheel -e .
-gsutil -q cp ${TEMP}/cupy-*-cp${PYTHON//.}-*.whl \
+gsutil -q cp cupy-*-cp${PYTHON//.}-*.whl \
        gs://tmp-pfn-public-ci/cupy/wheel/${CI_COMMIT_ID}/cupy-cuda92-py${PYTHON//.}.whl
 '
 

--- a/.pfnci/wheel_nightly.sh
+++ b/.pfnci/wheel_nightly.sh
@@ -22,7 +22,7 @@ PID3=$!
 wait ${PID2} ${PID3}
 
 if [ -n ${CI_COMMIT_ID:-} ]; then
-    gsutil cp -q ${TEMP2}/dist/* gs://tmp-pfn-public-ci/cupy/nightly/${CI_COMMIT_ID}/
-    gsutil cp -q ${TEMP3}/dist/* gs://tmp-pfn-public-ci/cupy/nightly/${CI_COMMIT_ID}/
-    echo ${CI_COMMIT_ID} | gsutil cp -q - gs://tmp-pfn-public-ci/cupy/nightly/master
+    gsutil cp -q ${TEMP2}/dist/* gs://tmp-pfn-public-ci/cupy/wheel/${CI_COMMIT_ID}/
+    gsutil cp -q ${TEMP3}/dist/* gs://tmp-pfn-public-ci/cupy/wheel/${CI_COMMIT_ID}/
+    echo ${CI_COMMIT_ID} | gsutil cp -q - gs://tmp-pfn-public-ci/cupy/wheel/master
 fi

--- a/.pfnci/wheel_nightly.sh
+++ b/.pfnci/wheel_nightly.sh
@@ -12,7 +12,7 @@ gsutil -q cp gs://tmp-pfn-public-ci/cupy/ccache.tar - | tar -xf - -C ${CCACHE}/ 
 docker run --rm \
        --volume ${CCACHE}/:/root/.ccache/ \
        devel \
-       ccache --max-size=1Gi --set-config=compiler_check=content
+       ccache --max-size=256Mi --set-config=compiler_check=content
 
 TEMP2=$(mktemp -d)
 cp -r . ${TEMP2}/

--- a/.pfnci/wheel_nightly.sh
+++ b/.pfnci/wheel_nightly.sh
@@ -4,17 +4,17 @@ set -eux
 docker build -t devel .pfnci/docker/devel/
 
 TEMP2=$(mktemp -d)
-cp -r . ${TEMP2}
+cp -r . ${TEMP2}/
 docker run --rm \
-       --volume ${TEMP2}:/cupy/ --workdir /cupy/ \
+       --volume ${TEMP2}/:/cupy/ --workdir /cupy/ \
        devel \
        python2 setup.py bdist_wheel &
 PID2=$!
 
 TEMP3=$(mktemp -d)
-cp -r . ${TEMP3}
+cp -r . ${TEMP3}/
 docker run --rm \
-       --volume ${TEMP3}:/cupy/ --workdir /cupy/ \
+       --volume ${TEMP3}/:/cupy/ --workdir /cupy/ \
        devel \
        python3 setup.py bdist_wheel &
 PID3=$!

--- a/.pfnci/wheel_nightly.sh
+++ b/.pfnci/wheel_nightly.sh
@@ -32,6 +32,6 @@ wait ${PID2} ${PID3}
 
 tar -cf - -C ${CCACHE}/ -R . | gsutil -q cp - gs://tmp-pfn-public-ci/cupy/ccache.tar
 
-gsutil cp -q ${TEMP2}/dist/* gs://tmp-pfn-public-ci/cupy/wheel/${CI_COMMIT_ID}/
-gsutil cp -q ${TEMP3}/dist/* gs://tmp-pfn-public-ci/cupy/wheel/${CI_COMMIT_ID}/
-echo ${CI_COMMIT_ID} | gsutil cp -q - gs://tmp-pfn-public-ci/cupy/wheel/master
+gsutil -q cp ${TEMP2}/dist/* gs://tmp-pfn-public-ci/cupy/wheel/${CI_COMMIT_ID}/
+gsutil -q cp ${TEMP3}/dist/* gs://tmp-pfn-public-ci/cupy/wheel/${CI_COMMIT_ID}/
+echo ${CI_COMMIT_ID} | gsutil -q cp - gs://tmp-pfn-public-ci/cupy/wheel/master

--- a/.pfnci/wheel_nightly.sh
+++ b/.pfnci/wheel_nightly.sh
@@ -9,6 +9,10 @@ docker build -t devel .pfnci/docker/devel/
 CCACHE=$(mktemp -d)
 mount -t tmpfs tmpfs ${CCACHE}/ -o size=75%
 gsutil -q cp gs://tmp-pfn-public-ci/cupy/ccache.tar - | tar -xf - -C ${CCACHE}/ || true
+docker run --rm \
+       --volume ${CCACHE}/:/root/.ccache/ \
+       devel \
+       ccache --max-size=256Mi
 
 TEMP2=$(mktemp -d)
 cp -r . ${TEMP2}/


### PR DESCRIPTION
This PR adds a config of pfnCI that makes wheel package of master branch. The wheel packages are uploaded to GCS and they can be used in Chainer families CI.