### PR TITLE
Fix `det` and `slogdet` on singular inputs

### DIFF
--- a/cupy/linalg/norms.py
+++ b/cupy/linalg/norms.py
@@ -236,7 +236,7 @@ def _slogdet_one(a):
     handle = device.get_cusolver_handle()
     m = len(a)
     ipiv = cupy.empty(m, dtype=numpy.int32)
-    dev_info = cupy.empty(1, dtype=numpy.int32)
+    dev_info = cupy.empty((), dtype=numpy.int32)
 
     # Need to make a copy because getrf works inplace
     a_copy = a.copy(order='F')
@@ -253,22 +253,25 @@ def _slogdet_one(a):
     getrf(handle, m, m, a_copy.data.ptr, m, workspace.data.ptr,
           ipiv.data.ptr, dev_info.data.ptr)
 
-    try:
-        cupy.linalg.util._check_cusolver_dev_info_if_synchronization_allowed(
-            getrf, dev_info)
+    # dev_info < 0 means illegal value
+    dev_info_err = cupy.fmin(dev_info, 0)
+    cupy.linalg.util._check_cusolver_dev_info_if_synchronization_allowed(
+        getrf, dev_info_err)
 
-        diag = cupy.diag(a_copy)
-        # ipiv is 1-origin
-        non_zero = (cupy.count_nonzero(ipiv != cupy.arange(1, m + 1)) +
-                    cupy.count_nonzero(diag < 0))
-        # Note: sign == -1 ** (non_zero % 2)
-        sign = (non_zero % 2) * -2 + 1
-        logdet = cupy.log(abs(diag)).sum()
-    except linalg.LinAlgError:
-        sign = cupy.array(0.0, dtype=dtype)
-        logdet = cupy.array(float('-inf'), dtype)
+    diag = cupy.diag(a_copy)
+    # ipiv is 1-origin
+    non_zero = (cupy.count_nonzero(ipiv != cupy.arange(1, m + 1)) +
+                cupy.count_nonzero(diag < 0))
 
-    return sign, logdet
+    # Note: sign == -1 ** (non_zero % 2)
+    sign = (non_zero % 2) * -2 + 1
+    logdet = cupy.log(abs(diag)).sum()
+
+    singular = dev_info > 0
+    return (
+        cupy.where(singular, dtype.type(0), sign),
+        cupy.where(singular, dtype.type('-inf'), logdet),
+    )
 
 
 def trace(a, offset=0, axis1=0, axis2=1, dtype=None, out=None):

--- a/cupy/linalg/norms.py
+++ b/cupy/linalg/norms.py
@@ -253,7 +253,8 @@ def _slogdet_one(a):
     getrf(handle, m, m, a_copy.data.ptr, m, workspace.data.ptr,
           ipiv.data.ptr, dev_info.data.ptr)
 
-    # dev_info < 0 means illegal value
+    # dev_info < 0 means illegal value (in dimensions, strides, and etc.) that
+    # should never happen even if the matrix contains nan or inf.
     # TODO(kataoka): assert dev_info >= 0 if synchronization is allowed for
     # debugging purposes.
 

--- a/cupy/linalg/norms.py
+++ b/cupy/linalg/norms.py
@@ -254,9 +254,8 @@ def _slogdet_one(a):
           ipiv.data.ptr, dev_info.data.ptr)
 
     # dev_info < 0 means illegal value
-    dev_info_err = cupy.fmin(dev_info, 0)
-    cupy.linalg.util._check_cusolver_dev_info_if_synchronization_allowed(
-        getrf, dev_info_err)
+    # TODO(kataoka): assert dev_info >= 0 if synchronization is allowed for
+    # debugging purposes.
 
     diag = cupy.diag(a_copy)
     # ipiv is 1-origin

--- a/tests/cupy_tests/linalg_tests/test_norms.py
+++ b/tests/cupy_tests/linalg_tests/test_norms.py
@@ -130,6 +130,12 @@ class TestDet(unittest.TestCase):
         a = testing.shaped_arange((), xp, dtype)
         xp.linalg.det(a)
 
+    @testing.for_float_dtypes(no_float16=True)
+    @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-4)
+    def test_det_singular(self, xp, dtype):
+        a = xp.zeros((2, 3, 3), dtype)
+        return xp.linalg.det(a)
+
 
 @testing.gpu
 class TestSlogdet(unittest.TestCase):
@@ -157,11 +163,18 @@ class TestSlogdet(unittest.TestCase):
 
     @testing.for_float_dtypes(no_float16=True)
     @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-4)
-    def test_slogdet_fail(self, xp, dtype):
+    def test_slogdet_singular(self, xp, dtype):
+        a = xp.zeros((3, 3), dtype)
+        sign, logdet = xp.linalg.slogdet(a)
+        return xp.array([sign, logdet], dtype)
+
+    @testing.for_float_dtypes(no_float16=True)
+    @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-4)
+    def test_slogdet_singular_errstate(self, xp, dtype):
         a = xp.zeros((3, 3), dtype)
         with cupyx.errstate(linalg='raise'):
-            # `cupy.linalg.slogdet` internally catches a raised error from
-            # cuSOLVER, but yield a valid output to mimic NumPy.
+            # `cupy.linalg.slogdet` internally catches `dev_info < 0` from
+            # cuSOLVER, which should not affect `dev_info > 0` cases.
             sign, logdet = xp.linalg.slogdet(a)
         return xp.array([sign, logdet], dtype)
 


### PR DESCRIPTION
Use `cupy.where(dev_info, ...)` to avoid sync.

Fix #2650.