### PR TITLE
Add helpers to measure execution times

### DIFF
--- a/cupyx/__init__.py
+++ b/cupyx/__init__.py
@@ -4,9 +4,9 @@ from cupyx.runtime import get_runtime_info  # NOQA
 from cupyx.scatter import scatter_add  # NOQA
 from cupyx.scatter import scatter_max  # NOQA
 from cupyx.scatter import scatter_min  # NOQA
-from cupyx.time import run  # NOQA
 
 from cupyx import linalg  # NOQA
+from cupyx import time  # NOQA
 from cupyx import scipy  # NOQA
 
 from cupyx._ufunc_config import errstate  # NOQA

--- a/cupyx/__init__.py
+++ b/cupyx/__init__.py
@@ -4,6 +4,7 @@ from cupyx.runtime import get_runtime_info  # NOQA
 from cupyx.scatter import scatter_add  # NOQA
 from cupyx.scatter import scatter_max  # NOQA
 from cupyx.scatter import scatter_min  # NOQA
+from cupyx.time import run  # NOQA
 
 from cupyx import linalg  # NOQA
 from cupyx import scipy  # NOQA

--- a/cupyx/time.py
+++ b/cupyx/time.py
@@ -1,0 +1,65 @@
+import time
+
+import numpy
+
+import cupy
+
+
+class _PerfCaseResult(object):
+    def __init__(self, name, ts):
+        assert ts.ndim == 2 and ts.shape[0] == 2 and ts.shape[1] > 0
+        self.name = name
+        self._ts = ts
+
+    @property
+    def cpu_times(self):
+        return self._ts[0]
+
+    @property
+    def gpu_times(self):
+        return self._ts[1]
+
+    @staticmethod
+    def _to_str_per_item(t):
+        assert t.size > 0
+        t *= 1e6
+
+        s = ' {:9.03f} us'.format(t.mean())
+        if t.size > 1:
+            s += '   +/-{:6.03f} (min:{:9.03f} / max:{:9.03f}) us'.format(
+                t.std(), t.min(), t.max())
+        return s
+
+    def to_str(self, show_gpu=False):
+        ts = self._ts if show_gpu else self._ts[[0]]
+        return '{:<20s}:{}'.format(
+            self.name, ' '.join([self._to_str_per_item(t) for t in ts]))
+
+    def __str__(self):
+        return self.to_str(show_gpu=True)
+
+
+def run(name, func, args=(), n=10000, *, n_warmup=10):
+    ts = numpy.empty((2, n,), dtype=numpy.float64)
+    ev1 = cupy.cuda.stream.Event()
+    ev2 = cupy.cuda.stream.Event()
+
+    for i in range(n_warmup):
+        func(*args)
+
+    for i in range(n):
+        ev1.synchronize()
+        ev1.record()
+        t1 = time.perf_counter()
+
+        func(*args)
+
+        t2 = time.perf_counter()
+        ev2.record()
+        ev2.synchronize()
+        cpu_time = t2 - t1
+        gpu_time = cupy.cuda.get_elapsed_time(ev1, ev2) * 1e-3
+        ts[0, i] = cpu_time
+        ts[1, i] = gpu_time
+
+    return _PerfCaseResult(name, ts)

--- a/cupyx/time.py
+++ b/cupyx/time.py
@@ -61,8 +61,10 @@ def repeat(func, args=(), n=10000, *, name=None, n_warmup=10):
     for i in range(n_warmup):
         func(*args)
 
+    ev1.record()
+    ev1.synchronize()
+
     for i in range(n):
-        ev1.synchronize()
         ev1.record()
         t1 = time.perf_counter()
 

--- a/cupyx/time.py
+++ b/cupyx/time.py
@@ -43,6 +43,17 @@ def run(func, args=(), n=10000, *, name=None, n_warmup=10):
     if name is None:
         name = func.__name__
 
+    if not callable(func):
+        raise ValueError('`func` should be a callable object.')
+    if not isinstance(args, tuple):
+        raise ValueError('`args` should be of tuple type.')
+    if not isinstance(n, int):
+        raise ValueError('`n` should be an integer.')
+    if not isinstance(name, str):
+        raise ValueError('`str` should be a string.')
+    if not isinstance(n_warmup, int):
+        raise ValueError('`n_warmup` should be an integer.')
+
     ts = numpy.empty((2, n,), dtype=numpy.float64)
     ev1 = cupy.cuda.stream.Event()
     ev2 = cupy.cuda.stream.Event()

--- a/cupyx/time.py
+++ b/cupyx/time.py
@@ -39,7 +39,7 @@ class _PerfCaseResult(object):
         return self.to_str(show_gpu=True)
 
 
-def run(func, args=(), n=10000, *, name=None, n_warmup=10):
+def repeat(func, args=(), n=10000, *, name=None, n_warmup=10):
     if name is None:
         name = func.__name__
 

--- a/cupyx/time.py
+++ b/cupyx/time.py
@@ -39,7 +39,10 @@ class _PerfCaseResult(object):
         return self.to_str(show_gpu=True)
 
 
-def run(name, func, args=(), n=10000, *, n_warmup=10):
+def run(func, args=(), n=10000, *, name=None, n_warmup=10):
+    if name is None:
+        name = func.__name__
+
     ts = numpy.empty((2, n,), dtype=numpy.float64)
     ev1 = cupy.cuda.stream.Event()
     ev2 = cupy.cuda.stream.Event()

--- a/tests/cupyx_tests/test_time.py
+++ b/tests/cupyx_tests/test_time.py
@@ -7,7 +7,7 @@ import cupy
 import cupyx
 
 
-class TestRun(unittest.TestCase):
+class TestRepeat(unittest.TestCase):
 
     def test_cpu_routine(self):
         with mock.patch('time.perf_counter',
@@ -20,7 +20,7 @@ class TestRun(unittest.TestCase):
                 y = cupy.testing.shaped_random((2, 3), cupy, 'int32')
                 assert mock_func.call_count == 0
 
-                perf = cupyx.run(
+                perf = cupyx.time.repeat(
                     mock_func, (x, y), n=10, n_warmup=3)
 
                 assert perf.name == 'test_name_xxx'

--- a/tests/cupyx_tests/test_time.py
+++ b/tests/cupyx_tests/test_time.py
@@ -1,0 +1,65 @@
+import mock
+import unittest
+
+import numpy
+
+import cupy
+import cupyx
+
+
+class TestRun(unittest.TestCase):
+
+    def test_cpu_routine(self):
+        with mock.patch('time.perf_counter',
+                        mock.Mock(side_effect=[2.4, 3.8] * 10)):
+            with mock.patch('cupy.cuda.get_elapsed_time',
+                            mock.Mock(return_value=2500)):
+                mock_func = mock.Mock()
+                x = cupy.testing.shaped_random((2, 3), cupy, 'int32')
+                y = cupy.testing.shaped_random((2, 3), cupy, 'int32')
+                assert mock_func.call_count == 0
+
+                perf = cupyx.run(
+                    'test_name_xxx', mock_func, (x, y), n=10, n_warmup=3)
+
+                assert perf.name == 'test_name_xxx'
+                assert mock_func.call_count == 13
+                assert (perf.cpu_times == 1.4).all()
+                assert (perf.gpu_times == 2.5).all()
+
+
+class TestPerfCaseResult(unittest.TestCase):
+    def test_show_gpu(self):
+        times = numpy.array([
+            [5.4, 7.1, 6.0, 5.4, 4.2],
+            [6.4, 4.3, 8.9, 9.6, 3.8],
+        ]) * 1e-6
+        perf = cupyx.time._PerfCaseResult('test_name_xxx', times)
+        expected = (
+            'test_name_xxx       :'
+            '     5.620 us   +/- 0.943 (min:    4.200 / max:    7.100) us '
+            '     6.600 us   +/- 2.344 (min:    3.800 / max:    9.600) us'
+        )
+        assert str(perf) == expected
+
+    def test_no_show_gpu(self):
+        times = numpy.array([
+            [5.4, 7.1, 6.0, 5.4, 4.2],
+            [6.4, 4.3, 8.9, 9.6, 3.8],
+        ]) * 1e-6
+        perf = cupyx.time._PerfCaseResult('test_name_xxx', times)
+        expected = (
+            'test_name_xxx       :'
+            '     5.620 us   +/- 0.943 (min:    4.200 / max:    7.100) us'
+        )
+        assert perf.to_str() == expected
+
+    def test_single_show_gpu(self):
+        times = numpy.array([[5.4], [6.4]]) * 1e-6
+        perf = cupyx.time._PerfCaseResult('test_name_xxx', times)
+        assert str(perf) == 'test_name_xxx       :     5.400 us      6.400 us'
+
+    def test_single_no_show_gpu(self):
+        times = numpy.array([[5.4], [6.4]]) * 1e-6
+        perf = cupyx.time._PerfCaseResult('test_name_xxx', times)
+        assert perf.to_str() == 'test_name_xxx       :     5.400 us'

--- a/tests/cupyx_tests/test_time.py
+++ b/tests/cupyx_tests/test_time.py
@@ -15,12 +15,13 @@ class TestRun(unittest.TestCase):
             with mock.patch('cupy.cuda.get_elapsed_time',
                             mock.Mock(return_value=2500)):
                 mock_func = mock.Mock()
+                mock_func.__name__ = 'test_name_xxx'
                 x = cupy.testing.shaped_random((2, 3), cupy, 'int32')
                 y = cupy.testing.shaped_random((2, 3), cupy, 'int32')
                 assert mock_func.call_count == 0
 
                 perf = cupyx.run(
-                    'test_name_xxx', mock_func, (x, y), n=10, n_warmup=3)
+                    mock_func, (x, y), n=10, n_warmup=3)
 
                 assert perf.name == 'test_name_xxx'
                 assert mock_func.call_count == 13


### PR DESCRIPTION
I want to officially support some helpers to measure CPU/GPU execution times.

CuPy organization has [cupy-benchmark](https://github.com/cupy/cupy-benchmark) currently, but it is for the maintainers to show users the performance results. I want to support this feature for also external contributors and users.