### PR TITLE
Pass environment variables to Popen

### DIFF
--- a/install/build.py
+++ b/install/build.py
@@ -169,7 +169,8 @@ def _get_compiler_base_options():
         proc = subprocess.Popen(
             nvcc_path + ['-o', test_out_path, test_cu_path],
             stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE)
+            stderr=subprocess.PIPE,
+            env=os.environ)
         stdoutdata, stderrdata = proc.communicate()
         stderrlines = stderrdata.split(b'\n')
         if proc.returncode != 0:


### PR DESCRIPTION
Previously, when testing `nvcc`, environment variables were not being passed along to the subprocess. This could cause issues as compiler flags would get stripped or the `$PATH` not preserved. This fixes that issue by passing `os.environ` to `Popen`'s `env` argument.