### PR TITLE
Remove unnecessary `Arg` instantiation in `cuda/function.pyx`

### DIFF
--- a/cupy/cuda/function.pxd
+++ b/cupy/cuda/function.pxd
@@ -16,8 +16,6 @@ cdef class Function:
     cpdef linear_launch(self, size_t size, args, size_t shared_mem=*,
                         size_t block_max_size=*, stream=*)
 
-    cdef list _wrap_args(self, args)
-
 
 cdef class Module:
 


### PR DESCRIPTION
This PR resolves performance degradation in `function.pyx`.
note: https://github.com/cupy/cupy/pull/2920#pullrequestreview-382636309

- `v8.0.01b`
```
time_raw             - case 10                            :    CPU:    6.197 us   +/- 0.341 (min:    5.882 / max:    6.814) us     GPU:    9.843 us   +/- 1.630 (min:    8.704 / max:   13.056) us
time_raw             - case 100                           :    CPU:    5.816 us   +/- 0.195 (min:    5.621 / max:    6.114) us     GPU:    8.787 us   +/- 0.831 (min:    8.064 / max:   10.400) us
time_raw             - case 1000                          :    CPU:    6.399 us   +/- 0.194 (min:    6.213 / max:    6.682) us     GPU:   10.067 us   +/- 0.403 (min:    9.664 / max:   10.688) us
time_raw             - case 10000                         :    CPU:    6.029 us   +/- 0.260 (min:    5.758 / max:    6.444) us     GPU:   25.376 us   +/- 0.385 (min:   24.896 / max:   26.016) us
time_raw             - case 20000                         :    CPU:    5.994 us   +/- 0.269 (min:    5.720 / max:    6.460) us     GPU:   42.470 us   +/- 0.379 (min:   42.112 / max:   43.200) us
```
- `master`
```
time_raw             - case 10                            :    CPU:   10.597 us   +/- 0.464 (min:   10.216 / max:   11.361) us     GPU:   14.394 us   +/- 2.039 (min:   12.800 / max:   18.368) us
time_raw             - case 100                           :    CPU:   10.103 us   +/- 0.239 (min:    9.860 / max:   10.512) us     GPU:   13.453 us   +/- 1.118 (min:   12.640 / max:   15.648) us
time_raw             - case 1000                          :    CPU:   10.352 us   +/- 0.282 (min:    9.969 / max:   10.693) us     GPU:   13.709 us   +/- 0.425 (min:   13.248 / max:   14.432) us
time_raw             - case 10000                         :    CPU:   10.400 us   +/- 0.323 (min:   10.021 / max:   10.917) us     GPU:   29.338 us   +/- 0.430 (min:   28.928 / max:   30.080) us
time_raw             - case 20000                         :    CPU:   10.636 us   +/- 0.205 (min:   10.279 / max:   10.903) us     GPU:   46.707 us   +/- 0.332 (min:   46.432 / max:   47.360) us
```
- this PR (`f2bee1b`)
```
time_raw             - case 10                            :    CPU:    7.010 us   +/- 0.406 (min:    6.679 / max:    7.688) us     GPU:   10.912 us   +/- 2.074 (min:    9.344 / max:   14.976) us
time_raw             - case 100                           :    CPU:    6.775 us   +/- 0.222 (min:    6.532 / max:    7.181) us     GPU:    9.984 us   +/- 0.759 (min:    9.280 / max:   11.456) us
time_raw             - case 1000                          :    CPU:    6.854 us   +/- 0.202 (min:    6.642 / max:    7.187) us     GPU:   10.464 us   +/- 0.385 (min:   10.176 / max:   11.200) us
time_raw             - case 10000                         :    CPU:    6.980 us   +/- 0.236 (min:    6.687 / max:    7.276) us     GPU:   26.118 us   +/- 0.298 (min:   25.760 / max:   26.592) us
time_raw             - case 20000                         :    CPU:    6.930 us   +/- 0.281 (min:    6.673 / max:    7.316) us     GPU:   43.418 us   +/- 0.335 (min:   43.104 / max:   44.000) us
```