### PR TITLE
[backport] Fix `true_divide` with dtype argument

### DIFF
--- a/cupy/core/_kernel.pxd
+++ b/cupy/core/_kernel.pxd
@@ -1,3 +1,31 @@
 cpdef create_ufunc(name, ops, routine=*, preamble=*, doc=*,
+<<<<<<< HEAD
                    default_casting=*, loop_prep=*)
 cpdef create_reduction_func(name, ops, routine=*, identity=*, preamble=*)
+=======
+                   default_casting=*, loop_prep=*, out_ops=*)
+
+cpdef tuple _get_args_info(list args)
+
+cpdef str _get_kernel_params(tuple params, tuple args_info)
+
+cdef tuple _broadcast(list args, tuple params, bint use_size)
+
+cdef list _get_out_args(list out_args, tuple out_types, tuple out_shape,
+                        casting)
+
+cdef list _get_out_args_with_params(
+    list out_args, tuple out_types, tuple out_shape, tuple out_params,
+    bint is_size_specified)
+
+cdef tuple _guess_routine_from_dtype(list ops, object dtype)
+
+cdef tuple _guess_routine(
+    str name, dict cache, list ops, list in_args, dtype, list out_ops)
+
+cdef _check_array_device_id(ndarray arr, int device_id)
+
+cdef list _preprocess_args(int dev_id, args, bint use_c_scalar)
+
+cdef tuple _reduce_dims(list args, tuple params, tuple shape)
+>>>>>>> b544536a3... Merge pull request #2076 from okuta/fix-true-divide

--- a/cupy/core/_kernel.pxd
+++ b/cupy/core/_kernel.pxd
@@ -1,31 +1,3 @@
 cpdef create_ufunc(name, ops, routine=*, preamble=*, doc=*,
-<<<<<<< HEAD
-                   default_casting=*, loop_prep=*)
-cpdef create_reduction_func(name, ops, routine=*, identity=*, preamble=*)
-=======
                    default_casting=*, loop_prep=*, out_ops=*)
-
-cpdef tuple _get_args_info(list args)
-
-cpdef str _get_kernel_params(tuple params, tuple args_info)
-
-cdef tuple _broadcast(list args, tuple params, bint use_size)
-
-cdef list _get_out_args(list out_args, tuple out_types, tuple out_shape,
-                        casting)
-
-cdef list _get_out_args_with_params(
-    list out_args, tuple out_types, tuple out_shape, tuple out_params,
-    bint is_size_specified)
-
-cdef tuple _guess_routine_from_dtype(list ops, object dtype)
-
-cdef tuple _guess_routine(
-    str name, dict cache, list ops, list in_args, dtype, list out_ops)
-
-cdef _check_array_device_id(ndarray arr, int device_id)
-
-cdef list _preprocess_args(int dev_id, args, bint use_c_scalar)
-
-cdef tuple _reduce_dims(list args, tuple params, tuple shape)
->>>>>>> b544536a3... Merge pull request #2076 from okuta/fix-true-divide
+cpdef create_reduction_func(name, ops, routine=*, identity=*, preamble=*)

--- a/cupy/core/_kernel.pyx
+++ b/cupy/core/_kernel.pyx
@@ -744,7 +744,32 @@ cdef inline bint _check_should_use_min_scalar(list in_args) except? -1:
             max_array_kind >= max_scalar_kind)
 
 
+<<<<<<< HEAD
 cdef tuple _guess_routine(name, dict cache, list ops, list in_args, dtype):
+=======
+cdef dict _mst_unsigned_to_signed = {
+    i: (numpy.iinfo(j).max, (i, j))
+    for i, j in [(numpy.dtype(i).type, numpy.dtype(i.lower()).type)
+                 for i in "BHILQ"]}
+cdef _numpy_min_scalar_type = numpy.min_scalar_type
+
+cdef _min_scalar_type(x):
+    # A non-negative integer may have two locally minimum scalar
+    # types: signed/unsigned integer.
+    # Return both for can_cast, while numpy.min_scalar_type only returns
+    # the unsigned type.
+    t = _numpy_min_scalar_type(x)
+    dt = t.type
+    if t.kind == 'u':
+        m, dt2 = <tuple>_mst_unsigned_to_signed[dt]
+        if x <= m:
+            return dt2
+    return dt
+
+
+cdef tuple _guess_routine(
+        str name, dict cache, list ops, list in_args, dtype, list out_ops):
+>>>>>>> b544536a3... Merge pull request #2076 from okuta/fix-true-divide
     if dtype is None:
         use_raw_value = _check_should_use_min_scalar(in_args)
         if use_raw_value:
@@ -762,7 +787,7 @@ cdef tuple _guess_routine(name, dict cache, list ops, list in_args, dtype):
     else:
         op = cache.get(dtype, ())
         if op is ():
-            op = _guess_routine_from_dtype(ops, dtype)
+            op = _guess_routine_from_dtype(out_ops, dtype)
             cache[dtype] = op
 
     if op:
@@ -790,7 +815,9 @@ cdef class ufunc:
         readonly Py_ssize_t nout
         readonly Py_ssize_t nargs
         readonly object name
-        readonly list _ops
+        readonly list _ops  # normal routines
+        readonly list _out_ops
+        # routines based on explicitly given output dtype
         readonly object _preamble
         readonly object _loop_prep
         readonly object _default_casting
@@ -802,7 +829,7 @@ cdef class ufunc:
         readonly object __module__
 
     def __init__(self, name, nin, nout, ops, preamble='', loop_prep='', doc='',
-                 default_casting=None):
+                 default_casting=None, *, out_ops=None):
         self.name = name
         self.__name__ = name
         self.nin = nin
@@ -816,6 +843,7 @@ cdef class ufunc:
             self._default_casting = 'same_kind'
         else:
             self._default_casting = default_casting
+        self._out_ops = ops if out_ops is None else out_ops
         _in_params = tuple(
             ParameterInfo('T in%d' % i, True)
             for i in range(nin))
@@ -904,7 +932,8 @@ cdef class ufunc:
         shape = tuple(vec_shape)
 
         op = _guess_routine(
-            self.name, self._routine_cache, self._ops, in_args, dtype)
+            self.name, self._routine_cache, self._ops, in_args, dtype,
+            self._out_ops)
         in_types, out_types, routine = op
         out_args = _get_out_args(out_args, out_types, shape, casting)
         if self.nout == 1:
@@ -957,8 +986,8 @@ cdef class ufunc:
         return kern
 
 
-cpdef create_ufunc(name, ops, routine=None, preamble='', doc='',
-                   default_casting=None, loop_prep=''):
+cdef list _get_ops(ops, routine):
+    """Parse dtype character mapping"""
     _ops = []
     for t in ops:
         if not isinstance(t, tuple):
@@ -975,9 +1004,15 @@ cpdef create_ufunc(name, ops, routine=None, preamble='', doc='',
         in_types = tuple([get_dtype(t).type for t in in_types])
         out_types = tuple([get_dtype(t).type for t in out_types])
         _ops.append((in_types, out_types, rt))
+    return _ops
 
+
+cpdef create_ufunc(name, ops, routine=None, preamble='', doc='',
+                   default_casting=None, loop_prep='', out_ops=None):
+    _ops = _get_ops(ops, routine)
+    _out_ops = None if out_ops is None else _get_ops(out_ops, routine)
     ret = ufunc(name, len(_ops[0][0]), len(_ops[0][1]), _ops, preamble,
-                loop_prep, doc, default_casting=default_casting)
+                loop_prep, doc, default_casting, out_ops=_out_ops)
     return ret
 
 include 'reduction.pxi'

--- a/cupy/core/_kernel.pyx
+++ b/cupy/core/_kernel.pyx
@@ -744,32 +744,8 @@ cdef inline bint _check_should_use_min_scalar(list in_args) except? -1:
             max_array_kind >= max_scalar_kind)
 
 
-<<<<<<< HEAD
-cdef tuple _guess_routine(name, dict cache, list ops, list in_args, dtype):
-=======
-cdef dict _mst_unsigned_to_signed = {
-    i: (numpy.iinfo(j).max, (i, j))
-    for i, j in [(numpy.dtype(i).type, numpy.dtype(i.lower()).type)
-                 for i in "BHILQ"]}
-cdef _numpy_min_scalar_type = numpy.min_scalar_type
-
-cdef _min_scalar_type(x):
-    # A non-negative integer may have two locally minimum scalar
-    # types: signed/unsigned integer.
-    # Return both for can_cast, while numpy.min_scalar_type only returns
-    # the unsigned type.
-    t = _numpy_min_scalar_type(x)
-    dt = t.type
-    if t.kind == 'u':
-        m, dt2 = <tuple>_mst_unsigned_to_signed[dt]
-        if x <= m:
-            return dt2
-    return dt
-
-
 cdef tuple _guess_routine(
         str name, dict cache, list ops, list in_args, dtype, list out_ops):
->>>>>>> b544536a3... Merge pull request #2076 from okuta/fix-true-divide
     if dtype is None:
         use_raw_value = _check_should_use_min_scalar(in_args)
         if use_raw_value:

--- a/cupy/core/_routines_math.pyx
+++ b/cupy/core/_routines_math.pyx
@@ -554,7 +554,9 @@ _true_divide = create_ufunc(
 
     .. seealso:: :data:`numpy.true_divide`
 
-    ''')
+    ''',
+    out_ops=('ee->e', 'ff->f', 'dd->d', 'FF->F', 'DD->D'),
+)
 
 
 if six.PY3:

--- a/cupy/core/reduction.pxi
+++ b/cupy/core/reduction.pxi
@@ -274,7 +274,13 @@ class simple_reduction_function(object):
             out_args = [out]
 
         in_types, out_types, routine = _guess_routine(
+<<<<<<< HEAD:cupy/core/reduction.pxi
             self.name, self._routine_cache, self._ops, in_args, dtype)
+=======
+            self.name, self._routine_cache, self._ops, in_args, dtype,
+            self._ops)
+        map_expr, reduce_expr, post_map_expr, reduce_type = routine
+>>>>>>> b544536a3... Merge pull request #2076 from okuta/fix-true-divide:cupy/core/_reduction.pyx
 
         reduce_axis, out_axis = _get_axis(axis, arr._shape.size())
         del axis  # to avoid bug

--- a/cupy/core/reduction.pxi
+++ b/cupy/core/reduction.pxi
@@ -274,13 +274,8 @@ class simple_reduction_function(object):
             out_args = [out]
 
         in_types, out_types, routine = _guess_routine(
-<<<<<<< HEAD:cupy/core/reduction.pxi
-            self.name, self._routine_cache, self._ops, in_args, dtype)
-=======
             self.name, self._routine_cache, self._ops, in_args, dtype,
             self._ops)
-        map_expr, reduce_expr, post_map_expr, reduce_type = routine
->>>>>>> b544536a3... Merge pull request #2076 from okuta/fix-true-divide:cupy/core/_reduction.pyx
 
         reduce_axis, out_axis = _get_axis(axis, arr._shape.size())
         del axis  # to avoid bug

--- a/tests/cupy_tests/statics_tests/test_meanvar.py
+++ b/tests/cupy_tests/statics_tests/test_meanvar.py
@@ -88,6 +88,11 @@ class TestMeanVar(unittest.TestCase):
         a = testing.shaped_arange((2, 3, 4), xp, dtype)
         return xp.mean(a, axis=1)
 
+    @testing.numpy_cupy_allclose()
+    def test_mean_all_dtype(self, xp):
+        a = xp.full((2, 3, 4), 123456789, dtype=numpy.int64)
+        return xp.mean(a, dtype=numpy.float64)
+
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_var_all(self, xp, dtype):


### PR DESCRIPTION
Backport of #2076