### PR TITLE
Fix GMM example for matplotlib 3

### DIFF
--- a/examples/gmm/gmm.py
+++ b/examples/gmm/gmm.py
@@ -97,7 +97,7 @@ def draw(X, pred, means, covariances, output):
         labels = X[pred == i]
         if xp is cupy:
             labels = labels.get()
-        plt.scatter(labels[:, 0], labels[:, 1], c=np.random.rand(3))
+        plt.scatter(labels[:, 0], labels[:, 1], c=np.random.rand(1, 3))
     if xp is cupy:
         means = means.get()
         covariances = covariances.get()

--- a/examples/gmm/gmm.py
+++ b/examples/gmm/gmm.py
@@ -2,9 +2,9 @@ import argparse
 import contextlib
 import time
 
-from matplotlib import mlab
 import matplotlib.pyplot as plt
 import numpy as np
+from scipy import stats
 
 import cupy
 
@@ -107,9 +107,8 @@ def draw(X, pred, means, covariances, output):
     y = np.linspace(-5, 5, 1000)
     X, Y = np.meshgrid(x, y)
     for i in range(2):
-        Z = mlab.bivariate_normal(X, Y, np.sqrt(covariances[i][0]),
-                                  np.sqrt(covariances[i][1]),
-                                  means[i][0], means[i][1])
+        dist = stats.multivariate_normal(means[i], covariances[i])
+        Z = dist.pdf(np.stack([X, Y], axis=-1))
         plt.contour(X, Y, Z)
     plt.savefig(output)
 


### PR DESCRIPTION
On the GMM (Gaussian Mixture Model) example, fix the following.
- Use `scipy.stats` to compute bivariate normal.  `matplotlab.mlab.bivariate_normal` is deprecated since matplotlib 2.2 and is removed since 3.0
- Surpress the warning message:
  > 'c' argument looks like a single numeric RGB or RGBA sequence, which should be avoided as value-mapping will have precedence in case its length matches with 'x' & 'y'.  Please use a 2-D array with a single row if you really want to specify the same RGB or RGBA value for all points.

```
% python gmm.py --output-image=tmp.png
Running CPU...
train_accuracy : 92.143100
test_accuracy : 92.000000
 CPU :  1.087882 sec
Running GPU...
train_accuracy : 92.030900
test_accuracy : 92.000000
 GPU :  0.651976 sec
% imgcat tmp.png
```
![tmp.png](https://user-images.githubusercontent.com/1964281/72984780-ce0fa580-3e27-11ea-8459-5431b16e98fb.png)