### PR TITLE
Performance improvement for `cupy.var` complex inputs

### DIFF
--- a/cupy/core/_routines_statistics.pyx
+++ b/cupy/core/_routines_statistics.pyx
@@ -268,9 +268,9 @@ cdef ndarray _var(
         else:
             var_core = _var_core_float64
         return var_core(a, arrmean, alpha, axis=axis, keepdims=keepdims)
-    else:
-        out = _var_core_out(a, arrmean, alpha, out, axis=axis, keepdims=keepdims)
-        return out.astype(dtype_out, copy=False)
+
+    out = _var_core_out(a, arrmean, alpha, out, axis=axis, keepdims=keepdims)
+    return out.astype(dtype_out, copy=False)
 
 
 cdef ndarray _std(

--- a/cupy/core/_routines_statistics.pyx
+++ b/cupy/core/_routines_statistics.pyx
@@ -1,3 +1,5 @@
+import numpy
+
 from cupy.core._kernel import create_reduction_func
 from cupy.core._kernel import ReductionKernel
 
@@ -234,49 +236,41 @@ cdef _nanargmax = create_reduction_func(
 cdef ndarray _var(
         ndarray a, axis=None, dtype=None, out=None, ddof=0, keepdims=False):
 
-    if a.dtype.kind == 'c':
-        if out is not None:
-            raise NotImplementedError(
-                'Variance for complex numbers is not implemented when out != '
-                'None. Current implemention does not convert the dtype.'
-            )
-        dtype_out = dtype
-        if dtype in ['D', 'F']:
-            dtype == dtype.lower()
-        out = _var(a.real, axis, dtype, None, ddof, keepdims)
-        out += _var(a.imag, axis, dtype, None, ddof, keepdims)
-        if dtype_out is not None and dtype_out != dtype:
-            out = out.astype(dtype_out, copy=False)
-        return out
-
     if axis is None:
         axis = tuple(range(a.ndim))
     if not isinstance(axis, tuple):
         axis = (axis,)
 
-    dtype_out = dtype
-    if dtype in ['D', 'F']:
-        if a.dtype.kind == 'f':
-            dtype = a.dtype.char
+    dtype_mean = a.dtype
+    dtype_out = numpy.dtype(dtype)
+    if dtype is None:
+        if a.dtype.kind in 'biu':
+            dtype_mean = 'float64'
+            dtype_out = 'float64'
         else:
-            dtype = 'd'
-    elif dtype is None and a.dtype.kind in 'biu':
-        dtype = 'd'
+            dtype_mean = a.dtype
+            dtype_out = a.dtype
+            if a.dtype.kind == 'c':
+                dtype_out = numpy.dtype(a.dtype.char.lower())
 
     shape = a.shape
     items = 1
     for ax in axis:
         items *= shape[ax]
-    alpha = 1. / max(items - ddof, 0)
-    arrmean = a.mean(axis=axis, dtype=dtype, out=None, keepdims=True)
+    alpha = numpy.dtype(dtype_out).type(1) / max(items - ddof, 0)
+    arrmean = a.mean(axis=axis, dtype=dtype_mean, out=None, keepdims=True)
+
     if out is None:
-        out = _var_core(a, arrmean, alpha, axis=axis, keepdims=keepdims)
+        if dtype_out == 'float16':
+            var_core = _var_core_float16
+        elif dtype_out == 'float32':
+            var_core = _var_core_float32
+        else:
+            var_core = _var_core_float64
+        return var_core(a, arrmean, alpha, axis=axis, keepdims=keepdims)
     else:
-        out = _var_core_out(
-            a, arrmean, alpha, out, axis=axis, keepdims=keepdims)
-    if dtype_out is not None and dtype_out != dtype:
-        out = out.astype(dtype_out, copy=False)
-    return out
+        out = _var_core_out(a, arrmean, alpha, out, axis=axis, keepdims=keepdims)
+        return out.astype(dtype_out, copy=False)
 
 
 cdef ndarray _std(
@@ -286,15 +280,36 @@ cdef ndarray _std(
     return _math._sqrt(ret, dtype=dtype, out=out)
 
 
-cdef _var_core = ReductionKernel(
-    'S x, T mean, T alpha', 'T out',
-    '(x - mean) * (x - mean)',
-    'a + b', 'out = alpha * a', '0', '_var_core')
+cdef _norm_preamble = '''
+template <typename T> __device__ T my_norm(T x) { return x * x; }
+__device__ float my_norm(const complex<float>& x) { return norm(x); }
+__device__ double my_norm(const complex<double>& x) { return norm(x); }
+'''
+
+
+cdef _var_core_float16 = ReductionKernel(
+    'S x, T mean, float32 alpha', 'float16 out',
+    'my_norm(x - mean)',
+    'a + b', 'out = alpha * a', '0', '_var_core', preamble=_norm_preamble)
+
+
+cdef _var_core_float32 = ReductionKernel(
+    'S x, T mean, float32 alpha', 'float32 out',
+    'my_norm(x - mean)',
+    'a + b', 'out = alpha * a', '0', '_var_core', preamble=_norm_preamble)
+
+
+cdef _var_core_float64 = ReductionKernel(
+    'S x, T mean, float64 alpha', 'float64 out',
+    'my_norm(x - mean)',
+    'a + b', 'out = alpha * a', '0', '_var_core', preamble=_norm_preamble)
+
 
 cdef _var_core_out = ReductionKernel(
-    'S x, T mean, T alpha', 'U out',
-    '(x - mean) * (x - mean)',
-    'a + b', 'out = alpha * a', '0', '_var_core')
+    'S x, T mean, U alpha', 'U out',
+    'my_norm(x - mean)',
+    'a + b', 'out = alpha * a', '0', '_var_core', preamble=_norm_preamble)
+
 
 # TODO(okuta) needs cast
 cdef _mean = create_reduction_func(

--- a/cupy/core/_routines_statistics.pyx
+++ b/cupy/core/_routines_statistics.pyx
@@ -254,10 +254,10 @@ cdef ndarray _var(
                 dtype_out = numpy.dtype(a.dtype.char.lower())
 
     shape = a.shape
-    items = 1
+    cdef Py_ssize_t items = 1
     for ax in axis:
         items *= shape[ax]
-    alpha = numpy.dtype(dtype_out).type(1) / max(items - ddof, 0)
+    alpha = 1 / max(items - ddof, 0)
     arrmean = a.mean(axis=axis, dtype=dtype_mean, out=None, keepdims=True)
 
     if out is None:


### PR DESCRIPTION
Rel #2411.
Speed up `cupy.var` for complex inputs by defining custom kernel for complex value.