### PR TITLE
Fix `_reduce_dims` call in reduction

### DIFF
--- a/cupy/core/_reduction.pyx
+++ b/cupy/core/_reduction.pyx
@@ -264,7 +264,8 @@ cdef class _AbstractReductionKernel:
         out_shape = _get_out_shape(a_shape, reduce_axis, out_axis, keepdims)
         # Needs to create the empty arrays first and access them for the
         # _reduce_dims to work.
-        out_args_ = self._get_out_args(out_args, out_types, out_shape)
+        out_args_ = [Arg.from_obj(a) for a in out_args]
+        out_args_ = self._get_out_args(out_args_, out_types, out_shape)
         out_arrays_ = [(<Arg>a).obj for a in out_args_]
 
         if self.identity == '':

--- a/cupy/core/_reduction.pyx
+++ b/cupy/core/_reduction.pyx
@@ -262,6 +262,10 @@ cdef class _AbstractReductionKernel:
             out_axis = _sort_axis(out_axis, strides)
 
         out_shape = _get_out_shape(a_shape, reduce_axis, out_axis, keepdims)
+        # Needs to create the empty arrays first and access them for the
+        # _reduce_dims to work.
+        out_args_ = self._get_out_args(out_args, out_types, out_shape)
+        out_arrays_ = [(<Arg>a).obj for a in out_args_]
 
         if self.identity == '':
             for axis in reduce_axis:
@@ -269,19 +273,19 @@ cdef class _AbstractReductionKernel:
                     raise ValueError(('zero-size array to reduction operation'
                                       ' %s which has no identity') % self.name)
 
-        if len(out_args) == 1:
+        if len(out_arrays_) == 1:
             # Check the shape of out_args.
-            if out_args[0].shape[-len(out_shape):] != out_shape:
+            if out_arrays_[0].shape[-len(out_shape):] != out_shape:
                 raise ValueError('Shape mismatch')
 
         in_shape = _set_permuted_args(
             in_args, reduce_axis + out_axis, a_shape, self.in_params)
-
         if reduce_dims:
             in_shape = _reduce_dims(in_args, self.in_params, in_shape)
-            out_shape = _reduce_dims(out_args, self.out_params, out_shape)
-
+            out_shape = _reduce_dims(out_arrays_, self.out_params, out_shape)
         in_args_ = [Arg.from_obj(a) for a in in_args]
+        # out_args_ needs to be recreated as the number of dimensions
+        # might have changed
         out_args_ = [Arg.from_obj(a) for a in out_args]
         out_args_ = self._get_out_args(out_args_, out_types, out_shape)
 

--- a/cupy/core/_reduction.pyx
+++ b/cupy/core/_reduction.pyx
@@ -278,6 +278,10 @@ cdef class _AbstractReductionKernel:
             if out_arrays_[0].shape[-len(out_shape):] != out_shape:
                 raise ValueError('Shape mismatch')
 
+        ret = (<Arg>out_args_[0]).obj
+        if ret.size == 0:
+            return ret
+
         in_shape = _set_permuted_args(
             in_args, reduce_axis + out_axis, a_shape, self.in_params)
         if reduce_dims:
@@ -286,12 +290,7 @@ cdef class _AbstractReductionKernel:
         in_args_ = [Arg.from_obj(a) for a in in_args]
         # out_args_ needs to be recreated as the number of dimensions
         # might have changed
-        out_args_ = [Arg.from_obj(a) for a in out_args]
-        out_args_ = self._get_out_args(out_args_, out_types, out_shape)
-
-        ret = (<Arg>out_args_[0]).obj
-        if ret.size == 0:
-            return ret
+        out_args_ = [Arg.from_obj(a) for a in out_arrays_]
 
         # Calculate the reduction block dimensions.
         contiguous_size = _get_contiguous_size(

--- a/tests/cupy_tests/core_tests/test_reduction.py
+++ b/tests/cupy_tests/core_tests/test_reduction.py
@@ -139,3 +139,15 @@ class TestReductionKernelInvalidArgument(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, 'Invalid kernel name'):
             cupy.ReductionKernel(
                 'T x', 'T y', 'x', 'a + b', 'y = a', '0', name='1')
+
+
+@testing.gpu
+class TestLargeMultiDimReduction(
+        ReductionKernelTestBase, unittest.TestCase):
+
+    def test_large_dims_keep_kernels(self):
+        # This test creates a CUDA_ERROR_LAUNCH_OUT_OF_RESOURCES
+        # if the output array dims are not reduced
+        shape = (4, 3, 2, 4, 3, 2, 2)
+        axis = (1, 4, 3, 6)
+        self.check_int8_sum(shape, axis=axis, keepdims=True)


### PR DESCRIPTION
Closes #3258

When calling `_reduce_dims`, the out_args tuple was empty, so dimensions were never reduced.
`_get_out_args` is the function that initializes the actual arrays if the `out` parameter is an empty list, and it wasn't called until later.

This PR calls `_get_out_args` before and then retrieves its `ndarray` objects, so that dimensions can be effectively reduced. Then it recreated the output as the dimensionality might have changed.

Another way to solve this could be to make `_reduce_dims` allow a list of `Arg` objects as the parameter and modify it accordingly.

`ElementwiseKernel` should be check to verify if this problem also happens there.