### PR TITLE
[v6] Add missing FlexCI configurations

### DIFF
--- a/.pfnci/config.pbtxt
+++ b/.pfnci/config.pbtxt
@@ -1,0 +1,89 @@
+configs {
+  key: "cupy.wheel.nightly"
+  value {
+    requirement {
+      cpu: 2
+      memory: 12
+    }
+    time_limit {
+      seconds: 1800
+    }
+    command: "sh .pfnci/wheel_nightly.sh"
+  }
+}
+
+# Python 2 tests are disabled in the master branch, but configs can be removed
+# only after removing web hooks.
+# TODO(niboshi): Completely remove them after discontinuing v6 series.
+configs {
+  key: "cupy.py2.cv.gpu"
+  value {
+    command: "true"
+  }
+}
+configs {
+  key: "cupy.py2.cv.examples"
+  value {
+    command: "true"
+  }
+}
+configs {
+  key: "cupy.py3.cv.gpu"
+  value {
+    requirement {
+      cpu: 4
+      memory: 24
+      disk: 10
+      gpu: 1
+    }
+    time_limit {
+      seconds: 1800
+    }
+    checkout_strategy {
+      include_dot_git: true
+    }
+    command: "git clone https://github.com/chainer/chainercv.git --depth 1 && sh chainercv/.pfnci/tests_gpu.sh"
+    environment_variables {
+      key: "REPOSITORY"
+      value: "cupy"
+    }
+    environment_variables {
+      key: "PYTHON"
+      value: "3"
+    }
+    environment_variables {
+      key: "OPTIONAL_MODULES"
+      value: "1"
+    }
+  }
+}
+configs {
+  key: "cupy.py3.cv.examples"
+  value {
+    requirement {
+      cpu: 6
+      memory: 36
+      disk: 10
+      gpu: 2
+    }
+    time_limit {
+      seconds: 3600
+    }
+    checkout_strategy {
+      include_dot_git: true
+    }
+    command: "git clone https://github.com/chainer/chainercv.git --depth 1 && sh chainercv/.pfnci/examples_tests.sh"
+    environment_variables {
+      key: "REPOSITORY"
+      value: "cupy"
+    }
+    environment_variables {
+      key: "PYTHON"
+      value: "3"
+    }
+    environment_variables {
+      key: "OPTIONAL_MODULES"
+      value: "1"
+    }
+  }
+}

--- a/.pfnci/config.pbtxt
+++ b/.pfnci/config.pbtxt
@@ -12,19 +12,64 @@ configs {
   }
 }
 
-# Python 2 tests are disabled in the master branch, but configs can be removed
-# only after removing web hooks.
-# TODO(niboshi): Completely remove them after discontinuing v6 series.
 configs {
   key: "cupy.py2.cv.gpu"
   value {
-    command: "true"
+    requirement {
+      cpu: 4
+      memory: 24
+      gpu: 1
+      disk: 10
+    }
+    time_limit {
+      seconds: 1800
+    }
+    checkout_strategy {
+      include_dot_git: true
+    }
+    command: "git clone https://github.com/chainer/chainercv.git --depth 1 && sh chainercv/.pfnci/tests_gpu.sh"
+    environment_variables {
+      key: "REPOSITORY"
+      value: "cupy"
+    }
+    environment_variables {
+      key: "PYTHON"
+      value: "2"
+    }
+    environment_variables {
+      key: "OPTIONAL_MODULES"
+      value: "1"
+    }
   }
 }
 configs {
   key: "cupy.py2.cv.examples"
   value {
-    command: "true"
+    requirement {
+      cpu: 6
+      memory: 36
+      disk: 10
+      gpu: 2
+    }
+    time_limit {
+      seconds: 3600
+    }
+    checkout_strategy {
+      include_dot_git: true
+    }
+    command: "git clone https://github.com/chainer/chainercv.git --depth 1 && sh chainercv/.pfnci/examples_tests.sh"
+    environment_variables {
+      key: "REPOSITORY"
+      value: "cupy"
+    }
+    environment_variables {
+      key: "PYTHON"
+      value: "2"
+    }
+    environment_variables {
+      key: "OPTIONAL_MODULES"
+      value: "1"
+    }
   }
 }
 configs {

--- a/.pfnci/docker/devel/Dockerfile
+++ b/.pfnci/docker/devel/Dockerfile
@@ -1,0 +1,14 @@
+FROM nvidia/cuda:9.2-cudnn7-devel-ubuntu18.04
+
+ARG PYTHON
+RUN apt-get update -y && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    python${PYTHON}-dev \
+    $([ ${PYTHON} = 2.7 ] || echo python${PYTHON}-distutils) \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl -LO https://bootstrap.pypa.io/get-pip.py \
+    && python${PYTHON} get-pip.py --no-cache-dir \
+    && rm get-pip.py \
+    && pip${PYTHON} install --no-cache-dir cython

--- a/.pfnci/wheel_nightly.sh
+++ b/.pfnci/wheel_nightly.sh
@@ -1,0 +1,27 @@
+#! /usr/bin/env sh
+set -eux
+
+systemctl stop docker.service
+mount -t tmpfs tmpfs /var/lib/docker/
+systemctl start docker.service
+
+TEMP=$(mktemp -d)
+mount -t tmpfs tmpfs ${TEMP}/
+cp -a . ${TEMP}/
+cd ${TEMP}/
+
+echo -n 2.7 3.6 | xargs -i -d ' ' -P $(nproc) sh -euxc '
+PYTHON={}
+
+docker build \
+       --build-arg PYTHON=${PYTHON} \
+       -t devel:${PYTHON} \
+       .pfnci/docker/devel/
+docker run --rm \
+       --volume $(pwd):/cupy/ --workdir /cupy/ \
+       devel:${PYTHON} \
+       pip${PYTHON} wheel -e .
+'
+
+gsutil -q cp cupy-*.whl gs://tmp-asia-pfn-public-ci/cupy/wheel/${CI_COMMIT_ID}/cuda9.2/
+echo ${CI_COMMIT_ID} | gsutil -q cp - gs://tmp-asia-pfn-public-ci/cupy/wheel/master

--- a/.pfnci/wheel_nightly.sh
+++ b/.pfnci/wheel_nightly.sh
@@ -24,4 +24,4 @@ docker run --rm \
 '
 
 gsutil -q cp cupy-*.whl gs://tmp-asia-pfn-public-ci/cupy/wheel/${CI_COMMIT_ID}/cuda9.2/
-echo ${CI_COMMIT_ID} | gsutil -q cp - gs://tmp-asia-pfn-public-ci/cupy/wheel/master
+echo ${CI_COMMIT_ID} | gsutil -q cp - gs://tmp-asia-pfn-public-ci/cupy/wheel/v6


### PR DESCRIPTION
* Copy configuration from master branch.
* Activate `cupy.py2.cv.gpu`, `cupy.py2.cv.examples` configurations (copy configuration from the default config) and enable `include_dot_git` for https://github.com/chainer/chainercv/pull/935 .

See also: https://github.com/chainer/chainer/pull/8352