### PR TITLE
Remove stubs for APIs dropped in CUDA 10.1 Update 2

### DIFF
--- a/cupy/cuda/cupy_cusparse.h
+++ b/cupy/cuda/cupy_cusparse.h
@@ -564,22 +564,6 @@ cusparseStatus_t cusparseZcsrilu02_bufferSize(...) {
   return CUSPARSE_STATUS_SUCCESS;
 }
 
-cusparseStatus_t cusparseScsrilu02_bufferSizeExt(...) {
-  return CUSPARSE_STATUS_SUCCESS;
-}
-
-cusparseStatus_t cusparseDcsrilu02_bufferSizeExt(...) {
-  return CUSPARSE_STATUS_SUCCESS;
-}
-
-cusparseStatus_t cusparseCcsrilu02_bufferSizeExt(...) {
-  return CUSPARSE_STATUS_SUCCESS;
-}
-
-cusparseStatus_t cusparseZcsrilu02_bufferSizeExt(...) {
-  return CUSPARSE_STATUS_SUCCESS;
-}
-
 cusparseStatus_t cusparseScsrilu02_analysis(...) {
   return CUSPARSE_STATUS_SUCCESS;
 }
@@ -648,22 +632,6 @@ cusparseStatus_t cusparseZbsrilu02_bufferSize(...) {
   return CUSPARSE_STATUS_SUCCESS;
 }
 
-cusparseStatus_t cusparseSbsrilu02_bufferSizeExt(...) {
-  return CUSPARSE_STATUS_SUCCESS;
-}
-
-cusparseStatus_t cusparseDbsrilu02_bufferSizeExt(...) {
-  return CUSPARSE_STATUS_SUCCESS;
-}
-
-cusparseStatus_t cusparseCbsrilu02_bufferSizeExt(...) {
-  return CUSPARSE_STATUS_SUCCESS;
-}
-
-cusparseStatus_t cusparseZbsrilu02_bufferSizeExt(...) {
-  return CUSPARSE_STATUS_SUCCESS;
-}
-
 cusparseStatus_t cusparseSbsrilu02_analysis(...) {
   return CUSPARSE_STATUS_SUCCESS;
 }
@@ -716,22 +684,6 @@ cusparseStatus_t cusparseZcsric02_bufferSize(...) {
   return CUSPARSE_STATUS_SUCCESS;
 }
 
-cusparseStatus_t cusparseScsric02_bufferSizeExt(...) {
-  return CUSPARSE_STATUS_SUCCESS;
-}
-
-cusparseStatus_t cusparseDcsric02_bufferSizeExt(...) {
-  return CUSPARSE_STATUS_SUCCESS;
-}
-
-cusparseStatus_t cusparseCcsric02_bufferSizeExt(...) {
-  return CUSPARSE_STATUS_SUCCESS;
-}
-
-cusparseStatus_t cusparseZcsric02_bufferSizeExt(...) {
-  return CUSPARSE_STATUS_SUCCESS;
-}
-
 cusparseStatus_t cusparseScsric02_analysis(...) {
   return CUSPARSE_STATUS_SUCCESS;
 }
@@ -781,22 +733,6 @@ cusparseStatus_t cusparseCbsric02_bufferSize(...) {
 }
 
 cusparseStatus_t cusparseZbsric02_bufferSize(...) {
-  return CUSPARSE_STATUS_SUCCESS;
-}
-
-cusparseStatus_t cusparseSbsric02_bufferSizeExt(...) {
-  return CUSPARSE_STATUS_SUCCESS;
-}
-
-cusparseStatus_t cusparseDbsric02_bufferSizeExt(...) {
-  return CUSPARSE_STATUS_SUCCESS;
-}
-
-cusparseStatus_t cusparseCbsric02_bufferSizeExt(...) {
-  return CUSPARSE_STATUS_SUCCESS;
-}
-
-cusparseStatus_t cusparseZbsric02_bufferSizeExt(...) {
   return CUSPARSE_STATUS_SUCCESS;
 }
 


### PR DESCRIPTION
Follow-up for #2573