### PR TITLE
Support TF32

### DIFF
--- a/cupy/core/__init__.py
+++ b/cupy/core/__init__.py
@@ -64,8 +64,8 @@ from cupy.core.core import ndarray  # NOQA
 from cupy.core.core import not_equal  # NOQA
 from cupy.core.core import right_shift  # NOQA
 from cupy.core.core import tensordot_core  # NOQA
-from cupy.core.core import set_fp32_compute_type  # NOQA
-from cupy.core.core import get_fp32_compute_type  # NOQA
+from cupy.core.core import set_compute_type  # NOQA
+from cupy.core.core import get_compute_type  # NOQA
 from cupy.core.dlpack import fromDlpack  # NOQA
 from cupy.core.internal import complete_slice  # NOQA
 from cupy.core.internal import get_size  # NOQA

--- a/cupy/core/__init__.py
+++ b/cupy/core/__init__.py
@@ -64,6 +64,8 @@ from cupy.core.core import ndarray  # NOQA
 from cupy.core.core import not_equal  # NOQA
 from cupy.core.core import right_shift  # NOQA
 from cupy.core.core import tensordot_core  # NOQA
+from cupy.core.core import set_fp32_compute_type  # NOQA
+from cupy.core.core import get_fp32_compute_type  # NOQA
 from cupy.core.dlpack import fromDlpack  # NOQA
 from cupy.core.internal import complete_slice  # NOQA
 from cupy.core.internal import get_size  # NOQA

--- a/cupy/core/core.pxd
+++ b/cupy/core/core.pxd
@@ -118,7 +118,11 @@ cdef ndarray _create_ndarray_from_shape_strides(
     const shape_t& shape, const strides_t& strides, dtype)
 
 cpdef enum:
-    FP32_COMPUTE_TBD = 0
-    FP32_COMPUTE_DEFAULT = 1    # default
-    FP32_COMPUTE_PEDANTIC = 2   # disable algorithmic optimizations
-    FP32_COMPUTE_FAST_TF32 = 3  # allow down-converting inputs to TF32
+    COMPUTE_TYPE_TBD = 0
+    COMPUTE_TYPE_DEFAULT = 1   # default
+    COMPUTE_TYPE_PEDANTIC = 2  # disable algorithmic optimizations
+    COMPUTE_TYPE_FP16 = 3      # allow converting inputs to FP16
+    COMPUTE_TYPE_FP32 = 4      # allow converting inputs to FP32
+    COMPUTE_TYPE_FP64 = 5      # allow converting inputs to FP64
+    COMPUTE_TYPE_BF16 = 6      # allow converting inputs to BF16
+    COMPUTE_TYPE_TF32 = 7      # allow converting inputs to TF32

--- a/cupy/core/core.pxd
+++ b/cupy/core/core.pxd
@@ -116,3 +116,9 @@ cdef ndarray _ndarray_init(const shape_t& shape, dtype)
 
 cdef ndarray _create_ndarray_from_shape_strides(
     const shape_t& shape, const strides_t& strides, dtype)
+
+cpdef enum:
+    FP32_COMPUTE_TBD = 0
+    FP32_COMPUTE_DEFAULT = 1    # default
+    FP32_COMPUTE_PEDANTIC = 2   # disable algorithmic optimizations
+    FP32_COMPUTE_FAST_TF32 = 3  # allow down-converting inputs to TF32

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2951,7 +2951,7 @@ cpdef ndarray tensordot_core_v11(
             fp32_compute_type = FP32_COMPUTE_FAST_TF32
         set_fp32_compute_type(fp32_compute_type)
 
-    cdef int compute_type
+    cdef int compute_type = -1
     if c.dtype.char == 'e':
         compute_type = cublas.CUBLAS_COMPUTE_32F
     elif c.dtype.char in 'fF':
@@ -2963,8 +2963,6 @@ cpdef ndarray tensordot_core_v11(
             compute_type = cublas.CUBLAS_COMPUTE_32F
     elif c.dtype.char in 'dD':
         compute_type = cublas.CUBLAS_COMPUTE_64F
-    else:
-        raise ValueError('Invalid dtype: {}'.format(c.dtype))
 
     cdef int compute_capability = int(device.get_compute_capability())
     cdef int algo = cublas.CUBLAS_GEMM_DEFAULT

--- a/docs/source/reference/environment.rst
+++ b/docs/source/reference/environment.rst
@@ -57,6 +57,11 @@ Here are the environment variables CuPy uses.
 |                                    | its priority. Default is empty string (all         |
 |                                    | accelerators are disabled).                        |
 +------------------------------------+----------------------------------------------------+
+| ``CUPY_TF32``                      | If set to 1, it allows CUDA libraries to use       |
+|                                    | Tensor Cores TF32 compute for 32-bit floating      |
+|                                    | point compute.                                     |
+|                                    | The default is 0 and TF32 is not used.             |
++------------------------------------+----------------------------------------------------+
 | ``NVCC``                           | Define the compiler to use when compiling CUDA     |
 |                                    | source. Note that most CuPy kernels are built with |
 |                                    | NVRTC; this environment is only effective for      |

--- a/tests/cupy_tests/math_tests/test_matmul.py
+++ b/tests/cupy_tests/math_tests/test_matmul.py
@@ -151,9 +151,9 @@ class _TestMatmulComputeTypes(unittest.TestCase):
             cupy.core.core.COMPUTE_TYPE_PEDANTIC,
         ],
         'shape_pair': [
-            ((100, 200), (200, 300)),
-            ((200, 300), (300, 100)),
-            ((300, 100), (100, 200)),
+            ((32, 64), (64, 96)),
+            ((64, 96), (96, 32)),
+            ((96, 32), (32, 64)),
         ],
     }))
 @testing.gpu

--- a/tests/cupy_tests/math_tests/test_matmul.py
+++ b/tests/cupy_tests/math_tests/test_matmul.py
@@ -132,6 +132,53 @@ class TestMatmulLarge(unittest.TestCase):
 @testing.parameterize(
     *testing.product({
         'shape_pair': [
+            ((100, 200), (200, 300)),
+            ((200, 300), (300, 100)),
+            ((300, 100), (100, 200)),
+        ],
+        'dtype_pair': [
+            (numpy.float16, numpy.float32),
+            (numpy.float32, numpy.float32),
+            (numpy.float16, numpy.complex64),
+            (numpy.float32, numpy.complex64),
+            (numpy.complex64, numpy.complex64),
+        ],
+        'fp32_compute_type': [
+            cupy.core.core.FP32_COMPUTE_DEFAULT,
+            cupy.core.core.FP32_COMPUTE_PEDANTIC,
+            cupy.core.core.FP32_COMPUTE_FAST_TF32,
+        ],
+    }))
+@testing.gpu
+class TestMatmulFp32ComputeTypes(unittest.TestCase):
+
+    def setUp(self):
+        self.old_fp32_compute_type = cupy.core.get_fp32_compute_type()
+        cupy.core.set_fp32_compute_type(self.fp32_compute_type)
+
+    def tearDown(self):
+        cupy.core.set_fp32_compute_type(self.old_fp32_compute_type)
+
+    @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-3)
+    def test_operator_matmul(self, xp):
+        shape1, shape2 = self.shape_pair
+        dtype1, dtype2 = self.dtype_pair
+        x1 = testing.shaped_random(shape1, xp, dtype1)
+        x2 = testing.shaped_random(shape2, xp, dtype2)
+        return operator.matmul(x1, x2)
+
+    @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-3)
+    def test_cupy_matmul(self, xp):
+        shape1, shape2 = self.shape_pair
+        dtype1, dtype2 = self.dtype_pair
+        x1 = testing.shaped_random(shape1, xp, dtype1)
+        x2 = testing.shaped_random(shape2, xp, dtype2)
+        return xp.matmul(x1, x2)
+
+
+@testing.parameterize(
+    *testing.product({
+        'shape_pair': [
             ((5, 3, 1), (3, 1, 4)),
             ((3, 2, 3), (3, 2, 4)),
             ((3, 2), ()),

--- a/tests/cupy_tests/math_tests/test_matmul.py
+++ b/tests/cupy_tests/math_tests/test_matmul.py
@@ -136,6 +136,49 @@ class TestMatmulLarge(unittest.TestCase):
             ((200, 300), (300, 100)),
             ((300, 100), (100, 200)),
         ],
+        'compute_type': [
+            cupy.core.core.COMPUTE_TYPE_DEFAULT,
+            cupy.core.core.COMPUTE_TYPE_PEDANTIC,
+        ],
+    }))
+@testing.gpu
+class TestMatmulFp16ComputeTypes(unittest.TestCase):
+    dtype = numpy.float16
+
+    def setUp(self):
+        self.old_compute_type = cupy.core.get_compute_type(self.dtype)
+        cupy.core.set_compute_type(self.dtype, self.compute_type)
+
+    def tearDown(self):
+        cupy.core.set_compute_type(self.dtype, self.old_compute_type)
+
+    @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-3)
+    def test_operator_matmul(self, xp):
+        shape1, shape2 = self.shape_pair
+        x1 = testing.shaped_random(shape1, xp, self.dtype)
+        x2 = testing.shaped_random(shape2, xp, self.dtype)
+        return operator.matmul(x1, x2)
+
+    @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-3)
+    def test_cupy_matmul(self, xp):
+        shape1, shape2 = self.shape_pair
+        x1 = testing.shaped_random(shape1, xp, self.dtype)
+        x2 = testing.shaped_random(shape2, xp, self.dtype)
+        return xp.matmul(x1, x2)
+
+
+@testing.parameterize(
+    *testing.product({
+        'shape_pair': [
+            ((100, 200), (200, 300)),
+            ((200, 300), (300, 100)),
+            ((300, 100), (100, 200)),
+        ],
+        'compute_type': [
+            cupy.core.core.COMPUTE_TYPE_DEFAULT,
+            cupy.core.core.COMPUTE_TYPE_PEDANTIC,
+            cupy.core.core.COMPUTE_TYPE_TF32,
+        ],
         'dtype_pair': [
             (numpy.float16, numpy.float32),
             (numpy.float32, numpy.float32),
@@ -143,21 +186,17 @@ class TestMatmulLarge(unittest.TestCase):
             (numpy.float32, numpy.complex64),
             (numpy.complex64, numpy.complex64),
         ],
-        'fp32_compute_type': [
-            cupy.core.core.FP32_COMPUTE_DEFAULT,
-            cupy.core.core.FP32_COMPUTE_PEDANTIC,
-            cupy.core.core.FP32_COMPUTE_FAST_TF32,
-        ],
     }))
 @testing.gpu
 class TestMatmulFp32ComputeTypes(unittest.TestCase):
+    dtype = numpy.float32
 
     def setUp(self):
-        self.old_fp32_compute_type = cupy.core.get_fp32_compute_type()
-        cupy.core.set_fp32_compute_type(self.fp32_compute_type)
+        self.old_compute_type = cupy.core.get_compute_type(self.dtype)
+        cupy.core.set_compute_type(self.dtype, self.compute_type)
 
     def tearDown(self):
-        cupy.core.set_fp32_compute_type(self.old_fp32_compute_type)
+        cupy.core.set_compute_type(self.dtype, self.old_compute_type)
 
     @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-3)
     def test_operator_matmul(self, xp):
@@ -168,6 +207,54 @@ class TestMatmulFp32ComputeTypes(unittest.TestCase):
         return operator.matmul(x1, x2)
 
     @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-3)
+    def test_cupy_matmul(self, xp):
+        shape1, shape2 = self.shape_pair
+        dtype1, dtype2 = self.dtype_pair
+        x1 = testing.shaped_random(shape1, xp, dtype1)
+        x2 = testing.shaped_random(shape2, xp, dtype2)
+        return xp.matmul(x1, x2)
+
+
+@testing.parameterize(
+    *testing.product({
+        'shape_pair': [
+            ((100, 200), (200, 300)),
+            ((200, 300), (300, 100)),
+            ((300, 100), (100, 200)),
+        ],
+        'compute_type': [
+            cupy.core.core.COMPUTE_TYPE_DEFAULT,
+            cupy.core.core.COMPUTE_TYPE_PEDANTIC,
+        ],
+        'dtype_pair': [
+            (numpy.float32, numpy.float64),
+            (numpy.float64, numpy.float64),
+            (numpy.float32, numpy.complex128),
+            (numpy.float64, numpy.complex128),
+            (numpy.complex64, numpy.complex128),
+            (numpy.complex128, numpy.complex128),
+        ],
+    }))
+@testing.gpu
+class TestMatmulFp64ComputeTypes(unittest.TestCase):
+    dtype = numpy.float64
+
+    def setUp(self):
+        self.old_compute_type = cupy.core.get_compute_type(self.dtype)
+        cupy.core.set_compute_type(self.dtype, self.compute_type)
+
+    def tearDown(self):
+        cupy.core.set_compute_type(self.dtype, self.old_compute_type)
+
+    @testing.numpy_cupy_allclose()
+    def test_operator_matmul(self, xp):
+        shape1, shape2 = self.shape_pair
+        dtype1, dtype2 = self.dtype_pair
+        x1 = testing.shaped_random(shape1, xp, dtype1)
+        x2 = testing.shaped_random(shape2, xp, dtype2)
+        return operator.matmul(x1, x2)
+
+    @testing.numpy_cupy_allclose()
     def test_cupy_matmul(self, xp):
         shape1, shape2 = self.shape_pair
         dtype1, dtype2 = self.dtype_pair


### PR DESCRIPTION
This PR allows users to use TF32 for single precision matrix multiply computation on A100 GPU.

You can enable use of TF32 by setting a environment variable `CUPY_TF32=1`. 
This is related to https://github.com/cupy/cupy/issues/3602.
