### PR TITLE
Sort type map in `_kernel.pyx`

### DIFF
--- a/cupy/core/_kernel.pyx
+++ b/cupy/core/_kernel.pyx
@@ -337,7 +337,7 @@ cdef tuple _decide_params_type_core(
                       for p in in_params])
     out_types = tuple([type_dict[p.ctype] if p.dtype is None else p.dtype
                        for p in out_params])
-    return in_types, out_types, tuple(type_dict.items())
+    return in_types, out_types, tuple(sorted(type_dict.items()))
 
 
 cdef tuple _broadcast(list args, tuple params, bint use_size):


### PR DESCRIPTION
`items()` is not guaranteed to be in any order (at least before Python 3.7).
This value is used as a cache key, so it should be sorted.