### PR TITLE
Make `__cuda_array_interface__()['strides']` be `tuple`

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -145,7 +145,7 @@ cdef class ndarray:
             'version': 0,
         }
         if not self._c_contiguous:
-            desc['strides'] = tuple(self._strides)
+            desc['strides'] = self.strides
 
         return desc
 

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -145,7 +145,7 @@ cdef class ndarray:
             'version': 0,
         }
         if not self._c_contiguous:
-            desc['strides'] = self._strides
+            desc['strides'] = tuple(self._strides)
 
         return desc
 

--- a/tests/cupy_tests/core_tests/test_ndarray.py
+++ b/tests/cupy_tests/core_tests/test_ndarray.py
@@ -222,7 +222,7 @@ class TestNdarrayCudaInterface(unittest.TestCase):
         assert iface['data'][0] == arr.data.ptr
         assert not iface['data'][1]
         assert iface['version'] == 0
-        assert iface['strides'] == [320, 40]
+        assert iface['strides'] == (320, 40)
         assert iface['descr'] == [('', '<f8')]
 
 

--- a/tests/cupy_tests/core_tests/test_ndarray_cuda_array_interface.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_cuda_array_interface.py
@@ -162,3 +162,50 @@ class TestSlicingMemoryPointer(unittest.TestCase):
         assert cai_ptr == cupy_data_ptr
         assert slice_cai_ptr == sliced_cupy_data_ptr
         assert slice_cai_ptr == cai_ptr+offset
+
+
+@testing.parameterize(
+    {'shape': (10,), 'slices': (slice(0, None),)},
+    {'shape': (10,), 'slices': (slice(2, None),)},
+    {'shape': (10, 10), 'slices': (slice(0, None), slice(0, None))},
+    {'shape': (10, 10), 'slices': (slice(0, None), slice(2, None))},
+    {'shape': (10, 10), 'slices': (slice(2, None), slice(0, None))},
+    {'shape': (10, 10), 'slices': (slice(2, None), slice(2, None))},
+    {'shape': (10, 10), 'slices': (slice(2, None), slice(4, None))},
+)
+@testing.gpu
+class TestCUDAArrayInterfaceCompliance(unittest.TestCase):
+
+    @testing.for_all_dtypes_combination(names=['dtype'])
+    @testing.for_orders('CF')
+    def test_value_type(self, dtype, order):
+        x = cupy.zeros(self.shape, dtype=dtype, order=order)
+        y = x[self.slices]
+
+        # mandatory entries
+        shape = y.__cuda_array_interface__['shape']
+        typestr = y.__cuda_array_interface__['typestr']
+        ptr, readonly = y.__cuda_array_interface__['data']
+        version = y.__cuda_array_interface__['version']
+
+        # optional entries
+        if 'strides' in y.__cuda_array_interface__:
+            strides = y.__cuda_array_interface__['strides']
+        else:
+            strides = None
+        if 'descr' in y.__cuda_array_interface__:
+            descr = y.__cuda_array_interface__['descr']
+        else:
+            descr = None
+
+        # Don't validate correctness of data here, just their types
+        assert isinstance(shape, tuple)
+        assert isinstance(typestr, str)
+        assert isinstance(ptr, int)
+        assert isinstance(readonly, bool)
+        assert version == 0  # update this when the standard is updated!
+        assert (strides is None) or isinstance(strides, tuple)
+        assert (descr is None) or isinstance(descr, list)
+        if isinstance(descr, list):
+            for item in descr:
+                assert isinstance(item, tuple)


### PR DESCRIPTION
Fixes #2259. Added a test to ensure the compliance with `__cuda_array_interface__` standard.