### PR TITLE
add support for `ord` = 2, -2, and 'nuc' in `cupy.linalg.norm`

### DIFF
--- a/cupy/linalg/norms.py
+++ b/cupy/linalg/norms.py
@@ -6,6 +6,7 @@ from cupy.linalg import decomposition
 from cupy.linalg import util
 from cupy.linalg import svd
 
+
 def _multi_svd_norm(x, row_axis, col_axis, op):
     """Compute a function of the singular values of the 2-D matrices in `x`.
     This is a private utility function used by `cumpy.linalg.norm()`.
@@ -28,6 +29,7 @@ def _multi_svd_norm(x, row_axis, col_axis, op):
     y = cupy.moveaxis(x, (row_axis, col_axis), (-2, -1))
     result = op(svd(y, compute_uv=False), axis=-1)
     return result
+
 
 def norm(x, ord=None, axis=None, keepdims=False):
     """Returns one of matrix norms specified by ``ord`` parameter.
@@ -121,7 +123,7 @@ def norm(x, ord=None, axis=None, keepdims=False):
         if row_axis == col_axis:
             raise ValueError('Duplicate axes given.')
         if ord == 2:
-            ret =  _multi_svd_norm(x, row_axis, col_axis, cupy.amax)
+            ret = _multi_svd_norm(x, row_axis, col_axis, cupy.amax)
         elif ord == -2:
             ret = _multi_svd_norm(x, row_axis, col_axis, cupy.amin)
         elif ord == 1:

--- a/cupy/linalg/norms.py
+++ b/cupy/linalg/norms.py
@@ -5,7 +5,7 @@ import cupy
 from cupy.linalg import decomposition
 from cupy.linalg import util
 
-from functools import partial
+import functools
 
 
 def _multi_svd_norm(x, row_axis, col_axis, op):
@@ -106,10 +106,10 @@ def norm(x, ord=None, axis=None, keepdims=False):
         if row_axis == col_axis:
             raise ValueError('Duplicate axes given.')
         if ord == 2:
-            op_max = partial(cupy.take, indices=0)
+            op_max = functools.partial(cupy.take, indices=0)
             ret = _multi_svd_norm(x, row_axis, col_axis, op_max)
         elif ord == -2:
-            op_min = partial(cupy.take, indices=-1)
+            op_min = functools.partial(cupy.take, indices=-1)
             ret = _multi_svd_norm(x, row_axis, col_axis, op_min)
         elif ord == 1:
             if col_axis > row_axis:

--- a/cupy/linalg/norms.py
+++ b/cupy/linalg/norms.py
@@ -7,24 +7,6 @@ from cupy.linalg import util
 
 
 def _multi_svd_norm(x, row_axis, col_axis, op):
-    """Compute a function of the singular values of the 2-D matrices in `x`.
-    This is a private utility function used by `cumpy.linalg.norm()`.
-    Parameters
-    ----------
-    x : cupy.ndarray
-    row_axis, col_axis : int
-        The axes of `x` that hold the 2-D matrices.
-    op : callable
-        This should be either `cupy.amin` or `cumpy.amax` or `cumpy.sum`.
-    Returns
-    -------
-    result : float or cupy.ndarray
-        If `x` is 2-D, the return values is a float.
-        Otherwise, it is an array with ``x.ndim - 2`` dimensions.
-        The return values are either the minimum or maximum or sum of the
-        singular values of the matrices, depending on whether `op`
-        is `cupy.amin` or `cupy.amax` or `cupy.sum`.
-    """
     y = cupy.moveaxis(x, (row_axis, col_axis), (-2, -1))
     result = op(decomposition.svd(y, compute_uv=False), axis=-1)
     return result

--- a/cupy/linalg/norms.py
+++ b/cupy/linalg/norms.py
@@ -5,6 +5,8 @@ import cupy
 from cupy.linalg import decomposition
 from cupy.linalg import util
 
+from functools import partial
+
 
 def _multi_svd_norm(x, row_axis, col_axis, op):
     y = cupy.moveaxis(x, (row_axis, col_axis), (-2, -1))
@@ -104,9 +106,11 @@ def norm(x, ord=None, axis=None, keepdims=False):
         if row_axis == col_axis:
             raise ValueError('Duplicate axes given.')
         if ord == 2:
-            ret = _multi_svd_norm(x, row_axis, col_axis, cupy.amax)
+            op_max = partial(cupy.take, indices=0)
+            ret = _multi_svd_norm(x, row_axis, col_axis, op_max)
         elif ord == -2:
-            ret = _multi_svd_norm(x, row_axis, col_axis, cupy.amin)
+            op_min = partial(cupy.take, indices=-1)
+            ret = _multi_svd_norm(x, row_axis, col_axis, op_min)
         elif ord == 1:
             if col_axis > row_axis:
                 col_axis -= 1

--- a/cupy/linalg/norms.py
+++ b/cupy/linalg/norms.py
@@ -4,7 +4,6 @@ from numpy import linalg
 import cupy
 from cupy.linalg import decomposition
 from cupy.linalg import util
-from cupy.linalg import svd
 
 
 def _multi_svd_norm(x, row_axis, col_axis, op):
@@ -27,7 +26,7 @@ def _multi_svd_norm(x, row_axis, col_axis, op):
         is `cupy.amin` or `cupy.amax` or `cupy.sum`.
     """
     y = cupy.moveaxis(x, (row_axis, col_axis), (-2, -1))
-    result = op(svd(y, compute_uv=False), axis=-1)
+    result = op(decomposition.svd(y, compute_uv=False), axis=-1)
     return result
 
 

--- a/tests/cupy_tests/linalg_tests/test_norms.py
+++ b/tests/cupy_tests/linalg_tests/test_norms.py
@@ -55,7 +55,8 @@ class TestNorm(unittest.TestCase):
     @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-4, type_check=False)
     def test_norm(self, xp, dtype):
         a = testing.shaped_arange(self.shape, xp, dtype)
-        return xp.linalg.norm(a, self.ord, self.axis, self.keepdims)
+        with testing.NumpyError(divide='ignore'):
+            return xp.linalg.norm(a, self.ord, self.axis, self.keepdims)
 
 
 @testing.parameterize(*testing.product({

--- a/tests/cupy_tests/linalg_tests/test_norms.py
+++ b/tests/cupy_tests/linalg_tests/test_norms.py
@@ -30,7 +30,7 @@ class TestTrace(unittest.TestCase):
     'keepdims': [True, False],
 }) + testing.product({
     'shape': [(1, 2), (2, 2)],
-    'ord': [-numpy.Inf, -1, 1, numpy.Inf, 'fro'],
+    'ord': [-numpy.Inf, -2, -1, 1, 2, numpy.Inf, 'fro', 'nuc'],
     'axis': [(0, 1), None],
     'keepdims': [True, False],
 }) + testing.product({
@@ -55,8 +55,7 @@ class TestNorm(unittest.TestCase):
     @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-4, type_check=False)
     def test_norm(self, xp, dtype):
         a = testing.shaped_arange(self.shape, xp, dtype)
-        with testing.NumpyError(divide='ignore'):
-            return xp.linalg.norm(a, self.ord, self.axis, self.keepdims)
+        return xp.linalg.norm(a, self.ord, self.axis, self.keepdims)
 
 
 @testing.parameterize(*testing.product({

--- a/tests/cupy_tests/linalg_tests/test_norms.py
+++ b/tests/cupy_tests/linalg_tests/test_norms.py
@@ -51,12 +51,11 @@ class TestNorm(unittest.TestCase):
     # TODO(kmaehashi) Currently dtypes returned from CuPy is not compatible
     # with NumPy. We should remove `type_check=False` once NumPy is fixed.
     # See https://github.com/cupy/cupy/pull/875 for details.
-    @testing.for_all_dtypes()
+    @testing.for_all_dtypes(no_float16=True)
     @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-4, type_check=False)
     def test_norm(self, xp, dtype):
         a = testing.shaped_arange(self.shape, xp, dtype)
-        with testing.NumpyError(divide='ignore'):
-            return xp.linalg.norm(a, self.ord, self.axis, self.keepdims)
+        return xp.linalg.norm(a, self.ord, self.axis, self.keepdims)
 
 
 @testing.parameterize(*testing.product({


### PR DESCRIPTION
closes #3053 