### PR TITLE
Add different dtype input test in histogram

### DIFF
--- a/cupy/_statistics/histogram.py
+++ b/cupy/_statistics/histogram.py
@@ -224,7 +224,8 @@ def histogram(x, bins=10, range=None, weights=None, density=False):
                 # Need to ensure the dtype of bin_edges as it's needed for both
                 # the CUB call and the correction later
                 assert isinstance(bin_edges, cupy.ndarray)
-                if numpy.issubdtype(x.dtype, numpy.integer):
+                if (isinstance(bins, int)
+                        or numpy.issubdtype(x.dtype, numpy.integer)):
                     bin_type = numpy.float
                 else:
                     bin_type = numpy.result_type(bin_edges.dtype, x.dtype)
@@ -233,6 +234,7 @@ def histogram(x, bins=10, range=None, weights=None, density=False):
                         bin_type = numpy.float32
                     x = x.astype(bin_type, copy=False)
                 acc_bin_edge = bin_edges.astype(bin_type, copy=True)
+
                 # CUB's upper bin boundary is exclusive for all bins, including
                 # the last bin, so we must shift it to comply with NumPy
                 if x.dtype.kind in 'ui':

--- a/cupy/_statistics/histogram.py
+++ b/cupy/_statistics/histogram.py
@@ -224,8 +224,7 @@ def histogram(x, bins=10, range=None, weights=None, density=False):
                 # Need to ensure the dtype of bin_edges as it's needed for both
                 # the CUB call and the correction later
                 assert isinstance(bin_edges, cupy.ndarray)
-                if (isinstance(bins, int)
-                        or numpy.issubdtype(x.dtype, numpy.integer)):
+                if numpy.issubdtype(x.dtype, numpy.integer):
                     bin_type = numpy.float
                 else:
                     bin_type = numpy.result_type(bin_edges.dtype, x.dtype)
@@ -234,7 +233,6 @@ def histogram(x, bins=10, range=None, weights=None, density=False):
                         bin_type = numpy.float32
                     x = x.astype(bin_type, copy=False)
                 acc_bin_edge = bin_edges.astype(bin_type, copy=True)
-
                 # CUB's upper bin boundary is exclusive for all bins, including
                 # the last bin, so we must shift it to comply with NumPy
                 if x.dtype.kind in 'ui':

--- a/tests/cupy_tests/statistics_tests/test_histogram.py
+++ b/tests/cupy_tests/statistics_tests/test_histogram.py
@@ -375,7 +375,7 @@ class TestCubHistogram(unittest.TestCase):
             return xp.histogram(x, bins)[0]
 
         # xp is cupy, first ensure we really use CUB
-        cub_func = 'cupy.statistics.histogram.cub.device_histogram'
+        cub_func = 'cupy._statistics.histogram.cub.device_histogram'
         with testing.AssertFunctionIsCalled(cub_func):
             xp.histogram(x, bins)
         # ...then perform the actual computation
@@ -392,7 +392,7 @@ class TestCubHistogram(unittest.TestCase):
             return xp.histogram(x, bins)[1]
 
         # xp is cupy, first ensure we really use CUB
-        cub_func = 'cupy.statistics.histogram.cub.device_histogram'
+        cub_func = 'cupy._statistics.histogram.cub.device_histogram'
         with testing.AssertFunctionIsCalled(cub_func):
             xp.histogram(x, bins)
         # ...then perform the actual computation

--- a/tests/cupy_tests/statistics_tests/test_histogram.py
+++ b/tests/cupy_tests/statistics_tests/test_histogram.py
@@ -364,6 +364,23 @@ class TestCubHistogram(unittest.TestCase):
         assert int(h.sum()) == 10
         return h, b
 
+    @testing.for_all_dtypes_combination(['dtype_a', 'dtype_b'],
+                                        no_bool=True, no_complex=True)
+    @testing.numpy_cupy_array_equal()
+    def test_histogram_with_bins(self, xp, dtype_a, dtype_b):
+        x = testing.shaped_arange((10,), xp, dtype_a)
+        bins = testing.shaped_arange((10,), xp, dtype_a)
+
+        if xp is numpy:
+            return xp.histogram(x, bins)[0]
+
+        # xp is cupy, first ensure we really use CUB
+        cub_func = 'cupy.statistics.histogram.cub.device_histogram'
+        with testing.AssertFunctionIsCalled(cub_func):
+            xp.histogram(x, bins)
+        # ...then perform the actual computation
+        return xp.histogram(x, bins)[0]
+
 
 @testing.gpu
 @testing.parameterize(*testing.product(

--- a/tests/cupy_tests/statistics_tests/test_histogram.py
+++ b/tests/cupy_tests/statistics_tests/test_histogram.py
@@ -369,7 +369,7 @@ class TestCubHistogram(unittest.TestCase):
     @testing.numpy_cupy_array_equal()
     def test_histogram_with_bins(self, xp, dtype_a, dtype_b):
         x = testing.shaped_arange((10,), xp, dtype_a)
-        bins = testing.shaped_arange((10,), xp, dtype_a)
+        bins = testing.shaped_arange((4,), xp, dtype_a)
 
         if xp is numpy:
             return xp.histogram(x, bins)[0]

--- a/tests/cupy_tests/statistics_tests/test_histogram.py
+++ b/tests/cupy_tests/statistics_tests/test_histogram.py
@@ -369,7 +369,7 @@ class TestCubHistogram(unittest.TestCase):
     @testing.numpy_cupy_array_equal()
     def test_histogram_with_bins(self, xp, dtype_a, dtype_b):
         x = testing.shaped_arange((10,), xp, dtype_a)
-        bins = testing.shaped_arange((4,), xp, dtype_a)
+        bins = testing.shaped_arange((4,), xp, dtype_b)
 
         if xp is numpy:
             return xp.histogram(x, bins)[0]
@@ -380,6 +380,23 @@ class TestCubHistogram(unittest.TestCase):
             xp.histogram(x, bins)
         # ...then perform the actual computation
         return xp.histogram(x, bins)[0]
+
+    @testing.for_all_dtypes_combination(['dtype_a', 'dtype_b'],
+                                        no_bool=True, no_complex=True)
+    @testing.numpy_cupy_array_equal()
+    def test_histogram_with_bins2(self, xp, dtype_a, dtype_b):
+        x = testing.shaped_arange((10,), xp, dtype_a)
+        bins = testing.shaped_arange((4,), xp, dtype_b)
+
+        if xp is numpy:
+            return xp.histogram(x, bins)[1]
+
+        # xp is cupy, first ensure we really use CUB
+        cub_func = 'cupy.statistics.histogram.cub.device_histogram'
+        with testing.AssertFunctionIsCalled(cub_func):
+            xp.histogram(x, bins)
+        # ...then perform the actual computation
+        return xp.histogram(x, bins)[1]
 
 
 @testing.gpu


### PR DESCRIPTION
`cub.device_histogram` assumes following dtype combination.
-  same float dptye `x` and `bin_edge` 
- `x` is `integer` dtype, `binedge` is `double` dtype

