### PR TITLE
Ignore warning caused by fastrlock

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -10,8 +10,8 @@ from cupy import _version
 
 try:
     with warnings.catch_warnings():
-        distutils_warning = 'can\'t resolve package from __spec__'
-        warnings.filterwarnings("ignore", message=distutils_warning)
+        warnings.filterwarnings('ignore', category=ImportWarning,
+                                message='can\'t resolve package from __spec__')
         from cupy import core  # NOQA
 except ImportError:
     # core is a c-extension module.

--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -9,7 +9,10 @@ from cupy import _version
 
 
 try:
-    from cupy import core  # NOQA
+    with warnings.catch_warnings():
+        distutils_warning = 'can\'t resolve package from __spec__'
+        warnings.filterwarnings("ignore", message=distutils_warning)
+        from cupy import core  # NOQA
 except ImportError:
     # core is a c-extension module.
     # When a user cannot import core, it represents that CuPy is not correctly


### PR DESCRIPTION
Closes #2476
```
$ python -W error
>>> import cupy
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/ecastill/em-cupy/cupy/__init__.py", line 12, in <module>
    from cupy import core  # NOQA
  File "/home/ecastill/em-cupy/cupy/core/__init__.py", line 1, in <module>
    from cupy.core import core  # NOQA
  File "cupy/core/core.pyx", line 1, in init cupy.core.core
    # distutils: language = c++
  File "/home/ecastill/em-cupy/cupy/cuda/__init__.py", line 4, in <module>
    from cupy.cuda import compiler  # NOQA
  File "/home/ecastill/em-cupy/cupy/cuda/compiler.py", line 12, in <module>
    from cupy.cuda import function
  File "cupy/cuda/memory.pxd", line 12, in init cupy.cuda.function

  File "cupy/cuda/memory.pyx", line 1, in init cupy.cuda.memory
    # distutils: language = c++
  File "fastrlock/_lock.pxi", line 4, in init fastrlock.rlock
ImportWarning: can't resolve package from __spec__ or __package__, falling back on __name__ and __path__
```

The problem is on the code generated by Cython when compiling memory.pyx, its introduced by distutils when it add the stubs to call fastrlock
The PR silences it right before importing the main offending module.