### PR TITLE
Document `convolve` and `correlate`

### DIFF
--- a/docs/source/reference/ndimage.rst
+++ b/docs/source/reference/ndimage.rst
@@ -17,6 +17,8 @@ Interpolation
    :nosignatures:
 
    cupyx.scipy.ndimage.affine_transform
+   cupyx.scipy.ndimage.convolve
+   cupyx.scipy.ndimage.correlate
    cupyx.scipy.ndimage.map_coordinates
    cupyx.scipy.ndimage.rotate
    cupyx.scipy.ndimage.shift


### PR DESCRIPTION
These were missing from the API docs previously. So this just makes sure they are included.

cc @beckernick @awthomp