### PR TITLE
[backport] Fix: duplicate object description of cupy

### DIFF
--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -3,7 +3,7 @@
 Overview
 ========
 
-.. module:: cupy
+.. currentmodule:: cupy
 
 `CuPy <https://github.com/cupy/cupy>`_ is an implementation of NumPy-compatible multi-dimensional array on CUDA.
 CuPy consists of :class:`cupy.ndarray`, the core multi-dimensional array class,

--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -11,7 +11,7 @@ This is the official reference of CuPy, a multi-dimensional array on CUDA with a
 
 ----
 
-.. module:: cupy
+.. currentmodule:: cupy
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/reference/routines.rst
+++ b/docs/source/reference/routines.rst
@@ -6,7 +6,7 @@ The following pages describe NumPy-compatible routines.
 These functions cover a subset of
 `NumPy routines <https://docs.scipy.org/doc/numpy/reference/routines.html>`_.
 
-.. module:: cupy
+.. currentmodule:: cupy
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
Backport of #2233