### PR TITLE
Fix split and array_split with unordered indices supplied

### DIFF
--- a/cupy/core/_routines_manipulation.pyx
+++ b/cupy/core/_routines_manipulation.pyx
@@ -436,7 +436,7 @@ cpdef array_split(ndarray ary, indices_or_sections, Py_ssize_t axis):
         stride = 0
     for index in indices:
         index = min(index, size)
-        shape[axis] = index - prev
+        shape[axis] = max(index - prev, 0)
         v = ary.view()
         v.data = ary.data + prev * stride
         # TODO(niboshi): Confirm update_x_contiguity flags

--- a/cupy/core/_routines_manipulation.pyx
+++ b/cupy/core/_routines_manipulation.pyx
@@ -435,6 +435,7 @@ cpdef array_split(ndarray ary, indices_or_sections, Py_ssize_t axis):
     if ary.size == 0:
         stride = 0
     for index in indices:
+        index = min(index, size)
         shape[axis] = index - prev
         v = ary.view()
         v.data = ary.data + prev * stride

--- a/tests/cupy_tests/manipulation_tests/test_split.py
+++ b/tests/cupy_tests/manipulation_tests/test_split.py
@@ -39,6 +39,11 @@ class TestSplit(unittest.TestCase):
         return xp.array_split(a, [1])
 
     @testing.numpy_cupy_array_list_equal()
+    def test_array_split_unordered_sections(self, xp):
+        a = testing.shaped_arange((5,), xp)
+        return xp.array_split(a, [4, 2])
+
+    @testing.numpy_cupy_array_list_equal()
     def test_array_split_non_divisible(self, xp):
         a = testing.shaped_arange((5, 3), xp)
         return xp.array_split(a, 4)
@@ -83,6 +88,11 @@ class TestSplit(unittest.TestCase):
     def test_split_out_of_bound2(self, xp):
         a = testing.shaped_arange((0,), xp)
         return xp.split(a, [1])
+
+    @testing.numpy_cupy_array_list_equal()
+    def test_split_unordered_sections(self, xp):
+        a = testing.shaped_arange((5,), xp)
+        return xp.split(a, [4, 2])
 
     @testing.numpy_cupy_array_list_equal()
     def test_vsplit(self, xp):

--- a/tests/cupy_tests/manipulation_tests/test_split.py
+++ b/tests/cupy_tests/manipulation_tests/test_split.py
@@ -27,6 +27,7 @@ class TestSplit(unittest.TestCase):
         a = testing.shaped_arange((3, 11), xp)
         return xp.array_split(a, [])
 
+    @testing.with_requires('numpy>=1.11')
     @testing.numpy_cupy_array_list_equal()
     def test_array_split_out_of_bound1(self, xp):
         a = testing.shaped_arange((2, 3), xp)
@@ -72,6 +73,7 @@ class TestSplit(unittest.TestCase):
         a = testing.shaped_arange((3, 11), xp)
         return xp.split(a, (-9, 4, -2), 1)
 
+    @testing.with_requires('numpy>=1.11')
     @testing.numpy_cupy_array_list_equal()
     def test_split_out_of_bound1(self, xp):
         a = testing.shaped_arange((2, 3), xp)

--- a/tests/cupy_tests/manipulation_tests/test_split.py
+++ b/tests/cupy_tests/manipulation_tests/test_split.py
@@ -28,6 +28,16 @@ class TestSplit(unittest.TestCase):
         return xp.array_split(a, [])
 
     @testing.numpy_cupy_array_list_equal()
+    def test_array_split_out_of_bound1(self, xp):
+        a = testing.shaped_arange((2, 3), xp)
+        return xp.array_split(a, [3])
+
+    @testing.numpy_cupy_array_list_equal()
+    def test_array_split_out_of_bound2(self, xp):
+        a = testing.shaped_arange((0,), xp)
+        return xp.array_split(a, [1])
+
+    @testing.numpy_cupy_array_list_equal()
     def test_array_split_non_divisible(self, xp):
         a = testing.shaped_arange((5, 3), xp)
         return xp.array_split(a, 4)
@@ -61,6 +71,16 @@ class TestSplit(unittest.TestCase):
     def test_split_by_sections3(self, xp):
         a = testing.shaped_arange((3, 11), xp)
         return xp.split(a, (-9, 4, -2), 1)
+
+    @testing.numpy_cupy_array_list_equal()
+    def test_split_out_of_bound1(self, xp):
+        a = testing.shaped_arange((2, 3), xp)
+        return xp.split(a, [3])
+
+    @testing.numpy_cupy_array_list_equal()
+    def test_split_out_of_bound2(self, xp):
+        a = testing.shaped_arange((0,), xp)
+        return xp.split(a, [1])
 
     @testing.numpy_cupy_array_list_equal()
     def test_vsplit(self, xp):


### PR DESCRIPTION
Follows #2814 .

`cupy.split` and `cupy.array_split` raise an error when they take unordered indices as `[4, 2]`. NumPy does not require indices ordered and, in such case, it return an empty array for a going-back index. I'm not sure it is meaningful, but it actually does. This PR fix the functions to follow NumPy's behavior.

```Python
>>> import numpy as np
>>> import cupy as cp
>>> np.split(np.array([0, 1, 2, 3, 4]), [4, 2])
[array([0, 1, 2, 3]), array([], dtype=int64), array([2, 3, 4])]
>>> cp.split(cp.array([0, 1, 2, 3, 4]), [4, 2])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "cupy/core/core.pyx", line 1341, in cupy.core.core.ndarray.__repr__
    return repr(self.get())
  File "cupy/core/core.pyx", line 1432, in cupy.core.core.ndarray.get
    a_cpu = numpy.empty(self._shape, dtype=self.dtype, order=order)
ValueError: negative dimensions are not allowed
```
