### PR TITLE
Add `compress`

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -436,6 +436,7 @@ from cupy.indexing.generate import unravel_index  # NOQA
 
 from cupy.indexing.indexing import choose  # NOQA
 from cupy.indexing.indexing import diagonal  # NOQA
+from cupy.indexing.indexing import compress  # NOQA
 from cupy.indexing.indexing import take  # NOQA
 from cupy.indexing.indexing import take_along_axis  # NOQA
 

--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -435,8 +435,8 @@ from cupy.indexing.generate import r_  # NOQA
 from cupy.indexing.generate import unravel_index  # NOQA
 
 from cupy.indexing.indexing import choose  # NOQA
-from cupy.indexing.indexing import diagonal  # NOQA
 from cupy.indexing.indexing import compress  # NOQA
+from cupy.indexing.indexing import diagonal  # NOQA
 from cupy.indexing.indexing import take  # NOQA
 from cupy.indexing.indexing import take_along_axis  # NOQA
 

--- a/cupy/core/_routines_indexing.pxd
+++ b/cupy/core/_routines_indexing.pxd
@@ -10,6 +10,7 @@ cdef _ndarray_scatter_min(ndarray self, slices, value)
 cdef ndarray _ndarray_take(ndarray self, indices, axis, out)
 cdef ndarray _ndarray_put(ndarray self, indices, values, mode)
 cdef ndarray _ndarray_choose(ndarray self, choices, out, mode)
+cdef ndarray _ndarray_compress(ndarray self, condition, axis, out)
 cdef ndarray _ndarray_diagonal(ndarray self, offset, axis1, axis2)
 
 cdef ndarray _simple_getitem(ndarray a, list slice_list)

--- a/cupy/core/_routines_indexing.pyx
+++ b/cupy/core/_routines_indexing.pyx
@@ -152,6 +152,30 @@ cdef ndarray _ndarray_choose(ndarray self, choices, out, mode):
     return out
 
 
+cdef ndarray _ndarray_compress(ndarray self, condition, axis, out):
+    a = self
+
+    if numpy.isscalar(condition):
+        raise ValueError('condition must be a 1-d array')
+    
+    if not isinstance(condition, ndarray):
+        condition = core.array(condition, dtype=int)
+        if condition.ndim != 1:
+            raise ValueError('condition must be a 1-d array')
+    
+    res = _ndarray_nonzero(condition)
+    
+    if out is None:
+        out = ndarray(out_shape, dtype=a.dtype)
+    else:
+        if out.dtype != a.dtype:
+            raise TypeError('Output dtype mismatch')
+        if out.shape != out_shape:
+            raise ValueError('Output shape mismatch')
+    
+    return _ndarray_take(a, res[0], axis, out)
+
+
 cdef ndarray _ndarray_diagonal(ndarray self, offset, axis1, axis2):
     return _diagonal(self, offset, axis1, axis2)
 

--- a/cupy/core/_routines_indexing.pyx
+++ b/cupy/core/_routines_indexing.pyx
@@ -163,7 +163,7 @@ cdef ndarray _ndarray_compress(ndarray self, condition, axis, out):
         if condition.ndim != 1:
             raise ValueError('condition must be a 1-d array')
 
-    res = _ndarray_nonzero(condition)
+    res = _ndarray_nonzero(condition)  # synchronize
 
     return _ndarray_take(a, res[0], axis, out)
 

--- a/cupy/core/_routines_indexing.pyx
+++ b/cupy/core/_routines_indexing.pyx
@@ -165,14 +165,6 @@ cdef ndarray _ndarray_compress(ndarray self, condition, axis, out):
     
     res = _ndarray_nonzero(condition)
     
-    if out is None:
-        out = ndarray(out_shape, dtype=a.dtype)
-    else:
-        if out.dtype != a.dtype:
-            raise TypeError('Output dtype mismatch')
-        if out.shape != out_shape:
-            raise ValueError('Output shape mismatch')
-    
     return _ndarray_take(a, res[0], axis, out)
 
 

--- a/cupy/core/_routines_indexing.pyx
+++ b/cupy/core/_routines_indexing.pyx
@@ -157,14 +157,14 @@ cdef ndarray _ndarray_compress(ndarray self, condition, axis, out):
 
     if numpy.isscalar(condition):
         raise ValueError('condition must be a 1-d array')
-    
+
     if not isinstance(condition, ndarray):
         condition = core.array(condition, dtype=int)
         if condition.ndim != 1:
             raise ValueError('condition must be a 1-d array')
-    
+
     res = _ndarray_nonzero(condition)
-    
+
     return _ndarray_take(a, res[0], axis, out)
 
 

--- a/cupy/core/core.pxd
+++ b/cupy/core/core.pxd
@@ -43,6 +43,7 @@ cdef class ndarray:
     cpdef partition(self, kth, int axis=*)
     cpdef ndarray argpartition(self, kth, axis=*)
     cpdef tuple nonzero(self)
+    cpdef ndarray compress(self, condition, axis=*, out=*)
     cpdef ndarray diagonal(self, offset=*, axis1=*, axis2=*)
     cpdef ndarray max(self, axis=*, out=*, keepdims=*)
     cpdef ndarray argmax(self, axis=*, out=*, dtype=*,

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -724,7 +724,15 @@ cdef class ndarray:
 
         return _indexing._ndarray_nonzero(self)
 
-    # TODO(okuta): Implement compress
+    cpdef ndarray compress(self, condition, axis=None, out=None):
+        """Return selected slices of this array along given axis.
+
+        .. seealso::
+           :func:`cupy.compress` for full documentation,
+           :meth:`numpy.ndarray.compress`
+
+        """
+        return _indexing._ndarray_compress(self, condition, axis, out)
 
     cpdef ndarray diagonal(self, offset=0, axis1=0, axis2=1):
         """Returns a view of the specified diagonals.

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -725,7 +725,11 @@ cdef class ndarray:
         return _indexing._ndarray_nonzero(self)
 
     cpdef ndarray compress(self, condition, axis=None, out=None):
-        """Return selected slices of this array along given axis.
+        """Returns selected slices of this array along given axis.
+
+        .. warning::
+
+            This function may synchronize the device.
 
         .. seealso::
            :func:`cupy.compress` for full documentation,

--- a/cupy/indexing/indexing.py
+++ b/cupy/indexing/indexing.py
@@ -77,7 +77,7 @@ def choose(a, choices, out=None, mode='raise'):
 
 
 def compress(condition, a, axis=None, out=None):
-    """Return selected slices of an array along given axis.
+    """Returns selected slices of an array along given axis.
 
     Args:
         condition (1-D array of bools): Array that selects which entries to
@@ -94,7 +94,12 @@ def compress(condition, a, axis=None, out=None):
         cupy.ndarray: A copy of a without the slices along axis for which
             condition is false.
 
-    . seealso:: :func:`numpy.compress`
+    .. warning::
+
+            This function may synchronize the device.
+
+
+    .. seealso:: :func:`numpy.compress`
 
     """
     return a.compress(condition, axis, out)

--- a/cupy/indexing/indexing.py
+++ b/cupy/indexing/indexing.py
@@ -89,7 +89,7 @@ def compress(condition, a, axis=None, out=None):
             on the flattened array.
         out (cupy.ndarray): Output array. If provided, it should be of
             appropriate shape and dtype.
-    
+
     Returns:
         cupy.ndarray: A copy of a without the slices along axis for which
             condition is false.

--- a/cupy/indexing/indexing.py
+++ b/cupy/indexing/indexing.py
@@ -76,7 +76,28 @@ def choose(a, choices, out=None, mode='raise'):
     return a.choose(choices, out, mode)
 
 
-# TODO(okuta): Implement compress
+def compress(condition, a, axis=None, out=None):
+    """Return selected slices of an array along given axis.
+
+    Args:
+        condition (1-D array of bools): Array that selects which entries to
+            return. If len(condition) is less than the size of a along the
+            given axis, then output is truncated to the length of the condition
+            array.
+        a (cupy.ndarray): Array from which to extract a part.
+        axis (int): Axis along which to take slices. If None (default), work
+            on the flattened array.
+        out (cupy.ndarray): Output array. If provided, it should be of
+            appropriate shape and dtype.
+    
+    Returns:
+        cupy.ndarray: A copy of a without the slices along axis for which
+            condition is false.
+
+    . seealso:: :func:`numpy.compress`
+
+    """
+    return a.compress(condition, axis, out)
 
 
 def diagonal(a, offset=0, axis1=0, axis2=1):

--- a/docs/source/reference/indexing.rst
+++ b/docs/source/reference/indexing.rst
@@ -17,6 +17,7 @@ Indexing Routines
    cupy.take
    cupy.take_along_axis
    cupy.choose
+   cupy.compress
    cupy.diag
    cupy.diagonal
    cupy.lib.stride_tricks.as_strided

--- a/tests/cupy_tests/indexing_tests/test_indexing.py
+++ b/tests/cupy_tests/indexing_tests/test_indexing.py
@@ -40,13 +40,13 @@ class TestIndexing(unittest.TestCase):
         a = testing.shaped_random((2, 4, 3), xp, dtype='float32')
         b = testing.shaped_random((30,), xp, dtype='int64', scale=24)
         return xp.take_along_axis(a, b, axis=None)
-    
+
     @testing.numpy_cupy_array_equal()
     def test_compress(self, xp):
         a = testing.shaped_arange((3, 4, 5), xp)
         b = xp.array([True, False, True])
         return xp.compress(b, a, axis=1)
-    
+
     @testing.numpy_cupy_array_equal()
     def test_compress_no_axis(self, xp):
         a = testing.shaped_arange((3, 4, 5), xp)

--- a/tests/cupy_tests/indexing_tests/test_indexing.py
+++ b/tests/cupy_tests/indexing_tests/test_indexing.py
@@ -53,6 +53,25 @@ class TestIndexing(unittest.TestCase):
         b = xp.array([True, False, True])
         return xp.compress(b, a)
 
+    @testing.for_int_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_compress_no_bool(self, xp, dtype):
+        a = testing.shaped_arange((3, 4, 5), xp)
+        b = testing.shaped_arange((3,), xp, dtype)
+        return xp.compress(b, a, axis=1)
+
+    @testing.numpy_cupy_array_equal()
+    def test_compress_empty_1dim(self, xp):
+        a = testing.shaped_arange((3, 4, 5), xp)
+        b = xp.array([])
+        return xp.compress(b, a, axis=1)
+
+    @testing.numpy_cupy_array_equal()
+    def test_compress_empty_1dim_no_axis(self, xp):
+        a = testing.shaped_arange((3, 4, 5), xp)
+        b = xp.array([])
+        return xp.compress(b, a)
+
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_diagonal(self, xp, dtype):

--- a/tests/cupy_tests/indexing_tests/test_indexing.py
+++ b/tests/cupy_tests/indexing_tests/test_indexing.py
@@ -40,6 +40,18 @@ class TestIndexing(unittest.TestCase):
         a = testing.shaped_random((2, 4, 3), xp, dtype='float32')
         b = testing.shaped_random((30,), xp, dtype='int64', scale=24)
         return xp.take_along_axis(a, b, axis=None)
+    
+    @testing.numpy_cupy_array_equal()
+    def test_compress(self, xp):
+        a = testing.shaped_arange((3, 4, 5), xp)
+        b = xp.array([True, False, True])
+        return xp.compress(b, a, axis=1)
+    
+    @testing.numpy_cupy_array_equal()
+    def test_compress_no_axis(self, xp):
+        a = testing.shaped_arange((3, 4, 5), xp)
+        b = xp.array([True, False, True])
+        return xp.compress(b, a)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()


### PR DESCRIPTION
I tried to mimic numpy as much as possible. I observed that `PyArray_Compress` in numpy internally calls `nonzero` and `take`. So, I tried to do it in the same way instead of making a separate kernel. I would be happy to receive suggestions on how to implement the kernel for `compress`, if it is required to do so.