### PR TITLE
Reduce `numpy.ndarray` creation in cuTENSOR operation preparation

### DIFF
--- a/cupy/cutensor.py
+++ b/cupy/cutensor.py
@@ -221,9 +221,9 @@ def elementwise_trinary(alpha, A, desc_A, mode_A,
 
     if compute_dtype is None:
         compute_dtype = A.dtype
-    alpha = numpy.array(alpha, compute_dtype)
-    beta = numpy.array(beta, compute_dtype)
-    gamma = numpy.array(gamma, compute_dtype)
+    alpha = numpy.asarray(alpha, compute_dtype)
+    beta = numpy.asarray(beta, compute_dtype)
+    gamma = numpy.asarray(gamma, compute_dtype)
     handle = get_handle()
     cuda_dtype = get_cuda_dtype(compute_dtype)
     cutensor.elementwiseTrinary(
@@ -276,8 +276,8 @@ def elementwise_binary(alpha, A, desc_A, mode_A,
 
     if compute_dtype is None:
         compute_dtype = A.dtype
-    alpha = numpy.array(alpha, compute_dtype)
-    gamma = numpy.array(gamma, compute_dtype)
+    alpha = numpy.asarray(alpha, compute_dtype)
+    gamma = numpy.asarray(gamma, compute_dtype)
     handle = get_handle()
     cuda_dtype = get_cuda_dtype(compute_dtype)
     cutensor.elementwiseBinary(
@@ -425,8 +425,8 @@ def contraction(alpha, A, desc_A, mode_A, B, desc_B, mode_B,
     out = C
     compute_dtype = _set_compute_dtype(A.dtype, compute_dtype)
     handle = get_handle()
-    alpha = numpy.array(alpha, compute_dtype)
-    beta = numpy.array(beta, compute_dtype)
+    alpha = numpy.asarray(alpha, compute_dtype)
+    beta = numpy.asarray(beta, compute_dtype)
     desc = _create_contraction_descriptor(A, desc_A, mode_A,
                                           B, desc_B, mode_B,
                                           C, desc_C, mode_C,
@@ -492,8 +492,8 @@ def reduction(alpha, A, desc_A, mode_A, beta, C, desc_C, mode_C,
 
     out = C
     compute_dtype = _set_compute_dtype(A.dtype, compute_dtype)
-    alpha = numpy.array(alpha, compute_dtype)
-    beta = numpy.array(beta, compute_dtype)
+    alpha = numpy.asarray(alpha, compute_dtype)
+    beta = numpy.asarray(beta, compute_dtype)
     handle = get_handle()
     cutensor_dtype = get_cutensor_dtype(compute_dtype)
     ws_size = cutensor.reductionGetWorkspace(

--- a/cupy/cutensor.py
+++ b/cupy/cutensor.py
@@ -89,6 +89,10 @@ def get_cutensor_dtype(numpy_dtype):
 
 def create_mode(*mode):
     """Create the tensor mode from the given integers or characters.
+
+    Args:
+        mode (tuple of int/str): A tuple that holds the labels of the modes
+            of tensor A (e.g., if A_{x,y,z}, mode_A = {'x','y','z'})
     """
     integer_mode = []
     for x in mode:
@@ -168,24 +172,21 @@ def elementwise_trinary(alpha, A, desc_A, mode_A,
     See cupy/cuda/cutensor.elementwiseTrinary() for details.
 
     Args:
-        alpha: Scaling factor for tensor A.
+        alpha (scalar or 0-dim numpy.ndarray): Scaling factor for tensor A.
         A (cupy.ndarray): Input tensor.
         desc_A (class Descriptor): A descriptor that holds the information
             about the data type, modes, and strides of tensor A.
-        mode_A (tuple of int/str): A tuple that holds the labels of the modes
-            of tensor A (e.g., if A_{x,y,z}, mode_A = {'x','y','z'})
-        beta: Scaling factor for tensor B.
+        mode_A (cutensor.Mode): A mode object created by `create_mode`.
+        beta (scalar or 0-dim numpy.ndarray): Scaling factor for tensor B.
         B (cupy.ndarray): Input tensor.
         desc_B (class Descriptor): A descriptor that holds the information
             about the data type, modes, and strides of tensor B.
-        mode_B (tuple of int/str): A tuple that holds the labels of the modes
-            of tensor B.
-        gamma: Scaling factor for tensor C.
+        mode_B (cutensor.Mode): A mode object created by `create_mode`.
+        gamma (scalar or 0-dim numpy.ndarray): Scaling factor for tensor C.
         C (cupy.ndarray): Input tensor.
         desc_C (class Descriptor): A descriptor that holds the information
             about the data type, modes, and strides of tensor C.
-        mode_C (tuple of int/str): A tuple that holds the labels of the modes
-            of tensor C.
+        mode_C (cutensor.Mode): A mode object created by `create_mode`.
         out (cupy.ndarray): Output tensor.
         op_AB (cutensorOperator_t): Element-wise binary operator.
         op_ABC (cutensorOperator_t): Element-wise binary operator.
@@ -377,23 +378,20 @@ def contraction(alpha, A, desc_A, mode_A, B, desc_B, mode_B,
     See cupy/cuda/cutensor.contraction for details.
 
     Args:
-        alpha: Scaling factor for A * B.
+        alpha (scalar or 0-dim numpy.ndarray): Scaling factor for A * B.
         A (cupy.ndarray): Input tensor.
         desc_A (class Descriptor): A descriptor that holds the information
             about the data type, modes, and strides of tensor A.
-        mode_A (tuple of int/str): A tuple that holds the labels of the modes
-            of tensor A (e.g., if A_{x,y,z}, mode_A = {'x','y','z'})
+        mode_A (cutensor.Mode): A mode object created by `create_mode`.
         B (cupy.ndarray): Input tensor.
         desc_B (class Descriptor): A descriptor that holds the information
             about the data type, modes, and strides of tensor B.
-        mode_B (tuple of int/str): A tuple that holds the labels of the modes
-            of tensor B.
-        beta: Scaling factor for C.
+        mode_B (cutensor.Mode): A mode object created by `create_mode`.
+        beta (scalar or 0-dim numpy.ndarray): Scaling factor for C.
         C (cupy.ndarray): Input/output tensor.
         desc_C (class Descriptor): A descriptor that holds the information
             about the data type, modes, and strides of tensor C.
-        mode_C (tuple of int/str): A tuple that holds the labels of the modes
-            of tensor C.
+        mode_C (cutensor.Mode): A mode object created by `create_mode`.
         compute_dtype (numpy.dtype): Compute type for the intermediate
             computation.
         algo (cutenorAlgo_t): Allows users to select a specific algorithm.
@@ -458,20 +456,18 @@ def reduction(alpha, A, desc_A, mode_A, beta, C, desc_C, mode_C,
     See :func:`cupy.cuda.cutensor.reduction` for details.
 
     Args:
-        alpha: Scaling factor for A.
+        alpha (scalar or 0-dim numpy.ndarray): Scaling factor for A.
         A (cupy.ndarray): Input tensor.
         desc_A (class Descriptor): A descriptor that holds the information
             about the data type, modes, strides and unary operator (uop_A) of
             tensor A.
-        mode_A (tuple of int/str): A tuple that holds the labels of the modes
-            of tensor A (e.g., if A_{x,y,z}, mode_A = {'x','y','z'})
-        beta: Scaling factor for C.
+        mode_A (cutensor.Mode): A mode object created by `create_mode`.
+        beta (scalar or 0-dim numpy.ndarray): Scaling factor for C.
         C (cupy.ndarray): Input/output tensor.
         desc_C (class Descriptor): A descriptor that holds the information
             about the data type, modes, strides and unary operator (uop_C) of
             tensor C.
-        mode_C (tuple of int/str): A tuple that holds the labels of the modes
-            of tensor C.
+        mode_C (cutensor.Mode): A mode object created by `create_mode`.
         reduce_op (cutensorOperator_t): Binary operator used to reduce A.
         compute_dtype (numpy.dtype): Compute type for the intermediate
             computation.

--- a/examples/cutensor/elementwise_binary.py
+++ b/examples/cutensor/elementwise_binary.py
@@ -4,7 +4,8 @@
 import numpy
 import cupy
 from cupy import cutensor
-from cupy.cuda import stream
+import cupyx.time
+
 
 dtype = numpy.float32
 
@@ -21,32 +22,25 @@ c = c.astype(dtype)
 desc_a = cutensor.create_tensor_descriptor(a)
 desc_c = cutensor.create_tensor_descriptor(c)
 
-alpha = 1.1
-gamma = 1.3
+mode_a = cutensor.create_mode(*mode_a)
+mode_c = cutensor.create_mode(*mode_c)
+alpha = numpy.array(1.1, dtype)
+gamma = numpy.array(1.3, dtype)
 
-# rehearsal
-d = cutensor.elementwise_binary(alpha, a, desc_a, mode_a,
-                                gamma, c, desc_c, mode_c)
+perf = cupyx.time.repeat(
+    cutensor.elementwise_binary,
+    (alpha, a, desc_a, mode_a, gamma, c, desc_c, mode_c),
+    n_warmup=1, n_repeat=5)
 
-ev_start = stream.Event()
-ev_end = stream.Event()
-st = stream.Stream()
-with st:
-    # measurement
-    ev_start.record()
-    d = cutensor.elementwise_binary(alpha, a, desc_a, mode_a,
-                                    gamma, c, desc_c, mode_c)
-    ev_end.record()
-st.synchronize()
-
-elapsed_ms = stream.get_elapsed_time(ev_start, ev_end)
-transfer_byte = d.size * d.itemsize
-if alpha != 0.0:
-    transfer_byte += a.size * a.itemsize
-if gamma != 0.0:
-    transfer_byte += c.size * c.itemsize
-gbs = transfer_byte / elapsed_ms / 1e6
+itemsize = numpy.dtype(dtype).itemsize
+transfer_byte = a.size * itemsize
+if alpha.item() != 0.0:
+    transfer_byte += a.size * itemsize
+if gamma.item() != 0.0:
+    transfer_byte += c.size * itemsize
+elapsed = perf.gpu_times.mean()
+gbs = transfer_byte / elapsed / 1e9
 
 print('dtype: {}'.format(numpy.dtype(dtype).name))
-print('time (ms): {}'.format(elapsed_ms))
+print(perf)
 print('effective memory bandwidth (GB/s): {}'.format(gbs))

--- a/examples/cutensor/elementwise_trinary.py
+++ b/examples/cutensor/elementwise_trinary.py
@@ -4,7 +4,8 @@
 import numpy
 import cupy
 from cupy import cutensor
-from cupy.cuda import stream
+import cupyx.time
+
 
 dtype = numpy.float32
 
@@ -25,37 +26,31 @@ desc_a = cutensor.create_tensor_descriptor(a)
 desc_b = cutensor.create_tensor_descriptor(b)
 desc_c = cutensor.create_tensor_descriptor(c)
 
-alpha = 1.1
-beta = 1.2
-gamma = 1.3
+mode_a = cutensor.create_mode(*mode_a)
+mode_b = cutensor.create_mode(*mode_b)
+mode_c = cutensor.create_mode(*mode_c)
+alpha = numpy.array(1.1, dtype)
+beta = numpy.array(1.2, dtype)
+gamma = numpy.array(1.3, dtype)
 
-# rehearsal
-d = cutensor.elementwise_trinary(alpha, a, desc_a, mode_a,
-                                 beta,  b, desc_b, mode_b,
-                                 gamma, c, desc_c, mode_c)
+perf = cupyx.time.repeat(
+    cutensor.elementwise_trinary,
+    (alpha, a, desc_a, mode_a,
+     beta, b, desc_b, mode_b,
+     gamma, c, desc_c, mode_c),
+    n_warmup=1, n_repeat=5)
 
-ev_start = stream.Event()
-ev_end = stream.Event()
-st = stream.Stream()
-with st:
-    # measurement
-    ev_start.record()
-    d = cutensor.elementwise_trinary(alpha, a, desc_a, mode_a,
-                                     beta,  b, desc_b, mode_b,
-                                     gamma, c, desc_c, mode_c)
-    ev_end.record()
-st.synchronize()
-
-elapsed_ms = stream.get_elapsed_time(ev_start, ev_end)
-transfer_byte = d.size * d.itemsize
+itemsize = numpy.dtype(dtype).itemsize
+transfer_byte = a.size * itemsize
 if alpha != 0.0:
-    transfer_byte += a.size * a.itemsize
+    transfer_byte += a.size * itemsize
 if beta != 0.0:
-    transfer_byte += b.size * b.itemsize
+    transfer_byte += b.size * itemsize
 if gamma != 0.0:
-    transfer_byte += c.size * c.itemsize
-gbs = transfer_byte / elapsed_ms / 1e6
+    transfer_byte += c.size * itemsize
+elapsed = perf.gpu_times.mean()
+gbs = transfer_byte / elapsed / 1e9
 
 print('dtype: {}'.format(numpy.dtype(dtype).name))
-print('time (ms): {}'.format(elapsed_ms))
+print(perf)
 print('effective memory bandwidth (GB/s): {}'.format(gbs))

--- a/examples/cutensor/reduction.py
+++ b/examples/cutensor/reduction.py
@@ -4,7 +4,8 @@
 import numpy
 import cupy
 from cupy import cutensor
-from cupy.cuda import stream
+import cupyx.time
+
 
 dtype = numpy.float32
 
@@ -21,30 +22,22 @@ c = c.astype(dtype)
 desc_a = cutensor.create_tensor_descriptor(a)
 desc_c = cutensor.create_tensor_descriptor(c)
 
-alpha = 1.0
-beta = 0.1
+mode_a = cutensor.create_mode(*mode_a)
+mode_c = cutensor.create_mode(*mode_c)
+alpha = numpy.array(1.0, dtype)
+beta = numpy.array(0.1, dtype)
 
-# rehearsal
-c = cutensor.reduction(alpha, a, desc_a, mode_a,
-                       beta, c, desc_c, mode_c)
+perf = cupyx.time.repeat(
+    cutensor.reduction,
+    (alpha, a, desc_a, mode_a, beta, c, desc_c, mode_c),
+    n_warmup=1, n_repeat=5)
 
-ev_start = stream.Event()
-ev_end = stream.Event()
-st = stream.Stream()
-with st:
-    # measurement
-    ev_start.record()
-    c = cutensor.reduction(alpha, a, desc_a, mode_a,
-                           beta, c, desc_c, mode_c)
-    ev_end.record()
-st.synchronize()
-
-elapsed_ms = stream.get_elapsed_time(ev_start, ev_end)
 transfer_byte = a.size * a.itemsize + c.size * c.itemsize
 if beta != 0.0:
     transfer_byte += c.size * c.itemsize
-gbs = transfer_byte / elapsed_ms / 1e6
+elapsed = perf.gpu_times.mean()
+gbs = transfer_byte / elapsed / 1e9
 
 print('dtype: {}'.format(numpy.dtype(dtype).name))
-print('time (ms): {}'.format(elapsed_ms))
+print(perf)
 print('effective memory bandwidth (GB/s): {}'.format(gbs))

--- a/tests/cupy_tests/test_cutensor.py
+++ b/tests/cupy_tests/test_cutensor.py
@@ -27,9 +27,9 @@ class TestCuTensor(unittest.TestCase):
             (40, 30, 20), cupy, self.dtype, seed=1)
         self.c = testing.shaped_random(
             (30, 20, 40), cupy, self.dtype, seed=2)
-        self.mode_a = cutensor.create_mode('y', 'z', 'x')
-        self.mode_b = cutensor.create_mode('z', 'x', 'y')
-        self.mode_c = cutensor.create_mode('x', 'y', 'z')
+        self.mode_a = ('y', 'z', 'x')
+        self.mode_b = ('z', 'x', 'y')
+        self.mode_c = ('x', 'y', 'z')
         self.alpha = 1.1
         self.beta = 1.2
         self.gamma = 1.3
@@ -146,11 +146,10 @@ class TestCuTensor(unittest.TestCase):
 
         desc_a = cutensor.create_tensor_descriptor(self.a)
         desc_c = cutensor.create_tensor_descriptor(c)
-        mode_c = cutensor.create_mode('x')
 
         d = cutensor.reduction(
             self.alpha, self.a, desc_a, self.mode_a,
-            self.beta, c, desc_c, mode_c
+            self.beta, c, desc_c, ('x',)
         )
 
         assert c is d
@@ -172,9 +171,9 @@ class TestCuTensorDescriptor(unittest.TestCase):
             (40, 30, 20), cupy, numpy.float32, seed=1)
         self.c = testing.shaped_random(
             (30, 20, 40), cupy, numpy.float32, seed=2)
-        self.mode_a = cutensor.create_mode('y', 'z', 'x')
-        self.mode_b = cutensor.create_mode('z', 'x', 'y')
-        self.mode_c = cutensor.create_mode('x', 'y', 'z')
+        self.mode_a = ('y', 'z', 'x')
+        self.mode_b = ('z', 'x', 'y')
+        self.mode_c = ('x', 'y', 'z')
         self.alpha = 1.1
         self.beta = 1.2
         self.gamma = 1.3
@@ -225,11 +224,10 @@ class TestCuTensorDescriptor(unittest.TestCase):
 
         desc_a = cutensor.create_tensor_descriptor(self.a, ct.OP_COS)
         desc_c = cutensor.create_tensor_descriptor(c, ct.OP_TANH)
-        mode_c = cutensor.create_mode('x')
 
         d = cutensor.reduction(
             self.alpha, self.a, desc_a, self.mode_a,
-            self.beta, c, desc_c, mode_c,
+            self.beta, c, desc_c, ('x',),
             reduce_op=ct.OP_MAX
         )
 
@@ -237,6 +235,106 @@ class TestCuTensorDescriptor(unittest.TestCase):
         testing.assert_allclose(
             self.alpha * cupy.cos(self.a_transposed).max(axis=(1, 2)) +
             self.beta * cupy.tanh(c_orig),
+            d,
+            rtol=1e-6, atol=1e-6
+        )
+
+
+@unittest.skipUnless(cupy.cuda.cutensor_enabled, 'cuTensor is unavailable')
+class TestCuTensorReduceNumpyArrayCreation(unittest.TestCase):
+
+    def setUp(self):
+        self.a = testing.shaped_random(
+            (20, 40, 30), cupy, numpy.float32, seed=0)
+        self.b = testing.shaped_random(
+            (40, 30, 20), cupy, numpy.float32, seed=1)
+        self.c = testing.shaped_random(
+            (30, 20, 40), cupy, numpy.float32, seed=2)
+        self.mode_a = cutensor.create_mode('y', 'z', 'x')
+        self.mode_b = cutensor.create_mode('z', 'x', 'y')
+        self.mode_c = cutensor.create_mode('x', 'y', 'z')
+        self.alpha = numpy.array(1.1, dtype=numpy.float32)
+        self.beta = numpy.array(1.2, dtype=numpy.float32)
+        self.gamma = numpy.array(1.3, dtype=numpy.float32)
+        self.a_transposed = self.a.transpose(2, 0, 1).copy()
+        self.b_transposed = self.b.transpose(1, 2, 0).copy()
+        self.c_transposed = self.c.copy()
+
+    def test_elementwise_trinary(self):
+        desc_a = cutensor.create_tensor_descriptor(self.a)
+        desc_b = cutensor.create_tensor_descriptor(self.b)
+        desc_c = cutensor.create_tensor_descriptor(self.c)
+
+        d = cutensor.elementwise_trinary(
+            self.alpha, self.a, desc_a, self.mode_a,
+            self.beta, self.b, desc_b, self.mode_b,
+            self.gamma, self.c, desc_c, self.mode_c
+        )
+
+        assert d.dtype == numpy.float32
+
+        testing.assert_allclose(
+            self.alpha.item() * self.a_transposed +
+            self.beta.item() * self.b_transposed +
+            self.gamma.item() * self.c_transposed,
+            d,
+            rtol=1e-6, atol=1e-6
+        )
+
+    def test_elementwise_binary(self):
+        desc_a = cutensor.create_tensor_descriptor(self.a)
+        desc_c = cutensor.create_tensor_descriptor(self.c)
+
+        d = cutensor.elementwise_binary(
+            self.alpha, self.a, desc_a, self.mode_a,
+            self.gamma, self.c, desc_c, self.mode_c
+        )
+
+        assert d.dtype == numpy.float32
+
+        testing.assert_allclose(
+            self.alpha.item() * self.a_transposed +
+            self.gamma.item() * self.c_transposed,
+            d,
+            rtol=1e-6, atol=1e-6
+        )
+
+    def test_contraction(self):
+        desc_a = cutensor.create_tensor_descriptor(self.a)
+        desc_b = cutensor.create_tensor_descriptor(self.b)
+        desc_c = cutensor.create_tensor_descriptor(self.c)
+
+        d = cutensor.contraction(
+            self.alpha, self.a, desc_a, self.mode_a,
+            self.b, desc_b, self.mode_b,
+            self.beta, self.c, desc_c, self.mode_c
+        )
+
+        assert self.c is d
+        testing.assert_allclose(
+            self.alpha.item() * self.a_transposed * self.b_transposed +
+            self.beta.item() * self.c_transposed,
+            d,
+            rtol=1e-6, atol=1e-6
+        )
+
+    def test_reduction(self):
+        c = testing.shaped_random((30,), cupy, numpy.float32, seed=2)
+        c_orig = c.copy()
+
+        desc_a = cutensor.create_tensor_descriptor(self.a)
+        desc_c = cutensor.create_tensor_descriptor(c)
+        mode_c = cutensor.create_mode('x')
+
+        d = cutensor.reduction(
+            self.alpha, self.a, desc_a, self.mode_a,
+            self.beta, c, desc_c, mode_c
+        )
+
+        assert c is d
+        testing.assert_allclose(
+            self.alpha.item() * self.a_transposed.sum(axis=(1, 2)) +
+            self.beta.item() * c_orig,
             d,
             rtol=1e-6, atol=1e-6
         )

--- a/tests/cupy_tests/test_cutensor.py
+++ b/tests/cupy_tests/test_cutensor.py
@@ -27,9 +27,9 @@ class TestCuTensor(unittest.TestCase):
             (40, 30, 20), cupy, self.dtype, seed=1)
         self.c = testing.shaped_random(
             (30, 20, 40), cupy, self.dtype, seed=2)
-        self.mode_a = ('y', 'z', 'x')
-        self.mode_b = ('z', 'x', 'y')
-        self.mode_c = ('x', 'y', 'z')
+        self.mode_a = cutensor.create_mode('y', 'z', 'x')
+        self.mode_b = cutensor.create_mode('z', 'x', 'y')
+        self.mode_c = cutensor.create_mode('x', 'y', 'z')
         self.alpha = 1.1
         self.beta = 1.2
         self.gamma = 1.3
@@ -146,10 +146,11 @@ class TestCuTensor(unittest.TestCase):
 
         desc_a = cutensor.create_tensor_descriptor(self.a)
         desc_c = cutensor.create_tensor_descriptor(c)
+        mode_c = cutensor.create_mode('x')
 
         d = cutensor.reduction(
             self.alpha, self.a, desc_a, self.mode_a,
-            self.beta, c, desc_c, ('x',)
+            self.beta, c, desc_c, mode_c
         )
 
         assert c is d
@@ -171,9 +172,9 @@ class TestCuTensorDescriptor(unittest.TestCase):
             (40, 30, 20), cupy, numpy.float32, seed=1)
         self.c = testing.shaped_random(
             (30, 20, 40), cupy, numpy.float32, seed=2)
-        self.mode_a = ('y', 'z', 'x')
-        self.mode_b = ('z', 'x', 'y')
-        self.mode_c = ('x', 'y', 'z')
+        self.mode_a = cutensor.create_mode('y', 'z', 'x')
+        self.mode_b = cutensor.create_mode('z', 'x', 'y')
+        self.mode_c = cutensor.create_mode('x', 'y', 'z')
         self.alpha = 1.1
         self.beta = 1.2
         self.gamma = 1.3
@@ -224,10 +225,11 @@ class TestCuTensorDescriptor(unittest.TestCase):
 
         desc_a = cutensor.create_tensor_descriptor(self.a, ct.OP_COS)
         desc_c = cutensor.create_tensor_descriptor(c, ct.OP_TANH)
+        mode_c = cutensor.create_mode('x')
 
         d = cutensor.reduction(
             self.alpha, self.a, desc_a, self.mode_a,
-            self.beta, c, desc_c, ('x',),
+            self.beta, c, desc_c, mode_c,
             reduce_op=ct.OP_MAX
         )
 


### PR DESCRIPTION
This PR avoids creating `numpy.ndarray` for each operation.

TODO:
- [x] Fix documentations
- [x] Fix examples
- [x] Enhance test coverage