### PR TITLE
Add multi-gpu support to time

### DIFF
--- a/cupyx/time.py
+++ b/cupyx/time.py
@@ -10,7 +10,7 @@ from cupy import util
 class _PerfCaseResult(object):
     def __init__(self, name, ts, devices):
         assert ts.ndim == 2
-        assert ts.shape[0] >= 2
+        assert ts.shape[0] == len(devices) + 1
         assert ts.shape[1] > 0
         self.name = name
         self._ts = ts
@@ -102,7 +102,7 @@ def _repeat(
         event.synchronize()
 
     cpu_times = []
-    gpu_times = [[] for i in range(len(events_1))]
+    gpu_times = [[] for i in events_1]
     duration = 0
     for i in range(n_repeat):
         for event, device in zip(events_1, devices):
@@ -123,11 +123,9 @@ def _repeat(
         for event, device in zip(events_2, devices):
             with cupy.cuda.Device(device):
                 event.synchronize()
-        i = 0
-        for ev1, ev2 in zip(events_1, events_2):
+        for i, (ev1, ev2) in enumerate(zip(events_1, events_2)):
             gpu_time = cupy.cuda.get_elapsed_time(ev1, ev2) * 1e-3
             gpu_times[i].append(gpu_time)
-            i += 1
 
         duration += time.perf_counter() - t1
         if duration > max_duration:

--- a/tests/cupyx_tests/test_time.py
+++ b/tests/cupyx_tests/test_time.py
@@ -4,6 +4,7 @@ from unittest import mock
 import numpy
 
 import cupy
+from cupy import testing
 import cupyx
 
 
@@ -26,7 +27,29 @@ class TestRepeat(unittest.TestCase):
                 assert perf.name == 'test_name_xxx'
                 assert mock_func.call_count == 13
                 assert perf.cpu_times.shape == (10,)
-                assert perf.gpu_times.shape == (10,)
+                assert perf.gpu_times.shape == (1, 10,)
+                assert (perf.cpu_times == 1.4).all()
+                assert (perf.gpu_times == 2.5).all()
+
+    @testing.multi_gpu(2)
+    def test_multigpu_routine(self):
+        with mock.patch('time.perf_counter',
+                        mock.Mock(side_effect=[2.4, 3.8, 3.8] * 10)):
+            with mock.patch('cupy.cuda.get_elapsed_time',
+                            mock.Mock(return_value=2500)):
+                mock_func = mock.Mock()
+                mock_func.__name__ = 'test_name_xxx'
+                x = cupy.testing.shaped_random((2, 3), cupy, 'int32')
+                y = cupy.testing.shaped_random((2, 3), cupy, 'int32')
+                assert mock_func.call_count == 0
+
+                perf = cupyx.time.repeat(
+                    mock_func, (x, y), n_repeat=10, n_warmup=3, devices=(0, 1))
+
+                assert perf.name == 'test_name_xxx'
+                assert mock_func.call_count == 13
+                assert perf.cpu_times.shape == (10,)
+                assert perf.gpu_times.shape == (2, 10,)
                 assert (perf.cpu_times == 1.4).all()
                 assert (perf.gpu_times == 2.5).all()
 
@@ -47,7 +70,7 @@ class TestRepeat(unittest.TestCase):
                 assert perf.name == 'test_name_xxx'
                 assert mock_func.call_count == 6
                 assert perf.cpu_times.shape == (3,)
-                assert perf.gpu_times.shape == (3,)
+                assert perf.gpu_times.shape == (1, 3)
                 assert (perf.cpu_times == 1.).all()
                 assert (perf.gpu_times == 2.5).all()
 
@@ -63,12 +86,12 @@ class TestPerfCaseResult(unittest.TestCase):
             [5.4, 7.1, 6.0, 5.4, 4.2],
             [6.4, 4.3, 8.9, 9.6, 3.8],
         ]) * 1e-6
-        perf = cupyx.time._PerfCaseResult('test_name_xxx', times)
+        perf = cupyx.time._PerfCaseResult('test_name_xxx', times, (0,))
         expected = (
             'test_name_xxx       :'
             '    CPU:    5.620 us   +/- 0.943 '
             '(min:    4.200 / max:    7.100) us '
-            '    GPU:    6.600 us   +/- 2.344 '
+            '    GPU-0:    6.600 us   +/- 2.344 '
             '(min:    3.800 / max:    9.600) us'
         )
         assert str(perf) == expected
@@ -78,7 +101,7 @@ class TestPerfCaseResult(unittest.TestCase):
             [5.4, 7.1, 6.0, 5.4, 4.2],
             [6.4, 4.3, 8.9, 9.6, 3.8],
         ]) * 1e-6
-        perf = cupyx.time._PerfCaseResult('test_name_xxx', times)
+        perf = cupyx.time._PerfCaseResult('test_name_xxx', times, (0,))
         expected = (
             'test_name_xxx       :'
             '    CPU:    5.620 us   +/- 0.943 '
@@ -90,11 +113,19 @@ class TestPerfCaseResult(unittest.TestCase):
 
     def test_single_show_gpu(self):
         times = numpy.array([[5.4], [6.4]]) * 1e-6
-        perf = cupyx.time._PerfCaseResult('test_name_xxx', times)
+        perf = cupyx.time._PerfCaseResult('test_name_xxx', times, (0,))
         assert str(perf) == ('test_name_xxx       :    CPU:    5.400 us '
-                             '    GPU:    6.400 us')
+                             '    GPU-0:    6.400 us')
 
     def test_single_no_show_gpu(self):
         times = numpy.array([[5.4], [6.4]]) * 1e-6
-        perf = cupyx.time._PerfCaseResult('test_name_xxx', times)
+        perf = cupyx.time._PerfCaseResult('test_name_xxx', times, (0,))
         assert perf.to_str() == 'test_name_xxx       :    CPU:    5.400 us'
+
+    def test_show_multigpu(self):
+        times = numpy.array([[5.4], [6.4], [7.0], [8.1]]) * 1e-6
+        perf = cupyx.time._PerfCaseResult('test_name_xxx', times, (0, 1, 2))
+        assert str(perf) == ('test_name_xxx       :    CPU:    5.400 us '
+                             '    GPU-0:    6.400 us '
+                             '    GPU-1:    7.000 us '
+                             '    GPU-2:    8.100 us')


### PR DESCRIPTION
Closes #3484 



Check with

```python
import cupy
import cupyx
import time


size = 10 ** 8


def single_device():
    with cupy.cuda.Device(0):
        arr_0 = cupy.ones(size)
        arr_1 = cupy.ones(size)
        arr_0 * arr_1


def multi_device():
    streams = []
    with cupy.cuda.Device(0):
        arr_0_0 = cupy.ones(size // 2)
        arr_0_1 = cupy.ones(size // 2)

    with cupy.cuda.Device(1):
        arr_1_0 = cupy.ones(size // 2)
        arr_1_1 = cupy.ones(size // 2)

    with cupy.cuda.Device(0):
        arr_0_0 * arr_0_1

    with cupy.cuda.Device(1):
        arr_1_0 * arr_1_1


print(cupyx.time.repeat(single_device, n_repeat=10))
print(cupyx.time.repeat(multi_device, n_repeat=10, devices=[0,1]))
```