### PR TITLE
Remove unnecessary imports in `cupy._sorting`

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -64,7 +64,6 @@ from cupy import manipulation  # NOQA
 from cupy import padding  # NOQA
 from cupy import polynomial  # NOQA
 from cupy import random  # NOQA
-from cupy import _sorting  # NOQA
 from cupy import sparse  # NOQA
 from cupy import statistics  # NOQA
 from cupy import testing  # NOQA  # NOQA

--- a/cupy/_sorting/__init__.py
+++ b/cupy/_sorting/__init__.py
@@ -1,7 +1,2 @@
 # Functions from the following NumPy document
 # https://docs.scipy.org/doc/numpy/reference/routines.sort.html
-
-# "NOQA" to suppress flake8 warning
-from cupy._sorting import count  # NOQA
-from cupy._sorting import search  # NOQA
-from cupy._sorting import sort  # NOQA


### PR DESCRIPTION
Rel #3420.

This PR removes unnecessary imports from `cupy._sorting` submodule.