### PR TITLE
Add optuna and remove theano for doctest requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ requirements = {
     ],
     'doctest': [
         'matplotlib',
-        'theano',
+        'optuna',
     ],
     'docs': [
         'sphinx==3.0.4',


### PR DESCRIPTION
(note: currently this configuration is not used by CIs)

Theano is not needed in CuPy (maybe it was inherited from Chainer).