### PR TITLE
Make `RawKernel` and `RawModule` aware of CUDA context

### DIFF
--- a/cupy/core/raw.pxd
+++ b/cupy/core/raw.pxd
@@ -4,10 +4,10 @@ cdef class RawKernel:
         readonly str code
         readonly str name
         readonly tuple options
-        object _kernel
         readonly str backend
-        bint translate_cucomplex
         readonly bint enable_cooperative_groups
+        bint translate_cucomplex
+        dict kernels
 
 
 cdef class RawModule:
@@ -16,8 +16,11 @@ cdef class RawModule:
         readonly str code
         readonly str cubin_path
         readonly tuple options
-        dict kernels
         readonly str backend
-        object module
-        bint translate_cucomplex
         readonly bint enable_cooperative_groups
+        bint translate_cucomplex
+        dict kernels
+        dict modules
+
+        _load_from_path(self, str)
+        _compile_from_source(self, str, tuple, str, bint, bint)

--- a/tests/cupy_tests/core_tests/test_raw.py
+++ b/tests/cupy_tests/core_tests/test_raw.py
@@ -285,6 +285,9 @@ _test_cache_dir = None
 class TestRaw(unittest.TestCase):
 
     def setUp(self):
+        self.dev = cupy.cuda.runtime.getDevice()
+        assert self.dev != 1
+
         global _test_cache_dir
         _test_cache_dir = tempfile.mkdtemp()
         os.environ['CUPY_CACHE_DIR'] = _test_cache_dir
@@ -310,6 +313,8 @@ class TestRaw(unittest.TestCase):
         else:
             os.environ.pop('CUPY_CACHE_DIR')
         compiler._empty_file_preprocess_cache = {}
+
+        cupy.cuda.runtime.setDevice(self.dev)
 
     def _helper(self, kernel, dtype):
         N = 10
@@ -544,6 +549,38 @@ class TestRaw(unittest.TestCase):
         ker((1,), (100,), (output_arr, cupy.int32(100)))
         assert (data == output_arr).all()
 
+    @testing.multi_gpu(2)
+    def test_context_switch_RawKernel(self):
+        # run test_basic() on another device
+
+        # For RawKernel, we need to launch it once to force compiling
+        x1, x2, y = self._helper(self.kern, cupy.float32)
+        cupy.cuda.runtime.setDevice(1)
+
+        x1, x2, y = self._helper(self.kern, cupy.float32)
+        assert cupy.allclose(y, x1 + x2)
+
+    @testing.multi_gpu(2)
+    def test_context_switch_RawModule1(self):
+        # run test_module() on another device
+        # in this test, re-compiling happens at get_function()
+        cupy.cuda.runtime.setDevice(1)
+
+        module = self.mod2
+        ker_sum = module.get_function('test_sum')
+        x1, x2, y = self._helper(ker_sum, cupy.float32)
+        assert cupy.allclose(y, x1 + x2)
+
+    @testing.multi_gpu(2)
+    def test_context_switch_RawModule2(self):
+        # run test_module() on another device
+        # in this test, re-compiling happens at kernel launch
+        module = self.mod2
+        ker_sum = module.get_function('test_sum')
+        cupy.cuda.runtime.setDevice(1)
+
+        x1, x2, y = self._helper(ker_sum, cupy.float32)
+        assert cupy.allclose(y, x1 + x2)
 
 _test_grid_sync = r'''
 #include <cooperative_groups.h>

--- a/tests/cupy_tests/core_tests/test_raw.py
+++ b/tests/cupy_tests/core_tests/test_raw.py
@@ -582,6 +582,7 @@ class TestRaw(unittest.TestCase):
         x1, x2, y = self._helper(ker_sum, cupy.float32)
         assert cupy.allclose(y, x1 + x2)
 
+
 _test_grid_sync = r'''
 #include <cooperative_groups.h>
 


### PR DESCRIPTION
Close #3193.

In #3193, I found the case from @mnicely hit this subtle **bug**: If a `RawKernel`/`RawModule` is compiled for one device, it cannot be reused on another device. This PR fixes that by detecting current device and recompiling when necessary. (See the added tests for how to reproduce the bug --- the current master branch, or v7, would fail in these tests.)

Usually, this issue is circumvented by using the `cupy.util.memoize(for_each_device=True)` decorator. However, because we can't use that for cdef classes afaik, the internal caching with device ID being part of the key is necessary. 

I also took this chance to enforce some typing that we didn't do before moving to PY3-only. If it's considered unnecessary, let me know and I'll revert. I don't think this would cause any backward incompatibility though.

May be in conflict with #2966? cc: @emcastillo 