### PR TITLE
Proposal: Support transforming NumPy arrays with multi-GPU `Plan1d`

### DIFF
--- a/cupy/cuda/cufft.pyx
+++ b/cupy/cuda/cufft.pyx
@@ -547,7 +547,7 @@ class Plan1d(object):
         assert isinstance(a, (cupy.ndarray, numpy.ndarray))
 
         start = 0
-        assert a._c_contiguous
+        assert a.flags.c_contiguous  # NumPy does not have _c_contiguous
         b = a.ravel()
         assert b.flags['OWNDATA'] is False
         assert self.xtArr_buffer is not None

--- a/cupy/cuda/cufft.pyx
+++ b/cupy/cuda/cufft.pyx
@@ -761,6 +761,8 @@ class PlanNd(object):
 
     def __del__(self):
         cdef Handle plan = self.plan
+        cdef int result
+
         if plan != 0:
             with nogil:
                 result = cufftDestroy(plan)
@@ -850,6 +852,7 @@ class PlanNd(object):
 
 
 cpdef execC2C(Handle plan, intptr_t idata, intptr_t odata, int direction):
+    cdef int result
     with nogil:
         result = cufftExecC2C(plan, <Complex*>idata, <Complex*>odata,
                               direction)
@@ -857,18 +860,21 @@ cpdef execC2C(Handle plan, intptr_t idata, intptr_t odata, int direction):
 
 
 cpdef execR2C(Handle plan, intptr_t idata, intptr_t odata):
+    cdef int result
     with nogil:
         result = cufftExecR2C(plan, <Float*>idata, <Complex*>odata)
     check_result(result)
 
 
 cpdef execC2R(Handle plan, intptr_t idata, intptr_t odata):
+    cdef int result
     with nogil:
         result = cufftExecC2R(plan, <Complex*>idata, <Float*>odata)
     check_result(result)
 
 
 cpdef execZ2Z(Handle plan, intptr_t idata, intptr_t odata, int direction):
+    cdef int result
     with nogil:
         result = cufftExecZ2Z(plan, <DoubleComplex*>idata,
                               <DoubleComplex*>odata, direction)
@@ -876,12 +882,14 @@ cpdef execZ2Z(Handle plan, intptr_t idata, intptr_t odata, int direction):
 
 
 cpdef execD2Z(Handle plan, intptr_t idata, intptr_t odata):
+    cdef int result
     with nogil:
         result = cufftExecD2Z(plan, <Double*>idata, <DoubleComplex*>odata)
     check_result(result)
 
 
 cpdef execZ2D(Handle plan, intptr_t idata, intptr_t odata):
+    cdef int result
     with nogil:
         result = cufftExecZ2D(plan, <DoubleComplex*>idata, <Double*>odata)
     check_result(result)
@@ -889,6 +897,7 @@ cpdef execZ2D(Handle plan, intptr_t idata, intptr_t odata):
 
 cpdef multi_gpu_execC2C(Handle plan, intptr_t idata, intptr_t odata,
                         int direction):
+    cdef int result
     with nogil:
         result = cufftXtExecDescriptorC2C(plan, <XtArray*>idata,
                                           <XtArray*>odata, direction)
@@ -897,6 +906,7 @@ cpdef multi_gpu_execC2C(Handle plan, intptr_t idata, intptr_t odata,
 
 cpdef multi_gpu_execZ2Z(Handle plan, intptr_t idata, intptr_t odata,
                         int direction):
+    cdef int result
     with nogil:
         result = cufftXtExecDescriptorZ2Z(plan, <XtArray*>idata,
                                           <XtArray*>odata, direction)

--- a/cupy/fft/fft.py
+++ b/cupy/fft/fft.py
@@ -155,6 +155,8 @@ def _fft_c2c(a, direction, norm, axes, overwrite_x, plan=None):
 
 def _fft(a, s, axes, norm, direction, value_type='C2C', overwrite_x=False,
          plan=None):
+    if isinstance(a, np.ndarray):
+        raise TypeError('The input array a must be a cupy.ndarray')
     if norm not in (None, 'ortho'):
         raise ValueError('Invalid norm value %s, should be None or "ortho".'
                          % norm)
@@ -475,6 +477,8 @@ def _exec_fftn(a, direction, value_type, norm, axes, overwrite_x,
 
 def _fftn(a, s, axes, norm, direction, value_type='C2C', order='A', plan=None,
           overwrite_x=False, out=None):
+    if isinstance(a, np.ndarray):
+        raise TypeError('The input array a must be a cupy.ndarray')
     if norm not in (None, 'ortho'):
         raise ValueError('Invalid norm value %s, should be None or "ortho".'
                          % norm)

--- a/tests/cupy_tests/cuda_tests/test_cufft.py
+++ b/tests/cupy_tests/cuda_tests/test_cufft.py
@@ -56,9 +56,6 @@ class TestMultiGpuPlan1dNumPy(unittest.TestCase):
         assert numpy.allclose(out_cp, out_np, rtol=1e-4, atol=1e-7)
 
         # compute it again to ensure Plan1d's internal state is reset
-        cufft_type = _convert_fft_type(a.dtype, 'C2C')
-        plan = cufft.Plan1d(nx, cufft_type, batch, devices=config._devices)
-        out_cp = numpy.empty_like(a)
         plan.fft(a, out_cp, cufft.CUFFT_FORWARD)
 
         assert numpy.allclose(out_cp, out_np, rtol=1e-4, atol=1e-7)
@@ -91,9 +88,6 @@ class TestMultiGpuPlan1dNumPy(unittest.TestCase):
         assert numpy.allclose(out_cp, out_np, rtol=1e-4, atol=1e-7)
 
         # compute it again to ensure Plan1d's internal state is reset
-        cufft_type = _convert_fft_type(a.dtype, 'C2C')
-        plan = cufft.Plan1d(nx, cufft_type, batch, devices=config._devices)
-        out_cp = numpy.empty_like(a)
         plan.fft(a, out_cp, cufft.CUFFT_INVERSE)
         # normalization
         out_cp /= nx

--- a/tests/cupy_tests/cuda_tests/test_cufft.py
+++ b/tests/cupy_tests/cuda_tests/test_cufft.py
@@ -1,7 +1,14 @@
 import pickle
 import unittest
 
+import numpy
+
+from cupy import testing
 from cupy.cuda import cufft
+from cupy.fft import config
+from cupy.fft.fft import _convert_fft_type
+
+from ..fft_tests.test_fft import multi_gpu_config
 
 
 class TestExceptionPicklable(unittest.TestCase):
@@ -11,3 +18,84 @@ class TestExceptionPicklable(unittest.TestCase):
         e2 = pickle.loads(pickle.dumps(e1))
         assert e1.args == e2.args
         assert str(e1) == str(e2)
+
+
+# This class tests multi-GPU Plan1d with data sitting on host.
+# Internally, we use cuFFT's data transfer API to ensure the
+# data is in order.
+
+@testing.parameterize(*testing.product({
+    'shape': [(64,), (4, 16), (128,), (8, 32)],
+}))
+@testing.multi_gpu(2)
+class TestMultiGpuPlan1dNumPy(unittest.TestCase):
+
+    @multi_gpu_config(gpu_configs=[[0, 1], [1, 0]])
+    @testing.for_complex_dtypes()
+    def test_fft(self, dtype):
+        a = testing.shaped_random(self.shape, numpy, dtype)
+
+        if len(self.shape) == 1:
+            batch = 1
+            nx = self.shape[0]
+        elif len(self.shape) == 2:
+            batch = self.shape[0]
+            nx = self.shape[1]
+
+        # compute via cuFFT
+        cufft_type = _convert_fft_type(a.dtype, 'C2C')
+        plan = cufft.Plan1d(nx, cufft_type, batch, devices=config._devices)
+        out_cp = numpy.empty_like(a)
+        plan.fft(a, out_cp, cufft.CUFFT_FORWARD)
+
+        out_np = numpy.fft.fft(a)
+        # np.fft.fft alway returns np.complex128
+        if dtype is numpy.complex64:
+            out_np = out_np.astype(dtype)
+
+        assert numpy.allclose(out_cp, out_np, rtol=1e-4, atol=1e-7)
+
+        # compute it again to ensure Plan1d's internal state is reset
+        cufft_type = _convert_fft_type(a.dtype, 'C2C')
+        plan = cufft.Plan1d(nx, cufft_type, batch, devices=config._devices)
+        out_cp = numpy.empty_like(a)
+        plan.fft(a, out_cp, cufft.CUFFT_FORWARD)
+
+        assert numpy.allclose(out_cp, out_np, rtol=1e-4, atol=1e-7)
+
+    @multi_gpu_config(gpu_configs=[[0, 1], [1, 0]])
+    @testing.for_complex_dtypes()
+    def test_ifft(self, dtype):
+        a = testing.shaped_random(self.shape, numpy, dtype)
+
+        if len(self.shape) == 1:
+            batch = 1
+            nx = self.shape[0]
+        elif len(self.shape) == 2:
+            batch = self.shape[0]
+            nx = self.shape[1]
+
+        # compute via cuFFT
+        cufft_type = _convert_fft_type(a.dtype, 'C2C')
+        plan = cufft.Plan1d(nx, cufft_type, batch, devices=config._devices)
+        out_cp = numpy.empty_like(a)
+        plan.fft(a, out_cp, cufft.CUFFT_INVERSE)
+        # normalization
+        out_cp /= nx
+
+        out_np = numpy.fft.ifft(a)
+        # np.fft.fft alway returns np.complex128
+        if dtype is numpy.complex64:
+            out_np = out_np.astype(dtype)
+
+        assert numpy.allclose(out_cp, out_np, rtol=1e-4, atol=1e-7)
+
+        # compute it again to ensure Plan1d's internal state is reset
+        cufft_type = _convert_fft_type(a.dtype, 'C2C')
+        plan = cufft.Plan1d(nx, cufft_type, batch, devices=config._devices)
+        out_cp = numpy.empty_like(a)
+        plan.fft(a, out_cp, cufft.CUFFT_INVERSE)
+        # normalization
+        out_cp /= nx
+
+        assert numpy.allclose(out_cp, out_np, rtol=1e-4, atol=1e-7)

--- a/tests/cupy_tests/cuda_tests/test_cufft.py
+++ b/tests/cupy_tests/cuda_tests/test_cufft.py
@@ -3,13 +3,12 @@ import unittest
 
 import numpy
 
-import cupy
 from cupy import testing
 from cupy.cuda import cufft
 from cupy.fft import config
 from cupy.fft.fft import _convert_fft_type
 
-from ..fft_tests.test_fft import multi_gpu_config
+from ..fft_tests.test_fft import (multi_gpu_config, _skip_multi_gpu_bug)
 
 
 class TestExceptionPicklable(unittest.TestCase):
@@ -34,13 +33,7 @@ class TestMultiGpuPlan1dNumPy(unittest.TestCase):
     @multi_gpu_config(gpu_configs=[[0, 1], [1, 0]])
     @testing.for_complex_dtypes()
     def test_fft(self, dtype):
-        # avoid CUDA 11 bug triggered by
-        # - batch = 1
-        # - gpus = [1, 0]
-        if (cupy.cuda.runtime.runtimeGetVersion() == 11000
-                and len(self.shape) == 1
-                and self.gpus == [1, 0]):
-            self.skipTest('avoid CUDA 11 bug')
+        _skip_multi_gpu_bug(self.shape, self.gpus)
 
         a = testing.shaped_random(self.shape, numpy, dtype)
 
@@ -72,13 +65,7 @@ class TestMultiGpuPlan1dNumPy(unittest.TestCase):
     @multi_gpu_config(gpu_configs=[[0, 1], [1, 0]])
     @testing.for_complex_dtypes()
     def test_ifft(self, dtype):
-        # avoid CUDA 11 bug triggered by
-        # - batch = 1
-        # - gpus = [1, 0]
-        if (cupy.cuda.runtime.runtimeGetVersion() == 11000
-                and len(self.shape) == 1
-                and self.gpus == [1, 0]):
-            self.skipTest('avoid CUDA 11 bug')
+        _skip_multi_gpu_bug(self.shape, self.gpus)
 
         a = testing.shaped_random(self.shape, numpy, dtype)
 

--- a/tests/cupy_tests/cuda_tests/test_cufft.py
+++ b/tests/cupy_tests/cuda_tests/test_cufft.py
@@ -3,6 +3,7 @@ import unittest
 
 import numpy
 
+import cupy
 from cupy import testing
 from cupy.cuda import cufft
 from cupy.fft import config
@@ -33,6 +34,14 @@ class TestMultiGpuPlan1dNumPy(unittest.TestCase):
     @multi_gpu_config(gpu_configs=[[0, 1], [1, 0]])
     @testing.for_complex_dtypes()
     def test_fft(self, dtype):
+        # avoid CUDA 11 bug triggered by
+        # - batch = 1
+        # - gpus = [1, 0]
+        if (cupy.cuda.runtime.runtimeGetVersion() == 11000
+                and len(self.shape) == 1
+                and self.gpus == [1, 0]):
+            self.skipTest('avoid CUDA 11 bug')
+
         a = testing.shaped_random(self.shape, numpy, dtype)
 
         if len(self.shape) == 1:
@@ -63,6 +72,14 @@ class TestMultiGpuPlan1dNumPy(unittest.TestCase):
     @multi_gpu_config(gpu_configs=[[0, 1], [1, 0]])
     @testing.for_complex_dtypes()
     def test_ifft(self, dtype):
+        # avoid CUDA 11 bug triggered by
+        # - batch = 1
+        # - gpus = [1, 0]
+        if (cupy.cuda.runtime.runtimeGetVersion() == 11000
+                and len(self.shape) == 1
+                and self.gpus == [1, 0]):
+            self.skipTest('avoid CUDA 11 bug')
+
         a = testing.shaped_random(self.shape, numpy, dtype)
 
         if len(self.shape) == 1:


### PR DESCRIPTION
Follow-up of #2644. Close #1429, close #2742, and address https://github.com/cupy/cupy/issues/2742#issuecomment-608951598.

This PR supports `Plan1d.fft(a, b, direction)` with `a` and `b` being NumPy arrays. The main purpose is to transform a massive dataset that single GPUs cannot hold (which to me is one of the biggest motivations to do multi-GPU FFTs). 

No real code is added in this PR, only tests --- all of the work was done in #2644, but the NumPy support at both low- and high- levels were commented out in 3e2b7d0 and 705fe1a, respectively, and this PR restores the former so that advanced users can allocate and use `Plan1d` if needed. **This PR does not affect any high-level APIs** such as `cupy.fft.fft()`.

I also made a few variables cdef'd, but this is just a very minor code fix.