### PR TITLE
Skip FFT input checks for some CUDA >= 10.1 cases

### DIFF
--- a/cupy/fft/fft.py
+++ b/cupy/fft/fft.py
@@ -703,6 +703,7 @@ def irfft(a, n=None, axis=-1, norm=None):
 
     Args:
         a (cupy.ndarray): Array to be transform.
+            WARNING: May be modified in CUDA 10.1 and above.
         n (None or int): Length of the transformed axis of the output. For
             ``n`` output points, ``n//2+1`` input points are necessary. If
             ``n`` is not given, it is determined from the length of the input
@@ -750,6 +751,7 @@ def irfft2(a, s=None, axes=(-2, -1), norm=None):
 
     Args:
         a (cupy.ndarray): Array to be transform.
+            WARNING: May be modified in CUDA 10.1 and above.
         s (None or tuple of ints): Shape of the output. If ``s`` is not given,
             they are determined from the lengths of the input along the axes
             specified by ``axes``.

--- a/cupy/fft/fft.py
+++ b/cupy/fft/fft.py
@@ -703,7 +703,6 @@ def irfft(a, n=None, axis=-1, norm=None):
 
     Args:
         a (cupy.ndarray): Array to be transform.
-            WARNING: May be modified in CUDA 10.1 and above.
         n (None or int): Length of the transformed axis of the output. For
             ``n`` output points, ``n//2+1`` input points are necessary. If
             ``n`` is not given, it is determined from the length of the input
@@ -717,6 +716,8 @@ def irfft(a, n=None, axis=-1, norm=None):
             will convert to complex if the input is other. If ``n`` is not
             given, the length of the transformed axis is`2*(m-1)` where `m`
             is the length of the transformed axis of the input.
+
+    .. warning:: The input array may be modified in CUDA 10.1 and above.
 
     .. seealso:: :func:`numpy.fft.irfft`
     """
@@ -751,7 +752,6 @@ def irfft2(a, s=None, axes=(-2, -1), norm=None):
 
     Args:
         a (cupy.ndarray): Array to be transform.
-            WARNING: May be modified in CUDA 10.1 and above.
         s (None or tuple of ints): Shape of the output. If ``s`` is not given,
             they are determined from the lengths of the input along the axes
             specified by ``axes``.
@@ -765,6 +765,8 @@ def irfft2(a, s=None, axes=(-2, -1), norm=None):
             given, the length of final transformed axis of output will be
             `2*(m-1)` where `m` is the length of the final transformed axis of
             the input.
+
+    .. warning:: The input array may be modified in CUDA 10.1 and above.
 
     .. seealso:: :func:`numpy.fft.irfft2`
     """
@@ -822,6 +824,8 @@ def irfftn(a, s=None, axes=None, norm=None):
             given, the length of final transformed axis of output will be
             ``2*(m-1)`` where `m` is the length of the final transformed axis
             of the input.
+
+    .. warning:: The input array may be modified in CUDA 10.1 and above.
 
     .. seealso:: :func:`numpy.fft.irfftn`
     """

--- a/cupyx/scipy/fft/fft.py
+++ b/cupyx/scipy/fft/fft.py
@@ -333,6 +333,9 @@ def irfft(x, n=None, axis=-1, norm=None, overwrite_x=False, *, plan=None):
         cupy.ndarray:
             The transformed array.
 
+    .. warning:: The input array may be modified in CUDA 10.1 and above, even
+                 when `overwrite_x is False`.
+
     .. seealso:: :func:`scipy.fft.irfft`
     """
     return _fft(x, (n,), (axis,), norm, cufft.CUFFT_INVERSE, 'C2R',
@@ -401,6 +404,9 @@ def irfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, *,
             given, the length of final transformed axis of output will be
             `2*(m-1)` where `m` is the length of the final transformed axis of
             the input.
+
+    .. warning:: The input array may be modified in CUDA 10.1 and above, even
+                 when `overwrite_x is False`.
 
     .. seealso:: :func:`scipy.fft.irfft2`
     """
@@ -471,6 +477,9 @@ def irfftn(x, s=None, axes=None, norm=None, overwrite_x=False, *, plan=None):
             given, the length of final transformed axis of output will be
             ``2*(m-1)`` where `m` is the length of the final transformed axis
             of the input.
+
+    .. warning:: The input array may be modified in CUDA 10.1 and above, even
+                 when `overwrite_x is False`.
 
     .. seealso:: :func:`scipy.fft.irfftn`
     """

--- a/cupyx/scipy/fftpack/fft.py
+++ b/cupyx/scipy/fftpack/fft.py
@@ -426,6 +426,9 @@ def irfft(x, n=None, axis=-1, overwrite_x=False):
        This function does not support a precomputed `plan`. If you need this
        capability, please consider using :func:`cupy.fft.irfft` or :func:`
        cupyx.scipy.fft.irfft`.
+
+    .. warning:: The input array may be modified in CUDA 10.1 and above, even
+                 when `overwrite_x is False`.
     """
     if n is None:
         n = x.shape[axis]

--- a/tests/cupyx_tests/scipy_tests/fft_tests/test_fft.py
+++ b/tests/cupyx_tests/scipy_tests/fft_tests/test_fft.py
@@ -1492,7 +1492,7 @@ class TestRfftn(unittest.TestCase):
 class TestHfft(unittest.TestCase):
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose(rtol=2e-4, atol=1e-7, accept_error=ValueError,
+    @testing.numpy_cupy_allclose(rtol=4e-4, atol=1e-7, accept_error=ValueError,
                                  contiguous_check=False)
     def test_hfft(self, xp, dtype):
         x = testing.shaped_random(self.shape, xp, dtype)
@@ -1502,7 +1502,7 @@ class TestHfft(unittest.TestCase):
         return _correct_np_dtype(xp, dtype, out)
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose(rtol=2e-4, atol=1e-7, accept_error=ValueError,
+    @testing.numpy_cupy_allclose(rtol=4e-4, atol=1e-7, accept_error=ValueError,
                                  contiguous_check=False)
     def test_hfft_overwrite(self, xp, dtype):
         x = testing.shaped_random(self.shape, xp, dtype)
@@ -1521,7 +1521,7 @@ class TestHfft(unittest.TestCase):
 
     @testing.with_requires('scipy>=1.4.0')
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose(rtol=2e-4, atol=1e-7, accept_error=ValueError,
+    @testing.numpy_cupy_allclose(rtol=4e-4, atol=1e-7, accept_error=ValueError,
                                  contiguous_check=False)
     def test_hfft_backend(self, xp, dtype):
         x = testing.shaped_random(self.shape, xp, dtype)

--- a/tests/cupyx_tests/scipy_tests/fft_tests/test_fft.py
+++ b/tests/cupyx_tests/scipy_tests/fft_tests/test_fft.py
@@ -1103,7 +1103,12 @@ class TestRfft2(unittest.TestCase):
         x_orig = x.copy()
         out = _fft_module(xp).irfft2(x, s=self.s, axes=self.axes,
                                      norm=self.norm)
-        testing.assert_array_equal(x, x_orig)
+
+        # CUDA 10.1 and above may modify input, this fails for complex64
+        if (cp.cuda.runtime.runtimeGetVersion() <= 10000 and
+                dtype is np.complex64):
+            testing.assert_array_equal(x, x_orig)
+
         return _correct_np_dtype(xp, dtype, out)
 
     @pytest.mark.skipif(int(cp.cuda.device.get_compute_capability()) < 70 and
@@ -1141,7 +1146,12 @@ class TestRfft2(unittest.TestCase):
             kw = {}
         out = _fft_module(xp).irfft2(
             x, s=self.s, axes=self.axes, norm=self.norm, **kw)
-        testing.assert_array_equal(x, x_orig)
+
+        # CUDA 10.1 and above may modify input, this fails for complex64
+        if (cp.cuda.runtime.runtimeGetVersion() <= 10000 and
+                dtype is np.complex64):
+            testing.assert_array_equal(x, x_orig)
+
         return _correct_np_dtype(xp, dtype, out)
 
     @pytest.mark.skipif(int(cp.cuda.device.get_compute_capability()) < 70,
@@ -1191,7 +1201,12 @@ class TestRfft2(unittest.TestCase):
             assert get_current_plan() is None
         else:
             out = _fft_module(xp).irfft2(x, s=self.s, axes=self.axes)
-        testing.assert_array_equal(x, x_orig)
+
+        # CUDA 10.1 and above may modify input, this fails for complex64
+        if (cp.cuda.runtime.runtimeGetVersion() <= 10000 and
+                dtype is np.complex64):
+            testing.assert_array_equal(x, x_orig)
+
         return _correct_np_dtype(xp, dtype, out)
 
     @pytest.mark.skipif(int(cp.cuda.device.get_compute_capability()) < 70 and
@@ -1344,7 +1359,12 @@ class TestRfftn(unittest.TestCase):
         x_orig = x.copy()
         out = _fft_module(xp).irfftn(x, s=self.s, axes=self.axes,
                                      norm=self.norm)
-        testing.assert_array_equal(x, x_orig)
+
+        # CUDA 10.1 and above may modify input, this fails for complex64
+        if (cp.cuda.runtime.runtimeGetVersion() <= 10000 and
+                dtype is np.complex64):
+            testing.assert_array_equal(x, x_orig)
+
         return _correct_np_dtype(xp, dtype, out)
 
     @pytest.mark.skipif(int(cp.cuda.device.get_compute_capability()) < 70 and
@@ -1382,7 +1402,12 @@ class TestRfftn(unittest.TestCase):
             kw = {}
         out = _fft_module(xp).irfftn(
             x, s=self.s, axes=self.axes, norm=self.norm, **kw)
-        testing.assert_array_equal(x, x_orig)
+
+        # CUDA 10.1 and above may modify input, this fails for complex64
+        if (cp.cuda.runtime.runtimeGetVersion() <= 10000 and
+                dtype is np.complex64):
+            testing.assert_array_equal(x, x_orig)
+
         return _correct_np_dtype(xp, dtype, out)
 
     @pytest.mark.skipif(int(cp.cuda.device.get_compute_capability()) < 70,
@@ -1432,7 +1457,12 @@ class TestRfftn(unittest.TestCase):
             assert get_current_plan() is None
         else:
             out = _fft_module(xp).irfftn(x, s=self.s, axes=self.axes)
-        testing.assert_array_equal(x, x_orig)
+
+        # CUDA 10.1 and above may modify input, this fails for complex64
+        if (cp.cuda.runtime.runtimeGetVersion() <= 10000 and
+                dtype is np.complex64):
+            testing.assert_array_equal(x, x_orig)
+
         return _correct_np_dtype(xp, dtype, out)
 
     @pytest.mark.skipif(int(cp.cuda.device.get_compute_capability()) < 70 and

--- a/tests/cupyx_tests/scipy_tests/fft_tests/test_fft.py
+++ b/tests/cupyx_tests/scipy_tests/fft_tests/test_fft.py
@@ -1492,7 +1492,7 @@ class TestRfftn(unittest.TestCase):
 class TestHfft(unittest.TestCase):
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
+    @testing.numpy_cupy_allclose(rtol=2e-4, atol=1e-7, accept_error=ValueError,
                                  contiguous_check=False)
     def test_hfft(self, xp, dtype):
         x = testing.shaped_random(self.shape, xp, dtype)
@@ -1502,7 +1502,7 @@ class TestHfft(unittest.TestCase):
         return _correct_np_dtype(xp, dtype, out)
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
+    @testing.numpy_cupy_allclose(rtol=2e-4, atol=1e-7, accept_error=ValueError,
                                  contiguous_check=False)
     def test_hfft_overwrite(self, xp, dtype):
         x = testing.shaped_random(self.shape, xp, dtype)
@@ -1521,7 +1521,7 @@ class TestHfft(unittest.TestCase):
 
     @testing.with_requires('scipy>=1.4.0')
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
+    @testing.numpy_cupy_allclose(rtol=2e-4, atol=1e-7, accept_error=ValueError,
                                  contiguous_check=False)
     def test_hfft_backend(self, xp, dtype):
         x = testing.shaped_random(self.shape, xp, dtype)

--- a/tests/cupyx_tests/scipy_tests/fft_tests/test_fft.py
+++ b/tests/cupyx_tests/scipy_tests/fft_tests/test_fft.py
@@ -1106,7 +1106,7 @@ class TestRfft2(unittest.TestCase):
 
         # CUDA 10.1 and above may modify input, this fails for complex64
         if (cp.cuda.runtime.runtimeGetVersion() <= 10000 or
-                dtype is not np.complex64):
+                dtype not in [np.complex64, np.complex128]):
             testing.assert_array_equal(x, x_orig)
 
         return _correct_np_dtype(xp, dtype, out)
@@ -1149,7 +1149,7 @@ class TestRfft2(unittest.TestCase):
 
         # CUDA 10.1 and above may modify input, this fails for complex64
         if (cp.cuda.runtime.runtimeGetVersion() <= 10000 or
-                dtype is not np.complex64):
+                dtype not in [np.complex64, np.complex128]):
             testing.assert_array_equal(x, x_orig)
 
         return _correct_np_dtype(xp, dtype, out)
@@ -1204,7 +1204,7 @@ class TestRfft2(unittest.TestCase):
 
         # CUDA 10.1 and above may modify input, this fails for complex64
         if (cp.cuda.runtime.runtimeGetVersion() <= 10000 or
-                dtype is not np.complex64):
+                dtype not in [np.complex64, np.complex128]):
             testing.assert_array_equal(x, x_orig)
 
         return _correct_np_dtype(xp, dtype, out)
@@ -1362,7 +1362,7 @@ class TestRfftn(unittest.TestCase):
 
         # CUDA 10.1 and above may modify input, this fails for complex64
         if (cp.cuda.runtime.runtimeGetVersion() <= 10000 or
-                dtype is not np.complex64):
+                dtype not in [np.complex64, np.complex128]):
             testing.assert_array_equal(x, x_orig)
 
         return _correct_np_dtype(xp, dtype, out)
@@ -1405,7 +1405,7 @@ class TestRfftn(unittest.TestCase):
 
         # CUDA 10.1 and above may modify input, this fails for complex64
         if (cp.cuda.runtime.runtimeGetVersion() <= 10000 or
-                dtype is not np.complex64):
+                dtype not in [np.complex64, np.complex128]):
             testing.assert_array_equal(x, x_orig)
 
         return _correct_np_dtype(xp, dtype, out)
@@ -1460,7 +1460,7 @@ class TestRfftn(unittest.TestCase):
 
         # CUDA 10.1 and above may modify input, this fails for complex64
         if (cp.cuda.runtime.runtimeGetVersion() <= 10000 or
-                dtype is not np.complex64):
+                dtype not in [np.complex64, np.complex128]):
             testing.assert_array_equal(x, x_orig)
 
         return _correct_np_dtype(xp, dtype, out)

--- a/tests/cupyx_tests/scipy_tests/fft_tests/test_fft.py
+++ b/tests/cupyx_tests/scipy_tests/fft_tests/test_fft.py
@@ -1105,8 +1105,8 @@ class TestRfft2(unittest.TestCase):
                                      norm=self.norm)
 
         # CUDA 10.1 and above may modify input, this fails for complex64
-        if (cp.cuda.runtime.runtimeGetVersion() <= 10000 and
-                dtype is np.complex64):
+        if (cp.cuda.runtime.runtimeGetVersion() <= 10000 or
+                dtype is not np.complex64):
             testing.assert_array_equal(x, x_orig)
 
         return _correct_np_dtype(xp, dtype, out)
@@ -1148,8 +1148,8 @@ class TestRfft2(unittest.TestCase):
             x, s=self.s, axes=self.axes, norm=self.norm, **kw)
 
         # CUDA 10.1 and above may modify input, this fails for complex64
-        if (cp.cuda.runtime.runtimeGetVersion() <= 10000 and
-                dtype is np.complex64):
+        if (cp.cuda.runtime.runtimeGetVersion() <= 10000 or
+                dtype is not np.complex64):
             testing.assert_array_equal(x, x_orig)
 
         return _correct_np_dtype(xp, dtype, out)
@@ -1203,8 +1203,8 @@ class TestRfft2(unittest.TestCase):
             out = _fft_module(xp).irfft2(x, s=self.s, axes=self.axes)
 
         # CUDA 10.1 and above may modify input, this fails for complex64
-        if (cp.cuda.runtime.runtimeGetVersion() <= 10000 and
-                dtype is np.complex64):
+        if (cp.cuda.runtime.runtimeGetVersion() <= 10000 or
+                dtype is not np.complex64):
             testing.assert_array_equal(x, x_orig)
 
         return _correct_np_dtype(xp, dtype, out)
@@ -1361,8 +1361,8 @@ class TestRfftn(unittest.TestCase):
                                      norm=self.norm)
 
         # CUDA 10.1 and above may modify input, this fails for complex64
-        if (cp.cuda.runtime.runtimeGetVersion() <= 10000 and
-                dtype is np.complex64):
+        if (cp.cuda.runtime.runtimeGetVersion() <= 10000 or
+                dtype is not np.complex64):
             testing.assert_array_equal(x, x_orig)
 
         return _correct_np_dtype(xp, dtype, out)
@@ -1404,8 +1404,8 @@ class TestRfftn(unittest.TestCase):
             x, s=self.s, axes=self.axes, norm=self.norm, **kw)
 
         # CUDA 10.1 and above may modify input, this fails for complex64
-        if (cp.cuda.runtime.runtimeGetVersion() <= 10000 and
-                dtype is np.complex64):
+        if (cp.cuda.runtime.runtimeGetVersion() <= 10000 or
+                dtype is not np.complex64):
             testing.assert_array_equal(x, x_orig)
 
         return _correct_np_dtype(xp, dtype, out)
@@ -1459,8 +1459,8 @@ class TestRfftn(unittest.TestCase):
             out = _fft_module(xp).irfftn(x, s=self.s, axes=self.axes)
 
         # CUDA 10.1 and above may modify input, this fails for complex64
-        if (cp.cuda.runtime.runtimeGetVersion() <= 10000 and
-                dtype is np.complex64):
+        if (cp.cuda.runtime.runtimeGetVersion() <= 10000 or
+                dtype is not np.complex64):
             testing.assert_array_equal(x, x_orig)
 
         return _correct_np_dtype(xp, dtype, out)


### PR DESCRIPTION
Since CUDA 10.1, some of the behavior has changed with cuFFT to align it more closely to that of fftw, modifying the input in `cufftExecC2R`. Due to that, we prevent testing asserting that input wasn't indeed modified and document that as a warning to the user.

See https://github.com/cupy/cupy/issues/3736 for discussion.