### PR TITLE
Fixed `cupy.cuda.cufft.get_current_plan()` 

### DIFF
--- a/cupy/cuda/cufft.pyx
+++ b/cupy/cuda/cufft.pyx
@@ -9,8 +9,6 @@ from cupy.cuda cimport stream as stream_module
 
 
 cdef object _thread_local = threading.local()
-if not hasattr(_thread_local, '_current_plan'):
-    _thread_local._current_plan = None
 
 
 cpdef get_current_plan():
@@ -19,6 +17,8 @@ cpdef get_current_plan():
     Returns:
         None or cupy.cuda.cufft.Plan1d or cupy.cuda.cufft.PlanNd
     """
+    if not hasattr(_thread_local, '_current_plan'):
+        _thread_local._current_plan = None
     return _thread_local._current_plan
 
 

--- a/tests/cupy_tests/fft_tests/test_fft.py
+++ b/tests/cupy_tests/fft_tests/test_fft.py
@@ -710,3 +710,28 @@ class TestFftshift(unittest.TestCase):
         out = xp.fft.ifftshift(x, self.axes)
 
         return out
+
+
+class TestThreading(unittest.TestCase):
+
+    def test_threading1(self):
+        import threading
+        from cupy.cuda.cufft import get_current_plan
+
+        def thread_get_curr_plan():
+            return get_current_plan()
+
+        new_thread = threading.Thread(target=thread_get_curr_plan)
+        new_thread.start()
+
+    def test_threading2(self):
+        import threading
+
+        a = cupy.arange(100, dtype=cupy.complex64).reshape(10, 10)
+
+        def thread_do_fft():
+            b = cupy.fft.fftn(a)
+            return b
+
+        new_thread = threading.Thread(target=thread_do_fft)
+        new_thread.start()


### PR DESCRIPTION
Closes #2433, thanks to @elliottslaughter for reporting it. This bug appears in a multithreading setup and was an oversight of #2362. Now `cupy.cuda.cufft.get_current_plan()` works very much like this one: https://github.com/cupy/cupy/blob/a7d9fe0c6ff792b83bbe05f6029ae0a827512983/cupy/cudnn.pyx#L48-L51