### PR TITLE
[backport] Fix `get_fft_plan()` and some FFT tests

### DIFF
--- a/cupyx/scipy/fftpack/fft.py
+++ b/cupyx/scipy/fftpack/fft.py
@@ -60,32 +60,31 @@ def get_fft_plan(a, shape=None, axes=None, value_type='C2C'):
     else:
         raise ValueError('Input array a must be contiguous')
 
+    if isinstance(shape, int):
+        shape = (shape,)
+    if isinstance(axes, int):
+        axes = (axes,)
+    if (shape is not None) and (axes is not None) and len(shape) != len(axes):
+        raise ValueError('Shape and axes have different lengths.')
+
     # check axes
     # n=1: 1d (need axis1D); n>1: Nd
     if axes is None:
-        n = a.ndim
-        axes = tuple(i for i in range(n))
+        n = a.ndim if shape is None else len(shape)
+        axes = tuple(i for i in range(-n, 0))
         if n == 1:
             axis1D = 0
-    elif isinstance(axes, int):
-        n = 1
-        axis1D = axes
-        axes = (axes,)
-        if axis1D >= a.ndim or axis1D < -a.ndim:
-            raise ValueError('The chosen axis ({0}) exceeds the number of '
-                             'dimensions of a ({1})'.format(axis1D, a.ndim))
     else:  # axes is a tuple
         n = len(axes)
         if n == 1:
             axis1D = axes[0]
+            if axis1D >= a.ndim or axis1D < -a.ndim:
+                err = 'The chosen axis ({0}) exceeds the number of '\
+                      'dimensions of a ({1})'.format(axis1D, a.ndim)
+                raise ValueError(err)
         elif n > 3:
             raise ValueError('Only up to three axes is supported')
 
-    # check shape
-    if isinstance(shape, int):
-        shape = (shape,)
-    if (shape is not None) and len(shape) != n:
-        raise ValueError('Shape and axes have different lengths.')
     # Note that "shape" here refers to the shape along trasformed axes, not
     # the shape of the output array, and we need to convert it to the latter.
     # The result is as if "a=_cook_shape(a); return a.shape" is called.

--- a/tests/cupy_tests/fft_tests/test_fft.py
+++ b/tests/cupy_tests/fft_tests/test_fft.py
@@ -301,6 +301,7 @@ class TestFftn(unittest.TestCase):
     {'shape': (2, 3, 4), 's': None, 'axes': (-1, -2, -3), 'norm': None},
     {'shape': (2, 3, 4), 's': None, 'axes': (0, 1), 'norm': None},
     {'shape': (2, 3, 4), 's': None, 'axes': None, 'norm': 'ortho'},
+    {'shape': (2, 3, 4), 's': (2, 3), 'axes': None, 'norm': 'ortho'},
     {'shape': (2, 3, 4), 's': (2, 3), 'axes': (0, 1, 2), 'norm': 'ortho'},
 )
 @testing.gpu

--- a/tests/cupyx_tests/scipy_tests/fft_tests/test_fft.py
+++ b/tests/cupyx_tests/scipy_tests/fft_tests/test_fft.py
@@ -282,7 +282,8 @@ class TestRfft2(unittest.TestCase):
     def test_rfft2(self, xp, dtype):
         x = testing.shaped_random(self.shape, xp, dtype)
         x_orig = x.copy()
-        out = _fft_module(xp).rfft2(x, s=self.s, norm=self.norm)
+        out = _fft_module(xp).rfft2(x, s=self.s, axes=self.axes,
+                                    norm=self.norm)
         testing.assert_array_equal(x, x_orig)
         return _correct_np_dtype(xp, dtype, out)
 
@@ -292,8 +293,8 @@ class TestRfft2(unittest.TestCase):
     def test_rfft2_overwrite(self, xp, dtype):
         x = testing.shaped_random(self.shape, xp, dtype)
         overwrite_kw = {} if xp == np else {'overwrite_x': True}
-        out = _fft_module(xp).rfft2(x, s=self.s, norm=self.norm,
-                                    **overwrite_kw)
+        out = _fft_module(xp).rfft2(x, s=self.s, axes=self.axes,
+                                    norm=self.norm, **overwrite_kw)
         return _correct_np_dtype(xp, dtype, out)
 
     @testing.for_all_dtypes()
@@ -302,7 +303,8 @@ class TestRfft2(unittest.TestCase):
     def test_irfft2(self, xp, dtype):
         x = testing.shaped_random(self.shape, xp, dtype)
         x_orig = x.copy()
-        out = _fft_module(xp).irfft2(x, s=self.s, norm=self.norm)
+        out = _fft_module(xp).irfft2(x, s=self.s, axes=self.axes,
+                                     norm=self.norm)
         testing.assert_array_equal(x, x_orig)
         return _correct_np_dtype(xp, dtype, out)
 
@@ -312,8 +314,8 @@ class TestRfft2(unittest.TestCase):
     def test_irfft2_overwrite(self, xp, dtype):
         x = testing.shaped_random(self.shape, xp, dtype)
         overwrite_kw = {} if xp == np else {'overwrite_x': True}
-        out = _fft_module(xp).irfft2(x, s=self.s, norm=self.norm,
-                                     **overwrite_kw)
+        out = _fft_module(xp).irfft2(x, s=self.s, axes=self.axes,
+                                     norm=self.norm, **overwrite_kw)
         return _correct_np_dtype(xp, dtype, out)
 
 


### PR DESCRIPTION
Cherry-pick from #2998:
> 2. Fix a bug in cupyx.scipy.fftpack.get_fft_plan() following #2752 (1c6174d, should be backported)
> 3. Fix missing axes arguments in TestRfft2 (4ef81b1, should be backported)