### PR TITLE
support order argument in cupy.ones, cupy.full and cupy.eye

### DIFF
--- a/cupy/creation/basic.py
+++ b/cupy/creation/basic.py
@@ -130,7 +130,7 @@ def identity(n, dtype=float):
     return eye(n, dtype=dtype)
 
 
-def ones(shape, dtype=float):
+def ones(shape, dtype=float, order='C'):
     """Returns a new array of given shape and dtype, filled with ones.
 
     This function currently does not support ``order`` option.
@@ -145,8 +145,7 @@ def ones(shape, dtype=float):
     .. seealso:: :func:`numpy.ones`
 
     """
-    # TODO(beam2d): Support ordering option
-    a = cupy.ndarray(shape, dtype)
+    a = cupy.ndarray(shape, dtype, order=order)
     a.fill(1)
     return a
 
@@ -243,7 +242,7 @@ def zeros_like(a, dtype=None, order='K', subok=None, shape=None):
     return a
 
 
-def full(shape, fill_value, dtype=None):
+def full(shape, fill_value, dtype=None, order='C'):
     """Returns a new array of given shape and dtype, filled with a given value.
 
     This function currently does not support ``order`` option.
@@ -259,13 +258,12 @@ def full(shape, fill_value, dtype=None):
     .. seealso:: :func:`numpy.full`
 
     """
-    # TODO(beam2d): Support ordering option
     if dtype is None:
         if isinstance(fill_value, cupy.ndarray):
             dtype = fill_value.dtype
         else:
             dtype = numpy.array(fill_value).dtype
-    a = cupy.ndarray(shape, dtype)
+    a = cupy.ndarray(shape, dtype, order=order)
     a.fill(fill_value)
     return a
 

--- a/cupy/creation/basic.py
+++ b/cupy/creation/basic.py
@@ -87,7 +87,7 @@ def empty_like(a, dtype=None, order='K', subok=None, shape=None):
     return cupy.ndarray(shape, dtype, memptr, strides, order)
 
 
-def eye(N, M=None, k=0, dtype=float):
+def eye(N, M=None, k=0, dtype=float, order='C'):
     """Returns a 2-D array with ones on the diagonals and zeros elsewhere.
 
     Args:
@@ -97,6 +97,8 @@ def eye(N, M=None, k=0, dtype=float):
             a positive index an upper diagonal, and a negative index a lower
             diagonal.
         dtype: Data type specifier.
+        order ({'C', 'F'}): Row-major (C-style) or column-major
+            (Fortran-style) order.
 
     Returns:
         cupy.ndarray: A 2-D array with given diagonals filled with ones and
@@ -107,7 +109,7 @@ def eye(N, M=None, k=0, dtype=float):
     """
     if M is None:
         M = N
-    ret = zeros((N, M), dtype)
+    ret = zeros((N, M), dtype, order=order)
     ret.diagonal(k)[:] = 1
     return ret
 
@@ -138,6 +140,8 @@ def ones(shape, dtype=float, order='C'):
     Args:
         shape (int or tuple of ints): Dimensionalities of the array.
         dtype: Data type specifier.
+        order ({'C', 'F'}): Row-major (C-style) or column-major
+            (Fortran-style) order.
 
     Returns:
         cupy.ndarray: An array filled with ones.
@@ -251,6 +255,8 @@ def full(shape, fill_value, dtype=None, order='C'):
         shape (int or tuple of ints): Dimensionalities of the array.
         fill_value: A scalar value to fill a new array.
         dtype: Data type specifier.
+        order ({'C', 'F'}): Row-major (C-style) or column-major
+            (Fortran-style) order.
 
     Returns:
         cupy.ndarray: An array filled with ``fill_value``.

--- a/tests/cupy_tests/creation_tests/test_basic.py
+++ b/tests/cupy_tests/creation_tests/test_basic.py
@@ -208,10 +208,11 @@ class TestBasic(unittest.TestCase):
         with pytest.raises(TypeError):
             cupy.zeros_like(a, subok=True)
 
+    @testing.for_CF_orders()
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
-    def test_ones(self, xp, dtype):
-        return xp.ones((2, 3, 4), dtype=dtype)
+    def test_ones(self, xp, dtype, order):
+        return xp.ones((2, 3, 4), dtype=dtype, order=order)
 
     @testing.for_orders('CFAK')
     @testing.for_all_dtypes()
@@ -225,15 +226,17 @@ class TestBasic(unittest.TestCase):
         with pytest.raises(TypeError):
             cupy.ones_like(a, subok=True)
 
+    @testing.for_CF_orders()
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
-    def test_full(self, xp, dtype):
-        return xp.full((2, 3, 4), 1, dtype=dtype)
+    def test_full(self, xp, dtype, order):
+        return xp.full((2, 3, 4), 1, dtype=dtype, order=order)
 
+    @testing.for_CF_orders()
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
-    def test_full_default_dtype(self, xp, dtype):
-        return xp.full((2, 3, 4), xp.array(1, dtype=dtype))
+    def test_full_default_dtype(self, xp, dtype, order):
+        return xp.full((2, 3, 4), xp.array(1, dtype=dtype), order=order)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()

--- a/tests/cupy_tests/creation_tests/test_basic.py
+++ b/tests/cupy_tests/creation_tests/test_basic.py
@@ -162,10 +162,11 @@ class TestBasic(unittest.TestCase):
         b = cupy.empty((1, 0, 2), dtype='d', order=order)
         self.assertEqual(b.strides, a.strides)
 
+    @testing.for_CF_orders()
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
-    def test_eye(self, xp, dtype):
-        return xp.eye(5, 4, 1, dtype)
+    def test_eye(self, xp, dtype, order):
+        return xp.eye(5, 4, 1, dtype, order=order)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()


### PR DESCRIPTION
closes #3632

`empty` and `zeros` already supported this, but for some reason these two functions did not