### PR TITLE
Separate reduction code from `_kernel.pyx`

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -695,7 +695,7 @@ from cupy.util import memoize  # NOQA
 from cupy.core import ElementwiseKernel  # NOQA
 from cupy.core import RawKernel  # NOQA
 from cupy.core import RawModule  # NOQA
-from cupy.core import ReductionKernel  # NOQA
+from cupy.core._reduction import ReductionKernel  # NOQA
 
 # -----------------------------------------------------------------------------
 # DLPack

--- a/cupy/core/__init__.py
+++ b/cupy/core/__init__.py
@@ -4,11 +4,11 @@ from cupy.core import internal  # NOQA
 
 # import class and function
 from cupy.core._errors import _AxisError  # NOQA
-from cupy.core._kernel import create_reduction_func  # NOQA
 from cupy.core._kernel import create_ufunc  # NOQA
 from cupy.core._kernel import ElementwiseKernel  # NOQA
-from cupy.core._kernel import ReductionKernel  # NOQA
 from cupy.core._kernel import ufunc  # NOQA
+from cupy.core._reduction import create_reduction_func  # NOQA
+from cupy.core._reduction import ReductionKernel  # NOQA
 from cupy.core._routines_manipulation import array_split  # NOQA
 from cupy.core._routines_manipulation import broadcast  # NOQA
 from cupy.core._routines_manipulation import broadcast_to  # NOQA

--- a/cupy/core/_kernel.pxd
+++ b/cupy/core/_kernel.pxd
@@ -1,3 +1,37 @@
+from cupy.core.core cimport ndarray
+
+
+cdef class ParameterInfo:
+    cdef:
+        readonly str name
+        readonly object dtype
+        readonly str ctype
+        readonly bint raw
+        readonly bint is_const
+
+
 cpdef create_ufunc(name, ops, routine=*, preamble=*, doc=*,
                    default_casting=*, loop_prep=*)
-cpdef create_reduction_func(name, ops, routine=*, identity=*, preamble=*)
+
+cpdef tuple _get_args_info(list args)
+
+cpdef str _get_kernel_params(tuple params, tuple args_info)
+
+cdef tuple _broadcast(list args, tuple params, bint use_size)
+
+cdef list _get_out_args(list out_args, tuple out_types, tuple out_shape,
+                        casting)
+
+cdef list _get_out_args_with_params(
+    list out_args, tuple out_types, tuple out_shape, tuple out_params,
+    bint is_size_specified)
+
+cdef tuple _guess_routine_from_dtype(list ops, object dtype)
+
+cdef tuple _guess_routine(str name, dict cache, list ops, list in_args, dtype)
+
+cdef _check_array_device_id(ndarray arr, int device_id)
+
+cdef list _preprocess_args(int dev_id, args, bint use_c_scalar)
+
+cdef tuple _reduce_dims(list args, tuple params, tuple shape)

--- a/cupy/core/_kernel.pyx
+++ b/cupy/core/_kernel.pyx
@@ -17,7 +17,6 @@ from cupy.cuda cimport device
 from cupy.cuda cimport function
 from cupy.core cimport _scalar
 from cupy.core._dtype cimport get_dtype
-from cupy.core._routines_manipulation cimport _broadcast_core
 from cupy.core._scalar import get_typename as _get_typename
 from cupy.core.core cimport _convert_object_with_cuda_array_interface
 from cupy.core.core cimport compile_with_cache
@@ -81,7 +80,7 @@ cdef inline _check_array_device_id(ndarray arr, int device_id):
             % (arr.data.device_id, device_id))
 
 
-cpdef list _preprocess_args(int dev_id, args, bint use_c_scalar):
+cdef list _preprocess_args(int dev_id, args, bint use_c_scalar):
     """Preprocesses arguments for kernel invocation
 
     - Checks device compatibility for ndarrays
@@ -140,7 +139,7 @@ cpdef str _get_kernel_params(tuple params, tuple args_info):
     return ', '.join(ret)
 
 
-cpdef tuple _reduce_dims(list args, tuple params, tuple shape):
+cdef tuple _reduce_dims(list args, tuple params, tuple shape):
     """ Remove contiguous stride to optimize CUDA kernel."""
     cdef ndarray arr
 
@@ -237,12 +236,6 @@ cdef tuple _reduced_view_core(list args, tuple params, tuple shape):
 
 
 cdef class ParameterInfo:
-    cdef:
-        readonly str name
-        readonly object dtype
-        readonly str ctype
-        readonly bint raw
-        readonly bint is_const
 
     def __init__(self, str param, bint is_const):
         self.name = None
@@ -372,7 +365,7 @@ cdef tuple _broadcast(list args, tuple params, bint use_size):
     else:
         if not is_not_none:
             raise ValueError('Loop size is Undecided')
-    _broadcast_core(value, shape)
+    internal._broadcast_core(value, shape)
     for i, a in enumerate(value):
         if a is None:
             value[i] = args[i]
@@ -924,7 +917,7 @@ cdef class ufunc:
 
         _copy_in_args_if_needed(in_args, out_args)
         broad_values = in_args + out_args
-        _broadcast_core(broad_values, vec_shape)
+        internal._broadcast_core(broad_values, vec_shape)
         shape = tuple(vec_shape)
 
         op = _guess_routine(
@@ -1003,5 +996,3 @@ cpdef create_ufunc(name, ops, routine=None, preamble='', doc='',
     ret = ufunc(name, len(_ops[0][0]), len(_ops[0][1]), _ops, preamble,
                 loop_prep, doc, default_casting=default_casting)
     return ret
-
-include 'reduction.pxi'

--- a/cupy/core/_reduction.pxd
+++ b/cupy/core/_reduction.pxd
@@ -1,0 +1,50 @@
+from cupy.core.core cimport ndarray
+from cupy.cuda cimport function
+
+
+cdef class _AbstractReductionKernel:
+
+    cdef:
+        readonly str name
+        public str identity
+        readonly tuple in_params
+        readonly tuple out_params
+        readonly tuple _params
+
+    cpdef ndarray _call(
+        self,
+        list in_args, list out_args,
+        tuple a_shape, axis, dtype,
+        bint keepdims, bint reduce_dims,
+        stream)
+
+    cdef tuple _get_expressions_and_types(
+        self, list in_args, list out_args, dtype)
+
+    cdef list _get_out_args(
+        self, list out_args, tuple out_types, tuple out_shape)
+
+    cdef function.Function _get_function(
+        self,
+        tuple params, tuple args_info, tuple types,
+        str map_expr, str reduce_expr, str post_map_expr, str reduce_type,
+        Py_ssize_t block_size)
+
+
+cdef class ReductionKernel(_AbstractReductionKernel):
+
+    cdef:
+        readonly int nin
+        readonly int nout
+        readonly int nargs
+        readonly tuple params
+        readonly str reduce_expr
+        readonly str map_expr
+        readonly str post_map_expr
+        readonly object options
+        readonly bint reduce_dims
+        readonly object reduce_type
+        readonly str preamble
+
+
+cpdef create_reduction_func(name, ops, routine=*, identity=*, preamble=*)

--- a/cupy/core/_reduction.pyx
+++ b/cupy/core/_reduction.pyx
@@ -1,12 +1,33 @@
 from cpython cimport sequence
 
+from cupy.core._dtype cimport get_dtype
+from cupy.core._kernel cimport _broadcast
+from cupy.core._kernel cimport _check_array_device_id
+from cupy.core._kernel cimport _get_args_info
+from cupy.core._kernel cimport _get_kernel_params
+from cupy.core._kernel cimport _get_out_args
+from cupy.core._kernel cimport _get_out_args_with_params
+from cupy.core._kernel cimport _guess_routine
+from cupy.core._kernel cimport _preprocess_args
+from cupy.core._kernel cimport _reduce_dims
+from cupy.core._kernel cimport ParameterInfo
 from cupy.core cimport _routines_manipulation as _manipulation
+from cupy.core cimport _scalar
+from cupy.core._scalar import get_typename as _get_typename
+from cupy.core.core cimport _convert_object_with_cuda_array_interface
+from cupy.core.core cimport compile_with_cache
+from cupy.core.core cimport Indexer
+from cupy.core.core cimport ndarray
+from cupy.core cimport internal
+from cupy.cuda cimport device
 from cupy.cuda cimport function
 from cupy.cuda cimport runtime
 
 import string
 
 from cupy.core import _errors
+from cupy.core._kernel import _get_param_info
+from cupy.core._kernel import _decide_params_type
 from cupy.cuda import compiler
 from cupy import util
 
@@ -206,13 +227,6 @@ cdef tuple _get_reduction_args(
 
 
 cdef class _AbstractReductionKernel:
-
-    cdef:
-        readonly str name
-        public str identity
-        readonly tuple in_params
-        readonly tuple out_params
-        readonly tuple _params
 
     def __init__(
             self, str name, str identity, str in_params, str out_params):
@@ -476,19 +490,6 @@ cdef class ReductionKernel(_AbstractReductionKernel):
         options (tuple of str): Additional compilation options.
 
     """
-
-    cdef:
-        readonly int nin
-        readonly int nout
-        readonly int nargs
-        readonly tuple params
-        readonly str reduce_expr
-        readonly str map_expr
-        readonly str post_map_expr
-        readonly object options
-        readonly bint reduce_dims
-        readonly object reduce_type
-        readonly str preamble
 
     def __init__(self, str in_params, str out_params,
                  map_expr, reduce_expr, post_map_expr,

--- a/cupy/core/_routines_logic.pyx
+++ b/cupy/core/_routines_logic.pyx
@@ -1,4 +1,4 @@
-from cupy.core._kernel import create_reduction_func
+from cupy.core._reduction import create_reduction_func
 
 from cupy.core.core cimport ndarray
 

--- a/cupy/core/_routines_manipulation.pxd
+++ b/cupy/core/_routines_manipulation.pxd
@@ -10,7 +10,7 @@ cdef class broadcast:
         readonly Py_ssize_t size
         readonly Py_ssize_t nd
 
-cdef _broadcast_core(list arrays, vector.vector[Py_ssize_t]& shape)
+
 cdef _ndarray_shape_setter(ndarray self, newshape)
 cdef ndarray _ndarray_reshape(ndarray self, tuple shape, order)
 cdef ndarray _ndarray_transpose(ndarray self, tuple axes)

--- a/cupy/core/_routines_manipulation.pyx
+++ b/cupy/core/_routines_manipulation.pyx
@@ -8,76 +8,14 @@ from cupy.core import _errors
 from cupy.core._kernel import ElementwiseKernel
 from cupy.core._ufuncs import elementwise_copy
 
-cimport cython  # NOQA
 cimport cpython  # NOQA
+cimport cython  # NOQA
 from libcpp cimport vector
 
 from cupy.core cimport _routines_indexing as _indexing
 from cupy.core cimport core
 from cupy.core.core cimport ndarray
 from cupy.core cimport internal
-
-
-cdef Py_ssize_t PY_SSIZE_T_MAX = sys.maxsize
-
-
-cdef _broadcast_core(list arrays, vector.vector[Py_ssize_t]& shape):
-    cdef Py_ssize_t i, j, s, smin, smax, a_ndim, a_sh, nd
-    cdef vector.vector[Py_ssize_t] strides
-    cdef vector.vector[int] index
-    cdef ndarray a
-    cdef list ret
-
-    shape.clear()
-    index.reserve(len(arrays))
-    nd = 0
-    for i, x in enumerate(arrays):
-        if not isinstance(x, ndarray):
-            continue
-        a = x
-        index.push_back(i)
-        nd = max(nd, <Py_ssize_t>a._shape.size())
-
-    if index.size() == 0:
-        return
-
-    shape.reserve(nd)
-    for i in range(nd):
-        smin = PY_SSIZE_T_MAX
-        smax = 0
-        for j in index:
-            a = arrays[j]
-            a_ndim = <Py_ssize_t>a._shape.size()
-            if i >= nd - a_ndim:
-                s = a._shape[i - (nd - a_ndim)]
-                smin = min(smin, s)
-                smax = max(smax, s)
-        if smin == 0 and smax > 1:
-            raise ValueError(
-                'shape mismatch: objects cannot be broadcast to a '
-                'single shape')
-        shape.push_back(0 if smin == 0 else smax)
-
-    for i in index:
-        a = arrays[i]
-        if internal.vector_equal(a._shape, shape):
-            continue
-
-        strides.assign(nd, <Py_ssize_t>0)
-        a_ndim = <Py_ssize_t>a._shape.size()
-        for j in range(a_ndim):
-            a_sh = a._shape[j]
-            if a_sh == shape[j + nd - a_ndim]:
-                strides[j + nd - a_ndim] = a._strides[j]
-            elif a_sh != 1:
-                raise ValueError(
-                    'operands could not be broadcast together with shapes '
-                    '{}'.format(
-                        ', '.join([str(x.shape) if isinstance(x, ndarray)
-                                   else '()' for x in arrays])))
-
-        # TODO(niboshi): Confirm update_x_contiguity flags
-        arrays[i] = a._view(shape, strides, True, True)
 
 
 @cython.final
@@ -103,7 +41,7 @@ cdef class broadcast:
     def __init__(self, *arrays):
         cdef vector.vector[Py_ssize_t] shape
         cdef list val = list(arrays)
-        _broadcast_core(val, shape)
+        internal._broadcast_core(val, shape)
         self.values = tuple(val)
         self.shape = tuple(shape)
         self.nd = <Py_ssize_t>shape.size()

--- a/cupy/core/_routines_math.pyx
+++ b/cupy/core/_routines_math.pyx
@@ -4,7 +4,7 @@ import numpy
 import six
 
 import cupy
-from cupy.core._kernel import create_reduction_func
+from cupy.core._reduction import create_reduction_func
 from cupy.core._kernel import create_ufunc
 from cupy.core._scalar import get_typename
 from cupy.core._ufuncs import elementwise_copy

--- a/cupy/core/_routines_statistics.pyx
+++ b/cupy/core/_routines_statistics.pyx
@@ -1,8 +1,8 @@
 import numpy
 from numpy import nan
 
-from cupy.core._kernel import create_reduction_func
-from cupy.core._kernel import ReductionKernel
+from cupy.core._reduction import create_reduction_func
+from cupy.core._reduction import ReductionKernel
 
 from cupy.core cimport _routines_math as _math
 from cupy.core.core cimport ndarray

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -11,8 +11,8 @@ import cupy
 from cupy.core import _errors
 from cupy.core._kernel import create_ufunc
 from cupy.core._kernel import ElementwiseKernel
-from cupy.core._kernel import ReductionKernel
 from cupy.core._kernel import ufunc  # NOQA
+from cupy.core._reduction import ReductionKernel
 from cupy.core._ufuncs import elementwise_copy
 from cupy.core._ufuncs import elementwise_copy_where
 from cupy.core import flags

--- a/cupy/core/fusion.pyx
+++ b/cupy/core/fusion.pyx
@@ -9,6 +9,7 @@ from cupy.core._dtype import get_dtype
 from cupy.core import _errors
 from cupy.core import _kernel
 from cupy.core._kernel import _is_fusing
+from cupy.core import _reduction
 from cupy.core import core
 
 
@@ -821,7 +822,7 @@ class _FusionHistory(object):
                 reduce_ctype, postmap_dtype, postmap_cast_code)
             submodule_code += self._emit_postmap_code(out_params, postmap_code)
 
-            kernel = _kernel.ReductionKernel(
+            kernel = _reduction.ReductionKernel(
                 in_params_code,
                 out_params_code,
                 '_pre_map({})'.format(', '.join([repr(p) for p in in_params])),

--- a/cupy/core/internal.pxd
+++ b/cupy/core/internal.pxd
@@ -47,3 +47,5 @@ cpdef uint16_t to_float16(float f)
 cpdef float from_float16(uint16_t v)
 
 cdef int _normalize_order(order, cpp_bool allow_k=*) except? 0
+
+cdef _broadcast_core(list arrays, vector.vector[Py_ssize_t]& shape)

--- a/cupy/manipulation/rearrange.py
+++ b/cupy/manipulation/rearrange.py
@@ -4,7 +4,7 @@ import numpy
 
 import cupy
 from cupy import core
-from cupy.core._kernel import _get_axis
+from cupy.core._reduction import _get_axis
 
 
 def flip(a, axis):

--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -45,6 +45,7 @@ cuda_files = [
     'cupy.core._dtype',
     'cupy.core._kernel',
     'cupy.core._memory_range',
+    'cupy.core._reduction',
     'cupy.core._routines_indexing',
     'cupy.core._routines_logic',
     'cupy.core._routines_manipulation',

--- a/tests/cupy_tests/core_tests/fusion_tests/test_function.py
+++ b/tests/cupy_tests/core_tests/fusion_tests/test_function.py
@@ -195,13 +195,15 @@ class TestFusionKernelName(unittest.TestCase):
         # Test kernel name (with mock)
         if xp is cupy:
             target = (
-                'cupy.core._kernel.ElementwiseKernel' if is_elementwise
-                else 'cupy.core._kernel.ReductionKernel')
+                cupy.ElementwiseKernel if is_elementwise
+                else cupy.ReductionKernel)
+            target_full_name = '{}.{}'.format(
+                target.__module__, target.__name__)
 
-            with mock.patch(target) as Kernel:
+            with mock.patch(target_full_name) as kernel:
                 func(a, b, c)
-                Kernel.assert_called_once()
-                self.assertEqual(Kernel.call_args[1]['name'], expected_name)
+                kernel.assert_called_once()
+                self.assertEqual(kernel.call_args[1]['name'], expected_name)
 
         # Test there's no error in computation (without mock)
         return func(a, b, c)

--- a/tests/cupy_tests/core_tests/test_reduction.py
+++ b/tests/cupy_tests/core_tests/test_reduction.py
@@ -59,7 +59,7 @@ class SimpleReductionFunction(unittest.TestCase):
 class TestReductionKernel(unittest.TestCase):
 
     def setUp(self):
-        self.my_sum = core.ReductionKernel(
+        self.my_sum = cupy.ReductionKernel(
             'T x', 'T out', 'x', 'a + b', 'out = a', '0', 'my_sum')
 
     @testing.numpy_cupy_allclose()
@@ -101,5 +101,5 @@ class TestReductionKernelInvalidArgument(unittest.TestCase):
 
     def test_invalid_kernel_name(self):
         with six.assertRaisesRegex(self, ValueError, 'Invalid kernel name'):
-            core.ReductionKernel(
+            cupy.ReductionKernel(
                 'T x', 'T y', 'x', 'a + b', 'y = a', '0', name='1')


### PR DESCRIPTION
Removes `include 'reduction.pxi'` as it's confusing, because often you lose where functions are actually defined.

`_kernel.pyx` uses `_broadcast_core()`. Importing `_routines_manipulation.pyx` from `_kernel.pyx` causes cyclic dependencies. ~I refactored `_broadcast_core()` and `class broadcast` as `_broadcast.pyx`.~
I only moved `_broadcast_core` to `internal.pyx`.