### PR TITLE
Fix compilation error causes when thrust is enabled

### DIFF
--- a/cupy/core/include/cupy/complex/cpow.h
+++ b/cupy/core/include/cupy/complex/cpow.h
@@ -19,7 +19,7 @@ template <typename T>
 __host__ __device__ inline complex<T> pow(const T& x, const complex<T>& exponent) {
   // Find `log` by ADL.
   using std::log;
-  return exp(log(T(x)) * complex<T>(y));
+  return exp(log(T(x)) * complex<T>(exponent));
 }
 
 template <typename T, typename U>


### PR DESCRIPTION
Build fails during cythonizing.
`cupy/core/include/cupy/complex/cpow.h(22): error: identifier "y" is undefined`