### PR TITLE
Fix bug in CUB + **Native support** of complex numbers in CUB 

### DIFF
--- a/cupy/core/include/cupy/complex/complex.h
+++ b/cupy/core/include/cupy/complex/complex.h
@@ -75,7 +75,7 @@ struct complex {
    *  \param re The real part of the number.
    *  \param im The imaginary part of the number.
    */
-  inline __device__ complex(const T& re = T(), const T& im = T());
+  inline __host__ __device__ complex(const T& re = T(), const T& im = T());
 
   /*! This copy constructor copies from a \p complex with a type that
    *  is convertible to this \p complex \c value_type.
@@ -85,7 +85,7 @@ struct complex {
    *  \tparam X is convertible to \c value_type.
    */
   template <typename X>
-  inline __device__ complex(const complex<X>& z);
+  inline __host__ __device__ complex(const complex<X>& z);
 
   /* --- Compound Assignment Operators --- */
 
@@ -94,28 +94,28 @@ struct complex {
    *
    *  \param z The \p complex to be Added.
    */
-  __device__ inline complex<T>& operator+=(const complex<T> z);
+  __host__ __device__ inline complex<T>& operator+=(const complex<T> z);
 
   /*! Subtracts a \p complex from this \p complex and
    *  assigns the result to this \p complex.
    *
    *  \param z The \p complex to be subtracted.
    */
-  __device__ inline complex<T>& operator-=(const complex<T> z);
+  __host__ __device__ inline complex<T>& operator-=(const complex<T> z);
 
   /*! Multiplies this \p complex by another \p complex and
    *  assigns the result to this \p complex.
    *
    *  \param z The \p complex to be multiplied.
    */
-  __device__ inline complex<T>& operator*=(const complex<T> z);
+  __host__ __device__ inline complex<T>& operator*=(const complex<T> z);
 
   /*! Divides this \p complex by another \p complex and
    *  assigns the result to this \p complex.
    *
    *  \param z The \p complex to be divided.
    */
-  __device__ inline complex<T>& operator/=(const complex<T> z);
+  __host__ __device__ inline complex<T>& operator/=(const complex<T> z);
 
   /* --- Getter functions ---
    * The volatile ones are there to help for example
@@ -124,19 +124,19 @@ struct complex {
 
   /*! Returns the real part of this \p complex.
    */
-  __device__ inline T real() const volatile { return m_data[0]; }
+  __host__ __device__ inline T real() const volatile { return m_data[0]; }
 
   /*! Returns the imaginary part of this \p complex.
    */
-  __device__ inline T imag() const volatile { return m_data[1]; }
+  __host__ __device__ inline T imag() const volatile { return m_data[1]; }
 
   /*! Returns the real part of this \p complex.
    */
-  __device__ inline T real() const { return m_data[0]; }
+  __host__ __device__ inline T real() const { return m_data[0]; }
 
   /*! Returns the imaginary part of this \p complex.
    */
-  __device__ inline T imag() const { return m_data[1]; }
+  __host__ __device__ inline T imag() const { return m_data[1]; }
 
   /* --- Setter functions ---
    * The volatile ones are there to help for example
@@ -147,25 +147,25 @@ struct complex {
    *
    *  \param re The new real part of this \p complex.
    */
-  __device__ inline void real(T re) volatile { m_data[0] = re; }
+  __host__ __device__ inline void real(T re) volatile { m_data[0] = re; }
 
   /*! Sets the imaginary part of this \p complex.
    *
    *  \param im The new imaginary part of this \p complex.e
    */
-  __device__ inline void imag(T im) volatile { m_data[1] = im; }
+  __host__ __device__ inline void imag(T im) volatile { m_data[1] = im; }
 
   /*! Sets the real part of this \p complex.
    *
    *  \param re The new real part of this \p complex.
    */
-  __device__ inline void real(T re) { m_data[0] = re; }
+  __host__ __device__ inline void real(T re) { m_data[0] = re; }
 
   /*! Sets the imaginary part of this \p complex.
    *
    *  \param im The new imaginary part of this \p complex.
    */
-  __device__ inline void imag(T im) { m_data[1] = im; }
+  __host__ __device__ inline void imag(T im) { m_data[1] = im; }
 
  private:
   T m_data[2];
@@ -548,7 +548,7 @@ __device__ complex<T> atanh(const complex<T>& z);
  *  \param rhs The second \p complex.
  */
 template <typename T>
-__device__ inline bool operator==(const complex<T>& lhs, const complex<T>& rhs);
+__host__ __device__ inline bool operator==(const complex<T>& lhs, const complex<T>& rhs);
 
 /*! Returns true if the imaginary part of the  \p complex number is zero and the
  * real part is equal to the scalar. Returns false otherwise.
@@ -557,7 +557,7 @@ __device__ inline bool operator==(const complex<T>& lhs, const complex<T>& rhs);
  *  \param rhs The \p complex.
  */
 template <typename T>
-__device__ inline bool operator==(const T& lhs, const complex<T>& rhs);
+__host__ __device__ inline bool operator==(const T& lhs, const complex<T>& rhs);
 
 /*! Returns true if the imaginary part of the  \p complex number is zero and the
  * real part is equal to the scalar. Returns false otherwise.
@@ -566,7 +566,7 @@ __device__ inline bool operator==(const T& lhs, const complex<T>& rhs);
  *  \param rhs The scalar.
  */
 template <typename T>
-__device__ inline bool operator==(const complex<T>& lhs, const T& rhs);
+__host__ __device__ inline bool operator==(const complex<T>& lhs, const T& rhs);
 
 /*! Returns true if two \p complex numbers are different and false otherwise.
  *
@@ -574,7 +574,7 @@ __device__ inline bool operator==(const complex<T>& lhs, const T& rhs);
  *  \param rhs The second \p complex.
  */
 template <typename T>
-__device__ inline bool operator!=(const complex<T>& lhs, const complex<T>& rhs);
+__host__ __device__ inline bool operator!=(const complex<T>& lhs, const complex<T>& rhs);
 
 /*! Returns true if the imaginary part of the  \p complex number is not zero or
  * the real part is different from the scalar. Returns false otherwise.
@@ -583,7 +583,7 @@ __device__ inline bool operator!=(const complex<T>& lhs, const complex<T>& rhs);
  *  \param rhs The \p complex.
  */
 template <typename T>
-__device__ inline bool operator!=(const T& lhs, const complex<T>& rhs);
+__host__ __device__ inline bool operator!=(const T& lhs, const complex<T>& rhs);
 
 /*! Returns true if the imaginary part of the \p complex number is not zero or
  * the real part is different from the scalar. Returns false otherwise.
@@ -592,7 +592,7 @@ __device__ inline bool operator!=(const T& lhs, const complex<T>& rhs);
  *  \param rhs The scalar.
  */
 template <typename T>
-__device__ inline bool operator!=(const complex<T>& lhs, const T& rhs);
+__host__ __device__ inline bool operator!=(const complex<T>& lhs, const T& rhs);
 
 }  // end namespace thrust
 

--- a/cupy/core/include/cupy/complex/complex_inl.h
+++ b/cupy/core/include/cupy/complex/complex_inl.h
@@ -24,14 +24,14 @@ namespace thrust {
 /* --- Constructors --- */
 
 template <typename T>
-inline __device__ complex<T>::complex(const T& re, const T& im) {
+inline __host__ __device__ complex<T>::complex(const T& re, const T& im) {
   real(re);
   imag(im);
 }
 
 template <typename T>
 template <typename X>
-inline __device__ complex<T>::complex(const complex<X>& z) {
+inline __host__ __device__ complex<T>::complex(const complex<X>& z) {
   // The explicit T() is there no prevent Visual Studio from complaining
   // about potential loss of precision
   real(T(z.real()));
@@ -41,27 +41,27 @@ inline __device__ complex<T>::complex(const complex<X>& z) {
 /* --- Compound Assignment Operators --- */
 
 template <typename T>
-__device__ inline complex<T>& complex<T>::operator+=(const complex<T> z) {
+__host__ __device__ inline complex<T>& complex<T>::operator+=(const complex<T> z) {
   real(real() + z.real());
   imag(imag() + z.imag());
   return *this;
 }
 
 template <typename T>
-__device__ inline complex<T>& complex<T>::operator-=(const complex<T> z) {
+__host__ __device__ inline complex<T>& complex<T>::operator-=(const complex<T> z) {
   real(real() - z.real());
   imag(imag() - z.imag());
   return *this;
 }
 
 template <typename T>
-__device__ inline complex<T>& complex<T>::operator*=(const complex<T> z) {
+__host__ __device__ inline complex<T>& complex<T>::operator*=(const complex<T> z) {
   *this = *this * z;
   return *this;
 }
 
 template <typename T>
-__device__ inline complex<T>& complex<T>::operator/=(const complex<T> z) {
+__host__ __device__ inline complex<T>& complex<T>::operator/=(const complex<T> z) {
   *this = *this / z;
   return *this;
 }
@@ -69,7 +69,7 @@ __device__ inline complex<T>& complex<T>::operator/=(const complex<T> z) {
 /* --- Equality Operators --- */
 
 template <typename T>
-__device__ inline bool operator==(const complex<T>& lhs,
+__host__ __device__ inline bool operator==(const complex<T>& lhs,
                                   const complex<T>& rhs) {
   if (lhs.real() == rhs.real() && lhs.imag() == rhs.imag()) {
     return true;
@@ -78,7 +78,7 @@ __device__ inline bool operator==(const complex<T>& lhs,
 }
 
 template <typename T>
-__device__ inline bool operator==(const T& lhs, const complex<T>& rhs) {
+__host__ __device__ inline bool operator==(const T& lhs, const complex<T>& rhs) {
   if (lhs == rhs.real() && rhs.imag() == 0) {
     return true;
   }
@@ -86,7 +86,7 @@ __device__ inline bool operator==(const T& lhs, const complex<T>& rhs) {
 }
 
 template <typename T>
-__device__ inline bool operator==(const complex<T>& lhs, const T& rhs) {
+__host__ __device__ inline bool operator==(const complex<T>& lhs, const T& rhs) {
   if (lhs.real() == rhs && lhs.imag() == 0) {
     return true;
   }
@@ -94,18 +94,18 @@ __device__ inline bool operator==(const complex<T>& lhs, const T& rhs) {
 }
 
 template <typename T>
-__device__ inline bool operator!=(const complex<T>& lhs,
+__host__ __device__ inline bool operator!=(const complex<T>& lhs,
                                   const complex<T>& rhs) {
   return !(lhs == rhs);
 }
 
 template <typename T>
-__device__ inline bool operator!=(const T& lhs, const complex<T>& rhs) {
+__host__ __device__ inline bool operator!=(const T& lhs, const complex<T>& rhs) {
   return !(lhs == rhs);
 }
 
 template <typename T>
-__device__ inline bool operator!=(const complex<T>& lhs, const T& rhs) {
+__host__ __device__ inline bool operator!=(const complex<T>& lhs, const T& rhs) {
   return !(lhs == rhs);
 }
 }

--- a/cupy/cuda/cub.pyx
+++ b/cupy/cuda/cub.pyx
@@ -25,6 +25,8 @@ cdef enum:
     CUPY_CUB_FLOAT16 = 8
     CUPY_CUB_FLOAT32 = 9
     CUPY_CUB_FLOAT64 = 10
+    CUPY_CUB_COMPLEX64 = 11
+    CUPY_CUB_COMPLEX128 = 12
 
 ###############################################################################
 # Extern
@@ -43,19 +45,7 @@ cdef extern from 'cupy_cub.h':
 ###############################################################################
 
 
-# TODO(leofang): remove this hack when CUB supports complex numbers
 def reduce_sum(core.ndarray x, out=None):
-    if x.dtype in (numpy.complex64, numpy.complex128):
-        if out is None:
-            out = core.ndarray((), dtype=x.dtype)
-        _reduce_sum(x.real, out.real)
-        _reduce_sum(x.imag, out.imag)
-        return out
-    else:
-        return _reduce_sum(x, out)
-
-
-def _reduce_sum(core.ndarray x, out=None):
     cdef core.ndarray y
     cdef core.ndarray ws
     cdef int dtype_id
@@ -99,32 +89,7 @@ def can_use_reduce_sum(x_dtype, dtype=None):
     return True
 
 
-# TODO(leofang): remove this hack when CUB supports complex numbers
 def reduce_min(core.ndarray x, out=None):
-    if x.dtype in (numpy.complex64, numpy.complex128):
-        # NumPy does the comparison of complex numbers in lexical order
-        # (numpy/numpy#2004): test real part first, then imaginary
-        out_re = _reduce_min(x.real, out if out is None else out.real)
-        idx = (x.real == out_re).nonzero()
-        if len(idx) == x.ndim:
-            y = x[idx][0]
-            if out is not None:
-                out[...] = y
-                y = out
-            return y
-        else:
-            out_im = _reduce_min(x[idx].imag, out if out is None else out.imag)
-            # we know the full answer at this point, no need to search again
-            y = out_re + 1j * out_im
-            if out is not None:
-                out[...] = y
-                y = out
-            return y
-    else:
-        return _reduce_min(x, out)
-
-
-def _reduce_min(core.ndarray x, out=None):
     cdef core.ndarray y
     cdef core.ndarray ws
     cdef int dtype_id
@@ -160,32 +125,7 @@ def can_use_reduce_min(x_dtype, dtype=None):
     return True
 
 
-# TODO(leofang): remove this hack when CUB supports complex numbers
 def reduce_max(core.ndarray x, out=None):
-    if x.dtype in (numpy.complex64, numpy.complex128):
-        # NumPy does the comparison of complex numbers in lexical order
-        # (numpy/numpy#2004): test real part first, then imaginary
-        out_re = _reduce_max(x.real, out if out is None else out.real)
-        idx = (x.real == out_re).nonzero()
-        if len(idx) == x.ndim:
-            y = x[idx][0]
-            if out is not None:
-                out[...] = y
-                y = out
-            return y
-        else:
-            out_im = _reduce_max(x[idx].imag, out if out is None else out.imag)
-            # we know the full answer at this point, no need to search again
-            y = out_re + 1j * out_im
-            if out is not None:
-                out[...] = y
-                y = out
-            return y
-    else:
-        return _reduce_max(x, out)
-
-
-def _reduce_max(core.ndarray x, out=None):
     cdef core.ndarray y
     cdef core.ndarray ws
     cdef int dtype_id
@@ -242,6 +182,10 @@ def _get_dtype_id(dtype):
         ret = CUPY_CUB_FLOAT32
     elif dtype == numpy.float64:
         ret = CUPY_CUB_FLOAT64
+    elif dtype == numpy.complex64:
+        ret = CUPY_CUB_COMPLEX64
+    elif dtype == numpy.complex128:
+        ret = CUPY_CUB_COMPLEX128
     else:
         raise ValueError('Unsupported dtype ({})'.format(dtype))
     return ret

--- a/cupy/cuda/cupy_cub.cu
+++ b/cupy/cuda/cupy_cub.cu
@@ -1,19 +1,26 @@
 #include <cupy/complex.cuh>
 #include <cub/device/device_reduce.cuh>
 #include "cupy_cub.h"
-//#include <stdexcept>
+#include <stdexcept>
 
 using namespace cub;
 
+// Minimum boilerplate to support complex numbers in sum(), min(), and max():
+// - This works only because all data fields in the *Traits struct are not
+//   used in <cub/device/device_reduce.cuh>.
+// - DO NOT USE THIS STUB for supporting CUB sorting!!!!!!
+// - The Max() and Lowest() below are chosen to comply with NumPy's lexical
+//   ordering; note that std::numeric_limits<T> does not support complex
+//   numbers as in general the comparison is ill defined.
 template <>
 struct FpLimits<complex<float>>
 {
     static __host__ __device__ __forceinline__ complex<float> Max() {
-        return FLT_MAX;
+        return (complex<float>(FLT_MAX, FLT_MAX));
     }
 
     static __host__ __device__ __forceinline__ complex<float> Lowest() {
-        return FLT_MAX * float(-1);
+        return (complex<float>(FLT_MAX * float(-1), FLT_MAX * float(-1)));
     }
 };
 
@@ -21,16 +28,17 @@ template <>
 struct FpLimits<complex<double>>
 {
     static __host__ __device__ __forceinline__ complex<double> Max() {
-        return DBL_MAX;
+        return (complex<double>(DBL_MAX, DBL_MAX));
     }
 
     static __host__ __device__ __forceinline__ complex<double> Lowest() {
-        return DBL_MAX  * double(-1);
+        return (complex<double>(DBL_MAX * double(-1), DBL_MAX * double(-1)));
     }
 };
 
-template <> struct NumericTraits<complex<float>> :               BaseTraits<FLOATING_POINT, true, false, unsigned int, complex<float>> {};
-template <> struct NumericTraits<complex<double>> :              BaseTraits<FLOATING_POINT, true, false, unsigned long long, complex<double>> {};
+template <> struct NumericTraits<complex<float>>  : BaseTraits<FLOATING_POINT, true, false, unsigned int, complex<float>> {};
+template <> struct NumericTraits<complex<double>> : BaseTraits<FLOATING_POINT, true, false, unsigned long long, complex<double>> {};
+// end of boilerplate
 
 
 //

--- a/cupy/cuda/cupy_cub.cu
+++ b/cupy/cuda/cupy_cub.cu
@@ -1,8 +1,37 @@
+#include <cupy/complex.cuh>
 #include <cub/device/device_reduce.cuh>
 #include "cupy_cub.h"
-#include <stdexcept>
+//#include <stdexcept>
 
 using namespace cub;
+
+template <>
+struct FpLimits<complex<float>>
+{
+    static __host__ __device__ __forceinline__ complex<float> Max() {
+        return FLT_MAX;
+    }
+
+    static __host__ __device__ __forceinline__ complex<float> Lowest() {
+        return FLT_MAX * float(-1);
+    }
+};
+
+template <>
+struct FpLimits<complex<double>>
+{
+    static __host__ __device__ __forceinline__ complex<double> Max() {
+        return DBL_MAX;
+    }
+
+    static __host__ __device__ __forceinline__ complex<double> Lowest() {
+        return DBL_MAX  * double(-1);
+    }
+};
+
+template <> struct NumericTraits<complex<float>> :               BaseTraits<FLOATING_POINT, true, false, unsigned int, complex<float>> {};
+template <> struct NumericTraits<complex<double>> :              BaseTraits<FLOATING_POINT, true, false, unsigned long long, complex<double>> {};
+
 
 //
 // **** dtype_dispatcher ****
@@ -14,16 +43,18 @@ template <class functor_t, typename... Ts>
 void dtype_dispatcher(int dtype_id, functor_t f, Ts&&... args)
 {
     switch (dtype_id) {
-    case CUPY_CUB_INT8:	   return f.template operator()<char>(std::forward<Ts>(args)...);
-    case CUPY_CUB_INT16:   return f.template operator()<short>(std::forward<Ts>(args)...);
-    case CUPY_CUB_INT32:   return f.template operator()<int>(std::forward<Ts>(args)...);
-    case CUPY_CUB_INT64:   return f.template operator()<long>(std::forward<Ts>(args)...);
-    case CUPY_CUB_UINT8:   return f.template operator()<unsigned char>(std::forward<Ts>(args)...);
-    case CUPY_CUB_UINT16:  return f.template operator()<unsigned short>(std::forward<Ts>(args)...);
-    case CUPY_CUB_UINT32:  return f.template operator()<unsigned int>(std::forward<Ts>(args)...);
-    case CUPY_CUB_UINT64:  return f.template operator()<unsigned long>(std::forward<Ts>(args)...);
-    case CUPY_CUB_FLOAT32: return f.template operator()<float>(std::forward<Ts>(args)...);
-    case CUPY_CUB_FLOAT64: return f.template operator()<double>(std::forward<Ts>(args)...);
+    case CUPY_CUB_INT8:	      return f.template operator()<char>(std::forward<Ts>(args)...);
+    case CUPY_CUB_INT16:      return f.template operator()<short>(std::forward<Ts>(args)...);
+    case CUPY_CUB_INT32:      return f.template operator()<int>(std::forward<Ts>(args)...);
+    case CUPY_CUB_INT64:      return f.template operator()<long>(std::forward<Ts>(args)...);
+    case CUPY_CUB_UINT8:      return f.template operator()<unsigned char>(std::forward<Ts>(args)...);
+    case CUPY_CUB_UINT16:     return f.template operator()<unsigned short>(std::forward<Ts>(args)...);
+    case CUPY_CUB_UINT32:     return f.template operator()<unsigned int>(std::forward<Ts>(args)...);
+    case CUPY_CUB_UINT64:     return f.template operator()<unsigned long>(std::forward<Ts>(args)...);
+    case CUPY_CUB_FLOAT32:    return f.template operator()<float>(std::forward<Ts>(args)...);
+    case CUPY_CUB_FLOAT64:    return f.template operator()<double>(std::forward<Ts>(args)...);
+    case CUPY_CUB_COMPLEX64:  return f.template operator()<complex<float>>(std::forward<Ts>(args)...);
+    case CUPY_CUB_COMPLEX128: return f.template operator()<complex<double>>(std::forward<Ts>(args)...);
     default:
 	throw std::runtime_error("Unsupported dtype ID");
     }

--- a/cupy/cuda/cupy_cub.h
+++ b/cupy/cuda/cupy_cub.h
@@ -1,17 +1,19 @@
 #ifndef INCLUDE_GUARD_CUPY_CUDA_CUB_H
 #define INCLUDE_GUARD_CUPY_CUDA_CUB_H
 
-#define CUPY_CUB_INT8     0
-#define CUPY_CUB_UINT8    1
-#define CUPY_CUB_INT16    2
-#define CUPY_CUB_UINT16   3
-#define CUPY_CUB_INT32    4
-#define CUPY_CUB_UINT32   5
-#define CUPY_CUB_INT64    6
-#define CUPY_CUB_UINT64   7
-#define CUPY_CUB_FLOAT16  8
-#define CUPY_CUB_FLOAT32  9
-#define CUPY_CUB_FLOAT64 10
+#define CUPY_CUB_INT8        0
+#define CUPY_CUB_UINT8       1
+#define CUPY_CUB_INT16       2
+#define CUPY_CUB_UINT16      3
+#define CUPY_CUB_INT32       4
+#define CUPY_CUB_UINT32      5
+#define CUPY_CUB_INT64       6
+#define CUPY_CUB_UINT64      7
+#define CUPY_CUB_FLOAT16     8
+#define CUPY_CUB_FLOAT32     9
+#define CUPY_CUB_FLOAT64    10
+#define CUPY_CUB_COMPLEX64  11
+#define CUPY_CUB_COMPLEX128 12
 
 #ifndef CUPY_NO_CUDA
 

--- a/install/build.py
+++ b/install/build.py
@@ -143,6 +143,11 @@ def get_compiler_setting(use_cpp11):
 
     cub_path = os.environ.get('CUB_PATH', '')
     if os.path.exists(cub_path):
+        # for <cupy/complex.cuh>
+        cupy_header = os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                                   '../cupy/core/include')
+        #print("\n\n****************", cupy_header, "****************\n\n")
+        include_dirs.append(cupy_header)
         include_dirs.append(cub_path)
 
     return {

--- a/install/build.py
+++ b/install/build.py
@@ -146,7 +146,6 @@ def get_compiler_setting(use_cpp11):
         # for <cupy/complex.cuh>
         cupy_header = os.path.join(os.path.dirname(os.path.realpath(__file__)),
                                    '../cupy/core/include')
-        #print("\n\n****************", cupy_header, "****************\n\n")
         include_dirs.append(cupy_header)
         include_dirs.append(cub_path)
 


### PR DESCRIPTION
This PR supersedes #2508 (was at commit 34d6ed9). Now complex-number reductions are supported ***natively*** in CUB. 

Closes #2508. Addresses #2519. 

Specifically, to achieve this we need two changes:
1. Add `__host__` qualifier to basic `thrust::complex` operations: Note that this also complies with the latest Thrust, but more importantly we need this for 2 below. (Without this change the program would crash silently, not even throwing a segfault!)
2. Add two specializations of `NumericalTraits`: see the comment in `cupy/cuda/cupy_cub.cu`.

I see a much better improvement over the previous version #2508. Statistics follow below.

cc: @grlee77 @toslunar @anaruse 