### PR TITLE
Fix byte buffer handling to support PyPy

### DIFF
--- a/cupy/cuda/nvrtc.pyx
+++ b/cupy/cuda/nvrtc.pyx
@@ -120,37 +120,29 @@ cpdef compileProgram(intptr_t prog, options):
 
 cpdef unicode getPTX(intptr_t prog):
     cdef size_t ptxSizeRet
-    cdef bytes ptx
-    cdef char* ptx_ptr
+    cdef vector.vector[char] ptx
     with nogil:
         status = nvrtcGetPTXSize(<Program>prog, &ptxSizeRet)
     check_status(status)
-    ptx = b' ' * ptxSizeRet
-    ptx_ptr = ptx
+    ptx.resize(ptxSizeRet)
     with nogil:
-        status = nvrtcGetPTX(<Program>prog, ptx_ptr)
+        status = nvrtcGetPTX(<Program>prog, &ptx[0])
     check_status(status)
 
     # Strip the trailing NULL.
-    assert ptx.endswith(b'\x00')
-    ptx = ptx[:-1]
-    return ptx.decode('UTF-8')
+    return (&ptx[0])[:ptxSizeRet-1].decode('UTF-8')
 
 
 cpdef unicode getProgramLog(intptr_t prog):
     cdef size_t logSizeRet
-    cdef bytes log
-    cdef char* log_ptr
+    cdef vector.vector[char] log
     with nogil:
         status = nvrtcGetProgramLogSize(<Program>prog, &logSizeRet)
     check_status(status)
-    log = b' ' * logSizeRet
-    log_ptr = log
+    log.resize(logSizeRet)
     with nogil:
-        status = nvrtcGetProgramLog(<Program>prog, log_ptr)
+        status = nvrtcGetProgramLog(<Program>prog, &log[0])
     check_status(status)
 
     # Strip the trailing NULL.
-    assert log.endswith(b'\x00')
-    log = log[:-1]
-    return log.decode('UTF-8')
+    return (&log[0])[:logSizeRet-1].decode('UTF-8')


### PR DESCRIPTION
This PR solves conda-forge/cupy-feedstock#43 (#3221).

I tested on following environment.
```
Python 3.6.9 (1608da62bfc7, Dec 23 2019, 10:50:04)
[PyPy 7.3.0 with GCC 7.3.1 20180303 (Red Hat 7.3.1-5)] on linux
```