### PR TITLE
Support cusparse<t>csrgeam2 and cusparse<t>csrgemm2

### DIFF
--- a/cupy/cuda/cupy_cusparse.h
+++ b/cupy/cuda/cupy_cusparse.h
@@ -195,6 +195,7 @@ typedef void* csric02Info_t;
 typedef void* bsric02Info_t;
 typedef void* csrilu02Info_t;
 typedef void* bsrilu02Info_t;
+typedef void* csrgemm2Info_t;
 
 typedef enum {} cusparseMatrixType_t;
 typedef enum {} cusparseOperation_t;

--- a/cupy/cuda/cupy_cusparse.h
+++ b/cupy/cuda/cupy_cusparse.h
@@ -107,7 +107,7 @@ cusparseStatus_t cusparseZgtsv2StridedBatch(...) {
 }
 #endif // #if CUDA_VERSION < 9000
 
-#if CUDA_VERSION < 9200
+#if CUDA_VERSION < 9020
 // Functions added in CUDA 9.2
 cusparseStatus_t cusparseSgtsvInterleavedBatch_bufferSizeExt(...) {
   return CUSPARSE_STATUS_SUCCESS;
@@ -172,7 +172,44 @@ cusparseStatus_t cusparseCgpsvInterleavedBatch(...) {
 cusparseStatus_t cusparseZgpsvInterleavedBatch(...) {
   return CUSPARSE_STATUS_SUCCESS;
 }
-#endif // #if CUDA_VERSION < 9200
+
+cusparseStatus_t cusparseScsrgeam2_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDcsrgeam2_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseCcsrgeam2_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseZcsrgeam2_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseXcsrgeam2Nnz(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseScsrgeam2(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDcsrgeam2(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseCcsrgeam2(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseZcsrgeam2(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+#endif // #if CUDA_VERSION < 9020
 
 #else  // #if !defined(CUPY_NO_CUDA) && !defined(CUPY_USE_HIP)
 

--- a/cupy/cuda/cupy_cusparse.h
+++ b/cupy/cuda/cupy_cusparse.h
@@ -344,6 +344,41 @@ cusparseStatus_t cusparseZcsrgeam(...) {
   return CUSPARSE_STATUS_SUCCESS;
 }
 
+cusparseStatus_t cusparseScsrgeam2_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDcsrgeam2_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseCcsrgeam2_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseZcsrgeam2_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseXcsrgeam2Nnz(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseScsrgeam2(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDcsrgeam2(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseCcsrgeam2(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseZcsrgeam2(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
 
 cusparseStatus_t cusparseXcsrgemmNnz(...) {
   return CUSPARSE_STATUS_SUCCESS;
@@ -362,6 +397,50 @@ cusparseStatus_t cusparseCcsrgemm(...) {
 }
 
 cusparseStatus_t cusparseZcsrgemm(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseCreateCsrgemm2Info(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDestroyCsrgemm2Info(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseScsrgemm2_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDcsrgemm2_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseCcsrgemm2_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseZcsrgemm2_bufferSizeExt(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseXcsrgemm2Nnz(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseScsrgemm2(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDcsrgemm2(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseCcsrgemm2(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseZcsrgemm2(...) {
   return CUSPARSE_STATUS_SUCCESS;
 }
 

--- a/cupy/cuda/cusparse.pxd
+++ b/cupy/cuda/cusparse.pxd
@@ -26,6 +26,7 @@ cdef extern from *:
     ctypedef void* bsric02Info_t
     ctypedef void* csrilu02Info_t
     ctypedef void* bsrilu02Info_t
+    ctypedef void* csrgemm2Info_t
 
     ctypedef int cusparseStatus_t
     ctypedef int cusparseDirection_t

--- a/cupy/cuda/cusparse.pyx
+++ b/cupy/cuda/cusparse.pyx
@@ -318,87 +318,88 @@ cdef extern from 'cupy_cusparse.h' nogil:
     cusparseStatus_t cusparseDestroyCsrgemm2Info(csrgemm2Info_t info)
 
     Status cusparseScsrgemm2_bufferSizeExt(
-        Handle handle, int m, int n, int k,
-        const float *alpha,
-        const MatDescr descrA, int nnzA, const int *csrRowPtrA, const int *csrColIndA,
-        const MatDescr descrB, int nnzB, const int *csrRowPtrB, const int *csrColIndB,
-        const float *beta,
-        const MatDescr descrD, int nnzD, const int *csrRowPtrD, const int *csrColIndD,
-        const csrgemm2Info_t info, size_t* pBufferSize)
+        Handle handle, int m, int n, int k, const float *alpha,
+        const MatDescr descrA, int nnzA, const int *csrRowPtrA,
+        const int *csrColIndA, const MatDescr descrB, int nnzB,
+        const int *csrRowPtrB, const int *csrColIndB, const float *beta,
+        const MatDescr descrD, int nnzD, const int *csrRowPtrD,
+        const int *csrColIndD, const csrgemm2Info_t info, size_t* pBufferSize)
 
     Status cusparseDcsrgemm2_bufferSizeExt(
-        Handle handle, int m, int n, int k,
-        const double *alpha,
-        const MatDescr descrA, int nnzA, const int *csrRowPtrA, const int *csrColIndA,
-        const MatDescr descrB, int nnzB, const int *csrRowPtrB, const int *csrColIndB,
-        const double *beta,
-        const MatDescr descrD, int nnzD, const int *csrRowPtrD, const int *csrColIndD,
-        const csrgemm2Info_t info, size_t* pBufferSize)
+        Handle handle, int m, int n, int k, const double *alpha,
+        const MatDescr descrA, int nnzA, const int *csrRowPtrA,
+        const int *csrColIndA, const MatDescr descrB, int nnzB,
+        const int *csrRowPtrB, const int *csrColIndB, const double *beta,
+        const MatDescr descrD, int nnzD, const int *csrRowPtrD,
+        const int *csrColIndD, const csrgemm2Info_t info, size_t* pBufferSize)
 
     Status cusparseCcsrgemm2_bufferSizeExt(
-        Handle handle, int m, int n, int k,
-        const cuComplex *alpha,
-        const MatDescr descrA, int nnzA, const int *csrRowPtrA, const int *csrColIndA,
-        const MatDescr descrB, int nnzB, const int *csrRowPtrB, const int *csrColIndB,
-        const cuComplex *beta,
-        const MatDescr descrD, int nnzD, const int *csrRowPtrD, const int *csrColIndD,
-        const csrgemm2Info_t info, size_t* pBufferSize)
+        Handle handle, int m, int n, int k, const cuComplex *alpha,
+        const MatDescr descrA, int nnzA, const int *csrRowPtrA,
+        const int *csrColIndA, const MatDescr descrB, int nnzB,
+        const int *csrRowPtrB, const int *csrColIndB, const cuComplex *beta,
+        const MatDescr descrD, int nnzD, const int *csrRowPtrD,
+        const int *csrColIndD, const csrgemm2Info_t info, size_t* pBufferSize)
 
     Status cusparseZcsrgemm2_bufferSizeExt(
-        Handle handle, int m, int n, int k,
-        const cuDoubleComplex *alpha,
-        const MatDescr descrA, int nnzA, const int *csrRowPtrA, const int *csrColIndA,
-        const MatDescr descrB, int nnzB, const int *csrRowPtrB, const int *csrColIndB,
-        const cuDoubleComplex *beta,
-        const MatDescr descrD, int nnzD, const int *csrRowPtrD, const int *csrColIndD,
+        Handle handle, int m, int n, int k, const cuDoubleComplex *alpha,
+        const MatDescr descrA, int nnzA, const int *csrRowPtrA,
+        const int *csrColIndA, const MatDescr descrB, int nnzB,
+        const int *csrRowPtrB, const int *csrColIndB,
+        const cuDoubleComplex *beta, const MatDescr descrD, int nnzD,
+        const int *csrRowPtrD, const int *csrColIndD,
         const csrgemm2Info_t info, size_t* pBufferSize)
 
     Status cusparseXcsrgemm2Nnz(
-        Handle handle, int m, int n, int k,
-        const MatDescr descrA, int nnzA, const int *csrRowPtrA, const int *csrColIndA,
-        const MatDescr descrB, int nnzB, const int *csrRowPtrB, const int *csrColIndB,
-        const MatDescr descrD, int nnzD, const int *csrRowPtrD, const int *csrColIndD,
-        const MatDescr descrC, int *csrRowPtrC,
+        Handle handle, int m, int n, int k, const MatDescr descrA, int nnzA,
+        const int *csrRowPtrA, const int *csrColIndA, const MatDescr descrB,
+        int nnzB, const int *csrRowPtrB, const int *csrColIndB,
+        const MatDescr descrD, int nnzD, const int *csrRowPtrD,
+        const int *csrColIndD, const MatDescr descrC, int *csrRowPtrC,
         int *nnzTotalDevHostPtr, const csrgemm2Info_t info, void* pBuffer)
 
     Status cusparseScsrgemm2(
-        Handle handle, int m, int n, int k,
-        const float *alpha,
-        const MatDescr descrA, int nnzA, const float *csrValA, const int *csrRowPtrA, const int *csrColIndA,
-        const MatDescr descrB, int nnzB, const float *csrValB, const int *csrRowPtrB, const int *csrColIndB,
-        const float *beta,
-        const MatDescr descrD, int nnzD, const float *csrValD, const int *csrRowPtrD, const int *csrColIndD,
-        const MatDescr descrC,                 float *csrValC, const int *csrRowPtrC,       int *csrColIndC,
-        const csrgemm2Info_t info, void* pBuffer)
+        Handle handle, int m, int n, int k, const float *alpha,
+        const MatDescr descrA, int nnzA, const float *csrValA,
+        const int *csrRowPtrA, const int *csrColIndA, const MatDescr descrB,
+        int nnzB, const float *csrValB, const int *csrRowPtrB,
+        const int *csrColIndB, const float *beta, const MatDescr descrD,
+        int nnzD, const float *csrValD, const int *csrRowPtrD,
+        const int *csrColIndD, const MatDescr descrC, float *csrValC,
+        const int *csrRowPtrC, int *csrColIndC, const csrgemm2Info_t info,
+        void* pBuffer)
 
     Status cusparseDcsrgemm2(
-        Handle handle, int m, int n, int k,
-        const double *alpha,
-        const MatDescr descrA, int nnzA, const double *csrValA, const int *csrRowPtrA, const int *csrColIndA,
-        const MatDescr descrB, int nnzB, const double *csrValB, const int *csrRowPtrB, const int *csrColIndB,
-        const double *beta,
-        const MatDescr descrD, int nnzD, const double *csrValD, const int *csrRowPtrD, const int *csrColIndD,
-        const MatDescr descrC,                 double *csrValC, const int *csrRowPtrC,       int *csrColIndC,
-        const csrgemm2Info_t info, void* pBuffer)
+        Handle handle, int m, int n, int k, const double *alpha,
+        const MatDescr descrA, int nnzA, const double *csrValA,
+        const int *csrRowPtrA, const int *csrColIndA, const MatDescr descrB,
+        int nnzB, const double *csrValB, const int *csrRowPtrB,
+        const int *csrColIndB, const double *beta, const MatDescr descrD,
+        int nnzD, const double *csrValD, const int *csrRowPtrD,
+        const int *csrColIndD, const MatDescr descrC, double *csrValC,
+        const int *csrRowPtrC, int *csrColIndC, const csrgemm2Info_t info,
+        void* pBuffer)
 
     Status cusparseCcsrgemm2(
-        Handle handle, int m, int n, int k,
-        const cuComplex *alpha,
-        const MatDescr descrA, int nnzA, const cuComplex *csrValA, const int *csrRowPtrA, const int *csrColIndA,
-        const MatDescr descrB, int nnzB, const cuComplex *csrValB, const int *csrRowPtrB, const int *csrColIndB,
-        const cuComplex *beta,
-        const MatDescr descrD, int nnzD, const cuComplex *csrValD, const int *csrRowPtrD, const int *csrColIndD,
-        const MatDescr descrC,                 cuComplex *csrValC, const int *csrRowPtrC,       int *csrColIndC,
-        const csrgemm2Info_t info, void* pBuffer)
+        Handle handle, int m, int n, int k, const cuComplex *alpha,
+        const MatDescr descrA, int nnzA, const cuComplex *csrValA,
+        const int *csrRowPtrA, const int *csrColIndA, const MatDescr descrB,
+        int nnzB, const cuComplex *csrValB, const int *csrRowPtrB,
+        const int *csrColIndB, const cuComplex *beta, const MatDescr descrD,
+        int nnzD, const cuComplex *csrValD, const int *csrRowPtrD,
+        const int *csrColIndD, const MatDescr descrC, cuComplex *csrValC,
+        const int *csrRowPtrC, int *csrColIndC, const csrgemm2Info_t info,
+        void* pBuffer)
 
     Status cusparseZcsrgemm2(
-        Handle handle, int m, int n, int k,
-        const cuDoubleComplex *alpha,
-        const MatDescr descrA, int nnzA, const cuDoubleComplex *csrValA, const int *csrRowPtrA, const int *csrColIndA,
-        const MatDescr descrB, int nnzB, const cuDoubleComplex *csrValB, const int *csrRowPtrB, const int *csrColIndB,
-        const cuDoubleComplex *beta,
-        const MatDescr descrD, int nnzD, const cuDoubleComplex *csrValD, const int *csrRowPtrD, const int *csrColIndD,
-        const MatDescr descrC,           cuDoubleComplex *csrValC, const int *csrRowPtrC,       int *csrColIndC,
+        Handle handle, int m, int n, int k, const cuDoubleComplex *alpha,
+        const MatDescr descrA, int nnzA, const cuDoubleComplex *csrValA,
+        const int *csrRowPtrA, const int *csrColIndA, const MatDescr descrB,
+        int nnzB, const cuDoubleComplex *csrValB, const int *csrRowPtrB,
+        const int *csrColIndB, const cuDoubleComplex *beta,
+        const MatDescr descrD, int nnzD, const cuDoubleComplex *csrValD,
+        const int *csrRowPtrD, const int *csrColIndD, const MatDescr descrC,
+        cuDoubleComplex *csrValC, const int *csrRowPtrC, int *csrColIndC,
         const csrgemm2Info_t info, void* pBuffer)
 
     # cuSPARSE Format Convrsion
@@ -1852,87 +1853,79 @@ cpdef xcsrgemm2Nnz(
     check_status(status)
 
 cpdef scsrgemm2(
-        intptr_t handle, int m, int n, int k,
-        size_t alpha,
-        size_t descrA, int nnzA, size_t csrValA, size_t csrRowPtrA, size_t csrColIndA,
-        size_t descrB, int nnzB, size_t csrValB, size_t csrRowPtrB, size_t csrColIndB,
-        size_t beta,
-        size_t descrD, int nnzD, size_t csrValD, size_t csrRowPtrD, size_t csrColIndD,
-        size_t descrC, size_t csrValC, size_t csrRowPtrC, size_t csrColIndC,
-        size_t info, intptr_t pBuffer):
+        intptr_t handle, int m, int n, int k, size_t alpha, size_t descrA,
+        int nnzA, size_t csrValA, size_t csrRowPtrA, size_t csrColIndA,
+        size_t descrB, int nnzB, size_t csrValB, size_t csrRowPtrB,
+        size_t csrColIndB, size_t beta, size_t descrD, int nnzD,
+        size_t csrValD, size_t csrRowPtrD, size_t csrColIndD, size_t descrC,
+        size_t csrValC, size_t csrRowPtrC, size_t csrColIndC, size_t info,
+        intptr_t pBuffer):
     setStream(handle, stream_module.get_current_stream_ptr())
     status = cusparseScsrgemm2(
-        <Handle>handle, m, n, k,
-        <float*>alpha,
-        <MatDescr>descrA, nnzA, <float*>csrValA, <int*>csrRowPtrA, <int*>csrColIndA,
-        <MatDescr>descrB, nnzB, <float*>csrValB, <int*>csrRowPtrB, <int*>csrColIndB,
-        <float*>beta,
-        <MatDescr>descrD, nnzD, <float*>csrValD, <int*>csrRowPtrD, <int*>csrColIndD,
-        <MatDescr>descrC, <float*>csrValC, <int*>csrRowPtrC, <int*>csrColIndC,
-        <csrgemm2Info_t>info, <void*>pBuffer)
+        <Handle>handle, m, n, k, <float*>alpha, <MatDescr>descrA, nnzA,
+        <float*>csrValA, <int*>csrRowPtrA, <int*>csrColIndA, <MatDescr>descrB,
+        nnzB, <float*>csrValB, <int*>csrRowPtrB, <int*>csrColIndB,
+        <float*>beta, <MatDescr>descrD, nnzD, <float*>csrValD,
+        <int*>csrRowPtrD, <int*>csrColIndD, <MatDescr>descrC, <float*>csrValC,
+        <int*>csrRowPtrC, <int*>csrColIndC, <csrgemm2Info_t>info,
+        <void*>pBuffer)
     check_status(status)
 
 cpdef dcsrgemm2(
-        intptr_t handle, int m, int n, int k,
-        size_t alpha,
-        size_t descrA, int nnzA, size_t csrValA, size_t csrRowPtrA, size_t csrColIndA,
-        size_t descrB, int nnzB, size_t csrValB, size_t csrRowPtrB, size_t csrColIndB,
-        size_t beta,
-        size_t descrD, int nnzD, size_t csrValD, size_t csrRowPtrD, size_t csrColIndD,
-        size_t descrC, size_t csrValC, size_t csrRowPtrC, size_t csrColIndC,
-        size_t info, intptr_t pBuffer):
+        intptr_t handle, int m, int n, int k, size_t alpha, size_t descrA,
+        int nnzA, size_t csrValA, size_t csrRowPtrA, size_t csrColIndA,
+        size_t descrB, int nnzB, size_t csrValB, size_t csrRowPtrB,
+        size_t csrColIndB, size_t beta, size_t descrD, int nnzD,
+        size_t csrValD, size_t csrRowPtrD, size_t csrColIndD, size_t descrC,
+        size_t csrValC, size_t csrRowPtrC, size_t csrColIndC, size_t info,
+        intptr_t pBuffer):
     setStream(handle, stream_module.get_current_stream_ptr())
     status = cusparseDcsrgemm2(
-        <Handle>handle, m, n, k,
-        <double*>alpha,
-        <MatDescr>descrA, nnzA, <double*>csrValA, <int*>csrRowPtrA, <int*>csrColIndA,
-        <MatDescr>descrB, nnzB, <double*>csrValB, <int*>csrRowPtrB, <int*>csrColIndB,
-        <double*>beta,
-        <MatDescr>descrD, nnzD, <double*>csrValD, <int*>csrRowPtrD, <int*>csrColIndD,
-        <MatDescr>descrC, <double*>csrValC, <int*>csrRowPtrC, <int*>csrColIndC,
-        <csrgemm2Info_t>info, <void*>pBuffer)
+        <Handle>handle, m, n, k, <double*>alpha, <MatDescr>descrA, nnzA,
+        <double*>csrValA, <int*>csrRowPtrA, <int*>csrColIndA, <MatDescr>descrB,
+        nnzB, <double*>csrValB, <int*>csrRowPtrB, <int*>csrColIndB,
+        <double*>beta, <MatDescr>descrD, nnzD, <double*>csrValD,
+        <int*>csrRowPtrD, <int*>csrColIndD, <MatDescr>descrC, <double*>csrValC,
+        <int*>csrRowPtrC, <int*>csrColIndC, <csrgemm2Info_t>info,
+        <void*>pBuffer)
     check_status(status)
 
 cpdef ccsrgemm2(
-        intptr_t handle, int m, int n, int k,
-        size_t alpha,
-        size_t descrA, int nnzA, size_t csrValA, size_t csrRowPtrA, size_t csrColIndA,
-        size_t descrB, int nnzB, size_t csrValB, size_t csrRowPtrB, size_t csrColIndB,
-        size_t beta,
-        size_t descrD, int nnzD, size_t csrValD, size_t csrRowPtrD, size_t csrColIndD,
-        size_t descrC, size_t csrValC, size_t csrRowPtrC, size_t csrColIndC,
-        size_t info, intptr_t pBuffer):
+        intptr_t handle, int m, int n, int k, size_t alpha, size_t descrA,
+        int nnzA, size_t csrValA, size_t csrRowPtrA, size_t csrColIndA,
+        size_t descrB, int nnzB, size_t csrValB, size_t csrRowPtrB,
+        size_t csrColIndB, size_t beta, size_t descrD, int nnzD,
+        size_t csrValD, size_t csrRowPtrD, size_t csrColIndD, size_t descrC,
+        size_t csrValC, size_t csrRowPtrC, size_t csrColIndC, size_t info,
+        intptr_t pBuffer):
     setStream(handle, stream_module.get_current_stream_ptr())
     status = cusparseCcsrgemm2(
-        <Handle>handle, m, n, k,
-        <cuComplex*>alpha,
-        <MatDescr>descrA, nnzA, <cuComplex*>csrValA, <int*>csrRowPtrA, <int*>csrColIndA,
-        <MatDescr>descrB, nnzB, <cuComplex*>csrValB, <int*>csrRowPtrB, <int*>csrColIndB,
-        <cuComplex*>beta,
-        <MatDescr>descrD, nnzD, <cuComplex*>csrValD, <int*>csrRowPtrD, <int*>csrColIndD,
-        <MatDescr>descrC, <cuComplex*>csrValC, <int*>csrRowPtrC, <int*>csrColIndC,
-        <csrgemm2Info_t>info, <void*>pBuffer)
+        <Handle>handle, m, n, k, <cuComplex*>alpha, <MatDescr>descrA, nnzA,
+        <cuComplex*>csrValA, <int*>csrRowPtrA, <int*>csrColIndA,
+        <MatDescr>descrB, nnzB, <cuComplex*>csrValB, <int*>csrRowPtrB,
+        <int*>csrColIndB, <cuComplex*>beta, <MatDescr>descrD, nnzD,
+        <cuComplex*>csrValD, <int*>csrRowPtrD, <int*>csrColIndD,
+        <MatDescr>descrC, <cuComplex*>csrValC, <int*>csrRowPtrC,
+        <int*>csrColIndC, <csrgemm2Info_t>info, <void*>pBuffer)
     check_status(status)
 
 cpdef zcsrgemm2(
-        intptr_t handle, int m, int n, int k,
-        size_t alpha,
-        size_t descrA, int nnzA, size_t csrValA, size_t csrRowPtrA, size_t csrColIndA,
-        size_t descrB, int nnzB, size_t csrValB, size_t csrRowPtrB, size_t csrColIndB,
-        size_t beta,
-        size_t descrD, int nnzD, size_t csrValD, size_t csrRowPtrD, size_t csrColIndD,
-        size_t descrC, size_t csrValC, size_t csrRowPtrC, size_t csrColIndC,
-        size_t info, intptr_t pBuffer):
+        intptr_t handle, int m, int n, int k, size_t alpha, size_t descrA,
+        int nnzA, size_t csrValA, size_t csrRowPtrA, size_t csrColIndA,
+        size_t descrB, int nnzB, size_t csrValB, size_t csrRowPtrB,
+        size_t csrColIndB, size_t beta, size_t descrD, int nnzD,
+        size_t csrValD, size_t csrRowPtrD, size_t csrColIndD, size_t descrC,
+        size_t csrValC, size_t csrRowPtrC, size_t csrColIndC, size_t info,
+        intptr_t pBuffer):
     setStream(handle, stream_module.get_current_stream_ptr())
     status = cusparseZcsrgemm2(
-        <Handle>handle, m, n, k,
-        <cuDoubleComplex*>alpha,
-        <MatDescr>descrA, nnzA, <cuDoubleComplex*>csrValA, <int*>csrRowPtrA, <int*>csrColIndA,
-        <MatDescr>descrB, nnzB, <cuDoubleComplex*>csrValB, <int*>csrRowPtrB, <int*>csrColIndB,
-        <cuDoubleComplex*>beta,
-        <MatDescr>descrD, nnzD, <cuDoubleComplex*>csrValD, <int*>csrRowPtrD, <int*>csrColIndD,
-        <MatDescr>descrC, <cuDoubleComplex*>csrValC, <int*>csrRowPtrC, <int*>csrColIndC,
-        <csrgemm2Info_t>info, <void*>pBuffer)
+        <Handle>handle, m, n, k, <cuDoubleComplex*>alpha, <MatDescr>descrA,
+        nnzA, <cuDoubleComplex*>csrValA, <int*>csrRowPtrA, <int*>csrColIndA,
+        <MatDescr>descrB, nnzB, <cuDoubleComplex*>csrValB, <int*>csrRowPtrB,
+        <int*>csrColIndB, <cuDoubleComplex*>beta, <MatDescr>descrD, nnzD,
+        <cuDoubleComplex*>csrValD, <int*>csrRowPtrD, <int*>csrColIndD,
+        <MatDescr>descrC, <cuDoubleComplex*>csrValC, <int*>csrRowPtrC,
+        <int*>csrColIndC, <csrgemm2Info_t>info, <void*>pBuffer)
     check_status(status)
 
 ########################################

--- a/cupy/cuda/cusparse.pyx
+++ b/cupy/cuda/cusparse.pyx
@@ -194,6 +194,87 @@ cdef extern from 'cupy_cusparse.h' nogil:
         const int *csrColIndB, const MatDescr descrC,
         cuDoubleComplex *csrValC, int *csrRowPtrC, int *csrColIndC)
 
+    Status cusparseScsrgeam2_bufferSizeExt(
+        Handle handle, int m, int n, const float *alpha, const MatDescr descrA,
+        int nnzA, const float *csrValA, const int *csrRowPtrA,
+        const int *csrColIndA, const float *beta, const MatDescr descrB,
+        int nnzB, const float *csrValB, const int *csrRowPtrB,
+        const int *csrColIndB, const MatDescr descrC, float *csrValC,
+        int *csrRowPtrC, int *csrColIndC, size_t *pBufferSize)
+
+    Status cusparseDcsrgeam2_bufferSizeExt(
+        Handle handle, int m, int n, const double *alpha,
+        const MatDescr descrA,
+        int nnzA, const double *csrValA, const int *csrRowPtrA,
+        const int *csrColIndA, const double *beta, const MatDescr descrB,
+        int nnzB, const double *csrValB, const int *csrRowPtrB,
+        const int *csrColIndB, const MatDescr descrC, double *csrValC,
+        int *csrRowPtrC, int *csrColIndC, size_t *pBufferSize)
+
+    Status cusparseCcsrgeam2_bufferSizeExt(
+        Handle handle, int m, int n, const cuComplex *alpha,
+        const MatDescr descrA,
+        int nnzA, const cuComplex *csrValA, const int *csrRowPtrA,
+        const int *csrColIndA, const cuComplex *beta, const MatDescr descrB,
+        int nnzB, const cuComplex *csrValB, const int *csrRowPtrB,
+        const int *csrColIndB, const MatDescr descrC, cuComplex *csrValC,
+        int *csrRowPtrC, int *csrColIndC, size_t *pBufferSize)
+
+    Status cusparseZcsrgeam2_bufferSizeExt(
+        Handle handle, int m, int n, const cuDoubleComplex *alpha,
+        const MatDescr descrA,
+        int nnzA, const cuDoubleComplex *csrValA, const int *csrRowPtrA,
+        const int *csrColIndA, const cuDoubleComplex *beta,
+        const MatDescr descrB,
+        int nnzB, const cuDoubleComplex *csrValB, const int *csrRowPtrB,
+        const int *csrColIndB, const MatDescr descrC,
+        cuDoubleComplex *csrValC, int *csrRowPtrC, int *csrColIndC,
+        size_t *pBufferSize)
+
+    Status cusparseXcsrgeam2Nnz(
+        Handle handle, int m, int n, const MatDescr descrA, int nnzA,
+        const int *csrRowPtrA, const int *csrColIndA, const MatDescr descrB,
+        int nnzB, const int *csrRowPtrB, const int *csrColIndB,
+        const MatDescr descrC, int *csrRowPtrC, int *nnzTotalDevHostPtr,
+        void *workspace)
+
+    Status cusparseScsrgeam2(
+        Handle handle, int m, int n, const float *alpha, const MatDescr descrA,
+        int nnzA, const float *csrValA, const int *csrRowPtrA,
+        const int *csrColIndA, const float *beta, const MatDescr descrB,
+        int nnzB, const float *csrValB, const int *csrRowPtrB,
+        const int *csrColIndB, const MatDescr descrC, float *csrValC,
+        int *csrRowPtrC, int *csrColIndC, void *pBuffer)
+
+    Status cusparseDcsrgeam2(
+        Handle handle, int m, int n, const double *alpha,
+        const MatDescr descrA,
+        int nnzA, const double *csrValA, const int *csrRowPtrA,
+        const int *csrColIndA, const double *beta, const MatDescr descrB,
+        int nnzB, const double *csrValB, const int *csrRowPtrB,
+        const int *csrColIndB, const MatDescr descrC, double *csrValC,
+        int *csrRowPtrC, int *csrColIndC, void *pBuffer)
+
+    Status cusparseCcsrgeam2(
+        Handle handle, int m, int n, const cuComplex *alpha,
+        const MatDescr descrA,
+        int nnzA, const cuComplex *csrValA, const int *csrRowPtrA,
+        const int *csrColIndA, const cuComplex *beta, const MatDescr descrB,
+        int nnzB, const cuComplex *csrValB, const int *csrRowPtrB,
+        const int *csrColIndB, const MatDescr descrC, cuComplex *csrValC,
+        int *csrRowPtrC, int *csrColIndC, void *pBuffer)
+
+    Status cusparseZcsrgeam2(
+        Handle handle, int m, int n, const cuDoubleComplex *alpha,
+        const MatDescr descrA,
+        int nnzA, const cuDoubleComplex *csrValA, const int *csrRowPtrA,
+        const int *csrColIndA, const cuDoubleComplex *beta,
+        const MatDescr descrB,
+        int nnzB, const cuDoubleComplex *csrValB, const int *csrRowPtrB,
+        const int *csrColIndB, const MatDescr descrC,
+        cuDoubleComplex *csrValC, int *csrRowPtrC, int *csrColIndC,
+        void *pBuffer)
+
     Status cusparseXcsrgemmNnz(
         Handle handle, Operation transA, Operation transB, int m, int n, int k,
         const MatDescr descrA, const int nnzA, const int *csrRowPtrA,
@@ -232,6 +313,93 @@ cdef extern from 'cupy_cusparse.h' nogil:
         const int nnzB, const cuDoubleComplex *csrValB, const int *csrRowPtrB,
         const int *csrColIndB, const MatDescr descrC, cuDoubleComplex *csrValC,
         const int *csrRowPtrC, int *csrColIndC)
+
+    cusparseStatus_t cusparseCreateCsrgemm2Info(csrgemm2Info_t *info)
+    cusparseStatus_t cusparseDestroyCsrgemm2Info(csrgemm2Info_t info)
+
+    Status cusparseScsrgemm2_bufferSizeExt(
+        Handle handle, int m, int n, int k,
+        const float *alpha,
+        const MatDescr descrA, int nnzA, const int *csrRowPtrA, const int *csrColIndA,
+        const MatDescr descrB, int nnzB, const int *csrRowPtrB, const int *csrColIndB,
+        const float *beta,
+        const MatDescr descrD, int nnzD, const int *csrRowPtrD, const int *csrColIndD,
+        const csrgemm2Info_t info, size_t* pBufferSize)
+
+    Status cusparseDcsrgemm2_bufferSizeExt(
+        Handle handle, int m, int n, int k,
+        const double *alpha,
+        const MatDescr descrA, int nnzA, const int *csrRowPtrA, const int *csrColIndA,
+        const MatDescr descrB, int nnzB, const int *csrRowPtrB, const int *csrColIndB,
+        const double *beta,
+        const MatDescr descrD, int nnzD, const int *csrRowPtrD, const int *csrColIndD,
+        const csrgemm2Info_t info, size_t* pBufferSize)
+
+    Status cusparseCcsrgemm2_bufferSizeExt(
+        Handle handle, int m, int n, int k,
+        const cuComplex *alpha,
+        const MatDescr descrA, int nnzA, const int *csrRowPtrA, const int *csrColIndA,
+        const MatDescr descrB, int nnzB, const int *csrRowPtrB, const int *csrColIndB,
+        const cuComplex *beta,
+        const MatDescr descrD, int nnzD, const int *csrRowPtrD, const int *csrColIndD,
+        const csrgemm2Info_t info, size_t* pBufferSize)
+
+    Status cusparseZcsrgemm2_bufferSizeExt(
+        Handle handle, int m, int n, int k,
+        const cuDoubleComplex *alpha,
+        const MatDescr descrA, int nnzA, const int *csrRowPtrA, const int *csrColIndA,
+        const MatDescr descrB, int nnzB, const int *csrRowPtrB, const int *csrColIndB,
+        const cuDoubleComplex *beta,
+        const MatDescr descrD, int nnzD, const int *csrRowPtrD, const int *csrColIndD,
+        const csrgemm2Info_t info, size_t* pBufferSize)
+
+    Status cusparseXcsrgemm2Nnz(
+        Handle handle, int m, int n, int k,
+        const MatDescr descrA, int nnzA, const int *csrRowPtrA, const int *csrColIndA,
+        const MatDescr descrB, int nnzB, const int *csrRowPtrB, const int *csrColIndB,
+        const MatDescr descrD, int nnzD, const int *csrRowPtrD, const int *csrColIndD,
+        const MatDescr descrC, int *csrRowPtrC,
+        int *nnzTotalDevHostPtr, const csrgemm2Info_t info, void* pBuffer)
+
+    Status cusparseScsrgemm2(
+        Handle handle, int m, int n, int k,
+        const float *alpha,
+        const MatDescr descrA, int nnzA, const float *csrValA, const int *csrRowPtrA, const int *csrColIndA,
+        const MatDescr descrB, int nnzB, const float *csrValB, const int *csrRowPtrB, const int *csrColIndB,
+        const float *beta,
+        const MatDescr descrD, int nnzD, const float *csrValD, const int *csrRowPtrD, const int *csrColIndD,
+        const MatDescr descrC,                 float *csrValC, const int *csrRowPtrC,       int *csrColIndC,
+        const csrgemm2Info_t info, void* pBuffer)
+
+    Status cusparseDcsrgemm2(
+        Handle handle, int m, int n, int k,
+        const double *alpha,
+        const MatDescr descrA, int nnzA, const double *csrValA, const int *csrRowPtrA, const int *csrColIndA,
+        const MatDescr descrB, int nnzB, const double *csrValB, const int *csrRowPtrB, const int *csrColIndB,
+        const double *beta,
+        const MatDescr descrD, int nnzD, const double *csrValD, const int *csrRowPtrD, const int *csrColIndD,
+        const MatDescr descrC,                 double *csrValC, const int *csrRowPtrC,       int *csrColIndC,
+        const csrgemm2Info_t info, void* pBuffer)
+
+    Status cusparseCcsrgemm2(
+        Handle handle, int m, int n, int k,
+        const cuComplex *alpha,
+        const MatDescr descrA, int nnzA, const cuComplex *csrValA, const int *csrRowPtrA, const int *csrColIndA,
+        const MatDescr descrB, int nnzB, const cuComplex *csrValB, const int *csrRowPtrB, const int *csrColIndB,
+        const cuComplex *beta,
+        const MatDescr descrD, int nnzD, const cuComplex *csrValD, const int *csrRowPtrD, const int *csrColIndD,
+        const MatDescr descrC,                 cuComplex *csrValC, const int *csrRowPtrC,       int *csrColIndC,
+        const csrgemm2Info_t info, void* pBuffer)
+
+    Status cusparseZcsrgemm2(
+        Handle handle, int m, int n, int k,
+        const cuDoubleComplex *alpha,
+        const MatDescr descrA, int nnzA, const cuDoubleComplex *csrValA, const int *csrRowPtrA, const int *csrColIndA,
+        const MatDescr descrB, int nnzB, const cuDoubleComplex *csrValB, const int *csrRowPtrB, const int *csrColIndB,
+        const cuDoubleComplex *beta,
+        const MatDescr descrD, int nnzD, const cuDoubleComplex *csrValD, const int *csrRowPtrD, const int *csrColIndD,
+        const MatDescr descrC,           cuDoubleComplex *csrValC, const int *csrRowPtrC,       int *csrColIndC,
+        const csrgemm2Info_t info, void* pBuffer)
 
     # cuSPARSE Format Convrsion
     Status cusparseXcoo2csr(
@@ -1260,7 +1428,6 @@ cpdef scsrgeam(
         <int *>csrColIndC)
     check_status(status)
 
-
 cpdef dcsrgeam(
         intptr_t handle, int m, int n, size_t alpha, size_t descrA,
         int nnzA, size_t csrValA, size_t csrRowPtrA,
@@ -1317,6 +1484,177 @@ cpdef zcsrgeam(
         <int *>csrColIndC)
     check_status(status)
 
+cpdef size_t scsrgeam2_bufferSizeExt(
+        intptr_t handle, int m, int n, size_t alpha, size_t descrA,
+        int nnzA, size_t csrValA, size_t csrRowPtrA,
+        size_t csrColIndA, size_t beta, size_t descrB,
+        int nnzB, size_t csrValB, size_t csrRowPtrB,
+        size_t csrColIndB, size_t descrC, size_t csrValC,
+        size_t csrRowPtrC, size_t csrColIndC):
+    cdef size_t bufferSize
+    setStream(handle, stream_module.get_current_stream_ptr())
+    status = cusparseScsrgeam2_bufferSizeExt(
+        <Handle>handle, m, n, <const float *>alpha,
+        <const MatDescr>descrA, nnzA, <const float *>csrValA,
+        <const int *>csrRowPtrA, <const int *>csrColIndA, <const float *>beta,
+        <const MatDescr>descrB, nnzB, <const float *>csrValB,
+        <const int *>csrRowPtrB, <const int *>csrColIndB,
+        <const MatDescr>descrC, <float *>csrValC, <int *>csrRowPtrC,
+        <int *>csrColIndC, &bufferSize)
+    check_status(status)
+    return bufferSize
+
+cpdef size_t dcsrgeam2_bufferSizeExt(
+        intptr_t handle, int m, int n, size_t alpha, size_t descrA,
+        int nnzA, size_t csrValA, size_t csrRowPtrA,
+        size_t csrColIndA, size_t beta, size_t descrB,
+        int nnzB, size_t csrValB, size_t csrRowPtrB,
+        size_t csrColIndB, size_t descrC, size_t csrValC,
+        size_t csrRowPtrC, size_t csrColIndC):
+    cdef size_t bufferSize
+    setStream(handle, stream_module.get_current_stream_ptr())
+    status = cusparseDcsrgeam2_bufferSizeExt(
+        <Handle>handle, m, n, <const double *>alpha,
+        <const MatDescr>descrA, nnzA, <const double *>csrValA,
+        <const int *>csrRowPtrA, <const int *>csrColIndA, <const double *>beta,
+        <const MatDescr>descrB, nnzB, <const double *>csrValB,
+        <const int *>csrRowPtrB, <const int *>csrColIndB,
+        <const MatDescr>descrC, <double *>csrValC, <int *>csrRowPtrC,
+        <int *>csrColIndC, &bufferSize)
+    check_status(status)
+    return bufferSize
+
+cpdef size_t ccsrgeam2_bufferSizeExt(
+        intptr_t handle, int m, int n, size_t alpha, size_t descrA,
+        int nnzA, size_t csrValA, size_t csrRowPtrA,
+        size_t csrColIndA, size_t beta, size_t descrB,
+        int nnzB, size_t csrValB, size_t csrRowPtrB,
+        size_t csrColIndB, size_t descrC, size_t csrValC,
+        size_t csrRowPtrC, size_t csrColIndC):
+    cdef size_t bufferSize
+    setStream(handle, stream_module.get_current_stream_ptr())
+    status = cusparseCcsrgeam2_bufferSizeExt(
+        <Handle>handle, m, n, <const cuComplex *>alpha,
+        <const MatDescr>descrA, nnzA, <const cuComplex *>csrValA,
+        <const int *>csrRowPtrA, <const int *>csrColIndA,
+        <const cuComplex *>beta,
+        <const MatDescr>descrB, nnzB, <const cuComplex *>csrValB,
+        <const int *>csrRowPtrB, <const int *>csrColIndB,
+        <const MatDescr>descrC, <cuComplex *>csrValC, <int *>csrRowPtrC,
+        <int *>csrColIndC, &bufferSize)
+    check_status(status)
+    return bufferSize
+
+cpdef size_t zcsrgeam2_bufferSizeExt(
+        intptr_t handle, int m, int n, size_t alpha, size_t descrA,
+        int nnzA, size_t csrValA, size_t csrRowPtrA,
+        size_t csrColIndA, size_t beta, size_t descrB,
+        int nnzB, size_t csrValB, size_t csrRowPtrB,
+        size_t csrColIndB, size_t descrC, size_t csrValC,
+        size_t csrRowPtrC, size_t csrColIndC):
+    cdef size_t bufferSize
+    setStream(handle, stream_module.get_current_stream_ptr())
+    status = cusparseZcsrgeam2_bufferSizeExt(
+        <Handle>handle, m, n, <const cuDoubleComplex *>alpha,
+        <const MatDescr>descrA, nnzA, <const cuDoubleComplex *>csrValA,
+        <const int *>csrRowPtrA, <const int *>csrColIndA,
+        <const cuDoubleComplex *>beta,
+        <const MatDescr>descrB, nnzB, <const cuDoubleComplex *>csrValB,
+        <const int *>csrRowPtrB, <const int *>csrColIndB,
+        <const MatDescr>descrC, <cuDoubleComplex *>csrValC, <int *>csrRowPtrC,
+        <int *>csrColIndC, &bufferSize)
+    check_status(status)
+    return bufferSize
+
+cpdef xcsrgeam2Nnz(
+        intptr_t handle, int m, int n, size_t descrA, int nnzA,
+        size_t csrRowPtrA, size_t csrColIndA, size_t descrB,
+        int nnzB, size_t csrRowPtrB, size_t csrColIndB,
+        size_t descrC, size_t csrRowPtrC, size_t nnzTotalDevHostPtr,
+        size_t workspace):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    status = cusparseXcsrgeam2Nnz(
+        <Handle>handle, m, n, <const MatDescr>descrA, nnzA,
+        <const int *>csrRowPtrA, <const int *>csrColIndA,
+        <const MatDescr>descrB, nnzB, <const int *>csrRowPtrB,
+        <const int *>csrColIndB, <const MatDescr>descrC, <int *>csrRowPtrC,
+        <int *>nnzTotalDevHostPtr, <void*> workspace)
+    check_status(status)
+
+cpdef size_t scsrgeam2(
+        intptr_t handle, int m, int n, size_t alpha, size_t descrA,
+        int nnzA, size_t csrValA, size_t csrRowPtrA,
+        size_t csrColIndA, size_t beta, size_t descrB,
+        int nnzB, size_t csrValB, size_t csrRowPtrB,
+        size_t csrColIndB, size_t descrC, size_t csrValC,
+        size_t csrRowPtrC, size_t csrColIndC, size_t buffer):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    status = cusparseScsrgeam2(
+        <Handle>handle, m, n, <const float *>alpha,
+        <const MatDescr>descrA, nnzA, <const float *>csrValA,
+        <const int *>csrRowPtrA, <const int *>csrColIndA, <const float *>beta,
+        <const MatDescr>descrB, nnzB, <const float *>csrValB,
+        <const int *>csrRowPtrB, <const int *>csrColIndB,
+        <const MatDescr>descrC, <float *>csrValC, <int *>csrRowPtrC,
+        <int *>csrColIndC, <void*>buffer)
+    check_status(status)
+
+cpdef size_t dcsrgeam2(
+        intptr_t handle, int m, int n, size_t alpha, size_t descrA,
+        int nnzA, size_t csrValA, size_t csrRowPtrA,
+        size_t csrColIndA, size_t beta, size_t descrB,
+        int nnzB, size_t csrValB, size_t csrRowPtrB,
+        size_t csrColIndB, size_t descrC, size_t csrValC,
+        size_t csrRowPtrC, size_t csrColIndC, size_t buffer):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    status = cusparseDcsrgeam2(
+        <Handle>handle, m, n, <const double *>alpha,
+        <const MatDescr>descrA, nnzA, <const double *>csrValA,
+        <const int *>csrRowPtrA, <const int *>csrColIndA, <const double *>beta,
+        <const MatDescr>descrB, nnzB, <const double *>csrValB,
+        <const int *>csrRowPtrB, <const int *>csrColIndB,
+        <const MatDescr>descrC, <double *>csrValC, <int *>csrRowPtrC,
+        <int *>csrColIndC, <void*>buffer)
+    check_status(status)
+
+cpdef size_t ccsrgeam2(
+        intptr_t handle, int m, int n, size_t alpha, size_t descrA,
+        int nnzA, size_t csrValA, size_t csrRowPtrA,
+        size_t csrColIndA, size_t beta, size_t descrB,
+        int nnzB, size_t csrValB, size_t csrRowPtrB,
+        size_t csrColIndB, size_t descrC, size_t csrValC,
+        size_t csrRowPtrC, size_t csrColIndC, size_t buffer):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    status = cusparseCcsrgeam2(
+        <Handle>handle, m, n, <const cuComplex *>alpha,
+        <const MatDescr>descrA, nnzA, <const cuComplex *>csrValA,
+        <const int *>csrRowPtrA, <const int *>csrColIndA,
+        <const cuComplex *>beta,
+        <const MatDescr>descrB, nnzB, <const cuComplex *>csrValB,
+        <const int *>csrRowPtrB, <const int *>csrColIndB,
+        <const MatDescr>descrC, <cuComplex *>csrValC, <int *>csrRowPtrC,
+        <int *>csrColIndC, <void*>buffer)
+    check_status(status)
+
+cpdef size_t zcsrgeam2(
+        intptr_t handle, int m, int n, size_t alpha, size_t descrA,
+        int nnzA, size_t csrValA, size_t csrRowPtrA,
+        size_t csrColIndA, size_t beta, size_t descrB,
+        int nnzB, size_t csrValB, size_t csrRowPtrB,
+        size_t csrColIndB, size_t descrC, size_t csrValC,
+        size_t csrRowPtrC, size_t csrColIndC, size_t buffer):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    status = cusparseZcsrgeam2(
+        <Handle>handle, m, n, <const cuDoubleComplex *>alpha,
+        <const MatDescr>descrA, nnzA, <const cuDoubleComplex *>csrValA,
+        <const int *>csrRowPtrA, <const int *>csrColIndA,
+        <const cuDoubleComplex *>beta,
+        <const MatDescr>descrB, nnzB, <const cuDoubleComplex *>csrValB,
+        <const int *>csrRowPtrB, <const int *>csrColIndB,
+        <const MatDescr>descrC, <cuDoubleComplex *>csrValC, <int *>csrRowPtrC,
+        <int *>csrColIndC, <void*>buffer)
+    check_status(status)
+
 cpdef xcsrgemmNnz(
         intptr_t handle, int transA, int transB, int m, int n, int k,
         size_t descrA, int nnzA, size_t csrRowPtrA,
@@ -1331,7 +1669,6 @@ cpdef xcsrgemmNnz(
         <const int *>csrRowPtrB, <const int *>csrColIndB,
         <const MatDescr>descrC, <int *>csrRowPtrC, <int *>nnzTotalDevHostPtr)
     check_status(status)
-
 
 cpdef scsrgemm(
         intptr_t handle, int transA, int transB, int m, int n, int k,
@@ -1350,7 +1687,6 @@ cpdef scsrgemm(
         <const MatDescr>descrC, <float *>csrValC,
         <const int *>csrRowPtrC, <int *>csrColIndC)
     check_status(status)
-
 
 cpdef dcsrgemm(
         intptr_t handle, int transA, int transB, int m, int n, int k,
@@ -1404,6 +1740,199 @@ cpdef zcsrgemm(
         <const int *>csrRowPtrB, <const int *>csrColIndB,
         <const MatDescr>descrC, <cuDoubleComplex *>csrValC,
         <const int *>csrRowPtrC, <int *>csrColIndC)
+    check_status(status)
+
+cpdef size_t createCsrgemm2Info():
+    cdef csrgemm2Info_t info
+    with nogil:
+        status = cusparseCreateCsrgemm2Info(&info)
+    check_status(status)
+    return <size_t>info
+
+cpdef destroyCsrgemm2Info(size_t info):
+    with nogil:
+        status = cusparseDestroyCsrgemm2Info(<csrgemm2Info_t>info)
+    check_status(status)
+
+cpdef size_t scsrgemm2_bufferSizeExt(
+        intptr_t handle, int m, int n, int k,
+        size_t alpha,
+        size_t descrA, int nnzA, size_t csrRowPtrA, size_t csrColIndA,
+        size_t descrB, int nnzB, size_t csrRowPtrB, size_t csrColIndB,
+        size_t beta,
+        size_t descrD, int nnzD, size_t csrRowPtrD, size_t csrColIndD,
+        size_t info):
+    cdef size_t bufferSize
+    status = cusparseScsrgemm2_bufferSizeExt(
+        <Handle>handle, m, n, k,
+        <float*>alpha,
+        <MatDescr>descrA, nnzA, <int*>csrRowPtrA, <int*>csrColIndA,
+        <MatDescr>descrB, nnzB, <int*>csrRowPtrB, <int*>csrColIndB,
+        <float*>beta,
+        <MatDescr>descrD, nnzD, <int*>csrRowPtrD, <int*>csrColIndD,
+        <csrgemm2Info_t>info, &bufferSize)
+    check_status(status)
+    return bufferSize
+
+cpdef size_t dcsrgemm2_bufferSizeExt(
+        intptr_t handle, int m, int n, int k,
+        size_t alpha,
+        size_t descrA, int nnzA, size_t csrRowPtrA, size_t csrColIndA,
+        size_t descrB, int nnzB, size_t csrRowPtrB, size_t csrColIndB,
+        size_t beta,
+        size_t descrD, int nnzD, size_t csrRowPtrD, size_t csrColIndD,
+        size_t info):
+    cdef size_t bufferSize
+    status = cusparseDcsrgemm2_bufferSizeExt(
+        <Handle>handle, m, n, k,
+        <double*>alpha,
+        <MatDescr>descrA, nnzA, <int*>csrRowPtrA, <int*>csrColIndA,
+        <MatDescr>descrB, nnzB, <int*>csrRowPtrB, <int*>csrColIndB,
+        <double*>beta,
+        <MatDescr>descrD, nnzD, <int*>csrRowPtrD, <int*>csrColIndD,
+        <csrgemm2Info_t>info, &bufferSize)
+    check_status(status)
+    return bufferSize
+
+cpdef size_t ccsrgemm2_bufferSizeExt(
+        intptr_t handle, int m, int n, int k,
+        size_t alpha,
+        size_t descrA, int nnzA, size_t csrRowPtrA, size_t csrColIndA,
+        size_t descrB, int nnzB, size_t csrRowPtrB, size_t csrColIndB,
+        size_t beta,
+        size_t descrD, int nnzD, size_t csrRowPtrD, size_t csrColIndD,
+        size_t info):
+    cdef size_t bufferSize
+    status = cusparseCcsrgemm2_bufferSizeExt(
+        <Handle>handle, m, n, k,
+        <cuComplex*>alpha,
+        <MatDescr>descrA, nnzA, <int*>csrRowPtrA, <int*>csrColIndA,
+        <MatDescr>descrB, nnzB, <int*>csrRowPtrB, <int*>csrColIndB,
+        <cuComplex*>beta,
+        <MatDescr>descrD, nnzD, <int*>csrRowPtrD, <int*>csrColIndD,
+        <csrgemm2Info_t>info, &bufferSize)
+    check_status(status)
+    return bufferSize
+
+cpdef size_t zcsrgemm2_bufferSizeExt(
+        intptr_t handle, int m, int n, int k,
+        size_t alpha,
+        size_t descrA, int nnzA, size_t csrRowPtrA, size_t csrColIndA,
+        size_t descrB, int nnzB, size_t csrRowPtrB, size_t csrColIndB,
+        size_t beta,
+        size_t descrD, int nnzD, size_t csrRowPtrD, size_t csrColIndD,
+        size_t info):
+    cdef size_t bufferSize
+    status = cusparseZcsrgemm2_bufferSizeExt(
+        <Handle>handle, m, n, k,
+        <cuDoubleComplex*>alpha,
+        <MatDescr>descrA, nnzA, <int*>csrRowPtrA, <int*>csrColIndA,
+        <MatDescr>descrB, nnzB, <int*>csrRowPtrB, <int*>csrColIndB,
+        <cuDoubleComplex*>beta,
+        <MatDescr>descrD, nnzD, <int*>csrRowPtrD, <int*>csrColIndD,
+        <csrgemm2Info_t>info, &bufferSize)
+    check_status(status)
+    return bufferSize
+
+cpdef xcsrgemm2Nnz(
+        intptr_t handle, int m, int n, int k,
+        size_t descrA, int nnzA, size_t csrRowPtrA, size_t csrColIndA,
+        size_t descrB, int nnzB, size_t csrRowPtrB, size_t csrColIndB,
+        size_t descrD, int nnzD, size_t csrRowPtrD, size_t csrColIndD,
+        size_t descrC, size_t csrRowPtrC,
+        intptr_t nnzTotalDevHostPtr, size_t info, intptr_t pBuffer):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    status = cusparseXcsrgemm2Nnz(
+        <Handle>handle, m, n, k,
+        <MatDescr>descrA, nnzA, <int*>csrRowPtrA, <int*>csrColIndA,
+        <MatDescr>descrB, nnzB, <int*>csrRowPtrB, <int*>csrColIndB,
+        <MatDescr>descrD, nnzD, <int*>csrRowPtrD, <int*>csrColIndD,
+        <MatDescr>descrC, <int*>csrRowPtrC,
+        <int*>nnzTotalDevHostPtr, <csrgemm2Info_t>info, <void*>pBuffer)
+    check_status(status)
+
+cpdef scsrgemm2(
+        intptr_t handle, int m, int n, int k,
+        size_t alpha,
+        size_t descrA, int nnzA, size_t csrValA, size_t csrRowPtrA, size_t csrColIndA,
+        size_t descrB, int nnzB, size_t csrValB, size_t csrRowPtrB, size_t csrColIndB,
+        size_t beta,
+        size_t descrD, int nnzD, size_t csrValD, size_t csrRowPtrD, size_t csrColIndD,
+        size_t descrC, size_t csrValC, size_t csrRowPtrC, size_t csrColIndC,
+        size_t info, intptr_t pBuffer):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    status = cusparseScsrgemm2(
+        <Handle>handle, m, n, k,
+        <float*>alpha,
+        <MatDescr>descrA, nnzA, <float*>csrValA, <int*>csrRowPtrA, <int*>csrColIndA,
+        <MatDescr>descrB, nnzB, <float*>csrValB, <int*>csrRowPtrB, <int*>csrColIndB,
+        <float*>beta,
+        <MatDescr>descrD, nnzD, <float*>csrValD, <int*>csrRowPtrD, <int*>csrColIndD,
+        <MatDescr>descrC, <float*>csrValC, <int*>csrRowPtrC, <int*>csrColIndC,
+        <csrgemm2Info_t>info, <void*>pBuffer)
+    check_status(status)
+
+cpdef dcsrgemm2(
+        intptr_t handle, int m, int n, int k,
+        size_t alpha,
+        size_t descrA, int nnzA, size_t csrValA, size_t csrRowPtrA, size_t csrColIndA,
+        size_t descrB, int nnzB, size_t csrValB, size_t csrRowPtrB, size_t csrColIndB,
+        size_t beta,
+        size_t descrD, int nnzD, size_t csrValD, size_t csrRowPtrD, size_t csrColIndD,
+        size_t descrC, size_t csrValC, size_t csrRowPtrC, size_t csrColIndC,
+        size_t info, intptr_t pBuffer):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    status = cusparseDcsrgemm2(
+        <Handle>handle, m, n, k,
+        <double*>alpha,
+        <MatDescr>descrA, nnzA, <double*>csrValA, <int*>csrRowPtrA, <int*>csrColIndA,
+        <MatDescr>descrB, nnzB, <double*>csrValB, <int*>csrRowPtrB, <int*>csrColIndB,
+        <double*>beta,
+        <MatDescr>descrD, nnzD, <double*>csrValD, <int*>csrRowPtrD, <int*>csrColIndD,
+        <MatDescr>descrC, <double*>csrValC, <int*>csrRowPtrC, <int*>csrColIndC,
+        <csrgemm2Info_t>info, <void*>pBuffer)
+    check_status(status)
+
+cpdef ccsrgemm2(
+        intptr_t handle, int m, int n, int k,
+        size_t alpha,
+        size_t descrA, int nnzA, size_t csrValA, size_t csrRowPtrA, size_t csrColIndA,
+        size_t descrB, int nnzB, size_t csrValB, size_t csrRowPtrB, size_t csrColIndB,
+        size_t beta,
+        size_t descrD, int nnzD, size_t csrValD, size_t csrRowPtrD, size_t csrColIndD,
+        size_t descrC, size_t csrValC, size_t csrRowPtrC, size_t csrColIndC,
+        size_t info, intptr_t pBuffer):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    status = cusparseCcsrgemm2(
+        <Handle>handle, m, n, k,
+        <cuComplex*>alpha,
+        <MatDescr>descrA, nnzA, <cuComplex*>csrValA, <int*>csrRowPtrA, <int*>csrColIndA,
+        <MatDescr>descrB, nnzB, <cuComplex*>csrValB, <int*>csrRowPtrB, <int*>csrColIndB,
+        <cuComplex*>beta,
+        <MatDescr>descrD, nnzD, <cuComplex*>csrValD, <int*>csrRowPtrD, <int*>csrColIndD,
+        <MatDescr>descrC, <cuComplex*>csrValC, <int*>csrRowPtrC, <int*>csrColIndC,
+        <csrgemm2Info_t>info, <void*>pBuffer)
+    check_status(status)
+
+cpdef zcsrgemm2(
+        intptr_t handle, int m, int n, int k,
+        size_t alpha,
+        size_t descrA, int nnzA, size_t csrValA, size_t csrRowPtrA, size_t csrColIndA,
+        size_t descrB, int nnzB, size_t csrValB, size_t csrRowPtrB, size_t csrColIndB,
+        size_t beta,
+        size_t descrD, int nnzD, size_t csrValD, size_t csrRowPtrD, size_t csrColIndD,
+        size_t descrC, size_t csrValC, size_t csrRowPtrC, size_t csrColIndC,
+        size_t info, intptr_t pBuffer):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    status = cusparseZcsrgemm2(
+        <Handle>handle, m, n, k,
+        <cuDoubleComplex*>alpha,
+        <MatDescr>descrA, nnzA, <cuDoubleComplex*>csrValA, <int*>csrRowPtrA, <int*>csrColIndA,
+        <MatDescr>descrB, nnzB, <cuDoubleComplex*>csrValB, <int*>csrRowPtrB, <int*>csrColIndB,
+        <cuDoubleComplex*>beta,
+        <MatDescr>descrD, nnzD, <cuDoubleComplex*>csrValD, <int*>csrRowPtrD, <int*>csrColIndD,
+        <MatDescr>descrC, <cuDoubleComplex*>csrValC, <int*>csrRowPtrC, <int*>csrColIndC,
+        <csrgemm2Info_t>info, <void*>pBuffer)
     check_status(status)
 
 ########################################

--- a/cupy/cusparse.py
+++ b/cupy/cusparse.py
@@ -388,6 +388,68 @@ def csrgeam(a, b, alpha=1, beta=1):
     return c
 
 
+def csrgeam2(a, b, alpha=1, beta=1):
+    """Matrix-matrix addition.
+
+    .. math::
+        C = \\alpha A + \\beta B
+
+    Args:
+        a (cupyx.scipy.sparse.csr_matrix): Sparse matrix A.
+        b (cupyx.scipy.sparse.csr_matrix): Sparse matrix B.
+        alpha (float): Coefficient for A.
+        beta (float): Coefficient for B.
+
+    Returns:
+        cupyx.scipy.sparse.csr_matrix: Result matrix.
+
+    """
+    assert a.has_canonical_format
+    assert b.has_canonical_format
+    if a.shape != b.shape:
+        raise ValueError('inconsistent shapes')
+
+    handle = device.get_cusparse_handle()
+    m, n = a.shape
+    a, b = _cast_common_type(a, b)
+    nnz = numpy.empty((), 'i')
+    cusparse.setPointerMode(
+        handle, cusparse.CUSPARSE_POINTER_MODE_HOST)
+
+    alpha = numpy.array(alpha, a.dtype).ctypes
+    beta = numpy.array(beta, a.dtype).ctypes
+    c_descr = MatDescriptor.create()
+    c_indptr = cupy.empty(m + 1, 'i')
+
+    null_ptr = 0
+    buff_size = _call_cusparse(
+        'csrgeam2_bufferSizeExt', a.dtype,
+        handle, m, n, alpha.data, a._descr.descriptor, a.nnz, a.data.data.ptr,
+        a.indptr.data.ptr, a.indices.data.ptr, beta.data, b._descr.descriptor,
+        b.nnz, b.data.data.ptr, b.indptr.data.ptr, b.indices.data.ptr,
+        c_descr.descriptor, null_ptr, c_indptr.data.ptr, null_ptr)
+    buff = cupy.empty(buff_size, numpy.int8)
+    cusparse.xcsrgeam2Nnz(
+        handle, m, n, a._descr.descriptor, a.nnz, a.indptr.data.ptr,
+        a.indices.data.ptr, b._descr.descriptor, b.nnz, b.indptr.data.ptr,
+        b.indices.data.ptr, c_descr.descriptor, c_indptr.data.ptr,
+        nnz.ctypes.data, buff.data.ptr)
+    c_indices = cupy.empty(int(nnz), 'i')
+    c_data = cupy.empty(int(nnz), a.dtype)
+    _call_cusparse(
+        'csrgeam2', a.dtype,
+        handle, m, n, alpha.data, a._descr.descriptor, a.nnz, a.data.data.ptr,
+        a.indptr.data.ptr, a.indices.data.ptr, beta.data, b._descr.descriptor,
+        b.nnz, b.data.data.ptr, b.indptr.data.ptr, b.indices.data.ptr,
+        c_descr.descriptor, c_data.data.ptr, c_indptr.data.ptr,
+        c_indices.data.ptr, buff.data.ptr)
+
+    c = cupyx.scipy.sparse.csr_matrix(
+        (c_data, c_indices, c_indptr), shape=a.shape)
+    c._has_canonical_format = True
+    return c
+
+
 def csrgemm(a, b, transa=False, transb=False):
     """Matrix-matrix product for CSR-matrix.
 
@@ -444,13 +506,105 @@ def csrgemm(a, b, transa=False, transb=False):
         handle, op_a, op_b, m, n, k, a._descr.descriptor, a.nnz,
         a.data.data.ptr, a.indptr.data.ptr, a.indices.data.ptr,
         b._descr.descriptor, b.nnz, b.data.data.ptr, b.indptr.data.ptr,
-        b.indices.data.ptr,
-        c_descr.descriptor, c_data.data.ptr, c_indptr.data.ptr,
-        c_indices.data.ptr)
+        b.indices.data.ptr, c_descr.descriptor, c_data.data.ptr,
+        c_indptr.data.ptr, c_indices.data.ptr)
 
     c = cupyx.scipy.sparse.csr_matrix(
         (c_data, c_indices, c_indptr), shape=(m, n))
     c._has_canonical_format = True
+    return c
+
+
+def csrgemm2(a, b, d=None, alpha=1, beta=1):
+    """Matrix-matrix product for CSR-matrix.
+
+    math::
+       C = alpha * A * B + beta * D
+
+    Args:
+        a (cupyx.scipy.sparse.csr_matrix): Sparse matrix A.
+        b (cupyx.scipy.sparse.csr_matrix): Sparse matrix B.
+        d (cupyx.scipy.sparse.csr_matrix or None): Sparse matrix D.
+        alpha (scalar): Coefficient
+        beta (scalar): Coefficient
+
+    Returns:
+        cupyx.scipy.sparse.csr_matrix
+
+    """
+    assert a.ndim == b.ndim == 2
+    assert a.has_canonical_format
+    assert b.has_canonical_format
+    assert a.shape[1] == b.shape[0]
+    if d is not None:
+        assert d.ndim == 2
+        assert d.has_canonical_format
+        assert a.shape[0] == d.shape[0]
+        assert b.shape[1] == d.shape[1]
+
+    handle = device.get_cusparse_handle()
+    m, k = a.shape
+    _, n = b.shape
+
+    if d is None:
+        a, b = _cast_common_type(a, b)
+    else:
+        a, b, d = _cast_common_type(a, b, d)
+
+    info = cusparse.createCsrgemm2Info()
+    alpha = numpy.array(alpha, a.dtype).ctypes
+    null_ptr = 0
+    if d is None:
+        beta_data = null_ptr
+        d_descr = MatDescriptor.create()
+        d_nnz = 0
+        d_data = null_ptr
+        d_indptr = null_ptr
+        d_indices = null_ptr
+    else:
+        beta = numpy.array(beta, a.dtype).ctypes
+        beta_data = beta.data
+        d_descr = d._descr
+        d_nnz = d.nnz
+        d_data = d.data.data.ptr
+        d_indptr = d.indptr.data.ptr
+        d_indices = d.indices.data.ptr
+
+    buff_size = _call_cusparse(
+        'csrgemm2_bufferSizeExt', a.dtype,
+        handle, m, n, k, alpha.data, a._descr.descriptor, a.nnz,
+        a.indptr.data.ptr, a.indices.data.ptr, b._descr.descriptor, b.nnz,
+        b.indptr.data.ptr, b.indices.data.ptr, beta_data, d_descr.descriptor,
+        d_nnz, d_indptr, d_indices, info)
+    buff = cupy.empty(buff_size, numpy.int8)
+
+    c_nnz = numpy.empty((), 'i')
+    cusparse.setPointerMode(handle, cusparse.CUSPARSE_POINTER_MODE_HOST)
+
+    c_descr = MatDescriptor.create()
+    c_indptr = cupy.empty(m + 1, 'i')
+    cusparse.xcsrgemm2Nnz(
+        handle, m, n, k, a._descr.descriptor, a.nnz, a.indptr.data.ptr,
+        a.indices.data.ptr, b._descr.descriptor, b.nnz, b.indptr.data.ptr,
+        b.indices.data.ptr, d_descr.descriptor, d_nnz, d_indptr, d_indices,
+        c_descr.descriptor, c_indptr.data.ptr, c_nnz.ctypes.data, info,
+        buff.data.ptr)
+
+    c_indices = cupy.empty(int(c_nnz), 'i')
+    c_data = cupy.empty(int(c_nnz), a.dtype)
+    _call_cusparse(
+        'csrgemm2', a.dtype,
+        handle, m, n, k, alpha.data, a._descr.descriptor, a.nnz,
+        a.data.data.ptr, a.indptr.data.ptr, a.indices.data.ptr,
+        b._descr.descriptor, b.nnz, b.data.data.ptr, b.indptr.data.ptr,
+        b.indices.data.ptr, beta_data, d_descr.descriptor, d_nnz, d_data,
+        d_indptr, d_indices, c_descr.descriptor, c_data.data.ptr,
+        c_indptr.data.ptr, c_indices.data.ptr, info, buff.data.ptr)
+
+    c = cupyx.scipy.sparse.csr_matrix(
+        (c_data, c_indices, c_indptr), shape=(m, n))
+    c._has_canonical_format = True
+    cusparse.destroyCsrgemm2Info(info)
     return c
 
 

--- a/cupy/cusparse.py
+++ b/cupy/cusparse.py
@@ -80,14 +80,14 @@ def _dtype_to_DataType(dtype):
 
 
 _available_cuda_version = {
-    'csrmv': (9000, 11000),
-    'csrmvEx': (9000, None),
-    'csrmm': (9000, 11000),
-    'csrmm2': (9000, 11000),
-    'csrgeam': (9000, 11000),
+    'csrmv': (8000, 11000),
+    'csrmvEx': (8000, None),
+    'csrmm': (8000, 11000),
+    'csrmm2': (8000, 11000),
+    'csrgeam': (8000, 11000),
     'csrgeam2': (9020, None),
-    'csrgemm': (9000, 11000),
-    'csrgemm2': (9000, None),
+    'csrgemm': (8000, 11000),
+    'csrgemm2': (8000, None),
     'spmv': (10010, None),
     'spmm': (10010, None),
 }

--- a/tests/cupy_tests/test_cusparse.py
+++ b/tests/cupy_tests/test_cusparse.py
@@ -1,6 +1,7 @@
 import unittest
 
 import numpy
+import pytest
 try:
     import scipy.sparse
 except ImportError:
@@ -93,6 +94,42 @@ class TestCsrmm2(unittest.TestCase):
 
 
 @testing.parameterize(*testing.product({
+    'dtype': [numpy.float32, numpy.float64, numpy.complex64, numpy.complex128],
+    'shape': [(3, 4), (4, 3)]
+}))
+@testing.with_requires('scipy')
+class TestCsrgeam(unittest.TestCase):
+
+    alpha = 0.5
+    beta = 0.25
+
+    def setUp(self):
+        m, n = self.shape
+        self.a = scipy.sparse.random(m, n, density=0.3, dtype=self.dtype)
+        self.b = scipy.sparse.random(m, n, density=0.3, dtype=self.dtype)
+
+    def test_csrgeam(self):
+        if not cupy.cusparse.check_availability('csrgeam'):
+            pytest.skip('csrgeam is not available')
+
+        a = sparse.csr_matrix(self.a)
+        b = sparse.csr_matrix(self.b)
+        c = cupy.cusparse.csrgeam(a, b, alpha=self.alpha, beta=self.beta)
+        expect = self.alpha * self.a + self.beta * self.b
+        testing.assert_array_almost_equal(c.toarray(), expect.toarray())
+
+    def test_csrgeam2(self):
+        if not cupy.cusparse.check_availability('csrgeam2'):
+            pytest.skip('csrgeam is not available')
+
+        a = sparse.csr_matrix(self.a)
+        b = sparse.csr_matrix(self.b)
+        c = cupy.cusparse.csrgeam2(a, b, alpha=self.alpha, beta=self.beta)
+        expect = self.alpha * self.a + self.beta * self.b
+        testing.assert_array_almost_equal(c.toarray(), expect.toarray())
+
+
+@testing.parameterize(*testing.product({
     'dtype': [numpy.float32, numpy.float64],
     'transa': [False, True],
     'transb': [False, True],
@@ -113,11 +150,52 @@ class TestCsrgemm(unittest.TestCase):
             self.b = self.op_b
 
     def test_csrgemm(self):
+        if not cupy.cusparse.check_availability('csrgemm'):
+            pytest.skip('csrgemm is not available.')
+
         a = sparse.csr_matrix(self.a)
         b = sparse.csr_matrix(self.b)
         y = cupy.cusparse.csrgemm(a, b, transa=self.transa, transb=self.transb)
         expect = self.op_a.dot(self.op_b)
         testing.assert_array_almost_equal(y.toarray(), expect.toarray())
+
+
+@testing.parameterize(*testing.product({
+    'dtype': [numpy.float32, numpy.float64, numpy.complex64, numpy.complex128],
+    'shape': [(2, 3, 4), (4, 3, 2)]
+}))
+@testing.with_requires('scipy')
+class TestCsrgemm2(unittest.TestCase):
+
+    alpha = 0.5
+    beta = 0.25
+
+    def setUp(self):
+        m, n, k = self.shape
+        self.a = scipy.sparse.random(m, k, density=0.5, dtype=self.dtype)
+        self.b = scipy.sparse.random(k, n, density=0.5, dtype=self.dtype)
+        self.d = scipy.sparse.random(m, n, density=0.5, dtype=self.dtype)
+
+    def test_csrgemm2_ab(self):
+        if not cupy.cusparse.check_availability('csrgemm2'):
+            pytest.skip('csrgemm2 is not available.')
+
+        a = sparse.csr_matrix(self.a)
+        b = sparse.csr_matrix(self.b)
+        c = cupy.cusparse.csrgemm2(a, b, alpha=self.alpha)
+        expect = self.alpha * self.a.dot(self.b)
+        testing.assert_array_almost_equal(c.toarray(), expect.toarray())
+
+    def test_csrgemm2_abpd(self):
+        if not cupy.cusparse.check_availability('csrgemm2'):
+            pytest.skip('csrgemm2 is not available.')
+
+        a = sparse.csr_matrix(self.a)
+        b = sparse.csr_matrix(self.b)
+        d = sparse.csr_matrix(self.d)
+        c = cupy.cusparse.csrgemm2(a, b, d=d, alpha=self.alpha, beta=self.beta)
+        expect = self.alpha * self.a.dot(self.b) + self.beta * self.d
+        testing.assert_array_almost_equal(c.toarray(), expect.toarray())
 
 
 @testing.parameterize(*testing.product({

--- a/tests/cupy_tests/test_cusparse.py
+++ b/tests/cupy_tests/test_cusparse.py
@@ -112,7 +112,7 @@ class TestCsrmm2(unittest.TestCase):
     'dtype': [numpy.float32, numpy.float64, numpy.complex64, numpy.complex128],
     'shape': [(3, 4), (4, 3)]
 }))
-@testing.with_requires('scipy')
+@testing.with_requires('scipy>=1.2.0')
 class TestCsrgeam(unittest.TestCase):
 
     alpha = 0.5
@@ -179,7 +179,7 @@ class TestCsrgemm(unittest.TestCase):
     'dtype': [numpy.float32, numpy.float64, numpy.complex64, numpy.complex128],
     'shape': [(2, 3, 4), (4, 3, 2)]
 }))
-@testing.with_requires('scipy')
+@testing.with_requires('scipy>=1.2.0')
 class TestCsrgemm2(unittest.TestCase):
 
     alpha = 0.5


### PR DESCRIPTION
This PR is to support some cuSparse functions, `cusparse<t>csrgeam2` and `cusparse<t>csrgemm2`, mainly for next CUDA release.

Currently, `cusparse<t>csrgeam` and `cusparse<t>csrgemm` are used in `csrgeam` and `csrgemm` in cupy/cusparse.py as backend implementation for sparse matrix addition and multiplication respectively. As you might know, those were deprecated in CUDA 10.1 and will be removed and unavailable in next CUDA release. `cusparse<t>csrgeam2` and `cusparse<t>csrgemm2` remain available in next CUDA release, so you can use these as alternatives.

