### PR TITLE
Add cupyx.scipy.ndimage sum, mean,standard deviation and variance

### DIFF
--- a/cupyx/scipy/ndimage/__init__.py
+++ b/cupyx/scipy/ndimage/__init__.py
@@ -8,6 +8,9 @@ from cupyx.scipy.ndimage.interpolation import shift  # NOQA
 from cupyx.scipy.ndimage.interpolation import zoom  # NOQA
 
 from cupyx.scipy.ndimage.measurements import label  # NOQA
+from cupyx.scipy.ndimage.measurements import sum  # NOQA
+from cupyx.scipy.ndimage.measurements import mean  # NOQA
+from cupyx.scipy.ndimage.measurements import variance  # NOQA
 
 from cupyx.scipy.ndimage.morphology import grey_erosion  # NOQA
 from cupyx.scipy.ndimage.morphology import grey_dilation  # NOQA

--- a/cupyx/scipy/ndimage/__init__.py
+++ b/cupyx/scipy/ndimage/__init__.py
@@ -11,6 +11,7 @@ from cupyx.scipy.ndimage.measurements import label  # NOQA
 from cupyx.scipy.ndimage.measurements import sum  # NOQA
 from cupyx.scipy.ndimage.measurements import mean  # NOQA
 from cupyx.scipy.ndimage.measurements import variance  # NOQA
+from cupyx.scipy.ndimage.measurements import standard_deviation  # NOQA
 
 from cupyx.scipy.ndimage.morphology import grey_erosion  # NOQA
 from cupyx.scipy.ndimage.morphology import grey_dilation  # NOQA

--- a/cupyx/scipy/ndimage/measurements.py
+++ b/cupyx/scipy/ndimage/measurements.py
@@ -322,13 +322,13 @@ def variance(input, labels=None, index=None):
         use_kern = True
 
     if labels is None:
-        return input.var().astype(cupy.float64)
+        return input.var().astype(cupy.float64, copy=False)
 
     if not isinstance(labels, cupy.ndarray):
         raise TypeError('label must be cupy.ndarray')
 
     if index is None:
-        return (input[labels != 0]).var().astype(cupy.float64)
+        return (input[labels != 0]).var().astype(cupy.float64, copy=False)
 
     input, labels = cupy.broadcast_arrays(input, labels)
 
@@ -336,7 +336,8 @@ def variance(input, labels=None, index=None):
         if not isinstance(index, int):
             raise TypeError('index must be cupy.ndarray or a scalar int')
         else:
-            return (input[labels == index]).var().astype(cupy.float64)
+            return (input[labels == index]).var().astype(cupy.float64,
+                                                         copy=False)
 
     mean_val, count = _mean_driver(input, labels, index, True, use_kern)
     if use_kern:

--- a/cupyx/scipy/ndimage/measurements.py
+++ b/cupyx/scipy/ndimage/measurements.py
@@ -10,15 +10,15 @@ def label(input, structure=None, output=None):
 
     Args:
         input (cupy.ndarray): The input array.
-        structure (array_like or None): A structuring element that defines
-            feature connections. ```structure``` must be centersymmetric. If
-            None, structure is automatically generated with a squared
+        structure (array_like or None): A structuring element that defines \
+            feature connections. ```structure``` must be centersymmetric. If \
+            None, structure is automatically generated with a squared \
             connectivity equal to one.
-        output (cupy.ndarray, dtype or None): The array in which to place the
+        output (cupy.ndarray, dtype or None): The array in which to place the \
             output.
 
     Returns:
-        label (cupy.ndarray): An integer array where each unique feature in
+        label (cupy.ndarray): An integer array where each unique feature in \
             ```input``` has a unique label in the array.
         num_features (int): Number of features found.
 
@@ -252,8 +252,8 @@ def _stats(input, labels=None, index=None, mean=False):
 
 
 def variance(input, labels=None, index=None):
-    """Calculate the variance of the values of an n-D image array, optionally
-       at specified sub-regions.
+    """Calculate the variance of the values of an n-D image array, optionally \
+    at specified sub-regions.
 
     Args:
         input (cupy.ndarray) :Nd-image data to process.
@@ -263,7 +263,7 @@ def variance(input, labels=None, index=None):
             (default), all values where `labels` is non-zero are used.
 
     Returns:
-       variance (cupy.ndarray): Values of variance, for each sub-region if
+       variance (cupy.ndarray): Values of variance, for each sub-region if \
             `labels` and `index` are specified.
 
 
@@ -275,7 +275,7 @@ def variance(input, labels=None, index=None):
         raise TypeError('Complex type not supported')
 
     if labels is None:
-        return input.sum()
+        return input.var()
 
     if not isinstance(labels, cupy.ndarray):
         raise TypeError('label must be cupy.ndarray')
@@ -291,11 +291,12 @@ def variance(input, labels=None, index=None):
     sum, count = _stats(input, labels, index, mean=True)
     mean = sum/count
     ret = cupy.zeros_like(index).astype(mean.dtype)
-    return _variance_kernel()(input, labels, index, index.size, mean, ret)
+    return _variance_kernel()(input, labels, index,
+                              index.size, mean, ret)/count
 
 
 def sum(input, labels=None, index=None):
-    """Calculate the sum of the values of an n-D image array, optionally
+    """Calculate the sum of the values of an n-D image array, optionally \
        at specified sub-regions.
 
     Args:
@@ -306,7 +307,7 @@ def sum(input, labels=None, index=None):
             (default), all values where `labels` is non-zero are used.
 
     Returns:
-       sum (cupy.ndarray): sum of values, for each sub-region if
+       sum (cupy.ndarray): sum of values, for each sub-region if \
             `labels` and `index` are specified.
 
 
@@ -335,7 +336,7 @@ def sum(input, labels=None, index=None):
 
 
 def mean(input, labels=None, index=None):
-    """Calculate the mean of the values of an n-D image array, optionally
+    """Calculate the mean of the values of an n-D image array, optionally \
        at specified sub-regions.
 
     Args:
@@ -346,7 +347,7 @@ def mean(input, labels=None, index=None):
             (default), all values where `labels` is non-zero are used.
 
     Returns:
-        mean (cupy.ndarray): mean of values, for each sub-region if
+        mean (cupy.ndarray): mean of values, for each sub-region if \
             `labels` and `index` are specified.
 
 
@@ -358,7 +359,7 @@ def mean(input, labels=None, index=None):
         raise TypeError('Complex type not supported')
 
     if labels is None:
-        return input.sum()
+        return input.sum()/input.size
 
     if not isinstance(labels, cupy.ndarray):
         raise TypeError('label must be cupy.ndarray')

--- a/cupyx/scipy/ndimage/measurements.py
+++ b/cupyx/scipy/ndimage/measurements.py
@@ -262,8 +262,8 @@ def _ndimage_mean_kernel_2(input, labels, index, batch_size=4,
     for i in range(0, index.size, batch_size):
         matched = labels == index[i:i + batch_size].reshape(
             (-1,) + (1,) * input.ndim)
-        count[i:i + batch_size] = matched.sum(axis=1)
         mean_axes = tuple(range(1, 1 + input.ndim))
+        count[i:i + batch_size] = matched.sum(axis=mean_axes)
         out[i:i + batch_size] = cupy.where(matched, input, 0).sum(
             axis=mean_axes)
     if return_count:

--- a/cupyx/scipy/ndimage/measurements.py
+++ b/cupyx/scipy/ndimage/measurements.py
@@ -388,6 +388,8 @@ def sum(input, labels=None, index=None):
 
     if labels is None:
         return input.sum()
+    if len(labels) == 0:
+        return cupy.array([], dtype=cupy.int64)
 
     if not isinstance(labels, cupy.ndarray):
         raise TypeError('label must be cupy.ndarray')

--- a/cupyx/scipy/ndimage/measurements.py
+++ b/cupyx/scipy/ndimage/measurements.py
@@ -273,7 +273,7 @@ def _ndimage_mean_kernel_2(input, labels, index, batch_size=4,
 
 def _mean_driver(input, labels, index, return_count=False, use_kern=False):
     # The following parameters for sum where determined using a Tesla P100.
-    if (input.size >= 262144 and index.size <= 4) or use_kern:
+    if use_kern:
         return _ndimage_mean_kernel_2(input, labels, index,
                                       return_count=return_count)
 

--- a/cupyx/scipy/ndimage/measurements.py
+++ b/cupyx/scipy/ndimage/measurements.py
@@ -345,9 +345,10 @@ def variance(input, labels=None, index=None):
 
     mean_val, count = _mean_driver(input, labels, index, True, use_kern)
     if use_kern:
-        return cupy.where(labels == index[..., None],
-                          cupy.square(input - mean_val[..., None]),
-                          0).sum(axis=(1,)) / count
+        new_axis = (..., *(cupy.newaxis for _ in range(input.ndim)))
+        return cupy.where(labels[None, ...] == index[new_axis],
+                          cupy.square(input - mean_val[new_axis]),
+                          0).sum(tuple(range(1, input.ndim + 1))) / count
     out = cupy.zeros_like(index, dtype=mean_val.dtype)
     return _ndimage_variance_kernel(input, labels, index, index.size, mean_val,
                                     out)/count

--- a/docs/source/reference/ndimage.rst
+++ b/docs/source/reference/ndimage.rst
@@ -26,7 +26,7 @@ Interpolation
 
 
 Measurements
--------------
+------------
 
 .. autosummary::
    :toctree: generated/
@@ -34,9 +34,9 @@ Measurements
 
    cupyx.scipy.ndimage.label
    cupyx.scipy.ndimage.mean
+   cupyx.scipy.ndimage.standard_deviation
    cupyx.scipy.ndimage.sum
    cupyx.scipy.ndimage.variance
-   cupyx.scipy.ndimage.standard_deviation
 
 
 OpenCV mode

--- a/docs/source/reference/ndimage.rst
+++ b/docs/source/reference/ndimage.rst
@@ -25,6 +25,19 @@ Interpolation
    cupyx.scipy.ndimage.zoom
 
 
+Measurements
+-------------
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+
+   cupyx.scipy.ndimage.label
+   cupyx.scipy.ndimage.mean
+   cupyx.scipy.ndimage.sum
+   cupyx.scipy.ndimage.variance
+
+
 OpenCV mode
 -----------
 :mod:`cupyx.scipy.ndimage` supports additional mode, ``opencv``.

--- a/docs/source/reference/ndimage.rst
+++ b/docs/source/reference/ndimage.rst
@@ -36,6 +36,7 @@ Measurements
    cupyx.scipy.ndimage.mean
    cupyx.scipy.ndimage.sum
    cupyx.scipy.ndimage.variance
+   cupyx.scipy.ndimage.standard_deviation
 
 
 OpenCV mode

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
@@ -142,6 +142,23 @@ class TestNdimage(unittest.TestCase):
         label = testing.shaped_random((100,), xp, dtype=xp.int32, scale=3)
         return getattr(scp.ndimage, self.op)(image, label, 1)
 
+    @testing.numpy_cupy_array_almost_equal(scipy_name='scp', decimal=1)
+    def test_ndimage_only_input_float16(self, xp, scp):
+        image = xp.arange(100, dtype=xp.float16)
+        return getattr(scp.ndimage, self.op)(image)
+
+    @testing.numpy_cupy_array_almost_equal(scipy_name='scp', decimal=1)
+    def test_ndimage_no_index_float16(self, xp, scp):
+        image = xp.arange(50, dtype=xp.float16)
+        label = testing.shaped_random((50,), xp, dtype=xp.int32, scale=3)
+        return getattr(scp.ndimage, self.op)(image, label)
+
+    @testing.numpy_cupy_array_almost_equal(scipy_name='scp', decimal=1)
+    def test_ndimage_scalar_index_float16(self, xp, scp):
+        image = xp.arange(100, dtype=xp.float16)
+        label = testing.shaped_random((100,), xp, dtype=xp.int32, scale=3)
+        return getattr(scp.ndimage, self.op)(image, label, 1)
+
     @testing.for_dtypes([cupy.bool_, cupy.complex64, cupy.complex128])
     def test_ndimage_wrong_dtype(self, dtype):
         image = cupy.arange(100).astype(dtype)

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
@@ -105,7 +105,8 @@ class TestLabelSpecialCases(unittest.TestCase):
 class TestNdimageSum(unittest.TestCase):
 
     @testing.for_dtypes([cupy.int32, cupy.float32, cupy.float64, cupy.uint32,
-                         cupy.uint64, cupy.ulonglong])
+                         cupy.uint64, cupy.ulonglong, cupy.int64, cupy.uint8,
+                         cupy.uint16])
     @testing.numpy_cupy_array_almost_equal(scipy_name='scp')
     def test_ndimage_sum(self, xp, scp, dtype):
         image = xp.arange(100, dtype=dtype)
@@ -114,14 +115,16 @@ class TestNdimageSum(unittest.TestCase):
         return scp.ndimage.sum(image, label, index).astype(dtype)
 
     @testing.for_dtypes([cupy.int32, cupy.float32, cupy.float64, cupy.uint32,
-                         cupy.uint64, cupy.ulonglong])
+                         cupy.uint64, cupy.ulonglong, cupy.int64, cupy.uint8,
+                         cupy.uint16])
     @testing.numpy_cupy_array_almost_equal(scipy_name='scp')
     def test_ndimage_sum_only_input(self, xp, scp, dtype):
         image = xp.arange(100, dtype=dtype)
         return scp.ndimage.sum(image).astype(dtype)
 
     @testing.for_dtypes([cupy.int32, cupy.float32, cupy.float64, cupy.uint32,
-                         cupy.uint64, cupy.ulonglong])
+                         cupy.uint64, cupy.ulonglong, cupy.int64, cupy.uint8,
+                         cupy.uint16])
     @testing.numpy_cupy_array_almost_equal(scipy_name='scp')
     def test_ndimage_sum_no_index(self, xp, scp, dtype):
         image = xp.arange(100, dtype=dtype)
@@ -129,15 +132,15 @@ class TestNdimageSum(unittest.TestCase):
         return scp.ndimage.sum(image, label).astype(dtype)
 
     @testing.for_dtypes([cupy.int32, cupy.float32, cupy.float64, cupy.uint32,
-                         cupy.uint64, cupy.ulonglong])
+                         cupy.uint64, cupy.ulonglong, cupy.int64, cupy.uint8,
+                         cupy.uint16])
     @testing.numpy_cupy_array_almost_equal(scipy_name='scp')
     def test_ndimage_sum_scalar_index(self, xp, scp, dtype):
         image = xp.arange(100, dtype=dtype)
         label = testing.shaped_random((100,), xp, dtype=xp.int32, scale=3) + 1
         return scp.ndimage.sum(image, label, 1).astype(dtype)
 
-    @testing.for_dtypes([cupy.int8, cupy.int16, cupy.int64, cupy.uint8,
-                         cupy.uint16, cupy.complex64, cupy.complex128])
+    @testing.for_dtypes([cupy.complex64, cupy.complex128])
     def test_ndimage_sum_wrong_dtype(self, dtype):
         image = cupy.arange(100, dtype=dtype)
         label = cupy.random.randint(1, 3, dtype=cupy.int32)
@@ -267,7 +270,8 @@ class TestNdimageVariance(unittest.TestCase):
 class TestNdimageMean(unittest.TestCase):
 
     @testing.for_dtypes([cupy.int32, cupy.float32, cupy.float64, cupy.uint32,
-                         cupy.uint64, cupy.ulonglong])
+                         cupy.uint64, cupy.ulonglong, cupy.int64, cupy.int16,
+                         cupy.uint16])
     @testing.numpy_cupy_array_almost_equal(scipy_name='scp', decimal=5)
     def test_ndimage_mean(self, xp, scp, dtype):
         image = xp.arange(100, dtype=dtype)
@@ -276,14 +280,16 @@ class TestNdimageMean(unittest.TestCase):
         return scp.ndimage.mean(image, label, index).astype(dtype)
 
     @testing.for_dtypes([cupy.int32, cupy.float32, cupy.float64, cupy.uint32,
-                         cupy.uint64, cupy.ulonglong])
+                         cupy.uint64, cupy.ulonglong, cupy.int64, cupy.uint8,
+                         cupy.uint16])
     @testing.numpy_cupy_array_almost_equal(scipy_name='scp')
     def test_ndimage_mean_only_input(self, xp, scp, dtype):
         image = xp.arange(100, dtype=dtype)
         return scp.ndimage.mean(image).astype(dtype)
 
     @testing.for_dtypes([cupy.int32, cupy.float32, cupy.float64, cupy.uint32,
-                         cupy.uint64, cupy.ulonglong])
+                         cupy.uint64, cupy.ulonglong, cupy.int64, cupy.uint8,
+                         cupy.uint16])
     @testing.numpy_cupy_array_almost_equal(scipy_name='scp')
     def test_ndimage_mean_no_index(self, xp, scp, dtype):
         image = xp.arange(100, dtype=dtype)
@@ -291,15 +297,15 @@ class TestNdimageMean(unittest.TestCase):
         return scp.ndimage.mean(image, label).astype(dtype)
 
     @testing.for_dtypes([cupy.int32, cupy.float32, cupy.float64, cupy.uint32,
-                         cupy.uint64, cupy.ulonglong])
+                         cupy.uint64, cupy.ulonglong, cupy.int64, cupy.uint8,
+                         cupy.uint16])
     @testing.numpy_cupy_array_almost_equal(scipy_name='scp')
     def test_ndimage_mean_scalar_index(self, xp, scp, dtype):
         image = xp.arange(100, dtype=dtype)
         label = testing.shaped_random((100,), xp, dtype=xp.int32, scale=3) + 1
         return scp.ndimage.mean(image, label, 1).astype(dtype)
 
-    @testing.for_dtypes([cupy.int8, cupy.int16, cupy.int64, cupy.uint8,
-                         cupy.uint16, cupy.complex64, cupy.complex128])
+    @testing.for_dtypes([cupy.complex64, cupy.complex128])
     def test_ndimage_mean_wrong_dtype(self, dtype):
         image = cupy.arange(100, dtype=dtype)
         label = cupy.random.randint(1, 3, dtype=cupy.int32)

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
@@ -104,51 +104,51 @@ class TestLabelSpecialCases(unittest.TestCase):
 @testing.with_requires('scipy')
 class TestNdimageSum(unittest.TestCase):
 
-    @testing.for_dtypes([cupy.int32, cupy.float32, cupy.float64, cupy.uint32,
-                         cupy.uint64, cupy.ulonglong, cupy.int64, cupy.uint8,
-                         cupy.uint16])
-    @testing.numpy_cupy_array_almost_equal(scipy_name='scp')
+    @testing.for_all_dtypes(no_bool=True, no_complex=True)
+    @testing.numpy_cupy_array_equal(scipy_name='scp')
     def test_ndimage_sum(self, xp, scp, dtype):
         image = xp.arange(100, dtype=dtype)
         label = testing.shaped_random((100,), xp, dtype=xp.int32, scale=3) + 1
         index = xp.array([1, 2, 3])
-        return scp.ndimage.sum(image, label, index).astype(dtype)
+        return scp.ndimage.sum(image, label, index)
 
-    @testing.for_dtypes([cupy.int32, cupy.float32, cupy.float64, cupy.uint32,
-                         cupy.uint64, cupy.ulonglong, cupy.int64, cupy.uint8,
-                         cupy.uint16])
+    @testing.for_all_dtypes(no_bool=True, no_complex=True)
     @testing.numpy_cupy_array_almost_equal(scipy_name='scp')
+    def test_ndimage_sum_multi_dim(self, xp, scp, dtype):
+        image = xp.arange(512, dtype=dtype).reshape(8, 8, 8)
+        label = testing.shaped_random((8, 8, 8), xp, dtype=xp.int32, scale=3)
+        index = xp.array([0, 1, 2])
+        return scp.ndimage.sum(image, label, index)
+
+    @testing.for_all_dtypes(no_bool=True, no_complex=True)
+    @testing.numpy_cupy_array_equal(scipy_name='scp')
     def test_ndimage_sum_only_input(self, xp, scp, dtype):
         image = xp.arange(100, dtype=dtype)
-        return scp.ndimage.sum(image).astype(dtype)
+        return scp.ndimage.sum(image)
 
-    @testing.for_dtypes([cupy.int32, cupy.float32, cupy.float64, cupy.uint32,
-                         cupy.uint64, cupy.ulonglong, cupy.int64, cupy.uint8,
-                         cupy.uint16])
-    @testing.numpy_cupy_array_almost_equal(scipy_name='scp')
+    @testing.for_all_dtypes(no_bool=True, no_complex=True)
+    @testing.numpy_cupy_array_equal(scipy_name='scp')
     def test_ndimage_sum_no_index(self, xp, scp, dtype):
         image = xp.arange(100, dtype=dtype)
         label = testing.shaped_random((100,), xp, dtype=xp.int32, scale=3) + 1
-        return scp.ndimage.sum(image, label).astype(dtype)
+        return scp.ndimage.sum(image, label)
 
-    @testing.for_dtypes([cupy.int32, cupy.float32, cupy.float64, cupy.uint32,
-                         cupy.uint64, cupy.ulonglong, cupy.int64, cupy.uint8,
-                         cupy.uint16])
-    @testing.numpy_cupy_array_almost_equal(scipy_name='scp')
+    @testing.for_all_dtypes(no_bool=True, no_complex=True)
+    @testing.numpy_cupy_array_equal(scipy_name='scp')
     def test_ndimage_sum_scalar_index(self, xp, scp, dtype):
         image = xp.arange(100, dtype=dtype)
         label = testing.shaped_random((100,), xp, dtype=xp.int32, scale=3) + 1
-        return scp.ndimage.sum(image, label, 1).astype(dtype)
+        return scp.ndimage.sum(image, label, 1)
 
-    @testing.for_dtypes([cupy.complex64, cupy.complex128])
+    @testing.for_dtypes([cupy.bool_, cupy.complex64, cupy.complex128])
     def test_ndimage_sum_wrong_dtype(self, dtype):
-        image = cupy.arange(100, dtype=dtype)
-        label = cupy.random.randint(1, 3, dtype=cupy.int32)
+        image = cupy.arange(100).astype(dtype)
+        label = cupy.random.randint(1, 4, dtype=cupy.int32)
         index = cupy.array([1, 2, 3])
         with pytest.raises(TypeError):
             cupyx.scipy.ndimage.sum(image, label, index)
 
-    def test_ndimage_sum_wrong_label_size(self):
+    def test_ndimage_sum_wrong_label_shape(self):
         image = cupy.arange(100, dtype=cupy.int32)
         label = cupy.random.randint(1, 3, dtype=cupy.int32, size=50)
         index = cupy.array([1, 2, 3])
@@ -188,47 +188,51 @@ class TestNdimageSum(unittest.TestCase):
 @testing.with_requires('scipy')
 class TestNdimageVariance(unittest.TestCase):
 
-    @testing.for_dtypes([cupy.int32, cupy.float32, cupy.float64, cupy.uint32,
-                         cupy.uint64, cupy.ulonglong, cupy.int64, cupy.uint16])
-    @testing.numpy_cupy_array_almost_equal(scipy_name='scp', decimal=5)
+    @testing.for_all_dtypes(no_bool=True, no_complex=True)
+    @testing.numpy_cupy_array_almost_equal(scipy_name='scp')
     def test_ndimage_variance(self, xp, scp, dtype):
         image = xp.arange(100, dtype=dtype)
         label = testing.shaped_random((100,), xp, dtype=xp.int32, scale=3)
         index = xp.array([0, 1, 2])
-        return scp.ndimage.variance(image, label, index).astype(dtype)
+        return scp.ndimage.variance(image, label, index)
 
-    @testing.for_dtypes([cupy.int32, cupy.float32, cupy.float64, cupy.uint32,
-                         cupy.uint64, cupy.ulonglong])
+    @testing.for_all_dtypes(no_bool=True, no_complex=True)
+    @testing.numpy_cupy_array_almost_equal(scipy_name='scp')
+    def test_ndimage_variance_multi_dim(self, xp, scp, dtype):
+        image = xp.arange(512, dtype=dtype).reshape(8, 8, 8)
+        label = testing.shaped_random((8, 8, 8), xp, dtype=xp.int32, scale=3)
+        index = xp.array([0, 1, 2])
+        return scp.ndimage.variance(image, label, index)
+
+    @testing.for_all_dtypes(no_bool=True, no_complex=True, no_float16=True)
     @testing.numpy_cupy_array_almost_equal(scipy_name='scp')
     def test_ndimage_variance_only_input(self, xp, scp, dtype):
         image = xp.arange(50, dtype=dtype)
-        return scp.ndimage.variance(image).astype(dtype)
+        return scp.ndimage.variance(image)
 
-    @testing.for_dtypes([cupy.int32, cupy.float32, cupy.float64, cupy.uint32,
-                         cupy.uint64, cupy.ulonglong])
-    @testing.numpy_cupy_array_almost_equal(scipy_name='scp')
+    @testing.for_all_dtypes(no_bool=True, no_complex=True, no_float16=True)
+    @testing.numpy_cupy_array_almost_equal(scipy_name='scp', decimal=5)
     def test_ndimage_variance_no_index(self, xp, scp, dtype):
         image = xp.arange(100, dtype=dtype)
         label = testing.shaped_random((100,), xp, dtype=xp.int32, scale=3)
-        return scp.ndimage.variance(image, label).astype(dtype)
+        return scp.ndimage.variance(image, label)
 
-    @testing.for_dtypes([cupy.int32, cupy.float32, cupy.float64, cupy.uint32,
-                         cupy.uint64, cupy.ulonglong])
+    @testing.for_all_dtypes(no_bool=True, no_complex=True, no_float16=True)
     @testing.numpy_cupy_array_almost_equal(scipy_name='scp', decimal=4)
     def test_ndimage_variance_scalar_index(self, xp, scp, dtype):
         image = xp.arange(100, dtype=dtype)
         label = testing.shaped_random((100,), xp, dtype=xp.int32, scale=3) + 1
-        return scp.ndimage.variance(image, label, 1).astype(dtype)
+        return scp.ndimage.variance(image, label, 1)
 
-    @testing.for_dtypes([cupy.complex64, cupy.complex128])
+    @testing.for_dtypes([cupy.bool_, cupy.complex64, cupy.complex128])
     def test_ndimage_variance_wrong_dtype(self, dtype):
-        image = cupy.arange(100, dtype=dtype)
-        label = cupy.random.randint(1, 3, dtype=cupy.int32)
+        image = cupy.arange(100).astype(dtype)
+        label = cupy.random.randint(1, 4, dtype=cupy.int32)
         index = cupy.array([1, 2, 3])
         with pytest.raises(TypeError):
             cupyx.scipy.ndimage.variance(image, label, index)
 
-    def test_ndimage_variance_wrong_label_size(self):
+    def test_ndimage_variance_wrong_label_shape(self):
         image = cupy.arange(100, dtype=cupy.int32)
         label = cupy.random.randint(1, 3, dtype=cupy.int32, size=50)
         index = cupy.array([1, 2, 3])
@@ -268,51 +272,51 @@ class TestNdimageVariance(unittest.TestCase):
 @testing.with_requires('scipy')
 class TestNdimageMean(unittest.TestCase):
 
-    @testing.for_dtypes([cupy.int32, cupy.float32, cupy.float64, cupy.uint32,
-                         cupy.uint64, cupy.ulonglong, cupy.int64, cupy.int16,
-                         cupy.uint16])
-    @testing.numpy_cupy_array_almost_equal(scipy_name='scp', decimal=5)
+    @testing.for_all_dtypes(no_bool=True, no_complex=True)
+    @testing.numpy_cupy_array_almost_equal(scipy_name='scp')
     def test_ndimage_mean(self, xp, scp, dtype):
         image = xp.arange(100, dtype=dtype)
         label = testing.shaped_random((100,), xp, dtype=xp.int32, scale=3)
         index = xp.array([0, 1, 2])
-        return scp.ndimage.mean(image, label, index).astype(dtype)
+        return scp.ndimage.mean(image, label, index)
 
-    @testing.for_dtypes([cupy.int32, cupy.float32, cupy.float64, cupy.uint32,
-                         cupy.uint64, cupy.ulonglong, cupy.int64, cupy.uint8,
-                         cupy.uint16])
+    @testing.for_all_dtypes(no_bool=True, no_complex=True)
+    @testing.numpy_cupy_array_almost_equal(scipy_name='scp')
+    def test_ndimage_mean_multi_dim(self, xp, scp, dtype):
+        image = xp.arange(512, dtype=dtype).reshape(8, 8, 8)
+        label = testing.shaped_random((8, 8, 8), xp, dtype=xp.int32, scale=3)
+        index = xp.array([0, 1, 2])
+        return scp.ndimage.mean(image, label, index)
+
+    @testing.for_all_dtypes(no_bool=True, no_complex=True, no_float16=True)
     @testing.numpy_cupy_array_almost_equal(scipy_name='scp')
     def test_ndimage_mean_only_input(self, xp, scp, dtype):
         image = xp.arange(100, dtype=dtype)
-        return scp.ndimage.mean(image).astype(dtype)
+        return scp.ndimage.mean(image)
 
-    @testing.for_dtypes([cupy.int32, cupy.float32, cupy.float64, cupy.uint32,
-                         cupy.uint64, cupy.ulonglong, cupy.int64, cupy.uint8,
-                         cupy.uint16])
+    @testing.for_all_dtypes(no_bool=True, no_complex=True, no_float16=True)
     @testing.numpy_cupy_array_almost_equal(scipy_name='scp')
     def test_ndimage_mean_no_index(self, xp, scp, dtype):
         image = xp.arange(100, dtype=dtype)
         label = testing.shaped_random((100,), xp, dtype=xp.int32, scale=3)
-        return scp.ndimage.mean(image, label).astype(dtype)
+        return scp.ndimage.mean(image, label)
 
-    @testing.for_dtypes([cupy.int32, cupy.float32, cupy.float64, cupy.uint32,
-                         cupy.uint64, cupy.ulonglong, cupy.int64, cupy.uint8,
-                         cupy.uint16])
+    @testing.for_all_dtypes(no_bool=True, no_complex=True, no_float16=True)
     @testing.numpy_cupy_array_almost_equal(scipy_name='scp')
     def test_ndimage_mean_scalar_index(self, xp, scp, dtype):
         image = xp.arange(100, dtype=dtype)
         label = testing.shaped_random((100,), xp, dtype=xp.int32, scale=3) + 1
-        return scp.ndimage.mean(image, label, 1).astype(dtype)
+        return scp.ndimage.mean(image, label, 1)
 
-    @testing.for_dtypes([cupy.complex64, cupy.complex128])
+    @testing.for_dtypes([cupy.bool_, cupy.complex64, cupy.complex128])
     def test_ndimage_mean_wrong_dtype(self, dtype):
-        image = cupy.arange(100, dtype=dtype)
-        label = cupy.random.randint(1, 3, dtype=cupy.int32)
+        image = cupy.arange(100).astype(dtype)
+        label = cupy.random.randint(1, 4, dtype=cupy.int32)
         index = cupy.array([1, 2, 3])
         with pytest.raises(TypeError):
             cupyx.scipy.ndimage.mean(image, label, index)
 
-    def test_ndimage_mean_wrong_label_size(self):
+    def test_ndimage_mean_wrong_label_shape(self):
         image = cupy.arange(100, dtype=cupy.int32)
         label = cupy.random.randint(1, 3, dtype=cupy.int32, size=50)
         index = cupy.array([1, 2, 3])
@@ -352,48 +356,51 @@ class TestNdimageMean(unittest.TestCase):
 @testing.with_requires('scipy')
 class TestNdimageStandardDeviation(unittest.TestCase):
 
-    @testing.for_dtypes([cupy.int32, cupy.float32, cupy.float64, cupy.uint32,
-                         cupy.uint64, cupy.ulonglong, cupy.int64, cupy.uint16])
-    @testing.numpy_cupy_array_almost_equal(scipy_name='scp', decimal=5)
+    @testing.for_all_dtypes(no_bool=True, no_complex=True)
+    @testing.numpy_cupy_array_almost_equal(scipy_name='scp')
     def test_ndimage_standard_deviation(self, xp, scp, dtype):
         image = xp.arange(100, dtype=dtype)
         label = testing.shaped_random((100,), xp, dtype=xp.int32, scale=3)
         index = xp.array([0, 1, 2])
-        return scp.ndimage.standard_deviation(image,
-                                              label, index).astype(dtype)
+        return scp.ndimage.standard_deviation(image, label, index)
 
-    @testing.for_dtypes([cupy.int32, cupy.float32, cupy.float64, cupy.uint32,
-                         cupy.uint64, cupy.ulonglong])
+    @testing.for_all_dtypes(no_bool=True, no_complex=True)
+    @testing.numpy_cupy_array_almost_equal(scipy_name='scp')
+    def test_ndimage_standard_deviation_multi_dim(self, xp, scp, dtype):
+        image = xp.arange(512, dtype=dtype).reshape(8, 8, 8)
+        label = testing.shaped_random((8, 8, 8), xp, dtype=xp.int32, scale=3)
+        index = xp.array([0, 1, 2])
+        return scp.ndimage.standard_deviation(image, label, index)
+
+    @testing.for_all_dtypes(no_bool=True, no_complex=True, no_float16=True)
     @testing.numpy_cupy_array_almost_equal(scipy_name='scp')
     def test_ndimage_standard_deviation_only_input(self, xp, scp, dtype):
         image = xp.arange(100, dtype=dtype)
-        return scp.ndimage.standard_deviation(image).astype(dtype)
+        return scp.ndimage.standard_deviation(image)
 
-    @testing.for_dtypes([cupy.int32, cupy.float32, cupy.float64, cupy.uint32,
-                         cupy.uint64, cupy.ulonglong])
+    @testing.for_all_dtypes(no_bool=True, no_complex=True, no_float16=True)
     @testing.numpy_cupy_array_almost_equal(scipy_name='scp')
     def test_ndimage_standard_deviation_no_index(self, xp, scp, dtype):
         image = xp.arange(100, dtype=dtype)
         label = testing.shaped_random((100,), xp, dtype=xp.int32, scale=3)
-        return scp.ndimage.standard_deviation(image, label).astype(dtype)
+        return scp.ndimage.standard_deviation(image, label)
 
-    @testing.for_dtypes([cupy.int32, cupy.float32, cupy.float64, cupy.uint32,
-                         cupy.uint64, cupy.ulonglong])
+    @testing.for_all_dtypes(no_bool=True, no_complex=True, no_float16=True)
     @testing.numpy_cupy_array_almost_equal(scipy_name='scp', decimal=5)
     def test_ndimage_standard_deviation_scalar_index(self, xp, scp, dtype):
         image = xp.arange(100, dtype=dtype)
         label = testing.shaped_random((100,), xp, dtype=xp.int32, scale=3) + 1
-        return scp.ndimage.standard_deviation(image, label, 1).astype(dtype)
+        return scp.ndimage.standard_deviation(image, label, 1)
 
-    @testing.for_dtypes([cupy.complex64, cupy.complex128])
+    @testing.for_dtypes([cupy.bool_, cupy.complex64, cupy.complex128])
     def test_ndimage_standard_deviation_wrong_dtype(self, dtype):
-        image = cupy.arange(100, dtype=dtype)
-        label = cupy.random.randint(1, 3, dtype=cupy.int32)
+        image = cupy.arange(100).astype(dtype)
+        label = cupy.random.randint(1, 4, dtype=cupy.int32)
         index = cupy.array([1, 2, 3])
         with pytest.raises(TypeError):
             cupyx.scipy.ndimage.standard_deviation(image, label, index)
 
-    def test_ndimage_standard_deviation_wrong_label_size(self):
+    def test_ndimage_standard_deviation_wrong_label_shape(self):
         image = cupy.arange(100, dtype=cupy.int32)
         label = cupy.random.randint(1, 3, dtype=cupy.int32, size=50)
         index = cupy.array([1, 2, 3])

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
@@ -137,7 +137,7 @@ class TestNdimageSum(unittest.TestCase):
         return scp.ndimage.sum(image, label, 1).astype(dtype)
 
     @testing.for_dtypes([cupy.int8, cupy.int16, cupy.int64, cupy.uint8,
-                        cupy.uint16, cupy.complex64, cupy.complex128])
+                         cupy.uint16, cupy.complex64, cupy.complex128])
     def test_ndimage_sum_wrong_dtype(self, dtype):
         image = cupy.arange(100, dtype=dtype)
         label = cupy.random.randint(1, 3, dtype=cupy.int32)
@@ -218,7 +218,7 @@ class TestNdimageVariance(unittest.TestCase):
         return scp.ndimage.variance(image, label, 1).astype(dtype)
 
     @testing.for_dtypes([cupy.int8, cupy.int16, cupy.int64, cupy.uint8,
-                        cupy.uint16, cupy.complex64, cupy.complex128])
+                         cupy.uint16, cupy.complex64, cupy.complex128])
     def test_ndimage_variance_wrong_dtype(self, dtype):
         image = cupy.arange(100, dtype=dtype)
         label = cupy.random.randint(1, 3, dtype=cupy.int32)
@@ -299,7 +299,7 @@ class TestNdimageMean(unittest.TestCase):
         return scp.ndimage.mean(image, label, 1).astype(dtype)
 
     @testing.for_dtypes([cupy.int8, cupy.int16, cupy.int64, cupy.uint8,
-                        cupy.uint16, cupy.complex64, cupy.complex128])
+                         cupy.uint16, cupy.complex64, cupy.complex128])
     def test_ndimage_mean_wrong_dtype(self, dtype):
         image = cupy.arange(100, dtype=dtype)
         label = cupy.random.randint(1, 3, dtype=cupy.int32)
@@ -381,7 +381,7 @@ class TestNdimageStandardDeviation(unittest.TestCase):
         return scp.ndimage.standard_deviation(image, label, 1).astype(dtype)
 
     @testing.for_dtypes([cupy.int8, cupy.int16, cupy.int64, cupy.uint8,
-                        cupy.uint16, cupy.complex64, cupy.complex128])
+                         cupy.uint16, cupy.complex64, cupy.complex128])
     def test_ndimage_standard_deviation_wrong_dtype(self, dtype):
         image = cupy.arange(100, dtype=dtype)
         label = cupy.random.randint(1, 3, dtype=cupy.int32)

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
@@ -101,336 +101,86 @@ class TestLabelSpecialCases(unittest.TestCase):
 
 
 @testing.gpu
+@testing.parameterize({'op': 'sum'}, {'op': 'mean'}, {'op': 'variance'},
+                      {'op': 'standard_deviation'})
 @testing.with_requires('scipy')
-class TestNdimageSum(unittest.TestCase):
-
-    @testing.for_all_dtypes(no_bool=True, no_complex=True)
-    @testing.numpy_cupy_array_equal(scipy_name='scp')
-    def test_ndimage_sum(self, xp, scp, dtype):
-        image = xp.arange(100, dtype=dtype)
-        label = testing.shaped_random((100,), xp, dtype=xp.int32, scale=4)
-        index = xp.array([0, 1, 2, 3])
-        return scp.ndimage.sum(image, label, index)
-
-    @testing.for_all_dtypes(no_bool=True, no_complex=True)
-    @testing.numpy_cupy_array_equal(scipy_name='scp')
-    def test_ndimage_sum_multi_dim(self, xp, scp, dtype):
-        image = xp.arange(512, dtype=dtype).reshape(8, 8, 8)
-        label = testing.shaped_random((8, 8, 8), xp, dtype=xp.int32, scale=4)
-        index = xp.array([1, 2, 3])
-        return scp.ndimage.sum(image, label, index)
-
-    @testing.for_all_dtypes(no_bool=True, no_complex=True)
-    @testing.numpy_cupy_array_equal(scipy_name='scp')
-    def test_ndimage_sum_only_input(self, xp, scp, dtype):
-        image = xp.arange(100, dtype=dtype)
-        return scp.ndimage.sum(image)
-
-    @testing.for_all_dtypes(no_bool=True, no_complex=True)
-    @testing.numpy_cupy_array_equal(scipy_name='scp')
-    def test_ndimage_sum_no_index(self, xp, scp, dtype):
-        image = xp.arange(100, dtype=dtype)
-        label = testing.shaped_random((100,), xp, dtype=xp.int32, scale=4)
-        return scp.ndimage.sum(image, label)
-
-    @testing.for_all_dtypes(no_bool=True, no_complex=True)
-    @testing.numpy_cupy_array_equal(scipy_name='scp')
-    def test_ndimage_sum_scalar_index(self, xp, scp, dtype):
-        image = xp.arange(100, dtype=dtype)
-        label = testing.shaped_random((100,), xp, dtype=xp.int32, scale=4)
-        return scp.ndimage.sum(image, label, 1)
-
-    @testing.for_dtypes([cupy.bool_, cupy.complex64, cupy.complex128])
-    def test_ndimage_sum_wrong_image_dtype(self, dtype):
-        image = cupy.arange(100).astype(dtype)
-        label = cupy.random.randint(1, 4, dtype=cupy.int32, size=100)
-        index = cupy.array([1, 2, 3])
-        with pytest.raises(TypeError):
-            cupyx.scipy.ndimage.sum(image, label, index)
-
-    def test_ndimage_sum_wrong_label_shape(self):
-        image = cupy.arange(100, dtype=cupy.int32)
-        label = cupy.random.randint(1, 3, dtype=cupy.int32, size=50)
-        index = cupy.array([1, 2, 3])
-        with pytest.raises(ValueError):
-            cupyx.scipy.ndimage.sum(image, label, index)
-
-    def test_ndimage_sum_wrong_image_type(self):
-        image = list(range(100))
-        label = cupy.random.randint(1, 3, dtype=cupy.int32, size=100)
-        index = cupy.array([1, 2, 3])
-        with pytest.raises(TypeError):
-            cupyx.scipy.ndimage.sum(image, label, index)
-
-    def test_ndimage_sum_wrong_label_type(self):
-        image = cupy.arange(100, dtype=cupy.int32)
-        label = numpy.random.randint(1, 3, dtype=numpy.int32, size=100)
-        index = cupy.array([1, 2, 3])
-        with pytest.raises(TypeError):
-            cupyx.scipy.ndimage.sum(image, label, index)
-
-    def test_ndimage_sum_wrong_index_type(self):
-        image = cupy.arange(100, dtype=cupy.int32)
-        label = cupy.random.randint(1, 3, dtype=cupy.int32, size=100)
-        index = [1, 2, 3]
-        with pytest.raises(TypeError):
-            cupyx.scipy.ndimage.sum(image, label, index)
-
-    @testing.numpy_cupy_array_almost_equal(scipy_name='scp')
-    def test_ndimage_sum_zero_values(self, xp, scp):
-        image = cupy.array([])
-        label = cupy.array([])
-        index = cupy.array([])
-        return cupyx.scipy.ndimage.sum(image, label, index)
-
-
-@testing.gpu
-@testing.with_requires('scipy')
-class TestNdimageVariance(unittest.TestCase):
+class TestNdimage(unittest.TestCase):
 
     @testing.for_all_dtypes(no_bool=True, no_complex=True)
     @testing.numpy_cupy_array_almost_equal(scipy_name='scp')
-    def test_ndimage_variance(self, xp, scp, dtype):
+    def test_ndimage_single_dim(self, xp, scp, dtype):
         image = xp.arange(100, dtype=dtype)
         label = testing.shaped_random((100,), xp, dtype=xp.int32, scale=3)
         index = xp.array([0, 1, 2])
-        return scp.ndimage.variance(image, label, index)
+        return getattr(scp.ndimage, self.op)(image, label, index)
 
     @testing.for_all_dtypes(no_bool=True, no_complex=True)
     @testing.numpy_cupy_array_almost_equal(scipy_name='scp')
-    def test_ndimage_variance_multi_dim(self, xp, scp, dtype):
+    def test_ndimage_multi_dim(self, xp, scp, dtype):
         image = xp.arange(512, dtype=dtype).reshape(8, 8, 8)
         label = testing.shaped_random((8, 8, 8), xp, dtype=xp.int32, scale=3)
         index = xp.array([0, 1, 2])
-        return scp.ndimage.variance(image, label, index)
-
-    @testing.for_all_dtypes(no_bool=True, no_complex=True, no_float16=True)
-    @testing.numpy_cupy_array_almost_equal(scipy_name='scp')
-    def test_ndimage_variance_only_input(self, xp, scp, dtype):
-        image = xp.arange(50, dtype=dtype)
-        return scp.ndimage.variance(image)
+        return getattr(scp.ndimage, self.op)(image, label, index)
 
     @testing.for_all_dtypes(no_bool=True, no_complex=True, no_float16=True)
     @testing.numpy_cupy_array_almost_equal(scipy_name='scp', decimal=5)
-    def test_ndimage_variance_no_index(self, xp, scp, dtype):
+    def test_ndimage_only_input(self, xp, scp, dtype):
+        image = xp.arange(100, dtype=dtype)
+        return getattr(scp.ndimage, self.op)(image)
+
+    @testing.for_all_dtypes(no_bool=True, no_complex=True, no_float16=True)
+    @testing.numpy_cupy_array_almost_equal(scipy_name='scp', decimal=5)
+    def test_ndimage_no_index(self, xp, scp, dtype):
         image = xp.arange(100, dtype=dtype)
         label = testing.shaped_random((100,), xp, dtype=xp.int32, scale=3)
-        return scp.ndimage.variance(image, label)
+        return getattr(scp.ndimage, self.op)(image, label)
 
     @testing.for_all_dtypes(no_bool=True, no_complex=True, no_float16=True)
     @testing.numpy_cupy_array_almost_equal(scipy_name='scp', decimal=4)
-    def test_ndimage_variance_scalar_index(self, xp, scp, dtype):
+    def test_ndimage_scalar_index(self, xp, scp, dtype):
         image = xp.arange(100, dtype=dtype)
-        label = testing.shaped_random((100,), xp, dtype=xp.int32, scale=4)
-        return scp.ndimage.variance(image, label, 1)
+        label = testing.shaped_random((100,), xp, dtype=xp.int32, scale=3)
+        return getattr(scp.ndimage, self.op)(image, label, 1)
 
     @testing.for_dtypes([cupy.bool_, cupy.complex64, cupy.complex128])
-    def test_ndimage_variance_wrong_dtype(self, dtype):
+    def test_ndimage_wrong_dtype(self, dtype):
         image = cupy.arange(100).astype(dtype)
         label = cupy.random.randint(1, 4, dtype=cupy.int32)
         index = cupy.array([1, 2, 3])
         with pytest.raises(TypeError):
-            cupyx.scipy.ndimage.variance(image, label, index)
+            getattr(cupyx.scipy.ndimage, self.op)(image, label, index)
 
-    def test_ndimage_variance_wrong_label_shape(self):
+    def test_ndimage_wrong_label_shape(self):
         image = cupy.arange(100, dtype=cupy.int32)
         label = cupy.random.randint(1, 3, dtype=cupy.int32, size=50)
         index = cupy.array([1, 2, 3])
         with pytest.raises(ValueError):
-            cupyx.scipy.ndimage.variance(image, label, index)
+            getattr(cupyx.scipy.ndimage, self.op)(image, label, index)
 
-    def test_ndimage_variance_wrong_image_type(self):
+    def test_ndimage_wrong_image_type(self):
         image = list(range(100))
         label = cupy.random.randint(1, 3, dtype=cupy.int32, size=100)
         index = cupy.array([1, 2, 3])
         with pytest.raises(TypeError):
-            cupyx.scipy.ndimage.variance(image, label, index)
+            getattr(cupyx.scipy.ndimage, self.op)(image, label, index)
 
-    def test_ndimage_variance_wrong_label_type(self):
+    def test_ndimage_wrong_label_type(self):
         image = cupy.arange(100, dtype=cupy.int32)
         label = numpy.random.randint(1, 3, dtype=numpy.int32, size=100)
         index = cupy.array([1, 2, 3])
         with pytest.raises(TypeError):
-            cupyx.scipy.ndimage.variance(image, label, index)
+            getattr(cupyx.scipy.ndimage, self.op)(image, label, index)
 
-    def test_ndimage_variance_wrong_index_type(self):
+    def test_ndimage_wrong_index_type(self):
         image = cupy.arange(100, dtype=cupy.int32)
         label = cupy.random.randint(1, 3, dtype=cupy.int32, size=100)
         index = [1, 2, 3]
         with pytest.raises(TypeError):
-            cupyx.scipy.ndimage.variance(image, label, index)
+            getattr(cupyx.scipy.ndimage, self.op)(image, label, index)
 
     @testing.numpy_cupy_array_almost_equal(scipy_name='scp')
-    def test_ndimage_variance_zero_values(self, xp, scp):
-        image = cupy.array([])
-        label = cupy.array([])
-        index = cupy.array([])
-        return cupyx.scipy.ndimage.variance(image, label, index)
-
-
-@testing.gpu
-@testing.with_requires('scipy')
-class TestNdimageMean(unittest.TestCase):
-
-    @testing.for_all_dtypes(no_bool=True, no_complex=True)
-    @testing.numpy_cupy_array_almost_equal(scipy_name='scp')
-    def test_ndimage_mean(self, xp, scp, dtype):
-        image = xp.arange(100, dtype=dtype)
-        label = testing.shaped_random((100,), xp, dtype=xp.int32, scale=3)
-        index = xp.array([0, 1, 2])
-        return scp.ndimage.mean(image, label, index)
-
-    @testing.for_all_dtypes(no_bool=True, no_complex=True)
-    @testing.numpy_cupy_array_almost_equal(scipy_name='scp')
-    def test_ndimage_mean_multi_dim(self, xp, scp, dtype):
-        image = xp.arange(512, dtype=dtype).reshape(8, 8, 8)
-        label = testing.shaped_random((8, 8, 8), xp, dtype=xp.int32, scale=3)
-        index = xp.array([0, 1, 2])
-        return scp.ndimage.mean(image, label, index)
-
-    @testing.for_all_dtypes(no_bool=True, no_complex=True, no_float16=True)
-    @testing.numpy_cupy_array_almost_equal(scipy_name='scp')
-    def test_ndimage_mean_only_input(self, xp, scp, dtype):
-        image = xp.arange(100, dtype=dtype)
-        return scp.ndimage.mean(image)
-
-    @testing.for_all_dtypes(no_bool=True, no_complex=True, no_float16=True)
-    @testing.numpy_cupy_array_almost_equal(scipy_name='scp')
-    def test_ndimage_mean_no_index(self, xp, scp, dtype):
-        image = xp.arange(100, dtype=dtype)
-        label = testing.shaped_random((100,), xp, dtype=xp.int32, scale=3)
-        return scp.ndimage.mean(image, label)
-
-    @testing.for_all_dtypes(no_bool=True, no_complex=True, no_float16=True)
-    @testing.numpy_cupy_array_almost_equal(scipy_name='scp')
-    def test_ndimage_mean_scalar_index(self, xp, scp, dtype):
-        image = xp.arange(100, dtype=dtype)
-        label = testing.shaped_random((100,), xp, dtype=xp.int32, scale=4)
-        return scp.ndimage.mean(image, label, 1)
-
-    @testing.for_dtypes([cupy.bool_, cupy.complex64, cupy.complex128])
-    def test_ndimage_mean_wrong_dtype(self, dtype):
-        image = cupy.arange(100).astype(dtype)
-        label = cupy.random.randint(1, 4, dtype=cupy.int32)
-        index = cupy.array([1, 2, 3])
-        with pytest.raises(TypeError):
-            cupyx.scipy.ndimage.mean(image, label, index)
-
-    def test_ndimage_mean_wrong_label_shape(self):
-        image = cupy.arange(100, dtype=cupy.int32)
-        label = cupy.random.randint(1, 3, dtype=cupy.int32, size=50)
-        index = cupy.array([1, 2, 3])
-        with pytest.raises(ValueError):
-            cupyx.scipy.ndimage.mean(image, label, index)
-
-    def test_ndimage_mean_wrong_image_type(self):
-        image = list(range(100))
-        label = cupy.random.randint(1, 3, dtype=cupy.int32, size=100)
-        index = cupy.array([1, 2, 3])
-        with pytest.raises(TypeError):
-            cupyx.scipy.ndimage.mean(image, label, index)
-
-    def test_ndimage_mean_wrong_label_type(self):
-        image = cupy.arange(100, dtype=cupy.int32)
-        label = numpy.random.randint(1, 3, dtype=numpy.int32, size=100)
-        index = cupy.array([1, 2, 3])
-        with pytest.raises(TypeError):
-            cupyx.scipy.ndimage.mean(image, label, index)
-
-    def test_ndimage_mean_wrong_index_type(self):
-        image = cupy.arange(100, dtype=cupy.int32)
-        label = cupy.random.randint(1, 3, dtype=cupy.int32, size=100)
-        index = [1, 2, 3]
-        with pytest.raises(TypeError):
-            cupyx.scipy.ndimage.mean(image, label, index)
-
-    @testing.numpy_cupy_array_almost_equal(scipy_name='scp')
-    def test_ndimage_mean_zero_values(self, xp, scp):
-        image = cupy.array([])
-        label = cupy.array([])
-        index = cupy.array([])
-        return cupyx.scipy.ndimage.mean(image, label, index)
-
-
-@testing.gpu
-@testing.with_requires('scipy')
-class TestNdimageStandardDeviation(unittest.TestCase):
-
-    @testing.for_all_dtypes(no_bool=True, no_complex=True)
-    @testing.numpy_cupy_array_almost_equal(scipy_name='scp')
-    def test_ndimage_standard_deviation(self, xp, scp, dtype):
-        image = xp.arange(100, dtype=dtype)
-        label = testing.shaped_random((100,), xp, dtype=xp.int32, scale=3)
-        index = xp.array([0, 1, 2])
-        return scp.ndimage.standard_deviation(image, label, index)
-
-    @testing.for_all_dtypes(no_bool=True, no_complex=True)
-    @testing.numpy_cupy_array_almost_equal(scipy_name='scp')
-    def test_ndimage_standard_deviation_multi_dim(self, xp, scp, dtype):
-        image = xp.arange(512, dtype=dtype).reshape(8, 8, 8)
-        label = testing.shaped_random((8, 8, 8), xp, dtype=xp.int32, scale=3)
-        index = xp.array([0, 1, 2])
-        return scp.ndimage.standard_deviation(image, label, index)
-
-    @testing.for_all_dtypes(no_bool=True, no_complex=True, no_float16=True)
-    @testing.numpy_cupy_array_almost_equal(scipy_name='scp')
-    def test_ndimage_standard_deviation_only_input(self, xp, scp, dtype):
-        image = xp.arange(100, dtype=dtype)
-        return scp.ndimage.standard_deviation(image)
-
-    @testing.for_all_dtypes(no_bool=True, no_complex=True, no_float16=True)
-    @testing.numpy_cupy_array_almost_equal(scipy_name='scp')
-    def test_ndimage_standard_deviation_no_index(self, xp, scp, dtype):
-        image = xp.arange(100, dtype=dtype)
-        label = testing.shaped_random((100,), xp, dtype=xp.int32, scale=3)
-        return scp.ndimage.standard_deviation(image, label)
-
-    @testing.for_all_dtypes(no_bool=True, no_complex=True, no_float16=True)
-    @testing.numpy_cupy_array_almost_equal(scipy_name='scp', decimal=5)
-    def test_ndimage_standard_deviation_scalar_index(self, xp, scp, dtype):
-        image = xp.arange(100, dtype=dtype)
-        label = testing.shaped_random((100,), xp, dtype=xp.int32, scale=4)
-        return scp.ndimage.standard_deviation(image, label, 1)
-
-    @testing.for_dtypes([cupy.bool_, cupy.complex64, cupy.complex128])
-    def test_ndimage_standard_deviation_wrong_dtype(self, dtype):
-        image = cupy.arange(100).astype(dtype)
-        label = cupy.random.randint(1, 4, dtype=cupy.int32)
-        index = cupy.array([1, 2, 3])
-        with pytest.raises(TypeError):
-            cupyx.scipy.ndimage.standard_deviation(image, label, index)
-
-    def test_ndimage_standard_deviation_wrong_label_shape(self):
-        image = cupy.arange(100, dtype=cupy.int32)
-        label = cupy.random.randint(1, 3, dtype=cupy.int32, size=50)
-        index = cupy.array([1, 2, 3])
-        with pytest.raises(ValueError):
-            cupyx.scipy.ndimage.standard_deviation(image, label, index)
-
-    def test_ndimage_standard_deviation_wrong_image_type(self):
-        image = list(range(100))
-        label = cupy.random.randint(1, 3, dtype=cupy.int32, size=100)
-        index = cupy.array([1, 2, 3])
-        with pytest.raises(TypeError):
-            cupyx.scipy.ndimage.standard_deviation(image, label, index)
-
-    def test_ndimage_standard_deviation_wrong_label_type(self):
-        image = cupy.arange(100, dtype=cupy.int32)
-        label = numpy.random.randint(1, 3, dtype=numpy.int32, size=100)
-        index = cupy.array([1, 2, 3])
-        with pytest.raises(TypeError):
-            cupyx.scipy.ndimage.standard_deviation(image, label, index)
-
-    def test_ndimage_standard_deviation_wrong_index_type(self):
-        image = cupy.arange(100, dtype=cupy.int32)
-        label = cupy.random.randint(1, 3, dtype=cupy.int32, size=100)
-        index = [1, 2, 3]
-        with pytest.raises(TypeError):
-            cupyx.scipy.ndimage.standard_deviation(image, label, index)
-
-    @testing.numpy_cupy_array_almost_equal(scipy_name='scp')
-    def test_ndimage_stadard_deviation_zero_values(self, xp, scp):
-        image = cupy.array([])
-        label = cupy.array([])
-        index = cupy.array([])
-        return cupyx.scipy.ndimage.standard_deviation(image, label, index)
+    def test_ndimage_zero_values(self, xp, scp):
+        image = xp.array([])
+        label = xp.array([])
+        index = xp.array([])
+        return getattr(scp.ndimage, self.op)(image, label, index)

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
@@ -108,16 +108,16 @@ class TestNdimageSum(unittest.TestCase):
     @testing.numpy_cupy_array_equal(scipy_name='scp')
     def test_ndimage_sum(self, xp, scp, dtype):
         image = xp.arange(100, dtype=dtype)
-        label = testing.shaped_random((100,), xp, dtype=xp.int32, scale=3) + 1
-        index = xp.array([1, 2, 3])
+        label = testing.shaped_random((100,), xp, dtype=xp.int32, scale=4)
+        index = xp.array([0, 1, 2, 3])
         return scp.ndimage.sum(image, label, index)
 
     @testing.for_all_dtypes(no_bool=True, no_complex=True)
-    @testing.numpy_cupy_array_almost_equal(scipy_name='scp')
+    @testing.numpy_cupy_array_equal(scipy_name='scp')
     def test_ndimage_sum_multi_dim(self, xp, scp, dtype):
         image = xp.arange(512, dtype=dtype).reshape(8, 8, 8)
-        label = testing.shaped_random((8, 8, 8), xp, dtype=xp.int32, scale=3)
-        index = xp.array([0, 1, 2])
+        label = testing.shaped_random((8, 8, 8), xp, dtype=xp.int32, scale=4)
+        index = xp.array([1, 2, 3])
         return scp.ndimage.sum(image, label, index)
 
     @testing.for_all_dtypes(no_bool=True, no_complex=True)
@@ -130,20 +130,20 @@ class TestNdimageSum(unittest.TestCase):
     @testing.numpy_cupy_array_equal(scipy_name='scp')
     def test_ndimage_sum_no_index(self, xp, scp, dtype):
         image = xp.arange(100, dtype=dtype)
-        label = testing.shaped_random((100,), xp, dtype=xp.int32, scale=3) + 1
+        label = testing.shaped_random((100,), xp, dtype=xp.int32, scale=4)
         return scp.ndimage.sum(image, label)
 
     @testing.for_all_dtypes(no_bool=True, no_complex=True)
     @testing.numpy_cupy_array_equal(scipy_name='scp')
     def test_ndimage_sum_scalar_index(self, xp, scp, dtype):
         image = xp.arange(100, dtype=dtype)
-        label = testing.shaped_random((100,), xp, dtype=xp.int32, scale=3) + 1
+        label = testing.shaped_random((100,), xp, dtype=xp.int32, scale=4)
         return scp.ndimage.sum(image, label, 1)
 
     @testing.for_dtypes([cupy.bool_, cupy.complex64, cupy.complex128])
-    def test_ndimage_sum_wrong_dtype(self, dtype):
+    def test_ndimage_sum_wrong_image_dtype(self, dtype):
         image = cupy.arange(100).astype(dtype)
-        label = cupy.random.randint(1, 4, dtype=cupy.int32)
+        label = cupy.random.randint(1, 4, dtype=cupy.int32, size=100)
         index = cupy.array([1, 2, 3])
         with pytest.raises(TypeError):
             cupyx.scipy.ndimage.sum(image, label, index)
@@ -221,7 +221,7 @@ class TestNdimageVariance(unittest.TestCase):
     @testing.numpy_cupy_array_almost_equal(scipy_name='scp', decimal=4)
     def test_ndimage_variance_scalar_index(self, xp, scp, dtype):
         image = xp.arange(100, dtype=dtype)
-        label = testing.shaped_random((100,), xp, dtype=xp.int32, scale=3) + 1
+        label = testing.shaped_random((100,), xp, dtype=xp.int32, scale=4)
         return scp.ndimage.variance(image, label, 1)
 
     @testing.for_dtypes([cupy.bool_, cupy.complex64, cupy.complex128])
@@ -305,7 +305,7 @@ class TestNdimageMean(unittest.TestCase):
     @testing.numpy_cupy_array_almost_equal(scipy_name='scp')
     def test_ndimage_mean_scalar_index(self, xp, scp, dtype):
         image = xp.arange(100, dtype=dtype)
-        label = testing.shaped_random((100,), xp, dtype=xp.int32, scale=3) + 1
+        label = testing.shaped_random((100,), xp, dtype=xp.int32, scale=4)
         return scp.ndimage.mean(image, label, 1)
 
     @testing.for_dtypes([cupy.bool_, cupy.complex64, cupy.complex128])
@@ -389,7 +389,7 @@ class TestNdimageStandardDeviation(unittest.TestCase):
     @testing.numpy_cupy_array_almost_equal(scipy_name='scp', decimal=5)
     def test_ndimage_standard_deviation_scalar_index(self, xp, scp, dtype):
         image = xp.arange(100, dtype=dtype)
-        label = testing.shaped_random((100,), xp, dtype=xp.int32, scale=3) + 1
+        label = testing.shaped_random((100,), xp, dtype=xp.int32, scale=4)
         return scp.ndimage.standard_deviation(image, label, 1)
 
     @testing.for_dtypes([cupy.bool_, cupy.complex64, cupy.complex128])

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
@@ -174,7 +174,7 @@ class TestNdimageSum(unittest.TestCase):
             cupyx.scipy.ndimage.sum(image, label, index)
 
     @testing.numpy_cupy_array_almost_equal(scipy_name='scp')
-    def test_ndimage_zero_values(self, xp, scp):
+    def test_ndimage_sum_zero_values(self, xp, scp):
         image = cupy.array([])
         label = cupy.array([])
         index = cupy.array([])
@@ -255,7 +255,7 @@ class TestNdimageVariance(unittest.TestCase):
             cupyx.scipy.ndimage.variance(image, label, index)
 
     @testing.numpy_cupy_array_almost_equal(scipy_name='scp')
-    def test_ndimage_zero_values(self, xp, scp):
+    def test_ndimage_variance_zero_values(self, xp, scp):
         image = cupy.array([])
         label = cupy.array([])
         index = cupy.array([])
@@ -336,7 +336,7 @@ class TestNdimageMean(unittest.TestCase):
             cupyx.scipy.ndimage.mean(image, label, index)
 
     @testing.numpy_cupy_array_almost_equal(scipy_name='scp')
-    def test_ndimage_zero_values(self, xp, scp):
+    def test_ndimage_mean_zero_values(self, xp, scp):
         image = cupy.array([])
         label = cupy.array([])
         index = cupy.array([])
@@ -418,7 +418,7 @@ class TestNdimageStandardDeviation(unittest.TestCase):
             cupyx.scipy.ndimage.standard_deviation(image, label, index)
 
     @testing.numpy_cupy_array_almost_equal(scipy_name='scp')
-    def test_ndimage_zero_values(self, xp, scp):
+    def test_ndimage_stadard_deviation_zero_values(self, xp, scp):
         image = cupy.array([])
         label = cupy.array([])
         index = cupy.array([])

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
@@ -189,7 +189,7 @@ class TestNdimageSum(unittest.TestCase):
 class TestNdimageVariance(unittest.TestCase):
 
     @testing.for_dtypes([cupy.int32, cupy.float32, cupy.float64, cupy.uint32,
-                         cupy.uint64, cupy.ulonglong])
+                         cupy.uint64, cupy.ulonglong, cupy.int64, cupy.uint16])
     @testing.numpy_cupy_array_almost_equal(scipy_name='scp', decimal=5)
     def test_ndimage_variance(self, xp, scp, dtype):
         image = xp.arange(100, dtype=dtype)
@@ -220,8 +220,7 @@ class TestNdimageVariance(unittest.TestCase):
         label = testing.shaped_random((100,), xp, dtype=xp.int32, scale=3) + 1
         return scp.ndimage.variance(image, label, 1).astype(dtype)
 
-    @testing.for_dtypes([cupy.int8, cupy.int16, cupy.int64, cupy.uint8,
-                         cupy.uint16, cupy.complex64, cupy.complex128])
+    @testing.for_dtypes([cupy.complex64, cupy.complex128])
     def test_ndimage_variance_wrong_dtype(self, dtype):
         image = cupy.arange(100, dtype=dtype)
         label = cupy.random.randint(1, 3, dtype=cupy.int32)
@@ -354,7 +353,7 @@ class TestNdimageMean(unittest.TestCase):
 class TestNdimageStandardDeviation(unittest.TestCase):
 
     @testing.for_dtypes([cupy.int32, cupy.float32, cupy.float64, cupy.uint32,
-                         cupy.uint64, cupy.ulonglong])
+                         cupy.uint64, cupy.ulonglong, cupy.int64, cupy.uint16])
     @testing.numpy_cupy_array_almost_equal(scipy_name='scp', decimal=5)
     def test_ndimage_standard_deviation(self, xp, scp, dtype):
         image = xp.arange(100, dtype=dtype)
@@ -386,8 +385,7 @@ class TestNdimageStandardDeviation(unittest.TestCase):
         label = testing.shaped_random((100,), xp, dtype=xp.int32, scale=3) + 1
         return scp.ndimage.standard_deviation(image, label, 1).astype(dtype)
 
-    @testing.for_dtypes([cupy.int8, cupy.int16, cupy.int64, cupy.uint8,
-                         cupy.uint16, cupy.complex64, cupy.complex128])
+    @testing.for_dtypes([cupy.complex64, cupy.complex128])
     def test_ndimage_standard_deviation_wrong_dtype(self, dtype):
         image = cupy.arange(100, dtype=dtype)
         label = cupy.random.randint(1, 3, dtype=cupy.int32)


### PR DESCRIPTION
This PR adds the following routines for cupyx.scipy.ndimage

- sum
- mean
- variance

Currently this method uses Elementwise Kernels,I tried to use Reduction Kernel but couldnt get it to work, if possible can someone recommend a way to use Reduction Kernels.

This PR is still a work in progress.
Todo list

- [x] Fix variance in accordance to alpha values
- [x] Performance Testing
- [x] Add tests 
- [x] Fix Documentation 
- [x] Add more robust type checking 