### PR TITLE
fix compile error on CUDA 10.1 and GCC 7 or 8

### DIFF
--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -364,11 +364,6 @@ def make_extensions(options, compiler, use_cython):
     use_wheel_libs_rpath = (
         0 < len(options['wheel_libs']) and not PLATFORM_WIN32)
 
-    # This is a workaround for Anaconda.
-    # Anaconda installs libstdc++ from GCC 4.8 and it is not compatible
-    # with GCC 5's new ABI.
-    settings['define_macros'].append(('_GLIBCXX_USE_CXX11_ABI', '0'))
-
     # In the environment with CUDA 7.5 on Ubuntu 16.04, gcc5.3 does not
     # automatically deal with memcpy because string.h header file has
     # been changed. This is a workaround for that environment.


### PR DESCRIPTION
Fixes #2070. Though basic CUDA 10.1 support is added by #2117, compile error with GCC 7 or 8  has persisted on Ubuntu 18.04, Arch and Gentoo .

The error is at `basic_string.tcc`. [GCC's C++11 ABI change to support non-CoW string](https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_dual_abi.html) is likely related. As I noted on #2070, Anaconda had updated GCC. I think removing this workaround won't be problematic on Chainer v6 or later.