### PR TITLE
Add `bitwise_not` as alias to `invert`

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -332,6 +332,7 @@ from cupy.manipulation.rearrange import rot90  # NOQA
 from cupy.binary.elementwise import bitwise_and  # NOQA
 from cupy.binary.elementwise import bitwise_or  # NOQA
 from cupy.binary.elementwise import bitwise_xor  # NOQA
+from cupy.binary.elementwise import bitwise_not  # NOQA
 from cupy.binary.elementwise import invert  # NOQA
 from cupy.binary.elementwise import left_shift  # NOQA
 from cupy.binary.elementwise import right_shift  # NOQA

--- a/cupy/binary/elementwise.py
+++ b/cupy/binary/elementwise.py
@@ -10,6 +10,9 @@ bitwise_or = core.bitwise_or
 bitwise_xor = core.bitwise_xor
 
 
+bitwise_not = core.invert
+
+
 invert = core.invert
 
 

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2322,6 +2322,9 @@ invert = create_ufunc(
 
     Only integer and boolean arrays are handled.
 
+    .. note::
+        :func:`cupy.bitwise_not` is an alias for :func:`cupy.invert`.
+
     .. seealso:: :data:`numpy.invert`
 
     ''')

--- a/tests/cupy_tests/test_init.py
+++ b/tests/cupy_tests/test_init.py
@@ -113,6 +113,10 @@ class TestAliases(unittest.TestCase):
         for xp in (numpy, cupy):
             assert xp.conj is xp.conjugate
 
+    def test_bitwise_not_is_invert(self):
+        for xp in (numpy, cupy):
+            assert xp.bitwise_not is xp.invert
+
 
 # This is copied from chainer/testing/__init__.py, so should be replaced in
 # some way.


### PR DESCRIPTION
Added alias for `invert`. Modified docstring of `invert` to include `bitwise_not` as a note.