### PR TITLE
Add `choose_conv_method`

### DIFF
--- a/cupyx/__init__.py
+++ b/cupyx/__init__.py
@@ -14,5 +14,7 @@ from cupyx._ufunc_config import errstate  # NOQA
 from cupyx._ufunc_config import geterr  # NOQA
 from cupyx._ufunc_config import seterr  # NOQA
 
+from cupyx.scipy import signal  # NOQA
+
 from cupy.core.syncdetect import allow_synchronize  # NOQA
 from cupy.core.syncdetect import DeviceSynchronized  # NOQA

--- a/cupyx/scipy/signal/__init__.py
+++ b/cupyx/scipy/signal/__init__.py
@@ -1,0 +1,2 @@
+# "NOQA" to suppress flake8 warning
+from cupyx.scipy.signal.signaltools import choose_conv_method  # NOQA

--- a/cupyx/scipy/signal/signaltools.py
+++ b/cupyx/scipy/signal/signaltools.py
@@ -1,5 +1,3 @@
-import math
-
 
 def choose_conv_method(in1, in2, mode='full'):
     """Find the fastest convolution/correlation method.
@@ -38,26 +36,5 @@ def _fftconv_faster(x, h, mode):
     .. seealso:: :func: `scipy.signal.signaltools._fftconv_faster`
 
     """
-    fft_ops, direct_ops = _conv_ops(x.size, h.size, mode)
     # TODO(Dahlia-Chehata): replace with GPU-based constants.
     return True
-
-
-def _conv_ops(siz1, siz2, mode):
-    if mode == 'full':
-        direct_ops = siz1 * siz2
-    elif mode == 'valid':
-        if siz2 >= siz1:
-            direct_ops = (siz2 - siz1 + 1) * siz1
-        else:
-            direct_ops = (siz1 - siz2 + 1) * siz2
-    elif mode == 'same':
-        if siz1 < siz2:
-            direct_ops = siz1 * siz2
-        else:
-            direct_ops = siz1 * siz2 - (siz2 / 2) * ((siz2 + 1) / 2)
-    else:
-        raise ValueError('Unsupported mode')
-    N = siz1 + siz2 - 1
-    fft_ops = 3 * N * math.log(N)
-    return fft_ops, direct_ops

--- a/cupyx/scipy/signal/signaltools.py
+++ b/cupyx/scipy/signal/signaltools.py
@@ -15,9 +15,8 @@ def choose_conv_method(in1, in2, mode='full'):
 
     .. warning::
         This function currently doesn't support measure option,
-        nor multidimensional inputs. It differs from SciPy's
-        behavior in handling signed and unsigned integers by
-        always choosing ``direct`` convolution method.
+        nor multidimensional inputs. It does not guarantee
+        the compatibility of the return value to NumPy's one.
 
     .. seealso:: :func:`scipy.signal.choose_conv_method`
 
@@ -40,16 +39,8 @@ def _fftconv_faster(x, h, mode):
 
     """
     fft_ops, direct_ops = _conv_ops(x.size, h.size, mode)
-    offset = -1e-3
-    constants = {
-        'valid': (1.89095737e-9, 2.1364985e-10, offset),
-        'full': (1.7649070e-9, 2.1414831e-10, offset),
-        'same': (3.2646654e-9, 2.8478277e-10, offset)
-        if h.size <= x.size
-        else (3.21635404e-9, 1.1773253e-8, -1e-5),
-    }
-    O_fft, O_direct, O_offset = constants[mode]
-    return O_fft * fft_ops < O_direct * direct_ops + O_offset
+    # TODO(Dahlia-Chehata): replace with GPU-based constants.
+    return True
 
 
 def _conv_ops(siz1, siz2, mode):

--- a/cupyx/scipy/signal/signaltools.py
+++ b/cupyx/scipy/signal/signaltools.py
@@ -1,0 +1,87 @@
+import math
+
+import cupy
+
+
+def _numeric_arrays(arrays, kinds='buifc'):
+    if type(arrays) == cupy.ndarray:
+        return arrays.dtype.kind in kinds
+    for array in arrays:
+        if array.dtype.kind not in kinds:
+            return False
+    return True
+
+
+def choose_conv_method(in1, in2, mode='full'):
+    """Find the fastest convolution/correlation method.
+
+    Args:
+        in1 (cupy.ndarray): first input.
+        in2 (cupy.ndarray): second input.
+        mode (str, optional): `valid`, `same`, `full`
+
+    Returns:
+        str: A string indicating which convolution method is fastest,
+         either ‘direct’ or ‘fft’.
+
+    .. warning::
+        This function currently doesn't support measure option,
+        nor multidimensional inputs.
+
+    .. seealso:: :func:`scipy.signal.choose_conv_method`
+
+    """
+    if in1.ndim != 1 or in2.ndim != 1:
+        raise NotImplementedError('Only 1d inputs are supported currently')
+
+    if any([_numeric_arrays([x], kinds='ui') for x in [in1, in2]]):
+        # max_value = int(cupy.abs(in1).max()) * int(cupy.abs(in2).max())
+        # max_value *= int(min(in1.size, in2.size))
+        # if max_value > 2 ** cupy.finfo('float').nmant - 1:
+        return 'direct'
+
+    if _numeric_arrays([in1, in2], kinds='b'):
+        return 'direct'
+
+    if _fftconv_faster(in1, in2, mode):
+        return 'fft'
+
+    return 'direct'
+
+
+def _fftconv_faster(x, h, mode):
+    """
+    .. seealso:: :func: `scipy.signal.signaltools._fftconv_faster`
+
+    """
+    fft_ops, direct_ops = _conv_ops(x.size, h.size, mode)
+    offset = -1e-3
+    constants = {
+        'valid': (1.89095737e-9, 2.1364985e-10, offset),
+        'full': (1.7649070e-9, 2.1414831e-10, offset),
+        'same': (3.2646654e-9, 2.8478277e-10, offset)
+        if h.size <= x.size
+        else (3.21635404e-9, 1.1773253e-8, -1e-5),
+    }
+    O_fft, O_direct, O_offset = constants[mode]
+    return O_fft * fft_ops < O_direct * direct_ops + O_offset
+
+
+def _conv_ops(siz1, siz2, mode):
+    if mode == "full":
+        direct_ops = siz1 * siz2
+    elif mode == "valid":
+        if siz2 >= siz1:
+            direct_ops = (siz2 - siz1 + 1) * siz1
+        else:
+            direct_ops = (siz1 - siz2 + 1) * siz2
+    elif mode == "same":
+        if siz1 < siz2:
+            direct_ops = siz1 * siz2
+        else:
+            direct_ops = siz1 * siz2 - (siz2 / 2) * ((siz2 + 1) / 2)
+    else:
+        raise ValueError('Unsupported mode')
+    N = siz1 + siz2 - 1
+    fft_ops = 3 * N * math.log(N)
+    return fft_ops, direct_ops

--- a/cupyx/scipy/signal/signaltools.py
+++ b/cupyx/scipy/signal/signaltools.py
@@ -1,16 +1,5 @@
 import math
 
-import cupy
-
-
-def _numeric_arrays(arrays, kinds='buifc'):
-    if type(arrays) == cupy.ndarray:
-        return arrays.dtype.kind in kinds
-    for array in arrays:
-        if array.dtype.kind not in kinds:
-            return False
-    return True
-
 
 def choose_conv_method(in1, in2, mode='full'):
     """Find the fastest convolution/correlation method.
@@ -18,15 +7,17 @@ def choose_conv_method(in1, in2, mode='full'):
     Args:
         in1 (cupy.ndarray): first input.
         in2 (cupy.ndarray): second input.
-        mode (str, optional): `valid`, `same`, `full`
+        mode (str, optional): ``valid``, ``same``, ``full``.
 
     Returns:
         str: A string indicating which convolution method is fastest,
-         either ‘direct’ or ‘fft’.
+        either ``direct`` or ``fft1``.
 
     .. warning::
         This function currently doesn't support measure option,
-        nor multidimensional inputs.
+        nor multidimensional inputs. It differs from SciPy's
+        behavior in handling signed and unsigned integers by
+        always choosing ``direct`` convolution method.
 
     .. seealso:: :func:`scipy.signal.choose_conv_method`
 
@@ -34,7 +25,7 @@ def choose_conv_method(in1, in2, mode='full'):
     if in1.ndim != 1 or in2.ndim != 1:
         raise NotImplementedError('Only 1d inputs are supported currently')
 
-    if _numeric_arrays([in1, in2], kinds='bui'):
+    if in1.dtype.kind in 'bui' or in2.dtype.kind in 'bui':
         return 'direct'
 
     if _fftconv_faster(in1, in2, mode):

--- a/cupyx/scipy/signal/signaltools.py
+++ b/cupyx/scipy/signal/signaltools.py
@@ -34,13 +34,7 @@ def choose_conv_method(in1, in2, mode='full'):
     if in1.ndim != 1 or in2.ndim != 1:
         raise NotImplementedError('Only 1d inputs are supported currently')
 
-    if any([_numeric_arrays([x], kinds='ui') for x in [in1, in2]]):
-        # max_value = int(cupy.abs(in1).max()) * int(cupy.abs(in2).max())
-        # max_value *= int(min(in1.size, in2.size))
-        # if max_value > 2 ** cupy.finfo('float').nmant - 1:
-        return 'direct'
-
-    if _numeric_arrays([in1, in2], kinds='b'):
+    if _numeric_arrays([in1, in2], kinds='bui'):
         return 'direct'
 
     if _fftconv_faster(in1, in2, mode):
@@ -68,14 +62,14 @@ def _fftconv_faster(x, h, mode):
 
 
 def _conv_ops(siz1, siz2, mode):
-    if mode == "full":
+    if mode == 'full':
         direct_ops = siz1 * siz2
-    elif mode == "valid":
+    elif mode == 'valid':
         if siz2 >= siz1:
             direct_ops = (siz2 - siz1 + 1) * siz1
         else:
             direct_ops = (siz1 - siz2 + 1) * siz2
-    elif mode == "same":
+    elif mode == 'same':
         if siz1 < siz2:
             direct_ops = siz1 * siz2
         else:

--- a/cupyx/scipy/signal/signaltools.py
+++ b/cupyx/scipy/signal/signaltools.py
@@ -14,7 +14,7 @@ def choose_conv_method(in1, in2, mode='full'):
     .. warning::
         This function currently doesn't support measure option,
         nor multidimensional inputs. It does not guarantee
-        the compatibility of the return value to NumPy's one.
+        the compatibility of the return value to SciPy's one.
 
     .. seealso:: :func:`scipy.signal.choose_conv_method`
 

--- a/docs/source/reference/scipy.rst
+++ b/docs/source/reference/scipy.rst
@@ -17,3 +17,4 @@ These functions cover a subset of
    ndimage
    sparse
    special
+   signal

--- a/docs/source/reference/signal.rst
+++ b/docs/source/reference/signal.rst
@@ -1,0 +1,13 @@
+Signal processing
+=================
+
+.. https://docs.scipy.org/doc/scipy/reference/signal.html
+
+Convolution
+-----------
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+
+    cupyx.scipy.signal.choose_conv_method

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
@@ -10,8 +10,7 @@ from cupy import testing
 
 @testing.gpu
 @testing.parameterize(*testing.product({
-    'mode': ['valid', 'same', 'full'],
-    'shape': [((), (5,)), ((3, 4, 5), (1, 2))]
+    'mode': ['valid', 'same', 'full']
 }))
 @testing.with_requires('scipy')
 class TestChooseConvMethod(unittest.TestCase):
@@ -23,17 +22,36 @@ class TestChooseConvMethod(unittest.TestCase):
         b = testing.shaped_arange((5,), xp, dtype)
         return scp.signal.choose_conv_method(a, b, mode=self.mode)
 
-    @testing.for_dtypes('bBhHiIlLqQpP')
-    def test_choose_conv_method2(self, dtype):
+    @testing.for_dtypes('efdFD')
+    @testing.numpy_cupy_equal(scipy_name='scp')
+    def test_choose_conv_method2(self, xp, scp, dtype):
+        a = testing.shaped_arange((5,), xp, dtype)
+        b = testing.shaped_arange((10,), xp, dtype)
+        return scp.signal.choose_conv_method(a, b, mode=self.mode)
+
+    @testing.for_dtypes('efdFD')
+    @testing.numpy_cupy_equal(scipy_name='scp')
+    def test_choose_conv_method_same(self, xp, scp, dtype):
+        a = testing.shaped_arange((10,), xp, dtype)
+        return scp.signal.choose_conv_method(a, a, mode=self.mode)
+
+    @testing.for_int_dtypes()
+    def test_choose_conv_method_int(self, dtype):
         a = testing.shaped_arange((10,), cupy, dtype)
-        b = testing.shaped_arange((20,), cupy, dtype)
+        b = testing.shaped_arange((5,), cupy, dtype)
         assert cupyx.scipy.signal.choose_conv_method(
             a, b, mode=self.mode) == 'direct'
 
     @testing.for_all_dtypes()
     def test_choose_conv_method_ndim(self, dtype):
-        shape_a, shape_b = self.shape
-        a = testing.shaped_arange(shape_a, cupy, dtype)
-        b = testing.shaped_arange(shape_b, cupy, dtype)
+        a = testing.shaped_arange((3, 4, 5), cupy, dtype)
+        b = testing.shaped_arange((1, 2), cupy, dtype)
+        with pytest.raises(NotImplementedError):
+            cupyx.scipy.signal.choose_conv_method(a, b, mode=self.mode)
+
+    @testing.for_all_dtypes()
+    def test_choose_conv_method_zero_dim(self, dtype):
+        a = testing.shaped_arange((), cupy, dtype)
+        b = testing.shaped_arange((5,), cupy, dtype)
         with pytest.raises(NotImplementedError):
             cupyx.scipy.signal.choose_conv_method(a, b, mode=self.mode)

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
@@ -18,22 +18,16 @@ class TestChooseConvMethod(unittest.TestCase):
     @testing.for_dtypes('efdFD')
     @testing.numpy_cupy_equal(scipy_name='scp')
     def test_choose_conv_method1(self, xp, scp, dtype):
-        a = testing.shaped_arange((10,), xp, dtype)
-        b = testing.shaped_arange((5,), xp, dtype)
+        a = testing.shaped_arange((10000,), xp, dtype)
+        b = testing.shaped_arange((5000,), xp, dtype)
         return scp.signal.choose_conv_method(a, b, mode=self.mode)
 
     @testing.for_dtypes('efdFD')
     @testing.numpy_cupy_equal(scipy_name='scp')
     def test_choose_conv_method2(self, xp, scp, dtype):
-        a = testing.shaped_arange((5,), xp, dtype)
-        b = testing.shaped_arange((10,), xp, dtype)
+        a = testing.shaped_arange((5000,), xp, dtype)
+        b = testing.shaped_arange((10000,), xp, dtype)
         return scp.signal.choose_conv_method(a, b, mode=self.mode)
-
-    @testing.for_dtypes('efdFD')
-    @testing.numpy_cupy_equal(scipy_name='scp')
-    def test_choose_conv_method_same(self, xp, scp, dtype):
-        a = testing.shaped_arange((10,), xp, dtype)
-        return scp.signal.choose_conv_method(a, a, mode=self.mode)
 
     @testing.for_int_dtypes()
     def test_choose_conv_method_int(self, dtype):

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
@@ -1,0 +1,39 @@
+import unittest
+
+import pytest
+import scipy.signal  # NOQA
+
+import cupy
+import cupyx
+from cupy import testing
+
+
+@testing.gpu
+@testing.parameterize(*testing.product({
+    'mode': ['valid', 'same', 'full'],
+    'shape': [((), (5,)), ((3, 4, 5), (1, 2))]
+}))
+@testing.with_requires('scipy')
+class TestChooseConvMethod(unittest.TestCase):
+
+    @testing.for_dtypes('efdFD')
+    @testing.numpy_cupy_equal(scipy_name='scp')
+    def test_choose_conv_method1(self, xp, scp, dtype):
+        a = testing.shaped_arange((10,), xp, dtype)
+        b = testing.shaped_arange((5,), xp, dtype)
+        return scp.signal.choose_conv_method(a, b, mode=self.mode)
+
+    @testing.for_dtypes('bBhHiIlLqQpP')
+    def test_choose_conv_method2(self, dtype):
+        a = testing.shaped_arange((10,), cupy, dtype)
+        b = testing.shaped_arange((20,), cupy, dtype)
+        assert cupyx.scipy.signal.choose_conv_method(
+            a, b, mode=self.mode) == 'direct'
+
+    @testing.for_all_dtypes()
+    def test_choose_conv_method_ndim(self, dtype):
+        shape_a, shape_b = self.shape
+        a = testing.shaped_arange(shape_a, cupy, dtype)
+        b = testing.shaped_arange(shape_b, cupy, dtype)
+        with pytest.raises(NotImplementedError):
+            cupyx.scipy.signal.choose_conv_method(a, b, mode=self.mode)

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
@@ -1,7 +1,6 @@
 import unittest
 
 import pytest
-import scipy.signal  # NOQA
 
 import cupy
 import cupyx
@@ -12,22 +11,21 @@ from cupy import testing
 @testing.parameterize(*testing.product({
     'mode': ['valid', 'same', 'full']
 }))
-@testing.with_requires('scipy')
 class TestChooseConvMethod(unittest.TestCase):
 
     @testing.for_dtypes('efdFD')
-    @testing.numpy_cupy_equal(scipy_name='scp')
-    def test_choose_conv_method1(self, xp, scp, dtype):
-        a = testing.shaped_arange((10000,), xp, dtype)
-        b = testing.shaped_arange((5000,), xp, dtype)
-        return scp.signal.choose_conv_method(a, b, mode=self.mode)
+    def test_choose_conv_method1(self, dtype):
+        a = testing.shaped_arange((10000,), cupy, dtype)
+        b = testing.shaped_arange((5000,), cupy, dtype)
+        assert cupyx.scipy.signal.choose_conv_method(
+            a, b, mode=self.mode) == 'fft'
 
     @testing.for_dtypes('efdFD')
-    @testing.numpy_cupy_equal(scipy_name='scp')
-    def test_choose_conv_method2(self, xp, scp, dtype):
-        a = testing.shaped_arange((5000,), xp, dtype)
-        b = testing.shaped_arange((10000,), xp, dtype)
-        return scp.signal.choose_conv_method(a, b, mode=self.mode)
+    def test_choose_conv_method2(self, dtype):
+        a = testing.shaped_arange((5000,), cupy, dtype)
+        b = testing.shaped_arange((10000,), cupy, dtype)
+        assert cupyx.scipy.signal.choose_conv_method(
+            a, b, mode=self.mode) == 'fft'
 
     @testing.for_int_dtypes()
     def test_choose_conv_method_int(self, dtype):


### PR DESCRIPTION
This PR blocks #3371.
It is an implementation of `scipy.signal.choose_conv_method ` (supporting only 1D inputs currently). One difference from SciPy's behaviour is that it always chooses direct convolution for signed/unsigned integers