### PR TITLE
Fix the internal streams in multi-GPU Plan1d 

### DIFF
--- a/cupy/cuda/cufft.pyx
+++ b/cupy/cuda/cufft.pyx
@@ -569,10 +569,10 @@ class Plan1d(object):
                     curr_event = self.scatter_events[s_device][dev]
                     xtArr_buffer[dev].copy_from_device_async(
                         b[start:start+count].data, size, curr_stream)
-                    curr_event.record(curr_stream)
                     if dev != 0:
                         prev_event = self.scatter_events[s_device][dev-1]
                         curr_stream.wait_event(prev_event)
+                    curr_event.record(curr_stream)
                     start += count
                 assert start == b.size
                 self.scatter_events[s_device][-1].synchronize()
@@ -600,10 +600,10 @@ class Plan1d(object):
                     curr_event = self.gather_events[i]
                     b[start:start+count].data.copy_from_device_async(
                         xtArr_buffer[i], size, curr_stream)
-                    curr_event.record(curr_stream)
                     if i != 0:
                         prev_event = self.gather_events[i-1]
                         curr_stream.wait_event(prev_event)
+                    curr_event.record(curr_stream)
                     start += count
                 assert start == b.size
                 self.gather_events[-1].synchronize()


### PR DESCRIPTION
Follow-up of #2644. I overlooked an undocumented CUDA behavior that for `cudaMemcpyAsync`/`cudaMemcpyPeerAsync`, the `stream` argument should reside on the **source** device (see, e.g., [here](https://stackoverflow.com/a/22792494/2344149); I also confirmed it with someone from NVIDIA). If this condition is not met, then CUDA would neglect the input `stream` and instead use its internal stream to do the job (can be checked on nvvp). 

If we don't want to rely on CUDA doing the job for us and prefer to be explicit, it means: 
- for the `'scatter'` operation: all streams should be on the same device as is the source
- for the `'gather'` operation: each device needs one stream. 

This PR addresses this distinction.