### PR TITLE
Fix `AttributeError` of `stride_tricks`

### DIFF
--- a/cupy/lib/__init__.py
+++ b/cupy/lib/__init__.py
@@ -1,0 +1,1 @@
+from cupy.lib import stride_tricks  # NOQA


### PR DESCRIPTION
This PR fixes AttributeError of `stride_tricks`. The following code works with NumPy, but not with CuPy.

```
import numpy
numpy.lib.stride_tricks.as_strided

import cupy
cupy.lib.stride_tricks.as_strided
```
```
AttributeError: module 'cupy.lib' has no attribute 'stride_tricks'
```