### PR TITLE
Fix: n-dimensional FFTs must preserve array contiguity when copying a view

### DIFF
--- a/cupy/fft/fft.py
+++ b/cupy/fft/fft.py
@@ -356,7 +356,7 @@ def _exec_fftn(a, direction, value_type, norm, axes, overwrite_x,
     if fft_type not in [cufft.CUFFT_C2C, cufft.CUFFT_Z2Z]:
         raise NotImplementedError('Only C2C and Z2Z are supported.')
 
-    if a.base is not None:
+    if a.base is not None and not a.flags.forc:
         a = a.copy(order='A')
 
     if a.flags.c_contiguous:

--- a/cupy/fft/fft.py
+++ b/cupy/fft/fft.py
@@ -356,9 +356,6 @@ def _exec_fftn(a, direction, value_type, norm, axes, overwrite_x,
     if fft_type not in [cufft.CUFFT_C2C, cufft.CUFFT_Z2Z]:
         raise NotImplementedError('Only C2C and Z2Z are supported.')
 
-    if a.base is not None and not a.flags.forc:
-        a = a.copy(order='A')
-
     if a.flags.c_contiguous:
         order = 'C'
     elif a.flags.f_contiguous:

--- a/cupy/fft/fft.py
+++ b/cupy/fft/fft.py
@@ -357,7 +357,7 @@ def _exec_fftn(a, direction, value_type, norm, axes, overwrite_x,
         raise NotImplementedError('Only C2C and Z2Z are supported.')
 
     if a.base is not None:
-        a = a.copy()
+        a = a.copy(order='A')
 
     if a.flags.c_contiguous:
         order = 'C'


### PR DESCRIPTION
closes #3033
closes #3079

A concrete example of the issue is given in #3033. This PR fixes that use case, adding a corresponding test case over both C and Fortran ordered views.

Please also backport this fix to the ~~7.x and 6.x branches.~~ 7.x branch.
