### PR TITLE
Speed up `cupy.vdot`

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2811,12 +2811,15 @@ cpdef ndarray tensordot_core(
         if out.dtype != dtype:
             out = _ndarray_init(ret_shape, dtype)
 
+    cdef int ace
     if m == 1 and n == 1:
-        if len(_accelerator._routine_accelerators) > 0:
-            # fast path using CUB or cuTENSOR; if not applicable, it'd fall
-            # back to CuPy's reduction kernel
-            out = (a.ravel() * b.ravel()).sum(
-                out=_manipulation._reshape(out, ()))
+        for ace in _accelerator._routine_accelerators:
+            # fast path using CUB or cuTENSOR
+            if ace in (_accelerator.ACCELERATOR_CUB,
+                       _accelerator.ACCELERATOR_CUTENSOR):
+                out = (a.ravel() * b.ravel()).sum(
+                    out=_manipulation._reshape(out, ()))
+                break
         else:
             _tensordot_core_mul_sum(
                 a.ravel(), b.ravel(),


### PR DESCRIPTION
Close #3672. Use CUB device reduction to accelerate it. If not available, fall back to the original kernel.

Before: 
```
vdot                :    CPU:   17.272 us   +/- 0.938 (min:   16.300 / max:   39.416) us     GPU-0:  640.646 us   +/-18.809 (min:  630.496 / max:  774.144) us
```
After:
```
vdot                :    CPU:   57.839 us   +/- 6.615 (min:   55.680 / max:  216.692) us     GPU-0:   80.302 us   +/-18.042 (min:   75.776 / max:  232.096) us
```
For some reason CPU overhead is unexpectedly increased...Not sure what I overlooked 😞
