### PR TITLE
[backport] Add `cupy.searchsorted` to doc

### DIFF
--- a/docs/source/reference/sorting.rst
+++ b/docs/source/reference/sorting.rst
@@ -36,6 +36,7 @@ Searching
    cupy.flatnonzero
    cupy.where
    cupy.argwhere
+   cupy.searchsorted
 
 Counting
 --------


### PR DESCRIPTION
Backport of #3908