### PR TITLE
Bug: Fix `coosort`

### DIFF
--- a/cupy/cusparse.py
+++ b/cupy/cusparse.py
@@ -574,14 +574,16 @@ def coosort(x):
         handle, m, n, nnz, x.row.data.ptr, x.col.data.ptr)
     buf = cupy.empty(buffer_size, 'b')
     P = cupy.empty(nnz, 'i')
+    data_sorted = cupy.empty_like(x.data)
     cusparse.createIdentityPermutation(handle, nnz, P.data.ptr)
     cusparse.xcoosortByRow(
         handle, m, n, nnz, x.row.data.ptr, x.col.data.ptr,
         P.data.ptr, buf.data.ptr)
     _call_cusparse(
         'gthr', x.dtype,
-        handle, nnz, x.data.data.ptr, x.data.data.ptr,
+        handle, nnz, x.data.data.ptr, data_sorted.data.ptr,
         P.data.ptr, cusparse.CUSPARSE_INDEX_BASE_ZERO)
+    x.data = data_sorted
 
 
 def coo2csr(x):

--- a/cupy/cusparse.py
+++ b/cupy/cusparse.py
@@ -525,13 +525,14 @@ def csrsort(x):
         x.indices.data.ptr)
     buf = cupy.empty(buffer_size, 'b')
     P = cupy.empty(nnz, 'i')
+    data_orig = x.data.copy()
     cusparse.createIdentityPermutation(handle, nnz, P.data.ptr)
     cusparse.xcsrsort(
         handle, m, n, nnz, x._descr.descriptor, x.indptr.data.ptr,
         x.indices.data.ptr, P.data.ptr, buf.data.ptr)
     _call_cusparse(
         'gthr', x.dtype,
-        handle, nnz, x.data.data.ptr, x.data.data.ptr,
+        handle, nnz, data_orig.data.ptr, x.data.data.ptr,
         P.data.ptr, cusparse.CUSPARSE_INDEX_BASE_ZERO)
 
 
@@ -553,18 +554,19 @@ def cscsort(x):
         x.indices.data.ptr)
     buf = cupy.empty(buffer_size, 'b')
     P = cupy.empty(nnz, 'i')
+    data_orig = x.data.copy()
     cusparse.createIdentityPermutation(handle, nnz, P.data.ptr)
     cusparse.xcscsort(
         handle, m, n, nnz, x._descr.descriptor, x.indptr.data.ptr,
         x.indices.data.ptr, P.data.ptr, buf.data.ptr)
     _call_cusparse(
         'gthr', x.dtype,
-        handle, nnz, x.data.data.ptr, x.data.data.ptr,
+        handle, nnz, data_orig.data.ptr, x.data.data.ptr,
         P.data.ptr, cusparse.CUSPARSE_INDEX_BASE_ZERO)
 
 
 def coosort(x):
-    """Sorts indices of COO-matrix in place
+    """Sorts indices of COO-matrix in place.
 
     Args:
         x (cupyx.scipy.sparse.coo_matrix): A sparse matrix to sort.
@@ -580,7 +582,6 @@ def coosort(x):
         handle, m, n, nnz, x.row.data.ptr, x.col.data.ptr)
     buf = cupy.empty(buffer_size, 'b')
     P = cupy.empty(nnz, 'i')
-    # copy data to do safe in-place edits by gthr
     data_orig = x.data.copy()
     cusparse.createIdentityPermutation(handle, nnz, P.data.ptr)
     cusparse.xcoosortByRow(

--- a/tests/cupy_tests/test_cusparse.py
+++ b/tests/cupy_tests/test_cusparse.py
@@ -195,6 +195,7 @@ class TestCsrmv(unittest.TestCase):
         testing.assert_array_almost_equal(y, expect)
 
 
+@testing.with_requires('scipy')
 class TestCoosort(unittest.TestCase):
 
     def setUp(self):

--- a/tests/cupy_tests/test_cusparse.py
+++ b/tests/cupy_tests/test_cusparse.py
@@ -193,3 +193,19 @@ class TestCsrmv(unittest.TestCase):
         expect = self.alpha * self.op_a.dot(self.x) + self.beta * self.y
         self.assertIs(y, z)
         testing.assert_array_almost_equal(y, expect)
+
+
+class TestCoosort(unittest.TestCase):
+
+    def setUp(self):
+        self.a = scipy.sparse.random(
+            100, 100, density=0.9, dtype=numpy.float32, format='coo')
+
+    def test_coosort(self):
+        a = sparse.coo_matrix(self.a)
+        cupy.cusparse.coosort(a)
+        # lexsort by row first and col second
+        argsort = numpy.lexsort((self.a.col, self.a.row))
+        testing.assert_array_equal(self.a.row[argsort], a.row)
+        testing.assert_array_equal(self.a.col[argsort], a.col)
+        testing.assert_array_almost_equal(self.a.data[argsort], a.data)

--- a/tests/cupy_tests/test_cusparse.py
+++ b/tests/cupy_tests/test_cusparse.py
@@ -210,3 +210,41 @@ class TestCoosort(unittest.TestCase):
         testing.assert_array_equal(self.a.row[argsort], a.row)
         testing.assert_array_equal(self.a.col[argsort], a.col)
         testing.assert_array_almost_equal(self.a.data[argsort], a.data)
+
+
+@testing.with_requires('scipy')
+class TestCsrsort(unittest.TestCase):
+
+    def setUp(self):
+        self.a = scipy.sparse.random(
+            1, 1000, density=0.9, dtype=numpy.float32, format='csr')
+        numpy.random.shuffle(self.a.indices)
+        self.a.has_sorted_indices = False
+
+    def test_csrsort(self):
+        a = sparse.csr_matrix(self.a)
+        cupy.cusparse.csrsort(a)
+
+        self.a.sort_indices()
+        testing.assert_array_equal(self.a.indptr, a.indptr)
+        testing.assert_array_equal(self.a.indices, a.indices)
+        testing.assert_array_almost_equal(self.a.data, a.data)
+
+
+@testing.with_requires('scipy')
+class TestCscsort(unittest.TestCase):
+
+    def setUp(self):
+        self.a = scipy.sparse.random(
+            1000, 1, density=0.9, dtype=numpy.float32, format='csc')
+        numpy.random.shuffle(self.a.indices)
+        self.a.has_sorted_indices = False
+
+    def test_csrsort(self):
+        a = sparse.csc_matrix(self.a)
+        cupy.cusparse.cscsort(a)
+
+        self.a.sort_indices()
+        testing.assert_array_equal(self.a.indptr, a.indptr)
+        testing.assert_array_equal(self.a.indices, a.indices)
+        testing.assert_array_almost_equal(self.a.data, a.data)


### PR DESCRIPTION
Fixes #2005
Fixes #2365

Fix `coosort` by having `gthr` write to separated buffer instead of reading and writing to `x.data`
