### PR TITLE
Support 0-sized arrays for `linalg.qr`

### DIFF
--- a/cupy/linalg/decomposition.py
+++ b/cupy/linalg/decomposition.py
@@ -118,8 +118,20 @@ def qr(a, mode='reduced'):
         dtype = numpy.find_common_type((a.dtype.char, 'f'), ()).char
 
     m, n = a.shape
-    x = a.transpose().astype(dtype, order='C', copy=True)
     mn = min(m, n)
+    if mn == 0:
+        if mode == 'reduced':
+            return cupy.empty((m, 0), dtype), cupy.empty((0, n), dtype)
+        elif mode == 'complete':
+            return cupy.identity(m, dtype), cupy.empty((m, n), dtype)
+        elif mode == 'r':
+            return cupy.empty((0, n), dtype)
+        else:  # mode == 'raw'
+            # compatibility with numpy.linalg.qr
+            dtype = numpy.find_common_type((dtype, 'd'), ())
+            return cupy.empty((n, m), dtype), cupy.empty((0,), dtype)
+
+    x = a.transpose().astype(dtype, order='C', copy=True)
     handle = device.get_cusolver_handle()
     dev_info = cupy.empty(1, dtype=numpy.int32)
     # compute working space of geqrf and orgqr, and solve R

--- a/tests/cupy_tests/linalg_tests/test_decomposition.py
+++ b/tests/cupy_tests/linalg_tests/test_decomposition.py
@@ -89,6 +89,11 @@ class TestQRDecomposition(unittest.TestCase):
         self.check_mode(numpy.random.randn(3, 3), mode=self.mode)
         self.check_mode(numpy.random.randn(5, 4), mode=self.mode)
 
+    @testing.with_requires('numpy>=1.16')
+    def test_empty_array(self):
+        self.check_mode(numpy.empty((0, 3)), mode=self.mode)
+        self.check_mode(numpy.empty((3, 0)), mode=self.mode)
+
 
 @testing.parameterize(*testing.product({
     'full_matrices': [True, False],


### PR DESCRIPTION
Part of #2371.  LAPACK does not have to be called for 0-sized arrays.

The test cases are from #2372.
