### PR TITLE
Update setuptools and pip in docker image

### DIFF
--- a/docker/python3/Dockerfile
+++ b/docker/python3/Dockerfile
@@ -8,4 +8,5 @@ RUN apt-get update -y && \
     python3-setuptools && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
+RUN pip3 install --no-cache-dir -U install setuptools pip
 RUN pip3 install --no-cache-dir cupy-cuda92==8.0.0b4


### PR DESCRIPTION
Related to #2993.
We need to use NumPy<1.18 as the base image contains Python 3.5, but pip is too old to recognize `python_requires` tag, so it tries to install the latest NumPy and build fails.