### PR TITLE
Adding scipy.signal functions that are simple wrappers of ndimage functions

### DIFF
--- a/cupyx/__init__.py
+++ b/cupyx/__init__.py
@@ -1,4 +1,3 @@
-# "NOQA" to suppress flake8 warning
 from cupyx.rsqrt import rsqrt  # NOQA
 from cupyx.runtime import get_runtime_info  # NOQA
 from cupyx.scatter import scatter_add  # NOQA
@@ -13,8 +12,6 @@ from cupyx import optimizing  # NOQA
 from cupyx._ufunc_config import errstate  # NOQA
 from cupyx._ufunc_config import geterr  # NOQA
 from cupyx._ufunc_config import seterr  # NOQA
-
-from cupyx.scipy import signal  # NOQA
 
 from cupy.core.syncdetect import allow_synchronize  # NOQA
 from cupy.core.syncdetect import DeviceSynchronized  # NOQA

--- a/cupyx/__init__.py
+++ b/cupyx/__init__.py
@@ -1,3 +1,4 @@
+# "NOQA" to suppress flake8 warning
 from cupyx.rsqrt import rsqrt  # NOQA
 from cupyx.runtime import get_runtime_info  # NOQA
 from cupyx.scatter import scatter_add  # NOQA

--- a/cupyx/scipy/signal/__init__.py
+++ b/cupyx/scipy/signal/__init__.py
@@ -1,2 +1,7 @@
-# "NOQA" to suppress flake8 warning
 from cupyx.scipy.signal.signaltools import choose_conv_method  # NOQA
+from cupyx.scipy.signal.signaltools import wiener  # NOQA
+from cupyx.scipy.signal.signaltools import order_filter  # NOQA
+from cupyx.scipy.signal.signaltools import medfilt  # NOQA
+from cupyx.scipy.signal.signaltools import medfilt2d  # NOQA
+
+from cupyx.scipy.signal.bsplines import sepfir2d  # NOQA

--- a/cupyx/scipy/signal/bsplines.py
+++ b/cupyx/scipy/signal/bsplines.py
@@ -19,6 +19,11 @@ def sepfir2d(input, hrow, hcol):
 
     .. seealso:: :func:`scipy.signal.sepfir2d`
     """
+    if input.dtype.kind != 'f':
+        input = input.astype(float)
+    hrow = hrow.astype(input.dtype, copy=False)
+    hcol = hcol.astype(input.dtype, copy=False)
     filters = (hcol[::-1], hrow[::-1])
+    origins = (0 if x.size % 2 else -1 for x in filters)
     return cupyx.scipy.ndimage.filters._run_1d_correlates(
-        input, (0, 1), lambda i: filters[i], None, 'reflect', 0.0)
+        input, (0, 1), lambda i: filters[i], None, 'reflect', 0.0, origins)

--- a/cupyx/scipy/signal/bsplines.py
+++ b/cupyx/scipy/signal/bsplines.py
@@ -1,3 +1,6 @@
+import cupyx.scipy.ndimage
+
+
 def sepfir2d(input, hrow, hcol):
     """Convolve with a 2-D separable FIR filter.
 
@@ -16,7 +19,6 @@ def sepfir2d(input, hrow, hcol):
 
     .. seealso:: :func:`scipy.signal.sepfir2d`
     """
-    from cupyx.scipy.ndimage.filters import _run_1d_correlates
     filters = (hcol[::-1], hrow[::-1])
-    return _run_1d_correlates(input, (0, 1), lambda i: filters[i],
-                              None, 'reflect', 0.0)
+    return cupyx.scipy.ndimage.filters._run_1d_correlates(
+        input, (0, 1), lambda i: filters[i], None, 'reflect', 0.0)

--- a/cupyx/scipy/signal/bsplines.py
+++ b/cupyx/scipy/signal/bsplines.py
@@ -1,0 +1,22 @@
+def sepfir2d(input, hrow, hcol):
+    """Convolve with a 2-D separable FIR filter.
+
+    Convolve the rank-2 input array with the separable filter defined by the
+    rank-1 arrays hrow, and hcol. Mirror symmetric boundary conditions are
+    assumed. This function can be used to find an image given its B-spline
+    representation.
+
+    Args:
+        input (cupy.ndarray): The input signal
+        hrow (cupy.ndarray): Row direction filter
+        hcol (cupy.ndarray): Column direction filter
+
+    Returns:
+        cupy.ndarray: The filtered signal
+
+    .. seealso:: :func:`scipy.signal.sepfir2d`
+    """
+    from cupyx.scipy.ndimage.filters import _run_1d_correlates
+    filters = (hcol[::-1], hrow[::-1])
+    return _run_1d_correlates(input, (0, 1), lambda i: filters[i],
+                              None, 'reflect', 0.0)

--- a/cupyx/scipy/signal/signaltools.py
+++ b/cupyx/scipy/signal/signaltools.py
@@ -1,3 +1,5 @@
+import cupy
+
 
 def choose_conv_method(in1, in2, mode='full'):
     """Find the fastest convolution/correlation method.
@@ -9,7 +11,7 @@ def choose_conv_method(in1, in2, mode='full'):
 
     Returns:
         str: A string indicating which convolution method is fastest,
-        either ``direct`` or ``fft1``.
+        either ``direct`` or ``fft``.
 
     .. warning::
         This function currently doesn't support measure option,
@@ -38,3 +40,156 @@ def _fftconv_faster(x, h, mode):
     """
     # TODO(Dahlia-Chehata): replace with GPU-based constants.
     return True
+
+
+def wiener(im, mysize=None, noise=None):
+    """Perform a Wiener filter on an N-dimensional array.
+
+    Apply a Wiener filter to the N-dimensional array `im`.
+
+    Args:
+        im (cupy.ndarray): An N-dimensional array.
+        mysize (int or cupy.ndarray, optional): A scalar or an N-length list
+            giving the size of the Wiener filter window in each dimension.
+            Elements of mysize should be odd. If mysize is a scalar, then this
+            scalar is used as the size in each dimension.
+        noise (float, optional): The noise-power to use. If None, then noise is
+            estimated as the average of the local variance of the input.
+
+    Returns:
+        cupy.ndarray: Wiener filtered result with the same shape as `im`.
+
+    .. seealso:: :func:`scipy.signal.wiener`
+    """
+    from cupyx.scipy.ndimage import uniform_filter
+    from cupyx.scipy.ndimage._filters_core import _fix_sequence_arg
+
+    if mysize is None:
+        mysize = 3
+    mysize = _fix_sequence_arg(mysize, im.ndim, 'mysize', int)
+
+    # Estimate the local mean
+    local_mean = uniform_filter(im, mysize, mode='constant')
+
+    # Estimate the local variance
+    local_var = uniform_filter(im*im, mysize, mode='constant')
+    local_var -= local_mean*local_mean
+
+    # Estimate the noise power if needed.
+    if noise is None:
+        noise = local_var.mean()
+
+    # Perform the filtering
+    res = im - local_mean
+    res *= (1 - noise / local_var)
+    res += local_mean
+    return cupy.where(local_var < noise, local_mean, res)
+
+
+def order_filter(a, domain, rank):
+    """Perform an order filter on an N-D array.
+
+    Perform an order filter on the array in. The domain argument acts as a mask
+    centered over each pixel. The non-zero elements of domain are used to
+    select elements surrounding each input pixel which are placed in a list.
+    The list is sorted, and the output for that pixel is the element
+    corresponding to rank in the sorted list.
+
+    Args:
+        a (cupy.ndarray): The N-dimensional input array.
+        domain (cupy.ndarray): A mask array with the same number of dimensions
+            as `a`. Each dimension should have an odd number of elements.
+        rank (int): A non-negative integer which selects the element from the
+            sorted list (0 corresponds to the smallest element).
+
+    Returns:
+        cupy.ndarray: The results of the order filter in an array with the same
+            shape as `a`.
+
+    .. seealso:: :func:`cupyx.scipy.ndimage.rank_filter`
+    .. seealso:: :func:`scipy.signal.order_filter`
+    """
+    from cupyx.scipy.ndimage import rank_filter
+    size = domain.shape
+    for k in range(len(size)):
+        if (size[k] % 2) != 1:
+            raise ValueError("Each dimension of domain argument "
+                             " should have an odd number of elements.")
+    return rank_filter(a, rank, footprint=domain,
+                       output=float, mode='constant')
+
+
+def medfilt(volume, kernel_size=None):
+    """Perform a median filter on an N-dimensional array.
+
+    Apply a median filter to the input array using a local window-size
+    given by `kernel_size`. The array will automatically be zero-padded.
+
+    Args:
+        volume (cupy.ndarray): An N-dimensional input array.
+        kernel_size (int or list of ints): Gives the size of the median filter
+            window in each dimension. Elements of `kernel_size` should be odd.
+            If `kernel_size` is a scalar, then this scalar is used as the size
+            in each dimension. Default size is 3 for each dimension.
+
+    Returns:
+        cupy.ndarray: An array the same size as input containing the median
+        filtered result.
+
+    .. seealso:: :func:`cupyx.scipy.ndimage.median_filter`
+    .. seealso:: :func:`scipy.signal.medfilt`
+    """
+    from cupyx.scipy.ndimage import rank_filter
+    from warnings import warn
+
+    kernel_size = _get_kernel_size(kernel_size, volume.ndim)
+    if any(k > s for k, s in zip(kernel_size, volume.shape)):
+        warn('kernel_size exceeds volume extent: volume will be zero-padded')
+
+    size = 1
+    for ks in kernel_size:
+        size *= ks
+    return rank_filter(volume, size // 2, size=kernel_size,
+                       output=float, mode='constant')
+
+
+def medfilt2d(input, kernel_size=3):
+    """Median filter a 2-dimensional array.
+
+    Apply a median filter to the `input` array using a local window-size given
+    by `kernel_size` (must be odd). The array is zero-padded automatically.
+
+    Args:
+        input (cupy.ndarray): A 2-dimensional input array.
+        kernel_size (int of list of ints of length 2): Gives the size of the
+            median filter window in each dimension. Elements of `kernel_size`
+            should be odd. If `kernel_size` is a scalar, then this scalar is
+            used as the size in each dimension. Default is a kernel of size
+            (3, 3).
+
+    Returns:
+        cupy.ndarray: An array the same size as input containing the median
+            filtered result.
+    See also
+    --------
+    .. seealso:: :func:`cupyx.scipy.ndimage.median_filter`
+    .. seealso:: :func:`cupyx.scipy.signal.medfilt`
+    .. seealso:: :func:`scipy.signal.medfilt2d`
+    """
+    # Scipy's version only supports uint8, float32, and float64
+    from cupyx.scipy.ndimage import rank_filter
+    kernel_size = _get_kernel_size(kernel_size, input.ndim)
+    order = kernel_size[0] * kernel_size[1] // 2
+    return rank_filter(input, order, size=kernel_size, mode='constant')
+
+
+def _get_kernel_size(kernel_size, ndim):
+    if kernel_size is None:
+        kernel_size = (3,) * ndim
+    try:
+        kernel_size = tuple(int(x) for x in kernel_size)
+    except TypeError:
+        kernel_size = (int(kernel_size),)*ndim
+    if any((k % 2) != 1 for k in kernel_size):
+        raise ValueError("Each element of kernel_size should be odd")
+    return kernel_size

--- a/cupyx/scipy/signal/signaltools.py
+++ b/cupyx/scipy/signal/signaltools.py
@@ -184,8 +184,8 @@ def medfilt2d(input, kernel_size=3):
 def _get_kernel_size(kernel_size, ndim):
     if kernel_size is None:
         kernel_size = (3,) * ndim
-    kernel_size = ._util._fix_sequence_arg(kernel_size, ndim,
-                                           'kernel_size', int)
+    kernel_size = _util._fix_sequence_arg(kernel_size, ndim,
+                                          'kernel_size', int)
     if any((k % 2) != 1 for k in kernel_size):
         raise ValueError("Each element of kernel_size should be odd")
     return kernel_size

--- a/cupyx/scipy/signal/signaltools.py
+++ b/cupyx/scipy/signal/signaltools.py
@@ -1,7 +1,6 @@
 import warnings
 
 import cupy
-import cupyx
 
 from cupyx.scipy.ndimage import _util
 from cupyx.scipy.ndimage import filters

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_bsplines.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_bsplines.py
@@ -14,14 +14,14 @@ except ImportError:
     'input': [(256, 256), (4, 512), (512, 3)],
     'hrow': [1, 3, 4],
     'hcol': [1, 3, 4],
-    'dtype': ['int32', 'float32', 'float64'],
 }))
 @testing.gpu
 @testing.with_requires('scipy')
 class TestSepFIR2d(unittest.TestCase):
+    @testing.for_all_dtypes(no_complex=True)  # TODO: support complex
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
-    def test_sepfir2d(self, xp, scp):
-        input = testing.shaped_random(self.input, xp, self.dtype)
-        hrow = testing.shaped_random((self.hrow,), xp, self.dtype)
-        hcol = testing.shaped_random((self.hcol,), xp, self.dtype)
+    def test_sepfir2d(self, xp, scp, dtype):
+        input = testing.shaped_random(self.input, xp, dtype)
+        hrow = testing.shaped_random((self.hrow,), xp, dtype)
+        hcol = testing.shaped_random((self.hcol,), xp, dtype)
         return scp.signal.sepfir2d(input, hrow, hcol)

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_bsplines.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_bsplines.py
@@ -1,0 +1,27 @@
+import unittest
+
+from cupy import testing
+
+import cupyx.scipy.signal  # NOQA
+
+try:
+    import scipy.signal  # NOQA
+except ImportError:
+    pass
+
+
+@testing.parameterize(*testing.product({
+    'input': [(256, 256), (4, 512), (512, 3)],
+    'hrow': [1, 3, 4],
+    'hcol': [1, 3, 4],
+    'dtype': ['int32', 'float32', 'float64'],
+}))
+@testing.gpu
+@testing.with_requires('scipy')
+class TestSepFIR2d(unittest.TestCase):
+    @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
+    def test_sepfir2d(self, xp, scp):
+        input = testing.shaped_random(self.input, xp, self.dtype)
+        hrow = testing.shaped_random((self.hrow,), xp, self.dtype)
+        hcol = testing.shaped_random((self.hcol,), xp, self.dtype)
+        return scp.signal.sepfir2d(input, hrow, hcol)

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
@@ -3,8 +3,14 @@ import unittest
 import pytest
 
 import cupy
-import cupyx
 from cupy import testing
+
+import cupyx.scipy.signal  # NOQA
+
+try:
+    import scipy.signal  # NOQA
+except ImportError:
+    pass
 
 
 @testing.gpu
@@ -47,3 +53,77 @@ class TestChooseConvMethod(unittest.TestCase):
         b = testing.shaped_arange((5,), cupy, dtype)
         with pytest.raises(NotImplementedError):
             cupyx.scipy.signal.choose_conv_method(a, b, mode=self.mode)
+
+
+@testing.parameterize(*testing.product({
+    'im': [(10,), (5, 10), (10, 3), (3, 4, 10)],
+    'mysize': [3, 4, (3, 4, 5)],
+    'noise': [False, True],
+    'dtype': ['int32', 'float32', 'float64'],
+}))
+@testing.gpu
+@testing.with_requires('scipy')
+class TestWiener(unittest.TestCase):
+    @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
+    def test_wiener(self, xp, scp):
+        im = testing.shaped_random(self.im, xp, self.dtype)
+        mysize = self.mysize
+        if isinstance(mysize, tuple):
+            mysize = mysize[:im.ndim]
+        noise = (testing.shaped_random(self.im, xp, self.dtype)
+                 if self.noise else None)
+        return scp.signal.wiener(im, mysize, noise)
+
+
+@testing.parameterize(*testing.product({
+    'a': [(10,), (5, 10), (10, 3), (3, 4, 10)],
+    'domain': [3, 4, (3, 3, 5)],
+    'rank': [0, 1, 2],
+    'dtype': ['int32', 'float32', 'float64'],
+}))
+@testing.gpu
+@testing.with_requires('scipy')
+class TestOrderFilter(unittest.TestCase):
+    @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp',
+                                 accept_error=ValueError)
+    def test_order_filter(self, xp, scp):
+        a = testing.shaped_random(self.a, xp, self.dtype)
+        d = self.domain
+        d = d[:a.ndim] if isinstance(d, tuple) else (d,)*a.ndim
+        domain = testing.shaped_random(d, xp) > 0.25
+        rank = min(self.rank, domain.sum())
+        return scp.signal.order_filter(a, domain, rank)
+
+
+@testing.parameterize(*testing.product({
+    'volume': [(10,), (5, 10), (10, 5), (5, 6, 10)],
+    'kernel_size': [3, 4, (3, 3, 5)],
+    'dtype': ['int32', 'float32', 'float64'],
+}))
+@testing.gpu
+@testing.with_requires('scipy')
+class TestMedFilt(unittest.TestCase):
+    @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp',
+                                 accept_error=ValueError)
+    def test_medfilt(self, xp, scp):
+        volume = testing.shaped_random(self.volume, xp, self.dtype)
+        kernel_size = self.kernel_size
+        if isinstance(kernel_size, tuple):
+            kernel_size = kernel_size[:volume.ndim]
+        return scp.signal.medfilt(volume, kernel_size)
+
+
+@testing.parameterize(*testing.product({
+    'input': [(5, 10), (10, 5)],
+    'kernel_size': [3, 4, (3, 5)],
+    'dtype': ['uint8', 'float32', 'float64'],
+}))
+@testing.gpu
+@testing.with_requires('scipy')
+class TestMedFilt2d(unittest.TestCase):
+    @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp',
+                                 accept_error=ValueError)
+    def test_medfilt2d(self, xp, scp):
+        input = testing.shaped_random(self.input, xp, self.dtype)
+        kernel_size = self.kernel_size
+        return scp.signal.medfilt2d(input, kernel_size)

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
@@ -98,7 +98,7 @@ class TestWiener(unittest.TestCase):
 class TestOrderFilter(unittest.TestCase):
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp',
-                                 accept_error=ValueError) # for even kernels
+                                 accept_error=ValueError)  # for even kernels
     def test_order_filter(self, xp, scp, dtype):
         a = testing.shaped_random(self.a, xp, dtype)
         d = self.domain
@@ -117,7 +117,7 @@ class TestOrderFilter(unittest.TestCase):
 class TestMedFilt(unittest.TestCase):
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp',
-                                 accept_error=ValueError) # for even kernels
+                                 accept_error=ValueError)  # for even kernels
     def test_medfilt(self, xp, scp, dtype):
         volume = testing.shaped_random(self.volume, xp, dtype)
         kernel_size = self.kernel_size
@@ -135,7 +135,7 @@ class TestMedFilt(unittest.TestCase):
 class TestMedFilt2d(unittest.TestCase):
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp',
-                                 accept_error=ValueError) # for even kernels
+                                 accept_error=ValueError)  # for even kernels
     def test_medfilt2d(self, xp, scp, dtype):
         input = testing.shaped_random(self.input, xp, dtype)
         kernel_size = self.kernel_size


### PR DESCRIPTION
I have implemented most of `scipy.signal.signaltools`. This is the first batch that should be the most straightforward since it is just utilizing the ndimage functions which includes:
 * `wiener`
 * `order_filter`
 * `med_filt`
 * `med_filt2d`
 * `sepfir2d` (which is actually in bsplines.py)

Next batch will be some of the utility functions and functions like `hilbert`. After that will be `convolve` and friends (but those are dependent on #3614). After that, there will be `lfilter` and `sosfilt` and friends. By then I may have the splines completed as well.

Currently there are no formal tests for these but those are coming shortly.