### PR TITLE
[backport] Do not allow `reshape` on empty arrays

### DIFF
--- a/cupy/core/_routines_manipulation.pyx
+++ b/cupy/core/_routines_manipulation.pyx
@@ -333,6 +333,11 @@ cpdef ndarray _reshape(ndarray self,
     if internal.vector_equal(shape, self._shape):
         return self.view()
 
+    cdef size_t shape_size = internal.prod(shape)
+    if self.size != shape_size:
+        raise ValueError('cannot reshape array of size {}'
+                         ' into shape {}'.format(self.size, shape_size))
+
     _get_strides_for_nocopy_reshape(self, shape, strides)
     if strides.size() == shape.size():
         return self._view(shape, strides, False, True)

--- a/cupy/testing/__init__.py
+++ b/cupy/testing/__init__.py
@@ -15,6 +15,7 @@ from cupy.testing.attr import gpu  # NOQA
 from cupy.testing.attr import multi_gpu  # NOQA
 from cupy.testing.attr import slow  # NOQA
 from cupy.testing.helper import assert_warns  # NOQA
+from cupy.testing.helper import empty  # NOQA
 from cupy.testing.helper import for_all_dtypes  # NOQA
 from cupy.testing.helper import for_all_dtypes_combination  # NOQA
 from cupy.testing.helper import for_CF_orders  # NOQA

--- a/cupy/testing/helper.py
+++ b/cupy/testing/helper.py
@@ -1089,6 +1089,10 @@ def shaped_random(shape, xp=cupy, dtype=numpy.float32, scale=10, seed=0):
         return xp.asarray((numpy.random.rand(*shape) * scale).astype(dtype))
 
 
+def empty(xp=cupy, dtype=numpy.float32):
+    return xp.zeros((0,))
+
+
 class NumpyError(object):
 
     def __init__(self, **kw):

--- a/tests/cupy_tests/manipulation_tests/test_shape.py
+++ b/tests/cupy_tests/manipulation_tests/test_shape.py
@@ -66,6 +66,16 @@ class TestShape(unittest.TestCase):
         a = testing.shaped_arange((2, 3, 4))
         a.reshape(2, 4, 4, order='K')
 
+    @testing.numpy_cupy_raises()
+    def test_reshape_empty_invalid(self, xp):
+        a = testing.empty(xp)
+        a = a.reshape(())
+
+    @testing.numpy_cupy_array_equal()
+    def test_reshape_empty(self, xp):
+        a = testing.empty(xp)
+        return a.reshape((0,))
+
     @testing.for_orders('CFA')
     @testing.numpy_cupy_array_equal()
     def test_external_reshape(self, xp, order):


### PR DESCRIPTION
Backport of #2648