### PR TITLE
Add cuSPARSE routines for preconditioners

### DIFF
--- a/cupy/cuda/cupy_cusparse.h
+++ b/cupy/cuda/cupy_cusparse.h
@@ -191,6 +191,10 @@ typedef enum {
 
 typedef void* cusparseHandle_t;
 typedef void* cusparseMatDescr_t;
+typedef void* csric02Info_t;
+typedef void* bsric02Info_t;
+typedef void* csrilu02Info_t;
+typedef void* bsrilu02Info_t;
 
 typedef enum {} cusparseMatrixType_t;
 typedef enum {} cusparseOperation_t;
@@ -198,6 +202,7 @@ typedef enum {} cusparsePointerMode_t;
 typedef enum {} cusparseAction_t;
 typedef enum {} cusparseDirection_t;
 typedef enum {} cusparseAlgMode_t;
+typedef enum {} cusparseSolvePolicy_t;
 
 // cuSPARSE Helper Function
 cusparseStatus_t cusparseCreate(...) {
@@ -513,6 +518,14 @@ cusparseStatus_t cusparseCreateCsric02Info(...) {
 }
 
 cusparseStatus_t cusparseDestroyCsric02Info(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseCreateBsric02Info(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDestroyBsric02Info(...) {
   return CUSPARSE_STATUS_SUCCESS;
 }
 

--- a/cupy/cuda/cupy_cusparse.h
+++ b/cupy/cuda/cupy_cusparse.h
@@ -8,6 +8,172 @@
 #include <cuda.h>
 #include <cusparse.h>
 
+#if CUDA_VERSION < 9000
+// Functions added in CUDA 9.0
+cusparseStatus_t cusparseSgtsv2_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDgtsv2_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseCgtsv2_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseZgtsv2_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseSgtsv2(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDgtsv2(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseCgtsv2(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseZgtsv2(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseSgtsv2_nopivot_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDgtsv2_nopivot_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseCgtsv2_nopivot_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseZgtsv2_nopivot_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseSgtsv2_nopivot(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDgtsv2_nopivot(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseCgtsv2_nopivot(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseZgtsv2_nopivot(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseSgtsv2StridedBatch_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDgtsv2StridedBatch_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseCgtsv2StridedBatch_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseZgtsv2StridedBatch_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseSgtsv2StridedBatch(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDgtsv2StridedBatch(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseCgtsv2StridedBatch(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseZgtsv2StridedBatch(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+#endif // #if CUDA_VERSION < 9000
+
+#if CUDA_VERSION < 9200
+// Functions added in CUDA 9.2
+cusparseStatus_t cusparseSgtsvInterleavedBatch_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDgtsvInterleavedBatch_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseCgtsvInterleavedBatch_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseZgtsvInterleavedBatch_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseSgtsvInterleavedBatch(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDgtsvInterleavedBatch(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseCgtsvInterleavedBatch(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseZgtsvInterleavedBatch(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseSgpsvInterleavedBatch_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDgpsvInterleavedBatch_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseCgpsvInterleavedBatch_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseZgpsvInterleavedBatch_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseSgpsvInterleavedBatch(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDgpsvInterleavedBatch(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseCgpsvInterleavedBatch(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseZgpsvInterleavedBatch(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+#endif // #if CUDA_VERSION < 9200
+
 #else  // #if !defined(CUPY_NO_CUDA) && !defined(CUPY_USE_HIP)
 
 #ifdef CUPY_USE_HIP
@@ -321,6 +487,496 @@ cusparseStatus_t cusparseXcscsort_bufferSizeExt(...) {
 }
 
 cusparseStatus_t cusparseXcscsort(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+// cuSPARSE PRECONDITIONERS
+
+cusparseStatus_t cusparseCreateCsrilu02Info(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDestroyCsrilu02Info(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseCreateBsrilu02Info(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDestroyBsrilu02Info(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseCreateCsric02Info(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDestroyCsric02Info(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseScsrilu02_numericBoost(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDcsrilu02_numericBoost(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseCcsrilu02_numericBoost(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseZcsrilu02_numericBoost(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseXcsrilu02_zeroPivot(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseScsrilu02_bufferSize(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDcsrilu02_bufferSize(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseCcsrilu02_bufferSize(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseZcsrilu02_bufferSize(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseScsrilu02_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDcsrilu02_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseCcsrilu02_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseZcsrilu02_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseScsrilu02_analysis(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDcsrilu02_analysis(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseCcsrilu02_analysis(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseZcsrilu02_analysis(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseScsrilu02(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDcsrilu02(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseCcsrilu02(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseZcsrilu02(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseSbsrilu02_numericBoost(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDbsrilu02_numericBoost(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseCbsrilu02_numericBoost(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseZbsrilu02_numericBoost(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseXbsrilu02_zeroPivot(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseSbsrilu02_bufferSize(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDbsrilu02_bufferSize(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseCbsrilu02_bufferSize(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseZbsrilu02_bufferSize(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseSbsrilu02_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDbsrilu02_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseCbsrilu02_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseZbsrilu02_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseSbsrilu02_analysis(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDbsrilu02_analysis(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseCbsrilu02_analysis(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseZbsrilu02_analysis(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseSbsrilu02(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDbsrilu02(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseCbsrilu02(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseZbsrilu02(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseXcsric02_zeroPivot(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseScsric02_bufferSize(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDcsric02_bufferSize(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseCcsric02_bufferSize(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseZcsric02_bufferSize(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseScsric02_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDcsric02_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseCcsric02_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseZcsric02_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseScsric02_analysis(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDcsric02_analysis(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseCcsric02_analysis(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseZcsric02_analysis(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseScsric02(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDcsric02(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseCcsric02(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseZcsric02(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseXbsric02_zeroPivot(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseSbsric02_bufferSize(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDbsric02_bufferSize(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseCbsric02_bufferSize(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseZbsric02_bufferSize(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseSbsric02_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDbsric02_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseCbsric02_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseZbsric02_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseSbsric02_analysis(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDbsric02_analysis(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseCbsric02_analysis(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseZbsric02_analysis(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseSbsric02(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDbsric02(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseCbsric02(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseZbsric02(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseSgtsv2_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDgtsv2_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseCgtsv2_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseZgtsv2_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseSgtsv2(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDgtsv2(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseCgtsv2(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseZgtsv2(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseSgtsv2_nopivot_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDgtsv2_nopivot_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseCgtsv2_nopivot_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseZgtsv2_nopivot_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseSgtsv2_nopivot(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDgtsv2_nopivot(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseCgtsv2_nopivot(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseZgtsv2_nopivot(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseSgtsv2StridedBatch_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDgtsv2StridedBatch_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseCgtsv2StridedBatch_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseZgtsv2StridedBatch_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseSgtsv2StridedBatch(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDgtsv2StridedBatch(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseCgtsv2StridedBatch(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseZgtsv2StridedBatch(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseSgtsvInterleavedBatch_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDgtsvInterleavedBatch_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseCgtsvInterleavedBatch_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseZgtsvInterleavedBatch_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseSgtsvInterleavedBatch(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDgtsvInterleavedBatch(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseCgtsvInterleavedBatch(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseZgtsvInterleavedBatch(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseSgpsvInterleavedBatch_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDgpsvInterleavedBatch_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseCgpsvInterleavedBatch_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseZgpsvInterleavedBatch_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseSgpsvInterleavedBatch(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDgpsvInterleavedBatch(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseCgpsvInterleavedBatch(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseZgpsvInterleavedBatch(...) {
   return CUSPARSE_STATUS_SUCCESS;
 }
 

--- a/cupy/cuda/cusparse.pxd
+++ b/cupy/cuda/cusparse.pxd
@@ -17,6 +17,17 @@ cdef extern from *:
     ctypedef int Action 'cusparseAction_t'
     ctypedef int AlgMode 'cusparseAlgMode_t'
 
+    ctypedef void* cusparseHandle_t
+    ctypedef void* cusparseMatDescr_t
+    ctypedef void* csric02Info_t
+    ctypedef void* bsric02Info_t
+    ctypedef void* csrilu02Info_t
+    ctypedef void* bsrilu02Info_t
+
+    ctypedef int cusparseStatus_t
+    ctypedef int cusparseDirection_t
+    ctypedef int cusparseSolvePolicy_t
+
 cpdef enum:
     CUSPARSE_POINTER_MODE_HOST = 0
     CUSPARSE_POINTER_MODE_DEVICE = 1
@@ -38,6 +49,9 @@ cpdef enum:
 
     CUSPARSE_DIRECTION_ROW = 0
     CUSPARSE_DIRECTION_COLUMN = 1
+
+    CUSPARSE_SOLVE_POLICY_NO_LEVEL = 0
+    CUSPARSE_SOLVE_POLICY_USE_LEVEL = 1
 
     CUSPARSE_ALG_NAIVE = 0
     CUSPARSE_ALG_MERGE_PATH = 1

--- a/cupy/cuda/cusparse.pyx
+++ b/cupy/cuda/cusparse.pyx
@@ -11,7 +11,7 @@ cdef extern from 'cupy_cuComplex.h':
     ctypedef struct cuDoubleComplex 'cuDoubleComplex':
         double x, y
 
-cdef extern from 'cupy_cusparse.h':
+cdef extern from 'cupy_cusparse.h' nogil:
 
     # cuSPARSE Helper Function
     Status cusparseCreate(Handle *handle)
@@ -432,6 +432,522 @@ cdef extern from 'cupy_cusparse.h':
         Handle handle, int m, int n, int nnz, const MatDescr descrA,
         const int *cscColPtr, int *cscRowInd, int *P, void *pBuffer)
 
+    # cuSparse PRECONDITIONERS
+    cusparseStatus_t cusparseCreateCsrilu02Info(csrilu02Info_t *info)
+    cusparseStatus_t cusparseDestroyCsrilu02Info(csrilu02Info_t info)
+    cusparseStatus_t cusparseCreateBsrilu02Info(bsrilu02Info_t *info)
+    cusparseStatus_t cusparseDestroyBsrilu02Info(bsrilu02Info_t info)
+    cusparseStatus_t cusparseCreateCsric02Info(csric02Info_t *info)
+    cusparseStatus_t cusparseDestroyCsric02Info(csric02Info_t info)
+    cusparseStatus_t cusparseCreateBsric02Info(bsric02Info_t *info)
+    cusparseStatus_t cusparseDestroyBsric02Info(bsric02Info_t info)
+    cusparseStatus_t cusparseScsrilu02_numericBoost(
+        cusparseHandle_t handle, csrilu02Info_t info, int enable_boost,
+        double *tol, float *boost_val)
+    cusparseStatus_t cusparseDcsrilu02_numericBoost(
+        cusparseHandle_t handle, csrilu02Info_t info, int enable_boost,
+        double *tol, double *boost_val)
+    cusparseStatus_t cusparseCcsrilu02_numericBoost(
+        cusparseHandle_t handle, csrilu02Info_t info, int enable_boost,
+        double *tol, cuComplex *boost_val)
+    cusparseStatus_t cusparseZcsrilu02_numericBoost(
+        cusparseHandle_t handle, csrilu02Info_t info, int enable_boost,
+        double *tol, cuDoubleComplex *boost_val)
+    cusparseStatus_t cusparseXcsrilu02_zeroPivot(
+        cusparseHandle_t handle, csrilu02Info_t info, int *position)
+    cusparseStatus_t cusparseScsrilu02_bufferSize(
+        cusparseHandle_t handle, int m, int nnz,
+        const cusparseMatDescr_t descrA, float *csrSortedValA,
+        const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+        csrilu02Info_t info, int *pBufferSizeInBytes)
+    cusparseStatus_t cusparseDcsrilu02_bufferSize(
+        cusparseHandle_t handle, int m, int nnz,
+        const cusparseMatDescr_t descrA, double *csrSortedValA,
+        const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+        csrilu02Info_t info, int *pBufferSizeInBytes)
+    cusparseStatus_t cusparseCcsrilu02_bufferSize(
+        cusparseHandle_t handle, int m, int nnz,
+        const cusparseMatDescr_t descrA, cuComplex *csrSortedValA,
+        const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+        csrilu02Info_t info, int *pBufferSizeInBytes)
+    cusparseStatus_t cusparseZcsrilu02_bufferSize(
+        cusparseHandle_t handle, int m, int nnz,
+        const cusparseMatDescr_t descrA, cuDoubleComplex *csrSortedValA,
+        const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+        csrilu02Info_t info, int *pBufferSizeInBytes)
+    cusparseStatus_t cusparseScsrilu02_bufferSizeExt(
+        cusparseHandle_t handle, int m, int nnz,
+        const cusparseMatDescr_t descrA, float *csrSortedVal,
+        const int *csrSortedRowPtr, const int *csrSortedColInd,
+        csrilu02Info_t info, size_t *pBufferSize)
+    cusparseStatus_t cusparseDcsrilu02_bufferSizeExt(
+        cusparseHandle_t handle, int m, int nnz,
+        const cusparseMatDescr_t descrA, double *csrSortedVal,
+        const int *csrSortedRowPtr, const int *csrSortedColInd,
+        csrilu02Info_t info, size_t *pBufferSize)
+    cusparseStatus_t cusparseCcsrilu02_bufferSizeExt(
+        cusparseHandle_t handle, int m, int nnz,
+        const cusparseMatDescr_t descrA, cuComplex *csrSortedVal,
+        const int *csrSortedRowPtr, const int *csrSortedColInd,
+        csrilu02Info_t info, size_t *pBufferSize)
+    cusparseStatus_t cusparseZcsrilu02_bufferSizeExt(
+        cusparseHandle_t handle, int m, int nnz,
+        const cusparseMatDescr_t descrA, cuDoubleComplex *csrSortedVal,
+        const int *csrSortedRowPtr, const int *csrSortedColInd,
+        csrilu02Info_t info, size_t *pBufferSize)
+    cusparseStatus_t cusparseScsrilu02_analysis(
+        cusparseHandle_t handle, int m, int nnz,
+        const cusparseMatDescr_t descrA, const float *csrSortedValA,
+        const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+        csrilu02Info_t info, cusparseSolvePolicy_t policy, void *pBuffer)
+    cusparseStatus_t cusparseDcsrilu02_analysis(
+        cusparseHandle_t handle, int m, int nnz,
+        const cusparseMatDescr_t descrA, const double *csrSortedValA,
+        const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+        csrilu02Info_t info, cusparseSolvePolicy_t policy, void *pBuffer)
+    cusparseStatus_t cusparseCcsrilu02_analysis(
+        cusparseHandle_t handle, int m, int nnz,
+        const cusparseMatDescr_t descrA, const cuComplex *csrSortedValA,
+        const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+        csrilu02Info_t info, cusparseSolvePolicy_t policy, void *pBuffer)
+    cusparseStatus_t cusparseZcsrilu02_analysis(
+        cusparseHandle_t handle, int m, int nnz,
+        const cusparseMatDescr_t descrA, const cuDoubleComplex *csrSortedValA,
+        const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+        csrilu02Info_t info, cusparseSolvePolicy_t policy, void *pBuffer)
+    cusparseStatus_t cusparseScsrilu02(
+        cusparseHandle_t handle, int m, int nnz,
+        const cusparseMatDescr_t descrA, float *csrSortedValA_valM,
+        const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+        csrilu02Info_t info, cusparseSolvePolicy_t policy, void *pBuffer)
+    cusparseStatus_t cusparseDcsrilu02(
+        cusparseHandle_t handle, int m, int nnz,
+        const cusparseMatDescr_t descrA, double *csrSortedValA_valM,
+        const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+        csrilu02Info_t info, cusparseSolvePolicy_t policy, void *pBuffer)
+    cusparseStatus_t cusparseCcsrilu02(
+        cusparseHandle_t handle, int m, int nnz,
+        const cusparseMatDescr_t descrA, cuComplex *csrSortedValA_valM,
+        const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+        csrilu02Info_t info, cusparseSolvePolicy_t policy, void *pBuffer)
+    cusparseStatus_t cusparseZcsrilu02(
+        cusparseHandle_t handle, int m, int nnz,
+        const cusparseMatDescr_t descrA, cuDoubleComplex *csrSortedValA_valM,
+        const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+        csrilu02Info_t info, cusparseSolvePolicy_t policy, void *pBuffer)
+    cusparseStatus_t cusparseSbsrilu02_numericBoost(
+        cusparseHandle_t handle, bsrilu02Info_t info, int enable_boost,
+        double *tol, float *boost_val)
+    cusparseStatus_t cusparseDbsrilu02_numericBoost(
+        cusparseHandle_t handle, bsrilu02Info_t info, int enable_boost,
+        double *tol, double *boost_val)
+    cusparseStatus_t cusparseCbsrilu02_numericBoost(
+        cusparseHandle_t handle, bsrilu02Info_t info, int enable_boost,
+        double *tol, cuComplex *boost_val)
+    cusparseStatus_t cusparseZbsrilu02_numericBoost(
+        cusparseHandle_t handle, bsrilu02Info_t info, int enable_boost,
+        double *tol, cuDoubleComplex *boost_val)
+    cusparseStatus_t cusparseXbsrilu02_zeroPivot(
+        cusparseHandle_t handle, bsrilu02Info_t info, int *position)
+    cusparseStatus_t cusparseSbsrilu02_bufferSize(
+        cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
+        const cusparseMatDescr_t descrA, float *bsrSortedVal,
+        const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
+        bsrilu02Info_t info, int *pBufferSizeInBytes)
+    cusparseStatus_t cusparseDbsrilu02_bufferSize(
+        cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
+        const cusparseMatDescr_t descrA, double *bsrSortedVal,
+        const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
+        bsrilu02Info_t info, int *pBufferSizeInBytes)
+    cusparseStatus_t cusparseCbsrilu02_bufferSize(
+        cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
+        const cusparseMatDescr_t descrA, cuComplex *bsrSortedVal,
+        const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
+        bsrilu02Info_t info, int *pBufferSizeInBytes)
+    cusparseStatus_t cusparseZbsrilu02_bufferSize(
+        cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
+        const cusparseMatDescr_t descrA, cuDoubleComplex *bsrSortedVal,
+        const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
+        bsrilu02Info_t info, int *pBufferSizeInBytes)
+    cusparseStatus_t cusparseSbsrilu02_bufferSizeExt(
+        cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
+        const cusparseMatDescr_t descrA, float *bsrSortedVal,
+        const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockSize,
+        bsrilu02Info_t info, size_t *pBufferSize)
+    cusparseStatus_t cusparseDbsrilu02_bufferSizeExt(
+        cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
+        const cusparseMatDescr_t descrA, double *bsrSortedVal,
+        const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockSize,
+        bsrilu02Info_t info, size_t *pBufferSize)
+    cusparseStatus_t cusparseCbsrilu02_bufferSizeExt(
+        cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
+        const cusparseMatDescr_t descrA, cuComplex *bsrSortedVal,
+        const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockSize,
+        bsrilu02Info_t info, size_t *pBufferSize)
+    cusparseStatus_t cusparseZbsrilu02_bufferSizeExt(
+        cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
+        const cusparseMatDescr_t descrA, cuDoubleComplex *bsrSortedVal,
+        const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockSize,
+        bsrilu02Info_t info, size_t *pBufferSize)
+    cusparseStatus_t cusparseSbsrilu02_analysis(
+        cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
+        const cusparseMatDescr_t descrA, float *bsrSortedVal,
+        const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
+        bsrilu02Info_t info, cusparseSolvePolicy_t policy, void *pBuffer)
+    cusparseStatus_t cusparseDbsrilu02_analysis(
+        cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
+        const cusparseMatDescr_t descrA, double *bsrSortedVal,
+        const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
+        bsrilu02Info_t info, cusparseSolvePolicy_t policy, void *pBuffer)
+    cusparseStatus_t cusparseCbsrilu02_analysis(
+        cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
+        const cusparseMatDescr_t descrA, cuComplex *bsrSortedVal,
+        const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
+        bsrilu02Info_t info, cusparseSolvePolicy_t policy, void *pBuffer)
+    cusparseStatus_t cusparseZbsrilu02_analysis(
+        cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
+        const cusparseMatDescr_t descrA, cuDoubleComplex *bsrSortedVal,
+        const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
+        bsrilu02Info_t info, cusparseSolvePolicy_t policy, void *pBuffer)
+    cusparseStatus_t cusparseSbsrilu02(
+        cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
+        const cusparseMatDescr_t descrA, float *bsrSortedVal,
+        const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
+        bsrilu02Info_t info, cusparseSolvePolicy_t policy, void *pBuffer)
+    cusparseStatus_t cusparseDbsrilu02(
+        cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
+        const cusparseMatDescr_t descrA, double *bsrSortedVal,
+        const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
+        bsrilu02Info_t info, cusparseSolvePolicy_t policy, void *pBuffer)
+    cusparseStatus_t cusparseCbsrilu02(
+        cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
+        const cusparseMatDescr_t descrA, cuComplex *bsrSortedVal,
+        const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
+        bsrilu02Info_t info, cusparseSolvePolicy_t policy, void *pBuffer)
+    cusparseStatus_t cusparseZbsrilu02(
+        cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
+        const cusparseMatDescr_t descrA, cuDoubleComplex *bsrSortedVal,
+        const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
+        bsrilu02Info_t info, cusparseSolvePolicy_t policy, void *pBuffer)
+    cusparseStatus_t cusparseXcsric02_zeroPivot(
+        cusparseHandle_t handle, csric02Info_t info, int *position)
+    cusparseStatus_t cusparseScsric02_bufferSize(
+        cusparseHandle_t handle, int m, int nnz,
+        const cusparseMatDescr_t descrA, float *csrSortedValA,
+        const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+        csric02Info_t info, int *pBufferSizeInBytes)
+    cusparseStatus_t cusparseDcsric02_bufferSize(
+        cusparseHandle_t handle, int m, int nnz,
+        const cusparseMatDescr_t descrA, double *csrSortedValA,
+        const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+        csric02Info_t info, int *pBufferSizeInBytes)
+    cusparseStatus_t cusparseCcsric02_bufferSize(
+        cusparseHandle_t handle, int m, int nnz,
+        const cusparseMatDescr_t descrA, cuComplex *csrSortedValA,
+        const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+        csric02Info_t info, int *pBufferSizeInBytes)
+    cusparseStatus_t cusparseZcsric02_bufferSize(
+        cusparseHandle_t handle, int m, int nnz,
+        const cusparseMatDescr_t descrA, cuDoubleComplex *csrSortedValA,
+        const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+        csric02Info_t info, int *pBufferSizeInBytes)
+    cusparseStatus_t cusparseScsric02_bufferSizeExt(
+        cusparseHandle_t handle, int m, int nnz,
+        const cusparseMatDescr_t descrA, float *csrSortedVal,
+        const int *csrSortedRowPtr, const int *csrSortedColInd,
+        csric02Info_t info, size_t *pBufferSize)
+    cusparseStatus_t cusparseDcsric02_bufferSizeExt(
+        cusparseHandle_t handle, int m, int nnz,
+        const cusparseMatDescr_t descrA, double *csrSortedVal,
+        const int *csrSortedRowPtr, const int *csrSortedColInd,
+        csric02Info_t info, size_t *pBufferSize)
+    cusparseStatus_t cusparseCcsric02_bufferSizeExt(
+        cusparseHandle_t handle, int m, int nnz,
+        const cusparseMatDescr_t descrA, cuComplex *csrSortedVal,
+        const int *csrSortedRowPtr, const int *csrSortedColInd,
+        csric02Info_t info, size_t *pBufferSize)
+    cusparseStatus_t cusparseZcsric02_bufferSizeExt(
+        cusparseHandle_t handle, int m, int nnz,
+        const cusparseMatDescr_t descrA, cuDoubleComplex *csrSortedVal,
+        const int *csrSortedRowPtr, const int *csrSortedColInd,
+        csric02Info_t info, size_t *pBufferSize)
+    cusparseStatus_t cusparseScsric02_analysis(
+        cusparseHandle_t handle, int m, int nnz,
+        const cusparseMatDescr_t descrA, const float *csrSortedValA,
+        const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+        csric02Info_t info, cusparseSolvePolicy_t policy, void *pBuffer)
+    cusparseStatus_t cusparseDcsric02_analysis(
+        cusparseHandle_t handle, int m, int nnz,
+        const cusparseMatDescr_t descrA, const double *csrSortedValA,
+        const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+        csric02Info_t info, cusparseSolvePolicy_t policy, void *pBuffer)
+    cusparseStatus_t cusparseCcsric02_analysis(
+        cusparseHandle_t handle, int m, int nnz,
+        const cusparseMatDescr_t descrA, const cuComplex *csrSortedValA,
+        const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+        csric02Info_t info, cusparseSolvePolicy_t policy, void *pBuffer)
+    cusparseStatus_t cusparseZcsric02_analysis(
+        cusparseHandle_t handle, int m, int nnz,
+        const cusparseMatDescr_t descrA, const cuDoubleComplex *csrSortedValA,
+        const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+        csric02Info_t info, cusparseSolvePolicy_t policy, void *pBuffer)
+    cusparseStatus_t cusparseScsric02(
+        cusparseHandle_t handle, int m, int nnz,
+        const cusparseMatDescr_t descrA, float *csrSortedValA_valM,
+        const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+        csric02Info_t info, cusparseSolvePolicy_t policy, void *pBuffer)
+    cusparseStatus_t cusparseDcsric02(
+        cusparseHandle_t handle, int m, int nnz,
+        const cusparseMatDescr_t descrA, double *csrSortedValA_valM,
+        const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+        csric02Info_t info, cusparseSolvePolicy_t policy, void *pBuffer)
+    cusparseStatus_t cusparseCcsric02(
+        cusparseHandle_t handle, int m, int nnz,
+        const cusparseMatDescr_t descrA, cuComplex *csrSortedValA_valM,
+        const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+        csric02Info_t info, cusparseSolvePolicy_t policy, void *pBuffer)
+    cusparseStatus_t cusparseZcsric02(
+        cusparseHandle_t handle, int m, int nnz,
+        const cusparseMatDescr_t descrA, cuDoubleComplex *csrSortedValA_valM,
+        const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+        csric02Info_t info, cusparseSolvePolicy_t policy, void *pBuffer)
+    cusparseStatus_t cusparseXbsric02_zeroPivot(
+        cusparseHandle_t handle, bsric02Info_t info, int *position)
+    cusparseStatus_t cusparseSbsric02_bufferSize(
+        cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
+        const cusparseMatDescr_t descrA, float *bsrSortedVal,
+        const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
+        bsric02Info_t info, int *pBufferSizeInBytes)
+    cusparseStatus_t cusparseDbsric02_bufferSize(
+        cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
+        const cusparseMatDescr_t descrA, double *bsrSortedVal,
+        const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
+        bsric02Info_t info, int *pBufferSizeInBytes)
+    cusparseStatus_t cusparseCbsric02_bufferSize(
+        cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
+        const cusparseMatDescr_t descrA, cuComplex *bsrSortedVal,
+        const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
+        bsric02Info_t info, int *pBufferSizeInBytes)
+    cusparseStatus_t cusparseZbsric02_bufferSize(
+        cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
+        const cusparseMatDescr_t descrA, cuDoubleComplex *bsrSortedVal,
+        const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
+        bsric02Info_t info, int *pBufferSizeInBytes)
+    cusparseStatus_t cusparseSbsric02_bufferSizeExt(
+        cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
+        const cusparseMatDescr_t descrA, float *bsrSortedVal,
+        const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockSize,
+        bsric02Info_t info, size_t *pBufferSize)
+    cusparseStatus_t cusparseDbsric02_bufferSizeExt(
+        cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
+        const cusparseMatDescr_t descrA, double *bsrSortedVal,
+        const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockSize,
+        bsric02Info_t info, size_t *pBufferSize)
+    cusparseStatus_t cusparseCbsric02_bufferSizeExt(
+        cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
+        const cusparseMatDescr_t descrA, cuComplex *bsrSortedVal,
+        const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockSize,
+        bsric02Info_t info, size_t *pBufferSize)
+    cusparseStatus_t cusparseZbsric02_bufferSizeExt(
+        cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
+        const cusparseMatDescr_t descrA, cuDoubleComplex *bsrSortedVal,
+        const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockSize,
+        bsric02Info_t info, size_t *pBufferSize)
+    cusparseStatus_t cusparseSbsric02_analysis(
+        cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
+        const cusparseMatDescr_t descrA, const float *bsrSortedVal,
+        const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
+        bsric02Info_t info, cusparseSolvePolicy_t policy, void *pInputBuffer)
+    cusparseStatus_t cusparseDbsric02_analysis(
+        cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
+        const cusparseMatDescr_t descrA, const double *bsrSortedVal,
+        const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
+        bsric02Info_t info, cusparseSolvePolicy_t policy, void *pInputBuffer)
+    cusparseStatus_t cusparseCbsric02_analysis(
+        cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
+        const cusparseMatDescr_t descrA, const cuComplex *bsrSortedVal,
+        const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
+        bsric02Info_t info, cusparseSolvePolicy_t policy, void *pInputBuffer)
+    cusparseStatus_t cusparseZbsric02_analysis(
+        cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
+        const cusparseMatDescr_t descrA, const cuDoubleComplex *bsrSortedVal,
+        const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
+        bsric02Info_t info, cusparseSolvePolicy_t policy, void *pInputBuffer)
+    cusparseStatus_t cusparseSbsric02(
+        cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
+        const cusparseMatDescr_t descrA, float *bsrSortedVal,
+        const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
+        bsric02Info_t info, cusparseSolvePolicy_t policy, void *pBuffer)
+    cusparseStatus_t cusparseDbsric02(
+        cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
+        const cusparseMatDescr_t descrA, double *bsrSortedVal,
+        const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
+        bsric02Info_t info, cusparseSolvePolicy_t policy, void *pBuffer)
+    cusparseStatus_t cusparseCbsric02(
+        cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
+        const cusparseMatDescr_t descrA, cuComplex *bsrSortedVal,
+        const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
+        bsric02Info_t info, cusparseSolvePolicy_t policy, void *pBuffer)
+    cusparseStatus_t cusparseZbsric02(
+        cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
+        const cusparseMatDescr_t descrA, cuDoubleComplex *bsrSortedVal,
+        const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
+        bsric02Info_t info, cusparseSolvePolicy_t policy, void *pBuffer)
+    cusparseStatus_t cusparseSgtsv2_bufferSizeExt(
+        cusparseHandle_t handle, int m, int n, const float *dl, const float *d,
+        const float *du, const float *B, int ldb, size_t *bufferSizeInBytes)
+    cusparseStatus_t cusparseDgtsv2_bufferSizeExt(
+        cusparseHandle_t handle, int m, int n, const double *dl,
+        const double *d, const double *du, const double *B, int ldb,
+        size_t *bufferSizeInBytes)
+    cusparseStatus_t cusparseCgtsv2_bufferSizeExt(
+        cusparseHandle_t handle, int m, int n, const cuComplex *dl,
+        const cuComplex *d, const cuComplex *du, const cuComplex *B, int ldb,
+        size_t *bufferSizeInBytes)
+    cusparseStatus_t cusparseZgtsv2_bufferSizeExt(
+        cusparseHandle_t handle, int m, int n, const cuDoubleComplex *dl,
+        const cuDoubleComplex *d, const cuDoubleComplex *du,
+        const cuDoubleComplex *B, int ldb, size_t *bufferSizeInBytes)
+    cusparseStatus_t cusparseSgtsv2(
+        cusparseHandle_t handle, int m, int n, const float *dl, const float *d,
+        const float *du, float *B, int ldb, void *pBuffer)
+    cusparseStatus_t cusparseDgtsv2(
+        cusparseHandle_t handle, int m, int n, const double *dl,
+        const double *d, const double *du, double *B, int ldb, void *pBuffer)
+    cusparseStatus_t cusparseCgtsv2(cusparseHandle_t handle, int m, int n,
+                                    const cuComplex *dl, const cuComplex *d,
+                                    const cuComplex *du, cuComplex *B, int ldb,
+                                    void *pBuffer)
+    cusparseStatus_t cusparseZgtsv2(
+        cusparseHandle_t handle, int m, int n, const cuDoubleComplex *dl,
+        const cuDoubleComplex *d, const cuDoubleComplex *du,
+        cuDoubleComplex *B, int ldb, void *pBuffer)
+    cusparseStatus_t cusparseSgtsv2_nopivot_bufferSizeExt(
+        cusparseHandle_t handle, int m, int n, const float *dl, const float *d,
+        const float *du, const float *B, int ldb, size_t *bufferSizeInBytes)
+    cusparseStatus_t cusparseDgtsv2_nopivot_bufferSizeExt(
+        cusparseHandle_t handle, int m, int n, const double *dl,
+        const double *d, const double *du, const double *B, int ldb,
+        size_t *bufferSizeInBytes)
+    cusparseStatus_t cusparseCgtsv2_nopivot_bufferSizeExt(
+        cusparseHandle_t handle, int m, int n, const cuComplex *dl,
+        const cuComplex *d, const cuComplex *du, const cuComplex *B, int ldb,
+        size_t *bufferSizeInBytes)
+    cusparseStatus_t cusparseZgtsv2_nopivot_bufferSizeExt(
+        cusparseHandle_t handle, int m, int n, const cuDoubleComplex *dl,
+        const cuDoubleComplex *d, const cuDoubleComplex *du,
+        const cuDoubleComplex *B, int ldb, size_t *bufferSizeInBytes)
+    cusparseStatus_t cusparseSgtsv2_nopivot(
+        cusparseHandle_t handle, int m, int n, const float *dl, const float *d,
+        const float *du, float *B, int ldb, void *pBuffer)
+    cusparseStatus_t cusparseDgtsv2_nopivot(
+        cusparseHandle_t handle, int m, int n, const double *dl,
+        const double *d, const double *du, double *B, int ldb, void *pBuffer)
+    cusparseStatus_t cusparseCgtsv2_nopivot(
+        cusparseHandle_t handle, int m, int n, const cuComplex *dl,
+        const cuComplex *d, const cuComplex *du, cuComplex *B, int ldb,
+        void *pBuffer)
+    cusparseStatus_t cusparseZgtsv2_nopivot(
+        cusparseHandle_t handle, int m, int n, const cuDoubleComplex *dl,
+        const cuDoubleComplex *d, const cuDoubleComplex *du,
+        cuDoubleComplex *B, int ldb, void *pBuffer)
+    cusparseStatus_t cusparseSgtsv2StridedBatch_bufferSizeExt(
+        cusparseHandle_t handle, int m, const float *dl, const float *d,
+        const float *du, const float *x, int batchCount, int batchStride,
+        size_t *bufferSizeInBytes)
+    cusparseStatus_t cusparseDgtsv2StridedBatch_bufferSizeExt(
+        cusparseHandle_t handle, int m, const double *dl, const double *d,
+        const double *du, const double *x, int batchCount, int batchStride,
+        size_t *bufferSizeInBytes)
+    cusparseStatus_t cusparseCgtsv2StridedBatch_bufferSizeExt(
+        cusparseHandle_t handle, int m, const cuComplex *dl,
+        const cuComplex *d, const cuComplex *du, const cuComplex *x,
+        int batchCount, int batchStride, size_t *bufferSizeInBytes)
+    cusparseStatus_t cusparseZgtsv2StridedBatch_bufferSizeExt(
+        cusparseHandle_t handle, int m, const cuDoubleComplex *dl,
+        const cuDoubleComplex *d, const cuDoubleComplex *du,
+        const cuDoubleComplex *x, int batchCount, int batchStride,
+        size_t *bufferSizeInBytes)
+    cusparseStatus_t cusparseSgtsv2StridedBatch(
+        cusparseHandle_t handle, int m, const float *dl, const float *d,
+        const float *du, float *x, int batchCount, int batchStride,
+        void *pBuffer)
+    cusparseStatus_t cusparseDgtsv2StridedBatch(
+        cusparseHandle_t handle, int m, const double *dl, const double *d,
+        const double *du, double *x, int batchCount, int batchStride,
+        void *pBuffer)
+    cusparseStatus_t cusparseCgtsv2StridedBatch(
+        cusparseHandle_t handle, int m, const cuComplex *dl,
+        const cuComplex *d, const cuComplex *du, cuComplex *x, int batchCount,
+        int batchStride, void *pBuffer)
+    cusparseStatus_t cusparseZgtsv2StridedBatch(
+        cusparseHandle_t handle, int m, const cuDoubleComplex *dl,
+        const cuDoubleComplex *d, const cuDoubleComplex *du,
+        cuDoubleComplex *x, int batchCount, int batchStride, void *pBuffer)
+    cusparseStatus_t cusparseSgtsvInterleavedBatch_bufferSizeExt(
+        cusparseHandle_t handle, int algo, int m, const float *dl,
+        const float *d, const float *du, const float *x, int batchCount,
+        size_t *pBufferSizeInBytes)
+    cusparseStatus_t cusparseDgtsvInterleavedBatch_bufferSizeExt(
+        cusparseHandle_t handle, int algo, int m, const double *dl,
+        const double *d, const double *du, const double *x, int batchCount,
+        size_t *pBufferSizeInBytes)
+    cusparseStatus_t cusparseCgtsvInterleavedBatch_bufferSizeExt(
+        cusparseHandle_t handle, int algo, int m, const cuComplex *dl,
+        const cuComplex *d, const cuComplex *du, const cuComplex *x,
+        int batchCount, size_t *pBufferSizeInBytes)
+    cusparseStatus_t cusparseZgtsvInterleavedBatch_bufferSizeExt(
+        cusparseHandle_t handle, int algo, int m, const cuDoubleComplex *dl,
+        const cuDoubleComplex *d, const cuDoubleComplex *du,
+        const cuDoubleComplex *x, int batchCount, size_t *pBufferSizeInBytes)
+    cusparseStatus_t cusparseSgtsvInterleavedBatch(
+        cusparseHandle_t handle, int algo, int m, float *dl, float *d,
+        float *du, float *x, int batchCount, void *pBuffer)
+    cusparseStatus_t cusparseDgtsvInterleavedBatch(
+        cusparseHandle_t handle, int algo, int m, double *dl, double *d,
+        double *du, double *x, int batchCount, void *pBuffer)
+    cusparseStatus_t cusparseCgtsvInterleavedBatch(
+        cusparseHandle_t handle, int algo, int m, cuComplex *dl, cuComplex *d,
+        cuComplex *du, cuComplex *x, int batchCount, void *pBuffer)
+    cusparseStatus_t cusparseZgtsvInterleavedBatch(
+        cusparseHandle_t handle, int algo, int m, cuDoubleComplex *dl,
+        cuDoubleComplex *d, cuDoubleComplex *du, cuDoubleComplex *x,
+        int batchCount, void *pBuffer)
+    cusparseStatus_t cusparseSgpsvInterleavedBatch_bufferSizeExt(
+        cusparseHandle_t handle, int algo, int m, const float *ds,
+        const float *dl, const float *d, const float *du, const float *dw,
+        const float *x, int batchCount, size_t *pBufferSizeInBytes)
+    cusparseStatus_t cusparseDgpsvInterleavedBatch_bufferSizeExt(
+        cusparseHandle_t handle, int algo, int m, const double *ds,
+        const double *dl, const double *d, const double *du, const double *dw,
+        const double *x, int batchCount, size_t *pBufferSizeInBytes)
+    cusparseStatus_t cusparseCgpsvInterleavedBatch_bufferSizeExt(
+        cusparseHandle_t handle, int algo, int m, const cuComplex *ds,
+        const cuComplex *dl, const cuComplex *d, const cuComplex *du,
+        const cuComplex *dw, const cuComplex *x, int batchCount,
+        size_t *pBufferSizeInBytes)
+    cusparseStatus_t cusparseZgpsvInterleavedBatch_bufferSizeExt(
+        cusparseHandle_t handle, int algo, int m, const cuDoubleComplex *ds,
+        const cuDoubleComplex *dl, const cuDoubleComplex *d,
+        const cuDoubleComplex *du, const cuDoubleComplex *dw,
+        const cuDoubleComplex *x, int batchCount, size_t *pBufferSizeInBytes)
+    cusparseStatus_t cusparseSgpsvInterleavedBatch(
+        cusparseHandle_t handle, int algo, int m, float *ds, float *dl,
+        float *d, float *du, float *dw, float *x, int batchCount,
+        void *pBuffer)
+    cusparseStatus_t cusparseDgpsvInterleavedBatch(
+        cusparseHandle_t handle, int algo, int m, double *ds, double *dl,
+        double *d, double *du, double *dw, double *x, int batchCount,
+        void *pBuffer)
+    cusparseStatus_t cusparseCgpsvInterleavedBatch(
+        cusparseHandle_t handle, int algo, int m, cuComplex *ds, cuComplex *dl,
+        cuComplex *d, cuComplex *du, cuComplex *dw, cuComplex *x,
+        int batchCount, void *pBuffer)
+    cusparseStatus_t cusparseZgpsvInterleavedBatch(
+        cusparseHandle_t handle, int algo, int m, cuDoubleComplex *ds,
+        cuDoubleComplex *dl, cuDoubleComplex *d, cuDoubleComplex *du,
+        cuDoubleComplex *dw, cuDoubleComplex *x, int batchCount, void *pBuffer)
+
 
 cdef dict STATUS = {
     0: 'CUSPARSE_STATUS_SUCCESS',
@@ -444,6 +960,7 @@ cdef dict STATUS = {
     7: 'CUSPARSE_STATUS_INTERNAL_ERROR',
     8: 'CUSPARSE_STATUS_MATRIX_TYPE_NOT_SUPPORTED',
     9: 'CUSPARSE_STATUS_ZERO_PIVOT',
+    10: 'CUSPARSE_STATUS_NOT_SUPPORTED',
 }
 
 
@@ -1433,4 +1950,1486 @@ cpdef xcscsort(
     status = cusparseXcscsort(
         <Handle>handle, m, n, nnz, <const MatDescr>descrA,
         <const int *>cscColPtr, <int *>cscRowInd, <int *>P, <void *>pBuffer)
+    check_status(status)
+
+########################################
+# cuSPARSE PRECONDITIONERS
+
+cpdef size_t createCsrilu02Info():
+    cdef csrilu02Info_t info
+    with nogil:
+        status = cusparseCreateCsrilu02Info(&info)
+    check_status(status)
+    return <size_t>info
+
+cpdef destroyCsrilu02Info(size_t info):
+    with nogil:
+        status = cusparseDestroyCsrilu02Info(<csrilu02Info_t>info)
+    check_status(status)
+
+cpdef size_t createBsrilu02Info():
+    cdef bsrilu02Info_t info
+    with nogil:
+        status = cusparseCreateBsrilu02Info(&info)
+    check_status(status)
+    return <size_t>info
+
+cpdef destroyBsrilu02Info(size_t info):
+    with nogil:
+        status = cusparseDestroyBsrilu02Info(<bsrilu02Info_t>info)
+    check_status(status)
+
+cpdef size_t createCsric02Info():
+    cdef csric02Info_t info
+    with nogil:
+        status = cusparseCreateCsric02Info(&info)
+    check_status(status)
+    return <size_t>info
+
+cpdef destroyCsric02Info(size_t info):
+    with nogil:
+        status = cusparseDestroyCsric02Info(<csric02Info_t>info)
+    check_status(status)
+
+cpdef size_t createBsric02Info():
+    cdef bsric02Info_t info
+    with nogil:
+        status = cusparseCreateBsric02Info(&info)
+    check_status(status)
+    return <size_t>info
+
+cpdef destroyBsric02Info(size_t info):
+    with nogil:
+        status = cusparseDestroyBsric02Info(<bsric02Info_t>info)
+    check_status(status)
+
+cpdef scsrilu02_numericBoost(size_t handle, size_t info, int enable_boost,
+                             size_t tol, size_t boost_val):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseScsrilu02_numericBoost(
+            <cusparseHandle_t>handle, <csrilu02Info_t>info, enable_boost,
+            <double*>tol, <float*>boost_val)
+    check_status(status)
+
+cpdef dcsrilu02_numericBoost(size_t handle, size_t info, int enable_boost,
+                             size_t tol, size_t boost_val):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseDcsrilu02_numericBoost(
+            <cusparseHandle_t>handle, <csrilu02Info_t>info, enable_boost,
+            <double*>tol, <double*>boost_val)
+    check_status(status)
+
+cpdef ccsrilu02_numericBoost(size_t handle, size_t info, int enable_boost,
+                             size_t tol, size_t boost_val):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseCcsrilu02_numericBoost(
+            <cusparseHandle_t>handle, <csrilu02Info_t>info, enable_boost,
+            <double*>tol, <cuComplex*>boost_val)
+    check_status(status)
+
+cpdef zcsrilu02_numericBoost(size_t handle, size_t info, int enable_boost,
+                             size_t tol, size_t boost_val):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseZcsrilu02_numericBoost(
+            <cusparseHandle_t>handle, <csrilu02Info_t>info, enable_boost,
+            <double*>tol, <cuDoubleComplex*>boost_val)
+    check_status(status)
+
+cpdef xcsrilu02_zeroPivot(size_t handle, size_t info, size_t position):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseXcsrilu02_zeroPivot(
+            <cusparseHandle_t>handle, <csrilu02Info_t>info, <int*>position)
+    check_status(status)
+
+cpdef int scsrilu02_bufferSize(size_t handle, int m, int nnz, size_t descrA,
+                               size_t csrSortedValA, size_t csrSortedRowPtrA,
+                               size_t csrSortedColIndA, size_t info):
+    cdef int pBufferSizeInBytes
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseScsrilu02_bufferSize(
+            <cusparseHandle_t>handle, m, nnz, <const cusparseMatDescr_t>descrA,
+            <float*>csrSortedValA, <const int*>csrSortedRowPtrA,
+            <const int*>csrSortedColIndA, <csrilu02Info_t>info,
+            &pBufferSizeInBytes)
+    check_status(status)
+    return <int>pBufferSizeInBytes
+
+cpdef int dcsrilu02_bufferSize(size_t handle, int m, int nnz, size_t descrA,
+                               size_t csrSortedValA, size_t csrSortedRowPtrA,
+                               size_t csrSortedColIndA, size_t info):
+    cdef int pBufferSizeInBytes
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseDcsrilu02_bufferSize(
+            <cusparseHandle_t>handle, m, nnz, <const cusparseMatDescr_t>descrA,
+            <double*>csrSortedValA, <const int*>csrSortedRowPtrA,
+            <const int*>csrSortedColIndA, <csrilu02Info_t>info,
+            &pBufferSizeInBytes)
+    check_status(status)
+    return <int>pBufferSizeInBytes
+
+cpdef int ccsrilu02_bufferSize(size_t handle, int m, int nnz, size_t descrA,
+                               size_t csrSortedValA, size_t csrSortedRowPtrA,
+                               size_t csrSortedColIndA, size_t info):
+    cdef int pBufferSizeInBytes
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseCcsrilu02_bufferSize(
+            <cusparseHandle_t>handle, m, nnz, <const cusparseMatDescr_t>descrA,
+            <cuComplex*>csrSortedValA, <const int*>csrSortedRowPtrA,
+            <const int*>csrSortedColIndA, <csrilu02Info_t>info,
+            &pBufferSizeInBytes)
+    check_status(status)
+    return <int>pBufferSizeInBytes
+
+cpdef int zcsrilu02_bufferSize(size_t handle, int m, int nnz, size_t descrA,
+                               size_t csrSortedValA, size_t csrSortedRowPtrA,
+                               size_t csrSortedColIndA, size_t info):
+    cdef int pBufferSizeInBytes
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseZcsrilu02_bufferSize(
+            <cusparseHandle_t>handle, m, nnz, <const cusparseMatDescr_t>descrA,
+            <cuDoubleComplex*>csrSortedValA, <const int*>csrSortedRowPtrA,
+            <const int*>csrSortedColIndA, <csrilu02Info_t>info,
+            &pBufferSizeInBytes)
+    check_status(status)
+    return <int>pBufferSizeInBytes
+
+cpdef size_t scsrilu02_bufferSizeExt(
+        size_t handle, int m, int nnz, size_t descrA, size_t csrSortedVal,
+        size_t csrSortedRowPtr, size_t csrSortedColInd, size_t info):
+    cdef size_t pBufferSize
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseScsrilu02_bufferSizeExt(
+            <cusparseHandle_t>handle, m, nnz, <const cusparseMatDescr_t>descrA,
+            <float*>csrSortedVal, <const int*>csrSortedRowPtr,
+            <const int*>csrSortedColInd, <csrilu02Info_t>info, &pBufferSize)
+    check_status(status)
+    return <size_t>pBufferSize
+
+cpdef size_t dcsrilu02_bufferSizeExt(
+        size_t handle, int m, int nnz, size_t descrA, size_t csrSortedVal,
+        size_t csrSortedRowPtr, size_t csrSortedColInd, size_t info):
+    cdef size_t pBufferSize
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseDcsrilu02_bufferSizeExt(
+            <cusparseHandle_t>handle, m, nnz, <const cusparseMatDescr_t>descrA,
+            <double*>csrSortedVal, <const int*>csrSortedRowPtr,
+            <const int*>csrSortedColInd, <csrilu02Info_t>info, &pBufferSize)
+    check_status(status)
+    return <size_t>pBufferSize
+
+cpdef size_t ccsrilu02_bufferSizeExt(
+        size_t handle, int m, int nnz, size_t descrA, size_t csrSortedVal,
+        size_t csrSortedRowPtr, size_t csrSortedColInd, size_t info):
+    cdef size_t pBufferSize
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseCcsrilu02_bufferSizeExt(
+            <cusparseHandle_t>handle, m, nnz, <const cusparseMatDescr_t>descrA,
+            <cuComplex*>csrSortedVal, <const int*>csrSortedRowPtr,
+            <const int*>csrSortedColInd, <csrilu02Info_t>info, &pBufferSize)
+    check_status(status)
+    return <size_t>pBufferSize
+
+cpdef size_t zcsrilu02_bufferSizeExt(
+        size_t handle, int m, int nnz, size_t descrA, size_t csrSortedVal,
+        size_t csrSortedRowPtr, size_t csrSortedColInd, size_t info):
+    cdef size_t pBufferSize
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseZcsrilu02_bufferSizeExt(
+            <cusparseHandle_t>handle, m, nnz, <const cusparseMatDescr_t>descrA,
+            <cuDoubleComplex*>csrSortedVal, <const int*>csrSortedRowPtr,
+            <const int*>csrSortedColInd, <csrilu02Info_t>info, &pBufferSize)
+    check_status(status)
+    return <size_t>pBufferSize
+
+cpdef scsrilu02_analysis(size_t handle, int m, int nnz, size_t descrA,
+                         size_t csrSortedValA, size_t csrSortedRowPtrA,
+                         size_t csrSortedColIndA, size_t info, int policy,
+                         size_t pBuffer):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseScsrilu02_analysis(
+            <cusparseHandle_t>handle, m, nnz, <const cusparseMatDescr_t>descrA,
+            <const float*>csrSortedValA, <const int*>csrSortedRowPtrA,
+            <const int*>csrSortedColIndA, <csrilu02Info_t>info,
+            <cusparseSolvePolicy_t>policy, <void*>pBuffer)
+    check_status(status)
+
+cpdef dcsrilu02_analysis(size_t handle, int m, int nnz, size_t descrA,
+                         size_t csrSortedValA, size_t csrSortedRowPtrA,
+                         size_t csrSortedColIndA, size_t info, int policy,
+                         size_t pBuffer):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseDcsrilu02_analysis(
+            <cusparseHandle_t>handle, m, nnz, <const cusparseMatDescr_t>descrA,
+            <const double*>csrSortedValA, <const int*>csrSortedRowPtrA,
+            <const int*>csrSortedColIndA, <csrilu02Info_t>info,
+            <cusparseSolvePolicy_t>policy, <void*>pBuffer)
+    check_status(status)
+
+cpdef ccsrilu02_analysis(size_t handle, int m, int nnz, size_t descrA,
+                         size_t csrSortedValA, size_t csrSortedRowPtrA,
+                         size_t csrSortedColIndA, size_t info, int policy,
+                         size_t pBuffer):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseCcsrilu02_analysis(
+            <cusparseHandle_t>handle, m, nnz, <const cusparseMatDescr_t>descrA,
+            <const cuComplex*>csrSortedValA, <const int*>csrSortedRowPtrA,
+            <const int*>csrSortedColIndA, <csrilu02Info_t>info,
+            <cusparseSolvePolicy_t>policy, <void*>pBuffer)
+    check_status(status)
+
+cpdef zcsrilu02_analysis(size_t handle, int m, int nnz, size_t descrA,
+                         size_t csrSortedValA, size_t csrSortedRowPtrA,
+                         size_t csrSortedColIndA, size_t info, int policy,
+                         size_t pBuffer):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseZcsrilu02_analysis(
+            <cusparseHandle_t>handle, m, nnz, <const cusparseMatDescr_t>descrA,
+            <const cuDoubleComplex*>csrSortedValA,
+            <const int*>csrSortedRowPtrA, <const int*>csrSortedColIndA,
+            <csrilu02Info_t>info, <cusparseSolvePolicy_t>policy,
+            <void*>pBuffer)
+    check_status(status)
+
+cpdef scsrilu02(size_t handle, int m, int nnz, size_t descrA,
+                size_t csrSortedValA_valM, size_t csrSortedRowPtrA,
+                size_t csrSortedColIndA, size_t info, int policy,
+                size_t pBuffer):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseScsrilu02(
+            <cusparseHandle_t>handle, m, nnz, <const cusparseMatDescr_t>descrA,
+            <float*>csrSortedValA_valM, <const int*>csrSortedRowPtrA,
+            <const int*>csrSortedColIndA, <csrilu02Info_t>info,
+            <cusparseSolvePolicy_t>policy, <void*>pBuffer)
+    check_status(status)
+
+cpdef dcsrilu02(size_t handle, int m, int nnz, size_t descrA,
+                size_t csrSortedValA_valM, size_t csrSortedRowPtrA,
+                size_t csrSortedColIndA, size_t info, int policy,
+                size_t pBuffer):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseDcsrilu02(
+            <cusparseHandle_t>handle, m, nnz, <const cusparseMatDescr_t>descrA,
+            <double*>csrSortedValA_valM, <const int*>csrSortedRowPtrA,
+            <const int*>csrSortedColIndA, <csrilu02Info_t>info,
+            <cusparseSolvePolicy_t>policy, <void*>pBuffer)
+    check_status(status)
+
+cpdef ccsrilu02(size_t handle, int m, int nnz, size_t descrA,
+                size_t csrSortedValA_valM, size_t csrSortedRowPtrA,
+                size_t csrSortedColIndA, size_t info, int policy,
+                size_t pBuffer):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseCcsrilu02(
+            <cusparseHandle_t>handle, m, nnz, <const cusparseMatDescr_t>descrA,
+            <cuComplex*>csrSortedValA_valM, <const int*>csrSortedRowPtrA,
+            <const int*>csrSortedColIndA, <csrilu02Info_t>info,
+            <cusparseSolvePolicy_t>policy, <void*>pBuffer)
+    check_status(status)
+
+cpdef zcsrilu02(size_t handle, int m, int nnz, size_t descrA,
+                size_t csrSortedValA_valM, size_t csrSortedRowPtrA,
+                size_t csrSortedColIndA, size_t info, int policy,
+                size_t pBuffer):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseZcsrilu02(
+            <cusparseHandle_t>handle, m, nnz, <const cusparseMatDescr_t>descrA,
+            <cuDoubleComplex*>csrSortedValA_valM, <const int*>csrSortedRowPtrA,
+            <const int*>csrSortedColIndA, <csrilu02Info_t>info,
+            <cusparseSolvePolicy_t>policy, <void*>pBuffer)
+    check_status(status)
+
+cpdef sbsrilu02_numericBoost(size_t handle, size_t info, int enable_boost,
+                             size_t tol, size_t boost_val):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseSbsrilu02_numericBoost(
+            <cusparseHandle_t>handle, <bsrilu02Info_t>info, enable_boost,
+            <double*>tol, <float*>boost_val)
+    check_status(status)
+
+cpdef dbsrilu02_numericBoost(size_t handle, size_t info, int enable_boost,
+                             size_t tol, size_t boost_val):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseDbsrilu02_numericBoost(
+            <cusparseHandle_t>handle, <bsrilu02Info_t>info, enable_boost,
+            <double*>tol, <double*>boost_val)
+    check_status(status)
+
+cpdef cbsrilu02_numericBoost(size_t handle, size_t info, int enable_boost,
+                             size_t tol, size_t boost_val):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseCbsrilu02_numericBoost(
+            <cusparseHandle_t>handle, <bsrilu02Info_t>info, enable_boost,
+            <double*>tol, <cuComplex*>boost_val)
+    check_status(status)
+
+cpdef zbsrilu02_numericBoost(size_t handle, size_t info, int enable_boost,
+                             size_t tol, size_t boost_val):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseZbsrilu02_numericBoost(
+            <cusparseHandle_t>handle, <bsrilu02Info_t>info, enable_boost,
+            <double*>tol, <cuDoubleComplex*>boost_val)
+    check_status(status)
+
+cpdef xbsrilu02_zeroPivot(size_t handle, size_t info, size_t position):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseXbsrilu02_zeroPivot(
+            <cusparseHandle_t>handle, <bsrilu02Info_t>info, <int*>position)
+    check_status(status)
+
+cpdef int sbsrilu02_bufferSize(size_t handle, int dirA, int mb, int nnzb,
+                               size_t descrA, size_t bsrSortedVal,
+                               size_t bsrSortedRowPtr, size_t bsrSortedColInd,
+                               int blockDim, size_t info):
+    cdef int pBufferSizeInBytes
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseSbsrilu02_bufferSize(
+            <cusparseHandle_t>handle, <cusparseDirection_t>dirA, mb, nnzb,
+            <const cusparseMatDescr_t>descrA, <float*>bsrSortedVal,
+            <const int*>bsrSortedRowPtr, <const int*>bsrSortedColInd, blockDim,
+            <bsrilu02Info_t>info, &pBufferSizeInBytes)
+    check_status(status)
+    return <int>pBufferSizeInBytes
+
+cpdef int dbsrilu02_bufferSize(size_t handle, int dirA, int mb, int nnzb,
+                               size_t descrA, size_t bsrSortedVal,
+                               size_t bsrSortedRowPtr, size_t bsrSortedColInd,
+                               int blockDim, size_t info):
+    cdef int pBufferSizeInBytes
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseDbsrilu02_bufferSize(
+            <cusparseHandle_t>handle, <cusparseDirection_t>dirA, mb, nnzb,
+            <const cusparseMatDescr_t>descrA, <double*>bsrSortedVal,
+            <const int*>bsrSortedRowPtr, <const int*>bsrSortedColInd, blockDim,
+            <bsrilu02Info_t>info, &pBufferSizeInBytes)
+    check_status(status)
+    return <int>pBufferSizeInBytes
+
+cpdef int cbsrilu02_bufferSize(size_t handle, int dirA, int mb, int nnzb,
+                               size_t descrA, size_t bsrSortedVal,
+                               size_t bsrSortedRowPtr, size_t bsrSortedColInd,
+                               int blockDim, size_t info):
+    cdef int pBufferSizeInBytes
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseCbsrilu02_bufferSize(
+            <cusparseHandle_t>handle, <cusparseDirection_t>dirA, mb, nnzb,
+            <const cusparseMatDescr_t>descrA, <cuComplex*>bsrSortedVal,
+            <const int*>bsrSortedRowPtr, <const int*>bsrSortedColInd, blockDim,
+            <bsrilu02Info_t>info, &pBufferSizeInBytes)
+    check_status(status)
+    return <int>pBufferSizeInBytes
+
+cpdef int zbsrilu02_bufferSize(size_t handle, int dirA, int mb, int nnzb,
+                               size_t descrA, size_t bsrSortedVal,
+                               size_t bsrSortedRowPtr, size_t bsrSortedColInd,
+                               int blockDim, size_t info):
+    cdef int pBufferSizeInBytes
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseZbsrilu02_bufferSize(
+            <cusparseHandle_t>handle, <cusparseDirection_t>dirA, mb, nnzb,
+            <const cusparseMatDescr_t>descrA, <cuDoubleComplex*>bsrSortedVal,
+            <const int*>bsrSortedRowPtr, <const int*>bsrSortedColInd, blockDim,
+            <bsrilu02Info_t>info, &pBufferSizeInBytes)
+    check_status(status)
+    return <int>pBufferSizeInBytes
+
+cpdef size_t sbsrilu02_bufferSizeExt(
+        size_t handle, int dirA, int mb, int nnzb, size_t descrA,
+        size_t bsrSortedVal, size_t bsrSortedRowPtr, size_t bsrSortedColInd,
+        int blockSize, size_t info):
+    cdef size_t pBufferSize
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseSbsrilu02_bufferSizeExt(
+            <cusparseHandle_t>handle, <cusparseDirection_t>dirA, mb, nnzb,
+            <const cusparseMatDescr_t>descrA, <float*>bsrSortedVal,
+            <const int*>bsrSortedRowPtr, <const int*>bsrSortedColInd,
+            blockSize, <bsrilu02Info_t>info, &pBufferSize)
+    check_status(status)
+    return <size_t>pBufferSize
+
+cpdef size_t dbsrilu02_bufferSizeExt(
+        size_t handle, int dirA, int mb, int nnzb, size_t descrA,
+        size_t bsrSortedVal, size_t bsrSortedRowPtr, size_t bsrSortedColInd,
+        int blockSize, size_t info):
+    cdef size_t pBufferSize
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseDbsrilu02_bufferSizeExt(
+            <cusparseHandle_t>handle, <cusparseDirection_t>dirA, mb, nnzb,
+            <const cusparseMatDescr_t>descrA, <double*>bsrSortedVal,
+            <const int*>bsrSortedRowPtr, <const int*>bsrSortedColInd,
+            blockSize, <bsrilu02Info_t>info, &pBufferSize)
+    check_status(status)
+    return <size_t>pBufferSize
+
+cpdef size_t cbsrilu02_bufferSizeExt(
+        size_t handle, int dirA, int mb, int nnzb, size_t descrA,
+        size_t bsrSortedVal, size_t bsrSortedRowPtr, size_t bsrSortedColInd,
+        int blockSize, size_t info):
+    cdef size_t pBufferSize
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseCbsrilu02_bufferSizeExt(
+            <cusparseHandle_t>handle, <cusparseDirection_t>dirA, mb, nnzb,
+            <const cusparseMatDescr_t>descrA, <cuComplex*>bsrSortedVal,
+            <const int*>bsrSortedRowPtr, <const int*>bsrSortedColInd,
+            blockSize, <bsrilu02Info_t>info, &pBufferSize)
+    check_status(status)
+    return <size_t>pBufferSize
+
+cpdef size_t zbsrilu02_bufferSizeExt(
+        size_t handle, int dirA, int mb, int nnzb, size_t descrA,
+        size_t bsrSortedVal, size_t bsrSortedRowPtr, size_t bsrSortedColInd,
+        int blockSize, size_t info):
+    cdef size_t pBufferSize
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseZbsrilu02_bufferSizeExt(
+            <cusparseHandle_t>handle, <cusparseDirection_t>dirA, mb, nnzb,
+            <const cusparseMatDescr_t>descrA, <cuDoubleComplex*>bsrSortedVal,
+            <const int*>bsrSortedRowPtr, <const int*>bsrSortedColInd,
+            blockSize, <bsrilu02Info_t>info, &pBufferSize)
+    check_status(status)
+    return <size_t>pBufferSize
+
+cpdef sbsrilu02_analysis(
+        size_t handle, int dirA, int mb, int nnzb, size_t descrA,
+        size_t bsrSortedVal, size_t bsrSortedRowPtr, size_t bsrSortedColInd,
+        int blockDim, size_t info, int policy, size_t pBuffer):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseSbsrilu02_analysis(
+            <cusparseHandle_t>handle, <cusparseDirection_t>dirA, mb, nnzb,
+            <const cusparseMatDescr_t>descrA, <float*>bsrSortedVal,
+            <const int*>bsrSortedRowPtr, <const int*>bsrSortedColInd, blockDim,
+            <bsrilu02Info_t>info, <cusparseSolvePolicy_t>policy,
+            <void*>pBuffer)
+    check_status(status)
+
+cpdef dbsrilu02_analysis(
+        size_t handle, int dirA, int mb, int nnzb, size_t descrA,
+        size_t bsrSortedVal, size_t bsrSortedRowPtr, size_t bsrSortedColInd,
+        int blockDim, size_t info, int policy, size_t pBuffer):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseDbsrilu02_analysis(
+            <cusparseHandle_t>handle, <cusparseDirection_t>dirA, mb, nnzb,
+            <const cusparseMatDescr_t>descrA, <double*>bsrSortedVal,
+            <const int*>bsrSortedRowPtr, <const int*>bsrSortedColInd, blockDim,
+            <bsrilu02Info_t>info, <cusparseSolvePolicy_t>policy,
+            <void*>pBuffer)
+    check_status(status)
+
+cpdef cbsrilu02_analysis(
+        size_t handle, int dirA, int mb, int nnzb, size_t descrA,
+        size_t bsrSortedVal, size_t bsrSortedRowPtr, size_t bsrSortedColInd,
+        int blockDim, size_t info, int policy, size_t pBuffer):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseCbsrilu02_analysis(
+            <cusparseHandle_t>handle, <cusparseDirection_t>dirA, mb, nnzb,
+            <const cusparseMatDescr_t>descrA, <cuComplex*>bsrSortedVal,
+            <const int*>bsrSortedRowPtr, <const int*>bsrSortedColInd, blockDim,
+            <bsrilu02Info_t>info, <cusparseSolvePolicy_t>policy,
+            <void*>pBuffer)
+    check_status(status)
+
+cpdef zbsrilu02_analysis(
+        size_t handle, int dirA, int mb, int nnzb, size_t descrA,
+        size_t bsrSortedVal, size_t bsrSortedRowPtr, size_t bsrSortedColInd,
+        int blockDim, size_t info, int policy, size_t pBuffer):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseZbsrilu02_analysis(
+            <cusparseHandle_t>handle, <cusparseDirection_t>dirA, mb, nnzb,
+            <const cusparseMatDescr_t>descrA, <cuDoubleComplex*>bsrSortedVal,
+            <const int*>bsrSortedRowPtr, <const int*>bsrSortedColInd, blockDim,
+            <bsrilu02Info_t>info, <cusparseSolvePolicy_t>policy,
+            <void*>pBuffer)
+    check_status(status)
+
+cpdef sbsrilu02(size_t handle, int dirA, int mb, int nnzb, size_t descrA,
+                size_t bsrSortedVal, size_t bsrSortedRowPtr,
+                size_t bsrSortedColInd, int blockDim, size_t info, int policy,
+                size_t pBuffer):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseSbsrilu02(
+            <cusparseHandle_t>handle, <cusparseDirection_t>dirA, mb, nnzb,
+            <const cusparseMatDescr_t>descrA, <float*>bsrSortedVal,
+            <const int*>bsrSortedRowPtr, <const int*>bsrSortedColInd, blockDim,
+            <bsrilu02Info_t>info, <cusparseSolvePolicy_t>policy,
+            <void*>pBuffer)
+    check_status(status)
+
+cpdef dbsrilu02(size_t handle, int dirA, int mb, int nnzb, size_t descrA,
+                size_t bsrSortedVal, size_t bsrSortedRowPtr,
+                size_t bsrSortedColInd, int blockDim, size_t info, int policy,
+                size_t pBuffer):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseDbsrilu02(
+            <cusparseHandle_t>handle, <cusparseDirection_t>dirA, mb, nnzb,
+            <const cusparseMatDescr_t>descrA, <double*>bsrSortedVal,
+            <const int*>bsrSortedRowPtr, <const int*>bsrSortedColInd, blockDim,
+            <bsrilu02Info_t>info, <cusparseSolvePolicy_t>policy,
+            <void*>pBuffer)
+    check_status(status)
+
+cpdef cbsrilu02(size_t handle, int dirA, int mb, int nnzb, size_t descrA,
+                size_t bsrSortedVal, size_t bsrSortedRowPtr,
+                size_t bsrSortedColInd, int blockDim, size_t info, int policy,
+                size_t pBuffer):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseCbsrilu02(
+            <cusparseHandle_t>handle, <cusparseDirection_t>dirA, mb, nnzb,
+            <const cusparseMatDescr_t>descrA, <cuComplex*>bsrSortedVal,
+            <const int*>bsrSortedRowPtr, <const int*>bsrSortedColInd, blockDim,
+            <bsrilu02Info_t>info, <cusparseSolvePolicy_t>policy,
+            <void*>pBuffer)
+    check_status(status)
+
+cpdef zbsrilu02(size_t handle, int dirA, int mb, int nnzb, size_t descrA,
+                size_t bsrSortedVal, size_t bsrSortedRowPtr,
+                size_t bsrSortedColInd, int blockDim, size_t info, int policy,
+                size_t pBuffer):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseZbsrilu02(
+            <cusparseHandle_t>handle, <cusparseDirection_t>dirA, mb, nnzb,
+            <const cusparseMatDescr_t>descrA, <cuDoubleComplex*>bsrSortedVal,
+            <const int*>bsrSortedRowPtr, <const int*>bsrSortedColInd, blockDim,
+            <bsrilu02Info_t>info, <cusparseSolvePolicy_t>policy,
+            <void*>pBuffer)
+    check_status(status)
+
+cpdef xcsric02_zeroPivot(size_t handle, size_t info, size_t position):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseXcsric02_zeroPivot(
+            <cusparseHandle_t>handle, <csric02Info_t>info, <int*>position)
+    check_status(status)
+
+cpdef int scsric02_bufferSize(size_t handle, int m, int nnz, size_t descrA,
+                              size_t csrSortedValA, size_t csrSortedRowPtrA,
+                              size_t csrSortedColIndA, size_t info):
+    cdef int pBufferSizeInBytes
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseScsric02_bufferSize(
+            <cusparseHandle_t>handle, m, nnz, <const cusparseMatDescr_t>descrA,
+            <float*>csrSortedValA, <const int*>csrSortedRowPtrA,
+            <const int*>csrSortedColIndA, <csric02Info_t>info,
+            &pBufferSizeInBytes)
+    check_status(status)
+    return <int>pBufferSizeInBytes
+
+cpdef int dcsric02_bufferSize(size_t handle, int m, int nnz, size_t descrA,
+                              size_t csrSortedValA, size_t csrSortedRowPtrA,
+                              size_t csrSortedColIndA, size_t info):
+    cdef int pBufferSizeInBytes
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseDcsric02_bufferSize(
+            <cusparseHandle_t>handle, m, nnz, <const cusparseMatDescr_t>descrA,
+            <double*>csrSortedValA, <const int*>csrSortedRowPtrA,
+            <const int*>csrSortedColIndA, <csric02Info_t>info,
+            &pBufferSizeInBytes)
+    check_status(status)
+    return <int>pBufferSizeInBytes
+
+cpdef int ccsric02_bufferSize(size_t handle, int m, int nnz, size_t descrA,
+                              size_t csrSortedValA, size_t csrSortedRowPtrA,
+                              size_t csrSortedColIndA, size_t info):
+    cdef int pBufferSizeInBytes
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseCcsric02_bufferSize(
+            <cusparseHandle_t>handle, m, nnz, <const cusparseMatDescr_t>descrA,
+            <cuComplex*>csrSortedValA, <const int*>csrSortedRowPtrA,
+            <const int*>csrSortedColIndA, <csric02Info_t>info,
+            &pBufferSizeInBytes)
+    check_status(status)
+    return <int>pBufferSizeInBytes
+
+cpdef int zcsric02_bufferSize(size_t handle, int m, int nnz, size_t descrA,
+                              size_t csrSortedValA, size_t csrSortedRowPtrA,
+                              size_t csrSortedColIndA, size_t info):
+    cdef int pBufferSizeInBytes
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseZcsric02_bufferSize(
+            <cusparseHandle_t>handle, m, nnz, <const cusparseMatDescr_t>descrA,
+            <cuDoubleComplex*>csrSortedValA, <const int*>csrSortedRowPtrA,
+            <const int*>csrSortedColIndA, <csric02Info_t>info,
+            &pBufferSizeInBytes)
+    check_status(status)
+    return <int>pBufferSizeInBytes
+
+cpdef size_t scsric02_bufferSizeExt(
+        size_t handle, int m, int nnz, size_t descrA, size_t csrSortedVal,
+        size_t csrSortedRowPtr, size_t csrSortedColInd, size_t info):
+    cdef size_t pBufferSize
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseScsric02_bufferSizeExt(
+            <cusparseHandle_t>handle, m, nnz, <const cusparseMatDescr_t>descrA,
+            <float*>csrSortedVal, <const int*>csrSortedRowPtr,
+            <const int*>csrSortedColInd, <csric02Info_t>info, &pBufferSize)
+    check_status(status)
+    return <size_t>pBufferSize
+
+cpdef size_t dcsric02_bufferSizeExt(
+        size_t handle, int m, int nnz, size_t descrA, size_t csrSortedVal,
+        size_t csrSortedRowPtr, size_t csrSortedColInd, size_t info):
+    cdef size_t pBufferSize
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseDcsric02_bufferSizeExt(
+            <cusparseHandle_t>handle, m, nnz, <const cusparseMatDescr_t>descrA,
+            <double*>csrSortedVal, <const int*>csrSortedRowPtr,
+            <const int*>csrSortedColInd, <csric02Info_t>info, &pBufferSize)
+    check_status(status)
+    return <size_t>pBufferSize
+
+cpdef size_t ccsric02_bufferSizeExt(
+        size_t handle, int m, int nnz, size_t descrA, size_t csrSortedVal,
+        size_t csrSortedRowPtr, size_t csrSortedColInd, size_t info):
+    cdef size_t pBufferSize
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseCcsric02_bufferSizeExt(
+            <cusparseHandle_t>handle, m, nnz, <const cusparseMatDescr_t>descrA,
+            <cuComplex*>csrSortedVal, <const int*>csrSortedRowPtr,
+            <const int*>csrSortedColInd, <csric02Info_t>info, &pBufferSize)
+    check_status(status)
+    return <size_t>pBufferSize
+
+cpdef size_t zcsric02_bufferSizeExt(
+        size_t handle, int m, int nnz, size_t descrA, size_t csrSortedVal,
+        size_t csrSortedRowPtr, size_t csrSortedColInd, size_t info):
+    cdef size_t pBufferSize
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseZcsric02_bufferSizeExt(
+            <cusparseHandle_t>handle, m, nnz, <const cusparseMatDescr_t>descrA,
+            <cuDoubleComplex*>csrSortedVal, <const int*>csrSortedRowPtr,
+            <const int*>csrSortedColInd, <csric02Info_t>info, &pBufferSize)
+    check_status(status)
+    return <size_t>pBufferSize
+
+cpdef scsric02_analysis(size_t handle, int m, int nnz, size_t descrA,
+                        size_t csrSortedValA, size_t csrSortedRowPtrA,
+                        size_t csrSortedColIndA, size_t info, int policy,
+                        size_t pBuffer):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseScsric02_analysis(
+            <cusparseHandle_t>handle, m, nnz, <const cusparseMatDescr_t>descrA,
+            <const float*>csrSortedValA, <const int*>csrSortedRowPtrA,
+            <const int*>csrSortedColIndA, <csric02Info_t>info,
+            <cusparseSolvePolicy_t>policy, <void*>pBuffer)
+    check_status(status)
+
+cpdef dcsric02_analysis(size_t handle, int m, int nnz, size_t descrA,
+                        size_t csrSortedValA, size_t csrSortedRowPtrA,
+                        size_t csrSortedColIndA, size_t info, int policy,
+                        size_t pBuffer):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseDcsric02_analysis(
+            <cusparseHandle_t>handle, m, nnz, <const cusparseMatDescr_t>descrA,
+            <const double*>csrSortedValA, <const int*>csrSortedRowPtrA,
+            <const int*>csrSortedColIndA, <csric02Info_t>info,
+            <cusparseSolvePolicy_t>policy, <void*>pBuffer)
+    check_status(status)
+
+cpdef ccsric02_analysis(size_t handle, int m, int nnz, size_t descrA,
+                        size_t csrSortedValA, size_t csrSortedRowPtrA,
+                        size_t csrSortedColIndA, size_t info, int policy,
+                        size_t pBuffer):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseCcsric02_analysis(
+            <cusparseHandle_t>handle, m, nnz, <const cusparseMatDescr_t>descrA,
+            <const cuComplex*>csrSortedValA, <const int*>csrSortedRowPtrA,
+            <const int*>csrSortedColIndA, <csric02Info_t>info,
+            <cusparseSolvePolicy_t>policy, <void*>pBuffer)
+    check_status(status)
+
+cpdef zcsric02_analysis(size_t handle, int m, int nnz, size_t descrA,
+                        size_t csrSortedValA, size_t csrSortedRowPtrA,
+                        size_t csrSortedColIndA, size_t info, int policy,
+                        size_t pBuffer):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseZcsric02_analysis(
+            <cusparseHandle_t>handle, m, nnz, <const cusparseMatDescr_t>descrA,
+            <const cuDoubleComplex*>csrSortedValA,
+            <const int*>csrSortedRowPtrA, <const int*>csrSortedColIndA,
+            <csric02Info_t>info, <cusparseSolvePolicy_t>policy, <void*>pBuffer)
+    check_status(status)
+
+cpdef scsric02(size_t handle, int m, int nnz, size_t descrA,
+               size_t csrSortedValA_valM, size_t csrSortedRowPtrA,
+               size_t csrSortedColIndA, size_t info, int policy,
+               size_t pBuffer):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseScsric02(
+            <cusparseHandle_t>handle, m, nnz, <const cusparseMatDescr_t>descrA,
+            <float*>csrSortedValA_valM, <const int*>csrSortedRowPtrA,
+            <const int*>csrSortedColIndA, <csric02Info_t>info,
+            <cusparseSolvePolicy_t>policy, <void*>pBuffer)
+    check_status(status)
+
+cpdef dcsric02(size_t handle, int m, int nnz, size_t descrA,
+               size_t csrSortedValA_valM, size_t csrSortedRowPtrA,
+               size_t csrSortedColIndA, size_t info, int policy,
+               size_t pBuffer):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseDcsric02(
+            <cusparseHandle_t>handle, m, nnz, <const cusparseMatDescr_t>descrA,
+            <double*>csrSortedValA_valM, <const int*>csrSortedRowPtrA,
+            <const int*>csrSortedColIndA, <csric02Info_t>info,
+            <cusparseSolvePolicy_t>policy, <void*>pBuffer)
+    check_status(status)
+
+cpdef ccsric02(size_t handle, int m, int nnz, size_t descrA,
+               size_t csrSortedValA_valM, size_t csrSortedRowPtrA,
+               size_t csrSortedColIndA, size_t info, int policy,
+               size_t pBuffer):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseCcsric02(
+            <cusparseHandle_t>handle, m, nnz, <const cusparseMatDescr_t>descrA,
+            <cuComplex*>csrSortedValA_valM, <const int*>csrSortedRowPtrA,
+            <const int*>csrSortedColIndA, <csric02Info_t>info,
+            <cusparseSolvePolicy_t>policy, <void*>pBuffer)
+    check_status(status)
+
+cpdef zcsric02(size_t handle, int m, int nnz, size_t descrA,
+               size_t csrSortedValA_valM, size_t csrSortedRowPtrA,
+               size_t csrSortedColIndA, size_t info, int policy,
+               size_t pBuffer):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseZcsric02(
+            <cusparseHandle_t>handle, m, nnz, <const cusparseMatDescr_t>descrA,
+            <cuDoubleComplex*>csrSortedValA_valM, <const int*>csrSortedRowPtrA,
+            <const int*>csrSortedColIndA, <csric02Info_t>info,
+            <cusparseSolvePolicy_t>policy, <void*>pBuffer)
+    check_status(status)
+
+cpdef xbsric02_zeroPivot(size_t handle, size_t info, size_t position):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseXbsric02_zeroPivot(
+            <cusparseHandle_t>handle, <bsric02Info_t>info, <int*>position)
+    check_status(status)
+
+cpdef int sbsric02_bufferSize(size_t handle, int dirA, int mb, int nnzb,
+                              size_t descrA, size_t bsrSortedVal,
+                              size_t bsrSortedRowPtr, size_t bsrSortedColInd,
+                              int blockDim, size_t info):
+    cdef int pBufferSizeInBytes
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseSbsric02_bufferSize(
+            <cusparseHandle_t>handle, <cusparseDirection_t>dirA, mb, nnzb,
+            <const cusparseMatDescr_t>descrA, <float*>bsrSortedVal,
+            <const int*>bsrSortedRowPtr, <const int*>bsrSortedColInd, blockDim,
+            <bsric02Info_t>info, &pBufferSizeInBytes)
+    check_status(status)
+    return <int>pBufferSizeInBytes
+
+cpdef int dbsric02_bufferSize(size_t handle, int dirA, int mb, int nnzb,
+                              size_t descrA, size_t bsrSortedVal,
+                              size_t bsrSortedRowPtr, size_t bsrSortedColInd,
+                              int blockDim, size_t info):
+    cdef int pBufferSizeInBytes
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseDbsric02_bufferSize(
+            <cusparseHandle_t>handle, <cusparseDirection_t>dirA, mb, nnzb,
+            <const cusparseMatDescr_t>descrA, <double*>bsrSortedVal,
+            <const int*>bsrSortedRowPtr, <const int*>bsrSortedColInd, blockDim,
+            <bsric02Info_t>info, &pBufferSizeInBytes)
+    check_status(status)
+    return <int>pBufferSizeInBytes
+
+cpdef int cbsric02_bufferSize(size_t handle, int dirA, int mb, int nnzb,
+                              size_t descrA, size_t bsrSortedVal,
+                              size_t bsrSortedRowPtr, size_t bsrSortedColInd,
+                              int blockDim, size_t info):
+    cdef int pBufferSizeInBytes
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseCbsric02_bufferSize(
+            <cusparseHandle_t>handle, <cusparseDirection_t>dirA, mb, nnzb,
+            <const cusparseMatDescr_t>descrA, <cuComplex*>bsrSortedVal,
+            <const int*>bsrSortedRowPtr, <const int*>bsrSortedColInd, blockDim,
+            <bsric02Info_t>info, &pBufferSizeInBytes)
+    check_status(status)
+    return <int>pBufferSizeInBytes
+
+cpdef int zbsric02_bufferSize(size_t handle, int dirA, int mb, int nnzb,
+                              size_t descrA, size_t bsrSortedVal,
+                              size_t bsrSortedRowPtr, size_t bsrSortedColInd,
+                              int blockDim, size_t info):
+    cdef int pBufferSizeInBytes
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseZbsric02_bufferSize(
+            <cusparseHandle_t>handle, <cusparseDirection_t>dirA, mb, nnzb,
+            <const cusparseMatDescr_t>descrA, <cuDoubleComplex*>bsrSortedVal,
+            <const int*>bsrSortedRowPtr, <const int*>bsrSortedColInd, blockDim,
+            <bsric02Info_t>info, &pBufferSizeInBytes)
+    check_status(status)
+    return <int>pBufferSizeInBytes
+
+cpdef size_t sbsric02_bufferSizeExt(
+        size_t handle, int dirA, int mb, int nnzb, size_t descrA,
+        size_t bsrSortedVal, size_t bsrSortedRowPtr, size_t bsrSortedColInd,
+        int blockSize, size_t info):
+    cdef size_t pBufferSize
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseSbsric02_bufferSizeExt(
+            <cusparseHandle_t>handle, <cusparseDirection_t>dirA, mb, nnzb,
+            <const cusparseMatDescr_t>descrA, <float*>bsrSortedVal,
+            <const int*>bsrSortedRowPtr, <const int*>bsrSortedColInd,
+            blockSize, <bsric02Info_t>info, &pBufferSize)
+    check_status(status)
+    return <size_t>pBufferSize
+
+cpdef size_t dbsric02_bufferSizeExt(
+        size_t handle, int dirA, int mb, int nnzb, size_t descrA,
+        size_t bsrSortedVal, size_t bsrSortedRowPtr, size_t bsrSortedColInd,
+        int blockSize, size_t info):
+    cdef size_t pBufferSize
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseDbsric02_bufferSizeExt(
+            <cusparseHandle_t>handle, <cusparseDirection_t>dirA, mb, nnzb,
+            <const cusparseMatDescr_t>descrA, <double*>bsrSortedVal,
+            <const int*>bsrSortedRowPtr, <const int*>bsrSortedColInd,
+            blockSize, <bsric02Info_t>info, &pBufferSize)
+    check_status(status)
+    return <size_t>pBufferSize
+
+cpdef size_t cbsric02_bufferSizeExt(
+        size_t handle, int dirA, int mb, int nnzb, size_t descrA,
+        size_t bsrSortedVal, size_t bsrSortedRowPtr, size_t bsrSortedColInd,
+        int blockSize, size_t info):
+    cdef size_t pBufferSize
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseCbsric02_bufferSizeExt(
+            <cusparseHandle_t>handle, <cusparseDirection_t>dirA, mb, nnzb,
+            <const cusparseMatDescr_t>descrA, <cuComplex*>bsrSortedVal,
+            <const int*>bsrSortedRowPtr, <const int*>bsrSortedColInd,
+            blockSize, <bsric02Info_t>info, &pBufferSize)
+    check_status(status)
+    return <size_t>pBufferSize
+
+cpdef size_t zbsric02_bufferSizeExt(
+        size_t handle, int dirA, int mb, int nnzb, size_t descrA,
+        size_t bsrSortedVal, size_t bsrSortedRowPtr, size_t bsrSortedColInd,
+        int blockSize, size_t info):
+    cdef size_t pBufferSize
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseZbsric02_bufferSizeExt(
+            <cusparseHandle_t>handle, <cusparseDirection_t>dirA, mb, nnzb,
+            <const cusparseMatDescr_t>descrA, <cuDoubleComplex*>bsrSortedVal,
+            <const int*>bsrSortedRowPtr, <const int*>bsrSortedColInd,
+            blockSize, <bsric02Info_t>info, &pBufferSize)
+    check_status(status)
+    return <size_t>pBufferSize
+
+cpdef sbsric02_analysis(
+        size_t handle, int dirA, int mb, int nnzb, size_t descrA,
+        size_t bsrSortedVal, size_t bsrSortedRowPtr, size_t bsrSortedColInd,
+        int blockDim, size_t info, int policy, size_t pInputBuffer):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseSbsric02_analysis(
+            <cusparseHandle_t>handle, <cusparseDirection_t>dirA, mb, nnzb,
+            <const cusparseMatDescr_t>descrA, <const float*>bsrSortedVal,
+            <const int*>bsrSortedRowPtr, <const int*>bsrSortedColInd, blockDim,
+            <bsric02Info_t>info, <cusparseSolvePolicy_t>policy,
+            <void*>pInputBuffer)
+    check_status(status)
+
+cpdef dbsric02_analysis(
+        size_t handle, int dirA, int mb, int nnzb, size_t descrA,
+        size_t bsrSortedVal, size_t bsrSortedRowPtr, size_t bsrSortedColInd,
+        int blockDim, size_t info, int policy, size_t pInputBuffer):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseDbsric02_analysis(
+            <cusparseHandle_t>handle, <cusparseDirection_t>dirA, mb, nnzb,
+            <const cusparseMatDescr_t>descrA, <const double*>bsrSortedVal,
+            <const int*>bsrSortedRowPtr, <const int*>bsrSortedColInd, blockDim,
+            <bsric02Info_t>info, <cusparseSolvePolicy_t>policy,
+            <void*>pInputBuffer)
+    check_status(status)
+
+cpdef cbsric02_analysis(
+        size_t handle, int dirA, int mb, int nnzb, size_t descrA,
+        size_t bsrSortedVal, size_t bsrSortedRowPtr, size_t bsrSortedColInd,
+        int blockDim, size_t info, int policy, size_t pInputBuffer):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseCbsric02_analysis(
+            <cusparseHandle_t>handle, <cusparseDirection_t>dirA, mb, nnzb,
+            <const cusparseMatDescr_t>descrA, <const cuComplex*>bsrSortedVal,
+            <const int*>bsrSortedRowPtr, <const int*>bsrSortedColInd, blockDim,
+            <bsric02Info_t>info, <cusparseSolvePolicy_t>policy,
+            <void*>pInputBuffer)
+    check_status(status)
+
+cpdef zbsric02_analysis(
+        size_t handle, int dirA, int mb, int nnzb, size_t descrA,
+        size_t bsrSortedVal, size_t bsrSortedRowPtr, size_t bsrSortedColInd,
+        int blockDim, size_t info, int policy, size_t pInputBuffer):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseZbsric02_analysis(
+            <cusparseHandle_t>handle, <cusparseDirection_t>dirA, mb, nnzb,
+            <const cusparseMatDescr_t>descrA,
+            <const cuDoubleComplex*>bsrSortedVal, <const int*>bsrSortedRowPtr,
+            <const int*>bsrSortedColInd, blockDim, <bsric02Info_t>info,
+            <cusparseSolvePolicy_t>policy, <void*>pInputBuffer)
+    check_status(status)
+
+cpdef sbsric02(size_t handle, int dirA, int mb, int nnzb, size_t descrA,
+               size_t bsrSortedVal, size_t bsrSortedRowPtr,
+               size_t bsrSortedColInd, int blockDim, size_t info, int policy,
+               size_t pBuffer):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseSbsric02(
+            <cusparseHandle_t>handle, <cusparseDirection_t>dirA, mb, nnzb,
+            <const cusparseMatDescr_t>descrA, <float*>bsrSortedVal,
+            <const int*>bsrSortedRowPtr, <const int*>bsrSortedColInd, blockDim,
+            <bsric02Info_t>info, <cusparseSolvePolicy_t>policy, <void*>pBuffer)
+    check_status(status)
+
+cpdef dbsric02(size_t handle, int dirA, int mb, int nnzb, size_t descrA,
+               size_t bsrSortedVal, size_t bsrSortedRowPtr,
+               size_t bsrSortedColInd, int blockDim, size_t info, int policy,
+               size_t pBuffer):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseDbsric02(
+            <cusparseHandle_t>handle, <cusparseDirection_t>dirA, mb, nnzb,
+            <const cusparseMatDescr_t>descrA, <double*>bsrSortedVal,
+            <const int*>bsrSortedRowPtr, <const int*>bsrSortedColInd, blockDim,
+            <bsric02Info_t>info, <cusparseSolvePolicy_t>policy, <void*>pBuffer)
+    check_status(status)
+
+cpdef cbsric02(size_t handle, int dirA, int mb, int nnzb, size_t descrA,
+               size_t bsrSortedVal, size_t bsrSortedRowPtr,
+               size_t bsrSortedColInd, int blockDim, size_t info, int policy,
+               size_t pBuffer):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseCbsric02(
+            <cusparseHandle_t>handle, <cusparseDirection_t>dirA, mb, nnzb,
+            <const cusparseMatDescr_t>descrA, <cuComplex*>bsrSortedVal,
+            <const int*>bsrSortedRowPtr, <const int*>bsrSortedColInd, blockDim,
+            <bsric02Info_t>info, <cusparseSolvePolicy_t>policy, <void*>pBuffer)
+    check_status(status)
+
+cpdef zbsric02(size_t handle, int dirA, int mb, int nnzb, size_t descrA,
+               size_t bsrSortedVal, size_t bsrSortedRowPtr,
+               size_t bsrSortedColInd, int blockDim, size_t info, int policy,
+               size_t pBuffer):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseZbsric02(
+            <cusparseHandle_t>handle, <cusparseDirection_t>dirA, mb, nnzb,
+            <const cusparseMatDescr_t>descrA, <cuDoubleComplex*>bsrSortedVal,
+            <const int*>bsrSortedRowPtr, <const int*>bsrSortedColInd, blockDim,
+            <bsric02Info_t>info, <cusparseSolvePolicy_t>policy, <void*>pBuffer)
+    check_status(status)
+
+cpdef sgtsv2_bufferSizeExt(size_t handle, int m, int n, size_t dl, size_t d,
+                           size_t du, size_t B, int ldb,
+                           size_t bufferSizeInBytes):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseSgtsv2_bufferSizeExt(
+            <cusparseHandle_t>handle, m, n, <const float*>dl, <const float*>d,
+            <const float*>du, <const float*>B, ldb, <size_t*>bufferSizeInBytes)
+    check_status(status)
+
+cpdef dgtsv2_bufferSizeExt(size_t handle, int m, int n, size_t dl, size_t d,
+                           size_t du, size_t B, int ldb,
+                           size_t bufferSizeInBytes):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseDgtsv2_bufferSizeExt(
+            <cusparseHandle_t>handle, m, n, <const double*>dl,
+            <const double*>d, <const double*>du, <const double*>B, ldb,
+            <size_t*>bufferSizeInBytes)
+    check_status(status)
+
+cpdef cgtsv2_bufferSizeExt(size_t handle, int m, int n, size_t dl, size_t d,
+                           size_t du, size_t B, int ldb,
+                           size_t bufferSizeInBytes):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseCgtsv2_bufferSizeExt(
+            <cusparseHandle_t>handle, m, n, <const cuComplex*>dl,
+            <const cuComplex*>d, <const cuComplex*>du, <const cuComplex*>B,
+            ldb, <size_t*>bufferSizeInBytes)
+    check_status(status)
+
+cpdef zgtsv2_bufferSizeExt(size_t handle, int m, int n, size_t dl, size_t d,
+                           size_t du, size_t B, int ldb,
+                           size_t bufferSizeInBytes):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseZgtsv2_bufferSizeExt(
+            <cusparseHandle_t>handle, m, n, <const cuDoubleComplex*>dl,
+            <const cuDoubleComplex*>d, <const cuDoubleComplex*>du,
+            <const cuDoubleComplex*>B, ldb, <size_t*>bufferSizeInBytes)
+    check_status(status)
+
+cpdef sgtsv2(size_t handle, int m, int n, size_t dl, size_t d, size_t du,
+             size_t B, int ldb, size_t pBuffer):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseSgtsv2(
+            <cusparseHandle_t>handle, m, n, <const float*>dl, <const float*>d,
+            <const float*>du, <float*>B, ldb, <void*>pBuffer)
+    check_status(status)
+
+cpdef dgtsv2(size_t handle, int m, int n, size_t dl, size_t d, size_t du,
+             size_t B, int ldb, size_t pBuffer):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseDgtsv2(<cusparseHandle_t>handle, m, n,
+                                <const double*>dl, <const double*>d,
+                                <const double*>du, <double*>B, ldb,
+                                <void*>pBuffer)
+    check_status(status)
+
+cpdef cgtsv2(size_t handle, int m, int n, size_t dl, size_t d, size_t du,
+             size_t B, int ldb, size_t pBuffer):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseCgtsv2(<cusparseHandle_t>handle, m, n,
+                                <const cuComplex*>dl, <const cuComplex*>d,
+                                <const cuComplex*>du, <cuComplex*>B, ldb,
+                                <void*>pBuffer)
+    check_status(status)
+
+cpdef zgtsv2(size_t handle, int m, int n, size_t dl, size_t d, size_t du,
+             size_t B, int ldb, size_t pBuffer):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseZgtsv2(
+            <cusparseHandle_t>handle, m, n, <const cuDoubleComplex*>dl,
+            <const cuDoubleComplex*>d, <const cuDoubleComplex*>du,
+            <cuDoubleComplex*>B, ldb, <void*>pBuffer)
+    check_status(status)
+
+cpdef sgtsv2_nopivot_bufferSizeExt(size_t handle, int m, int n, size_t dl,
+                                   size_t d, size_t du, size_t B, int ldb,
+                                   size_t bufferSizeInBytes):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseSgtsv2_nopivot_bufferSizeExt(
+            <cusparseHandle_t>handle, m, n, <const float*>dl, <const float*>d,
+            <const float*>du, <const float*>B, ldb, <size_t*>bufferSizeInBytes)
+    check_status(status)
+
+cpdef dgtsv2_nopivot_bufferSizeExt(size_t handle, int m, int n, size_t dl,
+                                   size_t d, size_t du, size_t B, int ldb,
+                                   size_t bufferSizeInBytes):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseDgtsv2_nopivot_bufferSizeExt(
+            <cusparseHandle_t>handle, m, n, <const double*>dl,
+            <const double*>d, <const double*>du, <const double*>B, ldb,
+            <size_t*>bufferSizeInBytes)
+    check_status(status)
+
+cpdef cgtsv2_nopivot_bufferSizeExt(size_t handle, int m, int n, size_t dl,
+                                   size_t d, size_t du, size_t B, int ldb,
+                                   size_t bufferSizeInBytes):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseCgtsv2_nopivot_bufferSizeExt(
+            <cusparseHandle_t>handle, m, n, <const cuComplex*>dl,
+            <const cuComplex*>d, <const cuComplex*>du, <const cuComplex*>B,
+            ldb, <size_t*>bufferSizeInBytes)
+    check_status(status)
+
+cpdef zgtsv2_nopivot_bufferSizeExt(size_t handle, int m, int n, size_t dl,
+                                   size_t d, size_t du, size_t B, int ldb,
+                                   size_t bufferSizeInBytes):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseZgtsv2_nopivot_bufferSizeExt(
+            <cusparseHandle_t>handle, m, n, <const cuDoubleComplex*>dl,
+            <const cuDoubleComplex*>d, <const cuDoubleComplex*>du,
+            <const cuDoubleComplex*>B, ldb, <size_t*>bufferSizeInBytes)
+    check_status(status)
+
+cpdef sgtsv2_nopivot(size_t handle, int m, int n, size_t dl, size_t d,
+                     size_t du, size_t B, int ldb, size_t pBuffer):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseSgtsv2_nopivot(
+            <cusparseHandle_t>handle, m, n, <const float*>dl, <const float*>d,
+            <const float*>du, <float*>B, ldb, <void*>pBuffer)
+    check_status(status)
+
+cpdef dgtsv2_nopivot(size_t handle, int m, int n, size_t dl, size_t d,
+                     size_t du, size_t B, int ldb, size_t pBuffer):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseDgtsv2_nopivot(<cusparseHandle_t>handle, m, n,
+                                        <const double*>dl, <const double*>d,
+                                        <const double*>du, <double*>B, ldb,
+                                        <void*>pBuffer)
+    check_status(status)
+
+cpdef cgtsv2_nopivot(size_t handle, int m, int n, size_t dl, size_t d,
+                     size_t du, size_t B, int ldb, size_t pBuffer):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseCgtsv2_nopivot(
+            <cusparseHandle_t>handle, m, n, <const cuComplex*>dl,
+            <const cuComplex*>d, <const cuComplex*>du, <cuComplex*>B, ldb,
+            <void*>pBuffer)
+    check_status(status)
+
+cpdef zgtsv2_nopivot(size_t handle, int m, int n, size_t dl, size_t d,
+                     size_t du, size_t B, int ldb, size_t pBuffer):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseZgtsv2_nopivot(
+            <cusparseHandle_t>handle, m, n, <const cuDoubleComplex*>dl,
+            <const cuDoubleComplex*>d, <const cuDoubleComplex*>du,
+            <cuDoubleComplex*>B, ldb, <void*>pBuffer)
+    check_status(status)
+
+cpdef sgtsv2StridedBatch_bufferSizeExt(
+        size_t handle, int m, size_t dl, size_t d, size_t du, size_t x,
+        int batchCount, int batchStride, size_t bufferSizeInBytes):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseSgtsv2StridedBatch_bufferSizeExt(
+            <cusparseHandle_t>handle, m, <const float*>dl, <const float*>d,
+            <const float*>du, <const float*>x, batchCount, batchStride,
+            <size_t*>bufferSizeInBytes)
+    check_status(status)
+
+cpdef dgtsv2StridedBatch_bufferSizeExt(
+        size_t handle, int m, size_t dl, size_t d, size_t du, size_t x,
+        int batchCount, int batchStride, size_t bufferSizeInBytes):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseDgtsv2StridedBatch_bufferSizeExt(
+            <cusparseHandle_t>handle, m, <const double*>dl, <const double*>d,
+            <const double*>du, <const double*>x, batchCount, batchStride,
+            <size_t*>bufferSizeInBytes)
+    check_status(status)
+
+cpdef cgtsv2StridedBatch_bufferSizeExt(
+        size_t handle, int m, size_t dl, size_t d, size_t du, size_t x,
+        int batchCount, int batchStride, size_t bufferSizeInBytes):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseCgtsv2StridedBatch_bufferSizeExt(
+            <cusparseHandle_t>handle, m, <const cuComplex*>dl,
+            <const cuComplex*>d, <const cuComplex*>du, <const cuComplex*>x,
+            batchCount, batchStride, <size_t*>bufferSizeInBytes)
+    check_status(status)
+
+cpdef zgtsv2StridedBatch_bufferSizeExt(
+        size_t handle, int m, size_t dl, size_t d, size_t du, size_t x,
+        int batchCount, int batchStride, size_t bufferSizeInBytes):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseZgtsv2StridedBatch_bufferSizeExt(
+            <cusparseHandle_t>handle, m, <const cuDoubleComplex*>dl,
+            <const cuDoubleComplex*>d, <const cuDoubleComplex*>du,
+            <const cuDoubleComplex*>x, batchCount, batchStride,
+            <size_t*>bufferSizeInBytes)
+    check_status(status)
+
+cpdef sgtsv2StridedBatch(size_t handle, int m, size_t dl, size_t d, size_t du,
+                         size_t x, int batchCount, int batchStride,
+                         size_t pBuffer):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseSgtsv2StridedBatch(
+            <cusparseHandle_t>handle, m, <const float*>dl, <const float*>d,
+            <const float*>du, <float*>x, batchCount, batchStride,
+            <void*>pBuffer)
+    check_status(status)
+
+cpdef dgtsv2StridedBatch(size_t handle, int m, size_t dl, size_t d, size_t du,
+                         size_t x, int batchCount, int batchStride,
+                         size_t pBuffer):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseDgtsv2StridedBatch(
+            <cusparseHandle_t>handle, m, <const double*>dl, <const double*>d,
+            <const double*>du, <double*>x, batchCount, batchStride,
+            <void*>pBuffer)
+    check_status(status)
+
+cpdef cgtsv2StridedBatch(size_t handle, int m, size_t dl, size_t d, size_t du,
+                         size_t x, int batchCount, int batchStride,
+                         size_t pBuffer):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseCgtsv2StridedBatch(
+            <cusparseHandle_t>handle, m, <const cuComplex*>dl,
+            <const cuComplex*>d, <const cuComplex*>du, <cuComplex*>x,
+            batchCount, batchStride, <void*>pBuffer)
+    check_status(status)
+
+cpdef zgtsv2StridedBatch(size_t handle, int m, size_t dl, size_t d, size_t du,
+                         size_t x, int batchCount, int batchStride,
+                         size_t pBuffer):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseZgtsv2StridedBatch(
+            <cusparseHandle_t>handle, m, <const cuDoubleComplex*>dl,
+            <const cuDoubleComplex*>d, <const cuDoubleComplex*>du,
+            <cuDoubleComplex*>x, batchCount, batchStride, <void*>pBuffer)
+    check_status(status)
+
+cpdef size_t sgtsvInterleavedBatch_bufferSizeExt(
+        size_t handle, int algo, int m, size_t dl, size_t d, size_t du,
+        size_t x, int batchCount):
+    cdef size_t pBufferSizeInBytes
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseSgtsvInterleavedBatch_bufferSizeExt(
+            <cusparseHandle_t>handle, algo, m, <const float*>dl,
+            <const float*>d, <const float*>du, <const float*>x, batchCount,
+            &pBufferSizeInBytes)
+    check_status(status)
+    return <size_t>pBufferSizeInBytes
+
+cpdef size_t dgtsvInterleavedBatch_bufferSizeExt(
+        size_t handle, int algo, int m, size_t dl, size_t d, size_t du,
+        size_t x, int batchCount):
+    cdef size_t pBufferSizeInBytes
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseDgtsvInterleavedBatch_bufferSizeExt(
+            <cusparseHandle_t>handle, algo, m, <const double*>dl,
+            <const double*>d, <const double*>du, <const double*>x, batchCount,
+            &pBufferSizeInBytes)
+    check_status(status)
+    return <size_t>pBufferSizeInBytes
+
+cpdef size_t cgtsvInterleavedBatch_bufferSizeExt(
+        size_t handle, int algo, int m, size_t dl, size_t d, size_t du,
+        size_t x, int batchCount):
+    cdef size_t pBufferSizeInBytes
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseCgtsvInterleavedBatch_bufferSizeExt(
+            <cusparseHandle_t>handle, algo, m, <const cuComplex*>dl,
+            <const cuComplex*>d, <const cuComplex*>du, <const cuComplex*>x,
+            batchCount, &pBufferSizeInBytes)
+    check_status(status)
+    return <size_t>pBufferSizeInBytes
+
+cpdef size_t zgtsvInterleavedBatch_bufferSizeExt(
+        size_t handle, int algo, int m, size_t dl, size_t d, size_t du,
+        size_t x, int batchCount):
+    cdef size_t pBufferSizeInBytes
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseZgtsvInterleavedBatch_bufferSizeExt(
+            <cusparseHandle_t>handle, algo, m, <const cuDoubleComplex*>dl,
+            <const cuDoubleComplex*>d, <const cuDoubleComplex*>du,
+            <const cuDoubleComplex*>x, batchCount, &pBufferSizeInBytes)
+    check_status(status)
+    return <size_t>pBufferSizeInBytes
+
+cpdef sgtsvInterleavedBatch(size_t handle, int algo, int m, size_t dl,
+                            size_t d, size_t du, size_t x, int batchCount,
+                            size_t pBuffer):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseSgtsvInterleavedBatch(
+            <cusparseHandle_t>handle, algo, m, <float*>dl, <float*>d,
+            <float*>du, <float*>x, batchCount, <void*>pBuffer)
+    check_status(status)
+
+cpdef dgtsvInterleavedBatch(size_t handle, int algo, int m, size_t dl,
+                            size_t d, size_t du, size_t x, int batchCount,
+                            size_t pBuffer):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseDgtsvInterleavedBatch(
+            <cusparseHandle_t>handle, algo, m, <double*>dl, <double*>d,
+            <double*>du, <double*>x, batchCount, <void*>pBuffer)
+    check_status(status)
+
+cpdef cgtsvInterleavedBatch(size_t handle, int algo, int m, size_t dl,
+                            size_t d, size_t du, size_t x, int batchCount,
+                            size_t pBuffer):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseCgtsvInterleavedBatch(
+            <cusparseHandle_t>handle, algo, m, <cuComplex*>dl, <cuComplex*>d,
+            <cuComplex*>du, <cuComplex*>x, batchCount, <void*>pBuffer)
+    check_status(status)
+
+cpdef zgtsvInterleavedBatch(size_t handle, int algo, int m, size_t dl,
+                            size_t d, size_t du, size_t x, int batchCount,
+                            size_t pBuffer):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseZgtsvInterleavedBatch(
+            <cusparseHandle_t>handle, algo, m, <cuDoubleComplex*>dl,
+            <cuDoubleComplex*>d, <cuDoubleComplex*>du, <cuDoubleComplex*>x,
+            batchCount, <void*>pBuffer)
+    check_status(status)
+
+cpdef size_t sgpsvInterleavedBatch_bufferSizeExt(
+        size_t handle, int algo, int m, size_t ds, size_t dl, size_t d,
+        size_t du, size_t dw, size_t x, int batchCount):
+    cdef size_t pBufferSizeInBytes
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseSgpsvInterleavedBatch_bufferSizeExt(
+            <cusparseHandle_t>handle, algo, m, <const float*>ds,
+            <const float*>dl, <const float*>d, <const float*>du,
+            <const float*>dw, <const float*>x, batchCount, &pBufferSizeInBytes)
+    check_status(status)
+    return <size_t>pBufferSizeInBytes
+
+cpdef size_t dgpsvInterleavedBatch_bufferSizeExt(
+        size_t handle, int algo, int m, size_t ds, size_t dl, size_t d,
+        size_t du, size_t dw, size_t x, int batchCount):
+    cdef size_t pBufferSizeInBytes
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseDgpsvInterleavedBatch_bufferSizeExt(
+            <cusparseHandle_t>handle, algo, m, <const double*>ds,
+            <const double*>dl, <const double*>d, <const double*>du,
+            <const double*>dw, <const double*>x, batchCount,
+            &pBufferSizeInBytes)
+    check_status(status)
+    return <size_t>pBufferSizeInBytes
+
+cpdef size_t cgpsvInterleavedBatch_bufferSizeExt(
+        size_t handle, int algo, int m, size_t ds, size_t dl, size_t d,
+        size_t du, size_t dw, size_t x, int batchCount):
+    cdef size_t pBufferSizeInBytes
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseCgpsvInterleavedBatch_bufferSizeExt(
+            <cusparseHandle_t>handle, algo, m, <const cuComplex*>ds,
+            <const cuComplex*>dl, <const cuComplex*>d, <const cuComplex*>du,
+            <const cuComplex*>dw, <const cuComplex*>x, batchCount,
+            &pBufferSizeInBytes)
+    check_status(status)
+    return <size_t>pBufferSizeInBytes
+
+cpdef size_t zgpsvInterleavedBatch_bufferSizeExt(
+        size_t handle, int algo, int m, size_t ds, size_t dl, size_t d,
+        size_t du, size_t dw, size_t x, int batchCount):
+    cdef size_t pBufferSizeInBytes
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseZgpsvInterleavedBatch_bufferSizeExt(
+            <cusparseHandle_t>handle, algo, m, <const cuDoubleComplex*>ds,
+            <const cuDoubleComplex*>dl, <const cuDoubleComplex*>d,
+            <const cuDoubleComplex*>du, <const cuDoubleComplex*>dw,
+            <const cuDoubleComplex*>x, batchCount, &pBufferSizeInBytes)
+    check_status(status)
+    return <size_t>pBufferSizeInBytes
+
+cpdef sgpsvInterleavedBatch(size_t handle, int algo, int m, size_t ds,
+                            size_t dl, size_t d, size_t du, size_t dw,
+                            size_t x, int batchCount, size_t pBuffer):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseSgpsvInterleavedBatch(
+            <cusparseHandle_t>handle, algo, m, <float*>ds, <float*>dl,
+            <float*>d, <float*>du, <float*>dw, <float*>x, batchCount,
+            <void*>pBuffer)
+    check_status(status)
+
+cpdef dgpsvInterleavedBatch(size_t handle, int algo, int m, size_t ds,
+                            size_t dl, size_t d, size_t du, size_t dw,
+                            size_t x, int batchCount, size_t pBuffer):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseDgpsvInterleavedBatch(
+            <cusparseHandle_t>handle, algo, m, <double*>ds, <double*>dl,
+            <double*>d, <double*>du, <double*>dw, <double*>x, batchCount,
+            <void*>pBuffer)
+    check_status(status)
+
+cpdef cgpsvInterleavedBatch(size_t handle, int algo, int m, size_t ds,
+                            size_t dl, size_t d, size_t du, size_t dw,
+                            size_t x, int batchCount, size_t pBuffer):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseCgpsvInterleavedBatch(
+            <cusparseHandle_t>handle, algo, m, <cuComplex*>ds, <cuComplex*>dl,
+            <cuComplex*>d, <cuComplex*>du, <cuComplex*>dw, <cuComplex*>x,
+            batchCount, <void*>pBuffer)
+    check_status(status)
+
+cpdef zgpsvInterleavedBatch(size_t handle, int algo, int m, size_t ds,
+                            size_t dl, size_t d, size_t du, size_t dw,
+                            size_t x, int batchCount, size_t pBuffer):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusparseZgpsvInterleavedBatch(
+            <cusparseHandle_t>handle, algo, m, <cuDoubleComplex*>ds,
+            <cuDoubleComplex*>dl, <cuDoubleComplex*>d, <cuDoubleComplex*>du,
+            <cuDoubleComplex*>dw, <cuDoubleComplex*>x, batchCount,
+            <void*>pBuffer)
     check_status(status)


### PR DESCRIPTION
The PR adds wrappers to cuSPARSE routines for preconditioners except routines deprecated in CUDA 10.1.
https://docs.nvidia.com/cuda/cusparse/index.html#preconditioners-reference