### PR TITLE
Fix intermediate dtypes for float16 inputs in `cupyx.scipy.ndimage` stats functions

### DIFF
--- a/cupyx/scipy/ndimage/measurements.py
+++ b/cupyx/scipy/ndimage/measurements.py
@@ -321,14 +321,24 @@ def variance(input, labels=None, index=None):
             'for the fast implmentation', util.PerformanceWarning)
         use_kern = True
 
+    def single_group(vals):
+        vals_c = vals - vals.mean()
+        return vals.size, cupy.square(vals_c).sum()
+
     if labels is None:
-        return input.var().astype(cupy.float64, copy=False)
+        count, sum_c_sq = single_group(input)
+        return sum_c_sq / cupy.asanyarray(count).astype(float)
 
     if not isinstance(labels, cupy.ndarray):
         raise TypeError('label must be cupy.ndarray')
 
     if index is None:
-        return (input[labels != 0]).var().astype(cupy.float64, copy=False)
+        count, sum_c_sq = single_group(input[labels > 0])
+        return sum_c_sq / cupy.asanyarray(count).astype(float)
+
+    if cupy.isscalar(index):
+        count, sum_c_sq = single_group(input[labels == index])
+        return sum_c_sq / cupy.asanyarray(count).astype(float)
 
     input, labels = cupy.broadcast_arrays(input, labels)
 
@@ -450,14 +460,23 @@ def mean(input, labels=None, index=None):
             'for the fast implmentation', util.PerformanceWarning)
         use_kern = True
 
+    def single_group(vals):
+        return vals.size, vals.sum()
+
     if labels is None:
-        return input.mean(dtype=cupy.float64)
+        count, sum = single_group(input)
+        return sum / cupy.asanyarray(count).astype(float)
 
     if not isinstance(labels, cupy.ndarray):
         raise TypeError('label must be cupy.ndarray')
 
     if index is None:
-        return (input[labels != 0]).mean(dtype=cupy.float64)
+        count, sum = single_group(input[labels > 0])
+        return sum / cupy.asanyarray(count).astype(float)
+
+    if cupy.isscalar(index):
+        count, sum = single_group(input[labels == index])
+        return sum / cupy.asanyarray(count).astype(float)
 
     input, labels = cupy.broadcast_arrays(input, labels)
 

--- a/cupyx/scipy/ndimage/measurements.py
+++ b/cupyx/scipy/ndimage/measurements.py
@@ -321,24 +321,24 @@ def variance(input, labels=None, index=None):
             'for the fast implmentation', util.PerformanceWarning)
         use_kern = True
 
-    def single_group(vals):
-        vals_c = vals - vals.mean()
-        return vals.size, cupy.square(vals_c).sum()
+    def calc_var_with_intermediate_float(input):
+        vals_c = input - input.mean()
+        count = vals_c.size
+        # Does not use `ndarray.mean()` here to return the same results as
+        # SciPy does, especially in case `input`'s dtype is float16.
+        return cupy.square(vals_c).sum() / cupy.asanyarray(count).astype(float)
 
     if labels is None:
-        count, sum_c_sq = single_group(input)
-        return sum_c_sq / cupy.asanyarray(count).astype(float)
+        return calc_var_with_intermediate_float(input)
 
     if not isinstance(labels, cupy.ndarray):
         raise TypeError('label must be cupy.ndarray')
 
     if index is None:
-        count, sum_c_sq = single_group(input[labels > 0])
-        return sum_c_sq / cupy.asanyarray(count).astype(float)
+        return calc_var_with_intermediate_float(input[labels > 0])
 
     if cupy.isscalar(index):
-        count, sum_c_sq = single_group(input[labels == index])
-        return sum_c_sq / cupy.asanyarray(count).astype(float)
+        return calc_var_with_intermediate_float(input[labels == index])
 
     input, labels = cupy.broadcast_arrays(input, labels)
 
@@ -460,23 +460,24 @@ def mean(input, labels=None, index=None):
             'for the fast implmentation', util.PerformanceWarning)
         use_kern = True
 
-    def single_group(vals):
-        return vals.size, vals.sum()
+    def calc_mean_with_intermediate_float(input):
+        sum = input.sum()
+        count = input.size
+        # Does not use `ndarray.mean()` here to return the same results as
+        # SciPy does, especially in case `input`'s dtype is float16.
+        return sum / cupy.asanyarray(count).astype(float)
 
     if labels is None:
-        count, sum = single_group(input)
-        return sum / cupy.asanyarray(count).astype(float)
+        return calc_mean_with_intermediate_float(input)
 
     if not isinstance(labels, cupy.ndarray):
         raise TypeError('label must be cupy.ndarray')
 
     if index is None:
-        count, sum = single_group(input[labels > 0])
-        return sum / cupy.asanyarray(count).astype(float)
+        return calc_mean_with_intermediate_float(input[labels > 0])
 
     if cupy.isscalar(index):
-        count, sum = single_group(input[labels == index])
-        return sum / cupy.asanyarray(count).astype(float)
+        return calc_mean_with_intermediate_float(input[labels == index])
 
     input, labels = cupy.broadcast_arrays(input, labels)
 

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
@@ -123,40 +123,23 @@ class TestNdimage(unittest.TestCase):
         index = xp.array([0, 1, 2])
         return getattr(scp.ndimage, self.op)(image, label, index)
 
-    @testing.for_all_dtypes(no_bool=True, no_complex=True, no_float16=True)
-    @testing.numpy_cupy_array_almost_equal(scipy_name='scp', decimal=5)
+    @testing.for_all_dtypes(no_bool=True, no_complex=True)
+    @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_ndimage_only_input(self, xp, scp, dtype):
         image = xp.arange(100, dtype=dtype)
         return getattr(scp.ndimage, self.op)(image)
 
-    @testing.for_all_dtypes(no_bool=True, no_complex=True, no_float16=True)
-    @testing.numpy_cupy_array_almost_equal(scipy_name='scp', decimal=5)
+    @testing.for_all_dtypes(no_bool=True, no_complex=True)
+    @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_ndimage_no_index(self, xp, scp, dtype):
         image = xp.arange(100, dtype=dtype)
         label = testing.shaped_random((100,), xp, dtype=xp.int32, scale=3)
         return getattr(scp.ndimage, self.op)(image, label)
 
-    @testing.for_all_dtypes(no_bool=True, no_complex=True, no_float16=True)
-    @testing.numpy_cupy_array_almost_equal(scipy_name='scp', decimal=4)
+    @testing.for_all_dtypes(no_bool=True, no_complex=True)
+    @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_ndimage_scalar_index(self, xp, scp, dtype):
         image = xp.arange(100, dtype=dtype)
-        label = testing.shaped_random((100,), xp, dtype=xp.int32, scale=3)
-        return getattr(scp.ndimage, self.op)(image, label, 1)
-
-    @testing.numpy_cupy_array_almost_equal(scipy_name='scp', decimal=1)
-    def test_ndimage_only_input_float16(self, xp, scp):
-        image = xp.arange(100, dtype=xp.float16)
-        return getattr(scp.ndimage, self.op)(image)
-
-    @testing.numpy_cupy_array_almost_equal(scipy_name='scp', decimal=1)
-    def test_ndimage_no_index_float16(self, xp, scp):
-        image = xp.arange(50, dtype=xp.float16)
-        label = testing.shaped_random((50,), xp, dtype=xp.int32, scale=3)
-        return getattr(scp.ndimage, self.op)(image, label)
-
-    @testing.numpy_cupy_array_almost_equal(scipy_name='scp', decimal=1)
-    def test_ndimage_scalar_index_float16(self, xp, scp):
-        image = xp.arange(100, dtype=xp.float16)
         label = testing.shaped_random((100,), xp, dtype=xp.int32, scale=3)
         return getattr(scp.ndimage, self.op)(image, label, 1)
 


### PR DESCRIPTION
Follows https://github.com/cupy/cupy/pull/3259#discussion_r431205268.

NumPy's `ndarray.sum()` and `ndarray.mean()` use different intermediate dtypes for summation and return a little different results for float16 inputs.

```Python
import numpy as np
a = (np.arange(100) / 2).astype(np.float16)
>>> print(a.sum() / a.size)
24.76
>>> print(a.mean())
24.75
```

Because of this, `cupyx.scipy.ndimage` stats functions introduced in #3259 return slightly different results for float16 inputs compared with their SciPy counterparts. This PR fixes the functions to follow SciPy's way to compute such values.