### PR TITLE
Remove global state from tests

### DIFF
--- a/tests/cupy_tests/cuda_tests/test_texture.py
+++ b/tests/cupy_tests/cuda_tests/test_texture.py
@@ -12,7 +12,6 @@ from cupy.cuda.texture import (ChannelFormatDescriptor, CUDAarray,
 
 
 dev = cupy.cuda.Device(runtime.getDevice())
-stream_for_async_cpy = cupy.cuda.Stream()
 
 
 @testing.gpu
@@ -27,7 +26,7 @@ stream_for_async_cpy = cupy.cuda.Stream()
 class TestCUDAarray(unittest.TestCase):
     def test_array_gen_cpy(self):
         xp = numpy if self.xp == 'numpy' else cupy
-        stream = None if not self.stream else stream_for_async_cpy
+        stream = None if not self.stream else cupy.cuda.Stream()
         width, height, depth = self.dimensions
         n_channel = self.n_channels
 


### PR DESCRIPTION
It seems pytest does not handle global states outside of unittest classes properly. When testing `test_texture.py` from my earlier PR #2432 locally, I kept observing a cleanup error after all tests passed (!):
```shell
leofang@macbook:~/cupy$ python -m pytest tests/cupy_tests/cuda_tests/
========================================================================= test session starts =========================================================================
platform linux -- Python 3.6.5, pytest-3.6.0, py-1.5.3, pluggy-0.6.0
rootdir: /home/leofang/cupy, inifile: setup.cfg
plugins: remotedata-0.3.0, openfiles-0.3.0, doctestplus-0.1.3, arraydiff-0.2
collected 450 items                                                                                                                                                   

tests/cupy_tests/cuda_tests/test_compiler.py s.s.........                                                                                                       [  2%]
tests/cupy_tests/cuda_tests/test_cublas.py .                                                                                                                    [  2%]
tests/cupy_tests/cuda_tests/test_cudnn.py s                                                                                                                     [  3%]
tests/cupy_tests/cuda_tests/test_cufft.py .                                                                                                                     [  3%]
tests/cupy_tests/cuda_tests/test_curand.py .....                                                                                                                [  4%]
tests/cupy_tests/cuda_tests/test_cusolver.py ..                                                                                                                 [  4%]
tests/cupy_tests/cuda_tests/test_cusparse.py .                                                                                                                  [  5%]
tests/cupy_tests/cuda_tests/test_cutensor.py s                                                                                                                  [  5%]
tests/cupy_tests/cuda_tests/test_device.py ............                                                                                                         [  8%]
tests/cupy_tests/cuda_tests/test_driver.py ...                                                                                                                  [  8%]
tests/cupy_tests/cuda_tests/test_memory.py ....................................................................                                                 [ 23%]
tests/cupy_tests/cuda_tests/test_memory_hook.py .                                                                                                               [ 24%]
tests/cupy_tests/cuda_tests/test_nccl.py ss...s.                                                                                                                [ 25%]
tests/cupy_tests/cuda_tests/test_nvrtc.py .                                                                                                                     [ 25%]
tests/cupy_tests/cuda_tests/test_nvtx.py ....                                                                                                                   [ 26%]
tests/cupy_tests/cuda_tests/test_pinned_memory.py ............                                                                                                  [ 29%]
tests/cupy_tests/cuda_tests/test_profile.py ..                                                                                                                  [ 29%]
tests/cupy_tests/cuda_tests/test_stream.py .....                                                                                                                [ 30%]
tests/cupy_tests/cuda_tests/test_texture.py ................................................................................................................... [ 56%]
............................................................................................................................................................... [ 91%]
..................ss..ss....ssss..                                                                                                                              [ 99%]
tests/cupy_tests/cuda_tests/memory_hooks_tests/test_debug_print.py .                                                                                            [ 99%]
tests/cupy_tests/cuda_tests/memory_hooks_tests/test_line_profile.py ..                                                                                          [100%]

=============================================================== 435 passed, 15 skipped in 14.28 seconds ===============================================================
Exception ignored in: <bound method Stream.__del__ of <cupy.cuda.stream.Stream object at 0x7f9431c708d0>>
Traceback (most recent call last):
  File "cupy/cuda/stream.pyx", line 186, in cupy.cuda.stream.Stream.__del__
AttributeError: 'NoneType' object has no attribute 'streamDestroy'
```
This PR fixed that by making the stream local to each individual test. 