### PR TITLE
[v6] Fix axes handling in `_fftn`

### DIFF
--- a/cupy/fft/fft.py
+++ b/cupy/fft/fft.py
@@ -373,13 +373,17 @@ def _fftn(a, s, axes, norm, direction, value_type='C2C', order='A', plan=None,
                          % norm)
 
     a = _convert_dtype(a, value_type)
+
+    if (s is not None) and (axes is not None) and len(s) != len(axes):
+        raise ValueError('Shape and axes have different lengths.')
+
     if axes is None:
-        dim = a.ndim
+        if s is None:
+            dim = a.ndim
+        else:
+            dim = len(s)
         axes = [i for i in six.moves.range(-dim, 0)]
     axes = tuple(axes)
-
-    if (s is not None) and len(s) != len(axes):
-        raise ValueError('Shape and axes have different lengths.')
 
     if order == 'A':
         if a.flags.f_contiguous:

--- a/cupy/fft/fft.py
+++ b/cupy/fft/fft.py
@@ -381,9 +381,6 @@ def _fftn(a, s, axes, norm, direction, value_type='C2C', order='A', plan=None,
     if (s is not None) and len(s) != len(axes):
         raise ValueError('Shape and axes have different lengths.')
 
-    # sort the provided axes in ascending order
-    axes = tuple(sorted(np.mod(axes, a.ndim)))
-
     if order == 'A':
         if a.flags.f_contiguous:
             order = 'F'
@@ -400,6 +397,9 @@ def _fftn(a, s, axes, norm, direction, value_type='C2C', order='A', plan=None,
         a = cupy.ascontiguousarray(a)
     elif order == 'F' and not a.flags.f_contiguous:
         a = cupy.asfortranarray(a)
+
+    # sort the provided axes in ascending order
+    axes = tuple(sorted(np.mod(axes, a.ndim)))
 
     a = _exec_fftn(a, direction, value_type, norm=norm, axes=axes,
                    overwrite_x=overwrite_x, plan=plan, out=out)

--- a/tests/cupy_tests/fft_tests/test_fft.py
+++ b/tests/cupy_tests/fft_tests/test_fft.py
@@ -243,6 +243,7 @@ class TestFft2(unittest.TestCase):
     {'shape': (2, 3, 4), 's': None, 'axes': (0, 1), 'norm': None},
     {'shape': (2, 3, 4), 's': None, 'axes': None, 'norm': 'ortho'},
     {'shape': (2, 3, 4), 's': (2, 3), 'axes': (0, 1, 2), 'norm': 'ortho'},
+    {'shape': (2, 3, 4), 's': (4, 3, 2), 'axes': (2, 0, 1), 'norm': 'ortho'},
     {'shape': (2, 3, 4, 5), 's': None, 'axes': None, 'norm': None},
 )
 @testing.gpu


### PR DESCRIPTION
From #2355, this PR backports the fixes in `cupy/fft/fft.py`.

The n-dim FFT implementation `_fftn` should correctly handle
- `axes=None` regardless of whether `shape` is specified, and
- unsorted `axes`