### PR TITLE
Fix handling of dtypes in cupy.mean

### DIFF
--- a/cupy/core/_routines_statistics.pyx
+++ b/cupy/core/_routines_statistics.pyx
@@ -58,7 +58,8 @@ cdef ndarray _ndarray_mean(ndarray self, axis, dtype, out, keepdims):
     dtype_sum = dtype_out = dtype
     if dtype is None:
         if self.dtype.kind in 'iub':
-            dtype_out = dtype_sum = numpy.float64
+            dtype_out = numpy.float64
+            dtype_sum = numpy.float64
         elif self.dtype.char == 'e':
             dtype_sum = numpy.float32
             dtype_out = numpy.float16

--- a/cupy/core/_routines_statistics.pyx
+++ b/cupy/core/_routines_statistics.pyx
@@ -55,18 +55,31 @@ cdef ndarray _ndarray_argmin(ndarray self, axis, out, dtype, keepdims):
 
 
 cdef ndarray _ndarray_mean(ndarray self, axis, dtype, out, keepdims):
+    dtype_sum = dtype_out = dtype
+    if dtype is None:
+        if self.dtype.kind in 'iub':
+            dtype_out = dtype_sum = numpy.float64
+        elif self.dtype.char == 'e':
+            dtype_sum = numpy.float32
+            dtype_out = numpy.float16
+    elif numpy.dtype(dtype).kind in 'iub':
+        # output will be the requested type, but compute the mean using float
+        dtype_out = dtype
+        dtype_sum = numpy.float64
+
+    result = None
     if (cupy.cuda.cub_enabled and self.size != 0):
-        dtype_sum = dtype
-        if dtype is None and self.dtype.kind in 'iub':
-            # cast integer types to float (like the _mean ufunc)
-            dtype_sum = numpy.float64
         result = cub.cub_reduction(self, cub.CUPY_CUB_SUM, axis, dtype_sum,
                                    out, keepdims)
-        if result is not None:
-            n = self.size // result.size
-            cupy.true_divide(result, n, out=result, casting='unsafe')
-            return result
-    return _mean(self, axis=axis, dtype=dtype, out=out, keepdims=keepdims)
+    if result is not None:
+        n = self.size // result.size
+        cupy.true_divide(result, n, out=result, casting='unsafe')
+    else:
+        result = _mean(self, axis=axis, dtype=dtype_sum, out=out,
+                       keepdims=keepdims)
+    if dtype_out is not None and out is None:
+        result = result.astype(dtype_out)
+    return result
 
 
 cdef ndarray _ndarray_var(ndarray self, axis, dtype, out, ddof, keepdims):

--- a/tests/cupy_tests/statics_tests/test_meanvar.py
+++ b/tests/cupy_tests/statics_tests/test_meanvar.py
@@ -88,10 +88,23 @@ class TestMeanVar(unittest.TestCase):
         a = testing.shaped_arange((2, 3, 4), xp, dtype)
         return xp.mean(a, axis=1)
 
+    @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose()
-    def test_mean_all_dtype(self, xp):
-        a = xp.full((2, 3, 4), 123456789, dtype=numpy.int64)
+    def test_mean_all_float64_dtype(self, xp, dtype):
+        a = xp.full((2, 3, 4), 123456789, dtype=dtype)
         return xp.mean(a, dtype=numpy.float64)
+
+    @testing.for_all_dtypes(no_complex=True)
+    @testing.numpy_cupy_allclose()
+    def test_mean_all_int64_dtype(self, xp, dtype):
+        a = testing.shaped_arange((2, 3, 4), xp, dtype)
+        return xp.mean(a, dtype=numpy.int64)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose()
+    def test_mean_all_complex_dtype(self, xp, dtype):
+        a = testing.shaped_arange((2, 3, 4), xp, dtype)
+        return xp.mean(a, dtype=numpy.complex64)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()


### PR DESCRIPTION
The first commit here fixes a bug in CUB-based mean that was introduced in #2860. When the input had an integer dtype, the in-place addition with a float would fail with a `TypeError`.

The second two commits fix both the CUB code path and the non-CUB one to return the requested dtype. In current master, mean would fail when dtype was not a floating (or complex) type as there is not case for that defined in the `_mean_core` ufunc. NumPy does allow such cases. The newly added tests verify consistent behavior. They pass when I tried it locally for both `CUB_DISABLED=0` and `CUB_DISABLED=1`.