### PR TITLE
Remove `IndexOrValueError`

### DIFF
--- a/cupy/core/__init__.py
+++ b/cupy/core/__init__.py
@@ -3,7 +3,6 @@ from cupy.core import internal  # NOQA
 
 
 # import class and function
-from cupy.core._errors import _AxisError  # NOQA
 from cupy.core._kernel import create_ufunc  # NOQA
 from cupy.core._kernel import ElementwiseKernel  # NOQA
 from cupy.core._kernel import ufunc  # NOQA

--- a/cupy/core/_errors.py
+++ b/cupy/core/_errors.py
@@ -1,4 +1,0 @@
-import numpy
-
-
-_AxisError = numpy.AxisError

--- a/cupy/core/_errors.py
+++ b/cupy/core/_errors.py
@@ -1,12 +1,4 @@
 import numpy
 
 
-try:
-    _AxisError = numpy.AxisError
-except AttributeError:
-    class IndexOrValueError(IndexError, ValueError):
-
-        def __init__(self, *args, **kwargs):
-            super(IndexOrValueError, self).__init__(*args, **kwargs)
-
-    _AxisError = IndexOrValueError
+_AxisError = numpy.AxisError

--- a/cupy/core/_reduction.pyx
+++ b/cupy/core/_reduction.pyx
@@ -25,7 +25,8 @@ from cupy.cuda cimport runtime
 
 import string
 
-from cupy.core import _errors
+import numpy
+
 from cupy.core._kernel import _get_param_info
 from cupy.core._kernel import _decide_params_type
 from cupy.cuda import compiler
@@ -117,7 +118,7 @@ cpdef tuple _get_axis(object axis, Py_ssize_t ndim):
 
     for dim in axis:
         if dim < -ndim or dim >= ndim:
-            raise _errors._AxisError('Axis overrun')
+            raise numpy.AxisError('Axis overrun')
     reduce_axis = tuple(sorted([dim % ndim for dim in axis]))
     out_axis = tuple([dim for dim in range(ndim) if dim not in reduce_axis])
     return reduce_axis, out_axis

--- a/cupy/core/_routines_indexing.pyx
+++ b/cupy/core/_routines_indexing.pyx
@@ -4,7 +4,6 @@ import sys
 import numpy
 
 import cupy
-from cupy.core import _errors
 from cupy.core._kernel import ElementwiseKernel
 from cupy.core._ufuncs import elementwise_copy
 
@@ -602,7 +601,7 @@ cdef ndarray _take(ndarray a, indices, int li, int ri, ndarray out=None):
         ndim = 1
 
     if not (-ndim <= li < ndim and -ndim <= ri < ndim):
-        raise _errors._AxisError('Axis overrun')
+        raise numpy.AxisError('Axis overrun')
 
     if ndim == 1:
         li = ri = 0
@@ -828,7 +827,7 @@ cdef ndarray _diagonal(
         Py_ssize_t axis2=1):
     cdef Py_ssize_t ndim = a.ndim
     if not (-ndim <= axis1 < ndim and -ndim <= axis2 < ndim):
-        raise _errors._AxisError(
+        raise numpy.AxisError(
             'axis1(={0}) and axis2(={1}) must be within range '
             '(ndim={2})'.format(axis1, axis2, ndim))
 

--- a/cupy/core/_routines_manipulation.pyx
+++ b/cupy/core/_routines_manipulation.pyx
@@ -4,7 +4,6 @@ import sys
 
 import numpy
 
-from cupy.core import _errors
 from cupy.core._kernel import ElementwiseKernel
 from cupy.core._ufuncs import elementwise_copy
 
@@ -165,7 +164,7 @@ cdef ndarray _ndarray_squeeze(ndarray self, axis):
             if _axis < 0:
                 _axis += ndim
             if _axis < 0 or _axis >= ndim:
-                raise _errors._AxisError(
+                raise numpy.AxisError(
                     '\'axis\' entry %d is out of bounds [-%d, %d)' %
                     (axis_orig, ndim, ndim))
             if axis_flags[_axis] == 1:
@@ -182,7 +181,7 @@ cdef ndarray _ndarray_squeeze(ndarray self, axis):
             pass
         else:
             if _axis < 0 or _axis >= ndim:
-                raise _errors._AxisError(
+                raise numpy.AxisError(
                     '\'axis\' entry %d is out of bounds [-%d, %d)' %
                     (axis_orig, ndim, ndim))
             axis_flags[_axis] = 1
@@ -500,7 +499,7 @@ cpdef ndarray _repeat(ndarray a, repeats, axis=None):
             a = a.ravel()
             axis = 0
     elif not (-a.ndim <= axis < a.ndim):
-        raise _errors._AxisError(
+        raise numpy.AxisError(
             'axis {} is out of bounds for array of dimension {}'.format(
                 axis, a.ndim))
 
@@ -555,7 +554,7 @@ cpdef ndarray concatenate_method(tup, int axis, ndarray out=None):
             if axis < 0:
                 axis += ndim
             if axis < 0 or axis >= ndim:
-                raise _errors._AxisError(
+                raise numpy.AxisError(
                     'axis {} out of bounds [0, {})'.format(axis, ndim))
             dtype = a.dtype
             continue
@@ -717,11 +716,11 @@ cdef _normalize_axis_tuple(axis, Py_ssize_t ndim,
 
     for ax in axis:
         if ax >= ndim or ax < -ndim:
-            raise _errors._AxisError(
+            raise numpy.AxisError(
                 'axis {} is out of bounds for array of '
                 'dimension {}'.format(ax, ndim))
         if _has_element(ret, ax):
-            raise _errors._AxisError('repeated axis')
+            raise numpy.AxisError('repeated axis')
         ret.push_back(ax % ndim)
 
 

--- a/cupy/core/_routines_sorting.pyx
+++ b/cupy/core/_routines_sorting.pyx
@@ -3,7 +3,6 @@ import string
 import numpy
 
 import cupy
-from cupy.core import _errors
 from cupy.core._scalar import get_typename as _get_typename
 from cupy.core._ufuncs import elementwise_copy
 from cupy import util
@@ -39,7 +38,7 @@ cdef _ndarray_sort(ndarray self, int axis):
     if axis < 0:
         axis += ndim
     if not (0 <= axis < ndim):
-        raise _errors._AxisError('Axis out of range')
+        raise numpy.AxisError('Axis out of range')
 
     if axis == ndim - 1:
         data = self
@@ -83,7 +82,7 @@ cdef ndarray _ndarray_argsort(ndarray self, axis):
     if _axis < 0:
         _axis += ndim
     if not (0 <= _axis < ndim):
-        raise _errors._AxisError('Axis out of range')
+        raise numpy.AxisError('Axis out of range')
 
     if _axis == ndim - 1:
         data = data.copy()
@@ -143,7 +142,7 @@ cdef _ndarray_partition(ndarray self, kth, int axis):
     if axis < 0:
         axis += ndim
     if not (0 <= axis < ndim):
-        raise _errors._AxisError('Axis out of range')
+        raise numpy.AxisError('Axis out of range')
 
     if axis == ndim - 1:
         data = self
@@ -240,7 +239,7 @@ cdef ndarray _ndarray_argpartition(self, kth, axis):
     if _axis < 0:
         _axis += ndim
     if not (0 <= _axis < ndim):
-        raise _errors._AxisError('Axis out of range')
+        raise numpy.AxisError('Axis out of range')
 
     length = data._shape[_axis]
     if isinstance(kth, int):

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -10,7 +10,6 @@ import ctypes
 import numpy
 
 import cupy
-from cupy.core import _errors
 from cupy.core._kernel import create_ufunc
 from cupy.core._kernel import ElementwiseKernel
 from cupy.core._kernel import ufunc  # NOQA

--- a/cupy/core/fusion.pyx
+++ b/cupy/core/fusion.pyx
@@ -5,7 +5,6 @@ import numpy
 
 import cupy
 from cupy.core._dtype import get_dtype
-from cupy.core import _errors
 from cupy.core import _kernel
 from cupy.core._kernel import _is_fusing
 from cupy.core import _reduction
@@ -985,7 +984,7 @@ def _call_reduction(fusion_op, *args, **kwargs):
         ndim = 0
     if ndim < 0:
         mes = 'axis {} is out of bounds for array of dimension {}'
-        raise _errors._AxisError(mes.format(axis, src_ndim))
+        raise numpy.AxisError(mes.format(axis, src_ndim))
 
     _thread_local.history.ndim = ndim
     if ndim >= 1:

--- a/cupy/cuda/cub.pyx
+++ b/cupy/cuda/cub.pyx
@@ -6,7 +6,6 @@ from cpython cimport sequence
 
 import numpy
 
-from cupy.core._errors import _AxisError
 from cupy.core.core cimport _internal_ascontiguousarray
 from cupy.core.core cimport _internal_asfortranarray
 from cupy.core.core cimport ndarray

--- a/cupy/indexing/indexing.py
+++ b/cupy/indexing/indexing.py
@@ -1,5 +1,6 @@
+import numpy
+
 import cupy
-from cupy.core import _errors
 
 
 def take(a, indices, axis=None, out=None):
@@ -52,7 +53,7 @@ def take_along_axis(a, indices, axis):
     ndim = a.ndim
 
     if not (-ndim <= axis < ndim):
-        raise _errors._AxisError('Axis overrun')
+        raise numpy.AxisError('Axis overrun')
 
     axis %= a.ndim
 

--- a/cupy/manipulation/join.py
+++ b/cupy/manipulation/join.py
@@ -1,3 +1,5 @@
+import numpy
+
 import cupy
 from cupy import core
 
@@ -130,7 +132,7 @@ def stack(tup, axis=0, out=None):
     # TODO(okuta) Remove this if exampd_dims is updated
     for x in tup:
         if not (-x.ndim - 1 <= axis <= x.ndim):
-            raise core._AxisError(
+            raise numpy.AxisError(
                 'axis {} out of bounds [{}, {}]'.format(
                     axis, -x.ndim - 1, x.ndim))
     return concatenate([cupy.expand_dims(x, axis) for x in tup], axis, out)
@@ -141,6 +143,6 @@ def _get_positive_axis(ndim, axis):
     if a < 0:
         a += ndim
     if a < 0 or a >= ndim:
-        raise core._AxisError(
+        raise numpy.AxisError(
             'axis {} out of bounds [0, {})'.format(axis, ndim))
     return a

--- a/cupy/manipulation/rearrange.py
+++ b/cupy/manipulation/rearrange.py
@@ -3,7 +3,6 @@ import itertools
 import numpy
 
 import cupy
-from cupy import core
 from cupy.core._reduction import _get_axis
 
 
@@ -25,11 +24,11 @@ def flip(a, axis):
     """
     a_ndim = a.ndim
     if a_ndim < 1:
-        raise core._AxisError('Input must be >= 1-d')
+        raise numpy.AxisError('Input must be >= 1-d')
 
     axis = int(axis)
     if not -a_ndim <= axis < a_ndim:
-        raise core._AxisError(
+        raise numpy.AxisError(
             'axis must be >= %d and < %d' % (-a_ndim, a_ndim))
 
     return _flip(a, axis)

--- a/cupy/util.pyx
+++ b/cupy/util.pyx
@@ -6,9 +6,10 @@ import functools
 import os
 import warnings
 
+import numpy
+
 import cupy
 from cupy.cuda cimport device
-from cupy.core import _errors
 
 
 ENABLE_SLICE_COPY = bool(
@@ -39,7 +40,7 @@ def _normalize_axis_index(axis, ndim):
     if axis < 0:
         axis += ndim
     if not (0 <= axis < ndim):
-        raise _errors._AxisError('axis out of bounds')
+        raise numpy.AxisError('axis out of bounds')
     return axis
 
 

--- a/tests/cupy_tests/core_tests/test_ndarray.py
+++ b/tests/cupy_tests/core_tests/test_ndarray.py
@@ -367,7 +367,7 @@ class TestNdarrayTakeErrorAxisOverRun(unittest.TestCase):
 
     def test_axis_overrun2(self):
         a = testing.shaped_arange(self.shape, cupy)
-        with pytest.raises(core._AxisError):
+        with pytest.raises(numpy.AxisError):
             wrap_take(a, self.indices, axis=self.axis)
 
 

--- a/tests/cupy_tests/manipulation_tests/test_dims.py
+++ b/tests/cupy_tests/manipulation_tests/test_dims.py
@@ -180,7 +180,7 @@ class TestDims(unittest.TestCase):
 
     def test_squeeze_int_axis_failure2(self):
         a = testing.shaped_arange((1, 2, 1, 3, 1, 1, 4, 1), cupy)
-        with self.assertRaises(cupy.core._AxisError):
+        with self.assertRaises(numpy.AxisError):
             a.squeeze(axis=-9)
 
     @testing.numpy_cupy_array_equal()
@@ -215,7 +215,7 @@ class TestDims(unittest.TestCase):
 
     def test_squeeze_tuple_axis_failure3(self):
         a = testing.shaped_arange((1, 2, 1, 3, 1, 1, 4, 1), cupy)
-        with self.assertRaises(cupy.core._AxisError):
+        with self.assertRaises(numpy.AxisError):
             a.squeeze(axis=(-9,))
 
     @testing.numpy_cupy_array_equal()
@@ -240,12 +240,12 @@ class TestDims(unittest.TestCase):
 
     def test_squeeze_scalar_failure3(self):
         a = testing.shaped_arange((), cupy)
-        with self.assertRaises(cupy.core._AxisError):
+        with self.assertRaises(numpy.AxisError):
             a.squeeze(axis=-2)
 
     def test_squeeze_scalar_failure4(self):
         a = testing.shaped_arange((), cupy)
-        with self.assertRaises(cupy.core._AxisError):
+        with self.assertRaises(numpy.AxisError):
             a.squeeze(axis=1)
 
     @testing.numpy_cupy_raises()

--- a/tests/cupy_tests/manipulation_tests/test_join.py
+++ b/tests/cupy_tests/manipulation_tests/test_join.py
@@ -1,7 +1,8 @@
 import unittest
 
-import cupy
+import numpy
 
+import cupy
 from cupy import testing
 
 
@@ -306,7 +307,7 @@ class TestJoin(unittest.TestCase):
 
     def test_stack_out_of_bounds2(self):
         a = testing.shaped_arange((2, 3), cupy)
-        with self.assertRaises(cupy.core._AxisError):
+        with self.assertRaises(numpy.AxisError):
             return cupy.stack([a, a], axis=3)
 
     @testing.for_all_dtypes(name='dtype')

--- a/tests/cupy_tests/manipulation_tests/test_transpose.py
+++ b/tests/cupy_tests/manipulation_tests/test_transpose.py
@@ -1,5 +1,7 @@
 import unittest
 
+import numpy
+
 import cupy
 from cupy import testing
 
@@ -45,7 +47,7 @@ class TestTranspose(unittest.TestCase):
 
     def test_moveaxis_invalid1_2(self):
         a = testing.shaped_arange((2, 3, 4), cupy)
-        with self.assertRaises(cupy.core._AxisError):
+        with self.assertRaises(numpy.AxisError):
             return cupy.moveaxis(a, [0, 1], [1, 3])
 
     # dim is too small
@@ -56,7 +58,7 @@ class TestTranspose(unittest.TestCase):
 
     def test_moveaxis_invalid2_2(self):
         a = testing.shaped_arange((2, 3, 4), cupy)
-        with self.assertRaises(cupy.core._AxisError):
+        with self.assertRaises(numpy.AxisError):
             return cupy.moveaxis(a, [0, -4], [1, 2])
 
     # len(source) != len(destination)
@@ -74,17 +76,17 @@ class TestTranspose(unittest.TestCase):
     # Use the same axis twice
     def test_moveaxis_invalid5_1(self):
         a = testing.shaped_arange((2, 3, 4), cupy)
-        with self.assertRaises(cupy.core._AxisError):
+        with self.assertRaises(numpy.AxisError):
             return cupy.moveaxis(a, [1, -1], [1, 3])
 
     def test_moveaxis_invalid5_2(self):
         a = testing.shaped_arange((2, 3, 4), cupy)
-        with self.assertRaises(cupy.core._AxisError):
+        with self.assertRaises(numpy.AxisError):
             return cupy.moveaxis(a, [0, 1], [-1, 2])
 
     def test_moveaxis_invalid5_3(self):
         a = testing.shaped_arange((2, 3, 4), cupy)
-        with self.assertRaises(cupy.core._AxisError):
+        with self.assertRaises(numpy.AxisError):
             return cupy.moveaxis(a, [0, 1], [1, 1])
 
     @testing.numpy_cupy_array_equal()

--- a/tests/cupy_tests/math_tests/test_sumprod.py
+++ b/tests/cupy_tests/math_tests/test_sumprod.py
@@ -398,7 +398,7 @@ class TestCumsum(unittest.TestCase):
     @testing.for_all_dtypes()
     def test_invalid_axis_lower2(self, dtype):
         a = testing.shaped_arange((4, 5), cupy, dtype)
-        with self.assertRaises(cupy.core._AxisError):
+        with self.assertRaises(numpy.AxisError):
             return cupy.cumsum(a, axis=-a.ndim - 1)
 
     @testing.for_all_dtypes()
@@ -410,7 +410,7 @@ class TestCumsum(unittest.TestCase):
     @testing.for_all_dtypes()
     def test_invalid_axis_upper2(self, dtype):
         a = testing.shaped_arange((4, 5), cupy, dtype)
-        with self.assertRaises(cupy.core._AxisError):
+        with self.assertRaises(numpy.AxisError):
             return cupy.cumsum(a, axis=a.ndim + 1)
 
     def test_cumsum_arraylike(self):
@@ -489,7 +489,7 @@ class TestCumprod(unittest.TestCase):
     @testing.for_all_dtypes()
     def test_invalid_axis_lower2(self, dtype):
         a = testing.shaped_arange((4, 5), cupy, dtype)
-        with self.assertRaises(cupy.core._AxisError):
+        with self.assertRaises(numpy.AxisError):
             return cupy.cumprod(a, axis=-a.ndim - 1)
 
     @testing.for_all_dtypes()
@@ -501,7 +501,7 @@ class TestCumprod(unittest.TestCase):
     @testing.for_all_dtypes()
     def test_invalid_axis_upper2(self, dtype):
         a = testing.shaped_arange((4, 5), cupy, dtype)
-        with self.assertRaises(cupy.core._AxisError):
+        with self.assertRaises(numpy.AxisError):
             return cupy.cumprod(a, axis=a.ndim)
 
     def test_cumprod_arraylike(self):

--- a/tests/cupy_tests/sorting_tests/test_sort.py
+++ b/tests/cupy_tests/sorting_tests/test_sort.py
@@ -123,7 +123,7 @@ class TestSort(unittest.TestCase):
 
     def test_sort_invalid_axis2(self):
         a = testing.shaped_random((2, 3, 3), cupy)
-        with self.assertRaises(cupy.core._AxisError):
+        with self.assertRaises(numpy.AxisError):
             a.sort(axis=3)
 
     @testing.numpy_cupy_raises()
@@ -133,7 +133,7 @@ class TestSort(unittest.TestCase):
 
     def test_external_sort_invalid_axis2(self):
         a = testing.shaped_random((2, 3, 3), cupy)
-        with self.assertRaises(cupy.core._AxisError):
+        with self.assertRaises(numpy.AxisError):
             cupy.sort(a, axis=3)
 
     @testing.numpy_cupy_raises()
@@ -143,7 +143,7 @@ class TestSort(unittest.TestCase):
 
     def test_sort_invalid_negative_axis2(self):
         a = testing.shaped_random((2, 3, 3), cupy)
-        with self.assertRaises(cupy.core._AxisError):
+        with self.assertRaises(numpy.AxisError):
             a.sort(axis=-4)
 
     @testing.numpy_cupy_raises()
@@ -153,7 +153,7 @@ class TestSort(unittest.TestCase):
 
     def test_external_sort_invalid_negative_axis2(self):
         a = testing.shaped_random((2, 3, 3), cupy)
-        with self.assertRaises(cupy.core._AxisError):
+        with self.assertRaises(numpy.AxisError):
             cupy.sort(a, axis=-4)
 
 
@@ -272,7 +272,7 @@ class TestArgsort(unittest.TestCase):
 
     def test_argsort_invalid_axis2(self):
         a = testing.shaped_random((2, 3, 3), cupy)
-        with self.assertRaises(cupy.core._AxisError):
+        with self.assertRaises(numpy.AxisError):
             return self.argsort(a, axis=3)
 
     @testing.numpy_cupy_raises()
@@ -282,7 +282,7 @@ class TestArgsort(unittest.TestCase):
 
     def test_argsort_invalid_negative_axis2(self):
         a = testing.shaped_random((2, 3, 3), cupy)
-        with self.assertRaises(cupy.core._AxisError):
+        with self.assertRaises(numpy.AxisError):
             return self.argsort(a, axis=-4)
 
     # Misc tests
@@ -480,7 +480,7 @@ class TestPartition(unittest.TestCase):
 
     def test_partition_invalid_axis2(self):
         a = testing.shaped_random((2, 2, self.length), cupy)
-        with self.assertRaises(cupy.core._AxisError):
+        with self.assertRaises(numpy.AxisError):
             kth = 2
             axis = 3
             return self.partition(a, kth, axis=axis)
@@ -494,7 +494,7 @@ class TestPartition(unittest.TestCase):
 
     def test_partition_invalid_negative_axis2(self):
         a = testing.shaped_random((2, 2, self.length), cupy)
-        with self.assertRaises(cupy.core._AxisError):
+        with self.assertRaises(numpy.AxisError):
             kth = 2
             axis = -4
             return self.partition(a, kth, axis=axis)
@@ -652,7 +652,7 @@ class TestArgpartition(unittest.TestCase):
         a = testing.shaped_random((2, 2, 2), cupy, scale=100)
         kth = 1
         axis = 3
-        with self.assertRaises(cupy.core._AxisError):
+        with self.assertRaises(numpy.AxisError):
             self.argpartition(a, kth, axis=axis)
 
     @testing.numpy_cupy_raises()
@@ -666,5 +666,5 @@ class TestArgpartition(unittest.TestCase):
         a = testing.shaped_random((2, 2, 2), cupy, scale=100)
         kth = 1
         axis = -4
-        with self.assertRaises(cupy.core._AxisError):
+        with self.assertRaises(numpy.AxisError):
             self.argpartition(a, kth, axis=axis)

--- a/tests/cupy_tests/testing_tests/test_helper.py
+++ b/tests/cupy_tests/testing_tests/test_helper.py
@@ -161,7 +161,7 @@ class TestCheckCupyNumpyError(unittest.TestCase):
         @testing.helper.numpy_cupy_raises()
         def dummy_axis_error(self, xp):
             if xp is cupy:
-                raise cupy.core._errors._AxisError(self.tbs.get(cupy))
+                raise numpy.AxisError(self.tbs.get(cupy))
             elif xp is numpy:
                 raise TypeError(self.tbs.get(numpy))
 
@@ -174,7 +174,7 @@ class TestCheckCupyNumpyError(unittest.TestCase):
         @testing.helper.numpy_cupy_raises()
         def dummy_axis_error(self, xp):
             if xp is cupy:
-                raise cupy.core._errors._AxisError(self.tbs.get(cupy))
+                raise numpy.AxisError(self.tbs.get(cupy))
             elif xp is numpy:
                 raise ValueError(self.tbs.get(numpy))
 
@@ -187,7 +187,7 @@ class TestCheckCupyNumpyError(unittest.TestCase):
         @testing.helper.numpy_cupy_raises()
         def dummy_axis_error(self, xp):
             if xp is cupy:
-                raise cupy.core._errors._AxisError(self.tbs.get(cupy))
+                raise numpy.AxisError(self.tbs.get(cupy))
             elif xp is numpy:
                 raise IndexError(self.tbs.get(numpy))
 


### PR DESCRIPTION
`numpy.AxisError` was introduced from NumPy 1.13.0.
We decided to drop NumPy<1.15 support from CuPy v8. (#2938)