### PR TITLE
fix cupyx.scipy.ndimage.map_coordinates for cases with coords > 2d

### DIFF
--- a/cupyx/scipy/ndimage/interpolation.py
+++ b/cupyx/scipy/ndimage/interpolation.py
@@ -120,11 +120,11 @@ def map_coordinates(input, coordinates, output=None, order=None,
             else:
                 sides.append([0, 1])
 
-        out = cupy.zeros(coordinates.shape[1], dtype=input.dtype)
+        out = cupy.zeros(coordinates.shape[1:], dtype=input.dtype)
         if input.dtype in (cupy.float64, cupy.complex128):
-            weight = cupy.empty(coordinates.shape[1], dtype=cupy.float64)
+            weight = cupy.empty(coordinates.shape[1:], dtype=cupy.float64)
         else:
-            weight = cupy.empty(coordinates.shape[1], dtype=cupy.float32)
+            weight = cupy.empty(coordinates.shape[1:], dtype=cupy.float32)
         for side in itertools.product(*sides):
             weight.fill(1)
             ind = []
@@ -139,7 +139,7 @@ def map_coordinates(input, coordinates, output=None, order=None,
         del weight
 
     if mode == 'constant':
-        mask = cupy.zeros(coordinates.shape[1], dtype=cupy.bool_)
+        mask = cupy.zeros(coordinates.shape[1:], dtype=cupy.bool_)
         for i in six.moves.range(input.ndim):
             mask += coordinates[i] < 0
             mask += coordinates[i] > input.shape[i] - 1

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
@@ -38,7 +38,7 @@ class TestMapCoordinates(unittest.TestCase):
 
         map_coordinates = scp.ndimage.map_coordinates
         if self.output == 'empty':
-            output = xp.empty(coordinates.shape[1], dtype=a.dtype)
+            output = xp.empty(coordinates.shape[1:], dtype=a.dtype)
             return_value = map_coordinates(a, coordinates, output, self.order,
                                            self.mode, self.cval,
                                            self.prefilter)
@@ -53,6 +53,14 @@ class TestMapCoordinates(unittest.TestCase):
     def test_map_coordinates_float(self, xp, scp, dtype):
         a = testing.shaped_random((100, 100), xp, dtype)
         coordinates = testing.shaped_random((a.ndim, 100), xp, dtype)
+        return self._map_coordinates(xp, scp, a, coordinates)
+
+    @testing.for_float_dtypes(no_float16=True)
+    @testing.numpy_cupy_allclose(atol=1e-5, scipy_name='scp')
+    def test_map_coordinates_float_nd_coords(self, xp, scp, dtype):
+        a = testing.shaped_random((100, 100), xp, dtype)
+        coordinates = testing.shaped_random((a.ndim, 10, 10), xp, dtype,
+                                            scale=99.0)
         return self._map_coordinates(xp, scp, a, coordinates)
 
     @testing.for_int_dtypes(no_bool=True)


### PR DESCRIPTION
Currently ``map_coordinates`` with ``order=1`` assumes ``coords`` is a 2d array, but this restriction is not present in SciPy itself. This PR fixes the code to handle ``coords`` with >2 dimensions.

