### PR TITLE
Use `_csr_row_index` for CSR matrix major-axis slicing with step

### DIFF
--- a/cupyx/scipy/sparse/_index.py
+++ b/cupyx/scipy/sparse/_index.py
@@ -269,36 +269,6 @@ def _csr_row_index(rows,
     return Bj, Bx
 
 
-def _csr_row_slice(start_maj, step_maj, Ap, Aj, Ax, Bp):
-    """Populate indices and data arrays of sparse matrix by slicing the
-    rows of an input sparse matrix
-
-    Args
-        start : starting row
-        step : step increment size
-        Ap : indptr array of input sparse matrix
-        Aj : indices array of input sparse matrix
-        Ax : data array of input sparse matrix
-        Bp : indices array of output sparse matrix
-
-    Returns
-        Bj : indices array of output sparse matrix
-        Bx : data array of output sparse matrix
-    """
-
-    in_rows = cupy.arange(start_maj, start_maj + (Bp.size - 1) * step_maj,
-                          step_maj, dtype=Bp.dtype)
-    offsetsB = Ap[in_rows] - Bp[:-1]
-    B_size = int(Bp[-1])
-    offsetsA = offsetsB[
-        cupy.searchsorted(
-            Bp, cupy.arange(B_size, dtype=Bp.dtype), 'right') - 1]
-    offsetsA += cupy.arange(offsetsA.size, dtype=offsetsA.dtype)
-    Bj = Aj[offsetsA]
-    Bx = Ax[offsetsA]
-    return Bj, Bx
-
-
 def _csr_sample_values(n_row, n_col,
                        Ap, Aj, Ax,
                        Bi, Bj):

--- a/cupyx/scipy/sparse/compressed.py
+++ b/cupyx/scipy/sparse/compressed.py
@@ -667,8 +667,11 @@ class _compressed_sparse_matrix(sparse_data._data_matrix,
                                      copy=copy)
             res_data = cupy.array(self.data[idx_start:idx_stop], copy=copy)
         else:
-            res_indices, res_data = _index._csr_row_slice(
-                start, step, self.indptr, self.indices, self.data, res_indptr)
+            rows = cupy.arange(
+                start, start + (res_indptr.size - 1) * step, step,
+                dtype=res_indptr.dtype)
+            res_indices, res_data = _index._csr_row_index(
+                rows, self.indptr, self.indices, self.data, res_indptr)
 
         return self.__class__((res_data, res_indices, res_indptr),
                               shape=new_shape, copy=False)


### PR DESCRIPTION
- Current master
```
- name = major_slice_with_step, major = slice(1, 2000, 2), minor = slice(1, 500, 1), format = csr, density = 0.5, dtype = float32, n_rows = 15000, n_cols = 15000
cupy.sparse         :    CPU: 2618.350 us   +/-37.772 (min: 2603.562 / max: 3321.213) us     GPU-0: 2682.434 us   +/-35.877 (min: 2667.520 / max: 3347.456) us
- name = major_slice_with_step, major = slice(1, 2000, 2), minor = slice(1, 500, 1), format = csr, density = 0.5, dtype = float32, n_rows = 15000, n_cols = 15000
cupy.sparse         :    CPU: 2615.678 us   +/- 4.734 (min: 2602.753 / max: 2630.037) us     GPU-0: 2680.169 us   +/- 4.704 (min: 2667.520 / max: 2696.192) us
- name = major_slice_with_step, major = slice(1, 3000, 2), minor = slice(1, 5000, 1), format = csr, density = 0.5, dtype = float32, n_rows = 15000, n_cols = 15000
cupy.sparse         :    CPU: 3782.382 us   +/- 4.486 (min: 3771.239 / max: 3797.323) us     GPU-0: 3892.929 us   +/- 4.496 (min: 3881.984 / max: 3908.608) us
- name = major_slice_with_step, major = slice(4000, 1, 5), minor = slice(1, 5000, 1), format = csr, density = 0.5, dtype = float32, n_rows = 15000, n_cols = 15000
cupy.sparse         :    CPU:  153.250 us   +/- 5.226 (min:  149.183 / max:  211.506) us     GPU-0:  159.881 us   +/- 5.450 (min:  155.648 / max:  219.136) us
- name = major_slice_with_step, major = slice(1, 4000, 5), minor = slice(1, 5000, 1), format = csr, density = 0.5, dtype = float32, n_rows = 15000, n_cols = 15000
cupy.sparse         :    CPU: 2203.256 us   +/-56.989 (min: 2186.925 / max: 3395.244) us     GPU-0: 2250.098 us   +/-55.509 (min: 2233.344 / max: 3410.944) us
- name = major_slice_with_step, major = slice(2000, 1, 5), minor = slice(None, None, None), format = csr, density = 0.5, dtype = float32, n_rows = 15000, n_cols = 15000
cupy.sparse         :    CPU:   36.950 us   +/- 0.890 (min:   35.760 / max:   70.259) us     GPU-0:   41.417 us   +/- 1.265 (min:   38.912 / max:   77.824) us
- name = major_slice_with_step, major = slice(1, 8000, 5), minor = slice(None, None, None), format = csr, density = 0.5, dtype = float32, n_rows = 15000, n_cols = 15000
cupy.sparse         :    CPU:  384.822 us   +/- 4.121 (min:  377.761 / max:  402.798) us     GPU-0: 2027.716 us   +/- 3.842 (min: 2020.352 / max: 2045.952) us
- name = major_slice_with_step, major = slice(1, 5000, 1), minor = slice(1, 2000, 2), format = csc, density = 0.5, dtype = float32, n_rows = 15000, n_cols = 15000
cupy.sparse         :    CPU: 2638.219 us   +/- 4.742 (min: 2627.506 / max: 2656.222) us     GPU-0: 2703.993 us   +/- 4.691 (min: 2693.120 / max: 2722.816) us
- name = major_slice_with_step, major = slice(1, 5000, 1), minor = slice(2000, 1, 2), format = csc, density = 0.5, dtype = float32, n_rows = 15000, n_cols = 15000
cupy.sparse         :    CPU:  151.155 us   +/- 3.509 (min:  147.597 / max:  214.942) us     GPU-0:  157.778 us   +/- 3.720 (min:  153.600 / max:  222.208) us
- name = major_slice_with_step, major = slice(1, 5000, 1), minor = slice(1, 4000, 2), format = csc, density = 0.5, dtype = float32, n_rows = 15000, n_cols = 15000
cupy.sparse         :    CPU: 4921.069 us   +/-149.628 (min: 4900.054 / max: 7013.090) us     GPU-0: 5077.569 us   +/-147.247 (min: 5056.512 / max: 7136.256) us
- name = major_slice_with_step, major = slice(1, 5000, 1), minor = slice(4000, 1, 5), format = csc, density = 0.5, dtype = float32, n_rows = 15000, n_cols = 15000
cupy.sparse         :    CPU:  150.524 us   +/- 3.478 (min:  147.035 / max:  213.704) us     GPU-0:  157.079 us   +/- 3.646 (min:  152.576 / max:  221.184) us
- name = major_slice_with_step, major = slice(None, None, None), minor = slice(8000, 1, 5), format = csc, density = 0.5, dtype = float32, n_rows = 15000, n_cols = 15000
cupy.sparse         :    CPU:   36.907 us   +/- 0.780 (min:   35.778 / max:   58.017) us     GPU-0:   41.379 us   +/- 1.175 (min:   38.912 / max:   77.824) us
- name = major_slice_with_step, major = slice(None, None, None), minor = slice(1, 4000, 5), format = csc, density = 0.5, dtype = float32, n_rows = 15000, n_cols = 15000
cupy.sparse         :    CPU:  379.306 us   +/- 4.289 (min:  372.477 / max:  397.796) us     GPU-0: 1126.421 us   +/- 3.857 (min: 1121.280 / max: 1143.808) us
```

- This PR
```
- name = major_slice_with_step, major = slice(1, 2000, 2), minor = slice(1, 500, 1), format = csr, density = 0.5, dtype = float32, n_rows = 15000, n_cols = 15000
cupy.sparse         :    CPU: 1744.484 us   +/-17.448 (min: 1725.273 / max: 2034.924) us     GPU-0: 1809.633 us   +/-16.146 (min: 1790.976 / max: 2061.312) us
- name = major_slice_with_step, major = slice(1, 2000, 2), minor = slice(1, 500, 1), format = csr, density = 0.5, dtype = float32, n_rows = 15000, n_cols = 15000
cupy.sparse         :    CPU: 1744.791 us   +/-69.034 (min: 1727.738 / max: 3355.653) us     GPU-0: 1810.490 us   +/-67.716 (min: 1793.024 / max: 3390.464) us
- name = major_slice_with_step, major = slice(1, 3000, 2), minor = slice(1, 5000, 1), format = csr, density = 0.5, dtype = float32, n_rows = 15000, n_cols = 15000
cupy.sparse         :    CPU: 2489.997 us   +/- 5.945 (min: 2476.890 / max: 2521.397) us     GPU-0: 2601.441 us   +/- 5.833 (min: 2588.672 / max: 2630.656) us
- name = major_slice_with_step, major = slice(4000, 1, 5), minor = slice(1, 5000, 1), format = csr, density = 0.5, dtype = float32, n_rows = 15000, n_cols = 15000
cupy.sparse         :    CPU:  151.016 us   +/- 6.091 (min:  146.736 / max:  227.042) us     GPU-0:  157.182 us   +/- 6.277 (min:  152.576 / max:  235.520) us
- name = major_slice_with_step, major = slice(1, 4000, 5), minor = slice(1, 5000, 1), format = csr, density = 0.5, dtype = float32, n_rows = 15000, n_cols = 15000
cupy.sparse         :    CPU: 1492.158 us   +/- 5.011 (min: 1479.547 / max: 1515.215) us     GPU-0: 1539.994 us   +/- 4.891 (min: 1527.808 / max: 1562.624) us
- name = major_slice_with_step, major = slice(2000, 1, 5), minor = slice(None, None, None), format = csr, density = 0.5, dtype = float32, n_rows = 15000, n_cols = 15000
cupy.sparse         :    CPU:   36.184 us   +/- 1.022 (min:   35.185 / max:   74.115) us     GPU-0:   40.589 us   +/- 1.271 (min:   38.912 / max:   87.040) us
- name = major_slice_with_step, major = slice(1, 8000, 5), minor = slice(None, None, None), format = csr, density = 0.5, dtype = float32, n_rows = 15000, n_cols = 15000
cupy.sparse         :    CPU:  215.879 us   +/- 3.909 (min:  211.027 / max:  261.767) us     GPU-0:  649.246 us   +/- 4.894 (min:  637.952 / max:  696.320) us
- name = major_slice_with_step, major = slice(1, 5000, 1), minor = slice(1, 2000, 2), format = csc, density = 0.5, dtype = float32, n_rows = 15000, n_cols = 15000
cupy.sparse         :    CPU: 1769.059 us   +/- 4.940 (min: 1757.554 / max: 1788.990) us     GPU-0: 1834.691 us   +/- 4.828 (min: 1822.720 / max: 1853.440) us
- name = major_slice_with_step, major = slice(1, 5000, 1), minor = slice(2000, 1, 2), format = csc, density = 0.5, dtype = float32, n_rows = 15000, n_cols = 15000
cupy.sparse         :    CPU:  151.144 us   +/- 4.908 (min:  147.107 / max:  219.482) us     GPU-0:  157.283 us   +/- 5.077 (min:  152.576 / max:  227.328) us
- name = major_slice_with_step, major = slice(1, 5000, 1), minor = slice(1, 4000, 2), format = csc, density = 0.5, dtype = float32, n_rows = 15000, n_cols = 15000
cupy.sparse         :    CPU: 3210.966 us   +/- 6.480 (min: 3192.029 / max: 3240.478) us     GPU-0: 3367.667 us   +/- 6.376 (min: 3348.480 / max: 3395.584) us
- name = major_slice_with_step, major = slice(1, 5000, 1), minor = slice(4000, 1, 5), format = csc, density = 0.5, dtype = float32, n_rows = 15000, n_cols = 15000
cupy.sparse         :    CPU:  151.536 us   +/- 6.202 (min:  147.408 / max:  233.591) us     GPU-0:  157.660 us   +/- 6.373 (min:  152.576 / max:  242.688) us
- name = major_slice_with_step, major = slice(None, None, None), minor = slice(8000, 1, 5), format = csc, density = 0.5, dtype = float32, n_rows = 15000, n_cols = 15000
cupy.sparse         :    CPU:   36.365 us   +/- 1.263 (min:   35.363 / max:   83.692) us     GPU-0:   40.729 us   +/- 1.433 (min:   38.912 / max:   89.088) us
- name = major_slice_with_step, major = slice(None, None, None), minor = slice(1, 4000, 5), format = csc, density = 0.5, dtype = float32, n_rows = 15000, n_cols = 15000
cupy.sparse         :    CPU:  213.949 us   +/- 4.416 (min:  209.793 / max:  312.434) us     GPU-0:  411.340 us   +/- 4.355 (min:  404.480 / max:  495.616) us
```
cc: @cjnolet 