### PR TITLE
Support cusolverDn<t>gesvdj and cusolverDn<t>gesvdaStridedBatched

### DIFF
--- a/cupy/cuda/cupy_cusolver.h
+++ b/cupy/cuda/cupy_cusolver.h
@@ -28,6 +28,7 @@ typedef enum{} cusolverEigMode_t;
 typedef void* cusolverDnHandle_t;
 typedef void* cusolverSpHandle_t;
 typedef void* cusparseMatDescr_t;
+typedef void* gesvdjInfo_t;
 
 cusolverStatus_t cusolverDnCreate(...) {
     return CUSOLVER_STATUS_SUCCESS;
@@ -343,6 +344,67 @@ cusolverStatus_t cusolverDnCgesvd(...) {
 }
 
 cusolverStatus_t cusolverDnZgesvd(...) {
+    return CUSOLVER_STATUS_SUCCESS;
+}
+
+//
+cusolverStatus_t cusolverDnCreateGesvdjInfo(...) {
+    return CUSOLVER_STATUS_SUCCESS;
+}
+
+cusolverStatus_t cusolverDnDestroyGesvdjInfo(...) {
+    return CUSOLVER_STATUS_SUCCESS;
+}
+
+cusolverStatus_t cusolverDnXgesvdjSetTolerance(...) {
+    return CUSOLVER_STATUS_SUCCESS;
+}
+
+cusolverStatus_t cusolverDnXgesvdjSetMaxSweeps(...) {
+    return CUSOLVER_STATUS_SUCCESS;
+}
+
+cusolverStatus_t cusolverDnXgesvdjSetSortEig(...) {
+    return CUSOLVER_STATUS_SUCCESS;
+}
+
+cusolverStatus_t cusolverDnXgesvdjGetResidual(...) {
+    return CUSOLVER_STATUS_SUCCESS;
+}
+
+cusolverStatus_t cusolverDnXgesvdjGetSweeps(...) {
+    return CUSOLVER_STATUS_SUCCESS;
+}
+
+cusolverStatus_t cusolverDnSgesvdj_bufferSize(...) {
+    return CUSOLVER_STATUS_SUCCESS;
+}
+
+cusolverStatus_t cusolverDnDgesvdj_bufferSize(...) {
+    return CUSOLVER_STATUS_SUCCESS;
+}
+
+cusolverStatus_t cusolverDnCgesvdj_bufferSize(...) {
+    return CUSOLVER_STATUS_SUCCESS;
+}
+
+cusolverStatus_t cusolverDnZgesvdj_bufferSize(...) {
+    return CUSOLVER_STATUS_SUCCESS;
+}
+
+cusolverStatus_t cusolverDnSgesvdj(...) {
+    return CUSOLVER_STATUS_SUCCESS;
+}
+
+cusolverStatus_t cusolverDnDgesvdj(...) {
+    return CUSOLVER_STATUS_SUCCESS;
+}
+
+cusolverStatus_t cusolverDnCgesvdj(...) {
+    return CUSOLVER_STATUS_SUCCESS;
+}
+
+cusolverStatus_t cusolverDnZgesvdj(...) {
     return CUSOLVER_STATUS_SUCCESS;
 }
 

--- a/cupy/cuda/cupy_cusolver.h
+++ b/cupy/cuda/cupy_cusolver.h
@@ -74,6 +74,41 @@ cusolverStatus_t cusolverDnZgesvdj(...) {
 }
 #endif // #if CUDA_VERSION < 9000
 
+#if CUDA_VERSION < 10010
+// Functions addes in CUDA 10.1
+cusolverStatus_t cusolverDnSgesvdaStridedBatched_bufferSize(...) {
+    return CUSOLVER_STATUS_SUCCESS;
+}
+
+cusolverStatus_t cusolverDnDgesvdaStridedBatched_bufferSize(...) {
+    return CUSOLVER_STATUS_SUCCESS;
+}
+
+cusolverStatus_t cusolverDnCgesvdaStridedBatched_bufferSize(...) {
+    return CUSOLVER_STATUS_SUCCESS;
+}
+
+cusolverStatus_t cusolverDnZgesvdaStridedBatched_bufferSize(...) {
+    return CUSOLVER_STATUS_SUCCESS;
+}
+
+cusolverStatus_t cusolverDnSgesvdaStridedBatched(...) {
+    return CUSOLVER_STATUS_SUCCESS;
+}
+
+cusolverStatus_t cusolverDnDgesvdaStridedBatched(...) {
+    return CUSOLVER_STATUS_SUCCESS;
+}
+
+cusolverStatus_t cusolverDnCgesvdaStridedBatched(...) {
+    return CUSOLVER_STATUS_SUCCESS;
+}
+
+cusolverStatus_t cusolverDnZgesvdaStridedBatched(...) {
+    return CUSOLVER_STATUS_SUCCESS;
+}
+#endif // #if CUDA_VERSION < 10010
+
 #else // #if !defined(CUPY_NO_CUDA) && !defined(CUPY_USE_HIP)
 
 #ifdef CUPY_USE_HIP

--- a/cupy/cuda/cupy_cusolver.h
+++ b/cupy/cuda/cupy_cusolver.h
@@ -8,6 +8,71 @@
 #include <cusolverDn.h>
 #include <cusolverSp.h>
 
+#if CUDA_VERSION < 9000
+// Data types and functions addes in CUDA 9.0
+typedef void* gesvdjInfo_t;
+
+cusolverStatus_t cusolverDnCreateGesvdjInfo(...) {
+    return CUSOLVER_STATUS_SUCCESS;
+}
+
+cusolverStatus_t cusolverDnDestroyGesvdjInfo(...) {
+    return CUSOLVER_STATUS_SUCCESS;
+}
+
+cusolverStatus_t cusolverDnXgesvdjSetTolerance(...) {
+    return CUSOLVER_STATUS_SUCCESS;
+}
+
+cusolverStatus_t cusolverDnXgesvdjSetMaxSweeps(...) {
+    return CUSOLVER_STATUS_SUCCESS;
+}
+
+cusolverStatus_t cusolverDnXgesvdjSetSortEig(...) {
+    return CUSOLVER_STATUS_SUCCESS;
+}
+
+cusolverStatus_t cusolverDnXgesvdjGetResidual(...) {
+    return CUSOLVER_STATUS_SUCCESS;
+}
+
+cusolverStatus_t cusolverDnXgesvdjGetSweeps(...) {
+    return CUSOLVER_STATUS_SUCCESS;
+}
+
+cusolverStatus_t cusolverDnSgesvdj_bufferSize(...) {
+    return CUSOLVER_STATUS_SUCCESS;
+}
+
+cusolverStatus_t cusolverDnDgesvdj_bufferSize(...) {
+    return CUSOLVER_STATUS_SUCCESS;
+}
+
+cusolverStatus_t cusolverDnCgesvdj_bufferSize(...) {
+    return CUSOLVER_STATUS_SUCCESS;
+}
+
+cusolverStatus_t cusolverDnZgesvdj_bufferSize(...) {
+    return CUSOLVER_STATUS_SUCCESS;
+}
+
+cusolverStatus_t cusolverDnSgesvdj(...) {
+    return CUSOLVER_STATUS_SUCCESS;
+}
+
+cusolverStatus_t cusolverDnDgesvdj(...) {
+    return CUSOLVER_STATUS_SUCCESS;
+}
+
+cusolverStatus_t cusolverDnCgesvdj(...) {
+    return CUSOLVER_STATUS_SUCCESS;
+}
+
+cusolverStatus_t cusolverDnZgesvdj(...) {
+    return CUSOLVER_STATUS_SUCCESS;
+}
+#endif // #if CUDA_VERSION < 9000
+
 #else // #if !defined(CUPY_NO_CUDA) && !defined(CUPY_USE_HIP)
 
 #ifdef CUPY_USE_HIP
@@ -347,7 +412,6 @@ cusolverStatus_t cusolverDnZgesvd(...) {
     return CUSOLVER_STATUS_SUCCESS;
 }
 
-//
 cusolverStatus_t cusolverDnCreateGesvdjInfo(...) {
     return CUSOLVER_STATUS_SUCCESS;
 }

--- a/cupy/cuda/cupy_cusolver.h
+++ b/cupy/cuda/cupy_cusolver.h
@@ -5,6 +5,7 @@
 
 #if !defined(CUPY_NO_CUDA) && !defined(CUPY_USE_HIP)
 
+#include <cuda.h>
 #include <cusolverDn.h>
 #include <cusolverSp.h>
 
@@ -469,6 +470,38 @@ cusolverStatus_t cusolverDnCgesvdj(...) {
 }
 
 cusolverStatus_t cusolverDnZgesvdj(...) {
+    return CUSOLVER_STATUS_SUCCESS;
+}
+
+cusolverStatus_t cusolverDnSgesvdaStrideBatched_bufferSize(...) {
+    return CUSOLVER_STATUS_SUCCESS;
+}
+
+cusolverStatus_t cusolverDnDgesvdaStrideBatched_bufferSize(...) {
+    return CUSOLVER_STATUS_SUCCESS;
+}
+
+cusolverStatus_t cusolverDnCgesvdaStrideBatched_bufferSize(...) {
+    return CUSOLVER_STATUS_SUCCESS;
+}
+
+cusolverStatus_t cusolverDnZgesvdaStrideBatched_bufferSize(...) {
+    return CUSOLVER_STATUS_SUCCESS;
+}
+
+cusolverStatus_t cusolverDnSgesvdaStrideBatched(...) {
+    return CUSOLVER_STATUS_SUCCESS;
+}
+
+cusolverStatus_t cusolverDnDgesvdaStrideBatched(...) {
+    return CUSOLVER_STATUS_SUCCESS;
+}
+
+cusolverStatus_t cusolverDnCgesvdaStrideBatched(...) {
+    return CUSOLVER_STATUS_SUCCESS;
+}
+
+cusolverStatus_t cusolverDnZgesvdaStrideBatched(...) {
     return CUSOLVER_STATUS_SUCCESS;
 }
 

--- a/cupy/cuda/cupy_cusolver.h
+++ b/cupy/cuda/cupy_cusolver.h
@@ -10,7 +10,7 @@
 #include <cusolverSp.h>
 
 #if CUDA_VERSION < 9000
-// Data types and functions addes in CUDA 9.0
+// Data types and functions added in CUDA 9.0
 typedef void* gesvdjInfo_t;
 
 cusolverStatus_t cusolverDnCreateGesvdjInfo(...) {
@@ -75,7 +75,7 @@ cusolverStatus_t cusolverDnZgesvdj(...) {
 #endif // #if CUDA_VERSION < 9000
 
 #if CUDA_VERSION < 10010
-// Functions addes in CUDA 10.1
+// Functions added in CUDA 10.1
 cusolverStatus_t cusolverDnSgesvdaStridedBatched_bufferSize(...) {
     return CUSOLVER_STATUS_SUCCESS;
 }

--- a/cupy/cuda/cupy_cusolver.h
+++ b/cupy/cuda/cupy_cusolver.h
@@ -508,35 +508,35 @@ cusolverStatus_t cusolverDnZgesvdj(...) {
     return CUSOLVER_STATUS_SUCCESS;
 }
 
-cusolverStatus_t cusolverDnSgesvdaStrideBatched_bufferSize(...) {
+cusolverStatus_t cusolverDnSgesvdaStridedBatched_bufferSize(...) {
     return CUSOLVER_STATUS_SUCCESS;
 }
 
-cusolverStatus_t cusolverDnDgesvdaStrideBatched_bufferSize(...) {
+cusolverStatus_t cusolverDnDgesvdaStridedBatched_bufferSize(...) {
     return CUSOLVER_STATUS_SUCCESS;
 }
 
-cusolverStatus_t cusolverDnCgesvdaStrideBatched_bufferSize(...) {
+cusolverStatus_t cusolverDnCgesvdaStridedBatched_bufferSize(...) {
     return CUSOLVER_STATUS_SUCCESS;
 }
 
-cusolverStatus_t cusolverDnZgesvdaStrideBatched_bufferSize(...) {
+cusolverStatus_t cusolverDnZgesvdaStridedBatched_bufferSize(...) {
     return CUSOLVER_STATUS_SUCCESS;
 }
 
-cusolverStatus_t cusolverDnSgesvdaStrideBatched(...) {
+cusolverStatus_t cusolverDnSgesvdaStridedBatched(...) {
     return CUSOLVER_STATUS_SUCCESS;
 }
 
-cusolverStatus_t cusolverDnDgesvdaStrideBatched(...) {
+cusolverStatus_t cusolverDnDgesvdaStridedBatched(...) {
     return CUSOLVER_STATUS_SUCCESS;
 }
 
-cusolverStatus_t cusolverDnCgesvdaStrideBatched(...) {
+cusolverStatus_t cusolverDnCgesvdaStridedBatched(...) {
     return CUSOLVER_STATUS_SUCCESS;
 }
 
-cusolverStatus_t cusolverDnZgesvdaStrideBatched(...) {
+cusolverStatus_t cusolverDnZgesvdaStridedBatched(...) {
     return CUSOLVER_STATUS_SUCCESS;
 }
 

--- a/cupy/cuda/cusolver.pxd
+++ b/cupy/cuda/cusolver.pxd
@@ -26,6 +26,8 @@ cdef extern from *:
     ctypedef void* cuComplex 'cuComplex'
     ctypedef void* cuDoubleComplex 'cuDoubleComplex'
 
+    ctypedef void* GesvdjInfo 'gesvdjInfo_t'
+
 ###############################################################################
 # Enum
 ###############################################################################
@@ -263,6 +265,42 @@ cpdef cgesvd(intptr_t handle, char jobu, char jobvt, int m, int n, size_t A,
 cpdef zgesvd(intptr_t handle, char jobu, char jobvt, int m, int n, size_t A,
              int lda, size_t S, size_t U, int ldu, size_t VT, int ldvt,
              size_t Work, int lwork, size_t rwork, size_t devInfo)
+
+# gesvdj ... Singular value decomposition using Jacobi mathod
+cpdef intptr_t createGesvdjInfo() except? 0
+cpdef destroyGesvdjInfo(intptr_t info)
+
+cpdef xgesvdjSetTolerance(intptr_t info, double tolerance)
+cpdef xgesvdjSetMaxSweeps(intptr_t info, int max_sweeps)
+cpdef xgesvdjSetSortEig(intptr_t info, int sort_svd)
+cpdef double xgesvdjGetResidual(intptr_t handle, intptr_t info)
+cpdef int xgesvdjGetSweeps(intptr_t handle, intptr_t info)
+
+cpdef int sgesvdj_bufferSize(intptr_t handle, int jobz, int econ, int m, int n,
+                             intptr_t A, int lda, intptr_t S, intptr_t U,
+                             int ldu, intptr_t V, int ldv, intptr_t params)
+cpdef int dgesvdj_bufferSize(intptr_t handle, int jobz, int econ, int m, int n,
+                             intptr_t A, int lda, intptr_t S, intptr_t U,
+                             int ldu, intptr_t V, int ldv, intptr_t params)
+cpdef int cgesvdj_bufferSize(intptr_t handle, int jobz, int econ, int m, int n,
+                             intptr_t A, int lda, intptr_t S, intptr_t U,
+                             int ldu, intptr_t V, int ldv, intptr_t params)
+cpdef int zgesvdj_bufferSize(intptr_t handle, int jobz, int econ, int m, int n,
+                             intptr_t A, int lda, intptr_t S, intptr_t U,
+                             int ldu, intptr_t V, int ldv, intptr_t params)
+
+cpdef sgesvdj(intptr_t handle, int jobz, int econ, int m, int n, intptr_t A,
+              int lda, intptr_t S, intptr_t U, int ldu, intptr_t V, int ldv,
+              intptr_t work, int lwork, intptr_t info, intptr_t params)
+cpdef dgesvdj(intptr_t handle, int jobz, int econ, int m, int n, intptr_t A,
+              int lda, intptr_t S, intptr_t U, int ldu, intptr_t V, int ldv,
+              intptr_t work, int lwork, intptr_t info, intptr_t params)
+cpdef cgesvdj(intptr_t handle, int jobz, int econ, int m, int n, intptr_t A,
+              int lda, intptr_t S, intptr_t U, int ldu, intptr_t V, int ldv,
+              intptr_t work, int lwork, intptr_t info, intptr_t params)
+cpdef zgesvdj(intptr_t handle, int jobz, int econ, int m, int n, intptr_t A,
+              int lda, intptr_t S, intptr_t U, int ldu, intptr_t V, int ldv,
+              intptr_t work, int lwork, intptr_t info, intptr_t params)
 
 # Standard symmetric eigenvalue solver
 cpdef int ssyevd_bufferSize(intptr_t handle, int jobz, int uplo, int n,

--- a/cupy/cuda/cusolver.pxd
+++ b/cupy/cuda/cusolver.pxd
@@ -302,6 +302,53 @@ cpdef zgesvdj(intptr_t handle, int jobz, int econ, int m, int n, intptr_t A,
               int lda, intptr_t S, intptr_t U, int ldu, intptr_t V, int ldv,
               intptr_t work, int lwork, intptr_t info, intptr_t params)
 
+# gesvda ... Approximate singular value decomposition
+cpdef int sgesvdaStridedBatched_bufferSize(
+    intptr_t handle, int jobz, int rank, int m, int n, intptr_t d_A,
+    int lda, long long int strideA, intptr_t d_S, long long int strideS,
+    intptr_t d_U, int ldu, long long int strideU, intptr_t d_V, int ldv,
+    long long int strideV, int batchSize)
+cpdef int dgesvdaStridedBatched_bufferSize(
+    intptr_t handle, int jobz, int rank, int m, int n, intptr_t d_A,
+    int lda, long long int strideA, intptr_t d_S, long long int strideS,
+    intptr_t d_U, int ldu, long long int strideU, intptr_t d_V, int ldv,
+    long long int strideV, int batchSize)
+cpdef int cgesvdaStridedBatched_bufferSize(
+    intptr_t handle, int jobz, int rank, int m, int n, intptr_t d_A,
+    int lda, long long int strideA, intptr_t d_S, long long int strideS,
+    intptr_t d_U, int ldu, long long int strideU, intptr_t d_V, int ldv,
+    long long int strideV, int batchSize)
+cpdef int zgesvdaStridedBatched_bufferSize(
+    intptr_t handle, int jobz, int rank, int m, int n, intptr_t d_A,
+    int lda, long long int strideA, intptr_t d_S, long long int strideS,
+    intptr_t d_U, int ldu, long long int strideU, intptr_t d_V, int ldv,
+    long long int strideV, int batchSize)
+
+cpdef sgesvdaStridedBatched(
+    intptr_t handle, int jobz, int rank, int m, int n, intptr_t d_A,
+    int lda, long long int strideA, intptr_t d_S, long long int strideS,
+    intptr_t d_U, int ldu, long long int strideU, intptr_t d_V, int ldv,
+    long long int strideV, intptr_t d_work, int lwork, intptr_t d_info,
+    intptr_t h_R_nrmF, int batchSize)
+cpdef dgesvdaStridedBatched(
+    intptr_t handle, int jobz, int rank, int m, int n, intptr_t d_A,
+    int lda, long long int strideA, intptr_t d_S, long long int strideS,
+    intptr_t d_U, int ldu, long long int strideU, intptr_t d_V, int ldv,
+    long long int strideV, intptr_t d_work, int lwork, intptr_t d_info,
+    intptr_t h_R_nrmF, int batchSize)
+cpdef cgesvdaStridedBatched(
+    intptr_t handle, int jobz, int rank, int m, int n, intptr_t d_A,
+    int lda, long long int strideA, intptr_t d_S, long long int strideS,
+    intptr_t d_U, int ldu, long long int strideU, intptr_t d_V, int ldv,
+    long long int strideV, intptr_t d_work, int lwork, intptr_t d_info,
+    intptr_t h_R_nrmF, int batchSize)
+cpdef zgesvdaStridedBatched(
+    intptr_t handle, int jobz, int rank, int m, int n, intptr_t d_A,
+    int lda, long long int strideA, intptr_t d_S, long long int strideS,
+    intptr_t d_U, int ldu, long long int strideU, intptr_t d_V, int ldv,
+    long long int strideV, intptr_t d_work, int lwork, intptr_t d_info,
+    intptr_t h_R_nrmF, int batchSize)
+
 # Standard symmetric eigenvalue solver
 cpdef int ssyevd_bufferSize(intptr_t handle, int jobz, int uplo, int n,
                             size_t A, int lda, size_t W) except? -1

--- a/cupy/cuda/cusolver.pyx
+++ b/cupy/cuda/cusolver.pyx
@@ -308,6 +308,58 @@ cdef extern from 'cupy_cusolver.h' nogil:
                          cuDoubleComplex* Work, int lwork,
                          double* rwork, int* devInfo)
 
+    # gesvdj ... Singular value decomposition using Jacobi mathod
+    int cusolverDnCreateGesvdjInfo(GesvdjInfo *info)
+    int cusolverDnDestroyGesvdjInfo(GesvdjInfo info)
+
+    int cusolverDnXgesvdjSetTolerance(GesvdjInfo info, double tolerance)
+    int cusolverDnXgesvdjSetMaxSweeps(GesvdjInfo info, int max_sweeps)
+    int cusolverDnXgesvdjSetSortEig(GesvdjInfo info, int sort_svd)
+    int cusolverDnXgesvdjGetResidual(Handle handle, GesvdjInfo info,
+                                     double* residual)
+    int cusolverDnXgesvdjGetSweeps(Handle handle, GesvdjInfo info,
+                                   int* executed_sweeps)
+
+    int cusolverDnSgesvdj_bufferSize(Handle handle, EigMode jobz, int econ,
+                                     int m, int n, const float* A, int lda,
+                                     const float* S, const float* U, int ldu,
+                                     const float* V, int ldv, int* lwork,
+                                     GesvdjInfo params)
+    int cusolverDnDgesvdj_bufferSize(Handle handle, EigMode jobz, int econ,
+                                     int m, int n, const double* A, int lda,
+                                     const double* S, const double* U, int ldu,
+                                     const double* V, int ldv, int* lwork,
+                                     GesvdjInfo params)
+    int cusolverDnCgesvdj_bufferSize(Handle handle, EigMode jobz, int econ,
+                                     int m, int n, const cuComplex* A, int lda,
+                                     const float* S, const cuComplex* U,
+                                     int ldu, const cuComplex* V, int ldv,
+                                     int* lwork, GesvdjInfo params)
+    int cusolverDnZgesvdj_bufferSize(Handle handle, EigMode jobz, int econ,
+                                     int m, int n, const cuDoubleComplex* A,
+                                     int lda, const double* S,
+                                     const cuDoubleComplex* U, int ldu,
+                                     const cuDoubleComplex* V, int ldv,
+                                     int* lwork, GesvdjInfo params)
+
+    int cusolverDnSgesvdj(Handle handle, EigMode jobz, int econ, int m, int n,
+                          float *A, int lda, float *S, float *U, int ldu,
+                          float *V, int ldv, float *work, int lwork, int *info,
+                          GesvdjInfo params)
+    int cusolverDnDgesvdj(Handle handle, EigMode jobz, int econ, int m, int n,
+                          double *A, int lda, double *S, double *U, int ldu,
+                          double *V, int ldv, double *work, int lwork,
+                          int *info, GesvdjInfo params)
+    int cusolverDnCgesvdj(Handle handle, EigMode jobz, int econ, int m, int n,
+                          cuComplex *A, int lda, float *S, cuComplex *U,
+                          int ldu, cuComplex *V, int ldv, cuComplex *work,
+                          int lwork, int *info, GesvdjInfo params)
+    int cusolverDnZgesvdj(Handle handle, EigMode jobz, int econ, int m, int n,
+                          cuDoubleComplex *A, int lda, double *S,
+                          cuDoubleComplex *U, int ldu, cuDoubleComplex *V,
+                          int ldv, cuDoubleComplex *work, int lwork, int *info,
+                          GesvdjInfo params)
+
     # Standard symmetric eigenvalue solver
     int cusolverDnSsyevd_bufferSize(Handle handle,
                                     EigMode jobz, FillMode uplo, int n,
@@ -1302,6 +1354,139 @@ cpdef zgesvd(intptr_t handle, char jobu, char jobvt, int m, int n, size_t A,
             <cuDoubleComplex*>Work, lwork, <double*>rwork, <int*>devInfo)
     check_status(status)
 
+# gesvdj ... Singular value decomposition using Jacobi mathod
+cpdef intptr_t createGesvdjInfo() except? 0:
+    cdef GesvdjInfo info
+    status = cusolverDnCreateGesvdjInfo(&info)
+    check_status(status)
+    return <intptr_t>info
+
+cpdef destroyGesvdjInfo(intptr_t info):
+    status = cusolverDnDestroyGesvdjInfo(<GesvdjInfo>info)
+    check_status(status)
+
+cpdef xgesvdjSetTolerance(intptr_t info, double tolerance):
+    status = cusolverDnXgesvdjSetTolerance(<GesvdjInfo>info, tolerance)
+    check_status(status)
+
+cpdef xgesvdjSetMaxSweeps(intptr_t info, int max_sweeps):
+    status = cusolverDnXgesvdjSetMaxSweeps(<GesvdjInfo>info, max_sweeps)
+    check_status(status)
+
+cpdef xgesvdjSetSortEig(intptr_t info, int sort_svd):
+    status = cusolverDnXgesvdjSetSortEig(<GesvdjInfo>info, sort_svd)
+    check_status(status)
+
+cpdef double xgesvdjGetResidual(intptr_t handle, intptr_t info):
+    cdef double residual
+    status = cusolverDnXgesvdjGetResidual(<Handle>handle, <GesvdjInfo>info,
+                                          &residual)
+    check_status(status)
+    return residual
+
+cpdef int xgesvdjGetSweeps(intptr_t handle, intptr_t info):
+    cdef int executed_sweeps
+    status = cusolverDnXgesvdjGetSweeps(<Handle>handle, <GesvdjInfo>info,
+                                        &executed_sweeps)
+    check_status(status)
+    return executed_sweeps
+
+cpdef int sgesvdj_bufferSize(intptr_t handle, int jobz, int econ, int m, int n,
+                             intptr_t A, int lda, intptr_t S, intptr_t U,
+                             int ldu, intptr_t V, int ldv, intptr_t params):
+    cdef int lwork, status
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusolverDnSgesvdj_bufferSize(
+            <Handle>handle, <EigMode>jobz, econ, m, n, <const float*>A, lda,
+            <const float*>S, <const float*>U, ldu, <const float*>V, ldv,
+            &lwork, <GesvdjInfo>params)
+    check_status(status)
+    return lwork
+
+cpdef int dgesvdj_bufferSize(intptr_t handle, int jobz, int econ, int m, int n,
+                             intptr_t A, int lda, intptr_t S, intptr_t U,
+                             int ldu, intptr_t V, int ldv, intptr_t params):
+    cdef int lwork, status
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusolverDnDgesvdj_bufferSize(
+            <Handle>handle, <EigMode>jobz, econ, m, n, <const double*>A, lda,
+            <const double*>S, <const double*>U, ldu, <const double*>V, ldv,
+            &lwork, <GesvdjInfo>params)
+    check_status(status)
+    return lwork
+
+cpdef int cgesvdj_bufferSize(intptr_t handle, int jobz, int econ, int m, int n,
+                             intptr_t A, int lda, intptr_t S, intptr_t U,
+                             int ldu, intptr_t V, int ldv, intptr_t params):
+    cdef int lwork, status
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusolverDnCgesvdj_bufferSize(
+            <Handle>handle, <EigMode>jobz, econ, m, n, <const cuComplex*>A,
+            lda, <const float*>S, <const cuComplex*>U, ldu,
+            <const cuComplex*>V, ldv, &lwork, <GesvdjInfo>params)
+    check_status(status)
+    return lwork
+
+cpdef int zgesvdj_bufferSize(intptr_t handle, int jobz, int econ, int m, int n,
+                             intptr_t A, int lda, intptr_t S, intptr_t U,
+                             int ldu, intptr_t V, int ldv, intptr_t params):
+    cdef int lwork, status
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusolverDnZgesvdj_bufferSize(
+            <Handle>handle, <EigMode>jobz, econ, m, n,
+            <const cuDoubleComplex*>A, lda, <const double*>S,
+            <const cuDoubleComplex*>U, ldu, <const cuDoubleComplex*>V,
+            ldv, &lwork, <GesvdjInfo>params)
+    check_status(status)
+    return lwork
+
+cpdef sgesvdj(intptr_t handle, int jobz, int econ, int m, int n, intptr_t A,
+              int lda, intptr_t S, intptr_t U, int ldu, intptr_t V, int ldv,
+              intptr_t work, int lwork, intptr_t info, intptr_t params):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusolverDnSgesvdj(<Handle>handle, <EigMode>jobz, econ, m, n,
+                                   <float*>A, lda, <float*>S, <float*>U, ldu,
+                                   <float*>V, ldv, <float*>work, lwork,
+                                   <int*>info, <GesvdjInfo>params)
+    check_status(status)
+
+cpdef dgesvdj(intptr_t handle, int jobz, int econ, int m, int n, intptr_t A,
+              int lda, intptr_t S, intptr_t U, int ldu, intptr_t V, int ldv,
+              intptr_t work, int lwork, intptr_t info, intptr_t params):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusolverDnDgesvdj(<Handle>handle, <EigMode>jobz, econ, m, n,
+                                   <double*>A, lda, <double*>S, <double*>U,
+                                   ldu, <double*>V, ldv, <double*>work, lwork,
+                                   <int*>info, <GesvdjInfo>params)
+    check_status(status)
+
+cpdef cgesvdj(intptr_t handle, int jobz, int econ, int m, int n, intptr_t A,
+              int lda, intptr_t S, intptr_t U, int ldu, intptr_t V, int ldv,
+              intptr_t work, int lwork, intptr_t info, intptr_t params):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusolverDnCgesvdj(
+            <Handle>handle, <EigMode>jobz, econ, m, n, <cuComplex*>A, lda,
+            <float*>S, <cuComplex*>U, ldu, <cuComplex*>V, ldv,
+            <cuComplex*>work, lwork, <int*>info, <GesvdjInfo>params)
+    check_status(status)
+
+cpdef zgesvdj(intptr_t handle, int jobz, int econ, int m, int n, intptr_t A,
+              int lda, intptr_t S, intptr_t U, int ldu, intptr_t V, int ldv,
+              intptr_t work, int lwork, intptr_t info, intptr_t params):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusolverDnZgesvdj(
+            <Handle>handle, <EigMode>jobz, econ, m, n, <cuDoubleComplex*>A,
+            lda, <double*>S, <cuDoubleComplex*>U, ldu, <cuDoubleComplex*>V,
+            ldv, <cuDoubleComplex*>work, lwork, <int*>info, <GesvdjInfo>params)
+    check_status(status)
 
 # Standard symmetric eigenvalue solver
 cpdef int ssyevd_bufferSize(intptr_t handle, int jobz, int uplo, int n,

--- a/cupy/cuda/cusolver.pyx
+++ b/cupy/cuda/cusolver.pyx
@@ -360,6 +360,64 @@ cdef extern from 'cupy_cusolver.h' nogil:
                           int ldv, cuDoubleComplex *work, int lwork, int *info,
                           GesvdjInfo params)
 
+    # gesvda ... Approximate singular value decomposition
+    int cusolverDnSgesvdaStridedBatched_bufferSize(
+        Handle handle, EigMode jobz, int rank, int m, int n, const float *d_A,
+        int lda, long long int strideA, const float *d_S,
+        long long int strideS, const float *d_U, int ldu,
+        long long int strideU, const float *d_V, int ldv,
+        long long int strideV, int *lwork, int batchSize)
+
+    int cusolverDnDgesvdaStridedBatched_bufferSize(
+        Handle handle, EigMode jobz, int rank, int m, int n, const double *d_A,
+        int lda, long long int strideA, const double *d_S,
+        long long int strideS, const double *d_U, int ldu,
+        long long int strideU, const double *d_V, int ldv,
+        long long int strideV, int *lwork, int batchSize)
+
+    int cusolverDnCgesvdaStridedBatched_bufferSize(
+        Handle handle, EigMode jobz, int rank, int m, int n,
+        const cuComplex *d_A, int lda, long long int strideA, const float *d_S,
+        long long int strideS, const cuComplex *d_U, int ldu,
+        long long int strideU, const cuComplex *d_V, int ldv,
+        long long int strideV, int *lwork, int batchSize)
+
+    int cusolverDnZgesvdaStridedBatched_bufferSize(
+        Handle handle, EigMode jobz, int rank, int m, int n,
+        const cuDoubleComplex *d_A, int lda, long long int strideA,
+        const double *d_S, long long int strideS, const cuDoubleComplex *d_U,
+        int ldu, long long int strideU, const cuDoubleComplex *d_V, int ldv,
+        long long int strideV, int *lwork, int batchSize)
+
+    int cusolverDnSgesvdaStridedBatched(
+        Handle handle, EigMode jobz, int rank, int m, int n, const float *d_A,
+        int lda, long long int strideA, float *d_S, long long int strideS,
+        float *d_U, int ldu, long long int strideU, float *d_V, int ldv,
+        long long int strideV, float *d_work, int lwork, int *d_info,
+        double *h_R_nrmF, int batchSize)
+
+    int cusolverDnDgesvdaStridedBatched(
+        Handle handle, EigMode jobz, int rank, int m, int n, const double *d_A,
+        int lda, long long int strideA, double *d_S, long long int strideS,
+        double *d_U, int ldu, long long int strideU, double *d_V, int ldv,
+        long long int strideV, double *d_work, int lwork, int *d_info,
+        double *h_R_nrmF, int batchSize)
+
+    int cusolverDnCgesvdaStridedBatched(
+        Handle handle, EigMode jobz, int rank, int m, int n,
+        const cuComplex *d_A, int lda, long long int strideA, float *d_S,
+        long long int strideS, cuComplex *d_U, int ldu, long long int strideU,
+        cuComplex *d_V, int ldv, long long int strideV, cuComplex *d_work,
+        int lwork, int *d_info, double *h_R_nrmF, int batchSize)
+
+    int cusolverDnZgesvdaStridedBatched(
+        Handle handle, EigMode jobz, int rank, int m, int n,
+        const cuDoubleComplex *d_A, int lda, long long int strideA,
+        double *d_S, long long int strideS, cuDoubleComplex *d_U, int ldu,
+        long long int strideU, cuDoubleComplex *d_V, int ldv,
+        long long int strideV, cuDoubleComplex *d_work, int lwork, int *d_info,
+        double *h_R_nrmF, int batchSize)
+
     # Standard symmetric eigenvalue solver
     int cusolverDnSsyevd_bufferSize(Handle handle,
                                     EigMode jobz, FillMode uplo, int n,
@@ -1486,6 +1544,121 @@ cpdef zgesvdj(intptr_t handle, int jobz, int econ, int m, int n, intptr_t A,
             <Handle>handle, <EigMode>jobz, econ, m, n, <cuDoubleComplex*>A,
             lda, <double*>S, <cuDoubleComplex*>U, ldu, <cuDoubleComplex*>V,
             ldv, <cuDoubleComplex*>work, lwork, <int*>info, <GesvdjInfo>params)
+    check_status(status)
+
+# gesvda ... Approximate singular value decomposition
+cpdef int sgesvdaStridedBatched_bufferSize(
+        intptr_t handle, int jobz, int rank, int m, int n, intptr_t d_A,
+        int lda, long long int strideA, intptr_t d_S, long long int strideS,
+        intptr_t d_U, int ldu, long long int strideU, intptr_t d_V, int ldv,
+        long long int strideV, int batchSize):
+    cdef int lwork
+    status = cusolverDnSgesvdaStridedBatched_bufferSize(
+        <Handle>handle, <EigMode>jobz, rank, m, n, <const float*>d_A, lda,
+        strideA, <const float*>d_S, strideS, <const float*>d_U, ldu, strideU,
+        <const float*>d_V, ldv, strideV, &lwork, batchSize)
+    check_status(status)
+    return lwork
+
+cpdef int dgesvdaStridedBatched_bufferSize(
+        intptr_t handle, int jobz, int rank, int m, int n, intptr_t d_A,
+        int lda, long long int strideA, intptr_t d_S, long long int strideS,
+        intptr_t d_U, int ldu, long long int strideU, intptr_t d_V, int ldv,
+        long long int strideV, int batchSize):
+    cdef int lwork
+    status = cusolverDnDgesvdaStridedBatched_bufferSize(
+        <Handle>handle, <EigMode>jobz, rank, m, n, <const double*>d_A, lda,
+        strideA, <const double*>d_S, strideS, <const double*>d_U, ldu, strideU,
+        <const double*>d_V, ldv, strideV, &lwork, batchSize)
+    check_status(status)
+    return lwork
+
+cpdef int cgesvdaStridedBatched_bufferSize(
+        intptr_t handle, int jobz, int rank, int m, int n, intptr_t d_A,
+        int lda, long long int strideA, intptr_t d_S, long long int strideS,
+        intptr_t d_U, int ldu, long long int strideU, intptr_t d_V, int ldv,
+        long long int strideV, int batchSize):
+    cdef int lwork
+    status = cusolverDnCgesvdaStridedBatched_bufferSize(
+        <Handle>handle, <EigMode>jobz, rank, m, n, <const cuComplex*>d_A, lda,
+        strideA, <const float*>d_S, strideS, <const cuComplex*>d_U, ldu,
+        strideU, <const cuComplex*>d_V, ldv, strideV, &lwork, batchSize)
+    check_status(status)
+    return lwork
+
+cpdef int zgesvdaStridedBatched_bufferSize(
+        intptr_t handle, int jobz, int rank, int m, int n, intptr_t d_A,
+        int lda, long long int strideA, intptr_t d_S, long long int strideS,
+        intptr_t d_U, int ldu, long long int strideU, intptr_t d_V, int ldv,
+        long long int strideV, int batchSize):
+    cdef int lwork
+    status = cusolverDnZgesvdaStridedBatched_bufferSize(
+        <Handle>handle, <EigMode>jobz, rank, m, n, <const cuDoubleComplex*>d_A,
+        lda, strideA, <const double*>d_S, strideS, <const cuDoubleComplex*>d_U,
+        ldu, strideU, <const cuDoubleComplex*>d_V, ldv, strideV, &lwork,
+        batchSize)
+    check_status(status)
+    return lwork
+
+cpdef sgesvdaStridedBatched(
+        intptr_t handle, int jobz, int rank, int m, int n, intptr_t d_A,
+        int lda, long long int strideA, intptr_t d_S, long long int strideS,
+        intptr_t d_U, int ldu, long long int strideU, intptr_t d_V, int ldv,
+        long long int strideV, intptr_t d_work, int lwork, intptr_t d_info,
+        intptr_t h_R_nrmF, int batchSize):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusolverDnSgesvdaStridedBatched(
+            <Handle>handle, <EigMode>jobz, rank, m, n, <const float*>d_A, lda,
+            strideA, <float*>d_S, strideS, <float*>d_U, ldu, strideU,
+            <float*>d_V, ldv, strideV, <float*>d_work, lwork, <int*>d_info,
+            <double*>h_R_nrmF, batchSize)
+    check_status(status)
+
+cpdef dgesvdaStridedBatched(
+        intptr_t handle, int jobz, int rank, int m, int n, intptr_t d_A,
+        int lda, long long int strideA, intptr_t d_S, long long int strideS,
+        intptr_t d_U, int ldu, long long int strideU, intptr_t d_V, int ldv,
+        long long int strideV, intptr_t d_work, int lwork, intptr_t d_info,
+        intptr_t h_R_nrmF, int batchSize):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusolverDnDgesvdaStridedBatched(
+            <Handle>handle, <EigMode>jobz, rank, m, n, <const double*>d_A, lda,
+            strideA, <double*>d_S, strideS, <double*>d_U, ldu, strideU,
+            <double*>d_V, ldv, strideV, <double*>d_work, lwork, <int*>d_info,
+            <double*>h_R_nrmF, batchSize)
+    check_status(status)
+
+cpdef cgesvdaStridedBatched(
+        intptr_t handle, int jobz, int rank, int m, int n, intptr_t d_A,
+        int lda, long long int strideA, intptr_t d_S, long long int strideS,
+        intptr_t d_U, int ldu, long long int strideU, intptr_t d_V, int ldv,
+        long long int strideV, intptr_t d_work, int lwork, intptr_t d_info,
+        intptr_t h_R_nrmF, int batchSize):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusolverDnCgesvdaStridedBatched(
+            <Handle>handle, <EigMode>jobz, rank, m, n, <const cuComplex*>d_A,
+            lda, strideA, <float*>d_S, strideS, <cuComplex*>d_U, ldu, strideU,
+            <cuComplex*>d_V, ldv, strideV, <cuComplex*>d_work, lwork,
+            <int*>d_info, <double*>h_R_nrmF, batchSize)
+    check_status(status)
+
+cpdef zgesvdaStridedBatched(
+        intptr_t handle, int jobz, int rank, int m, int n, intptr_t d_A,
+        int lda, long long int strideA, intptr_t d_S, long long int strideS,
+        intptr_t d_U, int ldu, long long int strideU, intptr_t d_V, int ldv,
+        long long int strideV, intptr_t d_work, int lwork, intptr_t d_info,
+        intptr_t h_R_nrmF, int batchSize):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusolverDnZgesvdaStridedBatched(
+            <Handle>handle, <EigMode>jobz, rank, m, n,
+            <const cuDoubleComplex*>d_A, lda, strideA, <double*>d_S, strideS,
+            <cuDoubleComplex*>d_U, ldu, strideU, <cuDoubleComplex*>d_V, ldv,
+            strideV, <cuDoubleComplex*>d_work, lwork, <int*>d_info,
+            <double*>h_R_nrmF, batchSize)
     check_status(status)
 
 # Standard symmetric eigenvalue solver

--- a/cupy/cusolver.py
+++ b/cupy/cusolver.py
@@ -70,11 +70,8 @@ def gesvdj(a, full_matrices=True, compute_uv=True, overwrite_a=False):
 
     handle = device.get_cusolver_handle()
     m, n = a.shape
+    a = cupy.array(a, order='F', copy=not overwrite_a)
     lda = m
-    if not a.flags['F_CONTIGUOUS']:
-        a = cupy.asfortranarray(a)
-    elif not overwrite_a:
-        a = a.copy()
     mn = min(m, n)
     s = cupy.empty(mn, dtype=s_dtype)
     ldu = m

--- a/cupy/cusolver.py
+++ b/cupy/cusolver.py
@@ -1,0 +1,110 @@
+import numpy
+
+import cupy
+from cupy.cuda import cusolver
+from cupy.cuda import runtime
+from cupy.cuda import device
+
+
+_available_cuda_version = {
+    'gesvdj': (9000, None),
+    'gesvda': (10010, None),
+}
+
+
+def check_availability(name):
+    if name not in _available_cuda_version:
+        msg = 'No available version information specified for {}'.name
+        raise ValueError(msg)
+    version_added, version_removed = _available_cuda_version[name]
+    cuda_version = runtime.runtimeGetVersion()
+    if version_added is not None and cuda_version < version_added:
+        return False
+    if version_removed is not None and cuda_version >= version_removed:
+        return False
+    return True
+
+
+def gesvdj(a, full_matrices=True, compute_uv=True, overwrite_a=False):
+    """Singular value decomposition using cusolverDn<t>gesvdj().
+
+    Factorizes the matrix ``a`` into two unitary matrices ``u`` and ``v`` and
+    a singular values vector ``s`` such that ``a == u @ diag(s) @ v*``.
+
+    Args:
+        a (cupy.ndarray): The input matrix with dimension ``(M, N)``.
+        full_matrices (bool): If True, it returns u and v with dimensions
+            ``(M, M)`` and ``(N, N)``. Otherwise, the dimensions of u and v
+            are respectively ``(M, K)`` and ``(K, N)``, where
+            ``K = min(M, N)``.
+        compute_uv (bool): If ``False``, it only returns singular values.
+        overwrite_a (bool): If ``True``, matrix ``a`` might be overwritten.
+
+    Returns:
+        tuple of :class:`cupy.ndarray`:
+            A tuple of ``(u, s, v)``.
+    """
+    if not check_availability('gesvdj'):
+        raise RuntimeError('gesvdj is not available.')
+
+    assert a.ndim == 2
+
+    if a.dtype == 'f':
+        helper = cusolver.sgesvdj_bufferSize
+        solver = cusolver.sgesvdj
+        s_dtype = 'f'
+    elif a.dtype == 'd':
+        helper = cusolver.dgesvdj_bufferSize
+        solver = cusolver.dgesvdj
+        s_dtype = 'd'
+    elif a.dtype == 'F':
+        helper = cusolver.cgesvdj_bufferSize
+        solver = cusolver.cgesvdj
+        s_dtype = 'f'
+    elif a.dtype == 'D':
+        helper = cusolver.zgesvdj_bufferSize
+        solver = cusolver.zgesvdj
+        s_dtype = 'd'
+    else:
+        raise TypeError
+
+    handle = device.get_cusolver_handle()
+    m, n = a.shape
+    lda = m
+    if not a.flags['F_CONTIGUOUS']:
+        a = cupy.asfortranarray(a)
+    elif not overwrite_a:
+        a = a.copy()
+    mn = min(m, n)
+    s = cupy.empty(mn, dtype=s_dtype)
+    ldu = m
+    ldv = n
+    if compute_uv:
+        jobz = cusolver.CUSOLVER_EIG_MODE_VECTOR
+    else:
+        jobz = cusolver.CUSOLVER_EIG_MODE_NOVECTOR
+        full_matrices = False
+    if full_matrices:
+        econ = 0
+        u = cupy.empty((ldu, m), dtype=a.dtype, order='F')
+        v = cupy.empty((ldv, n), dtype=a.dtype, order='F')
+    else:
+        econ = 1
+        u = cupy.empty((ldu, mn), dtype=a.dtype, order='F')
+        v = cupy.empty((ldv, mn), dtype=a.dtype, order='F')
+    params = cusolver.createGesvdjInfo()
+    lwork = helper(handle, jobz, econ, m, n, a.data.ptr, lda, s.data.ptr,
+                   u.data.ptr, ldu, v.data.ptr, ldv, params)
+    work = cupy.empty(lwork, dtype=a.dtype)
+    info = cupy.empty(1, dtype=numpy.int32)
+    solver(handle, jobz, econ, m, n, a.data.ptr, lda, s.data.ptr,
+           u.data.ptr, ldu, v.data.ptr, ldv, work.data.ptr, lwork,
+           info.data.ptr, params)
+    cupy.linalg.util._check_cusolver_dev_info_if_synchronization_allowed(
+        gesvdj, info)
+
+    cusolver.destroyGesvdjInfo(params)
+    if compute_uv:
+        return u, s, v
+    else:
+        return s

--- a/tests/cupy_tests/test_cusolver.py
+++ b/tests/cupy_tests/test_cusolver.py
@@ -1,0 +1,67 @@
+import unittest
+
+import numpy
+
+import cupy
+from cupy import testing
+from cupy import cusolver
+
+
+@testing.parameterize(*testing.product({
+    'dtype': [numpy.float32, numpy.float64, numpy.complex64, numpy.complex128],
+    'shape': [(5, 3), (4, 4), (3, 5)],
+    'order': ['C', 'F'],
+    'full_matrices': [True, False],
+    'overwrite_a': [True, False],
+}))
+class TestGesvdj(unittest.TestCase):
+
+    def setUp(self):
+        m, n = self.shape
+        if self.dtype == numpy.complex64:
+            a_real = numpy.random.random((m, n)).astype(numpy.float32)
+            a_imag = numpy.random.random((m, n)).astype(numpy.float32)
+            self.a = a_real + 1.j * a_imag
+        elif self.dtype == numpy.complex128:
+            a_real = numpy.random.random((m, n)).astype(numpy.float64)
+            a_imag = numpy.random.random((m, n)).astype(numpy.float64)
+            self.a = a_real + 1.j * a_imag
+        else:
+            self.a = numpy.random.random((m, n)).astype(self.dtype)
+
+    def test_gesvdj(self):
+        a = cupy.array(self.a, order=self.order)
+        u, s, v = cusolver.gesvdj(a, full_matrices=self.full_matrices,
+                                  overwrite_a=self.overwrite_a)
+        m, n = self.shape
+        mn = min(m, n)
+        if self.full_matrices:
+            sigma = numpy.zeros((m, n), dtype=self.dtype)
+            for i in range(mn):
+                sigma[i][i] = s[i]
+            sigma = cupy.array(sigma)
+        else:
+            sigma = cupy.diag(s)
+        if self.dtype in (numpy.complex64, numpy.complex128):
+            vh = v.T.conjugate()
+        else:
+            vh = v.T
+        aa = cupy.matmul(cupy.matmul(u, sigma), vh)
+        if self.dtype in (numpy.float32, numpy.complex64):
+            decimal = 5
+        else:
+            decimal = 10
+        testing.assert_array_almost_equal(aa, self.a, decimal=decimal)
+
+    def test_gesvdj_no_uv(self):
+        a = cupy.array(self.a, order=self.order)
+        s = cusolver.gesvdj(a, full_matrices=self.full_matrices,
+                            compute_uv=False, overwrite_a=self.overwrite_a)
+        expect = numpy.linalg.svd(self.a, full_matrices=self.full_matrices,
+                                  compute_uv=False)
+        if self.dtype in (numpy.float32, numpy.complex64):
+            decimal = 5
+        else:
+            decimal = 10
+        testing.assert_array_almost_equal(s, expect, decimal=decimal)
+

--- a/tests/cupy_tests/test_cusolver.py
+++ b/tests/cupy_tests/test_cusolver.py
@@ -65,3 +65,55 @@ class TestGesvdj(unittest.TestCase):
             decimal = 10
         testing.assert_array_almost_equal(s, expect, decimal=decimal)
 
+
+@testing.parameterize(*testing.product({
+    'dtype': [numpy.float32, numpy.float64, numpy.complex64, numpy.complex128],
+    'shape': [(5, 4), (1, 4, 3), (4, 3, 2)],
+}))
+class TestGesvda(unittest.TestCase):
+
+    def setUp(self):
+        if self.dtype == numpy.complex64:
+            a_real = numpy.random.random(self.shape).astype(numpy.float32)
+            a_imag = numpy.random.random(self.shape).astype(numpy.float32)
+            self.a = a_real + 1.j * a_imag
+        elif self.dtype == numpy.complex128:
+            a_real = numpy.random.random(self.shape).astype(numpy.float64)
+            a_imag = numpy.random.random(self.shape).astype(numpy.float64)
+            self.a = a_real + 1.j * a_imag
+        else:
+            self.a = numpy.random.random(self.shape).astype(self.dtype)
+
+    def test_gesvda(self):
+        a = cupy.array(self.a)
+        u, s, v = cusolver.gesvda(a)
+        if a.ndim == 2:
+            batch_size = 1
+            a = a.reshape((1,) + a.shape)
+            u = u.reshape((1,) + u.shape)
+            s = s.reshape((1,) + s.shape)
+            v = v.reshape((1,) + v.shape)
+        else:
+            batch_size = a.shape[0]
+        for i in range(batch_size):
+            sigma = cupy.diag(s[i])
+            if self.dtype in (numpy.complex64, numpy.complex128):
+                vh = v[i].T.conjugate()
+            else:
+                vh = v[i].T
+            aa = cupy.matmul(cupy.matmul(u[i], sigma), vh)
+            if self.dtype in (numpy.float32, numpy.complex64):
+                decimal = 5
+            else:
+                decimal = 10
+            testing.assert_array_almost_equal(aa, a[i], decimal=decimal)
+
+    def test_gesvda_no_uv(self):
+        a = cupy.array(self.a)
+        s = cusolver.gesvda(a, compute_uv=False)
+        expect = numpy.linalg.svd(self.a, compute_uv=False)
+        if self.dtype in (numpy.float32, numpy.complex64):
+            decimal = 5
+        else:
+            decimal = 10
+        testing.assert_array_almost_equal(s, expect, decimal=decimal)

--- a/tests/cupy_tests/test_cusolver.py
+++ b/tests/cupy_tests/test_cusolver.py
@@ -1,6 +1,7 @@
 import unittest
 
 import numpy
+import pytest
 
 import cupy
 from cupy import testing
@@ -30,6 +31,8 @@ class TestGesvdj(unittest.TestCase):
             self.a = numpy.random.random((m, n)).astype(self.dtype)
 
     def test_gesvdj(self):
+        if not cusolver.check_availability('gesvdj'):
+            pytest.skip('gesvdj is not available')
         a = cupy.array(self.a, order=self.order)
         u, s, v = cusolver.gesvdj(a, full_matrices=self.full_matrices,
                                   overwrite_a=self.overwrite_a)
@@ -54,6 +57,8 @@ class TestGesvdj(unittest.TestCase):
         testing.assert_array_almost_equal(aa, self.a, decimal=decimal)
 
     def test_gesvdj_no_uv(self):
+        if not cusolver.check_availability('gesvdj'):
+            pytest.skip('gesvdj is not available')
         a = cupy.array(self.a, order=self.order)
         s = cusolver.gesvdj(a, full_matrices=self.full_matrices,
                             compute_uv=False, overwrite_a=self.overwrite_a)
@@ -85,6 +90,8 @@ class TestGesvda(unittest.TestCase):
             self.a = numpy.random.random(self.shape).astype(self.dtype)
 
     def test_gesvda(self):
+        if not cusolver.check_availability('gesvda'):
+            pytest.skip('gesvda is not available')
         a = cupy.array(self.a)
         u, s, v = cusolver.gesvda(a)
         if a.ndim == 2:
@@ -109,6 +116,8 @@ class TestGesvda(unittest.TestCase):
             testing.assert_array_almost_equal(aa, a[i], decimal=decimal)
 
     def test_gesvda_no_uv(self):
+        if not cusolver.check_availability('gesvda'):
+            pytest.skip('gesvda is not available')
         a = cupy.array(self.a)
         s = cusolver.gesvda(a, compute_uv=False)
         expect = numpy.linalg.svd(self.a, compute_uv=False)


### PR DESCRIPTION
This PR makes following two types of cuSolver SVD implementations available in CuPy.
* `gesvdj` ... https://docs.nvidia.com/cuda/cusolver/index.html#cuds-lt-t-gt-gesvdj
* `gesvda` ... https://docs.nvidia.com/cuda/cusolver/index.html#cuds-lt-t-gt-gesvda

`gesvdj` uses Jacobi method and can give better performance compared with standard [gesvd](https://docs.nvidia.com/cuda/cusolver/index.html#cuds-lt-t-gt-gesvd) using QR factorization when matrix size is not large.

`gesvda` is approximate SVD solver and better in performance when a tall skinny matrix.

This is related to  https://github.com/cupy/cupy/issues/3174
