### PR TITLE
Make `set_allocator` and `get_allocator` symmetric

### DIFF
--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -554,6 +554,9 @@ cpdef set_allocator(allocator=None):
     global _current_allocator
     if allocator is None:
         allocator = _malloc
+    if getattr(_thread_local, 'allocator', None) is not None:
+        raise ValueError('Can\'t change the global allocator inside '
+                         '`using_allocator` context manager')
     _current_allocator = allocator
 
 

--- a/tests/cupy_tests/cuda_tests/test_memory.py
+++ b/tests/cupy_tests/cuda_tests/test_memory.py
@@ -636,6 +636,13 @@ class TestAllocator(unittest.TestCase):
             assert memory.get_allocator() == new_pool.malloc
         assert memory.get_allocator() == self.pool.malloc
 
+    def test_set_allocator_cm(self):
+        new_pool = memory.MemoryPool()
+        new_pool2 = memory.MemoryPool()
+        with memory.using_allocator(new_pool.malloc):
+            with self.assertRaises(ValueError):
+                memory.set_allocator(new_pool2.malloc)
+
     def test_allocator_nested_context_manager(self):
         new_pool = memory.MemoryPool()
         with memory.using_allocator(new_pool.malloc):


### PR DESCRIPTION
set_allocator should throw an error when used inside `using_allocator` context manager