### PR TITLE
Fix missing imports and `cupy.show_config`

### DIFF
--- a/cupy/cuda/__init__.py
+++ b/cupy/cuda/__init__.py
@@ -52,6 +52,12 @@ except ImportError:
     nccl_enabled = False
 
 try:
+    from cupy_backends.cuda.libs import cudnn  # NOQA
+    cudnn_enabled = True
+except ImportError:
+    cudnn_enabled = False
+
+try:
     from cupy_backends.cuda.libs import cutensor  # NOQA
     cutensor_enabled = True
 except ImportError:

--- a/cupy/cuda/__init__.py
+++ b/cupy/cuda/__init__.py
@@ -52,12 +52,6 @@ except ImportError:
     nccl_enabled = False
 
 try:
-    from cupy_backends.cuda.libs import cudnn  # NOQA
-    cudnn_enabled = True
-except ImportError:
-    cudnn_enabled = False
-
-try:
     from cupy_backends.cuda.libs import cutensor  # NOQA
     cutensor_enabled = True
 except ImportError:

--- a/cupyx/runtime.py
+++ b/cupyx/runtime.py
@@ -10,7 +10,7 @@ except ImportError:
     thrust = None
 
 try:
-    import cupy.cuda.cudnn as cudnn
+    import cupy_backends.cuda.libs.cudnn as cudnn
 except ImportError:
     cudnn = None
 
@@ -25,7 +25,7 @@ except ImportError:
     cub = None
 
 try:
-    import cupy.cuda.cutensor as cutensor
+    import cupy_backends.cuda.libs.cutensor as cutensor
 except ImportError:
     cutensor = None
 


### PR DESCRIPTION
After creating `cuda_backends` some imports where not changed and `cupy.show_config` wasn't able to detect cudnn, cutensor and other libraries