### PR TITLE
[backport] Separate code and path arguments in `RawModule`

### DIFF
--- a/cupy/core/raw.pyx
+++ b/cupy/core/raw.pyx
@@ -217,7 +217,8 @@ cdef class RawModule:
     providing its path, and kernels therein can be retrieved similarly.
 
     Args:
-        code_or_path (str): CUDA source code or path to cubin.
+        code (str): CUDA source code. Mutually exclusive with ``path``.
+        path (str): Path to cubin/ptx. Mutually exclusive with ``code``.
         options (tuple of str): Compiler options passed to the backend (NVRTC
             or NVCC). For details, see
             https://docs.nvidia.com/cuda/nvrtc/index.html#group__options or
@@ -231,21 +232,21 @@ cdef class RawModule:
     .. note::
         Each kernel in ``RawModule`` possesses independent function attributes.
     """
-    def __init__(self, code_or_path, options=(), backend='nvrtc', *,
+    def __init__(self, *, code=None, path=None, options=(), backend='nvrtc',
                  translate_cucomplex=False):
-        if isinstance(code_or_path, six.binary_type):
-            code_or_path = code_or_path.decode('UTF-8')
+        if (code is None) == (path is None):
+            raise TypeError(
+                'Exactly one of `code` and `path` keyword arguments must be '
+                'given.')
+        if path is not None and isinstance(path, six.binary_type):
+            path = path.decode('UTF-8')
+        if code is not None and isinstance(code, six.binary_type):
+            code = code.decode('UTF-8')
         if isinstance(backend, six.binary_type):
             backend = backend.decode('UTF-8')
 
-        if code_or_path.endswith('.cubin'):
-            path = code_or_path
-            self.code = None
-            self.cubin_path = path
-        else:
-            code = code_or_path
-            self.code = code
-            self.cubin_path = None
+        self.code = code
+        self.cubin_path = path
 
         if self.code is not None:
             self.module = cupy.core.core.compile_with_cache(

--- a/docs/source/tutorial/kernel.rst
+++ b/docs/source/tutorial/kernel.rst
@@ -297,7 +297,7 @@ For dealing a large raw CUDA source or loading an existing CUDA binary, the :cla
     ... }
     ...
     ... }'''
-    >>> module = cp.RawModule(loaded_from_source)
+    >>> module = cp.RawModule(code=loaded_from_source)
     >>> ker_sum = module.get_function('test_sum')
     >>> ker_times = module.get_function('test_multiply')
     >>> N = 10

--- a/tests/cupy_tests/core_tests/test_raw.py
+++ b/tests/cupy_tests/core_tests/test_raw.py
@@ -276,11 +276,16 @@ class TestRaw(unittest.TestCase):
         _test_cache_dir = tempfile.mkdtemp()
         os.environ['CUPY_CACHE_DIR'] = _test_cache_dir
 
-        self.kern = cupy.RawKernel(_test_source1, 'test_sum',
-                                   backend=self.backend)
-        self.mod2 = cupy.RawModule(_test_source2, backend=self.backend)
-        self.mod3 = cupy.RawModule(_test_source3, ('-DPRECISION=2',),
-                                   backend=self.backend)
+        self.kern = cupy.RawKernel(
+            _test_source1, 'test_sum',
+            backend=self.backend)
+        self.mod2 = cupy.RawModule(
+            code=_test_source2,
+            backend=self.backend)
+        self.mod3 = cupy.RawModule(
+            code=_test_source3,
+            options=('-DPRECISION=2',),
+            backend=self.backend)
 
     def tearDown(self):
         # To avoid cache interference, we remove cached files after every test,
@@ -346,8 +351,10 @@ class TestRaw(unittest.TestCase):
 
     def test_invalid_compiler_flag(self):
         with pytest.raises(cupy.cuda.compiler.CompileException) as ex:
-            cupy.RawModule(_test_source3, ('-DPRECISION=3',),
-                           backend=self.backend)
+            cupy.RawModule(
+                code=_test_source3,
+                options=('-DPRECISION=3',),
+                backend=self.backend)
         assert 'precision not supported' in str(ex.value)
 
     def test_module_load_failure(self):
@@ -355,9 +362,20 @@ class TestRaw(unittest.TestCase):
         # this error is more likely to appear when using RawModule, so
         # let us do it here
         with pytest.raises(cupy.cuda.driver.CUDADriverError) as ex:
-            cupy.RawModule(os.path.expanduser('~/this_does_not_exist.cubin'),
-                           backend=self.backend)
+            cupy.RawModule(
+                path=os.path.expanduser('~/this_does_not_exist.cubin'),
+                backend=self.backend)
         assert 'CUDA_ERROR_FILE_NOT_FOUND' in str(ex.value)
+
+    def test_module_neither_code_nor_path(self):
+        with pytest.raises(TypeError):
+            cupy.RawModule()
+
+    def test_module_both_code_and_path(self):
+        with pytest.raises(TypeError):
+            cupy.RawModule(
+                code=_test_source1,
+                path='test.cubin')
 
     def test_get_function_failure(self):
         # in principle this test is better done in test_driver.py, but
@@ -397,7 +415,9 @@ class TestRaw(unittest.TestCase):
         grid = (N + block - 1) // block
         dtype = cupy.complex64
 
-        mod = cupy.RawModule(_test_cuComplex, translate_cucomplex=True)
+        mod = cupy.RawModule(
+            code=_test_cuComplex,
+            translate_cucomplex=True)
         a = cupy.random.random((N,)) + 1j*cupy.random.random((N,))
         a = a.astype(dtype)
         b = cupy.random.random((N,)) + 1j*cupy.random.random((N,))
@@ -451,7 +471,9 @@ class TestRaw(unittest.TestCase):
         grid = (N + block - 1) // block
         dtype = cupy.complex128
 
-        mod = cupy.RawModule(_test_cuComplex, translate_cucomplex=True)
+        mod = cupy.RawModule(
+            code=_test_cuComplex,
+            translate_cucomplex=True)
         a = cupy.random.random((N,)) + 1j*cupy.random.random((N,))
         a = a.astype(dtype)
         b = cupy.random.random((N,)) + 1j*cupy.random.random((N,))

--- a/tests/cupy_tests/cuda_tests/test_texture.py
+++ b/tests/cupy_tests/cuda_tests/test_texture.py
@@ -302,9 +302,9 @@ class TestTexture(unittest.TestCase):
         if self.target == 'object':
             # create a texture object
             texobj = TextureObject(res, tex)
-            mod = cupy.RawModule(source_obj)
+            mod = cupy.RawModule(code=source_obj)
         else:  # self.target == 'reference'
-            mod = cupy.RawModule(source_ref)
+            mod = cupy.RawModule(code=source_ref)
             texref_name = 'texref'
             texref_name += '3D' if dim == 3 else '2D' if dim == 2 else '1D'
             texrefPtr = mod.get_texref(texref_name)
@@ -375,9 +375,9 @@ class TestTextureVectorType(unittest.TestCase):
         if self.target == 'object':
             # create a texture object
             texobj = TextureObject(res, tex)
-            mod = cupy.RawModule(source_obj)
+            mod = cupy.RawModule(code=source_obj)
         else:  # self.target == 'reference'
-            mod = cupy.RawModule(source_ref)
+            mod = cupy.RawModule(code=source_ref)
             texrefPtr = mod.get_texref('texref3Df4')
             # bind texture ref to resource
             texref = TextureReference(texrefPtr, res, tex)  # noqa


### PR DESCRIPTION
Backport of #2784

Was not cleanly cherry-picked