### PR TITLE
[v7] Skip tests failing due to exception type changes in NumPy 1.19

### DIFF
--- a/tests/cupy_tests/core_tests/test_ndarray.py
+++ b/tests/cupy_tests/core_tests/test_ndarray.py
@@ -89,6 +89,7 @@ class TestNdarrayInit(unittest.TestCase):
             (2, 3), numpy.float32, buf.data, strides=(8, 4), order='C')
         assert a.strides == (8, 4)
 
+    @testing.with_requires('numpy<1.19')
     @testing.numpy_cupy_raises(accept_error=TypeError)
     def test_strides_is_given_but_order_is_invalid(self, xp):
         xp.ndarray((2, 3), numpy.float32, strides=(8, 4), order='!')

--- a/tests/cupy_tests/creation_tests/test_basic.py
+++ b/tests/cupy_tests/creation_tests/test_basic.py
@@ -143,6 +143,7 @@ class TestBasic(unittest.TestCase):
         self.assertEqual(b.strides, bg.strides)
         return
 
+    @testing.with_requires('numpy<1.19')
     @testing.for_all_dtypes()
     @testing.numpy_cupy_raises(accept_error=TypeError)
     def test_empty_like_invalid_order(self, xp, dtype):

--- a/tests/cupy_tests/indexing_tests/test_generate.py
+++ b/tests/cupy_tests/indexing_tests/test_generate.py
@@ -152,6 +152,7 @@ class TestUnravelIndex(unittest.TestCase):
         a = xp.minimum(a, 6 * 4 - 1)
         return xp.unravel_index(a, (6, 4), order=order)
 
+    @testing.with_requires('numpy<1.19')
     @testing.for_int_dtypes()
     @testing.numpy_cupy_raises(accept_error=TypeError)
     def test_invalid_order(self, xp, dtype):

--- a/tests/cupy_tests/indexing_tests/test_insert.py
+++ b/tests/cupy_tests/indexing_tests/test_insert.py
@@ -129,6 +129,7 @@ class TestPutRaises(unittest.TestCase):
         vals = testing.shaped_random((4,), xp, dtype)
         xp.put(a, inds, vals, mode='raise')
 
+    @testing.with_requires('numpy<1.19')
     @testing.for_all_dtypes()
     @testing.numpy_cupy_raises(accept_error=TypeError)
     def test_put_mode_error(self, xp, dtype):

--- a/tests/cupy_tests/linalg_tests/test_einsum.py
+++ b/tests/cupy_tests/linalg_tests/test_einsum.py
@@ -203,6 +203,7 @@ class TestEinSumError(unittest.TestCase):
 @testing.with_requires('numpy!=1.14.0')
 class TestListArgEinSumError(unittest.TestCase):
 
+    @testing.with_requires('numpy<1.19')
     @testing.numpy_cupy_raises()
     def test_invalid_sub1(self, xp):
         xp.einsum(xp.arange(2), [None])

--- a/tests/cupy_tests/logic_tests/test_type_test.py
+++ b/tests/cupy_tests/logic_tests/test_type_test.py
@@ -5,6 +5,7 @@ import numpy
 from cupy import testing
 
 
+@testing.with_requires('numpy<1.19')
 class TestIsScalar(testing.NumpyAliasBasicTestBase):
 
     func = 'isscalar'

--- a/tests/cupy_tests/manipulation_tests/test_dims.py
+++ b/tests/cupy_tests/manipulation_tests/test_dims.py
@@ -115,6 +115,7 @@ class TestDims(unittest.TestCase):
         a = testing.shaped_arange((2, 3), xp)
         return xp.expand_dims(a, -2)
 
+    @testing.with_requires('numpy<1.19')
     @testing.with_requires('numpy>=1.13')
     @testing.numpy_cupy_array_equal()
     def test_expand_dims_negative2(self, xp):


### PR DESCRIPTION
Skip some tests that fail due to recent exception type changes in NumPy 1.19, as discussed in https://github.com/cupy/cupy/issues/3406#issuecomment-673715890 .