### PR TITLE
Enhancement: Performance Improvements to blackman, hanning and hamming methods

### DIFF
--- a/cupy/math/window.py
+++ b/cupy/math/window.py
@@ -8,6 +8,14 @@ from cupy.creation import ranges
 from cupy.math import trigonometric
 
 
+_blackman_kernel = core.ElementwiseKernel(
+    "float64 alpha",
+    "float64 arr",
+    """
+    arr = 0.42 - (0.5 * cos(i * alpha)) + (0.08 * cos(2 * alpha * i));
+    """)
+
+
 def blackman(M):
     """Returns the Blackman window.
 
@@ -28,13 +36,13 @@ def blackman(M):
 
     .. seealso:: :func:`numpy.blackman`
     """
-    if M < 1:
-        return from_data.array([])
     if M == 1:
-        return basic.ones(1, float)
-    n = ranges.arange(0, M)
-    return 0.42 - 0.5 * trigonometric.cos(2.0 * numpy.pi * n / (M - 1))\
-        + 0.08 * trigonometric.cos(4.0 * numpy.pi * n / (M - 1))
+        return cupy.array([1.])
+    if M <= 0:
+        return cupy.array([])
+    alpha = (numpy.pi * 2)/(M - 1)
+    out = cupy.empty(M, dtype=cupy.float64)
+    return _blackman_kernel(alpha, out)
 
 
 def hamming(M):

--- a/cupy/math/window.py
+++ b/cupy/math/window.py
@@ -9,7 +9,7 @@ from cupy.math import trigonometric
 
 
 _blackman_kernel = core.ElementwiseKernel(
-    "float64 alpha",
+    "float32 alpha",
     "float64 arr",
     """
     arr = 0.42 - (0.5 * cos(i * alpha)) + (0.08 * cos(2 * alpha * i));

--- a/cupy/math/window.py
+++ b/cupy/math/window.py
@@ -7,8 +7,8 @@ _blackman_kernel = core.ElementwiseKernel(
     "float32 alpha",
     "float64 out",
     """
-    out = 0.42 - (0.5 * cos(i * alpha)) + (0.08 * cos(2 * alpha * i));
-    """)
+    out = 0.42 - 0.5 * cos(i * alpha) + 0.08 * cos(2 * alpha * i);
+    """, name="cupy_blackman")
 
 
 def blackman(M):
@@ -32,10 +32,10 @@ def blackman(M):
     .. seealso:: :func:`numpy.blackman`
     """
     if M == 1:
-        return cupy.creation.basic.ones(1, float)
+        return cupy.ones(1, dtype=cupy.float64)
     if M <= 0:
-        return cupy.creation.from_data.array([])
-    alpha = (numpy.pi * 2)/(M - 1)
+        return cupy.array([])
+    alpha = numpy.pi * 2 / (M - 1)
     out = cupy.empty(M, dtype=cupy.float64)
     return _blackman_kernel(alpha, out)
 
@@ -45,7 +45,7 @@ _hamming_kernel = core.ElementwiseKernel(
     "float64 out",
     """
     out = 0.54 - 0.46 * cos(i * alpha);
-    """)
+    """, name="cupy_hamming")
 
 
 def hamming(M):
@@ -68,10 +68,10 @@ def hamming(M):
     .. seealso:: :func:`numpy.hamming`
     """
     if M == 1:
-        return cupy.creation.basic.ones(1, float)
+        return cupy.ones(1, dtype=cupy.float64)
     if M <= 0:
-        return cupy.creation.from_data.array([])
-    alpha = (numpy.pi * 2)/(M - 1)
+        return cupy.array([])
+    alpha = numpy.pi * 2 / (M - 1)
     out = cupy.empty(M, dtype=cupy.float64)
     return _hamming_kernel(alpha, out)
 
@@ -81,7 +81,7 @@ _hanning_kernel = core.ElementwiseKernel(
     "float64 out",
     """
     out = 0.5 - 0.5 * cos(i * alpha);
-    """)
+    """, name="cupy_hanning")
 
 
 def hanning(M):
@@ -104,10 +104,10 @@ def hanning(M):
     .. seealso:: :func:`numpy.hanning`
     """
     if M == 1:
-        return cupy.creation.basic.ones(1, float)
+        return cupy.ones(1, dtype=cupy.float64)
     if M <= 0:
-        return cupy.creation.from_data.array([])
-    alpha = (numpy.pi * 2)/(M - 1)
+        return cupy.array([])
+    alpha = numpy.pi * 2 / (M - 1)
     out = cupy.empty(M, dtype=cupy.float64)
     return _hanning_kernel(alpha, out)
 
@@ -119,7 +119,7 @@ _kaiser_kernel = core.ElementwiseKernel(
     float temp = (i - alpha) / alpha;
     arr = cyl_bessel_i0(beta * sqrt(1 - (temp * temp)));
     arr /= cyl_bessel_i0(beta);
-    """)
+    """, name="cupy_kaiser")
 
 
 def kaiser(M, beta):

--- a/cupy/math/window.py
+++ b/cupy/math/window.py
@@ -32,9 +32,9 @@ def blackman(M):
     .. seealso:: :func:`numpy.blackman`
     """
     if M == 1:
-        return cupy.array([1.])
+        return cupy.creation.basic.ones(1, float)
     if M <= 0:
-        return cupy.array([])
+        return cupy.creation.from_data.array([])
     alpha = (numpy.pi * 2)/(M - 1)
     out = cupy.empty(M, dtype=cupy.float64)
     return _blackman_kernel(alpha, out)
@@ -68,9 +68,9 @@ def hamming(M):
     .. seealso:: :func:`numpy.hamming`
     """
     if M == 1:
-        return cupy.array([1.])
+        return cupy.creation.basic.ones(1, float)
     if M <= 0:
-        return cupy.array([])
+        return cupy.creation.from_data.array([])
     alpha = (numpy.pi * 2)/(M - 1)
     out = cupy.empty(M, dtype=cupy.float64)
     return _hamming_kernel(alpha, out)
@@ -104,9 +104,9 @@ def hanning(M):
     .. seealso:: :func:`numpy.hanning`
     """
     if M == 1:
-        return cupy.array([1.])
+        return cupy.creation.basic.ones(1, float)
     if M <= 0:
-        return cupy.array([])
+        return cupy.creation.from_data.array([])
     alpha = (numpy.pi * 2)/(M - 1)
     out = cupy.empty(M, dtype=cupy.float64)
     return _hanning_kernel(alpha, out)


### PR DESCRIPTION
This PR adds performance improvements to the following methods

- cupy.blackman
- cupy.hamming
- cupy.hanning

by incorporating Elementwise kernels.

The benchmarks are as follows

for cupy.blackman
size |  numpy |  This PR |  existing |
----- | ------ | ------ | ------ |
10 | 0.03 | 0.03 | 0.39 | 
100 | 0.02 | 0.03 | 0.39 | 
1000 | 0.05 | 0.03 | 0.39 | 
10000 | 0.35 | 0.03 | 0.39 | 
100000 | 4.12 | 0.05 | 0.50 | 
1000000 | 35.42 | 0.16 | 3.25 | 
10000000 | 403.96 | 1.33 | 22.36 | 

for cupy.hamming
size |  numpy |  This PR |  existing |
----- | ------ | ------ | ------ |
10 | 0.04 | 0.04 | 0.44 | 
100 | 0.03 | 0.07 | 0.43 | 
1000 | 0.05 | 0.03 | 0.24 | 
10000 | 0.41 | 0.04 | 0.24 | 
100000 | 3.36 | 0.04 | 0.36 | 
1000000 | 28.83 | 0.15 | 1.66 | 
10000000 | 327.42 | 1.18 | 11.22 | 


for cupy.hanning
size |  numpy |  This PR |  existing |
----- | ------ | ------ | ------ |
10 | 0.14 | 0.03 | 0.20 | 
100 | 0.02 | 0.04 | 0.39 | 
1000 | 0.08 | 0.05 | 0.33 | 
10000 | 0.43 | 0.04 | 0.23 | 
100000 | 3.47 | 0.06 | 0.27 | 
1000000 | 30.60 | 0.15 | 1.64 | 
10000000 | 328.86 | 1.24 | 11.25 | 
