### PR TITLE
Make `RawKernel` and `RawModule` aware of CUDA context (alt)

### DIFF
--- a/cupy/core/raw.pxd
+++ b/cupy/core/raw.pxd
@@ -2,6 +2,7 @@ cdef class RawKernel:
 
     cdef:
         readonly str code
+        readonly str file_path
         readonly str name
         readonly tuple options
         readonly str backend
@@ -13,7 +14,7 @@ cdef class RawModule:
 
     cdef:
         readonly str code
-        readonly str cubin_path
+        readonly str file_path
         readonly tuple options
         readonly str backend
         readonly bint enable_cooperative_groups

--- a/cupy/core/raw.pxd
+++ b/cupy/core/raw.pxd
@@ -4,10 +4,9 @@ cdef class RawKernel:
         readonly str code
         readonly str name
         readonly tuple options
-        object _kernel
         readonly str backend
-        bint translate_cucomplex
         readonly bint enable_cooperative_groups
+        bint translate_cucomplex
 
 
 cdef class RawModule:
@@ -16,8 +15,6 @@ cdef class RawModule:
         readonly str code
         readonly str cubin_path
         readonly tuple options
-        dict kernels
         readonly str backend
-        object module
-        bint translate_cucomplex
         readonly bint enable_cooperative_groups
+        bint translate_cucomplex

--- a/cupy/core/raw.pyx
+++ b/cupy/core/raw.pyx
@@ -1,7 +1,8 @@
 import cupy
 from cupy import util
 from cupy.cuda cimport driver
-from cupy.cuda.function cimport Module
+from cupy.cuda cimport runtime
+from cupy.cuda.function cimport Function, Module
 
 
 cdef class RawKernel:
@@ -36,21 +37,15 @@ cdef class RawKernel:
             This feature is only supported in CUDA 9 or later.
     """
 
-    def __init__(self, code, name, options=(), backend='nvrtc', *,
-                 translate_cucomplex=False, enable_cooperative_groups=False):
-        if isinstance(code, bytes):
-            code = code.decode('UTF-8')
-        if isinstance(name, bytes):
-            name = name.decode('UTF-8')
-        if isinstance(backend, bytes):
-            backend = backend.decode('UTF-8')
+    def __init__(self, str code, str name, tuple options=(),
+                 str backend='nvrtc', *, bint translate_cucomplex=False,
+                 bint enable_cooperative_groups=False):
 
         self.code = code
         self.name = name
         self.options = options
         self.backend = backend
         self.translate_cucomplex = translate_cucomplex
-        self._kernel = None
         self.enable_cooperative_groups = enable_cooperative_groups
 
     def __call__(self, grid, block, args, **kwargs):
@@ -75,11 +70,14 @@ cdef class RawKernel:
 
     @property
     def kernel(self):
-        if self._kernel is None:
-            self._kernel = _get_raw_kernel(
-                self.code, self.name, self.options, self.backend,
-                self.translate_cucomplex, self.enable_cooperative_groups)
-        return self._kernel
+        # The kernel is cached, so on the device where this has been called,
+        # we would just look up from the cache, and do recompiling only when
+        # switching to a different device
+        cdef Function ker
+        ker = _get_raw_kernel(
+            self.code, self.name, self.options, self.backend,
+            self.translate_cucomplex, self.enable_cooperative_groups)
+        return ker
 
     @property
     def attributes(self):
@@ -201,14 +199,15 @@ cdef class RawKernel:
 
 
 @cupy.util.memoize(for_each_device=True)
-def _get_raw_kernel(code, name, options=(), backend='nvrtc',
-                    translate_cucomplex=False,
-                    enable_cooperative_groups=False):
-    module = cupy.core.core.compile_with_cache(
-        code, options, prepend_cupy_headers=False, backend=backend,
-        translate_cucomplex=translate_cucomplex,
-        enable_cooperative_groups=enable_cooperative_groups)
-    return module.get_function(name)
+def _get_raw_kernel(str code, str name, tuple options=(), str backend='nvrtc',
+                    bint translate_cucomplex=False,
+                    bint enable_cooperative_groups=False):
+    cdef Module mod
+    cdef Function ker
+    mod = _get_raw_module(code, None, options, backend,
+                          translate_cucomplex, enable_cooperative_groups)
+    ker = mod.get_function(name)
+    return ker
 
 
 cdef class RawModule:
@@ -249,41 +248,42 @@ cdef class RawModule:
     .. note::
         Each kernel in ``RawModule`` possesses independent function attributes.
     """
-    def __init__(self, *, code=None, path=None, options=(), backend='nvrtc',
-                 translate_cucomplex=False, enable_cooperative_groups=False):
+    def __init__(self, *, str code=None, str path=None, tuple options=(),
+                 str backend='nvrtc', bint translate_cucomplex=False,
+                 bint enable_cooperative_groups=False):
         if (code is None) == (path is None):
             raise TypeError(
                 'Exactly one of `code` and `path` keyword arguments must be '
                 'given.')
-        if path is not None and isinstance(path, bytes):
-            path = path.decode('UTF-8')
-        if code is not None and isinstance(code, bytes):
-            code = code.decode('UTF-8')
-        if isinstance(backend, bytes):
-            backend = backend.decode('UTF-8')
 
         self.code = code
         self.cubin_path = path
         self.enable_cooperative_groups = enable_cooperative_groups
 
         if self.code is not None:
-            self.module = cupy.core.core.compile_with_cache(
-                code, options, prepend_cupy_headers=False, backend=backend,
-                translate_cucomplex=translate_cucomplex,
-                enable_cooperative_groups=self.enable_cooperative_groups)
             self.options = options
             self.backend = backend
             self.translate_cucomplex = translate_cucomplex
         elif self.cubin_path is not None:
-            self.module = Module()
-            self.module.load_file(self.cubin_path)
             self.options = ()
             self.backend = 'nvcc'
             self.translate_cucomplex = False
 
-        self.kernels = {}
+        # trigger compiling or loading
+        cdef Module mod = self.module  # noqa
 
-    def get_function(self, name):
+    @property
+    def module(self):
+        # The module is cached, so on the device where this has been called,
+        # we would just look up from the cache, and do recompiling only when
+        # switching to a different device
+        cdef Module mod
+        mod = _get_raw_module(
+            self.code, self.cubin_path, self.options, self.backend,
+            self.translate_cucomplex, self.enable_cooperative_groups)
+        return mod
+
+    def get_function(self, str name):
         """Retrieve a CUDA kernel by its name from the module.
 
         Args:
@@ -292,16 +292,16 @@ cdef class RawModule:
         Returns:
             RawKernel: An ``RawKernel`` instance.
         """
-        if name in self.kernels:
-            return self.kernels[name]
-        else:
-            ker = RawKernel(
-                None, name, self.options, self.backend,
-                translate_cucomplex=self.translate_cucomplex,
-                enable_cooperative_groups=self.enable_cooperative_groups)
-            ker._kernel = self.module.get_function(name)
-            self.kernels[name] = ker
-            return ker
+        # When RawKernel is called, it would look up the module from
+        # cache, do get_function, and then launch
+        cdef RawKernel ker
+        cdef Function func
+        ker = RawKernel(
+            self.code, name, self.options, self.backend,
+            translate_cucomplex=self.translate_cucomplex,
+            enable_cooperative_groups=self.enable_cooperative_groups)
+        func = ker.kernel  # just register the cache  # noqa
+        return ker
 
     def get_texref(self, name):
         '''Retrieve a texture reference by its name from the module.
@@ -339,8 +339,25 @@ cdef class RawModule:
 
         '''
         from cupy.cuda.memory import MemoryPointer, UnownedMemory
-        ptr = self.module.get_global_var(name)
+        cdef Module mod = self.module
+        ptr = mod.get_global_var(name)
         # unable to retrieve size, plus it's not used anywhere, so just put 0
-        mem = UnownedMemory(ptr, 0, self.module)
+        mem = UnownedMemory(ptr, 0, mod)
         memptr = MemoryPointer(mem, 0)
         return memptr
+
+
+@cupy.util.memoize(for_each_device=True)
+def _get_raw_module(str code, str path, tuple options=(), str backend='nvrtc',
+                    bint translate_cucomplex=False,
+                    bint enable_cooperative_groups=False):
+    cdef Module mod
+    if code is not None:
+        mod = cupy.core.core.compile_with_cache(
+            code, options, prepend_cupy_headers=False, backend=backend,
+            translate_cucomplex=translate_cucomplex,
+            enable_cooperative_groups=enable_cooperative_groups)
+    elif path is not None:
+        mod = Module()
+        mod.load_file(path)
+    return mod


### PR DESCRIPTION
Close #3193. Close #3200. 

For motivation see the initial PR #3200. This is an alternative attempt (didn't want to force push there).

After offline discussion with @emcastillo, I am convinced to try and utilize the internal per-device cache (`cupy.util.memoize`), so we don't have to do the cache by ourselves in this module. This should greatly simplifies the code.

This PR has the same expected behavior as the previous one: The same `RawKernel`/`RawModule` instance would be usable on any device. Recompiling (and caching) is done internally when necessary.

No backward compatibility is broken in either PR: Note that if the context is not switched, for `RawKernel`, the actual compilation happens at first launch, whereas for `RawModule`, the compilation happens when creating the instance. Both PRs only addresses the context switching bug.

Tests are simply taken from #3200.