### PR TITLE
Require `scipy` in `test_gmm`

### DIFF
--- a/tests/example_tests/test_gmm.py
+++ b/tests/example_tests/test_gmm.py
@@ -12,6 +12,7 @@ os.environ['MPLBACKEND'] = 'Agg'
 
 
 @testing.with_requires('matplotlib')
+@testing.with_requires('scipy')
 class TestGMM(unittest.TestCase):
 
     def test_gmm(self):


### PR DESCRIPTION
This amends #2996 for test environments without `scipy` (but with `matplotlib`).