### PR TITLE
Reduce device memory alignment size

### DIFF
--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -676,9 +676,12 @@ cdef class PooledMemory(BaseMemory):
 cdef size_t _index_compaction_threshold = 512
 
 
-# cudaMalloc() is aligned to at least 512 bytes
-# cf. https://gist.github.com/sonots/41daaa6432b1c8b27ef782cd14064269
-DEF ALLOCATION_UNIT_SIZE = 512
+# cudaMalloc() is aligned to at least 256 bytes:
+# "Any address of a variable residing in global memory or returned by one of
+# the memory allocation routines from the driver or runtime API is always
+# aligned to at least 256 bytes", see
+# https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#device-memory-accesses  # noqa
+DEF ALLOCATION_UNIT_SIZE = 256
 # for test
 _allocation_unit_size = ALLOCATION_UNIT_SIZE
 


### PR DESCRIPTION
Not sure if there's any other design decisions that I overlooked, but according to @jrhemstad in https://github.com/cupy/cupy/pull/3212#discussion_r396686736 the documented alignment is 256 bytes, not 512 bytes.

Also, it seems like 512 is hard-coded in pinned memory as well? I didn't touch it in this PR, though.

@okuta Any comments? I'm trying to tracing back to the original commit. Thanks.

