### PR TITLE
Add the missing initialization value in the reduction test

### DIFF
--- a/tests/cupy_tests/core_tests/test_reduction.py
+++ b/tests/cupy_tests/core_tests/test_reduction.py
@@ -41,7 +41,7 @@ class SimpleReductionFunctionTestBase(AbstractReductionTestBase):
 
     def get_sum_func(self):
         return core.create_reduction_func(
-            'my_sum', ('b->b',), ('in0', 'a + b', 'out0 = a', None))
+            'my_sum', ('b->b',), ('in0', 'a + b', 'out0 = a', None), 0)
 
 
 @testing.gpu


### PR DESCRIPTION
I noticed this reduction test is passed by luck -- the initial accumulation value is not initialized at all, so in the generated kernel we get this line:
```C
...
       _i_base += (ptrdiff_t)gridDim.x * _block_stride) {
    _type_reduce _s = _type_reduce();     // <--- implicitly zero initialized
    ptrdiff_t _i =
...
```
It's fine here only because we are testing `sum`; for `prod`, say, this would be totally wrong. Better be explicit and avoid surprise I think.

With this change, the line of concern becomes
```C
    _type_reduce _s = _type_reduce(0);     // <--- the identity '0' enters here
```