### PR TITLE
Support CUB `prod`

### DIFF
--- a/cupy/core/_routines_math.pyx
+++ b/cupy/core/_routines_math.pyx
@@ -75,6 +75,12 @@ cdef ndarray _ndarray_imag_setter(ndarray self, value):
 
 
 cdef ndarray _ndarray_prod(ndarray self, axis, dtype, out, keepdims):
+    if cupy.cuda.cub_enabled:
+        # result will be None if the reduction is not compatible with CUB
+        result = cub.cub_reduction(self, cub.CUPY_CUB_PROD, axis, dtype, out,
+                                   keepdims)
+        if result is not None:
+            return result
     if dtype is None:
         return _prod_auto_dtype(self, axis, dtype, out, keepdims)
     else:

--- a/cupy/cuda/cub.pxd
+++ b/cupy/cuda/cub.pxd
@@ -6,3 +6,4 @@ cpdef enum cupy_cub_op:
     CUPY_CUB_ARGMAX = 4
     CUPY_CUB_CUMSUM = 5
     CUPY_CUB_CUMPROD = 6
+    CUPY_CUB_PROD = 7

--- a/cupy/cuda/cub.pyx
+++ b/cupy/cuda/cub.pyx
@@ -123,7 +123,7 @@ def device_reduce(ndarray x, op, tuple out_axis, out=None,
             'output parameter for reduction operation has the wrong number of '
             'dimensions')
     if op not in (CUPY_CUB_SUM, CUPY_CUB_PROD, CUPY_CUB_MIN, CUPY_CUB_MAX,
-        CUPY_CUB_ARGMIN, CUPY_CUB_ARGMAX):
+                  CUPY_CUB_ARGMIN, CUPY_CUB_ARGMAX):
         raise ValueError('only CUPY_CUB_SUM, CUPY_CUB_PROD, CUPY_CUB_MIN, '
                          'CUPY_CUB_MAX, CUPY_CUB_ARGMIN, and CUPY_CUB_ARGMAX '
                          'are supported.')

--- a/cupy/cuda/cub.pyx
+++ b/cupy/cuda/cub.pyx
@@ -122,15 +122,17 @@ def device_reduce(ndarray x, op, tuple out_axis, out=None,
         raise ValueError(
             'output parameter for reduction operation has the wrong number of '
             'dimensions')
-    if op < CUPY_CUB_SUM or op > CUPY_CUB_ARGMAX:
-        raise ValueError('only CUPY_CUB_SUM, CUPY_CUB_MIN, CUPY_CUB_MAX, '
-                         'CUPY_CUB_ARGMIN, and CUPY_CUB_ARGMAX are supported.')
-    if x.size == 0 and op != CUPY_CUB_SUM:
+    if op not in (CUPY_CUB_SUM, CUPY_CUB_PROD, CUPY_CUB_MIN, CUPY_CUB_MAX,
+        CUPY_CUB_ARGMIN, CUPY_CUB_ARGMAX):
+        raise ValueError('only CUPY_CUB_SUM, CUPY_CUB_PROD, CUPY_CUB_MIN, '
+                         'CUPY_CUB_MAX, CUPY_CUB_ARGMIN, and CUPY_CUB_ARGMAX '
+                         'are supported.')
+    if x.size == 0 and op not in (CUPY_CUB_SUM, CUPY_CUB_PROD):
         raise ValueError('zero-size array to reduction operation {} which has '
                          'no identity'.format(op.name))
     x = _internal_ascontiguousarray(x)
 
-    if CUPY_CUB_SUM <= op <= CUPY_CUB_MAX:
+    if op in (CUPY_CUB_SUM, CUPY_CUB_PROD, CUPY_CUB_MIN, CUPY_CUB_MAX):
         y = ndarray((), x.dtype)
     else:  # argmin and argmax
         # cub::KeyValuePair has 1 int + 1 arbitrary type
@@ -181,10 +183,10 @@ def device_segmented_reduce(ndarray x, op, tuple reduce_axis,
     cdef tuple out_shape
     cdef Stream_t s
 
-    if op < CUPY_CUB_SUM or op > CUPY_CUB_MAX:
-        raise ValueError('only CUPY_CUB_SUM, CUPY_CUB_MIN, and CUPY_CUB_MAX '
-                         'are supported.')
-    if x.size == 0 and op != CUPY_CUB_SUM:
+    if op not in (CUPY_CUB_SUM, CUPY_CUB_PROD, CUPY_CUB_MIN, CUPY_CUB_MAX):
+        raise ValueError('only CUPY_CUB_SUM, CUPY_CUB_PROD, CUPY_CUB_MIN, '
+                         'and CUPY_CUB_MAX are supported.')
+    if x.size == 0 and op not in (CUPY_CUB_SUM, CUPY_CUB_PROD):
         raise ValueError('zero-size array to reduction operation {} which has '
                          'no identity'.format(op.name))
     if x.flags.c_contiguous:
@@ -203,10 +205,13 @@ def device_segmented_reduce(ndarray x, op, tuple reduce_axis,
     if out is not None and out.shape != out_shape:
         raise ValueError(
             'output parameter for reduction operation has the wrong shape')
-    if x.size == 0:  # for CUPY_CUB_SUM
+    if x.size == 0:  # for CUPY_CUB_SUM & CUPY_CUB_PROD
         if out is not None:
             y = out
-        y[...] = 0
+        if op == CUPY_CUB_SUM:
+            y[...] = 0
+        elif op == CUPY_CUB_PROD:
+            y[...] = 1
         return y
     n_segments = x.size//contiguous_size
     # CUB internally use int for offset...
@@ -349,7 +354,7 @@ def can_use_device_segmented_reduce(int op, x_dtype, Py_ssize_t ndim,
 
 cdef _cub_reduce_dtype_compatible(x_dtype, int op, dtype=None):
     if dtype is None:
-        if op == CUPY_CUB_SUM:
+        if op in (CUPY_CUB_SUM, CUPY_CUB_PROD):
             # auto dtype:
             # CUB reduce_sum does not support dtype promotion.
             # See _sum_auto_dtype in cupy/core/_routines_math.pyx for which
@@ -430,7 +435,7 @@ def cub_scan(arr, op):
 
     If the specified scan is not possible, None is returned.
     """
-    if op < CUPY_CUB_CUMSUM or op > CUPY_CUB_CUMPROD:
+    if op not in (CUPY_CUB_CUMSUM, CUPY_CUB_CUMPROD):
         return None
 
     # cub_device_scan seems buggy for complex128:

--- a/cupy/cuda/cupy_cub.cu
+++ b/cupy/cuda/cupy_cub.cu
@@ -51,6 +51,18 @@ template <> struct NumericTraits<complex<double>> : BaseTraits<FLOATING_POINT, t
 */
 
 //
+// product functor
+//
+struct _multiply
+{
+    template <typename T>
+    __host__ __device__ __forceinline__ T operator()(const T &a, const T &b) const
+    {
+        return a * b;
+    }
+};
+
+//
 // Max()
 //
 
@@ -337,6 +349,32 @@ struct _cub_segmented_reduce_sum {
 };
 
 //
+// **** CUB Prod ****
+//
+struct _cub_reduce_prod {
+    template <typename T>
+    void operator()(void* workspace, size_t& workspace_size, void* x, void* y,
+        int num_items, cudaStream_t s)
+    {
+        _multiply product_op;
+        DeviceReduce::Reduce(workspace, workspace_size, static_cast<T*>(x),
+            static_cast<T*>(y), num_items, product_op, static_cast<T>(1), s);
+    }
+};
+
+//struct _cub_segmented_reduce_prod {
+//    template <typename T>
+//    void operator()(void* workspace, size_t& workspace_size, void* x, void* y,
+//        int num_segments, void* offset_start, void* offset_end, cudaStream_t s)
+//    {
+//        DeviceSegmentedReduce::Sum(workspace, workspace_size,
+//            static_cast<T*>(x), static_cast<T*>(y), num_segments,
+//            static_cast<int*>(offset_start),
+//            static_cast<int*>(offset_end), s);
+//    }
+//};
+
+//
 // **** CUB Min ****
 //
 struct _cub_reduce_min {
@@ -457,16 +495,6 @@ struct _cub_inclusive_product {
         DeviceScan::InclusiveScan(workspace, workspace_size, static_cast<T*>(input),
             static_cast<T*>(output), product_op, num_items, s);
     }
-
-    // product functor
-    struct _multiply
-    {
-        template <typename T>
-        __host__ __device__ __forceinline__
-        T operator()(const T &a, const T &b) const {
-            return a * b;
-        }
-    };
 };
 
 //
@@ -488,6 +516,8 @@ void cub_device_reduce(void* workspace, size_t& workspace_size, void* x, void* y
     case CUPY_CUB_ARGMIN:   return dtype_dispatcher(dtype_id, _cub_reduce_argmin(),
                                 workspace, workspace_size, x, y, num_items, stream);
     case CUPY_CUB_ARGMAX:   return dtype_dispatcher(dtype_id, _cub_reduce_argmax(),
+                                workspace, workspace_size, x, y, num_items, stream);
+    case CUPY_CUB_PROD:     return dtype_dispatcher(dtype_id, _cub_reduce_prod(),
                                 workspace, workspace_size, x, y, num_items, stream);
     default:            throw std::runtime_error("Unsupported operation");
     }

--- a/cupy/cuda/cupy_cub.h
+++ b/cupy/cuda/cupy_cub.h
@@ -22,6 +22,7 @@
 #define CUPY_CUB_ARGMAX  4
 #define CUPY_CUB_CUMSUM  5
 #define CUPY_CUB_CUMPROD 6
+#define CUPY_CUB_PROD    7
 
 #ifndef CUPY_NO_CUDA
 #include <cuda_runtime.h>  // for cudaStream_t


### PR DESCRIPTION
Both full and segmented reductions are supported.

TODO: 
- [x] ~~Add tests?~~ **EDIT:** Done in #2598
- [ ] Post timing?