### PR TITLE
[v7] Skip TestDiaMatrixScipyComparison failing with scipy>=1.5.0

### DIFF
--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_dia.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_dia.py
@@ -270,6 +270,7 @@ class TestDiaMatrixScipyComparison(unittest.TestCase):
         return m.transpose()
 
     @testing.numpy_cupy_raises(sp_name='sp')
+    @testing.with_requires('scipy<1.5.0')
     @testing.with_requires('scipy>=1.0')
     def test_diagonal_error(self, xp, sp):
         m = _make(xp, sp, self.dtype)


### PR DESCRIPTION
Skip test if scipy>=1.5.0, see https://github.com/cupy/cupy/issues/3469 for the fix in v8.