### PR TITLE
Fix `ParameterInfo` as a cache key

### DIFF
--- a/cupy/core/_kernel.pyx
+++ b/cupy/core/_kernel.pyx
@@ -273,6 +273,22 @@ cdef class ParameterInfo:
             else:
                 raise Exception('Unknown keyword "%s"' % i)
 
+    def __hash__(self):
+        return hash((
+            self.name, self.dtype, self.ctype, self.raw, self.is_const))
+
+    def __eq__(self, other):
+        cdef ParameterInfo oth
+        if not isinstance(other, ParameterInfo):
+            return False
+        oth = other
+        return (
+            self.name == oth.name
+            and self.dtype == oth.dtype
+            and self.ctype == oth.ctype
+            and self.raw == oth.raw
+            and self.is_const == oth.is_const)
+
     def __repr__(self):
         return '<ParameterInfo({})>'.format(
             ' '.join([


### PR DESCRIPTION
`__hash__` and `__eq__`, required to be suitable as a cache key, were missing in `ParameterInfo`.

You can check the behavior by the following code.
```py
import cupy
a = cupy.core._kernel.ParameterInfo('raw T x', False)
b = cupy.core._kernel.ParameterInfo('raw T x', False)
print(hash(a))
print(hash(b))
print(a == b)
```

After the fix:
```
2788533504290071466
2788533504290071466
True
```