### PR TITLE
[backport] Update `__cuda_array_interface__` to protocol version 2

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -142,11 +142,9 @@ cdef class ndarray:
             'typestr': self.dtype.str,
             'descr': self.dtype.descr,
             'data': (self.data.ptr, False),
-            'version': 2,
+            'version': 0,
         }
-        if self._c_contiguous:
-            desc['strides'] = None
-        else:
+        if not self._c_contiguous:
             desc['strides'] = self.strides
 
         return desc

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -142,9 +142,11 @@ cdef class ndarray:
             'typestr': self.dtype.str,
             'descr': self.dtype.descr,
             'data': (self.data.ptr, False),
-            'version': 0,
+            'version': 2,
         }
-        if not self._c_contiguous:
+        if self._c_contiguous:
+            desc['strides'] = None
+        else:
             desc['strides'] = self.strides
 
         return desc
@@ -2513,13 +2515,16 @@ cpdef ndarray _convert_object_with_cuda_array_interface(a):
     desc = a.__cuda_array_interface__
     shape = desc['shape']
     dtype = numpy.dtype(desc['typestr'])
-    if 'strides' in desc:
-        strides = desc['strides']
+    if 'mask' in desc:
+        mask = desc['mask']
+        if mask is not None:
+            raise ValueError('CuPy currently does not support masked arrays.')
+    strides = desc.get('strides')
+    if strides is not None:
         nbytes = 0
         for sh, st in zip(shape, strides):
             nbytes = max(nbytes, abs(sh * st))
     else:
-        strides = None
         nbytes = internal.prod(shape) * dtype.itemsize
     mem = memory_module.UnownedMemory(desc['data'][0], nbytes, a)
     memptr = memory.MemoryPointer(mem, 0)

--- a/tests/cupy_tests/core_tests/test_ndarray.py
+++ b/tests/cupy_tests/core_tests/test_ndarray.py
@@ -198,15 +198,17 @@ class TestNdarrayCudaInterface(unittest.TestCase):
         arr = cupy.zeros(shape=(2, 3), dtype=cupy.float64)
         iface = arr.__cuda_array_interface__
         assert (set(iface.keys()) ==
-                set(['shape', 'typestr', 'data', 'version', 'descr']))
+                set(['shape', 'typestr', 'data', 'version', 'descr',
+                     'strides']))
         assert iface['shape'] == (2, 3)
         assert iface['typestr'] == '<f8'
         assert isinstance(iface['data'], tuple)
         assert len(iface['data']) == 2
         assert iface['data'][0] == arr.data.ptr
         assert not iface['data'][1]
-        assert iface['version'] == 0
+        assert iface['version'] == 2
         assert iface['descr'] == [('', '<f8')]
+        assert iface['strides'] is None
 
     def test_cuda_array_interface_view(self):
         arr = cupy.zeros(shape=(10, 20), dtype=cupy.float64)
@@ -221,7 +223,7 @@ class TestNdarrayCudaInterface(unittest.TestCase):
         assert len(iface['data']) == 2
         assert iface['data'][0] == arr.data.ptr
         assert not iface['data'][1]
-        assert iface['version'] == 0
+        assert iface['version'] == 2
         assert iface['strides'] == (320, 40)
         assert iface['descr'] == [('', '<f8')]
 

--- a/tests/cupy_tests/core_tests/test_ndarray.py
+++ b/tests/cupy_tests/core_tests/test_ndarray.py
@@ -198,17 +198,15 @@ class TestNdarrayCudaInterface(unittest.TestCase):
         arr = cupy.zeros(shape=(2, 3), dtype=cupy.float64)
         iface = arr.__cuda_array_interface__
         assert (set(iface.keys()) ==
-                set(['shape', 'typestr', 'data', 'version', 'descr',
-                     'strides']))
+                set(['shape', 'typestr', 'data', 'version', 'descr']))
         assert iface['shape'] == (2, 3)
         assert iface['typestr'] == '<f8'
         assert isinstance(iface['data'], tuple)
         assert len(iface['data']) == 2
         assert iface['data'][0] == arr.data.ptr
         assert not iface['data'][1]
-        assert iface['version'] == 2
+        assert iface['version'] == 0
         assert iface['descr'] == [('', '<f8')]
-        assert iface['strides'] is None
 
     def test_cuda_array_interface_view(self):
         arr = cupy.zeros(shape=(10, 20), dtype=cupy.float64)
@@ -223,7 +221,7 @@ class TestNdarrayCudaInterface(unittest.TestCase):
         assert len(iface['data']) == 2
         assert iface['data'][0] == arr.data.ptr
         assert not iface['data'][1]
-        assert iface['version'] == 2
+        assert iface['version'] == 0
         assert iface['strides'] == (320, 40)
         assert iface['descr'] == [('', '<f8')]
 

--- a/tests/cupy_tests/core_tests/test_ndarray_cuda_array_interface.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_cuda_array_interface.py
@@ -18,7 +18,7 @@ class DummyObjectWithCudaArrayInterface(object):
             'typestr': self.a.dtype.str,
             'descr': self.a.dtype.descr,
             'data': (self.a.data.ptr, False),
-            'version': 0,
+            'version': 2,
         }
         return desc
 
@@ -187,12 +187,9 @@ class TestCUDAArrayInterfaceCompliance(unittest.TestCase):
         typestr = y.__cuda_array_interface__['typestr']
         ptr, readonly = y.__cuda_array_interface__['data']
         version = y.__cuda_array_interface__['version']
+        strides = y.__cuda_array_interface__['strides']
 
         # optional entries
-        if 'strides' in y.__cuda_array_interface__:
-            strides = y.__cuda_array_interface__['strides']
-        else:
-            strides = None
         if 'descr' in y.__cuda_array_interface__:
             descr = y.__cuda_array_interface__['descr']
         else:
@@ -203,7 +200,7 @@ class TestCUDAArrayInterfaceCompliance(unittest.TestCase):
         assert isinstance(typestr, str)
         assert isinstance(ptr, int)
         assert isinstance(readonly, bool)
-        assert version == 0  # update this when the standard is updated!
+        assert version == 2  # update this when the standard is updated!
         assert (strides is None) or isinstance(strides, tuple)
         assert (descr is None) or isinstance(descr, list)
         if isinstance(descr, list):

--- a/tests/cupy_tests/core_tests/test_ndarray_cuda_array_interface.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_cuda_array_interface.py
@@ -187,9 +187,12 @@ class TestCUDAArrayInterfaceCompliance(unittest.TestCase):
         typestr = y.__cuda_array_interface__['typestr']
         ptr, readonly = y.__cuda_array_interface__['data']
         version = y.__cuda_array_interface__['version']
-        strides = y.__cuda_array_interface__['strides']
 
         # optional entries
+        if 'strides' in y.__cuda_array_interface__:
+            strides = y.__cuda_array_interface__['strides']
+        else:
+            strides = None
         if 'descr' in y.__cuda_array_interface__:
             descr = y.__cuda_array_interface__['descr']
         else:
@@ -200,7 +203,7 @@ class TestCUDAArrayInterfaceCompliance(unittest.TestCase):
         assert isinstance(typestr, str)
         assert isinstance(ptr, int)
         assert isinstance(readonly, bool)
-        assert version == 2  # update this when the standard is updated!
+        assert version == 0  # update this when the standard is updated!
         assert (strides is None) or isinstance(strides, tuple)
         assert (descr is None) or isinstance(descr, list)
         if isinstance(descr, list):

--- a/tests/cupy_tests/creation_tests/test_from_data.py
+++ b/tests/cupy_tests/creation_tests/test_from_data.py
@@ -191,42 +191,6 @@ class TestFromData(unittest.TestCase):
         a.fill(0)
         return b
 
-    @testing.for_all_dtypes()
-    def test_asarray_cuda_array_interface(self, dtype):
-        a = testing.shaped_arange((2, 3, 4), cupy, dtype)
-        b = cupy.asarray(DummyObjectWithCudaArrayInterface(a))
-        testing.assert_array_equal(a, b)
-
-    @testing.for_all_dtypes()
-    def test_asarray_cuda_array_interface_is_not_copied(self, dtype):
-        a = testing.shaped_arange((2, 3, 4), cupy, dtype)
-        b = cupy.asarray(DummyObjectWithCudaArrayInterface(a))
-        a.fill(0)
-        testing.assert_array_equal(a, b)
-
-    @testing.for_all_dtypes()
-    def test_asarray_cuda_array_interface_order(self, dtype):
-        a = testing.shaped_arange((2, 3, 4), cupy, dtype)
-        b = cupy.asarray(DummyObjectWithCudaArrayInterface(a), order='F')
-        assert b.flags.f_contiguous
-        testing.assert_array_equal(a, b)
-
-    @testing.for_all_dtypes()
-    def test_asarray_cuda_array_interface_with_strides(self, dtype):
-        a = testing.shaped_arange((2, 3, 4), cupy, dtype).T
-        b = cupy.asarray(DummyObjectWithCudaArrayInterface(a))
-        assert a.strides == b.strides
-        assert a.nbytes == b.data.mem.size
-
-    # TODO(leofang): remove this test when masked array is supported
-    def test_asarray_cuda_array_interface_with_masked_array(self):
-        a = cupy.arange(10)
-        mask = cupy.zeros(10)
-        a = DummyObjectWithCudaArrayInterface(a, mask)
-        with pytest.raises(ValueError) as ex:
-            b = cupy.asarray(a)  # noqa
-        assert 'does not support' in str(ex.value)
-
     def test_ascontiguousarray_on_noncontiguous_array(self):
         a = testing.shaped_arange((2, 3, 4))
         b = a.transpose(2, 0, 1)
@@ -266,22 +230,91 @@ class TestFromData(unittest.TestCase):
         return (b.flags.c_contiguous, b.flags.f_contiguous)
 
 
-class DummyObjectWithCudaArrayInterface(object):
+max_cuda_array_interface_version = 2
 
-    def __init__(self, a, mask=None):
+
+@testing.gpu
+@testing.parameterize(*testing.product({
+    'ver': tuple(range(max_cuda_array_interface_version+1)),
+    'strides': (False, None, True),
+}))
+class TestCudaArrayInterface(unittest.TestCase):
+    @testing.for_all_dtypes()
+    def test_base(self, dtype):
+        a = testing.shaped_arange((2, 3, 4), cupy, dtype)
+        b = cupy.asarray(
+            DummyObjectWithCudaArrayInterface(a, self.ver, self.strides))
+        testing.assert_array_equal(a, b)
+
+    @testing.for_all_dtypes()
+    def test_not_copied(self, dtype):
+        a = testing.shaped_arange((2, 3, 4), cupy, dtype)
+        b = cupy.asarray(
+            DummyObjectWithCudaArrayInterface(a, self.ver, self.strides))
+        a.fill(0)
+        testing.assert_array_equal(a, b)
+
+    @testing.for_all_dtypes()
+    def test_order(self, dtype):
+        a = testing.shaped_arange((2, 3, 4), cupy, dtype)
+        b = cupy.asarray(
+            DummyObjectWithCudaArrayInterface(a, self.ver, self.strides),
+            order='F')
+        assert b.flags.f_contiguous
+        testing.assert_array_equal(a, b)
+
+    @testing.for_all_dtypes()
+    def test_with_strides(self, dtype):
+        a = testing.shaped_arange((2, 3, 4), cupy, dtype).T
+        b = cupy.asarray(
+            DummyObjectWithCudaArrayInterface(a, self.ver, self.strides))
+        assert a.strides == b.strides
+        assert a.nbytes == b.data.mem.size
+
+
+@testing.gpu
+@testing.parameterize(*testing.product({
+    'ver': tuple(range(1, max_cuda_array_interface_version+1)),
+    'strides': (False, None, True),
+}))
+class TestCudaArrayInterfaceMaskedArray(unittest.TestCase):
+    # TODO(leofang): update this test when masked array is supported
+    @testing.for_all_dtypes()
+    def test_masked_array(self, dtype):
+        a = testing.shaped_arange((2, 3, 4), cupy, dtype)
+        mask = testing.shaped_arange((2, 3, 4), cupy, dtype)
+        a = DummyObjectWithCudaArrayInterface(a, self.ver, self.strides, mask)
+        with pytest.raises(ValueError) as ex:
+            b = cupy.asarray(a)  # noqa
+        assert 'does not support' in str(ex.value)
+
+
+class DummyObjectWithCudaArrayInterface(object):
+    def __init__(self, a, ver, include_strides=False, mask=None):
+        assert ver in tuple(range(max_cuda_array_interface_version+1))
         self.a = a
+        self.ver = ver
+        self.include_strides = include_strides
         self.mask = mask
 
     @property
     def __cuda_array_interface__(self):
         desc = {
             'shape': self.a.shape,
-            'strides': self.a.strides,
             'typestr': self.a.dtype.str,
             'descr': self.a.dtype.descr,
             'data': (self.a.data.ptr, False),
-            'version': 2,
+            'version': self.ver,
         }
+        if self.a.flags.c_contiguous:
+            if self.include_strides is True:
+                desc['strides'] = self.a.strides
+            elif self.include_strides is None:
+                desc['strides'] = None
+            else:  # self.include_strides is False
+                pass
+        else:  # F contiguous or neither
+            desc['strides'] = self.a.strides
         if self.mask is not None:
             desc['mask'] = self.mask
         return desc

--- a/tests/cupy_tests/creation_tests/test_from_data.py
+++ b/tests/cupy_tests/creation_tests/test_from_data.py
@@ -1,5 +1,7 @@
 import unittest
 
+import pytest
+
 import cupy
 from cupy import cuda
 from cupy import testing
@@ -210,11 +212,20 @@ class TestFromData(unittest.TestCase):
         testing.assert_array_equal(a, b)
 
     @testing.for_all_dtypes()
-    def test_asarray_cuda_array_interface_with_strdies(self, dtype):
+    def test_asarray_cuda_array_interface_with_strides(self, dtype):
         a = testing.shaped_arange((2, 3, 4), cupy, dtype).T
-        b = cupy.asarray(DummyObjectWithCudaArrayInterface(a, True))
+        b = cupy.asarray(DummyObjectWithCudaArrayInterface(a))
         assert a.strides == b.strides
         assert a.nbytes == b.data.mem.size
+
+    # TODO(leofang): remove this test when masked array is supported
+    def test_asarray_cuda_array_interface_with_masked_array(self):
+        a = cupy.arange(10)
+        mask = cupy.zeros(10)
+        a = DummyObjectWithCudaArrayInterface(a, mask)
+        with pytest.raises(ValueError) as ex:
+            b = cupy.asarray(a)  # noqa
+        assert 'does not support' in str(ex.value)
 
     def test_ascontiguousarray_on_noncontiguous_array(self):
         a = testing.shaped_arange((2, 3, 4))
@@ -257,21 +268,22 @@ class TestFromData(unittest.TestCase):
 
 class DummyObjectWithCudaArrayInterface(object):
 
-    def __init__(self, a, has_strides=False):
+    def __init__(self, a, mask=None):
         self.a = a
-        self.has_strides = has_strides
+        self.mask = mask
 
     @property
     def __cuda_array_interface__(self):
         desc = {
             'shape': self.a.shape,
+            'strides': self.a.strides,
             'typestr': self.a.dtype.str,
             'descr': self.a.dtype.descr,
-            'data': (self.a.data.mem.ptr, False),
-            'version': 0,
+            'data': (self.a.data.ptr, False),
+            'version': 2,
         }
-        if self.has_strides:
-            desc['strides'] = self.a.strides
+        if self.mask is not None:
+            desc['mask'] = self.mask
         return desc
 
 


### PR DESCRIPTION
Backport of #2491 and #2536

Only consuming side is being backported.