### PR TITLE
add cupyx.scipy.ndimage.fourier_shift, fourier_gaussian, fourier_uniform

### DIFF
--- a/cupyx/scipy/ndimage/__init__.py
+++ b/cupyx/scipy/ndimage/__init__.py
@@ -23,6 +23,8 @@ from cupyx.scipy.ndimage.filters import percentile_filter  # NOQA
 from cupyx.scipy.ndimage.filters import generic_filter  # NOQA
 from cupyx.scipy.ndimage.filters import generic_filter1d  # NOQA
 
+from cupyx.scipy.ndimage.fourier import fourier_shift  # NOQA
+
 from cupyx.scipy.ndimage.interpolation import affine_transform  # NOQA
 from cupyx.scipy.ndimage.interpolation import map_coordinates  # NOQA
 from cupyx.scipy.ndimage.interpolation import rotate  # NOQA

--- a/cupyx/scipy/ndimage/__init__.py
+++ b/cupyx/scipy/ndimage/__init__.py
@@ -23,7 +23,9 @@ from cupyx.scipy.ndimage.filters import percentile_filter  # NOQA
 from cupyx.scipy.ndimage.filters import generic_filter  # NOQA
 from cupyx.scipy.ndimage.filters import generic_filter1d  # NOQA
 
+from cupyx.scipy.ndimage.fourier import fourier_gaussian  # NOQA
 from cupyx.scipy.ndimage.fourier import fourier_shift  # NOQA
+from cupyx.scipy.ndimage.fourier import fourier_uniform  # NOQA
 
 from cupyx.scipy.ndimage.interpolation import affine_transform  # NOQA
 from cupyx.scipy.ndimage.interpolation import map_coordinates  # NOQA

--- a/cupyx/scipy/ndimage/fourier.py
+++ b/cupyx/scipy/ndimage/fourier.py
@@ -47,13 +47,7 @@ def fourier_shift(input, shift, n=-1, axis=-1, output=None):
             If given, the result of shifting the input is placed in this array.
 
     Returns:
-        output (ndarray or None): The shifted output (in the Fourier domain).
-
-    Returns
-    -------
-    fourier_shift : ndarray
-        The shifted input.
-
+        output (ndarray): The shifted output (in the Fourier domain).
     """
     ndim = input.ndim
     output = _get_output_fourier_complex(output, input)

--- a/cupyx/scipy/ndimage/fourier.py
+++ b/cupyx/scipy/ndimage/fourier.py
@@ -4,6 +4,23 @@ import cupy
 from cupyx.scipy.ndimage import filters
 
 
+def _get_output_fourier(output, input):
+    if output is None:
+        if input.dtype.type in [cupy.complex64, cupy.complex128,
+                                cupy.float32]:
+            output = cupy.zeros(input.shape, dtype=input.dtype)
+        else:
+            output = cupy.zeros(input.shape, dtype=cupy.float64)
+    elif type(output) is type:
+        if output not in [cupy.complex64, cupy.complex128,
+                          cupy.float32, cupy.float64]:
+            raise RuntimeError("output type not supported")
+        output = cupy.zeros(input.shape, dtype=output)
+    elif output.shape != input.shape:
+        raise RuntimeError("output shape not correct")
+    return output
+
+
 def _get_output_fourier_complex(output, input):
     if output is None:
         if input.dtype.type in [cupy.complex64, cupy.complex128]:
@@ -25,6 +42,109 @@ def _reshape_nd(arr, ndim, axis):
     return arr.reshape(nd_shape)
 
 
+def fourier_gaussian(input, sigma, n=-1, axis=-1, output=None):
+    """Multidimensional Gaussian shift filter.
+
+    The array is multiplied with the Fourier transform of a (separable)
+    Gaussian kernel.
+
+    Args:
+        input (cupy.ndarray): The input array.
+        sigma (float or sequence of float):  The sigma of the Gaussian kernel.
+            If a float, `sigma` is the same for all axes. If a sequence,
+            `sigma` has to contain one value for each axis.
+        n (int, optional):  If `n` is negative (default), then the input is
+            assumed to be the result of a complex fft. If `n` is larger than or
+            equal to zero, the input is assumed to be the result of a real fft,
+            and `n` gives the length of the array before transformation along
+            the real transform direction.
+        axis (int, optional): The axis of the real transform (only used when
+            ``n > -1``).
+        output (cupy.ndarray, optional):
+            If given, the result of shifting the input is placed in this array.
+
+    Returns:
+        output (cupy.ndarray): The filtered output.
+    """
+    ndim = input.ndim
+    output = _get_output_fourier(output, input)
+    axis = cupy.util._normalize_axis_index(axis, ndim)
+    sigmas = filters._fix_sequence_arg(sigma, ndim, 'sigma')
+
+    output[...] = input
+    for ax, (sigmak, ax_size) in enumerate(zip(sigmas, output.shape)):
+
+        # compute the frequency grid in Hz
+        if ax == axis and n > 0:
+            arr = cupy.arange(ax_size, dtype=output.real.dtype)
+            arr /= n
+        else:
+            arr = cupy.fft.fftfreq(ax_size)
+        arr = arr.astype(output.real.dtype, copy=False)
+
+        # compute the Gaussian weights
+        arr *= arr
+        scale = sigmak * sigmak / -2
+        arr *= (4 * np.pi * np.pi) * scale
+        cupy.exp(arr, out=arr)
+
+        # reshape for broadcasting
+        arr = _reshape_nd(arr, ndim=ndim, axis=ax)
+        output *= arr
+
+    return output
+
+
+def fourier_uniform(input, size, n=-1, axis=-1, output=None):
+    """Multidimensional uniform shift filter.
+
+    The array is multiplied with the Fourier transform of a box of given size.
+
+    Args:
+        input (cupy.ndarray): The input array.
+        size (float or sequence of float):  The sigma of the box used for
+            filtering. If a float, `size` is the same for all axes. If a
+            sequence, `size` has to contain one value for each axis.
+        n (int, optional):  If `n` is negative (default), then the input is
+            assumed to be the result of a complex fft. If `n` is larger than or
+            equal to zero, the input is assumed to be the result of a real fft,
+            and `n` gives the length of the array before transformation along
+            the real transform direction.
+        axis (int, optional): The axis of the real transform (only used when
+            ``n > -1``).
+        output (cupy.ndarray, optional):
+            If given, the result of shifting the input is placed in this array.
+
+    Returns:
+        output (cupy.ndarray): The filtered output.
+    """
+    ndim = input.ndim
+    output = _get_output_fourier(output, input)
+    axis = cupy.util._normalize_axis_index(axis, ndim)
+    sizes = filters._fix_sequence_arg(size, ndim, 'size')
+
+    output[...] = input
+    for ax, (size, ax_size) in enumerate(zip(sizes, output.shape)):
+
+        # compute the frequency grid in Hz
+        if ax == axis and n > 0:
+            arr = cupy.arange(ax_size, dtype=output.real.dtype)
+            arr /= n
+        else:
+            arr = cupy.fft.fftfreq(ax_size)
+        arr = arr.astype(output.real.dtype, copy=False)
+
+        # compute the uniform filter weights
+        arr *= size
+        cupy.sinc(arr, out=arr)
+
+        # reshape for broadcasting
+        arr = _reshape_nd(arr, ndim=ndim, axis=ax)
+        output *= arr
+
+    return output
+
+
 def fourier_shift(input, shift, n=-1, axis=-1, output=None):
     """Multidimensional Fourier shift filter.
 
@@ -43,11 +163,11 @@ def fourier_shift(input, shift, n=-1, axis=-1, output=None):
             the real transform direction.
         axis (int, optional): The axis of the real transform (only used when
             ``n > -1``).
-        output (ndarray, optional):
+        output (cupy.ndarray, optional):
             If given, the result of shifting the input is placed in this array.
 
     Returns:
-        output (ndarray): The shifted output (in the Fourier domain).
+        output (cupy.ndarray): The shifted output (in the Fourier domain).
     """
     ndim = input.ndim
     output = _get_output_fourier_complex(output, input)

--- a/cupyx/scipy/ndimage/fourier.py
+++ b/cupyx/scipy/ndimage/fourier.py
@@ -1,0 +1,94 @@
+import cupy
+import numpy as np
+
+
+def _get_output_fourier_complex(output, input):
+    if output is None:
+        if input.dtype.type in [cupy.complex64, cupy.complex128]:
+            output = cupy.zeros(input.shape, dtype=input.dtype)
+        else:
+            output = cupy.zeros(input.shape, dtype=cupy.complex128)
+    elif type(output) is type:
+        if output not in [cupy.complex64, cupy.complex128]:
+            raise RuntimeError("output type not supported")
+        output = cupy.zeros(input.shape, dtype=output)
+    elif output.shape != input.shape:
+        raise RuntimeError("output shape not correct")
+    return output
+
+
+def _reshape_nd(arr, ndim, axis):
+    """Promote a 1d array to ndim with non-singleton size along axis."""
+    if arr.ndim != 1:
+        raise ValueError("expected a 1d array")
+    if axis < -ndim or axis > ndim - 1:
+        raise ValueError("invalid axis")
+    if ndim < 1:
+        raise ValueError("ndim must be >= 1")
+    axis = axis % ndim
+    nd_shape = (1,) * axis + (arr.size,) + (1,) * (ndim - axis - 1)
+    return arr.reshape(nd_shape)
+
+
+def fourier_shift(input, shift, n=-1, axis=-1, output=None):
+    """Multidimensional Fourier shift filter.
+
+    The array is multiplied with the Fourier transform of a shift operation.
+
+    Args:
+        input (cupy.ndarray): The input array. This should be in the Fourier
+            domain.
+        shift (float or sequence of float):  The size of shift. If a float,
+            `shift` is the same for all axes. If a sequence, `shift` has to
+            contain one value for each axis.
+        n (int, optional):  If `n` is negative (default), then the input is
+            assumed to be the result of a complex fft. If `n` is larger than or
+            equal to zero, the input is assumed to be the result of a real fft,
+            and `n` gives the length of the array before transformation along
+            the real transform direction.
+        axis (int, optional): The axis of the real transform (only used when
+            ``n > -1``).
+        output (ndarray, optional):
+            If given, the result of shifting the input is placed in this array.
+
+    Returns:
+        output (ndarray or None): The shifted output (in the Fourier domain).
+
+    Returns
+    -------
+    fourier_shift : ndarray
+        The shifted input.
+
+    """
+    output = _get_output_fourier_complex(output, input)
+    output[...] = input
+
+    ndim = output.ndim
+    if axis < -ndim or axis >= ndim:
+        raise ValueError("invalid axis")
+    axis = axis % ndim
+
+    if np.isscalar(shift):
+        shift = (shift,) * ndim
+    elif len(shift) != ndim:
+        raise ValueError("number of shifts must match input.ndim")
+
+    for kk in range(ndim):
+        ax_size = output.shape[kk]
+        shiftk = shift[kk]
+        if shiftk == 0:
+            continue
+        if kk == axis and n > 0:
+            # cp.fft.rfftfreq(ax_size) * (-2j * np.pi * shiftk *  ax_size / n)
+            arr = cupy.arange(ax_size, dtype=output.dtype)
+            arr *= -2j * np.pi * shiftk / n
+        else:
+            arr = cupy.fft.fftfreq(ax_size)
+            arr = arr * (-2j * np.pi * shiftk)
+        cupy.exp(arr, out=arr)
+
+        # reshape for broadcasting
+        arr = _reshape_nd(arr, ndim=ndim, axis=kk)
+        output *= arr
+
+    return output

--- a/cupyx/scipy/ndimage/fourier.py
+++ b/cupyx/scipy/ndimage/fourier.py
@@ -4,31 +4,18 @@ import cupy
 from cupyx.scipy.ndimage import _util
 
 
-def _get_output_fourier(output, input):
+def _get_output_fourier(output, input, complex_only=False):
+    types = [cupy.complex64, cupy.complex128]
+    if not complex_only:
+        types += [cupy.float32, cupy.float64]
+
     if output is None:
-        if input.dtype.type in [cupy.complex64, cupy.complex128,
-                                cupy.float32]:
+        if input.dtype in types:
             output = cupy.zeros(input.shape, dtype=input.dtype)
         else:
-            output = cupy.zeros(input.shape, dtype=cupy.float64)
+            output = cupy.zeros(input.shape, dtype=types[-1])
     elif type(output) is type:
-        if output not in [cupy.complex64, cupy.complex128,
-                          cupy.float32, cupy.float64]:
-            raise RuntimeError("output type not supported")
-        output = cupy.zeros(input.shape, dtype=output)
-    elif output.shape != input.shape:
-        raise RuntimeError("output shape not correct")
-    return output
-
-
-def _get_output_fourier_complex(output, input):
-    if output is None:
-        if input.dtype.type in [cupy.complex64, cupy.complex128]:
-            output = cupy.zeros(input.shape, dtype=input.dtype)
-        else:
-            output = cupy.zeros(input.shape, dtype=cupy.complex128)
-    elif type(output) is type:
-        if output not in [cupy.complex64, cupy.complex128]:
+        if output not in types:
             raise RuntimeError("output type not supported")
         output = cupy.zeros(input.shape, dtype=output)
     elif output.shape != input.shape:
@@ -170,7 +157,7 @@ def fourier_shift(input, shift, n=-1, axis=-1, output=None):
         output (cupy.ndarray): The shifted output (in the Fourier domain).
     """
     ndim = input.ndim
-    output = _get_output_fourier_complex(output, input)
+    output = _get_output_fourier(output, input, complex_only=True)
     axis = cupy.util._normalize_axis_index(axis, ndim)
     shifts = _util._fix_sequence_arg(shift, ndim, 'shift')
 

--- a/cupyx/scipy/ndimage/fourier.py
+++ b/cupyx/scipy/ndimage/fourier.py
@@ -1,4 +1,4 @@
-import numpy as np
+import numpy
 
 import cupy
 from cupyx.scipy.ndimage import _util
@@ -72,7 +72,7 @@ def fourier_gaussian(input, sigma, n=-1, axis=-1, output=None):
         # compute the Gaussian weights
         arr *= arr
         scale = sigmak * sigmak / -2
-        arr *= (4 * np.pi * np.pi) * scale
+        arr *= (4 * numpy.pi * numpy.pi) * scale
         cupy.exp(arr, out=arr)
 
         # reshape for broadcasting
@@ -166,12 +166,12 @@ def fourier_shift(input, shift, n=-1, axis=-1, output=None):
         if shiftk == 0:
             continue
         if ax == axis and n > 0:
-            # cp.fft.rfftfreq(ax_size) * (-2j * np.pi * shiftk *  ax_size / n)
+            # cp.fft.rfftfreq(ax_size) * (-2j * numpy.pi * shiftk *  ax_size/n)
             arr = cupy.arange(ax_size, dtype=output.dtype)
-            arr *= -2j * np.pi * shiftk / n
+            arr *= -2j * numpy.pi * shiftk / n
         else:
             arr = cupy.fft.fftfreq(ax_size)
-            arr = arr * (-2j * np.pi * shiftk)
+            arr = arr * (-2j * numpy.pi * shiftk)
         cupy.exp(arr, out=arr)
 
         # reshape for broadcasting

--- a/cupyx/scipy/ndimage/fourier.py
+++ b/cupyx/scipy/ndimage/fourier.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 import cupy
-from cupyx.scipy.ndimage import filters
+from cupyx.scipy.ndimage import _util
 
 
 def _get_output_fourier(output, input):
@@ -69,7 +69,7 @@ def fourier_gaussian(input, sigma, n=-1, axis=-1, output=None):
     ndim = input.ndim
     output = _get_output_fourier(output, input)
     axis = cupy.util._normalize_axis_index(axis, ndim)
-    sigmas = filters._fix_sequence_arg(sigma, ndim, 'sigma')
+    sigmas = _util._fix_sequence_arg(sigma, ndim, 'sigma')
 
     output[...] = input
     for ax, (sigmak, ax_size) in enumerate(zip(sigmas, output.shape)):
@@ -121,7 +121,7 @@ def fourier_uniform(input, size, n=-1, axis=-1, output=None):
     ndim = input.ndim
     output = _get_output_fourier(output, input)
     axis = cupy.util._normalize_axis_index(axis, ndim)
-    sizes = filters._fix_sequence_arg(size, ndim, 'size')
+    sizes = _util._fix_sequence_arg(size, ndim, 'size')
 
     output[...] = input
     for ax, (size, ax_size) in enumerate(zip(sizes, output.shape)):
@@ -172,7 +172,7 @@ def fourier_shift(input, shift, n=-1, axis=-1, output=None):
     ndim = input.ndim
     output = _get_output_fourier_complex(output, input)
     axis = cupy.util._normalize_axis_index(axis, ndim)
-    shifts = filters._fix_sequence_arg(shift, ndim, 'shift')
+    shifts = _util._fix_sequence_arg(shift, ndim, 'shift')
 
     output[...] = input
     for ax, (shiftk, ax_size) in enumerate(zip(shifts, output.shape)):

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_fourier.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_fourier.py
@@ -1,0 +1,99 @@
+import unittest
+
+import numpy
+
+from cupy import testing
+import cupyx.scipy.fft  # NOQA
+import cupyx.scipy.ndimage  # NOQA
+
+try:
+    import scipy.fft  # NOQA
+    import scipy.ndimage  # NOQA
+except ImportError:
+    pass
+
+
+@testing.parameterize(
+    *(
+        testing.product(
+            {
+                "shape": [(32, 16), (31, 15)],
+                "dtype": [numpy.float32, numpy.float64, numpy.complex64,
+                          numpy.complex128],
+                "shift": [1, -3, (5, 5.3), (3, 5)],
+            }
+        )
+        + testing.product(
+            {
+                "shape": [(5, 16, 7), ],
+                "dtype": [numpy.float32, numpy.float64, numpy.complex64,
+                          numpy.complex128],
+                "shift": [3, (-1, 2.5, 1)],
+            }
+        )
+        + testing.product(
+            {
+                "shape": [(15, ), ],
+                "dtype": [numpy.float32, numpy.float64, numpy.complex64,
+                          numpy.complex128],
+                "shift": [8.5, (5,)],
+            }
+        )
+    )
+)
+@testing.gpu
+@testing.with_requires("scipy")
+class TestFourierShift(unittest.TestCase):
+
+    def _test_real_nd(self, xp, scp, x, real_axis):
+        a = scp.fft.rfft(x, axis=real_axis)
+        # complex-valued FFTs on all other axes
+        complex_axes = tuple([ax for ax in range(x.ndim) if ax != real_axis])
+        if complex_axes:
+            a = scp.fft.fftn(a, axes=complex_axes)
+
+        a = scp.ndimage.fourier_shift(
+            a, self.shift, n=x.shape[real_axis], axis=real_axis)
+
+        if complex_axes:
+            a = scp.fft.ifftn(a, axes=complex_axes)
+        a = scp.fft.irfft(a, axis=real_axis)
+        if not x.dtype.kind == 'c':
+            a = a.real
+        return xp.ascontiguousarray(a)
+
+    @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name="scp")
+    def test_real_fft_axis0(self, xp, scp):
+        x = testing.shaped_random(self.shape, xp, self.dtype)
+        if x.dtype.kind == 'c':
+            # skip: can't use rfft on complex-valued x
+            return x
+        return self._test_real_nd(xp, scp, x, 0)
+
+    @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name="scp")
+    def test_real_fft_axis1(self, xp, scp):
+        x = testing.shaped_random(self.shape, xp, self.dtype)
+        if x.dtype.kind == 'c' or x.ndim < 2:
+            # skip: can't use rfft along axis 1 on complex-valued x or 1d x
+            return x
+        return self._test_real_nd(xp, scp, x, 1)
+
+    @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name="scp")
+    def test_complex_fft(self, xp, scp):
+        x = testing.shaped_random(self.shape, xp, self.dtype)
+        a = scp.fft.fftn(x)
+        a = scp.ndimage.fourier_shift(a, self.shift)
+        a = scp.fft.ifftn(a)
+        if not x.dtype.kind == 'c':
+            a = a.real
+        return xp.ascontiguousarray(a)
+
+    @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name="scp")
+    def test_complex_fft_with_output(self, xp, scp):
+        x = testing.shaped_random(self.shape, xp, self.dtype)
+        a = scp.fft.fftn(x)
+        scp.ndimage.fourier_shift(a, self.shift, output=a)
+        a = scp.fft.ifftn(a)
+        if not x.dtype.kind == 'c':
+            a = a.real
+        return xp.ascontiguousarray(a)

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_fourier.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_fourier.py
@@ -185,7 +185,6 @@ class TestFourierGaussian(unittest.TestCase):
         return xp.ascontiguousarray(a)
 
 
-
 @testing.parameterize(
     *(
         testing.product(

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_fourier.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_fourier.py
@@ -3,11 +3,14 @@ import unittest
 import numpy
 
 from cupy import testing
+# TODO (grlee77): use fft instead of fftpack once min. supported scipy >= 1.4
 import cupyx.scipy.fft  # NOQA
+import cupyx.scipy.fftpack  # NOQA
 import cupyx.scipy.ndimage  # NOQA
 
 try:
     import scipy.fft  # NOQA
+    import scipy.fftpack  # NOQA
     import scipy.ndimage  # NOQA
 except ImportError:
     pass
@@ -62,6 +65,7 @@ class TestFourierShift(unittest.TestCase):
             a = a.real
         return xp.ascontiguousarray(a)
 
+    @testing.with_requires("scipy>=1.4.0")
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name="scp")
     def test_real_fft_axis0(self, xp, scp):
         x = testing.shaped_random(self.shape, xp, self.dtype)
@@ -70,6 +74,7 @@ class TestFourierShift(unittest.TestCase):
             return x
         return self._test_real_nd(xp, scp, x, 0)
 
+    @testing.with_requires("scipy>=1.4.0")
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name="scp")
     def test_real_fft_axis1(self, xp, scp):
         x = testing.shaped_random(self.shape, xp, self.dtype)
@@ -81,9 +86,9 @@ class TestFourierShift(unittest.TestCase):
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name="scp")
     def test_complex_fft(self, xp, scp):
         x = testing.shaped_random(self.shape, xp, self.dtype)
-        a = scp.fft.fftn(x)
+        a = scp.fftpack.fftn(x)
         a = scp.ndimage.fourier_shift(a, self.shift)
-        a = scp.fft.ifftn(a)
+        a = scp.fftpack.ifftn(a)
         if not x.dtype.kind == 'c':
             a = a.real
         return xp.ascontiguousarray(a)
@@ -91,9 +96,9 @@ class TestFourierShift(unittest.TestCase):
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name="scp")
     def test_complex_fft_with_output(self, xp, scp):
         x = testing.shaped_random(self.shape, xp, self.dtype)
-        a = scp.fft.fftn(x)
+        a = scp.fftpack.fftn(x)
         scp.ndimage.fourier_shift(a, self.shift, output=a)
-        a = scp.fft.ifftn(a)
+        a = scp.fftpack.ifftn(a)
         if not x.dtype.kind == 'c':
             a = a.real
         return xp.ascontiguousarray(a)
@@ -148,6 +153,7 @@ class TestFourierGaussian(unittest.TestCase):
             a = a.real
         return xp.ascontiguousarray(a)
 
+    @testing.with_requires("scipy>=1.4.0")
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name="scp")
     def test_real_fft_axis0(self, xp, scp):
         x = testing.shaped_random(self.shape, xp, self.dtype)
@@ -156,6 +162,7 @@ class TestFourierGaussian(unittest.TestCase):
             return x
         return self._test_real_nd(xp, scp, x, 0)
 
+    @testing.with_requires("scipy>=1.4.0")
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name="scp")
     def test_real_fft_axis1(self, xp, scp):
         x = testing.shaped_random(self.shape, xp, self.dtype)
@@ -167,9 +174,9 @@ class TestFourierGaussian(unittest.TestCase):
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name="scp")
     def test_complex_fft(self, xp, scp):
         x = testing.shaped_random(self.shape, xp, self.dtype)
-        a = scp.fft.fftn(x)
+        a = scp.fftpack.fftn(x)
         a = scp.ndimage.fourier_gaussian(a, self.sigma)
-        a = scp.fft.ifftn(a)
+        a = scp.fftpack.ifftn(a)
         if not x.dtype.kind == 'c':
             a = a.real
         return xp.ascontiguousarray(a)
@@ -177,9 +184,9 @@ class TestFourierGaussian(unittest.TestCase):
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name="scp")
     def test_complex_fft_with_output(self, xp, scp):
         x = testing.shaped_random(self.shape, xp, self.dtype)
-        a = scp.fft.fftn(x)
+        a = scp.fftpack.fftn(x)
         scp.ndimage.fourier_gaussian(a, self.sigma, output=a)
-        a = scp.fft.ifftn(a)
+        a = scp.fftpack.ifftn(a)
         if not x.dtype.kind == 'c':
             a = a.real
         return xp.ascontiguousarray(a)
@@ -234,6 +241,7 @@ class TestFourierUniform(unittest.TestCase):
             a = a.real
         return xp.ascontiguousarray(a)
 
+    @testing.with_requires("scipy>=1.4.0")
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name="scp")
     def test_real_fft_axis0(self, xp, scp):
         x = testing.shaped_random(self.shape, xp, self.dtype)
@@ -242,6 +250,7 @@ class TestFourierUniform(unittest.TestCase):
             return x
         return self._test_real_nd(xp, scp, x, 0)
 
+    @testing.with_requires("scipy>=1.4.0")
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name="scp")
     def test_real_fft_axis1(self, xp, scp):
         x = testing.shaped_random(self.shape, xp, self.dtype)
@@ -253,9 +262,9 @@ class TestFourierUniform(unittest.TestCase):
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name="scp")
     def test_complex_fft(self, xp, scp):
         x = testing.shaped_random(self.shape, xp, self.dtype)
-        a = scp.fft.fftn(x)
+        a = scp.fftpack.fftn(x)
         a = scp.ndimage.fourier_uniform(a, self.size)
-        a = scp.fft.ifftn(a)
+        a = scp.fftpack.ifftn(a)
         if not x.dtype.kind == 'c':
             a = a.real
         return xp.ascontiguousarray(a)
@@ -263,9 +272,9 @@ class TestFourierUniform(unittest.TestCase):
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name="scp")
     def test_complex_fft_with_output(self, xp, scp):
         x = testing.shaped_random(self.shape, xp, self.dtype)
-        a = scp.fft.fftn(x)
+        a = scp.fftpack.fftn(x)
         scp.ndimage.fourier_uniform(a, self.size, output=a)
-        a = scp.fft.ifftn(a)
+        a = scp.fftpack.ifftn(a)
         if not x.dtype.kind == 'c':
             a = a.real
         return xp.ascontiguousarray(a)

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_fourier.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_fourier.py
@@ -97,3 +97,176 @@ class TestFourierShift(unittest.TestCase):
         if not x.dtype.kind == 'c':
             a = a.real
         return xp.ascontiguousarray(a)
+
+
+@testing.parameterize(
+    *(
+        testing.product(
+            {
+                "shape": [(32, 16), (31, 15)],
+                "dtype": [numpy.float32, numpy.float64, numpy.complex64,
+                          numpy.complex128],
+                "sigma": [1, (5, 5.3), (3, 5)],
+            }
+        )
+        + testing.product(
+            {
+                "shape": [(5, 16, 7), ],
+                "dtype": [numpy.float32, numpy.float64, numpy.complex64,
+                          numpy.complex128],
+                "sigma": [3, (1, 2.5, 3)],
+            }
+        )
+        + testing.product(
+            {
+                "shape": [(15, ), ],
+                "dtype": [numpy.float32, numpy.float64, numpy.complex64,
+                          numpy.complex128],
+                "sigma": [8.5, (5,)],
+            }
+        )
+    )
+)
+@testing.gpu
+@testing.with_requires("scipy")
+class TestFourierGaussian(unittest.TestCase):
+
+    def _test_real_nd(self, xp, scp, x, real_axis):
+        a = scp.fft.rfft(x, axis=real_axis)
+        # complex-valued FFTs on all other axes
+        complex_axes = tuple([ax for ax in range(x.ndim) if ax != real_axis])
+        if complex_axes:
+            a = scp.fft.fftn(a, axes=complex_axes)
+
+        a = scp.ndimage.fourier_gaussian(
+            a, self.sigma, n=x.shape[real_axis], axis=real_axis)
+
+        if complex_axes:
+            a = scp.fft.ifftn(a, axes=complex_axes)
+        a = scp.fft.irfft(a, axis=real_axis)
+        if not x.dtype.kind == 'c':
+            a = a.real
+        return xp.ascontiguousarray(a)
+
+    @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name="scp")
+    def test_real_fft_axis0(self, xp, scp):
+        x = testing.shaped_random(self.shape, xp, self.dtype)
+        if x.dtype.kind == 'c':
+            # skip: can't use rfft on complex-valued x
+            return x
+        return self._test_real_nd(xp, scp, x, 0)
+
+    @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name="scp")
+    def test_real_fft_axis1(self, xp, scp):
+        x = testing.shaped_random(self.shape, xp, self.dtype)
+        if x.dtype.kind == 'c' or x.ndim < 2:
+            # skip: can't use rfft along axis 1 on complex-valued x or 1d x
+            return x
+        return self._test_real_nd(xp, scp, x, 1)
+
+    @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name="scp")
+    def test_complex_fft(self, xp, scp):
+        x = testing.shaped_random(self.shape, xp, self.dtype)
+        a = scp.fft.fftn(x)
+        a = scp.ndimage.fourier_gaussian(a, self.sigma)
+        a = scp.fft.ifftn(a)
+        if not x.dtype.kind == 'c':
+            a = a.real
+        return xp.ascontiguousarray(a)
+
+    @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name="scp")
+    def test_complex_fft_with_output(self, xp, scp):
+        x = testing.shaped_random(self.shape, xp, self.dtype)
+        a = scp.fft.fftn(x)
+        scp.ndimage.fourier_gaussian(a, self.sigma, output=a)
+        a = scp.fft.ifftn(a)
+        if not x.dtype.kind == 'c':
+            a = a.real
+        return xp.ascontiguousarray(a)
+
+
+
+@testing.parameterize(
+    *(
+        testing.product(
+            {
+                "shape": [(32, 16), (31, 15)],
+                "dtype": [numpy.float32, numpy.float64, numpy.complex64,
+                          numpy.complex128],
+                "size": [1, (5, 5.3), (3, 5)],
+            }
+        )
+        + testing.product(
+            {
+                "shape": [(5, 16, 7), ],
+                "dtype": [numpy.float32, numpy.float64, numpy.complex64,
+                          numpy.complex128],
+                "size": [3, (1, 2.5, 3)],
+            }
+        )
+        + testing.product(
+            {
+                "shape": [(15, ), ],
+                "dtype": [numpy.float32, numpy.float64, numpy.complex64,
+                          numpy.complex128],
+                "size": [8.5, (5,)],
+            }
+        )
+    )
+)
+@testing.gpu
+@testing.with_requires("scipy")
+class TestFourierUniform(unittest.TestCase):
+
+    def _test_real_nd(self, xp, scp, x, real_axis):
+        a = scp.fft.rfft(x, axis=real_axis)
+        # complex-valued FFTs on all other axes
+        complex_axes = tuple([ax for ax in range(x.ndim) if ax != real_axis])
+        if complex_axes:
+            a = scp.fft.fftn(a, axes=complex_axes)
+
+        a = scp.ndimage.fourier_uniform(
+            a, self.size, n=x.shape[real_axis], axis=real_axis)
+
+        if complex_axes:
+            a = scp.fft.ifftn(a, axes=complex_axes)
+        a = scp.fft.irfft(a, axis=real_axis)
+        if not x.dtype.kind == 'c':
+            a = a.real
+        return xp.ascontiguousarray(a)
+
+    @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name="scp")
+    def test_real_fft_axis0(self, xp, scp):
+        x = testing.shaped_random(self.shape, xp, self.dtype)
+        if x.dtype.kind == 'c':
+            # skip: can't use rfft on complex-valued x
+            return x
+        return self._test_real_nd(xp, scp, x, 0)
+
+    @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name="scp")
+    def test_real_fft_axis1(self, xp, scp):
+        x = testing.shaped_random(self.shape, xp, self.dtype)
+        if x.dtype.kind == 'c' or x.ndim < 2:
+            # skip: can't use rfft along axis 1 on complex-valued x or 1d x
+            return x
+        return self._test_real_nd(xp, scp, x, 1)
+
+    @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name="scp")
+    def test_complex_fft(self, xp, scp):
+        x = testing.shaped_random(self.shape, xp, self.dtype)
+        a = scp.fft.fftn(x)
+        a = scp.ndimage.fourier_uniform(a, self.size)
+        a = scp.fft.ifftn(a)
+        if not x.dtype.kind == 'c':
+            a = a.real
+        return xp.ascontiguousarray(a)
+
+    @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name="scp")
+    def test_complex_fft_with_output(self, xp, scp):
+        x = testing.shaped_random(self.shape, xp, self.dtype)
+        a = scp.fft.fftn(x)
+        scp.ndimage.fourier_uniform(a, self.size, output=a)
+        a = scp.fft.ifftn(a)
+        if not x.dtype.kind == 'c':
+            a = a.real
+        return xp.ascontiguousarray(a)


### PR DESCRIPTION

This adds the `fourier_shift` function from ndimage. These functions take a Fourier-domain image and apply the complex exponentials that would be needed to give a (circular) shift in the spatial domain. (i.e. based on the [Fourier shift theorem](https://www.dsprelated.com/freebooks/sasp/Shift_Theorem.html)).

It seems like we might already have a utility like `_reshape_nd` here somewhere else, but I'm not sure. If desired we could move it to `cupy.core.internal`.

`_get_output_fourier_complex` was copied from SciPy

The SciPy implementation is in C and could be emulated via an `ElementwiseKernel`. This separable implementation only has to take the complex exponential of a 1d array along each axis rather than at every n-d element, though, so I think it might be faster.
