### PR TITLE
Add Mergify configuration file

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,16 @@
+pull_request_rules:
+  - name: Auto merge
+    conditions:
+      - "#changes-requested-reviews-by=0"
+      - label=st:test-and-merge
+      - status-success=Jenkins
+      - status-success=continuous-integration/travis-ci/pr
+      - status-success=pfn-public-ci/cupy.py2.cv.examples
+      - status-success=pfn-public-ci/cupy.py2.cv.gpu
+      - status-success=pfn-public-ci/cupy.py3.amd
+      - status-success=pfn-public-ci/cupy.py3.cv.examples
+      - status-success=pfn-public-ci/cupy.py3.cv.gpu
+    actions:
+      merge:
+        method: merge
+        strict: false  # strict mode and manually-triggered CIs do not get along


### PR DESCRIPTION
Adding mergify configuration.

It's also necessary to configure the organization following the instruction: https://doc.mergify.io/getting-started.html

Should `continuous-integration/appveyor/pr` also be included?
