### PR TITLE
[WIP] Fix Windows build failure of cuSparse generic API

### DIFF
--- a/cupy/cusparse.py
+++ b/cupy/cusparse.py
@@ -89,7 +89,7 @@ _available_cusparse_version = {
     'csrgeam2': (9020, None),
     'csrgemm': (8000, 11000),
     'csrgemm2': (8000, None),
-    'spmv': (10200, None),
+    'spmv': ({'Linux': 10200, 'Windows': 11000}, None),
     'spmm': (10301, None),  # accuracy bugs in cuSparse 10.3.0
     'csr2dense': (8000, None),
     'csc2dense': (8000, None),

--- a/cupy_backends/cuda/libs/cupy_cusparse.h
+++ b/cupy_backends/cuda/libs/cupy_cusparse.h
@@ -219,8 +219,9 @@ cusparseStatus_t cusparseZcsrgeam2(...) {
 
 #endif // #if CUSPARSE_VERSION < 9020
 
-#if CUSPARSE_VERSION < 10200
+#if (CUSPARSE_VERSION < 10200) || (CUSPARSE_VERSION < 11000 && defined(_WIN32))
 // Types, macro and functions added in cuSparse 10.2
+// Windows support added in cuSparse 11.0
 
 // cuSPARSE generic API
 typedef void* cusparseSpVecDescr_t;


### PR DESCRIPTION
Fix build failure using CUDA 10.1 / 10.2 on Windows.

I retested #3491 and found that:

* CuPy + cuSPARSE 10.2.0 (= CUDA 10.1.168 = Update 1) cannot be built on Windows.
* CuPy + cuSPARSE 10.3.0 (= CUDA 10.1.243 = Update 2) can be built on Windows, but actually it is not working.

So we should provide generic API support in Windows for cuSPARSE 11.1.0 (= CUDA 11.0 stable) or later.

ref: #3491