### PR TITLE
Remove `dtype` argument from `min`/`max`

### DIFF
--- a/cupy/core/core.pxd
+++ b/cupy/core/core.pxd
@@ -44,10 +44,10 @@ cdef class ndarray:
     cpdef ndarray argpartition(self, kth, axis=*)
     cpdef tuple nonzero(self)
     cpdef ndarray diagonal(self, offset=*, axis1=*, axis2=*)
-    cpdef ndarray max(self, axis=*, out=*, dtype=*, keepdims=*)
+    cpdef ndarray max(self, axis=*, out=*, keepdims=*)
     cpdef ndarray argmax(self, axis=*, out=*, dtype=*,
                          keepdims=*)
-    cpdef ndarray min(self, axis=*, out=*, dtype=*, keepdims=*)
+    cpdef ndarray min(self, axis=*, out=*, keepdims=*)
     cpdef ndarray argmin(self, axis=*, out=*, dtype=*,
                          keepdims=*)
     cpdef ndarray clip(self, a_min=*, a_max=*, out=*)

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -740,7 +740,7 @@ cdef class ndarray:
     # -------------------------------------------------------------------------
     # Calculation
     # -------------------------------------------------------------------------
-    cpdef ndarray max(self, axis=None, out=None, dtype=None, keepdims=False):
+    cpdef ndarray max(self, axis=None, out=None, keepdims=False):
         """Returns the maximum along a given axis.
 
         .. seealso::
@@ -748,7 +748,7 @@ cdef class ndarray:
            :meth:`numpy.ndarray.max`
 
         """
-        return _statistics._ndarray_max(self, axis, out, dtype, keepdims)
+        return _statistics._ndarray_max(self, axis, out, None, keepdims)
 
     cpdef ndarray argmax(self, axis=None, out=None, dtype=None,
                          keepdims=False):
@@ -761,7 +761,7 @@ cdef class ndarray:
         """
         return _statistics._ndarray_argmax(self, axis, out, dtype, keepdims)
 
-    cpdef ndarray min(self, axis=None, out=None, dtype=None, keepdims=False):
+    cpdef ndarray min(self, axis=None, out=None, keepdims=False):
         """Returns the minimum along a given axis.
 
         .. seealso::
@@ -769,7 +769,7 @@ cdef class ndarray:
            :meth:`numpy.ndarray.min`
 
         """
-        return _statistics._ndarray_min(self, axis, out, dtype, keepdims)
+        return _statistics._ndarray_min(self, axis, out, None, keepdims)
 
     cpdef ndarray argmin(self, axis=None, out=None, dtype=None,
                          keepdims=False):

--- a/cupy/statistics/order.py
+++ b/cupy/statistics/order.py
@@ -7,7 +7,7 @@ from cupy.core import fusion
 from cupy.logic import content
 
 
-def amin(a, axis=None, out=None, keepdims=False, dtype=None):
+def amin(a, axis=None, out=None, keepdims=False):
     """Returns the minimum of an array or the minimum along an axis.
 
     .. note::
@@ -22,7 +22,6 @@ def amin(a, axis=None, out=None, keepdims=False, dtype=None):
         out (cupy.ndarray): Output array.
         keepdims (bool): If ``True``, the axis is remained as an axis of
             size one.
-        dtype: Data type specifier.
 
     Returns:
         cupy.ndarray: The minimum of ``a``, along the axis if specified.
@@ -35,13 +34,13 @@ def amin(a, axis=None, out=None, keepdims=False, dtype=None):
             raise NotImplementedError(
                 'cupy.amin does not support `keepdims` in fusion yet.')
         return fusion._call_reduction(_statistics.amin,
-                                      a, axis=axis, dtype=dtype, out=out)
+                                      a, axis=axis, out=out)
 
     # TODO(okuta): check type
-    return a.min(axis=axis, dtype=dtype, out=out, keepdims=keepdims)
+    return a.min(axis=axis, out=out, keepdims=keepdims)
 
 
-def amax(a, axis=None, out=None, keepdims=False, dtype=None):
+def amax(a, axis=None, out=None, keepdims=False):
     """Returns the maximum of an array or the maximum along an axis.
 
     .. note::
@@ -56,7 +55,6 @@ def amax(a, axis=None, out=None, keepdims=False, dtype=None):
         out (cupy.ndarray): Output array.
         keepdims (bool): If ``True``, the axis is remained as an axis of
             size one.
-        dtype: Data type specifier.
 
     Returns:
         cupy.ndarray: The maximum of ``a``, along the axis if specified.
@@ -69,10 +67,10 @@ def amax(a, axis=None, out=None, keepdims=False, dtype=None):
             raise NotImplementedError(
                 'cupy.amax does not support `keepdims` in fusion yet.')
         return fusion._call_reduction(_statistics.amax,
-                                      a, axis=axis, dtype=dtype, out=out)
+                                      a, axis=axis, out=out)
 
     # TODO(okuta): check type
-    return a.max(axis=axis, dtype=dtype, out=out, keepdims=keepdims)
+    return a.max(axis=axis, out=out, keepdims=keepdims)
 
 
 def nanmin(a, axis=None, out=None, keepdims=False):


### PR DESCRIPTION
Fixes #2865 