### PR TITLE
Parameterize sparse min/max/argmin/argmax tests

### DIFF
--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
@@ -1020,6 +1020,12 @@ class TestCscMatrixScipyCompressed(unittest.TestCase):
         return _make(xp, sp, self.dtype).getnnz()
 
 
+@testing.parameterize(*testing.product({
+    # TODO(takagi) Test dtypes
+    # TODO(takagi) Test negative axis
+    'axis': [None, 0, 1],
+    'dense': [False, True],  # means a sparse matrix but all elements filled
+}))
 @testing.with_requires('scipy>=0.19.0')
 class TestCscMatrixScipyCompressedMinMax(unittest.TestCase):
 
@@ -1071,142 +1077,46 @@ class TestCscMatrixScipyCompressedMinMax(unittest.TestCase):
         return -self._make_data_min_nonzero(xp, sp, axis=axis)
 
     @testing.numpy_cupy_array_equal(sp_name='sp')
-    def test_min_sparse_axis_none(self, xp, sp):
-        data = self._make_data_min(xp, sp)
-        return data.min(axis=None)
+    def test_min(self, xp, sp):
+        data = self._make_data_min(xp, sp, dense=self.dense)
+        return data.min(axis=self.axis)
 
     @testing.numpy_cupy_array_equal(sp_name='sp')
-    def test_min_sparse_axis_none_nonzero(self, xp, sp):
-        data = self._make_data_min_nonzero(xp, sp, axis=None)
+    def test_min_nonzero(self, xp, sp):
+        data = self._make_data_min_nonzero(xp, sp, axis=self.axis)
         if xp is cupy:
-            return data.min(axis=None, nonzero=True)
+            return data.min(axis=self.axis, nonzero=True)
         else:
-            return data.min(axis=None)
+            return data.min(axis=self.axis)
 
     @testing.numpy_cupy_array_equal(sp_name='sp')
-    def test_min_sparse_axis_0(self, xp, sp):
-        data = self._make_data_min(xp, sp)
-        return data.min(axis=0)
+    def test_max(self, xp, sp):
+        data = self._make_data_max(xp, sp, dense=self.dense)
+        return data.max(axis=self.axis)
 
     @testing.numpy_cupy_array_equal(sp_name='sp')
-    def test_min_dense_axis_0(self, xp, sp):
-        data = self._make_data_min(xp, sp, dense=True)
-        return data.min(axis=0)
-
-    @testing.numpy_cupy_array_equal(sp_name='sp')
-    def test_min_axis_0_nonzero(self, xp, sp):
-        data = self._make_data_min_nonzero(xp, sp, axis=0)
+    def test_max_nonzero(self, xp, sp):
+        data = self._make_data_max_nonzero(xp, sp, axis=self.axis)
         if xp is cupy:
-            return data.min(axis=0, nonzero=True)
+            return data.max(axis=self.axis, nonzero=True)
         else:
-            return data.min(axis=0)
+            return data.max(axis=self.axis)
 
     @testing.numpy_cupy_array_equal(sp_name='sp')
-    def test_min_sparse_axis_1(self, xp, sp):
-        data = self._make_data_min(xp, sp)
-        return data.min(axis=1)
+    def test_argmin(self, xp, sp):
+        # TODO(takagi) Fix axis=None
+        if self.axis is None:
+            pytest.skip()
+        data = self._make_data_min(xp, sp, dense=self.dense)
+        return data.argmin(axis=self.axis)
 
     @testing.numpy_cupy_array_equal(sp_name='sp')
-    def test_min_dense_axis_1(self, xp, sp):
-        data = self._make_data_min(xp, sp, dense=True)
-        return data.min(axis=1)
-
-    @testing.numpy_cupy_array_equal(sp_name='sp')
-    def test_min_axis_1_nonzero(self, xp, sp):
-        data = self._make_data_min_nonzero(xp, sp, axis=1)
-        if xp is cupy:
-            return data.min(axis=1, nonzero=True)
-        else:
-            return data.min(axis=1)
-
-    @testing.numpy_cupy_array_equal(sp_name='sp')
-    def test_max_sparse_axis_none(self, xp, sp):
-        data = self._make_data_max(xp, sp)
-        return data.max(axis=None)
-
-    @testing.numpy_cupy_array_equal(sp_name='sp')
-    def test_max_sparse_axis_none_nonzero(self, xp, sp):
-        data = self._make_data_max_nonzero(xp, sp, axis=None)
-        if xp is cupy:
-            return data.max(axis=None, nonzero=True)
-        else:
-            return data.max(axis=None)
-
-    @testing.numpy_cupy_array_equal(sp_name='sp')
-    def test_max_sparse_axis_0(self, xp, sp):
-        data = self._make_data_max(xp, sp)
-        return data.max(axis=0)
-
-    @testing.numpy_cupy_array_equal(sp_name='sp')
-    def test_max_dense_axis_0(self, xp, sp):
-        data = self._make_data_max(xp, sp, dense=True)
-        return data.max(axis=0)
-
-    @testing.numpy_cupy_array_equal(sp_name='sp')
-    def test_max_axis_0_nonzero(self, xp, sp):
-        data = self._make_data_max_nonzero(xp, sp, axis=0)
-        if xp is cupy:
-            return data.max(axis=0, nonzero=True)
-        else:
-            return data.max(axis=0)
-
-    @testing.numpy_cupy_array_equal(sp_name='sp')
-    def test_max_sparse_axis_1(self, xp, sp):
-        data = self._make_data_max(xp, sp)
-        return data.max(axis=1)
-
-    @testing.numpy_cupy_array_equal(sp_name='sp')
-    def test_max_dense_axis_1(self, xp, sp):
-        data = self._make_data_max(xp, sp, dense=True)
-        return data.max(axis=1)
-
-    @testing.numpy_cupy_array_equal(sp_name='sp')
-    def test_max_axis_1_nonzero(self, xp, sp):
-        data = self._make_data_max_nonzero(xp, sp, axis=1)
-        if xp is cupy:
-            return data.max(axis=1, nonzero=True)
-        else:
-            return data.max(axis=1)
-
-    @testing.numpy_cupy_array_equal(sp_name='sp')
-    def test_argmin_sparse_axis_0(self, xp, sp):
-        data = self._make_data_min(xp, sp)
-        return data.argmin(axis=0)
-
-    @testing.numpy_cupy_array_equal(sp_name='sp')
-    def test_argmin_dense_axis_0(self, xp, sp):
-        data = self._make_data_min(xp, sp, dense=True)
-        return data.argmin(axis=0)
-
-    @testing.numpy_cupy_array_equal(sp_name='sp')
-    def test_argmin_sparse_axis_1(self, xp, sp):
-        data = self._make_data_min(xp, sp)
-        return data.argmin(axis=1)
-
-    @testing.numpy_cupy_array_equal(sp_name='sp')
-    def test_argmin_dense_axis_1(self, xp, sp):
-        data = self._make_data_min(xp, sp, dense=True)
-        return data.argmin(axis=1)
-
-    @testing.numpy_cupy_array_equal(sp_name='sp')
-    def test_argmax_sparse_axis_0(self, xp, sp):
-        data = self._make_data_max(xp, sp)
-        return data.argmax(axis=0)
-
-    @testing.numpy_cupy_array_equal(sp_name='sp')
-    def test_argmax_dense_axis_0(self, xp, sp):
-        data = self._make_data_max(xp, sp, dense=True)
-        return data.argmax(axis=0)
-
-    @testing.numpy_cupy_array_equal(sp_name='sp')
-    def test_argmax_sparse_axis_1(self, xp, sp):
-        data = self._make_data_max(xp, sp)
-        return data.argmax(axis=1)
-
-    @testing.numpy_cupy_array_equal(sp_name='sp')
-    def test_argmax_dense_axis_1(self, xp, sp):
-        data = self._make_data_max(xp, sp, dense=True)
-        return data.argmax(axis=1)
+    def test_argmax(self, xp, sp):
+        # TODO(takagi) Fix axis=None
+        if self.axis is None:
+            pytest.skip()
+        data = self._make_data_max(xp, sp, dense=self.dense)
+        return data.argmax(axis=self.axis)
 
 
 @testing.parameterize(*testing.product({

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -1140,6 +1140,12 @@ class TestCsrMatrixScipyCompressed(unittest.TestCase):
         return _make(xp, sp, self.dtype).getnnz()
 
 
+@testing.parameterize(*testing.product({
+    # TODO(takagi) Test dtypes
+    # TODO(takagi) Test negative axis
+    'axis': [None, 0, 1],
+    'dense': [False, True],  # means a sparse matrix but all elements filled
+}))
 @testing.with_requires('scipy>=0.19.0')
 class TestCsrMatrixScipyCompressedMinMax(unittest.TestCase):
 
@@ -1191,142 +1197,46 @@ class TestCsrMatrixScipyCompressedMinMax(unittest.TestCase):
         return -self._make_data_min_nonzero(xp, sp, axis=axis)
 
     @testing.numpy_cupy_array_equal(sp_name='sp')
-    def test_min_sparse_axis_none(self, xp, sp):
-        data = self._make_data_min(xp, sp)
-        return data.min(axis=None)
+    def test_min(self, xp, sp):
+        data = self._make_data_min(xp, sp, dense=self.dense)
+        return data.min(axis=self.axis)
 
     @testing.numpy_cupy_array_equal(sp_name='sp')
-    def test_min_sparse_axis_none_nonzero(self, xp, sp):
-        data = self._make_data_min_nonzero(xp, sp, axis=None)
+    def test_min_nonzero(self, xp, sp):
+        data = self._make_data_min_nonzero(xp, sp, axis=self.axis)
         if xp is cupy:
-            return data.min(axis=None, nonzero=True)
+            return data.min(axis=self.axis, nonzero=True)
         else:
-            return data.min(axis=None)
+            return data.min(axis=self.axis)
 
     @testing.numpy_cupy_array_equal(sp_name='sp')
-    def test_min_sparse_axis_0(self, xp, sp):
-        data = self._make_data_min(xp, sp)
-        return data.min(axis=0)
+    def test_max(self, xp, sp):
+        data = self._make_data_max(xp, sp, dense=self.dense)
+        return data.max(axis=self.axis)
 
     @testing.numpy_cupy_array_equal(sp_name='sp')
-    def test_min_dense_axis_0(self, xp, sp):
-        data = self._make_data_min(xp, sp, dense=True)
-        return data.min(axis=0)
-
-    @testing.numpy_cupy_array_equal(sp_name='sp')
-    def test_min_axis_0_nonzero(self, xp, sp):
-        data = self._make_data_min_nonzero(xp, sp, axis=0)
+    def test_max_nonzero(self, xp, sp):
+        data = self._make_data_max_nonzero(xp, sp, axis=self.axis)
         if xp is cupy:
-            return data.min(axis=0, nonzero=True)
+            return data.max(axis=self.axis, nonzero=True)
         else:
-            return data.min(axis=0)
+            return data.max(axis=self.axis)
 
     @testing.numpy_cupy_array_equal(sp_name='sp')
-    def test_min_sparse_axis_1(self, xp, sp):
-        data = self._make_data_min(xp, sp)
-        return data.min(axis=1)
+    def test_argmin(self, xp, sp):
+        # TODO(takagi) Fix axis=None
+        if self.axis is None:
+            pytest.skip()
+        data = self._make_data_min(xp, sp, dense=self.dense)
+        return data.argmin(axis=self.axis)
 
     @testing.numpy_cupy_array_equal(sp_name='sp')
-    def test_min_dense_axis_1(self, xp, sp):
-        data = self._make_data_min(xp, sp, dense=True)
-        return data.min(axis=1)
-
-    @testing.numpy_cupy_array_equal(sp_name='sp')
-    def test_min_axis_1_nonzero(self, xp, sp):
-        data = self._make_data_min_nonzero(xp, sp, axis=1)
-        if xp is cupy:
-            return data.min(axis=1, nonzero=True)
-        else:
-            return data.min(axis=1)
-
-    @testing.numpy_cupy_array_equal(sp_name='sp')
-    def test_max_sparse_axis_none(self, xp, sp):
-        data = self._make_data_max(xp, sp)
-        return data.max(axis=None)
-
-    @testing.numpy_cupy_array_equal(sp_name='sp')
-    def test_max_sparse_axis_none_nonzero(self, xp, sp):
-        data = self._make_data_max_nonzero(xp, sp, axis=None)
-        if xp is cupy:
-            return data.max(axis=None, nonzero=True)
-        else:
-            return data.max(axis=None)
-
-    @testing.numpy_cupy_array_equal(sp_name='sp')
-    def test_max_sparse_axis_0(self, xp, sp):
-        data = self._make_data_max(xp, sp)
-        return data.max(axis=0)
-
-    @testing.numpy_cupy_array_equal(sp_name='sp')
-    def test_max_dense_axis_0(self, xp, sp):
-        data = self._make_data_max(xp, sp, dense=True)
-        return data.max(axis=0)
-
-    @testing.numpy_cupy_array_equal(sp_name='sp')
-    def test_max_axis_0_nonzero(self, xp, sp):
-        data = self._make_data_max_nonzero(xp, sp, axis=0)
-        if xp is cupy:
-            return data.max(axis=0, nonzero=True)
-        else:
-            return data.max(axis=0)
-
-    @testing.numpy_cupy_array_equal(sp_name='sp')
-    def test_max_sparse_axis_1(self, xp, sp):
-        data = self._make_data_max(xp, sp)
-        return data.max(axis=1)
-
-    @testing.numpy_cupy_array_equal(sp_name='sp')
-    def test_max_dense_axis_1(self, xp, sp):
-        data = self._make_data_max(xp, sp, dense=True)
-        return data.max(axis=1)
-
-    @testing.numpy_cupy_array_equal(sp_name='sp')
-    def test_max_axis_1_nonzero(self, xp, sp):
-        data = self._make_data_max_nonzero(xp, sp, axis=1)
-        if xp is cupy:
-            return data.max(axis=1, nonzero=True)
-        else:
-            return data.max(axis=1)
-
-    @testing.numpy_cupy_array_equal(sp_name='sp')
-    def test_argmin_sparse_axis_0(self, xp, sp):
-        data = self._make_data_min(xp, sp)
-        return data.argmin(axis=0)
-
-    @testing.numpy_cupy_array_equal(sp_name='sp')
-    def test_argmin_dense_axis_0(self, xp, sp):
-        data = self._make_data_min(xp, sp, dense=True)
-        return data.argmin(axis=0)
-
-    @testing.numpy_cupy_array_equal(sp_name='sp')
-    def test_argmin_sparse_axis_1(self, xp, sp):
-        data = self._make_data_min(xp, sp)
-        return data.argmin(axis=1)
-
-    @testing.numpy_cupy_array_equal(sp_name='sp')
-    def test_argmin_dense_axis_1(self, xp, sp):
-        data = self._make_data_min(xp, sp, dense=True)
-        return data.argmin(axis=1)
-
-    @testing.numpy_cupy_array_equal(sp_name='sp')
-    def test_argmax_sparse_axis_0(self, xp, sp):
-        data = self._make_data_max(xp, sp)
-        return data.argmax(axis=0)
-
-    @testing.numpy_cupy_array_equal(sp_name='sp')
-    def test_argmax_dense_axis_0(self, xp, sp):
-        data = self._make_data_max(xp, sp, dense=True)
-        return data.argmax(axis=0)
-
-    @testing.numpy_cupy_array_equal(sp_name='sp')
-    def test_argmax_sparse_axis_1(self, xp, sp):
-        data = self._make_data_max(xp, sp)
-        return data.argmax(axis=1)
-
-    @testing.numpy_cupy_array_equal(sp_name='sp')
-    def test_argmax_dense_axis_1(self, xp, sp):
-        data = self._make_data_max(xp, sp, dense=True)
-        return data.argmax(axis=1)
+    def test_argmax(self, xp, sp):
+        # TODO(takagi) Fix axis=None
+        if self.axis is None:
+            pytest.skip()
+        data = self._make_data_max(xp, sp, dense=self.dense)
+        return data.argmax(axis=self.axis)
 
 
 @testing.parameterize(*testing.product({


### PR DESCRIPTION
Merge #3639 first.

This PR parameterizes the tests of sparse min/max/argmin/argmax. As argmin/argmax currently do not work with `axis=None`, I make the corresponding tests skip here and will post another PR to fix it.