### PR TITLE
MAINT: Use builtins directly

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -226,13 +226,16 @@ from numpy import complex128  # NOQA
 # Built-in Python types
 # -----------------------------------------------------------------------------
 
-int = __builtins__['int']  # NOQA
+# After NumPy 1.20 is released, CuPy should mimic the DeprecationWarning
+# behavior for these types
 
-bool = __builtins__['bool']  # NOQA
+from builtins import int  # NOQA
 
-float = __builtins__['float']  # NOQA
+from builtins import bool  # NOQA
 
-complex = __builtins__['complex']  # NOQA
+from builtins import float  # NOQA
+
+from builtins import complex  # NOQA
 
 # Not supported by CuPy:
 # from numpy import object

--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -226,13 +226,13 @@ from numpy import complex128  # NOQA
 # Built-in Python types
 # -----------------------------------------------------------------------------
 
-from numpy import int  # NOQA
+int = __builtins__['int']  # NOQA
 
-from numpy import bool  # NOQA
+bool = __builtins__['bool']  # NOQA
 
-from numpy import float  # NOQA
+float = __builtins__['float']  # NOQA
 
-from numpy import complex  # NOQA
+complex = __builtins__['complex']  # NOQA
 
 # Not supported by CuPy:
 # from numpy import object


### PR DESCRIPTION
Avoid warnings with latest `numpy` of the form:
```
E   DeprecationWarning: `np.complex` is a deprecated alias for the builtin `complex`. Use `complex` by itself, which is identical in behavior, to silence this warning. If you specifically wanted the numpy scalar type, use `np.complex_` here.
```