### PR TITLE
Fix `cub_reduction` for `CUPY_CUB_MIN` and float16 arrays

### DIFF
--- a/cupy/cuda/cupy_cub.cu
+++ b/cupy/cuda/cupy_cub.cu
@@ -201,7 +201,7 @@ __host__ __device__ __forceinline__ __half Min::operator()(const __half &a, cons
     if (half_isnan(a)) {return a;}
     else if (half_isnan(b)) {return b;}
     else if (half_less(a, b)) {return a;}
-    else {return a;}
+    else {return b;}
 }
 #endif
 


### PR DESCRIPTION
Fix #3097.