### PR TITLE
Fix dtype in CSR matrix division

### DIFF
--- a/cupyx/scipy/sparse/csr.py
+++ b/cupyx/scipy/sparse/csr.py
@@ -180,16 +180,13 @@ class csr_matrix(compressed._compressed_sparse_matrix):
     def __truediv__(self, other):
         """Point-wise division by scalar"""
         if util.isscalarlike(other):
-            if self.dtype == numpy.complex64:
+            dtype = self.dtype
+            if dtype == numpy.float32:
                 # Note: This is a work-around to make the output dtype the same
                 # as SciPy. It might be SciPy version dependent.
-                dtype = numpy.float32
-            else:
-                if cupy.isscalar(other):
-                    dtype = numpy.float64
-                else:
-                    dtype = numpy.promote_types(numpy.float64, other.dtype)
-            d = cupy.array(1. / other, dtype=dtype)
+                dtype = numpy.float64
+            dtype = cupy.result_type(dtype, other)
+            d = cupy.reciprocal(other, dtype=dtype)
             return multiply_by_scalar(self, d)
         # TODO(anaruse): Implement divide by dense or sparse matrix
         raise NotImplementedError

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -1094,16 +1094,19 @@ class TestCsrMatrixScipyComparison(unittest.TestCase):
         return m.multiply(x).toarray()
 
     # divide
+    @testing.for_dtypes('ifdFD')
     @testing.numpy_cupy_allclose(sp_name='sp')
-    def test_divide_scalar(self, xp, sp):
+    def test_divide_scalar(self, xp, sp, dtype):
         m = self.make(xp, sp, self.dtype)
-        y = m / 2
+        y = m / dtype(2)
         return y.toarray()
 
-    @testing.numpy_cupy_allclose(sp_name='sp')
-    def test_divide_scalarlike(self, xp, sp):
+    @testing.for_dtypes('ifdFD')
+    # type promotion rules are different for ()-shaped arrays
+    @testing.numpy_cupy_allclose(sp_name='sp', type_check=False)
+    def test_divide_scalarlike(self, xp, sp, dtype):
         m = self.make(xp, sp, self.dtype)
-        y = m / xp.array(2)
+        y = m / xp.array(2, dtype)
         return y.toarray()
 
 

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -1093,12 +1093,20 @@ class TestCsrMatrixScipyComparison(unittest.TestCase):
         x = _make_col(xp, sp, self.dtype)
         return m.multiply(x).toarray()
 
+    def _make_scalar(self, dtype):
+        if numpy.issubdtype(dtype, numpy.integer):
+            return dtype(2)
+        elif numpy.issubdtype(dtype, numpy.floating):
+            return dtype(2.5)
+        else:
+            return dtype(2.5 - 1.5j)
+
     # divide
     @testing.for_dtypes('ifdFD')
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_divide_scalar(self, xp, sp, dtype):
         m = self.make(xp, sp, self.dtype)
-        y = m / dtype(2)
+        y = m / self._make_scalar(dtype)
         return y.toarray()
 
     @testing.for_dtypes('ifdFD')
@@ -1106,7 +1114,7 @@ class TestCsrMatrixScipyComparison(unittest.TestCase):
     @testing.numpy_cupy_allclose(sp_name='sp', type_check=False)
     def test_divide_scalarlike(self, xp, sp, dtype):
         m = self.make(xp, sp, self.dtype)
-        y = m / xp.array(2, dtype)
+        y = m / xp.array(self._make_scalar(dtype))
         return y.toarray()
 
 


### PR DESCRIPTION
Follows-up #3680.

Some dtypes were not compatible with SciPy.  Moreover, some of the result values were wrong due to unsafe casting.
```
>>> (sparse.csr_matrix(cupy.array(1+2j))/cupy.array(3+4j)).todense()  # ok
array([[0.44+0.08j]])
>>> (sparse.csr_matrix(cupy.array(1+2j, 'F'))/cupy.array(3+4j)).todense()  # not ok
/path/to/cupy/_creation/from_data.py:41: ComplexWarning: Casting complex values to real discards the imaginary part
  return core.array(obj, dtype, copy, order, subok, ndmin)
array([[0.12+0.24j]], dtype=complex64)
```