### PR TITLE
Deprecate `testing.empty`

### DIFF
--- a/cupy/testing/__init__.py
+++ b/cupy/testing/__init__.py
@@ -15,7 +15,6 @@ from cupy.testing.attr import gpu  # NOQA
 from cupy.testing.attr import multi_gpu  # NOQA
 from cupy.testing.attr import slow  # NOQA
 from cupy.testing.helper import assert_warns  # NOQA
-from cupy.testing.helper import empty  # NOQA
 from cupy.testing.helper import for_all_dtypes  # NOQA
 from cupy.testing.helper import for_all_dtypes_combination  # NOQA
 from cupy.testing.helper import for_CF_orders  # NOQA

--- a/cupy/testing/helper.py
+++ b/cupy/testing/helper.py
@@ -1190,6 +1190,10 @@ def shaped_random(shape, xp=cupy, dtype=numpy.float32, scale=10, seed=0):
 
 
 def empty(xp=cupy, dtype=numpy.float32):
+    warnings.warn(
+        '`cupy.testing.empty` is deprecated. '
+        'Use `xp.zeros((0,), dtype)` instead.',
+        DeprecationWarning)
     return xp.zeros((0,), dtype=dtype)
 
 

--- a/cupy/testing/helper.py
+++ b/cupy/testing/helper.py
@@ -1189,14 +1189,6 @@ def shaped_random(shape, xp=cupy, dtype=numpy.float32, scale=10, seed=0):
         return xp.asarray(numpy.random.rand(*shape) * scale, dtype=dtype)
 
 
-def empty(xp=cupy, dtype=numpy.float32):
-    warnings.warn(
-        '`cupy.testing.empty` is deprecated. '
-        'Use `xp.zeros((0,), dtype)` instead.',
-        DeprecationWarning)
-    return xp.zeros((0,), dtype=dtype)
-
-
 class NumpyError(object):
 
     def __init__(self, **kw):

--- a/cupy/testing/helper.py
+++ b/cupy/testing/helper.py
@@ -1190,7 +1190,7 @@ def shaped_random(shape, xp=cupy, dtype=numpy.float32, scale=10, seed=0):
 
 
 def empty(xp=cupy, dtype=numpy.float32):
-    return xp.zeros((0,))
+    return xp.zeros((0,), dtype=dtype)
 
 
 class NumpyError(object):

--- a/tests/cupy_tests/manipulation_tests/test_shape.py
+++ b/tests/cupy_tests/manipulation_tests/test_shape.py
@@ -70,15 +70,15 @@ class TestShape(unittest.TestCase):
             with pytest.raises(ValueError):
                 a.reshape(2, 4, 4, order='K')
 
-    def test_reshape_empty_invalid(self):
+    def test_reshape_zerosize_invalid(self):
         for xp in (numpy, cupy):
-            a = testing.empty(xp)
+            a = xp.zeros((0,))
             with pytest.raises(ValueError):
                 a.reshape(())
 
     @testing.numpy_cupy_array_equal()
-    def test_reshape_empty(self, xp):
-        a = testing.empty(xp)
+    def test_reshape_zerosize(self, xp):
+        a = xp.zeros((0,))
         return a.reshape((0,))
 
     @testing.for_orders('CFA')

--- a/tests/cupy_tests/polynomial_tests/test_polynomial.py
+++ b/tests/cupy_tests/polynomial_tests/test_polynomial.py
@@ -24,9 +24,9 @@ class TestPolynomial(unittest.TestCase):
                 xp.polynomial.polynomial.polycompanion(a)
 
     @testing.for_all_dtypes()
-    def test_polycompanion_empty(self, dtype):
+    def test_polycompanion_zerosize(self, dtype):
         for xp in (numpy, cupy):
-            a = testing.empty(xp, dtype)
+            a = xp.zeros((0,), dtype)
             with pytest.raises(ValueError):
                 xp.polynomial.polynomial.polycompanion(a)
 

--- a/tests/cupy_tests/polynomial_tests/test_polyutils.py
+++ b/tests/cupy_tests/polynomial_tests/test_polyutils.py
@@ -82,8 +82,8 @@ class TestTrimseq(unittest.TestCase):
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
-    def test_trimseq_empty(self, xp, dtype):
-        a = testing.empty(xp, dtype)
+    def test_trimseq_zerosize(self, xp, dtype):
+        a = xp.zeros((0,), dtype)
         return xp.polynomial.polyutils.trimseq(a)
 
     @testing.for_all_dtypes()


### PR DESCRIPTION
The behavior of `cupy.testing.empty` is so different from `xp.empty` that I feel confusing. So I want to deprecate this feature and encourage to use `xp.zeros((0,))` instead.