### PR TITLE
Add CUDA API runtime API list

### DIFF
--- a/docs/source/reference/cuda.rst
+++ b/docs/source/reference/cuda.rst
@@ -103,3 +103,71 @@ NCCL
    cupy.cuda.nccl.get_unique_id
    cupy.cuda.nccl.groupStart
    cupy.cuda.nccl.groupEnd
+
+
+Runtime API
+-----------
+
+CuPy wraps CUDA Runtime APIs to provide native CUDA operation.
+Please check `Original CUDA Runtime document <<https://docs.nvidia.com/cuda/cuda-runtime-api/index.html>`_
+to use these functions.
+
+
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+
+   cupy.cuda.runtime.driverGetVersion
+   cupy.cuda.runtime.runtimeGetVersion
+   cupy.cuda.runtime.getDevice
+   cupy.cuda.runtime.deviceGetAttribute
+   cupy.cuda.runtime.deviceGetByPCIBusId
+   cupy.cuda.runtime.deviceGetPCIBusId
+   cupy.cuda.runtime.getDeviceCount
+   cupy.cuda.runtime.setDevice
+   cupy.cuda.runtime.deviceSynchronize
+   cupy.cuda.runtime.deviceCanAccessPeer
+   cupy.cuda.runtime.deviceEnablePeerAccess
+   cupy.cuda.runtime.malloc
+   cupy.cuda.runtime.mallocManaged
+   cupy.cuda.runtime.malloc3DArray
+   cupy.cuda.runtime.mallocArray
+   cupy.cuda.runtime.hostAlloc
+   cupy.cuda.runtime.hostRegister
+   cupy.cuda.runtime.hostUnregister
+   cupy.cuda.runtime.free
+   cupy.cuda.runtime.freeHost
+   cupy.cuda.runtime.freeArray
+   cupy.cuda.runtime.memGetInfo
+   cupy.cuda.runtime.memcpy
+   cupy.cuda.runtime.memcpyAsync
+   cupy.cuda.runtime.memcpyPeer
+   cupy.cuda.runtime.memcpyPeerAsync
+   cupy.cuda.runtime.memcpy2D
+   cupy.cuda.runtime.memcpy2DAsync
+   cupy.cuda.runtime.memcpy2DFromArray
+   cupy.cuda.runtime.memcpy2DFromArrayAsync
+   cupy.cuda.runtime.memcpy2DToArray
+   cupy.cuda.runtime.memcpy2DToArrayAsync
+   cupy.cuda.runtime.memcpy3D
+   cupy.cuda.runtime.memcpy3DAsync
+   cupy.cuda.runtime.memset
+   cupy.cuda.runtime.memsetAsync
+   cupy.cuda.runtime.memPrefetchAsync
+   cupy.cuda.runtime.memAdvise
+   cupy.cuda.runtime.pointerGetAttributes
+   cupy.cuda.runtime.streamCreate
+   cupy.cuda.runtime.streamCreateWithFlags
+   cupy.cuda.runtime.streamDestroy
+   cupy.cuda.runtime.streamSynchronize
+   cupy.cuda.runtime.streamAddCallback
+   cupy.cuda.runtime.streamQuery
+   cupy.cuda.runtime.streamWaitEvent
+   cupy.cuda.runtime.eventCreate
+   cupy.cuda.runtime.eventCreateWithFlags
+   cupy.cuda.runtime.eventDestroy
+   cupy.cuda.runtime.eventElapsedTime
+   cupy.cuda.runtime.eventQuery
+   cupy.cuda.runtime.eventRecord
+   cupy.cuda.runtime.eventSynchronize

--- a/docs/source/reference/cuda.rst
+++ b/docs/source/reference/cuda.rst
@@ -108,7 +108,7 @@ NCCL
 Runtime API
 -----------
 
-CuPy wraps CUDA Runtime APIs to provide native CUDA operation.
+CuPy wraps CUDA Runtime APIs to provide the native CUDA operations.
 Please check `Original CUDA Runtime document <<https://docs.nvidia.com/cuda/cuda-runtime-api/index.html>`_
 to use these functions.
 

--- a/docs/source/reference/cuda.rst
+++ b/docs/source/reference/cuda.rst
@@ -109,7 +109,7 @@ Runtime API
 -----------
 
 CuPy wraps CUDA Runtime APIs to provide the native CUDA operations.
-Please check `Original CUDA Runtime document <<https://docs.nvidia.com/cuda/cuda-runtime-api/index.html>`_
+Please check the `Original CUDA Runtime API document <https://docs.nvidia.com/cuda/cuda-runtime-api/index.html>`_
 to use these functions.
 
 


### PR DESCRIPTION
Fix #1956.

CuPy wraps CUDA runtime API. But it is not documented yet.
