### PR TITLE
Added wrappers for `cusolverDn<t>potrfBatched` and `cusolverDn<t>potrsBatched`

### DIFF
--- a/cupy/core/core.pxd
+++ b/cupy/core/core.pxd
@@ -94,6 +94,7 @@ cdef class ndarray:
 
 cpdef ndarray _internal_ascontiguousarray(ndarray a)
 cpdef ndarray _internal_asfortranarray(ndarray a)
+cpdef ndarray _mat_ptrs(ndarray a)
 cpdef ndarray ascontiguousarray(ndarray a, dtype=*)
 cpdef ndarray asfortranarray(ndarray a, dtype=*)
 

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2466,7 +2466,7 @@ cdef _mat_ptrs_kernel = ElementwiseKernel(
     reduce_dims=False)
 
 
-cdef ndarray _mat_ptrs(ndarray a):
+cpdef ndarray _mat_ptrs(ndarray a):
     """Creates an array of pointers to matrices
     Args:
         a: A batch of matrices on GPU.

--- a/cupy/cuda/cupy_cusolver.h
+++ b/cupy/cuda/cupy_cusolver.h
@@ -224,6 +224,22 @@ cusolverStatus_t cusolverDnZpotrf(...) {
     return CUSOLVER_STATUS_SUCCESS;
 }
 
+cusolverStatus_t cusolverDnSpotrfBatched(...) {
+    return CUSOLVER_STATUS_SUCCESS;
+}
+
+cusolverStatus_t cusolverDnDpotrfBatched(...) {
+    return CUSOLVER_STATUS_SUCCESS;
+}
+
+cusolverStatus_t cusolverDnCpotrfBatched(...) {
+    return CUSOLVER_STATUS_SUCCESS;
+}
+
+cusolverStatus_t cusolverDnZpotrfBatched(...) {
+    return CUSOLVER_STATUS_SUCCESS;
+}
+
 cusolverStatus_t cusolverDnSpotrs(...) {
     return CUSOLVER_STATUS_SUCCESS;
 }
@@ -237,6 +253,22 @@ cusolverStatus_t cusolverDnCpotrs(...) {
 }
 
 cusolverStatus_t cusolverDnZpotrs(...) {
+    return CUSOLVER_STATUS_SUCCESS;
+}
+
+cusolverStatus_t cusolverDnSpotrsBatched(...) {
+    return CUSOLVER_STATUS_SUCCESS;
+}
+
+cusolverStatus_t cusolverDnDpotrsBatched(...) {
+    return CUSOLVER_STATUS_SUCCESS;
+}
+
+cusolverStatus_t cusolverDnCpotrsBatched(...) {
+    return CUSOLVER_STATUS_SUCCESS;
+}
+
+cusolverStatus_t cusolverDnZpotrsBatched(...) {
     return CUSOLVER_STATUS_SUCCESS;
 }
 

--- a/cupy/cuda/cupy_cusolver.h
+++ b/cupy/cuda/cupy_cusolver.h
@@ -106,6 +106,41 @@ cusolverStatus_t cusolverDnZgesvdjBatched(...) {
 }
 #endif // #if CUDA_VERSION < 9000
 
+#if CUDA_VERSION < 9010
+// Functions added in CUDA 9.1
+cusolverStatus_t cusolverDnSpotrfBatched(...) {
+    return CUSOLVER_STATUS_SUCCESS;
+}
+
+cusolverStatus_t cusolverDnDpotrfBatched(...) {
+    return CUSOLVER_STATUS_SUCCESS;
+}
+
+cusolverStatus_t cusolverDnCpotrfBatched(...) {
+    return CUSOLVER_STATUS_SUCCESS;
+}
+
+cusolverStatus_t cusolverDnZpotrfBatched(...) {
+    return CUSOLVER_STATUS_SUCCESS;
+}
+
+cusolverStatus_t cusolverDnSpotrsBatched(...) {
+    return CUSOLVER_STATUS_SUCCESS;
+}
+
+cusolverStatus_t cusolverDnDpotrsBatched(...) {
+    return CUSOLVER_STATUS_SUCCESS;
+}
+
+cusolverStatus_t cusolverDnCpotrsBatched(...) {
+    return CUSOLVER_STATUS_SUCCESS;
+}
+
+cusolverStatus_t cusolverDnZpotrsBatched(...) {
+    return CUSOLVER_STATUS_SUCCESS;
+}
+#endif // #if CUDA_VERSION < 9010
+
 #if CUDA_VERSION < 10010
 // Functions added in CUDA 10.1
 cusolverStatus_t cusolverDnSgesvdaStridedBatched_bufferSize(...) {

--- a/cupy/cuda/cusolver.pxd
+++ b/cupy/cuda/cusolver.pxd
@@ -105,13 +105,17 @@ cpdef zpotrfBatched(intptr_t handle, int uplo, int n, size_t Aarray, int lda,
                     size_t infoArray, int batchSize)
 
 cpdef spotrsBatched(intptr_t handle, int uplo, int n, int nrhs, size_t Aarray,
-                    int lda, size_t Barray, int ldb, size_t devInfo, int batchSize)
+                    int lda, size_t Barray, int ldb, size_t devInfo,
+                    int batchSize)
 cpdef dpotrsBatched(intptr_t handle, int uplo, int n, int nrhs, size_t Aarray,
-                    int lda, size_t Barray, int ldb, size_t devInfo, int batchSize)
+                    int lda, size_t Barray, int ldb, size_t devInfo,
+                    int batchSize)
 cpdef cpotrsBatched(intptr_t handle, int uplo, int n, int nrhs, size_t Aarray,
-                    int lda, size_t Barray, int ldb, size_t devInfo, int batchSize)
+                    int lda, size_t Barray, int ldb, size_t devInfo,
+                    int batchSize)
 cpdef zpotrsBatched(intptr_t handle, int uplo, int n, int nrhs, size_t Aarray,
-                    int lda, size_t Barray, int ldb, size_t devInfo, int batchSize)
+                    int lda, size_t Barray, int ldb, size_t devInfo,
+                    int batchSize)
 
 # LU factorization
 cpdef int sgetrf_bufferSize(intptr_t handle, int m, int n,

--- a/cupy/cuda/cusolver.pxd
+++ b/cupy/cuda/cusolver.pxd
@@ -96,6 +96,23 @@ cpdef zpotrs(intptr_t handle, int uplo, int n, int nrhs,
              size_t A, int lda, size_t B, int ldb, size_t devInfo)
 
 # TODO(anaruse): potrfBatched and potrsBatched
+cpdef spotrfBatched(intptr_t handle, int uplo, int n, size_t Aarray, int lda,
+                    size_t infoArray, int batchSize)
+cpdef dpotrfBatched(intptr_t handle, int uplo, int n, size_t Aarray, int lda,
+                    size_t infoArray, int batchSize)
+cpdef cpotrfBatched(intptr_t handle, int uplo, int n, size_t Aarray, int lda,
+                    size_t infoArray, int batchSize)
+cpdef zpotrfBatched(intptr_t handle, int uplo, int n, size_t Aarray, int lda,
+                    size_t infoArray, int batchSize)
+
+cpdef spotrsBatched(intptr_t handle, int uplo, int n, int nrhs, size_t Aarray,
+                    int lda, size_t Barray, int ldb, size_t devInfo, int batchSize)
+cpdef dpotrsBatched(intptr_t handle, int uplo, int n, int nrhs, size_t Aarray,
+                    int lda, size_t Barray, int ldb, size_t devInfo, int batchSize)
+cpdef cpotrsBatched(intptr_t handle, int uplo, int n, int nrhs, size_t Aarray,
+                    int lda, size_t Barray, int ldb, size_t devInfo, int batchSize)
+cpdef zpotrsBatched(intptr_t handle, int uplo, int n, int nrhs, size_t Aarray,
+                    int lda, size_t Barray, int ldb, size_t devInfo, int batchSize)
 
 # LU factorization
 cpdef int sgetrf_bufferSize(intptr_t handle, int m, int n,

--- a/cupy/cuda/cusolver.pxd
+++ b/cupy/cuda/cusolver.pxd
@@ -95,7 +95,6 @@ cpdef cpotrs(intptr_t handle, int uplo, int n, int nrhs,
 cpdef zpotrs(intptr_t handle, int uplo, int n, int nrhs,
              size_t A, int lda, size_t B, int ldb, size_t devInfo)
 
-# TODO(anaruse): potrfBatched and potrsBatched
 cpdef spotrfBatched(intptr_t handle, int uplo, int n, size_t Aarray, int lda,
                     size_t infoArray, int batchSize)
 cpdef dpotrfBatched(intptr_t handle, int uplo, int n, size_t Aarray, int lda,

--- a/cupy/cuda/cusolver.pyx
+++ b/cupy/cuda/cusolver.pyx
@@ -78,6 +78,35 @@ cdef extern from 'cupy_cusolver.h' nogil:
                          cuDoubleComplex* B, int ldb, int* devInfo)
 
     # TODO(anaruse): potrfBatched and potrsBatched
+    int cusolverDnSpotrfBatched(Handle handle, FillMode uplo, int n,
+                                float** Aarray, int lda,
+                                int* infoArray, int batchSize)
+    int cusolverDnDpotrfBatched(Handle handle, FillMode uplo, int n,
+                                double** Aarray, int lda,
+                                int* infoArray, int batchSize)
+    int cusolverDnCpotrfBatched(Handle handle, FillMode uplo, int n,
+                                cuComplex** Aarray, int lda,
+                                int* infoArray, int batchSize)
+    int cusolverDnZpotrfBatched(Handle handle, FillMode uplo, int n,
+                                cuDoubleComplex** Aarray, int lda,
+                                int* infoArray, int batchSize)
+
+    int cusolverDnSpotrsBatched(Handle handle, FillMode uplo, int n,
+                                int nrhs, float** Aarray, int lda,
+                                float** Barray, int ldb,
+                                int* devInfo, int batchSize)
+    int cusolverDnDpotrsBatched(Handle handle, FillMode uplo, int n,
+                                int nrhs, double** Aarray, int lda,
+                                double** Barray, int ldb,
+                                int* devInfo, int batchSize)
+    int cusolverDnCpotrsBatched(Handle handle, FillMode uplo, int n,
+                                int nrhs, cuComplex** Aarray, int lda,
+                                cuComplex** Barray, int ldb,
+                                int* devInfo, int batchSize)
+    int cusolverDnZpotrsBatched(Handle handle, FillMode uplo, int n,
+                                int nrhs, cuDoubleComplex** Aarray, int lda,
+                                cuDoubleComplex** Barray, int ldb,
+                                int* devInfo, int batchSize)
 
     # LU factorization
     int cusolverDnSgetrf_bufferSize(Handle handle, int m, int n,
@@ -793,6 +822,81 @@ cpdef zpotrs(intptr_t handle, int uplo, int n, int nrhs,
             <int*>devInfo)
     check_status(status)
 
+cpdef spotrfBatched(intptr_t handle, int uplo, int n, size_t Aarray, int lda,
+             size_t infoArray, int batchSize):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusolverDnSpotrfBatched(
+            <Handle>handle, <FillMode>uplo, n, <float**>Aarray,
+            lda, <int*>infoArray, batchSize)
+    check_status(status)
+
+cpdef dpotrfBatched(intptr_t handle, int uplo, int n, size_t Aarray, int lda,
+             size_t infoArray, int batchSize):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusolverDnDpotrfBatched(
+            <Handle>handle, <FillMode>uplo, n, <double**>Aarray,
+            lda, <int*>infoArray, batchSize)
+    check_status(status)
+
+cpdef cpotrfBatched(intptr_t handle, int uplo, int n, size_t Aarray, int lda,
+             size_t infoArray, int batchSize):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusolverDnCpotrfBatched(
+            <Handle>handle, <FillMode>uplo, n, <cuComplex**>Aarray,
+            lda, <int*>infoArray, batchSize)
+    check_status(status)
+
+cpdef zpotrfBatched(intptr_t handle, int uplo, int n, size_t Aarray, int lda,
+             size_t infoArray, int batchSize):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusolverDnZpotrfBatched(
+            <Handle>handle, <FillMode>uplo, n, <cuDoubleComplex**>Aarray,
+            lda, <int*>infoArray, batchSize)
+    check_status(status)
+
+cpdef spotrsBatched(intptr_t handle, int uplo, int n, int nrhs, size_t Aarray,
+                    int lda, size_t Barray, int ldb, size_t devInfo, int batchSize):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusolverDnSpotrsBatched(
+            <Handle>handle, <FillMode>uplo, n, nrhs,
+            <float**>Aarray, lda, <float**>Barray, ldb,
+            <int*>devInfo, batchSize)
+    check_status(status)
+
+cpdef dpotrsBatched(intptr_t handle, int uplo, int n, int nrhs, size_t Aarray,
+                    int lda, size_t Barray, int ldb, size_t devInfo, int batchSize):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusolverDnDpotrsBatched(
+            <Handle>handle, <FillMode>uplo, n, nrhs,
+            <double**>Aarray, lda, <double**>Barray, ldb,
+            <int*>devInfo, batchSize)
+    check_status(status)
+
+cpdef cpotrsBatched(intptr_t handle, int uplo, int n, int nrhs, size_t Aarray,
+                    int lda, size_t Barray, int ldb, size_t devInfo, int batchSize):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusolverDnCpotrsBatched(
+            <Handle>handle, <FillMode>uplo, n, nrhs,
+            <cuComplex**>Aarray, lda, <cuComplex**>Barray, ldb,
+            <int*>devInfo, batchSize)
+    check_status(status)
+
+cpdef zpotrsBatched(intptr_t handle, int uplo, int n, int nrhs, size_t Aarray,
+                    int lda, size_t Barray, int ldb, size_t devInfo, int batchSize):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    with nogil:
+        status = cusolverDnZpotrsBatched(
+            <Handle>handle, <FillMode>uplo, n, nrhs,
+            <cuDoubleComplex**>Aarray, lda, <cuDoubleComplex**>Barray, ldb,
+            <int*>devInfo, batchSize)
+    check_status(status)
 
 # LU factorization
 cpdef int sgetrf_bufferSize(intptr_t handle, int m, int n,

--- a/cupy/cuda/cusolver.pyx
+++ b/cupy/cuda/cusolver.pyx
@@ -77,7 +77,6 @@ cdef extern from 'cupy_cusolver.h' nogil:
                          const cuDoubleComplex* A, int lda,
                          cuDoubleComplex* B, int ldb, int* devInfo)
 
-    # TODO(anaruse): potrfBatched and potrsBatched
     int cusolverDnSpotrfBatched(Handle handle, FillMode uplo, int n,
                                 float** Aarray, int lda,
                                 int* infoArray, int batchSize)

--- a/cupy/cuda/cusolver.pyx
+++ b/cupy/cuda/cusolver.pyx
@@ -822,7 +822,7 @@ cpdef zpotrs(intptr_t handle, int uplo, int n, int nrhs,
     check_status(status)
 
 cpdef spotrfBatched(intptr_t handle, int uplo, int n, size_t Aarray, int lda,
-             size_t infoArray, int batchSize):
+                    size_t infoArray, int batchSize):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cusolverDnSpotrfBatched(
@@ -831,7 +831,7 @@ cpdef spotrfBatched(intptr_t handle, int uplo, int n, size_t Aarray, int lda,
     check_status(status)
 
 cpdef dpotrfBatched(intptr_t handle, int uplo, int n, size_t Aarray, int lda,
-             size_t infoArray, int batchSize):
+                    size_t infoArray, int batchSize):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cusolverDnDpotrfBatched(
@@ -840,7 +840,7 @@ cpdef dpotrfBatched(intptr_t handle, int uplo, int n, size_t Aarray, int lda,
     check_status(status)
 
 cpdef cpotrfBatched(intptr_t handle, int uplo, int n, size_t Aarray, int lda,
-             size_t infoArray, int batchSize):
+                    size_t infoArray, int batchSize):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cusolverDnCpotrfBatched(
@@ -849,7 +849,7 @@ cpdef cpotrfBatched(intptr_t handle, int uplo, int n, size_t Aarray, int lda,
     check_status(status)
 
 cpdef zpotrfBatched(intptr_t handle, int uplo, int n, size_t Aarray, int lda,
-             size_t infoArray, int batchSize):
+                    size_t infoArray, int batchSize):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cusolverDnZpotrfBatched(
@@ -858,7 +858,8 @@ cpdef zpotrfBatched(intptr_t handle, int uplo, int n, size_t Aarray, int lda,
     check_status(status)
 
 cpdef spotrsBatched(intptr_t handle, int uplo, int n, int nrhs, size_t Aarray,
-                    int lda, size_t Barray, int ldb, size_t devInfo, int batchSize):
+                    int lda, size_t Barray, int ldb, size_t devInfo,
+                    int batchSize):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cusolverDnSpotrsBatched(
@@ -868,7 +869,8 @@ cpdef spotrsBatched(intptr_t handle, int uplo, int n, int nrhs, size_t Aarray,
     check_status(status)
 
 cpdef dpotrsBatched(intptr_t handle, int uplo, int n, int nrhs, size_t Aarray,
-                    int lda, size_t Barray, int ldb, size_t devInfo, int batchSize):
+                    int lda, size_t Barray, int ldb, size_t devInfo,
+                    int batchSize):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cusolverDnDpotrsBatched(
@@ -878,7 +880,8 @@ cpdef dpotrsBatched(intptr_t handle, int uplo, int n, int nrhs, size_t Aarray,
     check_status(status)
 
 cpdef cpotrsBatched(intptr_t handle, int uplo, int n, int nrhs, size_t Aarray,
-                    int lda, size_t Barray, int ldb, size_t devInfo, int batchSize):
+                    int lda, size_t Barray, int ldb, size_t devInfo,
+                    int batchSize):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cusolverDnCpotrsBatched(
@@ -888,7 +891,8 @@ cpdef cpotrsBatched(intptr_t handle, int uplo, int n, int nrhs, size_t Aarray,
     check_status(status)
 
 cpdef zpotrsBatched(intptr_t handle, int uplo, int n, int nrhs, size_t Aarray,
-                    int lda, size_t Barray, int ldb, size_t devInfo, int batchSize):
+                    int lda, size_t Barray, int ldb, size_t devInfo,
+                    int batchSize):
     setStream(handle, stream_module.get_current_stream_ptr())
     with nogil:
         status = cusolverDnZpotrsBatched(

--- a/cupy/cusolver.py
+++ b/cupy/cusolver.py
@@ -9,6 +9,8 @@ from cupy.cuda import device
 _available_cuda_version = {
     'gesvdj': (9000, None),
     'gesvda': (10010, None),
+    'potrfBatched': (9010, None),
+    'potrsBatched': (9010, None),
 }
 
 

--- a/cupy/linalg/decomposition.py
+++ b/cupy/linalg/decomposition.py
@@ -4,6 +4,7 @@ import cupy
 from cupy.cuda import cublas
 from cupy.cuda import cusolver
 from cupy.cuda import device
+from cupy.cusolver import check_availability
 from cupy.linalg import util
 
 
@@ -108,6 +109,9 @@ def _potrf_batched(a):
     Returns:
         cupy.ndarray: The lower-triangular matrix.
     """
+    if not check_availability('potrfBatched'):
+        raise RuntimeError('potrfBatched is not available')
+
     if a.dtype.char == 'f' or a.dtype.char == 'd':
         dtype = a.dtype.char
     else:

--- a/cupy/linalg/decomposition.py
+++ b/cupy/linalg/decomposition.py
@@ -127,7 +127,7 @@ def _potrf_batched(a):
     n = x.shape[-1]
     ldx = x.strides[-2] // x.dtype.itemsize
     handle = device.get_cusolver_handle()
-    batch_size = int(numpy.prod(x.shape[:-2]))
+    batch_size = cupy.core.internal.prod(x.shape[:-2])
     dev_info = cupy.empty(batch_size, dtype=numpy.int32)
 
     potrfBatched(

--- a/cupy/linalg/decomposition.py
+++ b/cupy/linalg/decomposition.py
@@ -94,6 +94,51 @@ def _lu_factor(a_t, dtype):
     )
 
 
+def _potrf_batched(a):
+    """Batched Cholesky decomposition.
+
+    Decompose a given array of two-dimensional square matrices into
+    ``L * L.T``, where ``L`` is a lower-triangular matrix and ``.T``
+    is a conjugate transpose operator.
+
+    Args:
+        a (cupy.ndarray): The input array of matrices
+            with dimension ``(..., N, N)``
+
+    Returns:
+        cupy.ndarray: The lower-triangular matrix.
+    """
+    if a.dtype.char == 'f' or a.dtype.char == 'd':
+        dtype = a.dtype.char
+    else:
+        dtype = numpy.promote_types(a.dtype.char, 'f').char
+
+    if dtype == 'f':
+        potrfBatched = cusolver.spotrfBatched
+    elif dtype == 'd':
+        potrfBatched = cusolver.dpotrfBatched
+    elif dtype == 'F':
+        potrfBatched = cusolver.cpotrfBatched
+    else:  # dtype == 'D':
+        potrfBatched = cusolver.zpotrfBatched
+
+    x = a.astype(dtype, order='C', copy=True)
+    xp = cupy.core.core._mat_ptrs(x)
+    n = x.shape[-1]
+    ldx = x.strides[-2] // x.dtype.itemsize
+    handle = device.get_cusolver_handle()
+    batch_size = int(numpy.prod(x.shape[:-2]))
+    dev_info = cupy.empty(batch_size, dtype=numpy.int32)
+
+    potrfBatched(
+        handle, cublas.CUBLAS_FILL_MODE_UPPER, n, xp.data.ptr, ldx,
+        dev_info.data.ptr, batch_size)
+    cupy.linalg.util._check_cusolver_dev_info_if_synchronization_allowed(
+        potrfBatched, dev_info)
+
+    return cupy.tril(x)
+
+
 def cholesky(a):
     """Cholesky decomposition.
 
@@ -116,10 +161,11 @@ def cholesky(a):
 
     .. seealso:: :func:`numpy.linalg.cholesky`
     """
-    # TODO(Saito): Current implementation only accepts two-dimensional arrays
     util._assert_cupy_array(a)
-    util._assert_rank2(a)
     util._assert_nd_squareness(a)
+
+    if a.ndim > 2:
+        return _potrf_batched(a)
 
     if a.dtype.char == 'f' or a.dtype.char == 'd':
         dtype = a.dtype.char

--- a/cupy/linalg/util.py
+++ b/cupy/linalg/util.py
@@ -32,7 +32,6 @@ def _check_cusolver_dev_info_if_synchronization_allowed(routine, dev_info):
     # routine call. It is referred to as "infoArray" or "devInfo" in the
     # official cuSOLVER documentation.
     assert isinstance(dev_info, core.ndarray)
-    assert dev_info.ndim == 1
     config_linalg = cupyx._ufunc_config.get_config_linalg()
     # Only 'ignore' and 'raise' are currently supported.
     if config_linalg == 'ignore':

--- a/cupy/linalg/util.py
+++ b/cupy/linalg/util.py
@@ -28,23 +28,22 @@ def _assert_nd_squareness(*arrays):
 
 
 def _check_cusolver_dev_info_if_synchronization_allowed(routine, dev_info):
-    # `dev_info` contains a single integer, the status code of a cuSOLVER
-    # routine call. It is referred to as "devInfo" in the official cuSOLVER
-    # documentation.
+    # `dev_info` contains integers, the status code of a cuSOLVER
+    # routine call. It is referred to as "infoArray" or "devInfo" in the
+    # official cuSOLVER documentation.
     assert isinstance(dev_info, core.ndarray)
-    assert dev_info.size == 1
+    assert dev_info.ndim == 1
     config_linalg = cupyx._ufunc_config.get_config_linalg()
     # Only 'ignore' and 'raise' are currently supported.
     if config_linalg == 'ignore':
         return
 
     assert config_linalg == 'raise'
-    dev_info_host = dev_info.item()
-    if dev_info_host != 0:
+    if (dev_info != 0).any():
         raise linalg.LinAlgError(
             'Error reported by {} in cuSOLVER. devInfo = {}. Please refer'
             ' to the cuSOLVER documentation.'.format(
-                routine.__name__, dev_info_host))
+                routine.__name__, dev_info))
 
 
 def _check_cublas_info_array_if_synchronization_allowed(routine, info_array):

--- a/cupyx/linalg/solve.py
+++ b/cupyx/linalg/solve.py
@@ -60,7 +60,8 @@ def _batched_invh(a):
         potrfBatched, dev_info)
 
     identity_matrix = cupy.eye(n, dtype=dtype)
-    b = cupy.tile(identity_matrix, (*a.shape[:-2], 1, 1))
+    b = cupy.empty(a.shape, dtype)
+    b[...] = identity_matrix
     nrhs = b.shape[-1]
     ldb = b.strides[-2] // a.dtype.itemsize
     bp = cupy.core.core._mat_ptrs(b)

--- a/cupyx/linalg/solve.py
+++ b/cupyx/linalg/solve.py
@@ -7,6 +7,74 @@ from cupy.cuda import device
 from cupy.linalg import util
 
 
+def _batched_invh(a):
+    """Compute the inverse of an array of Hermitian matrices.
+
+    This function computes an inverse of a real symmetric or complex hermitian
+    positive-definite matrix using Cholesky factorization. If matrix ``a[i]``
+    is not positive definite, Cholesky factorization fails and it raises
+    an error.
+
+    Args:
+        a (cupy.ndarray): Array of real symmetric or complex hermitian
+            matrices with dimension (..., N, N).
+
+    Returns:
+        cupy.ndarray: The array of inverses of matrices ``a[i]``.
+    """
+    if a.dtype.char == 'f' or a.dtype.char == 'd':
+        dtype = a.dtype.char
+    else:
+        dtype = numpy.promote_types(a.dtype.char, 'f').char
+
+    if dtype == 'f':
+        potrfBatched = cusolver.spotrfBatched
+        potrsBatched = cusolver.spotrsBatched
+    elif dtype == 'd':
+        potrfBatched = cusolver.dpotrfBatched
+        potrsBatched = cusolver.dpotrsBatched
+    elif dtype == 'F':
+        potrfBatched = cusolver.cpotrfBatched
+        potrsBatched = cusolver.cpotrsBatched
+    elif dtype == 'D':
+        potrfBatched = cusolver.zpotrfBatched
+        potrsBatched = cusolver.zpotrsBatched
+    else:
+        msg = ('dtype must be float32, float64, complex64 or complex128'
+               ' (actual: {})'.format(a.dtype))
+        raise ValueError(msg)
+
+    a = a.astype(dtype, order='C', copy=True)
+    ap = cupy.core.core._mat_ptrs(a)
+    n = a.shape[-1]
+    lda = a.strides[-2] // a.dtype.itemsize
+    handle = device.get_cusolver_handle()
+    uplo = cublas.CUBLAS_FILL_MODE_LOWER
+    batch_size = int(numpy.prod(a.shape[:-2]))
+    dev_info = cupy.empty(batch_size, dtype=numpy.int32)
+
+    # Cholesky factorization
+    potrfBatched(handle, uplo, n, ap.data.ptr, lda, dev_info.data.ptr,
+                 batch_size)
+    cupy.linalg.util._check_cusolver_dev_info_if_synchronization_allowed(
+        potrfBatched, dev_info)
+
+    identity_matrix = cupy.eye(n, dtype=dtype)
+    b = cupy.tile(identity_matrix, (*a.shape[:-2], 1, 1))
+    nrhs = b.shape[-1]
+    ldb = b.strides[-2] // a.dtype.itemsize
+    bp = cupy.core.core._mat_ptrs(b)
+    dev_info = cupy.empty(1, dtype=numpy.int32)
+
+    # NOTE: potrsBatched does not currently support nrhs > 1 (CUDA v10.2)
+    # Solve: A[i] * X[i] = B[i]
+    potrsBatched(handle, uplo, n, nrhs, ap.data.ptr, lda, bp.data.ptr, ldb,
+                 dev_info.data.ptr, batch_size)
+    cupy.linalg.util._check_cusolver_dev_info_if_synchronization_allowed(
+        potrfBatched, dev_info)
+
+    return b
+
 def invh(a):
     """Compute the inverse of a Hermitian matrix.
 
@@ -21,12 +89,16 @@ def invh(a):
         cupy.ndarray: The inverse of matrix ``a``.
     """
 
+    util._assert_cupy_array(a)
+    util._assert_nd_squareness(a)
+
+    # TODO: Remove this assert once cusolver supports nrhs > 1 for potrsBatched
+    util._assert_rank2(a)
+    if a.ndim > 2:
+        _batched_invh(a)
+
     # to prevent `a` from being overwritten
     a = a.copy()
-
-    util._assert_cupy_array(a)
-    util._assert_rank2(a)
-    util._assert_nd_squareness(a)
 
     # support float32, float64, complex64, and complex128
     if a.dtype.char in 'fdFD':

--- a/cupyx/linalg/solve.py
+++ b/cupyx/linalg/solve.py
@@ -4,6 +4,7 @@ import cupy
 from cupy.cuda import cublas
 from cupy.cuda import cusolver
 from cupy.cuda import device
+from cupy.cusolver import check_availability
 from cupy.linalg import util
 
 
@@ -22,6 +23,9 @@ def _batched_invh(a):
     Returns:
         cupy.ndarray: The array of inverses of matrices ``a[i]``.
     """
+    if not check_availability('potrsBatched'):
+        raise RuntimeError('potrsBatched is not available')
+
     if a.dtype.char == 'f' or a.dtype.char == 'd':
         dtype = a.dtype.char
     else:

--- a/cupyx/linalg/solve.py
+++ b/cupyx/linalg/solve.py
@@ -96,7 +96,7 @@ def invh(a):
     # TODO: Remove this assert once cusolver supports nrhs > 1 for potrsBatched
     util._assert_rank2(a)
     if a.ndim > 2:
-        _batched_invh(a)
+        return _batched_invh(a)
 
     # to prevent `a` from being overwritten
     a = a.copy()

--- a/cupyx/linalg/solve.py
+++ b/cupyx/linalg/solve.py
@@ -75,6 +75,7 @@ def _batched_invh(a):
 
     return b
 
+
 def invh(a):
     """Compute the inverse of a Hermitian matrix.
 

--- a/tests/cupy_tests/linalg_tests/test_decomposition.py
+++ b/tests/cupy_tests/linalg_tests/test_decomposition.py
@@ -4,6 +4,7 @@ import numpy
 import pytest
 
 import cupy
+from cupy import cusolver
 from cupy import testing
 from cupy.testing import condition
 import cupyx
@@ -66,6 +67,8 @@ class TestCholeskyDecomposition(unittest.TestCase):
         numpy.int32, numpy.int64, numpy.uint32, numpy.uint64,
         numpy.float32, numpy.float64, numpy.complex64, numpy.complex128])
     def test_batched_decomposition(self, dtype):
+        if not cusolver.check_availability('potrfBatched'):
+            pytest.skip('potrfBatched is not available')
         Ab1 = random_matrix((3, 5, 5), dtype, scale=(10, 10000), sym=True)
         self.check_L(Ab1)
         Ab2 = random_matrix((2, 2, 5, 5), dtype, scale=(10, 10000), sym=True)

--- a/tests/cupy_tests/linalg_tests/test_decomposition.py
+++ b/tests/cupy_tests/linalg_tests/test_decomposition.py
@@ -62,6 +62,15 @@ class TestCholeskyDecomposition(unittest.TestCase):
         # np.linalg.cholesky only uses a lower triangle of an array
         self.check_L(numpy.array([[1, 2], [1, 9]], dtype))
 
+    @testing.for_dtypes([
+        numpy.int32, numpy.int64, numpy.uint32, numpy.uint64,
+        numpy.float32, numpy.float64, numpy.complex64, numpy.complex128])
+    def test_batched_decomposition(self, dtype):
+        Ab1 = random_matrix((3, 5, 5), dtype, scale=(10, 10000), sym=True)
+        self.check_L(Ab1)
+        Ab2 = random_matrix((2, 2, 5, 5), dtype, scale=(10, 10000), sym=True)
+        self.check_L(Ab2)
+
 
 @testing.gpu
 class TestCholeskyInvalid(unittest.TestCase):

--- a/tests/cupyx_tests/linalg_tests/test_solve.py
+++ b/tests/cupyx_tests/linalg_tests/test_solve.py
@@ -1,8 +1,10 @@
 import unittest
 
 import numpy
+import pytest
 
 import cupy
+from cupy import cusolver
 from cupy import testing
 import cupyx
 
@@ -65,6 +67,8 @@ class TestErrorInvh(unittest.TestCase):
 class TestXFailBatchedInvh(unittest.TestCase):
 
     def test_invh(self):
+        if not cusolver.check_availability('potrsBatched'):
+            pytest.skip('potrsBatched is not available')
         a = self._create_symmetric_matrix(self.shape, self.dtype)
         with cupyx.errstate(linalg='ignore'):
             with self.assertRaises(cupy.cuda.cusolver.CUSOLVERError):

--- a/tests/cupyx_tests/linalg_tests/test_solve.py
+++ b/tests/cupyx_tests/linalg_tests/test_solve.py
@@ -54,3 +54,22 @@ class TestErrorInvh(unittest.TestCase):
         a = testing.shaped_random((n, n), cupy, dtype, scale=1)
         a = a + a.T - cupy.eye(n, dtype=dtype)
         return a
+
+
+# TODO: cusolver does not support nrhs > 1 for potrsBatched
+@testing.parameterize(*testing.product({
+    'shape': [(2, 3, 3)],
+    'dtype': [numpy.float32, numpy.float64, numpy.complex64, numpy.complex128],
+}))
+@testing.gpu
+class TestXFailBatchedInvh(unittest.TestCase):
+
+    def test_invh(self):
+        a = self._create_symmetric_matrix(self.shape, self.dtype)
+        with self.assertRaises(cupy.cuda.cusolver.CUSOLVERError):
+            cupyx.linalg.solve._batched_invh(a)
+
+    def _create_symmetric_matrix(self, shape, dtype):
+        a = testing.shaped_random(shape, cupy, dtype, scale=1)
+        a = a @ a.transpose(0, 2, 1)
+        return a

--- a/tests/cupyx_tests/linalg_tests/test_solve.py
+++ b/tests/cupyx_tests/linalg_tests/test_solve.py
@@ -66,8 +66,9 @@ class TestXFailBatchedInvh(unittest.TestCase):
 
     def test_invh(self):
         a = self._create_symmetric_matrix(self.shape, self.dtype)
-        with self.assertRaises(cupy.cuda.cusolver.CUSOLVERError):
-            cupyx.linalg.solve._batched_invh(a)
+        with cupyx.errstate(linalg='ignore'):
+            with self.assertRaises(cupy.cuda.cusolver.CUSOLVERError):
+                cupyx.linalg.solve._batched_invh(a)
 
     def _create_symmetric_matrix(self, shape, dtype):
         a = testing.shaped_random(shape, cupy, dtype, scale=1)


### PR DESCRIPTION
This PR adds Cython wrappers for cusolverDn<t>potrfBatched and cusolverDn<t>potrsBatched.

I've implemented batched version of `cupy.linalg.cholesky` using `potrfBatched`. Added test cases that cover input arrays of shape `(..., N, N)`. So now the functionality is the same as in NumPy.

Using `potrsBatched` I've implemented batched version of `cupyx.linalg.invh`, but it does not work yet because cusolver does not yet support `nrhs != 1` for this routine (see remarks in cusolver's documentation). But I think the code is correct and once the issue is solved in cusolver it will be available for use here.