### PR TITLE
Avoid using Tensor Core with cuDNN deterministic mode in convolution backward

### DIFF
--- a/cupy/cudnn.pyx
+++ b/cupy/cudnn.pyx
@@ -1652,7 +1652,8 @@ def convolution_backward_filter(
         zero = <size_t>&float_zero
         one = <size_t>&float_one
 
-    cdef bint use_tensor_core = _should_use_tensor_core(tensor_core, x.dtype)
+    cdef bint use_tensor_core = (
+        not deterministic and _should_use_tensor_core(tensor_core, x.dtype))
     cdef tuple conv_param = (pad, stride, x.dtype, use_tensor_core)
 
     handle = get_handle()
@@ -1732,7 +1733,8 @@ def convolution_backward_data(
         zero = <size_t>&float_zero
         one = <size_t>&float_one
 
-    cdef bint use_tensor_core = _should_use_tensor_core(tensor_core, x.dtype)
+    cdef bint use_tensor_core = (
+        not deterministic and _should_use_tensor_core(tensor_core, x.dtype))
     cdef tuple conv_param = (pad, stride, x.dtype, use_tensor_core)
 
     # cuDNN 7 supports dilation only in *_FWD_ALGO_IMPLICIT_GEMM, but

--- a/cupy/cudnn.pyx
+++ b/cupy/cudnn.pyx
@@ -1652,6 +1652,8 @@ def convolution_backward_filter(
         zero = <size_t>&float_zero
         one = <size_t>&float_one
 
+    # Disable use_tensor_core in deterministic mode because
+    # CUDNN_CONVOLUTION_BWD_FILTER_ALGO_1 does not use Tensor Core.
     cdef bint use_tensor_core = (
         not deterministic and _should_use_tensor_core(tensor_core, x.dtype))
     cdef tuple conv_param = (pad, stride, x.dtype, use_tensor_core)
@@ -1679,6 +1681,7 @@ def convolution_backward_filter(
             cudnn.CUDNN_CROSS_CORRELATION, use_tensor_core)
 
         if deterministic:
+            # TODO(imanishi): Support Tensor Core in deterministic mode.
             algo = cudnn.CUDNN_CONVOLUTION_BWD_FILTER_ALGO_1
             workspace_size = cudnn.getConvolutionBackwardFilterWorkspaceSize(
                 handle, x_desc, gy_desc, conv_desc, filter_desc, algo)
@@ -1733,6 +1736,8 @@ def convolution_backward_data(
         zero = <size_t>&float_zero
         one = <size_t>&float_one
 
+    # Disable use_tensor_core in deterministic mode because
+    # CUDNN_CONVOLUTION_BWD_DATA_ALGO_1 does not use Tensor Core.
     cdef bint use_tensor_core = (
         not deterministic and _should_use_tensor_core(tensor_core, x.dtype))
     cdef tuple conv_param = (pad, stride, x.dtype, use_tensor_core)
@@ -1770,6 +1775,7 @@ def convolution_backward_data(
             cudnn.CUDNN_CROSS_CORRELATION, use_tensor_core)
 
         if deterministic:
+            # TODO(imanishi): Support Tensor Core in deterministic mode.
             algo = cudnn.CUDNN_CONVOLUTION_BWD_DATA_ALGO_1
             workspace_size = cudnn.getConvolutionBackwardDataWorkspaceSize(
                 handle, filter_desc, x_desc, conv_desc, y_desc, algo)


### PR DESCRIPTION
This PR may fix: https://ci.preferred.jp/chainer.py37.gpu/5842/
```py
    try:
        _create_tensor_descriptor(x_desc, x, format=d_layout)
        _create_tensor_descriptor(gy_desc, gy, format=d_layout)
        _create_filter_descriptor(filter_desc, gW, w_layout)
        _create_convolution_descriptor(
            conv_desc, pad, stride, dilation, groups, x.dtype,
            cudnn.CUDNN_CROSS_CORRELATION, use_tensor_core)
        if deterministic:
            algo = cudnn.CUDNN_CONVOLUTION_BWD_FILTER_ALGO_1
            workspace_size = cudnn.getConvolutionBackwardFilterWorkspaceSize(
                handle, x_desc, gy_desc, conv_desc, filter_desc, algo)
            math_type = cudnn.CUDNN_DEFAULT_MATH
            # TODO(okuta): check workspace size
```
In deterministic mode, `conv_desc` might be created with `use_tensor_core` is `True` whereas the algorithm does not Tensor Core.
This PR fixes this bug by disabling `use_tensor_core` in deterministic mode.

Related to #1380.