### PR TITLE
Improve ndimage convolve/correlate

### DIFF
--- a/cupyx/scipy/ndimage/filters.py
+++ b/cupyx/scipy/ndimage/filters.py
@@ -151,8 +151,8 @@ def _generate_correlete_kernel(ndim, mode, cval, xshape, wshape, origin):
     out_params = 'Y y'
 
     ops = []
-    ops.append('X* _x = (X*)&(x[0]);')
-    ops.append('W* _w = (W*)&(w[0]);')
+    ops.append('X* x_data = (X*)&(x[0]);')
+    ops.append('W* w_data = (W*)&(w[0]);')
     ops.append('const int sx_{} = 1;'.format(ndim-1))
     for j in range(ndim-1, 0, -1):
         ops.append('int sx_{jm} = sx_{j} * {xsize_j};'.
@@ -177,7 +177,7 @@ def _generate_correlete_kernel(ndim, mode, cval, xshape, wshape, origin):
         ops.append('        ix_{j} *= sx_{j};'.format(j=j))
 
     ops.append('''
-        W wval = _w[iw];
+        W wval = w_data[iw];
         if (wval == (W)0) {{
             iw += 1;
             continue;
@@ -189,7 +189,7 @@ def _generate_correlete_kernel(ndim, mode, cval, xshape, wshape, origin):
             sum += (W){cval} * wval;
         }} else {{
             int ix = {expr};
-            sum += (W)_x[ix] * wval;
+            sum += (W)x_data[ix] * wval;
         }}
         iw += 1;'''.format(cond=_cond, expr=_expr, cval=cval))
 

--- a/cupyx/scipy/ndimage/filters.py
+++ b/cupyx/scipy/ndimage/filters.py
@@ -151,6 +151,8 @@ def _generate_correlete_kernel(ndim, mode, cval, xshape, wshape, origin):
     out_params = 'Y y'
 
     ops = []
+    ops.append('X* _x = (X*)&(x[0]);')
+    ops.append('W* _w = (W*)&(w[0]);')
     ops.append('const int sx_{} = 1;'.format(ndim-1))
     for j in range(ndim-1, 0, -1):
         ops.append('int sx_{jm} = sx_{j} * {xsize_j};'.
@@ -175,7 +177,7 @@ def _generate_correlete_kernel(ndim, mode, cval, xshape, wshape, origin):
         ops.append('        ix_{j} *= sx_{j};'.format(j=j))
 
     ops.append('''
-        W wval = w[iw];
+        W wval = _w[iw];
         if (wval == (W)0) {{
             iw += 1;
             continue;
@@ -187,7 +189,7 @@ def _generate_correlete_kernel(ndim, mode, cval, xshape, wshape, origin):
             sum += (W){cval} * wval;
         }} else {{
             int ix = {expr};
-            sum += (W)x[ix] * wval;
+            sum += (W)_x[ix] * wval;
         }}
         iw += 1;'''.format(cond=_cond, expr=_expr, cval=cval))
 


### PR DESCRIPTION
This PR improves performance of `convolve` and `correlate` in `cupyx.scipy.ndimage.filter.py`.

I was investing why the performance of `convolve` and `correlate` was slower than expected, and it seems one of the causes is that raw array access via `CArray` is slow.. The issue will be addressed with this PR.

Performance (convolution, fp32)

[sec]  | scipy convolve | cupyx convolve (current) | cupyx convolve (this PR)
-----  | ---------------- | --------------------------- | ---------------------------
x.shape = (4000, 4000), w.shape = (3,3) | 0.225978 | 0.002195 | 0.000670
x.shape = (4000, 4000), w.shape = (5,5) | 0.390014 | 0.005525 | 0.001229
x.shape = (4000, 4000), w.shape = (7,7) | 0.761595 | 0.011325 | 0.002043
x.shape = (300, 300, 300), w.shape = (3, 3, 3) | 0.702484 | 0.028360 | 0.002025

* Quadro GV100
* CUDA 10.2

