### PR TITLE
Use more stable input to test `linalg.matrix_power`

### DIFF
--- a/tests/cupy_tests/linalg_tests/test_product.py
+++ b/tests/cupy_tests/linalg_tests/test_product.py
@@ -431,19 +431,22 @@ class TestMatrixPower(unittest.TestCase):
     @testing.for_float_dtypes(no_float16=True)
     @testing.numpy_cupy_allclose(rtol=1e-5)
     def test_matrix_power_inv1(self, xp, dtype):
-        a = testing.shaped_arange((3, 3), xp, dtype) ** 2
+        a = testing.shaped_arange((3, 3), xp, dtype)
+        a = a * a % 30
         return xp.linalg.matrix_power(a, -1)
 
     @testing.for_float_dtypes(no_float16=True)
     @testing.numpy_cupy_allclose(rtol=1e-5)
     def test_matrix_power_inv2(self, xp, dtype):
-        a = testing.shaped_arange((3, 3), xp, dtype) ** 2
+        a = testing.shaped_arange((3, 3), xp, dtype)
+        a = a * a % 30
         return xp.linalg.matrix_power(a, -2)
 
     @testing.for_float_dtypes(no_float16=True)
     @testing.numpy_cupy_allclose(rtol=1e-4)
     def test_matrix_power_inv3(self, xp, dtype):
-        a = testing.shaped_arange((3, 3), xp, dtype) ** 2
+        a = testing.shaped_arange((3, 3), xp, dtype)
+        a = a * a % 30
         return xp.linalg.matrix_power(a, -3)
 
     @testing.for_all_dtypes()


### PR DESCRIPTION
The issue is found in #2569.

The PR fixes:
- `a ** 2` is less accurate than `a * a`;
- condition number of `[[1, 4, 9], [16, 25, 36], [49, 64, 81]]` is somewhat large.