### PR TITLE
add diagonal method to dia_matrix class (cupyx.scipy.sparse)

### DIFF
--- a/cupyx/scipy/sparse/dia.py
+++ b/cupyx/scipy/sparse/dia.py
@@ -78,6 +78,21 @@ class dia_matrix(data._data_matrix):
         else:
             return dia_matrix((data, self.offsets), shape=self.shape)
 
+    def diagonal(self, k=0):
+        """Returns the k-th diagonal of the matrix.
+
+        Args:
+            k (int): The diagonal to get (corresponds to elements a[i, i + k]).
+        """
+        rows, cols = self.shape
+        if k <= -rows or k >= cols:
+            raise ValueError("k exceeds matrix dimensions")
+        idx, = cupy.nonzero(self.offsets == k)
+        first_col, last_col = max(0, k), min(rows + k, cols)
+        if idx.size == 0:
+            return cupy.zeros(last_col - first_col, dtype=self.data.dtype)
+        return self.data[idx[0], first_col:last_col]
+
     def get(self, stream=None):
         """Returns a copy of the array on host memory.
 

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_dia.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_dia.py
@@ -55,6 +55,20 @@ class TestDiaMatrix(unittest.TestCase):
         testing.assert_array_equal(
             self.m.data, cupy.array([[0, 1, 2], [3, 4, 5]], self.dtype))
 
+    def test_diagonal(self):
+        testing.assert_array_equal(
+            self.m.diagonal(-2), cupy.array([0], self.dtype))
+        testing.assert_array_equal(
+            self.m.diagonal(-1), cupy.array([3, 4], self.dtype))
+        testing.assert_array_equal(
+            self.m.diagonal(), cupy.array([0, 1, 2], self.dtype))
+        testing.assert_array_equal(
+            self.m.diagonal(1), cupy.array([0, 0, 0], self.dtype))
+        testing.assert_array_equal(
+            self.m.diagonal(2), cupy.array([0, 0], self.dtype))
+        testing.assert_array_equal(
+            self.m.diagonal(3), cupy.array([0], self.dtype))
+
     def test_offsets(self):
         self.assertEqual(self.m.offsets.dtype, numpy.int32)
         testing.assert_array_equal(
@@ -245,6 +259,12 @@ class TestDiaMatrixScipyComparison(unittest.TestCase):
     def test_transpose(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
         return m.transpose()
+
+    @testing.with_requires('scipy>=1.0.0')
+    @testing.numpy_cupy_raises(sp_name='sp')
+    def test_diagonal_error(self, xp, sp):
+        m = _make(xp, sp, self.dtype)
+        m.diagonal(k=10)  # out of range
 
 
 @testing.parameterize(*testing.product({


### PR DESCRIPTION
The implementation of diagonal used here is adapted from SciPy's. Prior to this PR, this method existed in the base class where it would try conversion to CSR, but CSR's own `diagonal` method is still marked TODO.

I have not attempted the CSR case here as it is a bit more complicated and will likely need some compiled code.
