### PR TITLE
Avoid CUDNN_STATUS_BAD_PARAMS

### DIFF
--- a/cupy/cudnn.pyx
+++ b/cupy/cudnn.pyx
@@ -1052,11 +1052,11 @@ def rnn_backward_data(
         cx = core._internal_ascontiguousarray(cx)
     w = core._internal_ascontiguousarray(w)
     xs = core._internal_ascontiguousarray(xs)
-    ys = core._internal_ascontiguousarray(ys)
+    ys = core._internal_ascontiguousarray(ys.copy())
     dhy = core._internal_ascontiguousarray(dhy)
     if dcy is not None:
         dcy = core._internal_ascontiguousarray(dcy)
-    dys = core._internal_ascontiguousarray(dys)
+    dys = core._internal_ascontiguousarray(dys.copy())
 
     cdef int length = len(lengths)
     cdef int n_layers = _get_n_layers(direction_mode, hx)

--- a/cupy/cudnn.pyx
+++ b/cupy/cudnn.pyx
@@ -1052,11 +1052,11 @@ def rnn_backward_data(
         cx = core._internal_ascontiguousarray(cx)
     w = core._internal_ascontiguousarray(w)
     xs = core._internal_ascontiguousarray(xs)
-    ys = core._internal_ascontiguousarray(ys.copy())
+    ys = core._internal_ascontiguousarray(ys)
     dhy = core._internal_ascontiguousarray(dhy)
     if dcy is not None:
         dcy = core._internal_ascontiguousarray(dcy)
-    dys = core._internal_ascontiguousarray(dys.copy())
+    dys = core._internal_ascontiguousarray(ys.view())
 
     cdef int length = len(lengths)
     cdef int n_layers = _get_n_layers(direction_mode, hx)

--- a/cupy/cudnn.pyx
+++ b/cupy/cudnn.pyx
@@ -236,6 +236,8 @@ cpdef _create_convolution_descriptor(
 
 
 cpdef core.ndarray _ascontiguousarray_normalized_strides(core.ndarray a):
+    cdef core.ndarray newarray
+
     if a._c_contiguous:
         newarray = a.view()
         newarray._set_contiguous_strides(newarray.itemsize, True)

--- a/cupy/cudnn.pyx
+++ b/cupy/cudnn.pyx
@@ -1052,11 +1052,11 @@ def rnn_backward_data(
         cx = core._internal_ascontiguousarray(cx)
     w = core._internal_ascontiguousarray(w)
     xs = core._internal_ascontiguousarray(xs)
-    ys = core._internal_ascontiguousarray(ys)
+    ys = core._internal_ascontiguousarray(ys.copy())
     dhy = core._internal_ascontiguousarray(dhy)
     if dcy is not None:
         dcy = core._internal_ascontiguousarray(dcy)
-    dys = core._internal_ascontiguousarray(ys.view())
+    dys = core._internal_ascontiguousarray(dys.copy())
 
     cdef int length = len(lengths)
     cdef int n_layers = _get_n_layers(direction_mode, hx)

--- a/cupy/cudnn.pyx
+++ b/cupy/cudnn.pyx
@@ -14,6 +14,7 @@ from cupy.core cimport internal
 from cupy.cuda cimport memory
 
 from cupy import util
+from cupy.core._ufuncs import elementwise_copy
 from cupy.cuda import cudnn as py_cudnn
 
 
@@ -232,6 +233,16 @@ cpdef _create_convolution_descriptor(
             cudnn.setConvolutionGroupCount(desc, groups)
     elif groups > 1:
         raise ValueError('groups must be one when cuDNN < 7.0')
+
+
+cpdef core.ndarray _ascontiguousarray_normalized_strides(core.ndarray a):
+    if a._c_contiguous:
+        newarray = a.view()
+        newarray._set_contiguous_strides(newarray.itemsize, True)
+    else:
+        newarray = core.ndarray(a.shape, a.dtype)
+        elementwise_copy(a, newarray)
+    return newarray
 
 
 def create_tensor_descriptor(arr, format=cudnn.CUDNN_TENSOR_NCHW):
@@ -1052,11 +1063,11 @@ def rnn_backward_data(
         cx = core._internal_ascontiguousarray(cx)
     w = core._internal_ascontiguousarray(w)
     xs = core._internal_ascontiguousarray(xs)
-    ys = core._internal_ascontiguousarray(ys.copy())
+    ys = _ascontiguousarray_normalized_strides(ys)
     dhy = core._internal_ascontiguousarray(dhy)
     if dcy is not None:
         dcy = core._internal_ascontiguousarray(dcy)
-    dys = core._internal_ascontiguousarray(dys.copy())
+    dys = _ascontiguousarray_normalized_strides(dys)
 
     cdef int length = len(lengths)
     cdef int n_layers = _get_n_layers(direction_mode, hx)


### PR DESCRIPTION
Related to https://github.com/chainer/chainer/issues/7545.

When `rnn_backward_data` takes a sequence whose length is one,
it raises `CUDNN_STATUS_BAD_PARAMS`.

As pointed out by @kmaehashi, strides of `ys` and `dys` are different from each other.
Based on his comment, I put `copy` before `_internal_ascontiguousarray`.