### PR TITLE
Fix `cupy.repeat` error message about `repeats` argument type

### DIFF
--- a/cupy/core/_routines_manipulation.pyx
+++ b/cupy/core/_routines_manipulation.pyx
@@ -496,6 +496,10 @@ cpdef ndarray _repeat(ndarray a, repeats, axis=None):
     """
     cdef ndarray ret
 
+    if isinstance(repeats, ndarray):
+        raise ValueError(
+            'cupy.ndaray cannot be specified as `repeats` argument.')
+
     # Scalar and size 1 'repeat' arrays broadcast to any shape, for all
     # other inputs the dimension must match exactly.
     cdef bint broadcast = False

--- a/tests/cupy_tests/manipulation_tests/test_tiling.py
+++ b/tests/cupy_tests/manipulation_tests/test_tiling.py
@@ -1,5 +1,8 @@
 import unittest
 
+import pytest
+
+import cupy
 from cupy import testing
 
 
@@ -19,6 +22,21 @@ class TestRepeat(unittest.TestCase):
     def test_array_repeat(self, xp):
         x = testing.shaped_arange((2, 3, 4), xp)
         return xp.repeat(x, self.repeats, self.axis)
+
+
+class TestRepeatRepeatsNdarray(unittest.TestCase):
+
+    def test_func(self):
+        a = testing.shaped_arange((2, 3, 4), cupy)
+        repeats = cupy.array([2, 3], dtype=cupy.int32)
+        with pytest.raises(ValueError, match=r'repeats'):
+            cupy.repeat(a, repeats)
+
+    def test_method(self):
+        a = testing.shaped_arange((2, 3, 4), cupy)
+        repeats = cupy.array([2, 3], dtype=cupy.int32)
+        with pytest.raises(ValueError, match=r'repeats'):
+            a.repeat(repeats)
 
 
 @testing.parameterize(


### PR DESCRIPTION
Fixes #2221