### PR TITLE
Provide full coverage for NCCL APIs in CuPy

### DIFF
--- a/cupy/cuda/cupy_nccl.h
+++ b/cupy/cuda/cupy_nccl.h
@@ -62,6 +62,18 @@ ncclResult_t ncclCommInitRank(...) {
     return ncclSuccess;
 }
 
+ncclResult_t ncclCommInitAll(...) {
+    return ncclSuccess;
+}
+
+ncclResult_t ncclGroupStart(...) {
+    return ncclSuccess;
+}
+
+ncclResult_t ncclGroupEnd(...) {
+    return ncclSuccess;
+}
+
 void ncclCommDestroy(...) {
 }
 
@@ -73,6 +85,10 @@ ncclResult_t ncclCommCuDevice(...) {
 }
 
 ncclResult_t ncclCommUserRank(...) {
+    return ncclSuccess;
+}
+
+ncclResult_t ncclCommCount(...) {
     return ncclSuccess;
 }
 

--- a/cupy/cuda/cupy_nccl.h
+++ b/cupy/cuda/cupy_nccl.h
@@ -66,11 +66,11 @@ ncclResult_t ncclCommInitAll(...) {
     return ncclSuccess;
 }
 
-ncclResult_t ncclGroupStart() {
+ncclResult_t ncclGroupStart(...) {
     return ncclSuccess;
 }
 
-ncclResult_t ncclGroupEnd() {
+ncclResult_t ncclGroupEnd(...) {
     return ncclSuccess;
 }
 

--- a/cupy/cuda/cupy_nccl.h
+++ b/cupy/cuda/cupy_nccl.h
@@ -186,6 +186,7 @@ ncclResult_t ncclGetVersion(int *version) {
 
 #endif // #if (NCCL_VERSION_CODE < 2304)
 
+#ifndef CUPY_NO_CUDA
 #if (NCCL_VERSION_CODE < 2200)
 // New functions in 2.2
 ncclResult_t ncclGroupStart() {
@@ -196,6 +197,7 @@ ncclResult_t ncclGroupEnd() {
     return ncclSuccess;
 }
 #endif // #if (NCCL_VERSION_CODE < 2200)
+#endif // #ifndef CUPY_NO_CUDA
 
 ncclResult_t _ncclAllReduce(const void* sendbuff, void* recvbuff, size_t count,
                             ncclDataType_t datatype, ncclRedOp_t op, ncclComm_t comm,

--- a/cupy/cuda/cupy_nccl.h
+++ b/cupy/cuda/cupy_nccl.h
@@ -66,11 +66,11 @@ ncclResult_t ncclCommInitAll(...) {
     return ncclSuccess;
 }
 
-ncclResult_t ncclGroupStart(...) {
+ncclResult_t ncclGroupStart() {
     return ncclSuccess;
 }
 
-ncclResult_t ncclGroupEnd(...) {
+ncclResult_t ncclGroupEnd() {
     return ncclSuccess;
 }
 
@@ -185,6 +185,17 @@ ncclResult_t ncclGetVersion(int *version) {
 }
 
 #endif // #if (NCCL_VERSION_CODE < 2304)
+
+#if (NCCL_VERSION_CODE < 2200)
+// New functions in 2.2
+ncclResult_t ncclGroupStart() {
+    return ncclSuccess;
+}
+
+ncclResult_t ncclGroupEnd() {
+    return ncclSuccess;
+}
+#endif // #if (NCCL_VERSION_CODE < 2200)
 
 ncclResult_t _ncclAllReduce(const void* sendbuff, void* recvbuff, size_t count,
                             ncclDataType_t datatype, ncclRedOp_t op, ncclComm_t comm,

--- a/cupy/cuda/cupy_nccl.h
+++ b/cupy/cuda/cupy_nccl.h
@@ -187,8 +187,7 @@ ncclResult_t ncclGetVersion(int *version) {
 #endif // #if (NCCL_VERSION_CODE < 2304)
 
 #ifndef CUPY_NO_CUDA
-#if (NCCL_VERSION_CODE < 2200)
-// New functions in 2.2
+#if (NCCL_VERSION_CODE < 2000)
 ncclResult_t ncclGroupStart() {
     return ncclSuccess;
 }

--- a/cupy/cuda/nccl.pyx
+++ b/cupy/cuda/nccl.pyx
@@ -177,7 +177,7 @@ cpdef groupStart():
     .. _ncclGroupStart:
         https://docs.nvidia.com/deeplearning/sdk/nccl-developer-guide/docs/api/group.html#ncclgroupstart
     """  # noqa
-    if NCCL_VERSION_CODE < 2200:
+    if NCCL_VERSION_CODE < 2000:
         raise RuntimeError('ncclGroupStart is not available in this version')
     with nogil:
         status = ncclGroupStart()
@@ -206,7 +206,7 @@ cpdef groupEnd():
     .. _ncclGroupEnd:
         https://docs.nvidia.com/deeplearning/sdk/nccl-developer-guide/docs/api/group.html#ncclgroupend
     """  # noqa
-    if NCCL_VERSION_CODE < 2200:
+    if NCCL_VERSION_CODE < 2000:
         raise RuntimeError('ncclGroupEnd is not available in this version')
     with nogil:
         status = ncclGroupEnd()

--- a/cupy/cuda/nccl.pyx
+++ b/cupy/cuda/nccl.pyx
@@ -311,10 +311,10 @@ cdef class NcclCommunicator:
             rank (int): The rank in the NCCL worker pool.
 
         .. note::
-            This method is only useful in the scenario where multiple devices
-            are controlled by a single process. This method allows switching 
-            among the underlying NCCL communicators, each associated with a 
-            particular device. A typical usage pattern is like this:
+            This method is only useful when the `NcclCommunicator` instance is
+            created via initAll(). This method allows switching among the
+            underlying NCCL communicators, each associated with a particular
+            device. A typical usage pattern is like this:
 
             .. code-block:: python
 
@@ -324,10 +324,11 @@ cdef class NcclCommunicator:
                     # ... do some collective calls ...
                 comm.groupEnd()
 
-            This method has no effect when each process only controls one
-            device.
         """
         if self._comm.size() > 1:
+            self._current_comm = &self._comm[rank]
+        elif self._comm.size() == 1:  # edge case
+            assert rank == 0
             self._current_comm = &self._comm[rank]
 
     def allReduce(self, size_t sendbuf, size_t recvbuf,

--- a/cupy/cuda/nccl.pyx
+++ b/cupy/cuda/nccl.pyx
@@ -154,67 +154,152 @@ def _bytesize(datatype):
     return bytesize[datatype]
 
 
+cpdef groupStart():
+    """Start a group of NCCL calls. Must be paired with :func:`groupEnd()`.
+
+    .. note::
+        This method is only useful when the ``NcclCommunicator`` instances are
+        created via :meth:`~.NcclCommunicator.initAll`. A typical usage pattern
+        is like this:
+
+        .. code-block:: python
+
+            comms = cupy.cuda.nccl.NcclCommunicator.initAll(n, dev_list)
+            # ... do some preparation work
+            cupy.cuda.nccl.groupStart()
+            for rank, comm in enumerate(comms):
+                # ... make some collective calls ...
+            cupy.cuda.nccl.groupEnd()
+
+    .. seealso:: `ncclGroupStart`_
+
+    .. _ncclGroupStart:
+        https://docs.nvidia.com/deeplearning/sdk/nccl-developer-guide/docs/api/group.html#ncclgroupstart
+    """  # noqa
+    with nogil:
+        status = ncclGroupStart()
+    check_status(status)
+
+
+cpdef groupEnd():
+    """End a group of NCCL calls. Must be paired with :func:`groupStart()`.
+
+    .. note::
+        This method is only useful when the ``NcclCommunicator`` instances are
+        created via :meth:`~.NcclCommunicator.initAll`. A typical usage pattern
+        is like this:
+
+        .. code-block:: python
+
+            comms = cupy.cuda.nccl.NcclCommunicator.initAll(n, dev_list)
+            # ... do some preparation work
+            cupy.cuda.nccl.groupStart()
+            for rank, comm in enumerate(comms):
+                # ... make some collective calls ...
+            cupy.cuda.nccl.groupEnd()
+
+    .. seealso:: `ncclGroupEnd`_
+
+    .. _ncclGroupEnd:
+        https://docs.nvidia.com/deeplearning/sdk/nccl-developer-guide/docs/api/group.html#ncclgroupend
+    """  # noqa
+    with nogil:
+        status = ncclGroupEnd()
+    check_status(status)
+
+
 cdef class NcclCommunicator:
+    """ Initialize an NCCL communicator for one device controlled by one
+    process.
+
+    Args:
+        ndev (int): Total number of GPUs to be used.
+        commId (tuple): The unique ID returned by :func:`get_unique_id`.
+        rank (int): The rank of the GPU managed by the current process.
+
+    Returns:
+        NcclCommunicator: An ``NcclCommunicator`` instance.
+
+    .. note::
+        This method is for creating an NCCL communicator in a multi-process
+        environment, typically managed by MPI or ``multiprocessing``.
+
+    .. seealso:: `ncclCommInitRank`_
+
+    .. _ncclCommInitRank:
+        https://docs.nvidia.com/deeplearning/sdk/nccl-developer-guide/docs/api/comms.html#ncclcomminitrank
+    """  # noqa
 
     cdef:
-        ncclComm_t* _current_comm
-        vector.vector[ncclComm_t] _comm
-        bint _initialized
+        ncclComm_t _comm
 
     def __cinit__(self):
-        self._current_comm = NULL
-        self._initialized = 0
+        self._comm = <ncclComm_t>0
 
     def __init__(self, int ndev, tuple commId, int rank):
         cdef ncclUniqueId _uniqueId
-        assert self._comm.size() == 0
-        self._comm.push_back(<ncclComm_t>0)
-        self._current_comm = &self._comm[0]
         assert len(commId) == NCCL_UNIQUE_ID_BYTES
         for i in range(NCCL_UNIQUE_ID_BYTES):
             _uniqueId.internal[i] = commId[i]
-        status = ncclCommInitRank(self._current_comm, ndev, _uniqueId, rank)
+        status = ncclCommInitRank(&self._comm, ndev, _uniqueId, rank)
         check_status(status)
-        self._initialized = 1
 
     def __dealloc__(self):
         self.destroy()
 
     @staticmethod
     def initAll(int ndev, list devlist=None):
-        """ Initialize NCCL communicator in a single process.
+        """ Initialize NCCL communicators for multiple devices in a single
+        process.
 
         Args:
             ndev (int): Number of GPUs to be used.
             devlist (None or list): A list of integers that label the GPUs to
-                be used. The default is `None`, meaning that the first `ndev`
-                GPUs will be chosen.
+                be used. The default is ``None``, meaning that the first
+                ``ndev`` GPUs will be chosen.
 
         Returns:
-            NcclCommunicator: An `NcclCommunicator` instance.
+            list: A list of ``NcclCommunicator`` instances, each of which
+                controls one device.
 
         .. note::
-            This method is for creating an NCCL communicator in a single
-            process like this:
+            This method is for creating NCCL communicators in a single process
+            like this:
 
             .. code-block:: python
 
                 from cupy.cuda import nccl
                 # Use 3 GPUs: #0, #2, and #3
-                comm = nccl.NcclCommunicator.initAll(3, [0, 2, 3])
+                comms = nccl.NcclCommunicator.initAll(3, [0, 2, 3])
+                assert len(comms) == 3
 
             In a multi-process setup, use the default initializer instead.
-        """
-        # Call to __new__ bypasses __init__ constructor
-        cdef NcclCommunicator NcclComm = \
-            NcclCommunicator.__new__(NcclCommunicator)
-        NcclComm._initAll(ndev, devlist)
-        return NcclComm
 
-    def _initAll(self, int ndev, list devlist=None):
-        # A helper function which does not return is favorable
+        .. seealso:: `ncclCommInitAll`_
+
+        .. _ncclCommInitAll:
+            https://docs.nvidia.com/deeplearning/sdk/nccl-developer-guide/docs/api/comms.html#ncclcomminitall
+        """  # noqa
+        cdef int i
+        cdef list comms = []
+        cdef NcclCommunicator NcclComm
+
+        for i in range(ndev):
+            # Call to __new__ bypasses __init__ constructor
+            # these are just placeholders
+            NcclComm = NcclCommunicator.__new__(NcclCommunicator)
+            comms.append(NcclComm)
+        NcclCommunicator._initAll(comms, ndev, devlist)
+
+        return comms
+
+    @staticmethod
+    def _initAll(list comms, int ndev, list devlist=None):
+        # A helper function which does not return is favorable for subclassing
         cdef vector.vector[int] devices
-        cdef int i, *devices_ptr
+        cdef vector.vector[ncclComm_t] ncclComms
+        cdef NcclCommunicator NcclComm
+        cdef int* devices_ptr
 
         if devlist is not None:
             assert len(devlist) == ndev
@@ -223,135 +308,55 @@ cdef class NcclCommunicator:
             devices_ptr = devices.data()
         else:
             devices_ptr = NULL
-
         for i in range(ndev):
-            self._comm.push_back(<ncclComm_t>0)
-        assert self._comm.size() == ndev
-        status = ncclCommInitAll(self._comm.data(), ndev, devices_ptr)
+            ncclComms.push_back(<ncclComm_t>0)
+        status = ncclCommInitAll(ncclComms.data(), ndev, devices_ptr)
         check_status(status)
-        self._initialized = 1
+        # overwrite the _comm attribute in existing NcclCommunicator instances
+        for i in range(ndev):
+            NcclComm = comms[i]
+            NcclComm._comm = ncclComms[i]
 
     cpdef destroy(self):
-        cdef int i, ndev
-        ndev = self._comm.size()
-        if self._initialized:
-            for i in range(ndev):
-                ncclCommDestroy(self._comm[i])
-            if ndev > 1:
-                self._comm.resize(0)
-                self._current_comm = NULL
-            else:
-                # for backward compatibility
-                self._comm[0] = <ncclComm_t>0
-                self._current_comm = &self._comm[0]
-            self._initialized = 0
+        if self._comm:
+            ncclCommDestroy(self._comm)
+            self._comm = <ncclComm_t>0
 
     cpdef abort(self):
         if NCCL_VERSION_CODE < 2400:
             raise RuntimeError('ncclCommAbort is not available'
                                ' in this version')
-        cdef int i, ndev
-        ndev = self._comm.size()
-        if self._initialized:
-            for i in range(ndev):
-                ncclCommAbort(self._comm[i])
-            if ndev > 1:
-                self._comm.resize(0)
-                self._current_comm = NULL
-            else:
-                # for backward compatibility
-                self._comm[0] = <ncclComm_t>0
-                self._current_comm = &self._comm[0]
-            self._initialized = 0
+        if self._comm:
+            ncclCommAbort(self._comm)
+            self._comm = <ncclComm_t>0
 
     def device_id(self):
-        cdef int device_id, i, ndev
-        cdef vector.vector[int] device_ids
-        ndev = self._comm.size()
-        for i in range(ndev):
-            status = ncclCommCuDevice(self._comm[i], &device_id)
-            check_status(status)
-            device_ids.push_back(device_id)
-        if ndev == 1:
-            # for backward compatibility
-            return device_ids[0]
-        else:
-            # for single process
-            return list(device_ids)
+        cdef int device_id
+        status = ncclCommCuDevice(self._comm, &device_id)
+        check_status(status)
+        return device_id
 
     def rank_id(self):
-        cdef int rank_id, i, ndev
-        cdef vector.vector[int] rank_ids
-        ndev = self._comm.size()
-        for i in range(ndev):
-            status = ncclCommUserRank(self._comm[i], &rank_id)
-            check_status(status)
-            rank_ids.push_back(rank_id)
-        if ndev == 1:
-            # for backward compatibility
-            return rank_ids[0]
-        else:
-            # for single process
-            return list(rank_ids)
-
-    def groupStart(self):
-        cdef int ndev = self._comm.size()
-        if ndev > 1:
-            with nogil:
-                status = ncclGroupStart()
-            check_status(status)
-
-    def groupEnd(self):
-        cdef int ndev = self._comm.size()
-        if ndev > 1:
-            with nogil:
-                status = ncclGroupEnd()
-            check_status(status)
-
-    def setCurrentComm(self, int rank):
-        """ Set the communicator for the given NCCL rank.
-
-        Args:
-            rank (int): The rank in the NCCL worker pool.
-
-        .. note::
-            This method is only useful when the `NcclCommunicator` instance is
-            created via initAll(). This method allows switching among the
-            underlying NCCL communicators, each associated with a particular
-            device. A typical usage pattern is like this:
-
-            .. code-block:: python
-
-                comm.groupStart()
-                for rank, dev_num in enumerate(dev_list):
-                    comm.setCurrentComm(rank)
-                    # ... do some collective calls ...
-                comm.groupEnd()
-
-        """
-        if self._comm.size() > 1:
-            self._current_comm = &self._comm[rank]
-        elif self._comm.size() == 1:  # edge case
-            assert rank == 0
-            self._current_comm = &self._comm[rank]
+        cdef int rank_id
+        status = ncclCommUserRank(self._comm, &rank_id)
+        check_status(status)
+        return rank_id
 
     def allReduce(self, size_t sendbuf, size_t recvbuf,
                   size_t count, int datatype, int op, size_t stream):
-        cdef ncclComm_t* comm = self._current_comm
         with nogil:
             status = _ncclAllReduce(<void*>sendbuf, <void*>recvbuf,
                                     count, <ncclDataType_t>datatype,
-                                    <ncclRedOp_t>op, comm[0],
+                                    <ncclRedOp_t>op, self._comm,
                                     <driver.Stream>stream)
         check_status(status)
 
     def reduce(self, size_t sendbuf, size_t recvbuf,
                size_t count, int datatype, int op, int root, size_t stream):
-        cdef ncclComm_t* comm = self._current_comm
         with nogil:
             status = _ncclReduce(<void*>sendbuf, <void*>recvbuf,
                                  count, <ncclDataType_t>datatype,
-                                 <ncclRedOp_t>op, root, comm[0],
+                                 <ncclRedOp_t>op, root, self._comm,
                                  <driver.Stream>stream)
         check_status(status)
 
@@ -373,42 +378,38 @@ cdef class NcclCommunicator:
 
     def bcast(self, size_t buff, int count, int datatype,
               int root, size_t stream):
-        cdef ncclComm_t* comm = self._current_comm
         with nogil:
             status = _ncclBcast(<void*>buff, count,
                                 <ncclDataType_t>datatype, root,
-                                comm[0], <driver.Stream>stream)
+                                self._comm, <driver.Stream>stream)
         check_status(status)
 
     def reduceScatter(self, size_t sendbuf, size_t recvbuf,
                       size_t recvcount, int datatype, int op, size_t stream):
-        cdef ncclComm_t* comm = self._current_comm
         with nogil:
             status = _ncclReduceScatter(<void*>sendbuf, <void*>recvbuf,
                                         recvcount, <ncclDataType_t>datatype,
-                                        <ncclRedOp_t>op, comm[0],
+                                        <ncclRedOp_t>op, self._comm,
                                         <driver.Stream>stream)
         check_status(status)
 
     def allGather(self, size_t sendbuf, size_t recvbuf, size_t count,
                   int datatype, size_t stream):
-        cdef ncclComm_t* comm = self._current_comm
         with nogil:
             status = _ncclAllGather(<void*>sendbuf, <void*>recvbuf,
                                     count, <ncclDataType_t>datatype,
-                                    comm[0], <driver.Stream>stream)
+                                    self._comm, <driver.Stream>stream)
         check_status(status)
 
     def check_async_error(self):
         if NCCL_VERSION_CODE < 2400:
             raise RuntimeError('ncclCommGetAsyncError is not available'
                                ' in this version')
-        cdef ncclComm_t* comm = self._current_comm
         cdef ncclResult_t asyncError = ncclSuccess
         # Releasing GIL as the function *might* block in future and
         # this won't be a hot code path. At least in NCCL 2.4 it does
         # not block so far.
         with nogil:
-            result = ncclCommGetAsyncError(comm[0], &asyncError)
+            result = ncclCommGetAsyncError(self._comm, &asyncError)
         check_status(asyncError)
         check_status(result)

--- a/cupy/cuda/nccl.pyx
+++ b/cupy/cuda/nccl.pyx
@@ -239,9 +239,11 @@ cdef class NcclCommunicator:
                 ncclCommDestroy(self._comm[i])
             if ndev > 1:
                 self._comm.resize(0)
+                self._current_comm = NULL
             else:
                 # for backward compatibility
                 self._comm[0] = <ncclComm_t>0
+                self._current_comm = &self._comm[0]
             self._initialized = 0
 
     cpdef abort(self):
@@ -255,9 +257,11 @@ cdef class NcclCommunicator:
                 ncclCommAbort(self._comm[i])
             if ndev > 1:
                 self._comm.resize(0)
+                self._current_comm = NULL
             else:
                 # for backward compatibility
                 self._comm[0] = <ncclComm_t>0
+                self._current_comm = &self._comm[0]
             self._initialized = 0
 
     def device_id(self):

--- a/cupy/cuda/nccl.pyx
+++ b/cupy/cuda/nccl.pyx
@@ -177,6 +177,8 @@ cpdef groupStart():
     .. _ncclGroupStart:
         https://docs.nvidia.com/deeplearning/sdk/nccl-developer-guide/docs/api/group.html#ncclgroupstart
     """  # noqa
+    if NCCL_VERSION_CODE < 2200:
+        raise RuntimeError('ncclGroupStart is not available in this version')
     with nogil:
         status = ncclGroupStart()
     check_status(status)
@@ -204,6 +206,8 @@ cpdef groupEnd():
     .. _ncclGroupEnd:
         https://docs.nvidia.com/deeplearning/sdk/nccl-developer-guide/docs/api/group.html#ncclgroupend
     """  # noqa
+    if NCCL_VERSION_CODE < 2200:
+        raise RuntimeError('ncclGroupEnd is not available in this version')
     with nogil:
         status = ncclGroupEnd()
     check_status(status)

--- a/cupy/cuda/nccl.pyx
+++ b/cupy/cuda/nccl.pyx
@@ -40,6 +40,7 @@ cdef extern from 'cupy_nccl.h':
     void ncclCommAbort(ncclComm_t comm)
     ncclResult_t ncclCommCuDevice(const ncclComm_t comm, int* device)
     ncclResult_t ncclCommUserRank(const ncclComm_t comm, int* rank)
+    ncclResult_t ncclCommCount(const ncclComm_t comm, int* count)
     ncclResult_t _ncclAllReduce(const void* sendbuff, void* recvbuff,
                                 size_t count,
                                 ncclDataType_t datatype, ncclRedOp_t op,
@@ -351,6 +352,12 @@ cdef class NcclCommunicator:
         status = ncclCommUserRank(self._comm, &rank_id)
         check_status(status)
         return rank_id
+
+    def size(self):
+        cdef int ranks
+        status = ncclCommCount(self._comm, &ranks)
+        check_status(status)
+        return ranks
 
     def allReduce(self, size_t sendbuf, size_t recvbuf,
                   size_t count, int datatype, int op, size_t stream):

--- a/docs/source/reference/cuda.rst
+++ b/docs/source/reference/cuda.rst
@@ -87,4 +87,3 @@ NCCL
    cupy.cuda.nccl.get_unique_id
    cupy.cuda.nccl.groupStart
    cupy.cuda.nccl.groupEnd
-

--- a/docs/source/reference/cuda.rst
+++ b/docs/source/reference/cuda.rst
@@ -72,3 +72,19 @@ Profiler
    cupy.cuda.nvtx.RangePush
    cupy.cuda.nvtx.RangePushC
    cupy.cuda.nvtx.RangePop
+
+
+NCCL
+----
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+
+   cupy.cuda.nccl.NcclCommunicator
+   cupy.cuda.nccl.get_build_version
+   cupy.cuda.nccl.get_version
+   cupy.cuda.nccl.get_unique_id
+   cupy.cuda.nccl.groupStart
+   cupy.cuda.nccl.groupEnd
+

--- a/tests/cupy_tests/cuda_tests/test_nccl.py
+++ b/tests/cupy_tests/cuda_tests/test_nccl.py
@@ -42,7 +42,7 @@ class TestNCCL(unittest.TestCase):
 
     @attr.gpu
     @unittest.skipUnless(cuda.nccl_enabled and
-                         cuda.nccl.get_version() >= 2200, 'Using old NCCL')
+                         cuda.nccl.get_version() >= 2000, 'Using old NCCL')
     def test_single_proc_single_dev(self):
         comms = cuda.nccl.NcclCommunicator.initAll(1)
         cuda.nccl.groupStart()

--- a/tests/cupy_tests/cuda_tests/test_nccl.py
+++ b/tests/cupy_tests/cuda_tests/test_nccl.py
@@ -1,5 +1,6 @@
 import unittest
 
+import cupy
 from cupy import cuda
 from cupy.testing import attr
 
@@ -36,3 +37,17 @@ class TestNCCL(unittest.TestCase):
         comm = cuda.nccl.NcclCommunicator.initAll(1)
         assert 0 == comm.rank_id()
         comm.destroy()
+
+    @attr.gpu
+    def test_single_proc_single_dev(self):
+        comm = cuda.nccl.NcclCommunicator.initAll(1)
+        comm.groupStart()
+        for rank in range(1):
+            comm.setCurrentComm(rank)
+            sendbuf = cupy.arange(10)
+            recvbuf = cupy.zeros_like(sendbuf)
+            comm.allReduce(sendbuf.data.ptr, recvbuf.data.ptr, 10,
+                           cuda.nccl.NCCL_INT64, cuda.nccl.NCCL_SUM,
+                           cuda.Stream.null.ptr)
+        comm.groupEnd()
+        assert cupy.allclose(sendbuf, recvbuf)

--- a/tests/cupy_tests/cuda_tests/test_nccl.py
+++ b/tests/cupy_tests/cuda_tests/test_nccl.py
@@ -41,6 +41,8 @@ class TestNCCL(unittest.TestCase):
             comms[i].destroy()
 
     @attr.gpu
+    @unittest.skipUnless(cuda.nccl_enabled and
+                         cuda.nccl.get_version() >= 2200, 'Using old NCCL')
     def test_single_proc_single_dev(self):
         comms = cuda.nccl.NcclCommunicator.initAll(1)
         cuda.nccl.groupStart()

--- a/tests/cupy_tests/cuda_tests/test_nccl.py
+++ b/tests/cupy_tests/cuda_tests/test_nccl.py
@@ -30,3 +30,9 @@ class TestNCCL(unittest.TestCase):
         comm = cuda.nccl.NcclCommunicator(1, id, 0)
         comm.check_async_error()
         comm.destroy()
+
+    @attr.gpu
+    def test_init_all(self):
+        comm = cuda.nccl.NcclCommunicator.initAll(1)
+        assert 0 == comm.rank_id()
+        comm.destroy()

--- a/tests/cupy_tests/cuda_tests/test_nccl.py
+++ b/tests/cupy_tests/cuda_tests/test_nccl.py
@@ -53,3 +53,9 @@ class TestNCCL(unittest.TestCase):
                            cuda.Stream.null.ptr)
         cuda.nccl.groupEnd()
         assert cupy.allclose(sendbuf, recvbuf)
+
+    @attr.gpu
+    def test_comm_size(self):
+        id = cuda.nccl.get_unique_id()
+        comm = cuda.nccl.NcclCommunicator(1, id, 0)
+        assert 1 == comm.size()

--- a/tests/cupy_tests/cuda_tests/test_nccl.py
+++ b/tests/cupy_tests/cuda_tests/test_nccl.py
@@ -63,6 +63,7 @@ class TestNCCL(unittest.TestCase):
         comm = cuda.nccl.NcclCommunicator(1, id, 0)
         assert 1 == comm.size()
 
+
 @unittest.skipUnless(cuda.nccl_enabled, 'nccl is not installed')
 class TestExceptionPicklable(unittest.TestCase):
 


### PR DESCRIPTION
The main purpose of PR is to add a factory function to `NcclCommunicator` so that it is possible to create a group of NCCL communicators for multiple devices in a single process:
```python
from cupy.cuda import nccl

# Use GPU #0, #2, and #3
# comms is a list of NcclCommunicator
comms = nccl.NcclCommunicator.initAll([0, 2, 3])
```
Since Python/Cython does not support overloading multiple constructors, in order to preserve backward compatibility creating a factory function seems to be a necessary design decision to me. Please let me know if you have any better alternatives, thanks! 

In addition, this PR also wraps several other NCCL APIs (mainly to serve the above need). With this PR, **now CuPy supports the full NCCL APIs!** See below for a complete and finalized list for the changes:

**=== FINAL UPDATE ===**
- added `initAll()`, `groupStart()` and `groupEnd()` to support controlling multiple devices in a single process.
- added `size()` that returns the total number of NCCL ranks.
- added tests for the above functions
- added documentation for NCCL APIs.
- backward compatibility is still preserved

For a working demo enabled by this PR, see https://github.com/cupy/cupy/pull/2325#issuecomment-515299903.