### PR TITLE
handle tuple with value 0 and return empty array

### DIFF
--- a/cupy/random/generator.py
+++ b/cupy/random/generator.py
@@ -606,6 +606,9 @@ class RandomState(object):
 
         n = functools.reduce(operator.mul, size, 1)
 
+        if n is 0:
+            return cupy.array(())
+
         sample = cupy.empty((n,), dtype=dtype)
         n_rem = n  # The number of remaining elements to sample
         ret = None
@@ -632,9 +635,7 @@ class RandomState(object):
             n_rem -= n_succ
 
         assert n_rem == 0
-
-        if ret is None:
-            return cupy.array(())
+        assert n is not None
 
         return ret.reshape(size)
 

--- a/cupy/random/generator.py
+++ b/cupy/random/generator.py
@@ -606,7 +606,7 @@ class RandomState(object):
 
         n = functools.reduce(operator.mul, size, 1)
 
-        if n is 0:
+        if n == 0:
             return cupy.array(())
 
         sample = cupy.empty((n,), dtype=dtype)

--- a/cupy/random/generator.py
+++ b/cupy/random/generator.py
@@ -633,7 +633,7 @@ class RandomState(object):
 
         assert n_rem == 0
 
-        if not ret:
+        if ret is None:
             return cupy.array(())
 
         return ret.reshape(size)

--- a/cupy/random/generator.py
+++ b/cupy/random/generator.py
@@ -632,6 +632,10 @@ class RandomState(object):
             n_rem -= n_succ
 
         assert n_rem == 0
+
+        if not ret:
+            return cupy.array(())
+
         return ret.reshape(size)
 
     def seed(self, seed=None):

--- a/tests/cupy_tests/random_tests/test_sample.py
+++ b/tests/cupy_tests/random_tests/test_sample.py
@@ -246,6 +246,7 @@ class TestRandomSample(unittest.TestCase):
     {'size': None},
     {'size': ()},
     {'size': 4},
+    {'size': (0,)},
     {'size': (1, 0)},
 )
 @testing.fix_random()

--- a/tests/cupy_tests/random_tests/test_sample.py
+++ b/tests/cupy_tests/random_tests/test_sample.py
@@ -4,6 +4,7 @@ import unittest
 import numpy
 import six
 
+import cupy
 from cupy import cuda
 from cupy import random
 from cupy import testing
@@ -17,6 +18,13 @@ class TestRandint(unittest.TestCase):
     def test_lo_hi_reversed(self):
         with self.assertRaises(ValueError):
             random.randint(100, 1)
+
+    def test_zero_sizes(self):
+        a = random.randint(10, size=(0,))
+        testing.assert_array_equal(a, cupy.array(()))
+
+        a = random.randint(10, size=0)
+        testing.assert_array_equal(a, cupy.array(()))
 
 
 @testing.fix_random()
@@ -238,7 +246,6 @@ class TestRandomSample(unittest.TestCase):
     {'size': None},
     {'size': ()},
     {'size': 4},
-    {'size': (0,)},
     {'size': (1, 0)},
 )
 @testing.fix_random()


### PR DESCRIPTION
Currently randint will fail when handed tuple with a value `(0,)`

>cupy.random.randint(10, None, size=(0,))
> AttributeError: 'NoneType' object has no attribute 'reshape'

This PR resolves the error by handing back any empty cupy array if the ret value is `None`