### PR TITLE
[backport] Fix an issue using non-existing attribute in cub.pyx

### DIFF
--- a/cupy/cuda/cub.pyx
+++ b/cupy/cuda/cub.pyx
@@ -96,7 +96,7 @@ cpdef Py_ssize_t _preprocess_array(ndarray arr, tuple reduce_axis,
     return contiguous_size
 
 
-def device_reduce(ndarray x, int op, tuple out_axis, out=None,
+def device_reduce(ndarray x, op, tuple out_axis, out=None,
                   bint keepdims=False):
     cdef ndarray y
     cdef memory.MemoryPointer ws
@@ -156,7 +156,7 @@ def device_reduce(ndarray x, int op, tuple out_axis, out=None,
     return y
 
 
-def device_segmented_reduce(ndarray x, int op, tuple reduce_axis,
+def device_segmented_reduce(ndarray x, op, tuple reduce_axis,
                             tuple out_axis, out=None, bint keepdims=False):
     # if import at the top level, a segfault would happen when import cupy!
     from cupy.creation.ranges import arange


### PR DESCRIPTION
Backport of #2985. 

While the problematic commit f7320d2 does not show up in the `v7` branch, for some reason (likely due to a backport?) the bug still appears in `v7`. The difference between this PR and #2985 is that `nogil` is not present in `v7`, so we don't need to explicitly cast `op` to `int` in the CUB calls.

cc: @emcastillo @anaruse 