### PR TITLE
Add `digitize`

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -678,6 +678,7 @@ from cupy.statistics.meanvar import nanstd  # NOQA
 from cupy.statistics.meanvar import nanvar  # NOQA
 
 from cupy.statistics.histogram import bincount  # NOQA
+from cupy.statistics.histogram import digitize  # NOQA
 from cupy.statistics.histogram import histogram  # NOQA
 
 # -----------------------------------------------------------------------------

--- a/cupy/sorting/search.py
+++ b/cupy/sorting/search.py
@@ -222,11 +222,10 @@ _searchsorted_kernel = core.ElementwiseKernel(
     // allowing both, increasing and decreasing
     bool inc = true;
     if (check_mono && n_bins >= 2) {
-        int i=0;
-        // Need to iterate because of possible NaN values
-        do {
-            inc = bins[i] <= bins[i+1];
-        } while (bins[i] == bins[++i]);
+        // In the case all the bins are nan the array is considered
+        // to be decreasing in numpy
+        inc = (bins[0] <= bins[n_bins-1]) \
+              || (!_isnan<T>(bins[0]) && _isnan<T>(bins[n_bins-1]));
     }
 
     if (_isnan<S>(x)) {
@@ -353,6 +352,7 @@ def _searchsorted(a, v, side, sorter, check):
         a = a.take(sorter)
 
     y = cupy.zeros(v.shape, dtype=cupy.int64)
+
     _searchsorted_kernel(v, a, a.size, side == 'right', check, y)
     return y
 

--- a/cupy/statistics/histogram.py
+++ b/cupy/statistics/histogram.py
@@ -139,7 +139,7 @@ def bincount(x, weights=None, minlength=None):
 
 
 def digitize(x, bins, right=False):
-    """ Finds the indices of the bins to which each value in input array belongs.
+    """Finds the indices of the bins to which each value in input array belongs.
 
     .. note::
 
@@ -159,25 +159,15 @@ def digitize(x, bins, right=False):
 
     .. seealso:: :func:`numpy.digitize`
     """
-    bins = cupy.asarray(bins)
-
     # This is for NumPy compat, although it works fine
     if x.dtype.kind == 'c':
-        raise TypeError("x may not be complex")
+        raise TypeError('x may not be complex')
 
     if bins.ndim > 1:
         raise ValueError('object too deep for desired array')
     if bins.ndim < 1:
         raise ValueError('object of too small depth for desired array')
 
-    if not isinstance(bins, cupy.ndarray):
-        raise NotImplementedError('Only int or ndarray are supported for bins')
-
     # As the order of the arguments are reversed, the side must be too.
     side = 'left' if right else 'right'
-    if right:
-        return cupy.sorting.search._searchsorted(
-            bins, x, side, None, True)
-    else:
-        return cupy.sorting.search._searchsorted(
-            bins, x, side, None, True)
+    return cupy.sorting.search._searchsorted(bins, x, side, None, False)

--- a/cupy/statistics/histogram.py
+++ b/cupy/statistics/histogram.py
@@ -136,3 +136,48 @@ def bincount(x, weights=None, minlength=None):
         _bincount_with_weight_kernel(x, weights, b)
 
     return b
+
+
+def digitize(x, bins, right=False):
+    """ Finds the indices of the bins to which each value in input array belongs.
+
+    .. note::
+
+        In order to avoid device synchronization, digitize does not raise
+        an exception when the array is not monotonic
+
+    Args:
+        x (cupy.ndarray): Input array.
+        bins (cupy.ndarray): Array of bins.
+            It has to be 1-dimensional and monotonic increasing or decreasing.
+        right (bool):
+            Indicates whether the intervals include the right or the left bin
+            edge.
+
+    Returns:
+        cupy.ndarray: Output array of indices, of same shape as ``x``.
+
+    .. seealso:: :func:`numpy.digitize`
+    """
+    bins = cupy.asarray(bins)
+
+    # This is for NumPy compat, although it works fine
+    if x.dtype.kind == 'c':
+        raise TypeError("x may not be complex")
+
+    if bins.ndim > 1:
+        raise ValueError('object too deep for desired array')
+    if bins.ndim < 1:
+        raise ValueError('object of too small depth for desired array')
+
+    if not isinstance(bins, cupy.ndarray):
+        raise NotImplementedError('Only int or ndarray are supported for bins')
+
+    # As the order of the arguments are reversed, the side must be too.
+    side = 'left' if right else 'right'
+    if right:
+        return cupy.sorting.search._searchsorted(
+            bins, x, side, None, True)
+    else:
+        return cupy.sorting.search._searchsorted(
+            bins, x, side, None, True)

--- a/tests/cupy_tests/statics_tests/test_histogram.py
+++ b/tests/cupy_tests/statics_tests/test_histogram.py
@@ -153,19 +153,14 @@ class TestHistogram(unittest.TestCase):
 @testing.gpu
 @testing.parameterize(*testing.product(
     {'bins': [
-        [0, 1, 2, 4, 10],
-        [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-        [0.0, 1.0, 2.5, 4.0, 10.0],
-        [-1.0, 1.0, 2.5, 4.0, 20.0],
+        # Test monotonically increasing with in-bounds values
         [1.5, 2.5, 4.0, 6.0],
+        # Explicit out-of-bounds for x values
+        [-1.0, 1.0, 2.5, 4.0, 20.0],
+        # Repeated values should yield right-most or left-most indexes
         [0.0, 1.0, 1.0, 4.0, 4.0, 10.0],
-        [0.0, 1.0, 1.0, 4.0, 4.0, 4.0, 4.0, 10.0],
-        [10.0, 4.0, 2.5, 1.0, 0.0],
-        [10.0, 4.0, 4.0, 2.5, 1.0, 0.0],
-        [10.0, 10.0, 4.0, 4.0, 4.0, 4.0, 2.5, 1.0, 0.0, 0.0],
-        [15.0, 4.0, 2.5, 1.0, -1.0],
-        [4.0, 3.0, 2.5, 1.0],
     ],
+        'increasing': [True, False],
         'right': [True, False],
         'shape': [(), (10,), (6, 3, 3)]})
 )
@@ -176,7 +171,10 @@ class TestDigitize(unittest.TestCase):
     @testing.numpy_cupy_array_list_equal()
     def test_digitize(self, xp, dtype):
         x = testing.shaped_arange(self.shape, xp, dtype)
-        bins = xp.array(self.bins)
+        bins = self.bins
+        if not self.increasing:
+            bins = bins[::-1]
+        bins = xp.array(bins)
         y = xp.digitize(x, bins, right=self.right)
         return y,
 

--- a/tests/cupy_tests/statics_tests/test_histogram.py
+++ b/tests/cupy_tests/statics_tests/test_histogram.py
@@ -148,3 +148,134 @@ class TestHistogram(unittest.TestCase):
     def test_bincount_too_small_minlength(self, xp, dtype):
         x = testing.shaped_arange((3,), xp, dtype)
         return xp.bincount(x, minlength=-1)
+
+
+@testing.gpu
+@testing.parameterize(*testing.product(
+    {'bins': [
+        [0, 1, 2, 4, 10],
+        [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        [0.0, 1.0, 2.5, 4.0, 10.0],
+        [-1.0, 1.0, 2.5, 4.0, 20.0],
+        [1.5, 2.5, 4.0, 6.0],
+        [0.0, 1.0, 1.0, 4.0, 4.0, 10.0],
+        [0.0, 1.0, 1.0, 4.0, 4.0, 4.0, 4.0, 10.0],
+        [10.0, 4.0, 2.5, 1.0, 0.0],
+        [10.0, 4.0, 4.0, 2.5, 1.0, 0.0],
+        [10.0, 10.0, 4.0, 4.0, 4.0, 4.0, 2.5, 1.0, 0.0, 0.0],
+        [15.0, 4.0, 2.5, 1.0, -1.0],
+        [4.0, 3.0, 2.5, 1.0],
+    ],
+        'right': [True, False],
+        'shape': [(), (10,), (6, 3, 3)]})
+)
+class TestDigitize(unittest.TestCase):
+
+    @testing.with_requires('numpy>=1.10.0')
+    @testing.for_all_dtypes(no_bool=True, no_complex=True)
+    @testing.numpy_cupy_array_list_equal()
+    def test_digitize(self, xp, dtype):
+        x = testing.shaped_arange(self.shape, xp, dtype)
+        bins = xp.array(self.bins)
+        y = xp.digitize(x, bins, right=self.right)
+        return y,
+
+
+@testing.gpu
+@testing.parameterize(
+    {'right': True},
+    {'right': False})
+class TestDigitizeNanInf(unittest.TestCase):
+
+    @testing.with_requires('numpy>=1.10.0')
+    @testing.numpy_cupy_array_list_equal()
+    def test_digitize_nan(self, xp):
+        x = testing.shaped_arange((14,), xp, xp.float32)
+        x[5] = float('nan')
+        bins = xp.array([1.0, 3.0, 5.0, 8.0, 12.0], xp.float32)
+        y = xp.digitize(x, bins, right=self.right)
+        return y,
+
+    @testing.with_requires('numpy>=1.10.0')
+    @testing.numpy_cupy_array_list_equal()
+    def test_digitize_nan_bins(self, xp):
+        x = testing.shaped_arange((14,), xp, xp.float32)
+        bins = xp.array([1.0, 3.0, 5.0, 8.0, float('nan')], xp.float32)
+        y = xp.digitize(x, bins, right=self.right)
+        return y,
+
+    @testing.with_requires('numpy>=1.10.0')
+    @testing.numpy_cupy_array_list_equal()
+    def test_digitize_nan_bins_repeated(self, xp):
+        x = testing.shaped_arange((14,), xp, xp.float32)
+        x[5] = float('nan')
+        bins = [1.0, 3.0, 5.0, 8.0, float('nan'), float('nan')]
+        bins = xp.array(bins, xp.float32)
+        y = xp.digitize(x, bins, right=self.right)
+        return y,
+
+    @testing.with_requires('numpy>=1.10.0')
+    @testing.numpy_cupy_array_list_equal()
+    def test_digitize_nan_bins_decreasing(self, xp):
+        x = testing.shaped_arange((14,), xp, xp.float32)
+        x[5] = float('nan')
+        bins = [float('nan'), 8.0, 5.0, 3.0, 1.0]
+        bins = xp.array(bins, xp.float32)
+        y = xp.digitize(x, bins, right=self.right)
+        return y,
+
+    @testing.with_requires('numpy>=1.10.0')
+    @testing.numpy_cupy_array_list_equal()
+    def test_digitize_nan_bins_decreasing_repeated(self, xp):
+        x = testing.shaped_arange((14,), xp, xp.float32)
+        x[5] = float('nan')
+        bins = [float('nan'), float('nan'), float('nan'), 5.0, 3.0, 1.0]
+        bins = xp.array(bins, xp.float32)
+        y = xp.digitize(x, bins, right=self.right)
+        return y,
+
+    @testing.with_requires('numpy>=1.10.0')
+    @testing.numpy_cupy_array_list_equal()
+    def test_digitize_all_nan_bins(self, xp):
+        x = testing.shaped_arange((14,), xp, xp.float32)
+        x[5] = float('nan')
+        bins = [float('nan'), float('nan'), float('nan'), float('nan')]
+        bins = xp.array(bins, xp.float32)
+        y = xp.digitize(x, bins, right=self.right)
+        return y,
+
+    @testing.with_requires('numpy>=1.10.0')
+    @testing.numpy_cupy_array_list_equal()
+    def test_searchsorted_inf(self, xp):
+        x = testing.shaped_arange((14,), xp, xp.float64)
+        x[5] = float('inf')
+        bins = xp.array([0, 1, 2, 4, 10])
+        y = xp.digitize(x, bins, right=self.right)
+        return y,
+
+    @testing.with_requires('numpy>=1.10.0')
+    @testing.numpy_cupy_array_list_equal()
+    def test_searchsorted_minf(self, xp):
+        x = testing.shaped_arange((14,), xp, xp.float64)
+        x[5] = float('-inf')
+        bins = xp.array([0, 1, 2, 4, 10])
+        y = xp.digitize(x, bins, right=self.right)
+        return y,
+
+
+@testing.gpu
+class TestDigitizeInvalid(unittest.TestCase):
+
+    @testing.with_requires('numpy>=1.10.0')
+    @testing.numpy_cupy_raises(accept_error=TypeError)
+    def test_digitize_complex(self, xp):
+        x = testing.shaped_arange((14,), xp, xp.complex)
+        bins = xp.array([1.0, 3.0, 5.0, 8.0, 12.0], xp.complex)
+        xp.digitize(x, bins)
+
+    @testing.with_requires('numpy>=1.10.0')
+    @testing.numpy_cupy_raises(accept_error=ValueError)
+    def test_digitize_nd_bins(self, xp):
+        x = testing.shaped_arange((14,), xp, xp.float64)
+        bins = xp.array([[1], [2]])
+        xp.digitize(x, bins)


### PR DESCRIPTION
Adds `digitize` using `searchsorted`

As `digitize` supports increasing and decreasing arrays, I tuned the `searchsorted` kernel to do the monotonicity check and support both sorting directions. However, a specific kernel only for digitize can be made or the arrays could be simply reversed as in the numpy implementation.