### PR TITLE
Avoid creating empty numpy ndarray in `common_type`

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -357,8 +357,13 @@ def common_type(*arrays):
 
     .. seealso:: :func:`numpy.common_type`
     """
-    dtype_arrays = [numpy.empty((), a.dtype) for a in arrays]
-    return numpy.common_type(*dtype_arrays)
+    if len(arrays) == 0:
+        return numpy.float16
+
+    return numpy.find_common_type(
+        [(numpy.float64 if a.dtype.kind in 'iu' else a.dtype) for a in arrays],
+        []
+    ).type
 
 
 def result_type(*arrays_and_dtypes):

--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -360,10 +360,17 @@ def common_type(*arrays):
     if len(arrays) == 0:
         return numpy.float16
 
-    return numpy.find_common_type(
-        [(numpy.float64 if a.dtype.kind in 'iu' else a.dtype) for a in arrays],
-        []
-    ).type
+    default_float_dtype = numpy.dtype('float64')
+    dtypes = []
+    for a in arrays:
+        if a.dtype.kind == 'b':
+            raise TypeError('can\'t get common type for non-numeric array')
+        elif a.dtype.kind in 'iu':
+            dtypes.append(default_float_dtype)
+        else:
+            dtypes.append(a.dtype)
+
+    return numpy.find_common_type(dtypes, []).type
 
 
 def result_type(*arrays_and_dtypes):

--- a/tests/cupy_tests/test_type_routines.py
+++ b/tests/cupy_tests/test_type_routines.py
@@ -64,6 +64,13 @@ class TestCommonType(unittest.TestCase):
         assert type(ret) == type
         return ret
 
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_raises(accept_error=TypeError)
+    def test_common_type_bool(self, xp, dtype):
+        array1 = _generate_type_routines_input(xp, dtype, 'array')
+        array2 = _generate_type_routines_input(xp, 'bool_', 'array')
+        xp.common_type(array1, array2)
+
 
 @testing.parameterize(
     *testing.product({

--- a/tests/cupy_tests/test_type_routines.py
+++ b/tests/cupy_tests/test_type_routines.py
@@ -36,13 +36,28 @@ class TestCanCast(unittest.TestCase):
         return ret
 
 
+# NumPy 1.9 cannot handle float16 in ``numpy.common_type``.
+@testing.with_requires('numpy>=1.10')
 class TestCommonType(unittest.TestCase):
 
-    # NumPy 1.9 cannot handle float16 in ``numpy.common_type``.
-    @testing.with_requires('numpy>=1.10')
-    @testing.for_dtypes_combination('efdFD', names=('dtype1', 'dtype2'))
     @testing.numpy_cupy_equal()
-    def test_common_type(self, xp, dtype1, dtype2):
+    def test_common_type_empty(self, xp):
+        ret = xp.common_type()
+        assert type(ret) == type
+        return ret
+
+    @testing.for_all_dtypes(no_bool=True)
+    @testing.numpy_cupy_equal()
+    def test_common_type_single_argument(self, xp, dtype):
+        array = _generate_type_routines_input(xp, dtype, 'array')
+        ret = xp.common_type(array)
+        assert type(ret) == type
+        return ret
+
+    @testing.for_all_dtypes_combination(
+        names=('dtype1', 'dtype2'), no_bool=True)
+    @testing.numpy_cupy_equal()
+    def test_common_type_two_arguments(self, xp, dtype1, dtype2):
         array1 = _generate_type_routines_input(xp, dtype1, 'array')
         array2 = _generate_type_routines_input(xp, dtype2, 'array')
         ret = xp.common_type(array1, array2)


### PR DESCRIPTION
Fixed to use `numpy.find_common_type`