### PR TITLE
Fix error type and message in `coo_matrix`

### DIFF
--- a/cupyx/scipy/sparse/coo.py
+++ b/cupyx/scipy/sparse/coo.py
@@ -103,8 +103,7 @@ class coo_matrix(sparse_data._data_matrix):
             has_canonical_format = False
 
         else:
-            raise ValueError(
-                'Only (data, (row, col)) format is supported')
+            raise TypeError('invalid input format')
 
         if dtype is None:
             dtype = data.dtype


### PR DESCRIPTION
Current error message is outdated.
The type and the message in this PR is aligned with numpy.