### PR TITLE
Add `get_global()` to `cupy.RawModule`

### DIFF
--- a/docs/source/tutorial/kernel.rst
+++ b/docs/source/tutorial/kernel.rst
@@ -311,7 +311,7 @@ For dealing a large raw CUDA source or loading an existing CUDA binary, the :cla
 
 The instruction above for using complex numbers in :class:`~cupy.RawKernel` also applies to :class:`~cupy.RawModule`.
 
-For CUDA kernels that need to access globol symbols, such as constant memory, the :meth:`~cupy.RawModule.get_global` method can be used, see its documentation for further detail.
+For CUDA kernels that need to access global symbols, such as constant memory, the :meth:`~cupy.RawModule.get_global` method can be used, see its documentation for further detail.
 
 CuPy also supports the Texture Reference API. A handle to the texture reference in a module can be retrieved by name via :meth:`~cupy.RawModule.get_texref`. Then, you need to pass it to :class:`~cupy.cuda.texture.TextureReference`, along with a resource descriptor and texture descriptor, for binding the reference to the array. (The interface of :class:`~cupy.cuda.texture.TextureReference` is meant to mimic that of :class:`~cupy.cuda.texture.TextureObject` to help users make transition to the latter, since as of CUDA Toolkit 10.1 the former is marked as deprecated.)
 

--- a/docs/source/tutorial/kernel.rst
+++ b/docs/source/tutorial/kernel.rst
@@ -311,6 +311,8 @@ For dealing a large raw CUDA source or loading an existing CUDA binary, the :cla
 
 The instruction above for using complex numbers in :class:`~cupy.RawKernel` also applies to :class:`~cupy.RawModule`.
 
+For CUDA kernels that need to access globol symbols, such as constant memory, the :meth:`~cupy.RawModule.get_global` method can be used, see its documentation for further detail.
+
 CuPy also supports the Texture Reference API. A handle to the texture reference in a module can be retrieved by name via :meth:`~cupy.RawModule.get_texref`. Then, you need to pass it to :class:`~cupy.cuda.texture.TextureReference`, along with a resource descriptor and texture descriptor, for binding the reference to the array. (The interface of :class:`~cupy.cuda.texture.TextureReference` is meant to mimic that of :class:`~cupy.cuda.texture.TextureObject` to help users make transition to the latter, since as of CUDA Toolkit 10.1 the former is marked as deprecated.)
 
 

--- a/tests/cupy_tests/core_tests/test_raw.py
+++ b/tests/cupy_tests/core_tests/test_raw.py
@@ -534,15 +534,15 @@ class TestRaw(unittest.TestCase):
         assert (out_down == a.astype(cupy.complex64)).all()
 
     def test_const_memory(self):
-        mod = cupy.RawModule(code=test_const_mem)
+        mod = cupy.RawModule(test_const_mem, backend=self.backend)
         ker = mod.get_function('multiply_by_const')
         mem_ptr = mod.get_global('some_array')
         const_arr = cupy.ndarray((100,), cupy.float32, mem_ptr)
-        const_data = cupy.arange(100, dtype=cupy.float32)
-        const_arr[...] = const_data
+        data = cupy.arange(100, dtype=cupy.float32)
+        const_arr[...] = data
         output_arr = cupy.ones(100, dtype=cupy.float32)
         ker((1,), (100,), (output_arr, cupy.int32(100)))
-        assert (const_data == output_arr).all()
+        assert (data == output_arr).all()
 
 
 _test_grid_sync = r'''

--- a/tests/cupy_tests/core_tests/test_raw.py
+++ b/tests/cupy_tests/core_tests/test_raw.py
@@ -534,7 +534,7 @@ class TestRaw(unittest.TestCase):
         assert (out_down == a.astype(cupy.complex64)).all()
 
     def test_const_memory(self):
-        mod = cupy.RawModule(test_const_mem, backend=self.backend)
+        mod = cupy.RawModule(code=test_const_mem, backend=self.backend)
         ker = mod.get_function('multiply_by_const')
         mem_ptr = mod.get_global('some_array')
         const_arr = cupy.ndarray((100,), cupy.float32, mem_ptr)


### PR DESCRIPTION
Close #1703.

This PR adds a public API to `cupy.RawModule`. This enables, for example, the usage of constant memory in `RawKernel`s, which makes it easier for PyCUDA and general CUDA users to migrate to CuPy, part of an ongoing effort tracked in #2450. See also the discussion in #1703.

Note that a Cython wrapper for the CUDA driver API `cuModuleGetGlobal()` already exists, so with this PR all `cuModuleGet*()` functions are exposed to end users via `cupy.RawModule`.