### PR TITLE
Fix `_count_non_nan` datatype for windows

### DIFF
--- a/cupy/core/_dtype.pyx
+++ b/cupy/core/_dtype.pyx
@@ -14,7 +14,7 @@ all_type_chars = '?bhilqBHILQefdFD'
 # B ... uint8
 # H ... uint16
 # I ... uint32
-# L ... uint64  (uint32 in windows0
+# L ... uint64  (uint32 in windows)
 # Q ... uint64
 # e ... float16
 # f ... float32

--- a/cupy/core/_dtype.pyx
+++ b/cupy/core/_dtype.pyx
@@ -9,12 +9,12 @@ all_type_chars = '?bhilqBHILQefdFD'
 # b ... int8
 # h ... int16
 # i ... int32
-# l ... int64
+# l ... int64  (int32 in windows)
 # q ... int64
 # B ... uint8
 # H ... uint16
 # I ... uint32
-# L ... uint64
+# L ... uint64  (uint32 in windows0
 # Q ... uint64
 # e ... float16
 # f ... float32

--- a/cupy/core/_routines_statistics.pyx
+++ b/cupy/core/_routines_statistics.pyx
@@ -521,7 +521,7 @@ cdef _nanmean_func = create_reduction_func(
 
 _count_non_nan = create_reduction_func(
     'cupy_count_non_nan',
-    ('e->l', 'f->l', 'd->l'),
+    ('e->q', 'f->q', 'd->q'),
     ('isnan(in0) ? 0 : 1', 'a + b', 'out0 = a', None), 0)
 
 


### PR DESCRIPTION
Closes #2780 

dtype `l` is `int32` in windows and `int64` in linux causing `_count_non_nan` to return different types. 
This value is then passed as parameter to _nanvar_core which explicitly declares it as `int64 _count` in its args list.

Fix it by using the datatype `q` which is int64 in both, windows and linux.
The test suite detects this error when running in windows.

I think we should change several of the `l`s in the code base to `q`s to avoid different behaviors