### PR TITLE
Document more environment variables

### DIFF
--- a/docs/source/install_rocm.rst
+++ b/docs/source/install_rocm.rst
@@ -1,6 +1,8 @@
 [Experimental] Installation Guide for ROCm environemt
 =====================================================
 
+.. _install_hip:
+
 .. contents:: :local:
 
 This is an experimental feature. We recommend only for advanced users to use this.

--- a/docs/source/install_rocm.rst
+++ b/docs/source/install_rocm.rst
@@ -1,8 +1,6 @@
 [Experimental] Installation Guide for ROCm environemt
 =====================================================
 
-.. _install_hip:
-
 .. contents:: :local:
 
 This is an experimental feature. We recommend only for advanced users to use this.
@@ -37,6 +35,8 @@ Before installing CuPy, we recommend you to upgrade ``setuptools`` and ``pip``::
 
   $ pip install -U setuptools pip
 
+
+.. _install_hip:
 
 Install CuPy from Source
 ------------------------

--- a/docs/source/reference/environment.rst
+++ b/docs/source/reference/environment.rst
@@ -41,6 +41,13 @@ Here are the environment variables CuPy uses.
 |                                    | See :doc:`memory` for details.                     |
 |                                    | ``0`` (unlimited) is used by default.              |
 +------------------------------------+----------------------------------------------------+
+| ``CUPY_SEED``                      | Set the seed for random number generators. For     |
+|                                    | historical reasons ``CHAINER_SEED`` is used if     |
+|                                    | ``CUPY_SEED`` is unspecified                       |
++------------------------------------+----------------------------------------------------+
+| ``CUPY_EXPERIMENTAL_SLICE_COPY``   | If set to 1, the following syntax is enabled:      |
+|                                    | ``cupy_ndarray[:] = numpy_ndarray``                |
++------------------------------------+----------------------------------------------------+
 
 
 For install
@@ -48,11 +55,20 @@ For install
 
 These environment variables are used during installation (building CuPy from source).
 
-+-------------------+---------------------------------------------------------------------+
-| ``CUDA_PATH``     | See the description above.                                          |
-+-------------------+---------------------------------------------------------------------+
-| ``CUTENSOR_PATH`` | Path to the cuTENSOR root directory that contains ``lib`` and       |
-|                   | ``include`` directories. (experimental)                             |
-+-------------------+---------------------------------------------------------------------+
-| ``NVCC``          | Define the compiler to use when compiling CUDA files.               |
-+-------------------+---------------------------------------------------------------------+
++-----------------------------+----------------------------------------------------------------+
+| ``CUDA_PATH``               | See the description above.                                     |
++-----------------------------+----------------------------------------------------------------+
+| ``CUTENSOR_PATH``           | Path to the cuTENSOR root directory that contains ``lib`` and  |
+|                             | ``include`` directories. (experimental)                        |
++-----------------------------+----------------------------------------------------------------+
+| ``NVCC``                    | Define the compiler to use when compiling CUDA files.          |
++-----------------------------+----------------------------------------------------------------+
+| ``CUPY_PYTHON_350_FORCE``   | Enforce CuPy to be installed against Python 3.5.0 (not         |
+|                             | recommended).                                                  |
++-----------------------------+----------------------------------------------------------------+
+| ``CUPY_INSTALL_USE_HIP``    | For building the ROCm support, see :doc:`../install_rocm` for  |
+|                             | further detail.                                                |
++-----------------------------+----------------------------------------------------------------+
+| ``CUPY_NVCC_GENERATE_CODE`` | To build CuPy for a particular CUDA architecture. For example, |
+|                             | ``CUPY_NVCC_GENERATE_CODE=compute_60,sm_60``.                  |
++-----------------------------+----------------------------------------------------------------+

--- a/docs/source/reference/environment.rst
+++ b/docs/source/reference/environment.rst
@@ -42,10 +42,10 @@ Here are the environment variables CuPy uses.
 +------------------------------------+----------------------------------------------------+
 | ``CUPY_SEED``                      | Set the seed for random number generators. For     |
 |                                    | historical reasons ``CHAINER_SEED`` is used if     |
-|                                    | ``CUPY_SEED`` is unspecified                       |
+|                                    | ``CUPY_SEED`` is unspecified.                      |
 +------------------------------------+----------------------------------------------------+
 | ``CUPY_EXPERIMENTAL_SLICE_COPY``   | If set to 1, the following syntax is enabled:      |
-|                                    | ``cupy_ndarray[:] = numpy_ndarray``                |
+|                                    | ``cupy_ndarray[:] = numpy_ndarray``.               |
 +------------------------------------+----------------------------------------------------+
 
 Moreover, as in any CUDA programs, all of the CUDA environment variables listed in the `CUDA Toolkit
@@ -70,7 +70,7 @@ These environment variables are used during installation (building CuPy from sou
 | ``CUPY_PYTHON_350_FORCE``   | Enforce CuPy to be installed against Python 3.5.0 (not         |
 |                             | recommended).                                                  |
 +-----------------------------+----------------------------------------------------------------+
-| ``CUPY_INSTALL_USE_HIP``    | For building the ROCm support, see :doc:`../install_rocm` for  |
+| ``CUPY_INSTALL_USE_HIP``    | For building the ROCm support, see :ref:`install_hip` for      |
 |                             | further detail.                                                |
 +-----------------------------+----------------------------------------------------------------+
 | ``CUPY_NVCC_GENERATE_CODE`` | To build CuPy for a particular CUDA architecture. For example, |

--- a/docs/source/reference/environment.rst
+++ b/docs/source/reference/environment.rst
@@ -5,7 +5,6 @@ Environment variables
 
 Here are the environment variables CuPy uses.
 
-
 +------------------------------------+----------------------------------------------------+
 | ``CUDA_PATH``                      | Path to the directory containing CUDA.             |
 |                                    | The parent of the directory containing ``nvcc`` is |
@@ -49,9 +48,14 @@ Here are the environment variables CuPy uses.
 |                                    | ``cupy_ndarray[:] = numpy_ndarray``                |
 +------------------------------------+----------------------------------------------------+
 
+Moreover, as in any CUDA programs, all of the CUDA environment variables listed in the `CUDA Toolkit
+Documentation`_ will also be honored.
 
-For install
------------
+.. _CUDA Toolkit Documentation: https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#env-vars
+
+
+For installation
+----------------
 
 These environment variables are used during installation (building CuPy from source).
 
@@ -70,5 +74,6 @@ These environment variables are used during installation (building CuPy from sou
 |                             | further detail.                                                |
 +-----------------------------+----------------------------------------------------------------+
 | ``CUPY_NVCC_GENERATE_CODE`` | To build CuPy for a particular CUDA architecture. For example, |
-|                             | ``CUPY_NVCC_GENERATE_CODE=compute_60,sm_60``.                  |
+|                             | ``CUPY_NVCC_GENERATE_CODE=compute_60,sm_60``. When this is not |
+|                             | set, the default is to support all architectures.              |
 +-----------------------------+----------------------------------------------------------------+


### PR DESCRIPTION
Closes #661. As per requested in https://github.com/cupy/cupy/issues/661#issuecomment-524750781. 

All of the env variables are searched via `grep --include=\*.{pyx,pxd,pxi,py} -R './' -e 'CUPY_'`. Except for `CUB_PATH` and `CUB_DISABLED` (to be discussed with CuPy core devs, see https://github.com/cupy/cupy/pull/2562#issuecomment-548390938), I hope I am not missing anything.