### PR TITLE
Extend test helper coverage; simplify CUB axis test

### DIFF
--- a/cupy/core/_cub_reduction.pyx
+++ b/cupy/core/_cub_reduction.pyx
@@ -263,9 +263,9 @@ cpdef inline tuple _can_use_cub_block_reduction(
 
     # check reduction axes, if not contiguous then fall back to old kernel
     if in_arr._f_contiguous:
-        axis_permutes_cub = tuple(sorted(reduce_axis) + sorted(out_axis))
+        axis_permutes_cub = reduce_axis + out_axis
     elif in_arr._c_contiguous:
-        axis_permutes_cub = tuple(sorted(out_axis) + sorted(reduce_axis))
+        axis_permutes_cub = out_axis + reduce_axis
     else:
         return None
     if axis_permutes_cub != tuple(range(in_arr.ndim)):

--- a/cupy/testing/helper.py
+++ b/cupy/testing/helper.py
@@ -1077,8 +1077,10 @@ def for_contiguous_axes(name='axis'):
     .. note::
         1. Adapted from tests/cupy_tests/fft_tests/test_fft.py.
         2. Example: for ``shape = (1, 2, 3)``, the tested axes are
-            ``[(2,), (1, 2), (0, 1, 2)]`` for the C order, and
-            ``[(0,), (0, 1), (0, 1, 2)]`` for the F order.
+            ``[(0, 1, 2), (-3, -2, -1), (1, 2), (-2, -1), (2,), (-1,)]`` for
+            the C order, and
+            ``[(0,), (-3,), (0, 1), (-3, -2), (0, 1, 2), (-3, -2, -1)]`` for
+            the F order.
     '''
     def decorator(impl):
         @functools.wraps(impl)
@@ -1096,6 +1098,9 @@ def for_contiguous_axes(name='axis'):
                 else:
                     raise ValueError('Please specify the array order.')
                 try:
+                    kw[name] = a
+                    impl(self, *args, **kw)
+                    a = tuple(i - ndim for i in a)
                     kw[name] = a
                     impl(self, *args, **kw)
                 except Exception:

--- a/cupy/testing/helper.py
+++ b/cupy/testing/helper.py
@@ -1100,7 +1100,7 @@ def for_contiguous_axes(name='axis'):
                 try:
                     kw[name] = a
                     impl(self, *args, **kw)
-                    a = tuple(i - ndim for i in a)
+                    a = tuple([i - ndim for i in a])
                     kw[name] = a
                     impl(self, *args, **kw)
                 except Exception:

--- a/tests/cupy_tests/core_tests/test_cub_reduction.py
+++ b/tests/cupy_tests/core_tests/test_cub_reduction.py
@@ -49,6 +49,8 @@ class TestSimpleCubReductionKernelContiguity(CubReductionTestBase):
     def test_can_use_cub_contiguous(self, axis):
         r_axis = axis
         i_shape = self.shape
+        dim = len(i_shape)
+        r_axis = tuple(ax % dim for ax in r_axis)
         o_axis = tuple(i for i in range(len(i_shape)) if i not in r_axis)
         o_shape = tuple(self.shape[i] for i in o_axis)
         self._test_can_use(i_shape, o_shape, r_axis, o_axis, self.order, True)
@@ -58,6 +60,7 @@ class TestSimpleCubReductionKernelContiguity(CubReductionTestBase):
         # array is contiguous, but reduce_axis is not
         dim = len(self.shape)
         r_dim = len(axis)
+        axis = tuple([ax % dim for ax in axis])
         non_contiguous_axes = [i for i in combinations(range(dim), r_dim)
                                if i != axis]
 


### PR DESCRIPTION
Split from #3740. This PR does two things:
1. Cover more valid contiguous axes for the tests: now negative axes are also tested. 
2. Improve `_can_use_cub_block_reduction()`: the tuples `out_axis` and `reduce_axis` there are returned by `_get_axis()`, which makes the axes always sorted and positive, so we can simply join them as we do in `cupy.cuda.cub._preprocess_array()`. But, this also means that for its tests we need to convert the negative axes to positive ones. Thanks @grlee77 for suggestions!