### PR TITLE
[backport] Add wrappers for can_cast, common_type and result_type functions

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -341,12 +341,40 @@ def binary_repr(num, width=None):
 # -----------------------------------------------------------------------------
 # Data type routines (borrowed from NumPy)
 # -----------------------------------------------------------------------------
-from numpy import can_cast  # NOQA
-from numpy import common_type  # NOQA
+def can_cast(from_, to, casting='safe'):
+    """Returns True if cast between data types can occur according to the
+    casting rule. If from is a scalar or array scalar, also returns True if the
+    scalar value can be cast without overflow or truncation to an integer.
+
+    .. seealso:: :func:`numpy.can_cast`
+    """
+    from_ = from_.dtype if isinstance(from_, cupy.ndarray) else from_
+    return numpy.can_cast(from_, to, casting=casting)
+
+
+def common_type(*arrays):
+    """Return a scalar type which is common to the input arrays.
+
+    .. seealso:: :func:`numpy.common_type`
+    """
+    dtype_arrays = [numpy.empty((), a.dtype) for a in arrays]
+    return numpy.common_type(*dtype_arrays)
+
+
+def result_type(*arrays_and_dtypes):
+    """Returns the type that results from applying the NumPy type promotion
+    rules to the arguments.
+
+    .. seealso:: :func:`numpy.result_type`
+    """
+    dtypes = [a.dtype if isinstance(a, cupy.ndarray)
+              else a for a in arrays_and_dtypes]
+    return numpy.result_type(*dtypes)
+
+
 from numpy import min_scalar_type  # NOQA
 from numpy import obj2sctype  # NOQA
 from numpy import promote_types  # NOQA
-from numpy import result_type  # NOQA
 
 from numpy import dtype  # NOQA
 from numpy import format_parser  # NOQA

--- a/tests/cupy_tests/core_tests/test_array_function.py
+++ b/tests/cupy_tests/core_tests/test_array_function.py
@@ -28,3 +28,19 @@ class TestArrayFunction(unittest.TestCase):
         else:
             self.assertEqual(qr_cpu.dtype, qr_gpu.dtype)
             cupy.testing.assert_allclose(qr_cpu, qr_gpu, atol=1e-4)
+
+    @testing.with_requires('numpy>=1.17.0')
+    @testing.numpy_cupy_equal()
+    def test_array_function_can_cast(self, xp):
+        return numpy.can_cast(xp.arange(2), 'f4')
+
+    @testing.with_requires('numpy>=1.17.0')
+    @testing.numpy_cupy_equal()
+    def test_array_function_common_type(self, xp):
+        return numpy.common_type(xp.arange(2, dtype='f8'),
+                                 xp.arange(2, dtype='f4'))
+
+    @testing.with_requires('numpy>=1.17.0')
+    @testing.numpy_cupy_equal()
+    def test_array_function_result_type(self, xp):
+        return numpy.result_type(3, xp.arange(2, dtype='f8'))

--- a/tests/cupy_tests/core_tests/test_core.py
+++ b/tests/cupy_tests/core_tests/test_core.py
@@ -56,3 +56,19 @@ class TestOrder(unittest.TestCase):
         expect_f = order_expect == 'F'
         assert a.flags.c_contiguous == expect_c
         assert a.flags.f_contiguous == expect_f
+
+
+class TestNumPyWrappers(unittest.TestCase):
+
+    @testing.numpy_cupy_equal()
+    def test_array_function_can_cast(self, xp):
+        return xp.can_cast(xp.arange(2), 'f4')
+
+    @testing.numpy_cupy_equal()
+    def test_array_function_common_type(self, xp):
+        return xp.common_type(xp.arange(2, dtype='f8'),
+                              xp.arange(2, dtype='f4'))
+
+    @testing.numpy_cupy_equal()
+    def test_array_function_result_type(self, xp):
+        return xp.result_type(3, xp.arange(2, dtype='f8'))


### PR DESCRIPTION
Backport of #2249