### PR TITLE
Add `cupy.cuda.ExternalStream`

### DIFF
--- a/cupy/cuda/__init__.py
+++ b/cupy/cuda/__init__.py
@@ -98,6 +98,7 @@ from cupy.cuda.stream import Event  # NOQA
 from cupy.cuda.stream import get_current_stream  # NOQA
 from cupy.cuda.stream import get_elapsed_time  # NOQA
 from cupy.cuda.stream import Stream  # NOQA
+from cupy.cuda.stream import ExternalStream  # NOQA
 
 
 @contextlib.contextmanager

--- a/docs/source/reference/cuda.rst
+++ b/docs/source/reference/cuda.rst
@@ -53,6 +53,7 @@ Streams and events
    :nosignatures:
 
    cupy.cuda.Stream
+   cupy.cuda.ExternalStream
    cupy.cuda.get_current_stream
    cupy.cuda.Event
    cupy.cuda.get_elapsed_time

--- a/tests/cupy_tests/cuda_tests/test_stream.py
+++ b/tests/cupy_tests/cuda_tests/test_stream.py
@@ -65,3 +65,29 @@ class TestStream(unittest.TestCase):
         self.assertEqual(stream1, cuda.get_current_stream())
         cuda.Stream.null.use()
         self.assertEqual(cuda.Stream.null, cuda.get_current_stream())
+
+
+class TestExternalStream(unittest.TestCase):
+
+    def setUp(self):
+        self.stream_ptr = cuda.runtime.streamCreate()
+        self.stream = cuda.ExternalStream(self.stream_ptr)
+
+    def tearDown(self):
+        cuda.runtime.streamDestroy(self.stream_ptr)
+
+    @attr.gpu
+    def test_get_and_add_callback(self):
+        N = 100
+        cupy_arrays = [testing.shaped_random((2, 3)) for _ in range(N)]
+
+        stream = self.stream
+        out = []
+        for i in range(N):
+            numpy_array = cupy_arrays[i].get(stream=stream)
+            stream.add_callback(
+                lambda _, __, t: out.append(t[0]),
+                (i, numpy_array))
+
+        stream.synchronize()
+        self.assertEqual(out, list(range(N)))


### PR DESCRIPTION
Related to #3126 and https://github.com/pytorch/pytorch/pull/33860

This allows using external streams in CuPy by creating a `ExternalStream` object from a given `cudaStream_t` pointer.

The main use-case for this is to allow interface cupy with other frameworks such as numba or PyTorch. In PyTorch the streams are managed in a pool so although we can trick and reassign the`.ptr` attribute of a CuPy stream to use a Torch managed stream, the RAII interface can delete this stream thus making this approach not safe.

The approach is similar to `cupy.cuda.BaseMemory` and `cupy.cuda.Memory`

TODO: add more tests

cc @leofang 