### PR TITLE
[backport] Fix `fill_diagonal`

### DIFF
--- a/cupy/indexing/insert.py
+++ b/cupy/indexing/insert.py
@@ -1,6 +1,7 @@
 import numpy
 
 import cupy
+from cupy import core
 
 
 def place(arr, mask, vals):
@@ -69,6 +70,12 @@ def put(a, ind, v, mode='wrap'):
 # TODO(okuta): Implement putmask
 
 
+_fill_diagonal_kernel = core.ElementwiseKernel(
+    'int64 start, int64 stop, int64 step, raw T val', 'raw T a',
+    'a[start + i * step] = val[i % val.size()];',
+    'cupy_fill_diagonal')
+
+
 def fill_diagonal(a, val, wrap=False):
     """Fills the main diagonal of the given array of any dimensionality.
 
@@ -97,7 +104,7 @@ def fill_diagonal(a, val, wrap=False):
     # The followings are imported from the original numpy
     if a.ndim < 2:
         raise ValueError('array must be at least 2-d')
-    end = None
+    end = a.size
     if a.ndim == 2:
         step = a.shape[1] + 1
         if not wrap:
@@ -107,6 +114,7 @@ def fill_diagonal(a, val, wrap=False):
             raise ValueError('All dimensions of input must be of equal length')
         step = 1 + numpy.cumprod(a.shape[:-1]).sum()
 
-    # Since the current cupy does not support a.flat,
-    # we use a.ravel() instead of a.flat
-    a.ravel()[:end:step] = val
+    val = cupy.asarray(val, dtype=a.dtype)
+
+    size = end // step + 1
+    _fill_diagonal_kernel(0, end, step, val, a, size=size)

--- a/tests/cupy_tests/indexing_tests/test_insert.py
+++ b/tests/cupy_tests/indexing_tests/test_insert.py
@@ -1,6 +1,7 @@
 import unittest
 
 import numpy
+import pytest
 
 from cupy import testing
 
@@ -112,21 +113,40 @@ class TestPutRaises(unittest.TestCase):
 
 @testing.parameterize(*testing.product({
     'shape': [(3, 3), (2, 2, 2), (3, 5), (5, 3)],
-    'val': [1, 0],
+    'val': [1, 0, (2,), (2, 2)],
     'wrap': [True, False],
 }))
 @testing.gpu
 class TestFillDiagonal(unittest.TestCase):
 
+    def _compute_val(self, xp):
+        if type(self.val) is int:
+            return self.val
+        else:
+            return xp.arange(numpy.prod(self.val)).reshape(self.val)
+
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_fill_diagonal(self, xp, dtype):
         a = testing.shaped_arange(self.shape, xp, dtype)
-        xp.fill_diagonal(a, val=self.val, wrap=self.wrap)
+        val = self._compute_val(xp)
+        xp.fill_diagonal(a, val=val, wrap=self.wrap)
+        return a
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_columnar_slice(self, xp, dtype):  # see cupy#2970
+        if self.shape == (2, 2, 2):
+            pytest.skip(
+                'The length of each dimension must be the same after slicing')
+        a = testing.shaped_arange(self.shape, xp, dtype)
+        val = self._compute_val(xp)
+        xp.fill_diagonal(a[:, 1:], val=val, wrap=self.wrap)
         return a
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_raises()
     def test_1darray(self, xp, dtype):
         a = testing.shaped_arange(5, xp, dtype)
-        xp.fill_diagonal(a, val=self.val, wrap=self.wrap)
+        val = self._compute_val(xp)
+        xp.fill_diagonal(a, val=val, wrap=self.wrap)


### PR DESCRIPTION
This is a manual backport of both #3011 and #3139 since #3011 couldn't be easily backported but #3139 was pretty easy.