### PR TITLE
Normalize hidden layer strides in cuDNN RNN

### DIFF
--- a/cupy/cudnn.pyx
+++ b/cupy/cudnn.pyx
@@ -1015,7 +1015,7 @@ def rnn_forward_training(
         DropoutStates states, int direction_mode, int rnn_mode,
         core.ndarray hx, core.ndarray cx, core.ndarray w, core.ndarray xs,
         lengths):
-    hx = core._internal_ascontiguousarray(hx)
+    hx = _ascontiguousarray_normalized_strides(hx)
     if cx is not None:
         cx = core._internal_ascontiguousarray(cx)
     w = core._internal_ascontiguousarray(w)


### PR DESCRIPTION
Rel https://github.com/chainer/chainer/pull/5808 and #2261.

cuDNN requires the strides as '(8, 8, 4)' for a tensor with the shape as '(1, 1, 2)' where the tensor is C contiguous and its shape starts with ones. On the other hand, CuPy, as well as NumPy, allows the strides as '(4, 4, 4)' even if a ndarray is C contiguous in such a case.

The latter strides makes cuDNN RNN functions fail with `CUDNN_STATUS_BAD_PARAMS`.

This PR fixes the problem with normalizing the supplied ndarray so that it has the strides cuDNN expects as done in #2261.


