### PR TITLE
Clean up `_scalar.pyx`

### DIFF
--- a/cupy/core/_kernel.pyx
+++ b/cupy/core/_kernel.pyx
@@ -84,13 +84,19 @@ cdef list _preprocess_args(int dev_id, args, bint use_c_scalar):
     """Preprocesses arguments for kernel invocation
 
     - Checks device compatibility for ndarrays
-    - Converts Python scalars into NumPy scalars
+    - Converts Python/NumPy scalars:
+      - If use_c_scalar is True, into CScalars.
+      - If use_c_scalar is False, into NumPy scalars.
     """
     cdef list ret = []
 
     for arg in args:
         if type(arg) is not ndarray:
-            s = _scalar.convert_scalar(arg, use_c_scalar)
+            if use_c_scalar:
+                s = _scalar.scalar_to_c_scalar(arg)
+            else:
+                s = _scalar.scalar_to_numpy_scalar(arg)
+
             if s is not None:
                 ret.append(s)
                 continue
@@ -890,8 +896,9 @@ cdef class ufunc:
         inout_args = []
         for i, t in enumerate(op.in_types):
             x = broad_values[i]
-            inout_args.append(x if isinstance(x, ndarray) else
-                              _scalar.get_scalar_from_numpy(x, t))
+            inout_args.append(
+                x if isinstance(x, ndarray) else
+                _scalar.CScalar.from_numpy_scalar_with_dtype(x, t))
         inout_args.extend(out_args)
         shape = _reduce_dims(inout_args, self._params, shape)
         indexer = _carray.Indexer(shape)

--- a/cupy/core/_reduction.pyx
+++ b/cupy/core/_reduction.pyx
@@ -266,7 +266,7 @@ cdef class _AbstractReductionKernel:
                               ' %s which has no identity') % self.name)
 
         in_args = [x if isinstance(x, ndarray) else
-                   _scalar.get_scalar_from_numpy(x, t)
+                   _scalar.CScalar.from_numpy_scalar_with_dtype(x, t)
                    for x, t in zip(in_args, in_types)]
         in_shape = _set_permuted_args(
             in_args, reduce_axis + out_axis, a_shape, self.in_params)
@@ -291,7 +291,7 @@ cdef class _AbstractReductionKernel:
                 _carray.Indexer(in_shape),
                 _carray.Indexer(out_shape),
                 # block_stride is passed as the last argument.
-                _scalar.CScalar_from_int32(block_stride),
+                _scalar.CScalar.from_int32(block_stride),
             ])
 
         # Retrieve the kernel function

--- a/cupy/core/_scalar.pxd
+++ b/cupy/core/_scalar.pxd
@@ -13,12 +13,23 @@ cdef class CScalar(CPointer):
         char kind
         int8_t size
 
+    @staticmethod
+    cdef CScalar from_int32(int32_t value)
+
+    @staticmethod
+    cdef CScalar from_numpy_scalar_with_dtype(object x, object dtype)
+
+    @staticmethod
+    cdef CScalar _from_python_scalar(object x)
+
+    @staticmethod
+    cdef CScalar _from_numpy_scalar(object x)
+
     cpdef apply_dtype(self, dtype)
     cpdef get_numpy_type(self)
 
 
-cdef CScalar CScalar_from_int32(int32_t value)
-
 cpdef str get_typename(dtype)
-cpdef get_scalar_from_numpy(x, dtype)
-cpdef convert_scalar(x, bint use_c_scalar)
+
+cdef CScalar scalar_to_c_scalar(object x)
+cdef object scalar_to_numpy_scalar(object x)


### PR DESCRIPTION
Cleans up `_scalar.pyx/pxd`.

* Previously, `convert_scalar()` returned different types of objects depending on a flag. This is confusing because the return type is obscure.
* Unifies `CScalar`'s various creation functions into static methods `CScalar.from_xxx()`. 