### PR TITLE
Fixed `TestDLTensorMemory.test_delete`

### DIFF
--- a/tests/cupy_tests/core_tests/test_dlpack.py
+++ b/tests/cupy_tests/core_tests/test_dlpack.py
@@ -32,13 +32,20 @@ class TestDLPackConversion(unittest.TestCase):
 
 class TestDLTensorMemory(unittest.TestCase):
 
+    def setUp(self):
+        self.old_pool = cupy.get_default_memory_pool()
+        self.pool = cupy.cuda.MemoryPool()
+        cupy.cuda.set_allocator(self.pool.malloc)
+
+    def tearDown(self):
+        cupy.cuda.set_allocator(self.old_pool.malloc)
+
     def test_deleter(self):
-        pool = cupy.get_default_memory_pool()
-        pool.free_all_blocks()
+        self.pool.free_all_blocks()
         array = cupy.empty(10)
         tensor = array.toDlpack()
-        assert pool.n_free_blocks() == 0
+        assert self.pool.n_free_blocks() == 0
         del array
-        assert pool.n_free_blocks() == 0
+        assert self.pool.n_free_blocks() == 0
         del tensor
-        assert pool.n_free_blocks() == 1
+        assert self.pool.n_free_blocks() == 1

--- a/tests/cupy_tests/core_tests/test_dlpack.py
+++ b/tests/cupy_tests/core_tests/test_dlpack.py
@@ -41,7 +41,6 @@ class TestDLTensorMemory(unittest.TestCase):
         cupy.cuda.set_allocator(self.old_pool.malloc)
 
     def test_deleter(self):
-        self.pool.free_all_blocks()
         array = cupy.empty(10)
         tensor = array.toDlpack()
         assert self.pool.n_free_blocks() == 0


### PR DESCRIPTION
Closes #2444 

In some cases, the default memory pool might not be empty after `free_all_blocks` is called. This is happening because the gc has yet to collect some dead objects and free their references so the pool chunks can be actually freed.

This solves the issue in Jenkins by creating a new pool only for this test.