### PR TITLE
Avoid tricky initialization of block stride

### DIFF
--- a/cupy/core/_scalar.pxd
+++ b/cupy/core/_scalar.pxd
@@ -1,4 +1,5 @@
 from libc.stdint cimport int8_t
+from libc.stdint cimport int32_t
 
 from cupy.cuda.function cimport CPointer
 
@@ -12,6 +13,8 @@ cdef class CScalar(CPointer):
     cpdef apply_dtype(self, dtype)
     cpdef get_numpy_type(self)
 
+
+cdef CScalar CScalar_from_int32(int32_t value)
 
 cpdef str get_typename(dtype)
 cpdef get_scalar_from_numpy(x, dtype)

--- a/cupy/core/_scalar.pyx
+++ b/cupy/core/_scalar.pyx
@@ -236,6 +236,14 @@ cdef class CScalar(CPointer):
         assert False
 
 
+cdef CScalar CScalar_from_int32(int32_t value):
+    cdef CScalar s = CScalar.__new__(CScalar)
+    (<int32_t *>s.ptr)[0] = value
+    s.kind = b'i'
+    s.size = 4
+    return s
+
+
 cpdef CScalar _python_scalar_to_c_scalar(x):
     cdef CScalar ret = CScalar.__new__(CScalar)
     cdef Scalar* s = <Scalar*>ret.ptr

--- a/cupy/core/reduction.pxi
+++ b/cupy/core/reduction.pxi
@@ -160,17 +160,20 @@ cpdef (Py_ssize_t, Py_ssize_t, Py_ssize_t) _get_block_specs(  # NOQA
 cpdef list _get_inout_args(
         list in_args, list out_args, Indexer in_indexer, Indexer out_indexer,
         Py_ssize_t block_stride, tuple params, bint reduce_dims):
+    # Returns a list of arguments passed to the __global__ function.
+
     if reduce_dims:
         in_shape = _reduce_dims(in_args, params, in_indexer.shape)
         out_shape = _reduce_dims(
             out_args, params[len(in_args):], out_indexer.shape)
         in_indexer.shape = in_shape
         out_indexer.shape = out_shape
-    cdef _scalar.CScalar s = _scalar.CScalar.__new__(_scalar.CScalar)
-    (<int32_t *>s.ptr)[0] = block_stride
-    s.kind = b'i'
-    s.size = 4
-    return in_args + out_args + [in_indexer, out_indexer, s]
+    return in_args + out_args + [
+        in_indexer,
+        out_indexer,
+        # The last argument is always block_stride.
+        _scalar.CScalar_from_int32(block_stride),
+    ]
 
 
 @util.memoize(for_each_device=True)


### PR DESCRIPTION
I would have defined `@staticmethod cdef CScalar.from_int32()`, but `cdef` class cannot have a static method.
