### PR TITLE
Add NHWC layout support to batch normalization

### DIFF
--- a/cupy/cudnn.pyx
+++ b/cupy/cudnn.pyx
@@ -581,6 +581,14 @@ def rnn_backward_weights_ex(
     return dw
 
 
+def create_activation_descriptor(mode, nan_prop_mode=cudnn.CUDNN_PROPAGATE_NAN,
+                                 coef=0.0):
+    desc = Descriptor(cudnn.createActivationDescriptor(),
+                      py_cudnn.destroyActivationDescriptor)
+    cudnn.setActivationDescriptor(desc.value, mode, nan_prop_mode, coef)
+    return desc
+
+
 def activation_forward(core.ndarray x, int mode, double coef=0.0):
     cdef float float_zero = 0, float_one = 1
     cdef double double_zero = 0, double_one = 1
@@ -1892,12 +1900,13 @@ def pooling_backward(
 
 
 cdef _create_tensor_descriptor_for_bn(
-        size_t desc, core.ndarray arr, bint is_for_conv2d):
+        size_t desc, core.ndarray arr, bint is_for_conv2d,
+        int format=cudnn.CUDNN_TENSOR_NCHW):
     assert arr._c_contiguous
-    data_type = get_data_type(arr.dtype)
     if is_for_conv2d:
-        _create_tensor_nd_descriptor(desc, arr, data_type)
+        _create_tensor_descriptor(desc, arr, format)
         return
+    data_type = get_data_type(arr.dtype)
     cdef Py_ssize_t dim1, dim2
     cdef int ndim = arr._shape.size()
     dim2 = 1
@@ -1924,7 +1933,8 @@ def batch_normalization_forward_training(
         core.ndarray x, core.ndarray gamma, core.ndarray beta,
         core.ndarray running_mean, core.ndarray running_var,
         mean, inv_std, double eps, double decay,
-        bint is_for_conv2d, int cudnn_mode, bint debug):
+        bint is_for_conv2d, int cudnn_mode, bint debug,
+        int d_layout=cudnn.CUDNN_TENSOR_NCHW):
     # Usually supply None to mean and inv_std, which are left for backward
     # compatibility. See cupy#2060 and cupy#2070.
     if (mean is None) != (inv_std is None):
@@ -1946,7 +1956,8 @@ def batch_normalization_forward_training(
     cdef size_t x_desc = cudnn.createTensorDescriptor()
     cdef size_t derivedBnDesc = cudnn.createTensorDescriptor()
     try:
-        _create_tensor_descriptor_for_bn(x_desc, x, is_for_conv2d)
+        _create_tensor_descriptor_for_bn(x_desc, x, is_for_conv2d,
+                                         format=d_layout)
         cudnn.deriveBNTensorDescriptor(derivedBnDesc, x_desc, cudnn_mode)
         dtype_param = _get_dtype_of_tensor_descriptor(derivedBnDesc)
         if gamma.dtype != dtype_param:
@@ -2010,7 +2021,8 @@ def batch_normalization_forward_training(
 def batch_normalization_forward_inference(
         core.ndarray x, core.ndarray gamma, core.ndarray beta,
         core.ndarray mean, core.ndarray var,
-        double eps, bint is_for_conv2d, int cudnn_mode):
+        double eps, bint is_for_conv2d, int cudnn_mode,
+        int d_layout=cudnn.CUDNN_TENSOR_NCHW):
     x = core._internal_ascontiguousarray(x)
     dtype = x.dtype
     y = core.ndarray(x._shape, dtype)
@@ -2027,7 +2039,8 @@ def batch_normalization_forward_inference(
     cdef size_t x_desc = cudnn.createTensorDescriptor()
     cdef size_t derivedBnDesc = cudnn.createTensorDescriptor()
     try:
-        _create_tensor_descriptor_for_bn(x_desc, x, is_for_conv2d)
+        _create_tensor_descriptor_for_bn(x_desc, x, is_for_conv2d,
+                                         format=d_layout)
         cudnn.deriveBNTensorDescriptor(derivedBnDesc, x_desc, cudnn_mode)
         dtype_param = _get_dtype_of_tensor_descriptor(derivedBnDesc)
         if gamma.dtype != dtype_param:
@@ -2053,7 +2066,8 @@ def batch_normalization_forward_inference(
 def batch_normalization_backward(
         core.ndarray x, core.ndarray gamma, core.ndarray gy,
         core.ndarray mean, core.ndarray inv_std,
-        double eps, bint is_for_conv2d, int cudnn_mode, bint debug):
+        double eps, bint is_for_conv2d, int cudnn_mode, bint debug,
+        int d_layout=cudnn.CUDNN_TENSOR_NCHW):
     cdef core.ndarray ggamma, gbeta
     cdef bint need_cast
     x = core._internal_ascontiguousarray(x)
@@ -2073,7 +2087,8 @@ def batch_normalization_backward(
     cdef size_t x_desc = cudnn.createTensorDescriptor()
     cdef size_t derivedBnDesc = cudnn.createTensorDescriptor()
     try:
-        _create_tensor_descriptor_for_bn(x_desc, x, is_for_conv2d)
+        _create_tensor_descriptor_for_bn(x_desc, x, is_for_conv2d,
+                                         format=d_layout)
         cudnn.deriveBNTensorDescriptor(derivedBnDesc, x_desc, cudnn_mode)
         dtype_param = _get_dtype_of_tensor_descriptor(derivedBnDesc)
         need_cast = gamma.dtype != dtype_param


### PR DESCRIPTION
This PR adds support of NHWC tensor layout in batch normalization related routines in CuPy.

This is related to https://github.com/chainer/chainer/pull/7375.