### PR TITLE
Raise `TypeError` in `cupy.ndarray.__array__`

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1161,10 +1161,12 @@ cdef class ndarray:
     # cupy.ndarray does not define __new__
 
     def __array__(self, dtype=None):
-        if dtype is None or self.dtype == dtype:
-            return self
-        else:
-            return self.astype(dtype)
+        # TODO(imanishi): Support an environment variable or a global
+        # configure flag that allows implicit conversions to NumPy array.
+        # (See https://github.com/cupy/cupy/issues/589 for the detail.)
+        raise TypeError(
+            'Implicit conversion to a NumPy array is not allowed. '
+            'Please use `.get()` to construct a NumPy array explicitly.')
 
     # TODO(okuta): Implement __array_wrap__
 

--- a/tests/cupy_tests/core_tests/test_ndarray.py
+++ b/tests/cupy_tests/core_tests/test_ndarray.py
@@ -503,3 +503,12 @@ class TestPythonInterface(unittest.TestCase):
     def test_bytes_tobytes_scalar(self, xp, dtype):
         x = xp.array([3], dtype).item()
         return bytes(x)
+
+
+@testing.gpu
+class TestNdarrayImplicitConversion(unittest.TestCase):
+
+    def test_array(self):
+        a = testing.shaped_arange((3, 4, 5), cupy, numpy.int64)
+        with pytest.raises(TypeError):
+            numpy.asarray(a)


### PR DESCRIPTION
Related: #589, #734.

Fix the type of the error and error message.
```py
>>> numpy.asarray(cupy.array([1, 2, 3]))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/imanishi/.pyenv/versions/anaconda3-5.3.1/lib/python3.7/site-packages/numpy/core/_asarray.py", line 85, in asarray
    return array(a, dtype, copy=False, order=order)
ValueError: object __array__ method not producing an array
```