### PR TITLE
Support negative `axis` in sparse min/max/argmin/argmax

### DIFF
--- a/cupyx/scipy/sparse/data.py
+++ b/cupyx/scipy/sparse/data.py
@@ -190,10 +190,10 @@ class _minmax_mixin(object):
                     assert False
             return m
 
-        if axis == 0 or axis == 1:
-            return self._min_or_max_axis(axis, min_or_max, explicit)
-        else:
-            raise ValueError("axis out of range")
+        if axis < 0:
+            axis += 2
+
+        return self._min_or_max_axis(axis, min_or_max, explicit)
 
     def _arg_min_or_max_axis(self, axis, op):
         if self.shape[axis] == 0:
@@ -247,6 +247,9 @@ class _minmax_mixin(object):
                             return min(zero_ind, am)
                         else:
                             return zero_ind
+
+        if axis < 0:
+            axis += 2
 
         return self._arg_min_or_max_axis(axis, op)
 

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
@@ -1021,9 +1021,8 @@ class TestCscMatrixScipyCompressed(unittest.TestCase):
 
 
 @testing.parameterize(*testing.product({
-    # TODO(takagi) Test dtypes
-    # TODO(takagi) Test negative axis
-    'axis': [None, 0, 1],
+    # TODO(takagi): Test dtypes
+    'axis': [None, -2, -1, 0, 1],
     'dense': [False, True],  # means a sparse matrix but all elements filled
 }))
 @testing.with_requires('scipy>=0.19.0')
@@ -1059,6 +1058,9 @@ class TestCscMatrixScipyCompressedMinMax(unittest.TestCase):
                 if numpy.isinf(dm_data).all():
                     dm_data[0, 0] = 0
             else:
+                if axis < 0:
+                    axis += 2
+
                 # If all elements in a row/column are set to infinity, we make
                 # it have at least a zero so spmatrix.min(axis=axis) returns
                 # zero for the row/column.

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -1224,9 +1224,8 @@ class TestCsrMatrixScipyCompressed(unittest.TestCase):
 
 
 @testing.parameterize(*testing.product({
-    # TODO(takagi) Test dtypes
-    # TODO(takagi) Test negative axis
-    'axis': [None, 0, 1],
+    # TODO(takagi): Test dtypes
+    'axis': [None, -2, -1, 0, 1],
     'dense': [False, True],  # means a sparse matrix but all elements filled
 }))
 @testing.with_requires('scipy>=0.19.0')
@@ -1261,6 +1260,9 @@ class TestCsrMatrixScipyCompressedMinMax(unittest.TestCase):
                 if numpy.isinf(dm_data).all():
                     dm_data[0, 0] = 0
             else:
+                if axis < 0:
+                    axis += 2
+
                 # If all elements in a row/column are set to infinity, we make
                 # it have at least a zero so spmatrix.min(axis=axis) returns
                 # zero for the row/column.


### PR DESCRIPTION
Close #3474.

~~This PR fixes sparse `min` and `max` to take a negative `axis`. I'll parameterize its test in another PR.~~

Merge #3656 first. This PR fixes sparse min/max/argmin/argmax to take a negative `axis`.