### PR TITLE
make diff return AxisError for an invalid axis

### DIFF
--- a/cupy/math/sumprod.py
+++ b/cupy/math/sumprod.py
@@ -3,6 +3,7 @@ import numpy
 import cupy
 from cupy.core import _routines_math as _math
 from cupy.core import fusion
+from cupy.util import _normalize_axis_index
 
 
 def sum(a, axis=None, dtype=None, out=None, keepdims=False):
@@ -183,6 +184,7 @@ def diff(a, n=1, axis=-1, prepend=None, append=None):
 
     a = cupy.asanyarray(a)
     nd = a.ndim
+    axis = _normalize_axis_index(axis, nd)
 
     combined = []
 

--- a/tests/cupy_tests/math_tests/test_sumprod.py
+++ b/tests/cupy_tests/math_tests/test_sumprod.py
@@ -580,4 +580,3 @@ class TestDiff(unittest.TestCase):
                 xp.diff(a, axis=3)
             with pytest.raises(numpy.AxisError):
                 xp.diff(a, axis=-4)
-        return

--- a/tests/cupy_tests/math_tests/test_sumprod.py
+++ b/tests/cupy_tests/math_tests/test_sumprod.py
@@ -1,6 +1,7 @@
 import unittest
 
 import numpy
+import pytest
 
 import cupy
 from cupy import testing
@@ -570,3 +571,13 @@ class TestDiff(unittest.TestCase):
     def test_diff_2dim_with_scalar_append(self, xp, dtype):
         a = testing.shaped_arange((4, 5), xp, dtype)
         return xp.diff(a, prepend=1, append=0)
+
+    @testing.with_requires('numpy>=1.16')
+    def test_diff_invalid_axis(self):
+        for xp in (numpy, cupy):
+            a = testing.shaped_arange((2, 3, 4), xp)
+            with pytest.raises(numpy.AxisError):
+                xp.diff(a, axis=3)
+            with pytest.raises(numpy.AxisError):
+                xp.diff(a, axis=-4)
+        return


### PR DESCRIPTION
Currently calling `cupy.diff` with an out-of-range axis results in an `IndexError` when trying to access an invalid list element. NumPy explicitly checks the axis and raises an `AxisError` in this case. This PR makes the error types consistent.
