### PR TITLE
Use `!=` instead of `is not`  for literal

### DIFF
--- a/install/build.py
+++ b/install/build.py
@@ -37,7 +37,7 @@ def get_rocm_path():
 
     # Use a magic word to represent the cache not filled because None is a
     # valid return value.
-    if _rocm_path is not 'NOT_INITIALIZED':
+    if _rocm_path != 'NOT_INITIALIZED':
         return _rocm_path
 
     _rocm_path = os.environ.get('ROCM_HOME', '')


### PR DESCRIPTION
See this commit for the same fix at another line https://github.com/cupy/cupy/commit/c3f11da8405440a563b86f828b689cc0a49b73bd