### PR TITLE
Support boolean in `cupyx.scipy.ndimage` stats functions

### DIFF
--- a/cupyx/scipy/ndimage/measurements.py
+++ b/cupyx/scipy/ndimage/measurements.py
@@ -305,7 +305,7 @@ def variance(input, labels=None, index=None):
     if not isinstance(input, cupy.ndarray):
         raise TypeError('input must be cupy.ndarray')
 
-    if input.dtype in (cupy.bool_, cupy.complex64, cupy.complex128):
+    if input.dtype in (cupy.complex64, cupy.complex128):
         raise TypeError("cupyx.scipy.ndimage.variance doesn't support %{}"
                         "".format(input.dtype.type))
 
@@ -380,7 +380,7 @@ def sum(input, labels=None, index=None):
     if not isinstance(input, cupy.ndarray):
         raise TypeError('input must be cupy.ndarray')
 
-    if input.dtype in (cupy.bool_, cupy.complex64, cupy.complex128):
+    if input.dtype in (cupy.complex64, cupy.complex128):
         raise TypeError("cupyx.scipy.ndimage.sum doesnt support %{}".format(
             input.dtype.type))
 
@@ -444,7 +444,7 @@ def mean(input, labels=None, index=None):
     if not isinstance(input, cupy.ndarray):
         raise TypeError('input must be cupy.ndarray')
 
-    if input.dtype in (cupy.bool_, cupy.complex64, cupy.complex128):
+    if input.dtype in (cupy.complex64, cupy.complex128):
         raise TypeError("cupyx.scipy.ndimage.mean doesnt support %{}".format(
             input.dtype.type))
 

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
@@ -107,52 +107,58 @@ class TestLabelSpecialCases(unittest.TestCase):
 @testing.with_requires('scipy')
 class TestNdimage(unittest.TestCase):
 
-    @testing.for_all_dtypes(no_bool=True, no_complex=True)
+    def _make_image(self, shape, xp, dtype):
+        if dtype == xp.bool_:
+            return testing.shaped_random(shape, xp, dtype=xp.bool_)
+        else:
+            return testing.shaped_arange(shape, xp, dtype=dtype)
+
+    @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_array_almost_equal(scipy_name='scp')
     def test_ndimage_single_dim(self, xp, scp, dtype):
-        image = xp.arange(100, dtype=dtype)
+        image = self._make_image((100,), xp, dtype)
         label = testing.shaped_random((100,), xp, dtype=xp.int32, scale=3)
         index = xp.array([0, 1, 2])
         return getattr(scp.ndimage, self.op)(image, label, index)
 
-    @testing.for_all_dtypes(no_bool=True, no_complex=True)
+    @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_array_almost_equal(scipy_name='scp')
     def test_ndimage_multi_dim(self, xp, scp, dtype):
-        image = xp.arange(512, dtype=dtype).reshape(8, 8, 8)
+        image = self._make_image((8, 8, 8), xp, dtype)
         label = testing.shaped_random((8, 8, 8), xp, dtype=xp.int32, scale=3)
         index = xp.array([0, 1, 2])
         return getattr(scp.ndimage, self.op)(image, label, index)
 
-    @testing.for_all_dtypes(no_bool=True, no_complex=True)
+    @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_ndimage_only_input(self, xp, scp, dtype):
-        image = xp.arange(100, dtype=dtype)
+        image = self._make_image((100,), xp, dtype)
         return getattr(scp.ndimage, self.op)(image)
 
-    @testing.for_all_dtypes(no_bool=True, no_complex=True)
+    @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_ndimage_no_index(self, xp, scp, dtype):
-        image = xp.arange(100, dtype=dtype)
+        image = self._make_image((100,), xp, dtype)
         label = testing.shaped_random((100,), xp, dtype=xp.int32, scale=3)
         return getattr(scp.ndimage, self.op)(image, label)
 
-    @testing.for_all_dtypes(no_bool=True, no_complex=True)
+    @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_ndimage_scalar_index(self, xp, scp, dtype):
-        image = xp.arange(100, dtype=dtype)
+        image = self._make_image((100,), xp, dtype)
         label = testing.shaped_random((100,), xp, dtype=xp.int32, scale=3)
         return getattr(scp.ndimage, self.op)(image, label, 1)
 
-    @testing.for_dtypes([cupy.bool_, cupy.complex64, cupy.complex128])
+    @testing.for_dtypes([cupy.complex64, cupy.complex128])
     def test_ndimage_wrong_dtype(self, dtype):
-        image = cupy.arange(100).astype(dtype)
+        image = self._make_image((100,), cupy, dtype)
         label = cupy.random.randint(1, 4, dtype=cupy.int32)
         index = cupy.array([1, 2, 3])
         with pytest.raises(TypeError):
             getattr(cupyx.scipy.ndimage, self.op)(image, label, index)
 
     def test_ndimage_wrong_label_shape(self):
-        image = cupy.arange(100, dtype=cupy.int32)
+        image = self._make_image((100,), cupy, cupy.int32)
         label = cupy.random.randint(1, 3, dtype=cupy.int32, size=50)
         index = cupy.array([1, 2, 3])
         with pytest.raises(ValueError):
@@ -166,14 +172,14 @@ class TestNdimage(unittest.TestCase):
             getattr(cupyx.scipy.ndimage, self.op)(image, label, index)
 
     def test_ndimage_wrong_label_type(self):
-        image = cupy.arange(100, dtype=cupy.int32)
+        image = self._make_image((100,), cupy, cupy.int32)
         label = numpy.random.randint(1, 3, dtype=numpy.int32, size=100)
         index = cupy.array([1, 2, 3])
         with pytest.raises(TypeError):
             getattr(cupyx.scipy.ndimage, self.op)(image, label, index)
 
     def test_ndimage_wrong_index_type(self):
-        image = cupy.arange(100, dtype=cupy.int32)
+        image = self._make_image((100,), cupy, cupy.int32)
         label = cupy.random.randint(1, 3, dtype=cupy.int32, size=100)
         index = [1, 2, 3]
         with pytest.raises(TypeError):


### PR DESCRIPTION
Follows #3259.

This PR fixes `cupyx.scipy.ndimage` stats functions to support `cupy.bool_`.