### PR TITLE
Fix `cupy.sparse.*` deprecation

### DIFF
--- a/cupy/sparse/__init__.py
+++ b/cupy/sparse/__init__.py
@@ -16,6 +16,8 @@ if (3, 7) <= sys.version_info:
             msg = 'cupy.sparse is deprecated. Use cupyx.scipy.sparse instead.'
             warnings.warn(msg, DeprecationWarning)
             return getattr(cupyx.scipy.sparse, name)
+        raise AttributeError(
+            "module 'cupyx.scipy.sparse' has no attribute '{}'".format(name))
 else:
     from cupyx.scipy.sparse.base import issparse  # NOQA
     from cupyx.scipy.sparse.base import isspmatrix  # NOQA

--- a/cupy/sparse/__init__.py
+++ b/cupy/sparse/__init__.py
@@ -19,46 +19,4 @@ if (3, 7) <= sys.version_info:
         raise AttributeError(
             "module 'cupyx.scipy.sparse' has no attribute '{}'".format(name))
 else:
-    from cupyx.scipy.sparse.base import issparse  # NOQA
-    from cupyx.scipy.sparse.base import isspmatrix  # NOQA
-    from cupyx.scipy.sparse.base import spmatrix  # NOQA
-    from cupyx.scipy.sparse.coo import coo_matrix  # NOQA
-    from cupyx.scipy.sparse.coo import isspmatrix_coo  # NOQA
-    from cupyx.scipy.sparse.csc import csc_matrix  # NOQA
-    from cupyx.scipy.sparse.csc import isspmatrix_csc  # NOQA
-    from cupyx.scipy.sparse.csr import csr_matrix  # NOQA
-    from cupyx.scipy.sparse.csr import isspmatrix_csr  # NOQA
-    from cupyx.scipy.sparse.dia import dia_matrix  # NOQA
-    from cupyx.scipy.sparse.dia import isspmatrix_dia  # NOQA
-
-    from cupyx.scipy.sparse.construct import eye  # NOQA
-    from cupyx.scipy.sparse.construct import identity  # NOQA
-    from cupyx.scipy.sparse.construct import rand  # NOQA
-    from cupyx.scipy.sparse.construct import random  # NOQA
-    from cupyx.scipy.sparse.construct import spdiags  # NOQA
-
-    from cupyx.scipy.sparse.construct import bmat  # NOQA
-    from cupyx.scipy.sparse.construct import hstack  # NOQA
-    from cupyx.scipy.sparse.construct import vstack  # NOQA
-
-    # TODO(unno): implement bsr_matrix
-    # TODO(unno): implement dok_matrix
-    # TODO(unno): implement lil_matrix
-
-    from cupyx.scipy.sparse.construct import kron  # NOQA
-    # TODO(unno): implement kronsum
-    # TODO(unno): implement diags
-    # TODO(unno): implement block_diag
-    # TODO(unno): implement tril
-    # TODO(unno): implement triu
-
-    # TODO(unno): implement save_npz
-    # TODO(unno): implement load_npz
-
-    # TODO(unno): implement find
-
-    # TODO(unno): implement isspmatrix_bsr(x)
-    # TODO(unno): implement isspmatrix_lil(x)
-    # TODO(unno): implement isspmatrix_dok(x)
-
-    from cupyx.scipy.sparse import linalg  # NOQA
+    from cupyx.scipy.sparse import *  # NOQA

--- a/cupy/sparse/__init__.py
+++ b/cupy/sparse/__init__.py
@@ -17,6 +17,6 @@ if (3, 7) <= sys.version_info:
             warnings.warn(msg, DeprecationWarning)
             return getattr(cupyx.scipy.sparse, name)
         raise AttributeError(
-            "module 'cupyx.scipy.sparse' has no attribute '{}'".format(name))
+            "module 'cupy.sparse' has no attribute {!r}".format(name))
 else:
     from cupyx.scipy.sparse import *  # NOQA

--- a/cupy/sparse/linalg/__init__.py
+++ b/cupy/sparse/linalg/__init__.py
@@ -1,5 +1,18 @@
-# Functions from the following SciPy document
-# https://docs.scipy.org/doc/scipy/reference/sparse.linalg.html
+import sys
+import warnings
 
-# "NOQA" to suppress flake8 warning
-from cupyx.scipy.sparse.linalg.solve import lsqr  # NOQA
+import cupyx.scipy.sparse.linalg
+
+
+if (3, 7) <= sys.version_info:
+    def __getattr__(name):
+        if hasattr(cupyx.scipy.sparse.linalg, name):
+            warnings.warn(
+                'cupy.sparse.linalg is deprecated.'
+                ' Use cupyx.scipy.sparse.linalg instead.', DeprecationWarning)
+            return getattr(cupyx.scipy.sparse.linalg, name)
+        raise AttributeError(
+            "module 'cupyx.scipy.sparse.linalg' has no attribute '{}'".format(
+                name))
+else:
+    from cupyx.scipy.sparse.linalg import *  # NOQA

--- a/cupy/sparse/linalg/__init__.py
+++ b/cupy/sparse/linalg/__init__.py
@@ -12,7 +12,6 @@ if (3, 7) <= sys.version_info:
                 ' Use cupyx.scipy.sparse.linalg instead.', DeprecationWarning)
             return getattr(cupyx.scipy.sparse.linalg, name)
         raise AttributeError(
-            "module 'cupyx.scipy.sparse.linalg' has no attribute '{}'".format(
-                name))
+            "module 'cupy.sparse.linalg' has no attribute {!r}".format(name))
 else:
     from cupyx.scipy.sparse.linalg import *  # NOQA


### PR DESCRIPTION
Follow-up #3839