### PR TITLE
Add missing `cupy_cub.cu` in package data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -130,6 +130,7 @@ package_data = {
         'core/include/cupy/_cuda/cuda-*/*.h',
         'core/include/cupy/_cuda/cuda-*/*.hpp',
         'cuda/cupy_thrust.cu',
+        'cuda/cupy_cub.cu',
     ],
 }
 


### PR DESCRIPTION
Part of chainer/chainer-test#586.