### PR TITLE
Avoid threading.local() object overhead

### DIFF
--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -596,8 +596,6 @@ def using_allocator(allocator=None):
         yield
     finally:
         _thread_local.allocator = previous_allocator
-        if previous_allocator is None:
-            delattr(_thread_local, 'allocator')
 
 
 @cython.final


### PR DESCRIPTION
`getattr(_thread_local, 'allocator', _current_allocator)` is slow because it creates error object.