### PR TITLE
Fix to raise `TypeError` for invalid subscripts in `einsum`

### DIFF
--- a/cupy/linalg/einsum.py
+++ b/cupy/linalg/einsum.py
@@ -52,7 +52,7 @@ def _parse_int_subscript(list_subscript):
         elif isinstance(s, int):
             str_subscript += einsum_symbols[s]
         else:
-            raise ValueError(
+            raise TypeError(
                 'each subscript must be either an integer or an ellipsis'
                 ' to provide subscripts strings as lists')
     return str_subscript

--- a/tests/cupy_tests/linalg_tests/test_einsum.py
+++ b/tests/cupy_tests/linalg_tests/test_einsum.py
@@ -234,9 +234,10 @@ class TestEinSumError(unittest.TestCase):
 
 class TestListArgEinSumError(unittest.TestCase):
 
+    @testing.with_requires('numpy>=1.19')
     def test_invalid_sub1(self):
         for xp in (numpy, cupy):
-            with pytest.raises(ValueError):
+            with pytest.raises(TypeError):
                 xp.einsum(xp.arange(2), [None])
 
     def test_invalid_sub2(self):


### PR DESCRIPTION
Fixed to follow the NumPy 1.19 specification.