### PR TITLE
`MemoryPointer.__repr__`

### DIFF
--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -287,6 +287,11 @@ cdef class MemoryPointer:
         """Returns the pointer value."""
         return self.ptr
 
+    def __repr__(self):
+        return '<{} 0x{:x} device={} mem={!r}>'.format(
+            self.__class__.__name__,
+            self.ptr, self.device_id, self.mem)
+
     @property
     def device(self):
         return device.Device(self.device_id)


### PR DESCRIPTION
It might be useful for debugging to include the pointer value etc.
```
>>> import cupy
>>> a = cupy.array([1, 2, 3], 'float32')
>>> a.data
<MemoryPointer 0x7f9be0800000 device=0 mem=<cupy.cuda.memory.PooledMemory object at 0x7f9cde8edb30>>
```