### PR TITLE
Fix `cupy.testing.parameterize` to reraise error of AssertionError type

### DIFF
--- a/cupy/testing/parameterized.py
+++ b/cupy/testing/parameterized.py
@@ -6,8 +6,6 @@ import typing as tp  # NOQA
 import unittest
 
 from cupy.testing import _bundle
-from cupy.cuda import cufft
-from cupy.cuda import driver
 
 
 def _param_to_str(obj):
@@ -85,16 +83,15 @@ def _parameterize_test_case(base, i, param):
                 raise
             except Exception as e:
                 s = io.StringIO()
-                s.write('Parameterized test failed.\n\n')
+                s.write('Parameterized test failed with {}.\n\n'.format(
+                    e.__class__.__name__))
                 s.write('Base test method: {}.{}\n'.format(
                     base.__name__, base_method.__name__))
                 s.write('Test parameters:\n')
                 for k, v in sorted(param.items()):
                     s.write('  {}: {}\n'.format(k, v))
-                err_class = e.__class__
-                if isinstance(e, (driver.CUDADriverError, cufft.CuFFTError)):
-                    err_class, = err_class.__bases__
-                raise err_class(s.getvalue()).with_traceback(e.__traceback__)
+                raise AssertionError(s.getvalue()).with_traceback(
+                    e.__traceback__)
         return new_method
 
     return (cls_name, mb, method_generator)


### PR DESCRIPTION
Fix #3915.