### PR TITLE
Add _ndarray_init to reduce ndarray creation cost

### DIFF
--- a/cupy/core/core.pxd
+++ b/cupy/core/core.pxd
@@ -110,4 +110,4 @@ cpdef ndarray array(obj, dtype=*, bint copy=*, order=*, bint subok=*,
                     Py_ssize_t ndmin=*)
 cpdef ndarray _convert_object_with_cuda_array_interface(a)
 
-cdef _ndarray_init(const vector.vector[Py_ssize_t]& shape, dtype)
+cdef ndarray _ndarray_init(const vector.vector[Py_ssize_t]& shape, dtype)

--- a/cupy/core/core.pxd
+++ b/cupy/core/core.pxd
@@ -18,6 +18,8 @@ cdef class ndarray:
         # underlying memory is UnownedMemory.
         readonly ndarray base
 
+    cdef _init_fast(self, const vector.vector[Py_ssize_t]& shape, dtype,
+                    bint c_order)
     cpdef item(self)
     cpdef tolist(self)
     cpdef bytes tobytes(self, order=*)
@@ -107,3 +109,5 @@ cpdef Module compile_with_cache(str source, tuple options=*, arch=*,
 cpdef ndarray array(obj, dtype=*, bint copy=*, order=*, bint subok=*,
                     Py_ssize_t ndmin=*)
 cpdef ndarray _convert_object_with_cuda_array_interface(a)
+
+cdef _ndarray_init(const vector.vector[Py_ssize_t]& shape, dtype)

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2778,7 +2778,7 @@ cpdef ndarray _convert_object_with_cuda_array_interface(a):
     return ndarray(shape, dtype, memptr, strides)
 
 
-cdef _ndarray_init(const vector.vector[Py_ssize_t]& shape, dtype):
+cdef ndarray _ndarray_init(const vector.vector[Py_ssize_t]& shape, dtype):
     cdef ndarray ret = ndarray.__new__(ndarray)
     ret._init_fast(shape, dtype, True)
     return ret


### PR DESCRIPTION
`ndarray` only accepts `tuple` like object. `_ndarray_init` accepts `vector`. We will be able to pass `vector` without cast.