### PR TITLE
avoid enum comparison (-Wenum-compare)

### DIFF
--- a/cupy/cuda/texture.pyx
+++ b/cupy/cuda/texture.pyx
@@ -583,7 +583,7 @@ cdef class TextureReference:
         driver.texRefSetFilterMode(texref, TexDescPtr.filterMode)
 
         cdef int flag = 0x00
-        if TexDescPtr.readMode == runtime.cudaReadModeElementType:
+        if TexDescPtr.readMode == <int>(runtime.cudaReadModeElementType):
             flag = flag | driver.CU_TRSF_READ_AS_INTEGER
         if TexDescPtr.normalizedCoords:
             flag = flag | driver.CU_TRSF_NORMALIZED_COORDINATES


### PR DESCRIPTION
Suppress this warning: 
```bash
    building 'cupy.cuda.texture' extension
    gcc -pthread -B /home/leofang/miniconda3/envs/cupy_dev/compiler_compat -Wl,--sysroot=/ -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -D_FORCE_INLINES=1 -I/usr/local/cuda/include -I/home/leofang/cupy/install/../cupy/core/include -I/home/leofang/sources/cub-1.8.0 -I/home/leofang/miniconda3/envs/cupy_dev/include/python3.7m -c cupy/cuda/texture.cpp -o build/temp.linux-x86_64-3.7/cupy/cuda/texture.o
    cc1plus: warning: command line option ‘-Wstrict-prototypes’ is valid for C/ObjC but not for C++
    cupy/cuda/texture.cpp: In function ‘int __pyx_pf_4cupy_4cuda_7texture_16TextureReference___init__(__pyx_obj_4cupy_4cuda_7texture_TextureReference*, intptr_t, __pyx_obj_4cupy_4cuda_7texture_ResourceDescriptor*, __pyx_obj_4cupy_4cuda_7texture_TextureDescriptor*)’:
    cupy/cuda/texture.cpp:11070:50: warning: comparison between ‘enum cudaTextureReadMode’ and ‘enum<unnamed>’ [-Wenum-compare]
       __pyx_t_10 = ((__pyx_v_TexDescPtr->readMode == __pyx_e_4cupy_4cuda_7runtime_cudaReadModeElementType) != 0);
                                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    /usr/bin/gcc -pthread -shared -B /home/leofang/miniconda3/envs/cupy_dev/compiler_compat -L/home/leofang/miniconda3/envs/cupy_dev/lib -Wl,-rpath=/home/leofang/miniconda3/envs/cupy_dev/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.7/cupy/cuda/texture.o -L/usr/local/cuda/lib64 -lcublas -lcuda -lcudart -lcufft -lcurand -lcusparse -lnvrtc -o build/lib.linux-x86_64-3.7/cupy/cuda/texture.cpython-37m-x86_64-linux-gnu.so -Wl,--disable-new-dtags,-rpath,/usr/local/cuda/lib64
```