### PR TITLE
Fix float16 ndarray input in histogram with CUB

### DIFF
--- a/cupy/statistics/histogram.py
+++ b/cupy/statistics/histogram.py
@@ -6,6 +6,7 @@ import numpy
 import cupy
 from cupy import core
 from cupy.core import _accelerator
+from cupy.cuda import device
 # TODO(leofang): always import cub when hipCUB is supported
 if not cupy.cuda.runtime.is_hip:
     from cupy.cuda import cub
@@ -223,7 +224,8 @@ def histogram(x, bins=10, range=None, weights=None, density=False):
                     bin_type = numpy.float
                 else:
                     # TODO(okuta): support float16
-                    if bin_type == numpy.float16:
+                    if (bin_type == numpy.float16 and
+                            int(device.get_compute_capability()) < 53):
                         bin_type = numpy.float32
                     x = x.astype(bin_type, copy=False)
                 acc_bin_edge = bin_edges.astype(bin_type, copy=True)
@@ -264,7 +266,7 @@ def histogram(x, bins=10, range=None, weights=None, density=False):
 
     if density:
         db = cupy.array(cupy.diff(bin_edges), cupy.float64)
-        return y/db/y.sum(), bin_edges
+        return y / db / y.sum(), bin_edges
     return y, bin_edges
 
 

--- a/cupy/statistics/histogram.py
+++ b/cupy/statistics/histogram.py
@@ -6,7 +6,7 @@ import numpy
 import cupy
 from cupy import core
 from cupy.core import _accelerator
-from cupy.cuda import device
+from cupy.cuda import common
 # TODO(leofang): always import cub when hipCUB is supported
 if not cupy.cuda.runtime.is_hip:
     from cupy.cuda import cub
@@ -219,13 +219,13 @@ def histogram(x, bins=10, range=None, weights=None, density=False):
                 # Need to ensure the dtype of bin_edges as it's needed for both
                 # the CUB call and the correction later
                 assert isinstance(bin_edges, cupy.ndarray)
-                bin_type = numpy.result_type(bin_edges.dtype, x.dtype)
                 if numpy.issubdtype(x.dtype, numpy.integer):
                     bin_type = numpy.float
                 else:
+                    bin_type = numpy.result_type(bin_edges.dtype, x.dtype)
                     # TODO(okuta): support float16
                     if (bin_type == numpy.float16 and
-                            int(device.get_compute_capability()) < 53):
+                            not common._is_fp16_supported()):
                         bin_type = numpy.float32
                     x = x.astype(bin_type, copy=False)
                 acc_bin_edge = bin_edges.astype(bin_type, copy=True)

--- a/cupy/statistics/histogram.py
+++ b/cupy/statistics/histogram.py
@@ -223,7 +223,6 @@ def histogram(x, bins=10, range=None, weights=None, density=False):
                     bin_type = numpy.float
                 else:
                     bin_type = numpy.result_type(bin_edges.dtype, x.dtype)
-                    # TODO(okuta): support float16
                     if (bin_type == numpy.float16 and
                             not common._is_fp16_supported()):
                         bin_type = numpy.float32

--- a/tests/cupy_tests/statics_tests/test_histogram.py
+++ b/tests/cupy_tests/statics_tests/test_histogram.py
@@ -340,6 +340,14 @@ class TestCubHistogram(unittest.TestCase):
         # ...then perform the actual computation
         return xp.histogram(x)
 
+    @testing.for_all_dtypes(no_bool=True, no_complex=True)
+    @testing.numpy_cupy_array_equal()
+    def test_histogram_range_float(self, xp, dtype):
+        a = testing.shaped_arange((10,), xp, dtype)
+        h, b = xp.histogram(a, testing.shaped_arange((10,), xp, numpy.float64))
+        assert int(h.sum()) == 10
+        return h, b
+
 
 @testing.gpu
 @testing.parameterize(*testing.product(


### PR DESCRIPTION
In my environment, histogram test is failed with float16.
I use GeForce GTX Titan X (sm_52). 

```
% pytest tests/cupy_tests/statics_tests/test_histogram.py -s
============================================================================================== test session starts ==============================================================================================
platform linux -- Python 3.7.6, pytest-4.1.1, py-1.8.1, pluggy-0.13.1
rootdir: /home/okuta/env/chainer37/cupy, inifile: setup.cfg
collected 88 items

tests/cupy_tests/statics_tests/test_histogram.py .....................................................................................dtype is <class 'numpy.float16'>
F..

=================================================================================================== FAILURES ====================================================================================================
________________________________________________________________________________________ TestCubHistogram.test_histogram ________________________________________________________________________________________
cupy/testing/helper.py:659: in test_func
    impl(self, *args, **kw)
cupy/testing/helper.py:253: in test_func
    check_func(cupy_r, numpy_r)
cupy/testing/helper.py:488: in check_func
    array.assert_array_equal(x, y, err_msg, verbose, strides_check)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

x = array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0]), y = array([1, 1, 1, 1, 1, 1, 1, 1, 1, 1]), err_msg = '', verbose = True, strides_check = False

    def assert_array_equal(x, y, err_msg='', verbose=True, strides_check=False):
        """Raises an AssertionError if two array_like objects are not equal.

        Args:
             x(numpy.ndarray or cupy.ndarray): The actual object to check.
             y(numpy.ndarray or cupy.ndarray): The desired, expected object.
             strides_check(bool): If ``True``, consistency of strides is also
                 checked.
             err_msg(str): The error message to be printed in case of failure.
             verbose(bool): If ``True``, the conflicting values
                 are appended to the error message.

        .. seealso:: :func:`numpy.testing.assert_array_equal`
        """
        numpy.testing.assert_array_equal(
            cupy.asnumpy(x), cupy.asnumpy(y), err_msg=err_msg,
>           verbose=verbose)
E       AssertionError:
E       Arrays are not equal
E
E       Mismatched elements: 10 / 10 (100%)
E       Max absolute difference: 1
E       Max relative difference: 1.
E        x: array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
E        y: array([1, 1, 1, 1, 1, 1, 1, 1, 1, 1])

cupy/testing/array.py:93: AssertionError
====================================================================================== 1 failed, 87 passed in 1.94 seconds ======================================================================================```
