### PR TITLE
Use LU-decomposition based solver in cupy.linalg.solver

### DIFF
--- a/cupy/cusolver.py
+++ b/cupy/cusolver.py
@@ -480,13 +480,13 @@ def gesv(a, b):
             The matrix with dimension ``(M)`` or ``(M, K)``.
     """
     if a.ndim != 2:
-        raise ValueError('a.ndim must be 2 (actual:{})'.format(a.ndim))
+        raise ValueError('a.ndim must be 2 (actual: {})'.format(a.ndim))
     if b.ndim not in (1, 2):
-        raise ValueError('b.ndim must be 1 or 2 (actual:{})'.format(b.ndim))
+        raise ValueError('b.ndim must be 1 or 2 (actual: {})'.format(b.ndim))
     if a.shape[0] != a.shape[1]:
         raise ValueError('a must be a square matrix.')
     if a.shape[0] != b.shape[0]:
-        raise ValueError('shape mismatch (a:{}, b:{}).'.
+        raise ValueError('shape mismatch (a: {}, b: {}).'.
                          format(a.shape, b.shape))
 
     dtype = numpy.promote_types(a.dtype.char, 'f')

--- a/cupy/cusolver.py
+++ b/cupy/cusolver.py
@@ -13,7 +13,6 @@ _available_cuda_version = {
     'potrfBatched': (9010, None),
     'potrsBatched': (9010, None),
     'syevj': (9000, None),
-    'gesv': (None, None),
 }
 
 
@@ -480,9 +479,6 @@ def gesv(a, b):
         cupy.ndarray:
             The matrix with dimension ``(M)`` or ``(M, K)``.
     """
-    if not check_availability('gesv'):
-        raise RuntimeError('gesv is not available.')
-
     if a.ndim != 2:
         raise ValueError('a.ndim must be 2 (actual:{})'.format(a.ndim))
     if b.ndim not in (1, 2):

--- a/cupy/cusolver.py
+++ b/cupy/cusolver.py
@@ -524,8 +524,14 @@ def gesv(a, b):
     dinfo = cupy.empty(1, dtype=numpy.int32)
     lwork = helper(handle, n, n, a.data.ptr, n)
     dwork = cupy.empty(lwork, dtype=a.dtype)
+    # LU factrization (A = L * U)
     getrf(handle, n, n, a.data.ptr, n, dwork.data.ptr, dipiv.data.ptr,
           dinfo.data.ptr)
+    cupy.linalg.util._check_cusolver_dev_info_if_synchronization_allowed(
+        getrf, dinfo)
+    # Solves Ax = b
     getrs(handle, cublas.CUBLAS_OP_N, n, nrhs, a.data.ptr, n,
           dipiv.data.ptr, b.data.ptr, n, dinfo.data.ptr)
+    cupy.linalg.util._check_cusolver_dev_info_if_synchronization_allowed(
+        getrs, dinfo)
     return b

--- a/cupy/linalg/solve.py
+++ b/cupy/linalg/solve.py
@@ -34,10 +34,6 @@ def solve(a, b):
 
     .. seealso:: :func:`numpy.linalg.solve`
     """
-    # NOTE: Since cusolver in CUDA 8.0 does not support gesv,
-    #       we manually solve a linear system with QR decomposition.
-    #       For details, please see the following:
-    #       https://docs.nvidia.com/cuda/cusolver/index.html#qr_examples
     util._assert_cupy_array(a, b)
     util._assert_nd_squareness(a)
 
@@ -53,19 +49,16 @@ def solve(a, b):
     else:
         dtype = numpy.promote_types(a.dtype.char, 'f')
 
-    cublas_handle = device.get_cublas_handle()
-    cusolver_handle = device.get_cusolver_handle()
-
     a = a.astype(dtype)
     b = b.astype(dtype)
     if a.ndim == 2:
-        return _solve(a, b, cublas_handle, cusolver_handle)
+        return cupy.cusolver.gesv(a, b)
 
     x = cupy.empty_like(b)
     shape = a.shape[:-2]
     for i in range(numpy.prod(shape)):
         index = numpy.unravel_index(i, shape)
-        x[index] = _solve(a[index], b[index], cublas_handle, cusolver_handle)
+        x[index] = cupy.cusolver.gesv(a[index], b[index])
     return x
 
 

--- a/tests/cupy_tests/test_cusolver.py
+++ b/tests/cupy_tests/test_cusolver.py
@@ -177,3 +177,56 @@ class TestSyevj(unittest.TestCase):
 
         self.assertEqual(v.shape, a.shape)
         self.assertEqual(w.shape, a.shape[:-1])
+
+
+@testing.parameterize(*testing.product({
+    'dtype': ['float32', 'float64', 'complex64', 'complex128'],
+    'n': [10, 40, 160],
+    'nrhs': [None, 1, 10],
+}))
+@attr.gpu
+class TestGesv(unittest.TestCase):
+    _tol = {'f': 1e-5, 'd': 1e-12}
+
+    def _make_array(self, shape, alpha, beta):
+        a = testing.shaped_random(shape, cupy, dtype=self.r_dtype,
+                                  scale=alpha) + beta
+        return a
+
+    def _make_matrix(self, shape, alpha, beta):
+        a = self._make_array(shape, alpha, beta)
+        if self.dtype.char in 'FD':
+            a = a + 1j * self._make_array(shape, alpha, beta)
+        return a
+
+    def setUp(self):
+        self.dtype = numpy.dtype(self.dtype)
+        if self.dtype.char in 'fF':
+            self.r_dtype = numpy.float32
+        else:
+            self.r_dtype = numpy.float64
+        n = self.n
+        nrhs = 1 if self.nrhs is None else self.nrhs
+        # Diagonally dominant matrix is used as it is stable
+        alpha = 2.0 / n
+        a = self._make_matrix((n, n), alpha, -alpha / 2)
+        diag = cupy.diag(cupy.ones((n,), dtype=self.r_dtype))
+        a[diag > 0] = 0
+        a += diag
+        x = self._make_matrix((n, nrhs), 0.2, 0.9)
+        b = cupy.matmul(a, x)
+        b_shape = [n]
+        if self.nrhs is not None:
+            b_shape.append(nrhs)
+        self.a = a
+        self.b = b.reshape(b_shape)
+        self.x_ref = x.reshape(b_shape)
+        if self.r_dtype == numpy.float32:
+            self.tol = self._tol['f']
+        elif self.r_dtype == numpy.float64:
+            self.tol = self._tol['d']
+
+    def test_gesv(self):
+        x = cusolver.gesv(self.a, self.b)
+        cupy.testing.assert_allclose(x, self.x_ref,
+                                     rtol=self.tol, atol=self.tol)

--- a/tests/cupy_tests/test_cusolver.py
+++ b/tests/cupy_tests/test_cusolver.py
@@ -180,9 +180,9 @@ class TestSyevj(unittest.TestCase):
 
 
 @testing.parameterize(*testing.product({
-    'dtype': ['float32', 'float64', 'complex64', 'complex128'],
-    'n': [10, 40, 160],
-    'nrhs': [None, 1, 10],
+    'dtype': [numpy.float32, numpy.float64, numpy.complex64, numpy.complex128],
+    'n': [3],
+    'nrhs': [None, 1, 4],
 }))
 @attr.gpu
 class TestGesv(unittest.TestCase):


### PR DESCRIPTION
This PR changes the solver used in `cupy.linalg.solver` to an LU decomposition based solver, so-called **gesv**.

As you know, `numpy.linalg.solve` uses **gesv** as its solver, while `cupy.linalg.solve` uses a QR decomposition based solver. There must have been some reason for this, but I think it is better to use **gesv** or equivalent solver in `cupy.linalg.solve` as well if you want to be compatible with numpy. In fact, **gesv** is a combination of **getrf** and **getrs**, and cuSOLVER supports them. This PR uses them to implement a **gesv**-equivalent routine, `cupy.cusolver.gesv`, and calls it from `cupy.linalg.solve`.