### PR TITLE
Small fix of `fusion.pyx` and docs

### DIFF
--- a/cupy/core/fusion.pyx
+++ b/cupy/core/fusion.pyx
@@ -533,7 +533,7 @@ class _FusionHistory(object):
                       (float, bool, complex, numpy.generic)):
             var = self._fresh_local(numpy.dtype(type(arg)), const_value=arg)
             return _FusionVarScalar(var, -1, self._has_reduction())
-        raise Exception('Unsupported type {}'.format(type(arg)))
+        raise TypeError('Unsupported type {}'.format(type(arg)))
 
     def call_ufunc(self, ufunc, args, kwargs):
         nin = ufunc.nin

--- a/cupy/core/fusion.pyx
+++ b/cupy/core/fusion.pyx
@@ -515,7 +515,7 @@ class _FusionHistory(object):
         self.preamble_set.add(preamble)
 
     def _get_fusion_var(self, arg):
-        """This converts `arg` to _FusionVarScalr or _FusionVarArray data.
+        """This converts `arg` to _FusionVarScalar or _FusionVarArray data.
 
         Args:
             arg (_FusionVarScalar, _FusionVarArray or a primitive type)

--- a/cupy/core/fusion.pyx
+++ b/cupy/core/fusion.pyx
@@ -162,7 +162,7 @@ class _FusionOp(object):
 
     def __repr__(self):
         return '<_FusionOp #{}, {} types=[{}]>'.format(
-            self.index, self.submodule.name, ', '.join(self.dtypes))
+            self.index, self.submodule.name, ', '.join(map(str, self.dtypes)))
 
     def declaration_args(self):
         return ' '.join('{} v{}_{};'.format(_dtype_to_ctype[t], self.index, j)
@@ -533,7 +533,7 @@ class _FusionHistory(object):
                       (float, bool, complex, numpy.generic)):
             var = self._fresh_local(numpy.dtype(type(arg)), const_value=arg)
             return _FusionVarScalar(var, -1, self._has_reduction())
-        raise Exception('Unsupported type {}'.format(type(type)))
+        raise Exception('Unsupported type {}'.format(type(arg)))
 
     def call_ufunc(self, ufunc, args, kwargs):
         nin = ufunc.nin

--- a/cupy/core/fusion.pyx
+++ b/cupy/core/fusion.pyx
@@ -432,8 +432,8 @@ class _FusionHistory(object):
         self.postmap_local_list = []
 
     def __repr__(self):
-        return '<_FusionMem, op_list={}, var_list={}>'.format(
-            self.op_list, self.var_list)
+        return '<_FusionMem, op_list={}, param_list={}, local_list={}>'.format(
+            self.op_list, self.param_list, self.local_list)
 
     def _has_reduction(self):
         return self.reduce_op is not None

--- a/cupy/core/include/cupy/complex/complex.h
+++ b/cupy/core/include/cupy/complex/complex.h
@@ -238,7 +238,7 @@ __device__ inline complex<T> operator*(const complex<T>& lhs,
 template <typename T>
 __device__ inline complex<T> operator*(const complex<T>& lhs, const T& rhs);
 
-/*! Multiplies a scalr by a \p complex number.
+/*! Multiplies a scalar by a \p complex number.
  *
  *  \param lhs The scalar.
  *  \param rhs The \p complex.

--- a/docs/source/tutorial/kernel.rst
+++ b/docs/source/tutorial/kernel.rst
@@ -186,9 +186,9 @@ In other words, you have control over grid size, block size, shared memory size 
    ...     y[tid] = x1[tid] + x2[tid];
    ... }
    ... ''', 'my_add')
-   >>> x1 = cupy.arange(25, dtype=cupy.float32).reshape(5, 5)
-   >>> x2 = cupy.arange(25, dtype=cupy.float32).reshape(5, 5)
-   >>> y = cupy.zeros((5, 5), dtype=cupy.float32)
+   >>> x1 = cp.arange(25, dtype=cp.float32).reshape(5, 5)
+   >>> x2 = cp.arange(25, dtype=cp.float32).reshape(5, 5)
+   >>> y = cp.zeros((5, 5), dtype=cp.float32)
    >>> add_kernel((5,), (5,), (x1, x2, y))  # grid, block and arguments
    >>> y
    array([[ 0.,  2.,  4.,  6.,  8.],
@@ -246,7 +246,7 @@ At the first function call, the fused function analyzes the original function ba
 
    >>> @cp.fuse()
    ... def sum_of_products(x, y):
-   ...     return cupy.sum(x * y, axis = -1)
+   ...     return cp.sum(x * y, axis = -1)
 
 You can specify the kernel name by using the ``kernel_name`` keyword argument as follows:
 


### PR DESCRIPTION
For docs, I replaced all `cupy.~` by `cp.~` in `kernel.rst` when it is used in code example, as `basics.rst` does so.