### PR TITLE
TST/ENH: have the parameterize decorator generate descriptive ids

### DIFF
--- a/cupy/testing/parameterized.py
+++ b/cupy/testing/parameterized.py
@@ -62,8 +62,7 @@ def _idval(val, argname, i):
         return str(val)
     elif isinstance(val, REGEX_TYPE):
         return _ascii_escaped(val.pattern)
-    elif ((inspect.isclass(val) or inspect.isfunction(val)) and
-            hasattr(val, "__name__")):
+    elif hasattr(val, "__name__"):
         return val.__name__
     return str(argname) + str(i)
 

--- a/cupy/testing/parameterized.py
+++ b/cupy/testing/parameterized.py
@@ -1,15 +1,84 @@
+import enum
 import functools
 import inspect
 import itertools
+import re
 import sys
 import types
 import unittest
 
 import six
 
+STRING_TYPES = bytes, str
+
+# The type of re.compile objects is not exposed in Python.
+REGEX_TYPE = type(re.compile(""))
+
+_non_printable_ascii_translate_table = {
+    i: "\\x{:02x}".format(i) for i in range(128) if i not in range(32, 127)
+}
+_non_printable_ascii_translate_table.update(
+    {ord("\t"): "\\t", ord("\r"): "\\r", ord("\n"): "\\n"}
+)
+
+
+def _translate_non_printable(s):
+    return s.translate(_non_printable_ascii_translate_table)
+
+
+def _ascii_escaped(val):
+    """If val is pure ascii, returns it as a str().  Otherwise, escapes
+    bytes objects into a sequence of escaped bytes:
+
+    b'\xc3\xb4\xc5\xd6' -> '\\xc3\\xb4\\xc5\\xd6'
+
+    and escapes unicode objects into a sequence of escaped unicode
+    ids, e.g.:
+
+    '4\\nV\\U00043efa\\x0eMXWB\\x1e\\u3028\\u15fd\\xcd\\U0007d944'
+
+    note:
+       the obvious "v.decode('unicode-escape')" will return
+       valid utf-8 unicode if it finds them in bytes, but we
+       want to return escaped bytes for any byte, even if they match
+       a utf-8 string.
+
+    """
+    if isinstance(val, bytes):
+        ret = _bytes_to_ascii(val)
+    else:
+        ret = val.encode("unicode_escape").decode("ascii")
+    return _translate_non_printable(ret)
+
+
+def _bytes_to_ascii(val):
+    return val.decode("ascii", "backslashreplace")
+
+
+def _idval(val, argname, i):
+    if isinstance(val, STRING_TYPES):
+        return _ascii_escaped(val)
+    elif val is None or isinstance(val, (float, int, bool, enum.Enum)):
+        return str(val)
+    elif isinstance(val, REGEX_TYPE):
+        return _ascii_escaped(val.pattern)
+    elif ((inspect.isclass(val) or inspect.isfunction(val)) and
+            hasattr(val, "__name__")):
+        return val.__name__
+    return str(argname) + str(i)
+
+
+def _idmaker(param, i):
+    """Generate a descriptive id for the parameter set.
+
+    This is simplified from private code internal to pytest.
+    """
+    ids = [_idval(v, k, i) for k, v in param.items()]
+    return '[' + '-'.join(ids) + ']'
+
 
 def _gen_case(base, module, i, param):
-    cls_name = '%s_param_%d' % (base.__name__, i)
+    cls_name = '%s%s' % (base.__name__, _idmaker(param, i))
 
     # Add parameters as members
 

--- a/cupy/testing/parameterized.py
+++ b/cupy/testing/parameterized.py
@@ -2,66 +2,18 @@ import enum
 import functools
 import inspect
 import itertools
-import re
 import sys
 import types
 import unittest
 
 import six
 
-STRING_TYPES = bytes, str
-
-# The type of re.compile objects is not exposed in Python.
-REGEX_TYPE = type(re.compile(""))
-
-_non_printable_ascii_translate_table = {
-    i: "\\x{:02x}".format(i) for i in range(128) if i not in range(32, 127)
-}
-_non_printable_ascii_translate_table.update(
-    {ord("\t"): "\\t", ord("\r"): "\\r", ord("\n"): "\\n"}
-)
-
-
-def _translate_non_printable(s):
-    return s.translate(_non_printable_ascii_translate_table)
-
-
-def _ascii_escaped(val):
-    """If val is pure ascii, returns it as a str().  Otherwise, escapes
-    bytes objects into a sequence of escaped bytes:
-
-    b'\xc3\xb4\xc5\xd6' -> '\\xc3\\xb4\\xc5\\xd6'
-
-    and escapes unicode objects into a sequence of escaped unicode
-    ids, e.g.:
-
-    '4\\nV\\U00043efa\\x0eMXWB\\x1e\\u3028\\u15fd\\xcd\\U0007d944'
-
-    note:
-       the obvious "v.decode('unicode-escape')" will return
-       valid utf-8 unicode if it finds them in bytes, but we
-       want to return escaped bytes for any byte, even if they match
-       a utf-8 string.
-
-    """
-    if isinstance(val, bytes):
-        ret = _bytes_to_ascii(val)
-    else:
-        ret = val.encode("unicode_escape").decode("ascii")
-    return _translate_non_printable(ret)
-
-
-def _bytes_to_ascii(val):
-    return val.decode("ascii", "backslashreplace")
-
 
 def _idval(val, argname, i):
-    if isinstance(val, STRING_TYPES):
-        return _ascii_escaped(val)
+    if isinstance(val, str):
+        return str
     elif val is None or isinstance(val, (float, int, bool, enum.Enum)):
         return str(val)
-    elif isinstance(val, REGEX_TYPE):
-        return _ascii_escaped(val.pattern)
     elif hasattr(val, "__name__"):
         return val.__name__
     return str(argname) + str(i)


### PR DESCRIPTION
`pytest.mark.parametrize` generates descriptive IDs for the parameters provided.

This PR provides similar behavior for the `cupy.testing.parameterize` decorator. 

Prior to the present PR, this decorator justt enumerates the parameters as "_param_0", "_param_1", etc.
A concrete example:
```
tests/cupy_tests/creation_tests/test_from_data.py::TestArrayCopy_param_0.test_cupy_array ✓                20% ██▏       
tests/cupy_tests/creation_tests/test_from_data.py::TestArrayCopy_param_1.test_cupy_array ✓                22% ██▎       
tests/cupy_tests/creation_tests/test_from_data.py::TestArrayCopy_param_2.test_cupy_array ✓                23% ██▍       
tests/cupy_tests/creation_tests/test_from_data.py::TestArrayCopy_param_3.test_cupy_array ✓                24% ██▌       
tests/cupy_tests/creation_tests/test_from_data.py::TestArrayCopy_param_4.test_cupy_array ✓                25% ██▌       
tests/cupy_tests/creation_tests/test_from_data.py::TestArrayCopy_param_5.test_cupy_array ✓                27% ██▋       
tests/cupy_tests/creation_tests/test_from_data.py::TestArrayCopy_param_6.test_cupy_array ✓                28% ██▊       
tests/cupy_tests/creation_tests/test_from_data.py::TestArrayCopy_param_7.test_cupy_array ✓                29% ██▉       
tests/cupy_tests/creation_tests/test_from_data.py::TestArrayCopy_param_8.test_cupy_array ✓                30% ███       
tests/cupy_tests/creation_tests/test_from_data.py::TestArrayCopy_param_9.test_cupy_array ✓                31% ███▎      
tests/cupy_tests/creation_tests/test_from_data.py::TestArrayCopy_param_10.test_cupy_array ✓               33% ███▍      
tests/cupy_tests/creation_tests/test_from_data.py::TestArrayCopy_param_11.test_cupy_array ✓               34% ███▍      
tests/cupy_tests/creation_tests/test_from_data.py::TestArrayCopy_param_12.test_cupy_array ✓               35% ███▌      
tests/cupy_tests/creation_tests/test_from_data.py::TestArrayCopy_param_13.test_cupy_array ✓               36% ███▋      
tests/cupy_tests/creation_tests/test_from_data.py::TestArrayCopy_param_14.test_cupy_array ✓               37% ███▊      
tests/cupy_tests/creation_tests/test_from_data.py::TestArrayCopy_param_15.test_cupy_array ✓               39% ███▉      
```

after this PR, more decriptive ids are generated
```
tests/cupy_tests/creation_tests/test_from_data.py::TestArrayCopy[True-0-numpy].test_cupy_array ✓          20% ██▏       
tests/cupy_tests/creation_tests/test_from_data.py::TestArrayCopy[True-0-cupy].test_cupy_array ✓           22% ██▎       
tests/cupy_tests/creation_tests/test_from_data.py::TestArrayCopy[True-1-numpy].test_cupy_array ✓          23% ██▍       
tests/cupy_tests/creation_tests/test_from_data.py::TestArrayCopy[True-1-cupy].test_cupy_array ✓           24% ██▌       
tests/cupy_tests/creation_tests/test_from_data.py::TestArrayCopy[True-2-numpy].test_cupy_array ✓          25% ██▌       
tests/cupy_tests/creation_tests/test_from_data.py::TestArrayCopy[True-2-cupy].test_cupy_array ✓           27% ██▋       
tests/cupy_tests/creation_tests/test_from_data.py::TestArrayCopy[True-3-numpy].test_cupy_array ✓          28% ██▊       
tests/cupy_tests/creation_tests/test_from_data.py::TestArrayCopy[True-3-cupy].test_cupy_array ✓           29% ██▉       
tests/cupy_tests/creation_tests/test_from_data.py::TestArrayCopy[False-0-numpy].test_cupy_array ✓         30% ███       
tests/cupy_tests/creation_tests/test_from_data.py::TestArrayCopy[False-0-cupy].test_cupy_array ✓          31% ███▎      
tests/cupy_tests/creation_tests/test_from_data.py::TestArrayCopy[False-1-numpy].test_cupy_array ✓         33% ███▍      
tests/cupy_tests/creation_tests/test_from_data.py::TestArrayCopy[False-1-cupy].test_cupy_array ✓          34% ███▍      
tests/cupy_tests/creation_tests/test_from_data.py::TestArrayCopy[False-2-numpy].test_cupy_array ✓         35% ███▌      
tests/cupy_tests/creation_tests/test_from_data.py::TestArrayCopy[False-2-cupy].test_cupy_array ✓          36% ███▋      
tests/cupy_tests/creation_tests/test_from_data.py::TestArrayCopy[False-3-numpy].test_cupy_array ✓         37% ███▊      
tests/cupy_tests/creation_tests/test_from_data.py::TestArrayCopy[False-3-cupy].test_cupy_array ✓          39% ███▉      
```


I find this useful when testing to more quickly determine which cases are failing.