### PR TITLE
Add `ndarray` variants AND inplace support in `fallback_mode`

### DIFF
--- a/cupyx/fallback_mode/fallback.py
+++ b/cupyx/fallback_mode/fallback.py
@@ -265,9 +265,6 @@ class ndarray(object):
                 if self._remember_numpy:
                     self._update_cupy_array()
                 return getattr(self._cupy_array, attr)
-
-            if self._supports_cupy and not self._remember_numpy:
-                self._update_numpy_array()
             return getattr(self._numpy_array, attr)
 
         return _RecursiveAttr(numpy_object, cupy_object, self)

--- a/cupyx/fallback_mode/fallback.py
+++ b/cupyx/fallback_mode/fallback.py
@@ -24,9 +24,9 @@ class _RecursiveAttr(object):
             numpy_object (method): NumPy method.
             cupy_method (method): Corresponding CuPy method.
             array (ndarray): Acts as flag to know if _RecursiveAttr object
-            is called from ``ndarray`` class. Also, acts as container for
-            modifying args in case it is called from ``ndarray``.
-            None otherwise.
+                is called from ``ndarray`` class. Also, acts as container for
+                modifying args in case it is called from ``ndarray``.
+                None otherwise.
         """
 
         self._numpy_object = numpy_object
@@ -56,8 +56,11 @@ class _RecursiveAttr(object):
 
         Returns:
             (_RecursiveAttr object, NumPy scalar):
-            Returns_RecursiveAttr object with new numpy_object, cupy_object.
-            Returns objects in cupy which is an alias of numpy object.
+                Returns_RecursiveAttr object with new numpy_object,
+                cupy_object. OR
+                Returns objects in cupy which is an alias
+                of numpy object. OR
+                Returns wrapper objects, `ndarray`, `vectorize`.
         """
 
         numpy_object = getattr(self._numpy_object, attr)
@@ -91,7 +94,11 @@ class _RecursiveAttr(object):
     @staticmethod
     def _is_cupy_compatible(args, kwargs):
         """
-        Returns False if ndarray is not compatible with CuPy.
+        Returns False if CuPy's functions never accept the arguments as
+        parameters due to the following reasons.
+        - The inputs include an object of a NumPy's specific class other than
+          `np.ndarray`.
+        - The inputs include a dtype which is not supported in CuPy.
         """
         for arg in args:
             if isinstance(arg, ndarray) and arg._class is not cp.ndarray:
@@ -174,24 +181,26 @@ class ndarray(object):
     def __init__(self, *args, **kwargs):
         """
         Args:
-            _stored (None, ndarray): If _stored is None, object is not
-            initialized. Otherwise, _stored (ndarray) would be set to
-            _cupy_array and/or _numpy_array depending upon _class.
+            _stored (None, cp.ndarray or np.ndarray(including variants)):
+                If _stored is None, object is not initialized.
+                Otherwise, _stored (ndarray) would be set to
+                _cupy_array and/or _numpy_array depending upon _class.
             _class (ndarray type): If _class is `cp.ndarray`, _stored is
-            set as _cupy_array and _numpy_array. Otherwise, _stored is set
-            as only _numpy_array.
-            Intended values for _class are `np.ndarray`, `np.ma.MaskedArray`,
-            `np.matrix`, `np.chararray`, `np.recarray`.
+                set as _cupy_array and _numpy_array. Otherwise, _stored is
+                set as only _numpy_array. Intended values for _class are
+                `np.ndarray`, `np.ma.MaskedArray`, `np.matrix`,
+                `np.chararray`, `np.recarray`.
 
         Attributes:
-            _cupy_array (cp.ndarray): ndarray fully compatible with CuPy.
-            This will be always set to a ndarray in GPU.
-            _numpy_array (np.ndarray and variants): ndarray not supported by
-            CuPy. Such as np.ndarray(where dtype is not in '?bhilqBHILQefdFD')
-            and it's variants. This will be always set to a ndarray in CPU.
+            _cupy_array (None or cp.ndarray): ndarray fully compatible with
+                CuPy. This will be always set to a ndarray in GPU.
+            _numpy_array (None or np.ndarray(including variants)): ndarray not
+                supported by CuPy. Such as np.ndarray (where dtype is not in
+                '?bhilqBHILQefdFD') and it's variants. This will be always set
+                to a ndarray in CPU.
             _class (ndarray type): If _class is `cp.ndarray`, data of array
-            will contain in _cupy_array and _numpy_array.
-            In all other cases only _numpy_array will have the data.
+                will contain in _cupy_array and _numpy_array.
+                In all other cases only _numpy_array will have the data.
         """
 
         _class = kwargs.pop('_class', None)
@@ -392,12 +401,12 @@ def _get_xp_args(ndarray_instance, to_xp, arg):
 
     Args:
         ndarray_instance (numpy.ndarray, cupy.ndarray or fallback.ndarray):
-        Objects of type `ndarray_instance` will be converted using `to_xp`.
+            Objects of type `ndarray_instance` will be converted using `to_xp`.
         to_xp (FunctionType): Method to convert ndarray_instance type objects.
         arg (object): `ndarray_instance`, `tuple`, `list` and `dict` type
-        objects will be returned by either converting the object or it's
-        elements, if object is iterable.
-        Objects of other types is returned as it is.
+            objects will be returned by either converting the object or it's
+            elements, if object is iterable. Objects of other types is
+            returned as it is.
 
     Returns:
         Return data structure will be same as before after converting ndarrays.

--- a/cupyx/fallback_mode/fallback.py
+++ b/cupyx/fallback_mode/fallback.py
@@ -367,8 +367,10 @@ def _convert_fallback_to_cupy(args, kwargs):
 def _convert_cupy_to_fallback(cupy_res):
     return _get_xp_args(cp.ndarray, ndarray._store_cupy_array, cupy_res)
 
+
 def _prepare_for_cupy_dispatch(args, kwargs):
     return _get_xp_args(ndarray, ndarray._cupy_dispatch, (args, kwargs))
+
 
 def _prepare_for_numpy_dispatch(args, kwargs):
     return _get_xp_args(ndarray, ndarray._numpy_dispatch, (args, kwargs))

--- a/cupyx/fallback_mode/fallback.py
+++ b/cupyx/fallback_mode/fallback.py
@@ -212,10 +212,8 @@ class ndarray(object):
             if type(_stored) is cp.ndarray:
                 # _stored is in GPU memory (caller _store_array_from_cupy)
                 self._cupy_array = _stored
-                self._numpy_array = cp.asnumpy(_stored)
             else:
                 # _stored is in CPU memory (caller _store_array_from_numpy)
-                self._cupy_array = cp.array(_stored)
                 self._numpy_array = _stored
         else:
             self._numpy_array = _stored

--- a/cupyx/fallback_mode/fallback.py
+++ b/cupyx/fallback_mode/fallback.py
@@ -109,7 +109,8 @@ class _RecursiveAttr(object):
             return all([_RecursiveAttr._is_cupy_compatible(i) for i in arg])
 
         if isinstance(arg, dict):
-            return all([_RecursiveAttr._is_cupy_compatible(arg[key]) for key in arg])
+            bools = [_RecursiveAttr._is_cupy_compatible(arg[i]) for i in arg]
+            return all(bools)
 
         return True
 
@@ -134,7 +135,8 @@ class _RecursiveAttr(object):
         if self._fallback_array is not None:
             args = ((self._fallback_array,) + args)
 
-        if self._cupy_object is not None and _RecursiveAttr._is_cupy_compatible((args, kwargs)):
+        if self._cupy_object is not None and \
+           _RecursiveAttr._is_cupy_compatible((args, kwargs)):
             try:
                 return _call_cupy(self._cupy_object, args, kwargs)
             except Exception:
@@ -290,7 +292,8 @@ class ndarray(object):
         To be executed before calling numpy function.
         """
         base = self.base
-        _type = np.ndarray if self._supports_cupy else self._numpy_array.__class__
+        _type = np.ndarray if self._supports_cupy \
+            else self._numpy_array.__class__
 
         if self._supports_cupy:
             # cupy-compatible
@@ -338,7 +341,7 @@ def _create_magic_methods():
     def make_method(name):
         def method(self, *args, **kwargs):
             CLASS = cp.ndarray if self._supports_cupy \
-                    else self._numpy_array.__class__
+                else self._numpy_array.__class__
             _method = getattr(CLASS, name)
             args = ((self,) + args)
             if self._supports_cupy:

--- a/cupyx/fallback_mode/fallback.py
+++ b/cupyx/fallback_mode/fallback.py
@@ -428,9 +428,7 @@ def _call_numpy(func, args, kwargs):
     if numpy_out is not None and numpy_out is numpy_res:
         return kwargs.get('out')
 
-    fallback_res = _convert_numpy_to_fallback(numpy_res)
-
-    return fallback_res
+    return _convert_numpy_to_fallback(numpy_res)
 
 
 def _is_cupy_compatible(args, kwargs):

--- a/cupyx/fallback_mode/fallback.py
+++ b/cupyx/fallback_mode/fallback.py
@@ -161,26 +161,26 @@ class ndarray(object):
 
     def __new__(cls, *args, **kwargs):
         """
-        If `_stored` and `_class` are arguments, initialize cls(ndarray).
+        If `_initial_array` and `_class` are arguments, initialize cls(ndarray).
         Else get cupy.ndarray from provided arguments,
         then initialize cls(ndarray).
         """
-        _stored = kwargs.get('_stored', None)
-        if _stored is not None:
+        _initial_array = kwargs.get('_initial_array', None)
+        if _initial_array is not None:
             return object.__new__(cls)
 
         cupy_ndarray_init = cp.ndarray(*args, **kwargs)
-        return cls(_stored=cupy_ndarray_init, _class=cp.ndarray)
+        return cls(_initial_array=cupy_ndarray_init, _class=cp.ndarray)
 
     def __init__(self, *args, **kwargs):
         """
         Args:
-            _stored (None, cp.ndarray or np.ndarray(including variants)):
-                If _stored is None, object is not initialized.
-                Otherwise, _stored (ndarray) would be set to
+            _initial_array (None, cp.ndarray or np.ndarray(including variants)):
+                If _initial_array is None, object is not initialized.
+                Otherwise, _initial_array (ndarray) would be set to
                 _cupy_array and/or _numpy_array depending upon _class.
-            _class (ndarray type): If _class is `cp.ndarray`, _stored is
-                set as _cupy_array and _numpy_array. Otherwise, _stored is
+            _class (ndarray type): If _class is `cp.ndarray`, _initial_array is
+                set as _cupy_array and _numpy_array. Otherwise, _initial_array is
                 set as only _numpy_array. Intended values for _class are
                 `np.ndarray`, `np.ma.MaskedArray`, `np.matrix`,
                 `np.chararray`, `np.recarray`.
@@ -198,8 +198,8 @@ class ndarray(object):
         """
 
         _class = kwargs.pop('_class', None)
-        _stored = kwargs.pop('_stored', None)
-        if _stored is None:
+        _initial_array = kwargs.pop('_initial_array', None)
+        if _initial_array is None:
             return
 
         self._cupy_array = None
@@ -207,31 +207,31 @@ class ndarray(object):
         self.base = None
         self._class = _class
 
-        assert isinstance(_stored, (cp.ndarray, np.ndarray))
+        assert isinstance(_initial_array, (cp.ndarray, np.ndarray))
         if _class is cp.ndarray:
-            if type(_stored) is cp.ndarray:
-                # _stored is in GPU memory (caller _store_array_from_cupy)
-                self._cupy_array = _stored
+            if type(_initial_array) is cp.ndarray:
+                # _initial_array is in GPU memory (caller _store_array_from_cupy)
+                self._cupy_array = _initial_array
                 self._remember_numpy = False
             else:
-                # _stored is in CPU memory (caller _store_array_from_numpy)
-                self._numpy_array = _stored
-                self._cupy_array = cp.array(_stored)
+                # _initial_array is in CPU memory (caller _store_array_from_numpy)
+                self._numpy_array = _initial_array
+                self._cupy_array = cp.array(_initial_array)
                 self._remember_numpy = True
         else:
-            self._numpy_array = _stored
+            self._numpy_array = _initial_array
 
     @classmethod
     def _store_array_from_cupy(cls, array):
-        return cls(_stored=array, _class=cp.ndarray)
+        return cls(_initial_array=array, _class=cp.ndarray)
 
     @classmethod
     def _store_array_from_numpy(cls, array):
         if type(array) is np.ndarray and \
            array.dtype.kind in '?bhilqBHILQefdFD':
-            return cls(_stored=array, _class=cp.ndarray)
+            return cls(_initial_array=array, _class=cp.ndarray)
 
-        return cls(_stored=array, _class=array.__class__)
+        return cls(_initial_array=array, _class=array.__class__)
 
     def __getattr__(self, attr):
         """

--- a/cupyx/fallback_mode/fallback.py
+++ b/cupyx/fallback_mode/fallback.py
@@ -262,7 +262,7 @@ class ndarray(object):
 
     def _get_cupy_array(self):
         """
-        Returns _cupy_array (cupy.ndarray) of ndarray object. And marks 
+        Returns _cupy_array (cupy.ndarray) of ndarray object. And marks
         self(ndarray) and it's base (if exist) as numpy not up-to-date.
         """
         base = self.base

--- a/cupyx/fallback_mode/fallback.py
+++ b/cupyx/fallback_mode/fallback.py
@@ -161,7 +161,8 @@ class ndarray(object):
 
     def __new__(cls, *args, **kwargs):
         """
-        If `_initial_array` and `_class` are arguments, initialize cls(ndarray).
+        If `_initial_array` and `_class` are arguments,
+        initialize cls(ndarray).
         Else get cupy.ndarray from provided arguments,
         then initialize cls(ndarray).
         """
@@ -175,15 +176,16 @@ class ndarray(object):
     def __init__(self, *args, **kwargs):
         """
         Args:
-            _initial_array (None, cp.ndarray or np.ndarray(including variants)):
+            _initial_array (None, cp.ndarray/np.ndarray(including variants)):
                 If _initial_array is None, object is not initialized.
                 Otherwise, _initial_array (ndarray) would be set to
                 _cupy_array and/or _numpy_array depending upon _class.
-            _class (ndarray type): If _class is `cp.ndarray`, _initial_array is
-                set as _cupy_array and _numpy_array. Otherwise, _initial_array is
-                set as only _numpy_array. Intended values for _class are
-                `np.ndarray`, `np.ma.MaskedArray`, `np.matrix`,
-                `np.chararray`, `np.recarray`.
+            _class (ndarray type): If _class is `cp.ndarray`, _initial_array
+                is set as _cupy_array and _numpy_array.
+                Otherwise, _initial_array is set as only _numpy_array.
+                Intended values for _class are `np.ndarray`,
+                `np.ma.MaskedArray`, `np.matrix`, `np.chararray`,
+                `np.recarray`.
 
         Attributes:
             _cupy_array (None or cp.ndarray): ndarray fully compatible with
@@ -210,11 +212,13 @@ class ndarray(object):
         assert isinstance(_initial_array, (cp.ndarray, np.ndarray))
         if _class is cp.ndarray:
             if type(_initial_array) is cp.ndarray:
-                # _initial_array is in GPU memory (caller _store_array_from_cupy)
+                # _initial_array is in GPU memory
+                # called by _store_array_from_cupy
                 self._cupy_array = _initial_array
                 self._remember_numpy = False
             else:
-                # _initial_array is in CPU memory (caller _store_array_from_numpy)
+                # _initial_array is in CPU memory
+                # called by _store_array_from_numpy
                 self._numpy_array = _initial_array
                 self._cupy_array = cp.array(_initial_array)
                 self._remember_numpy = True

--- a/cupyx/fallback_mode/fallback.py
+++ b/cupyx/fallback_mode/fallback.py
@@ -144,17 +144,21 @@ class ndarray(object):
         return cls(_stored=cupy_ndarray_init, _class=cp.ndarray)
 
     def __init__(self, *args, **kwargs):
+
+        _class = kwargs.pop('_class', None)
+        _stored = kwargs.pop('_stored', None)
+        if _stored is None:
+            return
+
         self._cupy_array = None
         self._numpy_array = None
-        self._class = kwargs.pop('_class', None)
+        self._class = _class
 
-        _stored = kwargs.pop('_stored', None)
-        if _stored is not None:
-            if self._class is cp.ndarray:
-                self._cupy_array = _stored
-                self._latest = 'cupy'
-            else:
-                self._numpy_array = _stored
+        if _class is cp.ndarray:
+            self._cupy_array = _stored
+            self._latest = 'cupy'
+        else:
+            self._numpy_array = _stored
 
     @classmethod
     def _store_cupy_array(cls, array):

--- a/tests/cupyx_tests/fallback_mode_tests/test_fallback.py
+++ b/tests/cupyx_tests/fallback_mode_tests/test_fallback.py
@@ -628,3 +628,13 @@ class TestArrayVariants(unittest.TestCase):
     def test_record_array(self, xp):
         ra = xp.rec.array([1, 2, 3])
         return ra
+
+    # changes in MaskedArray should be reflected in base ndarray
+    @numpy_fallback_array_equal()
+    def test_ma_func(self, xp):
+        x = xp.array([1, 2, 3, 4])
+        x += x
+        mx = xp.ma.array(x, mask=[1, 0, 1, 0])
+        assert mx.base is x
+        mx += mx
+        return x

--- a/tests/cupyx_tests/fallback_mode_tests/test_fallback.py
+++ b/tests/cupyx_tests/fallback_mode_tests/test_fallback.py
@@ -237,21 +237,21 @@ class FallbackArray(unittest.TestCase):
 
         a = fallback_mode.numpy.array([[1, 2], [3, 4]])
         assert isinstance(a, fallback.ndarray)
-        assert a._class is cupy.ndarray
+        assert a._supports_cupy
 
         b = fallback_mode.numpy.arange(9)
         assert isinstance(b, fallback.ndarray)
-        assert a._class is cupy.ndarray
+        assert a._supports_cupy
 
     def test_ndarray_creation_not_compatible(self):
 
         a = fallback_mode.numpy.array([1, 2, 3], dtype=object)
         assert isinstance(a, fallback.ndarray)
-        assert a._class is numpy.ndarray
+        assert not a._supports_cupy
 
         b = fallback_mode.numpy.array(['a', 'b', 'c', 'd'], dtype='|S1')
         assert isinstance(b, fallback.ndarray)
-        assert b._class is numpy.ndarray
+        assert not b._supports_cupy
 
         # Structured array will automatically be _numpy_array
         c = fallback_mode.numpy.array(
@@ -259,7 +259,7 @@ class FallbackArray(unittest.TestCase):
             dtype=[('name', 'U10'), ('age', 'i4'), ('weight', 'f4')])
 
         assert isinstance(c, fallback.ndarray)
-        assert c._class is numpy.ndarray
+        assert not c._supports_cupy
 
     def test_getitem(self):
 
@@ -632,9 +632,10 @@ class TestArrayVariants(unittest.TestCase):
         y = xp.asmatrix(x)
 
         if xp is fallback_mode.numpy:
-            assert x._class is cupy.ndarray
+            assert x._supports_cupy
             assert isinstance(y, fallback.ndarray)
-            assert y._class is numpy.matrix
+            assert not y._supports_cupy
+            assert y._numpy_array.__class__ is numpy.matrix
 
         return y
 

--- a/tests/cupyx_tests/fallback_mode_tests/test_fallback.py
+++ b/tests/cupyx_tests/fallback_mode_tests/test_fallback.py
@@ -318,6 +318,12 @@ class FallbackArray(unittest.TestCase):
         a = xp.array([1, 2, 3])
         return type(a) == xp.ndarray
 
+    @numpy_fallback_equal()
+    def test_base(self, xp):
+        a = xp.arange(7)
+        b = a[2:]
+        return b.base is a
+
 
 @testing.parameterize(
     {'func': 'min', 'shape': (5,), 'args': (), 'kwargs': {}},

--- a/tests/cupyx_tests/fallback_mode_tests/test_fallback.py
+++ b/tests/cupyx_tests/fallback_mode_tests/test_fallback.py
@@ -71,7 +71,7 @@ def numpy_fallback_array_equal(name='xp'):
                 # if numpy returns scalar
                 # cupy may return 0-dim array
                 assert numpy_result == fallback_result._cupy_array.item() or \
-                       (numpy_result == fallback_result._numpy_array).all()
+                    (numpy_result == fallback_result._numpy_array).all()
 
             else:
                 assert False
@@ -228,12 +228,13 @@ class FallbackArray(unittest.TestCase):
         assert a._class is numpy.ndarray
 
         b = fallback_mode.numpy.array(['a', 'b', 'c', 'd'], dtype='|S1')
-        assert isinstance(a, fallback.ndarray)
-        assert a._class is numpy.ndarray
+        assert isinstance(b, fallback.ndarray)
+        assert b._class is numpy.ndarray
 
         # Structured array will automatically be _numpy_array
-        c = fallback_mode.numpy.array([('Rex', 9, 81.0), ('Fido', 3, 27.0)],
-             dtype=[('name', 'U10'), ('age', 'i4'), ('weight', 'f4')])
+        c = fallback_mode.numpy.array(
+            [('Rex', 9, 81.0), ('Fido', 3, 27.0)],
+            dtype=[('name', 'U10'), ('age', 'i4'), ('weight', 'f4')])
 
         assert isinstance(c, fallback.ndarray)
         assert c._class is numpy.ndarray

--- a/tests/cupyx_tests/fallback_mode_tests/test_fallback.py
+++ b/tests/cupyx_tests/fallback_mode_tests/test_fallback.py
@@ -295,9 +295,10 @@ class FallbackArray(unittest.TestCase):
 
         return x.shape
 
-    @numpy_fallback_array_allclose()
+    @numpy_fallback_equal()
     def test_ndarray_init(self, xp):
-        return xp.ndarray((3, 4))
+        a = xp.ndarray((3, 4))
+        return a.shape
 
     @numpy_fallback_equal()
     def test_ndarray_shape_creation(self, xp):
@@ -316,10 +317,11 @@ class FallbackArray(unittest.TestCase):
         a = fallback_mode.numpy.arange(3)
         assert isinstance(a, type(a))
 
-    @numpy_fallback_array_allclose()
+    @numpy_fallback_equal()
     def test_type_call(self, xp):
         a = xp.array([1])
-        return type(a)((2, 3))
+        b = type(a)((2, 3))
+        return b.shape
 
     @numpy_fallback_equal()
     def test_type_assert(self, xp):

--- a/tests/cupyx_tests/fallback_mode_tests/test_fallback.py
+++ b/tests/cupyx_tests/fallback_mode_tests/test_fallback.py
@@ -577,7 +577,7 @@ class TestInplaceSpecialMethods(unittest.TestCase):
 
     @numpy_fallback_array_allclose()
     def test_out_is_returned_when_not_fallbacked(self, xp):
-        a = testing.shaped_random((3, 4), xp)
+        a = testing.shaped_random((3, 4), xp, dtype=xp.float64)
         z = xp.zeros((4,))
         res = xp.var(a, axis=0, out=z)
         assert res is z


### PR DESCRIPTION
**EDIT:**
I've fixed the bug associated with `ndarray.__init__`.

**ORIGINAL:**
This PR is related to #2066 
This PR will support use of `numpy.MaskedArray`, `numpy.chararray`, `numpy.recarray`, `numpy.matrix`. Also, there will be some performance improvement when an `ndarray` is fallbacked consecutively.
And structure of `fallback.ndarray` is changed so that, it doesn't need to explicitly check for in-place updates. In-place changes to an `ndarray` will be confirmed before dispatching it for function execution (both `cupy` and `numpy`) including functions such as `__repr__`.

TO-DO:
* ~~Fix `ndarray` creation using `cupy.ndarray.__init__`, currently all attributes are returned as `NoneType`.~~

Recent changes caused this issue. Currently working to figure it out.