### PR TITLE
Implement `has_sorted_indices`, `has_canonical_format`, `sort(ed)_indices()` for sparse matrices

### DIFF
--- a/cupyx/scipy/sparse/compressed.py
+++ b/cupyx/scipy/sparse/compressed.py
@@ -681,8 +681,11 @@ class _compressed_sparse_matrix(sparse_data._data_matrix,
     def sorted_indices(self):
         """Return a copy of this matrix with sorted indices
 
-        Taken from SciPy as is.
+        .. warning::
+            Calling this function might synchronize the device.
+
         """
+        # Taken from SciPy as is.
         A = self.copy()
         A.sort_indices()
         return A
@@ -693,6 +696,15 @@ class _compressed_sparse_matrix(sparse_data._data_matrix,
         raise NotImplementedError
 
     def sum_duplicates(self):
+        """Eliminate duplicate matrix entries by adding them together.
+
+        .. note::
+            This is an *in place* operation.
+
+        .. warning::
+            Calling this function might synchronize the device.
+
+        """
         if self.has_canonical_format:
             return
         # TODO(leofang): add a kernel for compressed sparse matrices without

--- a/cupyx/scipy/sparse/compressed.py
+++ b/cupyx/scipy/sparse/compressed.py
@@ -583,18 +583,21 @@ class _compressed_sparse_matrix(sparse_data._data_matrix,
             (data, indices, indptr), shape=shape, dtype=self.dtype, copy=False)
 
     def __get_has_canonical_format(self):
-        """Determine whether the matrix has sorted indices and no duplicates
+        """Determine whether the matrix has sorted indices and no duplicates.
 
         Returns
-            - True: if the above applies
-            - False: otherwise
+            bool: ``True`` if the above applies, otherwise ``False``.
 
-        has_canonical_format implies has_sorted_indices, so if the latter flag
-        is False, so will the former be; if the former is found True, the
-        latter flag is also set.
+        .. note::
+            :attr:`has_canonical_format` implies :attr:`has_sorted_indices`, so
+            if the latter flag is ``False``, so will the former be; if the
+            former is found ``True``, the latter flag is also set.
 
-        Modified from the SciPy counterpart.
+        .. warning::
+            Getting this property might synchronize the device.
+
         """
+        # Modified from the SciPy counterpart.
 
         # In CuPy the implemented conversions do not exactly match those of
         # SciPy's, so it's hard to put this exactly as where it is in SciPy,
@@ -621,14 +624,18 @@ class _compressed_sparse_matrix(sparse_data._data_matrix,
                                     fset=__set_has_canonical_format)
 
     def __get_sorted(self):
-        """Determine whether the matrix has sorted indices
+        """Determine whether the matrix has sorted indices.
 
         Returns
-            - True: if the indices of the matrix are in sorted order
-            - False: otherwise
+            bool:
+                ``True`` if the indices of the matrix are in sorted order,
+                otherwise ``False``.
 
-        Modified from the SciPy counterpart.
+        .. warning::
+            Getting this property might synchronize the device.
+
         """
+        # Modified from the SciPy counterpart.
 
         # In CuPy the implemented conversions do not exactly match those of
         # SciPy's, so it's hard to put this exactly as where it is in SciPy,

--- a/cupyx/scipy/sparse/coo.py
+++ b/cupyx/scipy/sparse/coo.py
@@ -216,6 +216,9 @@ class coo_matrix(sparse_data._data_matrix):
     def sum_duplicates(self):
         """Eliminate duplicate matrix entries by adding them together.
 
+        .. warning::
+            Calling this function might synchronize the device.
+
         .. seealso::
            :meth:`scipy.sparse.coo_matrix.sum_duplicates`
 

--- a/cupyx/scipy/sparse/coo.py
+++ b/cupyx/scipy/sparse/coo.py
@@ -239,8 +239,7 @@ class coo_matrix(sparse_data._data_matrix):
             row = src_row
             col = src_col
         else:
-            # TODO(leofang): move the kernels outside this method, and handle
-            # large arrays indexed by int64
+            # TODO(leofang): move the kernels outside this method
             index = cupy.cumsum(diff, dtype='i')
             size = int(index[-1]) + 1
             data = cupy.zeros(size, dtype=self.data.dtype)
@@ -324,12 +323,11 @@ class coo_matrix(sparse_data._data_matrix):
             return csc.csc_matrix(self.shape, dtype=self.dtype)
         # copy is silently ignored (in line with SciPy) because both
         # sum_duplicates and coosort change the underlying data
-        self.sum_duplicates()
         x = self.copy()
+        x.sum_duplicates()
         cusparse.coosort(x, 'c')
         x = cusparse.coo2csc(x)
         x.has_canonical_format = True
-        x.has_sorted_indices = True
         return x
 
     def tocsr(self, copy=False):
@@ -348,12 +346,11 @@ class coo_matrix(sparse_data._data_matrix):
             return csr.csr_matrix(self.shape, dtype=self.dtype)
         # copy is silently ignored (in line with SciPy) because both
         # sum_duplicates and coosort change the underlying data
-        self.sum_duplicates()
         x = self.copy()
+        x.sum_duplicates()
         cusparse.coosort(x, 'r')
         x = cusparse.coo2csr(x)
         x.has_canonical_format = True
-        x.has_sorted_indices = True
         return x
 
     def transpose(self, axes=None, copy=False):

--- a/cupyx/scipy/sparse/coo.py
+++ b/cupyx/scipy/sparse/coo.py
@@ -73,7 +73,7 @@ class coo_matrix(sparse_data._data_matrix):
             # shape and copy argument is ignored
             shape = (m, n)
             copy = False
-            
+
             self.has_canonical_format = True
 
         elif _scipy_available and scipy.sparse.issparse(arg1):

--- a/cupyx/scipy/sparse/csc.py
+++ b/cupyx/scipy/sparse/csc.py
@@ -280,8 +280,10 @@ class csc_matrix(compressed._compressed_sparse_matrix):
                 'swapping dimensions is the only logical permutation.')
 
         shape = self.shape[1], self.shape[0]
-        return cupyx.scipy.sparse.csr.csr_matrix(
+        trans = cupyx.scipy.sparse.csr.csr_matrix(
             (self.data, self.indices, self.indptr), shape=shape, copy=copy)
+        trans.has_canonical_format = self.has_canonical_format
+        return trans
 
 
 def isspmatrix_csc(x):

--- a/cupyx/scipy/sparse/csc.py
+++ b/cupyx/scipy/sparse/csc.py
@@ -176,13 +176,15 @@ class csc_matrix(compressed._compressed_sparse_matrix):
         if self.nnz == 0:
             return cupy.zeros(shape=self.shape, dtype=self.dtype, order=order)
 
-        self.sum_duplicates()
+        x = self.copy()
+        x.has_canonical_format = False  # need to enforce sum_duplicates
+        x.sum_duplicates()
         # csc2dense and csr2dense returns F-contiguous array.
         if order == 'C':
             # To return C-contiguous array, it uses transpose.
-            return cusparse.csr2dense(self.T).T
+            return cusparse.csr2dense(x.T).T
         elif order == 'F':
-            return cusparse.csc2dense(self)
+            return cusparse.csc2dense(x)
         else:
             raise TypeError('order not understood')
 

--- a/cupyx/scipy/sparse/csc.py
+++ b/cupyx/scipy/sparse/csc.py
@@ -35,7 +35,7 @@ class csc_matrix(compressed._compressed_sparse_matrix):
         copy (bool): If ``True``, copies of given arrays are always used.
 
     .. seealso::
-       :class:`scipy.sparse.csc_matrix`
+        :class:`scipy.sparse.csc_matrix`
 
     """
 

--- a/cupyx/scipy/sparse/csc.py
+++ b/cupyx/scipy/sparse/csc.py
@@ -279,11 +279,8 @@ class csc_matrix(compressed._compressed_sparse_matrix):
                 'swapping dimensions is the only logical permutation.')
 
         shape = self.shape[1], self.shape[0]
-        trans = cupyx.scipy.sparse.csr.csr_matrix(
+        return cupyx.scipy.sparse.csr.csr_matrix(
             (self.data, self.indices, self.indptr), shape=shape, copy=copy)
-        trans.has_canonical_format = self.has_canonical_format
-        trans.has_sorted_indices = self.has_sorted_indices
-        return trans
 
 
 def isspmatrix_csc(x):

--- a/cupyx/scipy/sparse/csc.py
+++ b/cupyx/scipy/sparse/csc.py
@@ -151,7 +151,12 @@ class csc_matrix(compressed._compressed_sparse_matrix):
     # TODO(unno): Implement reshape
 
     def sort_indices(self):
-        """Sorts the indices of the matrix in place."""
+        """Sorts the indices of this matrix *in place*.
+
+        .. warning::
+            Calling this function might synchronize the device.
+
+        """
         if not self.has_sorted_indices:
             cusparse.cscsort(self)
             self.has_sorted_indices = True

--- a/cupyx/scipy/sparse/csc.py
+++ b/cupyx/scipy/sparse/csc.py
@@ -152,8 +152,9 @@ class csc_matrix(compressed._compressed_sparse_matrix):
 
     def sort_indices(self):
         """Sorts the indices of the matrix in place."""
-        cusparse.cscsort(self)
-        self.has_sorted_indices = True
+        if not self.has_sorted_indices:
+            cusparse.cscsort(self)
+            self.has_sorted_indices = True
 
     def toarray(self, order=None, out=None):
         """Returns a dense matrix representing the same value.

--- a/cupyx/scipy/sparse/csc.py
+++ b/cupyx/scipy/sparse/csc.py
@@ -153,6 +153,7 @@ class csc_matrix(compressed._compressed_sparse_matrix):
     def sort_indices(self):
         """Sorts the indices of the matrix in place."""
         cusparse.cscsort(self)
+        self.has_sorted_indices = True
 
     def toarray(self, order=None, out=None):
         """Returns a dense matrix representing the same value.
@@ -253,6 +254,7 @@ class csc_matrix(compressed._compressed_sparse_matrix):
             csc2csr = cusparse.csc2csrEx2
         else:
             raise NotImplementedError
+        # don't touch has_sorted_indices, as cuSPARSE made no guarantee
         return csc2csr(self)
 
     # TODO(unno): Implement todia
@@ -279,7 +281,8 @@ class csc_matrix(compressed._compressed_sparse_matrix):
         shape = self.shape[1], self.shape[0]
         trans = cupyx.scipy.sparse.csr.csr_matrix(
             (self.data, self.indices, self.indptr), shape=shape, copy=copy)
-        trans._has_canonical_format = self._has_canonical_format
+        trans.has_canonical_format = self.has_canonical_format
+        trans.has_sorted_indices = self.has_sorted_indices
         return trans
 
 

--- a/cupyx/scipy/sparse/csr.py
+++ b/cupyx/scipy/sparse/csr.py
@@ -205,7 +205,12 @@ class csr_matrix(compressed._compressed_sparse_matrix):
     # TODO(unno): Implement reshape
 
     def sort_indices(self):
-        """Sorts the indices of the matrix in place."""
+        """Sorts the indices of this matrix *in place*.
+
+        .. warning::
+            Calling this function might synchronize the device.
+
+        """
         if not self.has_sorted_indices:
             cusparse.csrsort(self)
             self.has_sorted_indices = True

--- a/cupyx/scipy/sparse/csr.py
+++ b/cupyx/scipy/sparse/csr.py
@@ -206,8 +206,9 @@ class csr_matrix(compressed._compressed_sparse_matrix):
 
     def sort_indices(self):
         """Sorts the indices of the matrix in place."""
-        cusparse.csrsort(self)
-        self.has_sorted_indices = True
+        if not self.has_sorted_indices:
+            cusparse.csrsort(self)
+            self.has_sorted_indices = True
 
     def toarray(self, order=None, out=None):
         """Returns a dense matrix representing the same value.

--- a/cupyx/scipy/sparse/csr.py
+++ b/cupyx/scipy/sparse/csr.py
@@ -230,13 +230,15 @@ class csr_matrix(compressed._compressed_sparse_matrix):
         if self.nnz == 0:
             return cupy.zeros(shape=self.shape, dtype=self.dtype, order=order)
 
-        self.sum_duplicates()
+        x = self.copy()
+        x.has_canonical_format = False  # need to enforce sum_duplicates
+        x.sum_duplicates()
         # csr2dense returns F-contiguous array.
         if order == 'C':
             # To return C-contiguous array, it uses transpose.
-            return cusparse.csc2dense(self.T).T
+            return cusparse.csc2dense(x.T).T
         elif order == 'F':
-            return cusparse.csr2dense(self)
+            return cusparse.csr2dense(x)
         else:
             raise TypeError('order not understood')
 

--- a/cupyx/scipy/sparse/csr.py
+++ b/cupyx/scipy/sparse/csr.py
@@ -37,7 +37,7 @@ class csr_matrix(compressed._compressed_sparse_matrix):
         copy (bool): If ``True``, copies of given arrays are always used.
 
     .. seealso::
-       :class:`scipy.sparse.csr_matrix`
+        :class:`scipy.sparse.csr_matrix`
 
     """
 

--- a/cupyx/scipy/sparse/csr.py
+++ b/cupyx/scipy/sparse/csr.py
@@ -43,8 +43,6 @@ class csr_matrix(compressed._compressed_sparse_matrix):
 
     format = 'csr'
 
-    # TODO(unno): Implement has_sorted_indices
-
     def get(self, stream=None):
         """Returns a copy of the array on host memory.
 
@@ -209,6 +207,7 @@ class csr_matrix(compressed._compressed_sparse_matrix):
     def sort_indices(self):
         """Sorts the indices of the matrix in place."""
         cusparse.csrsort(self)
+        self.has_sorted_indices = True
 
     def toarray(self, order=None, out=None):
         """Returns a dense matrix representing the same value.
@@ -283,6 +282,7 @@ class csr_matrix(compressed._compressed_sparse_matrix):
             csr2csc = cusparse.csr2cscEx2
         else:
             raise NotImplementedError
+        # don't touch has_sorted_indices, as cuSPARSE made no guarantee
         return csr2csc(self)
 
     def tocsr(self, copy=False):
@@ -333,7 +333,8 @@ class csr_matrix(compressed._compressed_sparse_matrix):
         shape = self.shape[1], self.shape[0]
         trans = csc.csc_matrix(
             (self.data, self.indices, self.indptr), shape=shape, copy=copy)
-        trans._has_canonical_format = self._has_canonical_format
+        trans.has_canonical_format = self.has_canonical_format
+        trans.has_sorted_indices = self.has_sorted_indices
         return trans
 
 

--- a/cupyx/scipy/sparse/csr.py
+++ b/cupyx/scipy/sparse/csr.py
@@ -331,11 +331,8 @@ class csr_matrix(compressed._compressed_sparse_matrix):
                 'swapping dimensions is the only logical permutation.')
 
         shape = self.shape[1], self.shape[0]
-        trans = csc.csc_matrix(
+        return csc.csc_matrix(
             (self.data, self.indices, self.indptr), shape=shape, copy=copy)
-        trans.has_canonical_format = self.has_canonical_format
-        trans.has_sorted_indices = self.has_sorted_indices
-        return trans
 
 
 def isspmatrix_csr(x):

--- a/cupyx/scipy/sparse/csr.py
+++ b/cupyx/scipy/sparse/csr.py
@@ -332,8 +332,10 @@ class csr_matrix(compressed._compressed_sparse_matrix):
                 'swapping dimensions is the only logical permutation.')
 
         shape = self.shape[1], self.shape[0]
-        return csc.csc_matrix(
+        trans = csc.csc_matrix(
             (self.data, self.indices, self.indptr), shape=shape, copy=copy)
+        trans.has_canonical_format = self.has_canonical_format
+        return trans
 
 
 def isspmatrix_csr(x):

--- a/tests/cupy_tests/test_cusparse.py
+++ b/tests/cupy_tests/test_cusparse.py
@@ -428,6 +428,8 @@ class TestCoosort(unittest.TestCase):
     def setUp(self):
         self.a = scipy.sparse.random(
             100, 100, density=0.9, dtype=numpy.float32, format='coo')
+        numpy.random.shuffle(self.a.row)
+        numpy.random.shuffle(self.a.col)
 
     def test_coosort(self):
         a = sparse.coo_matrix(self.a)

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
@@ -857,19 +857,23 @@ class TestCscMatrixScipyComparison(unittest.TestCase):
         m = self.make(xp, sp, self.dtype)
         return m.has_sorted_indices
 
-    def test_has_sorted_indices2(self):
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_has_sorted_indices2(self, xp, sp):
         # this test is adopted from SciPy's
-        xp = cupy
-        sp = sparse
-        dtype = xp.float32
-
         sorted_inds = xp.array([0, 1])
-        unsorted_inds = xp.array([1, 0])
-        data = xp.array([1, 1], dtype=dtype)
+        data = xp.array([1, 1], dtype=self.dtype)
         indptr = xp.array([0, 2])
         M = sp.csc_matrix((data, sorted_inds, indptr))
         assert M.has_sorted_indices
+        return M
 
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_has_sorted_indices3(self, xp, sp):
+        # this test is adopted from SciPy's
+        sorted_inds = xp.array([0, 1])
+        unsorted_inds = xp.array([1, 0])
+        data = xp.array([1, 1], dtype=self.dtype)
+        indptr = xp.array([0, 2])
         M = sp.csc_matrix((data, unsorted_inds, indptr))
         assert not M.has_sorted_indices
 
@@ -877,8 +881,16 @@ class TestCscMatrixScipyComparison(unittest.TestCase):
         M.sort_indices()
         assert M.has_sorted_indices
         assert (M.indices == sorted_inds).all()
+        return M
 
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_has_sorted_indices4(self, xp, sp):
+        # this test is adopted from SciPy's
+        unsorted_inds = xp.array([1, 0])
+        data = xp.array([1, 1], dtype=self.dtype)
+        indptr = xp.array([0, 2])
         M = sp.csc_matrix((data, unsorted_inds, indptr))
+
         # set manually (although underlyingly unsorted)
         M.has_sorted_indices = True
         assert M.has_sorted_indices
@@ -887,6 +899,7 @@ class TestCscMatrixScipyComparison(unittest.TestCase):
         # ensure sort bypassed when has_sorted_indices == True
         M.sort_indices()
         assert (M.indices == unsorted_inds).all()
+        return M
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_sort_indices(self, xp, sp):

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
@@ -810,18 +810,19 @@ class TestCscMatrixScipyComparison(unittest.TestCase):
         m = self.make(xp, sp, self.dtype)
         return m.has_canonical_format
 
-    def test_has_canonical_format2(self):
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_has_canonical_format2(self, xp, sp):
         # this test is adopted from SciPy's
-        xp = cupy
-        sp = sparse
-        dtype = xp.float32
-
-        M = sp.csc_matrix((xp.array([2], dtype=dtype),
+        M = sp.csc_matrix((xp.array([2], dtype=self.dtype),
                            xp.array([0]), xp.array([0, 1])))
         assert M.has_canonical_format
+        return M
 
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_has_canonical_format3(self, xp, sp):
+        # this test is adopted from SciPy's
         indices = xp.array([0, 0])  # contains duplicate
-        data = xp.array([1, 1], dtype=dtype)
+        data = xp.array([1, 1], dtype=self.dtype)
         indptr = xp.array([0, 2])
 
         M = sp.csc_matrix((data, indices, indptr))
@@ -831,6 +832,14 @@ class TestCscMatrixScipyComparison(unittest.TestCase):
         M.sum_duplicates()
         assert M.has_canonical_format
         assert 1 == len(M.indices)
+        return M
+
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_has_canonical_format4(self, xp, sp):
+        # this test is adopted from SciPy's
+        indices = xp.array([0, 0])  # contains duplicate
+        data = xp.array([1, 1], dtype=self.dtype)
+        indptr = xp.array([0, 2])
 
         M = sp.csc_matrix((data, indices, indptr))
         # set manually (although underlyingly duplicated)
@@ -841,6 +850,7 @@ class TestCscMatrixScipyComparison(unittest.TestCase):
         # ensure deduplication bypassed when has_canonical_format == True
         M.sum_duplicates()
         assert 2 == len(M.indices)  # unaffected content
+        return M
 
     @testing.numpy_cupy_equal(sp_name='sp')
     def test_has_sorted_indices(self, xp, sp):

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
@@ -805,10 +805,104 @@ class TestCscMatrixScipyComparison(unittest.TestCase):
             with pytest.raises(TypeError):
                 None * m
 
+    @testing.numpy_cupy_equal(sp_name='sp')
+    def test_has_canonical_format(self, xp, sp):
+        m = self.make(xp, sp, self.dtype)
+        return m.has_canonical_format
+
+    def test_has_canonical_format2(self):
+        # this test is adopted from SciPy's
+        xp = cupy
+        sp = sparse
+        dtype = xp.float32
+
+        M = sp.csc_matrix((xp.array([2], dtype=dtype),
+                           xp.array([0]), xp.array([0, 1])))
+        assert M.has_canonical_format
+
+        indices = xp.array([0, 0])  # contains duplicate
+        data = xp.array([1, 1], dtype=dtype)
+        indptr = xp.array([0, 2])
+
+        M = sp.csc_matrix((data, indices, indptr))
+        assert not M.has_canonical_format
+
+        # set by deduplicating
+        M.sum_duplicates()
+        assert M.has_canonical_format
+        assert 1 == len(M.indices)
+
+        M = sp.csc_matrix((data, indices, indptr))
+        # set manually (although underlyingly duplicated)
+        M.has_canonical_format = True
+        assert M.has_canonical_format
+        assert 2 == len(M.indices)  # unaffected content
+
+        # ensure deduplication bypassed when has_canonical_format == True
+        M.sum_duplicates()
+        assert 2 == len(M.indices)  # unaffected content
+
+    @testing.numpy_cupy_equal(sp_name='sp')
+    def test_has_sorted_indices(self, xp, sp):
+        m = self.make(xp, sp, self.dtype)
+        return m.has_sorted_indices
+
+    def test_has_sorted_indices2(self):
+        # this test is adopted from SciPy's
+        xp = cupy
+        sp = sparse
+        dtype = xp.float32
+
+        sorted_inds = xp.array([0, 1])
+        unsorted_inds = xp.array([1, 0])
+        data = xp.array([1, 1], dtype=dtype)
+        indptr = xp.array([0, 2])
+        M = sp.csc_matrix((data, sorted_inds, indptr))
+        assert M.has_sorted_indices
+
+        M = sp.csc_matrix((data, unsorted_inds, indptr))
+        assert not M.has_sorted_indices
+
+        # set by sorting
+        M.sort_indices()
+        assert M.has_sorted_indices
+        assert (M.indices == sorted_inds).all()
+
+        M = sp.csc_matrix((data, unsorted_inds, indptr))
+        # set manually (although underlyingly unsorted)
+        M.has_sorted_indices = True
+        assert M.has_sorted_indices
+        assert (M.indices == unsorted_inds).all()
+
+        # ensure sort bypassed when has_sorted_indices == True
+        M.sort_indices()
+        assert (M.indices == unsorted_inds).all()
+
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_sort_indices(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
         m.sort_indices()
+        assert m.has_sorted_indices
+        return m
+
+    @testing.numpy_cupy_allclose(sp_name='sp', contiguous_check=False)
+    def test_sort_indices2(self, xp, sp):
+        # 1. this test is adopted from SciPy's.
+        # 2. we don't check the contiguity flag because SciPy and CuPy handle
+        #    the underlying data differently
+        data = xp.arange(5).astype(xp.float32)
+        indices = xp.array([7, 2, 1, 5, 4])
+        indptr = xp.array([0, 3, 5])
+        asp = sp.csc_matrix((data, indices, indptr), shape=(10, 2))
+        asp.sort_indices()
+        assert (asp.indices == xp.array([1, 2, 7, 4, 5])).all()
+        return asp.todense()
+
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_sorted_indices(self, xp, sp):
+        m = self.make(xp, sp, self.dtype)
+        m = m.sorted_indices()
+        assert m.has_sorted_indices
         return m
 
     def test_sum_tuple_axis(self):

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -899,19 +899,23 @@ class TestCsrMatrixScipyComparison(unittest.TestCase):
         m = self.make(xp, sp, self.dtype)
         return m.has_sorted_indices
 
-    def test_has_sorted_indices2(self):
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_has_sorted_indices2(self, xp, sp):
         # this test is adopted from SciPy's
-        xp = cupy
-        sp = sparse
-        dtype = xp.float32
-
         sorted_inds = xp.array([0, 1])
-        unsorted_inds = xp.array([1, 0])
-        data = xp.array([1, 1], dtype=dtype)
+        data = xp.array([1, 1], dtype=self.dtype)
         indptr = xp.array([0, 2])
         M = sp.csr_matrix((data, sorted_inds, indptr))
         assert M.has_sorted_indices
+        return M
 
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_has_sorted_indices3(self, xp, sp):
+        # this test is adopted from SciPy's
+        sorted_inds = xp.array([0, 1])
+        unsorted_inds = xp.array([1, 0])
+        data = xp.array([1, 1], dtype=self.dtype)
+        indptr = xp.array([0, 2])
         M = sp.csr_matrix((data, unsorted_inds, indptr))
         assert not M.has_sorted_indices
 
@@ -919,8 +923,16 @@ class TestCsrMatrixScipyComparison(unittest.TestCase):
         M.sort_indices()
         assert M.has_sorted_indices
         assert (M.indices == sorted_inds).all()
+        return M
 
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_has_sorted_indices4(self, xp, sp):
+        # this test is adopted from SciPy's
+        unsorted_inds = xp.array([1, 0])
+        data = xp.array([1, 1], dtype=self.dtype)
+        indptr = xp.array([0, 2])
         M = sp.csr_matrix((data, unsorted_inds, indptr))
+
         # set manually (although underlyingly unsorted)
         M.has_sorted_indices = True
         assert M.has_sorted_indices
@@ -929,6 +941,7 @@ class TestCsrMatrixScipyComparison(unittest.TestCase):
         # ensure sort bypassed when has_sorted_indices == True
         M.sort_indices()
         assert (M.indices == unsorted_inds).all()
+        return M
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_sort_indices(self, xp, sp):

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -852,18 +852,19 @@ class TestCsrMatrixScipyComparison(unittest.TestCase):
         m = self.make(xp, sp, self.dtype)
         return m.has_canonical_format
 
-    def test_has_canonical_format2(self):
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_has_canonical_format2(self, xp, sp):
         # this test is adopted from SciPy's
-        xp = cupy
-        sp = sparse
-        dtype = xp.float32
-
-        M = sp.csr_matrix((xp.array([2], dtype=dtype),
+        M = sp.csr_matrix((xp.array([2], dtype=self.dtype),
                            xp.array([0]), xp.array([0, 1])))
         assert M.has_canonical_format
+        return M
 
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_has_canonical_format3(self, xp, sp):
+        # this test is adopted from SciPy's
         indices = xp.array([0, 0])  # contains duplicate
-        data = xp.array([1, 1], dtype=dtype)
+        data = xp.array([1, 1], dtype=self.dtype)
         indptr = xp.array([0, 2])
 
         M = sp.csr_matrix((data, indices, indptr))
@@ -873,6 +874,14 @@ class TestCsrMatrixScipyComparison(unittest.TestCase):
         M.sum_duplicates()
         assert M.has_canonical_format
         assert 1 == len(M.indices)
+        return M
+
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_has_canonical_format4(self, xp, sp):
+        # this test is adopted from SciPy's
+        indices = xp.array([0, 0])  # contains duplicate
+        data = xp.array([1, 1], dtype=self.dtype)
+        indptr = xp.array([0, 2])
 
         M = sp.csr_matrix((data, indices, indptr))
         # set manually (although underlyingly duplicated)
@@ -883,6 +892,7 @@ class TestCsrMatrixScipyComparison(unittest.TestCase):
         # ensure deduplication bypassed when has_canonical_format == True
         M.sum_duplicates()
         assert 2 == len(M.indices)  # unaffected content
+        return M
 
     @testing.numpy_cupy_equal(sp_name='sp')
     def test_has_sorted_indices(self, xp, sp):

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -847,10 +847,102 @@ class TestCsrMatrixScipyComparison(unittest.TestCase):
             with pytest.raises(TypeError):
                 None * m
 
+    @testing.numpy_cupy_equal(sp_name='sp')
+    def test_has_canonical_format(self, xp, sp):
+        m = self.make(xp, sp, self.dtype)
+        return m.has_canonical_format
+
+    def test_has_canonical_format2(self):
+        # this test is adopted from SciPy's
+        xp = cupy
+        sp = sparse
+        dtype = xp.float32
+
+        M = sp.csr_matrix((xp.array([2], dtype=dtype),
+                           xp.array([0]), xp.array([0, 1])))
+        assert M.has_canonical_format
+
+        indices = xp.array([0, 0])  # contains duplicate
+        data = xp.array([1, 1], dtype=dtype)
+        indptr = xp.array([0, 2])
+
+        M = sp.csr_matrix((data, indices, indptr))
+        assert not M.has_canonical_format
+
+        # set by deduplicating
+        M.sum_duplicates()
+        assert M.has_canonical_format
+        assert 1 == len(M.indices)
+
+        M = sp.csr_matrix((data, indices, indptr))
+        # set manually (although underlyingly duplicated)
+        M.has_canonical_format = True
+        assert M.has_canonical_format
+        assert 2 == len(M.indices)  # unaffected content
+
+        # ensure deduplication bypassed when has_canonical_format == True
+        M.sum_duplicates()
+        assert 2 == len(M.indices)  # unaffected content
+
+    @testing.numpy_cupy_equal(sp_name='sp')
+    def test_has_sorted_indices(self, xp, sp):
+        m = self.make(xp, sp, self.dtype)
+        return m.has_sorted_indices
+
+    def test_has_sorted_indices2(self):
+        # this test is adopted from SciPy's
+        xp = cupy
+        sp = sparse
+        dtype = xp.float32
+
+        sorted_inds = xp.array([0, 1])
+        unsorted_inds = xp.array([1, 0])
+        data = xp.array([1, 1], dtype=dtype)
+        indptr = xp.array([0, 2])
+        M = sp.csr_matrix((data, sorted_inds, indptr))
+        assert M.has_sorted_indices
+
+        M = sp.csr_matrix((data, unsorted_inds, indptr))
+        assert not M.has_sorted_indices
+
+        # set by sorting
+        M.sort_indices()
+        assert M.has_sorted_indices
+        assert (M.indices == sorted_inds).all()
+
+        M = sp.csr_matrix((data, unsorted_inds, indptr))
+        # set manually (although underlyingly unsorted)
+        M.has_sorted_indices = True
+        assert M.has_sorted_indices
+        assert (M.indices == unsorted_inds).all()
+
+        # ensure sort bypassed when has_sorted_indices == True
+        M.sort_indices()
+        assert (M.indices == unsorted_inds).all()
+
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_sort_indices(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
         m.sort_indices()
+        assert m.has_sorted_indices
+        return m
+
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_sort_indices2(self, xp, sp):
+        # this test is adopted from SciPy's
+        data = xp.arange(5).astype(xp.float32)
+        indices = xp.array([7, 2, 1, 5, 4])
+        indptr = xp.array([0, 3, 5])
+        asp = sp.csr_matrix((data, indices, indptr), shape=(2, 10))
+        asp.sort_indices()
+        assert (asp.indices == xp.array([1, 2, 7, 4, 5])).all()
+        return asp.todense()
+
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_sorted_indices(self, xp, sp):
+        m = self.make(xp, sp, self.dtype)
+        m = m.sorted_indices()
+        assert m.has_sorted_indices
         return m
 
     def test_sum_tuple_axis(self):


### PR DESCRIPTION
This PR brings the current implementation to full compliance with SciPy, but I don't know what's the best way to measure performance impacts...I measured SpMV and do not see slowdown with this PR. Not sure what else I should look into, but I think for compatibility this PR is good to go.

Notes:
1. The property code is largely borrowed from SciPy so that it's easier to maintain and stay compliant.
2. The two `has_*` properties are mainly for compressed matrices (i.e. CSC/CSR); for COO, it doesn't have `has_sorted_indices`, and its `has_canonical_format` is set during creation or when `sum_duplicate()` is called. 
Importantly, COO does not validate this property when it is accessed. 
3. The internal flags `_has_*` are not directly accessed anywhere in the codebase; they are maintained by the corresponding properties.  
4. Whenever an operation does not guarantee the status of these properties, they should not be overwritten manually. This is in line with SciPy.

TODO:
- [x] Expand PR description
- [x] Add tests?
- [x] Clean up
- [ ] ~~Measure performance changes (how?)~~