### PR TITLE
Use asynchronous copy in `cupy.copyto`

### DIFF
--- a/cupy/manipulation/basic.py
+++ b/cupy/manipulation/basic.py
@@ -55,7 +55,7 @@ def copyto(dst, src, casting='same_kind', where=None):
 
     if where is None:
         if _can_memcpy(dst, src):
-            dst.data.copy_from(src.data, src.nbytes)
+            dst.data.copy_from_async(src.data, src.nbytes)
         else:
             device = dst.device
             with device:


### PR DESCRIPTION
Part of #2159.

`cupy.copyto` currently uses synchronous DtoD copy in one of its branches, eventually using the default CUDA stream. This PR fixes it to use asynchronous DtoD copy with the current CUDA stream that CuPy manages.