### PR TITLE
Fixed not to import `cupyx.fallback_mode` default when importing `cupyx`

### DIFF
--- a/cupyx/__init__.py
+++ b/cupyx/__init__.py
@@ -7,4 +7,3 @@ from cupyx.scatter import scatter_min  # NOQA
 
 from cupyx import linalg  # NOQA
 from cupyx import scipy  # NOQA
-from cupyx import fallback_mode  # NOQA


### PR DESCRIPTION
Some initialization processes are triggered when importing `cupy.fallback_mode`, but these processes are not needed if fallback mode is not used.