### PR TITLE
[RFC] Redesign cuTENSOR handle initialization (version 2)

### DIFF
--- a/cupy/cuda/cutensor.pyx
+++ b/cupy/cuda/cutensor.pyx
@@ -125,10 +125,12 @@ cdef extern from 'cupy_cutensor.h' nogil:
 
 
 ###############################################################################
-# Enum
+# Enum and constants
 ###############################################################################
 
 cpdef enum:
+    HANDLE_SIZE = sizeof(Handle)
+
     # cutensorAlgo_t (values > 0 correspond to certain algorithms of GETT)
     ALGO_GETT = -4     # NOQA, Choose the GETT algorithm
     ALGO_TGETT = -3    # NOQA, Transpose (A or B) + GETT
@@ -226,17 +228,11 @@ cpdef inline check_status(int status):
 # Handler initialization
 ###############################################################################
 
-cpdef intptr_t init() except? 0:
+cpdef void init(intptr_t handle) except *:
     """Initializes the cuTENSOR library"""
-    cdef Handle *handle = <Handle*>PyMem_Malloc(sizeof(Handle))
     with nogil:
-        status = cutensorInit(handle)
+        status = cutensorInit(<Handle*>handle)
     check_status(status)
-    return <intptr_t>handle
-
-
-cpdef destroy(intptr_t handle):
-    PyMem_Free(<Handle*>handle)
 
 
 ###############################################################################

--- a/cupy/util.pyx
+++ b/cupy/util.pyx
@@ -1,5 +1,8 @@
 # distutils: language = c++
 
+from cpython cimport mem
+from libc.stdint cimport intptr_t
+
 import atexit
 import collections
 import functools
@@ -24,6 +27,16 @@ except AttributeError:  # python <3.3
 
 
 cdef list _memos = []
+
+
+cpdef intptr_t malloc(size_t size):
+    """Allocates a memory of specified size."""
+    return <intptr_t>mem.PyMem_Malloc(size)
+
+
+cpdef void free(intptr_t ptr):
+    """Frees the specified memory."""
+    mem.PyMem_Free(<void*>ptr)
 
 
 def _normalize_axis_index(axis, ndim):


### PR DESCRIPTION
See also: https://github.com/cupy/cupy/pull/2709#discussion_r352266025

This is one possible API design of `cupy/cuda/cutensor.pyx` for cuTENSOR handle initialization.

`cupy/cuda/cutensor.pyx` is seen as very thin layer to face cuTENSOR, with 1-to-1 correspondence to its C API.
