### PR TITLE
Added `cupy.cuda.memory.get_allocator` interface

### DIFF
--- a/cupy/cuda/__init__.py
+++ b/cupy/cuda/__init__.py
@@ -97,6 +97,7 @@ from cupy.cuda.memory import Memory  # NOQA
 from cupy.cuda.memory import MemoryPointer  # NOQA
 from cupy.cuda.memory import MemoryPool  # NOQA
 from cupy.cuda.memory import set_allocator  # NOQA
+from cupy.cuda.memory import get_allocator  # NOQA
 from cupy.cuda.memory import UnownedMemory  # NOQA
 from cupy.cuda.memory_hook import MemoryHook  # NOQA
 from cupy.cuda.pinned_memory import alloc_pinned_memory  # NOQA

--- a/cupy/cuda/memory.pxd
+++ b/cupy/cuda/memory.pxd
@@ -43,6 +43,7 @@ cpdef MemoryPointer alloc(size)
 
 
 cpdef set_allocator(allocator=*)
+cpdef get_allocator()
 
 
 cdef class MemoryPool:

--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -557,6 +557,15 @@ cpdef set_allocator(allocator=None):
     _current_allocator = allocator
 
 
+cpdef get_allocator():
+    """Returns the current allocator for GPU memory.
+
+    Returns:
+        function: CuPy memory allocator.
+    """
+    return _current_allocator
+
+
 @cython.final
 @cython.no_gc
 cdef class PooledMemory(BaseMemory):

--- a/tests/cupy_tests/cuda_tests/test_memory.py
+++ b/tests/cupy_tests/cuda_tests/test_memory.py
@@ -626,6 +626,9 @@ class TestAllocator(unittest.TestCase):
             self.assertEqual(1024, arr.data.mem.size)
             self.assertEqual(1024, self.pool.used_bytes())
 
+    def test_get_allocator(self):
+        assert memory.get_allocator() == self.pool.malloc
+
     @unittest.skipUnless(sys.version_info[0] >= 3,
                          'Only for Python3 or higher')
     def test_reuse_between_thread(self):


### PR DESCRIPTION
Closes #2481 

Adds a function to retrieve the current memory allocator.

Currently trying to figure out tests.