### PR TITLE
Fix `put` when using scalars

### DIFF
--- a/cupy/core/_routines_indexing.pyx
+++ b/cupy/core/_routines_indexing.pyx
@@ -113,11 +113,11 @@ cdef ndarray _ndarray_put(ndarray self, indices, values, mode):
 
     n = self.size
     if not isinstance(indices, ndarray):
-        indices = ndarray(indices)
+        indices = core.array(indices)
     indices = indices.ravel()
 
     if not isinstance(values, ndarray):
-        values = ndarray(values, dtype=self.dtype)
+        values = core.array(values, dtype=self.dtype)
     if values.size == 0:
         return
 

--- a/tests/cupy_tests/indexing_tests/test_insert.py
+++ b/tests/cupy_tests/indexing_tests/test_insert.py
@@ -82,6 +82,32 @@ class TestPut(unittest.TestCase):
 
 
 @testing.parameterize(*testing.product({
+    'shape': [(7,), (2, 3), (4, 3, 2)],
+}))
+@testing.gpu
+class TestPutScalars(unittest.TestCase):
+
+    @testing.numpy_cupy_array_equal()
+    def test_put_index_scalar(self, xp):
+        dtype = cupy.float32
+        a = testing.shaped_arange(self.shape, xp, dtype)
+        inds = 4
+        vals = testing.shaped_random((4,), xp, dtype)
+        xp.put(a, inds, vals)
+        return a
+
+    @testing.numpy_cupy_array_equal()
+    def test_put_values_scalar(self, xp):
+        dtype = cupy.float32
+        a = testing.shaped_arange(self.shape, xp, dtype)
+        # Take care so that actual indices don't overlap.
+        inds = xp.array([2, 3, 5])
+        vals = 3.0
+        xp.put(a, inds, vals)
+        return a
+
+
+@testing.parameterize(*testing.product({
     'shape': [(7,), (2, 3)],
 }))
 @testing.gpu


### PR DESCRIPTION
Closes #3325

When using scalars calling put,
`ndarray` is called, but `ndarray` takes the shape as parameter  instead of the actual data,
creating incorrect arrays.
