### PR TITLE
Support cuTENSOR

### DIFF
--- a/cupy/cuda/__init__.py
+++ b/cupy/cuda/__init__.py
@@ -39,6 +39,12 @@ try:
 except ImportError:
     nccl_enabled = False
 
+try:
+    from cupy.cuda import cutensor  # NOQA
+    cutensor_enabled = True
+except ImportError:
+    cutensor_enabled = False
+
 
 def is_available():
     global _available

--- a/cupy/cuda/cupy_cutensor.h
+++ b/cupy/cuda/cupy_cutensor.h
@@ -1,0 +1,72 @@
+// Stub header file of cuTENSOR
+
+#ifndef INCLUDE_GUARD_CUPY_CUTENSOR_H
+#define INCLUDE_GUARD_CUPY_CUTENSOR_H
+
+#ifndef CUPY_NO_CUDA
+
+#include <library_types.h>
+#include <cutensor.h>
+
+#else // #ifndef CUPY_NO_CUDA
+
+extern "C" {
+
+    typedef enum {} cudaDataType_t;
+
+    typedef enum {
+	CUTENSOR_STATUS_SUCCESS = 0,
+    } cutensorStatus_t;
+
+    typedef enum {} cutensorAlgo_t;
+    typedef enum {} cutensorOperator_t;
+    typedef enum {} cutensorWorksizePreference_t;
+
+    typedef void* cutensorHandle_t;
+    typedef void* cutensorTensorDescriptor_t;
+
+    cutensorStatus_t cutensorCreate(...) {
+	return CUTENSOR_STATUS_SUCCESS;
+    }
+
+    cutensorStatus_t cutensorDestroy(...) {
+	return CUTENSOR_STATUS_SUCCESS;
+    }
+
+    cutensorStatus_t cutensorCreateTensorDescriptor(...) {
+	return CUTENSOR_STATUS_SUCCESS;
+    }
+
+    cutensorStatus_t cutensorDestroyTensorDescriptor(...) {
+	return CUTENSOR_STATUS_SUCCESS;
+    }
+
+    cutensroStatus_t cutensorElementwiseTrinary(...) {
+	return CUTENSOR_STATUS_SUCCESS;
+    }
+
+    cutensroStatus_t cutensorElementwiseBinary(...) {
+	return CUTENSOR_STATUS_SUCCESS;
+    }
+
+    cutensroStatus_t cutensorContraction(...) {
+	return CUTENSOR_STATUS_SUCCESS;
+    }
+
+    cutensroStatus_t cutensorContractionGetWorkspace(...) {
+	return CUTENSOR_STATUS_SUCCESS;
+    }
+
+    cutensorStatus_t cutensorContractionMaxAlgos(...) {
+	return CUTENSOR_STATUS_SUCCESS;
+    }
+
+    const char* cutensorGetErrorString(...) {
+	return NULL;
+    }
+
+} // extern "C"
+
+#endif // #ifndef CUPY_NO_CUDA
+
+#endif // #ifndef INCLUDE_GUARD_CUPY_CUTENSOR_H

--- a/cupy/cuda/cupy_cutensor.h
+++ b/cupy/cuda/cupy_cutensor.h
@@ -41,19 +41,19 @@ extern "C" {
 	return CUTENSOR_STATUS_SUCCESS;
     }
 
-    cutensroStatus_t cutensorElementwiseTrinary(...) {
+    cutensorStatus_t cutensorElementwiseTrinary(...) {
 	return CUTENSOR_STATUS_SUCCESS;
     }
 
-    cutensroStatus_t cutensorElementwiseBinary(...) {
+    cutensorStatus_t cutensorElementwiseBinary(...) {
 	return CUTENSOR_STATUS_SUCCESS;
     }
 
-    cutensroStatus_t cutensorContraction(...) {
+    cutensorStatus_t cutensorContraction(...) {
 	return CUTENSOR_STATUS_SUCCESS;
     }
 
-    cutensroStatus_t cutensorContractionGetWorkspace(...) {
+    cutensorStatus_t cutensorContractionGetWorkspace(...) {
 	return CUTENSOR_STATUS_SUCCESS;
     }
 

--- a/cupy/cuda/cutensor.pyx
+++ b/cupy/cuda/cutensor.pyx
@@ -1,0 +1,525 @@
+# distutils: language = c++
+
+"""Thin wrapper of cuTENSOR."""
+
+cimport cython  # NOQA
+from libc.stdint cimport int32_t, uint32_t, int64_t, uint64_t  # NOQA
+
+from cupy.cuda cimport driver
+from cupy.cuda cimport stream as stream_module
+
+cdef extern from 'cupy_cutensor.h' nogil:
+    ctypedef int Status 'cutensorStatus_t'
+    ctypedef int Algo 'cutensorAlgo_t'
+    ctypedef int Operator 'cutensorOperator_t'
+    ctypedef int WorksizePreference 'cutensorWorksizePreference_t'
+    ctypedef int DataType 'cudaDataType_t'
+
+    ctypedef void* Handle 'cutensorHandle_t'
+    ctypedef void* TensorDescriptor 'cutensorTensorDescriptor_t'
+
+    const char* cutensorGetErrorString(Status status)
+
+    int cutensorCreate(Handle* handle)
+
+    int cutensorDestroy(Handle handle)
+
+    int cutensorCreateTensorDescriptor(
+        TensorDescriptor* desc,
+        uint32_t numModes,
+        int64_t* extent,
+        int64_t* stride,
+        DataType dataType,
+        Operator unaryOp,
+        uint32_t vectorWidth,
+        uint32_t vectorModeIndex)
+
+    int cutensorDestroyTensorDescriptor(TensorDescriptor desc)
+
+    int cutensorElementwiseTrinary(
+        Handle handle,
+        void* alpha,
+        void* A, TensorDescriptor descA, int32_t* modeA,
+        void* beta,
+        void* B, TensorDescriptor descB, int32_t* modeB,
+        void* gamma,
+        void* C, TensorDescriptor descC, int32_t* modeC,
+        void* D, TensorDescriptor descD, int32_t* modeD,
+        Operator otAB, Operator otABC,
+        DataType typeCompute, driver.Stream stream)
+
+    int cutensorElementwiseBinary(
+        Handle handle,
+        void* alpha,
+        void* A, TensorDescriptor descA, int32_t* modeA,
+        void* gamma,
+        void* C, TensorDescriptor descC, int32_t* modeC,
+        void* D, TensorDescriptor descD, int32_t* modeD,
+        Operator otAC,
+        DataType typeCompute, driver.Stream stream)
+
+    int cutensorContraction(
+        Handle handle,
+        void* alpha,
+        void* A, TensorDescriptor descA, int32_t* modeA,
+        void* B, TensorDescriptor descB, int32_t* modeB,
+        void* beta,
+        void* C, TensorDescriptor descC, int32_t* modeC,
+        void* D, TensorDescriptor descD, int32_t* modeD,
+        Operator opOut, DataType typeCompute, Algo algo,
+        void* workspace, uint64_t workspaceSize, driver.Stream stream)
+
+    int cutensorContractionGetWorkspace(
+        Handle handle,
+        void* A, TensorDescriptor descA, int32_t* modeA,
+        void* B, TensorDescriptor descB, int32_t* modeB,
+        void* C, TensorDescriptor descC, int32_t* modeC,
+        void* D, TensorDescriptor descD, int32_t* modeD,
+        Operator opOut, DataType typeCompute, Algo algo,
+        WorksizePreference pref, uint64_t* workspaceSize)
+
+    int cutensorContractionMaxAlgos(int32_t* maxNumAlgos)
+
+###############################################################################
+# Enum
+###############################################################################
+
+cpdef enum:
+    # cutensorAlgo_t (values > 0 correspond to certain algorithms of GETT)
+    ALGO_TGETT = -7           # NOQA, Transpose (A or B) + GETT
+    ALGO_GETT = -6            # NOQA, Choose the GETT algorithm
+    ALGO_LOG_TENSOR_OP = -5   # NOQA, Loop-over-GEMM approach using tensor cores
+    ALGO_LOG = -4             # NOQA, Loop-over-GEMM approach
+    ALGO_TTGT_TENSOR_OP = -3  # NOQA, Transpose-Transpose-GEMM-Transpose using tensor cores (requires additional memory)
+    ALGO_TTGT = -2            # NOQA, Transpose-Transpose-GEMM-Transpose (requires additional memory)
+    ALGO_DEFAULT = -1         # NOQA, Lets the internal heuristic choose
+
+    # cutensorOperator_t (Unary)
+    OP_IDENTITY = 1
+    OP_SQRT = 2
+    OP_RELU = 8
+    OP_CONJ = 9
+    OP_RCP = 10
+
+    # cutensorOperator_t (Binary)
+    OP_ADD = 3
+    OP_MUL = 5
+    OP_MAX = 6
+    OP_MIN = 7
+
+    # cutensorStatus_t
+    STATUS_SUCCESS = 0
+    STATUS_NOT_INITIALIZED = 1
+    STATUS_ALLOC_FAILED = 3
+    STATUS_INVALID_VALUE = 7
+    STATUS_ARCH_MISMATCH = 8  # NOQA, Indicates that the device is either not ready, or the target architecture is not supported.
+    STATUS_MAPPING_ERROR = 11
+    STATUS_EXECUTION_FAILED = 13
+    STATUS_INTERNAL_ERROR = 14
+    STATUS_NOT_SUPPORTED = 15
+    STATUS_LICENSE_ERROR = 16
+    STATUS_CUBLAS_ERROR = 17
+    STATUS_CUDA_ERROR = 18
+    STATUS_INSUFFICIENT_WORKSPACE = 19
+    STATUS_INSUFFICIENT_DRIVER = 20  # NOQA, Indicates that the driver version is insufficient.
+
+    # cutensorWorksizePreference_t
+    WORKSPACE_MIN = 1
+    WORKSPACE_RECOMMENDED = 2
+    WORKSPACE_MAX = 3
+
+
+###############################################################################
+# Error handling
+###############################################################################
+
+class CuTensorError(RuntimeError):
+
+    def __init__(self, int status):
+        self.status = status
+        msg = cutensorGetErrorString(<Status>status)
+        super(CuTensorError, self).__init__(msg.decode())
+
+
+@cython.profile(False)
+cpdef inline check_status(int status):
+    if status != STATUS_SUCCESS:
+        raise CuTensorError(status)
+
+
+###############################################################################
+# Handler creation/destruction
+###############################################################################
+
+cpdef size_t create() except? 0:
+    """Initializes the cuTensor library"""
+    cdef Handle handle
+    with nogil:
+        status = cutensorCreate(&handle)
+    check_status(status)
+    return <size_t>handle
+
+
+cpdef destroy(size_t handle):
+    """Release hardware resources used by cuTensor library"""
+    with nogil:
+        status = cutensorDestroy(<Handle>handle)
+    check_status(status)
+
+
+###############################################################################
+# Tensor descriptor creation/destruction
+###############################################################################
+
+cpdef size_t createTensorDescriptor(uint32_t numModes,
+                                    size_t extent,
+                                    size_t stride,
+                                    int dataType,
+                                    int unaryOp,
+                                    uint32_t vectorWidth,
+                                    uint32_t vectorModeIndex):
+    """Creates a tesnor descriptor
+
+    Args:
+        numModes (uint32_t): number of modes
+        extent (int64_t*): extent of each mode (must be larger than zero)
+        stride (int64_t*): stride[i] denotes the displacement (stride)
+            between two consecutive elements in the ith-mode. This value may be
+            NULL, in which case a generalized column-major memory layout is
+            assumed (i.e., the strides increase monotonically from left to
+            right). Each stride must be larger than zero (a zero stride is
+            identical to removing this mode entirely).
+        dataType (cudaDataType_t): data type of stored entries.
+        unaryOp (cutensorOperator_t): Unary operator that will be applied to
+            each element of the corresponding tensor in a lazy fashion (i.e.,
+            the algorithm uses this tensor as its operand only once). The
+            original data of this tensor remains unchanged.
+        vectorWidth (uint32_t): The vectorization-width of the vectorized mode
+            (i.e., the number of consecutive elements in that mode). Set this
+            value to 1 if no vectorization is desired. Allowed values are
+            limited to 1 (this should likely be your default choice), 2, 4, 8,
+            16, and 32.
+        vectorModeIndex (uint32_t): The position of the mode that is vectorized
+            (from left to right, 0-indexed). For instance, vectorModeIndex == i
+            means that the mode corresponding to extent[i] and stride[i] is
+            vectorized. This value is ignored if the vectorWidth is set to 1.
+
+    Returns:
+        desc (cutensorTensorDescriptor): Pointer to the address where the
+            allocated tensor descriptor object should be stored
+    """
+    cdef TensorDescriptor desc
+    status = cutensorCreateTensorDescriptor(
+        &desc, numModes,
+        <int64_t*> extent, <int64_t*> stride,
+        <DataType> dataType, <Operator> unaryOp,
+        vectorWidth, vectorModeIndex)
+    check_status(status)
+    return <size_t>desc
+
+
+cpdef destroyTensorDescriptor(size_t desc):
+    """Frees the memory associated to the provided descriptor"""
+    status = cutensorDestroyTensorDescriptor(<TensorDescriptor> desc)
+    check_status(status)
+
+
+###############################################################################
+# Tensor elementwise operations
+###############################################################################
+
+cpdef elementwiseTrinary(size_t handle,
+                         size_t alpha,
+                         size_t A, size_t descA, size_t modeA,
+                         size_t beta,
+                         size_t B, size_t descB, size_t modeB,
+                         size_t gamma,
+                         size_t C, size_t descC, size_t modeC,
+                         size_t D, size_t descD, size_t modeD,
+                         int opAB, int opABC,
+                         int typeCompute):
+    """Element-wise tensor operation for three input tensors
+
+    This function performs a element-wise tensor operation of the form:
+
+        D_{Pi^C(i_0,i_1,...,i_nc)} =
+            Phi_ABC(Phi_AB(alpha * Psi_A(A_{Pi^A(i_0,i_1,...,i_na)}),
+                           beta  * Psi_B(B_{Pi^B(i_0,i_1,...,i_nb)})),
+                           gamma * Psi_C(C_{Pi^C(i_0,i_1,...,i_nc)}))
+
+    Where
+     - A,B,C,D are multi-mode tensors (of arbitrary data types).
+     - Pi^A, Pi^B, Pi^C are permutation operators that permute the modes of A,
+       B, and C respectively.
+     - Psi_A, Psi_B, Psi_C are unary element-wise operators (e.g., IDENTITY,
+       SQR, CONJUGATE).
+     - Phi_ABC, Phi_AB are binary element-wise operators (e.g., ADD, MUL, MAX,
+       MIN).
+
+    Notice that the broadcasting (of a mode) can be achieved by simply omitting
+    that mode from the respective tensor.
+
+    Moreover, modes may appear in any order giving the user a greater
+    flexibility. The only restrictions are:
+     - modes that appear in A or B must also appear in the output tensor as
+       such a case would correspond to a tensor contraction.
+     - each mode may appear in each tensor at most once.
+
+    It is guaranteed that an input tensor will not be read if the corresponding
+    scalar is zero.
+
+    Finally, the output tensor is padded with zeros, if the extent of the
+    vectorized mode ---of the output tensor--- is not a multiple of the
+    vector-width (the user has to ensure that the output tensor has sufficient
+    memory available to facilitate such a padding). Let the i'th mode be
+    vectorized with a vector-width w, then the additional padding is limited to
+    (w - (extent[i] % w)) many elements in total.
+
+    Examples:
+     - B_{a,b,c,d} = A_{b,d,a,c}
+     - C_{a,b,c,d} = 2.2 * A_{b,d,a,c} + 1.3 * B_{c,b,d,a}
+     - D_{a,b,c,d} = 2.2 * A_{b,d,a,c} + 1.3 * B_{c,b,d,a} + C_{a,b,c,d}
+     - D_{a,b,c,d} = min((2.2 * A_{b,d,a,c} + 1.3 * B_{c,b,d,a}), C_{a,b,c,d})
+
+    Args:
+        handle (cutensorHandle_t): Opaque handle holding CUTENSOR's library
+            context.
+        alpha (void*): Scaling factor for A (see equation above) of the type
+            typeCompute. Pointer to the host memory. Note that A is not read if
+            alpha is equal to zero, and the corresponding unary operator will
+            not be performed.
+        A (void*): Multi-mode tensor of type typeA with nmodeA modes. Pointer
+            to the GPU-accessable memory (while a host memory pointer is
+            acceptable, support for it remains an experimental feature).
+        descA (cutensorDescriptor_t): A descriptor that holds the information
+            about the data type, modes, and strides of A.
+        modeA (int32_t*): Array (in host memory) of size descA->numModes that
+            holds the labels of the modes of A (e.g., if A_{a,b,c} => modeA =
+            {'a','b','c'}). The modeA[i] corresponds to extent[i] and stride[i]
+            w.r.t. the arguments provided to cutensorCreateTensorDescriptor.
+        beta (void*): Scaling factor for B (see equation above) of the type
+            typeCompute. Pointer to the host memory. Note that B is not read if
+            beta is equal to zero, and the corresponding unary operator will
+            not be performed.
+        B (void*): Multi-mode tensor of type typeB with nmodeB many modes.
+            Pointer to the GPU-accessable memory (while a host memory pointer
+            is acceptable, support for it remains an experimental feature).
+        descB (cutensorDescriptor_t): The B descriptor that holds information
+            about the data type, modes, and strides of B.
+        modeB (int32_t*): Array (in host memory) of size descB->numModes that
+            holds the names of the modes of B. modeB[i] corresponds to
+            extent[i] and stride[i] of the cutensorCreateTensorDescriptor
+        gamma (void*): Scaling factor for C (see equation above) of type
+            typeCompute. Pointer to the host memory. Note that C is not read if
+            gamma is equal to zero, and the corresponding unary operator will
+            not be performed.
+        C (void*): Multi-mode tensor of type typeC with nmodeC many modes.
+            Pointer to the GPU-accessable memory (while a host memory pointer
+            is acceptable, support for it remains an experimental feature).
+        descC (cutensorDescriptor_t): The C descriptor that holds information
+            about the data type, modes, and strides of C.
+        modeC (int32_t*): Array (in host memory) of size descC->numModes that
+            holds the names of the modes of C. The modeC[i] corresponds to
+            extent[i] and stride[i] of the cutensorCreateTensorDescriptor.
+        D (void*): Multi-mode output tensor of type typeC with nmodeC modes
+            that are ordered according to modeD. Pointer to the GPU-accessable
+            memory (while a host memory pointer is acceptable, support for it
+            remains an experimental feature). Notice that D may alias any input
+            tensor if they share the same memory layout (i.e., same tensor
+            descriptor).
+        descD (cutensorDescriptor_t): The D descriptor that holds information
+            about the data type, modes, and strides of D. Notice that we
+            currently request descD and descC to be identical.
+        modeD (int32_t*): Array (in host memory) of size descD->numModes that
+            holds the names of the modes of D. The modeD[i] corresponds to
+            extent[i] and stride[i] of the cutensorCreateTensorDescriptor.
+        opAB (cutensorOperator_t): Element-wise binary operator
+            (see Phi_AB above).
+        opABC (cutensorOperator_t): Element-wise binary operator
+            (see Phi_ABC above).
+        typeCompute (cudaDataType_t): Compute type for the intermediate
+            computation.
+    """
+    cdef size_t stream = stream_module.get_current_stream_ptr()
+    status = cutensorElementwiseTrinary(
+        <Handle> handle,
+        <void*> alpha,
+        <void*> A, <TensorDescriptor> descA, <int32_t*> modeA,
+        <void*> beta,
+        <void*> B, <TensorDescriptor> descB, <int32_t*> modeB,
+        <void*> gamma,
+        <void*> C, <TensorDescriptor> descC, <int32_t*> modeC,
+        <void*> D, <TensorDescriptor> descD, <int32_t*> modeD,
+        <Operator> opAB, <Operator> opABC,
+        <DataType> typeCompute, <driver.Stream> stream)
+    check_status(status)
+
+
+cpdef elementwiseBinary(size_t handle,
+                        size_t alpha,
+                        size_t A, size_t descA, size_t modeA,
+                        size_t gamma,
+                        size_t C, size_t descC, size_t modeC,
+                        size_t D, size_t descD, size_t modeD,
+                        int opAC, int typeCompute):
+    """Element-wise tensor operation for two input tensors
+
+    This function performs a element-wise tensor operation of the form:
+
+        D_{Pi^C(i_0,i_1,...,i_n)} =
+            Phi_AC(alpha * Psi_A(A_{Pi^A(i_0,i_1,...,i_n)}),
+                   gamma * Psi_C(C_{Pi^C(i_0,i_1,...,i_n)}))
+
+    See elementwiseTrinary() for details.
+    """
+    cdef size_t stream = stream_module.get_current_stream_ptr()
+    status = cutensorElementwiseBinary(
+        <Handle> handle,
+        <void*> alpha,
+        <void*> A, <TensorDescriptor> descA, <int32_t*> modeA,
+        <void*> gamma,
+        <void*> C, <TensorDescriptor> descC, <int32_t*> modeC,
+        <void*> D, <TensorDescriptor> descD, <int32_t*> modeD,
+        <Operator> opAC,
+        <DataType> typeCompute, <driver.Stream> stream)
+    check_status(status)
+
+
+###############################################################################
+# Tensor contraction
+###############################################################################
+
+cpdef contraction(size_t handle,
+                  size_t alpha,
+                  size_t A, size_t descA, size_t modeA,
+                  size_t B, size_t descB, size_t modeB,
+                  size_t beta,
+                  size_t C, size_t descC, size_t modeC,
+                  size_t D, size_t descD, size_t modeD,
+                  int opOut, int typeCompute, int algo,
+                  size_t workspace, uint64_t workspaceSize):
+    """General tensor contraction
+
+    This routine computes the tensor contraction
+    D = Psi_out(alpha * Psi_A(A) * Psi_B(B) + beta * Psi_C(C)).
+
+    Example:
+     - C_{a,b,c,d} = 1.3 * A_{b,e,d,f} * B_{f,e,a,c}
+
+    Args:
+        handle (cutensorHandle_t): Opaque handle holding CUTENSOR's library
+            context.
+        alpha (void*): Scaling for A*B. The data_type_t is determined by
+            'typeCompute'. Pointer to the host memory.
+        A (void*): Pointer to the data corresponding to A. Pointer to the
+            GPU-accessable memory (while a host memory pointer is acceptable,
+            support for it remains an experimental feature).
+        descA (cutensorDescriptor_t): A descriptor that holds the information
+            about the data type, modes and strides of A.
+        modeA (int32_t*): Array with 'nmodeA' entries that represent the modes
+            of A. The modeA[i] corresponds to extent[i] and stride[i] w.r.t.
+            the arguments provided to cutensorCreateTensorDescriptor.
+        B (void*): Pointer to the data corresponding to B. Pointer to the
+            GPU-accessable memory (while a host memory pointer is acceptable,
+            support for it remains an experimental feature).
+        descC (cutensorDescriptor_t): The C descriptor that holds information
+            about the data type, modes, and strides of C.
+        modeB (int32_t*): Array with 'nmodeB' entries that represent the modes
+            of B. The modeB[i] corresponds to extent[i] and stride[i] w.r.t.
+            the arguments provided to cutensorCreateTensorDescriptor.
+        beta (void*): Scaling for C. The data_type_t is determined by
+            'typeCompute'. Pointer to the host memory.
+        C (void*): Pointer to the data corresponding to C. Pointer to the
+            GPU-accessable memory (while a host memory pointer is acceptable,
+            support for it remains an experimental feature).
+        modeC (int32_t*): Array with 'nmodeC' entries that represent the modes
+            of C. The modeC[i] corresponds to extent[i] and stride[i] w.r.t.
+            the arguments provided to cutensorCreateTensorDescriptor.
+        descC (cutensorDescriptor_t): The C descriptor that holds information
+            about the data type, modes, and strides of C.
+        D (void*): Pointer to the data corresponding to D (must be identical
+            to C for now). Pointer to the GPU-accessable memory (while a host
+            memory pointer is acceptable, support for it remains an
+            experimental feature).
+        modeD (int32_t*): Array with 'nmodeD' entries that represent the modes
+            of D (must be identical to modeC for now). The modeD[i] corresponds
+            to extent[i] and stride[i] w.r.t. the arguments provided to
+            cutensorCreateTensorDescriptor.
+        descD (cutensorDescriptor_t): The D descriptor that holds information
+            about the data type, modes, and strides of D (must be identical to
+            descC for now).
+        opOut (cutensorOperator_t): The element-wise unary operator
+            (see Psi_out above).
+        typeCompute (cudaDataType_t): Datatype of for the intermediate
+            computation of typeCompute T = A * B.
+        algo (cutenorAlgo_t): Allows users to select a specific algorithm.
+            ALGO_DEFAULT lets the heuristic choose the algorithm.
+            Any value >= 0 selects a specific GEMM-like algorithm and
+            deactivates the heuristic. If a specified algorithm is not
+            supported, STATUS_NOT_SUPPORTED is returned.
+        workspace (void*): Optional parameter that may be NULL. This pointer
+            provides additional workspace, in device memory, to the library for
+            additional optimizations.
+        workspaceSize (uint64_t): Size of the workspace array in bytes.
+    """
+    cdef size_t stream = stream_module.get_current_stream_ptr()
+    status = cutensorContraction(
+        <Handle> handle,
+        <void*> alpha,
+        <void*> A, <TensorDescriptor> descA, <int32_t*> modeA,
+        <void*> B, <TensorDescriptor> descB, <int32_t*> modeB,
+        <void*> beta,
+        <void*> C, <TensorDescriptor> descC, <int32_t*> modeC,
+        <void*> D, <TensorDescriptor> descD, <int32_t*> modeD,
+        <Operator> opOut, <DataType> typeCompute, <Algo> algo,
+        <void*> workspace, workspaceSize, <driver.Stream> stream)
+    check_status(status)
+
+
+cpdef uint64_t contractionGetWorkspace(size_t handle,
+                                       size_t A, size_t descA, size_t modeA,
+                                       size_t B, size_t descB, size_t modeB,
+                                       size_t C, size_t descC, size_t modeC,
+                                       size_t D, size_t descD, size_t modeD,
+                                       int opOut, int typeCompute, int algo,
+                                       int pref):
+    """Determines the required workspaceSize for a given tensor contraction
+
+    Args:
+        perf (cutensorWorksizePreference_t): User preference for the workspace.
+
+        See contraction() about other args.
+
+    Returns:
+        workspaceSize (uint64_t): The workspace size (in bytes) that is
+            required for the given tensor contraction.
+    """
+    cdef uint64_t workspaceSize
+    status = cutensorContractionGetWorkspace(
+        <Handle> handle,
+        <void*> A, <TensorDescriptor> descA, <int32_t*> modeA,
+        <void*> B, <TensorDescriptor> descB, <int32_t*> modeB,
+        <void*> C, <TensorDescriptor> descC, <int32_t*> modeC,
+        <void*> D, <TensorDescriptor> descD, <int32_t*> modeD,
+        <Operator> opOut, <DataType> typeCompute, <Algo> algo,
+        <WorksizePreference> pref, &workspaceSize)
+    check_status(status)
+    return workspaceSize
+
+
+cpdef int32_t contractionMaxAlgos():
+    """Returns the maximum number of algorithms for cutensorContraction()
+
+    You can use the returned integer for auto-tuning purposes (i.e., iterate
+    overe all algorithms up to the returned value). Not all algorithms might be
+    applicable to your specific problem. cutensorContraction() will return
+    CUTENSOR_STATUS_NOT_SUPPORTED if an algorithm is not applicable.
+
+    Returns:
+        maxNumAlgos (int32_t): The maximum number of algorithms available for
+            cutensorContraction().
+    """
+    cdef int32_t maxNumAlgos
+    status = cutensorContractionMaxAlgos(&maxNumAlgos)
+    check_status(status)
+    return maxNumAlgos

--- a/cupy/cutensor.py
+++ b/cupy/cutensor.py
@@ -1,0 +1,309 @@
+import numpy
+import warnings
+
+import cupy
+from cupy.cuda import cutensor
+from cupy.cuda import device
+from cupy.cuda import runtime
+
+_handles = {}
+
+
+def get_handle():
+    dev = device.get_device_id()
+    if dev not in _handles:
+        _handles[dev] = cutensor.create()
+    return _handles[dev]
+
+
+class Descriptor:
+
+    def __init__(self, descriptor, destroyer):
+        self.value = descriptor
+        self.destroy = destroyer
+
+    def __dealloc__(self):
+        if self.value is not None:
+            self.destroy(self.value)
+            self.value = None
+
+
+def get_cuda_dtype(numpy_dtype):
+    if numpy_dtype == numpy.float16:
+        return runtime.CUDA_R_16F
+    elif numpy_dtype == numpy.float32:
+        return runtime.CUDA_R_32F
+    elif numpy_dtype == numpy.float64:
+        return runtime.CUDA_R_64F
+    elif numpy_dtype == numpy.complex64:
+        return runtime.CUDA_C_32F
+    elif numpy_dtype == numpy.complex128:
+        return runtime.CUDA_C_64F
+    else:
+        raise TypeError('Dtype {} is not supported'.format(numpy_dtype))
+
+
+def create_tensor_descriptor(a, uop=cutensor.OP_IDENTITY,
+                             vector_width=1, vector_mode_index=0):
+    """Create a tensor descriptor
+
+    Args:
+        a (cupy.ndarray): tensor for which a descritpor are created.
+        uop (cutensorOperator_t): unary operator that will be applied to each
+            element of the corresponding tensor in a lazy fashion (i.e., the
+            algorithm uses this tensor as its operand only once). The
+            original data of this tensor remains unchanged.
+        vectorWidth (integer): The vectorization-width of the vectorized mode
+            (i.e., the number of consecutive elements in that mode). Set this
+            value to 1 if no vectorization is desired. Allowed values are
+            limited to 1 (this should likely be your default choice), 2, 4, 8,
+            16, and 32.
+        vectorModeIndex (integer): The position of the mode that is vectorized
+            (from left to right, 0-indexed). For instance, vectorModeIndex == i
+            means that the mode corresponding to extent[i] and stride[i] is
+            vectorized. This value is ignored if the vectorWidth is set to 1.
+
+    Returns:
+        (Descriptor): A instance of class Descriptor which holds a pointer to
+            tensor descriptor and its destructor.
+    """
+    num_modes = a.ndim
+    extent = numpy.array(a.shape, dtype=numpy.int64)
+    stride = numpy.array(a.strides, dtype=numpy.int64) // a.itemsize
+    data_type = get_cuda_dtype(a.dtype)
+    desc = cutensor.createTensorDescriptor(
+        num_modes, extent.ctypes.data, stride.ctypes.data, data_type, uop,
+        vector_width, vector_mode_index)
+    return Descriptor(desc, cutensor.destroyTensorDescriptor)
+
+
+def elementwise_trinary(alpha, A, desc_A, mode_A,
+                        beta, B, desc_B, mode_B,
+                        gamma, C, desc_C, mode_C,
+                        out=None,
+                        op_AB=cutensor.OP_ADD, op_ABC=cutensor.OP_ADD,
+                        compute_dtype=None):
+    """Element-wise tensor operation for three input tensors
+
+    This function performs a element-wise tensor operation of the form:
+
+        D_{Pi^C(i_0,i_1,...,i_nc)} =
+            op_ABC(op_AB(alpha * uop_A(A_{Pi^A(i_0,i_1,...,i_na)}),
+                         beta  * uop_B(B_{Pi^B(i_0,i_1,...,i_nb)})),
+                         gamma * uop_C(C_{Pi^C(i_0,i_1,...,i_nc)}))
+
+    See cupy/cuda/cutensor.elementwiseTrinary() for details.
+
+    Args:
+        alpha: Scaling factor for tensor A.
+        A (cupy.ndarray): Input tensor.
+        desc_A (class Descriptor): A descriptor that holds the information
+            about the data type, modes, and strides of tensor A.
+        mode_A (tuple of int/str): A tuple that holds the labels of the modes
+            of tensor A (e.g., if A_{x,y,z} => mode_A = {'x','y','z'})
+        beta: Scaling factor for tensor B.
+        B (cupy.ndarray): Input tensor.
+        desc_B (class Descriptor): A descriptor that holds the information
+            about the data type, modes, and strides of tensor B.
+        mode_B (tuple of int/str): A tuple that holds the labels of the modes
+            of tensor B.
+        gamma: Scaling factor for tensor C.
+        C (cupy.ndarray): Input tensor.
+        desc_C (class Descriptor): A descriptor that holds the information
+            about the data type, modes, and strides of tensor C.
+        mode_C (tuple of int/str): A tuple that holds the labels of the modes
+            of tensor C.
+        out (cupy.ndarray): Output tensor.
+        op_AB (cutensorOperator_t): Element-wise binary operator.
+        op_ABC (cutensorOperator_t): Element-wise binary operator.
+        compute_dtype (numpy.dtype): Compute type for the intermediate
+            computation.
+
+    Returns:
+        out (cupy.ndarray): Output tensor.
+    """
+    assert A.dtype == B.dtype == C.dtype
+    assert A.ndim == len(mode_A)
+    assert B.ndim == len(mode_B)
+    assert C.ndim == len(mode_C)
+    mode_A = numpy.array([ord(x) if isinstance(x, str) else x for x in mode_A],
+                         dtype=numpy.int32)
+    mode_B = numpy.array([ord(x) if isinstance(x, str) else x for x in mode_B],
+                         dtype=numpy.int32)
+    mode_C = numpy.array([ord(x) if isinstance(x, str) else x for x in mode_C],
+                         dtype=numpy.int32)
+    if out is None:
+        out = cupy.ndarray(C.shape, dtype=C.dtype)
+    else:
+        assert C.dtype == out.dtype
+        assert C.ndim == out.ndim
+        for i in range(C.ndim):
+            assert C.shape[i] == out.shape[i]
+    if compute_dtype is None:
+        compute_dtype = A.dtype
+    alpha = numpy.array(alpha, compute_dtype)
+    beta = numpy.array(beta, compute_dtype)
+    gamma = numpy.array(gamma, compute_dtype)
+    handle = get_handle()
+    compute_dtype = get_cuda_dtype(compute_dtype)
+    cutensor.elementwiseTrinary(
+        handle,
+        alpha.ctypes.data,
+        A.data.ptr, desc_A.value, mode_A.ctypes.data,
+        beta.ctypes.data,
+        B.data.ptr, desc_B.value, mode_B.ctypes.data,
+        gamma.ctypes.data,
+        C.data.ptr, desc_C.value, mode_C.ctypes.data,
+        out.data.ptr, desc_C.value, mode_C.ctypes.data,
+        op_AB, op_ABC, compute_dtype)
+    return out
+
+
+def elementwise_binary(alpha, A, desc_A, mode_A,
+                       gamma, C, desc_C, mode_C,
+                       out=None,
+                       op_AC=cutensor.OP_ADD,
+                       compute_dtype=None):
+    """Element-wise tensor operation for two input tensors
+
+    This function performs a element-wise tensor operation of the form:
+
+        D_{Pi^C(i_0,i_1,...,i_n)} =
+            op_AC(alpha * uop_A(A_{Pi^A(i_0,i_1,...,i_n)}),
+                  gamma * uop_C(C_{Pi^C(i_0,i_1,...,i_n)}))
+
+    See elementwise_trinary() for details.
+    """
+    assert A.dtype == C.dtype
+    assert A.ndim == len(mode_A)
+    assert C.ndim == len(mode_C)
+    mode_A = numpy.array([ord(x) if isinstance(x, str) else x for x in mode_A],
+                         dtype=numpy.int32)
+    mode_C = numpy.array([ord(x) if isinstance(x, str) else x for x in mode_C],
+                         dtype=numpy.int32)
+    if out is None:
+        out = cupy.ndarray(C.shape, dtype=C.dtype)
+    else:
+        assert C.dtype == out.dtype
+        assert C.ndim == out.ndim
+        for i in range(C.ndim):
+            assert C.shape[i] == out.shape[i]
+    if compute_dtype is None:
+        compute_dtype = A.dtype
+    alpha = numpy.array(alpha, compute_dtype)
+    gamma = numpy.array(gamma, compute_dtype)
+    handle = get_handle()
+    compute_dtype = get_cuda_dtype(compute_dtype)
+    cutensor.elementwiseBinary(
+        handle,
+        alpha.ctypes.data,
+        A.data.ptr, desc_A.value, mode_A.ctypes.data,
+        gamma.ctypes.data,
+        C.data.ptr, desc_C.value, mode_C.ctypes.data,
+        out.data.ptr, desc_C.value, mode_C.ctypes.data,
+        op_AC, compute_dtype)
+    return out
+
+
+def contraction(alpha, A, desc_A, mode_A, B, desc_B, mode_B,
+                beta, C, desc_C, mode_C,
+                uop=cutensor.OP_IDENTITY, compute_dtype=None,
+                algo=cutensor.ALGO_DEFAULT,
+                ws_pref=cutensor.WORKSPACE_RECOMMENDED):
+    """General tensor contraction
+
+    This routine computes the tensor contraction:
+
+        C = uop(alpha * uop_A(A) * uop_B(B) + beta * uop_C(C))
+
+    See cupy/cuda/cutensor.contraction for details.
+
+    Args:
+        alpha: Scaling factor for A * B.
+        A (cupy.ndarray): Input tensor.
+        desc_A (class Descriptor): A descriptor that holds the information
+            about the data type, modes, and strides of tensor A.
+        mode_A (tuple of int/str): A tuple that holds the labels of the modes
+            of tensor A (e.g., if A_{x,y,z} => mode_A = {'x','y','z'})
+        B (cupy.ndarray): Input tensor.
+        desc_B (class Descriptor): A descriptor that holds the information
+            about the data type, modes, and strides of tensor B.
+        mode_B (tuple of int/str): A tuple that holds the labels of the modes
+            of tensor B.
+        beta: Scaling factor for C.
+        C (cupy.ndarray): Input tensor.
+        desc_C (class Descriptor): A descriptor that holds the information
+            about the data type, modes, and strides of tensor C.
+        mode_C (tuple of int/str): A tuple that holds the labels of the modes
+            of tensor C.
+        uop (cutensorOperator_t): The element-wise unary operator.
+        compute_dtype (numpy.dtype): Compute type for the intermediate
+            computation.
+        algo (cutenorAlgo_t): Allows users to select a specific algorithm.
+            ALGO_DEFAULT lets the heuristic choose the algorithm.
+            Any value >= 0 selects a specific GEMM-like algorithm and
+            deactivates the heuristic. If a specified algorithm is not
+            supported, STATUS_NOT_SUPPORTED is returned.
+        ws_perf (cutensorWorksizePreference_t): User preference for the
+            workspace of cuTensor.
+
+    Returns:
+        out (cupy.ndarray): Output tensor.
+    """
+    assert A.dtype == B.dtype == C.dtype
+    assert A.ndim == len(mode_A)
+    assert B.ndim == len(mode_B)
+    assert C.ndim == len(mode_C)
+    mode_A = numpy.array([ord(x) if isinstance(x, str) else x for x in mode_A],
+                         dtype=numpy.int32)
+    mode_B = numpy.array([ord(x) if isinstance(x, str) else x for x in mode_B],
+                         dtype=numpy.int32)
+    mode_C = numpy.array([ord(x) if isinstance(x, str) else x for x in mode_C],
+                         dtype=numpy.int32)
+    out = C
+    if compute_dtype is None:
+        if A.dtype == numpy.float16:
+            compute_dtype = numpy.float32
+        else:
+            compute_dtype = A.dtype
+    alpha = numpy.array(alpha, compute_dtype)
+    beta = numpy.array(beta, compute_dtype)
+    handle = get_handle()
+    compute_dtype = get_cuda_dtype(compute_dtype)
+    ws_allocation_success = False
+    for pref in (ws_pref, cutensor.WORKSPACE_MIN):
+        ws_size = cutensor.contractionGetWorkspace(
+            handle,
+            A.data.ptr, desc_A.value, mode_A.ctypes.data,
+            B.data.ptr, desc_B.value, mode_B.ctypes.data,
+            C.data.ptr, desc_C.value, mode_C.ctypes.data,
+            out.data.ptr, desc_C.value, mode_C.ctypes.data,
+            uop, compute_dtype, algo, pref)
+        try:
+            ws = cupy.ndarray((ws_size,), dtype=numpy.int8)
+            ws_allocation_success = True
+        except Exception:
+            warnings.warn('cuTENSOR: failed to allocate memory of workspace '
+                          'with preference ({}) and size ({}).'
+                          ''.format(pref, ws_size))
+        if ws_allocation_success:
+            break
+    if not ws_allocation_success:
+        raise RuntimeError('cuTENSOR: failed to allocate memory of workspace.')
+    cutensor.contraction(handle,
+                         alpha.ctypes.data,
+                         A.data.ptr, desc_A.value, mode_A.ctypes.data,
+                         B.data.ptr, desc_B.value, mode_B.ctypes.data,
+                         beta.ctypes.data,
+                         C.data.ptr, desc_C.value, mode_C.ctypes.data,
+                         out.data.ptr, desc_C.value, mode_C.ctypes.data,
+                         uop, compute_dtype, algo, ws.data.ptr, ws_size)
+    return out
+
+
+def contraction_max_algos():
+    """Returns the maximum number of algorithms for cutensor()
+
+    See cupy/cuda/cutensor.contractionMaxAlgos() for details.
+    """
+    return cutensor.contractionMaxAlgos()

--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -163,7 +163,22 @@ MODULES = [
             'cudart',
         ],
         'check_method': build.check_cuda_version,
-    }
+    },
+    {
+        'name': 'cutensor',
+        'file': [
+            'cupy.cuda.cutensor',
+        ],
+        'include': [
+            'cutensor.h',
+        ],
+        'libraries': [
+            'cutensor',
+            'cublas',
+        ],
+        'check_method': build.check_cutensor_version,
+        'version_method': build.get_cutensor_version,
+    },
 ]
 
 

--- a/examples/cutensor/contraction.py
+++ b/examples/cutensor/contraction.py
@@ -1,0 +1,51 @@
+#
+# C_{m,u,n,v} = alpha * A_{m,h,k,n} * B_{u,k,v,h} + gamma * C_{m,u,n,v}
+#
+import numpy
+import cupy
+from cupy import cutensor
+from cupy.cuda import stream
+
+dtype = numpy.float32
+
+mode_a = ('m', 'h', 'k', 'n')
+mode_b = ('u', 'k', 'v', 'h')
+mode_c = ('m', 'u', 'n', 'v')
+
+extent = {'m': 96, 'n': 96, 'u': 96, 'v': 64, 'h': 64, 'k': 64}
+
+a = cupy.random.random([extent[i] for i in mode_a])
+b = cupy.random.random([extent[i] for i in mode_b])
+c = cupy.random.random([extent[i] for i in mode_c])
+a = a.astype(dtype)
+b = b.astype(dtype)
+c = c.astype(dtype)
+
+desc_a = cutensor.create_tensor_descriptor(a)
+desc_b = cutensor.create_tensor_descriptor(b)
+desc_c = cutensor.create_tensor_descriptor(c)
+
+alpha = 1.1
+gamma = 1.0
+
+# rehearsal
+c = cutensor.contraction(alpha, a, desc_a, mode_a, b, desc_b, mode_b,
+                         gamma, c, desc_c, mode_c)
+
+ev_start = stream.Event()
+ev_end = stream.Event()
+st = stream.Stream()
+with st:
+    # measurement
+    ev_start.record()
+    c = cutensor.contraction(alpha, a, desc_a, mode_a, b, desc_b, mode_b,
+                             gamma, c, desc_c, mode_c)
+    ev_end.record()
+st.synchronize()
+
+elapsed_ms = stream.get_elapsed_time(ev_start, ev_end)
+total_flops = 2 * numpy.prod(numpy.array(list(extent.values())))
+
+print('dtype: {}'.format(numpy.dtype(dtype).name))
+print('time (ms): {}'.format(elapsed_ms))
+print('GFLOPS: {}'.format(total_flops / elapsed_ms / 1e6))

--- a/examples/cutensor/contraction.py
+++ b/examples/cutensor/contraction.py
@@ -1,5 +1,5 @@
 #
-# C_{m,u,n,v} = alpha * A_{m,h,k,n} * B_{u,k,v,h} + gamma * C_{m,u,n,v}
+# C_{m,u,n,v} = alpha * A_{m,h,k,n} * B_{u,k,v,h} + beta * C_{m,u,n,v}
 #
 import numpy
 import cupy
@@ -26,11 +26,11 @@ desc_b = cutensor.create_tensor_descriptor(b)
 desc_c = cutensor.create_tensor_descriptor(c)
 
 alpha = 1.1
-gamma = 1.0
+beta = 1.0
 
 # rehearsal
 c = cutensor.contraction(alpha, a, desc_a, mode_a, b, desc_b, mode_b,
-                         gamma, c, desc_c, mode_c)
+                         beta, c, desc_c, mode_c)
 
 ev_start = stream.Event()
 ev_end = stream.Event()
@@ -39,7 +39,7 @@ with st:
     # measurement
     ev_start.record()
     c = cutensor.contraction(alpha, a, desc_a, mode_a, b, desc_b, mode_b,
-                             gamma, c, desc_c, mode_c)
+                             beta, c, desc_c, mode_c)
     ev_end.record()
 st.synchronize()
 

--- a/examples/cutensor/elementwise_binary.py
+++ b/examples/cutensor/elementwise_binary.py
@@ -1,0 +1,52 @@
+#
+# D_{x,y,z} = alpha * A_{z,y,x} + gamma * C_{x,y,z}
+#
+import numpy
+import cupy
+from cupy import cutensor
+from cupy.cuda import stream
+
+dtype = numpy.float32
+
+mode_a = ('z', 'y', 'x')
+mode_c = ('x', 'y', 'z')
+
+extent = {'x': 400, 'y': 200, 'z': 300}
+
+a = cupy.random.random([extent[i] for i in mode_a])
+c = cupy.random.random([extent[i] for i in mode_c])
+a = a.astype(dtype)
+c = c.astype(dtype)
+
+desc_a = cutensor.create_tensor_descriptor(a)
+desc_c = cutensor.create_tensor_descriptor(c)
+
+alpha = 1.1
+gamma = 1.3
+
+# rehearsal
+d = cutensor.elementwise_binary(alpha, a, desc_a, mode_a,
+                                gamma, c, desc_c, mode_c)
+
+ev_start = stream.Event()
+ev_end = stream.Event()
+st = stream.Stream()
+with st:
+    # measurement
+    ev_start.record()
+    d = cutensor.elementwise_binary(alpha, a, desc_a, mode_a,
+                                    gamma, c, desc_c, mode_c)
+    ev_end.record()
+st.synchronize()
+
+elapsed_ms = stream.get_elapsed_time(ev_start, ev_end)
+transfer_byte = d.size * d.itemsize
+if alpha != 0.0:
+    transfer_byte += a.size * a.itemsize
+if gamma != 0.0:
+    transfer_byte += c.size * c.itemsize
+gbs = transfer_byte / elapsed_ms / 1e6
+
+print('dtype: {}'.format(numpy.dtype(dtype).name))
+print('time (ms): {}'.format(elapsed_ms))
+print('effective memory bandwidth (GB/s): {}'.format(gbs))

--- a/examples/cutensor/elementwise_trinary.py
+++ b/examples/cutensor/elementwise_trinary.py
@@ -1,0 +1,61 @@
+#
+# D_{x,y,z} = alpha * A_{z,y,x} + beta * B_{y,z,x} + gamma * C_{x,y,z}
+#
+import numpy
+import cupy
+from cupy import cutensor
+from cupy.cuda import stream
+
+dtype = numpy.float32
+
+mode_a = ('z', 'y', 'x')
+mode_b = ('y', 'z', 'x')
+mode_c = ('x', 'y', 'z')
+
+extent = {'x': 400, 'y': 200, 'z': 300}
+
+a = cupy.random.random([extent[i] for i in mode_a])
+b = cupy.random.random([extent[i] for i in mode_b])
+c = cupy.random.random([extent[i] for i in mode_c])
+a = a.astype(dtype)
+b = b.astype(dtype)
+c = c.astype(dtype)
+
+desc_a = cutensor.create_tensor_descriptor(a)
+desc_b = cutensor.create_tensor_descriptor(b)
+desc_c = cutensor.create_tensor_descriptor(c)
+
+alpha = 1.1
+beta = 1.2
+gamma = 1.3
+
+# rehearsal
+d = cutensor.elementwise_trinary(alpha, a, desc_a, mode_a,
+                                 beta,  b, desc_b, mode_b,
+                                 gamma, c, desc_c, mode_c)
+
+ev_start = stream.Event()
+ev_end = stream.Event()
+st = stream.Stream()
+with st:
+    # measurement
+    ev_start.record()
+    d = cutensor.elementwise_trinary(alpha, a, desc_a, mode_a,
+                                     beta,  b, desc_b, mode_b,
+                                     gamma, c, desc_c, mode_c)
+    ev_end.record()
+st.synchronize()
+
+elapsed_ms = stream.get_elapsed_time(ev_start, ev_end)
+transfer_byte = d.size * d.itemsize
+if alpha != 0.0:
+    transfer_byte += a.size * a.itemsize
+if beta != 0.0:
+    transfer_byte += b.size * b.itemsize
+if gamma != 0.0:
+    transfer_byte += c.size * c.itemsize
+gbs = transfer_byte / elapsed_ms / 1e6
+
+print('dtype: {}'.format(numpy.dtype(dtype).name))
+print('time (ms): {}'.format(elapsed_ms))
+print('effective memory bandwidth (GB/s): {}'.format(gbs))

--- a/install/build.py
+++ b/install/build.py
@@ -114,6 +114,11 @@ def get_compiler_setting():
         else:
             define_macros.append(('CUPY_NO_NVTX', '1'))
 
+    cutensor_path = os.environ.get('CUTENSOR_PATH', '')
+    if os.path.exists(cutensor_path):
+        include_dirs.append(os.path.join(cutensor_path, 'include'))
+        library_dirs.append(os.path.join(cutensor_path, 'lib'))
+
     return {
         'include_dirs': include_dirs,
         'library_dirs': library_dirs,
@@ -342,6 +347,44 @@ def check_nvtx(compiler, settings):
             return True
         return False
     return True
+
+
+def check_cutensor_version(compiler, settings):
+    global _cutensor_version
+    try:
+        out = build_and_run(compiler, '''
+        #include <cutensor.h>
+        #include <stdio.h>
+        #ifdef CUTENSOR_MAJOR
+        #ifndef CUTENSOR_VERSION
+        #define CUTENSOR_VERSION \
+                (CUTENSOR_MAJOR * 1000 + CUTENSOR_MINOR * 100 + CUTENSOR_PATCH)
+        #endif
+        #else
+        #  define CUTENSOR_VERSION 0
+        #endif
+        int main(int argc, char* argv[]) {
+          printf("%d", CUTENSOR_VERSION);
+          return 0;
+        }
+        ''', include_dirs=settings['include_dirs'])
+
+    except Exception as e:
+        utils.print_warning('Cannot check cuTENSOR version\n{0}'.format(e))
+        return False
+
+    _cutensor_version = int(out)
+
+    return True
+
+
+def get_cutensor_version(formatted=False):
+    """Return cuTENSOR version cached in check_cutensor_version()."""
+    global _cutensor_version
+    if _cutensor_version is None:
+        msg = 'check_cutensor_version() must be called first.'
+        raise RuntimeError(msg)
+    return _cutensor_version
 
 
 def build_shlib(compiler, source, libraries=(),


### PR DESCRIPTION
This PR proposes to make cuTENSOR, a high-performance CUDA library for tensor operations, available on CuPy. Please see [this link](https://developer.nvidia.com/gtc/2019/video/S9593) for details about cuTENSOR.

All cuTENSOR's C APIs are exposed in `cupy/cuda/cutensor.pyx`. In addition, a bit abstracted APIs such as **contraction**, **elemetwise_trinary** and **elementwise_binary** are exposed in `cupy/cutensor.py`, so that python developers can utilize cuTENSOR in rather pythonic way. Please see examples in `examples/cutensor/` on how to use these APIs.

In order to build CuPy with cuTENSOR enabled, you first need to download cuTENSOR from [here](https://developer.nvidia.com/cutensor-product-page) and tell a path where cuTENSOR is installed by an environment variable `CUTENSOR_PATH` when you build CuPy.

```
$ cd (to where cupy is installed)
$ CUTENSOR_PATH=/path/to/cutensor python setup.py install
```

Any feedback would be greatly appreciated.
Thanks in advance.