### PR TITLE
Add `cupy.RawModule()`

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -655,7 +655,7 @@ from cupy.util import memoize  # NOQA
 
 from cupy.core import ElementwiseKernel  # NOQA
 from cupy.core import RawKernel  # NOQA
-from cupy.core import RawModule  # NOQA
+from cupy.core import RawModule as Module  # NOQA
 from cupy.core import ReductionKernel  # NOQA
 
 # -----------------------------------------------------------------------------

--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -655,7 +655,7 @@ from cupy.util import memoize  # NOQA
 
 from cupy.core import ElementwiseKernel  # NOQA
 from cupy.core import RawKernel  # NOQA
-from cupy.core import RawModule as Module  # NOQA
+from cupy.core import RawModule  # NOQA
 from cupy.core import ReductionKernel  # NOQA
 
 # -----------------------------------------------------------------------------

--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -655,6 +655,7 @@ from cupy.util import memoize  # NOQA
 
 from cupy.core import ElementwiseKernel  # NOQA
 from cupy.core import RawKernel  # NOQA
+from cupy.core import RawModule  # NOQA
 from cupy.core import ReductionKernel  # NOQA
 
 # -----------------------------------------------------------------------------

--- a/cupy/core/__init__.py
+++ b/cupy/core/__init__.py
@@ -62,3 +62,4 @@ from cupy.core.dlpack import fromDlpack  # NOQA
 from cupy.core.internal import complete_slice  # NOQA
 from cupy.core.internal import get_size  # NOQA
 from cupy.core.raw import RawKernel  # NOQA
+from cupy.core.raw import RawModule  # NOQA

--- a/cupy/core/raw.pxd
+++ b/cupy/core/raw.pxd
@@ -13,5 +13,5 @@ cdef class RawModule:
         readonly str code
         readonly str cubin_path
         readonly tuple options
-        public dict kernels
+        dict kernels
         object module

--- a/cupy/core/raw.pxd
+++ b/cupy/core/raw.pxd
@@ -11,6 +11,7 @@ cdef class RawModule:
 
     cdef:
         readonly str code
+        readonly str cubin_path
         readonly tuple options
         public dict kernels
         object module

--- a/cupy/core/raw.pxd
+++ b/cupy/core/raw.pxd
@@ -4,3 +4,13 @@ cdef class RawKernel:
         readonly str code
         readonly str name
         readonly tuple options
+        object _kernel
+
+
+cdef class RawModule:
+
+    cdef:
+        readonly str code
+        readonly tuple options
+        public dict kernels
+        object module

--- a/cupy/core/raw.pyx
+++ b/cupy/core/raw.pyx
@@ -59,10 +59,6 @@ cdef class RawKernel:
             self._kernel = _get_raw_kernel(self.code, self.name, self.options)
         return self._kernel
 
-    @kernel.setter
-    def kernel(self, ker):
-        self._kernel = ker
-
     @property
     def attributes(self):
         """Returns a dictionary containing runtime kernel attributes. This is
@@ -249,6 +245,6 @@ cdef class RawModule:
             return self.kernels[name]
         else:
             ker = RawKernel(None, name, self.options)
-            ker.kernel = self.module.get_function(name)
+            ker._kernel = self.module.get_function(name)
             self.kernels[name] = ker
             return ker

--- a/cupy/core/raw.pyx
+++ b/cupy/core/raw.pyx
@@ -21,7 +21,7 @@ cdef class RawKernel:
     Args:
         code (str): CUDA source code.
         name (str): Name of the kernel function.
-        options (str): Compile options passed to NVRTC. For details, see
+        options (str): Compiler options passed to NVRTC. For details, see
             https://docs.nvidia.com/cuda/nvrtc/index.html#group__options.
 
     """
@@ -190,6 +190,29 @@ def _get_raw_kernel(code, name, options=()):
 
 
 cdef class RawModule:
+    """User-defined custom module.
+
+    This class can be used to either compile raw CUDA sources or load CUDA
+    modules (\*.cubin). This class is useful when a number of CUDA kernels in
+    the same source need to be retrieved.
+
+    For the former case, the CUDA source code is compiled when initializing a
+    new instance of this class, and the kernels can be retrieved by calling
+    :meth:`get_function`, which will return an instance of :class:`RawKernel`.
+    (Same as in :class:`RawKernel`, the generated binary is also cached.)
+
+    For the latter case, an existing CUDA binary (\*.cubin) can be loaded by
+    providing its path, and kernels therein can be retrieved similarly.
+
+    Args:
+        code_or_path (str): CUDA source code or path to cubin.
+        options (str): Compiler options passed to NVRTC if compilation is
+            needed. For details, see
+            https://docs.nvidia.com/cuda/nvrtc/index.html#group__options.
+
+    .. note::
+        Each kernel in ``RawModule`` possesses independent function attributes.
+    """
     def __init__(self, code_or_path, options=()):
         if isinstance(code_or_path, six.binary_type):
             code_or_path = code_or_path.decode('UTF-8')
@@ -214,6 +237,14 @@ cdef class RawModule:
         self.kernels = {}
 
     def get_function(self, name):
+        """Retrieve a CUDA kernel by its name from the module.
+
+        Args:
+            name (str): Name of the kernel function.
+
+        Returns:
+            RawKernel: An ``RawKernel`` instance.
+        """
         if name in self.kernels:
             return self.kernels[name]
         else:

--- a/cupy/core/raw.pyx
+++ b/cupy/core/raw.pyx
@@ -205,7 +205,7 @@ cdef class RawModule:
 
         if self.code is not None:
             self.module = cupy.core.core.compile_with_cache(
-                              code, options, prepend_cupy_headers=False)
+                code, options, prepend_cupy_headers=False)
         elif self.cubin_path is not None:
             self.module = Module()
             self.module.load_file(self.cubin_path)

--- a/docs/source/reference/kernel.rst
+++ b/docs/source/reference/kernel.rst
@@ -8,4 +8,5 @@ Custom kernels
    cupy.ElementwiseKernel
    cupy.ReductionKernel
    cupy.RawKernel
+   cupy.RawModule
    cupy.fuse

--- a/docs/source/tutorial/kernel.rst
+++ b/docs/source/tutorial/kernel.rst
@@ -233,6 +233,50 @@ attributes:
     You can use ``cupy.cuda.Stream.null.synchronize()`` if you are using the default stream.
 
 
+Raw Modules
+-----------
+
+For dealing a large raw CUDA source or loading an existing CUDA binary, the :class:`~cupy.RawModule` class can be more handy. It can be initialized either by a CUDA source code, or by a path to the CUDA binary. The needed kernels can then be retrieved by calling the :meth:`~cupy.RawModule.get_function` method, which returns a `~cupy.RawKernel` instance that can be invoked as discussed above.
+
+.. doctest::
+
+    >>> loaded_from_source = r'''
+    ... extern "C"{
+    ...
+    ... __global__ void test_sum(const float* x1, const float* x2, float* y, \
+    ...                          unsigned int N)
+    ... {
+    ...     unsigned int tid = blockDim.x * blockIdx.x + threadIdx.x;
+    ...     if (tid < N)
+    ...     {
+    ...         y[tid] = x1[tid] + x2[tid];
+    ...     }
+    ... }
+    ...
+    ... __global__ void test_multiply(const float* x1, const float* x2, float* y, \
+    ...                               unsigned int N)
+    ... {
+    ...     unsigned int tid = blockDim.x * blockIdx.x + threadIdx.x;
+    ...     if (tid < N)
+    ...     {
+    ...         y[tid] = x1[tid] * x2[tid];
+    ...     }
+    ... }
+    ...
+    ... }'''
+    >>> module = cp.RawModule(loaded_from_source)
+    >>> ker_sum = module.get_function('test_sum')
+    >>> ker_times = module.get_function('test_multiply')
+    >>> N = 10
+    >>> x1 = cp.arange(N**2, dtype=cp.float32).reshape(N, N)
+    >>> x2 = cp.ones((N, N), dtype=cp.float32)
+    >>> y = cp.zeros((N, N), dtype=cp.float32)
+    >>> ker_sum((N,), (N,), (x1, x2, y, N**2))   # y = x1 + x2
+    >>> assert cp.allclose(y, x1 + x2)
+    >>> ker_times((N,), (N,), (x1, x2, y, N**2)) # y = x1 * x2
+    >>> assert cp.allclose(y, x1 * x2)
+
+
 Kernel fusion
 --------------------
 

--- a/tests/cupy_tests/core_tests/test_raw.py
+++ b/tests/cupy_tests/core_tests/test_raw.py
@@ -1,9 +1,10 @@
 import unittest
+import pytest
 
 import cupy
 
 
-_test_source = r'''
+_test_source1 = r'''
 extern "C" __global__
 void test_sum(const float* x1, const float* x2, float* y) {
     int tid = blockDim.x * blockIdx.x + threadIdx.x;
@@ -11,11 +12,79 @@ void test_sum(const float* x1, const float* x2, float* y) {
 }
 '''
 
+# test compiling and invoking multiple kernels in one single .cubin
+_test_source2 = r'''
+extern "C"{
+
+__global__ void test_sum(const float* x1, const float* x2, float* y, \
+                         unsigned int N)
+{
+    unsigned int tid = blockDim.x * blockIdx.x + threadIdx.x;
+    if (tid < N)
+    {
+        y[tid] = x1[tid] + x2[tid];
+    }
+}
+
+__global__ void test_multiply(const float* x1, const float* x2, float* y, \
+                              unsigned int N)
+{
+    unsigned int tid = blockDim.x * blockIdx.x + threadIdx.x;
+    if (tid < N)
+    {
+        y[tid] = x1[tid] * x2[tid];
+    }
+}
+
+}
+'''
+
+# test C macros
+_test_source3 = r'''
+#ifndef PRECISION
+    #define PRECISION 2
+#endif
+
+#if PRECISION == 2
+    #define TYPE double
+#elif PRECISION == 1
+    #define TYPE float
+#else
+    #error precision not supported
+#endif
+
+extern "C"{
+
+__global__ void test_sum(const TYPE* x1, const TYPE* x2, TYPE* y, \
+                         unsigned int N)
+{
+    unsigned int tid = blockDim.x * blockIdx.x + threadIdx.x;
+    if (tid < N)
+    {
+        y[tid] = x1[tid] + x2[tid];
+    }
+}
+
+__global__ void test_multiply(const TYPE* x1, const TYPE* x2, TYPE* y, \
+                              unsigned int N)
+{
+    unsigned int tid = blockDim.x * blockIdx.x + threadIdx.x;
+    if (tid < N)
+    {
+        y[tid] = x1[tid] * x2[tid];
+    }
+}
+
+}
+'''
+
 
 class TestRaw(unittest.TestCase):
 
     def setUp(self):
-        self.kern = cupy.RawKernel(_test_source, 'test_sum')
+        self.kern = cupy.RawKernel(_test_source1, 'test_sum')
+        self.mod2 = cupy.RawModule(_test_source2)
+        self.mod3 = cupy.RawModule(_test_source3, ("-DPRECISION=2",))
 
     def test_basic(self):
         x1 = cupy.arange(100, dtype=cupy.float32).reshape(10, 10)
@@ -40,3 +109,40 @@ class TestRaw(unittest.TestCase):
         assert self.kern.num_regs > 0
         assert self.kern.max_threads_per_block > 0
         assert self.kern.shared_size_bytes == 0
+
+    def test_module(self):
+        module = self.mod2
+        ker_sum = module.get_function('test_sum')
+        ker_times = module.get_function('test_multiply')
+
+        N = 10
+        x1 = cupy.arange(N**2, dtype=cupy.float32).reshape(N, N)
+        x2 = cupy.ones((N, N), dtype=cupy.float32)
+        y = cupy.zeros((N, N), dtype=cupy.float32)
+
+        ker_sum((N,), (N,), (x1, x2, y, N**2))
+        assert cupy.allclose(y, x1 + x2)
+
+        ker_times((N,), (N,), (x1, x2, y, N**2))
+        assert cupy.allclose(y, x1 * x2)
+
+    def test_compiler_flag(self):
+        module = self.mod3
+        ker_sum = module.get_function('test_sum')
+        ker_times = module.get_function('test_multiply')
+
+        N = 10
+        x1 = cupy.arange(N**2, dtype=cupy.float64).reshape(N, N)
+        x2 = cupy.ones((N, N), dtype=cupy.float64)
+        y = cupy.zeros((N, N), dtype=cupy.float64)
+
+        ker_sum((N,), (N,), (x1, x2, y, N**2))
+        assert cupy.allclose(y, x1 + x2)
+
+        ker_times((N,), (N,), (x1, x2, y, N**2))
+        assert cupy.allclose(y, x1 * x2)
+
+    def test_invalid_compiler_flag(self):
+        with pytest.raises(cupy.cuda.compiler.CompileException) as ex:
+            cupy.RawModule(_test_source3, ("-DPRECISION=3",))
+        assert 'precision not supported' in str(ex)

--- a/tests/cupy_tests/core_tests/test_raw.py
+++ b/tests/cupy_tests/core_tests/test_raw.py
@@ -1,5 +1,5 @@
-import unittest
 import pytest
+import unittest
 
 import cupy
 
@@ -141,3 +141,20 @@ class TestRaw(unittest.TestCase):
         with pytest.raises(cupy.cuda.compiler.CompileException) as ex:
             cupy.RawModule(_test_source3, ("-DPRECISION=3",))
         assert 'precision not supported' in str(ex)
+
+    def test_module_load_failure(self):
+        # in principle this test is better done in test_driver.py, but
+        # this error is more likely to appear when using RawModule, so
+        # let us do it here
+        import os
+        with pytest.raises(cupy.cuda.driver.CUDADriverError) as ex:
+            cupy.RawModule(os.path.expanduser("~/this_does_not_exist.cubin"))
+        assert 'CUDA_ERROR_FILE_NOT_FOUND' in str(ex)
+
+    def test_get_function_failure(self):
+        # in principle this test is better done in test_driver.py, but
+        # this error is more likely to appear when using RawModule, so
+        # let us do it here
+        with pytest.raises(cupy.cuda.driver.CUDADriverError) as ex:
+            self.mod2.get_function("no_such_kernel")
+        assert 'CUDA_ERROR_NOT_FOUND' in str(ex)


### PR DESCRIPTION
### Summary
- This PR aims to provide a public API for compiling large CUDA codes or loading CUDA modules. 
- This PR is favored over an earlier attempt #1889 for reasons discussed below. 
- Closes #1657. Closes #1889. 
- ~~This PR is built upon, and thus **blocked by**, #2369.~~

#### Rationale 
(This also serves as a refreshment of what's discussed/done early on...)
- As initially discussed in #1657, it'd be nice if an API can be exposed so that legacy CUDA codebase can be "imported" in CuPy;
- It seems that `cupy.cuda.function.Module()` was intended to be used as private API;
- It was suggested that `RawKernel.compile(long_code)` can be used as a public API, which was implemented in #1889;
- However, `RawKernel.compile()` returns a `Module` instance, not `RawKernel`, which could be misleading/confusing;
- With the recent work #2369, `RawKernel` now has function attributes, and it'd be nice if each of the CUDA kernels compiled from the same source code can possess attributes independently, but #1889 does not meet this need;
- To achieve this, the new implementation `cupy.RawModule.get_function(kernel_name)` returns a `RawKernel` instance;
- `cupy.RawModule()` can be initialized either by a CUDA source code (same as `RawKernel`; the compilation is done at initialization) or by loading an existing CUDA cubin.

I'd like to discuss with core devs to see if this PR makes better sense ~~before proceeding to docs, tests (tested locally), and further refinement.~~ Thanks.

**UPDATE**:  The module name is changed to `RawModule` as discussed below.