### PR TITLE
Check NumPy compatibility in `flatiter` tests

### DIFF
--- a/tests/cupy_tests/indexing_tests/test_iterate.py
+++ b/tests/cupy_tests/indexing_tests/test_iterate.py
@@ -12,19 +12,22 @@ from cupy import testing
 class TestFlatiter(unittest.TestCase):
 
     def test_base(self):
-        a = cupy.zeros((2, 3, 4))
-        assert a.flat.base is a
+        for xp in (numpy, cupy):
+            a = xp.zeros((2, 3, 4))
+            assert a.flat.base is a
 
     def test_next(self):
-        a = testing.shaped_arange((2, 3, 4), cupy)
-        e = a.flatten()
-        for ai, ei in zip(a.flat, e):
-            assert ai == ei
+        for xp in (numpy, cupy):
+            a = testing.shaped_arange((2, 3, 4), xp)
+            e = a.flatten()
+            for ai, ei in zip(a.flat, e):
+                assert ai == ei
 
     def test_len(self):
-        a = cupy.zeros((2, 3, 4))
-        assert len(a.flat) == 24
-        assert len(a[::2].flat) == 12
+        for xp in (numpy, cupy):
+            a = xp.zeros((2, 3, 4))
+            assert len(a.flat) == 24
+            assert len(a[::2].flat) == 12
 
     @testing.numpy_cupy_array_equal()
     def test_copy(self, xp):


### PR DESCRIPTION
As suggested at https://github.com/cupy/cupy/pull/3508#pullrequestreview-439666718, this PR fixes some of `flatiter` tests to check NumPy compatibility too.