### PR TITLE
Improve median_filter, rank_filter and percentile_filter

### DIFF
--- a/cupyx/scipy/ndimage/filters.py
+++ b/cupyx/scipy/ndimage/filters.py
@@ -963,26 +963,6 @@ __device__ void sort(X *array, int size) {{
 }}'''
 
 
-__SELECTION_SORT = '''
-__device__ void sort(X *array, int size) {
-    for (int i = 0; i < size-1; ++i) {
-        X min_val = array[i];
-        int min_idx = i;
-        for (int j = i+1; j < size; ++j) {
-            X val_j = array[j];
-            if (val_j < min_val) {
-                min_idx = j;
-                min_val = val_j;
-            }
-        }
-        if (i != min_idx) {
-            array[min_idx] = array[i];
-            array[i] = min_val;
-        }
-    }
-}'''
-
-
 @cupy.util.memoize()
 def _get_shell_gap(filter_size):
     gap = 1
@@ -994,19 +974,11 @@ def _get_shell_gap(filter_size):
 @cupy.util.memoize(for_each_device=True)
 def _get_rank_kernel(filter_size, rank, mode, w_shape, offsets, cval,
                      int_type):
-    # Below 225 (15x15 median filter) selection sort is 1.5-2.5x faster
-    # Above, shell sort does progressively better (by 3025 (55x55) it is 9x)
-    # Also tried insertion sort, which is always slower than either one
-    sorter = __SELECTION_SORT if filter_size <= 255 else \
-        __SHELL_SORT.format(gap=_get_shell_gap(filter_size))
-
-    if filter_size > 255:
-        array_size = filter_size
-        found_post = ''
-        post = 'sort(values,{});\ny=cast<Y>(values[{}]);'.format(
-            filter_size, rank)
-    else:
-        s_rank = min(rank, filter_size - rank - 1)
+    s_rank = min(rank, filter_size - rank - 1)
+    if s_rank <= 80:
+        # When s_rank is small and register usage is low, this partial
+        # selection sort approach is faster than general sorting approach
+        # using shell sort.
         if s_rank == rank:
             comp_op = '<'
         else:
@@ -1014,10 +986,9 @@ def _get_rank_kernel(filter_size, rank, mode, w_shape, offsets, cval,
         array_size = s_rank + 1
         found_post = '''
             if (iv > {rank} + 1) {{{{
-                iv--;
-                int target_iv = {rank} + 1;
-                X target_val = values[{rank} + 1];
-                for (int jv = 0; jv <= {rank}; jv++) {{{{
+                int target_iv = 0;
+                X target_val = values[0];
+                for (int jv = 1; jv <= {rank} + 1; jv++) {{{{
                     if (target_val {comp_op} values[jv]) {{{{
                         target_val = values[jv];
                         target_iv = jv;
@@ -1026,6 +997,7 @@ def _get_rank_kernel(filter_size, rank, mode, w_shape, offsets, cval,
                 if (target_iv <= {rank}) {{{{
                     values[target_iv] = values[{rank} + 1];
                 }}}}
+                iv = {rank} + 1;
             }}}}'''.format(rank=s_rank, comp_op=comp_op)
         post = '''
             X target_val = values[0];
@@ -1035,6 +1007,13 @@ def _get_rank_kernel(filter_size, rank, mode, w_shape, offsets, cval,
                 }}
             }}
             y=cast<Y>(target_val);'''.format(rank=s_rank, comp_op=comp_op)
+        sorter = ''
+    else:
+        array_size = filter_size
+        found_post = ''
+        post = 'sort(values,{});\ny=cast<Y>(values[{}]);'.format(
+            filter_size, rank)
+        sorter = __SHELL_SORT.format(gap=_get_shell_gap(filter_size))
 
     return _filters_core._generate_nd_kernel(
         'rank_{}_{}'.format(filter_size, rank),


### PR DESCRIPTION
This PR improves the performance of `median_filter` and `rank_filter`.

The current implementation sorts it in ascending order after loading the data to registers and then retrieves the median, but you don't need to sort it completely if you just want to get the median. So, this PR uses a kind of incomplete sort to reduce the amount of comparisons. As you can seen below, for filter sizes of 15x15 or smaller, the performance improvement is about 2x.


* time-mf.py:
```
import cupy
import cupyx
import cupyx.scipy
import cupyx.scipy.ndimage

w, h = 1920, 1080 
print('w, h = {}, {}'.format(w, h))
a = cupy.random.rand(w, h, dtype=cupy.float32)
for size in 3, 5, 7, 9, 11, 13, 15:
    name = 'median_filter(' + str(size) + 'x' + str(size) + ')'
    perf = cupyx.time.repeat(cupyx.scipy.ndimage.median_filter, (a, size),
                             name=name, n_repeat=10, n_warmup=3)
    print(perf)
```

```
[Current implementation]
$ python time-mf.py 
w, h = 1920, 1080
median_filter(3x3)  :    CPU:  159.984 us   +/- 4.238 (min:  155.596 / max:  170.040) us     GPU-0:  530.883 us   +/- 4.633 (min:  527.104 / max:  543.104) us
median_filter(5x5)  :    CPU:  160.139 us   +/- 2.961 (min:  155.672 / max:  164.793) us     GPU-0: 1990.214 us   +/-11.140 (min: 1969.984 / max: 2013.568) us
median_filter(7x7)  :    CPU:  165.803 us   +/- 4.487 (min:  159.723 / max:  173.690) us     GPU-0:16050.630 us   +/-32.323 (min:15983.424 / max:16095.968) us
median_filter(9x9)  :    CPU:  164.968 us   +/- 3.751 (min:  160.380 / max:  171.572) us     GPU-0:59935.376 us   +/-123.373 (min:59773.602 / max:60218.143) us
median_filter(11x11):    CPU:  169.125 us   +/- 3.474 (min:  163.483 / max:  175.296) us     GPU-0:119576.460 us   +/-157.452 (min:119345.535 / max:119853.439) us
median_filter(13x13):    CPU:  173.116 us   +/- 5.555 (min:  168.570 / max:  188.751) us     GPU-0:224965.799 us   +/-308.200 (min:224281.479 / max:225359.528) us
median_filter(15x15):    CPU:  175.687 us   +/- 2.897 (min:  172.112 / max:  180.929) us     GPU-0:385540.472 us   +/-336.706 (min:385155.853 / max:386237.213) us

[This PR]
$ python time-mf.py 
w, h = 1920, 1080
median_filter(3x3)  :    CPU:  157.404 us   +/- 3.100 (min:  153.655 / max:  163.095) us     GPU-0:  355.120 us   +/- 3.435 (min:  351.488 / max:  362.240) us
median_filter(5x5)  :    CPU:  160.246 us   +/- 3.673 (min:  156.289 / max:  166.766) us     GPU-0: 1033.965 us   +/- 6.709 (min: 1025.888 / max: 1047.776) us
median_filter(7x7)  :    CPU:  163.897 us   +/- 5.963 (min:  158.253 / max:  175.108) us     GPU-0: 6635.002 us   +/-28.938 (min: 6593.568 / max: 6680.672) us
median_filter(9x9)  :    CPU:  160.784 us   +/- 1.976 (min:  157.023 / max:  164.171) us     GPU-0:31882.397 us   +/-179.481 (min:31748.735 / max:32185.986) us
median_filter(11x11):    CPU:  162.823 us   +/- 2.042 (min:  160.099 / max:  165.849) us     GPU-0:64438.470 us   +/-29.972 (min:64391.487 / max:64483.459) us
median_filter(13x13):    CPU:  164.799 us   +/- 4.729 (min:  159.304 / max:  172.886) us     GPU-0:117540.141 us   +/-37.108 (min:117467.773 / max:117624.641) us
median_filter(15x15):    CPU:  167.204 us   +/- 5.233 (min:  161.672 / max:  180.634) us     GPU-0:196855.058 us   +/-68.851 (min:196754.333 / max:196973.984) us
```