### PR TITLE
Fix CUB-based `cupy.prod` for half precision

### DIFF
--- a/cupy/cuda/cupy_cub.cu
+++ b/cupy/cuda/cupy_cub.cu
@@ -469,8 +469,10 @@ struct _cub_reduce_prod {
         int num_items, cudaStream_t s)
     {
         _multiply product_op;
+        // the init value is cast from 1.0f because on host __half can only be
+        // initialized by float or double; static_cast<__half>(1) = 0 on host.
         DeviceReduce::Reduce(workspace, workspace_size, static_cast<T*>(x),
-            static_cast<T*>(y), num_items, product_op, 1.0, s);
+            static_cast<T*>(y), num_items, product_op, static_cast<T>(1.0f), s);
     }
 };
 
@@ -480,11 +482,13 @@ struct _cub_segmented_reduce_prod {
         int num_segments, void* offset_start, void* offset_end, cudaStream_t s)
     {
         _multiply product_op;
+        // the init value is cast from 1.0f because on host __half can only be
+        // initialized by float or double; static_cast<__half>(1) = 0 on host.
         DeviceSegmentedReduce::Reduce(workspace, workspace_size,
             static_cast<T*>(x), static_cast<T*>(y), num_segments,
             static_cast<int*>(offset_start),
             static_cast<int*>(offset_end),
-            product_op, 1.0, s);
+            product_op, static_cast<T>(1.0f), s);
     }
 };
 

--- a/cupy/cuda/cupy_cub.cu
+++ b/cupy/cuda/cupy_cub.cu
@@ -469,8 +469,21 @@ struct _cub_reduce_prod {
         int num_items, cudaStream_t s)
     {
         _multiply product_op;
+        T init;
+
+        #if (__CUDACC_VER_MAJOR__ > 9 || (__CUDACC_VER_MAJOR__ == 9 && __CUDACC_VER_MINOR__ == 2)) \
+            && (!defined(__CUDA_ARCH__))  // support half & on host
+        if (Equals<T, __half>::VALUE) {  //Equals defined in cub/util_type.cuh
+            init = static_cast<T>(1.0f);
+        } else {
+            init = static_cast<T>(1);
+        }
+        #else  // either no support for half or on device
+        init = static_cast<T>(1);
+        #endif
+
         DeviceReduce::Reduce(workspace, workspace_size, static_cast<T*>(x),
-            static_cast<T*>(y), num_items, product_op, 1.0, s);
+            static_cast<T*>(y), num_items, product_op, init, s);
     }
 };
 
@@ -480,11 +493,24 @@ struct _cub_segmented_reduce_prod {
         int num_segments, void* offset_start, void* offset_end, cudaStream_t s)
     {
         _multiply product_op;
+        T init;
+
+        #if (__CUDACC_VER_MAJOR__ > 9 || (__CUDACC_VER_MAJOR__ == 9 && __CUDACC_VER_MINOR__ == 2)) \
+            && (!defined(__CUDA_ARCH__))  // support half & on host
+        if (Equals<T, __half>::VALUE) {  //Equals defined in cub/util_type.cuh
+            init = static_cast<T>(1.0f);
+        } else {
+            init = static_cast<T>(1);
+        }
+        #else  // either no support for half or on device
+        init = static_cast<T>(1);
+        #endif
+
         DeviceSegmentedReduce::Reduce(workspace, workspace_size,
             static_cast<T*>(x), static_cast<T*>(y), num_segments,
             static_cast<int*>(offset_start),
             static_cast<int*>(offset_end),
-            product_op, 1.0, s);
+            product_op, init, s);
     }
 };
 

--- a/cupy/cuda/cupy_cub.cu
+++ b/cupy/cuda/cupy_cub.cu
@@ -469,21 +469,8 @@ struct _cub_reduce_prod {
         int num_items, cudaStream_t s)
     {
         _multiply product_op;
-        T init;
-
-        #if (__CUDACC_VER_MAJOR__ > 9 || (__CUDACC_VER_MAJOR__ == 9 && __CUDACC_VER_MINOR__ == 2)) \
-            && (!defined(__CUDA_ARCH__))  // support half & on host
-        if (Equals<T, __half>::VALUE) {  //Equals defined in cub/util_type.cuh
-            init = static_cast<T>(1.0f);
-        } else {
-            init = static_cast<T>(1);
-        }
-        #else  // either no support for half or on device
-        init = static_cast<T>(1);
-        #endif
-
         DeviceReduce::Reduce(workspace, workspace_size, static_cast<T*>(x),
-            static_cast<T*>(y), num_items, product_op, init, s);
+            static_cast<T*>(y), num_items, product_op, 1.0, s);
     }
 };
 
@@ -493,24 +480,11 @@ struct _cub_segmented_reduce_prod {
         int num_segments, void* offset_start, void* offset_end, cudaStream_t s)
     {
         _multiply product_op;
-        T init;
-
-        #if (__CUDACC_VER_MAJOR__ > 9 || (__CUDACC_VER_MAJOR__ == 9 && __CUDACC_VER_MINOR__ == 2)) \
-            && (!defined(__CUDA_ARCH__))  // support half & on host
-        if (Equals<T, __half>::VALUE) {  //Equals defined in cub/util_type.cuh
-            init = static_cast<T>(1.0f);
-        } else {
-            init = static_cast<T>(1);
-        }
-        #else  // either no support for half or on device
-        init = static_cast<T>(1);
-        #endif
-
         DeviceSegmentedReduce::Reduce(workspace, workspace_size,
             static_cast<T*>(x), static_cast<T*>(y), num_segments,
             static_cast<int*>(offset_start),
             static_cast<int*>(offset_end),
-            product_op, init, s);
+            product_op, 1.0, s);
     }
 };
 

--- a/cupy/cuda/cupy_cub.cu
+++ b/cupy/cuda/cupy_cub.cu
@@ -470,7 +470,7 @@ struct _cub_reduce_prod {
     {
         _multiply product_op;
         DeviceReduce::Reduce(workspace, workspace_size, static_cast<T*>(x),
-            static_cast<T*>(y), num_items, product_op, static_cast<T>(1), s);
+            static_cast<T*>(y), num_items, product_op, 1.0, s);
     }
 };
 
@@ -484,7 +484,7 @@ struct _cub_segmented_reduce_prod {
             static_cast<T*>(x), static_cast<T*>(y), num_segments,
             static_cast<int*>(offset_start),
             static_cast<int*>(offset_end),
-            product_op, static_cast<T>(1), s);
+            product_op, 1.0, s);
     }
 };
 


### PR DESCRIPTION
Follow-up of #3067, in which I made yet another CUB bug 😞 Fortunately the tests in #2598 were able to catch it...

For reduction operations we need a start point, and for `prod` it's 1. On the device, `static_cast<__half>(1)` gives 1 in half precision as expected, but on the host it gives 0 (mdfk!) A correct behavior on host is important for CUB, because it doesn't directly launch a device kernel.

The reason is, quite annoyingly, that a conversion constructor is only available for device functions:
https://github.com/cupy/cupy/blob/106943a0006d27a2c4c164c4799bafcba1428160/cupy/core/include/cupy/_cuda/cuda-10.0/cuda_fp16.hpp#L184
and I have no idea where the zero comes from for host functions...Likely it just returns an uninitialized value?

The current workaround here is quite brute-force: we rely on the fact that a floating-point literal can be converted to other types and precisions correctly. (We might want a better solution here, preferably making an exception only for `__half`. But it's midnight here and I'm basically shutdown...😴 @emcastillo Any suggestion?)

 

