### PR TITLE
Use getrfBatched in `linalg.slogdet`

### DIFF
--- a/cupy/linalg/decomposition.py
+++ b/cupy/linalg/decomposition.py
@@ -7,6 +7,90 @@ from cupy.cuda import device
 from cupy.linalg import util
 
 
+def _lu_factor(a_t, dtype):
+    """Compute pivoted LU decomposition.
+
+    Decompose a given batch of square matrices. Inputs and outputs are
+    transposed.
+
+    Args:
+        a_t (cupy.ndarray): The input matrix with dimension ``(..., N, N)``.
+            The dimension condition is not checked.
+        dtype (numpy.dtype): float32, float64, complex64, or complex128.
+
+    Returns:
+        lu_t (cupy.ndarray): ``L`` without its unit diagonal and ``U`` with
+            dimension ``(..., N, N)``.
+        piv (cupy.ndarray): 1-origin pivot indices with dimension
+            ``(..., N)``.
+        dev_info (cupy.ndarray): ``getrf`` info with dimension ``(...)``.
+
+    .. seealso:: :func:`scipy.linalg.lu_factor`
+
+    """
+    orig_shape = a_t.shape
+    n = orig_shape[-2]
+
+    # copy is necessary to present `a` to be overwritten.
+    a_t = a_t.astype(dtype, order='C').reshape(-1, n, n)
+    batch_size = a_t.shape[0]
+    ipiv = cupy.empty((batch_size, n), dtype=numpy.int32)
+    dev_info = cupy.empty((batch_size,), dtype=numpy.int32)
+
+    use_batched = True  # TODO(kataoka): cond from experiments
+    if use_batched:
+        handle = device.get_cublas_handle()
+        lda = n
+        step = n * lda * a_t.itemsize
+        start = a_t.data.ptr
+        stop = start + step * batch_size
+        a_array = cupy.arange(start, stop, step, dtype=cupy.uintp)
+
+        if dtype == numpy.float32:
+            getrfBatched = cupy.cuda.cublas.sgetrfBatched
+        elif dtype == numpy.float64:
+            getrfBatched = cupy.cuda.cublas.dgetrfBatched
+        elif dtype == numpy.complex64:
+            getrfBatched = cupy.cuda.cublas.cgetrfBatched
+        elif dtype == numpy.complex128:
+            getrfBatched = cupy.cuda.cublas.zgetrfBatched
+        else:
+            assert False
+
+        getrfBatched(
+            handle, n, a_array.data.ptr, lda, ipiv.data.ptr,
+            dev_info.data.ptr, batch_size)
+
+    else:
+        handle = device.get_cusolver_handle()
+        if dtype == numpy.float32:
+            getrf_bufferSize = cusolver.sgetrf_bufferSize
+            getrf = cusolver.sgetrf
+        elif dtype == numpy.float64:
+            getrf_bufferSize = cusolver.dgetrf_bufferSize
+            getrf = cusolver.dgetrf
+        elif dtype == numpy.complex64:
+            getrfBatched = cupy.cuda.cublas.cgetrfBatched
+        elif dtype == numpy.complex128:
+            getrfBatched = cupy.cuda.cublas.zgetrfBatched
+        else:
+            assert False
+
+        for i in range(batch_size):
+            a_ptr = a_t[i].data.ptr
+            buffersize = getrf_bufferSize(handle, n, n, a_ptr, n)
+            workspace = cupy.empty(buffersize, dtype=dtype)
+            getrf(
+                handle, n, n, a_ptr, n, workspace.data.ptr,
+                ipiv[i].data.ptr, dev_info[i].data.ptr)
+
+    return (
+        a_t.reshape(orig_shape),
+        ipiv.reshape(orig_shape[:-1]),
+        dev_info.reshape(orig_shape[:-2]),
+    )
+
+
 def cholesky(a):
     """Cholesky decomposition.
 

--- a/cupy/linalg/decomposition.py
+++ b/cupy/linalg/decomposition.py
@@ -37,7 +37,10 @@ def _lu_factor(a_t, dtype):
     ipiv = cupy.empty((batch_size, n), dtype=numpy.int32)
     dev_info = cupy.empty((batch_size,), dtype=numpy.int32)
 
-    use_batched = True  # TODO(kataoka): cond from experiments
+    # Heuristic condition from some performance test.
+    # TODO(kataoka): autotune
+    use_batched = batch_size * 65536 >= n * n
+
     if use_batched:
         handle = device.get_cublas_handle()
         lda = n

--- a/tests/cupy_tests/linalg_tests/test_norms.py
+++ b/tests/cupy_tests/linalg_tests/test_norms.py
@@ -113,9 +113,35 @@ class TestDet(unittest.TestCase):
         return xp.linalg.det(a)
 
     @testing.for_float_dtypes(no_float16=True)
+    @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-4)
+    def test_det_empty_batch(self, xp, dtype):
+        a = xp.empty((2, 0, 3, 3), dtype)
+        return xp.linalg.det(a)
+
+    @testing.with_requires('numpy>=1.13')
+    @testing.for_float_dtypes(no_float16=True)
+    @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-4)
+    def test_det_empty_matrix(self, xp, dtype):
+        a = xp.empty((0, 0), dtype)
+        return xp.linalg.det(a)
+
+    @testing.with_requires('numpy>=1.13')
+    @testing.for_float_dtypes(no_float16=True)
+    @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-4)
+    def test_det_empty_matrices(self, xp, dtype):
+        a = xp.empty((2, 3, 0, 0), dtype)
+        return xp.linalg.det(a)
+
+    @testing.for_float_dtypes(no_float16=True)
     @testing.numpy_cupy_raises(accept_error=numpy.linalg.LinAlgError)
     def test_det_different_last_two_dims(self, xp, dtype):
         a = testing.shaped_arange((2, 3, 2), xp, dtype)
+        return xp.linalg.det(a)
+
+    @testing.for_float_dtypes(no_float16=True)
+    @testing.numpy_cupy_raises(accept_error=numpy.linalg.LinAlgError)
+    def test_det_different_last_two_dims_empty_batch(self, xp, dtype):
+        a = xp.empty((0, 3, 2), dtype)
         return xp.linalg.det(a)
 
     @testing.for_float_dtypes(no_float16=True)


### PR DESCRIPTION
`linalg.det` using `getrfBatched` is originally implemented in chainer/chainer#613.

For the input `random.randn(256, 256, 256)`,

- v6: 0.85 sec
- v7 (after #2437 and #2660): 1.2 sec
- this PR: 0.022 sec