### PR TITLE
CUB-based CSR sparse matrix vector multiply

### DIFF
--- a/cupy/cuda/cupy_cub.h
+++ b/cupy/cuda/cupy_cub.h
@@ -26,8 +26,10 @@
 
 void cub_device_reduce(void*, size_t&, void*, void*, int, cudaStream_t, int, int);
 void cub_device_segmented_reduce(void*, size_t&, void*, void*, int, void*, void*, cudaStream_t, int, int);
+void cub_device_spmv(void*, size_t&, void*, void*, void*, void*, void*, int, int, int, cudaStream_t, int);
 size_t cub_device_reduce_get_workspace_size(void*, void*, int, cudaStream_t, int, int);
 size_t cub_device_segmented_reduce_get_workspace_size(void*, void*, int, void*, void*, cudaStream_t, int, int);
+size_t cub_device_spmv_get_workspace_size(void*, void*, void*, void*, void*, int, int, int, cudaStream_t, int);
 
 #else // CUPY_NO_CUDA
 
@@ -39,11 +41,18 @@ void cub_device_reduce(...) {
 void cub_device_segmented_reduce(...) {
 }
 
+void cub_device_spmv(...) {
+}
+
 size_t cub_device_reduce_get_workspace_size(...) {
     return 0;
 }
 
 size_t cub_device_segmented_reduce_get_workspace_size(...) {
+    return 0;
+}
+
+size_t cub_device_spmv_get_workspace_size(...) {
     return 0;
 }
 

--- a/cupyx/scipy/sparse/csr.py
+++ b/cupyx/scipy/sparse/csr.py
@@ -9,6 +9,8 @@ from cupy import cusparse
 from cupyx.scipy.sparse import base
 from cupyx.scipy.sparse import compressed
 from cupyx.scipy.sparse import csc
+if cupy.cuda.cub_enabled:
+    from cupy.cuda.cub import device_csrmv
 
 
 class csr_matrix(compressed._compressed_sparse_matrix):
@@ -118,7 +120,12 @@ class csr_matrix(compressed._compressed_sparse_matrix):
                 other = cupy.asfortranarray(other)
                 # csrmvEx does not work if nnz == 0
                 if self.nnz > 0 and cusparse.csrmvExIsAligned(self, other):
-                    return cusparse.csrmvEx(self, other)
+                    if cupy.cuda.cub_enabled and other.flags.c_contiguous:
+                        return device_csrmv(
+                            self.shape[0], self.shape[1], self.nnz, self.data,
+                            self.indptr, self.indices, other)
+                    else:
+                        return cusparse.csrmvEx(self, other)
                 else:
                     return cusparse.csrmv(self, other)
             elif other.ndim == 2:


### PR DESCRIPTION
I was curious whether CUB would also improve the performance of sparse matrix multiplication. It seems that for < ~ 1,000,000 non-zero entries it is faster. At sizes larger than that, it is basically tied with cuSPARSE. A bit disappointing that the >3 fold gains at smaller sizes don't hold up for the larger problems of interest, although would be curious if this is also true for higher-end NVIDIA cards. (I tested with a GTX 1080 Ti)

The main limitation is that CUB only has this one sparse matrix function so it is limited to CSR only. Aside from performance, I think the other feature it has over cuSPARSE is that it can be used for additional dtypes such as `int` that are not supported by cuSPARSE. This can be done with the undocumented `device_spmv` function here, but the end-user interface is via the existing `__mul__` method of `csr_matrx` and is thus limited to floating point types.

I will post a benchmark below.