### PR TITLE
Support `scipy.ndimage` compatible `convolve` and `correlate`

### DIFF
--- a/cupyx/scipy/ndimage/__init__.py
+++ b/cupyx/scipy/ndimage/__init__.py
@@ -6,4 +6,3 @@ from cupyx.scipy.ndimage.interpolation import map_coordinates  # NOQA
 from cupyx.scipy.ndimage.interpolation import rotate  # NOQA
 from cupyx.scipy.ndimage.interpolation import shift  # NOQA
 from cupyx.scipy.ndimage.interpolation import zoom  # NOQA
-

--- a/cupyx/scipy/ndimage/__init__.py
+++ b/cupyx/scipy/ndimage/__init__.py
@@ -1,5 +1,9 @@
+from cupyx.scipy.ndimage.filters import correlate  # NOQA
+from cupyx.scipy.ndimage.filters import convolve  # NOQA
+
 from cupyx.scipy.ndimage.interpolation import affine_transform  # NOQA
 from cupyx.scipy.ndimage.interpolation import map_coordinates  # NOQA
 from cupyx.scipy.ndimage.interpolation import rotate  # NOQA
 from cupyx.scipy.ndimage.interpolation import shift  # NOQA
 from cupyx.scipy.ndimage.interpolation import zoom  # NOQA
+

--- a/cupyx/scipy/ndimage/filters.py
+++ b/cupyx/scipy/ndimage/filters.py
@@ -12,7 +12,8 @@ def correlate(input, weights, output=None, mode='reflect', cval=0.0, origin=0):
         input (cupy.ndarray): The input array.
         weights (cupy.ndarray): Array of weights, same number of dimensions as
             input
-        output (cupy.ndarray or None): The array in which to place the output.
+        output (cupy.ndarray, dtype or None): The array in which to place the
+            output.
         mode (str): The array borders are handled according to the given mode
             (``'reflect'``, ``'constant'``, ``'nearest'``, ``'mirror'``,
             ``'wrap'``). Default is ``'reflect'``.
@@ -41,7 +42,8 @@ def convolve(input, weights, output=None, mode='reflect', cval=0.0, origin=0):
         input (cupy.ndarray): The input array.
         weights (cupy.ndarray): Array of weights, same number of dimensions as
             input
-        output (cupy.ndarray or None): The array in which to place the output.
+        output (cupy.ndarray, dtype or None): The array in which to place the
+            output.
         mode (str): The array borders are handled according to the given mode
             (``'reflect'``, ``'constant'``, ``'nearest'``, ``'mirror'``,
             ``'wrap'``). Default is ``'reflect'``.
@@ -89,8 +91,8 @@ def _correlate_or_convolve(input, weights, output, mode, cval, origin,
     if convolution:
         weights = weights[tuple([slice(None, None, -1)] * weights.ndim)]
         for ii in range(len(origin)):
-            origin[ii] = - origin[ii]
-            if not weights.shape[ii] & 1:
+            origin[ii] = -origin[ii]
+            if weights.shape[ii] % 2 == 0:
                 origin[ii] -= 1
     for _origin, lenw in zip(origin, wshape):
         if (lenw // 2 + _origin < 0) or (lenw // 2 + _origin > lenw):

--- a/cupyx/scipy/ndimage/filters.py
+++ b/cupyx/scipy/ndimage/filters.py
@@ -105,7 +105,14 @@ def _correlate_or_convolve(input, weights, output, mode, cval, origin,
     if weights.size == 0:
         return output
     input = cupy.ascontiguousarray(input)
-    weights = cupy.ascontiguousarray(weights, cupy.float64)
+    if input.dtype in (cupy.int32, cupy.uint32,
+                       cupy.int64, cupy.uint64, cupy.float64):
+        # If the input dtype is one of the above dtypes, float64 must be used
+        # for correlation computation to get an output compatible with SciPy.
+        wdtype = cupy.float64
+    else:
+        wdtype = cupy.float32
+    weights = cupy.ascontiguousarray(weights, wdtype)
     in_params, out_params, operation, name = _generate_correlete_kernel(
         input.ndim, mode, cval, input.shape, wshape, origin)
     return cupy.ElementwiseKernel(in_params, out_params, operation, name)(

--- a/cupyx/scipy/ndimage/filters.py
+++ b/cupyx/scipy/ndimage/filters.py
@@ -105,14 +105,10 @@ def _correlate_or_convolve(input, weights, output, mode, cval, origin,
     if weights.size == 0:
         return output
     input = cupy.ascontiguousarray(input)
-    if input.dtype in (cupy.int32, cupy.uint32,
-                       cupy.int64, cupy.uint64, cupy.float64):
-        # If the input dtype is one of the above dtypes, float64 must be used
-        # for correlation computation to get an output compatible with SciPy.
-        wdtype = cupy.float64
-    else:
-        wdtype = cupy.float32
-    weights = cupy.ascontiguousarray(weights, wdtype)
+    weights = cupy.ascontiguousarray(weights, cupy.float64)
+    # weights is always casted to float64 in order to get an output compatible
+    # with SciPy, thought float32 might be sufficient when input dtype is low
+    # precision.
     in_params, out_params, operation, name = _generate_correlete_kernel(
         input.ndim, mode, cval, input.shape, wshape, origin)
     return cupy.ElementwiseKernel(in_params, out_params, operation, name)(

--- a/cupyx/scipy/ndimage/filters.py
+++ b/cupyx/scipy/ndimage/filters.py
@@ -100,6 +100,8 @@ def _correlate_or_convolve(input, weights, output, mode, cval, origin,
         raise RuntimeError(msg)
 
     output = _get_output(output, input)
+    if weights.size == 0:
+        return output
     input = cupy.ascontiguousarray(input)
     weights = cupy.ascontiguousarray(weights, cupy.float64)
     in_params, out_params, operation, name = _generate_correlete_kernel(

--- a/cupyx/scipy/ndimage/filters.py
+++ b/cupyx/scipy/ndimage/filters.py
@@ -81,6 +81,8 @@ def _correlate_or_convolve(input, weights, output, mode, cval, origin,
         raise TypeError('Complex type not supported.')
     if not hasattr(origin, '__getitem__'):
         origin = [origin, ] * input.ndim
+    else:
+        origin = list(origin)
     wshape = [ii for ii in weights.shape if ii > 0]
     if len(wshape) != input.ndim:
         raise RuntimeError('filter weights array has incorrect shape.')
@@ -170,8 +172,8 @@ def _generate_correlete_kernel(ndim, mode, cval, xshape, wshape, origin):
         ops.append(_generate_boundary_condition_ops(mode, ixvar, xshape[j]))
         ops.append('        ix_{j} *= sx_{j};'.format(j=j))
 
-    _cond = " || ".join(['(ix_{0} < 0)'.format(j) for j in range(ndim)])
-    _expr = " + ".join(['ix_{0}'.format(j) for j in range(ndim)])
+    _cond = ' || '.join(['(ix_{0} < 0)'.format(j) for j in range(ndim)])
+    _expr = ' + '.join(['ix_{0}'.format(j) for j in range(ndim)])
     ops.append('''
         if ({cond}) {{
             sum += (W){cval} * w[iw];
@@ -183,9 +185,9 @@ def _generate_correlete_kernel(ndim, mode, cval, xshape, wshape, origin):
 
     ops.append('} ' * ndim)
     ops.append('y = (Y)sum;')
-    operation = "\n".join(ops)
+    operation = '\n'.join(ops)
 
-    name = 'cupy_ndimage_correlate_{}_{}d_x{}_w{}'.format(
-        mode, ndim, "_".join(['{}'.format(j) for j in xshape]),
-        "_".join(['{}'.format(j) for j in wshape]))
+    name = 'cupy_ndimage_correlate_{}d_{}_x{}_w{}'.format(
+        ndim, mode, '_'.join(['{}'.format(j) for j in xshape]),
+        '_'.join(['{}'.format(j) for j in wshape]))
     return in_params, out_params, operation, name

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
@@ -1,7 +1,6 @@
 import unittest
 
 import numpy
-
 import pytest
 
 from cupy import testing
@@ -17,8 +16,8 @@ except ImportError:
     'shape': [(3, 4), (2, 3, 4), (1, 2, 3, 4)],
     'ksize': [3, 4],
     'mode': ['reflect', 'constant', 'nearest', 'mirror', 'wrap'],
-    'cval': [0.0],
-    'origin': [-1, 0, 1],
+    'cval': [0.0, 1.0],
+    'origin': [0, 1, None],
     'adtype': [numpy.int8, numpy.int16, numpy.int32,
                numpy.float32, numpy.float64],
     'wdtype': [None, numpy.int32, numpy.float64],
@@ -31,13 +30,17 @@ class TestConvolveAndCorrelate(unittest.TestCase):
 
     def _filter(self, xp, scp, a, w):
         filter = getattr(scp.ndimage, self.filter)
+        if self.origin is None:
+            origin = (-1, 1, -1, 1)[:a.ndim]
+        else:
+            origin = self.origin
         return filter(a, w, output=self.output, mode=self.mode,
-                      cval=self.cval, origin=self.origin)
+                      cval=self.cval, origin=origin)
 
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
     def test_convolve_and_correlate(self, xp, scp):
         if self.adtype == self.wdtype or self.adtype == self.output:
-            pytest.skip()
+            pytest.skip('skip duplicated test.')
         a = testing.shaped_random(self.shape, xp, self.adtype)
         if self.wdtype is None:
             wdtype = self.adtype

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
@@ -1,0 +1,44 @@
+import unittest
+
+import numpy
+
+from cupy import testing
+import cupyx.scipy.ndimage
+
+try:
+    import scipy.ndimage
+except ImportError:
+    pass
+
+
+@testing.parameterize(*testing.product({
+    'shape': [(3, 4), (2, 3, 4), (1, 2, 3, 4)],
+    'ksize': [3, 4],
+    'mode': ['reflect', 'constant', 'nearest', 'mirror', 'wrap'],
+    'cval': [0.0],
+    'origin': [-1, 0, 1],
+    'output': [None, numpy.float32, numpy.float64],
+    'filter': ['convolve', 'correlate']
+}))
+@testing.gpu
+@testing.with_requires('scipy')
+class TestConvolveAndCorrelate(unittest.TestCase):
+
+    def _filter(self, xp, scp, a, w):
+        filter = getattr(scp.ndimage, self.filter)
+        return filter(a, w, output=self.output, mode=self.mode,
+                      cval=self.cval, origin=self.origin)
+
+    @testing.for_float_dtypes(no_float16=True)
+    @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
+    def test_convolve_float(self, xp, scp, dtype):
+        a = testing.shaped_random(self.shape, xp, dtype)
+        w = testing.shaped_random((self.ksize,) * a.ndim, xp, dtype)
+        return self._filter(xp, scp, a, w)
+
+    @testing.for_int_dtypes(no_bool=True)
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_convolve_int(self, xp, scp, dtype):
+        a = testing.shaped_random(self.shape, xp, dtype)
+        w = testing.shaped_random((self.ksize,) * a.ndim, xp, dtype)
+        return self._filter(xp, scp, a, w)

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
@@ -3,10 +3,10 @@ import unittest
 import numpy
 
 from cupy import testing
-import cupyx.scipy.ndimage
+import cupyx.scipy.ndimage  # NOQA
 
 try:
-    import scipy.ndimage
+    import scipy.ndimage  # NOQA
 except ImportError:
     pass
 

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
@@ -1,7 +1,6 @@
 import unittest
 
 import numpy
-import pytest
 
 import cupy
 from cupy import testing
@@ -13,18 +12,40 @@ except ImportError:
     pass
 
 
-@testing.parameterize(*testing.product({
-    'shape': [(3, 4), (2, 3, 4), (1, 2, 3, 4)],
-    'ksize': [3, 4],
-    'mode': ['reflect', 'constant', 'nearest', 'mirror', 'wrap'],
-    'cval': [0.0, 1.0],
-    'origin': [0, 1, None],
-    'adtype': [numpy.int8, numpy.int16, numpy.int32,
-               numpy.float32, numpy.float64],
-    'wdtype': [None, numpy.int32, numpy.float64],
-    'output': [None, numpy.int32, numpy.float64],
-    'filter': ['convolve', 'correlate']
-}))
+@testing.parameterize(*(
+    testing.product({
+        'shape': [(3, 4), (2, 3, 4), (1, 2, 3, 4)],
+        'ksize': [3, 4],
+        'mode': ['reflect'],
+        'cval': [0.0],
+        'origin': [0, 1, None],
+        'adtype': [numpy.int8, numpy.int16, numpy.int32,
+                   numpy.float32, numpy.float64],
+        'wdtype': [None, numpy.int32, numpy.float64],
+        'output': [None, numpy.int32, numpy.float64],
+        'filter': ['convolve', 'correlate']
+    }) + testing.product({
+        'shape': [(3, 4), (2, 3, 4), (1, 2, 3, 4)],
+        'ksize': [3, 4],
+        'mode': ['constant'],
+        'cval': [-1.0, 0.0, 1.0],
+        'origin': [0],
+        'adtype': [numpy.int32, numpy.float64],
+        'wdtype': [None],
+        'output': [None],
+        'filter': ['convolve', 'correlate']
+    }) + testing.product({
+        'shape': [(3, 4), (2, 3, 4), (1, 2, 3, 4)],
+        'ksize': [3, 4],
+        'mode': ['nearest', 'mirror', 'wrap'],
+        'cval': [0.0],
+        'origin': [0],
+        'adtype': [numpy.int32, numpy.float64],
+        'wdtype': [None],
+        'output': [None],
+        'filter': ['convolve', 'correlate']
+    })
+))
 @testing.gpu
 @testing.with_requires('scipy')
 class TestConvolveAndCorrelate(unittest.TestCase):
@@ -41,7 +62,7 @@ class TestConvolveAndCorrelate(unittest.TestCase):
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
     def test_convolve_and_correlate(self, xp, scp):
         if self.adtype == self.wdtype or self.adtype == self.output:
-            pytest.skip('skip duplicated test.')
+            return xp.array(True)
         a = testing.shaped_random(self.shape, xp, self.adtype)
         if self.wdtype is None:
             wdtype = self.adtype

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
@@ -2,6 +2,8 @@ import unittest
 
 import numpy
 
+import pytest
+
 from cupy import testing
 import cupyx.scipy.ndimage  # NOQA
 
@@ -17,7 +19,10 @@ except ImportError:
     'mode': ['reflect', 'constant', 'nearest', 'mirror', 'wrap'],
     'cval': [0.0],
     'origin': [-1, 0, 1],
-    'output': [None, numpy.float32, numpy.float64],
+    'adtype': [numpy.int8, numpy.int16, numpy.int32,
+               numpy.float32, numpy.float64],
+    'wdtype': [None, numpy.int32, numpy.float64],
+    'output': [None, numpy.int32, numpy.float64],
     'filter': ['convolve', 'correlate']
 }))
 @testing.gpu
@@ -29,16 +34,14 @@ class TestConvolveAndCorrelate(unittest.TestCase):
         return filter(a, w, output=self.output, mode=self.mode,
                       cval=self.cval, origin=self.origin)
 
-    @testing.for_float_dtypes(no_float16=True)
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
-    def test_convolve_float(self, xp, scp, dtype):
-        a = testing.shaped_random(self.shape, xp, dtype)
-        w = testing.shaped_random((self.ksize,) * a.ndim, xp, dtype)
-        return self._filter(xp, scp, a, w)
-
-    @testing.for_int_dtypes(no_bool=True)
-    @testing.numpy_cupy_allclose(scipy_name='scp')
-    def test_convolve_int(self, xp, scp, dtype):
-        a = testing.shaped_random(self.shape, xp, dtype)
-        w = testing.shaped_random((self.ksize,) * a.ndim, xp, dtype)
+    def test_convolve_and_correlate(self, xp, scp):
+        if self.adtype == self.wdtype or self.adtype == self.output:
+            pytest.skip()
+        a = testing.shaped_random(self.shape, xp, self.adtype)
+        if self.wdtype is None:
+            wdtype = self.adtype
+        else:
+            wdtype = self.wdtype
+        w = testing.shaped_random((self.ksize,) * a.ndim, xp, wdtype)
         return self._filter(xp, scp, a, w)


### PR DESCRIPTION
This PR aims to support two filters, `convolve` and `correlate`, from scipy.ndimage.fiters.

This is related to https://github.com/cupy/cupy/issues/2099.

This PR supports almost all parameters available in `convolve` and `correlate` of scipy.ndimage.filters.  You can use any `mode` of 'reflect', 'constant', 'nearest', 'minnor' and 'wrap' and you can also change the values of `cval` and `origin` from default.

As discussed in https://github.com/cupy/cupy/issues/2099, I intented to utilize the Chainer convolution implementation that executes `tensordot` after `im2col`. However, it was found that `im2col` becomes performance limiter for use-case of ndimage `convolve` and `correlate`, so I wrote a "direct convolution" code that does not require `im2col` using ElementWiseKernel.

