### PR TITLE
Raise `IndexError` for R2C/C2R FFT with `axes=()`

### DIFF
--- a/cupy/fft/fft.py
+++ b/cupy/fft/fft.py
@@ -166,7 +166,7 @@ def _fft(a, s, axes, norm, direction, value_type='C2C', overwrite_x=False,
         axes = [i for i in range(-dim, 0)]
     else:
         axes = tuple(axes)
-    if len(axes) == 0:
+    if not axes:
         if value_type == 'C2C':
             return a
         else:
@@ -422,7 +422,7 @@ def _fftn(a, s, axes, norm, direction, value_type='C2C', order='A', plan=None,
                          % norm)
 
     axes, axes_sorted = _prep_fftn_axes(a.ndim, s, axes)
-    if len(axes_sorted) == 0:
+    if not axes_sorted:
         if value_type == 'C2C':
             return a
         else:

--- a/cupy/fft/fft.py
+++ b/cupy/fft/fft.py
@@ -166,8 +166,11 @@ def _fft(a, s, axes, norm, direction, value_type='C2C', overwrite_x=False,
         axes = [i for i in range(-dim, 0)]
     else:
         axes = tuple(axes)
-    if not axes:
-        return a
+    if len(axes) == 0:
+        if value_type == 'C2C':
+            return a
+        else:
+            raise IndexError('list index out of range')
     a = _convert_dtype(a, value_type)
     a = _cook_shape(a, s, axes, value_type)
 
@@ -419,8 +422,11 @@ def _fftn(a, s, axes, norm, direction, value_type='C2C', order='A', plan=None,
                          % norm)
 
     axes, axes_sorted = _prep_fftn_axes(a.ndim, s, axes)
-    if not axes_sorted:
-        return a
+    if len(axes_sorted) == 0:
+        if value_type == 'C2C':
+            return a
+        else:
+            raise IndexError('list index out of range')
     a = _convert_dtype(a, value_type)
 
     if order == 'A':

--- a/tests/cupy_tests/fft_tests/test_fft.py
+++ b/tests/cupy_tests/fft_tests/test_fft.py
@@ -310,6 +310,7 @@ class TestFftAllocate(unittest.TestCase):
     {'shape': (3, 4), 's': None, 'axes': (-1, -2), 'norm': None},
     {'shape': (3, 4), 's': None, 'axes': (0,), 'norm': None},
     {'shape': (3, 4), 's': None, 'axes': None, 'norm': 'ortho'},
+    {'shape': (3, 4), 's': None, 'axes': (), 'norm': None},
     {'shape': (2, 3, 4), 's': None, 'axes': None, 'norm': None},
     {'shape': (2, 3, 4), 's': (1, 4, None), 'axes': None, 'norm': None},
     {'shape': (2, 3, 4), 's': (1, 4, 10), 'axes': None, 'norm': None},
@@ -317,6 +318,7 @@ class TestFftAllocate(unittest.TestCase):
     {'shape': (2, 3, 4), 's': None, 'axes': (-1, -2, -3), 'norm': None},
     {'shape': (2, 3, 4), 's': None, 'axes': (0, 1), 'norm': None},
     {'shape': (2, 3, 4), 's': None, 'axes': None, 'norm': 'ortho'},
+    {'shape': (2, 3, 4), 's': None, 'axes': (), 'norm': None},
     {'shape': (2, 3, 4), 's': (2, 3), 'axes': (0, 1, 2), 'norm': 'ortho'},
     {'shape': (2, 3, 4, 5), 's': None, 'axes': None, 'norm': None},
 )
@@ -370,6 +372,7 @@ class TestFft2(unittest.TestCase):
     {'shape': (2, 3, 4), 's': None, 'axes': (-1, -3), 'norm': None},
     {'shape': (2, 3, 4), 's': None, 'axes': (0, 1), 'norm': None},
     {'shape': (2, 3, 4), 's': None, 'axes': None, 'norm': 'ortho'},
+    {'shape': (2, 3, 4), 's': None, 'axes': (), 'norm': 'ortho'},
     {'shape': (2, 3, 4), 's': (2, 3), 'axes': (0, 1, 2), 'norm': 'ortho'},
     {'shape': (2, 3, 4), 's': (4, 3, 2), 'axes': (2, 0, 1), 'norm': 'ortho'},
     {'shape': (2, 3, 4, 5), 's': None, 'axes': None, 'norm': None},
@@ -788,6 +791,28 @@ class TestRfft2(unittest.TestCase):
 
 
 @testing.parameterize(
+    {'shape': (3, 4), 's': None, 'axes': (), 'norm': None},
+    {'shape': (2, 3, 4), 's': None, 'axes': (), 'norm': None},
+)
+@testing.gpu
+class TestRfft2EmptyAxes(unittest.TestCase):
+
+    @testing.for_all_dtypes(no_complex=True)
+    def test_rfft2(self, dtype):
+        for xp in (np, cupy):
+            a = testing.shaped_random(self.shape, xp, dtype)
+            with pytest.raises(IndexError):
+                xp.fft.rfft2(a, s=self.s, axes=self.axes, norm=self.norm)
+
+    @testing.for_all_dtypes()
+    def test_irfft2(self, dtype):
+        for xp in (np, cupy):
+            a = testing.shaped_random(self.shape, xp, dtype)
+            with pytest.raises(IndexError):
+                xp.fft.irfft2(a, s=self.s, axes=self.axes, norm=self.norm)
+
+
+@testing.parameterize(
     {'shape': (3, 4), 's': None, 'axes': None, 'norm': None},
     {'shape': (3, 4), 's': (1, None), 'axes': None, 'norm': None},
     {'shape': (3, 4), 's': (1, 5), 'axes': None, 'norm': None},
@@ -837,6 +862,28 @@ class TestRfftn(unittest.TestCase):
             out = out.astype(np.float32)
 
         return out
+
+
+@testing.parameterize(
+    {'shape': (3, 4), 's': None, 'axes': (), 'norm': None},
+    {'shape': (2, 3, 4), 's': None, 'axes': (), 'norm': None},
+)
+@testing.gpu
+class TestRfftnEmptyAxes(unittest.TestCase):
+
+    @testing.for_all_dtypes(no_complex=True)
+    def test_rfftn(self, dtype):
+        for xp in (np, cupy):
+            a = testing.shaped_random(self.shape, xp, dtype)
+            with pytest.raises(IndexError):
+                xp.fft.rfftn(a, s=self.s, axes=self.axes, norm=self.norm)
+
+    @testing.for_all_dtypes()
+    def test_irfftn(self, dtype):
+        for xp in (np, cupy):
+            a = testing.shaped_random(self.shape, xp, dtype)
+            with pytest.raises(IndexError):
+                xp.fft.irfftn(a, s=self.s, axes=self.axes, norm=self.norm)
 
 
 @testing.parameterize(*testing.product({


### PR DESCRIPTION
Close #3240. This makes the behavior compatible with NumPy.