### PR TITLE
Support cuComplex.h in `cupy.RawKernel` and `cupy.RawModule`

### DIFF
--- a/cupy/core/carray.pxi
+++ b/cupy/core/carray.pxi
@@ -128,7 +128,7 @@ cpdef str _convert_cuComplex_to_Thrust(str source):
 
     # First, we comment out the line that includes cuComplex.h
     for i, line in enumerate(source_lines):
-        if '<cuComplex.h>' in line:
+        if '#include' in line and 'cuComplex.h' in line:
             source_lines[i] = r'//' + line
             break
     source = '\n'.join(source_lines)

--- a/cupy/core/carray.pxi
+++ b/cupy/core/carray.pxi
@@ -123,11 +123,20 @@ cpdef str _get_header_source():
     return _header_source
 
 
+# added at the module level for precompiling the regex
+_cucomplex_include_tokens = ['', '#', 'include', '<', r'cuComplex\.h', '>']
+_cucomplex_include_pattern = re.compile(r'\s*'.join(_cucomplex_include_tokens))
+
+
 cdef inline str _convert_cuComplex_to_Thrust(str source):
-    source = re.sub(r'<cuComplex.h>',
-                    r'<cupy/cuComplex_bridge.h>  // translate_cucomplex',
-                    source)
-    return source
+    lines = []
+    for line in source.splitlines(keepends=True):
+        if _cucomplex_include_pattern.match(line):
+            lines += '#include <cupy/cuComplex_bridge.h>  '\
+                     '// translate_cucomplex\n'
+        else:
+            lines += line
+    return ''.join(lines)
 
 
 cpdef function.Module compile_with_cache(

--- a/cupy/core/carray.pxi
+++ b/cupy/core/carray.pxi
@@ -122,7 +122,7 @@ cpdef str _get_header_source():
     return _header_source
 
 
-cpdef str _convert_cuComplex_to_Thrust(str source):
+cdef str _convert_cuComplex_to_Thrust(str source):
     cdef str macro, line
     cdef list source_lines = [line for line in source.split('\n')]
 

--- a/cupy/core/carray.pxi
+++ b/cupy/core/carray.pxi
@@ -143,13 +143,13 @@ cdef str _convert_cuComplex_to_Thrust(str source):
     #define make_cuFloatComplex(A, B)     complex<float>(A, B)
     #define make_cuComplex(A, B)          complex<float>(A, B)
     #define cuConjf                       conj
-    #define cuCaddf(A, B)                 A + B
-    #define cuCsubf(A, B)                 A - B
-    #define cuCmulf(A, B)                 A * B
-    #define cuCdivf(A, B)                 A / B
+    #define cuCaddf(A, B)                 (A + B)
+    #define cuCsubf(A, B)                 (A - B)
+    #define cuCmulf(A, B)                 (A * B)
+    #define cuCdivf(A, B)                 (A / B)
     #define cuCabsf                       abs
     #define cuComplexDoubleToFloat        complex<float>
-    #define cuCfmaf(A, B, C)              A * B + C
+    #define cuCfmaf(A, B, C)              (A * B + C)
 
     /* ------------------- double complex ------------------- */
     #define cuDoubleComplex               complex<double>
@@ -157,13 +157,13 @@ cdef str _convert_cuComplex_to_Thrust(str source):
     #define cuCimag                       imag
     #define make_cuDoubleComplex(A, B)    complex<double>(A, B)
     #define cuConj                        conj
-    #define cuCadd(A, B)                  A + B
-    #define cuCsub(A, B)                  A - B
-    #define cuCmul(A, B)                  A * B
-    #define cuCdiv(A, B)                  A / B
+    #define cuCadd(A, B)                  (A + B)
+    #define cuCsub(A, B)                  (A - B)
+    #define cuCmul(A, B)                  (A * B)
+    #define cuCdiv(A, B)                  (A / B)
     #define cuCabs                        abs
     #define cuComplexFloatToDouble        complex<double>
-    #define cuCfma(A, B, C)               A * B + C
+    #define cuCfma(A, B, C)               (A * B + C)
     '''
     source = macro + source
     return source

--- a/cupy/core/carray.pxi
+++ b/cupy/core/carray.pxi
@@ -122,9 +122,60 @@ cpdef str _get_header_source():
     return _header_source
 
 
+cpdef str _convert_cuComplex_to_Thrust(str source):
+    cdef str macro, line
+    cdef list source_lines = [line for line in source.split('\n')]
+
+    # First, we comment out the line that includes cuComplex.h
+    for i, line in enumerate(source_lines):
+        if '<cuComplex.h>' in line:
+            source_lines[i] = r'//' + line
+            break
+    source = '\n'.join(source_lines)
+
+    # Second, we use macros to replace cuComplex APIs by those of Thrust's
+    macro = r'''
+    /* ------------------- single complex ------------------- */
+    #define cuFloatComplex                complex<float>
+    #define cuComplex                     complex<float>
+    #define cuCrealf                      real
+    #define cuCimagf                      imag
+    #define make_cuFloatComplex(A, B)     complex<float>(A, B)
+    #define make_cuComplex(A, B)          complex<float>(A, B)
+    #define cuConjf                       conj
+    #define cuCaddf(A, B)                 A + B
+    #define cuCsubf(A, B)                 A - B
+    #define cuCmulf(A, B)                 A * B
+    #define cuCdivf(A, B)                 A / B
+    #define cuCabsf                       abs
+    #define cuComplexDoubleToFloat        complex<float>
+    #define cuCfmaf(A, B, C)              A * B + C
+
+    /* ------------------- double complex ------------------- */
+    #define cuDoubleComplex               complex<double>
+    #define cuCreal                       real
+    #define cuCimag                       imag
+    #define make_cuDoubleComplex(A, B)    complex<double>(A, B)
+    #define cuConj                        conj
+    #define cuCadd(A, B)                  A + B
+    #define cuCsub(A, B)                  A - B
+    #define cuCmul(A, B)                  A * B
+    #define cuCdiv(A, B)                  A / B
+    #define cuCabs                        abs
+    #define cuComplexFloatToDouble        complex<double>
+    #define cuCfma(A, B, C)               A * B + C
+    '''
+    source = macro + source
+    return source
+
+
 cpdef function.Module compile_with_cache(
         str source, tuple options=(), arch=None, cachd_dir=None,
-        prepend_cupy_headers=True, backend='nvrtc'):
+        prepend_cupy_headers=True, backend='nvrtc', enable_cuComplex=False):
+    if enable_cuComplex:
+        source = _convert_cuComplex_to_Thrust(source)
+        prepend_cupy_headers=True  # for <cupy/complex.cuh>
+
     if prepend_cupy_headers:
         source = _cupy_header + source
     extra_source = _get_header_source()

--- a/cupy/core/carray.pxi
+++ b/cupy/core/carray.pxi
@@ -128,7 +128,7 @@ _cucomplex_include_tokens = ['', '#', 'include', '<', r'cuComplex\.h', '>']
 _cucomplex_include_pattern = re.compile(r'\s*'.join(_cucomplex_include_tokens))
 
 
-cdef inline str _convert_cuComplex_to_Thrust(str source):
+cdef inline str _translate_cucomplex_to_thrust(str source):
     lines = []
     for line in source.splitlines(keepends=True):
         if _cucomplex_include_pattern.match(line):
@@ -143,9 +143,9 @@ cpdef function.Module compile_with_cache(
         str source, tuple options=(), arch=None, cachd_dir=None,
         prepend_cupy_headers=True, backend='nvrtc', translate_cucomplex=False):
     if translate_cucomplex:
-        source = _convert_cuComplex_to_Thrust(source)
+        source = _translate_cucomplex_to_thrust(source)
         _cupy_header_list.append('cupy/cuComplex_bridge.h')
-        prepend_cupy_headers=True
+        prepend_cupy_headers = True
 
     if prepend_cupy_headers:
         source = _cupy_header + source

--- a/cupy/core/core.pxd
+++ b/cupy/core/core.pxd
@@ -99,7 +99,7 @@ cpdef ndarray asfortranarray(ndarray a, dtype=*)
 
 cpdef Module compile_with_cache(str source, tuple options=*, arch=*,
                                 cachd_dir=*, prepend_cupy_headers=*,
-                                backend=*, enable_cuComplex=*)
+                                backend=*, translate_cucomplex=*)
 
 
 # TODO(niboshi): Move to _routines_creation.pyx

--- a/cupy/core/core.pxd
+++ b/cupy/core/core.pxd
@@ -99,7 +99,7 @@ cpdef ndarray asfortranarray(ndarray a, dtype=*)
 
 cpdef Module compile_with_cache(str source, tuple options=*, arch=*,
                                 cachd_dir=*, prepend_cupy_headers=*,
-                                backend=*)
+                                backend=*, enable_cuComplex=*)
 
 
 # TODO(niboshi): Move to _routines_creation.pyx

--- a/cupy/core/include/cupy/cuComplex_bridge.h
+++ b/cupy/core/include/cupy/cuComplex_bridge.h
@@ -1,0 +1,34 @@
+/* 
+   This header is to support the "translate_cucomplex" option
+   that turns cuComplex function calls to their Thrust counterparts.
+*/ 
+
+/* ------------------- single complex ------------------- */
+#define cuFloatComplex                complex<float>
+#define cuComplex                     complex<float>
+#define cuCrealf                      real
+#define cuCimagf                      imag
+#define make_cuFloatComplex(A, B)     complex<float>(A, B)
+#define make_cuComplex(A, B)          complex<float>(A, B)
+#define cuConjf                       conj
+#define cuCaddf(A, B)                 (A + B)
+#define cuCsubf(A, B)                 (A - B)
+#define cuCmulf(A, B)                 (A * B)
+#define cuCdivf(A, B)                 (A / B)
+#define cuCabsf                       abs
+#define cuComplexDoubleToFloat        complex<float>
+#define cuCfmaf(A, B, C)              (A * B + C)
+
+/* ------------------- double complex ------------------- */
+#define cuDoubleComplex               complex<double>
+#define cuCreal                       real
+#define cuCimag                       imag
+#define make_cuDoubleComplex(A, B)    complex<double>(A, B)
+#define cuConj                        conj
+#define cuCadd(A, B)                  (A + B)
+#define cuCsub(A, B)                  (A - B)
+#define cuCmul(A, B)                  (A * B)
+#define cuCdiv(A, B)                  (A / B)
+#define cuCabs                        abs
+#define cuComplexFloatToDouble        complex<double>
+#define cuCfma(A, B, C)               (A * B + C)

--- a/cupy/core/raw.pxd
+++ b/cupy/core/raw.pxd
@@ -18,3 +18,4 @@ cdef class RawModule:
         dict kernels
         readonly str backend
         object module
+        bint cuComplex

--- a/cupy/core/raw.pxd
+++ b/cupy/core/raw.pxd
@@ -6,6 +6,7 @@ cdef class RawKernel:
         readonly tuple options
         object _kernel
         readonly str backend
+        bint cuComplex
 
 
 cdef class RawModule:

--- a/cupy/core/raw.pxd
+++ b/cupy/core/raw.pxd
@@ -6,7 +6,7 @@ cdef class RawKernel:
         readonly tuple options
         object _kernel
         readonly str backend
-        bint cuComplex
+        bint translate_cucomplex
 
 
 cdef class RawModule:
@@ -18,4 +18,4 @@ cdef class RawModule:
         dict kernels
         readonly str backend
         object module
-        bint cuComplex
+        bint translate_cucomplex

--- a/cupy/core/raw.pyx
+++ b/cupy/core/raw.pyx
@@ -24,9 +24,12 @@ cdef class RawKernel:
         options (str): Compiler options passed to NVRTC. For details, see
             https://docs.nvidia.com/cuda/nvrtc/index.html#group__options.
         backend (str): Either `nvrtc` or `nvcc`. Defaults to `nvrtc`
+        enable_cuComplex (bool): Whether the CUDA source includes cuComplex.h
+            or not. Defaults to False.
     """
 
-    def __init__(self, code, name, options=(), backend='nvrtc'):
+    def __init__(self, code, name, options=(), backend='nvrtc',
+                 enable_cuComplex=False):
         if isinstance(code, six.binary_type):
             code = code.decode('UTF-8')
         if isinstance(name, six.binary_type):
@@ -38,6 +41,7 @@ cdef class RawKernel:
         self.options = options
         self._kernel = None
         self.backend = backend
+        self.cuComplex = enable_cuComplex
 
     def __call__(self, grid, block, args, **kwargs):
         """__call__(self, grid, block, args, *, shared_mem=0)
@@ -60,7 +64,7 @@ cdef class RawKernel:
     def kernel(self):
         if self._kernel is None:
             self._kernel = _get_raw_kernel(self.code, self.name, self.options,
-                                           self.backend)
+                                           self.backend, self.cuComplex)
         return self._kernel
 
     @property
@@ -183,9 +187,11 @@ cdef class RawKernel:
 
 
 @cupy.util.memoize(for_each_device=True)
-def _get_raw_kernel(code, name, options=(), backend='nvrtc'):
+def _get_raw_kernel(code, name, options=(), backend='nvrtc',
+                    enable_cuComplex=False):
     module = cupy.core.core.compile_with_cache(
-        code, options, prepend_cupy_headers=False, backend=backend)
+        code, options, prepend_cupy_headers=False, backend=backend,
+        enable_cuComplex=enable_cuComplex)
     return module.get_function(name)
 
 
@@ -210,11 +216,14 @@ cdef class RawModule:
             needed. For details, see
             https://docs.nvidia.com/cuda/nvrtc/index.html#group__options.
         backend (str): Either `nvrtc` or `nvcc`. Defaults to `nvrtc`
+        enable_cuComplex (bool): Whether the CUDA source includes cuComplex.h
+            or not. Defaults to False.
 
     .. note::
         Each kernel in ``RawModule`` possesses independent function attributes.
     """
-    def __init__(self, code_or_path, options=(), backend='nvrtc'):
+    def __init__(self, code_or_path, options=(), backend='nvrtc',
+                 enable_cuComplex=False):
         if isinstance(code_or_path, six.binary_type):
             code_or_path = code_or_path.decode('UTF-8')
         if isinstance(backend, six.binary_type):
@@ -231,7 +240,8 @@ cdef class RawModule:
 
         if self.code is not None:
             self.module = cupy.core.core.compile_with_cache(
-                code, options, prepend_cupy_headers=False, backend=backend)
+                code, options, prepend_cupy_headers=False, backend=backend,
+                enable_cuComplex=enable_cuComplex)
             self.backend = backend
         elif self.cubin_path is not None:
             self.module = Module()

--- a/cupy/core/raw.pyx
+++ b/cupy/core/raw.pyx
@@ -24,12 +24,12 @@ cdef class RawKernel:
         options (str): Compiler options passed to NVRTC. For details, see
             https://docs.nvidia.com/cuda/nvrtc/index.html#group__options.
         backend (str): Either `nvrtc` or `nvcc`. Defaults to `nvrtc`
-        enable_cuComplex (bool): Whether the CUDA source includes cuComplex.h
-            or not. Defaults to False.
+        translate_cucomplex (bool): Whether the CUDA source includes the
+            "cuComplex.h" header or not. Defaults to False.
     """
 
     def __init__(self, code, name, options=(), backend='nvrtc',
-                 enable_cuComplex=False):
+                 translate_cucomplex=False):
         if isinstance(code, six.binary_type):
             code = code.decode('UTF-8')
         if isinstance(name, six.binary_type):
@@ -41,7 +41,7 @@ cdef class RawKernel:
         self.options = options
         self._kernel = None
         self.backend = backend
-        self.cuComplex = enable_cuComplex
+        self.cuComplex = translate_cucomplex
 
     def __call__(self, grid, block, args, **kwargs):
         """__call__(self, grid, block, args, *, shared_mem=0)
@@ -188,10 +188,10 @@ cdef class RawKernel:
 
 @cupy.util.memoize(for_each_device=True)
 def _get_raw_kernel(code, name, options=(), backend='nvrtc',
-                    enable_cuComplex=False):
+                    translate_cucomplex=False):
     module = cupy.core.core.compile_with_cache(
         code, options, prepend_cupy_headers=False, backend=backend,
-        enable_cuComplex=enable_cuComplex)
+        translate_cucomplex=translate_cucomplex)
     return module.get_function(name)
 
 
@@ -216,14 +216,14 @@ cdef class RawModule:
             needed. For details, see
             https://docs.nvidia.com/cuda/nvrtc/index.html#group__options.
         backend (str): Either `nvrtc` or `nvcc`. Defaults to `nvrtc`
-        enable_cuComplex (bool): Whether the CUDA source includes cuComplex.h
-            or not. Defaults to False.
+        translate_cucomplex (bool): Whether the CUDA source includes the
+            "cuComplex.h" header or not. Defaults to False.
 
     .. note::
         Each kernel in ``RawModule`` possesses independent function attributes.
     """
     def __init__(self, code_or_path, options=(), backend='nvrtc',
-                 enable_cuComplex=False):
+                 translate_cucomplex=False):
         if isinstance(code_or_path, six.binary_type):
             code_or_path = code_or_path.decode('UTF-8')
         if isinstance(backend, six.binary_type):
@@ -241,7 +241,7 @@ cdef class RawModule:
         if self.code is not None:
             self.module = cupy.core.core.compile_with_cache(
                 code, options, prepend_cupy_headers=False, backend=backend,
-                enable_cuComplex=enable_cuComplex)
+                translate_cucomplex=translate_cucomplex)
             self.backend = backend
         elif self.cubin_path is not None:
             self.module = Module()
@@ -250,7 +250,7 @@ cdef class RawModule:
 
         self.options = options
         self.kernels = {}
-        self.cuComplex = enable_cuComplex
+        self.cuComplex = translate_cucomplex
 
     def get_function(self, name):
         """Retrieve a CUDA kernel by its name from the module.

--- a/cupy/core/raw.pyx
+++ b/cupy/core/raw.pyx
@@ -3,6 +3,8 @@ from cupy import util
 from cupy.cuda cimport driver
 from cupy.cuda.function cimport Module
 
+import six
+
 
 cdef class RawKernel:
 
@@ -28,8 +30,14 @@ cdef class RawKernel:
             counterpart. Defaults to ``False``.
     """
 
-    def __init__(self, code, name, options=(), backend='nvrtc', **kwargs):
-        translate_cucomplex = kwargs.get('translate_cucomplex', False)
+    def __init__(self, code, name, options=(), backend='nvrtc', *,
+                 translate_cucomplex=False):
+        if isinstance(code, six.binary_type):
+            code = code.decode('UTF-8')
+        if isinstance(name, six.binary_type):
+            name = name.decode('UTF-8')
+        if isinstance(backend, six.binary_type):
+            backend = backend.decode('UTF-8')
 
         self.code = code
         self.name = name
@@ -220,8 +228,12 @@ cdef class RawModule:
     .. note::
         Each kernel in ``RawModule`` possesses independent function attributes.
     """
-    def __init__(self, code_or_path, options=(), backend='nvrtc', **kwargs):
-        translate_cucomplex = kwargs.get('translate_cucomplex', False)
+    def __init__(self, code_or_path, options=(), backend='nvrtc', *,
+                 translate_cucomplex=False):
+        if isinstance(code_or_path, six.binary_type):
+            code_or_path = code_or_path.decode('UTF-8')
+        if isinstance(backend, six.binary_type):
+            backend = backend.decode('UTF-8')
 
         if code_or_path.endswith('.cubin'):
             path = code_or_path

--- a/cupy/core/raw.pyx
+++ b/cupy/core/raw.pyx
@@ -250,6 +250,7 @@ cdef class RawModule:
 
         self.options = options
         self.kernels = {}
+        self.cuComplex = enable_cuComplex
 
     def get_function(self, name):
         """Retrieve a CUDA kernel by its name from the module.
@@ -263,7 +264,8 @@ cdef class RawModule:
         if name in self.kernels:
             return self.kernels[name]
         else:
-            ker = RawKernel(None, name, self.options)
+            ker = RawKernel(None, name, self.options, self.backend,
+                            self.cuComplex)
             ker._kernel = self.module.get_function(name)
             self.kernels[name] = ker
             return ker

--- a/docs/source/tutorial/kernel.rst
+++ b/docs/source/tutorial/kernel.rst
@@ -254,7 +254,7 @@ Accessing texture memory in :class:`~cupy.RawKernel` is supported via CUDA Runti
     Especially note that when passing :class:`~cupy.ndarray`, its ``dtype`` should match with the type of the argument declared in the method signature of the CUDA source code (unless you are casting arrays intentionally).
     For example, ``cupy.float32`` and ``cupy.uint64`` arrays must be passed to the argument typed as ``float*`` and ``unsigned long long*``.
     For Python primitive types, ``int``, ``float`` and ``bool`` map to ``long long``, ``double`` and ``bool``, respectively.
-    To use complex types, the user must include ``<cupy/complex.cuh>`` as in the complex-valued example above; CUDA's complex-type header (`<cuComplex.h>`) does not work in CuPy.
+    To use complex types, the user must include ``<cupy/complex.cuh>`` as in the complex-valued example above; CUDA's complex-type header (``<cuComplex.h>``) does not work in CuPy.
 
 .. note::
     When using ``printf()`` in your CUDA kernel, you may need to synchronize the stream to see the output.

--- a/docs/source/tutorial/kernel.rst
+++ b/docs/source/tutorial/kernel.rst
@@ -197,6 +197,31 @@ In other words, you have control over grid size, block size, shared memory size 
           [30., 32., 34., 36., 38.],
           [40., 42., 44., 46., 48.]], dtype=float32)
 
+Raw kernels operating on complex-valued arrays can be created as well:
+
+.. doctest::
+
+   >>> complex_kernel = cp.RawKernel(r'''
+   ... #include <cupy/complex.cuh>
+   ... extern "C" __global__
+   ... void my_func(const complex<float>* x1, const complex<float>* x2,
+   ...              complex<float>* y, float a) {
+   ...     int tid = blockDim.x * blockIdx.x + threadIdx.x;
+   ...     y[tid] = x1[tid] + a * x2[tid];
+   ... }
+   ... ''', 'my_func')
+   >>> x1 = cupy.arange(25, dtype=cupy.complex64).reshape(5, 5)
+   >>> x2 = 1j*cupy.arange(25, dtype=cupy.complex64).reshape(5, 5)
+   >>> y = cupy.zeros((5, 5), dtype=cupy.complex64)
+   >>> complex_kernel((5,), (5,), (x1, x2, y, cupy.float32(2.0)))  # grid, block and arguments
+   >>> y
+   array([[ 0. +0.j,  1. +2.j,  2. +4.j,  3. +6.j,  4. +8.j],
+          [ 5.+10.j,  6.+12.j,  7.+14.j,  8.+16.j,  9.+18.j],
+          [10.+20.j, 11.+22.j, 12.+24.j, 13.+26.j, 14.+28.j],
+          [15.+30.j, 16.+32.j, 17.+34.j, 18.+36.j, 19.+38.j],
+          [20.+40.j, 21.+42.j, 22.+44.j, 23.+46.j, 24.+48.j]],
+         dtype=complex64)
+
 The CUDA kernel attributes can be retrieved by either accessing the :attr:`~cupy.RawKernel.attributes` dictionary,
 or by accessing the :class:`~cupy.RawKernel` object's attributes directly; the latter can also be used to set certain
 attributes:
@@ -229,6 +254,7 @@ Accessing texture memory in :class:`~cupy.RawKernel` is supported via CUDA Runti
     Especially note that when passing :class:`~cupy.ndarray`, its ``dtype`` should match with the type of the argument declared in the method signature of the CUDA source code (unless you are casting arrays intentionally).
     For example, ``cupy.float32`` and ``cupy.uint64`` arrays must be passed to the argument typed as ``float*`` and ``unsigned long long*``.
     For Python primitive types, ``int``, ``float`` and ``bool`` map to ``long long``, ``double`` and ``bool``, respectively.
+    To use complex types, the user must include ``<cupy/complex.cuh>`` as in the complex-valued example above.
 
 .. note::
     When using ``printf()`` in your CUDA kernel, you may need to synchronize the stream to see the output.

--- a/docs/source/tutorial/kernel.rst
+++ b/docs/source/tutorial/kernel.rst
@@ -254,7 +254,7 @@ Accessing texture memory in :class:`~cupy.RawKernel` is supported via CUDA Runti
     Especially note that when passing :class:`~cupy.ndarray`, its ``dtype`` should match with the type of the argument declared in the method signature of the CUDA source code (unless you are casting arrays intentionally).
     For example, ``cupy.float32`` and ``cupy.uint64`` arrays must be passed to the argument typed as ``float*`` and ``unsigned long long*``.
     For Python primitive types, ``int``, ``float`` and ``bool`` map to ``long long``, ``double`` and ``bool``, respectively.
-    To use complex types, the user must include ``<cupy/complex.cuh>`` as in the complex-valued example above.
+    To use complex types, the user must include ``<cupy/complex.cuh>`` as in the complex-valued example above; CUDA's complex-type header (`<cuComplex.h>`) does not work in CuPy.
 
 .. note::
     When using ``printf()`` in your CUDA kernel, you may need to synchronize the stream to see the output.

--- a/docs/source/tutorial/kernel.rst
+++ b/docs/source/tutorial/kernel.rst
@@ -222,6 +222,8 @@ Raw kernels operating on complex-valued arrays can be created as well:
           [20.+40.j, 21.+42.j, 22.+44.j, 23.+46.j, 24.+48.j]],
          dtype=complex64)
 
+Note that while we encourage the usage of ``complex<T>`` types for complex numbers (available by including ``<cupy/complex.cuh>`` as shown above), for CUDA codes already written using functions from ``cuComplex.h`` there is no need to make the conversion yourself: just set the option ``enable_cuComplex=True`` when creating a :class:`~cupy.RawKernel` instance.
+
 The CUDA kernel attributes can be retrieved by either accessing the :attr:`~cupy.RawKernel.attributes` dictionary,
 or by accessing the :class:`~cupy.RawKernel` object's attributes directly; the latter can also be used to set certain
 attributes:
@@ -254,7 +256,6 @@ Accessing texture memory in :class:`~cupy.RawKernel` is supported via CUDA Runti
     Especially note that when passing :class:`~cupy.ndarray`, its ``dtype`` should match with the type of the argument declared in the method signature of the CUDA source code (unless you are casting arrays intentionally).
     For example, ``cupy.float32`` and ``cupy.uint64`` arrays must be passed to the argument typed as ``float*`` and ``unsigned long long*``.
     For Python primitive types, ``int``, ``float`` and ``bool`` map to ``long long``, ``double`` and ``bool``, respectively.
-    To use complex types, the user must include ``<cupy/complex.cuh>`` as in the complex-valued example above; CUDA's complex-type header (``<cuComplex.h>``) does not work in CuPy.
 
 .. note::
     When using ``printf()`` in your CUDA kernel, you may need to synchronize the stream to see the output.
@@ -303,6 +304,8 @@ For dealing a large raw CUDA source or loading an existing CUDA binary, the :cla
     >>> assert cp.allclose(y, x1 + x2)
     >>> ker_times((N,), (N,), (x1, x2, y, N**2)) # y = x1 * x2
     >>> assert cp.allclose(y, x1 * x2)
+
+The instruction above for using complex numbers in :class:`~cupy.RawKernel` also applies to :class:`~cupy.RawModule`.
 
 CuPy also supports the Texture Reference API. A handle to the texture reference in a module can be retrieved by name via :meth:`~cupy.RawModule.get_texref`. Then, you need to pass it to :class:`~cupy.cuda.texture.TextureReference`, along with a resource descriptor and texture descriptor, for binding the reference to the array. (The interface of :class:`~cupy.cuda.texture.TextureReference` is meant to mimic that of :class:`~cupy.cuda.texture.TextureObject` to help users make transition to the latter, since as of CUDA Toolkit 10.1 the former is marked as deprecated.)
 

--- a/docs/source/tutorial/kernel.rst
+++ b/docs/source/tutorial/kernel.rst
@@ -222,7 +222,7 @@ Raw kernels operating on complex-valued arrays can be created as well:
           [20.+40.j, 21.+42.j, 22.+44.j, 23.+46.j, 24.+48.j]],
          dtype=complex64)
 
-Note that while we encourage the usage of ``complex<T>`` types for complex numbers (available by including ``<cupy/complex.cuh>`` as shown above), for CUDA codes already written using functions from ``cuComplex.h`` there is no need to make the conversion yourself: just set the option ``enable_cuComplex=True`` when creating a :class:`~cupy.RawKernel` instance.
+Note that while we encourage the usage of ``complex<T>`` types for complex numbers (available by including ``<cupy/complex.cuh>`` as shown above), for CUDA codes already written using functions from ``cuComplex.h`` there is no need to make the conversion yourself: just set the option ``translate_cucomplex=True`` when creating a :class:`~cupy.RawKernel` instance.
 
 The CUDA kernel attributes can be retrieved by either accessing the :attr:`~cupy.RawKernel.attributes` dictionary,
 or by accessing the :class:`~cupy.RawKernel` object's attributes directly; the latter can also be used to set certain

--- a/tests/cupy_tests/core_tests/test_raw.py
+++ b/tests/cupy_tests/core_tests/test_raw.py
@@ -260,7 +260,7 @@ class TestRaw(unittest.TestCase):
         grid = (N + block - 1) // block
         dtype = cupy.complex64
 
-        mod = cupy.RawModule(_test_cuComplex, enable_cuComplex=True)
+        mod = cupy.RawModule(_test_cuComplex, translate_cucomplex=True)
         a = cupy.random.random((N,)) + 1j*cupy.random.random((N,))
         a = a.astype(dtype)
         b = cupy.random.random((N,)) + 1j*cupy.random.random((N,))
@@ -288,7 +288,7 @@ class TestRaw(unittest.TestCase):
         grid = (N + block - 1) // block
         dtype = cupy.complex128
 
-        mod = cupy.RawModule(_test_cuComplex, enable_cuComplex=True)
+        mod = cupy.RawModule(_test_cuComplex, translate_cucomplex=True)
         a = cupy.random.random((N,)) + 1j*cupy.random.random((N,))
         a = a.astype(dtype)
         b = cupy.random.random((N,)) + 1j*cupy.random.random((N,))


### PR DESCRIPTION
Closes #1866. Closes #2111.

Previously the support of complex numbers in `cupy.RawKernel` (and thus `cupy.RawModule`) was poorly documented, see https://github.com/cupy/cupy/pull/1866#issuecomment-457791608 and #2111 for example. This PR aims to solve this problem once and for all. This PR supersedes #1866.

The support of the APIs from `cuComplex.h` is enabled by prepending a set of C macros that replace those APIs by their Thrust counterparts. Thus, users can just copy and paste their `cuComplex`-based codes to `cupy.RawKernel` or `cupy.RawModule`, and make them work without any modification. Note that the complex mathematical functions are supported without any additional macros.

For backward compatibility, the newly added option `enable_cuComplex` is set to `False` by default.

attn: @grlee77 