### PR TITLE
Implementation of `cupy.kaiser`

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -578,6 +578,7 @@ from cupy.math.sumprod import diff  # NOQA
 from cupy.math.window import blackman  # NOQA
 from cupy.math.window import hamming  # NOQA
 from cupy.math.window import hanning  # NOQA
+from cupy.math.window import kaiser  # NOQA
 
 from cupy.math.explog import exp  # NOQA
 from cupy.math.explog import exp2  # NOQA

--- a/cupy/math/window.py
+++ b/cupy/math/window.py
@@ -1,9 +1,13 @@
 import numpy
 
+from cupy import arange
+from cupy import array
 from cupy.creation import basic
 from cupy.creation import from_data
 from cupy.creation import ranges
 from cupy.math import trigonometric
+from cupy.math.special import i0
+from cupy.math.misc import sqrt
 
 
 def blackman(M):
@@ -87,3 +91,37 @@ def hanning(M):
         return basic.ones(1, float)
     n = ranges.arange(0, M)
     return 0.5 - 0.5 * trigonometric.cos(2.0 * numpy.pi * n / (M - 1))
+
+
+def kaiser(M, beta):
+    """Return the Kaiser window.
+    The Kaiser window is a taper formed by using a Bessel function.
+
+    .. math::  w(n) = I_0\\left( \\beta \\sqrt{1-\\frac{4n^2}{(M-1)^2}}
+               \\right)/I_0(\\beta)
+
+    with
+
+    .. math:: \\quad -\\frac{M-1}{2} \\leq n \\leq \\frac{M-1}{2}
+
+    where :math:`I_0` is the modified zeroth-order Bessel function.
+
+     Args:
+        M (:class:`~int`):
+            Number of points in the output window. If zero or less, an empty
+            array is returned.
+        beta (:class:`~float`):
+            Shape parameter for window
+
+    Returns:
+        ~cupy.ndarray:  The window, with the maximum value normalized to one
+        (the value one appears only if the number of samples is odd).
+
+    .. seealso:: :func:`numpy.kaiser`
+    """
+    if M == 1:
+        return array([1.])
+    n = arange(0, M)
+    alpha = (M-1)/2.0
+    temp = (n-alpha)/alpha
+    return i0(beta * sqrt(1 - (temp * temp)))/i0(float(beta))

--- a/cupy/math/window.py
+++ b/cupy/math/window.py
@@ -132,7 +132,7 @@ def kaiser(M, beta):
     """
     if M == 1:
         return cupy.array([1.])
-    if M < 0:
+    if M <= 0:
         return cupy.array([])
     alpha = (M - 1) / 2.0
     out = cupy.empty(M, dtype=cupy.float64)

--- a/cupy/math/window.py
+++ b/cupy/math/window.py
@@ -1,12 +1,11 @@
 import numpy
 
 import cupy
-from cupy import util
+from cupy import core
 from cupy.creation import basic
 from cupy.creation import from_data
 from cupy.creation import ranges
 from cupy.math import trigonometric
-from cupy.core import ElementwiseKernel
 
 
 def blackman(M):
@@ -92,16 +91,14 @@ def hanning(M):
     return 0.5 - 0.5 * trigonometric.cos(2.0 * numpy.pi * n / (M - 1))
 
 
-@util.memoize()
-def _kaiser_kernel():
-    return ElementwiseKernel("float32 beta, float32 alpha",
-                             "T arr",
-                             """
-                             float temp = (i - alpha) / alpha;
-                             arr = cyl_bessel_i0(beta *
-                                                 sqrt(1 - (temp * temp)));
-                             arr /= cyl_bessel_i0(beta);
-                             """)
+_kaiser_kernel = core.ElementwiseKernel(
+    "float32 beta, float32 alpha",
+    "T arr",
+    """
+    float temp = (i - alpha) / alpha;
+    arr = cyl_bessel_i0(beta * sqrt(1 - (temp * temp)));
+    arr /= cyl_bessel_i0(beta);
+    """)
 
 
 def kaiser(M, beta):
@@ -136,4 +133,4 @@ def kaiser(M, beta):
         return cupy.array([])
     alpha = (M - 1) / 2.0
     out = cupy.empty(M, dtype=cupy.float64)
-    return _kaiser_kernel()(beta, alpha, out)
+    return _kaiser_kernel(beta, alpha, out)

--- a/cupy/math/window.py
+++ b/cupy/math/window.py
@@ -1,8 +1,6 @@
 import numpy
 
-from cupy import array
-from cupy import empty
-from cupy import float64
+import cupy
 from cupy import util
 from cupy.creation import basic
 from cupy.creation import from_data
@@ -96,13 +94,12 @@ def hanning(M):
 
 @util.memoize()
 def _kaiser_kernel():
-    input_arguments = "float32 beta, float32 alpha"
-    output_arguments = "T arr"
-    return ElementwiseKernel(input_arguments,
-                             output_arguments,
+    return ElementwiseKernel("float32 beta, float32 alpha",
+                             "T arr",
                              """
-                             float temp = (i - alpha)/alpha;
-                             arr = cyl_bessel_i0(beta * sqrt(1-(temp * temp)));
+                             float temp = (i - alpha) / alpha;
+                             arr = cyl_bessel_i0(beta *
+                                                 sqrt(1 - (temp * temp)));
                              arr /= cyl_bessel_i0(beta);
                              """)
 
@@ -121,10 +118,10 @@ def kaiser(M, beta):
     where :math:`I_0` is the modified zeroth-order Bessel function.
 
      Args:
-        M (:class:`~int`):
+        M (int):
             Number of points in the output window. If zero or less, an empty
             array is returned.
-        beta (:class:`~float`):
+        beta (float):
             Shape parameter for window
 
     Returns:
@@ -134,9 +131,9 @@ def kaiser(M, beta):
     .. seealso:: :func:`numpy.kaiser`
     """
     if M == 1:
-        return array([1.])
+        return cupy.array([1.])
     if M < 0:
-        return array([])
-    alpha = (M-1)/2.0
-    out = empty(M, dtype=float64)
+        return cupy.array([])
+    alpha = (M - 1) / 2.0
+    out = cupy.empty(M, dtype=cupy.float64)
     return _kaiser_kernel()(beta, alpha, out)

--- a/docs/source/reference/math.rst
+++ b/docs/source/reference/math.rst
@@ -172,3 +172,4 @@ Miscellaneous
    cupy.blackman
    cupy.hamming
    cupy.hanning
+   cupy.kaiser

--- a/tests/cupy_tests/math_tests/test_window.py
+++ b/tests/cupy_tests/math_tests/test_window.py
@@ -18,13 +18,21 @@ class TestWindow(unittest.TestCase):
 
 @testing.parameterize(
     *testing.product({
-        'm': [0, 1, -1, 1024],
-        'beta': [0, 5, 6, 8.6],
+        'm': [10, 30, 1024],
+        'beta': [-3.4, 0, 5, 6, 8.6],
         'name': ['kaiser'],
     })
 )
 class TestKaiser(unittest.TestCase):
 
     @testing.numpy_cupy_allclose(atol=1e-5)
-    def test_kaiser(self, xp):
+    def test_kaiser_parametric(self, xp):
         return getattr(xp, self.name)(self.m, self.beta)
+
+
+@testing.parameterize(*testing.product({'m': [-1, 0, 1]}))
+class TestKaiserBoundary(unittest.TestCase):
+
+    @testing.numpy_cupy_allclose(atol=1e-5)
+    def test_kaiser(self, xp):
+        return xp.kaiser(self.m, 1.5)

--- a/tests/cupy_tests/math_tests/test_window.py
+++ b/tests/cupy_tests/math_tests/test_window.py
@@ -14,3 +14,17 @@ class TestWindow(unittest.TestCase):
     @testing.numpy_cupy_allclose(atol=1e-5)
     def test_window(self, xp):
         return getattr(xp, self.name)(self.m)
+
+
+@testing.parameterize(
+    *testing.product({
+        'm': [0, 1, -1, 1024],
+        'beta': [0, 5, 6, 8.6],
+        'name': ['kaiser'],
+    })
+)
+class TestKaiser(unittest.TestCase):
+
+    @testing.numpy_cupy_allclose(atol=1e-5)
+    def test_kaiser(self, xp):
+        return getattr(xp, self.name)(self.m, self.beta)


### PR DESCRIPTION
The following PR adds the function equivalent of numpy.kaiser. Most of the functionality required was already added by the ufunc i0, and hence this is a small PR.
The bencmark is as follows,
```
size = 10000
numpy
kaiser              :    CPU: 1032.667 us   +/-93.976 (min:  880.462 / max: 1274.299) us
cupy
kaiser              :    CPU:  257.534 us   +/-11.794 (min:  250.239 / max:  335.450) us     GPU:  261.903 us   +/-12.010 (min:  254.656 / max:  340.000) us

```

```
size = 100000
numpy
kaiser              :    CPU: 8782.974 us   +/-2339.073 (min: 7171.441 / max:15070.544) us
cupy
kaiser              :    CPU:  279.742 us   +/-45.929 (min:  245.857 / max:  520.667) us     GPU:  306.540 us   +/-43.233 (min:  242.912 / max:  533.888) us

```

```
size = 1000000
numpy
kaiser              :    CPU:134816.659 us   +/-8943.594 (min:121839.522 / max:189066.974) us
cupy
kaiser              :    CPU:  249.244 us   +/- 9.935 (min:  241.653 / max:  329.852) us     GPU: 1781.249 us   +/- 5.409 (min: 1775.680 / max: 1829.088) us

```
for larger array sizes the speed goes to 64 times, however if needed i dont mind creating a custom Elementise kernel for this if requried.