### PR TITLE
[backport] Fix test fail when cudnn is unavailable

### DIFF
--- a/tests/cupy_tests/cuda_tests/test_cudnn.py
+++ b/tests/cupy_tests/cuda_tests/test_cudnn.py
@@ -1,11 +1,10 @@
 import pickle
 import unittest
 
-try:
-    from cupy.cuda import cudnn
-    cudnn_available = True
-except Exception:
-    cudnn_available = False
+from cupy.cuda import cudnn
+
+
+cudnn_available = cudnn.available
 
 
 @unittest.skipUnless(cudnn_available, 'cuDNN is unavailable')


### PR DESCRIPTION
Backport of #3906