### PR TITLE
Use `intptr_t` for cuSOLVER  handles

### DIFF
--- a/cupy/cuda/cusolver.pxd
+++ b/cupy/cuda/cusolver.pxd
@@ -1,4 +1,5 @@
 """Thin wrapper of CUSOLVER."""
+from libc.stdint cimport intptr_t
 
 
 ###############################################################################
@@ -48,171 +49,171 @@ cpdef tuple _getVersion()
 # Context
 ###############################################################################
 
-cpdef size_t create() except? 0
-cpdef size_t spCreate() except? 0
-cpdef destroy(size_t handle)
-cpdef spDestroy(size_t handle)
+cpdef intptr_t create() except? 0
+cpdef intptr_t spCreate() except? 0
+cpdef destroy(intptr_t handle)
+cpdef spDestroy(intptr_t handle)
 
 ###############################################################################
 # Stream
 ###############################################################################
 
-cpdef setStream(size_t handle, size_t stream)
-cpdef size_t getStream(size_t handle) except? 0
+cpdef setStream(intptr_t handle, size_t stream)
+cpdef size_t getStream(intptr_t handle) except? 0
 
 ###############################################################################
 # Dense LAPACK Functions (Linear Solver)
 ###############################################################################
 
 # Cholesky factorization
-cpdef int spotrf_bufferSize(size_t handle, int uplo,
+cpdef int spotrf_bufferSize(intptr_t handle, int uplo,
                             int n, size_t A, int lda) except? -1
-cpdef int dpotrf_bufferSize(size_t handle, int uplo,
+cpdef int dpotrf_bufferSize(intptr_t handle, int uplo,
                             int n, size_t A, int lda) except? -1
-cpdef int cpotrf_bufferSize(size_t handle, int uplo,
+cpdef int cpotrf_bufferSize(intptr_t handle, int uplo,
                             int n, size_t A, int lda) except? -1
-cpdef int zpotrf_bufferSize(size_t handle, int uplo,
+cpdef int zpotrf_bufferSize(intptr_t handle, int uplo,
                             int n, size_t A, int lda) except? -1
 
-cpdef spotrf(size_t handle, int uplo, int n, size_t A, int lda,
+cpdef spotrf(intptr_t handle, int uplo, int n, size_t A, int lda,
              size_t work, int lwork, size_t devInfo)
-cpdef dpotrf(size_t handle, int uplo, int n, size_t A, int lda,
+cpdef dpotrf(intptr_t handle, int uplo, int n, size_t A, int lda,
              size_t work, int lwork, size_t devInfo)
-cpdef cpotrf(size_t handle, int uplo, int n, size_t A, int lda,
+cpdef cpotrf(intptr_t handle, int uplo, int n, size_t A, int lda,
              size_t work, int lwork, size_t devInfo)
-cpdef zpotrf(size_t handle, int uplo, int n, size_t A, int lda,
+cpdef zpotrf(intptr_t handle, int uplo, int n, size_t A, int lda,
              size_t work, int lwork, size_t devInfo)
 
-cpdef spotrs(size_t handle, int uplo, int n, int nrhs,
+cpdef spotrs(intptr_t handle, int uplo, int n, int nrhs,
              size_t A, int lda, size_t B, int ldb, size_t devInfo)
-cpdef dpotrs(size_t handle, int uplo, int n, int nrhs,
+cpdef dpotrs(intptr_t handle, int uplo, int n, int nrhs,
              size_t A, int lda, size_t B, int ldb, size_t devInfo)
-cpdef cpotrs(size_t handle, int uplo, int n, int nrhs,
+cpdef cpotrs(intptr_t handle, int uplo, int n, int nrhs,
              size_t A, int lda, size_t B, int ldb, size_t devInfo)
-cpdef zpotrs(size_t handle, int uplo, int n, int nrhs,
+cpdef zpotrs(intptr_t handle, int uplo, int n, int nrhs,
              size_t A, int lda, size_t B, int ldb, size_t devInfo)
 
 # TODO(anaruse): potrfBatched and potrsBatched
 
 # LU factorization
-cpdef int sgetrf_bufferSize(size_t handle, int m, int n,
+cpdef int sgetrf_bufferSize(intptr_t handle, int m, int n,
                             size_t A, int lda) except? -1
-cpdef int dgetrf_bufferSize(size_t handle, int m, int n,
+cpdef int dgetrf_bufferSize(intptr_t handle, int m, int n,
                             size_t A, int lda) except? -1
-cpdef int cgetrf_bufferSize(size_t handle, int m, int n,
+cpdef int cgetrf_bufferSize(intptr_t handle, int m, int n,
                             size_t A, int lda) except? -1
-cpdef int zgetrf_bufferSize(size_t handle, int m, int n,
+cpdef int zgetrf_bufferSize(intptr_t handle, int m, int n,
                             size_t A, int lda) except? -1
 
-cpdef sgetrf(size_t handle, int m, int n, size_t A, int lda,
+cpdef sgetrf(intptr_t handle, int m, int n, size_t A, int lda,
              size_t work, size_t devIpiv, size_t devInfo)
-cpdef dgetrf(size_t handle, int m, int n, size_t A, int lda,
+cpdef dgetrf(intptr_t handle, int m, int n, size_t A, int lda,
              size_t work, size_t devIpiv, size_t devInfo)
-cpdef cgetrf(size_t handle, int m, int n, size_t A, int lda,
+cpdef cgetrf(intptr_t handle, int m, int n, size_t A, int lda,
              size_t work, size_t devIpiv, size_t devInfo)
-cpdef zgetrf(size_t handle, int m, int n, size_t A, int lda,
+cpdef zgetrf(intptr_t handle, int m, int n, size_t A, int lda,
              size_t work, size_t devIpiv, size_t devInfo)
 
 # TODO(anaruse): laswp
 
 # LU solve
-cpdef sgetrs(size_t handle, int trans, int n, int nrhs,
+cpdef sgetrs(intptr_t handle, int trans, int n, int nrhs,
              size_t A, int lda, size_t devIpiv,
              size_t B, int ldb, size_t devInfo)
-cpdef dgetrs(size_t handle, int trans, int n, int nrhs,
+cpdef dgetrs(intptr_t handle, int trans, int n, int nrhs,
              size_t A, int lda, size_t devIpiv,
              size_t B, int ldb, size_t devInfo)
-cpdef cgetrs(size_t handle, int trans, int n, int nrhs,
+cpdef cgetrs(intptr_t handle, int trans, int n, int nrhs,
              size_t A, int lda, size_t devIpiv,
              size_t B, int ldb, size_t devInfo)
-cpdef zgetrs(size_t handle, int trans, int n, int nrhs,
+cpdef zgetrs(intptr_t handle, int trans, int n, int nrhs,
              size_t A, int lda, size_t devIpiv,
              size_t B, int ldb, size_t devInfo)
 
 # QR factorization
-cpdef int sgeqrf_bufferSize(size_t handle, int m, int n,
+cpdef int sgeqrf_bufferSize(intptr_t handle, int m, int n,
                             size_t A, int lda) except? -1
-cpdef int dgeqrf_bufferSize(size_t handle, int m, int n,
+cpdef int dgeqrf_bufferSize(intptr_t handle, int m, int n,
                             size_t A, int lda) except? -1
-cpdef int cgeqrf_bufferSize(size_t handle, int m, int n,
+cpdef int cgeqrf_bufferSize(intptr_t handle, int m, int n,
                             size_t A, int lda) except? -1
-cpdef int zgeqrf_bufferSize(size_t handle, int m, int n,
+cpdef int zgeqrf_bufferSize(intptr_t handle, int m, int n,
                             size_t A, int lda) except? -1
 
-cpdef sgeqrf(size_t handle, int m, int n, size_t A, int lda,
+cpdef sgeqrf(intptr_t handle, int m, int n, size_t A, int lda,
              size_t tau, size_t work, int lwork, size_t devInfo)
-cpdef dgeqrf(size_t handle, int m, int n, size_t A, int lda,
+cpdef dgeqrf(intptr_t handle, int m, int n, size_t A, int lda,
              size_t tau, size_t work, int lwork, size_t devInfo)
-cpdef cgeqrf(size_t handle, int m, int n, size_t A, int lda,
+cpdef cgeqrf(intptr_t handle, int m, int n, size_t A, int lda,
              size_t tau, size_t work, int lwork, size_t devInfo)
-cpdef zgeqrf(size_t handle, int m, int n, size_t A, int lda,
+cpdef zgeqrf(intptr_t handle, int m, int n, size_t A, int lda,
              size_t tau, size_t work, int lwork, size_t devInfo)
 
 # Generate unitary matrix Q from QR factorization
-cpdef int sorgqr_bufferSize(size_t handle, int m, int n, int k,
+cpdef int sorgqr_bufferSize(intptr_t handle, int m, int n, int k,
                             size_t A, int lda, size_t tau) except? -1
-cpdef int dorgqr_bufferSize(size_t handle, int m, int n, int k,
+cpdef int dorgqr_bufferSize(intptr_t handle, int m, int n, int k,
                             size_t A, int lda, size_t tau) except? -1
-cpdef int cungqr_bufferSize(size_t handle, int m, int n, int k,
+cpdef int cungqr_bufferSize(intptr_t handle, int m, int n, int k,
                             size_t A, int lda, size_t tau) except? -1
-cpdef int zungqr_bufferSize(size_t handle, int m, int n, int k,
+cpdef int zungqr_bufferSize(intptr_t handle, int m, int n, int k,
                             size_t A, int lda, size_t tau) except? -1
 
-cpdef sorgqr(size_t handle, int m, int n, int k, size_t A, int lda,
+cpdef sorgqr(intptr_t handle, int m, int n, int k, size_t A, int lda,
              size_t tau, size_t work, int lwork, size_t devInfo)
-cpdef dorgqr(size_t handle, int m, int n, int k, size_t A, int lda,
+cpdef dorgqr(intptr_t handle, int m, int n, int k, size_t A, int lda,
              size_t tau, size_t work, int lwork, size_t devInfo)
-cpdef cungqr(size_t handle, int m, int n, int k, size_t A, int lda,
+cpdef cungqr(intptr_t handle, int m, int n, int k, size_t A, int lda,
              size_t tau, size_t work, int lwork, size_t devInfo)
-cpdef zungqr(size_t handle, int m, int n, int k, size_t A, int lda,
+cpdef zungqr(intptr_t handle, int m, int n, int k, size_t A, int lda,
              size_t tau, size_t work, int lwork, size_t devInfo)
 
 # Compute Q**T*b in solve min||A*x = b||
-cpdef int sormqr_bufferSize(size_t handle, int side, int trans,
+cpdef int sormqr_bufferSize(intptr_t handle, int side, int trans,
                             int m, int n, int k, size_t A, int lda, size_t tau,
                             size_t C, int ldc) except? -1
-cpdef int dormqr_bufferSize(size_t handle, int side, int trans,
+cpdef int dormqr_bufferSize(intptr_t handle, int side, int trans,
                             int m, int n, int k, size_t A, int lda, size_t tau,
                             size_t C, int ldc) except? -1
-cpdef int cunmqr_bufferSize(size_t handle, int side, int trans,
+cpdef int cunmqr_bufferSize(intptr_t handle, int side, int trans,
                             int m, int n, int k, size_t A, int lda, size_t tau,
                             size_t C, int ldc) except? -1
-cpdef int zunmqr_bufferSize(size_t handle, int side, int trans,
+cpdef int zunmqr_bufferSize(intptr_t handle, int side, int trans,
                             int m, int n, int k, size_t A, int lda, size_t tau,
                             size_t C, int ldc) except? -1
 
-cpdef sormqr(size_t handle, int side, int trans,
+cpdef sormqr(intptr_t handle, int side, int trans,
              int m, int n, int k, size_t A, int lda, size_t tau, size_t C,
              int ldc, size_t work, int lwork, size_t devInfo)
-cpdef dormqr(size_t handle, int side, int trans,
+cpdef dormqr(intptr_t handle, int side, int trans,
              int m, int n, int k, size_t A, int lda, size_t tau, size_t C,
              int ldc, size_t work, int lwork, size_t devInfo)
-cpdef cunmqr(size_t handle, int side, int trans,
+cpdef cunmqr(intptr_t handle, int side, int trans,
              int m, int n, int k, size_t A, int lda, size_t tau, size_t C,
              int ldc, size_t work, int lwork, size_t devInfo)
-cpdef zunmqr(size_t handle, int side, int trans,
+cpdef zunmqr(intptr_t handle, int side, int trans,
              int m, int n, int k, size_t A, int lda, size_t tau, size_t C,
              int ldc, size_t work, int lwork, size_t devInfo)
-cpdef cormqr(size_t handle, int side, int trans,
+cpdef cormqr(intptr_t handle, int side, int trans,
              int m, int n, int k, size_t A, int lda, size_t tau, size_t C,
              int ldc, size_t work, int lwork, size_t devInfo)  # (obsoleted)
-cpdef zormqr(size_t handle, int side, int trans,
+cpdef zormqr(intptr_t handle, int side, int trans,
              int m, int n, int k, size_t A, int lda, size_t tau, size_t C,
              int ldc, size_t work, int lwork, size_t devInfo)  # (obsoleted)
 
 # L*D*L**T,U*D*U**T factorization
-cpdef int ssytrf_bufferSize(size_t handle, int n, size_t A, int lda) except? -1
-cpdef int dsytrf_bufferSize(size_t handle, int n, size_t A, int lda) except? -1
-cpdef int csytrf_bufferSize(size_t handle, int n, size_t A, int lda) except? -1
-cpdef int zsytrf_bufferSize(size_t handle, int n, size_t A, int lda) except? -1
+cpdef int ssytrf_bufferSize(intptr_t handle, int n, size_t A, int lda) except? -1
+cpdef int dsytrf_bufferSize(intptr_t handle, int n, size_t A, int lda) except? -1
+cpdef int csytrf_bufferSize(intptr_t handle, int n, size_t A, int lda) except? -1
+cpdef int zsytrf_bufferSize(intptr_t handle, int n, size_t A, int lda) except? -1
 
-cpdef ssytrf(size_t handle, int uplo, int n, size_t A, int lda,
+cpdef ssytrf(intptr_t handle, int uplo, int n, size_t A, int lda,
              size_t ipiv, size_t work, int lwork, size_t devInfo)
-cpdef dsytrf(size_t handle, int uplo, int n, size_t A, int lda,
+cpdef dsytrf(intptr_t handle, int uplo, int n, size_t A, int lda,
              size_t ipiv, size_t work, int lwork, size_t devInfo)
-cpdef csytrf(size_t handle, int uplo, int n, size_t A, int lda,
+cpdef csytrf(intptr_t handle, int uplo, int n, size_t A, int lda,
              size_t ipiv, size_t work, int lwork, size_t devInfo)
-cpdef zsytrf(size_t handle, int uplo, int n, size_t A, int lda,
+cpdef zsytrf(intptr_t handle, int uplo, int n, size_t A, int lda,
              size_t ipiv, size_t work, int lwork, size_t devInfo)
 
 ###############################################################################
@@ -220,62 +221,62 @@ cpdef zsytrf(size_t handle, int uplo, int n, size_t A, int lda,
 ###############################################################################
 
 # Bidiagonal factorization
-cpdef int sgebrd_bufferSize(size_t handle, int m, int n) except? -1
-cpdef int dgebrd_bufferSize(size_t handle, int m, int n) except? -1
-cpdef int cgebrd_bufferSize(size_t handle, int m, int n) except? -1
-cpdef int zgebrd_bufferSize(size_t handle, int m, int n) except? -1
+cpdef int sgebrd_bufferSize(intptr_t handle, int m, int n) except? -1
+cpdef int dgebrd_bufferSize(intptr_t handle, int m, int n) except? -1
+cpdef int cgebrd_bufferSize(intptr_t handle, int m, int n) except? -1
+cpdef int zgebrd_bufferSize(intptr_t handle, int m, int n) except? -1
 
-cpdef sgebrd(size_t handle, int m, int n, size_t A, int lda,
+cpdef sgebrd(intptr_t handle, int m, int n, size_t A, int lda,
              size_t D, size_t E, size_t tauQ, size_t tauP,
              size_t Work, int lwork, size_t devInfo)
-cpdef dgebrd(size_t handle, int m, int n, size_t A, int lda,
+cpdef dgebrd(intptr_t handle, int m, int n, size_t A, int lda,
              size_t D, size_t E, size_t tauQ, size_t tauP,
              size_t Work, int lwork, size_t devInfo)
-cpdef cgebrd(size_t handle, int m, int n, size_t A, int lda,
+cpdef cgebrd(intptr_t handle, int m, int n, size_t A, int lda,
              size_t D, size_t E, size_t tauQ, size_t tauP,
              size_t Work, int lwork, size_t devInfo)
-cpdef zgebrd(size_t handle, int m, int n, size_t A, int lda,
+cpdef zgebrd(intptr_t handle, int m, int n, size_t A, int lda,
              size_t D, size_t E, size_t tauQ, size_t tauP,
              size_t Work, int lwork, size_t devInfo)
 
 # TODO(anaruse): orgbr/ungbr, sytrd/hetrd, orgtr/ungtr, ormtr/unmtr
 
 # Singular value decomposition, A = U * Sigma * V^H
-cpdef int sgesvd_bufferSize(size_t handle, int m, int n) except? -1
-cpdef int dgesvd_bufferSize(size_t handle, int m, int n) except? -1
-cpdef int cgesvd_bufferSize(size_t handle, int m, int n) except? -1
-cpdef int zgesvd_bufferSize(size_t handle, int m, int n) except? -1
+cpdef int sgesvd_bufferSize(intptr_t handle, int m, int n) except? -1
+cpdef int dgesvd_bufferSize(intptr_t handle, int m, int n) except? -1
+cpdef int cgesvd_bufferSize(intptr_t handle, int m, int n) except? -1
+cpdef int zgesvd_bufferSize(intptr_t handle, int m, int n) except? -1
 
-cpdef sgesvd(size_t handle, char jobu, char jobvt, int m, int n, size_t A,
+cpdef sgesvd(intptr_t handle, char jobu, char jobvt, int m, int n, size_t A,
              int lda, size_t S, size_t U, int ldu, size_t VT, int ldvt,
              size_t Work, int lwork, size_t rwork, size_t devInfo)
-cpdef dgesvd(size_t handle, char jobu, char jobvt, int m, int n, size_t A,
+cpdef dgesvd(intptr_t handle, char jobu, char jobvt, int m, int n, size_t A,
              int lda, size_t S, size_t U, int ldu, size_t VT, int ldvt,
              size_t Work, int lwork, size_t rwork, size_t devInfo)
-cpdef cgesvd(size_t handle, char jobu, char jobvt, int m, int n, size_t A,
+cpdef cgesvd(intptr_t handle, char jobu, char jobvt, int m, int n, size_t A,
              int lda, size_t S, size_t U, int ldu, size_t VT, int ldvt,
              size_t Work, int lwork, size_t rwork, size_t devInfo)
-cpdef zgesvd(size_t handle, char jobu, char jobvt, int m, int n, size_t A,
+cpdef zgesvd(intptr_t handle, char jobu, char jobvt, int m, int n, size_t A,
              int lda, size_t S, size_t U, int ldu, size_t VT, int ldvt,
              size_t Work, int lwork, size_t rwork, size_t devInfo)
 
 # Standard symmetric eigenvalue solver
-cpdef int ssyevd_bufferSize(size_t handle, int jobz, int uplo, int n,
+cpdef int ssyevd_bufferSize(intptr_t handle, int jobz, int uplo, int n,
                             size_t A, int lda, size_t W) except? -1
-cpdef int dsyevd_bufferSize(size_t handle, int jobz, int uplo, int n,
+cpdef int dsyevd_bufferSize(intptr_t handle, int jobz, int uplo, int n,
                             size_t A, int lda, size_t W) except? -1
-cpdef int cheevd_bufferSize(size_t handle, int jobz, int uplo, int n,
+cpdef int cheevd_bufferSize(intptr_t handle, int jobz, int uplo, int n,
                             size_t A, int lda, size_t W) except? -1
-cpdef int zheevd_bufferSize(size_t handle, int jobz, int uplo, int n,
+cpdef int zheevd_bufferSize(intptr_t handle, int jobz, int uplo, int n,
                             size_t A, int lda, size_t W) except? -1
 
-cpdef ssyevd(size_t handle, int jobz, int uplo, int n, size_t A, int lda,
+cpdef ssyevd(intptr_t handle, int jobz, int uplo, int n, size_t A, int lda,
              size_t W, size_t work, int lwork, size_t info)
-cpdef dsyevd(size_t handle, int jobz, int uplo, int n, size_t A, int lda,
+cpdef dsyevd(intptr_t handle, int jobz, int uplo, int n, size_t A, int lda,
              size_t W, size_t work, int lwork, size_t info)
-cpdef cheevd(size_t handle, int jobz, int uplo, int n, size_t A, int lda,
+cpdef cheevd(intptr_t handle, int jobz, int uplo, int n, size_t A, int lda,
              size_t W, size_t work, int lwork, size_t info)
-cpdef zheevd(size_t handle, int jobz, int uplo, int n, size_t A, int lda,
+cpdef zheevd(intptr_t handle, int jobz, int uplo, int n, size_t A, int lda,
              size_t W, size_t work, int lwork, size_t info)
 
 # TODO(anaruse); sygvd/hegvd, sygvd/hegvd
@@ -284,41 +285,41 @@ cpdef zheevd(size_t handle, int jobz, int uplo, int n, size_t A, int lda,
 # Sparse LAPACK Functions
 ###############################################################################
 
-cpdef scsrlsvchol(size_t handle, int m, int nnz, size_t descrA, size_t csrValA,
+cpdef scsrlsvchol(intptr_t handle, int m, int nnz, size_t descrA, size_t csrValA,
                   size_t csrRowPtrA, size_t csrColIndA, size_t b, float tol,
                   int reorder, size_t x, size_t singularity)
-cpdef dcsrlsvchol(size_t handle, int m, int nnz, size_t descrA, size_t csrValA,
+cpdef dcsrlsvchol(intptr_t handle, int m, int nnz, size_t descrA, size_t csrValA,
                   size_t csrRowPtrA, size_t csrColIndA, size_t b, double tol,
                   int reorder, size_t x, size_t singularity)
-cpdef ccsrlsvchol(size_t handle, int m, int nnz, size_t descrA, size_t csrVal,
+cpdef ccsrlsvchol(intptr_t handle, int m, int nnz, size_t descrA, size_t csrVal,
                   size_t csrRowPtr, size_t csrColInd, size_t b, float tol,
                   int reorder, size_t x, size_t singularity)
-cpdef zcsrlsvchol(size_t handle, int m, int nnz, size_t descrA, size_t csrVal,
+cpdef zcsrlsvchol(intptr_t handle, int m, int nnz, size_t descrA, size_t csrVal,
                   size_t csrRowPtr, size_t csrColInd, size_t b, double tol,
                   int reorder, size_t x, size_t singularity)
 
-cpdef scsrlsvqr(size_t handle, int m, int nnz, size_t descrA, size_t csrValA,
+cpdef scsrlsvqr(intptr_t handle, int m, int nnz, size_t descrA, size_t csrValA,
                 size_t csrRowPtrA, size_t csrColIndA, size_t b, float tol,
                 int reorder, size_t x, size_t singularity)
-cpdef dcsrlsvqr(size_t handle, int m, int nnz, size_t descrA, size_t csrValA,
+cpdef dcsrlsvqr(intptr_t handle, int m, int nnz, size_t descrA, size_t csrValA,
                 size_t csrRowPtrA, size_t csrColIndA, size_t b, double tol,
                 int reorder, size_t x, size_t singularity)
-cpdef ccsrlsvqr(size_t handle, int m, int nnz, size_t descrA, size_t csrVal,
+cpdef ccsrlsvqr(intptr_t handle, int m, int nnz, size_t descrA, size_t csrVal,
                 size_t csrRowPtr, size_t csrColInd, size_t b, float tol,
                 int reorder, size_t x, size_t singularity)
-cpdef zcsrlsvqr(size_t handle, int m, int nnz, size_t descrA, size_t csrVal,
+cpdef zcsrlsvqr(intptr_t handle, int m, int nnz, size_t descrA, size_t csrVal,
                 size_t csrRowPtr, size_t csrColInd, size_t b, double tol,
                 int reorder, size_t x, size_t singularity)
 
-cpdef scsreigvsi(size_t handle, int m, int nnz, size_t descrA, size_t csrValA,
+cpdef scsreigvsi(intptr_t handle, int m, int nnz, size_t descrA, size_t csrValA,
                  size_t csrRowPtrA, size_t csrColIndA, float mu0,
                  size_t x0, int maxite, float eps, size_t mu, size_t x)
-cpdef dcsreigvsi(size_t handle, int m, int nnz, size_t descrA, size_t csrValA,
+cpdef dcsreigvsi(intptr_t handle, int m, int nnz, size_t descrA, size_t csrValA,
                  size_t csrRowPtrA, size_t csrColIndA, double mu0,
                  size_t x0, int maxite, double eps, size_t mu, size_t x)
-cpdef ccsreigvsi(size_t handle, int m, int nnz, size_t descrA, size_t csrValA,
+cpdef ccsreigvsi(intptr_t handle, int m, int nnz, size_t descrA, size_t csrValA,
                  size_t csrRowPtrA, size_t csrColIndA, size_t mu0,
                  size_t x0, int maxite, float eps, size_t mu, size_t x)
-cpdef zcsreigvsi(size_t handle, int m, int nnz, size_t descrA, size_t csrValA,
+cpdef zcsreigvsi(intptr_t handle, int m, int nnz, size_t descrA, size_t csrValA,
                  size_t csrRowPtrA, size_t csrColIndA, size_t mu0,
                  size_t x0, int maxite, double eps, size_t mu, size_t x)

--- a/cupy/cuda/cusolver.pxd
+++ b/cupy/cuda/cusolver.pxd
@@ -202,10 +202,14 @@ cpdef zormqr(intptr_t handle, int side, int trans,
              int ldc, size_t work, int lwork, size_t devInfo)  # (obsoleted)
 
 # L*D*L**T,U*D*U**T factorization
-cpdef int ssytrf_bufferSize(intptr_t handle, int n, size_t A, int lda) except? -1
-cpdef int dsytrf_bufferSize(intptr_t handle, int n, size_t A, int lda) except? -1
-cpdef int csytrf_bufferSize(intptr_t handle, int n, size_t A, int lda) except? -1
-cpdef int zsytrf_bufferSize(intptr_t handle, int n, size_t A, int lda) except? -1
+cpdef int ssytrf_bufferSize(intptr_t handle, int n, size_t A,
+                            int lda) except? -1
+cpdef int dsytrf_bufferSize(intptr_t handle, int n, size_t A,
+                            int lda) except? -1
+cpdef int csytrf_bufferSize(intptr_t handle, int n, size_t A,
+                            int lda) except? -1
+cpdef int zsytrf_bufferSize(intptr_t handle, int n, size_t A,
+                            int lda) except? -1
 
 cpdef ssytrf(intptr_t handle, int uplo, int n, size_t A, int lda,
              size_t ipiv, size_t work, int lwork, size_t devInfo)
@@ -285,18 +289,20 @@ cpdef zheevd(intptr_t handle, int jobz, int uplo, int n, size_t A, int lda,
 # Sparse LAPACK Functions
 ###############################################################################
 
-cpdef scsrlsvchol(intptr_t handle, int m, int nnz, size_t descrA, size_t csrValA,
-                  size_t csrRowPtrA, size_t csrColIndA, size_t b, float tol,
-                  int reorder, size_t x, size_t singularity)
-cpdef dcsrlsvchol(intptr_t handle, int m, int nnz, size_t descrA, size_t csrValA,
-                  size_t csrRowPtrA, size_t csrColIndA, size_t b, double tol,
-                  int reorder, size_t x, size_t singularity)
-cpdef ccsrlsvchol(intptr_t handle, int m, int nnz, size_t descrA, size_t csrVal,
-                  size_t csrRowPtr, size_t csrColInd, size_t b, float tol,
-                  int reorder, size_t x, size_t singularity)
-cpdef zcsrlsvchol(intptr_t handle, int m, int nnz, size_t descrA, size_t csrVal,
-                  size_t csrRowPtr, size_t csrColInd, size_t b, double tol,
-                  int reorder, size_t x, size_t singularity)
+cpdef scsrlsvchol(intptr_t handle, int m, int nnz, size_t descrA,
+                  size_t csrValA, size_t csrRowPtrA, size_t csrColIndA,
+                  size_t b, float tol, int reorder, size_t x,
+                  size_t singularity)
+cpdef dcsrlsvchol(intptr_t handle, int m, int nnz, size_t descrA,
+                  size_t csrValA, size_t csrRowPtrA, size_t csrColIndA,
+                  size_t b, double tol, int reorder, size_t x,
+                  size_t singularity)
+cpdef ccsrlsvchol(intptr_t handle, int m, int nnz, size_t descrA,
+                  size_t csrVal, size_t csrRowPtr, size_t csrColInd, size_t b,
+                  float tol, int reorder, size_t x, size_t singularity)
+cpdef zcsrlsvchol(intptr_t handle, int m, int nnz, size_t descrA,
+                  size_t csrVal, size_t csrRowPtr, size_t csrColInd, size_t b,
+                  double tol, int reorder, size_t x, size_t singularity)
 
 cpdef scsrlsvqr(intptr_t handle, int m, int nnz, size_t descrA, size_t csrValA,
                 size_t csrRowPtrA, size_t csrColIndA, size_t b, float tol,
@@ -311,15 +317,19 @@ cpdef zcsrlsvqr(intptr_t handle, int m, int nnz, size_t descrA, size_t csrVal,
                 size_t csrRowPtr, size_t csrColInd, size_t b, double tol,
                 int reorder, size_t x, size_t singularity)
 
-cpdef scsreigvsi(intptr_t handle, int m, int nnz, size_t descrA, size_t csrValA,
-                 size_t csrRowPtrA, size_t csrColIndA, float mu0,
-                 size_t x0, int maxite, float eps, size_t mu, size_t x)
-cpdef dcsreigvsi(intptr_t handle, int m, int nnz, size_t descrA, size_t csrValA,
-                 size_t csrRowPtrA, size_t csrColIndA, double mu0,
-                 size_t x0, int maxite, double eps, size_t mu, size_t x)
-cpdef ccsreigvsi(intptr_t handle, int m, int nnz, size_t descrA, size_t csrValA,
-                 size_t csrRowPtrA, size_t csrColIndA, size_t mu0,
-                 size_t x0, int maxite, float eps, size_t mu, size_t x)
-cpdef zcsreigvsi(intptr_t handle, int m, int nnz, size_t descrA, size_t csrValA,
-                 size_t csrRowPtrA, size_t csrColIndA, size_t mu0,
-                 size_t x0, int maxite, double eps, size_t mu, size_t x)
+cpdef scsreigvsi(intptr_t handle, int m, int nnz, size_t descrA,
+                 size_t csrValA, size_t csrRowPtrA, size_t csrColIndA,
+                 float mu0, size_t x0, int maxite, float eps, size_t mu,
+                 size_t x)
+cpdef dcsreigvsi(intptr_t handle, int m, int nnz, size_t descrA,
+                 size_t csrValA, size_t csrRowPtrA, size_t csrColIndA,
+                 double mu0, size_t x0, int maxite, double eps, size_t mu,
+                 size_t x)
+cpdef ccsreigvsi(intptr_t handle, int m, int nnz, size_t descrA,
+                 size_t csrValA, size_t csrRowPtrA, size_t csrColIndA,
+                 size_t mu0, size_t x0, int maxite, float eps, size_t mu,
+                 size_t x)
+cpdef zcsreigvsi(intptr_t handle, int m, int nnz, size_t descrA,
+                 size_t csrValA, size_t csrRowPtrA, size_t csrColIndA,
+                 size_t mu0, size_t x0, int maxite, double eps, size_t mu,
+                 size_t x)

--- a/cupy/cuda/cusolver.pyx
+++ b/cupy/cuda/cusolver.pyx
@@ -462,29 +462,29 @@ cpdef tuple _getVersion():
 # Context
 ###############################################################################
 
-cpdef size_t create() except? 0:
+cpdef intptr_t create() except? 0:
     cdef Handle handle
     with nogil:
         status = cusolverDnCreate(&handle)
     check_status(status)
-    return <size_t>handle
+    return <intptr_t>handle
 
 
-cpdef size_t spCreate() except? 0:
+cpdef intptr_t spCreate() except? 0:
     cdef SpHandle handle
     with nogil:
         status = cusolverSpCreate(&handle)
     check_status(status)
-    return <size_t>handle
+    return <intptr_t>handle
 
 
-cpdef destroy(size_t handle):
+cpdef destroy(intptr_t handle):
     with nogil:
         status = cusolverDnDestroy(<Handle>handle)
     check_status(status)
 
 
-cpdef spDestroy(size_t handle):
+cpdef spDestroy(intptr_t handle):
     with nogil:
         status = cusolverSpDestroy(<SpHandle>handle)
     check_status(status)
@@ -494,13 +494,13 @@ cpdef spDestroy(size_t handle):
 # Stream
 ###############################################################################
 
-cpdef setStream(size_t handle, size_t stream):
+cpdef setStream(intptr_t handle, size_t stream):
     with nogil:
         status = cusolverDnSetStream(<Handle>handle, <driver.Stream>stream)
     check_status(status)
 
 
-cpdef size_t getStream(size_t handle) except? 0:
+cpdef size_t getStream(intptr_t handle) except? 0:
     cdef driver.Stream stream
     with nogil:
         status = cusolverDnGetStream(<Handle>handle, &stream)
@@ -508,13 +508,13 @@ cpdef size_t getStream(size_t handle) except? 0:
     return <size_t>stream
 
 
-cpdef spSetStream(size_t handle, size_t stream):
+cpdef spSetStream(intptr_t handle, size_t stream):
     with nogil:
         status = cusolverSpSetStream(<SpHandle>handle, <driver.Stream>stream)
     check_status(status)
 
 
-cpdef size_t spGetStream(size_t handle) except *:
+cpdef size_t spGetStream(intptr_t handle) except *:
     cdef driver.Stream stream
     with nogil:
         status = cusolverSpGetStream(<SpHandle>handle, &stream)
@@ -527,7 +527,7 @@ cpdef size_t spGetStream(size_t handle) except *:
 ###########################################################################
 
 # Cholesky factorization
-cpdef int spotrf_bufferSize(size_t handle, int uplo,
+cpdef int spotrf_bufferSize(intptr_t handle, int uplo,
                             int n, size_t A, int lda) except? -1:
     cdef int lwork
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -538,7 +538,7 @@ cpdef int spotrf_bufferSize(size_t handle, int uplo,
     check_status(status)
     return lwork
 
-cpdef int dpotrf_bufferSize(size_t handle, int uplo,
+cpdef int dpotrf_bufferSize(intptr_t handle, int uplo,
                             int n, size_t A, int lda) except? -1:
     cdef int lwork
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -549,7 +549,7 @@ cpdef int dpotrf_bufferSize(size_t handle, int uplo,
     check_status(status)
     return lwork
 
-cpdef int cpotrf_bufferSize(size_t handle, int uplo,
+cpdef int cpotrf_bufferSize(intptr_t handle, int uplo,
                             int n, size_t A, int lda) except? -1:
     cdef int lwork
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -560,7 +560,7 @@ cpdef int cpotrf_bufferSize(size_t handle, int uplo,
     check_status(status)
     return lwork
 
-cpdef int zpotrf_bufferSize(size_t handle, int uplo,
+cpdef int zpotrf_bufferSize(intptr_t handle, int uplo,
                             int n, size_t A, int lda) except? -1:
     cdef int lwork
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -571,7 +571,7 @@ cpdef int zpotrf_bufferSize(size_t handle, int uplo,
     check_status(status)
     return lwork
 
-cpdef spotrf(size_t handle, int uplo, int n, size_t A, int lda,
+cpdef spotrf(intptr_t handle, int uplo, int n, size_t A, int lda,
              size_t work, int lwork, size_t devInfo):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -580,7 +580,7 @@ cpdef spotrf(size_t handle, int uplo, int n, size_t A, int lda,
             lda, <float*>work, lwork, <int*>devInfo)
     check_status(status)
 
-cpdef dpotrf(size_t handle, int uplo, int n, size_t A, int lda,
+cpdef dpotrf(intptr_t handle, int uplo, int n, size_t A, int lda,
              size_t work, int lwork, size_t devInfo):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -589,7 +589,7 @@ cpdef dpotrf(size_t handle, int uplo, int n, size_t A, int lda,
             lda, <double*>work, lwork, <int*>devInfo)
     check_status(status)
 
-cpdef cpotrf(size_t handle, int uplo, int n, size_t A, int lda,
+cpdef cpotrf(intptr_t handle, int uplo, int n, size_t A, int lda,
              size_t work, int lwork, size_t devInfo):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -598,7 +598,7 @@ cpdef cpotrf(size_t handle, int uplo, int n, size_t A, int lda,
             lda, <cuComplex*>work, lwork, <int*>devInfo)
     check_status(status)
 
-cpdef zpotrf(size_t handle, int uplo, int n, size_t A, int lda,
+cpdef zpotrf(intptr_t handle, int uplo, int n, size_t A, int lda,
              size_t work, int lwork, size_t devInfo):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -607,7 +607,7 @@ cpdef zpotrf(size_t handle, int uplo, int n, size_t A, int lda,
             lda, <cuDoubleComplex*>work, lwork, <int*>devInfo)
     check_status(status)
 
-cpdef spotrs(size_t handle, int uplo, int n, int nrhs,
+cpdef spotrs(intptr_t handle, int uplo, int n, int nrhs,
              size_t A, int lda, size_t B, int ldb, size_t devInfo):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -617,7 +617,7 @@ cpdef spotrs(size_t handle, int uplo, int n, int nrhs,
             <int*>devInfo)
     check_status(status)
 
-cpdef dpotrs(size_t handle, int uplo, int n, int nrhs,
+cpdef dpotrs(intptr_t handle, int uplo, int n, int nrhs,
              size_t A, int lda, size_t B, int ldb, size_t devInfo):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -627,7 +627,7 @@ cpdef dpotrs(size_t handle, int uplo, int n, int nrhs,
             <int*>devInfo)
     check_status(status)
 
-cpdef cpotrs(size_t handle, int uplo, int n, int nrhs,
+cpdef cpotrs(intptr_t handle, int uplo, int n, int nrhs,
              size_t A, int lda, size_t B, int ldb, size_t devInfo):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -637,7 +637,7 @@ cpdef cpotrs(size_t handle, int uplo, int n, int nrhs,
             <int*>devInfo)
     check_status(status)
 
-cpdef zpotrs(size_t handle, int uplo, int n, int nrhs,
+cpdef zpotrs(intptr_t handle, int uplo, int n, int nrhs,
              size_t A, int lda, size_t B, int ldb, size_t devInfo):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -649,7 +649,7 @@ cpdef zpotrs(size_t handle, int uplo, int n, int nrhs,
 
 
 # LU factorization
-cpdef int sgetrf_bufferSize(size_t handle, int m, int n,
+cpdef int sgetrf_bufferSize(intptr_t handle, int m, int n,
                             size_t A, int lda) except? -1:
     cdef int lwork
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -659,7 +659,7 @@ cpdef int sgetrf_bufferSize(size_t handle, int m, int n,
     check_status(status)
     return lwork
 
-cpdef int dgetrf_bufferSize(size_t handle, int m, int n,
+cpdef int dgetrf_bufferSize(intptr_t handle, int m, int n,
                             size_t A, int lda) except? -1:
     cdef int lwork
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -669,7 +669,7 @@ cpdef int dgetrf_bufferSize(size_t handle, int m, int n,
     check_status(status)
     return lwork
 
-cpdef int cgetrf_bufferSize(size_t handle, int m, int n,
+cpdef int cgetrf_bufferSize(intptr_t handle, int m, int n,
                             size_t A, int lda) except? -1:
     cdef int lwork
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -679,7 +679,7 @@ cpdef int cgetrf_bufferSize(size_t handle, int m, int n,
     check_status(status)
     return lwork
 
-cpdef int zgetrf_bufferSize(size_t handle, int m, int n,
+cpdef int zgetrf_bufferSize(intptr_t handle, int m, int n,
                             size_t A, int lda) except? -1:
     cdef int lwork
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -689,7 +689,7 @@ cpdef int zgetrf_bufferSize(size_t handle, int m, int n,
     check_status(status)
     return lwork
 
-cpdef sgetrf(size_t handle, int m, int n, size_t A, int lda,
+cpdef sgetrf(intptr_t handle, int m, int n, size_t A, int lda,
              size_t work, size_t devIpiv, size_t devInfo):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -698,7 +698,7 @@ cpdef sgetrf(size_t handle, int m, int n, size_t A, int lda,
             <float*>work, <int*>devIpiv, <int*>devInfo)
     check_status(status)
 
-cpdef dgetrf(size_t handle, int m, int n, size_t A, int lda,
+cpdef dgetrf(intptr_t handle, int m, int n, size_t A, int lda,
              size_t work, size_t devIpiv, size_t devInfo):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -707,7 +707,7 @@ cpdef dgetrf(size_t handle, int m, int n, size_t A, int lda,
             <double*>work, <int*>devIpiv, <int*>devInfo)
     check_status(status)
 
-cpdef cgetrf(size_t handle, int m, int n, size_t A, int lda,
+cpdef cgetrf(intptr_t handle, int m, int n, size_t A, int lda,
              size_t work, size_t devIpiv, size_t devInfo):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -716,7 +716,7 @@ cpdef cgetrf(size_t handle, int m, int n, size_t A, int lda,
             <cuComplex*>work, <int*>devIpiv, <int*>devInfo)
     check_status(status)
 
-cpdef zgetrf(size_t handle, int m, int n, size_t A, int lda,
+cpdef zgetrf(intptr_t handle, int m, int n, size_t A, int lda,
              size_t work, size_t devIpiv, size_t devInfo):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -727,7 +727,7 @@ cpdef zgetrf(size_t handle, int m, int n, size_t A, int lda,
 
 
 # LU solve
-cpdef sgetrs(size_t handle, int trans, int n, int nrhs,
+cpdef sgetrs(intptr_t handle, int trans, int n, int nrhs,
              size_t A, int lda, size_t devIpiv,
              size_t B, int ldb, size_t devInfo):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -738,7 +738,7 @@ cpdef sgetrs(size_t handle, int trans, int n, int nrhs,
             <float*>B, ldb, <int*> devInfo)
     check_status(status)
 
-cpdef dgetrs(size_t handle, int trans, int n, int nrhs,
+cpdef dgetrs(intptr_t handle, int trans, int n, int nrhs,
              size_t A, int lda, size_t devIpiv,
              size_t B, int ldb, size_t devInfo):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -749,7 +749,7 @@ cpdef dgetrs(size_t handle, int trans, int n, int nrhs,
             <double*>B, ldb, <int*> devInfo)
     check_status(status)
 
-cpdef cgetrs(size_t handle, int trans, int n, int nrhs,
+cpdef cgetrs(intptr_t handle, int trans, int n, int nrhs,
              size_t A, int lda, size_t devIpiv,
              size_t B, int ldb, size_t devInfo):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -760,7 +760,7 @@ cpdef cgetrs(size_t handle, int trans, int n, int nrhs,
             <cuComplex*>B, ldb, <int*> devInfo)
     check_status(status)
 
-cpdef zgetrs(size_t handle, int trans, int n, int nrhs,
+cpdef zgetrs(intptr_t handle, int trans, int n, int nrhs,
              size_t A, int lda, size_t devIpiv,
              size_t B, int ldb, size_t devInfo):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -773,7 +773,7 @@ cpdef zgetrs(size_t handle, int trans, int n, int nrhs,
 
 
 # QR factorization
-cpdef int sgeqrf_bufferSize(size_t handle, int m, int n,
+cpdef int sgeqrf_bufferSize(intptr_t handle, int m, int n,
                             size_t A, int lda) except? -1:
     cdef int lwork
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -783,7 +783,7 @@ cpdef int sgeqrf_bufferSize(size_t handle, int m, int n,
     check_status(status)
     return lwork
 
-cpdef int dgeqrf_bufferSize(size_t handle, int m, int n,
+cpdef int dgeqrf_bufferSize(intptr_t handle, int m, int n,
                             size_t A, int lda) except? -1:
     cdef int lwork
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -793,7 +793,7 @@ cpdef int dgeqrf_bufferSize(size_t handle, int m, int n,
     check_status(status)
     return lwork
 
-cpdef int cgeqrf_bufferSize(size_t handle, int m, int n,
+cpdef int cgeqrf_bufferSize(intptr_t handle, int m, int n,
                             size_t A, int lda) except? -1:
     cdef int lwork
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -803,7 +803,7 @@ cpdef int cgeqrf_bufferSize(size_t handle, int m, int n,
     check_status(status)
     return lwork
 
-cpdef int zgeqrf_bufferSize(size_t handle, int m, int n,
+cpdef int zgeqrf_bufferSize(intptr_t handle, int m, int n,
                             size_t A, int lda) except? -1:
     cdef int lwork
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -813,7 +813,7 @@ cpdef int zgeqrf_bufferSize(size_t handle, int m, int n,
     check_status(status)
     return lwork
 
-cpdef sgeqrf(size_t handle, int m, int n, size_t A, int lda,
+cpdef sgeqrf(intptr_t handle, int m, int n, size_t A, int lda,
              size_t tau, size_t work, int lwork, size_t devInfo):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -823,7 +823,7 @@ cpdef sgeqrf(size_t handle, int m, int n, size_t A, int lda,
             <int*>devInfo)
     check_status(status)
 
-cpdef dgeqrf(size_t handle, int m, int n, size_t A, int lda,
+cpdef dgeqrf(intptr_t handle, int m, int n, size_t A, int lda,
              size_t tau, size_t work, int lwork, size_t devInfo):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -833,7 +833,7 @@ cpdef dgeqrf(size_t handle, int m, int n, size_t A, int lda,
             <int*>devInfo)
     check_status(status)
 
-cpdef cgeqrf(size_t handle, int m, int n, size_t A, int lda,
+cpdef cgeqrf(intptr_t handle, int m, int n, size_t A, int lda,
              size_t tau, size_t work, int lwork, size_t devInfo):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -843,7 +843,7 @@ cpdef cgeqrf(size_t handle, int m, int n, size_t A, int lda,
             <int*>devInfo)
     check_status(status)
 
-cpdef zgeqrf(size_t handle, int m, int n, size_t A, int lda,
+cpdef zgeqrf(intptr_t handle, int m, int n, size_t A, int lda,
              size_t tau, size_t work, int lwork, size_t devInfo):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -855,7 +855,7 @@ cpdef zgeqrf(size_t handle, int m, int n, size_t A, int lda,
 
 
 # Generate unitary matrix Q from QR factorization
-cpdef int sorgqr_bufferSize(size_t handle, int m, int n, int k,
+cpdef int sorgqr_bufferSize(intptr_t handle, int m, int n, int k,
                             size_t A, int lda, size_t tau) except? -1:
     cdef int lwork
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -866,7 +866,7 @@ cpdef int sorgqr_bufferSize(size_t handle, int m, int n, int k,
     check_status(status)
     return lwork
 
-cpdef int dorgqr_bufferSize(size_t handle, int m, int n, int k,
+cpdef int dorgqr_bufferSize(intptr_t handle, int m, int n, int k,
                             size_t A, int lda, size_t tau) except? -1:
     cdef int lwork
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -877,7 +877,7 @@ cpdef int dorgqr_bufferSize(size_t handle, int m, int n, int k,
     check_status(status)
     return lwork
 
-cpdef int cungqr_bufferSize(size_t handle, int m, int n, int k,
+cpdef int cungqr_bufferSize(intptr_t handle, int m, int n, int k,
                             size_t A, int lda, size_t tau) except? -1:
     cdef int lwork
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -888,7 +888,7 @@ cpdef int cungqr_bufferSize(size_t handle, int m, int n, int k,
     check_status(status)
     return lwork
 
-cpdef int zungqr_bufferSize(size_t handle, int m, int n, int k,
+cpdef int zungqr_bufferSize(intptr_t handle, int m, int n, int k,
                             size_t A, int lda, size_t tau) except? -1:
     cdef int lwork
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -899,7 +899,7 @@ cpdef int zungqr_bufferSize(size_t handle, int m, int n, int k,
     check_status(status)
     return lwork
 
-cpdef sorgqr(size_t handle, int m, int n, int k, size_t A, int lda,
+cpdef sorgqr(intptr_t handle, int m, int n, int k, size_t A, int lda,
              size_t tau, size_t work, int lwork, size_t devInfo):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -909,7 +909,7 @@ cpdef sorgqr(size_t handle, int m, int n, int k, size_t A, int lda,
             <int*>devInfo)
     check_status(status)
 
-cpdef dorgqr(size_t handle, int m, int n, int k, size_t A, int lda,
+cpdef dorgqr(intptr_t handle, int m, int n, int k, size_t A, int lda,
              size_t tau, size_t work, int lwork, size_t devInfo):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -919,7 +919,7 @@ cpdef dorgqr(size_t handle, int m, int n, int k, size_t A, int lda,
             <int*>devInfo)
     check_status(status)
 
-cpdef cungqr(size_t handle, int m, int n, int k, size_t A, int lda,
+cpdef cungqr(intptr_t handle, int m, int n, int k, size_t A, int lda,
              size_t tau, size_t work, int lwork, size_t devInfo):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -929,7 +929,7 @@ cpdef cungqr(size_t handle, int m, int n, int k, size_t A, int lda,
             <int*>devInfo)
     check_status(status)
 
-cpdef zungqr(size_t handle, int m, int n, int k, size_t A, int lda,
+cpdef zungqr(intptr_t handle, int m, int n, int k, size_t A, int lda,
              size_t tau, size_t work, int lwork, size_t devInfo):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -941,7 +941,7 @@ cpdef zungqr(size_t handle, int m, int n, int k, size_t A, int lda,
 
 
 # Compute Q**T*b in solve min||A*x = b||
-cpdef int sormqr_bufferSize(size_t handle, int side, int trans,
+cpdef int sormqr_bufferSize(intptr_t handle, int side, int trans,
                             int m, int n, int k, size_t A, int lda, size_t tau,
                             size_t C, int ldc) except? -1:
     cdef int lwork
@@ -954,7 +954,7 @@ cpdef int sormqr_bufferSize(size_t handle, int side, int trans,
     check_status(status)
     return lwork
 
-cpdef int dormqr_bufferSize(size_t handle, int side, int trans,
+cpdef int dormqr_bufferSize(intptr_t handle, int side, int trans,
                             int m, int n, int k, size_t A, int lda, size_t tau,
                             size_t C, int ldc) except? -1:
     cdef int lwork
@@ -967,7 +967,7 @@ cpdef int dormqr_bufferSize(size_t handle, int side, int trans,
     check_status(status)
     return lwork
 
-cpdef int cunmqr_bufferSize(size_t handle, int side, int trans,
+cpdef int cunmqr_bufferSize(intptr_t handle, int side, int trans,
                             int m, int n, int k, size_t A, int lda, size_t tau,
                             size_t C, int ldc) except? -1:
     cdef int lwork
@@ -980,7 +980,7 @@ cpdef int cunmqr_bufferSize(size_t handle, int side, int trans,
     check_status(status)
     return lwork
 
-cpdef int zunmqr_bufferSize(size_t handle, int side, int trans,
+cpdef int zunmqr_bufferSize(intptr_t handle, int side, int trans,
                             int m, int n, int k, size_t A, int lda, size_t tau,
                             size_t C, int ldc) except? -1:
     cdef int lwork
@@ -994,7 +994,7 @@ cpdef int zunmqr_bufferSize(size_t handle, int side, int trans,
     return lwork
 
 
-cpdef sormqr(size_t handle, int side, int trans,
+cpdef sormqr(intptr_t handle, int side, int trans,
              int m, int n, int k, size_t A, int lda, size_t tau,
              size_t C, int ldc, size_t work, int lwork, size_t devInfo):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -1006,7 +1006,7 @@ cpdef sormqr(size_t handle, int side, int trans,
             <float*>work, lwork, <int*>devInfo)
     check_status(status)
 
-cpdef dormqr(size_t handle, int side, int trans,
+cpdef dormqr(intptr_t handle, int side, int trans,
              int m, int n, int k, size_t A, int lda, size_t tau,
              size_t C, int ldc, size_t work, int lwork, size_t devInfo):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -1018,7 +1018,7 @@ cpdef dormqr(size_t handle, int side, int trans,
             <double*>work, lwork, <int*>devInfo)
     check_status(status)
 
-cpdef cunmqr(size_t handle, int side, int trans,
+cpdef cunmqr(intptr_t handle, int side, int trans,
              int m, int n, int k, size_t A, int lda, size_t tau,
              size_t C, int ldc, size_t work, int lwork, size_t devInfo):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -1030,7 +1030,7 @@ cpdef cunmqr(size_t handle, int side, int trans,
             <cuComplex*>work, lwork, <int*>devInfo)
     check_status(status)
 
-cpdef zunmqr(size_t handle, int side, int trans,
+cpdef zunmqr(intptr_t handle, int side, int trans,
              int m, int n, int k, size_t A, int lda, size_t tau,
              size_t C, int ldc, size_t work, int lwork, size_t devInfo):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -1043,14 +1043,14 @@ cpdef zunmqr(size_t handle, int side, int trans,
     check_status(status)
 
 # (obsoleted)
-cpdef cormqr(size_t handle, int side, int trans,
+cpdef cormqr(intptr_t handle, int side, int trans,
              int m, int n, int k, size_t A, int lda, size_t tau,
              size_t C, int ldc, size_t work, int lwork, size_t devInfo):
     return cunmqr(handle, side, trans, m, n, k, A, lda, tau,
                   C, ldc, work, lwork, devInfo)
 
 # (obsoleted)
-cpdef zormqr(size_t handle, int side, int trans,
+cpdef zormqr(intptr_t handle, int side, int trans,
              int m, int n, int k, size_t A, int lda, size_t tau,
              size_t C, int ldc, size_t work, int lwork, size_t devInfo):
     return zunmqr(handle, side, trans, m, n, k, A, lda, tau,
@@ -1058,7 +1058,7 @@ cpdef zormqr(size_t handle, int side, int trans,
 
 
 # L*D*L**T,U*D*U**T factorization
-cpdef int ssytrf_bufferSize(size_t handle, int n, size_t A,
+cpdef int ssytrf_bufferSize(intptr_t handle, int n, size_t A,
                             int lda) except? -1:
     cdef int lwork
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -1068,7 +1068,7 @@ cpdef int ssytrf_bufferSize(size_t handle, int n, size_t A,
     check_status(status)
     return lwork
 
-cpdef int dsytrf_bufferSize(size_t handle, int n, size_t A,
+cpdef int dsytrf_bufferSize(intptr_t handle, int n, size_t A,
                             int lda) except? -1:
     cdef int lwork
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -1078,7 +1078,7 @@ cpdef int dsytrf_bufferSize(size_t handle, int n, size_t A,
     check_status(status)
     return lwork
 
-cpdef int csytrf_bufferSize(size_t handle, int n, size_t A,
+cpdef int csytrf_bufferSize(intptr_t handle, int n, size_t A,
                             int lda) except? -1:
     cdef int lwork
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -1088,7 +1088,7 @@ cpdef int csytrf_bufferSize(size_t handle, int n, size_t A,
     check_status(status)
     return lwork
 
-cpdef int zsytrf_bufferSize(size_t handle, int n, size_t A,
+cpdef int zsytrf_bufferSize(intptr_t handle, int n, size_t A,
                             int lda) except? -1:
     cdef int lwork
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -1098,7 +1098,7 @@ cpdef int zsytrf_bufferSize(size_t handle, int n, size_t A,
     check_status(status)
     return lwork
 
-cpdef ssytrf(size_t handle, int uplo, int n, size_t A, int lda,
+cpdef ssytrf(intptr_t handle, int uplo, int n, size_t A, int lda,
              size_t ipiv, size_t work, int lwork, size_t devInfo):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -1107,7 +1107,7 @@ cpdef ssytrf(size_t handle, int uplo, int n, size_t A, int lda,
             <int*>ipiv, <float*>work, lwork, <int*>devInfo)
     check_status(status)
 
-cpdef dsytrf(size_t handle, int uplo, int n, size_t A, int lda,
+cpdef dsytrf(intptr_t handle, int uplo, int n, size_t A, int lda,
              size_t ipiv, size_t work, int lwork, size_t devInfo):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -1116,7 +1116,7 @@ cpdef dsytrf(size_t handle, int uplo, int n, size_t A, int lda,
             <int*>ipiv, <double*>work, lwork, <int*>devInfo)
     check_status(status)
 
-cpdef csytrf(size_t handle, int uplo, int n, size_t A, int lda,
+cpdef csytrf(intptr_t handle, int uplo, int n, size_t A, int lda,
              size_t ipiv, size_t work, int lwork, size_t devInfo):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -1125,7 +1125,7 @@ cpdef csytrf(size_t handle, int uplo, int n, size_t A, int lda,
             <int*>ipiv, <cuComplex*>work, lwork, <int*>devInfo)
     check_status(status)
 
-cpdef zsytrf(size_t handle, int uplo, int n, size_t A, int lda,
+cpdef zsytrf(intptr_t handle, int uplo, int n, size_t A, int lda,
              size_t ipiv, size_t work, int lwork, size_t devInfo):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -1140,7 +1140,7 @@ cpdef zsytrf(size_t handle, int uplo, int n, size_t A, int lda,
 ###############################################################################
 
 # Bidiagonal factorization
-cpdef int sgebrd_bufferSize(size_t handle, int m, int n) except? -1:
+cpdef int sgebrd_bufferSize(intptr_t handle, int m, int n) except? -1:
     cdef int lwork
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -1148,7 +1148,7 @@ cpdef int sgebrd_bufferSize(size_t handle, int m, int n) except? -1:
     check_status(status)
     return lwork
 
-cpdef int dgebrd_bufferSize(size_t handle, int m, int n) except? -1:
+cpdef int dgebrd_bufferSize(intptr_t handle, int m, int n) except? -1:
     cdef int lwork
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -1156,7 +1156,7 @@ cpdef int dgebrd_bufferSize(size_t handle, int m, int n) except? -1:
     check_status(status)
     return lwork
 
-cpdef int cgebrd_bufferSize(size_t handle, int m, int n) except? -1:
+cpdef int cgebrd_bufferSize(intptr_t handle, int m, int n) except? -1:
     cdef int lwork
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -1164,7 +1164,7 @@ cpdef int cgebrd_bufferSize(size_t handle, int m, int n) except? -1:
     check_status(status)
     return lwork
 
-cpdef int zgebrd_bufferSize(size_t handle, int m, int n) except? -1:
+cpdef int zgebrd_bufferSize(intptr_t handle, int m, int n) except? -1:
     cdef int lwork
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -1172,7 +1172,7 @@ cpdef int zgebrd_bufferSize(size_t handle, int m, int n) except? -1:
     check_status(status)
     return lwork
 
-cpdef sgebrd(size_t handle, int m, int n, size_t A, int lda,
+cpdef sgebrd(intptr_t handle, int m, int n, size_t A, int lda,
              size_t D, size_t E, size_t tauQ, size_t tauP,
              size_t Work, int lwork, size_t devInfo):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -1185,7 +1185,7 @@ cpdef sgebrd(size_t handle, int m, int n, size_t A, int lda,
             <float*>Work, lwork, <int*>devInfo)
     check_status(status)
 
-cpdef dgebrd(size_t handle, int m, int n, size_t A, int lda,
+cpdef dgebrd(intptr_t handle, int m, int n, size_t A, int lda,
              size_t D, size_t E, size_t tauQ, size_t tauP,
              size_t Work, int lwork, size_t devInfo):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -1198,7 +1198,7 @@ cpdef dgebrd(size_t handle, int m, int n, size_t A, int lda,
             <double*>Work, lwork, <int*>devInfo)
     check_status(status)
 
-cpdef cgebrd(size_t handle, int m, int n, size_t A, int lda,
+cpdef cgebrd(intptr_t handle, int m, int n, size_t A, int lda,
              size_t D, size_t E, size_t tauQ, size_t tauP,
              size_t Work, int lwork, size_t devInfo):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -1211,7 +1211,7 @@ cpdef cgebrd(size_t handle, int m, int n, size_t A, int lda,
             <cuComplex*>Work, lwork, <int*>devInfo)
     check_status(status)
 
-cpdef zgebrd(size_t handle, int m, int n, size_t A, int lda,
+cpdef zgebrd(intptr_t handle, int m, int n, size_t A, int lda,
              size_t D, size_t E, size_t tauQ, size_t tauP,
              size_t Work, int lwork, size_t devInfo):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -1226,7 +1226,7 @@ cpdef zgebrd(size_t handle, int m, int n, size_t A, int lda,
 
 
 # Singular value decomposition, A = U * Sigma * V^H
-cpdef int sgesvd_bufferSize(size_t handle, int m, int n) except? -1:
+cpdef int sgesvd_bufferSize(intptr_t handle, int m, int n) except? -1:
     cdef int lwork
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -1234,7 +1234,7 @@ cpdef int sgesvd_bufferSize(size_t handle, int m, int n) except? -1:
     check_status(status)
     return lwork
 
-cpdef int dgesvd_bufferSize(size_t handle, int m, int n) except? -1:
+cpdef int dgesvd_bufferSize(intptr_t handle, int m, int n) except? -1:
     cdef int lwork
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -1242,7 +1242,7 @@ cpdef int dgesvd_bufferSize(size_t handle, int m, int n) except? -1:
     check_status(status)
     return lwork
 
-cpdef int cgesvd_bufferSize(size_t handle, int m, int n) except? -1:
+cpdef int cgesvd_bufferSize(intptr_t handle, int m, int n) except? -1:
     cdef int lwork
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -1250,7 +1250,7 @@ cpdef int cgesvd_bufferSize(size_t handle, int m, int n) except? -1:
     check_status(status)
     return lwork
 
-cpdef int zgesvd_bufferSize(size_t handle, int m, int n) except? -1:
+cpdef int zgesvd_bufferSize(intptr_t handle, int m, int n) except? -1:
     cdef int lwork
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -1258,7 +1258,7 @@ cpdef int zgesvd_bufferSize(size_t handle, int m, int n) except? -1:
     check_status(status)
     return lwork
 
-cpdef sgesvd(size_t handle, char jobu, char jobvt, int m, int n, size_t A,
+cpdef sgesvd(intptr_t handle, char jobu, char jobvt, int m, int n, size_t A,
              int lda, size_t S, size_t U, int ldu, size_t VT, int ldvt,
              size_t Work, int lwork, size_t rwork, size_t devInfo):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -1269,7 +1269,7 @@ cpdef sgesvd(size_t handle, char jobu, char jobvt, int m, int n, size_t A,
             <float*>Work, lwork, <float*>rwork, <int*>devInfo)
     check_status(status)
 
-cpdef dgesvd(size_t handle, char jobu, char jobvt, int m, int n, size_t A,
+cpdef dgesvd(intptr_t handle, char jobu, char jobvt, int m, int n, size_t A,
              int lda, size_t S, size_t U, int ldu, size_t VT, int ldvt,
              size_t Work, int lwork, size_t rwork, size_t devInfo):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -1280,7 +1280,7 @@ cpdef dgesvd(size_t handle, char jobu, char jobvt, int m, int n, size_t A,
             <double*>Work, lwork, <double*>rwork, <int*>devInfo)
     check_status(status)
 
-cpdef cgesvd(size_t handle, char jobu, char jobvt, int m, int n, size_t A,
+cpdef cgesvd(intptr_t handle, char jobu, char jobvt, int m, int n, size_t A,
              int lda, size_t S, size_t U, int ldu, size_t VT, int ldvt,
              size_t Work, int lwork, size_t rwork, size_t devInfo):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -1291,7 +1291,7 @@ cpdef cgesvd(size_t handle, char jobu, char jobvt, int m, int n, size_t A,
             <cuComplex*>Work, lwork, <float*>rwork, <int*>devInfo)
     check_status(status)
 
-cpdef zgesvd(size_t handle, char jobu, char jobvt, int m, int n, size_t A,
+cpdef zgesvd(intptr_t handle, char jobu, char jobvt, int m, int n, size_t A,
              int lda, size_t S, size_t U, int ldu, size_t VT, int ldvt,
              size_t Work, int lwork, size_t rwork, size_t devInfo):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -1304,7 +1304,7 @@ cpdef zgesvd(size_t handle, char jobu, char jobvt, int m, int n, size_t A,
 
 
 # Standard symmetric eigenvalue solver
-cpdef int ssyevd_bufferSize(size_t handle, int jobz, int uplo, int n,
+cpdef int ssyevd_bufferSize(intptr_t handle, int jobz, int uplo, int n,
                             size_t A, int lda, size_t W) except? -1:
     cdef int lwork, status
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -1316,7 +1316,7 @@ cpdef int ssyevd_bufferSize(size_t handle, int jobz, int uplo, int n,
     check_status(status)
     return lwork
 
-cpdef int dsyevd_bufferSize(size_t handle, int jobz, int uplo, int n,
+cpdef int dsyevd_bufferSize(intptr_t handle, int jobz, int uplo, int n,
                             size_t A, int lda, size_t W) except? -1:
     cdef int lwork, status
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -1328,7 +1328,7 @@ cpdef int dsyevd_bufferSize(size_t handle, int jobz, int uplo, int n,
     check_status(status)
     return lwork
 
-cpdef int cheevd_bufferSize(size_t handle, int jobz, int uplo, int n,
+cpdef int cheevd_bufferSize(intptr_t handle, int jobz, int uplo, int n,
                             size_t A, int lda, size_t W) except? -1:
     cdef int lwork, status
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -1340,7 +1340,7 @@ cpdef int cheevd_bufferSize(size_t handle, int jobz, int uplo, int n,
     check_status(status)
     return lwork
 
-cpdef int zheevd_bufferSize(size_t handle, int jobz, int uplo, int n,
+cpdef int zheevd_bufferSize(intptr_t handle, int jobz, int uplo, int n,
                             size_t A, int lda, size_t W) except? -1:
     cdef int lwork, status
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -1352,7 +1352,7 @@ cpdef int zheevd_bufferSize(size_t handle, int jobz, int uplo, int n,
     check_status(status)
     return lwork
 
-cpdef ssyevd(size_t handle, int jobz, int uplo, int n, size_t A, int lda,
+cpdef ssyevd(intptr_t handle, int jobz, int uplo, int n, size_t A, int lda,
              size_t W, size_t work, int lwork, size_t info):
     cdef int status
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -1363,7 +1363,7 @@ cpdef ssyevd(size_t handle, int jobz, int uplo, int n, size_t A, int lda,
             <float*>work, lwork, <int*>info)
     check_status(status)
 
-cpdef dsyevd(size_t handle, int jobz, int uplo, int n, size_t A, int lda,
+cpdef dsyevd(intptr_t handle, int jobz, int uplo, int n, size_t A, int lda,
              size_t W, size_t work, int lwork, size_t info):
     cdef int status
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -1374,7 +1374,7 @@ cpdef dsyevd(size_t handle, int jobz, int uplo, int n, size_t A, int lda,
             <double*>work, lwork, <int*>info)
     check_status(status)
 
-cpdef cheevd(size_t handle, int jobz, int uplo, int n, size_t A, int lda,
+cpdef cheevd(intptr_t handle, int jobz, int uplo, int n, size_t A, int lda,
              size_t W, size_t work, int lwork, size_t info):
     cdef int status
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -1385,7 +1385,7 @@ cpdef cheevd(size_t handle, int jobz, int uplo, int n, size_t A, int lda,
             <cuComplex*>work, lwork, <int*>info)
     check_status(status)
 
-cpdef zheevd(size_t handle, int jobz, int uplo, int n, size_t A, int lda,
+cpdef zheevd(intptr_t handle, int jobz, int uplo, int n, size_t A, int lda,
              size_t W, size_t work, int lwork, size_t info):
     cdef int status
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -1400,7 +1400,7 @@ cpdef zheevd(size_t handle, int jobz, int uplo, int n, size_t A, int lda,
 ###############################################################################
 # Sparse LAPACK Functions
 ###############################################################################
-cpdef scsrlsvchol(size_t handle, int m, int nnz, size_t descrA, size_t csrValA,
+cpdef scsrlsvchol(intptr_t handle, int m, int nnz, size_t descrA, size_t csrValA,
                   size_t csrRowPtrA, size_t csrColIndA, size_t b, float tol,
                   int reorder, size_t x, size_t singularity):
     cdef int status
@@ -1413,7 +1413,7 @@ cpdef scsrlsvchol(size_t handle, int m, int nnz, size_t descrA, size_t csrValA,
             tol, reorder, <float*> x, <int*> singularity)
     check_status(status)
 
-cpdef dcsrlsvchol(size_t handle, int m, int nnz, size_t descrA, size_t csrValA,
+cpdef dcsrlsvchol(intptr_t handle, int m, int nnz, size_t descrA, size_t csrValA,
                   size_t csrRowPtrA, size_t csrColIndA, size_t b, double tol,
                   int reorder, size_t x, size_t singularity):
     cdef int status
@@ -1426,7 +1426,7 @@ cpdef dcsrlsvchol(size_t handle, int m, int nnz, size_t descrA, size_t csrValA,
             tol, reorder, <double*> x, <int*> singularity)
     check_status(status)
 
-cpdef ccsrlsvchol(size_t handle, int m, int nnz, size_t descrA, size_t csrVal,
+cpdef ccsrlsvchol(intptr_t handle, int m, int nnz, size_t descrA, size_t csrVal,
                   size_t csrRowPtr, size_t csrColInd, size_t b, float tol,
                   int reorder, size_t x, size_t singularity):
     cdef int status
@@ -1439,7 +1439,7 @@ cpdef ccsrlsvchol(size_t handle, int m, int nnz, size_t descrA, size_t csrVal,
             <cuComplex*>x, <int*>singularity)
     check_status(status)
 
-cpdef zcsrlsvchol(size_t handle, int m, int nnz, size_t descrA, size_t csrVal,
+cpdef zcsrlsvchol(intptr_t handle, int m, int nnz, size_t descrA, size_t csrVal,
                   size_t csrRowPtr, size_t csrColInd, size_t b, double tol,
                   int reorder, size_t x, size_t singularity):
     cdef int status
@@ -1452,7 +1452,7 @@ cpdef zcsrlsvchol(size_t handle, int m, int nnz, size_t descrA, size_t csrVal,
             <cuDoubleComplex*>x, <int*>singularity)
     check_status(status)
 
-cpdef scsrlsvqr(size_t handle, int m, int nnz, size_t descrA, size_t csrValA,
+cpdef scsrlsvqr(intptr_t handle, int m, int nnz, size_t descrA, size_t csrValA,
                 size_t csrRowPtrA, size_t csrColIndA, size_t b, float tol,
                 int reorder, size_t x, size_t singularity):
     cdef int status
@@ -1465,7 +1465,7 @@ cpdef scsrlsvqr(size_t handle, int m, int nnz, size_t descrA, size_t csrValA,
             tol, reorder, <float*> x, <int*> singularity)
     check_status(status)
 
-cpdef dcsrlsvqr(size_t handle, int m, int nnz, size_t descrA, size_t csrValA,
+cpdef dcsrlsvqr(intptr_t handle, int m, int nnz, size_t descrA, size_t csrValA,
                 size_t csrRowPtrA, size_t csrColIndA, size_t b, double tol,
                 int reorder, size_t x, size_t singularity):
     cdef int status
@@ -1478,7 +1478,7 @@ cpdef dcsrlsvqr(size_t handle, int m, int nnz, size_t descrA, size_t csrValA,
             tol, reorder, <double*> x, <int*> singularity)
     check_status(status)
 
-cpdef ccsrlsvqr(size_t handle, int m, int nnz, size_t descrA, size_t csrVal,
+cpdef ccsrlsvqr(intptr_t handle, int m, int nnz, size_t descrA, size_t csrVal,
                 size_t csrRowPtr, size_t csrColInd, size_t b, float tol,
                 int reorder, size_t x, size_t singularity):
     cdef int status
@@ -1491,7 +1491,7 @@ cpdef ccsrlsvqr(size_t handle, int m, int nnz, size_t descrA, size_t csrVal,
             <cuComplex*>x, <int*>singularity)
     check_status(status)
 
-cpdef zcsrlsvqr(size_t handle, int m, int nnz, size_t descrA, size_t csrVal,
+cpdef zcsrlsvqr(intptr_t handle, int m, int nnz, size_t descrA, size_t csrVal,
                 size_t csrRowPtr, size_t csrColInd, size_t b, double tol,
                 int reorder, size_t x, size_t singularity):
     cdef int status
@@ -1504,7 +1504,7 @@ cpdef zcsrlsvqr(size_t handle, int m, int nnz, size_t descrA, size_t csrVal,
             <cuDoubleComplex*>x, <int*>singularity)
     check_status(status)
 
-cpdef scsreigvsi(size_t handle, int m, int nnz, size_t descrA, size_t csrValA,
+cpdef scsreigvsi(intptr_t handle, int m, int nnz, size_t descrA, size_t csrValA,
                  size_t csrRowPtrA, size_t csrColIndA, float mu0, size_t x0,
                  int maxite, float eps, size_t mu, size_t x):
     cdef int status
@@ -1517,7 +1517,7 @@ cpdef scsreigvsi(size_t handle, int m, int nnz, size_t descrA, size_t csrValA,
             <float*>mu, <float*>x)
     check_status(status)
 
-cpdef dcsreigvsi(size_t handle, int m, int nnz, size_t descrA, size_t csrValA,
+cpdef dcsreigvsi(intptr_t handle, int m, int nnz, size_t descrA, size_t csrValA,
                  size_t csrRowPtrA, size_t csrColIndA, double mu0,
                  size_t x0, int maxite, double eps, size_t mu, size_t x):
     cdef int status
@@ -1530,7 +1530,7 @@ cpdef dcsreigvsi(size_t handle, int m, int nnz, size_t descrA, size_t csrValA,
             <double*>mu, <double*>x)
     check_status(status)
 
-cpdef ccsreigvsi(size_t handle, int m, int nnz, size_t descrA, size_t csrValA,
+cpdef ccsreigvsi(intptr_t handle, int m, int nnz, size_t descrA, size_t csrValA,
                  size_t csrRowPtrA, size_t csrColIndA, size_t mu0,
                  size_t x0, int maxite, float eps, size_t mu, size_t x):
     cdef int status
@@ -1543,7 +1543,7 @@ cpdef ccsreigvsi(size_t handle, int m, int nnz, size_t descrA, size_t csrValA,
             maxite, eps, <cuComplex*>mu, <cuComplex*>x)
     check_status(status)
 
-cpdef zcsreigvsi(size_t handle, int m, int nnz, size_t descrA, size_t csrValA,
+cpdef zcsreigvsi(intptr_t handle, int m, int nnz, size_t descrA, size_t csrValA,
                  size_t csrRowPtrA, size_t csrColIndA, size_t mu0,
                  size_t x0, int maxite, double eps, size_t mu, size_t x):
     cdef int status

--- a/cupy/cuda/cusolver.pyx
+++ b/cupy/cuda/cusolver.pyx
@@ -1400,9 +1400,10 @@ cpdef zheevd(intptr_t handle, int jobz, int uplo, int n, size_t A, int lda,
 ###############################################################################
 # Sparse LAPACK Functions
 ###############################################################################
-cpdef scsrlsvchol(intptr_t handle, int m, int nnz, size_t descrA, size_t csrValA,
-                  size_t csrRowPtrA, size_t csrColIndA, size_t b, float tol,
-                  int reorder, size_t x, size_t singularity):
+cpdef scsrlsvchol(intptr_t handle, int m, int nnz, size_t descrA,
+                  size_t csrValA, size_t csrRowPtrA, size_t csrColIndA,
+                  size_t b, float tol, int reorder, size_t x,
+                  size_t singularity):
     cdef int status
     spSetStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -1413,9 +1414,10 @@ cpdef scsrlsvchol(intptr_t handle, int m, int nnz, size_t descrA, size_t csrValA
             tol, reorder, <float*> x, <int*> singularity)
     check_status(status)
 
-cpdef dcsrlsvchol(intptr_t handle, int m, int nnz, size_t descrA, size_t csrValA,
-                  size_t csrRowPtrA, size_t csrColIndA, size_t b, double tol,
-                  int reorder, size_t x, size_t singularity):
+cpdef dcsrlsvchol(intptr_t handle, int m, int nnz, size_t descrA,
+                  size_t csrValA, size_t csrRowPtrA, size_t csrColIndA,
+                  size_t b, double tol, int reorder, size_t x,
+                  size_t singularity):
     cdef int status
     spSetStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -1426,9 +1428,9 @@ cpdef dcsrlsvchol(intptr_t handle, int m, int nnz, size_t descrA, size_t csrValA
             tol, reorder, <double*> x, <int*> singularity)
     check_status(status)
 
-cpdef ccsrlsvchol(intptr_t handle, int m, int nnz, size_t descrA, size_t csrVal,
-                  size_t csrRowPtr, size_t csrColInd, size_t b, float tol,
-                  int reorder, size_t x, size_t singularity):
+cpdef ccsrlsvchol(intptr_t handle, int m, int nnz, size_t descrA,
+                  size_t csrVal, size_t csrRowPtr, size_t csrColInd, size_t b,
+                  float tol, int reorder, size_t x, size_t singularity):
     cdef int status
     spSetStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -1439,9 +1441,9 @@ cpdef ccsrlsvchol(intptr_t handle, int m, int nnz, size_t descrA, size_t csrVal,
             <cuComplex*>x, <int*>singularity)
     check_status(status)
 
-cpdef zcsrlsvchol(intptr_t handle, int m, int nnz, size_t descrA, size_t csrVal,
-                  size_t csrRowPtr, size_t csrColInd, size_t b, double tol,
-                  int reorder, size_t x, size_t singularity):
+cpdef zcsrlsvchol(intptr_t handle, int m, int nnz, size_t descrA,
+                  size_t csrVal, size_t csrRowPtr, size_t csrColInd, size_t b,
+                  double tol, int reorder, size_t x, size_t singularity):
     cdef int status
     spSetStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -1504,9 +1506,10 @@ cpdef zcsrlsvqr(intptr_t handle, int m, int nnz, size_t descrA, size_t csrVal,
             <cuDoubleComplex*>x, <int*>singularity)
     check_status(status)
 
-cpdef scsreigvsi(intptr_t handle, int m, int nnz, size_t descrA, size_t csrValA,
-                 size_t csrRowPtrA, size_t csrColIndA, float mu0, size_t x0,
-                 int maxite, float eps, size_t mu, size_t x):
+cpdef scsreigvsi(intptr_t handle, int m, int nnz, size_t descrA,
+                 size_t csrValA, size_t csrRowPtrA, size_t csrColIndA,
+                 float mu0, size_t x0, int maxite, float eps, size_t mu,
+                 size_t x):
     cdef int status
     spSetStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -1517,9 +1520,10 @@ cpdef scsreigvsi(intptr_t handle, int m, int nnz, size_t descrA, size_t csrValA,
             <float*>mu, <float*>x)
     check_status(status)
 
-cpdef dcsreigvsi(intptr_t handle, int m, int nnz, size_t descrA, size_t csrValA,
-                 size_t csrRowPtrA, size_t csrColIndA, double mu0,
-                 size_t x0, int maxite, double eps, size_t mu, size_t x):
+cpdef dcsreigvsi(intptr_t handle, int m, int nnz, size_t descrA,
+                 size_t csrValA, size_t csrRowPtrA, size_t csrColIndA,
+                 double mu0, size_t x0, int maxite, double eps, size_t mu,
+                 size_t x):
     cdef int status
     spSetStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -1530,9 +1534,10 @@ cpdef dcsreigvsi(intptr_t handle, int m, int nnz, size_t descrA, size_t csrValA,
             <double*>mu, <double*>x)
     check_status(status)
 
-cpdef ccsreigvsi(intptr_t handle, int m, int nnz, size_t descrA, size_t csrValA,
-                 size_t csrRowPtrA, size_t csrColIndA, size_t mu0,
-                 size_t x0, int maxite, float eps, size_t mu, size_t x):
+cpdef ccsreigvsi(intptr_t handle, int m, int nnz, size_t descrA,
+                 size_t csrValA, size_t csrRowPtrA, size_t csrColIndA,
+                 size_t mu0, size_t x0, int maxite, float eps, size_t mu,
+                 size_t x):
     cdef int status
     spSetStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -1543,9 +1548,10 @@ cpdef ccsreigvsi(intptr_t handle, int m, int nnz, size_t descrA, size_t csrValA,
             maxite, eps, <cuComplex*>mu, <cuComplex*>x)
     check_status(status)
 
-cpdef zcsreigvsi(intptr_t handle, int m, int nnz, size_t descrA, size_t csrValA,
-                 size_t csrRowPtrA, size_t csrColIndA, size_t mu0,
-                 size_t x0, int maxite, double eps, size_t mu, size_t x):
+cpdef zcsreigvsi(intptr_t handle, int m, int nnz, size_t descrA,
+                 size_t csrValA, size_t csrRowPtrA, size_t csrColIndA,
+                 size_t mu0, size_t x0, int maxite, double eps, size_t mu,
+                 size_t x):
     cdef int status
     spSetStream(handle, stream_module.get_current_stream_ptr())
     with nogil:


### PR DESCRIPTION
A part of #2716

Other types should be fixed, too (like `stream` and `devInfo`), but this PR only fixes handles.