### PR TITLE
Update docs for v8

### DIFF
--- a/docs/source/contribution.rst
+++ b/docs/source/contribution.rst
@@ -296,19 +296,6 @@ In order to run unit tests at the repository root, you first have to build Cytho
 
     $ git clean -fdx
 
-.. note::
-
-  It's not officially supported, but you can use `ccache <https://ccache.samba.org/>`_ to reduce compilation time.
-  On Ubuntu 16.04, you can set up as follows::
-
-    $ sudo apt-get install ccache
-    $ export PATH=/usr/lib/ccache:$PATH
-
-  See `ccache <https://ccache.samba.org/>`_ for details.
-
-  If you want to use ccache for nvcc, please install ccache v3.3 or later.
-  You also need to set environment variable ``NVCC='ccache nvcc'``.
-
 Once Cython modules are built, you can run unit tests by running the following command at the repository root::
 
   $ python -m pytest
@@ -454,3 +441,36 @@ Open ``index.html`` with the browser and see if it is rendered as expected.
 
    Docstrings (documentation comments in the source code) are collected from the installed CuPy module.
    If you modified docstrings, make sure to install the module (e.g., using `pip install -e .`) before building the documentation.
+
+
+Tips for Developers
+-------------------
+
+Here are some tips for developers hacking CuPy source code.
+
+Install as Editable
+~~~~~~~~~~~~~~~~~~~
+
+During the development we recommend using ``pip`` with ``-e`` option to install as editable mode::
+
+  $ pip install -e .
+
+Please note that even with ``-e``, you will have to rerun ``pip install -e .`` to regenerate C++ sources using Cython if you modified Cython source files (e.g., ``*.pyx`` files).
+
+Use ccache
+~~~~~~~~~~
+
+``NVCC`` environment variable can be specified at the build time to use the custom command instead of ``nvcc`` .
+You can speed up the rebuild using `ccache <https://ccache.dev/>`_ (v3.4 or later) by::
+
+  $ export NVCC='ccache nvcc'
+
+Limit Architecture
+~~~~~~~~~~~~~~~~~~
+
+Use ``CUPY_NVCC_GENERATE_CODE`` environment variable to reduce the build time by limiting the target CUDA architectures.
+For example, if you only run your CuPy build with NVIDIA P100 and V100, you can use::
+
+  $ export CUPY_NVCC_GENERATE_CODE=arch=compute_60,code=sm_60;arch=compute_70,code=sm_70
+
+See :doc:`reference/environment` for the description.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,6 +10,7 @@ This is the `CuPy <https://github.com/cupy/cupy>`_ documentation.
    :maxdepth: 2
 
    overview
+   install
    tutorial/index
    reference/index
 
@@ -24,7 +25,6 @@ This is the `CuPy <https://github.com/cupy/cupy>`_ documentation.
    :maxdepth: 2
    :caption: Misc Notes
 
-   install
    install_rocm
    upgrade
    license

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -29,7 +29,7 @@ Python Dependencies
 
 NumPy/SciPy-compatible API in CuPy v8 is based on NumPy 1.19 and SciPy 1.5, and has been tested against the following versions:
 
-* `NumPy <https://numpy.org/>`_: v1.15 / v1.16 / v1.17 / v1.18 / v1.19
+* `NumPy <https://numpy.org/>`_: v1.16 / v1.17 / v1.18 / v1.19
 
 * `SciPy <https://scipy.org/>`_ (*optional*): v1.3 / v1.4 / v1.5
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -1,92 +1,112 @@
 Installation Guide
 ==================
 
-.. contents:: :local:
-
-Recommended Environments
-------------------------
-
-We recommend the following Linux distributions.
-
-* `Ubuntu <https://www.ubuntu.com/>`_ 16.04 / 18.04 LTS (64-bit)
-* `CentOS <https://www.centos.org/>`_ 7 (64-bit)
-
-.. note::
-
-   We are automatically testing CuPy on all the recommended environments above.
-   We cannot guarantee that CuPy works on other environments including Windows and macOS, even if CuPy may seem to be running correctly.
-
-
 Requirements
 ------------
 
-You need to have the following components to use CuPy.
+The following Linux distributions are recommended.
 
-* `NVIDIA CUDA GPU <https://developer.nvidia.com/cuda-gpus>`_
-    * Compute Capability of the GPU must be at least 3.0.
-* `CUDA Toolkit <https://developer.nvidia.com/cuda-zone>`_
-    * Supported Versions: 9.0, 9.2, 10.0, 10.1 and 10.2
-    * If you have multiple versions of CUDA Toolkit installed, CuPy will choose one of the CUDA installations automatically.
+* `Ubuntu <https://www.ubuntu.com/>`_ 18.04 LTS (x86_64)
+* `CentOS <https://www.centos.org/>`_ 7 (x86_64)
+
+.. note::
+
+   CuPy requires ``g++-6`` or later.
+   Follow the instructions :ref:`here <install_gcc6>` if you are using Ubuntu 16.04, CentOS 6 or 7.
+
+These components must be installed to use CuPy:
+
+* `NVIDIA CUDA GPU <https://developer.nvidia.com/cuda-gpus>`_ with the Compute Capability 3.0 or larger.
+
+* `CUDA Toolkit <https://developer.nvidia.com/cuda-zone>`_: v9.0 / v9.2 / v10.0 / v10.1 / v10.2 / v11.0
+
+    * If you have multiple versions of CUDA Toolkit installed, CuPy will automatically choose one of the CUDA installations.
       See :ref:`install_cuda` for details.
-* `Python <https://python.org/>`_
-    * Supported Versions: 3.5.1+, 3.6.0+, 3.7.0+ and 3.8.0+.
-* `NumPy <http://www.numpy.org/>`_
-    * Supported Versions: 1.15, 1.16, 1.17 and 1.18.
-    * NumPy will be installed automatically during the installation of CuPy.
 
-Before installing CuPy, we recommend you to upgrade ``setuptools`` and ``pip``::
-
-  $ pip install -U setuptools pip
+* `Python <https://python.org/>`_: v3.5.1+ / v3.6.0+ / v3.7.0+ / v3.8.0+
 
 .. note::
 
    On Windows, CuPy only supports Python 3.6.0 or later.
 
-.. note::
+Python Libraries
+~~~~~~~~~~~~~~~~
 
-   Python 2 is not supported in CuPy v7.x releases.
-   Please consider migrating Python 3 or use CuPy v6.x, which is the last version that supports Python 2.
+NumPy/SciPy-compatible API in CuPy v8 is based on NumPy 1.19 and SciPy 1.5, and has been tested against the following versions:
 
-Optional Libraries
-~~~~~~~~~~~~~~~~~~
+* `NumPy <https://numpy.org/>`_: v1.15 / v1.16 / v1.17 / v1.18 / v1.19
 
-Some features in CuPy will only be enabled if the corresponding libraries are installed.
+* `SciPy <https://scipy.org/>`_ (*optional*): v1.3 / v1.4 / v1.5
 
-* `cuDNN <https://developer.nvidia.com/cudnn>`_ (library to accelerate deep neural network computations)
-    * Supported Versions: v7, v7.1, v7.2, v7.3, v7.4 and v7.5.
-* `NCCL <https://developer.nvidia.com/nccl>`_  (library to perform collective multi-GPU / multi-node computations)
-    * Supported Versions: v2, v2.1, v2.2, v2.3 and v2.4.
-* `cuTENSOR <https://developer.nvidia.com/cutensor>`_ (library for high-performance tensor operations)
-    * Supported Versions: v1.0.0 (experimental)
+    * Required only when using :doc:`reference/scipy` (``cupyx.scipy``).
 
+* `Optuna <https://optuna.org/>`_ (*optional*): v1.0
 
-Install CuPy
-------------
-
-Wheels (precompiled binary packages) are available for Linux (Python 2.7 or later) and Windows (Python 3.6 or later).
-Package names are different depending on the CUDA version you have installed on your host.
-
-::
-
-  (For CUDA 9.0)
-  $ pip install cupy-cuda90
-
-  (For CUDA 9.2)
-  $ pip install cupy-cuda92
-
-  (For CUDA 10.0)
-  $ pip install cupy-cuda100
-
-  (For CUDA 10.1)
-  $ pip install cupy-cuda101
-
-  (For CUDA 10.2)
-  $ pip install cupy-cuda102
+    * Required only when using :doc:`reference/optimize`.
 
 .. note::
 
-   The latest version of cuDNN and NCCL libraries are included in these wheels.
-   You don't have to install them manually.
+   SciPy and Optuna are optional dependencies and will not be installed automatically.
+
+.. note::
+
+   Before installing CuPy, we recommend you to upgrade ``setuptools`` and ``pip``::
+
+    $ python -m pip install -U setuptools pip
+
+Additional CUDA Libraries
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Part of the CUDA features in CuPy will be activated only when the corresponding libraries are installed.
+
+* `cuTENSOR <https://developer.nvidia.com/cutensor>`_: v1.2
+    * The library to accelerate tensor operations. See :docs:environment: for the details.
+
+* `NCCL <https://developer.nvidia.com/nccl>`_: v2.0 / v2.1 / v2.2 / v2.3 / v2.4
+    * The library to perform collective multi-GPU / multi-node computations.
+
+* `cuDNN <https://developer.nvidia.com/cudnn>`_: v7 / v7.1 / v7.2 / v7.3 / v7.4 / v7.5 / v7.6 / v8.0
+    * The library to accelerate deep neural network computations.
+
+
+Installing CuPy
+---------------
+
+Wheels (precompiled binary packages) are available for Linux (Python 3.5+) and Windows (Python 3.6+).
+Package names are different depending on your CUDA Toolkit version.
+
+.. list-table::
+   :header-rows: 1
+
+   * - CUDA
+     - Command
+   * - v9.0
+     - ``$ pip install cupy-cuda90``
+   * - v9.2
+     - ``$ pip install cupy-cuda92``
+   * - v10.0
+     - ``$ pip install cupy-cuda100``
+   * - v10.1
+     - ``$ pip install cupy-cuda101``
+   * - v10.2
+     - ``$ pip install cupy-cuda102``
+   * - v11.0
+     - ``$ pip install cupy-cuda110``
+
+.. note::
+
+   Wheel packages are built with NCCL (Linux only) and cuDNN support enabled.
+
+   * NCCL library is bundled with these packages.
+     You don't have to install it manually.
+
+   * cuDNN library is bundled with these packages except for CUDA 11.0+.
+     For CUDA 11.0+, you need to manually download and install cuDNN v8.0.x library to use cuDNN features.
+
+.. note::
+
+   Use ``pip install --pre cupy-cudaXXX`` if you want to install prerelease (development) versions.
+
 
 When using wheels, please be careful not to install multiple CuPy packages at the same time.
 Any of these packages and ``cupy`` package (source installation) conflict with each other.
@@ -95,8 +115,8 @@ Please make sure that only one CuPy package (``cupy`` or ``cupy-cudaXX`` where X
   $ pip freeze | grep cupy
 
 
-Install CuPy from conda-forge
------------------------------
+Installing CuPy from conda-forge
+--------------------------------
 
 Conda/Anaconda is a cross-platform package management solution widely used in scientific computing and other fields.
 The above ``pip install`` instruction is compatible with ``conda`` environments. Alternatively, for Linux 64 systems
@@ -116,70 +136,57 @@ the installation of a particular CUDA version (say 10.0) for driver compatibilit
 
 .. note::
 
-    If you encounter any problem with CuPy from ``conda-forge``, please feel free to report to `cupy-feedstock 
+    If you encounter any problem with CuPy from ``conda-forge``, please feel free to report to `cupy-feedstock
     <https://github.com/conda-forge/cupy-feedstock/issues>`_, and we will help investigate if it is just a packaging
     issue in ``conda-forge``'s recipe or a real issue in CuPy.
 
 .. note::
 
-    If you did not install CUDA Toolkit yourselves, the ``nvcc`` compiler might not be available. 
+    If you did not install CUDA Toolkit yourselves, the ``nvcc`` compiler might not be available.
     The ``cudatoolkit`` package from Anaconda does not have ``nvcc`` included.
 
-Install CuPy from Source
-------------------------
 
-It is recommended to use wheels whenever possible.
+Installing CuPy from Source
+---------------------------
+
+Use of wheel packages are recommended whenever possible.
 However, if wheels cannot meet your requirements (e.g., you are running non-Linux environment or want to use a version of CUDA / cuDNN / NCCL not supported by wheels), you can also build CuPy from source.
 
 When installing from source, C++ compiler such as ``g++`` is required.
-You need to install it before installing CuPy.
-This is typical installation method for each platform::
-
-  # Ubuntu 16.04
-  $ apt-get install g++
-
-  # CentOS 7
-  $ yum install gcc-c++
+You need to install it before installing CuPy, e.g, ``apt-get install g++`` on Ubuntu 18.04.
 
 .. note::
 
-   When installing CuPy from source, features provided by optional libraries (cuDNN and NCCL) will be disabled if these libraries are not available at the time of installation.
+   When installing CuPy from source, features provided by additional CUDA libraries will be disabled if these libraries are not available at the build time.
    See :ref:`install_cudnn` for the instructions.
 
 .. note::
 
-   If you upgrade or downgrade the version of CUDA Toolkit, cuDNN or NCCL, you may need to reinstall CuPy.
+   If you upgrade or downgrade the version of CUDA Toolkit, cuDNN, NCCL or cuTENSOR, you may need to reinstall CuPy.
    See :ref:`install_reinstall` for details.
 
-Using pip
-~~~~~~~~~
-
-You can install `CuPy package <https://pypi.python.org/pypi/cupy>`_ via ``pip``.
+You can install the latest stable release version of the `CuPy source package <https://pypi.python.org/pypi/cupy>`_ via ``pip``.
 
 ::
 
   $ pip install cupy
 
-Using Tarball
-~~~~~~~~~~~~~
-
-The tarball of the source tree is available via ``pip download cupy`` or from `the release notes page <https://github.com/cupy/cupy/releases>`_.
-You can install CuPy from the tarball::
-
-  $ pip install cupy-x.x.x.tar.gz
-
-You can also install the development version of CuPy from a cloned Git repository::
+If you want to install the latest development version of CuPy from a cloned Git repository::
 
   $ git clone --recursive https://github.com/cupy/cupy.git
   $ cd cupy
   $ pip install .
 
-If you are using source tree downloaded from GitHub, you need to install Cython 0.28.0 or later (``pip install cython``).
+.. note::
 
-Uninstall CuPy
---------------
+   To build the source tree downloaded from GitHub, you need to install Cython 0.28.0 or later (``pip install cython``).
+   You don't have to install Cython to build source packages hosted on PyPI as they include pre-generated C++ source files.
 
-Use pip to uninstall CuPy::
+
+Uninstalling CuPy
+-----------------
+
+Use ``pip`` to uninstall CuPy::
 
   $ pip uninstall cupy
 
@@ -192,8 +199,8 @@ Use pip to uninstall CuPy::
    If CuPy is installed via ``conda``, please do ``conda uninstall cupy`` instead.
 
 
-Upgrade CuPy
-------------
+Upgrading CuPy
+---------------
 
 Just use ``pip install`` with ``-U`` option::
 
@@ -206,11 +213,12 @@ Just use ``pip install`` with ``-U`` option::
 
 .. _install_reinstall:
 
-Reinstall CuPy
---------------
 
-If you want to reinstall CuPy, please uninstall CuPy and then install it.
-When reinstalling CuPy, we recommend to use ``--no-cache-dir`` option as ``pip`` caches the previously built binaries::
+Reinstalling CuPy
+-----------------
+
+To reinstall CuPy, please uninstall CuPy and then install it.
+When reinstalling CuPy, we recommend using ``--no-cache-dir`` option as ``pip`` caches the previously built binaries::
 
   $ pip uninstall cupy
   $ pip install cupy --no-cache-dir
@@ -220,18 +228,18 @@ When reinstalling CuPy, we recommend to use ``--no-cache-dir`` option as ``pip``
    If you are using a wheel, ``cupy`` shall be replaced with ``cupy-cudaXX`` (where XX is a CUDA version number).
 
 
-Run CuPy with Docker
---------------------
+Using CuPy inside Docker
+------------------------
 
-We are providing the `official Docker image <https://hub.docker.com/r/cupy/cupy/>`_.
-Use `nvidia-docker <https://github.com/NVIDIA/nvidia-docker>`_ command to run CuPy image with GPU.
+We are providing the `official Docker images <https://hub.docker.com/r/cupy/cupy/>`_.
+Use `NVIDIA Container Toolkit <https://github.com/NVIDIA/nvidia-docker>`_ to run CuPy image with GPU.
 You can login to the environment with bash, and run the Python interpreter::
 
-  $ nvidia-docker run -it cupy/cupy /bin/bash
+  $ docker run --gpus all -it cupy/cupy /bin/bash
 
 Or run the interpreter directly::
 
-  $ nvidia-docker run -it cupy/cupy /usr/bin/python
+  $ docker run --gpus all -it cupy/cupy /usr/bin/python
 
 
 FAQ
@@ -267,7 +275,7 @@ Installing cuDNN and NCCL
 
 We recommend installing cuDNN and NCCL using binary packages (i.e., using ``apt`` or ``yum``) provided by NVIDIA.
 
-If you want to install tar-gz version of cuDNN and NCCL, we recommend you to install it under CUDA directory.
+If you want to install tar-gz version of cuDNN and NCCL, we recommend installing it under the ``CUDA_PATH`` directory.
 For example, if you are using Ubuntu, copy ``*.h`` files to ``include`` directory and ``*.so*`` files to ``lib64`` directory::
 
   $ cp /path/to/cudnn.h $CUDA_PATH/include
@@ -277,29 +285,24 @@ The destination directories depend on your environment.
 
 If you want to use cuDNN or NCCL installed in another directory, please use ``CFLAGS``, ``LDFLAGS`` and ``LD_LIBRARY_PATH`` environment variables before installing CuPy::
 
-  export CFLAGS=-I/path/to/cudnn/include
-  export LDFLAGS=-L/path/to/cudnn/lib
-  export LD_LIBRARY_PATH=/path/to/cudnn/lib:$LD_LIBRARY_PATH
-
-.. note::
-
-   Use full paths for the environment variables.
-   ``distutils`` that is used in the setup script does not expand the home directory mark ``~``.
+  $ export CFLAGS=-I/path/to/cudnn/include
+  $ export LDFLAGS=-L/path/to/cudnn/lib
+  $ export LD_LIBRARY_PATH=/path/to/cudnn/lib:$LD_LIBRARY_PATH
 
 .. _install_cuda:
 
 Working with Custom CUDA Installation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you have installed CUDA on the non-default directory or have multiple CUDA versions installed, you may need to manually specify the CUDA installation directory to be used by CuPy.
+If you have installed CUDA on the non-default directory or multiple CUDA versions on the same host, you may need to manually specify the CUDA installation directory to be used by CuPy.
 
 CuPy uses the first CUDA installation directory found by the following order.
 
 #. ``CUDA_PATH`` environment variable.
-#. The parent directory of ``nvcc`` command. CuPy looks for ``nvcc`` command in each directory set in ``PATH`` environment variable.
+#. The parent directory of ``nvcc`` command. CuPy looks for ``nvcc`` command from ``PATH`` environment variable.
 #. ``/usr/local/cuda``
 
-For example, you can tell CuPy to use non-default CUDA directory by ``CUDA_PATH`` environment variable::
+For example, you can build CuPy using non-default CUDA directory by ``CUDA_PATH`` environment variable::
 
   $ CUDA_PATH=/opt/nvidia/cuda pip install cupy
 
@@ -308,31 +311,10 @@ For example, you can tell CuPy to use non-default CUDA directory by ``CUDA_PATH`
    CUDA installation discovery is also performed at runtime using the rule above.
    Depending on your system configuration, you may also need to set ``LD_LIBRARY_PATH`` environment variable to ``$CUDA_PATH/lib64`` at runtime.
 
-Using custom ``nvcc`` command during installation
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-If you want to use a custom ``nvcc`` compiler (for example, to use ``ccache``) to build CuPy, please set ``NVCC`` environment variables before installing CuPy::
-
-  export NVCC='ccache nvcc'
-
-.. note::
-
-   During runtime, you don't need to set this environment variable since CuPy doesn't use the nvcc command.
-
-Installation for Developers
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-If you are hacking CuPy source code, we recommend you to use ``pip`` with ``-e`` option for editable mode::
-
-  $ cd /path/to/cupy/source
-  $ pip install -e .
-
-Please note that even with ``-e``, you will have to rerun ``pip install -e .`` to regenerate C++ sources using Cython if you modified Cython source files (e.g., ``*.pyx`` files).
-
 CuPy always raises ``cupy.cuda.compiler.CompileException``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If CuPy does not work at all with ``CompileException``, it is possible that CuPy cannot detect CUDA installed on your system correctly.
+If CuPy raises a ``CompileException`` for almost everything, it is possible that CuPy cannot detect CUDA installed on your system correctly.
 The followings are error messages commonly observed in such cases.
 
 * ``nvrtc: error: failed to load builtins``
@@ -343,7 +325,27 @@ The followings are error messages commonly observed in such cases.
 Please try setting ``LD_LIBRARY_PATH`` and ``CUDA_PATH`` environment variable.
 For example, if you have CUDA installed at ``/usr/local/cuda-9.0``::
 
-  export CUDA_PATH=/usr/local/cuda-9.0
-  export LD_LIBRARY_PATH=$CUDA_PATH/lib64:$LD_LIBRARY_PATH
+  $ export CUDA_PATH=/usr/local/cuda-9.0
+  $ export LD_LIBRARY_PATH=$CUDA_PATH/lib64:$LD_LIBRARY_PATH
 
 Also see :ref:`install_cuda`.
+
+.. _install_gcc6:
+
+Build fails on Ubuntu 16.04, CentOS 6 or 7
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In order to build CuPy from source on systems with legacy GCC (g++-5 or earlier), you need to manually set up g++-6 or later and configure ``NVCC`` environment variable.
+
+On Ubuntu 16.04::
+
+  $ sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+  $ sudo apt update
+  $ sudo apt install g++-6
+  $ export NVCC="nvcc --compiler-bindir gcc-6"
+
+On CentOS 6 / 7::
+
+  $ sudo yum install centos-release-scl
+  $ sudo yum install devtoolset-7-gcc-c++
+  $ export NVCC="nvcc --compiler-bidir gcc-7"

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -147,7 +147,7 @@ the installation of a particular CUDA version (say 10.0) for driver compatibilit
 Installing CuPy from Source
 ---------------------------
 
-Use of wheel packages are recommended whenever possible.
+Use of wheel packages is recommended whenever possible.
 However, if wheels cannot meet your requirements (e.g., you are running non-Linux environment or want to use a version of CUDA / cuDNN / NCCL not supported by wheels), you can also build CuPy from source.
 
 .. note::

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -58,11 +58,11 @@ Part of the CUDA features in CuPy will be activated only when the corresponding 
 
     * The library to accelerate tensor operations. See :docs:environment: for the details.
 
-* `NCCL <https://developer.nvidia.com/nccl>`_: v2.0 / v2.1 / v2.2 / v2.3 / v2.4
+* `NCCL <https://developer.nvidia.com/nccl>`_: v2.0 / v2.1 / v2.2 / v2.3 / v2.4 / v2.5 / v2.6 / v2.7
 
     * The library to perform collective multi-GPU / multi-node computations.
 
-* `cuDNN <https://developer.nvidia.com/cudnn>`_: v7 / v7.1 / v7.2 / v7.3 / v7.4 / v7.5 / v7.6 / v8.0
+* `cuDNN <https://developer.nvidia.com/cudnn>`_: v7.0 / v7.1 / v7.2 / v7.3 / v7.4 / v7.5 / v7.6 / v8.0
 
     * The library to accelerate deep neural network computations.
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -24,8 +24,8 @@ These components must be installed to use CuPy:
 
    On Windows, CuPy only supports Python 3.6.0 or later.
 
-Python Libraries
-~~~~~~~~~~~~~~~~
+Python Dependencies
+~~~~~~~~~~~~~~~~~~~
 
 NumPy/SciPy-compatible API in CuPy v8 is based on NumPy 1.19 and SciPy 1.5, and has been tested against the following versions:
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -55,12 +55,15 @@ Additional CUDA Libraries
 Part of the CUDA features in CuPy will be activated only when the corresponding libraries are installed.
 
 * `cuTENSOR <https://developer.nvidia.com/cutensor>`_: v1.2
+
     * The library to accelerate tensor operations. See :docs:environment: for the details.
 
 * `NCCL <https://developer.nvidia.com/nccl>`_: v2.0 / v2.1 / v2.2 / v2.3 / v2.4
+
     * The library to perform collective multi-GPU / multi-node computations.
 
 * `cuDNN <https://developer.nvidia.com/cudnn>`_: v7 / v7.1 / v7.2 / v7.3 / v7.4 / v7.5 / v7.6 / v8.0
+
     * The library to accelerate deep neural network computations.
 
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -349,4 +349,5 @@ On CentOS 6 / 7::
 
   $ sudo yum install centos-release-scl
   $ sudo yum install devtoolset-7-gcc-c++
+  $ source /opt/rh/devtoolset-7/enable
   $ export NVCC="nvcc --compiler-bidir gcc-7"

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -35,7 +35,7 @@ NumPy/SciPy-compatible API in CuPy v8 is based on NumPy 1.19 and SciPy 1.5, and 
 
     * Required only when using :doc:`reference/scipy` (``cupyx.scipy``).
 
-* `Optuna <https://optuna.org/>`_ (*optional*): v1.0
+* `Optuna <https://optuna.org/>`_ (*optional*): v1.x
 
     * Required only when using :doc:`reference/optimize`.
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -13,7 +13,7 @@ These components must be installed to use CuPy:
 
 * `NVIDIA CUDA GPU <https://developer.nvidia.com/cuda-gpus>`_ with the Compute Capability 3.0 or larger.
 
-* `CUDA Toolkit <https://developer.nvidia.com/cuda-zone>`_: v9.0 / v9.2 / v10.0 / v10.1 / v10.2 / v11.0
+* `CUDA Toolkit <https://developer.nvidia.com/cuda-toolkit>`_: v9.0 / v9.2 / v10.0 / v10.1 / v10.2 / v11.0
 
     * If you have multiple versions of CUDA Toolkit installed, CuPy will automatically choose one of the CUDA installations.
       See :ref:`install_cuda` for details.

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -9,11 +9,6 @@ The following Linux distributions are recommended.
 * `Ubuntu <https://www.ubuntu.com/>`_ 18.04 LTS (x86_64)
 * `CentOS <https://www.centos.org/>`_ 7 (x86_64)
 
-.. note::
-
-   CuPy requires ``g++-6`` or later.
-   Follow the instructions :ref:`here <install_gcc6>` if you are using Ubuntu 16.04, CentOS 6 or 7.
-
 These components must be installed to use CuPy:
 
 * `NVIDIA CUDA GPU <https://developer.nvidia.com/cuda-gpus>`_ with the Compute Capability 3.0 or larger.
@@ -152,8 +147,11 @@ Installing CuPy from Source
 Use of wheel packages are recommended whenever possible.
 However, if wheels cannot meet your requirements (e.g., you are running non-Linux environment or want to use a version of CUDA / cuDNN / NCCL not supported by wheels), you can also build CuPy from source.
 
-When installing from source, C++ compiler such as ``g++`` is required.
-You need to install it before installing CuPy, e.g, ``apt-get install g++`` on Ubuntu 18.04.
+.. note::
+
+   CuPy source build requires ``g++-6`` or later.
+   For Ubuntu 18.04, run ``apt-get install g++``.
+   For Ubuntu 16.04, CentOS 6 or 7, follow the instructions :ref:`here <install_gcc6>`.
 
 .. note::
 

--- a/docs/source/reference/environment.rst
+++ b/docs/source/reference/environment.rst
@@ -51,6 +51,12 @@ Here are the environment variables CuPy uses.
 |                                    | its priority. Default is empty string (all         |
 |                                    | accelerators are disabled).                        |
 +------------------------------------+----------------------------------------------------+
+| ``NVCC``                           | Define the compiler to use when compiling CUDA     |
+|                                    | source. Note that most CuPy kernels are built with |
+|                                    | NVRTC; this environment is only effective for      |
+|                                    | RawKernels/RawModules with ``nvcc`` backend or     |
+|                                    | when using ``cub`` as the accelerator.             |
++------------------------------------+----------------------------------------------------+
 
 Moreover, as in any CUDA programs, all of the CUDA environment variables listed in the `CUDA Toolkit
 Documentation`_ will also be honored.

--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -1,8 +1,8 @@
 .. _cupy_reference:
 
-****************
-Reference Manual
-****************
+*************
+API Reference
+*************
 
 This is the official reference of CuPy, a multi-dimensional array on CUDA with a subset of NumPy interface.
 


### PR DESCRIPTION
* Clean up the installation guide
    * #3671 (Support cuDNN 7.6 and 8.0)
    * #3630 (Support NumPy 1.19)
    * #3643 (Drop support for NumPy 1.15 or earlier)
    * #3631 (Drop support for SciPy 1.2 or earlier)
    * #3521 (Declare baseline NumPy/SciPy version)
    * #3530 (Add docs to build cub module in Ubuntu 16.04 and RHEL 6/7)
* Fix NVCC environment variable missing from the runtime table
* Move developer tips (editable mode & ccache) to contributor guide