### PR TITLE
Fix condition to use slice copy in ndarray.__setitem__

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1233,8 +1233,9 @@ cdef class ndarray:
             array([9998., 9999.])
 
         """
-        if (util.ENABLE_SLICE_COPY and slices == slice(None, None, None) and
-                isinstance(value, numpy.ndarray)):
+        if (util.ENABLE_SLICE_COPY and
+            type(slices) is slice and slices == slice(None, None, None) and
+            isinstance(value, numpy.ndarray)):
             if (self.dtype == value.dtype and
                     self.shape == value.shape):
                 if self.strides == value.strides:

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1233,11 +1233,13 @@ cdef class ndarray:
             array([9998., 9999.])
 
         """
-        if (util.ENABLE_SLICE_COPY and
-            type(slices) is slice and slices == slice(None, None, None) and
-            isinstance(value, numpy.ndarray)):
-            if (self.dtype == value.dtype and
-                    self.shape == value.shape):
+        def does_slice_copy(slices, value):
+            return (type(slices) is slice and
+                    slices == slice(None, None, None) and
+                    isinstance(value, numpy.ndarray))
+
+        if util.ENABLE_SLICE_COPY and does_slice_copy(slices, value):
+            if self.dtype == value.dtype and self.shape == value.shape:
                 if self.strides == value.strides:
                     ptr = ctypes.c_void_p(value.__array_interface__['data'][0])
                 else:

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1233,12 +1233,11 @@ cdef class ndarray:
             array([9998., 9999.])
 
         """
-        def does_slice_copy(slices, value):
-            return (type(slices) is slice and
-                    slices == slice(None, None, None) and
-                    isinstance(value, numpy.ndarray))
-
-        if util.ENABLE_SLICE_COPY and does_slice_copy(slices, value):
+        if util.ENABLE_SLICE_COPY and (
+                type(slices) is slice
+                and slices == slice(None, None, None)
+                and isinstance(value, numpy.ndarray)
+        ):
             if self.dtype == value.dtype and self.shape == value.shape:
                 if self.strides == value.strides:
                     ptr = ctypes.c_void_p(value.__array_interface__['data'][0])

--- a/tests/cupy_tests/core_tests/test_ndarray_copy_and_view.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_copy_and_view.py
@@ -193,6 +193,13 @@ class TestArrayCopyAndView(unittest.TestCase):
         b = cupy.empty(100, dtype=a.dtype)
         b[:] = a
 
+    @unittest.skipUnless(util.ENABLE_SLICE_COPY, 'Special copy disabled')
+    @testing.numpy_cupy_array_equal()
+    def test_isinstance_numpy_copy_not_slice(self, xp):
+        a = xp.arange(5, dtype=numpy.float64)
+        a[a<3] = 0
+        return a
+
 
 @testing.parameterize(
     {'src_order': 'C'},

--- a/tests/cupy_tests/core_tests/test_ndarray_copy_and_view.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_copy_and_view.py
@@ -197,7 +197,7 @@ class TestArrayCopyAndView(unittest.TestCase):
     @testing.numpy_cupy_array_equal()
     def test_isinstance_numpy_copy_not_slice(self, xp):
         a = xp.arange(5, dtype=numpy.float64)
-        a[a<3] = 0
+        a[a < 3] = 0
         return a
 
 

--- a/tests/cupy_tests/core_tests/test_ndarray_indexing.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_indexing.py
@@ -3,9 +3,7 @@ import warnings
 
 import numpy
 
-import cupy
 from cupy import testing
-from cupy import util
 
 
 @testing.parameterize(
@@ -169,19 +167,3 @@ class TestArrayIndex(unittest.TestCase):
     def test_T_vector(self, xp):
         a = testing.shaped_arange((4,), xp)
         return a.T
-
-
-class TestSliceCopy(unittest.TestCase):
-
-    def setUp(self):
-        self.prev = util.ENABLE_SLICE_COPY
-        util.ENABLE_SLICE_COPY = True
-
-    def tearDown(self):
-        util.ENABLE_SLICE_COPY = self.prev
-
-    def test_setitem_slice_copy(self):
-        a = cupy.zeros((2, 3, 4))
-        a[:] = numpy.ones((2, 3, 4))
-        e = cupy.ones((2, 3, 4))
-        assert (a == e).all()

--- a/tests/cupy_tests/core_tests/test_ndarray_indexing.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_indexing.py
@@ -3,7 +3,9 @@ import warnings
 
 import numpy
 
+import cupy
 from cupy import testing
+from cupy import util
 
 
 @testing.parameterize(
@@ -167,3 +169,19 @@ class TestArrayIndex(unittest.TestCase):
     def test_T_vector(self, xp):
         a = testing.shaped_arange((4,), xp)
         return a.T
+
+
+class TestSliceCopy(unittest.TestCase):
+
+    def setUp(self):
+        self.prev = util.ENABLE_SLICE_COPY
+        util.ENABLE_SLICE_COPY = True
+
+    def tearDown(self):
+        util.ENABLE_SLICE_COPY = self.prev
+
+    def test_setitem_slice_copy(self):
+        a = cupy.zeros((2, 3, 4))
+        a[:] = numpy.ones((2, 3, 4))
+        e = cupy.ones((2, 3, 4))
+        assert (a == e).all()


### PR DESCRIPTION
Fix #3013 .

This PR fixes the condition to use CUPY_EXPERIMENTAL_SLICE_COPY feature in `ndarray.__setitem__` to check if the supplied `slices` is a slice object.