### PR TITLE
Minor fix to `using_allocator`

### DIFF
--- a/cupy/cuda/__init__.py
+++ b/cupy/cuda/__init__.py
@@ -111,14 +111,16 @@ def using_allocator(allocator=None):
             buffer size as an argument and returns the device buffer of that
             size. When ``None`` is specified, raw memory allocator will be
             used (i.e., memory pool is disabled).
-
-    Note:
-        This wraps an internal version of this function to provide a
-        `contextmanager` as `contextmanger` decoration doesn't behave
-        well in Cython.
     """
-    for y in memory._using_allocator(allocator):
-        yield y
+    # Note: cupy/memory.pyx would be the better place to implement this
+    # function but `contextmanager` decoration doesn't behave well in Cython.
+    if allocator is None:
+        allocator = memory._malloc
+    previous_allocator = memory._set_thread_local_allocator(allocator)
+    try:
+        yield
+    finally:
+        memory._set_thread_local_allocator(previous_allocator)
 
 
 @contextlib.contextmanager

--- a/cupy/cuda/__init__.py
+++ b/cupy/cuda/__init__.py
@@ -116,7 +116,8 @@ def using_allocator(allocator=None):
     # function but `contextmanager` decoration doesn't behave well in Cython.
     if allocator is None:
         allocator = memory._malloc
-    previous_allocator = memory._set_thread_local_allocator(allocator)
+    previous_allocator = memory._get_thread_local_allocator()
+    memory._set_thread_local_allocator(allocator)
     try:
         yield
     finally:

--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -541,6 +541,13 @@ cpdef MemoryPointer malloc_managed(size_t size):
 cdef object _current_allocator = _malloc
 cdef object _thread_local = threading.local()
 
+
+def _set_thread_local_allocator(allocator):
+    previous_allocator = getattr(_thread_local, 'allocator', None)
+    _thread_local.allocator = allocator
+    return previous_allocator
+
+
 cpdef MemoryPointer alloc(size):
     """Calls the current allocator.
 
@@ -590,28 +597,6 @@ cpdef get_allocator():
         return _current_allocator
     else:
         return allocator
-
-
-def _using_allocator(allocator=None):
-    """Sets a thread-local allocator for GPU memory inside
-       context manager
-
-    Args:
-        allocator (function): CuPy memory allocator. It must have the same
-            interface as the :func:`cupy.cuda.alloc` function, which takes the
-            buffer size as an argument and returns the device buffer of that
-            size. When ``None`` is specified, raw memory allocator will be
-            used (i.e., memory pool is disabled).
-
-    """
-    if allocator is None:
-        allocator = _malloc
-    previous_allocator = getattr(_thread_local, 'allocator', None)
-    _thread_local.allocator = allocator
-    try:
-        yield
-    finally:
-        _thread_local.allocator = previous_allocator
 
 
 @cython.final

--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -542,10 +542,16 @@ cdef object _current_allocator = _malloc
 cdef object _thread_local = threading.local()
 
 
+def _get_thread_local_allocator():
+    try:
+        allocator = _thread_local.allocator
+    except AttributeError:
+        allocator = _thread_local.allocator = None
+    return allocator
+
+
 def _set_thread_local_allocator(allocator):
-    previous_allocator = getattr(_thread_local, 'allocator', None)
     _thread_local.allocator = allocator
-    return previous_allocator
 
 
 cpdef MemoryPointer alloc(size):


### PR DESCRIPTION
Follow up https://github.com/cupy/cupy/pull/3087#pullrequestreview-360104578



I feel this version (introducing `memory._set_thread_local_allocator()`) is better than `for` loop trick, but not 100% confident.

