### PR TITLE
Fix rpath for wheel build

### DIFF
--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -549,11 +549,12 @@ def make_extensions(options, compiler, use_cython):
                 # Add `cupy/.data/lib` (where shared libraries included in
                 # wheels reside) to RPATH.
                 # The path is resolved relative to the module, e.g., use
-                # `$ORIGIN/.data/lib` for `cupy/cudnn.so` and
-                # `$ORIGIN/../.data/lib` for `cupy/cuda/cudnn.so`.
-                depth = name.count('.') - 1
+                # `$ORIGIN/../cupy/.data/lib` for `cupy/cudnn.so` and
+                # `$ORIGIN/../../../cupy/.data/lib` for
+                # `cupy_backends/cuda/libs/cudnn.so`.
+                depth = name.count('.')
                 rpath.append(
-                    '{}{}/.data/lib'.format(_rpath_base(), '/..' * depth))
+                    '{}{}/cupy/.data/lib'.format(_rpath_base(), '/..' * depth))
 
             if not PLATFORM_WIN32 and not PLATFORM_LINUX:
                 s['runtime_library_dirs'] = rpath


### PR DESCRIPTION
Fix the issue that rpath generation was expecting that all modules that use shared library are under `cupy.*`.
This is needed for `cuda_backends`.