### PR TITLE
[RFC] Disallow `testing.numpy_cupy_raises` without explicit error type

### DIFF
--- a/tests/cupy_tests/manipulation_tests/test_shape.py
+++ b/tests/cupy_tests/manipulation_tests/test_shape.py
@@ -51,22 +51,22 @@ class TestShape(unittest.TestCase):
         a = testing.shaped_arange((2, 3, 4), xp)
         return a.reshape(3, -1, order=order)
 
-    @testing.numpy_cupy_raises()
+    @testing.numpy_cupy_raises(TypeError)
     def test_reshape_with_multiple_unknown_dimensions(self):
         a = testing.shaped_arange((2, 3, 4))
         a.reshape(3, -1, -1)
 
-    @testing.numpy_cupy_raises()
-    def test_reshape_with_changed_arraysize(self):
+    @testing.numpy_cupy_raises(ValueError)
+    def test_reshape_with_changed_arraysize(self, xp):
         a = testing.shaped_arange((2, 3, 4))
         a.reshape(2, 4, 4)
 
-    @testing.numpy_cupy_raises()
-    def test_reshape_invalid_order(self):
+    @testing.numpy_cupy_raises(TypeError)
+    def test_reshape_invalid_order(self, xp):
         a = testing.shaped_arange((2, 3, 4))
         a.reshape(2, 4, 4, order='K')
 
-    @testing.numpy_cupy_raises()
+    @testing.numpy_cupy_raises(ValueError)
     def test_reshape_empty_invalid(self, xp):
         a = testing.empty(xp)
         a = a.reshape(())


### PR DESCRIPTION
Fixes #2871