### PR TITLE
Added functionality to print nvcc and nvrtc output

### DIFF
--- a/cupy/core/core.pxd
+++ b/cupy/core/core.pxd
@@ -104,7 +104,7 @@ cpdef Module compile_with_cache(str source, tuple options=*, arch=*,
                                 cachd_dir=*, prepend_cupy_headers=*,
                                 backend=*, translate_cucomplex=*,
                                 enable_cooperative_groups=*,
-                                name_expressions=*)
+                                name_expressions=*, log_stream=*)
 
 
 # TODO(niboshi): Move to _routines_creation.pyx

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1812,7 +1812,7 @@ cdef inline str _translate_cucomplex_to_thrust(str source):
 cpdef function.Module compile_with_cache(
         str source, tuple options=(), arch=None, cachd_dir=None,
         prepend_cupy_headers=True, backend='nvrtc', translate_cucomplex=False,
-        enable_cooperative_groups=False, name_expressions=None):
+        enable_cooperative_groups=False, name_expressions=None, log_stream=None):
     if translate_cucomplex:
         source = _translate_cucomplex_to_thrust(source)
         _cupy_header_list.append('cupy/cuComplex_bridge.h')
@@ -1863,7 +1863,7 @@ cpdef function.Module compile_with_cache(
     return cuda.compile_with_cache(
         source, options, arch, cachd_dir, extra_source, backend,
         enable_cooperative_groups=enable_cooperative_groups,
-        name_expressions=name_expressions)
+        name_expressions=name_expressions, log_stream=log_stream)
 
 
 # =============================================================================

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1812,7 +1812,8 @@ cdef inline str _translate_cucomplex_to_thrust(str source):
 cpdef function.Module compile_with_cache(
         str source, tuple options=(), arch=None, cachd_dir=None,
         prepend_cupy_headers=True, backend='nvrtc', translate_cucomplex=False,
-        enable_cooperative_groups=False, name_expressions=None, log_stream=None):
+        enable_cooperative_groups=False, name_expressions=None,
+        log_stream=None):
     if translate_cucomplex:
         source = _translate_cucomplex_to_thrust(source)
         _cupy_header_list.append('cupy/cuComplex_bridge.h')

--- a/cupy/core/raw.pxd
+++ b/cupy/core/raw.pxd
@@ -7,7 +7,7 @@ cdef class RawKernel:
         readonly tuple options
         readonly str backend
         readonly bint enable_cooperative_groups
-        readonly str log_stream
+        readonly log_stream
         tuple name_expressions
         bint translate_cucomplex
         list _kernel_cache
@@ -22,5 +22,5 @@ cdef class RawModule:
         readonly str backend
         readonly bint enable_cooperative_groups
         readonly tuple name_expressions
-        readonly str log_stream
+        readonly log_stream
         bint translate_cucomplex

--- a/cupy/core/raw.pxd
+++ b/cupy/core/raw.pxd
@@ -7,7 +7,7 @@ cdef class RawKernel:
         readonly tuple options
         readonly str backend
         readonly bint enable_cooperative_groups
-        readonly log_stream
+        object log_stream
         tuple name_expressions
         bint translate_cucomplex
         list _kernel_cache
@@ -22,5 +22,5 @@ cdef class RawModule:
         readonly str backend
         readonly bint enable_cooperative_groups
         readonly tuple name_expressions
-        readonly log_stream
+        object log_stream
         bint translate_cucomplex

--- a/cupy/core/raw.pxd
+++ b/cupy/core/raw.pxd
@@ -7,6 +7,7 @@ cdef class RawKernel:
         readonly tuple options
         readonly str backend
         readonly bint enable_cooperative_groups
+        readonly str log_stream
         tuple name_expressions
         bint translate_cucomplex
         list _kernel_cache
@@ -21,4 +22,5 @@ cdef class RawModule:
         readonly str backend
         readonly bint enable_cooperative_groups
         readonly tuple name_expressions
+        readonly str log_stream
         bint translate_cucomplex

--- a/cupy/core/raw.pyx
+++ b/cupy/core/raw.pyx
@@ -35,7 +35,10 @@ cdef class RawKernel:
             ``cuLaunchCooperativeKernel`` so that cooperative groups can be
             used from the CUDA source.
             This feature is only supported in CUDA 9 or later.
-        log_stream (str): TODO
+        log_stream (str): Whether the output of nvcc should be displayed in
+            'stdout' or stored to a 'file'. For example, `log_stream('file.txt')`
+            will write to output to file.txt. This variable is not used by 
+            nvrtc.
     """
 
     def __init__(self, str code, str name, tuple options=(),
@@ -260,7 +263,10 @@ cdef class RawModule:
             the template kernel ``func1<T>`` and non-template kernel ``func2``.
             Strings in this tuple must then be passed, one at a time, to
             :meth:`get_function` to retrieve the corresponding kernel.
-        log_stream (str): TODO
+        log_stream (str): Whether the output of nvcc should be displayed in
+            'stdout' or stored to a 'file'. For example, `log_stream('file.txt')`
+            will write to output to file.txt. This variable is not used by 
+            nvrtc.
 
     .. note::
         Each kernel in ``RawModule`` possesses independent function attributes.

--- a/cupy/core/raw.pyx
+++ b/cupy/core/raw.pyx
@@ -36,8 +36,8 @@ cdef class RawKernel:
             used from the CUDA source.
             This feature is only supported in CUDA 9 or later.
         log_stream (str): Whether the output of nvcc should be displayed in
-            'stdout' or stored to a 'file'. For example, `log_stream('file.txt')`
-            will write to output to file.txt.
+            'stdout' or stored to a 'file'. For example, ``log_stream='./file.txt'``
+            will write to output to ``file.txt`` in the current directory.
     """
 
     def __init__(self, str code, str name, tuple options=(),
@@ -263,8 +263,8 @@ cdef class RawModule:
             Strings in this tuple must then be passed, one at a time, to
             :meth:`get_function` to retrieve the corresponding kernel.
         log_stream (str): Whether the output of nvcc should be displayed in
-            'stdout' or stored to a 'file'. For example, `log_stream('file.txt')`
-            will write to output to file.txt.
+            'stdout' or stored to a 'file'. For example, ``log_stream='./file.txt'``
+            will write to output to ``file.txt`` in the current directory.
 
     .. note::
         Each kernel in ``RawModule`` possesses independent function attributes.

--- a/cupy/core/raw.pyx
+++ b/cupy/core/raw.pyx
@@ -43,7 +43,7 @@ cdef class RawKernel:
 
     def __init__(self, str code, str name, tuple options=(),
                  str backend='nvrtc', *, bint translate_cucomplex=False,
-                 bint enable_cooperative_groups=False, str log_stream=None):
+                 bint enable_cooperative_groups=False, log_stream=None):
 
         self.code = code
         self.name = name
@@ -274,7 +274,7 @@ cdef class RawModule:
     def __init__(self, *, str code=None, str path=None, tuple options=(),
                  str backend='nvrtc', bint translate_cucomplex=False,
                  bint enable_cooperative_groups=False,
-                 name_expressions=None, str log_stream=None):
+                 name_expressions=None, log_stream=None):
         if (code is None) == (path is None):
             raise TypeError(
                 'Exactly one of `code` and `path` keyword arguments must be '
@@ -434,7 +434,7 @@ cdef class RawModule:
 def _get_raw_module(str code, str path, tuple options=(), str backend='nvrtc',
                     bint translate_cucomplex=False,
                     bint enable_cooperative_groups=False,
-                    tuple name_expressions=None, str log_stream=None):
+                    tuple name_expressions=None, log_stream=None):
     cdef Module mod
     if code is not None:
         mod = cupy.core.core.compile_with_cache(

--- a/cupy/core/raw.pyx
+++ b/cupy/core/raw.pyx
@@ -274,7 +274,7 @@ cdef class RawModule:
     def __init__(self, *, str code=None, str path=None, tuple options=(),
                  str backend='nvrtc', bint translate_cucomplex=False,
                  bint enable_cooperative_groups=False,
-                 name_expressions=None, str log_stream=None):
+                 tuple name_expressions=None, str log_stream=None):
         if (code is None) == (path is None):
             raise TypeError(
                 'Exactly one of `code` and `path` keyword arguments must be '
@@ -376,7 +376,7 @@ cdef class RawModule:
         ker = RawKernel(
             self.code, name, self.options, self.backend,
             translate_cucomplex=self.translate_cucomplex,
-            enable_cooperative_groups=self.enable_cooperative_groups
+            enable_cooperative_groups=self.enable_cooperative_groups,
             log_stream=self.log_stream)
         # for lookup in case we loaded from cubin/ptx
         ker.file_path = self.file_path

--- a/cupy/core/raw.pyx
+++ b/cupy/core/raw.pyx
@@ -37,8 +37,7 @@ cdef class RawKernel:
             This feature is only supported in CUDA 9 or later.
         log_stream (str): Whether the output of nvcc should be displayed in
             'stdout' or stored to a 'file'. For example, `log_stream('file.txt')`
-            will write to output to file.txt. This variable is not used by 
-            nvrtc.
+            will write to output to file.txt.
     """
 
     def __init__(self, str code, str name, tuple options=(),
@@ -265,8 +264,7 @@ cdef class RawModule:
             :meth:`get_function` to retrieve the corresponding kernel.
         log_stream (str): Whether the output of nvcc should be displayed in
             'stdout' or stored to a 'file'. For example, `log_stream('file.txt')`
-            will write to output to file.txt. This variable is not used by 
-            nvrtc.
+            will write to output to file.txt.
 
     .. note::
         Each kernel in ``RawModule`` possesses independent function attributes.

--- a/cupy/core/raw.pyx
+++ b/cupy/core/raw.pyx
@@ -274,7 +274,7 @@ cdef class RawModule:
     def __init__(self, *, str code=None, str path=None, tuple options=(),
                  str backend='nvrtc', bint translate_cucomplex=False,
                  bint enable_cooperative_groups=False,
-                 tuple name_expressions=None, str log_stream=None):
+                 name_expressions=None, str log_stream=None):
         if (code is None) == (path is None):
             raise TypeError(
                 'Exactly one of `code` and `path` keyword arguments must be '

--- a/cupy/core/raw.pyx
+++ b/cupy/core/raw.pyx
@@ -36,8 +36,9 @@ cdef class RawKernel:
             used from the CUDA source.
             This feature is only supported in CUDA 9 or later.
         log_stream (str): Whether the output of nvcc should be displayed in
-            'stdout' or stored to a 'file'. For example, ``log_stream='./file.txt'``
-            will write to output to ``file.txt`` in the current directory.
+            'stdout' or stored to a 'file'. For example, 
+            ``log_stream='./file.txt'`` will write to output to 
+            ``file.txt`` in the current directory.
     """
 
     def __init__(self, str code, str name, tuple options=(),
@@ -263,8 +264,9 @@ cdef class RawModule:
             Strings in this tuple must then be passed, one at a time, to
             :meth:`get_function` to retrieve the corresponding kernel.
         log_stream (str): Whether the output of nvcc should be displayed in
-            'stdout' or stored to a 'file'. For example, ``log_stream='./file.txt'``
-            will write to output to ``file.txt`` in the current directory.
+            'stdout' or stored to a 'file'. For example, 
+            ``log_stream='./file.txt'`` will write to output to 
+            ``file.txt`` in the current directory.
 
     .. note::
         Each kernel in ``RawModule`` possesses independent function attributes.

--- a/cupy/core/raw.pyx
+++ b/cupy/core/raw.pyx
@@ -36,8 +36,8 @@ cdef class RawKernel:
             used from the CUDA source.
             This feature is only supported in CUDA 9 or later.
         log_stream (str): Whether the output of nvcc should be displayed in
-            'stdout' or stored to a 'file'. For example, 
-            ``log_stream='./file.txt'`` will write to output to 
+            'stdout' or stored to a 'file'. For example,
+            ``log_stream='./file.txt'`` will write to output to
             ``file.txt`` in the current directory.
     """
 
@@ -264,8 +264,8 @@ cdef class RawModule:
             Strings in this tuple must then be passed, one at a time, to
             :meth:`get_function` to retrieve the corresponding kernel.
         log_stream (str): Whether the output of nvcc should be displayed in
-            'stdout' or stored to a 'file'. For example, 
-            ``log_stream='./file.txt'`` will write to output to 
+            'stdout' or stored to a 'file'. For example,
+            ``log_stream='./file.txt'`` will write to output to
             ``file.txt`` in the current directory.
 
     .. note::

--- a/cupy/core/raw.pyx
+++ b/cupy/core/raw.pyx
@@ -35,10 +35,8 @@ cdef class RawKernel:
             ``cuLaunchCooperativeKernel`` so that cooperative groups can be
             used from the CUDA source.
             This feature is only supported in CUDA 9 or later.
-        log_stream (str): Whether the output of nvcc should be displayed in
-            'stdout' or stored to a 'file'. For example,
-            ``log_stream='./file.txt'`` will write to output to
-            ``file.txt`` in the current directory.
+        log_stream (object): Pass either ``sys.stdout`` or a file object to
+            which the compiler output will be written.
     """
 
     def __init__(self, str code, str name, tuple options=(),
@@ -263,10 +261,8 @@ cdef class RawModule:
             the template kernel ``func1<T>`` and non-template kernel ``func2``.
             Strings in this tuple must then be passed, one at a time, to
             :meth:`get_function` to retrieve the corresponding kernel.
-        log_stream (str): Whether the output of nvcc should be displayed in
-            'stdout' or stored to a 'file'. For example,
-            ``log_stream='./file.txt'`` will write to output to
-            ``file.txt`` in the current directory.
+        log_stream (object): Pass either ``sys.stdout`` or a file object to
+            which the compiler output will be written.
 
     .. note::
         Each kernel in ``RawModule`` possesses independent function attributes.

--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -1,5 +1,6 @@
 import hashlib
 import math
+import io
 import os
 import re
 import shutil
@@ -30,11 +31,8 @@ def _run_nvcc(cmd, cwd, log_stream=None):
         stdout = subprocess.check_output(cmd, cwd=cwd,
                                          stderr=subprocess.STDOUT,
                                          universal_newlines=True)
-        if log_stream == 'stdout':
-            print(stdout)
-        elif log_stream is not None:
-            with open(log_stream, 'w') as f:
-                f.write(stdout)
+        if log_stream is not None:
+            log_stream.write(stdout)
         return stdout
     except subprocess.CalledProcessError as e:
         msg = ('`nvcc` command returns non-zero exit status. \n'
@@ -485,11 +483,8 @@ class _NVRTCProgram(object):
                 mapping = {}
                 for ker in self.name_expressions:
                     mapping[ker] = nvrtc.getLoweredName(self.ptr, ker)
-            if log_stream == 'stdout':
-                print(nvrtc.getProgramLog(self.ptr))
-            elif log_stream is not None:
-                with open(log_stream, 'w') as f:
-                    f.write(nvrtc.getProgramLog(self.ptr))
+            if log_stream is not None:
+                log_stream.write(nvrtc.getProgramLog(self.ptr))
             return nvrtc.getPTX(self.ptr), mapping
         except nvrtc.NVRTCError:
             log = nvrtc.getProgramLog(self.ptr)

--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -30,11 +30,10 @@ def _run_nvcc(cmd, cwd, log_stream):
         stdout = subprocess.check_output(cmd, cwd=cwd,
                                          stderr=subprocess.STDOUT,
                                          universal_newlines=True)
-        if log_stream is None:
-            pass
-        elif log_stream == 'stdout':
+
+        if log_stream == 'stdout':
             print(stdout)
-        else:
+        elif log_stream is not None:
             with open(log_stream, 'w') as f:
                 f.write(stdout)
         return stdout
@@ -341,7 +340,7 @@ def _compile_with_cache_cuda(
     if _get_bool_env_variable('CUPY_CUDA_COMPILE_WITH_DEBUG', False):
         options += ('--device-debug', '--generate-line-info')
 
-    env = (arch, options, _get_nvrtc_version(), backend, log_stream)
+    env = (arch, options, _get_nvrtc_version(), backend)
     base = _empty_file_preprocess_cache.get(env, None)
     if base is None:
         # This is checking of NVRTC compiler internal version
@@ -388,9 +387,9 @@ def _compile_with_cache_cuda(
         mod._set_mapping(mapping)
     elif backend == 'nvcc':
         rdc = _is_cudadevrt_needed(options)
-        cubin = compile_using_nvcc(source, options, log_stream, arch,
+        cubin = compile_using_nvcc(source, options, arch,
                                    name + '.cu', code_type='cubin',
-                                   separate_compilation=rdc)
+                                   separate_compilation=rdc, log_stream=None)
     else:
         raise ValueError('Invalid backend %s' % backend)
 

--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -25,7 +25,7 @@ class NVCCException(Exception):
     pass
 
 
-def _run_nvcc(cmd, cwd, log_stream):
+def _run_nvcc(cmd, cwd, log_stream=None):
     try:
         stdout = subprocess.check_output(cmd, cwd=cwd,
                                          stderr=subprocess.STDOUT,
@@ -43,8 +43,7 @@ def _run_nvcc(cmd, cwd, log_stream):
                'stdout/stderr: \n'
                '{2}'.format(e.cmd,
                             e.returncode,
-                            e.output.decode(encoding='UTF-8',
-                                            errors='replace')))
+                            e.output))
         raise NVCCException(msg)
     except OSError as e:
         msg = 'Failed to run `nvcc` command. ' \
@@ -162,7 +161,7 @@ def compile_using_nvrtc(source, options=(), arch=None, filename='kern.cu',
                 with open(log_stream, 'w') as f:
                     f.write(ptx)
                     f.write("\n")
-                    f.write(mapping)
+                    f.write(str(mapping))
         except CompileException as e:
             dump = _get_bool_env_variable(
                 'CUPY_DUMP_CUDA_SOURCE_ON_ERROR', False)

--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -251,14 +251,14 @@ def compile_using_nvcc(source, options=(), arch=None,
             assert False, code_type
 
 
-def _preprocess(source, options, arch, backend, log_stream):
+def _preprocess(source, options, arch, backend):
     if backend == 'nvrtc':
         options += ('-arch=compute_{}'.format(arch),)
 
         prog = _NVRTCProgram(source, '')
         try:
 
-            result, _ = prog.compile(options, log_stream)
+            result, _ = prog.compile(options)
 
         except CompileException as e:
             dump = _get_bool_env_variable(
@@ -269,7 +269,7 @@ def _preprocess(source, options, arch, backend, log_stream):
     elif backend == 'nvcc':
         try:
             result = compile_using_nvcc(source, options, arch, 'preprocess.cu',
-                                        code_type='ptx', log_stream=None)
+                                        code_type='ptx')
         except CompileException as e:
             dump = _get_bool_env_variable(
                 'CUPY_DUMP_CUDA_SOURCE_ON_ERROR', False)
@@ -344,7 +344,7 @@ def _compile_with_cache_cuda(
     base = _empty_file_preprocess_cache.get(env, None)
     if base is None:
         # This is checking of NVRTC compiler internal version
-        base = _preprocess('', options, arch, backend, log_stream)
+        base = _preprocess('', options, arch, backend)
         _empty_file_preprocess_cache[env] = base
 
     key_src = '%s %s %s %s' % (env, base, source, extra_source)

--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -1,6 +1,5 @@
 import hashlib
 import math
-import io
 import os
 import re
 import shutil
@@ -29,8 +28,8 @@ class NVCCException(Exception):
 def _run_nvcc(cmd, cwd, log_stream=None):
     try:
         log = subprocess.check_output(cmd, cwd=cwd,
-                                         stderr=subprocess.STDOUT,
-                                         universal_newlines=True)
+                                      stderr=subprocess.STDOUT,
+                                      universal_newlines=True)
         if log_stream is not None:
             log_stream.write(log)
         return log

--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -257,9 +257,7 @@ def _preprocess(source, options, arch, backend):
 
         prog = _NVRTCProgram(source, '')
         try:
-
             result, _ = prog.compile(options)
-
         except CompileException as e:
             dump = _get_bool_env_variable(
                 'CUPY_DUMP_CUDA_SOURCE_ON_ERROR', False)

--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -30,7 +30,6 @@ def _run_nvcc(cmd, cwd, log_stream):
         stdout = subprocess.check_output(cmd, cwd=cwd,
                                          stderr=subprocess.STDOUT,
                                          universal_newlines=True)
-
         if log_stream == 'stdout':
             print(stdout)
         elif log_stream is not None:
@@ -389,7 +388,8 @@ def _compile_with_cache_cuda(
         rdc = _is_cudadevrt_needed(options)
         cubin = compile_using_nvcc(source, options, arch,
                                    name + '.cu', code_type='cubin',
-                                   separate_compilation=rdc, log_stream=None)
+                                   separate_compilation=rdc,
+                                   log_stream=log_stream)
     else:
         raise ValueError('Invalid backend %s' % backend)
 

--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -28,12 +28,12 @@ class NVCCException(Exception):
 
 def _run_nvcc(cmd, cwd, log_stream=None):
     try:
-        stdout = subprocess.check_output(cmd, cwd=cwd,
+        log = subprocess.check_output(cmd, cwd=cwd,
                                          stderr=subprocess.STDOUT,
                                          universal_newlines=True)
         if log_stream is not None:
-            log_stream.write(stdout)
-        return stdout
+            log_stream.write(log)
+        return log
     except subprocess.CalledProcessError as e:
         msg = ('`nvcc` command returns non-zero exit status. \n'
                'command: {0}\n'

--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -319,7 +319,8 @@ def compile_with_cache(
 
 def _compile_with_cache_cuda(
         source, options, arch, cache_dir, extra_source=None, backend='nvrtc',
-        enable_cooperative_groups=False, name_expressions=None, log_stream=None):
+        enable_cooperative_groups=False, name_expressions=None,
+        log_stream=None):
     # NVRTC does not use extra_source. extra_source is used for cache key.
     global _empty_file_preprocess_cache
     if cache_dir is None:

--- a/cupy/cuda/function.pyx
+++ b/cupy/cuda/function.pyx
@@ -144,7 +144,7 @@ cdef inline size_t _get_stream(stream) except *:
 cdef _launch(intptr_t func, Py_ssize_t grid0, int grid1, int grid2,
              Py_ssize_t block0, int block1, int block2,
              args, Py_ssize_t shared_mem, size_t stream,
-             bint enable_cooperative_groups=False, str log_stream=None):
+             bint enable_cooperative_groups=False):
     cdef list pargs = []
     cdef vector.vector[void*] kargs
     cdef CPointer cp
@@ -175,7 +175,7 @@ cdef class Function:
         self.ptr = driver.moduleGetFunction(module.ptr, funcname)
 
     def __call__(self, tuple grid, tuple block, args, size_t shared_mem=0,
-                 stream=None, enable_cooperative_groups=False, log_stream=None):
+                 stream=None, enable_cooperative_groups=False):
         grid = (grid + (1, 1))[:3]
         block = (block + (1, 1))[:3]
         s = _get_stream(stream)
@@ -183,7 +183,7 @@ cdef class Function:
             self.ptr,
             max(1, grid[0]), max(1, grid[1]), max(1, grid[2]),
             max(1, block[0]), max(1, block[1]), max(1, block[2]),
-            args, shared_mem, s, enable_cooperative_groups, log_stream)
+            args, shared_mem, s, enable_cooperative_groups)
 
     cpdef linear_launch(self, size_t size, args, size_t shared_mem=0,
                         size_t block_max_size=128, stream=None):

--- a/cupy/cuda/function.pyx
+++ b/cupy/cuda/function.pyx
@@ -144,7 +144,7 @@ cdef inline size_t _get_stream(stream) except *:
 cdef _launch(intptr_t func, Py_ssize_t grid0, int grid1, int grid2,
              Py_ssize_t block0, int block1, int block2,
              args, Py_ssize_t shared_mem, size_t stream,
-             bint enable_cooperative_groups=False):
+             bint enable_cooperative_groups=False, str log_stream=None):
     cdef list pargs = []
     cdef vector.vector[void*] kargs
     cdef CPointer cp
@@ -175,7 +175,7 @@ cdef class Function:
         self.ptr = driver.moduleGetFunction(module.ptr, funcname)
 
     def __call__(self, tuple grid, tuple block, args, size_t shared_mem=0,
-                 stream=None, enable_cooperative_groups=False):
+                 stream=None, enable_cooperative_groups=False, log_stream=None):
         grid = (grid + (1, 1))[:3]
         block = (block + (1, 1))[:3]
         s = _get_stream(stream)
@@ -183,7 +183,7 @@ cdef class Function:
             self.ptr,
             max(1, grid[0]), max(1, grid[1]), max(1, grid[2]),
             max(1, block[0]), max(1, block[1]), max(1, block[2]),
-            args, shared_mem, s, enable_cooperative_groups)
+            args, shared_mem, s, enable_cooperative_groups, log_stream)
 
     cpdef linear_launch(self, size_t size, args, size_t shared_mem=0,
                         size_t block_max_size=128, stream=None):


### PR DESCRIPTION
### Info
This PR pertains to #3482. Currently, no output from the nvcc compiler is displayed to stdout. 

The intent of this implementation is to add a `verbose` flag to `RawModule` and `RawKernel` to be able to print nvcc output.

Initial push only modifies `cupy/cuda/compiler.py`.

@leofang I think the parent function is `compile_with_cache` (in `cupy/cuda/compiler.py`). But I haven't quite figured out exactly which functions that call it should be modified to accept the new flag.

```python
def compile_with_cache(
        source, options=(), arch=None, cache_dir=None, extra_source=None,
        backend='nvrtc', *, enable_cooperative_groups=False,
        name_expressions=None, verbose=False):
```

The actual print is performed here.
```python
def _run_nvcc(cmd, cwd, verbose):
    try:
        stdout = subprocess.check_output(cmd, cwd=cwd, stderr=subprocess.STDOUT,
                                         universal_newlines=True)
        if verbose is True:
            print(stdout)
        return stdout
```