### PR TITLE
fix delayed import in cub.pyx

### DIFF
--- a/cupy/cuda/cub.pyx
+++ b/cupy/cuda/cub.pyx
@@ -67,7 +67,7 @@ cpdef _preprocess_array(ndarray arr, axis, bint keepdims, str order):
     reduction.pxi. The input array arr is C- or F- contiguous along axis.
     '''
     # if import at the top level, a segfault would happen when import cupy!
-    from cupy.core._kernel import _get_axis
+    from cupy.core._reduction import _get_axis
 
     cdef tuple reduce_axis, out_axis, axis_permutes, out_shape
     cdef Py_ssize_t contiguous_size = 1


### PR DESCRIPTION
This modification is necessary following #2785. It was not caught there because CUB isn't currently enabled on CI.

I did also try moving the import to the top of the file, but this caused an `ImportError`, so I have left it as-is.