### PR TITLE
Add support of complex dtypes for `sinc`

### DIFF
--- a/cupy/math/special.py
+++ b/cupy/math/special.py
@@ -12,8 +12,9 @@ i0 = ufunc.create_math_ufunc(
 
 
 sinc = core.create_ufunc(
-    'cupy_sinc', ('e->e', 'f->f', 'd->d'),
-    'out0 = abs(in0) > 1e-9 ? sinpi(in0) / (M_PI * in0) : 1',
+    'cupy_sinc', ('e->e', 'f->f', 'd->d', 'F->F', 'D->D'),
+    'in0_type pi_in0 = (in0_type) M_PI * in0;'
+    'out0 = abs(in0) > 1e-9 ? sin(pi_in0) / (pi_in0) : 1',
     doc='''Elementwise sinc function.
 
     .. seealso:: :func:`numpy.sinc`

--- a/cupy/math/special.py
+++ b/cupy/math/special.py
@@ -12,9 +12,13 @@ i0 = ufunc.create_math_ufunc(
 
 
 sinc = core.create_ufunc(
-    'cupy_sinc', ('e->e', 'f->f', 'd->d', 'F->F', 'D->D'),
-    'in0_type pi_in0 = (in0_type) M_PI * in0;'
-    'out0 = abs(in0) > 1e-9 ? sin(pi_in0) / (pi_in0) : 1',
+    'cupy_sinc',
+    ('e->e', 'f->f', 'd->',
+     ('F->F', 'in0_type pi_in0 = (in0_type) M_PI * in0;'
+              'out0 = abs(in0) > 1e-9 ? sin(pi_in0) / (pi_in0) : 1'),
+     ('D->D', 'in0_type pi_in0 = (in0_type) M_PI * in0;'
+              'out0 = abs(in0) > 1e-9 ? sin(pi_in0) / (pi_in0) : 1')),
+    'out0 = abs(in0) > 1e-9 ? sinpi(in0) / (M_PI * in0) : 1',
     doc='''Elementwise sinc function.
 
     .. seealso:: :func:`numpy.sinc`

--- a/cupy/math/special.py
+++ b/cupy/math/special.py
@@ -13,7 +13,7 @@ i0 = ufunc.create_math_ufunc(
 
 sinc = core.create_ufunc(
     'cupy_sinc',
-    ('e->e', 'f->f', 'd->',
+    ('e->e', 'f->f', 'd->d',
      ('F->F', 'in0_type pi_in0 = (in0_type) M_PI * in0;'
               'out0 = abs(in0) > 1e-9 ? sin(pi_in0) / (pi_in0) : 1'),
      ('D->D', 'in0_type pi_in0 = (in0_type) M_PI * in0;'

--- a/tests/cupy_tests/math_tests/test_special.py
+++ b/tests/cupy_tests/math_tests/test_special.py
@@ -13,13 +13,13 @@ class TestSpecial(unittest.TestCase):
         a = testing.shaped_random((2, 3), xp, dtype)
         return xp.i0(a)
 
-    @testing.for_dtypes(['e', 'f', 'd'])
+    @testing.for_dtypes(['e', 'f', 'd', 'F', 'D'])
     @testing.numpy_cupy_allclose(atol=1e-3)
     def test_sinc(self, xp, dtype):
-        a = testing.shaped_random((2, 3), xp, dtype)
+        a = testing.shaped_random((2, 3), xp, dtype, scale=1)
         return xp.sinc(a)
 
-    @testing.for_dtypes(['e', 'f', 'd'])
+    @testing.for_dtypes(['e', 'f', 'd', 'F', 'D'])
     def test_sinc_zero(self, dtype):
         a = cupy.sinc(cupy.zeros(1, dtype=dtype))
         testing.assert_array_equal(a, cupy.ones(1, dtype=dtype))


### PR DESCRIPTION
Closes #2645 

`sinpi` is a cuda only function that does not have an equivalent in thrust for complex numbers.
Note that the original numpy implementation uses the product of pi instead of an optimized sin.

Question:
Should we split the routines using a dispatcher, as the ufuncs doesnt seem to support overloading functions, one for complex and one for non-complex numbers?