### PR TITLE
rewrite cupyx.scipy.ndimage.interpolation using ElementwiseKernel

### DIFF
--- a/cupyx/scipy/ndimage/_interp_kernels.py
+++ b/cupyx/scipy/ndimage/_interp_kernels.py
@@ -1,0 +1,400 @@
+import cupy
+import cupy.core.internal
+
+from .filters import _generate_boundary_condition_ops
+_prod = cupy.core.internal.prod
+
+
+def _get_coord_map(ndim):
+    """Extract target coordinate from coords array (for map_coordinates).
+
+    Notes
+    -----
+    Assumes the following variables have been initialized on the device::
+
+        coords (ndarray): array of shape (ncoords, ndim) containing the target
+            coordinates.
+        c_j: variables to hold the target coordinates
+
+    computes::
+
+        c_j = coords[i + j * ncoords];
+
+    ncoords is determined by the size of the output array, y.
+    y will be indexed by the CIndexer, _ind.
+    Thus ncoords = _ind.size();
+
+    """
+    ops = []
+    ops.append('ptrdiff_t ncoords = _ind.size();')
+    for j in range(ndim):
+        ops.append(
+            """
+    W c_{j} = coords[i + {j} * ncoords];
+            """.format(j=j))
+    return ops
+
+
+def _get_coord_zoom_and_shift(ndim):
+    """Compute target coordinate based on a shift followed by a zoom.
+
+    Notes
+    -----
+    Assumes the following variables have been initialized on the device::
+
+        in_coord[ndim]: array containing the source coordinate
+        zoom[ndim]: array containing the zoom for each axis
+        shift[ndim]: array containing the zoom for each axis
+
+    computes::
+
+        c_j = zoom[j] * (in_coord[j] - shift[j])
+
+    """
+    ops = []
+    for j in range(ndim):
+        ops.append(
+            """
+    W c_{j} = zoom[{j}] * ((W)in_coord[{j}] - shift[{j}]);
+            """.format(j=j))
+    return ops
+
+
+def _get_coord_zoom(ndim):
+    """Compute target coordinate based on a zoom.
+
+    Notes
+    -----
+    Assumes the following variables have been initialized on the device::
+
+        in_coord[ndim]: array containing the source coordinate
+        zoom[ndim]: array containing the zoom for each axis
+
+    computes::
+
+        c_j = zoom[j] * in_coord[j]
+
+    """
+    ops = []
+    for j in range(ndim):
+        ops.append(
+            """
+    W c_{j} = zoom[{j}] * (W)in_coord[{j}];
+            """.format(j=j))
+    return ops
+
+
+def _get_coord_shift(ndim):
+    """Compute target coordinate based on a shift.
+
+    Notes
+    -----
+    Assumes the following variables have been initialized on the device::
+
+        in_coord[ndim]: array containing the source coordinate
+        shift[ndim]: array containing the zoom for each axis
+
+    computes::
+
+        c_j = in_coord[j] - shift[j]
+
+    """
+    ops = []
+    for j in range(ndim):
+        ops.append(
+            """
+    W c_{j} = (W)in_coord[{j}] - shift[{j}];
+            """.format(j=j))
+    return ops
+
+
+def _get_coord_affine(ndim):
+    """Compute target coordinate based on a homogeneous transformation matrix.
+
+    The homogeneous matrix has shape (ndim, ndim + 1). It corresponds to
+    affine matrix where the last row of the affine is assumed to be:
+    ``[0] * ndim + [1]``.
+
+    Notes
+    -----
+    Assumes the following variables have been initialized on the device::
+
+        mat(array): array containing the (ndim, ndim + 1) transform matrix.
+        in_coords(array): coordinates of the input
+
+    For example, in 2D:
+
+        c_0 = mat[0] * in_coords[0] + mat[1] * in_coords[1] + aff[2];
+        c_1 = mat[3] * in_coords[0] + mat[4] * in_coords[1] + aff[5];
+
+    """
+    ops = []
+    ncol = ndim + 1
+    for j in range(ndim):
+        ops.append("""
+            W c_{j} = (W)0.0;
+            """.format(j=j))
+        for k in range(ndim):
+            m_index = ncol * j + k
+            ops.append(
+                """
+            c_{j} += mat[{m_index}] * (W)in_coord[{k}];
+                """.format(j=j, k=k, m_index=m_index))
+        ops.append(
+            """
+            c_{j} += mat[{m_index}];
+            """.format(j=j, m_index=ncol * j + ndim))
+    return ops
+
+
+def _generate_interp_custom(coord_func, xshape, yshape, mode, cval, order,
+                            name='', integer_output=False):
+    """
+    Args:
+        coord_func (function): generates code to do the coordinate
+            transformation. See for example, `_get_coord_shift`.
+        xshape (tuple): Shape of the array to be transformed.
+        yshape (tuple): Shape of the output array.
+        mode (str): Signal extension mode to use at the array boundaries
+        cval (float): constant value used when `mode == 'constant'`.
+        name (str): base name for the interpolation kernel
+        integer_output (bool): boolean indicating whether the output has an
+            integer type.
+
+    Returns:
+        operation (str): code body for the ElementwiseKernel
+        name (str): name for the ElementwiseKernel
+    """
+
+    ndim = len(xshape)
+
+    ops = []
+    ops.append('double out = 0.0;')
+
+    size = max(_prod(xshape), _prod(yshape))
+    if (size > 1 << 31):
+        uint_t = 'size_t'
+        int_t = 'ptrdiff_t'
+    else:
+        uint_t = 'unsigned int'
+        int_t = 'int'
+    ops.append('{uint_t} in_coord[{ndim}];'.format(
+        uint_t=uint_t, ndim=ndim))
+
+    # determine strides for x along each axis
+    ops.append(
+        'const {uint_t} sx_{j} = 1;'.format(uint_t=uint_t, j=ndim - 1))
+    for j in range(ndim - 1, 0, -1):
+        ops.append(
+            'const {uint_t} sx_{jm} = sx_{j} * {xsize_j};'.format(
+                uint_t=uint_t, jm=j - 1, j=j, xsize_j=xshape[j]
+            )
+        )
+
+    # determine nd coordinate in x corresponding to a given raveled coordinate,
+    # i, in y.
+    ops.append("""
+        {uint_t} idx = i;
+        {uint_t} s, t;
+        """.format(uint_t=uint_t))
+    for j in range(ndim - 1, 0, -1):
+        ops.append("""
+        s = {zsize_j};
+        t = idx / s;
+        in_coord[{j}] = idx - t * s;
+        idx = t;
+        """.format(j=j, zsize_j=yshape[j]))
+    ops.append("in_coord[0] = idx;")
+
+    # compute the transformed (target) coordinates, c_j
+    ops = ops + coord_func(ndim)
+
+    if mode == 'constant':
+        # use cval if coordinate is outside the bounds of x
+        _cond = ' || '.join(
+            ['(c_{j} < 0) || (c_{j} > {cmax})'.format(j=j, cmax=xshape[j] - 1)
+             for j in range(ndim)])
+        ops.append("""
+        if ({cond})
+        {{
+            out = (double){cval};
+        }}
+        else
+        {{""".format(cond=_cond, cval=cval))
+
+    if order == 0:
+        for j in range(ndim):
+            # determine nearest neighbor
+            ops.append("""
+            {int_t} cf_{j} = ({int_t})lrint((double)c_{j});
+            """.format(int_t=int_t, j=j))
+
+            # handle boundary
+            if mode != 'constant':
+                ixvar = 'cf_{j}'.format(j=j)
+                ops.append(
+                    _generate_boundary_condition_ops(
+                        mode, ixvar, xshape[j]))
+
+            # sum over ic_j will give the raveled coordinate in the input
+            ops.append("""
+            {int_t} ic_{j} = cf_{j} * sx_{j};
+            """.format(int_t=int_t, j=j))
+        _coord_idx = ' + '.join(['ic_{}'.format(j) for j in range(ndim)])
+        ops.append("""
+            out = x[{coord_idx}];
+            """.format(coord_idx=_coord_idx))
+
+    elif order == 1:
+        for j in range(ndim):
+            # get coordinates for linear interpolation along axis j
+            ops.append("""
+            {int_t} cf_{j} = ({int_t})floor((double)c_{j});
+            {int_t} cc_{j} = cf_{j} + 1;
+            {int_t} n_{j} = (c_{j} == cf_{j}) ? 1 : 2;  // points needed
+            """.format(int_t=int_t, j=j))
+
+            # handle boundaries for extension modes.
+            ops.append("""
+            {int_t} cf_bounded_{j} = cf_{j};
+            {int_t} cc_bounded_{j} = cc_{j};
+            """.format(int_t=int_t, j=j))
+            if mode != 'constant':
+                ixvar = 'cf_bounded_{j}'.format(j=j)
+                ops.append(
+                    _generate_boundary_condition_ops(
+                        mode, ixvar, xshape[j]))
+                ixvar = 'cc_bounded_{j}'.format(j=j)
+                ops.append(
+                    _generate_boundary_condition_ops(
+                        mode, ixvar, xshape[j]))
+
+            ops.append("""
+            for (int s_{j} = 0; s_{j} < n_{j}; s_{j}++)
+                {{
+                    W w_{j};
+                    {int_t} ic_{j};
+                    if (s_{j} == 0)
+                    {{
+                        w_{j} = (W)cc_{j} - c_{j};
+                        ic_{j} = cf_bounded_{j} * sx_{j};
+                    }} else
+                    {{
+                        w_{j} = c_{j} - (W)cf_{j};
+                        ic_{j} = cc_bounded_{j} * sx_{j};
+                    }}""".format(int_t=int_t, j=j))
+
+        _weight = ' * '.join(['w_{j}'.format(j=j) for j in range(ndim)])
+        _coord_idx = ' + '.join(['ic_{j}'.format(j=j) for j in range(ndim)])
+        ops.append("""
+        X val = x[{coord_idx}];
+        out += val * ({weight});
+        """.format(coord_idx=_coord_idx, weight=_weight))
+        ops.append('}' * ndim)
+
+    if mode == 'constant':
+        ops.append('}')
+
+    if integer_output:
+        ops.append('y = (Y)rint((double)out);')
+    else:
+        ops.append('y = (Y)out;')
+    operation = '\n'.join(ops)
+
+    name = 'interpolate_{}_order{}_{}_x{}_y{}'.format(
+        name,
+        order,
+        mode,
+        '_'.join(['{}'.format(j) for j in xshape]),
+        '_'.join(['{}'.format(j) for j in yshape]),
+    )
+    return operation, name
+
+
+@cupy.util.memoize()
+def _get_map_kernel(xshape, mode, cval=0.0, order=1, integer_output=False):
+    in_params = 'raw X x, raw W coords'
+    out_params = 'Y y'
+    operation, name = _generate_interp_custom(
+        coord_func=_get_coord_map,
+        xshape=xshape,
+        yshape=xshape,
+        mode=mode,
+        cval=cval,
+        order=order,
+        name='shift',
+        integer_output=integer_output,
+    )
+    return cupy.ElementwiseKernel(in_params, out_params, operation, name)
+
+
+@cupy.util.memoize()
+def _get_shift_kernel(xshape, yshape, mode, cval=0.0, order=1,
+                      integer_output=False):
+    in_params = 'raw X x, raw W shift'
+    out_params = 'Y y'
+    operation, name = _generate_interp_custom(
+        coord_func=_get_coord_shift,
+        xshape=xshape,
+        yshape=yshape,
+        mode=mode,
+        cval=cval,
+        order=order,
+        name='shift',
+        integer_output=integer_output,
+    )
+    return cupy.ElementwiseKernel(in_params, out_params, operation, name)
+
+
+@cupy.util.memoize()
+def _get_zoom_shift_kernel(xshape, yshape, mode, cval=0.0, order=1,
+                           integer_output=False):
+    in_params = 'raw X x, raw W shift, raw W zoom'
+    out_params = 'Y y'
+    operation, name = _generate_interp_custom(
+        coord_func=_get_coord_zoom_and_shift,
+        xshape=xshape,
+        yshape=yshape,
+        mode=mode,
+        cval=cval,
+        order=order,
+        name='zoom_shift',
+        integer_output=integer_output,
+    )
+    return cupy.ElementwiseKernel(in_params, out_params, operation, name)
+
+
+@cupy.util.memoize()
+def _get_zoom_kernel(xshape, yshape, mode, cval=0.0, order=1,
+                     integer_output=False):
+    in_params = 'raw X x, raw W zoom'
+    out_params = 'Y y'
+    operation, name = _generate_interp_custom(
+        coord_func=_get_coord_zoom,
+        xshape=xshape,
+        yshape=yshape,
+        mode=mode,
+        cval=cval,
+        order=order,
+        name='zoom',
+        integer_output=integer_output,
+    )
+    return cupy.ElementwiseKernel(in_params, out_params, operation, name)
+
+
+@cupy.util.memoize()
+def _get_affine_kernel(xshape, yshape, mode, cval=0.0, order=1,
+                       integer_output=False):
+    in_params = 'raw X x, raw W mat'
+    out_params = 'Y y'
+    operation, name = _generate_interp_custom(
+        coord_func=_get_coord_affine,
+        xshape=xshape,
+        yshape=yshape,
+        mode=mode,
+        cval=cval,
+        order=order,
+        name='affine',
+        integer_output=integer_output,
+    )
+    return cupy.ElementwiseKernel(in_params, out_params, operation, name)

--- a/cupyx/scipy/ndimage/_interp_kernels.py
+++ b/cupyx/scipy/ndimage/_interp_kernels.py
@@ -1,7 +1,7 @@
 import cupy
 import cupy.core.internal
 
-from .filters import _generate_boundary_condition_ops
+from cupyx.scipy.ndimage import filters
 
 
 def _get_coord_map(ndim):
@@ -243,7 +243,7 @@ def _generate_interp_custom(coord_func, ndim, large_int, yshape, mode, cval,
             if mode != 'constant':
                 ixvar = 'cf_{j}'.format(j=j)
                 ops.append(
-                    _generate_boundary_condition_ops(
+                    filters._generate_boundary_condition_ops(
                         mode, ixvar, 'xsize_{}'.format(j)))
 
             # sum over ic_j will give the raveled coordinate in the input
@@ -272,11 +272,11 @@ def _generate_interp_custom(coord_func, ndim, large_int, yshape, mode, cval,
             if mode != 'constant':
                 ixvar = 'cf_bounded_{j}'.format(j=j)
                 ops.append(
-                    _generate_boundary_condition_ops(
+                    filters._generate_boundary_condition_ops(
                         mode, ixvar, 'xsize_{}'.format(j)))
                 ixvar = 'cc_bounded_{j}'.format(j=j)
                 ops.append(
-                    _generate_boundary_condition_ops(
+                    filters._generate_boundary_condition_ops(
                         mode, ixvar, 'xsize_{}'.format(j)))
 
             ops.append("""

--- a/cupyx/scipy/ndimage/_interp_kernels.py
+++ b/cupyx/scipy/ndimage/_interp_kernels.py
@@ -202,7 +202,8 @@ def _generate_interp_custom(coord_func, ndim, large_int, yshape, mode, cval,
     # determine strides for x along each axis
     for j in range(ndim):
         ops.append(
-            'const {int_t} xsize_{j} = x.shape()[{j}];'.format(int_t=int_t, j=j)
+            'const {int_t} xsize_{j} = x.shape()[{j}];'.format(
+                int_t=int_t, j=j)
         )
     ops.append('const {uint_t} sx_{j} = 1;'.format(uint_t=uint_t, j=ndim - 1))
     for j in range(ndim - 1, 0, -1):

--- a/cupyx/scipy/ndimage/_interp_kernels.py
+++ b/cupyx/scipy/ndimage/_interp_kernels.py
@@ -134,7 +134,7 @@ def _get_coord_affine(ndim):
             ops.append(
                 """
             c_{j} += mat[{m_index}] * (W)in_coord[{k}];""".format(
-                j=j, k=k, m_index=m_index))
+                    j=j, k=k, m_index=m_index))
         ops.append(
             """
             c_{j} += mat[{m_index}];""".format(

--- a/cupyx/scipy/ndimage/_interp_kernels.py
+++ b/cupyx/scipy/ndimage/_interp_kernels.py
@@ -29,8 +29,7 @@ def _get_coord_map(ndim):
     for j in range(ndim):
         ops.append(
             """
-    W c_{j} = coords[i + {j} * ncoords];
-            """.format(j=j))
+    W c_{j} = coords[i + {j} * ncoords];""".format(j=j))
     return ops
 
 
@@ -54,8 +53,7 @@ def _get_coord_zoom_and_shift(ndim):
     for j in range(ndim):
         ops.append(
             """
-    W c_{j} = zoom[{j}] * ((W)in_coord[{j}] - shift[{j}]);
-            """.format(j=j))
+    W c_{j} = zoom[{j}] * ((W)in_coord[{j}] - shift[{j}]);""".format(j=j))
     return ops
 
 
@@ -78,8 +76,7 @@ def _get_coord_zoom(ndim):
     for j in range(ndim):
         ops.append(
             """
-    W c_{j} = zoom[{j}] * (W)in_coord[{j}];
-            """.format(j=j))
+    W c_{j} = zoom[{j}] * (W)in_coord[{j}];""".format(j=j))
     return ops
 
 
@@ -102,8 +99,7 @@ def _get_coord_shift(ndim):
     for j in range(ndim):
         ops.append(
             """
-    W c_{j} = (W)in_coord[{j}] - shift[{j}];
-            """.format(j=j))
+    W c_{j} = (W)in_coord[{j}] - shift[{j}];""".format(j=j))
     return ops
 
 
@@ -137,12 +133,12 @@ def _get_coord_affine(ndim):
             m_index = ncol * j + k
             ops.append(
                 """
-            c_{j} += mat[{m_index}] * (W)in_coord[{k}];
-                """.format(j=j, k=k, m_index=m_index))
+            c_{j} += mat[{m_index}] * (W)in_coord[{k}];""".format(
+                j=j, k=k, m_index=m_index))
         ops.append(
             """
-            c_{j} += mat[{m_index}];
-            """.format(j=j, m_index=ncol * j + ndim))
+            c_{j} += mat[{m_index}];""".format(
+                j=j, m_index=ncol * j + ndim))
     return ops
 
 
@@ -155,15 +151,13 @@ def _unravel_loop_index(shape, uint_t='unsigned int'):
     code = [
         """
         {uint_t} in_coord[{ndim}];
-        {uint_t} s, t, idx = i;
-        """.format(uint_t=uint_t, ndim=ndim)]
+        {uint_t} s, t, idx = i;""".format(uint_t=uint_t, ndim=ndim)]
     for j in range(ndim - 1, 0, -1):
         code.append("""
         s = {size};
         t = idx / s;
         in_coord[{j}] = idx - t * s;
-        idx = t;
-        """.format(j=j, size=shape[j]))
+        idx = t;""".format(j=j, size=shape[j]))
     code.append("""
         in_coord[0] = idx;""")
     return '\n'.join(code)
@@ -252,8 +246,7 @@ def _generate_interp_custom(coord_func, ndim, large_int, yshape, mode, cval,
             """.format(int_t=int_t, j=j))
         _coord_idx = ' + '.join(['ic_{}'.format(j) for j in range(ndim)])
         ops.append("""
-            out = x[{coord_idx}];
-            """.format(coord_idx=_coord_idx))
+            out = x[{coord_idx}];""".format(coord_idx=_coord_idx))
 
     elif order == 1:
         for j in range(ndim):
@@ -298,8 +291,8 @@ def _generate_interp_custom(coord_func, ndim, large_int, yshape, mode, cval,
         _coord_idx = ' + '.join(['ic_{j}'.format(j=j) for j in range(ndim)])
         ops.append("""
         X val = x[{coord_idx}];
-        out += val * ({weight});
-        """.format(coord_idx=_coord_idx, weight=_weight))
+        out += val * ({weight});""".format(
+            coord_idx=_coord_idx, weight=_weight))
         ops.append('}' * ndim)
 
     if mode == 'constant':

--- a/cupyx/scipy/ndimage/_interp_kernels.py
+++ b/cupyx/scipy/ndimage/_interp_kernels.py
@@ -311,7 +311,7 @@ def _generate_interp_custom(coord_func, xshape, yshape, mode, cval, order,
     return operation, name
 
 
-@cupy.util.memoize()
+@cupy.util.memoize(for_each_device=True)
 def _get_map_kernel(xshape, mode, cval=0.0, order=1, integer_output=False):
     in_params = 'raw X x, raw W coords'
     out_params = 'Y y'
@@ -328,7 +328,7 @@ def _get_map_kernel(xshape, mode, cval=0.0, order=1, integer_output=False):
     return cupy.ElementwiseKernel(in_params, out_params, operation, name)
 
 
-@cupy.util.memoize()
+@cupy.util.memoize(for_each_device=True)
 def _get_shift_kernel(xshape, yshape, mode, cval=0.0, order=1,
                       integer_output=False):
     in_params = 'raw X x, raw W shift'
@@ -346,7 +346,7 @@ def _get_shift_kernel(xshape, yshape, mode, cval=0.0, order=1,
     return cupy.ElementwiseKernel(in_params, out_params, operation, name)
 
 
-@cupy.util.memoize()
+@cupy.util.memoize(for_each_device=True)
 def _get_zoom_shift_kernel(xshape, yshape, mode, cval=0.0, order=1,
                            integer_output=False):
     in_params = 'raw X x, raw W shift, raw W zoom'
@@ -364,7 +364,7 @@ def _get_zoom_shift_kernel(xshape, yshape, mode, cval=0.0, order=1,
     return cupy.ElementwiseKernel(in_params, out_params, operation, name)
 
 
-@cupy.util.memoize()
+@cupy.util.memoize(for_each_device=True)
 def _get_zoom_kernel(xshape, yshape, mode, cval=0.0, order=1,
                      integer_output=False):
     in_params = 'raw X x, raw W zoom'

--- a/cupyx/scipy/ndimage/interpolation.py
+++ b/cupyx/scipy/ndimage/interpolation.py
@@ -12,6 +12,9 @@ from ._interp_kernels import (
     _get_affine_kernel)
 
 
+_prod = cupy.core.internal.prod
+
+
 def _get_output(output, input, shape=None):
     if shape is None:
         shape = input.shape
@@ -100,7 +103,9 @@ def map_coordinates(input, coordinates, output=None, order=None,
     if input.dtype.kind in 'iu':
         input = input.astype(cupy.float32)
 
-    kern = _get_map_kernel(input.shape, mode=mode, cval=cval, order=order,
+    large_int = max(_prod(input.shape), coordinates.shape[0]) > 1 << 31
+    kern = _get_map_kernel(input.ndim, large_int, yshape=coordinates.shape,
+                           mode=mode, cval=cval, order=order,
                            integer_output=integer_output)
     kern(input, coordinates, ret)
     return ret
@@ -196,16 +201,17 @@ def affine_transform(input, matrix, offset=0.0, output_shape=None, output=None,
     if input.dtype.kind in 'iu':
         input = input.astype(cupy.float32)
     integer_output = output.dtype.kind in 'iu'
+    large_int = max(_prod(input.shape), _prod(output_shape)) > 1 << 31
     if matrix.ndim == 1:
         offset = cupy.asarray(offset, dtype=float)
         offset = -offset / matrix
         kern = _get_zoom_shift_kernel(
-            input.shape, output_shape, mode, cval=cval, order=order,
+            ndim, large_int, output_shape, mode, cval=cval, order=order,
             integer_output=integer_output)
         kern(input, offset, matrix, output)
     else:
         kern = _get_affine_kernel(
-            input.shape, output_shape, mode, cval=cval, order=order,
+            ndim, large_int, output_shape, mode, cval=cval, order=order,
             integer_output=integer_output)
         m = cupy.zeros((ndim, ndim + 1), dtype=float)
         m[:, :-1] = matrix
@@ -383,8 +389,9 @@ def shift(input, shift, output=None, order=None, mode='constant', cval=0.0,
         if input.dtype.kind in "iu":
             input = input.astype(cupy.float32)
         integer_output = output.dtype.kind in "iu"
+        large_int = _prod(input.shape) > 1 << 31
         kern = _get_shift_kernel(
-            input.shape, input.shape, mode, cval=cval, order=order,
+            input.ndim, large_int, input.shape, mode, cval=cval, order=order,
             integer_output=integer_output)
         shift = cupy.asarray(shift, dtype=float)
         kern(input, shift, output)
@@ -470,9 +477,11 @@ def zoom(input, zoom, output=None, order=None, mode='constant', cval=0.0,
         if input.dtype.kind in "iu":
             input = input.astype(cupy.float32)
         integer_output = output.dtype.kind in "iu"
+        large_int = max(_prod(input.shape), _prod(output_shape)) > 1 << 31
         kern = _get_zoom_kernel(
-            input.shape, output_shape, mode, order=order,
+            input.ndim, large_int, output_shape, mode, order=order,
             integer_output=integer_output)
         zoom = cupy.asarray(zoom, dtype=float)
         kern(input, zoom, output)
     return output
+

--- a/cupyx/scipy/ndimage/interpolation.py
+++ b/cupyx/scipy/ndimage/interpolation.py
@@ -163,7 +163,7 @@ def affine_transform(input, matrix, offset=0.0, output_shape=None, output=None,
     if not hasattr(offset, '__iter__') and type(offset) is not cupy.ndarray:
         offset = [offset] * input.ndim
 
-    if matrix.ndim not in [1, 2]:
+    if matrix.ndim not in [1, 2] or matrix.shape[0] < 1:
         raise RuntimeError('no proper affine matrix provided')
     if matrix.ndim == 2:
         if matrix.shape[0] == matrix.shape[1] - 1:
@@ -172,6 +172,8 @@ def affine_transform(input, matrix, offset=0.0, output_shape=None, output=None,
         elif matrix.shape[0] == input.ndim + 1:
             offset = matrix[:-1, -1]
             matrix = matrix[:-1, :-1]
+        if matrix.shape != (input.ndim, input.ndim):
+            raise RuntimeError("improper affine shape")
 
     if mode == 'opencv':
         m = cupy.zeros((input.ndim + 1, input.ndim + 1))

--- a/cupyx/scipy/ndimage/interpolation.py
+++ b/cupyx/scipy/ndimage/interpolation.py
@@ -4,13 +4,7 @@ import warnings
 import cupy
 import numpy
 
-from ._interp_kernels import (
-    _get_map_kernel,
-    _get_shift_kernel,
-    _get_zoom_kernel,
-    _get_zoom_shift_kernel,
-    _get_affine_kernel)
-
+from cupyx.scipy.ndimage import _interp_kernels
 
 _prod = cupy.core.internal.prod
 
@@ -104,9 +98,9 @@ def map_coordinates(input, coordinates, output=None, order=None,
         input = input.astype(cupy.float32)
 
     large_int = max(_prod(input.shape), coordinates.shape[0]) > 1 << 31
-    kern = _get_map_kernel(input.ndim, large_int, yshape=coordinates.shape,
-                           mode=mode, cval=cval, order=order,
-                           integer_output=integer_output)
+    kern = _interp_kernels._get_map_kernel(
+        input.ndim, large_int, yshape=coordinates.shape, mode=mode, cval=cval,
+        order=order, integer_output=integer_output)
     kern(input, coordinates, ret)
     return ret
 
@@ -205,12 +199,12 @@ def affine_transform(input, matrix, offset=0.0, output_shape=None, output=None,
     if matrix.ndim == 1:
         offset = cupy.asarray(offset, dtype=float)
         offset = -offset / matrix
-        kern = _get_zoom_shift_kernel(
+        kern = _interp_kernels._get_zoom_shift_kernel(
             ndim, large_int, output_shape, mode, cval=cval, order=order,
             integer_output=integer_output)
         kern(input, offset, matrix, output)
     else:
-        kern = _get_affine_kernel(
+        kern = _interp_kernels._get_affine_kernel(
             ndim, large_int, output_shape, mode, cval=cval, order=order,
             integer_output=integer_output)
         m = cupy.zeros((ndim, ndim + 1), dtype=float)
@@ -390,7 +384,7 @@ def shift(input, shift, output=None, order=None, mode='constant', cval=0.0,
             input = input.astype(cupy.float32)
         integer_output = output.dtype.kind in "iu"
         large_int = _prod(input.shape) > 1 << 31
-        kern = _get_shift_kernel(
+        kern = _interp_kernels._get_shift_kernel(
             input.ndim, large_int, input.shape, mode, cval=cval, order=order,
             integer_output=integer_output)
         shift = cupy.asarray(shift, dtype=float)
@@ -478,7 +472,7 @@ def zoom(input, zoom, output=None, order=None, mode='constant', cval=0.0,
             input = input.astype(cupy.float32)
         integer_output = output.dtype.kind in "iu"
         large_int = max(_prod(input.shape), _prod(output_shape)) > 1 << 31
-        kern = _get_zoom_kernel(
+        kern = _interp_kernels._get_zoom_kernel(
             input.ndim, large_int, output_shape, mode, order=order,
             integer_output=integer_output)
         zoom = cupy.asarray(zoom, dtype=float)

--- a/cupyx/scipy/ndimage/interpolation.py
+++ b/cupyx/scipy/ndimage/interpolation.py
@@ -484,4 +484,3 @@ def zoom(input, zoom, output=None, order=None, mode='constant', cval=0.0,
         zoom = cupy.asarray(zoom, dtype=float)
         kern(input, zoom, output)
     return output
-

--- a/cupyx/scipy/ndimage/interpolation.py
+++ b/cupyx/scipy/ndimage/interpolation.py
@@ -196,6 +196,7 @@ def affine_transform(input, matrix, offset=0.0, output_shape=None, output=None,
     output = _get_output(output, input, shape=output_shape)
     if input.dtype.kind in 'iu':
         input = input.astype(cupy.float32)
+
     integer_output = output.dtype.kind in 'iu'
     large_int = max(_prod(input.shape), _prod(output_shape)) > 1 << 31
     if matrix.ndim == 1:

--- a/cupyx/scipy/ndimage/interpolation.py
+++ b/cupyx/scipy/ndimage/interpolation.py
@@ -1,4 +1,3 @@
-import itertools
 import math
 import warnings
 
@@ -320,7 +319,6 @@ def rotate(input, angle, axes=(1, 0), reshape=True, output=None, order=None,
     matrix = cupy.asarray(matrix)
     offset = cupy.asarray(offset)
 
-
     return affine_transform(input, matrix, offset, output_shape, output, order,
                             mode, cval, prefilter)
 
@@ -391,6 +389,7 @@ def shift(input, shift, output=None, order=None, mode='constant', cval=0.0,
         shift = cupy.asarray(shift, dtype=float)
         kern(input, shift, output)
     return output
+
 
 def zoom(input, zoom, output=None, order=None, mode='constant', cval=0.0,
          prefilter=True):

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
@@ -168,7 +168,6 @@ class TestAffineExceptions(unittest.TestCase):
         ndimage_modules = (scipy.ndimage, cupyx.scipy.ndimage)
         for (xp, ndi) in zip((numpy, cupy), ndimage_modules):
             x = xp.ones((8, 8, 8))
-            angle = 15
             with pytest.raises(RuntimeError):
                 ndi.affine_transform(x, xp.ones((3, 3, 3)))
             with pytest.raises(RuntimeError):
@@ -178,7 +177,6 @@ class TestAffineExceptions(unittest.TestCase):
         ndimage_modules = (scipy.ndimage, cupyx.scipy.ndimage)
         for (xp, ndi) in zip((numpy, cupy), ndimage_modules):
             x = xp.ones((8, 8, 8))
-            angle = 15
             with pytest.raises(RuntimeError):
                 ndi.affine_transform(x, xp.ones((0, 3)))
             with pytest.raises(RuntimeError):

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
@@ -270,7 +270,8 @@ class TestRotate(unittest.TestCase):
 
 
 @testing.gpu
-@testing.with_requires('scipy')
+# Scipy older than 1.3.0 raises IndexError instead of ValueError
+@testing.with_requires('scipy>=1.3.0')
 class TestRotateExceptions(unittest.TestCase):
 
     def test_rotate_invalid_plane(self):

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
@@ -53,6 +53,15 @@ class TestMapCoordinates(unittest.TestCase):
 
     @testing.for_float_dtypes(no_float16=True)
     @testing.numpy_cupy_allclose(atol=1e-5, scipy_name='scp')
+    def test_map_coordinates_fortran_order(self, xp, scp, dtype):
+        a = testing.shaped_random((100, 100), xp, dtype)
+        coordinates = testing.shaped_random((a.ndim, 100), xp, dtype)
+        a = xp.asfortranarray(a)
+        coordinates = xp.asfortranarray(coordinates)
+        return self._map_coordinates(xp, scp, a, coordinates)
+
+    @testing.for_float_dtypes(no_float16=True)
+    @testing.numpy_cupy_allclose(atol=1e-5, scipy_name='scp')
     def test_map_coordinates_float_nd_coords(self, xp, scp, dtype):
         a = testing.shaped_random((100, 100), xp, dtype)
         coordinates = testing.shaped_random((a.ndim, 10, 10), xp, dtype,
@@ -121,6 +130,15 @@ class TestAffineTransform(unittest.TestCase):
     def test_affine_transform_float(self, xp, scp, dtype):
         a = testing.shaped_random((100, 100), xp, dtype)
         matrix = testing.shaped_random(self.matrix_shape, xp, dtype)
+        return self._affine_transform(xp, scp, a, matrix)
+
+    @testing.for_float_dtypes(no_float16=True)
+    @testing.numpy_cupy_allclose(atol=1e-5, scipy_name='scp')
+    def test_affine_transform_fortran_order(self, xp, scp, dtype):
+        a = testing.shaped_random((100, 100), xp, dtype)
+        a = xp.asfortranarray(a)
+        matrix = testing.shaped_random(self.matrix_shape, xp, dtype)
+        matrix = xp.asfortranarray(matrix)
         return self._affine_transform(xp, scp, a, matrix)
 
     @testing.for_int_dtypes(no_bool=True)
@@ -229,6 +247,13 @@ class TestRotate(unittest.TestCase):
         a = testing.shaped_random((10, 10), xp, dtype)
         return self._rotate(xp, scp, a)
 
+    @testing.for_float_dtypes(no_float16=True)
+    @testing.numpy_cupy_allclose(atol=1e-5, scipy_name='scp')
+    def test_rotate_fortran_order(self, xp, scp, dtype):
+        a = testing.shaped_random((10, 10), xp, dtype)
+        a = xp.asfortranarray(a)
+        return self._rotate(xp, scp, a)
+
     @testing.for_int_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose(atol=1e-5, scipy_name='scp')
     def test_rotate_int(self, xp, scp, dtype):
@@ -331,6 +356,13 @@ class TestShift(unittest.TestCase):
         a = testing.shaped_random((100, 100), xp, dtype)
         return self._shift(xp, scp, a)
 
+    @testing.for_float_dtypes(no_float16=True)
+    @testing.numpy_cupy_allclose(atol=1e-5, scipy_name='scp')
+    def test_shift_fortran_order(self, xp, scp, dtype):
+        a = testing.shaped_random((100, 100), xp, dtype)
+        a = xp.asfortranarray(a)
+        return self._shift(xp, scp, a)
+
     @testing.for_int_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose(atol=1e-5, scipy_name='scp')
     def test_shift_int(self, xp, scp, dtype):
@@ -398,6 +430,13 @@ class TestZoom(unittest.TestCase):
     @testing.numpy_cupy_allclose(atol=1e-5, scipy_name='scp')
     def test_zoom_float(self, xp, scp, dtype):
         a = testing.shaped_random((100, 100), xp, dtype)
+        return self._zoom(xp, scp, a)
+
+    @testing.for_float_dtypes(no_float16=True)
+    @testing.numpy_cupy_allclose(atol=1e-5, scipy_name='scp')
+    def test_zoom_fortran_order(self, xp, scp, dtype):
+        a = testing.shaped_random((100, 100), xp, dtype)
+        a = xp.asfortranarray(a)
         return self._zoom(xp, scp, a)
 
     @testing.for_int_dtypes(no_bool=True)


### PR DESCRIPTION
This PR improves the performance and reduces memory usage for the `cupyx.scipy.ndimage.interpolation` module. There should be no change in behavior from the prior implementation.

Memory overhead in various functions like `affine_transform` is greatly reduced by not explicitly generating dense n-dimensional coordinate arrays.

closes #2607
also resolves some issues with performance that were previously reported in: #1168, #2345, #2844

Will post the benchmarks in a follow-up comment, but performance is greatly improved on all cases I tested.

The main downside to this PR is that such template-based code generation is a bit harder to read than the previous implementations, but I tried to add some comments describing what is going on. 
