### PR TITLE
Make k-means example's custom kernels simpler

### DIFF
--- a/examples/kmeans/kmeans.py
+++ b/examples/kmeans/kmeans.py
@@ -69,7 +69,7 @@ def fit(X, n_clusters, max_iter, use_custom_kernel):
             centers = sums / counts
         else:
             sums = sum_kernel(X, pred[:, None], i[:, None, None], axis=1)
-            counts = count_kernel(pred, i[:,None], axis=1)
+            counts = count_kernel(pred, i[:, None], axis=1)
             centers = sums / counts
 
     return centers, pred

--- a/examples/kmeans/kmeans.py
+++ b/examples/kmeans/kmeans.py
@@ -66,8 +66,9 @@ def fit(X, n_clusters, max_iter, use_custom_kernel):
         i = xp.arange(n_clusters)
         mask = pred == i[:, None]
         if not use_custom_kernel or xp == np:
-            centers = xp.stack([X[pred == i].mean(axis=0)
-                                for i in six.moves.range(n_clusters)])
+            sums = xp.where(mask[:, :, None], X, 0).sum(axis=1)
+            counts = xp.count_nonzero(mask, axis=1)
+            centers = sums / counts
         else:
             sums = sum_kernel(X, mask[:, :, None], axis=1)
             counts = count_kernel(mask, axis=1)

--- a/examples/kmeans/kmeans.py
+++ b/examples/kmeans/kmeans.py
@@ -45,8 +45,6 @@ def fit(X, n_clusters, max_iter, use_custom_kernel):
     initial_indexes = np.random.choice(len(X), n_clusters,
                                        replace=False).astype(np.int32)
     centers = X[initial_indexes]
-    data_num = X.shape[0]
-    data_dim = X.shape[1]
 
     for _ in six.moves.range(max_iter):
         # calculate distances and label

--- a/examples/kmeans/kmeans.py
+++ b/examples/kmeans/kmeans.py
@@ -69,7 +69,7 @@ def fit(X, n_clusters, max_iter, use_custom_kernel):
             centers = sums / counts
         else:
             sums = sum_kernel(X, pred[:, None], i[:, None, None], axis=1)
-            counts = count_kernel(pred, i[:, None], axis=1)
+            counts = count_kernel(pred, i[:,None], axis=1)
             centers = sums / counts
 
     return centers, pred

--- a/examples/kmeans/kmeans.py
+++ b/examples/kmeans/kmeans.py
@@ -25,14 +25,14 @@ var_kernel = cupy.ElementwiseKernel(
     'var_kernel'
 )
 sum_kernel = cupy.ReductionKernel(
-    'T x, S p, S i', 'T out',
-    'p == i ? x : 0',
+    'T x, S mask', 'T out',
+    'mask ? x : 0',
     'a + b', 'out = a', '0',
     'sum_kernel'
 )
 count_kernel = cupy.ReductionKernel(
-    'T p, S i', 'float32 out',
-    'p == i ? 1.0 : 0.0',
+    'T mask', 'float32 out',
+    'mask ? 1.0 : 0.0',
     'a + b', 'out = a', '0.0',
     'count_kernel'
 )
@@ -61,15 +61,15 @@ def fit(X, n_clusters, max_iter, use_custom_kernel):
         pred = new_pred
 
         # calculate centers
-        i = xp.arange(n_clusters, dtype=np.int32)
+        i = xp.arange(n_clusters)
+        mask = pred == i[:, None]
         if not use_custom_kernel or xp == np:
-            mask = pred == i[:, None]
             sums = xp.where(mask[:, :, None], X, 0).sum(axis=1)
             counts = xp.count_nonzero(mask, axis=1)
             centers = sums / counts
         else:
-            sums = sum_kernel(X, pred[:, None], i[:, None, None], axis=1)
-            counts = count_kernel(pred, i[:,None], axis=1)
+            sums = sum_kernel(X, mask[:, :, None], axis=1)
+            counts = count_kernel(mask, axis=1)
             centers = sums / counts
 
     return centers, pred


### PR DESCRIPTION
Close #2143.

This PR makes the k-means example's custom kernels simpler. Additionally, it makes the algorithm computing the centroids completely parallel.