### PR TITLE
Show versions of cub and cutensor on `cupy.show_config`

### DIFF
--- a/cupy/cuda/cupy_cutensor.h
+++ b/cupy/cuda/cupy_cutensor.h
@@ -83,6 +83,10 @@ extern "C" {
 	return CUTENSOR_STATUS_SUCCESS;
     }
 
+    size_t cutensorGetVersion(...) {
+	return CUTENSOR_STATUS_SUCCESS;
+    }
+
     const char* cutensorGetErrorString(...) {
 	return NULL;
     }

--- a/cupy/cuda/cutensor.pyx
+++ b/cupy/cuda/cutensor.pyx
@@ -123,6 +123,8 @@ cdef extern from 'cupy_cutensor.h' nogil:
         TensorDescriptor* desc,
         uint32_t* alignmentReq)
 
+    size_t cutensorGetVersion()
+
 
 ###############################################################################
 # Enum
@@ -199,6 +201,13 @@ cpdef enum:
     R_MIN_32U = 128  # NOQA, real as a uint32
     R_MIN_8I  = 256  # NOQA, real as a int8
     R_MIN_32I = 512  # NOQA, real as a int32
+
+
+###############################################################################
+# Version information
+###############################################################################
+cpdef size_t get_version():
+    return cutensorGetVersion()
 
 
 ###############################################################################

--- a/cupyx/runtime.py
+++ b/cupyx/runtime.py
@@ -14,6 +14,16 @@ try:
 except ImportError:
     nccl = None
 
+try:
+    import cupy.cuda.cub as cub
+except ImportError:
+    cub = None
+
+try:
+    import cupy.cuda.cutensor as cutensor
+except ImportError:
+    cutensor = None
+
 
 def _eval_or_error(func, errors):
     # Evaluates `func` and return the result.
@@ -134,6 +144,14 @@ class _RuntimeInfo(object):
                 nccl_runtime_version = '(unknown)'
             self.nccl_runtime_version = nccl_runtime_version
 
+        if cub is not None:
+            # There is no API in CUB to retrieve the current version
+            # We show if its enabled or disabled
+            self.cub_version = 'Enabled'
+
+        if cutensor is not None:
+            self.cutensor_version = cutensor.get_version()
+
     def __str__(self):
         records = [
             ('CuPy Version', self.cupy_version),
@@ -159,6 +177,8 @@ class _RuntimeInfo(object):
             ('cuDNN Version', self.cudnn_version),
             ('NCCL Build Version', self.nccl_build_version),
             ('NCCL Runtime Version', self.nccl_runtime_version),
+            ('CUB Version', self.cub_version),
+            ('cuTENSOR Version', self.cutensor_version),
         ]
 
         width = max([len(r[0]) for r in records]) + 2


### PR DESCRIPTION
Cub has no way to retrieve the version number and it is not written in any header that we can parse  :( so it shows `Enabled` instead ...

