### PR TITLE
Histogram update: support range, weights and density

### DIFF
--- a/cupy/statistics/histogram.py
+++ b/cupy/statistics/histogram.py
@@ -93,7 +93,8 @@ def _get_outer_edges(a, range):
                 'max must be larger than min in range parameter.')
         if not (numpy.isfinite(first_edge) and numpy.isfinite(last_edge)):
             raise ValueError(
-                "supplied range of [{}, {}] is not finite".format(first_edge, last_edge))
+                "supplied range of [{}, {}] is not finite".format(
+                    first_edge, last_edge))
     elif a.size == 0:
         first_edge = 0.0
         last_edge = 1.0

--- a/cupy/statistics/histogram.py
+++ b/cupy/statistics/histogram.py
@@ -34,7 +34,7 @@ _histogram_kernel = core.ElementwiseKernel(
     preamble=_preamble)
 
 
-def histogram(x, bins=10):
+def histogram(x, bins=10, density=False):
     """Computes the histogram of a set of data.
 
     Args:
@@ -42,7 +42,9 @@ def histogram(x, bins=10):
         bins (int or cupy.ndarray): If ``bins`` is an int, it represents the
             number of bins. If ``bins`` is an :class:`~cupy.ndarray`, it
             represents a bin edges.
-
+        density (bool, optional): If False, the default, returns the number of
+            samples in each bin. If True, returns the probability *density*
+            function at the bin, ``bin_count / sample_count / bin_volume``.
     Returns:
         tuple: ``(hist, bin_edges)`` where ``hist`` is a :class:`cupy.ndarray`
         storing the values of the histogram, and ``bin_edges`` is a
@@ -79,6 +81,10 @@ def histogram(x, bins=10):
 
     y = cupy.zeros(bins.size - 1, dtype='l')
     _histogram_kernel(x, bins, bins.size, y)
+
+    if density:
+        db = cupy.array(cupy.diff(bins), float)
+        return y/db/y.sum(), bins
     return y, bins
 
 # TODO(okuta): Implement histogram2d

--- a/cupy/statistics/histogram.py
+++ b/cupy/statistics/histogram.py
@@ -181,7 +181,7 @@ def histogram(x, bins=10, range=None, weights=None, density=False):
             number of bins. If ``bins`` is an :class:`~cupy.ndarray`, it
             represents a bin edges.
         range (2-tuple of float, optional): The lower and upper range of the
-            bins.  If not provided, range is simply ``(a.min(), a.max())``.
+            bins.  If not provided, range is simply ``(x.min(), x.max())``.
             Values outside the range are ignored. The first element of the
             range must be less than or equal to the second. `range` affects the
             automatic bin computation as well. While bin width is computed to

--- a/tests/cupy_tests/statics_tests/test_histogram.py
+++ b/tests/cupy_tests/statics_tests/test_histogram.py
@@ -119,7 +119,7 @@ class TestHistogram(unittest.TestCase):
 
     @testing.for_all_dtypes(no_bool=True, no_complex=True)
     @testing.numpy_cupy_allclose()
-    def test_histogram_int_weights(self, xp, dtype):
+    def test_histogram_int_weights_dtype(self, xp, dtype):
         # Check the type of the returned histogram
         a = xp.arange(10, dtype=dtype)
         h, b = xp.histogram(a, weights=xp.ones(10, int))
@@ -128,7 +128,7 @@ class TestHistogram(unittest.TestCase):
 
     @testing.for_all_dtypes(no_bool=True, no_complex=True)
     @testing.numpy_cupy_allclose()
-    def test_histogram_float_weights(self, xp, dtype):
+    def test_histogram_float_weights_dtype(self, xp, dtype):
         # Check the type of the returned histogram
         a = xp.arange(10, dtype=dtype)
         h, b = xp.histogram(a, weights=xp.ones(10, float))

--- a/tests/cupy_tests/statics_tests/test_histogram.py
+++ b/tests/cupy_tests/statics_tests/test_histogram.py
@@ -54,6 +54,17 @@ class TestHistogram(unittest.TestCase):
 
     @testing.for_all_dtypes(no_bool=True, no_complex=True)
     @testing.numpy_cupy_array_list_equal()
+    def test_histogram_density(self, xp, dtype):
+        x = testing.shaped_arange((10,), xp, dtype)
+        y, bin_edges = xp.histogram(x, density=True)
+
+        area = xp.sum(y * xp.diff(bin_edges))
+        testing.assert_allclose(area, 1)
+
+        return y, bin_edges
+
+    @testing.for_all_dtypes(no_bool=True, no_complex=True)
+    @testing.numpy_cupy_array_list_equal()
     def test_histogram_empty(self, xp, dtype):
         x = xp.array([], dtype)
         y, bin_edges = xp.histogram(x)

--- a/tests/cupy_tests/statics_tests/test_histogram.py
+++ b/tests/cupy_tests/statics_tests/test_histogram.py
@@ -3,6 +3,7 @@ import unittest
 
 import numpy
 
+import cupy
 from cupy import testing
 
 
@@ -57,7 +58,6 @@ class TestHistogram(unittest.TestCase):
     def test_histogram_density(self, xp, dtype):
         x = testing.shaped_arange((10,), xp, dtype)
         y, bin_edges = xp.histogram(x, density=True)
-
         # check normalization
         area = xp.sum(y * xp.diff(bin_edges))
         testing.assert_allclose(area, 1)
@@ -90,6 +90,15 @@ class TestHistogram(unittest.TestCase):
         testing.assert_allclose(float((h * xp.diff(b)).sum()), 1)
         return h
 
+    @testing.for_float_dtypes()
+    @testing.numpy_cupy_allclose()
+    def test_histogram_range_with_weights_and_density(self, xp, dtype):
+        a = xp.arange(10, dtype=dtype) + .5
+        w = xp.arange(10, dtype=dtype) + .5
+        h, b = xp.histogram(a, range=[1, 9], weights=w, density=True)
+        testing.assert_allclose(float((h * xp.diff(b)).sum()), 1)
+        return h
+
     @testing.numpy_cupy_raises(accept_error=ValueError)
     def test_histogram_invalid_range(self, xp):
         # range must be None or have two elements
@@ -100,6 +109,103 @@ class TestHistogram(unittest.TestCase):
     def test_histogram_invalid_range2(self, xp):
         h, b = xp.histogram(xp.arange(10), range=10)
         return
+
+    @testing.for_all_dtypes(no_bool=True, no_complex=True)
+    @testing.numpy_cupy_raises(accept_error=ValueError)
+    def test_histogram_weights_mismatch(self, xp, dtype):
+        a = xp.arange(10, dtype=dtype) + .5
+        w = xp.arange(11, dtype=dtype) + .5
+        h, b = xp.histogram(a, range=[1, 9], weights=w, density=True)
+
+    @testing.for_all_dtypes(no_bool=True, no_complex=True)
+    @testing.numpy_cupy_allclose()
+    def test_histogram_int_weights(self, xp, dtype):
+        # Check the type of the returned histogram
+        a = xp.arange(10, dtype=dtype)
+        h, b = xp.histogram(a, weights=xp.ones(10, int))
+        assert xp.issubdtype(h.dtype, xp.integer)
+        return h, b
+
+    @testing.for_all_dtypes(no_bool=True, no_complex=True)
+    @testing.numpy_cupy_allclose()
+    def test_histogram_float_weights(self, xp, dtype):
+        # Check the type of the returned histogram
+        a = xp.arange(10, dtype=dtype)
+        h, b = xp.histogram(a, weights=xp.ones(10, float))
+        assert xp.issubdtype(h.dtype, xp.floating)
+        return h, b
+
+    def test_histogram_weights_basic(self):
+        v = cupy.random.rand(100)
+        w = cupy.ones(100) * 5
+        a, b = cupy.histogram(v)
+        na, nb = cupy.histogram(v, density=True)
+        wa, wb = cupy.histogram(v, weights=w)
+        nwa, nwb = cupy.histogram(v, weights=w, density=True)
+        testing.assert_array_almost_equal(a * 5, wa)
+        testing.assert_array_almost_equal(na, nwa)
+
+    @testing.for_float_dtypes()
+    @testing.numpy_cupy_allclose()
+    def test_histogram_float_weights(self, xp, dtype):
+        # Check weights are properly applied.
+        v = xp.linspace(0, 10, 10, dtype=dtype)
+        w = xp.concatenate((xp.zeros(5, dtype=dtype), xp.ones(5, dtype=dtype)))
+        wa, wb = xp.histogram(v, bins=xp.arange(11), weights=w)
+        testing.assert_array_almost_equal(wa, w)
+        return wb
+
+    @testing.for_int_dtypes(no_bool=True)
+    @testing.numpy_cupy_array_list_equal()
+    def test_histogram_int_weights(self, xp, dtype):
+        # Check with integer weights
+        v = xp.asarray([1, 2, 2, 4], dtype=dtype)
+        w = xp.asarray([4, 3, 2, 1], dtype=dtype)
+        wa, wb = xp.histogram(v, bins=4, weights=w)
+        testing.assert_array_equal(wa, [4, 5, 0, 1])
+        return wa, wb
+
+    @testing.for_int_dtypes(no_bool=True)
+    @testing.numpy_cupy_allclose()
+    def test_histogram_int_weights_normalized(self, xp, dtype):
+        v = xp.asarray([1, 2, 2, 4], dtype=dtype)
+        w = xp.asarray([4, 3, 2, 1], dtype=dtype)
+        wa, wb = xp.histogram(v, bins=4, weights=w, density=True)
+        testing.assert_array_almost_equal(
+            wa, xp.asarray([4, 5, 0, 1]) / 10. / 3. * 4)
+        return wb
+
+    @testing.for_int_dtypes(no_bool=True)
+    @testing.numpy_cupy_array_list_equal()
+    def test_histogram_int_weights_nonuniform_bins(self, xp, dtype):
+        # Check weights with non-uniform bin widths
+        a, b = xp.histogram(
+            xp.arange(9, dtype=dtype),
+            xp.asarray([0, 1, 3, 6, 10], dtype=dtype),
+            weights=xp.asarray([2, 1, 1, 1, 1, 1, 1, 1, 1], dtype=dtype),
+            density=True)
+        testing.assert_array_almost_equal(a, [.2, .1, .1, .075])
+        return a, b
+
+    @testing.for_complex_dtypes()
+    @testing.numpy_cupy_array_list_equal()
+    def test_histogram_complex_weights(self, xp, dtype):
+        values = xp.asarray([1.3, 2.5, 2.3])
+        weights = xp.asarray([1, -1, 2]) + 1j * xp.asarray([2, 1, 2])
+        weights = weights.astype(dtype)
+        a, b = xp.histogram(
+            values, bins=2, weights=weights)
+        return a, b
+
+    @testing.for_complex_dtypes()
+    @testing.numpy_cupy_array_list_equal()
+    def test_histogram_complex_weights_uneven_bins(self, xp, dtype):
+        values = xp.asarray([1.3, 2.5, 2.3])
+        weights = xp.asarray([1, -1, 2]) + 1j * xp.asarray([2, 1, 2])
+        weights = weights.astype(dtype)
+        a, b = xp.histogram(
+            values, bins=xp.asarray([0, 2, 3]), weights=weights)
+        return a, b
 
     @testing.for_all_dtypes(no_bool=True, no_complex=True)
     @testing.numpy_cupy_array_list_equal()

--- a/tests/cupy_tests/statics_tests/test_histogram.py
+++ b/tests/cupy_tests/statics_tests/test_histogram.py
@@ -124,7 +124,7 @@ class TestHistogram(unittest.TestCase):
         a = xp.arange(10, dtype=dtype)
         h, b = xp.histogram(a, weights=xp.ones(10, int))
         assert xp.issubdtype(h.dtype, xp.integer)
-        return h, b
+        return h
 
     @testing.for_all_dtypes(no_bool=True, no_complex=True)
     @testing.numpy_cupy_allclose()
@@ -133,7 +133,7 @@ class TestHistogram(unittest.TestCase):
         a = xp.arange(10, dtype=dtype)
         h, b = xp.histogram(a, weights=xp.ones(10, float))
         assert xp.issubdtype(h.dtype, xp.floating)
-        return h, b
+        return h
 
     def test_histogram_weights_basic(self):
         v = cupy.random.rand(100)


### PR DESCRIPTION
**Description**
This PR updates the `histogram` function to support the `range`, `weights` and `density` kwargs.

It should be easiest to review the 3 commits sequentially as each of them deals with a separate kwarg.

**Details**
The helpers `_get_outer_edges`, `_get_bin_edges` and `_ravel_and_check_weights` are closely based on their NumPy implementations (except that they do not automatically convert array-likes to `ndarray`).

NumPy itself has a fast code path for uniform bins that loops over blocks of ~65k elements using `bincount` and then a second path for non-uniform bins that uses `searchsorted`. I have not made any changes related to those here, but left the current implementation based on `ElementwiseKernel`.

**One question on API:**
In NumPy there is also a `normed` argument, but its use is deprecated, so I did not add it here. My question is whether the argument should still be in the function signature and just raise a `NotImplementedError` if the user tries to use it?

**Potential follow-ups:**
- add `histogramdd` (I have an implementation for this, and can make a follow-up PR)
- add various other bin selectors to `cupy.histogram`. I haven't worked on this but it looks like it would be easy to add.
