### PR TITLE
Use `.data()` for `std::vector`

### DIFF
--- a/cupy/cuda/cudnn.pyx
+++ b/cupy/cuda/cudnn.pyx
@@ -1086,7 +1086,7 @@ cpdef getFilterNdDescriptor(size_t wDesc, int nbDimsRequested):
 
     status = cudnnGetFilterNdDescriptor_v4(
         <FilterDescriptor>wDesc, nbDimsRequested, &dataType,
-        &format, &nbDims, &filterDimA[0])
+        &format, &nbDims, filterDimA.data())
     check_status(status)
     return dataType, format, nbDims, tuple(filterDimA)
 
@@ -1176,7 +1176,7 @@ cpdef findConvolutionForwardAlgorithm(
     status = cudnnFindConvolutionForwardAlgorithm(
         <Handle> handle, <TensorDescriptor>xDesc, <FilterDescriptor>wDesc,
         <ConvolutionDescriptor>convDesc, <TensorDescriptor>yDesc,
-        requestedAlgoCount, &returnedAlgoCount, &perfResults[0])
+        requestedAlgoCount, &returnedAlgoCount, perfResults.data())
     check_status(status)
     perfResults.resize(returnedAlgoCount)
     return perfResults
@@ -1193,7 +1193,7 @@ cpdef list findConvolutionForwardAlgorithmEx(
         <Handle> handle, <TensorDescriptor>xDesc, <void*>x,
         <FilterDescriptor>wDesc, <void*>w, <ConvolutionDescriptor>convDesc,
         <TensorDescriptor>yDesc, <void*>y, requestedAlgoCount,
-        &returnedAlgoCount, &perfResults[0], <void*>workSpace,
+        &returnedAlgoCount, perfResults.data(), <void*>workSpace,
         workSpaceSizeInBytes)
     check_status(status)
     perfResults.resize(returnedAlgoCount)
@@ -1212,7 +1212,7 @@ cpdef list findConvolutionForwardAlgorithmEx_v7(
         <Handle> handle, <TensorDescriptor>xDesc, <void*>x,
         <FilterDescriptor>wDesc, <void*>w, <ConvolutionDescriptor>convDesc,
         <TensorDescriptor>yDesc, <void*>y, requestedAlgoCount,
-        &returnedAlgoCount, &perfResults[0], <void*>workSpace,
+        &returnedAlgoCount, perfResults.data(), <void*>workSpace,
         workSpaceSizeInBytes)
     check_status(status)
     perfResults.resize(returnedAlgoCount)
@@ -1244,7 +1244,7 @@ cpdef list getConvolutionForwardAlgorithm_v7(
         <Handle> handle, <TensorDescriptor>srcDesc,
         <FilterDescriptor>filterDesc, <ConvolutionDescriptor>convDesc,
         <TensorDescriptor>destDesc, requestedAlgoCount,
-        &returnedAlgoCount, &perfResults[0])
+        &returnedAlgoCount, perfResults.data())
     check_status(status)
     perfResults.resize(returnedAlgoCount)
     return [CuDNNAlgoPerf(p.algo, p.status, p.time, p.memory,
@@ -1302,7 +1302,7 @@ cpdef findConvolutionBackwardFilterAlgorithm(
     status = cudnnFindConvolutionBackwardFilterAlgorithm(
         <Handle> handle, <TensorDescriptor>xDesc, <TensorDescriptor>dyDesc,
         <ConvolutionDescriptor>convDesc, <FilterDescriptor>dwDesc,
-        requestedAlgoCount, &returnedAlgoCount, &perfResults[0])
+        requestedAlgoCount, &returnedAlgoCount, perfResults.data())
     check_status(status)
     perfResults.resize(returnedAlgoCount)
     return perfResults
@@ -1319,7 +1319,7 @@ cpdef list findConvolutionBackwardFilterAlgorithmEx(
         <Handle> handle, <TensorDescriptor>xDesc, <void*>x,
         <TensorDescriptor>dyDesc, <void*>dy, <ConvolutionDescriptor>convDesc,
         <FilterDescriptor>dwDesc, <void*>dw,
-        requestedAlgoCount, &returnedAlgoCount, &perfResults[0],
+        requestedAlgoCount, &returnedAlgoCount, perfResults.data(),
         <void*>workSpace, workSpaceSizeInBytes)
     check_status(status)
     perfResults.resize(returnedAlgoCount)
@@ -1338,7 +1338,7 @@ cpdef list findConvolutionBackwardFilterAlgorithmEx_v7(
         <Handle> handle, <TensorDescriptor>xDesc, <void*>x,
         <TensorDescriptor>dyDesc, <void*>dy, <ConvolutionDescriptor>convDesc,
         <FilterDescriptor>dwDesc, <void*>dw,
-        requestedAlgoCount, &returnedAlgoCount, &perfResults[0],
+        requestedAlgoCount, &returnedAlgoCount, perfResults.data(),
         <void*>workSpace, workSpaceSizeInBytes)
     check_status(status)
     perfResults.resize(returnedAlgoCount)
@@ -1371,7 +1371,7 @@ cpdef list getConvolutionBackwardFilterAlgorithm_v7(
     status = cudnnGetConvolutionBackwardFilterAlgorithm_v7(
         <Handle>handle, <TensorDescriptor>srcDesc, <TensorDescriptor>diffDesc,
         <ConvolutionDescriptor>convDesc, <FilterDescriptor>gradDesc,
-        requestedAlgoCount, &returnedAlgoCount, &perfResults[0])
+        requestedAlgoCount, &returnedAlgoCount, perfResults.data())
     check_status(status)
     perfResults.resize(returnedAlgoCount)
     return [CuDNNAlgoPerf(p.algo, p.status, p.time, p.memory,
@@ -1418,7 +1418,7 @@ cpdef findConvolutionBackwardDataAlgorithm(
     status = cudnnFindConvolutionBackwardDataAlgorithm(
         <Handle> handle, <FilterDescriptor>wDesc, <TensorDescriptor>dyDesc,
         <ConvolutionDescriptor>convDesc, <TensorDescriptor>dxDesc,
-        requestedAlgoCount, &returnedAlgoCount, &perfResults[0])
+        requestedAlgoCount, &returnedAlgoCount, perfResults.data())
     check_status(status)
     perfResults.resize(returnedAlgoCount)
     return perfResults
@@ -1435,7 +1435,7 @@ cpdef list findConvolutionBackwardDataAlgorithmEx(
         <Handle> handle, <FilterDescriptor>wDesc, <void*>w,
         <TensorDescriptor>dyDesc, <void*>dy, <ConvolutionDescriptor>convDesc,
         <TensorDescriptor>dxDesc, <void*>dx,
-        requestedAlgoCount, &returnedAlgoCount, &perfResults[0],
+        requestedAlgoCount, &returnedAlgoCount, perfResults.data(),
         <void*>workSpace, workSpaceSizeInBytes)
     check_status(status)
     perfResults.resize(returnedAlgoCount)
@@ -1454,7 +1454,7 @@ cpdef list findConvolutionBackwardDataAlgorithmEx_v7(
         <Handle> handle, <FilterDescriptor>wDesc, <void*>w,
         <TensorDescriptor>dyDesc, <void*>dy, <ConvolutionDescriptor>convDesc,
         <TensorDescriptor>dxDesc, <void*>dx,
-        requestedAlgoCount, &returnedAlgoCount, &perfResults[0],
+        requestedAlgoCount, &returnedAlgoCount, perfResults.data(),
         <void*>workSpace, workSpaceSizeInBytes)
     check_status(status)
     perfResults.resize(returnedAlgoCount)
@@ -1487,7 +1487,7 @@ cpdef list getConvolutionBackwardDataAlgorithm_v7(
         <Handle>handle, <FilterDescriptor>filterDesc,
         <TensorDescriptor>diffDesc, <ConvolutionDescriptor>convDesc,
         <TensorDescriptor>gradDesc, requestedAlgoCount,
-        &returnedAlgoCount, &perfResults[0])
+        &returnedAlgoCount, perfResults.data())
     check_status(status)
     perfResults.resize(returnedAlgoCount)
     return [CuDNNAlgoPerf(p.algo, p.status, p.time, p.memory,

--- a/cupy/cuda/function.pyx
+++ b/cupy/cuda/function.pyx
@@ -146,11 +146,11 @@ cdef _launch(intptr_t func, Py_ssize_t grid0, int grid1, int grid2,
     if enable_cooperative_groups:
         driver.launchCooperativeKernel(
             func, <int>grid0, grid1, grid2, <int>block0, block1, block2,
-            <int>shared_mem, stream, <intptr_t>&(kargs[0]))
+            <int>shared_mem, stream, <intptr_t>kargs.data())
     else:
         driver.launchKernel(
             func, <int>grid0, grid1, grid2, <int>block0, block1, block2,
-            <int>shared_mem, stream, <intptr_t>&(kargs[0]), <intptr_t>0)
+            <int>shared_mem, stream, <intptr_t>kargs.data(), <intptr_t>0)
 
 
 cdef class Function:

--- a/cupy/cudnn.pyx
+++ b/cupy/cudnn.pyx
@@ -910,7 +910,8 @@ cdef _DescriptorArray _make_tensor_descriptor_array(xs, lengths):
         desc = cudnn.createTensorDescriptor()
         descs.append(desc)
         cudnn.setTensorNdDescriptor(
-            desc, data_type, 3, <size_t>c_shape.data(), <size_t>c_strides.data())
+            desc, data_type, 3,
+            <size_t>c_shape.data(), <size_t>c_strides.data())
 
     return descs
 
@@ -933,7 +934,8 @@ cdef _DescriptorArray _make_tensor_descriptor_array_for_padded(xs):
         desc = cudnn.createTensorDescriptor()
         descs.append(desc)
         cudnn.setTensorNdDescriptor(
-            desc, data_type, 3, <size_t>c_shape.data(), <size_t>c_strides.data())
+            desc, data_type, 3,
+            <size_t>c_shape.data(), <size_t>c_strides.data())
 
     return descs
 

--- a/cupy/cudnn.pyx
+++ b/cupy/cudnn.pyx
@@ -138,8 +138,8 @@ cpdef _create_tensor_nd_descriptor(
             next_stride = c_shape[i] * c_strides[i]
 
     cudnn.setTensorNdDescriptor(
-        desc, data_type, arr._shape.size(), <size_t>&c_shape[0],
-        <size_t>&c_strides[0])
+        desc, data_type, arr._shape.size(), <size_t>c_shape.data(),
+        <size_t>c_strides.data())
 
 
 cpdef _create_tensor_descriptor(size_t desc, core.ndarray arr,
@@ -190,7 +190,7 @@ cpdef _create_filter_descriptor(
         for s in arr._shape:
             c_shape.push_back(s)
         cudnn.setFilterNdDescriptor_v4(
-            desc, data_type, format, ndim, <size_t>&c_shape[0])
+            desc, data_type, format, ndim, <size_t>c_shape.data())
 
 
 cpdef _create_convolution_descriptor(
@@ -221,8 +221,8 @@ cpdef _create_convolution_descriptor(
                         raise ValueError(
                             'dilation must be one when cuDNN < 6.0')
         cudnn.setConvolutionNdDescriptor_v3(
-            desc, ndim, <size_t>&c_pad[0], <size_t>&c_stride[0],
-            <size_t>&c_dilation[0], mode, compute_type)
+            desc, ndim, <size_t>c_pad.data(), <size_t>c_stride.data(),
+            <size_t>c_dilation.data(), mode, compute_type)
     else:
         if dilation is None:
             d0 = d1 = 1
@@ -330,7 +330,8 @@ cdef _create_pooling_descriptor(
         c_stride = stride
         cudnn.setPoolingNdDescriptor_v4(
             desc, mode, cudnn.CUDNN_NOT_PROPAGATE_NAN, ndim,
-            <size_t>&c_ksize[0], <size_t>&c_pad[0], <size_t>&c_stride[0])
+            <size_t>c_ksize.data(), <size_t>c_pad.data(),
+            <size_t>c_stride.data())
 
     return desc
 
@@ -878,7 +879,7 @@ cdef class _DescriptorArray:
 
     @property
     def data(self):
-        return <size_t>&self._value[0]
+        return <size_t>self._value.data()
 
 
 cdef _DescriptorArray _make_tensor_descriptor_array(xs, lengths):
@@ -909,7 +910,7 @@ cdef _DescriptorArray _make_tensor_descriptor_array(xs, lengths):
         desc = cudnn.createTensorDescriptor()
         descs.append(desc)
         cudnn.setTensorNdDescriptor(
-            desc, data_type, 3, <size_t>&c_shape[0], <size_t>&c_strides[0])
+            desc, data_type, 3, <size_t>c_shape.data(), <size_t>c_strides.data())
 
     return descs
 
@@ -932,7 +933,7 @@ cdef _DescriptorArray _make_tensor_descriptor_array_for_padded(xs):
         desc = cudnn.createTensorDescriptor()
         descs.append(desc)
         cudnn.setTensorNdDescriptor(
-            desc, data_type, 3, <size_t>&c_shape[0], <size_t>&c_strides[0])
+            desc, data_type, 3, <size_t>c_shape.data(), <size_t>c_strides.data())
 
     return descs
 


### PR DESCRIPTION
Similar to #3020, but I don't know if the input vectors can be empty.

The remaining ones are not of type `std::vector`.
```
% git grep '&.*\[0]'
cupy/cuda/cufft.pyx:        cdef int* shape_ptr = &shape_arr[0]
cupy/cuda/cufft.pyx:            inembed_ptr = &inembed_arr[0]
cupy/cuda/cufft.pyx:            onembed_ptr = &onembed_arr[0]
cupyx/scipy/sparse/compressed.py:        'if (ind == minor) atomicAdd(&answer[0], d);',
cupyx/scipy/sparse/compressed.py:          atomicAdd(&answer_real[0], real);
cupyx/scipy/sparse/compressed.py:          atomicAdd(&answer_imag[0], imag);
```