### PR TITLE
allow axis=None in concatenate

### DIFF
--- a/cupy/manipulation/join.py
+++ b/cupy/manipulation/join.py
@@ -38,7 +38,9 @@ def concatenate(tup, axis=0):
     Args:
         tup (sequence of arrays): Arrays to be joined. All of these should have
             same dimensionalities except the specified axis.
-        axis (int): The axis to join arrays along.
+        axis (int or None): The axis to join arrays along.
+            If axis is None, arrays are flattened before use.
+            Default is 0.
 
     Returns:
         cupy.ndarray: Joined array.
@@ -46,6 +48,9 @@ def concatenate(tup, axis=0):
     .. seealso:: :func:`numpy.concatenate`
 
     """
+    if axis is None:
+        tup = [m.ravel() for m in tup]
+        axis = 0
     return core.concatenate_method(tup, axis)
 
 

--- a/tests/cupy_tests/manipulation_tests/test_join.py
+++ b/tests/cupy_tests/manipulation_tests/test_join.py
@@ -53,6 +53,14 @@ class TestJoin(unittest.TestCase):
 
     @testing.for_all_dtypes(name='dtype')
     @testing.numpy_cupy_array_equal()
+    def test_concatenate_axis_none(self, xp, dtype):
+        a = testing.shaped_arange((2, 3), xp, dtype)
+        b = testing.shaped_reverse_arange((3, 5, 2), xp, dtype)
+        c = testing.shaped_arange((7, ), xp, dtype)
+        return xp.concatenate((a, b, c), axis=None)
+
+    @testing.for_all_dtypes(name='dtype')
+    @testing.numpy_cupy_array_equal()
     def test_concatenate_large_2(self, xp, dtype):
         a = testing.shaped_arange((2, 3, 4), xp, dtype)
         b = testing.shaped_reverse_arange((2, 3, 2), xp, dtype)


### PR DESCRIPTION
Solves #2486 . Allow axis=None in `concatenate` in which case arrays are flattened before use to be compatible with NumPy.