### PR TITLE
Fix `linspace(..., num=1, endpoint=False, retstep=True)`

### DIFF
--- a/cupy/creation/ranges.py
+++ b/cupy/creation/ranges.py
@@ -87,13 +87,12 @@ def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None):
         dtype = float
 
     ret = cupy.empty((num,), dtype=dtype)
-    if num == 0:
-        step = float('nan')
-    elif num == 1:
-        ret.fill(start)
+    div = (num - 1) if endpoint else num
+    if div <= 0:
+        if num > 0:
+            ret.fill(start)
         step = float('nan')
     else:
-        div = (num - 1) if endpoint else num
         step = float(stop - start) / div
         stop = float(stop)
 
@@ -105,6 +104,7 @@ def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None):
             _linspace_ufunc(start, step, ret, casting='unsafe')
 
         if endpoint:
+            # num == div + 1 > 1
             ret[-1] = stop
 
     if retstep:

--- a/cupy/creation/ranges.py
+++ b/cupy/creation/ranges.py
@@ -104,7 +104,7 @@ def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None):
             _linspace_ufunc(start, step, ret, casting='unsafe')
 
         if endpoint:
-            # num == div + 1 > 1
+            # Here num == div + 1 > 1 is ensured.
             ret[-1] = stop
 
     if retstep:

--- a/tests/cupy_tests/creation_tests/test_ranges.py
+++ b/tests/cupy_tests/creation_tests/test_ranges.py
@@ -89,13 +89,14 @@ class TestRanges(unittest.TestCase):
         self.assertTrue(math.isnan(step))
         return x
 
-    @testing.with_requires('numpy>=1.10')
+    @testing.with_requires('numpy>=1.18')
     @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_array_equal()
     def test_linspace_one_num_no_endopoint_with_retstep(self, xp, dtype):
-        x, step = xp.linspace(0, 10, 1, dtype=dtype, endpoint=False,
+        start, stop = 3, 7
+        x, step = xp.linspace(start, stop, 1, dtype=dtype, endpoint=False,
                               retstep=True)
-        self.assertTrue(math.isnan(step))
+        self.assertEqual(step, stop - start)
         return x
 
     @testing.for_all_dtypes(no_bool=True)


### PR DESCRIPTION
`numpy.linspace(start, stop, num=1, endpoint=False, retstep=True)[1]` returns `stop - start` from 1.18.