### PR TITLE
Reduce arg creation cost in `Arg.from_obj`

### DIFF
--- a/cupy/cuda/function.pxd
+++ b/cupy/cuda/function.pxd
@@ -58,6 +58,9 @@ cdef class Arg:
         readonly int ndim
         readonly bint c_contiguous
 
+    cdef _init_fast_base(self, object obj, _ArgKind arg_kind, object typ,
+                         object dtype, int ndim, bint c_contiguous)
+
     @staticmethod
     cdef Arg from_obj(object obj)
 
@@ -81,10 +84,14 @@ cdef class IndexerArg(Arg):
     cdef:
         readonly tuple shape
 
+    cdef _init_fast(self, tuple shape)
+
     cdef CPointer get_pointer(self)
 
 
 cdef class NdarrayArg(Arg):
+
+    cdef _init_fast(self, core.ndarray obj, int ndim, bint c_contiguous)
 
     cdef CPointer get_pointer(self)
 
@@ -99,6 +106,8 @@ cdef class ScalarArg(Arg):
         readonly object _dtype
         bint _dtype_applied
 
+    cdef _init_fast(self, object obj)
+
     cdef object get_min_scalar_type(self)
 
     cdef apply_dtype(self, object dtype)
@@ -107,5 +116,7 @@ cdef class ScalarArg(Arg):
 
 
 cdef class PointerArg(Arg):
+
+    cdef _init_fast(self, intptr_t ptr)
 
     cdef CPointer get_pointer(self)


### PR DESCRIPTION
note: https://github.com/cupy/cupy/pull/2920#pullrequestreview-382636309
- `master`
```
time_abs             - case        100                    :    CPU:   18.968 us   +/- 0.256 (min:   18.684 / max:   19.358) us     GPU:   23.123 us   +/- 1.272 (min:   21.888 / max:   25.504) us
time_abs             - case        200                    :    CPU:   18.604 us   +/- 0.182 (min:   18.349 / max:   18.823) us     GPU:   22.074 us   +/- 0.479 (min:   21.504 / max:   22.816) us
time_abs             - case        300                    :    CPU:   18.727 us   +/- 0.174 (min:   18.502 / max:   19.000) us     GPU:   22.259 us   +/- 0.787 (min:   21.760 / max:   23.808) us
time_abs             - case        400                    :    CPU:   18.834 us   +/- 0.270 (min:   18.566 / max:   19.258) us     GPU:   22.272 us   +/- 0.649 (min:   21.504 / max:   23.200) us
time_abs             - case        500                    :    CPU:   19.239 us   +/- 0.195 (min:   18.953 / max:   19.466) us     GPU:   23.277 us   +/- 0.452 (min:   22.784 / max:   24.096) us
time_add             - case        100                    :    CPU:   21.446 us   +/- 0.300 (min:   21.097 / max:   21.883) us     GPU:   25.286 us   +/- 0.688 (min:   24.448 / max:   26.464) us
time_add             - case        200                    :    CPU:   21.501 us   +/- 0.184 (min:   21.274 / max:   21.782) us     GPU:   25.018 us   +/- 0.551 (min:   24.256 / max:   25.888) us
time_add             - case        300                    :    CPU:   21.573 us   +/- 0.265 (min:   21.234 / max:   22.020) us     GPU:   25.190 us   +/- 0.355 (min:   24.672 / max:   25.728) us
time_add             - case        400                    :    CPU:   21.320 us   +/- 0.119 (min:   21.165 / max:   21.469) us     GPU:   24.749 us   +/- 0.390 (min:   24.224 / max:   25.376) us
time_add             - case        500                    :    CPU:   21.486 us   +/- 0.207 (min:   21.183 / max:   21.798) us     GPU:   25.606 us   +/- 0.089 (min:   25.504 / max:   25.728) us
```
- `41281da`
```
time_abs             - case        100                    :    CPU:   18.046 us   +/- 0.569 (min:   17.406 / max:   18.898) us     GPU:   22.592 us   +/- 1.520 (min:   20.928 / max:   25.216) us
time_abs             - case        200                    :    CPU:   17.817 us   +/- 0.294 (min:   17.405 / max:   18.258) us     GPU:   21.619 us   +/- 0.408 (min:   21.248 / max:   22.368) us
time_abs             - case        300                    :    CPU:   17.715 us   +/- 0.067 (min:   17.612 / max:   17.805) us     GPU:   21.331 us   +/- 0.529 (min:   20.896 / max:   22.368) us
time_abs             - case        400                    :    CPU:   17.808 us   +/- 0.208 (min:   17.481 / max:   18.056) us     GPU:   21.741 us   +/- 0.641 (min:   20.992 / max:   22.720) us
time_abs             - case        500                    :    CPU:   17.758 us   +/- 0.169 (min:   17.627 / max:   18.085) us     GPU:   22.163 us   +/- 0.159 (min:   21.920 / max:   22.336) us
time_add             - case        100                    :    CPU:   19.367 us   +/- 0.279 (min:   18.965 / max:   19.785) us     GPU:   23.174 us   +/- 0.476 (min:   22.496 / max:   23.872) us
time_add             - case        200                    :    CPU:   19.336 us   +/- 0.155 (min:   19.100 / max:   19.522) us     GPU:   22.944 us   +/- 0.373 (min:   22.592 / max:   23.648) us
time_add             - case        300                    :    CPU:   19.331 us   +/- 0.123 (min:   19.134 / max:   19.448) us     GPU:   23.091 us   +/- 0.479 (min:   22.464 / max:   23.808) us
time_add             - case        400                    :    CPU:   19.383 us   +/- 0.189 (min:   19.148 / max:   19.648) us     GPU:   23.174 us   +/- 0.560 (min:   22.496 / max:   24.064) us
time_add             - case        500                    :    CPU:   19.523 us   +/- 0.091 (min:   19.385 / max:   19.666) us     GPU:   23.270 us   +/- 0.211 (min:   23.008 / max:   23.552) us
```