### PR TITLE
Implement `flatiter.base` property

### DIFF
--- a/cupy/indexing/iterate.py
+++ b/cupy/indexing/iterate.py
@@ -106,7 +106,10 @@ class flatiter:
 
     # TODO(Takagi): Implement copy
 
-    # TODO(Takagi): Implement base
+    @property
+    def base(self):
+        """A reference to the array that is iterate over."""
+        return self._base
 
     # TODO(Takagi): Implement coords
 

--- a/cupy/indexing/iterate.py
+++ b/cupy/indexing/iterate.py
@@ -15,6 +15,9 @@ class flatiter:
     Iteration is done in row-major, C-style order (the last index varying the
     fastest).
 
+    Attributes:
+        base (cupy.ndarray): A reference to the array that is iterated over.
+
     .. note::
        Restricted support of basic slicing is currently supplied. Advanced
        indexing is not supported yet.

--- a/cupy/indexing/iterate.py
+++ b/cupy/indexing/iterate.py
@@ -5,7 +5,7 @@ from cupy import core
 from cupy.core import internal
 
 
-class flatiter():
+class flatiter:
     """Flat iterator object to iterate over arrays.
 
     A flatiter iterator is returned by ``x.flat`` for any array ``x``. It

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -138,6 +138,10 @@ pygments_style = 'sphinx'
 # If true, keep warnings as "system message" paragraphs in the built documents.
 #keep_warnings = False
 
+# Suppress a warning that multiple targets are found for a cross-reference.
+# See #3250
+suppress_warnings = ['ref.python']
+
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False
 

--- a/tests/cupy_tests/indexing_tests/test_iterate.py
+++ b/tests/cupy_tests/indexing_tests/test_iterate.py
@@ -8,6 +8,14 @@ import cupy
 from cupy import testing
 
 
+@testing.gpu
+class TestFlatiter(unittest.TestCase):
+
+    def test_base(self):
+        a = cupy.zeros((2, 3, 4))
+        assert(a.flat.base is a)
+
+
 @testing.parameterize(
     {'shape': (2, 3, 4), 'index': Ellipsis},
     {'shape': (2, 3, 4), 'index': 0},

--- a/tests/cupy_tests/indexing_tests/test_iterate.py
+++ b/tests/cupy_tests/indexing_tests/test_iterate.py
@@ -13,7 +13,7 @@ class TestFlatiter(unittest.TestCase):
 
     def test_base(self):
         a = cupy.zeros((2, 3, 4))
-        assert(a.flat.base is a)
+        assert a.flat.base is a
 
 
 @testing.parameterize(


### PR DESCRIPTION
This PR implements `flatiter.base` proeprty that is a reference to the array that is iterated over.