### PR TITLE
A nit-picking code fix

### DIFF
--- a/cupy/fft/fft.py
+++ b/cupy/fft/fft.py
@@ -740,9 +740,9 @@ def irfftn(a, s=None, axes=None, norm=None):
 
     .. seealso:: :func:`numpy.fft.irfftn`
     """
-    if (10020 >= cupy.cuda.runtime.runtimeGetVersion() >= 10010 and
-            int(cupy.cuda.device.get_compute_capability()) < 70 and
-            _size_last_transform_axis(a.shape, s, axes) == 2):
+    if (10020 >= cupy.cuda.runtime.runtimeGetVersion() >= 10010
+            and int(cupy.cuda.device.get_compute_capability()) < 70
+            and _size_last_transform_axis(a.shape, s, axes) == 2):
         warnings.warn('Output of irfftn might not be correct due to issue '
                       'of cuFFT in CUDA 10.1/10.2 on Pascal or older GPUs.')
 

--- a/tests/cupy_tests/fft_tests/test_fft.py
+++ b/tests/cupy_tests/fft_tests/test_fft.py
@@ -638,10 +638,11 @@ class TestRfftn(unittest.TestCase):
     @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
                                  contiguous_check=False)
     def test_irfftn(self, xp, dtype):
-        if (10020 >= cupy.cuda.runtime.runtimeGetVersion() >= 10010 and
-                int(cupy.cuda.device.get_compute_capability()) < 70 and
-                _size_last_transform_axis(self.shape, self.s, self.axes) == 2):
-            pytest.skip('work-around for cuFFT issue')
+        if (10020 >= cupy.cuda.runtime.runtimeGetVersion() >= 10010
+                and int(cupy.cuda.device.get_compute_capability()) < 70
+                and _size_last_transform_axis(
+                    self.shape, self.s, self.axes) == 2):
+            raise unittest.SkipTest('work-around for cuFFT issue')
 
         a = testing.shaped_random(self.shape, xp, dtype)
         out = xp.fft.irfftn(a, s=self.s, axes=self.axes, norm=self.norm)


### PR DESCRIPTION
* Place operators after new lines
* `raise unittest.SkipTest()` instead of `pytest.skip()`