### PR TITLE
Remove `random.power` test with forbidden value

### DIFF
--- a/tests/cupy_tests/random_tests/test_distributions.py
+++ b/tests/cupy_tests/random_tests/test_distributions.py
@@ -535,13 +535,6 @@ class TestDistributionsPower(RandomDistributionsTestCase):
         a = numpy.full(self.a_shape, 0.5, dtype=a_dtype)
         self.check_distribution('power', {'a': a}, dtype)
 
-    @testing.with_requires('numpy>=1.12')
-    @cupy.testing.for_float_dtypes('dtype', no_float16=True)
-    @cupy.testing.for_float_dtypes('a_dtype')
-    def test_power_for_zero_a(self, a_dtype, dtype):
-        a = numpy.zeros(self.a_shape, dtype=a_dtype)
-        self.check_distribution('power', {'a': a}, dtype)
-
     @cupy.testing.for_float_dtypes('dtype', no_float16=True)
     @cupy.testing.for_float_dtypes('a_dtype')
     def test_power_for_negative_a(self, a_dtype, dtype):


### PR DESCRIPTION
Fixes part of #2370

`a=0` [has been forbidden](https://docs.scipy.org/doc/numpy-1.16.0/reference/generated/numpy.random.power.html) in `numpy.random.power`, but it seems it only became an error in NumPy 1.17.