### PR TITLE
[backport] Use `_csr_row_index` for CSR matrix major-axis slicing with step

### DIFF
--- a/cupyx/scipy/sparse/_index.py
+++ b/cupyx/scipy/sparse/_index.py
@@ -281,36 +281,6 @@ def _csr_row_index(rows,
     return Bj, Bx
 
 
-def _csr_row_slice(start_maj, step_maj, Ap, Aj, Ax, Bp):
-    """Populate indices and data arrays of sparse matrix by slicing the
-    rows of an input sparse matrix
-
-    Args
-        start : starting row
-        step : step increment size
-        Ap : indptr array of input sparse matrix
-        Aj : indices array of input sparse matrix
-        Ax : data array of input sparse matrix
-        Bp : indices array of output sparse matrix
-
-    Returns
-        Bj : indices array of output sparse matrix
-        Bx : data array of output sparse matrix
-    """
-
-    in_rows = cupy.arange(start_maj, start_maj + (Bp.size - 1) * step_maj,
-                          step_maj, dtype=Bp.dtype)
-    offsetsB = Ap[in_rows] - Bp[:-1]
-    B_size = int(Bp[-1])
-    offsetsA = offsetsB[
-        cupy.searchsorted(
-            Bp, cupy.arange(B_size, dtype=Bp.dtype), 'right') - 1]
-    offsetsA += cupy.arange(offsetsA.size, dtype=offsetsA.dtype)
-    Bj = Aj[offsetsA]
-    Bx = Ax[offsetsA]
-    return Bj, Bx
-
-
 def _csr_sample_values(n_row, n_col,
                        Ap, Aj, Ax,
                        Bi, Bj):

--- a/cupyx/scipy/sparse/compressed.py
+++ b/cupyx/scipy/sparse/compressed.py
@@ -677,8 +677,11 @@ class _compressed_sparse_matrix(sparse_data._data_matrix,
                                      copy=copy)
             res_data = cupy.array(self.data[idx_start:idx_stop], copy=copy)
         else:
-            res_indices, res_data = _index._csr_row_slice(
-                start, step, self.indptr, self.indices, self.data, res_indptr)
+            rows = cupy.arange(
+                start, start + (res_indptr.size - 1) * step, step,
+                dtype=res_indptr.dtype)
+            res_indices, res_data = _index._csr_row_index(
+                rows, self.indptr, self.indices, self.data, res_indptr)
 
         return self.__class__((res_data, res_indices, res_indptr),
                               shape=new_shape, copy=False)


### PR DESCRIPTION
Backport of #3852