### PR TITLE
Update `__cuda_array_interface__` to protocol version 3

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2745,24 +2745,21 @@ not_equal = create_comparison(
 cpdef ndarray _convert_object_with_cuda_array_interface(a):
     cdef Py_ssize_t sh, st
     desc = a.__cuda_array_interface__
-    # TODO(leofang): enforce compliance to the latest protocol?
     shape = desc['shape']
     dtype = numpy.dtype(desc['typestr'])
     if 'mask' in desc:
         mask = desc['mask']
         if mask is not None:
-            raise ValueError("CuPy currently does not support masked arrays.")
-    # TODO(leofang): for ver.2, 'strides' is always available, so don't check.
-    if 'strides' in desc:
+            raise ValueError('CuPy currently does not support masked arrays.')
+    if 'strides' in desc:  # for ver.2, 'strides' is always available
         strides = desc['strides']
-        if strides is not None:
-            nbytes = 0
-            for sh, st in zip(shape, strides):
-                nbytes = max(nbytes, abs(sh * st))
-        else:
-            nbytes = internal.prod(shape) * dtype.itemsize
     else:  # for backward compatibility with ver.0 & ver.1
         strides = None
+    if strides is not None:
+        nbytes = 0
+        for sh, st in zip(shape, strides):
+            nbytes = max(nbytes, abs(sh * st))
+    else:
         nbytes = internal.prod(shape) * dtype.itemsize
     mem = memory_module.UnownedMemory(desc['data'][0], nbytes, a)
     memptr = memory.MemoryPointer(mem, 0)

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2751,10 +2751,7 @@ cpdef ndarray _convert_object_with_cuda_array_interface(a):
         mask = desc['mask']
         if mask is not None:
             raise ValueError('CuPy currently does not support masked arrays.')
-    if 'strides' in desc:  # for ver.2, 'strides' is always available
-        strides = desc['strides']
-    else:  # for backward compatibility with ver.0 & ver.1
-        strides = None
+    strides = desc.get('strides')
     if strides is not None:
         nbytes = 0
         for sh, st in zip(shape, strides):

--- a/tests/cupy_tests/core_tests/test_ndarray.py
+++ b/tests/cupy_tests/core_tests/test_ndarray.py
@@ -198,15 +198,17 @@ class TestNdarrayCudaInterface(unittest.TestCase):
         arr = cupy.zeros(shape=(2, 3), dtype=cupy.float64)
         iface = arr.__cuda_array_interface__
         assert (set(iface.keys()) ==
-                set(['shape', 'typestr', 'data', 'version', 'descr']))
+                set(['shape', 'typestr', 'data', 'version', 'descr',
+                     'strides']))
         assert iface['shape'] == (2, 3)
         assert iface['typestr'] == '<f8'
         assert isinstance(iface['data'], tuple)
         assert len(iface['data']) == 2
         assert iface['data'][0] == arr.data.ptr
         assert not iface['data'][1]
-        assert iface['version'] == 0
+        assert iface['version'] == 2
         assert iface['descr'] == [('', '<f8')]
+        assert iface['strides'] is None
 
     def test_cuda_array_interface_view(self):
         arr = cupy.zeros(shape=(10, 20), dtype=cupy.float64)
@@ -221,7 +223,7 @@ class TestNdarrayCudaInterface(unittest.TestCase):
         assert len(iface['data']) == 2
         assert iface['data'][0] == arr.data.ptr
         assert not iface['data'][1]
-        assert iface['version'] == 0
+        assert iface['version'] == 2
         assert iface['strides'] == (320, 40)
         assert iface['descr'] == [('', '<f8')]
 

--- a/tests/cupy_tests/core_tests/test_ndarray_cuda_array_interface.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_cuda_array_interface.py
@@ -9,21 +9,18 @@ class DummyObjectWithCudaArrayInterface(object):
 
     def __init__(self, a):
         self.a = a
-        self._desc = None
 
     @property
     def __cuda_array_interface__(self):
-        if self._desc is None:
-            desc = {
-                'shape': self.a.shape,
-                'strides': self.a.strides,
-                'typestr': self.a.dtype.str,
-                'descr': self.a.dtype.descr,
-                'data': (self.a.data.ptr, False),
-                'version': 2,
-            }
-            self._desc = desc
-        return self._desc
+        desc = {
+            'shape': self.a.shape,
+            'strides': self.a.strides,
+            'typestr': self.a.dtype.str,
+            'descr': self.a.dtype.descr,
+            'data': (self.a.data.ptr, False),
+            'version': 2,
+        }
+        return desc
 
 
 @testing.gpu

--- a/tests/cupy_tests/creation_tests/test_from_data.py
+++ b/tests/cupy_tests/creation_tests/test_from_data.py
@@ -408,8 +408,7 @@ class TestFromData(unittest.TestCase):
     def test_asarray_cuda_array_interface_with_masked_array(self):
         a = cupy.arange(10)
         mask = cupy.zeros(10)
-        a = DummyObjectWithCudaArrayInterface(a)
-        a.set_mask(mask)
+        a = DummyObjectWithCudaArrayInterface(a, mask)
         with pytest.raises(ValueError) as ex:
             b = cupy.asarray(a)  # noqa
         assert 'does not support' in str(ex.value)
@@ -478,28 +477,23 @@ class TestFromData(unittest.TestCase):
 
 class DummyObjectWithCudaArrayInterface(object):
 
-    def __init__(self, a):
+    def __init__(self, a, mask=None):
         self.a = a
-        self._desc = None
+        self.mask = mask
 
     @property
     def __cuda_array_interface__(self):
-        if self._desc is None:
-            desc = {
-                'shape': self.a.shape,
-                'strides': self.a.strides,
-                'typestr': self.a.dtype.str,
-                'descr': self.a.dtype.descr,
-                'data': (self.a.data.ptr, False),
-                'version': 2,
-            }
-            self._desc = desc
-        return self._desc
-
-    def set_mask(self, mask):
-        if self._desc is None:
-            self.__cuda_array_interface__
-        self._desc['mask'] = mask
+        desc = {
+            'shape': self.a.shape,
+            'strides': self.a.strides,
+            'typestr': self.a.dtype.str,
+            'descr': self.a.dtype.descr,
+            'data': (self.a.data.ptr, False),
+            'version': 2,
+        }
+        if self.mask is not None:
+            desc['mask'] = self.mask
+        return desc
 
 
 @testing.parameterize(

--- a/tests/cupy_tests/creation_tests/test_from_data.py
+++ b/tests/cupy_tests/creation_tests/test_from_data.py
@@ -1,5 +1,7 @@
 import unittest
 
+import pytest
+
 import cupy
 from cupy import cuda
 from cupy import testing
@@ -396,11 +398,21 @@ class TestFromData(unittest.TestCase):
         testing.assert_array_equal(a, b)
 
     @testing.for_all_dtypes()
-    def test_asarray_cuda_array_interface_with_strdies(self, dtype):
+    def test_asarray_cuda_array_interface_with_strides(self, dtype):
         a = testing.shaped_arange((2, 3, 4), cupy, dtype).T
-        b = cupy.asarray(DummyObjectWithCudaArrayInterface(a, True))
+        b = cupy.asarray(DummyObjectWithCudaArrayInterface(a))
         assert a.strides == b.strides
         assert a.nbytes == b.data.mem.size
+
+    # TODO(leofang): remove this test when masked array is supported
+    def test_asarray_cuda_array_interface_with_masked_array(self):
+        a = cupy.arange(10)
+        mask = cupy.zeros(10)
+        a = DummyObjectWithCudaArrayInterface(a)
+        a.set_mask(mask)
+        with pytest.raises(ValueError) as ex:
+            b = cupy.asarray(a)  # noqa
+        assert 'does not support' in str(ex.value)
 
     def test_ascontiguousarray_on_noncontiguous_array(self):
         a = testing.shaped_arange((2, 3, 4))
@@ -466,22 +478,28 @@ class TestFromData(unittest.TestCase):
 
 class DummyObjectWithCudaArrayInterface(object):
 
-    def __init__(self, a, has_strides=False):
+    def __init__(self, a):
         self.a = a
-        self.has_strides = has_strides
+        self._desc = None
 
     @property
     def __cuda_array_interface__(self):
-        desc = {
-            'shape': self.a.shape,
-            'typestr': self.a.dtype.str,
-            'descr': self.a.dtype.descr,
-            'data': (self.a.data.mem.ptr, False),
-            'version': 0,
-        }
-        if self.has_strides:
-            desc['strides'] = self.a.strides
-        return desc
+        if self._desc is None:
+            desc = {
+                'shape': self.a.shape,
+                'strides': self.a.strides,
+                'typestr': self.a.dtype.str,
+                'descr': self.a.dtype.descr,
+                'data': (self.a.data.ptr, False),
+                'version': 2,
+            }
+            self._desc = desc
+        return self._desc
+
+    def set_mask(self, mask):
+        if self._desc is None:
+            self.__cuda_array_interface__
+        self._desc['mask'] = mask
 
 
 @testing.parameterize(


### PR DESCRIPTION
Closes #2462. 

This PR is a parallel effort of the upstream PR numba/numba#4609. Although this PR is ready, it is marked as WIP and please do not review or merge until that one is approved. I will ensure any changes there to be reflected here as well. 

In the proposed v2 protocol, the `strides` field is made mandatory, and `strides=None` can be used to indicate C contiguity. 

This PR explicitly disables masked arrays (so does Numba), which was added to the v1 protocol (numba/numba#4199). When #2225 is resolved, the checks and guards implemented here should be lifted. 

To be discussed with CuPy core devs:
- ~~Do we want to enforce a strict compliance with the protocol, say, in a future release? For example,  we can check `__cuda_array_interface__['version'] == 2`. NumPy does that for `__array_interface__`.~~

cc: @pentschev @stuartarchibald @dalcinl @jakirkham 