### PR TITLE
Fix `fill_diagonal`

### DIFF
--- a/cupy/indexing/insert.py
+++ b/cupy/indexing/insert.py
@@ -104,6 +104,7 @@ def _fill_diagonal_kernel(a, val):
     return __fill_diagonal_kernel(
         _scalar.get_typename(a.dtype), a.ndim, val.ndim)
 
+
 def fill_diagonal(a, val, wrap=False):
     """Fills the main diagonal of the given array of any dimensionality.
 
@@ -153,7 +154,7 @@ def fill_diagonal(a, val, wrap=False):
             raise ValueError(
                 'Array device must be same as the current '
                 'device: array device = %d while current = %d'
-                % (arr.data.device_id, device_id))
+                % (arr.data.device_id, dev_id))
 
     fill_diagonal_kernel = _fill_diagonal_kernel(a, val)
 

--- a/cupy/indexing/insert.py
+++ b/cupy/indexing/insert.py
@@ -129,7 +129,7 @@ def fill_diagonal(a, val, wrap=False):
     # The followings are imported from the original numpy
     if a.ndim < 2:
         raise ValueError('array must be at least 2-d')
-    end = None
+    end = a.size
     if a.ndim == 2:
         step = a.shape[1] + 1
         if not wrap:

--- a/cupy/indexing/insert.py
+++ b/cupy/indexing/insert.py
@@ -139,10 +139,7 @@ def fill_diagonal(a, val, wrap=False):
             raise ValueError('All dimensions of input must be of equal length')
         step = 1 + numpy.cumprod(a.shape[:-1]).sum()
 
-    if not isinstance(val, cupy.ndarray):
-        val = cupy.array(val, dtype=a.dtype)
-    else:
-        val = val.astype(a.dtype, copy=False)
+    val = cupy.asarray(val, dtype=a.dtype)
 
     dev_id = device.get_device_id()
     for arr in [a, val]:

--- a/cupy/indexing/insert.py
+++ b/cupy/indexing/insert.py
@@ -76,7 +76,8 @@ def put(a, ind, v, mode='wrap'):
 
 
 _fill_diagonal_template = string.Template(r'''
-#include <cupy/carray.cuh>,
+#include <cupy/complex.cuh>
+#include <cupy/carray.cuh>
 extern "C" __global__
 void cupy_fill_diagonal(CArray<${type}, ${a_ndim}> a,
                         CIndexer<${a_ndim}> a_ind,

--- a/tests/cupy_tests/indexing_tests/test_insert.py
+++ b/tests/cupy_tests/indexing_tests/test_insert.py
@@ -1,6 +1,7 @@
 import unittest
 
 import numpy
+import pytest
 
 from cupy import testing
 
@@ -123,6 +124,16 @@ class TestFillDiagonal(unittest.TestCase):
     def test_fill_diagonal(self, xp, dtype):
         a = testing.shaped_arange(self.shape, xp, dtype)
         xp.fill_diagonal(a, val=self.val, wrap=self.wrap)
+        return a
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_columnar_slice(self, xp, dtype):  # see cupy#2970
+        if self.shape == (2, 2, 2):
+            pytest.skip(
+                'The length of each dimension must be the same after slicing')
+        a = testing.shaped_arange(self.shape, xp, dtype)
+        xp.fill_diagonal(a[:,1:], val=self.val, wrap=self.wrap)
         return a
 
     @testing.for_all_dtypes()

--- a/tests/cupy_tests/indexing_tests/test_insert.py
+++ b/tests/cupy_tests/indexing_tests/test_insert.py
@@ -113,17 +113,24 @@ class TestPutRaises(unittest.TestCase):
 
 @testing.parameterize(*testing.product({
     'shape': [(3, 3), (2, 2, 2), (3, 5), (5, 3)],
-    'val': [1, 0],
+    'val': [1, 0, (2,), (2, 2)],
     'wrap': [True, False],
 }))
 @testing.gpu
 class TestFillDiagonal(unittest.TestCase):
 
+    def _compute_val(self, xp):
+        if type(self.val) is int:
+            return self.val
+        else:
+            return xp.arange(numpy.prod(self.val)).reshape(self.val)
+
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_fill_diagonal(self, xp, dtype):
         a = testing.shaped_arange(self.shape, xp, dtype)
-        xp.fill_diagonal(a, val=self.val, wrap=self.wrap)
+        val = self._compute_val(xp)
+        xp.fill_diagonal(a, val=val, wrap=self.wrap)
         return a
 
     @testing.for_all_dtypes()
@@ -133,11 +140,13 @@ class TestFillDiagonal(unittest.TestCase):
             pytest.skip(
                 'The length of each dimension must be the same after slicing')
         a = testing.shaped_arange(self.shape, xp, dtype)
-        xp.fill_diagonal(a[:,1:], val=self.val, wrap=self.wrap)
+        val = self._compute_val(xp)
+        xp.fill_diagonal(a[:, 1:], val=val, wrap=self.wrap)
         return a
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_raises()
     def test_1darray(self, xp, dtype):
         a = testing.shaped_arange(5, xp, dtype)
-        xp.fill_diagonal(a, val=self.val, wrap=self.wrap)
+        val = self._compute_val(xp)
+        xp.fill_diagonal(a, val=val, wrap=self.wrap)


### PR DESCRIPTION
Fix #2970 .

`cupy.fill_diagonal()` is currently implemented with `cupy.ndarray.ravel()` as opposed to NumPy that implements `numpy.fill_diagonal()` with `numpy.ndarray.flat`, that keeps off properly filling the value in the main diagonal of an array.

This PR fixes the problem with providing the counterpart of `numpy.flatiter` to touch an array by means of the flatten index space with 1D basic slicing.
