### PR TITLE
Allow to use `real` and `imag` on cuda kernels

### DIFF
--- a/cupy/core/include/cupy/complex.cuh
+++ b/cupy/core/include/cupy/complex.cuh
@@ -4,6 +4,8 @@
 
 using thrust::complex;
 using thrust::conj;
+using thrust::real;
+using thrust::imag;
 using thrust::arg;
 
 using thrust::exp;

--- a/cupy/core/include/cupy/complex/arithmetic.h
+++ b/cupy/core/include/cupy/complex/arithmetic.h
@@ -274,6 +274,16 @@ __device__ inline complex<ValueType> conj(const complex<ValueType>& z) {
 }
 
 template <typename ValueType>
+__device__ inline ValueType real(const complex<ValueType>& z) {
+  return z.real();
+}
+
+template <typename ValueType>
+__device__ inline ValueType imag(const complex<ValueType>& z) {
+  return z.imag();
+}
+
+template <typename ValueType>
 __device__ inline ValueType norm(const complex<ValueType>& z) {
   return z.real() * z.real() + z.imag() * z.imag();
 }

--- a/cupy/core/include/cupy/complex/complex.h
+++ b/cupy/core/include/cupy/complex/complex.h
@@ -201,6 +201,20 @@ __device__ inline T norm(const complex<T>& z);
 template <typename T>
 __device__ inline complex<T> conj(const complex<T>& z);
 
+/*! Returns the real part of a \p complex.
+ *
+ *  \param z The \p complex from which to return the real part
+ */
+template <typename T>
+__device__ inline T real(const complex<T>& z);
+
+/*! Returns the imaginary part of a \p complex.
+ *
+ *  \param z The \p complex from which to return the imaginary part
+ */
+template <typename T>
+__device__ inline T imag(const complex<T>& z);
+
 /*! Returns a \p complex with the specified magnitude and phase.
  *
  *  \param m The magnitude of the returned \p complex.


### PR DESCRIPTION
`ReductionKernel`, `ElementwiseKernel` and `RawKernel` couldn't use `real(number)` or `img(number)` to retrieve the real and imaginary parts of complex numbers