### PR TITLE
Revert "Improve kernel launch performance"

### DIFF
--- a/cupy/core/carray.pxi
+++ b/cupy/core/carray.pxi
@@ -1,8 +1,11 @@
 import os
 
 from cupy import cuda
+
 from cupy.cuda cimport function
 from cupy.cuda cimport runtime
+
+import warnings
 
 
 cdef struct _CArray:
@@ -17,7 +20,8 @@ cdef class CArray(CPointer):
         _CArray val
 
     def __init__(self, ndarray arr):
-        cdef int i, ndim = arr._shape.size()
+        cdef Py_ssize_t i
+        cdef int ndim = arr._shape.size()
         self.val.data = <void*>arr.data.ptr
         self.val.size = arr.size
         for i in range(ndim):
@@ -37,7 +41,7 @@ cdef class CIndexer(CPointer):
 
     def __init__(self, Py_ssize_t size, tuple shape):
         self.val.size = size
-        cdef int i
+        cdef Py_ssize_t i
         for i in range(len(shape)):
             self.val.shape_and_index[i] = shape[i]
         self.ptr = <void*>&self.val
@@ -45,7 +49,7 @@ cdef class CIndexer(CPointer):
 
 cdef class Indexer:
     def __init__(self, tuple shape):
-        cdef Py_ssize_t s, size = 1
+        cdef Py_ssize_t size = 1
         for s in shape:
             size *= s
         self.shape = shape

--- a/cupy/core/core.pxd
+++ b/cupy/core/core.pxd
@@ -1,9 +1,8 @@
 from libcpp cimport vector
+from cupy.cuda cimport memory
 
 from cupy.cuda.function cimport CPointer
 from cupy.cuda.function cimport Module
-from cupy.cuda cimport memory
-
 
 cdef class ndarray:
     cdef:

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2,7 +2,6 @@
 
 from __future__ import division
 import sys
-import warnings
 
 import ctypes
 import numpy

--- a/cupy/cuda/function.pyx
+++ b/cupy/cuda/function.pyx
@@ -4,28 +4,108 @@ import numpy
 import six
 
 cimport cpython  # NOQA
+from libc.stdint cimport int8_t
+from libc.stdint cimport int16_t
+from libc.stdint cimport int32_t
+from libc.stdint cimport int64_t
+from libc.stdint cimport intptr_t
 from libcpp cimport vector
 
 
 from cupy.cuda cimport driver
 from cupy.cuda cimport runtime
-from cupy.core cimport _scalar
 from cupy.core cimport core
 from cupy.cuda cimport stream as stream_module
 
 
+cdef class CPointer:
+    def __init__(self, p=0):
+        self.ptr = <void*>p
+
+
+cdef class CInt8(CPointer):
+    cdef:
+        int8_t val
+
+    def __init__(self, int8_t v):
+        self.val = v
+        self.ptr = <void*>&self.val
+
+
+cdef class CInt16(CPointer):
+    cdef:
+        int16_t val
+
+    def __init__(self, int16_t v):
+        self.val = v
+        self.ptr = <void*>&self.val
+
+
+cdef class CInt32(CPointer):
+    cdef:
+        int32_t val
+
+    def __init__(self, int32_t v):
+        self.val = v
+        self.ptr = <void*>&self.val
+
+
+cdef class CInt64(CPointer):
+    cdef:
+        int64_t val
+
+    def __init__(self, int64_t v):
+        self.val = v
+        self.ptr = <void*>&self.val
+
+
+cdef class CInt128(CPointer):
+    cdef:
+        double complex val
+
+    def __init__(self, double complex v):
+        self.val = v
+        self.ptr = <void*>&self.val
+
+
+cdef set _pointer_numpy_types = {numpy.dtype(i).type
+                                 for i in '?bhilqBHILQefdFD'}
+
+
 cdef inline CPointer _pointer(x):
-    if isinstance(x, CPointer):
-        return x
+    cdef Py_ssize_t itemsize
+    if x is None:
+        return CPointer()
     if isinstance(x, core.ndarray):
         return (<core.ndarray>x).get_pointer()
     if isinstance(x, core.Indexer):
         return (<core.Indexer>x).get_pointer()
 
-    ret = _scalar.convert_scalar(x, True)
-    if ret is None:
-        raise TypeError('Unsupported type %s' % type(x))
-    return ret
+    if isinstance(x, CPointer):
+        return x
+
+    if type(x) not in _pointer_numpy_types:
+        if isinstance(x, six.integer_types):
+            x = numpy.int64(x)
+        elif isinstance(x, float):
+            x = numpy.float64(x)
+        elif isinstance(x, bool):
+            x = numpy.bool_(x)
+        else:
+            raise TypeError('Unsupported type %s' % type(x))
+
+    itemsize = x.itemsize
+    if itemsize == 1:
+        return CInt8(x.view(numpy.int8))
+    if itemsize == 2:
+        return CInt16(x.view(numpy.int16))
+    if itemsize == 4:
+        return CInt32(x.view(numpy.int32))
+    if itemsize == 8:
+        return CInt64(x.view(numpy.int64))
+    if itemsize == 16:
+        return CInt128(x.view(numpy.complex128))
+    raise TypeError('Unsupported type %s. (size=%d)', type(x), itemsize)
 
 
 cdef inline size_t _get_stream(stream) except *:
@@ -43,8 +123,6 @@ cdef _launch(intptr_t func, Py_ssize_t grid0, int grid1, int grid2,
     cdef CPointer cp
     kargs.reserve(len(args))
     for a in args:
-        if a is None:
-            kargs.push_back(<void*>0)
         cp = _pointer(a)
         pargs.append(cp)
         kargs.push_back(cp.ptr)


### PR DESCRIPTION
Reverts cupy/cupy#719

This caused test errors in ChainerCV.
https://ci.preferred.jp/chainer.py3.cv.gpu/6895/