### PR TITLE
Cholesky decomposition to support complex values

### DIFF
--- a/cupy/linalg/decomposition.py
+++ b/cupy/linalg/decomposition.py
@@ -16,8 +16,7 @@ def cholesky(a):
 
     Decompose a given two-dimensional square matrix into ``L * L.T``,
     where ``L`` is a lower-triangular matrix and ``.T`` is a conjugate
-    transpose operator. Note that in the current implementation ``a`` must be
-    a real matrix, and only float32 and float64 are supported.
+    transpose operator.
 
     Args:
         a (cupy.ndarray): The input matrix with dimension ``(N, N)``
@@ -35,7 +34,6 @@ def cholesky(a):
     util._assert_rank2(a)
     util._assert_nd_squareness(a)
 
-    # Cast to float32 or float64
     if a.dtype.char == 'f' or a.dtype.char == 'd':
         dtype = a.dtype.char
     else:

--- a/cupy/linalg/decomposition.py
+++ b/cupy/linalg/decomposition.py
@@ -64,17 +64,13 @@ def cholesky(a):
         cusolver.cpotrf(
             handle, cublas.CUBLAS_FILL_MODE_UPPER, n, x.data.ptr, n,
             workspace.data.ptr, buffersize, dev_info.data.ptr)
-    elif dtype == 'D':
+    else:  # dtype == 'D':
         buffersize = cusolver.zpotrf_bufferSize(
             handle, cublas.CUBLAS_FILL_MODE_UPPER, n, x.data.ptr, n)
         workspace = cupy.empty(buffersize, dtype=numpy.complex128)
         cusolver.zpotrf(
             handle, cublas.CUBLAS_FILL_MODE_UPPER, n, x.data.ptr, n,
             workspace.data.ptr, buffersize, dev_info.data.ptr)
-    else:
-        raise ValueError(
-            'dtype must be int32, int64, uint32, uint64, float32, float64,'
-            ' complex64 or complex128 (actual: {})'.format(dtype))
 
     status = int(dev_info[0])
     if status > 0:

--- a/cupy/linalg/decomposition.py
+++ b/cupy/linalg/decomposition.py
@@ -52,13 +52,32 @@ def cholesky(a):
         cusolver.spotrf(
             handle, cublas.CUBLAS_FILL_MODE_UPPER, n, x.data.ptr, n,
             workspace.data.ptr, buffersize, dev_info.data.ptr)
-    else:  # dtype == 'd'
+    elif dtype == 'd':
         buffersize = cusolver.dpotrf_bufferSize(
             handle, cublas.CUBLAS_FILL_MODE_UPPER, n, x.data.ptr, n)
         workspace = cupy.empty(buffersize, dtype=numpy.float64)
         cusolver.dpotrf(
             handle, cublas.CUBLAS_FILL_MODE_UPPER, n, x.data.ptr, n,
             workspace.data.ptr, buffersize, dev_info.data.ptr)
+    elif dtype == 'F':
+        buffersize = cusolver.cpotrf_bufferSize(
+            handle, cublas.CUBLAS_FILL_MODE_UPPER, n, x.data.ptr, n)
+        workspace = cupy.empty(buffersize, dtype=numpy.complex64)
+        cusolver.cpotrf(
+            handle, cublas.CUBLAS_FILL_MODE_UPPER, n, x.data.ptr, n,
+            workspace.data.ptr, buffersize, dev_info.data.ptr)
+    elif dtype == 'D':
+        buffersize = cusolver.zpotrf_bufferSize(
+            handle, cublas.CUBLAS_FILL_MODE_UPPER, n, x.data.ptr, n)
+        workspace = cupy.empty(buffersize, dtype=numpy.complex128)
+        cusolver.zpotrf(
+            handle, cublas.CUBLAS_FILL_MODE_UPPER, n, x.data.ptr, n,
+            workspace.data.ptr, buffersize, dev_info.data.ptr)
+    else:
+        raise ValueError(
+            'dtype must be int32, int64, uint32, uint64, float32, float64,'
+            ' complex64 or complex128 (actual: {})'.format(dtype))
+
     status = int(dev_info[0])
     if status > 0:
         raise linalg.LinAlgError(

--- a/tests/cupy_tests/linalg_tests/test_decomposition.py
+++ b/tests/cupy_tests/linalg_tests/test_decomposition.py
@@ -55,7 +55,7 @@ class TestCholeskyDecomposition(unittest.TestCase):
 
     @testing.for_dtypes([
         numpy.int32, numpy.int64, numpy.uint32, numpy.uint64,
-        numpy.float32, numpy.float64])
+        numpy.float32, numpy.float64, numpy.complex64, numpy.complex128])
     def test_decomposition(self, dtype):
         # A positive definite matrix
         A = random_matrix((5, 5), dtype, scale=(10, 10000), sym=True)

--- a/tests/cupy_tests/linalg_tests/test_decomposition.py
+++ b/tests/cupy_tests/linalg_tests/test_decomposition.py
@@ -33,6 +33,7 @@ def random_matrix(shape, dtype, scale, sym=False):
         a = a + 1j * numpy.random.standard_normal(shape)
     u, s, vh = numpy.linalg.svd(a)
     if sym:
+        assert m == n
         vh = u.conj().swapaxes(-1, -2)
     new_s = numpy.random.uniform(low_s, high_s, s.shape)
     new_a = numpy.einsum('...ij,...j,...jk->...ik', u, new_s, vh)

--- a/tests/cupy_tests/linalg_tests/test_decomposition.py
+++ b/tests/cupy_tests/linalg_tests/test_decomposition.py
@@ -29,13 +29,13 @@ def random_matrix(shape, dtype, scale, sym=False):
             high_s = bias = high_s / (1 + numpy.sqrt(m * n))
     assert low_s <= high_s
     a = numpy.random.standard_normal(shape)
+    if dtype.kind == 'c':
+        a = a + 1j * numpy.random.standard_normal(shape)
     u, s, vh = numpy.linalg.svd(a)
-    new_s = numpy.random.uniform(low_s, high_s, s.shape)
     if sym:
-        assert m == n
-        new_a = numpy.einsum('...ij,...j,...kj', u, new_s, u)
-    else:
-        new_a = numpy.einsum('...ij,...j,...jk', u, new_s, vh)
+        vh = u.conj().swapaxes(-1, -2)
+    new_s = numpy.random.uniform(low_s, high_s, s.shape)
+    new_a = numpy.einsum('...ij,...j,...jk->...ik', u, new_s, vh)
     if bias is not None:
         new_a += bias
     if dtype.kind in 'iu':


### PR DESCRIPTION
Adds support for complex dtypes in `cupy.linalg.cholesky`. C.f. https://github.com/cupy/cupy/pull/2468.