### PR TITLE
Get arch per device and support CUDA 9.2+ 

### DIFF
--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -56,15 +56,18 @@ def _get_nvrtc_version():
 def _get_arch():
     # See Supported Compile Options section of NVRTC User Guide for
     # the maximum value allowed for `--gpu-architecture`.
+    # Note that the second-to-max values are used, as the max usually
+    # corresponds to Tegra/Jetson devices
+    # TODO(leofang): figure out a way to support Tegra/Jetson?
     major, minor = _get_nvrtc_version()
     if major < 9:
         # CUDA 8.0
-        _nvrtc_max_compute_capability = '62'
-    elif major < 10:
-        # CUDA 9.x
-        _nvrtc_max_compute_capability = '72'
+        _nvrtc_max_compute_capability = '52'
+    elif major < 10 or (major == 10 and minor == 0):
+        # CUDA 9.x / 10.0
+        _nvrtc_max_compute_capability = '70'
     else:
-        # CUDA 10.x
+        # CUDA 10.1 / 10.2
         _nvrtc_max_compute_capability = '75'
 
     return min(device.Device().compute_capability,

--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -14,7 +14,6 @@ from cupy.cuda import runtime
 from cupy import util
 
 _nvrtc_version = None
-_nvrtc_max_compute_capability = None
 _win32 = sys.platform.startswith('win32')
 _rdc_flags = ('--device-c', '-dc', '-rdc=true',
               '--relocatable-device-code=true')
@@ -53,18 +52,20 @@ def _get_nvrtc_version():
     return _nvrtc_version
 
 
+@util.memoize(for_each_device=True)
 def _get_arch():
-    global _nvrtc_max_compute_capability
-    if _nvrtc_max_compute_capability is None:
-        # See Supported Compile Options section of NVRTC User Guide for
-        # the maximum value allowed for `--gpu-architecture`.
-        major, minor = _get_nvrtc_version()
-        if major < 9:
-            # CUDA 7.0 / 7.5 / 8.0
-            _nvrtc_max_compute_capability = '50'
-        else:
-            # CUDA 9.0 / 9.1
-            _nvrtc_max_compute_capability = '70'
+    # See Supported Compile Options section of NVRTC User Guide for
+    # the maximum value allowed for `--gpu-architecture`.
+    major, minor = _get_nvrtc_version()
+    if major < 9:
+        # CUDA 8.0
+        _nvrtc_max_compute_capability = '62'
+    elif major < 10:
+        # CUDA 9.x
+        _nvrtc_max_compute_capability = '72'
+    else:
+        # CUDA 10.x
+        _nvrtc_max_compute_capability = '75'
 
     return min(device.Device().compute_capability,
                _nvrtc_max_compute_capability)

--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -52,13 +52,14 @@ def _get_nvrtc_version():
     return _nvrtc_version
 
 
+# Known archs for Tegra/Jetson/Xavier/etc
+_tegra_archs = ('53', '62', '72')
+
+
 @util.memoize(for_each_device=True)
 def _get_arch():
     # See Supported Compile Options section of NVRTC User Guide for
     # the maximum value allowed for `--gpu-architecture`.
-    # Note that the second-to-max values are used, as the max usually
-    # corresponds to Tegra/Jetson devices
-    # TODO(leofang): figure out a way to support Tegra/Jetson?
     major, minor = _get_nvrtc_version()
     if major < 9:
         # CUDA 8.0
@@ -70,8 +71,11 @@ def _get_arch():
         # CUDA 10.1 / 10.2
         _nvrtc_max_compute_capability = '75'
 
-    return min(device.Device().compute_capability,
-               _nvrtc_max_compute_capability)
+    arch = device.Device().compute_capability
+    if arch in _tegra_archs:
+        return arch
+    else:
+        return min(arch, _nvrtc_max_compute_capability)
 
 
 def _is_cudadevrt_needed(options):

--- a/tests/cupy_tests/cuda_tests/test_compiler.py
+++ b/tests/cupy_tests/cuda_tests/test_compiler.py
@@ -70,8 +70,8 @@ class TestNvrtcArch(unittest.TestCase):
         self.assertRaises(
             compiler.CompileException, self._compile, '73')
 
-    @unittest.skipUnless(10010 <= cuda_version(),
-                         'Requires CUDA 10.1 or later')
+    @unittest.skipUnless(10010 <= cuda_version() < 11000,
+                         'Requires CUDA 10.1 or 10.2')
     def test_compile_cuda101(self):
         # This test is intended to detect specification change in NVRTC API.
 
@@ -79,9 +79,9 @@ class TestNvrtcArch(unittest.TestCase):
         # (Do not test `compute_72` as it is for Tegra.)
         self._compile('75')
 
-        # It should fail.
+        # It should fail. (compute_80 is not supported until CUDA 11)
         self.assertRaises(
-            compiler.CompileException, self._compile, '76')
+            compiler.CompileException, self._compile, '80')
 
 
 @testing.gpu
@@ -98,7 +98,7 @@ class TestIsValidKernelName(unittest.TestCase):
     def test_valid(self):
         self.assertTrue(compiler.is_valid_kernel_name('valid_name_1'))
 
-    def test_empyt(self):
+    def test_empty(self):
         self.assertFalse(compiler.is_valid_kernel_name(''))
 
     def test_start_with_digit(self):

--- a/tests/cupy_tests/cuda_tests/test_compiler.py
+++ b/tests/cupy_tests/cuda_tests/test_compiler.py
@@ -14,6 +14,8 @@ def cuda_version():
 
 @testing.gpu
 class TestNvrtcArch(unittest.TestCase):
+    def setUp(self):
+        cupy.util.clear_memo()  # _get_arch result is cached
 
     def _check_get_arch(self, device_cc, expected_arch):
         with mock.patch('cupy.cuda.device.Device') as device_class:

--- a/tests/cupy_tests/cuda_tests/test_compiler.py
+++ b/tests/cupy_tests/cuda_tests/test_compiler.py
@@ -34,7 +34,8 @@ class TestNvrtcArch(unittest.TestCase):
         self._check_get_arch('70', '70')
         self._check_get_arch('72', '72')  # Tegra
 
-    @unittest.skipUnless(10010 <= cuda_version(), 'Requires CUDA 10.1 or later')
+    @unittest.skipUnless(10010 <= cuda_version(),
+                         'Requires CUDA 10.1 or later')
     def test_get_arch_cuda101(self):
         self._check_get_arch('75', '75')
 
@@ -69,7 +70,8 @@ class TestNvrtcArch(unittest.TestCase):
         self.assertRaises(
             compiler.CompileException, self._compile, '73')
 
-    @unittest.skipUnless(10010 <= cuda_version(), 'Requires CUDA 10.1 or later')
+    @unittest.skipUnless(10010 <= cuda_version(),
+                         'Requires CUDA 10.1 or later')
     def test_compile_cuda101(self):
         # This test is intended to detect specification change in NVRTC API.
 


### PR DESCRIPTION
I noticed the max compute capability used in the NVRTC support is slightly outdated, so I updated the values according to https://en.wikipedia.org/wiki/CUDA#GPUs_supported; I wasn't able to find a single table listing all these from CUDA's documentation, so it'd be worth double checking. 

Also, the global cache `_nvrtc_max_compute_capability` is replaced by a per-device cache to deal with heterogeneous environments (see https://github.com/cupy/cupy/issues/3292#issuecomment-616267757).