### PR TITLE
Improve 2D sparse row slicing

### DIFF
--- a/cupyx/scipy/sparse/_index.py
+++ b/cupyx/scipy/sparse/_index.py
@@ -59,15 +59,6 @@ def _get_csr_submatrix(Ap, Aj, Ax,
     return Bp, Bj, Bx
 
 
-_set_boolean_mask_for_offsets = core.ElementwiseKernel(
-    'raw T start_offsets, raw T stop_offsets', 'raw bool mask',
-    '''
-    for (int jj = start_offsets[i]; jj < stop_offsets[i]; jj++) {
-        mask[jj] = true;
-    }
-    ''', 'set_boolean_mask_for_offsets', no_return=True)
-
-
 def _csr_row_slice(start_maj, step_maj, Ap, Aj, Ax, Bp):
     """Populate indices and data arrays of sparse matrix by slicing the
     rows of an input sparse matrix
@@ -89,23 +80,14 @@ def _csr_row_slice(start_maj, step_maj, Ap, Aj, Ax, Bp):
 
     in_rows = cupy.arange(start_maj, start_maj + (Bp.size - 1) * step_maj,
                           step_maj, dtype=Bp.dtype)
-
-    start_offsets = Ap[in_rows]
-    stop_offsets = Ap[in_rows+1]
-
-    Aj_mask = cupy.zeros_like(Aj, dtype='bool')
-
-    _set_boolean_mask_for_offsets(
-        start_offsets, stop_offsets, Aj_mask, size=start_offsets.size)
-
-    Aj_mask = Aj_mask.nonzero()
-    Bj = Aj[Aj_mask]
-    Bx = Ax[Aj_mask]
-
-    if step_maj < 0:
-        Bj = Bj[::-1].copy()
-        Bx = Bx[::-1].copy()
-
+    offsetsB = Ap[in_rows] - Bp[:-1]
+    B_size = int(Bp[-1])
+    offsetsA = offsetsB[
+        cupy.searchsorted(
+            Bp, cupy.arange(B_size, dtype=Bp.dtype), 'right') - 1]
+    offsetsA += cupy.arange(offsetsA.size, dtype=offsetsA.dtype)
+    Bj = Aj[offsetsA]
+    Bx = Ax[offsetsA]
     return Bj, Bx
 
 

--- a/cupyx/scipy/sparse/_index.py
+++ b/cupyx/scipy/sparse/_index.py
@@ -2,7 +2,6 @@
 """
 
 import cupy
-from cupy import core
 
 from cupyx.scipy.sparse.base import isspmatrix
 from cupyx.scipy.sparse.base import spmatrix


### PR DESCRIPTION
Speed up `_csr_row_slice` implemented in #3657.
(cc: @cjnolet)

- Current master
```
- name = major_slice_with_step, major = slice(1, 2000, 2), minor = slice(1, 500, 1), format = csr, density = 0.5, dtype = float32, n_rows = 15000, n_cols = 15000
cupy.sparse         :    CPU: 8381.574 us   +/-273.936 (min: 8333.696 / max:11354.615) us     GPU-0: 8443.801 us   +/-270.144 (min: 8396.800 / max:11375.616) us
- name = major_slice_with_step, major = slice(1, 2000, 2), minor = slice(1, 500, 1), format = csr, density = 0.5, dtype = float32, n_rows = 15000, n_cols = 15000
cupy.sparse         :    CPU: 8353.152 us   +/- 8.223 (min: 8333.645 / max: 8372.479) us     GPU-0: 8415.525 us   +/- 8.251 (min: 8395.776 / max: 8434.688) us
- name = major_slice_with_step, major = slice(1, 3000, 2), minor = slice(1, 5000, 1), format = csr, density = 0.5, dtype = float32, n_rows = 15000, n_cols = 15000
cupy.sparse         :    CPU: 9121.002 us   +/-18.164 (min: 9095.374 / max: 9233.938) us     GPU-0: 9229.077 us   +/-17.850 (min: 9203.712 / max: 9333.760) us
- name = major_slice_with_step, major = slice(4000, 1, 5), minor = slice(1, 5000, 1), format = csr, density = 0.5, dtype = float32, n_rows = 15000, n_cols = 15000
cupy.sparse         :    CPU:  238.621 us   +/-33.943 (min:  232.334 / max: 2336.788) us     GPU-0:  245.356 us   +/-34.070 (min:  238.592 / max: 2350.080) us
- name = major_slice_with_step, major = slice(1, 4000, 5), minor = slice(1, 5000, 1), format = csr, density = 0.5, dtype = float32, n_rows = 15000, n_cols = 15000
cupy.sparse         :    CPU: 8107.651 us   +/- 8.283 (min: 8082.965 / max: 8135.486) us     GPU-0: 8152.863 us   +/- 8.258 (min: 8128.512 / max: 8179.712) us
- name = major_slice_with_step, major = slice(2000, 1, 5), minor = slice(None, None, None), format = csr, density = 0.5, dtype = float32, n_rows = 15000, n_cols = 15000
cupy.sparse         :    CPU:   35.547 us   +/-11.702 (min:   34.282 / max: 1199.835) us     GPU-0:   39.729 us   +/-11.938 (min:   37.888 / max: 1223.680) us
- name = major_slice_with_step, major = slice(1, 8000, 5), minor = slice(None, None, None), format = csr, density = 0.5, dtype = float32, n_rows = 15000, n_cols = 15000
cupy.sparse         :    CPU: 5409.984 us   +/-169.699 (min: 5382.330 / max: 7399.931) us     GPU-0: 7229.963 us   +/-162.580 (min: 7201.792 / max: 9136.128) us
- name = major_slice_with_step, major = slice(1, 5000, 1), minor = slice(1, 2000, 2), format = csc, density = 0.5, dtype = float32, n_rows = 15000, n_cols = 15000
cupy.sparse         :    CPU: 8380.905 us   +/- 6.994 (min: 8361.252 / max: 8401.170) us     GPU-0: 8444.704 us   +/- 6.940 (min: 8425.472 / max: 8464.384) us
- name = major_slice_with_step, major = slice(1, 5000, 1), minor = slice(2000, 1, 2), format = csc, density = 0.5, dtype = float32, n_rows = 15000, n_cols = 15000
cupy.sparse         :    CPU:  237.466 us   +/-31.647 (min:  232.219 / max: 2208.442) us     GPU-0:  244.189 us   +/-32.484 (min:  238.592 / max: 2267.136) us
- name = major_slice_with_step, major = slice(1, 5000, 1), minor = slice(1, 4000, 2), format = csc, density = 0.5, dtype = float32, n_rows = 15000, n_cols = 15000
cupy.sparse         :    CPU: 9853.610 us   +/-53.934 (min: 9823.445 / max:10354.913) us     GPU-0:10006.989 us   +/-46.344 (min: 9972.736 / max:10425.344) us
- name = major_slice_with_step, major = slice(1, 5000, 1), minor = slice(4000, 1, 5), format = csc, density = 0.5, dtype = float32, n_rows = 15000, n_cols = 15000
cupy.sparse         :    CPU:  237.306 us   +/- 3.258 (min:  232.721 / max:  260.252) us     GPU-0:  244.017 us   +/- 3.363 (min:  238.592 / max:  267.264) us
- name = major_slice_with_step, major = slice(None, None, None), minor = slice(8000, 1, 5), format = csc, density = 0.5, dtype = float32, n_rows = 15000, n_cols = 15000
cupy.sparse         :    CPU:   35.423 us   +/- 0.812 (min:   34.352 / max:   60.268) us     GPU-0:   39.550 us   +/- 1.201 (min:   37.888 / max:   75.776) us
- name = major_slice_with_step, major = slice(None, None, None), minor = slice(1, 4000, 5), format = csc, density = 0.5, dtype = float32, n_rows = 15000, n_cols = 15000
cupy.sparse         :    CPU: 5381.780 us   +/- 6.276 (min: 5364.664 / max: 5404.207) us     GPU-0: 6946.695 us   +/- 6.219 (min: 6931.456 / max: 6969.344) us
```

- This PR
```
- name = major_slice_with_step, major = slice(1, 2000, 2), minor = slice(1, 500, 1), format = csr, density = 0.5, dtype = float32, n_rows = 15000, n_cols = 15000
cupy.sparse         :    CPU: 2700.469 us   +/- 5.675 (min: 2685.594 / max: 2723.003) us     GPU-0: 2763.719 us   +/- 5.824 (min: 2749.440 / max: 2786.304) us
- name = major_slice_with_step, major = slice(1, 2000, 2), minor = slice(1, 500, 1), format = csr, density = 0.5, dtype = float32, n_rows = 15000, n_cols = 15000
cupy.sparse         :    CPU: 2698.360 us   +/- 5.942 (min: 2684.855 / max: 2717.927) us     GPU-0: 2762.500 us   +/- 5.878 (min: 2749.440 / max: 2782.208) us
- name = major_slice_with_step, major = slice(1, 3000, 2), minor = slice(1, 5000, 1), format = csr, density = 0.5, dtype = float32, n_rows = 15000, n_cols = 15000
cupy.sparse         :    CPU: 3866.582 us   +/- 6.003 (min: 3850.487 / max: 3885.967) us     GPU-0: 3976.253 us   +/- 6.002 (min: 3959.808 / max: 3995.648) us
- name = major_slice_with_step, major = slice(4000, 1, 5), minor = slice(1, 5000, 1), format = csr, density = 0.5, dtype = float32, n_rows = 15000, n_cols = 15000
cupy.sparse         :    CPU:  237.848 us   +/- 4.457 (min:  233.440 / max:  300.133) us     GPU-0:  244.757 us   +/- 4.603 (min:  239.616 / max:  307.200) us
- name = major_slice_with_step, major = slice(1, 4000, 5), minor = slice(1, 5000, 1), format = csr, density = 0.5, dtype = float32, n_rows = 15000, n_cols = 15000
cupy.sparse         :    CPU: 2287.649 us   +/- 5.982 (min: 2273.431 / max: 2308.702) us     GPU-0: 2333.830 us   +/- 5.863 (min: 2320.384 / max: 2354.176) us
- name = major_slice_with_step, major = slice(2000, 1, 5), minor = slice(None, None, None), format = csr, density = 0.5, dtype = float32, n_rows = 15000, n_cols = 15000
cupy.sparse         :    CPU:   35.047 us   +/- 0.760 (min:   33.895 / max:   68.138) us     GPU-0:   39.370 us   +/- 0.991 (min:   36.864 / max:   73.728) us
- name = major_slice_with_step, major = slice(1, 8000, 5), minor = slice(None, None, None), format = csr, density = 0.5, dtype = float32, n_rows = 15000, n_cols = 15000
cupy.sparse         :    CPU:  386.930 us   +/- 3.880 (min:  381.094 / max:  404.101) us     GPU-0: 2033.173 us   +/- 3.533 (min: 2024.448 / max: 2048.000) us
- name = major_slice_with_step, major = slice(1, 5000, 1), minor = slice(1, 2000, 2), format = csc, density = 0.5, dtype = float32, n_rows = 15000, n_cols = 15000
cupy.sparse         :    CPU: 2723.618 us   +/- 5.423 (min: 2709.349 / max: 2744.703) us     GPU-0: 2788.112 us   +/- 5.359 (min: 2774.016 / max: 2809.856) us
- name = major_slice_with_step, major = slice(1, 5000, 1), minor = slice(2000, 1, 2), format = csc, density = 0.5, dtype = float32, n_rows = 15000, n_cols = 15000
cupy.sparse         :    CPU:  237.320 us   +/- 3.187 (min:  233.112 / max:  258.475) us     GPU-0:  244.255 us   +/- 3.324 (min:  239.616 / max:  265.216) us
- name = major_slice_with_step, major = slice(1, 5000, 1), minor = slice(1, 4000, 2), format = csc, density = 0.5, dtype = float32, n_rows = 15000, n_cols = 15000
cupy.sparse         :    CPU: 4997.852 us   +/- 5.806 (min: 4980.654 / max: 5020.640) us     GPU-0: 5153.491 us   +/- 5.689 (min: 5137.408 / max: 5176.320) us
- name = major_slice_with_step, major = slice(1, 5000, 1), minor = slice(4000, 1, 5), format = csc, density = 0.5, dtype = float32, n_rows = 15000, n_cols = 15000
cupy.sparse         :    CPU:  236.917 us   +/- 3.134 (min:  232.814 / max:  257.926) us     GPU-0:  243.821 us   +/- 3.260 (min:  238.592 / max:  265.216) us
- name = major_slice_with_step, major = slice(None, None, None), minor = slice(8000, 1, 5), format = csc, density = 0.5, dtype = float32, n_rows = 15000, n_cols = 15000
cupy.sparse         :    CPU:   35.090 us   +/- 0.676 (min:   33.978 / max:   45.178) us     GPU-0:   39.414 us   +/- 0.917 (min:   37.888 / max:   68.608) us
- name = major_slice_with_step, major = slice(None, None, None), minor = slice(1, 4000, 5), format = csc, density = 0.5, dtype = float32, n_rows = 15000, n_cols = 15000
cupy.sparse         :    CPU:  384.381 us   +/- 4.199 (min:  376.445 / max:  405.073) us     GPU-0: 1132.248 us   +/- 3.535 (min: 1126.400 / max: 1152.000) us
```