### PR TITLE
Enable CUB support in CI

### DIFF
--- a/.pfnci/config.pbtxt
+++ b/.pfnci/config.pbtxt
@@ -167,3 +167,25 @@ configs {
     command: "bash .pfnci/script.sh py37.amd"
   }
 }
+
+# Use CUB
+configs {
+  key: "cupy.py37.cub"
+  value {
+    requirement {
+      cpu: 8
+      memory: 24
+      disk: 10
+      gpu: 2
+    }
+    time_limit {
+      seconds: 1800
+    }
+    checkout_strategy {
+      include_dot_git: true
+    }
+    environment_variables { key: "GPU" value: "2",
+                            key: "CUB_DISABLED" value:"0"}
+    command: "bash .pfnci/script.sh py37"
+  }
+}

--- a/.pfnci/run.sh
+++ b/.pfnci/run.sh
@@ -77,7 +77,10 @@ test_py37() {
   # TODO(niboshi): Allow option pass-through (https://github.com/chainer/xpytest/issues/14)
   export PYTEST_ADDOPTS=-rfEX
   # TODO(imos): Enable xpytest to support python_files setting in setup.cfg.
-  OMP_NUM_THREADS=1 xpytest "${xpytest_args[@]}" \
+  # OMP_NUM_THREADS=1 xpytest "${xpytest_args[@]}" \
+  #     '/cupy/tests/**/test_*.py' \
+  #     && :
+  python -m pytest -m 'not slow' \
       '/cupy/tests/**/test_*.py' \
       && :
   py_test_status=$?

--- a/.pfnci/run.sh
+++ b/.pfnci/run.sh
@@ -81,7 +81,7 @@ test_py37() {
   #     '/cupy/tests/**/test_*.py' \
   #     && :
   python3.7 -m pytest -m 'not slow' \
-      /cupy/tests/ \
+      /cupy/tests/cupy_tests \
       && :
   py_test_status=$?
 

--- a/.pfnci/run.sh
+++ b/.pfnci/run.sh
@@ -80,7 +80,7 @@ test_py37() {
   # OMP_NUM_THREADS=1 xpytest "${xpytest_args[@]}" \
   #     '/cupy/tests/**/test_*.py' \
   #     && :
-  python -m pytest -m 'not slow' \
+  python3.7 -m pytest -m 'not slow' \
       '/cupy/tests/**/test_*.py' \
       && :
   py_test_status=$?

--- a/.pfnci/run.sh
+++ b/.pfnci/run.sh
@@ -81,7 +81,7 @@ test_py37() {
   #     '/cupy/tests/**/test_*.py' \
   #     && :
   python3.7 -m pytest -m 'not slow' \
-      '/cupy/tests/**/test_*.py' \
+      /cupy/tests/ \
       && :
   py_test_status=$?
 

--- a/.pfnci/script.sh
+++ b/.pfnci/script.sh
@@ -21,7 +21,7 @@
 #       "1u5OYiPOL3XRppn73XBSgR-XyDuHKb_4Ilmx1kgJfa-k") to enable xpytest to
 #       report to a spreadsheet.
 
-set -eu
+set -eux
 
 ################################################################################
 # Main function


### PR DESCRIPTION
Create a separate configuration for pfnCI.

There might be problems with `git clone --recursive` once #2584 is merged.

Since some routines have cub implementations and these are not explicitly tested in #2598, this CI config will run all the tests with cub enabled while the main tests will be run with cub disabled to test both paths.