### PR TITLE
Small fixes for CUB block reduction kernels

### DIFF
--- a/cupy/core/_cub_reduction.pxd
+++ b/cupy/core/_cub_reduction.pxd
@@ -7,4 +7,4 @@ cdef bint _try_to_call_cub_reduction(
     stream, optimize_context, tuple key,
     map_expr, reduce_expr, post_map_expr, reduce_type, type_map,
     tuple reduce_axis, tuple out_axis, const shape_t& out_shape,
-    ndarray ret)
+    ndarray ret) except *

--- a/cupy/core/include/cupy/complex/complex.h
+++ b/cupy/core/include/cupy/complex/complex.h
@@ -75,12 +75,29 @@ struct complex {
 
   /* --- Constructors --- */
 
+  /*! Construct a complex number with an imaginary part of 0.
+   *
+   *  \param re The real part of the number.
+   */
+  inline __host__ __device__ complex(const T& re);
+
   /*! Construct a complex number from its real and imaginary parts.
    *
    *  \param re The real part of the number.
    *  \param im The imaginary part of the number.
    */
-  inline __host__ __device__ complex(const T& re = T(), const T& im = T());
+  inline __host__ __device__ complex(const T& re, const T& im);
+
+  /*! Default construct a complex number.
+   */
+  inline __host__ __device__ complex();
+
+  /*! This copy constructor copies from a \p complex with a type that is
+   *  convertible to this \p complex's \c value_type.
+   *
+   *  \param z The \p complex to copy from.
+   */
+  inline __host__ __device__ complex(const complex<T>& z);
 
   /*! This copy constructor copies from a \p complex with a type that
    *  is convertible to this \p complex \c value_type.
@@ -91,6 +108,32 @@ struct complex {
    */
   template <typename X>
   inline __host__ __device__ complex(const complex<X>& z);
+
+  /* --- Assignment Operators --- */
+
+  /*! Assign `re` to the real part of this \p complex and set the imaginary part
+   *  to 0.
+   *
+   *  \param re The real part of the number.
+   */
+  inline __host__ __device__ complex& operator=(const T& re);
+
+  /*! Assign `z.real()` and `z.imag()` to the real and imaginary parts of this
+   *  \p complex respectively.
+   *
+   *  \param z The \p complex to copy from.
+   */
+  inline __host__ __device__ complex& operator=(const complex<T>& z);
+
+  /*! Assign `z.real()` and `z.imag()` to the real and imaginary parts of this
+   *  \p complex respectively.
+   *
+   *  \param z The \p complex to copy from.
+   *
+   *  \tparam U is convertible to \c value_type.
+   */
+  template <typename U>
+  inline __host__ __device__ complex& operator=(const complex<U>& z);
 
   /* --- Compound Assignment Operators --- */
 

--- a/cupy/core/include/cupy/complex/complex_inl.h
+++ b/cupy/core/include/cupy/complex/complex_inl.h
@@ -22,12 +22,28 @@
 namespace thrust {
 
 /* --- Constructors --- */
-// TODO(leofang): support more kinds of constructors from upstream
+template <typename T>
+inline __host__ __device__ complex<T>::complex(const T& re) {
+  real(re);
+  imag(T());
+}
 
 template <typename T>
 inline __host__ __device__ complex<T>::complex(const T& re, const T& im) {
   real(re);
   imag(im);
+}
+
+template <typename T>
+inline __host__ __device__ complex<T>::complex() {
+  real(T());
+  imag(T());
+}
+
+template <typename T>
+inline __host__ __device__ complex<T>::complex(const complex<T>& z) {
+  real(z.real());
+  imag(z.imag());
 }
 
 template <typename T>
@@ -37,6 +53,30 @@ inline __host__ __device__ complex<T>::complex(const complex<X>& z) {
   // about potential loss of precision
   real(T(z.real()));
   imag(T(z.imag()));
+}
+
+/* --- Assignment Operators --- */
+
+template <typename T>
+inline __host__ __device__ complex<T>& complex<T>::operator=(const T& re) {
+  real(re);
+  imag(T());
+  return *this;
+}
+
+template <typename T>
+inline __host__ __device__ complex<T>& complex<T>::operator=(const complex<T>& z) {
+  real(z.real());
+  imag(z.imag());
+  return *this;
+}
+
+template <typename T>
+template <typename U>
+inline __host__ __device__ complex<T>& complex<T>::operator=(const complex<U>& z) {
+  real(T(z.real()));
+  imag(T(z.imag()));
+  return *this;
 }
 
 /* --- Compound Assignment Operators --- */

--- a/tests/cupy_tests/core_tests/test_raw.py
+++ b/tests/cupy_tests/core_tests/test_raw.py
@@ -558,7 +558,7 @@ class TestRaw(unittest.TestCase):
 
         ker = mod.get_function('test_mulf')
         ker((grid,), (block,), (a, b, out))
-        assert (out == a * b).all()
+        assert cupy.allclose(out, a * b)
 
         ker = mod.get_function('test_divf')
         ker((grid,), (block,), (a, b, out))
@@ -574,7 +574,7 @@ class TestRaw(unittest.TestCase):
 
         ker = mod.get_function('test_fmaf')
         ker((grid,), (block,), (a, b, c, out))
-        assert (out == a * b + c).all()
+        assert cupy.allclose(out, a * b + c)
 
         ker = mod.get_function('test_makef')
         ker((grid,), (block,), (out,))
@@ -620,7 +620,7 @@ class TestRaw(unittest.TestCase):
 
         ker = mod.get_function('test_mul')
         ker((grid,), (block,), (a, b, out))
-        assert (out == a * b).all()
+        assert cupy.allclose(out, a * b)
 
         ker = mod.get_function('test_div')
         ker((grid,), (block,), (a, b, out))
@@ -636,7 +636,7 @@ class TestRaw(unittest.TestCase):
 
         ker = mod.get_function('test_fma')
         ker((grid,), (block,), (a, b, c, out))
-        assert (out == a * b + c).all()
+        assert cupy.allclose(out, a * b + c)
 
         ker = mod.get_function('test_make')
         ker((grid,), (block,), (out,))


### PR DESCRIPTION
1. Remove all of the type constraints: I remember I set the limitations due to some errors when running the full test suite, but I could no longer reproduce it (with the latest master). @grlee77's [new `norm` kernels](https://github.com/cupy/cupy/issues/2516#issuecomment-538043247) might also need the support for complex numbers.
2. Add a possible exception to the optimizer: during the optuna optimization `CUDADriverError` could be raised due to out of resource. This was first observed in https://github.com/cupy/cupy/pull/3244#issuecomment-641479088, and I thought by constraining the search range it'd be remedied, but today I encountered it a few more times for different tasks, so apparently this is necessary. 
After adding this, I see that the error is gracefully handled:
```bash
[I 2020-06-30 22:29:07,612] Finished trial#1 with value: inf with parameters: {'block_size_log': 9, 'items_per_thread': 28}. Best is trial#0 with value: 0.0029116286219972552.
``` 
3. Allow compiler exceptions to propagate upward.
4. **(UPDATE)** Make `complex<T>` (almost) obey the rule of three (to fix fp16 -> complex conversion): This is basically a follow-up of #2629 and #2741. It turns out that by ensuring the rule of three (except for the destructor, which is trivial), we get the `float16` -> `complex<T>` conversion for free (through C++ implicit conversion fp16->fp32->complex<float>) without additional change. I should have done this when working on #2741...😢 Note the changes are in line with the Thrust implementation. 
5. **(UPDATE)** Fix tests