### PR TITLE
Revert "Raise `DeprecationWarning` on 0-dim arrays in `numpy.nonzero` to match NumPy 1.17 behavior"

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -697,11 +697,6 @@ cdef class ndarray:
             :func:`numpy.nonzero`
 
         """
-        if self.ndim == 0:
-            warnings.warn(
-                'calling nonzero on 0d arrays is deprecated',
-                DeprecationWarning)
-
         return _indexing._ndarray_nonzero(self)
 
     # TODO(okuta): Implement compress

--- a/tests/cupy_tests/sorting_tests/test_search.py
+++ b/tests/cupy_tests/sorting_tests/test_search.py
@@ -205,6 +205,8 @@ class TestWhereError(unittest.TestCase):
 @testing.parameterize(
     {'array': numpy.random.randint(0, 2, (20,))},
     {'array': numpy.random.randn(3, 2, 4)},
+    {'array': numpy.array(0)},
+    {'array': numpy.array(1)},
     {'array': numpy.empty((0,))},
     {'array': numpy.empty((0, 2))},
     {'array': numpy.empty((0, 2, 0))},
@@ -214,21 +216,6 @@ class TestNonzero(unittest.TestCase):
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_list_equal()
-    def test_nonzero(self, xp, dtype):
-        array = xp.array(self.array, dtype=dtype)
-        return xp.nonzero(array)
-
-
-@testing.parameterize(
-    {'array': numpy.array(0)},
-    {'array': numpy.array(1)},
-)
-@testing.gpu
-@testing.with_requires('numpy>=1.17.0')
-class TestNonzeroZeroDimension(unittest.TestCase):
-
-    @testing.for_all_dtypes()
-    @testing.numpy_cupy_raises()
     def test_nonzero(self, xp, dtype):
         array = xp.array(self.array, dtype=dtype)
         return xp.nonzero(array)


### PR DESCRIPTION
Reverts cupy/cupy#2374
The original PR has a bug, and #2385 fixes it.