### PR TITLE
Fix `cupy.random.multivariate_normal`

### DIFF
--- a/cupy/random/distributions.py
+++ b/cupy/random/distributions.py
@@ -439,7 +439,7 @@ def negative_binomial(n, p, size=None, dtype=int):
 
 
 def multivariate_normal(mean, cov, size=None, check_valid='ignore',
-                        tol=1e-08, dtype=float):
+                        tol=1e-08, method='cholesky', dtype=float):
     """Multivariate normal distribution.
 
     Returns an array of samples drawn from the multivariate normal
@@ -462,6 +462,13 @@ def multivariate_normal(mean, cov, size=None, check_valid='ignore',
             matrix is not positive semidefinite.
         tol (float): Tolerance when checking the singular values in
             covariance matrix.
+        method : { 'cholesky', 'eigh', 'svd'}, optional
+            The cov input is used to compute a factor matrix A such that
+            ``A @ A.T = cov``. This argument is used to select the method
+            used to compute the factor matrix A. The default method 'svd' is
+            the fastest, while 'svd' is the slowest but more robust than
+            the fastest method. The method `eigh` uses eigen decomposition to
+            compute A and is faster than svd but slower than cholesky.
         dtype: Data type specifier. Only :class:`numpy.float32` and
             :class:`numpy.float64` types are allowed.
 

--- a/cupy/random/distributions.py
+++ b/cupy/random/distributions.py
@@ -475,6 +475,18 @@ def multivariate_normal(mean, cov, size=None, check_valid='ignore',
     Returns:
         cupy.ndarray: Samples drawn from the multivariate normal distribution.
 
+    .. note:: Default `method` is set to fastest, 'cholesky'. Cholesky
+        decomposition in CuPy will fail silently if the input covariance matrix
+        is not positive definite and give invalid results, unlike in numpy,
+        where an invalid covariance matrix will raise an exception. Setting
+        `check_valid` to 'raise' will replicate numpy behavior by checking
+        the input, but will also force device synchronization. If validity of
+        input is unknown, setting `method` to 'einh' or 'svd' and
+        `check_valid` to 'warn' will use cholesky decomposition for positive
+        definite matrices, and fallback to the specified `method` for other
+        matrices (i.e., positive semi-definite), and will warn if
+        decomposition is suspect.
+
     .. seealso:: :meth:`numpy.random.multivariate_normal
                  <numpy.random.mtrand.RandomState.multivariate_normal>`
 

--- a/cupy/random/distributions.py
+++ b/cupy/random/distributions.py
@@ -438,9 +438,8 @@ def negative_binomial(n, p, size=None, dtype=int):
     return rs.negative_binomial(n, p, size=size, dtype=dtype)
 
 
-def multivariate_normal(mean, cov, size=None, check_valid='ignore', tol=1e-8,
-                        dtype=float):
-    """(experimental) Multivariate normal distribution.
+def multivariate_normal(mean, cov, size=None, dtype=float):
+    """Multivariate normal distribution.
 
     Returns an array of samples drawn from the multivariate normal
     distribution. Its probability density function is defined as
@@ -458,15 +457,18 @@ def multivariate_normal(mean, cov, size=None, check_valid='ignore', tol=1e-8,
             symmetric and positive-semidefinite for proper sampling.
         size (int or tuple of ints): The shape of the array. If ``None``, a
             zero-dimensional array is generated.
-        check_valid ('warn', 'raise', 'ignore'): Behavior when the covariance
-            matrix is not positive semidefinite.
-        tol (float): Tolerance when checking the singular values in
-            covariance matrix.
         dtype: Data type specifier. Only :class:`numpy.float32` and
             :class:`numpy.float64` types are allowed.
 
     Returns:
         cupy.ndarray: Samples drawn from the multivariate normal distribution.
+
+    .. warning::
+    This function calls one or more cuSOLVER routine(s) which may yield
+    invalid results if input conditions are not met.
+    To detect these invalid results, you can set the `linalg`
+    configuration to a value that is not `ignore` in
+    :func:`cupyx.errstate` or :func:`cupyx.seterr`.
 
     .. seealso:: :meth:`numpy.random.multivariate_normal
                  <numpy.random.mtrand.RandomState.multivariate_normal>`

--- a/cupy/random/distributions.py
+++ b/cupy/random/distributions.py
@@ -437,7 +437,8 @@ def negative_binomial(n, p, size=None, dtype=int):
     return rs.negative_binomial(n, p, size=size, dtype=dtype)
 
 
-def multivariate_normal(mean, cov, size=None, dtype=float):
+def multivariate_normal(mean, cov, check_valid='ignore', tol=1e-08,
+                        size=None, dtype=float):
     """Multivariate normal distribution.
 
     Returns an array of samples drawn from the multivariate normal
@@ -456,25 +457,22 @@ def multivariate_normal(mean, cov, size=None, dtype=float):
             symmetric and positive-semidefinite for proper sampling.
         size (int or tuple of ints): The shape of the array. If ``None``, a
             zero-dimensional array is generated.
+        check_valid ('warn', 'raise', 'ignore'): Behavior when the covariance
+            matrix is not positive semidefinite.
+        tol (float): Tolerance when checking the singular values in
+            covariance matrix.
         dtype: Data type specifier. Only :class:`numpy.float32` and
             :class:`numpy.float64` types are allowed.
 
     Returns:
         cupy.ndarray: Samples drawn from the multivariate normal distribution.
 
-    .. warning::
-        This function calls one or more cuSOLVER routine(s) which may yield
-        invalid results if input conditions are not met.
-        To detect these invalid results, you can set the `linalg`
-        configuration to a value that is not `ignore` in
-        :func:`cupyx.errstate` or :func:`cupyx.seterr`.
-
     .. seealso:: :meth:`numpy.random.multivariate_normal
                  <numpy.random.mtrand.RandomState.multivariate_normal>`
 
     """
     rs = generator.get_random_state()
-    x = rs.multivariate_normal(mean, cov, size, dtype)
+    x = rs.multivariate_normal(mean, cov, check_valid, tol, size, dtype)
     return x
 
 

--- a/cupy/random/distributions.py
+++ b/cupy/random/distributions.py
@@ -465,8 +465,8 @@ def multivariate_normal(mean, cov, size=None, check_valid='ignore',
         method : { 'cholesky', 'eigh', 'svd'}, optional
             The cov input is used to compute a factor matrix A such that
             ``A @ A.T = cov``. This argument is used to select the method
-            used to compute the factor matrix A. The default method 'svd' is
-            the fastest, while 'svd' is the slowest but more robust than
+            used to compute the factor matrix A. The default method 'cholesky'
+            is the fastest, while 'svd' is the slowest but more robust than
             the fastest method. The method `eigh` uses eigen decomposition to
             compute A and is faster than svd but slower than cholesky.
         dtype: Data type specifier. Only :class:`numpy.float32` and
@@ -475,17 +475,17 @@ def multivariate_normal(mean, cov, size=None, check_valid='ignore',
     Returns:
         cupy.ndarray: Samples drawn from the multivariate normal distribution.
 
-    .. note:: Default `method` is set to fastest, 'cholesky'. Cholesky
-        decomposition in CuPy will fail silently if the input covariance matrix
-        is not positive definite and give invalid results, unlike in numpy,
-        where an invalid covariance matrix will raise an exception. Setting
-        `check_valid` to 'raise' will replicate numpy behavior by checking
-        the input, but will also force device synchronization. If validity of
-        input is unknown, setting `method` to 'einh' or 'svd' and
-        `check_valid` to 'warn' will use cholesky decomposition for positive
-        definite matrices, and fallback to the specified `method` for other
-        matrices (i.e., positive semi-definite), and will warn if
-        decomposition is suspect.
+    .. note:: Default `method` is set to fastest, 'cholesky', unlike numpy
+        which defaults to 'svd'. Cholesky decomposition in CuPy will fail
+        silently if the input covariance matrix is not positive definite and
+        give invalid results, unlike in numpy, where an invalid covariance
+        matrix will raise an exception. Setting `check_valid` to 'raise' will
+        replicate numpy behavior by checking the input, but will also force
+        device synchronization. If validity of input is unknown, setting
+        `method` to 'einh' or 'svd' and `check_valid` to 'warn' will use
+        cholesky decomposition for positive definite matrices, and fallback to
+        the specified `method` for other matrices (i.e., not positive
+        semi-definite), and will warn if decomposition is suspect.
 
     .. seealso:: :meth:`numpy.random.multivariate_normal
                  <numpy.random.mtrand.RandomState.multivariate_normal>`

--- a/cupy/random/distributions.py
+++ b/cupy/random/distributions.py
@@ -437,8 +437,8 @@ def negative_binomial(n, p, size=None, dtype=int):
     return rs.negative_binomial(n, p, size=size, dtype=dtype)
 
 
-def multivariate_normal(mean, cov, check_valid='ignore', tol=1e-08,
-                        size=None, dtype=float):
+def multivariate_normal(mean, cov, size=None, check_valid='ignore',
+                        tol=1e-08, dtype=float):
     """Multivariate normal distribution.
 
     Returns an array of samples drawn from the multivariate normal
@@ -472,7 +472,7 @@ def multivariate_normal(mean, cov, check_valid='ignore', tol=1e-08,
 
     """
     rs = generator.get_random_state()
-    x = rs.multivariate_normal(mean, cov, check_valid, tol, size, dtype)
+    x = rs.multivariate_normal(mean, cov, size, check_valid, tol, dtype)
     return x
 
 

--- a/cupy/random/distributions.py
+++ b/cupy/random/distributions.py
@@ -1,5 +1,6 @@
 import cupy
 from cupy.random import generator
+from cupy import util
 
 
 # TODO(beam2d): Implement many distributions
@@ -471,6 +472,7 @@ def multivariate_normal(mean, cov, size=None, check_valid='ignore',
                  <numpy.random.mtrand.RandomState.multivariate_normal>`
 
     """
+    util.experimental('cupy.random.multivariate_normal')
     rs = generator.get_random_state()
     x = rs.multivariate_normal(mean, cov, size, check_valid, tol, dtype)
     return x

--- a/cupy/random/distributions.py
+++ b/cupy/random/distributions.py
@@ -1,6 +1,5 @@
 import cupy
 from cupy.random import generator
-from cupy import util
 
 
 # TODO(beam2d): Implement many distributions
@@ -474,9 +473,8 @@ def multivariate_normal(mean, cov, size=None, dtype=float):
                  <numpy.random.mtrand.RandomState.multivariate_normal>`
 
     """
-    util.experimental('cupy.random.multivariate_normal')
     rs = generator.get_random_state()
-    x = rs.multivariate_normal(mean, cov, size, check_valid, tol, dtype)
+    x = rs.multivariate_normal(mean, cov, size, dtype)
     return x
 
 

--- a/cupy/random/distributions.py
+++ b/cupy/random/distributions.py
@@ -481,7 +481,8 @@ def multivariate_normal(mean, cov, size=None, check_valid='ignore',
     """
     util.experimental('cupy.random.multivariate_normal')
     rs = generator.get_random_state()
-    x = rs.multivariate_normal(mean, cov, size, check_valid, tol, dtype)
+    x = rs.multivariate_normal(mean, cov, size, check_valid, tol, method,
+                               dtype)
     return x
 
 

--- a/cupy/random/distributions.py
+++ b/cupy/random/distributions.py
@@ -463,11 +463,11 @@ def multivariate_normal(mean, cov, size=None, dtype=float):
         cupy.ndarray: Samples drawn from the multivariate normal distribution.
 
     .. warning::
-    This function calls one or more cuSOLVER routine(s) which may yield
-    invalid results if input conditions are not met.
-    To detect these invalid results, you can set the `linalg`
-    configuration to a value that is not `ignore` in
-    :func:`cupyx.errstate` or :func:`cupyx.seterr`.
+        This function calls one or more cuSOLVER routine(s) which may yield
+        invalid results if input conditions are not met.
+        To detect these invalid results, you can set the `linalg`
+        configuration to a value that is not `ignore` in
+        :func:`cupyx.errstate` or :func:`cupyx.seterr`.
 
     .. seealso:: :meth:`numpy.random.multivariate_normal
                  <numpy.random.mtrand.RandomState.multivariate_normal>`

--- a/cupy/random/generator.py
+++ b/cupy/random/generator.py
@@ -313,8 +313,8 @@ class RandomState(object):
         self.rk_seed += numpy.prod(size, dtype=self.rk_seed.dtype)
         return y
 
-    def multivariate_normal(self, mean, cov, check_valid='ignore', tol=1e-08,
-                            size=None, dtype=float):
+    def multivariate_normal(self, mean, cov, size=None, check_valid='ignore',
+                            tol=1e-08, dtype=float):
         """Returns an array of samples drawn from the multivariate normal
         distribution.
 

--- a/cupy/random/generator.py
+++ b/cupy/random/generator.py
@@ -404,7 +404,7 @@ class RandomState(object):
                                       "matrix is positive-semidefinite, set" +
                                       "'check_valid' to 'warn'")
 
-        x = self.standard_normal(shape=final_shape,
+        x = self.standard_normal(final_shape,
                                  dtype=dtype).reshape(-1, mean.shape[0])
         x = cupy.dot(decomp, x.T)
         x = x.T

--- a/cupy/random/generator.py
+++ b/cupy/random/generator.py
@@ -1,6 +1,5 @@
 import atexit
 import binascii
-import collections.abc
 import functools
 import hashlib
 import operator
@@ -338,7 +337,7 @@ class RandomState(object):
         cov = cupy.asarray(cov, dtype=dtype)
         if size is None:
             shape = []
-        elif isinstance(size, (int, long, np.integer)):
+        elif isinstance(size, (int, cupy.integer)):
             shape = [size]
         else:
             shape = size
@@ -349,8 +348,6 @@ class RandomState(object):
             raise ValueError('cov must be 2 dimensional and square')
         if mean.shape[0] != cov.shape[0]:
             raise ValueError('mean and cov must have same length')
-        
-        #shape += (len(mean),)
 
         final_shape = list(shape[:])
         final_shape.append(mean.shape[0])

--- a/cupy/random/generator.py
+++ b/cupy/random/generator.py
@@ -355,21 +355,20 @@ class RandomState(object):
             if check_valid != 'warn' and check_valid != 'raise':
                 raise ValueError(
                     "check_valid must equal 'warn', 'raise', or 'ignore'")
-            elif check_valid == 'warn':
-                with cupyx.errstate(linalg='raise'):
-                    try:
-                        decomp = cupy.linalg.cholesky(cov)
-                    except LinAlgError:
-                        warnings.warn("Matrix is not positive definite, " +
-                                      "trying einh decomposition.",
-                                      RuntimeWarning)
-                        (s, u) = cupy.linalg.einh(cov)
-                        psd = not cupy.any(s < -tol)
-                        decomp = u * cupy.sqrt(cupy.abs(s))
-                        if not psd:
-                            if check_valid == 'warn':
-                                warnings.warn("covariance is not positive-" +
-                                              "semidefinite.", RuntimeWarning)
+
+        if check_valid == 'warn':
+            with cupyx.errstate(linalg='raise'):
+                try:
+                    decomp = cupy.linalg.cholesky(cov)
+                except LinAlgError:
+                    (s, u) = cupy.linalg.eigh(cov)
+                    psd = not cupy.any(s < -tol)
+                    decomp = u * cupy.sqrt(cupy.abs(s))
+                    if not psd:
+                        if check_valid == 'warn':
+                            warnings.warn("covariance is not positive-" +
+                                          "semidefinite, output may be " +
+                                          "invalid.", RuntimeWarning)
         else:
             with cupyx.errstate(linalg=check_valid):
                 try:

--- a/cupy/random/generator.py
+++ b/cupy/random/generator.py
@@ -366,7 +366,8 @@ class RandomState(object):
         x = self.standard_normal(size=shape, dtype=dtype)
         chol = cupy.linalg.cholesky(cov)
         x = cupy.dot(chol, x.T)
-        x = mean[:, cupy.newaxis] + x
+        x = x.T
+        x += mean
         return x
 
     def negative_binomial(self, n, p, size=None, dtype=int):

--- a/cupy/random/generator.py
+++ b/cupy/random/generator.py
@@ -348,7 +348,7 @@ class RandomState(object):
         x = self.standard_normal(size=shape, dtype=dtype)
         chol = cupy.linalg.cholesky(cov)
         x = cupy.dot(chol, x.T)
-        x += mean
+        x = mean[:, np.newaxis] + x
         return x
 
     def negative_binomial(self, n, p, size=None, dtype=int):

--- a/cupy/random/generator.py
+++ b/cupy/random/generator.py
@@ -370,7 +370,7 @@ class RandomState(object):
         try:
             chol = cupy.linalg.cholesky(cov)
         except numpy.linalg.LinAlgError:
-            print("Matrix is not positive definite")
+            raise numpy.linalg.LinAlgError("Matrix is not positive definite")
         x = cupy.dot(chol, x.T)
         x = x.T
         x += mean

--- a/cupy/random/generator.py
+++ b/cupy/random/generator.py
@@ -317,11 +317,11 @@ class RandomState(object):
         distribution.
 
         .. warning::
-        This function calls one or more cuSOLVER routine(s) which may yield
-        invalid results if input conditions are not met.
-        To detect these invalid results, you can set the `linalg`
-        configuration to a value that is not `ignore` in
-        :func:`cupyx.errstate` or :func:`cupyx.seterr`.
+            This function calls one or more cuSOLVER routine(s) which may yield
+            invalid results if input conditions are not met.
+            To detect these invalid results, you can set the `linalg`
+            configuration to a value that is not `ignore` in
+            :func:`cupyx.errstate` or :func:`cupyx.seterr`.
 
         .. seealso::
             :func:`cupy.random.multivariate_normal` for full documentation,

--- a/cupy/random/generator.py
+++ b/cupy/random/generator.py
@@ -358,9 +358,9 @@ class RandomState(object):
             elif check_valid == 'warn':
                 with cupyx.errstate(linalg='raise'):
                     try:
-                        chol = cupy.linalg.cholesky(cov)
+                        decomp = cupy.linalg.cholesky(cov)
                     except LinAlgError:
-                        warnings.warn("Matrix is not positive definite, " + 
+                        warnings.warn("Matrix is not positive definite, " +
                                       "trying einh decomposition.",
                                       RuntimeWarning)
                         (s, u) = cupy.linalg.einh(cov)

--- a/cupy/random/generator.py
+++ b/cupy/random/generator.py
@@ -343,6 +343,10 @@ class RandomState(object):
         else:
             shape = size,
 
+        if method not in {'eigh', 'svd', 'cholesky'}:
+            raise ValueError(
+                "method must be one of {'eigh', 'svd', 'cholesky'}")
+
         if mean.ndim != 1:
             raise ValueError('mean must be 1 dimensional')
         if (cov.ndim != 2) or (cov.shape[0] != cov.shape[1]):

--- a/cupy/random/generator.py
+++ b/cupy/random/generator.py
@@ -6,7 +6,6 @@ import hashlib
 import operator
 import os
 import time
-import warnings
 
 import numpy
 

--- a/cupy/random/generator.py
+++ b/cupy/random/generator.py
@@ -387,11 +387,11 @@ class RandomState(object):
                 try:
                     if method == 'cholesky':
                         decomp = cupy.linalg.cholesky(cov)
-                    else:
-                        if method == 'eigh':
-                            (s, u) = cupy.linalg.eigh(cov)
-                        if method == 'svd':
-                            (u, s, vh) = cupy.linalg.svd(cov)
+                    elif method == 'eigh':
+                        (s, u) = cupy.linalg.eigh(cov)
+                        decomp = u * cupy.sqrt(cupy.abs(s))
+                    elif method == 'svd':
+                        (u, s, vh) = cupy.linalg.svd(cov)
                         decomp = u * cupy.sqrt(cupy.abs(s))
 
                 except LinAlgError:


### PR DESCRIPTION
Multivariate normal doesn't seem to work... not sure if it's an issue with svd in cuda, or in how the svd is applied in python. Regardless, this PR uses cholesky decomposition, and seems quite fast. Using cholesky also fixes the issue for all versions of cuda where cholesky is working... which is all of them that I have tried.

Removes experimental label.