### PR TITLE
Re-add the `cudnn` and `profiler` `cupy.cuda` modules

### DIFF
--- a/cupy/cuda/cudnn.py
+++ b/cupy/cuda/cudnn.py
@@ -1,0 +1,1 @@
+from cupy_backends.cuda.libs.cudnn import *  # NOQA

--- a/cupy/cuda/profiler.py
+++ b/cupy/cuda/profiler.py
@@ -1,0 +1,1 @@
+from cupy_backends.cuda.libs.profiler import *  # NOQA


### PR DESCRIPTION
They were deleted from the namespace with the `cupy_backends` change