### PR TITLE
rewrite statistics tests not to use numpy_cupy_raises()

### DIFF
--- a/tests/cupy_tests/statics_tests/test_correlation.py
+++ b/tests/cupy_tests/statics_tests/test_correlation.py
@@ -1,5 +1,9 @@
 import unittest
 
+import numpy
+import pytest
+
+import cupy
 from cupy import testing
 
 
@@ -56,9 +60,10 @@ class TestCov(unittest.TestCase):
             return self._check(*args, **kw)
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_raises()
     def check_raises(self, *args, **kw):
-        self._check(*args, **kw)
+        for xp in (numpy, cupy):
+            with pytest.raises(ValueError):
+                self._check(xp=xp, *args, **kw)
 
     def test_cov(self):
         self.check((2, 3))

--- a/tests/cupy_tests/statics_tests/test_histogram.py
+++ b/tests/cupy_tests/statics_tests/test_histogram.py
@@ -2,6 +2,7 @@ import sys
 import unittest
 
 import numpy
+import pytest
 
 import cupy
 from cupy import testing
@@ -99,23 +100,24 @@ class TestHistogram(unittest.TestCase):
         testing.assert_allclose(float((h * xp.diff(b)).sum()), 1)
         return h
 
-    @testing.numpy_cupy_raises(accept_error=ValueError)
-    def test_histogram_invalid_range(self, xp):
+    def test_histogram_invalid_range(self):
         # range must be None or have two elements
-        h, b = xp.histogram(xp.arange(10), range=[1, 9, 15])
-        return
+        for xp in (numpy, cupy):
+            with pytest.raises(ValueError):
+                xp.histogram(xp.arange(10), range=[1, 9, 15])
 
-    @testing.numpy_cupy_raises(accept_error=TypeError)
-    def test_histogram_invalid_range2(self, xp):
-        h, b = xp.histogram(xp.arange(10), range=10)
-        return
+    def test_histogram_invalid_range2(self):
+        for xp in (numpy, cupy):
+            with pytest.raises(TypeError):
+                xp.histogram(xp.arange(10), range=10)
 
     @testing.for_all_dtypes(no_bool=True, no_complex=True)
-    @testing.numpy_cupy_raises(accept_error=ValueError)
-    def test_histogram_weights_mismatch(self, xp, dtype):
-        a = xp.arange(10, dtype=dtype) + .5
-        w = xp.arange(11, dtype=dtype) + .5
-        h, b = xp.histogram(a, range=[1, 9], weights=w, density=True)
+    def test_histogram_weights_mismatch(self, dtype):
+        for xp in (numpy, cupy):
+            a = xp.arange(10, dtype=dtype) + .5
+            w = xp.arange(11, dtype=dtype) + .5
+            with pytest.raises(ValueError):
+                xp.histogram(a, range=[1, 9], weights=w, density=True)
 
     @testing.for_all_dtypes(no_bool=True, no_complex=True)
     @testing.numpy_cupy_allclose()
@@ -230,12 +232,13 @@ class TestHistogram(unittest.TestCase):
         return y, bin_edges
 
     @testing.for_all_dtypes(no_bool=True, no_complex=True)
-    @testing.numpy_cupy_raises(accept_error=ValueError)
-    def test_histogram_bins_not_ordered(self, xp, dtype):
+    def test_histogram_bins_not_ordered(self, dtype):
         # numpy 1.13.1 does not check this error correctly with unsigned int.
-        x = testing.shaped_arange((10,), xp, dtype)
-        bins = xp.array([1, 3, 2], dtype)
-        xp.histogram(x, bins)
+        for xp in (numpy, cupy):
+            x = testing.shaped_arange((10,), xp, dtype)
+            bins = xp.array([1, 3, 2], dtype)
+            with pytest.raises(ValueError):
+                xp.histogram(x, bins)
 
     @for_all_dtypes_bincount()
     @testing.numpy_cupy_allclose(accept_error=TypeError)
@@ -263,29 +266,33 @@ class TestHistogram(unittest.TestCase):
         return xp.bincount(x, minlength=5)
 
     @for_all_dtypes_combination_bincount(names=['x_type', 'w_type'])
-    @testing.numpy_cupy_raises()
-    def test_bincount_invalid_weight_length(self, xp, x_type, w_type):
-        x = testing.shaped_arange((1,), xp, x_type)
-        w = testing.shaped_arange((2,), xp, w_type)
-        return xp.bincount(x, weights=w)
+    def test_bincount_invalid_weight_length(self, x_type, w_type):
+        for xp in (numpy, cupy):
+            x = testing.shaped_arange((1,), xp, x_type)
+            w = testing.shaped_arange((2,), xp, w_type)
+            with pytest.raises(ValueError):
+                xp.bincount(x, weights=w)
 
     @for_signed_dtypes_bincount()
-    @testing.numpy_cupy_raises()
-    def test_bincount_negative(self, xp, dtype):
-        x = testing.shaped_arange((3,), xp, dtype) - 2
-        return xp.bincount(x)
+    def test_bincount_negative(self, dtype):
+        for xp in (numpy, cupy):
+            x = testing.shaped_arange((3,), xp, dtype) - 2
+            with pytest.raises(ValueError):
+                return xp.bincount(x)
 
     @for_all_dtypes_bincount()
-    @testing.numpy_cupy_raises()
-    def test_bincount_too_deep(self, xp, dtype):
-        x = xp.array([[1]], dtype)
-        return xp.bincount(x)
+    def test_bincount_too_deep(self, dtype):
+        for xp in (numpy, cupy):
+            x = xp.array([[1]], dtype)
+            with pytest.raises(ValueError):
+                xp.bincount(x)
 
     @for_all_dtypes_bincount()
-    @testing.numpy_cupy_raises()
-    def test_bincount_too_small(self, xp, dtype):
-        x = xp.zeros((), dtype)
-        return xp.bincount(x)
+    def test_bincount_too_small(self, dtype):
+        for xp in (numpy, cupy):
+            x = xp.zeros((), dtype)
+            with pytest.raises(ValueError):
+                xp.bincount(x)
 
     @for_all_dtypes_bincount()
     @testing.numpy_cupy_allclose(accept_error=TypeError)
@@ -294,10 +301,11 @@ class TestHistogram(unittest.TestCase):
         return xp.bincount(x, minlength=0)
 
     @for_all_dtypes_bincount()
-    @testing.numpy_cupy_raises()
-    def test_bincount_too_small_minlength(self, xp, dtype):
-        x = testing.shaped_arange((3,), xp, dtype)
-        return xp.bincount(x, minlength=-1)
+    def test_bincount_too_small_minlength(self, dtype):
+        for xp in (numpy, cupy):
+            x = testing.shaped_arange((3,), xp, dtype)
+            with pytest.raises(ValueError):
+                xp.bincount(x, minlength=-1)
 
 
 @testing.gpu
@@ -405,14 +413,17 @@ class TestDigitizeNanInf(unittest.TestCase):
 @testing.gpu
 class TestDigitizeInvalid(unittest.TestCase):
 
-    @testing.numpy_cupy_raises(accept_error=TypeError)
-    def test_digitize_complex(self, xp):
-        x = testing.shaped_arange((14,), xp, xp.complex)
-        bins = xp.array([1.0, 3.0, 5.0, 8.0, 12.0], xp.complex)
-        xp.digitize(x, bins)
+    def test_digitize_complex(self):
+        for xp in (numpy, cupy):
+            x = testing.shaped_arange((14,), xp, xp.complex)
+            bins = xp.array([1.0, 3.0, 5.0, 8.0, 12.0], xp.complex)
+            with pytest.raises(TypeError):
+                xp.digitize(x, bins)
 
-    @testing.numpy_cupy_raises(accept_error=ValueError)
-    def test_digitize_nd_bins(self, xp):
-        x = testing.shaped_arange((14,), xp, xp.float64)
-        bins = xp.array([[1], [2]])
-        xp.digitize(x, bins)
+
+    def test_digitize_nd_bins(self):
+        for xp in (numpy, cupy):
+            x = testing.shaped_arange((14,), xp, xp.float64)
+            bins = xp.array([[1], [2]])
+            with pytest.raises(ValueError):
+                xp.digitize(x, bins)

--- a/tests/cupy_tests/statics_tests/test_histogram.py
+++ b/tests/cupy_tests/statics_tests/test_histogram.py
@@ -420,7 +420,6 @@ class TestDigitizeInvalid(unittest.TestCase):
             with pytest.raises(TypeError):
                 xp.digitize(x, bins)
 
-
     def test_digitize_nd_bins(self):
         for xp in (numpy, cupy):
             x = testing.shaped_arange((14,), xp, xp.float64)

--- a/tests/cupy_tests/statics_tests/test_order.py
+++ b/tests/cupy_tests/statics_tests/test_order.py
@@ -1,6 +1,10 @@
 import unittest
 import warnings
 
+import numpy
+import pytest
+
+import cupy
 from cupy import testing
 
 
@@ -80,18 +84,20 @@ class TestOrder(unittest.TestCase):
 
     @for_all_interpolations()
     @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
-    @testing.numpy_cupy_raises(accept_error=ValueError)
-    def test_percentile_bad_q(self, xp, dtype, interpolation):
-        a = testing.shaped_random((4, 2, 3, 2), xp, dtype)
-        q = testing.shaped_random((1, 2, 3), xp, dtype=dtype, scale=100)
-        return xp.percentile(a, q, axis=-1, interpolation=interpolation)
+    def test_percentile_bad_q(self, dtype, interpolation):
+        for xp in (numpy, cupy):
+            a = testing.shaped_random((4, 2, 3, 2), xp, dtype)
+            q = testing.shaped_random((1, 2, 3), xp, dtype=dtype, scale=100)
+            with pytest.raises(ValueError):
+                xp.percentile(a, q, axis=-1, interpolation=interpolation)
 
     @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
-    @testing.numpy_cupy_raises(accept_error=ValueError)
-    def test_percentile_unexpected_interpolation(self, xp, dtype):
-        a = testing.shaped_random((4, 2, 3, 2), xp, dtype)
-        q = testing.shaped_random((5,), xp, dtype=dtype, scale=100)
-        return xp.percentile(a, q, axis=-1, interpolation='deadbeef')
+    def test_percentile_unexpected_interpolation(self, dtype):
+        for xp in (numpy, cupy):
+            a = testing.shaped_random((4, 2, 3, 2), xp, dtype)
+            q = testing.shaped_random((5,), xp, dtype=dtype, scale=100)
+            with pytest.raises(ValueError):
+                xp.percentile(a, q, axis=-1, interpolation='deadbeef')
 
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose()


### PR DESCRIPTION
ready for #3098 

Found some `numpy_cupy_raises` calls in `test_histogram` while investigating for my gsoc project.
This PR rewrites the tests with `numpy_cupy_raises` calls in the `cupy/statistics/` directory.