### PR TITLE
Enhance type and argument manipulation in elementwise and reduction kernels

### DIFF
--- a/cupy/core/_kernel.pyx
+++ b/cupy/core/_kernel.pyx
@@ -38,9 +38,11 @@ cpdef inline bint _is_fusing() except? -1:
 
 
 cpdef function.Function _get_simple_elementwise_kernel(
-        params, operation, name, preamble,
-        loop_prep='', after_loop='', options=()):
+        tuple params, tuple arginfos, str operation, str name,
+        _TypeMap type_map, str preamble, str loop_prep='', str after_loop='',
+        tuple options=()):
     module_code = string.Template('''
+    ${typedef_preamble}
     ${preamble}
     extern "C" __global__ void ${name}(${params}) {
       ${loop_prep};
@@ -51,7 +53,8 @@ cpdef function.Function _get_simple_elementwise_kernel(
       ${after_loop};
     }
     ''').substitute(
-        params=params,
+        typedef_preamble=type_map.get_typedef_code(),
+        params=_get_kernel_params(params, arginfos),
         operation=operation,
         name=name,
         preamble=preamble,
@@ -110,39 +113,108 @@ cdef list _preprocess_args(int dev_id, args, bint use_c_scalar):
     return ret
 
 
-cpdef tuple _get_args_info(list args):
-    ret = []
-    for a in args:
-        t = type(a)
-        if t is _carray.Indexer:
-            dtype = None
-        elif t is _scalar.CScalar:
-            dtype = (<_scalar.CScalar>a).get_numpy_type()
-        else:
-            dtype = a.dtype.type
-        ret.append((t, dtype, a.ndim))
-    return tuple(ret)
+cdef class _ArgInfo:
+    # Holds metadata of an argument.
+    # This class is immutable and used as a part of hash keys.
+
+    def __init__(self, _ArgKind arg_kind, type typ, object dtype, int ndim):
+        self.arg_kind = arg_kind
+        self.type = typ
+        self.dtype = dtype
+        self.ndim = ndim
+
+    @staticmethod
+    cdef _ArgInfo from_arg(object arg):
+        typ = type(arg)
+        if typ is ndarray:
+            return _ArgInfo.from_ndarray(arg)
+        if typ is _scalar.CScalar:
+            return _ArgInfo.from_scalar(arg)
+        if typ is _carray.Indexer:
+            return _ArgInfo.from_indexer(arg)
+        assert False, typ
+
+    @staticmethod
+    cdef _ArgInfo from_ndarray(ndarray arg):
+        return _ArgInfo(ARG_KIND_NDARRAY, ndarray, arg.dtype.type, arg.ndim)
+
+    @staticmethod
+    cdef _ArgInfo from_scalar(_scalar.CScalar arg):
+        dtype = arg.get_numpy_type()
+        return _ArgInfo(ARG_KIND_SCALAR, _scalar.CScalar, dtype, 0)
+
+    @staticmethod
+    cdef _ArgInfo from_indexer(_carray.Indexer arg):
+        return _ArgInfo(ARG_KIND_INDEXER, _carray.Indexer, None, arg.ndim)
+
+    def __hash__(self):
+        return hash((self.arg_kind, self.type, self.dtype, self.ndim))
+
+    def __eq__(self, other):
+        cdef _ArgInfo oth
+        if not isinstance(other, _ArgInfo):
+            return False
+        oth = other
+        return (
+            self.arg_kind == oth.arg_kind
+            and self.type is oth.type
+            and self.dtype == oth.dtype
+            and self.ndim == oth.ndim)
+
+    cdef _ArgInfo as_ndarray_with_ndim(self, int ndim):
+        # Returns an ndarray _ArgInfo with altered ndim.
+        # If ndim is the same, self is returned untouched.
+        assert self.arg_kind == ARG_KIND_NDARRAY
+        if self.ndim == ndim:
+            return self
+        return _ArgInfo(ARG_KIND_NDARRAY, ndarray, self.dtype, ndim)
+
+    cdef bint is_ndarray(self):
+        return self.arg_kind == ARG_KIND_NDARRAY
+
+    cdef bint is_scalar(self):
+        return self.arg_kind == ARG_KIND_SCALAR
+
+    cdef str get_c_type(self):
+        # Returns the C type representation.
+        if self.arg_kind == ARG_KIND_NDARRAY:
+            return 'CArray<%s, %d>' % (_get_typename(self.dtype), self.ndim)
+        if self.arg_kind == ARG_KIND_SCALAR:
+            return _get_typename(self.dtype)
+        if self.arg_kind == ARG_KIND_INDEXER:
+            return 'CIndexer<%d>' % self.ndim
+        assert False
+
+    cdef str get_param_c_type(self, ParameterInfo p):
+        # Returns the C type representation in the global function's
+        # parameter list.
+        cdef str ctyp = self.get_c_type()
+        if p.is_const:
+            return 'const ' + ctyp
+        return ctyp
+
+    cdef str get_c_var_name(self, ParameterInfo p):
+        if self.arg_kind == ARG_KIND_NDARRAY and not p.raw:
+            return '_raw_' + p.name
+        return p.name
 
 
-cpdef str _get_kernel_params(tuple params, tuple args_info):
+cpdef tuple _get_arginfos(list args):
+    return tuple([_ArgInfo.from_arg(a) for a in args])
+
+
+cpdef str _get_kernel_params(tuple params, tuple arginfos):
     cdef ParameterInfo p
-    ret = []
+    cdef _ArgInfo arginfo
+    assert len(params) == len(arginfos)
+    lst = []
     for i in range(len(params)):
         p = params[i]
-        type, dtype, ndim = <tuple>(args_info[i])
-        is_array = type is ndarray
-        if type is _carray.Indexer:
-            t = 'CIndexer<%d>' % ndim
-        else:
-            t = _get_typename(dtype)
-            if is_array:
-                t = 'CArray<%s, %d>' % (t, ndim)
-        ret.append('{}{} {}{}'.format(
-            'const ' if p.is_const else '',
-            t,
-            '_raw_' if is_array and not p.raw else '',
-            p.name))
-    return ', '.join(ret)
+        arginfo = arginfos[i]
+        lst.append('{} {}'.format(
+            arginfo.get_param_c_type(p),
+            arginfo.get_c_var_name(p)))
+    return ', '.join(lst)
 
 
 cdef tuple _reduce_dims(list args, tuple params, tuple shape):
@@ -297,6 +369,29 @@ def _decide_params_type(in_params, out_params, in_args_dtype, out_args_dtype):
                                     out_args_dtype)
 
 
+cdef class _TypeMap:
+
+    def __init__(self, pairs):
+        self._pairs = pairs
+
+    def __hash__(self):
+        return hash(self._pairs)
+
+    def __eq__(self, other):
+        if not isinstance(other, _TypeMap):
+            return False
+        return self._pairs == (<_TypeMap>other)._pairs
+
+    def __str__(self):
+        return '<_TypeMap {}>'.format(self._pairs)
+
+    cdef str get_typedef_code(self):
+        # Returns a code fragment of typedef statements used as preamble.
+        return ''.join([
+            'typedef %s %s;\n' % (_get_typename(ctype2), ctype1)
+            for ctype1, ctype2 in self._pairs])
+
+
 cdef tuple _decide_params_type_core(
         tuple in_params, tuple out_params, tuple in_args_dtype,
         tuple out_args_dtype):
@@ -343,7 +438,8 @@ cdef tuple _decide_params_type_core(
                       for p in in_params])
     out_types = tuple([type_dict[p.ctype] if p.dtype is None else p.dtype
                        for p in out_params])
-    return in_types, out_types, tuple(sorted(type_dict.items()))
+    type_map = _TypeMap(tuple(sorted(type_dict.items())))
+    return in_types, out_types, type_map
 
 
 cdef tuple _broadcast(list args, tuple params, bint use_size):
@@ -459,16 +555,13 @@ cdef list _get_out_args_with_params(
 
 @util.memoize(for_each_device=True)
 def _get_elementwise_kernel(
-        tuple args_info, tuple types, tuple params, operation, name,
+        tuple arginfos, _TypeMap type_map, tuple params, operation, name,
         preamble, **kwargs):
-    kernel_params = _get_kernel_params(params, args_info)
-    types_preamble = '\n'.join(
-        'typedef %s %s;' % (_get_typename(v), k) for k, v in types)
-    preamble = types_preamble + '\n' + preamble
+    cdef _ArgInfo arginfo
 
     op = []
-    for p, a in zip(params, args_info):
-        if not p.raw and a[0] == ndarray:
+    for p, arginfo in zip(params, arginfos):
+        if arginfo.is_ndarray() and not p.raw:
             if p.is_const:
                 fmt = 'const {t} &{n} = _raw_{n}[_ind.get()];'
             else:
@@ -477,7 +570,7 @@ def _get_elementwise_kernel(
     op.append(operation)
     operation = '\n'.join(op)
     return _get_simple_elementwise_kernel(
-        kernel_params, operation, name,
+        params, arginfos, operation, name, type_map,
         preamble, **kwargs)
 
 
@@ -613,7 +706,7 @@ cdef class ElementwiseKernel:
              for a in in_args])
         out_ndarray_types = tuple([a.dtype.type for a in out_args])
 
-        in_types, out_types, types = self._decide_params_type(
+        in_types, out_types, type_map = self._decide_params_type(
             in_ndarray_types, out_ndarray_types)
 
         is_size_specified = False
@@ -644,8 +737,8 @@ cdef class ElementwiseKernel:
         indexer = _carray.Indexer(shape)
         inout_args.append(indexer)
 
-        args_info = _get_args_info(inout_args)
-        kern = self._get_elementwise_kernel(dev_id, args_info, types)
+        arginfos = _get_arginfos(inout_args)
+        kern = self._get_elementwise_kernel(dev_id, arginfos, type_map)
         kern.linear_launch(indexer.size, inout_args, shared_mem=0,
                            block_max_size=128, stream=stream)
         return ret
@@ -662,16 +755,16 @@ cdef class ElementwiseKernel:
         return ret
 
     cpdef function.Function _get_elementwise_kernel(
-            self, int dev_id, tuple args_info, tuple types):
+            self, int dev_id, tuple arginfos, _TypeMap type_map):
         key = (
             dev_id,
-            args_info,
-            types)
+            arginfos,
+            type_map)
         kern = self._elementwise_kernel_memo.get(key, None)
         if kern is not None:
             return kern
         kern = _get_elementwise_kernel(
-            args_info, types, self.params, self.operation,
+            arginfos, type_map, self.params, self.operation,
             self.name, self.preamble, **self.kwargs)
 
         # Store the compiled kernel in the cache.
@@ -682,32 +775,32 @@ cdef class ElementwiseKernel:
 
 
 cdef function.Function _get_ufunc_kernel(
-        tuple in_types, tuple out_types, routine, tuple args_info, params,
+        tuple in_types, tuple out_types, routine, tuple arginfos, params,
         name, preamble, loop_prep):
-    kernel_params = _get_kernel_params(params, args_info)
+    cdef _ArgInfo arginfo
 
     types = []
     op = []
     for i, x in enumerate(in_types):
-        types.append('typedef %s in%d_type;' % (_get_typename(x), i))
-        if args_info[i][0] is ndarray:
+        types.append(('in%d_type' % i, x))
+        arginfo = arginfos[i]
+        if arginfo.is_ndarray():
             op.append(
                 'const in{0}_type in{0}(_raw_in{0}[_ind.get()]);'
                 .format(i))
 
     for i, x in enumerate(out_types):
-        types.append('typedef %s out%d_type;' % (
-            _get_typename(args_info[i + len(in_types)][1]), i))
+        arginfo = arginfos[i + len(in_types)]
+        types.append(('out%d_type' % i, arginfo.dtype))
         op.append('out{0}_type &out{0} = _raw_out{0}[_ind.get()];'.format(i))
+    type_map = _TypeMap(tuple(types))
 
     op.append(routine)
     operation = '\n'.join(op)
 
-    types.append(preamble)
-    preamble = '\n'.join(types)
-
     return _get_simple_elementwise_kernel(
-        kernel_params, operation, name, preamble, loop_prep=loop_prep)
+        params, arginfos, operation, name, type_map, preamble,
+        loop_prep=loop_prep)
 
 
 cdef inline bint _check_should_use_min_scalar(list in_args) except? -1:
@@ -904,32 +997,33 @@ cdef class ufunc:
         shape = _reduce_dims(inout_args, self._params, shape)
         indexer = _carray.Indexer(shape)
         inout_args.append(indexer)
-        args_info = _get_args_info(inout_args)
+        arginfos = _get_arginfos(inout_args)
 
-        kern = self._get_ufunc_kernel(dev_id, op, args_info)
+        kern = self._get_ufunc_kernel(dev_id, op, arginfos)
 
         kern.linear_launch(indexer.size, inout_args)
         return ret
 
-    cdef str _get_name_with_type(self, tuple args_info):
+    cdef str _get_name_with_type(self, tuple arginfos):
+        cdef _ArgInfo arginfo
         inout_type_words = []
-        for t, dtype, ndim in args_info:
-            dtype = str(numpy.dtype(dtype))
-            if t is _scalar.CScalar:
-                inout_type_words.append(dtype.rstrip('0123456789'))
-            elif t is not _carray.Indexer:
+        for arginfo in arginfos:
+            dtype = str(numpy.dtype(arginfo.dtype))
+            if arginfo.is_ndarray():
                 inout_type_words.append(dtype)
+            elif arginfo.is_scalar():
+                inout_type_words.append(dtype.rstrip('0123456789'))
         return '{}__{}'.format(self.name, '_'.join(inout_type_words))
 
     cdef function.Function _get_ufunc_kernel(
-            self, int dev_id, _Op op, tuple args_info):
+            self, int dev_id, _Op op, tuple arginfos):
         cdef function.Function kern
-        key = (dev_id, op, args_info)
+        key = (dev_id, op, arginfos)
         kern = self._kernel_memo.get(key, None)
         if kern is None:
-            name = self._get_name_with_type(args_info)
+            name = self._get_name_with_type(arginfos)
             kern = _get_ufunc_kernel(
-                op.in_types, op.out_types, op.routine, args_info,
+                op.in_types, op.out_types, op.routine, arginfos,
                 self._params, name, self._preamble, self._loop_prep)
             self._kernel_memo[key] = kern
         return kern

--- a/cupy/core/_reduction.pxd
+++ b/cupy/core/_reduction.pxd
@@ -1,3 +1,4 @@
+from cupy.core cimport _kernel
 from cupy.core.core cimport ndarray
 from cupy.cuda cimport function
 
@@ -26,7 +27,7 @@ cdef class _AbstractReductionKernel:
 
     cdef function.Function _get_function(
         self,
-        tuple params, tuple args_info, tuple types,
+        tuple params, tuple arginfos, _kernel._TypeMap types,
         str map_expr, str reduce_expr, str post_map_expr, str reduce_type,
         Py_ssize_t block_size)
 


### PR DESCRIPTION
Separated from #2920.

Introduced `_ArgInfo` to hold argument metadata, and `_TypeMap` to abstract C type mapping.