### PR TITLE
Fix cub not bundled in wheels

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
+# Contents of sdist. See also `setup.py`.
 recursive-include cupy *.h *.hpp
 recursive-exclude cupy *.pyx *.pxd *.pxi
 recursive-include cupy_backends *.h *.hpp
@@ -8,4 +9,3 @@ recursive-include tests *.py
 include LICENSE
 include docs/LICENSE_THIRD_PARTY
 include docs/source/license.rst
-graft cupy/core/include/cupy/cub*

--- a/cupy/core/include/cupy/README.md
+++ b/cupy/core/include/cupy/README.md
@@ -1,3 +1,11 @@
+# "include" directory
+
+All files and directories in this directory will be copied to the distribution (sdist and wheel).
+Note that items starting with `.` (e.g., `cub/.git`) are excluded.
+See `setup.py` for details.
+
+## CUB
+
 The `cub` folder is a git submodule for the CUB project.
 Including the CUB headers as a submodule enables not only building the `cupy.cuda.cub` module,
 but also easier maintenance.

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import glob
 import os
 from setuptools import setup, find_packages
 import sys
@@ -100,38 +101,21 @@ setup_requires = requirements['setup']
 install_requires = requirements['install']
 tests_require = requirements['test']
 
+# List of files that needs to be in the distribution (sdist/wheel).
+# Notes:
+# - Files only needed in sdist should be added to `MANIFEST.in`.
+# - The following glob (`**`) ignores items starting with `.`.
+cupy_package_data = [
+    'cupy/cuda/cupy_thrust.cu',
+    'cupy/cuda/cupy_cub.cu',
+] + [
+    x for x in glob.glob('cupy/core/include/cupy/**', recursive=True)
+    if os.path.isfile(x)
+]
 
 package_data = {
     'cupy': [
-        'core/include/cupy/complex/arithmetic.h',
-        'core/include/cupy/complex/catrig.h',
-        'core/include/cupy/complex/catrigf.h',
-        'core/include/cupy/complex/ccosh.h',
-        'core/include/cupy/complex/ccoshf.h',
-        'core/include/cupy/complex/cexp.h',
-        'core/include/cupy/complex/cexpf.h',
-        'core/include/cupy/complex/clog.h',
-        'core/include/cupy/complex/clogf.h',
-        'core/include/cupy/complex/complex.h',
-        'core/include/cupy/complex/complex_inl.h',
-        'core/include/cupy/complex/cpow.h',
-        'core/include/cupy/complex/cproj.h',
-        'core/include/cupy/complex/csinh.h',
-        'core/include/cupy/complex/csinhf.h',
-        'core/include/cupy/complex/csqrt.h',
-        'core/include/cupy/complex/csqrtf.h',
-        'core/include/cupy/complex/ctanh.h',
-        'core/include/cupy/complex/ctanhf.h',
-        'core/include/cupy/complex/math_private.h',
-        'core/include/cupy/carray.cuh',
-        'core/include/cupy/complex.cuh',
-        'core/include/cupy/atomics.cuh',
-        'core/include/cupy/type_dispatcher.cuh',
-        'core/include/cupy/cuComplex_bridge.h',
-        'core/include/cupy/_cuda/cuda-*/*.h',
-        'core/include/cupy/_cuda/cuda-*/*.hpp',
-        'cuda/cupy_thrust.cu',
-        'cuda/cupy_cub.cu',
+        os.path.relpath(x, 'cupy') for x in cupy_package_data
     ],
 }
 


### PR DESCRIPTION
During the verification process, I found that CUB source tree is not bundled in CuPy wheels.