### PR TITLE
ndimage common linear filters

### DIFF
--- a/cupyx/scipy/ndimage/__init__.py
+++ b/cupyx/scipy/ndimage/__init__.py
@@ -2,6 +2,17 @@ from cupyx.scipy.ndimage.filters import correlate  # NOQA
 from cupyx.scipy.ndimage.filters import convolve  # NOQA
 from cupyx.scipy.ndimage.filters import correlate1d  # NOQA
 from cupyx.scipy.ndimage.filters import convolve1d  # NOQA
+from cupyx.scipy.ndimage.filters import uniform_filter1d  # NOQA
+from cupyx.scipy.ndimage.filters import uniform_filter  # NOQA
+from cupyx.scipy.ndimage.filters import gaussian_filter1d  # NOQA
+from cupyx.scipy.ndimage.filters import gaussian_filter  # NOQA
+from cupyx.scipy.ndimage.filters import prewitt  # NOQA
+from cupyx.scipy.ndimage.filters import sobel  # NOQA
+from cupyx.scipy.ndimage.filters import generic_laplace  # NOQA
+from cupyx.scipy.ndimage.filters import laplace  # NOQA
+from cupyx.scipy.ndimage.filters import gaussian_laplace  # NOQA
+from cupyx.scipy.ndimage.filters import generic_gradient_magnitude  # NOQA
+from cupyx.scipy.ndimage.filters import gaussian_gradient_magnitude  # NOQA
 from cupyx.scipy.ndimage.filters import minimum_filter  # NOQA
 from cupyx.scipy.ndimage.filters import maximum_filter  # NOQA
 from cupyx.scipy.ndimage.filters import minimum_filter1d  # NOQA

--- a/cupyx/scipy/ndimage/filters.py
+++ b/cupyx/scipy/ndimage/filters.py
@@ -26,9 +26,10 @@ def correlate(input, weights, output=None, mode='reflect', cval=0.0, origin=0):
         cupy.ndarray: The result of correlate.
 
     .. seealso:: :func:`scipy.ndimage.correlate`
-    .. note:: When the output data type is integral (or when no output is
-    provided and the input is integral) the results may not perfectly match the
-    results from SciPy due to floating-point rounding of intermediate results.
+    .. note::
+        When the output data type is integral (or when no output is provided
+        and input is integral) the results may not perfectly match the results
+        from SciPy due to floating-point rounding of intermediate results.
     """
     return _correlate_or_convolve(input, weights, output, mode, cval, origin)
 
@@ -58,9 +59,10 @@ def convolve(input, weights, output=None, mode='reflect', cval=0.0, origin=0):
         cupy.ndarray: The result of convolution.
 
     .. seealso:: :func:`scipy.ndimage.convolve`
-    .. note:: When the output data type is integral (or when no output is
-    provided and the input is integral) the results may not perfectly match the
-    results from SciPy due to floating-point rounding of intermediate results.
+    .. note::
+        When the output data type is integral (or when no output is provided
+        and input is integral) the results may not perfectly match the results
+        from SciPy due to floating-point rounding of intermediate results.
     """
     return _correlate_or_convolve(input, weights, output, mode, cval, origin,
                                   True)
@@ -89,9 +91,10 @@ def correlate1d(input, weights, axis=-1, output=None, mode="reflect", cval=0.0,
     Returns:
         cupy.ndarray: The result of the 1D correlation.
     .. seealso:: :func:`scipy.ndimage.correlate1d`
-    .. note:: When the output data type is integral (or when no output is
-    provided and the input is integral) the results may not perfectly match the
-    results from SciPy due to floating-point rounding of intermediate results.
+    .. note::
+        When the output data type is integral (or when no output is provided
+        and input is integral) the results may not perfectly match the results
+        from SciPy due to floating-point rounding of intermediate results.
     """
     weights, origins = _convert_1d_args(input.ndim, weights, origin, axis)
     return _correlate_or_convolve(input, weights, output, mode, cval, origins)
@@ -120,9 +123,10 @@ def convolve1d(input, weights, axis=-1, output=None, mode="reflect", cval=0.0,
     Returns:
         cupy.ndarray: The result of the 1D convolution.
     .. seealso:: :func:`scipy.ndimage.convolve1d`
-    .. note:: When the output data type is integral (or when no output is
-    provided and the input is integral) the results may not perfectly match the
-    results from SciPy due to floating-point rounding of intermediate results.
+    .. note::
+        When the output data type is integral (or when no output is provided
+        and input is integral) the results may not perfectly match the results
+        from SciPy due to floating-point rounding of intermediate results.
     """
     weights = weights[::-1]
     origin = -origin
@@ -182,9 +186,10 @@ def uniform_filter1d(input, size, axis=-1, output=None, mode="reflect",
     Returns:
         cupy.ndarray: The result of the filtering.
     .. seealso:: :func:`scipy.ndimage.uniform_filter1d`
-    .. note:: When the output data type is integral (or when no output is
-    provided and the input is integral) the results may not perfectly match the
-    results from SciPy due to floating-point rounding of intermediate results.
+    .. note::
+        When the output data type is integral (or when no output is provided
+        and input is integral) the results may not perfectly match the results
+        from SciPy due to floating-point rounding of intermediate results.
     """
     return correlate1d(input, cupy.ones(size) / size, axis, output, mode, cval,
                        origin)
@@ -211,9 +216,10 @@ def uniform_filter(input, size=3, output=None, mode="reflect", cval=0.0,
     Returns:
         cupy.ndarray: The result of the filtering.
     .. seealso:: :func:`scipy.ndimage.uniform_filter`
-    .. note:: When the output data type is integral (or when no output is
-    provided and the input is integral) the results may not perfectly match the
-    results from SciPy due to floating-point rounding of intermediate results.
+    .. note::
+        When the output data type is integral (or when no output is provided
+        and input is integral) the results may not perfectly match the results
+        from SciPy due to floating-point rounding of intermediate results.
     """
     sizes = _fix_sequence_arg(size, input.ndim, 'size', int)
 
@@ -247,9 +253,10 @@ def gaussian_filter1d(input, sigma, axis=-1, order=0, output=None,
     Returns:
         cupy.ndarray: The result of the filtering.
     .. seealso:: :func:`scipy.ndimage.gaussian_filter1d`
-    .. note:: When the output data type is integral (or when no output is
-    provided and the input is integral) the results may not perfectly match the
-    results from SciPy due to floating-point rounding of intermediate results.
+    .. note::
+        When the output data type is integral (or when no output is provided
+        and input is integral) the results may not perfectly match the results
+        from SciPy due to floating-point rounding of intermediate results.
     """
     radius = int(float(truncate) * float(sigma) + 0.5)
     weights = _gaussian_kernel1d(sigma, int(order), radius)
@@ -279,9 +286,10 @@ def gaussian_filter(input, sigma, order=0, output=None, mode="reflect",
     Returns:
         cupy.ndarray: The result of the filtering.
     .. seealso:: :func:`scipy.ndimage.gaussian_filter`
-    .. note:: When the output data type is integral (or when no output is
-    provided and the input is integral) the results may not perfectly match the
-    results from SciPy due to floating-point rounding of intermediate results.
+    .. note::
+        When the output data type is integral (or when no output is provided
+        and input is integral) the results may not perfectly match the results
+        from SciPy due to floating-point rounding of intermediate results.
     """
     sigmas = _fix_sequence_arg(sigma, input.ndim, 'sigma', float)
     orders = _fix_sequence_arg(order, input.ndim, 'order', int)
@@ -345,9 +353,10 @@ def prewitt(input, axis=-1, output=None, mode="reflect", cval=0.0):
     Returns:
         cupy.ndarray: The result of the filtering.
     .. seealso:: :func:`scipy.ndimage.prewitt`
-    .. note:: When the output data type is integral (or when no output is
-    provided and the input is integral) the results may not perfectly match the
-    results from SciPy due to floating-point rounding of intermediate results.
+    .. note::
+        When the output data type is integral (or when no output is provided
+        and input is integral) the results may not perfectly match the results
+        from SciPy due to floating-point rounding of intermediate results.
     """
     return _prewitt_or_sobel(input, axis, output, mode, cval, cupy.ones(3))
 
@@ -367,9 +376,10 @@ def sobel(input, axis=-1, output=None, mode="reflect", cval=0.0):
     Returns:
         cupy.ndarray: The result of the filtering.
     .. seealso:: :func:`scipy.ndimage.sobel`
-    .. note:: When the output data type is integral (or when no output is
-    provided and the input is integral) the results may not perfectly match the
-    results from SciPy due to floating-point rounding of intermediate results.
+    .. note::
+        When the output data type is integral (or when no output is provided
+        and input is integral) the results may not perfectly match the results
+        from SciPy due to floating-point rounding of intermediate results.
     """
     return _prewitt_or_sobel(input, axis, output, mode, cval,
                              cupy.array([1, 2, 1]))
@@ -413,9 +423,10 @@ def generic_laplace(input, derivative2, output=None, mode="reflect",
     Returns:
         cupy.ndarray: The result of the filtering.
     .. seealso:: :func:`scipy.ndimage.generic_laplace`
-    .. note:: When the output data type is integral (or when no output is
-    provided and the input is integral) the results may not perfectly match the
-    results from SciPy due to floating-point rounding of intermediate results.
+    .. note::
+        When the output data type is integral (or when no output is provided
+        and input is integral) the results may not perfectly match the results
+        from SciPy due to floating-point rounding of intermediate results.
     """
     if extra_keywords is None:
         extra_keywords = {}
@@ -450,9 +461,10 @@ def laplace(input, output=None, mode="reflect", cval=0.0):
     Returns:
         cupy.ndarray: The result of the filtering.
     .. seealso:: :func:`scipy.ndimage.laplace`
-    .. note:: When the output data type is integral (or when no output is
-    provided and the input is integral) the results may not perfectly match the
-    results from SciPy due to floating-point rounding of intermediate results.
+    .. note::
+        When the output data type is integral (or when no output is provided
+        and input is integral) the results may not perfectly match the results
+        from SciPy due to floating-point rounding of intermediate results.
     """
     weights = cupy.array([1, -2, 1], dtype=cupy.float64)
 
@@ -481,9 +493,10 @@ def gaussian_laplace(input, sigma, output=None, mode="reflect",
     Returns:
         cupy.ndarray: The result of the filtering.
     .. seealso:: :func:`scipy.ndimage.gaussian_laplace`
-    .. note:: When the output data type is integral (or when no output is
-    provided and the input is integral) the results may not perfectly match the
-    results from SciPy due to floating-point rounding of intermediate results.
+    .. note::
+        When the output data type is integral (or when no output is provided
+        and input is integral) the results may not perfectly match the results
+        from SciPy due to floating-point rounding of intermediate results.
     """
     def derivative2(input, axis, output, mode, cval):
         order = [0] * input.ndim
@@ -522,9 +535,10 @@ def generic_gradient_magnitude(input, derivative, output=None,
     Returns:
         cupy.ndarray: The result of the filtering.
     .. seealso:: :func:`scipy.ndimage.generic_gradient_magnitude`
-    .. note:: When the output data type is integral (or when no output is
-    provided and the input is integral) the results may not perfectly match the
-    results from SciPy due to floating-point rounding of intermediate results.
+    .. note::
+        When the output data type is integral (or when no output is provided
+        and input is integral) the results may not perfectly match the results
+        from SciPy due to floating-point rounding of intermediate results.
     """
     if extra_keywords is None:
         extra_keywords = {}
@@ -565,9 +579,10 @@ def gaussian_gradient_magnitude(input, sigma, output=None, mode="reflect",
     Returns:
         cupy.ndarray: The result of the filtering.
     .. seealso:: :func:`scipy.ndimage.gaussian_gradient_magnitude`
-    .. note:: When the output data type is integral (or when no output is
-    provided and the input is integral) the results may not perfectly match the
-    results from SciPy due to floating-point rounding of intermediate results.
+    .. note::
+        When the output data type is integral (or when no output is provided
+        and input is integral) the results may not perfectly match the results
+        from SciPy due to floating-point rounding of intermediate results.
     """
     def derivative(input, axis, output, mode, cval):
         order = [0] * input.ndim

--- a/cupyx/scipy/ndimage/filters.py
+++ b/cupyx/scipy/ndimage/filters.py
@@ -26,6 +26,9 @@ def correlate(input, weights, output=None, mode='reflect', cval=0.0, origin=0):
         cupy.ndarray: The result of correlate.
 
     .. seealso:: :func:`scipy.ndimage.correlate`
+    .. note:: When the output data type is integral (or when no output is
+    provided and the input is integral) the results may not perfectly match the
+    results from SciPy due to floating-point rounding of intermediate results.
     """
     return _correlate_or_convolve(input, weights, output, mode, cval, origin)
 
@@ -55,6 +58,9 @@ def convolve(input, weights, output=None, mode='reflect', cval=0.0, origin=0):
         cupy.ndarray: The result of convolution.
 
     .. seealso:: :func:`scipy.ndimage.convolve`
+    .. note:: When the output data type is integral (or when no output is
+    provided and the input is integral) the results may not perfectly match the
+    results from SciPy due to floating-point rounding of intermediate results.
     """
     return _correlate_or_convolve(input, weights, output, mode, cval, origin,
                                   True)
@@ -83,6 +89,9 @@ def correlate1d(input, weights, axis=-1, output=None, mode="reflect", cval=0.0,
     Returns:
         cupy.ndarray: The result of the 1D correlation.
     .. seealso:: :func:`scipy.ndimage.correlate1d`
+    .. note:: When the output data type is integral (or when no output is
+    provided and the input is integral) the results may not perfectly match the
+    results from SciPy due to floating-point rounding of intermediate results.
     """
     weights, origins = _convert_1d_args(input.ndim, weights, origin, axis)
     return _correlate_or_convolve(input, weights, output, mode, cval, origins)
@@ -111,6 +120,9 @@ def convolve1d(input, weights, axis=-1, output=None, mode="reflect", cval=0.0,
     Returns:
         cupy.ndarray: The result of the 1D convolution.
     .. seealso:: :func:`scipy.ndimage.convolve1d`
+    .. note:: When the output data type is integral (or when no output is
+    provided and the input is integral) the results may not perfectly match the
+    results from SciPy due to floating-point rounding of intermediate results.
     """
     weights = weights[::-1]
     origin = -origin
@@ -170,6 +182,9 @@ def uniform_filter1d(input, size, axis=-1, output=None, mode="reflect",
     Returns:
         cupy.ndarray: The result of the filtering.
     .. seealso:: :func:`scipy.ndimage.uniform_filter1d`
+    .. note:: When the output data type is integral (or when no output is
+    provided and the input is integral) the results may not perfectly match the
+    results from SciPy due to floating-point rounding of intermediate results.
     """
     return correlate1d(input, cupy.ones(size) / size, axis, output, mode, cval,
                        origin)
@@ -196,6 +211,9 @@ def uniform_filter(input, size=3, output=None, mode="reflect", cval=0.0,
     Returns:
         cupy.ndarray: The result of the filtering.
     .. seealso:: :func:`scipy.ndimage.uniform_filter`
+    .. note:: When the output data type is integral (or when no output is
+    provided and the input is integral) the results may not perfectly match the
+    results from SciPy due to floating-point rounding of intermediate results.
     """
     sizes = _fix_sequence_arg(size, input.ndim, 'size', int)
 
@@ -229,6 +247,9 @@ def gaussian_filter1d(input, sigma, axis=-1, order=0, output=None,
     Returns:
         cupy.ndarray: The result of the filtering.
     .. seealso:: :func:`scipy.ndimage.gaussian_filter1d`
+    .. note:: When the output data type is integral (or when no output is
+    provided and the input is integral) the results may not perfectly match the
+    results from SciPy due to floating-point rounding of intermediate results.
     """
     radius = int(float(truncate) * float(sigma) + 0.5)
     weights = _gaussian_kernel1d(sigma, int(order), radius)
@@ -258,6 +279,9 @@ def gaussian_filter(input, sigma, order=0, output=None, mode="reflect",
     Returns:
         cupy.ndarray: The result of the filtering.
     .. seealso:: :func:`scipy.ndimage.gaussian_filter`
+    .. note:: When the output data type is integral (or when no output is
+    provided and the input is integral) the results may not perfectly match the
+    results from SciPy due to floating-point rounding of intermediate results.
     """
     sigmas = _fix_sequence_arg(sigma, input.ndim, 'sigma', float)
     orders = _fix_sequence_arg(order, input.ndim, 'order', int)
@@ -321,6 +345,9 @@ def prewitt(input, axis=-1, output=None, mode="reflect", cval=0.0):
     Returns:
         cupy.ndarray: The result of the filtering.
     .. seealso:: :func:`scipy.ndimage.prewitt`
+    .. note:: When the output data type is integral (or when no output is
+    provided and the input is integral) the results may not perfectly match the
+    results from SciPy due to floating-point rounding of intermediate results.
     """
     return _prewitt_or_sobel(input, axis, output, mode, cval, cupy.ones(3))
 
@@ -340,6 +367,9 @@ def sobel(input, axis=-1, output=None, mode="reflect", cval=0.0):
     Returns:
         cupy.ndarray: The result of the filtering.
     .. seealso:: :func:`scipy.ndimage.sobel`
+    .. note:: When the output data type is integral (or when no output is
+    provided and the input is integral) the results may not perfectly match the
+    results from SciPy due to floating-point rounding of intermediate results.
     """
     return _prewitt_or_sobel(input, axis, output, mode, cval,
                              cupy.array([1, 2, 1]))
@@ -383,6 +413,9 @@ def generic_laplace(input, derivative2, output=None, mode="reflect",
     Returns:
         cupy.ndarray: The result of the filtering.
     .. seealso:: :func:`scipy.ndimage.generic_laplace`
+    .. note:: When the output data type is integral (or when no output is
+    provided and the input is integral) the results may not perfectly match the
+    results from SciPy due to floating-point rounding of intermediate results.
     """
     if extra_keywords is None:
         extra_keywords = {}
@@ -417,6 +450,9 @@ def laplace(input, output=None, mode="reflect", cval=0.0):
     Returns:
         cupy.ndarray: The result of the filtering.
     .. seealso:: :func:`scipy.ndimage.laplace`
+    .. note:: When the output data type is integral (or when no output is
+    provided and the input is integral) the results may not perfectly match the
+    results from SciPy due to floating-point rounding of intermediate results.
     """
     weights = cupy.array([1, -2, 1], dtype=cupy.float64)
 
@@ -445,6 +481,9 @@ def gaussian_laplace(input, sigma, output=None, mode="reflect",
     Returns:
         cupy.ndarray: The result of the filtering.
     .. seealso:: :func:`scipy.ndimage.gaussian_laplace`
+    .. note:: When the output data type is integral (or when no output is
+    provided and the input is integral) the results may not perfectly match the
+    results from SciPy due to floating-point rounding of intermediate results.
     """
     def derivative2(input, axis, output, mode, cval):
         order = [0] * input.ndim
@@ -483,6 +522,9 @@ def generic_gradient_magnitude(input, derivative, output=None,
     Returns:
         cupy.ndarray: The result of the filtering.
     .. seealso:: :func:`scipy.ndimage.generic_gradient_magnitude`
+    .. note:: When the output data type is integral (or when no output is
+    provided and the input is integral) the results may not perfectly match the
+    results from SciPy due to floating-point rounding of intermediate results.
     """
     if extra_keywords is None:
         extra_keywords = {}
@@ -523,6 +565,9 @@ def gaussian_gradient_magnitude(input, sigma, output=None, mode="reflect",
     Returns:
         cupy.ndarray: The result of the filtering.
     .. seealso:: :func:`scipy.ndimage.gaussian_gradient_magnitude`
+    .. note:: When the output data type is integral (or when no output is
+    provided and the input is integral) the results may not perfectly match the
+    results from SciPy due to floating-point rounding of intermediate results.
     """
     def derivative(input, axis, output, mode, cval):
         order = [0] * input.ndim

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
@@ -28,12 +28,16 @@ class FilterTestCaseBase(unittest.TestCase):
     dtype = numpy.float64
     footprint = True
     order = 'C'
+    mode = 'reflect'
+
+    # Params that need to be possibly shortened to the right number of dims
+    DIMS_PARAMS = ('origin', 'sigma')
 
     # Params that need no processing and just go into kwargs
-    KWARGS_PARAMS = ('output', 'axis', 'mode', 'cval')
+    KWARGS_PARAMS = ('output', 'axis', 'mode', 'cval', 'truncate')+DIMS_PARAMS
 
     # Params that need no processing go before weights in the arguments
-    ARGS_PARAMS = ('rank', 'percentile')
+    ARGS_PARAMS = ('rank', 'percentile', 'derivative', 'derivative2')
 
     def _filter(self, xp, scp):
         """
@@ -47,8 +51,11 @@ class FilterTestCaseBase(unittest.TestCase):
         kwargs = {param: getattr(self, param)
                   for param in FilterTestCaseBase.KWARGS_PARAMS
                   if hasattr(self, param)}
-        if hasattr(self, 'origin'):
-            kwargs['origin'] = self._origin
+        is_1d = self.filter.endswith('1d')
+        for param in FilterTestCaseBase.DIMS_PARAMS:
+            if param in kwargs and isinstance(kwargs[param], tuple):
+                value = kwargs[param]
+                kwargs[param] = value[0] if is_1d else value[:self._ndim]
 
         # The array we are filtering
         arr = testing.shaped_random(self.shape, xp, self.dtype)
@@ -65,7 +72,8 @@ class FilterTestCaseBase(unittest.TestCase):
         args = [getattr(self, param)
                 for param in FilterTestCaseBase.ARGS_PARAMS
                 if hasattr(self, param)]
-        args.append(wghts)
+        if wghts is not None:
+            args.append(wghts)
 
         # Actually perform filtering
         return filter(arr, *args, **kwargs)
@@ -75,9 +83,11 @@ class FilterTestCaseBase(unittest.TestCase):
         # For convolve/correlate/convolve1d/correlate1d this is the weights.
         # For minimum_filter1d/maximum_filter1d this is the kernel size.
         #
-        # For minimum_filter/maximum_filter this is a bit more complicated and
+        # For filters that take a footprint this is a bit more complicated and
         # is either the kernel size or a tuple of None and the footprint. The
         # _filter() method knows about this and handles it automatically.
+        #
+        # Many specialized filters have no weights and this returns None.
 
         if self.filter in ('convolve', 'correlate'):
             return testing.shaped_random(self._kshape, xp, self._dtype)
@@ -95,10 +105,16 @@ class FilterTestCaseBase(unittest.TestCase):
                 footprint = xp.ones(kshape)
             return None, footprint
 
-        if self.filter in ('minimum_filter1d', 'maximum_filter1d'):
+        if self.filter in ('uniform_filter1d',
+                           'minimum_filter1d', 'maximum_filter1d'):
             return self.ksize
 
-        raise RuntimeError('unsupported filter name')
+        if self.filter == 'uniform_filter':
+            return self._kshape
+
+        # gaussian_filter*, prewitt, sobel, *laplace, and *_gradient_magnitude
+        # all have no 'weights' or similar argument so return None
+        return None
 
     @property
     def _dtype(self):
@@ -112,20 +128,12 @@ class FilterTestCaseBase(unittest.TestCase):
     def _kshape(self):
         return getattr(self, 'kshape', (self.ksize,) * self._ndim)
 
-    @property
-    def _origin(self):
-        origin = getattr(self, 'origin', 0)
-        if origin is not None:
-            return origin
-        is_1d = self.filter.endswith('1d')
-        return -1 if is_1d else (-1, 1, -1, 1)[:self._ndim]
-
 
 # Parameters common across all modes (with some overrides)
 COMMON_PARAMS = {
     'shape': [(4, 5), (3, 4, 5), (1, 3, 4, 5)],
     'ksize': [3, 4],
-    'dtype': [numpy.int32, numpy.float64],
+    'dtype': [numpy.uint8, numpy.float64],
 }
 
 
@@ -148,8 +156,8 @@ COMMON_PARAMS = {
             **COMMON_PARAMS,
             'mode': ['reflect'],
             # With reflect test some of the other parameters as well
-            'origin': [0, 1, None],
-            'output': [None, numpy.int32, numpy.float64],
+            'origin': [0, 1, (-1, 1, -1, 1)],
+            'output': [None, numpy.uint8, numpy.float64],
         }) + testing.product({
             **COMMON_PARAMS,
             'mode': ['constant'], 'cval': [-1.0, 0.0, 1.0],
@@ -168,16 +176,29 @@ COMMON_PARAMS = {
 class TestFilter(FilterTestCaseBase):
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
     def test_filter(self, xp, scp):
+        #if (self.mode == 'constant' and self.cval < 0 and
+        #        self.dtype == numpy.uint8):
+        #    raise unittest.SkipTest("undefined behavior")
         if self.dtype == getattr(self, 'output', None):
             raise unittest.SkipTest("redundant")
         return self._filter(xp, scp)
+
+
+def dummy_deriv_func(input, axis, output, mode, cval, *args, **kwargs):
+    # For testing generic_laplace and generic_gradient_magnitude. Doesn't test
+    # mode, cval, or extra argument but those are tested indirectly with
+    # laplace, gaussian_laplace, & gaussian_gradient_magnitude.
+    if output is not None and not isinstance(output, numpy.dtype):
+        output[...] = input + axis
+    else:
+        output = input + axis
+    return output
 
 
 # This tests filters that are very similar to other filters so we only check
 # the basics with them.
 @testing.parameterize(*(
     testing.product([
-        # Filter-function specific params
         testing.product({
             'filter': ['maximum_filter1d', 'maximum_filter'],
         }) + testing.product({
@@ -187,13 +208,43 @@ class TestFilter(FilterTestCaseBase):
             'filter': ['rank_filter'],
             'rank': [0, 1, -1],
         }),
-
-        # Only do reflect with some extras
+        testing.product(COMMON_PARAMS)
+    ]) + testing.product([
+        # All of these filters have no ksize and evoke undef behavior
+        # outputting to uint8
         testing.product({
-            **COMMON_PARAMS,
-            'mode': ['reflect'],
-            'origin': [0, 1, None],
-            'output': [None, numpy.int32, numpy.float64],
+            'filter': ['gaussian_filter1d'],
+            'axis': [0, 1, -1],
+            'sigma': [1.5, 2],
+            'truncate': [2.75, 4],
+        }) + testing.product({
+            'filter': ['gaussian_filter', 'gaussian_laplace',
+                       'gaussian_gradient_magnitude'],
+            'sigma': [1.5, 2.25, (1.5, 2.25, 1.0, 3.0)],
+            'truncate': [2.75, 4],
+        }) + testing.product({
+            'filter': ['prewitt', 'sobel'],
+            'axis': [0, 1, -1],
+        }) + testing.product({
+            'filter': ['laplace'],
+        }),
+        testing.product({
+            'shape': [(4, 5), (3, 4, 5), (1, 3, 4, 5)],
+            'dtype': [numpy.uint8, numpy.float64],
+            'output': [numpy.float64],
+        })
+    ]) + testing.product([
+        # These take derivative functions to compute part of the process
+        testing.product({
+            'filter': ['generic_laplace'],
+            'derivative': [dummy_deriv_func],
+        }) + testing.product({
+            'filter': ['generic_gradient_magnitude'],
+            'derivative': [dummy_deriv_func],
+        }),
+        testing.product({
+            'shape': [(4, 5), (3, 4, 5), (1, 3, 4, 5)],
+            'dtype': [numpy.uint8, numpy.float64],
         })
     ])
 ))
@@ -256,7 +307,7 @@ class TestMirrorWithDim1(FilterTestCaseBase):
 ))
 @testing.gpu
 @testing.with_requires('scipy')
-class TestShelSort(FilterTestCaseBase):
+class TestShellSort(FilterTestCaseBase):
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
     def test_filter(self, xp, scp):
         return self._filter(xp, scp)
@@ -300,10 +351,10 @@ class TestFortranOrder(FilterTestCaseBase):
         testing.product({
             **COMMON_PARAMS,
             'mode': ['reflect'],
-            'output': [None, numpy.int32, numpy.float64],
+            'output': [None, numpy.uint8, numpy.float64],
             'dtype': [numpy.uint8, numpy.int16, numpy.int32,
                       numpy.float32, numpy.float64],
-            'wdtype': [numpy.int32, numpy.float64],
+            'wdtype': [numpy.uint8, numpy.float64],
         })
     ])
 ))
@@ -321,7 +372,7 @@ class TestWeightDtype(FilterTestCaseBase):
 @testing.parameterize(*testing.product({
     'filter': ['convolve', 'correlate', 'minimum_filter', 'maximum_filter'],
     'shape': [(3, 3), (3, 3, 3)],
-    'dtype': [numpy.int32, numpy.float64],
+    'dtype': [numpy.uint8, numpy.float64],
 }))
 @testing.gpu
 @testing.with_requires('scipy')
@@ -359,7 +410,7 @@ class TestSpecialWeightCases(FilterTestCaseBase):
     'filter': ['convolve1d', 'correlate1d',
                'minimum_filter1d', 'maximum_filter1d'],
     'shape': [(3, 3), (3, 3, 3)],
-    'dtype': [numpy.int32, numpy.float64],
+    'dtype': [numpy.uint8, numpy.float64],
 }))
 @testing.gpu
 @testing.with_requires('scipy')

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
@@ -176,9 +176,6 @@ COMMON_PARAMS = {
 class TestFilter(FilterTestCaseBase):
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
     def test_filter(self, xp, scp):
-        #if (self.mode == 'constant' and self.cval < 0 and
-        #        self.dtype == numpy.uint8):
-        #    raise unittest.SkipTest("undefined behavior")
         if self.dtype == getattr(self, 'output', None):
             raise unittest.SkipTest("redundant")
         return self._filter(xp, scp)


### PR DESCRIPTION
This adds implementations for 11 linear filters to `cupyx.scipy.ndimage.filters`. The following are nearly identical to scipy's code, just using the cupy's `convolve`/`convolve1d`/`correlate`/`correlate1d` as appropriate:

- `uniform_filter1d`
- `gaussian_filter1d`
- `generic_laplace`
- `laplace`
- `gaussian_laplace`
- `generic_gradient_magnitude`
- `gaussian_gradient_magnitude`

The following use an additional function making it easier to add any separable linear filters, but otherwise perform very closely to the original scipy's functions:

- `uniform_filter`
- `gaussian_filter`
- `prewitt`
- `sobel`

The function for handle separable filters also now handles the min/max filters when separable (in fact, the code was taken from there to make it work for any set of 1D filters to create an ND filter).

This code also introduces a new piece to the CUDA code: a templated `cast` function to add automatic casting from floats to unsigned ints in a compatible way to scipy. See https://github.com/cupy/cupy/issues/3111#issuecomment-650183301 for details discussing their implementation.

Some outstanding issues with the current code:

- Does not pass all tests. Apparently the min/max 1D filters utilize different casting behaviors than all of the other filters. I think those are the only tests failing (24 out of 4786 tests) and only in very specific cases.
- As suggested in https://github.com/cupy/cupy/issues/3111#issuecomment-650196144 we might want to add a note to the documentation that identical outputs cannot be guaranteed when the output is of integral data type due to floating point rounding issues since all intermediate results are floating-points.
- @emcastillo has suggested there are some minor edits from the previous PR that should instead be integrated here