### PR TITLE
[v7] Avoid testing exception type match on NumPy 1.19+

### DIFF
--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
@@ -440,6 +440,7 @@ class TestCscMatrixScipyComparison(unittest.TestCase):
         self.assertTrue(a.flags.f_contiguous)
         return a
 
+    @testing.with_requires('numpy<1.19')
     @testing.numpy_cupy_raises(sp_name='sp', accept_error=TypeError)
     def test_toarray_unknown_order(self, xp, sp):
         m = self.make(xp, sp, self.dtype)

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -463,6 +463,7 @@ class TestCsrMatrixScipyComparison(unittest.TestCase):
         self.assertTrue(a.flags.f_contiguous)
         return a
 
+    @testing.with_requires('numpy<1.19')
     @testing.numpy_cupy_raises(sp_name='sp', accept_error=TypeError)
     def test_toarray_unknown_order(self, xp, sp):
         m = self.make(xp, sp, self.dtype)


### PR DESCRIPTION
ref #3498.