### PR TITLE
Support CSR matrix division

### DIFF
--- a/cupyx/scipy/sparse/csr.py
+++ b/cupyx/scipy/sparse/csr.py
@@ -180,6 +180,20 @@ class csr_matrix(compressed._compressed_sparse_matrix):
         raise NotImplementedError
 
     def __truediv__(self, other):
+        """Point-wise division by scalar"""
+        if util.isscalarlike(other):
+            if self.dtype == numpy.complex64:
+                # Note: This is a work-around to make the output dtype the same
+                # as SciPy. It might be SciPy version dependent.
+                dtype = numpy.float32
+            else:
+                if cupy.isscalar(other):
+                    dtype = numpy.float64
+                else:
+                    dtype = numpy.promote_types(numpy.float64, other.dtype)
+            d = cupy.array(1. / other, dtype=dtype)
+            return multiply_by_scalar(self, d)
+        # TODO(anaruse): Implement divide by dense or sparse matrix
         raise NotImplementedError
 
     def __rtruediv__(self, other):

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -1091,6 +1091,19 @@ class TestCsrMatrixScipyComparison(unittest.TestCase):
         x = _make_col(xp, sp, self.dtype)
         return m.multiply(x).toarray()
 
+    # divide
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_divide_scalar(self, xp, sp):
+        m = self.make(xp, sp, self.dtype)
+        y = m / 2
+        return y.toarray()
+
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_divide_scalarlike(self, xp, sp):
+        m = self.make(xp, sp, self.dtype)
+        y = m / xp.array(2)
+        return y.toarray()
+
 
 @testing.parameterize(*testing.product({
     'dtype': [numpy.float32, numpy.float64, numpy.complex64, numpy.complex128],


### PR DESCRIPTION
This PR is to partially support `csr_matrix` division. With this PR, you can divide a sparse matrix in CSR format by a scalar number.

Division by dense or sparse matrix is not supported by this PR. This is partially because the SciPy implementation returns a `numpy.matrix` object as output in such cases, which is not supported by CuPy (AFAIK).