### PR TITLE
List all documented APIs to `__all__`

### DIFF
--- a/cupy/_sorting/__init__.py
+++ b/cupy/_sorting/__init__.py
@@ -5,3 +5,7 @@
 from cupy._sorting import count  # NOQA
 from cupy._sorting import search  # NOQA
 from cupy._sorting import sort  # NOQA
+
+from cupy._sorting.count import *  # NOQA
+from cupy._sorting.search import *  # NOQA
+from cupy._sorting.sort import *  # NOQA

--- a/cupy/_sorting/count.py
+++ b/cupy/_sorting/count.py
@@ -1,3 +1,6 @@
+__all__ = ['count_nonzero']
+
+
 from cupy import core
 
 

--- a/cupy/_sorting/search.py
+++ b/cupy/_sorting/search.py
@@ -1,3 +1,7 @@
+__all__ = ['argmax', 'nanargmax', 'argmin', 'nanargmin', 'argwhere', 'nonzero',
+           'flatnonzero', 'where', 'searchsorted']
+
+
 import cupy
 from cupy import core
 from cupy.core import fusion

--- a/cupy/_sorting/sort.py
+++ b/cupy/_sorting/sort.py
@@ -1,3 +1,7 @@
+__all__ = ['sort', 'lexsort', 'argsort', 'msort', 'sort_complex', 'partition',
+           'argpartition']
+
+
 import cupy
 import numpy
 

--- a/cupy/binary/__init__.py
+++ b/cupy/binary/__init__.py
@@ -4,3 +4,6 @@
 # "NOQA" to suppress flake8 warning
 from cupy.binary import elementwise  # NOQA
 from cupy.binary import packing  # NOQA
+
+from cupy.binary.elementwise import *  # NOQA
+from cupy.binary.packing import *  # NOQA

--- a/cupy/binary/elementwise.py
+++ b/cupy/binary/elementwise.py
@@ -1,3 +1,7 @@
+__all__ = ['bitwise_and', 'bitwise_or', 'bitwise_xor', 'invert', 'left_shift',
+           'right_shift']
+
+
 from cupy import core
 
 

--- a/cupy/binary/packing.py
+++ b/cupy/binary/packing.py
@@ -1,3 +1,6 @@
+__all__ = ['packbits', 'unpackbits']
+
+
 import cupy
 from cupy import core
 

--- a/cupy/core/__init__.py
+++ b/cupy/core/__init__.py
@@ -3,8 +3,7 @@ from cupy.core import internal  # NOQA
 
 
 # import class and function
-from cupy.core._accelerator import set_reduction_accelerators  # NOQA
-from cupy.core._accelerator import set_routine_accelerators  # NOQA
+from cupy.core._accelerator import *  # NOQA
 from cupy.core._kernel import create_ufunc  # NOQA
 from cupy.core._kernel import ElementwiseKernel  # NOQA
 from cupy.core._kernel import ufunc  # NOQA

--- a/cupy/core/__init__.py
+++ b/cupy/core/__init__.py
@@ -4,9 +4,8 @@ from cupy.core import internal  # NOQA
 
 # import class and function
 from cupy.core._accelerator import *  # NOQA
-from cupy.core._kernel import create_ufunc  # NOQA
-from cupy.core._kernel import ElementwiseKernel  # NOQA
-from cupy.core._kernel import ufunc  # NOQA
+from cupy.core._kernel import *  # NOQA
+
 from cupy.core._reduction import create_reduction_func  # NOQA
 from cupy.core._reduction import ReductionKernel  # NOQA
 from cupy.core._routines_manipulation import array_split  # NOQA

--- a/cupy/core/_accelerator.pyx
+++ b/cupy/core/_accelerator.pyx
@@ -1,3 +1,6 @@
+__all__ = ['set_reduction_accelerators', 'set_routine_accelerators']
+
+
 import os
 
 cdef list _reduction_accelerators = []

--- a/cupy/core/_kernel.pyx
+++ b/cupy/core/_kernel.pyx
@@ -1,3 +1,6 @@
+__all__ = ['ElementwiseKernel', 'ufunc']
+
+
 import string
 
 import numpy


### PR DESCRIPTION
Close #3420.

(The description will be described later.)

I need to have the following two steps:
- Define `__all__` variable for each modules
- Import `*` from its submodules for each package

I will use importing `*` from submodules instead of defining `__all__` for packages; otherwise, we have to repeatedly define a name in a module on packages that contain the module directly or indirectly. That means we can not partially expose submodules of a package, i.g. `cupy.core.internal` which is imported into `cupy.core` package but not into `cupy` package.

Is it enough to define `__all__` in the topmost packages only? If so, we can get the same thing with the current `cupy/__init__.py, modifying it to hide unnecessary names as standard libraries.