### PR TITLE
Remove `cupy.cupyx`

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -38,7 +38,8 @@ original error: {}'''.format(exc_info[1]))  # NOQA
 
 
 from cupy import cuda
-import cupyx
+# Do not make `cupy.cupyx` available because it is confusing.
+import cupyx as _cupyx
 
 
 def is_available():
@@ -802,7 +803,7 @@ def get_default_pinned_memory_pool():
 
 def show_config():
     """Prints the current runtime configuration to standard output."""
-    sys.stdout.write(str(cupyx.get_runtime_info()))
+    sys.stdout.write(str(_cupyx.get_runtime_info()))
     sys.stdout.flush()
 
 


### PR DESCRIPTION
`cupy.cupyx` may be too confusing to users who just did `pip install cupy`.

Ref: #2654.

