### PR TITLE
Make `testing.multi_gpu()` respect device counts

### DIFF
--- a/cupy/testing/attr.py
+++ b/cupy/testing/attr.py
@@ -1,6 +1,8 @@
 import os
 import unittest
 
+import cupy
+
 
 try:
     import pytest
@@ -55,7 +57,8 @@ def multi_gpu(gpu_num):
 
     check_available()
     return unittest.skipIf(
-        0 <= _gpu_limit < gpu_num,
+        0 <= _gpu_limit < gpu_num or
+        gpu_num > cupy.cuda.runtime.getDeviceCount(),
         reason='{} GPUs required'.format(gpu_num))
 
 


### PR DESCRIPTION
On systems with 1 GPU but  `CUPY_TEST_GPU_LIMIT` is unset, or with multiple GPUs but some of them are made invisible (by setting `CUDA_VISIBLE_DEVICES`), tests decorated by `@testing.multi_gpu()` might fail.