### PR TITLE
Avoid looking up null pointers' attributes

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2776,7 +2776,7 @@ not_equal = create_comparison(
 
 cpdef ndarray _convert_object_with_cuda_array_interface(a):
     cdef Py_ssize_t sh, st
-    cdef dict desc = a.__cuda_array_interface__
+    cdef object desc = a.__cuda_array_interface__
     cdef tuple shape = desc['shape']
     cdef int dev_id = -1
     cdef int nbytes

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2776,13 +2776,16 @@ not_equal = create_comparison(
 
 cpdef ndarray _convert_object_with_cuda_array_interface(a):
     cdef Py_ssize_t sh, st
-    desc = a.__cuda_array_interface__
-    shape = desc['shape']
+    cdef dict desc = a.__cuda_array_interface__
+    cdef tuple shape = desc['shape']
+    cdef int dev_id = -1
+    cdef int nbytes
+
+    ptr = desc['data'][0]
     dtype = numpy.dtype(desc['typestr'])
-    if 'mask' in desc:
-        mask = desc['mask']
-        if mask is not None:
-            raise ValueError('CuPy currently does not support masked arrays.')
+    mask = desc.get('mask')
+    if mask is not None:
+        raise ValueError('CuPy currently does not support masked arrays.')
     strides = desc.get('strides')
     if strides is not None:
         nbytes = 0
@@ -2790,7 +2793,11 @@ cpdef ndarray _convert_object_with_cuda_array_interface(a):
             nbytes = max(nbytes, abs(sh * st))
     else:
         nbytes = internal.prod_sequence(shape) * dtype.itemsize
-    mem = memory_module.UnownedMemory(desc['data'][0], nbytes, a)
+    # the v2 protocol sets ptr=0 for 0-size arrays, so we can't look up
+    # the pointer attributes and must use the current device
+    if nbytes == 0:
+        dev_id = device.get_device_id()
+    mem = memory_module.UnownedMemory(ptr, nbytes, a, dev_id)
     memptr = memory.MemoryPointer(mem, 0)
     return ndarray(shape, dtype, memptr, strides)
 

--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -129,7 +129,7 @@ cdef class UnownedMemory(BaseMemory):
                 ptr_attrs = runtime.pointerGetAttributes(ptr)
                 device_id = ptr_attrs.device
             else:
-                raise RuntimeError
+                raise RuntimeError('UnownedMemory requires explicit device ID for a null pointer.')
         self.size = size
         self.device_id = device_id
         self.ptr = ptr

--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -125,11 +125,11 @@ cdef class UnownedMemory(BaseMemory):
         # ptr=0 for 0-size arrays from __cuda_array_interface__ v2:
         # we need a valid device id as null ptr can't be looked up
         if device_id < 0:
-            if ptr > 0:
-                ptr_attrs = runtime.pointerGetAttributes(ptr)
-                device_id = ptr_attrs.device
-            else:
-                raise RuntimeError('UnownedMemory requires explicit device ID for a null pointer.')
+            if ptr == 0:
+                raise RuntimeError('UnownedMemory requires explicit'
+                                   ' device ID for a null pointer.')
+            ptr_attrs = runtime.pointerGetAttributes(ptr)
+            device_id = ptr_attrs.device
         self.size = size
         self.device_id = device_id
         self.ptr = ptr

--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -122,7 +122,8 @@ cdef class UnownedMemory(BaseMemory):
     def __init__(self, intptr_t ptr, size_t size, object owner,
                  int device_id=-1):
         cdef runtime.PointerAttributes ptr_attrs
-        if device_id < 0:
+        # ptr=0 for 0-size arrays from __cuda_array_interface__ v2 
+        if device_id < 0 and ptr > 0:
             ptr_attrs = runtime.pointerGetAttributes(ptr)
             device_id = ptr_attrs.device
         self.size = size

--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -122,7 +122,7 @@ cdef class UnownedMemory(BaseMemory):
     def __init__(self, intptr_t ptr, size_t size, object owner,
                  int device_id=-1):
         cdef runtime.PointerAttributes ptr_attrs
-        # ptr=0 for 0-size arrays from __cuda_array_interface__ v2 
+        # ptr=0 for 0-size arrays from __cuda_array_interface__ v2
         if device_id < 0 and ptr > 0:
             ptr_attrs = runtime.pointerGetAttributes(ptr)
             device_id = ptr_attrs.device

--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -122,10 +122,14 @@ cdef class UnownedMemory(BaseMemory):
     def __init__(self, intptr_t ptr, size_t size, object owner,
                  int device_id=-1):
         cdef runtime.PointerAttributes ptr_attrs
-        # ptr=0 for 0-size arrays from __cuda_array_interface__ v2
-        if device_id < 0 and ptr > 0:
-            ptr_attrs = runtime.pointerGetAttributes(ptr)
-            device_id = ptr_attrs.device
+        # ptr=0 for 0-size arrays from __cuda_array_interface__ v2:
+        # we need a valid device id as null ptr can't be looked up
+        if device_id < 0:
+            if ptr > 0:
+                ptr_attrs = runtime.pointerGetAttributes(ptr)
+                device_id = ptr_attrs.device
+            else:
+                raise RuntimeError
         self.size = size
         self.device_id = device_id
         self.ptr = ptr

--- a/tests/cupy_tests/creation_tests/test_from_data.py
+++ b/tests/cupy_tests/creation_tests/test_from_data.py
@@ -489,6 +489,16 @@ class TestCudaArrayInterface(unittest.TestCase):
         assert a.strides == b.strides
         assert a.nbytes == b.data.mem.size
 
+    @testing.for_all_dtypes()
+    def test_with_zero_size_array(self, dtype):
+        a = testing.shaped_arange((0,), cupy, dtype)
+        b = cupy.asarray(
+            DummyObjectWithCudaArrayInterface(a, self.ver, self.strides))
+        assert a.strides == b.strides
+        assert a.nbytes == b.data.mem.size
+        assert a.data.ptr == 0
+        assert a.size == 0
+
 
 @testing.gpu
 @testing.parameterize(*testing.product({


### PR DESCRIPTION
Follow-up of #2611. Close #2789.

This PR fixes the consumer side (while #2611 fixed the producer side) for handling zero-size arrays. 

cc: @jakirkham 