### PR TITLE
Support sorting complex arrays

### DIFF
--- a/cupy/cuda/cupy_thrust.cu
+++ b/cupy/cuda/cupy_thrust.cu
@@ -65,8 +65,40 @@ public:
 //      return false;
 //  }
 //}
+__host__ __device__ inline bool isnan(const cuComplex& z) {
+    return isnan(z.x) || isnan(z.y);
+}
+
+__host__ __device__ inline bool isnan(const cuDoubleComplex& z) {
+    return isnan(z.x) || isnan(z.y);
+}
+
 __host__ __device__ inline bool operator<(const cuComplex& lhs,
                                           const cuComplex& rhs) {
+  if (isnan(lhs)) {
+      if (!isnan(rhs)) {
+          return false;
+      } else if (isnan(lhs.x) && !isnan(rhs.x)) {
+          return false;
+      } else if (!isnan(lhs.x) && isnan(rhs.x)) {
+          return true;
+      } else if (isnan(lhs.y) && !isnan(rhs.y)) {
+          return false;
+      } else if (!isnan(lhs.y) && isnan(rhs.y)) {
+          return true;
+      } else if (isnan(lhs.y) && isnan(rhs.y)) {
+          return lhs.x < rhs.x;
+      } else if (isnan(lhs.x) && isnan(rhs.x)) {
+          return lhs.y < rhs.y;
+      } else { // both lhs & rhs = nan + nan I
+          return true;
+      }
+  } else { // !isnan(lhs)
+      if (isnan(rhs)) {
+          return true;
+      }
+  }
+
   if (lhs.x == rhs.x && lhs.y == rhs.y) {
       return false;
   } else if (lhs.x < rhs.x) {
@@ -79,6 +111,30 @@ __host__ __device__ inline bool operator<(const cuComplex& lhs,
 }
 __host__ __device__ inline bool operator<(const cuDoubleComplex& lhs,
                                           const cuDoubleComplex& rhs) {
+  if (isnan(lhs)) {
+      if (!isnan(rhs)) {
+          return false;
+      } else if (isnan(lhs.x) && !isnan(rhs.x)) {
+          return false;
+      } else if (!isnan(lhs.x) && isnan(rhs.x)) {
+          return true;
+      } else if (isnan(lhs.y) && !isnan(rhs.y)) {
+          return false;
+      } else if (!isnan(lhs.y) && isnan(rhs.y)) {
+          return true;
+      } else if (isnan(lhs.y) && isnan(rhs.y)) {
+          return lhs.x < rhs.x;
+      } else if (isnan(lhs.x) && isnan(rhs.x)) {
+          return lhs.y < rhs.y;
+      } else { // both lhs & rhs = nan + nan I
+          return true;
+      }
+  } else { // !isnan(lhs)
+      if (isnan(rhs)) {
+          return true;
+      }
+  }
+
   if (lhs.x == rhs.x && lhs.y == rhs.y) {
       return false;
   } else if (lhs.x < rhs.x) {

--- a/cupy/cuda/cupy_thrust.cu
+++ b/cupy/cuda/cupy_thrust.cu
@@ -291,6 +291,10 @@ void cupy::thrust::_lexsort(size_t *idx_start, void *keys_start, size_t k,
 //    size_t *, void *, size_t, size_t, size_t, void *);
 template void cupy::thrust::_lexsort<cpy_double>(
     size_t *, void *, size_t, size_t, size_t, void *);
+template void cupy::thrust::_lexsort<cuComplex>(
+    size_t *, void *, size_t, size_t, size_t, void *);
+template void cupy::thrust::_lexsort<cuDoubleComplex>(
+    size_t *, void *, size_t, size_t, size_t, void *);
 
 
 /*

--- a/cupy/cuda/cupy_thrust.cu
+++ b/cupy/cuda/cupy_thrust.cu
@@ -394,3 +394,9 @@ void cupy::thrust::_argsort(size_t *idx_start, void *data_start,
 template void cupy::thrust::_argsort<cpy_double>(
     size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, size_t,
     void *);
+template void cupy::thrust::_argsort<cuComplex>(
+    size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, size_t,
+    void *);
+template void cupy::thrust::_argsort<cuDoubleComplex>(
+    size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, size_t,
+    void *);

--- a/cupy/cuda/cupy_thrust.cu
+++ b/cupy/cuda/cupy_thrust.cu
@@ -5,8 +5,10 @@
 #include <thrust/sort.h>
 #include <thrust/tuple.h>
 #include <thrust/execution_policy.h>
+//#include <thrust/complex.h>
 #include "cupy_common.h"
 #include "cupy_thrust.h"
+#include "cupy_cuComplex.h"
 
 using namespace thrust;
 
@@ -41,6 +43,65 @@ public:
         cupy_free(memory, ptr);
     }
 };
+
+
+/* ------------------------------------ Minimum boilerplate to support complex numbers ------------------------------------ */
+// copied from cupy/core/include/cupy/complex/arithmetic.h
+//template <typename T>
+//__host__ __device__ inline T thrust::complex<T>::real(const device_reference<complex<T>>& z) {
+//  return z.real();
+//}
+//
+//template <typename T>
+//__host__ __device__ inline bool thrust::operator<(const complex<T>& lhs,
+//                                                           const complex<T>& rhs) {
+//  if (lhs == rhs) {
+//      return false;
+//  } else if (lhs.real() < rhs.real()) {
+//      return true;
+//  } else if (lhs.real() == rhs.real()) {
+//      return lhs.imag() < rhs.imag();
+//  } else {
+//      return false;
+//  }
+//}
+__host__ __device__ inline bool operator<(const cuComplex& lhs,
+                                          const cuComplex& rhs) {
+  if (lhs.x == rhs.x && lhs.y == rhs.y) {
+      return false;
+  } else if (lhs.x < rhs.x) {
+      return true;
+  } else if (lhs.x == rhs.x) {
+      return lhs.y < rhs.y;
+  } else {
+      return false;
+  }
+}
+__host__ __device__ inline bool operator<(const cuDoubleComplex& lhs,
+                                          const cuDoubleComplex& rhs) {
+  if (lhs.x == rhs.x && lhs.y == rhs.y) {
+      return false;
+  } else if (lhs.x < rhs.x) {
+      return true;
+  } else if (lhs.x == rhs.x) {
+      return lhs.y < rhs.y;
+  } else {
+      return false;
+  }
+}
+
+//template <typename ValueType>
+//__host__ __device__ inline bool operator<(const ValueType& lhs,
+//                                 const complex<ValueType>& rhs) {
+//    return complex<ValueType>(lhs) < rhs;
+//}
+//
+//template <typename ValueType>
+//__host__ __device__ inline bool operator<(const complex<ValueType>& lhs,
+//                                 const ValueType& rhs) {
+//    return lhs < complex<ValueType>(rhs);
+//}
+/* ------------------------------------ end of boilerplate ------------------------------------ */
 
 
 /*
@@ -87,25 +148,33 @@ void cupy::thrust::_sort(void *data_start, size_t *keys_start,
     }
 }
 
-template void cupy::thrust::_sort<cpy_byte>(
-    void *, size_t *, const std::vector<ptrdiff_t>& shape, size_t, void *);
-template void cupy::thrust::_sort<cpy_ubyte>(
-    void *, size_t *, const std::vector<ptrdiff_t>& shape, size_t, void *);
-template void cupy::thrust::_sort<cpy_short>(
-    void *, size_t *, const std::vector<ptrdiff_t>& shape, size_t, void *);
-template void cupy::thrust::_sort<cpy_ushort>(
-    void *, size_t *, const std::vector<ptrdiff_t>& shape, size_t, void *);
-template void cupy::thrust::_sort<cpy_int>(
-    void *, size_t *, const std::vector<ptrdiff_t>& shape, size_t, void *);
-template void cupy::thrust::_sort<cpy_uint>(
-    void *, size_t *, const std::vector<ptrdiff_t>& shape, size_t, void *);
-template void cupy::thrust::_sort<cpy_long>(
-    void *, size_t *, const std::vector<ptrdiff_t>& shape, size_t, void *);
-template void cupy::thrust::_sort<cpy_ulong>(
-    void *, size_t *, const std::vector<ptrdiff_t>& shape, size_t, void *);
-template void cupy::thrust::_sort<cpy_float>(
-    void *, size_t *, const std::vector<ptrdiff_t>& shape, size_t, void *);
+//template void cupy::thrust::_sort<cpy_byte>(
+//    void *, size_t *, const std::vector<ptrdiff_t>& shape, size_t, void *);
+//template void cupy::thrust::_sort<cpy_ubyte>(
+//    void *, size_t *, const std::vector<ptrdiff_t>& shape, size_t, void *);
+//template void cupy::thrust::_sort<cpy_short>(
+//    void *, size_t *, const std::vector<ptrdiff_t>& shape, size_t, void *);
+//template void cupy::thrust::_sort<cpy_ushort>(
+//    void *, size_t *, const std::vector<ptrdiff_t>& shape, size_t, void *);
+//template void cupy::thrust::_sort<cpy_int>(
+//    void *, size_t *, const std::vector<ptrdiff_t>& shape, size_t, void *);
+//template void cupy::thrust::_sort<cpy_uint>(
+//    void *, size_t *, const std::vector<ptrdiff_t>& shape, size_t, void *);
+//template void cupy::thrust::_sort<cpy_long>(
+//    void *, size_t *, const std::vector<ptrdiff_t>& shape, size_t, void *);
+//template void cupy::thrust::_sort<cpy_ulong>(
+//    void *, size_t *, const std::vector<ptrdiff_t>& shape, size_t, void *);
+//template void cupy::thrust::_sort<cpy_float>(
+//    void *, size_t *, const std::vector<ptrdiff_t>& shape, size_t, void *);
 template void cupy::thrust::_sort<cpy_double>(
+    void *, size_t *, const std::vector<ptrdiff_t>& shape, size_t, void *);
+//template void cupy::thrust::_sort<complex<float>>(
+//    void *, size_t *, const std::vector<ptrdiff_t>& shape, size_t, void *);
+//template void cupy::thrust::_sort<complex<double>>(
+//    void *, size_t *, const std::vector<ptrdiff_t>& shape, size_t, void *);
+template void cupy::thrust::_sort<cuComplex>(
+    void *, size_t *, const std::vector<ptrdiff_t>& shape, size_t, void *);
+template void cupy::thrust::_sort<cuDoubleComplex>(
     void *, size_t *, const std::vector<ptrdiff_t>& shape, size_t, void *);
 
 
@@ -146,24 +215,24 @@ void cupy::thrust::_lexsort(size_t *idx_start, void *keys_start, size_t k,
     }
 }
 
-template void cupy::thrust::_lexsort<cpy_byte>(
-    size_t *, void *, size_t, size_t, size_t, void *);
-template void cupy::thrust::_lexsort<cpy_ubyte>(
-    size_t *, void *, size_t, size_t, size_t, void *);
-template void cupy::thrust::_lexsort<cpy_short>(
-    size_t *, void *, size_t, size_t, size_t, void *);
-template void cupy::thrust::_lexsort<cpy_ushort>(
-    size_t *, void *, size_t, size_t, size_t, void *);
-template void cupy::thrust::_lexsort<cpy_int>(
-    size_t *, void *, size_t, size_t, size_t, void *);
-template void cupy::thrust::_lexsort<cpy_uint>(
-    size_t *, void *, size_t, size_t, size_t, void *);
-template void cupy::thrust::_lexsort<cpy_long>(
-    size_t *, void *, size_t, size_t, size_t, void *);
-template void cupy::thrust::_lexsort<cpy_ulong>(
-    size_t *, void *, size_t, size_t, size_t, void *);
-template void cupy::thrust::_lexsort<cpy_float>(
-    size_t *, void *, size_t, size_t, size_t, void *);
+//template void cupy::thrust::_lexsort<cpy_byte>(
+//    size_t *, void *, size_t, size_t, size_t, void *);
+//template void cupy::thrust::_lexsort<cpy_ubyte>(
+//    size_t *, void *, size_t, size_t, size_t, void *);
+//template void cupy::thrust::_lexsort<cpy_short>(
+//    size_t *, void *, size_t, size_t, size_t, void *);
+//template void cupy::thrust::_lexsort<cpy_ushort>(
+//    size_t *, void *, size_t, size_t, size_t, void *);
+//template void cupy::thrust::_lexsort<cpy_int>(
+//    size_t *, void *, size_t, size_t, size_t, void *);
+//template void cupy::thrust::_lexsort<cpy_uint>(
+//    size_t *, void *, size_t, size_t, size_t, void *);
+//template void cupy::thrust::_lexsort<cpy_long>(
+//    size_t *, void *, size_t, size_t, size_t, void *);
+//template void cupy::thrust::_lexsort<cpy_ulong>(
+//    size_t *, void *, size_t, size_t, size_t, void *);
+//template void cupy::thrust::_lexsort<cpy_float>(
+//    size_t *, void *, size_t, size_t, size_t, void *);
 template void cupy::thrust::_lexsort<cpy_double>(
     size_t *, void *, size_t, size_t, size_t, void *);
 
@@ -235,33 +304,33 @@ void cupy::thrust::_argsort(size_t *idx_start, void *data_start,
     }
 }
 
-template void cupy::thrust::_argsort<cpy_byte>(
-    size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, size_t,
-    void *);
-template void cupy::thrust::_argsort<cpy_ubyte>(
-    size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, size_t,
-    void *);
-template void cupy::thrust::_argsort<cpy_short>(
-    size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, size_t,
-    void *);
-template void cupy::thrust::_argsort<cpy_ushort>(
-    size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, size_t,
-    void *);
-template void cupy::thrust::_argsort<cpy_int>(
-    size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, size_t,
-    void *);
-template void cupy::thrust::_argsort<cpy_uint>(
-    size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, size_t,
-    void *);
-template void cupy::thrust::_argsort<cpy_long>(
-    size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, size_t,
-    void *);
-template void cupy::thrust::_argsort<cpy_ulong>(
-    size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, size_t,
-    void *);
-template void cupy::thrust::_argsort<cpy_float>(
-    size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, size_t,
-    void *);
+//template void cupy::thrust::_argsort<cpy_byte>(
+//    size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, size_t,
+//    void *);
+//template void cupy::thrust::_argsort<cpy_ubyte>(
+//    size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, size_t,
+//    void *);
+//template void cupy::thrust::_argsort<cpy_short>(
+//    size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, size_t,
+//    void *);
+//template void cupy::thrust::_argsort<cpy_ushort>(
+//    size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, size_t,
+//    void *);
+//template void cupy::thrust::_argsort<cpy_int>(
+//    size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, size_t,
+//    void *);
+//template void cupy::thrust::_argsort<cpy_uint>(
+//    size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, size_t,
+//    void *);
+//template void cupy::thrust::_argsort<cpy_long>(
+//    size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, size_t,
+//    void *);
+//template void cupy::thrust::_argsort<cpy_ulong>(
+//    size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, size_t,
+//    void *);
+//template void cupy::thrust::_argsort<cpy_float>(
+//    size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, size_t,
+//    void *);
 template void cupy::thrust::_argsort<cpy_double>(
     size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, size_t,
     void *);

--- a/cupy/cuda/thrust.pyx
+++ b/cupy/cuda/thrust.pyx
@@ -140,6 +140,10 @@ cpdef lexsort(dtype, size_t idx_start, size_t keys_start,
 #    elif dtype == numpy.float64:
     if dtype == numpy.float64:
         _lexsort[common.cpy_double](idx_ptr, keys_ptr, k, n, _strm, mem)
+    elif dtype == numpy.complex64:
+        _lexsort[cpy_complex64](idx_ptr, keys_ptr, k, n, _strm, mem)
+    elif dtype == numpy.complex128:
+        _lexsort[cpy_complex128](idx_ptr, keys_ptr, k, n, _strm, mem)
     else:
         raise TypeError('Sorting keys with dtype \'{}\' is not '
                         'supported'.format(dtype))
@@ -191,6 +195,12 @@ cpdef argsort(dtype, size_t idx_start, size_t data_start, size_t keys_start,
     if dtype == numpy.float64:
         _argsort[common.cpy_double](
             _idx_start, _data_start, _keys_start, shape, _strm, mem)
+#    elif dtype == numpy.complex64:
+#        _argsort[common.cpy_complex64](
+#            _idx_start, _data_start, _keys_start, shape, _strm, mem)
+#    elif dtype == numpy.complex128:
+#        _argsort[common.cpy_complex128](
+#            _idx_start, _data_start, _keys_start, shape, _strm, mem)
     else:
         raise NotImplementedError('Sorting arrays with dtype \'{}\' is not '
                                   'supported'.format(dtype))

--- a/cupy/cuda/thrust.pyx
+++ b/cupy/cuda/thrust.pyx
@@ -77,26 +77,25 @@ cpdef sort(dtype, size_t data_start, size_t keys_start,
     cdef void* mem = <void *>mem_obj
 
     # TODO(takagi): Support float16 and bool
-#    if dtype == numpy.int8:
-#        _sort[common.cpy_byte](_data_start, _keys_start, shape, _strm, mem)
-#    elif dtype == numpy.uint8:
-#        _sort[common.cpy_ubyte](_data_start, _keys_start, shape, _strm, mem)
-#    elif dtype == numpy.int16:
-#        _sort[common.cpy_short](_data_start, _keys_start, shape, _strm, mem)
-#    elif dtype == numpy.uint16:
-#        _sort[common.cpy_ushort](_data_start, _keys_start, shape, _strm, mem)
-#    elif dtype == numpy.int32:
-#        _sort[common.cpy_int](_data_start, _keys_start, shape, _strm, mem)
-#    elif dtype == numpy.uint32:
-#        _sort[common.cpy_uint](_data_start, _keys_start, shape, _strm, mem)
-#    elif dtype == numpy.int64:
-#        _sort[common.cpy_long](_data_start, _keys_start, shape, _strm, mem)
-#    elif dtype == numpy.uint64:
-#        _sort[common.cpy_ulong](_data_start, _keys_start, shape, _strm, mem)
-#    elif dtype == numpy.float32:
-#        _sort[common.cpy_float](_data_start, _keys_start, shape, _strm, mem)
-#    elif dtype == numpy.float64:
-    if dtype == numpy.float64:
+    if dtype == numpy.int8:
+        _sort[common.cpy_byte](_data_start, _keys_start, shape, _strm, mem)
+    elif dtype == numpy.uint8:
+        _sort[common.cpy_ubyte](_data_start, _keys_start, shape, _strm, mem)
+    elif dtype == numpy.int16:
+        _sort[common.cpy_short](_data_start, _keys_start, shape, _strm, mem)
+    elif dtype == numpy.uint16:
+        _sort[common.cpy_ushort](_data_start, _keys_start, shape, _strm, mem)
+    elif dtype == numpy.int32:
+        _sort[common.cpy_int](_data_start, _keys_start, shape, _strm, mem)
+    elif dtype == numpy.uint32:
+        _sort[common.cpy_uint](_data_start, _keys_start, shape, _strm, mem)
+    elif dtype == numpy.int64:
+        _sort[common.cpy_long](_data_start, _keys_start, shape, _strm, mem)
+    elif dtype == numpy.uint64:
+        _sort[common.cpy_ulong](_data_start, _keys_start, shape, _strm, mem)
+    elif dtype == numpy.float32:
+        _sort[common.cpy_float](_data_start, _keys_start, shape, _strm, mem)
+    elif dtype == numpy.float64:
         _sort[common.cpy_double](_data_start, _keys_start, shape, _strm, mem)
     elif dtype == numpy.complex64:
         _sort[cpy_complex64](_data_start, _keys_start, shape, _strm, mem)
@@ -119,26 +118,25 @@ cpdef lexsort(dtype, size_t idx_start, size_t keys_start,
     cdef void* mem = <void *>mem_obj
 
     # TODO(takagi): Support float16 and bool
-#    if dtype == numpy.int8:
-#        _lexsort[common.cpy_byte](idx_ptr, keys_ptr, k, n, _strm, mem)
-#    elif dtype == numpy.uint8:
-#        _lexsort[common.cpy_ubyte](idx_ptr, keys_ptr, k, n, _strm, mem)
-#    elif dtype == numpy.int16:
-#        _lexsort[common.cpy_short](idx_ptr, keys_ptr, k, n, _strm, mem)
-#    elif dtype == numpy.uint16:
-#        _lexsort[common.cpy_ushort](idx_ptr, keys_ptr, k, n, _strm, mem)
-#    elif dtype == numpy.int32:
-#        _lexsort[common.cpy_int](idx_ptr, keys_ptr, k, n, _strm, mem)
-#    elif dtype == numpy.uint32:
-#        _lexsort[common.cpy_uint](idx_ptr, keys_ptr, k, n, _strm, mem)
-#    elif dtype == numpy.int64:
-#        _lexsort[common.cpy_long](idx_ptr, keys_ptr, k, n, _strm, mem)
-#    elif dtype == numpy.uint64:
-#        _lexsort[common.cpy_ulong](idx_ptr, keys_ptr, k, n, _strm, mem)
-#    elif dtype == numpy.float32:
-#        _lexsort[common.cpy_float](idx_ptr, keys_ptr, k, n, _strm, mem)
-#    elif dtype == numpy.float64:
-    if dtype == numpy.float64:
+    if dtype == numpy.int8:
+        _lexsort[common.cpy_byte](idx_ptr, keys_ptr, k, n, _strm, mem)
+    elif dtype == numpy.uint8:
+        _lexsort[common.cpy_ubyte](idx_ptr, keys_ptr, k, n, _strm, mem)
+    elif dtype == numpy.int16:
+        _lexsort[common.cpy_short](idx_ptr, keys_ptr, k, n, _strm, mem)
+    elif dtype == numpy.uint16:
+        _lexsort[common.cpy_ushort](idx_ptr, keys_ptr, k, n, _strm, mem)
+    elif dtype == numpy.int32:
+        _lexsort[common.cpy_int](idx_ptr, keys_ptr, k, n, _strm, mem)
+    elif dtype == numpy.uint32:
+        _lexsort[common.cpy_uint](idx_ptr, keys_ptr, k, n, _strm, mem)
+    elif dtype == numpy.int64:
+        _lexsort[common.cpy_long](idx_ptr, keys_ptr, k, n, _strm, mem)
+    elif dtype == numpy.uint64:
+        _lexsort[common.cpy_ulong](idx_ptr, keys_ptr, k, n, _strm, mem)
+    elif dtype == numpy.float32:
+        _lexsort[common.cpy_float](idx_ptr, keys_ptr, k, n, _strm, mem)
+    elif dtype == numpy.float64:
         _lexsort[common.cpy_double](idx_ptr, keys_ptr, k, n, _strm, mem)
     elif dtype == numpy.complex64:
         _lexsort[cpy_complex64](idx_ptr, keys_ptr, k, n, _strm, mem)
@@ -164,35 +162,34 @@ cpdef argsort(dtype, size_t idx_start, size_t data_start, size_t keys_start,
     cdef void* mem = <void *>mem_obj
 
     # TODO(takagi): Support float16 and bool
-#    if dtype == numpy.int8:
-#        _argsort[common.cpy_byte](
-#            _idx_start, _data_start, _keys_start, shape, _strm, mem)
-#    elif dtype == numpy.uint8:
-#        _argsort[common.cpy_ubyte](
-#            _idx_start, _data_start, _keys_start, shape, _strm, mem)
-#    elif dtype == numpy.int16:
-#        _argsort[common.cpy_short](
-#            _idx_start, _data_start, _keys_start, shape, _strm, mem)
-#    elif dtype == numpy.uint16:
-#        _argsort[common.cpy_ushort](
-#            _idx_start, _data_start, _keys_start, shape, _strm, mem)
-#    elif dtype == numpy.int32:
-#        _argsort[common.cpy_int](
-#            _idx_start, _data_start, _keys_start, shape, _strm, mem)
-#    elif dtype == numpy.uint32:
-#        _argsort[common.cpy_uint](
-#            _idx_start, _data_start, _keys_start, shape, _strm, mem)
-#    elif dtype == numpy.int64:
-#        _argsort[common.cpy_long](
-#            _idx_start, _data_start, _keys_start, shape, _strm, mem)
-#    elif dtype == numpy.uint64:
-#        _argsort[common.cpy_ulong](
-#            _idx_start, _data_start, _keys_start, shape, _strm, mem)
-#    elif dtype == numpy.float32:
-#        _argsort[common.cpy_float](
-#            _idx_start, _data_start, _keys_start, shape, _strm, mem)
-#    elif dtype == numpy.float64:
-    if dtype == numpy.float64:
+    if dtype == numpy.int8:
+        _argsort[common.cpy_byte](
+            _idx_start, _data_start, _keys_start, shape, _strm, mem)
+    elif dtype == numpy.uint8:
+        _argsort[common.cpy_ubyte](
+            _idx_start, _data_start, _keys_start, shape, _strm, mem)
+    elif dtype == numpy.int16:
+        _argsort[common.cpy_short](
+            _idx_start, _data_start, _keys_start, shape, _strm, mem)
+    elif dtype == numpy.uint16:
+        _argsort[common.cpy_ushort](
+            _idx_start, _data_start, _keys_start, shape, _strm, mem)
+    elif dtype == numpy.int32:
+        _argsort[common.cpy_int](
+            _idx_start, _data_start, _keys_start, shape, _strm, mem)
+    elif dtype == numpy.uint32:
+        _argsort[common.cpy_uint](
+            _idx_start, _data_start, _keys_start, shape, _strm, mem)
+    elif dtype == numpy.int64:
+        _argsort[common.cpy_long](
+            _idx_start, _data_start, _keys_start, shape, _strm, mem)
+    elif dtype == numpy.uint64:
+        _argsort[common.cpy_ulong](
+            _idx_start, _data_start, _keys_start, shape, _strm, mem)
+    elif dtype == numpy.float32:
+        _argsort[common.cpy_float](
+            _idx_start, _data_start, _keys_start, shape, _strm, mem)
+    elif dtype == numpy.float64:
         _argsort[common.cpy_double](
             _idx_start, _data_start, _keys_start, shape, _strm, mem)
     elif dtype == numpy.complex64:

--- a/cupy/cuda/thrust.pyx
+++ b/cupy/cuda/thrust.pyx
@@ -51,6 +51,13 @@ cdef extern from '../cuda/cupy_thrust.h' namespace 'cupy::thrust':
     void _argsort[T](size_t *, void *, void *, const vector.vector[ptrdiff_t]&,
                      size_t, void *)
 
+cdef extern from 'cupy_cuComplex.h':
+    ctypedef struct cpy_complex64 'cuComplex':
+        float x, y
+
+    ctypedef struct cpy_complex128 'cuDoubleComplex':
+        double x, y
+
 
 ###############################################################################
 # Python interface
@@ -70,26 +77,31 @@ cpdef sort(dtype, size_t data_start, size_t keys_start,
     cdef void* mem = <void *>mem_obj
 
     # TODO(takagi): Support float16 and bool
-    if dtype == numpy.int8:
-        _sort[common.cpy_byte](_data_start, _keys_start, shape, _strm, mem)
-    elif dtype == numpy.uint8:
-        _sort[common.cpy_ubyte](_data_start, _keys_start, shape, _strm, mem)
-    elif dtype == numpy.int16:
-        _sort[common.cpy_short](_data_start, _keys_start, shape, _strm, mem)
-    elif dtype == numpy.uint16:
-        _sort[common.cpy_ushort](_data_start, _keys_start, shape, _strm, mem)
-    elif dtype == numpy.int32:
-        _sort[common.cpy_int](_data_start, _keys_start, shape, _strm, mem)
-    elif dtype == numpy.uint32:
-        _sort[common.cpy_uint](_data_start, _keys_start, shape, _strm, mem)
-    elif dtype == numpy.int64:
-        _sort[common.cpy_long](_data_start, _keys_start, shape, _strm, mem)
-    elif dtype == numpy.uint64:
-        _sort[common.cpy_ulong](_data_start, _keys_start, shape, _strm, mem)
-    elif dtype == numpy.float32:
-        _sort[common.cpy_float](_data_start, _keys_start, shape, _strm, mem)
-    elif dtype == numpy.float64:
+#    if dtype == numpy.int8:
+#        _sort[common.cpy_byte](_data_start, _keys_start, shape, _strm, mem)
+#    elif dtype == numpy.uint8:
+#        _sort[common.cpy_ubyte](_data_start, _keys_start, shape, _strm, mem)
+#    elif dtype == numpy.int16:
+#        _sort[common.cpy_short](_data_start, _keys_start, shape, _strm, mem)
+#    elif dtype == numpy.uint16:
+#        _sort[common.cpy_ushort](_data_start, _keys_start, shape, _strm, mem)
+#    elif dtype == numpy.int32:
+#        _sort[common.cpy_int](_data_start, _keys_start, shape, _strm, mem)
+#    elif dtype == numpy.uint32:
+#        _sort[common.cpy_uint](_data_start, _keys_start, shape, _strm, mem)
+#    elif dtype == numpy.int64:
+#        _sort[common.cpy_long](_data_start, _keys_start, shape, _strm, mem)
+#    elif dtype == numpy.uint64:
+#        _sort[common.cpy_ulong](_data_start, _keys_start, shape, _strm, mem)
+#    elif dtype == numpy.float32:
+#        _sort[common.cpy_float](_data_start, _keys_start, shape, _strm, mem)
+#    elif dtype == numpy.float64:
+    if dtype == numpy.float64:
         _sort[common.cpy_double](_data_start, _keys_start, shape, _strm, mem)
+    elif dtype == numpy.complex64:
+        _sort[cpy_complex64](_data_start, _keys_start, shape, _strm, mem)
+    elif dtype == numpy.complex128:
+        _sort[cpy_complex128](_data_start, _keys_start, shape, _strm, mem)
     else:
         raise NotImplementedError('Sorting arrays with dtype \'{}\' is not '
                                   'supported'.format(dtype))
@@ -107,25 +119,26 @@ cpdef lexsort(dtype, size_t idx_start, size_t keys_start,
     cdef void* mem = <void *>mem_obj
 
     # TODO(takagi): Support float16 and bool
-    if dtype == numpy.int8:
-        _lexsort[common.cpy_byte](idx_ptr, keys_ptr, k, n, _strm, mem)
-    elif dtype == numpy.uint8:
-        _lexsort[common.cpy_ubyte](idx_ptr, keys_ptr, k, n, _strm, mem)
-    elif dtype == numpy.int16:
-        _lexsort[common.cpy_short](idx_ptr, keys_ptr, k, n, _strm, mem)
-    elif dtype == numpy.uint16:
-        _lexsort[common.cpy_ushort](idx_ptr, keys_ptr, k, n, _strm, mem)
-    elif dtype == numpy.int32:
-        _lexsort[common.cpy_int](idx_ptr, keys_ptr, k, n, _strm, mem)
-    elif dtype == numpy.uint32:
-        _lexsort[common.cpy_uint](idx_ptr, keys_ptr, k, n, _strm, mem)
-    elif dtype == numpy.int64:
-        _lexsort[common.cpy_long](idx_ptr, keys_ptr, k, n, _strm, mem)
-    elif dtype == numpy.uint64:
-        _lexsort[common.cpy_ulong](idx_ptr, keys_ptr, k, n, _strm, mem)
-    elif dtype == numpy.float32:
-        _lexsort[common.cpy_float](idx_ptr, keys_ptr, k, n, _strm, mem)
-    elif dtype == numpy.float64:
+#    if dtype == numpy.int8:
+#        _lexsort[common.cpy_byte](idx_ptr, keys_ptr, k, n, _strm, mem)
+#    elif dtype == numpy.uint8:
+#        _lexsort[common.cpy_ubyte](idx_ptr, keys_ptr, k, n, _strm, mem)
+#    elif dtype == numpy.int16:
+#        _lexsort[common.cpy_short](idx_ptr, keys_ptr, k, n, _strm, mem)
+#    elif dtype == numpy.uint16:
+#        _lexsort[common.cpy_ushort](idx_ptr, keys_ptr, k, n, _strm, mem)
+#    elif dtype == numpy.int32:
+#        _lexsort[common.cpy_int](idx_ptr, keys_ptr, k, n, _strm, mem)
+#    elif dtype == numpy.uint32:
+#        _lexsort[common.cpy_uint](idx_ptr, keys_ptr, k, n, _strm, mem)
+#    elif dtype == numpy.int64:
+#        _lexsort[common.cpy_long](idx_ptr, keys_ptr, k, n, _strm, mem)
+#    elif dtype == numpy.uint64:
+#        _lexsort[common.cpy_ulong](idx_ptr, keys_ptr, k, n, _strm, mem)
+#    elif dtype == numpy.float32:
+#        _lexsort[common.cpy_float](idx_ptr, keys_ptr, k, n, _strm, mem)
+#    elif dtype == numpy.float64:
+    if dtype == numpy.float64:
         _lexsort[common.cpy_double](idx_ptr, keys_ptr, k, n, _strm, mem)
     else:
         raise TypeError('Sorting keys with dtype \'{}\' is not '
@@ -147,34 +160,35 @@ cpdef argsort(dtype, size_t idx_start, size_t data_start, size_t keys_start,
     cdef void* mem = <void *>mem_obj
 
     # TODO(takagi): Support float16 and bool
-    if dtype == numpy.int8:
-        _argsort[common.cpy_byte](
-            _idx_start, _data_start, _keys_start, shape, _strm, mem)
-    elif dtype == numpy.uint8:
-        _argsort[common.cpy_ubyte](
-            _idx_start, _data_start, _keys_start, shape, _strm, mem)
-    elif dtype == numpy.int16:
-        _argsort[common.cpy_short](
-            _idx_start, _data_start, _keys_start, shape, _strm, mem)
-    elif dtype == numpy.uint16:
-        _argsort[common.cpy_ushort](
-            _idx_start, _data_start, _keys_start, shape, _strm, mem)
-    elif dtype == numpy.int32:
-        _argsort[common.cpy_int](
-            _idx_start, _data_start, _keys_start, shape, _strm, mem)
-    elif dtype == numpy.uint32:
-        _argsort[common.cpy_uint](
-            _idx_start, _data_start, _keys_start, shape, _strm, mem)
-    elif dtype == numpy.int64:
-        _argsort[common.cpy_long](
-            _idx_start, _data_start, _keys_start, shape, _strm, mem)
-    elif dtype == numpy.uint64:
-        _argsort[common.cpy_ulong](
-            _idx_start, _data_start, _keys_start, shape, _strm, mem)
-    elif dtype == numpy.float32:
-        _argsort[common.cpy_float](
-            _idx_start, _data_start, _keys_start, shape, _strm, mem)
-    elif dtype == numpy.float64:
+#    if dtype == numpy.int8:
+#        _argsort[common.cpy_byte](
+#            _idx_start, _data_start, _keys_start, shape, _strm, mem)
+#    elif dtype == numpy.uint8:
+#        _argsort[common.cpy_ubyte](
+#            _idx_start, _data_start, _keys_start, shape, _strm, mem)
+#    elif dtype == numpy.int16:
+#        _argsort[common.cpy_short](
+#            _idx_start, _data_start, _keys_start, shape, _strm, mem)
+#    elif dtype == numpy.uint16:
+#        _argsort[common.cpy_ushort](
+#            _idx_start, _data_start, _keys_start, shape, _strm, mem)
+#    elif dtype == numpy.int32:
+#        _argsort[common.cpy_int](
+#            _idx_start, _data_start, _keys_start, shape, _strm, mem)
+#    elif dtype == numpy.uint32:
+#        _argsort[common.cpy_uint](
+#            _idx_start, _data_start, _keys_start, shape, _strm, mem)
+#    elif dtype == numpy.int64:
+#        _argsort[common.cpy_long](
+#            _idx_start, _data_start, _keys_start, shape, _strm, mem)
+#    elif dtype == numpy.uint64:
+#        _argsort[common.cpy_ulong](
+#            _idx_start, _data_start, _keys_start, shape, _strm, mem)
+#    elif dtype == numpy.float32:
+#        _argsort[common.cpy_float](
+#            _idx_start, _data_start, _keys_start, shape, _strm, mem)
+#    elif dtype == numpy.float64:
+    if dtype == numpy.float64:
         _argsort[common.cpy_double](
             _idx_start, _data_start, _keys_start, shape, _strm, mem)
     else:

--- a/cupy/cuda/thrust.pyx
+++ b/cupy/cuda/thrust.pyx
@@ -195,12 +195,12 @@ cpdef argsort(dtype, size_t idx_start, size_t data_start, size_t keys_start,
     if dtype == numpy.float64:
         _argsort[common.cpy_double](
             _idx_start, _data_start, _keys_start, shape, _strm, mem)
-#    elif dtype == numpy.complex64:
-#        _argsort[common.cpy_complex64](
-#            _idx_start, _data_start, _keys_start, shape, _strm, mem)
-#    elif dtype == numpy.complex128:
-#        _argsort[common.cpy_complex128](
-#            _idx_start, _data_start, _keys_start, shape, _strm, mem)
+    elif dtype == numpy.complex64:
+        _argsort[cpy_complex64](
+            _idx_start, _data_start, _keys_start, shape, _strm, mem)
+    elif dtype == numpy.complex128:
+        _argsort[cpy_complex128](
+            _idx_start, _data_start, _keys_start, shape, _strm, mem)
     else:
         raise NotImplementedError('Sorting arrays with dtype \'{}\' is not '
                                   'supported'.format(dtype))

--- a/tests/cupy_tests/sorting_tests/test_sort.py
+++ b/tests/cupy_tests/sorting_tests/test_sort.py
@@ -34,14 +34,14 @@ class TestSort(unittest.TestCase):
 
     # Test dtypes
 
-    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
+    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=False)
     @testing.numpy_cupy_allclose()
     def test_sort_dtype(self, xp, dtype):
         a = testing.shaped_random((10,), xp, dtype)
         a.sort()
         return a
 
-    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
+    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=False)
     @testing.numpy_cupy_allclose()
     def test_external_sort_dtype(self, xp, dtype):
         a = testing.shaped_random((10,), xp, dtype)
@@ -184,7 +184,7 @@ class TestLexsort(unittest.TestCase):
 
     # Test dtypes
 
-    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
+    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=False)
     @testing.numpy_cupy_allclose()
     def test_lexsort_dtype(self, xp, dtype):
         a = testing.shaped_random((2, 10), xp, dtype)
@@ -212,19 +212,19 @@ class TestArgsort(unittest.TestCase):
 
     # Test base cases
 
-    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
+    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=False)
     @testing.numpy_cupy_raises()
     def test_argsort_zero_dim(self, xp, dtype):
         a = testing.shaped_random((), xp, dtype)
         return self.argsort(a)
 
-    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
+    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=False)
     @testing.numpy_cupy_array_equal()
     def test_argsort_one_dim(self, xp, dtype):
         a = testing.shaped_random((10,), xp, dtype)
         return self.argsort(a)
 
-    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
+    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=False)
     @testing.numpy_cupy_array_equal()
     def test_argsort_multi_dim(self, xp, dtype):
         a = testing.shaped_random((2, 3, 3), xp, dtype)
@@ -237,7 +237,7 @@ class TestArgsort(unittest.TestCase):
 
     # Test unsupported dtype
 
-    @testing.for_dtypes([numpy.float16, numpy.bool_, numpy.complex64])
+    @testing.for_dtypes([numpy.float16, numpy.bool_])
     def test_argsort_unsupported_dtype(self, dtype):
         a = testing.shaped_random((10,), cupy, dtype)
         with self.assertRaises(NotImplementedError):
@@ -307,13 +307,13 @@ class TestMsort(unittest.TestCase):
         a = testing.shaped_random((), xp)
         return xp.msort(a)
 
-    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
+    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=False)
     @testing.numpy_cupy_array_equal()
     def test_msort_one_dim(self, xp, dtype):
         a = testing.shaped_random((10,), xp, dtype)
         return xp.msort(a)
 
-    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
+    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=False)
     @testing.numpy_cupy_array_equal()
     def test_msort_multi_dim(self, xp, dtype):
         a = testing.shaped_random((2, 3), xp, dtype)
@@ -321,7 +321,7 @@ class TestMsort(unittest.TestCase):
 
     # Test unsupported dtype
 
-    @testing.for_dtypes([numpy.float16, numpy.bool_, numpy.complex64])
+    @testing.for_dtypes([numpy.float16, numpy.bool_])
     def test_msort_unsupported_dtype(self, dtype):
         a = testing.shaped_random((10,), cupy, dtype)
         with self.assertRaises(NotImplementedError):


### PR DESCRIPTION
Support `sort()`/`msort()`, `lexsort()` and `argsort()` on `complex64` and `complex128` arrays. I am making the build time of the `cupy.cuda.thrust` module even longer! 🤣

Supporting complex numbers in the `thrust` module  is trickier than in the `cub` module, because it can only depend on `cuComplex.h`. I couldn't get the complex headers from either CuPy or Thrust to work. The former compiles but segfaults at import time (likely due to the namespace collision), and the latter gives me "no matching `thrust::complex<T>::real` found" error even after I added specializations of `operator<()` and `real()` (a77d1bf contains leftovers of failed attempts). Perhaps enabling CUB's `sort` support would circumvent this problem, but it should be a separate PR. 

NumPy has a special rule for sorting complex NaNs, see https://docs.scipy.org/doc/numpy/reference/generated/numpy.sort.html. It is taken care of in this PR.