### PR TITLE
Support multiple architectures in `CUPY_NVCC_GENERATE_CODE`

### DIFF
--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -762,7 +762,8 @@ def _nvcc_gencode_options(cuda_version):
 
     envcfg = os.getenv('CUPY_NVCC_GENERATE_CODE', None)
     if envcfg:
-        return ['--generate-code={}'.format(envcfg)]
+        return ['--generate-code={}'.format(arch)
+                for arch in envcfg.split(';') if len(arch) > 0]
 
     # The arch_list specifies virtual architectures, such as 'compute_61', and
     # real architectures, such as 'sm_61', for which the CUDA input files are

--- a/docs/source/reference/environment.rst
+++ b/docs/source/reference/environment.rst
@@ -74,6 +74,8 @@ These environment variables are used during installation (building CuPy from sou
 |                             | further detail.                                                |
 +-----------------------------+----------------------------------------------------------------+
 | ``CUPY_NVCC_GENERATE_CODE`` | To build CuPy for a particular CUDA architecture. For example, |
-|                             | ``CUPY_NVCC_GENERATE_CODE=arch=compute_60,code=sm_60``. When   |
-|                             | this is not set, the default is to support all architectures.  |
+|                             | ``CUPY_NVCC_GENERATE_CODE="arch=compute_60,code=sm_60"``. For  |
+|                             | specifying multiple archs, concatenate the ``arch=...`` strings|
+|                             | with semicolons (``;``). When this is not set, the default is  |
+|                             | to support all architectures.                                  |
 +-----------------------------+----------------------------------------------------------------+


### PR DESCRIPTION
Close #3317.