### PR TITLE
Fix memory pool disabled during tests

### DIFF
--- a/tests/cupy_tests/cuda_tests/test_memory.py
+++ b/tests/cupy_tests/cuda_tests/test_memory.py
@@ -650,7 +650,7 @@ class TestAllocator(unittest.TestCase):
 
 
 @testing.gpu
-class TestAllocatorDefault(unittest.TestCase):
+class TestAllocatorDisabled(unittest.TestCase):
 
     def setUp(self):
         self.pool = cupy.get_default_memory_pool()

--- a/tests/cupy_tests/cuda_tests/test_memory.py
+++ b/tests/cupy_tests/cuda_tests/test_memory.py
@@ -612,12 +612,13 @@ class TestMemoryPool(unittest.TestCase):
 class TestAllocator(unittest.TestCase):
 
     def setUp(self):
+        self.old_pool = cupy.get_default_memory_pool()
         self.pool = memory.MemoryPool()
         memory.set_allocator(self.pool.malloc)
 
     def tearDown(self):
-        memory.set_allocator()
         self.pool.free_all_blocks()
+        memory.set_allocator(self.old_pool.malloc)
 
     def test_set_allocator(self):
         with cupy.cuda.Device(0):


### PR DESCRIPTION
* `TestAllocator` wrongly disables the memory pool in `tearDown`.
* Renamed `TestAllocatorDefault` to `TestAllocatorDisabled` as it intends to test behavior when memory pool is disabled.