### PR TITLE
Simplify scalar manipulation

### DIFF
--- a/cupy/core/_kernel.pxd
+++ b/cupy/core/_kernel.pxd
@@ -67,6 +67,6 @@ cdef list _get_out_args_with_params(
 
 cdef _check_array_device_id(ndarray arr, int device_id)
 
-cdef list _preprocess_args(int dev_id, args, bint use_c_scalar)
+cdef list _preprocess_args(int dev_id, args)
 
 cdef tuple _reduce_dims(list args, tuple params, tuple shape)

--- a/cupy/core/_reduction.pyx
+++ b/cupy/core/_reduction.pyx
@@ -556,8 +556,8 @@ cdef class ReductionKernel(_AbstractReductionKernel):
             out_args = [out]
 
         dev_id = device.get_device_id()
-        in_args = _preprocess_args(dev_id, args[:self.nin], False)
-        out_args = _preprocess_args(dev_id, out_args, False)
+        in_args = _preprocess_args(dev_id, args[:self.nin])
+        out_args = _preprocess_args(dev_id, out_args)
         in_args, broad_shape = _broadcast(in_args, self.in_params, False)
 
         return self._call(

--- a/cupy/core/_scalar.pxd
+++ b/cupy/core/_scalar.pxd
@@ -13,6 +13,13 @@ cdef class CScalar(CPointer):
         char kind
         int8_t size
 
+        # None if initialized by from_int32().
+        public object dtype
+
+        # Corresponding NumPy scalar.
+        # None if initialized by from_int32().
+        object numpy_value
+
     @staticmethod
     cdef CScalar from_int32(int32_t value)
 
@@ -25,6 +32,7 @@ cdef class CScalar(CPointer):
     @staticmethod
     cdef CScalar _from_numpy_scalar(object x)
 
+    cdef object min_scalar_type(self)
     cpdef apply_dtype(self, dtype)
     cpdef get_numpy_type(self)
 


### PR DESCRIPTION
Simplifies scalar manipulation.

Removes necessity of two modes of `_preprocess_args` by always converting scalars to `CScalar`s.

Based on #2917.