### PR TITLE
Support stream in CUB

### DIFF
--- a/cupy/cuda/cupy_cub.cu
+++ b/cupy/cuda/cupy_cub.cu
@@ -74,24 +74,25 @@ void dtype_dispatcher(int dtype_id, functor_t f, Ts&&... args)
 struct _cub_reduce_sum {
     template <typename T>
     void operator()(void *x, void *y, int num_items, void *workspace,
-		    size_t &workspace_size) {
-	DeviceReduce::Sum(workspace, workspace_size, static_cast<T*>(x),
-			  static_cast<T*>(y), num_items);
+        size_t &workspace_size, cudaStream_t s)
+    {
+        DeviceReduce::Sum(workspace, workspace_size, static_cast<T*>(x),
+            static_cast<T*>(y), num_items, s);
     }
 };
 
-void cub_reduce_sum(void *x, void *y, int num_items,
-		    void *workspace, size_t &workspace_size, int dtype_id)
+void cub_reduce_sum(void *x, void *y, int num_items, void *workspace,
+    size_t &workspace_size, cudaStream_t stream, int dtype_id)
 {
     dtype_dispatcher(dtype_id, _cub_reduce_sum(),
-		     x, y, num_items, workspace, workspace_size);
+        x, y, num_items, workspace, workspace_size, stream);
 }
 
 size_t cub_reduce_sum_get_workspace_size(void *x, void *y, int num_items,
-					 int dtype_id)
+    cudaStream_t stream, int dtype_id)
 {
     size_t workspace_size = 0;
-    cub_reduce_sum(x, y, num_items, NULL, workspace_size, dtype_id);
+    cub_reduce_sum(x, y, num_items, NULL, workspace_size, stream, dtype_id);
     return workspace_size;
 }
 
@@ -101,24 +102,25 @@ size_t cub_reduce_sum_get_workspace_size(void *x, void *y, int num_items,
 struct _cub_reduce_min {
     template <typename T>
     void operator()(void *x, void *y, int num_items, void *workspace,
-		    size_t &workspace_size) {
-	DeviceReduce::Min(workspace, workspace_size, static_cast<T*>(x),
-			  static_cast<T*>(y), num_items);
+        size_t &workspace_size, cudaStream_t s)
+    {
+        DeviceReduce::Min(workspace, workspace_size, static_cast<T*>(x),
+            static_cast<T*>(y), num_items, s);
     }
 };
 
-void cub_reduce_min(void *x, void *y, int num_items,
-		    void *workspace, size_t &workspace_size, int dtype_id)
+void cub_reduce_min(void *x, void *y, int num_items, void *workspace,
+    size_t &workspace_size, cudaStream_t stream, int dtype_id)
 {
     dtype_dispatcher(dtype_id, _cub_reduce_min(),
-		     x, y, num_items, workspace, workspace_size);
+        x, y, num_items, workspace, workspace_size, stream);
 }
 
 size_t cub_reduce_min_get_workspace_size(void *x, void *y, int num_items,
-					 int dtype_id)
+    cudaStream_t stream, int dtype_id)
 {
     size_t workspace_size = 0;
-    cub_reduce_min(x, y, num_items, NULL, workspace_size, dtype_id);
+    cub_reduce_min(x, y, num_items, NULL, workspace_size, stream, dtype_id);
     return workspace_size;
 }
 
@@ -128,23 +130,24 @@ size_t cub_reduce_min_get_workspace_size(void *x, void *y, int num_items,
 struct _cub_reduce_max {
     template <typename T>
     void operator()(void *x, void *y, int num_items, void *workspace,
-		    size_t &workspace_size) {
-	DeviceReduce::Max(workspace, workspace_size, static_cast<T*>(x),
-			  static_cast<T*>(y), num_items);
+        size_t &workspace_size, cudaStream_t s)
+    {
+        DeviceReduce::Max(workspace, workspace_size, static_cast<T*>(x),
+            static_cast<T*>(y), num_items, s);
     }
 };
 
-void cub_reduce_max(void *x, void *y, int num_items,
-		    void *workspace, size_t &workspace_size, int dtype_id)
+void cub_reduce_max(void *x, void *y, int num_items, void *workspace,
+    size_t &workspace_size, cudaStream_t stream, int dtype_id)
 {
     dtype_dispatcher(dtype_id, _cub_reduce_max(),
-		     x, y, num_items, workspace, workspace_size);
+        x, y, num_items, workspace, workspace_size, stream);
 }
 
 size_t cub_reduce_max_get_workspace_size(void *x, void *y, int num_items,
-					 int dtype_id)
+    cudaStream_t stream, int dtype_id)
 {
     size_t workspace_size = 0;
-    cub_reduce_max(x, y, num_items, NULL, workspace_size, dtype_id);
+    cub_reduce_max(x, y, num_items, NULL, workspace_size, stream, dtype_id);
     return workspace_size;
 }

--- a/cupy/cuda/cupy_cub.h
+++ b/cupy/cuda/cupy_cub.h
@@ -1,6 +1,7 @@
 #ifndef INCLUDE_GUARD_CUPY_CUDA_CUB_H
 #define INCLUDE_GUARD_CUPY_CUDA_CUB_H
 
+#include <cuda_runtime.h>  // for cudaStream_t
 #define CUPY_CUB_INT8        0
 #define CUPY_CUB_UINT8       1
 #define CUPY_CUB_INT16       2
@@ -16,7 +17,6 @@
 #define CUPY_CUB_COMPLEX128 12
 
 #ifndef CUPY_NO_CUDA
-#include <cuda_runtime.h>  // for cudaStream_t
 
 void cub_reduce_sum(void *, void *, int, void *, size_t &, cudaStream_t, int);
 void cub_reduce_min(void *, void *, int, void *, size_t &, cudaStream_t, int);

--- a/cupy/cuda/cupy_cub.h
+++ b/cupy/cuda/cupy_cub.h
@@ -1,7 +1,6 @@
 #ifndef INCLUDE_GUARD_CUPY_CUDA_CUB_H
 #define INCLUDE_GUARD_CUPY_CUDA_CUB_H
 
-#include <cuda_runtime.h>  // for cudaStream_t
 #define CUPY_CUB_INT8        0
 #define CUPY_CUB_UINT8       1
 #define CUPY_CUB_INT16       2
@@ -17,6 +16,7 @@
 #define CUPY_CUB_COMPLEX128 12
 
 #ifndef CUPY_NO_CUDA
+#include <cuda_runtime.h>  // for cudaStream_t
 
 void cub_reduce_sum(void *, void *, int, void *, size_t &, cudaStream_t, int);
 void cub_reduce_min(void *, void *, int, void *, size_t &, cudaStream_t, int);
@@ -27,6 +27,7 @@ size_t cub_reduce_min_get_workspace_size(void *, void *, int, cudaStream_t, int)
 size_t cub_reduce_max_get_workspace_size(void *, void *, int, cudaStream_t, int);
 
 #else // CUPY_NO_CUDA
+typedef struct CUstream_st *cudaStream_t;
 
 void cub_reduce_sum(...) {
 }

--- a/cupy/cuda/cupy_cub.h
+++ b/cupy/cuda/cupy_cub.h
@@ -16,38 +16,36 @@
 #define CUPY_CUB_COMPLEX128 12
 
 #ifndef CUPY_NO_CUDA
+#include <cuda_runtime.h>  // for cudaStream_t
 
-void cub_reduce_sum(void *, void *, int, void *, size_t &, int);
-void cub_reduce_min(void *, void *, int, void *, size_t &, int);
-void cub_reduce_max(void *, void *, int, void *, size_t &, int);
+void cub_reduce_sum(void *, void *, int, void *, size_t &, cudaStream_t, int);
+void cub_reduce_min(void *, void *, int, void *, size_t &, cudaStream_t, int);
+void cub_reduce_max(void *, void *, int, void *, size_t &, cudaStream_t, int);
 
-size_t cub_reduce_sum_get_workspace_size(void *, void *, int, int);
-size_t cub_reduce_min_get_workspace_size(void *, void *, int, int);
-size_t cub_reduce_max_get_workspace_size(void *, void *, int, int);
+size_t cub_reduce_sum_get_workspace_size(void *, void *, int, cudaStream_t, int);
+size_t cub_reduce_min_get_workspace_size(void *, void *, int, cudaStream_t, int);
+size_t cub_reduce_max_get_workspace_size(void *, void *, int, cudaStream_t, int);
 
 #else // CUPY_NO_CUDA
 
-void cub_reduce_sum(void *, void *, int, void *, size_t &, int) {
-    return;
+void cub_reduce_sum(...) {
 }
 
-void cub_reduce_min(void *, void *, int, void *, size_t &, int) {
-    return;
+void cub_reduce_min(...) {
 }
 
-void cub_reduce_max(void *, void *, int, void *, size_t &, int) {
-    return;
+void cub_reduce_max(...) {
 }
 
-size_t cub_reduce_sum_get_workspace_size(void *, void *, int, int) {
+size_t cub_reduce_sum_get_workspace_size(...) {
     return 0;
 }
 
-size_t cub_reduce_min_get_workspace_size(void *, void *, int, int) {
+size_t cub_reduce_min_get_workspace_size(...) {
     return 0;
 }
 
-size_t cub_reduce_max_get_workspace_size(void *, void *, int, int) {
+size_t cub_reduce_max_get_workspace_size(...) {
     return 0;
 }
 


### PR DESCRIPTION
This now works (can be verified by nvvp):
```python
import cupy as cp

dtype = cp.complex128
shape = (200, 1000, 1000)
x = cp.random.random(shape).astype(dtype) \
    +1j*cp.random.random(shape).astype(dtype)

stream = cp.cuda.Stream()
with stream:
    y = x.sum()  # runs on "stream" instead of the default stream
```