### PR TITLE
Show numpy and scipy versions in `show_config`

### DIFF
--- a/cupyx/_runtime.py
+++ b/cupyx/_runtime.py
@@ -175,6 +175,8 @@ class _RuntimeInfo(object):
     def __str__(self):
         records = [
             ('CuPy Version', self.cupy_version),
+            ('NumPy Version', self.numpy_version),
+            ('SciPy Version', self.scipy_version),
             ('CUDA Root', self.cuda_path),
 
             ('CUDA Build Version', self.cuda_build_version),
@@ -200,11 +202,6 @@ class _RuntimeInfo(object):
             ('NCCL Build Version', self.nccl_build_version),
             ('NCCL Runtime Version', self.nccl_runtime_version),
             ('cuTENSOR Version', self.cutensor_version),
-        ]
-
-        records += [
-            ('NumPy Version', self.numpy_version),
-            ('SciPy Version', self.scipy_version),
         ]
 
         width = max([len(r[0]) for r in records]) + 2

--- a/cupyx/_runtime.py
+++ b/cupyx/_runtime.py
@@ -1,6 +1,7 @@
 import inspect
 import io
 import os
+import platform
 
 import cupy
 import numpy
@@ -174,6 +175,7 @@ class _RuntimeInfo(object):
 
     def __str__(self):
         records = [
+            ('OS',  platform.platform())
             ('CuPy Version', self.cupy_version),
             ('NumPy Version', self.numpy_version),
             ('SciPy Version', self.scipy_version),
@@ -203,6 +205,13 @@ class _RuntimeInfo(object):
             ('NCCL Runtime Version', self.nccl_runtime_version),
             ('cuTENSOR Version', self.cutensor_version),
         ]
+
+        for device_id in range(cupy.cuda.runtime.getDeviceCount()):
+            with cupy.cuda.Device(device_id) as device:
+                records += [
+                    ('Device Name', device.attributes),
+                    ('Compute Capability', device.compute_capability),
+                ]
 
         width = max([len(r[0]) for r in records]) + 2
         fmt = '{:' + str(width) + '}: {}\n'

--- a/cupyx/_runtime.py
+++ b/cupyx/_runtime.py
@@ -3,8 +3,9 @@ import io
 import os
 import platform
 
-import cupy
 import numpy
+
+import cupy
 
 try:
     import cupy.cuda.thrust as thrust

--- a/cupyx/_runtime.py
+++ b/cupyx/_runtime.py
@@ -175,7 +175,7 @@ class _RuntimeInfo(object):
 
     def __str__(self):
         records = [
-            ('OS',  platform.platform())
+            ('OS',  platform.platform()),
             ('CuPy Version', self.cupy_version),
             ('NumPy Version', self.numpy_version),
             ('SciPy Version', self.scipy_version),

--- a/cupyx/_runtime.py
+++ b/cupyx/_runtime.py
@@ -208,9 +208,12 @@ class _RuntimeInfo(object):
 
         for device_id in range(cupy.cuda.runtime.getDeviceCount()):
             with cupy.cuda.Device(device_id) as device:
+                props = cupy.cuda.runtime.getDeviceProperties(device_id)
                 records += [
-                    ('Device Name', device.attributes),
-                    ('Compute Capability', device.compute_capability),
+                    ('Device {} Name'.format(device_id),
+                     props['name'].decode('utf-8')),
+                    ('Device {} Compute Capability'.format(device_id),
+                     device.compute_capability),
                 ]
 
         width = max([len(r[0]) for r in records]) + 2

--- a/cupyx/_runtime.py
+++ b/cupyx/_runtime.py
@@ -3,6 +3,7 @@ import io
 import os
 
 import cupy
+import numpy
 
 try:
     import cupy.cuda.thrust as thrust
@@ -28,6 +29,11 @@ try:
     import cupy_backends.cuda.libs.cutensor as cutensor
 except ImportError:
     cutensor = None
+
+try:
+    import scipy
+except ImportError:
+    scipy = None
 
 
 def _eval_or_error(func, errors):
@@ -103,6 +109,9 @@ class _RuntimeInfo(object):
     cub_build_version = None
     cutensor_version = None
 
+    numpy_version = None
+    scipy_version = None
+
     def __init__(self):
         self.cupy_version = cupy.__version__
 
@@ -159,6 +168,10 @@ class _RuntimeInfo(object):
         if cutensor is not None:
             self.cutensor_version = cutensor.get_version()
 
+        self.numpy_version = numpy.version.full_version
+        if scipy is not None:
+            self.scipy_version = scipy.version.full_version
+
     def __str__(self):
         records = [
             ('CuPy Version', self.cupy_version),
@@ -187,6 +200,11 @@ class _RuntimeInfo(object):
             ('NCCL Build Version', self.nccl_build_version),
             ('NCCL Runtime Version', self.nccl_runtime_version),
             ('cuTENSOR Version', self.cutensor_version),
+        ]
+
+        records += [
+            ('NumPy Version', self.numpy_version),
+            ('SciPy Version', self.scipy_version),
         ]
 
         width = max([len(r[0]) for r in records]) + 2


### PR DESCRIPTION
Currently `cupy.show_config` only shows cuda related info.
In order to easily lookup for errors in CI and locally, printing numpy and scipy versions as well can be helpful.

Blocked by #3858 and #3877