### PR TITLE
Normalize strides of cuDNN descriptors

### DIFF
--- a/cupy/cudnn.pyx
+++ b/cupy/cudnn.pyx
@@ -1896,6 +1896,8 @@ def pooling_forward(
         zero = <size_t>&float_zero
         one = <size_t>&float_one
     x = core._internal_ascontiguousarray(x)
+    if not y._c_contiguous:
+        raise ValueError('pooling_forward supports c-contiguous y only')
     handle = get_handle()
     x_desc = cudnn.createTensorDescriptor()
     y_desc = cudnn.createTensorDescriptor()
@@ -1930,6 +1932,7 @@ def pooling_backward(
 
     gx = core.ndarray(x._shape, x.dtype)
     x = core._internal_ascontiguousarray(x)
+    y = core._internal_ascontiguousarray(y)
     gy = core._internal_ascontiguousarray(gy)
 
     handle = get_handle()

--- a/cupy/cudnn.pyx
+++ b/cupy/cudnn.pyx
@@ -1024,7 +1024,7 @@ def rnn_forward_training(
         DropoutStates states, int direction_mode, int rnn_mode,
         core.ndarray hx, core.ndarray cx, core.ndarray w, core.ndarray xs,
         lengths):
-    hx = _ascontiguousarray_normalized_strides(hx)
+    hx = core._internal_ascontiguousarray(hx)
     if cx is not None:
         cx = core._internal_ascontiguousarray(cx)
     w = core._internal_ascontiguousarray(w)


### PR DESCRIPTION
Fix chainer/chainer#6644 and some other cuDNN issues.  Revert an ad-hoc fix.  `_make_tensor_descriptor_array` could be fixed similarly, but not in this PR.

Drawback:

- Normalized stride is incorrect if an input array has 1-length axes and other contiguity is used.

Alternative fixes:

- Use `_ascontiguousarray_normalized_strides` (in #2261) everywhere
  - It will create more `ndarray` objects.
  - It is overhead if (4-dim) tensor discriptor is used.  It is too unmaintainable to keep `core._internal_ascontiguousarray` for the safe cases.
  - It depends that the internal `_reshape` preserves normalized strides. https://github.com/cupy/cupy/blob/b9db374f4d0ccee358a998d7b283248f77cef351/cupy/cudnn.pyx#L1673-L1674
- Make contiguous array and its cuDNN descriptor simultaneously.
  - Not easy to fix the relevant codes.