### PR TITLE
Fix not to use cupy.cuda.* from cupy codebase

### DIFF
--- a/cupy/cuda/cudnn.py
+++ b/cupy/cuda/cudnn.py
@@ -1,3 +1,9 @@
+"""
+cuDNN Wrapper
+
+Use `cupy_backends.cuda.libs.cudnn` directly in CuPy codebase.
+"""
+
 available = True
 
 try:

--- a/cupyx/runtime.py
+++ b/cupyx/runtime.py
@@ -4,11 +4,30 @@ import os
 
 import cupy
 
-from cupy.cuda import cub
-from cupy.cuda import cudnn
-from cupy.cuda import cutensor
-from cupy.cuda import nccl
-from cupy.cuda import thrust
+try:
+    import cupy.cuda.thrust as thrust
+except ImportError:
+    thrust = None
+
+try:
+    import cupy_backends.cuda.libs.cudnn as cudnn
+except ImportError:
+    cudnn = None
+
+try:
+    import cupy.cuda.nccl as nccl
+except ImportError:
+    nccl = None
+
+try:
+    import cupy.cuda.cub as cub
+except ImportError:
+    cub = None
+
+try:
+    import cupy_backends.cuda.libs.cutensor as cutensor
+except ImportError:
+    cutensor = None
 
 
 def _eval_or_error(func, errors):
@@ -119,25 +138,25 @@ class _RuntimeInfo(object):
             cupy.cuda.nvrtc.getVersion,
             cupy.cuda.nvrtc.NVRTCError)
 
-        if thrust.available:
+        if thrust is not None:
             self.thrust_version = thrust.get_build_version()
 
-        if cudnn.available:
+        if cudnn is not None:
             self.cudnn_build_version = cudnn.get_build_version()
             self.cudnn_version = _eval_or_error(
                 cudnn.getVersion, cudnn.CuDNNError)
 
-        if nccl.available:
+        if nccl is not None:
             self.nccl_build_version = nccl.get_build_version()
             nccl_runtime_version = nccl.get_version()
             if nccl_runtime_version == 0:
                 nccl_runtime_version = '(unknown)'
             self.nccl_runtime_version = nccl_runtime_version
 
-        if cub.available:
+        if cub is not None:
             self.cub_build_version = cub.get_build_version()
 
-        if cutensor.available:
+        if cutensor is not None:
             self.cutensor_version = cutensor.get_version()
 
     def __str__(self):

--- a/tests/cupyx_tests/test_runtime.py
+++ b/tests/cupyx_tests/test_runtime.py
@@ -40,7 +40,7 @@ class TestRuntime(unittest.TestCase):
             assert 'CUDARuntimeError' in str(runtime)
 
         with mock.patch(
-                'cupy.cuda.cudnn.getVersion',
+                'cupy_backends.cuda.libs.cudnn.getVersion',
                 side_effect=_get_error_func(cudnn.CuDNNError, 0)):
             runtime = cupyx.get_runtime_info()
             assert 'CuDNNError' in str(runtime)


### PR DESCRIPTION
In #3732, `cupyx/runtime.py` was fixed to use `cupy.cuda.cudnn` but this was incorrect.
`cupyx/runtime.py` is automatically imported when doing `import cupy`, so preloading warnings for cuDNN will be displayed just by doing `import cupy` if cudnn is unavailable.