### PR TITLE
[backport] keepdims should always preserve all dimensions in CUB-based reductions

### DIFF
--- a/cupy/core/_routines_math.pyx
+++ b/cupy/core/_routines_math.pyx
@@ -74,21 +74,11 @@ cdef ndarray _ndarray_prod(ndarray self, axis, dtype, out, keepdims):
 
 cdef ndarray _ndarray_sum(ndarray self, axis, dtype, out, keepdims):
     if cupy.cuda.cub_enabled:
-        if cub.can_use_device_reduce(cub.CUPY_CUB_SUM, self.dtype, self.ndim,
-                                     axis, dtype):
-            return cub.device_reduce(self, cub.CUPY_CUB_SUM, out=out,
-                                     keepdims=keepdims)
-
-        if self.flags.c_contiguous:
-            order = 'C'
-        elif self.flags.f_contiguous:
-            order = 'F'
-        else:
-            order = None
-        if cub.can_use_device_segmented_reduce(cub.CUPY_CUB_SUM, self.dtype,
-                                               self.ndim, axis, dtype, order):
-            return cub.device_segmented_reduce(self, cub.CUPY_CUB_SUM, axis,
-                                               out=out, keepdims=keepdims)
+        # result will be None if the reduction is not compatible with CUB
+        result = cub.cub_reduction(self, cub.CUPY_CUB_SUM, axis, dtype, out,
+                                   keepdims)
+        if result is not None:
+            return result
     if dtype is None:
         return _sum_auto_dtype(self, axis, dtype, out, keepdims)
     else:

--- a/cupy/core/_routines_statistics.pyx
+++ b/cupy/core/_routines_statistics.pyx
@@ -14,68 +14,43 @@ if cupy.cuda.cub_enabled:
 
 cdef ndarray _ndarray_max(ndarray self, axis, out, dtype, keepdims):
     if cupy.cuda.cub_enabled:
-        if cub.can_use_device_reduce(cub.CUPY_CUB_MAX, self.dtype, self.ndim,
-                                     axis, dtype):
-            return cub.device_reduce(self, cub.CUPY_CUB_MAX, out=out,
-                                     keepdims=keepdims)
-
-        if self.flags.c_contiguous:
-            order = 'C'
-        elif self.flags.f_contiguous:
-            order = 'F'
-        else:
-            order = None
-        if cub.can_use_device_segmented_reduce(cub.CUPY_CUB_MAX, self.dtype,
-                                               self.ndim, axis, dtype, order):
-            return cub.device_segmented_reduce(self, cub.CUPY_CUB_MAX, axis,
-                                               out=out, keepdims=keepdims)
+        # result will be None if the reduction is not compatible with CUB
+        result = cub.cub_reduction(self, cub.CUPY_CUB_MAX, axis, dtype, out,
+                                   keepdims)
+        if result is not None:
+            return result
     return _amax(self, axis=axis, out=out, dtype=dtype, keepdims=keepdims)
 
 
 cdef ndarray _ndarray_min(ndarray self, axis, out, dtype, keepdims):
     if cupy.cuda.cub_enabled:
-        if cub.can_use_device_reduce(cub.CUPY_CUB_MIN, self.dtype, self.ndim,
-                                     axis, dtype):
-            return cub.device_reduce(self, cub.CUPY_CUB_MIN, out=out,
-                                     keepdims=keepdims)
-        if self.flags.c_contiguous:
-            order = 'C'
-        elif self.flags.f_contiguous:
-            order = 'F'
-        else:
-            order = None
-        if cub.can_use_device_segmented_reduce(cub.CUPY_CUB_MIN, self.dtype,
-                                               self.ndim, axis, dtype, order):
-            return cub.device_segmented_reduce(self, cub.CUPY_CUB_MIN, axis,
-                                               out=out, keepdims=keepdims)
+        # result will be None if the reduction is not compatible with CUB
+        result = cub.cub_reduction(self, cub.CUPY_CUB_MIN, axis, out, dtype,
+                                   keepdims)
+        if result is not None:
+            return result
     return _amin(self, axis=axis, out=out, dtype=dtype, keepdims=keepdims)
 
 
 # TODO(leofang): this signature is incompatible with NumPy!
 cdef ndarray _ndarray_argmax(ndarray self, axis, out, dtype, keepdims):
     if cupy.cuda.cub_enabled:
-        # Note that the NumPy signature of argmax only has axis and out, so we
-        # need to disable the rest. Moreover, to be compatible with NumPy, axis
-        # can only be None or integers
-        if cub.can_use_device_reduce(
-                cub.CUPY_CUB_ARGMAX, self.dtype, self.ndim, axis, None):
-            return cub.device_reduce(self, cub.CUPY_CUB_ARGMAX, out=out,
-                                     keepdims=False)
-        # TODO(leofang): support device_segmented_reduce for axis=-1?
+        # result will be None if the reduction is not compatible with CUB
+        result = cub.cub_reduction(self, cub.CUPY_CUB_ARGMAX, axis, dtype, out,
+                                   keepdims)
+        if result is not None:
+            return result
     return _argmax(self, axis=axis, out=out, dtype=dtype, keepdims=keepdims)
 
 
 # TODO(leofang): this signature is incompatible with NumPy!
 cdef ndarray _ndarray_argmin(ndarray self, axis, out, dtype, keepdims):
     if cupy.cuda.cub_enabled:
-        # Note that the NumPy signature of argmax only has axis and out, so we
-        # need to disable the rest. Moreover, to be compatible with NumPy, axis
-        # can only be None or integers
-        if cub.can_use_device_reduce(
-                cub.CUPY_CUB_ARGMIN, self.dtype, self.ndim, axis, None):
-            return cub.device_reduce(self, cub.CUPY_CUB_ARGMIN, out=out,
-                                     keepdims=False)
-        # TODO(leofang): support device_segmented_reduce for axis=-1?
+        # result will be None if the reduction is not compatible with CUB
+        result = cub.cub_reduction(self, cub.CUPY_CUB_ARGMIN, axis, dtype, out,
+                                   keepdims)
+        if result is not None:
+            return result
     return _argmin(self, axis=axis, out=out, dtype=dtype, keepdims=keepdims)
 
 

--- a/cupy/core/internal.pxd
+++ b/cupy/core/internal.pxd
@@ -47,3 +47,5 @@ cpdef uint16_t to_float16(float f)
 cpdef float from_float16(uint16_t v)
 
 cdef int _normalize_order(order, cpp_bool allow_k=*) except? 0
+
+cpdef bint _contig_axes(tuple axes)

--- a/cupy/core/internal.pyx
+++ b/cupy/core/internal.pyx
@@ -291,3 +291,16 @@ cdef inline int _normalize_order(order, cpp_bool allow_k=True) except? 0:
     else:
         raise TypeError('order not understood')
     return order_char
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+cpdef bint _contig_axes(tuple axes):
+    # Indicate if the specified axes are in ascending order without gaps.
+    cdef Py_ssize_t n
+    cdef bint contig = True
+    for n in range(1, len(axes)):
+        contig = (axes[n] - axes[n - 1]) == 1
+        if not contig:
+            break
+    return contig

--- a/cupy/core/reduction.pxi
+++ b/cupy/core/reduction.pxi
@@ -89,7 +89,7 @@ extern "C" __global__ void ${name}(${params}) {
 cpdef tuple _get_axis(object axis, Py_ssize_t ndim):
     cdef Py_ssize_t dim
     if axis is None:
-        axis = tuple(range(ndim))
+        return (tuple(range(ndim)), ())
     elif sequence.PySequence_Check(axis):
         axis = tuple(axis)
     else:

--- a/tests/cupy_tests/core_tests/test_ndarray_reduction.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_reduction.py
@@ -14,6 +14,12 @@ class TestArrayReduction(unittest.TestCase):
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
+    def test_max_all_keepdims(self, xp, dtype):
+        a = testing.shaped_random((2, 3), xp, dtype)
+        return a.max(keepdims=True)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose()
     def test_max_axis_large(self, xp, dtype):
         a = testing.shaped_random((3, 1000), xp, dtype)
         return a.max(axis=0)
@@ -35,6 +41,18 @@ class TestArrayReduction(unittest.TestCase):
     def test_max_axis2(self, xp, dtype):
         a = testing.shaped_random((2, 3, 4), xp, dtype)
         return a.max(axis=2)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose()
+    def test_max_multiple_axes(self, xp, dtype):
+        a = testing.shaped_random((2, 3, 4), xp, dtype)
+        return a.max(axis=(1, 2))
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose()
+    def test_max_multiple_axes_keepdims(self, xp, dtype):
+        a = testing.shaped_random((2, 3, 4), xp, dtype)
+        return a.max(axis=(1, 2), keepdims=True)
 
     @testing.for_float_dtypes()
     @testing.numpy_cupy_allclose()
@@ -62,6 +80,12 @@ class TestArrayReduction(unittest.TestCase):
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
+    def test_min_all_keepdims(self, xp, dtype):
+        a = testing.shaped_random((2, 3), xp, dtype)
+        return a.min(keepdims=True)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose()
     def test_min_axis_large(self, xp, dtype):
         a = testing.shaped_random((3, 1000), xp, dtype)
         return a.min(axis=0)
@@ -83,6 +107,18 @@ class TestArrayReduction(unittest.TestCase):
     def test_min_axis2(self, xp, dtype):
         a = testing.shaped_random((2, 3, 4), xp, dtype)
         return a.min(axis=2)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose()
+    def test_min_multiple_axes(self, xp, dtype):
+        a = testing.shaped_random((2, 3, 4), xp, dtype)
+        return a.min(axis=(1, 2))
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose()
+    def test_min_multiple_axes_keepdims(self, xp, dtype):
+        a = testing.shaped_random((2, 3, 4), xp, dtype)
+        return a.min(axis=(1, 2), keepdims=True)
 
     @testing.for_float_dtypes()
     @testing.numpy_cupy_allclose()

--- a/tests/cupy_tests/math_tests/test_sumprod.py
+++ b/tests/cupy_tests/math_tests/test_sumprod.py
@@ -23,6 +23,12 @@ class TestSumprod(unittest.TestCase):
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
+    def test_sum_all_keepdims(self, xp, dtype):
+        a = testing.shaped_arange((2, 3, 4), xp, dtype)
+        return a.sum(keepdims=True)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose()
     def test_external_sum_all(self, xp, dtype):
         a = testing.shaped_arange((2, 3, 4), xp, dtype)
         return xp.sum(a)
@@ -126,10 +132,19 @@ class TestSumprod(unittest.TestCase):
         a = testing.shaped_arange((2, 3, 4), xp, src_dtype)
         return a.sum(dtype=dst_dtype)
 
+    @testing.for_all_dtypes_combination(names=['src_dtype', 'dst_dtype'])
     @testing.numpy_cupy_allclose()
-    def test_sum_keepdims(self, xp):
-        a = testing.shaped_arange((2, 3, 4), xp)
-        return a.sum(axis=1, keepdims=True)
+    def test_sum_keepdims_and_dtype(self, xp, src_dtype, dst_dtype):
+        if not xp.can_cast(src_dtype, dst_dtype):
+            return xp.array([])  # skip
+        a = testing.shaped_arange((2, 3, 4), xp, src_dtype)
+        return a.sum(axis=2, dtype=dst_dtype, keepdims=True)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose()
+    def test_sum_keepdims_multiple_axes(self, xp, dtype):
+        a = testing.shaped_arange((2, 3, 4), xp, dtype)
+        return a.sum(axis=(1, 2), keepdims=True)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()


### PR DESCRIPTION
Backport of #2725