### PR TITLE
Support 64 bit extent `randint`

### DIFF
--- a/cupy/random/generator.py
+++ b/cupy/random/generator.py
@@ -636,16 +636,13 @@ class RandomState(object):
             return cupy.array(())
 
         sample = cupy.empty((n,), dtype=dtype)
-        # 32-bit RNG will be called to fill 32-bit or 64-bit `sample`
-        generate_args = (
-            self._generator,
-            sample.data.ptr,
-            sample.view(dtype=numpy.uint32).size,
-        )
+        size32 = sample.view(dtype=numpy.uint32).size
         n_rem = n  # The number of remaining elements to sample
         ret = None
         while n_rem > 0:
-            curand.generate(*generate_args)
+            # Call 32-bit RNG to fill 32-bit or 64-bit `sample`
+            curand.generate(
+                self._generator, sample.data.ptr, size32)
             # Drop the samples that exceed the upper limit
             sample &= mask
             success = sample <= mx

--- a/tests/cupy_tests/random_tests/test_generator.py
+++ b/tests/cupy_tests/random_tests/test_generator.py
@@ -863,7 +863,7 @@ class TestInterval(RandomGeneratorTestCase):
         vals = self.generate_many(0, shape, _count=10)
         for val in vals:
             assert isinstance(val, cupy.ndarray)
-            assert val.dtype == numpy.int32
+            assert val.dtype.kind in 'iu'
             assert val.shape == shape
             assert (val == 0).all()
 
@@ -872,7 +872,7 @@ class TestInterval(RandomGeneratorTestCase):
         vals = self.generate_many(mx, None, _count=10)
         for val in vals:
             assert isinstance(val, cupy.ndarray)
-            assert val.dtype == numpy.int32
+            assert val.dtype.kind in 'iu'
             assert val.shape == ()
             assert (0 <= val).all()
             assert (val <= mx).all()
@@ -884,7 +884,7 @@ class TestInterval(RandomGeneratorTestCase):
         vals = self.generate_many(mx, size, _count=10)
         for val in vals:
             assert isinstance(val, cupy.ndarray)
-            assert val.dtype == numpy.int32
+            assert val.dtype.kind in 'iu'
             assert val.shape == (size,)
             assert (0 <= val).all()
             assert (val <= mx).all()
@@ -896,31 +896,17 @@ class TestInterval(RandomGeneratorTestCase):
         vals = self.generate_many(mx, shape, _count=10)
         for val in vals:
             assert isinstance(val, cupy.ndarray)
-            assert val.dtype == numpy.int32
+            assert val.dtype.kind in 'iu'
             assert val.shape == shape
             assert (0 <= val).all()
             assert (val <= mx).all()
         # TODO(niboshi): Distribution test
 
-    def test_int32_range(self):
-        v = self.generate(0x00000000, 2)
-        assert v.dtype == numpy.int32
-
-        v = self.generate(0x7fffffff, 2)
-        assert v.dtype == numpy.int32
-
-    def test_uint32_range(self):
-        v = self.generate(0x80000000, 2)
-        assert v.dtype == numpy.uint32
-
-        v = self.generate(0xffffffff, 2)
-        assert v.dtype == numpy.uint32
-
     def test_bound_1(self):
         vals = self.generate_many(10, (2, 3), _count=10)
         for val in vals:
             assert isinstance(val, cupy.ndarray)
-            assert val.dtype == numpy.int32
+            assert val.dtype.kind in 'iu'
             assert val.shape == (2, 3)
             assert (0 <= val).all()
             assert (val <= 10).all()
@@ -929,7 +915,7 @@ class TestInterval(RandomGeneratorTestCase):
         vals = self.generate_many(2, None, _count=20)
         for val in vals:
             assert isinstance(val, cupy.ndarray)
-            assert val.dtype == numpy.int32
+            assert val.dtype.kind in 'iu'
             assert val.shape == ()
             assert (0 <= val).all()
             assert (val <= 2).all()

--- a/tests/cupy_tests/random_tests/test_generator.py
+++ b/tests/cupy_tests/random_tests/test_generator.py
@@ -1191,6 +1191,9 @@ class TestRandint(RandomGeneratorTestCase):
     def test_randint_3(self):
         self.generate(3, 10, size=0)
 
+    def test_randint_int64_1(self):
+        self.generate(2**34, 2**40, 3)
+
 
 @testing.gpu
 @testing.fix_random()


### PR DESCRIPTION
Fix #2816.

Compared to #2823, this PR keeps using 32-bit RNG.