### PR TITLE
Avoid `numpy.can_cast` call to improve guess routine 

### DIFF
--- a/cupy/core/_kernel.pyx
+++ b/cupy/core/_kernel.pyx
@@ -707,7 +707,7 @@ cdef inline bint _check_should_use_min_scalar(list in_args) except? -1:
 
 
 cdef dict _mst_unsigned_to_signed = {
-    i : (numpy.iinfo(j).max, (i, j))
+    i: (numpy.iinfo(j).max, (i, j))
     for i, j in [(numpy.dtype(i).type, numpy.dtype(i.lower()).type)
                  for i in "BHILQ"]}
 cdef _numpy_min_scalar_type = numpy.min_scalar_type

--- a/cupy/core/_kernel.pyx
+++ b/cupy/core/_kernel.pyx
@@ -713,6 +713,10 @@ cdef dict _mst_unsigned_to_signed = {
 cdef _numpy_min_scalar_type = numpy.min_scalar_type
 
 cdef _min_scalar_type(x):
+    # A non-negative integer may have two locally minimum scalar
+    # types: signed/unsigned integer.
+    # Return both for can_cast, while numpy.min_scalar_type only returns
+    # the unsigned type.
     t = _numpy_min_scalar_type(x)
     dt = t.type
     if t.kind == 'u':

--- a/cupy/core/_kernel.pyx
+++ b/cupy/core/_kernel.pyx
@@ -710,10 +710,10 @@ cdef dict _mst_unsigned_to_signed = {
     i : (numpy.iinfo(j).max, (i, j))
     for i, j in [(numpy.dtype(i).type, numpy.dtype(i.lower()).type)
                  for i in "BHILQ"]}
+cdef _numpy_min_scalar_type = numpy.min_scalar_type
 
-
-cpdef _min_scalar_type(x):
-    t = numpy.min_scalar_type(x)
+cdef _min_scalar_type(x):
+    t = _numpy_min_scalar_type(x)
     dt = t.type
     if t.kind == 'u':
         m, dt2 = <tuple>_mst_unsigned_to_signed[dt]


### PR DESCRIPTION
`numpy.can_cast` is called many times.
The new routine uses ` numpy.min_scalar_type` instead of `numpy.can_cast`.

I added benchmark result.