### PR TITLE
Fix tests of linalg.svd

### DIFF
--- a/tests/cupy_tests/linalg_tests/test_decomposition.py
+++ b/tests/cupy_tests/linalg_tests/test_decomposition.py
@@ -106,7 +106,7 @@ class TestSVD(unittest.TestCase):
     def setUp(self):
         self.seed = testing.generate_seed()
 
-    @testing.for_float_dtypes(no_float16=True)
+    @testing.for_dtypes('fdFD')
     def check_usv(self, shape, dtype):
         array = testing.shaped_random(
             shape, numpy, dtype=dtype, seed=self.seed)
@@ -120,7 +120,7 @@ class TestSVD(unittest.TestCase):
             cupy.testing.assert_allclose(
                 numpy.abs(b_cpu), cupy.abs(b_gpu), atol=1e-4)
 
-    @testing.for_float_dtypes(no_float16=True)
+    @testing.for_dtypes('fdFD')
     @testing.numpy_cupy_allclose(atol=1e-4)
     def check_singular(self, shape, xp, dtype):
         array = testing.shaped_random(shape, xp, dtype=dtype, seed=self.seed)

--- a/tests/cupy_tests/linalg_tests/test_decomposition.py
+++ b/tests/cupy_tests/linalg_tests/test_decomposition.py
@@ -106,7 +106,10 @@ class TestSVD(unittest.TestCase):
     def setUp(self):
         self.seed = testing.generate_seed()
 
-    @testing.for_dtypes('fdFD')
+    @testing.for_dtypes([
+        numpy.int32, numpy.int64, numpy.uint32, numpy.uint64,
+        numpy.float32, numpy.float64, numpy.complex64, numpy.complex128,
+    ])
     def check_usv(self, shape, dtype):
         array = testing.shaped_random(
             shape, numpy, dtype=dtype, seed=self.seed)
@@ -147,7 +150,10 @@ class TestSVD(unittest.TestCase):
             numpy.testing.assert_allclose(
                 vhj, sign.conj() * vh_cpu[j, :], atol=1e-4)
 
-    @testing.for_dtypes('fdFD')
+    @testing.for_dtypes([
+        numpy.int32, numpy.int64, numpy.uint32, numpy.uint64,
+        numpy.float32, numpy.float64, numpy.complex64, numpy.complex128,
+    ])
     @testing.numpy_cupy_allclose(atol=1e-4)
     def check_singular(self, shape, xp, dtype):
         array = testing.shaped_random(shape, xp, dtype=dtype, seed=self.seed)
@@ -165,15 +171,15 @@ class TestSVD(unittest.TestCase):
 
     @condition.repeat(3, 10)
     def test_svd(self):
-        self.check_usv((2, 3))
+        self.check_usv((3, 7))
         self.check_usv((2, 2))
-        self.check_usv((3, 2))
+        self.check_usv((7, 3))
 
     @condition.repeat(3, 10)
     def test_svd_no_uv(self):
-        self.check_singular((2, 3))
+        self.check_singular((3, 7))
         self.check_singular((2, 2))
-        self.check_singular((3, 2))
+        self.check_singular((7, 3))
 
     @condition.repeat(3, 10)
     def test_rank2(self):


### PR DESCRIPTION
- Compare each `u[:, j]` up to a multiplication of `sign` with `abs(sign) == 1`, rather than comparing each `abs(u[i, j])`
- Do not compare vectors for `full_matrices=True` unless `abs(shape[-2] - shape[-1]) <= 1` (see below)
- Test complex inputs
- Test int inputs
- Follow `numpy.testing.assert_allclose(actual, desired)`

```python
import numpy
import cupy

numpy.random.seed(0)
numpy.set_printoptions(linewidth=100)

x = numpy.random.randn(8, 4)
print('u (numpy)')
print(numpy.linalg.svd(x)[0])
print('u (cupy)')
print(cupy.linalg.svd(cupy.array(x))[0])

x = numpy.random.randn(4, 8)
print('vh (numpy)')
print(numpy.linalg.svd(x)[2])
print('vh (cupy)')
print(cupy.linalg.svd(cupy.array(x))[2])
```

```
u (numpy)
[[-0.44713126 -0.61696779  0.21043358 -0.28435409  0.12524547  0.45223261 -0.12257623 -0.24302088]
 [-0.39681434  0.24148952  0.07060557 -0.5469773  -0.14894455 -0.2466916  -0.40206712  0.48513161]
 [-0.04021424 -0.45123004  0.27840988  0.04668508  0.37231349 -0.5983796   0.35291899  0.30635831]
 [-0.16464493 -0.09898343 -0.0831798  -0.18952489 -0.52110637 -0.52008759  0.13427343 -0.60015287]
 [-0.25266402  0.29308223 -0.41502762 -0.17376323  0.70827078 -0.15181578 -0.00368963 -0.35087459]
 [ 0.5156543  -0.07195456 -0.15116997 -0.72817684  0.01211493  0.15726861  0.38380254  0.06037167]
 [-0.46557788  0.39718488  0.23798928  0.00860211 -0.10058817  0.23317201  0.70667927  0.06989823]
 [-0.25958747 -0.31431961 -0.78394033  0.14611719 -0.2001191   0.06268208  0.18445145  0.34627419]]
u (cupy)
[[-0.44713126 -0.61696779 -0.21043358 -0.28435409  0.20360635  0.1804541  -0.3268036   0.3368457 ]
 [-0.39681434  0.24148952 -0.07060557 -0.5469773  -0.4776941   0.02783274 -0.1624313  -0.47402705]
 [-0.04021424 -0.45123004 -0.27840988  0.04668508  0.20135159  0.01450684  0.55846508 -0.60203534]
 [-0.16464493 -0.09898343  0.0831798  -0.18952489 -0.01821729 -0.91865269  0.20021149  0.18951646]
 [-0.25266402  0.29308223  0.41502762 -0.17376323  0.76333829  0.00284908 -0.09190607 -0.23807967]
 [ 0.5156543  -0.07195456  0.15116997 -0.72817684  0.0504308   0.18792553  0.31104064  0.20303636]
 [-0.46557788  0.39718488 -0.23798928  0.00860211  0.02186232  0.22971866  0.59205727  0.40618725]
 [-0.25958747 -0.31431961  0.78394033  0.14611719 -0.32213646  0.18556308  0.24315176  0.02401078]]
vh (numpy)
[[ 0.45442221  0.49060007  0.46730565 -0.45336015  0.04245722  0.09767576  0.29143128 -0.18062852]
 [ 0.03530071 -0.51339404  0.20772278 -0.08549357  0.55626594  0.60996527  0.05684502 -0.00131523]
 [-0.04758245  0.09054827  0.23714438  0.19708412  0.0917285  -0.09259851  0.39283401  0.85038236]
 [ 0.73039563  0.03091907 -0.03752251  0.48085422 -0.16443636  0.24703448 -0.35233189  0.14399445]
 [ 0.35815434  0.03476584 -0.46364233 -0.10969481  0.65979521 -0.4536999   0.03345926  0.03502572]
 [-0.0411733   0.30223741 -0.6710182  -0.13980892 -0.12926974  0.55428362  0.3169398   0.11293148]
 [ 0.33376516 -0.57929893 -0.09989623 -0.04096367 -0.37938644 -0.18762392  0.58697829 -0.132951  ]
 [ 0.12305895 -0.24174322 -0.07498261 -0.69558248 -0.23945291 -0.0229046  -0.43274271  0.43798489]]
vh (cupy)
[[-0.45442221 -0.49060007 -0.46730565  0.45336015 -0.04245722 -0.09767576 -0.29143128  0.18062852]
 [-0.03530071  0.51339404 -0.20772278  0.08549357 -0.55626594 -0.60996527 -0.05684502  0.00131523]
 [ 0.04758245 -0.09054827 -0.23714438 -0.19708412 -0.0917285   0.09259851 -0.39283401 -0.85038236]
 [-0.73039563 -0.03091907  0.03752251 -0.48085422  0.16443636 -0.24703448  0.35233189 -0.14399445]
 [ 0.33014307  0.0896733  -0.47210296 -0.06442231  0.68866379 -0.42383823  0.04237967  0.01549582]
 [ 0.12902541 -0.03199081 -0.63058226 -0.46428866 -0.31689612  0.38395425  0.22419368  0.26650378]
 [ 0.03574926  0.00522927 -0.17386714  0.50963984 -0.05552607  0.11423265  0.73545282 -0.38949839]
 [-0.3599895   0.6910073  -0.17345405  0.19402455  0.27486005  0.45682872 -0.2010732   0.02266432]]
```