### PR TITLE
Complex support for cp.where()

### DIFF
--- a/cupy/sorting/search.py
+++ b/cupy/sorting/search.py
@@ -100,7 +100,7 @@ _where_ufunc = core.create_ufunc(
      # works).
      # See issue #551.
      '?hd->d', '?Hd->d',
-     '?dd->d'),
+     '?dd->d', '?FF->F', '?DD->D'),
     'out0 = in0 ? in1 : in2')
 
 

--- a/tests/cupy_tests/sorting_tests/test_search.py
+++ b/tests/cupy_tests/sorting_tests/test_search.py
@@ -163,7 +163,7 @@ class TestSearch(unittest.TestCase):
 class TestWhereTwoArrays(unittest.TestCase):
 
     @testing.for_all_dtypes_combination(
-        names=['cond_type', 'x_type', 'y_type'], no_complex=True)
+        names=['cond_type', 'x_type', 'y_type'], no_complex=False)
     @testing.numpy_cupy_allclose()
     def test_where_two_arrays(self, xp, cond_type, x_type, y_type):
         m = testing.shaped_random(self.cond_shape, xp, xp.bool_)
@@ -184,7 +184,7 @@ class TestWhereTwoArrays(unittest.TestCase):
 @testing.gpu
 class TestWhereCond(unittest.TestCase):
 
-    @testing.for_all_dtypes(no_complex=True)
+    @testing.for_all_dtypes(no_complex=False)
     @testing.numpy_cupy_array_list_equal()
     def test_where_cond(self, xp, dtype):
         m = testing.shaped_random(self.cond_shape, xp, xp.bool_)

--- a/tests/cupy_tests/sorting_tests/test_search.py
+++ b/tests/cupy_tests/sorting_tests/test_search.py
@@ -163,7 +163,7 @@ class TestSearch(unittest.TestCase):
 class TestWhereTwoArrays(unittest.TestCase):
 
     @testing.for_all_dtypes_combination(
-        names=['cond_type', 'x_type', 'y_type'], no_complex=False)
+        names=['cond_type', 'x_type', 'y_type'])
     @testing.numpy_cupy_allclose()
     def test_where_two_arrays(self, xp, cond_type, x_type, y_type):
         m = testing.shaped_random(self.cond_shape, xp, xp.bool_)
@@ -184,7 +184,7 @@ class TestWhereTwoArrays(unittest.TestCase):
 @testing.gpu
 class TestWhereCond(unittest.TestCase):
 
-    @testing.for_all_dtypes(no_complex=False)
+    @testing.for_all_dtypes()
     @testing.numpy_cupy_array_list_equal()
     def test_where_cond(self, xp, dtype):
         m = testing.shaped_random(self.cond_shape, xp, xp.bool_)


### PR DESCRIPTION
This is an attempt to solve issue #2164.