### PR TITLE
Remove unreachable code

### DIFF
--- a/cupy/core/_kernel.pyx
+++ b/cupy/core/_kernel.pyx
@@ -111,7 +111,6 @@ cdef str _get_c_type(Arg arg):
         return _get_typename(arg.dtype)
     else:  # indexer
         return 'CIndexer<%d>' % arg.ndim
-    assert False
 
 
 cdef str _get_param_c_type(Arg arg, ParameterInfo p):


### PR DESCRIPTION
The change removes the following warning by cython(==0.29.16).
```
[ 1/16] Cythonizing cupy/core/_kernel.pyx
warning: cupy/core/_kernel.pyx:114:4: Unreachable code
```