### PR TITLE
Remove wrong tests in `test_raw.py`

### DIFF
--- a/tests/cupy_tests/core_tests/test_raw.py
+++ b/tests/cupy_tests/core_tests/test_raw.py
@@ -746,6 +746,46 @@ class TestRaw(unittest.TestCase):
             assert cupy.allclose(y, x1 + x2)
 
     @testing.multi_gpu(2)
+    def test_context_switch_RawModule3(self):
+        # run test_load_cubin() on another device
+        # generate cubin in the temp dir and load it on device 0
+
+        device0 = cupy.cuda.Device(0)
+        device1 = cupy.cuda.Device(1)
+        if device0.compute_capability != device1.compute_capability:
+            raise pytest.skip()
+
+        with device0:
+            file_path = self._generate_file('cubin')
+            mod = cupy.RawModule(path=file_path, backend=self.backend)
+
+        # in this test, reloading happens at get_function()
+        with device1:
+            ker = mod.get_function('test_div')
+            x1, x2, y = self._helper(ker, cupy.float32)
+            assert cupy.allclose(y, x1 / (x2 + 1.0))
+
+    @testing.multi_gpu(2)
+    def test_context_switch_RawModule4(self):
+        # run test_load_cubin() on another device
+        # generate cubin in the temp dir and load it on device 0
+
+        device0 = cupy.cuda.Device(0)
+        device1 = cupy.cuda.Device(1)
+        if device0.compute_capability != device1.compute_capability:
+            raise pytest.skip()
+
+        with device0:
+            file_path = self._generate_file('cubin')
+            mod = cupy.RawModule(path=file_path, backend=self.backend)
+            ker = mod.get_function('test_div')
+
+        # in this test, reloading happens at kernel launch
+        with device1:
+            x1, x2, y = self._helper(ker, cupy.float32)
+            assert cupy.allclose(y, x1 / (x2 + 1.0))
+
+    @testing.multi_gpu(2)
     def test_context_switch_RawModule5(self):
         # run test_template_specialization() on another device
         # in this test, re-compiling happens at get_function()

--- a/tests/cupy_tests/core_tests/test_raw.py
+++ b/tests/cupy_tests/core_tests/test_raw.py
@@ -746,32 +746,6 @@ class TestRaw(unittest.TestCase):
             assert cupy.allclose(y, x1 + x2)
 
     @testing.multi_gpu(2)
-    def test_context_switch_RawModule3(self):
-        # run test_load_cubin() on another device
-        # generate cubin in the temp dir and load it on device 0
-        file_path = self._generate_file('cubin')
-        mod = cupy.RawModule(path=file_path, backend=self.backend)
-
-        # in this test, reloading happens at get_function()
-        with cupy.cuda.Device(1):
-            ker = mod.get_function('test_div')
-            x1, x2, y = self._helper(ker, cupy.float32)
-            assert cupy.allclose(y, x1 / (x2 + 1.0))
-
-    @testing.multi_gpu(2)
-    def test_context_switch_RawModule4(self):
-        # run test_load_cubin() on another device
-        # generate cubin in the temp dir and load it on device 0
-        file_path = self._generate_file('cubin')
-        mod = cupy.RawModule(path=file_path, backend=self.backend)
-        ker = mod.get_function('test_div')
-
-        # in this test, reloading happens at kernel launch
-        with cupy.cuda.Device(1):
-            x1, x2, y = self._helper(ker, cupy.float32)
-            assert cupy.allclose(y, x1 / (x2 + 1.0))
-
-    @testing.multi_gpu(2)
     def test_context_switch_RawModule5(self):
         # run test_template_specialization() on another device
         # in this test, re-compiling happens at get_function()


### PR DESCRIPTION
These tests are not guaranteed to work when the compute capability of Device(0) exceeds that of Device(1).