### PR TITLE
Allow `ElementwiseKernel` to set the block_size

### DIFF
--- a/cupy/core/_kernel.pyx
+++ b/cupy/core/_kernel.pyx
@@ -568,6 +568,8 @@ cdef class ElementwiseKernel:
                 This parameter must be specified if and only if all ndarrays
                 are `raw` and the range size cannot be determined
                 automatically.
+            block_size (int): Number of threads per block. By default, the
+                value is set to 128.
 
         Returns:
             If ``no_return`` has not set, arrays are returned according to the
@@ -583,6 +585,7 @@ cdef class ElementwiseKernel:
         size = -1
         size = kwargs.pop('size', -1)
         stream = kwargs.pop('stream', None)
+        block_size = kwargs.pop('block_size', 128)
         if len(kwargs):
             raise TypeError('Wrong arguments %s' % kwargs)
 
@@ -635,7 +638,7 @@ cdef class ElementwiseKernel:
         args_info = _get_args_info(inout_args)
         kern = self._get_elementwise_kernel(dev_id, args_info, types)
         kern.linear_launch(indexer.size, inout_args, shared_mem=0,
-                           block_max_size=128, stream=stream)
+                           block_max_size=block_size, stream=stream)
         return ret
 
     cpdef tuple _decide_params_type(

--- a/cupy/core/_kernel.pyx
+++ b/cupy/core/_kernel.pyx
@@ -588,7 +588,8 @@ cdef class ElementwiseKernel:
         block_size = kwargs.pop('block_size', 128)
         if len(kwargs):
             raise TypeError('Wrong arguments %s' % kwargs)
-
+        if block_size <= 0:
+            raise ValueError('block_size must be greater than zero')
         n_args = len(args)
         if n_args != self.nin and n_args != self.nargs:
             raise TypeError('Wrong number of arguments for %s' % self.name)

--- a/tests/cupy_tests/core_tests/test_userkernel.py
+++ b/tests/cupy_tests/core_tests/test_userkernel.py
@@ -1,6 +1,7 @@
 import unittest
 
 import numpy
+import pytest
 
 import cupy
 from cupy import testing
@@ -82,3 +83,18 @@ class TestUserkernelScalar(unittest.TestCase):
         else:
             kernel = cupy.ElementwiseKernel('T x, T y', 'T z', 'z = x + y')
             return kernel(x, self.value)
+
+
+class TestUserkernelManualBlockSize(unittest.TestCase):
+
+    def test_invalid_block_size(self):
+        x = testing.shaped_arange((2, 3, 4), cupy, cupy.float32)
+        kernel = cupy.ElementwiseKernel('T x, T y', 'T z', 'z = x + y')
+        with pytest.raises(ValueError):
+            kernel(x, 1, block_size=0)
+
+    def test_block_size(self):
+        x = testing.shaped_arange((2, 3, 4), cupy, cupy.float32)
+        kernel = cupy.ElementwiseKernel('T x, T y', 'T z', 'z = x + y')
+        y = kernel(x, 1, block_size=1)
+        testing.assert_array_equal(y, x + 1)


### PR DESCRIPTION
Orthogonal to #2731

Right now the `ElementwiseKernel` class launches all kernels with the same block size which is not easily tunable.

This PR replaces the hardcoded value with a kwarg for the `__call__` method.