### PR TITLE
Remove unnecessary imports of `cupy.linalg`

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -59,6 +59,7 @@ from cupy import fft  # NOQA
 from cupy import functional  # NOQA
 from cupy import indexing  # NOQA
 from cupy import io  # NOQA
+from cupy import linalg  # NOQA
 from cupy import manipulation  # NOQA
 from cupy import padding  # NOQA
 from cupy import polynomial  # NOQA

--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -59,7 +59,6 @@ from cupy import fft  # NOQA
 from cupy import functional  # NOQA
 from cupy import indexing  # NOQA
 from cupy import io  # NOQA
-from cupy import linalg  # NOQA
 from cupy import manipulation  # NOQA
 from cupy import padding  # NOQA
 from cupy import polynomial  # NOQA

--- a/cupy/linalg/__init__.py
+++ b/cupy/linalg/__init__.py
@@ -36,4 +36,3 @@ from cupy.linalg.solve import lstsq  # NOQA
 from cupy.linalg.solve import inv  # NOQA
 from cupy.linalg.solve import pinv  # NOQA
 from cupy.linalg.solve import tensorinv  # NOQA
-

--- a/cupy/linalg/__init__.py
+++ b/cupy/linalg/__init__.py
@@ -1,30 +1,39 @@
 # Functions from the following NumPy document
 # https://docs.scipy.org/doc/numpy/reference/routines.linalg.html
 
-# "NOQA" to suppress flake8 warning
-from cupy.linalg import decomposition  # NOQA
-from cupy.linalg import eigenvalue  # NOQA
-from cupy.linalg import einsum  # NOQA
-from cupy.linalg import norms  # NOQA
-from cupy.linalg.norms import det  # NOQA
-from cupy.linalg.norms import matrix_rank  # NOQA
-from cupy.linalg.norms import norm  # NOQA
-from cupy.linalg.norms import slogdet  # NOQA
-from cupy.linalg import product  # NOQA
-from cupy.linalg import solve  # NOQA
+# -----------------------------------------------------------------------------
+# Matrix and vector products
+# -----------------------------------------------------------------------------
+from cupy.linalg.product import matrix_power  # NOQA
 
+# -----------------------------------------------------------------------------
+# Decompositions
+# -----------------------------------------------------------------------------
 from cupy.linalg.decomposition import cholesky  # NOQA
 from cupy.linalg.decomposition import qr  # NOQA
 from cupy.linalg.decomposition import svd  # NOQA
 
+# -----------------------------------------------------------------------------
+# Matrix eigenvalues
+# -----------------------------------------------------------------------------
 from cupy.linalg.eigenvalue import eigh  # NOQA
 from cupy.linalg.eigenvalue import eigvalsh  # NOQA
 
-from cupy.linalg.solve import inv  # NOQA
-from cupy.linalg.solve import lstsq  # NOQA
-from cupy.linalg.solve import pinv  # NOQA
-from cupy.linalg.solve import solve  # NOQA
-from cupy.linalg.solve import tensorinv  # NOQA
-from cupy.linalg.solve import tensorsolve  # NOQA
+# -----------------------------------------------------------------------------
+# Norms and other numbers
+# -----------------------------------------------------------------------------
+from cupy.linalg.norms import norm  # NOQA
+from cupy.linalg.norms import det  # NOQA
+from cupy.linalg.norms import matrix_rank  # NOQA
+from cupy.linalg.norms import slogdet  # NOQA
 
-from cupy.linalg.product import matrix_power  # NOQA
+# -----------------------------------------------------------------------------
+# Solving equations and inverting matrices
+# -----------------------------------------------------------------------------
+from cupy.linalg.solve import solve  # NOQA
+from cupy.linalg.solve import tensorsolve  # NOQA
+from cupy.linalg.solve import lstsq  # NOQA
+from cupy.linalg.solve import inv  # NOQA
+from cupy.linalg.solve import pinv  # NOQA
+from cupy.linalg.solve import tensorinv  # NOQA
+


### PR DESCRIPTION
Rel #3420.

This PR removes unnecessary imports of `cupy.linalg` as well as making `cupy/linalg/__init__.py` follow NumPy's reference.