### PR TITLE
Detect and show Thrust build version

### DIFF
--- a/cupy/cuda/cupy_thrust.h
+++ b/cupy/cuda/cupy_thrust.h
@@ -2,6 +2,7 @@
 #define INCLUDE_GUARD_CUPY_CUDA_THRUST_H
 
 #ifndef CUPY_NO_CUDA
+#include <thrust/version.h>  // for THRUST_VERSION
 
 namespace cupy {
 
@@ -34,6 +35,7 @@ void _argsort_fp16(size_t *, void *, void *, const std::vector<ptrdiff_t>&, intp
 #else // CUPY_NO_CUDA
 
 #include "cupy_common.h"
+#define THRUST_VERSION 0
 
 namespace cupy {
 

--- a/cupy/cuda/thrust.pyx
+++ b/cupy/cuda/thrust.pyx
@@ -65,10 +65,18 @@ cdef extern from '../cuda/cupy_thrust.h' namespace 'cupy::thrust':
     void _argsort_fp16(size_t *, void *, void *,
                        const vector.vector[ptrdiff_t]&, intptr_t, void *)
 
+cdef extern from '../cuda/cupy_thrust.h':
+    # Build-time version
+    int THRUST_VERSION
+
 
 ###############################################################################
 # Python interface
 ###############################################################################
+
+def get_build_version():
+    return THRUST_VERSION
+
 
 cpdef sort(dtype, intptr_t data_start, intptr_t keys_start,
            const vector.vector[ptrdiff_t]& shape) except +:

--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -250,7 +250,8 @@ if bool(int(os.environ.get('CUPY_SETUP_ENABLE_THRUST', 1))):
             'libraries': [
                 'cudart',
             ],
-            'check_method': build.check_cuda_version,
+            'check_method': build.check_thrust_version,
+            'version_method': build.get_thrust_version,
         })
 
 

--- a/cupyx/runtime.py
+++ b/cupyx/runtime.py
@@ -5,6 +5,11 @@ import os
 import cupy
 
 try:
+    import cupy.cuda.thrust as thrust
+except ImportError:
+    thrust = None
+
+try:
     import cupy.cuda.cudnn as cudnn
 except ImportError:
     cudnn = None
@@ -88,6 +93,7 @@ class _RuntimeInfo(object):
     cusolver_version = None
     cusparse_version = None
     nvrtc_version = None
+    thrust_version = None
 
     # Optional Libraries
     cudnn_build_version = None
@@ -132,6 +138,9 @@ class _RuntimeInfo(object):
             cupy.cuda.nvrtc.getVersion,
             cupy.cuda.nvrtc.NVRTCError)
 
+        if thrust is not None:
+            self.thrust_version = thrust.get_build_version()
+
         if cudnn is not None:
             self.cudnn_build_version = cudnn.get_build_version()
             self.cudnn_version = _eval_or_error(
@@ -170,6 +179,7 @@ class _RuntimeInfo(object):
             ('cuSOLVER Version', self.cusolver_version),
             ('cuSPARSE Version', self.cusparse_version),
             ('NVRTC Version', self.nvrtc_version),
+            ('Thrust Version', self.thrust_version),
         ]
 
         records += [

--- a/install/build.py
+++ b/install/build.py
@@ -253,6 +253,7 @@ def _get_compiler_base_options():
 
 
 _cuda_version = None
+_thrust_version = None
 _cudnn_version = None
 _nccl_version = None
 
@@ -297,6 +298,39 @@ def get_cuda_version(formatted=False):
     if formatted:
         return _format_cuda_version(_cuda_version)
     return _cuda_version
+
+
+def check_thrust_version(compiler, settings):
+    global _thrust_version
+
+    try:
+        out = build_and_run(compiler, '''
+        #include <thrust/version.h>
+        #include <stdio.h>
+
+        int main() {
+          printf("%d", THRUST_VERSION);
+          return 0;
+        }
+        ''', include_dirs=settings['include_dirs'])
+    except Exception as e:
+        utils.print_warning('Cannot check Thrust version\n{0}'.format(e))
+        return False
+
+    _thrust_version = int(out)
+
+    return True
+
+
+def get_thrust_version(formatted=False):
+    """Return Thrust version cached in check_thrust_version()."""
+    global _thrust_version
+    if _thrust_version is None:
+        msg = 'check_thrust_version() must be called first.'
+        raise RuntimeError(msg)
+    if formatted:
+        return str(_thrust_version)
+    return _thrust_version
 
 
 def check_cudnn_version(compiler, settings):


### PR DESCRIPTION
Companion PR of 03f4964 from #2584. Starting CUB & Thrust 1.9.9 they are version-locked with each other (in theory, explained below), so this could help detect/debug if there's any incompatibility issue.

* Thrust and CUB have a circular dependency. However, if we use CUB alone, there's a good chance it's decoupled from Thrust, unless iterators are used (see https://github.com/NVlabs/cub/issues/182#issuecomment-631272979). I tested with CuPy that the latest CUB 1.9.10 works with an old Thrust from CUDA 10.0, so I don't think there's any concern here, and this is just for richer config output.