### PR TITLE
enable fast CUB-based reductions in more cases (example cupy.linalg.norm)

### DIFF
--- a/cupy/core/_routines_math.pyx
+++ b/cupy/core/_routines_math.pyx
@@ -74,8 +74,8 @@ cdef ndarray _ndarray_prod(ndarray self, axis, dtype, out, keepdims):
 
 cdef ndarray _ndarray_sum(ndarray self, axis, dtype, out, keepdims):
     if cupy.cuda.cub_enabled:
-        if (cub.can_use_reduce_sum(self.dtype, dtype) and (axis is None)
-                and (not keepdims)):
+        if (cub.can_use_reduce_sum(self.dtype, self.ndim, dtype, axis) and
+                (not keepdims)):
             return cub.reduce_sum(self, out=out)
     if dtype is None:
         return _sum_auto_dtype(self, axis, dtype, out, keepdims)

--- a/cupy/core/_routines_math.pyx
+++ b/cupy/core/_routines_math.pyx
@@ -74,9 +74,8 @@ cdef ndarray _ndarray_prod(ndarray self, axis, dtype, out, keepdims):
 
 cdef ndarray _ndarray_sum(ndarray self, axis, dtype, out, keepdims):
     if cupy.cuda.cub_enabled:
-        if (cub.can_use_reduce_sum(self.dtype, self.ndim, dtype, axis) and
-                (not keepdims)):
-            return cub.reduce_sum(self, out=out)
+        if cub.can_use_reduce_sum(self.dtype, self.ndim, dtype, axis):
+            return cub.reduce_sum(self, out=out, keepdims=keepdims)
     if dtype is None:
         return _sum_auto_dtype(self, axis, dtype, out, keepdims)
     else:

--- a/cupy/core/_routines_statistics.pyx
+++ b/cupy/core/_routines_statistics.pyx
@@ -13,7 +13,7 @@ if cupy.cuda.cub_enabled:
 
 cdef ndarray _ndarray_max(ndarray self, axis, out, dtype, keepdims):
     if cupy.cuda.cub_enabled:
-        if (cub.can_use_reduce_max(self.dtype, dtype) and (axis is None) and
+        if (cub.can_use_reduce_max(self.dtype, self.ndim, dtype, axis) and
                 (not keepdims)):
             return cub.reduce_max(self, out=out)
     return _amax(self, axis=axis, out=out, dtype=dtype, keepdims=keepdims)
@@ -21,7 +21,7 @@ cdef ndarray _ndarray_max(ndarray self, axis, out, dtype, keepdims):
 
 cdef ndarray _ndarray_min(ndarray self, axis, out, dtype, keepdims):
     if cupy.cuda.cub_enabled:
-        if (cub.can_use_reduce_min(self.dtype, dtype) and (axis is None) and
+        if (cub.can_use_reduce_min(self.dtype, self.ndim, dtype, axis) and
                 (not keepdims)):
             return cub.reduce_min(self, out=out)
     return _amin(self, axis=axis, out=out, dtype=dtype, keepdims=keepdims)

--- a/cupy/core/_routines_statistics.pyx
+++ b/cupy/core/_routines_statistics.pyx
@@ -13,17 +13,15 @@ if cupy.cuda.cub_enabled:
 
 cdef ndarray _ndarray_max(ndarray self, axis, out, dtype, keepdims):
     if cupy.cuda.cub_enabled:
-        if (cub.can_use_reduce_max(self.dtype, self.ndim, dtype, axis) and
-                (not keepdims)):
-            return cub.reduce_max(self, out=out)
+        if cub.can_use_reduce_max(self.dtype, self.ndim, dtype, axis):
+            return cub.reduce_max(self, out=out, keepdims=keepdims)
     return _amax(self, axis=axis, out=out, dtype=dtype, keepdims=keepdims)
 
 
 cdef ndarray _ndarray_min(ndarray self, axis, out, dtype, keepdims):
     if cupy.cuda.cub_enabled:
-        if (cub.can_use_reduce_min(self.dtype, self.ndim, dtype, axis) and
-                (not keepdims)):
-            return cub.reduce_min(self, out=out)
+        if cub.can_use_reduce_min(self.dtype, self.ndim, dtype, axis):
+            return cub.reduce_min(self, out=out, keepdims=keepdims)
     return _amin(self, axis=axis, out=out, dtype=dtype, keepdims=keepdims)
 
 

--- a/cupy/cuda/cub.pyx
+++ b/cupy/cuda/cub.pyx
@@ -66,7 +66,13 @@ def reduce_sum(core.ndarray x, out=None):
     return y
 
 
-def can_use_reduce_sum(x_dtype, dtype=None):
+cpdef bint _cub_axis_compatible(axis, Py_ssize_t ndim):
+    if ((axis is None) or ndim == 1 or axis == tuple(range(ndim))):
+        return True
+    return False
+
+
+def can_use_reduce_sum(x_dtype, Py_ssize_t ndim, dtype=None, axis=None):
     if dtype is None:
         # auto dtype:
         # CUB reduce_sum does not support dtype promotion.
@@ -82,7 +88,7 @@ def can_use_reduce_sum(x_dtype, dtype=None):
         return False
     if x_dtype not in support_dtype:
         return False
-    return True
+    return _cub_axis_compatible(axis, ndim)
 
 
 def reduce_min(core.ndarray x, out=None):
@@ -108,7 +114,7 @@ def reduce_min(core.ndarray x, out=None):
     return y
 
 
-def can_use_reduce_min(x_dtype, dtype=None):
+def can_use_reduce_min(x_dtype, Py_ssize_t ndim, dtype=None, axis=None):
     if dtype is None or dtype == x_dtype:
         support_dtype = [numpy.int8, numpy.uint8, numpy.int16, numpy.uint16,
                          numpy.int32, numpy.uint32, numpy.int64, numpy.uint64,
@@ -117,7 +123,7 @@ def can_use_reduce_min(x_dtype, dtype=None):
         return False
     if x_dtype not in support_dtype:
         return False
-    return True
+    return _cub_axis_compatible(axis, ndim)
 
 
 def reduce_max(core.ndarray x, out=None):
@@ -143,7 +149,7 @@ def reduce_max(core.ndarray x, out=None):
     return y
 
 
-def can_use_reduce_max(x_dtype, dtype=None):
+def can_use_reduce_max(x_dtype, Py_ssize_t ndim, dtype=None, axis=None):
     if dtype is None or dtype == x_dtype:
         support_dtype = [numpy.int8, numpy.uint8, numpy.int16, numpy.uint16,
                          numpy.int32, numpy.uint32, numpy.int64, numpy.uint64,
@@ -152,7 +158,7 @@ def can_use_reduce_max(x_dtype, dtype=None):
         return False
     if x_dtype not in support_dtype:
         return False
-    return True
+    return _cub_axis_compatible(axis, ndim)
 
 
 def _get_dtype_id(dtype):

--- a/cupy/cuda/cub.pyx
+++ b/cupy/cuda/cub.pyx
@@ -43,7 +43,7 @@ cdef extern from 'cupy_cub.h':
 ###############################################################################
 
 
-def reduce_sum(core.ndarray x, out=None):
+def reduce_sum(core.ndarray x, out=None, bint keepdims=False):
     cdef core.ndarray y
     cdef core.ndarray ws
     cdef int dtype_id
@@ -60,7 +60,13 @@ def reduce_sum(core.ndarray x, out=None):
     ws = core.ndarray(ws_size, numpy.int8)
     ws_ptr = <void *>ws.data.ptr
     cub_reduce_sum(x_ptr, y_ptr, x.size, ws_ptr, ws_size, dtype_id)
+    if keepdims:
+        y = y.reshape((1,))
     if out is not None:
+        if y.ndim != out.ndim:
+            raise ValueError(
+                "output parameter for reduction operation sum has the wrong "
+                "number of dimensions")
         out[...] = y
         y = out
     return y
@@ -91,7 +97,7 @@ def can_use_reduce_sum(x_dtype, Py_ssize_t ndim, dtype=None, axis=None):
     return _cub_axis_compatible(axis, ndim)
 
 
-def reduce_min(core.ndarray x, out=None):
+def reduce_min(core.ndarray x, out=None, bint keepdims=False):
     cdef core.ndarray y
     cdef core.ndarray ws
     cdef int dtype_id
@@ -108,7 +114,13 @@ def reduce_min(core.ndarray x, out=None):
     ws = core.ndarray(ws_size, numpy.int8)
     ws_ptr = <void *>ws.data.ptr
     cub_reduce_min(x_ptr, y_ptr, x.size, ws_ptr, ws_size, dtype_id)
+    if keepdims:
+        y = y.reshape((1,))
     if out is not None:
+        if y.ndim != out.ndim:
+            raise ValueError(
+                "output parameter for reduction operation min has the wrong "
+                "number of dimensions")
         out[...] = y
         y = out
     return y
@@ -126,7 +138,7 @@ def can_use_reduce_min(x_dtype, Py_ssize_t ndim, dtype=None, axis=None):
     return _cub_axis_compatible(axis, ndim)
 
 
-def reduce_max(core.ndarray x, out=None):
+def reduce_max(core.ndarray x, out=None, bint keepdims=False):
     cdef core.ndarray y
     cdef core.ndarray ws
     cdef int dtype_id
@@ -143,7 +155,13 @@ def reduce_max(core.ndarray x, out=None):
     ws = core.ndarray(ws_size, numpy.int8)
     ws_ptr = <void *>ws.data.ptr
     cub_reduce_max(x_ptr, y_ptr, x.size, ws_ptr, ws_size, dtype_id)
+    if keepdims:
+        y = y.reshape((1,))
     if out is not None:
+        if y.ndim != out.ndim:
+            raise ValueError(
+                "output parameter for reduction operation max has the wrong "
+                "number of dimensions")
         out[...] = y
         y = out
     return y

--- a/cupy/cuda/cub.pyx
+++ b/cupy/cuda/cub.pyx
@@ -46,11 +46,16 @@ cdef extern from 'cupy_cub.h':
 def reduce_sum(core.ndarray x, out=None, bint keepdims=False):
     cdef core.ndarray y
     cdef core.ndarray ws
-    cdef int dtype_id
+    cdef int dtype_id, ndim_out
     cdef size_t ws_size
     cdef void *x_ptr
     cdef void *y_ptr
     cdef void *ws_ptr
+    ndim_out = keepdims
+    if out is not None and out.ndim != ndim_out:
+        raise ValueError(
+            "output parameter for reduction operation sum has the wrong "
+            "number of dimensions")
     x = core.ascontiguousarray(x)
     y = core.ndarray((), x.dtype)
     x_ptr = <void *>x.data.ptr
@@ -63,10 +68,6 @@ def reduce_sum(core.ndarray x, out=None, bint keepdims=False):
     if keepdims:
         y = y.reshape((1,))
     if out is not None:
-        if y.ndim != out.ndim:
-            raise ValueError(
-                "output parameter for reduction operation sum has the wrong "
-                "number of dimensions")
         out[...] = y
         y = out
     return y
@@ -100,11 +101,16 @@ def can_use_reduce_sum(x_dtype, Py_ssize_t ndim, dtype=None, axis=None):
 def reduce_min(core.ndarray x, out=None, bint keepdims=False):
     cdef core.ndarray y
     cdef core.ndarray ws
-    cdef int dtype_id
+    cdef int dtype_id, ndim_out
     cdef size_t ws_size
     cdef void *x_ptr
     cdef void *y_ptr
     cdef void *ws_ptr
+    ndim_out = keepdims
+    if out is not None and out.ndim != ndim_out:
+        raise ValueError(
+            "output parameter for reduction operation sum has the wrong "
+            "number of dimensions")
     x = core.ascontiguousarray(x)
     y = core.ndarray((), x.dtype)
     x_ptr = <void *>x.data.ptr
@@ -117,10 +123,6 @@ def reduce_min(core.ndarray x, out=None, bint keepdims=False):
     if keepdims:
         y = y.reshape((1,))
     if out is not None:
-        if y.ndim != out.ndim:
-            raise ValueError(
-                "output parameter for reduction operation min has the wrong "
-                "number of dimensions")
         out[...] = y
         y = out
     return y
@@ -141,11 +143,16 @@ def can_use_reduce_min(x_dtype, Py_ssize_t ndim, dtype=None, axis=None):
 def reduce_max(core.ndarray x, out=None, bint keepdims=False):
     cdef core.ndarray y
     cdef core.ndarray ws
-    cdef int dtype_id
+    cdef int dtype_id, ndim_out
     cdef size_t ws_size
     cdef void *x_ptr
     cdef void *y_ptr
     cdef void *ws_ptr
+    ndim_out = keepdims
+    if out is not None and out.ndim != ndim_out:
+        raise ValueError(
+            "output parameter for reduction operation sum has the wrong "
+            "number of dimensions")
     x = core.ascontiguousarray(x)
     y = core.ndarray((), x.dtype)
     x_ptr = <void *>x.data.ptr
@@ -158,10 +165,6 @@ def reduce_max(core.ndarray x, out=None, bint keepdims=False):
     if keepdims:
         y = y.reshape((1,))
     if out is not None:
-        if y.ndim != out.ndim:
-            raise ValueError(
-                "output parameter for reduction operation max has the wrong "
-                "number of dimensions")
         out[...] = y
         y = out
     return y

--- a/cupy/linalg/norms.py
+++ b/cupy/linalg/norms.py
@@ -61,20 +61,18 @@ def norm(x, ord=None, axis=None, keepdims=False):
         axis = (axis,)
 
     if len(axis) == 1:
-        if nd == 1:
-            # fast CUB-based reductions require axis=None, keepdims=False
-            axis = None
         if ord == numpy.Inf:
-            ret = abs(x).max(axis=axis)
+            return abs(x).max(axis=axis, keepdims=keepdims)
         elif ord == -numpy.Inf:
-            ret = abs(x).min(axis=axis)
+            return abs(x).min(axis=axis, keepdims=keepdims)
         elif ord == 0:
             # Zero norm
             # Convert to Python float in accordance with NumPy
-            ret = (x != 0).astype(x.real.dtype).sum(axis=axis)
+            return (x != 0).astype(x.real.dtype).sum(
+                axis=axis, keepdims=keepdims)
         elif ord == 1:
             # special case for speedup
-            ret = abs(x).sum(axis=axis)
+            return abs(x).sum(axis=axis, keepdims=keepdims)
         elif ord is None or ord == 2:
             # special case for speedup
             if x.dtype.kind == 'c':
@@ -82,7 +80,7 @@ def norm(x, ord=None, axis=None, keepdims=False):
                 s *= s
             else:
                 s = x * x
-            ret = cupy.sqrt(s.sum(axis=axis))
+            return cupy.sqrt(s.sum(axis=axis, keepdims=keepdims))
         else:
             try:
                 float(ord)
@@ -91,15 +89,9 @@ def norm(x, ord=None, axis=None, keepdims=False):
 
             absx = abs(x)
             absx **= ord
-            ret = absx.sum(axis=axis)
+            ret = absx.sum(axis=axis, keepdims=keepdims)
             ret **= cupy.reciprocal(ord, dtype=ret.dtype)
-        if keepdims:
-            if nd == 1:
-                return ret.reshape((1,))
-            ret_shape = list(x.shape)
-            ret_shape[axis[0]] = 1
-            ret = ret.reshape(ret_shape)
-        return ret
+            return ret
     elif len(axis) == 2:
         row_axis, col_axis = axis
         if row_axis < 0:

--- a/cupy/linalg/norms.py
+++ b/cupy/linalg/norms.py
@@ -61,6 +61,8 @@ def norm(x, ord=None, axis=None, keepdims=False):
         axis = (axis,)
 
     if len(axis) == 1:
+        if nd == 1:
+            axis = None  # fast CUB-based reductions require axis == None
         if ord == numpy.Inf:
             return abs(x).max(axis=axis, keepdims=keepdims)
         elif ord == -numpy.Inf:


### PR DESCRIPTION
This PR enables much faster 1D norms by ensuring calls to `max`, `min` and `sum` use 
```Python
axis=None, keepdims=False
```
to allow use of CUB for the reductions.

For large arrays, this can give an order of magnitude speed improvement.

For reference, the logic used here is chosen to enable the CUB code path based on:
https://github.com/cupy/cupy/blob/c9c7c4eedcca54e6f53b5dcfc205d4ad94a2b595/cupy/core/_routines_math.pyx#L76-L79

**edit**: in more recent commits below I have reverted the changes to `norm` itself and instead changed the CUB reduction code instead