### PR TITLE
Fix coding style in Cython files

### DIFF
--- a/.flake8.cython
+++ b/.flake8.cython
@@ -1,4 +1,4 @@
 [flake8]
 filename = *.pyx,*.px*
 exclude = .eggs,*.egg,build,docs,.git
-ignore = W503,W504,E225,E226,E227,E999
+ignore = E225,E226,E227,E999

--- a/cupy/core/_kernel.pyx
+++ b/cupy/core/_kernel.pyx
@@ -176,11 +176,11 @@ cdef class _ArgInfo:
             return False
         oth = other
         return (
-            self.arg_kind == oth.arg_kind
-            and self.type is oth.type
-            and self.dtype == oth.dtype
-            and self.ndim == oth.ndim
-            and self.c_contiguous == oth.c_contiguous)
+            self.arg_kind == oth.arg_kind and
+            self.type is oth.type and
+            self.dtype == oth.dtype and
+            self.ndim == oth.ndim and
+            self.c_contiguous == oth.c_contiguous)
 
     cdef _ArgInfo as_ndarray_with_ndim(self, int ndim):
         # Returns an ndarray _ArgInfo with altered ndim.
@@ -377,11 +377,11 @@ cdef class ParameterInfo:
             return False
         oth = other
         return (
-            self.name == oth.name
-            and self.dtype == oth.dtype
-            and self.ctype == oth.ctype
-            and self.raw == oth.raw
-            and self.is_const == oth.is_const)
+            self.name == oth.name and
+            self.dtype == oth.dtype and
+            self.ctype == oth.ctype and
+            self.raw == oth.raw and
+            self.is_const == oth.is_const)
 
     def __repr__(self):
         return '<ParameterInfo({})>'.format(

--- a/cupy/core/_memory_range.pyx
+++ b/cupy/core/_memory_range.pyx
@@ -1,9 +1,7 @@
 from cupy.core.core cimport ndarray
 from cupy.cuda cimport memory
 
-from libc.stdint cimport intptr_t
 from libcpp.pair cimport pair
-from libcpp.vector cimport vector
 
 
 cdef pair[Py_ssize_t, Py_ssize_t] _get_bound(ndarray array):
@@ -28,9 +26,9 @@ cpdef bint may_share_bounds(ndarray a, ndarray b):
     cdef memory.MemoryPointer b_data = b.data
     cdef pair[Py_ssize_t, Py_ssize_t] a_range, b_range
 
-    if (a_data.device_id != b_data.device_id
-            or a_data.mem.ptr != b_data.mem.ptr
-            or a.size == 0 or b.size == 0):
+    if (a_data.device_id != b_data.device_id or
+            a_data.mem.ptr != b_data.mem.ptr or
+            a.size == 0 or b.size == 0):
         return False
 
     a_range = _get_bound(a)

--- a/cupy/core/_reduction.pyx
+++ b/cupy/core/_reduction.pyx
@@ -180,7 +180,7 @@ cdef Py_ssize_t _get_contiguous_size(
     return contiguous_size
 
 
-cpdef (Py_ssize_t, Py_ssize_t, Py_ssize_t) _get_block_specs(  # NOQA
+cpdef(Py_ssize_t, Py_ssize_t, Py_ssize_t) _get_block_specs(  # NOQA
         Py_ssize_t in_size, Py_ssize_t out_size,
         Py_ssize_t contiguous_size) except*:
     cdef Py_ssize_t reduce_block_size, block_stride, out_block_num
@@ -214,10 +214,10 @@ cdef class _AbstractReductionKernel:
         in_params_ = _get_param_info(in_params, True)
         out_params_ = _get_param_info(out_params, False)
         params = (
-            in_params_
-            + out_params_
-            + _get_param_info('CIndexer _in_ind, CIndexer _out_ind', False)
-            + _get_param_info('int32 _block_stride', True))
+            in_params_ +
+            out_params_ +
+            _get_param_info('CIndexer _in_ind, CIndexer _out_ind', False) +
+            _get_param_info('int32 _block_stride', True))
 
         self.name = name
         self.identity = identity
@@ -251,9 +251,9 @@ cdef class _AbstractReductionKernel:
         # When there is only one input array, sort the axes in such a way that
         # contiguous (C or F) axes can be squashed in _reduce_dims() later.
         # TODO(niboshi): Support (out_axis) > 1
-        if (len(in_args) == 1
-                and len(out_axis) <= 1
-                and not in_args[0]._c_contiguous):
+        if (len(in_args) == 1 and
+                len(out_axis) <= 1 and
+                not in_args[0]._c_contiguous):
             strides = in_args[0].strides
             reduce_axis = _sort_axis(reduce_axis, strides)
             out_axis = _sort_axis(out_axis, strides)
@@ -288,9 +288,9 @@ cdef class _AbstractReductionKernel:
 
         # Kernel arguments passed to the __global__ function.
         inout_args = (
-            in_args
-            + out_args
-            + [
+            in_args +
+            out_args +
+            [
                 _carray.Indexer(in_shape),
                 _carray.Indexer(out_shape),
                 # block_stride is passed as the last argument.

--- a/cupy/core/_reduction.pyx
+++ b/cupy/core/_reduction.pyx
@@ -180,7 +180,7 @@ cdef Py_ssize_t _get_contiguous_size(
     return contiguous_size
 
 
-cpdef(Py_ssize_t, Py_ssize_t, Py_ssize_t) _get_block_specs(  # NOQA
+cpdef (Py_ssize_t, Py_ssize_t, Py_ssize_t) _get_block_specs(  # NOQA
         Py_ssize_t in_size, Py_ssize_t out_size,
         Py_ssize_t contiguous_size) except*:
     cdef Py_ssize_t reduce_block_size, block_stride, out_block_num

--- a/cupy/core/_routines_statistics.pyx
+++ b/cupy/core/_routines_statistics.pyx
@@ -246,8 +246,8 @@ nanmax = create_reduction_func(
 
 cdef _argmin = create_reduction_func(
     'cupy_argmin',
-    tuple(['{}->{}'.format(d, r) for r in 'qlihb' for d in '?BhHiIlLqQ'])
-    + (
+    tuple(['{}->{}'.format(d, r) for r in 'qlihb' for d in '?BhHiIlLqQ']) +
+    (
         ('e->q', (None, 'my_argmin_float(a, b)', None, None)),
         ('f->q', (None, 'my_argmin_float(a, b)', None, None)),
         ('d->q', (None, 'my_argmin_float(a, b)', None, None)),
@@ -260,8 +260,8 @@ cdef _argmin = create_reduction_func(
 
 cdef _argmax = create_reduction_func(
     'cupy_argmax',
-    tuple(['{}->{}'.format(d, r) for r in 'qlihb' for d in '?BhHiIlLqQ'])
-    + (
+    tuple(['{}->{}'.format(d, r) for r in 'qlihb' for d in '?BhHiIlLqQ']) +
+    (
         ('e->q', (None, 'my_argmax_float(a, b)', None, None)),
         ('f->q', (None, 'my_argmax_float(a, b)', None, None)),
         ('d->q', (None, 'my_argmax_float(a, b)', None, None)),

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1248,9 +1248,9 @@ cdef class ndarray:
 
         """
         if util.ENABLE_SLICE_COPY and (
-                type(slices) is slice
-                and slices == slice(None, None, None)
-                and isinstance(value, numpy.ndarray)
+                type(slices) is slice and
+                slices == slice(None, None, None) and
+                isinstance(value, numpy.ndarray)
         ):
             if self.dtype == value.dtype and self.shape == value.shape:
                 if self.strides == value.strides:
@@ -1304,7 +1304,6 @@ cdef class ndarray:
 
     # numpy/ufunc compat
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
-
         """Apply unary or binary ufunc to this array
 
         If binary, only allow if second argument is another cupy ndarray or
@@ -2048,7 +2047,7 @@ cdef tuple _get_concat_shape_impl(object obj):
     cdef obj_type = type(obj)
     if issubclass(obj_type, (numpy.ndarray, ndarray)):
         # obj.shape is () when obj.ndim == 0
-        return (obj.shape, obj_type, obj.dtype)
+        return obj.shape, obj_type, obj.dtype
     if isinstance(obj, (list, tuple)):
         shape = None
         typ = None
@@ -2065,10 +2064,10 @@ cdef tuple _get_concat_shape_impl(object obj):
 
             # `elem` is not concatable or the shape and dtype does not match
             # with siblings.
-            if (elem_shape is None
-                    or shape != elem_shape
-                    or dtype != elem_dtype):
-                return (None, obj_type, None)
+            if (elem_shape is None or
+                    shape != elem_shape or
+                    dtype != elem_dtype):
+                return None, obj_type, None
 
         if shape is None:
             shape = ()
@@ -2077,7 +2076,7 @@ cdef tuple _get_concat_shape_impl(object obj):
             typ,
             dtype)
     # scalar or object
-    return (None, obj_type, None)
+    return None, obj_type, None
 
 
 cdef list _flatten_list(object obj):
@@ -2173,8 +2172,8 @@ cdef bint _numpy_concatenate_has_out_argument = (
 cdef inline _concatenate_numpy_array(arrays, axis, src_dtype, dst_dtype, out):
     # type(*_dtype) must be numpy.dtype
 
-    if (_numpy_concatenate_has_out_argument
-            and src_dtype.kind == dst_dtype.kind):
+    if (_numpy_concatenate_has_out_argument and
+            src_dtype.kind == dst_dtype.kind):
         # concatenate only accepts same_kind casting
         numpy.concatenate(arrays, axis, out)
     else:

--- a/cupy/core/raw.pyx
+++ b/cupy/core/raw.pyx
@@ -253,6 +253,7 @@ cdef class RawModule:
     .. note::
         Each kernel in ``RawModule`` possesses independent function attributes.
     """
+
     def __init__(self, *, str code=None, str path=None, tuple options=(),
                  str backend='nvrtc', bint translate_cucomplex=False,
                  bint enable_cooperative_groups=False):

--- a/cupy/cuda/cutensor.pyx
+++ b/cupy/cuda/cutensor.pyx
@@ -195,9 +195,9 @@ cpdef enum:
     C_MIN_32F = 8    # NOQA, complex as a float
     R_MIN_64F = 16   # NOQA, real as a double
     C_MIN_64F = 32   # NOQA, complex as a double
-    R_MIN_8U  = 64   # NOQA, real as a uint8
+    R_MIN_8U = 64   # NOQA, real as a uint8
     R_MIN_32U = 128  # NOQA, real as a uint32
-    R_MIN_8I  = 256  # NOQA, real as a int8
+    R_MIN_8I = 256  # NOQA, real as a int8
     R_MIN_32I = 512  # NOQA, real as a int32
 
 

--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -1144,8 +1144,9 @@ cdef class SingleDeviceMemoryPool:
         cdef size_t bin_index = _bin_index_from_size(size)
         cdef _Arena a = self._arena(stream_ptr)
         index = <size_t>(
-            algorithm.lower_bound(a._index.begin(), a._index.end(), bin_index)
-            - a._index.begin())
+            algorithm.lower_bound(
+                a._index.begin(), a._index.end(), bin_index) -
+            a._index.begin())
         length = a._index.size()
         for i in range(index, length):
             if a._flag.at(i) == 0:

--- a/cupy/cuda/texture.pyx
+++ b/cupy/cuda/texture.pyx
@@ -30,6 +30,7 @@ cdef class ChannelFormatDescriptor:
     .. _cudaCreateChannelDesc():
         https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__TEXTURE__OBJECT.html#group__CUDART__TEXTURE__OBJECT_1g39df9e3b6edc41cd6f189d2109672ca5
     '''  # noqa
+
     def __init__(self, int x, int y, int z, int w, int f):
         # We don't call cudaCreateChannelDesc() here for two reasons: 1. to
         # avoid out of scope; 2. it doesn't do input verification for us.
@@ -102,6 +103,7 @@ cdef class ResourceDescriptor:
     .. _cudaCreateTextureObject():
         https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__TEXTURE__OBJECT.html#group__CUDART__TEXTURE__OBJECT_1g16ac75814780c3a16e4c63869feb9ad3
     '''  # noqa
+
     def __init__(self, int restype, CUDAarray cuArr=None, ndarray arr=None,
                  ChannelFormatDescriptor chDesc=None, size_t sizeInBytes=0,
                  size_t width=0, size_t height=0, size_t pitchInBytes=0):
@@ -194,6 +196,7 @@ cdef class TextureDescriptor:
     .. _cudaCreateTextureObject():
         https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__TEXTURE__OBJECT.html#group__CUDART__TEXTURE__OBJECT_1g16ac75814780c3a16e4c63869feb9ad3
     '''  # noqa
+
     def __init__(self, addressModes=None, int filterMode=0, int readMode=0,
                  sRGB=None, borderColors=None, normalizedCoords=None,
                  maxAnisotropy=None):
@@ -274,6 +277,7 @@ cdef class CUDAarray:
     '''  # noqa
     # TODO(leofang): perhaps this wrapper is not needed when cupy.ndarray
     # can be backed by texture memory/CUDA arrays?
+
     def __init__(self, ChannelFormatDescriptor desc, size_t width,
                  size_t height=0, size_t depth=0, unsigned int flags=0):
         if width == 0:
@@ -493,6 +497,7 @@ cdef class TextureObject:
     .. _cudaCreateTextureObject():
         https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__TEXTURE__OBJECT.html#group__CUDART__TEXTURE__OBJECT_1g16ac75814780c3a16e4c63869feb9ad3
     '''  # noqa
+
     def __init__(self, ResourceDescriptor ResDesc, TextureDescriptor TexDesc):
         self.ptr = runtime.createTextureObject(ResDesc.ptr, TexDesc.ptr)
         self.ResDesc = ResDesc
@@ -532,6 +537,7 @@ cdef class TextureReference:
     '''  # noqa
     # Basically, this class translates from the Runtime API's descriptors
     # to the driver API calls.
+
     def __init__(self, intptr_t texref, ResourceDescriptor ResDesc,
                  TextureDescriptor TexDesc):
         cdef ResourceDesc* ResDescPtr = <ResourceDesc*>(ResDesc.ptr)

--- a/cupy/cudnn.pyx
+++ b/cupy/cudnn.pyx
@@ -2173,10 +2173,10 @@ cdef _batch_normalization_forward_training(
             bn_ops = cudnn.CUDNN_BATCHNORM_OPS_BN
 
             if (
-                    cudnn_mode == cudnn.CUDNN_BATCHNORM_SPATIAL_PERSISTENT
-                    and x.dtype == numpy.float16
-                    and d_layout == cudnn.CUDNN_TENSOR_NHWC
-                    and x.shape[3] % 4 == 0  # C mod 4 == 0
+                    cudnn_mode == cudnn.CUDNN_BATCHNORM_SPATIAL_PERSISTENT and
+                    x.dtype == numpy.float16 and
+                    d_layout == cudnn.CUDNN_TENSOR_NHWC and
+                    x.shape[3] % 4 == 0  # C mod 4 == 0
             ):
 
                 # Faster NHWC kernel can be triggered by allocating extra


### PR DESCRIPTION
`ignore = W503,W504` is not necessary to format Ctyhon files.

