### PR TITLE
[backport] Use `CUSPARSE_VERSION` instead of `CUDA_VERSION`

### DIFF
--- a/cupy/cuda/cupy_cusparse.h
+++ b/cupy/cuda/cupy_cusparse.h
@@ -8,7 +8,15 @@
 #include <cuda.h>
 #include <cusparse.h>
 
-#if CUDA_VERSION < 9000
+#if !defined(CUSPARSE_VERSION)
+#if CUDA_VERSION < 10000
+#define CUSPARSE_VERSION CUDA_VERSION // CUDA_VERSION used instead
+#else
+#define CUSPARSE_VERSION 10000
+#endif
+#endif // #if !defined(CUSPARSE_VERSION)
+
+#if CUSPARSE_VERSION < 9000
 // Functions added in CUDA 9.0
 cusparseStatus_t cusparseSgtsv2_bufferSizeExt(...) {
   return CUSPARSE_STATUS_SUCCESS;
@@ -105,9 +113,9 @@ cusparseStatus_t cusparseCgtsv2StridedBatch(...) {
 cusparseStatus_t cusparseZgtsv2StridedBatch(...) {
   return CUSPARSE_STATUS_SUCCESS;
 }
-#endif // #if CUDA_VERSION < 9000
+#endif // #if CUSPARSE_VERSION < 9000
 
-#if CUDA_VERSION < 9020
+#if CUSPARSE_VERSION < 9020
 // Functions added in CUDA 9.2
 cusparseStatus_t cusparseSgtsvInterleavedBatch_bufferSizeExt(...) {
   return CUSPARSE_STATUS_SUCCESS;
@@ -209,13 +217,10 @@ cusparseStatus_t cusparseZcsrgeam2(...) {
   return CUSPARSE_STATUS_SUCCESS;
 }
 
-#endif // #if CUDA_VERSION < 9020
+#endif // #if CUSPARSE_VERSION < 9020
 
-#if (CUDA_VERSION < 10010) || defined(_WIN32)
-// Types, macro and functions added in CUDA 10.1 except Windows
-// TODO(anaruse): check availability on Windows when CUDA 11 is released
-
-#define CUSPARSE_VERSION CUDA_VERSION // CUDA_VERSION used instead
+#if CUSPARSE_VERSION < 10200
+// Types, macro and functions added in cuSparse 10.2
 
 // cuSPARSE generic API
 typedef void* cusparseSpVecDescr_t;
@@ -385,10 +390,10 @@ cusparseStatus_t cusparseConstrainedGeMM(...) {
   return CUSPARSE_STATUS_SUCCESS;
 }
 
-#endif // #if (CUDA_VERSION < 10010) || defined(_WIN32)
+#endif // #if CUSPARSE_VERSION < 10200
 
-#if (CUDA_VERSION < 10010)
-// Functions added in CUDA 10.1
+#if CUSPARSE_VERSION < 10200
+// Functions added in cuSparse 10.2
 
 // CSR2CSC
 typedef enum {} cusparseCsr2CscAlg_t;
@@ -400,10 +405,10 @@ cusparseStatus_t cusparseCsr2cscEx2_bufferSize(...) {
 cusparseStatus_t cusparseCsr2cscEx2(...) {
   return CUSPARSE_STATUS_SUCCESS;
 }
-#endif // #if (CUDA_VERSION < 10010)
+#endif // #if CUSPARSE_VERSION < 10200
 
-#if CUDA_VERSION >= 11000
-// Functions deleted in CUDA 11.0
+#if CUSPARSE_VERSION >= 11000
+// Functions deleted in cuSparse 11.0
 
 // cuSPARSE Level2 Function
 cusparseStatus_t cusparseScsrmv(...) {
@@ -517,7 +522,7 @@ cusparseStatus_t cusparseCcsr2csc(...) {
 cusparseStatus_t cusparseZcsr2csc(...) {
   return CUSPARSE_STATUS_SUCCESS;
 }
-#endif // #if CUDA_VERSION >= 11000
+#endif // #if CUSPARSE_VERSION >= 11000
 
 #else  // #if !defined(CUPY_NO_CUDA) && !defined(CUPY_USE_HIP)
 

--- a/cupy/cusparse.py
+++ b/cupy/cusparse.py
@@ -80,18 +80,17 @@ def _dtype_to_DataType(dtype):
         raise TypeError
 
 
-_available_cuda_version = {
+_available_cusparse_version = {
     'csrmv': (8000, 11000),
-    'csrmvEx': (8000, 11000),  # TODO(anaruse): failure in CUDA 11
+    'csrmvEx': (8000, 11000),  # TODO(anaruse): failure in cuSparse 11.0
     'csrmm': (8000, 11000),
     'csrmm2': (8000, 11000),
     'csrgeam': (8000, 11000),
     'csrgeam2': (9020, None),
     'csrgemm': (8000, 11000),
     'csrgemm2': (8000, None),
-    # TODO(anaruse): check availability on Windows when CUDA 11 is relased
-    'spmv': ({'Linux': 10010, 'Windows': 11000}, None),
-    'spmm': ({'Linux': 10010, 'Windows': 11000}, None),
+    'spmv': (10200, None),
+    'spmm': (10301, None),  # accuracy bugs in cuSparse 10.3.0
     'csr2dense': (8000, None),
     'csc2dense': (8000, None),
     'csrsort': (8000, None),
@@ -101,8 +100,8 @@ _available_cuda_version = {
     'csr2coo': (8000, None),
     'csr2csc': (8000, 11000),
     'csc2csr': (8000, 11000),  # the entity is csr2csc
-    'csr2cscEx2': (10010, None),
-    'csc2csrEx2': (10010, None),  # the entity is csr2cscEx2
+    'csr2cscEx2': (10200, None),
+    'csc2csrEx2': (10200, None),  # the entity is csr2cscEx2
     'dense2csc': (8000, None),
     'dense2csr': (8000, None),
     'csr2csr_compress': (8000, None),
@@ -122,16 +121,16 @@ def _get_version(x):
 
 @util.memoize()
 def check_availability(name):
-    if name not in _available_cuda_version:
+    if name not in _available_cusparse_version:
         msg = 'No available version information specified for {}'.format(name)
         raise ValueError(msg)
-    version_added, version_removed = _available_cuda_version[name]
+    version_added, version_removed = _available_cusparse_version[name]
     version_added = _get_version(version_added)
     version_removed = _get_version(version_removed)
-    cuda_version = runtime.runtimeGetVersion()
-    if version_added is not None and cuda_version < version_added:
+    cusparse_version = cusparse.getVersion(device.get_cusparse_handle())
+    if version_added is not None and cusparse_version < version_added:
         return False
-    if version_removed is not None and cuda_version >= version_removed:
+    if version_removed is not None and cusparse_version >= version_removed:
         return False
     return True
 


### PR DESCRIPTION
Backport of #3491