### PR TITLE
Use `numpy_cupy_array_equal` instead of `numpy_cupy_array_list_equal`

### DIFF
--- a/cupy/statistics/histogram.py
+++ b/cupy/statistics/histogram.py
@@ -236,6 +236,10 @@ def histogram(x, bins=10, range=None, weights=None, density=False):
                     bin_edges[-1] -= 1
                 elif x.dtype.kind == 'f':
                     bin_edges[-1] = old_edge
+
+                # TODO(asi1024): Refactor temporary fix for dtype compatibility
+                if isinstance(bins, cupy.ndarray):
+                    bin_edges = bin_edges.astype(bins.dtype, copy=False)
                 break
         else:
             _histogram_kernel(x, bin_edges, bin_edges.size, y)

--- a/tests/cupy_tests/statics_tests/test_histogram.py
+++ b/tests/cupy_tests/statics_tests/test_histogram.py
@@ -326,7 +326,7 @@ class TestCubHistogram(unittest.TestCase):
         _accelerator.set_routine_accelerators(self.old_accelerators)
 
     @testing.for_all_dtypes(no_bool=True, no_complex=True)
-    @testing.numpy_cupy_array_list_equal()
+    @testing.numpy_cupy_array_equal()
     def test_histogram(self, xp, dtype):
         x = testing.shaped_arange((10,), xp, dtype)
 


### PR DESCRIPTION
Resolve conflict of https://github.com/cupy/cupy/pull/3582 and https://github.com/cupy/cupy/pull/3473.