### PR TITLE
keepdims should always preserve all dimensions in CUB-based reductions

### DIFF
--- a/cupy/core/_reduction.pyx
+++ b/cupy/core/_reduction.pyx
@@ -109,7 +109,7 @@ extern "C" __global__ void ${name}(${params}) {
 cpdef tuple _get_axis(object axis, Py_ssize_t ndim):
     cdef Py_ssize_t dim
     if axis is None:
-        axis = tuple(range(ndim))
+        return (tuple(range(ndim)), ())
     elif sequence.PySequence_Check(axis):
         axis = tuple(axis)
     else:

--- a/cupy/core/_routines_math.pyx
+++ b/cupy/core/_routines_math.pyx
@@ -73,10 +73,10 @@ cdef ndarray _ndarray_prod(ndarray self, axis, dtype, out, keepdims):
 
 
 cdef ndarray _ndarray_sum(ndarray self, axis, dtype, out, keepdims):
+    cdef tuple reduce_axis, out_axis
     if cupy.cuda.cub_enabled:
         # if import at the top level, a segfault would happen when import cupy!
         from cupy.core._kernel import _get_axis
-        cdef tuple reduce_axis, out_axis
         reduce_axis, out_axis = _get_axis(axis, self.ndim)
         if cub.can_use_device_reduce(cub.CUPY_CUB_SUM, self.dtype, out_axis,
                                      dtype):

--- a/cupy/core/_routines_math.pyx
+++ b/cupy/core/_routines_math.pyx
@@ -75,26 +75,11 @@ cdef ndarray _ndarray_prod(ndarray self, axis, dtype, out, keepdims):
 cdef ndarray _ndarray_sum(ndarray self, axis, dtype, out, keepdims):
     cdef tuple reduce_axis, out_axis
     if cupy.cuda.cub_enabled:
-        # if import at the top level, a segfault would happen when import cupy!
-        from cupy.core._kernel import _get_axis
-        reduce_axis, out_axis = _get_axis(axis, self.ndim)
-        if cub.can_use_device_reduce(cub.CUPY_CUB_SUM, self.dtype, out_axis,
-                                     dtype):
-            return cub.device_reduce(self, cub.CUPY_CUB_SUM, out_axis,
-                                     out=out, keepdims=keepdims)
-
-        if self.flags.c_contiguous:
-            order = 'C'
-        elif self.flags.f_contiguous:
-            order = 'F'
-        else:
-            order = None
-        if cub.can_use_device_segmented_reduce(cub.CUPY_CUB_SUM, self.dtype,
-                                               self.ndim, reduce_axis, dtype,
-                                               order):
-            return cub.device_segmented_reduce(self, cub.CUPY_CUB_SUM,
-                                               reduce_axis, out_axis,
-                                               out=out, keepdims=keepdims)
+        # result will be None if the reduction is not compatible with CUB
+        result = cub.cub_reduction(self, cub.CUPY_CUB_SUM, axis, dtype, out,
+                                   keepdims)
+        if result is not None:
+            return result
     if dtype is None:
         return _sum_auto_dtype(self, axis, dtype, out, keepdims)
     else:

--- a/cupy/core/_routines_math.pyx
+++ b/cupy/core/_routines_math.pyx
@@ -73,7 +73,6 @@ cdef ndarray _ndarray_prod(ndarray self, axis, dtype, out, keepdims):
 
 
 cdef ndarray _ndarray_sum(ndarray self, axis, dtype, out, keepdims):
-    cdef tuple reduce_axis, out_axis
     if cupy.cuda.cub_enabled:
         # result will be None if the reduction is not compatible with CUB
         result = cub.cub_reduction(self, cub.CUPY_CUB_SUM, axis, dtype, out,

--- a/cupy/core/_routines_statistics.pyx
+++ b/cupy/core/_routines_statistics.pyx
@@ -15,10 +15,10 @@ if cupy.cuda.cub_enabled:
 
 
 cdef ndarray _ndarray_max(ndarray self, axis, out, dtype, keepdims):
+    cdef tuple reduce_axis, out_axis
     if cupy.cuda.cub_enabled:
         # if import at the top level, a segfault would happen when import cupy!
         from cupy.core._kernel import _get_axis
-        cdef tuple reduce_axis, out_axis
         reduce_axis, out_axis = _get_axis(axis, self.ndim)
         if cub.can_use_device_reduce(cub.CUPY_CUB_MAX, self.dtype, out_axis,
                                      dtype):
@@ -41,10 +41,10 @@ cdef ndarray _ndarray_max(ndarray self, axis, out, dtype, keepdims):
 
 
 cdef ndarray _ndarray_min(ndarray self, axis, out, dtype, keepdims):
+    cdef tuple reduce_axis, out_axis
     if cupy.cuda.cub_enabled:
         # if import at the top level, a segfault would happen when import cupy!
         from cupy.core._kernel import _get_axis
-        cdef tuple reduce_axis, out_axis
         reduce_axis, out_axis = _get_axis(axis, self.ndim)
         if cub.can_use_device_reduce(cub.CUPY_CUB_MIN, self.dtype, out_axis,
                                      dtype):
@@ -68,10 +68,10 @@ cdef ndarray _ndarray_min(ndarray self, axis, out, dtype, keepdims):
 
 # TODO(leofang): this signature is incompatible with NumPy!
 cdef ndarray _ndarray_argmax(ndarray self, axis, out, dtype, keepdims):
+    cdef tuple reduce_axis, out_axis
     if cupy.cuda.cub_enabled:
         # if import at the top level, a segfault would happen when import cupy!
         from cupy.core._kernel import _get_axis
-        cdef tuple reduce_axis, out_axis
 
         # Note that the NumPy signature of argmax only has axis and out, so we
         # need to disable the rest. Moreover, to be compatible with NumPy, axis
@@ -90,10 +90,10 @@ cdef ndarray _ndarray_argmax(ndarray self, axis, out, dtype, keepdims):
 
 # TODO(leofang): this signature is incompatible with NumPy!
 cdef ndarray _ndarray_argmin(ndarray self, axis, out, dtype, keepdims):
+    cdef tuple reduce_axis, out_axis
     if cupy.cuda.cub_enabled:
         # if import at the top level, a segfault would happen when import cupy!
         from cupy.core._kernel import _get_axis
-        cdef tuple reduce_axis, out_axis
 
         # Note that the NumPy signature of argmax only has axis and out, so we
         # need to disable the rest. Moreover, to be compatible with NumPy, axis

--- a/cupy/core/_routines_statistics.pyx
+++ b/cupy/core/_routines_statistics.pyx
@@ -13,7 +13,6 @@ if cupy.cuda.cub_enabled:
 
 
 cdef ndarray _ndarray_max(ndarray self, axis, out, dtype, keepdims):
-    cdef tuple reduce_axis, out_axis
     if cupy.cuda.cub_enabled:
         # result will be None if the reduction is not compatible with CUB
         result = cub.cub_reduction(self, cub.CUPY_CUB_MAX, axis, dtype, out,
@@ -24,7 +23,6 @@ cdef ndarray _ndarray_max(ndarray self, axis, out, dtype, keepdims):
 
 
 cdef ndarray _ndarray_min(ndarray self, axis, out, dtype, keepdims):
-    cdef tuple reduce_axis, out_axis
     if cupy.cuda.cub_enabled:
         # result will be None if the reduction is not compatible with CUB
         result = cub.cub_reduction(self, cub.CUPY_CUB_MIN, axis, out, dtype,
@@ -36,7 +34,6 @@ cdef ndarray _ndarray_min(ndarray self, axis, out, dtype, keepdims):
 
 # TODO(leofang): this signature is incompatible with NumPy!
 cdef ndarray _ndarray_argmax(ndarray self, axis, out, dtype, keepdims):
-    cdef tuple reduce_axis, out_axis
     if cupy.cuda.cub_enabled:
         # result will be None if the reduction is not compatible with CUB
         result = cub.cub_reduction(self, cub.CUPY_CUB_ARGMAX, axis, dtype, out,
@@ -48,7 +45,6 @@ cdef ndarray _ndarray_argmax(ndarray self, axis, out, dtype, keepdims):
 
 # TODO(leofang): this signature is incompatible with NumPy!
 cdef ndarray _ndarray_argmin(ndarray self, axis, out, dtype, keepdims):
-    cdef tuple reduce_axis, out_axis
     if cupy.cuda.cub_enabled:
         # result will be None if the reduction is not compatible with CUB
         result = cub.cub_reduction(self, cub.CUPY_CUB_ARGMIN, axis, dtype, out,

--- a/cupy/core/_routines_statistics.pyx
+++ b/cupy/core/_routines_statistics.pyx
@@ -1,5 +1,3 @@
-from cpython cimport sequence
-
 import numpy
 from numpy import nan
 
@@ -17,52 +15,22 @@ if cupy.cuda.cub_enabled:
 cdef ndarray _ndarray_max(ndarray self, axis, out, dtype, keepdims):
     cdef tuple reduce_axis, out_axis
     if cupy.cuda.cub_enabled:
-        # if import at the top level, a segfault would happen when import cupy!
-        from cupy.core._kernel import _get_axis
-        reduce_axis, out_axis = _get_axis(axis, self.ndim)
-        if cub.can_use_device_reduce(cub.CUPY_CUB_MAX, self.dtype, out_axis,
-                                     dtype):
-            return cub.device_reduce(self, cub.CUPY_CUB_MAX, out_axis,
-                                     out=out, keepdims=keepdims)
-
-        if self.flags.c_contiguous:
-            order = 'C'
-        elif self.flags.f_contiguous:
-            order = 'F'
-        else:
-            order = None
-        if cub.can_use_device_segmented_reduce(cub.CUPY_CUB_MAX, self.dtype,
-                                               self.ndim, reduce_axis, dtype,
-                                               order):
-            return cub.device_segmented_reduce(self, cub.CUPY_CUB_MAX,
-                                               reduce_axis, out_axis,
-                                               out=out, keepdims=keepdims)
+        # result will be None if the reduction is not compatible with CUB
+        result = cub.cub_reduction(self, cub.CUPY_CUB_MAX, axis, dtype, out,
+                                   keepdims)
+        if result is not None:
+            return result
     return _amax(self, axis=axis, out=out, dtype=dtype, keepdims=keepdims)
 
 
 cdef ndarray _ndarray_min(ndarray self, axis, out, dtype, keepdims):
     cdef tuple reduce_axis, out_axis
     if cupy.cuda.cub_enabled:
-        # if import at the top level, a segfault would happen when import cupy!
-        from cupy.core._kernel import _get_axis
-        reduce_axis, out_axis = _get_axis(axis, self.ndim)
-        if cub.can_use_device_reduce(cub.CUPY_CUB_MIN, self.dtype, out_axis,
-                                     dtype):
-            return cub.device_reduce(self, cub.CUPY_CUB_MIN, out_axis,
-                                     out=out, keepdims=keepdims)
-
-        if self.flags.c_contiguous:
-            order = 'C'
-        elif self.flags.f_contiguous:
-            order = 'F'
-        else:
-            order = None
-        if cub.can_use_device_segmented_reduce(cub.CUPY_CUB_MIN, self.dtype,
-                                               self.ndim, reduce_axis, dtype,
-                                               order):
-            return cub.device_segmented_reduce(self, cub.CUPY_CUB_MIN,
-                                               reduce_axis, out_axis,
-                                               out=out, keepdims=keepdims)
+        # result will be None if the reduction is not compatible with CUB
+        result = cub.cub_reduction(self, cub.CUPY_CUB_MIN, axis, out, dtype,
+                                   keepdims)
+        if result is not None:
+            return result
     return _amin(self, axis=axis, out=out, dtype=dtype, keepdims=keepdims)
 
 
@@ -70,21 +38,11 @@ cdef ndarray _ndarray_min(ndarray self, axis, out, dtype, keepdims):
 cdef ndarray _ndarray_argmax(ndarray self, axis, out, dtype, keepdims):
     cdef tuple reduce_axis, out_axis
     if cupy.cuda.cub_enabled:
-        # if import at the top level, a segfault would happen when import cupy!
-        from cupy.core._kernel import _get_axis
-
-        # Note that the NumPy signature of argmax only has axis and out, so we
-        # need to disable the rest. Moreover, to be compatible with NumPy, axis
-        # can only be None or integers
-        if sequence.PySequence_Check(axis):
-            raise TypeError(
-                "'tuple' object cannot be interpreted as an integer")
-        reduce_axis, out_axis = _get_axis(axis, self.ndim)
-        if cub.can_use_device_reduce(
-                cub.CUPY_CUB_ARGMAX, self.dtype, out_axis, None):
-            return cub.device_reduce(self, cub.CUPY_CUB_ARGMAX, out_axis,
-                                     out=out, keepdims=False)
-        # TODO(leofang): support device_segmented_reduce for axis=-1?
+        # result will be None if the reduction is not compatible with CUB
+        result = cub.cub_reduction(self, cub.CUPY_CUB_ARGMAX, axis, dtype, out,
+                                   keepdims)
+        if result is not None:
+            return result
     return _argmax(self, axis=axis, out=out, dtype=dtype, keepdims=keepdims)
 
 
@@ -92,21 +50,11 @@ cdef ndarray _ndarray_argmax(ndarray self, axis, out, dtype, keepdims):
 cdef ndarray _ndarray_argmin(ndarray self, axis, out, dtype, keepdims):
     cdef tuple reduce_axis, out_axis
     if cupy.cuda.cub_enabled:
-        # if import at the top level, a segfault would happen when import cupy!
-        from cupy.core._kernel import _get_axis
-
-        # Note that the NumPy signature of argmax only has axis and out, so we
-        # need to disable the rest. Moreover, to be compatible with NumPy, axis
-        # can only be None or integers
-        if sequence.PySequence_Check(axis):
-            raise TypeError(
-                "'tuple' object cannot be interpreted as an integer")
-        reduce_axis, out_axis = _get_axis(axis, self.ndim)
-        if cub.can_use_device_reduce(
-                cub.CUPY_CUB_ARGMIN, self.dtype, out_axis, None):
-            return cub.device_reduce(self, cub.CUPY_CUB_ARGMIN, out_axis,
-                                     out=out, keepdims=False)
-        # TODO(leofang): support device_segmented_reduce for axis=-1?
+        # result will be None if the reduction is not compatible with CUB
+        result = cub.cub_reduction(self, cub.CUPY_CUB_ARGMIN, axis, dtype, out,
+                                   keepdims)
+        if result is not None:
+            return result
     return _argmin(self, axis=axis, out=out, dtype=dtype, keepdims=keepdims)
 
 

--- a/cupy/core/internal.pxd
+++ b/cupy/core/internal.pxd
@@ -49,3 +49,5 @@ cpdef float from_float16(uint16_t v)
 cdef int _normalize_order(order, cpp_bool allow_k=*) except? 0
 
 cdef _broadcast_core(list arrays, vector.vector[Py_ssize_t]& shape)
+
+cpdef bint _contig_axes(tuple axes)

--- a/cupy/core/internal.pyx
+++ b/cupy/core/internal.pyx
@@ -357,3 +357,16 @@ cdef _broadcast_core(list arrays, vector.vector[Py_ssize_t]& shape):
 
         # TODO(niboshi): Confirm update_x_contiguity flags
         arrays[i] = a._view(shape, strides, True, True)
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+cpdef bint _contig_axes(tuple axes):
+    # Indicate if the specified axes are in ascending order without gaps.
+    cdef Py_ssize_t n
+    cdef bint contig = True
+    for n in range(1, len(axes)):
+        contig = (axes[n] - axes[n - 1]) == 1
+        if not contig:
+            break
+    return contig

--- a/cupy/cuda/cub.pyx
+++ b/cupy/cuda/cub.pyx
@@ -284,7 +284,8 @@ cdef bint _cub_device_segmented_reduce_axis_compatible(
     # This function checks if the reduced axes are contiguous.
 
     # the axes to be reduced must be C- or F- contiguous
-    if not numpy.all(numpy.diff(cub_axis) == 1):
+    if not all((ax - ax_prev) == 1
+               for ax, ax_prev in zip(cub_axis[1:], cub_axis[:-1])):
         return False
     if order not in ('c', 'C', 'f', 'F'):
         return False

--- a/cupy/cuda/cub.pyx
+++ b/cupy/cuda/cub.pyx
@@ -61,7 +61,8 @@ cdef extern from 'cupy_cub.h' nogil:
 # Python interface
 ###############################################################################
 
-cpdef _preprocess_array(ndarray arr, axis, bint keepdims, str order):
+cpdef _preprocess_array(ndarray arr, tuple reduce_axis, tuple out_axis,
+                        bint keepdims, str order):
     '''
     This function more or less follows the logic of _get_permuted_args() in
     reduction.pxi. The input array arr is C- or F- contiguous along axis.
@@ -69,10 +70,9 @@ cpdef _preprocess_array(ndarray arr, axis, bint keepdims, str order):
     # if import at the top level, a segfault would happen when import cupy!
     from cupy.core._kernel import _get_axis
 
-    cdef tuple reduce_axis, out_axis, axis_permutes, out_shape
+    cdef tuple axis_permutes, out_shape
     cdef Py_ssize_t contiguous_size = 1
 
-    reduce_axis, out_axis = _get_axis(axis, arr._shape.size())
     # one more sanity check?
     if order == 'C':
         axis_permutes = out_axis + reduce_axis
@@ -91,7 +91,8 @@ cpdef _preprocess_array(ndarray arr, axis, bint keepdims, str order):
     return out_shape, contiguous_size
 
 
-def device_reduce(ndarray x, int op, out=None, bint keepdims=False):
+def device_reduce(ndarray x, int op, tuple out_axis, out=None,
+                  bint keepdims=False):
     cdef ndarray y, z
     cdef memory.MemoryPointer ws
     cdef int dtype_id, ndim_out, kv_bytes, x_size
@@ -100,8 +101,15 @@ def device_reduce(ndarray x, int op, out=None, bint keepdims=False):
     cdef void *y_ptr
     cdef void *ws_ptr
     cdef Stream_t s
+    cdef tuple out_shape
 
-    ndim_out = keepdims
+    if keepdims:
+        out_shape = tuple([x.shape[axis] if axis in out_axis else 1
+                           for axis in range(x.ndim)])
+        ndim_out = len(out_shape)
+    else:
+        ndim_out = 0
+
     if out is not None and out.ndim != ndim_out:
         raise ValueError(
             'output parameter for reduction operation has the wrong number of '
@@ -139,15 +147,15 @@ def device_reduce(ndarray x, int op, out=None, bint keepdims=False):
         y = y.reshape(())
 
     if keepdims:
-        y = y.reshape((1,))
+        y = y.reshape(out_shape)
     if out is not None:
         out[...] = y
         y = out
     return y
 
 
-def device_segmented_reduce(ndarray x, int op, axis, out=None,
-                            bint keepdims=False):
+def device_segmented_reduce(ndarray x, int op, tuple reduce_axis,
+                            tuple out_axis, out=None, bint keepdims=False):
     # if import at the top level, a segfault would happen when import cupy!
     from cupy.creation.ranges import arange
 
@@ -178,7 +186,8 @@ def device_segmented_reduce(ndarray x, int op, axis, out=None,
         raise RuntimeError('input is neither C- nor F- contiguous.')
 
     # prepare input
-    out_shape, contiguous_size = _preprocess_array(x, axis, keepdims, order)
+    out_shape, contiguous_size = _preprocess_array(x, reduce_axis, out_axis,
+                                                   keepdims, order)
     x_ptr = <void*>x.data.ptr
     y = ndarray(out_shape, dtype=x.dtype, order=order)
     y_ptr = <void*>y.data.ptr
@@ -269,50 +278,26 @@ def device_csrmv(int n_rows, int n_cols, int nnz, ndarray values,
     return y
 
 
-cdef bint _cub_device_reduce_axis_compatible(axis, Py_ssize_t ndim):
-    if ((axis is None) or ndim == 1 or axis == tuple(range(ndim))):
-        return True
-    return False
-
-
 cdef bint _cub_device_segmented_reduce_axis_compatible(
-        axis, Py_ssize_t ndim, order):
+        tuple cub_axis, Py_ssize_t ndim, order):
     # Implementation borrowed from cupy.fft.fft._get_cufft_plan_nd().
     # This function checks if the reduced axes are contiguous.
-    cdef tuple cub_axis
 
-    if axis is None:
-        # this is impossible, just in case
-        raise ValueError('axis cannot be None.')
-    else:
-        if numpy.isscalar(axis):
-            axis = (axis,)
-        axis = tuple(axis)
-
-        if numpy.min(axis) < -ndim or numpy.max(axis) > ndim - 1:
-            raise ValueError('The specified axis exceed the array dimensions.')
-
-        # sort the provided axis in ascending order
-        cub_axis = tuple(sorted(numpy.mod(axis, ndim)))
-
-        # the axes to be reduced must be C- or F- contiguous
-        if not numpy.all(numpy.diff(cub_axis) == 1):
-            return False
-        if order not in ('c', 'C', 'f', 'F'):
-            return False
-        if order in ('c', 'C') and ((ndim - 1) not in cub_axis):
-            return False
-        if order in ('f', 'F') and (0 not in cub_axis):
-            return False
+    # the axes to be reduced must be C- or F- contiguous
+    if not numpy.all(numpy.diff(cub_axis) == 1):
+        return False
+    if order not in ('c', 'C', 'f', 'F'):
+        return False
+    if order in ('c', 'C') and ((ndim - 1) not in cub_axis):
+        return False
+    if order in ('f', 'F') and (0 not in cub_axis):
+        return False
 
     return True
 
 
-def can_use_device_reduce(int op, x_dtype, Py_ssize_t ndim, axis=None,
-                          dtype=None):
-    if not _cub_reduce_dtype_compatible(x_dtype, op, dtype):
-        return False
-    return _cub_device_reduce_axis_compatible(axis, ndim)
+def can_use_device_reduce(int op, x_dtype, tuple out_axis, dtype=None):
+    return out_axis is () and _cub_reduce_dtype_compatible(x_dtype, op, dtype)
 
 
 def can_use_device_segmented_reduce(int op, x_dtype, Py_ssize_t ndim, axis,

--- a/cupy/cuda/cub.pyx
+++ b/cupy/cuda/cub.pyx
@@ -2,6 +2,8 @@
 
 """Wrapper of CUB functions for CuPy API."""
 
+from cpython cimport sequence
+
 import numpy
 
 from cupy.core.core cimport ndarray, _internal_ascontiguousarray
@@ -75,8 +77,19 @@ cpdef bint _contig_axes(tuple axes):
     return contig
 
 
-cpdef _preprocess_array(ndarray arr, tuple reduce_axis, tuple out_axis,
-                        bint keepdims, str order):
+cdef tuple _get_output_shape(ndarray arr, tuple out_axis, bint keepdims):
+    cdef tuple out_shape
+
+    if not keepdims:
+        out_shape = tuple([arr.shape[axis] for axis in out_axis])
+    else:
+        out_shape = tuple([arr.shape[axis] if axis in out_axis else 1
+                           for axis in range(arr.ndim)])
+    return out_shape
+
+
+cpdef Py_ssize_t _preprocess_array(ndarray arr, tuple reduce_axis,
+                                   tuple out_axis, str order):
     '''
     This function more or less follows the logic of _get_permuted_args() in
     reduction.pxi. The input array arr is C- or F- contiguous along axis.
@@ -96,13 +109,7 @@ cpdef _preprocess_array(ndarray arr, tuple reduce_axis, tuple out_axis,
 
     for axis in reduce_axis:
         contiguous_size *= arr.shape[axis]
-    if not keepdims:
-        out_shape = tuple([arr.shape[axis] for axis in out_axis])
-    else:
-        out_shape = tuple([arr.shape[axis] if axis in out_axis else 1
-                           for axis in range(arr.ndim)])
-
-    return out_shape, contiguous_size
+    return contiguous_size
 
 
 def device_reduce(ndarray x, int op, tuple out_axis, out=None,
@@ -118,8 +125,7 @@ def device_reduce(ndarray x, int op, tuple out_axis, out=None,
     cdef tuple out_shape
 
     if keepdims:
-        out_shape = tuple([x.shape[axis] if axis in out_axis else 1
-                           for axis in range(x.ndim)])
+        out_shape = _get_output_shape(x, out_axis, keepdims)
         ndim_out = len(out_shape)
     else:
         ndim_out = 0
@@ -200,8 +206,8 @@ def device_segmented_reduce(ndarray x, int op, tuple reduce_axis,
         raise RuntimeError('input is neither C- nor F- contiguous.')
 
     # prepare input
-    out_shape, contiguous_size = _preprocess_array(x, reduce_axis, out_axis,
-                                                   keepdims, order)
+    contiguous_size = _preprocess_array(x, reduce_axis, out_axis, order)
+    out_shape = _get_output_shape(arr, out_axis, keepdims)
     x_ptr = <void*>x.data.ptr
     y = ndarray(out_shape, dtype=x.dtype, order=order)
     y_ptr = <void*>y.data.ptr
@@ -314,7 +320,8 @@ def can_use_device_segmented_reduce(int op, x_dtype, Py_ssize_t ndim,
                                     reduce_axis, dtype=None, order='C'):
     if not _cub_reduce_dtype_compatible(x_dtype, op, dtype):
         return False
-    return _cub_device_segmented_reduce_axis_compatible(reduce_axis, ndim, order)
+    return _cub_device_segmented_reduce_axis_compatible(reduce_axis, ndim,
+                                                        order)
 
 
 cdef _cub_reduce_dtype_compatible(x_dtype, int op, dtype=None,
@@ -337,6 +344,61 @@ cdef _cub_reduce_dtype_compatible(x_dtype, int op, dtype=None,
     if x_dtype not in support_dtype:
         return False
     return True
+
+
+def cub_reduction(arr, op, axis=None, dtype=None, out=None, keepdims=False):
+    """Perform a reduction using CUB.
+
+    If the specified reduction is not possible, None is returned.
+    """
+    # if import at the top level, a segfault would happen when import cupy!
+    from cupy.core._kernel import _get_axis
+    cdef bint enforce_numpy_API = False
+
+    if op > CUPY_CUB_MAX:
+        # For argmin and argmax, NumPy does not allow a tuple for axis.
+        # Also, the keepdims and dtype kwargs are not provided.
+
+        # For now we don't enforce these for consistency with existing CuPy
+        # non-CUB reduction behavior.
+        # https://github.com/cupy/cupy/issues/2595
+        enforce_numpy_API = False
+        if enforce_numpy_API:
+            # numpy's argmin and argmax do not support a tuple of axes
+            if sequence.PySequence_Check(axis):
+                raise TypeError(
+                    "'tuple' object cannot be interpreted as an integer")
+            if keepdims:
+                raise TypeError(
+                    "'keepdims' is an invalid keyword argument for "
+                    "argmin or argmax.")
+            if dtype is not None:
+                raise TypeError(
+                    "'dtype' is an invalid keyword argument for "
+                    "argmin or argmax.")
+        else:
+            if dtype is not None:
+                # fallback to existing non-CUB behavior
+                return None
+
+    reduce_axis, out_axis = _get_axis(axis, arr.ndim)
+    if can_use_device_reduce(op, arr.dtype, out_axis, dtype):
+        return device_reduce(arr, op, out_axis, out, keepdims)
+
+    if op > CUPY_CUB_MAX:
+        # segmented reduction not currently implemented for argmax, argmin
+        return None
+
+    if arr.flags.c_contiguous:
+        order = 'C'
+    elif arr.flags.f_contiguous:
+        order = 'F'
+    else:
+        order = None
+
+    if can_use_device_reduce(op, arr.dtype, out_axis, dtype):
+        return device_reduce(arr, op, out_axis, out, keepdims)
+    return None
 
 
 def _get_dtype_id(dtype):

--- a/cupy/cuda/cub.pyx
+++ b/cupy/cuda/cub.pyx
@@ -61,6 +61,15 @@ cdef extern from 'cupy_cub.h' nogil:
 # Python interface
 ###############################################################################
 
+cpdef _contig_axes(tuple axes):
+    # True if the specified axes are in ascending order without gaps
+    unsigned int n
+    bint bool = True
+    for n in range(1, len(axes)):
+        bint = (axes[n] - axes[n - 1]) == 1
+    return bint
+
+
 cpdef _preprocess_array(ndarray arr, tuple reduce_axis, tuple out_axis,
                         bint keepdims, str order):
     '''
@@ -284,14 +293,17 @@ cdef bint _cub_device_segmented_reduce_axis_compatible(
     # This function checks if the reduced axes are contiguous.
 
     # the axes to be reduced must be C- or F- contiguous
-    if not all((ax - ax_prev) == 1
-               for ax, ax_prev in zip(cub_axis[1:], cub_axis[:-1])):
+    if not _contig_axes(cub_axis):
         return False
     if order not in ('c', 'C', 'f', 'F'):
         return False
-    if order in ('c', 'C') and ((ndim - 1) not in cub_axis):
-        return False
-    if order in ('f', 'F') and (0 not in cub_axis):
+    if order in ('c', 'C')
+        if ((ndim - 1) not in cub_axis):
+            return False
+    elif order in ('f', 'F'):
+        if (0 not in cub_axis):
+            return False
+    else:
         return False
 
     return True

--- a/cupy/cuda/cub.pyx
+++ b/cupy/cuda/cub.pyx
@@ -95,7 +95,7 @@ cpdef Py_ssize_t _preprocess_array(ndarray arr, tuple reduce_axis,
     reduction.pxi. The input array arr is C- or F- contiguous along axis.
     '''
     # if import at the top level, a segfault would happen when import cupy!
-    from cupy.core._kernel import _get_axis
+    from cupy.core._reduction import _get_axis
 
     cdef tuple axis_permutes, out_shape
     cdef Py_ssize_t contiguous_size = 1
@@ -352,7 +352,7 @@ def cub_reduction(arr, op, axis=None, dtype=None, out=None, keepdims=False):
     If the specified reduction is not possible, None is returned.
     """
     # if import at the top level, a segfault would happen when import cupy!
-    from cupy.core._kernel import _get_axis
+    from cupy.core._reduction import _get_axis
     cdef bint enforce_numpy_API = False
 
     if op > CUPY_CUB_MAX:

--- a/cupy/cuda/cub.pyx
+++ b/cupy/cuda/cub.pyx
@@ -94,9 +94,6 @@ cpdef Py_ssize_t _preprocess_array(ndarray arr, tuple reduce_axis,
     This function more or less follows the logic of _get_permuted_args() in
     reduction.pxi. The input array arr is C- or F- contiguous along axis.
     '''
-    # if import at the top level, a segfault would happen when import cupy!
-    from cupy.core._reduction import _get_axis
-
     cdef tuple axis_permutes, out_shape
     cdef Py_ssize_t contiguous_size = 1
 

--- a/cupy/cuda/cub.pyx
+++ b/cupy/cuda/cub.pyx
@@ -8,6 +8,7 @@ import numpy
 
 from cupy.core.core cimport ndarray, _internal_ascontiguousarray
 from cupy.core.core cimport _internal_asfortranarray
+from cupy.core.internal cimport _contig_axes
 from cupy.cuda cimport memory
 from cupy.cuda cimport stream
 from cupy.cuda.driver cimport Stream as Stream_t
@@ -62,20 +63,6 @@ cdef extern from 'cupy_cub.h' nogil:
 ###############################################################################
 # Python interface
 ###############################################################################
-
-
-@cython.boundscheck(False)
-@cython.wraparound(False)
-cpdef bint _contig_axes(tuple axes):
-    # True if the specified axes are in ascending order without gaps
-    cdef Py_ssize_t n
-    cdef bint contig = True
-    for n in range(1, len(axes)):
-        contig = (axes[n] - axes[n - 1]) == 1
-        if not contig:
-            break
-    return contig
-
 
 cdef tuple _get_output_shape(ndarray arr, tuple out_axis, bint keepdims):
     cdef tuple out_shape

--- a/cupy/cuda/cub.pyx
+++ b/cupy/cuda/cub.pyx
@@ -207,7 +207,7 @@ def device_segmented_reduce(ndarray x, int op, tuple reduce_axis,
 
     # prepare input
     contiguous_size = _preprocess_array(x, reduce_axis, out_axis, order)
-    out_shape = _get_output_shape(arr, out_axis, keepdims)
+    out_shape = _get_output_shape(x, out_axis, keepdims)
     x_ptr = <void*>x.data.ptr
     y = ndarray(out_shape, dtype=x.dtype, order=order)
     y_ptr = <void*>y.data.ptr
@@ -358,7 +358,7 @@ def cub_reduction(arr, op, axis=None, dtype=None, out=None, keepdims=False):
     if op > CUPY_CUB_MAX:
         # For argmin and argmax, NumPy does not allow a tuple for axis.
         # Also, the keepdims and dtype kwargs are not provided.
-
+        #
         # For now we don't enforce these for consistency with existing CuPy
         # non-CUB reduction behavior.
         # https://github.com/cupy/cupy/issues/2595

--- a/tests/cupy_tests/core_tests/test_ndarray_reduction.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_reduction.py
@@ -14,6 +14,12 @@ class TestArrayReduction(unittest.TestCase):
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
+    def test_max_all_keepdims(self, xp, dtype):
+        a = testing.shaped_random((2, 3), xp, dtype)
+        return a.max(keepdims=True)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose()
     def test_max_axis_large(self, xp, dtype):
         a = testing.shaped_random((3, 1000), xp, dtype)
         return a.max(axis=0)
@@ -35,6 +41,18 @@ class TestArrayReduction(unittest.TestCase):
     def test_max_axis2(self, xp, dtype):
         a = testing.shaped_random((2, 3, 4), xp, dtype)
         return a.max(axis=2)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose()
+    def test_max_multiple_axes(self, xp, dtype):
+        a = testing.shaped_random((2, 3, 4), xp, dtype)
+        return a.max(axis=(1, 2))
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose()
+    def test_max_multiple_axes_keepdims(self, xp, dtype):
+        a = testing.shaped_random((2, 3, 4), xp, dtype)
+        return a.max(axis=(1, 2), keepdims=True)
 
     @testing.for_float_dtypes()
     @testing.numpy_cupy_allclose()
@@ -62,6 +80,12 @@ class TestArrayReduction(unittest.TestCase):
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
+    def test_min_all_keepdims(self, xp, dtype):
+        a = testing.shaped_random((2, 3), xp, dtype)
+        return a.min(keepdims=True)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose()
     def test_min_axis_large(self, xp, dtype):
         a = testing.shaped_random((3, 1000), xp, dtype)
         return a.min(axis=0)
@@ -83,6 +107,18 @@ class TestArrayReduction(unittest.TestCase):
     def test_min_axis2(self, xp, dtype):
         a = testing.shaped_random((2, 3, 4), xp, dtype)
         return a.min(axis=2)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose()
+    def test_min_multiple_axes(self, xp, dtype):
+        a = testing.shaped_random((2, 3, 4), xp, dtype)
+        return a.min(axis=(1, 2))
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose()
+    def test_min_multiple_axes_keepdims(self, xp, dtype):
+        a = testing.shaped_random((2, 3, 4), xp, dtype)
+        return a.min(axis=(1, 2), keepdims=True)
 
     @testing.for_float_dtypes()
     @testing.numpy_cupy_allclose()

--- a/tests/cupy_tests/math_tests/test_sumprod.py
+++ b/tests/cupy_tests/math_tests/test_sumprod.py
@@ -23,6 +23,12 @@ class TestSumprod(unittest.TestCase):
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
+    def test_sum_all_keepdims(self, xp, dtype):
+        a = testing.shaped_arange((2, 3, 4), xp, dtype)
+        return a.sum(keepdims=True)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose()
     def test_external_sum_all(self, xp, dtype):
         a = testing.shaped_arange((2, 3, 4), xp, dtype)
         return xp.sum(a)
@@ -130,6 +136,11 @@ class TestSumprod(unittest.TestCase):
     def test_sum_keepdims(self, xp):
         a = testing.shaped_arange((2, 3, 4), xp)
         return a.sum(axis=1, keepdims=True)
+
+    @testing.numpy_cupy_allclose()
+    def test_sum_keepdims_multiple_axes(self, xp):
+        a = testing.shaped_arange((2, 3, 4), xp)
+        return a.sum(axis=(1, 2), keepdims=True)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()

--- a/tests/cupy_tests/math_tests/test_sumprod.py
+++ b/tests/cupy_tests/math_tests/test_sumprod.py
@@ -132,14 +132,18 @@ class TestSumprod(unittest.TestCase):
         a = testing.shaped_arange((2, 3, 4), xp, src_dtype)
         return a.sum(dtype=dst_dtype)
 
+    @testing.for_all_dtypes_combination(names=['src_dtype', 'dst_dtype'])
     @testing.numpy_cupy_allclose()
-    def test_sum_keepdims(self, xp):
-        a = testing.shaped_arange((2, 3, 4), xp)
-        return a.sum(axis=1, keepdims=True)
+    def test_sum_keepdims_and_dtype(self, xp, src_dtype, dst_dtype):
+        if not xp.can_cast(src_dtype, dst_dtype):
+            return xp.array([])  # skip
+        a = testing.shaped_arange((2, 3, 4), xp, src_dtype)
+        return a.sum(axis=1, dtype=dst_dtype, keepdims=True)
 
+    @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
-    def test_sum_keepdims_multiple_axes(self, xp):
-        a = testing.shaped_arange((2, 3, 4), xp)
+    def test_sum_keepdims_multiple_axes(self, xp, dtype):
+        a = testing.shaped_arange((2, 3, 4), xp, dtype)
         return a.sum(axis=(1, 2), keepdims=True)
 
     @testing.for_all_dtypes()

--- a/tests/cupy_tests/math_tests/test_sumprod.py
+++ b/tests/cupy_tests/math_tests/test_sumprod.py
@@ -138,7 +138,7 @@ class TestSumprod(unittest.TestCase):
         if not xp.can_cast(src_dtype, dst_dtype):
             return xp.array([])  # skip
         a = testing.shaped_arange((2, 3, 4), xp, src_dtype)
-        return a.sum(axis=1, dtype=dst_dtype, keepdims=True)
+        return a.sum(axis=2, dtype=dst_dtype, keepdims=True)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()


### PR DESCRIPTION
closes #2720

The bug is fixed by the lines computing `out_shape` within `device_reduce`.

In order to avoid multiple calls to `_get_axis`, I moved the `_get_axis` call outside of `_preprocess_array` and call it directly in `_routines_math.pyx` and `_routines_statistics.pyx` instead. The duplicate logic could potentially be refactored into a common function

`_get_axes` will have already sorted the axes in ascending order and checked their range (It also separates out the axes to be reduced from those needed in determining the shape for keepdims).
This allows greatly simplifying the code in `_cub_device_segmented_reduce_axis_compatible` and removes the need for `_cub_device_reduce_axis_compatible` altogether.

Although not strictly part of the bug fix, I implemented a performance improvement in the segmented reduction case by replacing the following slow call

```Python
numpy.all(numpy.diff(cub_axis) == 1)
```
with a call to a new `_contig_axis` Cython helper function
