### PR TITLE
[backport] Update `__cuda_array_interface__` to protocol version 2 + Add backward compatibility test

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -142,9 +142,11 @@ cdef class ndarray:
             'typestr': self.dtype.str,
             'descr': self.dtype.descr,
             'data': (self.data.ptr, False),
-            'version': 0,
+            'version': 2,
         }
-        if not self._c_contiguous:
+        if self._c_contiguous:
+            desc['strides'] = None
+        else:
             desc['strides'] = self.strides
 
         return desc
@@ -2511,14 +2513,23 @@ not_equal = create_comparison(
 cpdef ndarray _convert_object_with_cuda_array_interface(a):
     cdef Py_ssize_t sh, st
     desc = a.__cuda_array_interface__
+    # TODO(leofang): enforce compliance to the latest protocol?
     shape = desc['shape']
     dtype = numpy.dtype(desc['typestr'])
+    if 'mask' in desc:
+        mask = desc['mask']
+        if mask is not None:
+            raise ValueError("CuPy currently does not support masked arrays.")
+    # TODO(leofang): for ver.2, 'strides' is always available, so don't check.
     if 'strides' in desc:
         strides = desc['strides']
-        nbytes = 0
-        for sh, st in zip(shape, strides):
-            nbytes = max(nbytes, abs(sh * st))
-    else:
+        if strides is not None:
+            nbytes = 0
+            for sh, st in zip(shape, strides):
+                nbytes = max(nbytes, abs(sh * st))
+        else:
+            nbytes = internal.prod(shape) * dtype.itemsize
+    else:  # for backward compatibility with ver.0 & ver.1
         strides = None
         nbytes = internal.prod(shape) * dtype.itemsize
     mem = memory_module.UnownedMemory(desc['data'][0], nbytes, a)

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2519,10 +2519,7 @@ cpdef ndarray _convert_object_with_cuda_array_interface(a):
         mask = desc['mask']
         if mask is not None:
             raise ValueError('CuPy currently does not support masked arrays.')
-    if 'strides' in desc:  # for ver.2, 'strides' is always available
-        strides = desc['strides']
-    else:  # for backward compatibility with ver.0 & ver.1
-        strides = None
+    strides = desc.get('strides')
     if strides is not None:
         nbytes = 0
         for sh, st in zip(shape, strides):

--- a/tests/cupy_tests/core_tests/test_ndarray.py
+++ b/tests/cupy_tests/core_tests/test_ndarray.py
@@ -198,15 +198,17 @@ class TestNdarrayCudaInterface(unittest.TestCase):
         arr = cupy.zeros(shape=(2, 3), dtype=cupy.float64)
         iface = arr.__cuda_array_interface__
         assert (set(iface.keys()) ==
-                set(['shape', 'typestr', 'data', 'version', 'descr']))
+                set(['shape', 'typestr', 'data', 'version', 'descr',
+                     'strides']))
         assert iface['shape'] == (2, 3)
         assert iface['typestr'] == '<f8'
         assert isinstance(iface['data'], tuple)
         assert len(iface['data']) == 2
         assert iface['data'][0] == arr.data.ptr
         assert not iface['data'][1]
-        assert iface['version'] == 0
+        assert iface['version'] == 2
         assert iface['descr'] == [('', '<f8')]
+        assert iface['strides'] is None
 
     def test_cuda_array_interface_view(self):
         arr = cupy.zeros(shape=(10, 20), dtype=cupy.float64)
@@ -221,7 +223,7 @@ class TestNdarrayCudaInterface(unittest.TestCase):
         assert len(iface['data']) == 2
         assert iface['data'][0] == arr.data.ptr
         assert not iface['data'][1]
-        assert iface['version'] == 0
+        assert iface['version'] == 2
         assert iface['strides'] == (320, 40)
         assert iface['descr'] == [('', '<f8')]
 

--- a/tests/cupy_tests/core_tests/test_ndarray_cuda_array_interface.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_cuda_array_interface.py
@@ -9,21 +9,18 @@ class DummyObjectWithCudaArrayInterface(object):
 
     def __init__(self, a):
         self.a = a
-        self._desc = None
 
     @property
     def __cuda_array_interface__(self):
-        if self._desc is None:
-            desc = {
-                'shape': self.a.shape,
-                'strides': self.a.strides,
-                'typestr': self.a.dtype.str,
-                'descr': self.a.dtype.descr,
-                'data': (self.a.data.ptr, False),
-                'version': 2,
-            }
-            self._desc = desc
-        return self._desc
+        desc = {
+            'shape': self.a.shape,
+            'strides': self.a.strides,
+            'typestr': self.a.dtype.str,
+            'descr': self.a.dtype.descr,
+            'data': (self.a.data.ptr, False),
+            'version': 2,
+        }
+        return desc
 
 
 @testing.gpu


### PR DESCRIPTION
This PR does two things:
1. backport #2491 (by applying the patch from there)
2. add backward compatibility test for older protocols, resolve #2521 

The compatibility test should be ported to v7 once this PR is merged.