### PR TITLE
[backport] Fix `erfinv` & `erfcinv` in `cupyx.scipy.special`

### DIFF
--- a/cupyx/scipy/special/erf.py
+++ b/cupyx/scipy/special/erf.py
@@ -33,35 +33,27 @@ erfcx = core.create_ufunc(
 
 erfinv = core.create_ufunc(
     'cupyx_scipy_erfinv', ('f->f', 'd->d'),
-    '''
-    if (in0 < -1) {
-        out0 = -1.0 / 0.0;
-    } else if (in0 > 1) {
-        out0 = 1.0 / 0.0;
-    } else {
-        out0 = erfinv(in0);
-    }
-    ''',
+    'out0 = erfinv(in0);',
     doc='''Inverse function of error function.
 
     .. seealso:: :meth:`scipy.special.erfinv`
+
+    .. note::
+        The behavior close to (and outside) the domain follows that of
+        SciPy v1.4.0+.
 
     ''')
 
 
 erfcinv = core.create_ufunc(
     'cupyx_scipy_erfcinv', ('f->f', 'd->d'),
-    '''
-    if (in0 < 0) {
-        out0 = 1.0 / 0.0;
-    } else if (in0 > 2) {
-        out0 = -1.0 / 0.0;
-    } else {
-        out0 = erfcinv(in0);
-    }
-    ''',
+    'out0 = erfcinv(in0);',
     doc='''Inverse function of complementary error function.
 
     .. seealso:: :meth:`scipy.special.erfcinv`
+
+    .. note::
+        The behavior close to (and outside) the domain follows that of
+        SciPy v1.4.0+.
 
     ''')

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_erf.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_erf.py
@@ -24,12 +24,14 @@ class _TestBase(object):
     def test_erfcx(self):
         self.check_unary('erfcx')
 
+    @testing.with_requires('scipy>=1.4.0')
     def test_erfinv(self):
         self.check_unary('erfinv')
         self.check_unary_random('erfinv', scale=2, offset=-1)
         self.check_unary_boundary('erfinv', boundary=-1)
         self.check_unary_boundary('erfinv', boundary=1)
 
+    @testing.with_requires('scipy>=1.4.0')
     def test_erfcinv(self):
         self.check_unary('erfcinv')
         self.check_unary_random('erfcinv', scale=2, offset=0)
@@ -65,6 +67,42 @@ class TestSpecial(unittest.TestCase, _TestBase):
         a = _boundary_inputs(boundary, 1.0 / 1024, 1.0 / 1024)
         a = xp.array(a, dtype=dtype)
         return getattr(scp.special, name)(a)
+
+    @testing.with_requires('scipy>=1.4.0')
+    @testing.for_dtypes(['f', 'd'])
+    def test_erfinv_behavior(self, dtype):
+        a = cupy.empty((1,), dtype=dtype)
+
+        a[:] = 1.0 + 1E-6
+        a = cupyx.scipy.special.erfinv(a)
+        assert cupy.isnan(a)
+        a[:] = -1.0 - 1E-6
+        a = cupyx.scipy.special.erfinv(a)
+        assert cupy.isnan(a)
+        a[:] = 1.0
+        a = cupyx.scipy.special.erfinv(a)
+        assert numpy.isposinf(cupy.asnumpy(a))
+        a[:] = -1.0
+        a = cupyx.scipy.special.erfinv(a)
+        assert numpy.isneginf(cupy.asnumpy(a))
+
+    @testing.with_requires('scipy>=1.4.0')
+    @testing.for_dtypes(['f', 'd'])
+    def test_erfcinv_behavior(self, dtype):
+        a = cupy.empty((1,), dtype=dtype)
+
+        a[:] = 2.0 + 1E-6
+        a = cupyx.scipy.special.erfcinv(a)
+        assert cupy.isnan(a)
+        a[:] = 0.0 - 1E-6
+        a = cupyx.scipy.special.erfcinv(a)
+        assert cupy.isnan(a)
+        a[:] = 0.0
+        a = cupyx.scipy.special.erfcinv(a)
+        assert numpy.isposinf(cupy.asnumpy(a))
+        a[:] = 2.0
+        a = cupyx.scipy.special.erfcinv(a)
+        assert numpy.isneginf(cupy.asnumpy(a))
 
 
 @testing.gpu


### PR DESCRIPTION
Backport of #3159