### PR TITLE
Add remaining greyscale morphology operations to `cupyx.scipy.ndimage`

### DIFF
--- a/cupyx/scipy/ndimage/__init__.py
+++ b/cupyx/scipy/ndimage/__init__.py
@@ -43,3 +43,7 @@ from cupyx.scipy.ndimage.morphology import grey_erosion  # NOQA
 from cupyx.scipy.ndimage.morphology import grey_dilation  # NOQA
 from cupyx.scipy.ndimage.morphology import grey_closing  # NOQA
 from cupyx.scipy.ndimage.morphology import grey_opening  # NOQA
+from cupyx.scipy.ndimage.morphology import morphological_gradient  # NOQA
+from cupyx.scipy.ndimage.morphology import morphological_laplace  # NOQA
+from cupyx.scipy.ndimage.morphology import white_tophat  # NOQA
+from cupyx.scipy.ndimage.morphology import black_tophat  # NOQA

--- a/cupyx/scipy/ndimage/morphology.py
+++ b/cupyx/scipy/ndimage/morphology.py
@@ -209,14 +209,14 @@ def morphological_gradient(
     Args:
         input (cupy.ndarray): The input array.
         size (tuple of ints): Shape of a flat and full structuring element used
-            for the morphological gradient. Optional if `footprint` or
-            `structure` is provided.
+            for the morphological gradient. Optional if ``footprint`` or
+            ``structure`` is provided.
         footprint (array of ints): Positions of non-infinite elements of a flat
             structuring element used for morphological gradient. Non-zero
             values give the set of neighbors of the center over which opening
             is chosen.
         structure (array of ints): Structuring element used for the
-            morphological gradient. `structure` may be a non-flat
+            morphological gradient. ``structure`` may be a non-flat
             structuring element.
         output (cupy.ndarray, dtype or None): The array in which to place the
             output.
@@ -265,14 +265,14 @@ def morphological_laplace(
     Args:
         input (cupy.ndarray): The input array.
         size (tuple of ints): Shape of a flat and full structuring element used
-            for the morphological laplace. Optional if `footprint` or
-            `structure` is provided.
+            for the morphological laplace. Optional if ``footprint`` or
+            ``structure`` is provided.
         footprint (array of ints): Positions of non-infinite elements of a flat
             structuring element used for morphological laplace. Non-zero
             values give the set of neighbors of the center over which opening
             is chosen.
         structure (array of ints): Structuring element used for the
-            morphological laplace. `structure` may be a non-flat
+            morphological laplace. ``structure`` may be a non-flat
             structuring element.
         output (cupy.ndarray, dtype or None): The array in which to place the
             output.
@@ -327,14 +327,14 @@ def white_tophat(
     Args:
         input (cupy.ndarray): The input array.
         size (tuple of ints): Shape of a flat and full structuring element used
-            for the white tophat. Optional if `footprint` or `structure` is
+            for the white tophat. Optional if ``footprint`` or ``structure`` is
             provided.
         footprint (array of ints): Positions of non-infinite elements of a flat
             structuring element used for the white tophat. Non-zero values
             give the set of neighbors of the center over which opening is
             chosen.
         structure (array of ints): Structuring element used for the white
-            tophat. `structure` may be a non-flat structuring element.
+            tophat. ``structure`` may be a non-flat structuring element.
         output (cupy.ndarray, dtype or None): The array in which to place the
             output.
         mode (str): The array borders are handled according to the given mode
@@ -348,7 +348,7 @@ def white_tophat(
             ``(0,)*input.ndim``.
 
     Returns:
-        cupy.ndarray: Result of the filter of `input` with `structure`.
+        cupy.ndarray: Result of the filter of ``input`` with ``structure``.
 
     .. seealso:: :func:`scipy.ndimage.white_tophat`
     """
@@ -385,14 +385,14 @@ def black_tophat(
     Args:
         input (cupy.ndarray): The input array.
         size (tuple of ints): Shape of a flat and full structuring element used
-            for the black tophat. Optional if `footprint` or `structure` is
+            for the black tophat. Optional if ``footprint`` or ``structure`` is
             provided.
         footprint (array of ints): Positions of non-infinite elements of a flat
             structuring element used for the black tophat. Non-zero values
             give the set of neighbors of the center over which opening is
             chosen.
         structure (array of ints): Structuring element used for the black
-            tophat. `structure` may be a non-flat structuring element.
+            tophat. ``structure`` may be a non-flat structuring element.
         output (cupy.ndarray, dtype or None): The array in which to place the
             output.
         mode (str): The array borders are handled according to the given mode
@@ -406,7 +406,7 @@ def black_tophat(
             ``(0,)*input.ndim``.
 
     Returns:
-        cupy.ndarry : Result of the filter of `input` with `structure`.
+        cupy.ndarry : Result of the filter of ``input`` with ``structure``.
 
     .. seealso:: :func:`scipy.ndimage.black_tophat`
     """

--- a/cupyx/scipy/ndimage/morphology.py
+++ b/cupyx/scipy/ndimage/morphology.py
@@ -141,7 +141,7 @@ def grey_closing(input, size=None, footprint=None, structure=None,
     .. seealso:: :func:`scipy.ndimage.grey_closing`
     """
     if (size is not None) and (footprint is not None):
-        warnings.warn("ignoring size because footprint is set", UserWarning,
+        warnings.warn('ignoring size because footprint is set', UserWarning,
                       stacklevel=2)
     tmp = grey_dilation(input, size, footprint, structure, None, mode, cval,
                         origin)
@@ -182,7 +182,7 @@ def grey_opening(input, size=None, footprint=None, structure=None,
     .. seealso:: :func:`scipy.ndimage.grey_opening`
     """
     if (size is not None) and (footprint is not None):
-        warnings.warn("ignoring size because footprint is set", UserWarning,
+        warnings.warn('ignoring size because footprint is set', UserWarning,
                       stacklevel=2)
     tmp = grey_erosion(input, size, footprint, structure, None, mode, cval,
                        origin)
@@ -196,7 +196,7 @@ def morphological_gradient(
     footprint=None,
     structure=None,
     output=None,
-    mode="reflect",
+    mode='reflect',
     cval=0.0,
     origin=0,
 ):
@@ -255,7 +255,7 @@ def morphological_laplace(
     footprint=None,
     structure=None,
     output=None,
-    mode="reflect",
+    mode='reflect',
     cval=0.0,
     origin=0,
 ):
@@ -317,7 +317,7 @@ def white_tophat(
     footprint=None,
     structure=None,
     output=None,
-    mode="reflect",
+    mode='reflect',
     cval=0.0,
     origin=0,
 ):
@@ -354,7 +354,7 @@ def white_tophat(
     """
     if (size is not None) and (footprint is not None):
         warnings.warn(
-            "ignoring size because footprint is set", UserWarning, stacklevel=2
+            'ignoring size because footprint is set', UserWarning, stacklevel=2
         )
     tmp = grey_erosion(
         input, size, footprint, structure, None, mode, cval, origin
@@ -375,7 +375,7 @@ def black_tophat(
     footprint=None,
     structure=None,
     output=None,
-    mode="reflect",
+    mode='reflect',
     cval=0.0,
     origin=0,
 ):
@@ -412,7 +412,7 @@ def black_tophat(
     """
     if (size is not None) and (footprint is not None):
         warnings.warn(
-            "ignoring size because footprint is set", UserWarning, stacklevel=2
+            'ignoring size because footprint is set', UserWarning, stacklevel=2
         )
     tmp = grey_dilation(
         input, size, footprint, structure, None, mode, cval, origin

--- a/cupyx/scipy/ndimage/morphology.py
+++ b/cupyx/scipy/ndimage/morphology.py
@@ -188,3 +188,240 @@ def grey_opening(input, size=None, footprint=None, structure=None,
                        origin)
     return grey_dilation(tmp, size, footprint, structure, output, mode, cval,
                          origin)
+
+
+def morphological_gradient(
+    input,
+    size=None,
+    footprint=None,
+    structure=None,
+    output=None,
+    mode="reflect",
+    cval=0.0,
+    origin=0,
+):
+    """
+    Multidimensional morphological gradient.
+
+    The morphological gradient is calculated as the difference between a
+    dilation and an erosion of the input with a given structuring element.
+
+    Args:
+        input (cupy.ndarray): The input array.
+        size (tuple of ints): Shape of a flat and full structuring element used
+            for the morphological gradient. Optional if `footprint` or
+            `structure` is provided.
+        footprint (array of ints): Positions of non-infinite elements of a flat
+            structuring element used for morphological gradient. Non-zero
+            values give the set of neighbors of the center over which opening
+            is chosen.
+        structure (array of ints): Structuring element used for the
+            morphological gradient. `structure` may be a non-flat
+            structuring element.
+        output (cupy.ndarray, dtype or None): The array in which to place the
+            output.
+        mode (str): The array borders are handled according to the given mode
+            (``'reflect'``, ``'constant'``, ``'nearest'``, ``'mirror'``,
+            ``'wrap'``). Default is ``'reflect'``.
+        cval (scalar): Value to fill past edges of input if mode is
+            ``constant``. Default is ``0.0``.
+        origin (scalar or tuple of scalar): The origin parameter controls the
+            placement of the filter, relative to the center of the current
+            element of the input. Default of 0 is equivalent to
+            ``(0,)*input.ndim``.
+
+    Returns:
+        cupy.ndarray: The morphological gradient of the input.
+
+    .. seealso:: :func:`scipy.ndimage.morphological_gradient`
+    """
+    tmp = grey_dilation(
+        input, size, footprint, structure, None, mode, cval, origin
+    )
+    if isinstance(output, cupy.ndarray):
+        grey_erosion(
+            input, size, footprint, structure, output, mode, cval, origin
+        )
+        return cupy.subtract(tmp, output, output)
+    else:
+        return tmp - grey_erosion(
+            input, size, footprint, structure, None, mode, cval, origin
+        )
+
+
+def morphological_laplace(
+    input,
+    size=None,
+    footprint=None,
+    structure=None,
+    output=None,
+    mode="reflect",
+    cval=0.0,
+    origin=0,
+):
+    """
+    Multidimensional morphological laplace.
+
+    Args:
+        input (cupy.ndarray): The input array.
+        size (tuple of ints): Shape of a flat and full structuring element used
+            for the morphological laplace. Optional if `footprint` or
+            `structure` is provided.
+        footprint (array of ints): Positions of non-infinite elements of a flat
+            structuring element used for morphological laplace. Non-zero
+            values give the set of neighbors of the center over which opening
+            is chosen.
+        structure (array of ints): Structuring element used for the
+            morphological laplace. `structure` may be a non-flat
+            structuring element.
+        output (cupy.ndarray, dtype or None): The array in which to place the
+            output.
+        mode (str): The array borders are handled according to the given mode
+            (``'reflect'``, ``'constant'``, ``'nearest'``, ``'mirror'``,
+            ``'wrap'``). Default is ``'reflect'``.
+        cval (scalar): Value to fill past edges of input if mode is
+            ``constant``. Default is ``0.0``.
+        origin (scalar or tuple of scalar): The origin parameter controls the
+            placement of the filter, relative to the center of the current
+            element of the input. Default of 0 is equivalent to
+            ``(0,)*input.ndim``.
+
+    Returns:
+        cupy.ndarray: The morphological laplace of the input.
+
+    .. seealso:: :func:`scipy.ndimage.morphological_laplace`
+    """
+    tmp1 = grey_dilation(
+        input, size, footprint, structure, None, mode, cval, origin
+    )
+    if isinstance(output, cupy.ndarray):
+        grey_erosion(
+            input, size, footprint, structure, output, mode, cval, origin
+        )
+        cupy.add(tmp1, output, output)
+        cupy.subtract(output, input, output)
+        return cupy.subtract(output, input, output)
+    else:
+        tmp2 = grey_erosion(
+            input, size, footprint, structure, None, mode, cval, origin
+        )
+        cupy.add(tmp1, tmp2, tmp2)
+        cupy.subtract(tmp2, input, tmp2)
+        cupy.subtract(tmp2, input, tmp2)
+        return tmp2
+
+
+def white_tophat(
+    input,
+    size=None,
+    footprint=None,
+    structure=None,
+    output=None,
+    mode="reflect",
+    cval=0.0,
+    origin=0,
+):
+    """
+    Multidimensional white tophat filter.
+
+    Args:
+        input (cupy.ndarray): The input array.
+        size (tuple of ints): Shape of a flat and full structuring element used
+            for the white tophat. Optional if `footprint` or `structure` is
+            provided.
+        footprint (array of ints): Positions of non-infinite elements of a flat
+            structuring element used for the white tophat. Non-zero values
+            give the set of neighbors of the center over which opening is
+            chosen.
+        structure (array of ints): Structuring element used for the white
+            tophat. `structure` may be a non-flat structuring element.
+        output (cupy.ndarray, dtype or None): The array in which to place the
+            output.
+        mode (str): The array borders are handled according to the given mode
+            (``'reflect'``, ``'constant'``, ``'nearest'``, ``'mirror'``,
+            ``'wrap'``). Default is ``'reflect'``.
+        cval (scalar): Value to fill past edges of input if mode is
+            ``constant``. Default is ``0.0``.
+        origin (scalar or tuple of scalar): The origin parameter controls the
+            placement of the filter, relative to the center of the current
+            element of the input. Default of 0 is equivalent to
+            ``(0,)*input.ndim``.
+
+    Returns:
+        cupy.ndarray: Result of the filter of `input` with `structure`.
+
+    .. seealso:: :func:`scipy.ndimage.white_tophat`
+    """
+    if (size is not None) and (footprint is not None):
+        warnings.warn(
+            "ignoring size because footprint is set", UserWarning, stacklevel=2
+        )
+    tmp = grey_erosion(
+        input, size, footprint, structure, None, mode, cval, origin
+    )
+    tmp = grey_dilation(
+        tmp, size, footprint, structure, output, mode, cval, origin
+    )
+    if input.dtype == numpy.bool_ and tmp.dtype == numpy.bool_:
+        cupy.bitwise_xor(input, tmp, out=tmp)
+    else:
+        cupy.subtract(input, tmp, out=tmp)
+    return tmp
+
+
+def black_tophat(
+    input,
+    size=None,
+    footprint=None,
+    structure=None,
+    output=None,
+    mode="reflect",
+    cval=0.0,
+    origin=0,
+):
+    """
+    Multidimensional black tophat filter.
+
+    Args:
+        input (cupy.ndarray): The input array.
+        size (tuple of ints): Shape of a flat and full structuring element used
+            for the black tophat. Optional if `footprint` or `structure` is
+            provided.
+        footprint (array of ints): Positions of non-infinite elements of a flat
+            structuring element used for the black tophat. Non-zero values
+            give the set of neighbors of the center over which opening is
+            chosen.
+        structure (array of ints): Structuring element used for the black
+            tophat. `structure` may be a non-flat structuring element.
+        output (cupy.ndarray, dtype or None): The array in which to place the
+            output.
+        mode (str): The array borders are handled according to the given mode
+            (``'reflect'``, ``'constant'``, ``'nearest'``, ``'mirror'``,
+            ``'wrap'``). Default is ``'reflect'``.
+        cval (scalar): Value to fill past edges of input if mode is
+            ``constant``. Default is ``0.0``.
+        origin (scalar or tuple of scalar): The origin parameter controls the
+            placement of the filter, relative to the center of the current
+            element of the input. Default of 0 is equivalent to
+            ``(0,)*input.ndim``.
+
+    Returns:
+        cupy.ndarry : Result of the filter of `input` with `structure`.
+
+    .. seealso:: :func:`scipy.ndimage.black_tophat`
+    """
+    if (size is not None) and (footprint is not None):
+        warnings.warn(
+            "ignoring size because footprint is set", UserWarning, stacklevel=2
+        )
+    tmp = grey_dilation(
+        input, size, footprint, structure, None, mode, cval, origin
+    )
+    tmp = grey_erosion(
+        tmp, size, footprint, structure, output, mode, cval, origin
+    )
+    if input.dtype == numpy.bool_ and tmp.dtype == numpy.bool_:
+        cupy.bitwise_xor(tmp, input, out=tmp)
+    else:
+        cupy.subtract(tmp, input, out=tmp)
+    return tmp

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_morphology.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_morphology.py
@@ -78,9 +78,9 @@ class TestGreyErosionAndDilation(unittest.TestCase):
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
     def test_grey_erosion_and_dilation(self, xp, scp):
         if self.mode == 'mirror' and 1 in self.shape:
-            raise unittest.SkipTest("not testable against scipy")
+            raise unittest.SkipTest('not testable against scipy')
         if self.x_dtype == self.output:
-            raise unittest.SkipTest("redundant")
+            raise unittest.SkipTest('redundant')
         x = testing.shaped_random(self.shape, xp, self.x_dtype)
         return self._filter(xp, scp, x)
 
@@ -180,7 +180,7 @@ class MorphologicalGradientAndLaplace(unittest.TestCase):
         x[4, 4] = 2
         x[2, 3] = 3
         if self.x_dtype == self.output:
-            raise unittest.SkipTest("redundant")
+            raise unittest.SkipTest('redundant')
         return self._filter(xp, scp, x)
 
 
@@ -240,5 +240,5 @@ class WhiteTophatAndBlackTopHat(unittest.TestCase):
     def test_white_tophat_and_black_tophat(self, xp, scp):
         x = testing.shaped_random(self.shape, xp, self.x_dtype)
         if self.x_dtype == self.output:
-            raise unittest.SkipTest("redundant")
+            raise unittest.SkipTest('redundant')
         return self._filter(xp, scp, x)

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_morphology.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_morphology.py
@@ -121,3 +121,124 @@ class TestGreyClosingAndOpening(unittest.TestCase):
     def test_grey_closing_and_opening(self, xp, scp):
         x = testing.shaped_random(self.shape, xp, self.x_dtype)
         return self._filter(xp, scp, x)
+
+
+@testing.parameterize(*(
+    testing.product({
+        'x_dtype': [numpy.int32],
+        'origin': [-1, 0, 1],
+        'filter': ['morphological_gradient', 'morphological_laplace'],
+        'mode': ['reflect', 'constant'],
+        'output': [None],
+        'size': [(3, 3), (4, 3)],
+        'footprint': [None, 'random'],
+        'structure': [None, 'random']}
+    ) + testing.product({
+        'x_dtype': [numpy.int32, numpy.float64],
+        'origin': [0],
+        'filter': ['morphological_gradient', 'morphological_laplace'],
+        'mode': ['reflect', 'constant', 'nearest', 'mirror', 'wrap'],
+        'output': [None, numpy.float32, 'zeros'],
+        'size': [3],
+        'footprint': [None, 'random'],
+        'structure': [None, 'random']}
+    ))
+)
+@testing.gpu
+@testing.with_requires('scipy')
+class MorphologicalGradientAndLaplace(unittest.TestCase):
+
+    def _filter(self, xp, scp, x):
+        filter = getattr(scp.ndimage, self.filter)
+        if xp.isscalar(self.size):
+            shape = (self.size,) * x.ndim
+        else:
+            shape = tuple(self.size)
+        if self.footprint is None:
+            footprint = None
+        else:
+            r = testing.shaped_random(shape, xp, scale=1)
+            footprint = xp.where(r < .5, 1, 0)
+            if not footprint.any():
+                footprint = xp.ones(shape)
+        if self.structure is None:
+            structure = None
+        else:
+            structure = testing.shaped_random(shape, xp, dtype=xp.int32)
+        if self.output == 'zeros':
+            output = xp.zeros_like(x)
+        else:
+            output = self.output
+        return filter(x, self.size, footprint, structure,
+                      output=output, mode=self.mode, cval=0.0,
+                      origin=self.origin)
+
+    @testing.numpy_cupy_array_equal(scipy_name='scp')
+    def test_morphological_gradient_and_laplace(self, xp, scp):
+        x = xp.zeros((7, 7), dtype=self.x_dtype)
+        x[2:5, 2:5] = 1
+        x[4, 4] = 2
+        x[2, 3] = 3
+        if self.x_dtype == self.output:
+            raise unittest.SkipTest("redundant")
+        return self._filter(xp, scp, x)
+
+
+@testing.parameterize(*(
+    testing.product({
+        'x_dtype': [numpy.int32],
+        'shape': [(5, 7)],
+        'origin': [-1, 0, 1],
+        'filter': ['white_tophat', 'black_tophat'],
+        'mode': ['reflect', 'constant'],
+        'output': [None],
+        'size': [(3, 3), (4, 3)],
+        'footprint': [None, 'random'],
+        'structure': [None, 'random']}
+    ) + testing.product({
+        'x_dtype': [numpy.int32, numpy.float64],
+        'shape': [(6, 8)],
+        'origin': [0],
+        'filter': ['white_tophat', 'black_tophat'],
+        'mode': ['reflect', 'constant', 'nearest', 'mirror', 'wrap'],
+        'output': [None, numpy.float32, 'zeros'],
+        'size': [3],
+        'footprint': [None, 'random'],
+        'structure': [None, 'random']}
+    ))
+)
+@testing.gpu
+@testing.with_requires('scipy')
+class WhiteTophatAndBlackTopHat(unittest.TestCase):
+
+    def _filter(self, xp, scp, x):
+        filter = getattr(scp.ndimage, self.filter)
+        if xp.isscalar(self.size):
+            shape = (self.size,) * x.ndim
+        else:
+            shape = tuple(self.size)
+        if self.footprint is None:
+            footprint = None
+        else:
+            r = testing.shaped_random(shape, xp, scale=1)
+            footprint = xp.where(r < .5, 1, 0)
+            if not footprint.any():
+                footprint = xp.ones(shape)
+        if self.structure is None:
+            structure = None
+        else:
+            structure = testing.shaped_random(shape, xp, dtype=xp.int32)
+        if self.output == 'zeros':
+            output = xp.zeros_like(x)
+        else:
+            output = self.output
+        return filter(x, self.size, footprint, structure,
+                      output=output, mode=self.mode, cval=0.0,
+                      origin=self.origin)
+
+    @testing.numpy_cupy_array_equal(scipy_name='scp')
+    def test_white_tophat_and_black_tophat(self, xp, scp):
+        x = testing.shaped_random(self.shape, xp, self.x_dtype)
+        if self.x_dtype == self.output:
+            raise unittest.SkipTest("redundant")
+        return self._filter(xp, scp, x)


### PR DESCRIPTION
This PR adds the four remaining greyscale morphology functions: `morphological_gradient`, `morphological_laplace`, `white_tophat`, `black_tophat`. In combination with gh-3907, this completes CuPy's coverage of `scipy.ndimage.morphology` module with the exception of `distance_transform_*`.

The implementations here are simple as they just rely on the existing `grey_erosion` and `grey_dilation` functions.
