### PR TITLE
[backport] Remove upper restrictions for numpy and scipy in doc build

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
 Cython==0.28.3
-numpy >=1.15, <1.16
-scipy >=1.1, <1.2
+numpy >=1.15
+scipy >=1.1


### PR DESCRIPTION
Backport of #3337