### PR TITLE
Rename `cupy.cudnn` submodule to `cupy._cudnn`

### DIFF
--- a/cupy/_cudnn.pyx
+++ b/cupy/_cudnn.pyx
@@ -146,7 +146,7 @@ cpdef _create_tensor_nd_descriptor(
 cpdef _create_tensor_descriptor(size_t desc, core.ndarray arr,
                                 int format=cudnn.CUDNN_TENSOR_NCHW):
     if not arr._c_contiguous:
-        raise ValueError('cupy.cudnn supports c-contiguous arrays only')
+        raise ValueError('cupy._cudnn supports c-contiguous arrays only')
     if arr._shape.size() == 4:
         data_type = get_data_type(arr.dtype)
         if format == cudnn.CUDNN_TENSOR_NCHW:
@@ -279,7 +279,7 @@ def create_tensor_nd_descriptor(core.ndarray arr):
     if arr.size == 0:
         return Descriptor(0, None)
     if not arr.flags.c_contiguous:
-        raise ValueError('cupy.cudnn supports c-contiguous arrays only')
+        raise ValueError('cupy._cudnn supports c-contiguous arrays only')
     data_type = get_data_type(arr.dtype)
     key = (data_type, tuple(arr._shape))
     cache = _get_nd_tensor_cache()

--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -160,7 +160,7 @@ if not use_hip:
         'name': 'cudnn',
         'file': [
             'cupy_backends.cuda.libs.cudnn',
-            'cupy.cudnn',
+            'cupy._cudnn',
         ],
         'include': [
             'cudnn.h',


### PR DESCRIPTION
Rel #3420.

This PR renames `cupy.cudnn` submodule to `cupy._cudnn` to indicate it is CuPy's private submodule and not intended to be used by users.