### PR TITLE
[WIP] Fix wheel not loading bundled cuDNN on Windows

### DIFF
--- a/cupy/_environment.py
+++ b/cupy/_environment.py
@@ -135,14 +135,43 @@ def _get_cub_path():
 
 
 def _setup_win32_dll_directory():
-    # Setup DLL directory to load CUDA Toolkit libs on Windows & Python 3.8+.
-    if sys.platform.startswith('win32') and (3, 8) <= sys.version_info:
+    # Setup DLL directory to load CUDA Toolkit libs and shared libraries
+    # added during the build process.
+    if sys.platform.startswith('win32'):
+        # Path to the CUDA Toolkit binaries
         cuda_path = get_cuda_path()
-        if cuda_path is None:
-            raise RuntimeError('CUDA path could not be detected.')
-        cuda_bin_path = os.path.join(cuda_path, 'bin')
-        _log('Adding DLL search path: {}'.format(cuda_bin_path))
-        os.add_dll_directory(cuda_bin_path)
+        if cuda_path is not None:
+            cuda_bin_path = os.path.join(cuda_path, 'bin')
+        else:
+            cuda_bin_path = None
+            warnings.warn(
+                'CUDA path could not be detected.'
+                ' Set CUDA_PATH environment variable if CuPy fails to load.')
+        _log('CUDA_PATH: {}'.format(cuda_path))
+
+        # Path to shared libraries in wheel
+        wheel_libdir = os.path.join(
+            get_cupy_install_path(), 'cupy', '.data', 'lib')
+        if os.path.isdir(wheel_libdir):
+            _log('Wheel shared libraries: {}'.format(wheel_libdir))
+        else:
+            _log('Not wheel distribution ({} not found)'.format(
+                wheel_libdir))
+            wheel_libdir = None
+
+        if (3, 8) <= sys.version_info:
+            if cuda_bin_path is not None:
+                _log('Adding DLL search path: {}'.format(cuda_bin_path))
+                os.add_dll_directory(cuda_bin_path)
+            if wheel_libdir is not None:
+                _log('Adding DLL search path: {}'.format(wheel_libdir))
+                os.add_dll_directory(wheel_libdir)
+        else:
+            # Users are responsible for adding `%CUDA_PATH%/bin` to PATH.
+            if wheel_libdir is not None:
+                _log('Adding to PATH: {}'.format(wheel_libdir))
+                path = os.environ.get('PATH', '')
+                os.environ['PATH'] = wheel_libdir + os.pathsep + path
 
 
 def get_cupy_install_path():

--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -654,64 +654,44 @@ def get_long_description():
 def prepare_wheel_libs():
     """Prepare shared libraries and include files for wheels.
 
-    On Windows, DLLs will be placed under `cupy/cuda`.
-    On other platforms, shared libraries are placed under `cupy/.data/lib` and
-    RUNPATH will be set to this directory later.
+    Shared libraries are placed under `cupy/.data/lib` and
+    RUNPATH will be set to this directory later (Linux only).
     Include files are placed under `cupy/.data/include`.
+
+    Returns the list of files (path relative to `cupy` module) to add to
+    the sdist/wheel distribution.
     """
-    data_dir = '.data'
+    data_dir = os.path.abspath(os.path.join('cupy', '.data'))
     if os.path.exists(data_dir):
         print('Removing directory: {}'.format(data_dir))
         shutil.rmtree(data_dir)
 
-    if PLATFORM_WIN32:
-        lib_dirname = 'cuda'
-        # Clean up existing libraries.
-        libfiles = glob.glob('cupy/{}/*.dll'.format(lib_dirname))
-        for libfile in libfiles:
-            print('Removing file: {}'.format(libfile))
-            os.remove(libfile)
-    else:
-        lib_dirname = os.path.join(data_dir, 'lib')
-
-    include_dirname = os.path.join(data_dir, 'include')
-
-    # Collect files to copy
+    # Generate list files to copy
+    # tuple of (src_path, dst_path)
     files_to_copy = []
 
     # Library files
-    lib_base_path = os.path.join('cupy', lib_dirname)
     for srcpath in cupy_setup_options['wheel_libs']:
         relpath = os.path.basename(srcpath)
-        dstpath = path.join(lib_base_path, relpath)
-        files_to_copy.append((
-            srcpath,
-            dstpath,
-            path.join(lib_dirname, relpath)))
+        dstpath = os.path.join(data_dir, 'lib', relpath)
+        files_to_copy.append((srcpath, dstpath))
 
     # Include files
-    include_base_path = os.path.join('cupy', include_dirname)
     for include_path_spec in cupy_setup_options['wheel_includes']:
-        # TODO(niboshi): Consider using platform-dependent path delimiter.
         srcpath, relpath = include_path_spec.rsplit(':', 1)
-        dstpath = os.path.join(include_base_path, relpath)
-        files_to_copy.append((
-            srcpath,
-            dstpath,
-            path.join(include_dirname, relpath)))
+        dstpath = os.path.join(data_dir, 'include', relpath)
+        files_to_copy.append((srcpath, dstpath))
 
     # Copy
-    package_data = []
-    for srcpath, dstpath, package_path in files_to_copy:
+    for srcpath, dstpath in files_to_copy:
         # Note: symlink is resolved by shutil.copy2.
         print('Copying file for wheel: {}'.format(srcpath))
         dirpath = os.path.dirname(dstpath)
         if not os.path.isdir(dirpath):
             os.makedirs(dirpath)
         shutil.copy2(srcpath, dstpath)
-        package_data.append(package_path)
 
-    return package_data
+    return [os.path.relpath(x[1], 'cupy') for x in files_to_copy]
 
 
 try:

--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -5,7 +5,6 @@ from distutils import errors
 from distutils import msvccompiler
 from distutils import sysconfig
 from distutils import unixccompiler
-import glob
 import os
 from os import path
 import shutil


### PR DESCRIPTION
After `cupy_backends` separation cuDNN bundled in wheels are not loaded on Windows.

The following description only applies for Windows. (Linux behavior is different).

Currently we are copying two DLLs in wheels:

- `nvToolsExt64_1.dll` (used from `cupy.cuda.nvtx`)
- `cudnn64_7.dll` (used from `cupy_backends.cuda.libs.cudnn`)

In wheels, DLLs are placed under `cupy/cuda/` directory. This is because DLLs are looked up from the same directory as the Python extension module requiring that DLL. This assumption was OK until `cupy_backends` separation.

This PR changes the path to place shared library to `cupy/.data/lib` (which is the same as Linux), and add that directory to `PATH` (for Python 3.7 or earlier) or DLL lookup directory `os.add_dll_directory` (for Python 3.8+).

TODO: I'm now testing the behavior on Windows.