### PR TITLE
Speed up CSR SpMV by orders of magnitude

### DIFF
--- a/cupy/cuda/cupy_cusparse.h
+++ b/cupy/cuda/cupy_cusparse.h
@@ -776,6 +776,10 @@ cusparseStatus_t cusparseXcoosortByRow(...) {
   return CUSPARSE_STATUS_SUCCESS;
 }
 
+cusparseStatus_t cusparseXcoosortByColumn(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
 cusparseStatus_t cusparseXcsrsort_bufferSizeExt(...) {
   return CUSPARSE_STATUS_SUCCESS;
 }

--- a/cupy/cuda/cusparse.pyx
+++ b/cupy/cuda/cusparse.pyx
@@ -587,6 +587,10 @@ cdef extern from 'cupy_cusparse.h' nogil:
         Handle handle, int m, int n, int nnz, int *cooRows, int *cooCols,
         int *P, void *pBuffer)
 
+    Status cusparseXcoosortByColumn(
+        Handle handle, int m, int n, int nnz, int *cooRows, int *cooCols,
+        int *P, void *pBuffer)
+
     Status cusparseXcsrsort_bufferSizeExt(
         Handle handle, int m, int n, int nnz, const int *csrRowPtr,
         const int *csrColInd, size_t *pBufferSizeInBytes)
@@ -2560,6 +2564,16 @@ cpdef xcoosortByRow(
         size_t P, size_t pBuffer):
     setStream(handle, stream_module.get_current_stream_ptr())
     status = cusparseXcoosortByRow(
+        <Handle>handle, m, n, nnz, <int *>cooRows, <int *>cooCols,
+        <int *>P, <void *>pBuffer)
+    check_status(status)
+
+
+cpdef xcoosortByColumn(
+        intptr_t handle, int m, int n, int nnz, size_t cooRows, size_t cooCols,
+        size_t P, size_t pBuffer):
+    setStream(handle, stream_module.get_current_stream_ptr())
+    status = cusparseXcoosortByColumn(
         <Handle>handle, m, n, nnz, <int *>cooRows, <int *>cooCols,
         <int *>P, <void *>pBuffer)
     check_status(status)

--- a/cupy/cusparse.py
+++ b/cupy/cusparse.py
@@ -896,6 +896,25 @@ def csr2csc(x):
         (data, indices, indptr), shape=x.shape)
 
 
+def csc2csr(x):
+    handle = device.get_cusparse_handle()
+    m, n = x.shape
+    nnz = x.nnz
+    data = cupy.empty(nnz, x.dtype)
+    indptr = cupy.empty(m + 1, 'i')
+    indices = cupy.empty(nnz, 'i')
+
+    _call_cusparse(
+        'csr2csc', x.dtype,
+        handle, n, m, nnz, x.data.data.ptr,
+        x.indptr.data.ptr, x.indices.data.ptr,
+        data.data.ptr, indices.data.ptr, indptr.data.ptr,
+        cusparse.CUSPARSE_ACTION_NUMERIC,
+        cusparse.CUSPARSE_INDEX_BASE_ZERO)
+    return cupyx.scipy.sparse.csr_matrix(
+        (data, indices, indptr), shape=x.shape)
+
+
 def dense2csc(x):
     """Converts a dense matrix in CSC format.
 

--- a/cupy/cusparse.py
+++ b/cupy/cusparse.py
@@ -896,6 +896,30 @@ def csr2csc(x):
         (data, indices, indptr), shape=x.shape)
 
 
+def csc2coo(x, data, indices):
+    """Converts a CSC-matrix to COO format.
+
+    Args:
+        x (cupyx.scipy.sparse.csc_matrix): A matrix to be converted.
+        data (cupy.ndarray): A data array for converted data.
+        indices (cupy.ndarray): An index array for converted data.
+
+    Returns:
+        cupyx.scipy.sparse.coo_matrix: A converted matrix.
+
+    """
+    handle = device.get_cusparse_handle()
+    n = x.shape[1]
+    nnz = len(x.data)
+    col = cupy.empty(nnz, 'i')
+    cusparse.xcsr2coo(
+        handle, x.indptr.data.ptr, nnz, n, col.data.ptr,
+        cusparse.CUSPARSE_INDEX_BASE_ZERO)
+    # data and indices did not need to be copied already
+    return cupyx.scipy.sparse.coo_matrix(
+        (data, (indices, col)), shape=x.shape)
+
+
 def csc2csr(x):
     handle = device.get_cusparse_handle()
     m, n = x.shape

--- a/cupy/cusparse.py
+++ b/cupy/cusparse.py
@@ -827,6 +827,8 @@ def coosort(x, sort_by='r'):
         'gthr', x.dtype,
         handle, nnz, data_orig.data.ptr, x.data.data.ptr,
         P.data.ptr, cusparse.CUSPARSE_INDEX_BASE_ZERO)
+    if sort_by == 'c':  # coo is sorted by row first
+        x._has_canonical_format = False
 
 
 def coo2csr(x):

--- a/cupyx/scipy/sparse/coo.py
+++ b/cupyx/scipy/sparse/coo.py
@@ -215,7 +215,7 @@ class coo_matrix(sparse_data._data_matrix):
         if self.data.size == 0:
             self._has_canonical_format = True
             return
-        keys = cupy.stack([self.row, self.col])
+        keys = cupy.stack([self.col, self.row])
         order = cupy.lexsort(keys)
         src_data = self.data[order]
         src_row = self.row[order]

--- a/cupyx/scipy/sparse/coo.py
+++ b/cupyx/scipy/sparse/coo.py
@@ -322,11 +322,8 @@ class coo_matrix(sparse_data._data_matrix):
         """
         if self.nnz == 0:
             return csc.csc_matrix(self.shape, dtype=self.dtype)
-        # copy is ignored because both sum_duplicates and coosort change
-        # the underlying data
-        if copy:
-            import warnings
-            warnings.warn("copy=True is not supported")
+        # copy is silently ignored (in line with SciPy) because both
+        # sum_duplicates and coosort change the underlying data
         self.sum_duplicates()
         x = self.copy()
         cusparse.coosort(x, 'c')
@@ -348,11 +345,8 @@ class coo_matrix(sparse_data._data_matrix):
         """
         if self.nnz == 0:
             return csr.csr_matrix(self.shape, dtype=self.dtype)
-        # copy is ignored because both sum_duplicates and coosort change
-        # the underlying data
-        if copy:
-            import warnings
-            warnings.warn("copy=True is not supported")
+        # copy is silently ignored (in line with SciPy) because both
+        # sum_duplicates and coosort change the underlying data
         self.sum_duplicates()
         x = self.copy()
         cusparse.coosort(x, 'r')

--- a/cupyx/scipy/sparse/coo.py
+++ b/cupyx/scipy/sparse/coo.py
@@ -103,7 +103,8 @@ class coo_matrix(sparse_data._data_matrix):
             has_canonical_format = False
 
         else:
-            raise TypeError('invalid input format')
+            raise ValueError(
+                'Only (data, (row, col)) format is supported')
 
         if dtype is None:
             dtype = data.dtype
@@ -215,7 +216,7 @@ class coo_matrix(sparse_data._data_matrix):
         if self.data.size == 0:
             self._has_canonical_format = True
             return
-        keys = cupy.stack([self.col, self.row])
+        keys = cupy.stack([self.row, self.col])
         order = cupy.lexsort(keys)
         src_data = self.data[order]
         src_row = self.row[order]
@@ -319,7 +320,11 @@ class coo_matrix(sparse_data._data_matrix):
             cupyx.scipy.sparse.csc_matrix: Converted matrix.
 
         """
-        return self.T.tocsr().T
+        x=self.T.tocsr().T
+        x._has_canonical_format=True
+        return x
+        #return self.T.tocsr().T
+    
 
     def tocsr(self, copy=False):
         """Converts the matrix to Compressed Sparse Row format.
@@ -339,7 +344,11 @@ class coo_matrix(sparse_data._data_matrix):
         # copy is ignored because coosort method breaks an original.
         x = self.copy()
         cusparse.coosort(x)
-        return cusparse.coo2csr(x)
+        #return cusparse.coo2csr(x)
+        x=cusparse.coo2csr(x)
+        x._has_canonical_format=True
+        return x
+
 
     def transpose(self, axes=None, copy=False):
         """Returns a transpose matrix.

--- a/cupyx/scipy/sparse/coo.py
+++ b/cupyx/scipy/sparse/coo.py
@@ -103,8 +103,7 @@ class coo_matrix(sparse_data._data_matrix):
             has_canonical_format = False
 
         else:
-            raise ValueError(
-                'Only (data, (row, col)) format is supported')
+            raise TypeError('invalid input format')
 
         if dtype is None:
             dtype = data.dtype
@@ -320,11 +319,9 @@ class coo_matrix(sparse_data._data_matrix):
             cupyx.scipy.sparse.csc_matrix: Converted matrix.
 
         """
-        x=self.T.tocsr().T
-        x._has_canonical_format=True
+        x = self.T.tocsr().T
+        x._has_canonical_format = True
         return x
-        #return self.T.tocsr().T
-    
 
     def tocsr(self, copy=False):
         """Converts the matrix to Compressed Sparse Row format.
@@ -344,11 +341,9 @@ class coo_matrix(sparse_data._data_matrix):
         # copy is ignored because coosort method breaks an original.
         x = self.copy()
         cusparse.coosort(x)
-        #return cusparse.coo2csr(x)
-        x=cusparse.coo2csr(x)
-        x._has_canonical_format=True
+        x = cusparse.coo2csr(x)
+        x._has_canonical_format = True
         return x
-
 
     def transpose(self, axes=None, copy=False):
         """Returns a transpose matrix.

--- a/cupyx/scipy/sparse/csc.py
+++ b/cupyx/scipy/sparse/csc.py
@@ -174,7 +174,14 @@ class csc_matrix(compressed._compressed_sparse_matrix):
             cupyx.scipy.sparse.coo_matrix: Converted matrix.
 
         """
-        return self.T.tocoo(copy).T
+        if copy:
+            data = self.data.copy()
+            indices = self.indices.copy()
+        else:
+            data = self.data
+            indices = self.indices
+
+        return cusparse.csc2coo(self, data, indices)
 
     def tocsc(self, copy=None):
         """Converts the matrix to Compressed Sparse Column format.

--- a/cupyx/scipy/sparse/csc.py
+++ b/cupyx/scipy/sparse/csc.py
@@ -204,7 +204,8 @@ class csc_matrix(compressed._compressed_sparse_matrix):
             cupyx.scipy.sparse.csr_matrix: Converted matrix.
 
         """
-        return self.T.tocsc(copy=False).T
+        # copy is ignored
+        return cusparse.csc2csr(self)
 
     # TODO(unno): Implement todia
     # TODO(unno): Implement todok

--- a/cupyx/scipy/sparse/csr.py
+++ b/cupyx/scipy/sparse/csr.py
@@ -295,8 +295,10 @@ class csr_matrix(compressed._compressed_sparse_matrix):
                 'swapping dimensions is the only logical permutation.')
 
         shape = self.shape[1], self.shape[0]
-        return csc.csc_matrix(
+        trans = csc.csc_matrix(
             (self.data, self.indices, self.indptr), shape=shape, copy=copy)
+        trans._has_canonical_format = self._has_canonical_format
+        return trans
 
 
 def isspmatrix_csr(x):

--- a/tests/cupy_tests/test_cusparse.py
+++ b/tests/cupy_tests/test_cusparse.py
@@ -456,7 +456,7 @@ class TestCscsort(unittest.TestCase):
         numpy.random.shuffle(self.a.indices)
         self.a.has_sorted_indices = False
 
-    def test_csrsort(self):
+    def test_cscsort(self):
         a = sparse.csc_matrix(self.a)
         cupy.cusparse.cscsort(a)
 

--- a/tests/cupy_tests/test_cusparse.py
+++ b/tests/cupy_tests/test_cusparse.py
@@ -418,6 +418,15 @@ class TestCoosort(unittest.TestCase):
         testing.assert_array_equal(self.a.col[argsort], a.col)
         testing.assert_array_almost_equal(self.a.data[argsort], a.data)
 
+    def test_coosort_by_column(self):
+        a = sparse.coo_matrix(self.a)
+        cupy.cusparse.coosort(a, sort_by='c')
+        # lexsort by col first and row second
+        argsort = numpy.lexsort((self.a.row, self.a.col))
+        testing.assert_array_equal(self.a.row[argsort], a.row)
+        testing.assert_array_equal(self.a.col[argsort], a.col)
+        testing.assert_array_almost_equal(self.a.data[argsort], a.data)
+
 
 @testing.with_requires('scipy')
 class TestCsrsort(unittest.TestCase):

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_coo.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_coo.py
@@ -449,25 +449,31 @@ class TestCooMatrixScipyComparison(unittest.TestCase):
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_tocsc(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
-        return m.tocsc()
+        out = m.tocsc()
+        assert out.has_canonical_format
+        return out
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_tocsc_copy(self, xp, sp):
         m = _make(xp, sp, self.dtype)
         n = m.tocsc(copy=True)
         self.assertIsNot(m.data, n.data)
+        assert n.has_canonical_format
         return n
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_tocsr(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
-        return m.tocsr()
+        out = m.tocsr()
+        assert out.has_canonical_format
+        return out
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_tocsr_copy(self, xp, sp):
         m = _make(xp, sp, self.dtype)
         n = m.tocsr(copy=True)
         self.assertIsNot(m.data, n.data)
+        assert n.has_canonical_format
         return n
 
     # dot


### PR DESCRIPTION
**Main credit goes to @smarkesini (from his #2790).**

Close #2790. Close #2664.

I don't know why this simple but great change was buried unnoticed 😢 Explained by @smarkesini in https://github.com/cupy/cupy/issues/2365#issuecomment-532133094: 
> I suspect this issue has something to do with '_has_canonical_format' not being set even after calling coosort. There are several places where to set this flag, and I am not sure if the following is the best place, anyway I was focusing on csr and modified the last 3 lines in cupyx/scipy/sparse/coo.py 'tocsr' function as described below and got better performance for my problem (SpMV with a csr matrix ), >100x speedup on the first iteration.

**UPDATE:** While performance improvement was the original concern in this PR, note that this is also a compatibility bug -- In SciPy it is guaranteed that a conversion from COO to CSR/CSC will always lead to a canonical format, because the duplicates are summed and the indices are sorted.

~~and in https://github.com/cupy/cupy/issues/2365#issuecomment-532434034:~~
> ~~following the definition in there [coo2csr](https://docs.nvidia.com/cuda/cusparse/index.html#coo2csr), this function converts the array containing the uncompressed row indices (corresponding to COO format) into an array of **compressed row pointers (corresponding to CSR format)**. In the [cuda definition](https://docs.nvidia.com/cuda/cusparse/index.html#csr-format): "Sparse matrices in CSR format are assumed to be stored in row-major CSR format, in other words, the index arrays are first sorted by row indices and then within the same row by column indices. It is assumed that each pair of row and column indices appears only once."~~

As for performance boost, as mentioned in the discussion there the speed-up is multiple orders of magnitude, which I verified. I'll double check my benchmark script and post the result below.