### PR TITLE
Fixed support of 0-sized arrays for 'linalg.qr'

### DIFF
--- a/tests/cupy_tests/linalg_tests/test_decomposition.py
+++ b/tests/cupy_tests/linalg_tests/test_decomposition.py
@@ -8,6 +8,8 @@ from cupy import cuda
 from cupy import testing
 from cupy.testing import condition
 
+from distutils.version import LooseVersion
+
 
 def random_matrix(shape, dtype, scale, sym=False):
     m, n = shape[-2:]
@@ -89,11 +91,18 @@ class TestQRDecomposition(unittest.TestCase):
     @testing.fix_random()
     @condition.repeat(3, 10)
     def test_mode(self):
-        self.check_mode(numpy.random.randn(0, 3), mode=self.mode)
-        self.check_mode(numpy.random.randn(3, 0), mode=self.mode)
         self.check_mode(numpy.random.randn(2, 4), mode=self.mode)
         self.check_mode(numpy.random.randn(3, 3), mode=self.mode)
         self.check_mode(numpy.random.randn(5, 4), mode=self.mode)
+
+    @testing.fix_random()
+    @condition.repeat(3, 10)
+    @unittest.skipUnless(
+        LooseVersion(numpy.__version__) > LooseVersion('1.16.0'),
+        'NumPy<1.16 does not work with empty arrays')
+    def test_empty_array(self):
+        self.check_mode(numpy.random.randn(0, 3), mode=self.mode)
+        self.check_mode(numpy.random.randn(3, 0), mode=self.mode)
 
 
 @testing.parameterize(*testing.product({

--- a/tests/cupy_tests/linalg_tests/test_decomposition.py
+++ b/tests/cupy_tests/linalg_tests/test_decomposition.py
@@ -8,8 +8,6 @@ from cupy import cuda
 from cupy import testing
 from cupy.testing import condition
 
-from distutils.version import LooseVersion
-
 
 def random_matrix(shape, dtype, scale, sym=False):
     m, n = shape[-2:]
@@ -97,9 +95,7 @@ class TestQRDecomposition(unittest.TestCase):
 
     @testing.fix_random()
     @condition.repeat(3, 10)
-    @unittest.skipUnless(
-        LooseVersion(numpy.__version__) > LooseVersion('1.16.0'),
-        'NumPy<1.16 does not work with empty arrays')
+    @testing.with_requires('numpy>=1.16')
     def test_empty_array(self):
         self.check_mode(numpy.random.randn(0, 3), mode=self.mode)
         self.check_mode(numpy.random.randn(3, 0), mode=self.mode)

--- a/tests/cupy_tests/linalg_tests/test_decomposition.py
+++ b/tests/cupy_tests/linalg_tests/test_decomposition.py
@@ -89,6 +89,8 @@ class TestQRDecomposition(unittest.TestCase):
     @testing.fix_random()
     @condition.repeat(3, 10)
     def test_mode(self):
+        self.check_mode(numpy.random.randn(0, 3), mode=self.mode)
+        self.check_mode(numpy.random.randn(3, 0), mode=self.mode)
         self.check_mode(numpy.random.randn(2, 4), mode=self.mode)
         self.check_mode(numpy.random.randn(3, 3), mode=self.mode)
         self.check_mode(numpy.random.randn(5, 4), mode=self.mode)


### PR DESCRIPTION
With reference to #2371 

Moreover, cuSOLVER does not calculate Q correctly if R is zero-sized. This case is handled separately.