### PR TITLE
Added `out` parameter to `cupy.concatenate` and `cupy.stack`

### DIFF
--- a/cupy/core/_routines_manipulation.pxd
+++ b/cupy/core/_routines_manipulation.pxd
@@ -29,5 +29,6 @@ cpdef ndarray _reshape(ndarray self,
                        const vector.vector[Py_ssize_t] &shape_spec)
 cpdef ndarray _T(ndarray self)
 cpdef ndarray _transpose(ndarray self, const vector.vector[Py_ssize_t] &axes)
-cpdef ndarray _concatenate(list arrays, Py_ssize_t axis, tuple shape, dtype)
-cpdef ndarray concatenate_method(tup, int axis)
+cpdef ndarray _concatenate(
+    list arrays, Py_ssize_t axis, tuple shape, ndarray out)
+cpdef ndarray concatenate_method(tup, int axis, ndarray out=*)

--- a/cupy/core/_routines_manipulation.pyx
+++ b/cupy/core/_routines_manipulation.pyx
@@ -531,7 +531,7 @@ cpdef ndarray _repeat(ndarray a, repeats, axis=None):
     return ret
 
 
-cpdef ndarray concatenate_method(tup, int axis):
+cpdef ndarray concatenate_method(tup, int axis, ndarray out=None):
     cdef int ndim, a_ndim
     cdef int i
     cdef ndarray a
@@ -577,15 +577,32 @@ cpdef ndarray concatenate_method(tup, int axis):
     if not have_same_types:
         dtype = functools.reduce(numpy.promote_types,
                                  set([a.dtype for a in arrays]))
-    return _concatenate(arrays, axis, tuple(shape), dtype)
+
+    shape_t = tuple(shape)
+    if out is None:
+        out = ndarray(shape_t, dtype=dtype)
+    else:
+        if len(out.shape) != len(shape_t):
+            raise ValueError('Output array has wrong dimensionality')
+        if out.shape != shape_t:
+            raise ValueError('Output array is the wrong shape')
+        if out.dtype.kind != dtype.kind:
+            raise TypeError('Cannot cast scalar from dtype(\'{}\')'
+                            ' to dtype(\'{}\') according to the'
+                            ' rule \'same_kind\''.format(dtype, out.dtype))
+
+    return _concatenate(arrays, axis, shape_t, out)
 
 
-cpdef ndarray _concatenate(list arrays, Py_ssize_t axis, tuple shape, dtype):
-    cdef ndarray a, ret
+cpdef ndarray _concatenate(
+        list arrays, Py_ssize_t axis, tuple shape, ndarray out):
+    cdef ndarray a
     cdef Py_ssize_t i, aw, itemsize, axis_size
     cdef bint all_same_type, same_shape_and_contiguous
     # If arrays are large, Issuing each copy method is efficient.
     cdef Py_ssize_t threshold_size = 2 * 1024 * 1024
+
+    dtype = out.dtype
 
     if len(arrays) > 8:
         all_same_type = True
@@ -604,17 +621,16 @@ cpdef ndarray _concatenate(list arrays, Py_ssize_t axis, tuple shape, dtype):
 
         if all_same_type and total_bytes < threshold_size * len(arrays):
             return _concatenate_single_kernel(
-                arrays, axis, shape, dtype, same_shape_and_contiguous)
+                arrays, axis, shape, dtype, same_shape_and_contiguous, out)
 
-    ret = ndarray(shape, dtype=dtype)
     i = 0
     slice_list = [slice(None)] * len(shape)
     for a in arrays:
         aw = a._shape[axis]
         slice_list[axis] = slice(i, i + aw)
-        elementwise_copy(a, _indexing._simple_getitem(ret, slice_list))
+        elementwise_copy(a, _indexing._simple_getitem(out, slice_list))
         i += aw
-    return ret
+    return out
 
 
 cpdef Py_ssize_t size(ndarray a, axis=None) except? -1:
@@ -711,24 +727,25 @@ cdef _normalize_axis_tuple(axis, Py_ssize_t ndim,
 
 cdef ndarray _concatenate_single_kernel(
         list arrays, Py_ssize_t axis, tuple shape, dtype,
-        bint same_shape_and_contiguous):
-    cdef ndarray a, x, ret
+        bint same_shape_and_contiguous, ndarray out):
+    cdef ndarray a, x
     cdef Py_ssize_t base, cum, ndim
     cdef int i, j
     cdef Py_ssize_t[:] ptrs
     cdef Py_ssize_t[:] cum_sizes
     cdef Py_ssize_t[:, :] x_strides
 
+    assert out is not None
+
     ptrs = numpy.ndarray(len(arrays), numpy.int64)
     for i, a in enumerate(arrays):
         ptrs[i] = a.data.ptr
     x = core.array(ptrs)
 
-    ret = core.ndarray(shape, dtype=dtype)
     if same_shape_and_contiguous:
         base = internal.prod_sequence(shape[axis:]) // len(arrays)
-        _concatenate_kernel_same_size(x, base, ret)
-        return ret
+        _concatenate_kernel_same_size(x, base, out)
+        return out
 
     ndim = len(shape)
     x_strides = numpy.ndarray((len(arrays), ndim), numpy.int64)
@@ -741,8 +758,8 @@ cdef ndarray _concatenate_single_kernel(
         cum += <int>a._shape[axis]
 
     _concatenate_kernel(
-        x, axis, core.array(cum_sizes), core.array(x_strides), ret)
-    return ret
+        x, axis, core.array(cum_sizes), core.array(x_strides), out)
+    return out
 
 
 cdef _concatenate_kernel_same_size = ElementwiseKernel(

--- a/cupy/manipulation/join.py
+++ b/cupy/manipulation/join.py
@@ -32,7 +32,7 @@ def column_stack(tup):
     return concatenate(lst, axis=1)
 
 
-def concatenate(tup, axis=0):
+def concatenate(tup, axis=0, out=None):
     """Joins arrays along an axis.
 
     Args:
@@ -41,6 +41,7 @@ def concatenate(tup, axis=0):
         axis (int or None): The axis to join arrays along.
             If axis is None, arrays are flattened before use.
             Default is 0.
+        out (cupy.ndarray): Output array.
 
     Returns:
         cupy.ndarray: Joined array.
@@ -51,7 +52,7 @@ def concatenate(tup, axis=0):
     if axis is None:
         tup = [m.ravel() for m in tup]
         axis = 0
-    return core.concatenate_method(tup, axis)
+    return core.concatenate_method(tup, axis, out)
 
 
 def dstack(tup):
@@ -113,12 +114,13 @@ def vstack(tup):
     return concatenate([cupy.atleast_2d(m) for m in tup], 0)
 
 
-def stack(tup, axis=0):
+def stack(tup, axis=0, out=None):
     """Stacks arrays along a new axis.
 
     Args:
         tup (sequence of arrays): Arrays to be stacked.
         axis (int): Axis along which the arrays are stacked.
+        out (cupy.ndarray): Output array.
 
     Returns:
         cupy.ndarray: Stacked array.
@@ -131,7 +133,7 @@ def stack(tup, axis=0):
             raise core._AxisError(
                 'axis {} out of bounds [{}, {}]'.format(
                     axis, -x.ndim - 1, x.ndim))
-    return concatenate([cupy.expand_dims(x, axis) for x in tup], axis)
+    return concatenate([cupy.expand_dims(x, axis) for x in tup], axis, out)
 
 
 def _get_positive_axis(ndim, axis):

--- a/tests/cupy_tests/manipulation_tests/test_join.py
+++ b/tests/cupy_tests/manipulation_tests/test_join.py
@@ -138,6 +138,49 @@ class TestJoin(unittest.TestCase):
         with self.assertRaises(ValueError):
             cupy.concatenate((a, b, c))
 
+    @testing.for_all_dtypes(name='dtype')
+    @testing.numpy_cupy_array_equal()
+    def test_concatenate_out(self, xp, dtype):
+        a = testing.shaped_arange((3, 4), xp, dtype)
+        b = testing.shaped_reverse_arange((3, 4), xp, dtype)
+        c = testing.shaped_arange((3, 4), xp, dtype)
+        out = xp.zeros((3, 12), dtype=dtype)
+        xp.concatenate((a, b, c), axis=1, out=out)
+        return out
+
+    @testing.numpy_cupy_array_equal()
+    def test_concatenate_out_same_kind(self, xp):
+        a = testing.shaped_arange((3, 4), xp, xp.float64)
+        b = testing.shaped_reverse_arange((3, 4), xp, xp.float64)
+        c = testing.shaped_arange((3, 4), xp, xp.float64)
+        out = xp.zeros((3, 12), dtype=xp.float32)
+        xp.concatenate((a, b, c), axis=1, out=out)
+        return out
+
+    @testing.numpy_cupy_raises(accept_error=ValueError)
+    def test_concatenate_out_invalid_shape(self, xp):
+        a = testing.shaped_arange((3, 4), xp, xp.float64)
+        b = testing.shaped_reverse_arange((3, 4), xp, xp.float64)
+        c = testing.shaped_arange((3, 4), xp, xp.float64)
+        out = xp.zeros((4, 10), dtype=xp.float64)
+        xp.concatenate((a, b, c), axis=1, out=out)
+
+    @testing.numpy_cupy_raises(accept_error=ValueError)
+    def test_concatenate_out_invalid_shape_2(self, xp):
+        a = testing.shaped_arange((3, 4), xp, xp.float64)
+        b = testing.shaped_reverse_arange((3, 4), xp, xp.float64)
+        c = testing.shaped_arange((3, 4), xp, xp.float64)
+        out = xp.zeros((2, 2, 10), dtype=xp.float64)
+        xp.concatenate((a, b, c), axis=1, out=out)
+
+    @testing.numpy_cupy_raises(accept_error=TypeError)
+    def test_concatenate_out_invalid_dtype(self, xp):
+        a = testing.shaped_arange((3, 4), xp, xp.float64)
+        b = testing.shaped_reverse_arange((3, 4), xp, xp.float64)
+        c = testing.shaped_arange((3, 4), xp, xp.float64)
+        out = xp.zeros((3, 12), dtype=xp.int64)
+        xp.concatenate((a, b, c), axis=1, out=out)
+
     @testing.numpy_cupy_array_equal()
     def test_dstack(self, xp):
         a = testing.shaped_arange((1, 3, 2), xp)
@@ -224,7 +267,7 @@ class TestJoin(unittest.TestCase):
         a = testing.shaped_arange((2, 3), xp)
         return xp.stack((a, a), axis=2)
 
-    @testing.numpy_cupy_raises()
+    @testing.numpy_cupy_raises(accept_error=ValueError)
     def test_stack_with_axis_over(self, xp):
         a = testing.shaped_arange((2, 3), xp)
         return xp.stack((a, a), axis=3)
@@ -250,13 +293,13 @@ class TestJoin(unittest.TestCase):
         cupy.testing.assert_array_equal(s[:, :, 0], a)
         cupy.testing.assert_array_equal(s[:, :, 1], a)
 
-    @testing.numpy_cupy_raises()
+    @testing.numpy_cupy_raises(accept_error=ValueError)
     def test_stack_different_shape(self, xp):
         a = testing.shaped_arange((2, 3), xp)
         b = testing.shaped_arange((2, 4), xp)
         return xp.stack([a, b])
 
-    @testing.numpy_cupy_raises()
+    @testing.numpy_cupy_raises(accept_error=ValueError)
     def test_stack_out_of_bounds1(self, xp):
         a = testing.shaped_arange((2, 3), xp)
         return xp.stack([a, a], axis=3)
@@ -265,3 +308,45 @@ class TestJoin(unittest.TestCase):
         a = testing.shaped_arange((2, 3), cupy)
         with self.assertRaises(cupy.core._AxisError):
             return cupy.stack([a, a], axis=3)
+
+    @testing.for_all_dtypes(name='dtype')
+    @testing.numpy_cupy_array_equal()
+    def test_stack_out(self, xp, dtype):
+        a = testing.shaped_arange((3, 4), xp, dtype)
+        b = testing.shaped_reverse_arange((3, 4), xp, dtype)
+        c = testing.shaped_arange((3, 4), xp, dtype)
+        out = xp.zeros((3, 3, 4), dtype=dtype)
+        xp.stack((a, b, c), axis=1, out=out)
+        return out
+
+    @testing.numpy_cupy_array_equal()
+    def test_stack_out_same_kind(self, xp):
+        a = testing.shaped_arange((3, 4), xp, xp.float64)
+        b = testing.shaped_reverse_arange((3, 4), xp, xp.float64)
+        c = testing.shaped_arange((3, 4), xp, xp.float64)
+        out = xp.zeros((3, 3, 4), dtype=xp.float32)
+        xp.stack((a, b, c), axis=1, out=out)
+        return out
+
+    def test_stack_out_invalid_shape(self, xp):
+        a = testing.shaped_arange((3, 4), xp, xp.float64)
+        b = testing.shaped_reverse_arange((3, 4), xp, xp.float64)
+        c = testing.shaped_arange((3, 4), xp, xp.float64)
+        out = xp.zeros((3, 3, 10), dtype=xp.float64)
+        xp.stack((a, b, c), axis=1, out=out)
+
+    @testing.numpy_cupy_raises(accept_error=ValueError)
+    def test_stack_out_invalid_shape_2(self, xp):
+        a = testing.shaped_arange((3, 4), xp, xp.float64)
+        b = testing.shaped_reverse_arange((3, 4), xp, xp.float64)
+        c = testing.shaped_arange((3, 4), xp, xp.float64)
+        out = xp.zeros((3, 3, 3, 10), dtype=xp.float64)
+        xp.stack((a, b, c), axis=1, out=out)
+
+    @testing.numpy_cupy_raises(accept_error=TypeError)
+    def test_stack_out_invalid_dtype(self, xp):
+        a = testing.shaped_arange((3, 4), xp, xp.float64)
+        b = testing.shaped_reverse_arange((3, 4), xp, xp.float64)
+        c = testing.shaped_arange((3, 4), xp, xp.float64)
+        out = xp.zeros((3, 3, 4), dtype=xp.int64)
+        xp.stack((a, b, c), axis=1, out=out)

--- a/tests/cupy_tests/manipulation_tests/test_join.py
+++ b/tests/cupy_tests/manipulation_tests/test_join.py
@@ -328,6 +328,7 @@ class TestJoin(unittest.TestCase):
         xp.stack((a, b, c), axis=1, out=out)
         return out
 
+    @testing.numpy_cupy_raises(accept_error=ValueError)
     def test_stack_out_invalid_shape(self, xp):
         a = testing.shaped_arange((3, 4), xp, xp.float64)
         b = testing.shaped_reverse_arange((3, 4), xp, xp.float64)


### PR DESCRIPTION
Numpy supports `out` for both `stack` and `concatenate`.
This PR matches the behavior

https://docs.scipy.org/doc/numpy/reference/generated/numpy.stack.html
https://docs.scipy.org/doc/numpy/reference/generated/numpy.concatenate.html