### PR TITLE
Ndimage generic filters

### DIFF
--- a/cupyx/scipy/ndimage/__init__.py
+++ b/cupyx/scipy/ndimage/__init__.py
@@ -20,6 +20,8 @@ from cupyx.scipy.ndimage.filters import maximum_filter1d  # NOQA
 from cupyx.scipy.ndimage.filters import median_filter  # NOQA
 from cupyx.scipy.ndimage.filters import rank_filter  # NOQA
 from cupyx.scipy.ndimage.filters import percentile_filter  # NOQA
+from cupyx.scipy.ndimage.filters import generic_filter  # NOQA
+from cupyx.scipy.ndimage.filters import generic_filter1d  # NOQA
 
 from cupyx.scipy.ndimage.interpolation import affine_transform  # NOQA
 from cupyx.scipy.ndimage.interpolation import map_coordinates  # NOQA

--- a/cupyx/scipy/ndimage/_filters_core.py
+++ b/cupyx/scipy/ndimage/_filters_core.py
@@ -1,0 +1,366 @@
+import cupy
+
+
+def _get_output(output, input, shape=None):
+    if shape is None:
+        shape = input.shape
+    if isinstance(output, cupy.ndarray):
+        if output.shape != tuple(shape):
+            raise ValueError('output shape is not correct')
+    else:
+        dtype = output
+        if dtype is None:
+            dtype = input.dtype
+        output = cupy.zeros(shape, dtype)
+    return output
+
+
+def _fix_sequence_arg(arg, ndim, name, conv=lambda x: x):
+    if isinstance(arg, str):
+        return [conv(arg)] * ndim
+    try:
+        arg = iter(arg)
+    except TypeError:
+        return [conv(arg)] * ndim
+    lst = [conv(x) for x in arg]
+    if len(lst) != ndim:
+        msg = "{} must have length equal to input rank".format(name)
+        raise RuntimeError(msg)
+    return lst
+
+
+def _check_origin(origin, width):
+    origin = int(origin)
+    if (width // 2 + origin < 0) or (width // 2 + origin >= width):
+        raise ValueError('invalid origin')
+    return origin
+
+
+def _check_mode(mode):
+    if mode not in ('reflect', 'constant', 'nearest', 'mirror', 'wrap'):
+        msg = 'boundary mode not supported (actual: {})'.format(mode)
+        raise RuntimeError(msg)
+    return mode
+
+
+def _get_inttype(input):
+    # The integer type to use for indices in the input array
+    # The indices actually use byte positions and we can't just use
+    # input.nbytes since that won't tell us the number of bytes between the
+    # first and last elements when the array is non-contiguous
+    nbytes = sum((x-1)*abs(stride) for x, stride in
+                 zip(input.shape, input.strides)) + input.dtype.itemsize
+    return 'int' if nbytes < (1 << 31) else 'ptrdiff_t'
+
+
+def _check_size_footprint_structure(ndim, size, footprint, structure,
+                                    stacklevel=3, force_footprint=False):
+    if structure is None and footprint is None:
+        if size is None:
+            raise RuntimeError("no footprint or filter size provided")
+        sizes = _fix_sequence_arg(size, ndim, 'size', int)
+        if force_footprint:
+            return None, cupy.ones(sizes, bool), None
+        return sizes, None, None
+    if size is not None:
+        import warnings
+        warnings.warn("ignoring size because {} is set".format(
+            'structure' if footprint is None else 'footprint'),
+            UserWarning, stacklevel=stacklevel+1)
+
+    if footprint is not None:
+        footprint = cupy.array(footprint, bool, True, 'C')
+        if not footprint.any():
+            raise ValueError("all-zero footprint is not supported")
+
+    if structure is None:
+        if not force_footprint and footprint.all():
+            if footprint.ndim != ndim:
+                raise RuntimeError("size must have length equal to input rank")
+            return footprint.shape, None, None
+        return None, footprint, None
+
+    structure = cupy.ascontiguousarray(structure)
+    if footprint is None:
+        footprint = cupy.ones(structure.shape, bool)
+    return None, footprint, structure
+
+
+def _convert_1d_args(ndim, weights, origin, axis):
+    if weights.ndim != 1 or weights.size < 1:
+        raise RuntimeError('incorrect filter size')
+    axis = cupy.util._normalize_axis_index(axis, ndim)
+    wshape = [1]*ndim
+    wshape[axis] = weights.size
+    weights = weights.reshape(wshape)
+    origins = [0]*ndim
+    origins[axis] = _check_origin(origin, weights.size)
+    return weights, tuple(origins)
+
+
+def _check_nd_args(input, weights, mode, origin, wghts_name='filter weights'):
+    if input.dtype.kind == 'c':
+        raise TypeError('Complex type not supported')
+    _check_mode(mode)
+    # Weights must always be 2 GiB or less
+    if weights.nbytes > (1 << 31):
+        raise RuntimeError('weights must be 2 GiB or less, use FFTs instead')
+    weight_dims = [x for x in weights.shape if x != 0]
+    if len(weight_dims) != input.ndim:
+        raise RuntimeError('{} array has incorrect shape'.format(wghts_name))
+    origins = _fix_sequence_arg(origin, len(weight_dims), 'origin', int)
+    for origin, width in zip(origins, weight_dims):
+        _check_origin(origin, width)
+    return tuple(origins), _get_inttype(input)
+
+
+def _run_1d_filters(filters, input, args, output, mode, cval, origin=0):
+    """
+    Runs a series of 1D filters forming an nd filter. The filters must be a
+    list of callables that take input, arg, axis, output, mode, cval, origin.
+    The args is a list of values that are passed for the arg value to the
+    filter. Individual filters can be None causing that axis to be skipped.
+    """
+    output_orig = output
+    output = _get_output(output, input)
+    modes = _fix_sequence_arg(mode, input.ndim, 'mode', _check_mode)
+    origins = _fix_sequence_arg(origin, input.ndim, 'origin', int)
+    n_filters = sum(filter is not None for filter in filters)
+    if n_filters == 0:
+        output[...] = input[...]
+        return output
+    # We can't operate in-place efficiently, so use a 2-buffer system
+    temp = _get_output(output.dtype, input) if n_filters > 1 else None
+    first = True
+    iterator = zip(filters, args, modes, origins)
+    for axis, (fltr, arg, mode, origin) in enumerate(iterator):
+        if fltr is None:
+            continue
+        fltr(input, arg, axis, output, mode, cval, origin)
+        input, output = output, temp if first else input
+    if isinstance(output_orig, cupy.ndarray) and input is not output_orig:
+        output_orig[...] = input
+        input = output_orig
+    return input
+
+
+def _call_kernel(kernel, input, weights, output, structure=None,
+                 weights_dtype=cupy.float64, structure_dtype=cupy.float64):
+    """
+    Calls a constructed ElementwiseKernel. The kernel must take an input image,
+    an optional array of weights, an optional array for the structure, and an
+    output array.
+
+    weights and structure can be given as None (structure defaults to None) in
+    which case they are not passed to the kernel at all. If the output is given
+    as None then it will be allocated in this function.
+
+    This function deals with making sure that the weights and structure are
+    contiguous and float64 (or bool for weights that are footprints)*, that the
+    output is allocated and appriopately shaped. This also deals with the
+    situation that the input and output arrays overlap in memory.
+
+    * weights is always cast to float64 or bool in order to get an output
+    compatible with SciPy, though float32 might be sufficient when input dtype
+    is low precision. If weights_dtype is passed as weights.dtype then no
+    dtype conversion will occur. The input and output are never converted.
+    """
+    args = [input]
+    if weights is not None:
+        weights = cupy.ascontiguousarray(weights, weights_dtype)
+        args.append(weights)
+    if structure is not None:
+        structure = cupy.ascontiguousarray(structure, structure_dtype)
+        args.append(structure)
+    output = _get_output(output, input)
+    needs_temp = cupy.shares_memory(output, input, 'MAY_SHARE_BOUNDS')
+    if needs_temp:
+        output, temp = _get_output(output.dtype, input), output
+    args.append(output)
+    kernel(*args)
+    if needs_temp:
+        temp[...] = output[...]
+        output = temp
+    return output
+
+
+def _generate_boundary_condition_ops(mode, ix, xsize):
+    if mode == 'reflect':
+        ops = '''
+        if ({ix} < 0) {{
+            {ix} = - 1 -{ix};
+        }}
+        {ix} %= {xsize} * 2;
+        {ix} = min({ix}, 2 * {xsize} - 1 - {ix});'''.format(ix=ix, xsize=xsize)
+    elif mode == 'mirror':
+        ops = '''
+        if ({xsize} == 1) {{
+            {ix} = 0;
+        }} else {{
+            if ({ix} < 0) {{
+                {ix} = -{ix};
+            }}
+            {ix} = 1 + ({ix} - 1) % (({xsize} - 1) * 2);
+            {ix} = min({ix}, 2 * {xsize} - 2 - {ix});
+        }}'''.format(ix=ix, xsize=xsize)
+    elif mode == 'nearest':
+        ops = '''
+        {ix} = min(max({ix}, 0), {xsize} - 1);'''.format(ix=ix, xsize=xsize)
+    elif mode == 'wrap':
+        ops = '''
+        {ix} %= {xsize};
+        if ({ix} < 0) {{
+            {ix} += {xsize};
+        }}'''.format(ix=ix, xsize=xsize)
+    elif mode == 'constant':
+        ops = '''
+        if ({ix} >= {xsize}) {{
+            {ix} = -1;
+        }}'''.format(ix=ix, xsize=xsize)
+    return ops
+
+
+_CAST_FUNCTION = """
+// Implements a casting function to make it compatible with scipy
+// Use like cast<to_type>(value)
+// It's actually really simple - most of this is <type_traits>
+
+// Small bit of <type_traits> which cannot be imported in NVRTC
+// Requires compiling with --std=c++11 or higher
+template<bool B, class T=void> struct enable_if {};
+template<class T> struct enable_if<true, T> { typedef T type; };
+template<class T> struct remove_const          { typedef T type; };
+template<class T> struct remove_const<const T> { typedef T type; };
+template<class T> struct remove_volatile             { typedef T type; };
+template<class T> struct remove_volatile<volatile T> { typedef T type; };
+template<class T> struct remove_cv {
+  typedef typename remove_volatile<typename remove_const<T>::type>::type type;
+};
+template<class T, T v>
+struct integral_constant { static constexpr T value = v; };
+typedef integral_constant<bool, true> true_type;
+typedef integral_constant<bool, false> false_type;
+template<class T> struct __is_fp : public false_type {};
+template<>        struct __is_fp<float16> : public true_type {};
+template<>        struct __is_fp<float> : public true_type {};
+template<>        struct __is_fp<double> : public true_type {};
+template<>        struct __is_fp<long double> : public true_type {};
+template<class T> struct is_floating_point
+    : public __is_fp<typename remove_cv<T>::type> {};
+template<class T> struct is_signed : integral_constant<bool, (T)(-1)<0> {};
+
+template <typename B, typename A>
+__device__
+typename enable_if<!is_floating_point<A>::value||is_signed<B>::value, B>::type
+cast(A a) { return (B)a; }
+
+template <typename B, typename A>
+__device__
+typename enable_if<is_floating_point<A>::value&&!is_signed<B>::value, B>::type
+cast(A a) { return (a >= 0) ? (B)a : -(B)(-a); }
+
+
+"""
+
+
+def _generate_nd_kernel(name, pre, found, post, mode, wshape, int_type,
+                        origins, cval, ctype='X', preamble='', options=(),
+                        has_weights=True, has_structure=False):
+    # Currently this code uses CArray for weights but avoids using CArray for
+    # the input data and instead does the indexing itself since it is faster.
+    # If CArray becomes faster than follow the comments that start with
+    # CArray: to switch over to using CArray for the input data as well.
+
+    ndim = len(wshape)
+    in_params = 'raw X x'
+    if has_weights:
+        in_params += ', raw W w'
+    if has_structure:
+        in_params += ', raw S s'
+    out_params = 'Y y'
+
+    # CArray: remove xstride_{j}=... from string
+    sizes = ['{type} xsize_{j}=x.shape()[{j}], xstride_{j}=x.strides()[{j}];'.
+             format(j=j, type=int_type) for j in range(ndim)]
+    inds = _generate_indices_ops(ndim, int_type,
+                                 [x//2 + o for x, o in zip(wshape, origins)])
+    # CArray: remove expr entirely
+    expr = ' + '.join(['ix_{}'.format(j) for j in range(ndim)])
+
+    ws_init = ws_pre = ws_post = ''
+    if has_weights or has_structure:
+        ws_init = 'int iws = 0;'
+        if has_structure:
+            ws_pre = 'S sval = s[iws];\n'
+        if has_weights:
+            ws_pre += 'W wval = w[iws];\nif (wval)'
+        ws_post = 'iws++;'
+
+    loops = []
+    for j in range(ndim):
+        if wshape[j] == 1:
+            # CArray: string becomes 'inds[{j}] = ind_{j};', remove (int_)type
+            loops.append('{{ {type} ix_{j} = ind_{j} * xstride_{j};'.
+                         format(j=j, type=int_type))
+        else:
+            boundary = _generate_boundary_condition_ops(
+                mode, 'ix_{}'.format(j), 'xsize_{}'.format(j))
+            # CArray: last line of string becomes inds[{j}] = ix_{j};
+            loops.append('''
+    for (int iw_{j} = 0; iw_{j} < {wsize}; iw_{j}++)
+    {{
+        {type} ix_{j} = ind_{j} + iw_{j};
+        {boundary}
+        ix_{j} *= xstride_{j};
+        '''.format(j=j, wsize=wshape[j], boundary=boundary, type=int_type))
+
+    # CArray: string becomes 'x[inds]', no format call needed
+    value = '(*(X*)&data[{expr}])'.format(expr=expr)
+    if mode == 'constant':
+        cond = ' || '.join(['(ix_{} < 0)'.format(j) for j in range(ndim)])
+        value = '(({cond}) ? cast<{ctype}>({cval}) : {value})'.format(
+            cond=cond, ctype=ctype, cval=cval, value=value)
+    found = found.format(value=value)
+
+    # CArray: replace comment and next line in string with
+    #   {type} inds[{ndim}] = {{0}};
+    # and add ndim=ndim, type=int_type to format call
+    operation = '''
+    {sizes}
+    {inds}
+    // don't use a CArray for indexing (faster to deal with indexing ourselves)
+    const unsigned char* data = (const unsigned char*)&x[0];
+    {ws_init}
+    {pre}
+    {loops}
+        // inner-most loop
+        {ws_pre} {{
+            {found}
+        }}
+        {ws_post}
+    {end_loops}
+    {post}
+    '''.format(sizes='\n'.join(sizes), inds=inds, pre=pre, post=post,
+               ws_init=ws_init, ws_pre=ws_pre, ws_post=ws_post,
+               loops='\n'.join(loops), found=found, end_loops='}'*ndim)
+
+    name = 'cupy_ndimage_{}_{}d_{}_w{}'.format(
+        name, ndim, mode, '_'.join(['{}'.format(x) for x in wshape]))
+    if int_type == 'ptrdiff_t':
+        name += '_i64'
+    if has_structure:
+        name += '_with_structure'
+    preamble = _CAST_FUNCTION + preamble
+    options += ('--std=c++11',)
+
+    return cupy.ElementwiseKernel(in_params, out_params, operation, name,
+                                  reduce_dims=False, preamble=preamble,
+                                  options=options)
+
+
+def _generate_indices_ops(ndim, int_type, offsets):
+    code = '{type} ind_{j} = _i % xsize_{j} - {offset}; _i /= xsize_{j};'
+    body = [code.format(type=int_type, j=j, offset=offsets[j])
+            for j in range(ndim-1, 0, -1)]
+    return '{type} _i = i;\n{body}\n{type} ind_0 = _i - {offset};'.format(
+        type=int_type, body='\n'.join(body), offset=offsets[0])

--- a/cupyx/scipy/ndimage/_filters_core.py
+++ b/cupyx/scipy/ndimage/_filters_core.py
@@ -366,11 +366,9 @@ def _generate_nd_kernel(name, pre, found, post, mode, w_shape, int_type,
     if has_structure:
         name += '_with_structure'
     preamble = _CAST_FUNCTION + preamble
-    options += ('--std=c++11',)
-
     return cupy.ElementwiseKernel(in_params, out_params, operation, name,
                                   reduce_dims=False, preamble=preamble,
-                                  options=options)
+                                  options=('--std=c++11',) + options)
 
 
 def _generate_indices_ops(ndim, int_type, offsets, xsize='xsize'):

--- a/cupyx/scipy/ndimage/_filters_core.py
+++ b/cupyx/scipy/ndimage/_filters_core.py
@@ -4,16 +4,10 @@ import cupy
 
 
 def _get_output(output, input, shape=None):
-    if shape is None:
-        shape = input.shape
-    if isinstance(output, cupy.ndarray):
-        if output.shape != tuple(shape):
-            raise ValueError('output shape is not correct')
-    else:
-        dtype = output
-        if dtype is None:
-            dtype = input.dtype
-        output = cupy.zeros(shape, dtype)
+    if not isinstance(output, cupy.ndarray):
+        return cupy.zeros_like(input, shape=shape, dtype=output, order='C')
+    if output.shape != (input.shape if shape is None else tuple(shape)):
+        raise ValueError('output shape is not correct')
     return output
 
 

--- a/cupyx/scipy/ndimage/_filters_core.py
+++ b/cupyx/scipy/ndimage/_filters_core.py
@@ -295,8 +295,8 @@ def _generate_nd_kernel(name, pre, found, post, mode, w_shape, int_type,
              format(j=j, type=int_type) for j in range(ndim)]
     if y_shape != 'same':
         sizes.extend('{type} ysize_{j} = xsize_{j} + {delta};'.
-                    format(j=j, type=int_type, delta=delta)
-                    for j, delta in enumerate(deltas))
+                     format(j=j, type=int_type, delta=delta)
+                     for j, delta in enumerate(deltas))
     inds = _generate_indices_ops(ndim, int_type, offsets,
                                  'ysize' if y_shape != 'same' else 'xsize')
     # CArray: remove expr entirely

--- a/cupyx/scipy/ndimage/_filters_generic.py
+++ b/cupyx/scipy/ndimage/_filters_generic.py
@@ -1,0 +1,536 @@
+import cupy
+
+
+from cupyx.scipy.ndimage._filters_core import _generate_nd_kernel
+
+
+def _get_sub_kernel(f, filter_size=0, in_dtype=cupy.dtype(float)):
+    """
+    Takes the "function" given to generic_filter and returns the "sub-kernel"
+    that will be called, one of RawKernel, ReductionKernel, or FusedKernel.
+
+    This supports:
+     * cupy.RawKernel
+       no checks are possible
+     * cupy.ReductionKernel
+       checks that there is a single input and output
+     * cupy.core._fusion_kernel.FusedKernel
+       checks that there is a single input and output and some of the
+       properties of those arguments
+     * cupy.core.fusion.Fusion and cupy.core.new_fusion.Fusion
+       retrieves underlying kernel and sends it back through this function
+     * any callable
+       attempts to fuse it then and sends it back through this function
+
+    The filter_size and in_dtype arguments are the size and data type used for
+    function fusions which requires calling the fused function with an array of
+    the appropriate size and data type to create the underlying kernel.
+    """
+    if isinstance(f, cupy.RawKernel):
+        # We will assume that it has the correct API
+        return f
+    elif isinstance(f, cupy.ReductionKernel):
+        if f.nin != 1 or f.nout != 1:
+            raise TypeError('ReductionKernel must have 1 input and output')
+        return f
+    elif isinstance(f, cupy.ElementwiseKernel):
+        # special error message for ElementwiseKernels
+        raise TypeError('only ReductionKernel allowed (not ElementwiseKernel)')
+    elif isinstance(f, cupy.core._fusion_kernel.FusedKernel):
+        from cupy.core._fusion_variable import _TraceArray
+        out = f._params[f._out_params[0]] if f._return_size == -2 else None
+        if (sum(i >= 0 for i in f._input_index) != 1 or
+                not isinstance(out, _TraceArray) or out.ndim != 0):
+            raise TypeError('fused function take must take 1 array argument '
+                            'and output 1 scalar')
+        return f
+
+    # The remaining ones need additional (recursive) processing
+    elif isinstance(f, cupy.core.new_fusion.Fusion):
+        kernel = _get_new_fused_kernel(f, filter_size, in_dtype)
+    elif isinstance(f, cupy.core.fusion.Fusion):
+        kernel = getattr(f, 'new_fusion', None)
+        if kernel is None:
+            kernel = _get_fused_kernel(f, filter_size, in_dtype)
+    elif callable(f):
+        kernel = cupy.fuse(f)
+    else:
+        raise TypeError('bad function type')
+    return _get_sub_kernel(kernel, filter_size, in_dtype)
+
+
+def _get_fused_kernel(func, filter_size, in_dtype):
+    # This may have to call the fused function so that it generates the
+    # reduction kernel for our datatype
+    key = (in_dtype.char, 1)
+    if key not in func._memo:
+        try:
+            func(cupy.zeros(filter_size, dtype=in_dtype))
+        except TypeError:
+            raise TypeError('fused function takes more >1 argument')
+    if key not in func._memo:
+        func = getattr(func, 'new_fusion', None)
+        if func is not None:
+            return _get_new_fused_kernel(func, filter_size, in_dtype)
+    kernel, kwargs = func._memo[key]
+    if kwargs:
+        # The only two kwargs don't make sense: axis and out
+        raise TypeError('fused reduction functions with axis or out')
+    return kernel
+
+
+def _get_new_fused_kernel(func, filter_size, in_dtype):
+    # This may have to call the fused function so that it generates the
+    # reduction kernel for our datatype and size
+    key = (in_dtype.char, 1, True)
+    shape_key = ((filter_size,),)
+    if key not in func._cache or shape_key not in func._cache[key][0]:
+        try:
+            func(cupy.zeros(filter_size, dtype=in_dtype))
+        except TypeError:
+            raise TypeError('fused function take must take 1 array argument '
+                            'and output 1 scalar')
+    return func._cache[key][0][shape_key][0]
+
+
+@cupy.util.memoize(for_each_device=True)
+def _get_generic_filter_fused(fk, in_dtype, out_dtype, filter_size, mode,
+                              wshape, origins, cval, int_type):
+    """Generic filter implementation based on a fused kernel."""
+    # The CArray/CIndexers for calling the sub-kernel
+    vars, args = _fused_kernel_arrays(fk, filter_size)
+
+    # Get code chunks
+    setup = 'int iv = 0;\n' + '\n'.join(vars)
+    sub_call = 'fused_kernel::{}({});\ny = cast<Y>(val_out[0]);'.format(
+        fk._name, ', '.join(args + ['1']*len(fk._block_strides)))
+    sub_kernel = 'namespace fused_kernel {{{}}}'.format(_fused_kernel_code(fk))
+
+    # Get the final kernel
+    return _generate_nd_kernel(
+        'generic_{}_{}'.format(filter_size, fk._name),
+        setup, 'values[iv++] = {value};', sub_call,
+        mode, wshape, int_type, origins, cval, preamble=sub_kernel)
+
+
+def _fused_kernel_code(fk):
+    import re
+    code = ('{code}\n__device__ void {name}({params}) {cuda_body}'
+            .format(name=fk._name, params=fk._cuda_params_memo[()],
+                    code=fk._submodule_code, cuda_body=fk._cuda_body))
+
+    # We need to change the code a bit to make it "single threaded":
+    #   disable synchronization (cg and syncthreads)
+    #   disable shared data (sdata)
+    #   change all id's to 0 (all the same thread/block/grid)
+    #   change all dim's to 1 (all one thread/block/grid)
+    #   change CUPY_FOR to use a regular for loop
+    code = re.sub(r'^(\s*)(_cg::|namespace _cg = |__syncthreads\(\);)',
+                  r'\1//\2', code, flags=re.MULTILINE)
+    code = re.sub(r'^(\s*)(.*?\b(sdata|_sdata_raw)\b)',
+                  r'\1//\2', code, flags=re.MULTILINE)
+    code = re.sub(r'\b(thread|block|grid)Idx\s*\.\s*[xyz]\b', '0', code)
+    code = re.sub(r'\b(thread|block|grid)Dim\s*\.\s*[xyz]\b', '1', code)
+    code = re.sub(r'\bCUPY_FOR\(', 'CUPY_FOR_ST(', code)
+    code = '#define CUPY_FOR_ST(i, n) for (int i = 0; i < (n); ++i)\n' + code
+
+    return code
+
+
+def _fused_kernel_arrays(fk, filter_size):
+    carrays = []
+    cindexers = []
+    var_names = []
+    carr_args = []
+    cind_args = []
+    shapes = _get_fused_kernel_shapes(fk, filter_size)
+    all_strides = []
+    for i, (param, shape) in enumerate(zip(fk._params, shapes)):
+        # Skip constants
+        is_scalar = isinstance(param, cupy.core._fusion_variable._TraceScalar)
+        if is_scalar and param.const_value is not None:
+            continue
+
+        # Get basics about the variable
+        ctype = cupy.core._scalar.get_typename(param.dtype)
+        var_name, ca_name, ind_name = ('_fk_{}{}'.format(s, i) for s in 'pai')
+        if param.is_input:
+            var_name, ctype = 'values', 'X'
+        elif param.is_output:
+            var_name = 'val_out'
+        var_names.append(var_name)
+        carr_args.append(ca_name)
+        cind_args.append(ind_name)
+
+        if not is_scalar:
+            cindexers.append(_cindexer_ctor(ind_name, shape))
+
+        if param.is_base:
+            # Allocate a new variable
+            decl = '{} {}[{}];'.format(ctype, var_name, _prod(shape))
+            strides = _contig_strides(shape, param.dtype.itemsize)
+        else:
+            # Reuse variable
+            base_i = fk._view_of[i]
+            strides_base = all_strides[base_i]
+            shape_base = shapes[base_i]
+            offset = 0
+            if param.is_broadcast:
+                strides = _broadcast_to(shape_base, strides_base, shape)
+            elif param.slice_key is not None:
+                offset, strides = _indexing(shape_base, strides_base,
+                                            param.slice_key)
+                offset //= param.dtype.itemsize
+            elif param.rotate_axis is not None:
+                axes = list(param.rotate_axis)
+                axes.extend(i for i in range(param.ndim) if i not in axes)
+                strides = _transpose(strides_base, axes)
+            else:
+                raise ValueError()
+            decl = '{} *{} = &({}[{}]);'.format(
+                ctype, var_name, var_names[base_i], offset)
+
+        ca = _carray_ctor(ca_name, ctype, var_name,
+                          shape, strides, param.is_base)
+        carrays.append('{} {}'.format(decl, ca))
+        all_strides.append(strides)
+
+    return carrays + cindexers, carr_args + cind_args
+
+
+def _get_fused_kernel_shapes(fk, filter_size):
+    # The get_shapes_of_kernel_params() function only uses the shape attribute
+    # of the ndarray objects, so instead of allocated actual arrays, just make
+    # a dummy array with the shape
+    import types
+    dummy_ndarray = types.SimpleNamespace(size=filter_size,
+                                          shape=(filter_size,))
+    return fk.get_shapes_of_kernel_params((dummy_ndarray,))
+
+
+def _indexing(shape_in, strides_in, indices):
+    # Takes the source shape and strides and the indices (ints, slices, None,
+    # Ellipsis) and the itemsize. This assumes the indexing is completely valid
+    if not isinstance(indices, tuple):
+        indices = (indices,)
+
+    i, offset, strides = 0, 0, []
+    for index in indices:
+        if isinstance(index, int):
+            offset += index*strides_in[i]
+            i += 1
+        elif isinstance(index, slice):
+            offset += index.start*strides_in[i]
+            strides.append(strides_in[i] * index.step)
+            i += 1
+        elif index is None:
+            strides.append(0)
+        elif index is Ellipsis:
+            skip = (len(strides_in) -
+                    sum(isinstance(ind, (int, slice)) for ind in indices))
+            strides.extend(strides_in[i:i+skip])
+            i += skip
+    strides.extend(strides_in[i:])
+
+    return offset, tuple(strides)
+
+
+def _broadcast_to(shape_in, strides_in, shape_out):
+    # Takes the source shape and strides and the destination shape and returns
+    # the destination strides. This assumes the broadcast is completely valid.
+    strides = [0] * len(shape_out)
+    offset = len(shape_out) - len(shape_in)
+    for i, (shape, stride) in enumerate(zip(shape_in, strides_in), offset):
+        if shape == shape_out[i]:
+            strides[i] = stride
+    return tuple(strides)
+
+
+def _transpose(strides, axes):
+    # Takes the source strides and the axes to transpose over and returns the
+    # destination strides. This assumes the transpose is completely valid.
+    if len(axes) == 0:
+        return strides[::-1]
+    ndim = len(strides)
+    return tuple(strides[axis % ndim] for axis in axes)
+
+
+@cupy.util.memoize(for_each_device=True)
+def _get_generic_filter_red(rk, in_dtype, out_dtype, filter_size, mode,
+                            wshape, origins, cval, int_type):
+    """Generic filter implementation based on a reduction kernel."""
+    # Get the temporary output c type
+    in_param, out_param = rk.in_params[0], rk.out_params[0]
+    out_ctype = out_param.ctype
+    if out_param.dtype is None:  # resolve template
+        out_ctype = cupy.core._scalar.get_typename(
+            in_dtype if out_param.ctype == in_param.ctype else out_dtype)
+
+    # Get code chunks
+    setup = '''
+    int iv = 0;
+    X values[{}];
+    {} val_out;'''.format(filter_size, out_ctype)
+    setup += (_carray_ctor('sub_in', 'X', 'values', (filter_size,)) + '\n' +
+              _carray_ctor('sub_out', out_ctype, '&val_out', (1,)))
+
+    sub_call = '''reduction_kernel::{}(sub_in, sub_out);
+    y = cast<Y>(val_out);'''.format(rk.name)
+
+    sub_kernel = _reduction_kernel_code(rk, filter_size, out_dtype, in_dtype)
+
+    # Get the final kernel
+    return _generate_nd_kernel(
+        'generic_{}_{}'.format(filter_size, rk.name),
+        setup, 'values[iv++] = {value};', sub_call,
+        mode, wshape, int_type, origins, cval, preamble=sub_kernel,
+        options=getattr(rk, 'options', ()))
+
+
+def _reduction_kernel_code(rk, filter_size, out_dtype, in_dtype):
+    # NOTE: differences from the code generated for real reduction kernels:
+    #  * input is always 1D and always less than 2^31 elements
+    #  * output is always 1D with a single element
+    #  * never across threads (no _block_stride, _sdata, _sdata_raw, _REDUCE,
+    #       _tid, _J, _i, _i_base, _j_offset, _J_offset, _j_stride, _J_stride)
+    # Also, the code is moved into a namespace so that clashes are minimized
+    # between the typedefs for the "template" variables.
+
+    # figure out the types
+    types = {}
+    in_param, out_param = rk.in_params[0], rk.out_params[0]
+    in_ctype = _get_type_info(in_param, in_dtype, types)
+    out_ctype = _get_type_info(out_param, out_dtype, types)
+    types = '\n'.join('typedef {} {};'.format(typ, name)
+                      for name, typ in types.items())
+
+    return '''namespace reduction_kernel {{
+{type_preamble}
+{preamble}
+__device__
+void {name}({in_const} CArray<{in_ctype}, 1, true, true>& _raw_{in_name},
+            CArray<{out_ctype}, 1, true, true>& _raw_{out_name}) {{
+    // these are just provided so if they are available for the RK
+    {in_ind}
+    {out_ind}
+
+    #define REDUCE(a, b) ({reduce_expr})
+    #define POST_MAP(a) ({post_map_expr})
+    typedef {reduce_type} _type_reduce;
+    _type_reduce _s = _type_reduce({identity});
+    for (int _j = 0; _j < {size}; ++_j) {{
+        _in_ind.set(_j);
+        {in_const} {in_ctype}& {in_name} = _raw_{in_name}[_j];
+        _type_reduce _a = static_cast<_type_reduce>({pre_map_expr});
+        _s = REDUCE(_s, _a);
+    }}
+    _out_ind.set(0);
+    {out_ctype} &{out_name} = _raw_{out_name}[0];
+    POST_MAP(_s);
+    #undef REDUCE
+    #undef POST_MAP
+}}
+}}'''.format(
+        name=rk.name, type_preamble=types, preamble=rk.preamble,
+        in_const='const' if in_param.is_const else '',
+        in_ctype=in_ctype, in_name=in_param.name,
+        in_ind=_cindexer_ctor('_in_ind', (filter_size,)),
+        out_ctype=out_ctype, out_name=out_param.name,
+        out_ind=_cindexer_ctor('_out_ind', ()),
+
+        pre_map_expr=rk.map_expr,
+        identity='' if rk.identity is None else rk.identity,
+        size=filter_size,
+        reduce_type=rk.reduce_type, reduce_expr=rk.reduce_expr,
+        post_map_expr=rk.post_map_expr,
+    )
+
+
+# No C++ constructor for CIndexer and CArray so we must manually set the fields
+def _cindexer_ctor(name, shape):
+    if len(shape) == 0:
+        return ('CIndexer<0> {name}; '
+                '((ptrdiff_t*)&{name})[0] = 1;').format(name=name)
+    return ('CIndexer<{ndim}> {name}; {{ '
+            'ptrdiff_t* _raw = (ptrdiff_t*)&{name}; '
+            '_raw[0] = {size}; {shape} }}').format(
+        name=name, ndim=len(shape), size=_prod(shape),
+        shape=_assign_array(shape, 1))
+
+
+def _carray_ctor(name, ctype, ptr, shape, strides=None, c_contig=None):
+    # TODO: assuming sizeof(T*) == sizeof(ptrdiff_t)
+    if len(shape) == 0:
+        return ('CArray<{ctype}, 0, true, true> {name}; '
+                '(({ctype}**)&{name})[0] = {ptr}; '
+                '((ptrdiff_t*)&{name})[1] = 1;'
+                ).format(name=name, ctype=ctype, ptr=ptr)
+    if c_contig is None:
+        c_contig = strides is None
+    c_contig = 'true' if c_contig else 'false'
+
+    if strides is None:
+        strides = _contig_strides(shape, 'sizeof({})'.format(ctype))
+
+    return ('CArray<{ctype}, 1, {c_contig}, true> {name}; {{ '
+            'ptrdiff_t* _raw = (ptrdiff_t*)&{name}; '
+            '(({ctype}**)_raw)[0] = {ptr}; '
+            '_raw[1] = {size}; {shape} {strides} }}'
+            ).format(name=name, ctype=ctype, ptr=ptr, size=_prod(shape),
+                     c_contig=c_contig, shape=_assign_array(shape, 2),
+                     strides=_assign_array(strides, 2+len(shape)))
+
+
+def _contig_strides(shape, itemsize):
+    strides = []
+    prod = 1
+    for x in shape[::-1]:
+        strides.append(prod*itemsize if isinstance(itemsize, int) else
+                       '{}*{}'.format(prod, itemsize))
+        prod *= x
+    return tuple(strides[::-1])
+
+
+def _prod(array):
+    prod = 1
+    for x in array:
+        prod *= x
+    return prod
+
+
+def _assign_array(array, offset):
+    return ' '.join('_raw[{}] = {};'.format(i, x)
+                    for i, x in enumerate(array, offset))
+
+
+def _get_type_info(param, dtype, types):
+    if param.dtype is not None:
+        return param.ctype
+    # Template type -> map to actual output type
+    ctype = cupy.core._scalar.get_typename(dtype)
+    types.setdefault(param.ctype, ctype)
+    return ctype
+
+
+@cupy.util.memoize(for_each_device=True)
+def _get_generic_filter_raw(rk, filter_size, mode, wshape, origins, cval,
+                            int_type):
+    """Generic filter implementation based on a raw kernel."""
+    setup = '''
+    int iv = 0;
+    double values[{}];
+    double val_out;'''.format(filter_size)
+
+    sub_call = '''raw_kernel::{}(values, {}, &val_out);
+    y = cast<Y>(val_out);'''.format(rk.name, filter_size)
+
+    return _generate_nd_kernel(
+        'generic_{}_{}'.format(filter_size, rk.name),
+        setup, 'values[iv++] = cast<double>({value});', sub_call,
+        mode, wshape, int_type, origins, cval,
+        preamble='namespace raw_kernel {{{}}}'.format(rk.code),
+        options=rk.options)
+
+
+@cupy.util.memoize(for_each_device=True)
+def _get_generic_filter1d(rk, length, n_lines, filter_size, origin, mode, cval,
+                          in_ctype, out_ctype, int_type):
+    """
+    The generic 1d filter is different than all other filters and thus is the
+    only filter that doesn't use _generate_nd_kernel() and has a completely
+    custom raw kernel.
+    """
+    from cupyx.scipy.ndimage._filters_core import _CAST_FUNCTION
+    in_length = length + filter_size - 1
+    start = filter_size // 2 + origin
+    end = start + length
+
+    if mode == 'constant':
+        boundary, boundary_early = '', '''
+        for (idx_t j = 0; j < {start}; ++j) {{ input_line[j] = {cval}; }}
+        for (idx_t j = {end}; j<{in_length}; ++j) {{ input_line[j] = {cval}; }}
+        '''.format(start=start, end=end, in_length=in_length, cval=cval)
+    else:
+        if mode == 'reflect':
+            j = ('j_ = ({j}) % ({length} * 2);\n'
+                 'j_ = min(j_, 2 * {length} - 1 - j_);')
+            a = j.format(j='-1 - j_', length=length)
+            b = j.format(j='j_', length=length)
+        elif mode == 'mirror':
+            if length == 1:
+                a = b = 'j_ = 0;'
+            else:
+                j = ('j_ = 1 + (({j}) - 1) % (({length} - 1) * 2);\n'
+                     'j_ = min(j_, 2 * {length} - 2 - j_);')
+                a = j.format('-j_', length=length)
+                b = j.format('j_', length=length)
+        elif mode == 'nearest':
+            a, b = 'j_ = 0;', 'j_ = {length}-1;'.format(length=length)
+        elif mode == 'wrap':
+            a = 'j_ = j_ % {length} + {length};'.format(length=length)
+            b = 'j_ = j_ % {length};'.format(length=length)
+        loop = '''for (idx_t j = {{}}; j < {{}}; ++j) {{{{
+            idx_t j_ = j - {start};
+            {{}}
+            input_line[j] = input_line[j_ + {start}];
+        }}}}'''.format(start=start)
+        boundary_early = ''
+        boundary = (loop.format(0, start, a) + '\n' +
+                    loop.format(end, in_length, b))
+
+    name = 'generic1d_{}_{}_{}'.format(length, filter_size, rk.name)
+    code = '''namespace raw_kernel {{{rk_code}}}
+
+{CAST}
+
+typedef unsigned char byte;
+typedef {in_ctype} X;
+typedef {out_ctype} Y;
+typedef {int_type} idx_t;
+
+__device__ idx_t offset(idx_t i, idx_t axis, idx_t ndim,
+                        const idx_t* shape, const idx_t* strides) {{
+    idx_t index = 0;
+    for (idx_t a = ndim; --a > 0; ) {{
+        if (a == axis) {{ continue; }}
+        index += (i % shape[a]) * strides[a];
+        i /= shape[a];
+    }}
+    return index + strides[0] * i;
+}}
+
+extern "C" __global__
+void {name}(const byte* input, byte* output, const idx_t* x) {{
+    const idx_t axis = x[0], ndim = x[1],
+        *shape = x+2, *in_strides = x+2+ndim, *out_strides = x+2+2*ndim;
+
+    const idx_t in_elem_stride = in_strides[axis];
+    const idx_t out_elem_stride = out_strides[axis];
+
+    double input_line[{in_length}];
+    double output_line[{length}];
+    {boundary_early}
+
+    for (idx_t i = ((idx_t)blockIdx.x) * blockDim.x + threadIdx.x;
+            i < {n_lines};
+            i += ((idx_t)blockDim.x) * gridDim.x) {{
+        // Copy line from input (with boundary filling)
+        const byte* input_ = input + offset(i, axis, ndim, shape, in_strides);
+        for (idx_t j = 0; j < {length}; ++j) {{
+            input_line[j+{start}] = (double)*(X*)(input_+j*in_elem_stride);
+        }}
+        {boundary}
+
+        raw_kernel::{rk_name}(input_line, {in_length}, output_line, {length});
+
+        // Copy line to output
+        byte* output_ = output + offset(i, axis, ndim, shape, out_strides);
+        for (idx_t j = 0; j < {length}; ++j) {{
+            *(Y*)(output_+j*out_elem_stride) = cast<Y>(output_line[j]);
+        }}
+    }}
+}}'''.format(n_lines=n_lines, length=length, in_length=in_length, start=start,
+             in_ctype=in_ctype, out_ctype=out_ctype, int_type=int_type,
+             boundary_early=boundary_early, boundary=boundary,
+             name=name, rk_name=rk.name, rk_code=rk.code, CAST=_CAST_FUNCTION)
+    return cupy.RawKernel(code, name, rk.options)

--- a/cupyx/scipy/ndimage/_filters_generic.py
+++ b/cupyx/scipy/ndimage/_filters_generic.py
@@ -480,7 +480,9 @@ def _get_generic_filter1d(rk, length, n_lines, filter_size, origin, mode, cval,
                     loop.format(end, in_length, b))
 
     name = 'generic1d_{}_{}_{}'.format(length, filter_size, rk.name)
-    code = '''namespace raw_kernel {{\n{rk_code}\n}}
+    code = '''#include "cupy/carray.cuh"
+
+namespace raw_kernel {{\n{rk_code}\n}}
 
 {CAST}
 
@@ -534,4 +536,4 @@ void {name}(const byte* input, byte* output, const idx_t* x) {{
              in_ctype=in_ctype, out_ctype=out_ctype, int_type=int_type,
              boundary_early=boundary_early, boundary=boundary,
              name=name, rk_name=rk.name, rk_code=rk.code, CAST=_CAST_FUNCTION)
-    return cupy.RawKernel(code, name, rk.options)
+    return cupy.RawKernel(code, name, ('--std=c++11',) + rk.options)

--- a/cupyx/scipy/ndimage/_filters_generic.py
+++ b/cupyx/scipy/ndimage/_filters_generic.py
@@ -104,7 +104,8 @@ def _get_generic_filter_fused(fk, in_dtype, out_dtype, filter_size, mode,
     setup = 'int iv = 0;\n' + '\n'.join(vars)
     sub_call = 'fused_kernel::{}({});\ny = cast<Y>(val_out[0]);'.format(
         fk._name, ', '.join(args + ['1']*len(fk._block_strides)))
-    sub_kernel = 'namespace fused_kernel {{\n{}\n}}'.format(_fused_kernel_code(fk))
+    sub_kernel = 'namespace fused_kernel {{\n{}\n}}'.format(
+        _fused_kernel_code(fk))
 
     # Get the final kernel
     return _generate_nd_kernel(

--- a/cupyx/scipy/ndimage/_filters_generic.py
+++ b/cupyx/scipy/ndimage/_filters_generic.py
@@ -452,19 +452,18 @@ def _get_generic_filter1d(rk, length, n_lines, filter_size, origin, mode, cval,
         for (idx_t j = {end}; j<{in_length}; ++j) {{ input_line[j] = {cval}; }}
         '''.format(start=start, end=end, in_length=in_length, cval=cval)
     else:
-        if mode == 'reflect':
+        if length == 1:
+            a = b = 'j_ = 0;'
+        elif mode == 'reflect':
             j = ('j_ = ({j}) % ({length} * 2);\n'
                  'j_ = min(j_, 2 * {length} - 1 - j_);')
             a = j.format(j='-1 - j_', length=length)
             b = j.format(j='j_', length=length)
         elif mode == 'mirror':
-            if length == 1:
-                a = b = 'j_ = 0;'
-            else:
-                j = ('j_ = 1 + (({j}) - 1) % (({length} - 1) * 2);\n'
-                     'j_ = min(j_, 2 * {length} - 2 - j_);')
-                a = j.format('-j_', length=length)
-                b = j.format('j_', length=length)
+            j = ('j_ = 1 + (({j}) - 1) % (({length} - 1) * 2);\n'
+                 'j_ = min(j_, 2 * {length} - 2 - j_);')
+            a = j.format(j='-j_', length=length)
+            b = j.format(j='j_', length=length)
         elif mode == 'nearest':
             a, b = 'j_ = 0;', 'j_ = {length}-1;'.format(length=length)
         elif mode == 'wrap':

--- a/cupyx/scipy/ndimage/_filters_generic.py
+++ b/cupyx/scipy/ndimage/_filters_generic.py
@@ -104,7 +104,7 @@ def _get_generic_filter_fused(fk, in_dtype, out_dtype, filter_size, mode,
     setup = 'int iv = 0;\n' + '\n'.join(vars)
     sub_call = 'fused_kernel::{}({});\ny = cast<Y>(val_out[0]);'.format(
         fk._name, ', '.join(args + ['1']*len(fk._block_strides)))
-    sub_kernel = 'namespace fused_kernel {{{}}}'.format(_fused_kernel_code(fk))
+    sub_kernel = 'namespace fused_kernel {{\n{}\n}}'.format(_fused_kernel_code(fk))
 
     # Get the final kernel
     return _generate_nd_kernel(
@@ -132,7 +132,7 @@ def _fused_kernel_code(fk):
     code = re.sub(r'\b(thread|block|grid)Idx\s*\.\s*[xyz]\b', '0', code)
     code = re.sub(r'\b(thread|block|grid)Dim\s*\.\s*[xyz]\b', '1', code)
     code = re.sub(r'\bCUPY_FOR\(', 'CUPY_FOR_ST(', code)
-    code = '#define CUPY_FOR_ST(i, n) for (int i = 0; i < (n); ++i)\n' + code
+    code = '\n#define CUPY_FOR_ST(i, n) for (int i = 0; i < (n); ++i)\n' + code
 
     return code
 
@@ -428,7 +428,7 @@ def _get_generic_filter_raw(rk, filter_size, mode, wshape, origins, cval,
         'generic_{}_{}'.format(filter_size, rk.name),
         setup, 'values[iv++] = cast<double>({value});', sub_call,
         mode, wshape, int_type, origins, cval,
-        preamble='namespace raw_kernel {{{}}}'.format(rk.code),
+        preamble='namespace raw_kernel {{\n{}\n}}'.format(rk.code),
         options=rk.options)
 
 
@@ -479,7 +479,7 @@ def _get_generic_filter1d(rk, length, n_lines, filter_size, origin, mode, cval,
                     loop.format(end, in_length, b))
 
     name = 'generic1d_{}_{}_{}'.format(length, filter_size, rk.name)
-    code = '''namespace raw_kernel {{{rk_code}}}
+    code = '''namespace raw_kernel {{\n{rk_code}\n}}
 
 {CAST}
 

--- a/cupyx/scipy/ndimage/_interp_kernels.py
+++ b/cupyx/scipy/ndimage/_interp_kernels.py
@@ -1,7 +1,7 @@
 import cupy
 import cupy.core.internal
 
-from cupyx.scipy.ndimage import filters
+from cupyx.scipy.ndimage import _util
 
 
 def _get_coord_map(ndim):
@@ -237,7 +237,7 @@ def _generate_interp_custom(coord_func, ndim, large_int, yshape, mode, cval,
             if mode != 'constant':
                 ixvar = 'cf_{j}'.format(j=j)
                 ops.append(
-                    filters._generate_boundary_condition_ops(
+                    _util._generate_boundary_condition_ops(
                         mode, ixvar, 'xsize_{}'.format(j)))
 
             # sum over ic_j will give the raveled coordinate in the input
@@ -265,11 +265,11 @@ def _generate_interp_custom(coord_func, ndim, large_int, yshape, mode, cval,
             if mode != 'constant':
                 ixvar = 'cf_bounded_{j}'.format(j=j)
                 ops.append(
-                    filters._generate_boundary_condition_ops(
+                    _util._generate_boundary_condition_ops(
                         mode, ixvar, 'xsize_{}'.format(j)))
                 ixvar = 'cc_bounded_{j}'.format(j=j)
                 ops.append(
-                    filters._generate_boundary_condition_ops(
+                    _util._generate_boundary_condition_ops(
                         mode, ixvar, 'xsize_{}'.format(j)))
 
             ops.append("""

--- a/cupyx/scipy/ndimage/_util.py
+++ b/cupyx/scipy/ndimage/_util.py
@@ -1,0 +1,91 @@
+import cupy
+
+
+def _get_output(output, input, shape=None):
+    if not isinstance(output, cupy.ndarray):
+        return cupy.zeros_like(input, shape=shape, dtype=output, order='C')
+    if output.shape != (input.shape if shape is None else tuple(shape)):
+        raise ValueError('output shape is not correct')
+    return output
+
+
+def _fix_sequence_arg(arg, ndim, name, conv=lambda x: x):
+    if isinstance(arg, str):
+        return [conv(arg)] * ndim
+    try:
+        arg = iter(arg)
+    except TypeError:
+        return [conv(arg)] * ndim
+    lst = [conv(x) for x in arg]
+    if len(lst) != ndim:
+        msg = "{} must have length equal to input rank".format(name)
+        raise RuntimeError(msg)
+    return lst
+
+
+def _check_origin(origin, width):
+    origin = int(origin)
+    if (width // 2 + origin < 0) or (width // 2 + origin >= width):
+        raise ValueError('invalid origin')
+    return origin
+
+
+def _check_mode(mode):
+    if mode not in ('reflect', 'constant', 'nearest', 'mirror', 'wrap'):
+        msg = 'boundary mode not supported (actual: {})'.format(mode)
+        raise RuntimeError(msg)
+    return mode
+
+
+def _get_inttype(input):
+    # The integer type to use for indices in the input array
+    # The indices actually use byte positions and we can't just use
+    # input.nbytes since that won't tell us the number of bytes between the
+    # first and last elements when the array is non-contiguous
+    nbytes = sum((x-1)*abs(stride) for x, stride in
+                 zip(input.shape, input.strides)) + input.dtype.itemsize
+    return 'int' if nbytes < (1 << 31) else 'ptrdiff_t'
+
+
+def _generate_boundary_condition_ops(mode, ix, xsize):
+    if mode == 'reflect':
+        ops = '''
+        if ({ix} < 0) {{
+            {ix} = - 1 -{ix};
+        }}
+        {ix} %= {xsize} * 2;
+        {ix} = min({ix}, 2 * {xsize} - 1 - {ix});'''.format(ix=ix, xsize=xsize)
+    elif mode == 'mirror':
+        ops = '''
+        if ({xsize} == 1) {{
+            {ix} = 0;
+        }} else {{
+            if ({ix} < 0) {{
+                {ix} = -{ix};
+            }}
+            {ix} = 1 + ({ix} - 1) % (({xsize} - 1) * 2);
+            {ix} = min({ix}, 2 * {xsize} - 2 - {ix});
+        }}'''.format(ix=ix, xsize=xsize)
+    elif mode == 'nearest':
+        ops = '''
+        {ix} = min(max({ix}, 0), {xsize} - 1);'''.format(ix=ix, xsize=xsize)
+    elif mode == 'wrap':
+        ops = '''
+        {ix} %= {xsize};
+        if ({ix} < 0) {{
+            {ix} += {xsize};
+        }}'''.format(ix=ix, xsize=xsize)
+    elif mode == 'constant':
+        ops = '''
+        if ({ix} >= {xsize}) {{
+            {ix} = -1;
+        }}'''.format(ix=ix, xsize=xsize)
+    return ops
+
+
+def _generate_indices_ops(ndim, int_type, offsets):
+    code = '{type} ind_{j} = _i % ysize_{j} - {offset}; _i /= ysize_{j};'
+    body = [code.format(type=int_type, j=j, offset=offsets[j])
+            for j in range(ndim-1, 0, -1)]
+    return '{type} _i = i;\n{body}\n{type} ind_0 = _i - {offset};'.format(
+        type=int_type, body='\n'.join(body), offset=offsets[0])

--- a/cupyx/scipy/ndimage/filters.py
+++ b/cupyx/scipy/ndimage/filters.py
@@ -161,7 +161,7 @@ def _correlate_or_convolve(input, weights, output, mode, cval, origin,
     return _call_kernel(kernel, input, weights, output)
 
 
-#@cupy.util.memoize(for_each_device=True)
+@cupy.util.memoize(for_each_device=True)
 def _get_correlate_kernel(mode, w_shape, int_type, offsets, cval):
     return _generate_nd_kernel(
         'correlate',

--- a/cupyx/scipy/ndimage/filters.py
+++ b/cupyx/scipy/ndimage/filters.py
@@ -2,6 +2,7 @@ import numpy
 
 import cupy
 
+from cupyx.scipy.ndimage import _util
 from cupyx.scipy.ndimage import _filters_core
 from cupyx.scipy.ndimage import _filters_generic
 
@@ -249,7 +250,7 @@ def uniform_filter(input, size=3, output=None, mode="reflect", cval=0.0,
         and input is integral) the results may not perfectly match the results
         from SciPy due to floating-point rounding of intermediate results.
     """
-    sizes = _filters_core._fix_sequence_arg(size, input.ndim, 'size', int)
+    sizes = _util._fix_sequence_arg(size, input.ndim, 'size', int)
 
     def get(size):
         return None if size <= 1 else cupy.ones(size) / size
@@ -319,8 +320,8 @@ def gaussian_filter(input, sigma, order=0, output=None, mode="reflect",
         and input is integral) the results may not perfectly match the results
         from SciPy due to floating-point rounding of intermediate results.
     """
-    sigmas = _filters_core._fix_sequence_arg(sigma, input.ndim, 'sigma', float)
-    orders = _filters_core._fix_sequence_arg(order, input.ndim, 'order', int)
+    sigmas = _util._fix_sequence_arg(sigma, input.ndim, 'sigma', float)
+    orders = _util._fix_sequence_arg(order, input.ndim, 'order', int)
     truncate = float(truncate)
 
     def get(param):
@@ -458,16 +459,16 @@ def generic_laplace(input, derivative2, output=None, mode="reflect",
     if extra_keywords is None:
         extra_keywords = {}
     ndim = input.ndim
-    modes = _filters_core._fix_sequence_arg(mode, ndim, 'mode',
-                                            _filters_core._check_mode)
-    output = _filters_core._get_output(output, input)
+    modes = _util._fix_sequence_arg(mode, ndim, 'mode',
+                                    _util._check_mode)
+    output = _util._get_output(output, input)
     if ndim == 0:
         output[...] = input
         return output
     derivative2(input, 0, output, modes[0], cval,
                 *extra_arguments, **extra_keywords)
     if ndim > 1:
-        tmp = _filters_core._get_output(output.dtype, input)
+        tmp = _util._get_output(output.dtype, input)
         for i in range(1, ndim):
             derivative2(input, i, tmp, modes[i], cval,
                         *extra_arguments, **extra_keywords)
@@ -572,9 +573,9 @@ def generic_gradient_magnitude(input, derivative, output=None,
     if extra_keywords is None:
         extra_keywords = {}
     ndim = input.ndim
-    modes = _filters_core._fix_sequence_arg(mode, ndim, 'mode',
-                                            _filters_core._check_mode)
-    output = _filters_core._get_output(output, input)
+    modes = _util._fix_sequence_arg(mode, ndim, 'mode',
+                                    _util._check_mode)
+    output = _util._get_output(output, input)
     if ndim == 0:
         output[...] = input
         return output
@@ -582,7 +583,7 @@ def generic_gradient_magnitude(input, derivative, output=None,
                *extra_arguments, **extra_keywords)
     output *= output
     if ndim > 1:
-        tmp = _filters_core._get_output(output.dtype, input)
+        tmp = _util._get_output(output.dtype, input)
         for i in range(1, ndim):
             derivative(input, i, tmp, modes[i], cval,
                        *extra_arguments, **extra_keywords)
@@ -1061,7 +1062,7 @@ def generic_filter(input, function, size=None, footprint=None,
     sub = _filters_generic._get_sub_kernel(function)
     if footprint.size == 0:
         return cupy.zeros_like(input)
-    output = _filters_core._get_output(output, input)
+    output = _util._get_output(output, input)
     offsets = _filters_core._origins_to_offsets(origins, footprint.shape)
     args = (filter_size, mode, footprint.shape, offsets, float(cval), int_type)
     if isinstance(sub, cupy.RawKernel):
@@ -1121,12 +1122,12 @@ def generic_filter1d(input, function, filter_size, axis=-1, output=None,
     if filter_size < 1:
         raise RuntimeError('invalid filter size')
     axis = cupy.util._normalize_axis_index(axis, input.ndim)
-    origin = _filters_core._check_origin(origin, filter_size)
-    _filters_core._check_mode(mode)
-    output = _filters_core._get_output(output, input)
+    origin = _util._check_origin(origin, filter_size)
+    _util._check_mode(mode)
+    output = _util._get_output(output, input)
     in_ctype = cupy.core._scalar.get_typename(input.dtype)
     out_ctype = cupy.core._scalar.get_typename(output.dtype)
-    int_type = _filters_core._get_inttype(input)
+    int_type = _util._get_inttype(input)
     n_lines = input.size // input.shape[axis]
     kernel = _filters_generic._get_generic_filter1d(
         function, input.shape[axis], n_lines, filter_size,

--- a/cupyx/scipy/ndimage/filters.py
+++ b/cupyx/scipy/ndimage/filters.py
@@ -980,7 +980,8 @@ def _get_shell_gap(filter_size):
 
 
 @cupy.util.memoize(for_each_device=True)
-def _get_rank_kernel(filter_size, rank, mode, w_shape, origins, cval, int_type):
+def _get_rank_kernel(filter_size, rank, mode, w_shape, origins, cval,
+                     int_type):
     # Below 225 (15x15 median filter) selection sort is 1.5-2.5x faster
     # Above, shell sort does progressively better (by 3025 (55x55) it is 9x)
     # Also tried insertion sort, which is always slower than either one

--- a/cupyx/scipy/ndimage/morphology.py
+++ b/cupyx/scipy/ndimage/morphology.py
@@ -4,7 +4,8 @@ import cupy
 
 import warnings
 
-from . import filters
+from cupyx.scipy.ndimage import _util
+from cupyx.scipy.ndimage import filters
 
 
 def grey_erosion(input, size=None, footprint=None, structure=None, output=None,
@@ -89,7 +90,7 @@ def grey_dilation(input, size=None, footprint=None, structure=None,
         footprint = cupy.array(footprint)
         footprint = footprint[tuple([slice(None, None, -1)] * footprint.ndim)]
 
-    origin = filters._fix_sequence_arg(origin, input.ndim, 'origin', int)
+    origin = _util._fix_sequence_arg(origin, input.ndim, 'origin', int)
     for i in range(len(origin)):
         origin[i] = -origin[i]
         if footprint is not None:

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
@@ -267,14 +267,8 @@ rms_red = cupy.ReductionKernel('X x', 'Y y', 'x*x',
                                'a + b', 'y = a/_in_ind.size()', '0', 'rms')
 
 
-def rms_fuse_wrapper(filter_size):
-    def rms_fuse(x):
-        return (x*x).sum()/filter_size
-    return rms_fuse
-
-
 def rms_pyfunc(x):
-    return (x*x).sum()/len(x)
+    return (x * x).sum()/len(x)
 
 
 lt_raw = cupy.RawKernel('''extern "C" __global__
@@ -288,18 +282,8 @@ lt_red = cupy.ReductionKernel('X x', 'Y y', '_raw_x[_in_ind.size()/2]>x',
                               'a + b', 'y = a', '0', 'lt', reduce_type='int')
 
 
-def lt_fuse_wrapper(filter_size):
-    def lt_fuse(x):
-        return (x[filter_size//2] > x).sum()
-    return lt_fuse
-
-
 def lt_pyfunc(x):
     return (x[len(x)//2] > x).sum()
-
-
-def _is_fuse_wrapper(f):
-    return f == rms_fuse_wrapper or f == lt_fuse_wrapper
 
 
 # This tests generic_filter.
@@ -331,9 +315,7 @@ def _is_fuse_wrapper(f):
         })
     ]) + testing.product({
         'filter': ['generic_filter'],
-        'func_or_kernel': [(rms_fuse_wrapper, rms_pyfunc),
-                           (lt_raw, lt_pyfunc), (lt_red, lt_pyfunc),
-                           (lt_fuse_wrapper, lt_pyfunc)],
+        'func_or_kernel': [(rms_red, rms_pyfunc), (lt_raw, lt_pyfunc)],
         'footprint': [False, True],
         **COMMON_PARAMS,
         'dtype': [numpy.float64],
@@ -346,12 +328,7 @@ class TestGenericFilter(FilterTestCaseBase):
     def test_filter(self, xp, scp):
         # Need to deal with the different versions of the functions given to
         # numpy vs cupy
-        if _is_fuse_wrapper(self.func_or_kernel[0]) and self.footprint:
-            raise unittest.SkipTest("don't know size for fused function")
-
         self.function = self.func_or_kernel[int(xp == numpy)]
-        if _is_fuse_wrapper(self.function):
-            self.function = self.function(self.ksize**len(self.shape))
         return self._filter(xp, scp)
 
 

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
@@ -2,6 +2,7 @@ import unittest
 
 import numpy
 
+import cupy
 from cupy import testing
 import cupyx.scipy.ndimage  # NOQA
 
@@ -37,7 +38,8 @@ class FilterTestCaseBase(unittest.TestCase):
     KWARGS_PARAMS = ('output', 'axis', 'mode', 'cval', 'truncate')+DIMS_PARAMS
 
     # Params that need no processing go before weights in the arguments
-    ARGS_PARAMS = ('rank', 'percentile', 'derivative', 'derivative2')
+    ARGS_PARAMS = ('rank', 'percentile',
+                   'derivative', 'derivative2', 'function')
 
     def _filter(self, xp, scp):
         """
@@ -96,7 +98,8 @@ class FilterTestCaseBase(unittest.TestCase):
             return testing.shaped_random((self.ksize,), xp, self._dtype)
 
         if self.filter in ('minimum_filter', 'maximum_filter', 'median_filter',
-                           'rank_filter', 'percentile_filter'):
+                           'rank_filter', 'percentile_filter', 'generic_filter'
+                           ):
             if not self.footprint:
                 return self.ksize
             kshape = self._kshape
@@ -105,7 +108,7 @@ class FilterTestCaseBase(unittest.TestCase):
                 footprint = xp.ones(kshape)
             return None, footprint
 
-        if self.filter in ('uniform_filter1d',
+        if self.filter in ('uniform_filter1d', 'generic_filter1d',
                            'minimum_filter1d', 'maximum_filter1d'):
             return self.ksize
 
@@ -184,7 +187,7 @@ class TestFilter(FilterTestCaseBase):
 def dummy_deriv_func(input, axis, output, mode, cval, *args, **kwargs):
     # For testing generic_laplace and generic_gradient_magnitude. Doesn't test
     # mode, cval, or extra argument but those are tested indirectly with
-    # laplace, gaussian_laplace, & gaussian_gradient_magnitude.
+    # laplace, gaussian_laplace, and gaussian_gradient_magnitude.
     if output is not None and not isinstance(output, numpy.dtype):
         output[...] = input + axis
     else:
@@ -250,6 +253,157 @@ def dummy_deriv_func(input, axis, output, mode, cval, *args, **kwargs):
 class TestFilterFast(FilterTestCaseBase):
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
     def test_filter(self, xp, scp):
+        return self._filter(xp, scp)
+
+
+# Kernels and Functions for testing generic_filter
+rms_raw = cupy.RawKernel('''extern "C" __global__
+void rms(const double* x, int filter_size, double* y) {
+    double ss = 0;
+    for (int i = 0; i < filter_size; ++i) { ss += x[i]*x[i]; }
+    y[0] = ss/filter_size;
+}''', 'rms')
+rms_red = cupy.ReductionKernel('X x', 'Y y', 'x*x',
+                               'a + b', 'y = a/_in_ind.size()', '0', 'rms')
+
+
+def rms_fuse_wrapper(filter_size):
+    def rms_fuse(x):
+        return (x*x).sum()/filter_size
+    return rms_fuse
+
+
+def rms_pyfunc(x):
+    return (x*x).sum()/len(x)
+
+
+lt_raw = cupy.RawKernel('''extern "C" __global__
+void lt(const double* x, int filter_size, double* y) {
+    int n = 0;
+    double c = x[filter_size/2];
+    for (int i = 0; i < filter_size; ++i) { n += c>x[i]; }
+    y[0] = n;
+}''', 'lt')
+lt_red = cupy.ReductionKernel('X x', 'Y y', '_raw_x[_in_ind.size()/2]>x',
+                              'a + b', 'y = a', '0', 'lt', reduce_type='int')
+
+
+def lt_fuse_wrapper(filter_size):
+    def lt_fuse(x):
+        return (x[filter_size//2] > x).sum()
+    return lt_fuse
+
+
+def lt_pyfunc(x):
+    return (x[len(x)//2] > x).sum()
+
+
+def _is_fuse_wrapper(f):
+    return f == rms_fuse_wrapper or f == lt_fuse_wrapper
+
+
+# This tests generic_filter.
+@testing.parameterize(*(
+    testing.product([
+        testing.product({
+            'filter': ['generic_filter'],
+            'func_or_kernel': [(rms_raw, rms_pyfunc), (lt_red, lt_pyfunc)],
+            'footprint': [False, True],
+        }),
+
+        # Mode-specific params
+        testing.product({
+            **COMMON_PARAMS,
+            'mode': ['reflect'],
+            # With reflect test some of the other parameters as well
+            'origin': [0, 1, (-1, 1, -1, 1)],
+            'output': [None, numpy.uint8, numpy.float64],
+        }) + testing.product({
+            **COMMON_PARAMS,
+            'mode': ['constant'], 'cval': [0.0, 1.0],
+        }) + testing.product({
+            **COMMON_PARAMS,
+            'mode': ['nearest', 'wrap'],
+        }) + testing.product({
+            **COMMON_PARAMS,
+            'shape': [(4, 5), (3, 4, 5)],
+            'mode': ['mirror'],
+        })
+    ]) + testing.product({
+        'filter': ['generic_filter'],
+        'func_or_kernel': [(rms_fuse_wrapper, rms_pyfunc),
+                           (lt_raw, lt_pyfunc), (lt_red, lt_pyfunc),
+                           (lt_fuse_wrapper, lt_pyfunc)],
+        'footprint': [False, True],
+        **COMMON_PARAMS,
+        'dtype': [numpy.float64],
+    })
+))
+@testing.gpu
+@testing.with_requires('scipy')
+class TestGenericFilter(FilterTestCaseBase):
+    @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
+    def test_filter(self, xp, scp):
+        # Need to deal with the different versions of the functions given to
+        # numpy vs cupy
+        if _is_fuse_wrapper(self.func_or_kernel[0]) and self.footprint:
+            raise unittest.SkipTest("don't know size for fused function")
+
+        self.function = self.func_or_kernel[int(xp == numpy)]
+        if _is_fuse_wrapper(self.function):
+            self.function = self.function(self.ksize**len(self.shape))
+        return self._filter(xp, scp)
+
+
+# Kernels and functions for use with generic_filter1d
+def shift_pyfunc(src, dst):
+    dst[:] = src[:dst.size]
+
+
+shift_raw = cupy.RawKernel('''extern "C" __global__
+void shift(const double* in, ptrdiff_t in_length,
+          double* out, ptrdiff_t out_length) {
+    for (int i = 0; i < out_length; ++i) { out[i] = in[i]; }
+}''', 'shift')
+
+
+# This tests generic_filter1d.
+@testing.parameterize(*(
+    testing.product([
+        testing.product({
+            'filter': ['generic_filter1d'],
+            'func_or_kernel': [(shift_raw, shift_pyfunc)],
+            'axis': [0, 1, -1],
+        }),
+
+        # Mode-specific params
+        testing.product({
+            **COMMON_PARAMS,
+            'mode': ['reflect'],
+            # With reflect test some of the other parameters as well
+            'origin': [0, 1, (-1, 1, -1, 1)],
+            'output': [None, numpy.uint8, numpy.float64],
+        }) + testing.product({
+            **COMMON_PARAMS,
+            'mode': ['constant'], 'cval': [0.0, 1.0],
+        }) + testing.product({
+            **COMMON_PARAMS,
+            'mode': ['nearest', 'wrap'],
+        }) + testing.product({
+            **COMMON_PARAMS,
+            'shape': [(4, 5), (3, 4, 5)],
+            'mode': ['mirror'],
+        })
+    ])
+))
+@testing.gpu
+@testing.with_requires('scipy')
+class TestGeneric1DFilter(FilterTestCaseBase):
+    @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
+    def test_filter(self, xp, scp):
+        # Need to deal with the different versions of the functions given to
+        # numpy vs cupy
+        self.function = self.func_or_kernel[int(xp == numpy)]
         return self._filter(xp, scp)
 
 


### PR DESCRIPTION
This is the final PR to close #2099 and close #3111.

Additionally, the filter code was split into multiple files as it was getting too unwieldy for a single file.

Some notes:

- The `generic_filter()` function cannot exactly match in Cupy and Scipy. Scipy's accepts any Python function with a single `ndarray` parameter and single scalar return value or a wrapped C function with a specific signature. The Cupy version accepts any *fuseable* Python function with the same restrictions (`ndarray` param, scalar return), a `RawKernel` with almost the same C signature (just missing return value) as with Scipy. It also accepts `ReductionKernel` with 1 input and 1 output.
  - Support for new fuseable functions is hackish, the `RawKernel` and `ReductionKernel` are significantly more 'legit'
- The `generic_filter1d()` function matches with Scipy even less. It only accepts a `RawKernel` with a similar C signature (just missing return value). It does not accept any Python functions. This is primarily due to the very odd way that Scipy defined the function.
  - Additionally due to their odd way Scipy defined the function it isn't as parallelizable and likely has significant performance issues compared to all of the other filter functions

Still in draft state since I would like:

- Feedback on the design. Some of this is a bit "radical" maybe and perhaps some people more familiar with Cupy and CUDA can help me straighten it out.
- There are no formal tests yet.

Some informal tests which help you gauge speed-up and my results are available at https://gist.github.com/coderforlife/e3a5fffa17be71c2f97779e0c41fb5a1

Speed Summary
--------------
1000x1000 input with 3x3, 15x15, and 25x25 filter sizes.

Using raw and reduction kernels are the fastest.

Fused functions are 1.25x to 7x slower (that is 25% to 600% slower) than directly writing the kernels - they get much closer with larger filter sizes. 

Numba functions used with Scipy are 6x to 26x slower than fused functions, generally losing more ground as the filter size goes up.

Pure Python functions used with Scipy are then 10x to 200x slower than the numba functions with scipy.

Ultimately, if you can hand-write your CUDA functions expect 200x-10000x speedup over Scipy with Python function. If your function is fuseable you only get a small amount of loss and you get to write it as Python!

I have done personal tests with `generic_filter1d`, and for larger sizes it does improve upon Scipy, but not nearly as much. I am mainly thinking of that implementation simply to make the library complete (it is still okay, just not stellar).