### PR TITLE
[backport] Avoid division by zero in tensordot, allowing 0-length arrays

### DIFF
--- a/cupy/linalg/product.py
+++ b/cupy/linalg/product.py
@@ -189,8 +189,10 @@ def tensordot(a, b, axes=2):
     ret_shape = a.shape[sum_ndim:] + b.shape[sum_ndim:]
 
     k = internal.prod(a.shape[:sum_ndim])
-    n = a.size // k
-    m = b.size // k
+    # Avoid division by zero: core.tensordot_core returns zeros without
+    # checking n, m consistency, thus allowing 0-length dimensions to work
+    n = a.size // k if k != 0 else 0
+    m = b.size // k if k != 0 else 0
 
     return core.tensordot_core(a, b, None, n, m, k, ret_shape)
 

--- a/tests/cupy_tests/linalg_tests/test_product.py
+++ b/tests/cupy_tests/linalg_tests/test_product.py
@@ -349,6 +349,28 @@ class TestProduct(unittest.TestCase):
         return xp.kron(a, b)
 
 
+@testing.parameterize(*testing.product({
+    'params': [
+        ((0, 0), 2),
+        ((0, 0), (1, 0)),
+        ((0, 0, 0), 2),
+        ((0, 0, 0), 3),
+        ((0, 0, 0), ([2, 1], [0, 2])),
+        ((0, 0, 0), ([0, 2, 1], [1, 2, 0])),
+    ],
+}))
+@testing.gpu
+@testing.with_requires('numpy>=1.14.0')
+class TestProductZeroLength(unittest.TestCase):
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose()
+    def test_tensordot_zero_length(self, xp, dtype):
+        shape, axes = self.params
+        a = testing.shaped_arange(shape, xp, dtype)
+        return xp.tensordot(a, a, axes=axes)
+
+
 @unittest.skipUnless(
     cuda.cusolver_enabled, 'Requires CUDA 8.0 for cuSOLVER')
 class TestMatrixPower(unittest.TestCase):


### PR DESCRIPTION
Backport of #2209