### PR TITLE
Add `cupy.median`

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -674,6 +674,7 @@ from cupy.statistics.order import nanmin  # NOQA
 from cupy.statistics.order import percentile  # NOQA
 from cupy.statistics.order import ptp  # NOQA
 
+from cupy.statistics.meanvar import median  # NOQA
 from cupy.statistics.meanvar import average  # NOQA
 from cupy.statistics.meanvar import mean  # NOQA
 from cupy.statistics.meanvar import std  # NOQA

--- a/cupy/core/_routines_statistics.pxd
+++ b/cupy/core/_routines_statistics.pxd
@@ -13,6 +13,8 @@ cdef ndarray _ndarray_mean(ndarray self, axis, dtype, out, keepdims)
 cdef ndarray _ndarray_var(ndarray self, axis, dtype, out, ddof, keepdims)
 cdef ndarray _ndarray_std(ndarray self, axis, dtype, out, ddof, keepdims)
 
+cpdef ndarray _median(ndarray a, axis, out, overwrite_input, keepdims)
+
 cpdef ndarray _nanmean(ndarray a, axis, dtype, out, keepdims)
 cpdef ndarray _nanvar(ndarray a, axis, dtype, out, ddof, keepdims)
 cpdef ndarray _nanstd(ndarray a, axis, dtype, out, ddof, keepdims)

--- a/cupy/core/_routines_statistics.pyx
+++ b/cupy/core/_routines_statistics.pyx
@@ -341,7 +341,7 @@ cpdef ndarray _median(
         part.partition(kth, axis=axis)
 
     if part.shape == ():
-        return part.item()
+        return part
     if axis is None:
         axis = 0
 

--- a/cupy/core/_routines_statistics.pyx
+++ b/cupy/core/_routines_statistics.pyx
@@ -1,11 +1,22 @@
+import string
+
 import numpy
 from numpy import nan
 
 from cupy.core._reduction import create_reduction_func
 from cupy.core._reduction import ReductionKernel
+from cupy.core._scalar import get_typename as _get_typename
+from cupy import util
+
+try:
+    from cupy.cuda import thrust
+except ImportError:
+    pass
 
 from cupy.core cimport _routines_math as _math
+from cupy.core cimport _routines_manipulation as _manipulation
 from cupy.core cimport _routines_sorting as _sorting
+from cupy.core.core cimport compile_with_cache
 from cupy.core.core cimport ndarray
 
 import cupy
@@ -311,55 +322,282 @@ cdef _nanargmax_func = create_reduction_func(
     None, _min_max_preamble)
 
 
+@util.memoize(for_each_device=True)
+def _median_partition_kernel(dtype):
+    name = 'median_partition_kernel'
+    dtype = _get_typename(dtype)
+    source = string.Template('''
+    template<typename T>
+    __device__ void bitonic_sort_step(CArray<T, 1> a,
+            ptrdiff_t x, ptrdiff_t y, int i, ptrdiff_t s, ptrdiff_t w) {
+        for (ptrdiff_t j = i; j < (y - x) / 2; j += 32) {
+            ptrdiff_t n = j + (j & -w);
+            T v = a[n + x], u = a[n + w + x];
+            if (n & s ? v < u : v > u) {
+                a[n + x] = u;
+                a[n + w + x] = v;
+            }
+        }
+    }
+
+    // Sort a[x:y].
+    template<typename T>
+    __device__ void bitonic_sort(
+            CArray<T, 1> a, ptrdiff_t x, ptrdiff_t y, int i) {
+        for (ptrdiff_t s = 2; s <= y - x; s *= 2) {
+            for (ptrdiff_t w = s / 2; w >= 1; w /= 2) {
+                bitonic_sort_step<T>(a, x, y, i, s, w);
+            }
+        }
+    }
+
+    // Merge first k elements and the next 32 times t elements.
+    template<typename T>
+    __device__ void merge(
+            CArray<T, 1> a, int k, int i, ptrdiff_t x, ptrdiff_t z, int u) {
+        for (int s = i; s < u; s += 32) {
+            if (a[x + k - s - 1] > a[z + s]) {
+                T tmp = a[x + k - s - 1];
+                a[x + k - s - 1] = a[z + s];
+                a[z + s] = tmp;
+            }
+        }
+
+        // After merge step, the first k elements are already bitonic.
+        // Therefore, we do not need to fully sort.
+        for (int w = k / 2; w >= 1; w /= 2) {
+            bitonic_sort_step<T>(a, x, k + x, i, k, w);
+        }
+    }
+
+    extern "C" {
+    // In this function, 32 threads handle one subarray. This number equals to
+    // the warp size. The first k elements are always sorted and the next 32
+    // times t elements stored values that have possibilities to be selected.
+    __global__ void ${name}(
+            CArray<${dtype}, 1> a, CArray<${dtype}, 1> out,
+            int k, ptrdiff_t n, int t, ptrdiff_t sz, ptrdiff_t len) {
+
+        // This thread handles a[z:m].
+        ptrdiff_t i = static_cast<ptrdiff_t>(blockIdx.x) * blockDim.x
+            + threadIdx.x;
+        ptrdiff_t z = i / 32 * len;
+        ptrdiff_t m = (i / 32 + 1) * len;
+        int id = i % 32;
+        int x = 0;
+
+        bitonic_sort<${dtype}>(a, z, k + z, id);
+        ptrdiff_t j;
+        for (j = k + id + z; j < m - (m - z) % 32; j += 32) {
+            if (a[j] < a[k - 1 + z]) {
+                ${dtype} tmp = a[k + 32 * x + id + z];
+                a[k + 32 * x + id + z] = a[j];
+                a[j] = tmp;
+                ++x;
+            }
+
+            // If at least one thread in the warp has found t values that
+            // can be selected, we update the first k elements.
+    #if __CUDACC_VER_MAJOR__ >= 9
+            if (__any_sync(0xffffffff, x >= t)) {
+    #else
+            if (__any(x >= t)) {
+    #endif
+                bitonic_sort<${dtype}>(a, k + z, 32 * t + k + z, id);
+                merge<${dtype}>(a, k, id, z, k + z, min(k, 32 * t));
+                x = 0;
+            }
+        }
+        if (j < m && a[j] < a[k - 1 + z]) {
+            ${dtype} tmp = a[k + 32 * x + id + z];
+            a[k + 32 * x + id + z] = a[j];
+            a[j] = tmp;
+        }
+
+        // Finally, we merge the first k elements and the remainders to be
+        // stored.
+        bitonic_sort<${dtype}>(a, k + z, 32 * t + k + z, id);
+        merge<${dtype}>(a, k, id, z, k + z, min(k, 32 * t));
+
+        int kth = len / 2;
+        if (len % 2)
+            out[i / 32] = a[z + kth];
+        else
+            out[i / 32] = (a[z + kth - 1] + a[z + kth]) / 2;
+    }
+    }
+    ''').substitute(name=name, dtype=dtype)
+    module = compile_with_cache(source)
+    return module.get_function(name)
+
+
+cdef _median_partition_core(ndarray data, max_k, ndarray out, int axis):
+
+    if data.dtype.kind == 'c':
+        raise NotImplementedError('Sorting arrays with dtype \'{}\' is '
+                                  'not supported'.format(data.dtype))
+
+    cdef int ndim = data._shape.size()
+    cdef Py_ssize_t length, s, sz, t
+
+    if not data._c_contiguous:
+        raise NotImplementedError('Sorting non-contiguous array is not '
+                                  'supported.')
+
+    # if out.size != self.size // self.shape[axis]:
+    #     raise ValueError('Out size is mismatched')
+
+    if axis < 0:
+        axis += ndim
+    if not (0 <= axis < ndim):
+        raise numpy.AxisError('Axis out of range')
+
+    if axis != ndim - 1:
+        data = _manipulation.rollaxis(data, axis, ndim).copy()
+
+    length = data._shape[ndim-1]
+
+    # For simplicity, max_k is round up to the power of 2. If max_k is
+    # already the power of 2, it is round up to the next power of 2 because
+    # we need to collect the first max(kth)+1 elements.
+    max_k = max(32, 1 << max_k.bit_length())
+
+    # The parameter t is the length of the list that stores elements to be
+    # selected for each thread. We divide the array into sz subarrays.
+    # These parameters are determined from the measurement on TITAN X.
+    t = 4
+    sz = 1
+    while sz > 0 and length // sz < max_k + 32 * t:
+        sz //= 2
+    sz *= data.size // length
+
+    # If the array size is small or k is large, we simply sort the array.
+    if length < 32 or sz < 1 or max_k >= 1024:
+        # kth is ignored.
+        data.sort(axis=-1)
+
+        indexer = [slice(None)] * ndim
+
+        index = length // 2
+        if length % 2 == 1:
+            indexer[ndim-1] = slice(index, index+1)
+        else:
+            indexer[ndim-1] = slice(index-1, index+1)
+        indexer = tuple(indexer)
+
+        out = _mean(
+            data[indexer], axis=-1, dtype=None, out=None, keepdims=False)
+
+    else:
+        shape = data.shape
+        data = data.ravel()
+
+        # For each subarray, we collect first k elements to the head.
+        kern = _median_partition_kernel(data.dtype)
+        block_size = 32
+        grid_size = sz
+        kern(grid=(grid_size,), block=(block_size,), args=(
+            data, out, max_k, data.size, t, sz, length))
+
+    return out
+
+
 cpdef ndarray _median(
         ndarray a, axis, out, overwrite_input, keepdims):
 
     if not isinstance(a, ndarray):
         raise TypeError('Array is not cupy.ndarray')
 
-    keep_ndim = a.ndim
+    keep_shape = a.shape
 
-    if axis is None:
-        sz = a.size
-    else:
-        sz = a.shape[axis]
-    if sz % 2 == 0:
-        szh = sz // 2
-        kth = [szh - 1, szh]
-    else:
-        kth = [(sz - 1) // 2]
+    if a.ndim == 0:
+        return a
 
     if overwrite_input:
-        part = a
+        data = a
     else:
-        part = a.copy()
+        data = a.copy()
 
     if axis is None:
-        part = part.ravel()
-        part.partition(kth)
+        sz = data.size
+        data = data.ravel()
+        axis = -1
+        if keepdims:
+            out_shape = tuple([1, ] * len(keep_shape))
+        else:
+            out_shape = ()
     else:
-        part.partition(kth, axis=axis)
+        sz = data.shape[axis]
+        out_shape = data.shape
+        if keepdims:
+            out_shape = out_shape[:axis] + (1,) + out_shape[axis+1:]
+        else:
+            out_shape = out_shape[:axis] + () + out_shape[axis+1:]
 
-    if part.shape == ():
-        return part
-    if axis is None:
-        axis = 0
+    if out is None:
+        out = cupy.empty(out_shape, dtype=data.dtype)
+    elif out.shape != out_shape:
+        raise ValueError('Out shape is mismatched')
 
-    indexer = [slice(None)] * part.ndim
-
-    if keepdims:
-        _indexer = [None] * (keep_ndim - part.ndim)
-        indexer.extend(_indexer)
-
-    index = part.shape[axis] // 2
-    if part.shape[axis] % 2 == 1:
-        indexer[axis] = slice(index, index+1)
+    if sz % 2 == 0:
+        szh = sz // 2
+        max_k = szh
     else:
-        indexer[axis] = slice(index-1, index+1)
-    indexer = tuple(indexer)
+        max_k = (sz - 1) // 2
 
-    return _mean(
-        part[indexer], axis=axis, dtype=None, out=out, keepdims=keepdims)
+    out = out.ravel()
+    out = _median_partition_core(data, max_k, out, axis=axis)
+
+    out = out.reshape(out_shape)
+
+    return out
+
+    # if not isinstance(a, ndarray):
+    #     raise TypeError('Array is not cupy.ndarray')
+
+    # keep_ndim = a.ndim
+
+    # if axis is None:
+    #     sz = a.size
+    # else:
+    #     sz = a.shape[axis]
+    # if sz % 2 == 0:
+    #     szh = sz // 2
+    #     kth = [szh - 1, szh]
+    # else:
+    #     kth = [(sz - 1) // 2]
+
+    # if overwrite_input:
+    #     part = a
+    # else:
+    #     part = a.copy()
+
+    # if axis is None:
+    #     part = part.ravel()
+    #     part.partition(kth)
+    # else:
+    #     part.partition(kth, axis=axis)
+
+    # if part.shape == ():
+    #     return part
+    # if axis is None:
+    #     axis = 0
+
+    # indexer = [slice(None)] * part.ndim
+
+    # if keepdims:
+    #     _indexer = [None] * (keep_ndim - part.ndim)
+    #     indexer.extend(_indexer)
+
+    # index = part.shape[axis] // 2
+    # if part.shape[axis] % 2 == 1:
+    #     indexer[axis] = slice(index, index+1)
+    # else:
+    #     indexer[axis] = slice(index-1, index+1)
+    # indexer = tuple(indexer)
+
+    # return _mean(
+    #     part[indexer], axis=axis, dtype=None, out=out, keepdims=keepdims)
 
 
 cdef ndarray _mean(

--- a/cupy/core/_routines_statistics.pyx
+++ b/cupy/core/_routines_statistics.pyx
@@ -444,9 +444,6 @@ cdef _median_partition_core(ndarray data, max_k, ndarray out, int axis):
         raise NotImplementedError('Sorting non-contiguous array is not '
                                   'supported.')
 
-    # if out.size != self.size // self.shape[axis]:
-    #     raise ValueError('Out size is mismatched')
-
     if axis < 0:
         axis += ndim
     if not (0 <= axis < ndim):
@@ -551,53 +548,6 @@ cpdef ndarray _median(
     out = out.reshape(out_shape)
 
     return out
-
-    # if not isinstance(a, ndarray):
-    #     raise TypeError('Array is not cupy.ndarray')
-
-    # keep_ndim = a.ndim
-
-    # if axis is None:
-    #     sz = a.size
-    # else:
-    #     sz = a.shape[axis]
-    # if sz % 2 == 0:
-    #     szh = sz // 2
-    #     kth = [szh - 1, szh]
-    # else:
-    #     kth = [(sz - 1) // 2]
-
-    # if overwrite_input:
-    #     part = a
-    # else:
-    #     part = a.copy()
-
-    # if axis is None:
-    #     part = part.ravel()
-    #     part.partition(kth)
-    # else:
-    #     part.partition(kth, axis=axis)
-
-    # if part.shape == ():
-    #     return part
-    # if axis is None:
-    #     axis = 0
-
-    # indexer = [slice(None)] * part.ndim
-
-    # if keepdims:
-    #     _indexer = [None] * (keep_ndim - part.ndim)
-    #     indexer.extend(_indexer)
-
-    # index = part.shape[axis] // 2
-    # if part.shape[axis] % 2 == 1:
-    #     indexer[axis] = slice(index, index+1)
-    # else:
-    #     indexer[axis] = slice(index-1, index+1)
-    # indexer = tuple(indexer)
-
-    # return _mean(
-    #     part[indexer], axis=axis, dtype=None, out=out, keepdims=keepdims)
 
 
 cdef ndarray _mean(

--- a/cupy/statistics/meanvar.py
+++ b/cupy/statistics/meanvar.py
@@ -5,7 +5,33 @@ import cupy
 from cupy.core import _routines_statistics as _statistics
 
 
-# TODO(okuta): Implement median
+def median(a, axis=None, out=None, overwrite_input=False, keepdims=False):
+    """Compute the median along the specified axis.
+
+    Returns the median of the array elements.
+
+    Args:
+        a (cupy.ndarray): Array to compute the median.
+        axis (int): Axis along which the medians are computed. The flattened
+            array is used by default.
+        out (cupy.ndarray): Output array.
+        overwrite_input (bool): If ``True``, then allow use of memory of input
+            array a for calculations. The input array will be modified by the
+            call to median. This will save memory when you do not need to
+            preserve the contents of the input array. Treat the input as
+            undefined, but it will probably be fully or partially sorted.
+            Default is ``False``. If ``overwrite_input`` is ``True`` and ``a``
+            is not already an ndarray, an error will be raised.
+        keepdims (bool): If ``True``, the axis is remained as an axis of size
+            one.
+
+    Returns:
+        cupy.ndarray: The median of ``a``, along the axis if specified.
+
+    .. seealso:: :func:`numpy.median`
+
+    """
+    return _statistics._median(a, axis, out, overwrite_input, keepdims)
 
 
 def average(a, axis=None, weights=None, returned=False):

--- a/tests/cupy_tests/statics_tests/test_meanvar.py
+++ b/tests/cupy_tests/statics_tests/test_meanvar.py
@@ -11,6 +11,46 @@ ignore_runtime_warnings = pytest.mark.filterwarnings(
 
 
 @testing.gpu
+class TestMedian(unittest.TestCase):
+
+    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
+    @testing.numpy_cupy_allclose()
+    def test_median_noaxis(self, xp, dtype):
+        a = testing.shaped_random((3, 4, 5), xp, dtype)
+        return xp.median(a)
+
+    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
+    @testing.numpy_cupy_allclose()
+    def test_median_axis1(self, xp, dtype):
+        a = testing.shaped_random((3, 4, 5), xp, dtype)
+        return xp.median(a, axis=1)
+
+    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
+    @testing.numpy_cupy_allclose()
+    def test_median_axis2(self, xp, dtype):
+        a = testing.shaped_random((3, 4, 5), xp, dtype)
+        return xp.median(a, axis=2)
+
+    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
+    @testing.numpy_cupy_allclose()
+    def test_median_overwrite_input(self, xp, dtype):
+        a = testing.shaped_random((3, 4, 5), xp, dtype)
+        return xp.median(a, overwrite_input=True)
+
+    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
+    @testing.numpy_cupy_allclose()
+    def test_median_keepdims_axis1(self, xp, dtype):
+        a = testing.shaped_random((3, 4, 5), xp, dtype)
+        return xp.median(a, axis=1, keepdims=True)
+
+    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
+    @testing.numpy_cupy_allclose()
+    def test_median_keepdims_noaxis(self, xp, dtype):
+        a = testing.shaped_random((3, 4, 5), xp, dtype)
+        return xp.median(a, keepdims=True)
+
+
+@testing.gpu
 class TestAverage(unittest.TestCase):
 
     _multiprocess_can_split_ = True


### PR DESCRIPTION
For the issue #2305

The implementation still lacks the functionality to calculate median for `float16`, `bool` and `complex` dtypes.

- `float16` and `bool` because of `thrust.sort`.
- `complex` because of `cupy.partition`.