### PR TITLE
Support CUB prefix sum & product

### DIFF
--- a/cupy/cuda/cub.pxd
+++ b/cupy/cuda/cub.pxd
@@ -4,3 +4,5 @@ cpdef enum cupy_cub_op:
     CUPY_CUB_MAX = 2
     CUPY_CUB_ARGMIN = 3
     CUPY_CUB_ARGMAX = 4
+    CUPY_CUB_CUMSUM = 5
+    CUPY_CUB_CUMPROD = 6

--- a/cupy/cuda/cub.pyx
+++ b/cupy/cuda/cub.pyx
@@ -402,7 +402,7 @@ def cub_reduction(arr, op, axis=None, dtype=None, out=None, keepdims=False):
     from cupy.core._reduction import _get_axis
     cdef bint enforce_numpy_API = False
 
-    if op > CUPY_CUB_MAX:
+    if op == CUPY_CUB_ARGMIN or op == CUPY_CUB_ARGMAX:
         # For argmin and argmax, NumPy does not allow a tuple for axis.
         # Also, the keepdims and dtype kwargs are not provided.
         #
@@ -432,7 +432,7 @@ def cub_reduction(arr, op, axis=None, dtype=None, out=None, keepdims=False):
     if can_use_device_reduce(op, arr.dtype, out_axis, dtype):
         return device_reduce(arr, op, out_axis, out, keepdims)
 
-    if op > CUPY_CUB_MAX:
+    if op == CUPY_CUB_ARGMIN or op == CUPY_CUB_ARGMAX:
         # segmented reduction not currently implemented for argmax, argmin
         return None
 

--- a/cupy/cuda/cub.pyx
+++ b/cupy/cuda/cub.pyx
@@ -6,6 +6,7 @@ from cpython cimport sequence
 
 import numpy
 
+from cupy.core._errors import _AxisError
 from cupy.core.core cimport ndarray, _internal_ascontiguousarray
 from cupy.core.core cimport _internal_asfortranarray
 from cupy.core.internal cimport _contig_axes
@@ -285,7 +286,7 @@ def device_csrmv(int n_rows, int n_cols, int nnz, ndarray values,
     return y
 
 
-def device_scan(ndarray x, int op, out=None):
+def device_scan(ndarray x, int op, dtype=None, ndarray out=None):
     cdef ndarray y
     cdef memory.MemoryPointer ws
     cdef int dtype_id, x_size
@@ -296,20 +297,41 @@ def device_scan(ndarray x, int op, out=None):
     cdef Stream_t s
 
     if out is not None and out.shape != x.shape:
-        raise ValueError()
+        raise ValueError('shape mismatch')
     if op != CUPY_CUB_CUMSUM and op != CUPY_CUB_CUMPROD:
         raise ValueError('only CUPY_CUB_CUMSUM and CUPY_CUB_CUMPROD '
                          'are supported.')
+
+    x_dtype = x.dtype
+    if dtype is None:
+        dtype = x_dtype
+    # TODO(leofang): how to determine system's default integer type?
+    if dtype in (numpy.int8, numpy.int16, numpy.int32):
+        dtype = numpy.int64
+    elif dtype in (numpy.uint8, numpy.uint16, numpy.uint32):
+        dtype = numpy.uint64
+    else:
+        dtype = x_dtype
+    x = x.astype(dtype)
+    if out is not None:
+        y = out.astype(dtype)
+    else:
+        y = ndarray(x.shape, dtype)
+
     if x.size == 0:
-        raise ValueError()
+        if out is not None:
+            out = out.reshape((0,))
+            y = out
+        else:
+            y = ndarray((0,), dtype=dtype)
+        return y
 
     x = _internal_ascontiguousarray(x)
     x_ptr = <void *>x.data.ptr
     x_size = <int>x.size
-    y = ndarray(x.shape, x.dtype)
     y_ptr = <void *>y.data.ptr
     s = <Stream_t>stream.get_current_stream_ptr()
-    dtype_id = _get_dtype_id(x.dtype)
+    dtype_id = _get_dtype_id(dtype)
     ws_size = cub_device_scan_get_workspace_size(x_ptr, y_ptr, x_size, s,
                                                  op, dtype_id)
     ws = memory.alloc(ws_size)
@@ -426,9 +448,10 @@ def cub_reduction(arr, op, axis=None, dtype=None, out=None, keepdims=False):
     return None
 
 
-def can_use_device_scan(int op, x_dtype, dtype=None):
-    #return out_axis is () and _cub_reduce_dtype_compatible(x_dtype, op, dtype)
-    return True
+def can_use_device_scan(x_dtype, dtype=None):
+    if dtype is not None:
+        return (dtype in CUB_support_dtype)
+    return (x_dtype in CUB_support_dtype)
 
 
 def cub_scan(arr, op, axis=None, dtype=None, out=None):
@@ -437,13 +460,19 @@ def cub_scan(arr, op, axis=None, dtype=None, out=None):
     If the specified scan is not possible, None is returned.
     """
     if axis is not None:
-        return None
+        if sequence.PySequence_Check(axis):
+            raise TypeError(
+                "'tuple' object cannot be interpreted as an integer")
+        if not (-arr.ndim <= axis < arr.ndim):
+            raise _AxisError('axis(={}) out of bounds'.format(axis))
+        if arr.ndim != 1 or axis != 0:
+            return None
 
     if op < CUPY_CUB_CUMSUM or op > CUPY_CUB_CUMPROD:
         return None
 
-    if can_use_device_scan(op, arr.dtype, dtype):
-        return device_scan(arr, op, out)
+    if can_use_device_scan(arr.dtype, dtype):
+        return device_scan(arr, op, dtype, out)
 
     return None
 

--- a/cupy/cuda/cub.pyx
+++ b/cupy/cuda/cub.pyx
@@ -317,10 +317,7 @@ def device_scan(ndarray x, int op, dtype=None, ndarray out=None):
 
     # determine shape: x is either 1D (with axis=None,0) or ND but ravelled.
     x_size = <int>x.size
-    if x.ndim != 1:
-        shape = (x_size,)
-    else:
-        shape = x.shape
+    shape = (x_size,)
 
     x = x.astype(dtype).reshape(shape)
     if out is not None:
@@ -372,8 +369,7 @@ def can_use_device_segmented_reduce(int op, x_dtype, Py_ssize_t ndim,
                                                         order)
 
 
-cdef _cub_reduce_dtype_compatible(x_dtype, int op, dtype=None,
-                                  bint segmented=False):
+cdef _cub_reduce_dtype_compatible(x_dtype, int op, dtype=None):
     if dtype is None:
         if op == CUPY_CUB_SUM:
             # auto dtype:
@@ -450,9 +446,11 @@ def cub_reduction(arr, op, axis=None, dtype=None, out=None, keepdims=False):
 
 
 def can_use_device_scan(x_dtype, dtype=None):
+    # cub_device_scan seems buggy for complex128:
+    # https://github.com/cupy/cupy/pull/2919#issuecomment-574633590
     if dtype is not None:
-        return (dtype in CUB_support_dtype)
-    return (x_dtype in CUB_support_dtype)
+        return (dtype in CUB_support_dtype and dtype != numpy.complex128)
+    return (x_dtype in CUB_support_dtype and x_dtype != numpy.complex128)
 
 
 def cub_scan(arr, op, axis=None, dtype=None, out=None):

--- a/cupy/cuda/cupy_cub.h
+++ b/cupy/cuda/cupy_cub.h
@@ -27,9 +27,11 @@
 void cub_device_reduce(void*, size_t&, void*, void*, int, cudaStream_t, int, int);
 void cub_device_segmented_reduce(void*, size_t&, void*, void*, int, void*, void*, cudaStream_t, int, int);
 void cub_device_spmv(void*, size_t&, void*, void*, void*, void*, void*, int, int, int, cudaStream_t, int);
+void cub_device_scan(void*, size_t&, void*, void*, int, cudaStream_t, int, int);
 size_t cub_device_reduce_get_workspace_size(void*, void*, int, cudaStream_t, int, int);
 size_t cub_device_segmented_reduce_get_workspace_size(void*, void*, int, void*, void*, cudaStream_t, int, int);
 size_t cub_device_spmv_get_workspace_size(void*, void*, void*, void*, void*, int, int, int, cudaStream_t, int);
+size_t cub_device_scan_get_workspace_size(void*, void*, int, cudaStream_t, int, int);
 
 #else // CUPY_NO_CUDA
 
@@ -44,6 +46,9 @@ void cub_device_segmented_reduce(...) {
 void cub_device_spmv(...) {
 }
 
+void cub_device_scan(...) {
+}
+
 size_t cub_device_reduce_get_workspace_size(...) {
     return 0;
 }
@@ -53,6 +58,10 @@ size_t cub_device_segmented_reduce_get_workspace_size(...) {
 }
 
 size_t cub_device_spmv_get_workspace_size(...) {
+    return 0;
+}
+
+size_t cub_device_scan_get_workspace_size(...) {
     return 0;
 }
 

--- a/cupy/cuda/cupy_cub.h
+++ b/cupy/cuda/cupy_cub.h
@@ -20,6 +20,8 @@
 #define CUPY_CUB_MAX     2
 #define CUPY_CUB_ARGMIN  3
 #define CUPY_CUB_ARGMAX  4
+#define CUPY_CUB_CUMSUM  5
+#define CUPY_CUB_CUMPROD 6
 
 #ifndef CUPY_NO_CUDA
 #include <cuda_runtime.h>  // for cudaStream_t

--- a/cupy/math/sumprod.py
+++ b/cupy/math/sumprod.py
@@ -6,6 +6,9 @@ from cupy import core
 from cupy.core import _routines_math as _math
 from cupy.core import fusion
 
+if cupy.cuda.cub_enabled:
+    from cupy.cuda import cub
+
 
 def sum(a, axis=None, dtype=None, out=None, keepdims=False):
     """Returns the sum of an array along given axes.
@@ -147,8 +150,15 @@ def _proc_as_batch(proc, x, axis):
     return r.reshape(s).transpose(revert)
 
 
-def _cum_core(a, axis, dtype, out, kern, batch_kern):
+def _cum_core(a, axis, dtype, out, kern, batch_kern, *, op=None):
     a = cupy.asarray(a)
+
+    if cupy.cuda.cub_enabled:
+        # result will be None if the scan is not compatible with CUB
+        result = cub.cub_scan(a, op, axis, dtype, out)
+        if result is not None:
+            return result
+
     if out is None:
         if dtype is None:
             kind = a.dtype.kind
@@ -219,7 +229,8 @@ def cumsum(a, axis=None, dtype=None, out=None):
     .. seealso:: :func:`numpy.cumsum`
 
     """
-    return _cum_core(a, axis, dtype, out, _cumsum_kern, _cumsum_batch_kern)
+    return _cum_core(a, axis, dtype, out, _cumsum_kern, _cumsum_batch_kern,
+                     op=cub.CUPY_CUB_CUMSUM)
 
 
 _cumprod_batch_kern = core.ElementwiseKernel(
@@ -262,7 +273,8 @@ def cumprod(a, axis=None, dtype=None, out=None):
     .. seealso:: :func:`numpy.cumprod`
 
     """
-    return _cum_core(a, axis, dtype, out, _cumprod_kern, _cumprod_batch_kern)
+    return _cum_core(a, axis, dtype, out, _cumprod_kern, _cumprod_batch_kern,
+                     op=cub.CUPY_CUB_CUMPROD)
 
 
 def diff(a, n=1, axis=-1, prepend=None, append=None):

--- a/cupy/math/sumprod.py
+++ b/cupy/math/sumprod.py
@@ -8,6 +8,8 @@ from cupy.core import fusion
 
 if cupy.cuda.cub_enabled:
     from cupy.cuda import cub
+else:
+    cub = None
 
 
 def sum(a, axis=None, dtype=None, out=None, keepdims=False):
@@ -229,8 +231,9 @@ def cumsum(a, axis=None, dtype=None, out=None):
     .. seealso:: :func:`numpy.cumsum`
 
     """
+    op = cub.CUPY_CUB_CUMSUM if cub is not None else None
     return _cum_core(a, axis, dtype, out, _cumsum_kern, _cumsum_batch_kern,
-                     op=cub.CUPY_CUB_CUMSUM)
+                     op=op)
 
 
 _cumprod_batch_kern = core.ElementwiseKernel(
@@ -273,8 +276,9 @@ def cumprod(a, axis=None, dtype=None, out=None):
     .. seealso:: :func:`numpy.cumprod`
 
     """
+    op = cub.CUPY_CUB_CUMPROD if cub is not None else None
     return _cum_core(a, axis, dtype, out, _cumprod_kern, _cumprod_batch_kern,
-                     op=cub.CUPY_CUB_CUMPROD)
+                     op=op)
 
 
 def diff(a, n=1, axis=-1, prepend=None, append=None):


### PR DESCRIPTION
In the demo below, CUB gets about a 4x speed-up on a P100:
```python
>>> import cupy as cp
>>> import cupyx
>>> 
>>> a = cp.random.random(1000000)
>>>
>>> cp.cuda.cub_enabled  =False
>>> print(cupyx.time.repeat(cp.cumprod, (a, )))
cumprod             :   428.775 us   +/-57.870 (min:  396.988 / max:  976.234) us    471.108 us   +/-45.524 (min:  449.888 / max:  992.736) us
>>> cp.cuda.cub_enabled = True
>>> print(cupyx.time.repeat(cp.cumprod, (a, )))
cumprod             :   103.053 us   +/-19.460 (min:   84.242 / max:  229.079) us    132.358 us   +/-17.695 (min:  113.888 / max:  250.048) us
>>>
>>> cp.cuda.cub_enabled = False
>>> print(cupyx.time.repeat(cp.cumsum, (a, )))
cumsum              :   428.253 us   +/-55.802 (min:  398.817 / max:  978.976) us    470.163 us   +/-43.695 (min:  450.464 / max:  995.872) us
>>> cp.cuda.cub_enabled = True
>>> print(cupyx.time.repeat(cp.cumsum, (a, )))
cumsum              :   103.998 us   +/-17.858 (min:   86.243 / max:  234.290) us    133.392 us   +/-16.486 (min:  115.808 / max:  256.320) us
```

TODO:
- [ ] compare performance with `cupy.core._routines_math.scan()` (Rel: #2905)
- [ ] add a CUB call path to `cupy.core._routines_math.scan()`
- [x] check if CUB handles `NaN`s correctly
- [ ] add tests (**Question:** to here or to #2598?)

The first two action items are for speeding up certain fancy indexing cases.