### PR TITLE
Add CUB support for `argmax()` and `argmin()`

### DIFF
--- a/cupy/core/_routines_statistics.pyx
+++ b/cupy/core/_routines_statistics.pyx
@@ -54,26 +54,28 @@ cdef ndarray _ndarray_min(ndarray self, axis, out, dtype, keepdims):
 # TODO(leofang): this signature is incompatible with NumPy!
 cdef ndarray _ndarray_argmax(ndarray self, axis, out, dtype, keepdims):
     if cupy.cuda.cub_enabled:
-        # Note that the signature of argmax only has axis and out, so we need to
-        # disable the rest
-        if cub.can_use_device_reduce(cub.CUPY_CUB_ARGMAX, self.dtype, self.ndim,
-                                     axis, None):
+        # Note that the NumPy signature of argmax only has axis and out, so we
+        # need to disable the rest. Moreover, to be compatible with NumPy, axis
+        # can only be None or integers
+        if axis is None and cub.can_use_device_reduce(
+            cub.CUPY_CUB_ARGMAX, self.dtype, self.ndim, axis, None):
             return cub.device_reduce(self, cub.CUPY_CUB_ARGMAX, out=out,
                                      keepdims=False)
-        # TODO(leofang): support device_segmented_reduce after arxmax is fixed
+        # TODO(leofang): support device_segmented_reduce for axis=-1?
     return _argmax(self, axis=axis, out=out, dtype=dtype, keepdims=keepdims)
 
 
 # TODO(leofang): this signature is incompatible with NumPy!
 cdef ndarray _ndarray_argmin(ndarray self, axis, out, dtype, keepdims):
     if cupy.cuda.cub_enabled:
-        # Note that the signature of argmin only has axis and out, so we need to
-        # disable the rest
-        if cub.can_use_device_reduce(cub.CUPY_CUB_ARGMIN, self.dtype, self.ndim,
-                                     axis, None):
+        # Note that the NumPy signature of argmax only has axis and out, so we
+        # need to disable the rest. Moreover, to be compatible with NumPy, axis
+        # can only be None or integers
+        if axis is None and cub.can_use_device_reduce(
+            cub.CUPY_CUB_ARGMIN, self.dtype, self.ndim, axis, None):
             return cub.device_reduce(self, cub.CUPY_CUB_ARGMIN, out=out,
                                      keepdims=False)
-        # TODO(leofang): support device_segmented_reduce after arxmin is fixed
+        # TODO(leofang): support device_segmented_reduce for axis=-1?
     return _argmin(self, axis=axis, out=out, dtype=dtype, keepdims=keepdims)
 
 

--- a/cupy/core/_routines_statistics.pyx
+++ b/cupy/core/_routines_statistics.pyx
@@ -52,9 +52,39 @@ cdef ndarray _ndarray_min(ndarray self, axis, out, dtype, keepdims):
 
 
 cdef ndarray _ndarray_argmax(ndarray self, axis, out, dtype, keepdims):
+    if cupy.cuda.cub_enabled:
+        if cub.can_use_device_reduce(cub.CUPY_CUB_ARGMAX, self.dtype, self.ndim,
+                                     axis, dtype):
+            return cub.device_reduce(self, cub.CUPY_CUB_ARGMAX, out=out,
+                                     keepdims=keepdims)
+        elif cub.can_use_device_segmented_reduce(
+                cub.CUPY_CUB_ARGMAX, self.dtype, self.ndim, axis, dtype):
+            if self.dtype in (numpy.complex64, numpy.complex128):
+                warnings.warn("CUB reduction for complex numbers may not be "
+                              "highly performant. If concerned, set "
+                              "cupy.cuda.cub_enabled=False to switch to CuPy's"
+                              " internal reduction routine and compare the "
+                              "timings.", util.PerformanceWarning)
+            return cub.device_segmented_reduce(
+                self, cub.CUPY_CUB_ARGMAX, axis, out=out, keepdims=keepdims)
     return _argmax(self, axis=axis, out=out, dtype=dtype, keepdims=keepdims)
 
 cdef ndarray _ndarray_argmin(ndarray self, axis, out, dtype, keepdims):
+    if cupy.cuda.cub_enabled:
+        if cub.can_use_device_reduce(cub.CUPY_CUB_ARGMIN, self.dtype, self.ndim,
+                                     axis, dtype):
+            return cub.device_reduce(self, cub.CUPY_CUB_ARGMIN, out=out,
+                                     keepdims=keepdims)
+        elif cub.can_use_device_segmented_reduce(
+                cub.CUPY_CUB_ARGMIN, self.dtype, self.ndim, axis, dtype):
+            if self.dtype in (numpy.complex64, numpy.complex128):
+                warnings.warn("CUB reduction for complex numbers may not be "
+                              "highly performant. If concerned, set "
+                              "cupy.cuda.cub_enabled=False to switch to CuPy's"
+                              " internal reduction routine and compare the "
+                              "timings.", util.PerformanceWarning)
+            return cub.device_segmented_reduce(
+                self, cub.CUPY_CUB_ARGMIN, axis, out=out, keepdims=keepdims)
     return _argmin(self, axis=axis, out=out, dtype=dtype, keepdims=keepdims)
 
 cdef ndarray _ndarray_mean(ndarray self, axis, dtype, out, keepdims):

--- a/cupy/core/_routines_statistics.pyx
+++ b/cupy/core/_routines_statistics.pyx
@@ -58,7 +58,7 @@ cdef ndarray _ndarray_argmax(ndarray self, axis, out, dtype, keepdims):
         # need to disable the rest. Moreover, to be compatible with NumPy, axis
         # can only be None or integers
         if axis is None and cub.can_use_device_reduce(
-            cub.CUPY_CUB_ARGMAX, self.dtype, self.ndim, axis, None):
+                cub.CUPY_CUB_ARGMAX, self.dtype, self.ndim, axis, None):
             return cub.device_reduce(self, cub.CUPY_CUB_ARGMAX, out=out,
                                      keepdims=False)
         # TODO(leofang): support device_segmented_reduce for axis=-1?
@@ -72,7 +72,7 @@ cdef ndarray _ndarray_argmin(ndarray self, axis, out, dtype, keepdims):
         # need to disable the rest. Moreover, to be compatible with NumPy, axis
         # can only be None or integers
         if axis is None and cub.can_use_device_reduce(
-            cub.CUPY_CUB_ARGMIN, self.dtype, self.ndim, axis, None):
+                cub.CUPY_CUB_ARGMIN, self.dtype, self.ndim, axis, None):
             return cub.device_reduce(self, cub.CUPY_CUB_ARGMIN, out=out,
                                      keepdims=False)
         # TODO(leofang): support device_segmented_reduce for axis=-1?

--- a/cupy/core/_routines_statistics.pyx
+++ b/cupy/core/_routines_statistics.pyx
@@ -51,41 +51,31 @@ cdef ndarray _ndarray_min(ndarray self, axis, out, dtype, keepdims):
     return _amin(self, axis=axis, out=out, dtype=dtype, keepdims=keepdims)
 
 
+# TODO(leofang): this signature is incompatible with NumPy!
 cdef ndarray _ndarray_argmax(ndarray self, axis, out, dtype, keepdims):
     if cupy.cuda.cub_enabled:
+        # Note that the signature of argmax only has axis and out, so we need to
+        # disable the rest
         if cub.can_use_device_reduce(cub.CUPY_CUB_ARGMAX, self.dtype, self.ndim,
-                                     axis, dtype):
+                                     axis, None):
             return cub.device_reduce(self, cub.CUPY_CUB_ARGMAX, out=out,
-                                     keepdims=keepdims)
-        elif cub.can_use_device_segmented_reduce(
-                cub.CUPY_CUB_ARGMAX, self.dtype, self.ndim, axis, dtype):
-            if self.dtype in (numpy.complex64, numpy.complex128):
-                warnings.warn("CUB reduction for complex numbers may not be "
-                              "highly performant. If concerned, set "
-                              "cupy.cuda.cub_enabled=False to switch to CuPy's"
-                              " internal reduction routine and compare the "
-                              "timings.", util.PerformanceWarning)
-            return cub.device_segmented_reduce(
-                self, cub.CUPY_CUB_ARGMAX, axis, out=out, keepdims=keepdims)
+                                     keepdims=False)
+        # TODO(leofang): support device_segmented_reduce after arxmax is fixed
     return _argmax(self, axis=axis, out=out, dtype=dtype, keepdims=keepdims)
 
+
+# TODO(leofang): this signature is incompatible with NumPy!
 cdef ndarray _ndarray_argmin(ndarray self, axis, out, dtype, keepdims):
     if cupy.cuda.cub_enabled:
+        # Note that the signature of argmin only has axis and out, so we need to
+        # disable the rest
         if cub.can_use_device_reduce(cub.CUPY_CUB_ARGMIN, self.dtype, self.ndim,
-                                     axis, dtype):
+                                     axis, None):
             return cub.device_reduce(self, cub.CUPY_CUB_ARGMIN, out=out,
-                                     keepdims=keepdims)
-        elif cub.can_use_device_segmented_reduce(
-                cub.CUPY_CUB_ARGMIN, self.dtype, self.ndim, axis, dtype):
-            if self.dtype in (numpy.complex64, numpy.complex128):
-                warnings.warn("CUB reduction for complex numbers may not be "
-                              "highly performant. If concerned, set "
-                              "cupy.cuda.cub_enabled=False to switch to CuPy's"
-                              " internal reduction routine and compare the "
-                              "timings.", util.PerformanceWarning)
-            return cub.device_segmented_reduce(
-                self, cub.CUPY_CUB_ARGMIN, axis, out=out, keepdims=keepdims)
+                                     keepdims=False)
+        # TODO(leofang): support device_segmented_reduce after arxmin is fixed
     return _argmin(self, axis=axis, out=out, dtype=dtype, keepdims=keepdims)
+
 
 cdef ndarray _ndarray_mean(ndarray self, axis, dtype, out, keepdims):
     return _mean(self, axis=axis, dtype=dtype, out=out, keepdims=keepdims)

--- a/cupy/cuda/cub.pxd
+++ b/cupy/cuda/cub.pxd
@@ -2,3 +2,5 @@ cpdef enum:
     CUPY_CUB_SUM = 0
     CUPY_CUB_MIN = 1
     CUPY_CUB_MAX = 2
+    CUPY_CUB_ARGMIN = 3
+    CUPY_CUB_ARGMAX = 4

--- a/cupy/cuda/cub.pyx
+++ b/cupy/cuda/cub.pyx
@@ -104,8 +104,8 @@ def device_reduce(ndarray x, int op, out=None, bint keepdims=False):
             "output parameter for reduction operation has the wrong number of "
             "dimensions")
     if op < 0 or op > 4:
-        raise ValueError("only CUPY_CUB_SUM, CUPY_CUB_MIN, and CUPY_CUB_MAX "
-                         "are supported.")
+        raise ValueError("only CUPY_CUB_SUM, CUPY_CUB_MIN, CUPY_CUB_MAX, "
+                         "CUPY_CUB_ARGMIN, and CUPY_CUB_ARGMAX are supported.")
     x = _internal_ascontiguousarray(x)
     if 0 <= op <= 2:
         y = ndarray((), x.dtype)
@@ -153,7 +153,7 @@ def device_segmented_reduce(ndarray x, int op, axis, out=None,
     cdef tuple out_shape
     cdef Stream_t s
 
-    if op < 0 or op > 4:
+    if op < 0 or op > 2:
         raise ValueError("only CUPY_CUB_SUM, CUPY_CUB_MIN, and CUPY_CUB_MAX "
                          "are supported.")
 

--- a/cupy/cuda/cub.pyx
+++ b/cupy/cuda/cub.pyx
@@ -103,11 +103,11 @@ def device_reduce(ndarray x, int op, out=None, bint keepdims=False):
         raise ValueError(
             "output parameter for reduction operation has the wrong number of "
             "dimensions")
-    if op < 0 or op > 4:
+    if op < CUPY_CUB_SUM or op > CUPY_CUB_ARGMAX:
         raise ValueError("only CUPY_CUB_SUM, CUPY_CUB_MIN, CUPY_CUB_MAX, "
                          "CUPY_CUB_ARGMIN, and CUPY_CUB_ARGMAX are supported.")
     x = _internal_ascontiguousarray(x)
-    if 0 <= op <= 2:
+    if CUPY_CUB_SUM <= op <= CUPY_CUB_MAX:
         y = ndarray((), x.dtype)
     else:  # argmin and argmax
         # cub::KeyValuePair has 1 int + 1 arbitrary type
@@ -123,7 +123,7 @@ def device_reduce(ndarray x, int op, out=None, bint keepdims=False):
     ws = ndarray(ws_size, numpy.int8)
     ws_ptr = <void *>ws.data.ptr
     cub_device_reduce(ws_ptr, ws_size, x_ptr, y_ptr, x.size, s, op, dtype_id)
-    if op > 2:  # argmin and argmax
+    if op == CUPY_CUB_ARGMIN or op == CUPY_CUB_ARGMAX:
         # get key from KeyValuePair: need to reinterpret the first 4 bytes
         # and then cast it
         y = y[0:4].view(numpy.int32).astype(numpy.int64)[0]
@@ -153,7 +153,7 @@ def device_segmented_reduce(ndarray x, int op, axis, out=None,
     cdef tuple out_shape
     cdef Stream_t s
 
-    if op < 0 or op > 2:
+    if op < CUPY_CUB_SUM or op > CUPY_CUB_MAX:
         raise ValueError("only CUPY_CUB_SUM, CUPY_CUB_MIN, and CUPY_CUB_MAX "
                          "are supported.")
 

--- a/cupy/cuda/cupy_cub.cu
+++ b/cupy/cuda/cupy_cub.cu
@@ -145,6 +145,56 @@ struct _cub_segmented_reduce_max {
 };
 
 //
+// **** CUB ArgMin ****
+//
+struct _cub_reduce_argmin {
+    template <typename T>
+    void operator()(void* workspace, size_t& workspace_size, void* x, void* y,
+        int num_items, cudaStream_t s)
+    {
+        DeviceReduce::ArgMin(workspace, workspace_size, static_cast<T*>(x),
+            static_cast<KeyValuePair<int, T>*>(y), num_items, s);
+    }
+};
+
+struct _cub_segmented_reduce_argmin {
+    template <typename T>
+    void operator()(void* workspace, size_t& workspace_size, void* x, void* y,
+        int num_segments, void* offset_start, void* offset_end, cudaStream_t s)
+    {
+        DeviceSegmentedReduce::ArgMin(workspace, workspace_size,
+            static_cast<T*>(x), static_cast<KeyValuePair<int, T>*>(y), num_segments,
+            static_cast<int*>(offset_start),
+            static_cast<int*>(offset_end), s);
+    }
+};
+
+//
+// **** CUB ArgMax ****
+//
+struct _cub_reduce_argmax {
+    template <typename T>
+    void operator()(void* workspace, size_t& workspace_size, void* x, void* y,
+        int num_items, cudaStream_t s)
+    {
+        DeviceReduce::ArgMax(workspace, workspace_size, static_cast<T*>(x),
+            static_cast<KeyValuePair<int, T>*>(y), num_items, s);
+    }
+};
+
+struct _cub_segmented_reduce_argmax {
+    template <typename T>
+    void operator()(void* workspace, size_t& workspace_size, void* x, void* y,
+        int num_segments, void* offset_start, void* offset_end, cudaStream_t s)
+    {
+        DeviceSegmentedReduce::ArgMax(workspace, workspace_size,
+            static_cast<T*>(x), static_cast<KeyValuePair<int, T>*>(y), num_segments,
+            static_cast<int*>(offset_start),
+            static_cast<int*>(offset_end), s);
+    }
+};
+
+//
 // APIs exposed to CuPy
 //
 
@@ -154,12 +204,16 @@ void cub_device_reduce(void* workspace, size_t& workspace_size, void* x, void* y
     int num_items, cudaStream_t stream, int op, int dtype_id)
 {
     switch(op) {
-    case CUPY_CUB_SUM:  return dtype_dispatcher(dtype_id, _cub_reduce_sum(),
-                            workspace, workspace_size, x, y, num_items, stream);
-    case CUPY_CUB_MIN:  return dtype_dispatcher(dtype_id, _cub_reduce_min(),
-                            workspace, workspace_size, x, y, num_items, stream);
-    case CUPY_CUB_MAX:  return dtype_dispatcher(dtype_id, _cub_reduce_max(),
-                            workspace, workspace_size, x, y, num_items, stream);
+    case CUPY_CUB_SUM:      return dtype_dispatcher(dtype_id, _cub_reduce_sum(),
+                                workspace, workspace_size, x, y, num_items, stream);
+    case CUPY_CUB_MIN:      return dtype_dispatcher(dtype_id, _cub_reduce_min(),
+                                workspace, workspace_size, x, y, num_items, stream);
+    case CUPY_CUB_MAX:      return dtype_dispatcher(dtype_id, _cub_reduce_max(),
+                                workspace, workspace_size, x, y, num_items, stream);
+    case CUPY_CUB_ARGMIN:   return dtype_dispatcher(dtype_id, _cub_reduce_argmin(),
+                                workspace, workspace_size, x, y, num_items, stream);
+    case CUPY_CUB_ARGMAX:   return dtype_dispatcher(dtype_id, _cub_reduce_argmax(),
+                                workspace, workspace_size, x, y, num_items, stream);
     default:            throw std::runtime_error("Unsupported operation");
     }
 }
@@ -190,6 +244,14 @@ void cub_device_segmented_reduce(void* workspace, size_t& workspace_size,
                    offset_end, stream);
     case CUPY_CUB_MAX:
         return dtype_dispatcher(dtype_id, _cub_segmented_reduce_max(),
+                   workspace, workspace_size, x, y, num_segments, offset_start,
+                   offset_end, stream);
+    case CUPY_CUB_ARGMIN:
+        return dtype_dispatcher(dtype_id, _cub_segmented_reduce_argmin(),
+                   workspace, workspace_size, x, y, num_segments, offset_start,
+                   offset_end, stream);
+    case CUPY_CUB_ARGMAX:
+        return dtype_dispatcher(dtype_id, _cub_segmented_reduce_argmax(),
                    workspace, workspace_size, x, y, num_segments, offset_start,
                    offset_end, stream);
     default:

--- a/cupy/cuda/cupy_cub.cu
+++ b/cupy/cuda/cupy_cub.cu
@@ -157,17 +157,7 @@ struct _cub_reduce_argmin {
     }
 };
 
-struct _cub_segmented_reduce_argmin {
-    template <typename T>
-    void operator()(void* workspace, size_t& workspace_size, void* x, void* y,
-        int num_segments, void* offset_start, void* offset_end, cudaStream_t s)
-    {
-        DeviceSegmentedReduce::ArgMin(workspace, workspace_size,
-            static_cast<T*>(x), static_cast<KeyValuePair<int, T>*>(y), num_segments,
-            static_cast<int*>(offset_start),
-            static_cast<int*>(offset_end), s);
-    }
-};
+// TODO(leofang): add _cub_segmented_reduce_argmin
 
 //
 // **** CUB ArgMax ****
@@ -182,17 +172,7 @@ struct _cub_reduce_argmax {
     }
 };
 
-struct _cub_segmented_reduce_argmax {
-    template <typename T>
-    void operator()(void* workspace, size_t& workspace_size, void* x, void* y,
-        int num_segments, void* offset_start, void* offset_end, cudaStream_t s)
-    {
-        DeviceSegmentedReduce::ArgMax(workspace, workspace_size,
-            static_cast<T*>(x), static_cast<KeyValuePair<int, T>*>(y), num_segments,
-            static_cast<int*>(offset_start),
-            static_cast<int*>(offset_end), s);
-    }
-};
+// TODO(leofang): add _cub_segmented_reduce_argmax
 
 //
 // APIs exposed to CuPy
@@ -244,14 +224,6 @@ void cub_device_segmented_reduce(void* workspace, size_t& workspace_size,
                    offset_end, stream);
     case CUPY_CUB_MAX:
         return dtype_dispatcher(dtype_id, _cub_segmented_reduce_max(),
-                   workspace, workspace_size, x, y, num_segments, offset_start,
-                   offset_end, stream);
-    case CUPY_CUB_ARGMIN:
-        return dtype_dispatcher(dtype_id, _cub_segmented_reduce_argmin(),
-                   workspace, workspace_size, x, y, num_segments, offset_start,
-                   offset_end, stream);
-    case CUPY_CUB_ARGMAX:
-        return dtype_dispatcher(dtype_id, _cub_segmented_reduce_argmax(),
                    workspace, workspace_size, x, y, num_segments, offset_start,
                    offset_end, stream);
     default:

--- a/cupy/cuda/cupy_cub.h
+++ b/cupy/cuda/cupy_cub.h
@@ -15,9 +15,11 @@
 #define CUPY_CUB_COMPLEX64  11
 #define CUPY_CUB_COMPLEX128 12
 
-#define CUPY_CUB_SUM  0
-#define CUPY_CUB_MIN  1
-#define CUPY_CUB_MAX  2
+#define CUPY_CUB_SUM     0
+#define CUPY_CUB_MIN     1
+#define CUPY_CUB_MAX     2
+#define CUPY_CUB_ARGMIN  3
+#define CUPY_CUB_ARGMAX  4
 
 #ifndef CUPY_NO_CUDA
 #include <cuda_runtime.h>  // for cudaStream_t


### PR DESCRIPTION
This PR is made easy based on the refactoring in #2562. Part of #2519.

Notes:
1. Currently an explicit `axis` argument is not supported. In fact, I am a bit reluctant to add CUB support for it because of two reasons:
    - According to the NumPy behavior `axis` can only be an integer, not a tuple (see #2595), meaning that only the special case `axis=-1` (searching over the last axis) can be benefited by `device_segmented_reduce` added in #2562, which doesn't seem worth the time...
    - On the technical side, the output of `device_segmented_reduce` would be an array of key-value pairs. I am not sure what's the best way to retrieve the keys (i.e. the wanted array indices). Seems like I need one extra kernel launch to loop data over and copy keys to another device array? Any comment or suggestion is welcome, as I think the core devs should have some experience for how to handle it. 
(You already did this in `_argmax` and `_argmin`, although I don't fully understand how it works there.)
2. The implementation already has the NumPy compatibility in mind (#2595).