### PR TITLE
Add four functions in scipy.ndimage

### DIFF
--- a/cupyx/scipy/ndimage/__init__.py
+++ b/cupyx/scipy/ndimage/__init__.py
@@ -13,3 +13,5 @@ from cupyx.scipy.ndimage.measurements import label  # NOQA
 
 from cupyx.scipy.ndimage.morphology import grey_erosion  # NOQA
 from cupyx.scipy.ndimage.morphology import grey_dilation  # NOQA
+from cupyx.scipy.ndimage.morphology import grey_closing  # NOQA
+from cupyx.scipy.ndimage.morphology import grey_opening  # NOQA

--- a/cupyx/scipy/ndimage/__init__.py
+++ b/cupyx/scipy/ndimage/__init__.py
@@ -1,5 +1,7 @@
 from cupyx.scipy.ndimage.filters import correlate  # NOQA
 from cupyx.scipy.ndimage.filters import convolve  # NOQA
+from cupyx.scipy.ndimage.filters import minimum_filter  # NOQA
+from cupyx.scipy.ndimage.filters import maximum_filter  # NOQA
 
 from cupyx.scipy.ndimage.interpolation import affine_transform  # NOQA
 from cupyx.scipy.ndimage.interpolation import map_coordinates  # NOQA

--- a/cupyx/scipy/ndimage/filters.py
+++ b/cupyx/scipy/ndimage/filters.py
@@ -354,3 +354,69 @@ def _get_min_or_max_kernel(ndim, fp_shape, use_structure, modes, cval,
     in_params, out_params, operation, name = _generate_min_or_max_kernel(
         ndim, fp_shape, use_structure, modes, cval, origins, minimum)
     return cupy.ElementwiseKernel(in_params, out_params, operation, name)
+
+
+def minimum_filter(input, size=None, footprint=None, output=None,
+                   mode='reflect', cval=0.0, origin=0):
+    """Calculates a multi-dimensional minimum filter.
+
+    Args:
+        input (cupy.ndarray): The input array.
+        size (tuple of ints): ```size``` specifies the shape that is taken from
+            the input array, at every element position, to define the input to
+            the filter function.
+        footprint (array of ints): ```footprint``` specifies the shape, but
+            also which elements within the shape will get passed to the filter
+             function.
+        output (cupy.ndarray, dtype or None): The array in which to place the
+            output.
+        mode (str): The array borders are handled according to the given mode
+            (``'reflect'``, ``'constant'``, ``'nearest'``, ``'mirror'``,
+            ``'wrap'``). Default is ``'reflect'``.
+        cval (scalar): Value to fill past edges of input if mode is
+            ``constant``. Default is ``0.0``.
+        origin (scalar or tuple of scalar): The origin parameter controls the
+            placement of the filter, relative to the center of the current
+            element of the input. Default of 0 is equivalent to
+            ``(0,)*input.ndim``.
+
+    Returns:
+        cupy.ndarray: The result of minimum filter.
+
+    .. seealso:: :func:`scipy.ndimage.minimum_filter`
+    """
+    return _min_or_max_filter(input, size, footprint, None, output, mode, cval,
+                              origin, True)
+
+
+def maximum_filter(input, size=None, footprint=None, output=None,
+                   mode='reflect', cval=0.0, origin=0):
+    """Calculates a multi-dimensional maximum filter.
+
+    Args:
+        input (cupy.ndarray): The input array.
+        size (tuple of ints): ```size``` specifies the shape that is taken from
+            the input array, at every element position, to define the input to
+            the filter function.
+        footprint (array of ints): ```footprint``` specifies the shape, but
+            also which elements within the shape will get passed to the filter
+             function.
+        output (cupy.ndarray, dtype or None): The array in which to place the
+            output.
+        mode (str): The array borders are handled according to the given mode
+            (``'reflect'``, ``'constant'``, ``'nearest'``, ``'mirror'``,
+            ``'wrap'``). Default is ``'reflect'``.
+        cval (scalar): Value to fill past edges of input if mode is
+            ``constant``. Default is ``0.0``.
+        origin (scalar or tuple of scalar): The origin parameter controls the
+            placement of the filter, relative to the center of the current
+            element of the input. Default of 0 is equivalent to
+            ``(0,)*input.ndim``.
+
+    Returns:
+        cupy.ndarray: The result of maximum filter.
+
+    .. seealso:: :func:`scipy.ndimage.maximum_filter`
+    """
+    return _min_or_max_filter(input, size, footprint, None, output, mode, cval,
+                              origin, False)

--- a/cupyx/scipy/ndimage/morphology.py
+++ b/cupyx/scipy/ndimage/morphology.py
@@ -114,14 +114,14 @@ def grey_closing(input, size=None, footprint=None, structure=None,
     Args:
         input (cupy.ndarray): The input array.
         size (tuple of ints): Shape of a flat and full structuring element used
-            for the greyscale dilation. Optional if ```footprint``` or
+            for the greyscale closing. Optional if ```footprint``` or
             ```structure``` is provided.
         footprint (array of ints): Positions of non-infinite elements of a flat
-            structuring element used for greyscale dilation. Non-zero values
-            give the set of neighbors of the center over which maximum is
+            structuring element used for greyscale closing. Non-zero values
+            give the set of neighbors of the center over which closing is
             chosen.
         structure (array of ints): Structuring element used for the greyscale
-            dilation. ```structure``` may be a non-flat structuring element.
+            closing. ```structure``` may be a non-flat structuring element.
         output (cupy.ndarray, dtype or None): The array in which to place the
             output.
         mode (str): The array borders are handled according to the given mode
@@ -155,14 +155,14 @@ def grey_opening(input, size=None, footprint=None, structure=None,
     Args:
         input (cupy.ndarray): The input array.
         size (tuple of ints): Shape of a flat and full structuring element used
-            for the greyscale dilation. Optional if ```footprint``` or
+            for the greyscale opening. Optional if ```footprint``` or
             ```structure``` is provided.
         footprint (array of ints): Positions of non-infinite elements of a flat
-            structuring element used for greyscale dilation. Non-zero values
-            give the set of neighbors of the center over which maximum is
+            structuring element used for greyscale opening. Non-zero values
+            give the set of neighbors of the center over which opening is
             chosen.
         structure (array of ints): Structuring element used for the greyscale
-            dilation. ```structure``` may be a non-flat structuring element.
+            opening. ```structure``` may be a non-flat structuring element.
         output (cupy.ndarray, dtype or None): The array in which to place the
             output.
         mode (str): The array borders are handled according to the given mode

--- a/cupyx/scipy/ndimage/morphology.py
+++ b/cupyx/scipy/ndimage/morphology.py
@@ -2,6 +2,8 @@ import numpy
 
 import cupy
 
+import warnings
+
 from . import filters
 
 
@@ -103,3 +105,85 @@ def grey_dilation(input, size=None, footprint=None, structure=None,
 
     return filters._min_or_max_filter(input, size, footprint, structure,
                                       output, mode, cval, origin, False)
+
+
+def grey_closing(input, size=None, footprint=None, structure=None,
+                 output=None, mode='reflect', cval=0.0, origin=0):
+    """Calculates a multi-dimensional greyscale closing.
+
+    Args:
+        input (cupy.ndarray): The input array.
+        size (tuple of ints): Shape of a flat and full structuring element used
+            for the greyscale dilation. Optional if ```footprint``` or
+            ```structure``` is provided.
+        footprint (array of ints): Positions of non-infinite elements of a flat
+            structuring element used for greyscale dilation. Non-zero values
+            give the set of neighbors of the center over which maximum is
+            chosen.
+        structure (array of ints): Structuring element used for the greyscale
+            dilation. ```structure``` may be a non-flat structuring element.
+        output (cupy.ndarray, dtype or None): The array in which to place the
+            output.
+        mode (str): The array borders are handled according to the given mode
+            (``'reflect'``, ``'constant'``, ``'nearest'``, ``'mirror'``,
+            ``'wrap'``). Default is ``'reflect'``.
+        cval (scalar): Value to fill past edges of input if mode is
+            ``constant``. Default is ``0.0``.
+        origin (scalar or tuple of scalar): The origin parameter controls the
+            placement of the filter, relative to the center of the current
+            element of the input. Default of 0 is equivalent to
+            ``(0,)*input.ndim``.
+
+    Returns:
+        cupy.ndarray: The result of greyscale closing.
+
+    .. seealso:: :func:`scipy.ndimage.grey_closing`
+    """
+    if (size is not None) and (footprint is not None):
+        warnings.warn("ignoring size because footprint is set", UserWarning,
+                      stacklevel=2)
+    tmp = grey_dilation(input, size, footprint, structure, None, mode, cval,
+                        origin)
+    return grey_erosion(tmp, size, footprint, structure, output, mode, cval,
+                        origin)
+
+
+def grey_opening(input, size=None, footprint=None, structure=None,
+                 output=None, mode='reflect', cval=0.0, origin=0):
+    """Calculates a multi-dimensional greyscale opening.
+
+    Args:
+        input (cupy.ndarray): The input array.
+        size (tuple of ints): Shape of a flat and full structuring element used
+            for the greyscale dilation. Optional if ```footprint``` or
+            ```structure``` is provided.
+        footprint (array of ints): Positions of non-infinite elements of a flat
+            structuring element used for greyscale dilation. Non-zero values
+            give the set of neighbors of the center over which maximum is
+            chosen.
+        structure (array of ints): Structuring element used for the greyscale
+            dilation. ```structure``` may be a non-flat structuring element.
+        output (cupy.ndarray, dtype or None): The array in which to place the
+            output.
+        mode (str): The array borders are handled according to the given mode
+            (``'reflect'``, ``'constant'``, ``'nearest'``, ``'mirror'``,
+            ``'wrap'``). Default is ``'reflect'``.
+        cval (scalar): Value to fill past edges of input if mode is
+            ``constant``. Default is ``0.0``.
+        origin (scalar or tuple of scalar): The origin parameter controls the
+            placement of the filter, relative to the center of the current
+            element of the input. Default of 0 is equivalent to
+            ``(0,)*input.ndim``.
+
+    Returns:
+        cupy.ndarray: The result of greyscale opening.
+
+    .. seealso:: :func:`scipy.ndimage.grey_opening`
+    """
+    if (size is not None) and (footprint is not None):
+        warnings.warn("ignoring size because footprint is set", UserWarning,
+                      stacklevel=2)
+    tmp = grey_erosion(input, size, footprint, structure, None, mode, cval,
+                       origin)
+    return grey_dilation(tmp, size, footprint, structure, output, mode, cval,
+                         origin)

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
@@ -119,3 +119,43 @@ class TestConvolveAndCorrelateSpecialCases(unittest.TestCase):
                         self._filter(cupyx.scipy, a, w, origin=origin)
                 else:
                     self._filter(cupyx.scipy, a, w, origin=origin)
+
+
+@testing.parameterize(*testing.product({
+    'size': [3, 4],
+    'footprint': [None, 'random'],
+    'mode': ['reflect', 'constant', 'nearest', 'mirror', 'wrap'],
+    'origin': [0, None],
+    'x_dtype': [numpy.int32, numpy.float32],
+    'output': [None, numpy.float64],
+    'filter': ['minimum_filter', 'maximum_filter']
+}))
+@testing.gpu
+@testing.with_requires('scipy')
+class TestMinimumMaximumFilter(unittest.TestCase):
+
+    shape = (4, 5)
+    cval = 0.0
+
+    def _filter(self, xp, scp, x):
+        filter = getattr(scp.ndimage, self.filter)
+        if self.origin is None:
+            origin = (-1, 1, -1, 1)[:x.ndim]
+        else:
+            origin = self.origin
+        if self.footprint is None:
+            footprint = None
+        else:
+            shape = (self.size, ) * x.ndim
+            r = testing.shaped_random(shape, xp, scale=1)
+            footprint = xp.where(r < .5, 1, 0)
+            if not footprint.any():
+                footprint = xp.ones(shape)
+        return filter(x, size=self.size, footprint=footprint,
+                      output=self.output, mode=self.mode, cval=self.cval,
+                      origin=origin)
+
+    @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
+    def test_minimum_and_maximum_filter(self, xp, scp):
+        x = testing.shaped_random(self.shape, xp, self.x_dtype)
+        return self._filter(xp, scp, x)


### PR DESCRIPTION
This PR is to make following four functions in scipy.ndimage available in CuPy.
* [minimum_filter](https://docs.scipy.org/doc/scipy/reference/generated/scipy.ndimage.minimum_filter.html)
* [maximum_filter](https://docs.scipy.org/doc/scipy/reference/generated/scipy.ndimage.maximum_filter.html)
* [grey_closing](https://docs.scipy.org/doc/scipy/reference/generated/scipy.ndimage.grey_closing.html)
* [grey_opening](https://docs.scipy.org/doc/scipy/reference/generated/scipy.ndimage.grey_opening.html)

I think this is relatively easy PR since the core routines required for the functions above are already implemented by https://github.com/cupy/cupy/pull/3216.