### PR TITLE
Enhance shuffle-test of `testing.for_dtypes_combination`

### DIFF
--- a/cupy/testing/helper.py
+++ b/cupy/testing/helper.py
@@ -838,25 +838,11 @@ def for_dtypes_combination(types, names=('dtype',), full=None):
     on the option ``full``. If ``full`` is ``True``,
     all combinations of ``types`` are tested.
     Sometimes, such an exhaustive test can be costly.
-    So, if ``full`` is ``False``, only the subset of possible
-    combinations is tested. Specifically, at first,
-    the shuffled lists of ``types`` are made for each argument
-    name in ``names``.
-    Let the lists be ``D1``, ``D2``, ..., ``Dn``
-    where :math:`n` is the number of arguments.
-    Then, the combinations to be tested will be ``zip(D1, ..., Dn)``.
-    If ``full`` is ``None``, the behavior is switched
-    by setting the environment variable ``CUPY_TEST_FULL_COMBINATION=1``.
-
-    For example, let ``types`` be ``[float16, float32, float64]``
-    and ``names`` be ``['a_type', 'b_type']``. If ``full`` is ``True``,
-    then the decorated test fixture is executed with all
-    :math:`2^3` patterns. On the other hand, if ``full`` is ``False``,
-    shuffled lists are made for ``a_type`` and ``b_type``.
-    Suppose the lists are ``(16, 64, 32)`` for ``a_type`` and
-    ``(32, 64, 16)`` for ``b_type`` (prefixes are removed for short).
-    Then the combinations of ``(a_type, b_type)`` to be tested are
-    ``(16, 32)``, ``(64, 64)`` and ``(32, 16)``.
+    So, if ``full`` is ``False``, only a subset of possible combinations
+    is randomly sampled. If ``full`` is ``None``, the behavior is
+    determined by an environment variable ``CUPY_TEST_FULL_COMBINATION``.
+    If the value is set to ``'1'``, it behaves as if ``full=True``, and
+    otherwise ``full=False``.
     """
 
     types = list(types)

--- a/cupy/testing/helper.py
+++ b/cupy/testing/helper.py
@@ -859,6 +859,12 @@ def for_dtypes_combination(types, names=('dtype',), full=None):
     ``(16, 32)``, ``(64, 64)`` and ``(32, 16)``.
     """
 
+    types = list(types)
+
+    if len(types) == 1:
+        name, = names
+        return for_dtypes(types, name)
+
     if full is None:
         full = int(os.environ.get('CUPY_TEST_FULL_COMBINATION', '0')) != 0
 
@@ -868,9 +874,9 @@ def for_dtypes_combination(types, names=('dtype',), full=None):
         ts = []
         for _ in range(len(names)):
             # Make shuffled list of types for each name
-            t = list(types)
-            random.shuffle(t)
-            ts.append(t)
+            shuffled_types = types[:]
+            random.shuffle(shuffled_types)
+            ts.append(types + shuffled_types)
 
         combination = [dict(zip(names, typs)) for typs in zip(*ts)]
 

--- a/cupy/testing/helper.py
+++ b/cupy/testing/helper.py
@@ -879,6 +879,7 @@ def for_dtypes_combination(types, names=('dtype',), full=None):
             ts.append(types + shuffled_types)
 
         combination = [tuple(zip(names, typs)) for typs in zip(*ts)]
+        # Remove duplicate entries
         combination = [dict(assoc_list) for assoc_list in set(combination)]
 
     def decorator(impl):

--- a/cupy/testing/helper.py
+++ b/cupy/testing/helper.py
@@ -878,7 +878,8 @@ def for_dtypes_combination(types, names=('dtype',), full=None):
             random.shuffle(shuffled_types)
             ts.append(types + shuffled_types)
 
-        combination = [dict(zip(names, typs)) for typs in zip(*ts)]
+        combination = [tuple(zip(names, typs)) for typs in zip(*ts)]
+        combination = [dict(assoc_list) for assoc_list in set(combination)]
 
     def decorator(impl):
         @functools.wraps(impl)


### PR DESCRIPTION
Current shuffle-test sometimes causes stochastic test failure because the dtypes combination whose `result_type` is `bool` is rarely chosen. This PR prevents passing such tests.