### PR TITLE
skip zero valued coefficients in cupyx.scipy.ndimage.convolve

### DIFF
--- a/cupyx/scipy/ndimage/filters.py
+++ b/cupyx/scipy/ndimage/filters.py
@@ -176,9 +176,9 @@ def _generate_correlete_kernel(ndim, mode, cval, xshape, wshape, origin):
         ops.append(_generate_boundary_condition_ops(mode, ixvar, xshape[j]))
         ops.append('        ix_{j} *= sx_{j};'.format(j=j))
 
-    ops.append('W wval = w[iw];')
     ops.append("""
-    if (wval == 0) {{
+    W wval = w[iw];
+    if (wval == (W)0) {{
         iw += 1;
         continue;
     }}""")

--- a/cupyx/scipy/ndimage/filters.py
+++ b/cupyx/scipy/ndimage/filters.py
@@ -176,14 +176,20 @@ def _generate_correlete_kernel(ndim, mode, cval, xshape, wshape, origin):
         ops.append(_generate_boundary_condition_ops(mode, ixvar, xshape[j]))
         ops.append('        ix_{j} *= sx_{j};'.format(j=j))
 
+    ops.append('W wval = w[iw];')
+    ops.append("""
+    if (wval == 0) {{
+        iw += 1;
+        continue;
+    }}""")
     _cond = ' || '.join(['(ix_{0} < 0)'.format(j) for j in range(ndim)])
     _expr = ' + '.join(['ix_{0}'.format(j) for j in range(ndim)])
     ops.append('''
         if ({cond}) {{
-            sum += (W){cval} * w[iw];
+            sum += (W){cval} * wval;
         }} else {{
             int ix = {expr};
-            sum += (W)x[ix] * w[iw];
+            sum += (W)x[ix] * wval;
         }}
         iw += 1;'''.format(cond=_cond, expr=_expr, cval=cval))
 

--- a/cupyx/scipy/ndimage/filters.py
+++ b/cupyx/scipy/ndimage/filters.py
@@ -176,12 +176,12 @@ def _generate_correlete_kernel(ndim, mode, cval, xshape, wshape, origin):
         ops.append(_generate_boundary_condition_ops(mode, ixvar, xshape[j]))
         ops.append('        ix_{j} *= sx_{j};'.format(j=j))
 
-    ops.append("""
-    W wval = w[iw];
-    if (wval == (W)0) {{
-        iw += 1;
-        continue;
-    }}""")
+    ops.append('''
+        W wval = w[iw];
+        if (wval == (W)0) {{
+            iw += 1;
+            continue;
+        }}''')
     _cond = ' || '.join(['(ix_{0} < 0)'.format(j) for j in range(ndim)])
     _expr = ' + '.join(['ix_{0}'.format(j) for j in range(ndim)])
     ops.append('''


### PR DESCRIPTION
This is a more minimal change than the one proposed in #2842. It just skips some logic checks and a multiply+add when a coefficient is zero.

As in the other issues
```Python
import cupy
from cupyx.scipy.ndimage import convolve
from cupyx.time import repeat

d = cupy.cuda.Device()
x = cupy.random.randn(256, 256, 256);

w = cupy.random.randn(5, 5, 5)  # dense case
# w = cupy.zeros((5, 5, 5)); w[0, 0, 0] = 0.5; w[-1, -1, -1] = 0.5;  # sparse case

perf = repeat(convolve, (x, w), n=50, n_warmup=10)
print(perf)
```
dense:
```
convolve            :   161.843 us   +/-73.898 (min:  112.840 / max:  485.355) us  199239.168 us   +/-620.967 (min:197391.357 / max:200185.852) us
```

sparse:
```
convolve            :   166.174 us   +/-72.078 (min:  112.363 / max:  615.620) us  74903.974 us   +/-88.711 (min:74803.200 / max:75203.583) us
```

vs. dense or sparse on master
```
convolve            :   185.285 us   +/-93.271 (min:  114.424 / max:  525.333) us  199177.132 us   +/-678.703 (min:197735.321 / max:200559.616) us
```

There is not as big a benefit in the sparse case, but appears to be no real down side for the fully dense case.
