### PR TITLE
Allow to pass a `kernel` argument to `RawKernel`

### DIFF
--- a/cupy/core/raw.pyx
+++ b/cupy/core/raw.pyx
@@ -72,7 +72,6 @@ cdef class RawKernel:
         """
         self.kernel(
             grid, block, args,
-            enable_cooperative_groups=self.enable_cooperative_groups,
             **kwargs)
 
     @property
@@ -83,123 +82,6 @@ cdef class RawKernel:
                 self.translate_cucomplex, self.enable_cooperative_groups)
         return self._kernel
 
-    @property
-    def attributes(self):
-        """Returns a dictionary containing runtime kernel attributes. This is
-        a read-only property; to overwrite the attributes, use
-
-        .. code-block:: python
-
-            kernel = RawKernel(...)  # arguments omitted
-            kernel.max_dynamic_shared_size_bytes = ...
-            kernel.preferred_shared_memory_carveout = ...
-
-        Note that the two attributes shown in the above example are the only
-        two currently settable in CUDA.
-
-        Any attribute not existing in the present CUDA toolkit version will
-        have the value -1.
-
-        Returns:
-            dict: A dictionary containing the kernel's attributes.
-        """
-        cdef dict attrs = {}
-        cdef list keys = ['max_threads_per_block', 'shared_size_bytes',
-                          'const_size_bytes', 'local_size_bytes',
-                          'num_regs', 'ptx_version', 'binary_version',
-                          'cache_mode_ca', 'max_dynamic_shared_size_bytes',
-                          'preferred_shared_memory_carveout']
-        for attr in keys:
-            attrs[attr] = getattr(self, attr)
-        return attrs
-
-    @property
-    def max_threads_per_block(self):
-        """The maximum number of threads per block that can successfully
-        launch the function on the device.
-        """
-        attr = driver.CU_FUNC_ATTRIBUTE_MAX_THREADS_PER_BLOCK
-        return driver.funcGetAttribute(attr, self.kernel.ptr)
-
-    @property
-    def shared_size_bytes(self):
-        """The size in bytes of the statically-allocated shared memory
-        used by the function. This is separate from any dynamically-allocated
-        shared memory, which must be specified when the function is called.
-        """
-        attr = driver.CU_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES
-        return driver.funcGetAttribute(attr, self.kernel.ptr)
-
-    @property
-    def const_size_bytes(self):
-        """The size in bytes of constant memory used by the function."""
-        attr = driver.CU_FUNC_ATTRIBUTE_CONST_SIZE_BYTES
-        return driver.funcGetAttribute(attr, self.kernel.ptr)
-
-    @property
-    def local_size_bytes(self):
-        """The size in bytes of local memory used by the function."""
-        attr = driver.CU_FUNC_ATTRIBUTE_LOCAL_SIZE_BYTES
-        return driver.funcGetAttribute(attr, self.kernel.ptr)
-
-    @property
-    def num_regs(self):
-        """The number of registers used by the function."""
-        attr = driver.CU_FUNC_ATTRIBUTE_NUM_REGS
-        return driver.funcGetAttribute(attr, self.kernel.ptr)
-
-    @property
-    def ptx_version(self):
-        """The PTX virtual architecture version that was used during
-        compilation, in the format: 10*major + minor.
-        """
-        attr = driver.CU_FUNC_ATTRIBUTE_PTX_VERSION
-        return driver.funcGetAttribute(attr, self.kernel.ptr)
-
-    @property
-    def binary_version(self):
-        """The binary architecture version that was used during compilation,
-        in the format: 10*major + minor.
-        """
-        attr = driver.CU_FUNC_ATTRIBUTE_BINARY_VERSION
-        return driver.funcGetAttribute(attr, self.kernel.ptr)
-
-    @property
-    def cache_mode_ca(self):
-        """Indicates whether option "-Xptxas --dlcm=ca" was set during
-        compilation.
-        """
-        attr = driver.CU_FUNC_ATTRIBUTE_CACHE_MODE_CA
-        return driver.funcGetAttribute(attr, self.kernel.ptr)
-
-    @property
-    def max_dynamic_shared_size_bytes(self):
-        """The maximum dynamically-allocated shared memory size in bytes that
-        can be used by the function. Can be set.
-        """
-        attr = driver.CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES
-        return driver.funcGetAttribute(attr, self.kernel.ptr)
-
-    @max_dynamic_shared_size_bytes.setter
-    def max_dynamic_shared_size_bytes(self, bytes):
-        attr = driver.CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES
-        driver.funcSetAttribute(self.kernel.ptr, attr, bytes)
-
-    @property
-    def preferred_shared_memory_carveout(self):
-        """On devices that have a unified L1 cache and shared memory,
-        indicates the fraction to be used for shared memory as a
-        `percentage` of the total. If the fraction does not exactly equal a
-        supported shared memory capacity, then the next larger supported
-        capacity is used. Can be set.
-        """
-        attr = driver.CU_FUNC_ATTRIBUTE_PREFERRED_SHARED_MEMORY_CARVEOUT
-        return driver.funcGetAttribute(attr, self.kernel.ptr)
-
-    @preferred_shared_memory_carveout.setter
-    def preferred_shared_memory_carveout(self, fraction):
-        attr = driver.CU_FUNC_ATTRIBUTE_PREFERRED_SHARED_MEMORY_CARVEOUT
-        driver.funcSetAttribute(self.kernel.ptr, attr, fraction)
 
 
 @cupy.util.memoize(for_each_device=True)
@@ -298,14 +180,8 @@ cdef class RawModule:
             return self.kernels[name]
         else:
             kernel = self.module.get_function(name)
-            r_kernel = RawKernel(
-                name=name, options=self.options,
-                backend=self.backend,
-                translate_cucomplex=self.translate_cucomplex,
-                enable_cooperative_groups=self.enable_cooperative_groups,
-                kernel=kernel)
-            self.kernels[name] = r_kernel
-            return r_kernel
+            self.kernels[name] = kernel
+            return kernel
 
     def get_texref(self, name):
         '''Retrieve a texture reference by its name from the module.

--- a/cupy/core/raw.pyx
+++ b/cupy/core/raw.pyx
@@ -1,3 +1,5 @@
+import warnings
+
 import cupy
 from cupy import util
 from cupy.cuda cimport driver
@@ -17,7 +19,7 @@ cdef class RawKernel:
     binary is reused by other processes.
 
     Args:
-        code (str): CUDA source code. Mutually exclusive with ``kernel``
+        code (str): CUDA source code.
         name (str): Name of the kernel function.
         options (tuple of str): Compiler options passed to the backend (NVRTC
             or NVCC). For details, see
@@ -34,8 +36,6 @@ cdef class RawKernel:
             ``cuLaunchCooperativeKernel`` so that cooperative groups can be
             used from the CUDA source.
             This feature is only supported in CUDA 9 or later.
-        kernel (:class:`cupy.cuda.Function`): CUDA Kernel object 
-            to be executed. Mutually exclusive with ``code``
     """
 
     def __init__(self, code, name, options=(), backend='nvrtc', *,
@@ -53,7 +53,7 @@ cdef class RawKernel:
         self.backend = backend
         self.translate_cucomplex = translate_cucomplex
         self.enable_cooperative_groups = enable_cooperative_groups
-        self._kernel = kernel
+        self._kernel = None
 
     def __call__(self, grid, block, args, **kwargs):
         """__call__(self, grid, block, args, *, shared_mem=0)
@@ -82,6 +82,146 @@ cdef class RawKernel:
                 self.translate_cucomplex, self.enable_cooperative_groups)
         return self._kernel
 
+    @property
+    def attributes(self):
+        """ (Deprecated) use `RawKernel.function.attributes` instead. """
+        warnings.warn(
+            'RawKernel.attributes is deprecated. '
+            'Use RawKernel.function.attributes instead.',
+            DeprecationWarning)
+        return self.function.attributes()
+
+    @property
+    def max_threads_per_block(self):
+        """ (Deprecated) use `RawKernel.function.max_threads_per_block`
+        instead.
+        """
+        warnings.warn(
+            'RawKernel.max_threads_per_block is deprecated. '
+            'Use RawKernel.function.max_threads_per_block instead.',
+            DeprecationWarning)
+        return self.function.max_threads_per_block()
+
+    @property
+    def shared_size_bytes(self):
+        """ (Deprecated) use `RawKernel.function.shared_size_bytes`
+        instead.
+        """
+        warnings.warn(
+            'RawKernel.shared_size_bytes is deprecated. '
+            'Use RawKernel.function.shared_size_bytes instead.',
+            DeprecationWarning)
+        return self.function.shared_size_bytes()
+
+    @property
+    def const_size_bytes(self):
+        """ (Deprecated) use `RawKernel.function.const_size_bytes`
+        instead.
+        """
+        warnings.warn(
+            'RawKernel.const_size_bytes is deprecated. '
+            'Use RawKernel.function.const_size_bytes instead.',
+            DeprecationWarning)
+        return self.function.const_size_bytes()
+
+    @property
+    def local_size_bytes(self):
+        """ (Deprecated) use `RawKernel.function.local_size_bytes`
+        instead.
+        """
+        warnings.warn(
+            'RawKernel.local_size_bytes is deprecated. '
+            'Use RawKernel.function.local_size_bytes instead.',
+            DeprecationWarning)
+        return self.function.local_size_bytes()
+
+    @property
+    def num_regs(self):
+        """ (Deprecated) use `RawKernel.function.num_regs`
+        instead.
+        """
+        warnings.warn(
+            'RawKernel.num_regs is deprecated. '
+            'Use RawKernel.function.num_regs instead.',
+            DeprecationWarning)
+        return self.function.num_regs()
+
+    @property
+    def ptx_version(self):
+        """ (Deprecated) use `RawKernel.function.ptx_version`
+        instead.
+        """
+        warnings.warn(
+            'RawKernel.ptx_version is deprecated. '
+            'Use RawKernel.function.ptx_version instead.',
+            DeprecationWarning)
+        return self.function.ptx_version()
+
+    @property
+    def binary_version(self):
+        """ (Deprecated) use `RawKernel.function.binary_version`
+        instead.
+        """
+        warnings.warn(
+            'RawKernel.binary_version is deprecated. '
+            'Use RawKernel.function.binary_version instead.',
+            DeprecationWarning)
+        return self.function.binary_version()
+
+    @property
+    def cache_mode_ca(self):
+        """ (Deprecated) use `RawKernel.function.cache_mode_ca`
+        instead.
+        """
+        warnings.warn(
+            'RawKernel.cache_mode_ca is deprecated. '
+            'Use RawKernel.function.cache_mode_ca instead.',
+            DeprecationWarning)
+        return self.function.cache_mode_ca()
+
+    @property
+    def max_dynamic_shared_size_bytes(self):
+        """ (Deprecated) use `RawKernel.function.max_dynamic_shared_size_bytes`
+        instead.
+        """
+        warnings.warn(
+            'RawKernel.max_dynamic_shared_size_bytes is deprecated. '
+            'Use RawKernel.function.max_dynamic_shared_size_bytes instead.',
+            DeprecationWarning)
+        return self.function.max_dynamic_shared_size_bytes()
+
+    @max_dynamic_shared_size_bytes.setter
+    def max_dynamic_shared_size_bytes(self, bytes):
+        """ (Deprecated) use `RawKernel.function.max_dynamic_shared_size_bytes`
+        instead.
+        """
+        warnings.warn(
+            'RawKernel.max_dynamic_shared_size_bytes is deprecated. '
+            'Use RawKernel.function.max_dynamic_shared_size_bytes instead.',
+            DeprecationWarning)
+        self.function.max_dynamic_shared_size_bytes(bytes)
+
+    @property
+    def preferred_shared_memory_carveout(self):
+        """ (Deprecated) use `RawKernel.function.preferred_shared_memory_carveout`
+        instead.
+        """
+        warnings.warn(
+            'RawKernel.preferred_shared_memory_carveout is deprecated. '
+            'Use RawKernel.function.preferred_shared_memory_carveout instead.',
+            DeprecationWarning)
+        return self.function.preferred_shared_memory_carveout()
+
+    @preferred_shared_memory_carveout.setter
+    def preferred_shared_memory_carveout(self, fraction):
+        """ (Deprecated) use `RawKernel.function.preferred_shared_memory_carveout`
+        instead.
+        """
+        warnings.warn(
+            'RawKernel.preferred_shared_memory_carveout is deprecated. '
+            'Use RawKernel.function.preferred_shared_memory_carveout instead.',
+            DeprecationWarning)
+        self.kernel.preferred_shared_memory_carveout(fraction)
 
 
 @cupy.util.memoize(for_each_device=True)
@@ -159,7 +299,7 @@ cdef class RawModule:
             self.backend = backend
             self.translate_cucomplex = translate_cucomplex
         elif self.cubin_path is not None:
-            self.module = Module()
+            self.module = Module(enable_cooperative_groups)
             self.module.load_file(self.cubin_path)
             self.options = ()
             self.backend = 'nvcc'

--- a/cupy/core/raw.pyx
+++ b/cupy/core/raw.pyx
@@ -34,8 +34,8 @@ cdef class RawKernel:
             ``cuLaunchCooperativeKernel`` so that cooperative groups can be
             used from the CUDA source.
             This feature is only supported in CUDA 9 or later.
-        kernel (:class:`cupy.cuda.function.Function`): Kernel object obtained
-            from the compilation backend. Mutually exclusive with ``code``
+        kernel (:class:`cupy.cuda.Function`): CUDA Kernel object 
+            to be executed. Mutually exclusive with ``code``
     """
 
     def __init__(self, code, name, options=(), backend='nvrtc', *,

--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -335,7 +335,7 @@ def _compile_with_cache_cuda(
             if not os.path.isdir(cache_dir):
                 raise
 
-    mod = function.Module()
+    mod = function.Module(enable_cooperative_groups)
     # To handle conflicts in concurrent situation, we adopt lock-free method
     # to avoid performance degradation.
     path = os.path.join(cache_dir, name)

--- a/cupy/cuda/function.pxd
+++ b/cupy/cuda/function.pxd
@@ -10,6 +10,7 @@ cdef class Function:
     cdef:
         public Module module
         public intptr_t ptr
+        public enable_cooperative_groups
 
     cpdef linear_launch(self, size_t size, args, size_t shared_mem=*,
                         size_t block_max_size=*, stream=*)
@@ -19,6 +20,7 @@ cdef class Module:
 
     cdef:
         public intptr_t ptr
+        public enable_cooperative_groups
 
     cpdef load_file(self, filename)
     cpdef load(self, bytes cubin)

--- a/cupy/cuda/function.pyx
+++ b/cupy/cuda/function.pyx
@@ -155,7 +155,11 @@ cdef _launch(intptr_t func, Py_ssize_t grid0, int grid1, int grid2,
 
 cdef class Function:
 
-    """CUDA kernel function."""
+    """CUDA kernel function.
+
+    Class dealing with the execution of a compiled CUDA function
+    and management of runtime attributes.
+    """
 
     def __init__(self, Module module, str funcname,
                  bint enable_cooperative_groups):

--- a/cupy/cuda/function.pyx
+++ b/cupy/cuda/function.pyx
@@ -182,6 +182,124 @@ cdef class Function:
         _launch(self.ptr,
                 gridx, 1, 1, blockx, 1, 1, args, shared_mem, s)
 
+    @property
+    def attributes(self):
+        """Returns a dictionary containing runtime kernel attributes. This is
+        a read-only property; to overwrite the attributes, use
+
+        .. code-block:: python
+
+            kernel = RawKernel(...)  # arguments omitted
+            kernel.max_dynamic_shared_size_bytes = ...
+            kernel.preferred_shared_memory_carveout = ...
+
+        Note that the two attributes shown in the above example are the only
+        two currently settable in CUDA.
+
+        Any attribute not existing in the present CUDA toolkit version will
+        have the value -1.
+
+        Returns:
+            dict: A dictionary containing the kernel's attributes.
+        """
+        cdef dict attrs = {}
+        cdef list keys = ['max_threads_per_block', 'shared_size_bytes',
+                          'const_size_bytes', 'local_size_bytes',
+                          'num_regs', 'ptx_version', 'binary_version',
+                          'cache_mode_ca', 'max_dynamic_shared_size_bytes',
+                          'preferred_shared_memory_carveout']
+        for attr in keys:
+            attrs[attr] = getattr(self, attr)
+        return attrs
+
+    @property
+    def max_threads_per_block(self):
+        """The maximum number of threads per block that can successfully
+        launch the function on the device.
+        """
+        attr = driver.CU_FUNC_ATTRIBUTE_MAX_THREADS_PER_BLOCK
+        return driver.funcGetAttribute(attr, self.ptr)
+
+    @property
+    def shared_size_bytes(self):
+        """The size in bytes of the statically-allocated shared memory
+        used by the function. This is separate from any dynamically-allocated
+        shared memory, which must be specified when the function is called.
+        """
+        attr = driver.CU_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES
+        return driver.funcGetAttribute(attr, self.ptr)
+
+    @property
+    def const_size_bytes(self):
+        """The size in bytes of constant memory used by the function."""
+        attr = driver.CU_FUNC_ATTRIBUTE_CONST_SIZE_BYTES
+        return driver.funcGetAttribute(attr, self.ptr)
+
+    @property
+    def local_size_bytes(self):
+        """The size in bytes of local memory used by the function."""
+        attr = driver.CU_FUNC_ATTRIBUTE_LOCAL_SIZE_BYTES
+        return driver.funcGetAttribute(attr, self.ptr)
+
+    @property
+    def num_regs(self):
+        """The number of registers used by the function."""
+        attr = driver.CU_FUNC_ATTRIBUTE_NUM_REGS
+        return driver.funcGetAttribute(attr, self.ptr)
+
+    @property
+    def ptx_version(self):
+        """The PTX virtual architecture version that was used during
+        compilation, in the format: 10*major + minor.
+        """
+        attr = driver.CU_FUNC_ATTRIBUTE_PTX_VERSION
+        return driver.funcGetAttribute(attr, self.ptr)
+
+    @property
+    def binary_version(self):
+        """The binary architecture version that was used during compilation,
+        in the format: 10*major + minor.
+        """
+        attr = driver.CU_FUNC_ATTRIBUTE_BINARY_VERSION
+        return driver.funcGetAttribute(attr, self.ptr)
+
+    @property
+    def cache_mode_ca(self):
+        """Indicates whether option "-Xptxas --dlcm=ca" was set during
+        compilation.
+        """
+        attr = driver.CU_FUNC_ATTRIBUTE_CACHE_MODE_CA
+        return driver.funcGetAttribute(attr, self.ptr)
+
+    @property
+    def max_dynamic_shared_size_bytes(self):
+        """The maximum dynamically-allocated shared memory size in bytes that
+        can be used by the function. Can be set.
+        """
+        attr = driver.CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES
+        return driver.funcGetAttribute(attr, self.ptr)
+
+    @max_dynamic_shared_size_bytes.setter
+    def max_dynamic_shared_size_bytes(self, bytes):
+        attr = driver.CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES
+        driver.funcSetAttribute(self.ptr, attr, bytes)
+
+    @property
+    def preferred_shared_memory_carveout(self):
+        """On devices that have a unified L1 cache and shared memory,
+        indicates the fraction to be used for shared memory as a
+        `percentage` of the total. If the fraction does not exactly equal a
+        supported shared memory capacity, then the next larger supported
+        capacity is used. Can be set.
+        """
+        attr = driver.CU_FUNC_ATTRIBUTE_PREFERRED_SHARED_MEMORY_CARVEOUT
+        return driver.funcGetAttribute(attr, self.ptr)
+
+    @preferred_shared_memory_carveout.setter
+    def preferred_shared_memory_carveout(self, fraction):
+        attr = driver.CU_FUNC_ATTRIBUTE_PREFERRED_SHARED_MEMORY_CARVEOUT
+        driver.funcSetAttribute(self.ptr, attr, fraction)
+
 
 cdef class Module:
 

--- a/docs/source/reference/kernel.rst
+++ b/docs/source/reference/kernel.rst
@@ -10,3 +10,4 @@ Custom kernels
    cupy.RawKernel
    cupy.RawModule
    cupy.fuse
+   cupy.cuda.Function

--- a/docs/source/tutorial/kernel.rst
+++ b/docs/source/tutorial/kernel.rst
@@ -224,8 +224,8 @@ Raw kernels operating on complex-valued arrays can be created as well:
 
 Note that while we encourage the usage of ``complex<T>`` types for complex numbers (available by including ``<cupy/complex.cuh>`` as shown above), for CUDA codes already written using functions from ``cuComplex.h`` there is no need to make the conversion yourself: just set the option ``translate_cucomplex=True`` when creating a :class:`~cupy.RawKernel` instance.
 
-The CUDA kernel attributes can be retrieved by either accessing the :attr:`~cupy.RawKernel.attributes` dictionary,
-or by accessing the :class:`~cupy.RawKernel` object's attributes directly; the latter can also be used to set certain
+The CUDA kernel attributes can be retrieved by either accessing the :attr:`~cupy.RawKernel.function.attributes` dictionary,
+or by accessing the :attr:`~cupy.RawKernel.function` object's (:class:`~cupy.cuda.Function`) attributes directly; the latter can also be used to set certain
 attributes:
 
 .. doctest::
@@ -237,12 +237,12 @@ attributes:
    ...     y[tid] = x1[tid] + x2[tid];
    ... }
    ... ''', 'my_add')
-   >>> add_kernel.attributes  # doctest: +SKIP
+   >>> add_kernel.function.attributes  # doctest: +SKIP
    {'max_threads_per_block': 1024, 'shared_size_bytes': 0, 'const_size_bytes': 0, 'local_size_bytes': 0, 'num_regs': 10, 'ptx_version': 70, 'binary_version': 70, 'cache_mode_ca': 0, 'max_dynamic_shared_size_bytes': 49152, 'preferred_shared_memory_carveout': -1}
-   >>> add_kernel.max_dynamic_shared_size_bytes  # doctest: +SKIP
+   >>> add_kernel.function.max_dynamic_shared_size_bytes  # doctest: +SKIP
    49152
-   >>> add_kernel.max_dynamic_shared_size_bytes = 50000  # set a new value for the attribute  # doctest: +SKIP
-   >>> add_kernel.max_dynamic_shared_size_bytes  # doctest: +SKIP
+   >>> add_kernel.function.max_dynamic_shared_size_bytes = 50000  # set a new value for the attribute  # doctest: +SKIP
+   >>> add_kernel.function.max_dynamic_shared_size_bytes  # doctest: +SKIP
    50000
 
 Dynamical parallelism is supported by :class:`~cupy.RawKernel`. You just need to provide the linking flag (such as ``-dc``) to :class:`~cupy.RawKernel`'s ``options`` arugment. The static CUDA device runtime library (``cudadevrt``) is automatically discovered by CuPy. For further detail, see `CUDA Toolkit's documentation`_.

--- a/tests/cupy_tests/core_tests/test_raw.py
+++ b/tests/cupy_tests/core_tests/test_raw.py
@@ -367,6 +367,22 @@ class TestRaw(unittest.TestCase):
                 backend=self.backend)
         assert 'CUDA_ERROR_FILE_NOT_FOUND' in str(ex.value)
 
+    def test_kernel_no_name(self):
+        with pytest.raises(ValueError):
+            cupy.RawKernel(
+                code=_test_source1)
+
+    def test_kernel_neither_code_or_kernel(self):
+        with pytest.raises(TypeError):
+            cupy.RawKernel(name='')
+
+    def test_kernel_both_code_and_kernel(self):
+        with pytest.raises(TypeError):
+            cupy.RawKernel(
+                code=_test_source1,
+                name='',
+                kernel=self.kern.kernel)
+
     def test_module_neither_code_nor_path(self):
         with pytest.raises(TypeError):
             cupy.RawModule()

--- a/tests/cupy_tests/core_tests/test_raw.py
+++ b/tests/cupy_tests/core_tests/test_raw.py
@@ -311,7 +311,7 @@ class TestRaw(unittest.TestCase):
         assert cupy.allclose(y, x1 + x2)
 
     def test_kernel_attributes(self):
-        attrs = self.kern.attributes
+        attrs = self.kern.kernel.attributes
         for attribute in ['binary_version',
                           'cache_mode_ca',
                           'const_size_bytes',
@@ -323,9 +323,9 @@ class TestRaw(unittest.TestCase):
                           'ptx_version',
                           'shared_size_bytes']:
             assert attribute in attrs
-        assert self.kern.num_regs > 0
-        assert self.kern.max_threads_per_block > 0
-        assert self.kern.shared_size_bytes == 0
+        assert self.kern.kernel.num_regs > 0
+        assert self.kern.kernel.max_threads_per_block > 0
+        assert self.kern.kernel.shared_size_bytes == 0
 
     def test_module(self):
         module = self.mod2

--- a/tests/cupy_tests/core_tests/test_raw.py
+++ b/tests/cupy_tests/core_tests/test_raw.py
@@ -367,22 +367,6 @@ class TestRaw(unittest.TestCase):
                 backend=self.backend)
         assert 'CUDA_ERROR_FILE_NOT_FOUND' in str(ex.value)
 
-    def test_kernel_no_name(self):
-        with pytest.raises(ValueError):
-            cupy.RawKernel(
-                code=_test_source1)
-
-    def test_kernel_neither_code_or_kernel(self):
-        with pytest.raises(TypeError):
-            cupy.RawKernel(name='')
-
-    def test_kernel_both_code_and_kernel(self):
-        with pytest.raises(TypeError):
-            cupy.RawKernel(
-                code=_test_source1,
-                name='',
-                kernel=self.kern.kernel)
-
     def test_module_neither_code_nor_path(self):
         with pytest.raises(TypeError):
             cupy.RawModule()


### PR DESCRIPTION
Similar approach to #2784 
prevents to instantiate a `RawKernel` object without code, or an actual kernel obtained from the compilation backend.

Thanks to @niboshi 