### PR TITLE
Improve `ElementwiseKernel` cpu time

### DIFF
--- a/cupy/core/_kernel.pyx
+++ b/cupy/core/_kernel.pyx
@@ -153,8 +153,8 @@ cdef class _ArgInfo:
             ARG_KIND_NDARRAY,
             ndarray,
             arg.dtype.type,
-            arg.ndim,
-            arg.flags.c_contiguous)
+            arg._shape.size(),
+            arg._c_contiguous)
 
     @staticmethod
     cdef _ArgInfo from_scalar(_scalar.CScalar arg):


### PR DESCRIPTION
Before

```
time_abs             - case        100                    :    CPU:   11.408 us   +/- 0.413 (min:   11.019 / max:   12.159) us     GPU:   15.149 us   +/- 1.590 (min:   13.888 / max:   19.616) us
time_abs             - case        200                    :    CPU:   11.355 us   +/- 0.401 (min:   10.908 / max:   12.262) us     GPU:   14.707 us   +/- 0.768 (min:   13.984 / max:   16.864) us
time_abs             - case       5000                    :    CPU:   11.993 us   +/- 1.310 (min:   10.898 / max:   15.197) us     GPU:  506.054 us   +/- 1.694 (min:  504.576 / max:  510.688) us
time_abs             - case      10000                    :    CPU:   54.580 us   +/-121.037 (min:   11.170 / max:  417.547) us     GPU: 2028.294 us   +/-128.319 (min: 1982.528 / max: 2413.120) us
time_absolute        - case        100                    :    CPU:   11.368 us   +/- 0.595 (min:   10.874 / max:   12.992) us     GPU:   14.765 us   +/- 0.823 (min:   14.016 / max:   16.384) us
time_absolute        - case        200                    :    CPU:   11.222 us   +/- 0.290 (min:   10.902 / max:   11.787) us     GPU:   14.630 us   +/- 0.483 (min:   14.112 / max:   15.744) us
time_absolute        - case       5000                    :    CPU:   12.010 us   +/- 1.190 (min:   11.079 / max:   15.091) us     GPU:  506.118 us   +/- 1.587 (min:  504.672 / max:  510.240) us
time_absolute        - case      10000                    :    CPU:   13.235 us   +/- 2.803 (min:   11.533 / max:   21.396) us     GPU: 1984.534 us   +/- 3.138 (min: 1982.304 / max: 1993.664) us
time_add             - case        100                    :    CPU:   17.537 us   +/- 0.430 (min:   17.043 / max:   18.355) us     GPU:   20.886 us   +/- 1.097 (min:   19.968 / max:   23.872) us
time_add             - case        200                    :    CPU:   17.692 us   +/- 0.357 (min:   17.330 / max:   18.425) us     GPU:   21.277 us   +/- 1.011 (min:   19.968 / max:   23.488) us
time_add             - case       5000                    :    CPU:   12.971 us   +/- 1.046 (min:   11.966 / max:   15.516) us     GPU:  507.398 us   +/- 1.364 (min:  505.984 / max:  511.104) us
time_add             - case      10000                    :    CPU:   13.211 us   +/- 1.161 (min:   11.979 / max:   16.140) us     GPU: 1985.219 us   +/- 1.835 (min: 1983.680 / max: 1990.368) us
time_arccos          - case        100                    :    CPU:   11.422 us   +/- 0.609 (min:   10.828 / max:   12.865) us     GPU:   15.123 us   +/- 1.240 (min:   14.048 / max:   18.304) us
time_arccos          - case        200                    :    CPU:   11.300 us   +/- 0.256 (min:   11.051 / max:   11.927) us     GPU:   14.723 us   +/- 0.431 (min:   14.272 / max:   15.648) us
time_arccos          - case       5000                    :    CPU:   12.094 us   +/- 1.087 (min:   11.152 / max:   14.979) us     GPU:  510.733 us   +/- 1.733 (min:  509.504 / max:  515.616) us
time_arccos          - case      10000                    :    CPU:   32.755 us   +/-59.443 (min:   11.530 / max:  211.023) us     GPU: 2019.968 us   +/-60.089 (min: 1997.920 / max: 2200.160) us
time_arccosh         - case        100                    :    CPU:   11.232 us   +/- 0.294 (min:   10.943 / max:   11.627) us     GPU:   14.870 us   +/- 0.932 (min:   14.144 / max:   17.280) us
time_arccosh         - case        200                    :    CPU:   11.264 us   +/- 0.333 (min:   10.878 / max:   11.908) us     GPU:   16.499 us   +/- 5.301 (min:   14.016 / max:   32.320) us
time_arccosh         - case       5000                    :    CPU:   11.837 us   +/- 1.167 (min:   10.945 / max:   15.100) us     GPU:  521.037 us   +/- 1.583 (min:  519.936 / max:  525.664) us
time_arccosh         - case      10000                    :    CPU:   13.535 us   +/- 3.630 (min:   11.282 / max:   24.185) us     GPU: 2044.358 us   +/- 4.015 (min: 2041.632 / max: 2056.224) us
time_arcsin          - case        100                    :    CPU:   11.269 us   +/- 0.242 (min:   10.941 / max:   11.571) us     GPU:   14.950 us   +/- 1.017 (min:   14.080 / max:   17.728) us
time_arcsin          - case        200                    :    CPU:   11.335 us   +/- 0.333 (min:   11.019 / max:   12.200) us     GPU:   14.835 us   +/- 0.634 (min:   14.240 / max:   16.480) us
time_arcsin          - case       5000                    :    CPU:   11.921 us   +/- 1.086 (min:   11.040 / max:   14.769) us     GPU:  510.838 us   +/- 1.501 (min:  509.280 / max:  514.752) us
```

After

```
time_abs             - case        100                    :    CPU:    9.908 us   +/- 0.306 (min:    9.526 / max:   10.563) us     GPU:   13.478 us   +/- 1.623 (min:   12.256 / max:   18.208) us
time_abs             - case        200                    :    CPU:    9.803 us   +/- 0.354 (min:    9.434 / max:   10.610) us     GPU:   12.851 us   +/- 0.813 (min:   11.776 / max:   14.208) us
time_abs             - case       5000                    :    CPU:   10.415 us   +/- 1.291 (min:    9.425 / max:   13.936) us     GPU:  504.080 us   +/- 2.064 (min:  502.240 / max:  509.920) us
time_abs             - case      10000                    :    CPU:   49.897 us   +/-111.213 (min:    9.840 / max:  383.368) us     GPU: 2021.850 us   +/-116.137 (min: 1980.192 / max: 2370.144) us
time_absolute        - case        100                    :    CPU:    9.703 us   +/- 0.192 (min:    9.416 / max:    9.984) us     GPU:   12.806 us   +/- 0.463 (min:   12.224 / max:   13.920) us
time_absolute        - case        200                    :    CPU:    9.762 us   +/- 0.443 (min:    9.291 / max:   10.945) us     GPU:   12.662 us   +/- 0.580 (min:   11.936 / max:   13.760) us
time_absolute        - case       5000                    :    CPU:   10.737 us   +/- 1.059 (min:    9.669 / max:   13.553) us     GPU:  504.365 us   +/- 1.678 (min:  502.816 / max:  508.960) us
time_absolute        - case      10000                    :    CPU:   11.482 us   +/- 1.742 (min:    9.859 / max:   15.983) us     GPU: 1981.789 us   +/- 1.986 (min: 1980.160 / max: 1985.824) us
time_add             - case        100                    :    CPU:   10.519 us   +/- 0.267 (min:   10.181 / max:   10.945) us     GPU:   13.814 us   +/- 1.651 (min:   12.832 / max:   18.624) us
time_add             - case        200                    :    CPU:   10.458 us   +/- 0.377 (min:   10.047 / max:   11.189) us     GPU:   13.536 us   +/- 0.664 (min:   12.672 / max:   14.816) us
time_add             - case       5000                    :    CPU:   11.366 us   +/- 1.016 (min:   10.598 / max:   14.257) us     GPU:  505.213 us   +/- 1.536 (min:  503.744 / max:  509.504) us
time_add             - case      10000                    :    CPU:   11.578 us   +/- 1.102 (min:   10.487 / max:   14.242) us     GPU: 1983.398 us   +/- 1.550 (min: 1981.888 / max: 1987.488) us
time_arccos          - case        100                    :    CPU:    9.943 us   +/- 0.381 (min:    9.473 / max:   10.785) us     GPU:   13.315 us   +/- 1.392 (min:   12.416 / max:   17.280) us
time_arccos          - case        200                    :    CPU:    9.760 us   +/- 0.212 (min:    9.511 / max:   10.166) us     GPU:   13.011 us   +/- 0.796 (min:   12.288 / max:   15.104) us
time_arccos          - case       5000                    :    CPU:   10.284 us   +/- 1.044 (min:    9.421 / max:   13.161) us     GPU:  508.976 us   +/- 1.260 (min:  508.064 / max:  512.640) us
time_arccos          - case      10000                    :    CPU:   10.984 us   +/- 1.149 (min:    9.783 / max:   13.728) us     GPU: 1998.048 us   +/- 1.830 (min: 1996.256 / max: 2002.592) us
time_arccosh         - case        100                    :    CPU:    9.966 us   +/- 0.324 (min:    9.663 / max:   10.764) us     GPU:   13.238 us   +/- 0.883 (min:   12.672 / max:   15.744) us
time_arccosh         - case        200                    :    CPU:    9.858 us   +/- 0.289 (min:    9.388 / max:   10.328) us     GPU:   13.907 us   +/- 2.967 (min:   12.320 / max:   22.688) us
time_arccosh         - case       5000                    :    CPU:   10.337 us   +/- 1.104 (min:    9.470 / max:   13.329) us     GPU:  519.821 us   +/- 2.273 (min:  518.176 / max:  526.336) us
time_arccosh         - case      10000                    :    CPU:   11.036 us   +/- 1.060 (min:    9.893 / max:   13.633) us     GPU: 2041.782 us   +/- 1.525 (min: 2039.744 / max: 2045.664) us
time_arcsin          - case        100                    :    CPU:    9.802 us   +/- 0.289 (min:    9.514 / max:   10.345) us     GPU:   13.008 us   +/- 1.093 (min:   12.288 / max:   16.064) us
time_arcsin          - case        200                    :    CPU:    9.855 us   +/- 0.227 (min:    9.535 / max:   10.360) us     GPU:   12.909 us   +/- 0.441 (min:   12.384 / max:   14.080) us
time_arcsin          - case       5000                    :    CPU:   10.293 us   +/- 1.255 (min:    9.419 / max:   13.808) us     GPU:  509.053 us   +/- 1.702 (min:  507.872 / max:  513.984) us
```
