### PR TITLE
Remove "min" from shown statistics of `cupyx.time.repeat`

### DIFF
--- a/cupyx/time.py
+++ b/cupyx/time.py
@@ -39,10 +39,9 @@ class _PerfCaseResult(object):
     def to_str(self, show_gpu=False):
         results = [self._to_str_per_item('CPU', self._ts[0])]
         if show_gpu:
-            for i, d in enumerate(self._devices):
+            for d, t in zip(self._devices, self._ts[1:]):
                 results.append(
-                    self._to_str_per_item('GPU-{}'.format(d),
-                                          self._ts[1 + i]))
+                    self._to_str_per_item('GPU-{}'.format(d), t))
         return '{:<20s}:{}'.format(self.name, ' '.join(results))
 
     def __str__(self):

--- a/cupyx/time.py
+++ b/cupyx/time.py
@@ -32,8 +32,8 @@ class _PerfCaseResult(object):
 
         s = '    {}:{:9.03f} us'.format(device_name, t_us.mean())
         if t.size > 1:
-            s += '   +/-{:6.03f} (min:{:9.03f} / max:{:9.03f}) us'.format(
-                t_us.std(), t_us.min(), t_us.max())
+            s += '   +/-{:6.03f} (max:{:9.03f}) us'.format(
+                t_us.std(), t_us.max())
         return s
 
     def to_str(self, show_gpu=False):

--- a/tests/cupyx_tests/test_time.py
+++ b/tests/cupyx_tests/test_time.py
@@ -89,10 +89,8 @@ class TestPerfCaseResult(unittest.TestCase):
         perf = cupyx.time._PerfCaseResult('test_name_xxx', times, (0,))
         expected = (
             'test_name_xxx       :'
-            '    CPU:    5.620 us   +/- 0.943 '
-            '(min:    4.200 / max:    7.100) us '
-            '    GPU-0:    6.600 us   +/- 2.344 '
-            '(min:    3.800 / max:    9.600) us'
+            '    CPU:    5.620 us   +/- 0.943 (max:    7.100) us '
+            '    GPU-0:    6.600 us   +/- 2.344 (max:    9.600) us'
         )
         assert str(perf) == expected
 
@@ -104,8 +102,7 @@ class TestPerfCaseResult(unittest.TestCase):
         perf = cupyx.time._PerfCaseResult('test_name_xxx', times, (0,))
         expected = (
             'test_name_xxx       :'
-            '    CPU:    5.620 us   +/- 0.943 '
-            '(min:    4.200 / max:    7.100) us'
+            '    CPU:    5.620 us   +/- 0.943 (max:    7.100) us'
         )
         assert perf.to_str() == expected
         # Checks if the result does not change.


### PR DESCRIPTION
We rarely refer to the minimum execution time.