### PR TITLE
Fix negative value test in test_helper

### DIFF
--- a/tests/cupy_tests/testing_tests/test_helper.py
+++ b/tests/cupy_tests/testing_tests/test_helper.py
@@ -147,18 +147,18 @@ class TestNumPyCuPyLess(unittest.TestCase, NumPyCuPyDecoratorBase,
 
 class TestIgnoreOfNegativeValueDifferenceOnCpuAndGpu(unittest.TestCase):
 
-    @helper.for_unsigned_dtypes('dtype1')
-    @helper.for_signed_dtypes('dtype2')
     @helper.numpy_cupy_allclose()
-    def correct_failure(self, xp, dtype1, dtype2):
+    def correct_failure(self, dtype1, dtype2, xp):
         if xp == numpy:
             return xp.array(-1, dtype=numpy.float32)
         else:
             return xp.array(-2, dtype=numpy.float32)
 
-    def test_correct_failure(self):
+    @helper.for_unsigned_dtypes('dtype1')
+    @helper.for_signed_dtypes('dtype2')
+    def test_correct_failure(self, dtype1, dtype2):
         with pytest.raises(AssertionError):
-            self.correct_failure()
+            self.correct_failure(dtype1, dtype2)
 
     @helper.for_unsigned_dtypes('dtype1')
     @helper.for_signed_dtypes('dtype2')


### PR DESCRIPTION
Taking over #2884 with making appropriate changes.

`raises` was wrapping a function decorated with `for_unsigned_dtypes` and
`for_signed_dtypes`. In this scheme, if an error was raised in any of
the combinations of dtypes, the test would pass, which would be unintended.