### PR TITLE
[backport] Avoid calling `numpy.nonzero` on 0-dim arrays in tests

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -697,6 +697,11 @@ cdef class ndarray:
             :func:`numpy.nonzero`
 
         """
+        if self.ndim == 0:
+            warnings.warn(
+                'calling nonzero on 0d arrays is deprecated',
+                DeprecationWarning)
+
         return _indexing._ndarray_nonzero(self)
 
     # TODO(okuta): Implement compress

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -697,11 +697,6 @@ cdef class ndarray:
             :func:`numpy.nonzero`
 
         """
-        if self.ndim == 0:
-            warnings.warn(
-                'calling nonzero on 0d arrays is deprecated',
-                DeprecationWarning)
-
         return _indexing._ndarray_nonzero(self)
 
     # TODO(okuta): Implement compress

--- a/cupy/testing/helper.py
+++ b/cupy/testing/helper.py
@@ -80,12 +80,11 @@ numpy
         self.fail(msg)
 
 
-def _make_positive_indices(self, impl, args, kw):
+def _make_positive_mask(self, impl, args, kw):
     ks = [k for k, v in kw.items() if v in _unsigned_dtypes]
     for k in ks:
         kw[k] = numpy.intp
-    mask = cupy.asnumpy(impl(self, *args, **kw)) >= 0
-    return numpy.nonzero(mask)
+    return cupy.asnumpy(impl(self, *args, **kw)) >= 0
 
 
 def _contains_signed_and_unsigned(kw):
@@ -132,10 +131,11 @@ def _make_decorator(check_func, name, type_check, accept_error, sp_name=None,
             skip = False
             if _contains_signed_and_unsigned(kw) and \
                     cupy_result.dtype in _unsigned_dtypes:
-                inds = _make_positive_indices(self, impl, args, kw)
-                if cupy_result.shape == ():
-                    skip = inds[0].size == 0
+                mask = _make_positive_mask(self, impl, args, kw)
+                if mask.shape == ():
+                    skip = mask == 0
                 else:
+                    inds = numpy.nonzero(mask)
                     cupy_result = cupy.asnumpy(cupy_result)[inds]
                     numpy_result = cupy.asnumpy(numpy_result)[inds]
 

--- a/tests/cupy_tests/sorting_tests/test_search.py
+++ b/tests/cupy_tests/sorting_tests/test_search.py
@@ -224,11 +224,11 @@ class TestNonzero(unittest.TestCase):
     {'array': numpy.array(1)},
 )
 @testing.gpu
-@testing.with_requires('numpy>=1.17.0')
+@testing.with_requires('numpy<1.17.0')
 class TestNonzeroZeroDimension(unittest.TestCase):
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_raises()
+    @testing.numpy_cupy_array_list_equal()
     def test_nonzero(self, xp, dtype):
         array = xp.array(self.array, dtype=dtype)
         return xp.nonzero(array)

--- a/tests/cupy_tests/sorting_tests/test_search.py
+++ b/tests/cupy_tests/sorting_tests/test_search.py
@@ -205,8 +205,6 @@ class TestWhereError(unittest.TestCase):
 @testing.parameterize(
     {'array': numpy.random.randint(0, 2, (20,))},
     {'array': numpy.random.randn(3, 2, 4)},
-    {'array': numpy.array(0)},
-    {'array': numpy.array(1)},
     {'array': numpy.empty((0,))},
     {'array': numpy.empty((0, 2))},
     {'array': numpy.empty((0, 2, 0))},
@@ -216,6 +214,21 @@ class TestNonzero(unittest.TestCase):
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_list_equal()
+    def test_nonzero(self, xp, dtype):
+        array = xp.array(self.array, dtype=dtype)
+        return xp.nonzero(array)
+
+
+@testing.parameterize(
+    {'array': numpy.array(0)},
+    {'array': numpy.array(1)},
+)
+@testing.gpu
+@testing.with_requires('numpy>=1.17.0')
+class TestNonzeroZeroDimension(unittest.TestCase):
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_raises()
     def test_nonzero(self, xp, dtype):
         array = xp.array(self.array, dtype=dtype)
         return xp.nonzero(array)


### PR DESCRIPTION
Backport of #2374

Fixes #2370