### PR TITLE
Handle `__cuda_array_interface__` in `asnumpy`

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -766,6 +766,8 @@ def asnumpy(a, stream=None, order='C'):
     """
     if isinstance(a, ndarray):
         return a.get(stream=stream, order=order)
+    elif hasattr(a, "__cuda_array_interface__"):
+        return array(a).get(stream=stream, order=order)
     else:
         return numpy.asarray(a, order=order)
 

--- a/tests/cupy_tests/creation_tests/test_from_data.py
+++ b/tests/cupy_tests/creation_tests/test_from_data.py
@@ -503,7 +503,7 @@ class TestCudaArrayInterface(unittest.TestCase):
     @testing.for_all_dtypes()
     def test_asnumpy(self, dtype):
         a = testing.shaped_arange((2, 3, 4), cupy, dtype)
-        b = DummyObjectWithCudaArrayInterface(a, self.ver, self.strides))
+        b = DummyObjectWithCudaArrayInterface(a, self.ver, self.strides)
         a_cpu = cupy.asnumpy(a)
         b_cpu = cupy.asnumpy(b)
         testing.assert_array_equal(a_cpu, b_cpu)

--- a/tests/cupy_tests/creation_tests/test_from_data.py
+++ b/tests/cupy_tests/creation_tests/test_from_data.py
@@ -500,6 +500,14 @@ class TestCudaArrayInterface(unittest.TestCase):
         assert a.data.ptr == 0
         assert a.size == 0
 
+    @testing.for_all_dtypes()
+    def test_asnumpy(self, dtype):
+        a = testing.shaped_arange((2, 3, 4), cupy, dtype)
+        b = DummyObjectWithCudaArrayInterface(a, self.ver, self.strides))
+        a_cpu = cupy.asnumpy(a)
+        b_cpu = cupy.asnumpy(b)
+        testing.assert_array_equal(a_cpu, b_cpu)
+
 
 @testing.gpu
 @testing.parameterize(*testing.product({


### PR DESCRIPTION
If the object given to `asnumpy` supports `__cuda_array_interface__`, then coerce it to a CuPy `ndarray` and use `.get(...)` to transfer it back to host (as would be done with a CuPy `ndarray`).