### PR TITLE
Add `cupyx.scipy.sparse.kron()`

### DIFF
--- a/cupy/sparse/__init__.py
+++ b/cupy/sparse/__init__.py
@@ -24,7 +24,7 @@ from cupyx.scipy.sparse.construct import vstack  # NOQA
 # TODO(unno): implement dok_matrix
 # TODO(unno): implement lil_matrix
 
-# TODO(unno): implement kron
+from cupyx.scipy.sparse.construct import kron  # NOQA
 # TODO(unno): implement kronsum
 # TODO(unno): implement diags
 # TODO(unno): implement block_diag

--- a/cupyx/scipy/sparse/__init__.py
+++ b/cupyx/scipy/sparse/__init__.py
@@ -25,7 +25,7 @@ from cupyx.scipy.sparse.construct import vstack  # NOQA
 # TODO(unno): implement dok_matrix
 # TODO(unno): implement lil_matrix
 
-# TODO(unno): implement kron
+from cupyx.scipy.sparse.construct import kron  # NOQA
 # TODO(unno): implement kronsum
 # TODO(unno): implement diags
 # TODO(unno): implement block_diag

--- a/cupyx/scipy/sparse/construct.py
+++ b/cupyx/scipy/sparse/construct.py
@@ -538,12 +538,10 @@ def kron(A, B, format=None):
         dtype = cupy.int64
     else:
         dtype = cupy.int32
-    row = A.row.repeat(B.nnz).astype(dtype)
-    col = A.col.repeat(B.nnz).astype(dtype)
-    data = A.data.repeat(B.nnz)  # data's dtype follows that of A in SciPy
-
-    row *= B.shape[0]
-    col *= B.shape[1]
+    row = A.row.astype(dtype, copy=True) * B.shape[0]
+    row = row.repeat(B.nnz)
+    col = A.col.astype(dtype, copy=True) * B.shape[1]
+    col = col.repeat(B.nnz)
 
     # increment block indices
     row, col = row.reshape(-1, B.nnz), col.reshape(-1, B.nnz)
@@ -552,6 +550,7 @@ def kron(A, B, format=None):
     row, col = row.ravel(), col.ravel()
 
     # compute block entries
+    data = A.data.repeat(B.nnz)  # data's dtype follows that of A in SciPy
     data = data.reshape(-1, B.nnz) * B.data
     data = data.ravel()
 

--- a/cupyx/scipy/sparse/construct.py
+++ b/cupyx/scipy/sparse/construct.py
@@ -502,8 +502,10 @@ def kron(A, B, format=None):
         format (str): the format of the returned sparse matrix.
 
     Returns:
-        cupyx.scipy.sparse.spmatrix: Generated sparse matrix in the
-            specified ``format``.
+        cupyx.scipy.sparse.spmatrix:
+            Generated sparse matrix with the specified ``format``.
+
+    .. seealso:: :func:`scipy.sparse.kron`
 
     """
     # TODO(leofang): support BSR format when it's added to CuPy

--- a/docs/source/reference/sparse.rst
+++ b/docs/source/reference/sparse.rst
@@ -58,6 +58,7 @@ Building sparse matrices
    cupyx.scipy.sparse.eye
    cupyx.scipy.sparse.hstack
    cupyx.scipy.sparse.identity
+   cupyx.scipy.sparse.kron
    cupyx.scipy.sparse.spdiags
    cupyx.scipy.sparse.rand
    cupyx.scipy.sparse.random

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_construct.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_construct.py
@@ -379,26 +379,44 @@ class TestDiags(unittest.TestCase):
         return x
 
 
+# borrowed from scipy:
+arrs = [[[0]],
+        [[-1]],
+        [[4]],
+        [[10]],
+        [[0], [0]],
+        [[0, 0]],
+        [[1, 2], [3, 4]],
+        [[0, 2], [5, 0]],
+        [[0, 2, -6], [8, 0, 14]],
+        [[5, 4], [0, 0], [6, 0]],
+        [[5, 4, 4], [1, 0, 0], [6, 0, 8]],
+        [[0, 1, 0, 2, 0, 5, 8]],
+        [[0.5, 0.125, 0, 3.25], [0, 2.5, 0, 0]], ]
+
+
 @testing.parameterize(*testing.product({
     'dtype': (numpy.float32, numpy.float64, numpy.complex64, numpy.complex128),
     'format': ('csr', 'csc', 'coo'),
+    'arrA': arrs,
+    'arrB': arrs,
 }))
 @testing.with_requires('scipy')
 class TestKron(unittest.TestCase):
 
-    def _make_sp_mat(self, xp, sp, shape, dtype):
-        a = testing.shaped_random(shape, xp, self.dtype)
-        a[a < 0.98] = 0.
+    def _make_sp_mat(self, xp, sp, arr, dtype):
+        a = xp.array(arr, dtype=dtype)
         a = sp.csr_matrix(a)
         return a
 
-    @testing.numpy_cupy_allclose(sp_name='sp', rtol=1E-6)
+    @testing.numpy_cupy_allclose(sp_name='sp')
     def test_kron(self, xp, sp):
-        a = self._make_sp_mat(xp, sp, (2, 3), self.dtype)
-        b = self._make_sp_mat(xp, sp, (4, 5), self.dtype)
-        kron = sp.kron(a.astype(self.dtype),
-                       b.astype(self.dtype),
-                       format=self.format)
-        assert kron.shape == (8, 15)
+        a = self._make_sp_mat(xp, sp, self.arrA, self.dtype)
+        b = self._make_sp_mat(xp, sp, self.arrB, self.dtype)
+        kron = sp.kron(a, b, format=self.format)
+        assert kron.shape == (a.shape[0] * b.shape[0], a.shape[1] * b.shape[1])
         assert kron.nnz == a.nnz * b.nnz
         return kron
+
+    # TODO(leofang): check oversize inputs as in scipy/scipy#11879 after
+    # #3513 is fixed


### PR DESCRIPTION
The implementation and test cases are largely borrowed from SciPy, with minor tweaks. 

I actually implemented a correct `ElementwiseKernel` to construct the arrays `row`, `col`, and `data` at once (see 7135ec9) instead of following SciPy, but in my local tests I found it's slower, so I abandoned it. I guess it's because the memory access pattern isn't optimal. 

Moreover, the real bottleneck in this function is the three `coo_matrix()` calls. Together they took about 90% of time, so how the rest is implemented really doesn't matter much. I am not sure if this is a defect or something expected, will look into it, but it shouldn't be a blocker.