### PR TITLE
Support complex dtypes in `cupy.linalg.inv()`

### DIFF
--- a/cupy/linalg/solve.py
+++ b/cupy/linalg/solve.py
@@ -288,7 +288,7 @@ def inv(a):
         getrf_bufferSize = cusolver.zgetrf_bufferSize
         getrs = cusolver.zgetrs
     else:
-        raise RuntimeError("unsupported dtype")
+        raise ValueError('unsupported dtype')
 
     m = a.shape[0]
 

--- a/cupy/linalg/solve.py
+++ b/cupy/linalg/solve.py
@@ -260,7 +260,8 @@ def inv(a):
     util._assert_rank2(a)
     util._assert_nd_squareness(a)
 
-    if a.dtype.char == 'f' or a.dtype.char == 'd':
+    # support float32, float64, complex64, and complex128
+    if a.dtype.char in 'fdFD':
         dtype = a.dtype.char
     else:
         dtype = numpy.find_common_type((a.dtype.char, 'f'), ()).char
@@ -274,10 +275,20 @@ def inv(a):
         getrf = cusolver.sgetrf
         getrf_bufferSize = cusolver.sgetrf_bufferSize
         getrs = cusolver.sgetrs
-    else:  # dtype == 'd'
+    elif dtype == 'd':
         getrf = cusolver.dgetrf
         getrf_bufferSize = cusolver.dgetrf_bufferSize
         getrs = cusolver.dgetrs
+    elif dtype == 'F':
+        getrf = cusolver.cgetrf
+        getrf_bufferSize = cusolver.cgetrf_bufferSize
+        getrs = cusolver.cgetrs
+    elif dtype == 'D':
+        getrf = cusolver.zgetrf
+        getrf_bufferSize = cusolver.zgetrf_bufferSize
+        getrs = cusolver.zgetrs
+    else:
+        raise RuntimeError("unsupported dtype")
 
     m = a.shape[0]
 

--- a/tests/cupy_tests/linalg_tests/test_solve.py
+++ b/tests/cupy_tests/linalg_tests/test_solve.py
@@ -82,7 +82,7 @@ class TestTensorSolve(unittest.TestCase):
 @testing.gpu
 class TestInv(unittest.TestCase):
 
-    @testing.for_float_dtypes(no_float16=True)
+    @testing.for_dtypes('fdFD')
     @condition.retry(10)
     def check_x(self, a_shape, dtype):
         a_cpu = numpy.random.randint(0, 10, size=a_shape).astype(dtype)


### PR DESCRIPTION
Closes #1903. Closes #2071. Closes #2464. 

Since this feature has been requested for multiple times, and it's not hard to fix (all needed Cython wrappers are already in place thanks to @rezoo's original commit), let us fix it once and for all.
