### PR TITLE
Avoid 0s in the diagonal of `TestSolveTriangular` inputs

### DIFF
--- a/tests/cupyx_tests/scipy_tests/linalg_tests/test_solve_triangular.py
+++ b/tests/cupyx_tests/scipy_tests/linalg_tests/test_solve_triangular.py
@@ -2,7 +2,6 @@ import unittest
 
 import cupy
 from cupy import testing
-from cupy.testing import condition
 import cupyx.scipy.linalg
 
 import numpy
@@ -26,10 +25,9 @@ except ImportError:
 class TestSolveTriangular(unittest.TestCase):
 
     @testing.for_float_dtypes(no_float16=True)
-    @condition.retry(10)
     def check_x(self, a_shape, b_shape, dtype):
-        a_cpu = numpy.random.randint(0, 10, size=a_shape).astype(dtype)
-        b_cpu = numpy.random.randint(0, 10, size=b_shape).astype(dtype)
+        a_cpu = numpy.random.randint(1, 10, size=a_shape).astype(dtype)
+        b_cpu = numpy.random.randint(1, 10, size=b_shape).astype(dtype)
         a_cpu = numpy.tril(a_cpu)
 
         if self.lower is False:


### PR DESCRIPTION
Solves a [rare flaky test](https://jenkins.preferred.jp/job/chainer/job/cupy_pr/829/TEST=cupy-py35,label=mn1-p100/testReport/junit/tests.cupyx_tests.scipy_tests.linalg_tests.test_solve_triangular/TestSolveTriangular_param_7_%7Bcheck_finite=True,%20lower=True,%20overwrite_b=True,%20trans=%27N%27,%20unit_diagonal=False%7D/test_solve/)

Thanks to @toslunar for finding the reason.