### PR TITLE
[backport] Detect interpreter shutdown for proper `__del__` behavior

### DIFF
--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -13,6 +13,7 @@ from cupy.cuda import device
 from cupy.cuda import function
 from cupy.cuda import nvrtc
 from cupy.cuda import runtime
+from cupy import util
 
 _nvrtc_version = None
 _nvrtc_max_compute_capability = None
@@ -425,7 +426,9 @@ class _NVRTCProgram(object):
         self.name = name
         self.ptr = nvrtc.createProgram(src, name, headers, include_names)
 
-    def __del__(self):
+    def __del__(self, is_shutting_down=util.is_shutting_down):
+        if is_shutting_down():
+            return
         if self.ptr:
             nvrtc.destroyProgram(self.ptr)
 

--- a/cupy/cuda/pinned_memory.pyx
+++ b/cupy/cuda/pinned_memory.pyx
@@ -9,6 +9,7 @@ from cupy.cuda import runtime
 
 from cupy.core cimport internal
 from cupy.cuda cimport runtime
+from cupy import util
 
 
 class PinnedMemory(object):
@@ -28,7 +29,9 @@ class PinnedMemory(object):
         if size > 0:
             self.ptr = runtime.hostAlloc(size, flags)
 
-    def __del__(self):
+    def __del__(self, is_shutting_down=util.is_shutting_down):
+        if is_shutting_down():
+            return
         if self.ptr:
             runtime.freeHost(self.ptr)
 

--- a/cupy/cuda/stream.pyx
+++ b/cupy/cuda/stream.pyx
@@ -2,6 +2,8 @@ from cupy.cuda import runtime
 import threading
 import weakref
 
+from cupy import util
+
 
 cdef object _thread_local = threading.local()
 
@@ -176,8 +178,10 @@ class Stream(object):
         else:
             self.ptr = runtime.streamCreate()
 
-    def __del__(self):
+    def __del__(self, is_shutting_down=util.is_shutting_down):
         cdef intptr_t current_ptr
+        if is_shutting_down():
+            return
         if self.ptr:
             tls = _StreamThreadLocal.get()
             current_ptr = <intptr_t>tls.get_current_stream_ptr()

--- a/cupy/cusparse.py
+++ b/cupy/cusparse.py
@@ -6,6 +6,7 @@ import cupy
 from cupy.cuda import cusparse
 from cupy.cuda import runtime
 from cupy.cuda import device
+from cupy import util
 import cupyx.scipy.sparse
 
 
@@ -19,7 +20,9 @@ class MatDescriptor(object):
         descr = cusparse.createMatDescr()
         return MatDescriptor(descr)
 
-    def __del__(self):
+    def __del__(self, is_shutting_down=util.is_shutting_down):
+        if is_shutting_down():
+            return
         if self.descriptor:
             cusparse.destroyMatDescr(self.descriptor)
             self.descriptor = None

--- a/cupy/cutensor.py
+++ b/cupy/cutensor.py
@@ -5,6 +5,7 @@ import cupy
 from cupy.cuda import cutensor
 from cupy.cuda import device
 from cupy.cuda import runtime
+from cupy import util
 
 _handles = {}
 _tensor_descriptors = {}
@@ -19,7 +20,9 @@ class Descriptor(object):
         self.value = descriptor
         self.destroy = destroyer
 
-    def __del__(self):
+    def __del__(self, is_shutting_down=util.is_shutting_down):
+        if is_shutting_down():
+            return
         if self.destroy is None:
             self.value = None
         elif self.value is not None:

--- a/cupy/random/generator.py
+++ b/cupy/random/generator.py
@@ -51,8 +51,10 @@ class RandomState(object):
         self._generator = curand.createGenerator(method)
         self.seed(seed)
 
-    def __del__(self):
+    def __del__(self, is_shutting_down=util.is_shutting_down):
         # When createGenerator raises an error, _generator is not initialized
+        if is_shutting_down():
+            return
         if hasattr(self, '_generator'):
             curand.destroyGenerator(self._generator)
 

--- a/cupy/util.pyx
+++ b/cupy/util.pyx
@@ -198,3 +198,28 @@ The interface can change in the future. ...
 
 class PerformanceWarning(RuntimeWarning):
     """Warning that indicates possible performance issues."""
+
+
+"""
+This code is to signal when the interpreter is in shutdown mode
+to prevent using globals that could be already deleted in
+objects `__del__` method
+
+This solution is taken from the Numba/llvmlite code
+"""
+_shutting_down = [False]
+
+
+@atexit.register
+def _at_shutdown():
+    _shutting_down[0] = True
+
+
+def is_shutting_down(_shutting_down=_shutting_down):
+    """
+    Whether the interpreter is currently shutting down.
+    For use in finalizers, __del__ methods, and similar; it is advised
+    to early bind this function rather than look it up when calling it,
+    since at shutdown module globals may be cleared.
+    """
+    return _shutting_down[0]


### PR DESCRIPTION
Backport of #2809