### PR TITLE
Refactor CUB to support an explicit `axis` argument; Fix alignments for Thrust's complex types

### DIFF
--- a/cupy/core/_routines_math.pyx
+++ b/cupy/core/_routines_math.pyx
@@ -74,10 +74,10 @@ cdef ndarray _ndarray_prod(ndarray self, axis, dtype, out, keepdims):
 
 cdef ndarray _ndarray_sum(ndarray self, axis, dtype, out, keepdims):
     if cupy.cuda.cub_enabled:
-        if cub.can_use_reduce_sum_min_max(
-            self.dtype, self.ndim, cub.CUPY_CUB_SUM, dtype, axis):
-            return cub.reduce_sum_min_max(self, cub.CUPY_CUB_SUM,
-                                          out=out, keepdims=keepdims)
+        if cub.can_use_device_reduce(self.dtype, self.ndim, cub.CUPY_CUB_SUM,
+                                     dtype, axis):
+            return cub.device_reduce(self, cub.CUPY_CUB_SUM, out=out,
+                                     keepdims=keepdims)
     if dtype is None:
         return _sum_auto_dtype(self, axis, dtype, out, keepdims)
     else:

--- a/cupy/core/_routines_math.pyx
+++ b/cupy/core/_routines_math.pyx
@@ -76,8 +76,15 @@ cdef ndarray _ndarray_sum(ndarray self, axis, dtype, out, keepdims):
     if cupy.cuda.cub_enabled:
         if cub.can_use_device_reduce(self.dtype, self.ndim, cub.CUPY_CUB_SUM,
                                      dtype, axis):
+            print("using device_reduce!")
             return cub.device_reduce(self, cub.CUPY_CUB_SUM, out=out,
                                      keepdims=keepdims)
+        elif cub.can_use_device_segmented_reduce(self.dtype, cub.CUPY_CUB_SUM,
+                                                 dtype):
+            print("using device_segmented_reduce!")
+            return cub.device_segmented_reduce(
+                       self, cub.CUPY_CUB_SUM, axis, out=out,
+                       keepdims=keepdims)
     if dtype is None:
         return _sum_auto_dtype(self, axis, dtype, out, keepdims)
     else:

--- a/cupy/core/_routines_math.pyx
+++ b/cupy/core/_routines_math.pyx
@@ -76,12 +76,10 @@ cdef ndarray _ndarray_sum(ndarray self, axis, dtype, out, keepdims):
     if cupy.cuda.cub_enabled:
         if cub.can_use_device_reduce(self.dtype, self.ndim, cub.CUPY_CUB_SUM,
                                      dtype, axis):
-            print("using device_reduce!")
             return cub.device_reduce(self, cub.CUPY_CUB_SUM, out=out,
                                      keepdims=keepdims)
         elif cub.can_use_device_segmented_reduce(self.dtype, cub.CUPY_CUB_SUM,
                                                  dtype):
-            print("using device_segmented_reduce!")
             return cub.device_segmented_reduce(
                        self, cub.CUPY_CUB_SUM, axis, out=out,
                        keepdims=keepdims)

--- a/cupy/core/_routines_math.pyx
+++ b/cupy/core/_routines_math.pyx
@@ -74,8 +74,10 @@ cdef ndarray _ndarray_prod(ndarray self, axis, dtype, out, keepdims):
 
 cdef ndarray _ndarray_sum(ndarray self, axis, dtype, out, keepdims):
     if cupy.cuda.cub_enabled:
-        if cub.can_use_reduce_sum(self.dtype, self.ndim, dtype, axis):
-            return cub.reduce_sum(self, out=out, keepdims=keepdims)
+        if cub.can_use_reduce_sum_min_max(
+            self.dtype, self.ndim, cub.CUPY_CUB_SUM, dtype, axis):
+            return cub.reduce_sum_min_max(self, cub.CUPY_CUB_SUM,
+                                          out=out, keepdims=keepdims)
     if dtype is None:
         return _sum_auto_dtype(self, axis, dtype, out, keepdims)
     else:

--- a/cupy/core/_routines_math.pyx
+++ b/cupy/core/_routines_math.pyx
@@ -89,8 +89,7 @@ cdef ndarray _ndarray_sum(ndarray self, axis, dtype, out, keepdims):
                               " internal reduction routine and compare the "
                               "timings.", util.PerformanceWarning)
             return cub.device_segmented_reduce(
-                       self, cub.CUPY_CUB_SUM, axis, out=out,
-                       keepdims=keepdims)
+                self, cub.CUPY_CUB_SUM, axis, out=out, keepdims=keepdims)
     if dtype is None:
         return _sum_auto_dtype(self, axis, dtype, out, keepdims)
     else:

--- a/cupy/core/_routines_math.pyx
+++ b/cupy/core/_routines_math.pyx
@@ -15,8 +15,6 @@ from cupy.core.core cimport compile_with_cache
 from cupy.core.core cimport ndarray
 
 if cupy.cuda.cub_enabled:
-    import warnings
-    from cupy import util
     from cupy.cuda import cub
 
 
@@ -82,12 +80,6 @@ cdef ndarray _ndarray_sum(ndarray self, axis, dtype, out, keepdims):
                                      keepdims=keepdims)
         elif cub.can_use_device_segmented_reduce(
                 cub.CUPY_CUB_SUM, self.dtype, self.ndim, axis, dtype):
-            if self.dtype in (numpy.complex64, numpy.complex128):
-                warnings.warn("CUB reduction for complex numbers may not be "
-                              "highly performant. If concerned, set "
-                              "cupy.cuda.cub_enabled=False to switch to CuPy's"
-                              " internal reduction routine and compare the "
-                              "timings.", util.PerformanceWarning)
             return cub.device_segmented_reduce(
                 self, cub.CUPY_CUB_SUM, axis, out=out, keepdims=keepdims)
     if dtype is None:

--- a/cupy/core/_routines_statistics.pyx
+++ b/cupy/core/_routines_statistics.pyx
@@ -13,19 +13,19 @@ if cupy.cuda.cub_enabled:
 
 cdef ndarray _ndarray_max(ndarray self, axis, out, dtype, keepdims):
     if cupy.cuda.cub_enabled:
-        if cub.can_use_reduce_sum_min_max(
-            self.dtype, self.ndim, cub.CUPY_CUB_MAX, dtype, axis):
-            return cub.reduce_sum_min_max(self, cub.CUPY_CUB_MAX,
-                                          out=out, keepdims=keepdims)
+        if cub.can_use_device_reduce(self.dtype, self.ndim, cub.CUPY_CUB_MAX,
+                                     dtype, axis):
+            return cub.device_reduce(self, cub.CUPY_CUB_MAX, out=out,
+                                     keepdims=keepdims)
     return _amax(self, axis=axis, out=out, dtype=dtype, keepdims=keepdims)
 
 
 cdef ndarray _ndarray_min(ndarray self, axis, out, dtype, keepdims):
     if cupy.cuda.cub_enabled:
-        if cub.can_use_reduce_sum_min_max(
-            self.dtype, self.ndim, cub.CUPY_CUB_MIN, dtype, axis):
-            return cub.reduce_sum_min_max(self, cub.CUPY_CUB_MIN,
-                                          out=out, keepdims=keepdims)
+        if cub.can_use_device_reduce(self.dtype, self.ndim, cub.CUPY_CUB_MIN,
+                                     dtype, axis):
+            return cub.device_reduce(self, cub.CUPY_CUB_MIN, out=out,
+                                     keepdims=keepdims)
     return _amin(self, axis=axis, out=out, dtype=dtype, keepdims=keepdims)
 
 

--- a/cupy/core/_routines_statistics.pyx
+++ b/cupy/core/_routines_statistics.pyx
@@ -8,17 +8,25 @@ from cupy.core.core cimport ndarray
 
 import cupy
 if cupy.cuda.cub_enabled:
+    import warnings
+    from cupy import util
     from cupy.cuda import cub
 
 
 cdef ndarray _ndarray_max(ndarray self, axis, out, dtype, keepdims):
     if cupy.cuda.cub_enabled:
-        if cub.can_use_device_reduce(self.dtype, self.ndim, cub.CUPY_CUB_MAX,
-                                     dtype, axis):
+        if cub.can_use_device_reduce(cub.CUPY_CUB_MAX, self.dtype, self.ndim,
+                                     axis, dtype):
             return cub.device_reduce(self, cub.CUPY_CUB_MAX, out=out,
                                      keepdims=keepdims)
-        elif cub.can_use_device_segmented_reduce(self.dtype, cub.CUPY_CUB_MAX,
-                                                 dtype):
+        elif cub.can_use_device_segmented_reduce(
+                cub.CUPY_CUB_MAX, self.dtype, self.ndim, axis, dtype):
+            if self.dtype in (numpy.complex64, numpy.complex128):
+                warnings.warn("CUB reduction for complex numbers may not be "
+                              "highly performant. If concerned, set "
+                              "cupy.cuda.cub_enabled=False to switch to CuPy's"
+                              " internal reduction routine and compare the "
+                              "timings.", util.PerformanceWarning)
             return cub.device_segmented_reduce(
                        self, cub.CUPY_CUB_MAX, axis, out=out,
                        keepdims=keepdims)
@@ -27,12 +35,18 @@ cdef ndarray _ndarray_max(ndarray self, axis, out, dtype, keepdims):
 
 cdef ndarray _ndarray_min(ndarray self, axis, out, dtype, keepdims):
     if cupy.cuda.cub_enabled:
-        if cub.can_use_device_reduce(self.dtype, self.ndim, cub.CUPY_CUB_MIN,
-                                     dtype, axis):
+        if cub.can_use_device_reduce(cub.CUPY_CUB_MIN, self.dtype, self.ndim,
+                                     axis, dtype):
             return cub.device_reduce(self, cub.CUPY_CUB_MIN, out=out,
                                      keepdims=keepdims)
-        elif cub.can_use_device_segmented_reduce(self.dtype, cub.CUPY_CUB_MIN,
-                                                 dtype):
+        elif cub.can_use_device_segmented_reduce(
+                cub.CUPY_CUB_MIN, self.dtype, self.ndim, axis, dtype):
+            if self.dtype in (numpy.complex64, numpy.complex128):
+                warnings.warn("CUB reduction for complex numbers may not be "
+                              "highly performant. If concerned, set "
+                              "cupy.cuda.cub_enabled=False to switch to CuPy's"
+                              " internal reduction routine and compare the "
+                              "timings.", util.PerformanceWarning)
             return cub.device_segmented_reduce(
                        self, cub.CUPY_CUB_MIN, axis, out=out,
                        keepdims=keepdims)

--- a/cupy/core/_routines_statistics.pyx
+++ b/cupy/core/_routines_statistics.pyx
@@ -28,8 +28,7 @@ cdef ndarray _ndarray_max(ndarray self, axis, out, dtype, keepdims):
                               " internal reduction routine and compare the "
                               "timings.", util.PerformanceWarning)
             return cub.device_segmented_reduce(
-                       self, cub.CUPY_CUB_MAX, axis, out=out,
-                       keepdims=keepdims)
+                self, cub.CUPY_CUB_MAX, axis, out=out, keepdims=keepdims)
     return _amax(self, axis=axis, out=out, dtype=dtype, keepdims=keepdims)
 
 
@@ -48,8 +47,7 @@ cdef ndarray _ndarray_min(ndarray self, axis, out, dtype, keepdims):
                               " internal reduction routine and compare the "
                               "timings.", util.PerformanceWarning)
             return cub.device_segmented_reduce(
-                       self, cub.CUPY_CUB_MIN, axis, out=out,
-                       keepdims=keepdims)
+                self, cub.CUPY_CUB_MIN, axis, out=out, keepdims=keepdims)
     return _amin(self, axis=axis, out=out, dtype=dtype, keepdims=keepdims)
 
 

--- a/cupy/core/_routines_statistics.pyx
+++ b/cupy/core/_routines_statistics.pyx
@@ -17,6 +17,11 @@ cdef ndarray _ndarray_max(ndarray self, axis, out, dtype, keepdims):
                                      dtype, axis):
             return cub.device_reduce(self, cub.CUPY_CUB_MAX, out=out,
                                      keepdims=keepdims)
+        elif cub.can_use_device_segmented_reduce(self.dtype, cub.CUPY_CUB_MAX,
+                                                 dtype):
+            return cub.device_segmented_reduce(
+                       self, cub.CUPY_CUB_MAX, axis, out=out,
+                       keepdims=keepdims)
     return _amax(self, axis=axis, out=out, dtype=dtype, keepdims=keepdims)
 
 
@@ -26,6 +31,11 @@ cdef ndarray _ndarray_min(ndarray self, axis, out, dtype, keepdims):
                                      dtype, axis):
             return cub.device_reduce(self, cub.CUPY_CUB_MIN, out=out,
                                      keepdims=keepdims)
+        elif cub.can_use_device_segmented_reduce(self.dtype, cub.CUPY_CUB_MIN,
+                                                 dtype):
+            return cub.device_segmented_reduce(
+                       self, cub.CUPY_CUB_MIN, axis, out=out,
+                       keepdims=keepdims)
     return _amin(self, axis=axis, out=out, dtype=dtype, keepdims=keepdims)
 
 

--- a/cupy/core/_routines_statistics.pyx
+++ b/cupy/core/_routines_statistics.pyx
@@ -13,15 +13,19 @@ if cupy.cuda.cub_enabled:
 
 cdef ndarray _ndarray_max(ndarray self, axis, out, dtype, keepdims):
     if cupy.cuda.cub_enabled:
-        if cub.can_use_reduce_max(self.dtype, self.ndim, dtype, axis):
-            return cub.reduce_max(self, out=out, keepdims=keepdims)
+        if cub.can_use_reduce_sum_min_max(
+            self.dtype, self.ndim, cub.CUPY_CUB_MAX, dtype, axis):
+            return cub.reduce_sum_min_max(self, cub.CUPY_CUB_MAX,
+                                          out=out, keepdims=keepdims)
     return _amax(self, axis=axis, out=out, dtype=dtype, keepdims=keepdims)
 
 
 cdef ndarray _ndarray_min(ndarray self, axis, out, dtype, keepdims):
     if cupy.cuda.cub_enabled:
-        if cub.can_use_reduce_min(self.dtype, self.ndim, dtype, axis):
-            return cub.reduce_min(self, out=out, keepdims=keepdims)
+        if cub.can_use_reduce_sum_min_max(
+            self.dtype, self.ndim, cub.CUPY_CUB_MIN, dtype, axis):
+            return cub.reduce_sum_min_max(self, cub.CUPY_CUB_MIN,
+                                          out=out, keepdims=keepdims)
     return _amin(self, axis=axis, out=out, dtype=dtype, keepdims=keepdims)
 
 

--- a/cupy/core/_routines_statistics.pyx
+++ b/cupy/core/_routines_statistics.pyx
@@ -8,8 +8,6 @@ from cupy.core.core cimport ndarray
 
 import cupy
 if cupy.cuda.cub_enabled:
-    import warnings
-    from cupy import util
     from cupy.cuda import cub
 
 
@@ -21,12 +19,6 @@ cdef ndarray _ndarray_max(ndarray self, axis, out, dtype, keepdims):
                                      keepdims=keepdims)
         elif cub.can_use_device_segmented_reduce(
                 cub.CUPY_CUB_MAX, self.dtype, self.ndim, axis, dtype):
-            if self.dtype in (numpy.complex64, numpy.complex128):
-                warnings.warn("CUB reduction for complex numbers may not be "
-                              "highly performant. If concerned, set "
-                              "cupy.cuda.cub_enabled=False to switch to CuPy's"
-                              " internal reduction routine and compare the "
-                              "timings.", util.PerformanceWarning)
             return cub.device_segmented_reduce(
                 self, cub.CUPY_CUB_MAX, axis, out=out, keepdims=keepdims)
     return _amax(self, axis=axis, out=out, dtype=dtype, keepdims=keepdims)
@@ -40,12 +32,6 @@ cdef ndarray _ndarray_min(ndarray self, axis, out, dtype, keepdims):
                                      keepdims=keepdims)
         elif cub.can_use_device_segmented_reduce(
                 cub.CUPY_CUB_MIN, self.dtype, self.ndim, axis, dtype):
-            if self.dtype in (numpy.complex64, numpy.complex128):
-                warnings.warn("CUB reduction for complex numbers may not be "
-                              "highly performant. If concerned, set "
-                              "cupy.cuda.cub_enabled=False to switch to CuPy's"
-                              " internal reduction routine and compare the "
-                              "timings.", util.PerformanceWarning)
             return cub.device_segmented_reduce(
                 self, cub.CUPY_CUB_MIN, axis, out=out, keepdims=keepdims)
     return _amin(self, axis=axis, out=out, dtype=dtype, keepdims=keepdims)

--- a/cupy/core/include/cupy/complex/complex.h
+++ b/cupy/core/include/cupy/complex/complex.h
@@ -62,7 +62,7 @@ struct _select_greater_type
  *
  */
 template <typename T>
-struct complex {
+struct __align__(sizeof(T)*2) complex {
  public:
   /*! \p value_type is the type of \p complex's real and imaginary parts.
    */

--- a/cupy/cuda/cub.pxd
+++ b/cupy/cuda/cub.pxd
@@ -1,0 +1,4 @@
+cpdef enum:
+    CUPY_CUB_SUM = 0
+    CUPY_CUB_MIN = 1
+    CUPY_CUB_MAX = 2

--- a/cupy/cuda/cub.pyx
+++ b/cupy/cuda/cub.pyx
@@ -4,8 +4,7 @@
 
 import numpy
 
-from cupy.core cimport core
-#from cupy.core._kernel import _get_axis, _get_out_shape, _get_permuted_args  # segfault!
+from cupy.core.core cimport ndarray, _internal_ascontiguousarray
 from cupy.cuda cimport stream
 from cupy.cuda.driver cimport Stream as Stream_t
 
@@ -36,19 +35,50 @@ cdef enum:
 ###############################################################################
 
 cdef extern from 'cupy_cub.h':
-    void cub_device_reduce(void*, void*, int, void*, size_t&, Stream_t,
+    void cub_device_reduce(void*, size_t&, void*, void*, int, Stream_t,
                            int, int)
+    void cub_device_segmented_reduce(void*, size_t&, void*, void*, int, void*,
+                                     void*, Stream_t, int, int)
     size_t cub_device_reduce_get_workspace_size(void*, void*, int, Stream_t,
                                                 int, int)
+    size_t cub_device_segmented_reduce_get_workspace_size(
+        void*, void*, int, void*, void*, Stream_t, int, int)
 
 ###############################################################################
 # Python interface
 ###############################################################################
 
 
-def device_reduce(core.ndarray x, int op, out=None, bint keepdims=False):
-    cdef core.ndarray y
-    cdef core.ndarray ws
+def _preprocess_array(ndarray arr, axis):
+    # if import at the top level, a segfault would happen when import cupy!
+    from cupy.core._kernel import _get_axis
+    from cupy.core._routines_manipulation import _transpose
+
+    cdef tuple reduce_axis, out_axis, axis_permutes, out_shape
+    cdef ndarray new_arr
+    cdef Py_ssize_t contiguous_size = 1
+
+    reduce_axis, out_axis = _get_axis(axis, arr._shape.size())
+#    del axis
+    axis_permutes = reduce_axis + out_axis
+    if axis_permutes != tuple(range(len(arr.shape))):
+        new_arr = _transpose(arr, axis_permutes)
+    else:
+        new_arr = arr
+    new_arr = _internal_ascontiguousarray(new_arr)
+
+    for axis in out_axis:
+        contiguous_size *= arr.shape[axis]
+    out_shape = tuple([arr.shape[axis] for axis in out_axis])
+
+    print("DEBUG", new_arr, out_shape, contiguous_size)
+        
+    return new_arr, out_shape, contiguous_size
+
+
+def device_reduce(ndarray x, int op, out=None, bint keepdims=False):
+    cdef ndarray y
+    cdef ndarray ws
     cdef int dtype_id, ndim_out
     cdef size_t ws_size
     cdef void *x_ptr
@@ -64,8 +94,8 @@ def device_reduce(core.ndarray x, int op, out=None, bint keepdims=False):
     if op < 0 or op > 2:
         raise ValueError("only CUPY_CUB_SUM, CUPY_CUB_MIN, and CUPY_CUB_MAX "
                          "are supported.")
-    x = core.ascontiguousarray(x)
-    y = core.ndarray((), x.dtype)
+    x = _internal_ascontiguousarray(x)
+    y = ndarray((), x.dtype)
     x_ptr = <void *>x.data.ptr
     y_ptr = <void *>y.data.ptr
     dtype_id = _get_dtype_id(x.dtype)
@@ -73,15 +103,72 @@ def device_reduce(core.ndarray x, int op, out=None, bint keepdims=False):
 
     ws_size = cub_device_reduce_get_workspace_size(x_ptr, y_ptr, x.size, s,
                                                    op, dtype_id)
-    ws = core.ndarray(ws_size, numpy.int8)
+    ws = ndarray(ws_size, numpy.int8)
     ws_ptr = <void *>ws.data.ptr
-    cub_device_reduce(x_ptr, y_ptr, x.size, ws_ptr, ws_size, s, op, dtype_id)
+    cub_device_reduce(ws_ptr, ws_size, x_ptr, y_ptr, x.size, s, op, dtype_id)
 
     if keepdims:
         y = y.reshape((1,))
     if out is not None:
         out[...] = y
         y = out
+    return y
+
+
+def device_segmented_reduce(ndarray x, int op, axis, out=None,
+                            bint keepdims=False):
+    # if import at the top level, a segfault would happen when import cupy!
+    from cupy.creation.ranges import arange
+
+    cdef ndarray x_reshaped, y, ws, offset
+    cdef int dtype_id, ndim_out, n_segments
+    cdef size_t ws_size
+    cdef Py_ssize_t contiguous_size
+    cdef tuple out_shape
+    cdef void *x_ptr, *y_ptr, *ws_ptr, *offset_start_ptr
+    cdef Stream_t s
+
+#    ndim_out = keepdims
+#    if out is not None and out.ndim != ndim_out:
+#        raise ValueError(
+#            "output parameter for reduction operation sum has the wrong "
+#            "number of dimensions")
+    if op < 0 or op > 2:
+        raise ValueError("only CUPY_CUB_SUM, CUPY_CUB_MIN, and CUPY_CUB_MAX "
+                         "are supported.")
+    x_reshaped, out_shape, contiguous_size = _preprocess_array(x, axis)
+#    del x
+    assert x_reshaped.dtype == x.dtype
+    y = ndarray(out_shape, dtype=x_reshaped.dtype)
+    offset = arange(0, x_reshaped.size+1, contiguous_size, dtype=numpy.int32)
+    print(offset)
+    x_ptr = <void*>x_reshaped.data.ptr
+    y_ptr = <void*>y.data.ptr
+    offset_start_ptr = <void*>offset.data.ptr
+#    offset_end_ptr = <void*>((<int*><void*>offset.data.ptr)+1)
+    dtype_id = _get_dtype_id(x_reshaped.dtype)
+    s = <Stream_t>stream.get_current_stream_ptr()
+    n_segments = x_reshaped.size//contiguous_size
+    print(n_segments)
+
+    ws_size = cub_device_segmented_reduce_get_workspace_size(
+#        x_ptr, y_ptr, n_segments, offset_start_ptr, offset_end_ptr, s,
+        x_ptr, y_ptr, n_segments, offset_start_ptr, offset_start_ptr, s,
+        op, dtype_id)
+    print(ws_size)
+    ws = ndarray(ws_size, numpy.int8)
+    ws_ptr = <void*>ws.data.ptr
+    cub_device_segmented_reduce(ws_ptr, ws_size, x_ptr, y_ptr, n_segments,
+#                                offset_start_ptr, offset_end_ptr, s,
+                                offset_start_ptr, offset_start_ptr, s,
+                                op, dtype_id)
+    print("cub_device_segmented_reduce finished!")
+
+#    if keepdims:
+#        y = y.reshape((1,))
+#    if out is not None:
+#        out[...] = y
+#        y = out
     return y
 
 

--- a/cupy/cuda/cub.pyx
+++ b/cupy/cuda/cub.pyx
@@ -29,6 +29,11 @@ cdef enum:
     CUPY_CUB_COMPLEX64 = 11
     CUPY_CUB_COMPLEX128 = 12
 
+cpdef enum:
+    CUPY_CUB_SUM = 0
+    CUPY_CUB_MIN = 1
+    CUPY_CUB_MAX = 2
+
 ###############################################################################
 # Extern
 ###############################################################################
@@ -46,7 +51,7 @@ cdef extern from 'cupy_cub.h':
 ###############################################################################
 
 
-def reduce_sum(core.ndarray x, out=None, bint keepdims=False):
+def reduce_sum_min_max(core.ndarray x, int op, out=None, bint keepdims=False):
     cdef core.ndarray y
     cdef core.ndarray ws
     cdef int dtype_id, ndim_out
@@ -55,22 +60,39 @@ def reduce_sum(core.ndarray x, out=None, bint keepdims=False):
     cdef void *y_ptr
     cdef void *ws_ptr
     cdef Stream_t s
+
     ndim_out = keepdims
     if out is not None and out.ndim != ndim_out:
         raise ValueError(
             "output parameter for reduction operation sum has the wrong "
             "number of dimensions")
+    if op < 0 or op > 2:
+        raise ValueError("only CUPY_CUB_SUM, CUPY_CUB_MIN, and CUPY_CUB_MAX "
+                         "are supported.")
     x = core.ascontiguousarray(x)
     y = core.ndarray((), x.dtype)
     x_ptr = <void *>x.data.ptr
     y_ptr = <void *>y.data.ptr
     dtype_id = _get_dtype_id(x.dtype)
     s = <Stream_t>stream.get_current_stream_ptr()
-    ws_size = cub_reduce_sum_get_workspace_size(x_ptr, y_ptr, x.size, s,
-                                                dtype_id)
+
+    if op == CUPY_CUB_SUM:
+        ws_size = cub_reduce_sum_get_workspace_size(x_ptr, y_ptr, x.size, s,
+                                                    dtype_id)
+    elif op == CUPY_CUB_MIN:
+        ws_size = cub_reduce_min_get_workspace_size(x_ptr, y_ptr, x.size, s,
+                                                    dtype_id)
+    elif op == CUPY_CUB_MAX:
+        ws_size = cub_reduce_max_get_workspace_size(x_ptr, y_ptr, x.size, s,
+                                                    dtype_id)
     ws = core.ndarray(ws_size, numpy.int8)
     ws_ptr = <void *>ws.data.ptr
-    cub_reduce_sum(x_ptr, y_ptr, x.size, ws_ptr, ws_size, s, dtype_id)
+    if op == CUPY_CUB_SUM:
+        cub_reduce_sum(x_ptr, y_ptr, x.size, ws_ptr, ws_size, s, dtype_id)
+    elif op == CUPY_CUB_MIN:
+        cub_reduce_min(x_ptr, y_ptr, x.size, ws_ptr, ws_size, s, dtype_id)
+    elif op == CUPY_CUB_MAX:
+        cub_reduce_max(x_ptr, y_ptr, x.size, ws_ptr, ws_size, s, dtype_id)
     if keepdims:
         y = y.reshape((1,))
     if out is not None:
@@ -85,110 +107,29 @@ cpdef bint _cub_axis_compatible(axis, Py_ssize_t ndim):
     return False
 
 
-def can_use_reduce_sum(x_dtype, Py_ssize_t ndim, dtype=None, axis=None):
+def can_use_reduce_sum_min_max(x_dtype, Py_ssize_t ndim, int op,
+                               dtype=None, axis=None):
     if dtype is None:
-        # auto dtype:
-        # CUB reduce_sum does not support dtype promotion.
-        # See _sum_auto_dtype in cupy/core/_routines_math.pyx for which dtypes
-        # are promoted.
-        support_dtype = [numpy.int64, numpy.uint64,
-                         numpy.float32, numpy.float64,
-                         numpy.complex64, numpy.complex128]
+        if op == CUPY_CUB_SUM:
+            # auto dtype:
+            # CUB reduce_sum does not support dtype promotion.
+            # See _sum_auto_dtype in cupy/core/_routines_math.pyx for which
+            # dtypes are promoted.
+            support_dtype = [numpy.int64, numpy.uint64,
+                             numpy.float32, numpy.float64,
+                             numpy.complex64, numpy.complex128]
+        else:
+            support_dtype = [numpy.int8, numpy.uint8,
+                             numpy.int16, numpy.uint16,
+                             numpy.int32, numpy.uint32,
+                             numpy.int64, numpy.uint64,
+                             numpy.float32, numpy.float64,
+                             numpy.complex64, numpy.complex128]
     elif dtype == x_dtype:
-        support_dtype = [numpy.int8, numpy.uint8, numpy.int16, numpy.uint16,
-                         numpy.int32, numpy.uint32, numpy.int64, numpy.uint64,
-                         numpy.float32, numpy.float64,
-                         numpy.complex64, numpy.complex128]
-    else:
-        return False
-    if x_dtype not in support_dtype:
-        return False
-    return _cub_axis_compatible(axis, ndim)
-
-
-def reduce_min(core.ndarray x, out=None, bint keepdims=False):
-    cdef core.ndarray y
-    cdef core.ndarray ws
-    cdef int dtype_id, ndim_out
-    cdef size_t ws_size
-    cdef void *x_ptr
-    cdef void *y_ptr
-    cdef void *ws_ptr
-    cdef Stream_t s
-    ndim_out = keepdims
-    if out is not None and out.ndim != ndim_out:
-        raise ValueError(
-            "output parameter for reduction operation sum has the wrong "
-            "number of dimensions")
-    x = core.ascontiguousarray(x)
-    y = core.ndarray((), x.dtype)
-    x_ptr = <void *>x.data.ptr
-    y_ptr = <void *>y.data.ptr
-    dtype_id = _get_dtype_id(x.dtype)
-    s = <Stream_t>stream.get_current_stream_ptr()
-    ws_size = cub_reduce_min_get_workspace_size(x_ptr, y_ptr, x.size, s,
-                                                dtype_id)
-    ws = core.ndarray(ws_size, numpy.int8)
-    ws_ptr = <void *>ws.data.ptr
-    cub_reduce_min(x_ptr, y_ptr, x.size, ws_ptr, ws_size, s, dtype_id)
-    if keepdims:
-        y = y.reshape((1,))
-    if out is not None:
-        out[...] = y
-        y = out
-    return y
-
-
-def can_use_reduce_min(x_dtype, Py_ssize_t ndim, dtype=None, axis=None):
-    if dtype is None or dtype == x_dtype:
-        support_dtype = [numpy.int8, numpy.uint8, numpy.int16, numpy.uint16,
-                         numpy.int32, numpy.uint32, numpy.int64, numpy.uint64,
-                         numpy.float32, numpy.float64,
-                         numpy.complex64, numpy.complex128]
-    else:
-        return False
-    if x_dtype not in support_dtype:
-        return False
-    return _cub_axis_compatible(axis, ndim)
-
-
-def reduce_max(core.ndarray x, out=None, bint keepdims=False):
-    cdef core.ndarray y
-    cdef core.ndarray ws
-    cdef int dtype_id, ndim_out
-    cdef size_t ws_size
-    cdef void *x_ptr
-    cdef void *y_ptr
-    cdef void *ws_ptr
-    cdef Stream_t s
-    ndim_out = keepdims
-    if out is not None and out.ndim != ndim_out:
-        raise ValueError(
-            "output parameter for reduction operation sum has the wrong "
-            "number of dimensions")
-    x = core.ascontiguousarray(x)
-    y = core.ndarray((), x.dtype)
-    x_ptr = <void *>x.data.ptr
-    y_ptr = <void *>y.data.ptr
-    dtype_id = _get_dtype_id(x.dtype)
-    s = <Stream_t>stream.get_current_stream_ptr()
-    ws_size = cub_reduce_max_get_workspace_size(x_ptr, y_ptr, x.size, s,
-                                                dtype_id)
-    ws = core.ndarray(ws_size, numpy.int8)
-    ws_ptr = <void *>ws.data.ptr
-    cub_reduce_max(x_ptr, y_ptr, x.size, ws_ptr, ws_size, s, dtype_id)
-    if keepdims:
-        y = y.reshape((1,))
-    if out is not None:
-        out[...] = y
-        y = out
-    return y
-
-
-def can_use_reduce_max(x_dtype, Py_ssize_t ndim, dtype=None, axis=None):
-    if dtype is None or dtype == x_dtype:
-        support_dtype = [numpy.int8, numpy.uint8, numpy.int16, numpy.uint16,
-                         numpy.int32, numpy.uint32, numpy.int64, numpy.uint64,
+        support_dtype = [numpy.int8, numpy.uint8,
+                         numpy.int16, numpy.uint16,
+                         numpy.int32, numpy.uint32,
+                         numpy.int64, numpy.uint64,
                          numpy.float32, numpy.float64,
                          numpy.complex64, numpy.complex128]
     else:

--- a/cupy/cuda/cub.pyx
+++ b/cupy/cuda/cub.pyx
@@ -60,14 +60,14 @@ def _preprocess_array(ndarray arr, axis):
 
     reduce_axis, out_axis = _get_axis(axis, arr._shape.size())
 #    del axis
-    axis_permutes = reduce_axis + out_axis
+    axis_permutes = out_axis + reduce_axis
     if axis_permutes != tuple(range(len(arr.shape))):
         new_arr = _transpose(arr, axis_permutes)
     else:
         new_arr = arr
     new_arr = _internal_ascontiguousarray(new_arr)
 
-    for axis in out_axis:
+    for axis in reduce_axis:
         contiguous_size *= arr.shape[axis]
     out_shape = tuple([arr.shape[axis] for axis in out_axis])
 

--- a/cupy/cuda/cupy_cub.cu
+++ b/cupy/cuda/cupy_cub.cu
@@ -70,7 +70,7 @@ void dtype_dispatcher(int dtype_id, functor_t f, Ts&&... args)
 }
 
 //
-// **** cub_reduce_sum ****
+// **** CUB Sum ****
 //
 struct _cub_reduce_sum {
     template <typename T>
@@ -95,7 +95,7 @@ struct _cub_segmented_reduce_sum {
 };
 
 //
-// **** cub_reduce_min ****
+// **** CUB Min ****
 //
 struct _cub_reduce_min {
     template <typename T>
@@ -114,13 +114,13 @@ struct _cub_segmented_reduce_min {
     {
         DeviceSegmentedReduce::Min(workspace, workspace_size,
             static_cast<T*>(x), static_cast<T*>(y), num_segments,
-            static_cast<unsigned int*>(offset_start),
-            static_cast<unsigned int*>(offset_end), s);
+            static_cast<int*>(offset_start),
+            static_cast<int*>(offset_end), s);
     }
 };
 
 //
-// **** cub_reduce_max ****
+// **** CUB Max ****
 //
 struct _cub_reduce_max {
     template <typename T>
@@ -139,14 +139,16 @@ struct _cub_segmented_reduce_max {
     {
         DeviceSegmentedReduce::Max(workspace, workspace_size,
             static_cast<T*>(x), static_cast<T*>(y), num_segments,
-            static_cast<unsigned int*>(offset_start),
-            static_cast<unsigned int*>(offset_end), s);
+            static_cast<int*>(offset_start),
+            static_cast<int*>(offset_end), s);
     }
 };
 
 //
 // APIs exposed to CuPy
 //
+
+/* -------- device reduce -------- */
 
 void cub_device_reduce(void* workspace, size_t& workspace_size, void* x, void* y,
     int num_items, cudaStream_t stream, int op, int dtype_id)
@@ -170,6 +172,8 @@ size_t cub_device_reduce_get_workspace_size(void* x, void* y, int num_items,
                       op, dtype_id);
     return workspace_size;
 }
+
+/* -------- device segmented reduce -------- */
 
 void cub_device_segmented_reduce(void* workspace, size_t& workspace_size,
     void* x, void* y, int num_segments, void* offset_start, void* offset_end,

--- a/cupy/cuda/cupy_cub.cu
+++ b/cupy/cuda/cupy_cub.cu
@@ -107,7 +107,7 @@ struct _cub_reduce_max {
     }
 };
 
-void cub_reduce_sum_min_max(void *x, void *y, int num_items, void *workspace, size_t &workspace_size, cudaStream_t stream,
+void cub_device_reduce(void *x, void *y, int num_items, void *workspace, size_t &workspace_size, cudaStream_t stream,
     int op, int dtype_id)
 {
     switch(op) {
@@ -121,10 +121,10 @@ void cub_reduce_sum_min_max(void *x, void *y, int num_items, void *workspace, si
     }
 }
 
-size_t cub_reduce_sum_min_max_get_workspace_size(void *x, void *y, int num_items, cudaStream_t stream,
+size_t cub_device_reduce_get_workspace_size(void *x, void *y, int num_items, cudaStream_t stream,
     int op, int dtype_id)
 {
     size_t workspace_size = 0;
-    cub_reduce_sum_min_max(x, y, num_items, NULL, workspace_size, stream, op, dtype_id);
+    cub_device_reduce(x, y, num_items, NULL, workspace_size, stream, op, dtype_id);
     return workspace_size;
 }

--- a/cupy/cuda/cupy_cub.cu
+++ b/cupy/cuda/cupy_cub.cu
@@ -81,21 +81,6 @@ struct _cub_reduce_sum {
     }
 };
 
-void cub_reduce_sum(void *x, void *y, int num_items, void *workspace,
-    size_t &workspace_size, cudaStream_t stream, int dtype_id)
-{
-    dtype_dispatcher(dtype_id, _cub_reduce_sum(),
-        x, y, num_items, workspace, workspace_size, stream);
-}
-
-size_t cub_reduce_sum_get_workspace_size(void *x, void *y, int num_items,
-    cudaStream_t stream, int dtype_id)
-{
-    size_t workspace_size = 0;
-    cub_reduce_sum(x, y, num_items, NULL, workspace_size, stream, dtype_id);
-    return workspace_size;
-}
-
 //
 // **** cub_reduce_min ****
 //
@@ -108,21 +93,6 @@ struct _cub_reduce_min {
             static_cast<T*>(y), num_items, s);
     }
 };
-
-void cub_reduce_min(void *x, void *y, int num_items, void *workspace,
-    size_t &workspace_size, cudaStream_t stream, int dtype_id)
-{
-    dtype_dispatcher(dtype_id, _cub_reduce_min(),
-        x, y, num_items, workspace, workspace_size, stream);
-}
-
-size_t cub_reduce_min_get_workspace_size(void *x, void *y, int num_items,
-    cudaStream_t stream, int dtype_id)
-{
-    size_t workspace_size = 0;
-    cub_reduce_min(x, y, num_items, NULL, workspace_size, stream, dtype_id);
-    return workspace_size;
-}
 
 //
 // **** cub_reduce_max ****
@@ -137,17 +107,24 @@ struct _cub_reduce_max {
     }
 };
 
-void cub_reduce_max(void *x, void *y, int num_items, void *workspace,
-    size_t &workspace_size, cudaStream_t stream, int dtype_id)
+void cub_reduce_sum_min_max(void *x, void *y, int num_items, void *workspace, size_t &workspace_size, cudaStream_t stream,
+    int op, int dtype_id)
 {
-    dtype_dispatcher(dtype_id, _cub_reduce_max(),
-        x, y, num_items, workspace, workspace_size, stream);
+    switch(op) {
+    case CUPY_CUB_SUM:  return dtype_dispatcher(dtype_id, _cub_reduce_sum(),
+                            x, y, num_items, workspace, workspace_size, stream);
+    case CUPY_CUB_MIN:  return dtype_dispatcher(dtype_id, _cub_reduce_min(),
+                            x, y, num_items, workspace, workspace_size, stream);
+    case CUPY_CUB_MAX:  return dtype_dispatcher(dtype_id, _cub_reduce_max(),
+                            x, y, num_items, workspace, workspace_size, stream);
+    default:            throw std::runtime_error("Unsupported operation");
+    }
 }
 
-size_t cub_reduce_max_get_workspace_size(void *x, void *y, int num_items,
-    cudaStream_t stream, int dtype_id)
+size_t cub_reduce_sum_min_max_get_workspace_size(void *x, void *y, int num_items, cudaStream_t stream,
+    int op, int dtype_id)
 {
     size_t workspace_size = 0;
-    cub_reduce_max(x, y, num_items, NULL, workspace_size, stream, dtype_id);
+    cub_reduce_sum_min_max(x, y, num_items, NULL, workspace_size, stream, op, dtype_id);
     return workspace_size;
 }

--- a/cupy/cuda/cupy_cub.cu
+++ b/cupy/cuda/cupy_cub.cu
@@ -90,7 +90,7 @@ struct _cub_segmented_reduce_sum {
         DeviceSegmentedReduce::Sum(workspace, workspace_size,
             static_cast<T*>(x), static_cast<T*>(y), num_segments,
             static_cast<int*>(offset_start),
-            static_cast<int*>(offset_end)+1, s);
+            static_cast<int*>(offset_end), s);
     }
 };
 

--- a/cupy/cuda/cupy_cub.h
+++ b/cupy/cuda/cupy_cub.h
@@ -24,10 +24,11 @@
 
 void cub_device_reduce(void*, size_t&, void*, void*, int, cudaStream_t, int, int);
 void cub_device_segmented_reduce(void*, size_t&, void*, void*, int, void*, void*, cudaStream_t, int, int);
-size_t cub_device_reduce_get_workspace_size(void *, void *, int, cudaStream_t, int, int);
-size_t cub_device_segmented_reduce_get_workspace_size(void *, void *, int, void*, void*, cudaStream_t, int, int);
+size_t cub_device_reduce_get_workspace_size(void*, void*, int, cudaStream_t, int, int);
+size_t cub_device_segmented_reduce_get_workspace_size(void*, void*, int, void*, void*, cudaStream_t, int, int);
 
 #else // CUPY_NO_CUDA
+
 typedef struct CUstream_st *cudaStream_t;
 
 void cub_device_reduce(...) {
@@ -43,6 +44,7 @@ size_t cub_device_reduce_get_workspace_size(...) {
 size_t cub_device_segmented_reduce_get_workspace_size(...) {
     return 0;
 }
+
 #endif // #ifndef CUPY_NO_CUDA
 
 #endif // #ifndef INCLUDE_GUARD_CUPY_CUDA_CUB_H

--- a/cupy/cuda/cupy_cub.h
+++ b/cupy/cuda/cupy_cub.h
@@ -22,8 +22,10 @@
 #ifndef CUPY_NO_CUDA
 #include <cuda_runtime.h>  // for cudaStream_t
 
-void cub_device_reduce(void *, void *, int, void *, size_t &, cudaStream_t, int, int);
+void cub_device_reduce(void*, size_t&, void*, void*, int, cudaStream_t, int, int);
+void cub_device_segmented_reduce(void*, size_t&, void*, void*, int, void*, void*, cudaStream_t, int, int);
 size_t cub_device_reduce_get_workspace_size(void *, void *, int, cudaStream_t, int, int);
+size_t cub_device_segmented_reduce_get_workspace_size(void *, void *, int, void*, void*, cudaStream_t, int, int);
 
 #else // CUPY_NO_CUDA
 typedef struct CUstream_st *cudaStream_t;
@@ -31,10 +33,16 @@ typedef struct CUstream_st *cudaStream_t;
 void cub_device_reduce(...) {
 }
 
+void cub_device_segmented_reduce(...) {
+}
+
 size_t cub_device_reduce_get_workspace_size(...) {
     return 0;
 }
 
+size_t cub_device_segmented_reduce_get_workspace_size(...) {
+    return 0;
+}
 #endif // #ifndef CUPY_NO_CUDA
 
 #endif // #ifndef INCLUDE_GUARD_CUPY_CUDA_CUB_H

--- a/cupy/cuda/cupy_cub.h
+++ b/cupy/cuda/cupy_cub.h
@@ -15,38 +15,23 @@
 #define CUPY_CUB_COMPLEX64  11
 #define CUPY_CUB_COMPLEX128 12
 
+#define CUPY_CUB_SUM  0
+#define CUPY_CUB_MIN  1
+#define CUPY_CUB_MAX  2
+
 #ifndef CUPY_NO_CUDA
 #include <cuda_runtime.h>  // for cudaStream_t
 
-void cub_reduce_sum(void *, void *, int, void *, size_t &, cudaStream_t, int);
-void cub_reduce_min(void *, void *, int, void *, size_t &, cudaStream_t, int);
-void cub_reduce_max(void *, void *, int, void *, size_t &, cudaStream_t, int);
-
-size_t cub_reduce_sum_get_workspace_size(void *, void *, int, cudaStream_t, int);
-size_t cub_reduce_min_get_workspace_size(void *, void *, int, cudaStream_t, int);
-size_t cub_reduce_max_get_workspace_size(void *, void *, int, cudaStream_t, int);
+void cub_reduce_sum_min_max(void *, void *, int, void *, size_t &, cudaStream_t, int, int);
+size_t cub_reduce_sum_min_max_get_workspace_size(void *, void *, int, cudaStream_t, int, int);
 
 #else // CUPY_NO_CUDA
 typedef struct CUstream_st *cudaStream_t;
 
-void cub_reduce_sum(...) {
+void cub_reduce_sum_min_max(...) {
 }
 
-void cub_reduce_min(...) {
-}
-
-void cub_reduce_max(...) {
-}
-
-size_t cub_reduce_sum_get_workspace_size(...) {
-    return 0;
-}
-
-size_t cub_reduce_min_get_workspace_size(...) {
-    return 0;
-}
-
-size_t cub_reduce_max_get_workspace_size(...) {
+size_t cub_reduce_sum_min_max_get_workspace_size(...) {
     return 0;
 }
 

--- a/cupy/cuda/cupy_cub.h
+++ b/cupy/cuda/cupy_cub.h
@@ -22,16 +22,16 @@
 #ifndef CUPY_NO_CUDA
 #include <cuda_runtime.h>  // for cudaStream_t
 
-void cub_reduce_sum_min_max(void *, void *, int, void *, size_t &, cudaStream_t, int, int);
-size_t cub_reduce_sum_min_max_get_workspace_size(void *, void *, int, cudaStream_t, int, int);
+void cub_device_reduce(void *, void *, int, void *, size_t &, cudaStream_t, int, int);
+size_t cub_device_reduce_get_workspace_size(void *, void *, int, cudaStream_t, int, int);
 
 #else // CUPY_NO_CUDA
 typedef struct CUstream_st *cudaStream_t;
 
-void cub_reduce_sum_min_max(...) {
+void cub_device_reduce(...) {
 }
 
-size_t cub_reduce_sum_min_max_get_workspace_size(...) {
+size_t cub_device_reduce_get_workspace_size(...) {
     return 0;
 }
 


### PR DESCRIPTION
Part of #2519.

This PR does three things:
1. Refactor `cupy/cuda/cub.pyx` and `cupy/cuda/cupy_cub.*` to eliminate a lot of redundant lines for making the No.2 change below much easier;
2. Support `sum(axis=...)`, `min(axis=...)`, and `max(axis=...)` using CUB's **device segmented reduce** API. Because this API can only reduce over contiguous segments, any reduction with non-contiguous axes (e.g., `axis=(0, 2)` for `ndim=3`) is still deferred to the old reduction kernel. 
3. Enforce the alignments for Thrust's complex types to ensure performance

(I tried making a device-device copy to transpose the array at commit 31304f4 for non-contiguous cases, but the performance was just killed by copy. I can post an `nvvp` screenshot if anyone is interested.)

~~Note that for complex numbers with an explicit `axis`, the CUB performance may not be always better than the old reduction, so I added a warning. I believe this is because the hard-coded `DeviceReducePolicy` in `cub/device/dispatch/dispatch_reduce.cuh` saturated the shared memory and caused too many memory transactions when a contiguous block has too many elements, but I don't know how to specialize it for complex numbers with a smaller block size and/or fewer items per thread, so let us leave a performance-tuning PR for the future.~~ 

***UPDATE***: this suboptimal performance is fixed by properly aligning the data (see No.3 above).

attn: @grlee77, @anaruse 