### PR TITLE
Fix `can_use_device_segmented_reduce()` for incompatible axes

### DIFF
--- a/cupy/cuda/cub.pyx
+++ b/cupy/cuda/cub.pyx
@@ -92,7 +92,7 @@ cdef tuple _get_output_shape(ndarray arr, tuple out_axis, bint keepdims):
 
 
 cpdef Py_ssize_t _preprocess_array(tuple arr_shape, tuple reduce_axis,
-                                   tuple out_axis, str order):
+                                   tuple out_axis, str order) except -1:
     '''
     This function more or less follows the logic of _get_permuted_args() in
     reduction.pxi. The input array arr is C- or F- contiguous along axis.

--- a/cupy/cuda/cub.pyx
+++ b/cupy/cuda/cub.pyx
@@ -395,12 +395,13 @@ cdef bint can_use_device_segmented_reduce(
         dtype=None, str order='C'):
     if not _cub_reduce_dtype_compatible(x.dtype, op, dtype):
         return False
+    if not _cub_device_segmented_reduce_axis_compatible(
+            reduce_axis, x.ndim, order):
+        return False
+    # until we resolve cupy/cupy#3309
     cdef Py_ssize_t contiguous_size = _preprocess_array(
         x.shape, reduce_axis, out_axis, order)
-    return (_cub_device_segmented_reduce_axis_compatible(
-        reduce_axis, x.ndim, order) and
-        # until we resolve cupy/cupy#3309
-        contiguous_size <= 0x7fffffff)
+    return contiguous_size <= 0x7fffffff
 
 
 cdef _cub_support_dtype(bint sum_mode, int dev_id):


### PR DESCRIPTION
Close #3738.

There are two errors in this function:
1. #3562 mistakenly assumed that it's safe to call `_preprocess_array()` right away, but that function assumes `reduce_axis` and `out_axis` being legitimate. 
2. If an exception is raised (in this case, `_preprocess_array()` raised an unexpected `AssertionError`), we should propagate it.

cc: @grlee77 