### PR TITLE
Handle PCI bus ID

### DIFF
--- a/cupy/cuda/cupy_cuda.h
+++ b/cupy/cuda/cupy_cuda.h
@@ -232,6 +232,14 @@ cudaError_t cudaDeviceGetAttribute(...) {
     return cudaSuccess;
 }
 
+cudaError_t cudaDeviceGetByPCIBusId(...) {
+    return cudaSuccess;
+}
+
+cudaError_t cudaDeviceGetPCIBusId(...) {
+    return cudaSuccess;
+}
+
 cudaError_t cudaGetDeviceCount(...) {
     return cudaSuccess;
 }

--- a/cupy/cuda/device.pyx
+++ b/cupy/cuda/device.pyx
@@ -131,7 +131,7 @@ cdef class Device:
                 given by the argument pci_bus_id.
         """
         device_id = runtime.deviceGetByPCIBusId(pci_bus_id)
-        return cls(new_id)
+        return cls(device_id)
 
     def __int__(self):
         return self.id

--- a/cupy/cuda/device.pyx
+++ b/cupy/cuda/device.pyx
@@ -81,6 +81,9 @@ def _get_attributes(device_id):
                     raise
     return d
 
+def _get_pci_bus_id(device_id):
+    """Return the string representing the PCI Bus ID"""
+    return runtime.deviceGetPCIBusId(device_id)
 
 cdef class Device:
 
@@ -250,6 +253,18 @@ cdef class Device:
                 `MaxThreadsPerBlock`.
         """
         return _get_attributes(self.id)
+
+    @property
+    def pci_bus_id(self):
+        """A string of the PCI Bus ID
+
+        Returns:
+            pci_bus_id (str):
+                Returned identifier string for the device in the following
+                format [domain]:[bus]:[device].[function] where domain, bus,
+                device, and function are all hexadecimal values.
+        """
+        return _get_pci_bus_id(self.id)
 
     def __richcmp__(Device self, object other, int op):
         if op == 2:

--- a/cupy/cuda/device.pyx
+++ b/cupy/cuda/device.pyx
@@ -81,9 +81,11 @@ def _get_attributes(device_id):
                     raise
     return d
 
+
 def _get_pci_bus_id(device_id):
     """Return the string representing the PCI Bus ID"""
     return runtime.deviceGetPCIBusId(device_id)
+
 
 cdef class Device:
 

--- a/cupy/cuda/device.pyx
+++ b/cupy/cuda/device.pyx
@@ -101,11 +101,10 @@ cdef class Device:
     original one.
 
     Args:
-        device (int or cupy.cuda.Device or str): Index of the device to
-            manipulate. Be careful that the device ID (a.k.a. GPU ID) is zero
-            origin. If it is a Device object, then its ID is used. If device is
-            a str, then it is used as a PCI bus ID to choose a specific device.
-            The current device is selected by default.
+        device (int or cupy.cuda.Device): Index of the device to manipulate. Be
+            careful that the device ID (a.k.a. GPU ID) is zero origin. If it is
+            a Device object, then its ID is used. The current device is
+            selected by default.
 
     Attributes:
         id (int): ID of this device.
@@ -116,10 +115,7 @@ cdef class Device:
         if device is None:
             self.id = runtime.getDevice()
         else:
-            try:
-                self.id = int(device)
-            except ValueError:
-                self.id = runtime.deviceGetByPCIBusId(str(device))
+            self.id = int(device)
 
         self._device_stack = []
 
@@ -265,6 +261,23 @@ cdef class Device:
                 device, and function are all hexadecimal values.
         """
         return _get_pci_bus_id(self.id)
+
+    @classmethod
+    def from_pci_bus_id(cls, pci_bus_id):
+        """Returns a new device instance based on a PCI Bus ID
+
+        Args:
+            pci_bus_id (str):
+                The string for a device in the following format
+                [domain]:[bus]:[device].[function] where domain, bus, device,
+                and function are all hexadecimal values.
+        Returns:
+            device (Device):
+                An instance of the Device class that has the PCI Bus ID as
+                given by the argument pci_bus_id.
+        """
+        new_id = runtime.deviceGetByPCIBusId(str(pci_bus_id))
+        return cls(new_id)
 
     def __richcmp__(Device self, object other, int op):
         if op == 2:

--- a/cupy/cuda/device.pyx
+++ b/cupy/cuda/device.pyx
@@ -116,6 +116,23 @@ cdef class Device:
 
         self._device_stack = []
 
+    @classmethod
+    def from_pci_bus_id(cls, pci_bus_id):
+        """Returns a new device instance based on a PCI Bus ID
+
+        Args:
+            pci_bus_id (str):
+                The string for a device in the following format
+                [domain]:[bus]:[device].[function] where domain, bus, device,
+                and function are all hexadecimal values.
+        Returns:
+            device (Device):
+                An instance of the Device class that has the PCI Bus ID as
+                given by the argument pci_bus_id.
+        """
+        device_id = runtime.deviceGetByPCIBusId(pci_bus_id)
+        return cls(new_id)
+
     def __int__(self):
         return self.id
 
@@ -258,23 +275,6 @@ cdef class Device:
                 device, and function are all hexadecimal values.
         """
         return runtime.deviceGetPCIBusId(self.id)
-
-    @classmethod
-    def from_pci_bus_id(cls, pci_bus_id):
-        """Returns a new device instance based on a PCI Bus ID
-
-        Args:
-            pci_bus_id (str):
-                The string for a device in the following format
-                [domain]:[bus]:[device].[function] where domain, bus, device,
-                and function are all hexadecimal values.
-        Returns:
-            device (Device):
-                An instance of the Device class that has the PCI Bus ID as
-                given by the argument pci_bus_id.
-        """
-        new_id = runtime.deviceGetByPCIBusId(str(pci_bus_id))
-        return cls(new_id)
 
     def __richcmp__(Device self, object other, int op):
         if op == 2:

--- a/cupy/cuda/device.pyx
+++ b/cupy/cuda/device.pyx
@@ -82,11 +82,6 @@ def _get_attributes(device_id):
     return d
 
 
-def _get_pci_bus_id(device_id):
-    """Return the string representing the PCI Bus ID"""
-    return runtime.deviceGetPCIBusId(device_id)
-
-
 cdef class Device:
 
     """Object that represents a CUDA device.
@@ -262,7 +257,7 @@ cdef class Device:
                 format [domain]:[bus]:[device].[function] where domain, bus,
                 device, and function are all hexadecimal values.
         """
-        return _get_pci_bus_id(self.id)
+        return runtime.deviceGetPCIBusId(self.id)
 
     @classmethod
     def from_pci_bus_id(cls, pci_bus_id):

--- a/cupy/cuda/device.pyx
+++ b/cupy/cuda/device.pyx
@@ -98,10 +98,11 @@ cdef class Device:
     original one.
 
     Args:
-        device (int or cupy.cuda.Device): Index of the device to manipulate. Be
-            careful that the device ID (a.k.a. GPU ID) is zero origin. If it is
-            a Device object, then its ID is used. The current device is
-            selected by default.
+        device (int or cupy.cuda.Device or str): Index of the device to
+            manipulate. Be careful that the device ID (a.k.a. GPU ID) is zero
+            origin. If it is a Device object, then its ID is used. If device is
+            a str, then it is used as a PCI bus ID to choose a specific device.
+            The current device is selected by default.
 
     Attributes:
         id (int): ID of this device.
@@ -112,7 +113,10 @@ cdef class Device:
         if device is None:
             self.id = runtime.getDevice()
         else:
-            self.id = int(device)
+            try:
+                self.id = int(device)
+            except ValueError:
+                self.id = runtime.deviceGetByPCIBusId(str(device))
 
         self._device_stack = []
 

--- a/cupy/cuda/runtime.pxd
+++ b/cupy/cuda/runtime.pxd
@@ -310,6 +310,7 @@ cpdef int runtimeGetVersion() except? -1
 cpdef int getDevice() except? -1
 cpdef int deviceGetAttribute(int attrib, int device) except? -1
 cpdef int deviceGetByPCIBusId(str pci_bus_id) except? -1
+cpdef unicode deviceGetPCIBusId(int device)
 cpdef int getDeviceCount() except? -1
 cpdef setDevice(int device)
 cpdef deviceSynchronize()

--- a/cupy/cuda/runtime.pxd
+++ b/cupy/cuda/runtime.pxd
@@ -310,7 +310,7 @@ cpdef int runtimeGetVersion() except? -1
 cpdef int getDevice() except? -1
 cpdef int deviceGetAttribute(int attrib, int device) except? -1
 cpdef int deviceGetByPCIBusId(str pci_bus_id) except? -1
-cpdef unicode deviceGetPCIBusId(int device)
+cpdef str deviceGetPCIBusId(int device)
 cpdef int getDeviceCount() except? -1
 cpdef setDevice(int device)
 cpdef deviceSynchronize()

--- a/cupy/cuda/runtime.pxd
+++ b/cupy/cuda/runtime.pxd
@@ -309,6 +309,7 @@ cpdef int runtimeGetVersion() except? -1
 
 cpdef int getDevice() except? -1
 cpdef int deviceGetAttribute(int attrib, int device) except? -1
+cpdef int deviceGetByPCIBusId(str pci_bus_id) except? -1
 cpdef int getDeviceCount() except? -1
 cpdef setDevice(int device)
 cpdef deviceSynchronize()

--- a/cupy/cuda/runtime.pyx
+++ b/cupy/cuda/runtime.pyx
@@ -61,6 +61,7 @@ cdef extern from 'cupy_cuda.h' nogil:
     int cudaGetDevice(int* device)
     int cudaDeviceGetAttribute(int* value, DeviceAttr attr, int device)
     int cudaDeviceGetByPCIBusId(int* device, const char* pciBusId)
+    int cudaDeviceGetPCIBusId(char* pciBusId, int len, int device)
     int cudaGetDeviceCount(int* count)
     int cudaSetDevice(int device)
     int cudaDeviceSynchronize()
@@ -244,6 +245,12 @@ cpdef int deviceGetByPCIBusId(str pci_bus_id) except? -1:
     status = cudaDeviceGetByPCIBusId(&device, c_pci_bus_id)
     check_status(status)
     return device
+
+cpdef unicode deviceGetPCIBusId(int device):
+    cdef char pci_bus_id[13]
+    status = cudaDeviceGetPCIBusId(pci_bus_id, 13, device)
+    check_status(status)
+    return pci_bus_id.decode("UTF-8")
 
 cpdef int getDeviceCount() except? -1:
     cdef int count

--- a/cupy/cuda/runtime.pyx
+++ b/cupy/cuda/runtime.pyx
@@ -238,7 +238,7 @@ cpdef int deviceGetAttribute(int attrib, int device) except? -1:
 
 cpdef int deviceGetByPCIBusId(str pci_bus_id) except? -1:
     # Encode the python string before passing to native code
-    byte_pci_bus_id = pci_bus_id.encode("UTF-8")
+    byte_pci_bus_id = pci_bus_id.encode("ascii")
     cdef const char* c_pci_bus_id = byte_pci_bus_id
 
     cdef int device
@@ -246,11 +246,11 @@ cpdef int deviceGetByPCIBusId(str pci_bus_id) except? -1:
     check_status(status)
     return device
 
-cpdef unicode deviceGetPCIBusId(int device):
+cpdef str deviceGetPCIBusId(int device):
     cdef char pci_bus_id[13]
     status = cudaDeviceGetPCIBusId(pci_bus_id, 13, device)
     check_status(status)
-    return pci_bus_id.decode("UTF-8")
+    return pci_bus_id.decode("ascii")
 
 cpdef int getDeviceCount() except? -1:
     cdef int count

--- a/cupy/cuda/runtime.pyx
+++ b/cupy/cuda/runtime.pyx
@@ -247,6 +247,9 @@ cpdef int deviceGetByPCIBusId(str pci_bus_id) except? -1:
     return device
 
 cpdef str deviceGetPCIBusId(int device):
+    # The PCI Bus ID string must be able to store 13 characters including the
+    # NULL-terminator according to the CUDA documentation.
+    # https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__DEVICE.html
     cdef char pci_bus_id[13]
     status = cudaDeviceGetPCIBusId(pci_bus_id, 13, device)
     check_status(status)

--- a/cupy/cuda/runtime.pyx
+++ b/cupy/cuda/runtime.pyx
@@ -241,7 +241,7 @@ cpdef int deviceGetByPCIBusId(str pci_bus_id) except? -1:
     byte_pci_bus_id = pci_bus_id.encode('ascii')
     cdef const char* c_pci_bus_id = byte_pci_bus_id
 
-    cdef int device
+    cdef int device = -1
     status = cudaDeviceGetByPCIBusId(&device, c_pci_bus_id)
     check_status(status)
     return device

--- a/cupy/cuda/runtime.pyx
+++ b/cupy/cuda/runtime.pyx
@@ -60,6 +60,7 @@ cdef extern from 'cupy_cuda.h' nogil:
     # Device operations
     int cudaGetDevice(int* device)
     int cudaDeviceGetAttribute(int* value, DeviceAttr attr, int device)
+    int cudaDeviceGetByPCIBusId(int* device, const char* pciBusId)
     int cudaGetDeviceCount(int* count)
     int cudaSetDevice(int device)
     int cudaDeviceSynchronize()
@@ -234,6 +235,15 @@ cpdef int deviceGetAttribute(int attrib, int device) except? -1:
     check_status(status)
     return ret
 
+cpdef int deviceGetByPCIBusId(str pci_bus_id) except? -1:
+    # Encode the python string before passing to native code
+    byte_pci_bus_id = pci_bus_id.encode("UTF-8")
+    cdef const char* c_pci_bus_id = byte_pci_bus_id
+
+    cdef int device
+    status = cudaDeviceGetByPCIBusId(&device, c_pci_bus_id)
+    check_status(status)
+    return device
 
 cpdef int getDeviceCount() except? -1:
     cdef int count

--- a/cupy/cuda/runtime.pyx
+++ b/cupy/cuda/runtime.pyx
@@ -238,7 +238,7 @@ cpdef int deviceGetAttribute(int attrib, int device) except? -1:
 
 cpdef int deviceGetByPCIBusId(str pci_bus_id) except? -1:
     # Encode the python string before passing to native code
-    byte_pci_bus_id = pci_bus_id.encode("ascii")
+    byte_pci_bus_id = pci_bus_id.encode('ascii')
     cdef const char* c_pci_bus_id = byte_pci_bus_id
 
     cdef int device
@@ -253,7 +253,7 @@ cpdef str deviceGetPCIBusId(int device):
     cdef char pci_bus_id[13]
     status = cudaDeviceGetPCIBusId(pci_bus_id, 13, device)
     check_status(status)
-    return pci_bus_id.decode("ascii")
+    return pci_bus_id.decode('ascii')
 
 cpdef int getDeviceCount() except? -1:
     cdef int count

--- a/tests/cupy_tests/cuda_tests/test_device.py
+++ b/tests/cupy_tests/cuda_tests/test_device.py
@@ -102,7 +102,7 @@ class TestDevicePCIBusId(unittest.TestCase):
         d = cuda.Device()
         pci_bus_id = d.pci_bus_id
         assert re.match(
-            "^[a-fA-F0-9]{4}:[a-fA-F0-9]{2}:[a-fA-F0-9]{2}.[a-fA-F0-9]",
+            '^[a-fA-F0-9]{4}:[a-fA-F0-9]{2}:[a-fA-F0-9]{2}.[a-fA-F0-9]',
             pci_bus_id
         )
 
@@ -114,12 +114,12 @@ class TestDevicePCIBusId(unittest.TestCase):
         assert d2 == d3
 
         with pytest.raises(cuda.runtime.CUDARuntimeError) as excinfo:
-            cuda.Device.from_pci_bus_id("fake:id")
-            assert excinfo == "cudaErrorInvalidValue: invalid argument"
+            cuda.Device.from_pci_bus_id('fake:id')
+            assert excinfo == 'cudaErrorInvalidValue: invalid argument'
 
         with pytest.raises(cuda.runtime.CUDARuntimeError) as excinfo:
-            cuda.Device.from_pci_bus_id("FFFF:FF:FF.F")
-            assert excinfo == "cudaErrorInvalidDevice: invalid device ordinal"
+            cuda.Device.from_pci_bus_id('FFFF:FF:FF.F')
+            assert excinfo == 'cudaErrorInvalidDevice: invalid device ordinal'
 
 
 @testing.gpu

--- a/tests/cupy_tests/cuda_tests/test_device.py
+++ b/tests/cupy_tests/cuda_tests/test_device.py
@@ -1,3 +1,4 @@
+import re
 import threading
 import unittest
 
@@ -98,7 +99,6 @@ class TestDeviceAttributes(unittest.TestCase):
 @testing.gpu
 class TestDevicePCIBusId(unittest.TestCase):
     def test_device_get_pci_bus_id(self):
-        import re
         d = cuda.Device()
         pci_bus_id = d.pci_bus_id
         assert re.match(

--- a/tests/cupy_tests/cuda_tests/test_device.py
+++ b/tests/cupy_tests/cuda_tests/test_device.py
@@ -94,13 +94,16 @@ class TestDeviceAttributes(unittest.TestCase):
             # try to retrieve attributes from a non-existent device
             cuda.device.Device(cuda.runtime.getDeviceCount()).attributes
 
+
 @testing.gpu
 class TestDevicePCIBusId(unittest.TestCase):
     def test_device_get_pci_bus_id(self):
         import re
         d = cuda.Device()
         pci_bus_id = d.pci_bus_id
-        assert re.match("^[a-fA-F0-9]{4}:[a-fA-F0-9]{2}:[a-fA-F0-9]{2}.[a-fA-F0-9]", pci_bus_id)
+        assert re.match(
+            "^[a-fA-F0-9]{4}:[a-fA-F0-9]{2}:[a-fA-F0-9]{2}.[a-fA-F0-9]", pci_bus_id)
+
     def test_device_by_pci_bus_id(self):
         d1 = cuda.Device()
         d2 = cuda.Device.from_pci_bus_id(d1.pci_bus_id)
@@ -109,12 +112,13 @@ class TestDevicePCIBusId(unittest.TestCase):
         assert d2 == d3
 
         with pytest.raises(cuda.runtime.CUDARuntimeError) as excinfo:
-            d4 = cuda.Device.from_pci_bus_id("fake:id")
+            cuda.Device.from_pci_bus_id("fake:id")
             assert excinfo == "cudaErrorInvalidValue: invalid argument"
 
         with pytest.raises(cuda.runtime.CUDARuntimeError) as excinfo:
-            d4 = cuda.Device.from_pci_bus_id("FFFF:FF:FF.F")
+            cuda.Device.from_pci_bus_id("FFFF:FF:FF.F")
             assert excinfo == "cudaErrorInvalidDevice: invalid device ordinal"
+
 
 @testing.gpu
 class TestDeviceHandles(unittest.TestCase):

--- a/tests/cupy_tests/cuda_tests/test_device.py
+++ b/tests/cupy_tests/cuda_tests/test_device.py
@@ -102,7 +102,9 @@ class TestDevicePCIBusId(unittest.TestCase):
         d = cuda.Device()
         pci_bus_id = d.pci_bus_id
         assert re.match(
-            "^[a-fA-F0-9]{4}:[a-fA-F0-9]{2}:[a-fA-F0-9]{2}.[a-fA-F0-9]", pci_bus_id)
+            "^[a-fA-F0-9]{4}:[a-fA-F0-9]{2}:[a-fA-F0-9]{2}.[a-fA-F0-9]",
+            pci_bus_id
+        )
 
     def test_device_by_pci_bus_id(self):
         d1 = cuda.Device()

--- a/tests/cupy_tests/cuda_tests/test_device.py
+++ b/tests/cupy_tests/cuda_tests/test_device.py
@@ -94,6 +94,22 @@ class TestDeviceAttributes(unittest.TestCase):
             # try to retrieve attributes from a non-existent device
             cuda.device.Device(cuda.runtime.getDeviceCount()).attributes
 
+@testing.gpu
+class TestDevicePCIBusId(unittest.TestCase):
+    def test_device_get_pci_bus_id(self):
+        import re
+        d = cuda.Device()
+        pci_bus_id = d.pci_bus_id
+        assert re.match("^[a-fA-F0-9]{4}:[a-fA-F0-9]{2}:[a-fA-F0-9]{2}.[a-fA-F0-9]", pci_bus_id)
+    def test_device_by_pci_bus_id(self):
+        d1 = cuda.Device()
+        d2 = cuda.Device(d1.pci_bus_id)
+        assert d1 == d2
+        d3 = cuda.Device(d2)
+        assert d2 == d3
+        with pytest.raises(cuda.runtime.CUDARuntimeError) as excinfo:
+            d4 = cuda.Device("fake:id")
+            assert excinfo == "cudaErrorInvalidValue: invalid argument"
 
 @testing.gpu
 class TestDeviceHandles(unittest.TestCase):

--- a/tests/cupy_tests/cuda_tests/test_device.py
+++ b/tests/cupy_tests/cuda_tests/test_device.py
@@ -112,6 +112,10 @@ class TestDevicePCIBusId(unittest.TestCase):
             d4 = cuda.Device.from_pci_bus_id("fake:id")
             assert excinfo == "cudaErrorInvalidValue: invalid argument"
 
+        with pytest.raises(cuda.runtime.CUDARuntimeError) as excinfo:
+            d4 = cuda.Device.from_pci_bus_id("FFFF:FF:FF.F")
+            assert excinfo == "cudaErrorInvalidDevice: invalid device ordinal"
+
 @testing.gpu
 class TestDeviceHandles(unittest.TestCase):
     def _check_handle(self, func):

--- a/tests/cupy_tests/cuda_tests/test_device.py
+++ b/tests/cupy_tests/cuda_tests/test_device.py
@@ -103,12 +103,13 @@ class TestDevicePCIBusId(unittest.TestCase):
         assert re.match("^[a-fA-F0-9]{4}:[a-fA-F0-9]{2}:[a-fA-F0-9]{2}.[a-fA-F0-9]", pci_bus_id)
     def test_device_by_pci_bus_id(self):
         d1 = cuda.Device()
-        d2 = cuda.Device(d1.pci_bus_id)
+        d2 = cuda.Device.from_pci_bus_id(d1.pci_bus_id)
         assert d1 == d2
         d3 = cuda.Device(d2)
         assert d2 == d3
+
         with pytest.raises(cuda.runtime.CUDARuntimeError) as excinfo:
-            d4 = cuda.Device("fake:id")
+            d4 = cuda.Device.from_pci_bus_id("fake:id")
             assert excinfo == "cudaErrorInvalidValue: invalid argument"
 
 @testing.gpu


### PR DESCRIPTION
From the issue #2440. 

This PR adds two features:

- Get a new Device by PCI Bus ID
- Get the PCI Bus ID from a Device

I'm not sure what tests I should add, I have:
- Check the returned PCI bus ID matches a specific format
- Ensure a device created with the PCI bus ID of another Device is the same device