### PR TITLE
Alias of shape type

### DIFF
--- a/cupy/core/_carray.pxd
+++ b/cupy/core/_carray.pxd
@@ -4,6 +4,9 @@ from libcpp cimport vector
 from cupy.cuda cimport function
 
 
+ctypedef vector.vector[Py_ssize_t] shape_t
+ctypedef vector.vector[Py_ssize_t] strides_t
+
 DEF MAX_NDIM = 25
 
 
@@ -21,8 +24,7 @@ cdef class CArray(function.CPointer):
 
     cdef void init(
         self, void* data_ptr, Py_ssize_t data_size,
-        const vector.vector[Py_ssize_t]& shape,
-        const vector.vector[Py_ssize_t]& strides)
+        const shape_t& shape, const strides_t& strides)
 
 
 cdef struct _CIndexer:

--- a/cupy/core/_carray.pyx
+++ b/cupy/core/_carray.pyx
@@ -9,8 +9,7 @@ cdef class CArray(function.CPointer):
 
     cdef void init(
             self, void* data_ptr, Py_ssize_t data_size,
-            const vector.vector[Py_ssize_t]& shape,
-            const vector.vector[Py_ssize_t]& strides):
+            const shape_t& shape, const strides_t& strides):
         cdef size_t ndim = shape.size()
         cdef Py_ssize_t* shape_and_strides = (
             self.val.shape_and_strides)

--- a/cupy/core/_kernel.pxd
+++ b/cupy/core/_kernel.pxd
@@ -2,6 +2,7 @@ from libcpp cimport vector
 
 from cupy.core cimport _carray
 from cupy.core cimport _scalar
+from cupy.core._carray cimport shape_t
 from cupy.core.core cimport ndarray
 
 
@@ -126,17 +127,14 @@ cpdef tuple _get_arginfos(list args)
 
 cpdef str _get_kernel_params(tuple params, tuple arginfos)
 
-cdef list _broadcast(list args, tuple params, bint use_size,
-                     vector.vector[Py_ssize_t]& shape)
+cdef list _broadcast(list args, tuple params, bint use_size, shape_t& shape)
 
 cdef list _get_out_args(list out_args, tuple out_types,
-                        const vector.vector[Py_ssize_t]& out_shape,
-                        casting)
+                        const shape_t& out_shape, casting)
 
 cdef list _get_out_args_with_params(
     list out_args, tuple out_types,
-    const vector.vector[Py_ssize_t]& out_shape,
-    tuple out_params, bint is_size_specified)
+    const shape_t& out_shape, tuple out_params, bint is_size_specified)
 
 cdef _check_array_device_id(ndarray arr, int device_id)
 

--- a/cupy/core/_kernel.pyx
+++ b/cupy/core/_kernel.pyx
@@ -36,7 +36,7 @@ cpdef inline bint _is_fusing() except? -1:
     return False
 
 
-cdef inline bint _contains_zero(const vector.vector[Py_ssize_t]& v) except? -1:
+cdef inline bint _contains_zero(const shape_t& v) except? -1:
     for i in range(v.size()):
         if v[i] == 0:
             return True
@@ -263,7 +263,7 @@ cdef tuple _reduce_dims(list args, tuple params, tuple shape):
 cdef tuple _reduced_view_core(list args, tuple params, tuple shape):
     cdef int i, ax, last_ax, ndim
     cdef Py_ssize_t x, total_size
-    cdef vector.vector[Py_ssize_t] vecshape, newshape, newstrides
+    cdef shape_t vecshape, newshape, newstrides
     cdef vector.vector[int] array_indexes, axes
     cdef vector.vector[int] strides_indexes
     cdef ParameterInfo p
@@ -480,8 +480,7 @@ cdef tuple _decide_params_type_core(
     return in_types, out_types, type_map
 
 
-cdef list _broadcast(list args, tuple params, bint use_size,
-                     vector.vector[Py_ssize_t]& shape):
+cdef list _broadcast(list args, tuple params, bint use_size, shape_t& shape):
     # `shape` is an output argument
     cdef Py_ssize_t i
     cdef ParameterInfo p
@@ -528,8 +527,7 @@ cdef bint _can_cast(d1, d2, casting):
 
 
 cdef list _get_out_args(list out_args, tuple out_types,
-                        const vector.vector[Py_ssize_t]& out_shape,
-                        casting):
+                        const shape_t& out_shape, casting):
     cdef ndarray arr
     if not out_args:
         return [_ndarray_init(out_shape, t) for t in out_types]
@@ -567,12 +565,11 @@ cdef _copy_in_args_if_needed(list in_args, list out_args):
 
 
 cdef list _get_out_args_with_params(
-        list out_args, tuple out_types,
-        const vector.vector[Py_ssize_t]& out_shape,
+        list out_args, tuple out_types, const shape_t& out_shape,
         tuple out_params, bint is_size_specified):
     cdef ParameterInfo p
     cdef ndarray arr
-    cdef vector.vector[Py_ssize_t] shape
+    cdef shape_t shape
     cdef Py_ssize_t x
     if not out_args:
         for p in out_params:
@@ -724,7 +721,7 @@ cdef class ElementwiseKernel:
         cdef Py_ssize_t size, i
         cdef list in_args, out_args
         cdef tuple in_types, out_types, types, shape
-        cdef vector.vector[Py_ssize_t] vec_shape
+        cdef shape_t vec_shape
 
         size = -1
         size = kwargs.pop('size', -1)
@@ -986,7 +983,7 @@ cdef class ufunc:
 
         cdef function.Function kern
         cdef list broad_values
-        cdef vector.vector[Py_ssize_t] vec_shape
+        cdef shape_t vec_shape
         cdef tuple shape
         cdef Py_ssize_t s
 

--- a/cupy/core/_reduction.pyx
+++ b/cupy/core/_reduction.pyx
@@ -3,6 +3,7 @@ from cpython cimport sequence
 from libcpp cimport vector
 
 from cupy.core cimport _carray
+from cupy.core._carray cimport shape_t
 from cupy.core._dtype cimport get_dtype
 from cupy.core cimport _kernel
 from cupy.core._kernel cimport _broadcast
@@ -532,7 +533,7 @@ cdef class ReductionKernel(_AbstractReductionKernel):
             ``__init__`` method.
 
         """
-        cdef vector.vector[Py_ssize_t] broad_shape
+        cdef shape_t broad_shape
 
         out = kwargs.pop('out', None)
         axis = kwargs.pop('axis', None)

--- a/cupy/core/_routines_indexing.pyx
+++ b/cupy/core/_routines_indexing.pyx
@@ -9,6 +9,8 @@ from cupy.core._ufuncs import elementwise_copy
 
 from libcpp cimport vector
 
+from cupy.core._carray cimport shape_t
+from cupy.core._carray cimport strides_t
 from cupy.core cimport core
 from cupy.core cimport _routines_math as _math
 from cupy.core cimport _routines_manipulation as _manipulation
@@ -299,7 +301,8 @@ cdef tuple _prepare_advanced_indexing(ndarray a, list slice_list):
     return a, adv_slices, adv_mask
 
 cdef ndarray _simple_getitem(ndarray a, list slice_list):
-    cdef vector.vector[Py_ssize_t] shape, strides
+    cdef shape_t shape
+    cdef strides_t strides
     cdef ndarray v
     cdef Py_ssize_t i, j, offset, ndim
     cdef Py_ssize_t s_start, s_stop, s_step, dim, ind

--- a/cupy/core/_routines_manipulation.pxd
+++ b/cupy/core/_routines_manipulation.pxd
@@ -1,5 +1,7 @@
 from libcpp cimport vector
 
+from cupy.core._carray cimport shape_t
+from cupy.core._carray cimport strides_t
 from cupy.core.core cimport ndarray
 
 
@@ -25,8 +27,7 @@ cpdef ndarray _expand_dims(ndarray a, tuple axis)
 cpdef ndarray moveaxis(ndarray a, source, destination)
 cpdef ndarray rollaxis(ndarray a, Py_ssize_t axis, Py_ssize_t start=*)
 cpdef ndarray broadcast_to(ndarray array, shape)
-cpdef ndarray _reshape(ndarray self,
-                       const vector.vector[Py_ssize_t] &shape_spec)
+cpdef ndarray _reshape(ndarray self, const shape_t &shape_spec)
 cpdef ndarray _T(ndarray self)
 cpdef ndarray _transpose(ndarray self, const vector.vector[Py_ssize_t] &axes)
 cpdef ndarray _concatenate(

--- a/cupy/core/core.pxd
+++ b/cupy/core/core.pxd
@@ -3,13 +3,16 @@ from cupy.cuda cimport memory
 
 from cupy.cuda.function cimport CPointer
 from cupy.cuda.function cimport Module
+from cupy.core._carray cimport shape_t
+from cupy.core._carray cimport strides_t
+
 
 cdef class ndarray:
     cdef:
         object __weakref__
         readonly Py_ssize_t size
-        public vector.vector[Py_ssize_t] _shape
-        public vector.vector[Py_ssize_t] _strides
+        public shape_t _shape
+        public strides_t _strides
         readonly bint _c_contiguous
         readonly bint _f_contiguous
         readonly object dtype
@@ -18,8 +21,7 @@ cdef class ndarray:
         # underlying memory is UnownedMemory.
         readonly ndarray base
 
-    cdef _init_fast(self, const vector.vector[Py_ssize_t]& shape, dtype,
-                    bint c_order)
+    cdef _init_fast(self, const shape_t& shape, dtype, bint c_order)
     cpdef item(self)
     cpdef tolist(self)
     cpdef bytes tobytes(self, order=*)
@@ -76,12 +78,12 @@ cdef class ndarray:
     cpdef _update_c_contiguity(self)
     cpdef _update_f_contiguity(self)
     cpdef _update_contiguity(self)
-    cpdef _set_shape_and_strides(self, const vector.vector[Py_ssize_t]& shape,
-                                 const vector.vector[Py_ssize_t]& strides,
+    cpdef _set_shape_and_strides(self, const shape_t& shape,
+                                 const strides_t& strides,
                                  bint update_c_contiguity,
                                  bint update_f_contiguity)
-    cdef ndarray _view(self, const vector.vector[Py_ssize_t]& shape,
-                       const vector.vector[Py_ssize_t]& strides,
+    cdef ndarray _view(self, const shape_t& shape,
+                       const strides_t& strides,
                        bint update_c_contiguity,
                        bint update_f_contiguity)
     cpdef _set_contiguous_strides(
@@ -106,4 +108,4 @@ cpdef ndarray array(obj, dtype=*, bint copy=*, order=*, bint subok=*,
                     Py_ssize_t ndmin=*)
 cpdef ndarray _convert_object_with_cuda_array_interface(a)
 
-cdef ndarray _ndarray_init(const vector.vector[Py_ssize_t]& shape, dtype)
+cdef ndarray _ndarray_init(const shape_t& shape, dtype)

--- a/cupy/core/internal.pxd
+++ b/cupy/core/internal.pxd
@@ -2,6 +2,9 @@ from libcpp cimport bool as cpp_bool
 from libcpp cimport vector
 from libc.stdint cimport uint16_t
 
+from cupy.core._carray cimport shape_t
+from cupy.core._carray cimport strides_t
+
 
 cpdef Py_ssize_t prod(const vector.vector[Py_ssize_t]& args)
 
@@ -13,22 +16,21 @@ cpdef bint vector_equal(
     const vector.vector[Py_ssize_t]& x, const vector.vector[Py_ssize_t]& y)
 
 cdef void get_reduced_dims(
-    vector.vector[Py_ssize_t]& shape, vector.vector[Py_ssize_t]& strides,
-    Py_ssize_t itemsize, vector.vector[Py_ssize_t]& reduced_shape,
-    vector.vector[Py_ssize_t]& reduced_strides)
+    shape_t& shape, strides_t& strides,
+    Py_ssize_t itemsize, shape_t& reduced_shape,
+    strides_t& reduced_strides)
 
 # Computes the contiguous strides given a shape and itemsize.
 # Returns the size (total number of elements).
 cdef Py_ssize_t get_contiguous_strides_inplace(
-    const vector.vector[Py_ssize_t]& shape, vector.vector[Py_ssize_t]& strides,
+    const shape_t& shape, strides_t& strides,
     Py_ssize_t itemsize, bint is_c_contiguous)
 
 cpdef bint get_c_contiguity(
-    vector.vector[Py_ssize_t]& shape, vector.vector[Py_ssize_t]& strides,
-    Py_ssize_t itemsize)
+    shape_t& shape, strides_t& strides, Py_ssize_t itemsize)
 
-cpdef vector.vector[Py_ssize_t] infer_unknown_dimension(
-    const vector.vector[Py_ssize_t]& shape, Py_ssize_t size) except *
+cpdef shape_t infer_unknown_dimension(
+    const shape_t& shape, Py_ssize_t size) except *
 
 cpdef slice complete_slice(slice slc, Py_ssize_t dim)
 
@@ -44,6 +46,6 @@ cpdef float from_float16(uint16_t v)
 
 cdef int _normalize_order(order, cpp_bool allow_k=*) except? 0
 
-cdef _broadcast_core(list arrays, vector.vector[Py_ssize_t]& shape)
+cdef _broadcast_core(list arrays, shape_t& shape)
 
 cpdef bint _contig_axes(tuple axes)

--- a/cupy/core/internal.pyx
+++ b/cupy/core/internal.pyx
@@ -60,9 +60,8 @@ cpdef inline bint vector_equal(
 
 @cython.profile(False)
 cdef void get_reduced_dims(
-        vector.vector[Py_ssize_t]& shape, vector.vector[Py_ssize_t]& strides,
-        Py_ssize_t itemsize, vector.vector[Py_ssize_t]& reduced_shape,
-        vector.vector[Py_ssize_t]& reduced_strides):
+        shape_t& shape, strides_t& strides, Py_ssize_t itemsize,
+        shape_t& reduced_shape, strides_t& reduced_strides):
     cdef Py_ssize_t i, ndim, sh, st, prev_st, index
     ndim = shape.size()
     reduced_shape.clear()
@@ -95,8 +94,7 @@ cdef void get_reduced_dims(
 
 @cython.profile(False)
 cdef inline Py_ssize_t get_contiguous_strides_inplace(
-        const vector.vector[Py_ssize_t]& shape,
-        vector.vector[Py_ssize_t]& strides,
+        const shape_t& shape, strides_t& strides,
         Py_ssize_t itemsize, bint is_c_contiguous):
     cdef Py_ssize_t st, sh
     cdef Py_ssize_t is_nonzero_size = 1
@@ -121,8 +119,7 @@ cdef inline Py_ssize_t get_contiguous_strides_inplace(
 
 @cython.profile(False)
 cpdef inline bint get_c_contiguity(
-        vector.vector[Py_ssize_t]& shape, vector.vector[Py_ssize_t]& strides,
-        Py_ssize_t itemsize):
+        shape_t& shape, strides_t& strides, Py_ssize_t itemsize):
     cdef Py_ssize_t i, prev_i, ndim, sh, st, index
     ndim = strides.size()
     if ndim == 0 or (ndim == 1 and strides[0] == itemsize):
@@ -143,9 +140,9 @@ cpdef inline bint get_c_contiguity(
 
 
 @cython.profile(False)
-cpdef vector.vector[Py_ssize_t] infer_unknown_dimension(
-        const vector.vector[Py_ssize_t]& shape, Py_ssize_t size) except *:
-    cdef vector.vector[Py_ssize_t] ret = shape
+cpdef shape_t infer_unknown_dimension(
+        const shape_t& shape, Py_ssize_t size) except *:
+    cdef shape_t ret = shape
     cdef Py_ssize_t cnt=0, index=-1, new_size=1
     for i in range(shape.size()):
         if shape[i] < 0:
@@ -293,9 +290,9 @@ cdef inline int _normalize_order(order, cpp_bool allow_k=True) except? 0:
     return order_char
 
 
-cdef _broadcast_core(list arrays, vector.vector[Py_ssize_t]& shape):
+cdef _broadcast_core(list arrays, shape_t& shape):
     cdef Py_ssize_t i, j, s, smin, smax, a_ndim, a_sh, nd
-    cdef vector.vector[Py_ssize_t] strides
+    cdef strides_t strides
     cdef vector.vector[int] index
     cdef ndarray a
     cdef list ret

--- a/cupy/cudnn.pyx
+++ b/cupy/cudnn.pyx
@@ -7,11 +7,12 @@ import warnings
 
 import numpy
 
+from cupy.core._carray cimport shape_t
 from cupy.core cimport _routines_manipulation as _manipulation
 from cupy.core cimport core
+from cupy.core cimport internal
 from cupy.cuda cimport cudnn
 from cupy.cuda cimport device
-from cupy.core cimport internal
 from cupy.cuda cimport memory
 
 from cupy.core._ufuncs import elementwise_copy
@@ -1685,7 +1686,7 @@ def convolution_forward(
     cdef size_t conv_desc = cudnn.createConvolutionDescriptor()
 
     cdef size_t max_workspace_size = get_max_workspace_size()
-    cdef vector.vector[Py_ssize_t] b_shape
+    cdef shape_t b_shape
     cdef _Algorithm perf
     try:
         _create_tensor_descriptor(x_desc, x, format=d_layout)
@@ -1889,7 +1890,7 @@ def convolution_backward_data(
     cdef int algo
     cdef size_t max_workspace_size = get_max_workspace_size()
     cdef size_t workspace_size = 0
-    cdef vector.vector[Py_ssize_t] b_shape
+    cdef shape_t b_shape
     try:
         _create_tensor_descriptor(x_desc, x, format=d_layout)
         _create_tensor_descriptor(y_desc, y, format=d_layout)


### PR DESCRIPTION
Declare `shape_t` and `strides_t` as aliases of `vector.vector[Py_ssize_t]` for the readability.