### PR TITLE
update slicing of CSR and CSC matrices for compatibility with SciPy 1.4.0

### DIFF
--- a/cupyx/scipy/sparse/compressed.py
+++ b/cupyx/scipy/sparse/compressed.py
@@ -285,7 +285,8 @@ class _compressed_sparse_matrix(sparse_data._data_matrix):
             raise ValueError('slicing with step != 1 not supported')
 
         if not (major_start <= major_stop):
-            raise IndexError('index out of bounds')
+            # will give an empty slice, but preserve shape on the other axis
+            major_start = major_stop
 
         start = self.indptr[major_start]
         stop = self.indptr[major_stop]

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
@@ -1008,16 +1008,11 @@ class TestCsrMatrixGetitem(unittest.TestCase):
     def test_getitem_slice_negative(self, xp, sp):
         return _make(xp, sp, self.dtype)[:, -2:-1]
 
-    # avoid segfault in 1.3.x: https://github.com/scipy/scipy/issues/11125
-    @testing.with_requires('scipy<1.3.0')
-    @testing.numpy_cupy_raises(sp_name='sp', accept_error=IndexError)
-    def test_getitem_slice_start_larger_than_stop(self, xp, sp):
-        _make(xp, sp, self.dtype)[:, 3:2]
-
-    # SciPy 1.4 returns an empty matrix instead of raising an error
+    # SciPy prior to 1.4 has bugs where either an IndexError is raised or a
+    # segfault occurs instead of returning an empty slice.
     @testing.with_requires('scipy>=1.4')
     @testing.numpy_cupy_allclose(sp_name='sp')
-    def test_getitem_slice_start_larger_than_stop2(self, xp, sp):
+    def test_getitem_slice_start_larger_than_stop(self, xp, sp):
         return _make(xp, sp, self.dtype)[:, 3:2]
 
     def test_getitem_slice_step_2(self):

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
@@ -1008,11 +1008,17 @@ class TestCsrMatrixGetitem(unittest.TestCase):
     def test_getitem_slice_negative(self, xp, sp):
         return _make(xp, sp, self.dtype)[:, -2:-1]
 
-    # avoid segfault: https://github.com/scipy/scipy/issues/11125
-    @testing.with_requires('scipy!=1.3.*')
+    # avoid segfault in 1.3.x: https://github.com/scipy/scipy/issues/11125
+    @testing.with_requires('scipy<1.3.0')
     @testing.numpy_cupy_raises(sp_name='sp', accept_error=IndexError)
     def test_getitem_slice_start_larger_than_stop(self, xp, sp):
         _make(xp, sp, self.dtype)[:, 3:2]
+
+    # SciPy 1.4 returns an empty matrix instead of raising an error
+    @testing.with_requires('scipy>=1.4')
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_getitem_slice_start_larger_than_stop2(self, xp, sp):
+        return _make(xp, sp, self.dtype)[:, 3:2]
 
     def test_getitem_slice_step_2(self):
         with self.assertRaises(ValueError):

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -1118,16 +1118,11 @@ class TestCsrMatrixGetitem(unittest.TestCase):
     def test_getitem_slice_negative(self, xp, sp):
         return _make(xp, sp, self.dtype)[-2:-1]
 
-    # avoid segfault in 1.3.x: https://github.com/scipy/scipy/issues/11125
-    @testing.with_requires('scipy<1.3.0')
-    @testing.numpy_cupy_raises(sp_name='sp', accept_error=IndexError)
-    def test_getitem_slice_start_larger_than_stop(self, xp, sp):
-        _make(xp, sp, self.dtype)[3:2]
-
-    # SciPy 1.4 returns an empty matrix instead of raising an error
+    # SciPy prior to 1.4 has bugs where either an IndexError is raised or a
+    # segfault occurs instead of returning an empty slice.
     @testing.with_requires('scipy>=1.4')
     @testing.numpy_cupy_allclose(sp_name='sp')
-    def test_getitem_slice_start_larger_than_stop2(self, xp, sp):
+    def test_getitem_slice_start_larger_than_stop(self, xp, sp):
         return _make(xp, sp, self.dtype)[3:2]
 
     def test_getitem_slice_step_2(self):

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -1118,11 +1118,17 @@ class TestCsrMatrixGetitem(unittest.TestCase):
     def test_getitem_slice_negative(self, xp, sp):
         return _make(xp, sp, self.dtype)[-2:-1]
 
-    # avoid segfault: https://github.com/scipy/scipy/issues/11125
-    @testing.with_requires('scipy!=1.3.*')
+    # avoid segfault in 1.3.x: https://github.com/scipy/scipy/issues/11125
+    @testing.with_requires('scipy<1.3.0')
     @testing.numpy_cupy_raises(sp_name='sp', accept_error=IndexError)
     def test_getitem_slice_start_larger_than_stop(self, xp, sp):
         _make(xp, sp, self.dtype)[3:2]
+
+    # SciPy 1.4 returns an empty matrix instead of raising an error
+    @testing.with_requires('scipy>=1.4')
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_getitem_slice_start_larger_than_stop2(self, xp, sp):
+        return _make(xp, sp, self.dtype)[3:2]
 
     def test_getitem_slice_step_2(self):
         with self.assertRaises(ValueError):


### PR DESCRIPTION
This is a follow up to #2712 that updates CSR and CSC sparse matrix slicing tests for 1.4.0. The prior PR just skipped the existing tests on 1.3.x to avoid segfaults. 

In SciPy 1.4.0, the behavior for this tests case is changed from raising an `IndexError` to instead return an empty slice. [For reference see this comment at at SciPy](https://github.com/scipy/scipy/pull/11127#issuecomment-560936956) (and the implementation in scipy/scipy#11166). The new behavior is consistent with slicing of NumPy arrays/matrices. 

The PR corresponding to this behavior is being backported to the 1.4.0 branch for inclusion prior to the upcoming 1.4.0 release (see scipy/scipy#11161). For the moment I have just verified that the new test cases pass vs. current SciPy master.
