### PR TITLE
Specify dtype of indptr and indices as int32 explicitly

### DIFF
--- a/cupyx/scipy/sparse/_index.py
+++ b/cupyx/scipy/sparse/_index.py
@@ -64,7 +64,7 @@ def _get_csr_submatrix_minor_axis(Ap, Aj, Ax, start, stop):
 
     """
     mask = (start <= Aj) & (Aj < stop)
-    mask_sum = cupy.empty(Aj.size + 1, dtype=Aj.dtype)
+    mask_sum = cupy.empty(Aj.size + 1, dtype=numpy.int32)
     mask_sum[0] = 0
     mask_sum[1:] = mask
     cupy.cumsum(mask_sum, out=mask_sum)
@@ -76,7 +76,8 @@ def _get_csr_submatrix_minor_axis(Ap, Aj, Ax, start, stop):
 
 
 _csr_row_index_ker = core.ElementwiseKernel(
-    'I out_rows, raw I rows, raw I Ap, raw I Aj, raw T Ax, raw I Bp',
+    'int32 out_rows, raw I rows, '
+    'raw int32 Ap, raw int32 Aj, raw T Ax, raw int32 Bp',
     'I Bj, T Bx',
     '''
     const I row = rows[out_rows];
@@ -107,12 +108,12 @@ def _csr_row_index(rows, Ap, Aj, Ax):
 
     """
     row_nnz = cupy.diff(Ap)
-    Bp = cupy.empty(rows.size + 1, dtype=Ap.dtype)
+    Bp = cupy.empty(rows.size + 1, dtype=numpy.int32)
     Bp[0] = 0
     cupy.cumsum(row_nnz[rows], out=Bp[1:])
     nnz = int(Bp[-1])
 
-    out_rows = cupy.empty(nnz, dtype=rows.dtype)
+    out_rows = cupy.empty(nnz, dtype=numpy.int32)
 
     # Build a COO row array from output CSR indptr.
     # Calling backend cusparse API directly to avoid

--- a/cupyx/scipy/sparse/compressed.py
+++ b/cupyx/scipy/sparse/compressed.py
@@ -500,11 +500,10 @@ class _compressed_sparse_matrix(sparse_data._data_matrix,
 
     def _get_arrayXarray(self, row, col):
         # inner indexing
-        idx_dtype = self.indices.dtype
         M, N = self._swap(*self.shape)
         major, minor = self._swap(row, col)
-        major = cupy.asarray(major, dtype=idx_dtype)
-        minor = cupy.asarray(minor, dtype=idx_dtype)
+        major = cupy.asarray(major, dtype=numpy.int32)
+        minor = cupy.asarray(minor, dtype=numpy.int32)
 
         val = _index._csr_sample_values(
             M, N, self.indptr, self.indices, self.data,
@@ -650,7 +649,7 @@ class _compressed_sparse_matrix(sparse_data._data_matrix,
                 self.indptr, self.indices, self.data, start, stop)
         else:
             rows = cupy.arange(
-                start, start + M * step, step, dtype=self.indptr.dtype)
+                start, start + M * step, step, dtype=numpy.int32)
             indptr, indices, data = _index._csr_row_index(
                 rows, self.indptr, self.indices, self.data)
 


### PR DESCRIPTION
`indptr` and `indices` are always int32 dtype.