### PR TITLE
Fix `cupy.ndim` test style

### DIFF
--- a/tests/cupy_tests/test_ndim.py
+++ b/tests/cupy_tests/test_ndim.py
@@ -14,43 +14,43 @@ class TestNdim(unittest.TestCase):
 
     @testing.numpy_cupy_equal()
     def test_ndim_ndarray2d(self, xp):
-        assert xp.ndim(xp.ones((2, 4))) == 2
+        return xp.ndim(xp.ones((2, 4)))
 
     @testing.numpy_cupy_equal()
     def test_ndim_ndarray0d(self, xp):
-        assert xp.ndim(xp.asarray(5)) == 1
+        return xp.ndim(xp.asarray(5))
 
     @testing.numpy_cupy_equal()
     def test_ndim_scalar(self, xp):
-        assert xp.ndim(5) == 0
+        return xp.ndim(5)
 
     @testing.numpy_cupy_equal()
     def test_ndim_none(self, xp):
-        assert xp.ndim(None) == 0
+        return xp.ndim(None)
 
     @testing.numpy_cupy_equal()
     def test_ndim_string(self, xp):
-        assert xp.ndim('abc') == 0
+        return xp.ndim('abc')
 
     @testing.numpy_cupy_equal()
     def test_ndim_list1(self, xp):
-        assert xp.ndim([1, 2, 3]) == 1
+        return xp.ndim([1, 2, 3])
 
     @testing.numpy_cupy_equal()
     def test_ndim_list2(self, xp):
-        assert xp.ndim([[1, 2, 3], [4, 5, 6]]) == 2
+        return xp.ndim([[1, 2, 3], [4, 5, 6]])
 
     @testing.numpy_cupy_equal()
     def test_ndim_tuple(self, xp):
-        assert xp.ndim(((1, 2, 3), (4, 5, 6))) == 2
+        return xp.ndim(((1, 2, 3), (4, 5, 6)))
 
     @testing.numpy_cupy_equal()
     def test_ndim_set(self, xp):
-        assert xp.ndim({1, 2, 3}) == 1
+        return xp.ndim({1, 2, 3})
 
     @testing.numpy_cupy_equal()
     def test_ndim_object(self, xp):
-        assert xp.ndim(dict(a=5, b='b')) == 0
+        return xp.ndim(dict(a=5, b='b'))
 
     # numpy.dim works on CuPy arrays and cupy.ndim works on NumPy arrays
     def test_ndim_array_function(self):


### PR DESCRIPTION
Follow-up of #3060. Changed `assert` to `return` (https://github.com/cupy/cupy/pull/3060#discussion_r476174676).