### PR TITLE
Allow `MatDescriptor` to be pickle-able

### DIFF
--- a/cupy/cusparse.py
+++ b/cupy/cusparse.py
@@ -20,6 +20,9 @@ class MatDescriptor(object):
         descr = cusparse.createMatDescr()
         return MatDescriptor(descr)
 
+    def __reduce__(self):
+        return self.create, ()
+
     def __del__(self, is_shutting_down=util.is_shutting_down):
         if is_shutting_down():
             return

--- a/tests/cupy_tests/test_cusparse.py
+++ b/tests/cupy_tests/test_cusparse.py
@@ -1,3 +1,4 @@
+import pickle
 import unittest
 
 import numpy
@@ -8,7 +9,21 @@ except ImportError:
 
 import cupy
 from cupy import testing
+from cupy import cusparse
 from cupyx.scipy import sparse
+
+
+class TestMatDescriptor(unittest.TestCase):
+
+    def test_create(self):
+        md = cusparse.MatDescriptor.create()
+        assert isinstance(md.descriptor, int)
+
+    def test_pickle(self):
+        md = cusparse.MatDescriptor.create()
+        md2 = pickle.loads(pickle.dumps(md))
+        assert isinstance(md2.descriptor, int)
+        assert md.descriptor != md2.descriptor
 
 
 @testing.parameterize(*testing.product({

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_coo.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_coo.py
@@ -156,8 +156,8 @@ class TestCooMatrix(unittest.TestCase):
         assert n.shape == m.shape
         return n
 
-    def test_pickle_roundtrip(self, xp, sp):
-        s = _make(xp, sp, self.dtype)
+    def test_pickle_roundtrip(self):
+        s = _make(cupy, sparse, self.dtype)
         s2 = pickle.loads(pickle.dumps(s))
         assert s._descr.descriptor != s2._descr.descriptor
         assert s.shape == s2.shape

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_coo.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_coo.py
@@ -162,7 +162,7 @@ class TestCooMatrix(unittest.TestCase):
         assert s.shape == s2.shape
         assert s.dtype == s2.dtype
         if scipy_available:
-            assert (s.get() != s2.get()).count_nonzero()
+            assert (s.get() != s2.get()).count_nonzero() == 0
 
     def test_shape(self):
         self.assertEqual(self.m.shape, (3, 4))

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_coo.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_coo.py
@@ -161,7 +161,8 @@ class TestCooMatrix(unittest.TestCase):
         s2 = pickle.loads(pickle.dumps(s))
         assert s.shape == s2.shape
         assert s.dtype == s2.dtype
-        assert (s != s2).count_nonzero()
+        if scipy_available:
+            assert (s.get() != s2.get()).count_nonzero()
 
     def test_shape(self):
         self.assertEqual(self.m.shape, (3, 4))

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_coo.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_coo.py
@@ -159,6 +159,7 @@ class TestCooMatrix(unittest.TestCase):
     def test_pickle_roundtrip(self, xp, sp):
         s = _make(xp, sp, self.dtype)
         s2 = pickle.loads(pickle.dumps(s))
+        assert s._descr.descriptor != s2._descr.descriptor
         assert s.shape == s2.shape
         assert s.dtype == s2.dtype
         assert (s != s2).count_nonzero()

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_coo.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_coo.py
@@ -159,7 +159,6 @@ class TestCooMatrix(unittest.TestCase):
     def test_pickle_roundtrip(self):
         s = _make(cupy, sparse, self.dtype)
         s2 = pickle.loads(pickle.dumps(s))
-        assert s._descr.descriptor != s2._descr.descriptor
         assert s.shape == s2.shape
         assert s.dtype == s2.dtype
         assert (s != s2).count_nonzero()

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_coo.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_coo.py
@@ -1,3 +1,4 @@
+import pickle
 import unittest
 
 import numpy
@@ -154,6 +155,13 @@ class TestCooMatrix(unittest.TestCase):
         assert len(n.col) == len(m.col)
         assert n.shape == m.shape
         return n
+
+    def test_pickle_roundtrip(self, xp, sp):
+        s = _make(xp, sp, self.dtype)
+        s2 = pickle.loads(pickle.dumps(s))
+        assert s.shape == s2.shape
+        assert s.dtype == s2.dtype
+        assert (s != s2).count_nonzero()
 
     def test_shape(self):
         self.assertEqual(self.m.shape, (3, 4))

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
@@ -264,7 +264,8 @@ class TestCscMatrix(unittest.TestCase):
         assert s._descr.descriptor != s2._descr.descriptor
         assert s.shape == s2.shape
         assert s.dtype == s2.dtype
-        assert (s != s2).count_nonzero()
+        if scipy_available:
+            assert (s.get() != s2.get()).count_nonzero()
 
 
 @testing.parameterize(*testing.product({

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
@@ -261,6 +261,7 @@ class TestCscMatrix(unittest.TestCase):
     def test_pickle_roundtrip(self, xp, sp):
         s = _make(xp, sp, self.dtype)
         s2 = pickle.loads(pickle.dumps(s))
+        assert s._descr.descriptor != s2._descr.descriptor
         assert s.shape == s2.shape
         assert s.dtype == s2.dtype
         assert (s != s2).count_nonzero()

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
@@ -1,3 +1,4 @@
+import pickle
 import unittest
 
 import numpy
@@ -256,6 +257,13 @@ class TestCscMatrix(unittest.TestCase):
         ]
         self.assertTrue(m.flags.c_contiguous)
         cupy.testing.assert_allclose(m, expect)
+
+    def test_pickle_roundtrip(self, xp, sp):
+        s = _make(xp, sp, self.dtype)
+        s2 = pickle.loads(pickle.dumps(s))
+        assert s.shape == s2.shape
+        assert s.dtype == s2.dtype
+        assert (s != s2).count_nonzero()
 
 
 @testing.parameterize(*testing.product({

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
@@ -258,8 +258,8 @@ class TestCscMatrix(unittest.TestCase):
         self.assertTrue(m.flags.c_contiguous)
         cupy.testing.assert_allclose(m, expect)
 
-    def test_pickle_roundtrip(self, xp, sp):
-        s = _make(xp, sp, self.dtype)
+    def test_pickle_roundtrip(self):
+        s = _make(cupy, sparse, self.dtype)
         s2 = pickle.loads(pickle.dumps(s))
         assert s._descr.descriptor != s2._descr.descriptor
         assert s.shape == s2.shape

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
@@ -265,7 +265,7 @@ class TestCscMatrix(unittest.TestCase):
         assert s.shape == s2.shape
         assert s.dtype == s2.dtype
         if scipy_available:
-            assert (s.get() != s2.get()).count_nonzero()
+            assert (s.get() != s2.get()).count_nonzero() == 0
 
 
 @testing.parameterize(*testing.product({

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -271,8 +271,8 @@ class TestCsrMatrix(unittest.TestCase):
         self.assertTrue(m.flags.c_contiguous)
         cupy.testing.assert_allclose(m, expect)
 
-    def test_pickle_roundtrip(self, xp, sp):
-        s = _make(xp, sp, self.dtype)
+    def test_pickle_roundtrip(self):
+        s = _make(cupy, sparse, self.dtype)
         s2 = pickle.loads(pickle.dumps(s))
         assert s._descr.descriptor != s2._descr.descriptor
         assert s.shape == s2.shape

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -1,3 +1,4 @@
+import pickle
 import unittest
 
 import numpy
@@ -269,6 +270,13 @@ class TestCsrMatrix(unittest.TestCase):
         ]
         self.assertTrue(m.flags.c_contiguous)
         cupy.testing.assert_allclose(m, expect)
+
+    def test_pickle_roundtrip(self, xp, sp):
+        s = _make(xp, sp, self.dtype)
+        s2 = pickle.loads(pickle.dumps(s))
+        assert s.shape == s2.shape
+        assert s.dtype == s2.dtype
+        assert (s != s2).count_nonzero()
 
 
 @testing.parameterize(*testing.product({

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -274,6 +274,7 @@ class TestCsrMatrix(unittest.TestCase):
     def test_pickle_roundtrip(self, xp, sp):
         s = _make(xp, sp, self.dtype)
         s2 = pickle.loads(pickle.dumps(s))
+        assert s._descr.descriptor != s2._descr.descriptor
         assert s.shape == s2.shape
         assert s.dtype == s2.dtype
         assert (s != s2).count_nonzero()

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -278,7 +278,7 @@ class TestCsrMatrix(unittest.TestCase):
         assert s.shape == s2.shape
         assert s.dtype == s2.dtype
         if scipy_available:
-            assert (s.get() != s2.get()).count_nonzero()
+            assert (s.get() != s2.get()).count_nonzero() == 0
 
 
 @testing.parameterize(*testing.product({

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -277,7 +277,8 @@ class TestCsrMatrix(unittest.TestCase):
         assert s._descr.descriptor != s2._descr.descriptor
         assert s.shape == s2.shape
         assert s.dtype == s2.dtype
-        assert (s != s2).count_nonzero()
+        if scipy_available:
+            assert (s.get() != s2.get()).count_nonzero()
 
 
 @testing.parameterize(*testing.product({

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_dia.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_dia.py
@@ -106,6 +106,7 @@ class TestDiaMatrix(unittest.TestCase):
     def test_pickle_roundtrip(self, xp, sp):
         s = _make(xp, sp, self.dtype)
         s2 = pickle.loads(pickle.dumps(s))
+        assert s._descr.descriptor != s2._descr.descriptor
         assert s.shape == s2.shape
         assert s.dtype == s2.dtype
         assert (s != s2).count_nonzero()

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_dia.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_dia.py
@@ -1,3 +1,4 @@
+import pickle
 import unittest
 
 
@@ -101,6 +102,13 @@ class TestDiaMatrix(unittest.TestCase):
         ]
         self.assertTrue(m.flags.c_contiguous)
         cupy.testing.assert_allclose(m, expect)
+
+    def test_pickle_roundtrip(self, xp, sp):
+        s = _make(xp, sp, self.dtype)
+        s2 = pickle.loads(pickle.dumps(s))
+        assert s.shape == s2.shape
+        assert s.dtype == s2.dtype
+        assert (s != s2).count_nonzero()
 
     def test_diagonal(self):
         testing.assert_array_equal(

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_dia.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_dia.py
@@ -108,7 +108,8 @@ class TestDiaMatrix(unittest.TestCase):
         s2 = pickle.loads(pickle.dumps(s))
         assert s.shape == s2.shape
         assert s.dtype == s2.dtype
-        assert (s != s2).count_nonzero()
+        if scipy_available:
+            assert (s.get() != s2.get()).count_nonzero()
 
     def test_diagonal(self):
         testing.assert_array_equal(

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_dia.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_dia.py
@@ -106,7 +106,6 @@ class TestDiaMatrix(unittest.TestCase):
     def test_pickle_roundtrip(self):
         s = _make(cupy, sparse, self.dtype)
         s2 = pickle.loads(pickle.dumps(s))
-        assert s._descr.descriptor != s2._descr.descriptor
         assert s.shape == s2.shape
         assert s.dtype == s2.dtype
         assert (s != s2).count_nonzero()

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_dia.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_dia.py
@@ -103,8 +103,8 @@ class TestDiaMatrix(unittest.TestCase):
         self.assertTrue(m.flags.c_contiguous)
         cupy.testing.assert_allclose(m, expect)
 
-    def test_pickle_roundtrip(self, xp, sp):
-        s = _make(xp, sp, self.dtype)
+    def test_pickle_roundtrip(self):
+        s = _make(cupy, sparse, self.dtype)
         s2 = pickle.loads(pickle.dumps(s))
         assert s._descr.descriptor != s2._descr.descriptor
         assert s.shape == s2.shape

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_dia.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_dia.py
@@ -109,7 +109,7 @@ class TestDiaMatrix(unittest.TestCase):
         assert s.shape == s2.shape
         assert s.dtype == s2.dtype
         if scipy_available:
-            assert (s.get() != s2.get()).count_nonzero()
+            assert (s.get() != s2.get()).count_nonzero() == 0
 
     def test_diagonal(self):
         testing.assert_array_equal(


### PR DESCRIPTION
Fixes https://github.com/cupy/cupy/issues/3061