### PR TITLE
Add `PythonFunctionAllocator`

### DIFF
--- a/cupy/cuda/__init__.py
+++ b/cupy/cuda/__init__.py
@@ -85,6 +85,7 @@ from cupy.cuda.memory import ManagedMemory  # NOQA
 from cupy.cuda.memory import Memory  # NOQA
 from cupy.cuda.memory import MemoryPointer  # NOQA
 from cupy.cuda.memory import MemoryPool  # NOQA
+from cupy.cuda.memory import PythonFunctionAllocator  # NOQA
 from cupy.cuda.memory import set_allocator  # NOQA
 from cupy.cuda.memory import get_allocator  # NOQA
 from cupy.cuda.memory import UnownedMemory  # NOQA

--- a/cupy/cuda/memory.pxd
+++ b/cupy/cuda/memory.pxd
@@ -88,16 +88,13 @@ cdef class CFunctionAllocator:
 cdef class PythonFunctionAllocatorMemory(BaseMemory):
 
     cdef:
-        object _param
         object _free_func
 
 
 cdef class PythonFunctionAllocator:
 
     cdef:
-        object _param
         object _malloc_func
         object _free_func
-        object _owner
 
     cpdef MemoryPointer malloc(self, size_t size)

--- a/cupy/cuda/memory.pxd
+++ b/cupy/cuda/memory.pxd
@@ -82,3 +82,22 @@ cdef class CFunctionAllocator:
         object _owner
 
     cpdef MemoryPointer malloc(self, size_t size)
+
+
+@cython.no_gc
+cdef class PythonFunctionAllocatorMemory(BaseMemory):
+
+    cdef:
+        object _param
+        object _free_func
+
+
+cdef class PythonFunctionAllocator:
+
+    cdef:
+        object _param
+        object _malloc_func
+        object _free_func
+        object _owner
+
+    cpdef MemoryPointer malloc(self, size_t size)

--- a/cupy/cuda/memory.pxd
+++ b/cupy/cuda/memory.pxd
@@ -84,7 +84,6 @@ cdef class CFunctionAllocator:
     cpdef MemoryPointer malloc(self, size_t size)
 
 
-@cython.no_gc
 cdef class PythonFunctionAllocatorMemory(BaseMemory):
 
     cdef:

--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -1470,6 +1470,10 @@ cdef class PythonFunctionAllocator:
     ``free(int, int)`` with no return, taking the pointer to the
     allocated memory and the device id on which the memory was allocated.
 
+    If the external memory management supports asynchronous operations,
+    the current CuPy stream can be retrieved inside ``malloc_func`` and
+    ``free_func`` by calling :func:`cupy.cuda.get_current_stream()`.
+
     Args:
         malloc_func (function): *malloc* function to be called.
         free_func (function): *free* function to be called.

--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -1472,7 +1472,8 @@ cdef class PythonFunctionAllocator:
 
     If the external memory management supports asynchronous operations,
     the current CuPy stream can be retrieved inside ``malloc_func`` and
-    ``free_func`` by calling :func:`cupy.cuda.get_current_stream()`.
+    ``free_func`` by calling :func:`cupy.cuda.get_current_stream()`. To
+    use external streams, wrap them with :func:`cupy.cuda.ExternalStream`.
 
     Args:
         malloc_func (function): *malloc* function to be called.

--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -1434,3 +1434,64 @@ cdef class CFunctionAllocator:
         mem = CFunctionAllocatorMemory(size, self._param, self._malloc_func,
                                        self._free_func, device.get_device_id())
         return MemoryPointer(mem, 0)
+
+
+@cython.no_gc
+cdef class PythonFunctionAllocatorMemory(BaseMemory):
+
+    def __init__(self, size_t size, object param,
+                 malloc_func, free_func,
+                 int device_id):
+        self._param = param
+        self._free_func = free_func
+        self.device_id = device_id
+        self.size = size
+        self.ptr = 0
+        if size > 0:
+            self.ptr = malloc_func(param, size, device_id)
+
+    def __dealloc__(self):
+        if self.ptr:
+            self._free_func(self._param, self.ptr, self.device_id)
+
+
+cdef class PythonFunctionAllocator:
+
+    """Allocator with python functions to perform memory allocation.
+
+    This allocator keeps a *param* object along with functions
+    corresponding to *malloc* and *free*, delegating the actual allocation to
+    external sources while only handling the timing of the resource allocation
+    and deallocation.
+
+    *malloc* should follow the signature ``malloc(object, int, int) -> int``
+    returning the pointer to the allocated memory given the *param* object,
+    the number of bytes to allocate and the device id on which the
+    allocation should take place.
+
+    Similarly, *free* should follow the signature
+    ``free(object, int, int)`` with no return, taking the *param* object,
+    the pointer to the allocated memory and the device id on which the
+    memory was allocated.
+
+    Args:
+        param (object): *param* object to be passed on allocation and deletion.
+        malloc_func (function): *malloc* function to be called.
+        free_func (function): *free* function to be called.
+        owner (object): Reference to the owner object to keep the param and
+            the functions alive.
+
+    """
+
+    def __init__(self, object param, malloc_func,
+                 free_func, object owner):
+        self._param = param
+        self._malloc_func = malloc_func
+        self._free_func = free_func
+        self._owner = owner
+
+    cpdef MemoryPointer malloc(self, size_t size):
+        mem = PythonFunctionAllocatorMemory(
+            size, self._param, self._malloc_func,
+            self._free_func, device.get_device_id())
+        return MemoryPointer(mem, 0)

--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -1436,7 +1436,6 @@ cdef class CFunctionAllocator:
         return MemoryPointer(mem, 0)
 
 
-@cython.no_gc
 cdef class PythonFunctionAllocatorMemory(BaseMemory):
 
     def __init__(self, size_t size, malloc_func, free_func,

--- a/docs/source/reference/cuda.rst
+++ b/docs/source/reference/cuda.rst
@@ -31,6 +31,7 @@ Memory management
    cupy.cuda.set_pinned_memory_allocator
    cupy.cuda.MemoryPool
    cupy.cuda.PinnedMemoryPool
+   cupy.cuda.PythonFunctionAllocator
 
 
 Memory hook


### PR DESCRIPTION
This allows cupy to perform memory allocation from a given python interface.
I.e. if the pytorch allocator is exposed in python, it can be used through this new `PythonFunctionAllocator` class.

The difference with `CFunctionAllocator` is that the later uses function pointers that are not easily callable from python and limiting the interoperability with other tools.