### PR TITLE
Fix `AssertionError` for `numpy>=1.18`

### DIFF
--- a/tests/cupy_tests/testing_tests/test_helper.py
+++ b/tests/cupy_tests/testing_tests/test_helper.py
@@ -368,8 +368,14 @@ class TestIgnoreOfNegativeValueDifferenceOnCpuAndGpu(unittest.TestCase):
         else:
             return xp.array(-2, dtype=numpy.float32)
 
-    @testing.with_requires('numpy>=1.16.1')
+    @testing.with_requires('numpy>=1.18.0')
     def test_correct_failure(self):
+        with six.assertRaisesRegex(self, AssertionError,
+                                   'Mismatched elements:'' 1 / 1 \\(100%\\)'):
+            self.correct_failure()
+
+    @testing.with_requires('numpy>=1.16.1,<1.18.0')
+    def test_correct_failure_np_16_17(self):
         with six.assertRaisesRegex(self, AssertionError, 'Mismatch: 100%'):
             self.correct_failure()
 


### PR DESCRIPTION
New version of NumPy changed the error message for this test
[Example](https://jenkins.preferred.jp/job/chainer/job/cupy_pr/811/TEST=cupy-py3,label=mn1-p100/testReport/tests.cupy_tests.testing_tests.test_helper/TestIgnoreOfNegativeValueDifferenceOnCpuAndGpu/test_correct_failure/)

Creates a new test case only for 1.18 and restricts the older one.