### PR TITLE
[backport] Fix: n-dimensional FFTs must preserve array contiguity when copying a view

### DIFF
--- a/cupy/fft/fft.py
+++ b/cupy/fft/fft.py
@@ -325,9 +325,6 @@ def _exec_fftn(a, direction, value_type, norm, axes, overwrite_x,
     if fft_type not in [cufft.CUFFT_C2C, cufft.CUFFT_Z2Z]:
         raise NotImplementedError('Only C2C and Z2Z are supported.')
 
-    if a.base is not None:
-        a = a.copy()
-
     if a.flags.c_contiguous:
         order = 'C'
     elif a.flags.f_contiguous:

--- a/tests/cupyx_tests/scipy_tests/fftpack_tests/test_fftpack.py
+++ b/tests/cupyx_tests/scipy_tests/fftpack_tests/test_fftpack.py
@@ -1,6 +1,7 @@
 import unittest
 import pytest
 
+import cupy
 from cupy import testing
 import cupyx.scipy.fftpack  # NOQA
 from cupy.fft.fft import _default_plan_type
@@ -578,3 +579,64 @@ class TestRfft(unittest.TestCase):
         x = testing.shaped_random(self.shape, xp, dtype)
         return scp.fftpack.irfft(x, n=self.n, axis=self.axis,
                                  overwrite_x=True)
+
+
+@testing.parameterize(
+    {'shape': (32, 16, 4), 'data_order': 'F'},
+    {'shape': (4, 32, 16), 'data_order': 'C'},
+)
+class TestFftnView(unittest.TestCase):
+
+    @testing.for_complex_dtypes()
+    def test_contiguous_view(self, dtype):
+        # Fortran-ordered case tests: https://github.com/cupy/cupy/issues/3079
+        a = testing.shaped_random(self.shape, cupy, dtype)
+        if self.data_order == 'F':
+            a = cupy.asfortranarray(a)
+            sl = [Ellipsis, 0]
+        else:
+            sl = [0, Ellipsis]
+
+        # transform a contiguous view without pre-planning
+        view = a[sl]
+        expected = cupyx.scipy.fftpack.fftn(view)
+
+        # create plan and then apply it to a contiguous view
+        plan = cupyx.scipy.fftpack.get_fft_plan(view)
+        with plan:
+            out = cupyx.scipy.fftpack.fftn(view)
+        testing.assert_allclose(expected, out)
+
+    @testing.for_complex_dtypes()
+    def test_noncontiguous_view(self, dtype):
+        a = testing.shaped_random(self.shape, cupy, dtype)
+        if self.data_order == 'F':
+            a = cupy.asfortranarray(a)
+            sl = [Ellipsis, slice(None, None, 2)]
+        else:
+            sl = [slice(None, None, 2), Ellipsis]
+
+        # transform a non-contiguous view without pre-planning
+        view = a[sl]
+        expected = cupyx.scipy.fftpack.fftn(view)
+
+        # create plan and then apply it to a non-contiguous view
+        plan = cupyx.scipy.fftpack.get_fft_plan(view.copy())
+        with plan:
+            out = cupyx.scipy.fftpack.fftn(view)
+        testing.assert_allclose(expected, out)
+
+    @testing.for_complex_dtypes()
+    def test_overwrite_x_with_contiguous_view(self, dtype):
+        # Test case for: https://github.com/cupy/cupy/issues/3079
+        a = testing.shaped_random(self.shape, cupy, dtype)
+        if self.data_order == 'C':
+            # C-contiguous view
+            b = a[:a.shape[0] // 2, ...]
+        else:
+            # F-contiguous view
+            a = cupy.asfortranarray(a)
+            b = a[..., :a.shape[-1] // 2]
+        b_ptr = b.data.ptr
+        out = cupyx.scipy.fftpack.fftn(b, overwrite_x=True)
+        assert out.data.ptr == b_ptr


### PR DESCRIPTION
Backport of #3034