### PR TITLE
Add tests for sparse max with `axis=None`

### DIFF
--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
@@ -1120,6 +1120,19 @@ class TestCscMatrixScipyCompressedMinMax(unittest.TestCase):
             return data.min(axis=1)
 
     @testing.numpy_cupy_array_equal(sp_name='sp')
+    def test_max_sparse_axis_none(self, xp, sp):
+        data = self._make_data_max(xp, sp)
+        return data.max(axis=None)
+
+    @testing.numpy_cupy_array_equal(sp_name='sp')
+    def test_max_sparse_axis_none_nonzero(self, xp, sp):
+        data = self._make_data_max_nonzero(xp, sp, axis=None)
+        if xp is cupy:
+            return data.max(axis=None, nonzero=True)
+        else:
+            return data.max(axis=None)
+
+    @testing.numpy_cupy_array_equal(sp_name='sp')
     def test_max_sparse_axis_0(self, xp, sp):
         data = self._make_data_max(xp, sp)
         return data.max(axis=0)

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -1240,6 +1240,19 @@ class TestCsrMatrixScipyCompressedMinMax(unittest.TestCase):
             return data.min(axis=1)
 
     @testing.numpy_cupy_array_equal(sp_name='sp')
+    def test_max_sparse_axis_none(self, xp, sp):
+        data = self._make_data_max(xp, sp)
+        return data.max(axis=None)
+
+    @testing.numpy_cupy_array_equal(sp_name='sp')
+    def test_max_sparse_axis_none_nonzero(self, xp, sp):
+        data = self._make_data_max_nonzero(xp, sp, axis=None)
+        if xp is cupy:
+            return data.max(axis=None, nonzero=True)
+        else:
+            return data.max(axis=None)
+
+    @testing.numpy_cupy_array_equal(sp_name='sp')
     def test_max_sparse_axis_0(self, xp, sp):
         data = self._make_data_max(xp, sp)
         return data.max(axis=0)


### PR DESCRIPTION
Rel #3515. Merge #3536 first.

This PR adds missing tests for sparse max with `axis=None`.