### PR TITLE
add all binary morphology functions to cupyx.scipy.ndimage

### DIFF
--- a/cupyx/scipy/ndimage/__init__.py
+++ b/cupyx/scipy/ndimage/__init__.py
@@ -43,6 +43,11 @@ from cupyx.scipy.ndimage.morphology import generate_binary_structure  # NOQA
 from cupyx.scipy.ndimage.morphology import iterate_structure  # NOQA
 from cupyx.scipy.ndimage.morphology import binary_erosion  # NOQA
 from cupyx.scipy.ndimage.morphology import binary_dilation  # NOQA
+from cupyx.scipy.ndimage.morphology import binary_opening  # NOQA
+from cupyx.scipy.ndimage.morphology import binary_closing  # NOQA
+from cupyx.scipy.ndimage.morphology import binary_hit_or_miss  # NOQA
+from cupyx.scipy.ndimage.morphology import binary_fill_holes  # NOQA
+from cupyx.scipy.ndimage.morphology import binary_propagation  # NOQA
 from cupyx.scipy.ndimage.morphology import grey_erosion  # NOQA
 from cupyx.scipy.ndimage.morphology import grey_dilation  # NOQA
 from cupyx.scipy.ndimage.morphology import grey_closing  # NOQA

--- a/cupyx/scipy/ndimage/__init__.py
+++ b/cupyx/scipy/ndimage/__init__.py
@@ -39,6 +39,10 @@ from cupyx.scipy.ndimage.measurements import mean  # NOQA
 from cupyx.scipy.ndimage.measurements import variance  # NOQA
 from cupyx.scipy.ndimage.measurements import standard_deviation  # NOQA
 
+from cupyx.scipy.ndimage.morphology import generate_binary_structure  # NOQA
+from cupyx.scipy.ndimage.morphology import iterate_structure  # NOQA
+from cupyx.scipy.ndimage.morphology import binary_erosion  # NOQA
+from cupyx.scipy.ndimage.morphology import binary_dilation  # NOQA
 from cupyx.scipy.ndimage.morphology import grey_erosion  # NOQA
 from cupyx.scipy.ndimage.morphology import grey_dilation  # NOQA
 from cupyx.scipy.ndimage.morphology import grey_closing  # NOQA

--- a/cupyx/scipy/ndimage/_filters_core.py
+++ b/cupyx/scipy/ndimage/_filters_core.py
@@ -195,7 +195,8 @@ __device__ bool nonzero(complex<T> x) { return x.real() || x.imag(); }
 
 def _generate_nd_kernel(name, pre, found, post, mode, w_shape, int_type,
                         offsets, cval, ctype='X', preamble='', options=(),
-                        has_weights=True, has_structure=False):
+                        has_weights=True, has_structure=False, has_mask=False,
+                        binary_morphology=False):
     # Currently this code uses CArray for weights but avoids using CArray for
     # the input data and instead does the indexing itself since it is faster.
     # If CArray becomes faster than follow the comments that start with
@@ -207,6 +208,8 @@ def _generate_nd_kernel(name, pre, found, post, mode, w_shape, int_type,
         in_params += ', raw W w'
     if has_structure:
         in_params += ', raw S s'
+    if has_mask:
+        in_params += ', raw M mask'
     out_params = 'Y y'
 
     # CArray: remove xstride_{j}=... from string
@@ -248,9 +251,14 @@ def _generate_nd_kernel(name, pre, found, post, mode, w_shape, int_type,
     value = '(*(X*)&data[{expr}])'.format(expr=expr)
     if mode == 'constant':
         cond = ' || '.join(['(ix_{} < 0)'.format(j) for j in range(ndim)])
-        value = '(({cond}) ? cast<{ctype}>({cval}) : {value})'.format(
-            cond=cond, ctype=ctype, cval=cval, value=value)
-    found = found.format(value=value)
+
+    if binary_morphology:
+        found = found.format(cond=cond, value=value)
+    else:
+        if mode == 'constant':
+            value = '(({cond}) ? cast<{ctype}>({cval}) : {value})'.format(
+                cond=cond, ctype=ctype, cval=cval, value=value)
+        found = found.format(value=value)
 
     # CArray: replace comment and next line in string with
     #   {type} inds[{ndim}] = {{0}};
@@ -280,6 +288,8 @@ def _generate_nd_kernel(name, pre, found, post, mode, w_shape, int_type,
         name += '_i64'
     if has_structure:
         name += '_with_structure'
+    if has_mask:
+        name += '_with_mask'
     preamble = _CAST_FUNCTION + preamble
     return cupy.ElementwiseKernel(in_params, out_params, operation, name,
                                   reduce_dims=False, preamble=preamble,

--- a/cupyx/scipy/ndimage/morphology.py
+++ b/cupyx/scipy/ndimage/morphology.py
@@ -10,7 +10,7 @@ from cupyx.scipy.ndimage import _util
 from cupyx.scipy.ndimage import filters
 
 
-@cupy._util.memoize(for_each_device=True)
+@cupy.memoize(for_each_device=True)
 def _get_binary_erosion_kernel(
     w_shape, int_type, offsets, center_is_true, border_value, invert, masked
 ):

--- a/cupyx/scipy/ndimage/morphology.py
+++ b/cupyx/scipy/ndimage/morphology.py
@@ -10,7 +10,7 @@ from cupyx.scipy.ndimage import _util
 from cupyx.scipy.ndimage import filters
 
 
-@cupy.util.memoize(for_each_device=True)
+@cupy._util.memoize(for_each_device=True)
 def _get_binary_erosion_kernel(
     w_shape, int_type, offsets, center_is_true, border_value, invert, masked
 ):

--- a/cupyx/scipy/ndimage/morphology.py
+++ b/cupyx/scipy/ndimage/morphology.py
@@ -76,7 +76,7 @@ def _get_binary_erosion_kernel(
 
 def _center_is_true(structure, origin):
     coor = tuple([oo + ss // 2 for ss, oo in zip(structure.shape, origin)])
-    return bool(structure[coor])
+    return bool(structure[coor])  # devie synchronization
 
 
 def iterate_structure(structure, iterations, origin=None):
@@ -188,7 +188,7 @@ def _binary_erosion(input, structure, iterations, mask, output, border_value,
     else:
         masked = False
     origin = _util._fix_sequence_arg(origin, input.ndim, 'origin', int)
-    center_is_true = _center_is_true(structure, origin)
+    center_is_true = _center_is_true(structure, origin)  # synchronization
     if isinstance(output, cupy.ndarray) and output.dtype.kind == 'c':
         raise TypeError("Complex output type not supported")
     else:
@@ -291,6 +291,10 @@ def binary_erosion(input, structure=None, iterations=1, mask=None, output=None,
     Returns:
         cupy.ndarray: The result of binary erosion.
 
+    .. warning::
+
+        This function may synchronize the device.
+
     .. seealso:: :func:`scipy.ndimage.binary_erosion`
     """
     return _binary_erosion(input, structure, iterations, mask, output,
@@ -329,6 +333,10 @@ def binary_dilation(input, structure=None, iterations=1, mask=None,
 
     Returns:
         cupy.ndarray: The result of binary dilation.
+
+    .. warning::
+
+        This function may synchronize the device.
 
     .. seealso:: :func:`scipy.ndimage.binary_dilation`
     """
@@ -381,6 +389,10 @@ def binary_opening(input, structure=None, iterations=1, output=None, origin=0,
     Returns:
         cupy.ndarray: The result of binary opening.
 
+    .. warning::
+
+        This function may synchronize the device.
+
     .. seealso:: :func:`scipy.ndimage.binary_opening`
     """
     if structure is None:
@@ -429,6 +441,10 @@ def binary_closing(input, structure=None, iterations=1, output=None, origin=0,
     Returns:
         cupy.ndarray: The result of binary closing.
 
+    .. warning::
+
+        This function may synchronize the device.
+
     .. seealso:: :func:`scipy.ndimage.binary_closing`
     """
     if structure is None:
@@ -470,6 +486,10 @@ def binary_hit_or_miss(input, structure1=None, structure2=None, output=None,
     Returns:
         cupy.ndarray: Hit-or-miss transform of `input` with the given
             structuring element (`structure1`, `structure2`).
+
+    .. warning::
+
+        This function may synchronize the device.
 
     .. seealso:: :func:`scipy.ndimage.binary_hit_or_miss`
     """
@@ -519,6 +539,10 @@ def binary_propagation(input, structure=None, mask=None, output=None,
     Returns:
         cupy.ndarray : Binary propagation of `input` inside `mask`.
 
+    .. warning::
+
+        This function may synchronize the device.
+
     .. seealso:: :func:`scipy.ndimage.binary_propagation`
     """
     return binary_dilation(input, structure, -1, mask, output, border_value,
@@ -545,8 +569,11 @@ def binary_fill_holes(input, structure=None, output=None, origin=0):
         cupy.ndarray: Transformation of the initial image `input` where holes
             have been filled.
 
-    .. seealso:: :func:`scipy.ndimage.binary_fill_holes`
+    .. warning::
 
+        This function may synchronize the device.
+
+    .. seealso:: :func:`scipy.ndimage.binary_fill_holes`
     """
     mask = cupy.logical_not(input)
     tmp = cupy.zeros(mask.shape, bool)

--- a/cupyx/scipy/ndimage/morphology.py
+++ b/cupyx/scipy/ndimage/morphology.py
@@ -590,14 +590,14 @@ def grey_erosion(input, size=None, footprint=None, structure=None, output=None,
     Args:
         input (cupy.ndarray): The input array.
         size (tuple of ints): Shape of a flat and full structuring element used
-            for the greyscale erosion. Optional if ```footprint``` or
-            ```structure``` is provided.
+            for the greyscale erosion. Optional if ``footprint`` or
+            ``structure`` is provided.
         footprint (array of ints): Positions of non-infinite elements of a flat
             structuring element used for greyscale erosion. Non-zero values
             give the set of neighbors of the center over which minimum is
             chosen.
         structure (array of ints): Structuring element used for the greyscale
-            erosion. ```structure``` may be a non-flat structuring element.
+            erosion. ``structure`` may be a non-flat structuring element.
         output (cupy.ndarray, dtype or None): The array in which to place the
             output.
         mode (str): The array borders are handled according to the given mode
@@ -630,14 +630,14 @@ def grey_dilation(input, size=None, footprint=None, structure=None,
     Args:
         input (cupy.ndarray): The input array.
         size (tuple of ints): Shape of a flat and full structuring element used
-            for the greyscale dilation. Optional if ```footprint``` or
-            ```structure``` is provided.
+            for the greyscale dilation. Optional if ``footprint`` or
+            ``structure`` is provided.
         footprint (array of ints): Positions of non-infinite elements of a flat
             structuring element used for greyscale dilation. Non-zero values
             give the set of neighbors of the center over which maximum is
             chosen.
         structure (array of ints): Structuring element used for the greyscale
-            dilation. ```structure``` may be a non-flat structuring element.
+            dilation. ``structure`` may be a non-flat structuring element.
         output (cupy.ndarray, dtype or None): The array in which to place the
             output.
         mode (str): The array borders are handled according to the given mode
@@ -690,14 +690,14 @@ def grey_closing(input, size=None, footprint=None, structure=None,
     Args:
         input (cupy.ndarray): The input array.
         size (tuple of ints): Shape of a flat and full structuring element used
-            for the greyscale closing. Optional if ```footprint``` or
-            ```structure``` is provided.
+            for the greyscale closing. Optional if ``footprint`` or
+            ``structure`` is provided.
         footprint (array of ints): Positions of non-infinite elements of a flat
             structuring element used for greyscale closing. Non-zero values
             give the set of neighbors of the center over which closing is
             chosen.
         structure (array of ints): Structuring element used for the greyscale
-            closing. ```structure``` may be a non-flat structuring element.
+            closing. ``structure`` may be a non-flat structuring element.
         output (cupy.ndarray, dtype or None): The array in which to place the
             output.
         mode (str): The array borders are handled according to the given mode
@@ -731,14 +731,14 @@ def grey_opening(input, size=None, footprint=None, structure=None,
     Args:
         input (cupy.ndarray): The input array.
         size (tuple of ints): Shape of a flat and full structuring element used
-            for the greyscale opening. Optional if ```footprint``` or
-            ```structure``` is provided.
+            for the greyscale opening. Optional if ``footprint`` or
+            ``structure`` is provided.
         footprint (array of ints): Positions of non-infinite elements of a flat
             structuring element used for greyscale opening. Non-zero values
             give the set of neighbors of the center over which opening is
             chosen.
         structure (array of ints): Structuring element used for the greyscale
-            opening. ```structure``` may be a non-flat structuring element.
+            opening. ``structure`` may be a non-flat structuring element.
         output (cupy.ndarray, dtype or None): The array in which to place the
             output.
         mode (str): The array borders are handled according to the given mode

--- a/cupyx/scipy/ndimage/morphology.py
+++ b/cupyx/scipy/ndimage/morphology.py
@@ -159,28 +159,28 @@ def _binary_erosion(input, structure, iterations, mask, output, border_value,
     try:
         iterations = operator.index(iterations)
     except TypeError:
-        raise TypeError("iterations parameter should be an integer")
+        raise TypeError('iterations parameter should be an integer')
 
     if not input.flags.c_contiguous:
         # TODO: grlee77: is C-contiguity required?
         input = cupy.ascontiguousarray(input)
-    if input.dtype.kind == "c":
-        raise TypeError("Complex type not supported")
+    if input.dtype.kind == 'c':
+        raise TypeError('Complex type not supported')
     if structure is None:
         structure = generate_binary_structure(input.ndim, 1)
     else:
         structure = cupy.asarray(structure, dtype=bool)
     if structure.ndim != input.ndim:
-        raise RuntimeError("structure and input must have same dimensionality")
+        raise RuntimeError('structure and input must have same dimensionality')
     if not structure.flags.c_contiguous:
         # TODO: grlee77: is C-contiguity required?
         structure = cupy.ascontiguousarray(structure)
     if structure.size < 1:
-        raise RuntimeError("structure must not be empty")
+        raise RuntimeError('structure must not be empty')
 
     if mask is not None:
         if mask.shape != input.shape:
-            raise RuntimeError("mask and input must have equal sizes")
+            raise RuntimeError('mask and input must have equal sizes')
         if not mask.flags.c_contiguous:
             # TODO: grlee77: current indexing requires C contiguous arrays.
             mask = cupy.asacontiguousarray(mask)
@@ -190,11 +190,11 @@ def _binary_erosion(input, structure, iterations, mask, output, border_value,
     origin = _util._fix_sequence_arg(origin, input.ndim, 'origin', int)
     center_is_true = _center_is_true(structure, origin)  # synchronization
     if isinstance(output, cupy.ndarray) and output.dtype.kind == 'c':
-        raise TypeError("Complex output type not supported")
+        raise TypeError('Complex output type not supported')
     else:
         output = bool
     output = _util._get_output(output, input)
-    temp_needed = cupy.shares_memory(output, input, "MAY_SHARE_BOUNDS")
+    temp_needed = cupy.shares_memory(output, input, 'MAY_SHARE_BOUNDS')
     if temp_needed:
         # input and output arrays cannot share memory
         temp = output
@@ -221,11 +221,11 @@ def _binary_erosion(input, structure, iterations, mask, output, border_value,
             output = erode_kernel(input, structure, output)
     elif center_is_true and not brute_force:
         raise NotImplementedError(
-            "only brute_force iteration has been implemented"
+            'only brute_force iteration has been implemented'
         )
     else:
-        if cupy.shares_memory(output, input, "MAY_SHARE_BOUNDS"):
-            raise ValueError("output and input may not overlap in memory")
+        if cupy.shares_memory(output, input, 'MAY_SHARE_BOUNDS'):
+            raise ValueError('output and input may not overlap in memory')
         tmp_in = cupy.empty_like(input, dtype=output.dtype)
         tmp_out = output
         if iterations >= 1 and not iterations & 1:
@@ -723,7 +723,7 @@ def grey_closing(input, size=None, footprint=None, structure=None,
     .. seealso:: :func:`scipy.ndimage.grey_closing`
     """
     if (size is not None) and (footprint is not None):
-        warnings.warn("ignoring size because footprint is set", UserWarning,
+        warnings.warn('ignoring size because footprint is set', UserWarning,
                       stacklevel=2)
     tmp = grey_dilation(input, size, footprint, structure, None, mode, cval,
                         origin)
@@ -764,7 +764,7 @@ def grey_opening(input, size=None, footprint=None, structure=None,
     .. seealso:: :func:`scipy.ndimage.grey_opening`
     """
     if (size is not None) and (footprint is not None):
-        warnings.warn("ignoring size because footprint is set", UserWarning,
+        warnings.warn('ignoring size because footprint is set', UserWarning,
                       stacklevel=2)
     tmp = grey_erosion(input, size, footprint, structure, None, mode, cval,
                        origin)

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_morphology.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_morphology.py
@@ -84,7 +84,10 @@ class TestIterateStructure(unittest.TestCase):
 class BinaryErosionAndDilation1d(unittest.TestCase):
     def _filter(self, xp, scp, x):
         filter = getattr(scp.ndimage, self.filter)
-        return filter(x, self.structure, iterations=1, mask=None,
+        structure = self.structure
+        if structure is not None:
+            structure = xp.asarray(structure)
+        return filter(x, structure, iterations=1, mask=None,
                       output=self.output, border_value=self.border_value,
                       origin=self.origin, brute_force=True)
 

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_morphology.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_morphology.py
@@ -89,7 +89,7 @@ class BinaryErosionAndDilation1d(unittest.TestCase):
     @testing.numpy_cupy_array_equal(scipy_name='scp')
     def test_binary_erosion_and_dilation_1d(self, xp, scp):
         if self.x_dtype == self.output:
-            raise unittest.SkipTest("redundant")
+            raise unittest.SkipTest('redundant')
         x = xp.asarray(self.data, dtype=self.x_dtype)
         return self._filter(xp, scp, x)
 
@@ -136,7 +136,7 @@ class BinaryOpeningAndClosing(unittest.TestCase):
     @testing.numpy_cupy_array_equal(scipy_name='scp')
     def test_binary_opening_and_closing(self, xp, scp):
         if self.x_dtype == self.output:
-            raise unittest.SkipTest("redundant")
+            raise unittest.SkipTest('redundant')
         x = xp.asarray(self.data, dtype=self.x_dtype)
         return self._filter(xp, scp, x)
 
@@ -185,7 +185,7 @@ class BinaryFillHoles(unittest.TestCase):
     @testing.numpy_cupy_array_equal(scipy_name='scp')
     def test_binary_fill_holes(self, xp, scp):
         if self.x_dtype == self.output:
-            raise unittest.SkipTest("redundant")
+            raise unittest.SkipTest('redundant')
         x = xp.asarray(self.data, dtype=self.x_dtype)
         return self._filter(xp, scp, x)
 
@@ -245,7 +245,7 @@ class BinaryHitOrMiss(unittest.TestCase):
     @testing.numpy_cupy_array_equal(scipy_name='scp')
     def test_binary_hit_or_miss(self, xp, scp):
         if self.x_dtype == self.output:
-            raise unittest.SkipTest("redundant")
+            raise unittest.SkipTest('redundant')
         x = xp.asarray(self.data, dtype=self.x_dtype)
         return self._filter(xp, scp, x)
 
@@ -309,7 +309,7 @@ class BinaryPropagation(unittest.TestCase):
     @testing.numpy_cupy_array_equal(scipy_name='scp')
     def test_binary_propagation(self, xp, scp):
         if self.x_dtype == self.output:
-            raise unittest.SkipTest("redundant")
+            raise unittest.SkipTest('redundant')
         x = xp.asarray(self.data, dtype=self.x_dtype)
         return self._filter(xp, scp, x)
 
@@ -342,7 +342,7 @@ class BinaryErosionAndDilation(unittest.TestCase):
     @testing.numpy_cupy_array_equal(scipy_name='scp')
     def test_binary_erosion_and_dilation(self, xp, scp):
         if self.x_dtype == self.output:
-            raise unittest.SkipTest("redundant")
+            raise unittest.SkipTest('redundant')
         rstate = numpy.random.RandomState(5)
         x = rstate.randn(*self.shape) > self.density
         x = xp.asarray(x, dtype=self.x_dtype)
@@ -416,9 +416,9 @@ class TestGreyErosionAndDilation(unittest.TestCase):
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
     def test_grey_erosion_and_dilation(self, xp, scp):
         if self.mode == 'mirror' and 1 in self.shape:
-            raise unittest.SkipTest("not testable against scipy")
+            raise unittest.SkipTest('not testable against scipy')
         if self.x_dtype == self.output:
-            raise unittest.SkipTest("redundant")
+            raise unittest.SkipTest('redundant')
         x = testing.shaped_random(self.shape, xp, self.x_dtype)
         return self._filter(xp, scp, x)
 

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_morphology.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_morphology.py
@@ -2,7 +2,6 @@
 import unittest
 
 import numpy
-import pytest
 
 from cupy import testing
 import cupyx.scipy.ndimage  # NOQA
@@ -12,10 +11,6 @@ try:
 except ImportError:
     pass
 
-# @pytest.mark.parametrize('rank, connectivity', [(2, 2)])
-# @testing.numpy_cupy_array_equal(scipy_name='scp')
-# def test_generate_binary_structure(xp, scp, rank, connectivity):
-#     return scp.ndimage.generate_binary_structure(rank, connectivity)
 
 @testing.parameterize(
     {'rank': 0, 'connectivity': 1},

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_morphology.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_morphology.py
@@ -1,6 +1,8 @@
+
 import unittest
 
 import numpy
+import pytest
 
 from cupy import testing
 import cupyx.scipy.ndimage  # NOQA
@@ -9,6 +11,124 @@ try:
     import scipy.ndimage  # NOQA
 except ImportError:
     pass
+
+# @pytest.mark.parametrize('rank, connectivity', [(2, 2)])
+# @testing.numpy_cupy_array_equal(scipy_name='scp')
+# def test_generate_binary_structure(xp, scp, rank, connectivity):
+#     return scp.ndimage.generate_binary_structure(rank, connectivity)
+
+@testing.parameterize(
+    {'rank': 0, 'connectivity': 1},
+    {'rank': 1, 'connectivity': 1},
+    {'rank': 2, 'connectivity': 1},
+    {'rank': 2, 'connectivity': 2},
+    {'rank': 3, 'connectivity': 1},
+    {'rank': 3, 'connectivity': 2},
+    {'rank': 3, 'connectivity': 3},
+    # edge cases
+    {'rank': -1, 'connectivity': 0},
+    {'rank': 3, 'connectivity': 0},
+    {'rank': 3, 'connectivity': 500})
+@testing.gpu
+@testing.with_requires('scipy')
+class TestGenerateBinaryStructure(unittest.TestCase):
+
+    @testing.numpy_cupy_array_equal(scipy_name='scp')
+    def test_generate_binary_structure(self, xp, scp):
+        return scp.ndimage.generate_binary_structure(self.rank,
+                                                     self.connectivity)
+
+
+@testing.gpu
+@testing.with_requires('scipy')
+class TestIterateStructure(unittest.TestCase):
+
+    @testing.numpy_cupy_array_equal(scipy_name='scp')
+    def test_iterate_structure1(self, xp, scp):
+        struct = xp.asarray([[0, 1, 0],
+                             [1, 1, 1],
+                             [0, 1, 0]])
+        return scp.ndimage.iterate_structure(struct, 2)
+
+    @testing.numpy_cupy_array_equal(scipy_name='scp')
+    def test_iterate_structure2(self, xp, scp):
+        struct = xp.asarray([[0, 1],
+                             [1, 1],
+                             [0, 1]])
+        return scp.ndimage.iterate_structure(struct, 2)
+
+    @testing.numpy_cupy_array_equal(scipy_name='scp')
+    def test_iterate_structure3(self, xp, scp):
+        struct = xp.asarray([[0, 1, 0],
+                             [1, 1, 1],
+                             [0, 1, 0]])
+        out, origin = scp.ndimage.iterate_structure(struct, 2, 1)
+        assert origin == [2, 2]
+        return out
+
+
+@testing.parameterize(*(
+    testing.product({
+        'x_dtype': [numpy.bool, numpy.int8, numpy.uint8, numpy.float32,
+                    numpy.float64],
+        'border_value': [0, 1],
+        'structure': [None, [1, 0, 1], [1, 1, 0]],
+        'origin': [-1, 0, 1],
+        'data': [[], [1, 1, 0, 1, 1]],
+        'filter': ['binary_erosion', 'binary_dilation'],
+        'output': [None, numpy.float32, numpy.int8]}
+    ))
+)
+@testing.gpu
+@testing.with_requires('scipy')
+class BinaryErosionAndDilation1d(unittest.TestCase):
+    def _filter(self, xp, scp, x):
+        filter = getattr(scp.ndimage, self.filter)
+        return filter(x, self.structure, iterations=1, mask=None,
+                      output=self.output, border_value=self.border_value,
+                      origin=self.origin, brute_force=True)
+
+    @testing.numpy_cupy_array_equal(scipy_name='scp')
+    def test_binary_erosion_and_dilation_1d(self, xp, scp):
+        if self.x_dtype == self.output:
+            raise unittest.SkipTest("redundant")
+        x = xp.asarray(self.data, dtype=self.x_dtype)
+        return self._filter(xp, scp, x)
+
+
+@testing.parameterize(*(
+    testing.product({
+        'x_dtype': [numpy.int8, numpy.float32],
+        'border_value': [0, 1],
+        'connectivity': [1, 2],
+        'origin': [0, -1],
+        'shape': [(64,), (16, 15), (5, 7, 9)],
+        'density': [0.1, 0.5, 0.9],
+        'filter': ['binary_erosion', 'binary_dilation'],
+        'iterations': [1, 2, 0],
+        'output': [None, numpy.float32]}
+    ))
+)
+@testing.gpu
+@testing.with_requires('scipy')
+class BinaryErosionAndDilation(unittest.TestCase):
+    def _filter(self, xp, scp, x):
+        filter = getattr(scp.ndimage, self.filter)
+        ndim = len(self.shape)
+        structure = scp.ndimage.generate_binary_structure(ndim,
+                                                          self.connectivity)
+        return filter(x, structure, iterations=self.iterations, mask=None,
+                      output=self.output, border_value=self.border_value,
+                      origin=self.origin, brute_force=True)
+
+    @testing.numpy_cupy_array_equal(scipy_name='scp')
+    def test_binary_erosion_and_dilation(self, xp, scp):
+        if self.x_dtype == self.output:
+            raise unittest.SkipTest("redundant")
+        rstate = numpy.random.RandomState(5)
+        x = rstate.randn(*self.shape) > self.density
+        x = xp.asarray(x, dtype=self.x_dtype)
+        return self._filter(xp, scp, x)
 
 
 @testing.parameterize(*(


### PR DESCRIPTION
This PR adds `binary_erosion`, `binary_dilation`, `binary_opening`, `binary_closing`, `binary_hit_or_miss`, `binary_propagation`, `binary_fill_holes`, `generate_binary_structure` and `iterate_structure`.

The only new kernel is the one corresponding to binary erosion. I was able to mostly reuse the existing utility `_filters_core._generate_nd_kernel`, but did have to add a couple of arguments to get it to work for this case. @coderforlife, please take a look if you have a chance.

All other binary morphological operations are built on top of `binary_erosion`. Some of the specific data arrays used in the tests were borrowed from SciPy's test suite.

The only feature in SciPy that is not implemented here is the case where `iterations > 1` and `brute_force=False`. SciPy uses a different algorithm in that case, but I have only implemented the brute force kernel here.
