### PR TITLE
Expose cuda IPC runtime calls

### DIFF
--- a/cupy_backends/cuda/api/runtime.pxd
+++ b/cupy_backends/cuda/api/runtime.pxd
@@ -95,6 +95,13 @@ cdef extern from *:
         # TODO(leofang): support mipmap?
 
 
+    ctypedef struct IpcMemHandle 'cudaIpcMemHandle_t':
+        unsigned char[64] reserved
+
+    ctypedef struct IpcEventHandle 'cudaIpcEventHandle_t':
+        unsigned char[64] reserved
+
+
 ###############################################################################
 # Enum
 ###############################################################################
@@ -108,6 +115,8 @@ cpdef enum:
 
     cudaMemoryTypeHost = 1
     cudaMemoryTypeDevice = 2
+
+    cudaIpcMemLazyEnablePeerAccess = 1
 
     cudaMemAttachGlobal = 1
     cudaMemAttachHost = 2

--- a/cupy_backends/cuda/api/runtime.pxd
+++ b/cupy_backends/cuda/api/runtime.pxd
@@ -94,7 +94,6 @@ cdef extern from *:
         unsigned int maxAnisotropy
         # TODO(leofang): support mipmap?
 
-
     ctypedef struct IpcMemHandle 'cudaIpcMemHandle_t':
         unsigned char[64] reserved
 

--- a/cupy_backends/cuda/cupy_cuda.h
+++ b/cupy_backends/cuda/cupy_cuda.h
@@ -277,6 +277,26 @@ cudaError_t cudaDeviceSetLimit(...) {
     return cudaSuccess;
 }
 
+// IPC operations
+cudaError_t cudaIpcCloseMemHandle(...){
+    return cudaSuccess;
+}
+
+cudaError_t cudaIpcGetEventHandle(...){
+    return cudaSuccess;
+}
+
+cudaError_t cudaIpcGetMemHandle(...){
+    return cudaSuccess;
+}
+
+cudaError_t cudaIpcOpenEventHandle(...){
+    return cudaSuccess;
+}
+
+cudaError_t cudaIpcOpenMemHandle(...){
+    return cudaSuccess;
+}
 
 // Memory management
 cudaError_t cudaMalloc(...) {

--- a/cupy_backends/cuda/cupy_cuda_common.h
+++ b/cupy_backends/cuda/cupy_cuda_common.h
@@ -154,6 +154,16 @@ struct cudaTextureDesc {
     float maxMipmapLevelClamp;
 };
 
+// IPC operations
+typedef struct {
+    unsigned char reserved[64];
+} cudaIpcMemHandle_t;
+
+// IPC operations
+typedef struct {
+    unsigned char reserved[64];
+} cudaIpcEventHandle_t;
+
 
 ///////////////////////////////////////////////////////////////////////////////
 // library_types.h


### PR DESCRIPTION
This PR adds support for the `cudaIpc` calls in the API
https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__DEVICE.html

A simple example of how to use them:

```python
import multiprocessing as mp

import cupy


def child(handler, shape, dtype):
    import cupy

    data_ptr = cupy.cuda.runtime.ipcOpenMemHandle(handler)
    buff = {"data": (int(data_ptr), False), "shape": shape, "typestr": dtype}

    class capsule(object):
        pass

    cap = capsule()
    cap.__cuda_array_interface__ = buff
    a = cupy.asanyarray(cap)
    print(a)


if __name__ == "__main__":
    mp.set_start_method("spawn")
    a = cupy.arange(10)
    handler = cupy.cuda.runtime.ipcGetMemHandle(a.data.ptr)
    p = mp.Process(target=child, args=(handler, a.shape, str(a.dtype)))
    p.start()
    p.join()
```
The example is based in one from https://github.com/pytorch/pytorch/issues/36594
TODO: add tests?