### PR TITLE
support array-like start/stop and add axis argument to linspace

### DIFF
--- a/cupy/creation/ranges.py
+++ b/cupy/creation/ranges.py
@@ -145,11 +145,18 @@ def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None,
         raise ValueError('linspace with num<0 is not supported')
     div = (num - 1) if endpoint else num
 
-    if cupy.isscalar(start) and cupy.isscalar(stop):
+    scalar_start = cupy.isscalar(start)
+    scalar_stop = cupy.isscalar(stop)
+    if scalar_start and scalar_stop:
         return _linspace_scalar(start, stop, num, endpoint, retstep, dtype)
 
-    start = cupy.asarray(start) * 1.0
-    stop = cupy.asarray(stop) * 1.0
+    if not scalar_start:
+        if not (isinstance(start, cupy.ndarray) and start.dtype.kind == 'f'):
+            start = cupy.asarray(start) * 1.0
+
+    if not scalar_stop:
+        if not (isinstance(stop, cupy.ndarray) and stop.dtype.kind == 'f'):
+            stop = cupy.asarray(stop) * 1.0
 
     dt = cupy.result_type(start, stop, float(num))
     if dtype is None:

--- a/cupy/creation/ranges.py
+++ b/cupy/creation/ranges.py
@@ -120,22 +120,23 @@ def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None,
                 ret *= step
             else:
                 ret = ret * step
-
-        if endpoint:
-            ret[-1] = stop
     else:
         # 0 and 1 item long sequences have an undefined step
         step = float('nan')
         # Multiply with delta to allow possible override of output class.
         ret = ret * delta
 
+    ret += start
+    if endpoint and num > 1:
+        ret[-1] = stop
+
     if axis != 0:
         ret = cupy.moveaxis(ret, 0, axis)
 
     if retstep:
-        return ret, step
+        return ret.astype(dtype, copy=False), step
     else:
-        return ret
+        return ret.astype(dtype, copy=False)
 
 
 def logspace(start, stop, num=50, endpoint=True, base=10.0, dtype=None):

--- a/tests/cupy_tests/creation_tests/test_ranges.py
+++ b/tests/cupy_tests/creation_tests/test_ranges.py
@@ -145,6 +145,34 @@ class TestRanges(unittest.TestCase):
             x /= 2
         return xp.linspace(0., x, 10, dtype=float)
 
+    @testing.with_requires('numpy>=1.16')
+    @testing.numpy_cupy_array_equal()
+    def test_linspace_array_start_stop(self, xp):
+        start = xp.array([-120, 120], dtype="int8")
+        stop = xp.array([100, -100], dtype="int8")
+        return xp.linspace(start, stop, num=50, dtype=float)
+
+    @testing.with_requires('numpy>=1.16')
+    @testing.numpy_cupy_array_equal()
+    def test_linspace_mixed_start_stop(self, xp):
+        start = 0.0
+        stop = xp.array([100, -100], dtype="int8")
+        return xp.linspace(start, stop, num=50)
+
+    @testing.with_requires('numpy>=1.16')
+    @testing.numpy_cupy_array_equal()
+    def test_linspace_mixed_start_stop2(self, xp):
+        start = xp.array([-120, 120], dtype="int8")
+        stop = 0
+        return xp.linspace(start, stop, num=50)
+
+    @testing.with_requires('numpy>=1.16')
+    @testing.numpy_cupy_array_equal()
+    def test_linspace_array_start_stop_axis1(self, xp):
+        start = xp.array([-120, 120], dtype="int8")
+        stop = xp.array([100, -100], dtype="int8")
+        return xp.linspace(start, stop, num=50, dtype=float, axis=1)
+
     @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose()
     def test_logspace(self, xp, dtype):

--- a/tests/cupy_tests/creation_tests/test_ranges.py
+++ b/tests/cupy_tests/creation_tests/test_ranges.py
@@ -146,32 +146,62 @@ class TestRanges(unittest.TestCase):
         return xp.linspace(0., x, 10, dtype=float)
 
     @testing.with_requires('numpy>=1.16')
+    @testing.for_all_dtypes_combination(names=('dtype_range', 'dtype_out'),
+                                        no_bool=True, no_complex=True)
     @testing.numpy_cupy_array_equal()
-    def test_linspace_array_start_stop(self, xp):
-        start = xp.array([-120, 120], dtype="int8")
-        stop = xp.array([100, -100], dtype="int8")
-        return xp.linspace(start, stop, num=50, dtype=float)
+    def test_linspace_array_start_stop(self, xp, dtype_range, dtype_out):
+        start = xp.array([0, 120], dtype=dtype_range)
+        stop = xp.array([100, 0], dtype=dtype_range)
+        return xp.linspace(start, stop, num=50, dtype=dtype_out)
 
     @testing.with_requires('numpy>=1.16')
+    @testing.for_all_dtypes_combination(names=('dtype_range', 'dtype_out'),
+                                        no_bool=True, no_complex=True)
     @testing.numpy_cupy_array_equal()
-    def test_linspace_mixed_start_stop(self, xp):
+    def test_linspace_mixed_start_stop(self, xp, dtype_range, dtype_out):
         start = 0.0
-        stop = xp.array([100, -100], dtype="int8")
-        return xp.linspace(start, stop, num=50)
+        if xp.dtype(dtype_range).kind in 'u':
+            stop = xp.array([100, 16], dtype=dtype_range)
+        else:
+            stop = xp.array([100, -100], dtype=dtype_range)
+        return xp.linspace(start, stop, num=50, dtype=dtype_out)
 
     @testing.with_requires('numpy>=1.16')
+    @testing.for_all_dtypes_combination(names=('dtype_range', 'dtype_out'),
+                                        no_bool=True, no_complex=True)
     @testing.numpy_cupy_array_equal()
-    def test_linspace_mixed_start_stop2(self, xp):
-        start = xp.array([-120, 120], dtype="int8")
+    def test_linspace_mixed_start_stop2(self, xp, dtype_range, dtype_out):
+        if xp.dtype(dtype_range).kind in 'u':
+            start = xp.array([160, 120], dtype=dtype_range)
+        else:
+            start = xp.array([-120, 120], dtype=dtype_range)
         stop = 0
-        return xp.linspace(start, stop, num=50)
+        return xp.linspace(start, stop, num=50, dtype=dtype_out)
 
     @testing.with_requires('numpy>=1.16')
+    @testing.for_all_dtypes_combination(names=('dtype_range', 'dtype_out'),
+                                        no_bool=True, no_complex=True)
     @testing.numpy_cupy_array_equal()
-    def test_linspace_array_start_stop_axis1(self, xp):
-        start = xp.array([-120, 120], dtype="int8")
-        stop = xp.array([100, -100], dtype="int8")
-        return xp.linspace(start, stop, num=50, dtype=float, axis=1)
+    def test_linspace_array_start_stop_axis1(self, xp, dtype_range, dtype_out):
+        start = xp.array([0, 120], dtype=dtype_range)
+        stop = xp.array([100, 0], dtype=dtype_range)
+        return xp.linspace(start, stop, num=50, dtype=dtype_out, axis=1)
+
+    @testing.with_requires('numpy>=1.16')
+    @testing.for_complex_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_linspace_complex_start_stop(self, xp, dtype):
+        start = xp.array([0, 120], dtype=dtype)
+        stop = xp.array([100, 0], dtype=dtype)
+        return xp.linspace(start, stop, num=50, dtype=dtype)
+
+    @testing.with_requires('numpy>=1.16')
+    @testing.for_all_dtypes(no_bool=True)
+    @testing.numpy_cupy_array_equal()
+    def test_linspace_start_stop_list(self, xp, dtype):
+        start = [0, 0]
+        stop = [100, 16]
+        return xp.linspace(start, stop, num=50, dtype=dtype)
 
     @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose()


### PR DESCRIPTION
This supports array-like inputs and an `axis` argument in linspace as implemented in NumPy 1.16+.

closes #2446 

~I have marked this as WIP due to what is currently relatively slow performance for the array-like code path.~ (**edit:** slow for small `num`. For large enough `num`, cupy should always be faster)

A basic translation of the code from numpy 1.17 ends up being pretty slow for small arrays. It can be faster to just run `numpy.linspace` and transfer the result to the GPU in the case of array-like `start` and/or `stop` (as currently done in #2399).

For now, I check if both start & stop are scalars and run the current implementation as a fast path. This preserves performance for this common case, but results in some code duplication.
