### PR TITLE
Add mock tests to ensure `cupy.cuda.cub` is used

### DIFF
--- a/cupy/testing/__init__.py
+++ b/cupy/testing/__init__.py
@@ -43,7 +43,7 @@ from cupy.testing.helper import numpy_satisfies  # NOQA
 from cupy.testing.helper import NumpyAliasBasicTestBase  # NOQA
 from cupy.testing.helper import NumpyAliasValuesTestBase  # NOQA
 from cupy.testing.helper import NumpyError  # NOQA
-from cupy.testing.helper import CUBMockTest  # NOQA
+from cupy.testing.helper import AssertFunctionIsCalled  # NOQA
 from cupy.testing.helper import shaped_arange  # NOQA
 from cupy.testing.helper import shaped_random  # NOQA
 from cupy.testing.helper import shaped_reverse_arange  # NOQA

--- a/cupy/testing/__init__.py
+++ b/cupy/testing/__init__.py
@@ -43,6 +43,7 @@ from cupy.testing.helper import numpy_satisfies  # NOQA
 from cupy.testing.helper import NumpyAliasBasicTestBase  # NOQA
 from cupy.testing.helper import NumpyAliasValuesTestBase  # NOQA
 from cupy.testing.helper import NumpyError  # NOQA
+from cupy.testing.helper import CUBMockTest  # NOQA
 from cupy.testing.helper import shaped_arange  # NOQA
 from cupy.testing.helper import shaped_random  # NOQA
 from cupy.testing.helper import shaped_reverse_arange  # NOQA

--- a/cupy/testing/helper.py
+++ b/cupy/testing/helper.py
@@ -1256,7 +1256,7 @@ class NumpyAliasValuesTestBase(NumpyAliasTestBase):
         assert self.cupy_func(*self.args) == self.numpy_func(*self.args)
 
 
-class CUBMockTest:
+class AssertFunctionIsCalled:
 
     def __init__(self, mock_mod, **kwargs):
         self.patch = mock.patch(mock_mod, **kwargs)

--- a/cupy/testing/helper.py
+++ b/cupy/testing/helper.py
@@ -1258,8 +1258,8 @@ class NumpyAliasValuesTestBase(NumpyAliasTestBase):
 
 class CUBMockTest:
 
-    def __init__(self, mock_mod, return_value=None):
-        self.patch = mock.patch(mock_mod, return_value=return_value)
+    def __init__(self, mock_mod, **kwargs):
+        self.patch = mock.patch(mock_mod, **kwargs)
 
     def __enter__(self):
         self.handle = self.patch.__enter__()

--- a/cupy/testing/helper.py
+++ b/cupy/testing/helper.py
@@ -5,6 +5,7 @@ import os
 import random
 import traceback
 import unittest
+from unittest import mock
 import warnings
 
 import numpy
@@ -1253,3 +1254,19 @@ class NumpyAliasValuesTestBase(NumpyAliasTestBase):
 
     def test_values(self):
         assert self.cupy_func(*self.args) == self.numpy_func(*self.args)
+
+
+class CUBMockTest:
+
+    def __init__(self, mock_mod, return_value=None):
+        self.patch = mock.patch(mock_mod, return_value=return_value)
+
+    def __enter__(self):
+        self.handle = self.patch.__enter__()
+        assert self.handle.call_count == 0
+        return self.handle
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        assert self.handle.call_count == 1
+        del self.handle
+        return self.patch.__exit__(exc_type, exc_value, traceback)

--- a/tests/cupy_tests/core_tests/test_ndarray_reduction.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_reduction.py
@@ -1,5 +1,4 @@
 import unittest
-from unittest import mock
 
 import numpy
 
@@ -237,19 +236,12 @@ class TestCUBreduction(unittest.TestCase):
 
         # xp is cupy, first ensure we really use CUB
         ret = cupy.empty(())  # Cython checks return type, need to fool it
-        full_func = 'cupy.core._routines_statistics.cub.device_reduce'
-        full_patch = mock.patch(full_func, return_value=ret)
-        seg_func = 'cupy.core._routines_statistics.cub.device_segmented_reduce'
-        seg_patch = mock.patch(seg_func, return_value=ret)
-        with full_patch as f, seg_patch as s:
-            assert f.call_count == s.call_count == 0
+        if len(axis) == len(self.shape):
+            func = 'cupy.core._routines_statistics.cub.device_reduce'
+        else:
+            func = 'cupy.core._routines_statistics.cub.device_segmented_reduce'
+        with testing.CUBMockTest(func, return_value=ret):
             a.min(axis=axis)
-            if len(axis) == len(self.shape):
-                assert f.call_count == 1
-                assert s.call_count == 0
-            else:
-                assert f.call_count == 0
-                assert s.call_count == 1
         # ...then perform the actual computation
         return a.min(axis=axis)
 
@@ -269,18 +261,11 @@ class TestCUBreduction(unittest.TestCase):
 
         # xp is cupy, first ensure we really use CUB
         ret = cupy.empty(())  # Cython checks return type, need to fool it
-        full_func = 'cupy.core._routines_statistics.cub.device_reduce'
-        full_patch = mock.patch(full_func, return_value=ret)
-        seg_func = 'cupy.core._routines_statistics.cub.device_segmented_reduce'
-        seg_patch = mock.patch(seg_func, return_value=ret)
-        with full_patch as f, seg_patch as s:
-            assert f.call_count == s.call_count == 0
+        if len(axis) == len(self.shape):
+            func = 'cupy.core._routines_statistics.cub.device_reduce'
+        else:
+            func = 'cupy.core._routines_statistics.cub.device_segmented_reduce'
+        with testing.CUBMockTest(func, return_value=ret):
             a.max(axis=axis)
-            if len(axis) == len(self.shape):
-                assert f.call_count == 1
-                assert s.call_count == 0
-            else:
-                assert f.call_count == 0
-                assert s.call_count == 1
         # ...then perform the actual computation
         return a.max(axis=axis)

--- a/tests/cupy_tests/core_tests/test_ndarray_reduction.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_reduction.py
@@ -237,23 +237,20 @@ class TestCUBreduction(unittest.TestCase):
             return a.min(axis=axis)
 
         # xp is cupy, first ensure we really use CUB
+        ret = cupy.empty(())  # Cython checks return type, need to fool it
         full_func = 'cupy.core._routines_statistics.cub.device_reduce'
-        full_probe = Exception('gotcha_full')
-        full_patch = mock.patch(full_func, side_effect=full_probe)
+        full_patch = mock.patch(full_func, return_value=ret)
         seg_func = 'cupy.core._routines_statistics.cub.device_segmented_reduce'
-        seg_probe = Exception('gotcha_seg')
-        seg_patch = mock.patch(seg_func, side_effect=seg_probe)
-        with full_patch as f, seg_patch as s, pytest.raises(Exception) as e:
-            assert (f.call_count, s.call_count) == (0, 0)
+        seg_patch = mock.patch(seg_func, return_value=ret)
+        with full_patch as f, seg_patch as s:
+            assert f.call_count == s.call_count == 0
             a.min(axis=axis)
             if len(axis) == len(self.shape):
-                assert f.assert_called_with(axis=axis)
+                assert f.call_count == 1
                 assert s.call_count == 0
-                assert str(e.value) == 'gotcha_full'
             else:
                 assert f.call_count == 0
-                assert s.assert_called_with(axis=axis)
-                assert str(e.value) == 'gotcha_seg'
+                assert s.call_count == 1
         # ...then perform the actual computation
         return a.min(axis=axis)
 
@@ -272,22 +269,19 @@ class TestCUBreduction(unittest.TestCase):
             return a.max(axis=axis)
 
         # xp is cupy, first ensure we really use CUB
+        ret = cupy.empty(())  # Cython checks return type, need to fool it
         full_func = 'cupy.core._routines_statistics.cub.device_reduce'
-        full_probe = Exception('gotcha_full')
-        full_patch = mock.patch(full_func, side_effect=full_probe)
+        full_patch = mock.patch(full_func, return_value=ret)
         seg_func = 'cupy.core._routines_statistics.cub.device_segmented_reduce'
-        seg_probe = Exception('gotcha_seg')
-        seg_patch = mock.patch(seg_func, side_effect=seg_probe)
-        with full_patch as f, seg_patch as s, pytest.raises(Exception) as e:
-            assert (f.call_count, s.call_count) == (0, 0)
+        seg_patch = mock.patch(seg_func, return_value=ret)
+        with full_patch as f, seg_patch as s:
+            assert f.call_count == s.call_count == 0
             a.max(axis=axis)
             if len(axis) == len(self.shape):
-                assert f.assert_called_with(axis=axis)
+                assert f.call_count == 1
                 assert s.call_count == 0
-                assert str(e.value) == 'gotcha_full'
             else:
                 assert f.call_count == 0
-                assert s.assert_called_with(axis=axis)
-                assert str(e.value) == 'gotcha_seg'
+                assert s.call_count == 1
         # ...then perform the actual computation
         return a.max(axis=axis)

--- a/tests/cupy_tests/core_tests/test_ndarray_reduction.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_reduction.py
@@ -240,7 +240,7 @@ class TestCUBreduction(unittest.TestCase):
             func = 'cupy.core._routines_statistics.cub.device_reduce'
         else:
             func = 'cupy.core._routines_statistics.cub.device_segmented_reduce'
-        with testing.CUBMockTest(func, return_value=ret):
+        with testing.AssertFunctionIsCalled(func, return_value=ret):
             a.min(axis=axis)
         # ...then perform the actual computation
         return a.min(axis=axis)
@@ -265,7 +265,7 @@ class TestCUBreduction(unittest.TestCase):
             func = 'cupy.core._routines_statistics.cub.device_reduce'
         else:
             func = 'cupy.core._routines_statistics.cub.device_segmented_reduce'
-        with testing.CUBMockTest(func, return_value=ret):
+        with testing.AssertFunctionIsCalled(func, return_value=ret):
             a.max(axis=axis)
         # ...then perform the actual computation
         return a.max(axis=axis)

--- a/tests/cupy_tests/core_tests/test_ndarray_reduction.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_reduction.py
@@ -237,19 +237,23 @@ class TestCUBreduction(unittest.TestCase):
             return a.min(axis=axis)
 
         # xp is cupy, first ensure we really use CUB
-        full_reduction = 'cupy.core._routines_statistics.cub.device_reduce'
-        full_raise = NotImplementedError('gotcha_full')
-        segmented_reduction = ('cupy.core._routines_statistics.cub.'
-                               'device_segmented_reduce')
-        segmented_raise = NotImplementedError('gotcha_segment')
-        with mock.patch(full_reduction, side_effect=full_raise), \
-                mock.patch(segmented_reduction, side_effect=segmented_raise), \
-                pytest.raises(NotImplementedError) as e:
+        full_func = 'cupy.core._routines_statistics.cub.device_reduce'
+        full_probe = Exception('gotcha_full')
+        full_patch = mock.patch(full_func, side_effect=full_probe)
+        seg_func = 'cupy.core._routines_statistics.cub.device_segmented_reduce'
+        seg_probe = Exception('gotcha_seg')
+        seg_patch = mock.patch(seg_func, side_effect=seg_probe)
+        with full_patch as f, seg_patch as s, pytest.raises(Exception) as e:
+            assert (f.call_count, s.call_count) == (0, 0)
             a.min(axis=axis)
-        if len(axis) == len(self.shape):
-            assert str(e.value) == 'gotcha_full'
-        else:
-            assert str(e.value) == 'gotcha_segment'
+            if len(axis) == len(self.shape):
+                assert f.assert_called_with(axis=axis)
+                assert s.call_count == 0
+                assert str(e.value) == 'gotcha_full'
+            else:
+                assert f.call_count == 0
+                assert s.assert_called_with(axis=axis)
+                assert str(e.value) == 'gotcha_seg'
         # ...then perform the actual computation
         return a.min(axis=axis)
 
@@ -268,18 +272,22 @@ class TestCUBreduction(unittest.TestCase):
             return a.max(axis=axis)
 
         # xp is cupy, first ensure we really use CUB
-        full_reduction = 'cupy.core._routines_statistics.cub.device_reduce'
-        full_raise = NotImplementedError('gotcha_full')
-        segmented_reduction = ('cupy.core._routines_statistics.cub.'
-                               'device_segmented_reduce')
-        segmented_raise = NotImplementedError('gotcha_segment')
-        with mock.patch(full_reduction, side_effect=full_raise), \
-                mock.patch(segmented_reduction, side_effect=segmented_raise), \
-                pytest.raises(NotImplementedError) as e:
+        full_func = 'cupy.core._routines_statistics.cub.device_reduce'
+        full_probe = Exception('gotcha_full')
+        full_patch = mock.patch(full_func, side_effect=full_probe)
+        seg_func = 'cupy.core._routines_statistics.cub.device_segmented_reduce'
+        seg_probe = Exception('gotcha_seg')
+        seg_patch = mock.patch(seg_func, side_effect=seg_probe)
+        with full_patch as f, seg_patch as s, pytest.raises(Exception) as e:
+            assert (f.call_count, s.call_count) == (0, 0)
             a.max(axis=axis)
-        if len(axis) == len(self.shape):
-            assert str(e.value) == 'gotcha_full'
-        else:
-            assert str(e.value) == 'gotcha_segment'
+            if len(axis) == len(self.shape):
+                assert f.assert_called_with(axis=axis)
+                assert s.call_count == 0
+                assert str(e.value) == 'gotcha_full'
+            else:
+                assert f.call_count == 0
+                assert s.assert_called_with(axis=axis)
+                assert str(e.value) == 'gotcha_seg'
         # ...then perform the actual computation
         return a.max(axis=axis)

--- a/tests/cupy_tests/core_tests/test_ndarray_reduction.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_reduction.py
@@ -2,7 +2,6 @@ import unittest
 from unittest import mock
 
 import numpy
-import pytest
 
 import cupy
 from cupy import testing

--- a/tests/cupy_tests/math_tests/test_sumprod.py
+++ b/tests/cupy_tests/math_tests/test_sumprod.py
@@ -221,7 +221,7 @@ class TestCUBreduction(unittest.TestCase):
             func = 'cupy.core._routines_math.cub.device_reduce'
         else:
             func = 'cupy.core._routines_math.cub.device_segmented_reduce'
-        with testing.CUBMockTest(func, return_value=ret):
+        with testing.AssertFunctionIsCalled(func, return_value=ret):
             a.sum(axis=axis)
         # ...then perform the actual computation
         return a.sum(axis=axis)
@@ -247,7 +247,7 @@ class TestCUBreduction(unittest.TestCase):
             func = 'cupy.core._routines_math.cub.device_reduce'
         else:
             func = 'cupy.core._routines_math.cub.device_segmented_reduce'
-        with testing.CUBMockTest(func, return_value=ret):
+        with testing.AssertFunctionIsCalled(func, return_value=ret):
             a.prod(axis=axis)
         # ...then perform the actual computation
         return a.prod(axis=axis)
@@ -270,7 +270,7 @@ class TestCUBreduction(unittest.TestCase):
         # xp is cupy, first ensure we really use CUB
         ret = cupy.empty(())  # Cython checks return type, need to fool it
         func = 'cupy.core._routines_math.cub.device_scan'
-        with testing.CUBMockTest(func, return_value=ret):
+        with testing.AssertFunctionIsCalled(func, return_value=ret):
             a.cumsum()
         # ...then perform the actual computation
         return a.cumsum()
@@ -294,7 +294,7 @@ class TestCUBreduction(unittest.TestCase):
         # xp is cupy, first ensure we really use CUB
         ret = cupy.empty(())  # Cython checks return type, need to fool it
         func = 'cupy.core._routines_math.cub.device_scan'
-        with testing.CUBMockTest(func, return_value=ret):
+        with testing.AssertFunctionIsCalled(func, return_value=ret):
             a.cumprod()
         # ...then perform the actual computation
         result = a.cumprod()

--- a/tests/cupy_tests/math_tests/test_sumprod.py
+++ b/tests/cupy_tests/math_tests/test_sumprod.py
@@ -1,5 +1,4 @@
 import unittest
-from unittest import mock
 
 import numpy
 import pytest
@@ -218,19 +217,12 @@ class TestCUBreduction(unittest.TestCase):
 
         # xp is cupy, first ensure we really use CUB
         ret = cupy.empty(())  # Cython checks return type, need to fool it
-        full_func = 'cupy.core._routines_math.cub.device_reduce'
-        full_patch = mock.patch(full_func, return_value=ret)
-        seg_func = 'cupy.core._routines_math.cub.device_segmented_reduce'
-        seg_patch = mock.patch(seg_func, return_value=ret)
-        with full_patch as f, seg_patch as s:
-            assert f.call_count == s.call_count == 0
+        if len(axis) == len(self.shape):
+            func = 'cupy.core._routines_math.cub.device_reduce'
+        else:
+            func = 'cupy.core._routines_math.cub.device_segmented_reduce'
+        with testing.CUBMockTest(func, return_value=ret):
             a.sum(axis=axis)
-            if len(axis) == len(self.shape):
-                assert f.call_count == 1
-                assert s.call_count == 0
-            else:
-                assert f.call_count == 0
-                assert s.call_count == 1
         # ...then perform the actual computation
         return a.sum(axis=axis)
 
@@ -251,19 +243,12 @@ class TestCUBreduction(unittest.TestCase):
 
         # xp is cupy, first ensure we really use CUB
         ret = cupy.empty(())  # Cython checks return type, need to fool it
-        full_func = 'cupy.core._routines_math.cub.device_reduce'
-        full_patch = mock.patch(full_func, return_value=ret)
-        seg_func = 'cupy.core._routines_math.cub.device_segmented_reduce'
-        seg_patch = mock.patch(seg_func, return_value=ret)
-        with full_patch as f, seg_patch as s:
-            assert f.call_count == s.call_count == 0
+        if len(axis) == len(self.shape):
+            func = 'cupy.core._routines_math.cub.device_reduce'
+        else:
+            func = 'cupy.core._routines_math.cub.device_segmented_reduce'
+        with testing.CUBMockTest(func, return_value=ret):
             a.prod(axis=axis)
-            if len(axis) == len(self.shape):
-                assert f.call_count == 1
-                assert s.call_count == 0
-            else:
-                assert f.call_count == 0
-                assert s.call_count == 1
         # ...then perform the actual computation
         return a.prod(axis=axis)
 
@@ -284,12 +269,9 @@ class TestCUBreduction(unittest.TestCase):
 
         # xp is cupy, first ensure we really use CUB
         ret = cupy.empty(())  # Cython checks return type, need to fool it
-        full_func = 'cupy.core._routines_math.cub.device_scan'
-        full_patch = mock.patch(full_func, return_value=ret)
-        with full_patch as f:
-            assert f.call_count == 0
+        func = 'cupy.core._routines_math.cub.device_scan'
+        with testing.CUBMockTest(func, return_value=ret):
             a.cumsum()
-            assert f.call_count == 1
         # ...then perform the actual computation
         return a.cumsum()
 
@@ -311,12 +293,9 @@ class TestCUBreduction(unittest.TestCase):
 
         # xp is cupy, first ensure we really use CUB
         ret = cupy.empty(())  # Cython checks return type, need to fool it
-        full_func = 'cupy.core._routines_math.cub.device_scan'
-        full_patch = mock.patch(full_func, return_value=ret)
-        with full_patch as f:
-            assert f.call_count == 0
+        func = 'cupy.core._routines_math.cub.device_scan'
+        with testing.CUBMockTest(func, return_value=ret):
             a.cumprod()
-            assert f.call_count == 1
         # ...then perform the actual computation
         result = a.cumprod()
         return self._mitigate_cumprod(xp, dtype, result)

--- a/tests/cupy_tests/math_tests/test_sumprod.py
+++ b/tests/cupy_tests/math_tests/test_sumprod.py
@@ -217,23 +217,20 @@ class TestCUBreduction(unittest.TestCase):
             return a.sum(axis=axis)
 
         # xp is cupy, first ensure we really use CUB
+        ret = cupy.empty(())  # Cython checks return type, need to fool it
         full_func = 'cupy.core._routines_math.cub.device_reduce'
-        full_probe = Exception('gotcha_full')
-        full_patch = mock.patch(full_func, side_effect=full_probe)
+        full_patch = mock.patch(full_func, return_value=ret)
         seg_func = 'cupy.core._routines_math.cub.device_segmented_reduce'
-        seg_probe = Exception('gotcha_seg')
-        seg_patch = mock.patch(seg_func, side_effect=seg_probe)
-        with full_patch as f, seg_patch as s, pytest.raises(Exception) as e:
-            assert (f.call_count, s.call_count) == (0, 0)
+        seg_patch = mock.patch(seg_func, return_value=ret)
+        with full_patch as f, seg_patch as s:
+            assert f.call_count == s.call_count == 0
             a.sum(axis=axis)
             if len(axis) == len(self.shape):
-                assert f.assert_called_with(axis=axis)
+                assert f.call_count == 1
                 assert s.call_count == 0
-                assert str(e.value) == 'gotcha_full'
             else:
                 assert f.call_count == 0
-                assert s.assert_called_with(axis=axis)
-                assert str(e.value) == 'gotcha_seg'
+                assert s.call_count == 1
         # ...then perform the actual computation
         return a.sum(axis=axis)
 
@@ -253,23 +250,20 @@ class TestCUBreduction(unittest.TestCase):
             return a.prod(axis=axis)
 
         # xp is cupy, first ensure we really use CUB
+        ret = cupy.empty(())  # Cython checks return type, need to fool it
         full_func = 'cupy.core._routines_math.cub.device_reduce'
-        full_probe = Exception('gotcha_full')
-        full_patch = mock.patch(full_func, side_effect=full_probe)
+        full_patch = mock.patch(full_func, return_value=ret)
         seg_func = 'cupy.core._routines_math.cub.device_segmented_reduce'
-        seg_probe = Exception('gotcha_seg')
-        seg_patch = mock.patch(seg_func, side_effect=seg_probe)
-        with full_patch as f, seg_patch as s, pytest.raises(Exception) as e:
-            assert (f.call_count, s.call_count) == (0, 0)
+        seg_patch = mock.patch(seg_func, return_value=ret)
+        with full_patch as f, seg_patch as s:
+            assert f.call_count == s.call_count == 0
             a.prod(axis=axis)
             if len(axis) == len(self.shape):
-                assert f.assert_called_with(axis=axis)
+                assert f.call_count == 1
                 assert s.call_count == 0
-                assert str(e.value) == 'gotcha_full'
             else:
                 assert f.call_count == 0
-                assert s.assert_called_with(axis=axis)
-                assert str(e.value) == 'gotcha_seg'
+                assert s.call_count == 1
         # ...then perform the actual computation
         return a.prod(axis=axis)
 
@@ -289,14 +283,13 @@ class TestCUBreduction(unittest.TestCase):
             return a.cumsum()
 
         # xp is cupy, first ensure we really use CUB
+        ret = cupy.empty(())  # Cython checks return type, need to fool it
         full_func = 'cupy.core._routines_math.cub.device_scan'
-        full_probe = Exception('gotcha_full')
-        full_patch = mock.patch(full_func, side_effect=full_probe)
-        with full_patch as f, pytest.raises(Exception) as e:
+        full_patch = mock.patch(full_func, return_value=ret)
+        with full_patch as f:
             assert f.call_count == 0
             a.cumsum()
             assert f.call_count == 1
-            assert str(e.value) == 'gotcha_full'
         # ...then perform the actual computation
         return a.cumsum()
 
@@ -317,14 +310,13 @@ class TestCUBreduction(unittest.TestCase):
             return self._mitigate_cumprod(xp, dtype, result)
 
         # xp is cupy, first ensure we really use CUB
+        ret = cupy.empty(())  # Cython checks return type, need to fool it
         full_func = 'cupy.core._routines_math.cub.device_scan'
-        full_probe = Exception('gotcha_full')
-        full_patch = mock.patch(full_func, side_effect=full_probe)
-        with full_patch as f, pytest.raises(Exception) as e:
+        full_patch = mock.patch(full_func, return_value=ret)
+        with full_patch as f:
             assert f.call_count == 0
             a.cumprod()
             assert f.call_count == 1
-            assert str(e.value) == 'gotcha_full'
         # ...then perform the actual computation
         result = a.cumprod()
         return self._mitigate_cumprod(xp, dtype, result)

--- a/tests/cupy_tests/math_tests/test_sumprod.py
+++ b/tests/cupy_tests/math_tests/test_sumprod.py
@@ -217,19 +217,23 @@ class TestCUBreduction(unittest.TestCase):
             return a.sum(axis=axis)
 
         # xp is cupy, first ensure we really use CUB
-        full_reduction = 'cupy.core._routines_math.cub.device_reduce'
-        full_raise = NotImplementedError('gotcha_full')
-        segmented_reduction = ('cupy.core._routines_math.cub.'
-                               'device_segmented_reduce')
-        segmented_raise = NotImplementedError('gotcha_segment')
-        with mock.patch(full_reduction, side_effect=full_raise), \
-                mock.patch(segmented_reduction, side_effect=segmented_raise), \
-                pytest.raises(NotImplementedError) as e:
+        full_func = 'cupy.core._routines_math.cub.device_reduce'
+        full_probe = Exception('gotcha_full')
+        full_patch = mock.patch(full_func, side_effect=full_probe)
+        seg_func = 'cupy.core._routines_math.cub.device_segmented_reduce'
+        seg_probe = Exception('gotcha_seg')
+        seg_patch = mock.patch(seg_func, side_effect=seg_probe)
+        with full_patch as f, seg_patch as s, pytest.raises(Exception) as e:
+            assert (f.call_count, s.call_count) == (0, 0)
             a.sum(axis=axis)
-        if len(axis) == len(self.shape):
-            assert str(e.value) == 'gotcha_full'
-        else:
-            assert str(e.value) == 'gotcha_segment'
+            if len(axis) == len(self.shape):
+                assert f.assert_called_with(axis=axis)
+                assert s.call_count == 0
+                assert str(e.value) == 'gotcha_full'
+            else:
+                assert f.call_count == 0
+                assert s.assert_called_with(axis=axis)
+                assert str(e.value) == 'gotcha_seg'
         # ...then perform the actual computation
         return a.sum(axis=axis)
 
@@ -249,19 +253,23 @@ class TestCUBreduction(unittest.TestCase):
             return a.prod(axis=axis)
 
         # xp is cupy, first ensure we really use CUB
-        full_reduction = 'cupy.core._routines_math.cub.device_reduce'
-        full_raise = NotImplementedError('gotcha_full')
-        segmented_reduction = ('cupy.core._routines_math.cub.'
-                               'device_segmented_reduce')
-        segmented_raise = NotImplementedError('gotcha_segment')
-        with mock.patch(full_reduction, side_effect=full_raise), \
-                mock.patch(segmented_reduction, side_effect=segmented_raise), \
-                pytest.raises(NotImplementedError) as e:
+        full_func = 'cupy.core._routines_math.cub.device_reduce'
+        full_probe = Exception('gotcha_full')
+        full_patch = mock.patch(full_func, side_effect=full_probe)
+        seg_func = 'cupy.core._routines_math.cub.device_segmented_reduce'
+        seg_probe = Exception('gotcha_seg')
+        seg_patch = mock.patch(seg_func, side_effect=seg_probe)
+        with full_patch as f, seg_patch as s, pytest.raises(Exception) as e:
+            assert (f.call_count, s.call_count) == (0, 0)
             a.prod(axis=axis)
-        if len(axis) == len(self.shape):
-            assert str(e.value) == 'gotcha_full'
-        else:
-            assert str(e.value) == 'gotcha_segment'
+            if len(axis) == len(self.shape):
+                assert f.assert_called_with(axis=axis)
+                assert s.call_count == 0
+                assert str(e.value) == 'gotcha_full'
+            else:
+                assert f.call_count == 0
+                assert s.assert_called_with(axis=axis)
+                assert str(e.value) == 'gotcha_seg'
         # ...then perform the actual computation
         return a.prod(axis=axis)
 
@@ -281,12 +289,14 @@ class TestCUBreduction(unittest.TestCase):
             return a.cumsum()
 
         # xp is cupy, first ensure we really use CUB
-        full_scan = 'cupy.core._routines_math.cub.device_scan'
-        full_raise = NotImplementedError('gotcha_full')
-        with mock.patch(full_scan, side_effect=full_raise), \
-                pytest.raises(NotImplementedError) as e:
+        full_func = 'cupy.core._routines_math.cub.device_scan'
+        full_probe = Exception('gotcha_full')
+        full_patch = mock.patch(full_func, side_effect=full_probe)
+        with full_patch as f, pytest.raises(Exception) as e:
+            assert f.call_count == 0
             a.cumsum()
-        assert str(e.value) == 'gotcha_full'
+            assert f.call_count == 1
+            assert str(e.value) == 'gotcha_full'
         # ...then perform the actual computation
         return a.cumsum()
 
@@ -307,12 +317,14 @@ class TestCUBreduction(unittest.TestCase):
             return self._mitigate_cumprod(xp, dtype, result)
 
         # xp is cupy, first ensure we really use CUB
-        full_scan = 'cupy.core._routines_math.cub.device_scan'
-        full_raise = NotImplementedError('gotcha_full')
-        with mock.patch(full_scan, side_effect=full_raise), \
-                pytest.raises(NotImplementedError) as e:
+        full_func = 'cupy.core._routines_math.cub.device_scan'
+        full_probe = Exception('gotcha_full')
+        full_patch = mock.patch(full_func, side_effect=full_probe)
+        with full_patch as f, pytest.raises(Exception) as e:
+            assert f.call_count == 0
             a.cumprod()
-        assert str(e.value) == 'gotcha_full'
+            assert f.call_count == 1
+            assert str(e.value) == 'gotcha_full'
         # ...then perform the actual computation
         result = a.cumprod()
         return self._mitigate_cumprod(xp, dtype, result)

--- a/tests/cupy_tests/sorting_tests/test_search.py
+++ b/tests/cupy_tests/sorting_tests/test_search.py
@@ -1,5 +1,4 @@
 import unittest
-from unittest import mock
 
 import numpy
 import pytest
@@ -184,12 +183,9 @@ class TestCUBreduction(unittest.TestCase):
 
         # xp is cupy, first ensure we really use CUB
         ret = cupy.empty(())  # Cython checks return type, need to fool it
-        full_func = 'cupy.core._routines_statistics.cub.device_reduce'
-        full_patch = mock.patch(full_func, return_value=ret)
-        with full_patch as f:
-            assert f.call_count == 0
+        func = 'cupy.core._routines_statistics.cub.device_reduce'
+        with testing.CUBMockTest(func, return_value=ret):
             a.argmin()
-            assert f.call_count == 1
         # ...then perform the actual computation
         return a.argmin()
 
@@ -208,12 +204,9 @@ class TestCUBreduction(unittest.TestCase):
 
         # xp is cupy, first ensure we really use CUB
         ret = cupy.empty(())  # Cython checks return type, need to fool it
-        full_func = 'cupy.core._routines_statistics.cub.device_reduce'
-        full_patch = mock.patch(full_func, return_value=ret)
-        with full_patch as f:
-            assert f.call_count == 0
+        func = 'cupy.core._routines_statistics.cub.device_reduce'
+        with testing.CUBMockTest(func, return_value=ret):
             a.argmax()
-            assert f.call_count == 1
         # ...then perform the actual computation
         return a.argmax()
 

--- a/tests/cupy_tests/sorting_tests/test_search.py
+++ b/tests/cupy_tests/sorting_tests/test_search.py
@@ -183,14 +183,13 @@ class TestCUBreduction(unittest.TestCase):
             return a.argmin()
 
         # xp is cupy, first ensure we really use CUB
+        ret = cupy.empty(())  # Cython checks return type, need to fool it
         full_func = 'cupy.core._routines_statistics.cub.device_reduce'
-        full_probe = Exception('gotcha_full')
-        full_patch = mock.patch(full_func, side_effect=full_probe)
-        with full_patch as f, pytest.raises(Exception) as e:
+        full_patch = mock.patch(full_func, return_value=ret)
+        with full_patch as f:
             assert f.call_count == 0
             a.argmin()
             assert f.call_count == 1
-            assert str(e.value) == 'gotcha_full'
         # ...then perform the actual computation
         return a.argmin()
 
@@ -208,14 +207,13 @@ class TestCUBreduction(unittest.TestCase):
             return a.argmax()
 
         # xp is cupy, first ensure we really use CUB
+        ret = cupy.empty(())  # Cython checks return type, need to fool it
         full_func = 'cupy.core._routines_statistics.cub.device_reduce'
-        full_probe = Exception('gotcha_full')
-        full_patch = mock.patch(full_func, side_effect=full_probe)
-        with full_patch as f, pytest.raises(Exception) as e:
+        full_patch = mock.patch(full_func, return_value=ret)
+        with full_patch as f:
             assert f.call_count == 0
             a.argmax()
             assert f.call_count == 1
-            assert str(e.value) == 'gotcha_full'
         # ...then perform the actual computation
         return a.argmax()
 

--- a/tests/cupy_tests/sorting_tests/test_search.py
+++ b/tests/cupy_tests/sorting_tests/test_search.py
@@ -184,7 +184,7 @@ class TestCUBreduction(unittest.TestCase):
         # xp is cupy, first ensure we really use CUB
         ret = cupy.empty(())  # Cython checks return type, need to fool it
         func = 'cupy.core._routines_statistics.cub.device_reduce'
-        with testing.CUBMockTest(func, return_value=ret):
+        with testing.AssertFunctionIsCalled(func, return_value=ret):
             a.argmin()
         # ...then perform the actual computation
         return a.argmin()
@@ -205,7 +205,7 @@ class TestCUBreduction(unittest.TestCase):
         # xp is cupy, first ensure we really use CUB
         ret = cupy.empty(())  # Cython checks return type, need to fool it
         func = 'cupy.core._routines_statistics.cub.device_reduce'
-        with testing.CUBMockTest(func, return_value=ret):
+        with testing.AssertFunctionIsCalled(func, return_value=ret):
             a.argmax()
         # ...then perform the actual computation
         return a.argmax()

--- a/tests/cupy_tests/sorting_tests/test_search.py
+++ b/tests/cupy_tests/sorting_tests/test_search.py
@@ -183,12 +183,14 @@ class TestCUBreduction(unittest.TestCase):
             return a.argmin()
 
         # xp is cupy, first ensure we really use CUB
-        full_scan = 'cupy.core._routines_statistics.cub.device_reduce'
-        full_raise = NotImplementedError('gotcha_full')
-        with mock.patch(full_scan, side_effect=full_raise), \
-                pytest.raises(NotImplementedError) as e:
+        full_func = 'cupy.core._routines_statistics.cub.device_reduce'
+        full_probe = Exception('gotcha_full')
+        full_patch = mock.patch(full_func, side_effect=full_probe)
+        with full_patch as f, pytest.raises(Exception) as e:
+            assert f.call_count == 0
             a.argmin()
-        assert str(e.value) == 'gotcha_full'
+            assert f.call_count == 1
+            assert str(e.value) == 'gotcha_full'
         # ...then perform the actual computation
         return a.argmin()
 
@@ -206,12 +208,14 @@ class TestCUBreduction(unittest.TestCase):
             return a.argmax()
 
         # xp is cupy, first ensure we really use CUB
-        full_scan = 'cupy.core._routines_statistics.cub.device_reduce'
-        full_raise = NotImplementedError('gotcha_full')
-        with mock.patch(full_scan, side_effect=full_raise), \
-                pytest.raises(NotImplementedError) as e:
+        full_func = 'cupy.core._routines_statistics.cub.device_reduce'
+        full_probe = Exception('gotcha_full')
+        full_patch = mock.patch(full_func, side_effect=full_probe)
+        with full_patch as f, pytest.raises(Exception) as e:
+            assert f.call_count == 0
             a.argmax()
-        assert str(e.value) == 'gotcha_full'
+            assert f.call_count == 1
+            assert str(e.value) == 'gotcha_full'
         # ...then perform the actual computation
         return a.argmax()
 

--- a/tests/cupy_tests/sorting_tests/test_search.py
+++ b/tests/cupy_tests/sorting_tests/test_search.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest import mock
 
 import numpy
 import pytest
@@ -177,6 +178,18 @@ class TestCUBreduction(unittest.TestCase):
             a = xp.ascontiguousarray(a)
         else:
             a = xp.asfortranarray(a)
+
+        if xp is numpy:
+            return a.argmin()
+
+        # xp is cupy, first ensure we really use CUB
+        full_scan = 'cupy.core._routines_statistics.cub.device_reduce'
+        full_raise = NotImplementedError('gotcha_full')
+        with mock.patch(full_scan, side_effect=full_raise), \
+                pytest.raises(NotImplementedError) as e:
+            a.argmin()
+        assert str(e.value) == 'gotcha_full'
+        # ...then perform the actual computation
         return a.argmin()
 
     @testing.for_dtypes('bhilBHILefdFD')
@@ -188,6 +201,18 @@ class TestCUBreduction(unittest.TestCase):
             a = xp.ascontiguousarray(a)
         else:
             a = xp.asfortranarray(a)
+
+        if xp is numpy:
+            return a.argmax()
+
+        # xp is cupy, first ensure we really use CUB
+        full_scan = 'cupy.core._routines_statistics.cub.device_reduce'
+        full_raise = NotImplementedError('gotcha_full')
+        with mock.patch(full_scan, side_effect=full_raise), \
+                pytest.raises(NotImplementedError) as e:
+            a.argmax()
+        assert str(e.value) == 'gotcha_full'
+        # ...then perform the actual computation
         return a.argmax()
 
 

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -1550,7 +1550,7 @@ class TestCUBspmv(unittest.TestCase):
 
         # xp is cupy, first ensure we really use CUB
         func = 'cupyx.scipy.sparse.csr.device_csrmv'
-        with testing.CUBMockTest(func):
+        with testing.AssertFunctionIsCalled(func):
             m * x
         # ...then perform the actual computation
         return m * x

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -1551,10 +1551,12 @@ class TestCUBspmv(unittest.TestCase):
 
         # xp is cupy, first ensure we really use CUB
         func = 'cupyx.scipy.sparse.csr.device_csrmv'
-        side_effect = NotImplementedError('gotcha')
-        with mock.patch(func, side_effect=side_effect), \
-                pytest.raises(NotImplementedError) as e:
+        probe = Exception('gotcha')
+        patch = mock.patch(func, side_effect=probe)
+        with patch as f, pytest.raises(Exception) as e:
+            assert f.call_count == 0
             m * x
-        assert str(e.value) == 'gotcha'
+            assert f.call_count == 1
+            assert str(e.value) == 'gotcha'
         # ...then perform the actual computation
         return m * x

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -1551,12 +1551,9 @@ class TestCUBspmv(unittest.TestCase):
 
         # xp is cupy, first ensure we really use CUB
         func = 'cupyx.scipy.sparse.csr.device_csrmv'
-        probe = Exception('gotcha')
-        patch = mock.patch(func, side_effect=probe)
-        with patch as f, pytest.raises(Exception) as e:
+        with mock.patch(func) as f:
             assert f.call_count == 0
             m * x
             assert f.call_count == 1
-            assert str(e.value) == 'gotcha'
         # ...then perform the actual computation
         return m * x

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -1,5 +1,6 @@
 import pickle
 import unittest
+from unittest import mock
 
 import numpy
 import pytest
@@ -1526,10 +1527,9 @@ class TestCsrMatrixGetitem2(unittest.TestCase):
         return _make(xp, sp, self.dtype)[None:4]
 
 
+# CUB SpMV works only when the matrix size is nonzero
 @testing.parameterize(*testing.product({
-    'make_method': [
-        '_make', '_make_unordered', '_make_empty', '_make_duplicate',
-        '_make_shape'],
+    'make_method': ['_make', '_make_unordered', '_make_duplicate'],
     'dtype': [numpy.float32, numpy.float64, cupy.complex64, cupy.complex128],
 }))
 @testing.with_requires('scipy')
@@ -1546,4 +1546,15 @@ class TestCUBspmv(unittest.TestCase):
 
         m = self.make(xp, sp, self.dtype)
         x = xp.arange(4).astype(self.dtype)
+        if xp is numpy:
+            return m * x
+
+        # xp is cupy, first ensure we really use CUB
+        func = 'cupyx.scipy.sparse.csr.device_csrmv'
+        side_effect = NotImplementedError('gotcha')
+        with mock.patch(func, side_effect=side_effect), \
+                pytest.raises(NotImplementedError) as e:
+            m * x
+        assert str(e.value) == 'gotcha'
+        # ...then perform the actual computation
         return m * x

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -1,6 +1,5 @@
 import pickle
 import unittest
-from unittest import mock
 
 import numpy
 import pytest
@@ -1551,9 +1550,7 @@ class TestCUBspmv(unittest.TestCase):
 
         # xp is cupy, first ensure we really use CUB
         func = 'cupyx.scipy.sparse.csr.device_csrmv'
-        with mock.patch(func) as f:
-            assert f.call_count == 0
+        with testing.CUBMockTest(func):
             m * x
-            assert f.call_count == 1
         # ...then perform the actual computation
         return m * x


### PR DESCRIPTION
Follow up of #2598 and #3428. See https://github.com/cupy/cupy/pull/3428#issuecomment-647053948.

cc: @emcastillo 