### PR TITLE
Fix `scipy.dia_matrix.diagonal` for `scipy==1.5.0`

### DIFF
--- a/cupyx/scipy/sparse/dia.py
+++ b/cupyx/scipy/sparse/dia.py
@@ -199,7 +199,7 @@ class dia_matrix(data._data_matrix):
         """
         rows, cols = self.shape
         if k <= -rows or k >= cols:
-            raise ValueError("k exceeds matrix dimensions")
+            return cupy.empty(0, dtype=self.data.dtype)
         idx, = cupy.nonzero(self.offsets == k)
         first_col, last_col = max(0, k), min(rows + k, cols)
         if idx.size == 0:

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_dia.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_dia.py
@@ -291,12 +291,15 @@ class TestDiaMatrixScipyComparison(unittest.TestCase):
         m = self.make(xp, sp, self.dtype)
         return m.transpose()
 
-    @testing.with_requires('scipy>=1.0')
+    @testing.with_requires('scipy>=1.5.0')
     def test_diagonal_error(self):
+        # Before scipy 1.5.0 dia_matrix diagonal raised
+        # `ValueError`, now returns empty array.
+        # Check #3469
         for xp, sp in ((numpy, scipy.sparse), (cupy, sparse)):
             m = _make(xp, sp, self.dtype)
-            with pytest.raises(ValueError):
-                m.diagonal(k=10)  # out of range
+            d = m.diagonal(k=10)
+            assert d.size == 0
 
 
 @testing.parameterize(*testing.product({


### PR DESCRIPTION
In newer scipy released today (1.5.0)
The `dia_matrix.diagonal` method does not raise `ValueError` for invalid values anymore.
Now an empty array is returned instead.

https://github.com/scipy/scipy/blob/v1.5.0/scipy/sparse/dia.py#L323-L324