### PR TITLE
Avoid use of slow numpy.find_common_type

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -376,7 +376,7 @@ def common_type(*arrays):
         else:
             dtypes.append(a.dtype)
 
-    return functools.reduce(numpy.promote_types, dtypes)
+    return functools.reduce(numpy.promote_types, dtypes).type
 
 
 def result_type(*arrays_and_dtypes):

--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import division
+import functools
 import sys
 import warnings
 
@@ -375,7 +376,7 @@ def common_type(*arrays):
         else:
             dtypes.append(a.dtype)
 
-    return numpy.find_common_type(dtypes, []).type
+    return functools.reduce(numpy.promote_types, dtypes)
 
 
 def result_type(*arrays_and_dtypes):

--- a/cupy/core/_routines_manipulation.pyx
+++ b/cupy/core/_routines_manipulation.pyx
@@ -1,4 +1,5 @@
 # distutils: language = c++
+import functools
 import sys
 
 import numpy
@@ -615,7 +616,8 @@ cpdef ndarray concatenate_method(tup, int axis):
         raise ValueError('Cannot concatenate from empty tuple')
 
     if not have_same_types:
-        dtype = numpy.find_common_type([a.dtype for a in arrays], [])
+        dtype = functools.reduce(numpy.promote_types,
+                                 set([a.dtype for a in arrays]))
     return _concatenate(arrays, axis, tuple(shape), dtype)
 
 

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2338,7 +2338,7 @@ cpdef ndarray matmul(ndarray a, ndarray b, ndarray out=None):
             (0,) * (ndim - b_ndim) + b.strides,
             True, True)
 
-    ret_dtype = numpy.result_type(a.dtype, b.dtype)
+    ret_dtype = numpy.promote_types(a.dtype, b.dtype)
     dtype = numpy.promote_types(ret_dtype, 'f')
 
     a = ascontiguousarray(a, dtype)

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2339,7 +2339,7 @@ cpdef ndarray matmul(ndarray a, ndarray b, ndarray out=None):
             True, True)
 
     ret_dtype = numpy.result_type(a.dtype, b.dtype)
-    dtype = numpy.find_common_type((ret_dtype, 'f'), ())
+    dtype = numpy.promote_types(ret_dtype, 'f')
 
     a = ascontiguousarray(a, dtype)
     b = ascontiguousarray(b, dtype)
@@ -2532,7 +2532,7 @@ cpdef ndarray tensordot_core(
     cdef float one_fp32, zero_fp32
     ret_dtype = a.dtype.char
     if ret_dtype != b.dtype.char:
-        ret_dtype = numpy.find_common_type((ret_dtype, b.dtype), ()).char
+        ret_dtype = numpy.promote_types(ret_dtype, b.dtype).char
 
     if not a.size or not b.size:
         if out is None:
@@ -2553,7 +2553,7 @@ cpdef ndarray tensordot_core(
     if use_sgemmEx or ret_dtype in 'fdFD':
         dtype = ret_dtype
     else:
-        dtype = numpy.find_common_type((ret_dtype, 'f'), ()).char
+        dtype = numpy.promote_types(ret_dtype, 'f').char
 
     if out is None:
         out = ndarray(ret_shape, dtype)

--- a/cupy/cusparse.py
+++ b/cupy/cusparse.py
@@ -1,3 +1,5 @@
+import functools
+
 import numpy
 
 import cupy
@@ -31,7 +33,7 @@ class MatDescriptor(object):
 
 def _cast_common_type(*xs):
     dtypes = [x.dtype for x in xs if x is not None]
-    dtype = numpy.find_common_type(dtypes, [])
+    dtype = functools.reduce(numpy.promote_types, dtypes)
     return [x.astype(dtype) if x is not None and x.dtype != dtype else x
             for x in xs]
 

--- a/cupy/linalg/decomposition.py
+++ b/cupy/linalg/decomposition.py
@@ -37,7 +37,7 @@ def cholesky(a):
     if a.dtype.char == 'f' or a.dtype.char == 'd':
         dtype = a.dtype.char
     else:
-        dtype = numpy.find_common_type((a.dtype.char, 'f'), ()).char
+        dtype = numpy.promote_types(a.dtype.char, 'f').char
 
     x = a.astype(dtype, order='C', copy=True)
     n = len(a)
@@ -114,7 +114,7 @@ def qr(a, mode='reduced'):
     if a.dtype.char in 'fdFD':
         dtype = a.dtype.char
     else:
-        dtype = numpy.find_common_type((a.dtype.char, 'f'), ()).char
+        dtype = numpy.promote_types(a.dtype.char, 'f').char
 
     m, n = a.shape
     mn = min(m, n)
@@ -127,7 +127,7 @@ def qr(a, mode='reduced'):
             return cupy.empty((0, n), dtype)
         else:  # mode == 'raw'
             # compatibility with numpy.linalg.qr
-            dtype = numpy.find_common_type((dtype, 'd'), ())
+            dtype = numpy.promote_types(dtype, 'd')
             return cupy.empty((n, m), dtype), cupy.empty((0,), dtype)
 
     x = a.transpose().astype(dtype, order='C', copy=True)
@@ -245,7 +245,7 @@ def svd(a, full_matrices=True, compute_uv=True):
     util._assert_rank2(a)
 
     # Cast to float32 or float64
-    a_dtype = numpy.find_common_type((a.dtype.char, 'f'), ()).char
+    a_dtype = numpy.promote_types(a.dtype.char, 'f').char
     if a_dtype == 'f':
         s_dtype = 'f'
     elif a_dtype == 'd':

--- a/cupy/linalg/norms.py
+++ b/cupy/linalg/norms.py
@@ -215,7 +215,7 @@ def slogdet(a):
                'Array must be at least two-dimensional' % a.ndim)
         raise linalg.LinAlgError(msg)
 
-    dtype = numpy.find_common_type((a.dtype.char, 'f'), ())
+    dtype = numpy.promote_types(a.dtype.char, 'f')
     shape = a.shape[:-2]
     sign = cupy.empty(shape, dtype)
     logdet = cupy.empty(shape, dtype)

--- a/cupy/linalg/solve.py
+++ b/cupy/linalg/solve.py
@@ -52,7 +52,7 @@ def solve(a, b):
     if a.dtype.char == 'f' or a.dtype.char == 'd':
         dtype = a.dtype
     else:
-        dtype = numpy.find_common_type((a.dtype.char, 'f'), ())
+        dtype = numpy.promote_types(a.dtype.char, 'f')
 
     cublas_handle = device.get_cublas_handle()
     cusolver_handle = device.get_cusolver_handle()
@@ -280,7 +280,7 @@ def inv(a):
     if a.dtype.char in 'fdFD':
         dtype = a.dtype.char
     else:
-        dtype = numpy.find_common_type((a.dtype.char, 'f'), ()).char
+        dtype = numpy.promote_types(a.dtype.char, 'f')
 
     cusolver_handle = device.get_cusolver_handle()
     dev_info = cupy.empty(1, dtype=numpy.int32)

--- a/cupy/statistics/correlation.py
+++ b/cupy/statistics/correlation.py
@@ -1,3 +1,4 @@
+import functools
 import warnings
 
 import numpy
@@ -82,11 +83,12 @@ def cov(a, y=None, rowvar=True, bias=False, ddof=None):
         raise ValueError('Input must be <= 2-d')
 
     if y is None:
-        dtype = numpy.result_type(a.dtype, numpy.float64)
+        dtype = numpy.promote_types(a.dtype, numpy.float64)
     else:
         if y.ndim > 2:
             raise ValueError('y must be <= 2-d')
-        dtype = numpy.result_type(a.dtype, y.dtype, numpy.float64)
+        dtype = functools.reduce(numpy.promote_types,
+                                 (a.dtype, y.dtype, numpy.float64))
 
     X = cupy.array(a, ndmin=2, dtype=dtype)
     if not rowvar and X.shape[0] != 1:

--- a/cupy/statistics/meanvar.py
+++ b/cupy/statistics/meanvar.py
@@ -1,3 +1,4 @@
+import functools
 import numpy
 
 import cupy
@@ -35,9 +36,10 @@ def average(a, axis=None, weights=None, returned=False):
         wgt = cupy.asarray(weights)
 
         if issubclass(a.dtype.type, (numpy.integer, numpy.bool_)):
-            result_dtype = numpy.result_type(a.dtype, wgt.dtype, 'f8')
+            result_dtype = functools.reduce(numpy.promote_types,
+                                            (a.dtype, wgt.dtype, 'f8'))
         else:
-            result_dtype = numpy.result_type(a.dtype, wgt.dtype)
+            result_dtype = numpy.promote_types(a.dtype, wgt.dtype)
 
         # Sanity checks
         if a.shape != wgt.shape:

--- a/cupyx/linalg/solve.py
+++ b/cupyx/linalg/solve.py
@@ -32,7 +32,7 @@ def invh(a):
     if a.dtype.char in 'fdFD':
         dtype = a.dtype.char
     else:
-        dtype = numpy.find_common_type((a.dtype.char, 'f'), ()).char
+        dtype = numpy.promote_types(a.dtype.char, 'f').char
 
     cusolver_handle = device.get_cusolver_handle()
     dev_info = cupy.empty(1, dtype=numpy.int32)

--- a/cupyx/linalg/sparse/solve.py
+++ b/cupyx/linalg/sparse/solve.py
@@ -37,7 +37,7 @@ def lschol(A, b):
     if A.dtype == 'f' or A.dtype == 'd':
         dtype = A.dtype
     else:
-        dtype = numpy.find_common_type((A.dtype, 'f'), ())
+        dtype = numpy.promote_types(A.dtype, 'f')
 
     handle = device.get_cusolver_sp_handle()
     nnz = A.nnz

--- a/cupyx/scipy/linalg/solve_triangular.py
+++ b/cupyx/scipy/linalg/solve_triangular.py
@@ -51,7 +51,7 @@ def solve_triangular(a, b, trans=0, lower=False, unit_diagonal=False,
     if a.dtype.char in 'fd':
         dtype = a.dtype
     else:
-        dtype = numpy.find_common_type((a.dtype.char, 'f'), ())
+        dtype = numpy.promote_types(a.dtype.char, 'f')
 
     a = cupy.array(a, dtype=dtype, order='F', copy=False)
     b = cupy.array(b, dtype=dtype, order='F', copy=(not overwrite_b))

--- a/cupyx/scipy/sparse/base.py
+++ b/cupyx/scipy/sparse/base.py
@@ -238,7 +238,7 @@ class spmatrix(object):
         if self.dtype.kind == 'f':
             return self
         else:
-            typ = numpy.result_type(self.dtype, 'f')
+            typ = numpy.promote_types(self.dtype, 'f')
             return self.astype(typ)
 
     def astype(self, t):

--- a/cupyx/scipy/sparse/linalg/solve.py
+++ b/cupyx/scipy/sparse/linalg/solve.py
@@ -43,7 +43,7 @@ def lsqr(A, b):
     if A.dtype == 'f' or A.dtype == 'd':
         dtype = A.dtype
     else:
-        dtype = numpy.find_common_type((A.dtype, 'f'), ())
+        dtype = numpy.promote_types(A.dtype, 'f')
 
     handle = device.get_cusolver_sp_handle()
     nnz = A.nnz


### PR DESCRIPTION
I have replaced `numpy.find_common_type` with use of `numpy.promote_types` where possible.

A couple basic benchmarks showing relative timings (for NumPy 1.17.3):

e.g.
```
import numpy as np
%timeit np.find_common_type([np.int, 'f'], [])
6.4 µs ± 23.8 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

%timeit np.result_type(*(np.int, 'f'))
657 ns ± 1.19 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)

%timeit np.promote_types(np.int, 'f')
148 ns ± 0.644 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)
```

This is also true for long lists of types
```
import functools

import numpy as np

types = [np.int, 'f'] * 100

%timeit np.find_common_type(types, [])
84.8 µs ± 232 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)

%timeit functools.reduce(np.promote_types, types)
12.2 µs ± 31.4 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

# with a large number of types it helps to call set first
%timeit functools.reduce(np.promote_types, set(types))
1.38 µs ± 2.32 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)

```