### PR TITLE
Allow cuFFT plans to be used as a context manager; Set stream before executing cuFFT plans

### DIFF
--- a/cupy/cuda/cufft.pxd
+++ b/cupy/cuda/cufft.pxd
@@ -16,3 +16,6 @@ cpdef enum:
 
     CUFFT_FORWARD = -1
     CUFFT_INVERSE = 1
+
+
+cpdef get_current_plan()

--- a/cupy/cuda/cufft.pyx
+++ b/cupy/cuda/cufft.pyx
@@ -92,11 +92,8 @@ class Plan1d(object):
     def __init__(self, int nx, int fft_type, int batch):
         cdef Handle plan
         cdef size_t work_size
-        stream = stream_module.get_current_stream_ptr()
         with nogil:
             result = cufftCreate(&plan)
-            if result == 0:
-                result = cufftSetStream(<Handle>plan, <driver.Stream>stream)
             if result == 0:
                 result = cufftSetAutoAllocation(plan, 0)
             if result == 0:
@@ -138,6 +135,11 @@ class Plan1d(object):
         _current_plan = None
 
     def fft(self, a, out, direction):
+        cdef Handle plan = self.plan
+        stream = stream_module.get_current_stream_ptr()
+        with nogil:
+            result = cufftSetStream(plan, <driver.Stream>stream)
+        check_result(result)
         if self.fft_type == CUFFT_C2C:
             execC2C(self.plan, a.data, out.data, direction)
         elif self.fft_type == CUFFT_R2C:
@@ -222,11 +224,8 @@ class PlanNd(object):
             onembed_arr = numpy.asarray(onembed, dtype=numpy.intc)
             onembed_ptr = &onembed_arr[0]
 
-        stream = stream_module.get_current_stream_ptr()
         with nogil:
             result = cufftCreate(&plan)
-            if result == 0:
-                result = cufftSetStream(<Handle>plan, <driver.Stream>stream)
             if result == 0:
                 result = cufftSetAutoAllocation(plan, 0)
             if result == 0:
@@ -275,6 +274,11 @@ class PlanNd(object):
         _current_plan = None
 
     def fft(self, a, out, direction):
+        cdef Handle plan = self.plan
+        stream = stream_module.get_current_stream_ptr()
+        with nogil:
+            result = cufftSetStream(plan, <driver.Stream>stream)
+        check_result(result)
         if self.fft_type == CUFFT_C2C:
             execC2C(self.plan, a.data, out.data, direction)
         elif self.fft_type == CUFFT_Z2Z:

--- a/cupy/fft/fft.py
+++ b/cupy/fft/fft.py
@@ -328,6 +328,7 @@ def _exec_fftn(a, direction, value_type, norm, axes, overwrite_x,
     else:
         raise ValueError('a must be contiguous')
 
+    plan = cufft.get_current_plan()
     if plan is None:
         # generate a plan
         plan = _get_cufft_plan_nd(a.shape, fft_type, axes=axes, order=order)

--- a/cupy/fft/fft.py
+++ b/cupy/fft/fft.py
@@ -83,6 +83,7 @@ def _exec_fft(a, direction, value_type, norm, axis, overwrite_x,
         out_size = a.shape[-1]
 
     batch = a.size // a.shape[-1]
+    plan = cufft.get_current_plan()
     if plan is None:
         plan = cufft.Plan1d(out_size, fft_type, batch)
     else:
@@ -435,6 +436,10 @@ def _default_plan_type(a, s=None, axes=None):
 
 
 def _default_fft_func(a, s=None, axes=None, plan=None):
+    curr_plan = cufft.get_current_plan()
+    if curr_plan is not None:
+        plan = curr_plan
+
     if isinstance(plan, cufft.PlanNd):  # a shortcut for using _fftn
         return _fftn
     elif isinstance(plan, cufft.Plan1d):  # a shortcut for using _fft

--- a/cupyx/scipy/fftpack/fft.py
+++ b/cupyx/scipy/fftpack/fft.py
@@ -25,28 +25,32 @@ def get_fft_plan(a, shape=None, axes=None, value_type='C2C'):
             Currently only complex-to-complex transforms are supported.
 
     Returns:
-        a cuFFT plan for either 1D transform (cupy.cuda.cufft.Plan1d) or N-D
-        transform (cupy.cuda.cufft.PlanNd).
+        a cuFFT plan for either 1D transform (``cupy.cuda.cufft.Plan1d``) or
+        N-D transform (``cupy.cuda.cufft.PlanNd``).
 
     .. note::
-       1. This API is a deviation from SciPy's, is currently experimental, and
-           may be changed in the future version.
-       2. The returned plan can not only be passed as one of the arguments of
-           the functions in `cupyx.scipy.fftpack`, but also be used as a
-           context manager for both `cupy.fft` and `cupyx.scipy.fftpack`
-           functions:
+        The returned plan can not only be passed as one of the arguments of
+        the functions in ``cupyx.scipy.fftpack``, but also be used as a
+        context manager for both ``cupy.fft`` and ``cupyx.scipy.fftpack``
+        functions:
 
-          .. code-block:: python
+        .. code-block:: python
 
-              x = cupy.random.random(16).reshape(4, 4).astype(cupy.complex)
-              plan = cupyx.scipy.fftpack.get_fft_plan(x)
-              with plan:
-                  y = cupy.fft.fftn(x)
-                  # alternatively:
-                  y = cupyx.scipy.fftpack.fftn(x)  # no explicit plan is given!
+            x = cupy.random.random(16).reshape(4, 4).astype(cupy.complex)
+            plan = cupyx.scipy.fftpack.get_fft_plan(x)
+            with plan:
+                y = cupy.fft.fftn(x)
+                # alternatively:
+                y = cupyx.scipy.fftpack.fftn(x)  # no explicit plan is given!
+            # alternatively:
+            y = cupyx.scipy.fftpack.fftn(x, plan=plan)  # pass plan explicitly
 
-          In the first case, no cuFFT plan will be generated automatically,
-          even if `cupy.fft.config.enable_nd_planning = True` is set.
+        In the first case, no cuFFT plan will be generated automatically,
+        even if ``cupy.fft.config.enable_nd_planning = True`` is set.
+
+    .. warning::
+        This API is a deviation from SciPy's, is currently experimental, and
+        may be changed in the future version.
     """
     # check input array
     if a.flags.c_contiguous:

--- a/cupyx/scipy/fftpack/fft.py
+++ b/cupyx/scipy/fftpack/fft.py
@@ -25,8 +25,28 @@ def get_fft_plan(a, shape=None, axes=None, value_type='C2C'):
             Currently only complex-to-complex transforms are supported.
 
     Returns:
-        plan: a cuFFT plan for either 1D transform (cupy.cuda.cufft.Plan1d)
-            or N-D transform (cupy.cuda.cufft.PlanNd).
+        a cuFFT plan for either 1D transform (cupy.cuda.cufft.Plan1d) or N-D
+        transform (cupy.cuda.cufft.PlanNd).
+
+    .. note::
+       1. This API is a deviation from SciPy's, is currently experimental, and
+           may be changed in the future version.
+       2. The returned plan can not only be passed as one of the arguments of
+           the functions in `cupyx.scipy.fftpack`, but also be used as a
+           context manager for both `cupy.fft` and `cupyx.scipy.fftpack`
+           functions:
+
+          .. code-block:: python
+
+              x = cupy.random.random(16).reshape(4, 4).astype(cupy.complex)
+              plan = cupyx.scipy.fftpack.get_fft_plan(x)
+              with plan:
+                  y = cupy.fft.fftn(x)
+                  # alternatively:
+                  y = cupyx.scipy.fftpack.fftn(x)  # no explicit plan is given!
+
+          In the first case, no cuFFT plan will be generated automatically,
+          even if `cupy.fft.config.enable_nd_planning = True` is set.
     """
     # check input array
     if a.flags.c_contiguous:

--- a/docs/source/reference/fft.rst
+++ b/docs/source/reference/fft.rst
@@ -72,4 +72,6 @@ CuPy functions do not follow the behavior, they will return ``numpy.complex64`` 
 
 Internally, ``cupy.fft`` always generates a *cuFFT plan* (see the `cuFFT documentation`_ for detail) corresponding to the desired transform. When possible, an n-dimensional plan will be used, as opposed to applying separate 1D plans for each axis to be transformed. Using n-dimensional planning can provide better performance for multidimensional transforms, but requires more GPU memory than separable 1D planning. The user can disable n-dimensional planning by setting ``cupy.fft.config.enable_nd_planning = False``. This ability to adjust the planning type is a deviation from the NumPy API, which does not use precomputed FFT plans.
 
+Moreover, the automatic plan generation can be surpressed by using an existing plan returned by ``cupyx.scipy.fftpack.get_fft_plan`` as a context manager. This is again a deviation from NumPy.
+
 .. _cuFFT documentation: https://docs.nvidia.com/cuda/cufft/index.html

--- a/docs/source/reference/fft.rst
+++ b/docs/source/reference/fft.rst
@@ -72,6 +72,6 @@ CuPy functions do not follow the behavior, they will return ``numpy.complex64`` 
 
 Internally, ``cupy.fft`` always generates a *cuFFT plan* (see the `cuFFT documentation`_ for detail) corresponding to the desired transform. When possible, an n-dimensional plan will be used, as opposed to applying separate 1D plans for each axis to be transformed. Using n-dimensional planning can provide better performance for multidimensional transforms, but requires more GPU memory than separable 1D planning. The user can disable n-dimensional planning by setting ``cupy.fft.config.enable_nd_planning = False``. This ability to adjust the planning type is a deviation from the NumPy API, which does not use precomputed FFT plans.
 
-Moreover, the automatic plan generation can be surpressed by using an existing plan returned by :func:`cupyx.scipy.fftpack.get_fft_plan` as a context manager. This is again a deviation from NumPy.
+Moreover, the automatic plan generation can be suppressed by using an existing plan returned by :func:`cupyx.scipy.fftpack.get_fft_plan` as a context manager. This is again a deviation from NumPy.
 
 .. _cuFFT documentation: https://docs.nvidia.com/cuda/cufft/index.html

--- a/docs/source/reference/fft.rst
+++ b/docs/source/reference/fft.rst
@@ -72,6 +72,6 @@ CuPy functions do not follow the behavior, they will return ``numpy.complex64`` 
 
 Internally, ``cupy.fft`` always generates a *cuFFT plan* (see the `cuFFT documentation`_ for detail) corresponding to the desired transform. When possible, an n-dimensional plan will be used, as opposed to applying separate 1D plans for each axis to be transformed. Using n-dimensional planning can provide better performance for multidimensional transforms, but requires more GPU memory than separable 1D planning. The user can disable n-dimensional planning by setting ``cupy.fft.config.enable_nd_planning = False``. This ability to adjust the planning type is a deviation from the NumPy API, which does not use precomputed FFT plans.
 
-Moreover, the automatic plan generation can be surpressed by using an existing plan returned by ``cupyx.scipy.fftpack.get_fft_plan`` as a context manager. This is again a deviation from NumPy.
+Moreover, the automatic plan generation can be surpressed by using an existing plan returned by :func:`cupyx.scipy.fftpack.get_fft_plan` as a context manager. This is again a deviation from NumPy.
 
 .. _cuFFT documentation: https://docs.nvidia.com/cuda/cufft/index.html

--- a/tests/cupy_tests/fft_tests/test_fft.py
+++ b/tests/cupy_tests/fft_tests/test_fft.py
@@ -361,7 +361,7 @@ class TestPlanCtxManagerFftn(unittest.TestCase):
 
         try:
             with plan_wrong:
-                out = fftn(a, s=self.s, axes=self.axes, norm=self.norm)
+                fftn(a, s=self.s, axes=self.axes, norm=self.norm)
         except ValueError as ve:
             # targeting a particular error
             if ve.__str__().startswith('The CUFFT plan and a.shape do'
@@ -375,7 +375,7 @@ class TestPlanCtxManagerFftn(unittest.TestCase):
 
 @testing.parameterize(*testing.product({
     'n': [None, 5, 10, 15],
-    'shape': [(10,),],
+    'shape': [(10,), ],
     'norm': [None, 'ortho'],
 }))
 @testing.gpu
@@ -438,7 +438,7 @@ class TestPlanCtxManagerFft(unittest.TestCase):
 
         try:
             with plan_wrong:
-                out = fft(a, n=self.n, norm=self.norm)
+                fft(a, n=self.n, norm=self.norm)
         except ValueError as ve:
             # targeting a particular error
             if ve.__str__().startswith('Target array size does not match'
@@ -448,6 +448,7 @@ class TestPlanCtxManagerFft(unittest.TestCase):
                 raise ve
         else:
             raise Exception("No error is raised --- should not happen.")
+
 
 @testing.parameterize(
     {'shape': (3, 4), 's': None, 'axes': None, 'norm': None},

--- a/tests/cupy_tests/fft_tests/test_fft.py
+++ b/tests/cupy_tests/fft_tests/test_fft.py
@@ -364,10 +364,8 @@ class TestPlanCtxManagerFftn(unittest.TestCase):
                 fftn(a, s=self.s, axes=self.axes, norm=self.norm)
         except ValueError as ve:
             # targeting a particular error
-            if ve.__str__().startswith('The CUFFT plan and a.shape do'
-                                       ' not match'):
-                pass
-            else:
+            if not ve.__str__().startswith('The CUFFT plan and a.shape do'
+                                           ' not match'):
                 raise ve
         else:
             raise Exception("No error is raised --- should not happen.")
@@ -441,10 +439,8 @@ class TestPlanCtxManagerFft(unittest.TestCase):
                 fft(a, n=self.n, norm=self.norm)
         except ValueError as ve:
             # targeting a particular error
-            if ve.__str__().startswith('Target array size does not match'
-                                       ' the plan.'):
-                pass
-            else:
+            if not ve.__str__().startswith('Target array size does not match'
+                                           ' the plan.'):
                 raise ve
         else:
             raise Exception("No error is raised --- should not happen.")

--- a/tests/cupy_tests/fft_tests/test_fft.py
+++ b/tests/cupy_tests/fft_tests/test_fft.py
@@ -1,5 +1,6 @@
 import functools
 import unittest
+import pytest
 
 import numpy as np
 
@@ -359,16 +360,10 @@ class TestPlanCtxManagerFftn(unittest.TestCase):
         b = testing.shaped_random(bad_in_shape, cupy, dtype)
         plan_wrong = get_fft_plan(b, bad_out_shape, self.axes)
 
-        try:
-            with plan_wrong:
-                fftn(a, s=self.s, axes=self.axes, norm=self.norm)
-        except ValueError as ve:
-            # targeting a particular error
-            if not ve.__str__().startswith('The CUFFT plan and a.shape do'
-                                           ' not match'):
-                raise ve
-        else:
-            raise Exception("No error is raised --- should not happen.")
+        with pytest.raises(ValueError) as ex, plan_wrong:
+            fftn(a, s=self.s, axes=self.axes, norm=self.norm)
+        # targeting a particular error
+        assert 'The CUFFT plan and a.shape do not match' in str(ex.value)
 
 
 @testing.parameterize(*testing.product({
@@ -434,16 +429,10 @@ class TestPlanCtxManagerFft(unittest.TestCase):
         plan_wrong = get_fft_plan(b)
         assert isinstance(plan_wrong, cupy.cuda.cufft.Plan1d)
 
-        try:
-            with plan_wrong:
-                fft(a, n=self.n, norm=self.norm)
-        except ValueError as ve:
-            # targeting a particular error
-            if not ve.__str__().startswith('Target array size does not match'
-                                           ' the plan.'):
-                raise ve
-        else:
-            raise Exception("No error is raised --- should not happen.")
+        with pytest.raises(ValueError) as ex, plan_wrong:
+            fft(a, n=self.n, norm=self.norm)
+        # targeting a particular error
+        assert 'Target array size does not match the plan.' in str(ex.value)
 
 
 @testing.parameterize(

--- a/tests/cupyx_tests/scipy_tests/fftpack_tests/test_fftpack.py
+++ b/tests/cupyx_tests/scipy_tests/fftpack_tests/test_fftpack.py
@@ -71,6 +71,28 @@ class TestFft(unittest.TestCase):
                                 overwrite_x=True)
         return x
 
+    @testing.for_complex_dtypes()
+    @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
+                                 contiguous_check=False, scipy_name='scp')
+    def test_fft_plan_manager(self, xp, scp, dtype):
+        x = testing.shaped_random(self.shape, xp, dtype)
+        # hack: avoid testing the cases when the output array is of size 0
+        # because cuFFT and numpy raise different kinds of exceptions
+        if self.n == 0:
+            return x
+        x_orig = x.copy()
+        if scp is cupyx.scipy:
+            from cupy.cuda.cufft import get_current_plan
+            plan = scp.fftpack.get_fft_plan(x, shape=self.n, axes=self.axis)
+            with plan:
+                assert id(plan) == id(get_current_plan())
+                out = scp.fftpack.fft(x, n=self.n, axis=self.axis)
+            assert get_current_plan() is None
+        else:  # scipy
+            out = scp.fftpack.fft(x, n=self.n, axis=self.axis)
+        testing.assert_array_equal(x, x_orig)
+        return out
+
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
                                  contiguous_check=False, scipy_name='scp')
@@ -124,6 +146,28 @@ class TestFft(unittest.TestCase):
             x = scp.fftpack.ifft(x, n=self.n, axis=self.axis,
                                  overwrite_x=True)
         return x
+
+    @testing.for_complex_dtypes()
+    @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
+                                 contiguous_check=False, scipy_name='scp')
+    def test_ifft_plan_manager(self, xp, scp, dtype):
+        x = testing.shaped_random(self.shape, xp, dtype)
+        # hack: avoid testing the cases when the output array is of size 0
+        # because cuFFT and numpy raise different kinds of exceptions
+        if self.n == 0:
+            return x
+        x_orig = x.copy()
+        if scp is cupyx.scipy:
+            from cupy.cuda.cufft import get_current_plan
+            plan = scp.fftpack.get_fft_plan(x, shape=self.n, axes=self.axis)
+            with plan:
+                assert id(plan) == id(get_current_plan())
+                out = scp.fftpack.ifft(x, n=self.n, axis=self.axis)
+            assert get_current_plan() is None
+        else:  # scipy
+            out = scp.fftpack.ifft(x, n=self.n, axis=self.axis)
+        testing.assert_array_equal(x, x_orig)
+        return out
 
 
 @testing.parameterize(
@@ -199,6 +243,25 @@ class TestFft2(unittest.TestCase):
                                  overwrite_x=True)
         return x
 
+    @testing.for_complex_dtypes()
+    @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
+                                 contiguous_check=False, scipy_name='scp')
+    def test_fft2_plan_manager(self, xp, scp, dtype):
+        x = testing.shaped_random(self.shape, xp, dtype)
+        # hack: avoid testing the cases when getting a cuFFT plan is impossible
+        if _default_plan_type(x, s=self.s, axes=self.axes) != 'nd':
+            return x
+        if scp is cupyx.scipy:
+            from cupy.cuda.cufft import get_current_plan
+            plan = scp.fftpack.get_fft_plan(x, shape=self.s, axes=self.axes)
+            with plan:
+                assert id(plan) == id(get_current_plan())
+                out = scp.fftpack.fft2(x, shape=self.s, axes=self.axes)
+            assert get_current_plan() is None
+        else:  # scipy
+            out = scp.fftpack.fft2(x, shape=self.s, axes=self.axes)
+        return out
+
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
                                  contiguous_check=False, scipy_name='scp')
@@ -254,6 +317,25 @@ class TestFft2(unittest.TestCase):
             x = scp.fftpack.ifft2(x, shape=self.s, axes=self.axes,
                                   overwrite_x=True)
         return x
+
+    @testing.for_complex_dtypes()
+    @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
+                                 contiguous_check=False, scipy_name='scp')
+    def test_ifft2_plan_manager(self, xp, scp, dtype):
+        x = testing.shaped_random(self.shape, xp, dtype)
+        # hack: avoid testing the cases when getting a cuFFT plan is impossible
+        if _default_plan_type(x, s=self.s, axes=self.axes) != 'nd':
+            return x
+        if scp is cupyx.scipy:
+            from cupy.cuda.cufft import get_current_plan
+            plan = scp.fftpack.get_fft_plan(x, shape=self.s, axes=self.axes)
+            with plan:
+                assert id(plan) == id(get_current_plan())
+                out = scp.fftpack.ifft2(x, shape=self.s, axes=self.axes)
+            assert get_current_plan() is None
+        else:  # scipy
+            out = scp.fftpack.ifft2(x, shape=self.s, axes=self.axes)
+        return out
 
 
 @testing.parameterize(
@@ -329,6 +411,25 @@ class TestFftn(unittest.TestCase):
                                  overwrite_x=True)
         return x
 
+    @testing.for_complex_dtypes()
+    @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
+                                 contiguous_check=False, scipy_name='scp')
+    def test_fftn_plan_manager(self, xp, scp, dtype):
+        x = testing.shaped_random(self.shape, xp, dtype)
+        # hack: avoid testing the cases when getting a cuFFT plan is impossible
+        if _default_plan_type(x, s=self.s, axes=self.axes) != 'nd':
+            return x
+        if scp is cupyx.scipy:
+            from cupy.cuda.cufft import get_current_plan
+            plan = scp.fftpack.get_fft_plan(x, shape=self.s, axes=self.axes)
+            with plan:
+                assert id(plan) == id(get_current_plan())
+                out = scp.fftpack.fftn(x, shape=self.s, axes=self.axes)
+            assert get_current_plan() is None
+        else:  # scipy
+            out = scp.fftpack.fftn(x, shape=self.s, axes=self.axes)
+        return out
+
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
                                  contiguous_check=False, scipy_name='scp')
@@ -384,6 +485,25 @@ class TestFftn(unittest.TestCase):
             x = scp.fftpack.ifftn(x, shape=self.s, axes=self.axes,
                                   overwrite_x=True)
         return x
+
+    @testing.for_complex_dtypes()
+    @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
+                                 contiguous_check=False, scipy_name='scp')
+    def test_ifftn_plan_manager(self, xp, scp, dtype):
+        x = testing.shaped_random(self.shape, xp, dtype)
+        # hack: avoid testing the cases when getting a cuFFT plan is impossible
+        if _default_plan_type(x, s=self.s, axes=self.axes) != 'nd':
+            return x
+        if scp is cupyx.scipy:
+            from cupy.cuda.cufft import get_current_plan
+            plan = scp.fftpack.get_fft_plan(x, shape=self.s, axes=self.axes)
+            with plan:
+                assert id(plan) == id(get_current_plan())
+                out = scp.fftpack.ifftn(x, shape=self.s, axes=self.axes)
+            assert get_current_plan() is None
+        else:  # scipy
+            out = scp.fftpack.ifftn(x, shape=self.s, axes=self.axes)
+        return out
 
 
 @testing.parameterize(*testing.product({

--- a/tests/cupyx_tests/scipy_tests/fftpack_tests/test_fftpack.py
+++ b/tests/cupyx_tests/scipy_tests/fftpack_tests/test_fftpack.py
@@ -1,4 +1,5 @@
 import unittest
+import pytest
 
 from cupy import testing
 import cupyx.scipy.fftpack  # NOQA
@@ -179,14 +180,9 @@ class TestFft(unittest.TestCase):
         import cupyx.scipy.fftpack as fftpack
         x = testing.shaped_random(self.shape, cupy, dtype)
         plan = fftpack.get_fft_plan(x, shape=self.n, axes=self.axis)
-        try:
-            with plan:
-                fftpack.fft(x, n=self.n, axis=self.axis, plan=plan)
-        except RuntimeError as e:
-            if not e.__str__().startswith('Use the cuFFT plan'):
-                raise e
-        else:
-            raise Exception("No error is raised --- should not happen.")
+        with pytest.raises(RuntimeError) as ex, plan:
+            fftpack.fft(x, n=self.n, axis=self.axis, plan=plan)
+        assert 'Use the cuFFT plan either as' in str(ex.value)
 
 
 @testing.parameterize(
@@ -533,14 +529,9 @@ class TestFftn(unittest.TestCase):
         if _default_plan_type(x, s=self.s, axes=self.axes) != 'nd':
             return
         plan = fftpack.get_fft_plan(x, shape=self.s, axes=self.axes)
-        try:
-            with plan:
-                fftpack.fftn(x, shape=self.s, axes=self.axes, plan=plan)
-        except RuntimeError as e:
-            if not e.__str__().startswith('Use the cuFFT plan'):
-                raise e
-        else:
-            raise Exception("No error is raised --- should not happen.")
+        with pytest.raises(RuntimeError) as ex, plan:
+            fftpack.fftn(x, shape=self.s, axes=self.axes, plan=plan)
+        assert 'Use the cuFFT plan either as' in str(ex.value)
 
 
 @testing.parameterize(*testing.product({


### PR DESCRIPTION
Resolves #2356, resolves #2357. This PR enables the following (perhaps more pythonic) usage:
```python
import cupy
from cupyx.scipy.fftpack import get_fft_plan

x = cupy.arange(10)
fftplan = get_fft_plan(x)

with fftplan:
    y = cupy.fft.fft(x)
```
Note that the context manager pattern will work for functions in both `cupy.fft` and `cupyx.scipy.fftpack`.

Furthermore, this PR makes it easy to work with the new module `cupyx.scipy.fft` (to be added in #2355 following upstream changes):
```python
import cupy
import cupyx.scipy.fft as cu_fft
import scipy.fft
from cupyx.scipy.fftpack import get_fft_plan

x = cupy.arange(10)
fftplan = get_fft_plan(x)

with scipy.fft.set_backend(cu_fft), fftplan:
    scipy.fft.fft(x)  # Calls into cupyx, use fftplan, and returns a cupy array
```
While the `plan` argument might be added in upstream, see https://github.com/cupy/cupy/issues/2356#issuecomment-517355449 and scipy/scipy#10302, we should not count on that.

Finally, no backward compatibility is broken in this PR. 

Attn: @grlee77, @peterbell10