### PR TITLE
[backport] Support `allow_pickle` in `cupy.load` and `cupy.save`

### DIFF
--- a/cupy/io/npz.py
+++ b/cupy/io/npz.py
@@ -28,7 +28,7 @@ class NpzFile(object):
         self.npz_file.close()
 
 
-def load(file, mmap_mode=None, allow_pickle=None):
+def load(file, mmap_mode=None, allow_pickle=True):
     """Loads arrays or pickled objects from ``.npy``, ``.npz`` or pickled file.
 
     This function just calls ``numpy.load`` and then sends the arrays to the

--- a/cupy/io/npz.py
+++ b/cupy/io/npz.py
@@ -46,7 +46,7 @@ def load(file, mmap_mode=None, allow_pickle=True):
             disallowed, loading object arrays will fail.
             Please be aware that CuPy does not support arrays with dtype of
             `object`.
-            The default is False.
+            The default is True.
             This option is available only for NumPy 1.10 or later.
             In NumPy 1.9, this option cannot be specified (loading pickled
             objects is always allowed).

--- a/cupy/io/npz.py
+++ b/cupy/io/npz.py
@@ -60,7 +60,7 @@ def load(file, mmap_mode=None, allow_pickle=True):
 
     """
     if _support_allow_pickle:
-        allow_pickle = False if allow_pickle is None else allow_pickle
+        allow_pickle = True if allow_pickle is None else allow_pickle
         obj = numpy.load(file, mmap_mode, allow_pickle)
     else:
         if allow_pickle is not None:

--- a/tests/cupy_tests/io_tests/test_npz.py
+++ b/tests/cupy_tests/io_tests/test_npz.py
@@ -23,6 +23,38 @@ class TestNpz(unittest.TestCase):
 
         testing.assert_array_equal(a, b)
 
+    @testing.with_requires('numpy>=1.10')
+    def test_save_pickle(self):
+        data = object()
+
+        sio = six.BytesIO()
+        with self.assertRaises(ValueError):
+            cupy.save(sio, data, allow_pickle=False)
+        sio.close()
+
+        sio = six.BytesIO()
+        cupy.save(sio, data, allow_pickle=True)
+        sio.close()
+
+    @testing.with_requires('numpy>=1.10')
+    def test_load_pickle(self):
+        a = testing.shaped_arange((2, 3, 4), dtype=cupy.float32)
+
+        sio = six.BytesIO()
+        a.dump(sio)
+        s = sio.getvalue()
+        sio.close()
+
+        sio = six.BytesIO(s)
+        b = cupy.load(sio, allow_pickle=True)
+        testing.assert_array_equal(a, b)
+        sio.close()
+
+        sio = six.BytesIO(s)
+        with self.assertRaises(ValueError):
+            cupy.load(sio, allow_pickle=False)
+        sio.close()
+
     @testing.for_all_dtypes()
     def check_savez(self, savez, dtype):
         a1 = testing.shaped_arange((2, 3, 4), dtype=dtype)
@@ -56,6 +88,7 @@ class TestNpz(unittest.TestCase):
         testing.assert_array_equal(a, b)
 
     @testing.for_all_dtypes()
+    @testing.with_requires('numpy>=1.10')
     def test_dump(self, dtype):
         a = testing.shaped_arange((2, 3, 4), dtype=dtype)
 
@@ -65,7 +98,7 @@ class TestNpz(unittest.TestCase):
         sio.close()
 
         sio = six.BytesIO(s)
-        b = cupy.load(sio)
+        b = cupy.load(sio, allow_pickle=True)
         sio.close()
 
         testing.assert_array_equal(a, b)


### PR DESCRIPTION
Backport of #2290