### PR TITLE
Added min, max, argmin, argmax to sparse csr and csc matrices

### DIFF
--- a/cupyx/scipy/sparse/compressed.py
+++ b/cupyx/scipy/sparse/compressed.py
@@ -14,7 +14,8 @@ from cupyx.scipy.sparse import data as sparse_data
 from cupyx.scipy.sparse import util
 
 
-class _compressed_sparse_matrix(sparse_data._data_matrix):
+class _compressed_sparse_matrix(sparse_data._data_matrix,
+                                sparse_data._minmax_mixin):
 
     _compress_getitem_kern = core.ElementwiseKernel(
         'T d, S ind, int32 minor', 'raw T answer',
@@ -31,6 +32,265 @@ class _compressed_sparse_matrix(sparse_data._data_matrix):
         }
         ''',
         'compress_getitem_complex')
+
+    _max_reduction_kern = core.RawKernel(r'''
+        extern "C" __global__
+        void max_reduction(double* data, int* x, int* y, int length,
+                           double* z) {
+            // Get the index of the block
+            int tid = blockIdx.x * blockDim.x + threadIdx.x;
+
+            // Calculate the block length
+            int block_length = y[tid] - x[tid];
+
+            // Select initial value based on the block density
+            double running_value = 0;
+            if (block_length == length){
+                running_value = data[x[tid]];
+            } else {
+                running_value = 0;
+            }
+
+            // Iterate over the block and update
+            for (int entry = x[tid]; entry < y[tid]; entry++){
+                if (data[entry] != data[entry]){
+                    // Check for NaN
+                    running_value = nan("");
+                    break;
+                } else {
+                    // Check for a value update
+                    if (data[entry] > running_value){
+                        running_value = data[entry];
+                    }
+                }
+            }
+
+            // Store in the return function
+            z[tid] = running_value;
+        }
+        ''', 'max_reduction')
+
+    _max_nonzero_reduction_kern = core.RawKernel(r'''
+        extern "C" __global__
+        void max_nonzero_reduction(double* data, int* x, int* y, int length,
+                                   double* z) {
+            // Get the index of the block
+            int tid = blockIdx.x * blockDim.x + threadIdx.x;
+
+            // Calculate the block length
+            int block_length = y[tid] - x[tid];
+
+            // Select initial value based on the block density
+            double running_value = 0;
+            if (block_length > 0){
+                running_value = data[x[tid]];
+            } else {
+                running_value = 0;
+            }
+
+            // Iterate over the section of the sparse matrix
+            for (int entry = x[tid]; entry < y[tid]; entry++){
+                if (data[entry] != data[entry]){
+                    // Check for NaN
+                    running_value = nan("");
+                    break;
+                } else {
+                    // Check for a value update
+                    if (running_value < data[entry]){
+                        running_value = data[entry];
+                    }
+                }
+            }
+
+            // Store in the return function
+            z[tid] = running_value;
+        }
+        ''', 'max_nonzero_reduction')
+
+    _min_reduction_kern = core.RawKernel(r'''
+        extern "C" __global__
+        void min_reduction(double* data, int* x, int* y, int length,
+                           double* z) {
+            // Get the index of the block
+            int tid = blockIdx.x * blockDim.x + threadIdx.x;
+
+            // Calculate the block length
+            int block_length = y[tid] - x[tid];
+
+            // Select initial value based on the block density
+            double running_value = 0;
+            if (block_length == length){
+                running_value = data[x[tid]];
+            } else {
+                running_value = 0;
+            }
+
+            // Iterate over the block to update the initial value
+            for (int entry = x[tid]; entry < y[tid]; entry++){
+                if (data[entry] != data[entry]){
+                    // Check for NaN
+                    running_value = nan("");
+                    break;
+                } else {
+                    // Check for a value update
+                    if (data[entry] < running_value){
+                        running_value = data[entry];
+                    }
+                }
+            }
+
+            // Store in the return function
+            z[tid] = running_value;
+        }
+        ''', 'min_reduction')
+
+    _min_nonzero_reduction_kern = core.RawKernel(r'''
+        extern "C" __global__
+        void min_nonzero_reduction(double* data, int* x, int* y, int length,
+                                   double* z) {
+            // Get the index of hte block
+            int tid = blockIdx.x * blockDim.x + threadIdx.x;
+
+            // Calculate the block length
+            int block_length = y[tid] - x[tid];
+
+            // Select initial value based on the block density
+            double running_value = 0;
+            if (block_length > 0){
+                running_value = data[x[tid]];
+            } else {
+                running_value = 0;
+            }
+
+            // Iterate over the section of the sparse matrix
+            for (int entry = x[tid]; entry < y[tid]; entry++){
+                if (data[entry] != data[entry]){
+                    // Check for NaN
+                    running_value = nan("");
+                    break;
+                } else {
+                    // Check for a value update
+                    if (running_value > data[entry]){
+                        running_value = data[entry];
+                    }
+                }
+            }
+
+            // Store in the return function
+            z[tid] = running_value;
+        }
+        ''', 'min_nonzero_reduction')
+
+    _max_arg_reduction_kern = core.RawKernel(r'''
+        extern "C" __global__
+        void max_arg_reduction(double* data, int* indices, int* x, int* y,
+                               int length, long long* z) {
+            // Get the index of the block
+            int tid = blockIdx.x * blockDim.x + threadIdx.x;
+
+            // Calculate the block length
+            int block_length = y[tid] - x[tid];
+
+            // Select initial value based on the block density
+            int data_index = 0;
+            double data_value = 0;
+
+            if (block_length == length){
+                // Block is dense. Fill the first value
+                data_value = data[x[tid]];
+                data_index = indices[x[tid]];
+            } else if (block_length > 0)  {
+                // Block has at least one zero. Assign first occurrence as the
+                // starting reference
+                data_value = 0;
+                for (data_index = 0; data_index < length; data_index++){
+                    if (data_index != indices[x[tid] + data_index] ||
+                        x[tid] + data_index >= y[tid]){
+                        break;
+                    }
+                }
+            } else {
+                 // Zero valued array
+                data_value = 0;
+                data_index = 0;
+            }
+
+            // Iterate over the section of the sparse matrix
+            for (int entry = x[tid]; entry < y[tid]; entry++){
+                if (data[entry] != data[entry]){
+                    // Check for NaN
+                    data_value = nan("");
+                    data_index = 0;
+                    break;
+                } else {
+                    // Check for a value update
+                    if (data[entry] > data_value){
+                        data_index = indices[entry];
+                        data_value = data[entry];
+                    }
+                }
+            }
+
+            // Store in the return function
+            z[tid] = data_index;
+        }
+        ''', 'max_arg_reduction')
+
+    _min_arg_reduction_kern = core.RawKernel(r'''
+        extern "C" __global__
+        void min_arg_reduction(double* data, int* indices, int* x, int* y,
+                               int length, long long* z) {
+            // Get the index of hte block
+            int tid = blockIdx.x * blockDim.x + threadIdx.x;
+
+            // Calculate the block length
+            int block_length = y[tid] - x[tid];
+
+            // Select initial value based on the block density
+            int data_index = 0;
+            double data_value = 0;
+
+            if (block_length == length){
+                // Block is dense. Fill the first value
+                data_value = data[x[tid]];
+                data_index = indices[x[tid]];
+            } else if (block_length > 0)  {
+                // Block has at least one zero. Assign first occurrence as the
+                // starting reference
+                data_value = 0;
+                for (data_index = 0; data_index < length; data_index++){
+                    if (data_index != indices[x[tid] + data_index] ||
+                        x[tid] + data_index >= y[tid]){
+                        break;
+                    }
+                }
+            } else {
+                // Zero valued array
+                data_value = 0;
+                data_index = 0;
+            }
+
+            // Iterate over the section of the sparse matrix
+            for (int entry = x[tid]; entry < y[tid]; entry++){
+                if (data[entry] != data[entry]){
+                    // Check for NaN
+                    data_value = nan("");
+                    data_index = 0;
+                    break;
+                } else {
+                    // Check for a value update
+                    if (data[entry] < data_value){
+                        data_index = indices[entry];
+                        data_value = data[entry];
+                    }
+                }
+            }
+
+            // Store in the return function
+            z[tid] = data_index;
+
+        }
+        ''', 'min_arg_reduction')
 
     def __init__(self, arg1, shape=None, dtype=None, copy=False):
         if shape is not None:
@@ -306,6 +566,7 @@ class _compressed_sparse_matrix(sparse_data._data_matrix):
 
         Returns:
             tuple: Shape of the matrix.
+
         """
         return self._shape
 
@@ -336,3 +597,163 @@ class _compressed_sparse_matrix(sparse_data._data_matrix):
         coo.sum_duplicates()
         self.__init__(coo.asformat(self.format))
         self._has_canonical_format = True
+
+    #####################
+    # Reduce operations #
+    #####################
+
+    def _minor_reduce(self, ufunc, axis, nonzero):
+        """Reduce nonzeros with a ufunc over the minor axis when non-empty
+
+        Can be applied to a function of self.data by supplying data parameter.
+        Warning: this does not call sum_duplicates()
+
+        Args:
+            ufunc (object): Function handle giving the operation to be
+                conducted.
+            axis (int): Matrix over which the reduction should be
+                conducted.
+
+        Returns:
+            (cupy.ndarray): Reduce result for nonzeros in each
+                major_index.
+
+        """
+
+        # Call to the appropriate kernel function
+        if axis == 1:
+            # Create the vector to hold output
+            value = cupy.zeros(self.shape[0]).astype(cupy.float64)
+
+            if nonzero:
+                # Perform the calculation
+                if ufunc == cupy.amax:
+                    self._max_nonzero_reduction_kern(
+                        (self.shape[0],), (1,),
+                        (self.data.astype(cupy.float64),
+                         self.indptr[:len(self.indptr) - 1],
+                         self.indptr[1:], cupy.int64(self.shape[1]),
+                         value))
+                if ufunc == cupy.amin:
+                    self._min_nonzero_reduction_kern(
+                        (self.shape[0],), (1,),
+                        (self.data.astype(cupy.float64),
+                         self.indptr[:len(self.indptr) - 1],
+                         self.indptr[1:], cupy.int64(self.shape[1]),
+                         value))
+
+            else:
+                # Perform the calculation
+                if ufunc == cupy.amax:
+                    self._max_reduction_kern(
+                        (self.shape[0],), (1,),
+                        (self.data.astype(cupy.float64),
+                         self.indptr[:len(self.indptr) - 1],
+                         self.indptr[1:], cupy.int64(self.shape[1]),
+                         value))
+                if ufunc == cupy.amin:
+                    self._min_reduction_kern(
+                        (self.shape[0],), (1,),
+                        (self.data.astype(cupy.float64),
+                         self.indptr[:len(self.indptr) - 1],
+                         self.indptr[1:], cupy.int64(self.shape[1]),
+                         value))
+
+        if axis == 0:
+            # Create the vector to hold output
+            value = cupy.zeros(self.shape[1]).astype(cupy.float64)
+
+            if nonzero:
+                # Perform the calculation
+                if ufunc == cupy.amax:
+                    self._max_nonzero_reduction_kern(
+                        (self.shape[1],), (1,),
+                        (self.data.astype(cupy.float64),
+                         self.indptr[:len(self.indptr) - 1],
+                         self.indptr[1:], cupy.int64(self.shape[0]),
+                         value))
+                if ufunc == cupy.amin:
+                    self._min_nonzero_reduction_kern(
+                        (self.shape[1],), (1,),
+                        (self.data.astype(cupy.float64),
+                         self.indptr[:len(self.indptr) - 1],
+                         self.indptr[1:], cupy.int64(self.shape[0]),
+                         value))
+            else:
+                # Perform the calculation
+                if ufunc == cupy.amax:
+                    self._max_reduction_kern(
+                        (self.shape[1],), (1,),
+                        (self.data.astype(cupy.float64),
+                         self.indptr[:len(self.indptr) - 1],
+                         self.indptr[1:], cupy.int64(self.shape[0]),
+                         value))
+                if ufunc == cupy.amin:
+                    self._min_reduction_kern(
+                        (self.shape[1],), (1,),
+                        (self.data.astype(cupy.float64),
+                         self.indptr[:len(self.indptr) - 1],
+                         self.indptr[1:], cupy.int64(self.shape[0]),
+                         value))
+
+        return value
+
+    def _arg_minor_reduce(self, ufunc, axis):
+        """Reduce nonzeros with a ufunc over the minor axis when non-empty
+
+        Can be applied to a function of self.data by supplying data parameter.
+        Warning: this does not call sum_duplicates()
+
+        Args:
+            ufunc (object): Function handle giving the operation to be
+                conducted.
+            axis (int): Maxtrix over which the reduction should be conducted
+
+        Returns:
+            (cupy.ndarray): Reduce result for nonzeros in each
+                major_index
+
+        """
+
+        # Call to the appropriate kernel function
+        if axis == 1:
+            # Create the vector to hold output
+            value = cupy.zeros(self.shape[0]).astype(cupy.int64)
+
+            # Perform the calculation
+            if ufunc == cupy.argmax:
+                self._max_arg_reduction_kern(
+                    (self.shape[0],), (1,),
+                    (self.data.astype(cupy.float64), self.indices,
+                     self.indptr[:len(self.indptr) - 1],
+                     self.indptr[1:], cupy.int64(self.shape[1]),
+                     value))
+            if ufunc == cupy.argmin:
+                self._min_arg_reduction_kern(
+                    (self.shape[0],), (1,),
+                    (self.data.astype(cupy.float64), self.indices,
+                     self.indptr[:len(self.indptr) - 1],
+                     self.indptr[1:], cupy.int64(self.shape[1]),
+                     value))
+
+        if axis == 0:
+            # Create the vector to hold output
+            value = cupy.zeros(self.shape[1]).astype(cupy.int64)
+
+            # Perform the calculation
+            if ufunc == cupy.argmax:
+                self._max_arg_reduction_kern(
+                    (self.shape[1],), (1,),
+                    (self.data.astype(cupy.float64), self.indices,
+                     self.indptr[:len(self.indptr) - 1],
+                     self.indptr[1:], cupy.int64(self.shape[0]),
+                     value))
+            if ufunc == cupy.argmin:
+                self._min_arg_reduction_kern(
+                    (self.shape[1],), (1,),
+                    (self.data.astype(cupy.float64), self.indices,
+                     self.indptr[:len(self.indptr) - 1],
+                     self.indptr[1:],
+                     cupy.int64(self.shape[0]), value))
+
+        return value

--- a/cupyx/scipy/sparse/csc.py
+++ b/cupyx/scipy/sparse/csc.py
@@ -103,8 +103,6 @@ class csc_matrix(compressed._compressed_sparse_matrix):
         else:
             return NotImplemented
 
-    # TODO(unno): Implement argmax
-    # TODO(unno): Implement argmin
     # TODO(unno): Implement check_format
     # TODO(unno): Implement diagonal
 
@@ -117,9 +115,7 @@ class csc_matrix(compressed._compressed_sparse_matrix):
         self.indices = compress.indices
         self.indptr = compress.indptr
 
-    # TODO(unno): Implement max
     # TODO(unno): Implement maximum
-    # TODO(unno): Implement min
     # TODO(unno): Implement minimum
     # TODO(unno): Implement multiply
     # TODO(unno): Implement prune

--- a/cupyx/scipy/sparse/csr.py
+++ b/cupyx/scipy/sparse/csr.py
@@ -141,8 +141,6 @@ class csr_matrix(compressed._compressed_sparse_matrix):
     def __rtruediv__(self, other):
         raise NotImplementedError
 
-    # TODO(unno): Implement argmax
-    # TODO(unno): Implement argmin
     # TODO(unno): Implement check_format
 
     def diagonal(self, k=0):
@@ -156,13 +154,9 @@ class csr_matrix(compressed._compressed_sparse_matrix):
         self.indices = compress.indices
         self.indptr = compress.indptr
 
-    # TODO(unno): Implement max
-
     def maximum(self, other):
         # TODO(unno): Implement maximum
         raise NotImplementedError
-
-    # TODO(unno): Implement min
 
     def minimum(self, other):
         # TODO(unno): Implement minimum

--- a/cupyx/scipy/sparse/data.py
+++ b/cupyx/scipy/sparse/data.py
@@ -1,5 +1,6 @@
 import cupy
 from cupyx.scipy.sparse import base
+from .util import validateaxis
 
 
 _ufuncs = [
@@ -86,6 +87,230 @@ class _data_matrix(base.spmatrix):
             data = self.data.astype(dtype, copy=True)
         data **= n
         return self._with_data(data)
+
+
+def _find_missing_index(ind, n):
+    for k, a in enumerate(ind):
+        if k != a:
+            return k
+
+    k += 1
+    if k < n:
+        return k
+    else:
+        return -1
+
+
+class _minmax_mixin(object):
+    """Mixin for min and max methods.
+    These are not implemented for dia_matrix, hence the separate class.
+
+    """
+
+    def _min_or_max_axis(self, axis, min_or_max, sum_duplicates, nonzero):
+        N = self.shape[axis]
+        if N == 0:
+            raise ValueError("zero-size array to reduction operation")
+
+        mat = self.tocsc() if axis == 0 else self.tocsr()
+        if sum_duplicates:
+            mat.sum_duplicates()
+
+        # Do the reudction
+        value = mat._minor_reduce(min_or_max, axis, nonzero)
+
+        return value
+
+    def _min_or_max(self, axis, out, min_or_max, sum_duplicates, non_zero):
+        if out is not None:
+            raise ValueError(("Sparse matrices do not support "
+                              "an 'out' parameter."))
+
+        validateaxis(axis)
+
+        if axis == 0 or axis == 1:
+            return self._min_or_max_axis(axis, min_or_max, sum_duplicates,
+                                         non_zero)
+        else:
+            raise ValueError("axis out of range")
+
+    def _arg_min_or_max_axis(self, axis, op, sum_duplicates):
+        if self.shape[axis] == 0:
+            raise ValueError("Can't apply the operation along a zero-sized "
+                             "dimension.")
+
+        mat = self.tocsc() if axis == 0 else self.tocsr()
+
+        if sum_duplicates:
+            mat.sum_duplicates()
+
+        # Do the reudction
+        value = mat._arg_minor_reduce(op, axis)
+
+        return value
+
+    def _arg_min_or_max(self, axis, out, op, compare, sum_duplicates):
+        if out is not None:
+            raise ValueError("Sparse matrices do not support "
+                             "an 'out' parameter.")
+
+        validateaxis(axis)
+
+        if axis is None:
+            if 0 in self.shape:
+                raise ValueError("Can't apply the operation to "
+                                 "an empty matrix.")
+
+            if self.nnz == 0:
+                return 0
+            else:
+                zero = self.dtype.type(0)
+                mat = self.tocoo()
+
+                if sum_duplicates:
+                    mat.sum_duplicates()
+
+                am = op(mat.data)
+                m = mat.data[am]
+
+                if compare(m, zero):
+                    return mat.row[am] * mat.shape[1] + mat.col[am]
+                else:
+                    size = cupy.prod(mat.shape)
+                    if size == mat.nnz:
+                        return am
+                    else:
+                        ind = mat.row * mat.shape[1] + mat.col
+                        zero_ind = _find_missing_index(ind, size)
+                        if m == zero:
+                            return min(zero_ind, am)
+                        else:
+                            return zero_ind
+
+        return self._arg_min_or_max_axis(axis, op, sum_duplicates)
+
+    def max(self, axis=None, out=None, sum_duplicates=False, nonzero=False):
+        """Returns the maximum of the matrix or maximum along an axis.
+
+        Args:
+            axis (int): {-2, -1, 0, 1, ``None``} (optional)
+                Axis along which the sum is computed. The default is to
+                compute the maximum over all the matrix elements, returning
+                a scalar (i.e. ``axis`` = ``None``).
+            out (None): (optional)
+                This argument is in the signature *solely* for NumPy
+                compatibility reasons. Do not pass in anything except
+                for the default value, as this argument is not used.
+            sum_duplicates (bool): Flag to indicate that duplicate elements
+                should be combined prior to the operation
+            nonzero (bool): Return the maximum nonzero value and ignore all
+                zero entries. If the dimension has no nonzero values, a zero is
+                then returned to indicate that it is the only available value.
+
+        Returns:
+            (cupy.ndarray or float): Maximum of ``a``. If ``axis`` is
+                ``None``, the result is a scalar value. If ``axis`` is given,
+                the result is an array of dimension ``a.ndim - 1``. This
+                differs from numpy for computational efficiency.
+
+        .. seealso:: min : The minimum value of a sparse matrix along a given
+          axis.
+        .. seealso:: numpy.matrix.max : NumPy's implementation of ``max`` for
+          matrices
+
+        """
+
+        return self._min_or_max(axis, out, cupy.max, sum_duplicates, nonzero)
+
+    def min(self, axis=None, out=None, sum_duplicates=False, nonzero=False):
+        """Returns the minimum of the matrix or maximum along an axis.
+
+        Args:
+            axis (int): {-2, -1, 0, 1, ``None``} (optional)
+                Axis along which the sum is computed. The default is to
+                compute the minimum over all the matrix elements, returning
+                a scalar (i.e. ``axis`` = ``None``).
+            out (None): (optional)
+                This argument is in the signature *solely* for NumPy
+                compatibility reasons. Do not pass in anything except for
+                the default value, as this argument is not used.
+            sum_duplicates (bool): Flag to indicate that duplicate elements
+                should be combined prior to the operation
+            nonzero (bool): Return the minimum nonzero value and ignore all
+                zero entries. If the dimension has no nonzero values, a zero is
+                then returned to indicate that it is the only available value.
+
+        Returns:
+            (cupy.ndarray or float): Minimum of ``a``. If ``axis`` is
+                None, the result is a scalar value. If ``axis`` is given, the
+                result is an array of dimension ``a.ndim - 1``. This differs
+                from numpy for computational efficiency.
+
+        .. seealso:: max : The maximum value of a sparse matrix along a given
+          axis.
+        .. seealso:: numpy.matrix.min : NumPy's implementation of 'min' for
+          matrices
+
+        """
+
+        return self._min_or_max(axis, out, cupy.min, sum_duplicates, nonzero)
+
+    def argmax(self, axis=None, out=None, sum_duplicates=False):
+        """Returns indices of maximum elements along an axis.
+
+        Implicit zero elements are taken into account. If there are several
+        maximum values, the index of the first occurrence is returned. If
+        ``NaN`` values occur in the matrix, the output defaults to a zero entry
+        for the row/column in which the NaN occurs.
+
+        Args:
+            axis (int): {-2, -1, 0, 1, ``None``} (optional)
+                Axis along which the argmax is computed. If ``None`` (default),
+                index of the maximum element in the flatten data is returned.
+            out (None): (optional)
+                This argument is in the signature *solely* for NumPy
+                compatibility reasons. Do not pass in anything except for
+                the default value, as this argument is not used.
+            sum_duplicates (bool): Flag to indicate that duplicate elements
+                should be combined prior to the operation
+
+        Returns:
+            (cupy.narray or int): Indices of maximum elements. If array,
+                its size along ``axis`` is 1.
+
+        """
+
+        return self._arg_min_or_max(axis, out, cupy.argmax, cupy.greater,
+                                    sum_duplicates)
+
+    def argmin(self, axis=None, out=None, sum_duplicates=False):
+        """
+        Returns indices of minimum elements along an axis.
+
+        Implicit zero elements are taken into account. If there are several
+        minimum values, the index of the first occurrence is returned. If
+        ``NaN`` values occur in the matrix, the output defaults to a zero entry
+        for the row/column in which the NaN occurs.
+
+        Args:
+            axis (int): {-2, -1, 0, 1, ``None``} (optional)
+                Axis along which the argmin is computed. If ``None`` (default),
+                index of the minimum element in the flatten data is returned.
+            out (None): (optional)
+                This argument is in the signature *solely* for NumPy
+                compatibility reasons. Do not pass in anything except for
+                the default value, as this argument is not used.
+            sum_duplicates (bool): Flag to indicate that duplicate elements
+                should be combined prior to the operation
+
+        Returns:
+            (cupy.narray or int): Indices of minimum elements. If matrix,
+                its size along ``axis`` is 1.
+
+        """
+
+        return self._arg_min_or_max(axis, out, cupy.argmin, cupy.less,
+                                    sum_duplicates)
 
 
 def _install_ufunc(func_name):

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
@@ -856,6 +856,290 @@ class TestCscMatrixScipyCompressed(unittest.TestCase):
         return _make(xp, sp, self.dtype).getnnz()
 
 
+@unittest.skipUnless(scipy_available, 'requires scipy>=0.19')
+class TestCsrMatrixScipyCompressedMinMax(unittest.TestCase):
+
+    def test_min_sparse_axis_0(self):
+        dm_data = numpy.random.random((10, 20))
+        dm_data[dm_data < 0.95] = 0
+
+        dm_data = scipy.sparse.csc_matrix(dm_data)
+        cp_matrix = sparse.csc_matrix((cupy.array(dm_data.data),
+                                       cupy.array(dm_data.indices),
+                                       cupy.array(dm_data.indptr)),
+                                      shape=(10, 20))
+
+        da_cupy_values = cupy.asnumpy(cp_matrix.min(axis=0))
+        da_scipy_values = numpy.array(dm_data.min(axis=0).todense().ravel())
+        da_scipy_values = da_scipy_values[0, :]
+        assert numpy.array_equal(da_cupy_values, da_scipy_values)
+
+    def test_min_dense_axis_0(self):
+        dm_data = numpy.random.random((10, 20))
+
+        dm_data = scipy.sparse.csc_matrix(dm_data)
+        cp_matrix = sparse.csc_matrix((cupy.array(dm_data.data),
+                                       cupy.array(dm_data.indices),
+                                       cupy.array(dm_data.indptr)),
+                                      shape=(10, 20))
+
+        da_cupy_values = cupy.asnumpy(cp_matrix.min(axis=0))
+        da_scipy_values = numpy.array(dm_data.min(axis=0).todense().ravel())
+        da_scipy_values = da_scipy_values[0, :]
+        assert numpy.array_equal(da_cupy_values, da_scipy_values)
+
+    def test_min_axis_0_nonzero(self):
+        dm_data = numpy.arange(0, 100, 1).reshape((10, 10)).astype(float)
+
+        dm_sparse = scipy.sparse.csc_matrix(dm_data)
+        cp_matrix = sparse.csc_matrix((cupy.array(dm_sparse.data),
+                                       cupy.array(dm_sparse.indices),
+                                       cupy.array(dm_sparse.indptr)),
+                                      shape=(10, 10))
+
+        da_cupy_values = cupy.asnumpy(cp_matrix.min(axis=0, nonzero=True))
+        da_numpy_values = numpy.array([10, 1, 2, 3, 4,
+                                       5, 6, 7, 8, 9]).astype(float)
+        assert numpy.array_equal(da_cupy_values, da_numpy_values)
+
+    def test_min_sparse_axis_1(self):
+        dm_data = numpy.random.random((10, 20))
+        dm_data[dm_data < 0.95] = 0
+
+        dm_data = scipy.sparse.csc_matrix(dm_data)
+        cp_matrix = sparse.csc_matrix((cupy.array(dm_data.data),
+                                       cupy.array(dm_data.indices),
+                                       cupy.array(dm_data.indptr)),
+                                      shape=(10, 20))
+
+        da_cupy_values = cupy.asnumpy(cp_matrix.min(axis=1))
+        da_scipy_values = numpy.array(dm_data.min(axis=1).todense().ravel())
+        da_scipy_values = da_scipy_values[0, :]
+        assert numpy.array_equal(da_cupy_values, da_scipy_values)
+
+    def test_min_dense_axis_1(self):
+        dm_data = numpy.random.random((10, 20))
+
+        dm_data = scipy.sparse.csc_matrix(dm_data)
+        cp_matrix = sparse.csc_matrix((cupy.array(dm_data.data),
+                                       cupy.array(dm_data.indices),
+                                       cupy.array(dm_data.indptr)),
+                                      shape=(10, 20))
+
+        da_cupy_values = cupy.asnumpy(cp_matrix.min(axis=1))
+        da_scipy_values = numpy.array(dm_data.min(axis=1).todense().ravel())
+        da_scipy_values = da_scipy_values[0, :]
+        assert numpy.array_equal(da_cupy_values, da_scipy_values)
+
+    def test_min_axis_1_nonzero(self):
+        dm_data = numpy.arange(0, 100, 1).reshape((10, 10)).astype(float)
+
+        dm_sparse = scipy.sparse.csc_matrix(dm_data)
+        cp_matrix = sparse.csc_matrix((cupy.array(dm_sparse.data),
+                                       cupy.array(dm_sparse.indices),
+                                       cupy.array(dm_sparse.indptr)),
+                                      shape=(10, 10))
+
+        da_cupy_values = cupy.asnumpy(cp_matrix.min(axis=1, nonzero=True))
+        da_numpy_values = numpy.array([1, 10, 20, 30, 40,
+                                       50, 60, 70, 80, 90]).astype(float)
+        assert numpy.array_equal(da_cupy_values, da_numpy_values)
+
+    def test_max_sparse_axis_0(self):
+        dm_data = numpy.random.random((10, 20))
+        dm_data[dm_data < 0.95] = 0
+
+        dm_data = scipy.sparse.csc_matrix(dm_data)
+        cp_matrix = sparse.csc_matrix((cupy.array(dm_data.data),
+                                       cupy.array(dm_data.indices),
+                                       cupy.array(dm_data.indptr)),
+                                      shape=(10, 20))
+
+        da_cupy_values = cupy.asnumpy(cp_matrix.max(axis=0))
+        da_scipy_values = numpy.array(dm_data.max(axis=0).todense().ravel())
+        da_scipy_values = da_scipy_values[0, :]
+        assert numpy.array_equal(da_cupy_values, da_scipy_values)
+
+    def test_max_dense_axis_0(self):
+        dm_data = numpy.random.random((10, 20))
+
+        dm_data = scipy.sparse.csc_matrix(dm_data)
+        cp_matrix = sparse.csc_matrix((cupy.array(dm_data.data),
+                                       cupy.array(dm_data.indices),
+                                       cupy.array(dm_data.indptr)),
+                                      shape=(10, 20))
+
+        da_cupy_values = cupy.asnumpy(cp_matrix.max(axis=0))
+        da_scipy_values = numpy.array(dm_data.max(axis=0).todense().ravel())
+        da_scipy_values = da_scipy_values[0, :]
+        assert numpy.array_equal(da_cupy_values, da_scipy_values)
+
+    def test_max_axis_0_nonzero(self):
+        dm_data = numpy.arange(0, 100, 1).reshape((10, 10)).astype(float)
+
+        dm_sparse = scipy.sparse.csc_matrix(dm_data)
+        cp_matrix = sparse.csc_matrix((cupy.array(dm_sparse.data),
+                                       cupy.array(dm_sparse.indices),
+                                       cupy.array(dm_sparse.indptr)),
+                                      shape=(10, 10))
+
+        da_cupy_values = cupy.asnumpy(cp_matrix.max(axis=0, nonzero=True))
+        da_numpy_values = numpy.array([90, 91, 92, 93, 94,
+                                       95, 96, 97, 98, 99]).astype(float)
+        assert numpy.array_equal(da_cupy_values, da_numpy_values)
+
+    def test_max_sparse_axis_1(self):
+        dm_data = numpy.random.random((10, 20))
+        dm_data[dm_data < 0.95] = 0
+
+        dm_data = scipy.sparse.csc_matrix(dm_data)
+        cp_matrix = sparse.csc_matrix((cupy.array(dm_data.data),
+                                       cupy.array(dm_data.indices),
+                                       cupy.array(dm_data.indptr)),
+                                      shape=(10, 20))
+
+        da_cupy_values = cupy.asnumpy(cp_matrix.max(axis=1))
+        da_scipy_values = numpy.array(dm_data.max(axis=1).todense().ravel())
+        da_scipy_values = da_scipy_values[0, :]
+        assert numpy.array_equal(da_cupy_values, da_scipy_values)
+
+    def test_max_dense_axis_1(self):
+        dm_data = numpy.random.random((10, 20))
+
+        dm_data = scipy.sparse.csc_matrix(dm_data)
+        cp_matrix = sparse.csc_matrix((cupy.array(dm_data.data),
+                                       cupy.array(dm_data.indices),
+                                       cupy.array(dm_data.indptr)),
+                                      shape=(10, 20))
+
+        da_cupy_values = cupy.asnumpy(cp_matrix.max(axis=1))
+        da_scipy_values = numpy.array(dm_data.max(axis=1).todense().ravel())
+        da_scipy_values = da_scipy_values[0, :]
+        assert numpy.array_equal(da_cupy_values, da_scipy_values)
+
+    def test_max_axis_1_nonzero(self):
+        dm_data = numpy.arange(0, 100, 1).reshape((10, 10)).astype(float)
+
+        dm_sparse = scipy.sparse.csc_matrix(dm_data)
+        cp_matrix = sparse.csc_matrix((cupy.array(dm_sparse.data),
+                                       cupy.array(dm_sparse.indices),
+                                       cupy.array(dm_sparse.indptr)),
+                                      shape=(10, 10))
+
+        da_cupy_values = cupy.asnumpy(cp_matrix.max(axis=1, nonzero=True))
+        da_numpy_values = numpy.array([9, 19, 29, 39, 49,
+                                       59, 69, 79, 89, 99]).astype(float)
+        assert numpy.array_equal(da_cupy_values, da_numpy_values)
+
+    def test_argmin_sparse_axis_0(self):
+        dm_data = numpy.random.random((10, 20))
+        dm_data[dm_data < 0.95] = 0
+
+        dm_data = scipy.sparse.csc_matrix(dm_data)
+        cp_matrix = sparse.csc_matrix((cupy.array(dm_data.data),
+                                       cupy.array(dm_data.indices),
+                                       cupy.array(dm_data.indptr)),
+                                      shape=(10, 20))
+
+        da_cupy_values = cupy.asnumpy(cp_matrix.argmin(axis=0))
+        da_scipy_values = numpy.array(dm_data.argmin(axis=0))[0, :]
+        assert numpy.array_equal(da_cupy_values, da_scipy_values)
+
+    def test_argmin_dense_axis_0(self):
+        dm_data = numpy.random.random((10, 20))
+
+        dm_data = scipy.sparse.csc_matrix(dm_data)
+        cp_matrix = sparse.csc_matrix((cupy.array(dm_data.data),
+                                       cupy.array(dm_data.indices),
+                                       cupy.array(dm_data.indptr)),
+                                      shape=(10, 20))
+
+        da_cupy_values = cupy.asnumpy(cp_matrix.argmin(axis=0))
+        da_scipy_values = numpy.array(dm_data.argmin(axis=0))[0, :]
+        assert numpy.array_equal(da_cupy_values, da_scipy_values)
+
+    def test_argmin_sparse_axis_1(self):
+        dm_data = numpy.random.random((10, 20))
+        dm_data[dm_data < 0.95] = 0
+
+        dm_data = scipy.sparse.csc_matrix(dm_data)
+        cp_matrix = sparse.csc_matrix((cupy.array(dm_data.data),
+                                       cupy.array(dm_data.indices),
+                                       cupy.array(dm_data.indptr)),
+                                      shape=(10, 20))
+
+        da_cupy_values = cupy.asnumpy(cp_matrix.argmin(axis=1))
+        da_scipy_values = numpy.array(dm_data.argmin(axis=1))[:, 0]
+        assert numpy.array_equal(da_cupy_values, da_scipy_values)
+
+    def test_argmin_dense_axis_1(self):
+        dm_data = numpy.random.random((10, 20))
+
+        dm_data = scipy.sparse.csc_matrix(dm_data)
+        cp_matrix = sparse.csc_matrix((cupy.array(dm_data.data),
+                                       cupy.array(dm_data.indices),
+                                       cupy.array(dm_data.indptr)),
+                                      shape=(10, 20))
+
+        da_cupy_values = cupy.asnumpy(cp_matrix.argmin(axis=1))
+        da_scipy_values = numpy.array(dm_data.argmin(axis=1))[:, 0]
+        assert numpy.array_equal(da_cupy_values, da_scipy_values)
+
+    def test_argmax_sparse_axis_0(self):
+        dm_data = numpy.random.random((10, 20))
+        dm_data[dm_data < 0.95] = 0
+
+        dm_data = scipy.sparse.csc_matrix(dm_data)
+        cp_matrix = sparse.csc_matrix((cupy.array(dm_data.data),
+                                       cupy.array(dm_data.indices),
+                                       cupy.array(dm_data.indptr)),
+                                      shape=(10, 20))
+
+        da_cupy_values = cupy.asnumpy(cp_matrix.argmax(axis=0))
+        da_scipy_values = numpy.array(dm_data.argmax(axis=0))[0, :]
+        assert numpy.array_equal(da_cupy_values, da_scipy_values)
+
+    def test_argmax_dense_axis_0(self):
+        dm_data = numpy.random.random((10, 20))
+
+        dm_data = scipy.sparse.csc_matrix(dm_data)
+        cp_matrix = sparse.csc_matrix((cupy.array(dm_data.data),
+                                       cupy.array(dm_data.indices),
+                                       cupy.array(dm_data.indptr)),
+                                      shape=(10, 20))
+
+        da_cupy_values = cupy.asnumpy(cp_matrix.argmax(axis=0))
+        da_scipy_values = numpy.array(dm_data.argmax(axis=0))[0, :]
+        assert numpy.array_equal(da_cupy_values, da_scipy_values)
+
+    def test_argmax_sparse_axis_1(self):
+        dm_data = numpy.random.random((10, 20))
+        dm_data[dm_data < 0.95] = 0
+
+        dm_data = scipy.sparse.csc_matrix(dm_data)
+        cp_matrix = sparse.csc_matrix((cupy.array(dm_data.data),
+                                       cupy.array(dm_data.indices),
+                                       cupy.array(dm_data.indptr)),
+                                      shape=(10, 20))
+
+        da_cupy_values = cupy.asnumpy(cp_matrix.argmax(axis=1))
+        da_scipy_values = numpy.array(dm_data.argmax(axis=1))[:, 0]
+        assert numpy.array_equal(da_cupy_values, da_scipy_values)
+
+    def test_argmax_dense_axis_1(self):
+        dm_data = numpy.random.random((10, 20))
+
+        dm_data = scipy.sparse.csc_matrix(dm_data)
+        cp_matrix = sparse.csc_matrix((cupy.array(dm_data.data),
+                                       cupy.array(dm_data.indices),
+                                       cupy.array(dm_data.indptr)),
+                                      shape=(10, 20))
+
+        da_cupy_values = cupy.asnumpy(cp_matrix.argmax(axis=1))
+        da_scipy_values = numpy.array(dm_data.argmax(axis=1))[:, 0]
+        assert numpy.array_equal(da_cupy_values, da_scipy_values)
+
+
 @testing.parameterize(*testing.product({
     'dtype': [numpy.float32, numpy.float64, numpy.complex64, numpy.complex128],
 }))

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
@@ -124,7 +124,7 @@ class TestCscMatrix(unittest.TestCase):
         cupy.testing.assert_array_equal(n.indptr, self.m.indptr)
         self.assertEqual(n.shape, self.m.shape)
 
-    @unittest.skipUnless(scipy_available, 'requires scipy')
+    @testing.with_requires('scipy')
     def test_init_copy_scipy_sparse(self):
         m = _make(numpy, scipy.sparse, self.dtype)
         n = sparse.csc_matrix(m)
@@ -136,7 +136,7 @@ class TestCscMatrix(unittest.TestCase):
         cupy.testing.assert_array_equal(n.indptr, m.indptr)
         self.assertEqual(n.shape, m.shape)
 
-    @unittest.skipUnless(scipy_available, 'requires scipy')
+    @testing.with_requires('scipy')
     def test_init_copy_other_scipy_sparse(self):
         m = _make(numpy, scipy.sparse, self.dtype)
         n = sparse.csc_matrix(m.tocsr())
@@ -188,7 +188,7 @@ class TestCscMatrix(unittest.TestCase):
         cupy.testing.assert_array_equal(n.indices, [0])
         cupy.testing.assert_array_equal(n.indptr, [0, 1])
 
-    @unittest.skipUnless(scipy_available, 'requires scipy')
+    @testing.with_requires('scipy')
     @testing.numpy_cupy_raises(sp_name='sp', accept_error=TypeError)
     def test_init_dense_invalid_ndim(self, xp, sp):
         m = xp.zeros((1, 1, 1), dtype=self.dtype)
@@ -219,7 +219,7 @@ class TestCscMatrix(unittest.TestCase):
         n = _make_complex(cupy, sparse, self.dtype)
         cupy.testing.assert_array_equal(n.conj().data, n.data.conj())
 
-    @unittest.skipUnless(scipy_available, 'requires scipy')
+    @testing.with_requires('scipy')
     def test_get(self):
         m = self.m.get()
         self.assertIsInstance(m, scipy.sparse.csc_matrix)
@@ -230,7 +230,7 @@ class TestCscMatrix(unittest.TestCase):
         ]
         numpy.testing.assert_allclose(m.toarray(), expect)
 
-    @unittest.skipUnless(scipy_available, 'requires scipy')
+    @testing.with_requires('scipy')
     def test_str(self):
         if numpy.dtype(self.dtype).kind == 'f':
             expect = '''  (0, 0)\t0.0
@@ -259,7 +259,7 @@ class TestCscMatrix(unittest.TestCase):
 @testing.parameterize(*testing.product({
     'dtype': [numpy.float32, numpy.float64, numpy.complex64, numpy.complex128],
 }))
-@unittest.skipUnless(scipy_available, 'requires scipy')
+@testing.with_requires('scipy')
 class TestCscMatrixInit(unittest.TestCase):
 
     def setUp(self):
@@ -391,7 +391,7 @@ class TestCscMatrixInit(unittest.TestCase):
         '_make_shape'],
     'dtype': [numpy.float32, numpy.float64, numpy.complex64, numpy.complex128],
 }))
-@unittest.skipUnless(scipy_available, 'requires scipy')
+@testing.with_requires('scipy')
 class TestCscMatrixScipyComparison(unittest.TestCase):
 
     @property
@@ -816,7 +816,7 @@ class TestCscMatrixScipyComparison(unittest.TestCase):
     'ret_dtype': [None, numpy.float32, numpy.float64],
     'axis': [None, 0, 1, -1, -2],
 }))
-@unittest.skipUnless(scipy_available, 'requires scipy')
+@testing.with_requires('scipy')
 class TestCscMatrixSum(unittest.TestCase):
 
     @testing.numpy_cupy_allclose(sp_name='sp')
@@ -844,7 +844,7 @@ class TestCscMatrixSum(unittest.TestCase):
 @testing.parameterize(*testing.product({
     'dtype': [numpy.float32, numpy.float64, numpy.complex64, numpy.complex128],
 }))
-@unittest.skipUnless(scipy_available, 'requires scipy')
+@testing.with_requires('scipy')
 class TestCscMatrixScipyCompressed(unittest.TestCase):
 
     @testing.numpy_cupy_equal(sp_name='sp')
@@ -856,7 +856,7 @@ class TestCscMatrixScipyCompressed(unittest.TestCase):
         return _make(xp, sp, self.dtype).getnnz()
 
 
-@unittest.skipUnless(scipy_available, 'requires scipy>=0.19')
+@testing.with_requires('scipy>=0.19.0')
 class TestCsrMatrixScipyCompressedMinMax(unittest.TestCase):
 
     def test_min_sparse_axis_0(self):
@@ -1143,7 +1143,7 @@ class TestCsrMatrixScipyCompressedMinMax(unittest.TestCase):
 @testing.parameterize(*testing.product({
     'dtype': [numpy.float32, numpy.float64, numpy.complex64, numpy.complex128],
 }))
-@unittest.skipUnless(scipy_available, 'requires scipy')
+@testing.with_requires('scipy')
 class TestCscMatrixData(unittest.TestCase):
 
     @testing.numpy_cupy_equal(sp_name='sp')
@@ -1197,7 +1197,7 @@ class TestCscMatrixData(unittest.TestCase):
         'tan', 'tanh', 'trunc',
     ],
 }))
-@unittest.skipUnless(scipy_available, 'requires scipy')
+@testing.with_requires('scipy')
 class TestUfunc(unittest.TestCase):
 
     @testing.numpy_cupy_allclose(sp_name='sp', atol=1e-5)
@@ -1237,7 +1237,7 @@ class TestIsspmatrixCsc(unittest.TestCase):
 @testing.parameterize(*testing.product({
     'dtype': [numpy.float32, numpy.float64, numpy.complex64, numpy.complex128],
 }))
-@unittest.skipUnless(scipy_available, 'requires scipy')
+@testing.with_requires('scipy')
 class TestCsrMatrixGetitem(unittest.TestCase):
 
     @testing.numpy_cupy_equal(sp_name='sp')
@@ -1304,7 +1304,7 @@ class TestCsrMatrixGetitem(unittest.TestCase):
 @testing.parameterize(*testing.product({
     'dtype': [numpy.float32, numpy.float64, numpy.complex64, numpy.complex128],
 }))
-@testing.with_requires('scipy>=1.0')
+@testing.with_requires('scipy>=1.0.0')
 class TestCsrMatrixGetitem2(unittest.TestCase):
 
     @testing.numpy_cupy_allclose(sp_name='sp')

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -138,7 +138,7 @@ class TestCsrMatrix(unittest.TestCase):
         cupy.testing.assert_array_equal(n.indptr, self.m.indptr)
         self.assertEqual(n.shape, self.m.shape)
 
-    @unittest.skipUnless(scipy_available, 'requires scipy')
+    @testing.with_requires('scipy')
     def test_init_copy_scipy_sparse(self):
         m = _make(numpy, scipy.sparse, self.dtype)
         n = sparse.csr_matrix(m)
@@ -150,7 +150,7 @@ class TestCsrMatrix(unittest.TestCase):
         cupy.testing.assert_array_equal(n.indptr, m.indptr)
         self.assertEqual(n.shape, m.shape)
 
-    @unittest.skipUnless(scipy_available, 'requires scipy')
+    @testing.with_requires('scipy')
     def test_init_copy_other_scipy_sparse(self):
         m = _make(numpy, scipy.sparse, self.dtype)
         n = sparse.csr_matrix(m.tocsc())
@@ -202,7 +202,7 @@ class TestCsrMatrix(unittest.TestCase):
         cupy.testing.assert_array_equal(n.indices, [0])
         cupy.testing.assert_array_equal(n.indptr, [0, 1])
 
-    @unittest.skipUnless(scipy_available, 'requires scipy')
+    @testing.with_requires('scipy')
     @testing.numpy_cupy_raises(sp_name='sp', accept_error=TypeError)
     def test_init_dense_invalid_ndim(self, xp, sp):
         m = xp.zeros((1, 1, 1), dtype=self.dtype)
@@ -233,7 +233,7 @@ class TestCsrMatrix(unittest.TestCase):
         n = _make_complex(cupy, sparse, self.dtype)
         cupy.testing.assert_array_equal(n.conj().data, n.data.conj())
 
-    @unittest.skipUnless(scipy_available, 'requires scipy')
+    @testing.with_requires('scipy')
     def test_get(self):
         m = self.m.get()
         self.assertIsInstance(m, scipy.sparse.csr_matrix)
@@ -244,7 +244,7 @@ class TestCsrMatrix(unittest.TestCase):
         ]
         numpy.testing.assert_allclose(m.toarray(), expect)
 
-    @unittest.skipUnless(scipy_available, 'requires scipy')
+    @testing.with_requires('scipy')
     def test_str(self):
         if numpy.dtype(self.dtype).kind == 'f':
             expect = '''  (0, 0)\t0.0
@@ -273,7 +273,7 @@ class TestCsrMatrix(unittest.TestCase):
 @testing.parameterize(*testing.product({
     'dtype': [numpy.float32, numpy.float64, numpy.complex64, numpy.complex128],
 }))
-@unittest.skipUnless(scipy_available, 'requires scipy')
+@testing.with_requires('scipy')
 class TestCsrMatrixInit(unittest.TestCase):
 
     def setUp(self):
@@ -405,7 +405,7 @@ class TestCsrMatrixInit(unittest.TestCase):
         '_make_shape'],
     'dtype': [numpy.float32, numpy.float64, numpy.complex64, numpy.complex128],
 }))
-@unittest.skipUnless(scipy_available, 'requires scipy')
+@testing.with_requires('scipy')
 class TestCsrMatrixScipyComparison(unittest.TestCase):
 
     @property
@@ -860,7 +860,7 @@ class TestCsrMatrixScipyComparison(unittest.TestCase):
 @testing.parameterize(*testing.product({
     'dtype': [numpy.float32, numpy.float64, numpy.complex64, numpy.complex128],
 }))
-@unittest.skipUnless(scipy_available, 'requires scipy')
+@testing.with_requires('scipy')
 class TestCsrMatrixPowScipyComparison(unittest.TestCase):
 
     @testing.numpy_cupy_allclose(sp_name='sp')
@@ -910,7 +910,7 @@ class TestCsrMatrixPowScipyComparison(unittest.TestCase):
     'ret_dtype': [None, numpy.float32, numpy.float64],
     'axis': [None, 0, 1, -1, -2],
 }))
-@unittest.skipUnless(scipy_available, 'requires scipy')
+@testing.with_requires('scipy')
 class TestCsrMatrixSum(unittest.TestCase):
 
     @testing.numpy_cupy_allclose(sp_name='sp')
@@ -938,7 +938,7 @@ class TestCsrMatrixSum(unittest.TestCase):
 @testing.parameterize(*testing.product({
     'dtype': [numpy.float32, numpy.float64, numpy.complex64, numpy.complex128],
 }))
-@unittest.skipUnless(scipy_available, 'requires scipy')
+@testing.with_requires('scipy')
 class TestCsrMatrixScipyCompressed(unittest.TestCase):
 
     @testing.numpy_cupy_equal(sp_name='sp')
@@ -950,7 +950,7 @@ class TestCsrMatrixScipyCompressed(unittest.TestCase):
         return _make(xp, sp, self.dtype).getnnz()
 
 
-@unittest.skipUnless(scipy_available, 'requires scipy>=0.19')
+@testing.with_requires('scipy>=0.19.0')
 class TestCsrMatrixScipyCompressedMinMax(unittest.TestCase):
 
     def test_min_sparse_axis_0(self):
@@ -1237,7 +1237,7 @@ class TestCsrMatrixScipyCompressedMinMax(unittest.TestCase):
 @testing.parameterize(*testing.product({
     'dtype': [numpy.float32, numpy.float64, numpy.complex64, numpy.complex128],
 }))
-@unittest.skipUnless(scipy_available, 'requires scipy')
+@testing.with_requires('scipy')
 class TestCsrMatrixData(unittest.TestCase):
 
     @testing.numpy_cupy_equal(sp_name='sp')
@@ -1291,7 +1291,7 @@ class TestCsrMatrixData(unittest.TestCase):
         'tan', 'tanh', 'trunc',
     ],
 }))
-@unittest.skipUnless(scipy_available, 'requires scipy')
+@testing.with_requires('scipy')
 class TestUfunc(unittest.TestCase):
 
     @testing.numpy_cupy_allclose(sp_name='sp', atol=1e-5)
@@ -1331,7 +1331,7 @@ class TestIsspmatrixCsr(unittest.TestCase):
 @testing.parameterize(*testing.product({
     'dtype': [numpy.float32, numpy.float64, cupy.complex64, cupy.complex128],
 }))
-@unittest.skipUnless(scipy_available, 'requires scipy')
+@testing.with_requires('scipy')
 class TestCsrMatrixGetitem(unittest.TestCase):
 
     @testing.numpy_cupy_equal(sp_name='sp')
@@ -1422,7 +1422,7 @@ class TestCsrMatrixGetitem(unittest.TestCase):
 @testing.parameterize(*testing.product({
     'dtype': [numpy.float32, numpy.float64, cupy.complex64, cupy.complex128],
 }))
-@testing.with_requires('scipy>=1.0')
+@testing.with_requires('scipy>=1.0.0')
 class TestCsrMatrixGetitem2(unittest.TestCase):
 
     @testing.numpy_cupy_allclose(sp_name='sp')

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -950,6 +950,290 @@ class TestCsrMatrixScipyCompressed(unittest.TestCase):
         return _make(xp, sp, self.dtype).getnnz()
 
 
+@unittest.skipUnless(scipy_available, 'requires scipy>=0.19')
+class TestCsrMatrixScipyCompressedMinMax(unittest.TestCase):
+
+    def test_min_sparse_axis_0(self):
+        dm_data = numpy.random.random((10, 20))
+        dm_data[dm_data < 0.95] = 0
+
+        dm_data = scipy.sparse.csr_matrix(dm_data)
+        cp_matrix = sparse.csr_matrix((cupy.array(dm_data.data),
+                                       cupy.array(dm_data.indices),
+                                       cupy.array(dm_data.indptr)),
+                                      shape=(10, 20))
+
+        da_cupy_values = cupy.asnumpy(cp_matrix.min(axis=0))
+        da_scipy_values = numpy.array(dm_data.min(axis=0).todense().ravel())
+        da_scipy_values = da_scipy_values[0, :]
+        assert numpy.array_equal(da_cupy_values, da_scipy_values)
+
+    def test_min_dense_axis_0(self):
+        dm_data = numpy.random.random((10, 20))
+
+        dm_data = scipy.sparse.csr_matrix(dm_data)
+        cp_matrix = sparse.csr_matrix((cupy.array(dm_data.data),
+                                       cupy.array(dm_data.indices),
+                                       cupy.array(dm_data.indptr)),
+                                      shape=(10, 20))
+
+        da_cupy_values = cupy.asnumpy(cp_matrix.min(axis=0))
+        da_scipy_values = numpy.array(dm_data.min(axis=0).todense().ravel())
+        da_scipy_values = da_scipy_values[0, :]
+        assert numpy.array_equal(da_cupy_values, da_scipy_values)
+
+    def test_min_axis_0_nonzero(self):
+        dm_data = numpy.arange(0, 100, 1).reshape((10, 10)).astype(float)
+
+        dm_sparse = scipy.sparse.csr_matrix(dm_data)
+        cp_matrix = sparse.csr_matrix((cupy.array(dm_sparse.data),
+                                       cupy.array(dm_sparse.indices),
+                                       cupy.array(dm_sparse.indptr)),
+                                      shape=(10, 10))
+
+        da_cupy_values = cupy.asnumpy(cp_matrix.min(axis=0, nonzero=True))
+        da_numpy_values = numpy.array([10, 1, 2, 3, 4,
+                                       5, 6, 7, 8, 9]).astype(float)
+        assert numpy.array_equal(da_cupy_values, da_numpy_values)
+
+    def test_min_sparse_axis_1(self):
+        dm_data = numpy.random.random((10, 20))
+        dm_data[dm_data < 0.95] = 0
+
+        dm_data = scipy.sparse.csr_matrix(dm_data)
+        cp_matrix = sparse.csr_matrix((cupy.array(dm_data.data),
+                                       cupy.array(dm_data.indices),
+                                       cupy.array(dm_data.indptr)),
+                                      shape=(10, 20))
+
+        da_cupy_values = cupy.asnumpy(cp_matrix.min(axis=1))
+        da_scipy_values = numpy.array(dm_data.min(axis=1).todense().ravel())
+        da_scipy_values = da_scipy_values[0, :]
+        assert numpy.array_equal(da_cupy_values, da_scipy_values)
+
+    def test_min_dense_axis_1(self):
+        dm_data = numpy.random.random((10, 20))
+
+        dm_data = scipy.sparse.csr_matrix(dm_data)
+        cp_matrix = sparse.csr_matrix((cupy.array(dm_data.data),
+                                       cupy.array(dm_data.indices),
+                                       cupy.array(dm_data.indptr)),
+                                      shape=(10, 20))
+
+        da_cupy_values = cupy.asnumpy(cp_matrix.min(axis=1))
+        da_scipy_values = numpy.array(dm_data.min(axis=1).todense().ravel())
+        da_scipy_values = da_scipy_values[0, :]
+        assert numpy.array_equal(da_cupy_values, da_scipy_values)
+
+    def test_min_axis_1_nonzero(self):
+        dm_data = numpy.arange(0, 100, 1).reshape((10, 10)).astype(float)
+
+        dm_sparse = scipy.sparse.csr_matrix(dm_data)
+        cp_matrix = sparse.csr_matrix((cupy.array(dm_sparse.data),
+                                       cupy.array(dm_sparse.indices),
+                                       cupy.array(dm_sparse.indptr)),
+                                      shape=(10, 10))
+
+        da_cupy_values = cupy.asnumpy(cp_matrix.min(axis=1, nonzero=True))
+        da_numpy_values = numpy.array([1, 10, 20, 30, 40,
+                                       50, 60, 70, 80, 90]).astype(float)
+        assert numpy.array_equal(da_cupy_values, da_numpy_values)
+
+    def test_max_sparse_axis_0(self):
+        dm_data = numpy.random.random((10, 20))
+        dm_data[dm_data < 0.95] = 0
+
+        dm_data = scipy.sparse.csr_matrix(dm_data)
+        cp_matrix = sparse.csr_matrix((cupy.array(dm_data.data),
+                                       cupy.array(dm_data.indices),
+                                       cupy.array(dm_data.indptr)),
+                                      shape=(10, 20))
+
+        da_cupy_values = cupy.asnumpy(cp_matrix.max(axis=0))
+        da_scipy_values = numpy.array(dm_data.max(axis=0).todense().ravel())
+        da_scipy_values = da_scipy_values[0, :]
+        assert numpy.array_equal(da_cupy_values, da_scipy_values)
+
+    def test_max_dense_axis_0(self):
+        dm_data = numpy.random.random((10, 20))
+
+        dm_data = scipy.sparse.csr_matrix(dm_data)
+        cp_matrix = sparse.csr_matrix((cupy.array(dm_data.data),
+                                       cupy.array(dm_data.indices),
+                                       cupy.array(dm_data.indptr)),
+                                      shape=(10, 20))
+
+        da_cupy_values = cupy.asnumpy(cp_matrix.max(axis=0))
+        da_scipy_values = numpy.array(dm_data.max(axis=0).todense().ravel())
+        da_scipy_values = da_scipy_values[0, :]
+        assert numpy.array_equal(da_cupy_values, da_scipy_values)
+
+    def test_max_axis_0_nonzero(self):
+        dm_data = numpy.arange(0, 100, 1).reshape((10, 10)).astype(float)
+
+        dm_sparse = scipy.sparse.csr_matrix(dm_data)
+        cp_matrix = sparse.csr_matrix((cupy.array(dm_sparse.data),
+                                       cupy.array(dm_sparse.indices),
+                                       cupy.array(dm_sparse.indptr)),
+                                      shape=(10, 10))
+
+        da_cupy_values = cupy.asnumpy(cp_matrix.max(axis=0, nonzero=True))
+        da_numpy_values = numpy.array([90, 91, 92, 93, 94,
+                                       95, 96, 97, 98, 99]).astype(float)
+        assert numpy.array_equal(da_cupy_values, da_numpy_values)
+
+    def test_max_sparse_axis_1(self):
+        dm_data = numpy.random.random((10, 20))
+        dm_data[dm_data < 0.95] = 0
+
+        dm_data = scipy.sparse.csr_matrix(dm_data)
+        cp_matrix = sparse.csr_matrix((cupy.array(dm_data.data),
+                                       cupy.array(dm_data.indices),
+                                       cupy.array(dm_data.indptr)),
+                                      shape=(10, 20))
+
+        da_cupy_values = cupy.asnumpy(cp_matrix.max(axis=1))
+        da_scipy_values = numpy.array(dm_data.max(axis=1).todense().ravel())
+        da_scipy_values = da_scipy_values[0, :]
+        assert numpy.array_equal(da_cupy_values, da_scipy_values)
+
+    def test_max_dense_axis_1(self):
+        dm_data = numpy.random.random((10, 20))
+
+        dm_data = scipy.sparse.csr_matrix(dm_data)
+        cp_matrix = sparse.csr_matrix((cupy.array(dm_data.data),
+                                       cupy.array(dm_data.indices),
+                                       cupy.array(dm_data.indptr)),
+                                      shape=(10, 20))
+
+        da_cupy_values = cupy.asnumpy(cp_matrix.max(axis=1))
+        da_scipy_values = numpy.array(dm_data.max(axis=1).todense().ravel())
+        da_scipy_values = da_scipy_values[0, :]
+        assert numpy.array_equal(da_cupy_values, da_scipy_values)
+
+    def test_max_axis_1_nonzero(self):
+        dm_data = numpy.arange(0, 100, 1).reshape((10, 10)).astype(float)
+
+        dm_sparse = scipy.sparse.csr_matrix(dm_data)
+        cp_matrix = sparse.csr_matrix((cupy.array(dm_sparse.data),
+                                       cupy.array(dm_sparse.indices),
+                                       cupy.array(dm_sparse.indptr)),
+                                      shape=(10, 10))
+
+        da_cupy_values = cupy.asnumpy(cp_matrix.max(axis=1, nonzero=True))
+        da_numpy_values = numpy.array([9, 19, 29, 39, 49,
+                                       59, 69, 79, 89, 99]).astype(float)
+        assert numpy.array_equal(da_cupy_values, da_numpy_values)
+
+    def test_argmin_sparse_axis_0(self):
+        dm_data = numpy.random.random((10, 20))
+        dm_data[dm_data < 0.95] = 0
+
+        dm_data = scipy.sparse.csr_matrix(dm_data)
+        cp_matrix = sparse.csr_matrix((cupy.array(dm_data.data),
+                                       cupy.array(dm_data.indices),
+                                       cupy.array(dm_data.indptr)),
+                                      shape=(10, 20))
+
+        da_cupy_values = cupy.asnumpy(cp_matrix.argmin(axis=0))
+        da_scipy_values = numpy.array(dm_data.argmin(axis=0))[0, :]
+        assert numpy.array_equal(da_cupy_values, da_scipy_values)
+
+    def test_argmin_dense_axis_0(self):
+        dm_data = numpy.random.random((10, 20))
+
+        dm_data = scipy.sparse.csr_matrix(dm_data)
+        cp_matrix = sparse.csr_matrix((cupy.array(dm_data.data),
+                                       cupy.array(dm_data.indices),
+                                       cupy.array(dm_data.indptr)),
+                                      shape=(10, 20))
+
+        da_cupy_values = cupy.asnumpy(cp_matrix.argmin(axis=0))
+        da_scipy_values = numpy.array(dm_data.argmin(axis=0))[0, :]
+        assert numpy.array_equal(da_cupy_values, da_scipy_values)
+
+    def test_argmin_sparse_axis_1(self):
+        dm_data = numpy.random.random((10, 20))
+        dm_data[dm_data < 0.95] = 0
+
+        dm_data = scipy.sparse.csr_matrix(dm_data)
+        cp_matrix = sparse.csr_matrix((cupy.array(dm_data.data),
+                                       cupy.array(dm_data.indices),
+                                       cupy.array(dm_data.indptr)),
+                                      shape=(10, 20))
+
+        da_cupy_values = cupy.asnumpy(cp_matrix.argmin(axis=1))
+        da_scipy_values = numpy.array(dm_data.argmin(axis=1))[:, 0]
+        assert numpy.array_equal(da_cupy_values, da_scipy_values)
+
+    def test_argmin_dense_axis_1(self):
+        dm_data = numpy.random.random((10, 20))
+
+        dm_data = scipy.sparse.csr_matrix(dm_data)
+        cp_matrix = sparse.csr_matrix((cupy.array(dm_data.data),
+                                       cupy.array(dm_data.indices),
+                                       cupy.array(dm_data.indptr)),
+                                      shape=(10, 20))
+
+        da_cupy_values = cupy.asnumpy(cp_matrix.argmin(axis=1))
+        da_scipy_values = numpy.array(dm_data.argmin(axis=1))[:, 0]
+        assert numpy.array_equal(da_cupy_values, da_scipy_values)
+
+    def test_argmax_sparse_axis_0(self):
+        dm_data = numpy.random.random((10, 20))
+        dm_data[dm_data < 0.95] = 0
+
+        dm_data = scipy.sparse.csr_matrix(dm_data)
+        cp_matrix = sparse.csr_matrix((cupy.array(dm_data.data),
+                                       cupy.array(dm_data.indices),
+                                       cupy.array(dm_data.indptr)),
+                                      shape=(10, 20))
+
+        da_cupy_values = cupy.asnumpy(cp_matrix.argmax(axis=0))
+        da_scipy_values = numpy.array(dm_data.argmax(axis=0))[0, :]
+        assert numpy.array_equal(da_cupy_values, da_scipy_values)
+
+    def test_argmax_dense_axis_0(self):
+        dm_data = numpy.random.random((10, 20))
+
+        dm_data = scipy.sparse.csr_matrix(dm_data)
+        cp_matrix = sparse.csr_matrix((cupy.array(dm_data.data),
+                                       cupy.array(dm_data.indices),
+                                       cupy.array(dm_data.indptr)),
+                                      shape=(10, 20))
+
+        da_cupy_values = cupy.asnumpy(cp_matrix.argmax(axis=0))
+        da_scipy_values = numpy.array(dm_data.argmax(axis=0))[0, :]
+        assert numpy.array_equal(da_cupy_values, da_scipy_values)
+
+    def test_argmax_sparse_axis_1(self):
+        dm_data = numpy.random.random((10, 20))
+        dm_data[dm_data < 0.95] = 0
+
+        dm_data = scipy.sparse.csr_matrix(dm_data)
+        cp_matrix = sparse.csr_matrix((cupy.array(dm_data.data),
+                                       cupy.array(dm_data.indices),
+                                       cupy.array(dm_data.indptr)),
+                                      shape=(10, 20))
+
+        da_cupy_values = cupy.asnumpy(cp_matrix.argmax(axis=1))
+        da_scipy_values = numpy.array(dm_data.argmax(axis=1))[:, 0]
+        assert numpy.array_equal(da_cupy_values, da_scipy_values)
+
+    def test_argmax_dense_axis_1(self):
+        dm_data = numpy.random.random((10, 20))
+
+        dm_data = scipy.sparse.csr_matrix(dm_data)
+        cp_matrix = sparse.csr_matrix((cupy.array(dm_data.data),
+                                       cupy.array(dm_data.indices),
+                                       cupy.array(dm_data.indptr)),
+                                      shape=(10, 20))
+
+        da_cupy_values = cupy.asnumpy(cp_matrix.argmax(axis=1))
+        da_scipy_values = numpy.array(dm_data.argmax(axis=1))[:, 0]
+        assert numpy.array_equal(da_cupy_values, da_scipy_values)
+
+
 @testing.parameterize(*testing.product({
     'dtype': [numpy.float32, numpy.float64, numpy.complex64, numpy.complex128],
 }))


### PR DESCRIPTION
This adds min, max, argmin, and argmax functionality to cupy sparse csr and csc matrix formats. Format differences from scipy are to improve computational performance by eliminating duplicate summation and coo matrix construction time. 