### PR TITLE
Fix to raise `ValueError` for invalid clipmode

### DIFF
--- a/cupy/core/_routines_indexing.pyx
+++ b/cupy/core/_routines_indexing.pyx
@@ -109,7 +109,7 @@ cdef ndarray _ndarray_take(ndarray self, indices, axis, out):
 
 cdef ndarray _ndarray_put(ndarray self, indices, values, mode):
     if mode not in ('raise', 'wrap', 'clip'):
-        raise TypeError('clipmode not understood')
+        raise ValueError('clipmode not understood')
 
     n = self.size
     if not isinstance(indices, ndarray):
@@ -159,7 +159,7 @@ cdef ndarray _ndarray_choose(ndarray self, choices, out, mode):
     elif mode == 'clip':
         _choose_clip_kernel(ba[0], bcs, n_channel, n, out)
     else:
-        raise TypeError('clipmode not understood')
+        raise ValueError('clipmode not understood')
 
     return out
 

--- a/cupy/indexing/generate.py
+++ b/cupy/indexing/generate.py
@@ -360,7 +360,7 @@ def ravel_multi_index(multi_index, dims, mode='wrap', order='C'):
         elif _mode == 'wrap':
             idx = idx % d
         else:
-            raise TypeError("Unrecognized mode: {}".format(_mode))
+            raise ValueError('Unrecognized mode: {}'.format(_mode))
         raveled_indices += stride * idx
     return raveled_indices
 

--- a/tests/cupy_tests/indexing_tests/test_generate.py
+++ b/tests/cupy_tests/indexing_tests/test_generate.py
@@ -275,10 +275,11 @@ class TestRavelMultiIndex(unittest.TestCase):
                 xp.ravel_multi_index(
                     a, (xp.iinfo(xp.int64).max, 4), order=order)
 
+    @testing.with_requires('numpy>=1.19')
     @testing.for_int_dtypes(no_bool=True)
     def test_invalid_mode(self, dtype):
         for xp in (numpy, cupy):
             dims = (8, 4)
             a = tuple([xp.arange(min(dims), dtype=dtype) for d in dims])
-            with pytest.raises(TypeError):
+            with pytest.raises(ValueError):
                 xp.ravel_multi_index(a, dims, mode='invalid')

--- a/tests/cupy_tests/indexing_tests/test_indexing.py
+++ b/tests/cupy_tests/indexing_tests/test_indexing.py
@@ -227,11 +227,13 @@ class TestChoose(unittest.TestCase):
         c = testing.shaped_arange((3, 4), xp, dtype)
         return a.choose(c, mode='clip')
 
+    @testing.with_requires('numpy>=1.19')
     def test_unknown_clip(self):
-        a = cupy.array([0, 3, -1, 5])
-        c = testing.shaped_arange((3, 4), cupy, cupy.float32)
-        with self.assertRaises(TypeError):
-            a.choose(c, mode='unknow')
+        for xp in (numpy, cupy):
+            a = xp.array([0, 3, -1, 5])
+            c = testing.shaped_arange((3, 4), xp, numpy.float32)
+            with pytest.raises(ValueError):
+                a.choose(c, mode='unknow')
 
     def test_raise(self):
         a = cupy.array([2])

--- a/tests/cupy_tests/indexing_tests/test_insert.py
+++ b/tests/cupy_tests/indexing_tests/test_insert.py
@@ -131,13 +131,14 @@ class TestPutRaises(unittest.TestCase):
             with pytest.raises(IndexError):
                 xp.put(a, inds, vals, mode='raise')
 
+    @testing.with_requires('numpy>=1.19')
     @testing.for_all_dtypes()
     def test_put_mode_error(self, dtype):
         for xp in (numpy, cupy):
             a = testing.shaped_arange(self.shape, xp, dtype)
             inds = xp.array([2, -1, 3, 0])
             vals = testing.shaped_random((4,), xp, dtype)
-            with pytest.raises(TypeError):
+            with pytest.raises(ValueError):
                 xp.put(a, inds, vals, mode='unknown')
 
 


### PR DESCRIPTION
Fixed to follow the NumPy 1.19 specification.