### PR TITLE
[backport] Fix `test_helper.py` for NumPy 1.18

### DIFF
--- a/tests/cupy_tests/testing_tests/test_helper.py
+++ b/tests/cupy_tests/testing_tests/test_helper.py
@@ -297,14 +297,8 @@ class TestIgnoreOfNegativeValueDifferenceOnCpuAndGpu(unittest.TestCase):
         else:
             return xp.array(-2, dtype=numpy.float32)
 
-    @testing.with_requires('numpy>=1.16.1')
     def test_correct_failure(self):
-        with six.assertRaisesRegex(self, AssertionError, 'Mismatch: 100%'):
-            self.correct_failure()
-
-    @testing.with_requires('numpy<1.16.1')
-    def test_correct_failure_old_np(self):
-        with six.assertRaisesRegex(self, AssertionError, 'mismatch 100\\.0%'):
+        with pytest.raises(AssertionError):
             self.correct_failure()
 
     @helper.for_unsigned_dtypes('dtype1')


### PR DESCRIPTION
Backport of #2883