### PR TITLE
Drop support for Python 2.7 and 3.4

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -33,18 +33,6 @@ original error: {}'''.format(exc_info[1]))  # NOQA
     six.reraise(ImportError, ImportError(msg), exc_info[2])
 
 
-if sys.version_info[:1] == (2,):
-    warnings.warn('''
---------------------------------------------------------------------------------
-CuPy is going to stop supporting Python 2 in v7.x releases.
-
-Future releases of CuPy v7.x will not run on Python 2.
-If you need to continue using Python 2, consider using CuPy v6.x, which
-will be the last version that runs on Python 2.
---------------------------------------------------------------------------------
-''')  # NOQA
-
-
 from cupy import cuda
 import cupyx
 
@@ -781,3 +769,18 @@ def show_config():
     """Prints the current runtime configuration to standard output."""
     sys.stdout.write(str(cupyx.get_runtime_info()))
     sys.stdout.flush()
+
+
+# -----------------------------------------------------------------------------
+# Warning for Python 2 users
+# -----------------------------------------------------------------------------
+if sys.version_info[:1] == (2,):
+    warnings.warn('''
+--------------------------------------------------------------------------------
+CuPy is going to stop supporting Python 2 in v7.x releases.
+
+Future releases of CuPy v7.x will not run on Python 2.
+If you need to continue using Python 2, consider using CuPy v6.x, which
+will be the last version that runs on Python 2.
+--------------------------------------------------------------------------------
+''')  # NOQA

--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import division
 import sys
+import warnings
 
 import numpy
 import six
@@ -30,6 +31,18 @@ Check the Installation Guide for details:
 original error: {}'''.format(exc_info[1]))  # NOQA
 
     six.reraise(ImportError, ImportError(msg), exc_info[2])
+
+
+if sys.version_info[:1] == (2,):
+    warnings.warn('''
+--------------------------------------------------------------------------------
+CuPy is going to stop supporting Python 2 in v7.x releases.
+
+Future releases of CuPy v7.x will not run on Python 2.
+If you need to continue using Python 2, consider using CuPy v6.x, which
+will be the last version that runs on Python 2.
+--------------------------------------------------------------------------------
+''')  # NOQA
 
 
 from cupy import cuda

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -29,7 +29,7 @@ You need to have the following components to use CuPy.
     * If you have multiple versions of CUDA Toolkit installed, CuPy will choose one of the CUDA installations automatically.
       See :ref:`install_cuda` for details.
 * `Python <https://python.org/>`_
-    * Supported Versions: 2.7.6+, 3.4.3+, 3.5.1+, 3.6.0+ and 3.7.0+.
+    * Supported Versions: 3.5.1+, 3.6.0+ and 3.7.0+.
 * `NumPy <http://www.numpy.org/>`_
     * Supported Versions: 1.9, 1.10, 1.11, 1.12, 1.13, 1.14, 1.15 and 1.16.
     * NumPy will be installed automatically during the installation of CuPy.
@@ -41,6 +41,11 @@ Before installing CuPy, we recommend you to upgrade ``setuptools`` and ``pip``::
 .. note::
 
    On Windows, CuPy only supports Python 3.6.0 or later.
+
+.. note::
+
+   Python 2 is not supported in CuPy v7.x releases.
+   Please consider migrating Python 3 or use CuPy v6.x, which is the last version that supports Python 2.
 
 Optional Libraries
 ~~~~~~~~~~~~~~~~~~

--- a/docs/source/upgrade.rst
+++ b/docs/source/upgrade.rst
@@ -7,6 +7,17 @@ Upgrade Guide
 This is a list of changes introduced in each release that users should be aware of when migrating from older versions.
 Most changes are carefully designed not to break existing code; however changes that may possibly break them are highlighted with a box.
 
+CuPy v7
+=======
+
+Dropping Support of Python 2.7 and 3.4
+--------------------------------------
+
+Starting from CuPy v7, Python 2.7 and 3.4 are no longer supported as it reaches its end-of-life (EOL) in January 2020 (2.7) and March 2019 (3.4).
+Python 3.5.1 is the minimum Python version supported by CuPy v7.
+Please upgrade the Python version if you are using affected versions of Python to any later versions listed under :ref:`install-guide`.
+
+
 CuPy v6
 =======
 
@@ -15,6 +26,7 @@ Binary Packages Ignore ``LD_LIBRARY_PATH``
 
 Prior to CuPy v6, ``LD_LIBRARY_PATH`` environment variable can be used to override cuDNN / NCCL libraries bundled in the binary distribution (also known as wheels).
 In CuPy v6, ``LD_LIBRARY_PATH`` will be ignored during discovery of cuDNN / NCCL; CuPy binary distributions always use libraries that comes with the package to avoid errors caused by unexpected override.
+
 
 CuPy v5
 =======


### PR DESCRIPTION
* Emit warnings for Python 2 users
* Drop support for Python 2.7 and Python 3.4 as well as it is already EOLed