### PR TITLE
[backport] Skip some FFT tests on NumPy 1.17.0 due to a NumPy bug

### DIFF
--- a/tests/cupy_tests/fft_tests/test_fft.py
+++ b/tests/cupy_tests/fft_tests/test_fft.py
@@ -74,6 +74,7 @@ class TestFft(unittest.TestCase):
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
                                  contiguous_check=False)
+    @testing.with_requires('numpy!=1.17.0')  # 1.17.0 raises ZeroDivisonError
     def test_ifft(self, xp, dtype):
         a = testing.shaped_random(self.shape, xp, dtype)
         out = xp.fft.ifft(a, n=self.n, norm=self.norm)
@@ -111,6 +112,7 @@ class TestFftOrder(unittest.TestCase):
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
                                  contiguous_check=False)
+    @testing.with_requires('numpy!=1.17.0')  # 1.17.0 raises ZeroDivisonError
     def test_ifft(self, xp, dtype):
         a = testing.shaped_random(self.shape, xp, dtype)
         if self.data_order == 'F':


### PR DESCRIPTION
Backport of #2363