### PR TITLE
Avoid early compilation when initializing a RawModule instance

### DIFF
--- a/cupy/core/raw.pyx
+++ b/cupy/core/raw.pyx
@@ -301,7 +301,8 @@ cdef class RawModule:
             self.translate_cucomplex = False
 
         # trigger compiling or loading
-        cdef Module mod = self.module  # noqa
+        IF no_cuda == 0:
+            cdef Module mod = self.module  # noqa
 
     @property
     def module(self):

--- a/cupy/core/raw.pyx
+++ b/cupy/core/raw.pyx
@@ -225,14 +225,13 @@ cdef class RawModule:
     modules (\\*.cubin, \\*.ptx). This class is useful when a number of CUDA
     kernels in the same source need to be retrieved.
 
-    For the former case, the CUDA source code is compiled when initializing a
-    new instance of this class, and the kernels can be retrieved by calling
+    For the former case, the CUDA source code is compiled when any method is
+    called. For the latter case, an existing CUDA binary (\\*.cubin) or a PTX
+    file can be loaded by providing its path.
+
+    CUDA kernels in a :class:`RawModule` can be retrieved by calling
     :meth:`get_function`, which will return an instance of :class:`RawKernel`.
     (Same as in :class:`RawKernel`, the generated binary is also cached.)
-
-    For the latter case, an existing CUDA binary (\\*.cubin) or a PTX file can
-    be loaded by providing its path, and kernels therein can be retrieved
-    similarly.
 
     Args:
         code (str): CUDA source code. Mutually exclusive with ``path``.
@@ -261,6 +260,12 @@ cdef class RawModule:
 
     .. note::
         Each kernel in ``RawModule`` possesses independent function attributes.
+
+    .. note::
+        Before CuPy v8.0.0, the compilation happens at initialization. Now, it
+        happens at the first time retrieving any object (kernels, pointers, or
+        texrefs) from the module.
+
     """
     def __init__(self, *, str code=None, str path=None, tuple options=(),
                  str backend='nvrtc', bint translate_cucomplex=False,
@@ -299,12 +304,6 @@ cdef class RawModule:
             self.options = ()
             self.backend = 'nvcc'
             self.translate_cucomplex = False
-
-        cdef Module mod = None
-        # no_cuda is defined at build time
-        IF not no_cuda:
-            # trigger compiling or loading
-            mod = self.module
 
     @property
     def module(self):

--- a/cupy/core/raw.pyx
+++ b/cupy/core/raw.pyx
@@ -300,9 +300,11 @@ cdef class RawModule:
             self.backend = 'nvcc'
             self.translate_cucomplex = False
 
-        # trigger compiling or loading
-        IF no_cuda == 0:
-            cdef Module mod = self.module  # noqa
+        cdef Module mod = None
+        # no_cuda is defined at build time
+        IF not no_cuda:
+            # trigger compiling or loading
+            mod = self.module
 
     @property
     def module(self):

--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -628,9 +628,6 @@ def parse_args():
     }
     if check_readthedocs_environment():
         arg_options['no_cuda'] = True
-    # make some compile-time expressions available to Cython codes;
-    # currently we do not expose any, and leave this for future extension
-    arg_options['compile_time_env'] = {}
     return arg_options
 
 
@@ -731,7 +728,7 @@ def cythonize(extensions, arg_options):
     # Embed signatures for Sphinx documentation.
     directives['embedsignature'] = True
 
-    cythonize_option_keys = ('annotate', 'compile_time_env')
+    cythonize_option_keys = ('annotate',)
     cythonize_options = {key: arg_options[key]
                          for key in cythonize_option_keys}
 

--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -628,6 +628,10 @@ def parse_args():
     }
     if check_readthedocs_environment():
         arg_options['no_cuda'] = True
+        # pass no_cuda to Cython
+        arg_options['compile_time_env'] = {'no_cuda': True}
+    else:
+        arg_options['compile_time_env'] = {'no_cuda': False}
     return arg_options
 
 
@@ -728,7 +732,7 @@ def cythonize(extensions, arg_options):
     # Embed signatures for Sphinx documentation.
     directives['embedsignature'] = True
 
-    cythonize_option_keys = ('annotate',)
+    cythonize_option_keys = ('annotate', 'compile_time_env')
     cythonize_options = {key: arg_options[key]
                          for key in cythonize_option_keys}
 

--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -628,10 +628,10 @@ def parse_args():
     }
     if check_readthedocs_environment():
         arg_options['no_cuda'] = True
-        # pass no_cuda to Cython
-        arg_options['compile_time_env'] = {'no_cuda': True}
-    else:
-        arg_options['compile_time_env'] = {'no_cuda': False}
+    # make some compile-time expressions available to Cython codes
+    arg_options['compile_time_env'] = {
+        'no_cuda': arg_options['no_cuda'],
+    }
     return arg_options
 
 

--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -628,10 +628,9 @@ def parse_args():
     }
     if check_readthedocs_environment():
         arg_options['no_cuda'] = True
-    # make some compile-time expressions available to Cython codes
-    arg_options['compile_time_env'] = {
-        'no_cuda': arg_options['no_cuda'],
-    }
+    # make some compile-time expressions available to Cython codes;
+    # currently we do not expose any, and leave this for future extension
+    arg_options['compile_time_env'] = {}
     return arg_options
 
 

--- a/tests/cupy_tests/core_tests/test_raw.py
+++ b/tests/cupy_tests/core_tests/test_raw.py
@@ -413,10 +413,10 @@ class TestRaw(unittest.TestCase):
 
     def test_invalid_compiler_flag(self):
         with pytest.raises(cupy.cuda.compiler.CompileException) as ex:
-            cupy.RawModule(
-                code=_test_source3,
-                options=('-DPRECISION=3',),
-                backend=self.backend)
+            mod = cupy.RawModule(code=_test_source3,
+                                 options=('-DPRECISION=3',),
+                                 backend=self.backend)
+            mod.get_function('test_sum')  # enforce compilation
         assert 'precision not supported' in str(ex.value)
 
     def _generate_file(self, ext: str):
@@ -470,9 +470,10 @@ class TestRaw(unittest.TestCase):
         # this error is more likely to appear when using RawModule, so
         # let us do it here
         with pytest.raises(cupy.cuda.driver.CUDADriverError) as ex:
-            cupy.RawModule(
+            mod = cupy.RawModule(
                 path=os.path.expanduser('~/this_does_not_exist.cubin'),
                 backend=self.backend)
+            mod.get_function('nonexisting_kernel')  # enforce loading
         assert 'CUDA_ERROR_FILE_NOT_FOUND' in str(ex.value)
 
     def test_module_neither_code_nor_path(self):

--- a/tests/cupy_tests/core_tests/test_raw.py
+++ b/tests/cupy_tests/core_tests/test_raw.py
@@ -718,7 +718,7 @@ class TestRaw(unittest.TestCase):
     def test_context_switch_RawKernel(self):
         # run test_basic() on another device
 
-        # For RawKernel, we need to launch it once to force compiling
+        # we need to launch it once to force compiling
         x1, x2, y = self._helper(self.kern, cupy.float32)
 
         with cupy.cuda.Device(1):
@@ -728,9 +728,12 @@ class TestRaw(unittest.TestCase):
     @testing.multi_gpu(2)
     def test_context_switch_RawModule1(self):
         # run test_module() on another device
-        # in this test, re-compiling happens at get_function()
+        # in this test, re-compiling happens at 2nd get_function()
+        module = self.mod2
+        with cupy.cuda.Device(0):
+            module.get_function('test_sum')
+
         with cupy.cuda.Device(1):
-            module = self.mod2
             ker_sum = module.get_function('test_sum')
             x1, x2, y = self._helper(ker_sum, cupy.float32)
             assert cupy.allclose(y, x1 + x2)
@@ -740,7 +743,8 @@ class TestRaw(unittest.TestCase):
         # run test_module() on another device
         # in this test, re-compiling happens at kernel launch
         module = self.mod2
-        ker_sum = module.get_function('test_sum')
+        with cupy.cuda.Device(0):
+            ker_sum = module.get_function('test_sum')
 
         with cupy.cuda.Device(1):
             x1, x2, y = self._helper(ker_sum, cupy.float32)
@@ -759,8 +763,9 @@ class TestRaw(unittest.TestCase):
         with device0:
             file_path = self._generate_file('cubin')
             mod = cupy.RawModule(path=file_path, backend=self.backend)
+            mod.get_function('test_div')
 
-        # in this test, reloading happens at get_function()
+        # in this test, reloading happens at 2nd get_function()
         with device1:
             ker = mod.get_function('test_div')
             x1, x2, y = self._helper(ker, cupy.float32)
@@ -795,13 +800,18 @@ class TestRaw(unittest.TestCase):
 
         # compile code
         name_expressions = ['my_sqrt<unsigned int>']
-        mod = cupy.RawModule(code=test_cxx_template, options=('--std=c++11',),
-                             name_expressions=name_expressions)
+        name = name_expressions[0]
+        with cupy.cuda.Device(0):
+            mod = cupy.RawModule(code=test_cxx_template,
+                                 options=('--std=c++11',),
+                                 name_expressions=name_expressions)
+
+            # get specialized kernels
+            mod.get_function(name)
 
         # switch device
         with cupy.cuda.Device(1):
             # get specialized kernels
-            name = name_expressions[0]
             ker = mod.get_function(name)
 
             # prepare inputs & expected outputs
@@ -823,12 +833,14 @@ class TestRaw(unittest.TestCase):
 
         # compile code
         name_expressions = ['my_sqrt<unsigned int>']
-        mod = cupy.RawModule(code=test_cxx_template, options=('--std=c++11',),
-                             name_expressions=name_expressions)
-
-        # get specialized kernels
         name = name_expressions[0]
-        ker = mod.get_function(name)
+        with cupy.cuda.Device(0):
+            mod = cupy.RawModule(code=test_cxx_template,
+                                 options=('--std=c++11',),
+                                 name_expressions=name_expressions)
+
+            # get specialized kernels
+            ker = mod.get_function(name)
 
         # switch device
         with cupy.cuda.Device(1):


### PR DESCRIPTION
Fix https://github.com/cupy/cupy/pull/3486#issuecomment-653145880. There, the CI error occurred because `RawModule` compiles at initialization, not when `get_function()` is called, so in a Read the Docs environment where nvcc is not available, the build fails. Now it's fixed by ~~checking if the build environment has CUDA or not~~ (**UPDATE**) deferring the compilation to when something needs to be fetched.

~~In fact, making this `no_cuda` flag (and potentially a few other ones) available could help some other Cython modules to conditionally compile.~~

cc: @cjnolet 