### PR TITLE
Support `axis=None` in sparse min/max

### DIFF
--- a/cupyx/scipy/sparse/data.py
+++ b/cupyx/scipy/sparse/data.py
@@ -1,4 +1,5 @@
 import cupy
+from cupy.core import internal
 from cupyx.scipy.sparse import base
 from cupyx.scipy.sparse import util
 
@@ -155,6 +156,27 @@ class _minmax_mixin(object):
                               "an 'out' parameter."))
 
         util.validateaxis(axis)
+
+        if axis is None:
+            if 0 in self.shape:
+                raise ValueError("zero-size array to reduction operation")
+
+            zero = self.dtype.type(0)
+            if self.nnz == 0:
+                return zero
+            if sum_duplicates:
+                self.sum_duplicates()
+            m = min_or_max(self.data.ravel())
+            if non_zero:
+                return m
+            if self.nnz != internal.prod(self.shape):
+                if min_or_max is cupy.min:
+                    m = cupy.minimum(zero, m)
+                elif min_or_max is cupy.max:
+                    m = cupy.maximum(zero, m)
+                else:
+                    assert False
+            return m
 
         if axis == 0 or axis == 1:
             return self._min_or_max_axis(axis, min_or_max, sum_duplicates,

--- a/cupyx/scipy/sparse/data.py
+++ b/cupyx/scipy/sparse/data.py
@@ -166,7 +166,7 @@ class _minmax_mixin(object):
                 return zero
             if sum_duplicates:
                 self.sum_duplicates()
-            m = min_or_max(self.data.ravel())
+            m = min_or_max(self.data)
             if non_zero:
                 return m
             if self.nnz != internal.prod(self.shape):

--- a/cupyx/scipy/sparse/data.py
+++ b/cupyx/scipy/sparse/data.py
@@ -161,7 +161,7 @@ class _minmax_mixin(object):
             if 0 in self.shape:
                 raise ValueError("zero-size array to reduction operation")
 
-            zero = self.dtype.type(0)
+            zero = cupy.zeros((), dtype=self.dtype)
             if self.nnz == 0:
                 return zero
             if sum_duplicates:

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
@@ -903,7 +903,34 @@ class TestCscMatrixScipyCompressed(unittest.TestCase):
 
 
 @testing.with_requires('scipy>=0.19.0')
-class TestCsrMatrixScipyCompressedMinMax(unittest.TestCase):
+class TestCscMatrixScipyCompressedMinMax(unittest.TestCase):
+
+    def test_min_sparse_axis_none(self):
+        dm_data = numpy.random.random((10, 20))
+        dm_data[dm_data < 0.95] = 0
+
+        dm_data = scipy.sparse.csc_matrix(dm_data)
+        cp_matrix = sparse.csc_matrix((cupy.array(dm_data.data),
+                                       cupy.array(dm_data.indices),
+                                       cupy.array(dm_data.indptr)),
+                                      shape=(10, 20))
+
+        da_cupy_values = cp_matrix.min()
+        da_scipy_values = dm_data.min()
+        testing.assert_array_equal(da_cupy_values, da_scipy_values)
+
+    def test_min_sparse_axis_none_nonzero(self):
+        dm_data = numpy.arange(0, 100, 1).reshape((10, 10)).astype(float)
+
+        dm_sparse = scipy.sparse.csc_matrix(dm_data)
+        cp_matrix = sparse.csc_matrix((cupy.array(dm_sparse.data),
+                                       cupy.array(dm_sparse.indices),
+                                       cupy.array(dm_sparse.indptr)),
+                                      shape=(10, 10))
+
+        da_cupy_values = cp_matrix.min(nonzero=True)
+        da_numpy_values = numpy.array(1).astype(float)
+        testing.assert_array_equal(da_cupy_values, da_numpy_values)
 
     def test_min_sparse_axis_0(self):
         dm_data = numpy.random.random((10, 20))

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -1026,6 +1026,33 @@ class TestCsrMatrixScipyCompressed(unittest.TestCase):
 @testing.with_requires('scipy>=0.19.0')
 class TestCsrMatrixScipyCompressedMinMax(unittest.TestCase):
 
+    def test_min_sparse_axis_none(self):
+        dm_data = numpy.random.random((10, 20))
+        dm_data[dm_data < 0.95] = 0
+
+        dm_data = scipy.sparse.csr_matrix(dm_data)
+        cp_matrix = sparse.csr_matrix((cupy.array(dm_data.data),
+                                       cupy.array(dm_data.indices),
+                                       cupy.array(dm_data.indptr)),
+                                      shape=(10, 20))
+
+        da_cupy_values = cp_matrix.min()
+        da_scipy_values = dm_data.min()
+        testing.assert_array_equal(da_cupy_values, da_scipy_values)
+
+    def test_min_sparse_axis_none_nonzero(self):
+        dm_data = numpy.arange(0, 100, 1).reshape((10, 10)).astype(float)
+
+        dm_sparse = scipy.sparse.csr_matrix(dm_data)
+        cp_matrix = sparse.csr_matrix((cupy.array(dm_sparse.data),
+                                       cupy.array(dm_sparse.indices),
+                                       cupy.array(dm_sparse.indptr)),
+                                      shape=(10, 10))
+
+        da_cupy_values = cp_matrix.min(nonzero=True)
+        da_numpy_values = numpy.array(1).astype(float)
+        testing.assert_array_equal(da_cupy_values, da_numpy_values)
+
     def test_min_sparse_axis_0(self):
         dm_data = numpy.random.random((10, 20))
         dm_data[dm_data < 0.95] = 0


### PR DESCRIPTION
Close #3506.

This PR fixes sparse min/max to support `axis=None`.