### PR TITLE
Implement `tobytes` for CuPy arrays

### DIFF
--- a/cupy/core/core.pxd
+++ b/cupy/core/core.pxd
@@ -20,6 +20,7 @@ cdef class ndarray:
 
     cpdef item(self)
     cpdef tolist(self)
+    cpdef bytes tobytes(self, order=*)
     cpdef tofile(self, fid, sep=*, format=*)
     cpdef dump(self, file)
     cpdef dumps(self)

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -294,7 +294,10 @@ cdef class ndarray:
 
     # TODO(okuta): Implement itemset
     # TODO(okuta): Implement tostring
-    # TODO(okuta): Implement tobytes
+
+    cpdef bytes tobytes(self, order='C'):
+        """Turns the array into a Python bytes object."""
+        return self.get().tobytes(order)
 
     cpdef tofile(self, fid, sep='', format='%s'):
         """Writes the array to a file.

--- a/tests/cupy_tests/core_tests/test_ndarray_conversion.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_conversion.py
@@ -41,7 +41,7 @@ class TestNdarrayToBytes(unittest.TestCase):
     @testing.for_all_dtypes()
     @testing.numpy_cupy_equal()
     def test_item(self, xp, dtype):
-        a = testing.shaped_arange(self.shape, xp, xp.int64)
+        a = testing.shaped_arange(self.shape, xp, dtype)
         if hasattr(self, 'order'):
             return a.tobytes(self.order)
         else:

--- a/tests/cupy_tests/core_tests/test_ndarray_conversion.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_conversion.py
@@ -28,3 +28,21 @@ class TestNdarrayItemRaise(unittest.TestCase):
     def test_item(self, xp):
         a = testing.shaped_arange(self.shape, xp, xp.float32)
         a.item()
+
+
+@testing.parameterize(
+    {'shape': (1,)},
+    {'shape': (2, 3)},
+    {'shape': (2, 3), 'order': 'C'},
+    {'shape': (2, 3), 'order': 'F'},
+)
+class TestNdarrayToBytes(unittest.TestCase):
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_equal()
+    def test_item(self, xp, dtype):
+        a = testing.shaped_arange(self.shape, xp, xp.int64)
+        if hasattr(self, 'order'):
+            return a.tobytes(self.order)
+        else:
+            return a.tobytes()

--- a/tests/cupy_tests/core_tests/test_ndarray_conversion.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_conversion.py
@@ -31,6 +31,7 @@ class TestNdarrayItemRaise(unittest.TestCase):
 
 
 @testing.parameterize(
+    {'shape': ()},
     {'shape': (1,)},
     {'shape': (2, 3)},
     {'shape': (2, 3), 'order': 'C'},


### PR DESCRIPTION
Makes a simple implementation of `tobytes` for CuPy arrays, which converts the data back into a NumPy array and let's NumPy do the heavy lifting.