### PR TITLE
[backport] update slicing of CSR and CSC matrices for compatibility with SciPy 1.4.0

### DIFF
--- a/cupyx/scipy/sparse/compressed.py
+++ b/cupyx/scipy/sparse/compressed.py
@@ -285,7 +285,8 @@ class _compressed_sparse_matrix(sparse_data._data_matrix):
             raise ValueError('slicing with step != 1 not supported')
 
         if not (major_start <= major_stop):
-            raise IndexError('index out of bounds')
+            # will give an empty slice, but preserve shape on the other axis
+            major_start = major_stop
 
         start = self.indptr[major_start]
         stop = self.indptr[major_stop]

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
@@ -1008,11 +1008,12 @@ class TestCsrMatrixGetitem(unittest.TestCase):
     def test_getitem_slice_negative(self, xp, sp):
         return _make(xp, sp, self.dtype)[:, -2:-1]
 
-    # avoid segfault: https://github.com/scipy/scipy/issues/11125
-    @testing.with_requires('scipy!=1.3.*')
-    @testing.numpy_cupy_raises(sp_name='sp', accept_error=IndexError)
+    # SciPy prior to 1.4 has bugs where either an IndexError is raised or a
+    # segfault occurs instead of returning an empty slice.
+    @testing.with_requires('scipy>=1.4')
+    @testing.numpy_cupy_allclose(sp_name='sp')
     def test_getitem_slice_start_larger_than_stop(self, xp, sp):
-        _make(xp, sp, self.dtype)[:, 3:2]
+        return _make(xp, sp, self.dtype)[:, 3:2]
 
     def test_getitem_slice_step_2(self):
         with self.assertRaises(ValueError):

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -1118,11 +1118,12 @@ class TestCsrMatrixGetitem(unittest.TestCase):
     def test_getitem_slice_negative(self, xp, sp):
         return _make(xp, sp, self.dtype)[-2:-1]
 
-    # avoid segfault: https://github.com/scipy/scipy/issues/11125
-    @testing.with_requires('scipy!=1.3.*')
-    @testing.numpy_cupy_raises(sp_name='sp', accept_error=IndexError)
+    # SciPy prior to 1.4 has bugs where either an IndexError is raised or a
+    # segfault occurs instead of returning an empty slice.
+    @testing.with_requires('scipy>=1.4')
+    @testing.numpy_cupy_allclose(sp_name='sp')
     def test_getitem_slice_start_larger_than_stop(self, xp, sp):
-        _make(xp, sp, self.dtype)[3:2]
+        return _make(xp, sp, self.dtype)[3:2]
 
     def test_getitem_slice_step_2(self):
         with self.assertRaises(ValueError):


### PR DESCRIPTION
Backport of #2776