### PR TITLE
[backport] Remove Python 3.4 matrix from Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ cache:
   - ccache
 
 python:
-  - "3.4"
   - "3.5"
 
 install:


### PR DESCRIPTION
Backport of #2794