### PR TITLE
fix behavior of result_type when 0-dimensional arrays are involved

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -389,8 +389,17 @@ def result_type(*arrays_and_dtypes):
 
     .. seealso:: :func:`numpy.result_type`
     """
-    dtypes = [a.dtype if isinstance(a, cupy.ndarray)
-              else a for a in arrays_and_dtypes]
+    dtypes = []
+    for a in arrays_and_dtypes:
+        if isinstance(a, cupy.ndarray):
+            if a.ndim == 0:
+                # NumPy handles 0-dimensional arrays differently
+                dtypes.append(numpy.asarray(0, dtype=a.dtype))
+            else:
+                dtypes.append(a.dtype)
+        else:
+            dtypes.append(a)
+
     return numpy.result_type(*dtypes)
 
 

--- a/tests/cupy_tests/test_type_routines.py
+++ b/tests/cupy_tests/test_type_routines.py
@@ -5,6 +5,9 @@ import numpy
 from cupy import testing
 
 
+_obj_types = ['dtype', 'specifier', 'scalar', 'array', 'primitive']
+
+
 def _generate_type_routines_input(xp, dtype, obj_type):
     dtype = numpy.dtype(dtype)
     if obj_type == 'dtype':
@@ -17,12 +20,14 @@ def _generate_type_routines_input(xp, dtype, obj_type):
         return xp.zeros(3, dtype=dtype)
     if obj_type == 'primitive':
         return type(dtype.type(3).tolist())
+    if obj_type == 'zero_dim':
+        return xp.asarray(3, dtype=dtype)
     assert False
 
 
 @testing.parameterize(
     *testing.product({
-        'obj_type': ['dtype', 'specifier', 'scalar', 'array', 'primitive'],
+        'obj_type': _obj_types,
     })
 )
 class TestCanCast(unittest.TestCase):
@@ -74,8 +79,8 @@ class TestCommonType(unittest.TestCase):
 
 @testing.parameterize(
     *testing.product({
-        'obj_type1': ['dtype', 'specifier', 'scalar', 'array', 'primitive'],
-        'obj_type2': ['dtype', 'specifier', 'scalar', 'array', 'primitive'],
+        'obj_type1': _obj_types + ['zero_dim'],
+        'obj_type2': _obj_types + ['zero_dim'],
     })
 )
 class TestResultType(unittest.TestCase):


### PR DESCRIPTION
closes #3035

This fixes the different behaviour for 0-dimensional arrays in `result_type` by generating 0-dimensional NumPy arrays of the corresponding `dtype` instead of passing the `dtype` directly.

The `'zero_dim'` test cases added in 8845706 fail on current master, but should pass with the change introduced in cadf203.

(please also backport to the 7.x branch)
