### PR TITLE
ROCm: Support rocTX

### DIFF
--- a/cupy_backends/cuda/cupy_cuda.h
+++ b/cupy_backends/cuda/cupy_cuda.h
@@ -920,6 +920,29 @@ cudaError_t cudaProfilerStop() {
 
 #define NVTX_VERSION 1
 
+void nvtxMarkA(...) {
+}
+
+int nvtxRangePushA(...) {
+    return 0;
+}
+
+int nvtxRangePop() {
+    return 0;
+}
+
+} // extern "C"
+
+#endif // #ifndef CUPY_NO_CUDA
+
+#if (defined(CUPY_NO_CUDA) || defined(CUPY_USE_HIP))
+// Common stubs shared by both no-cuda and hip environments
+extern "C" {
+
+///////////////////////////////////////////////////////////////////////////////
+// nvToolsExt.h
+///////////////////////////////////////////////////////////////////////////////
+
 typedef enum nvtxColorType_t
 {
     NVTX_COLOR_UNKNOWN  = 0,
@@ -960,21 +983,10 @@ typedef struct nvtxEventAttributes_v1
 
 typedef nvtxEventAttributes_v1 nvtxEventAttributes_t;
 
-void nvtxMarkA(...) {
-}
-
 void nvtxMarkEx(...) {
 }
 
-int nvtxRangePushA(...) {
-    return 0;
-}
-
 int nvtxRangePushEx(...) {
-    return 0;
-}
-
-int nvtxRangePop() {
     return 0;
 }
 
@@ -985,7 +997,8 @@ uint64_t nvtxRangeStartEx(...) {
 void nvtxRangeEnd(...) {
 }
 
+#endif // #if (defined(CUPY_NO_CUDA) || defined(CUPY_USE_HIP))
+
 } // extern "C"
 
-#endif // #ifndef CUPY_NO_CUDA
 #endif // #ifndef INCLUDE_GUARD_CUPY_CUDA_H

--- a/cupy_backends/cuda/cupy_cuda.h
+++ b/cupy_backends/cuda/cupy_cuda.h
@@ -997,8 +997,8 @@ uint64_t nvtxRangeStartEx(...) {
 void nvtxRangeEnd(...) {
 }
 
-#endif // #if (defined(CUPY_NO_CUDA) || defined(CUPY_USE_HIP))
-
 } // extern "C"
+
+#endif // #if (defined(CUPY_NO_CUDA) || defined(CUPY_USE_HIP))
 
 #endif // #ifndef INCLUDE_GUARD_CUPY_CUDA_H

--- a/cupy_backends/cuda/cupy_hip.h
+++ b/cupy_backends/cuda/cupy_hip.h
@@ -6,6 +6,9 @@
 #include <hiprand/hiprand.h>
 #include "cupy_hip_common.h"
 #include "cupy_cuComplex.h"
+#ifndef CUPY_NO_NVTX
+#include <roctx.h>
+#endif // #ifndef CUPY_NO_NVTX
 
 extern "C" {
 
@@ -1064,6 +1067,38 @@ cudaError_t cudaProfilerStart() {
 
 cudaError_t cudaProfilerStop() {
   return hipProfilerStop();
+}
+
+
+///////////////////////////////////////////////////////////////////////////////
+// roctx
+///////////////////////////////////////////////////////////////////////////////
+
+void nvtxMarkA(const char* message) {
+    roctxMarkA(message);
+}
+
+int nvtxRangePushA(const char* message) {
+    return roctxRangePushA(message);
+}
+
+int nvtxRangePop() {
+    return roctxRangePop();
+}
+
+// ----- stubs that are no-ops (copied from cupy_backends/cuda/cupy_cuda.h) -----
+void nvtxMarkEx(...) {
+}
+
+int nvtxRangePushEx(...) {
+    return 0;
+}
+
+uint64_t nvtxRangeStartEx(...) {
+    return 0;
+}
+
+void nvtxRangeEnd(...) {
 }
 
 } // extern "C"

--- a/cupy_backends/cuda/cupy_hip.h
+++ b/cupy_backends/cuda/cupy_hip.h
@@ -1086,21 +1086,6 @@ int nvtxRangePop() {
     return roctxRangePop();
 }
 
-// ----- stubs that are no-ops (copied from cupy_backends/cuda/cupy_cuda.h) -----
-void nvtxMarkEx(...) {
-}
-
-int nvtxRangePushEx(...) {
-    return 0;
-}
-
-uint64_t nvtxRangeStartEx(...) {
-    return 0;
-}
-
-void nvtxRangeEnd(...) {
-}
-
 } // extern "C"
 
 #endif // #ifndef INCLUDE_GUARD_CUPY_HIP_H

--- a/cupy_backends/cuda/cupy_hip_common.h
+++ b/cupy_backends/cuda/cupy_hip_common.h
@@ -130,49 +130,8 @@ typedef enum libraryPropertyType_t {
 // roctx
 ///////////////////////////////////////////////////////////////////////////////
 
-// this is to make roctxMarkA etc work; ROCm does not yet support the "Ex" APIs
+// this is to ensure we use non-"Ex" APIs like roctxMarkA etc
 #define NVTX_VERSION (100 * ROCTX_VERSION_MAJOR + 10 * ROCTX_VERSION_MINOR)
-
-// ----- stubs that are no-ops (copied from cupy_backends/cuda/cupy_cuda.h) -----
-typedef enum nvtxColorType_t
-{
-    NVTX_COLOR_UNKNOWN  = 0,
-    NVTX_COLOR_ARGB     = 1
-} nvtxColorType_t;
-
-typedef enum nvtxMessageType_t
-{
-    NVTX_MESSAGE_UNKNOWN          = 0,
-    NVTX_MESSAGE_TYPE_ASCII       = 1,
-    NVTX_MESSAGE_TYPE_UNICODE     = 2,
-} nvtxMessageType_t;
-
-typedef union nvtxMessageValue_t
-{
-    const char* ascii;
-    const wchar_t* unicode;
-} nvtxMessageValue_t;
-
-typedef struct nvtxEventAttributes_v1
-{
-    uint16_t version;
-    uint16_t size;
-    uint32_t category;
-    int32_t colorType;
-    uint32_t color;
-    int32_t payloadType;
-    int32_t reserved0;
-    union payload_t
-    {
-        uint64_t ullValue;
-        int64_t llValue;
-        double dValue;
-    } payload;
-    int32_t messageType;
-    nvtxMessageValue_t message;
-} nvtxEventAttributes_v1;
-
-typedef nvtxEventAttributes_v1 nvtxEventAttributes_t;
 
 } // extern "C"
 

--- a/cupy_backends/cuda/cupy_hip_common.h
+++ b/cupy_backends/cuda/cupy_hip_common.h
@@ -125,6 +125,55 @@ typedef enum libraryPropertyType_t {
     PATCH_LEVEL
 } libraryPropertyType;
 
+
+///////////////////////////////////////////////////////////////////////////////
+// roctx
+///////////////////////////////////////////////////////////////////////////////
+
+// this is to make roctxMarkA etc work; ROCm does not yet support the "Ex" APIs
+#define NVTX_VERSION (100 * ROCTX_VERSION_MAJOR + 10 * ROCTX_VERSION_MINOR)
+
+// ----- stubs that are no-ops (copied from cupy_backends/cuda/cupy_cuda.h) -----
+typedef enum nvtxColorType_t
+{
+    NVTX_COLOR_UNKNOWN  = 0,
+    NVTX_COLOR_ARGB     = 1
+} nvtxColorType_t;
+
+typedef enum nvtxMessageType_t
+{
+    NVTX_MESSAGE_UNKNOWN          = 0,
+    NVTX_MESSAGE_TYPE_ASCII       = 1,
+    NVTX_MESSAGE_TYPE_UNICODE     = 2,
+} nvtxMessageType_t;
+
+typedef union nvtxMessageValue_t
+{
+    const char* ascii;
+    const wchar_t* unicode;
+} nvtxMessageValue_t;
+
+typedef struct nvtxEventAttributes_v1
+{
+    uint16_t version;
+    uint16_t size;
+    uint32_t category;
+    int32_t colorType;
+    uint32_t color;
+    int32_t payloadType;
+    int32_t reserved0;
+    union payload_t
+    {
+        uint64_t ullValue;
+        int64_t llValue;
+        double dValue;
+    } payload;
+    int32_t messageType;
+    nvtxMessageValue_t message;
+} nvtxEventAttributes_v1;
+
+typedef nvtxEventAttributes_v1 nvtxEventAttributes_t;
+
 } // extern "C"
 
 #endif // #ifndef INCLUDE_GUARD_CUPY_HIP_COMMON_H

--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -89,20 +89,26 @@ cuda_files = [
 ]
 
 if use_hip:
+    # We handle nvtx (and likely any other future support) here, because
+    # the HIP stubs (cupy_hip.h/cupy_hip_common.h) would cause many symbols
+    # to leak into all these modules even if unused. It's easier for all of
+    # them to link to the same set of shared libraries.
     MODULES.append({
         'name': 'cuda',
-        'file': cuda_files,
+        'file': cuda_files + ['cupy.cuda.nvtx'],
         'include': [
             'hip/hip_runtime_api.h',
             'hip/hiprtc.h',
             'hipblas.h',
             'hiprand/hiprand.h',
+            'roctx.h',
         ],
         'libraries': [
             'hiprtc',
             'hip_hcc',
             'hipblas',
             'hiprand',
+            'roctx64',
         ],
     })
 else:

--- a/install/build.py
+++ b/install/build.py
@@ -147,9 +147,9 @@ def get_compiler_setting(use_hip):
     if rocm_path:
         include_dirs.append(os.path.join(rocm_path, 'include'))
         include_dirs.append(os.path.join(rocm_path, 'include', 'hip'))
-        include_dirs.append(os.path.join(rocm_path, 'rocrand', 'include'))
+        include_dirs.append(os.path.join(rocm_path, 'include', 'rocrand'))
+        include_dirs.append(os.path.join(rocm_path, 'include', 'roctracer'))
         library_dirs.append(os.path.join(rocm_path, 'lib'))
-        library_dirs.append(os.path.join(rocm_path, 'rocrand', 'lib'))
 
     if use_hip:
         extra_compile_args.append('-std=c++11')


### PR DESCRIPTION
rocTX seems to be NVTX's counterpart on ROCm. `tests/cupy_tests/prof_tests/test_range.py` and `tests/cupy_tests/cuda_tests/test_nvtx.py` passed locally.