### PR TITLE
Change check condition of `accept_error`

### DIFF
--- a/cupy/testing/helper.py
+++ b/cupy/testing/helper.py
@@ -41,12 +41,23 @@ def _call_func(self, impl, args, kw):
     return result, error, tb_str
 
 
-# List of exception classes numpy and cupy routines raise.
-_numpy_errors = [
-    AttributeError, Exception, IndexError, TypeError, ValueError,
-    NotImplementedError, DeprecationWarning,
-    numpy.AxisError, numpy.linalg.LinAlgError,
-]
+# Returns the list of exception classes numpy and cupy routines raise.
+def _get_numpy_errors():
+    errors = [
+        AttributeError, Exception, IndexError, TypeError, ValueError,
+        NotImplementedError, DeprecationWarning,
+    ]
+
+    numpy_version = numpy.lib.NumpyVersion(numpy.__version__)
+    if numpy_version >= '1.13.0':
+        errors.append(numpy.AxisError)
+    if numpy_version >= '1.15.0':
+        errors.append(numpy.linalg.LinAlgError)
+
+    return errors
+
+
+_numpy_errors = _get_numpy_errors()
 
 
 def _check_cupy_numpy_error(self, cupy_error, cupy_tb, numpy_error,

--- a/cupy/testing/helper.py
+++ b/cupy/testing/helper.py
@@ -41,6 +41,7 @@ def _call_func(self, impl, args, kw):
     return result, error, tb_str
 
 
+# List of exception classes numpy and cupy routines raise.
 _numpy_errors = [
     AttributeError, Exception, IndexError, TypeError, ValueError,
     NotImplementedError, DeprecationWarning,
@@ -65,6 +66,8 @@ def _check_cupy_numpy_error(self, cupy_error, cupy_tb, numpy_error,
 
     elif any([isinstance(cupy_error, err) != isinstance(numpy_error, err)
               for err in _numpy_errors]):
+        # Checks if there is no error in `_numpy_errors`, which only one of
+        # `cupy_error` and `numpy_error` is a instance of.
         msg = '''Different types of errors occurred
 
 cupy

--- a/tests/cupy_tests/testing_tests/test_helper.py
+++ b/tests/cupy_tests/testing_tests/test_helper.py
@@ -157,6 +157,69 @@ class TestCheckCupyNumpyError(unittest.TestCase):
         with six.assertRaisesRegex(self, AssertionError, pattern):
             dummy_forbidden_error(self)
 
+    def test_axis_error_different_type(self):
+        @testing.helper.numpy_cupy_raises()
+        def dummy_axis_error(self, xp):
+            if xp is cupy:
+                raise cupy.core._errors._AxisError(self.tbs.get(cupy))
+            elif xp is numpy:
+                raise TypeError(self.tbs.get(numpy))
+
+        pattern = re.compile(
+            self.tbs.get(cupy) + '.*' + self.tbs.get(numpy), re.S)
+        with six.assertRaisesRegex(self, AssertionError, pattern):
+            dummy_axis_error(self)
+
+    @testing.with_requires('numpy>=1.13')
+    def test_axis_error_value_different_type(self):
+        @testing.helper.numpy_cupy_raises()
+        def dummy_axis_error(self, xp):
+            if xp is cupy:
+                raise cupy.core._errors._AxisError(self.tbs.get(cupy))
+            elif xp is numpy:
+                raise ValueError(self.tbs.get(numpy))
+
+        pattern = re.compile(
+            self.tbs.get(cupy) + '.*' + self.tbs.get(numpy), re.S)
+        with six.assertRaisesRegex(self, AssertionError, pattern):
+            dummy_axis_error(self)
+
+    @testing.with_requires('numpy>=1.13')
+    def test_axis_error_index_different_type(self):
+        @testing.helper.numpy_cupy_raises()
+        def dummy_axis_error(self, xp):
+            if xp is cupy:
+                raise cupy.core._errors._AxisError(self.tbs.get(cupy))
+            elif xp is numpy:
+                raise IndexError(self.tbs.get(numpy))
+
+        pattern = re.compile(
+            self.tbs.get(cupy) + '.*' + self.tbs.get(numpy), re.S)
+        with six.assertRaisesRegex(self, AssertionError, pattern):
+            dummy_axis_error(self)
+
+    @testing.with_requires('numpy<1.13')
+    def test_axis_error_value(self):
+        @testing.helper.numpy_cupy_raises()
+        def dummy_axis_error(self, xp):
+            if xp is cupy:
+                raise cupy.core._errors._AxisError(self.tbs.get(cupy))
+            elif xp is numpy:
+                raise ValueError(self.tbs.get(numpy))
+
+        dummy_axis_error(self)
+
+    @testing.with_requires('numpy<1.13')
+    def test_axis_error_index(self):
+        @testing.helper.numpy_cupy_raises()
+        def dummy_axis_error(self, xp):
+            if xp is cupy:
+                raise cupy.core._errors._AxisError(self.tbs.get(cupy))
+            elif xp is numpy:
+                raise IndexError(self.tbs.get(numpy))
+
+        dummy_axis_error(self)
+
 
 class NumPyCuPyDecoratorBase(object):
 

--- a/tests/cupy_tests/testing_tests/test_helper.py
+++ b/tests/cupy_tests/testing_tests/test_helper.py
@@ -9,6 +9,14 @@ from cupy import testing
 from cupy.testing import helper
 
 
+class _Exception1(Exception):
+    pass
+
+
+class _Exception2(Exception):
+    pass
+
+
 class TestContainsSignedAndUnsigned(unittest.TestCase):
 
     def test_include(self):
@@ -81,9 +89,9 @@ class TestCheckCupyNumpyError(unittest.TestCase):
         @testing.helper.numpy_cupy_raises()
         def dummy_cupy_derived_error(self, xp):
             if xp is cupy:
-                raise ValueError(self.tbs.get(cupy))
+                raise _Exception1(self.tbs.get(cupy))
             elif xp is numpy:
-                raise Exception(self.tbs.get(numpy))
+                raise _Exception2(self.tbs.get(numpy))
 
         dummy_cupy_derived_error(self)  # Assert no exceptions
 


### PR DESCRIPTION
Another solution for #2377.
Related to #2376, #2379.

Currently, `accept_error` requires the type of `cupy_error` to be a sub-type that of `numpy_error`. This behavior is inconvenient for us when the target NumPy's function raises an error of NumPy's private exception class.
This PR relaxes this check condition of `accept_error`.