### PR TITLE
Remove python 2.7 builds

### DIFF
--- a/.pfnci/py27and35.Dockerfile
+++ b/.pfnci/py27and35.Dockerfile
@@ -17,17 +17,9 @@ RUN wget 'https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x8
     rm 'libcutensor1_1.0.0-1_amd64.deb'
 
 RUN python3.5 -m pip install --upgrade pip setuptools
-RUN python2.7 -m pip install --upgrade pip setuptools
 
 RUN python3.5 -m pip install \
     'cython>=0.28.0' 'pytest==4.1.1' 'pytest-xdist==1.26.1' \
     mock setuptools filelock 'numpy>=1.9.0' 'protobuf>=3.0.0'
-
-RUN python2.7 -m pip install \
-    'cython>=0.28.0' 'pytest==4.1.1' 'pytest-xdist==1.26.1' \
-    mock setuptools filelock 'protobuf>=3.0.0'
-
-# Newer versions of numpy and more-itertools no longer support python2.
-RUN python2.7 -m pip install 'numpy<=1.16.5' 'more-itertools<=5.0.0'
 
 COPY --from=xpytest /usr/local/bin/xpytest /usr/local/bin/xpytest

--- a/.pfnci/wheel_nightly.sh
+++ b/.pfnci/wheel_nightly.sh
@@ -10,7 +10,7 @@ mount -t tmpfs tmpfs ${TEMP}/
 cp -a . ${TEMP}/
 cd ${TEMP}/
 
-echo -n 2.7 3.6 | xargs -i -d ' ' -P $(nproc) sh -euxc '
+echo -n 3.6 | xargs -i -d ' ' -P $(nproc) sh -euxc '
 PYTHON={}
 
 docker build \


### PR DESCRIPTION
Remove python2.7 builds from pfnCI.

File names and config file keys should be changed too, but it requires changes to CI configuration.
Kept them now for compatibility

Thanks to @toslunar and @Hakuyume for finding it.