### PR TITLE
Add upgrade guide for v8

### DIFF
--- a/docs/source/upgrade.rst
+++ b/docs/source/upgrade.rst
@@ -30,14 +30,14 @@ CUB Support and Compiler Requirement
 ------------------------------------
 
 CUB module is now built by default.
-You can enable the use of CUB by setting ``CUPY_ACCERELATORS="cub"`` (see :doc:`reference/environment` for details).
+You can enable the use of CUB by setting ``CUPY_ACCELERATORS="cub"`` (see :doc:`reference/environment` for details).
 
 Due to this change, g++-6 or later is required when building CuPy from the source.
 See :doc:`install` for details.
 
 The following environment variables are no longer effective:
 
-* ``CUB_DISABLED``: Use ``CUPY_ACCERELATORS`` as aforementioned.
+* ``CUB_DISABLED``: Use ``CUPY_ACCELERATORS`` as aforementioned.
 * ``CUB_PATH``: No longer required as CuPy uses CUB source tree bundled with CUDA (only when using CUDA 11.0 or later) or CuPy distribution.
 
 API Changes

--- a/docs/source/upgrade.rst
+++ b/docs/source/upgrade.rst
@@ -5,7 +5,6 @@ Upgrade Guide
 =============
 
 This is a list of changes introduced in each release that users should be aware of when migrating from older versions.
-Most changes are carefully designed not to break existing code; however changes that may possibly break them are highlighted with a box.
 
 CuPy v8
 =======
@@ -13,13 +12,44 @@ CuPy v8
 Dropping Support of CUDA 8.0 and 9.1
 ------------------------------------
 
-Starting from CuPy v8, CUDA 8.0 and 9.1 are no longer supported.
-Use CUDA 9.0, 9.2, 10.0 or later.
+CUDA 8.0 and 9.1 are no longer supported.
+Use CUDA 9.0, 9.2, 10.0, or later.
+
+Dropping Support of NumPy 1.15 and SciPy 1.2
+--------------------------------------------
+
+NumPy 1.15 (or earlier) and SciPy 1.2 (or earlier) are no longer supported.
 
 Update of Docker Images
 -----------------------
 
-CuPy official Docker images (see :doc:`install` for details) are now updated to use CUDA 10.2 and Python 3.6.
+* CuPy official Docker images (see :doc:`install` for details) are now updated to use CUDA 10.2 and Python 3.6.
+* SciPy and Optuna are now pre-installed.
+
+CUB Support and Compiler Requirement
+------------------------------------
+
+CUB module is now built by default.
+You can enable the use of CUB by setting ``CUPY_ACCERELATORS="cub"`` (see :doc:`reference/environment` for details).
+
+Due to this change, g++-6 or later is required when building CuPy from the source.
+See :doc:`install` for details.
+
+The following environment variables are no longer effective:
+
+* ``CUB_DISABLED``: Use ``CUPY_ACCERELATORS`` as aforementioned.
+* ``CUB_PATH``: No longer required as CuPy uses CUB source tree bundled with CUDA (only when using CUDA 11.0 or later) or CuPy distribution.
+
+API Changes
+-----------
+
+* ``cupy.scatter_add``, which was deprecated in CuPy v4, has been removed. Use :func:`cupyx.scatter_add` instead.
+* ``cupy.sparse`` module has been deprecated and will be removed in future releases. Use :mod:`cupyx.scipy.sparse` instead.
+* ``dtype`` argument of :func:`cupy.ndarray.min` and :func:`cupy.ndarray.max` has been removed to align with the NumPy specification.
+* :func:`cupy.allclose` now returns the result as 0-dim GPU array instead of Python bool to avoid device synchronization.
+* :class:`cupy.RawModule` now delays the compilation to the time of the first call to align the behavior with :class:`cupy.RawKernel`.
+* ``cupy.cuda.*_enabled`` flags (``nccl_enabled``, ``nvtx_enabled``, etc.) has been deprecated. Use ``cupy.cuda.*.available`` flag (``cupy.cuda.nccl.available``, ``cupy.cuda.nvtx.available``, etc.) instead.
+* ``CHAINER_SEED`` environment variable is no longer effective. Use ``CUPY_SEED`` instead.
 
 
 CuPy v7

--- a/docs/source/upgrade.rst
+++ b/docs/source/upgrade.rst
@@ -38,7 +38,7 @@ See :doc:`install` for details.
 The following environment variables are no longer effective:
 
 * ``CUB_DISABLED``: Use ``CUPY_ACCELERATORS`` as aforementioned.
-* ``CUB_PATH``: No longer required as CuPy uses CUB source tree bundled with CUDA (only when using CUDA 11.0 or later) or CuPy distribution.
+* ``CUB_PATH``: No longer required as CuPy uses either the CUB source bundled with CUDA (only when using CUDA 11.0 or later) or the one in the CuPy distribution.
 
 API Changes
 -----------


### PR DESCRIPTION
Closes #3516

This guide is generated from no-compat labelled PRs: https://github.com/cupy/cupy/issues?q=label%3Ano-compat

Note that no-compat changes between v8 pre-releases (alpha/beta/rc) are excluded from this guide.