### PR TITLE
ENH: support additional dtypes and axis sequences in cupy.median

### DIFF
--- a/cupy/core/_routines_sorting.pyx
+++ b/cupy/core/_routines_sorting.pyx
@@ -172,14 +172,8 @@ cdef _ndarray_partition(ndarray self, kth, int axis):
 
     # If the array size is small or k is large, we simply sort the array.
     if length < 32 or sz <= 32 or max_k >= 1024:
-        if data.dtype.char == 'e':
-            # thrust.sort does not support float16
-            data = data.astype(cupy.float32)
-            data.sort(axis=-1)
-            data = data.astype(cupy.float16)
-        else:
-            # kth is ignored.
-            data.sort(axis=-1)
+        # kth is ignored.
+        data.sort(axis=-1)
     else:
         shape = data.shape
         data = data.ravel()
@@ -204,8 +198,6 @@ cdef _ndarray_partition(ndarray self, kth, int axis):
 
     if axis != ndim - 1:
         data = _manipulation.rollaxis(data, -1, axis)
-        elementwise_copy(data, self)
-    elif data.dtype.char == 'e':
         elementwise_copy(data, self)
 
 

--- a/cupy/core/_routines_sorting.pyx
+++ b/cupy/core/_routines_sorting.pyx
@@ -172,8 +172,14 @@ cdef _ndarray_partition(ndarray self, kth, int axis):
 
     # If the array size is small or k is large, we simply sort the array.
     if length < 32 or sz <= 32 or max_k >= 1024:
-        # kth is ignored.
-        data.sort(axis=-1)
+        if data.dtype.char == 'e':
+            # thrust.sort does not support float16
+            data = data.astype(cupy.float32)
+            data.sort(axis=-1)
+            data = data.astype(cupy.float16)
+        else:
+            # kth is ignored.
+            data.sort(axis=-1)
     else:
         shape = data.shape
         data = data.ravel()
@@ -198,6 +204,8 @@ cdef _ndarray_partition(ndarray self, kth, int axis):
 
     if axis != ndim - 1:
         data = _manipulation.rollaxis(data, -1, axis)
+        elementwise_copy(data, self)
+    elif data.dtype.char == 'e':
         elementwise_copy(data, self)
 
 

--- a/cupy/core/_routines_statistics.pyx
+++ b/cupy/core/_routines_statistics.pyx
@@ -326,19 +326,21 @@ cpdef ndarray _median(
         # cupy.sort and cupy.partition only support integer axis, so move
         # all reduced dimensions to the end and reshape them into a single
         # reduction axis.
-        reduce_axis, out_axis = _reduction._get_axis(axis, ndim)
+        reduce_axis, out_axis = _reduction._get_axis(axis, keep_ndim)
         out_shape = _reduction._get_out_shape(a.shape, reduce_axis, out_axis,
                                               keepdims)
         a = a.transpose(out_axis + reduce_axis)
         sort_shape = tuple([a.shape[n] for n in range(len(out_axis))]) + (-1,)
         a = a.reshape(sort_shape)
         if not a.flags.c_contiguous:
-            a = cp.ascontiguousarray(a)
+            a = cupy.ascontiguousarray(a)
         axis = -1
 
     if axis is None:
         sz = a.size
     else:
+        if axis < -keep_ndim or axis >= keep_ndim:
+            raise numpy.AxisError('Axis overrun')
         sz = a.shape[axis]
     if sz % 2 == 0:
         szh = sz // 2
@@ -370,7 +372,7 @@ cpdef ndarray _median(
 
     indexer = [slice(None)] * part.ndim
 
-    if keepdims:
+    if keepdims and out_shape is None:
         _indexer = [None] * (keep_ndim - part.ndim)
         indexer.extend(_indexer)
 

--- a/cupy/core/_routines_statistics.pyx
+++ b/cupy/core/_routines_statistics.pyx
@@ -328,10 +328,7 @@ cpdef ndarray _median(
     else:
         kth = [(sz - 1) // 2]
 
-    if a.dtype.char == 'e':
-        # partition doesn't support float16, so temporarily convert to float32
-        part = a.astype(cupy.float32)
-    elif overwrite_input:
+    if overwrite_input:
         part = a
     else:
         part = a.copy()
@@ -350,8 +347,6 @@ cpdef ndarray _median(
 
     if part.shape == ():
         return part
-    if a.dtype.char == 'e':
-        part = part.astype(cupy.float16)
     if axis is None:
         axis = 0
 

--- a/cupy/core/_routines_statistics.pyx
+++ b/cupy/core/_routines_statistics.pyx
@@ -316,9 +316,6 @@ cdef _nanargmax_func = create_reduction_func(
 cpdef ndarray _median(
         ndarray a, axis, out, overwrite_input, keepdims):
 
-    if a.dtype.char == '?':
-        a = a.astype(cupy.float64)
-
     keep_ndim = a.ndim
 
     out_shape = None
@@ -355,15 +352,9 @@ cpdef ndarray _median(
 
     if axis is None:
         part = part.ravel()
-        if part.dtype.kind == 'c':
-            part.sort()
-        else:
-            part.partition(kth)
+        part.partition(kth)
     else:
-        if part.dtype.kind == 'c':
-            part.sort(axis=axis)
-        else:
-            part.partition(kth, axis=axis)
+        part.partition(kth, axis=axis)
 
     if part.shape == ():
         return part

--- a/tests/cupy_tests/statics_tests/test_meanvar.py
+++ b/tests/cupy_tests/statics_tests/test_meanvar.py
@@ -49,6 +49,38 @@ class TestMedian(unittest.TestCase):
         a = testing.shaped_random((3, 4, 5), xp, dtype)
         return xp.median(a, keepdims=True)
 
+    def test_median_invalid_axis(self):
+        for xp in [numpy, cupy]:
+            a = testing.shaped_random((3, 4, 5), xp)
+            with pytest.raises(numpy.AxisError):
+                return xp.median(a, -a.ndim - 1, keepdims=False)
+
+            with pytest.raises(numpy.AxisError):
+                return xp.median(a, a.ndim, keepdims=False)
+
+            with pytest.raises(numpy.AxisError):
+                return xp.median(a, (-a.ndim - 1, 1), keepdims=False)
+
+            with pytest.raises(numpy.AxisError):
+                return xp.median(a, (0, a.ndim,), keepdims=False)
+
+
+@testing.parameterize(
+    *testing.product({
+        'shape': [(3, 4, 5)],
+        'axis': [(0, 1), (0, -1), (1, 2), (1,)],
+        'keepdims': [True, False]
+    })
+)
+@testing.gpu
+class TestMedianAxis(unittest.TestCase):
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose()
+    def test_median_axis_sequence(self, xp, dtype):
+        a = testing.shaped_random(self.shape, xp, dtype)
+        return xp.median(a, self.axis, keepdims=self.keepdims)
+
 
 @testing.gpu
 class TestAverage(unittest.TestCase):

--- a/tests/cupy_tests/statics_tests/test_meanvar.py
+++ b/tests/cupy_tests/statics_tests/test_meanvar.py
@@ -13,37 +13,37 @@ ignore_runtime_warnings = pytest.mark.filterwarnings(
 @testing.gpu
 class TestMedian(unittest.TestCase):
 
-    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
+    @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_median_noaxis(self, xp, dtype):
         a = testing.shaped_random((3, 4, 5), xp, dtype)
         return xp.median(a)
 
-    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
+    @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_median_axis1(self, xp, dtype):
         a = testing.shaped_random((3, 4, 5), xp, dtype)
         return xp.median(a, axis=1)
 
-    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
+    @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_median_axis2(self, xp, dtype):
         a = testing.shaped_random((3, 4, 5), xp, dtype)
         return xp.median(a, axis=2)
 
-    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
+    @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_median_overwrite_input(self, xp, dtype):
         a = testing.shaped_random((3, 4, 5), xp, dtype)
         return xp.median(a, overwrite_input=True)
 
-    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
+    @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_median_keepdims_axis1(self, xp, dtype):
         a = testing.shaped_random((3, 4, 5), xp, dtype)
         return xp.median(a, axis=1, keepdims=True)
 
-    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
+    @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_median_keepdims_noaxis(self, xp, dtype):
         a = testing.shaped_random((3, 4, 5), xp, dtype)


### PR DESCRIPTION
~As in NumPy, bool gets converted to double~

~float16 inputs are temporarily converted to float32 for compatibility with `partition`~

~For complex dtypes, `sort` is used because `partition` lacks complex support.~
#3286 removed the need for the above workarounds.

**edit**: 
I updated this PR with enhancements for axis support as well. Let me know if you would prefer to keep that in a separate PR instead.
- Support for axis as a sequence of ints has been added
- when `axis` is out of range, `numpy.AxisError` is now returned instead of `IndexError`.