### PR TITLE
ndimage rank-based filters

### DIFF
--- a/cupyx/scipy/ndimage/__init__.py
+++ b/cupyx/scipy/ndimage/__init__.py
@@ -6,6 +6,9 @@ from cupyx.scipy.ndimage.filters import minimum_filter  # NOQA
 from cupyx.scipy.ndimage.filters import maximum_filter  # NOQA
 from cupyx.scipy.ndimage.filters import minimum_filter1d  # NOQA
 from cupyx.scipy.ndimage.filters import maximum_filter1d  # NOQA
+from cupyx.scipy.ndimage.filters import median_filter  # NOQA
+from cupyx.scipy.ndimage.filters import rank_filter  # NOQA
+from cupyx.scipy.ndimage.filters import percentile_filter  # NOQA
 
 from cupyx.scipy.ndimage.interpolation import affine_transform  # NOQA
 from cupyx.scipy.ndimage.interpolation import map_coordinates  # NOQA

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
@@ -76,7 +76,8 @@ class FilterTestCaseBase(unittest.TestCase):
         if self.filter in ('convolve1d', 'correlate1d'):
             return testing.shaped_random((self.ksize,), xp, self._dtype)
 
-        if self.filter in ('minimum_filter', 'maximum_filter'):
+        if self.filter in ('minimum_filter', 'maximum_filter', 'median_filter',
+                           'rank_filter', 'percentile_filter'):
             if not self.footprint:
                 return self.ksize
             kshape = self._kshape
@@ -130,8 +131,16 @@ COMMON_PARAMS = {
                        'minimum_filter1d', 'maximum_filter1d'],
             'axis': [0, 1, -1],
         }) + testing.product({
-            'filter': ['minimum_filter', 'maximum_filter'],
+            'filter': ['minimum_filter', 'maximum_filter', 'median_filter'],
             'footprint': [False, True],
+        }) + testing.product({
+            'filter': ['percentile_filter'],
+            'footprint': [False, True],
+            'percentile': [0, 25, 50, -25, 100],
+        }) + testing.product({
+            'filter': ['rank_filter'],
+            'footprint': [False, True],
+            'rank': [0, 1, -1],
         }),
 
         # Mode-specific params

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
@@ -262,7 +262,6 @@ class TestShelSort(FilterTestCaseBase):
         return self._filter(xp, scp)
 
 
-
 # Tests with Fortran-ordered arrays
 @testing.parameterize(*(
     testing.product([

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
@@ -32,6 +32,9 @@ class FilterTestCaseBase(unittest.TestCase):
     # Params that need no processing and just go into kwargs
     KWARGS_PARAMS = ('output', 'axis', 'mode', 'cval')
 
+    # Params that need no processing go before weights in the arguments
+    ARGS_PARAMS = ('rank', 'percentile')
+
     def _filter(self, xp, scp):
         """
         The function that all tests end up calling, possibly after a few
@@ -58,8 +61,14 @@ class FilterTestCaseBase(unittest.TestCase):
             # w is actually a tuple of (None, footprint)
             wghts, kwargs['footprint'] = wghts
 
+        # Bulid the arguments
+        args = [getattr(self, param)
+                for param in FilterTestCaseBase.ARGS_PARAMS
+                if hasattr(self, param)]
+        args.append(wghts)
+
         # Actually perform filtering
-        return filter(arr, wghts, **kwargs)
+        return filter(arr, *args, **kwargs)
 
     def _get_weights(self, xp):
         # Gets the second argument to the filter functions.
@@ -127,20 +136,11 @@ COMMON_PARAMS = {
         testing.product({
             'filter': ['convolve', 'correlate'],
         }) + testing.product({
-            'filter': ['convolve1d', 'correlate1d',
-                       'minimum_filter1d', 'maximum_filter1d'],
+            'filter': ['convolve1d', 'correlate1d', 'minimum_filter1d'],
             'axis': [0, 1, -1],
         }) + testing.product({
-            'filter': ['minimum_filter', 'maximum_filter', 'median_filter'],
+            'filter': ['minimum_filter', 'median_filter'],
             'footprint': [False, True],
-        }) + testing.product({
-            'filter': ['percentile_filter'],
-            'footprint': [False, True],
-            'percentile': [0, 25, 50, -25, 100],
-        }) + testing.product({
-            'filter': ['rank_filter'],
-            'footprint': [False, True],
-            'rank': [0, 1, -1],
         }),
 
         # Mode-specific params
@@ -173,6 +173,38 @@ class TestFilter(FilterTestCaseBase):
         return self._filter(xp, scp)
 
 
+# This tests filters that are very similar to other filters so we only check
+# the basics with them.
+@testing.parameterize(*(
+    testing.product([
+        # Filter-function specific params
+        testing.product({
+            'filter': ['maximum_filter1d', 'maximum_filter'],
+        }) + testing.product({
+            'filter': ['percentile_filter'],
+            'percentile': [0, 25, 50, -25, 100],
+        }) + testing.product({
+            'filter': ['rank_filter'],
+            'rank': [0, 1, -1],
+        }),
+
+        # Only do reflect with some extras
+        testing.product({
+            **COMMON_PARAMS,
+            'mode': ['reflect'],
+            'origin': [0, 1, None],
+            'output': [None, numpy.int32, numpy.float64],
+        })
+    ])
+))
+@testing.gpu
+@testing.with_requires('scipy')
+class TestFilterFast(FilterTestCaseBase):
+    @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
+    def test_filter(self, xp, scp):
+        return self._filter(xp, scp)
+
+
 # Tests things requiring scipy >= 1.5.0
 @testing.parameterize(*(
     testing.product([
@@ -201,6 +233,34 @@ class TestMirrorWithDim1(FilterTestCaseBase):
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
     def test_filter(self, xp, scp):
         return self._filter(xp, scp)
+
+
+# Tests kernels large enough to trigger shell sort in rank-based filters
+@testing.parameterize(*(
+    testing.product([
+        testing.product({
+            'filter': ['median_filter'],
+        }) + testing.product({
+            'filter': ['percentile_filter'],
+            'percentile': [25, -25],
+        }) + testing.product({
+            'filter': ['rank_filter'],
+            'rank': [1],
+        }),
+        testing.product({
+            'fooprint': [False, True],
+            'ksize': [16, 17],
+            'shape': [(20, 21)],
+        })
+    ])
+))
+@testing.gpu
+@testing.with_requires('scipy')
+class TestShelSort(FilterTestCaseBase):
+    @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
+    def test_filter(self, xp, scp):
+        return self._filter(xp, scp)
+
 
 
 # Tests with Fortran-ordered arrays


### PR DESCRIPTION
This implements the rank-based filters (median, rank, and percentile filters).

These all use the same logic (in `_rank_filter`) and utilize the same underlying CUDA kernel as the other ndimage filters
just with some adjustments that the `_generate_nd_kernel()` function already allowed for. The biggest piece of CUDA code is the sorting function required for these filters. It chooses either selection or shell sort to be used to establish the rankings. CUB or similar sorts are not used since the sort is done per-kernel instead of with dynamic parallelism (there is 1 small sort to be done for every pixel in an image, should not parallelize within a single sort but instead parallelize across the sorts).

The cutoff of 225 (15x15), for which selection sort is used below and shell sort is used above, was chosen based on my hardware (Titan V) using uint8 images and definitely made a large different in speed by being able to use both. Selection sort is up to 2.5x faster below and shell sort is progressively faster above, tested up to 3025-sized (55x55) footprint and it was 9x faster then. Near the cutoff point it matters much less which is chosen since they are fairly close. Thus, its okay if that number is a little off.