### PR TITLE
Support all dtypes in every sorting function in `cupy.cuda.thrust`

### DIFF
--- a/cupy/core/_routines_sorting.pyx
+++ b/cupy/core/_routines_sorting.pyx
@@ -122,10 +122,6 @@ cdef _ndarray_partition(ndarray self, kth, int axis):
 
     """
 
-    if self.dtype.kind == 'c':
-        raise NotImplementedError('Sorting arrays with dtype \'{}\' is '
-                                  'not supported'.format(self.dtype))
-
     cdef int ndim = self._shape.size()
     cdef Py_ssize_t k, max_k, length, s, sz, t
     cdef ndarray data
@@ -282,7 +278,7 @@ def _partition_kernel(dtype):
             CArray<T, 1, true> a, ptrdiff_t x, ptrdiff_t y, int i) {
         for (ptrdiff_t s = 2; s <= y - x; s *= 2) {
             for (ptrdiff_t w = s / 2; w >= 1; w /= 2) {
-                bitonic_sort_step<T>(a, x, y, i, s, w);
+                bitonic_sort_step< T >(a, x, y, i, s, w);
             }
         }
     }
@@ -303,7 +299,7 @@ def _partition_kernel(dtype):
         // After merge step, the first k elements are already bitonic.
         // Therefore, we do not need to fully sort.
         for (int w = k / 2; w >= 1; w /= 2) {
-            bitonic_sort_step<T>(a, x, k + x, i, k, w);
+            bitonic_sort_step< T >(a, x, k + x, i, k, w);
         }
     }
 
@@ -323,7 +319,7 @@ def _partition_kernel(dtype):
         int id = i % 32;
         int x = 0;
 
-        bitonic_sort<${dtype}>(a, z, k + z, id);
+        bitonic_sort< ${dtype} >(a, z, k + z, id);
         ptrdiff_t j;
         for (j = k + id + z; j < m - (m - z) % 32; j += 32) {
             if (a[j] < a[k - 1 + z]) {
@@ -340,8 +336,8 @@ def _partition_kernel(dtype):
     #else
             if (__any(x >= t)) {
     #endif
-                bitonic_sort<${dtype}>(a, k + z, 32 * t + k + z, id);
-                merge<${dtype}>(a, k, id, z, k + z, min(k, 32 * t));
+                bitonic_sort< ${dtype} >(a, k + z, 32 * t + k + z, id);
+                merge< ${dtype} >(a, k, id, z, k + z, min(k, 32 * t));
                 x = 0;
             }
         }
@@ -353,8 +349,8 @@ def _partition_kernel(dtype):
 
         // Finally, we merge the first k elements and the remainders to be
         // stored.
-        bitonic_sort<${dtype}>(a, k + z, 32 * t + k + z, id);
-        merge<${dtype}>(a, k, id, z, k + z, min(k, 32 * t));
+        bitonic_sort< ${dtype} >(a, k + z, 32 * t + k + z, id);
+        merge< ${dtype} >(a, k, id, z, k + z, min(k, 32 * t));
     }
 
     __global__ void ${merge_kernel}(
@@ -364,7 +360,7 @@ def _partition_kernel(dtype):
         ptrdiff_t z = i / 32 * 2 * s * n / sz;
         ptrdiff_t m = (i / 32 * 2 + 1) * s * n / sz;
         int id = i % 32;
-        merge<${dtype}>(a, k, id, z, m, k);
+        merge< ${dtype} >(a, k, id, z, m, k);
     }
     }
     ''').substitute(name=name, merge_kernel=merge_kernel, dtype=dtype)

--- a/cupy/cuda/common.pxd
+++ b/cupy/cuda/common.pxd
@@ -11,3 +11,6 @@ cdef extern from '../cuda/cupy_common.h':  # thru parent to import in core
     ctypedef unsigned long long cpy_ulong
     ctypedef float cpy_float
     ctypedef double cpy_double
+    ctypedef struct cpy_complex64 'cuComplex'
+    ctypedef struct cpy_complex128 'cuDoubleComplex'
+    ctypedef struct cpy_half '__half'

--- a/cupy/cuda/common.pxd
+++ b/cupy/cuda/common.pxd
@@ -1,5 +1,7 @@
 # distutils: language = c++
 
+from libcpp cimport bool as bool_t
+
 cdef extern from '../cuda/cupy_common.h':  # thru parent to import in core
     ctypedef char cpy_byte
     ctypedef unsigned char cpy_ubyte
@@ -13,4 +15,5 @@ cdef extern from '../cuda/cupy_common.h':  # thru parent to import in core
     ctypedef double cpy_double
     ctypedef struct cpy_complex64 'cuComplex'
     ctypedef struct cpy_complex128 'cuDoubleComplex'
+    ctypedef bool_t cpy_bool 'bool'
     ctypedef struct cpy_half '__half'

--- a/cupy/cuda/common.pxd
+++ b/cupy/cuda/common.pxd
@@ -16,4 +16,3 @@ cdef extern from '../cuda/cupy_common.h':  # thru parent to import in core
     ctypedef struct cpy_complex64 'cuComplex'
     ctypedef struct cpy_complex128 'cuDoubleComplex'
     ctypedef bool_t cpy_bool 'bool'
-    ctypedef struct cpy_half '__half'

--- a/cupy/cuda/cupy_common.h
+++ b/cupy/cuda/cupy_common.h
@@ -1,5 +1,5 @@
-#ifndef INCLUDE_GUARD_CUPY_CUDA_COMMON_H
-#define INCLUDE_GUARD_CUPY_CUDA_COMMON_H
+#ifndef INCLUDE_GUARD_CUPY_COMMON_H
+#define INCLUDE_GUARD_CUPY_COMMON_H
 
 #include "cupy_cuComplex.h"
 
@@ -17,13 +17,13 @@ typedef cuComplex cpy_complex64;
 typedef cuDoubleComplex cpy_complex128;
 typedef bool cpy_bool;
 
+#ifndef CUPY_NO_CUDA
 #if (__CUDACC_VER_MAJOR__ > 9 || (__CUDACC_VER_MAJOR__ == 9 && __CUDACC_VER_MINOR__ == 2)) \
     && (__CUDA_ARCH__ >= 530 || !defined(__CUDA_ARCH__))
 #include <cuda_fp16.h>
-#else
-// still declare it to avoid build time errors, but it won't be usable
-struct __half;
 #endif
-typedef __half cpy_half;
+#endif // CUPY_NO_CUDA
 
-#endif // INCLUDE_GUARD_CUPY_CUDA_COMMON_H
+typedef struct __half cpy_half;
+
+#endif // INCLUDE_GUARD_CUPY_COMMON_H

--- a/cupy/cuda/cupy_common.h
+++ b/cupy/cuda/cupy_common.h
@@ -2,6 +2,11 @@
 #define INCLUDE_GUARD_CUPY_COMMON_H
 
 #include "cupy_cuComplex.h"
+/*
+   cuda_fp16.h should only be included in C++ codes that actually
+   need __half. For bookkeeping purposes, in Cython codes we simply
+   use cupy.float16.
+*/
 
 typedef char cpy_byte;
 typedef unsigned char cpy_ubyte;
@@ -17,13 +22,5 @@ typedef cuComplex cpy_complex64;
 typedef cuDoubleComplex cpy_complex128;
 typedef bool cpy_bool;
 
-#ifndef CUPY_NO_CUDA
-#if (__CUDACC_VER_MAJOR__ > 9 || (__CUDACC_VER_MAJOR__ == 9 && __CUDACC_VER_MINOR__ == 2)) \
-    && (__CUDA_ARCH__ >= 530 || !defined(__CUDA_ARCH__))
-#include <cuda_fp16.h>
-#endif
-#endif // CUPY_NO_CUDA
-
-typedef struct __half cpy_half;
 
 #endif // INCLUDE_GUARD_CUPY_COMMON_H

--- a/cupy/cuda/cupy_common.h
+++ b/cupy/cuda/cupy_common.h
@@ -15,14 +15,15 @@ typedef float cpy_float;
 typedef double cpy_double;
 typedef cuComplex cpy_complex64;
 typedef cuDoubleComplex cpy_complex128;
+typedef bool cpy_bool;
 
 #if (__CUDACC_VER_MAJOR__ > 9 || (__CUDACC_VER_MAJOR__ == 9 && __CUDACC_VER_MINOR__ == 2)) \
     && (__CUDA_ARCH__ >= 530 || !defined(__CUDA_ARCH__))
 #include <cuda_fp16.h>
-typedef __half cpy_half;
 #else
 // still declare it to avoid build time errors, but it won't be usable
-typedef struct __half cpy_half;
+struct __half;
 #endif
+typedef __half cpy_half;
 
 #endif // INCLUDE_GUARD_CUPY_CUDA_COMMON_H

--- a/cupy/cuda/cupy_common.h
+++ b/cupy/cuda/cupy_common.h
@@ -1,6 +1,8 @@
 #ifndef INCLUDE_GUARD_CUPY_CUDA_COMMON_H
 #define INCLUDE_GUARD_CUPY_CUDA_COMMON_H
 
+#include "cupy_cuComplex.h"
+
 typedef char cpy_byte;
 typedef unsigned char cpy_ubyte;
 typedef short cpy_short;
@@ -11,5 +13,16 @@ typedef long long cpy_long;
 typedef unsigned long long cpy_ulong;
 typedef float cpy_float;
 typedef double cpy_double;
+typedef cuComplex cpy_complex64;
+typedef cuDoubleComplex cpy_complex128;
+
+#if (__CUDACC_VER_MAJOR__ > 9 || (__CUDACC_VER_MAJOR__ == 9 && __CUDACC_VER_MINOR__ == 2)) \
+    && (__CUDA_ARCH__ >= 530 || !defined(__CUDA_ARCH__))
+#include <cuda_fp16.h>
+typedef __half cpy_half;
+#else
+// still declare it to avoid build time errors, but it won't be usable
+typedef struct __half cpy_half;
+#endif
 
 #endif // INCLUDE_GUARD_CUPY_CUDA_COMMON_H

--- a/cupy/cuda/cupy_thrust.cu
+++ b/cupy/cuda/cupy_thrust.cu
@@ -7,6 +7,10 @@
 #include <thrust/execution_policy.h>
 #include "cupy_common.h"
 #include "cupy_thrust.h"
+#if (__CUDACC_VER_MAJOR__ > 9 || (__CUDACC_VER_MAJOR__ == 9 && __CUDACC_VER_MINOR__ == 2)) \
+    && (__CUDA_ARCH__ >= 530 || !defined(__CUDA_ARCH__))
+#include <cuda_fp16.h>
+#endif
 
 using namespace thrust;
 
@@ -118,7 +122,7 @@ __host__ __device__ __forceinline__ bool operator<(const cuDoubleComplex& lhs, c
 
 #if (__CUDACC_VER_MAJOR__ > 9 || (__CUDACC_VER_MAJOR__ == 9 && __CUDACC_VER_MINOR__ == 2)) \
     && (__CUDA_ARCH__ >= 530 || !defined(__CUDA_ARCH__))
-__host__ __device__ __forceinline__ bool half_isnan(const cpy_half& x) {
+__host__ __device__ __forceinline__ bool half_isnan(const __half& x) {
 #ifdef __CUDA_ARCH__
     return __hisnan(x);
 #else
@@ -129,8 +133,8 @@ __host__ __device__ __forceinline__ bool half_isnan(const cpy_half& x) {
 
 // specialize thrust::less for __half
 template <>
-struct less<cpy_half> {
-    __host__ __device__ __forceinline__ bool operator() (const cpy_half& lhs, const cpy_half& rhs) const {
+struct less<__half> {
+    __host__ __device__ __forceinline__ bool operator() (const __half& lhs, const __half& rhs) const {
         if (half_isnan(lhs)) {
             return false;
         } else if (half_isnan(rhs)) {
@@ -212,11 +216,6 @@ template void cupy::thrust::_sort<cpy_long>(
     void *, size_t *, const std::vector<ptrdiff_t>& shape, size_t, void *);
 template void cupy::thrust::_sort<cpy_ulong>(
     void *, size_t *, const std::vector<ptrdiff_t>& shape, size_t, void *);
-#if (__CUDACC_VER_MAJOR__ > 9 || (__CUDACC_VER_MAJOR__ == 9 && __CUDACC_VER_MINOR__ == 2)) \
-    && (__CUDA_ARCH__ >= 530 || !defined(__CUDA_ARCH__))
-template void cupy::thrust::_sort<cpy_half>(
-    void *, size_t *, const std::vector<ptrdiff_t>& shape, size_t, void *);
-#endif
 template void cupy::thrust::_sort<cpy_float>(
     void *, size_t *, const std::vector<ptrdiff_t>& shape, size_t, void *);
 template void cupy::thrust::_sort<cpy_double>(
@@ -227,6 +226,14 @@ template void cupy::thrust::_sort<cpy_complex128>(
     void *, size_t *, const std::vector<ptrdiff_t>& shape, size_t, void *);
 template void cupy::thrust::_sort<cpy_bool>(
     void *, size_t *, const std::vector<ptrdiff_t>& shape, size_t, void *);
+void cupy::thrust::_sort_fp16(void *data_start, size_t *keys_start,
+                              const std::vector<ptrdiff_t>& shape, size_t stream,
+                              void* memory) {
+#if (__CUDACC_VER_MAJOR__ > 9 || (__CUDACC_VER_MAJOR__ == 9 && __CUDACC_VER_MINOR__ == 2)) \
+    && (__CUDA_ARCH__ >= 530 || !defined(__CUDA_ARCH__))
+    cupy::thrust::_sort<__half>(data_start, keys_start, shape, stream, memory);
+#endif
+}
 
 
 /*
@@ -283,11 +290,6 @@ template void cupy::thrust::_lexsort<cpy_long>(
     size_t *, void *, size_t, size_t, size_t, void *);
 template void cupy::thrust::_lexsort<cpy_ulong>(
     size_t *, void *, size_t, size_t, size_t, void *);
-#if (__CUDACC_VER_MAJOR__ > 9 || (__CUDACC_VER_MAJOR__ == 9 && __CUDACC_VER_MINOR__ == 2)) \
-    && (__CUDA_ARCH__ >= 530 || !defined(__CUDA_ARCH__))
-template void cupy::thrust::_lexsort<cpy_half>(
-    size_t *, void *, size_t, size_t, size_t, void *);
-#endif
 template void cupy::thrust::_lexsort<cpy_float>(
     size_t *, void *, size_t, size_t, size_t, void *);
 template void cupy::thrust::_lexsort<cpy_double>(
@@ -298,6 +300,13 @@ template void cupy::thrust::_lexsort<cpy_complex128>(
     size_t *, void *, size_t, size_t, size_t, void *);
 template void cupy::thrust::_lexsort<cpy_bool>(
     size_t *, void *, size_t, size_t, size_t, void *);
+void cupy::thrust::_lexsort_fp16(size_t *idx_start, void *keys_start, size_t k,
+                                 size_t n, size_t stream, void *memory) {
+#if (__CUDACC_VER_MAJOR__ > 9 || (__CUDACC_VER_MAJOR__ == 9 && __CUDACC_VER_MINOR__ == 2)) \
+    && (__CUDA_ARCH__ >= 530 || !defined(__CUDA_ARCH__))
+    cupy::thrust::_lexsort<__half>(idx_start, keys_start, k, n, stream, memory);
+#endif
+}
 
 
 /*
@@ -391,12 +400,6 @@ template void cupy::thrust::_argsort<cpy_long>(
 template void cupy::thrust::_argsort<cpy_ulong>(
     size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, size_t,
     void *);
-#if (__CUDACC_VER_MAJOR__ > 9 || (__CUDACC_VER_MAJOR__ == 9 && __CUDACC_VER_MINOR__ == 2)) \
-    && (__CUDA_ARCH__ >= 530 || !defined(__CUDA_ARCH__))
-template void cupy::thrust::_argsort<cpy_half>(
-    size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, size_t,
-    void *);
-#endif
 template void cupy::thrust::_argsort<cpy_float>(
     size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, size_t,
     void *);
@@ -412,3 +415,12 @@ template void cupy::thrust::_argsort<cpy_complex128>(
 template void cupy::thrust::_argsort<cpy_bool>(
     size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, size_t,
     void *);
+void cupy::thrust::_argsort_fp16(size_t *idx_start, void *data_start,
+                                 void *keys_start,
+                                 const std::vector<ptrdiff_t>& shape,
+                                 size_t stream, void *memory) {
+#if (__CUDACC_VER_MAJOR__ > 9 || (__CUDACC_VER_MAJOR__ == 9 && __CUDACC_VER_MINOR__ == 2)) \
+    && (__CUDA_ARCH__ >= 530 || !defined(__CUDA_ARCH__))
+    cupy::thrust::_argsort<__half>(idx_start, data_start, keys_start, shape, stream, memory);
+#endif
+}

--- a/cupy/cuda/cupy_thrust.cu
+++ b/cupy/cuda/cupy_thrust.cu
@@ -7,7 +7,6 @@
 #include <thrust/execution_policy.h>
 #include "cupy_common.h"
 #include "cupy_thrust.h"
-#include "cupy_cuComplex.h"
 
 using namespace thrust;
 
@@ -108,7 +107,47 @@ __host__ __device__ __forceinline__ bool operator<(const cuComplex& lhs, const c
 __host__ __device__ __forceinline__ bool operator<(const cuDoubleComplex& lhs, const cuDoubleComplex& rhs) {
     return _cmp_less(lhs, rhs);
 }
+
 /* ------------------------------------ end of boilerplate ------------------------------------ */
+
+///*
+// * --------------------------------- Minimum boilerplate to support half precision floats ----------------------------------
+// * These stubs are copied from cupy/cuda/cupy_cub.cu.
+// * TODO(leofang): refactor the code to avoid repetition!
+// */
+//
+//#if (__CUDACC_VER_MAJOR__ > 9 || (__CUDACC_VER_MAJOR__ == 9 && __CUDACC_VER_MINOR__ == 2)) \
+//    && (__CUDA_ARCH__ >= 530 || !defined(__CUDA_ARCH__))
+//__host__ __device__ __forceinline__ bool half_isnan(const __half& x) {
+//#ifdef __CUDA_ARCH__
+//    return __hisnan(x);
+//#else
+//    // TODO: avoid cast to float
+//    return isnan(__half2float(x));
+//#endif
+//}
+//
+//__host__ __device__ __forceinline__ bool half_less(const __half& l, const __half& r) {
+//#ifdef __CUDA_ARCH__
+//    return l < r;
+//#else
+//    // TODO: avoid cast to float
+//    return __half2float(l) < __half2float(r);
+//#endif
+//}
+//
+//__host__ __device__ __forceinline__ bool operator<(const __half& lhs, const __half& rhs) {
+//    if (half_isnan(lhs)) {
+//        return false;
+//    } else if (half_isnan(rhs)) {
+//        return true;
+//    } else {
+//        return half_less(lhs, rhs);
+//    }
+//}
+//#endif  // include cupy_fp16.h
+//
+///* ------------------------------------ end of boilerplate ------------------------------------ */
 
 
 /*
@@ -171,13 +210,18 @@ template void cupy::thrust::_sort<cpy_long>(
     void *, size_t *, const std::vector<ptrdiff_t>& shape, size_t, void *);
 template void cupy::thrust::_sort<cpy_ulong>(
     void *, size_t *, const std::vector<ptrdiff_t>& shape, size_t, void *);
+#if (__CUDACC_VER_MAJOR__ > 9 || (__CUDACC_VER_MAJOR__ == 9 && __CUDACC_VER_MINOR__ == 2)) \
+    && (__CUDA_ARCH__ >= 530 || !defined(__CUDA_ARCH__))
+template void cupy::thrust::_sort<cpy_half>(
+    void *, size_t *, const std::vector<ptrdiff_t>& shape, size_t, void *);
+#endif
 template void cupy::thrust::_sort<cpy_float>(
     void *, size_t *, const std::vector<ptrdiff_t>& shape, size_t, void *);
 template void cupy::thrust::_sort<cpy_double>(
     void *, size_t *, const std::vector<ptrdiff_t>& shape, size_t, void *);
-template void cupy::thrust::_sort<cuComplex>(
+template void cupy::thrust::_sort<cpy_complex64>(
     void *, size_t *, const std::vector<ptrdiff_t>& shape, size_t, void *);
-template void cupy::thrust::_sort<cuDoubleComplex>(
+template void cupy::thrust::_sort<cpy_complex128>(
     void *, size_t *, const std::vector<ptrdiff_t>& shape, size_t, void *);
 
 
@@ -234,13 +278,18 @@ template void cupy::thrust::_lexsort<cpy_long>(
     size_t *, void *, size_t, size_t, size_t, void *);
 template void cupy::thrust::_lexsort<cpy_ulong>(
     size_t *, void *, size_t, size_t, size_t, void *);
+#if (__CUDACC_VER_MAJOR__ > 9 || (__CUDACC_VER_MAJOR__ == 9 && __CUDACC_VER_MINOR__ == 2)) \
+    && (__CUDA_ARCH__ >= 530 || !defined(__CUDA_ARCH__))
+template void cupy::thrust::_lexsort<cpy_half>(
+    size_t *, void *, size_t, size_t, size_t, void *);
+#endif
 template void cupy::thrust::_lexsort<cpy_float>(
     size_t *, void *, size_t, size_t, size_t, void *);
 template void cupy::thrust::_lexsort<cpy_double>(
     size_t *, void *, size_t, size_t, size_t, void *);
-template void cupy::thrust::_lexsort<cuComplex>(
+template void cupy::thrust::_lexsort<cpy_complex64>(
     size_t *, void *, size_t, size_t, size_t, void *);
-template void cupy::thrust::_lexsort<cuDoubleComplex>(
+template void cupy::thrust::_lexsort<cpy_complex128>(
     size_t *, void *, size_t, size_t, size_t, void *);
 
 
@@ -335,15 +384,21 @@ template void cupy::thrust::_argsort<cpy_long>(
 template void cupy::thrust::_argsort<cpy_ulong>(
     size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, size_t,
     void *);
+#if (__CUDACC_VER_MAJOR__ > 9 || (__CUDACC_VER_MAJOR__ == 9 && __CUDACC_VER_MINOR__ == 2)) \
+    && (__CUDA_ARCH__ >= 530 || !defined(__CUDA_ARCH__))
+template void cupy::thrust::_argsort<cpy_half>(
+    size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, size_t,
+    void *);
+#endif
 template void cupy::thrust::_argsort<cpy_float>(
     size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, size_t,
     void *);
 template void cupy::thrust::_argsort<cpy_double>(
     size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, size_t,
     void *);
-template void cupy::thrust::_argsort<cuComplex>(
+template void cupy::thrust::_argsort<cpy_complex64>(
     size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, size_t,
     void *);
-template void cupy::thrust::_argsort<cuDoubleComplex>(
+template void cupy::thrust::_argsort<cpy_complex128>(
     size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, size_t,
     void *);

--- a/cupy/cuda/cupy_thrust.cu
+++ b/cupy/cuda/cupy_thrust.cu
@@ -287,8 +287,9 @@ template <typename T>
 class elem_less {
 public:
     elem_less(const T *data):_data(data) {}
-    __device__ bool operator()(size_t i, size_t j) {
-        return _data[i] < _data[j];
+    __device__ __forceinline__ bool operator()(size_t i, size_t j) const {
+        less<T> comp;
+        return comp(_data[i], _data[j]);
     }
 private:
     const T *_data;
@@ -344,6 +345,8 @@ template void cupy::thrust::_lexsort<cpy_double>(
 template void cupy::thrust::_lexsort<cpy_complex64>(
     size_t *, void *, size_t, size_t, size_t, void *);
 template void cupy::thrust::_lexsort<cpy_complex128>(
+    size_t *, void *, size_t, size_t, size_t, void *);
+template void cupy::thrust::_lexsort<cpy_bool>(
     size_t *, void *, size_t, size_t, size_t, void *);
 
 
@@ -454,5 +457,8 @@ template void cupy::thrust::_argsort<cpy_complex64>(
     size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, size_t,
     void *);
 template void cupy::thrust::_argsort<cpy_complex128>(
+    size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, size_t,
+    void *);
+template void cupy::thrust::_argsort<cpy_bool>(
     size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, size_t,
     void *);

--- a/cupy/cuda/cupy_thrust.cu
+++ b/cupy/cuda/cupy_thrust.cu
@@ -108,28 +108,12 @@ __host__ __device__ __forceinline__ bool operator<(const cuDoubleComplex& lhs, c
     return _cmp_less(lhs, rhs);
 }
 
-//// specialize thrust::less for cuComplex
-//template <>
-//struct less<cuComplex> {
-//    __host__ __device__ __forceinline__ bool operator() (const cuComplex& lhs, const cuComplex& rhs) {
-//        return _cmp_less(lhs, rhs);
-//    }
-//};
-
-//
-//// specialize thrust::less for cuDoubleComplex
-//template <>
-//struct less<cuDoubleComplex> {
-//    __host__ __device__ __forceinline__ bool operator() (const cuDoubleComplex& lhs, const cuDoubleComplex& rhs) {
-//        return _cmp_less(lhs, rhs);
-//    }
-//};
 /* ------------------------------------ end of boilerplate ------------------------------------ */
 
 /*
  * --------------------------------- Minimum boilerplate to support half precision floats ----------------------------------
- * half_isnan is copied from cupy/cuda/cupy_cub.cu, and half_less is also modified from there.
- * TODO(leofang): refactor the code to avoid repetition!
+ * half_isnan is copied from cupy/cuda/cupy_cub.cu, and the specialization of less<__half> is also borrowed from there.
+ * TODO(leofang): is it possible to refactor the code and avoid repetition?
  */
 
 #if (__CUDACC_VER_MAJOR__ > 9 || (__CUDACC_VER_MAJOR__ == 9 && __CUDACC_VER_MINOR__ == 2)) \
@@ -138,7 +122,7 @@ __host__ __device__ __forceinline__ bool half_isnan(const cpy_half& x) {
 #ifdef __CUDA_ARCH__
     return __hisnan(x);
 #else
-    // TODO: avoid cast to float
+    // TODO(leofang): do we really need this branch?
     return isnan(__half2float(x));
 #endif
 }
@@ -162,41 +146,7 @@ struct less<cpy_half> {
     }
 };
 
-//typedef tuple<size_t, cpy_half> cpy_kv_half;
-//
-//// specialize thrust::less for tuple of __half
-//template <>
-//struct less<cpy_kv_half> {
-//    __host__ __device__ __forceinline__ bool operator() (const cpy_kv_half& lhs, const cpy_kv_half& rhs) {
-//        const cpy_half& lhs_v = lhs.get<1>();
-//        const cpy_half& rhs_v = rhs.get<1>();
-//
-//        if (half_isnan(lhs_v)) {
-//            return false;
-//        } else if (half_isnan(rhs_v)) {
-//            return true;
-//        } else {
-//        #ifdef __CUDA_ARCH__
-//            return lhs_v < rhs_v;
-//        #else
-//            // TODO(leofang): do we really need this branch?
-//            return __half2float(lhs_v) < __half2float(rhs_v);
-//        #endif
-//        }
-//    }
-//};
 #endif  // include cupy_fp16.h
-
-//// specialize thrust::less for thrust::tuple
-//template <typename T>
-//struct less< tuple<size_t, T> > {
-//    __host__ __device__ __forceinline__ bool operator() (const tuple<size_t, T>& lhs, const tuple<size_t, T>& rhs) const {
-//        const T& lhs_v = lhs.get<1>();
-//        const T& rhs_v = rhs.get<1>();
-//        less<T> comp;
-//        return comp(lhs_v, rhs_v);
-//    }
-//};
 
 /* ------------------------------------ end of boilerplate ------------------------------------ */
 

--- a/cupy/cuda/cupy_thrust.h
+++ b/cupy/cuda/cupy_thrust.h
@@ -17,6 +17,16 @@ template <typename T>
 void _argsort(size_t *, void *, void *, const std::vector<ptrdiff_t>&, size_t,
               void *);
 
+/*
+   The functions with the suffix _fp16 are used only when certain conditions are met
+*/
+void _sort_fp16(void *, size_t *, const std::vector<ptrdiff_t>&, size_t, void *);
+
+void _lexsort_fp16(size_t *, void *, size_t, size_t, size_t, void *);
+
+void _argsort_fp16(size_t *, void *, void *, const std::vector<ptrdiff_t>&, size_t,
+                   void *);
+
 } // namespace thrust
 
 } // namespace cupy
@@ -43,6 +53,16 @@ template <typename T>
 void _argsort(size_t *, void *, void *, const std::vector<ptrdiff_t>&, size_t,
               void *) {
     return;
+}
+
+void _sort_fp16(void *, size_t *, const std::vector<ptrdiff_t>&, size_t, void *) {
+}
+
+void _lexsort_fp16(size_t *, void *, size_t, size_t, size_t, void *) {
+}
+
+void _argsort_fp16(size_t *, void *, void *, const std::vector<ptrdiff_t>&, size_t,
+                   void *) {
 }
 
 } // namespace thrust

--- a/cupy/cuda/thrust.pyx
+++ b/cupy/cuda/thrust.pyx
@@ -98,6 +98,8 @@ cpdef sort(dtype, size_t data_start, size_t keys_start,
         _sort[common.cpy_complex64](_data_start, _keys_start, shape, _strm, mem)
     elif dtype == numpy.complex128:
         _sort[common.cpy_complex128](_data_start, _keys_start, shape, _strm, mem)
+    elif dtype == numpy.bool:
+        _sort[common.cpy_bool](_data_start, _keys_start, shape, _strm, mem)
     else:
         raise NotImplementedError('Sorting arrays with dtype \'{}\' is not '
                                   'supported'.format(dtype))

--- a/cupy/cuda/thrust.pyx
+++ b/cupy/cuda/thrust.pyx
@@ -73,7 +73,7 @@ cpdef sort(dtype, size_t data_start, size_t keys_start,
 
     if dtype == numpy.float16:
         if int(device.get_compute_capability()) < 53 or \
-            runtime.runtimeGetVersion() < 9020:
+                runtime.runtimeGetVersion() < 9020:
             raise RuntimeError('either the GPU or the CUDA Toolkit does not '
                                'support fp16')
 
@@ -100,9 +100,11 @@ cpdef sort(dtype, size_t data_start, size_t keys_start,
     elif dtype == numpy.float64:
         _sort[common.cpy_double](_data_start, _keys_start, shape, _strm, mem)
     elif dtype == numpy.complex64:
-        _sort[common.cpy_complex64](_data_start, _keys_start, shape, _strm, mem)
+        _sort[common.cpy_complex64](
+            _data_start, _keys_start, shape, _strm, mem)
     elif dtype == numpy.complex128:
-        _sort[common.cpy_complex128](_data_start, _keys_start, shape, _strm, mem)
+        _sort[common.cpy_complex128](
+            _data_start, _keys_start, shape, _strm, mem)
     elif dtype == numpy.bool:
         _sort[common.cpy_bool](_data_start, _keys_start, shape, _strm, mem)
     else:
@@ -123,7 +125,7 @@ cpdef lexsort(dtype, size_t idx_start, size_t keys_start,
 
     if dtype == numpy.float16:
         if int(device.get_compute_capability()) < 53 or \
-            runtime.runtimeGetVersion() < 9020:
+                runtime.runtimeGetVersion() < 9020:
             raise RuntimeError('either the GPU or the CUDA Toolkit does not '
                                'support fp16')
 
@@ -176,7 +178,7 @@ cpdef argsort(dtype, size_t idx_start, size_t data_start, size_t keys_start,
 
     if dtype == numpy.float16:
         if int(device.get_compute_capability()) < 53 or \
-            runtime.runtimeGetVersion() < 9020:
+                runtime.runtimeGetVersion() < 9020:
             raise RuntimeError('either the GPU or the CUDA Toolkit does not '
                                'support fp16')
 

--- a/cupy/cuda/thrust.pyx
+++ b/cupy/cuda/thrust.pyx
@@ -51,13 +51,6 @@ cdef extern from '../cuda/cupy_thrust.h' namespace 'cupy::thrust':
     void _argsort[T](size_t *, void *, void *, const vector.vector[ptrdiff_t]&,
                      size_t, void *)
 
-cdef extern from 'cupy_cuComplex.h':
-    ctypedef struct cpy_complex64 'cuComplex':
-        float x, y
-
-    ctypedef struct cpy_complex128 'cuDoubleComplex':
-        double x, y
-
 
 ###############################################################################
 # Python interface
@@ -76,6 +69,8 @@ cpdef sort(dtype, size_t data_start, size_t keys_start,
     mem_obj = _MemoryManager()
     cdef void* mem = <void *>mem_obj
 
+    # TODO(leofang): check if CUDA >= 9.2 for fp16
+
     # TODO(takagi): Support float16 and bool
     if dtype == numpy.int8:
         _sort[common.cpy_byte](_data_start, _keys_start, shape, _strm, mem)
@@ -93,14 +88,16 @@ cpdef sort(dtype, size_t data_start, size_t keys_start,
         _sort[common.cpy_long](_data_start, _keys_start, shape, _strm, mem)
     elif dtype == numpy.uint64:
         _sort[common.cpy_ulong](_data_start, _keys_start, shape, _strm, mem)
+    elif dtype == numpy.float16:
+        _sort[common.cpy_half](_data_start, _keys_start, shape, _strm, mem)
     elif dtype == numpy.float32:
         _sort[common.cpy_float](_data_start, _keys_start, shape, _strm, mem)
     elif dtype == numpy.float64:
         _sort[common.cpy_double](_data_start, _keys_start, shape, _strm, mem)
     elif dtype == numpy.complex64:
-        _sort[cpy_complex64](_data_start, _keys_start, shape, _strm, mem)
+        _sort[common.cpy_complex64](_data_start, _keys_start, shape, _strm, mem)
     elif dtype == numpy.complex128:
-        _sort[cpy_complex128](_data_start, _keys_start, shape, _strm, mem)
+        _sort[common.cpy_complex128](_data_start, _keys_start, shape, _strm, mem)
     else:
         raise NotImplementedError('Sorting arrays with dtype \'{}\' is not '
                                   'supported'.format(dtype))
@@ -116,6 +113,8 @@ cpdef lexsort(dtype, size_t idx_start, size_t keys_start,
     _strm = <size_t>(stream.get_current_stream_ptr())
     mem_obj = _MemoryManager()
     cdef void* mem = <void *>mem_obj
+
+    # TODO(leofang): check if CUDA >= 9.2 for fp16
 
     # TODO(takagi): Support float16 and bool
     if dtype == numpy.int8:
@@ -134,14 +133,16 @@ cpdef lexsort(dtype, size_t idx_start, size_t keys_start,
         _lexsort[common.cpy_long](idx_ptr, keys_ptr, k, n, _strm, mem)
     elif dtype == numpy.uint64:
         _lexsort[common.cpy_ulong](idx_ptr, keys_ptr, k, n, _strm, mem)
+    elif dtype == numpy.float16:
+        _lexsort[common.cpy_half](idx_ptr, keys_ptr, k, n, _strm, mem)
     elif dtype == numpy.float32:
         _lexsort[common.cpy_float](idx_ptr, keys_ptr, k, n, _strm, mem)
     elif dtype == numpy.float64:
         _lexsort[common.cpy_double](idx_ptr, keys_ptr, k, n, _strm, mem)
     elif dtype == numpy.complex64:
-        _lexsort[cpy_complex64](idx_ptr, keys_ptr, k, n, _strm, mem)
+        _lexsort[common.cpy_complex64](idx_ptr, keys_ptr, k, n, _strm, mem)
     elif dtype == numpy.complex128:
-        _lexsort[cpy_complex128](idx_ptr, keys_ptr, k, n, _strm, mem)
+        _lexsort[common.cpy_complex128](idx_ptr, keys_ptr, k, n, _strm, mem)
     else:
         raise TypeError('Sorting keys with dtype \'{}\' is not '
                         'supported'.format(dtype))
@@ -160,6 +161,8 @@ cpdef argsort(dtype, size_t idx_start, size_t data_start, size_t keys_start,
     _strm = <size_t>(stream.get_current_stream_ptr())
     mem_obj = _MemoryManager()
     cdef void* mem = <void *>mem_obj
+
+    # TODO(leofang): check if CUDA >= 9.2 for fp16
 
     # TODO(takagi): Support float16 and bool
     if dtype == numpy.int8:
@@ -186,6 +189,9 @@ cpdef argsort(dtype, size_t idx_start, size_t data_start, size_t keys_start,
     elif dtype == numpy.uint64:
         _argsort[common.cpy_ulong](
             _idx_start, _data_start, _keys_start, shape, _strm, mem)
+    elif dtype == numpy.float16:
+        _argsort[common.cpy_half](
+            _idx_start, _data_start, _keys_start, shape, _strm, mem)
     elif dtype == numpy.float32:
         _argsort[common.cpy_float](
             _idx_start, _data_start, _keys_start, shape, _strm, mem)
@@ -193,10 +199,10 @@ cpdef argsort(dtype, size_t idx_start, size_t data_start, size_t keys_start,
         _argsort[common.cpy_double](
             _idx_start, _data_start, _keys_start, shape, _strm, mem)
     elif dtype == numpy.complex64:
-        _argsort[cpy_complex64](
+        _argsort[common.cpy_complex64](
             _idx_start, _data_start, _keys_start, shape, _strm, mem)
     elif dtype == numpy.complex128:
-        _argsort[cpy_complex128](
+        _argsort[common.cpy_complex128](
             _idx_start, _data_start, _keys_start, shape, _strm, mem)
     else:
         raise NotImplementedError('Sorting arrays with dtype \'{}\' is not '

--- a/cupy/cuda/thrust.pyx
+++ b/cupy/cuda/thrust.pyx
@@ -53,6 +53,15 @@ cdef extern from '../cuda/cupy_thrust.h' namespace 'cupy::thrust':
     void _argsort[T](size_t *, void *, void *, const vector.vector[ptrdiff_t]&,
                      size_t, void *)
 
+    # for half precision
+    # TODO(leofang): eliminate the extra delegation call when we have a dtype
+    # dispatcher in C++
+    void _sort_fp16(void *, size_t *, const vector.vector[ptrdiff_t]&, size_t,
+                    void *)
+    void _lexsort_fp16(size_t *, void *, size_t, size_t, size_t, void *)
+    void _argsort_fp16(size_t *, void *, void *,
+                       const vector.vector[ptrdiff_t]&,  size_t, void *)
+
 
 ###############################################################################
 # Python interface
@@ -94,7 +103,7 @@ cpdef sort(dtype, size_t data_start, size_t keys_start,
     elif dtype == numpy.uint64:
         _sort[common.cpy_ulong](_data_start, _keys_start, shape, _strm, mem)
     elif dtype == numpy.float16:
-        _sort[common.cpy_half](_data_start, _keys_start, shape, _strm, mem)
+        _sort_fp16(_data_start, _keys_start, shape, _strm, mem)
     elif dtype == numpy.float32:
         _sort[common.cpy_float](_data_start, _keys_start, shape, _strm, mem)
     elif dtype == numpy.float64:
@@ -146,7 +155,7 @@ cpdef lexsort(dtype, size_t idx_start, size_t keys_start,
     elif dtype == numpy.uint64:
         _lexsort[common.cpy_ulong](idx_ptr, keys_ptr, k, n, _strm, mem)
     elif dtype == numpy.float16:
-        _lexsort[common.cpy_half](idx_ptr, keys_ptr, k, n, _strm, mem)
+        _lexsort_fp16(idx_ptr, keys_ptr, k, n, _strm, mem)
     elif dtype == numpy.float32:
         _lexsort[common.cpy_float](idx_ptr, keys_ptr, k, n, _strm, mem)
     elif dtype == numpy.float64:
@@ -207,7 +216,7 @@ cpdef argsort(dtype, size_t idx_start, size_t data_start, size_t keys_start,
         _argsort[common.cpy_ulong](
             _idx_start, _data_start, _keys_start, shape, _strm, mem)
     elif dtype == numpy.float16:
-        _argsort[common.cpy_half](
+        _argsort_fp16(
             _idx_start, _data_start, _keys_start, shape, _strm, mem)
     elif dtype == numpy.float32:
         _argsort[common.cpy_float](

--- a/cupy/cuda/thrust.pyx
+++ b/cupy/cuda/thrust.pyx
@@ -60,7 +60,7 @@ cdef extern from '../cuda/cupy_thrust.h' namespace 'cupy::thrust':
                     void *)
     void _lexsort_fp16(size_t *, void *, size_t, size_t, size_t, void *)
     void _argsort_fp16(size_t *, void *, void *,
-                       const vector.vector[ptrdiff_t]&,  size_t, void *)
+                       const vector.vector[ptrdiff_t]&, size_t, void *)
 
 
 ###############################################################################

--- a/tests/cupy_tests/sorting_tests/test_sort.py
+++ b/tests/cupy_tests/sorting_tests/test_sort.py
@@ -37,30 +37,18 @@ class TestSort(unittest.TestCase):
 
     # Test dtypes
 
-    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=False)
+    @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_sort_dtype(self, xp, dtype):
         a = testing.shaped_random((10,), xp, dtype)
         a.sort()
         return a
 
-    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=False)
+    @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_external_sort_dtype(self, xp, dtype):
         a = testing.shaped_random((10,), xp, dtype)
         return xp.sort(a)
-
-    @testing.for_dtypes([numpy.float16, numpy.bool_])
-    def test_sort_unsupported_dtype(self, dtype):
-        a = testing.shaped_random((10,), cupy, dtype)
-        with self.assertRaises(NotImplementedError):
-            a.sort()
-
-    @testing.for_dtypes([numpy.float16, numpy.bool_])
-    def test_external_sort_unsupported_dtype(self, dtype):
-        a = testing.shaped_random((10,), cupy, dtype)
-        with self.assertRaises(NotImplementedError):
-            return cupy.sort(a)
 
     # Test contiguous arrays
 

--- a/tests/cupy_tests/sorting_tests/test_sort.py
+++ b/tests/cupy_tests/sorting_tests/test_sort.py
@@ -178,17 +178,11 @@ class TestLexsort(unittest.TestCase):
 
     # Test dtypes
 
-    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=False)
+    @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_lexsort_dtype(self, xp, dtype):
         a = testing.shaped_random((2, 10), xp, dtype)
         return xp.lexsort(a)
-
-    @testing.for_dtypes([numpy.float16, numpy.bool_])
-    def test_lexsort_unsupported_dtype(self, dtype):
-        a = testing.shaped_random((2, 10), cupy, dtype)
-        with self.assertRaises(TypeError):
-            return cupy.lexsort(a)
 
 
 @testing.parameterize(*testing.product({
@@ -206,19 +200,19 @@ class TestArgsort(unittest.TestCase):
 
     # Test base cases
 
-    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=False)
+    @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_argsort_zero_dim(self, xp, dtype):
         a = testing.shaped_random((), xp, dtype)
         return self.argsort(a)
 
-    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=False)
+    @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_argsort_one_dim(self, xp, dtype):
         a = testing.shaped_random((10,), xp, dtype)
         return self.argsort(a)
 
-    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=False)
+    @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_argsort_multi_dim(self, xp, dtype):
         a = testing.shaped_random((2, 3, 3), xp, dtype)
@@ -228,14 +222,6 @@ class TestArgsort(unittest.TestCase):
     def test_argsort_non_contiguous(self, xp):
         a = xp.array([1, 0, 2, 3])[::2]
         return self.argsort(a)
-
-    # Test unsupported dtype
-
-    @testing.for_dtypes([numpy.float16, numpy.bool_])
-    def test_argsort_unsupported_dtype(self, dtype):
-        a = testing.shaped_random((10,), cupy, dtype)
-        with self.assertRaises(NotImplementedError):
-            return self.argsort(a)
 
     # Test axis
 
@@ -315,25 +301,17 @@ class TestMsort(unittest.TestCase):
             with pytest.raises(numpy.AxisError):
                 xp.msort(a)
 
-    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=False)
+    @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_msort_one_dim(self, xp, dtype):
         a = testing.shaped_random((10,), xp, dtype)
         return xp.msort(a)
 
-    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=False)
+    @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_msort_multi_dim(self, xp, dtype):
         a = testing.shaped_random((2, 3), xp, dtype)
         return xp.msort(a)
-
-    # Test unsupported dtype
-
-    @testing.for_dtypes([numpy.float16, numpy.bool_])
-    def test_msort_unsupported_dtype(self, dtype):
-        a = testing.shaped_random((10,), cupy, dtype)
-        with self.assertRaises(NotImplementedError):
-            return cupy.msort(a)
 
 
 @testing.parameterize(*testing.product({
@@ -360,12 +338,9 @@ class TestPartition(unittest.TestCase):
             with pytest.raises(numpy.AxisError):
                 self.partition(a, kth)
 
-    @testing.for_all_dtypes(no_complex=True)
+    @testing.for_all_dtypes()
     @testing.numpy_cupy_equal()
     def test_partition_one_dim(self, xp, dtype):
-        if self.length == 10 and dtype in [xp.float16, xp.bool_]:
-            return cupy.zeros(1)  # dummy
-
         a = testing.shaped_random((self.length,), xp, dtype)
         kth = 2
         x = self.partition(a, kth)
@@ -373,31 +348,15 @@ class TestPartition(unittest.TestCase):
         self.assertTrue(xp.all(x[kth:kth + 1] <= x[kth + 1:]))
         return x[kth]
 
-    @testing.for_all_dtypes(no_complex=True)
+    @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_partition_multi_dim(self, xp, dtype):
-        if self.length == 10 and dtype in [xp.float16, xp.bool_]:
-            return cupy.zeros(1)  # dummy
-
         a = testing.shaped_random((10, 10, self.length), xp, dtype)
         kth = 2
         x = self.partition(a, kth)
         self.assertTrue(xp.all(x[:, :, 0:kth] <= x[:, :, kth:kth + 1]))
         self.assertTrue(xp.all(x[:, :, kth:kth + 1] <= x[:, :, kth + 1:]))
         return x[:, :, kth:kth + 1]
-
-    # Test unsupported dtype
-
-    @testing.for_dtypes([numpy.float16, numpy.bool_, numpy.complex64,
-                         numpy.complex128])
-    def test_partition_unsupported_dtype(self, dtype):
-        if self.length != 10 and not cupy.issubdtype(dtype, complex):
-            return
-
-        a = testing.shaped_random((self.length,), cupy, dtype)
-        kth = 2
-        with self.assertRaises(NotImplementedError):
-            return self.partition(a, kth)
 
     # Test non-contiguous array
 
@@ -528,7 +487,7 @@ class TestArgpartition(unittest.TestCase):
             with pytest.raises(ValueError):
                 self.argpartition(a, kth)
 
-    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
+    @testing.for_all_dtypes()
     @testing.numpy_cupy_equal()
     def test_argpartition_one_dim(self, xp, dtype):
         a = testing.shaped_random((10,), xp, dtype, 100)
@@ -538,7 +497,9 @@ class TestArgpartition(unittest.TestCase):
         self.assertTrue((a[idx[kth]] < a[idx[kth + 1:]]).all())
         return idx[kth]
 
-    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
+    # TODO(leofang): test all dtypes -- this workaround needs to be kept,
+    # likely due to #3287? Need investigation.
+    @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_array_equal()
     def test_argpartition_multi_dim(self, xp, dtype):
         a = testing.shaped_random((3, 3, 10), xp, dtype, 100)
@@ -551,15 +512,6 @@ class TestArgpartition(unittest.TestCase):
         self.assertTrue((a[rows, cols, idx[:, :, kth:kth + 1]] <
                          a[rows, cols, idx[:, :, kth + 1:]]).all())
         return idx[:, :, kth:kth + 1]
-
-    # Test unsupported dtype
-
-    @testing.for_dtypes([numpy.float16, numpy.bool_])
-    def test_argpartition_unsupported_dtype(self, dtype):
-        a = testing.shaped_random((10,), cupy, dtype, 100)
-        kth = 2
-        with self.assertRaises(NotImplementedError):
-            return self.argpartition(a, kth)
 
     # Test non-contiguous array
 

--- a/tests/cupy_tests/sorting_tests/test_sort.py
+++ b/tests/cupy_tests/sorting_tests/test_sort.py
@@ -146,6 +146,16 @@ class TestSort(unittest.TestCase):
         with self.assertRaises(numpy.AxisError):
             cupy.sort(a, axis=-4)
 
+    # Test NaN ordering
+
+    @testing.for_dtypes('efdFD')
+    @testing.numpy_cupy_allclose()
+    def test_nan(self, xp, dtype):
+        a = testing.shaped_random((10,), xp, dtype)
+        a[2] = a[6] = xp.nan
+        a.sort()
+        return a
+
 
 @testing.gpu
 class TestLexsort(unittest.TestCase):
@@ -182,6 +192,18 @@ class TestLexsort(unittest.TestCase):
     @testing.numpy_cupy_allclose()
     def test_lexsort_dtype(self, xp, dtype):
         a = testing.shaped_random((2, 10), xp, dtype)
+        return xp.lexsort(a)
+
+    # Test NaN ordering
+    # TODO(leofang): test two more cases after #3232 is fixed
+    # 1. a[1, 2] = a[1, 6] = xp.nan
+    # 2. a[0, 2] = a[1, 6] = xp.nan
+
+    @testing.for_dtypes('efdFD')
+    @testing.numpy_cupy_allclose()
+    def test_nan(self, xp, dtype):
+        a = testing.shaped_random((2, 10), xp, dtype)
+        a[0, 2] = a[0, 6] = xp.nan
         return xp.lexsort(a)
 
 
@@ -286,6 +308,15 @@ class TestArgsort(unittest.TestCase):
         b = cupy.array(a)
         self.argsort(a)
         testing.assert_allclose(a, b)
+
+    # Test NaN ordering
+
+    @testing.for_dtypes('efdFD')
+    @testing.numpy_cupy_allclose()
+    def test_nan(self, xp, dtype):
+        a = testing.shaped_random((10,), xp, dtype)
+        a[2] = a[6] = xp.nan
+        return xp.argsort(a)
 
 
 @testing.gpu


### PR DESCRIPTION
All kinds of sort functions work with all dtypes now!

~~Ongoing, **DO NOT MERGE!**~~
- ~~msort~~
- ~~lexsort~~
- ~~remove redundant tests~~
- ~~clean up~~
- ~~test for performance regression~~ LGTM