### PR TITLE
add linalg.lstsq

### DIFF
--- a/cupy/linalg/__init__.py
+++ b/cupy/linalg/__init__.py
@@ -21,6 +21,7 @@ from cupy.linalg.eigenvalue import eigh  # NOQA
 from cupy.linalg.eigenvalue import eigvalsh  # NOQA
 
 from cupy.linalg.solve import inv  # NOQA
+from cupy.linalg.solve import lstsq  # NOQA
 from cupy.linalg.solve import pinv  # NOQA
 from cupy.linalg.solve import solve  # NOQA
 from cupy.linalg.solve import tensorinv  # NOQA

--- a/cupy/linalg/solve.py
+++ b/cupy/linalg/solve.py
@@ -166,7 +166,46 @@ def tensorsolve(a, b, axes=None):
     return result.reshape(oldshape)
 
 
-# TODO(okuta): Implement lstsq
+def lstsq(a, b, rcond=1e-15):
+    """Return the least-squares solution to a linear matrix equation.
+
+    Solves the equation `a x = b` by computing a vector `x` that
+    minimizes the Euclidean 2-norm `|| b - a x ||^2`.  The equation may
+    be under-, well-, or over- determined (i.e., the number of
+    linearly independent rows of `a` can be less than, equal to, or
+    greater than its number of linearly independent columns).  If `a`
+    is square and of full rank, then `x` (but for round-off error) is
+    the "exact" solution of the equation.
+
+    Args:
+        a (cupy.ndarray): "Coefficient" matrix with dimension ``(M, N)``
+        b (cupy.ndarray): "Dependent variable" values with dimension ``(M,)``
+            or ``(M, K)``
+        rcond (float): Cutoff parameter for small singular values.
+            For stability it computes the largest singular value denoted by
+            ``s``, and sets all singular values smaller than ``s`` to zero.
+
+    Returns:
+        cupy.ndarray: The least-squares solution with shape ``(N,)`` or
+            ``(N, K)`` depending if ``b`` was two-dimensional.
+
+    Notes:
+        This only returns the least-squares solution! Note that
+        `numpy.linalg.lstsq` returns the residuals, rank, and singular values
+        in addition to the least-squares solution.
+
+    .. seealso:: :func:`numpy.linalg.lstsq`
+    """
+    b_shape = b.shape
+    u, s, vt = decomposition.svd(a, full_matrices=False)
+    cutoff = rcond * s.max()
+    s1 = 1 / s
+    s1[s <= cutoff] = 0
+    if len(b_shape) > 1:
+        s1 = cupy.repeat(s1.reshape(-1, 1), b_shape[1], axis=1)
+    z = core.dot(u.transpose(), b) * s1
+    x = core.dot(vt.transpose(), z)
+    return x
 
 
 def inv(a):

--- a/cupy/linalg/solve.py
+++ b/cupy/linalg/solve.py
@@ -196,11 +196,6 @@ def lstsq(a, b, rcond=1e-15):
             the shape is (K,). The ``rank`` of matrix ``a`` is an integer. The
             singular values of ``a`` are ``s``.
 
-    Notes:
-        This only returns the least-squares solution! Note that
-        `numpy.linalg.lstsq` returns the residuals, rank, and singular values
-        in addition to the least-squares solution.
-
     .. seealso:: :func:`numpy.linalg.lstsq`
     """
     m, n = a.shape[-2:]

--- a/tests/cupy_tests/linalg_tests/test_solve.py
+++ b/tests/cupy_tests/linalg_tests/test_solve.py
@@ -162,18 +162,18 @@ class TestLstsq(unittest.TestCase):
         b_gpu = cupy.asarray(b_cpu)
         a_gpu_copy = a_gpu.copy()
         b_gpu_copy = b_gpu.copy()
-        result_cpu, resids_cpu, rank_cpu, s_cpu = numpy.linalg.lstsq(a_cpu,
-                                                                     b_cpu,
-                                                                     rcond=rcond)  # noqa E501
-        result_gpu, resids_gpu, rank_gpu, s_gpu = cupy.linalg.lstsq(a_gpu,
-                                                                    b_gpu,
-                                                                    rcond=rcond)  # noqa E501
-        self.assertEqual(result_cpu.dtype, result_gpu.dtype)
+        x_cpu, resids_cpu, rank_cpu, s_cpu = numpy.linalg.lstsq(a_cpu,
+                                                                b_cpu,
+                                                                rcond=rcond)
+        x_gpu, resids_gpu, rank_gpu, s_gpu = cupy.linalg.lstsq(a_gpu,
+                                                               b_gpu,
+                                                               rcond=rcond)
+        self.assertEqual(x_cpu.dtype, x_gpu.dtype)
         # check the least squares solutions are close
-        cupy.testing.assert_allclose(result_cpu, result_gpu, atol=1e-3)
-        cupy.testing.assert_allclose(resids_cpu, resids_gpu, atol=1e-3)
-        cupy.testing.assert_allclose(rank_cpu, rank_gpu, atol=1e-3)
-        cupy.testing.assert_allclose(s_cpu, s_gpu, atol=1e-3)
+        cupy.testing.assert_allclose(x_cpu, x_gpu, atol=1e-5)
+        cupy.testing.assert_allclose(resids_cpu, resids_gpu, atol=1e-5)
+        cupy.testing.assert_allclose(rank_cpu, rank_gpu, atol=1e-5)
+        cupy.testing.assert_allclose(s_cpu, s_gpu, atol=1e-5)
         # check that lstsq did not modify arrays
         cupy.testing.assert_array_equal(a_gpu_copy, a_gpu)
         cupy.testing.assert_array_equal(b_gpu_copy, b_gpu)

--- a/tests/cupy_tests/linalg_tests/test_solve.py
+++ b/tests/cupy_tests/linalg_tests/test_solve.py
@@ -162,11 +162,18 @@ class TestLstsq(unittest.TestCase):
         b_gpu = cupy.asarray(b_cpu)
         a_gpu_copy = a_gpu.copy()
         b_gpu_copy = b_gpu.copy()
-        result_cpu, _, _, _ = numpy.linalg.lstsq(a_cpu, b_cpu, rcond=rcond)
-        result_gpu = cupy.linalg.lstsq(a_gpu, b_gpu, rcond=rcond)
+        result_cpu, resids_cpu, rank_cpu, s_cpu = numpy.linalg.lstsq(a_cpu,
+                                                                     b_cpu,
+                                                                     rcond=rcond)  # noqa E501
+        result_gpu, resids_gpu, rank_gpu, s_gpu = cupy.linalg.lstsq(a_gpu,
+                                                                    b_gpu,
+                                                                    rcond=rcond)  # noqa E501
 
         self.assertEqual(result_cpu.dtype, result_gpu.dtype)
         cupy.testing.assert_allclose(result_cpu, result_gpu, atol=1e-3)
+        cupy.testing.assert_allclose(resids_cpu, resids_gpu, atol=1e-3)
+        cupy.testing.assert_allclose(rank_cpu, rank_gpu, atol=1e-3)
+        cupy.testing.assert_allclose(s_cpu, s_gpu, atol=1e-3)
         cupy.testing.assert_array_equal(a_gpu_copy, a_gpu)
         cupy.testing.assert_array_equal(b_gpu_copy, b_gpu)
 

--- a/tests/cupy_tests/linalg_tests/test_solve.py
+++ b/tests/cupy_tests/linalg_tests/test_solve.py
@@ -170,10 +170,10 @@ class TestLstsq(unittest.TestCase):
                                                                rcond=rcond)
         self.assertEqual(x_cpu.dtype, x_gpu.dtype)
         # check the least squares solutions are close
-        cupy.testing.assert_allclose(x_cpu, x_gpu, atol=1e-5)
-        cupy.testing.assert_allclose(resids_cpu, resids_gpu, atol=1e-5)
+        cupy.testing.assert_allclose(x_cpu, x_gpu, atol=1e-3)
+        cupy.testing.assert_allclose(resids_cpu, resids_gpu, atol=1e-3)
         self.assertEqual(rank_cpu, rank_gpu)
-        cupy.testing.assert_allclose(s_cpu, s_gpu, atol=1e-5)
+        cupy.testing.assert_allclose(s_cpu, s_gpu, atol=1e-3)
         # check that lstsq did not modify arrays
         cupy.testing.assert_array_equal(a_gpu_copy, a_gpu)
         cupy.testing.assert_array_equal(b_gpu_copy, b_gpu)

--- a/tests/cupy_tests/linalg_tests/test_solve.py
+++ b/tests/cupy_tests/linalg_tests/test_solve.py
@@ -172,7 +172,7 @@ class TestLstsq(unittest.TestCase):
         # check the least squares solutions are close
         cupy.testing.assert_allclose(x_cpu, x_gpu, atol=1e-5)
         cupy.testing.assert_allclose(resids_cpu, resids_gpu, atol=1e-5)
-        cupy.testing.assert_allclose(rank_cpu, rank_gpu, atol=1e-5)
+        self.assertEqual(rank_cpu, rank_gpu)
         cupy.testing.assert_allclose(s_cpu, s_gpu, atol=1e-5)
         # check that lstsq did not modify arrays
         cupy.testing.assert_array_equal(a_gpu_copy, a_gpu)


### PR DESCRIPTION
Adds ```cupy.linalg.lstsq```

This solves a least squares problem using SVD similar to ```numpy.linalg.lstsq```.

This only returns the least-squares solution, while `numpy.linalg.lstsq` returns the residuals, rank, and singular values in addition to the least-squares solution.

If it's necessary to have 100% return syntax match to `numpy.linalg.lstsq`, I can modify this pr to include residuals, rank, and singular values.


Closes https://github.com/cupy/cupy/issues/1273

---
Edit 04-28-2019 22:54 EDT.

I have a [benchmark](https://jekel.me/2019/Compare-lstsq-performance-in-Python/) comparing the performance of this ```cupy.linalg.lstsq``` vs ```numpy.linalg.lstsq```, where CuPy was about six times faster on an AMD FX-8350 with NVIDIA Titan Xp for 6,000,000 data points. I'd be curious if this was true on different hardware configurations. The code to run the benchmark is [here](https://github.com/cjekel/pwlf_scipy_tf_benchmarks/tree/master/cupy), and was run in the following order:
```python
python3 sine_benchmark_fixed_six_break_points.py
python3 sine_benchmark_fixed_six_break_points_TFnoGPU.py
python3 sine_benchmark_fixed_twenty_break_points.py
python3 sine_benchmark_fixed_twenty_break_points_TFnoGPU.py
python3 plot_results.py
```

