### PR TITLE
Remove unused descriptor definition

### DIFF
--- a/cupy/cutensor.py
+++ b/cupy/cutensor.py
@@ -5,7 +5,6 @@ import cupy
 from cupy_backends.cuda.api import runtime
 from cupy.cuda import cutensor
 from cupy.cuda import device
-from cupy import util
 
 _handles = {}
 _tensor_descriptors = {}

--- a/cupy/cutensor.py
+++ b/cupy/cutensor.py
@@ -14,22 +14,6 @@ _contraction_finds = {}
 _contraction_plans = {}
 
 
-class Descriptor(object):
-
-    def __init__(self, descriptor, destroyer=None):
-        self.value = descriptor
-        self.destroy = destroyer
-
-    def __del__(self, is_shutting_down=util.is_shutting_down):
-        if is_shutting_down():
-            return
-        if self.destroy is None:
-            self.value = None
-        elif self.value is not None:
-            self.destroy(self.value)
-            self.value = None
-
-
 class Mode(object):
 
     def __init__(self, mode):


### PR DESCRIPTION
Modified not to use `Descriptor` in `cupy/cutensor.py` [while refactoring cutensor.py](https://github.com/cupy/cupy/pull/2772/files#diff-142bdbde8a244a83c4d0c894c1f1d185L107-L110)