### PR TITLE
Ensure runtime context on a per-device basis

### DIFF
--- a/cupy/cuda/runtime.pyx
+++ b/cupy/cuda/runtime.pyx
@@ -35,10 +35,11 @@ cdef object _thread_local = threading.local()
 
 cdef class _ThreadLocal:
 
-    cdef bint context_initialized
+    cdef list context_initialized
 
     def __init__(self):
-        self.context_initialized = False
+        cdef int i
+        self.context_initialized = [False for i in range(getDeviceCount())]
 
     @staticmethod
     cdef _ThreadLocal get():
@@ -642,10 +643,11 @@ cdef _ensure_context():
     See discussion on https://github.com/cupy/cupy/issues/72 for details.
     """
     tls = _ThreadLocal.get()
-    if not tls.context_initialized:
+    cdef int dev = getDevice()
+    if not tls.context_initialized[dev]:
         # Call Runtime API to establish context on this host thread.
         memGetInfo()
-        tls.context_initialized = True
+        tls.context_initialized[dev] = True
 
 
 ##############################################################################


### PR DESCRIPTION
Close #3320.

If we need a test for this, we'll need to run it as a subprocess, because somewhere else in the test suite we'll establish contexts for all devices, and this bug won't show up (which is why we didn't see it until now). Let me know if a test is desired.

I think the overhead of extra runtime API calls like `getDevice()` and `getDeviceCount()` are very low, so performance impact, if any, can only come from the usage of a Python list. I could try to do some quick benchmarks if desired, but I think this bug definitely needs to be fixed one way or another.