### PR TITLE
Improve error message for wrong number of arguments in elementwise kernels

### DIFF
--- a/cupy/core/_kernel.pyx
+++ b/cupy/core/_kernel.pyx
@@ -600,7 +600,11 @@ cdef class ElementwiseKernel:
 
         n_args = len(args)
         if n_args != self.nin and n_args != self.nargs:
-            raise TypeError('Wrong number of arguments for %s' % self.name)
+            raise TypeError(
+                'Wrong number of arguments for {!r}. '
+                'It must be either {} or {} (with outputs), '
+                'but given {}.'.format(
+                    self.name, self.nin, self.nargs, n_args))
         dev_id = device.get_device_id()
         args = _preprocess_args(dev_id, args, True)
 
@@ -864,7 +868,11 @@ cdef class ufunc:
 
         n_args = len(args)
         if n_args != self.nin and n_args != self.nargs:
-            raise TypeError('Wrong number of arguments for %s' % self.name)
+            raise TypeError(
+                'Wrong number of arguments for {!r}. '
+                'It must be either {} or {} (with outputs), '
+                'but given {}.'.format(
+                    self.name, self.nin, self.nargs, n_args))
 
         dev_id = device.get_device_id()
         args = _preprocess_args(dev_id, args, False)


### PR DESCRIPTION
Adds expected and actual numbers.
```
TypeError: Wrong number of arguments for 'cupy_add'. It must be either 2 or 3 (with outputs), but given 4.
```