### PR TITLE
Remove `cupy.ndarray.{nansum/nanprod}`

### DIFF
--- a/cupy/core/core.pxd
+++ b/cupy/core/core.pxd
@@ -54,7 +54,7 @@ cdef class ndarray:
                         out=*)
     cpdef ndarray sum(self, axis=*, dtype=*, out=*, keepdims=*)
     cpdef ndarray cumsum(self, axis=*, dtype=*, out=*)
-    cpdef ndarray nansum(self, axis=*, dtype=*, out=*, keepdims=*)
+    cpdef ndarray _nansum(self, axis=*, dtype=*, out=*, keepdims=*)
 
     cpdef ndarray mean(self, axis=*, dtype=*, out=*, keepdims=*)
     cpdef ndarray var(self, axis=*, dtype=*, out=*, ddof=*,
@@ -63,7 +63,7 @@ cdef class ndarray:
                       keepdims=*)
     cpdef ndarray prod(self, axis=*, dtype=*, out=*, keepdims=*)
     cpdef ndarray cumprod(self, axis=*, dtype=*, out=*)
-    cpdef ndarray nanprod(self, axis=*, dtype=*, out=*, keepdims=*)
+    cpdef ndarray _nanprod(self, axis=*, dtype=*, out=*, keepdims=*)
 
     cpdef ndarray all(self, axis=*, out=*, keepdims=*)
     cpdef ndarray any(self, axis=*, out=*, keepdims=*)

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -810,7 +810,7 @@ cdef class ndarray:
         """
         return _math._ndarray_cumsum(self, axis, dtype, out)
 
-    cpdef ndarray nansum(
+    cpdef ndarray _nansum(
             self, axis=None, dtype=None, out=None, keepdims=False):
         """Returns the sum along a given axis treating Not a Numbers (NaNs) as zero.
 
@@ -874,7 +874,7 @@ cdef class ndarray:
         """
         return _math._ndarray_cumprod(self, axis, dtype, out)
 
-    cpdef ndarray nanprod(
+    cpdef ndarray _nanprod(
             self, axis=None, dtype=None, out=None, keepdims=None):
         """Returns the product along a given axis treating Not a Numbers (NaNs)
         as zero.

--- a/cupy/math/sumprod.py
+++ b/cupy/math/sumprod.py
@@ -89,7 +89,7 @@ def nansum(a, axis=None, dtype=None, out=None, keepdims=False):
                                       a, axis=axis, dtype=dtype, out=out)
 
     # TODO(okuta): check type
-    return a.nansum(axis, dtype, out, keepdims)
+    return a._nansum(axis, dtype, out, keepdims)
 
 
 def nanprod(a, axis=None, dtype=None, out=None, keepdims=False):
@@ -118,7 +118,7 @@ def nanprod(a, axis=None, dtype=None, out=None, keepdims=False):
                                       a, axis=axis, dtype=dtype, out=out)
 
     # TODO(okuta): check type
-    return a.nanprod(axis, dtype, out, keepdims)
+    return a._nanprod(axis, dtype, out, keepdims)
 
 
 def _axis_to_first(x, axis):


### PR DESCRIPTION
`cupy.{nansum/nanprod}` and `cupy.ndarray.{nansum/nanprod}` were supported in #2252. However, `numpy.ndarray` does not have `nansum` and `nanprod` as attributes, so they should be removed.