### PR TITLE
[backport] Allow copying in the format `cupy_array[:] = numpy_array`

### DIFF
--- a/cupy/util.pyx
+++ b/cupy/util.pyx
@@ -3,10 +3,15 @@
 import atexit
 import collections
 import functools
+import os
 import warnings
 
 import cupy
 from cupy.cuda cimport device
+
+
+ENABLE_SLICE_COPY = bool(
+    int(os.environ.get('CUPY_EXPERIMENTAL_SLICE_COPY', 0)))
 
 
 # TODO(kmaehashi) remove this when `six.moves.collections_abc` is implemented.


### PR DESCRIPTION
Backport of #2079