### PR TITLE
Rewrite manipulation tests not to use `numpy_cupy_raises`

### DIFF
--- a/tests/cupy_tests/manipulation_tests/test_dims.py
+++ b/tests/cupy_tests/manipulation_tests/test_dims.py
@@ -1,5 +1,7 @@
-import numpy
 import unittest
+
+import numpy
+import pytest
 
 import cupy
 from cupy import testing
@@ -53,18 +55,20 @@ class TestDims(unittest.TestCase):
         return b
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_raises()
-    def test_broadcast_to_fail(self, xp, dtype):
-        # Note that broadcast_to is only supported on numpy>=1.10
-        a = testing.shaped_arange((3, 1, 4), xp, dtype)
-        xp.broadcast_to(a, (1, 3, 4))
+    def test_broadcast_to_fail(self, dtype):
+        for xp in (numpy, cupy):
+            # Note that broadcast_to is only supported on numpy>=1.10
+            a = testing.shaped_arange((3, 1, 4), xp, dtype)
+            with pytest.raises(ValueError):
+                xp.broadcast_to(a, (1, 3, 4))
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_raises()
-    def test_broadcast_to_short_shape(self, xp, dtype):
-        # Note that broadcast_to is only supported on numpy>=1.10
-        a = testing.shaped_arange((1, 3, 4), xp, dtype)
-        xp.broadcast_to(a, (3, 4))
+    def test_broadcast_to_short_shape(self, dtype):
+        for xp in (numpy, cupy):
+            # Note that broadcast_to is only supported on numpy>=1.10
+            a = testing.shaped_arange((1, 3, 4), xp, dtype)
+            with pytest.raises(ValueError):
+                xp.broadcast_to(a, (3, 4))
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
@@ -80,17 +84,19 @@ class TestDims(unittest.TestCase):
 
     @testing.for_all_dtypes()
     def test_broadcast_to_fail_numpy19(self, dtype):
-        # Note that broadcast_to is only supported on numpy>=1.10
-        a = testing.shaped_arange((3, 1, 4), cupy, dtype)
-        with self.assertRaises(ValueError):
-            cupy.broadcast_to(a, (1, 3, 4))
+        for xp in (numpy, cupy):
+            # Note that broadcast_to is only supported on numpy>=1.10
+            a = testing.shaped_arange((3, 1, 4), xp, dtype)
+            with pytest.raises(ValueError):
+                xp.broadcast_to(a, (1, 3, 4))
 
     @testing.for_all_dtypes()
     def test_broadcast_to_short_shape_numpy19(self, dtype):
-        # Note that broadcast_to is only supported on numpy>=1.10
-        a = testing.shaped_arange((1, 3, 4), cupy, dtype)
-        with self.assertRaises(ValueError):
-            cupy.broadcast_to(a, (3, 4))
+        for xp in (numpy, cupy):
+            # Note that broadcast_to is only supported on numpy>=1.10
+            a = testing.shaped_arange((1, 3, 4), xp, dtype)
+            with pytest.raises(ValueError):
+                xp.broadcast_to(a, (3, 4))
 
     @testing.numpy_cupy_array_equal()
     def test_expand_dims0(self, xp):
@@ -113,12 +119,11 @@ class TestDims(unittest.TestCase):
         return xp.expand_dims(a, -2)
 
     @testing.with_requires('numpy>=1.18')
-    @testing.numpy_cupy_array_equal()
-    def test_expand_dims_negative2(self, xp):
-        a = testing.shaped_arange((2, 3), xp)
-        with self.assertRaises(numpy.AxisError):
-            xp.expand_dims(a, -4)
-        return xp.array(True)
+    def test_expand_dims_negative2(self):
+        for xp in (numpy, cupy):
+            a = testing.shaped_arange((2, 3), xp)
+            with pytest.raises(numpy.AxisError):
+                xp.expand_dims(a, -4)
 
     @testing.with_requires('numpy>=1.18')
     @testing.numpy_cupy_array_list_equal()
@@ -134,24 +139,19 @@ class TestDims(unittest.TestCase):
         ]]
 
     @testing.with_requires('numpy>=1.18')
-    @testing.numpy_cupy_array_equal()
-    def test_expand_dims_out_of_range(self, xp):
-        a = testing.shaped_arange((2, 2, 2), xp)
-        for axis in [
-                (1, -6),
-                (1, 5),
-        ]:
-            with self.assertRaises(numpy.AxisError):
-                xp.expand_dims(a, axis)
-        return xp.array(True)
+    def test_expand_dims_out_of_range(self):
+        for xp in (numpy, cupy):
+            a = testing.shaped_arange((2, 2, 2), xp)
+            for axis in [(1, -6), (1, 5)]:
+                with pytest.raises(numpy.AxisError):
+                    xp.expand_dims(a, axis)
 
     @testing.with_requires('numpy>=1.18')
-    @testing.numpy_cupy_array_equal()
-    def test_expand_dims_repeated_axis(self, xp):
-        a = testing.shaped_arange((2, 2, 2), xp)
-        with self.assertRaises(ValueError):
-            xp.expand_dims(a, (1, 1))
-        return xp.array(True)
+    def test_expand_dims_repeated_axis(self):
+        for xp in (numpy, cupy):
+            a = testing.shaped_arange((2, 2, 2), xp)
+            with pytest.raises(ValueError):
+                xp.expand_dims(a, (1, 1))
 
     @testing.numpy_cupy_array_equal()
     def test_squeeze1(self, xp):
@@ -173,15 +173,17 @@ class TestDims(unittest.TestCase):
         a = testing.shaped_arange((1, 2, 1, 3, 1, 1, 4, 1), xp)
         return a.squeeze(axis=-3)
 
-    @testing.numpy_cupy_raises()
-    def test_squeeze_int_axis_failure1(self, xp):
-        a = testing.shaped_arange((1, 2, 1, 3, 1, 1, 4, 1), xp)
-        a.squeeze(axis=-9)
+    def test_squeeze_int_axis_failure1(self):
+        for xp in (numpy, cupy):
+            a = testing.shaped_arange((1, 2, 1, 3, 1, 1, 4, 1), xp)
+            with pytest.raises(ValueError):
+                a.squeeze(axis=-9)
 
     def test_squeeze_int_axis_failure2(self):
-        a = testing.shaped_arange((1, 2, 1, 3, 1, 1, 4, 1), cupy)
-        with self.assertRaises(numpy.AxisError):
-            a.squeeze(axis=-9)
+        for xp in (numpy, cupy):
+            a = testing.shaped_arange((1, 2, 1, 3, 1, 1, 4, 1), xp)
+            with pytest.raises(numpy.AxisError):
+                a.squeeze(axis=-9)
 
     @testing.numpy_cupy_array_equal()
     def test_squeeze_tuple_axis1(self, xp):
@@ -203,20 +205,23 @@ class TestDims(unittest.TestCase):
         a = testing.shaped_arange((1, 2, 1, 3, 1, 1, 4, 1), xp)
         return a.squeeze(axis=())
 
-    @testing.numpy_cupy_raises()
-    def test_squeeze_tuple_axis_failure1(self, xp):
-        a = testing.shaped_arange((1, 2, 1, 3, 1, 1, 4, 1), xp)
-        a.squeeze(axis=(-9,))
+    def test_squeeze_tuple_axis_failure1(self):
+        for xp in (numpy, cupy):
+            a = testing.shaped_arange((1, 2, 1, 3, 1, 1, 4, 1), xp)
+            with pytest.raises(ValueError):
+                a.squeeze(axis=(-9,))
 
-    @testing.numpy_cupy_raises()
-    def test_squeeze_tuple_axis_failure2(self, xp):
-        a = testing.shaped_arange((1, 2, 1, 3, 1, 1, 4, 1), xp)
-        a.squeeze(axis=(2, 2))
+    def test_squeeze_tuple_axis_failure2(self):
+        for xp in (numpy, cupy):
+            a = testing.shaped_arange((1, 2, 1, 3, 1, 1, 4, 1), xp)
+            with pytest.raises(ValueError):
+                a.squeeze(axis=(2, 2))
 
     def test_squeeze_tuple_axis_failure3(self):
-        a = testing.shaped_arange((1, 2, 1, 3, 1, 1, 4, 1), cupy)
-        with self.assertRaises(numpy.AxisError):
-            a.squeeze(axis=(-9,))
+        for xp in (numpy, cupy):
+            a = testing.shaped_arange((1, 2, 1, 3, 1, 1, 4, 1), xp)
+            with pytest.raises(numpy.AxisError):
+                a.squeeze(axis=(-9,))
 
     @testing.numpy_cupy_array_equal()
     def test_squeeze_scalar1(self, xp):
@@ -228,30 +233,35 @@ class TestDims(unittest.TestCase):
         a = testing.shaped_arange((), xp)
         return a.squeeze(axis=-1)
 
-    @testing.numpy_cupy_raises()
-    def test_squeeze_scalar_failure1(self, xp):
-        a = testing.shaped_arange((), xp)
-        a.squeeze(axis=-2)
+    def test_squeeze_scalar_failure1(self):
+        for xp in (numpy, cupy):
+            a = testing.shaped_arange((), xp)
+            with pytest.raises(ValueError):
+                a.squeeze(axis=-2)
 
-    @testing.numpy_cupy_raises()
-    def test_squeeze_scalar_failure2(self, xp):
-        a = testing.shaped_arange((), xp)
-        a.squeeze(axis=1)
+    def test_squeeze_scalar_failure2(self):
+        for xp in (numpy, cupy):
+            a = testing.shaped_arange((), xp)
+            with pytest.raises(ValueError):
+                a.squeeze(axis=1)
 
     def test_squeeze_scalar_failure3(self):
-        a = testing.shaped_arange((), cupy)
-        with self.assertRaises(numpy.AxisError):
-            a.squeeze(axis=-2)
+        for xp in (numpy, cupy):
+            a = testing.shaped_arange((), xp)
+            with pytest.raises(numpy.AxisError):
+                a.squeeze(axis=-2)
 
     def test_squeeze_scalar_failure4(self):
-        a = testing.shaped_arange((), cupy)
-        with self.assertRaises(numpy.AxisError):
-            a.squeeze(axis=1)
+        for xp in (numpy, cupy):
+            a = testing.shaped_arange((), cupy)
+            with pytest.raises(numpy.AxisError):
+                a.squeeze(axis=1)
 
-    @testing.numpy_cupy_raises()
-    def test_squeeze_failure(self, xp):
-        a = testing.shaped_arange((2, 1, 3, 4), xp)
-        a.squeeze(axis=2)
+    def test_squeeze_failure(self):
+        for xp in (numpy, cupy):
+            a = testing.shaped_arange((2, 1, 3, 4), xp)
+            with pytest.raises(ValueError):
+                a.squeeze(axis=2)
 
     @testing.numpy_cupy_array_equal()
     def test_external_squeeze(self, xp):
@@ -306,15 +316,15 @@ class TestBroadcast(unittest.TestCase):
 class TestInvalidBroadcast(unittest.TestCase):
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_raises()
-    def test_invalid_broadcast(self, xp, dtype):
-        arrays = [
-            testing.shaped_arange(s, xp, dtype) for s in self.shapes]
-        xp.broadcast(*arrays)
+    def test_invalid_broadcast(self, dtype):
+        for xp in (numpy, cupy):
+            arrays = [testing.shaped_arange(s, xp, dtype) for s in self.shapes]
+            with pytest.raises(ValueError):
+                xp.broadcast(*arrays)
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_raises()
-    def test_invalid_broadcast_arrays(self, xp, dtype):
-        arrays = [
-            testing.shaped_arange(s, xp, dtype) for s in self.shapes]
-        xp.broadcast_arrays(*arrays)
+    def test_invalid_broadcast_arrays(self, dtype):
+        for xp in (numpy, cupy):
+            arrays = [testing.shaped_arange(s, xp, dtype) for s in self.shapes]
+            with pytest.raises(ValueError):
+                xp.broadcast_arrays(*arrays)

--- a/tests/cupy_tests/manipulation_tests/test_join.py
+++ b/tests/cupy_tests/manipulation_tests/test_join.py
@@ -1,6 +1,7 @@
 import unittest
 
 import numpy
+import pytest
 
 import cupy
 from cupy import testing
@@ -158,29 +159,32 @@ class TestJoin(unittest.TestCase):
         xp.concatenate((a, b, c), axis=1, out=out)
         return out
 
-    @testing.numpy_cupy_raises(accept_error=ValueError)
-    def test_concatenate_out_invalid_shape(self, xp):
-        a = testing.shaped_arange((3, 4), xp, xp.float64)
-        b = testing.shaped_reverse_arange((3, 4), xp, xp.float64)
-        c = testing.shaped_arange((3, 4), xp, xp.float64)
-        out = xp.zeros((4, 10), dtype=xp.float64)
-        xp.concatenate((a, b, c), axis=1, out=out)
+    def test_concatenate_out_invalid_shape(self):
+        for xp in (numpy, cupy):
+            a = testing.shaped_arange((3, 4), xp, xp.float64)
+            b = testing.shaped_reverse_arange((3, 4), xp, xp.float64)
+            c = testing.shaped_arange((3, 4), xp, xp.float64)
+            out = xp.zeros((4, 10), dtype=xp.float64)
+            with pytest.raises(ValueError):
+                xp.concatenate((a, b, c), axis=1, out=out)
 
-    @testing.numpy_cupy_raises(accept_error=ValueError)
-    def test_concatenate_out_invalid_shape_2(self, xp):
-        a = testing.shaped_arange((3, 4), xp, xp.float64)
-        b = testing.shaped_reverse_arange((3, 4), xp, xp.float64)
-        c = testing.shaped_arange((3, 4), xp, xp.float64)
-        out = xp.zeros((2, 2, 10), dtype=xp.float64)
-        xp.concatenate((a, b, c), axis=1, out=out)
+    def test_concatenate_out_invalid_shape_2(self):
+        for xp in (numpy, cupy):
+            a = testing.shaped_arange((3, 4), xp, xp.float64)
+            b = testing.shaped_reverse_arange((3, 4), xp, xp.float64)
+            c = testing.shaped_arange((3, 4), xp, xp.float64)
+            out = xp.zeros((2, 2, 10), dtype=xp.float64)
+            with pytest.raises(ValueError):
+                xp.concatenate((a, b, c), axis=1, out=out)
 
-    @testing.numpy_cupy_raises(accept_error=TypeError)
-    def test_concatenate_out_invalid_dtype(self, xp):
-        a = testing.shaped_arange((3, 4), xp, xp.float64)
-        b = testing.shaped_reverse_arange((3, 4), xp, xp.float64)
-        c = testing.shaped_arange((3, 4), xp, xp.float64)
-        out = xp.zeros((3, 12), dtype=xp.int64)
-        xp.concatenate((a, b, c), axis=1, out=out)
+    def test_concatenate_out_invalid_dtype(self):
+        for xp in (numpy, cupy):
+            a = testing.shaped_arange((3, 4), xp, xp.float64)
+            b = testing.shaped_reverse_arange((3, 4), xp, xp.float64)
+            c = testing.shaped_arange((3, 4), xp, xp.float64)
+            out = xp.zeros((3, 12), dtype=xp.int64)
+            with pytest.raises(TypeError):
+                xp.concatenate((a, b, c), axis=1, out=out)
 
     @testing.numpy_cupy_array_equal()
     def test_dstack(self, xp):
@@ -268,10 +272,11 @@ class TestJoin(unittest.TestCase):
         a = testing.shaped_arange((2, 3), xp)
         return xp.stack((a, a), axis=2)
 
-    @testing.numpy_cupy_raises(accept_error=ValueError)
-    def test_stack_with_axis_over(self, xp):
-        a = testing.shaped_arange((2, 3), xp)
-        return xp.stack((a, a), axis=3)
+    def test_stack_with_axis_over(self):
+        for xp in (numpy, cupy):
+            a = testing.shaped_arange((2, 3), xp)
+            with pytest.raises(ValueError):
+                xp.stack((a, a), axis=3)
 
     def test_stack_with_axis_value(self):
         a = testing.shaped_arange((2, 3), cupy)
@@ -294,16 +299,18 @@ class TestJoin(unittest.TestCase):
         cupy.testing.assert_array_equal(s[:, :, 0], a)
         cupy.testing.assert_array_equal(s[:, :, 1], a)
 
-    @testing.numpy_cupy_raises(accept_error=ValueError)
-    def test_stack_different_shape(self, xp):
-        a = testing.shaped_arange((2, 3), xp)
-        b = testing.shaped_arange((2, 4), xp)
-        return xp.stack([a, b])
+    def test_stack_different_shape(self):
+        for xp in (numpy, cupy):
+            a = testing.shaped_arange((2, 3), xp)
+            b = testing.shaped_arange((2, 4), xp)
+            with pytest.raises(ValueError):
+                xp.stack([a, b])
 
-    @testing.numpy_cupy_raises(accept_error=ValueError)
-    def test_stack_out_of_bounds1(self, xp):
-        a = testing.shaped_arange((2, 3), xp)
-        return xp.stack([a, a], axis=3)
+    def test_stack_out_of_bounds1(self):
+        for xp in (numpy, cupy):
+            a = testing.shaped_arange((2, 3), xp)
+            with pytest.raises(ValueError):
+                xp.stack([a, a], axis=3)
 
     def test_stack_out_of_bounds2(self):
         a = testing.shaped_arange((2, 3), cupy)
@@ -329,26 +336,29 @@ class TestJoin(unittest.TestCase):
         xp.stack((a, b, c), axis=1, out=out)
         return out
 
-    @testing.numpy_cupy_raises(accept_error=ValueError)
-    def test_stack_out_invalid_shape(self, xp):
-        a = testing.shaped_arange((3, 4), xp, xp.float64)
-        b = testing.shaped_reverse_arange((3, 4), xp, xp.float64)
-        c = testing.shaped_arange((3, 4), xp, xp.float64)
-        out = xp.zeros((3, 3, 10), dtype=xp.float64)
-        xp.stack((a, b, c), axis=1, out=out)
+    def test_stack_out_invalid_shape(self):
+        for xp in (numpy, cupy):
+            a = testing.shaped_arange((3, 4), xp, xp.float64)
+            b = testing.shaped_reverse_arange((3, 4), xp, xp.float64)
+            c = testing.shaped_arange((3, 4), xp, xp.float64)
+            out = xp.zeros((3, 3, 10), dtype=xp.float64)
+            with pytest.raises(ValueError):
+                xp.stack((a, b, c), axis=1, out=out)
 
-    @testing.numpy_cupy_raises(accept_error=ValueError)
-    def test_stack_out_invalid_shape_2(self, xp):
-        a = testing.shaped_arange((3, 4), xp, xp.float64)
-        b = testing.shaped_reverse_arange((3, 4), xp, xp.float64)
-        c = testing.shaped_arange((3, 4), xp, xp.float64)
-        out = xp.zeros((3, 3, 3, 10), dtype=xp.float64)
-        xp.stack((a, b, c), axis=1, out=out)
+    def test_stack_out_invalid_shape_2(self):
+        for xp in (numpy, cupy):
+            a = testing.shaped_arange((3, 4), xp, xp.float64)
+            b = testing.shaped_reverse_arange((3, 4), xp, xp.float64)
+            c = testing.shaped_arange((3, 4), xp, xp.float64)
+            out = xp.zeros((3, 3, 3, 10), dtype=xp.float64)
+            with pytest.raises(ValueError):
+                xp.stack((a, b, c), axis=1, out=out)
 
-    @testing.numpy_cupy_raises(accept_error=TypeError)
-    def test_stack_out_invalid_dtype(self, xp):
-        a = testing.shaped_arange((3, 4), xp, xp.float64)
-        b = testing.shaped_reverse_arange((3, 4), xp, xp.float64)
-        c = testing.shaped_arange((3, 4), xp, xp.float64)
-        out = xp.zeros((3, 3, 4), dtype=xp.int64)
-        xp.stack((a, b, c), axis=1, out=out)
+    def test_stack_out_invalid_dtype(self):
+        for xp in (numpy, cupy):
+            a = testing.shaped_arange((3, 4), xp, xp.float64)
+            b = testing.shaped_reverse_arange((3, 4), xp, xp.float64)
+            c = testing.shaped_arange((3, 4), xp, xp.float64)
+            out = xp.zeros((3, 3, 4), dtype=xp.int64)
+            with pytest.raises(TypeError):
+                xp.stack((a, b, c), axis=1, out=out)

--- a/tests/cupy_tests/manipulation_tests/test_rearrange.py
+++ b/tests/cupy_tests/manipulation_tests/test_rearrange.py
@@ -1,5 +1,8 @@
 import unittest
 
+import numpy
+import pytest
+
 import cupy
 from cupy import testing
 
@@ -103,45 +106,53 @@ class TestRoll(unittest.TestCase):
         x = testing.shaped_arange((5, 2), xp, dtype)
         return xp.roll(x, (2, 1, 3), axis=None)
 
-    @testing.numpy_cupy_raises()
-    def test_roll_invalid_shift(self, xp):
-        x = testing.shaped_arange((5, 2), xp)
-        return xp.roll(x, '0', axis=0)
+    def test_roll_invalid_shift(self):
+        for xp in (numpy, cupy):
+            x = testing.shaped_arange((5, 2), xp)
+            with pytest.raises(TypeError):
+                xp.roll(x, '0', axis=0)
 
-    @testing.numpy_cupy_raises()
-    def test_roll_shape_mismatch(self, xp):
-        x = testing.shaped_arange((5, 2, 3), xp)
-        return xp.roll(x, (2, 2, 2), axis=(0, 1))
+    def test_roll_shape_mismatch(self):
+        for xp in (numpy, cupy):
+            x = testing.shaped_arange((5, 2, 3), xp)
+            with pytest.raises(ValueError):
+                xp.roll(x, (2, 2, 2), axis=(0, 1))
 
-    @testing.numpy_cupy_raises()
-    def test_roll_invalid_axis1(self, xp):
-        x = testing.shaped_arange((5, 2), xp)
-        return xp.roll(x, 1, axis=2)
+    def test_roll_invalid_axis1(self):
+        for xp in (numpy, cupy):
+            x = testing.shaped_arange((5, 2), xp)
+            with pytest.raises(ValueError):
+                xp.roll(x, 1, axis=2)
 
-    @testing.numpy_cupy_raises()
-    def test_roll_invalid_axis2(self, xp):
-        x = testing.shaped_arange((5, 2), xp)
-        return xp.roll(x, 1, axis=-3)
+    def test_roll_invalid_axis2(self):
+        for xp in (numpy, cupy):
+            x = testing.shaped_arange((5, 2), xp)
+            with pytest.raises(ValueError):
+                xp.roll(x, 1, axis=-3)
 
-    @testing.numpy_cupy_raises()
-    def test_roll_invalid_axis_length(self, xp):
-        x = testing.shaped_arange((5, 2, 2), xp)
-        return cupy.roll(x, shift=(1, 0), axis=(0, 1, 2))
+    def test_roll_invalid_axis_length(self):
+        for xp in (numpy, cupy):
+            x = testing.shaped_arange((5, 2, 2), xp)
+            with pytest.raises(ValueError):
+                cupy.roll(x, shift=(1, 0), axis=(0, 1, 2))
 
-    @testing.numpy_cupy_raises()
-    def test_roll_invalid_axis_type(self, xp):
-        x = testing.shaped_arange((5, 2), xp)
-        return xp.roll(x, 2, axis='0')
+    def test_roll_invalid_axis_type(self):
+        for xp in (numpy, cupy):
+            x = testing.shaped_arange((5, 2), xp)
+            with pytest.raises(TypeError):
+                xp.roll(x, 2, axis='0')
 
-    @testing.numpy_cupy_raises()
-    def test_roll_invalid_negative_axis1(self, xp):
-        x = testing.shaped_arange((5, 2), xp)
-        return xp.roll(x, 1, axis=-3)
+    def test_roll_invalid_negative_axis1(self):
+        for xp in (numpy, cupy):
+            x = testing.shaped_arange((5, 2), xp)
+            with pytest.raises(ValueError):
+                xp.roll(x, 1, axis=-3)
 
-    @testing.numpy_cupy_raises()
-    def test_roll_invalid_negative_axis2(self, xp):
-        x = testing.shaped_arange((5, 2), xp)
-        return xp.roll(x, 1, axis=(1, -3))
+    def test_roll_invalid_negative_axis2(self):
+        for xp in (numpy, cupy):
+            x = testing.shaped_arange((5, 2), xp)
+            with pytest.raises(ValueError):
+                xp.roll(x, 1, axis=(1, -3))
 
 
 @testing.gpu
@@ -160,10 +171,11 @@ class TestFliplr(unittest.TestCase):
         return xp.fliplr(x)
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_raises()
-    def test_fliplr_insufficient_ndim(self, xp, dtype):
-        x = testing.shaped_arange((3,), xp, dtype)
-        return xp.fliplr(x)
+    def test_fliplr_insufficient_ndim(self, dtype):
+        for xp in (numpy, cupy):
+            x = testing.shaped_arange((3,), xp, dtype)
+            with pytest.raises(ValueError):
+                xp.fliplr(x)
 
 
 @testing.gpu
@@ -182,10 +194,11 @@ class TestFlipud(unittest.TestCase):
         return xp.flipud(x)
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_raises()
-    def test_flipud_insufficient_ndim(self, xp, dtype):
-        x = testing.shaped_arange((), xp, dtype)
-        return xp.flipud(x)
+    def test_flipud_insufficient_ndim(self, dtype):
+        for xp in (numpy, cupy):
+            x = testing.shaped_arange((), xp, dtype)
+            with pytest.raises(ValueError):
+                xp.flipud(x)
 
 
 @testing.gpu
@@ -228,22 +241,25 @@ class TestFlip(unittest.TestCase):
         return xp.flip(x, 1)
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_raises()
-    def test_flip_insufficient_ndim(self, xp, dtype):
-        x = testing.shaped_arange((), xp, dtype)
-        return xp.flip(x, 0)
+    def test_flip_insufficient_ndim(self, dtype):
+        for xp in (numpy, cupy):
+            x = testing.shaped_arange((), xp, dtype)
+            with pytest.raises(ValueError):
+                xp.flip(x, 0)
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_raises()
-    def test_flip_invalid_axis(self, xp, dtype):
-        x = testing.shaped_arange((3, 4), xp, dtype)
-        return xp.flip(x, 2)
+    def test_flip_invalid_axis(self, dtype):
+        for xp in (numpy, cupy):
+            x = testing.shaped_arange((3, 4), xp, dtype)
+            with pytest.raises(ValueError):
+                xp.flip(x, 2)
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_raises()
-    def test_flip_invalid_negative_axis(self, xp, dtype):
-        x = testing.shaped_arange((3, 4), xp, dtype)
-        return xp.flip(x, -3)
+    def test_flip_invalid_negative_axis(self, dtype):
+        for xp in (numpy, cupy):
+            x = testing.shaped_arange((3, 4), xp, dtype)
+            with pytest.raises(ValueError):
+                xp.flip(x, -3)
 
 
 @testing.gpu
@@ -280,25 +296,29 @@ class TestRot90(unittest.TestCase):
         return xp.rot90(x, 1, axes=(1, -1))
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_raises()
-    def test_rot90_insufficient_ndim(self, xp, dtype):
-        x = testing.shaped_arange((3,), xp, dtype)
-        return xp.rot90(x)
+    def test_rot90_insufficient_ndim(self, dtype):
+        for xp in (numpy, cupy):
+            x = testing.shaped_arange((3,), xp, dtype)
+            with pytest.raises(ValueError):
+                xp.rot90(x)
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_raises()
-    def test_rot90_too_much_axes(self, xp, dtype):
-        x = testing.shaped_arange((3, 4, 2), xp, dtype)
-        return xp.rot90(x, 1, axes=(0, 1, 2))
+    def test_rot90_too_much_axes(self, dtype):
+        for xp in (numpy, cupy):
+            x = testing.shaped_arange((3, 4, 2), xp, dtype)
+            with pytest.raises(ValueError):
+                xp.rot90(x, 1, axes=(0, 1, 2))
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_raises()
-    def test_rot90_invalid_axes(self, xp, dtype):
-        x = testing.shaped_arange((3, 4, 2), xp, dtype)
-        return xp.rot90(x, 1, axes=(1, 3))
+    def test_rot90_invalid_axes(self, dtype):
+        for xp in (numpy, cupy):
+            x = testing.shaped_arange((3, 4, 2), xp, dtype)
+            with pytest.raises(ValueError):
+                xp.rot90(x, 1, axes=(1, 3))
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_raises()
-    def test_rot90_invalid_negative_axes(self, xp, dtype):
-        x = testing.shaped_arange((3, 4, 2), xp, dtype)
-        return xp.rot90(x, 1, axes=(1, -2))
+    def test_rot90_invalid_negative_axes(self, dtype):
+        for xp in (numpy, cupy):
+            x = testing.shaped_arange((3, 4, 2), xp, dtype)
+            with pytest.raises(ValueError):
+                xp.rot90(x, 1, axes=(1, -2))

--- a/tests/cupy_tests/manipulation_tests/test_shape.py
+++ b/tests/cupy_tests/manipulation_tests/test_shape.py
@@ -52,15 +52,17 @@ class TestShape(unittest.TestCase):
         a = testing.shaped_arange((2, 3, 4), xp)
         return a.reshape(3, -1, order=order)
 
-    @testing.numpy_cupy_raises()
-    def test_reshape_with_multiple_unknown_dimensions(self, xp):
-        a = testing.shaped_arange((2, 3, 4))
-        a.reshape(3, -1, -1)
+    def test_reshape_with_multiple_unknown_dimensions(self):
+        for xp in (numpy, cupy):
+            a = testing.shaped_arange((2, 3, 4), xp)
+            with pytest.raises(ValueError):
+                a.reshape(3, -1, -1)
 
-    @testing.numpy_cupy_raises()
-    def test_reshape_with_changed_arraysize(self, xp):
-        a = testing.shaped_arange((2, 3, 4))
-        a.reshape(2, 4, 4)
+    def test_reshape_with_changed_arraysize(self):
+        for xp in (numpy, cupy):
+            a = testing.shaped_arange((2, 3, 4), xp)
+            with pytest.raises(ValueError):
+                a.reshape(2, 4, 4)
 
     def test_reshape_invalid_order(self):
         for xp in (numpy, cupy):
@@ -68,10 +70,11 @@ class TestShape(unittest.TestCase):
             with pytest.raises(ValueError):
                 a.reshape(2, 4, 4, order='K')
 
-    @testing.numpy_cupy_raises()
-    def test_reshape_empty_invalid(self, xp):
-        a = testing.empty(xp)
-        a = a.reshape(())
+    def test_reshape_empty_invalid(self):
+        for xp in (numpy, cupy):
+            a = testing.empty(xp)
+            with pytest.raises(ValueError):
+                a.reshape(())
 
     @testing.numpy_cupy_array_equal()
     def test_reshape_empty(self, xp):

--- a/tests/cupy_tests/manipulation_tests/test_tiling.py
+++ b/tests/cupy_tests/manipulation_tests/test_tiling.py
@@ -1,5 +1,6 @@
 import unittest
 
+import numpy
 import pytest
 
 import cupy
@@ -99,10 +100,11 @@ class TestRepeat1DListBroadcast(unittest.TestCase):
 @testing.gpu
 class TestRepeatFailure(unittest.TestCase):
 
-    @testing.numpy_cupy_raises()
-    def test_repeat_failure(self, xp):
-        x = testing.shaped_arange((2, 3, 4), xp)
-        xp.repeat(x, self.repeats, self.axis)
+    def test_repeat_failure(self):
+        for xp in (numpy, cupy):
+            x = testing.shaped_arange((2, 3, 4), xp)
+            with pytest.raises(ValueError):
+                xp.repeat(x, self.repeats, self.axis)
 
 
 @testing.parameterize(
@@ -129,7 +131,8 @@ class TestTile(unittest.TestCase):
 @testing.gpu
 class TestTileFailure(unittest.TestCase):
 
-    @testing.numpy_cupy_raises()
-    def test_tile_failure(self, xp):
-        x = testing.shaped_arange((2, 3, 4), xp)
-        xp.tile(x, -3)
+    def test_tile_failure(self):
+        for xp in (numpy, cupy):
+            x = testing.shaped_arange((2, 3, 4), xp)
+            with pytest.raises(ValueError):
+                xp.tile(x, -3)

--- a/tests/cupy_tests/manipulation_tests/test_transpose.py
+++ b/tests/cupy_tests/manipulation_tests/test_transpose.py
@@ -1,6 +1,7 @@
 import unittest
 
 import numpy
+import pytest
 
 import cupy
 from cupy import testing
@@ -40,54 +41,63 @@ class TestTranspose(unittest.TestCase):
         return xp.moveaxis(a, [0, 2, 1], [3, 4, 0])
 
     # dim is too large
-    @testing.numpy_cupy_raises()
-    def test_moveaxis_invalid1_1(self, xp):
-        a = testing.shaped_arange((2, 3, 4), xp)
-        return xp.moveaxis(a, [0, 1], [1, 3])
+    def test_moveaxis_invalid1_1(self):
+        for xp in (numpy, cupy):
+            a = testing.shaped_arange((2, 3, 4), xp)
+            with pytest.raises(numpy.AxisError):
+                xp.moveaxis(a, [0, 1], [1, 3])
 
     def test_moveaxis_invalid1_2(self):
-        a = testing.shaped_arange((2, 3, 4), cupy)
-        with self.assertRaises(numpy.AxisError):
-            return cupy.moveaxis(a, [0, 1], [1, 3])
+        for xp in (numpy, cupy):
+            a = testing.shaped_arange((2, 3, 4), xp)
+            with pytest.raises(numpy.AxisError):
+                xp.moveaxis(a, [0, 1], [1, 3])
 
     # dim is too small
-    @testing.numpy_cupy_raises()
-    def test_moveaxis_invalid2_1(self, xp):
-        a = testing.shaped_arange((2, 3, 4), xp)
-        return xp.moveaxis(a, [0, -4], [1, 2])
+    def test_moveaxis_invalid2_1(self):
+        for xp in (numpy, cupy):
+            a = testing.shaped_arange((2, 3, 4), xp)
+            with pytest.raises(numpy.AxisError):
+                xp.moveaxis(a, [0, -4], [1, 2])
 
     def test_moveaxis_invalid2_2(self):
-        a = testing.shaped_arange((2, 3, 4), cupy)
-        with self.assertRaises(numpy.AxisError):
-            return cupy.moveaxis(a, [0, -4], [1, 2])
+        for xp in (numpy, cupy):
+            a = testing.shaped_arange((2, 3, 4), xp)
+            with pytest.raises(numpy.AxisError):
+                xp.moveaxis(a, [0, -4], [1, 2])
 
     # len(source) != len(destination)
-    @testing.numpy_cupy_raises()
-    def test_moveaxis_invalid3(self, xp):
-        a = testing.shaped_arange((2, 3, 4), xp)
-        return xp.moveaxis(a, [0, 1, 2], [1, 2])
+    def test_moveaxis_invalid3(self):
+        for xp in (numpy, cupy):
+            a = testing.shaped_arange((2, 3, 4), xp)
+            with pytest.raises(ValueError):
+                xp.moveaxis(a, [0, 1, 2], [1, 2])
 
     # len(source) != len(destination)
-    @testing.numpy_cupy_raises()
-    def test_moveaxis_invalid4(self, xp):
-        a = testing.shaped_arange((2, 3, 4), xp)
-        return xp.moveaxis(a, [0, 1], [1, 2, 0])
+    def test_moveaxis_invalid4(self):
+        for xp in (numpy, cupy):
+            a = testing.shaped_arange((2, 3, 4), xp)
+            with pytest.raises(ValueError):
+                xp.moveaxis(a, [0, 1], [1, 2, 0])
 
     # Use the same axis twice
     def test_moveaxis_invalid5_1(self):
-        a = testing.shaped_arange((2, 3, 4), cupy)
-        with self.assertRaises(numpy.AxisError):
-            return cupy.moveaxis(a, [1, -1], [1, 3])
+        for xp in (numpy, cupy):
+            a = testing.shaped_arange((2, 3, 4), xp)
+            with pytest.raises(numpy.AxisError):
+                xp.moveaxis(a, [1, -1], [1, 3])
 
     def test_moveaxis_invalid5_2(self):
-        a = testing.shaped_arange((2, 3, 4), cupy)
-        with self.assertRaises(numpy.AxisError):
-            return cupy.moveaxis(a, [0, 1], [-1, 2])
+        for xp in (numpy, cupy):
+            a = testing.shaped_arange((2, 3, 4), xp)
+            with pytest.raises(ValueError):
+                xp.moveaxis(a, [0, 1], [-1, 2])
 
     def test_moveaxis_invalid5_3(self):
-        a = testing.shaped_arange((2, 3, 4), cupy)
-        with self.assertRaises(numpy.AxisError):
-            return cupy.moveaxis(a, [0, 1], [1, 1])
+        for xp in (numpy, cupy):
+            a = testing.shaped_arange((2, 3, 4), xp)
+            with pytest.raises(ValueError):
+                xp.moveaxis(a, [0, 1], [1, 1])
 
     @testing.numpy_cupy_array_equal()
     def test_rollaxis(self, xp):
@@ -95,9 +105,10 @@ class TestTranspose(unittest.TestCase):
         return xp.rollaxis(a, 2)
 
     def test_rollaxis_failure(self):
-        a = testing.shaped_arange((2, 3, 4))
-        with self.assertRaises(ValueError):
-            cupy.rollaxis(a, 3)
+        for xp in (numpy, cupy):
+            a = testing.shaped_arange((2, 3, 4), xp)
+            with pytest.raises(ValueError):
+                xp.rollaxis(a, 3)
 
     @testing.numpy_cupy_array_equal()
     def test_swapaxes(self, xp):
@@ -105,9 +116,10 @@ class TestTranspose(unittest.TestCase):
         return xp.swapaxes(a, 2, 0)
 
     def test_swapaxes_failure(self):
-        a = testing.shaped_arange((2, 3, 4))
-        with self.assertRaises(ValueError):
-            cupy.swapaxes(a, 3, 0)
+        for xp in (numpy, cupy):
+            a = testing.shaped_arange((2, 3, 4), xp)
+            with pytest.raises(ValueError):
+                xp.swapaxes(a, 3, 0)
 
     @testing.numpy_cupy_array_equal()
     def test_transpose(self, xp):


### PR DESCRIPTION
Ready for #3098.