### PR TITLE
Fix `block_stride` in `reduction.pxi` for performance improvement

### DIFF
--- a/cupy/core/reduction.pxi
+++ b/cupy/core/reduction.pxi
@@ -165,6 +165,7 @@ cpdef (Py_ssize_t, Py_ssize_t, Py_ssize_t) _get_block_specs(  # NOQA
     reduce_block_size = max(1, in_size // out_size)
     contiguous_size = min(contiguous_size, 32)
     block_stride = max(contiguous_size, _block_size // reduce_block_size)
+    block_stride = min(block_stride, (out_size + 31) // 32)
     block_stride = internal.clp2(block_stride // 2 + 1)  # floor
     out_block_num = (out_size + block_stride - 1) // block_stride
 


### PR DESCRIPTION
This PR speeds up reduction operations when
1. output-axis is contiguous, and
1. output size is less than 1024 (= 32(warp size) * 32(maximum number of blocks)).

Benchmark script: https://gist.github.com/asi1024/01081416f54d28cb7043f6d1fa755764
Current master (8d6317313): https://gist.github.com/asi1024/2b5d8d119a6ef82421e62893157dd468
This PR (3c2117dcf): https://gist.github.com/asi1024/563e47924533196d130df35ce04388bd