### PR TITLE
Ignore error when peer access is already enabled 

### DIFF
--- a/cupy/cuda/cupy_cuda_common.h
+++ b/cupy/cuda/cupy_cuda_common.h
@@ -61,6 +61,7 @@ typedef enum {
     cudaSuccess = 0,
     cudaErrorInvalidValue = 1,
     cudaErrorMemoryAllocation = 2,
+    cudaErrorPeerAccessAlreadyEnabled = 704,
 } cudaError_t;
 typedef enum {} cudaDataType;
 enum cudaDeviceAttr {};

--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -192,6 +192,10 @@ cpdef _set_peer_access(int device, int peer):
     runtime.setDevice(device)
     try:
         runtime.deviceEnablePeerAccess(peer)
+    # peer access could already be set by external libraries at this point
+    except runtime.CUDARuntimeError as e:
+        if e.status != runtime.cudaErrorPeerAccessAlreadyEnabled:
+            raise
     finally:
         runtime.setDevice(current)
 

--- a/cupy/cuda/runtime.pxd
+++ b/cupy/cuda/runtime.pxd
@@ -279,6 +279,7 @@ cpdef enum:
 cdef extern from '../cuda/cupy_cuda.h':  # thru parent to import in core
     int cudaErrorMemoryAllocation
     int cudaErrorInvalidValue
+    int cudaErrorPeerAccessAlreadyEnabled
 
 ###############################################################################
 # Const value


### PR DESCRIPTION
Cherry-pick from #2644. This PR fixes the error when peer access is enabled by some external libraries (cuFFT in the case of #2644). The `CUDARuntimeError` should be silently ignored in this case.