### PR TITLE
Use sphinx 2.x on Read the Docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
+sphinx<3
 Cython==0.28.3
 numpy >=1.15, <1.16
 scipy >=1.1, <1.2

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx<3
+sphinx==2.0.1
 Cython==0.28.3
 numpy >=1.15, <1.16
 scipy >=1.1, <1.2


### PR DESCRIPTION
Rel #3250 and https://github.com/chainer/chainer-test/issues/571 .

This PR changes the requirements file to specify sphinx 2.x to use on Read the Docs.