### PR TITLE
Fix document format of `as_strided`

### DIFF
--- a/cupy/lib/stride_tricks.py
+++ b/cupy/lib/stride_tricks.py
@@ -4,6 +4,7 @@ import cupy
 def as_strided(x, shape=None, strides=None):
     """
     Create a view into the array with the given shape and strides.
+
     .. warning:: This function has to be used with extreme care, see notes.
 
     Parameters


### PR DESCRIPTION
The warning in the document of `as_strided` has not been correctly shown.
https://docs-cupy.chainer.org/en/v7.0.0rc1/reference/generated/cupy.lib.stride_tricks.as_strided.html