### PR TITLE
Fix scipy version check in cupyx.scipy.fft

### DIFF
--- a/cupyx/scipy/fft/fft.py
+++ b/cupyx/scipy/fft/fft.py
@@ -17,7 +17,9 @@ __all__ = ['fft', 'ifft', 'fft2', 'ifft2', 'fftn', 'ifftn',
            'fftshift', 'ifftshift', 'fftfreq', 'rfftfreq',
            'get_fft_plan']
 
+_scipy_150 = False
 try:
+    import scipy
     import scipy.fft as _scipy_fft
 except ImportError:
     class _DummyModule:
@@ -25,15 +27,11 @@ except ImportError:
             return None
 
     _scipy_fft = _DummyModule()
-
-try:
-    from _scipy_fft._lib._pep440 import Version
-except ImportError:
-    # either _scipy_fft is _DummyModule, or scipy < 1.4.0
-    _scipy_150 = False
 else:
-    _scipy_150 = Version(_scipy_fft.version.version) >= Version('1.5.0')
+    from numpy.lib import NumpyVersion as Version
+    _scipy_150 = Version(scipy.__version__) >= Version('1.5.0')
     del Version
+    del scipy
 
 # Backend support for scipy.fft
 


### PR DESCRIPTION
It seems that the current code in `cupyx/scipy/fft/fft.py` that checks for SciPy >= 1.5.0 will always evaluate to False. 

It seems `from _scipy_fft._lib._pep440 import Version` will always fail because the `Version` function lives in  `scipy._lib._pep440`. Also, should we really be importing anything from a private `_lib` folder? (We could use an alternative like `numpy.lib.NumpyVersion` or distutils `LooseVersion` instead)

@peterbell10, can you verify if this fix looks correct to you?
