### PR TITLE
Skip tests that segfault when using SciPy 1.3.x

### DIFF
--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
@@ -1008,6 +1008,7 @@ class TestCsrMatrixGetitem(unittest.TestCase):
     def test_getitem_slice_negative(self, xp, sp):
         return _make(xp, sp, self.dtype)[:, -2:-1]
 
+    @testing.with_reqires('scipy!=1.3.*')  # avoid segfault
     @testing.numpy_cupy_raises(sp_name='sp', accept_error=IndexError)
     def test_getitem_slice_start_larger_than_stop(self, xp, sp):
         _make(xp, sp, self.dtype)[:, 3:2]

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
@@ -1009,7 +1009,7 @@ class TestCsrMatrixGetitem(unittest.TestCase):
         return _make(xp, sp, self.dtype)[:, -2:-1]
 
     # avoid segfault: https://github.com/scipy/scipy/issues/11125
-    @testing.with_reqires('scipy!=1.3.*')
+    @testing.with_requires('scipy!=1.3.*')
     @testing.numpy_cupy_raises(sp_name='sp', accept_error=IndexError)
     def test_getitem_slice_start_larger_than_stop(self, xp, sp):
         _make(xp, sp, self.dtype)[:, 3:2]

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
@@ -1008,7 +1008,8 @@ class TestCsrMatrixGetitem(unittest.TestCase):
     def test_getitem_slice_negative(self, xp, sp):
         return _make(xp, sp, self.dtype)[:, -2:-1]
 
-    @testing.with_reqires('scipy!=1.3.*')  # avoid segfault
+    # avoid segfault: https://github.com/scipy/scipy/issues/11125
+    @testing.with_reqires('scipy!=1.3.*')
     @testing.numpy_cupy_raises(sp_name='sp', accept_error=IndexError)
     def test_getitem_slice_start_larger_than_stop(self, xp, sp):
         _make(xp, sp, self.dtype)[:, 3:2]

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -1119,7 +1119,7 @@ class TestCsrMatrixGetitem(unittest.TestCase):
         return _make(xp, sp, self.dtype)[-2:-1]
 
     # avoid segfault: https://github.com/scipy/scipy/issues/11125
-    @testing.with_reqires('scipy!=1.3.*')
+    @testing.with_requires('scipy!=1.3.*')
     @testing.numpy_cupy_raises(sp_name='sp', accept_error=IndexError)
     def test_getitem_slice_start_larger_than_stop(self, xp, sp):
         _make(xp, sp, self.dtype)[3:2]

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -1118,6 +1118,7 @@ class TestCsrMatrixGetitem(unittest.TestCase):
     def test_getitem_slice_negative(self, xp, sp):
         return _make(xp, sp, self.dtype)[-2:-1]
 
+    @testing.with_reqires('scipy!=1.3.*')  # avoid segfault
     @testing.numpy_cupy_raises(sp_name='sp', accept_error=IndexError)
     def test_getitem_slice_start_larger_than_stop(self, xp, sp):
         _make(xp, sp, self.dtype)[3:2]

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -1118,7 +1118,8 @@ class TestCsrMatrixGetitem(unittest.TestCase):
     def test_getitem_slice_negative(self, xp, sp):
         return _make(xp, sp, self.dtype)[-2:-1]
 
-    @testing.with_reqires('scipy!=1.3.*')  # avoid segfault
+    # avoid segfault: https://github.com/scipy/scipy/issues/11125
+    @testing.with_reqires('scipy!=1.3.*')
     @testing.numpy_cupy_raises(sp_name='sp', accept_error=IndexError)
     def test_getitem_slice_start_larger_than_stop(self, xp, sp):
         _make(xp, sp, self.dtype)[3:2]


### PR DESCRIPTION
Avoid two tests that segfault within SciPy when it is version 1.3.* (or 1.4.0rc1). See scipy/scipy#11125.

Hopefully this will be fixed prior to the final 1.4.0 release.