### PR TITLE
[backport] Assert that all the pointers are in the same device in `concatenate`

### DIFF
--- a/tests/cupy_tests/manipulation_tests/test_join.py
+++ b/tests/cupy_tests/manipulation_tests/test_join.py
@@ -1,7 +1,8 @@
 import unittest
 
-import cupy
+import pytest
 
+import cupy
 from cupy import testing
 from cupy import cuda
 

--- a/tests/cupy_tests/manipulation_tests/test_join.py
+++ b/tests/cupy_tests/manipulation_tests/test_join.py
@@ -3,6 +3,7 @@ import unittest
 import cupy
 
 from cupy import testing
+from cupy import cuda
 
 
 @testing.gpu
@@ -89,6 +90,15 @@ class TestJoin(unittest.TestCase):
         a = testing.shaped_arange((2, 3, 4), xp, dtype)
         b = testing.shaped_reverse_arange((2, 3, 4), xp, 'i')
         return xp.concatenate((a, b) * 10, axis=-1)
+
+    @testing.multi_gpu(2)
+    def test_concatenate_large_different_devices(self):
+        arrs = []
+        for i in range(10):
+            with cuda.Device(i % 2):
+                arrs.append(cupy.empty((2, 3, 4)))
+        with pytest.raises(ValueError):
+            cupy.concatenate(arrs)
 
     @testing.for_all_dtypes(name='dtype')
     @testing.numpy_cupy_array_equal()


### PR DESCRIPTION
Backport of #3285