### PR TITLE
`__bytes__` for `cupy.ndarray`

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -144,6 +144,9 @@ cdef class ndarray:
         self._set_contiguous_strides(itemsize, c_order)
         self.data = memory.alloc(self.size * itemsize)
 
+    def __bytes__(self):
+        return self.tobytes()
+
     @property
     def __cuda_array_interface__(self):
         desc = {

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -144,9 +144,6 @@ cdef class ndarray:
         self._set_contiguous_strides(itemsize, c_order)
         self.data = memory.alloc(self.size * itemsize)
 
-    def __bytes__(self):
-        return self.tobytes()
-
     @property
     def __cuda_array_interface__(self):
         desc = {
@@ -1385,6 +1382,9 @@ cdef class ndarray:
 
     def __hex__(self):
         return hex(self.get())
+
+    def __bytes__(self):
+        return self.tobytes()
 
     # String representations:
 

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1384,7 +1384,7 @@ cdef class ndarray:
         return hex(self.get())
 
     def __bytes__(self):
-        return self.tobytes()
+        return bytes(self.get())
 
     # String representations:
 

--- a/tests/cupy_tests/core_tests/test_ndarray.py
+++ b/tests/cupy_tests/core_tests/test_ndarray.py
@@ -466,3 +466,11 @@ class TestSize(unittest.TestCase):
     def test_size_zero_dim_array_with_axis(self, xp):
         x = testing.shaped_arange((), xp, numpy.int32)
         return xp.size(x, 0)
+
+
+@testing.gpu
+class TestPythonInterface(unittest.TestCase):
+
+    def test_bytes_tobytes(self):
+        x = testing.shaped_arange((3, 4, 5))
+        assert x.tobytes() == bytes(x)

--- a/tests/cupy_tests/core_tests/test_ndarray.py
+++ b/tests/cupy_tests/core_tests/test_ndarray.py
@@ -492,5 +492,5 @@ class TestPythonInterface(unittest.TestCase):
     @testing.for_all_dtypes()
     @testing.numpy_cupy_equal()
     def test_bytes_tobytes_scalar(self, xp, dtype):
-        x = xp.asscalar(xp.array([3], dtype))
+        x = xp.array([3], dtype).item()
         return bytes(x)

--- a/tests/cupy_tests/core_tests/test_ndarray.py
+++ b/tests/cupy_tests/core_tests/test_ndarray.py
@@ -471,6 +471,20 @@ class TestSize(unittest.TestCase):
 @testing.gpu
 class TestPythonInterface(unittest.TestCase):
 
-    def test_bytes_tobytes(self):
-        x = testing.shaped_arange((3, 4, 5))
-        assert x.tobytes() == bytes(x)
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_equal()
+    def test_bytes_tobytes(self, xp, dtype):
+        x = testing.shaped_arange((3, 4, 5), xp, dtype)
+        return bytes(x)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_equal()
+    def test_bytes_tobytes_empty(self, xp, dtype):
+        x = xp.empty((3, 4, 5), dtype)
+        return bytes(x)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_equal()
+    def test_bytes_tobytes_scalar(self, xp, dtype):
+        x = xp.asscalar(xp.array([3], dtype))
+        return bytes(x)

--- a/tests/cupy_tests/core_tests/test_ndarray.py
+++ b/tests/cupy_tests/core_tests/test_ndarray.py
@@ -485,6 +485,12 @@ class TestPythonInterface(unittest.TestCase):
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_equal()
+    def test_bytes_tobytes_empty2(self, xp, dtype):
+        x = xp.empty((), dtype)
+        return bytes(x)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_equal()
     def test_bytes_tobytes_scalar(self, xp, dtype):
         x = xp.asscalar(xp.array([3], dtype))
         return bytes(x)


### PR DESCRIPTION
Initial PR for `__bytes__` for `cupy.ndarray`

Resolves #3007 