### PR TITLE
Fix bug in CUB + support complex numbers using CUB

### DIFF
--- a/cupy/cuda/cub.pyx
+++ b/cupy/cuda/cub.pyx
@@ -46,13 +46,11 @@ cdef extern from 'cupy_cub.h':
 # TODO(leofang): remove this hack when CUB supports complex numbers
 def reduce_sum(core.ndarray x, out=None):
     if x.dtype in (numpy.complex64, numpy.complex128):
-        out_re = _reduce_sum(x.real, out if out is None else out.real)
-        out_im = _reduce_sum(x.imag, out if out is None else out.imag)
-        y = out_re + 1j * out_im
-        if out is not None:
-            out[...] = y
-            y = out
-        return y
+        if out is None:
+            out = core.ndarray((), dtype=x.dtype)
+        _reduce_sum(x.real, out.real)
+        _reduce_sum(x.imag, out.imag)
+        return out
     else:
         return _reduce_sum(x, out)
 

--- a/cupy/cuda/cub.pyx
+++ b/cupy/cuda/cub.pyx
@@ -43,7 +43,17 @@ cdef extern from 'cupy_cub.h':
 ###############################################################################
 
 
+# TODO(leofang): remove this hack when CUB supports complex numbers
 def reduce_sum(core.ndarray x, out=None):
+    if x.dtype in (numpy.complex64, numpy.complex128):
+        out_re = _reduce_sum(x.real, out)
+        out_im = _reduce_sum(x.imag, out)
+        return out_re + 1j * out_im
+    else:
+        return _reduce_sum(x, out)
+
+
+def _reduce_sum(core.ndarray x, out=None):
     cdef core.ndarray y
     cdef core.ndarray ws
     cdef int dtype_id
@@ -73,11 +83,13 @@ def can_use_reduce_sum(x_dtype, dtype=None):
         # See _sum_auto_dtype in cupy/core/_routines_math.pyx for which dtypes
         # are promoted.
         support_dtype = [numpy.int64, numpy.uint64,
-                         numpy.float32, numpy.float64]
+                         numpy.float32, numpy.float64,
+                         numpy.complex64, numpy.complex128]
     elif dtype == x_dtype:
         support_dtype = [numpy.int8, numpy.uint8, numpy.int16, numpy.uint16,
                          numpy.int32, numpy.uint32, numpy.int64, numpy.uint64,
-                         numpy.float32, numpy.float64]
+                         numpy.float32, numpy.float64,
+                         numpy.complex64, numpy.complex128]
     else:
         return False
     if x_dtype not in support_dtype:
@@ -85,7 +97,18 @@ def can_use_reduce_sum(x_dtype, dtype=None):
     return True
 
 
+# TODO(leofang): remove this hack when CUB supports complex numbers
 def reduce_min(core.ndarray x, out=None):
+    if x.dtype in (numpy.complex64, numpy.complex128):
+        # Here we only look at the real part, as NumPy does the comparison of
+        # complex numbers in lexical order (numpy/numpy#2004)
+        out_re = _reduce_min(x.real, out)
+        return x[(x.real == out_re).nonzero()]
+    else:
+        return _reduce_min(x, out)
+
+
+def _reduce_min(core.ndarray x, out=None):
     cdef core.ndarray y
     cdef core.ndarray ws
     cdef int dtype_id
@@ -112,7 +135,8 @@ def can_use_reduce_min(x_dtype, dtype=None):
     if dtype is None or dtype == x_dtype:
         support_dtype = [numpy.int8, numpy.uint8, numpy.int16, numpy.uint16,
                          numpy.int32, numpy.uint32, numpy.int64, numpy.uint64,
-                         numpy.float32, numpy.float64]
+                         numpy.float32, numpy.float64,
+                         numpy.complex64, numpy.complex128]
     else:
         return False
     if x_dtype not in support_dtype:
@@ -120,7 +144,18 @@ def can_use_reduce_min(x_dtype, dtype=None):
     return True
 
 
+# TODO(leofang): remove this hack when CUB supports complex numbers
 def reduce_max(core.ndarray x, out=None):
+    if x.dtype in (numpy.complex64, numpy.complex128):
+        # Here we only look at the real part, as NumPy does the comparison of
+        # complex numbers in lexical order (numpy/numpy#2004)
+        out_re = _reduce_max(x.real, out)
+        return x[(x.real == out_re).nonzero()]
+    else:
+        return _reduce_max(x, out)
+
+
+def _reduce_max(core.ndarray x, out=None):
     cdef core.ndarray y
     cdef core.ndarray ws
     cdef int dtype_id
@@ -147,7 +182,8 @@ def can_use_reduce_max(x_dtype, dtype=None):
     if dtype is None or dtype == x_dtype:
         support_dtype = [numpy.int8, numpy.uint8, numpy.int16, numpy.uint16,
                          numpy.int32, numpy.uint32, numpy.int64, numpy.uint64,
-                         numpy.float32, numpy.float64]
+                         numpy.float32, numpy.float64,
+                         numpy.complex64, numpy.complex128]
     else:
         return False
     if x_dtype not in support_dtype:

--- a/cupy/cuda/cub.pyx
+++ b/cupy/cuda/cub.pyx
@@ -116,8 +116,8 @@ def reduce_min(core.ndarray x, out=None):
             return y
         else:
             out_im = _reduce_min(x[idx].imag, out if out is None else out.imag)
-            idx = (x.imag == out_im).nonzero()
-            y = x[idx][0]
+            # we know the full answer at this point, no need to search again
+            y = out_re + 1j * out_im
             if out is not None:
                 out[...] = y
                 y = out
@@ -177,8 +177,8 @@ def reduce_max(core.ndarray x, out=None):
             return y
         else:
             out_im = _reduce_max(x[idx].imag, out if out is None else out.imag)
-            idx = (x.imag == out_im).nonzero()
-            y = x[idx][0]
+            # we know the full answer at this point, no need to search again
+            y = out_re + 1j * out_im
             if out is not None:
                 out[...] = y
                 y = out

--- a/cupy/cuda/cupy_cub.cu
+++ b/cupy/cuda/cupy_cub.cu
@@ -1,5 +1,6 @@
 #include <cub/device/device_reduce.cuh>
 #include "cupy_cub.h"
+#include <stdexcept>
 
 using namespace cub;
 


### PR DESCRIPTION
This is a followup of #2090. The bulk of this PR is completed, but I mark it WIP so as to gather early feedbacks and comments before proceeding to write tests.

This PR does two things:
1. Fix build-time bug: without `#include <stdexcept>` in `cupy/cuda/cupy_cub.cu`, I found that there is a build-time error:
```shell
    building 'cupy.cuda.cub' extension
    gcc -pthread -B /home/leofang/conda_envs/cupy_dev/compiler_compat -Wl,--sysroot=/ -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -I/home/leofang/.nccl_2.1.15-1+cuda9.1_x86_64/include/ -fPIC -D_FORCE_INLINES=1 -I/usr/local/cuda/include -I/home/leofang/sources/cub-1.8.0/ -I/home/leofang/conda_envs/cupy_dev/include/python3.6m -c cupy/cuda/cub.cpp -o build/temp.linux-x86_64-3.6/cupy/cuda/cub.o
    cc1plus: warning: command line option ‘-Wstrict-prototypes’ is valid for C/ObjC but not for C++
    NVCC options: ['--generate-code=arch=compute_30,code=compute_30', '--generate-code=arch=compute_50,code=compute_50', '--generate-code=arch=compute_60,code=sm_60', '--generate-code=arch=compute_61,code=sm_61', '--generate-code=arch=compute_70,code=sm_70', '--generate-code=arch=compute_70,code=compute_70', '-O2', '--compiler-options="-fPIC"', '--std=c++11']
    /usr/local/cuda/bin/nvcc -D_FORCE_INLINES=1 -I/usr/local/cuda/include -I/home/leofang/sources/cub-1.8.0/ -I/home/leofang/conda_envs/cupy_dev/include/python3.6m -c cupy/cuda/cupy_cub.cu -o build/temp.linux-x86_64-3.6/cupy/cuda/cupy_cub.o --generate-code=arch=compute_30,code=compute_30 --generate-code=arch=compute_50,code=compute_50 --generate-code=arch=compute_60,code=sm_60 --generate-code=arch=compute_61,code=sm_61 --generate-code=arch=compute_70,code=sm_70 --generate-code=arch=compute_70,code=compute_70 -O2 --compiler-options="-fPIC" --std=c++11
    cupy/cuda/cupy_cub.cu(28): error: namespace "std" has no member "runtime_error"
```
2.  Support `sum()`/`max()`/`min()` for complex numbers using CUB. This support is compliant with NumPy behavior. 

The current implementation is, admittedly, an ugly and not fully optimized hack for two reasons: (i) CUB does not provide native support for complex numbers (see the CUB source code `cub/util_type.cuh`), and (ii) since the comparison of two complex numbers is ill-defined, NumPy uses a lexical search for `max()` and `min()`, which requires two passes (separately examining the real and imaginary parts) in the worst-case scenario.

However, in my tests this hack still offers substantial speedup (see https://github.com/cupy/cupy/pull/2508#issuecomment-536244675) so that I think it's worth considering. We can revisit this issue once CUB has better support.

Attn: @anaruse 