### PR TITLE
Add backward compatibility test for `__cuda_array_interface__`

### DIFF
--- a/tests/cupy_tests/creation_tests/test_from_data.py
+++ b/tests/cupy_tests/creation_tests/test_from_data.py
@@ -481,7 +481,9 @@ class TestFromData(unittest.TestCase):
         a = xp.ones((), dtype=dtype_a)
         return xp.asfortranarray(a, dtype=dtype_b)
 
+
 max_cuda_array_interface_version = 2
+
 
 class DummyObjectWithCudaArrayInterface(object):
 

--- a/tests/cupy_tests/creation_tests/test_from_data.py
+++ b/tests/cupy_tests/creation_tests/test_from_data.py
@@ -515,16 +515,14 @@ class DummyObjectWithCudaArrayInterface(object):
             'data': (self.a.data.ptr, False),
             'version': self.ver,
         }
-        if self.a.flags.f_contiguous:
-            desc['strides'] = self.a.strides
-        elif self.a.flags.c_contiguous:
+        if self.a.flags.c_contiguous:
             if self.include_strides is True:
                 desc['strides'] = self.a.strides
             elif self.include_strides is None:
                 desc['strides'] = None
             else:  # self.include_strides is False
                 pass
-        else:  # unlikely, just in case
+        else:  # F contiguous or neither
             desc['strides'] = self.a.strides
         if self.mask is not None:
             desc['mask'] = self.mask

--- a/tests/cupy_tests/creation_tests/test_from_data.py
+++ b/tests/cupy_tests/creation_tests/test_from_data.py
@@ -515,9 +515,9 @@ class DummyObjectWithCudaArrayInterface(object):
             'data': (self.a.data.ptr, False),
             'version': self.ver,
         }
-        if self.a._f_contiguous:
+        if self.a.flags.f_contiguous:
             desc['strides'] = self.a.strides
-        elif self.a._c_contiguous:
+        elif self.a.flags.c_contiguous:
             if self.include_strides is True:
                 desc['strides'] = self.a.strides
             elif self.include_strides is None:

--- a/tests/cupy_tests/creation_tests/test_from_data.py
+++ b/tests/cupy_tests/creation_tests/test_from_data.py
@@ -379,39 +379,46 @@ class TestFromData(unittest.TestCase):
 
     @testing.for_all_dtypes()
     def test_asarray_cuda_array_interface(self, dtype):
-        a = testing.shaped_arange((2, 3, 4), cupy, dtype)
-        b = cupy.asarray(DummyObjectWithCudaArrayInterface(a))
-        testing.assert_array_equal(a, b)
+        for ver in range(max_cuda_array_interface_version+1):
+            a = testing.shaped_arange((2, 3, 4), cupy, dtype)
+            b = cupy.asarray(DummyObjectWithCudaArrayInterface(a, ver))
+            testing.assert_array_equal(a, b)
 
     @testing.for_all_dtypes()
     def test_asarray_cuda_array_interface_is_not_copied(self, dtype):
-        a = testing.shaped_arange((2, 3, 4), cupy, dtype)
-        b = cupy.asarray(DummyObjectWithCudaArrayInterface(a))
-        a.fill(0)
-        testing.assert_array_equal(a, b)
+        for ver in range(max_cuda_array_interface_version+1):
+            a = testing.shaped_arange((2, 3, 4), cupy, dtype)
+            b = cupy.asarray(DummyObjectWithCudaArrayInterface(a, ver))
+            a.fill(0)
+            testing.assert_array_equal(a, b)
 
     @testing.for_all_dtypes()
     def test_asarray_cuda_array_interface_order(self, dtype):
-        a = testing.shaped_arange((2, 3, 4), cupy, dtype)
-        b = cupy.asarray(DummyObjectWithCudaArrayInterface(a), order='F')
-        assert b.flags.f_contiguous
-        testing.assert_array_equal(a, b)
+        for ver in range(max_cuda_array_interface_version+1):
+            a = testing.shaped_arange((2, 3, 4), cupy, dtype)
+            b = cupy.asarray(DummyObjectWithCudaArrayInterface(a, ver),
+                             order='F')
+            assert b.flags.f_contiguous
+            testing.assert_array_equal(a, b)
 
     @testing.for_all_dtypes()
     def test_asarray_cuda_array_interface_with_strides(self, dtype):
-        a = testing.shaped_arange((2, 3, 4), cupy, dtype).T
-        b = cupy.asarray(DummyObjectWithCudaArrayInterface(a))
-        assert a.strides == b.strides
-        assert a.nbytes == b.data.mem.size
+        for ver in range(max_cuda_array_interface_version+1):
+            a = testing.shaped_arange((2, 3, 4), cupy, dtype).T
+            b = cupy.asarray(DummyObjectWithCudaArrayInterface(a, ver))
+            assert a.strides == b.strides
+            assert a.nbytes == b.data.mem.size
 
-    # TODO(leofang): remove this test when masked array is supported
-    def test_asarray_cuda_array_interface_with_masked_array(self):
-        a = cupy.arange(10)
-        mask = cupy.zeros(10)
-        a = DummyObjectWithCudaArrayInterface(a, mask)
-        with pytest.raises(ValueError) as ex:
-            b = cupy.asarray(a)  # noqa
-        assert 'does not support' in str(ex.value)
+    # TODO(leofang): update this test when masked array is supported
+    @testing.for_all_dtypes()
+    def test_asarray_cuda_array_interface_with_masked_array(self, dtype):
+        for ver in range(1, max_cuda_array_interface_version+1):
+            a = testing.shaped_arange((2, 3, 4), cupy, dtype)
+            mask = testing.shaped_arange((2, 3, 4), cupy, dtype)
+            a = DummyObjectWithCudaArrayInterface(a, ver, mask)
+            with pytest.raises(ValueError) as ex:
+                b = cupy.asarray(a)  # noqa
+            assert 'does not support' in str(ex.value)
 
     def test_ascontiguousarray_on_noncontiguous_array(self):
         a = testing.shaped_arange((2, 3, 4))
@@ -474,25 +481,30 @@ class TestFromData(unittest.TestCase):
         a = xp.ones((), dtype=dtype_a)
         return xp.asfortranarray(a, dtype=dtype_b)
 
+max_cuda_array_interface_version = 2
 
 class DummyObjectWithCudaArrayInterface(object):
 
-    def __init__(self, a, mask=None):
+    def __init__(self, a, ver, mask=None):
+        assert ver in tuple(range(max_cuda_array_interface_version+1))
         self.a = a
+        self.ver = ver
         self.mask = mask
 
     @property
     def __cuda_array_interface__(self):
         desc = {
             'shape': self.a.shape,
-            'strides': self.a.strides,
             'typestr': self.a.dtype.str,
             'descr': self.a.dtype.descr,
             'data': (self.a.data.ptr, False),
-            'version': 2,
+            'version': self.ver,
         }
-        if self.mask is not None:
-            desc['mask'] = self.mask
+        if self.ver == 2 or self.a._f_contiguous:
+            desc['strides'] = self.a.strides
+        if self.ver > 0:
+            if self.mask is not None:
+                desc['mask'] = self.mask
         return desc
 
 

--- a/tests/cupy_tests/creation_tests/test_from_data.py
+++ b/tests/cupy_tests/creation_tests/test_from_data.py
@@ -446,9 +446,9 @@ max_cuda_array_interface_version = 2
 @testing.parameterize(*testing.product({
     'ver': tuple(range(max_cuda_array_interface_version+1)),
 }))
-class TestFromExternalData(unittest.TestCase):
+class TestCudaArrayInterface(unittest.TestCase):
     @testing.for_all_dtypes()
-    def test_asarray_cuda_array_interface(self, dtype):
+    def test_base(self, dtype):
         a = testing.shaped_arange((2, 3, 4), cupy, dtype)
         b = cupy.asarray(DummyObjectWithCudaArrayInterface(a, self.ver))
         testing.assert_array_equal(a, b)

--- a/tests/cupy_tests/creation_tests/test_from_data.py
+++ b/tests/cupy_tests/creation_tests/test_from_data.py
@@ -452,14 +452,14 @@ class TestCudaArrayInterface(unittest.TestCase):
     def test_base(self, dtype):
         a = testing.shaped_arange((2, 3, 4), cupy, dtype)
         b = cupy.asarray(
-                DummyObjectWithCudaArrayInterface(a, self.ver, self.strides))
+            DummyObjectWithCudaArrayInterface(a, self.ver, self.strides))
         testing.assert_array_equal(a, b)
 
     @testing.for_all_dtypes()
     def test_not_copied(self, dtype):
         a = testing.shaped_arange((2, 3, 4), cupy, dtype)
         b = cupy.asarray(
-                DummyObjectWithCudaArrayInterface(a, self.ver, self.strides))
+            DummyObjectWithCudaArrayInterface(a, self.ver, self.strides))
         a.fill(0)
         testing.assert_array_equal(a, b)
 
@@ -467,8 +467,8 @@ class TestCudaArrayInterface(unittest.TestCase):
     def test_order(self, dtype):
         a = testing.shaped_arange((2, 3, 4), cupy, dtype)
         b = cupy.asarray(
-                DummyObjectWithCudaArrayInterface(a, self.ver, self.strides),
-                order='F')
+            DummyObjectWithCudaArrayInterface(a, self.ver, self.strides),
+            order='F')
         assert b.flags.f_contiguous
         testing.assert_array_equal(a, b)
 
@@ -476,7 +476,7 @@ class TestCudaArrayInterface(unittest.TestCase):
     def test_with_strides(self, dtype):
         a = testing.shaped_arange((2, 3, 4), cupy, dtype).T
         b = cupy.asarray(
-                DummyObjectWithCudaArrayInterface(a, self.ver, self.strides))
+            DummyObjectWithCudaArrayInterface(a, self.ver, self.strides))
         assert a.strides == b.strides
         assert a.nbytes == b.data.mem.size
 

--- a/tests/cupy_tests/creation_tests/test_from_data.py
+++ b/tests/cupy_tests/creation_tests/test_from_data.py
@@ -454,14 +454,14 @@ class TestCudaArrayInterface(unittest.TestCase):
         testing.assert_array_equal(a, b)
 
     @testing.for_all_dtypes()
-    def test_asarray_cuda_array_interface_is_not_copied(self, dtype):
+    def test_not_copied(self, dtype):
         a = testing.shaped_arange((2, 3, 4), cupy, dtype)
         b = cupy.asarray(DummyObjectWithCudaArrayInterface(a, self.ver))
         a.fill(0)
         testing.assert_array_equal(a, b)
 
     @testing.for_all_dtypes()
-    def test_asarray_cuda_array_interface_order(self, dtype):
+    def test_order(self, dtype):
         a = testing.shaped_arange((2, 3, 4), cupy, dtype)
         b = cupy.asarray(DummyObjectWithCudaArrayInterface(a, self.ver),
                          order='F')
@@ -469,18 +469,21 @@ class TestCudaArrayInterface(unittest.TestCase):
         testing.assert_array_equal(a, b)
 
     @testing.for_all_dtypes()
-    def test_asarray_cuda_array_interface_with_strides(self, dtype):
+    def test_with_strides(self, dtype):
         a = testing.shaped_arange((2, 3, 4), cupy, dtype).T
         b = cupy.asarray(DummyObjectWithCudaArrayInterface(a, self.ver))
         assert a.strides == b.strides
         assert a.nbytes == b.data.mem.size
 
+
+@testing.gpu
+@testing.parameterize(*testing.product({
+    'ver': tuple(range(1, max_cuda_array_interface_version+1)),
+}))
+class TestCudaArrayInterfaceMaskedArray(unittest.TestCase):
     # TODO(leofang): update this test when masked array is supported
     @testing.for_all_dtypes()
-    def test_asarray_cuda_array_interface_with_masked_array(self, dtype):
-        if self.ver == 0:
-            raise unittest.SkipTest("Version 0 does not have the mask "
-                                    "attribute")
+    def test_masked_array(self, dtype):
         a = testing.shaped_arange((2, 3, 4), cupy, dtype)
         mask = testing.shaped_arange((2, 3, 4), cupy, dtype)
         a = DummyObjectWithCudaArrayInterface(a, self.ver, mask)


### PR DESCRIPTION
Followup of #2491. Resolves #2521. 

cf. https://github.com/cupy/cupy/pull/2534#issuecomment-539341617.