### PR TITLE
Fix variable names in `tri` kernel

### DIFF
--- a/cupy/creation/matrix.py
+++ b/cupy/creation/matrix.py
@@ -85,9 +85,9 @@ def tri(N, M=None, k=0, dtype=float):
         'int32 m, int32 k',
         'T out',
         '''
-        int row = i % m;
-        int col = i / m;
-        out = (row <= col + k);
+        int row = i / m;
+        int col = i % m;
+        out = (col <= row + k);
         ''',
         'tri',
     )(M, k, out)


### PR DESCRIPTION
The `row` and `col` variables were mixed up in `tri`'s kernel so I corrected their names. The logic hasn't changed.