### PR TITLE
[v7] Skip csc and erf tests for `scipy>1.2`

### DIFF
--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
@@ -953,7 +953,7 @@ class TestIsspmatrixCsc(unittest.TestCase):
 @testing.parameterize(*testing.product({
     'dtype': [numpy.float32, numpy.float64, numpy.complex64, numpy.complex128],
 }))
-@unittest.skipUnless(scipy_available, 'requires scipy')
+@testing.with_requires('scipy<=1.2')
 class TestCsrMatrixGetitem(unittest.TestCase):
 
     @testing.numpy_cupy_equal(sp_name='sp')

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -1047,7 +1047,7 @@ class TestIsspmatrixCsr(unittest.TestCase):
 @testing.parameterize(*testing.product({
     'dtype': [numpy.float32, numpy.float64, cupy.complex64, cupy.complex128],
 }))
-@unittest.skipUnless(scipy_available, 'requires scipy')
+@testing.with_requires('scipy<=1.2')
 class TestCsrMatrixGetitem(unittest.TestCase):
 
     @testing.numpy_cupy_equal(sp_name='sp')

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_erf.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_erf.py
@@ -38,7 +38,7 @@ class _TestBase(object):
 
 
 @testing.gpu
-@testing.with_requires('scipy')
+@testing.with_requires('scipy<=1.2')
 class TestSpecial(unittest.TestCase, _TestBase):
 
     @testing.for_dtypes(['e', 'f', 'd'])
@@ -68,7 +68,7 @@ class TestSpecial(unittest.TestCase, _TestBase):
 
 
 @testing.gpu
-@testing.with_requires('scipy')
+@testing.with_requires('scipy<=1.2')
 class TestFusionSpecial(unittest.TestCase, _TestBase):
 
     @testing.for_dtypes(['e', 'f', 'd'])


### PR DESCRIPTION
Fix CI errors