### PR TITLE
Fix `fill_diaogonal`

### DIFF
--- a/cupy/core/raw.pyx
+++ b/cupy/core/raw.pyx
@@ -204,8 +204,9 @@ cdef class RawKernel:
 def _get_raw_kernel(code, name, options=(), backend='nvrtc',
                     translate_cucomplex=False,
                     enable_cooperative_groups=False):
+    # WIP: temporarily prepend cupy headers
     module = cupy.core.core.compile_with_cache(
-        code, options, prepend_cupy_headers=False, backend=backend,
+        code, options, prepend_cupy_headers=True, backend=backend,
         translate_cucomplex=translate_cucomplex,
         enable_cooperative_groups=enable_cooperative_groups)
     return module.get_function(name)


### PR DESCRIPTION
Fix #2970 .

`cupy.fill_diagonal()` is currently implemented with `cupy.ndarray.ravel()` as opposed to NumPy that implements `numpy.fill_diagonal()` with `numpy.ndarray.flat`, that keeps off properly filling the value in the main diagonal of an array.

This PR fixes the problem with providing the counterpart of `numpy.flatiter` to touch an array by means of the flatten index space with 1D basic slicing.
