### PR TITLE
[RFC] Apply synchronization detection in unit tests

### DIFF
--- a/cupy/testing/array.py
+++ b/cupy/testing/array.py
@@ -1,6 +1,7 @@
 import numpy.testing
 
 import cupy
+import cupyx
 
 
 # NumPy-like assertion functions that accept both NumPy and CuPy arrays
@@ -21,9 +22,10 @@ def assert_allclose(actual, desired, rtol=1e-7, atol=0, err_msg='',
     .. seealso:: :func:`numpy.testing.assert_allclose`
 
     """  # NOQA
-    numpy.testing.assert_allclose(
-        cupy.asnumpy(actual), cupy.asnumpy(desired),
-        rtol=rtol, atol=atol, err_msg=err_msg, verbose=verbose)
+    with cupyx.allow_synchronize(True):
+        numpy.testing.assert_allclose(
+            cupy.asnumpy(actual), cupy.asnumpy(desired),
+            rtol=rtol, atol=atol, err_msg=err_msg, verbose=verbose)
 
 
 def assert_array_almost_equal(x, y, decimal=6, err_msg='', verbose=True):
@@ -39,9 +41,10 @@ def assert_array_almost_equal(x, y, decimal=6, err_msg='', verbose=True):
 
     .. seealso:: :func:`numpy.testing.assert_array_almost_equal`
     """  # NOQA
-    numpy.testing.assert_array_almost_equal(
-        cupy.asnumpy(x), cupy.asnumpy(y), decimal=decimal,
-        err_msg=err_msg, verbose=verbose)
+    with cupyx.allow_synchronize(True):
+        numpy.testing.assert_array_almost_equal(
+            cupy.asnumpy(x), cupy.asnumpy(y), decimal=decimal,
+            err_msg=err_msg, verbose=verbose)
 
 
 def assert_array_almost_equal_nulp(x, y, nulp=1):
@@ -54,8 +57,9 @@ def assert_array_almost_equal_nulp(x, y, nulp=1):
 
     .. seealso:: :func:`numpy.testing.assert_array_almost_equal_nulp`
     """
-    numpy.testing.assert_array_almost_equal_nulp(
-        cupy.asnumpy(x), cupy.asnumpy(y), nulp=nulp)
+    with cupyx.allow_synchronize(True):
+        numpy.testing.assert_array_almost_equal_nulp(
+            cupy.asnumpy(x), cupy.asnumpy(y), nulp=nulp)
 
 
 def assert_array_max_ulp(a, b, maxulp=1, dtype=None):
@@ -70,8 +74,9 @@ def assert_array_max_ulp(a, b, maxulp=1, dtype=None):
 
     .. seealso:: :func:`numpy.testing.assert_array_max_ulp`
     """  # NOQA
-    numpy.testing.assert_array_max_ulp(
-        cupy.asnumpy(a), cupy.asnumpy(b), maxulp=maxulp, dtype=dtype)
+    with cupyx.allow_synchronize(True):
+        numpy.testing.assert_array_max_ulp(
+            cupy.asnumpy(a), cupy.asnumpy(b), maxulp=maxulp, dtype=dtype)
 
 
 def assert_array_equal(x, y, err_msg='', verbose=True, strides_check=False):
@@ -88,9 +93,10 @@ def assert_array_equal(x, y, err_msg='', verbose=True, strides_check=False):
 
     .. seealso:: :func:`numpy.testing.assert_array_equal`
     """
-    numpy.testing.assert_array_equal(
-        cupy.asnumpy(x), cupy.asnumpy(y), err_msg=err_msg,
-        verbose=verbose)
+    with cupyx.allow_synchronize(True):
+        numpy.testing.assert_array_equal(
+            cupy.asnumpy(x), cupy.asnumpy(y), err_msg=err_msg,
+            verbose=verbose)
 
     if strides_check:
         if x.strides != y.strides:
@@ -134,10 +140,11 @@ def assert_array_list_equal(xlist, ylist, err_msg='', verbose=True):
             'List or tuple is expected, but was {}'.format(x_type))
     if len(xlist) != len(ylist):
         raise AssertionError('List size is different')
-    for x, y in zip(xlist, ylist):
-        numpy.testing.assert_array_equal(
-            cupy.asnumpy(x), cupy.asnumpy(y), err_msg=err_msg,
-            verbose=verbose)
+    with cupyx.allow_synchronize(True):
+        for x, y in zip(xlist, ylist):
+            numpy.testing.assert_array_equal(
+                cupy.asnumpy(x), cupy.asnumpy(y), err_msg=err_msg,
+                verbose=verbose)
 
 
 def assert_array_less(x, y, err_msg='', verbose=True):
@@ -152,6 +159,7 @@ def assert_array_less(x, y, err_msg='', verbose=True):
 
     .. seealso:: :func:`numpy.testing.assert_array_less`
     """  # NOQA
-    numpy.testing.assert_array_less(
-        cupy.asnumpy(x), cupy.asnumpy(y), err_msg=err_msg,
-        verbose=verbose)
+    with cupyx.allow_synchronize(True):
+        numpy.testing.assert_array_less(
+            cupy.asnumpy(x), cupy.asnumpy(y), err_msg=err_msg,
+            verbose=verbose)

--- a/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
@@ -5,6 +5,9 @@ import numpy
 
 import cupy
 from cupy import testing
+import cupyx
+
+from cupy_tests import utils
 
 
 def perm(iterable):
@@ -118,7 +121,9 @@ class TestArrayAdvancedIndexingGetitemParametrized(unittest.TestCase):
     @testing.numpy_cupy_array_equal()
     def test_adv_getitem(self, xp, dtype):
         a = testing.shaped_arange(self.shape, xp, dtype)
-        return a[self.indexes]
+        allow_sync = utils.is_indexing_cause_synchronize(self.indexes)
+        with cupyx.allow_synchronize(allow_sync):
+            return a[self.indexes]
 
 
 @testing.parameterize(
@@ -135,7 +140,9 @@ class TestArrayAdvancedIndexingGetitemParametrized2(unittest.TestCase):
     @testing.numpy_cupy_array_equal()
     def test_adv_getitem(self, xp, dtype):
         a = testing.shaped_arange(self.shape, xp, dtype)
-        return a[self.indexes]
+        allow_sync = utils.is_indexing_cause_synchronize(self.indexes)
+        with cupyx.allow_synchronize(allow_sync):
+            return a[self.indexes]
 
 
 @testing.parameterize(
@@ -462,7 +469,9 @@ class TestArrayAdvancedIndexingSetitemScalarValue(unittest.TestCase):
     @testing.numpy_cupy_array_equal()
     def test_adv_setitem(self, xp, dtype):
         a = xp.zeros(self.shape, dtype=dtype)
-        a[self.indexes] = self.value
+        allow_sync = utils.is_indexing_cause_synchronize(self.indexes)
+        with cupyx.allow_synchronize(allow_sync):
+            a[self.indexes] = self.value
         return a
 
 
@@ -480,7 +489,9 @@ class TestArrayAdvancedIndexingSetitemScalarValue2(unittest.TestCase):
     @testing.numpy_cupy_array_equal()
     def test_adv_setitem(self, xp, dtype):
         a = xp.zeros(self.shape, dtype=dtype)
-        a[self.indexes] = self.value
+        allow_sync = utils.is_indexing_cause_synchronize(self.indexes)
+        with cupyx.allow_synchronize(allow_sync):
+            a[self.indexes] = self.value
         return a
 
 
@@ -552,7 +563,9 @@ class TestArrayAdvancedIndexingVectorValue(unittest.TestCase):
     @testing.numpy_cupy_array_equal()
     def test_adv_setitem(self, xp, dtype):
         a = xp.zeros(self.shape, dtype=dtype)
-        a[self.indexes] = self.value.astype(a.dtype)
+        allow_sync = utils.is_indexing_cause_synchronize(self.indexes)
+        with cupyx.allow_synchronize(allow_sync):
+            a[self.indexes] = self.value.astype(a.dtype)
         return a
 
 
@@ -618,7 +631,8 @@ class TestArrayAdvancedIndexingSetitemDifferetnDtypes(unittest.TestCase):
         shape = (2, 3)
         a = xp.zeros(shape, dtype=src_dtype)
         indexes = xp.array([True, False])
-        a[indexes] = xp.array(1, dtype=dst_dtype)
+        with cupyx.allow_synchronize(True):
+            a[indexes] = xp.array(1, dtype=dst_dtype)
         return a
 
 

--- a/tests/cupy_tests/core_tests/test_ndarray_conversion.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_conversion.py
@@ -11,7 +11,7 @@ from cupy import testing
 class TestNdarrayItem(unittest.TestCase):
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_equal()
+    @testing.numpy_cupy_equal(allow_synchronize=True)
     def test_item(self, xp, dtype):
         a = xp.full(self.shape, 3, dtype)
         return a.item()
@@ -24,7 +24,7 @@ class TestNdarrayItem(unittest.TestCase):
 )
 class TestNdarrayItemRaise(unittest.TestCase):
 
-    @testing.numpy_cupy_raises()
+    @testing.numpy_cupy_raises(allow_synchronize=True)
     def test_item(self, xp):
         a = testing.shaped_arange(self.shape, xp, xp.float32)
         a.item()
@@ -40,7 +40,7 @@ class TestNdarrayItemRaise(unittest.TestCase):
 class TestNdarrayToBytes(unittest.TestCase):
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_equal()
+    @testing.numpy_cupy_equal(allow_synchronize=True)
     def test_item(self, xp, dtype):
         a = testing.shaped_arange(self.shape, xp, dtype)
         if hasattr(self, 'order'):

--- a/tests/cupy_tests/core_tests/test_ndarray_scatter.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_scatter.py
@@ -4,6 +4,9 @@ import numpy
 
 import cupy
 from cupy import testing
+import cupyx
+
+from cupy_tests import utils
 
 
 @testing.parameterize(
@@ -118,7 +121,9 @@ class TestScatterParametrized(unittest.TestCase):
     def test_scatter_add(self, xp, dtype):
         a = xp.zeros(self.shape, dtype)
         if xp is cupy:
-            a.scatter_add(self.slices, self.value)
+            allow_sync = utils.is_indexing_cause_synchronize(self.slices)
+            with cupyx.allow_synchronize(allow_sync):
+                a.scatter_add(self.slices, self.value)
         else:
             numpy.add.at(a, self.slices, self.value)
         return a
@@ -129,7 +134,9 @@ class TestScatterParametrized(unittest.TestCase):
     def test_scatter_max(self, xp, dtype):
         a = xp.zeros(self.shape, dtype)
         if xp is cupy:
-            a.scatter_max(self.slices, self.value)
+            allow_sync = utils.is_indexing_cause_synchronize(self.slices)
+            with cupyx.allow_synchronize(allow_sync):
+                a.scatter_max(self.slices, self.value)
         else:
             numpy.maximum.at(a, self.slices, self.value)
         return a
@@ -140,7 +147,9 @@ class TestScatterParametrized(unittest.TestCase):
     def test_scatter_min(self, xp, dtype):
         a = xp.zeros(self.shape, dtype)
         if xp is cupy:
-            a.scatter_min(self.slices, self.value)
+            allow_sync = utils.is_indexing_cause_synchronize(self.slices)
+            with cupyx.allow_synchronize(allow_sync):
+                a.scatter_min(self.slices, self.value)
         else:
             numpy.minimum.at(a, self.slices, self.value)
         return a

--- a/tests/cupy_tests/sorting_tests/test_search.py
+++ b/tests/cupy_tests/sorting_tests/test_search.py
@@ -210,7 +210,7 @@ class TestWhereTwoArrays(unittest.TestCase):
 class TestWhereCond(unittest.TestCase):
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_array_list_equal()
+    @testing.numpy_cupy_array_list_equal(allow_synchronize=True)
     def test_where_cond(self, xp, dtype):
         m = testing.shaped_random(self.cond_shape, xp, xp.bool_)
         cond = testing.shaped_random(self.cond_shape, xp, dtype) * m
@@ -238,7 +238,7 @@ class TestWhereError(unittest.TestCase):
 class TestNonzero(unittest.TestCase):
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_array_list_equal()
+    @testing.numpy_cupy_array_list_equal(allow_synchronize=True)
     def test_nonzero(self, xp, dtype):
         array = xp.array(self.array, dtype=dtype)
         return xp.nonzero(array)
@@ -272,7 +272,7 @@ class TestNonzeroZeroDimension(unittest.TestCase):
 class TestFlatNonzero(unittest.TestCase):
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_array_equal()
+    @testing.numpy_cupy_array_equal(allow_synchronize=True)
     def test_flatnonzero(self, xp, dtype):
         array = xp.array(self.array, dtype=dtype)
         return xp.flatnonzero(array)

--- a/tests/cupy_tests/utils.py
+++ b/tests/cupy_tests/utils.py
@@ -1,0 +1,16 @@
+import numpy
+
+
+def is_indexing_cause_synchronize(indexes):
+    # Returns whether advanced indexing with the given indexes causes
+    # synchronization.
+    if isinstance(indexes, bool):
+        return True
+    if (isinstance(indexes, numpy.ndarray)
+            and indexes.dtype == numpy.bool_):
+        return True
+    if (isinstance(indexes, tuple)
+            and any(is_indexing_cause_synchronize(idx)
+                    for idx in indexes)):
+        return True
+    return False


### PR DESCRIPTION
Addresses https://github.com/cupy/cupy/pull/2819#issuecomment-568971301

I'm not sure if we should fix all the tests and apply `allow_synchronize=False` by default, because there are so many tests that were caught.
I made this PR at least for record.