### PR TITLE
Add fromfile

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -258,6 +258,7 @@ from cupy.creation.from_data import array  # NOQA
 from cupy.creation.from_data import asanyarray  # NOQA
 from cupy.creation.from_data import asarray  # NOQA
 from cupy.creation.from_data import ascontiguousarray  # NOQA
+from cupy.creation.from_data import fromfile  # NOQA
 
 from cupy.creation.ranges import arange  # NOQA
 from cupy.creation.ranges import linspace  # NOQA

--- a/cupy/creation/from_data.py
+++ b/cupy/creation/from_data.py
@@ -145,7 +145,7 @@ def fromfile(file, dtype=float, count=-1, sep='', offset=0):
     .. note::
         Uses NumPy's ``fromfile`` and coerces the result to a CuPy array.
 
-    .. seealso:: func:`numpy.fromfile`
+    .. seealso:: :func:`numpy.fromfile`
     """
 
     return asarray(numpy.fromfile(file, dtype, count, sep, offset))

--- a/cupy/creation/from_data.py
+++ b/cupy/creation/from_data.py
@@ -1,3 +1,5 @@
+import numpy
+
 from cupy import core
 from cupy.core import fusion
 
@@ -137,7 +139,8 @@ def copy(a, order='K'):
 # TODO(okuta): Implement frombuffer
 
 
-# TODO(okuta): Implement fromfile
+def fromfile(file, dtype=float, count=-1, sep='', offset=0):
+    return asarray(numpy.fromfile(file, dtype, count, sep, offset))
 
 
 # TODO(okuta): Implement fromfunction

--- a/cupy/creation/from_data.py
+++ b/cupy/creation/from_data.py
@@ -140,6 +140,14 @@ def copy(a, order='K'):
 
 
 def fromfile(file, dtype=float, count=-1, sep='', offset=0):
+    """Reads an array from a file.
+
+    .. note::
+        Uses NumPy's ``fromfile`` and coerces the result to a CuPy array.
+
+    .. seealso:: func:`numpy.fromfile`
+    """
+
     return asarray(numpy.fromfile(file, dtype, count, sep, offset))
 
 

--- a/cupy/creation/from_data.py
+++ b/cupy/creation/from_data.py
@@ -139,7 +139,7 @@ def copy(a, order='K'):
 # TODO(okuta): Implement frombuffer
 
 
-def fromfile(file, dtype=float, count=-1, sep='', offset=0):
+def fromfile(*args, **kwargs):
     """Reads an array from a file.
 
     .. note::
@@ -148,7 +148,7 @@ def fromfile(file, dtype=float, count=-1, sep='', offset=0):
     .. seealso:: :func:`numpy.fromfile`
     """
 
-    return asarray(numpy.fromfile(file, dtype, count, sep, offset))
+    return asarray(numpy.fromfile(*args, **kwargs))
 
 
 # TODO(okuta): Implement fromfunction

--- a/cupy/io/__init__.py
+++ b/cupy/io/__init__.py
@@ -4,5 +4,4 @@
 # "NOQA" to suppress flake8 warning
 from cupy.io import formatting  # NOQA
 from cupy.io import npz  # NOQA
-from cupy.io import rawfile  # NOQA
 from cupy.io import text  # NOQA

--- a/cupy/io/rawfile.py
+++ b/cupy/io/rawfile.py
@@ -1,4 +1,0 @@
-# flake8: NOQA
-# "flake8: NOQA" to suppress warning "H104  File contains nothing but comments"
-
-# TODO(okuta): Implement fromfile

--- a/tests/cupy_tests/creation_tests/test_from_data.py
+++ b/tests/cupy_tests/creation_tests/test_from_data.py
@@ -1,3 +1,4 @@
+import tempfile
 import unittest
 
 import pytest
@@ -473,6 +474,14 @@ class TestFromData(unittest.TestCase):
             self, xp, dtype_a, dtype_b):
         a = xp.ones((), dtype=dtype_a)
         return xp.asfortranarray(a, dtype=dtype_b)
+
+    @testing.numpy_cupy_array_equal()
+    def test_fromfile(self, xp):
+        with tempfile.TemporaryFile() as fh:
+            fh.write(b"\x00\x01\x02\x03\x04")
+            fh.flush()
+            fh.seek(0)
+            return xp.fromfile(fh, dtype="u1")
 
 
 class DummyObjectWithCudaArrayInterface(object):

--- a/tests/cupy_tests/io_tests/test_rawfile.py
+++ b/tests/cupy_tests/io_tests/test_rawfile.py
@@ -1,9 +1,0 @@
-import unittest
-
-from cupy import testing
-
-
-@testing.gpu
-class TestRawfile(unittest.TestCase):
-
-    pass


### PR DESCRIPTION
For now this does the simple thing of calling `numpy.fromfile` and converting the result to a CuPy array, which is returned. In the future this could be replaced by something more optimal (like https://github.com/cupy/cupy/issues/2576 ;).