### PR TITLE
[backport] Allow `MatDescriptor` to be pickle-able

### DIFF
--- a/cupy/cusparse.py
+++ b/cupy/cusparse.py
@@ -21,6 +21,9 @@ class MatDescriptor(object):
         descr = cusparse.createMatDescr()
         return MatDescriptor(descr)
 
+    def __reduce__(self):
+        return self.create, ()
+
     def __del__(self, is_shutting_down=util.is_shutting_down):
         if is_shutting_down():
             return

--- a/tests/cupy_tests/test_cusparse.py
+++ b/tests/cupy_tests/test_cusparse.py
@@ -1,3 +1,4 @@
+import pickle
 import unittest
 
 import numpy
@@ -9,7 +10,21 @@ except ImportError:
 
 import cupy
 from cupy import testing
+from cupy import cusparse
 from cupyx.scipy import sparse
+
+
+class TestMatDescriptor(unittest.TestCase):
+
+    def test_create(self):
+        md = cusparse.MatDescriptor.create()
+        assert isinstance(md.descriptor, int)
+
+    def test_pickle(self):
+        md = cusparse.MatDescriptor.create()
+        md2 = pickle.loads(pickle.dumps(md))
+        assert isinstance(md2.descriptor, int)
+        assert md.descriptor != md2.descriptor
 
 
 @testing.parameterize(*testing.product({

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_coo.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_coo.py
@@ -1,3 +1,4 @@
+import pickle
 import unittest
 
 import numpy
@@ -163,6 +164,14 @@ class TestCooMatrix(unittest.TestCase):
         assert len(n.col) == len(m.col)
         assert n.shape == m.shape
         return n
+
+    def test_pickle_roundtrip(self):
+        s = _make(cupy, sparse, self.dtype)
+        s2 = pickle.loads(pickle.dumps(s))
+        assert s.shape == s2.shape
+        assert s.dtype == s2.dtype
+        if scipy_available:
+            assert (s.get() != s2.get()).count_nonzero() == 0
 
     def test_shape(self):
         self.assertEqual(self.m.shape, (3, 4))

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
@@ -1,3 +1,4 @@
+import pickle
 import unittest
 
 import numpy
@@ -254,6 +255,15 @@ class TestCscMatrix(unittest.TestCase):
         ]
         self.assertTrue(m.flags.c_contiguous)
         cupy.testing.assert_allclose(m, expect)
+
+    def test_pickle_roundtrip(self):
+        s = _make(cupy, sparse, self.dtype)
+        s2 = pickle.loads(pickle.dumps(s))
+        assert s._descr.descriptor != s2._descr.descriptor
+        assert s.shape == s2.shape
+        assert s.dtype == s2.dtype
+        if scipy_available:
+            assert (s.get() != s2.get()).count_nonzero() == 0
 
 
 @testing.parameterize(*testing.product({

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -1,3 +1,4 @@
+import pickle
 import unittest
 
 import numpy
@@ -268,6 +269,15 @@ class TestCsrMatrix(unittest.TestCase):
         ]
         self.assertTrue(m.flags.c_contiguous)
         cupy.testing.assert_allclose(m, expect)
+
+    def test_pickle_roundtrip(self):
+        s = _make(cupy, sparse, self.dtype)
+        s2 = pickle.loads(pickle.dumps(s))
+        assert s._descr.descriptor != s2._descr.descriptor
+        assert s.shape == s2.shape
+        assert s.dtype == s2.dtype
+        if scipy_available:
+            assert (s.get() != s2.get()).count_nonzero() == 0
 
 
 @testing.parameterize(*testing.product({

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_dia.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_dia.py
@@ -1,3 +1,4 @@
+import pickle
 import unittest
 
 
@@ -100,6 +101,14 @@ class TestDiaMatrix(unittest.TestCase):
         ]
         self.assertTrue(m.flags.c_contiguous)
         cupy.testing.assert_allclose(m, expect)
+
+    def test_pickle_roundtrip(self):
+        s = _make(cupy, sparse, self.dtype)
+        s2 = pickle.loads(pickle.dumps(s))
+        assert s.shape == s2.shape
+        assert s.dtype == s2.dtype
+        if scipy_available:
+            assert (s.get() != s2.get()).count_nonzero() == 0
 
     def test_diagonal(self):
         testing.assert_array_equal(


### PR DESCRIPTION
Backports PR ( https://github.com/cupy/cupy/pull/3157 ) to CuPy 7.