### PR TITLE
Properly reset current stream in case null stream is destroyed

### DIFF
--- a/cupy/cuda/stream.pyx
+++ b/cupy/cuda/stream.pyx
@@ -276,12 +276,16 @@ class Stream(BaseStream):
         cdef intptr_t current_ptr
         if is_shutting_down():
             return
+        tls = _ThreadLocal.get()
         if self.ptr:
-            tls = _ThreadLocal.get()
             current_ptr = <intptr_t>tls.get_current_stream_ptr()
             if <intptr_t>self.ptr == current_ptr:
                 tls.set_current_stream(self.null)
             runtime.streamDestroy(self.ptr)
+        else:
+            current_stream = tls.get_current_stream()
+            if current_stream == self:
+                tls.set_current_stream(self.null)
         # Note that we can not release memory pool of the stream held in CPU
         # because the memory would still be used in kernels executed in GPU.
 

--- a/tests/cupy_tests/cuda_tests/test_stream.py
+++ b/tests/cupy_tests/cuda_tests/test_stream.py
@@ -19,9 +19,8 @@ class TestStream(unittest.TestCase):
         self.assertEqual(null1, null2)
         self.assertNotEqual(null2, null3)
 
-    @attr.gpu
-    def test_del(self):
-        stream = cuda.Stream().use()
+    def check_del(self, null):
+        stream = cuda.Stream(null=null).use()
         stream_ptr = stream.ptr
         x = from_data.array([1, 2, 3])
         del stream
@@ -30,6 +29,14 @@ class TestStream(unittest.TestCase):
         # runtime.streamQuery(stream_ptr) causes SEGV. We cannot test...
         del stream_ptr
         del x
+
+    @attr.gpu
+    def test_del(self):
+        self.check_del(null=False)
+
+    @attr.gpu
+    def test_del_null(self):
+        self.check_del(null=True)
 
     @attr.gpu
     def test_get_and_add_callback(self):


### PR DESCRIPTION
Rel. #3316.

When a CuPy stream object set to the current stream is about to be destroyed, the current stream is automatically replaced with `Stream.null`. However, it does not work when the stream is a user-defined null stream, causing the error reported in #3316.

This PR fixes the problem to properly reset the current stream even if a user-defined null stream is used.
