### PR TITLE
Raise error when no available algorithm found by cudnnFindConvolution*

### DIFF
--- a/cupy/cudnn.pyx
+++ b/cupy/cudnn.pyx
@@ -1330,6 +1330,8 @@ cpdef _Algorithm _find_algorithm_fwd(
         perf = cudnn.findConvolutionForwardAlgorithmEx(
             handle, x_desc, x.data.ptr, filter_desc, W.data.ptr, conv_desc,
             y_desc, y.data.ptr, 1, workspace.ptr, max_workspace_size)[0]
+    if perf.status != cudnn.CUDNN_STATUS_SUCCESS:
+        raise RuntimeError('No available algorithm found.')
     algo = _Algorithm(perf.algo, perf.memory, perf.mathType)
     _algorithm_fwd_cache[key] = algo
     return algo
@@ -1406,6 +1408,8 @@ cpdef _Algorithm _find_algorithm_bwd_filter(
         perf = cudnn.findConvolutionBackwardFilterAlgorithmEx(
             handle, x_desc, x.data.ptr, dy_desc, dy.data.ptr, conv_desc,
             filter_desc, dW.data.ptr, 1, workspace.ptr, max_workspace_size)[0]
+    if perf.status != cudnn.CUDNN_STATUS_SUCCESS:
+        raise RuntimeError('No available algorithm found.')
     algo = _Algorithm(perf.algo, perf.memory, perf.mathType)
     _algorithm_bwd_filter_cache[key] = algo
     return algo
@@ -1483,6 +1487,8 @@ cpdef _Algorithm _find_algorithm_bwd_data(
         perf = cudnn.findConvolutionBackwardDataAlgorithmEx(
             handle, filter_desc, W.data.ptr, x_desc, x.data.ptr, conv_desc,
             y_desc, y.data.ptr, 1, workspace.ptr, max_workspace_size)[0]
+    if perf.status != cudnn.CUDNN_STATUS_SUCCESS:
+        raise RuntimeError('No available algorithm found.')
     algo = _Algorithm(perf.algo, perf.memory, perf.mathType)
     _algorithm_bwd_data_cache[key] = algo
     return algo

--- a/cupy/cudnn.pyx
+++ b/cupy/cudnn.pyx
@@ -1459,7 +1459,7 @@ cpdef _warn_algorithm_bwd_data(
         core.ndarray W, core.ndarray x, core.ndarray y, tuple conv_param):
     warnings.warn(
         'Tensor Core mode is set but the selected convolution backward '
-        'filter algorithm is not a Tensor Core enabled algorithm. '
+        'data algorithm is not a Tensor Core enabled algorithm. '
         'This might be due to lack of workspace memory. '
         'W.shape:{}, x.shape:{}, y.shape:{}, pad:{}, stride:{}'
         .format(W.shape, x.shape, y.shape, conv_param[0], conv_param[1]),

--- a/tests/cupy_tests/test_cudnn.py
+++ b/tests/cupy_tests/test_cudnn.py
@@ -145,6 +145,7 @@ class TestConvolutionForward(unittest.TestCase):
             out_channels_a_group = 2
         in_channels = in_channels_a_group * self.groups
         out_channels = out_channels_a_group * self.groups
+        # TODO(anaruse): increase test cases.
         ksize = 3
         stride = 2
         pad = ksize // stride * self.dilate
@@ -227,6 +228,7 @@ class TestConvolutionBackwardFilter(unittest.TestCase):
         out_channels_a_group = 2
         in_channels = in_channels_a_group * self.groups
         out_channels = out_channels_a_group * self.groups
+        # TODO(anaruse): increase test cases.
         ksize = 3
         stride = 2
         pad = ksize // stride * self.dilate
@@ -295,6 +297,7 @@ class TestConvolutionBackwardData(unittest.TestCase):
         out_channels_a_group = 2
         in_channels = in_channels_a_group * self.groups
         out_channels = out_channels_a_group * self.groups
+        # TODO(anaruse): increase test cases.
         ksize = 3
         stride = 2
         pad = ksize // stride * self.dilate

--- a/tests/cupy_tests/test_cudnn.py
+++ b/tests/cupy_tests/test_cudnn.py
@@ -349,9 +349,9 @@ class TestConvolutionBackwardData(unittest.TestCase):
 
 
 @testing.parameterize(*testing.product({
-    'dtype': [numpy.float16, numpy.float32, numpy.float64],
+    'dtype': [numpy.float32, numpy.float64],
     'ksize': [1, 3, 5],
-    'stride': [1, 2, 4],
+    'stride': [2, 4],
     'auto_tune': [True, False],
 }))
 @unittest.skipUnless(cudnn_enabled, 'cuDNN is not available')
@@ -414,13 +414,7 @@ class TestConvolutionNoAvailableAlgorithm(unittest.TestCase):
     def test_backward_data(self):
         err = None
         if self.layout == libcudnn.CUDNN_TENSOR_NHWC:
-            if self.dtype == numpy.float16:
-                if self.stride == 4:
-                    err = self._get_error_type()
-                elif self.stride == 2 and self.ksize == 5:
-                    err = self._get_error_type()
-            else:
-                err = self._get_error_type()
+            err = self._get_error_type()
         if err is None:
             return unittest.SkipTest()
         with self.assertRaises(err):


### PR DESCRIPTION
This PR helps developers identify a cause of convolution algorithm selection related cudnn error.

When auto tuning is enabled, cudnnFindConvolution* API is called to find optimal cudnn algorithm for each convolution layer at first attempt, but sometimes no algorithm returned by the API is available. This error case is not currently checked, so I added that check. 