### PR TITLE
Use `intptr_t` instead of `size_t` for cuSPARSE and cuBLAS handles

### DIFF
--- a/cupy/cuda/cublas.pxd
+++ b/cupy/cuda/cublas.pxd
@@ -59,80 +59,80 @@ cpdef enum:
 ###############################################################################
 
 cpdef size_t create() except? 0
-cpdef destroy(size_t handle)
-cpdef int getVersion(size_t handle) except? -1
-cpdef int getPointerMode(size_t handle) except? -1
-cpdef setPointerMode(size_t handle, int mode)
+cpdef destroy(intptr_t handle)
+cpdef int getVersion(intptr_t handle) except? -1
+cpdef int getPointerMode(intptr_t handle) except? -1
+cpdef setPointerMode(intptr_t handle, int mode)
 
 
 ###############################################################################
 # Stream
 ###############################################################################
 
-cpdef setStream(size_t handle, size_t stream)
-cpdef size_t getStream(size_t handle) except? 0
+cpdef setStream(intptr_t handle, size_t stream)
+cpdef size_t getStream(intptr_t handle) except? 0
 
 
 ###############################################################################
 # Math Mode
 ###############################################################################
 
-cpdef setMathMode(size_t handle, int mode)
-cpdef int getMathMode(size_t handle) except? -1
+cpdef setMathMode(intptr_t handle, int mode)
+cpdef int getMathMode(intptr_t handle) except? -1
 
 
 ###############################################################################
 # BLAS Level 1
 ###############################################################################
 
-cpdef int isamax(size_t handle, int n, size_t x, int incx) except? 0
-cpdef int isamin(size_t handle, int n, size_t x, int incx) except? 0
-cpdef float sasum(size_t handle, int n, size_t x, int incx) except? 0
-cpdef saxpy(size_t handle, int n, float alpha, size_t x, int incx, size_t y,
+cpdef int isamax(intptr_t handle, int n, size_t x, int incx) except? 0
+cpdef int isamin(intptr_t handle, int n, size_t x, int incx) except? 0
+cpdef float sasum(intptr_t handle, int n, size_t x, int incx) except? 0
+cpdef saxpy(intptr_t handle, int n, float alpha, size_t x, int incx, size_t y,
             int incy)
-cpdef daxpy(size_t handle, int n, double alpha, size_t x, int incx, size_t y,
+cpdef daxpy(intptr_t handle, int n, double alpha, size_t x, int incx, size_t y,
             int incy)
-cpdef sdot(size_t handle, int n, size_t x, int incx, size_t y, int incy,
+cpdef sdot(intptr_t handle, int n, size_t x, int incx, size_t y, int incy,
            size_t result)
-cpdef ddot(size_t handle, int n, size_t x, int incx, size_t y, int incy,
+cpdef ddot(intptr_t handle, int n, size_t x, int incx, size_t y, int incy,
            size_t result)
-cpdef cdotu(size_t handle, int n, size_t x, int incx, size_t y, int incy,
+cpdef cdotu(intptr_t handle, int n, size_t x, int incx, size_t y, int incy,
             size_t result)
-cpdef cdotc(size_t handle, int n, size_t x, int incx, size_t y, int incy,
+cpdef cdotc(intptr_t handle, int n, size_t x, int incx, size_t y, int incy,
             size_t result)
-cpdef zdotu(size_t handle, int n, size_t x, int incx, size_t y, int incy,
+cpdef zdotu(intptr_t handle, int n, size_t x, int incx, size_t y, int incy,
             size_t result)
-cpdef zdotc(size_t handle, int n, size_t x, int incx, size_t y, int incy,
+cpdef zdotc(intptr_t handle, int n, size_t x, int incx, size_t y, int incy,
             size_t result)
-cpdef float snrm2(size_t handle, int n, size_t x, int incx) except? 0
-cpdef sscal(size_t handle, int n, float alpha, size_t x, int incx)
+cpdef float snrm2(intptr_t handle, int n, size_t x, int incx) except? 0
+cpdef sscal(intptr_t handle, int n, float alpha, size_t x, int incx)
 
 
 ###############################################################################
 # BLAS Level 2
 ###############################################################################
 
-cpdef sgemv(size_t handle, int trans, int m, int n, float alpha, size_t A,
+cpdef sgemv(intptr_t handle, int trans, int m, int n, float alpha, size_t A,
             int lda, size_t x, int incx, float beta, size_t y, int incy)
-cpdef dgemv(size_t handle, int trans, int m, int n, double alpha, size_t A,
+cpdef dgemv(intptr_t handle, int trans, int m, int n, double alpha, size_t A,
             int lda, size_t x, int incx, double beta, size_t y, int incy)
-cpdef cgemv(size_t handle, int trans, int m, int n, float complex alpha,
+cpdef cgemv(intptr_t handle, int trans, int m, int n, float complex alpha,
             size_t A, int lda, size_t x, int incx, float complex beta,
             size_t y, int incy)
-cpdef zgemv(size_t handle, int trans, int m, int n, double complex alpha,
+cpdef zgemv(intptr_t handle, int trans, int m, int n, double complex alpha,
             size_t A, int lda, size_t x, int incx, double complex beta,
             size_t y, int incy)
-cpdef sger(size_t handle, int m, int n, float alpha, size_t x, int incx,
+cpdef sger(intptr_t handle, int m, int n, float alpha, size_t x, int incx,
            size_t y, int incy, size_t A, int lda)
-cpdef dger(size_t handle, int m, int n, double alpha, size_t x, int incx,
+cpdef dger(intptr_t handle, int m, int n, double alpha, size_t x, int incx,
            size_t y, int incy, size_t A, int lda)
-cpdef cgeru(size_t handle, int m, int n, float complex alpha, size_t x,
+cpdef cgeru(intptr_t handle, int m, int n, float complex alpha, size_t x,
             int incx, size_t y, int incy, size_t A, int lda)
-cpdef cgerc(size_t handle, int m, int n, float complex alpha, size_t x,
+cpdef cgerc(intptr_t handle, int m, int n, float complex alpha, size_t x,
             int incx, size_t y, int incy, size_t A, int lda)
-cpdef zgeru(size_t handle, int m, int n, double complex alpha, size_t x,
+cpdef zgeru(intptr_t handle, int m, int n, double complex alpha, size_t x,
             int incx, size_t y, int incy, size_t A, int lda)
-cpdef zgerc(size_t handle, int m, int n, double complex alpha, size_t x,
+cpdef zgerc(intptr_t handle, int m, int n, double complex alpha, size_t x,
             int incx, size_t y, int incy, size_t A, int lda)
 
 
@@ -140,72 +140,72 @@ cpdef zgerc(size_t handle, int m, int n, double complex alpha, size_t x,
 # BLAS Level 3
 ###############################################################################
 
-cpdef sgemm(size_t handle, int transa, int transb,
+cpdef sgemm(intptr_t handle, int transa, int transb,
             int m, int n, int k, float alpha, size_t A, int lda,
             size_t B, int ldb, float beta, size_t C, int ldc)
-cpdef dgemm(size_t handle, int transa, int transb,
+cpdef dgemm(intptr_t handle, int transa, int transb,
             int m, int n, int k, double alpha, size_t A, int lda,
             size_t B, int ldb, double beta, size_t C, int ldc)
-cpdef cgemm(size_t handle, int transa, int transb,
+cpdef cgemm(intptr_t handle, int transa, int transb,
             int m, int n, int k, float complex alpha, size_t A, int lda,
             size_t B, int ldb, float complex beta, size_t C, int ldc)
-cpdef zgemm(size_t handle, int transa, int transb,
+cpdef zgemm(intptr_t handle, int transa, int transb,
             int m, int n, int k, double complex alpha, size_t A, int lda,
             size_t B, int ldb, double complex beta, size_t C, int ldc)
-cpdef sgemmBatched(size_t handle, int transa, int transb,
+cpdef sgemmBatched(intptr_t handle, int transa, int transb,
                    int m, int n, int k, float alpha, size_t Aarray, int lda,
                    size_t Barray, int ldb, float beta, size_t Carray, int ldc,
                    int batchCount)
-cpdef dgemmBatched(size_t handle, int transa, int transb,
+cpdef dgemmBatched(intptr_t handle, int transa, int transb,
                    int m, int n, int k, double alpha, size_t Aarray, int lda,
                    size_t Barray, int ldb, double beta, size_t Carray, int ldc,
                    int batchCount)
-cpdef cgemmBatched(size_t handle, int transa, int transb,
+cpdef cgemmBatched(intptr_t handle, int transa, int transb,
                    int m, int n, int k, float complex alpha, size_t Aarray,
                    int lda, size_t Barray, int ldb, float complex beta,
                    size_t Carray, int ldc, int batchCount)
-cpdef zgemmBatched(size_t handle, int transa, int transb,
+cpdef zgemmBatched(intptr_t handle, int transa, int transb,
                    int m, int n, int k, double complex alpha, size_t Aarray,
                    int lda, size_t Barray, int ldb, double complex beta,
                    size_t Carray, int ldc, int batchCount)
-cpdef sgemmStridedBatched(size_t handle, int transa, int transb,
+cpdef sgemmStridedBatched(intptr_t handle, int transa, int transb,
                           int m, int n, int k, float alpha,
                           size_t A, int lda, long long strideA,
                           size_t B, int ldb, long long strideB,
                           float beta,
                           size_t C, int ldc, long long strideC,
                           int batchCount)
-cpdef dgemmStridedBatched(size_t handle, int transa, int transb,
+cpdef dgemmStridedBatched(intptr_t handle, int transa, int transb,
                           int m, int n, int k, double alpha,
                           size_t A, int lda, long long strideA,
                           size_t B, int ldb, long long strideB,
                           double beta,
                           size_t C, int ldc, long long strideC,
                           int batchCount)
-cpdef cgemmStridedBatched(size_t handle, int transa, int transb,
+cpdef cgemmStridedBatched(intptr_t handle, int transa, int transb,
                           int m, int n, int k, float complex alpha,
                           size_t A, int lda, long long strideA,
                           size_t B, int ldb, long long strideB,
                           float complex beta,
                           size_t C, int ldc, long long strideC,
                           int batchCount)
-cpdef zgemmStridedBatched(size_t handle, int transa, int transb,
+cpdef zgemmStridedBatched(intptr_t handle, int transa, int transb,
                           int m, int n, int k, double complex alpha,
                           size_t A, int lda, long long strideA,
                           size_t B, int ldb, long long strideB,
                           double complex beta,
                           size_t C, int ldc, long long strideC,
                           int batchCount)
-cpdef strsm(size_t handle, int side, int uplo, int trans, int diag,
+cpdef strsm(intptr_t handle, int side, int uplo, int trans, int diag,
             int m, int n, float alpha, size_t Aarray, int lda,
             size_t Barray, int ldb)
-cpdef dtrsm(size_t handle, int side, int uplo, int trans, int diag,
+cpdef dtrsm(intptr_t handle, int side, int uplo, int trans, int diag,
             int m, int n, double alpha, size_t Aarray, int lda,
             size_t Barray, int ldb)
-cpdef ctrsm(size_t handle, int side, int uplo, int trans, int diag,
+cpdef ctrsm(intptr_t handle, int side, int uplo, int trans, int diag,
             int m, int n, float complex alpha, size_t Aarray, int lda,
             size_t Barray, int ldb)
-cpdef ztrsm(size_t handle, int side, int uplo, int trans, int diag,
+cpdef ztrsm(intptr_t handle, int side, int uplo, int trans, int diag,
             int m, int n, double complex alpha, size_t Aarray, int lda,
             size_t Barray, int ldb)
 
@@ -213,46 +213,46 @@ cpdef ztrsm(size_t handle, int side, int uplo, int trans, int diag,
 # BLAS extension
 ###############################################################################
 
-cpdef sgeam(size_t handle, int transa, int transb, int m, int n,
+cpdef sgeam(intptr_t handle, int transa, int transb, int m, int n,
             float alpha, size_t A, int lda, float beta, size_t B, int ldb,
             size_t C, int ldc)
-cpdef dgeam(size_t handle, int transa, int transb, int m, int n,
+cpdef dgeam(intptr_t handle, int transa, int transb, int m, int n,
             double alpha, size_t A, int lda, double beta, size_t B, int ldb,
             size_t C, int ldc)
-cpdef sdgmm(size_t handle, int mode, int m, int n, size_t A, int lda,
+cpdef sdgmm(intptr_t handle, int mode, int m, int n, size_t A, int lda,
             size_t x, int incx, size_t C, int ldc)
-cpdef sgemmEx(size_t handle, int transa, int transb, int m, int n, int k,
+cpdef sgemmEx(intptr_t handle, int transa, int transb, int m, int n, int k,
               float alpha, size_t A, int Atype, int lda, size_t B,
               int Btype, int ldb, float beta, size_t C, int Ctype,
               int ldc)
-cpdef sgetrfBatched(size_t handle, int n, size_t Aarray, int lda,
+cpdef sgetrfBatched(intptr_t handle, int n, size_t Aarray, int lda,
                     size_t PivotArray, size_t infoArray, int batchSize)
-cpdef dgetrfBatched(size_t handle, int n, size_t Aarray, int lda,
+cpdef dgetrfBatched(intptr_t handle, int n, size_t Aarray, int lda,
                     size_t PivotArray, size_t infoArray, int batchSize)
-cpdef cgetrfBatched(size_t handle, int n, size_t Aarray, int lda,
+cpdef cgetrfBatched(intptr_t handle, int n, size_t Aarray, int lda,
                     size_t PivotArray, size_t infoArray, int batchSize)
-cpdef zgetrfBatched(size_t handle, int n, size_t Aarray, int lda,
+cpdef zgetrfBatched(intptr_t handle, int n, size_t Aarray, int lda,
                     size_t PivotArray, size_t infoArray, int batchSize)
 
-cpdef sgetriBatched(size_t handle, int n, size_t Aarray, int lda,
+cpdef sgetriBatched(intptr_t handle, int n, size_t Aarray, int lda,
                     size_t PivotArray, size_t Carray, int ldc,
                     size_t infoArray, int batchSize)
-cpdef dgetriBatched(size_t handle, int n, size_t Aarray, int lda,
+cpdef dgetriBatched(intptr_t handle, int n, size_t Aarray, int lda,
                     size_t PivotArray, size_t Carray, int ldc,
                     size_t infoArray, int batchSize)
-cpdef cgetriBatched(size_t handle, int n, size_t Aarray, int lda,
+cpdef cgetriBatched(intptr_t handle, int n, size_t Aarray, int lda,
                     size_t PivotArray, size_t Carray, int ldc,
                     size_t infoArray, int batchSize)
-cpdef zgetriBatched(size_t handle, int n, size_t Aarray, int lda,
+cpdef zgetriBatched(intptr_t handle, int n, size_t Aarray, int lda,
                     size_t PivotArray, size_t Carray, int ldc,
                     size_t infoArray, int batchSize)
-cpdef gemmEx(size_t handle, int transa, int transb, int m, int n, int k,
+cpdef gemmEx(intptr_t handle, int transa, int transb, int m, int n, int k,
              size_t alpha, size_t A, int Atype, int lda, size_t B,
              int Btype, int ldb, size_t beta, size_t C, int Ctype,
              int ldc, int computeType, int algo)
 
-cpdef stpttr(size_t handle, int uplo, int n, size_t AP, size_t A, int lda)
-cpdef dtpttr(size_t handle, int uplo, int n, size_t AP, size_t A, int lda)
+cpdef stpttr(intptr_t handle, int uplo, int n, size_t AP, size_t A, int lda)
+cpdef dtpttr(intptr_t handle, int uplo, int n, size_t AP, size_t A, int lda)
 
-cpdef strttp(size_t handle, int uplo, int n, size_t A, int lda, size_t AP)
-cpdef dtrttp(size_t handle, int uplo, int n, size_t A, int lda, size_t AP)
+cpdef strttp(intptr_t handle, int uplo, int n, size_t A, int lda, size_t AP)
+cpdef dtrttp(intptr_t handle, int uplo, int n, size_t A, int lda, size_t AP)

--- a/cupy/cuda/cublas.pxd
+++ b/cupy/cuda/cublas.pxd
@@ -1,4 +1,5 @@
 """Thin wrapper of CUBLAS."""
+from libc.stdint cimport intptr_t
 
 
 ###############################################################################
@@ -58,7 +59,7 @@ cpdef enum:
 # Context
 ###############################################################################
 
-cpdef size_t create() except? 0
+cpdef intptr_t create() except? 0
 cpdef destroy(intptr_t handle)
 cpdef int getVersion(intptr_t handle) except? -1
 cpdef int getPointerMode(intptr_t handle) except? -1

--- a/cupy/cuda/cublas.pyx
+++ b/cupy/cuda/cublas.pyx
@@ -323,13 +323,13 @@ cpdef size_t create() except? 0:
     return <size_t>handle
 
 
-cpdef destroy(size_t handle):
+cpdef destroy(intptr_t handle):
     with nogil:
         status = cublasDestroy(<Handle>handle)
     check_status(status)
 
 
-cpdef int getVersion(size_t handle) except? -1:
+cpdef int getVersion(intptr_t handle) except? -1:
     cdef int version
     with nogil:
         status = cublasGetVersion(<Handle>handle, &version)
@@ -337,7 +337,7 @@ cpdef int getVersion(size_t handle) except? -1:
     return version
 
 
-cpdef int getPointerMode(size_t handle) except? -1:
+cpdef int getPointerMode(intptr_t handle) except? -1:
     cdef PointerMode mode
     with nogil:
         status = cublasGetPointerMode(<Handle>handle, &mode)
@@ -345,7 +345,7 @@ cpdef int getPointerMode(size_t handle) except? -1:
     return mode
 
 
-cpdef setPointerMode(size_t handle, int mode):
+cpdef setPointerMode(intptr_t handle, int mode):
     with nogil:
         status = cublasSetPointerMode(<Handle>handle, <PointerMode>mode)
     check_status(status)
@@ -355,13 +355,13 @@ cpdef setPointerMode(size_t handle, int mode):
 # Stream
 ###############################################################################
 
-cpdef setStream(size_t handle, size_t stream):
+cpdef setStream(intptr_t handle, size_t stream):
     with nogil:
         status = cublasSetStream(<Handle>handle, <driver.Stream>stream)
     check_status(status)
 
 
-cpdef size_t getStream(size_t handle) except? 0:
+cpdef size_t getStream(intptr_t handle) except? 0:
     cdef driver.Stream stream
     with nogil:
         status = cublasGetStream(<Handle>handle, &stream)
@@ -373,13 +373,13 @@ cpdef size_t getStream(size_t handle) except? 0:
 # Math Mode
 ###############################################################################
 
-cpdef setMathMode(size_t handle, int mode):
+cpdef setMathMode(intptr_t handle, int mode):
     with nogil:
         status = cublasSetMathMode(<Handle>handle, <Math>mode)
     check_status(status)
 
 
-cpdef int getMathMode(size_t handle) except? -1:
+cpdef int getMathMode(intptr_t handle) except? -1:
     cdef Math mode
     with nogil:
         status = cublasGetMathMode(<Handle>handle, &mode)
@@ -391,7 +391,7 @@ cpdef int getMathMode(size_t handle) except? -1:
 # BLAS Level 1
 ###############################################################################
 
-cpdef int isamax(size_t handle, int n, size_t x, int incx) except? 0:
+cpdef int isamax(intptr_t handle, int n, size_t x, int incx) except? 0:
     cdef int result
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -401,7 +401,7 @@ cpdef int isamax(size_t handle, int n, size_t x, int incx) except? 0:
     return result
 
 
-cpdef int isamin(size_t handle, int n, size_t x, int incx) except? 0:
+cpdef int isamin(intptr_t handle, int n, size_t x, int incx) except? 0:
     cdef int result
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -411,7 +411,7 @@ cpdef int isamin(size_t handle, int n, size_t x, int incx) except? 0:
     return result
 
 
-cpdef float sasum(size_t handle, int n, size_t x, int incx) except? 0:
+cpdef float sasum(intptr_t handle, int n, size_t x, int incx) except? 0:
     cdef float result
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -421,7 +421,7 @@ cpdef float sasum(size_t handle, int n, size_t x, int incx) except? 0:
     return result
 
 
-cpdef saxpy(size_t handle, int n, float alpha, size_t x, int incx, size_t y,
+cpdef saxpy(intptr_t handle, int n, float alpha, size_t x, int incx, size_t y,
             int incy):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -430,7 +430,7 @@ cpdef saxpy(size_t handle, int n, float alpha, size_t x, int incx, size_t y,
     check_status(status)
 
 
-cpdef daxpy(size_t handle, int n, double alpha, size_t x, int incx, size_t y,
+cpdef daxpy(intptr_t handle, int n, double alpha, size_t x, int incx, size_t y,
             int incy):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -439,7 +439,7 @@ cpdef daxpy(size_t handle, int n, double alpha, size_t x, int incx, size_t y,
     check_status(status)
 
 
-cpdef sdot(size_t handle, int n, size_t x, int incx, size_t y, int incy,
+cpdef sdot(intptr_t handle, int n, size_t x, int incx, size_t y, int incy,
            size_t result):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -449,7 +449,7 @@ cpdef sdot(size_t handle, int n, size_t x, int incx, size_t y, int incy,
     check_status(status)
 
 
-cpdef ddot(size_t handle, int n, size_t x, int incx, size_t y, int incy,
+cpdef ddot(intptr_t handle, int n, size_t x, int incx, size_t y, int incy,
            size_t result):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -459,7 +459,7 @@ cpdef ddot(size_t handle, int n, size_t x, int incx, size_t y, int incy,
     check_status(status)
 
 
-cpdef cdotu(size_t handle, int n, size_t x, int incx, size_t y, int incy,
+cpdef cdotu(intptr_t handle, int n, size_t x, int incx, size_t y, int incy,
             size_t result):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -469,7 +469,7 @@ cpdef cdotu(size_t handle, int n, size_t x, int incx, size_t y, int incy,
     check_status(status)
 
 
-cpdef cdotc(size_t handle, int n, size_t x, int incx, size_t y, int incy,
+cpdef cdotc(intptr_t handle, int n, size_t x, int incx, size_t y, int incy,
             size_t result):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -479,7 +479,7 @@ cpdef cdotc(size_t handle, int n, size_t x, int incx, size_t y, int incy,
     check_status(status)
 
 
-cpdef zdotu(size_t handle, int n, size_t x, int incx, size_t y, int incy,
+cpdef zdotu(intptr_t handle, int n, size_t x, int incx, size_t y, int incy,
             size_t result):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -489,7 +489,7 @@ cpdef zdotu(size_t handle, int n, size_t x, int incx, size_t y, int incy,
     check_status(status)
 
 
-cpdef zdotc(size_t handle, int n, size_t x, int incx, size_t y, int incy,
+cpdef zdotc(intptr_t handle, int n, size_t x, int incx, size_t y, int incy,
             size_t result):
     with nogil:
         status = cublasZdotc(
@@ -498,7 +498,7 @@ cpdef zdotc(size_t handle, int n, size_t x, int incx, size_t y, int incy,
     check_status(status)
 
 
-cpdef float snrm2(size_t handle, int n, size_t x, int incx) except? 0:
+cpdef float snrm2(intptr_t handle, int n, size_t x, int incx) except? 0:
     cdef float result
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -507,7 +507,7 @@ cpdef float snrm2(size_t handle, int n, size_t x, int incx) except? 0:
     return result
 
 
-cpdef sscal(size_t handle, int n, float alpha, size_t x, int incx):
+cpdef sscal(intptr_t handle, int n, float alpha, size_t x, int incx):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cublasSscal(<Handle>handle, n, &alpha, <float*>x, incx)
@@ -518,7 +518,7 @@ cpdef sscal(size_t handle, int n, float alpha, size_t x, int incx):
 # BLAS Level 2
 ###############################################################################
 
-cpdef sgemv(size_t handle, int trans, int m, int n, float alpha, size_t A,
+cpdef sgemv(intptr_t handle, int trans, int m, int n, float alpha, size_t A,
             int lda, size_t x, int incx, float beta, size_t y, int incy):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -528,7 +528,7 @@ cpdef sgemv(size_t handle, int trans, int m, int n, float alpha, size_t A,
     check_status(status)
 
 
-cpdef dgemv(size_t handle, int trans, int m, int n, double alpha, size_t A,
+cpdef dgemv(intptr_t handle, int trans, int m, int n, double alpha, size_t A,
             int lda, size_t x, int incx, double beta, size_t y, int incy):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -538,7 +538,7 @@ cpdef dgemv(size_t handle, int trans, int m, int n, double alpha, size_t A,
     check_status(status)
 
 
-cpdef cgemv(size_t handle, int trans, int m, int n, float complex alpha,
+cpdef cgemv(intptr_t handle, int trans, int m, int n, float complex alpha,
             size_t A, int lda, size_t x, int incx, float complex beta,
             size_t y, int incy):
     cdef cuComplex a = get_cu_complex(alpha)
@@ -551,7 +551,7 @@ cpdef cgemv(size_t handle, int trans, int m, int n, float complex alpha,
     check_status(status)
 
 
-cpdef zgemv(size_t handle, int trans, int m, int n, double complex alpha,
+cpdef zgemv(intptr_t handle, int trans, int m, int n, double complex alpha,
             size_t A, int lda, size_t x, int incx, double complex beta,
             size_t y, int incy):
     cdef cuDoubleComplex a = get_cu_double_complex(alpha)
@@ -564,7 +564,7 @@ cpdef zgemv(size_t handle, int trans, int m, int n, double complex alpha,
     check_status(status)
 
 
-cpdef sger(size_t handle, int m, int n, float alpha, size_t x, int incx,
+cpdef sger(intptr_t handle, int m, int n, float alpha, size_t x, int incx,
            size_t y, int incy, size_t A, int lda):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -574,7 +574,7 @@ cpdef sger(size_t handle, int m, int n, float alpha, size_t x, int incx,
     check_status(status)
 
 
-cpdef dger(size_t handle, int m, int n, double alpha, size_t x, int incx,
+cpdef dger(intptr_t handle, int m, int n, double alpha, size_t x, int incx,
            size_t y, int incy, size_t A, int lda):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -584,7 +584,7 @@ cpdef dger(size_t handle, int m, int n, double alpha, size_t x, int incx,
     check_status(status)
 
 
-cpdef cgeru(size_t handle, int m, int n, float complex alpha, size_t x,
+cpdef cgeru(intptr_t handle, int m, int n, float complex alpha, size_t x,
             int incx, size_t y, int incy, size_t A, int lda):
     cdef cuComplex a = get_cu_complex(alpha)
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -595,7 +595,7 @@ cpdef cgeru(size_t handle, int m, int n, float complex alpha, size_t x,
     check_status(status)
 
 
-cpdef cgerc(size_t handle, int m, int n, float complex alpha, size_t x,
+cpdef cgerc(intptr_t handle, int m, int n, float complex alpha, size_t x,
             int incx, size_t y, int incy, size_t A, int lda):
     cdef cuComplex a = get_cu_complex(alpha)
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -606,7 +606,7 @@ cpdef cgerc(size_t handle, int m, int n, float complex alpha, size_t x,
     check_status(status)
 
 
-cpdef zgeru(size_t handle, int m, int n, double complex alpha, size_t x,
+cpdef zgeru(intptr_t handle, int m, int n, double complex alpha, size_t x,
             int incx, size_t y, int incy, size_t A, int lda):
     cdef cuDoubleComplex a = get_cu_double_complex(alpha)
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -618,7 +618,7 @@ cpdef zgeru(size_t handle, int m, int n, double complex alpha, size_t x,
     check_status(status)
 
 
-cpdef zgerc(size_t handle, int m, int n, double complex alpha, size_t x,
+cpdef zgerc(intptr_t handle, int m, int n, double complex alpha, size_t x,
             int incx, size_t y, int incy, size_t A, int lda):
     cdef cuDoubleComplex a = get_cu_double_complex(alpha)
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -634,7 +634,7 @@ cpdef zgerc(size_t handle, int m, int n, double complex alpha, size_t x,
 # BLAS Level 3
 ###############################################################################
 
-cpdef sgemm(size_t handle, int transa, int transb,
+cpdef sgemm(intptr_t handle, int transa, int transb,
             int m, int n, int k, float alpha, size_t A, int lda,
             size_t B, int ldb, float beta, size_t C, int ldc):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -645,7 +645,7 @@ cpdef sgemm(size_t handle, int transa, int transb,
     check_status(status)
 
 
-cpdef dgemm(size_t handle, int transa, int transb,
+cpdef dgemm(intptr_t handle, int transa, int transb,
             int m, int n, int k, double alpha, size_t A, int lda,
             size_t B, int ldb, double beta, size_t C, int ldc):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -656,7 +656,7 @@ cpdef dgemm(size_t handle, int transa, int transb,
     check_status(status)
 
 
-cpdef cgemm(size_t handle, int transa, int transb,
+cpdef cgemm(intptr_t handle, int transa, int transb,
             int m, int n, int k, float complex alpha, size_t A, int lda,
             size_t B, int ldb, float complex beta, size_t C, int ldc):
     cdef cuComplex a = get_cu_complex(alpha)
@@ -670,7 +670,7 @@ cpdef cgemm(size_t handle, int transa, int transb,
     check_status(status)
 
 
-cpdef zgemm(size_t handle, int transa, int transb,
+cpdef zgemm(intptr_t handle, int transa, int transb,
             int m, int n, int k, double complex alpha, size_t A, int lda,
             size_t B, int ldb, double complex beta, size_t C, int ldc):
     cdef cuDoubleComplex a = get_cu_double_complex(alpha)
@@ -686,7 +686,7 @@ cpdef zgemm(size_t handle, int transa, int transb,
 
 
 cpdef sgemmBatched(
-        size_t handle, int transa, int transb, int m, int n, int k,
+        intptr_t handle, int transa, int transb, int m, int n, int k,
         float alpha, size_t Aarray, int lda, size_t Barray, int ldb,
         float beta, size_t Carray, int ldc, int batchCount):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -699,7 +699,7 @@ cpdef sgemmBatched(
 
 
 cpdef dgemmBatched(
-        size_t handle, int transa, int transb, int m, int n, int k,
+        intptr_t handle, int transa, int transb, int m, int n, int k,
         double alpha, size_t Aarray, int lda, size_t Barray, int ldb,
         double beta, size_t Carray, int ldc, int batchCount):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -712,7 +712,7 @@ cpdef dgemmBatched(
 
 
 cpdef cgemmBatched(
-        size_t handle, int transa, int transb, int m, int n, int k,
+        intptr_t handle, int transa, int transb, int m, int n, int k,
         float complex alpha, size_t Aarray, int lda, size_t Barray, int ldb,
         float complex beta, size_t Carray, int ldc, int batchCount):
     cdef cuComplex a = get_cu_complex(alpha)
@@ -727,7 +727,7 @@ cpdef cgemmBatched(
 
 
 cpdef zgemmBatched(
-        size_t handle, int transa, int transb, int m, int n, int k,
+        intptr_t handle, int transa, int transb, int m, int n, int k,
         double complex alpha, size_t Aarray, int lda, size_t Barray, int ldb,
         double complex beta, size_t Carray, int ldc, int batchCount):
     cdef cuDoubleComplex a = get_cu_double_complex(alpha)
@@ -742,7 +742,7 @@ cpdef zgemmBatched(
 
 
 cpdef sgemmStridedBatched(
-        size_t handle, int transa, int transb, int m, int n, int k,
+        intptr_t handle, int transa, int transb, int m, int n, int k,
         float alpha,
         size_t A, int lda, long long strideA,
         size_t B, int ldb, long long strideB,
@@ -763,7 +763,7 @@ cpdef sgemmStridedBatched(
 
 
 cpdef dgemmStridedBatched(
-        size_t handle, int transa, int transb, int m, int n, int k,
+        intptr_t handle, int transa, int transb, int m, int n, int k,
         double alpha,
         size_t A, int lda, long long strideA,
         size_t B, int ldb, long long strideB,
@@ -784,7 +784,7 @@ cpdef dgemmStridedBatched(
 
 
 cpdef cgemmStridedBatched(
-        size_t handle, int transa, int transb, int m, int n, int k,
+        intptr_t handle, int transa, int transb, int m, int n, int k,
         float complex alpha,
         size_t A, int lda, long long strideA,
         size_t B, int ldb, long long strideB,
@@ -805,7 +805,7 @@ cpdef cgemmStridedBatched(
 
 
 cpdef zgemmStridedBatched(
-        size_t handle, int transa, int transb, int m, int n, int k,
+        intptr_t handle, int transa, int transb, int m, int n, int k,
         double complex alpha,
         size_t A, int lda, long long strideA,
         size_t B, int ldb, long long strideB,
@@ -826,7 +826,7 @@ cpdef zgemmStridedBatched(
 
 
 cpdef strsm(
-        size_t handle, int side, int uplo, int trans, int diag,
+        intptr_t handle, int side, int uplo, int trans, int diag,
         int m, int n, float alpha, size_t Aarray, int lda,
         size_t Barray, int ldb):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -839,7 +839,7 @@ cpdef strsm(
 
 
 cpdef dtrsm(
-        size_t handle, int side, int uplo, int trans, int diag,
+        intptr_t handle, int side, int uplo, int trans, int diag,
         int m, int n, double alpha, size_t Aarray, int lda,
         size_t Barray, int ldb):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -851,7 +851,7 @@ cpdef dtrsm(
     check_status(status)
 
 cpdef ctrsm(
-        size_t handle, int side, int uplo, int trans, int diag,
+        intptr_t handle, int side, int uplo, int trans, int diag,
         int m, int n, float complex alpha, size_t Aarray, int lda,
         size_t Barray, int ldb):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -865,7 +865,7 @@ cpdef ctrsm(
 
 
 cpdef ztrsm(
-        size_t handle, int side, int uplo, int trans, int diag,
+        intptr_t handle, int side, int uplo, int trans, int diag,
         int m, int n, double complex alpha, size_t Aarray, int lda,
         size_t Barray, int ldb):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -881,7 +881,7 @@ cpdef ztrsm(
 # BLAS extension
 ###############################################################################
 
-cpdef sgeam(size_t handle, int transa, int transb, int m, int n,
+cpdef sgeam(intptr_t handle, int transa, int transb, int m, int n,
             float alpha, size_t A, int lda, float beta, size_t B, int ldb,
             size_t C, int ldc):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -893,7 +893,7 @@ cpdef sgeam(size_t handle, int transa, int transb, int m, int n,
     check_status(status)
 
 
-cpdef dgeam(size_t handle, int transa, int transb, int m, int n,
+cpdef dgeam(intptr_t handle, int transa, int transb, int m, int n,
             double alpha, size_t A, int lda, double beta, size_t B, int ldb,
             size_t C, int ldc):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -905,7 +905,7 @@ cpdef dgeam(size_t handle, int transa, int transb, int m, int n,
     check_status(status)
 
 
-cpdef sdgmm(size_t handle, int mode, int m, int n, size_t A, int lda,
+cpdef sdgmm(intptr_t handle, int mode, int m, int n, size_t A, int lda,
             size_t x, int incx, size_t C, int ldc):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -916,7 +916,7 @@ cpdef sdgmm(size_t handle, int mode, int m, int n, size_t A, int lda,
 
 
 cpdef sgemmEx(
-        size_t handle, int transa, int transb, int m, int n, int k,
+        intptr_t handle, int transa, int transb, int m, int n, int k,
         float alpha, size_t A, int Atype, int lda, size_t B,
         int Btype, int ldb, float beta, size_t C, int Ctype,
         int ldc):
@@ -930,7 +930,7 @@ cpdef sgemmEx(
     check_status(status)
 
 
-cpdef sgetrfBatched(size_t handle, int n, size_t Aarray, int lda,
+cpdef sgetrfBatched(intptr_t handle, int n, size_t Aarray, int lda,
                     size_t PivotArray, size_t infoArray, int batchSize):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -940,7 +940,7 @@ cpdef sgetrfBatched(size_t handle, int n, size_t Aarray, int lda,
     check_status(status)
 
 
-cpdef dgetrfBatched(size_t handle, int n, size_t Aarray, int lda,
+cpdef dgetrfBatched(intptr_t handle, int n, size_t Aarray, int lda,
                     size_t PivotArray, size_t infoArray, int batchSize):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -950,7 +950,7 @@ cpdef dgetrfBatched(size_t handle, int n, size_t Aarray, int lda,
     check_status(status)
 
 
-cpdef cgetrfBatched(size_t handle, int n, size_t Aarray, int lda,
+cpdef cgetrfBatched(intptr_t handle, int n, size_t Aarray, int lda,
                     size_t PivotArray, size_t infoArray, int batchSize):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -960,7 +960,7 @@ cpdef cgetrfBatched(size_t handle, int n, size_t Aarray, int lda,
     check_status(status)
 
 
-cpdef zgetrfBatched(size_t handle, int n, size_t Aarray, int lda,
+cpdef zgetrfBatched(intptr_t handle, int n, size_t Aarray, int lda,
                     size_t PivotArray, size_t infoArray, int batchSize):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -971,7 +971,7 @@ cpdef zgetrfBatched(size_t handle, int n, size_t Aarray, int lda,
 
 
 cpdef sgetriBatched(
-        size_t handle, int n, size_t Aarray, int lda, size_t PivotArray,
+        intptr_t handle, int n, size_t Aarray, int lda, size_t PivotArray,
         size_t Carray, int ldc, size_t infoArray, int batchSize):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -982,7 +982,7 @@ cpdef sgetriBatched(
 
 
 cpdef dgetriBatched(
-        size_t handle, int n, size_t Aarray, int lda, size_t PivotArray,
+        intptr_t handle, int n, size_t Aarray, int lda, size_t PivotArray,
         size_t Carray, int ldc, size_t infoArray, int batchSize):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -993,7 +993,7 @@ cpdef dgetriBatched(
 
 
 cpdef cgetriBatched(
-        size_t handle, int n, size_t Aarray, int lda, size_t PivotArray,
+        intptr_t handle, int n, size_t Aarray, int lda, size_t PivotArray,
         size_t Carray, int ldc, size_t infoArray, int batchSize):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -1005,7 +1005,7 @@ cpdef cgetriBatched(
 
 
 cpdef zgetriBatched(
-        size_t handle, int n, size_t Aarray, int lda, size_t PivotArray,
+        intptr_t handle, int n, size_t Aarray, int lda, size_t PivotArray,
         size_t Carray, int ldc, size_t infoArray, int batchSize):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -1017,7 +1017,7 @@ cpdef zgetriBatched(
 
 
 cpdef gemmEx(
-        size_t handle, int transa, int transb, int m, int n, int k,
+        intptr_t handle, int transa, int transb, int m, int n, int k,
         size_t alpha, size_t A, int Atype, int lda, size_t B,
         int Btype, int ldb, size_t beta, size_t C, int Ctype,
         int ldc, int computeType, int algo):
@@ -1034,7 +1034,7 @@ cpdef gemmEx(
     check_status(status)
 
 
-cpdef stpttr(size_t handle, int uplo, int n, size_t AP, size_t A, int lda):
+cpdef stpttr(intptr_t handle, int uplo, int n, size_t AP, size_t A, int lda):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cublasStpttr(<Handle>handle, <FillMode>uplo, n,
@@ -1042,7 +1042,7 @@ cpdef stpttr(size_t handle, int uplo, int n, size_t AP, size_t A, int lda):
     check_status(status)
 
 
-cpdef dtpttr(size_t handle, int uplo, int n, size_t AP, size_t A, int lda):
+cpdef dtpttr(intptr_t handle, int uplo, int n, size_t AP, size_t A, int lda):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cublasDtpttr(<Handle>handle, <FillMode>uplo, n,
@@ -1050,7 +1050,7 @@ cpdef dtpttr(size_t handle, int uplo, int n, size_t AP, size_t A, int lda):
     check_status(status)
 
 
-cpdef strttp(size_t handle, int uplo, int n, size_t A, int lda, size_t AP):
+cpdef strttp(intptr_t handle, int uplo, int n, size_t A, int lda, size_t AP):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cublasStrttp(<Handle>handle, <FillMode>uplo, n,
@@ -1058,7 +1058,7 @@ cpdef strttp(size_t handle, int uplo, int n, size_t A, int lda, size_t AP):
     check_status(status)
 
 
-cpdef dtrttp(size_t handle, int uplo, int n, size_t A, int lda, size_t AP):
+cpdef dtrttp(intptr_t handle, int uplo, int n, size_t A, int lda, size_t AP):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cublasDtrttp(<Handle>handle, <FillMode>uplo, n,

--- a/cupy/cuda/cublas.pyx
+++ b/cupy/cuda/cublas.pyx
@@ -315,12 +315,12 @@ cpdef inline check_status(int status):
 # Context
 ###############################################################################
 
-cpdef size_t create() except? 0:
+cpdef intptr_t create() except? 0:
     cdef Handle handle
     with nogil:
         status = cublasCreate(&handle)
     check_status(status)
-    return <size_t>handle
+    return <intptr_t>handle
 
 
 cpdef destroy(intptr_t handle):

--- a/cupy/cuda/cusparse.pxd
+++ b/cupy/cuda/cusparse.pxd
@@ -1,3 +1,4 @@
+
 from libc.stdint cimport intptr_t
 
 cdef extern from *:

--- a/cupy/cuda/cusparse.pxd
+++ b/cupy/cuda/cusparse.pxd
@@ -56,5 +56,5 @@ cpdef enum:
     CUSPARSE_ALG_NAIVE = 0
     CUSPARSE_ALG_MERGE_PATH = 1
 
-cpdef size_t create() except? 0
-cpdef destroy(size_t handle)
+cpdef intptr_t create() except? 0
+cpdef destroy(intptr_t handle)

--- a/cupy/cuda/cusparse.pxd
+++ b/cupy/cuda/cusparse.pxd
@@ -1,3 +1,5 @@
+from libc.stdint cimport intptr_t
+
 cdef extern from *:
     ctypedef int IndexBase 'cusparseIndexBase_t'
     ctypedef int Status 'cusparseStatus_t'

--- a/cupy/cuda/cusparse.pyx
+++ b/cupy/cuda/cusparse.pyx
@@ -918,7 +918,7 @@ cdef inline cuDoubleComplex double_complex_to_cuda(double complex value):
     return value_cuda
 
 
-cpdef int getVersion(size_t handle) except? -1:
+cpdef int getVersion(intptr_t handle) except? -1:
     cdef int version
     status = cusparseGetVersion(<Handle>handle, &version)
     check_status(status)
@@ -928,11 +928,11 @@ cpdef int getVersion(size_t handle) except? -1:
 ########################################
 # cuSPARSE Helper Function
 
-cpdef size_t create() except? 0:
+cpdef intptr_t create() except? 0:
     cdef Handle handle
     status = cusparseCreate(& handle)
     check_status(status)
-    return <size_t >handle
+    return <intptr_t>handle
 
 
 cpdef size_t createMatDescr():
@@ -942,7 +942,7 @@ cpdef size_t createMatDescr():
     return <size_t>desc
 
 
-cpdef destroy(size_t handle):
+cpdef destroy(intptr_t handle):
     status = cusparseDestroy(<Handle >handle)
     check_status(status)
 
@@ -962,19 +962,19 @@ cpdef setMatType(size_t descr, typ):
     check_status(status)
 
 
-cpdef setPointerMode(size_t handle, int mode):
+cpdef setPointerMode(intptr_t handle, int mode):
     status = cusparseSetPointerMode(<Handle>handle, <PointerMode>mode)
     check_status(status)
 
 ########################################
 # Stream
 
-cpdef setStream(size_t handle, size_t stream):
+cpdef setStream(intptr_t handle, size_t stream):
     status = cusparseSetStream(<Handle>handle, <driver.Stream>stream)
     check_status(status)
 
 
-cpdef size_t getStream(size_t handle) except? 0:
+cpdef size_t getStream(intptr_t handle) except? 0:
     cdef driver.Stream stream
     status = cusparseGetStream(<Handle>handle, &stream)
     check_status(status)
@@ -984,7 +984,7 @@ cpdef size_t getStream(size_t handle) except? 0:
 ########################################
 # cuSPARSE Level1 Function
 
-cpdef sgthr(size_t handle, int nnz, size_t y, size_t xVal, size_t xInd,
+cpdef sgthr(intptr_t handle, int nnz, size_t y, size_t xVal, size_t xInd,
             int idxBase):
     setStream(handle, stream_module.get_current_stream_ptr())
     status = cusparseSgthr(
@@ -992,7 +992,7 @@ cpdef sgthr(size_t handle, int nnz, size_t y, size_t xVal, size_t xInd,
         <const int *>xInd, <IndexBase>idxBase)
     check_status(status)
 
-cpdef dgthr(size_t handle, int nnz, size_t y, size_t xVal, size_t xInd,
+cpdef dgthr(intptr_t handle, int nnz, size_t y, size_t xVal, size_t xInd,
             int idxBase):
     setStream(handle, stream_module.get_current_stream_ptr())
     status = cusparseDgthr(
@@ -1000,7 +1000,7 @@ cpdef dgthr(size_t handle, int nnz, size_t y, size_t xVal, size_t xInd,
         <const int *>xInd, <IndexBase>idxBase)
     check_status(status)
 
-cpdef cgthr(size_t handle, int nnz, size_t y, size_t xVal, size_t xInd,
+cpdef cgthr(intptr_t handle, int nnz, size_t y, size_t xVal, size_t xInd,
             int idxBase):
     setStream(handle, stream_module.get_current_stream_ptr())
     status = cusparseCgthr(
@@ -1008,7 +1008,7 @@ cpdef cgthr(size_t handle, int nnz, size_t y, size_t xVal, size_t xInd,
         <const int *>xInd, <IndexBase>idxBase)
     check_status(status)
 
-cpdef zgthr(size_t handle, int nnz, size_t y, size_t xVal, size_t xInd,
+cpdef zgthr(intptr_t handle, int nnz, size_t y, size_t xVal, size_t xInd,
             int idxBase):
     setStream(handle, stream_module.get_current_stream_ptr())
     status = cusparseZgthr(
@@ -1020,7 +1020,7 @@ cpdef zgthr(size_t handle, int nnz, size_t y, size_t xVal, size_t xInd,
 # cuSPARSE Level2 Function
 
 cpdef scsrmv(
-        size_t handle, int transA, int m, int n, int nnz,
+        intptr_t handle, int transA, int m, int n, int nnz,
         size_t alpha, size_t descrA, size_t csrSortedValA,
         size_t csrSortedRowPtrA, size_t csrSortedColIndA,
         size_t x, size_t beta, size_t y):
@@ -1033,7 +1033,7 @@ cpdef scsrmv(
     check_status(status)
 
 cpdef dcsrmv(
-        size_t handle, int transA, int m, int n, int nnz,
+        intptr_t handle, int transA, int m, int n, int nnz,
         size_t alpha, size_t descrA, size_t csrSortedValA,
         size_t csrSortedRowPtrA, size_t csrSortedColIndA,
         size_t x, size_t beta, size_t y):
@@ -1046,7 +1046,7 @@ cpdef dcsrmv(
     check_status(status)
 
 cpdef ccsrmv(
-        size_t handle, int transA, int m, int n, int nnz,
+        intptr_t handle, int transA, int m, int n, int nnz,
         size_t alpha, size_t descrA, size_t csrSortedValA,
         size_t csrSortedRowPtrA, size_t csrSortedColIndA,
         size_t x, size_t beta, size_t y):
@@ -1060,7 +1060,7 @@ cpdef ccsrmv(
     check_status(status)
 
 cpdef zcsrmv(
-        size_t handle, int transA, int m, int n, int nnz,
+        intptr_t handle, int transA, int m, int n, int nnz,
         size_t alpha, size_t descrA, size_t csrSortedValA,
         size_t csrSortedRowPtrA, size_t csrSortedColIndA,
         size_t x, size_t beta, size_t y):
@@ -1075,7 +1075,7 @@ cpdef zcsrmv(
     check_status(status)
 
 cpdef size_t csrmvEx_bufferSize(
-        size_t handle, int alg, int transA, int m, int n,
+        intptr_t handle, int alg, int transA, int m, int n,
         int nnz, size_t alpha, int alphatype, size_t descrA,
         size_t csrValA, int csrValAtype, size_t csrRowPtrA,
         size_t csrColIndA, size_t x, int xtype, size_t beta,
@@ -1094,7 +1094,7 @@ cpdef size_t csrmvEx_bufferSize(
     return bufferSizeInBytes
 
 cpdef csrmvEx(
-        size_t handle, int alg, int transA, int m, int n,
+        intptr_t handle, int alg, int transA, int m, int n,
         int nnz, size_t alpha, int alphatype, size_t descrA,
         size_t csrValA, int csrValAtype, size_t csrRowPtrA,
         size_t csrColIndA, size_t x, int xtype, size_t beta,
@@ -1115,7 +1115,7 @@ cpdef csrmvEx(
 # cuSPARSE Level3 Function
 
 cpdef scsrmm(
-        size_t handle, int transA, int m, int n, int k, int nnz,
+        intptr_t handle, int transA, int m, int n, int k, int nnz,
         size_t alpha, size_t descrA, size_t csrSortedValA,
         size_t csrSortedRowPtrA, size_t csrSortedColIndA,
         size_t B, int ldb, size_t beta, size_t C, int ldc):
@@ -1128,7 +1128,7 @@ cpdef scsrmm(
     check_status(status)
 
 cpdef dcsrmm(
-        size_t handle, int transA, int m, int n, int k, int nnz,
+        intptr_t handle, int transA, int m, int n, int k, int nnz,
         size_t alpha, size_t descrA, size_t csrSortedValA,
         size_t csrSortedRowPtrA, size_t csrSortedColIndA,
         size_t B, int ldb, size_t beta, size_t C, int ldc):
@@ -1141,7 +1141,7 @@ cpdef dcsrmm(
     check_status(status)
 
 cpdef ccsrmm(
-        size_t handle, int transA, int m, int n, int k, int nnz,
+        intptr_t handle, int transA, int m, int n, int k, int nnz,
         size_t alpha, size_t descrA, size_t csrSortedValA,
         size_t csrSortedRowPtrA, size_t csrSortedColIndA,
         size_t B, int ldb, size_t beta, size_t C, int ldc):
@@ -1156,7 +1156,7 @@ cpdef ccsrmm(
     check_status(status)
 
 cpdef zcsrmm(
-        size_t handle, int transA, int m, int n, int k, int nnz,
+        intptr_t handle, int transA, int m, int n, int k, int nnz,
         size_t alpha, size_t descrA, size_t csrSortedValA,
         size_t csrSortedRowPtrA, size_t csrSortedColIndA,
         size_t B, int ldb, size_t beta, size_t C, int ldc):
@@ -1171,7 +1171,7 @@ cpdef zcsrmm(
     check_status(status)
 
 cpdef scsrmm2(
-        size_t handle, int transA, int transB, int m, int n, int k, int nnz,
+        intptr_t handle, int transA, int transB, int m, int n, int k, int nnz,
         size_t alpha, size_t descrA, size_t csrValA,
         size_t csrRowPtrA, size_t csrColIndA,
         size_t B, int ldb, size_t beta, size_t C, int ldc):
@@ -1184,7 +1184,7 @@ cpdef scsrmm2(
     check_status(status)
 
 cpdef dcsrmm2(
-        size_t handle, int transA, int transB, int m, int n, int k, int nnz,
+        intptr_t handle, int transA, int transB, int m, int n, int k, int nnz,
         size_t alpha, size_t descrA, size_t csrValA,
         size_t csrRowPtrA, size_t csrColIndA,
         size_t B, int ldb, size_t beta, size_t C, int ldc):
@@ -1197,7 +1197,7 @@ cpdef dcsrmm2(
     check_status(status)
 
 cpdef ccsrmm2(
-        size_t handle, int transA, int transB, int m, int n, int k, int nnz,
+        intptr_t handle, int transA, int transB, int m, int n, int k, int nnz,
         size_t alpha, size_t descrA, size_t csrValA,
         size_t csrRowPtrA, size_t csrColIndA,
         size_t B, int ldb, size_t beta, size_t C, int ldc):
@@ -1211,7 +1211,7 @@ cpdef ccsrmm2(
     check_status(status)
 
 cpdef zcsrmm2(
-        size_t handle, int transA, int transB, int m, int n, int k, int nnz,
+        intptr_t handle, int transA, int transB, int m, int n, int k, int nnz,
         size_t alpha, size_t descrA, size_t csrValA,
         size_t csrRowPtrA, size_t csrColIndA,
         size_t B, int ldb, size_t beta, size_t C, int ldc):
@@ -1229,7 +1229,7 @@ cpdef zcsrmm2(
 # cuSPARSE Extra Function
 
 cpdef xcsrgeamNnz(
-        size_t handle, int m, int n, size_t descrA, int nnzA,
+        intptr_t handle, int m, int n, size_t descrA, int nnzA,
         size_t csrRowPtrA, size_t csrColIndA, size_t descrB,
         int nnzB, size_t csrRowPtrB, size_t csrColIndB,
         size_t descrC, size_t csrRowPtrC, size_t nnzTotalDevHostPtr):
@@ -1243,7 +1243,7 @@ cpdef xcsrgeamNnz(
     check_status(status)
 
 cpdef scsrgeam(
-        size_t handle, int m, int n, size_t alpha, size_t descrA,
+        intptr_t handle, int m, int n, size_t alpha, size_t descrA,
         int nnzA, size_t csrValA, size_t csrRowPtrA,
         size_t csrColIndA, size_t beta, size_t descrB,
         int nnzB, size_t csrValB, size_t csrRowPtrB,
@@ -1262,7 +1262,7 @@ cpdef scsrgeam(
 
 
 cpdef dcsrgeam(
-        size_t handle, int m, int n, size_t alpha, size_t descrA,
+        intptr_t handle, int m, int n, size_t alpha, size_t descrA,
         int nnzA, size_t csrValA, size_t csrRowPtrA,
         size_t csrColIndA, size_t beta, size_t descrB,
         int nnzB, size_t csrValB, size_t csrRowPtrB,
@@ -1280,7 +1280,7 @@ cpdef dcsrgeam(
     check_status(status)
 
 cpdef ccsrgeam(
-        size_t handle, int m, int n, size_t alpha, size_t descrA,
+        intptr_t handle, int m, int n, size_t alpha, size_t descrA,
         int nnzA, size_t csrValA, size_t csrRowPtrA,
         size_t csrColIndA, size_t beta, size_t descrB,
         int nnzB, size_t csrValB, size_t csrRowPtrB,
@@ -1299,7 +1299,7 @@ cpdef ccsrgeam(
     check_status(status)
 
 cpdef zcsrgeam(
-        size_t handle, int m, int n, size_t alpha, size_t descrA,
+        intptr_t handle, int m, int n, size_t alpha, size_t descrA,
         int nnzA, size_t csrValA, size_t csrRowPtrA,
         size_t csrColIndA, size_t beta, size_t descrB,
         int nnzB, size_t csrValB, size_t csrRowPtrB,
@@ -1318,7 +1318,7 @@ cpdef zcsrgeam(
     check_status(status)
 
 cpdef xcsrgemmNnz(
-        size_t handle, int transA, int transB, int m, int n, int k,
+        intptr_t handle, int transA, int transB, int m, int n, int k,
         size_t descrA, int nnzA, size_t csrRowPtrA,
         size_t csrColIndA, size_t descrB, int nnzB,
         size_t csrRowPtrB, size_t csrColIndB,
@@ -1334,7 +1334,7 @@ cpdef xcsrgemmNnz(
 
 
 cpdef scsrgemm(
-        size_t handle, int transA, int transB, int m, int n, int k,
+        intptr_t handle, int transA, int transB, int m, int n, int k,
         size_t descrA, const int nnzA, size_t csrValA,
         size_t csrRowPtrA, size_t csrColIndA, size_t descrB,
         const int nnzB, size_t csrValB, size_t csrRowPtrB,
@@ -1353,7 +1353,7 @@ cpdef scsrgemm(
 
 
 cpdef dcsrgemm(
-        size_t handle, int transA, int transB, int m, int n, int k,
+        intptr_t handle, int transA, int transB, int m, int n, int k,
         size_t descrA, const int nnzA, size_t csrValA,
         size_t csrRowPtrA, size_t csrColIndA, size_t descrB,
         const int nnzB, size_t csrValB, size_t csrRowPtrB,
@@ -1371,7 +1371,7 @@ cpdef dcsrgemm(
     check_status(status)
 
 cpdef ccsrgemm(
-        size_t handle, int transA, int transB, int m, int n, int k,
+        intptr_t handle, int transA, int transB, int m, int n, int k,
         size_t descrA, const int nnzA, size_t csrValA,
         size_t csrRowPtrA, size_t csrColIndA, size_t descrB,
         const int nnzB, size_t csrValB, size_t csrRowPtrB,
@@ -1389,7 +1389,7 @@ cpdef ccsrgemm(
     check_status(status)
 
 cpdef zcsrgemm(
-        size_t handle, int transA, int transB, int m, int n, int k,
+        intptr_t handle, int transA, int transB, int m, int n, int k,
         size_t descrA, const int nnzA, size_t csrValA,
         size_t csrRowPtrA, size_t csrColIndA, size_t descrB,
         const int nnzB, size_t csrValB, size_t csrRowPtrB,
@@ -1410,7 +1410,7 @@ cpdef zcsrgemm(
 # cuSPARSE Format Convrsion
 
 cpdef xcoo2csr(
-        size_t handle, size_t cooRowInd, int nnz, int m, size_t csrRowPtr,
+        intptr_t handle, size_t cooRowInd, int nnz, int m, size_t csrRowPtr,
         int idxBase):
     setStream(handle, stream_module.get_current_stream_ptr())
     status = cusparseXcoo2csr(
@@ -1420,7 +1420,7 @@ cpdef xcoo2csr(
 
 
 cpdef scsc2dense(
-        size_t handle, int m, int n, size_t descrA,
+        intptr_t handle, int m, int n, size_t descrA,
         size_t cscSortedValA, size_t cscSortedRowIndA,
         size_t cscSortedColPtrA, size_t A, int lda):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -1432,7 +1432,7 @@ cpdef scsc2dense(
 
 
 cpdef dcsc2dense(
-        size_t handle, int m, int n, size_t descrA,
+        intptr_t handle, int m, int n, size_t descrA,
         size_t cscSortedValA, size_t cscSortedRowIndA,
         size_t cscSortedColPtrA, size_t A, int lda):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -1443,7 +1443,7 @@ cpdef dcsc2dense(
     check_status(status)
 
 cpdef ccsc2dense(
-        size_t handle, int m, int n, size_t descrA,
+        intptr_t handle, int m, int n, size_t descrA,
         size_t cscSortedValA, size_t cscSortedRowIndA,
         size_t cscSortedColPtrA, size_t A, int lda):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -1454,7 +1454,7 @@ cpdef ccsc2dense(
     check_status(status)
 
 cpdef zcsc2dense(
-        size_t handle, int m, int n, size_t descrA,
+        intptr_t handle, int m, int n, size_t descrA,
         size_t cscSortedValA, size_t cscSortedRowIndA,
         size_t cscSortedColPtrA, size_t A, int lda):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -1465,7 +1465,7 @@ cpdef zcsc2dense(
     check_status(status)
 
 cpdef xcsr2coo(
-        size_t handle, size_t csrRowPtr, int nnz, int m, size_t cooRowInd,
+        intptr_t handle, size_t csrRowPtr, int nnz, int m, size_t cooRowInd,
         int idxBase):
     setStream(handle, stream_module.get_current_stream_ptr())
     status = cusparseXcsr2coo(
@@ -1475,7 +1475,7 @@ cpdef xcsr2coo(
 
 
 cpdef scsr2csc(
-        size_t handle, int m, int n, int nnz, size_t csrVal,
+        intptr_t handle, int m, int n, int nnz, size_t csrVal,
         size_t csrRowPtr, size_t csrColInd, size_t cscVal,
         size_t cscRowInd, size_t cscColPtr, int copyValues, int idxBase):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -1488,7 +1488,7 @@ cpdef scsr2csc(
 
 
 cpdef dcsr2csc(
-        size_t handle, int m, int n, int nnz, size_t csrVal,
+        intptr_t handle, int m, int n, int nnz, size_t csrVal,
         size_t csrRowPtr, size_t csrColInd, size_t cscVal,
         size_t cscRowInd, size_t cscColPtr, int copyValues, int idxBase):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -1500,7 +1500,7 @@ cpdef dcsr2csc(
     check_status(status)
 
 cpdef ccsr2csc(
-        size_t handle, int m, int n, int nnz, size_t csrVal,
+        intptr_t handle, int m, int n, int nnz, size_t csrVal,
         size_t csrRowPtr, size_t csrColInd, size_t cscVal,
         size_t cscRowInd, size_t cscColPtr, int copyValues, int idxBase):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -1512,7 +1512,7 @@ cpdef ccsr2csc(
     check_status(status)
 
 cpdef zcsr2csc(
-        size_t handle, int m, int n, int nnz, size_t csrVal,
+        intptr_t handle, int m, int n, int nnz, size_t csrVal,
         size_t csrRowPtr, size_t csrColInd, size_t cscVal,
         size_t cscRowInd, size_t cscColPtr, int copyValues, int idxBase):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -1525,7 +1525,7 @@ cpdef zcsr2csc(
     check_status(status)
 
 cpdef scsr2dense(
-        size_t handle, int m, int n, size_t descrA,
+        intptr_t handle, int m, int n, size_t descrA,
         size_t csrSortedValA, size_t csrSortedRowPtrA,
         size_t csrSortedColIndA, size_t A, int lda):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -1536,7 +1536,7 @@ cpdef scsr2dense(
     check_status(status)
 
 cpdef dcsr2dense(
-        size_t handle, int m, int n, size_t descrA,
+        intptr_t handle, int m, int n, size_t descrA,
         size_t csrSortedValA, size_t csrSortedRowPtrA,
         size_t csrSortedColIndA, size_t A, int lda):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -1547,7 +1547,7 @@ cpdef dcsr2dense(
     check_status(status)
 
 cpdef ccsr2dense(
-        size_t handle, int m, int n, size_t descrA,
+        intptr_t handle, int m, int n, size_t descrA,
         size_t csrSortedValA, size_t csrSortedRowPtrA,
         size_t csrSortedColIndA, size_t A, int lda):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -1558,7 +1558,7 @@ cpdef ccsr2dense(
     check_status(status)
 
 cpdef zcsr2dense(
-        size_t handle, int m, int n, size_t descrA,
+        intptr_t handle, int m, int n, size_t descrA,
         size_t csrSortedValA, size_t csrSortedRowPtrA,
         size_t csrSortedColIndA, size_t A, int lda):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -1569,7 +1569,7 @@ cpdef zcsr2dense(
     check_status(status)
 
 cpdef snnz_compress(
-        size_t handle, int m, size_t descr,
+        intptr_t handle, int m, size_t descr,
         size_t values, size_t rowPtr, size_t nnzPerRow,
         float tol):
     cdef int nnz_total
@@ -1582,7 +1582,7 @@ cpdef snnz_compress(
     return nnz_total
 
 cpdef dnnz_compress(
-        size_t handle, int m, size_t descr,
+        intptr_t handle, int m, size_t descr,
         size_t values, size_t rowPtr, size_t nnzPerRow,
         double tol):
     cdef int nnz_total
@@ -1595,7 +1595,7 @@ cpdef dnnz_compress(
     return nnz_total
 
 cpdef cnnz_compress(
-        size_t handle, int m, size_t descr,
+        intptr_t handle, int m, size_t descr,
         size_t values, size_t rowPtr, size_t nnzPerRow,
         complex tol):
     cdef int nnz_total
@@ -1608,7 +1608,7 @@ cpdef cnnz_compress(
     return nnz_total
 
 cpdef znnz_compress(
-        size_t handle, int m, size_t descr,
+        intptr_t handle, int m, size_t descr,
         size_t values, size_t rowPtr, size_t nnzPerRow,
         double complex tol):
     cdef int nnz_total
@@ -1621,7 +1621,7 @@ cpdef znnz_compress(
     return nnz_total
 
 cpdef scsr2csr_compress(
-        size_t handle, int m, int n, size_t descrA,
+        intptr_t handle, int m, int n, size_t descrA,
         size_t inVal, size_t inColInd, size_t inRowPtr,
         int inNnz, size_t nnzPerRow, size_t outVal, size_t outColInd,
         size_t outRowPtr, float tol):
@@ -1635,7 +1635,7 @@ cpdef scsr2csr_compress(
 
 
 cpdef dcsr2csr_compress(
-        size_t handle, int m, int n, size_t descrA,
+        intptr_t handle, int m, int n, size_t descrA,
         size_t inVal, size_t inColInd, size_t inRowPtr,
         int inNnz, size_t nnzPerRow, size_t outVal, size_t outColInd,
         size_t outRowPtr, float tol):
@@ -1648,7 +1648,7 @@ cpdef dcsr2csr_compress(
     check_status(status)
 
 cpdef ccsr2csr_compress(
-        size_t handle, int m, int n, size_t descrA,
+        intptr_t handle, int m, int n, size_t descrA,
         size_t inVal, size_t inColInd, size_t inRowPtr,
         int inNnz, size_t nnzPerRow, size_t outVal, size_t outColInd,
         size_t outRowPtr, complex tol):
@@ -1661,7 +1661,7 @@ cpdef ccsr2csr_compress(
     check_status(status)
 
 cpdef zcsr2csr_compress(
-        size_t handle, int m, int n, size_t descrA,
+        intptr_t handle, int m, int n, size_t descrA,
         size_t inVal, size_t inColInd, size_t inRowPtr,
         int inNnz, size_t nnzPerRow, size_t outVal, size_t outColInd,
         size_t outRowPtr, double complex tol):
@@ -1675,7 +1675,7 @@ cpdef zcsr2csr_compress(
     check_status(status)
 
 cpdef sdense2csc(
-        size_t handle, int m, int n, size_t descrA, size_t A,
+        intptr_t handle, int m, int n, size_t descrA, size_t A,
         int lda, size_t nnzPerCol, size_t cscValA, size_t cscRowIndA,
         size_t cscColPtrA):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -1687,7 +1687,7 @@ cpdef sdense2csc(
 
 
 cpdef ddense2csc(
-        size_t handle, int m, int n, size_t descrA, size_t A,
+        intptr_t handle, int m, int n, size_t descrA, size_t A,
         int lda, size_t nnzPerCol, size_t cscValA, size_t cscRowIndA,
         size_t cscColPtrA):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -1698,7 +1698,7 @@ cpdef ddense2csc(
     check_status(status)
 
 cpdef cdense2csc(
-        size_t handle, int m, int n, size_t descrA, size_t A,
+        intptr_t handle, int m, int n, size_t descrA, size_t A,
         int lda, size_t nnzPerCol, size_t cscValA, size_t cscRowIndA,
         size_t cscColPtrA):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -1709,7 +1709,7 @@ cpdef cdense2csc(
     check_status(status)
 
 cpdef zdense2csc(
-        size_t handle, int m, int n, size_t descrA, size_t A,
+        intptr_t handle, int m, int n, size_t descrA, size_t A,
         int lda, size_t nnzPerCol, size_t cscValA, size_t cscRowIndA,
         size_t cscColPtrA):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -1722,7 +1722,7 @@ cpdef zdense2csc(
     check_status(status)
 
 cpdef sdense2csr(
-        size_t handle, int m, int n, size_t descrA,
+        intptr_t handle, int m, int n, size_t descrA,
         size_t A, int lda, size_t nnzPerRow, size_t csrValA,
         size_t csrRowPtrA, size_t csrColIndA):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -1734,7 +1734,7 @@ cpdef sdense2csr(
 
 
 cpdef ddense2csr(
-        size_t handle, int m, int n, size_t descrA,
+        intptr_t handle, int m, int n, size_t descrA,
         size_t A, int lda, size_t nnzPerRow, size_t csrValA,
         size_t csrRowPtrA, size_t csrColIndA):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -1745,7 +1745,7 @@ cpdef ddense2csr(
     check_status(status)
 
 cpdef cdense2csr(
-        size_t handle, int m, int n, size_t descrA,
+        intptr_t handle, int m, int n, size_t descrA,
         size_t A, int lda, size_t nnzPerRow, size_t csrValA,
         size_t csrRowPtrA, size_t csrColIndA):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -1756,7 +1756,7 @@ cpdef cdense2csr(
     check_status(status)
 
 cpdef zdense2csr(
-        size_t handle, int m, int n, size_t descrA,
+        intptr_t handle, int m, int n, size_t descrA,
         size_t A, int lda, size_t nnzPerRow, size_t csrValA,
         size_t csrRowPtrA, size_t csrColIndA):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -1767,7 +1767,7 @@ cpdef zdense2csr(
     check_status(status)
 
 cpdef snnz(
-        size_t handle, int dirA, int m, int n, size_t descrA,
+        intptr_t handle, int dirA, int m, int n, size_t descrA,
         size_t A, int lda, size_t nnzPerRowColumn, size_t nnzTotalDevHostPtr):
     setStream(handle, stream_module.get_current_stream_ptr())
     status = cusparseSnnz(
@@ -1778,7 +1778,7 @@ cpdef snnz(
 
 
 cpdef dnnz(
-        size_t handle, int dirA, int m, int n, size_t descrA,
+        intptr_t handle, int dirA, int m, int n, size_t descrA,
         size_t A, int lda, size_t nnzPerRowColumn, size_t nnzTotalDevHostPtr):
     setStream(handle, stream_module.get_current_stream_ptr())
     status = cusparseDnnz(
@@ -1788,7 +1788,7 @@ cpdef dnnz(
     check_status(status)
 
 cpdef cnnz(
-        size_t handle, int dirA, int m, int n, size_t descrA,
+        intptr_t handle, int dirA, int m, int n, size_t descrA,
         size_t A, int lda, size_t nnzPerRowColumn, size_t nnzTotalDevHostPtr):
     setStream(handle, stream_module.get_current_stream_ptr())
     status = cusparseCnnz(
@@ -1798,7 +1798,7 @@ cpdef cnnz(
     check_status(status)
 
 cpdef znnz(
-        size_t handle, int dirA, int m, int n, size_t descrA,
+        intptr_t handle, int dirA, int m, int n, size_t descrA,
         size_t A, int lda, size_t nnzPerRowColumn, size_t nnzTotalDevHostPtr):
     setStream(handle, stream_module.get_current_stream_ptr())
     status = cusparseZnnz(
@@ -1808,7 +1808,7 @@ cpdef znnz(
     check_status(status)
 
 cpdef createIdentityPermutation(
-        size_t handle, int n, size_t p):
+        intptr_t handle, int n, size_t p):
     setStream(handle, stream_module.get_current_stream_ptr())
     status = cusparseCreateIdentityPermutation(
         <Handle>handle, n, <int *>p)
@@ -1816,7 +1816,7 @@ cpdef createIdentityPermutation(
 
 
 cpdef size_t xcoosort_bufferSizeExt(
-        size_t handle, int m, int n, int nnz, size_t cooRows,
+        intptr_t handle, int m, int n, int nnz, size_t cooRows,
         size_t cooCols):
     cdef size_t bufferSizeInBytes
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -1828,7 +1828,7 @@ cpdef size_t xcoosort_bufferSizeExt(
 
 
 cpdef xcoosortByRow(
-        size_t handle, int m, int n, int nnz, size_t cooRows, size_t cooCols,
+        intptr_t handle, int m, int n, int nnz, size_t cooRows, size_t cooCols,
         size_t P, size_t pBuffer):
     setStream(handle, stream_module.get_current_stream_ptr())
     status = cusparseXcoosortByRow(
@@ -1838,7 +1838,7 @@ cpdef xcoosortByRow(
 
 
 cpdef size_t xcsrsort_bufferSizeExt(
-        size_t handle, int m, int n, int nnz, size_t csrRowPtr,
+        intptr_t handle, int m, int n, int nnz, size_t csrRowPtr,
         size_t csrColInd):
     cdef size_t bufferSizeInBytes
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -1850,7 +1850,7 @@ cpdef size_t xcsrsort_bufferSizeExt(
 
 
 cpdef xcsrsort(
-        size_t handle, int m, int n, int nnz, size_t descrA,
+        intptr_t handle, int m, int n, int nnz, size_t descrA,
         size_t csrRowPtr, size_t csrColInd, size_t P, size_t pBuffer):
     setStream(handle, stream_module.get_current_stream_ptr())
     status = cusparseXcsrsort(
@@ -1860,7 +1860,7 @@ cpdef xcsrsort(
 
 
 cpdef size_t xcscsort_bufferSizeExt(
-        size_t handle, int m, int n, int nnz, size_t cscColPtr,
+        intptr_t handle, int m, int n, int nnz, size_t cscColPtr,
         size_t cscRowInd):
     cdef size_t bufferSizeInBytes
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -1872,7 +1872,7 @@ cpdef size_t xcscsort_bufferSizeExt(
 
 
 cpdef xcscsort(
-        size_t handle, int m, int n, int nnz, size_t descrA,
+        intptr_t handle, int m, int n, int nnz, size_t descrA,
         size_t cscColPtr, size_t cscRowInd, size_t P, size_t pBuffer):
     setStream(handle, stream_module.get_current_stream_ptr())
     status = cusparseXcscsort(
@@ -1931,7 +1931,7 @@ cpdef destroyBsric02Info(size_t info):
         status = cusparseDestroyBsric02Info(<bsric02Info_t>info)
     check_status(status)
 
-cpdef scsrilu02_numericBoost(size_t handle, size_t info, int enable_boost,
+cpdef scsrilu02_numericBoost(intptr_t handle, size_t info, int enable_boost,
                              size_t tol, size_t boost_val):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -1940,7 +1940,7 @@ cpdef scsrilu02_numericBoost(size_t handle, size_t info, int enable_boost,
             <double*>tol, <float*>boost_val)
     check_status(status)
 
-cpdef dcsrilu02_numericBoost(size_t handle, size_t info, int enable_boost,
+cpdef dcsrilu02_numericBoost(intptr_t handle, size_t info, int enable_boost,
                              size_t tol, size_t boost_val):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -1949,7 +1949,7 @@ cpdef dcsrilu02_numericBoost(size_t handle, size_t info, int enable_boost,
             <double*>tol, <double*>boost_val)
     check_status(status)
 
-cpdef ccsrilu02_numericBoost(size_t handle, size_t info, int enable_boost,
+cpdef ccsrilu02_numericBoost(intptr_t handle, size_t info, int enable_boost,
                              size_t tol, size_t boost_val):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -1958,7 +1958,7 @@ cpdef ccsrilu02_numericBoost(size_t handle, size_t info, int enable_boost,
             <double*>tol, <cuComplex*>boost_val)
     check_status(status)
 
-cpdef zcsrilu02_numericBoost(size_t handle, size_t info, int enable_boost,
+cpdef zcsrilu02_numericBoost(intptr_t handle, size_t info, int enable_boost,
                              size_t tol, size_t boost_val):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -1967,14 +1967,14 @@ cpdef zcsrilu02_numericBoost(size_t handle, size_t info, int enable_boost,
             <double*>tol, <cuDoubleComplex*>boost_val)
     check_status(status)
 
-cpdef xcsrilu02_zeroPivot(size_t handle, size_t info, size_t position):
+cpdef xcsrilu02_zeroPivot(intptr_t handle, size_t info, size_t position):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cusparseXcsrilu02_zeroPivot(
             <cusparseHandle_t>handle, <csrilu02Info_t>info, <int*>position)
     check_status(status)
 
-cpdef int scsrilu02_bufferSize(size_t handle, int m, int nnz, size_t descrA,
+cpdef int scsrilu02_bufferSize(intptr_t handle, int m, int nnz, size_t descrA,
                                size_t csrSortedValA, size_t csrSortedRowPtrA,
                                size_t csrSortedColIndA, size_t info):
     cdef int pBufferSizeInBytes
@@ -1988,7 +1988,7 @@ cpdef int scsrilu02_bufferSize(size_t handle, int m, int nnz, size_t descrA,
     check_status(status)
     return <int>pBufferSizeInBytes
 
-cpdef int dcsrilu02_bufferSize(size_t handle, int m, int nnz, size_t descrA,
+cpdef int dcsrilu02_bufferSize(intptr_t handle, int m, int nnz, size_t descrA,
                                size_t csrSortedValA, size_t csrSortedRowPtrA,
                                size_t csrSortedColIndA, size_t info):
     cdef int pBufferSizeInBytes
@@ -2002,7 +2002,7 @@ cpdef int dcsrilu02_bufferSize(size_t handle, int m, int nnz, size_t descrA,
     check_status(status)
     return <int>pBufferSizeInBytes
 
-cpdef int ccsrilu02_bufferSize(size_t handle, int m, int nnz, size_t descrA,
+cpdef int ccsrilu02_bufferSize(intptr_t handle, int m, int nnz, size_t descrA,
                                size_t csrSortedValA, size_t csrSortedRowPtrA,
                                size_t csrSortedColIndA, size_t info):
     cdef int pBufferSizeInBytes
@@ -2016,7 +2016,7 @@ cpdef int ccsrilu02_bufferSize(size_t handle, int m, int nnz, size_t descrA,
     check_status(status)
     return <int>pBufferSizeInBytes
 
-cpdef int zcsrilu02_bufferSize(size_t handle, int m, int nnz, size_t descrA,
+cpdef int zcsrilu02_bufferSize(intptr_t handle, int m, int nnz, size_t descrA,
                                size_t csrSortedValA, size_t csrSortedRowPtrA,
                                size_t csrSortedColIndA, size_t info):
     cdef int pBufferSizeInBytes
@@ -2030,7 +2030,7 @@ cpdef int zcsrilu02_bufferSize(size_t handle, int m, int nnz, size_t descrA,
     check_status(status)
     return <int>pBufferSizeInBytes
 
-cpdef scsrilu02_analysis(size_t handle, int m, int nnz, size_t descrA,
+cpdef scsrilu02_analysis(intptr_t handle, int m, int nnz, size_t descrA,
                          size_t csrSortedValA, size_t csrSortedRowPtrA,
                          size_t csrSortedColIndA, size_t info, int policy,
                          size_t pBuffer):
@@ -2043,7 +2043,7 @@ cpdef scsrilu02_analysis(size_t handle, int m, int nnz, size_t descrA,
             <cusparseSolvePolicy_t>policy, <void*>pBuffer)
     check_status(status)
 
-cpdef dcsrilu02_analysis(size_t handle, int m, int nnz, size_t descrA,
+cpdef dcsrilu02_analysis(intptr_t handle, int m, int nnz, size_t descrA,
                          size_t csrSortedValA, size_t csrSortedRowPtrA,
                          size_t csrSortedColIndA, size_t info, int policy,
                          size_t pBuffer):
@@ -2056,7 +2056,7 @@ cpdef dcsrilu02_analysis(size_t handle, int m, int nnz, size_t descrA,
             <cusparseSolvePolicy_t>policy, <void*>pBuffer)
     check_status(status)
 
-cpdef ccsrilu02_analysis(size_t handle, int m, int nnz, size_t descrA,
+cpdef ccsrilu02_analysis(intptr_t handle, int m, int nnz, size_t descrA,
                          size_t csrSortedValA, size_t csrSortedRowPtrA,
                          size_t csrSortedColIndA, size_t info, int policy,
                          size_t pBuffer):
@@ -2069,7 +2069,7 @@ cpdef ccsrilu02_analysis(size_t handle, int m, int nnz, size_t descrA,
             <cusparseSolvePolicy_t>policy, <void*>pBuffer)
     check_status(status)
 
-cpdef zcsrilu02_analysis(size_t handle, int m, int nnz, size_t descrA,
+cpdef zcsrilu02_analysis(intptr_t handle, int m, int nnz, size_t descrA,
                          size_t csrSortedValA, size_t csrSortedRowPtrA,
                          size_t csrSortedColIndA, size_t info, int policy,
                          size_t pBuffer):
@@ -2083,7 +2083,7 @@ cpdef zcsrilu02_analysis(size_t handle, int m, int nnz, size_t descrA,
             <void*>pBuffer)
     check_status(status)
 
-cpdef scsrilu02(size_t handle, int m, int nnz, size_t descrA,
+cpdef scsrilu02(intptr_t handle, int m, int nnz, size_t descrA,
                 size_t csrSortedValA_valM, size_t csrSortedRowPtrA,
                 size_t csrSortedColIndA, size_t info, int policy,
                 size_t pBuffer):
@@ -2096,7 +2096,7 @@ cpdef scsrilu02(size_t handle, int m, int nnz, size_t descrA,
             <cusparseSolvePolicy_t>policy, <void*>pBuffer)
     check_status(status)
 
-cpdef dcsrilu02(size_t handle, int m, int nnz, size_t descrA,
+cpdef dcsrilu02(intptr_t handle, int m, int nnz, size_t descrA,
                 size_t csrSortedValA_valM, size_t csrSortedRowPtrA,
                 size_t csrSortedColIndA, size_t info, int policy,
                 size_t pBuffer):
@@ -2109,7 +2109,7 @@ cpdef dcsrilu02(size_t handle, int m, int nnz, size_t descrA,
             <cusparseSolvePolicy_t>policy, <void*>pBuffer)
     check_status(status)
 
-cpdef ccsrilu02(size_t handle, int m, int nnz, size_t descrA,
+cpdef ccsrilu02(intptr_t handle, int m, int nnz, size_t descrA,
                 size_t csrSortedValA_valM, size_t csrSortedRowPtrA,
                 size_t csrSortedColIndA, size_t info, int policy,
                 size_t pBuffer):
@@ -2122,7 +2122,7 @@ cpdef ccsrilu02(size_t handle, int m, int nnz, size_t descrA,
             <cusparseSolvePolicy_t>policy, <void*>pBuffer)
     check_status(status)
 
-cpdef zcsrilu02(size_t handle, int m, int nnz, size_t descrA,
+cpdef zcsrilu02(intptr_t handle, int m, int nnz, size_t descrA,
                 size_t csrSortedValA_valM, size_t csrSortedRowPtrA,
                 size_t csrSortedColIndA, size_t info, int policy,
                 size_t pBuffer):
@@ -2135,7 +2135,7 @@ cpdef zcsrilu02(size_t handle, int m, int nnz, size_t descrA,
             <cusparseSolvePolicy_t>policy, <void*>pBuffer)
     check_status(status)
 
-cpdef sbsrilu02_numericBoost(size_t handle, size_t info, int enable_boost,
+cpdef sbsrilu02_numericBoost(intptr_t handle, size_t info, int enable_boost,
                              size_t tol, size_t boost_val):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -2144,7 +2144,7 @@ cpdef sbsrilu02_numericBoost(size_t handle, size_t info, int enable_boost,
             <double*>tol, <float*>boost_val)
     check_status(status)
 
-cpdef dbsrilu02_numericBoost(size_t handle, size_t info, int enable_boost,
+cpdef dbsrilu02_numericBoost(intptr_t handle, size_t info, int enable_boost,
                              size_t tol, size_t boost_val):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -2153,7 +2153,7 @@ cpdef dbsrilu02_numericBoost(size_t handle, size_t info, int enable_boost,
             <double*>tol, <double*>boost_val)
     check_status(status)
 
-cpdef cbsrilu02_numericBoost(size_t handle, size_t info, int enable_boost,
+cpdef cbsrilu02_numericBoost(intptr_t handle, size_t info, int enable_boost,
                              size_t tol, size_t boost_val):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -2162,7 +2162,7 @@ cpdef cbsrilu02_numericBoost(size_t handle, size_t info, int enable_boost,
             <double*>tol, <cuComplex*>boost_val)
     check_status(status)
 
-cpdef zbsrilu02_numericBoost(size_t handle, size_t info, int enable_boost,
+cpdef zbsrilu02_numericBoost(intptr_t handle, size_t info, int enable_boost,
                              size_t tol, size_t boost_val):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -2171,14 +2171,14 @@ cpdef zbsrilu02_numericBoost(size_t handle, size_t info, int enable_boost,
             <double*>tol, <cuDoubleComplex*>boost_val)
     check_status(status)
 
-cpdef xbsrilu02_zeroPivot(size_t handle, size_t info, size_t position):
+cpdef xbsrilu02_zeroPivot(intptr_t handle, size_t info, size_t position):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cusparseXbsrilu02_zeroPivot(
             <cusparseHandle_t>handle, <bsrilu02Info_t>info, <int*>position)
     check_status(status)
 
-cpdef int sbsrilu02_bufferSize(size_t handle, int dirA, int mb, int nnzb,
+cpdef int sbsrilu02_bufferSize(intptr_t handle, int dirA, int mb, int nnzb,
                                size_t descrA, size_t bsrSortedVal,
                                size_t bsrSortedRowPtr, size_t bsrSortedColInd,
                                int blockDim, size_t info):
@@ -2193,7 +2193,7 @@ cpdef int sbsrilu02_bufferSize(size_t handle, int dirA, int mb, int nnzb,
     check_status(status)
     return <int>pBufferSizeInBytes
 
-cpdef int dbsrilu02_bufferSize(size_t handle, int dirA, int mb, int nnzb,
+cpdef int dbsrilu02_bufferSize(intptr_t handle, int dirA, int mb, int nnzb,
                                size_t descrA, size_t bsrSortedVal,
                                size_t bsrSortedRowPtr, size_t bsrSortedColInd,
                                int blockDim, size_t info):
@@ -2208,7 +2208,7 @@ cpdef int dbsrilu02_bufferSize(size_t handle, int dirA, int mb, int nnzb,
     check_status(status)
     return <int>pBufferSizeInBytes
 
-cpdef int cbsrilu02_bufferSize(size_t handle, int dirA, int mb, int nnzb,
+cpdef int cbsrilu02_bufferSize(intptr_t handle, int dirA, int mb, int nnzb,
                                size_t descrA, size_t bsrSortedVal,
                                size_t bsrSortedRowPtr, size_t bsrSortedColInd,
                                int blockDim, size_t info):
@@ -2223,7 +2223,7 @@ cpdef int cbsrilu02_bufferSize(size_t handle, int dirA, int mb, int nnzb,
     check_status(status)
     return <int>pBufferSizeInBytes
 
-cpdef int zbsrilu02_bufferSize(size_t handle, int dirA, int mb, int nnzb,
+cpdef int zbsrilu02_bufferSize(intptr_t handle, int dirA, int mb, int nnzb,
                                size_t descrA, size_t bsrSortedVal,
                                size_t bsrSortedRowPtr, size_t bsrSortedColInd,
                                int blockDim, size_t info):
@@ -2239,7 +2239,7 @@ cpdef int zbsrilu02_bufferSize(size_t handle, int dirA, int mb, int nnzb,
     return <int>pBufferSizeInBytes
 
 cpdef sbsrilu02_analysis(
-        size_t handle, int dirA, int mb, int nnzb, size_t descrA,
+        intptr_t handle, int dirA, int mb, int nnzb, size_t descrA,
         size_t bsrSortedVal, size_t bsrSortedRowPtr, size_t bsrSortedColInd,
         int blockDim, size_t info, int policy, size_t pBuffer):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -2253,7 +2253,7 @@ cpdef sbsrilu02_analysis(
     check_status(status)
 
 cpdef dbsrilu02_analysis(
-        size_t handle, int dirA, int mb, int nnzb, size_t descrA,
+        intptr_t handle, int dirA, int mb, int nnzb, size_t descrA,
         size_t bsrSortedVal, size_t bsrSortedRowPtr, size_t bsrSortedColInd,
         int blockDim, size_t info, int policy, size_t pBuffer):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -2267,7 +2267,7 @@ cpdef dbsrilu02_analysis(
     check_status(status)
 
 cpdef cbsrilu02_analysis(
-        size_t handle, int dirA, int mb, int nnzb, size_t descrA,
+        intptr_t handle, int dirA, int mb, int nnzb, size_t descrA,
         size_t bsrSortedVal, size_t bsrSortedRowPtr, size_t bsrSortedColInd,
         int blockDim, size_t info, int policy, size_t pBuffer):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -2281,7 +2281,7 @@ cpdef cbsrilu02_analysis(
     check_status(status)
 
 cpdef zbsrilu02_analysis(
-        size_t handle, int dirA, int mb, int nnzb, size_t descrA,
+        intptr_t handle, int dirA, int mb, int nnzb, size_t descrA,
         size_t bsrSortedVal, size_t bsrSortedRowPtr, size_t bsrSortedColInd,
         int blockDim, size_t info, int policy, size_t pBuffer):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -2294,7 +2294,7 @@ cpdef zbsrilu02_analysis(
             <void*>pBuffer)
     check_status(status)
 
-cpdef sbsrilu02(size_t handle, int dirA, int mb, int nnzb, size_t descrA,
+cpdef sbsrilu02(intptr_t handle, int dirA, int mb, int nnzb, size_t descrA,
                 size_t bsrSortedVal, size_t bsrSortedRowPtr,
                 size_t bsrSortedColInd, int blockDim, size_t info, int policy,
                 size_t pBuffer):
@@ -2308,7 +2308,7 @@ cpdef sbsrilu02(size_t handle, int dirA, int mb, int nnzb, size_t descrA,
             <void*>pBuffer)
     check_status(status)
 
-cpdef dbsrilu02(size_t handle, int dirA, int mb, int nnzb, size_t descrA,
+cpdef dbsrilu02(intptr_t handle, int dirA, int mb, int nnzb, size_t descrA,
                 size_t bsrSortedVal, size_t bsrSortedRowPtr,
                 size_t bsrSortedColInd, int blockDim, size_t info, int policy,
                 size_t pBuffer):
@@ -2322,7 +2322,7 @@ cpdef dbsrilu02(size_t handle, int dirA, int mb, int nnzb, size_t descrA,
             <void*>pBuffer)
     check_status(status)
 
-cpdef cbsrilu02(size_t handle, int dirA, int mb, int nnzb, size_t descrA,
+cpdef cbsrilu02(intptr_t handle, int dirA, int mb, int nnzb, size_t descrA,
                 size_t bsrSortedVal, size_t bsrSortedRowPtr,
                 size_t bsrSortedColInd, int blockDim, size_t info, int policy,
                 size_t pBuffer):
@@ -2336,7 +2336,7 @@ cpdef cbsrilu02(size_t handle, int dirA, int mb, int nnzb, size_t descrA,
             <void*>pBuffer)
     check_status(status)
 
-cpdef zbsrilu02(size_t handle, int dirA, int mb, int nnzb, size_t descrA,
+cpdef zbsrilu02(intptr_t handle, int dirA, int mb, int nnzb, size_t descrA,
                 size_t bsrSortedVal, size_t bsrSortedRowPtr,
                 size_t bsrSortedColInd, int blockDim, size_t info, int policy,
                 size_t pBuffer):
@@ -2350,14 +2350,14 @@ cpdef zbsrilu02(size_t handle, int dirA, int mb, int nnzb, size_t descrA,
             <void*>pBuffer)
     check_status(status)
 
-cpdef xcsric02_zeroPivot(size_t handle, size_t info, size_t position):
+cpdef xcsric02_zeroPivot(intptr_t handle, size_t info, size_t position):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cusparseXcsric02_zeroPivot(
             <cusparseHandle_t>handle, <csric02Info_t>info, <int*>position)
     check_status(status)
 
-cpdef int scsric02_bufferSize(size_t handle, int m, int nnz, size_t descrA,
+cpdef int scsric02_bufferSize(intptr_t handle, int m, int nnz, size_t descrA,
                               size_t csrSortedValA, size_t csrSortedRowPtrA,
                               size_t csrSortedColIndA, size_t info):
     cdef int pBufferSizeInBytes
@@ -2371,7 +2371,7 @@ cpdef int scsric02_bufferSize(size_t handle, int m, int nnz, size_t descrA,
     check_status(status)
     return <int>pBufferSizeInBytes
 
-cpdef int dcsric02_bufferSize(size_t handle, int m, int nnz, size_t descrA,
+cpdef int dcsric02_bufferSize(intptr_t handle, int m, int nnz, size_t descrA,
                               size_t csrSortedValA, size_t csrSortedRowPtrA,
                               size_t csrSortedColIndA, size_t info):
     cdef int pBufferSizeInBytes
@@ -2385,7 +2385,7 @@ cpdef int dcsric02_bufferSize(size_t handle, int m, int nnz, size_t descrA,
     check_status(status)
     return <int>pBufferSizeInBytes
 
-cpdef int ccsric02_bufferSize(size_t handle, int m, int nnz, size_t descrA,
+cpdef int ccsric02_bufferSize(intptr_t handle, int m, int nnz, size_t descrA,
                               size_t csrSortedValA, size_t csrSortedRowPtrA,
                               size_t csrSortedColIndA, size_t info):
     cdef int pBufferSizeInBytes
@@ -2399,7 +2399,7 @@ cpdef int ccsric02_bufferSize(size_t handle, int m, int nnz, size_t descrA,
     check_status(status)
     return <int>pBufferSizeInBytes
 
-cpdef int zcsric02_bufferSize(size_t handle, int m, int nnz, size_t descrA,
+cpdef int zcsric02_bufferSize(intptr_t handle, int m, int nnz, size_t descrA,
                               size_t csrSortedValA, size_t csrSortedRowPtrA,
                               size_t csrSortedColIndA, size_t info):
     cdef int pBufferSizeInBytes
@@ -2413,7 +2413,7 @@ cpdef int zcsric02_bufferSize(size_t handle, int m, int nnz, size_t descrA,
     check_status(status)
     return <int>pBufferSizeInBytes
 
-cpdef scsric02_analysis(size_t handle, int m, int nnz, size_t descrA,
+cpdef scsric02_analysis(intptr_t handle, int m, int nnz, size_t descrA,
                         size_t csrSortedValA, size_t csrSortedRowPtrA,
                         size_t csrSortedColIndA, size_t info, int policy,
                         size_t pBuffer):
@@ -2426,7 +2426,7 @@ cpdef scsric02_analysis(size_t handle, int m, int nnz, size_t descrA,
             <cusparseSolvePolicy_t>policy, <void*>pBuffer)
     check_status(status)
 
-cpdef dcsric02_analysis(size_t handle, int m, int nnz, size_t descrA,
+cpdef dcsric02_analysis(intptr_t handle, int m, int nnz, size_t descrA,
                         size_t csrSortedValA, size_t csrSortedRowPtrA,
                         size_t csrSortedColIndA, size_t info, int policy,
                         size_t pBuffer):
@@ -2439,7 +2439,7 @@ cpdef dcsric02_analysis(size_t handle, int m, int nnz, size_t descrA,
             <cusparseSolvePolicy_t>policy, <void*>pBuffer)
     check_status(status)
 
-cpdef ccsric02_analysis(size_t handle, int m, int nnz, size_t descrA,
+cpdef ccsric02_analysis(intptr_t handle, int m, int nnz, size_t descrA,
                         size_t csrSortedValA, size_t csrSortedRowPtrA,
                         size_t csrSortedColIndA, size_t info, int policy,
                         size_t pBuffer):
@@ -2452,7 +2452,7 @@ cpdef ccsric02_analysis(size_t handle, int m, int nnz, size_t descrA,
             <cusparseSolvePolicy_t>policy, <void*>pBuffer)
     check_status(status)
 
-cpdef zcsric02_analysis(size_t handle, int m, int nnz, size_t descrA,
+cpdef zcsric02_analysis(intptr_t handle, int m, int nnz, size_t descrA,
                         size_t csrSortedValA, size_t csrSortedRowPtrA,
                         size_t csrSortedColIndA, size_t info, int policy,
                         size_t pBuffer):
@@ -2465,7 +2465,7 @@ cpdef zcsric02_analysis(size_t handle, int m, int nnz, size_t descrA,
             <csric02Info_t>info, <cusparseSolvePolicy_t>policy, <void*>pBuffer)
     check_status(status)
 
-cpdef scsric02(size_t handle, int m, int nnz, size_t descrA,
+cpdef scsric02(intptr_t handle, int m, int nnz, size_t descrA,
                size_t csrSortedValA_valM, size_t csrSortedRowPtrA,
                size_t csrSortedColIndA, size_t info, int policy,
                size_t pBuffer):
@@ -2478,7 +2478,7 @@ cpdef scsric02(size_t handle, int m, int nnz, size_t descrA,
             <cusparseSolvePolicy_t>policy, <void*>pBuffer)
     check_status(status)
 
-cpdef dcsric02(size_t handle, int m, int nnz, size_t descrA,
+cpdef dcsric02(intptr_t handle, int m, int nnz, size_t descrA,
                size_t csrSortedValA_valM, size_t csrSortedRowPtrA,
                size_t csrSortedColIndA, size_t info, int policy,
                size_t pBuffer):
@@ -2491,7 +2491,7 @@ cpdef dcsric02(size_t handle, int m, int nnz, size_t descrA,
             <cusparseSolvePolicy_t>policy, <void*>pBuffer)
     check_status(status)
 
-cpdef ccsric02(size_t handle, int m, int nnz, size_t descrA,
+cpdef ccsric02(intptr_t handle, int m, int nnz, size_t descrA,
                size_t csrSortedValA_valM, size_t csrSortedRowPtrA,
                size_t csrSortedColIndA, size_t info, int policy,
                size_t pBuffer):
@@ -2504,7 +2504,7 @@ cpdef ccsric02(size_t handle, int m, int nnz, size_t descrA,
             <cusparseSolvePolicy_t>policy, <void*>pBuffer)
     check_status(status)
 
-cpdef zcsric02(size_t handle, int m, int nnz, size_t descrA,
+cpdef zcsric02(intptr_t handle, int m, int nnz, size_t descrA,
                size_t csrSortedValA_valM, size_t csrSortedRowPtrA,
                size_t csrSortedColIndA, size_t info, int policy,
                size_t pBuffer):
@@ -2517,14 +2517,14 @@ cpdef zcsric02(size_t handle, int m, int nnz, size_t descrA,
             <cusparseSolvePolicy_t>policy, <void*>pBuffer)
     check_status(status)
 
-cpdef xbsric02_zeroPivot(size_t handle, size_t info, size_t position):
+cpdef xbsric02_zeroPivot(intptr_t handle, size_t info, size_t position):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cusparseXbsric02_zeroPivot(
             <cusparseHandle_t>handle, <bsric02Info_t>info, <int*>position)
     check_status(status)
 
-cpdef int sbsric02_bufferSize(size_t handle, int dirA, int mb, int nnzb,
+cpdef int sbsric02_bufferSize(intptr_t handle, int dirA, int mb, int nnzb,
                               size_t descrA, size_t bsrSortedVal,
                               size_t bsrSortedRowPtr, size_t bsrSortedColInd,
                               int blockDim, size_t info):
@@ -2539,7 +2539,7 @@ cpdef int sbsric02_bufferSize(size_t handle, int dirA, int mb, int nnzb,
     check_status(status)
     return <int>pBufferSizeInBytes
 
-cpdef int dbsric02_bufferSize(size_t handle, int dirA, int mb, int nnzb,
+cpdef int dbsric02_bufferSize(intptr_t handle, int dirA, int mb, int nnzb,
                               size_t descrA, size_t bsrSortedVal,
                               size_t bsrSortedRowPtr, size_t bsrSortedColInd,
                               int blockDim, size_t info):
@@ -2554,7 +2554,7 @@ cpdef int dbsric02_bufferSize(size_t handle, int dirA, int mb, int nnzb,
     check_status(status)
     return <int>pBufferSizeInBytes
 
-cpdef int cbsric02_bufferSize(size_t handle, int dirA, int mb, int nnzb,
+cpdef int cbsric02_bufferSize(intptr_t handle, int dirA, int mb, int nnzb,
                               size_t descrA, size_t bsrSortedVal,
                               size_t bsrSortedRowPtr, size_t bsrSortedColInd,
                               int blockDim, size_t info):
@@ -2569,7 +2569,7 @@ cpdef int cbsric02_bufferSize(size_t handle, int dirA, int mb, int nnzb,
     check_status(status)
     return <int>pBufferSizeInBytes
 
-cpdef int zbsric02_bufferSize(size_t handle, int dirA, int mb, int nnzb,
+cpdef int zbsric02_bufferSize(intptr_t handle, int dirA, int mb, int nnzb,
                               size_t descrA, size_t bsrSortedVal,
                               size_t bsrSortedRowPtr, size_t bsrSortedColInd,
                               int blockDim, size_t info):
@@ -2585,7 +2585,7 @@ cpdef int zbsric02_bufferSize(size_t handle, int dirA, int mb, int nnzb,
     return <int>pBufferSizeInBytes
 
 cpdef sbsric02_analysis(
-        size_t handle, int dirA, int mb, int nnzb, size_t descrA,
+        intptr_t handle, int dirA, int mb, int nnzb, size_t descrA,
         size_t bsrSortedVal, size_t bsrSortedRowPtr, size_t bsrSortedColInd,
         int blockDim, size_t info, int policy, size_t pInputBuffer):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -2599,7 +2599,7 @@ cpdef sbsric02_analysis(
     check_status(status)
 
 cpdef dbsric02_analysis(
-        size_t handle, int dirA, int mb, int nnzb, size_t descrA,
+        intptr_t handle, int dirA, int mb, int nnzb, size_t descrA,
         size_t bsrSortedVal, size_t bsrSortedRowPtr, size_t bsrSortedColInd,
         int blockDim, size_t info, int policy, size_t pInputBuffer):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -2613,7 +2613,7 @@ cpdef dbsric02_analysis(
     check_status(status)
 
 cpdef cbsric02_analysis(
-        size_t handle, int dirA, int mb, int nnzb, size_t descrA,
+        intptr_t handle, int dirA, int mb, int nnzb, size_t descrA,
         size_t bsrSortedVal, size_t bsrSortedRowPtr, size_t bsrSortedColInd,
         int blockDim, size_t info, int policy, size_t pInputBuffer):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -2627,7 +2627,7 @@ cpdef cbsric02_analysis(
     check_status(status)
 
 cpdef zbsric02_analysis(
-        size_t handle, int dirA, int mb, int nnzb, size_t descrA,
+        intptr_t handle, int dirA, int mb, int nnzb, size_t descrA,
         size_t bsrSortedVal, size_t bsrSortedRowPtr, size_t bsrSortedColInd,
         int blockDim, size_t info, int policy, size_t pInputBuffer):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -2640,7 +2640,7 @@ cpdef zbsric02_analysis(
             <cusparseSolvePolicy_t>policy, <void*>pInputBuffer)
     check_status(status)
 
-cpdef sbsric02(size_t handle, int dirA, int mb, int nnzb, size_t descrA,
+cpdef sbsric02(intptr_t handle, int dirA, int mb, int nnzb, size_t descrA,
                size_t bsrSortedVal, size_t bsrSortedRowPtr,
                size_t bsrSortedColInd, int blockDim, size_t info, int policy,
                size_t pBuffer):
@@ -2653,7 +2653,7 @@ cpdef sbsric02(size_t handle, int dirA, int mb, int nnzb, size_t descrA,
             <bsric02Info_t>info, <cusparseSolvePolicy_t>policy, <void*>pBuffer)
     check_status(status)
 
-cpdef dbsric02(size_t handle, int dirA, int mb, int nnzb, size_t descrA,
+cpdef dbsric02(intptr_t handle, int dirA, int mb, int nnzb, size_t descrA,
                size_t bsrSortedVal, size_t bsrSortedRowPtr,
                size_t bsrSortedColInd, int blockDim, size_t info, int policy,
                size_t pBuffer):
@@ -2666,7 +2666,7 @@ cpdef dbsric02(size_t handle, int dirA, int mb, int nnzb, size_t descrA,
             <bsric02Info_t>info, <cusparseSolvePolicy_t>policy, <void*>pBuffer)
     check_status(status)
 
-cpdef cbsric02(size_t handle, int dirA, int mb, int nnzb, size_t descrA,
+cpdef cbsric02(intptr_t handle, int dirA, int mb, int nnzb, size_t descrA,
                size_t bsrSortedVal, size_t bsrSortedRowPtr,
                size_t bsrSortedColInd, int blockDim, size_t info, int policy,
                size_t pBuffer):
@@ -2679,7 +2679,7 @@ cpdef cbsric02(size_t handle, int dirA, int mb, int nnzb, size_t descrA,
             <bsric02Info_t>info, <cusparseSolvePolicy_t>policy, <void*>pBuffer)
     check_status(status)
 
-cpdef zbsric02(size_t handle, int dirA, int mb, int nnzb, size_t descrA,
+cpdef zbsric02(intptr_t handle, int dirA, int mb, int nnzb, size_t descrA,
                size_t bsrSortedVal, size_t bsrSortedRowPtr,
                size_t bsrSortedColInd, int blockDim, size_t info, int policy,
                size_t pBuffer):
@@ -2692,7 +2692,7 @@ cpdef zbsric02(size_t handle, int dirA, int mb, int nnzb, size_t descrA,
             <bsric02Info_t>info, <cusparseSolvePolicy_t>policy, <void*>pBuffer)
     check_status(status)
 
-cpdef sgtsv2_bufferSizeExt(size_t handle, int m, int n, size_t dl, size_t d,
+cpdef sgtsv2_bufferSizeExt(intptr_t handle, int m, int n, size_t dl, size_t d,
                            size_t du, size_t B, int ldb,
                            size_t bufferSizeInBytes):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -2702,7 +2702,7 @@ cpdef sgtsv2_bufferSizeExt(size_t handle, int m, int n, size_t dl, size_t d,
             <const float*>du, <const float*>B, ldb, <size_t*>bufferSizeInBytes)
     check_status(status)
 
-cpdef dgtsv2_bufferSizeExt(size_t handle, int m, int n, size_t dl, size_t d,
+cpdef dgtsv2_bufferSizeExt(intptr_t handle, int m, int n, size_t dl, size_t d,
                            size_t du, size_t B, int ldb,
                            size_t bufferSizeInBytes):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -2713,7 +2713,7 @@ cpdef dgtsv2_bufferSizeExt(size_t handle, int m, int n, size_t dl, size_t d,
             <size_t*>bufferSizeInBytes)
     check_status(status)
 
-cpdef cgtsv2_bufferSizeExt(size_t handle, int m, int n, size_t dl, size_t d,
+cpdef cgtsv2_bufferSizeExt(intptr_t handle, int m, int n, size_t dl, size_t d,
                            size_t du, size_t B, int ldb,
                            size_t bufferSizeInBytes):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -2724,7 +2724,7 @@ cpdef cgtsv2_bufferSizeExt(size_t handle, int m, int n, size_t dl, size_t d,
             ldb, <size_t*>bufferSizeInBytes)
     check_status(status)
 
-cpdef zgtsv2_bufferSizeExt(size_t handle, int m, int n, size_t dl, size_t d,
+cpdef zgtsv2_bufferSizeExt(intptr_t handle, int m, int n, size_t dl, size_t d,
                            size_t du, size_t B, int ldb,
                            size_t bufferSizeInBytes):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -2735,7 +2735,7 @@ cpdef zgtsv2_bufferSizeExt(size_t handle, int m, int n, size_t dl, size_t d,
             <const cuDoubleComplex*>B, ldb, <size_t*>bufferSizeInBytes)
     check_status(status)
 
-cpdef sgtsv2(size_t handle, int m, int n, size_t dl, size_t d, size_t du,
+cpdef sgtsv2(intptr_t handle, int m, int n, size_t dl, size_t d, size_t du,
              size_t B, int ldb, size_t pBuffer):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -2744,7 +2744,7 @@ cpdef sgtsv2(size_t handle, int m, int n, size_t dl, size_t d, size_t du,
             <const float*>du, <float*>B, ldb, <void*>pBuffer)
     check_status(status)
 
-cpdef dgtsv2(size_t handle, int m, int n, size_t dl, size_t d, size_t du,
+cpdef dgtsv2(intptr_t handle, int m, int n, size_t dl, size_t d, size_t du,
              size_t B, int ldb, size_t pBuffer):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -2754,7 +2754,7 @@ cpdef dgtsv2(size_t handle, int m, int n, size_t dl, size_t d, size_t du,
                                 <void*>pBuffer)
     check_status(status)
 
-cpdef cgtsv2(size_t handle, int m, int n, size_t dl, size_t d, size_t du,
+cpdef cgtsv2(intptr_t handle, int m, int n, size_t dl, size_t d, size_t du,
              size_t B, int ldb, size_t pBuffer):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -2764,7 +2764,7 @@ cpdef cgtsv2(size_t handle, int m, int n, size_t dl, size_t d, size_t du,
                                 <void*>pBuffer)
     check_status(status)
 
-cpdef zgtsv2(size_t handle, int m, int n, size_t dl, size_t d, size_t du,
+cpdef zgtsv2(intptr_t handle, int m, int n, size_t dl, size_t d, size_t du,
              size_t B, int ldb, size_t pBuffer):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -2774,7 +2774,7 @@ cpdef zgtsv2(size_t handle, int m, int n, size_t dl, size_t d, size_t du,
             <cuDoubleComplex*>B, ldb, <void*>pBuffer)
     check_status(status)
 
-cpdef sgtsv2_nopivot_bufferSizeExt(size_t handle, int m, int n, size_t dl,
+cpdef sgtsv2_nopivot_bufferSizeExt(intptr_t handle, int m, int n, size_t dl,
                                    size_t d, size_t du, size_t B, int ldb,
                                    size_t bufferSizeInBytes):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -2784,7 +2784,7 @@ cpdef sgtsv2_nopivot_bufferSizeExt(size_t handle, int m, int n, size_t dl,
             <const float*>du, <const float*>B, ldb, <size_t*>bufferSizeInBytes)
     check_status(status)
 
-cpdef dgtsv2_nopivot_bufferSizeExt(size_t handle, int m, int n, size_t dl,
+cpdef dgtsv2_nopivot_bufferSizeExt(intptr_t handle, int m, int n, size_t dl,
                                    size_t d, size_t du, size_t B, int ldb,
                                    size_t bufferSizeInBytes):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -2795,7 +2795,7 @@ cpdef dgtsv2_nopivot_bufferSizeExt(size_t handle, int m, int n, size_t dl,
             <size_t*>bufferSizeInBytes)
     check_status(status)
 
-cpdef cgtsv2_nopivot_bufferSizeExt(size_t handle, int m, int n, size_t dl,
+cpdef cgtsv2_nopivot_bufferSizeExt(intptr_t handle, int m, int n, size_t dl,
                                    size_t d, size_t du, size_t B, int ldb,
                                    size_t bufferSizeInBytes):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -2806,7 +2806,7 @@ cpdef cgtsv2_nopivot_bufferSizeExt(size_t handle, int m, int n, size_t dl,
             ldb, <size_t*>bufferSizeInBytes)
     check_status(status)
 
-cpdef zgtsv2_nopivot_bufferSizeExt(size_t handle, int m, int n, size_t dl,
+cpdef zgtsv2_nopivot_bufferSizeExt(intptr_t handle, int m, int n, size_t dl,
                                    size_t d, size_t du, size_t B, int ldb,
                                    size_t bufferSizeInBytes):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -2817,7 +2817,7 @@ cpdef zgtsv2_nopivot_bufferSizeExt(size_t handle, int m, int n, size_t dl,
             <const cuDoubleComplex*>B, ldb, <size_t*>bufferSizeInBytes)
     check_status(status)
 
-cpdef sgtsv2_nopivot(size_t handle, int m, int n, size_t dl, size_t d,
+cpdef sgtsv2_nopivot(intptr_t handle, int m, int n, size_t dl, size_t d,
                      size_t du, size_t B, int ldb, size_t pBuffer):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -2826,7 +2826,7 @@ cpdef sgtsv2_nopivot(size_t handle, int m, int n, size_t dl, size_t d,
             <const float*>du, <float*>B, ldb, <void*>pBuffer)
     check_status(status)
 
-cpdef dgtsv2_nopivot(size_t handle, int m, int n, size_t dl, size_t d,
+cpdef dgtsv2_nopivot(intptr_t handle, int m, int n, size_t dl, size_t d,
                      size_t du, size_t B, int ldb, size_t pBuffer):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -2836,7 +2836,7 @@ cpdef dgtsv2_nopivot(size_t handle, int m, int n, size_t dl, size_t d,
                                         <void*>pBuffer)
     check_status(status)
 
-cpdef cgtsv2_nopivot(size_t handle, int m, int n, size_t dl, size_t d,
+cpdef cgtsv2_nopivot(intptr_t handle, int m, int n, size_t dl, size_t d,
                      size_t du, size_t B, int ldb, size_t pBuffer):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -2846,7 +2846,7 @@ cpdef cgtsv2_nopivot(size_t handle, int m, int n, size_t dl, size_t d,
             <void*>pBuffer)
     check_status(status)
 
-cpdef zgtsv2_nopivot(size_t handle, int m, int n, size_t dl, size_t d,
+cpdef zgtsv2_nopivot(intptr_t handle, int m, int n, size_t dl, size_t d,
                      size_t du, size_t B, int ldb, size_t pBuffer):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -2857,7 +2857,7 @@ cpdef zgtsv2_nopivot(size_t handle, int m, int n, size_t dl, size_t d,
     check_status(status)
 
 cpdef sgtsv2StridedBatch_bufferSizeExt(
-        size_t handle, int m, size_t dl, size_t d, size_t du, size_t x,
+        intptr_t handle, int m, size_t dl, size_t d, size_t du, size_t x,
         int batchCount, int batchStride, size_t bufferSizeInBytes):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -2868,7 +2868,7 @@ cpdef sgtsv2StridedBatch_bufferSizeExt(
     check_status(status)
 
 cpdef dgtsv2StridedBatch_bufferSizeExt(
-        size_t handle, int m, size_t dl, size_t d, size_t du, size_t x,
+        intptr_t handle, int m, size_t dl, size_t d, size_t du, size_t x,
         int batchCount, int batchStride, size_t bufferSizeInBytes):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -2879,7 +2879,7 @@ cpdef dgtsv2StridedBatch_bufferSizeExt(
     check_status(status)
 
 cpdef cgtsv2StridedBatch_bufferSizeExt(
-        size_t handle, int m, size_t dl, size_t d, size_t du, size_t x,
+        intptr_t handle, int m, size_t dl, size_t d, size_t du, size_t x,
         int batchCount, int batchStride, size_t bufferSizeInBytes):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -2890,7 +2890,7 @@ cpdef cgtsv2StridedBatch_bufferSizeExt(
     check_status(status)
 
 cpdef zgtsv2StridedBatch_bufferSizeExt(
-        size_t handle, int m, size_t dl, size_t d, size_t du, size_t x,
+        intptr_t handle, int m, size_t dl, size_t d, size_t du, size_t x,
         int batchCount, int batchStride, size_t bufferSizeInBytes):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -2901,7 +2901,7 @@ cpdef zgtsv2StridedBatch_bufferSizeExt(
             <size_t*>bufferSizeInBytes)
     check_status(status)
 
-cpdef sgtsv2StridedBatch(size_t handle, int m, size_t dl, size_t d, size_t du,
+cpdef sgtsv2StridedBatch(intptr_t handle, int m, size_t dl, size_t d, size_t du,
                          size_t x, int batchCount, int batchStride,
                          size_t pBuffer):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -2912,7 +2912,7 @@ cpdef sgtsv2StridedBatch(size_t handle, int m, size_t dl, size_t d, size_t du,
             <void*>pBuffer)
     check_status(status)
 
-cpdef dgtsv2StridedBatch(size_t handle, int m, size_t dl, size_t d, size_t du,
+cpdef dgtsv2StridedBatch(intptr_t handle, int m, size_t dl, size_t d, size_t du,
                          size_t x, int batchCount, int batchStride,
                          size_t pBuffer):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -2923,7 +2923,7 @@ cpdef dgtsv2StridedBatch(size_t handle, int m, size_t dl, size_t d, size_t du,
             <void*>pBuffer)
     check_status(status)
 
-cpdef cgtsv2StridedBatch(size_t handle, int m, size_t dl, size_t d, size_t du,
+cpdef cgtsv2StridedBatch(intptr_t handle, int m, size_t dl, size_t d, size_t du,
                          size_t x, int batchCount, int batchStride,
                          size_t pBuffer):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -2934,7 +2934,7 @@ cpdef cgtsv2StridedBatch(size_t handle, int m, size_t dl, size_t d, size_t du,
             batchCount, batchStride, <void*>pBuffer)
     check_status(status)
 
-cpdef zgtsv2StridedBatch(size_t handle, int m, size_t dl, size_t d, size_t du,
+cpdef zgtsv2StridedBatch(intptr_t handle, int m, size_t dl, size_t d, size_t du,
                          size_t x, int batchCount, int batchStride,
                          size_t pBuffer):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -2946,7 +2946,7 @@ cpdef zgtsv2StridedBatch(size_t handle, int m, size_t dl, size_t d, size_t du,
     check_status(status)
 
 cpdef size_t sgtsvInterleavedBatch_bufferSizeExt(
-        size_t handle, int algo, int m, size_t dl, size_t d, size_t du,
+        intptr_t handle, int algo, int m, size_t dl, size_t d, size_t du,
         size_t x, int batchCount):
     cdef size_t pBufferSizeInBytes
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -2959,7 +2959,7 @@ cpdef size_t sgtsvInterleavedBatch_bufferSizeExt(
     return <size_t>pBufferSizeInBytes
 
 cpdef size_t dgtsvInterleavedBatch_bufferSizeExt(
-        size_t handle, int algo, int m, size_t dl, size_t d, size_t du,
+        intptr_t handle, int algo, int m, size_t dl, size_t d, size_t du,
         size_t x, int batchCount):
     cdef size_t pBufferSizeInBytes
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -2972,7 +2972,7 @@ cpdef size_t dgtsvInterleavedBatch_bufferSizeExt(
     return <size_t>pBufferSizeInBytes
 
 cpdef size_t cgtsvInterleavedBatch_bufferSizeExt(
-        size_t handle, int algo, int m, size_t dl, size_t d, size_t du,
+        intptr_t handle, int algo, int m, size_t dl, size_t d, size_t du,
         size_t x, int batchCount):
     cdef size_t pBufferSizeInBytes
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -2985,7 +2985,7 @@ cpdef size_t cgtsvInterleavedBatch_bufferSizeExt(
     return <size_t>pBufferSizeInBytes
 
 cpdef size_t zgtsvInterleavedBatch_bufferSizeExt(
-        size_t handle, int algo, int m, size_t dl, size_t d, size_t du,
+        intptr_t handle, int algo, int m, size_t dl, size_t d, size_t du,
         size_t x, int batchCount):
     cdef size_t pBufferSizeInBytes
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -2997,7 +2997,7 @@ cpdef size_t zgtsvInterleavedBatch_bufferSizeExt(
     check_status(status)
     return <size_t>pBufferSizeInBytes
 
-cpdef sgtsvInterleavedBatch(size_t handle, int algo, int m, size_t dl,
+cpdef sgtsvInterleavedBatch(intptr_t handle, int algo, int m, size_t dl,
                             size_t d, size_t du, size_t x, int batchCount,
                             size_t pBuffer):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -3007,7 +3007,7 @@ cpdef sgtsvInterleavedBatch(size_t handle, int algo, int m, size_t dl,
             <float*>du, <float*>x, batchCount, <void*>pBuffer)
     check_status(status)
 
-cpdef dgtsvInterleavedBatch(size_t handle, int algo, int m, size_t dl,
+cpdef dgtsvInterleavedBatch(intptr_t handle, int algo, int m, size_t dl,
                             size_t d, size_t du, size_t x, int batchCount,
                             size_t pBuffer):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -3017,7 +3017,7 @@ cpdef dgtsvInterleavedBatch(size_t handle, int algo, int m, size_t dl,
             <double*>du, <double*>x, batchCount, <void*>pBuffer)
     check_status(status)
 
-cpdef cgtsvInterleavedBatch(size_t handle, int algo, int m, size_t dl,
+cpdef cgtsvInterleavedBatch(intptr_t handle, int algo, int m, size_t dl,
                             size_t d, size_t du, size_t x, int batchCount,
                             size_t pBuffer):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -3027,7 +3027,7 @@ cpdef cgtsvInterleavedBatch(size_t handle, int algo, int m, size_t dl,
             <cuComplex*>du, <cuComplex*>x, batchCount, <void*>pBuffer)
     check_status(status)
 
-cpdef zgtsvInterleavedBatch(size_t handle, int algo, int m, size_t dl,
+cpdef zgtsvInterleavedBatch(intptr_t handle, int algo, int m, size_t dl,
                             size_t d, size_t du, size_t x, int batchCount,
                             size_t pBuffer):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -3039,7 +3039,7 @@ cpdef zgtsvInterleavedBatch(size_t handle, int algo, int m, size_t dl,
     check_status(status)
 
 cpdef size_t sgpsvInterleavedBatch_bufferSizeExt(
-        size_t handle, int algo, int m, size_t ds, size_t dl, size_t d,
+        intptr_t handle, int algo, int m, size_t ds, size_t dl, size_t d,
         size_t du, size_t dw, size_t x, int batchCount):
     cdef size_t pBufferSizeInBytes
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -3052,7 +3052,7 @@ cpdef size_t sgpsvInterleavedBatch_bufferSizeExt(
     return <size_t>pBufferSizeInBytes
 
 cpdef size_t dgpsvInterleavedBatch_bufferSizeExt(
-        size_t handle, int algo, int m, size_t ds, size_t dl, size_t d,
+        intptr_t handle, int algo, int m, size_t ds, size_t dl, size_t d,
         size_t du, size_t dw, size_t x, int batchCount):
     cdef size_t pBufferSizeInBytes
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -3066,7 +3066,7 @@ cpdef size_t dgpsvInterleavedBatch_bufferSizeExt(
     return <size_t>pBufferSizeInBytes
 
 cpdef size_t cgpsvInterleavedBatch_bufferSizeExt(
-        size_t handle, int algo, int m, size_t ds, size_t dl, size_t d,
+        intptr_t handle, int algo, int m, size_t ds, size_t dl, size_t d,
         size_t du, size_t dw, size_t x, int batchCount):
     cdef size_t pBufferSizeInBytes
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -3080,7 +3080,7 @@ cpdef size_t cgpsvInterleavedBatch_bufferSizeExt(
     return <size_t>pBufferSizeInBytes
 
 cpdef size_t zgpsvInterleavedBatch_bufferSizeExt(
-        size_t handle, int algo, int m, size_t ds, size_t dl, size_t d,
+        intptr_t handle, int algo, int m, size_t ds, size_t dl, size_t d,
         size_t du, size_t dw, size_t x, int batchCount):
     cdef size_t pBufferSizeInBytes
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -3093,7 +3093,7 @@ cpdef size_t zgpsvInterleavedBatch_bufferSizeExt(
     check_status(status)
     return <size_t>pBufferSizeInBytes
 
-cpdef sgpsvInterleavedBatch(size_t handle, int algo, int m, size_t ds,
+cpdef sgpsvInterleavedBatch(intptr_t handle, int algo, int m, size_t ds,
                             size_t dl, size_t d, size_t du, size_t dw,
                             size_t x, int batchCount, size_t pBuffer):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -3104,7 +3104,7 @@ cpdef sgpsvInterleavedBatch(size_t handle, int algo, int m, size_t ds,
             <void*>pBuffer)
     check_status(status)
 
-cpdef dgpsvInterleavedBatch(size_t handle, int algo, int m, size_t ds,
+cpdef dgpsvInterleavedBatch(intptr_t handle, int algo, int m, size_t ds,
                             size_t dl, size_t d, size_t du, size_t dw,
                             size_t x, int batchCount, size_t pBuffer):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -3115,7 +3115,7 @@ cpdef dgpsvInterleavedBatch(size_t handle, int algo, int m, size_t ds,
             <void*>pBuffer)
     check_status(status)
 
-cpdef cgpsvInterleavedBatch(size_t handle, int algo, int m, size_t ds,
+cpdef cgpsvInterleavedBatch(intptr_t handle, int algo, int m, size_t ds,
                             size_t dl, size_t d, size_t du, size_t dw,
                             size_t x, int batchCount, size_t pBuffer):
     setStream(handle, stream_module.get_current_stream_ptr())
@@ -3126,7 +3126,7 @@ cpdef cgpsvInterleavedBatch(size_t handle, int algo, int m, size_t ds,
             batchCount, <void*>pBuffer)
     check_status(status)
 
-cpdef zgpsvInterleavedBatch(size_t handle, int algo, int m, size_t ds,
+cpdef zgpsvInterleavedBatch(intptr_t handle, int algo, int m, size_t ds,
                             size_t dl, size_t d, size_t du, size_t dw,
                             size_t x, int batchCount, size_t pBuffer):
     setStream(handle, stream_module.get_current_stream_ptr())

--- a/cupy/cuda/cusparse.pyx
+++ b/cupy/cuda/cusparse.pyx
@@ -2901,8 +2901,8 @@ cpdef zgtsv2StridedBatch_bufferSizeExt(
             <size_t*>bufferSizeInBytes)
     check_status(status)
 
-cpdef sgtsv2StridedBatch(intptr_t handle, int m, size_t dl, size_t d, size_t du,
-                         size_t x, int batchCount, int batchStride,
+cpdef sgtsv2StridedBatch(intptr_t handle, int m, size_t dl, size_t d,
+                         size_t du, size_t x, int batchCount, int batchStride,
                          size_t pBuffer):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -2912,8 +2912,8 @@ cpdef sgtsv2StridedBatch(intptr_t handle, int m, size_t dl, size_t d, size_t du,
             <void*>pBuffer)
     check_status(status)
 
-cpdef dgtsv2StridedBatch(intptr_t handle, int m, size_t dl, size_t d, size_t du,
-                         size_t x, int batchCount, int batchStride,
+cpdef dgtsv2StridedBatch(intptr_t handle, int m, size_t dl, size_t d,
+                         size_t du, size_t x, int batchCount, int batchStride,
                          size_t pBuffer):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -2923,8 +2923,8 @@ cpdef dgtsv2StridedBatch(intptr_t handle, int m, size_t dl, size_t d, size_t du,
             <void*>pBuffer)
     check_status(status)
 
-cpdef cgtsv2StridedBatch(intptr_t handle, int m, size_t dl, size_t d, size_t du,
-                         size_t x, int batchCount, int batchStride,
+cpdef cgtsv2StridedBatch(intptr_t handle, int m, size_t dl, size_t d,
+                         size_t du, size_t x, int batchCount, int batchStride,
                          size_t pBuffer):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
@@ -2934,8 +2934,8 @@ cpdef cgtsv2StridedBatch(intptr_t handle, int m, size_t dl, size_t d, size_t du,
             batchCount, batchStride, <void*>pBuffer)
     check_status(status)
 
-cpdef zgtsv2StridedBatch(intptr_t handle, int m, size_t dl, size_t d, size_t du,
-                         size_t x, int batchCount, int batchStride,
+cpdef zgtsv2StridedBatch(intptr_t handle, int m, size_t dl, size_t d,
+                         size_t du, size_t x, int batchCount, int batchStride,
                          size_t pBuffer):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:


### PR DESCRIPTION
Modified `size_t` with `intptr_t` for cuSPARSE and cuBLAS as a part of #2716