### PR TITLE
Support cuTENSOR 0.2

### DIFF
--- a/cupy/cuda/cupy_cutensor.h
+++ b/cupy/cuda/cupy_cutensor.h
@@ -61,6 +61,14 @@ extern "C" {
 	return CUTENSOR_STATUS_SUCCESS;
     }
 
+    cutensorStatus_t cutensorReduction(...) {
+	return CUTENSOR_STATUS_SUCCESS;
+    }
+
+    cutensorStatus_t cutensorReductionGetWorkspace(...) {
+	return CUTENSOR_STATUS_SUCCESS;
+    }
+
     const char* cutensorGetErrorString(...) {
 	return NULL;
     }

--- a/cupy/cuda/cutensor.pyx
+++ b/cupy/cuda/cutensor.pyx
@@ -80,6 +80,26 @@ cdef extern from 'cupy_cutensor.h' nogil:
 
     int cutensorContractionMaxAlgos(int32_t* maxNumAlgos)
 
+    int cutensorReduction(
+        Handle handle,
+        void* alpha,
+        void* A, TensorDescriptor descA, int32_t* modeA,
+        void* beta,
+        void* C, TensorDescriptor descC, int32_t* modeC,
+        void* D, TensorDescriptor descD, int32_t* modeD,
+        Operator opReduce, DataType typeCompute,
+        void* workspace, uint64_t workspaceSize,
+        driver.Stream stream)
+
+    int cutensorReductionGetWorkspace(
+        Handle handle,
+        void* A, TensorDescriptor descA, int32_t* modeA,
+        void* C, TensorDescriptor descC, int32_t* modeC,
+        void* D, TensorDescriptor descD, int32_t* modeD,
+        Operator opReduce, DataType typeCompute,
+        uint64_t* workspaceSize);
+
+
 ###############################################################################
 # Enum
 ###############################################################################
@@ -523,3 +543,103 @@ cpdef int32_t contractionMaxAlgos():
     status = cutensorContractionMaxAlgos(&maxNumAlgos)
     check_status(status)
     return maxNumAlgos
+
+
+###############################################################################
+# Tensor reduction
+###############################################################################
+
+cpdef reduction(size_t handle,
+                size_t alpha,
+                size_t A, size_t descA, size_t modeA,
+                size_t beta,
+                size_t C, size_t descC, size_t modeC,
+                size_t D, size_t descD, size_t modeD,
+                int opReduce, int typeCompute,
+                size_t workspace, uint64_t workspaceSize):
+    """Tensor reduction
+
+    This routine computes the tensor reduction of the form
+    D = alpha * opReduce(opA(A)) + beta * opC(C).
+
+    Example:
+     - D_{a,d} = 0.9 * A_{a,b,c,d} + 0.1 * C_{a,d}
+
+    Args:
+        handle (cutensorHandle_t): Opaque handle holding CUTENSOR's library
+            context.
+        alpha (void*): Scaling for A. The data_type_t is determined by
+            'typeCompute'. Pointer to the host memory.
+        A (void*): Pointer to the data corresponding to A. Pointer to the
+            GPU-accessable memory.
+        descA (cutensorDescriptor_t): A descriptor that holds the information
+            about the data type, modes, strides and unary operator (opA) of A.
+        modeA (int32_t*): Array with 'nmodeA' entries that represent the modes
+            of A. The modeA[i] corresponds to extent[i] and stride[i] w.r.t.
+            the arguments provided to cutensorCreateTensorDescriptor.
+        beta (void*): Scaling for C. The data_type_t is determined by
+            'typeCompute'. Pointer to the host memory.
+        C (void*): Pointer to the data corresponding to C. Pointer to the
+            GPU-accessable memory.
+        modeC (int32_t*): Array with 'nmodeC' entries that represent the modes
+            of C. The modeC[i] corresponds to extent[i] and stride[i] w.r.t.
+            the arguments provided to cutensorCreateTensorDescriptor.
+        descC (cutensorDescriptor_t): The C descriptor that holds information
+            about the data type, modes, strides and unary operator (opC) of C.
+        D (void*): Pointer to the data corresponding to D (must be identical
+            to C for now). Pointer to the GPU-accessable memory.
+        modeD (int32_t*): Array with 'nmodeD' entries that represent the modes
+            of D (must be identical to modeC for now). The modeD[i] corresponds
+            to extent[i] and stride[i] w.r.t. the arguments provided to
+            cutensorCreateTensorDescriptor.
+        descD (cutensorDescriptor_t): The D descriptor that holds information
+            about the data type, modes, and strides of D (must be identical to
+            descC for now).
+        opReduce (cutensorOperator_t): Binary operator used to reduce elements
+            of A.
+        typeCompute (cudaDataType_t): All arithmetic is performed using this
+            data type (i.e., it affects the accuracy and performance).
+        workspace (void*): Scratchpad (device) memory.
+        workspaceSize (uint64_t): Please use reductionGetWorkspace() to query
+            the required workspace. That being said, a workspaceSize of zero is
+            valid but it can lead to (grossly) suboptimal performance. Hence,
+            if you don't want to call reductionGetWorkspace() prior to each
+            reduction call (which is not really necessary), then you could
+            provide some small and fixed workspace (e.g., 8192 bytes).
+    """
+    cdef size_t stream = stream_module.get_current_stream_ptr()
+    status = cutensorReduction(
+        <Handle> handle,
+        <void*> alpha,
+        <void*> A, <TensorDescriptor> descA, <int32_t*> modeA,
+        <void*> beta,
+        <void*> C, <TensorDescriptor> descC, <int32_t*> modeC,
+        <void*> D, <TensorDescriptor> descD, <int32_t*> modeD,
+        <Operator> opReduce, <DataType> typeCompute,
+        <void*> workspace, workspaceSize, <driver.Stream> stream)
+    check_status(status)
+
+
+cpdef uint64_t reductionGetWorkspace(size_t handle,
+                                     size_t A, size_t descA, size_t modeA,
+                                     size_t C, size_t descC, size_t modeC,
+                                     size_t D, size_t descD, size_t modeD,
+                                     int opReduce, int typeCompute):
+    """Determines the required workspaceSize for a given tensor reduction
+
+    Args:
+        See reduction() about args.
+
+    Returns:
+        workspaceSize (uint64_t): The workspace size (in bytes) that is
+            required for the given tensor reduction.
+    """
+    cdef uint64_t workspaceSize
+    status = cutensorReductionGetWorkspace(
+        <Handle> handle,
+        <void*> A, <TensorDescriptor> descA, <int32_t*> modeA,
+        <void*> C, <TensorDescriptor> descC, <int32_t*> modeC,
+        <void*> D, <TensorDescriptor> descD, <int32_t*> modeD,
+        <Operator> opReduce, <DataType> typeCompute, &workspaceSize)
+    check_status(status)
+    return workspaceSize

--- a/cupy/cuda/cutensor.pyx
+++ b/cupy/cuda/cutensor.pyx
@@ -97,7 +97,7 @@ cdef extern from 'cupy_cutensor.h' nogil:
         void* C, TensorDescriptor descC, int32_t* modeC,
         void* D, TensorDescriptor descD, int32_t* modeD,
         Operator opReduce, DataType typeCompute,
-        uint64_t* workspaceSize);
+        uint64_t* workspaceSize)
 
 
 ###############################################################################

--- a/cupy/cutensor.py
+++ b/cupy/cutensor.py
@@ -374,13 +374,13 @@ def reduction(alpha, A, desc_A, mode_A, beta, C, desc_C, mode_C,
         C.data.ptr, desc_C.value, mode_C.ctypes.data,
         out.data.ptr, desc_C.value, mode_C.ctypes.data,
         reduce_op, compute_dtype)
-    if ws_size > 0:
-        try:
-            ws = cupy.ndarray((ws_size,), dtype=numpy.int8)
-        except Exception:
-            warnings.warn('cuTENSOR: failed to allocate memory of workspace.')
-            ws_size = 0
-            ws = cupy.ndarray((ws_size,), dtype=numpy.int8)
+    try:
+        ws = cupy.ndarray((ws_size,), dtype=numpy.int8)
+    except Exception:
+        warnings.warn('cuTENSOR: failed to allocate memory of workspace '
+                      '(size: {}).'.format(ws_size))
+        ws_size = 0
+        ws = cupy.ndarray((ws_size,), dtype=numpy.int8)
     cutensor.reduction(handle,
                        alpha.ctypes.data,
                        A.data.ptr, desc_A.value, mode_A.ctypes.data,

--- a/cupy/cutensor.py
+++ b/cupy/cutensor.py
@@ -16,7 +16,7 @@ def get_handle():
     return _handles[dev]
 
 
-class Descriptor:
+class Descriptor(object):
 
     def __init__(self, descriptor, destroyer):
         self.value = descriptor
@@ -41,6 +41,11 @@ def get_cuda_dtype(numpy_dtype):
         return runtime.CUDA_C_64F
     else:
         raise TypeError('Dtype {} is not supported'.format(numpy_dtype))
+
+
+def _convert_mode(mode):
+    return numpy.array([ord(x) if isinstance(x, str) else x for x in mode],
+                       dtype=numpy.int32)
 
 
 def create_tensor_descriptor(a, uop=cutensor.OP_IDENTITY,
@@ -100,7 +105,7 @@ def elementwise_trinary(alpha, A, desc_A, mode_A,
         desc_A (class Descriptor): A descriptor that holds the information
             about the data type, modes, and strides of tensor A.
         mode_A (tuple of int/str): A tuple that holds the labels of the modes
-            of tensor A (e.g., if A_{x,y,z} => mode_A = {'x','y','z'})
+            of tensor A (e.g., if A_{x,y,z}, mode_A = {'x','y','z'})
         beta: Scaling factor for tensor B.
         B (cupy.ndarray): Input tensor.
         desc_B (class Descriptor): A descriptor that holds the information
@@ -121,17 +126,17 @@ def elementwise_trinary(alpha, A, desc_A, mode_A,
 
     Returns:
         out (cupy.ndarray): Output tensor.
+
+    Examples:
+        See examples/cutensor/elementwise_trinary.py
     """
     assert A.dtype == B.dtype == C.dtype
     assert A.ndim == len(mode_A)
     assert B.ndim == len(mode_B)
     assert C.ndim == len(mode_C)
-    mode_A = numpy.array([ord(x) if isinstance(x, str) else x for x in mode_A],
-                         dtype=numpy.int32)
-    mode_B = numpy.array([ord(x) if isinstance(x, str) else x for x in mode_B],
-                         dtype=numpy.int32)
-    mode_C = numpy.array([ord(x) if isinstance(x, str) else x for x in mode_C],
-                         dtype=numpy.int32)
+    mode_A = _convert_mode(mode_A)
+    mode_B = _convert_mode(mode_B)
+    mode_C = _convert_mode(mode_C)
     if out is None:
         out = cupy.ndarray(C.shape, dtype=C.dtype)
     else:
@@ -173,14 +178,15 @@ def elementwise_binary(alpha, A, desc_A, mode_A,
                   gamma * uop_C(C_{Pi^C(i_0,i_1,...,i_n)}))
 
     See elementwise_trinary() for details.
+
+    Examples:
+        See examples/cutensor/elementwise_binary.py
     """
     assert A.dtype == C.dtype
     assert A.ndim == len(mode_A)
     assert C.ndim == len(mode_C)
-    mode_A = numpy.array([ord(x) if isinstance(x, str) else x for x in mode_A],
-                         dtype=numpy.int32)
-    mode_C = numpy.array([ord(x) if isinstance(x, str) else x for x in mode_C],
-                         dtype=numpy.int32)
+    mode_A = _convert_mode(mode_A)
+    mode_C = _convert_mode(mode_C)
     if out is None:
         out = cupy.ndarray(C.shape, dtype=C.dtype)
     else:
@@ -224,14 +230,14 @@ def contraction(alpha, A, desc_A, mode_A, B, desc_B, mode_B,
         desc_A (class Descriptor): A descriptor that holds the information
             about the data type, modes, and strides of tensor A.
         mode_A (tuple of int/str): A tuple that holds the labels of the modes
-            of tensor A (e.g., if A_{x,y,z} => mode_A = {'x','y','z'})
+            of tensor A (e.g., if A_{x,y,z}, mode_A = {'x','y','z'})
         B (cupy.ndarray): Input tensor.
         desc_B (class Descriptor): A descriptor that holds the information
             about the data type, modes, and strides of tensor B.
         mode_B (tuple of int/str): A tuple that holds the labels of the modes
             of tensor B.
         beta: Scaling factor for C.
-        C (cupy.ndarray): Input tensor.
+        C (cupy.ndarray): Input/output tensor.
         desc_C (class Descriptor): A descriptor that holds the information
             about the data type, modes, and strides of tensor C.
         mode_C (tuple of int/str): A tuple that holds the labels of the modes
@@ -249,6 +255,9 @@ def contraction(alpha, A, desc_A, mode_A, B, desc_B, mode_B,
 
     Returns:
         out (cupy.ndarray): Output tensor.
+
+    Examples:
+        See examples/cutensor/contraction.py
     """
     assert A.dtype == B.dtype == C.dtype
     assert A.ndim == len(mode_A)
@@ -307,3 +316,76 @@ def contraction_max_algos():
     See cupy/cuda/cutensor.contractionMaxAlgos() for details.
     """
     return cutensor.contractionMaxAlgos()
+
+
+def reduction(alpha, A, desc_A, mode_A, beta, C, desc_C, mode_C,
+              reduce_op=cutensor.OP_ADD, compute_dtype=None):
+    """Tensor reduction
+
+    This routine computes the tensor reduction:
+
+        C = alpha * reduce_op(uop_A(A)) + beta * uop_C(C))
+
+    See cupy/cuda/cutensor.reduction for details.
+
+    Args:
+        alpha: Scaling factor for A.
+        A (cupy.ndarray): Input tensor.
+        desc_A (class Descriptor): A descriptor that holds the information
+            about the data type, modes, strides and unary operator (uop_A) of
+            tensor A.
+        mode_A (tuple of int/str): A tuple that holds the labels of the modes
+            of tensor A (e.g., if A_{x,y,z}, mode_A = {'x','y','z'})
+        beta: Scaling factor for C.
+        C (cupy.ndarray): Input/output tensor.
+        desc_C (class Descriptor): A descriptor that holds the information
+            about the data type, modes, strides and unary operator (uop_C) of
+            tensor C.
+        mode_C (tuple of int/str): A tuple that holds the labels of the modes
+            of tensor C.
+        reduce_op (cutensorOperator_t): Binary operator used to reduce A.
+        compute_dtype (numpy.dtype): Compute type for the intermediate
+            computation.
+
+    Returns:
+        out (cupy.ndarray): Output tensor.
+
+    Examples:
+        See examples/cutensor/reduction.py
+    """
+    assert A.dtype == C.dtype
+    assert A.ndim == len(mode_A)
+    assert C.ndim == len(mode_C)
+    mode_A = _convert_mode(mode_A)
+    mode_C = _convert_mode(mode_C)
+    out = C
+    if compute_dtype is None:
+        if A.dtype == numpy.float16:
+            compute_dtype = numpy.float32
+        else:
+            compute_dtype = A.dtype
+    alpha = numpy.array(alpha, compute_dtype)
+    beta = numpy.array(beta, compute_dtype)
+    handle = get_handle()
+    compute_dtype = get_cuda_dtype(compute_dtype)
+    ws_size = cutensor.reductionGetWorkspace(
+        handle,
+        A.data.ptr, desc_A.value, mode_A.ctypes.data,
+        C.data.ptr, desc_C.value, mode_C.ctypes.data,
+        out.data.ptr, desc_C.value, mode_C.ctypes.data,
+        reduce_op, compute_dtype)
+    if ws_size > 0:
+        try:
+            ws = cupy.ndarray((ws_size,), dtype=numpy.int8)
+        except Exception:
+            warnings.warn('cuTENSOR: failed to allocate memory of workspace.')
+            ws_size = 0
+            ws = cupy.ndarray((ws_size,), dtype=numpy.int8)
+    cutensor.reduction(handle,
+                       alpha.ctypes.data,
+                       A.data.ptr, desc_A.value, mode_A.ctypes.data,
+                       beta.ctypes.data,
+                       C.data.ptr, desc_C.value, mode_C.ctypes.data,
+                       out.data.ptr, desc_C.value, mode_C.ctypes.data,
+                       reduce_op, compute_dtype, ws.data.ptr, ws_size)
+    return out

--- a/cupy/cutensor.py
+++ b/cupy/cutensor.py
@@ -326,7 +326,7 @@ def reduction(alpha, A, desc_A, mode_A, beta, C, desc_C, mode_C,
 
         C = alpha * reduce_op(uop_A(A)) + beta * uop_C(C))
 
-    See cupy/cuda/cutensor.reduction for details.
+    See :func:`cupy.cuda.cutensor.reduction` for details.
 
     Args:
         alpha: Scaling factor for A.
@@ -376,7 +376,7 @@ def reduction(alpha, A, desc_A, mode_A, beta, C, desc_C, mode_C,
         reduce_op, compute_dtype)
     try:
         ws = cupy.ndarray((ws_size,), dtype=numpy.int8)
-    except Exception:
+    except cupy.cuda.memory.OutOfMemoryError:
         warnings.warn('cuTENSOR: failed to allocate memory of workspace '
                       '(size: {}).'.format(ws_size))
         ws_size = 0

--- a/examples/cutensor/reduction.py
+++ b/examples/cutensor/reduction.py
@@ -1,0 +1,50 @@
+#
+# C_{m,v} = alpha * A_{m,h,k,v} + beta * C_{m,v}
+#
+import numpy
+import cupy
+from cupy import cutensor
+from cupy.cuda import stream
+
+dtype = numpy.float32
+
+mode_a = ('m', 'h', 'k', 'v')
+mode_c = ('m', 'v')
+
+extent = {'m': 196, 'h': 256, 'k': 64, 'v': 64}
+
+a = cupy.random.random([extent[i] for i in mode_a])
+c = cupy.random.random([extent[i] for i in mode_c])
+a = a.astype(dtype)
+c = c.astype(dtype)
+
+desc_a = cutensor.create_tensor_descriptor(a)
+desc_c = cutensor.create_tensor_descriptor(c)
+
+alpha = 1.0
+beta = 0.1
+
+# rehearsal
+c = cutensor.reduction(alpha, a, desc_a, mode_a,
+                       beta, c, desc_c, mode_c)
+
+ev_start = stream.Event()
+ev_end = stream.Event()
+st = stream.Stream()
+with st:
+    # measurement
+    ev_start.record()
+    c = cutensor.reduction(alpha, a, desc_a, mode_a,
+                           beta, c, desc_c, mode_c)
+    ev_end.record()
+st.synchronize()
+
+elapsed_ms = stream.get_elapsed_time(ev_start, ev_end)
+transfer_byte = a.size * a.itemsize + c.size * c.itemsize
+if beta != 0.0:
+    transfer_byte += c.size * c.itemsize
+gbs = transfer_byte / elapsed_ms / 1e6
+
+print('dtype: {}'.format(numpy.dtype(dtype).name))
+print('time (ms): {}'.format(elapsed_ms))
+print('effective memory bandwidth (GB/s): {}'.format(gbs))


### PR DESCRIPTION
This PR aims to support new APIs for tensor reduction added in cuTENSOR 0.2.

cuTENSOR C APIs for tensor reduction are exposed in `cupy/cuda/cutensor.pyx`. In addition, a bit abstracted API **reduction()** is also exposed in `cupy/cutensor.py` so that python developers can use it easily. An example is in `cupy/example/cutensor`.

Please note that you need to set an environment variable `CUTENSOR_PATH` when you build CuPy with cuTENSOR enabled.

    $ cd (to where cupy is installed)
    $ CUTENSOR_PATH=/path/to/cutensor python setup.py install
