### PR TITLE
Fix slow import of cupy

### DIFF
--- a/cupy/testing/helper.py
+++ b/cupy/testing/helper.py
@@ -1016,7 +1016,10 @@ def with_requires(*requirements):
             run a given test case.
 
     """
+    # Delay import of pkg_resources because it is excruciatingly slow.
+    # See https://github.com/pypa/setuptools/issues/510
     import pkg_resources
+
     ws = pkg_resources.WorkingSet()
     try:
         ws.require(*requirements)
@@ -1034,7 +1037,10 @@ def numpy_satisfies(version_range):
     Args:
         version_range: A version specifier (e.g., `>=1.13.0`).
     """
+    # Delay import of pkg_resources because it is excruciatingly slow.
+    # See https://github.com/pypa/setuptools/issues/510
     import pkg_resources
+
     spec = 'numpy{}'.format(version_range)
     try:
         pkg_resources.require(spec)

--- a/cupy/testing/helper.py
+++ b/cupy/testing/helper.py
@@ -5,7 +5,6 @@ import contextlib
 import functools
 import inspect
 import os
-import pkg_resources
 import random
 import sys
 import traceback
@@ -1017,6 +1016,7 @@ def with_requires(*requirements):
             run a given test case.
 
     """
+    import pkg_resources
     ws = pkg_resources.WorkingSet()
     try:
         ws.require(*requirements)
@@ -1034,6 +1034,7 @@ def numpy_satisfies(version_range):
     Args:
         version_range: A version specifier (e.g., `>=1.13.0`).
     """
+    import pkg_resources
     spec = 'numpy{}'.format(version_range)
     try:
         pkg_resources.require(spec)


### PR DESCRIPTION
Delay import of pkg_resources

On my Windows workstation, `import cupy` takes 3.5 s, about 3 s of which are spent in `import pkg_resources`.

Importing `pkg_resources` is known to be excruciatingly slow. See https://github.com/pypa/setuptools/issues/510