### PR TITLE
[backport] Update Installation Guide

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -176,7 +176,7 @@ You can install CuPy from the tarball::
 
 You can also install the development version of CuPy from a cloned Git repository::
 
-  $ git clone https://github.com/cupy/cupy.git
+  $ git clone --recursive https://github.com/cupy/cupy.git
   $ cd cupy
   $ pip install .
 

--- a/docs/source/install_rocm.rst
+++ b/docs/source/install_rocm.rst
@@ -79,7 +79,7 @@ You can install CuPy from the tarball::
 
 You can also install the development version of CuPy from a cloned Git repository::
 
-  $ git clone https://github.com/cupy/cupy.git
+  $ git clone --recursive https://github.com/cupy/cupy.git
   $ cd cupy
   $ export HCC_AMDGPU_TARGET=gfx900  # This value should be changed based on your GPU
   $ export __HIP_PLATFORM_HCC__


### PR DESCRIPTION
Fix #3648. This PR backports the doc change from #2584 so that the users know a deep clone is needed.

Thanks to @Nicholas-Mitchell for bringing this up!