### PR TITLE
Remove `cupy/internal.py`

### DIFF
--- a/cupy/internal.py
+++ b/cupy/internal.py
@@ -1,4 +1,0 @@
-def prod(args, init=1):
-    for arg in args:
-        init *= arg
-    return init

--- a/cupy/linalg/einsum.py
+++ b/cupy/linalg/einsum.py
@@ -286,7 +286,7 @@ def _flatten_transpose(a, axeses):
         shapes.append([a.shape[axis] for axis in axes])
     return (
         a.transpose(transpose_axes).reshape(
-            tuple([cupy.internal.prod(shape) for shape in shapes])),
+            tuple([cupy.core.internal.prod(shape) for shape in shapes])),
         shapes
     )
 

--- a/cupy/linalg/product.py
+++ b/cupy/linalg/product.py
@@ -3,7 +3,7 @@ import six
 
 import cupy
 from cupy import core
-from cupy import internal
+from cupy.core import internal
 
 from cupy.linalg.solve import inv
 from cupy import util

--- a/cupy/linalg/solve.py
+++ b/cupy/linalg/solve.py
@@ -163,7 +163,7 @@ def tensorsolve(a, b, axes=None):
         a = a.transpose(allaxes)
 
     oldshape = a.shape[-(a.ndim - b.ndim):]
-    prod = cupy.internal.prod(oldshape)
+    prod = cupy.core.internal.prod(oldshape)
 
     a = a.reshape(-1, prod)
     b = b.ravel()
@@ -458,7 +458,7 @@ def tensorinv(a, ind=2):
         raise ValueError('Invalid ind argument')
     oldshape = a.shape
     invshape = oldshape[ind:] + oldshape[:ind]
-    prod = cupy.internal.prod(oldshape[ind:])
+    prod = cupy.core.internal.prod(oldshape[ind:])
     a = a.reshape(prod, -1)
     a_inv = inv(a)
     return a_inv.reshape(*invshape)

--- a/cupy/testing/helper.py
+++ b/cupy/testing/helper.py
@@ -16,7 +16,7 @@ import numpy
 import six
 
 import cupy
-from cupy import internal
+from cupy.core import internal
 from cupy.testing import array
 from cupy.testing import parameterized
 import cupyx


### PR DESCRIPTION
Close #2661. Removed `cupy.internal.prod()` by redirecting to `cupy.core.internal.prod()`. 

Not sure if my `grep` caught all of the target `prod()` calls, so I need to rely on CI tests for this.