### PR TITLE
Add `searchsorted`

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -631,15 +631,15 @@ pad = padding.pad.pad
 # Sorting, searching, and counting
 # -----------------------------------------------------------------------------
 from cupy.sorting.count import count_nonzero  # NOQA
-from cupy.sorting.search import flatnonzero  # NOQA
-from cupy.sorting.search import nonzero  # NOQA
 
+from cupy.sorting.search import argmax  # NOQA
+from cupy.sorting.search import argmin  # NOQA
+from cupy.sorting.search import flatnonzero  # NOQA
+from cupy.sorting.search import nanargmax  # NOQA
+from cupy.sorting.search import nanargmin  # NOQA
+from cupy.sorting.search import nonzero  # NOQA
 from cupy.sorting.search import searchsorted  # NOQA
 from cupy.sorting.search import where  # NOQA
-from cupy.sorting.search import argmax  # NOQA
-from cupy.sorting.search import nanargmax  # NOQA
-from cupy.sorting.search import argmin  # NOQA
-from cupy.sorting.search import nanargmin  # NOQA
 
 from cupy.sorting.sort import argpartition  # NOQA
 from cupy.sorting.sort import argsort  # NOQA

--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -635,6 +635,7 @@ from cupy.sorting.search import flatnonzero  # NOQA
 from cupy.sorting.search import nonzero  # NOQA
 
 from cupy.sorting.search import where  # NOQA
+from cupy.sorting.search import searchsorted  # NOQA
 from cupy.sorting.search import argmax  # NOQA
 from cupy.sorting.search import nanargmax  # NOQA
 from cupy.sorting.search import argmin  # NOQA

--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -634,8 +634,8 @@ from cupy.sorting.count import count_nonzero  # NOQA
 from cupy.sorting.search import flatnonzero  # NOQA
 from cupy.sorting.search import nonzero  # NOQA
 
-from cupy.sorting.search import where  # NOQA
 from cupy.sorting.search import searchsorted  # NOQA
+from cupy.sorting.search import where  # NOQA
 from cupy.sorting.search import argmax  # NOQA
 from cupy.sorting.search import nanargmax  # NOQA
 from cupy.sorting.search import argmin  # NOQA

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -690,8 +690,6 @@ cdef class ndarray:
         """
         return _sorting._ndarray_argpartition(self, kth, axis)
 
-    # TODO(okuta): Implement searchsorted
-
     cpdef tuple nonzero(self):
         """Return the indices of the elements that are non-zero.
 

--- a/cupy/sorting/search.py
+++ b/cupy/sorting/search.py
@@ -216,16 +216,7 @@ _searchsorted_kernel_left = core.ElementwiseKernel(
     'U y',
     '''
     y = 0;
-    // Array is assumed to be monotonically
-    // increasing unless a check is requested
-    // because of functions like digitize
-    // allowing both, increasing and decreasing.
-    bool inc = true;
-    if (_isnan<S>(x)) {
-        y = (inc ? n_bins : 0);
-        return;
-    }
-    if (inc && x > bins[n_bins-1] || !inc && x <= bins[n_bins-1]) {
+    if (_isnan<S>(x) || x > bins[n_bins-1]) {
         y = n_bins;
         return;
     }
@@ -233,7 +224,7 @@ _searchsorted_kernel_left = core.ElementwiseKernel(
     size_t r = n_bins-1;
     while (l<r) {
         size_t m = l + (r - l) / 2;
-        if ((inc && bins[m] >= x) || (!inc && bins[m] < x)) {
+        if (bins[m] >= x) {
             r = m;
         } else {
             l = m + 1;
@@ -248,16 +239,7 @@ _searchsorted_kernel_right = core.ElementwiseKernel(
     'U y',
     '''
     y = 0;
-    // Array is assumed to be monotonically
-    // increasing unless a check is requested
-    // because of functions like digitize
-    // allowing both, increasing and decreasing.
-    bool inc = true;
-    if(_isnan<S>(x)) {
-        y = (inc ? n_bins : 0);
-        return;
-    }
-    if (inc && x >= bins[n_bins-1]) {
+    if(_isnan<S>(x) || x >= bins[n_bins-1]) {
         y = n_bins;
         return;
     }
@@ -265,7 +247,7 @@ _searchsorted_kernel_right = core.ElementwiseKernel(
     size_t r = n_bins-1;
     while (l<r) {
         size_t m = l + (r - l) / 2;
-        if ((inc && bins[m] <= x) || (!inc && bins[m] > x)) {
+        if (bins[m] <= x) {
             l = m + 1;
         } else {
             r = m;

--- a/cupy/statistics/histogram.py
+++ b/cupy/statistics/histogram.py
@@ -136,6 +136,3 @@ def bincount(x, weights=None, minlength=None):
         _bincount_with_weight_kernel(x, weights, b)
 
     return b
-
-
-# TODO(okuta): Implement digitize

--- a/tests/cupy_tests/sorting_tests/test_search.py
+++ b/tests/cupy_tests/sorting_tests/test_search.py
@@ -431,3 +431,94 @@ class TestNanArgMax(unittest.TestCase):
     def test_nanargmax_zero_size_axis1(self, xp, dtype):
         a = testing.shaped_random((0, 1), xp, dtype)
         return xp.nanargmax(a, axis=1)
+
+
+@testing.gpu
+@testing.parameterize(*testing.product(
+    {'bins': [
+        [],
+        [0, 1, 2, 4, 10],
+        [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        [0.0, 1.0, 2.5, 4.0, 10.0],
+        [-1.0, 1.0, 2.5, 4.0, 20.0],
+        [1.5, 2.5, 4.0, 6.0],
+        [0.0, 1.0, 1.0, 4.0, 4.0, 10.0],
+        [0.0, 1.0, 1.0, 4.0, 4.0, 4.0, 4.0, 10.0],
+    ],
+        'side': ['left', 'right'],
+        'shape': [(), (10,), (6, 3, 3)]})
+)
+class TestSearchSorted(unittest.TestCase):
+
+    @testing.with_requires('numpy>=1.10.0')
+    @testing.for_all_dtypes(no_bool=True)
+    @testing.numpy_cupy_array_list_equal()
+    def test_searchsorted(self, xp, dtype):
+        x = testing.shaped_arange(self.shape, xp, dtype)
+        bins = xp.array(self.bins)
+        y = xp.searchsorted(bins, x, side=self.side)
+        return y,
+
+
+@testing.gpu
+class TestSearchSortedNan(unittest.TestCase):
+
+    @testing.with_requires('numpy>=1.10.0')
+    @testing.numpy_cupy_array_list_equal()
+    def test_searchsorted_nanbins(self, xp):
+        x = testing.shaped_arange((10,), xp, xp.float64)
+        bins = xp.array([0, 1, 2, 4, 10, float('nan')])
+        y = xp.searchsorted(bins, x)
+        return y,
+
+    @testing.with_requires('numpy>=1.10.0')
+    @testing.numpy_cupy_array_list_equal()
+    def test_searchsorted_nan(self, xp):
+        x = testing.shaped_arange((10,), xp, xp.float64)
+        x[5] = float('nan')
+        bins = xp.array([0, 1, 2, 4, 10])
+        y = xp.searchsorted(bins, x)
+        return y,
+
+
+@testing.gpu
+class TestSearchSortedInvalid(unittest.TestCase):
+
+    # Cant test unordered bins due to numpy undefined
+    # behavior for searchsorted
+    @testing.with_requires('numpy>=1.10.0')
+    @testing.numpy_cupy_raises(accept_error=ValueError)
+    def test_searchsorted_ndbins(self, xp):
+        x = testing.shaped_arange((10,), xp, xp.float64)
+        bins = xp.array([[10, 4], [2, 1], [7, 8]])
+        y = xp.searchsorted(bins, x)
+        return y,
+
+
+@testing.gpu
+class TestSearchSortedWithSorter(unittest.TestCase):
+
+    @testing.with_requires('numpy>=1.10.0')
+    @testing.numpy_cupy_array_list_equal()
+    def test_sorter(self, xp):
+        x = testing.shaped_arange((12,), xp, xp.float64)
+        bins = xp.array([10, 4, 2, 1, 8])
+        sorter = xp.array([3, 2, 1, 4, 0])
+        y = xp.searchsorted(bins, x, sorter=sorter)
+        return y,
+
+    @testing.with_requires('numpy>=1.10.0')
+    @testing.numpy_cupy_raises(accept_error=ValueError)
+    def test_invalid_sorter(self, xp):
+        x = testing.shaped_arange((12,), xp, xp.float64)
+        bins = xp.array([10, 4, 2, 1, 8])
+        sorter = xp.array([0])
+        xp.searchsorted(bins, x, sorter=sorter)
+
+    @testing.with_requires('numpy>=1.10.0')
+    @testing.numpy_cupy_raises(accept_error=TypeError)
+    def test_nonint_sorter(self, xp):
+        x = testing.shaped_arange((12,), xp, xp.float64)
+        bins = xp.array([10, 4, 2, 1, 8])
+        sorter = xp.array([], dtype=xp.float64)
+        xp.searchsorted(bins, x, sorter=sorter)


### PR DESCRIPTION
Implements `searchsorted`

As in NumPy the function assumes that the `a` array is monotonic increasing and doesn't explicitly check it.

The implemented kernel adds a `check` option to detect wether the array is increasing or decreasing by comparing two values. This is to allow an efficient implementation of `digitize`.