### PR TITLE
[backport] Fix split and array_split with unordered indices supplied

### DIFF
--- a/cupy/core/_routines_manipulation.pyx
+++ b/cupy/core/_routines_manipulation.pyx
@@ -436,7 +436,7 @@ cpdef array_split(ndarray ary, indices_or_sections, Py_ssize_t axis):
         stride = 0
     for index in indices:
         index = min(index, size)
-        shape[axis] = index - prev
+        shape[axis] = max(index - prev, 0)
         v = ary.view()
         v.data = ary.data + prev * stride
         # TODO(niboshi): Confirm update_x_contiguity flags

--- a/tests/cupy_tests/manipulation_tests/test_split.py
+++ b/tests/cupy_tests/manipulation_tests/test_split.py
@@ -39,6 +39,11 @@ class TestSplit(unittest.TestCase):
         return xp.array_split(a, [1])
 
     @testing.numpy_cupy_array_list_equal()
+    def test_array_split_unordered_sections(self, xp):
+        a = testing.shaped_arange((5,), xp)
+        return xp.array_split(a, [4, 2])
+
+    @testing.numpy_cupy_array_list_equal()
     def test_array_split_non_divisible(self, xp):
         a = testing.shaped_arange((5, 3), xp)
         return xp.array_split(a, 4)
@@ -83,6 +88,11 @@ class TestSplit(unittest.TestCase):
     def test_split_out_of_bound2(self, xp):
         a = testing.shaped_arange((0,), xp)
         return xp.split(a, [1])
+
+    @testing.numpy_cupy_array_list_equal()
+    def test_split_unordered_sections(self, xp):
+        a = testing.shaped_arange((5,), xp)
+        return xp.split(a, [4, 2])
 
     @testing.numpy_cupy_array_list_equal()
     def test_vsplit(self, xp):


### PR DESCRIPTION
Backport of #2815