### PR TITLE
Remove unused `cuParamSetTexRef()`

### DIFF
--- a/cupy/cuda/cupy_cuda.h
+++ b/cupy/cuda/cupy_cuda.h
@@ -185,10 +185,6 @@ CUresult cuTexRefSetMaxAnisotropy (...) {
     return CUDA_SUCCESS;
 }
 
-CUresult cuParamSetTexRef (...) {
-    return CUDA_SUCCESS;
-}
-
 // Occupancy
 typedef size_t (*CUoccupancyB2DSize)(int);
 

--- a/cupy/cuda/cupy_hip.h
+++ b/cupy/cuda/cupy_hip.h
@@ -157,10 +157,6 @@ CUresult cuTexRefSetMaxAnisotropy (...) {
     return hipErrorUnknown;
 }
 
-CUresult cuParamSetTexRef (...) {
-    return hipErrorUnknown;
-}
-
 // Occupancy
 typedef size_t (*CUoccupancyB2DSize)(int);
 

--- a/cupy/cuda/driver.pxd
+++ b/cupy/cuda/driver.pxd
@@ -143,7 +143,6 @@ cpdef texRefSetFilterMode(intptr_t texref, int fm)
 cpdef texRefSetFlags(intptr_t texref, unsigned int Flags)
 cpdef texRefSetFormat(intptr_t texref, int fmt, int NumPackedComponents)
 cpdef texRefSetMaxAnisotropy(intptr_t texref, unsigned int maxAniso)
-cpdef paramSetTexRef(intptr_t func, intptr_t texref)
 
 ###############################################################################
 # Occupancy

--- a/cupy/cuda/driver.pxd
+++ b/cupy/cuda/driver.pxd
@@ -82,8 +82,6 @@ cpdef enum:
     CU_TRSF_NORMALIZED_COORDINATES = 0x02
     CU_TRSF_SRGB = 0x10
 
-    CU_PARAM_TR_DEFAULT = -1
-
 
 ###############################################################################
 # Primary context management

--- a/cupy/cuda/driver.pyx
+++ b/cupy/cuda/driver.pyx
@@ -79,7 +79,6 @@ cdef extern from 'cupy_cuda.h' nogil:
     int cuTexRefSetFormat(TexRef hTexRef, Array_format fmt,
                           int NumPackedComponents)
     int cuTexRefSetMaxAnisotropy(TexRef hTexRef, unsigned int maxAniso)
-    int cuParamSetTexRef(Function hfunc, int texunit, TexRef hTexRef)
 
     # Occupancy
     int cuOccupancyMaxActiveBlocksPerMultiprocessor(
@@ -384,13 +383,6 @@ cpdef texRefSetFormat(intptr_t texref, int fmt, int NumPackedComponents):
 cpdef texRefSetMaxAnisotropy(intptr_t texref, unsigned int maxAniso):
     with nogil:
         status = cuTexRefSetMaxAnisotropy(<TexRef>texref, maxAniso)
-    check_status(status)
-
-
-cpdef paramSetTexRef(intptr_t func, intptr_t texref):
-    with nogil:
-        status = cuParamSetTexRef(<Function>func, CU_PARAM_TR_DEFAULT,
-                                  <TexRef>texref)
     check_status(status)
 
 


### PR DESCRIPTION
Part of #2768. It's currently unused in the codebase, and it's marked deprecated for quite some time, so let us remove it to suppress some deprecate warnings.