### PR TITLE
Fix for NumPy 1.14.x compatibility

### DIFF
--- a/tests/cupy_tests/indexing_tests/test_indexing.py
+++ b/tests/cupy_tests/indexing_tests/test_indexing.py
@@ -85,11 +85,13 @@ class TestIndexing(unittest.TestCase):
         a = testing.shaped_arange((3, 3, 3), xp, dtype)
         return a.diagonal(0, -1, -3)
 
+    @testing.with_requires('numpy>=1.15')
     @testing.numpy_cupy_raises()
     def test_diagonal_invalid1(self, xp):
         a = testing.shaped_arange((3, 3, 3), xp)
         a.diagonal(0, 1, 3)
 
+    @testing.with_requires('numpy>=1.15')
     @testing.numpy_cupy_raises()
     def test_diagonal_invalid2(self, xp):
         a = testing.shaped_arange((3, 3, 3), xp)

--- a/tests/cupy_tests/manipulation_tests/test_rearrange.py
+++ b/tests/cupy_tests/manipulation_tests/test_rearrange.py
@@ -240,18 +240,21 @@ class TestFlip(unittest.TestCase):
         x = xp.array([], dtype).reshape((1, 0, 1))
         return xp.flip(x, 1)
 
+    @testing.with_requires('numpy>=1.15')
     @testing.for_all_dtypes()
     @testing.numpy_cupy_raises()
     def test_flip_insufficient_ndim(self, xp, dtype):
         x = testing.shaped_arange((), xp, dtype)
         return xp.flip(x, 0)
 
+    @testing.with_requires('numpy>=1.15')
     @testing.for_all_dtypes()
     @testing.numpy_cupy_raises()
     def test_flip_invalid_axis(self, xp, dtype):
         x = testing.shaped_arange((3, 4), xp, dtype)
         return xp.flip(x, 2)
 
+    @testing.with_requires('numpy>=1.15')
     @testing.for_all_dtypes()
     @testing.numpy_cupy_raises()
     def test_flip_invalid_negative_axis(self, xp, dtype):


### PR DESCRIPTION
In these error cases:
* NumPy 1.14.6 or earlier emits `ValueError` instead of `numpy.core._internal.AxisError`.
* NumPy 1.15 or later emits `numpy.core._internal.AxisError`

```py
xp.arange(27).reshape((3,3,3)).diagonal(0,1,3)
```