### PR TITLE
[WIP] `cupy.around` behaves differently from NumPy for EVEN_NUMBER+0.5

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1751,7 +1751,9 @@ _round_ufunc = create_ufunc(
      ('Fq->F', _round_complex),
      ('Dq->D', _round_complex)),
     '''
-    if (in1 < 0) {
+    if (in1 >= 0) {
+        out0 = in0;
+    } else {
         // TODO(okuta): Move before loop
         long long x = pow10<long long>(-in1 - 1);
 
@@ -1762,10 +1764,8 @@ _round_ufunc = create_ufunc(
         // (3) round the latter by `rint()`: -123400 + (-6.0 * 10)
         // (4) unscale by `x` above: -123460000
         long long q = in0 / x / 100;
-        double r = (in0 - q*x*100) / static_cast<double>(x);
-        out0 = (q*100 + static_cast<long long>(rint(r/10.0)*10)) * x;
-    } else {
-        out0 = in0;
+        int r = in0 - q*x*100;
+        out0 = (q*100 + __float2ll_rn(r/(x*10.0f))*10) * x;
     }''', preamble=_round_preamble)
 
 

--- a/cupy/math/rounding.py
+++ b/cupy/math/rounding.py
@@ -8,7 +8,7 @@ def around(a, decimals=0, out=None):
 
     Args:
         a (cupy.ndarray): The source array.
-        decimals (int): umber of decimal places to round to (default: 0).
+        decimals (int): Number of decimal places to round to (default: 0).
             If decimals is negative, it specifies the number of positions to
             the left of the decimal point.
         out (cupy.ndarray): Output array.

--- a/tests/cupy_tests/core_tests/test_ndarray_math.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_math.py
@@ -32,3 +32,84 @@ class TestRound(unittest.TestCase):
         out = xp.empty_like(a)
         a.round(self.decimals, out)
         return out
+
+
+@testing.parameterize(*testing.product({
+    # limit to:
+    # * <=0: values like 0.35 and 0.035 cannot be expressed exactly in IEEE 754
+    # * >-4: to avoid float16 overflow
+    'decimals': [-3, -2, -1, 0],
+}))
+class TestRoundHalfway(unittest.TestCase):
+
+    shape = (20,)
+
+    @testing.for_float_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_round_halfway_float(self, xp, dtype):
+        # generate [..., -1.5, -0.5, 0.5, 1.5, ...] * 10^{-decimals}
+        a = testing.shaped_arange(self.shape, xp, dtype=dtype)
+        a *= 2
+        a -= a.size + 1
+        scale = 10**abs(self.decimals)
+        if self.decimals < 0:
+            a *= scale
+        else:
+            a /= scale
+        a /= 2
+
+        print(xp, dtype, self.decimals, a, a.round(self.decimals))
+        return a.round(self.decimals)
+
+    @testing.for_signed_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_round_halfway_int(self, xp, dtype):
+        # generate [..., -1.5, -0.5, 0.5, 1.5, ...] * 10^{-decimals}
+        a = testing.shaped_arange(self.shape, xp, dtype=dtype)
+        a *= 2
+        a -= a.size + 1
+        scale = 10**abs(self.decimals)
+        if self.decimals < 0:
+            a *= xp.array(scale, dtype=dtype)
+        a >>= 1
+
+        return a.round(self.decimals)
+
+    @testing.for_unsigned_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_round_halfway_uint(self, xp, dtype):
+        # generate [0.5, 1.5, ...] * 10^{-decimals}
+        a = testing.shaped_arange(self.shape, xp, dtype=dtype)
+        a *= 2
+        a -= 1
+        scale = 10**abs(self.decimals)
+        if self.decimals < 0:
+            a *= xp.array(scale, dtype=dtype)
+        a >>= 1
+
+        return a.round(self.decimals)
+
+
+@testing.parameterize(*testing.product({
+    'decimals': [-5, -4, -3, -2, -1, 0]
+}))
+class TestRoundMinMax(unittest.TestCase):
+
+    @unittest.skip('Known incompatibility: see core.pyx')
+    @testing.numpy_cupy_array_equal()
+    def _test_round_int64(self, xp):
+        a = xp.array([-2**62, 2**62], dtype=xp.int64)
+        return a.round(self.decimals)
+
+    @unittest.skip('Known incompatibility: see core.pyx')
+    @testing.numpy_cupy_array_equal()
+    def test_round_uint64(self, xp):
+        a = xp.array([2**63], dtype=xp.uint64)
+        return a.round(self.decimals)
+
+    @unittest.skip('Known incompatibility: see core.pyx')
+    @testing.for_int_dtypes(no_bool=True)
+    @testing.numpy_cupy_array_equal()
+    def test_round_minmax(self, xp, dtype):
+        a = xp.array([xp.iinfo(dtype).min, xp.iinfo(dtype).max], dtype=dtype)
+        return a.round(self.decimals)


### PR DESCRIPTION
`cupy.around` is incompatible with `numpy.around` such as `cupy.around(2.5) == numpy.around(2.5)` gives `False` (tested on CuPy 7.0.0b1 vs. NumPy 1.16.4).
This PR fixes the problem, and also solves #2276.

We may need additional fix and/or discussion because there still be incompatible case(s) even with this PR:
 * `cupy.around(2**63, -1)` differs from NumPy, the latter does *not* round the last digit,
 * corner cases like `cupy.array(255, cupy.uint8).round(-1)` are not exhaustively tested.