### PR TITLE
Fix nvcc command lookup

### DIFF
--- a/cupy/cuda/_environment.py
+++ b/cupy/cuda/_environment.py
@@ -1,0 +1,56 @@
+import os
+import shutil
+
+
+_cuda_path = ()
+_nvcc_path = ()
+
+
+def get_cuda_path():
+    # Returns the CUDA installation path or None if not found.
+    global _cuda_path
+    if _cuda_path == ():
+        _cuda_path = _get_cuda_path()
+    return _cuda_path
+
+
+def get_nvcc_path():
+    # Returns the path to the nvcc command or None if not found.
+    global _nvcc_path
+    if _nvcc_path == ():
+        _nvcc_path = _get_nvcc_path()
+    return _nvcc_path
+
+
+def _get_cuda_path():
+    # Use environment variable
+    cuda_path = os.environ.get('CUDA_PATH', '')  # Nvidia default on Windows
+    if os.path.exists(cuda_path):
+        return cuda_path
+
+    # Use nvcc path
+    nvcc_path = shutil.which('nvcc')
+    if nvcc_path is not None:
+        return os.path.dirname(os.path.dirname(nvcc_path))
+
+    # Use typical path
+    if os.path.exists('/usr/local/cuda'):
+        return '/usr/local/cuda'
+
+    return None
+
+
+def _get_nvcc_path():
+    # Directly lookup PATH
+    nvcc_path = shutil.which('nvcc')
+    if nvcc_path is not None:
+        return nvcc_path
+
+    # Lookup <CUDA>/bin
+    cuda_path = get_cuda_path()
+    if cuda_path is None:
+        return None
+
+    return shutil.which(
+        'nvcc',
+        path=os.path.join(cuda_path, 'bin'))

--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -7,6 +7,7 @@ import subprocess
 import sys
 import tempfile
 
+from cupy.cuda import _environment
 from cupy.cuda import device
 from cupy.cuda import function
 from cupy.cuda import nvrtc
@@ -164,7 +165,7 @@ def compile_using_nvcc(source, options=(), arch=None,
         assert not separate_compilation
 
     arch_str = '-gencode=arch=compute_{cc},code=sm_{cc}'.format(cc=arch)
-    cmd = ['nvcc', arch_str]
+    cmd = [_environment.get_nvcc_path(), arch_str]
 
     with TemporaryDirectory() as root_dir:
         first_part = filename.split('.')[0]


### PR DESCRIPTION
Takes over #3023

In some environment, `nvcc` is not necessarilly looked up by`PATH`.