### PR TITLE
Fix broken imports for `cupy.cuda.*`

### DIFF
--- a/cupy/cuda/cudnn.py
+++ b/cupy/cuda/cudnn.py
@@ -1,0 +1,1 @@
+from cupy_backends.cuda.libs.cudnn import *  # NOQA

--- a/cupy/cuda/profiler.py
+++ b/cupy/cuda/profiler.py
@@ -1,0 +1,1 @@
+from cupy_backends.cuda.libs.profiler import *  # NOQA

--- a/cupy/cuda/runtime.py
+++ b/cupy/cuda/runtime.py
@@ -1,0 +1,1 @@
+from cupy_backends.cuda.api.runtime import *  # NOQA

--- a/tests/cupyx_tests/test_runtime.py
+++ b/tests/cupyx_tests/test_runtime.py
@@ -6,7 +6,7 @@ import cupyx
 
 
 try:
-    import cupy.cuda.cudnn as cudnn
+    import cupy_backends.cuda.libs.cudnn as cudnn
 except ImportError:
     cudnn = None
 
@@ -29,21 +29,21 @@ class TestRuntime(unittest.TestCase):
         assert 'Error' not in str(runtime)
 
         with mock.patch(
-                'cupy.cuda.runtime.driverGetVersion',
+                'cupy_backends.cuda.api.runtime.driverGetVersion',
                 side_effect=_get_error_func(
                     cupy.cuda.runtime.CUDARuntimeError, 0)):
             runtime = cupyx.get_runtime_info()
             assert 'CUDARuntimeError' in str(runtime)
 
         with mock.patch(
-                'cupy.cuda.runtime.runtimeGetVersion',
+                'cupy_backends.cuda.api.runtime.runtimeGetVersion',
                 side_effect=_get_error_func(
                     cupy.cuda.runtime.CUDARuntimeError, 0)):
             runtime = cupyx.get_runtime_info()
             assert 'CUDARuntimeError' in str(runtime)
 
         with mock.patch(
-                'cupy.cuda.cudnn.getVersion',
+                'cupy_backends.cuda.libs.cudnn.getVersion',
                 side_effect=_get_error_func(cudnn.CuDNNError, 0)):
             runtime = cupyx.get_runtime_info()
             assert 'CuDNNError' in str(runtime)


### PR DESCRIPTION
Supersedes #3685 

This fixes the issue that `import cupy.cuda.{runtime,profiler,cudnn}` is not working after cupy_backends refactoring.
discussion: https://github.com/cupy/cupy/pull/3681#issuecomment-665093779

(although the code freeze period is already over, we will include this fix to v8b5 as this will break user code)