### PR TITLE
[RFC] Use current stream in `ElementwiseKernel` and `ReductionKernel`

### DIFF
--- a/cupy/core/_kernel.pyx
+++ b/cupy/core/_kernel.pyx
@@ -25,6 +25,7 @@ from cupy.core.core cimport Indexer
 from cupy.core.core cimport ndarray
 from cupy.core cimport internal
 from cupy.core._memory_range cimport may_share_bounds
+from cupy.cuda cimport stream as stream_module
 
 
 _thread_local = threading.local()
@@ -534,7 +535,7 @@ cdef class ElementwiseKernel:
 
         size = -1
         size = kwargs.pop('size', -1)
-        stream = kwargs.pop('stream', None)
+        stream = kwargs.pop('stream', stream_module.get_current_stream_ptr())
         if len(kwargs):
             raise TypeError('Wrong arguments %s' % kwargs)
 

--- a/cupy/core/reduction.pxi
+++ b/cupy/core/reduction.pxi
@@ -3,6 +3,7 @@ from libc.stdint cimport int32_t
 
 from cupy.core cimport _routines_manipulation as _manipulation
 from cupy.cuda cimport runtime
+from cupy.cuda cimport stream as stream_module
 
 import string
 
@@ -393,7 +394,7 @@ class ReductionKernel(object):
         out = kwargs.pop('out', None)
         axis = kwargs.pop('axis', None)
         keepdims = kwargs.pop('keepdims', False)
-        stream = kwargs.pop('stream', None)
+        stream = kwargs.pop('stream', stream_module.get_current_stream_ptr())
         if kwargs:
             raise TypeError('Wrong arguments %s' % kwargs)
 


### PR DESCRIPTION
Fixes #2524