### PR TITLE
[backport] Support all dtypes in every sorting function in `cupy.cuda.thrust`

### DIFF
--- a/cupy/cuda/common.pxd
+++ b/cupy/cuda/common.pxd
@@ -1,5 +1,7 @@
 # distutils: language = c++
 
+from libcpp cimport bool as bool_t
+
 cdef extern from '../cuda/cupy_common.h':  # thru parent to import in core
     ctypedef char cpy_byte
     ctypedef unsigned char cpy_ubyte
@@ -11,3 +13,6 @@ cdef extern from '../cuda/cupy_common.h':  # thru parent to import in core
     ctypedef unsigned long long cpy_ulong
     ctypedef float cpy_float
     ctypedef double cpy_double
+    ctypedef struct cpy_complex64 'cuComplex'
+    ctypedef struct cpy_complex128 'cuDoubleComplex'
+    ctypedef bool_t cpy_bool 'bool'

--- a/cupy/cuda/cupy_common.h
+++ b/cupy/cuda/cupy_common.h
@@ -1,5 +1,12 @@
-#ifndef INCLUDE_GUARD_CUPY_CUDA_COMMON_H
-#define INCLUDE_GUARD_CUPY_CUDA_COMMON_H
+#ifndef INCLUDE_GUARD_CUPY_COMMON_H
+#define INCLUDE_GUARD_CUPY_COMMON_H
+
+#include "cupy_cuComplex.h"
+/*
+   cuda_fp16.h should only be included in C++ codes that actually
+   need __half. For bookkeeping purposes, in Cython codes we simply
+   use cupy.float16.
+*/
 
 typedef char cpy_byte;
 typedef unsigned char cpy_ubyte;
@@ -11,5 +18,9 @@ typedef long long cpy_long;
 typedef unsigned long long cpy_ulong;
 typedef float cpy_float;
 typedef double cpy_double;
+typedef cuComplex cpy_complex64;
+typedef cuDoubleComplex cpy_complex128;
+typedef bool cpy_bool;
 
-#endif // INCLUDE_GUARD_CUPY_CUDA_COMMON_H
+
+#endif // INCLUDE_GUARD_CUPY_COMMON_H

--- a/cupy/cuda/cupy_thrust.h
+++ b/cupy/cuda/cupy_thrust.h
@@ -17,6 +17,16 @@ template <typename T>
 void _argsort(size_t *, void *, void *, const std::vector<ptrdiff_t>&, size_t,
               void *);
 
+/*
+   The functions with the suffix _fp16 are used only when certain conditions are met
+*/
+void _sort_fp16(void *, size_t *, const std::vector<ptrdiff_t>&, size_t, void *);
+
+void _lexsort_fp16(size_t *, void *, size_t, size_t, size_t, void *);
+
+void _argsort_fp16(size_t *, void *, void *, const std::vector<ptrdiff_t>&, size_t,
+                   void *);
+
 } // namespace thrust
 
 } // namespace cupy
@@ -43,6 +53,16 @@ template <typename T>
 void _argsort(size_t *, void *, void *, const std::vector<ptrdiff_t>&, size_t,
               void *) {
     return;
+}
+
+void _sort_fp16(void *, size_t *, const std::vector<ptrdiff_t>&, size_t, void *) {
+}
+
+void _lexsort_fp16(size_t *, void *, size_t, size_t, size_t, void *) {
+}
+
+void _argsort_fp16(size_t *, void *, void *, const std::vector<ptrdiff_t>&, size_t,
+                   void *) {
 }
 
 } // namespace thrust

--- a/tests/cupy_tests/sorting_tests/test_sort.py
+++ b/tests/cupy_tests/sorting_tests/test_sort.py
@@ -39,30 +39,18 @@ class TestSort(unittest.TestCase):
 
     # Test dtypes
 
-    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=False)
+    @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_sort_dtype(self, xp, dtype):
         a = testing.shaped_random((10,), xp, dtype)
         a.sort()
         return a
 
-    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=False)
+    @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_external_sort_dtype(self, xp, dtype):
         a = testing.shaped_random((10,), xp, dtype)
         return xp.sort(a)
-
-    @testing.for_dtypes([numpy.float16, numpy.bool_])
-    def test_sort_unsupported_dtype(self, dtype):
-        a = testing.shaped_random((10,), cupy, dtype)
-        with self.assertRaises(NotImplementedError):
-            a.sort()
-
-    @testing.for_dtypes([numpy.float16, numpy.bool_])
-    def test_external_sort_unsupported_dtype(self, dtype):
-        a = testing.shaped_random((10,), cupy, dtype)
-        with self.assertRaises(NotImplementedError):
-            return cupy.sort(a)
 
     # Test contiguous arrays
 
@@ -160,6 +148,16 @@ class TestSort(unittest.TestCase):
         with self.assertRaises(cupy.core._AxisError):
             cupy.sort(a, axis=-4)
 
+    # Test NaN ordering
+
+    @testing.for_dtypes('efdFD')
+    @testing.numpy_cupy_allclose()
+    def test_nan(self, xp, dtype):
+        a = testing.shaped_random((10,), xp, dtype)
+        a[2] = a[6] = xp.nan
+        a.sort()
+        return a
+
 
 @testing.gpu
 class TestLexsort(unittest.TestCase):
@@ -191,17 +189,23 @@ class TestLexsort(unittest.TestCase):
 
     # Test dtypes
 
-    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=False)
+    @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_lexsort_dtype(self, xp, dtype):
         a = testing.shaped_random((2, 10), xp, dtype)
         return xp.lexsort(a)
 
-    @testing.for_dtypes([numpy.float16, numpy.bool_])
-    def test_lexsort_unsupported_dtype(self, dtype):
-        a = testing.shaped_random((2, 10), cupy, dtype)
-        with self.assertRaises(TypeError):
-            return cupy.lexsort(a)
+    # Test NaN ordering
+    # TODO(leofang): test two more cases after #3232 is fixed
+    # 1. a[1, 2] = a[1, 6] = xp.nan
+    # 2. a[0, 2] = a[1, 6] = xp.nan
+
+    @testing.for_dtypes('efdFD')
+    @testing.numpy_cupy_allclose()
+    def test_nan(self, xp, dtype):
+        a = testing.shaped_random((2, 10), xp, dtype)
+        a[0, 2] = a[0, 6] = xp.nan
+        return xp.lexsort(a)
 
 
 @testing.parameterize(*testing.product({
@@ -219,21 +223,19 @@ class TestArgsort(unittest.TestCase):
 
     # Test base cases
 
-    # TODO(niboshi): Fix xfail
-    @pytest.mark.xfail(reason='Explicit error types required')
-    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=False)
-    @testing.numpy_cupy_raises()
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
     def test_argsort_zero_dim(self, xp, dtype):
         a = testing.shaped_random((), xp, dtype)
         return self.argsort(a)
 
-    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=False)
+    @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_argsort_one_dim(self, xp, dtype):
         a = testing.shaped_random((10,), xp, dtype)
         return self.argsort(a)
 
-    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=False)
+    @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_argsort_multi_dim(self, xp, dtype):
         a = testing.shaped_random((2, 3, 3), xp, dtype)
@@ -243,14 +245,6 @@ class TestArgsort(unittest.TestCase):
     def test_argsort_non_contiguous(self, xp):
         a = xp.array([1, 0, 2, 3])[::2]
         return self.argsort(a)
-
-    # Test unsupported dtype
-
-    @testing.for_dtypes([numpy.float16, numpy.bool_])
-    def test_argsort_unsupported_dtype(self, dtype):
-        a = testing.shaped_random((10,), cupy, dtype)
-        with self.assertRaises(NotImplementedError):
-            return self.argsort(a)
 
     # Test axis
 
@@ -305,6 +299,15 @@ class TestArgsort(unittest.TestCase):
         self.argsort(a)
         testing.assert_allclose(a, b)
 
+    # Test NaN ordering
+
+    @testing.for_dtypes('efdFD')
+    @testing.numpy_cupy_allclose()
+    def test_nan(self, xp, dtype):
+        a = testing.shaped_random((10,), xp, dtype)
+        a[2] = a[6] = xp.nan
+        return xp.argsort(a)
+
 
 @testing.gpu
 class TestMsort(unittest.TestCase):
@@ -318,25 +321,17 @@ class TestMsort(unittest.TestCase):
         a = testing.shaped_random((), xp)
         return xp.msort(a)
 
-    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=False)
+    @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_msort_one_dim(self, xp, dtype):
         a = testing.shaped_random((10,), xp, dtype)
         return xp.msort(a)
 
-    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=False)
+    @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_msort_multi_dim(self, xp, dtype):
         a = testing.shaped_random((2, 3), xp, dtype)
         return xp.msort(a)
-
-    # Test unsupported dtype
-
-    @testing.for_dtypes([numpy.float16, numpy.bool_])
-    def test_msort_unsupported_dtype(self, dtype):
-        a = testing.shaped_random((10,), cupy, dtype)
-        with self.assertRaises(NotImplementedError):
-            return cupy.msort(a)
 
 
 @testing.parameterize(*testing.product({
@@ -364,12 +359,9 @@ class TestPartition(unittest.TestCase):
         kth = 2
         return self.partition(a, kth)
 
-    @testing.for_all_dtypes(no_complex=True)
+    @testing.for_all_dtypes()
     @testing.numpy_cupy_equal()
     def test_partition_one_dim(self, xp, dtype):
-        if self.length == 10 and dtype in [xp.float16, xp.bool_]:
-            return cupy.zeros(1)  # dummy
-
         a = testing.shaped_random((self.length,), xp, dtype)
         kth = 2
         x = self.partition(a, kth)
@@ -377,31 +369,15 @@ class TestPartition(unittest.TestCase):
         self.assertTrue(xp.all(x[kth:kth + 1] <= x[kth + 1:]))
         return x[kth]
 
-    @testing.for_all_dtypes(no_complex=True)
+    @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_partition_multi_dim(self, xp, dtype):
-        if self.length == 10 and dtype in [xp.float16, xp.bool_]:
-            return cupy.zeros(1)  # dummy
-
         a = testing.shaped_random((10, 10, self.length), xp, dtype)
         kth = 2
         x = self.partition(a, kth)
         self.assertTrue(xp.all(x[:, :, 0:kth] <= x[:, :, kth:kth + 1]))
         self.assertTrue(xp.all(x[:, :, kth:kth + 1] <= x[:, :, kth + 1:]))
         return x[:, :, kth:kth + 1]
-
-    # Test unsupported dtype
-
-    @testing.for_dtypes([numpy.float16, numpy.bool_, numpy.complex64,
-                         numpy.complex128])
-    def test_partition_unsupported_dtype(self, dtype):
-        if self.length != 10 and not cupy.issubdtype(dtype, complex):
-            return
-
-        a = testing.shaped_random((self.length,), cupy, dtype)
-        kth = 2
-        with self.assertRaises(NotImplementedError):
-            return self.partition(a, kth)
 
     # Test non-contiguous array
 
@@ -531,7 +507,7 @@ class TestArgpartition(unittest.TestCase):
         kth = 2
         return self.argpartition(a, kth)
 
-    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
+    @testing.for_all_dtypes()
     @testing.numpy_cupy_equal()
     def test_argpartition_one_dim(self, xp, dtype):
         a = testing.shaped_random((10,), xp, dtype, 100)
@@ -541,7 +517,9 @@ class TestArgpartition(unittest.TestCase):
         self.assertTrue((a[idx[kth]] < a[idx[kth + 1:]]).all())
         return idx[kth]
 
-    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
+    # TODO(leofang): test all dtypes -- this workaround needs to be kept,
+    # likely due to #3287? Need investigation.
+    @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_array_equal()
     def test_argpartition_multi_dim(self, xp, dtype):
         a = testing.shaped_random((3, 3, 10), xp, dtype, 100)
@@ -554,15 +532,6 @@ class TestArgpartition(unittest.TestCase):
         self.assertTrue((a[rows, cols, idx[:, :, kth:kth + 1]] <
                          a[rows, cols, idx[:, :, kth + 1:]]).all())
         return idx[:, :, kth:kth + 1]
-
-    # Test unsupported dtype
-
-    @testing.for_dtypes([numpy.float16, numpy.bool_])
-    def test_argpartition_unsupported_dtype(self, dtype):
-        a = testing.shaped_random((10,), cupy, dtype, 100)
-        kth = 2
-        with self.assertRaises(NotImplementedError):
-            return self.argpartition(a, kth)
 
     # Test non-contiguous array
 


### PR DESCRIPTION
Backport of #3286