### PR TITLE
logaddexp for complex

### DIFF
--- a/cupy/math/explog.py
+++ b/cupy/math/explog.py
@@ -66,10 +66,13 @@ log1p = ufunc.create_math_ufunc(
 
     ''')
 
+complex_logaddexp = 'out0 = max(in0, in1) + log1p(exp(-abs(in0 - in1)))'
+
 
 logaddexp = core.create_ufunc(
     'cupy_logaddexp',
-    ('ee->e', 'ff->f', 'dd->d'),
+    ('ee->e', 'ff->f', 'dd->d',
+     ('FF->F', complex_logaddexp), ('DD->D', complex_logaddexp)),
     'out0 = fmax(in0, in1) + log1p(exp(-fabs(in0 - in1)))',
     doc='''Computes ``log(exp(x1) + exp(x2))`` elementwise.
 

--- a/tests/cupy_tests/math_tests/test_explog.py
+++ b/tests/cupy_tests/math_tests/test_explog.py
@@ -52,7 +52,7 @@ class TestExplog(unittest.TestCase):
         self.check_unary('log1p')
 
     def test_logaddexp(self):
-        self.check_binary('logaddexp', no_complex=True)
+        self.check_binary('logaddexp', no_complex=False)
 
     def test_logaddexp2(self):
         self.check_binary('logaddexp2', no_complex=True)


### PR DESCRIPTION
Hello,
this PR implements the ufunc for complex for logaddexp as noted in #1281 .

numpy doesnt support logaddex for complex types, so is this PR necessary or should we close the related issue ? 
