### PR TITLE
Implement `cupy.flatiter`

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -447,6 +447,9 @@ from cupy.indexing.indexing import take_along_axis  # NOQA
 from cupy.indexing.insert import place  # NOQA
 from cupy.indexing.insert import put  # NOQA
 from cupy.indexing.insert import fill_diagonal  # NOQA
+
+from cupy.indexing.iterate import flatiter  # NOQA
+
 # -----------------------------------------------------------------------------
 # Input and output
 # -----------------------------------------------------------------------------

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -255,6 +255,10 @@ cdef class ndarray:
         else:
             return _manipulation._T(self)
 
+    @property
+    def flat(self):
+        return cupy.flatiter(self)
+
     __array_priority__ = 100
 
     # -------------------------------------------------------------------------

--- a/cupy/indexing/__init__.py
+++ b/cupy/indexing/__init__.py
@@ -5,3 +5,4 @@
 from cupy.indexing import generate  # NOQA
 from cupy.indexing import indexing  # NOQA
 from cupy.indexing import insert  # NOQA
+from cupy.indexing import iterate  # NOQA

--- a/cupy/indexing/iterate.py
+++ b/cupy/indexing/iterate.py
@@ -1,0 +1,97 @@
+import numpy
+
+import cupy
+from cupy import core
+from cupy.core import internal
+
+
+class flatiter():
+
+    def __init__(self, a):
+        self._base = a
+
+    def __setitem__(self, ind, value):
+        if ind is Ellipsis:
+            self[:] = value
+            return
+
+        if isinstance(ind, tuple):
+            raise IndexError('unsupported iterator index')
+
+        if isinstance(ind, bool):
+            raise IndexError('unsupported iterator index')
+
+        if numpy.isscalar(ind):
+            ind = int(ind)
+            base = self._base
+            size = base.size
+            indices = []
+            for s in base.shape:
+                size = size // s
+                indices.append(ind // size)
+                ind %= size
+            base[tuple(indices)] = value
+            return
+
+        if isinstance(ind, slice):
+            base = self._base
+            s = internal.complete_slice(ind, base.size)
+            s_start = s.start
+            s_stop = s.stop
+            s_step = s.step
+            if s_step > 0:
+                size = (s_stop - s_start - 1) // s_step + 1
+            else:
+                size = (s_stop - s_start + 1) // s_step + 1
+            value = cupy.asarray(value, dtype=base.dtype)
+            _flatiter_setitem_slice(value, s_start, s_step, base, size=size)
+            return
+
+        raise IndexError('unsupported iterator index')
+
+    def __getitem__(self, ind):
+        if ind is Ellipsis:
+            return self[:]
+
+        if isinstance(ind, tuple):
+            raise IndexError('unsupported iterator index')
+
+        if isinstance(ind, bool):
+            raise IndexError('unsupported iterator index')
+
+        if numpy.isscalar(ind):
+            ind = int(ind)
+            base = self._base
+            size = base.size
+            indices = []
+            for s in base.shape:
+                size = size // s
+                indices.append(ind // size)
+                ind %= size
+            return base[tuple(indices)].copy()
+
+        if isinstance(ind, slice):
+            base = self._base
+            s = internal.complete_slice(ind, base.size)
+            s_start = s.start
+            s_stop = s.stop
+            s_step = s.step
+            if s_step > 0:
+                size = (s_stop - s_start - 1) // s_step + 1
+            else:
+                size = (s_stop - s_start + 1) // s_step + 1
+            return _flatiter_getitem_slice(base, s_start, s_step, size=size)
+
+        raise IndexError('unsupported iterator index')
+
+
+_flatiter_setitem_slice = core.ElementwiseKernel(
+    'raw T val, int64 start, int64 step', 'raw T a',
+    'a[start + i * step] = val[i % val.size()]',
+    'cupy_flatiter_setitem_slice')
+
+
+_flatiter_getitem_slice = core.ElementwiseKernel(
+    'raw T a, int64 start, int64 step', 'T o',
+    'o = a[start + i * step]',
+    'cupy_flatiter_getitem_slice')

--- a/cupy/indexing/iterate.py
+++ b/cupy/indexing/iterate.py
@@ -84,6 +84,32 @@ class flatiter():
 
         raise IndexError('unsupported iterator index')
 
+    # TODO(Takagi): Implement __iter__ just raising NotImplementedError
+
+    # TODO(Takagi): Implement __next__ just raising NotImplementedError
+
+    # TODO(Takagi): Implement copy
+
+    # TODO(Takagi): Implement base
+
+    # TODO(Takagi): Implement coords
+
+    # TODO(Takagi): Implement index
+
+    # TODO(Takagi): Implement __lt__
+
+    # TODO(Takagi): Implement __le__
+
+    # TODO(Takagi): Implement __eq__
+
+    # TODO(Takagi): Implement __ne__
+
+    # TODO(Takagi): Implement __ge__
+
+    # TODO(Takagi): Implement __gt__
+
+    # TODO(Takagi): Implement __len__
+
 
 _flatiter_setitem_slice = core.ElementwiseKernel(
     'raw T val, int64 start, int64 step', 'raw T a',

--- a/cupy/indexing/iterate.py
+++ b/cupy/indexing/iterate.py
@@ -84,9 +84,9 @@ class flatiter():
 
         raise IndexError('unsupported iterator index')
 
-    # TODO(Takagi): Implement __iter__ just raising NotImplementedError
+    # TODO(Takagi): Implement __iter__
 
-    # TODO(Takagi): Implement __next__ just raising NotImplementedError
+    # TODO(Takagi): Implement __next__
 
     # TODO(Takagi): Implement copy
 

--- a/cupy/indexing/iterate.py
+++ b/cupy/indexing/iterate.py
@@ -53,12 +53,12 @@ class flatiter():
             base = self._base
             s = internal.complete_slice(ind, base.size)
             s_start = s.start
-            s_stop = s.stop
             s_step = s.step
+            size = s.stop - s.start
             if s_step > 0:
-                size = (s_stop - s_start - 1) // s_step + 1
+                size = (size - 1) // s_step + 1
             else:
-                size = (s_stop - s_start + 1) // s_step + 1
+                size = (size + 1) // s_step + 1
             value = cupy.asarray(value, dtype=base.dtype)
             _flatiter_setitem_slice(value, s_start, s_step, base, size=size)
             return
@@ -90,12 +90,12 @@ class flatiter():
             base = self._base
             s = internal.complete_slice(ind, base.size)
             s_start = s.start
-            s_stop = s.stop
             s_step = s.step
+            size = s.stop = s.start
             if s_step > 0:
-                size = (s_stop - s_start - 1) // s_step + 1
+                size = (size - 1) // s_step + 1
             else:
-                size = (s_stop - s_start + 1) // s_step + 1
+                size = (size + 1) // s_step + 1
             return _flatiter_getitem_slice(base, s_start, s_step, size=size)
 
         raise IndexError('unsupported iterator index')

--- a/cupy/indexing/iterate.py
+++ b/cupy/indexing/iterate.py
@@ -91,7 +91,7 @@ class flatiter():
             s = internal.complete_slice(ind, base.size)
             s_start = s.start
             s_step = s.step
-            size = s.stop = s.start
+            size = s.stop - s.start
             if s_step > 0:
                 size = (size - 1) // s_step + 1
             else:

--- a/cupy/indexing/iterate.py
+++ b/cupy/indexing/iterate.py
@@ -6,6 +6,22 @@ from cupy.core import internal
 
 
 class flatiter():
+    """Flat iterator object to iterate over arrays.
+
+    A flatiter iterator is returned by ``x.flat`` for any array ``x``. It
+    allows iterating over the array as if it were a 1-D array, either in a
+    for-loop or by calling its ``next`` method.
+
+    Iteration is done in row-major, C-style order (the last index varying the
+    fastest).
+
+    .. note::
+       Restricted support of basic slicing is currently supplied. Advanced
+       indexing is not supported yet.
+
+    .. seealso:: :func:`numpy.flatiter`
+
+    """
 
     def __init__(self, a):
         self._base = a

--- a/docs/source/reference/indexing.rst
+++ b/docs/source/reference/indexing.rst
@@ -26,3 +26,4 @@ Indexing Routines
    cupy.place
    cupy.put
    cupy.fill_diagonal
+   cupy.flatiter

--- a/tests/cupy_tests/indexing_tests/test_iterate.py
+++ b/tests/cupy_tests/indexing_tests/test_iterate.py
@@ -24,46 +24,52 @@ from cupy import testing
 @testing.gpu
 class TestFlatiterSubscript(unittest.TestCase):
 
+    @testing.for_CF_orders()
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
-    def test_getitem(self, xp, dtype):
-        a = testing.shaped_arange(self.shape, xp, dtype)
+    def test_getitem(self, xp, dtype, order):
+        a = testing.shaped_arange(self.shape, xp, dtype, order)
         return a.flat[self.index]
 
+    @testing.for_CF_orders()
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
-    def test_setitem_scalar(self, xp, dtype):
-        a = xp.zeros(self.shape, dtype=dtype)
+    def test_setitem_scalar(self, xp, dtype, order):
+        a = xp.zeros(self.shape, dtype=dtype, order=order)
         a.flat[self.index] = 1
         return a
 
+    @testing.for_CF_orders()
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
-    def test_setitem_ndarray_1d(self, xp, dtype):
+    def test_setitem_ndarray_1d(self, xp, dtype, order):
         if numpy.isscalar(self.index):
             return xp.array([])  # skip
-        a = xp.zeros(self.shape, dtype=dtype)
-        v = testing.shaped_arange((3,), xp, dtype)
+        a = xp.zeros(self.shape, dtype=dtype, order=order)
+        v = testing.shaped_arange((3,), xp, dtype, order)
         a.flat[self.index] = v
         return a
 
+    @testing.for_CF_orders()
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
-    def test_setitem_ndarray_nd(self, xp, dtype):
+    def test_setitem_ndarray_nd(self, xp, dtype, order):
         if numpy.isscalar(self.index):
             return xp.array([])  # skip
-        a = xp.zeros(self.shape, dtype=dtype)
-        v = testing.shaped_arange((2, 3), xp, dtype)
+        a = xp.zeros(self.shape, dtype=dtype, order=order)
+        v = testing.shaped_arange((2, 3), xp, dtype, order)
         a.flat[self.index] = v
         return a
 
+    @testing.for_CF_orders()
     @testing.for_all_dtypes_combination(('a_dtype', 'v_dtype'))
     @testing.numpy_cupy_array_equal()
-    def test_setitem_ndarray_different_types(self, xp, a_dtype, v_dtype):
+    def test_setitem_ndarray_different_types(
+            self, xp, a_dtype, v_dtype, order):
         if numpy.isscalar(self.index):
             return xp.array([])  # skip
-        a = xp.zeros(self.shape, dtype=a_dtype)
-        v = testing.shaped_arange((3,), xp, v_dtype)
+        a = xp.zeros(self.shape, dtype=a_dtype, order=order)
+        v = testing.shaped_arange((3,), xp, v_dtype, order)
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', numpy.ComplexWarning)
             a.flat[self.index] = v

--- a/tests/cupy_tests/indexing_tests/test_iterate.py
+++ b/tests/cupy_tests/indexing_tests/test_iterate.py
@@ -1,0 +1,94 @@
+import unittest
+import warnings
+
+import numpy
+import pytest
+
+import cupy
+from cupy import testing
+
+
+@testing.parameterize(
+    {'shape': (2, 3, 4), 'index': Ellipsis},
+    {'shape': (2, 3, 4), 'index': 0},
+    {'shape': (2, 3, 4), 'index': 10},
+    {'shape': (2, 3, 4), 'index': slice(None)},
+    {'shape': (2, 3, 4), 'index': slice(None, 10)},
+    {'shape': (2, 3, 4), 'index': slice(None, None, 2)},
+    {'shape': (2, 3, 4), 'index': slice(None, None, -1)},
+    {'shape': (2, 3, 4), 'index': slice(10, None, -1)},
+    {'shape': (2, 3, 4), 'index': slice(10, None, -2)},
+    {'shape': (), 'index': slice(None)},
+    {'shape': (10,), 'index': slice(None)},
+)
+@testing.gpu
+class TestFlatiterSubscript(unittest.TestCase):
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_getitem(self, xp, dtype):
+        a = testing.shaped_arange(self.shape, xp, dtype)
+        return a.flat[self.index]
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_setitem_scalar(self, xp, dtype):
+        a = xp.zeros(self.shape, dtype=dtype)
+        a.flat[self.index] = 1
+        return a
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_setitem_ndarray_1d(self, xp, dtype):
+        if numpy.isscalar(self.index):
+            return xp.array([])  # skip
+        a = xp.zeros(self.shape, dtype=dtype)
+        v = testing.shaped_arange((3,), xp, dtype)
+        a.flat[self.index] = v
+        return a
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_setitem_ndarray_nd(self, xp, dtype):
+        if numpy.isscalar(self.index):
+            return xp.array([])  # skip
+        a = xp.zeros(self.shape, dtype=dtype)
+        v = testing.shaped_arange((2, 3), xp, dtype)
+        a.flat[self.index] = v
+        return a
+
+    @testing.for_all_dtypes_combination(('a_dtype', 'v_dtype'))
+    @testing.numpy_cupy_array_equal()
+    def test_setitem_ndarray_different_types(self, xp, a_dtype, v_dtype):
+        if numpy.isscalar(self.index):
+            return xp.array([])  # skip
+        a = xp.zeros(self.shape, dtype=a_dtype)
+        v = testing.shaped_arange((3,), xp, v_dtype)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', numpy.ComplexWarning)
+            a.flat[self.index] = v
+        return a
+
+
+@testing.parameterize(
+    {'shape': (2, 3, 4), 'index': None},
+    {'shape': (2, 3, 4), 'index': (0,)},
+    {'shape': (2, 3, 4), 'index': True},
+    {'shape': (2, 3, 4), 'index': cupy.array([0])},
+    {'shape': (2, 3, 4), 'index': [0]},
+)
+@testing.gpu
+class TestFlatiterSubscriptIndexError(unittest.TestCase):
+
+    @testing.for_all_dtypes()
+    def test_getitem(self, dtype):
+        a = testing.shaped_arange(self.shape, cupy, dtype)
+        with pytest.raises(IndexError):
+            a.flat[self.index]
+
+    @testing.for_all_dtypes()
+    def test_setitem(self, dtype):
+        a = testing.shaped_arange(self.shape, cupy, dtype)
+        v = testing.shaped_arange((1,), cupy, dtype)
+        with pytest.raises(IndexError):
+            a.flat[self.index] = v


### PR DESCRIPTION
Follows #3139 .

I will post several PRs to implement `cupy.flatiter`. It will have similar interface to `cupy.ndarray` as `numpy.flatiter` does to `numpy.ndarray`. For the first, this PR implements its subscript operators so that we can replace `cupy.fill_diagonal`’s implementation using it.

I suppose that `cupy.flatiter` would not provide its iteration interface, as for-loop or the `next` method,  in contrast to `numpy.fatiter` because iteration is essentially serial concept and does not suit to GPU’s pararell computation model. 
