### PR TITLE
improve efficiency of cupy.fft.fftfreq and rfftfreq

### DIFF
--- a/cupy/fft/fft.py
+++ b/cupy/fft/fft.py
@@ -896,7 +896,7 @@ def fftfreq(n, d=1.0):
     .. seealso:: :func:`numpy.fft.fftfreq`
     """
     return cupy.hstack((cupy.arange(0, (n - 1) // 2 + 1, dtype=np.float64),
-                        cupy.arange(-(n // 2), 0, dtype=np.float64))) / n / d
+                        cupy.arange(-(n // 2), 0, dtype=np.float64))) / (n * d)
 
 
 def rfftfreq(n, d=1.0):
@@ -912,7 +912,7 @@ def rfftfreq(n, d=1.0):
 
     .. seealso:: :func:`numpy.fft.rfftfreq`
     """
-    return cupy.arange(0, n // 2 + 1, dtype=np.float64) / n / d
+    return cupy.arange(0, n // 2 + 1, dtype=np.float64) / (n * d)
 
 
 def fftshift(x, axes=None):


### PR DESCRIPTION
This is a minor change to reduce the number of elementwise division kernels called in `fftfreq` and `rfftfreq`.

For `fftfreq` with n=16,  it reduces execution time from ~75 us to ~60 us.
For `fftfreq` with n = 10,000,000 it reduces execution time from ~1.4 ms to 1.0 ms.
