### PR TITLE
Implement `flatiter.__next__()` special method

### DIFF
--- a/cupy/indexing/iterate.py
+++ b/cupy/indexing/iterate.py
@@ -106,7 +106,10 @@ class flatiter:
 
     # TODO(Takagi): Implement copy
 
-    # TODO(Takagi): Implement base
+    @property
+    def base(self):
+        """A reference to the array that is iterate over."""
+        return self._base
 
     # TODO(Takagi): Implement coords
 

--- a/cupy/indexing/iterate.py
+++ b/cupy/indexing/iterate.py
@@ -127,7 +127,8 @@ class flatiter:
 
     # TODO(Takagi): Implement __gt__
 
-    # TODO(Takagi): Implement __len__
+    def __len__(self):
+        return self.base.size
 
 
 _flatiter_setitem_slice = core.ElementwiseKernel(

--- a/cupy/indexing/iterate.py
+++ b/cupy/indexing/iterate.py
@@ -5,7 +5,7 @@ from cupy import core
 from cupy.core import internal
 
 
-class flatiter():
+class flatiter:
     """Flat iterator object to iterate over arrays.
 
     A flatiter iterator is returned by ``x.flat`` for any array ``x``. It

--- a/cupy/indexing/iterate.py
+++ b/cupy/indexing/iterate.py
@@ -25,6 +25,7 @@ class flatiter:
 
     def __init__(self, a):
         self._base = a
+        self._index = 0
 
     def __setitem__(self, ind, value):
         if ind is Ellipsis:
@@ -102,7 +103,12 @@ class flatiter:
 
     # TODO(Takagi): Implement __iter__
 
-    # TODO(Takagi): Implement __next__
+    def __next__(self):
+        index = self._index
+        if index == len(self):
+            raise StopIteration()
+        self._index += 1
+        return self[index]
 
     # TODO(Takagi): Implement copy
 

--- a/tests/cupy_tests/indexing_tests/test_iterate.py
+++ b/tests/cupy_tests/indexing_tests/test_iterate.py
@@ -15,6 +15,12 @@ class TestFlatiter(unittest.TestCase):
         a = cupy.zeros((2, 3, 4))
         assert(a.flat.base is a)
 
+    def test_next(self):
+        a = testing.shaped_arange((2, 3, 4), cupy)
+        e = a.flatten()
+        for ai, ei in zip(a.flat, e):
+            assert(ai == ei)
+
     def test_len(self):
         a = cupy.zeros((2, 3, 4))
         assert(len(a.flat) == 24)

--- a/tests/cupy_tests/indexing_tests/test_iterate.py
+++ b/tests/cupy_tests/indexing_tests/test_iterate.py
@@ -15,6 +15,11 @@ class TestFlatiter(unittest.TestCase):
         a = cupy.zeros((2, 3, 4))
         assert(a.flat.base is a)
 
+    def test_len(self):
+        a = cupy.zeros((2, 3, 4))
+        assert(len(a.flat) == 24)
+        assert(len(a[::2].flat) == 12)
+
 
 @testing.parameterize(
     {'shape': (2, 3, 4), 'index': Ellipsis},

--- a/tests/cupy_tests/indexing_tests/test_iterate.py
+++ b/tests/cupy_tests/indexing_tests/test_iterate.py
@@ -8,6 +8,14 @@ import cupy
 from cupy import testing
 
 
+@testing.gpu
+class TestFlatiter(unittest.TestCase):
+
+    def test_base(self):
+        a = cupy.zeros((2, 3, 4))
+        assert(a.flat.base is a)
+
+
 @testing.parameterize(
     {'shape': (2, 3, 4), 'index': Ellipsis},
     {'shape': (2, 3, 4), 'index': 0},


### PR DESCRIPTION
Follows #3251 .

This PR implements `flatiter.__next__()` special method.
https://github.com/takagi/cupy/compare/flatiter-len...flatiter-next

Note that `flatiter.__next__()` returns an instance of `cupy.ndarray`, as opposed to NumPy's counterpart that returns an element of the iterator's base array, to keep off device synchronization.