### PR TITLE
Add `ptp` ndarray method and function

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -660,6 +660,7 @@ from cupy.statistics.order import amin as min  # NOQA
 from cupy.statistics.order import nanmax  # NOQA
 from cupy.statistics.order import nanmin  # NOQA
 from cupy.statistics.order import percentile  # NOQA
+from cupy.statistics.order import ptp  # NOQA
 
 from cupy.statistics.meanvar import average  # NOQA
 from cupy.statistics.meanvar import mean  # NOQA

--- a/cupy/core/_routines_statistics.pxd
+++ b/cupy/core/_routines_statistics.pxd
@@ -6,7 +6,7 @@ from cupy.core.core cimport ndarray
 
 cdef ndarray _ndarray_max(ndarray self, axis, out, dtype, keepdims)
 cdef ndarray _ndarray_min(ndarray self, axis, out, dtype, keepdims)
-cdef ndarray _ndarray_ptp(ndarray self, axis, out, dtype, keepdims)
+cdef ndarray _ndarray_ptp(ndarray self, axis, out, keepdims)
 cdef ndarray _ndarray_argmax(ndarray self, axis, out, dtype, keepdims)
 cdef ndarray _ndarray_argmin(ndarray self, axis, out, dtype, keepdims)
 cdef ndarray _ndarray_mean(ndarray self, axis, dtype, out, keepdims)

--- a/cupy/core/_routines_statistics.pxd
+++ b/cupy/core/_routines_statistics.pxd
@@ -6,6 +6,7 @@ from cupy.core.core cimport ndarray
 
 cdef ndarray _ndarray_max(ndarray self, axis, out, dtype, keepdims)
 cdef ndarray _ndarray_min(ndarray self, axis, out, dtype, keepdims)
+cdef ndarray _ndarray_ptp(ndarray self, axis, out, dtype, keepdims)
 cdef ndarray _ndarray_argmax(ndarray self, axis, out, dtype, keepdims)
 cdef ndarray _ndarray_argmin(ndarray self, axis, out, dtype, keepdims)
 cdef ndarray _ndarray_mean(ndarray self, axis, dtype, out, keepdims)

--- a/cupy/core/_routines_statistics.pyx
+++ b/cupy/core/_routines_statistics.pyx
@@ -38,19 +38,18 @@ cdef ndarray _ndarray_min(ndarray self, axis, out, dtype, keepdims):
     return _amin(self, axis=axis, out=out, dtype=dtype, keepdims=keepdims)
 
 
-# TODO(grlee77): this signature is incompatible with NumPy!
-cdef ndarray _ndarray_ptp(ndarray self, axis, out, dtype, keepdims):
+cdef ndarray _ndarray_ptp(ndarray self, axis, out, keepdims):
     if cupy.cuda.cub_enabled:
         # result will be None if the reduction is not compatible with CUB
-        result = cub.cub_reduction(self, cub.CUPY_CUB_MAX, axis, out, dtype,
+        result = cub.cub_reduction(self, cub.CUPY_CUB_MAX, axis, out, None,
                                    keepdims)
         if result is not None:
-            result -= cub.cub_reduction(self, cub.CUPY_CUB_MIN, axis, None, dtype,
-                                   keepdims)
+            result -= cub.cub_reduction(self, cub.CUPY_CUB_MIN, axis, None,
+                                        None, keepdims)
             return result
 
-    result = _amax(self, axis=axis, out=out, dtype=dtype, keepdims=keepdims)
-    result -= _amin(self, axis=axis, out=None, dtype=dtype, keepdims=keepdims)
+    result = _amax(self, axis=axis, out=out, keepdims=keepdims)
+    result -= _amin(self, axis=axis, out=None, keepdims=keepdims)
     return result
 
 

--- a/cupy/core/_routines_statistics.pyx
+++ b/cupy/core/_routines_statistics.pyx
@@ -38,6 +38,22 @@ cdef ndarray _ndarray_min(ndarray self, axis, out, dtype, keepdims):
     return _amin(self, axis=axis, out=out, dtype=dtype, keepdims=keepdims)
 
 
+# TODO(grlee77): this signature is incompatible with NumPy!
+cdef ndarray _ndarray_ptp(ndarray self, axis, out, dtype, keepdims):
+    if cupy.cuda.cub_enabled:
+        # result will be None if the reduction is not compatible with CUB
+        result = cub.cub_reduction(self, cub.CUPY_CUB_MAX, axis, out, dtype,
+                                   keepdims)
+        if result is not None:
+            result -= cub.cub_reduction(self, cub.CUPY_CUB_MIN, axis, None, dtype,
+                                   keepdims)
+            return result
+
+    result = _amax(self, axis=axis, out=out, dtype=dtype, keepdims=keepdims)
+    result -= _amin(self, axis=axis, out=None, dtype=dtype, keepdims=keepdims)
+    return result
+
+
 # TODO(leofang): this signature is incompatible with NumPy!
 cdef ndarray _ndarray_argmax(ndarray self, axis, out, dtype, keepdims):
     if cupy.cuda.cub_enabled and self._c_contiguous:

--- a/cupy/core/core.pxd
+++ b/cupy/core/core.pxd
@@ -48,6 +48,7 @@ cdef class ndarray:
     cpdef ndarray min(self, axis=*, out=*, dtype=*, keepdims=*)
     cpdef ndarray argmin(self, axis=*, out=*, dtype=*,
                          keepdims=*)
+    cpdef ndarray ptp(self, axis=*, out=*, dtype=*, keepdims=*)
     cpdef ndarray clip(self, a_min=*, a_max=*, out=*)
     cpdef ndarray round(self, decimals=*, out=*)
 

--- a/cupy/core/core.pxd
+++ b/cupy/core/core.pxd
@@ -48,7 +48,7 @@ cdef class ndarray:
     cpdef ndarray min(self, axis=*, out=*, dtype=*, keepdims=*)
     cpdef ndarray argmin(self, axis=*, out=*, dtype=*,
                          keepdims=*)
-    cpdef ndarray ptp(self, axis=*, out=*, dtype=*, keepdims=*)
+    cpdef ndarray ptp(self, axis=*, out=*, keepdims=*)
     cpdef ndarray clip(self, a_min=*, a_max=*, out=*)
     cpdef ndarray round(self, decimals=*, out=*)
 

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -769,7 +769,15 @@ cdef class ndarray:
         """
         return _statistics._ndarray_argmin(self, axis, out, dtype, keepdims)
 
-    # TODO(okuta): Implement ptp
+    cpdef ndarray ptp(self, axis=None, out=None, dtype=None, keepdims=False):
+        """Returns (maximum - minimum) along a given axis.
+
+        .. seealso::
+           :func:`cupy.ptp` for full documentation,
+           :meth:`numpy.ndarray.ptp`
+
+        """
+        return _statistics._ndarray_ptp(self, axis, out, dtype, keepdims)
 
     cpdef ndarray clip(self, a_min=None, a_max=None, out=None):
         """Returns an array with values limited to [a_min, a_max].

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -769,7 +769,7 @@ cdef class ndarray:
         """
         return _statistics._ndarray_argmin(self, axis, out, dtype, keepdims)
 
-    cpdef ndarray ptp(self, axis=None, out=None, dtype=None, keepdims=False):
+    cpdef ndarray ptp(self, axis=None, out=None, keepdims=False):
         """Returns (maximum - minimum) along a given axis.
 
         .. seealso::
@@ -777,7 +777,7 @@ cdef class ndarray:
            :meth:`numpy.ndarray.ptp`
 
         """
-        return _statistics._ndarray_ptp(self, axis, out, dtype, keepdims)
+        return _statistics._ndarray_ptp(self, axis, out, keepdims)
 
     cpdef ndarray clip(self, a_min=None, a_max=None, out=None):
         """Returns an array with values limited to [a_min, a_max].

--- a/cupy/statistics/order.py
+++ b/cupy/statistics/order.py
@@ -127,7 +127,7 @@ def nanmax(a, axis=None, out=None, keepdims=False):
     return res
 
 
-def ptp(a, axis=None, out=None, keepdims=False, dtype=None):
+def ptp(a, axis=None, out=None, keepdims=False):
     """Returns the range of values (maximum - minimum) along an axis.
 
     .. note::
@@ -151,7 +151,7 @@ def ptp(a, axis=None, out=None, keepdims=False, dtype=None):
     .. seealso:: :func:`numpy.amin`
 
     """
-    return a.ptp(axis=axis, out=out, dtype=dtype, keepdims=keepdims)
+    return a.ptp(axis=axis, out=out, keepdims=keepdims)
 
 
 def percentile(a, q, axis=None, out=None, interpolation='linear',

--- a/cupy/statistics/order.py
+++ b/cupy/statistics/order.py
@@ -127,7 +127,31 @@ def nanmax(a, axis=None, out=None, keepdims=False):
     return res
 
 
-# TODO(okuta): Implement ptp
+def ptp(a, axis=None, out=None, keepdims=False, dtype=None):
+    """Returns the range of values (maximum - minimum) along an axis.
+
+    .. note::
+
+       The name of the function comes from the acronym for 'peak to peak'.
+
+       When at least one element is NaN, the corresponding ptp value will be
+       NaN.
+
+    Args:
+        a (cupy.ndarray): Array over which to take the range.
+        axis (int): Axis along which to take the minimum. The flattened
+            array is used by default.
+        out (cupy.ndarray): Output array.
+        keepdims (bool): If ``True``, the axis is retained as an axis of
+            size one.
+
+    Returns:
+        cupy.ndarray: The minimum of ``a``, along the axis if specified.
+
+    .. seealso:: :func:`numpy.amin`
+
+    """
+    return a.ptp(axis=axis, out=out, dtype=dtype, keepdims=keepdims)
 
 
 def percentile(a, q, axis=None, out=None, interpolation='linear',

--- a/tests/cupy_tests/core_tests/test_ndarray_reduction.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_reduction.py
@@ -101,3 +101,70 @@ class TestArrayReduction(unittest.TestCase):
     def test_min_nan_imag(self, xp, dtype):
         a = xp.array([float('nan')*1.j, 1.j, -1.j], dtype)
         return a.min()
+
+    # skip bool: numpy's ptp raises a TypeError on bool inputs
+    @testing.for_all_dtypes(no_bool=True)
+    @testing.numpy_cupy_allclose()
+    def test_ptp_all(self, xp, dtype):
+        a = testing.shaped_random((2, 3), xp, dtype)
+        return a.ptp()
+
+    @testing.for_all_dtypes(no_bool=True)
+    @testing.numpy_cupy_allclose()
+    def test_ptp_all_keepdims(self, xp, dtype):
+        a = testing.shaped_random((2, 3), xp, dtype)
+        return a.ptp(keepdims=True)
+
+    @testing.for_all_dtypes(no_bool=True)
+    @testing.numpy_cupy_allclose()
+    def test_ptp_axis_large(self, xp, dtype):
+        a = testing.shaped_random((3, 1000), xp, dtype)
+        return a.ptp(axis=0)
+
+    @testing.for_all_dtypes(no_bool=True)
+    @testing.numpy_cupy_allclose()
+    def test_ptp_axis0(self, xp, dtype):
+        a = testing.shaped_random((2, 3, 4), xp, dtype)
+        return a.ptp(axis=0)
+
+    @testing.for_all_dtypes(no_bool=True)
+    @testing.numpy_cupy_allclose()
+    def test_ptp_axis1(self, xp, dtype):
+        a = testing.shaped_random((2, 3, 4), xp, dtype)
+        return a.ptp(axis=1)
+
+    @testing.for_all_dtypes(no_bool=True)
+    @testing.numpy_cupy_allclose()
+    def test_ptp_axis2(self, xp, dtype):
+        a = testing.shaped_random((2, 3, 4), xp, dtype)
+        return a.ptp(axis=2)
+
+    @testing.for_all_dtypes(no_bool=True)
+    @testing.numpy_cupy_allclose()
+    def test_ptp_multiple_axes(self, xp, dtype):
+        a = testing.shaped_random((2, 3, 4), xp, dtype)
+        return a.ptp(axis=(1, 2))
+
+    @testing.for_all_dtypes(no_bool=True)
+    @testing.numpy_cupy_allclose()
+    def test_ptp_multiple_axes_keepdims(self, xp, dtype):
+        a = testing.shaped_random((2, 3, 4), xp, dtype)
+        return a.ptp(axis=(1, 2), keepdims=True)
+
+    @testing.for_float_dtypes()
+    @testing.numpy_cupy_allclose()
+    def test_ptp_nan(self, xp, dtype):
+        a = xp.array([float('nan'), 1, -1], dtype)
+        return a.ptp()
+
+    @testing.for_complex_dtypes()
+    @testing.numpy_cupy_allclose()
+    def test_ptp_nan_real(self, xp, dtype):
+        a = xp.array([float('nan'), 1, -1], dtype)
+        return a.ptp()
+
+    @testing.for_complex_dtypes()
+    @testing.numpy_cupy_allclose()
+    def test_ptp_nan_imag(self, xp, dtype):
+        a = xp.array([float('nan')*1.j, 1.j, -1.j], dtype)
+        return a.ptp()

--- a/tests/cupy_tests/core_tests/test_ndarray_reduction.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_reduction.py
@@ -109,6 +109,7 @@ class TestArrayReduction(unittest.TestCase):
         a = testing.shaped_random((2, 3), xp, dtype)
         return a.ptp()
 
+    @testing.with_requires('numpy>=1.15')
     @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose()
     def test_ptp_all_keepdims(self, xp, dtype):
@@ -139,12 +140,14 @@ class TestArrayReduction(unittest.TestCase):
         a = testing.shaped_random((2, 3, 4), xp, dtype)
         return a.ptp(axis=2)
 
+    @testing.with_requires('numpy>=1.15')
     @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose()
     def test_ptp_multiple_axes(self, xp, dtype):
         a = testing.shaped_random((2, 3, 4), xp, dtype)
         return a.ptp(axis=(1, 2))
 
+    @testing.with_requires('numpy>=1.15')
     @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose()
     def test_ptp_multiple_axes_keepdims(self, xp, dtype):

--- a/tests/cupy_tests/statics_tests/test_order.py
+++ b/tests/cupy_tests/statics_tests/test_order.py
@@ -189,3 +189,45 @@ class TestOrder(unittest.TestCase):
         self.assertEqual(len(w), 1)
         self.assertIs(w[0].category, RuntimeWarning)
         return m
+
+    @testing.for_all_dtypes(no_bool=True)
+    @testing.numpy_cupy_allclose()
+    def test_ptp_all(self, xp, dtype):
+        a = testing.shaped_random((2, 3), xp, dtype)
+        return xp.ptp(a)
+
+    @testing.for_all_dtypes(no_bool=True)
+    @testing.numpy_cupy_allclose()
+    def test_ptp_axis_large(self, xp, dtype):
+        a = testing.shaped_random((3, 1000), xp, dtype)
+        return xp.ptp(a, axis=0)
+
+    @testing.for_all_dtypes(no_bool=True)
+    @testing.numpy_cupy_allclose()
+    def test_ptp_axis0(self, xp, dtype):
+        a = testing.shaped_random((2, 3, 4), xp, dtype)
+        return xp.ptp(a, axis=0)
+
+    @testing.for_all_dtypes(no_bool=True)
+    @testing.numpy_cupy_allclose()
+    def test_ptp_axis1(self, xp, dtype):
+        a = testing.shaped_random((2, 3, 4), xp, dtype)
+        return xp.ptp(a, axis=1)
+
+    @testing.for_all_dtypes(no_bool=True)
+    @testing.numpy_cupy_allclose()
+    def test_ptp_axis2(self, xp, dtype):
+        a = testing.shaped_random((2, 3, 4), xp, dtype)
+        return xp.ptp(a, axis=2)
+
+    @testing.for_float_dtypes()
+    @testing.numpy_cupy_allclose()
+    def test_ptp_nan(self, xp, dtype):
+        a = xp.array([float('nan'), 1, -1], dtype)
+        return xp.ptp(a)
+
+    @testing.for_float_dtypes()
+    @testing.numpy_cupy_allclose()
+    def test_ptp_all_nan(self, xp, dtype):
+        a = xp.array([float('nan'), float('nan')], dtype)
+        return xp.ptp(a)


### PR DESCRIPTION
This PR adds `ptp` (peak-to-peak). 

I have included a `dtype` argument to make it consistent with CuPy's min & max (which `ptp` calls internally), but this argument is not present in the NumPy API. If preferred it can be removed (I wasn't sure what the reasoning for its inclusion was).

Also, unlike `amin` or `amax`, `ptp` as implemented here does not currently support Fusion. I haven't looked at the Fusion code implementation, so am not sure how easy it might be to support? The current implementation calls both `_amin` and `_amax` ufuncs rather than implementing its own separate reduction kernel, so there was not a single kernel to point to as done in the `amin` function I looked at as a reference.

Finally, should we also check explicitly for `bool` dtype and raise a TypeError in that case to match NumPy's behavior?