### PR TITLE
Show better performance improvement in `examples/stream/map_reduce.py`

### DIFF
--- a/examples/stream/map_reduce.py
+++ b/examples/stream/map_reduce.py
@@ -19,8 +19,8 @@ start_time = time.time()
 # Map
 for stream in map_streams:
     with stream:
-        x = rand.normal(size=(1, 1024 * 256))
-        y = rand.normal(size=(1024 * 256, 1))
+        x = rand.normal(size=(1, 1024**2))
+        y = rand.normal(size=(1024**2, 1))
         z = cupy.matmul(x, y)
         zs.append(z)
     stop_event = stream.record()


### PR DESCRIPTION
Closes #1695. Closes #2524.

In #1695 it was reported by @mrocklin that no concurrency was seen in the demo even with multiple streams. In #2524 it was found by @emcastillo that it was simply because the workload was too small. Increasing the workload helps observe stream overlap, see below.

Before this PR:
<img width="641" alt="螢幕快照 2019-10-30 下午1 53 29" src="https://user-images.githubusercontent.com/5534781/67885209-870e5e80-fb1d-11e9-9810-6e549684b9a6.png">

With this PR:
<img width="789" alt="螢幕快照 2019-10-30 下午1 49 58" src="https://user-images.githubusercontent.com/5534781/67885233-942b4d80-fb1d-11e9-866e-8c370497f2c9.png">

Tested on P100.
