### PR TITLE
[backport] Include `UnownedMemory` in the API docs

### DIFF
--- a/docs/source/reference/cuda.rst
+++ b/docs/source/reference/cuda.rst
@@ -21,6 +21,7 @@ Memory management
    cupy.get_default_memory_pool
    cupy.get_default_pinned_memory_pool
    cupy.cuda.Memory
+   cupy.cuda.UnownedMemory
    cupy.cuda.PinnedMemory
    cupy.cuda.MemoryPointer
    cupy.cuda.PinnedMemoryPointer


### PR DESCRIPTION
Backport of #3086