### PR TITLE
checks for whether cuSOLVER is enabled aren't needed anymore

### DIFF
--- a/cupy/cuda/__init__.py
+++ b/cupy/cuda/__init__.py
@@ -21,6 +21,8 @@ _cub_disabled = None
 
 
 from cupy.cuda import cusolver  # NOQA
+# This flag is kept for backward compatibility.
+# It is always True as cuSOLVER library is always available in CUDA 8.0+.
 cusolver_enabled = True
 
 try:

--- a/cupy/cuda/cupy_cusparse.h
+++ b/cupy/cuda/cupy_cusparse.h
@@ -67,10 +67,9 @@ cusparseStatus_t cusparseSetStream(...) {
   return CUSPARSE_STATUS_SUCCESS;
 }
 
-// cusparseGetStream is only available from CUDA 8.0
-// cusparseStatus_t cusparseGetStream(...) {
-//   return CUSPARSE_STATUS_SUCCESS;
-// }
+cusparseStatus_t cusparseGetStream(...) {
+   return CUSPARSE_STATUS_SUCCESS;
+}
 
 // cuSPARSE Level1 Function
 cusparseStatus_t cusparseSgthr(...) {
@@ -113,7 +112,7 @@ cusparseStatus_t cusparseCsrmvEx_bufferSize(...) {
 cusparseStatus_t cusparseCsrmvEx(...) {
   return CUSPARSE_STATUS_SUCCESS;
 }
-  
+
 // cuSPARSE Level3 Function
 cusparseStatus_t cusparseScsrmm(...) {
   return CUSPARSE_STATUS_SUCCESS;

--- a/cupy/cuda/cusparse.pyx
+++ b/cupy/cuda/cusparse.pyx
@@ -24,8 +24,7 @@ cdef extern from 'cupy_cusparse.h':
 
     # Stream
     Status cusparseSetStream(Handle handle, driver.Stream streamId)
-    # cusparseGetStream is only available from CUDA 8.0
-    # Status cusparseGetStream(Handle handle, driver.Stream* streamId)
+    Status cusparseGetStream(Handle handle, driver.Stream* streamId)
 
     # cuSPARSE Level1 Function
     Status cusparseSgthr(
@@ -528,12 +527,11 @@ cpdef setStream(size_t handle, size_t stream):
     check_status(status)
 
 
-# cusparseGetStream is only available from CUDA 8.0
-# cpdef size_t getStream(size_t handle) except? 0:
-#     cdef driver.Stream stream
-#     status = cusparseGetStream(<Handle>handle, &stream)
-#     check_status(status)
-#     return <size_t>stream
+cpdef size_t getStream(size_t handle) except? 0:
+    cdef driver.Stream stream
+    status = cusparseGetStream(<Handle>handle, &stream)
+    check_status(status)
+    return <size_t>stream
 
 
 ########################################

--- a/cupy/cuda/device.pyx
+++ b/cupy/cuda/device.pyx
@@ -3,17 +3,13 @@
 import threading
 
 from cupy.cuda import cublas
+from cupy.cuda import cusolver
 from cupy.cuda import cusparse
 from cupy.cuda cimport runtime
 from cupy.cuda import runtime as runtime_module
 from cupy import util
 
-try:
-    from cupy.cuda import cusolver
-    cusolver_enabled = True
-except ImportError:
-    cusolver_enabled = False
-
+cusolver_enabled = True
 
 cdef object _thread_local = threading.local()
 

--- a/cupy/cuda/device.pyx
+++ b/cupy/cuda/device.pyx
@@ -9,6 +9,8 @@ from cupy.cuda cimport runtime
 from cupy.cuda import runtime as runtime_module
 from cupy import util
 
+# This flag is kept for backward compatibility.
+# It is always True as cuSOLVER library is always available in CUDA 8.0+.
 cusolver_enabled = True
 
 cdef object _thread_local = threading.local()

--- a/cupy/linalg/decomposition.py
+++ b/cupy/linalg/decomposition.py
@@ -2,13 +2,10 @@ import numpy
 from numpy import linalg
 
 import cupy
-from cupy import cuda
 from cupy.cuda import cublas
+from cupy.cuda import cusolver
 from cupy.cuda import device
 from cupy.linalg import util
-
-if cuda.cusolver_enabled:
-    from cupy.cuda import cusolver
 
 
 def cholesky(a):
@@ -27,9 +24,6 @@ def cholesky(a):
 
     .. seealso:: :func:`numpy.linalg.cholesky`
     """
-    if not cuda.cusolver_enabled:
-        raise RuntimeError('Current cupy only supports cusolver in CUDA 8.0')
-
     # TODO(Saito): Current implementation only accepts two-dimensional arrays
     util._assert_cupy_array(a)
     util._assert_rank2(a)
@@ -93,9 +87,6 @@ def qr(a, mode='reduced'):
 
     .. seealso:: :func:`numpy.linalg.qr`
     """
-    if not cuda.cusolver_enabled:
-        raise RuntimeError('Current cupy only supports cusolver in CUDA 8.0')
-
     # TODO(Saito): Current implementation only accepts two-dimensional arrays
     util._assert_cupy_array(a)
     util._assert_rank2(a)
@@ -201,9 +192,6 @@ def svd(a, full_matrices=True, compute_uv=True):
 
     .. seealso:: :func:`numpy.linalg.svd`
     """
-    if not cuda.cusolver_enabled:
-        raise RuntimeError('Current cupy only supports cusolver in CUDA 8.0')
-
     # TODO(Saito): Current implementation only accepts two-dimensional arrays
     util._assert_cupy_array(a)
     util._assert_rank2(a)

--- a/cupy/linalg/eigenvalue.py
+++ b/cupy/linalg/eigenvalue.py
@@ -1,12 +1,9 @@
 import numpy
 
 import cupy
-from cupy import cuda
 from cupy.cuda import cublas
+from cupy.cuda import cusolver
 from cupy.cuda import device
-
-if cuda.cusolver_enabled:
-    from cupy.cuda import cusolver
 
 
 def _syevd(a, UPLO, with_eigen_vector):
@@ -102,10 +99,6 @@ def eigh(a, UPLO='L'):
 
        Currenlty only 2-D matrix is supported.
 
-    .. note::
-
-       CUDA >=8.0 is required.
-
     Args:
         a (cupy.ndarray): A symmetric 2-D square matrix.
         UPLO (str): Select from ``'L'`` or ``'U'``. It specifies which
@@ -119,8 +112,6 @@ def eigh(a, UPLO='L'):
 
     .. seealso:: :func:`numpy.linalg.eigh`
     """
-    if not cuda.cusolver_enabled:
-        raise RuntimeError('Current cupy only supports cusolver in CUDA 8.0')
     return _syevd(a, UPLO, True)
 
 
@@ -138,10 +129,6 @@ def eigvalsh(a, UPLO='L'):
 
        Currenlty only 2-D matrix is supported.
 
-    .. note::
-
-       CUDA >=8.0 is required.
-
     Args:
         a (cupy.ndarray): A symmetric 2-D square matrix.
         UPLO (str): Select from ``'L'`` or ``'U'``. It specifies which
@@ -153,6 +140,4 @@ def eigvalsh(a, UPLO='L'):
 
     .. seealso:: :func:`numpy.linalg.eigvalsh`
     """
-    if not cuda.cusolver_enabled:
-        raise RuntimeError('Current cupy only supports cusolver in CUDA 8.0')
     return _syevd(a, UPLO, False)[0]

--- a/cupy/linalg/norms.py
+++ b/cupy/linalg/norms.py
@@ -2,14 +2,10 @@ import numpy
 from numpy import linalg
 
 import cupy
-from cupy import cuda
+from cupy.cuda import cusolver
 from cupy.cuda import device
 from cupy.linalg import decomposition
 from cupy.linalg import util
-
-
-if cuda.cusolver_enabled:
-    from cupy.cuda import cusolver
 
 
 def norm(x, ord=None, axis=None, keepdims=False):
@@ -203,9 +199,6 @@ def slogdet(a):
 
     .. seealso:: :func:`numpy.linalg.slogdet`
     """
-    if not cuda.cusolver_enabled:
-        raise RuntimeError('Current cupy only supports cusolver in CUDA 8.0')
-
     if a.ndim < 2:
         msg = ('%d-dimensional array given. '
                'Array must be at least two-dimensional' % a.ndim)

--- a/cupy/linalg/solve.py
+++ b/cupy/linalg/solve.py
@@ -4,14 +4,11 @@ import six
 
 import cupy
 from cupy.core import core
-from cupy import cuda
 from cupy.cuda import cublas
+from cupy.cuda import cusolver
 from cupy.cuda import device
 from cupy.linalg import decomposition
 from cupy.linalg import util
-
-if cuda.cusolver_enabled:
-    from cupy.cuda import cusolver
 
 
 def solve(a, b):
@@ -35,9 +32,6 @@ def solve(a, b):
     #       we manually solve a linear system with QR decomposition.
     #       For details, please see the following:
     #       https://docs.nvidia.com/cuda/cusolver/index.html#qr_examples
-    if not cuda.cusolver_enabled:
-        raise RuntimeError('Current cupy only supports cusolver in CUDA 8.0')
-
     util._assert_cupy_array(a, b)
     util._assert_nd_squareness(a)
 
@@ -249,9 +243,6 @@ def inv(a):
     """
     if a.ndim >= 3:
         return _batched_inv(a)
-
-    if not cuda.cusolver_enabled:
-        raise RuntimeError('Current cupy only supports cusolver in CUDA 8.0')
 
     # to prevent `a` to be overwritten
     a = a.copy()

--- a/cupyx/linalg/sparse/solve.py
+++ b/cupyx/linalg/sparse/solve.py
@@ -1,14 +1,10 @@
 import numpy
 
 import cupy
-from cupy import cuda
+from cupy.cuda import cusolver
 from cupy.cuda import device
 from cupy.linalg import util
 import cupy.sparse
-
-
-if cuda.cusolver_enabled:
-    from cupy.cuda import cusolver
 
 
 def lschol(A, b):
@@ -28,9 +24,6 @@ def lschol(A, b):
         ret (cupy.ndarray): The solution vector ``x``.
 
     """
-
-    if not cuda.cusolver_enabled:
-        raise RuntimeError('Current cupy only supports cusolver in CUDA 8.0')
 
     if not cupy.sparse.isspmatrix_csr(A):
         A = cupy.sparse.csr_matrix(A)

--- a/cupyx/scipy/linalg/decomp_lu.py
+++ b/cupyx/scipy/linalg/decomp_lu.py
@@ -3,13 +3,10 @@ from warnings import warn
 import numpy
 
 import cupy
-from cupy import cuda
 from cupy.cuda import cublas
+from cupy.cuda import cusolver
 from cupy.cuda import device
 from cupy.linalg import util
-
-if cuda.cusolver_enabled:
-    from cupy.cuda import cusolver
 
 
 def lu_factor(a, overwrite_a=False, check_finite=True):
@@ -62,9 +59,6 @@ dtype=cp.float32))
         (array([[ 0.,  1.],
                [nan, nan]], dtype=float32), array([0, 1], dtype=int32))
     """
-
-    if not cuda.cusolver_enabled:
-        raise RuntimeError('Current cupy only supports cusolver in CUDA 8.0')
 
     a = cupy.asarray(a)
     util._assert_rank2(a)
@@ -144,9 +138,6 @@ def lu_solve(lu_and_piv, b, trans=0, overwrite_b=False, check_finite=True):
 
     .. seealso:: :func:`scipy.linalg.lu_solve`
     """
-
-    if not cuda.cusolver_enabled:
-        raise RuntimeError('Current cupy only supports cusolver in CUDA 8.0')
 
     (lu, ipiv) = lu_and_piv
 

--- a/cupyx/scipy/sparse/linalg/solve.py
+++ b/cupyx/scipy/sparse/linalg/solve.py
@@ -1,14 +1,10 @@
 import numpy
 
 import cupy
-from cupy import cuda
+from cupy.cuda import cusolver
 from cupy.cuda import device
 from cupy.linalg import util
 import cupyx.scipy.sparse
-
-
-if cuda.cusolver_enabled:
-    from cupy.cuda import cusolver
 
 
 def lsqr(A, b):
@@ -34,9 +30,6 @@ def lsqr(A, b):
 
     .. seealso:: :func:`scipy.sparse.linalg.lsqr`
     """
-
-    if not cuda.cusolver_enabled:
-        raise RuntimeError('Current cupy only supports cusolver in CUDA 8.0')
 
     if not cupyx.scipy.sparse.isspmatrix_csr(A):
         A = cupyx.scipy.sparse.csr_matrix(A)

--- a/tests/cupy_tests/cuda_tests/test_cusolver.py
+++ b/tests/cupy_tests/cuda_tests/test_cusolver.py
@@ -11,7 +11,6 @@ class TestCusolver(unittest.TestCase):
                          cuda.cusolver_enabled)
 
 
-@unittest.skipUnless(cuda.cusolver_enabled, 'cuSOLVER is unavailable')
 class TestExceptionPicklable(unittest.TestCase):
 
     def test(self):

--- a/tests/cupy_tests/linalg_tests/test_decomposition.py
+++ b/tests/cupy_tests/linalg_tests/test_decomposition.py
@@ -4,7 +4,6 @@ import numpy
 import six
 
 import cupy
-from cupy import cuda
 from cupy import testing
 from cupy.testing import condition
 
@@ -43,8 +42,6 @@ def random_matrix(shape, dtype, scale, sym=False):
     return new_a.astype(dtype)
 
 
-@unittest.skipUnless(
-    cuda.cusolver_enabled, 'Only cusolver in CUDA 8.0 is supported')
 @testing.gpu
 class TestCholeskyDecomposition(unittest.TestCase):
 
@@ -67,8 +64,6 @@ class TestCholeskyDecomposition(unittest.TestCase):
 @testing.parameterize(*testing.product({
     'mode': ['r', 'raw', 'complete', 'reduced'],
 }))
-@unittest.skipUnless(
-    cuda.cusolver_enabled, 'Only cusolver in CUDA 8.0 is supported')
 @testing.gpu
 class TestQRDecomposition(unittest.TestCase):
 
@@ -98,8 +93,6 @@ class TestQRDecomposition(unittest.TestCase):
     'full_matrices': [True, False],
 }))
 @testing.fix_random()
-@unittest.skipUnless(
-    cuda.cusolver_enabled, 'Only cusolver in CUDA 8.0 is supported')
 @testing.gpu
 class TestSVD(unittest.TestCase):
 

--- a/tests/cupy_tests/linalg_tests/test_eigenvalue.py
+++ b/tests/cupy_tests/linalg_tests/test_eigenvalue.py
@@ -3,15 +3,12 @@ import unittest
 import numpy
 
 import cupy
-from cupy import cuda
 from cupy import testing
 
 
 @testing.parameterize(*testing.product({
     'UPLO': ['U', 'L'],
 }))
-@unittest.skipUnless(
-    cuda.cusolver_enabled, 'Only cusolver in CUDA 8.0 is supported')
 @testing.gpu
 class TestEigenvalue(unittest.TestCase):
 

--- a/tests/cupy_tests/linalg_tests/test_norms.py
+++ b/tests/cupy_tests/linalg_tests/test_norms.py
@@ -3,7 +3,6 @@ import unittest
 import numpy
 
 import cupy
-from cupy import cuda
 from cupy import testing
 
 
@@ -71,8 +70,6 @@ class TestNorm(unittest.TestCase):
     ],
     'tol': [None, 1]
 }))
-@unittest.skipUnless(
-    cuda.cusolver_enabled, 'Only cusolver in CUDA 8.0 is supported')
 @testing.gpu
 class TestMatrixRank(unittest.TestCase):
 
@@ -93,8 +90,6 @@ class TestMatrixRank(unittest.TestCase):
         return y
 
 
-@unittest.skipUnless(
-    cuda.cusolver_enabled, 'Only cusolver in CUDA 8.0 is supported')
 @testing.gpu
 class TestDet(unittest.TestCase):
 
@@ -135,8 +130,6 @@ class TestDet(unittest.TestCase):
         xp.linalg.det(a)
 
 
-@unittest.skipUnless(
-    cuda.cusolver_enabled, 'Only cusolver in CUDA 8.0 is supported')
 @testing.gpu
 class TestSlogdet(unittest.TestCase):
 

--- a/tests/cupy_tests/linalg_tests/test_product.py
+++ b/tests/cupy_tests/linalg_tests/test_product.py
@@ -2,7 +2,6 @@ import unittest
 
 import numpy
 
-from cupy import cuda
 from cupy import testing
 
 
@@ -404,8 +403,6 @@ class TestProductZeroLength(unittest.TestCase):
         return xp.tensordot(a, a, axes=axes)
 
 
-@unittest.skipUnless(
-    cuda.cusolver_enabled, 'Requires CUDA 8.0 for cuSOLVER')
 class TestMatrixPower(unittest.TestCase):
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()

--- a/tests/cupy_tests/linalg_tests/test_solve.py
+++ b/tests/cupy_tests/linalg_tests/test_solve.py
@@ -3,13 +3,10 @@ import unittest
 import numpy
 
 import cupy
-from cupy import cuda
 from cupy import testing
 from cupy.testing import condition
 
 
-@unittest.skipUnless(
-    cuda.cusolver_enabled, 'Only cusolver in CUDA 8.0 is supported')
 @testing.gpu
 @testing.fix_random()
 class TestSolve(unittest.TestCase):
@@ -60,8 +57,6 @@ class TestSolve(unittest.TestCase):
 }))
 @testing.fix_random()
 @testing.gpu
-@unittest.skipUnless(
-    cuda.cusolver_enabled, 'Only cusolver in CUDA 8.0 is supported')
 class TestTensorSolve(unittest.TestCase):
 
     def setUp(self):
@@ -77,8 +72,6 @@ class TestTensorSolve(unittest.TestCase):
         return xp.linalg.tensorsolve(a, b, axes=self.axes)
 
 
-@unittest.skipUnless(
-    cuda.cusolver_enabled, 'Only cusolver in CUDA 8.0 is supported')
 @testing.gpu
 class TestInv(unittest.TestCase):
 
@@ -114,8 +107,6 @@ class TestInv(unittest.TestCase):
         self.check_shape((2, 4, 3))
 
 
-@unittest.skipUnless(
-    cuda.cusolver_enabled, 'Only cusolver in CUDA 8.0 is supported')
 @testing.gpu
 class TestPinv(unittest.TestCase):
 
@@ -153,8 +144,6 @@ class TestPinv(unittest.TestCase):
         self.check_shape((4, 3, 2, 1), rcond=0.1)
 
 
-@unittest.skipUnless(
-    cuda.cusolver_enabled, 'Only cusolver in CUDA 8.0 is supported')
 @testing.gpu
 class TestLstsq(unittest.TestCase):
 
@@ -227,8 +216,6 @@ class TestLstsq(unittest.TestCase):
         self.check_invalid_shapes((4, 3), (10, 3, 3))
 
 
-@unittest.skipUnless(
-    cuda.cusolver_enabled, 'Only cusolver in CUDA 8.0 is supported')
 @testing.gpu
 class TestTensorInv(unittest.TestCase):
 

--- a/tests/cupy_tests/random_tests/test_distributions.py
+++ b/tests/cupy_tests/random_tests/test_distributions.py
@@ -3,7 +3,6 @@ import unittest
 import numpy
 
 import cupy
-from cupy import cuda
 from cupy.random import distributions
 from cupy import testing
 
@@ -333,8 +332,6 @@ class TestDistributionsLogseries(RandomDistributionsTestCase):
 })
 )
 @testing.gpu
-@unittest.skipUnless(
-    cuda.cusolver_enabled, 'Only cusolver in CUDA 8.0 is supported')
 class TestDistributionsMultivariateNormal(unittest.TestCase):
 
     def check_distribution(self, dist_func, mean_dtype, cov_dtype, dtype):

--- a/tests/cupy_tests/random_tests/test_generator.py
+++ b/tests/cupy_tests/random_tests/test_generator.py
@@ -534,8 +534,6 @@ class TestLogseries(RandomGeneratorTestCase):
     {'args': ([0., 0.], [[1., 0.], [0., 1.]]), 'size': (3, 3), 'tol': 1e-6},
     {'args': ([0., 0.], [[1., 0.], [0., 1.]]), 'size': (), 'tol': 1e-6},
 ])
-@unittest.skipUnless(
-    cuda.cusolver_enabled, 'Only cusolver in CUDA 8.0 is supported')
 @testing.fix_random()
 class TestMultivariateNormal(RandomGeneratorTestCase):
 

--- a/tests/cupyx_tests/linalg_tests/sparse_tests/test_solve.py
+++ b/tests/cupyx_tests/linalg_tests/sparse_tests/test_solve.py
@@ -11,7 +11,6 @@ except ImportError:
     scipy_available = False
 
 import cupy as cp
-from cupy import cuda
 import cupy.sparse as sp
 from cupy import testing
 from cupy.testing import condition
@@ -21,8 +20,6 @@ import cupyx
 @testing.parameterize(*testing.product({
     'dtype': [numpy.float32, numpy.float64],
 }))
-@unittest.skipUnless(
-    cuda.cusolver_enabled, 'Only cusolver in CUDA 8.0 is supported')
 @unittest.skipUnless(scipy_available, 'requires scipy')
 class TestLschol(unittest.TestCase):
 

--- a/tests/cupyx_tests/scipy_tests/linalg_tests/test_decomp_lu.py
+++ b/tests/cupyx_tests/scipy_tests/linalg_tests/test_decomp_lu.py
@@ -2,7 +2,6 @@ import unittest
 
 import numpy
 import cupy
-from cupy import cuda
 from cupy import testing
 import cupyx.scipy.linalg
 if cupyx.scipy._scipy_available:
@@ -14,8 +13,6 @@ if cupyx.scipy._scipy_available:
     'shape': [(1, 1), (2, 2), (3, 3), (5, 5), (1, 5), (5, 1), (2, 5), (5, 2)],
 }))
 @testing.fix_random()
-@unittest.skipUnless(
-    cuda.cusolver_enabled, 'Only cusolver in CUDA 8.0 is supported')
 @testing.with_requires('scipy')
 class TestLUFactor(unittest.TestCase):
 
@@ -69,8 +66,6 @@ class TestLUFactor(unittest.TestCase):
     'shapes': [((4, 4), (4,)), ((5, 5), (5, 2))],
 }))
 @testing.fix_random()
-@unittest.skipUnless(
-    cuda.cusolver_enabled, 'Only cusolver in CUDA 8.0 is supported')
 @testing.with_requires('scipy')
 class TestLUSolve(unittest.TestCase):
 

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
@@ -8,7 +8,6 @@ try:
 except ImportError:
     scipy_available = False
 
-from cupy import cuda
 from cupy import testing
 from cupy.testing import condition
 
@@ -16,8 +15,6 @@ from cupy.testing import condition
 @testing.parameterize(*testing.product({
     'dtype': [numpy.float32, numpy.float64],
 }))
-@unittest.skipUnless(
-    cuda.cusolver_enabled, 'Only cusolver in CUDA 8.0 is supported')
 @unittest.skipUnless(scipy_available, 'requires scipy')
 class TestLsqr(unittest.TestCase):
 


### PR DESCRIPTION
This PR removes some checks that were supporting CUDA Toolkit versions older than 8.0.  [It seems that older Toolkit versions are no longer supported](https://docs-cupy.chainer.org/en/stable/install.html#requirements).

Aside from the checks, the only other change is the second commit which enables a commented-out `cusparse.getStream` method also requires CUDA Toolkit >=8.0.