### PR TITLE
Make `cupy.tensordot` use Tensor Core also in case of compute-capability > 70

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2539,7 +2539,7 @@ cpdef ndarray tensordot_core(
                    (ret_dtype == 'e' or ret_dtype == 'f'))
     use_tensor_core = (use_sgemmEx and
                        _cuda_runtime_version >= 9000 and
-                       int(device.get_compute_capability()) == 70)
+                       int(device.get_compute_capability()) >= 70)
 
     if use_sgemmEx or ret_dtype in 'fdFD':
         dtype = ret_dtype


### PR DESCRIPTION
Rel. #2197