### PR TITLE
Support batched slogdet with complex numbers

### DIFF
--- a/cupy/linalg/decomposition.py
+++ b/cupy/linalg/decomposition.py
@@ -74,9 +74,11 @@ def _lu_factor(a_t, dtype):
             getrf_bufferSize = cusolver.dgetrf_bufferSize
             getrf = cusolver.dgetrf
         elif dtype == numpy.complex64:
-            getrfBatched = cupy.cuda.cublas.cgetrfBatched
+            getrf_bufferSize = cusolver.cgetrf_bufferSize
+            getrf = cusolver.cgetrf
         elif dtype == numpy.complex128:
-            getrfBatched = cupy.cuda.cublas.zgetrfBatched
+            getrf_bufferSize = cusolver.zgetrf_bufferSize
+            getrf = cusolver.zgetrf
         else:
             assert False
 

--- a/cupy/linalg/norms.py
+++ b/cupy/linalg/norms.py
@@ -241,12 +241,7 @@ def slogdet(a):
     util._assert_nd_squareness(a)
 
     dtype = numpy.promote_types(a.dtype.char, 'f')
-    if dtype == numpy.complex64:
-        real_dtype = numpy.dtype("f")
-    elif dtype == numpy.complex128:
-        real_dtype = numpy.dtype("d")
-    else:
-        real_dtype = dtype
+    real_dtype = numpy.dtype(dtype.char.lower())
 
     if dtype not in (numpy.float32, numpy.float64,
                      numpy.complex64, numpy.complex128):

--- a/cupy/linalg/norms.py
+++ b/cupy/linalg/norms.py
@@ -275,17 +275,14 @@ def slogdet(a):
 
     logdet = cupy.log(cupy.abs(diag)).sum(axis=-1)
 
+    # ipiv is 1-origin
+    non_zero = cupy.count_nonzero(ipiv != cupy.arange(1, n + 1), axis=-1)
     if dtype.kind == "f":
-        # ipiv is 1-origin
-        non_zero = (cupy.count_nonzero(ipiv != cupy.arange(1, n + 1), axis=-1) +
-                    cupy.count_nonzero(diag < 0, axis=-1))
-    
-        # Note: sign == -1 ** (non_zero % 2)
-        sign = (non_zero % 2) * -2 + 1
-    else:  # for complex numbers
-        non_zero = cupy.count_nonzero(ipiv != cupy.arange(1, n + 1), axis=-1)
-        
-        sign = (non_zero % 2) * -2 + 1
+        non_zero += cupy.count_nonzero(diag < 0, axis=-1)
+
+    # Note: sign == -1 ** (non_zero % 2)
+    sign = (non_zero % 2) * -2 + 1
+    if dtype.kind == "c":
         sign = sign * cupy.prod(diag, axis=-1) / cupy.exp(logdet)
 
     singular = dev_info > 0

--- a/cupy/linalg/norms.py
+++ b/cupy/linalg/norms.py
@@ -282,7 +282,7 @@ def slogdet(a):
     # Note: sign == -1 ** (non_zero % 2)
     sign = (non_zero % 2) * -2 + 1
     if dtype.kind == "c":
-        sign = sign * cupy.prod(diag, axis=-1) / cupy.exp(logdet)
+        sign = sign * cupy.prod(diag / cupy.abs(diag), axis=-1)
 
     singular = dev_info > 0
     return (

--- a/cupy/linalg/norms.py
+++ b/cupy/linalg/norms.py
@@ -248,7 +248,8 @@ def slogdet(a):
     else:
         real_dtype = dtype
 
-    if dtype not in ("f", "d", "F", "D"):
+    if dtype not in (numpy.float32, numpy.float64,
+                     numpy.complex64, numpy.complex128):
         msg = ('dtype must be float32, float64, complex64, or complex128'
                ' (actual: {})'.format(a.dtype))
         raise ValueError(msg)

--- a/cupy/linalg/norms.py
+++ b/cupy/linalg/norms.py
@@ -241,7 +241,6 @@ def slogdet(a):
     util._assert_nd_squareness(a)
 
     dtype = numpy.promote_types(a.dtype.char, 'f')
-    print(type(dtype))
     if dtype == numpy.complex64:
         real_dtype = numpy.dtype("f")
     elif dtype == numpy.complex128:

--- a/tests/cupy_tests/linalg_tests/test_norms.py
+++ b/tests/cupy_tests/linalg_tests/test_norms.py
@@ -169,28 +169,28 @@ class TestSlogdet(unittest.TestCase):
     def test_slogdet(self, xp, dtype):
         a = testing.shaped_arange((2, 2), xp, dtype) + 1
         sign, logdet = xp.linalg.slogdet(a)
-        return xp.array([sign, logdet], dtype)
+        return xp.array([sign, logdet.astype(sign.dtype)], dtype)
 
     @testing.for_dtypes('fdFD')
     @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-4)
     def test_slogdet_3(self, xp, dtype):
         a = testing.shaped_arange((2, 2, 2), xp, dtype) + 1
         sign, logdet = xp.linalg.slogdet(a)
-        return xp.array([sign, logdet], dtype)
+        return xp.array([sign, logdet.astype(sign.dtype)], dtype)
 
     @testing.for_dtypes('fdFD')
     @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-4)
     def test_slogdet_4(self, xp, dtype):
         a = testing.shaped_arange((2, 2, 2, 2), xp, dtype) + 1
         sign, logdet = xp.linalg.slogdet(a)
-        return xp.array([sign, logdet], dtype)
+        return xp.array([sign, logdet.astype(sign.dtype)], dtype)
 
     @testing.for_dtypes('fdFD')
     @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-4)
     def test_slogdet_singular(self, xp, dtype):
         a = xp.zeros((3, 3), dtype)
         sign, logdet = xp.linalg.slogdet(a)
-        return xp.array([sign, logdet], dtype)
+        return xp.array([sign, logdet.astype(sign.dtype)], dtype)
 
     @testing.for_dtypes('fdFD')
     @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-4)
@@ -200,7 +200,7 @@ class TestSlogdet(unittest.TestCase):
             # `cupy.linalg.slogdet` internally catches `dev_info < 0` from
             # cuSOLVER, which should not affect `dev_info > 0` cases.
             sign, logdet = xp.linalg.slogdet(a)
-        return xp.array([sign, logdet], dtype)
+        return xp.array([sign, logdet.astype(sign.dtype)], dtype)
 
     @testing.for_dtypes('fdFD')
     def test_slogdet_one_dim(self, dtype):

--- a/tests/cupy_tests/linalg_tests/test_norms.py
+++ b/tests/cupy_tests/linalg_tests/test_norms.py
@@ -164,35 +164,35 @@ class TestDet(unittest.TestCase):
 @testing.gpu
 class TestSlogdet(unittest.TestCase):
 
-    @testing.for_float_dtypes(no_float16=True)
+    @testing.for_dtypes('fdFD')
     @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-4)
     def test_slogdet(self, xp, dtype):
         a = testing.shaped_arange((2, 2), xp, dtype) + 1
         sign, logdet = xp.linalg.slogdet(a)
         return xp.array([sign, logdet], dtype)
 
-    @testing.for_float_dtypes(no_float16=True)
+    @testing.for_dtypes('fdFD')
     @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-4)
     def test_slogdet_3(self, xp, dtype):
         a = testing.shaped_arange((2, 2, 2), xp, dtype) + 1
         sign, logdet = xp.linalg.slogdet(a)
         return xp.array([sign, logdet], dtype)
 
-    @testing.for_float_dtypes(no_float16=True)
+    @testing.for_dtypes('fdFD')
     @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-4)
     def test_slogdet_4(self, xp, dtype):
         a = testing.shaped_arange((2, 2, 2, 2), xp, dtype) + 1
         sign, logdet = xp.linalg.slogdet(a)
         return xp.array([sign, logdet], dtype)
 
-    @testing.for_float_dtypes(no_float16=True)
+    @testing.for_dtypes('fdFD')
     @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-4)
     def test_slogdet_singular(self, xp, dtype):
         a = xp.zeros((3, 3), dtype)
         sign, logdet = xp.linalg.slogdet(a)
         return xp.array([sign, logdet], dtype)
 
-    @testing.for_float_dtypes(no_float16=True)
+    @testing.for_dtypes('fdFD')
     @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-4)
     def test_slogdet_singular_errstate(self, xp, dtype):
         a = xp.zeros((3, 3), dtype)
@@ -202,7 +202,7 @@ class TestSlogdet(unittest.TestCase):
             sign, logdet = xp.linalg.slogdet(a)
         return xp.array([sign, logdet], dtype)
 
-    @testing.for_float_dtypes(no_float16=True)
+    @testing.for_dtypes('fdFD')
     def test_slogdet_one_dim(self, dtype):
         for xp in (numpy, cupy):
             a = testing.shaped_arange((2,), xp, dtype)


### PR DESCRIPTION
Related to #3522, I added support for `cupy.linalg.slogdet` to handle complex numbers.
This PR also includes a bug fix on `cupy.linalg.decomposition._lu_factor` that incorrectly handled complex ndarrays with cuSolver.