### PR TITLE
Remove unnecessary import of `cupy.fft`

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -55,7 +55,6 @@ __version__ = _version.__version__
 from cupy import binary  # NOQA
 import cupy.core.fusion  # NOQA
 from cupy import creation  # NOQA
-from cupy import fft  # NOQA
 from cupy import functional  # NOQA
 from cupy import indexing  # NOQA
 from cupy import io  # NOQA


### PR DESCRIPTION
Rel #3420.

This PR removes unnecessary import of `cupy.fft`, which is naturally imported without the line.