### PR TITLE
Support surface memory in `RawKernel`

### DIFF
--- a/cupy/cuda/cupy_cuda.h
+++ b/cupy/cuda/cupy_cuda.h
@@ -479,6 +479,15 @@ cudaPos make_cudaPos(...) {
     return pos;
 }
 
+// Surface
+cudaError_t cudaCreateSurfaceObject(...) {
+    return cudaSuccess;
+}
+
+cudaError_t cudaDestroySurfaceObject(...) {
+    return cudaSuccess;
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 // cuComplex.h
 ///////////////////////////////////////////////////////////////////////////////

--- a/cupy/cuda/cupy_cuda_common.h
+++ b/cupy/cuda/cupy_cuda_common.h
@@ -82,6 +82,7 @@ struct cudaPointerAttributes{
 
 enum cudaChannelFormatKind {};
 typedef unsigned long long cudaTextureObject_t;
+typedef unsigned long long cudaSurfaceObject_t;
 enum cudaResourceType {};
 enum cudaTextureAddressMode {};
 enum cudaTextureFilterMode {};

--- a/cupy/cuda/cupy_hip_common.h
+++ b/cupy/cuda/cupy_hip_common.h
@@ -72,6 +72,7 @@ typedef hipPointerAttribute_t cudaPointerAttributes;
 
 typedef hipChannelFormatKind cudaChannelFormatKind;
 typedef hipTextureObject_t cudaTextureObject_t;
+typedef hipSurfaceObject_t cudaSurfaceObject_t;
 typedef hipResourceType cudaResourceType;
 typedef hipTextureAddressMode cudaTextureAddressMode;
 typedef hipTextureFilterMode cudaTextureFilterMode;

--- a/cupy/cuda/function.pyx
+++ b/cupy/cuda/function.pyx
@@ -18,7 +18,7 @@ from cupy.core cimport core
 from cupy.cuda cimport driver
 from cupy.cuda cimport runtime
 from cupy.cuda cimport stream as stream_module
-from cupy.cuda.texture cimport TextureObject
+from cupy.cuda.texture cimport TextureObject, SurfaceObject
 
 
 cdef class CPointer:
@@ -92,6 +92,9 @@ cdef inline CPointer _pointer(x):
     if isinstance(x, core.ndarray):
         return (<core.ndarray>x).get_pointer()
     if isinstance(x, TextureObject):
+        return CUIntMax(x.ptr)
+
+    if isinstance(x, SurfaceObject):
         return CUIntMax(x.ptr)
 
     if type(x) not in _pointer_numpy_types:

--- a/cupy/cuda/runtime.pxd
+++ b/cupy/cuda/runtime.pxd
@@ -21,6 +21,7 @@ cdef extern from *:
         int x, y, z, w
         ChannelFormatKind f
     ctypedef uintmax_t TextureObject 'cudaTextureObject_t'
+    ctypedef uintmax_t SurfaceObject 'cudaSurfaceObject_t'
     ctypedef int ResourceType 'cudaResourceType'
     ctypedef int TextureAddressMode 'cudaTextureAddressMode'
     ctypedef int TextureFilterMode 'cudaTextureFilterMode'
@@ -410,3 +411,7 @@ cdef TextureDesc getTextureObjectTextureDesc(uintmax_t texobj)
 cdef Extent make_Extent(size_t w, size_t h, size_t d)
 cdef Pos make_Pos(size_t x, size_t y, size_t z)
 cdef PitchedPtr make_PitchedPtr(intptr_t d, size_t p, size_t xsz, size_t ysz)
+
+
+cpdef uintmax_t createSurfaceObject(intptr_t ResDesc)
+cpdef destroySurfaceObject(uintmax_t surfObject)

--- a/cupy/cuda/runtime.pxd
+++ b/cupy/cuda/runtime.pxd
@@ -250,6 +250,13 @@ cpdef enum:
     cudaChannelFormatKindFloat = 2
     cudaChannelFormatKindNone = 3
 
+    # CUDA array flags
+    cudaArrayDefault = 0
+    # cudaArrayLayered = 1
+    cudaArraySurfaceLoadStore = 2
+    # cudaArrayCubemap = 4
+    # cudaArrayTextureGather = 8
+
     # cudaResourceType
     cudaResourceTypeArray = 0
     cudaResourceTypeMipmappedArray = 1

--- a/cupy/cuda/runtime.pxd
+++ b/cupy/cuda/runtime.pxd
@@ -412,6 +412,6 @@ cdef Extent make_Extent(size_t w, size_t h, size_t d)
 cdef Pos make_Pos(size_t x, size_t y, size_t z)
 cdef PitchedPtr make_PitchedPtr(intptr_t d, size_t p, size_t xsz, size_t ysz)
 
-
 cpdef uintmax_t createSurfaceObject(intptr_t ResDesc)
 cpdef destroySurfaceObject(uintmax_t surfObject)
+# TODO(leofang): add cudaGetSurfaceObjectResourceDesc

--- a/cupy/cuda/runtime.pyx
+++ b/cupy/cuda/runtime.pyx
@@ -179,6 +179,11 @@ cdef extern from 'cupy_cuda.h' nogil:
     int cudaGetTextureObjectResourceDesc(ResourceDesc* desc, TextureObject obj)
     int cudaGetTextureObjectTextureDesc(TextureDesc* desc, TextureObject obj)
 
+    # Surface
+    int cudaCreateSurfaceObject(SurfaceObject* pSurObject,
+                                const ResourceDesc* pResDesc)
+    int cudaDestroySurfaceObject(SurfaceObject surObject)
+
     bint hip_environment
     int cudaDevAttrComputeCapabilityMajor
     int cudaDevAttrComputeCapabilityMinor
@@ -660,6 +665,19 @@ cpdef uintmax_t createTextureObject(intptr_t ResDescPtr, intptr_t TexDescPtr):
 cpdef destroyTextureObject(uintmax_t texObject):
     with nogil:
         status = cudaDestroyTextureObject(<TextureObject>texObject)
+    check_status(status)
+
+cpdef uintmax_t createSurfaceObject(intptr_t ResDescPtr):
+    cdef uintmax_t surfobj = 0
+    with nogil:
+        status = cudaCreateSurfaceObject(<SurfaceObject*>(&surfobj),
+                                         <ResourceDesc*>ResDescPtr)
+    check_status(status)
+    return surfobj
+
+cpdef destroySurfaceObject(uintmax_t surfObject):
+    with nogil:
+        status = cudaDestroySurfaceObject(<SurfaceObject>surfObject)
     check_status(status)
 
 cdef ChannelFormatDesc getChannelDesc(intptr_t array):

--- a/cupy/cuda/texture.pxd
+++ b/cupy/cuda/texture.pxd
@@ -39,6 +39,11 @@ cdef class TextureObject:
         readonly ResourceDescriptor ResDesc
         readonly TextureDescriptor TexDesc
 
+cdef class SurfaceObject:
+    cdef:
+        readonly uintmax_t ptr
+        readonly ResourceDescriptor ResDesc
+
 
 cdef class TextureReference:
     cdef:

--- a/cupy/cuda/texture.pxd
+++ b/cupy/cuda/texture.pxd
@@ -39,6 +39,7 @@ cdef class TextureObject:
         readonly ResourceDescriptor ResDesc
         readonly TextureDescriptor TexDesc
 
+
 cdef class SurfaceObject:
     cdef:
         readonly uintmax_t ptr

--- a/cupy/cuda/texture.pyx
+++ b/cupy/cuda/texture.pyx
@@ -502,6 +502,15 @@ cdef class TextureObject:
         runtime.destroyTextureObject(self.ptr)
         self.ptr = 0
 
+cdef class SurfaceObject:
+    def __init__(self, ResourceDescriptor ResDesc):
+        self.ptr = runtime.createSurfaceObject(ResDesc.ptr)
+        self.ResDesc = ResDesc
+
+    def __dealloc__(self):
+        runtime.destroySurfaceObject(self.ptr)
+        self.ptr = 0
+
 
 cdef class TextureReference:
     '''A class that holds a texture reference. Equivalent to ``CUtexref`` (the

--- a/cupy/cuda/texture.pyx
+++ b/cupy/cuda/texture.pyx
@@ -502,7 +502,20 @@ cdef class TextureObject:
         runtime.destroyTextureObject(self.ptr)
         self.ptr = 0
 
+
 cdef class SurfaceObject:
+    '''A class that holds a surface object. Equivalent to
+    ``cudaSurfaceObject_t``. The returned :class:`SurfaceObject` instance can
+    be passed as a argument when launching :class:`~cupy.RawKernel`.
+
+    Args:
+        ResDesc (ResourceDescriptor): an intance of the resource descriptor.
+
+    .. seealso:: `cudaCreateSurfaceObject()`_
+
+    .. _cudaCreateSurfaceObject():
+        https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__SURFACE__OBJECT.html#group__CUDART__SURFACE__OBJECT_1g958899474ab2c5f40d233b524d6c5a01
+    '''  # noqa
     def __init__(self, ResourceDescriptor ResDesc):
         self.ptr = runtime.createSurfaceObject(ResDesc.ptr)
         self.ResDesc = ResDesc

--- a/docs/source/reference/cuda.rst
+++ b/docs/source/reference/cuda.rst
@@ -61,8 +61,8 @@ Streams and events
    cupy.cuda.get_elapsed_time
 
 
-Texture memory
---------------
+Texture and surface memory
+--------------------------
 
 .. autosummary::
    :toctree: generated/
@@ -73,6 +73,7 @@ Texture memory
    cupy.cuda.texture.ResourceDescriptor
    cupy.cuda.texture.TextureDescriptor
    cupy.cuda.texture.TextureObject
+   cupy.cuda.texture.SurfaceObject
    cupy.cuda.texture.TextureReference
 
 

--- a/docs/source/tutorial/kernel.rst
+++ b/docs/source/tutorial/kernel.rst
@@ -249,7 +249,7 @@ Dynamical parallelism is supported by :class:`~cupy.RawKernel`. You just need to
 
 .. _CUDA Toolkit's documentation: https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#compiling-and-linking
 
-Accessing texture memory in :class:`~cupy.RawKernel` is supported via CUDA Runtime's Texture Object API, see :class:`~cupy.cuda.texture.TextureObject`'s documentation as well as CUDA C Programming Guide. For using the Texture Reference API, which is marked as deprecated as of CUDA Toolkit 10.1, see the introduction to :class:`~cupy.RawModule` below.
+Accessing texture (surface) memory in :class:`~cupy.RawKernel` is supported via CUDA Runtime's Texture (Surface) Object API, see the documentation for :class:`~cupy.cuda.texture.TextureObject` (:class:`~cupy.cuda.texture.SurfaceObject`) as well as CUDA C Programming Guide. For using the Texture Reference API, which is marked as deprecated as of CUDA Toolkit 10.1, see the introduction to :class:`~cupy.RawModule` below.
 
 .. note::
     The kernel does not have return values.


### PR DESCRIPTION
Takeover from #3197. **Main credit goes to @Fokatu**. Close #2624. 

This is a follow-up of #2432. The surface object API is supported. Although I don't think there're many users who need this capability (compared to texture memory), @Fokatu has shown it's simple to support this in CuPy with little maintenance burden, so I think it's still worth adding. 

With this support, CuPy is now a full (and far better!) replacement for PyCUDA. 

