### PR TITLE
Add NumPy 1.17.1 to skip list of 0-length `ifft` test

### DIFF
--- a/tests/cupy_tests/fft_tests/test_fft.py
+++ b/tests/cupy_tests/fft_tests/test_fft.py
@@ -75,7 +75,9 @@ class TestFft(unittest.TestCase):
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
                                  contiguous_check=False)
-    @testing.with_requires('numpy!=1.17.0')  # 1.17.0 raises ZeroDivisonError
+    # NumPy 1.17.0 and 1.17.1 raises ZeroDivisonError due to a bug
+    @testing.with_requires('numpy!=1.17.0')
+    @testing.with_requires('numpy!=1.17.1')
     def test_ifft(self, xp, dtype):
         a = testing.shaped_random(self.shape, xp, dtype)
         out = xp.fft.ifft(a, n=self.n, norm=self.norm)


### PR DESCRIPTION
Related: #2363, https://github.com/numpy/numpy/issues/14176