### PR TITLE
Improve CSR matrix `getrow`, `getcol` and some slicing

### DIFF
--- a/cupyx/scipy/sparse/compressed.py
+++ b/cupyx/scipy/sparse/compressed.py
@@ -486,9 +486,10 @@ class _compressed_sparse_matrix(sparse_data._data_matrix,
     def _get_intXint(self, row, col):
         major, minor = self._swap(row, col)
 
-        indptr, indices, data = _index._get_csr_submatrix(
-            self.indptr, self.indices, self.data,
-            major, major + 1, minor, minor + 1)
+        indptr, indices, data = _index._get_csr_submatrix_major_axis(
+            self.indptr, self.indices, self.data, major, major + 1)
+        indptr, indices, data = _index._get_csr_submatrix_minor_axis(
+            indptr, indices, data, minor, minor + 1)
         return data.sum(dtype=self.dtype)
 
     def _get_sliceXslice(self, row, col):
@@ -633,8 +634,10 @@ class _compressed_sparse_matrix(sparse_data._data_matrix,
         if i0 == 0 and j0 == 0 and i1 == M and j1 == N:
             return self.copy() if copy else self
 
-        indptr, indices, data = _index._get_csr_submatrix(
-            self.indptr, self.indices, self.data, i0, i1, j0, j1)
+        indptr, indices, data = _index._get_csr_submatrix_major_axis(
+            self.indptr, self.indices, self.data, i0, i1)
+        indptr, indices, data = _index._get_csr_submatrix_minor_axis(
+            indptr, indices, data, j0, j1)
 
         shape = self._swap(i1 - i0, j1 - j0)
         return self.__class__((data, indices, indptr), shape=shape,

--- a/cupyx/scipy/sparse/compressed.py
+++ b/cupyx/scipy/sparse/compressed.py
@@ -631,13 +631,20 @@ class _compressed_sparse_matrix(sparse_data._data_matrix,
         i0, i1 = self._process_slice(major, M)
         j0, j1 = self._process_slice(minor, N)
 
-        if i0 == 0 and j0 == 0 and i1 == M and j1 == N:
+        is_major_full = i0 == 0 and i1 == M
+        is_minor_full = j0 == 0 and j1 == N
+
+        if is_major_full and is_minor_full:
             return self.copy() if copy else self
 
-        indptr, indices, data = _index._get_csr_submatrix_major_axis(
-            self.indptr, self.indices, self.data, i0, i1)
-        indptr, indices, data = _index._get_csr_submatrix_minor_axis(
-            indptr, indices, data, j0, j1)
+        indptr, indices, data = self.indptr, self.indices, self.data
+
+        if not is_major_full:
+            indptr, indices, data = _index._get_csr_submatrix_major_axis(
+                indptr, indices, data, i0, i1)
+        if not is_minor_full:
+            indptr, indices, data = _index._get_csr_submatrix_minor_axis(
+                indptr, indices, data, j0, j1)
 
         shape = self._swap(i1 - i0, j1 - j0)
         return self.__class__((data, indices, indptr), shape=shape,

--- a/cupyx/scipy/sparse/csr.py
+++ b/cupyx/scipy/sparse/csr.py
@@ -392,8 +392,8 @@ class csr_matrix(compressed._compressed_sparse_matrix):
         """
         M, N = self.shape
         i = _index._normalize_index(i, M, 'index')
-        indptr, indices, data = _index._get_csr_submatrix(
-            self.indptr, self.indices, self.data, i, i + 1, 0, N)
+        indptr, indices, data = _index._get_csr_submatrix_major_axis(
+            self.indptr, self.indices, self.data, i, i + 1)
         return csr_matrix((data, indices, indptr), shape=(1, N),
                           dtype=self.dtype, copy=False)
 
@@ -409,8 +409,8 @@ class csr_matrix(compressed._compressed_sparse_matrix):
         """
         M, N = self.shape
         i = _index._normalize_index(i, N, 'index')
-        indptr, indices, data = _index._get_csr_submatrix(
-            self.indptr, self.indices, self.data, 0, M, i, i + 1)
+        indptr, indices, data = _index._get_csr_submatrix_minor_axis(
+            self.indptr, self.indices, self.data, i, i + 1)
         return csr_matrix((data, indices, indptr), shape=(M, 1),
                           dtype=self.dtype, copy=False)
 


### PR DESCRIPTION
Split `_get_csr_submatrix` into `_get_csr_submatrix_major_axis` and `_get_csr_submatrix_minor_axis`, and reduced redundant operations in `getrow`, `getcol` and `_get_submatrix` methods.

- Current master
```
- name = major_slice_minor_all, major = slice(1, 500, None), minor = slice(None, None, None), format = csr, density = 0.5, dtype = float32, n_rows = 15000, n_cols = 15000
cupy.sparse         :    CPU:  898.847 us   +/-22.038 (min:  884.982 / max: 1584.682) us     GPU-0:  936.310 us   +/-21.587 (min:  923.648 / max: 1607.680) us
- name = major_slice_minor_all, major = slice(1, 500, None), minor = slice(None, None, None), format = csc, density = 0.5, dtype = float32, n_rows = 15000, n_cols = 15000
cupy.sparse         :    CPU:17697.888 us   +/-10.398 (min:17671.201 / max:17723.284) us     GPU-0:19043.966 us   +/-10.759 (min:19016.705 / max:19068.928) us
- name = major_slice_minor_all, major = slice(500, 1, None), minor = slice(None, None, None), format = csr, density = 0.5, dtype = float32, n_rows = 15000, n_cols = 15000
cupy.sparse         :    CPU:  212.216 us   +/- 8.211 (min:  207.250 / max:  328.133) us     GPU-0:  218.726 us   +/- 8.340 (min:  212.992 / max:  334.848) us
- name = major_slice_minor_all, major = slice(500, 1, None), minor = slice(None, None, None), format = csc, density = 0.5, dtype = float32, n_rows = 15000, n_cols = 15000
cupy.sparse         :    CPU:16274.945 us   +/- 9.836 (min:16249.525 / max:16300.259) us     GPU-0:16282.394 us   +/- 9.891 (min:16256.832 / max:16307.520) us
```

- This PR
```
- name = major_slice_minor_all, major = slice(1, 500, None), minor = slice(None, None, None), format = csr, density = 0.5, dtype = float32, n_rows = 15000, n_cols = 15000
cupy.sparse         :    CPU:  113.284 us   +/- 8.050 (min:  109.473 / max:  392.246) us     GPU-0:  119.021 us   +/- 8.252 (min:  114.688 / max:  417.792) us
- name = major_slice_minor_all, major = slice(1, 500, None), minor = slice(None, None, None), format = csc, density = 0.5, dtype = float32, n_rows = 15000, n_cols = 15000
cupy.sparse         :    CPU:17630.860 us   +/- 8.538 (min:17605.982 / max:17649.280) us     GPU-0:18977.483 us   +/- 8.478 (min:18952.192 / max:18996.223) us
- name = major_slice_minor_all, major = slice(500, 1, None), minor = slice(None, None, None), format = csr, density = 0.5, dtype = float32, n_rows = 15000, n_cols = 15000
cupy.sparse         :    CPU:  112.120 us   +/- 4.398 (min:  109.138 / max:  170.031) us     GPU-0:  117.900 us   +/- 4.524 (min:  114.688 / max:  177.152) us
- name = major_slice_minor_all, major = slice(500, 1, None), minor = slice(None, None, None), format = csc, density = 0.5, dtype = float32, n_rows = 15000, n_cols = 15000
cupy.sparse         :    CPU:16206.764 us   +/-10.481 (min:16169.540 / max:16233.565) us     GPU-0:16214.711 us   +/-10.464 (min:16177.504 / max:16241.535) us
```

cc: @cjnolet 