### PR TITLE
Update style checker version for Python 3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,10 +41,10 @@ requirements = {
         'fastrlock>=0.3',
     ],
     'stylecheck': [
-        'autopep8==1.3.5',
-        'flake8==3.5.0',
+        'autopep8==1.4.4',
+        'flake8==3.7.9',
         'pbr==4.0.4',
-        'pycodestyle==2.3.1',
+        'pycodestyle==2.5.0',
     ],
     'test': [
         'pytest<4.2.0',  # 4.2.0 is slow collecting tests and times out on CI.


### PR DESCRIPTION
The following message is output In Python 3.7.
```
% ~/env/chainer/check.sh
/home/okuta/env/chainer37/.direnv/python-3.7.6/lib/python3.7/site-packages/pycodestyle.py:113: FutureWarning: Possible nested set at position 1
  EXTRANEOUS_WHITESPACE_REGEX = re.compile(r'[[({] | []}),;:]')
/home/okuta/env/chainer37/.direnv/python-3.7.6/lib/python3.7/site-packages/pycodestyle.py:113: FutureWarning: Possible nested set at position 1
  EXTRANEOUS_WHITESPACE_REGEX = re.compile(r'[[({] | []}),;:]')
/home/okuta/env/chainer37/.direnv/python-3.7.6/lib/python3.7/site-packages/pycodestyle.py:113: FutureWarning: Possible nested set at position 1
  EXTRANEOUS_WHITESPACE_REGEX = re.compile(r'[[({] | []}),;:]')
```

This PR updates style checker version.