### PR TITLE
Deprecate `cupy.sparse` package

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -796,7 +796,7 @@ def get_array_module(*args):
 
     """
     for arg in args:
-        if isinstance(arg, (ndarray, sparse.spmatrix,
+        if isinstance(arg, (ndarray, cupyx.scipy.sparse.spmatrix,
                             cupy.core.fusion._FusionVarArray,
                             cupy.core.new_fusion._ArrayProxy)):
             return _cupy

--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -59,6 +59,7 @@ from cupy import linalg  # NOQA
 from cupy import manipulation  # NOQA
 from cupy import polynomial  # NOQA
 from cupy import random  # NOQA
+# `cupy.sparse` is deprecated in v8
 from cupy import sparse  # NOQA
 from cupy import statistics  # NOQA
 from cupy import testing  # NOQA  # NOQA

--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -797,7 +797,7 @@ def get_array_module(*args):
 
     """
     for arg in args:
-        if isinstance(arg, (ndarray, cupyx.scipy.sparse.spmatrix,
+        if isinstance(arg, (ndarray, _cupyx.scipy.sparse.spmatrix,
                             cupy.core.fusion._FusionVarArray,
                             cupy.core.new_fusion._ArrayProxy)):
             return _cupy

--- a/cupy/sparse/__init__.py
+++ b/cupy/sparse/__init__.py
@@ -1,49 +1,62 @@
+import sys
 import warnings
 
-warnings.warn(
-    'cupy.sparse is deprecated. Use cupyx.scipy.sparse instead.',
-    DeprecationWarning)
+import cupyx.scipy.sparse
 
-from cupyx.scipy.sparse.base import issparse  # NOQA
-from cupyx.scipy.sparse.base import isspmatrix  # NOQA
-from cupyx.scipy.sparse.base import spmatrix  # NOQA
-from cupyx.scipy.sparse.coo import coo_matrix  # NOQA
-from cupyx.scipy.sparse.coo import isspmatrix_coo  # NOQA
-from cupyx.scipy.sparse.csc import csc_matrix  # NOQA
-from cupyx.scipy.sparse.csc import isspmatrix_csc  # NOQA
-from cupyx.scipy.sparse.csr import csr_matrix  # NOQA
-from cupyx.scipy.sparse.csr import isspmatrix_csr  # NOQA
-from cupyx.scipy.sparse.dia import dia_matrix  # NOQA
-from cupyx.scipy.sparse.dia import isspmatrix_dia  # NOQA
 
-from cupyx.scipy.sparse.construct import eye  # NOQA
-from cupyx.scipy.sparse.construct import identity  # NOQA
-from cupyx.scipy.sparse.construct import rand  # NOQA
-from cupyx.scipy.sparse.construct import random  # NOQA
-from cupyx.scipy.sparse.construct import spdiags  # NOQA
+# Raise a `DeprecationWarning` for `cupy.sparse` submodule when its functions
+# are called. We could raise the warning on importing the submodule, but we
+# use module level `__getattr__` function here as the submodule is also
+# imported in cupy/__init__.py. Unfortunately, module level `__getattr__` is
+# supported on Python 3.7 and higher, so we need to keep the explicit import
+# list for older Python.
+if (3, 7) <= sys.version_info:
+    def __getattr__(name):
+        if hasattr(cupyx.scipy.sparse, name):
+            msg = 'cupy.sparse is deprecated. Use cupyx.scipy.sparse instead.'
+            warnings.warn(msg, DeprecationWarning)
+            return getattr(cupyx.scipy.sparse, name)
+else:
+    from cupyx.scipy.sparse.base import issparse  # NOQA
+    from cupyx.scipy.sparse.base import isspmatrix  # NOQA
+    from cupyx.scipy.sparse.base import spmatrix  # NOQA
+    from cupyx.scipy.sparse.coo import coo_matrix  # NOQA
+    from cupyx.scipy.sparse.coo import isspmatrix_coo  # NOQA
+    from cupyx.scipy.sparse.csc import csc_matrix  # NOQA
+    from cupyx.scipy.sparse.csc import isspmatrix_csc  # NOQA
+    from cupyx.scipy.sparse.csr import csr_matrix  # NOQA
+    from cupyx.scipy.sparse.csr import isspmatrix_csr  # NOQA
+    from cupyx.scipy.sparse.dia import dia_matrix  # NOQA
+    from cupyx.scipy.sparse.dia import isspmatrix_dia  # NOQA
 
-from cupyx.scipy.sparse.construct import bmat  # NOQA
-from cupyx.scipy.sparse.construct import hstack  # NOQA
-from cupyx.scipy.sparse.construct import vstack  # NOQA
+    from cupyx.scipy.sparse.construct import eye  # NOQA
+    from cupyx.scipy.sparse.construct import identity  # NOQA
+    from cupyx.scipy.sparse.construct import rand  # NOQA
+    from cupyx.scipy.sparse.construct import random  # NOQA
+    from cupyx.scipy.sparse.construct import spdiags  # NOQA
 
-# TODO(unno): implement bsr_matrix
-# TODO(unno): implement dok_matrix
-# TODO(unno): implement lil_matrix
+    from cupyx.scipy.sparse.construct import bmat  # NOQA
+    from cupyx.scipy.sparse.construct import hstack  # NOQA
+    from cupyx.scipy.sparse.construct import vstack  # NOQA
 
-from cupyx.scipy.sparse.construct import kron  # NOQA
-# TODO(unno): implement kronsum
-# TODO(unno): implement diags
-# TODO(unno): implement block_diag
-# TODO(unno): implement tril
-# TODO(unno): implement triu
+    # TODO(unno): implement bsr_matrix
+    # TODO(unno): implement dok_matrix
+    # TODO(unno): implement lil_matrix
 
-# TODO(unno): implement save_npz
-# TODO(unno): implement load_npz
+    from cupyx.scipy.sparse.construct import kron  # NOQA
+    # TODO(unno): implement kronsum
+    # TODO(unno): implement diags
+    # TODO(unno): implement block_diag
+    # TODO(unno): implement tril
+    # TODO(unno): implement triu
 
-# TODO(unno): implement find
+    # TODO(unno): implement save_npz
+    # TODO(unno): implement load_npz
 
-# TODO(unno): implement isspmatrix_bsr(x)
-# TODO(unno): implement isspmatrix_lil(x)
-# TODO(unno): implement isspmatrix_dok(x)
+    # TODO(unno): implement find
 
-from cupyx.scipy.sparse import linalg  # NOQA
+    # TODO(unno): implement isspmatrix_bsr(x)
+    # TODO(unno): implement isspmatrix_lil(x)
+    # TODO(unno): implement isspmatrix_dok(x)
+
+    from cupyx.scipy.sparse import linalg  # NOQA

--- a/cupy/sparse/__init__.py
+++ b/cupy/sparse/__init__.py
@@ -1,3 +1,9 @@
+import warnings
+
+warnings.warn(
+    'cupy.sparse is deprecated. Use cupyx.scipy.sparse instead.',
+    DeprecationWarning)
+
 from cupyx.scipy.sparse.base import issparse  # NOQA
 from cupyx.scipy.sparse.base import isspmatrix  # NOQA
 from cupyx.scipy.sparse.base import spmatrix  # NOQA

--- a/cupyx/linalg/sparse/solve.py
+++ b/cupyx/linalg/sparse/solve.py
@@ -4,7 +4,7 @@ import cupy
 from cupy.cuda import cusolver
 from cupy.cuda import device
 from cupy.linalg import util
-import cupy.sparse
+from cupyx.scipy import sparse
 
 
 def lschol(A, b):
@@ -15,8 +15,8 @@ def lschol(A, b):
     decomposed into ``L * L^*``.
 
     Args:
-        A (cupy.ndarray or cupy.sparse.csr_matrix): The input matrix with
-            dimension ``(N, N)``. Must be positive-definite input matrix.
+        A (cupy.ndarray or cupyx.scipy.sparse.csr_matrix): The input matrix
+            with dimension ``(N, N)``. Must be positive-definite input matrix.
             Only symmetric real matrix is supported currently.
         b (cupy.ndarray): Right-hand side vector.
 
@@ -25,8 +25,8 @@ def lschol(A, b):
 
     """
 
-    if not cupy.sparse.isspmatrix_csr(A):
-        A = cupy.sparse.csr_matrix(A)
+    if not sparse.isspmatrix_csr(A):
+        A = sparse.csr_matrix(A)
     util._assert_nd_squareness(A)
     util._assert_cupy_array(b)
     m = A.shape[0]

--- a/cupyx/scipy/sparse/construct.py
+++ b/cupyx/scipy/sparse/construct.py
@@ -145,7 +145,7 @@ def hstack(blocks, format=None, dtype=None):
 
     Examples:
         >>> from cupy import array
-        >>> from cupy.sparse import csr_matrix, hstack
+        >>> from cupyx.scipy.sparse import csr_matrix, hstack
         >>> A = csr_matrix(array([[1., 2.], [3., 4.]]))
         >>> B = csr_matrix(array([[5.], [6.]]))
         >>> hstack([A, B]).toarray()
@@ -176,7 +176,7 @@ def vstack(blocks, format=None, dtype=None):
 
     Examples:
         >>> from cupy import array
-        >>> from cupy.sparse import csr_matrix, vstack
+        >>> from cupyx.scipy.sparse import csr_matrix, vstack
         >>> A = csr_matrix(array([[1., 2.], [3., 4.]]))
         >>> B = csr_matrix(array([[5., 6.]]))
         >>> vstack([A, B]).toarray()
@@ -208,7 +208,7 @@ def bmat(blocks, format=None, dtype=None):
 
     Examples:
         >>> from cupy import array
-        >>> from cupy.sparse import csr_matrix, bmat
+        >>> from cupyx.scipy.sparse import csr_matrix, bmat
         >>> A = csr_matrix(array([[1., 2.], [3., 4.]]))
         >>> B = csr_matrix(array([[5.], [6.]]))
         >>> C = csr_matrix(array([[7.]]))

--- a/examples/stream/cusparse.py
+++ b/examples/stream/cusparse.py
@@ -1,5 +1,6 @@
 # nvprof --print-gpu-trace python examples/stream/cusparse.py
 import cupy
+import cupyx
 
 
 def _make(xp, sp, dtype):
@@ -12,7 +13,7 @@ def _make(xp, sp, dtype):
     return sp.csc_matrix((data, indices, indptr), shape=(3, 4))
 
 
-x = _make(cupy, cupy.sparse, float)
+x = _make(cupy, cupyx.scipy.sparse, float)
 expected = cupy.cusparse.cscsort(x)
 cupy.cuda.Device().synchronize()
 

--- a/tests/cupy_tests/test_numpy_interop.py
+++ b/tests/cupy_tests/test_numpy_interop.py
@@ -4,7 +4,7 @@ import numpy
 
 import cupy
 from cupy import testing
-
+import cupyx
 
 try:
     import scipy.sparse
@@ -19,7 +19,7 @@ class TestGetArrayModule(unittest.TestCase):
     def test_get_array_module_1(self):
         n1 = numpy.array([2], numpy.float32)
         c1 = cupy.array([2], numpy.float32)
-        csr1 = cupy.sparse.csr_matrix((5, 3), dtype=numpy.float32)
+        csr1 = cupyx.scipy.sparse.csr_matrix((5, 3), dtype=numpy.float32)
 
         self.assertIs(numpy, cupy.get_array_module())
         self.assertIs(numpy, cupy.get_array_module(n1))

--- a/tests/cupyx_tests/linalg_tests/sparse_tests/test_solve.py
+++ b/tests/cupyx_tests/linalg_tests/sparse_tests/test_solve.py
@@ -12,10 +12,10 @@ except ImportError:
     scipy_available = False
 
 import cupy as cp
-import cupy.sparse as sp
 from cupy import testing
 from cupy.testing import condition
 import cupyx
+import cupyx.scipy.sparse as sp
 
 
 @testing.parameterize(*testing.product({

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_index.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_index.py
@@ -2,8 +2,8 @@ import unittest
 
 import cupy
 
-from cupy import sparse
 from cupy import testing
+from cupyx.scipy import sparse
 
 import numpy
 


### PR DESCRIPTION
Close #3773.

This PR raises a deprecation warning for `cupy.sparse` package as discussed in #3773.
