### PR TITLE
Remove redundant definitions in `cupy_cufft.h`

### DIFF
--- a/cupy/cuda/cupy_cufft.h
+++ b/cupy/cuda/cupy_cufft.h
@@ -14,14 +14,8 @@ extern "C" {
 
 typedef float cufftReal;
 typedef double cufftDoubleReal;
-
-struct cufftComplex{
-    float x, y;
-};
-
-struct cufftDoubleComplex{
-    double x, y;
-};
+typedef cuComplex cufftComplex;
+typedef cuDoubleComplex cufftDoubleComplex;
 
 typedef enum {
     CUFFT_SUCCESS = 0,


### PR DESCRIPTION
Complex numbers are defined in `cupy_cuComplex.h`, which gets included in `cupy_cuda.h`. We should just take advantage of the existing ones.