### PR TITLE
Fix test to run without cuDNN

### DIFF
--- a/tests/cupy_tests/test_cudnn.py
+++ b/tests/cupy_tests/test_cudnn.py
@@ -4,6 +4,7 @@ import numpy
 
 import cupy
 import cupy.cuda.cudnn as libcudnn
+from cupy import testing
 
 
 cudnn_enabled = libcudnn.available
@@ -32,8 +33,6 @@ else:
     modes = []
     coef_modes = []
     layouts = []
-
-from cupy import testing
 
 
 @testing.parameterize(*testing.product({

--- a/tests/cupy_tests/test_cudnn.py
+++ b/tests/cupy_tests/test_cudnn.py
@@ -3,10 +3,13 @@ import unittest
 import numpy
 
 import cupy
+import cupy.cuda.cudnn as libcudnn
 
-try:
-    import cupy.cuda.cudnn as libcudnn
-    cudnn_enabled = True
+
+cudnn_enabled = libcudnn.available
+
+
+if cudnn_enabled:
     modes = [
         libcudnn.CUDNN_ACTIVATION_SIGMOID,
         libcudnn.CUDNN_ACTIVATION_RELU,
@@ -24,8 +27,7 @@ try:
         coef_modes.append(libcudnn.CUDNN_ACTIVATION_ELU)
 
     from cupy import cudnn
-except ImportError:
-    cudnn_enabled = False
+else:
     cudnn_version = -1
     modes = []
     coef_modes = []


### PR DESCRIPTION
Follow-up #3731.

The test fails to run in environment without cuDNN.