### PR TITLE
Add wrappers for can_cast, common_type and result_type functions

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -344,9 +344,9 @@ def binary_repr(num, width=None):
 # -----------------------------------------------------------------------------
 def numpy_implementation(func, *args, **kwargs):
     if hasattr(func, '_implementation'):
-        return func._implementation(*args, *kwargs)
+        return func._implementation(*args, **kwargs)
     else:
-        return func(*args, *kwargs)
+        return func(*args, **kwargs)
 
 
 can_cast = partial(numpy_implementation, numpy.can_cast)

--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -370,6 +370,7 @@ def result_type(*arrays_and_dtypes):
     dtype_arrays = [getattr(a, 'dtype', a) for a in arrays_and_dtypes]
     return numpy.result_type(*dtype_arrays)
 
+
 from numpy import min_scalar_type  # NOQA
 from numpy import obj2sctype  # NOQA
 from numpy import promote_types  # NOQA

--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -367,8 +367,9 @@ def result_type(*arrays_and_dtypes):
 
     .. seealso:: :func:`numpy.result_type`
     """
-    dtype_arrays = [getattr(a, 'dtype', a) for a in arrays_and_dtypes]
-    return numpy.result_type(*dtype_arrays)
+    dtypes = [a.dtype if isinstance(a, cupy.ndarray)
+              else a for a in arrays_and_dtypes]
+    return numpy.result_type(*dtypes)
 
 
 from numpy import min_scalar_type  # NOQA

--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -348,8 +348,8 @@ def can_cast(from_, to, casting='safe'):
 
     .. seealso:: :func:`numpy.can_cast`
     """
-    from_dtype = getattr(from_, 'dtype', from_)
-    return numpy.can_cast(from_dtype, to, casting=casting)
+    from_ = from_.dtype if isinstance(from_, cupy.ndarray) else from_
+    return numpy.can_cast(from_, to, casting=casting)
 
 
 def common_type(*arrays):
@@ -369,7 +369,6 @@ def result_type(*arrays_and_dtypes):
     """
     dtype_arrays = [getattr(a, 'dtype', a) for a in arrays_and_dtypes]
     return numpy.result_type(*dtype_arrays)
-
 
 from numpy import min_scalar_type  # NOQA
 from numpy import obj2sctype  # NOQA

--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -3,6 +3,7 @@ import sys
 
 import numpy
 import six
+from functools import partial
 
 from cupy import _version
 
@@ -341,12 +342,20 @@ def binary_repr(num, width=None):
 # -----------------------------------------------------------------------------
 # Data type routines (borrowed from NumPy)
 # -----------------------------------------------------------------------------
-from numpy import can_cast  # NOQA
-from numpy import common_type  # NOQA
+def numpy_implementation(func, *args, **kwargs):
+    if hasattr(func, '_implementation'):
+        return func._implementation(*args, *kwargs)
+    else:
+        return func(*args, *kwargs)
+
+
+can_cast = partial(numpy_implementation, numpy.can_cast)
+common_type = partial(numpy_implementation, numpy.common_type)
+result_type = partial(numpy_implementation, numpy.result_type)
+
 from numpy import min_scalar_type  # NOQA
 from numpy import obj2sctype  # NOQA
 from numpy import promote_types  # NOQA
-from numpy import result_type  # NOQA
 
 from numpy import dtype  # NOQA
 from numpy import format_parser  # NOQA

--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -3,7 +3,6 @@ import sys
 
 import numpy
 import six
-from functools import partial
 
 from cupy import _version
 
@@ -342,16 +341,35 @@ def binary_repr(num, width=None):
 # -----------------------------------------------------------------------------
 # Data type routines (borrowed from NumPy)
 # -----------------------------------------------------------------------------
-def numpy_implementation(func, *args, **kwargs):
-    if hasattr(func, '_implementation'):
-        return func._implementation(*args, **kwargs)
-    else:
-        return func(*args, **kwargs)
+def can_cast(from_, to, casting='safe'):
+    """Returns True if cast between data types can occur according to the
+    casting rule. If from is a scalar or array scalar, also returns True if the
+    scalar value can be cast without overflow or truncation to an integer.
+
+    .. seealso:: :func:`numpy.can_cast`
+    """
+    from_dtype = getattr(from_, 'dtype', from_)
+    return numpy.can_cast(from_dtype, to, casting=casting)
 
 
-can_cast = partial(numpy_implementation, numpy.can_cast)
-common_type = partial(numpy_implementation, numpy.common_type)
-result_type = partial(numpy_implementation, numpy.result_type)
+def common_type(*arrays):
+    """Return a scalar type which is common to the input arrays.
+
+    .. seealso:: :func:`numpy.common_type`
+    """
+    dtype_arrays = [numpy.empty((), a.dtype) for a in arrays]
+    return numpy.common_type(*dtype_arrays)
+
+
+def result_type(*arrays_and_dtypes):
+    """Returns the type that results from applying the NumPy type promotion
+    rules to the arguments.
+
+    .. seealso:: :func:`numpy.result_type`
+    """
+    dtype_arrays = [getattr(a, 'dtype', a) for a in arrays_and_dtypes]
+    return numpy.result_type(*dtype_arrays)
+
 
 from numpy import min_scalar_type  # NOQA
 from numpy import obj2sctype  # NOQA

--- a/tests/cupy_tests/core_tests/test_array_function.py
+++ b/tests/cupy_tests/core_tests/test_array_function.py
@@ -29,15 +29,18 @@ class TestArrayFunction(unittest.TestCase):
             self.assertEqual(qr_cpu.dtype, qr_gpu.dtype)
             cupy.testing.assert_allclose(qr_cpu, qr_gpu, atol=1e-4)
 
+    @testing.with_requires('numpy>=1.17.0')
     @testing.numpy_cupy_equal()
     def test_array_function_can_cast(self, xp):
         return numpy.can_cast(xp.arange(2), 'f4')
 
+    @testing.with_requires('numpy>=1.17.0')
     @testing.numpy_cupy_equal()
     def test_array_function_common_type(self, xp):
         return numpy.common_type(xp.arange(2, dtype='f8'),
                                  xp.arange(2, dtype='f4'))
 
+    @testing.with_requires('numpy>=1.17.0')
     @testing.numpy_cupy_equal()
     def test_array_function_result_type(self, xp):
         return numpy.result_type(3, xp.arange(2, dtype='f8'))

--- a/tests/cupy_tests/core_tests/test_array_function.py
+++ b/tests/cupy_tests/core_tests/test_array_function.py
@@ -28,3 +28,15 @@ class TestArrayFunction(unittest.TestCase):
         else:
             self.assertEqual(qr_cpu.dtype, qr_gpu.dtype)
             cupy.testing.assert_allclose(qr_cpu, qr_gpu, atol=1e-4)
+
+    @testing.numpy_cupy_equal()
+    def test_array_function_can_cast(self, xp):
+        return numpy.can_cast(xp.arange(2), 'f4')
+
+    @testing.numpy_cupy_equal()
+    def test_array_function_common_type(self, xp):
+        return numpy.common_type(xp.arange(2, dtype='f8'), xp.arange(2, dtype='f4'))
+
+    @testing.numpy_cupy_equal()
+    def test_array_function_result_type(self, xp):
+        return numpy.result_type(3, xp.arange(2, dtype='f8'))

--- a/tests/cupy_tests/core_tests/test_array_function.py
+++ b/tests/cupy_tests/core_tests/test_array_function.py
@@ -35,7 +35,8 @@ class TestArrayFunction(unittest.TestCase):
 
     @testing.numpy_cupy_equal()
     def test_array_function_common_type(self, xp):
-        return numpy.common_type(xp.arange(2, dtype='f8'), xp.arange(2, dtype='f4'))
+        return numpy.common_type(xp.arange(2, dtype='f8'),
+                                 xp.arange(2, dtype='f4'))
 
     @testing.numpy_cupy_equal()
     def test_array_function_result_type(self, xp):

--- a/tests/cupy_tests/core_tests/test_core.py
+++ b/tests/cupy_tests/core_tests/test_core.py
@@ -56,3 +56,19 @@ class TestOrder(unittest.TestCase):
         expect_f = order_expect == 'F'
         assert a.flags.c_contiguous == expect_c
         assert a.flags.f_contiguous == expect_f
+
+
+class TestNumPyWrappers(unittest.TestCase):
+
+    @testing.numpy_cupy_equal()
+    def test_array_function_can_cast(self, xp):
+        return xp.can_cast(xp.arange(2), 'f4')
+
+    @testing.numpy_cupy_equal()
+    def test_array_function_common_type(self, xp):
+        return xp.common_type(xp.arange(2, dtype='f8'),
+                              xp.arange(2, dtype='f4'))
+
+    @testing.numpy_cupy_equal()
+    def test_array_function_result_type(self, xp):
+        return xp.result_type(3, xp.arange(2, dtype='f8'))


### PR DESCRIPTION
With the introduction of `__array_function__` it has become impossible to use NumPy's implementation directly by aliasing such functions. To fix this behavior, a new `_implementation` attribute was added, ensuring libraries built on top of NumPy can fallback to its implementation.

This PR makes use of this new attribute to ensure functions like `cupy.can_cast` will fallback to `numpy.can_cast`. The tests added here will work for both NumPy < 1.17 (internally using the previous behavior of simply calling `numpy.can_cast` directly), and for NumPy >= 1.17 (internally calling `numpy.can_cast._implementation`). Tests won't work if `NUMPY_EXPERIMENTAL_ARRAY_FUNCTION=1` for NumPy 1.16.x, that doesn't have the `_implementation` attribute that allows these functions to work.