### PR TITLE
WIP: Implement `__sizeof__` protocol for `ndarray`s

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -231,6 +231,16 @@ cdef class ndarray:
         """
         return self.size * self.dtype.itemsize
 
+    def __sizeof__(self):
+        """Total size of all elements in bytes.
+
+        It does not count skips between elements.
+
+        .. seealso:: :func:`sys.getsizeof`
+
+        """
+        return self.nbytes
+
     # -------------------------------------------------------------------------
     # Other attributes
     # -------------------------------------------------------------------------


### PR DESCRIPTION
In order to use things like `sys.getsizeof` effectively on CuPy `ndarray`s, implement the `__sizeof__` method. This just returns the value from `nbytes`. It can be a useful metric for things trying to estimate memory usage or the cost of transferring data.

cc @pentschev @mrocklin