### PR TITLE
Improve performance of `cumsum` and `cumprod`

### DIFF
--- a/cupy/core/_routines_math.pxd
+++ b/cupy/core/_routines_math.pxd
@@ -19,7 +19,7 @@ cpdef enum scan_op:
     SCAN_SUM = 0
     SCAN_PROD = 1
 
-cdef ndarray scan(ndarray a, op=*, dtype=*, ndarray out=*)
+cdef ndarray scan(ndarray a, op, dtype=*, ndarray out=*)
 cdef object _sum_auto_dtype
 cdef object _add
 cdef object _conj

--- a/cupy/core/_routines_math.pxd
+++ b/cupy/core/_routines_math.pxd
@@ -15,7 +15,11 @@ cdef ndarray _ndarray_clip(ndarray self, a_min, a_max, out)
 cpdef ndarray _nansum(ndarray a, axis, dtype, out, keepdims)
 cpdef ndarray _nanprod(ndarray a, axis, dtype, out, keepdims)
 
-cdef ndarray scan(ndarray a, ndarray out=*)
+cpdef enum scan_op:
+    SCAN_SUM = 0
+    SCAN_PROD = 1
+
+cdef ndarray scan(ndarray a, op=*, dtype=*, ndarray out=*)
 cdef object _sum_auto_dtype
 cdef object _add
 cdef object _conj

--- a/cupy/core/_routines_math.pyx
+++ b/cupy/core/_routines_math.pyx
@@ -114,7 +114,118 @@ cdef ndarray _ndarray_clip(ndarray self, a_min, a_max, out):
 
 
 @util.memoize(for_each_device=True)
-def _inclusive_scan_kernel(dtype, block_size):
+def _inclusive_batch_scan_kernel(dtype, block_size, op):
+    """return Prefix Sum(Scan) cuda kernel
+    for a 2d array over axis 1
+    used for scanning over different axes
+
+    e.g
+    if blocksize > len(src[0])
+    src [[1, 2, 3, 4],
+         [5, 6, 7, 8]]
+    dst [[1, 3, 6, 10],
+         [5, 11, 18, 26]]
+
+    if blocksize < len(src[0])
+    block_size: 2
+    # TODO show partialness
+    src [[1, 2, 3, 4],
+         [5, 6, 7, 8]]
+    dst [[1, 3, 3, 7],
+         [5, 11, 7, 15]]
+
+    Args:
+        dtype: src, dst array type
+        block_size: block_size
+
+    Returns:
+         cupy.cuda.Function: cuda function
+    """
+    ops = {scan_op.SCAN_SUM: '+', scan_op.SCAN_PROD: '*'}
+    elem = {scan_op.SCAN_SUM: 0, scan_op.SCAN_PROD: 1}
+    name = 'inclusive_batch_scan_kernel'
+    dtype = get_typename(dtype)
+    source = string.Template("""
+    extern "C" __global__ void ${name}(const CArray<${dtype}, 2> src,
+        CArray<${dtype}, 2> dst, int batch_size){
+        long long n = src.size();
+
+        extern __shared__ ${dtype} temp[];
+
+        unsigned int thid = threadIdx.x;
+        unsigned int block = blockIdx.x * blockDim.x;
+
+        unsigned int pad_batch_size = batch_size;
+        bool must_copy = true;
+
+        if (batch_size & (batch_size -1)) {
+            pad_batch_size = 1 << (32 - __clz(batch_size));
+            must_copy = (thid & (pad_batch_size-1)) < batch_size;
+        }
+        if (pad_batch_size > ${block_size}) {
+            int blocks_per_batch = (batch_size - 1) / ${block_size} + 1;
+            pad_batch_size = ${block_size} * blocks_per_batch;
+
+            // Must copy enables for all blocks but the last one in the batch
+            bool last_block = (blockIdx.x + 1) % blocks_per_batch == 0;
+            int remaining_batch = batch_size % ${block_size};
+            if (remaining_batch == 0) {
+                remaining_batch = ${block_size};
+            }
+            must_copy = !last_block || (thid < (remaining_batch));
+        }
+
+        int pad_per_batch = pad_batch_size-batch_size;
+        int n_batches_block = ${block_size} / pad_batch_size;
+
+        unsigned int idx0 = thid + block;
+
+        int batch_id = idx0 / pad_batch_size;
+        idx0 = idx0 - pad_per_batch * batch_id;
+
+        int row = idx0 / batch_size;
+        int col = idx0 % batch_size;
+        const ptrdiff_t idx0_idx[] = {row, col};
+
+        if(idx0 < n){
+            temp[thid] = (must_copy) ? src[idx0_idx] : (${dtype}) ${elem};
+            __syncthreads();
+            if (!n_batches_block) {
+                n_batches_block = 1;
+                pad_batch_size = ${block_size};
+            }
+            for (int j = 0; j < n_batches_block; j++) {
+                int offset = j * pad_batch_size;
+                for (int i = 1; i <= pad_batch_size; i <<= 1) {
+                    int index = ((threadIdx.x + 1) * 2 * i - 1);
+                    int index_block = offset + index;
+                    if (index < (pad_batch_size)){
+                        temp[index_block] ${op}= temp[index_block-i];
+                    }
+                    __syncthreads();
+                }
+                for(int i = pad_batch_size >> 1; i > 0; i >>= 1){
+                    int index = ((threadIdx.x + 1) * 2 * i - 1);
+                    int index_block = offset + index;
+                    if((index + i) < (pad_batch_size)){
+                        temp[index_block + i] ${op}= temp[index_block];
+                    }
+                    __syncthreads();
+                }
+            }
+            if(must_copy){
+                dst[idx0_idx] = temp[thid];
+            }
+        }
+    }
+    """).substitute(name=name, dtype=dtype, block_size=block_size,
+                    op=ops[op], elem=elem[op])
+    module = compile_with_cache(source)
+    return module.get_function(name)
+
+
+@util.memoize(for_each_device=True)
+def _inclusive_scan_kernel(dtype, block_size, op):
     """return Prefix Sum(Scan) cuda kernel
 
     e.g
@@ -137,6 +248,8 @@ def _inclusive_scan_kernel(dtype, block_size):
 
     name = 'inclusive_scan_kernel'
     dtype = get_typename(dtype)
+    ops = {scan_op.SCAN_SUM: '+', scan_op.SCAN_PROD: '*'}
+    elem = {scan_op.SCAN_SUM: 0, scan_op.SCAN_PROD: 1}
     source = string.Template("""
     extern "C" __global__ void ${name}(const CArray<${dtype}, 1> src,
         CArray<${dtype}, 1> dst){
@@ -148,14 +261,14 @@ def _inclusive_scan_kernel(dtype, block_size):
         unsigned int idx0 = thid + block;
         unsigned int idx1 = thid + blockDim.x + block;
 
-        temp[thid] = (idx0 < n) ? src[idx0] : (${dtype})0;
-        temp[thid + blockDim.x] = (idx1 < n) ? src[idx1] : (${dtype})0;
+        temp[thid] = (idx0 < n) ? src[idx0] : (${dtype}) ${elem};
+        temp[thid + blockDim.x] = (idx1 < n) ? src[idx1] : (${dtype}) ${elem};
         __syncthreads();
 
         for(int i = 1; i <= ${block_size}; i <<= 1){
             int index = (threadIdx.x + 1) * i * 2 - 1;
             if (index < (${block_size} << 1)){
-                temp[index] = temp[index] + temp[index - i];
+                temp[index] ${op}= temp[index - i];
             }
             __syncthreads();
         }
@@ -163,7 +276,7 @@ def _inclusive_scan_kernel(dtype, block_size):
         for(int i = ${block_size} >> 1; i > 0; i >>= 1){
             int index = (threadIdx.x + 1) * i * 2 - 1;
             if(index + i < (${block_size} << 1)){
-                temp[index + i] = temp[index + i] + temp[index];
+                temp[index + i] ${op}= temp[index];
             }
             __syncthreads();
         }
@@ -175,15 +288,52 @@ def _inclusive_scan_kernel(dtype, block_size):
             dst[idx1] = temp[thid + blockDim.x];
         }
     }
-    """).substitute(name=name, dtype=dtype, block_size=block_size)
+    """).substitute(name=name, dtype=dtype, block_size=block_size,
+                    op=ops[op], elem=elem[op])
     module = compile_with_cache(source)
     return module.get_function(name)
 
 
 @util.memoize(for_each_device=True)
-def _add_scan_blocked_sum_kernel(dtype):
+def _add_scan_batch_blocked_sum_kernel(dtype, op, block_size):
     name = 'add_scan_blocked_sum_kernel'
     dtype = get_typename(dtype)
+    ops = {scan_op.SCAN_SUM: '+', scan_op.SCAN_PROD: '*'}
+    source = string.Template("""
+    extern "C" __global__ void ${name}(CArray<${dtype}, 2> src_dst,
+        int batch_size){
+        long long n = src_dst.size();
+
+        unsigned int thid = threadIdx.x;
+        unsigned int block = blockIdx.x * ${block_size};
+
+        unsigned int idx0 = thid + block;
+
+        // Respect padding
+        unsigned int row = idx0 / batch_size;
+        unsigned int col = idx0 % batch_size;
+        int my_block = ${block_size} * (col / ${block_size});
+        const ptrdiff_t dst_idx[] = {row, col};
+        const ptrdiff_t src_idx[] = {row, my_block - 1};
+
+        // Avoid for the first block of every row
+        // This can be tweaked with kernel launch settings
+        bool first = col < ${block_size};
+        bool is_block = (col % (${block_size})) == ${block_size} - 1;
+        if(idx0 < n && !first && !is_block){
+            src_dst[dst_idx] ${op}= src_dst[src_idx];
+        }
+    }
+    """).substitute(name=name, dtype=dtype, op=ops[op], block_size=block_size)
+    module = compile_with_cache(source)
+    return module.get_function(name)
+
+
+@util.memoize(for_each_device=True)
+def _add_scan_blocked_sum_kernel(dtype, op):
+    name = 'add_scan_blocked_sum_kernel'
+    dtype = get_typename(dtype)
+    ops = {scan_op.SCAN_SUM: '+', scan_op.SCAN_PROD: '*'}
     source = string.Template("""
     extern "C" __global__ void ${name}(CArray<${dtype}, 1> src_dst){
         long long n = src_dst.size();
@@ -192,15 +342,20 @@ def _add_scan_blocked_sum_kernel(dtype):
         unsigned int idxAdd = idxBase - 1;
 
         if(idxAdded < n){
-            src_dst[idxAdded] += src_dst[idxAdd];
+            src_dst[idxAdded] ${op}= src_dst[idxAdd];
         }
     }
-    """).substitute(name=name, dtype=dtype)
+    """).substitute(name=name, dtype=dtype, op=ops[op])
     module = compile_with_cache(source)
     return module.get_function(name)
 
 
-cdef ndarray scan(ndarray a, ndarray out=None):
+cdef ndarray scan(
+        ndarray a, op=scan_op.SCAN_SUM, dtype=None, ndarray out=None):
+    return _scan_op(a, op, dtype, out)
+
+
+cdef ndarray _scan_op(ndarray a, op, dtype, ndarray out=None):
     """Return the prefix sum(scan) of the elements.
 
     Args:
@@ -213,17 +368,16 @@ cdef ndarray scan(ndarray a, ndarray out=None):
 
     """
     if a._shape.size() != 1:
-        raise TypeError('Input array should be 1D array.')
+        a = a.ravel()
 
     cdef Py_ssize_t block_size = 256
-
     if out is None:
-        out = ndarray(a.shape, dtype=a.dtype)
+        out = ndarray(a.shape, a.dtype)
     else:
         if a.size != out.size:
             raise ValueError('Provided out is the wrong size')
 
-    kern_scan = _inclusive_scan_kernel(a.dtype, block_size)
+    kern_scan = _inclusive_scan_kernel(a.dtype, block_size, op)
     kern_scan(grid=((a.size - 1) // (2 * block_size) + 1,),
               block=(block_size,),
               args=(a, out),
@@ -231,17 +385,100 @@ cdef ndarray scan(ndarray a, ndarray out=None):
 
     if (a.size - 1) // (block_size * 2) > 0:
         blocked_sum = out[block_size * 2 - 1:None:block_size * 2]
-        scan(blocked_sum, blocked_sum)
-        kern_add = _add_scan_blocked_sum_kernel(out.dtype)
+        _scan_op(blocked_sum, op, dtype, blocked_sum)
+        kern_add = _add_scan_blocked_sum_kernel(out.dtype, op)
         kern_add(grid=((a.size - 1) // (2 * block_size),),
                  block=(2 * block_size - 1,),
                  args=(out,))
     return out
 
 
+cdef ndarray _batch_scan_op(ndarray a, op, dtype=None, out=None):
+    batch_size = a.shape[1]
+
+    block_size = 512
+    # Since we need to pad each batch we spawn more threads as some
+    # of them will be idle
+    # Calc the total number of blocks
+    padded_bs = 1 << ((batch_size - 1).bit_length())
+    if padded_bs > block_size:
+        blocks_per_batch = (batch_size - 1) // block_size + 1
+        padded_bs = block_size * blocks_per_batch
+    padded_size = a.size // batch_size * padded_bs
+
+    kern_scan = _inclusive_batch_scan_kernel(a.dtype, block_size, op)
+    kern_scan(grid=((padded_size - 1) // (block_size) + 1,),
+              block=(block_size,),
+              args=(a, out, batch_size),
+              shared_mem=a.itemsize * block_size)
+    if batch_size > block_size:
+        blocked_sum = out[:, block_size-1::block_size]
+        _batch_scan_op(blocked_sum, op, dtype, blocked_sum)
+        kern_add = _add_scan_batch_blocked_sum_kernel(
+            out.dtype, op, block_size)
+        kern_add(
+            grid=((out.size - 1) // (block_size) + 1,),
+            block=(block_size,),
+            args=(out, batch_size))
+    return out
+
+
+cdef _axis_to_first(ndarray x, axis):
+    if axis < 0:
+        axis = x.ndim + axis
+    trans = [axis] + [a for a in range(x.ndim) if a != axis]
+    pre = list(range(1, axis + 1))
+    succ = list(range(axis + 1, x.ndim))
+    revert = pre + [0] + succ
+    return trans, revert
+
+
+cdef _proc_as_batch(ndarray x, axis, dtype, op):
+    if x.shape[axis] == 0:
+        return cupy.empty_like(x)
+    trans, revert = _axis_to_first(x, axis)
+    t = x.transpose(trans)
+    s = t.shape
+    r = t.reshape(x.shape[axis], -1)
+    # This is to use the current implemented fast scan
+    # TODO(ecastill) merge with above transformations
+    r = r.transpose((1, 0))
+    r = _batch_scan_op(r, op, dtype, r)
+    r = r.transpose((1, 0))
+    return r.reshape(s).transpose(revert)
+
+
+cdef _cum_core(ndarray a, axis, op, dtype, ndarray out):
+    if out is None:
+        if dtype is None:
+            kind = a.dtype.kind
+            if kind == 'b':
+                dtype = numpy.dtype('l')
+            elif kind == 'i' and a.dtype.itemsize < numpy.dtype('l').itemsize:
+                dtype = numpy.dtype('l')
+            elif kind == 'u' and a.dtype.itemsize < numpy.dtype('L').itemsize:
+                dtype = numpy.dtype('L')
+            else:
+                dtype = a.dtype
+        out = a.astype(dtype=dtype)
+    else:
+        out[...] = a
+    if axis is None:
+        out = out.ravel()
+        return _scan_op(out, op, dtype, out)
+    elif not (-a.ndim <= axis < a.ndim):
+        raise cupy.core._AxisError('axis(={}) out of bounds'.format(axis))
+    else:
+        return _proc_as_batch(out, axis, dtype, op)
+
+
 # Only for test
 def _scan_for_test(a, out=None):
-    return scan(a, out)
+    return scan(a, scan_op.SCAN_SUM, dtype=None, out=out)
+
+
+def scan_core(a, axis, op, dtype=None, out=None):
+    return _cum_core(a, axis, op, dtype, out)
 
 
 cpdef ndarray _nansum(ndarray a, axis, dtype, out, keepdims):

--- a/cupy/math/sumprod.py
+++ b/cupy/math/sumprod.py
@@ -1,14 +1,8 @@
 import numpy
 
 import cupy
-from cupy import core
 from cupy.core import _routines_math as _math
 from cupy.core import fusion
-
-if cupy.cuda.cub_enabled:
-    from cupy.cuda import cub
-else:
-    cub = None
 
 
 def sum(a, axis=None, dtype=None, out=None, keepdims=False):
@@ -125,95 +119,6 @@ def nanprod(a, axis=None, dtype=None, out=None, keepdims=False):
     return _math._nanprod(a, axis, dtype, out, keepdims)
 
 
-def _axis_to_first(x, axis):
-    if axis < 0:
-        axis = x.ndim + axis
-    trans = [axis] + [a for a in range(x.ndim) if a != axis]
-    pre = list(range(1, axis + 1))
-    succ = list(range(axis + 1, x.ndim))
-    revert = pre + [0] + succ
-    return trans, revert
-
-
-def _proc_as_batch(proc, x, axis):
-    if x.shape[axis] == 0:
-        return cupy.empty_like(x)
-    trans, revert = _axis_to_first(x, axis)
-    t = x.transpose(trans)
-    s = t.shape
-    r = t.reshape(x.shape[axis], -1)
-    pos = 1
-    size = r.size
-    batch = r.shape[1]
-    while pos < size:
-        proc(pos, batch, r, size=size)
-        pos <<= 1
-    return r.reshape(s).transpose(revert)
-
-
-def _cum_core(a, axis, dtype, out, kern, batch_kern, *, op=None):
-    a = cupy.asarray(a)
-
-    if out is None:
-        if dtype is None:
-            kind = a.dtype.kind
-            if kind == 'b':
-                dtype = numpy.dtype('l')
-            elif kind == 'i' and a.dtype.itemsize < numpy.dtype('l').itemsize:
-                dtype = numpy.dtype('l')
-            elif kind == 'u' and a.dtype.itemsize < numpy.dtype('L').itemsize:
-                dtype = numpy.dtype('L')
-            else:
-                dtype = a.dtype
-
-        out = a.astype(dtype)
-    else:
-        out[...] = a
-
-    if axis is None:
-        out = out.ravel()
-    elif not (-a.ndim <= axis < a.ndim):
-        raise core._AxisError('axis(={}) out of bounds'.format(axis))
-    else:
-        return _proc_as_batch(batch_kern, out, axis=axis)
-
-    if cupy.cuda.cub_enabled:
-        # result will be None if the scan is not compatible with CUB
-        result = cub.cub_scan(out, op)
-        if result is not None:
-            return result
-
-    pos = 1
-    while pos < out.size:
-        kern(pos, out, size=out.size)
-        pos <<= 1
-    return out
-
-
-_cumsum_batch_kern = core.ElementwiseKernel(
-    'int64 pos, int64 batch', 'raw T x',
-    '''
-    ptrdiff_t b = i % batch;
-    ptrdiff_t j = i / batch;
-    if (j & pos) {
-      const ptrdiff_t dst_index[] = {j, b};
-      const ptrdiff_t src_index[] = {j ^ pos | (pos - 1), b};
-      x[dst_index] += x[src_index];
-    }
-    ''',
-    'cumsum_batch_kernel'
-)
-_cumsum_kern = core.ElementwiseKernel(
-    'int64 pos', 'raw T x',
-    '''
-    if (i & pos) {
-      x[i] += x[i ^ pos | (pos - 1)];
-    }
-    ''',
-    'cumsum_kernel'
-)
-
-
 def cumsum(a, axis=None, dtype=None, out=None):
     """Returns the cumulative sum of an array along a given axis.
 
@@ -230,33 +135,8 @@ def cumsum(a, axis=None, dtype=None, out=None):
     .. seealso:: :func:`numpy.cumsum`
 
     """
-    op = cub.CUPY_CUB_CUMSUM if cub is not None else None
-    return _cum_core(a, axis, dtype, out, _cumsum_kern, _cumsum_batch_kern,
-                     op=op)
-
-
-_cumprod_batch_kern = core.ElementwiseKernel(
-    'int64 pos, int64 batch', 'raw T x',
-    '''
-    ptrdiff_t b = i % batch;
-    ptrdiff_t j = i / batch;
-    if (j & pos) {
-      const ptrdiff_t dst_index[] = {j, b};
-      const ptrdiff_t src_index[] = {j ^ pos | (pos - 1), b};
-      x[dst_index] *= x[src_index];
-    }
-    ''',
-    'cumprod_batch_kernel'
-)
-_cumprod_kern = core.ElementwiseKernel(
-    'int64 pos', 'raw T x',
-    '''
-    if (i & pos) {
-      x[i] *= x[i ^ pos | (pos - 1)];
-    }
-    ''',
-    'cumprod_kernel'
-)
+    a = cupy.asarray(a)
+    return _math.scan_core(a, axis, _math.scan_op.SCAN_SUM, dtype, out)
 
 
 def cumprod(a, axis=None, dtype=None, out=None):
@@ -275,9 +155,8 @@ def cumprod(a, axis=None, dtype=None, out=None):
     .. seealso:: :func:`numpy.cumprod`
 
     """
-    op = cub.CUPY_CUB_CUMPROD if cub is not None else None
-    return _cum_core(a, axis, dtype, out, _cumprod_kern, _cumprod_batch_kern,
-                     op=op)
+    a = cupy.asarray(a)
+    return _math.scan_core(a, axis, _math.scan_op.SCAN_PROD, dtype, out)
 
 
 def diff(a, n=1, axis=-1, prepend=None, append=None):

--- a/cupy/math/sumprod.py
+++ b/cupy/math/sumprod.py
@@ -135,7 +135,6 @@ def cumsum(a, axis=None, dtype=None, out=None):
     .. seealso:: :func:`numpy.cumsum`
 
     """
-    a = cupy.asarray(a)
     return _math.scan_core(a, axis, _math.scan_op.SCAN_SUM, dtype, out)
 
 
@@ -155,7 +154,6 @@ def cumprod(a, axis=None, dtype=None, out=None):
     .. seealso:: :func:`numpy.cumprod`
 
     """
-    a = cupy.asarray(a)
     return _math.scan_core(a, axis, _math.scan_op.SCAN_PROD, dtype, out)
 
 

--- a/tests/cupy_tests/math_tests/test_sumprod.py
+++ b/tests/cupy_tests/math_tests/test_sumprod.py
@@ -331,6 +331,22 @@ class TestCumsum(unittest.TestCase):
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
+    def test_cumsum_out(self, xp, dtype):
+        a = testing.shaped_arange((5,), xp, dtype)
+        out = xp.zeros((5,), dtype=dtype)
+        xp.cumsum(a, out=out)
+        return out
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose()
+    def test_cumsum_out_noncontiguous(self, xp, dtype):
+        a = testing.shaped_arange((5,), xp, dtype)
+        out = xp.zeros((10,), dtype=dtype)[::2]  # Non contiguous view
+        xp.cumsum(a, out=out)
+        return out
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose()
     def test_cumsum_2dim(self, xp, dtype):
         a = testing.shaped_arange((4, 5), xp, dtype)
         return xp.cumsum(a)
@@ -341,6 +357,26 @@ class TestCumsum(unittest.TestCase):
         n = len(axes)
         a = testing.shaped_arange(tuple(range(4, 4 + n)), xp, dtype)
         return xp.cumsum(a, axis=self.axis)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose()
+    def test_cumsum_axis_out(self, xp, dtype):
+        n = len(axes)
+        shape = tuple(range(4, 4 + n))
+        a = testing.shaped_arange(shape, xp, dtype)
+        out = xp.zeros(shape, dtype=dtype)
+        xp.cumsum(a, axis=self.axis, out=out)
+        return out
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose()
+    def test_cumsum_axis_out_noncontiguous(self, xp, dtype):
+        n = len(axes)
+        shape = tuple(range(4, 4 + n))
+        a = testing.shaped_arange(shape, xp, dtype)
+        out = xp.zeros((8,)+shape[1:], dtype=dtype)[::2]  # Non contiguous view
+        xp.cumsum(a, axis=self.axis, out=out)
+        return out
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(contiguous_check=False)
@@ -401,6 +437,22 @@ class TestCumprod(unittest.TestCase):
     def test_cumprod_1dim(self, xp, dtype):
         a = testing.shaped_arange((5,), xp, dtype)
         return xp.cumprod(a)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose()
+    def test_cumprod_out(self, xp, dtype):
+        a = testing.shaped_arange((5,), xp, dtype)
+        out = xp.zeros((5,), dtype=dtype)
+        xp.cumprod(a, out=out)
+        return out
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose()
+    def test_cumprod_out_noncontiguous(self, xp, dtype):
+        a = testing.shaped_arange((5,), xp, dtype)
+        out = xp.zeros((10,), dtype=dtype)[::2]  # Non contiguous view
+        xp.cumprod(a, out=out)
+        return out
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(rtol=1e-6)

--- a/tests/cupy_tests/math_tests/test_sumprod.py
+++ b/tests/cupy_tests/math_tests/test_sumprod.py
@@ -382,15 +382,15 @@ class TestCumsum(unittest.TestCase):
         with self.assertRaises(cupy.core._AxisError):
             return cupy.cumsum(a, axis=a.ndim + 1)
 
-    @testing.numpy_cupy_allclose()
-    def test_cumsum_arraylike(self, xp):
-        return xp.cumsum((1, 2, 3))
+    def test_cumsum_arraylike(self):
+        with self.assertRaises(TypeError):
+            return cupy.cumsum((1, 2, 3))
 
     @testing.for_float_dtypes()
-    @testing.numpy_cupy_allclose()
-    def test_cumsum_numpy_array(self, xp, dtype):
+    def test_cumsum_numpy_array(self, dtype):
         a_numpy = numpy.arange(8, dtype=dtype)
-        return xp.cumsum(a_numpy)
+        with self.assertRaises(TypeError):
+            return cupy.cumsum(a_numpy)
 
 
 @testing.gpu
@@ -459,15 +459,15 @@ class TestCumprod(unittest.TestCase):
         with self.assertRaises(cupy.core._AxisError):
             return cupy.cumprod(a, axis=a.ndim)
 
-    @testing.numpy_cupy_allclose()
-    def test_cumprod_arraylike(self, xp):
-        return xp.cumprod((1, 2, 3))
+    def test_cumprod_arraylike(self):
+        with self.assertRaises(TypeError):
+            return cupy.cumprod((1, 2, 3))
 
     @testing.for_float_dtypes()
-    @testing.numpy_cupy_allclose()
-    def test_cumprod_numpy_array(self, xp, dtype):
+    def test_cumprod_numpy_array(self, dtype):
         a_numpy = numpy.arange(1, 6, dtype=dtype)
-        return xp.cumprod(a_numpy)
+        with self.assertRaises(TypeError):
+            return cupy.cumprod(a_numpy)
 
 
 @testing.gpu


### PR DESCRIPTION
Solves #2905 

Uses the fast scan available in _math_routines and adds new kernels for batched cumsum/cumprod

Matrix size : (550, 100, 72, 50)

Previous to this PR:
```
cumsum   axis=None  :   228.304 us   +/-23.550 (min:  217.939 / max:  358.161) us  80835.688 us   +/-37.779 (min:80798.241 / max:81046.272) us
cumsum   axis=0     :   241.658 us   +/-11.215 (min:  234.609 / max:  315.020) us  84766.405 us   +/- 9.216 (min:84760.162 / max:84825.439) us
cumsum   axis=1     :   261.572 us   +/- 8.596 (min:  255.286 / max:  308.073) us  85690.466 us   +/- 6.717 (min:85684.509 / max:85727.554) us
cumsum   axis=2     :   261.069 us   +/- 6.102 (min:  255.105 / max:  292.426) us  85336.803 us   +/-49.660 (min:85323.997 / max:85682.014) us
cumsum   axis=3     :   258.408 us   +/-48.437 (min:  239.055 / max:  570.139) us  345277.179 us   +/-337.118 (min:344687.134 / max:346113.464) us
```

This PR:
```
cumsum   axis=None  :    65.940 us   +/-14.030 (min:   60.568 / max:  148.783) us  13706.375 us   +/-27.500 (min:13665.888 / max:13767.488) us
cumsum   axis=0     :    71.601 us   +/-20.592 (min:   63.724 / max:  185.169) us  53530.026 us   +/-17.431 (min:53509.281 / max:53601.856) us
cumsum   axis=1     :    64.266 us   +/- 3.725 (min:   61.088 / max:   83.882) us  37469.175 us   +/- 7.742 (min:37457.344 / max:37487.873) us
cumsum   axis=2     :    64.903 us   +/- 4.328 (min:   61.789 / max:   86.990) us  41359.191 us   +/-61.012 (min:41322.079 / max:41601.791) us
cumsum   axis=3     :    46.353 us   +/- 4.449 (min:   43.463 / max:   62.435) us  38549.706 us   +/- 9.629 (min:38543.297 / max:38612.896) us
```