### PR TITLE
Rename and reorder private functions in `reduction.pxi`

### DIFF
--- a/cupy/core/reduction.pxi
+++ b/cupy/core/reduction.pxi
@@ -1,6 +1,7 @@
 from cpython cimport sequence
 
 from cupy.core cimport _routines_manipulation as _manipulation
+from cupy.cuda cimport function
 from cupy.cuda cimport runtime
 
 import string


### PR DESCRIPTION
I just want to make `reduction.pxi` a bit more organized and consistent.

This PR only includes renames and reorder of private functions/class.

* `_get_simple_reduction_kernel()` -> `_create_reduction_function()`
* `class simple_reduction_function` -> `class _SimpleReductionKernel`
* `_get_simple_reduction_function()` -> `_SimpleReductionKernel_get_cached_function()`
* `_get_reduction_kernel()` -> `_ReductionKernel_get_cached_function()`

Any comments are welcome (as usual).
