### PR TITLE
add multi-axis support to cupy.flip

### DIFF
--- a/cupy/manipulation/rearrange.py
+++ b/cupy/manipulation/rearrange.py
@@ -3,10 +3,12 @@ import itertools
 import numpy
 
 import cupy
-from cupy.core._reduction import _get_axis
+from cupy import util
+from cupy.core import _reduction
 
 
-def flip(a, axis):
+
+def flip(a, axis=None):
     """Reverse the order of elements in an array along the given axis.
 
     Note that ``flip`` function has been introduced since NumPy v1.12.
@@ -14,7 +16,11 @@ def flip(a, axis):
 
     Args:
         a (~cupy.ndarray): Input array.
-        axis (int): Axis in array, which entries are reversed.
+        axis (int or tuple of int or None): Axis or axes along which to flip
+            over. The default, ``axis=None``, will flip over all of the axes of
+            the input array. If axis is negative it counts from the last to the
+            first axis. If axis is a tuple of ints, flipping is performed on
+            all of the axes specified in the tuple.
 
     Returns:
         ~cupy.ndarray: Output array.
@@ -26,12 +32,8 @@ def flip(a, axis):
     if a_ndim < 1:
         raise numpy.AxisError('Input must be >= 1-d')
 
-    axis = int(axis)
-    if not -a_ndim <= axis < a_ndim:
-        raise numpy.AxisError(
-            'axis must be >= %d and < %d' % (-a_ndim, a_ndim))
-
-    return _flip(a, axis)
+    axes = util._normalize_axis_indices(axis, a_ndim)
+    return _flip(a, axes)
 
 
 def fliplr(a):
@@ -99,7 +101,7 @@ def roll(a, shift, axis=None):
     if axis is None:
         return roll(a.ravel(), shift, 0).reshape(a.shape)
     else:
-        axis = _get_axis(axis, a.ndim)[0]
+        axis = _reduction._get_axis(axis, a.ndim)[0]
 
         broadcasted = numpy.broadcast(shift, axis)
         if broadcasted.nd > 1:
@@ -160,20 +162,21 @@ def rot90(a, k=1, axes=(0, 1)):
     if k == 0:
         return a[:]
     if k == 2:
-        return _flip(_flip(a, axes[0]), axes[1])
+        return _flip(a, axes)
 
     axes_t = list(range(0, a_ndim))
     axes_t[axes[0]], axes_t[axes[1]] = axes_t[axes[1]], axes_t[axes[0]]
 
     if k == 1:
-        return cupy.transpose(_flip(a, axes[1]), axes_t)
+        return cupy.transpose(_flip(a, (axes[1],)), axes_t)
     else:
-        return _flip(cupy.transpose(a, axes_t), axes[1])
+        return _flip(cupy.transpose(a, axes_t), (axes[1],))
 
 
-def _flip(a, axis):
+def _flip(a, axes):
     # This function flips array without checking args.
     indexer = [slice(None)] * a.ndim
-    indexer[axis] = slice(None, None, -1)
+    for ax in axes:
+        indexer[ax] = slice(None, None, -1)
 
     return a[tuple(indexer)]

--- a/cupy/manipulation/rearrange.py
+++ b/cupy/manipulation/rearrange.py
@@ -7,7 +7,6 @@ from cupy import util
 from cupy.core import _reduction
 
 
-
 def flip(a, axis=None):
     """Reverse the order of elements in an array along the given axis.
 

--- a/tests/cupy_tests/manipulation_tests/test_rearrange.py
+++ b/tests/cupy_tests/manipulation_tests/test_rearrange.py
@@ -218,9 +218,21 @@ class TestFlip(unittest.TestCase):
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
+    def test_flip_all(self, xp, dtype):
+        x = testing.shaped_arange((3, 4), xp, dtype)
+        return xp.flip(x)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
     def test_flip_with_negative_axis(self, xp, dtype):
         x = testing.shaped_arange((3, 4, 2), xp, dtype)
         return xp.flip(x, -1)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_flip_with_axis_tuple(self, xp, dtype):
+        x = testing.shaped_arange((3, 4, 2), xp, dtype)
+        return xp.flip(x, (0, 2))
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
@@ -239,6 +251,12 @@ class TestFlip(unittest.TestCase):
     def test_flip_empty_dim_3(self, xp, dtype):
         x = xp.array([], dtype).reshape((1, 0, 1))
         return xp.flip(x, 1)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_flip_empty_dim_all(self, xp, dtype):
+        x = xp.array([], dtype).reshape((1, 0, 1))
+        return xp.flip(x)
 
     @testing.for_all_dtypes()
     def test_flip_insufficient_ndim(self, dtype):


### PR DESCRIPTION
This PR updates axis handling in `cupy.flip` to be consistent with NumPy 1.15+