### PR TITLE
Workaround bug in NumPy 1.12.x or earlier

### DIFF
--- a/tests/cupy_tests/core_tests/test_ndarray_ufunc.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_ufunc.py
@@ -88,7 +88,7 @@ class TestArrayUfunc(unittest.TestCase):
         b = cupy.testing.shaped_arange((3, 2), xp)[:, None, :]
         return a * b
 
-    @testing.with_requires('numpy>=1.11')
+    @testing.with_requires('numpy>=1.13')
     @testing.numpy_cupy_array_equal()
     def test_shares_memory(self, xp):
         a = cupy.testing.shaped_arange((1000, 1000), xp, 'int64')


### PR DESCRIPTION
It seems that NumPy 1.12.x or earlier does not handle overlapped arrays correctly. NumPy 1.13 works fine.

```py
import numpy as xp

a1 = xp.arange(1000000, dtype=xp.int64).reshape((1000,1000))
b1 = xp.transpose(a1)
a1 += b1

a2 = xp.arange(1000000, dtype=xp.int64).reshape(1000,1000)
b2 = xp.transpose(a2).copy()
a2 += b2

xp.all(a1 == b1)  # False
```