### PR TITLE
Add cupy.bartlett

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -575,6 +575,7 @@ from cupy.math.sumprod import cumsum  # NOQA
 from cupy.math.sumprod import nansum  # NOQA
 from cupy.math.sumprod import nanprod  # NOQA
 from cupy.math.sumprod import diff  # NOQA
+from cupy.math.window import bartlett  # NOQA
 from cupy.math.window import blackman  # NOQA
 from cupy.math.window import hamming  # NOQA
 from cupy.math.window import hanning  # NOQA

--- a/cupy/math/window.py
+++ b/cupy/math/window.py
@@ -12,11 +12,11 @@ _bartlett_kernel = core.ElementwiseKernel(
     "float32 alpha",
     "T arr",
     """
-    if(i < alpha)
-        arr = i/alpha;
+    if (i < alpha)
+        arr = i / alpha;
     else
-        arr = 2.0 - i/alpha;
-    """)
+        arr = 2.0 - i / alpha;
+    """, name="bartlett_kernel")
 
 
 def bartlett(M):

--- a/cupy/math/window.py
+++ b/cupy/math/window.py
@@ -16,7 +16,7 @@ _bartlett_kernel = core.ElementwiseKernel(
         arr = i / alpha;
     else
         arr = 2.0 - i / alpha;
-    """, name="bartlett_kernel")
+    """, name="cupy_bartlett")
 
 
 def bartlett(M):

--- a/cupy/math/window.py
+++ b/cupy/math/window.py
@@ -8,6 +8,46 @@ from cupy.creation import ranges
 from cupy.math import trigonometric
 
 
+_bartlett_kernel = core.ElementwiseKernel(
+    "float32 alpha",
+    "T arr",
+    """
+    if(i < alpha)
+        arr = i/alpha;
+    else
+        arr = 2.0 - i/alpha;
+    """)
+
+
+def bartlett(M):
+    """Returns the Bartlett window.
+
+    The Bartlett window is defined as
+
+    .. math::
+            w(n) = \\frac{2}{M-1} \\left(
+            \\frac{M-1}{2} - \\left|n - \\frac{M-1}{2}\\right|
+            \\right)
+
+    Args:
+        M (int):
+            Number of points in the output window. If zero or less, an empty
+            array is returned.
+
+    Returns:
+        ~cupy.ndarray: Output ndarray.
+
+    .. seealso:: :func:`numpy.bartlett`
+    """
+    if M == 1:
+        return cupy.array([1.])
+    if M <= 0:
+        return cupy.array([])
+    alpha = (M - 1) / 2.0
+    out = cupy.empty(M, dtype=cupy.float64)
+    return _bartlett_kernel(alpha, out)
+
+
 def blackman(M):
     """Returns the Blackman window.
 

--- a/cupy/math/window.py
+++ b/cupy/math/window.py
@@ -40,7 +40,7 @@ def bartlett(M):
     .. seealso:: :func:`numpy.bartlett`
     """
     if M == 1:
-        return cupy.array([1.])
+        return cupy.ones(1, dtype=cupy.float64)
     if M <= 0:
         return cupy.array([])
     alpha = (M - 1) / 2.0

--- a/docs/source/reference/math.rst
+++ b/docs/source/reference/math.rst
@@ -169,6 +169,7 @@ Miscellaneous
    cupy.fmax
    cupy.fmin
    cupy.nan_to_num
+   cupy.bartlett
    cupy.blackman
    cupy.hamming
    cupy.hanning

--- a/tests/cupy_tests/math_tests/test_window.py
+++ b/tests/cupy_tests/math_tests/test_window.py
@@ -6,7 +6,7 @@ from cupy import testing
 @testing.parameterize(
     *testing.product({
         'm': [0, 1, -1, 1024],
-        'name': ['blackman', 'hamming', 'hanning'],
+        'name': ['bartlett', 'blackman', 'hamming', 'hanning'],
     })
 )
 class TestWindow(unittest.TestCase):


### PR DESCRIPTION
This PR adds the function cupy.bartlett.
| size(M) |  numpy |  This PR | 
| ----------- | ----------- | ----------- |
| 10 | 0.03 | 0.04 | 
| 100 | 0.01 | 0.04 | 
1000 | 0.02 | 0.04 | 
10000 | 0.08 | 0.04 | 
100000 | 0.97 | 0.04 | 
1000000 | 8.09 | 0.15 | 
10000000 | 109.34 | 1.19 |

Benchmarks for cupy.bartlett

Additionally, while I was implementing the following PR, I saw the implementations of the blackman, hamming and hanning and think that they can be improved significantly using Elementwise kernels. Should I create a new PR for this or implement them in this PR ?