### PR TITLE
Add wrapper for `numpy.vectorize` in `fallback_mode`

### DIFF
--- a/cupyx/fallback_mode/fallback.py
+++ b/cupyx/fallback_mode/fallback.py
@@ -38,6 +38,8 @@ class _RecursiveAttr(object):
         Enable support for isinstance(instance, _RecursiveAttr instance)
         by redirecting it to appropriate isinstance method.
         """
+        if isinstance(instance, _RecursiveAttr):
+            instance = instance._numpy_object
 
         if self._cupy_object is not None:
             return isinstance(instance, self._cupy_object)
@@ -281,6 +283,10 @@ def _get_xp_args(ndarray_instance, to_xp, arg):
 
     if isinstance(arg, list):
         return [_get_xp_args(ndarray_instance, to_xp, x) for x in arg]
+
+    if callable(arg):
+        if isinstance(arg, (np.vectorize, )):
+            return _RecursiveAttr(arg, None)
 
     return arg
 

--- a/cupyx/fallback_mode/fallback.py
+++ b/cupyx/fallback_mode/fallback.py
@@ -38,8 +38,6 @@ class _RecursiveAttr(object):
         Enable support for isinstance(instance, _RecursiveAttr instance)
         by redirecting it to appropriate isinstance method.
         """
-        if isinstance(instance, _RecursiveAttr):
-            instance = instance._numpy_object
 
         if self._cupy_object is not None:
             return isinstance(instance, self._cupy_object)
@@ -121,7 +119,7 @@ numpy = _RecursiveAttr(np, cp)
 
 
 # -----------------------------------------------------------------------------
-# ndarray wrapper and proxying of magic methods
+# proxying of ndarray magic methods and wrappers
 # -----------------------------------------------------------------------------
 
 
@@ -264,14 +262,14 @@ class vectorize(object):
         return getattr(self.__dict__['vec_obj'], attr)
 
     def __setattr__(self, name, value):
-        return setattr(self.__dict__['vec_obj'], name, value)
+        return setattr(self.vec_obj, name, value)
+
+    @property
+    def __doc__(self):
+        return self.vec_obj.__doc__
 
     def __call__(self, *args, **kwargs):
-        res = self.vec_obj(*args, **kwargs)
-
-        if isinstance(res, np.ndarray):
-            return ndarray._store(cp.array(res))
-        return res
+        return _call_numpy(self.vec_obj, args, kwargs)
 
 
 # -----------------------------------------------------------------------------

--- a/cupyx/fallback_mode/fallback.py
+++ b/cupyx/fallback_mode/fallback.py
@@ -68,6 +68,9 @@ class _RecursiveAttr(object):
         if numpy_object is np.ndarray:
             return ndarray
 
+        if numpy_object is np.vectorize:
+            return vectorize
+
         if numpy_object is cupy_object:
             return numpy_object
 
@@ -249,6 +252,28 @@ def _create_magic_methods():
 _create_magic_methods()
 
 
+class vectorize(object):
+
+    def __init__(self, *args, **kwargs):
+        # NumPy will raise error if pyfunc is a cupy method
+        if isinstance(args[0], _RecursiveAttr):
+            args = (args[0]._numpy_object,) + args[1:]
+        self.__dict__['vec_obj'] = np.vectorize(*args, **kwargs)
+
+    def __getattr__(self, attr):
+        return getattr(self.__dict__['vec_obj'], attr)
+
+    def __setattr__(self, name, value):
+        return setattr(self.__dict__['vec_obj'], name, value)
+
+    def __call__(self, *args, **kwargs):
+        res = self.vec_obj(*args, **kwargs)
+
+        if isinstance(res, np.ndarray):
+            return ndarray._store(cp.array(res))
+        return res
+
+
 # -----------------------------------------------------------------------------
 # Data Transfer methods
 # -----------------------------------------------------------------------------
@@ -283,10 +308,6 @@ def _get_xp_args(ndarray_instance, to_xp, arg):
 
     if isinstance(arg, list):
         return [_get_xp_args(ndarray_instance, to_xp, x) for x in arg]
-
-    if callable(arg):
-        if isinstance(arg, (np.vectorize, )):
-            return _RecursiveAttr(arg, None)
 
     return arg
 

--- a/tests/cupyx_tests/fallback_mode_tests/test_fallback.py
+++ b/tests/cupyx_tests/fallback_mode_tests/test_fallback.py
@@ -105,16 +105,6 @@ def numpy_fallback_array_allclose(name='xp'):
 @testing.gpu
 class TestFallbackMode(unittest.TestCase):
 
-    @numpy_fallback_array_equal()
-    def test_vectorize(self, xp):
-
-        def function(a, b):
-            if a > b:
-                return a - b
-            return a + b
-
-        return xp.vectorize(function)([1, 2, 3, 4], 2)
-
     def test_module_not_callable(self):
 
         pytest.raises(TypeError, fallback_mode.numpy)
@@ -399,3 +389,46 @@ class TestArrayMatmul(unittest.TestCase):
         b = testing.shaped_random((5, 3), xp, seed=5)
 
         return a.__matmul__(b)
+
+
+@testing.gpu
+class TestVectorizeWrapper(unittest.TestCase):
+
+    @numpy_fallback_array_equal()
+    def test_pyfunc_custom_list(self, xp):
+
+        def function(a, b):
+            if a > b:
+                return a - b
+            return a + b
+
+        return xp.vectorize(function)([1, 2, 3, 4], 2)
+
+    @numpy_fallback_array_equal()
+    def test_pyfunc_builtin(self, xp):
+        a = testing.shaped_random((4, 5), xp)
+        vabs = xp.vectorize(abs)
+        return vabs(a)
+
+    @numpy_fallback_array_equal()
+    def test_pyfunc_numpy(self, xp):
+        a = testing.shaped_random((4, 5), xp)
+        vabs = xp.vectorize(numpy.abs)
+        return vabs(a)
+
+    @numpy_fallback_equal()
+    def test_getattr(self, xp):
+        vabs = xp.vectorize(numpy.abs)
+        return vabs.pyfunc
+
+    @numpy_fallback_array_equal()
+    def test_setattr(self, xp):
+        a = xp.array([-1, 2, -3])
+        vabs = xp.vectorize(abs)
+        vabs.otypes = ['float']
+        return vabs(a)
+
+    @numpy_fallback_equal()
+    def test_doc(self, xp):
+        vabs = xp.vectorize(abs)
+        return vabs.__doc__

--- a/tests/cupyx_tests/fallback_mode_tests/test_fallback.py
+++ b/tests/cupyx_tests/fallback_mode_tests/test_fallback.py
@@ -105,24 +105,15 @@ def numpy_fallback_array_allclose(name='xp'):
 @testing.gpu
 class TestFallbackMode(unittest.TestCase):
 
-    def test_vectorize(self):
+    @numpy_fallback_array_equal()
+    def test_vectorize(self, xp):
 
         def function(a, b):
             if a > b:
                 return a - b
             return a + b
 
-        actual = numpy.vectorize(function)([1, 2, 3, 4], 2)
-        expected = fallback_mode.numpy.vectorize(function)([1, 2, 3, 4], 2)
-
-        assert isinstance(actual, numpy.ndarray)
-
-        # ([1,2,3,4], 2) are arguments to
-        # numpy.vectorize(function), not numpy.vectorize
-        # So, it returns numpy.ndarray
-        assert isinstance(expected, numpy.ndarray)
-
-        testing.assert_array_equal(expected, actual)
+        return xp.vectorize(function)([1, 2, 3, 4], 2)
 
     def test_module_not_callable(self):
 


### PR DESCRIPTION
This PR is related to #2066 
This will add wrapper around `numpy.vectorize` object.
It shows following behaviour:
```python
>>> from cupyx.fallback_mode import numpy
>>> vabs = numpy.vectorize(abs)
>>> vabs
<cupyx.fallback_mode.fallback.vectorize object at 0x7f0a2ba61ba8>
>>> isinstance(vabs, numpy.vectorize)
True
>>> a = numpy.array([-1, 2, -3])
>>> type(a)
<class 'cupyx.fallback_mode.fallback.ndarray'>
>>> res = vabs(a)
>>> res
array([1, 2, 3])
>>> type(res)
<class 'cupyx.fallback_mode.fallback.ndarray'>
>>> vabs.pyfunc is abs
True
>>> vabs.__doc__
'Return the absolute value of the argument.'
>>> 
```