### PR TITLE
Fix cooperative kernel launch

### DIFF
--- a/cupy/cuda/function.pyx
+++ b/cupy/cuda/function.pyx
@@ -158,6 +158,9 @@ cdef _launch(intptr_t func, Py_ssize_t grid0, int grid1, int grid2,
 
     runtime._ensure_context()
 
+    cdef int dev_id
+    cdef int num_sm
+    cdef int max_grid_size
     if enable_cooperative_groups:
         dev_id = device.get_device_id()
         num_sm = device._get_attributes(dev_id)['MultiProcessorCount']

--- a/tests/cupy_tests/core_tests/test_raw.py
+++ b/tests/cupy_tests/core_tests/test_raw.py
@@ -973,20 +973,25 @@ _test_grid_sync = r'''
 #include <cooperative_groups.h>
 
 extern "C" __global__
-void test_grid_sync(const float* x1, const float* x2, float* y) {
+void test_grid_sync(const float* x1, const float* x2, float* y, int n) {
     namespace cg = cooperative_groups;
     cg::grid_group grid = cg::this_grid();
     int size = gridDim.x * blockDim.x;
     int tid = blockDim.x * blockIdx.x + threadIdx.x;
-    y[tid] = x1[tid];
+    for (int i = tid; i < n; i += size) {
+        y[i] = x1[i];
+    }
     cg::sync(grid);
-    y[size - tid - 1] += x2[size - tid - 1];
+    for (int i = n - 1 - tid; i >= 0; i -= size) {
+        y[i] += x2[i];
+    }
 }
 '''
 
 
 @testing.parameterize(*testing.product({
-    'n': [10, 100, 256]
+    'n': [10, 100, 1000],
+    'block': [64, 256],
 }))
 @unittest.skipUnless(
     9000 <= cupy.cuda.runtime.runtimeGetVersion(),
@@ -1005,7 +1010,9 @@ class TestRawGridSync(unittest.TestCase):
             x1 = cupy.arange(n ** 2, dtype='float32').reshape(n, n)
             x2 = cupy.ones((n, n), dtype='float32')
             y = cupy.zeros((n, n), dtype='float32')
-            kern_grid_sync((n,), (n,), (x1, x2, y, n ** 2))
+            block = self.block
+            grid = (n * n + block - 1) // block
+            kern_grid_sync((grid,), (block,), (x1, x2, y, n ** 2))
             assert cupy.allclose(y, x1 + x2)
 
     def test_grid_sync_rawmodule(self):
@@ -1018,5 +1025,7 @@ class TestRawGridSync(unittest.TestCase):
             x2 = cupy.ones((n, n), dtype='float32')
             y = cupy.zeros((n, n), dtype='float32')
             kern = mod_grid_sync.get_function('test_grid_sync')
-            kern((n,), (n,), (x1, x2, y, n ** 2))
+            block = self.block
+            grid = (n * n + block - 1) // block
+            kern((grid,), (block,), (x1, x2, y, n ** 2))
             assert cupy.allclose(y, x1 + x2)


### PR DESCRIPTION
This PR fixs an issue when a kernel is launched by cuLaunchCooperativeKernel().

When launching a kernel with [cuLaunchCooperativeKernel()](https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__EXEC.html#group__CUDA__EXEC_1g06d753134145c4584c0c62525c1894cb), the kernel grid size must not exceed the limit determined by [cuOcupancyMaxActiveBlocksPerMultiprocessor()](https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__OCCUPANCY.html#group__CUDA__OCCUPANCY_1gcc6e1094d05cba2cee17fe33ddd04a98). It looks the current implementation requires the user to select a grid size that meets this limit, but I don't think it's realistic to ask the user to do this, as this limit varies with kernel register usage, number of SMs of GPUs used, etc. Please see https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#grid-synchronization-cg for details.

This PR makes sure that the specified grid size does not exceed the limit before launching the kernel by cuLaunchCooperativeKernel(). If the limit is exceeded, it outputs a warning message and reduces the grid size to meet the limit when the grid shape is 1D, otherwise it raises an error.

The related tests have also been fixed.