### PR TITLE
[backport] support order argument in cupy.ones, cupy.full and cupy.eye

### DIFF
--- a/cupy/creation/basic.py
+++ b/cupy/creation/basic.py
@@ -86,7 +86,7 @@ def empty_like(a, dtype=None, order='K', subok=None, shape=None):
     return cupy.ndarray(shape, dtype, memptr, strides, order)
 
 
-def eye(N, M=None, k=0, dtype=float):
+def eye(N, M=None, k=0, dtype=float, order='C'):
     """Returns a 2-D array with ones on the diagonals and zeros elsewhere.
 
     Args:
@@ -96,6 +96,8 @@ def eye(N, M=None, k=0, dtype=float):
             a positive index an upper diagonal, and a negative index a lower
             diagonal.
         dtype: Data type specifier.
+        order ({'C', 'F'}): Row-major (C-style) or column-major
+            (Fortran-style) order.
 
     Returns:
         cupy.ndarray: A 2-D array with given diagonals filled with ones and
@@ -106,7 +108,7 @@ def eye(N, M=None, k=0, dtype=float):
     """
     if M is None:
         M = N
-    ret = zeros((N, M), dtype)
+    ret = zeros((N, M), dtype, order=order)
     ret.diagonal(k)[:] = 1
     return ret
 
@@ -129,7 +131,7 @@ def identity(n, dtype=float):
     return eye(n, dtype=dtype)
 
 
-def ones(shape, dtype=float):
+def ones(shape, dtype=float, order='C'):
     """Returns a new array of given shape and dtype, filled with ones.
 
     This function currently does not support ``order`` option.
@@ -137,6 +139,8 @@ def ones(shape, dtype=float):
     Args:
         shape (int or tuple of ints): Dimensionalities of the array.
         dtype: Data type specifier.
+        order ({'C', 'F'}): Row-major (C-style) or column-major
+            (Fortran-style) order.
 
     Returns:
         cupy.ndarray: An array filled with ones.
@@ -144,8 +148,7 @@ def ones(shape, dtype=float):
     .. seealso:: :func:`numpy.ones`
 
     """
-    # TODO(beam2d): Support ordering option
-    a = cupy.ndarray(shape, dtype)
+    a = cupy.ndarray(shape, dtype, order=order)
     a.fill(1)
     return a
 
@@ -242,7 +245,7 @@ def zeros_like(a, dtype=None, order='K', subok=None, shape=None):
     return a
 
 
-def full(shape, fill_value, dtype=None):
+def full(shape, fill_value, dtype=None, order='C'):
     """Returns a new array of given shape and dtype, filled with a given value.
 
     This function currently does not support ``order`` option.
@@ -251,6 +254,8 @@ def full(shape, fill_value, dtype=None):
         shape (int or tuple of ints): Dimensionalities of the array.
         fill_value: A scalar value to fill a new array.
         dtype: Data type specifier.
+        order ({'C', 'F'}): Row-major (C-style) or column-major
+            (Fortran-style) order.
 
     Returns:
         cupy.ndarray: An array filled with ``fill_value``.
@@ -258,13 +263,12 @@ def full(shape, fill_value, dtype=None):
     .. seealso:: :func:`numpy.full`
 
     """
-    # TODO(beam2d): Support ordering option
     if dtype is None:
         if isinstance(fill_value, cupy.ndarray):
             dtype = fill_value.dtype
         else:
             dtype = numpy.array(fill_value).dtype
-    a = cupy.ndarray(shape, dtype)
+    a = cupy.ndarray(shape, dtype, order=order)
     a.fill(fill_value)
     return a
 

--- a/tests/cupy_tests/creation_tests/test_basic.py
+++ b/tests/cupy_tests/creation_tests/test_basic.py
@@ -164,7 +164,14 @@ class TestBasic(unittest.TestCase):
     @testing.for_CF_orders()
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
-    def test_eye(self, xp, dtype, order):
+    def test_eye(self, xp, dtype):
+        return xp.eye(5, 4, 1, dtype)
+
+    @testing.for_CF_orders()
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    @testing.with_requires('numpy>=1.14.0')
+    def test_eye_order(self, xp, dtype, order):
         return xp.eye(5, 4, 1, dtype, order=order)
 
     @testing.for_all_dtypes()

--- a/tests/cupy_tests/creation_tests/test_basic.py
+++ b/tests/cupy_tests/creation_tests/test_basic.py
@@ -236,7 +236,7 @@ class TestBasic(unittest.TestCase):
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     @testing.with_requires('numpy>=1.12.0')
-    def test_full_default_dtype(self, xp, dtype):
+    def test_full_default_dtype(self, xp, dtype, order):
         return xp.full((2, 3, 4), xp.array(1, dtype=dtype), order=order)
 
     @testing.for_all_dtypes()

--- a/tests/cupy_tests/creation_tests/test_basic.py
+++ b/tests/cupy_tests/creation_tests/test_basic.py
@@ -161,10 +161,11 @@ class TestBasic(unittest.TestCase):
         b = cupy.empty((1, 0, 2), dtype='d', order=order)
         self.assertEqual(b.strides, a.strides)
 
+    @testing.for_CF_orders()
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
-    def test_eye(self, xp, dtype):
-        return xp.eye(5, 4, 1, dtype)
+    def test_eye(self, xp, dtype, order):
+        return xp.eye(5, 4, 1, dtype, order=order)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
@@ -207,10 +208,11 @@ class TestBasic(unittest.TestCase):
         with pytest.raises(TypeError):
             cupy.zeros_like(a, subok=True)
 
+    @testing.for_CF_orders()
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
-    def test_ones(self, xp, dtype):
-        return xp.ones((2, 3, 4), dtype=dtype)
+    def test_ones(self, xp, dtype, order):
+        return xp.ones((2, 3, 4), dtype=dtype, order=order)
 
     @testing.for_orders('CFAK')
     @testing.for_all_dtypes()
@@ -224,16 +226,18 @@ class TestBasic(unittest.TestCase):
         with pytest.raises(TypeError):
             cupy.ones_like(a, subok=True)
 
+    @testing.for_CF_orders()
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
-    def test_full(self, xp, dtype):
-        return xp.full((2, 3, 4), 1, dtype=dtype)
+    def test_full(self, xp, dtype, order):
+        return xp.full((2, 3, 4), 1, dtype=dtype, order=order)
 
+    @testing.for_CF_orders()
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     @testing.with_requires('numpy>=1.12.0')
     def test_full_default_dtype(self, xp, dtype):
-        return xp.full((2, 3, 4), xp.array(1, dtype=dtype))
+        return xp.full((2, 3, 4), xp.array(1, dtype=dtype), order=order)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()

--- a/tests/cupy_tests/creation_tests/test_basic.py
+++ b/tests/cupy_tests/creation_tests/test_basic.py
@@ -161,7 +161,6 @@ class TestBasic(unittest.TestCase):
         b = cupy.empty((1, 0, 2), dtype='d', order=order)
         self.assertEqual(b.strides, a.strides)
 
-    @testing.for_CF_orders()
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_eye(self, xp, dtype):


### PR DESCRIPTION
Backport of #3655