### PR TITLE
[backport] Require `scipy` in `test_gmm`

### DIFF
--- a/tests/example_tests/test_gmm.py
+++ b/tests/example_tests/test_gmm.py
@@ -14,6 +14,7 @@ os.environ['MPLBACKEND'] = 'Agg'
 
 
 @testing.with_requires('matplotlib')
+@testing.with_requires('scipy')
 class TestGMM(unittest.TestCase):
 
     def test_gmm(self):


### PR DESCRIPTION
Backport of #3048