### PR TITLE
silence sign comparison warning (cont'd) 

### DIFF
--- a/cupy/core/_memory_range.pyx
+++ b/cupy/core/_memory_range.pyx
@@ -10,7 +10,7 @@ cdef pair[Py_ssize_t, Py_ssize_t] _get_bound(ndarray array):
     cdef Py_ssize_t left = array.data.ptr
     cdef Py_ssize_t right = left
     cdef pair[Py_ssize_t, Py_ssize_t] ret
-    cdef int i
+    cdef size_t i
 
     for i in range(array._shape.size()):
         right += (array._shape[i] - 1) * array._strides[i]


### PR DESCRIPTION
Follow-up of #2949.

```bash
    building 'cupy.core._memory_range' extension
    gcc -pthread -B /home/leofang/miniconda3/envs/cupy_dev/compiler_compat -Wl,--sysroot=/ -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -D_FORCE_INLINES=1 -I/usr/local/cuda/include -I/home/leofang/cupy/install/../cupy/core/include -I/home/leofang/sources/cub-1.8.0 -I/home/leofang/miniconda3/envs/cupy_dev/include/python3.7m -c cupy/core/_memory_range.cpp -o build/temp.linux-x86_64-3.7/cupy/core/_memory_range.o
    cc1plus: warning: command line option ‘-Wstrict-prototypes’ is valid for C/ObjC but not for C++
    cupy/core/_memory_range.cpp: In function ‘std::pair<long int, long int> __pyx_f_4cupy_4core_13_memory_range__get_bound(__pyx_obj_4cupy_4core_4core_ndarray*)’:
    cupy/core/_memory_range.cpp:2334:33: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
       for (__pyx_t_4 = 0; __pyx_t_4 < __pyx_t_3; __pyx_t_4+=1) {
                           ~~~~~~~~~~^~~~~~~~~~~
    /usr/bin/gcc -pthread -shared -B /home/leofang/miniconda3/envs/cupy_dev/compiler_compat -L/home/leofang/miniconda3/envs/cupy_dev/lib -Wl,-rpath=/home/leofang/miniconda3/envs/cupy_dev/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.7/cupy/core/_memory_range.o -L/usr/local/cuda/lib64 -lcublas -lcuda -lcudart -lcufft -lcurand -lcusparse -lnvrtc -o build/lib.linux-x86_64-3.7/cupy/core/_memory_range.cpython-37m-x86_64-linux-gnu.so -Wl,--disable-new-dtags,-rpath,/usr/local/cuda/lib64
```