### PR TITLE
Change sorting order of COO sparse matrix for suSPARSE

### DIFF
--- a/cupyx/scipy/sparse/coo.py
+++ b/cupyx/scipy/sparse/coo.py
@@ -225,11 +225,12 @@ class coo_matrix(sparse_data._data_matrix):
         """
         if self.has_canonical_format:
             return
-        # Note: it is unclear how the sorting order would matter. However, this
-        # is what SciPy performs in sum_duplicates(). Although this order is
-        # different from cuSPARSE convention (first row then col), we are not
-        # calling coosort here so it should be alright.
-        keys = cupy.stack([self.row, self.col])
+        # Note: The sorting order below follows the cuSPARSE convention (first
+        # row then col, so-called row-major) and differs from that of SciPy, as
+        # the cuSPARSE functions such as cusparseSpMV() assume this sorting
+        # order.
+        # See https://docs.nvidia.com/cuda/cusparse/index.html#coo-format
+        keys = cupy.stack([self.col, self.row])
         order = cupy.lexsort(keys)
         src_data = self.data[order]
         src_row = self.row[order]


### PR DESCRIPTION
This PR fixes cuSPARSE related test failures when matrix format is COO and CUDA version is 10.2 or later.