### PR TITLE
`cupy.linalg.norm`: update docstring and improve performance for ord=2 cases

### DIFF
--- a/cupy/linalg/norms.py
+++ b/cupy/linalg/norms.py
@@ -75,7 +75,11 @@ def norm(x, ord=None, axis=None, keepdims=False):
             return abs(x).sum(axis=axis, keepdims=keepdims)
         elif ord is None or ord == 2:
             # special case for speedup
-            s = (x.conj() * x).real
+            if x.dtype.kind == 'c':
+                s = abs(x)
+                s *= s
+            else:
+                s = x * x
             return cupy.sqrt(s.sum(axis=axis, keepdims=keepdims))
         else:
             try:

--- a/cupy/linalg/norms.py
+++ b/cupy/linalg/norms.py
@@ -15,7 +15,6 @@ if cuda.cusolver_enabled:
 def norm(x, ord=None, axis=None, keepdims=False):
     """Returns one of matrix norms specified by ``ord`` parameter.
 
-    Complex valued matrices and vectors are not supported.
     See numpy.linalg.norm for more detail.
 
     Args:

--- a/cupy/linalg/norms.py
+++ b/cupy/linalg/norms.py
@@ -43,7 +43,7 @@ def norm(x, ord=None, axis=None, keepdims=False):
                 s *= s
                 ret = cupy.sqrt(s.sum())
             else:
-                ret = cupy.sqrt((x.ravel() ** 2).sum())
+                ret = cupy.sqrt((x * x).ravel().sum())
             if keepdims:
                 ret = ret.reshape((1,) * ndim)
             return ret
@@ -121,7 +121,7 @@ def norm(x, ord=None, axis=None, keepdims=False):
                 s *= s
                 ret = cupy.sqrt(s.sum(axis=axis))
             else:
-                ret = cupy.sqrt((x ** 2).sum(axis=axis))
+                ret = cupy.sqrt((x * x).sum(axis=axis))
         else:
             raise ValueError('Invalid norm order for matrices.')
         if keepdims:

--- a/cupy/linalg/norms.py
+++ b/cupy/linalg/norms.py
@@ -43,7 +43,7 @@ def norm(x, ord=None, axis=None, keepdims=False):
                 s *= s
                 ret = cupy.sqrt(s.sum())
             else:
-                ret = cupy.sqrt((x * x).ravel().sum())
+                ret = cupy.sqrt((x * x).sum())
             if keepdims:
                 ret = ret.reshape((1,) * ndim)
             return ret

--- a/cupy/linalg/norms.py
+++ b/cupy/linalg/norms.py
@@ -38,7 +38,7 @@ def norm(x, ord=None, axis=None, keepdims=False):
         ndim = x.ndim
         if (ord is None or (ndim == 1 and ord == 2) or
                 (ndim == 2 and ord in ('f', 'fro'))):
-            if issubclass(x.dtype.type, numpy.complexfloating):
+            if x.dtype.kind == 'c':
                 s = abs(x.ravel())
                 s *= s
                 ret = cupy.sqrt(s.sum())
@@ -116,7 +116,7 @@ def norm(x, ord=None, axis=None, keepdims=False):
                 row_axis -= 1
             ret = abs(x).sum(axis=col_axis).min(axis=row_axis)
         elif ord in [None, 'fro', 'f']:
-            if issubclass(x.dtype.type, numpy.complexfloating):
+            if x.dtype.kind == 'c':
                 s = abs(x)
                 s *= s
                 ret = cupy.sqrt(s.sum(axis=axis))


### PR DESCRIPTION
This PR updates the docstring of `cupy.linalg.norm` to remove an outdated disclaimer about lack of complex support.

A few minor performance enhancements to the common `ord= 2` case were also made. There is no change in behaviour and the commits are pretty self-explanatory.