### PR TITLE
Fix `array_split` with non-equally dividing sections

### DIFF
--- a/cupy/core/_routines_manipulation.pyx
+++ b/cupy/core/_routines_manipulation.pyx
@@ -398,6 +398,7 @@ cpdef ndarray _transpose(ndarray self, const vector.vector[Py_ssize_t] &axes):
 
 cpdef array_split(ndarray ary, indices_or_sections, Py_ssize_t axis):
     cdef Py_ssize_t i, ndim, size, each_size, index, prev, offset, stride
+    cdef Py_ssize_t num_large
     cdef vector.vector[Py_ssize_t] shape
 
     ndim = ary.ndim
@@ -408,8 +409,9 @@ cpdef array_split(ndarray ary, indices_or_sections, Py_ssize_t axis):
     size = ary._shape[axis]
 
     if numpy.isscalar(indices_or_sections):
-        each_size = (size - 1) // indices_or_sections + 1
-        indices = [i * each_size
+        each_size = (size - 1) // indices_or_sections
+        num_large = (size - 1) % indices_or_sections + 1
+        indices = [i * each_size + min(i, num_large)
                    for i in range(1, indices_or_sections)]
     else:
         indices = [i if i >= 0 else size + i for i in indices_or_sections]

--- a/tests/cupy_tests/manipulation_tests/test_split.py
+++ b/tests/cupy_tests/manipulation_tests/test_split.py
@@ -1,3 +1,4 @@
+import itertools
 import unittest
 
 from cupy import testing
@@ -6,69 +7,58 @@ from cupy import testing
 @testing.gpu
 class TestSplit(unittest.TestCase):
 
-    @testing.numpy_cupy_array_equal()
+    @testing.numpy_cupy_array_list_equal()
     def test_array_split1(self, xp):
         a = testing.shaped_arange((3, 11), xp)
-        split = xp.array_split(a, 4, 1)
-        return xp.concatenate(split, 1)
+        return xp.array_split(a, 4, 1)
 
-    @testing.numpy_cupy_array_equal()
+    @testing.numpy_cupy_array_list_equal()
     def test_array_split2(self, xp):
         a = testing.shaped_arange((3, 11), xp)
-        split = xp.array_split(a, 4, -1)
-        return xp.concatenate(split, -1)
+        return xp.array_split(a, 4, -1)
 
     @testing.with_requires('numpy>=1.11')
-    @testing.numpy_cupy_array_equal()
+    @testing.numpy_cupy_array_list_equal()
     def test_array_split_empty_array(self, xp):
         a = testing.shaped_arange((5, 0), xp)
-        split = xp.array_split(a, [2, 4], 0)
-        return xp.concatenate(split, 0)
+        return xp.array_split(a, [2, 4], 0)
 
-    @testing.numpy_cupy_array_equal()
+    @testing.numpy_cupy_array_list_equal()
     def test_array_split_empty_sections(self, xp):
         a = testing.shaped_arange((3, 11), xp)
-        split = xp.array_split(a, [])
-        return xp.concatenate(split, 0)
+        return xp.array_split(a, [])
 
-    @testing.numpy_cupy_array_equal()
+    @testing.numpy_cupy_array_list_equal()
     def test_dsplit(self, xp):
         a = testing.shaped_arange((3, 3, 12), xp)
-        split = xp.dsplit(a, 4)
-        return xp.dstack(split)
+        return xp.dsplit(a, 4)
 
-    @testing.numpy_cupy_array_equal()
+    @testing.numpy_cupy_array_list_equal()
     def test_hsplit_vectors(self, xp):
         a = testing.shaped_arange((12,), xp)
-        split = xp.hsplit(a, 4)
-        return xp.hstack(split)
+        return xp.hsplit(a, 4)
 
-    @testing.numpy_cupy_array_equal()
+    @testing.numpy_cupy_array_list_equal()
     def test_hsplit(self, xp):
         a = testing.shaped_arange((3, 12), xp)
-        split = xp.hsplit(a, 4)
-        return xp.hstack(split)
+        return xp.hsplit(a, 4)
 
-    @testing.numpy_cupy_array_equal()
+    @testing.numpy_cupy_array_list_equal()
     def test_split_by_sections1(self, xp):
         a = testing.shaped_arange((3, 11), xp)
-        split = xp.split(a, (2, 4, 9), 1)
-        return xp.concatenate(split, 1)
+        return xp.split(a, (2, 4, 9), 1)
 
-    @testing.numpy_cupy_array_equal()
+    @testing.numpy_cupy_array_list_equal()
     def test_split_by_sections2(self, xp):
         a = testing.shaped_arange((3, 11), xp)
-        split = xp.split(a, (2, 4, 9), -1)
-        return xp.concatenate(split, -1)
+        return xp.split(a, (2, 4, 9), -1)
 
-    @testing.numpy_cupy_array_equal()
+    @testing.numpy_cupy_array_list_equal()
     def test_split_by_sections3(self, xp):
         a = testing.shaped_arange((3, 11), xp)
-        split = xp.split(a, (-9, 4, -2), 1)
-        return xp.concatenate(split, 1)
+        return xp.split(a, (-9, 4, -2), 1)
 
-    @testing.numpy_cupy_array_equal()
+    @testing.numpy_cupy_array_list_equal()
     def test_vsplit(self, xp):
         a = testing.shaped_arange((12, 3), xp)
-        split = xp.vsplit(a, 4)
-        return xp.vstack(split)
+        return xp.vsplit(a, 4)

--- a/tests/cupy_tests/manipulation_tests/test_split.py
+++ b/tests/cupy_tests/manipulation_tests/test_split.py
@@ -1,4 +1,3 @@
-import itertools
 import unittest
 
 from cupy import testing
@@ -27,6 +26,11 @@ class TestSplit(unittest.TestCase):
     def test_array_split_empty_sections(self, xp):
         a = testing.shaped_arange((3, 11), xp)
         return xp.array_split(a, [])
+
+    @testing.numpy_cupy_array_list_equal()
+    def test_array_split_non_divisible(self, xp):
+        a = testing.shaped_arange((5, 3), xp)
+        return xp.array_split(a, 4)
 
     @testing.numpy_cupy_array_list_equal()
     def test_dsplit(self, xp):


### PR DESCRIPTION
Fix #2206.

The incorrect result appears when `sections` does not divide the input length. I also fixed all the tests for `split.py` to check the divided inputs rather than the re-concatenated one so that the split points are also checked.