### PR TITLE
Increase numbers of retries for K-S tests

### DIFF
--- a/tests/cupy_tests/random_tests/test_generator.py
+++ b/tests/cupy_tests/random_tests/test_generator.py
@@ -237,7 +237,7 @@ class TestBeta(RandomGeneratorTestCase):
         self.generate(a=self.a, b=self.b, size=(3, 2))
 
     @testing.for_dtypes('fd')
-    @condition.repeat_with_success_at_least(5, 3)
+    @condition.repeat_with_success_at_least(10, 3)
     def test_beta_ks(self, dtype):
         self.check_ks(0.05)(
             a=self.a, b=self.b, size=2000, dtype=dtype)
@@ -276,7 +276,7 @@ class TestChisquare(RandomGeneratorTestCase):
         self.generate(df=self.df, size=(3, 2))
 
     @testing.for_dtypes('fd')
-    @condition.repeat_with_success_at_least(5, 3)
+    @condition.repeat_with_success_at_least(10, 3)
     def test_chisquare_ks(self, dtype):
         self.check_ks(0.05)(
             df=self.df, size=2000, dtype=dtype)
@@ -313,7 +313,7 @@ class TestExponential(RandomGeneratorTestCase):
         self.generate(scale=self.scale, size=(3, 2))
 
     @testing.for_dtypes('fd')
-    @condition.repeat_with_success_at_least(5, 3)
+    @condition.repeat_with_success_at_least(10, 3)
     def test_exponential_ks(self, dtype):
         self.check_ks(0.05)(
             self.scale, size=2000, dtype=dtype)
@@ -334,7 +334,7 @@ class TestF(RandomGeneratorTestCase):
         self.generate(dfnum=self.dfnum, dfden=self.dfden, size=(3, 2))
 
     @testing.for_dtypes('fd')
-    @condition.repeat_with_success_at_least(5, 3)
+    @condition.repeat_with_success_at_least(10, 3)
     def test_f_ks(self, dtype):
         self.check_ks(0.05)(
             self.dfnum, self.dfden, size=2000, dtype=dtype)
@@ -364,7 +364,7 @@ class TestGamma(RandomGeneratorTestCase):
         self.generate(shape=self.shape, size=(3, 2))
 
     @testing.for_dtypes('fd')
-    @condition.repeat_with_success_at_least(5, 3)
+    @condition.repeat_with_success_at_least(10, 3)
     def test_gamma_ks(self, dtype):
         self.check_ks(0.05)(
             self.shape, self.scale, size=2000, dtype=dtype)
@@ -385,7 +385,7 @@ class TestGeometric(RandomGeneratorTestCase):
         self.generate(p=self.p, size=(3, 2))
 
     @testing.for_dtypes('fd')
-    @condition.repeat_with_success_at_least(5, 3)
+    @condition.repeat_with_success_at_least(10, 3)
     def test_geometric_ks(self, dtype):
         self.check_ks(0.05)(
             p=self.p, size=2000, dtype=dtype)
@@ -421,13 +421,13 @@ class TestLaplace(RandomGeneratorTestCase):
         self.generate(0.0, 1.0, size=(3, 2))
 
     @testing.for_dtypes('fd')
-    @condition.repeat_with_success_at_least(5, 3)
+    @condition.repeat_with_success_at_least(10, 3)
     def test_laplace_ks_1(self, dtype):
         self.check_ks(0.05)(
             size=2000, dtype=dtype)
 
     @testing.for_dtypes('fd')
-    @condition.repeat_with_success_at_least(5, 3)
+    @condition.repeat_with_success_at_least(10, 3)
     def test_laplace_ks_2(self, dtype):
         self.check_ks(0.05)(
             2.3, 4.5, size=2000, dtype=dtype)
@@ -452,13 +452,13 @@ class TestLogistic(RandomGeneratorTestCase):
         self.assertTrue(cupy.isfinite(x).all())
 
     @testing.for_dtypes('fd')
-    @condition.repeat_with_success_at_least(5, 3)
+    @condition.repeat_with_success_at_least(10, 3)
     def test_logistic_ks_1(self, dtype):
         self.check_ks(0.05)(
             size=2000, dtype=dtype)
 
     @testing.for_dtypes('fd')
-    @condition.repeat_with_success_at_least(5, 3)
+    @condition.repeat_with_success_at_least(10, 3)
     def test_logistic_ks_2(self, dtype):
         self.check_ks(0.05)(
             2.3, 4.5, size=2000, dtype=dtype)
@@ -500,7 +500,7 @@ class TestLogNormal(RandomGeneratorTestCase):
         self.check_lognormal(numpy.float64)
 
     @testing.for_dtypes('fd')
-    @condition.repeat_with_success_at_least(5, 3)
+    @condition.repeat_with_success_at_least(10, 3)
     def test_lognormal_ks(self, dtype):
         self.check_ks(0.05)(
             *self.args, size=self.size, dtype=dtype)
@@ -590,7 +590,7 @@ class TestNoncentralChisquare(RandomGeneratorTestCase):
         self.generate(df=self.df, nonc=self.nonc, size=(3, 2))
 
     @testing.for_dtypes('fd')
-    @condition.repeat_with_success_at_least(5, 3)
+    @condition.repeat_with_success_at_least(10, 3)
     def test_noncentral_chisquare_ks(self, dtype):
         self.check_ks(0.05)(
             self.df, self.nonc, size=2000, dtype=dtype)
@@ -611,7 +611,7 @@ class TestNoncentralF(RandomGeneratorTestCase):
             dfnum=self.dfnum, dfden=self.dfden, nonc=self.nonc, size=(3, 2))
 
     @testing.for_dtypes('fd')
-    @condition.repeat_with_success_at_least(5, 3)
+    @condition.repeat_with_success_at_least(10, 3)
     def test_noncentral_f_ks(self, dtype):
         self.check_ks(0.05)(
             self.dfnum, self.dfden, self.nonc, size=2000, dtype=dtype)
@@ -649,7 +649,7 @@ class TestNormal(RandomGeneratorTestCase):
         self.check_normal(numpy.float64)
 
     @testing.for_dtypes('fd')
-    @condition.repeat_with_success_at_least(5, 3)
+    @condition.repeat_with_success_at_least(10, 3)
     def test_normal_ks(self, dtype):
         self.check_ks(0.05)(
             *self.args, size=self.size, dtype=dtype)
@@ -670,7 +670,7 @@ class TestPareto(RandomGeneratorTestCase):
         self.generate(a=self.a, size=(3, 2))
 
     @testing.for_dtypes('fd')
-    @condition.repeat_with_success_at_least(5, 3)
+    @condition.repeat_with_success_at_least(10, 3)
     def test_pareto_ks(self, dtype):
         self.check_ks(0.05)(
             a=self.a, size=2000, dtype=dtype)
@@ -708,7 +708,7 @@ class TestStandardT(RandomGeneratorTestCase):
         self.generate(df=self.df, size=(3, 2))
 
     @testing.for_dtypes('fd')
-    @condition.repeat_with_success_at_least(5, 3)
+    @condition.repeat_with_success_at_least(10, 3)
     def test_standard_t_ks(self, dtype):
         self.check_ks(0.05)(
             df=self.df, size=2000, dtype=dtype)
@@ -750,7 +750,7 @@ class TestRandomSample(unittest.TestCase):
 class TestRandomSampleDistrib(unittest.TestCase):
 
     @testing.for_dtypes('fd')
-    @condition.repeat_with_success_at_least(5, 3)
+    @condition.repeat_with_success_at_least(10, 3)
     @numpy_cupy_equal_continuous_distribution(0.05)
     def test_random_sample_ks(self, xp, dtype):
         return _xp_random(xp, 'random_sample')(size=2000, dtype=dtype)
@@ -785,7 +785,7 @@ class TestPower(RandomGeneratorTestCase):
         self.generate(a=self.a, size=(3, 2))
 
     @testing.for_dtypes('fd')
-    @condition.repeat_with_success_at_least(5, 3)
+    @condition.repeat_with_success_at_least(10, 3)
     def test_power_ks(self, dtype):
         self.check_ks(0.05)(
             a=self.a, size=2000, dtype=dtype)
@@ -805,7 +805,7 @@ class TestRayleigh(RandomGeneratorTestCase):
         self.generate(scale=self.scale, size=(3, 2))
 
     @testing.for_dtypes('fd')
-    @condition.repeat_with_success_at_least(5, 3)
+    @condition.repeat_with_success_at_least(10, 3)
     def test_rayleigh_ks(self, dtype):
         self.check_ks(0.05)(
             scale=self.scale, size=2000, dtype=dtype)
@@ -827,7 +827,7 @@ class TestStandardCauchy(RandomGeneratorTestCase):
         self.assertTrue(cupy.isfinite(x).all())
 
     @testing.for_dtypes('fd')
-    @condition.repeat_with_success_at_least(5, 3)
+    @condition.repeat_with_success_at_least(10, 3)
     def test_standard_cauchy_ks(self, dtype):
         self.check_ks(0.05)(
             size=2000, dtype=dtype)
@@ -848,7 +848,7 @@ class TestStandardGamma(RandomGeneratorTestCase):
         self.generate(shape=self.shape, size=(3, 2))
 
     @testing.for_dtypes('fd')
-    @condition.repeat_with_success_at_least(5, 3)
+    @condition.repeat_with_success_at_least(10, 3)
     def test_standard_gamma_ks(self, dtype):
         self.check_ks(0.05)(
             shape=self.shape, size=2000, dtype=dtype)
@@ -1163,13 +1163,13 @@ class TestGumbel(RandomGeneratorTestCase):
         self.generate(0.0, 1.0, size=(3, 2))
 
     @testing.for_dtypes('fd')
-    @condition.repeat_with_success_at_least(5, 3)
+    @condition.repeat_with_success_at_least(10, 3)
     def test_gumbel_ks_1(self, dtype):
         self.check_ks(0.05)(
             size=2000, dtype=dtype)
 
     @testing.for_dtypes('fd')
-    @condition.repeat_with_success_at_least(5, 3)
+    @condition.repeat_with_success_at_least(10, 3)
     def test_gumbel_ks_2(self, dtype):
         self.check_ks(0.05)(
             2.3, 4.5, size=2000, dtype=dtype)
@@ -1207,13 +1207,13 @@ class TestUniform(RandomGeneratorTestCase):
         self.generate(-4.2, 2.4, size=(3, 2))
 
     @testing.for_dtypes('fd')
-    @condition.repeat_with_success_at_least(5, 3)
+    @condition.repeat_with_success_at_least(10, 3)
     def test_uniform_ks_1(self, dtype):
         self.check_ks(0.05)(
             size=2000, dtype=dtype)
 
     @testing.for_dtypes('fd')
-    @condition.repeat_with_success_at_least(5, 3)
+    @condition.repeat_with_success_at_least(10, 3)
     def test_uniform_ks_2(self, dtype):
         self.check_ks(0.05)(
             -4.2, 2.4, size=2000, dtype=dtype)
@@ -1234,7 +1234,7 @@ class TestVonmises(RandomGeneratorTestCase):
         self.generate(mu=self.mu, kappa=self.kappa, size=(3, 2))
 
     @testing.for_dtypes('fd')
-    @condition.repeat_with_success_at_least(5, 3)
+    @condition.repeat_with_success_at_least(10, 3)
     def test_vonmises_ks(self, dtype):
         self.check_ks(0.05)(
             self.mu, self.kappa, size=2000, dtype=dtype)
@@ -1255,7 +1255,7 @@ class TestWald(RandomGeneratorTestCase):
         self.generate(mean=self.mean, scale=self.scale, size=(3, 2))
 
     @testing.for_dtypes('fd')
-    @condition.repeat_with_success_at_least(5, 3)
+    @condition.repeat_with_success_at_least(10, 3)
     def test_wald_ks(self, dtype):
         self.check_ks(0.05)(
             self.mean, self.scale, size=2000, dtype=dtype)
@@ -1277,7 +1277,7 @@ class TestWeibull(RandomGeneratorTestCase):
         self.generate(a=self.a, size=(3, 2))
 
     @testing.for_dtypes('fd')
-    @condition.repeat_with_success_at_least(5, 3)
+    @condition.repeat_with_success_at_least(10, 3)
     def test_weibull_ks(self, dtype):
         self.check_ks(0.05)(
             a=self.a, size=2000, dtype=dtype)
@@ -1381,7 +1381,7 @@ class TestStandardExponential(RandomGeneratorTestCase):
         self.assertTrue(cupy.isfinite(x).all())
 
     @testing.for_dtypes('fd')
-    @condition.repeat_with_success_at_least(5, 3)
+    @condition.repeat_with_success_at_least(10, 3)
     def test_standard_exponential_ks(self, dtype):
         self.check_ks(0.05)(
             size=2000, dtype=dtype)


### PR DESCRIPTION
Each test added in #1300 theoretically fails with probability 0.1158125 %.  It seems OK to increase the numbers of retries because wrong implementation rarely passes K-S test with 2000 samples by chance.

Fix #2373.