### PR TITLE
Assert that all the pointers are in the same device in `concatenate`

### DIFF
--- a/cupy/core/_routines_manipulation.pyx
+++ b/cupy/core/_routines_manipulation.pyx
@@ -741,7 +741,11 @@ cdef ndarray _concatenate_single_kernel(
     ptrs = numpy.ndarray(len(arrays), numpy.int64)
     for i, a in enumerate(arrays):
         ptrs[i] = a.data.ptr
-        assert a.data.device_id == device_id
+        if a.data.device_id != device_id:
+            raise ValueError(
+                'Array device must be same as the current '
+                'device: array device = %d while current = %d'
+                % (a.data.device_id, device_id))
     x = core.array(ptrs)
 
     if same_shape_and_contiguous:

--- a/cupy/core/_routines_manipulation.pyx
+++ b/cupy/core/_routines_manipulation.pyx
@@ -15,6 +15,7 @@ from cupy.core cimport _routines_indexing as _indexing
 from cupy.core cimport core
 from cupy.core.core cimport ndarray
 from cupy.core cimport internal
+from cupy.cuda import device
 
 
 @cython.final
@@ -733,12 +734,14 @@ cdef ndarray _concatenate_single_kernel(
     cdef Py_ssize_t[:] ptrs
     cdef Py_ssize_t[:] cum_sizes
     cdef Py_ssize_t[:, :] x_strides
+    cdef int device_id = device.get_device_id()
 
     assert out is not None
 
     ptrs = numpy.ndarray(len(arrays), numpy.int64)
     for i, a in enumerate(arrays):
         ptrs[i] = a.data.ptr
+        assert a.data.device_id == device_id
     x = core.array(ptrs)
 
     if same_shape_and_contiguous:

--- a/tests/cupy_tests/manipulation_tests/test_join.py
+++ b/tests/cupy_tests/manipulation_tests/test_join.py
@@ -5,6 +5,7 @@ import pytest
 
 import cupy
 from cupy import testing
+from cupy import cuda
 
 
 @testing.gpu
@@ -91,6 +92,15 @@ class TestJoin(unittest.TestCase):
         a = testing.shaped_arange((2, 3, 4), xp, dtype)
         b = testing.shaped_reverse_arange((2, 3, 4), xp, 'i')
         return xp.concatenate((a, b) * 10, axis=-1)
+
+    @testing.multi_gpu(2)
+    def test_concatenate_large_different_devices(self):
+        arrs = []
+        for i in range(10):
+            with cuda.Device(i % 2):
+                arrs.append(cupy.empty((2, 3, 4)))
+        with pytest.raises(ValueError):
+            cupy.concatenate(arrs)
 
     @testing.for_all_dtypes(name='dtype')
     @testing.numpy_cupy_array_equal()


### PR DESCRIPTION
Closes #3283

Concatenate creates an array of pointers, but the device here is not verified so it can fail
with hard to understand errors.

TODO: Add test
