### PR TITLE
[backport] Skip FFT input checks for some CUDA >= 10.1 cases

### DIFF
--- a/cupy/fft/fft.py
+++ b/cupy/fft/fft.py
@@ -639,6 +639,8 @@ def irfft(a, n=None, axis=-1, norm=None):
             given, the length of the transformed axis is`2*(m-1)` where `m`
             is the length of the transformed axis of the input.
 
+    .. warning:: The input array may be modified in CUDA 10.1 and above.
+
     .. seealso:: :func:`numpy.fft.irfft`
     """
     return _fft(a, (n,), (axis,), norm, cufft.CUFFT_INVERSE, 'C2R')
@@ -684,6 +686,8 @@ def irfft2(a, s=None, axes=(-2, -1), norm=None):
             given, the length of final transformed axis of output will be
             `2*(m-1)` where `m` is the length of the final transformed axis of
             the input.
+
+    .. warning:: The input array may be modified in CUDA 10.1 and above.
 
     .. seealso:: :func:`numpy.fft.irfft2`
     """
@@ -739,6 +743,8 @@ def irfftn(a, s=None, axes=None, norm=None):
             given, the length of final transformed axis of output will be
             ``2*(m-1)`` where `m` is the length of the final transformed axis
             of the input.
+
+    .. warning:: The input array may be modified in CUDA 10.1 and above.
 
     .. seealso:: :func:`numpy.fft.irfftn`
     """

--- a/cupyx/scipy/fft/fft.py
+++ b/cupyx/scipy/fft/fft.py
@@ -262,6 +262,9 @@ def irfft(x, n=None, axis=-1, norm=None, overwrite_x=False):
         cupy.ndarray:
             The transformed array.
 
+    .. warning:: The input array may be modified in CUDA 10.1 and above, even
+                 when `overwrite_x is False`.
+
     .. seealso:: :func:`scipy.fft.irfft`
     """
     return _fft(x, (n,), (axis,), norm, cufft.CUFFT_INVERSE, 'C2R',
@@ -312,6 +315,9 @@ def irfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False):
             given, the length of final transformed axis of output will be
             `2*(m-1)` where `m` is the length of the final transformed axis of
             the input.
+
+    .. warning:: The input array may be modified in CUDA 10.1 and above, even
+                 when `overwrite_x is False`.
 
     .. seealso:: :func:`scipy.fft.irfft2`
     """
@@ -364,6 +370,9 @@ def irfftn(x, s=None, axes=None, norm=None, overwrite_x=False):
             given, the length of final transformed axis of output will be
             ``2*(m-1)`` where `m` is the length of the final transformed axis
             of the input.
+
+    .. warning:: The input array may be modified in CUDA 10.1 and above, even
+                 when `overwrite_x is False`.
 
     .. seealso:: :func:`scipy.fft.irfftn`
     """

--- a/cupyx/scipy/fftpack/fft.py
+++ b/cupyx/scipy/fftpack/fft.py
@@ -388,6 +388,9 @@ def irfft(x, n=None, axis=-1, overwrite_x=False):
         cupy.ndarray:
             The transformed array.
 
+    .. warning:: The input array may be modified in CUDA 10.1 and above, even
+                 when `overwrite_x is False`.
+
     .. seealso:: :func:`scipy.fftpack.irfft`
     """
     if n is None:

--- a/tests/cupyx_tests/scipy_tests/fft_tests/test_fft.py
+++ b/tests/cupyx_tests/scipy_tests/fft_tests/test_fft.py
@@ -305,7 +305,12 @@ class TestRfft2(unittest.TestCase):
         x_orig = x.copy()
         out = _fft_module(xp).irfft2(x, s=self.s, axes=self.axes,
                                      norm=self.norm)
-        testing.assert_array_equal(x, x_orig)
+
+        # CUDA 10.1 and above may modify input, this fails for complex64
+        if (cp.cuda.runtime.runtimeGetVersion() <= 10000 or
+                dtype not in [np.complex64, np.complex128]):
+            testing.assert_array_equal(x, x_orig)
+
         return _correct_np_dtype(xp, dtype, out)
 
     @testing.for_all_dtypes()
@@ -370,7 +375,12 @@ class TestRfftn(unittest.TestCase):
         x_orig = x.copy()
         out = _fft_module(xp).irfftn(x, s=self.s, axes=self.axes,
                                      norm=self.norm)
-        testing.assert_array_equal(x, x_orig)
+
+        # CUDA 10.1 and above may modify input, this fails for complex64
+        if (cp.cuda.runtime.runtimeGetVersion() <= 10000 or
+                dtype not in [np.complex64, np.complex128]):
+            testing.assert_array_equal(x, x_orig)
+
         return _correct_np_dtype(xp, dtype, out)
 
     @testing.for_all_dtypes()
@@ -395,7 +405,7 @@ class TestRfftn(unittest.TestCase):
 class TestHfft(unittest.TestCase):
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
+    @testing.numpy_cupy_allclose(rtol=4e-4, atol=1e-7, accept_error=ValueError,
                                  contiguous_check=False)
     def test_hfft(self, xp, dtype):
         x = testing.shaped_random(self.shape, xp, dtype)
@@ -405,7 +415,7 @@ class TestHfft(unittest.TestCase):
         return _correct_np_dtype(xp, dtype, out)
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
+    @testing.numpy_cupy_allclose(rtol=4e-4, atol=1e-7, accept_error=ValueError,
                                  contiguous_check=False)
     def test_hfft_overwrite(self, xp, dtype):
         x = testing.shaped_random(self.shape, xp, dtype)


### PR DESCRIPTION
Backport of #3763