### PR TITLE
Fix `reshape` to raise `ValueError` for order 'K'

### DIFF
--- a/cupy/core/internal.pyx
+++ b/cupy/core/internal.pyx
@@ -278,7 +278,9 @@ cpdef float from_float16(uint16_t v):
 cdef inline int _normalize_order(order, cpp_bool allow_k=True) except? 0:
     cdef int order_char
     order_char = b'C' if len(order) == 0 else ord(order[0])
-    if allow_k and (order_char == b'K' or order_char == b'k'):
+    if order_char == b'K' or order_char == b'k':
+        if not allow_k:
+            raise ValueError('order \'K\' is not permitted')
         order_char = b'K'
     elif order_char == b'A' or order_char == b'a':
         order_char = b'A'

--- a/tests/cupy_tests/manipulation_tests/test_shape.py
+++ b/tests/cupy_tests/manipulation_tests/test_shape.py
@@ -1,6 +1,7 @@
 import unittest
 
 import numpy
+import pytest
 
 import cupy
 from cupy import testing
@@ -61,10 +62,11 @@ class TestShape(unittest.TestCase):
         a = testing.shaped_arange((2, 3, 4))
         a.reshape(2, 4, 4)
 
-    @testing.numpy_cupy_raises()
-    def test_reshape_invalid_order(self, xp):
-        a = testing.shaped_arange((2, 3, 4))
-        a.reshape(2, 4, 4, order='K')
+    def test_reshape_invalid_order(self):
+        for xp in (numpy, cupy):
+            a = testing.shaped_arange((2, 3, 4), xp)
+            with pytest.raises(ValueError):
+                a.reshape(2, 4, 4, order='K')
 
     @testing.numpy_cupy_raises()
     def test_reshape_empty_invalid(self, xp):


### PR DESCRIPTION
Split from #3122.