### PR TITLE
Code fix + bug fix for `cupy.cuda.thrust`

### DIFF
--- a/cupy/_sorting/sort.py
+++ b/cupy/_sorting/sort.py
@@ -73,6 +73,10 @@ def lexsort(keys):
         raise NotImplementedError('Keys with the rank of three or more is not '
                                   'supported in lexsort')
 
+    # thrust.lexsort() assumes a C-contiguous array
+    if not keys.flags.c_contiguous:
+        keys = keys.copy('C')
+
     idx_array = cupy.ndarray(keys._shape[1:], dtype=numpy.intp)
     k = keys._shape[0]
     n = keys._shape[1]
@@ -120,7 +124,6 @@ def msort(a):
 
     """
 
-    # TODO(takagi): Support float16 and bool.
     return sort(a, axis=0)
 
 

--- a/cupy/cuda/cupy_thrust.cu
+++ b/cupy/cuda/cupy_thrust.cu
@@ -135,10 +135,10 @@ __host__ __device__ __forceinline__ bool _real_less(const T& lhs, const T& rhs) 
 template <typename T>
 __host__ __device__ __forceinline__ bool _tuple_real_less(const tuple<size_t, T>& lhs,
                                                           const tuple<size_t, T>& rhs) {
-    const size_t& lhs_k = lhs.get<0>();
-    const size_t& rhs_k = rhs.get<0>();
-    const T& lhs_v = lhs.get<1>();
-    const T& rhs_v = rhs.get<1>();
+    const size_t& lhs_k = lhs.template get<0>();
+    const size_t& rhs_k = rhs.template get<0>();
+    const T& lhs_v = lhs.template get<1>();
+    const T& rhs_v = rhs.template get<1>();
 
     // tuple's comparison rule: compare the 1st member, then 2nd, then 3rd, ...,
     // which should be respected

--- a/cupy/cuda/cupy_thrust.cu
+++ b/cupy/cuda/cupy_thrust.cu
@@ -185,7 +185,7 @@ __host__ __device__ __forceinline__ bool less< tuple<size_t, double> >::operator
 }
 
 /*
- * ********** real numbers (half precision) **********
+ * ********** real numbers (specializations for half precision) **********
  */
 
 #if (__CUDACC_VER_MAJOR__ > 9 || (__CUDACC_VER_MAJOR__ == 9 && __CUDACC_VER_MINOR__ == 2)) \

--- a/cupy/cuda/cupy_thrust.cu
+++ b/cupy/cuda/cupy_thrust.cu
@@ -24,7 +24,7 @@ namespace cuda {
 #endif // #if CUPY_USE_HIP
 
 
-extern "C" char *cupy_malloc(void *, ptrdiff_t);
+extern "C" char *cupy_malloc(void *, size_t);
 extern "C" void cupy_free(void *, char *);
 
 
@@ -37,7 +37,7 @@ public:
 
     cupy_allocator(void* memory) : memory(memory) {}
 
-    char *allocate(std::ptrdiff_t num_bytes) {
+    char *allocate(size_t num_bytes) {
         return cupy_malloc(memory, num_bytes);
     }
 
@@ -161,7 +161,7 @@ struct less<__half> {
 
 template <typename T>
 void cupy::thrust::_sort(void *data_start, size_t *keys_start,
-                         const std::vector<ptrdiff_t>& shape, size_t stream,
+                         const std::vector<ptrdiff_t>& shape, intptr_t stream,
                          void* memory) {
     size_t ndim = shape.size();
     ptrdiff_t size;
@@ -201,33 +201,33 @@ void cupy::thrust::_sort(void *data_start, size_t *keys_start,
 }
 
 template void cupy::thrust::_sort<cpy_byte>(
-    void *, size_t *, const std::vector<ptrdiff_t>& shape, size_t, void *);
+    void *, size_t *, const std::vector<ptrdiff_t>& shape, intptr_t, void *);
 template void cupy::thrust::_sort<cpy_ubyte>(
-    void *, size_t *, const std::vector<ptrdiff_t>& shape, size_t, void *);
+    void *, size_t *, const std::vector<ptrdiff_t>& shape, intptr_t, void *);
 template void cupy::thrust::_sort<cpy_short>(
-    void *, size_t *, const std::vector<ptrdiff_t>& shape, size_t, void *);
+    void *, size_t *, const std::vector<ptrdiff_t>& shape, intptr_t, void *);
 template void cupy::thrust::_sort<cpy_ushort>(
-    void *, size_t *, const std::vector<ptrdiff_t>& shape, size_t, void *);
+    void *, size_t *, const std::vector<ptrdiff_t>& shape, intptr_t, void *);
 template void cupy::thrust::_sort<cpy_int>(
-    void *, size_t *, const std::vector<ptrdiff_t>& shape, size_t, void *);
+    void *, size_t *, const std::vector<ptrdiff_t>& shape, intptr_t, void *);
 template void cupy::thrust::_sort<cpy_uint>(
-    void *, size_t *, const std::vector<ptrdiff_t>& shape, size_t, void *);
+    void *, size_t *, const std::vector<ptrdiff_t>& shape, intptr_t, void *);
 template void cupy::thrust::_sort<cpy_long>(
-    void *, size_t *, const std::vector<ptrdiff_t>& shape, size_t, void *);
+    void *, size_t *, const std::vector<ptrdiff_t>& shape, intptr_t, void *);
 template void cupy::thrust::_sort<cpy_ulong>(
-    void *, size_t *, const std::vector<ptrdiff_t>& shape, size_t, void *);
+    void *, size_t *, const std::vector<ptrdiff_t>& shape, intptr_t, void *);
 template void cupy::thrust::_sort<cpy_float>(
-    void *, size_t *, const std::vector<ptrdiff_t>& shape, size_t, void *);
+    void *, size_t *, const std::vector<ptrdiff_t>& shape, intptr_t, void *);
 template void cupy::thrust::_sort<cpy_double>(
-    void *, size_t *, const std::vector<ptrdiff_t>& shape, size_t, void *);
+    void *, size_t *, const std::vector<ptrdiff_t>& shape, intptr_t, void *);
 template void cupy::thrust::_sort<cpy_complex64>(
-    void *, size_t *, const std::vector<ptrdiff_t>& shape, size_t, void *);
+    void *, size_t *, const std::vector<ptrdiff_t>& shape, intptr_t, void *);
 template void cupy::thrust::_sort<cpy_complex128>(
-    void *, size_t *, const std::vector<ptrdiff_t>& shape, size_t, void *);
+    void *, size_t *, const std::vector<ptrdiff_t>& shape, intptr_t, void *);
 template void cupy::thrust::_sort<cpy_bool>(
-    void *, size_t *, const std::vector<ptrdiff_t>& shape, size_t, void *);
+    void *, size_t *, const std::vector<ptrdiff_t>& shape, intptr_t, void *);
 void cupy::thrust::_sort_fp16(void *data_start, size_t *keys_start,
-                              const std::vector<ptrdiff_t>& shape, size_t stream,
+                              const std::vector<ptrdiff_t>& shape, intptr_t stream,
                               void* memory) {
 #if (__CUDACC_VER_MAJOR__ > 9 || (__CUDACC_VER_MAJOR__ == 9 && __CUDACC_VER_MINOR__ == 2)) \
     && (__CUDA_ARCH__ >= 530 || !defined(__CUDA_ARCH__))
@@ -254,7 +254,7 @@ private:
 
 template <typename T>
 void cupy::thrust::_lexsort(size_t *idx_start, void *keys_start, size_t k,
-                            size_t n, size_t stream, void *memory) {
+                            size_t n, intptr_t stream, void *memory) {
     /* idx_start is the beginning of the output array where the indexes that
        would sort the data will be placed. The original contents of idx_start
        will be destroyed. */
@@ -275,33 +275,33 @@ void cupy::thrust::_lexsort(size_t *idx_start, void *keys_start, size_t k,
 }
 
 template void cupy::thrust::_lexsort<cpy_byte>(
-    size_t *, void *, size_t, size_t, size_t, void *);
+    size_t *, void *, size_t, size_t, intptr_t, void *);
 template void cupy::thrust::_lexsort<cpy_ubyte>(
-    size_t *, void *, size_t, size_t, size_t, void *);
+    size_t *, void *, size_t, size_t, intptr_t, void *);
 template void cupy::thrust::_lexsort<cpy_short>(
-    size_t *, void *, size_t, size_t, size_t, void *);
+    size_t *, void *, size_t, size_t, intptr_t, void *);
 template void cupy::thrust::_lexsort<cpy_ushort>(
-    size_t *, void *, size_t, size_t, size_t, void *);
+    size_t *, void *, size_t, size_t, intptr_t, void *);
 template void cupy::thrust::_lexsort<cpy_int>(
-    size_t *, void *, size_t, size_t, size_t, void *);
+    size_t *, void *, size_t, size_t, intptr_t, void *);
 template void cupy::thrust::_lexsort<cpy_uint>(
-    size_t *, void *, size_t, size_t, size_t, void *);
+    size_t *, void *, size_t, size_t, intptr_t, void *);
 template void cupy::thrust::_lexsort<cpy_long>(
-    size_t *, void *, size_t, size_t, size_t, void *);
+    size_t *, void *, size_t, size_t, intptr_t, void *);
 template void cupy::thrust::_lexsort<cpy_ulong>(
-    size_t *, void *, size_t, size_t, size_t, void *);
+    size_t *, void *, size_t, size_t, intptr_t, void *);
 template void cupy::thrust::_lexsort<cpy_float>(
-    size_t *, void *, size_t, size_t, size_t, void *);
+    size_t *, void *, size_t, size_t, intptr_t, void *);
 template void cupy::thrust::_lexsort<cpy_double>(
-    size_t *, void *, size_t, size_t, size_t, void *);
+    size_t *, void *, size_t, size_t, intptr_t, void *);
 template void cupy::thrust::_lexsort<cpy_complex64>(
-    size_t *, void *, size_t, size_t, size_t, void *);
+    size_t *, void *, size_t, size_t, intptr_t, void *);
 template void cupy::thrust::_lexsort<cpy_complex128>(
-    size_t *, void *, size_t, size_t, size_t, void *);
+    size_t *, void *, size_t, size_t, intptr_t, void *);
 template void cupy::thrust::_lexsort<cpy_bool>(
-    size_t *, void *, size_t, size_t, size_t, void *);
+    size_t *, void *, size_t, size_t, intptr_t, void *);
 void cupy::thrust::_lexsort_fp16(size_t *idx_start, void *keys_start, size_t k,
-                                 size_t n, size_t stream, void *memory) {
+                                 size_t n, intptr_t stream, void *memory) {
 #if (__CUDACC_VER_MAJOR__ > 9 || (__CUDACC_VER_MAJOR__ == 9 && __CUDACC_VER_MINOR__ == 2)) \
     && (__CUDA_ARCH__ >= 530 || !defined(__CUDA_ARCH__))
     cupy::thrust::_lexsort<__half>(idx_start, keys_start, k, n, stream, memory);
@@ -317,7 +317,7 @@ template <typename T>
 void cupy::thrust::_argsort(size_t *idx_start, void *data_start,
                             void *keys_start,
                             const std::vector<ptrdiff_t>& shape,
-                            size_t stream, void *memory) {
+                            intptr_t stream, void *memory) {
     /* idx_start is the beginning of the output array where the indexes that
        would sort the data will be placed. The original contents of idx_start
        will be destroyed. */
@@ -377,48 +377,48 @@ void cupy::thrust::_argsort(size_t *idx_start, void *data_start,
 }
 
 template void cupy::thrust::_argsort<cpy_byte>(
-    size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, size_t,
+    size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, intptr_t,
     void *);
 template void cupy::thrust::_argsort<cpy_ubyte>(
-    size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, size_t,
+    size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, intptr_t,
     void *);
 template void cupy::thrust::_argsort<cpy_short>(
-    size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, size_t,
+    size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, intptr_t,
     void *);
 template void cupy::thrust::_argsort<cpy_ushort>(
-    size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, size_t,
+    size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, intptr_t,
     void *);
 template void cupy::thrust::_argsort<cpy_int>(
-    size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, size_t,
+    size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, intptr_t,
     void *);
 template void cupy::thrust::_argsort<cpy_uint>(
-    size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, size_t,
+    size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, intptr_t,
     void *);
 template void cupy::thrust::_argsort<cpy_long>(
-    size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, size_t,
+    size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, intptr_t,
     void *);
 template void cupy::thrust::_argsort<cpy_ulong>(
-    size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, size_t,
+    size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, intptr_t,
     void *);
 template void cupy::thrust::_argsort<cpy_float>(
-    size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, size_t,
+    size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, intptr_t,
     void *);
 template void cupy::thrust::_argsort<cpy_double>(
-    size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, size_t,
+    size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, intptr_t,
     void *);
 template void cupy::thrust::_argsort<cpy_complex64>(
-    size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, size_t,
+    size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, intptr_t,
     void *);
 template void cupy::thrust::_argsort<cpy_complex128>(
-    size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, size_t,
+    size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, intptr_t,
     void *);
 template void cupy::thrust::_argsort<cpy_bool>(
-    size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, size_t,
+    size_t *, void *, void *, const std::vector<ptrdiff_t>& shape, intptr_t,
     void *);
 void cupy::thrust::_argsort_fp16(size_t *idx_start, void *data_start,
                                  void *keys_start,
                                  const std::vector<ptrdiff_t>& shape,
-                                 size_t stream, void *memory) {
+                                 intptr_t stream, void *memory) {
 #if (__CUDACC_VER_MAJOR__ > 9 || (__CUDACC_VER_MAJOR__ == 9 && __CUDACC_VER_MINOR__ == 2)) \
     && (__CUDA_ARCH__ >= 530 || !defined(__CUDA_ARCH__))
     cupy::thrust::_argsort<__half>(idx_start, data_start, keys_start, shape, stream, memory);

--- a/cupy/cuda/cupy_thrust.h
+++ b/cupy/cuda/cupy_thrust.h
@@ -8,23 +8,23 @@ namespace cupy {
 namespace thrust {
 
 template <typename T>
-void _sort(void *, size_t *, const std::vector<ptrdiff_t>&, size_t, void *);
+void _sort(void *, size_t *, const std::vector<ptrdiff_t>&, intptr_t, void *);
 
 template <typename T>
-void _lexsort(size_t *, void *, size_t, size_t, size_t, void *);
+void _lexsort(size_t *, void *, size_t, size_t, intptr_t, void *);
 
 template <typename T>
-void _argsort(size_t *, void *, void *, const std::vector<ptrdiff_t>&, size_t,
+void _argsort(size_t *, void *, void *, const std::vector<ptrdiff_t>&, intptr_t,
               void *);
 
 /*
    The functions with the suffix _fp16 are used only when certain conditions are met
 */
-void _sort_fp16(void *, size_t *, const std::vector<ptrdiff_t>&, size_t, void *);
+void _sort_fp16(void *, size_t *, const std::vector<ptrdiff_t>&, intptr_t, void *);
 
-void _lexsort_fp16(size_t *, void *, size_t, size_t, size_t, void *);
+void _lexsort_fp16(size_t *, void *, size_t, size_t, intptr_t, void *);
 
-void _argsort_fp16(size_t *, void *, void *, const std::vector<ptrdiff_t>&, size_t,
+void _argsort_fp16(size_t *, void *, void *, const std::vector<ptrdiff_t>&, intptr_t,
                    void *);
 
 } // namespace thrust
@@ -40,28 +40,28 @@ namespace cupy {
 namespace thrust {
 
 template <typename T>
-void _sort(void *, size_t *, const std::vector<ptrdiff_t>&, size_t, void *) {
+void _sort(void *, size_t *, const std::vector<ptrdiff_t>&, intptr_t, void *) {
     return;
 }
 
 template <typename T>
-void _lexsort(size_t *, void *, size_t, size_t, size_t, void *) {
+void _lexsort(size_t *, void *, size_t, size_t, intptr_t, void *) {
     return;
 }
 
 template <typename T>
-void _argsort(size_t *, void *, void *, const std::vector<ptrdiff_t>&, size_t,
+void _argsort(size_t *, void *, void *, const std::vector<ptrdiff_t>&, intptr_t,
               void *) {
     return;
 }
 
-void _sort_fp16(void *, size_t *, const std::vector<ptrdiff_t>&, size_t, void *) {
+void _sort_fp16(void *, size_t *, const std::vector<ptrdiff_t>&, intptr_t, void *) {
 }
 
-void _lexsort_fp16(size_t *, void *, size_t, size_t, size_t, void *) {
+void _lexsort_fp16(size_t *, void *, size_t, size_t, intptr_t, void *) {
 }
 
-void _argsort_fp16(size_t *, void *, void *, const std::vector<ptrdiff_t>&, size_t,
+void _argsort_fp16(size_t *, void *, void *, const std::vector<ptrdiff_t>&, intptr_t,
                    void *) {
 }
 

--- a/cupy/cuda/thrust.pyx
+++ b/cupy/cuda/thrust.pyx
@@ -70,7 +70,7 @@ cdef extern from '../cuda/cupy_thrust.h' namespace 'cupy::thrust':
 # Python interface
 ###############################################################################
 
-cpdef sort(dtype, size_t data_start, size_t keys_start,
+cpdef sort(dtype, intptr_t data_start, intptr_t keys_start,
            const vector.vector[ptrdiff_t]& shape) except +:
 
     cdef void* _data_start = <void*>data_start
@@ -120,7 +120,7 @@ cpdef sort(dtype, size_t data_start, size_t keys_start,
                                   'supported'.format(dtype))
 
 
-cpdef lexsort(dtype, size_t idx_start, size_t keys_start,
+cpdef lexsort(dtype, intptr_t idx_start, intptr_t keys_start,
               size_t k, size_t n) except +:
 
     cdef size_t* idx_ptr = <size_t*>idx_start
@@ -168,11 +168,13 @@ cpdef lexsort(dtype, size_t idx_start, size_t keys_start,
                         'supported'.format(dtype))
 
 
-cpdef argsort(dtype, size_t idx_start, size_t data_start, size_t keys_start,
+cpdef argsort(dtype, intptr_t idx_start, intptr_t data_start,
+              intptr_t keys_start,
               const vector.vector[ptrdiff_t]& shape) except +:
+
     cdef size_t*_idx_start = <size_t*>idx_start
     cdef void* _data_start = <void*>data_start
-    cdef size_t*_keys_start = <size_t*>keys_start
+    cdef size_t* _keys_start = <size_t*>keys_start
     cdef intptr_t _strm = stream.get_current_stream_ptr()
     cdef _MemoryManager mem_obj = _MemoryManager()
     cdef void* mem = <void *>mem_obj

--- a/cupy/cuda/thrust.pyx
+++ b/cupy/cuda/thrust.pyx
@@ -5,6 +5,7 @@
 import numpy
 
 cimport cython  # NOQA
+from libc.stdint cimport intptr_t
 from libcpp cimport vector
 
 from cupy.cuda cimport common
@@ -18,6 +19,8 @@ from cupy.cuda cimport stream
 # Memory Management
 ###############################################################################
 
+# Before attempting refactoring this part, please read the discussion in #3212.
+
 cdef class _MemoryManager:
     cdef:
         dict memory
@@ -26,7 +29,7 @@ cdef class _MemoryManager:
         self.memory = dict()
 
 
-cdef public char* cupy_malloc(void *m, ptrdiff_t size) with gil:
+cdef public char* cupy_malloc(void *m, size_t size) with gil:
     if size == 0:
         return <char *>0
     cdef _MemoryManager mm = <_MemoryManager>m
@@ -47,20 +50,20 @@ cdef public void cupy_free(void *m, char* ptr) with gil:
 ###############################################################################
 
 cdef extern from '../cuda/cupy_thrust.h' namespace 'cupy::thrust':
-    void _sort[T](void *, size_t *, const vector.vector[ptrdiff_t]&, size_t,
+    void _sort[T](void *, size_t *, const vector.vector[ptrdiff_t]&, intptr_t,
                   void *)
-    void _lexsort[T](size_t *, void *, size_t, size_t, size_t, void *)
+    void _lexsort[T](size_t *, void *, size_t, size_t, intptr_t, void *)
     void _argsort[T](size_t *, void *, void *, const vector.vector[ptrdiff_t]&,
-                     size_t, void *)
+                     intptr_t, void *)
 
     # for half precision
     # TODO(leofang): eliminate the extra delegation call when we have a dtype
     # dispatcher in C++
-    void _sort_fp16(void *, size_t *, const vector.vector[ptrdiff_t]&, size_t,
-                    void *)
-    void _lexsort_fp16(size_t *, void *, size_t, size_t, size_t, void *)
+    void _sort_fp16(void *, size_t *, const vector.vector[ptrdiff_t]&,
+                    intptr_t, void *)
+    void _lexsort_fp16(size_t *, void *, size_t, size_t, intptr_t, void *)
     void _argsort_fp16(size_t *, void *, void *,
-                       const vector.vector[ptrdiff_t]&, size_t, void *)
+                       const vector.vector[ptrdiff_t]&, intptr_t, void *)
 
 
 ###############################################################################
@@ -70,15 +73,11 @@ cdef extern from '../cuda/cupy_thrust.h' namespace 'cupy::thrust':
 cpdef sort(dtype, size_t data_start, size_t keys_start,
            const vector.vector[ptrdiff_t]& shape) except +:
 
-    cdef void *_data_start
-    cdef size_t *_keys_start
-    cdef size_t _strm
-
-    _data_start = <void *>data_start
-    _keys_start = <size_t *>keys_start
-    _strm = <size_t>(stream.get_current_stream_ptr())
-    mem_obj = _MemoryManager()
-    cdef void* mem = <void *>mem_obj
+    cdef void* _data_start = <void*>data_start
+    cdef size_t* _keys_start = <size_t*>keys_start
+    cdef intptr_t _strm = stream.get_current_stream_ptr()
+    cdef _MemoryManager mem_obj = _MemoryManager()
+    cdef void* mem = <void*>mem_obj
 
     if dtype == numpy.float16:
         if int(device.get_compute_capability()) < 53 or \
@@ -124,13 +123,11 @@ cpdef sort(dtype, size_t data_start, size_t keys_start,
 cpdef lexsort(dtype, size_t idx_start, size_t keys_start,
               size_t k, size_t n) except +:
 
-    cdef size_t _strm
-
-    idx_ptr = <size_t *>idx_start
-    keys_ptr = <void *>keys_start
-    _strm = <size_t>(stream.get_current_stream_ptr())
-    mem_obj = _MemoryManager()
-    cdef void* mem = <void *>mem_obj
+    cdef size_t* idx_ptr = <size_t*>idx_start
+    cdef void* keys_ptr = <void*>keys_start
+    cdef intptr_t _strm = stream.get_current_stream_ptr()
+    cdef _MemoryManager mem_obj = _MemoryManager()
+    cdef void* mem = <void*>mem_obj
 
     if dtype == numpy.float16:
         if int(device.get_compute_capability()) < 53 or \
@@ -173,16 +170,11 @@ cpdef lexsort(dtype, size_t idx_start, size_t keys_start,
 
 cpdef argsort(dtype, size_t idx_start, size_t data_start, size_t keys_start,
               const vector.vector[ptrdiff_t]& shape) except +:
-    cdef size_t *_idx_start
-    cdef size_t *_keys_start
-    cdef void *_data_start
-    cdef size_t _strm
-
-    _idx_start = <size_t *>idx_start
-    _data_start = <void *>data_start
-    _keys_start = <size_t *>keys_start
-    _strm = <size_t>(stream.get_current_stream_ptr())
-    mem_obj = _MemoryManager()
+    cdef size_t*_idx_start = <size_t*>idx_start
+    cdef void* _data_start = <void*>data_start
+    cdef size_t*_keys_start = <size_t*>keys_start
+    cdef intptr_t _strm = stream.get_current_stream_ptr()
+    cdef _MemoryManager mem_obj = _MemoryManager()
     cdef void* mem = <void *>mem_obj
 
     if dtype == numpy.float16:

--- a/cupy/cuda/thrust.pyx
+++ b/cupy/cuda/thrust.pyx
@@ -19,7 +19,7 @@ from cupy.cuda cimport stream
 # Memory Management
 ###############################################################################
 
-# Before attempting refactoring this part, please read the discussion in #3212.
+# Before attempting to refactor this part, read the discussion in #3212 first.
 
 cdef class _MemoryManager:
     cdef:

--- a/tests/cupy_tests/sorting_tests/test_sort.py
+++ b/tests/cupy_tests/sorting_tests/test_sort.py
@@ -38,21 +38,21 @@ class TestSort(unittest.TestCase):
     # Test dtypes
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_array_equal()
     def test_sort_dtype(self, xp, dtype):
         a = testing.shaped_random((10,), xp, dtype)
         a.sort()
         return a
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_array_equal()
     def test_external_sort_dtype(self, xp, dtype):
         a = testing.shaped_random((10,), xp, dtype)
         return xp.sort(a)
 
     # Test contiguous arrays
 
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_array_equal()
     def test_sort_contiguous(self, xp):
         a = testing.shaped_random((10,), xp)  # C contiguous view
         a.sort()
@@ -63,12 +63,12 @@ class TestSort(unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             a.sort()
 
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_array_equal()
     def test_external_sort_contiguous(self, xp):
         a = testing.shaped_random((10,), xp)  # C contiguous view
         return xp.sort(a)
 
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_array_equal()
     def test_external_sort_non_contiguous(self, xp):
         a = testing.shaped_random((10,), xp)[::2]  # Non contiguous view
         return xp.sort(a)
@@ -161,7 +161,7 @@ class TestSort(unittest.TestCase):
     # Test NaN ordering
 
     @testing.for_dtypes('efdFD')
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_array_equal()
     def test_nan1(self, xp, dtype):
         a = testing.shaped_random((10,), xp, dtype)
         a[2] = a[6] = xp.nan
@@ -225,7 +225,7 @@ class TestLexsort(unittest.TestCase):
     # Test dtypes
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_array_equal()
     def test_lexsort_dtype(self, xp, dtype):
         a = testing.shaped_random((2, 10), xp, dtype)
         return xp.lexsort(a)
@@ -233,21 +233,21 @@ class TestLexsort(unittest.TestCase):
     # Test NaN ordering
 
     @testing.for_dtypes('efdFD')
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_array_equal()
     def test_nan1(self, xp, dtype):
         a = testing.shaped_random((2, 10), xp, dtype)
         a[0, 2] = a[0, 6] = xp.nan
         return xp.lexsort(a)
 
     @testing.for_dtypes('efdFD')
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_array_equal()
     def test_nan2(self, xp, dtype):
         a = testing.shaped_random((2, 10), xp, dtype)
         a[1, 2] = a[0, 6] = xp.nan
         return xp.lexsort(a)
 
     @testing.for_dtypes('efdFD')
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_array_equal()
     def test_nan3(self, xp, dtype):
         a = testing.shaped_random((2, 10), xp, dtype)
         a[1, 2] = a[1, 6] = xp.nan
@@ -255,14 +255,14 @@ class TestLexsort(unittest.TestCase):
 
     # Test non C-contiguous input
 
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_array_equal()
     def test_view(self, xp):
         # from #3232
         a = testing.shaped_random((4, 8), xp, dtype=xp.float64)
         a = a.T[::-1]
         return xp.lexsort(a)
 
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_array_equal()
     def test_F_order(self, xp):
         a = testing.shaped_random((4, 8), xp, dtype=xp.float64)
         a = xp.asfortranarray(a)
@@ -376,11 +376,18 @@ class TestArgsort(unittest.TestCase):
     # Test NaN ordering
 
     @testing.for_dtypes('efdFD')
-    @testing.numpy_cupy_allclose()
-    def test_nan(self, xp, dtype):
+    @testing.numpy_cupy_array_equal()
+    def test_nan1(self, xp, dtype):
         a = testing.shaped_random((10,), xp, dtype)
         a[2] = a[6] = xp.nan
-        return xp.argsort(a)
+        return self.argsort(a)
+
+    @testing.for_dtypes('efdFD')
+    @testing.numpy_cupy_array_equal()
+    def test_nan2(self, xp, dtype):
+        a = testing.shaped_random((2, 3, 4), xp, dtype)
+        a[0, 2, 1] = a[1, 1, 3] = xp.nan
+        return self.argsort(a)
 
 
 @testing.gpu

--- a/tests/cupy_tests/sorting_tests/test_sort.py
+++ b/tests/cupy_tests/sorting_tests/test_sort.py
@@ -90,7 +90,7 @@ class TestSort(unittest.TestCase):
     @testing.numpy_cupy_array_equal()
     def test_sort_axis3(self, xp):
         a = testing.shaped_random((2, 3, 4), xp)
-        a.sort(axis=1)
+        a.sort(axis=2)
         return a
 
     @testing.numpy_cupy_array_equal()
@@ -251,6 +251,23 @@ class TestLexsort(unittest.TestCase):
     def test_nan3(self, xp, dtype):
         a = testing.shaped_random((2, 10), xp, dtype)
         a[1, 2] = a[1, 6] = xp.nan
+        return xp.lexsort(a)
+
+    # Test non C-contiguous input
+
+    @testing.numpy_cupy_allclose()
+    def test_view(self, xp):
+        # from #3232
+        a = testing.shaped_random((4, 8), xp, dtype=xp.float64)
+        a = a.T[::-1]
+        return xp.lexsort(a)
+
+    @testing.numpy_cupy_allclose()
+    def test_F_order(self, xp):
+        a = testing.shaped_random((4, 8), xp, dtype=xp.float64)
+        a = xp.asfortranarray(a)
+        assert a.flags.f_contiguous
+        assert not a.flags.c_contiguous
         return xp.lexsort(a)
 
 

--- a/tests/cupy_tests/sorting_tests/test_sort.py
+++ b/tests/cupy_tests/sorting_tests/test_sort.py
@@ -76,9 +76,21 @@ class TestSort(unittest.TestCase):
     # Test axis
 
     @testing.numpy_cupy_array_equal()
-    def test_sort_axis(self, xp):
-        a = testing.shaped_random((2, 3, 3), xp)
+    def test_sort_axis1(self, xp):
+        a = testing.shaped_random((2, 3, 4), xp)
         a.sort(axis=0)
+        return a
+
+    @testing.numpy_cupy_array_equal()
+    def test_sort_axis2(self, xp):
+        a = testing.shaped_random((2, 3, 4), xp)
+        a.sort(axis=1)
+        return a
+
+    @testing.numpy_cupy_array_equal()
+    def test_sort_axis3(self, xp):
+        a = testing.shaped_random((2, 3, 4), xp)
+        a.sort(axis=1)
         return a
 
     @testing.numpy_cupy_array_equal()
@@ -150,11 +162,35 @@ class TestSort(unittest.TestCase):
 
     @testing.for_dtypes('efdFD')
     @testing.numpy_cupy_allclose()
-    def test_nan(self, xp, dtype):
+    def test_nan1(self, xp, dtype):
         a = testing.shaped_random((10,), xp, dtype)
         a[2] = a[6] = xp.nan
-        a.sort()
-        return a
+        out = xp.sort(a)
+        return out
+
+    @testing.for_dtypes('efdFD')
+    @testing.numpy_cupy_array_equal()
+    def test_nan2(self, xp, dtype):
+        a = testing.shaped_random((2, 3, 4), xp, dtype)
+        a[0, 2, 1] = a[1, 0, 3] = xp.nan
+        out = xp.sort(a, axis=0)
+        return out
+
+    @testing.for_dtypes('efdFD')
+    @testing.numpy_cupy_array_equal()
+    def test_nan3(self, xp, dtype):
+        a = testing.shaped_random((2, 3, 4), xp, dtype)
+        a[0, 2, 1] = a[1, 0, 3] = xp.nan
+        out = xp.sort(a, axis=1)
+        return out
+
+    @testing.for_dtypes('efdFD')
+    @testing.numpy_cupy_array_equal()
+    def test_nan4(self, xp, dtype):
+        a = testing.shaped_random((2, 3, 4), xp, dtype)
+        a[0, 2, 1] = a[1, 0, 3] = xp.nan
+        out = xp.sort(a, axis=2)
+        return out
 
 
 @testing.gpu
@@ -195,15 +231,26 @@ class TestLexsort(unittest.TestCase):
         return xp.lexsort(a)
 
     # Test NaN ordering
-    # TODO(leofang): test two more cases after #3232 is fixed
-    # 1. a[1, 2] = a[1, 6] = xp.nan
-    # 2. a[0, 2] = a[1, 6] = xp.nan
 
     @testing.for_dtypes('efdFD')
     @testing.numpy_cupy_allclose()
-    def test_nan(self, xp, dtype):
+    def test_nan1(self, xp, dtype):
         a = testing.shaped_random((2, 10), xp, dtype)
         a[0, 2] = a[0, 6] = xp.nan
+        return xp.lexsort(a)
+
+    @testing.for_dtypes('efdFD')
+    @testing.numpy_cupy_allclose()
+    def test_nan2(self, xp, dtype):
+        a = testing.shaped_random((2, 10), xp, dtype)
+        a[1, 2] = a[0, 6] = xp.nan
+        return xp.lexsort(a)
+
+    @testing.for_dtypes('efdFD')
+    @testing.numpy_cupy_allclose()
+    def test_nan3(self, xp, dtype):
+        a = testing.shaped_random((2, 10), xp, dtype)
+        a[1, 2] = a[1, 6] = xp.nan
         return xp.lexsort(a)
 
 


### PR DESCRIPTION
Close #3232, in which two different bugs were reported. Follow-up of #2745 & #3286.  

This PR does two things:
1. code fix: most pointers passed from Cython are of type `intptr_t` (#2455). Shouldn't have to cast them to `size_t`.
2. bug fix: #3232 has two bugs reported:
    - `cupy::thrust::_lexsort()` assumes a C-contiguous input but we didn't check it
    - lack of NaN handling for real numbers 

Context for the 2nd bug: In #2745 (#3286) when sorting complex (half precision) numbers was supported, NaN handling was added, but I forgot to extend it to single and double precisions 😅 Now this is done in a unified fashion, similar to how it's handled in `cupy/cuda/cupy_cub.cu`. (Perhaps I will do more refactoring later to reduce code repetition.) The master branch fails most of the added tests (for NaN and non-C-contiguous arrays), which this PR passes.