### PR TITLE
Update thrust::complex headers with a bug fix

### DIFF
--- a/cupy/core/include/cupy/complex.cuh
+++ b/cupy/core/include/cupy/complex.cuh
@@ -29,23 +29,31 @@ __host__ __device__ bool isnan(complex<T> x) {
     return isnan(x.real()) || isnan(x.imag());
 }
 
-template<typename T> __device__ bool isinf(complex<T> x) {
+template<typename T>
+__host__ __device__ bool isinf(complex<T> x) {
     return isinf(x.real()) || isinf(x.imag());
 }
-template<typename T> __device__ bool isfinite(complex<T> x) {
+
+template<typename T>
+__host__ __device__ bool isfinite(complex<T> x) {
     return isfinite(x.real()) && isfinite(x.imag());
 }
 
-template<typename T> __device__ complex<T> log1p(complex<T> x) {
+template<typename T>
+__host__ __device__ complex<T> log1p(complex<T> x) {
     x += 1;
     return log(x);
 }
-template<typename T> __device__ complex<T> log2(complex<T> x) {
+
+template<typename T>
+__host__ __device__ complex<T> log2(complex<T> x) {
     complex<T> y = log(x);
     y /= log(T(2));
     return y;
 }
-template<typename T> __device__ complex<T> expm1(complex<T> x) {
+
+template<typename T>
+__host__ __device__ complex<T> expm1(complex<T> x) {
     complex<T> y = exp(x);
     y -= 1;
     return y;
@@ -85,7 +93,8 @@ __host__ __device__ complex<T> max(complex<T> x, complex<T> y) {
     }
 }
 
-template<typename T> __device__ complex<T> rint(complex<T> x) {
+template<typename T>
+__host__ __device__ complex<T> rint(complex<T> x) {
     return complex<T>(rint(x.real()), rint(x.imag()));
 }
 

--- a/cupy/core/include/cupy/complex/arithmetic.h
+++ b/cupy/core/include/cupy/complex/arithmetic.h
@@ -24,272 +24,260 @@ namespace thrust {
 
 /* --- Binary Arithmetic Operators --- */
 
-template <typename ValueType>
-__device__ inline complex<ValueType> operator+(const complex<ValueType>& lhs,
-                                               const complex<ValueType>& rhs) {
-  return complex<ValueType>(lhs.real() + rhs.real(), lhs.imag() + rhs.imag());
+template <typename T>
+__host__ __device__ inline complex<T> operator+(const complex<T>& lhs,
+                                                const complex<T>& rhs) {
+  return complex<T>(lhs.real() + rhs.real(), lhs.imag() + rhs.imag());
 }
 
-template <typename ValueType>
-__device__ inline complex<ValueType> operator+(
-    const volatile complex<ValueType>& lhs,
-    const volatile complex<ValueType>& rhs) {
-  return complex<ValueType>(lhs.real() + rhs.real(), lhs.imag() + rhs.imag());
+template <typename T>
+__host__ __device__ inline complex<T> operator+(const volatile complex<T>& lhs,
+                                                const volatile complex<T>& rhs) {
+  return complex<T>(lhs.real() + rhs.real(), lhs.imag() + rhs.imag());
 }
 
-template <typename ValueType>
-__device__ inline complex<ValueType> operator+(const complex<ValueType>& lhs,
-                                               const ValueType& rhs) {
-  return complex<ValueType>(lhs.real() + rhs, lhs.imag());
+template <typename T>
+__host__ __device__ inline complex<T> operator+(const complex<T>& lhs,
+                                                const T& rhs) {
+  return complex<T>(lhs.real() + rhs, lhs.imag());
 }
 
-template <typename ValueType>
-__device__ inline complex<ValueType> operator+(const ValueType& lhs,
-                                               const complex<ValueType>& rhs) {
-  return complex<ValueType>(rhs.real() + lhs, rhs.imag());
+template <typename T>
+__host__ __device__ inline complex<T> operator+(const T& lhs,
+                                                const complex<T>& rhs) {
+  return complex<T>(rhs.real() + lhs, rhs.imag());
 }
 
-template <typename ValueType>
-__device__ inline complex<ValueType> operator-(const complex<ValueType>& lhs,
-                                               const complex<ValueType>& rhs) {
-  return complex<ValueType>(lhs.real() - rhs.real(), lhs.imag() - rhs.imag());
+template <typename T>
+__host__ __device__ inline complex<T> operator-(const complex<T>& lhs,
+                                                const complex<T>& rhs) {
+  return complex<T>(lhs.real() - rhs.real(), lhs.imag() - rhs.imag());
 }
 
-template <typename ValueType>
-__device__ inline complex<ValueType> operator-(const complex<ValueType>& lhs,
-                                               const ValueType& rhs) {
-  return complex<ValueType>(lhs.real() - rhs, lhs.imag());
+template <typename T>
+__host__ __device__ inline complex<T> operator-(const complex<T>& lhs,
+                                                const T& rhs) {
+  return complex<T>(lhs.real() - rhs, lhs.imag());
 }
 
-template <typename ValueType>
-__device__ inline complex<ValueType> operator-(const ValueType& lhs,
-                                               const complex<ValueType>& rhs) {
-  return complex<ValueType>(lhs - rhs.real(), -rhs.imag());
+template <typename T>
+__host__ __device__ inline complex<T> operator-(const T& lhs,
+                                                const complex<T>& rhs) {
+  return complex<T>(lhs - rhs.real(), -rhs.imag());
 }
 
-template <typename ValueType>
-__device__ inline complex<ValueType> operator*(const complex<ValueType>& lhs,
-                                               const complex<ValueType>& rhs) {
-  return complex<ValueType>(lhs.real() * rhs.real() - lhs.imag() * rhs.imag(),
+template <typename T>
+__host__ __device__ inline complex<T> operator*(const complex<T>& lhs,
+                                                const complex<T>& rhs) {
+  return complex<T>(lhs.real() * rhs.real() - lhs.imag() * rhs.imag(),
                             lhs.real() * rhs.imag() + lhs.imag() * rhs.real());
 }
 
-template <typename ValueType>
-__device__ inline complex<ValueType> operator*(const complex<ValueType>& lhs,
-                                               const ValueType& rhs) {
-  return complex<ValueType>(lhs.real() * rhs, lhs.imag() * rhs);
+template <typename T>
+__host__ __device__ inline complex<T> operator*(const complex<T>& lhs,
+                                                const T& rhs) {
+  return complex<T>(lhs.real() * rhs, lhs.imag() * rhs);
 }
 
-template <typename ValueType>
-__device__ inline complex<ValueType> operator*(const ValueType& lhs,
-                                               const complex<ValueType>& rhs) {
-  return complex<ValueType>(rhs.real() * lhs, rhs.imag() * lhs);
+template <typename T>
+__host__ __device__ inline complex<T> operator*(const T& lhs,
+                                                const complex<T>& rhs) {
+  return complex<T>(rhs.real() * lhs, rhs.imag() * lhs);
 }
 
-template <typename ValueType>
-__device__ inline complex<ValueType> operator/(const complex<ValueType>& lhs,
-                                               const complex<ValueType>& rhs) {
-  ValueType s = abs(rhs.real()) + abs(rhs.imag());
-  ValueType oos = ValueType(1.0) / s;
-  ValueType ars = lhs.real() * oos;
-  ValueType ais = lhs.imag() * oos;
-  ValueType brs = rhs.real() * oos;
-  ValueType bis = rhs.imag() * oos;
+template <typename T>
+__host__ __device__ inline complex<T> operator/(const complex<T>& lhs,
+                                                const complex<T>& rhs) {
+  T s = abs(rhs.real()) + abs(rhs.imag());
+  T oos = T(1.0) / s;
+  T ars = lhs.real() * oos;
+  T ais = lhs.imag() * oos;
+  T brs = rhs.real() * oos;
+  T bis = rhs.imag() * oos;
   s = (brs * brs) + (bis * bis);
-  oos = ValueType(1.0) / s;
-  complex<ValueType> quot(((ars * brs) + (ais * bis)) * oos,
-                          ((ais * brs) - (ars * bis)) * oos);
+  oos = T(1.0) / s;
+  complex<T> quot(((ars * brs) + (ais * bis)) * oos,
+                  ((ais * brs) - (ars * bis)) * oos);
   return quot;
 }
 
-template <typename ValueType>
-__device__ inline complex<ValueType> operator/(const complex<ValueType>& lhs,
-                                               const ValueType& rhs) {
-  return complex<ValueType>(lhs.real() / rhs, lhs.imag() / rhs);
+template <typename T>
+__host__ __device__ inline complex<T> operator/(const complex<T>& lhs,
+                                                const T& rhs) {
+  return complex<T>(lhs.real() / rhs, lhs.imag() / rhs);
 }
 
-template <typename ValueType>
-__device__ inline complex<ValueType> operator/(const ValueType& lhs,
-                                               const complex<ValueType>& rhs) {
-  return complex<ValueType>(lhs) / rhs;
+template <typename T>
+__host__ __device__ inline complex<T> operator/(const T& lhs,
+                                                const complex<T>& rhs) {
+  return complex<T>(lhs) / rhs;
 }
 
 /* --- Unary comparison with Numpy logic. This means that a + bi > c + di if either
  * a > c or a == c and b > d. --- */
 
-template <typename ValueType>
-__host__ __device__ inline bool operator<(const complex<ValueType>& lhs,
-                                 const complex<ValueType>& rhs) {
-  if (lhs == rhs)
-  {
+template <typename T>
+__host__ __device__ inline bool operator<(const complex<T>& lhs,
+                                          const complex<T>& rhs) {
+  if (lhs == rhs) {
       return false;
-  } else if (lhs.real() < rhs.real())
-  {
+  } else if (lhs.real() < rhs.real()) {
       return true;
-  } else if (lhs.real() == rhs.real())
-  {
+  } else if (lhs.real() == rhs.real()) {
       return lhs.imag() < rhs.imag();
-  } else
-  {
+  } else {
       return false;
   }
 }
 
-template <typename ValueType>
-__host__ __device__ inline bool operator<=(const complex<ValueType>& lhs,
-                                  const complex<ValueType>& rhs) {
-  if (lhs == rhs)
-  {
+template <typename T>
+__host__ __device__ inline bool operator<=(const complex<T>& lhs,
+                                           const complex<T>& rhs) {
+  if (lhs == rhs) {
       return true;
-  } else if (lhs < rhs)
-  {
+  } else if (lhs < rhs) {
       return true;
-  } else
-  {
+  } else {
       return false;
   }
 }
 
-template <typename ValueType>
-__host__ __device__ inline bool operator>(const complex<ValueType>& lhs,
-                                 const complex<ValueType>& rhs) {
-  if (lhs == rhs)
-  {
+template <typename T>
+__host__ __device__ inline bool operator>(const complex<T>& lhs,
+                                          const complex<T>& rhs) {
+  if (lhs == rhs) {
       return false;
-  } else
-  {
+  } else {
       return !(lhs < rhs);
   }
 }
 
-template <typename ValueType>
-__host__ __device__ inline bool operator>=(const complex<ValueType>& lhs,
-                                  const complex<ValueType>& rhs) {
-  if (lhs == rhs || lhs > rhs)
-  {
+template <typename T>
+__host__ __device__ inline bool operator>=(const complex<T>& lhs,
+                                           const complex<T>& rhs) {
+  if (lhs == rhs || lhs > rhs) {
       return true;
-  } else
-  {
+  } else {
       return false;
   }
 }
 
-template <typename ValueType>
-__host__ __device__ inline bool operator<(const ValueType& lhs,
-                                 const complex<ValueType>& rhs) {
-    return complex<ValueType>(lhs) < rhs;
+template <typename T>
+__host__ __device__ inline bool operator<(const T& lhs,
+                                          const complex<T>& rhs) {
+    return complex<T>(lhs) < rhs;
 }
 
-template <typename ValueType>
-__host__ __device__ inline bool operator>(const ValueType& lhs,
-                                 const complex<ValueType>& rhs) {
-    return complex<ValueType>(lhs) > rhs;
+template <typename T>
+__host__ __device__ inline bool operator>(const T& lhs,
+                                          const complex<T>& rhs) {
+    return complex<T>(lhs) > rhs;
 }
 
-template <typename ValueType>
-__host__ __device__ inline bool operator<(const complex<ValueType>& lhs,
-                                 const ValueType& rhs) {
-    return lhs < complex<ValueType>(rhs);
+template <typename T>
+__host__ __device__ inline bool operator<(const complex<T>& lhs,
+                                          const T& rhs) {
+    return lhs < complex<T>(rhs);
 }
 
-template <typename ValueType>
-__host__ __device__ inline bool operator>(const complex<ValueType>& lhs,
-                                 const ValueType& rhs) {
-    return lhs > complex<ValueType>(rhs);
+template <typename T>
+__host__ __device__ inline bool operator>(const complex<T>& lhs,
+                                          const T& rhs) {
+    return lhs > complex<T>(rhs);
 }
 
-template <typename ValueType>
-__host__ __device__ inline bool operator<=(const ValueType& lhs,
-                                  const complex<ValueType>& rhs) {
-    return complex<ValueType>(lhs) <= rhs;
+template <typename T>
+__host__ __device__ inline bool operator<=(const T& lhs,
+                                           const complex<T>& rhs) {
+    return complex<T>(lhs) <= rhs;
 }
 
-template <typename ValueType>
-__host__ __device__ inline bool operator>=(const ValueType& lhs,
-                                  const complex<ValueType>& rhs) {
-    return complex<ValueType>(lhs) >= rhs;
+template <typename T>
+__host__ __device__ inline bool operator>=(const T& lhs,
+                                           const complex<T>& rhs) {
+    return complex<T>(lhs) >= rhs;
 }
 
-template <typename ValueType>
-__host__ __device__ inline bool operator<=(const complex<ValueType>& lhs,
-                                  const ValueType& rhs) {
-    return lhs <= complex<ValueType>(rhs);
+template <typename T>
+__host__ __device__ inline bool operator<=(const complex<T>& lhs,
+                                           const T& rhs) {
+    return lhs <= complex<T>(rhs);
 }
 
-template <typename ValueType>
-__host__ __device__ inline bool operator>=(const complex<ValueType>& lhs,
-                                  const ValueType& rhs) {
-    return lhs >= complex<ValueType>(rhs);
+template <typename T>
+__host__ __device__ inline bool operator>=(const complex<T>& lhs,
+                                           const T& rhs) {
+    return lhs >= complex<T>(rhs);
 }
 
 /* --- Unary Arithmetic Operators --- */
 
-template <typename ValueType>
-__device__ inline complex<ValueType> operator+(const complex<ValueType>& rhs) {
+template <typename T>
+__host__ __device__ inline complex<T> operator+(const complex<T>& rhs) {
   return rhs;
 }
 
-template <typename ValueType>
-__device__ inline complex<ValueType> operator-(const complex<ValueType>& rhs) {
-  return rhs * -ValueType(1);
+template <typename T>
+__host__ __device__ inline complex<T> operator-(const complex<T>& rhs) {
+  return rhs * -T(1);
 }
 
 /* --- Other Basic Arithmetic Functions --- */
 
 // As hypot is only C++11 we have to use the C interface
-template <typename ValueType>
-__device__ inline ValueType abs(const complex<ValueType>& z) {
+template <typename T>
+__host__ __device__ inline T abs(const complex<T>& z) {
   return hypot(z.real(), z.imag());
 }
 
 namespace detail {
 namespace complex {
-__device__ inline float abs(const thrust::complex<float>& z) {
+__host__ __device__ inline float abs(const thrust::complex<float>& z) {
   return hypotf(z.real(), z.imag());
 }
 
-__device__ inline double abs(const thrust::complex<double>& z) {
+__host__ __device__ inline double abs(const thrust::complex<double>& z) {
   return hypot(z.real(), z.imag());
 }
 }
 }
 
 template <>
-__device__ inline float abs(const complex<float>& z) {
+__host__ __device__ inline float abs(const complex<float>& z) {
   return detail::complex::abs(z);
 }
 template <>
-__device__ inline double abs(const complex<double>& z) {
+__host__ __device__ inline double abs(const complex<double>& z) {
   return detail::complex::abs(z);
 }
 
-template <typename ValueType>
-__device__ inline ValueType arg(const complex<ValueType>& z) {
+template <typename T>
+__host__ __device__ inline T arg(const complex<T>& z) {
   return atan2(z.imag(), z.real());
 }
 
-template <typename ValueType>
-__device__ inline complex<ValueType> conj(const complex<ValueType>& z) {
-  return complex<ValueType>(z.real(), -z.imag());
+template <typename T>
+__host__ __device__ inline complex<T> conj(const complex<T>& z) {
+  return complex<T>(z.real(), -z.imag());
 }
 
-template <typename ValueType>
-__device__ inline ValueType real(const complex<ValueType>& z) {
+template <typename T>
+__host__ __device__ inline T real(const complex<T>& z) {
   return z.real();
 }
 
-template <typename ValueType>
-__device__ inline ValueType imag(const complex<ValueType>& z) {
+template <typename T>
+__host__ __device__ inline T imag(const complex<T>& z) {
   return z.imag();
 }
 
-template <typename ValueType>
-__device__ inline ValueType norm(const complex<ValueType>& z) {
+template <typename T>
+__host__ __device__ inline T norm(const complex<T>& z) {
   return z.real() * z.real() + z.imag() * z.imag();
 }
 
 template <>
-__device__ inline float norm(const complex<float>& z) {
+__host__ __device__ inline float norm(const complex<float>& z) {
   if (abs(z.real()) < ::sqrtf(FLT_MIN) && abs(z.imag()) < ::sqrtf(FLT_MIN)) {
     float a = z.real() * 4.0f;
     float b = z.imag() * 4.0f;
@@ -299,7 +287,7 @@ __device__ inline float norm(const complex<float>& z) {
 }
 
 template <>
-__device__ inline double norm(const complex<double>& z) {
+__host__ __device__ inline double norm(const complex<double>& z) {
   if (abs(z.real()) < ::sqrt(DBL_MIN) && abs(z.imag()) < ::sqrt(DBL_MIN)) {
     double a = z.real() * 4.0;
     double b = z.imag() * 4.0;
@@ -308,9 +296,9 @@ __device__ inline double norm(const complex<double>& z) {
   return z.real() * z.real() + z.imag() * z.imag();
 }
 
-template <typename ValueType>
-__device__ inline complex<ValueType> polar(const ValueType& m,
-                                           const ValueType& theta) {
-  return complex<ValueType>(m * cos(theta), m * sin(theta));
+template <typename T>
+__host__ __device__ inline complex<T> polar(const T& m,
+                                           const T& theta) {
+  return complex<T>(m * cos(theta), m * sin(theta));
 }
 }

--- a/cupy/core/include/cupy/complex/arithmetic.h
+++ b/cupy/core/include/cupy/complex/arithmetic.h
@@ -48,6 +48,8 @@ __host__ __device__ inline complex<T> operator+(const T& lhs,
   return complex<T>(rhs.real() + lhs, rhs.imag());
 }
 
+// TODO(leofang): support operator+ for (complex<T0> x, complex<T1> y)
+
 template <typename T>
 __host__ __device__ inline complex<T> operator-(const complex<T>& lhs,
                                                 const complex<T>& rhs) {
@@ -65,6 +67,8 @@ __host__ __device__ inline complex<T> operator-(const T& lhs,
                                                 const complex<T>& rhs) {
   return complex<T>(lhs - rhs.real(), -rhs.imag());
 }
+
+// TODO(leofang): support operator- for (complex<T0> x, complex<T1> y)
 
 template <typename T>
 __host__ __device__ inline complex<T> operator*(const complex<T>& lhs,
@@ -84,6 +88,8 @@ __host__ __device__ inline complex<T> operator*(const T& lhs,
                                                 const complex<T>& rhs) {
   return complex<T>(rhs.real() * lhs, rhs.imag() * lhs);
 }
+
+// TODO(leofang): support operator* for (complex<T0> x, complex<T1> y)
 
 template <typename T>
 __host__ __device__ inline complex<T> operator/(const complex<T>& lhs,
@@ -112,6 +118,8 @@ __host__ __device__ inline complex<T> operator/(const T& lhs,
                                                 const complex<T>& rhs) {
   return complex<T>(lhs) / rhs;
 }
+
+// TODO(leofang): support operator/ for (complex<T0> x, complex<T1> y)
 
 /* --- Unary comparison with Numpy logic. This means that a + bi > c + di if either
  * a > c or a == c and b > d. --- */

--- a/cupy/core/include/cupy/complex/arithmetic.h
+++ b/cupy/core/include/cupy/complex/arithmetic.h
@@ -141,9 +141,7 @@ __host__ __device__ inline bool operator<(const complex<T>& lhs,
 template <typename T>
 __host__ __device__ inline bool operator<=(const complex<T>& lhs,
                                            const complex<T>& rhs) {
-  if (lhs == rhs) {
-      return true;
-  } else if (lhs < rhs) {
+  if (lhs == rhs || lhs < rhs) {
       return true;
   } else {
       return false;
@@ -155,8 +153,12 @@ __host__ __device__ inline bool operator>(const complex<T>& lhs,
                                           const complex<T>& rhs) {
   if (lhs == rhs) {
       return false;
+  } else if (lhs.real() > rhs.real()) {
+      return true;
+  } else if (lhs.real() == rhs.real()) {
+      return lhs.imag() > rhs.imag();
   } else {
-      return !(lhs < rhs);
+      return false;
   }
 }
 

--- a/cupy/core/include/cupy/complex/catrig.h
+++ b/cupy/core/include/cupy/complex/catrig.h
@@ -57,14 +57,14 @@ namespace complex {
 
 using thrust::complex;
 
-__device__ inline void raise_inexact() {
+__host__ __device__ inline void raise_inexact() {
   const volatile float tiny = 7.888609052210118054117286e-31; /* 0x1p-100; */
   // needs the volatile to prevent compiler from ignoring it
   volatile float junk = 1 + tiny;
   (void)junk;
 }
 
-__device__ inline complex<double> clog_for_large_values(complex<double> z);
+__host__ __device__ inline complex<double> clog_for_large_values(complex<double> z);
 
 /*
  * Testing indicates that all these functions are accurate up to 4 ULP.
@@ -133,7 +133,7 @@ __device__ inline complex<double> clog_for_large_values(complex<double> z);
  * Function f(a, b, hypot_a_b) = (hypot(a, b) - b) / 2.
  * Pass hypot(a, b) as the third argument.
  */
-__device__ inline double f(double a, double b, double hypot_a_b) {
+__host__ __device__ inline double f(double a, double b, double hypot_a_b) {
   if (b < 0) return ((hypot_a_b - b) / 2);
   if (b == 0) return (a / 2);
   return (a * a / (hypot_a_b + b) / 2);
@@ -149,7 +149,7 @@ __device__ inline double f(double a, double b, double hypot_a_b) {
  * If returning sqrt_A2my2 has potential to result in an underflow, it is
  * rescaled, and new_y is similarly rescaled.
  */
-__device__ inline void do_hard_work(double x, double y, double* rx,
+__host__ __device__ inline void do_hard_work(double x, double y, double* rx,
                                     int* B_is_usable, double* B,
                                     double* sqrt_A2my2, double* new_y) {
   double R, S, A;  /* A, B, R, and S are as in Hull et al. */
@@ -274,7 +274,7 @@ __device__ inline void do_hard_work(double x, double y, double* rx,
  * Im(casinh(z)) = sign(x)*atan2(sign(x)*y, fabs(x)) + O(y/z^3)
  *    as z -> infinity, uniformly in y
  */
-__device__ inline complex<double> casinh(complex<double> z) {
+__host__ __device__ inline complex<double> casinh(complex<double> z) {
   double x, y, ax, ay, rx, ry, B, sqrt_A2my2, new_y;
   int B_is_usable;
   complex<double> w;
@@ -331,7 +331,7 @@ __device__ inline complex<double> casinh(complex<double> z) {
  * casin(z) = reverse(casinh(reverse(z)))
  * where reverse(x + I*y) = y + I*x = I*conj(z).
  */
-__device__ inline complex<double> casin(complex<double> z) {
+__host__ __device__ inline complex<double> casin(complex<double> z) {
   complex<double> w = casinh(complex<double>(z.imag(), z.real()));
 
   return (complex<double>(w.imag(), w.real()));
@@ -349,7 +349,7 @@ __device__ inline complex<double> casin(complex<double> z) {
  * Re(cacos(z)) = atan2(fabs(y), x) + O(y/z^3)
  *    as z -> infinity, uniformly in y
  */
-__device__ inline complex<double> cacos(complex<double> z) {
+__host__ __device__ inline complex<double> cacos(complex<double> z) {
   double x, y, ax, ay, rx, ry, B, sqrt_A2mx2, new_x;
   int sx, sy;
   int B_is_usable;
@@ -422,7 +422,7 @@ __device__ inline complex<double> cacos(complex<double> z) {
  * cacosh(z) = I*cacos(z) or -I*cacos(z)
  * where the sign is chosen so Re(cacosh(z)) >= 0.
  */
-__device__ inline complex<double> cacosh(complex<double> z) {
+__host__ __device__ inline complex<double> cacosh(complex<double> z) {
   complex<double> w;
   double rx, ry;
 
@@ -442,7 +442,7 @@ __device__ inline complex<double> cacosh(complex<double> z) {
 /*
  * Optimized version of clog() for |z| finite and larger than ~RECIP_EPSILON.
  */
-__device__ inline complex<double> clog_for_large_values(complex<double> z) {
+__host__ __device__ inline complex<double> clog_for_large_values(complex<double> z) {
   double x, y;
   double ax, ay, t;
   const double m_e = 2.7182818284590452e0; /*  0x15bf0a8b145769.0p-51 */
@@ -494,7 +494,7 @@ __device__ inline complex<double> clog_for_large_values(complex<double> z) {
    * Assumes y is non-negative.
    * Assumes fabs(x) >= DBL_EPSILON.
    */
-__device__ inline double sum_squares(double x, double y) {
+__host__ __device__ inline double sum_squares(double x, double y) {
   const double SQRT_MIN =
       1.491668146240041348658193e-154; /* = 0x1p-511; >= sqrt(DBL_MIN) */
   /* Avoid underflow when y is small. */
@@ -512,7 +512,7 @@ __device__ inline double sum_squares(double x, double y) {
  * This is only called in a context where inexact is always raised before
  * the call, so no effort is made to avoid or force inexact.
  */
-__device__ inline double real_part_reciprocal(double x, double y) {
+__host__ __device__ inline double real_part_reciprocal(double x, double y) {
   double scale;
   uint32_t hx, hy;
   int32_t ix, iy;
@@ -556,7 +556,7 @@ __device__ inline double real_part_reciprocal(double x, double y) {
  *    as z -> infinity, uniformly in x
  */
 #if __cplusplus >= 201103L || !defined _MSC_VER
-__device__ inline complex<double> catanh(complex<double> z) {
+__host__ __device__ inline complex<double> catanh(complex<double> z) {
   double x, y, ax, ay, rx, ry;
   const volatile double pio2_lo =
       6.1232339957367659e-17;                  /*  0x11a62633145c07.0p-106 */
@@ -625,7 +625,7 @@ __device__ inline complex<double> catanh(complex<double> z) {
  * catan(z) = reverse(catanh(reverse(z)))
  * where reverse(x + I*y) = y + I*x = I*conj(z).
  */
-__device__ inline complex<double> catan(complex<double> z) {
+__host__ __device__ inline complex<double> catan(complex<double> z) {
   complex<double> w = catanh(complex<double>(z.imag(), z.real()));
   return (complex<double>(w.imag(), w.real()));
 }
@@ -637,26 +637,26 @@ __device__ inline complex<double> catan(complex<double> z) {
 }  // namespace detail
 
 template <typename ValueType>
-__device__ inline complex<ValueType> acos(const complex<ValueType>& z) {
+__host__ __device__ inline complex<ValueType> acos(const complex<ValueType>& z) {
   const complex<ValueType> ret = thrust::asin(z);
   const ValueType pi = ValueType(3.14159265358979323846);
   return complex<ValueType>(pi / 2 - ret.real(), -ret.imag());
 }
 
 template <typename ValueType>
-__device__ inline complex<ValueType> asin(const complex<ValueType>& z) {
+__host__ __device__ inline complex<ValueType> asin(const complex<ValueType>& z) {
   const complex<ValueType> i(0, 1);
   return -i * asinh(i * z);
 }
 
 template <typename ValueType>
-__device__ inline complex<ValueType> atan(const complex<ValueType>& z) {
+__host__ __device__ inline complex<ValueType> atan(const complex<ValueType>& z) {
   const complex<ValueType> i(0, 1);
   return -i * thrust::atanh(i * z);
 }
 
 template <typename ValueType>
-__device__ inline complex<ValueType> acosh(const complex<ValueType>& z) {
+__host__ __device__ inline complex<ValueType> acosh(const complex<ValueType>& z) {
   thrust::complex<ValueType> ret(
       (z.real() - z.imag()) * (z.real() + z.imag()) - ValueType(1.0),
       ValueType(2.0) * z.real() * z.imag());
@@ -673,12 +673,12 @@ __device__ inline complex<ValueType> acosh(const complex<ValueType>& z) {
 }
 
 template <typename ValueType>
-__device__ inline complex<ValueType> asinh(const complex<ValueType>& z) {
+__host__ __device__ inline complex<ValueType> asinh(const complex<ValueType>& z) {
   return thrust::log(thrust::sqrt(z * z + ValueType(1)) + z);
 }
 
 template <typename ValueType>
-__device__ inline complex<ValueType> atanh(const complex<ValueType>& z) {
+__host__ __device__ inline complex<ValueType> atanh(const complex<ValueType>& z) {
   ValueType imag2 = z.imag() * z.imag();
   ValueType n = ValueType(1.0) + z.real();
   n = imag2 + n * n;
@@ -694,35 +694,35 @@ __device__ inline complex<ValueType> atanh(const complex<ValueType>& z) {
 }
 
 template <>
-__device__ inline complex<double> acos(const complex<double>& z) {
+__host__ __device__ inline complex<double> acos(const complex<double>& z) {
   return detail::complex::cacos(z);
 }
 
 template <>
-__device__ inline complex<double> asin(const complex<double>& z) {
+__host__ __device__ inline complex<double> asin(const complex<double>& z) {
   return detail::complex::casin(z);
 }
 
 #if __cplusplus >= 201103L || !defined _MSC_VER
 template <>
-__device__ inline complex<double> atan(const complex<double>& z) {
+__host__ __device__ inline complex<double> atan(const complex<double>& z) {
   return detail::complex::catan(z);
 }
 #endif
 
 template <>
-__device__ inline complex<double> acosh(const complex<double>& z) {
+__host__ __device__ inline complex<double> acosh(const complex<double>& z) {
   return detail::complex::cacosh(z);
 }
 
 template <>
-__device__ inline complex<double> asinh(const complex<double>& z) {
+__host__ __device__ inline complex<double> asinh(const complex<double>& z) {
   return detail::complex::casinh(z);
 }
 
 #if __cplusplus >= 201103L || !defined _MSC_VER
 template <>
-__device__ inline complex<double> atanh(const complex<double>& z) {
+__host__ __device__ inline complex<double> atanh(const complex<double>& z) {
   return detail::complex::catanh(z);
 }
 #endif

--- a/cupy/core/include/cupy/complex/catrigf.h
+++ b/cupy/core/include/cupy/complex/catrigf.h
@@ -58,7 +58,7 @@ namespace complex {
 
 using thrust::complex;
 
-__device__ inline complex<float> clog_for_large_values(complex<float> z);
+__host__ __device__ inline complex<float> clog_for_large_values(complex<float> z);
 
 /*
  * The algorithm is very close to that in "Implementing the complex arcsine
@@ -74,7 +74,7 @@ __device__ inline complex<float> clog_for_large_values(complex<float> z);
  * a few comments on the right of declarations remain.
  */
 
-__device__ inline float f(float a, float b, float hypot_a_b) {
+__host__ __device__ inline float f(float a, float b, float hypot_a_b) {
   if (b < 0.0f) return ((hypot_a_b - b) / 2.0f);
   if (b == 0.0f) return (a / 2.0f);
   return (a * a / (hypot_a_b + b) / 2.0f);
@@ -90,9 +90,9 @@ __device__ inline float f(float a, float b, float hypot_a_b) {
  * If returning sqrt_A2my2 has potential to result in an underflow, it is
  * rescaled, and new_y is similarly rescaled.
  */
-__device__ inline void do_hard_work(float x, float y, float* rx,
-                                    int* B_is_usable, float* B,
-                                    float* sqrt_A2my2, float* new_y) {
+__host__ __device__ inline void do_hard_work(float x, float y, float* rx,
+                                             int* B_is_usable, float* B,
+                                             float* sqrt_A2my2, float* new_y) {
   float R, S, A;  /* A, B, R, and S are as in Hull et al. */
   float Am1, Amy; /* A-1, A-y. */
   const float A_crossover =
@@ -150,7 +150,7 @@ __device__ inline void do_hard_work(float x, float y, float* rx,
   }
 }
 
-__device__ inline complex<float> casinhf(complex<float> z) {
+__host__ __device__ inline complex<float> casinhf(complex<float> z) {
   float x, y, ax, ay, rx, ry, B, sqrt_A2my2, new_y;
   int B_is_usable;
   complex<float> w;
@@ -191,13 +191,13 @@ __device__ inline complex<float> casinhf(complex<float> z) {
   return (complex<float>(copysignf(rx, x), copysignf(ry, y)));
 }
 
-__device__ inline complex<float> casinf(complex<float> z) {
+__host__ __device__ inline complex<float> casinf(complex<float> z) {
   complex<float> w = casinhf(complex<float>(z.imag(), z.real()));
 
   return (complex<float>(w.imag(), w.real()));
 }
 
-__device__ inline complex<float> cacosf(complex<float> z) {
+__host__ __device__ inline complex<float> cacosf(complex<float> z) {
   float x, y, ax, ay, rx, ry, B, sqrt_A2mx2, new_x;
   int sx, sy;
   int B_is_usable;
@@ -254,7 +254,7 @@ __device__ inline complex<float> cacosf(complex<float> z) {
   return (complex<float>(rx, ry));
 }
 
-__device__ inline complex<float> cacoshf(complex<float> z) {
+__host__ __device__ inline complex<float> cacoshf(complex<float> z) {
   complex<float> w;
   float rx, ry;
 
@@ -274,7 +274,7 @@ __device__ inline complex<float> cacoshf(complex<float> z) {
 /*
  * Optimized version of clog() for |z| finite and larger than ~RECIP_EPSILON.
  */
-__device__ inline complex<float> clog_for_large_values(complex<float> z) {
+__host__ __device__ inline complex<float> clog_for_large_values(complex<float> z) {
   float x, y;
   float ax, ay, t;
   const float m_e = 2.7182818284590452e0f; /*  0x15bf0a8b145769.0p-51 */
@@ -315,7 +315,7 @@ __device__ inline complex<float> clog_for_large_values(complex<float> z) {
  * Assumes y is non-negative.
  * Assumes fabsf(x) >= FLT_EPSILON.
  */
-__device__ inline float sum_squares(float x, float y) {
+__host__ __device__ inline float sum_squares(float x, float y) {
   const float SQRT_MIN =
       1.084202172485504434007453e-19f; /* 0x1p-63; >= sqrt(FLT_MIN) */
   /* Avoid underflow when y is small. */
@@ -324,7 +324,7 @@ __device__ inline float sum_squares(float x, float y) {
   return (x * x + y * y);
 }
 
-__device__ inline float real_part_reciprocal(float x, float y) {
+__host__ __device__ inline float real_part_reciprocal(float x, float y) {
   float scale;
   uint32_t hx, hy;
   int32_t ix, iy;
@@ -348,7 +348,7 @@ __device__ inline float real_part_reciprocal(float x, float y) {
 }
 
 #if __cplusplus >= 201103L || !defined _MSC_VER
-__device__ inline complex<float> catanhf(complex<float> z) {
+__host__ __device__ inline complex<float> catanhf(complex<float> z) {
   float x, y, ax, ay, rx, ry;
   const volatile float pio2_lo =
       6.1232339957367659e-17;                 /*  0x11a62633145c07.0p-106 */
@@ -397,7 +397,7 @@ __device__ inline complex<float> catanhf(complex<float> z) {
   return (complex<float>(copysignf(rx, x), copysignf(ry, y)));
 }
 
-__device__ inline complex<float> catanf(complex<float> z) {
+__host__ __device__ inline complex<float> catanf(complex<float> z) {
   complex<float> w = catanhf(complex<float>(z.imag(), z.real()));
   return (complex<float>(w.imag(), w.real()));
 }
@@ -408,35 +408,35 @@ __device__ inline complex<float> catanf(complex<float> z) {
 }  // namespace detail
 
 template <>
-__device__ inline complex<float> acos(const complex<float>& z) {
+__host__ __device__ inline complex<float> acos(const complex<float>& z) {
   return detail::complex::cacosf(z);
 }
 
 template <>
-__device__ inline complex<float> asin(const complex<float>& z) {
+__host__ __device__ inline complex<float> asin(const complex<float>& z) {
   return detail::complex::casinf(z);
 }
 
 #if __cplusplus >= 201103L || !defined _MSC_VER
 template <>
-__device__ inline complex<float> atan(const complex<float>& z) {
+__host__ __device__ inline complex<float> atan(const complex<float>& z) {
   return detail::complex::catanf(z);
 }
 #endif
 
 template <>
-__device__ inline complex<float> acosh(const complex<float>& z) {
+__host__ __device__ inline complex<float> acosh(const complex<float>& z) {
   return detail::complex::cacoshf(z);
 }
 
 template <>
-__device__ inline complex<float> asinh(const complex<float>& z) {
+__host__ __device__ inline complex<float> asinh(const complex<float>& z) {
   return detail::complex::casinhf(z);
 }
 
 #if __cplusplus >= 201103L || !defined _MSC_VER
 template <>
-__device__ inline complex<float> atanh(const complex<float>& z) {
+__host__ __device__ inline complex<float> atanh(const complex<float>& z) {
   return detail::complex::catanhf(z);
 }
 #endif

--- a/cupy/core/include/cupy/complex/ccosh.h
+++ b/cupy/core/include/cupy/complex/ccosh.h
@@ -64,7 +64,7 @@ namespace complex {
  * These values and the return value were taken from n1124.pdf.
  */
 
-__device__ inline thrust::complex<double> ccosh(
+__host__ __device__ inline thrust::complex<double> ccosh(
     const thrust::complex<double>& z) {
   const double huge = 8.98846567431157953864652595395e+307;  // 0x1p1023
   double x, y, h;
@@ -166,7 +166,7 @@ __device__ inline thrust::complex<double> ccosh(
   return (thrust::complex<double>((x * x) * (y - y), (x + x) * (y - y)));
 }
 
-__device__ inline thrust::complex<double> ccos(
+__host__ __device__ inline thrust::complex<double> ccos(
     const thrust::complex<double>& z) {
   /* ccos(z) = ccosh(I * z) */
   return (ccosh(thrust::complex<double>(-z.imag(), z.real())));
@@ -177,27 +177,27 @@ __device__ inline thrust::complex<double> ccos(
 }  // namespace detail
 
 template <typename ValueType>
-__device__ inline complex<ValueType> cos(const complex<ValueType>& z) {
+__host__ __device__ inline complex<ValueType> cos(const complex<ValueType>& z) {
   const ValueType re = z.real();
   const ValueType im = z.imag();
   return complex<ValueType>(::cos(re) * ::cosh(im), -::sin(re) * ::sinh(im));
 }
 
 template <typename ValueType>
-__device__ inline complex<ValueType> cosh(const complex<ValueType>& z) {
+__host__ __device__ inline complex<ValueType> cosh(const complex<ValueType>& z) {
   const ValueType re = z.real();
   const ValueType im = z.imag();
   return complex<ValueType>(::cosh(re) * ::cos(im), ::sinh(re) * ::sin(im));
 }
 
 template <>
-__device__ inline thrust::complex<double> cos(
+__host__ __device__ inline thrust::complex<double> cos(
     const thrust::complex<double>& z) {
   return detail::complex::ccos(z);
 }
 
 template <>
-__device__ inline thrust::complex<double> cosh(
+__host__ __device__ inline thrust::complex<double> cosh(
     const thrust::complex<double>& z) {
   return detail::complex::ccosh(z);
 }

--- a/cupy/core/include/cupy/complex/ccoshf.h
+++ b/cupy/core/include/cupy/complex/ccoshf.h
@@ -57,7 +57,7 @@ namespace complex {
 
 using thrust::complex;
 
-__device__ inline complex<float> ccoshf(const complex<float>& z) {
+__host__ __device__ inline complex<float> ccoshf(const complex<float>& z) {
   float x, y, h;
   uint32_t hx, hy, ix, iy;
   const float huge = 1.70141183460469231731687303716e+38;  // 0x1p127;
@@ -114,7 +114,7 @@ __device__ inline complex<float> ccoshf(const complex<float>& z) {
   return (complex<float>((x * x) * (y - y), (x + x) * (y - y)));
 }
 
-__device__ inline complex<float> ccosf(const complex<float>& z) {
+__host__ __device__ inline complex<float> ccosf(const complex<float>& z) {
   return (ccoshf(complex<float>(-z.imag(), z.real())));
 }
 
@@ -123,12 +123,12 @@ __device__ inline complex<float> ccosf(const complex<float>& z) {
 }  // namespace detail
 
 template <>
-__device__ inline complex<float> cos(const complex<float>& z) {
+__host__ __device__ inline complex<float> cos(const complex<float>& z) {
   return detail::complex::ccosf(z);
 }
 
 template <>
-__device__ inline complex<float> cosh(const complex<float>& z) {
+__host__ __device__ inline complex<float> cosh(const complex<float>& z) {
   return detail::complex::ccoshf(z);
 }
 

--- a/cupy/core/include/cupy/complex/cexp.h
+++ b/cupy/core/include/cupy/complex/cexp.h
@@ -63,7 +63,7 @@ namespace complex {
  * Input:  ln(DBL_MAX) <= x < ln(2 * DBL_MAX / DBL_MIN_DENORM) ~= 1454.91
  * Output: 2**1023 <= y < 2**1024
  */
-__device__ inline double frexp_exp(double x, int* expt) {
+__host__ __device__ inline double frexp_exp(double x, int* expt) {
   const uint32_t k = 1799;                    /* constant for reduction */
   const double kln2 = 1246.97177782734161156; /* k * ln2 */
 
@@ -83,7 +83,7 @@ __device__ inline double frexp_exp(double x, int* expt) {
   return (exp_x);
 }
 
-__device__ inline complex<double> ldexp_cexp(complex<double> z, int expt) {
+__host__ __device__ inline complex<double> ldexp_cexp(complex<double> z, int expt) {
   double x, y, exp_x, scale1, scale2;
   int ex_expt, half_expt;
 
@@ -105,7 +105,7 @@ __device__ inline complex<double> ldexp_cexp(complex<double> z, int expt) {
                           ::sin(y) * exp_x * scale1 * scale2));
 }
 
-__device__ inline complex<double> cexp(const complex<double>& z) {
+__host__ __device__ inline complex<double> cexp(const complex<double>& z) {
   double x, y, exp_x;
   uint32_t hx, hy, lx, ly;
 
@@ -161,12 +161,12 @@ __device__ inline complex<double> cexp(const complex<double>& z) {
 }  // namespace detail
 
 template <typename ValueType>
-__device__ inline complex<ValueType> exp(const complex<ValueType>& z) {
+__host__ __device__ inline complex<ValueType> exp(const complex<ValueType>& z) {
   return polar(::exp(z.real()), z.imag());
 }
 
 template <>
-__device__ inline complex<double> exp(const complex<double>& z) {
+__host__ __device__ inline complex<double> exp(const complex<double>& z) {
   return detail::complex::cexp(z);
 }
 

--- a/cupy/core/include/cupy/complex/cexpf.h
+++ b/cupy/core/include/cupy/complex/cexpf.h
@@ -56,7 +56,7 @@ namespace thrust {
 namespace detail {
 namespace complex {
 
-__device__ inline float frexp_expf(float x, int* expt) {
+__host__ __device__ inline float frexp_expf(float x, int* expt) {
   const uint32_t k = 235;           /* constant for reduction */
   const float kln2 = 162.88958740F; /* k * ln2 */
 
@@ -71,7 +71,7 @@ __device__ inline float frexp_expf(float x, int* expt) {
   return (exp_x);
 }
 
-__device__ inline complex<float> ldexp_cexpf(complex<float> z, int expt) {
+__host__ __device__ inline complex<float> ldexp_cexpf(complex<float> z, int expt) {
   float x, y, exp_x, scale1, scale2;
   int ex_expt, half_expt;
 
@@ -89,7 +89,7 @@ __device__ inline complex<float> ldexp_cexpf(complex<float> z, int expt) {
                          sin(y) * exp_x * scale1 * scale2));
 }
 
-__device__ inline complex<float> cexpf(const complex<float>& z) {
+__host__ __device__ inline complex<float> cexpf(const complex<float>& z) {
   float x, y, exp_x;
   uint32_t hx, hy;
 
@@ -146,7 +146,7 @@ __device__ inline complex<float> cexpf(const complex<float>& z) {
 }  // namespace detail
 
 template <>
-__device__ inline complex<float> exp(const complex<float>& z) {
+__host__ __device__ inline complex<float> exp(const complex<float>& z) {
   return detail::complex::cexpf(z);
 }
 

--- a/cupy/core/include/cupy/complex/clog.h
+++ b/cupy/core/include/cupy/complex/clog.h
@@ -55,14 +55,14 @@ namespace complex {
 using thrust::complex;
 
 /* round down to 18 = 54/3 bits */
-__device__ inline double trim(double x) {
+__host__ __device__ inline double trim(double x) {
   uint32_t hi;
   get_high_word(hi, x);
   insert_words(x, hi & 0xfffffff8, 0);
   return x;
 }
 
-__device__ inline complex<double> clog(const complex<double>& z) {
+__host__ __device__ inline complex<double> clog(const complex<double>& z) {
   // Adapted from FreeBSDs msun
   double x, y;
   double ax, ay;
@@ -184,17 +184,17 @@ __device__ inline complex<double> clog(const complex<double>& z) {
 }  // namespace detail
 
 template <typename ValueType>
-__device__ inline complex<ValueType> log(const complex<ValueType>& z) {
+__host__ __device__ inline complex<ValueType> log(const complex<ValueType>& z) {
   return complex<ValueType>(::log(thrust::abs(z)), thrust::arg(z));
 }
 
 template <>
-__device__ inline complex<double> log(const complex<double>& z) {
+__host__ __device__ inline complex<double> log(const complex<double>& z) {
   return detail::complex::clog(z);
 }
 
 template <typename ValueType>
-__device__ inline complex<ValueType> log10(const complex<ValueType>& z) {
+__host__ __device__ inline complex<ValueType> log10(const complex<ValueType>& z) {
   // Using the explicit literal prevents compile time warnings in
   // devices that don't support doubles
   return thrust::log(z) / ValueType(2.30258509299404568402);

--- a/cupy/core/include/cupy/complex/clogf.h
+++ b/cupy/core/include/cupy/complex/clogf.h
@@ -55,7 +55,7 @@ namespace complex {
 using thrust::complex;
 
 /* round down to 8 = 24/3 bits */
-__device__ inline float trim(float x) {
+__host__ __device__ inline float trim(float x) {
   uint32_t hx;
   get_float_word(hx, x);
   hx &= 0xffff0000;
@@ -64,7 +64,7 @@ __device__ inline float trim(float x) {
   return ret;
 }
 
-__device__ inline complex<float> clogf(const complex<float>& z) {
+__host__ __device__ inline complex<float> clogf(const complex<float>& z) {
   // Adapted from FreeBSDs msun
   float x, y;
   float ax, ay;
@@ -185,7 +185,7 @@ __device__ inline complex<float> clogf(const complex<float>& z) {
 }  // namespace detail
 
 template <>
-__device__ inline complex<float> log(const complex<float>& z) {
+__host__ __device__ inline complex<float> log(const complex<float>& z) {
   return detail::complex::clogf(z);
 }
 

--- a/cupy/core/include/cupy/complex/complex.h
+++ b/cupy/core/include/cupy/complex/complex.h
@@ -183,42 +183,42 @@ struct complex {
  *  \param z The \p complex from which to calculate the absolute value.
  */
 template <typename T>
-__device__ inline T abs(const complex<T>& z);
+__host__ __device__ inline T abs(const complex<T>& z);
 
 /*! Returns the phase angle (also known as argument) in radians of a \p complex.
  *
  *  \param z The \p complex from which to calculate the phase angle.
  */
 template <typename T>
-__device__ inline T arg(const complex<T>& z);
+__host__ __device__ inline T arg(const complex<T>& z);
 
 /*! Returns the square of the magnitude of a \p complex.
  *
  *  \param z The \p complex from which to calculate the norm.
  */
 template <typename T>
-__device__ inline T norm(const complex<T>& z);
+__host__ __device__ inline T norm(const complex<T>& z);
 
 /*! Returns the complex conjugate of a \p complex.
  *
  *  \param z The \p complex from which to calculate the complex conjugate.
  */
 template <typename T>
-__device__ inline complex<T> conj(const complex<T>& z);
+__host__ __device__ inline complex<T> conj(const complex<T>& z);
 
 /*! Returns the real part of a \p complex.
  *
  *  \param z The \p complex from which to return the real part
  */
 template <typename T>
-__device__ inline T real(const complex<T>& z);
+__host__ __device__ inline T real(const complex<T>& z);
 
 /*! Returns the imaginary part of a \p complex.
  *
  *  \param z The \p complex from which to return the imaginary part
  */
 template <typename T>
-__device__ inline T imag(const complex<T>& z);
+__host__ __device__ inline T imag(const complex<T>& z);
 
 /*! Returns a \p complex with the specified magnitude and phase.
  *
@@ -226,7 +226,7 @@ __device__ inline T imag(const complex<T>& z);
  *  \param theta The phase of the returned \p complex in radians.
  */
 template <typename T>
-__device__ inline complex<T> polar(const T& m, const T& theta = 0);
+__host__ __device__ inline complex<T> polar(const T& m, const T& theta = 0);
 
 /*! Returns the projection of a \p complex on the Riemann sphere.
  *  For all finite \p complex it returns the argument. For \p complexs
@@ -236,7 +236,7 @@ __device__ inline complex<T> polar(const T& m, const T& theta = 0);
  *  \param z The \p complex argument.
  */
 template <typename T>
-__device__ inline complex<T> proj(const T& z);
+__host__ __device__ inline complex<T> proj(const T& z);
 
 /* --- Binary Arithmetic operators --- */
 
@@ -246,7 +246,7 @@ __device__ inline complex<T> proj(const T& z);
  *  \param rhs The second \p complex.
  */
 template <typename T>
-__device__ inline complex<T> operator*(const complex<T>& lhs,
+__host__ __device__ inline complex<T> operator*(const complex<T>& lhs,
                                        const complex<T>& rhs);
 
 /*! Multiplies a \p complex number by a scalar.
@@ -255,7 +255,7 @@ __device__ inline complex<T> operator*(const complex<T>& lhs,
  *  \param rhs The scalar.
  */
 template <typename T>
-__device__ inline complex<T> operator*(const complex<T>& lhs, const T& rhs);
+__host__ __device__ inline complex<T> operator*(const complex<T>& lhs, const T& rhs);
 
 /*! Multiplies a scalar by a \p complex number.
  *
@@ -263,7 +263,7 @@ __device__ inline complex<T> operator*(const complex<T>& lhs, const T& rhs);
  *  \param rhs The \p complex.
  */
 template <typename T>
-__device__ inline complex<T> operator*(const T& lhs, const complex<T>& rhs);
+__host__ __device__ inline complex<T> operator*(const T& lhs, const complex<T>& rhs);
 
 /*! Divides two \p complex numbers.
  *
@@ -271,7 +271,7 @@ __device__ inline complex<T> operator*(const T& lhs, const complex<T>& rhs);
  *  \param rhs The denomimator (divisor).
  */
 template <typename T>
-__device__ inline complex<T> operator/(const complex<T>& lhs,
+__host__ __device__ inline complex<T> operator/(const complex<T>& lhs,
                                        const complex<T>& rhs);
 
 /*! Divides a \p complex number by a scalar.
@@ -280,7 +280,7 @@ __device__ inline complex<T> operator/(const complex<T>& lhs,
  *  \param rhs The scalar denomimator (divisor).
  */
 template <typename T>
-__device__ inline complex<T> operator/(const complex<T>& lhs, const T& rhs);
+__host__ __device__ inline complex<T> operator/(const complex<T>& lhs, const T& rhs);
 
 /*! Divides a scalar by a \p complex number.
  *
@@ -288,7 +288,7 @@ __device__ inline complex<T> operator/(const complex<T>& lhs, const T& rhs);
  *  \param rhs The complex denomimator (divisor).
  */
 template <typename T>
-__device__ inline complex<T> operator/(const T& lhs, const complex<T>& rhs);
+__host__ __device__ inline complex<T> operator/(const T& lhs, const complex<T>& rhs);
 
 /*! Adds two \p complex numbers.
  *
@@ -296,7 +296,7 @@ __device__ inline complex<T> operator/(const T& lhs, const complex<T>& rhs);
  *  \param rhs The second \p complex.
  */
 template <typename T>
-__device__ inline complex<T> operator+(const complex<T>& lhs,
+__host__ __device__ inline complex<T> operator+(const complex<T>& lhs,
                                        const complex<T>& rhs);
 
 /*! Adds a scalar to a \p complex number.
@@ -305,7 +305,7 @@ __device__ inline complex<T> operator+(const complex<T>& lhs,
  *  \param rhs The scalar.
  */
 template <typename T>
-__device__ inline complex<T> operator+(const complex<T>& lhs, const T& rhs);
+__host__ __device__ inline complex<T> operator+(const complex<T>& lhs, const T& rhs);
 
 /*! Adds a \p complex number to a scalar.
  *
@@ -313,7 +313,7 @@ __device__ inline complex<T> operator+(const complex<T>& lhs, const T& rhs);
  *  \param rhs The \p complex.
  */
 template <typename T>
-__device__ inline complex<T> operator+(const T& lhs, const complex<T>& rhs);
+__host__ __device__ inline complex<T> operator+(const T& lhs, const complex<T>& rhs);
 
 /*! Subtracts two \p complex numbers.
  *
@@ -321,7 +321,7 @@ __device__ inline complex<T> operator+(const T& lhs, const complex<T>& rhs);
  *  \param rhs The second \p complex (subtrahend).
  */
 template <typename T>
-__device__ inline complex<T> operator-(const complex<T>& lhs,
+__host__ __device__ inline complex<T> operator-(const complex<T>& lhs,
                                        const complex<T>& rhs);
 
 /*! Subtracts a scalar from a \p complex number.
@@ -330,7 +330,7 @@ __device__ inline complex<T> operator-(const complex<T>& lhs,
  *  \param rhs The scalar (subtrahend).
  */
 template <typename T>
-__device__ inline complex<T> operator-(const complex<T>& lhs, const T& rhs);
+__host__ __device__ inline complex<T> operator-(const complex<T>& lhs, const T& rhs);
 
 /*! Subtracts a \p complex number from a scalar.
  *
@@ -338,7 +338,7 @@ __device__ inline complex<T> operator-(const complex<T>& lhs, const T& rhs);
  *  \param rhs The \p complex (subtrahend).
  */
 template <typename T>
-__device__ inline complex<T> operator-(const T& lhs, const complex<T>& rhs);
+__host__ __device__ inline complex<T> operator-(const T& lhs, const complex<T>& rhs);
 
 /* --- Unary Arithmetic operators --- */
 
@@ -347,7 +347,7 @@ __device__ inline complex<T> operator-(const T& lhs, const complex<T>& rhs);
  *  \param rhs The \p complex argument.
  */
 template <typename T>
-__device__ inline complex<T> operator+(const complex<T>& rhs);
+__host__ __device__ inline complex<T> operator+(const complex<T>& rhs);
 
 /*! Unary minus, returns the additive inverse (negation) of its \p complex
  * argument.
@@ -355,7 +355,7 @@ __device__ inline complex<T> operator+(const complex<T>& rhs);
  *  \param rhs The \p complex argument.
  */
 template <typename T>
-__device__ inline complex<T> operator-(const complex<T>& rhs);
+__host__ __device__ inline complex<T> operator-(const complex<T>& rhs);
 
 /* --- Exponential Functions --- */
 
@@ -364,21 +364,21 @@ __device__ inline complex<T> operator-(const complex<T>& rhs);
  *  \param z The \p complex argument.
  */
 template <typename T>
-__device__ complex<T> exp(const complex<T>& z);
+__host__ __device__ complex<T> exp(const complex<T>& z);
 
 /*! Returns the complex natural logarithm of a \p complex number.
  *
  *  \param z The \p complex argument.
  */
 template <typename T>
-__device__ complex<T> log(const complex<T>& z);
+__host__ __device__ complex<T> log(const complex<T>& z);
 
 /*! Returns the complex base 10 logarithm of a \p complex number.
  *
  *  \param z The \p complex argument.
  */
 template <typename T>
-__device__ inline complex<T> log10(const complex<T>& z);
+__host__ __device__ inline complex<T> log10(const complex<T>& z);
 
 /* --- Power Functions --- */
 
@@ -388,7 +388,7 @@ __device__ inline complex<T> log10(const complex<T>& z);
  *  \param y The exponent.
  */
 template <typename T>
-__device__ complex<T> pow(const complex<T>& x, const complex<T>& y);
+__host__ __device__ complex<T> pow(const complex<T>& x, const complex<T>& y);
 
 /*! Returns a \p complex number raised to a scalar.
  *
@@ -396,7 +396,7 @@ __device__ complex<T> pow(const complex<T>& x, const complex<T>& y);
  *  \param y The scalar exponent.
  */
 template <typename T>
-__device__ complex<T> pow(const complex<T>& x, const T& y);
+__host__ __device__ complex<T> pow(const complex<T>& x, const T& y);
 
 /*! Returns a scalar raised to a \p complex number.
  *
@@ -404,7 +404,7 @@ __device__ complex<T> pow(const complex<T>& x, const T& y);
  *  \param y The \p complex exponent.
  */
 template <typename T>
-__device__ complex<T> pow(const T& x, const complex<T>& y);
+__host__ __device__ complex<T> pow(const T& x, const complex<T>& y);
 
 /*! Returns a \p complex number raised to another. The types of the two \p
  * complex should be compatible
@@ -415,7 +415,7 @@ __device__ complex<T> pow(const T& x, const complex<T>& y);
  *  \param y The exponent.
  */
 template <typename T, typename U>
-__device__ complex<typename _select_greater_type<T, U>::type> pow(
+__host__ __device__ complex<typename _select_greater_type<T, U>::type> pow(
     const complex<T>& x, const complex<U>& y);
 
 /*! Returns a \p complex number raised to a scalar. The type of the \p complex
@@ -427,7 +427,7 @@ __device__ complex<typename _select_greater_type<T, U>::type> pow(
  *  \param y The exponent.
  */
 template <typename T, typename U>
-__device__ complex<typename _select_greater_type<T, U>::type> pow(
+__host__ __device__ complex<typename _select_greater_type<T, U>::type> pow(
     const complex<T>& x, const U& y);
 
 /*! Returns a scalar raised to a \p complex number. The type of the \p complex
@@ -439,7 +439,7 @@ __device__ complex<typename _select_greater_type<T, U>::type> pow(
  *  \param y The exponent.
  */
 template <typename T, typename U>
-__device__ complex<typename _select_greater_type<T, U>::type> pow(
+__host__ __device__ complex<typename _select_greater_type<T, U>::type> pow(
     const T& x, const complex<U>& y);
 
 /*! Returns the complex square root of a \p complex number.
@@ -447,7 +447,7 @@ __device__ complex<typename _select_greater_type<T, U>::type> pow(
  *  \param z The \p complex argument.
  */
 template <typename T>
-__device__ complex<T> sqrt(const complex<T>& z);
+__host__ __device__ complex<T> sqrt(const complex<T>& z);
 
 /* --- Trigonometric Functions --- */
 
@@ -456,21 +456,21 @@ __device__ complex<T> sqrt(const complex<T>& z);
  *  \param z The \p complex argument.
  */
 template <typename T>
-__device__ complex<T> cos(const complex<T>& z);
+__host__ __device__ complex<T> cos(const complex<T>& z);
 
 /*! Returns the complex sine of a \p complex number.
  *
  *  \param z The \p complex argument.
  */
 template <typename T>
-__device__ complex<T> sin(const complex<T>& z);
+__host__ __device__ complex<T> sin(const complex<T>& z);
 
 /*! Returns the complex tangent of a \p complex number.
  *
  *  \param z The \p complex argument.
  */
 template <typename T>
-__device__ complex<T> tan(const complex<T>& z);
+__host__ __device__ complex<T> tan(const complex<T>& z);
 
 /* --- Hyperbolic Functions --- */
 
@@ -479,21 +479,21 @@ __device__ complex<T> tan(const complex<T>& z);
  *  \param z The \p complex argument.
  */
 template <typename T>
-__device__ complex<T> cosh(const complex<T>& z);
+__host__ __device__ complex<T> cosh(const complex<T>& z);
 
 /*! Returns the complex hyperbolic sine of a \p complex number.
  *
  *  \param z The \p complex argument.
  */
 template <typename T>
-__device__ complex<T> sinh(const complex<T>& z);
+__host__ __device__ complex<T> sinh(const complex<T>& z);
 
 /*! Returns the complex hyperbolic tangent of a \p complex number.
  *
  *  \param z The \p complex argument.
  */
 template <typename T>
-__device__ complex<T> tanh(const complex<T>& z);
+__host__ __device__ complex<T> tanh(const complex<T>& z);
 
 /* --- Inverse Trigonometric Functions --- */
 
@@ -505,7 +505,7 @@ __device__ complex<T> tanh(const complex<T>& z);
  *  \param z The \p complex argument.
  */
 template <typename T>
-__device__ complex<T> acos(const complex<T>& z);
+__host__ __device__ complex<T> acos(const complex<T>& z);
 
 /*! Returns the complex arc sine of a \p complex number.
  *
@@ -515,7 +515,7 @@ __device__ complex<T> acos(const complex<T>& z);
  *  \param z The \p complex argument.
  */
 template <typename T>
-__device__ complex<T> asin(const complex<T>& z);
+__host__ __device__ complex<T> asin(const complex<T>& z);
 
 /*! Returns the complex arc tangent of a \p complex number.
  *
@@ -525,7 +525,7 @@ __device__ complex<T> asin(const complex<T>& z);
  *  \param z The \p complex argument.
  */
 template <typename T>
-__device__ complex<T> atan(const complex<T>& z);
+__host__ __device__ complex<T> atan(const complex<T>& z);
 
 /* --- Inverse Hyperbolic Functions --- */
 
@@ -537,7 +537,7 @@ __device__ complex<T> atan(const complex<T>& z);
  *  \param z The \p complex argument.
  */
 template <typename T>
-__device__ complex<T> acosh(const complex<T>& z);
+__host__ __device__ complex<T> acosh(const complex<T>& z);
 
 /*! Returns the complex inverse hyperbolic sine of a \p complex number.
  *
@@ -547,7 +547,7 @@ __device__ complex<T> acosh(const complex<T>& z);
  *  \param z The \p complex argument.
  */
 template <typename T>
-__device__ complex<T> asinh(const complex<T>& z);
+__host__ __device__ complex<T> asinh(const complex<T>& z);
 
 /*! Returns the complex inverse hyperbolic tangent of a \p complex number.
  *
@@ -557,7 +557,7 @@ __device__ complex<T> asinh(const complex<T>& z);
  *  \param z The \p complex argument.
  */
 template <typename T>
-__device__ complex<T> atanh(const complex<T>& z);
+__host__ __device__ complex<T> atanh(const complex<T>& z);
 
 /* --- Equality Operators --- */
 

--- a/cupy/core/include/cupy/complex/complex_inl.h
+++ b/cupy/core/include/cupy/complex/complex_inl.h
@@ -22,6 +22,7 @@
 namespace thrust {
 
 /* --- Constructors --- */
+// TODO(leofang): support more kinds of constructors from upstream
 
 template <typename T>
 inline __host__ __device__ complex<T>::complex(const T& re, const T& im) {
@@ -39,18 +40,17 @@ inline __host__ __device__ complex<T>::complex(const complex<X>& z) {
 }
 
 /* --- Compound Assignment Operators --- */
+// TODO(leofang): support operators with argument of type T, see upstream
 
 template <typename T>
 __host__ __device__ inline complex<T>& complex<T>::operator+=(const complex<T> z) {
-  real(real() + z.real());
-  imag(imag() + z.imag());
+  *this = *this + z;
   return *this;
 }
 
 template <typename T>
 __host__ __device__ inline complex<T>& complex<T>::operator-=(const complex<T> z) {
-  real(real() - z.real());
-  imag(imag() - z.imag());
+  *this = *this - z;
   return *this;
 }
 
@@ -70,32 +70,23 @@ __host__ __device__ inline complex<T>& complex<T>::operator/=(const complex<T> z
 
 template <typename T>
 __host__ __device__ inline bool operator==(const complex<T>& lhs,
-                                  const complex<T>& rhs) {
-  if (lhs.real() == rhs.real() && lhs.imag() == rhs.imag()) {
-    return true;
-  }
-  return false;
+                                           const complex<T>& rhs) {
+  return lhs.real() == rhs.real() && lhs.imag() == rhs.imag();
 }
 
 template <typename T>
 __host__ __device__ inline bool operator==(const T& lhs, const complex<T>& rhs) {
-  if (lhs == rhs.real() && rhs.imag() == 0) {
-    return true;
-  }
-  return false;
+  return lhs == rhs.real() && rhs.imag() == 0;
 }
 
 template <typename T>
 __host__ __device__ inline bool operator==(const complex<T>& lhs, const T& rhs) {
-  if (lhs.real() == rhs && lhs.imag() == 0) {
-    return true;
-  }
-  return false;
+  return lhs.real() == rhs && lhs.imag() == 0;
 }
 
 template <typename T>
 __host__ __device__ inline bool operator!=(const complex<T>& lhs,
-                                  const complex<T>& rhs) {
+                                           const complex<T>& rhs) {
   return !(lhs == rhs);
 }
 

--- a/cupy/core/include/cupy/complex/cpow.h
+++ b/cupy/core/include/cupy/complex/cpow.h
@@ -5,8 +5,8 @@
 namespace thrust {
 
 template <typename T>
-__device__ inline complex<T> pow(const complex<T>& z,
-                                 const complex<T>& exponent) {
+__host__ __device__ inline complex<T> pow(const complex<T>& z,
+                                          const complex<T>& exponent) {
   const T absz = abs(z);
   if (absz == 0) {
     return complex<T>(0, 0);
@@ -24,31 +24,31 @@ __device__ inline complex<T> pow(const complex<T>& z,
 }
 
 template <typename T>
-__device__ inline complex<T> pow(const complex<T>& z, const T& exponent) {
+__host__ __device__ inline complex<T> pow(const complex<T>& z, const T& exponent) {
   return pow(z, complex<T>(exponent));
 }
 
 template <typename T>
-__device__ inline complex<T> pow(const T& x, const complex<T>& exponent) {
+__host__ __device__ inline complex<T> pow(const T& x, const complex<T>& exponent) {
   return pow(complex<T>(x), exponent);
 }
 
 template <typename T, typename U>
-__device__ inline complex<typename _select_greater_type<T, U>::type> pow(
+__host__ __device__ inline complex<typename _select_greater_type<T, U>::type> pow(
     const complex<T>& z, const complex<T>& exponent) {
   typedef typename _select_greater_type<T, U>::type PromotedType;
   return pow(complex<PromotedType>(z), complex<PromotedType>(exponent));
 }
 
 template <typename T, typename U>
-__device__ inline complex<typename _select_greater_type<T, U>::type> pow(
+__host__ __device__ inline complex<typename _select_greater_type<T, U>::type> pow(
     const complex<T>& z, const U& exponent) {
   typedef typename _select_greater_type<T, U>::type PromotedType;
   return pow(complex<PromotedType>(z), PromotedType(exponent));
 }
 
 template <typename T, typename U>
-__device__ inline complex<typename _select_greater_type<T, U>::type> pow(
+__host__ __device__ inline complex<typename _select_greater_type<T, U>::type> pow(
     const T& x, const complex<U>& exponent) {
   typedef typename _select_greater_type<T, U>::type PromotedType;
   return pow(PromotedType(x), complex<PromotedType>(exponent));

--- a/cupy/core/include/cupy/complex/cpow.h
+++ b/cupy/core/include/cupy/complex/cpow.h
@@ -7,30 +7,19 @@ namespace thrust {
 template <typename T>
 __host__ __device__ inline complex<T> pow(const complex<T>& z,
                                           const complex<T>& exponent) {
-  const T absz = abs(z);
-  if (absz == 0) {
-    return complex<T>(0, 0);
-  }
-  const T real = exponent.real();
-  const T imag = exponent.imag();
-  const T argz = arg(z);
-  T r = ::pow(absz, real);
-  T theta = real * argz;
-  if (imag != 0) {
-    r *= ::exp(-imag * argz);
-    theta += imag * ::log(absz);
-  }
-  return complex<T>(r * cos(theta), r * sin(theta));
+  return exp(log(complex<T>(z)) * complex<T>(exponent));
 }
 
 template <typename T>
 __host__ __device__ inline complex<T> pow(const complex<T>& z, const T& exponent) {
-  return pow(z, complex<T>(exponent));
+  return exp(log(complex<T>(z)) * T(exponent));
 }
 
 template <typename T>
 __host__ __device__ inline complex<T> pow(const T& x, const complex<T>& exponent) {
-  return pow(complex<T>(x), exponent);
+  // Find `log` by ADL.
+  using std::log;
+  return exp(log(T(x)) * complex<T>(y));
 }
 
 template <typename T, typename U>

--- a/cupy/core/include/cupy/complex/cproj.h
+++ b/cupy/core/include/cupy/complex/cproj.h
@@ -26,7 +26,7 @@ namespace complex {
 
 using thrust::complex;
 
-__device__ inline complex<float> cprojf(const complex<float>& z) {
+__host__ __device__ inline complex<float> cprojf(const complex<float>& z) {
   if (!isinf(z.real()) && !isinf(z.imag())) {
     return z;
   } else {
@@ -35,7 +35,7 @@ __device__ inline complex<float> cprojf(const complex<float>& z) {
   }
 }
 
-__device__ inline complex<double> cproj(const complex<double>& z) {
+__host__ __device__ inline complex<double> cproj(const complex<double>& z) {
   if (!isinf(z.real()) && !isinf(z.imag())) {
     return z;
   } else {
@@ -47,18 +47,18 @@ __device__ inline complex<double> cproj(const complex<double>& z) {
 }
 
 template <typename T>
-__device__ inline thrust::complex<T> proj(const thrust::complex<T>& z) {
+__host__ __device__ inline thrust::complex<T> proj(const thrust::complex<T>& z) {
   return detail::complex::cproj(z);
 }
 
 template <>
-__device__ inline thrust::complex<double> proj(
+__host__ __device__ inline thrust::complex<double> proj(
     const thrust::complex<double>& z) {
   return detail::complex::cproj(z);
 }
 
 template <>
-__device__ inline thrust::complex<float> proj(const thrust::complex<float>& z) {
+__host__ __device__ inline thrust::complex<float> proj(const thrust::complex<float>& z) {
   return detail::complex::cprojf(z);
 }
 }

--- a/cupy/core/include/cupy/complex/csinh.h
+++ b/cupy/core/include/cupy/complex/csinh.h
@@ -56,7 +56,7 @@ namespace complex {
 
 using thrust::complex;
 
-__device__ inline complex<double> csinh(const complex<double>& z) {
+__host__ __device__ inline complex<double> csinh(const complex<double>& z) {
   double x, y, h;
   uint32_t hx, hy, ix, iy, lx, ly;
   const double huge = 8.98846567431157953864652595395e+307;  // 0x1p1023;
@@ -155,7 +155,7 @@ __device__ inline complex<double> csinh(const complex<double>& z) {
   return (complex<double>((x * x) * (y - y), (x + x) * (y - y)));
 }
 
-__device__ inline complex<double> csin(complex<double> z) {
+__host__ __device__ inline complex<double> csin(complex<double> z) {
   /* csin(z) = -I * csinh(I * z) */
   z = csinh(complex<double>(-z.imag(), z.real()));
   return (complex<double>(z.imag(), -z.real()));
@@ -166,26 +166,26 @@ __device__ inline complex<double> csin(complex<double> z) {
 }  // namespace detail
 
 template <typename ValueType>
-__device__ inline complex<ValueType> sin(const complex<ValueType>& z) {
+__host__ __device__ inline complex<ValueType> sin(const complex<ValueType>& z) {
   const ValueType re = z.real();
   const ValueType im = z.imag();
   return complex<ValueType>(::sin(re) * ::cosh(im), ::cos(re) * ::sinh(im));
 }
 
 template <typename ValueType>
-__device__ inline complex<ValueType> sinh(const complex<ValueType>& z) {
+__host__ __device__ inline complex<ValueType> sinh(const complex<ValueType>& z) {
   const ValueType re = z.real();
   const ValueType im = z.imag();
   return complex<ValueType>(::sinh(re) * ::cos(im), ::cosh(re) * ::sin(im));
 }
 
 template <>
-__device__ inline complex<double> sin(const complex<double>& z) {
+__host__ __device__ inline complex<double> sin(const complex<double>& z) {
   return detail::complex::csin(z);
 }
 
 template <>
-__device__ inline complex<double> sinh(const complex<double>& z) {
+__host__ __device__ inline complex<double> sinh(const complex<double>& z) {
   return detail::complex::csinh(z);
 }
 

--- a/cupy/core/include/cupy/complex/csinhf.h
+++ b/cupy/core/include/cupy/complex/csinhf.h
@@ -56,7 +56,7 @@ namespace complex {
 
 using thrust::complex;
 
-__device__ inline complex<float> csinhf(const complex<float>& z) {
+__host__ __device__ inline complex<float> csinhf(const complex<float>& z) {
   float x, y, h;
   uint32_t hx, hy, ix, iy;
 
@@ -111,7 +111,7 @@ __device__ inline complex<float> csinhf(const complex<float>& z) {
   return (complex<float>((x * x) * (y - y), (x + x) * (y - y)));
 }
 
-__device__ inline complex<float> csinf(complex<float> z) {
+__host__ __device__ inline complex<float> csinf(complex<float> z) {
   z = csinhf(complex<float>(-z.imag(), z.real()));
   return (complex<float>(z.imag(), -z.real()));
 }
@@ -121,12 +121,12 @@ __device__ inline complex<float> csinf(complex<float> z) {
 }  // namespace detail
 
 template <>
-__device__ inline complex<float> sin(const complex<float>& z) {
+__host__ __device__ inline complex<float> sin(const complex<float>& z) {
   return detail::complex::csinf(z);
 }
 
 template <>
-__device__ inline complex<float> sinh(const complex<float>& z) {
+__host__ __device__ inline complex<float> sinh(const complex<float>& z) {
   return detail::complex::csinhf(z);
 }
 

--- a/cupy/core/include/cupy/complex/csqrt.h
+++ b/cupy/core/include/cupy/complex/csqrt.h
@@ -57,7 +57,7 @@ namespace complex {
 
 using thrust::complex;
 
-__device__ inline complex<double> csqrt(const complex<double>& z) {
+__host__ __device__ inline complex<double> csqrt(const complex<double>& z) {
   complex<double> result;
   double a, b;
   double t;
@@ -132,12 +132,12 @@ __device__ inline complex<double> csqrt(const complex<double>& z) {
 }  // namespace detail
 
 template <typename ValueType>
-__device__ inline complex<ValueType> sqrt(const complex<ValueType>& z) {
+__host__ __device__ inline complex<ValueType> sqrt(const complex<ValueType>& z) {
   return thrust::polar(::sqrt(thrust::abs(z)), thrust::arg(z) / ValueType(2));
 }
 
 template <>
-__device__ inline complex<double> sqrt(const complex<double>& z) {
+__host__ __device__ inline complex<double> sqrt(const complex<double>& z) {
   return detail::complex::csqrt(z);
 }
 

--- a/cupy/core/include/cupy/complex/csqrtf.h
+++ b/cupy/core/include/cupy/complex/csqrtf.h
@@ -57,7 +57,7 @@ namespace complex {
 
 using thrust::complex;
 
-__device__ inline complex<float> csqrtf(const complex<float>& z) {
+__host__ __device__ inline complex<float> csqrtf(const complex<float>& z) {
   float a = z.real(), b = z.imag();
   float t;
   int scale;
@@ -134,7 +134,7 @@ __device__ inline complex<float> csqrtf(const complex<float>& z) {
 }  // namespace detail
 
 template <>
-__device__ inline complex<float> sqrt(const complex<float>& z) {
+__host__ __device__ inline complex<float> sqrt(const complex<float>& z) {
   return detail::complex::csqrtf(z);
 }
 

--- a/cupy/core/include/cupy/complex/ctanh.h
+++ b/cupy/core/include/cupy/complex/ctanh.h
@@ -96,7 +96,7 @@ namespace complex {
 
 using thrust::complex;
 
-__device__ inline complex<double> ctanh(const complex<double>& z) {
+__host__ __device__ inline complex<double> ctanh(const complex<double>& z) {
   double x, y;
   double t, beta, s, rho, denom;
   uint32_t hx, ix, lx;
@@ -156,7 +156,7 @@ __device__ inline complex<double> ctanh(const complex<double>& z) {
   return (complex<double>((beta * rho * s) / denom, t / denom));
 }
 
-__device__ inline complex<double> ctan(complex<double> z) {
+__host__ __device__ inline complex<double> ctan(complex<double> z) {
   /* ctan(z) = -I * ctanh(I * z) */
   z = ctanh(complex<double>(-z.imag(), z.real()));
   return (complex<double>(z.imag(), -z.real()));
@@ -167,24 +167,24 @@ __device__ inline complex<double> ctan(complex<double> z) {
 }  // namespace detail
 
 template <typename ValueType>
-__device__ inline complex<ValueType> tan(const complex<ValueType>& z) {
+__host__ __device__ inline complex<ValueType> tan(const complex<ValueType>& z) {
   return sin(z) / cos(z);
 }
 
 template <typename ValueType>
-__device__ inline complex<ValueType> tanh(const complex<ValueType>& z) {
+__host__ __device__ inline complex<ValueType> tanh(const complex<ValueType>& z) {
   // This implementation seems better than the simple sin/cos
   return (thrust::exp(ValueType(2) * z) - ValueType(1)) /
          (thrust::exp(ValueType(2) * z) + ValueType(1));
 }
 
 template <>
-__device__ inline complex<double> tan(const complex<double>& z) {
+__host__ __device__ inline complex<double> tan(const complex<double>& z) {
   return detail::complex::ctan(z);
 }
 
 template <>
-__device__ inline complex<double> tanh(const complex<double>& z) {
+__host__ __device__ inline complex<double> tanh(const complex<double>& z) {
   return detail::complex::ctanh(z);
 }
 

--- a/cupy/core/include/cupy/complex/ctanhf.h
+++ b/cupy/core/include/cupy/complex/ctanhf.h
@@ -61,7 +61,7 @@ namespace complex {
 
 using thrust::complex;
 
-__device__ inline complex<float> ctanhf(const complex<float>& z) {
+__host__ __device__ inline complex<float> ctanhf(const complex<float>& z) {
   float x, y;
   float t, beta, s, rho, denom;
   uint32_t hx, ix;
@@ -94,7 +94,7 @@ __device__ inline complex<float> ctanhf(const complex<float>& z) {
   return (complex<float>((beta * rho * s) / denom, t / denom));
 }
 
-__device__ inline complex<float> ctanf(complex<float> z) {
+__host__ __device__ inline complex<float> ctanf(complex<float> z) {
   z = ctanhf(complex<float>(-z.imag(), z.real()));
   return (complex<float>(z.imag(), -z.real()));
 }
@@ -104,12 +104,12 @@ __device__ inline complex<float> ctanf(complex<float> z) {
 }  // namespace detail
 
 template <>
-__device__ inline complex<float> tan(const complex<float>& z) {
+__host__ __device__ inline complex<float> tan(const complex<float>& z) {
   return detail::complex::ctanf(z);
 }
 
 template <>
-__device__ inline complex<float> tanh(const complex<float>& z) {
+__host__ __device__ inline complex<float> tanh(const complex<float>& z) {
   return detail::complex::ctanhf(z);
 }
 

--- a/cupy/core/include/cupy/complex/math_private.h
+++ b/cupy/core/include/cupy/complex/math_private.h
@@ -59,19 +59,19 @@ typedef union {
   uint32_t word;
 } ieee_float_shape_type;
 
-__device__ inline void get_float_word(uint32_t& i, float d) {
+__host__ __device__ inline void get_float_word(uint32_t& i, float d) {
   ieee_float_shape_type gf_u;
   gf_u.value = (d);
   (i) = gf_u.word;
 }
 
-__device__ inline void get_float_word(int32_t& i, float d) {
+__host__ __device__ inline void get_float_word(int32_t& i, float d) {
   ieee_float_shape_type gf_u;
   gf_u.value = (d);
   (i) = gf_u.word;
 }
 
-__device__ inline void set_float_word(float& d, uint32_t i) {
+__host__ __device__ inline void set_float_word(float& d, uint32_t i) {
   ieee_float_shape_type sf_u;
   sf_u.word = (i);
   (d) = sf_u.value;
@@ -89,21 +89,21 @@ typedef union {
   } xparts;
 } ieee_double_shape_type;
 
-__device__ inline void get_high_word(uint32_t& i, double d) {
+__host__ __device__ inline void get_high_word(uint32_t& i, double d) {
   ieee_double_shape_type gh_u;
   gh_u.value = (d);
   (i) = gh_u.parts.msw;
 }
 
 /* Set the more significant 32 bits of a double from an int.  */
-__device__ inline void set_high_word(double& d, uint32_t v) {
+__host__ __device__ inline void set_high_word(double& d, uint32_t v) {
   ieee_double_shape_type sh_u;
   sh_u.value = (d);
   sh_u.parts.msw = (v);
   (d) = sh_u.value;
 }
 
-__device__ inline void insert_words(double& d, uint32_t ix0, uint32_t ix1) {
+__host__ __device__ inline void insert_words(double& d, uint32_t ix0, uint32_t ix1) {
   ieee_double_shape_type iw_u;
   iw_u.parts.msw = (ix0);
   iw_u.parts.lsw = (ix1);
@@ -111,7 +111,7 @@ __device__ inline void insert_words(double& d, uint32_t ix0, uint32_t ix1) {
 }
 
 /* Get two 32 bit ints from a double.  */
-__device__ inline void extract_words(uint32_t& ix0, uint32_t& ix1, double d) {
+__host__ __device__ inline void extract_words(uint32_t& ix0, uint32_t& ix1, double d) {
   ieee_double_shape_type ew_u;
   ew_u.value = (d);
   (ix0) = ew_u.parts.msw;
@@ -119,7 +119,7 @@ __device__ inline void extract_words(uint32_t& ix0, uint32_t& ix1, double d) {
 }
 
 /* Get two 32 bit ints from a double.  */
-__device__ inline void extract_words(int32_t& ix0, int32_t& ix1, double d) {
+__host__ __device__ inline void extract_words(int32_t& ix0, int32_t& ix1, double d) {
   ieee_double_shape_type ew_u;
   ew_u.value = (d);
   (ix0) = ew_u.parts.msw;
@@ -127,17 +127,17 @@ __device__ inline void extract_words(int32_t& ix0, int32_t& ix1, double d) {
 }
 
 template <typename T>
-inline __device__ T infinity();
+inline __host__ __device__ T infinity();
 
 template <>
-inline __device__ float infinity<float>() {
+inline __host__ __device__ float infinity<float>() {
   float res;
   set_float_word(res, 0x7f800000);
   return res;
 }
 
 template <>
-inline __device__ double infinity<double>() {
+inline __host__ __device__ double infinity<double>() {
   double res;
   insert_words(res, 0x7ff00000, 0);
   return res;


### PR DESCRIPTION
Closes #2629. Changes (see the discussion starting https://github.com/cupy/cupy/issues/2629#issuecomment-558448086):
1. Add a `__host__` qualifier to all functions
2. Sync a few function implementations with the upstream counterparts
3. Adjust some style and format
4. Fix a bug: https://github.com/cupy/cupy/pull/2741#discussion_r353360865