### PR TITLE
Allow squashing f-contiguous axes for faster reduction

### DIFF
--- a/cupy/core/_reduction.pyx
+++ b/cupy/core/_reduction.pyx
@@ -248,7 +248,9 @@ cdef class _AbstractReductionKernel:
         # When there is only one input array, sort the axes in such a way that
         # contiguous (C or F) axes can be squashed in _reduce_dims() later.
         # TODO(niboshi): Support (out_axis) > 1
-        if len(in_args) == 1 and len(out_axis) <= 1:
+        if (len(in_args) == 1
+                and len(out_axis) <= 1
+                and not in_args[0]._c_contiguous):
             strides = in_args[0].strides
             reduce_axis = _sort_axis(reduce_axis, strides)
             out_axis = _sort_axis(out_axis, strides)


### PR DESCRIPTION
`_reduce_dims()` (and `ndarray.reduced_view()`) can only squash C-contiguous dimensions.
This PR sorts the axes so that they can be squashed even if they're F-contiguous.

Benchmark code using [cupy-perf](https://github.com/niboshi/cupy-perf/):
```py
import cupy
import cupy_perf


class Perf1(cupy_perf.PerfCases):

    def setUp(self):
        shape = (100,) * 3
        self.a = cupy.empty(shape, 'float32')
        self.b = cupy.empty(shape, 'float32').T

    @cupy_perf.attr(n=100)
    def perf_ccont(self):
        self.a.sum(axis=(1, 2))

    @cupy_perf.attr(n=100)
    def perf_fcont(self):
        self.b.sum(axis=(0, 1))


cupy_perf.run(__name__)
```

Result:
```
# Before                CPU Time                                    GPU Time
ccont               :    22.412 us   +/- 2.332 (min:   20.623) us    896.698 us   +/- 5.373 (min:  875.040) us
fcont               :    26.003 us   +/-17.168 (min:   17.974) us   2862.353 us   +/-16.635 (min: 2845.184) us

# This PR
ccont               :    26.467 us   +/- 1.182 (min:   25.313) us    901.093 us   +/- 4.774 (min:  882.048) us
fcont               :    26.440 us   +/- 1.400 (min:   24.819) us    899.893 us   +/- 4.466 (min:  883.712) us
```

~TODO: I think output arrays should be transposed.~
Currently targeting only 0- or 1-dim output.