### PR TITLE
Remove skip test

### DIFF
--- a/tests/cupy_tests/testing_tests/test_parameterized.py
+++ b/tests/cupy_tests/testing_tests/test_parameterized.py
@@ -3,12 +3,6 @@ import unittest
 from cupy import testing
 
 
-class TestParameterize(unittest.TestCase):
-    def test_skip(self):
-        # Skipping the test case should not report error.
-        self.skipTest('skip')
-
-
 @testing.parameterize(
     {'actual': {'a': [1, 2], 'b': [3, 4, 5]},
      'expect': [{'a': 1, 'b': 3}, {'a': 1, 'b': 4}, {'a': 1, 'b': 5},


### PR DESCRIPTION
I think there's no point to test this in CuPy.
(The test does not even use `parameterize`.)