### PR TITLE
Fix `linalg.svd` for 0-sized matrices

### DIFF
--- a/cupy/linalg/decomposition.py
+++ b/cupy/linalg/decomposition.py
@@ -349,6 +349,20 @@ def svd(a, full_matrices=True, compute_uv=True):
     # Remark 4: Remark 2 is removed since cuda 8.0 (new!)
     n, m = a.shape
 
+    mn = min(m, n)
+    if mn == 0:
+        s = cupy.empty((0,), s_dtype)
+        if compute_uv:
+            if full_matrices:
+                u = cupy.eye(n, dtype=a_dtype)
+                vt = cupy.eye(m, dtype=a_dtype)
+            else:
+                u = cupy.empty((n, 0), dtype=a_dtype)
+                vt = cupy.empty((0, m), dtype=a_dtype)
+            return u, s, vt
+        else:
+            return s
+
     # `a` must be copied because xgesvd destroys the matrix
     if m >= n:
         x = a.astype(a_dtype, order='C', copy=True)
@@ -357,16 +371,6 @@ def svd(a, full_matrices=True, compute_uv=True):
         m, n = a.shape
         x = a.transpose().astype(a_dtype, order='C', copy=True)
         trans_flag = True
-
-    mn = min(m, n)
-    if mn == 0:
-        if compute_uv:
-            if full_matrices:
-                return cupy.eye(m, m), cupy.empty((0,)), cupy.empty((0, 0))
-            else:
-                return cupy.empty((m, 0)), cupy.empty((0,)), cupy.empty((0, 0))
-        else:
-            return cupy.empty((0,))
 
     if compute_uv:
         if full_matrices:

--- a/tests/cupy_tests/linalg_tests/test_decomposition.py
+++ b/tests/cupy_tests/linalg_tests/test_decomposition.py
@@ -138,7 +138,10 @@ class TestSVD(unittest.TestCase):
         # Check if the input matrix is not broken
         cupy.testing.assert_allclose(a_gpu, a_cpu)
 
-        self.assertEqual(len(result_gpu), len(result_cpu))
+        assert len(result_gpu) == 3
+        for i in range(3):
+            assert result_gpu[i].shape == result_cpu[i].shape
+            assert result_gpu[i].dtype == result_cpu[i].dtype
         u_cpu, s_cpu, vh_cpu = result_cpu
         u_gpu, s_gpu, vh_gpu = result_gpu
         cupy.testing.assert_allclose(s_gpu, s_cpu, atol=1e-4)
@@ -186,7 +189,7 @@ class TestSVD(unittest.TestCase):
         return result
 
     def check_rank2(self, array):
-        with self.assertRaises(numpy.linalg.LinAlgError):
+        with pytest.raises(numpy.linalg.LinAlgError):
             cupy.linalg.svd(array, full_matrices=self.full_matrices)
 
     @condition.repeat(3, 10)


### PR DESCRIPTION
Fix #2371.