### PR TITLE
Implement `flatiter.copy()`

### DIFF
--- a/cupy/indexing/iterate.py
+++ b/cupy/indexing/iterate.py
@@ -113,11 +113,13 @@ class flatiter:
         self._index += 1
         return self[index]
 
-    # TODO(Takagi): Implement copy
+    def copy(self):
+        """Get a copy of the iterator as a 1-D array."""
+        return self.base.flatten()
 
     @property
     def base(self):
-        """A reference to the array that is iterate over."""
+        """A reference to the array that is iterated over."""
         return self._base
 
     # TODO(Takagi): Implement coords

--- a/tests/cupy_tests/indexing_tests/test_iterate.py
+++ b/tests/cupy_tests/indexing_tests/test_iterate.py
@@ -19,12 +19,12 @@ class TestFlatiter(unittest.TestCase):
         a = testing.shaped_arange((2, 3, 4), cupy)
         e = a.flatten()
         for ai, ei in zip(a.flat, e):
-            assert(ai == ei)
+            assert ai == ei
 
     def test_len(self):
         a = cupy.zeros((2, 3, 4))
-        assert(len(a.flat) == 24)
-        assert(len(a[::2].flat) == 12)
+        assert len(a.flat) == 24
+        assert len(a[::2].flat) == 12
 
     @testing.numpy_cupy_array_equal()
     def test_copy(self, xp):

--- a/tests/cupy_tests/indexing_tests/test_iterate.py
+++ b/tests/cupy_tests/indexing_tests/test_iterate.py
@@ -26,6 +26,20 @@ class TestFlatiter(unittest.TestCase):
         assert(len(a.flat) == 24)
         assert(len(a[::2].flat) == 12)
 
+    @testing.numpy_cupy_array_equal()
+    def test_copy(self, xp):
+        a = testing.shaped_arange((2, 3, 4), xp)
+        o = a.flat.copy()
+        assert a is not o
+        return a.flat.copy()
+
+    @testing.numpy_cupy_array_equal()
+    def test_copy_next(self, xp):
+        a = testing.shaped_arange((2, 3, 4), xp)
+        it = a.flat
+        it.__next__()
+        return it.copy()  # Returns the flattened copy of whole `a`
+
 
 @testing.parameterize(
     {'shape': (2, 3, 4), 'index': Ellipsis},


### PR DESCRIPTION
Follows #3165.

This PR implements `flatiter.copy()` that returns a copy of the iterator as a 1-D array.