### PR TITLE
implement diagonal method for cupyx.scipy.sparse.dia_matrix

### DIFF
--- a/cupyx/scipy/sparse/base.py
+++ b/cupyx/scipy/sparse/base.py
@@ -293,7 +293,15 @@ class spmatrix(object):
         raise NotImplementedError
 
     def diagonal(self, k=0):
-        """Returns the main diagonal of the matrix"""
+        """Returns the k-th diagonal of the matrix.
+
+        Args:
+            k (int, optional): Which diagonal to get, corresponding to elements
+            a[i, i+k]. Default: 0 (the main diagonal).
+
+        Returns:
+            cupy.ndarray : The k-th diagonal.
+        """
         return self.tocsr().diagonal(k=k)
 
     def dot(self, other):

--- a/cupyx/scipy/sparse/base.py
+++ b/cupyx/scipy/sparse/base.py
@@ -292,9 +292,9 @@ class spmatrix(object):
         """Number of non-zero entries, equivalent to"""
         raise NotImplementedError
 
-    def diagonal(self):
+    def diagonal(self, k=0):
         """Returns the main diagonal of the matrix"""
-        return self.tocsr().diagonal()
+        return self.tocsr().diagonal(k=k)
 
     def dot(self, other):
         """Ordinary dot product"""

--- a/cupyx/scipy/sparse/csr.py
+++ b/cupyx/scipy/sparse/csr.py
@@ -145,9 +145,11 @@ class csr_matrix(compressed._compressed_sparse_matrix):
     # TODO(unno): Implement argmin
     # TODO(unno): Implement check_format
 
-    def diagonal(self):
+    def diagonal(self, k=0):
         # TODO(unno): Implement diagonal
         raise NotImplementedError
+
+    diagonal.__doc__ = base.spmatrix.diagonal.__doc__
 
     def eliminate_zeros(self):
         """Removes zero entories in place."""

--- a/cupyx/scipy/sparse/csr.py
+++ b/cupyx/scipy/sparse/csr.py
@@ -149,8 +149,6 @@ class csr_matrix(compressed._compressed_sparse_matrix):
         # TODO(unno): Implement diagonal
         raise NotImplementedError
 
-    diagonal.__doc__ = base.spmatrix.diagonal.__doc__
-
     def eliminate_zeros(self):
         """Removes zero entories in place."""
         compress = cusparse.csr2csr_compress(self, 0)

--- a/cupyx/scipy/sparse/dia.py
+++ b/cupyx/scipy/sparse/dia.py
@@ -6,6 +6,7 @@ except ImportError:
 
 import cupy
 from cupy import core
+from cupyx.scipy.sparse import base
 from cupyx.scipy.sparse import csc
 from cupyx.scipy.sparse import data
 from cupyx.scipy.sparse import util
@@ -189,6 +190,8 @@ class dia_matrix(data._data_matrix):
         if idx.size == 0:
             return cupy.zeros(last_col - first_col, dtype=self.data.dtype)
         return self.data[idx[0], first_col:last_col]
+
+    diagonal.__doc__ = base.spmatrix.diagonal.__doc__
 
 
 def isspmatrix_dia(x):

--- a/cupyx/scipy/sparse/dia.py
+++ b/cupyx/scipy/sparse/dia.py
@@ -6,7 +6,6 @@ except ImportError:
 
 import cupy
 from cupy import core
-from cupyx.scipy.sparse import base
 from cupyx.scipy.sparse import csc
 from cupyx.scipy.sparse import data
 from cupyx.scipy.sparse import util

--- a/cupyx/scipy/sparse/dia.py
+++ b/cupyx/scipy/sparse/dia.py
@@ -180,6 +180,16 @@ class dia_matrix(data._data_matrix):
         """
         return self.tocsc().tocsr()
 
+    def diagonal(self, k=0):
+        rows, cols = self.shape
+        if k <= -rows or k >= cols:
+            raise ValueError("k exceeds matrix dimensions")
+        idx, = cupy.nonzero(self.offsets == k)
+        first_col, last_col = max(0, k), min(rows + k, cols)
+        if idx.size == 0:
+            return cupy.zeros(last_col - first_col, dtype=self.data.dtype)
+        return self.data[idx[0], first_col:last_col]
+
 
 def isspmatrix_dia(x):
     """Checks if a given matrix is of DIA format.

--- a/cupyx/scipy/sparse/dia.py
+++ b/cupyx/scipy/sparse/dia.py
@@ -182,6 +182,15 @@ class dia_matrix(data._data_matrix):
         return self.tocsc().tocsr()
 
     def diagonal(self, k=0):
+        """Returns the k-th diagonal of the matrix.
+
+        Args:
+            k (int, optional): Which diagonal to get, corresponding to elements
+            a[i, i+k]. Default: 0 (the main diagonal).
+
+        Returns:
+            cupy.ndarray : The k-th diagonal.
+        """
         rows, cols = self.shape
         if k <= -rows or k >= cols:
             raise ValueError("k exceeds matrix dimensions")
@@ -190,8 +199,6 @@ class dia_matrix(data._data_matrix):
         if idx.size == 0:
             return cupy.zeros(last_col - first_col, dtype=self.data.dtype)
         return self.data[idx[0], first_col:last_col]
-
-    diagonal.__doc__ = base.spmatrix.diagonal.__doc__
 
 
 def isspmatrix_dia(x):

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_dia.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_dia.py
@@ -101,6 +101,20 @@ class TestDiaMatrix(unittest.TestCase):
         self.assertTrue(m.flags.c_contiguous)
         cupy.testing.assert_allclose(m, expect)
 
+    def test_diagonal(self):
+        testing.assert_array_equal(
+            self.m.diagonal(-2), cupy.array([0], self.dtype))
+        testing.assert_array_equal(
+            self.m.diagonal(-1), cupy.array([3, 4], self.dtype))
+        testing.assert_array_equal(
+            self.m.diagonal(), cupy.array([0, 1, 2], self.dtype))
+        testing.assert_array_equal(
+            self.m.diagonal(1), cupy.array([0, 0, 0], self.dtype))
+        testing.assert_array_equal(
+            self.m.diagonal(2), cupy.array([0, 0], self.dtype))
+        testing.assert_array_equal(
+            self.m.diagonal(3), cupy.array([0], self.dtype))
+
 
 @testing.parameterize(*testing.product({
     'dtype': [numpy.float32, numpy.float64, numpy.complex64, numpy.complex128],
@@ -245,6 +259,11 @@ class TestDiaMatrixScipyComparison(unittest.TestCase):
     def test_transpose(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
         return m.transpose()
+
+    @testing.numpy_cupy_raises(sp_name='sp')
+    def test_diagonal_error(self, xp, sp):
+        m = _make(xp, sp, self.dtype)
+        m.diagonal(k=10)  # out of range
 
 
 @testing.parameterize(*testing.product({

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_dia.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_dia.py
@@ -261,6 +261,7 @@ class TestDiaMatrixScipyComparison(unittest.TestCase):
         return m.transpose()
 
     @testing.numpy_cupy_raises(sp_name='sp')
+    @testing.with_requires('scipy>=1.0')
     def test_diagonal_error(self, xp, sp):
         m = _make(xp, sp, self.dtype)
         m.diagonal(k=10)  # out of range


### PR DESCRIPTION
This PR implements the `diagonal` method for the DIA sparse matrix type.

The ``k`` argument (introduced in SciPy 1.0) was also added to the base `spmatrix` class.