### PR TITLE
Document interoperability with mpi4py

### DIFF
--- a/docs/source/reference/interoperability.rst
+++ b/docs/source/reference/interoperability.rst
@@ -71,7 +71,7 @@ mpi4py
 
 `MPI for Python (mpi4py) <https://mpi4py.readthedocs.io/en/latest/>`_ is a Python wrapper for the Message Passing Interface (MPI) libraries.
 
-MPI is the *de facto* standard for high-performance inter-process communications. Recently several MPI vendors, including Open MPI and MVAPICH, have extended their support beyond the v3.1 standard to enable "CUDA-awareness"; that is, passing CUDA device pointers directly to MPI calls to avoid explicit data movement between the host and the device.
+MPI is the most widely used standard for high-performance inter-process communications. Recently several MPI vendors, including Open MPI and MVAPICH, have extended their support beyond the v3.1 standard to enable "CUDA-awareness"; that is, passing CUDA device pointers directly to MPI calls to avoid explicit data movement between the host and the device.
 
 With the aforementioned ``__cuda_array_interface__`` standard implemented in CuPy, mpi4py now provides (experimental) support for passing CuPy arrays to MPI calls, provided that mpi4py is built against a CUDA-aware MPI implementation. The folowing is a simple example code borrowed from `mpi4py Tutorial <https://mpi4py.readthedocs.io/en/latest/tutorial.html>`_:
 

--- a/docs/source/reference/interoperability.rst
+++ b/docs/source/reference/interoperability.rst
@@ -21,7 +21,7 @@ This enables NumPy ufuncs to be directly operated on CuPy arrays.
 
 :class:`cupy.ndarray` also implements ``__array_function__`` interface (see `NEP 18 — A dispatch mechanism for NumPy’s high level array functions <http://www.numpy.org/neps/nep-0018-array-function-protocol.html>`_ for details).
 This enables code using NumPy to be directly operated on CuPy arrays.
-``__array_function__`` feature requires NumPy 1.16 or later; note that this is currently defined as an experimental feature of NumPy and you need to specify the environment variable to enable it.
+``__array_function__`` feature requires NumPy 1.16 or later; note that this is currently defined as an experimental feature of NumPy and you need to specify the environment variable (``NUMPY_EXPERIMENTAL_ARRAY_FUNCTION=1``) to enable it.
 
 Numba
 -----
@@ -65,6 +65,34 @@ In addition, :func:`cupy.asarray` supports zero-copy conversion from Numba CUDA 
     x = numpy.arange(10)  # type: numpy.ndarray
     x_numba = numba.cuda.to_device(x)  # type: numba.cuda.cudadrv.devicearray.DeviceNDArray
     x_cupy = cupy.asarray(x_numba)  # type: cupy.ndarray
+
+mpi4py
+------
+
+`MPI for Python (mpi4py) <https://mpi4py.readthedocs.io/>`_ is a Python wrapper for the Message Passing Interface (MPI) libraries.
+
+MPI is the *de facto* standard for high-performance multi-process communications. Recently several MPI vendors, including Open MPI and MVAPICH, have extended their support beyond the v3.1 standard to enable "CUDA-awareness"; that is, passing CUDA device pointers directly to MPI calls to avoid explicit data movement between the host and the device.
+
+With the aforementioned ``__cuda_array_interface__`` standard implemented in CuPy, mpi4py now provides (experimental) support for passing CuPy arrays to MPI calls, provided that mpi4py is built against a CUDA-aware MPI implementation. The folowing is a simple example code borrowed from `mpi4py Tutorial <https://mpi4py.readthedocs.io/en/latest/tutorial.html>`_:
+
+.. code:: python
+
+    # To run this script with N MPI processes, do
+    # mpiexec -n N python this_script.py
+
+    import cupy
+    from mpi4py import MPI
+
+    comm = MPI.COMM_WORLD
+    size = comm.Get_size()
+
+    # Allreduce
+    sendbuf = cupy.arange(10, dtype='i')
+    recvbuf = cupy.empty_like(sendbuf)
+    comm.Allreduce(sendbuf, recvbuf)
+    assert cupy.allclose(recvbuf, sendbuf*size)
+
+This new feature will be officially released in mpi4py 3.1.0. To try it out, please build mpi4py from source for the time being.
 
 DLPack
 ------

--- a/docs/source/reference/interoperability.rst
+++ b/docs/source/reference/interoperability.rst
@@ -69,7 +69,7 @@ In addition, :func:`cupy.asarray` supports zero-copy conversion from Numba CUDA 
 mpi4py
 ------
 
-`MPI for Python (mpi4py) <https://mpi4py.readthedocs.io/>`_ is a Python wrapper for the Message Passing Interface (MPI) libraries.
+`MPI for Python (mpi4py) <https://mpi4py.readthedocs.io/en/latest/>`_ is a Python wrapper for the Message Passing Interface (MPI) libraries.
 
 MPI is the *de facto* standard for high-performance inter-process communications. Recently several MPI vendors, including Open MPI and MVAPICH, have extended their support beyond the v3.1 standard to enable "CUDA-awareness"; that is, passing CUDA device pointers directly to MPI calls to avoid explicit data movement between the host and the device.
 

--- a/docs/source/reference/interoperability.rst
+++ b/docs/source/reference/interoperability.rst
@@ -71,7 +71,7 @@ mpi4py
 
 `MPI for Python (mpi4py) <https://mpi4py.readthedocs.io/>`_ is a Python wrapper for the Message Passing Interface (MPI) libraries.
 
-MPI is the *de facto* standard for high-performance multi-process communications. Recently several MPI vendors, including Open MPI and MVAPICH, have extended their support beyond the v3.1 standard to enable "CUDA-awareness"; that is, passing CUDA device pointers directly to MPI calls to avoid explicit data movement between the host and the device.
+MPI is the *de facto* standard for high-performance inter-process communications. Recently several MPI vendors, including Open MPI and MVAPICH, have extended their support beyond the v3.1 standard to enable "CUDA-awareness"; that is, passing CUDA device pointers directly to MPI calls to avoid explicit data movement between the host and the device.
 
 With the aforementioned ``__cuda_array_interface__`` standard implemented in CuPy, mpi4py now provides (experimental) support for passing CuPy arrays to MPI calls, provided that mpi4py is built against a CUDA-aware MPI implementation. The folowing is a simple example code borrowed from `mpi4py Tutorial <https://mpi4py.readthedocs.io/en/latest/tutorial.html>`_:
 
@@ -92,7 +92,7 @@ With the aforementioned ``__cuda_array_interface__`` standard implemented in CuP
     comm.Allreduce(sendbuf, recvbuf)
     assert cupy.allclose(recvbuf, sendbuf*size)
 
-This new feature will be officially released in mpi4py 3.1.0. To try it out, please build mpi4py from source for the time being.
+This new feature will be officially released in mpi4py 3.1.0. To try it out, please build mpi4py from source for the time being. See the `mpi4py website <https://mpi4py.readthedocs.io/en/latest/>`_ for more information.
 
 DLPack
 ------


### PR DESCRIPTION
This PR adds a section on interoperability with mpi4py.

We recently added support for `__cuda_array_interface__` in the master branch of [mpi4py](https://bitbucket.org/mpi4py/mpi4py) so that GPU arrays from CuPy or Numba can work seamlessly with a CUDA-aware MPI as long as they have `__cuda_array_interface__`. I think it's worth documenting and advertising (for example, I saw mpi4py is used in [Chainer](https://github.com/chainer/chainer)'s codebase, and the Chainer users are highly overlapped with CuPy's). More examples are available in mpi4py's `demo` folder:
https://bitbucket.org/mpi4py/mpi4py/src/master/demo/cuda-aware-mpi/