### PR TITLE
Fix sphinx version for travis

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ requirements = {
         'theano',
     ],
     'docs': [
-        'sphinx',
+        'sphinx==3.0.4',
         'sphinx_rtd_theme',
     ],
     'travis': [


### PR DESCRIPTION
Travis started installing sphinx 3.1.0,
set it to 3.0.4 while we look for the issue 

https://travis-ci.org/github/cupy/cupy/builds/696302151