### PR TITLE
[backport] Rename `cupy.util` submodule to `cupy._util`

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -63,7 +63,6 @@ from cupy import random  # NOQA
 from cupy import sparse  # NOQA
 from cupy import statistics  # NOQA
 from cupy import testing  # NOQA  # NOQA
-from cupy import util  # NOQA
 from cupy import lib  # NOQA
 
 
@@ -749,8 +748,8 @@ def ndim(a):
 # CuPy specific functions
 # -----------------------------------------------------------------------------
 
-from cupy.util import clear_memo  # NOQA
-from cupy.util import memoize  # NOQA
+from cupy._util import clear_memo  # NOQA
+from cupy._util import memoize  # NOQA
 
 from cupy.core import ElementwiseKernel  # NOQA
 from cupy.core import RawKernel  # NOQA

--- a/cupy/_sorting/search.py
+++ b/cupy/_sorting/search.py
@@ -1,7 +1,7 @@
 import cupy
 from cupy import core
 from cupy.core import fusion
-from cupy import util
+from cupy import _util
 
 from cupy.core import _routines_indexing as _indexing
 from cupy.core import _routines_statistics as _statistics
@@ -140,7 +140,7 @@ def nonzero(a):
     .. seealso:: :func:`numpy.nonzero`
 
     """
-    util.check_array(a, arg_name='a')
+    _util.check_array(a, arg_name='a')
     return a.nonzero()
 
 
@@ -162,7 +162,7 @@ def flatnonzero(a):
 
     .. seealso:: :func:`numpy.flatnonzero`
     """
-    util.check_array(a, arg_name='a')
+    _util.check_array(a, arg_name='a')
     return a.ravel().nonzero()[0]
 
 
@@ -231,7 +231,7 @@ def argwhere(a):
     .. seealso:: :func:`numpy.argwhere`
 
     """
-    util.check_array(a, arg_name='a')
+    _util.check_array(a, arg_name='a')
     if a.ndim == 0:
         warnings.warn(
             'calling argwhere on 0d arrays is deprecated',

--- a/cupy/_util.pyx
+++ b/cupy/_util.pyx
@@ -149,10 +149,10 @@ def experimental(api_name):
 
     .. testcode::
 
-        from cupy import util
+        from cupy import _util
 
         def f(x):
-            util.experimental('cupy.foo.bar.f')
+            _util.experimental('cupy.foo.bar.f')
             # concrete implementation of f follows
 
         f(1)
@@ -170,7 +170,7 @@ The interface can change in the future. ...
 
         class C():
             def __init__(self):
-              util.experimental('cupy.foo.C')
+              _util.experimental('cupy.foo.C')
 
         C()
 
@@ -187,7 +187,7 @@ The interface can change in the future. ...
 
         class D():
             def __init__(self):
-                util.experimental('D.__init__')
+                _util.experimental('D.__init__')
 
         D()
 
@@ -205,7 +205,7 @@ The interface can change in the future. ...
 
         def g(x, experimental_arg=None):
             if experimental_arg is not None:
-                util.experimental('experimental_arg of cupy.foo.g')
+                _util.experimental('experimental_arg of cupy.foo.g')
 
     Args:
         api_name(str): The name of an API marked as experimental.

--- a/cupy/core/_cub_reduction.pyx
+++ b/cupy/core/_cub_reduction.pyx
@@ -16,7 +16,7 @@ import string
 from cupy import _environment
 from cupy.core._kernel import _get_param_info
 from cupy.cuda import driver
-from cupy import util
+from cupy import _util
 
 
 cdef function.Function _create_cub_reduction_function(
@@ -197,7 +197,7 @@ __global__ void ${name}(${params}) {
     return module.get_function(name)
 
 
-@util.memoize(for_each_device=True)
+@_util.memoize(for_each_device=True)
 def _SimpleCubReductionKernel_get_cached_function(
         map_expr, reduce_expr, post_map_expr, reduce_type,
         params, arginfos, _kernel._TypeMap type_map,

--- a/cupy/core/_fusion_kernel.pyx
+++ b/cupy/core/_fusion_kernel.pyx
@@ -16,7 +16,7 @@ from cupy_backends.cuda.api cimport runtime
 from cupy.core cimport _reduction
 
 from cupy.core import _dtype
-from cupy import util
+from cupy import _util
 from cupy.core import _fusion_emit_code
 from cupy.core import _fusion_op
 from cupy.core._fusion_variable import _AbstractDim
@@ -29,7 +29,7 @@ cdef Py_ssize_t _default_block_size = (
     256 if runtime._is_hip_environment else 512)
 
 
-@util.memoize(for_each_device=True)
+@_util.memoize(for_each_device=True)
 def _cuda_compile(preamble, name, cuda_params, cuda_body, use_grid_sync):
     template = (
         '${preamble}\n\n'

--- a/cupy/core/_fusion_trace.pyx
+++ b/cupy/core/_fusion_trace.pyx
@@ -13,7 +13,7 @@ from cupy.core._fusion_variable import _TraceArray
 from cupy.core._fusion_variable import _VariableSet
 from cupy.core import _fusion_op
 from cupy.core import _fusion_optimization
-from cupy import util
+from cupy import _util
 
 
 _thread_local = _fusion_thread_local.thread_local
@@ -438,7 +438,7 @@ class TraceImpl:
             raise NotImplementedError(
                 'Reduction for scalar arguments is not supported.')
 
-        axes = util._normalize_axis_indices(axis, in_param.ndim)
+        axes = _util._normalize_axis_indices(axis, in_param.ndim)
 
         if dtype is not None:
             dtype = numpy.dtype(dtype)

--- a/cupy/core/_kernel.pyx
+++ b/cupy/core/_kernel.pyx
@@ -3,7 +3,7 @@ import string
 import numpy
 
 from cupy.cuda import compiler
-from cupy import util
+from cupy import _util
 
 cimport cpython  # NOQA
 cimport cython  # NOQA
@@ -426,14 +426,14 @@ cdef class ParameterInfo:
             ]))
 
 
-@util.memoize()
+@_util.memoize()
 def _get_param_info(str s, is_const):
     if len(s) == 0:
         return ()
     return tuple([ParameterInfo(i, is_const) for i in s.strip().split(',')])
 
 
-@util.memoize()
+@_util.memoize()
 def _decide_params_type(in_params, out_params, in_args_dtype, out_args_dtype):
     return _decide_params_type_core(in_params, out_params, in_args_dtype,
                                     out_args_dtype)
@@ -620,7 +620,7 @@ cdef list _get_out_args_with_params(
     return out_args
 
 
-@util.memoize(for_each_device=True)
+@_util.memoize(for_each_device=True)
 def _get_elementwise_kernel(
         tuple arginfos, _TypeMap type_map, tuple params, operation, name,
         preamble, **kwargs):

--- a/cupy/core/_reduction.pyx
+++ b/cupy/core/_reduction.pyx
@@ -40,7 +40,7 @@ from cupy.core._kernel import _get_param_info
 from cupy.core._kernel import _decide_params_type
 from cupy.core._ufuncs import elementwise_copy
 from cupy.cuda import compiler
-from cupy import util
+from cupy import _util
 
 
 cpdef function.Function _create_reduction_function(
@@ -597,7 +597,7 @@ cdef class _SimpleReductionKernel(_AbstractReductionKernel):
             self._input_expr, self._output_expr, self._preamble, ())
 
 
-@util.memoize(for_each_device=True)
+@_util.memoize(for_each_device=True)
 def _SimpleReductionKernel_get_cached_function(
         map_expr, reduce_expr, post_map_expr, reduce_type,
         params, arginfos, _kernel._TypeMap type_map,
@@ -760,7 +760,7 @@ cdef class ReductionKernel(_AbstractReductionKernel):
             self.preamble, self.options)
 
 
-@util.memoize(for_each_device=True)
+@_util.memoize(for_each_device=True)
 def _ReductionKernel_get_cached_function(
         nin, nout, params, arginfos, _kernel._TypeMap type_map,
         name, block_size, reduce_type, identity, map_expr, reduce_expr,

--- a/cupy/core/_routines_math.pyx
+++ b/cupy/core/_routines_math.pyx
@@ -7,7 +7,7 @@ from cupy.core._reduction import create_reduction_func
 from cupy.core._kernel import create_ufunc
 from cupy.core._scalar import get_typename
 from cupy.core._ufuncs import elementwise_copy
-from cupy import util
+from cupy import _util
 
 from cupy.core cimport _accelerator
 from cupy.core._dtype cimport get_dtype
@@ -147,7 +147,7 @@ cdef ndarray _ndarray_clip(ndarray self, a_min, a_max, out):
 # private/internal
 
 
-@util.memoize(for_each_device=True)
+@_util.memoize(for_each_device=True)
 def _inclusive_batch_scan_kernel(
         dtype, block_size, op, src_c_cont, out_c_cont):
     """return Prefix Sum(Scan) cuda kernel
@@ -261,7 +261,7 @@ def _inclusive_batch_scan_kernel(
     return module.get_function(name)
 
 
-@util.memoize(for_each_device=True)
+@_util.memoize(for_each_device=True)
 def _inclusive_scan_kernel(src_dtype, dtype, block_size, op, src_c_cont,
                            out_c_cont):
     """return Prefix Sum(Scan) cuda kernel
@@ -340,7 +340,7 @@ def _inclusive_scan_kernel(src_dtype, dtype, block_size, op, src_c_cont,
     return module.get_function(name)
 
 
-@util.memoize(for_each_device=True)
+@_util.memoize(for_each_device=True)
 def _add_scan_batch_blocked_sum_kernel(dtype, op, block_size, c_cont):
     name = 'add_scan_blocked_sum_kernel'
     dtype = get_typename(dtype)
@@ -376,7 +376,7 @@ def _add_scan_batch_blocked_sum_kernel(dtype, op, block_size, c_cont):
     return module.get_function(name)
 
 
-@util.memoize(for_each_device=True)
+@_util.memoize(for_each_device=True)
 def _add_scan_blocked_sum_kernel(dtype, op, c_cont):
     name = 'add_scan_blocked_sum_kernel'
     dtype = get_typename(dtype)
@@ -532,7 +532,7 @@ cpdef scan_core(ndarray a, axis, scan_op op, dtype=None, ndarray out=None):
         else:
             scan(result, op, dtype, result)
     else:
-        axis = cupy.util._normalize_axis_index(axis, a.ndim)
+        axis = _util._normalize_axis_index(axis, a.ndim)
         result = _proc_as_batch(result, axis, dtype, op)
     # This is for when the original out param was not contiguous
     if out is not None and out.data != result.data:

--- a/cupy/core/_routines_sorting.pyx
+++ b/cupy/core/_routines_sorting.pyx
@@ -5,7 +5,7 @@ import numpy
 import cupy
 from cupy.core._scalar import get_typename as _get_typename
 from cupy.core._ufuncs import elementwise_copy
-from cupy import util
+from cupy import _util
 from cupy.cuda import thrust
 
 from cupy.core cimport _routines_manipulation as _manipulation
@@ -249,7 +249,7 @@ cdef ndarray _ndarray_argpartition(self, kth, axis):
     return data.argsort(_axis)
 
 
-@util.memoize(for_each_device=True)
+@_util.memoize(for_each_device=True)
 def _partition_kernel(dtype):
     name = 'partition_kernel'
     merge_kernel = 'partition_merge_kernel'

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -24,7 +24,7 @@ from cupy.cuda import memory as memory_module
 
 
 from cupy_backends.cuda.api.runtime import CUDARuntimeError
-from cupy import util
+from cupy import _util
 
 cimport cpython  # NOQA
 cimport cython  # NOQA
@@ -1315,7 +1315,7 @@ cdef class ndarray:
             array([9998., 9999.])
 
         """
-        if util.ENABLE_SLICE_COPY and (
+        if _util.ENABLE_SLICE_COPY and (
                 type(slices) is slice
                 and slices == slice(None, None, None)
                 and isinstance(value, numpy.ndarray)
@@ -2284,7 +2284,7 @@ cdef inline _alloc_async_transfer_buffer(Py_ssize_t nbytes):
             'could not be allocated. '
             'This generally occurs because of insufficient host memory. '
             'The original error was: {}'.format(nbytes, e),
-            util.PerformanceWarning)
+            _util.PerformanceWarning)
 
     return None
 

--- a/cupy/core/raw.pyx
+++ b/cupy/core/raw.pyx
@@ -471,7 +471,7 @@ cdef class RawModule:
         return memptr
 
 
-@cupy.util.memoize(for_each_device=True)
+@cupy._util.memoize(for_each_device=True)
 def _get_raw_module(str code, str path, tuple options, str backend,
                     bint translate_cucomplex,
                     bint enable_cooperative_groups,

--- a/cupy/core/syncdetect.py
+++ b/cupy/core/syncdetect.py
@@ -1,7 +1,7 @@
 import contextlib
 import threading
 
-from cupy import util
+from cupy import _util
 
 
 _thread_local = threading.local()
@@ -47,7 +47,7 @@ thread.
     Note that there can be false negatives and positives.
     Device synchronization outside CuPy will not be detected.
     """
-    util.experimental('cupyx.allow_synchronize')
+    _util.experimental('cupyx.allow_synchronize')
     old = _is_allowed()
     _thread_local.allowed = allow
     try:

--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -11,7 +11,7 @@ from cupy.cuda import device
 from cupy.cuda import function
 from cupy_backends.cuda.api import runtime
 from cupy_backends.cuda.libs import nvrtc
-from cupy import util
+from cupy import _util
 
 
 _nvrtc_version = None
@@ -73,7 +73,7 @@ def _get_nvrtc_version():
 _tegra_archs = ('53', '62', '72')
 
 
-@util.memoize(for_each_device=True)
+@_util.memoize(for_each_device=True)
 def _get_arch():
     # See Supported Compile Options section of NVRTC User Guide for
     # the maximum value allowed for `--gpu-architecture`.
@@ -500,7 +500,7 @@ class _NVRTCProgram(object):
         self.ptr = nvrtc.createProgram(src, name, headers, include_names)
         self.name_expressions = name_expressions
 
-    def __del__(self, is_shutting_down=util.is_shutting_down):
+    def __del__(self, is_shutting_down=_util.is_shutting_down):
         if is_shutting_down():
             return
         if self.ptr:

--- a/cupy/cuda/device.pyx
+++ b/cupy/cuda/device.pyx
@@ -8,7 +8,7 @@ from cupy_backends.cuda.api import runtime as runtime_module
 from cupy_backends.cuda.libs import cublas
 from cupy_backends.cuda.libs import cusolver
 from cupy_backends.cuda.libs import cusparse
-from cupy import util
+from cupy import _util
 
 
 # This flag is kept for backward compatibility.
@@ -67,7 +67,7 @@ cpdef str get_compute_capability():
     return Device().compute_capability
 
 
-@util.memoize()
+@_util.memoize()
 def _get_attributes(device_id):
     """Return a dict containing all device attributes."""
     d = {}

--- a/cupy/cuda/pinned_memory.pyx
+++ b/cupy/cuda/pinned_memory.pyx
@@ -9,7 +9,7 @@ from cupy_backends.cuda.api import runtime
 
 from cupy.core cimport internal
 from cupy_backends.cuda.api cimport runtime
-from cupy import util
+from cupy import _util
 
 
 class PinnedMemory(object):
@@ -29,7 +29,7 @@ class PinnedMemory(object):
         if size > 0:
             self.ptr = runtime.hostAlloc(size, flags)
 
-    def __del__(self, is_shutting_down=util.is_shutting_down):
+    def __del__(self, is_shutting_down=_util.is_shutting_down):
         if is_shutting_down():
             return
         if self.ptr:

--- a/cupy/cuda/stream.pyx
+++ b/cupy/cuda/stream.pyx
@@ -4,7 +4,7 @@ from cupy_backends.cuda cimport stream as stream_module
 import threading
 import weakref
 
-from cupy import util
+from cupy import _util
 
 
 cdef object _thread_local = threading.local()
@@ -103,7 +103,7 @@ class Event(object):
                 (interprocess and runtime.eventInterprocess))
         self.ptr = runtime.eventCreateWithFlags(flag)
 
-    def __del__(self, is_shutting_down=util.is_shutting_down):
+    def __del__(self, is_shutting_down=_util.is_shutting_down):
         if is_shutting_down():
             return
         if self.ptr:
@@ -278,7 +278,7 @@ class Stream(BaseStream):
         else:
             self.ptr = runtime.streamCreate()
 
-    def __del__(self, is_shutting_down=util.is_shutting_down):
+    def __del__(self, is_shutting_down=_util.is_shutting_down):
         cdef intptr_t current_ptr
         if is_shutting_down():
             return

--- a/cupy/cudnn.pyx
+++ b/cupy/cudnn.pyx
@@ -16,7 +16,7 @@ from cupy.cuda cimport memory
 from cupy_backends.cuda.libs cimport cudnn
 
 from cupy.core._ufuncs import elementwise_copy
-from cupy import util
+from cupy import _util
 from cupy_backends.cuda.libs import cudnn as py_cudnn
 
 cdef int _cudnn_version = cudnn.getVersion()
@@ -1340,7 +1340,7 @@ cpdef _warn_algorithm_fwd(
         'This might be due to lack of workspace memory. '
         'x.shape:{}, W.shape:{}, y.shape:{}, pad:{}, stride:{}'
         .format(x.shape, W.shape, y.shape, conv_param[0], conv_param[1]),
-        util.PerformanceWarning)
+        _util.PerformanceWarning)
 
 
 cpdef _Algorithm _find_algorithm_fwd(
@@ -1398,7 +1398,7 @@ cpdef _Algorithm _get_algorithm_fwd(
             warnings.warn(
                 'The best algo of conv fwd might not be selected due to '
                 'lack of workspace size ({})'.format(max_workspace_size),
-                util.PerformanceWarning)
+                _util.PerformanceWarning)
         algo = perf.algo
         workspace_size = perf.memory
         math_type = perf.mathType
@@ -1425,7 +1425,7 @@ cpdef _warn_algorithm_bwd_filter(
         'This might be due to lack of workspace memory. '
         'x.shape:{}, dy.shape:{}, dW.shape:{}, pad:{}, stride:{}'
         .format(x.shape, dy.shape, dW.shape, conv_param[0], conv_param[1]),
-        util.PerformanceWarning)
+        _util.PerformanceWarning)
 
 
 cpdef _Algorithm _find_algorithm_bwd_filter(
@@ -1503,7 +1503,7 @@ cpdef _Algorithm _get_algorithm_bwd_filter(
             warnings.warn(
                 'The best algo of conv bwd filter might not not selected due '
                 'to lack of workspace size ({})'.format(max_workspace_size),
-                util.PerformanceWarning)
+                _util.PerformanceWarning)
         algo = perf.algo
         workspace_size = perf.memory
         math_type = perf.mathType
@@ -1530,7 +1530,7 @@ cpdef _warn_algorithm_bwd_data(
         'This might be due to lack of workspace memory. '
         'W.shape:{}, x.shape:{}, y.shape:{}, pad:{}, stride:{}'
         .format(W.shape, x.shape, y.shape, conv_param[0], conv_param[1]),
-        util.PerformanceWarning)
+        _util.PerformanceWarning)
 
 
 cpdef _Algorithm _find_algorithm_bwd_data(
@@ -1606,7 +1606,7 @@ cpdef _Algorithm _get_algorithm_bwd_data(
             warnings.warn(
                 'The best algo of conv bwd data might not not selected due '
                 'to lack of workspace size ({})'.format(max_workspace_size),
-                util.PerformanceWarning)
+                _util.PerformanceWarning)
         algo = perf.algo
         workspace_size = perf.memory
         math_type = perf.mathType
@@ -2079,7 +2079,7 @@ def batch_normalization_forward_training(
             'Could be faster by calling '
             'batch_normalization_forward_training_ex() instead of '
             'batch_normalization_forward_training().',
-            util.PerformanceWarning)
+            _util.PerformanceWarning)
     if mean is None:
         return y, save_mean, save_inv_std
     else:

--- a/cupy/cusolver.py
+++ b/cupy/cusolver.py
@@ -5,8 +5,7 @@ from cupy_backends.cuda.api import runtime
 from cupy_backends.cuda.libs import cublas
 from cupy_backends.cuda.libs import cusolver
 from cupy.cuda import device
-from cupy import util
-
+from cupy import _util
 
 _available_cuda_version = {
     'gesvdj': (9000, None),
@@ -17,7 +16,7 @@ _available_cuda_version = {
 }
 
 
-@util.memoize()
+@_util.memoize()
 def check_availability(name):
     if name not in _available_cuda_version:
         msg = 'No available version information specified for {}'.format(name)

--- a/cupy/cusparse.py
+++ b/cupy/cusparse.py
@@ -7,7 +7,7 @@ import cupy
 from cupy_backends.cuda.libs import cusparse
 from cupy_backends.cuda.api import runtime
 from cupy.cuda import device
-from cupy import util
+from cupy import _util
 import cupyx.scipy.sparse
 
 
@@ -24,7 +24,7 @@ class MatDescriptor(object):
     def __reduce__(self):
         return self.create, ()
 
-    def __del__(self, is_shutting_down=util.is_shutting_down):
+    def __del__(self, is_shutting_down=_util.is_shutting_down):
         if is_shutting_down():
             return
         if self.descriptor:
@@ -119,7 +119,7 @@ def _get_version(x):
     return x
 
 
-@util.memoize()
+@_util.memoize()
 def check_availability(name):
     if name not in _available_cusparse_version:
         msg = 'No available version information specified for {}'.format(name)
@@ -1195,7 +1195,7 @@ class BaseDescriptor(object):
         self.get = get
         self.destroy = destroyer
 
-    def __del__(self, is_shutting_down=util.is_shutting_down):
+    def __del__(self, is_shutting_down=_util.is_shutting_down):
         if is_shutting_down():
             return
         if self.destroy is None:

--- a/cupy/fft/config.py
+++ b/cupy/fft/config.py
@@ -1,4 +1,4 @@
-from cupy import util
+from cupy import _util
 
 
 enable_nd_planning = True
@@ -23,7 +23,7 @@ def set_cufft_gpus(gpus):
     .. _Multiple GPU cuFFT Transforms:
         https://docs.nvidia.com/cuda/cufft/index.html#multiple-GPU-cufft-transforms
     '''
-    util.experimental('cupy.fft.config.set_cufft_gpus')
+    _util.experimental('cupy.fft.config.set_cufft_gpus')
     global _devices
 
     if isinstance(gpus, int):

--- a/cupy/fft/fft.py
+++ b/cupy/fft/fft.py
@@ -13,7 +13,7 @@ _reduce = functools.reduce
 _prod = cupy.core.internal.prod
 
 
-@cupy.util.memoize()
+@cupy._util.memoize()
 def _output_dtype(dtype, value_type):
     if value_type != 'R2C':
         if dtype in [np.float16, np.float32]:

--- a/cupy/linalg/einsum.py
+++ b/cupy/linalg/einsum.py
@@ -5,7 +5,7 @@ import warnings
 
 import cupy
 from cupy.core import _accelerator
-from cupy import util
+from cupy import _util
 from cupy.cuda import cutensor as cuda_cutensor
 from cupy.linalg.einsum_opt import _greedy_path
 from cupy.linalg.einsum_opt import _optimal_path
@@ -633,7 +633,7 @@ def einsum(*operands, **kwargs):
         if any(len(indices) > 2 for indices in path):
             warnings.warn(
                 'memory efficient einsum is not supported yet',
-                util.PerformanceWarning)
+                _util.PerformanceWarning)
 
     for idx0, idx1 in _iter_path_pairs(path):
         # "reduced" binary einsum

--- a/cupy/linalg/product.py
+++ b/cupy/linalg/product.py
@@ -7,7 +7,7 @@ from cupy import core
 from cupy.core import internal
 
 from cupy.linalg.solve import inv
-from cupy import util
+from cupy import _util
 
 matmul = core.matmul
 
@@ -102,8 +102,8 @@ def cross(a, b, axisa=-1, axisb=-1, axisc=-1, axis=None):
     a = cupy.asarray(a)
     b = cupy.asarray(b)
     # Check axisa and axisb are within bounds
-    axisa = util._normalize_axis_index(axisa, a.ndim)
-    axisb = util._normalize_axis_index(axisb, b.ndim)
+    axisa = _util._normalize_axis_index(axisa, a.ndim)
+    axisb = _util._normalize_axis_index(axisb, b.ndim)
 
     # Move working axis to the end of the shape
     a = cupy.moveaxis(a, axisa, -1)
@@ -118,7 +118,7 @@ def cross(a, b, axisa=-1, axisb=-1, axisc=-1, axis=None):
     if a.shape[-1] == 3 or b.shape[-1] == 3:
         shape += (3,)
         # Check axisc is within bounds
-        axisc = util._normalize_axis_index(axisc, len(shape))
+        axisc = _util._normalize_axis_index(axisc, len(shape))
     dtype = cupy.promote_types(a.dtype, b.dtype)
     cp = cupy.empty(shape, dtype)
 

--- a/cupy/logic/truth.py
+++ b/cupy/logic/truth.py
@@ -1,7 +1,7 @@
 import cupy
 from cupy.core import _routines_logic as _logic
 from cupy.core import _fusion_thread_local
-from cupy import util
+from cupy import _util
 
 
 def all(a, axis=None, out=None, keepdims=False):
@@ -28,7 +28,7 @@ def all(a, axis=None, out=None, keepdims=False):
         return _fusion_thread_local.call_reduction(
             _logic.all, a, axis=axis, out=out)
 
-    util.check_array(a, arg_name='a')
+    _util.check_array(a, arg_name='a')
 
     return a.all(axis=axis, out=out, keepdims=keepdims)
 
@@ -57,7 +57,7 @@ def any(a, axis=None, out=None, keepdims=False):
         return _fusion_thread_local.call_reduction(
             _logic.any, a, axis=axis, out=out)
 
-    util.check_array(a, arg_name='a')
+    _util.check_array(a, arg_name='a')
 
     return a.any(axis=axis, out=out, keepdims=keepdims)
 

--- a/cupy/manipulation/rearrange.py
+++ b/cupy/manipulation/rearrange.py
@@ -3,7 +3,7 @@ import itertools
 import numpy
 
 import cupy
-from cupy import util
+from cupy import _util
 from cupy.core import _reduction
 
 
@@ -31,7 +31,7 @@ def flip(a, axis=None):
     if a_ndim < 1:
         raise numpy.AxisError('Input must be >= 1-d')
 
-    axes = util._normalize_axis_indices(axis, a_ndim)
+    axes = _util._normalize_axis_indices(axis, a_ndim)
     return _flip(a, axes)
 
 

--- a/cupy/math/sumprod.py
+++ b/cupy/math/sumprod.py
@@ -3,7 +3,7 @@ import numpy
 import cupy
 from cupy.core import _routines_math as _math
 from cupy.core import _fusion_thread_local
-from cupy.util import _normalize_axis_index
+from cupy._util import _normalize_axis_index
 
 
 def sum(a, axis=None, dtype=None, out=None, keepdims=False):

--- a/cupy/random/_distributions.py
+++ b/cupy/random/_distributions.py
@@ -1,6 +1,6 @@
 import cupy
 from cupy.random import _generator
-from cupy import util
+from cupy import _util
 
 
 # TODO(beam2d): Implement many distributions
@@ -491,7 +491,7 @@ def multivariate_normal(mean, cov, size=None, check_valid='ignore',
                  <numpy.random.mtrand.RandomState.multivariate_normal>`
 
     """
-    util.experimental('cupy.random.multivariate_normal')
+    _util.experimental('cupy.random.multivariate_normal')
     rs = _generator.get_random_state()
     x = rs.multivariate_normal(mean, cov, size, check_valid, tol, method,
                                dtype)

--- a/cupy/random/_generator.py
+++ b/cupy/random/_generator.py
@@ -16,7 +16,7 @@ from cupy import cuda
 from cupy.cuda import curand
 from cupy.cuda import device
 from cupy.random import _kernels
-from cupy import util
+from cupy import _util
 
 import cupyx
 
@@ -58,7 +58,7 @@ class RandomState(object):
         self.method = method
         self.seed(seed)
 
-    def __del__(self, is_shutting_down=util.is_shutting_down):
+    def __del__(self, is_shutting_down=_util.is_shutting_down):
         # When createGenerator raises an error, _generator is not initialized
         if is_shutting_down():
             return
@@ -340,7 +340,7 @@ class RandomState(object):
             :meth:`numpy.random.RandomState.multivariate_normal
             <numpy.random.mtrand.RandomState.multivariate_normal>`
         """
-        util.experimental('cupy.random.RandomState.multivariate_normal')
+        _util.experimental('cupy.random.RandomState.multivariate_normal')
         mean = cupy.asarray(mean, dtype=dtype)
         cov = cupy.asarray(cov, dtype=dtype)
         if size is None:

--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -84,7 +84,7 @@ cuda_files = [
     'cupy.cuda.stream',
     'cupy.cuda.texture',
     'cupy.lib.polynomial',
-    'cupy.util'
+    'cupy._util'
 ]
 
 if use_hip:

--- a/cupyx/fallback_mode/__init__.py
+++ b/cupyx/fallback_mode/__init__.py
@@ -1,4 +1,4 @@
-from cupy import util as _util
+from cupy import _util
 
 # Attributes and Methods for fallback_mode
 # Auto-execute numpy method when corresponding cupy method is not found

--- a/cupyx/scipy/ndimage/_filters_core.py
+++ b/cupyx/scipy/ndimage/_filters_core.py
@@ -45,7 +45,7 @@ def _check_size_footprint_structure(ndim, size, footprint, structure,
 def _convert_1d_args(ndim, weights, origin, axis):
     if weights.ndim != 1 or weights.size < 1:
         raise RuntimeError('incorrect filter size')
-    axis = cupy.util._normalize_axis_index(axis, ndim)
+    axis = cupy._util._normalize_axis_index(axis, ndim)
     w_shape = [1]*ndim
     w_shape[axis] = weights.size
     weights = weights.reshape(w_shape)

--- a/cupyx/scipy/ndimage/_filters_generic.py
+++ b/cupyx/scipy/ndimage/_filters_generic.py
@@ -1,5 +1,6 @@
 import cupy
 
+from cupy import _util
 from cupyx.scipy.ndimage import _filters_core
 
 
@@ -28,7 +29,7 @@ def _get_sub_kernel(f):
         raise TypeError('bad function type')
 
 
-@cupy.util.memoize(for_each_device=True)
+@_util.memoize(for_each_device=True)
 def _get_generic_filter_red(rk, in_dtype, out_dtype, filter_size, mode,
                             wshape, offsets, cval, int_type):
     """Generic filter implementation based on a reduction kernel."""
@@ -179,7 +180,7 @@ def _get_type_info(param, dtype, types):
     return ctype
 
 
-@cupy.util.memoize(for_each_device=True)
+@_util.memoize(for_each_device=True)
 def _get_generic_filter_raw(rk, filter_size, mode, wshape, offsets, cval,
                             int_type):
     """Generic filter implementation based on a raw kernel."""
@@ -199,7 +200,7 @@ def _get_generic_filter_raw(rk, filter_size, mode, wshape, offsets, cval,
         options=rk.options)
 
 
-@cupy.util.memoize(for_each_device=True)
+@_util.memoize(for_each_device=True)
 def _get_generic_filter1d(rk, length, n_lines, filter_size, origin, mode, cval,
                           in_ctype, out_ctype, int_type):
     """

--- a/cupyx/scipy/ndimage/_interp_kernels.py
+++ b/cupyx/scipy/ndimage/_interp_kernels.py
@@ -312,7 +312,7 @@ def _generate_interp_custom(coord_func, ndim, large_int, yshape, mode, cval,
     return operation, name
 
 
-@cupy.util.memoize(for_each_device=True)
+@cupy._util.memoize(for_each_device=True)
 def _get_map_kernel(ndim, large_int, yshape, mode, cval=0.0, order=1,
                     integer_output=False):
     in_params = 'raw X x, raw W coords'
@@ -331,7 +331,7 @@ def _get_map_kernel(ndim, large_int, yshape, mode, cval=0.0, order=1,
     return cupy.ElementwiseKernel(in_params, out_params, operation, name)
 
 
-@cupy.util.memoize(for_each_device=True)
+@cupy._util.memoize(for_each_device=True)
 def _get_shift_kernel(ndim, large_int, yshape, mode, cval=0.0, order=1,
                       integer_output=False):
     in_params = 'raw X x, raw W shift'
@@ -350,7 +350,7 @@ def _get_shift_kernel(ndim, large_int, yshape, mode, cval=0.0, order=1,
     return cupy.ElementwiseKernel(in_params, out_params, operation, name)
 
 
-@cupy.util.memoize(for_each_device=True)
+@cupy._util.memoize(for_each_device=True)
 def _get_zoom_shift_kernel(ndim, large_int, yshape, mode, cval=0.0, order=1,
                            integer_output=False):
     in_params = 'raw X x, raw W shift, raw W zoom'
@@ -369,7 +369,7 @@ def _get_zoom_shift_kernel(ndim, large_int, yshape, mode, cval=0.0, order=1,
     return cupy.ElementwiseKernel(in_params, out_params, operation, name)
 
 
-@cupy.util.memoize(for_each_device=True)
+@cupy._util.memoize(for_each_device=True)
 def _get_zoom_kernel(ndim, large_int, yshape, mode, cval=0.0, order=1,
                      integer_output=False):
     in_params = 'raw X x, raw W zoom'
@@ -388,7 +388,7 @@ def _get_zoom_kernel(ndim, large_int, yshape, mode, cval=0.0, order=1,
     return cupy.ElementwiseKernel(in_params, out_params, operation, name)
 
 
-@cupy.util.memoize(for_each_device=True)
+@cupy._util.memoize(for_each_device=True)
 def _get_affine_kernel(ndim, large_int, yshape, mode, cval=0.0, order=1,
                        integer_output=False):
     in_params = 'raw X x, raw W mat'

--- a/cupyx/scipy/ndimage/filters.py
+++ b/cupyx/scipy/ndimage/filters.py
@@ -164,7 +164,7 @@ def _correlate_or_convolve(input, weights, output, mode, cval, origin,
     return _filters_core._call_kernel(kernel, input, weights, output)
 
 
-@cupy.util.memoize(for_each_device=True)
+@cupy._util.memoize(for_each_device=True)
 def _get_correlate_kernel(mode, w_shape, int_type, offsets, cval):
     return _filters_core._generate_nd_kernel(
         'correlate',
@@ -414,7 +414,7 @@ def sobel(input, axis=-1, output=None, mode="reflect", cval=0.0):
 
 
 def _prewitt_or_sobel(input, axis, output, mode, cval, weights):
-    axis = cupy.util._normalize_axis_index(axis, input.ndim)
+    axis = cupy._util._normalize_axis_index(axis, input.ndim)
 
     def get(is_diff):
         return cupy.array([-1, 0, 1]) if is_diff else weights
@@ -781,7 +781,7 @@ def _min_or_max_1d(input, size, axis=-1, output=None, mode="reflect", cval=0.0,
                                       weights_dtype=bool)
 
 
-@cupy.util.memoize(for_each_device=True)
+@cupy._util.memoize(for_each_device=True)
 def _get_min_or_max_kernel(mode, w_shape, func, offsets, cval, int_type,
                            has_weights=True, has_structure=False,
                            has_central_value=True):
@@ -963,7 +963,7 @@ __device__ void sort(X *array, int size) {{
 }}'''
 
 
-@cupy.util.memoize()
+@cupy._util.memoize()
 def _get_shell_gap(filter_size):
     gap = 1
     while gap < filter_size:
@@ -971,7 +971,7 @@ def _get_shell_gap(filter_size):
     return gap
 
 
-@cupy.util.memoize(for_each_device=True)
+@cupy._util.memoize(for_each_device=True)
 def _get_rank_kernel(filter_size, rank, mode, w_shape, offsets, cval,
                      int_type):
     s_rank = min(rank, filter_size - rank - 1)
@@ -1136,7 +1136,7 @@ def generic_filter1d(input, function, filter_size, axis=-1, output=None,
         raise TypeError('bad function type')
     if filter_size < 1:
         raise RuntimeError('invalid filter size')
-    axis = cupy.util._normalize_axis_index(axis, input.ndim)
+    axis = cupy._util._normalize_axis_index(axis, input.ndim)
     origin = _util._check_origin(origin, filter_size)
     _util._check_mode(mode)
     output = _util._get_output(output, input)

--- a/cupyx/scipy/ndimage/fourier.py
+++ b/cupyx/scipy/ndimage/fourier.py
@@ -55,7 +55,7 @@ def fourier_gaussian(input, sigma, n=-1, axis=-1, output=None):
     """
     ndim = input.ndim
     output = _get_output_fourier(output, input)
-    axis = cupy.util._normalize_axis_index(axis, ndim)
+    axis = cupy._util._normalize_axis_index(axis, ndim)
     sigmas = _util._fix_sequence_arg(sigma, ndim, 'sigma')
 
     output[...] = input
@@ -107,7 +107,7 @@ def fourier_uniform(input, size, n=-1, axis=-1, output=None):
     """
     ndim = input.ndim
     output = _get_output_fourier(output, input)
-    axis = cupy.util._normalize_axis_index(axis, ndim)
+    axis = cupy._util._normalize_axis_index(axis, ndim)
     sizes = _util._fix_sequence_arg(size, ndim, 'size')
 
     output[...] = input
@@ -158,7 +158,7 @@ def fourier_shift(input, shift, n=-1, axis=-1, output=None):
     """
     ndim = input.ndim
     output = _get_output_fourier(output, input, complex_only=True)
-    axis = cupy.util._normalize_axis_index(axis, ndim)
+    axis = cupy._util._normalize_axis_index(axis, ndim)
     shifts = _util._fix_sequence_arg(shift, ndim, 'shift')
 
     output[...] = input

--- a/cupyx/scipy/ndimage/measurements.py
+++ b/cupyx/scipy/ndimage/measurements.py
@@ -4,7 +4,7 @@ import numpy
 
 import cupy
 from cupy import core
-from cupy import util
+from cupy import _util
 
 
 def label(input, structure=None, output=None):
@@ -319,7 +319,7 @@ def variance(input, labels=None, index=None):
             'Using the slower implmentation as '
             'cupyx.scipy.ndimage.sum supports int32, float16, '
             'float32, float64, uint32, uint64 as data types'
-            'for the fast implmentation', util.PerformanceWarning)
+            'for the fast implmentation', _util.PerformanceWarning)
         use_kern = True
 
     def calc_var_with_intermediate_float(input):
@@ -394,7 +394,7 @@ def sum(input, labels=None, index=None):
             'Using the slower implmentation as '
             'cupyx.scipy.ndimage.sum supports int32, float16, '
             'float32, float64, uint32, uint64 as data types'
-            'for the fast implmentation', util.PerformanceWarning)
+            'for the fast implmentation', _util.PerformanceWarning)
         use_kern = True
 
     if labels is None:
@@ -459,7 +459,7 @@ def mean(input, labels=None, index=None):
             'Using the slower implmentation as '
             'cupyx.scipy.ndimage.mean supports int32, float16, '
             'float32, float64, uint32, uint64 as data types '
-            'for the fast implmentation', util.PerformanceWarning)
+            'for the fast implmentation', _util.PerformanceWarning)
         use_kern = True
 
     def calc_mean_with_intermediate_float(input):

--- a/cupyx/scipy/sparse/csr.py
+++ b/cupyx/scipy/sparse/csr.py
@@ -505,7 +505,7 @@ def multiply_by_dense(sp, dn):
     return csr_matrix((data, indices, indptr), shape=(m, n))
 
 
-@cupy.util.memoize(for_each_device=True)
+@cupy._util.memoize(for_each_device=True)
 def cupy_multiply_by_dense():
     return cupy.ElementwiseKernel(
         '''
@@ -604,7 +604,7 @@ def multiply_by_csr(a, b):
     return csr_matrix((d_data, d_indices, d_indptr), shape=(m, n))
 
 
-@cupy.util.memoize(for_each_device=True)
+@cupy._util.memoize(for_each_device=True)
 def cupy_multiply_by_csr_step1():
     return cupy.ElementwiseKernel(
         '''
@@ -676,7 +676,7 @@ def cupy_multiply_by_csr_step1():
     )
 
 
-@cupy.util.memoize(for_each_device=True)
+@cupy._util.memoize(for_each_device=True)
 def cupy_multiply_by_csr_step2():
     return cupy.ElementwiseKernel(
         'T C_DATA, I C_INDICES, raw I FLAGS',

--- a/cupyx/scipy/sparse/data.py
+++ b/cupyx/scipy/sparse/data.py
@@ -1,5 +1,6 @@
 import cupy
 from cupy.core import internal
+from cupy import _util
 from cupyx.scipy.sparse import base
 from cupyx.scipy.sparse import coo
 from cupyx.scipy.sparse import sputils
@@ -286,7 +287,7 @@ class _minmax_mixin(object):
         if explicit:
             api_name = 'explicit of cupyx.scipy.sparse.{}.max'.format(
                 self.__class__.__name__)
-            cupy.util.experimental(api_name)
+            _util.experimental(api_name)
         return self._min_or_max(axis, out, cupy.max, explicit)
 
     def min(self, axis=None, out=None, *, explicit=False):
@@ -322,7 +323,7 @@ class _minmax_mixin(object):
         if explicit:
             api_name = 'explicit of cupyx.scipy.sparse.{}.min'.format(
                 self.__class__.__name__)
-            cupy.util.experimental(api_name)
+            _util.experimental(api_name)
         return self._min_or_max(axis, out, cupy.min, explicit)
 
     def argmax(self, axis=None, out=None):

--- a/cupyx/time.py
+++ b/cupyx/time.py
@@ -4,7 +4,7 @@ import time
 import numpy
 
 import cupy
-from cupy import util
+from cupy import _util
 
 
 class _PerfCaseResult(object):
@@ -53,7 +53,7 @@ def repeat(
         func, args=(), kwargs={}, n_repeat=10000, *,
         name=None, n_warmup=10, max_duration=math.inf, devices=None):
 
-    util.experimental('cupyx.time.repeat')
+    _util.experimental('cupyx.time.repeat')
     if name is None:
         name = func.__name__
 

--- a/tests/cupy_tests/core_tests/test_ndarray_copy_and_view.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_copy_and_view.py
@@ -5,7 +5,7 @@ import pytest
 
 import cupy
 from cupy import testing
-from cupy import util
+from cupy import _util
 
 
 def astype_without_warning(x, dtype, *args, **kwargs):
@@ -167,7 +167,7 @@ class TestArrayCopyAndView(unittest.TestCase):
         a = testing.shaped_arange((3, 4, 5), xp, dtype)
         return a.diagonal(-1, 2, 0)
 
-    @unittest.skipUnless(util.ENABLE_SLICE_COPY, 'Special copy disabled')
+    @unittest.skipUnless(_util.ENABLE_SLICE_COPY, 'Special copy disabled')
     @testing.for_orders('CF')
     @testing.for_dtypes([numpy.int16, numpy.int64,
                          numpy.float16, numpy.float64])
@@ -178,7 +178,7 @@ class TestArrayCopyAndView(unittest.TestCase):
         b[:] = a
         return b
 
-    @unittest.skipUnless(util.ENABLE_SLICE_COPY, 'Special copy disabled')
+    @unittest.skipUnless(_util.ENABLE_SLICE_COPY, 'Special copy disabled')
     def test_isinstance_numpy_copy_wrong_dtype(self):
         for xp in (numpy, cupy):
             a = numpy.arange(100, dtype=numpy.float64).reshape(10, 10)
@@ -186,7 +186,7 @@ class TestArrayCopyAndView(unittest.TestCase):
             with pytest.raises(ValueError):
                 b[:] = a
 
-    @unittest.skipUnless(util.ENABLE_SLICE_COPY, 'Special copy disabled')
+    @unittest.skipUnless(_util.ENABLE_SLICE_COPY, 'Special copy disabled')
     def test_isinstance_numpy_copy_wrong_shape(self):
         for xp in (numpy, cupy):
             a = numpy.arange(100, dtype=numpy.float64).reshape(10, 10)
@@ -194,7 +194,7 @@ class TestArrayCopyAndView(unittest.TestCase):
             with pytest.raises(ValueError):
                 b[:] = a
 
-    @unittest.skipUnless(util.ENABLE_SLICE_COPY, 'Special copy disabled')
+    @unittest.skipUnless(_util.ENABLE_SLICE_COPY, 'Special copy disabled')
     @testing.numpy_cupy_array_equal()
     def test_isinstance_numpy_copy_not_slice(self, xp):
         a = xp.arange(5, dtype=numpy.float64)
@@ -208,7 +208,7 @@ class TestArrayCopyAndView(unittest.TestCase):
 )
 @testing.gpu
 class TestNumPyArrayCopyView(unittest.TestCase):
-    @unittest.skipUnless(util.ENABLE_SLICE_COPY, 'Special copy disabled')
+    @unittest.skipUnless(_util.ENABLE_SLICE_COPY, 'Special copy disabled')
     @testing.for_orders('CF')
     @testing.for_dtypes([numpy.int16, numpy.int64,
                          numpy.float16, numpy.float64])

--- a/tests/cupy_tests/core_tests/test_raw.py
+++ b/tests/cupy_tests/core_tests/test_raw.py
@@ -10,7 +10,7 @@ import pytest
 
 import cupy
 from cupy import testing
-from cupy import util
+from cupy import _util
 from cupy.core import _accelerator
 from cupy.cuda import compiler
 from cupy.cuda import memory
@@ -388,7 +388,7 @@ class TestRaw(unittest.TestCase):
 
     def setUp(self):
         if hasattr(self, 'clean_up'):
-            util.clear_memo()
+            _util.clear_memo()
         self.dev = cupy.cuda.runtime.getDevice()
         assert self.dev != 1
 

--- a/tests/cupy_tests/cuda_tests/test_compiler.py
+++ b/tests/cupy_tests/cuda_tests/test_compiler.py
@@ -14,13 +14,13 @@ def cuda_version():
 @testing.gpu
 class TestNvrtcArch(unittest.TestCase):
     def setUp(self):
-        cupy.util.clear_memo()  # _get_arch result is cached
+        cupy.clear_memo()  # _get_arch result is cached
 
     def _check_get_arch(self, device_cc, expected_arch):
         with mock.patch('cupy.cuda.device.Device') as device_class:
             device_class.return_value.compute_capability = device_cc
             assert compiler._get_arch() == expected_arch
-        cupy.util.clear_memo()  # _get_arch result is cached
+        cupy.clear_memo()  # _get_arch result is cached
 
     @unittest.skipUnless(9000 <= cuda_version(), 'Requires CUDA 9.x or later')
     def test_get_arch_cuda9(self):

--- a/tests/cupyx_tests/fallback_mode_tests/test_fallback.py
+++ b/tests/cupyx_tests/fallback_mode_tests/test_fallback.py
@@ -117,10 +117,10 @@ def enable_slice_copy(func):
     And then restores it to previous state.
     """
     def decorator(*args, **kwargs):
-        old = cupy.util.ENABLE_SLICE_COPY
-        cupy.util.ENABLE_SLICE_COPY = True
+        old = cupy._util.ENABLE_SLICE_COPY
+        cupy._util.ENABLE_SLICE_COPY = True
         func(*args, **kwargs)
-        cupy.util.ENABLE_SLICE_COPY = old
+        cupy._util.ENABLE_SLICE_COPY = old
 
     return decorator
 


### PR DESCRIPTION
Backport of #3779