### PR TITLE
Support primitive complex scalar in `RawKernel`

### DIFF
--- a/cupy/cuda/function.pyx
+++ b/cupy/cuda/function.pyx
@@ -107,6 +107,8 @@ cdef inline CPointer _pointer(x):
             x = numpy.float64(x)
         elif isinstance(x, bool):
             x = numpy.bool_(x)
+        elif isinstance(x, complex):
+            x = numpy.complex128(x)
         else:
             raise TypeError('Unsupported type %s' % type(x))
 

--- a/docs/source/tutorial/kernel.rst
+++ b/docs/source/tutorial/kernel.rst
@@ -259,7 +259,7 @@ Accessing texture (surface) memory in :class:`~cupy.RawKernel` is supported via 
     No validation will be performed by CuPy for arguments passed to the kernel, including types and number of arguments.
     Especially note that when passing :class:`~cupy.ndarray`, its ``dtype`` should match with the type of the argument declared in the method signature of the CUDA source code (unless you are casting arrays intentionally).
     For example, ``cupy.float32`` and ``cupy.uint64`` arrays must be passed to the argument typed as ``float*`` and ``unsigned long long*``.
-    For Python primitive types, ``int``, ``float`` and ``bool`` map to ``long long``, ``double`` and ``bool``, respectively.
+    For Python primitive types, ``int``, ``float``, ``complex`` and ``bool`` map to ``long long``, ``double``, ``cuDoubleComplex`` and ``bool``, respectively.
 
 .. note::
     When using ``printf()`` in your CUDA kernel, you may need to synchronize the stream to see the output.


### PR DESCRIPTION
Fix for Python complex scalar inputs.