### PR TITLE
Fix `csr_matrix._get_intXslice` for step < 0 case

### DIFF
--- a/cupyx/scipy/sparse/csr.py
+++ b/cupyx/scipy/sparse/csr.py
@@ -463,35 +463,7 @@ class csr_matrix(compressed._compressed_sparse_matrix):
         return self.getrow(row)._minor_index_fancy(col)
 
     def _get_intXslice(self, row, col):
-        if col.step in (1, None):
-            return self._get_submatrix(slice(row, row+1, 1), col, copy=True)
-
-        M, N = self.shape
-        start, stop, stride = col.indices(N)
-
-        ii, jj = self.indptr[row:row+2]
-        row_indices = self.indices[ii:jj]
-        row_data = self.data[ii:jj]
-
-        if stride > 0:
-            ind = (row_indices >= start) & (row_indices < stop)
-        else:
-            ind = (row_indices <= start) & (row_indices > stop)
-
-        if abs(stride) > 1:
-            ind &= (row_indices - start) % stride == 0
-
-        row_indices = (row_indices[ind] - start) // stride
-        row_data = row_data[ind]
-        row_indptr = cupy.array([0, row_indices.size])
-
-        if stride < 0:
-            row_data = row_data[::-1]
-            row_indices = cupy.abs(row_indices[::-1])
-
-        shape = (1, (stop - start + stride - 1) // stride)
-        return csr_matrix((row_data, row_indices, row_indptr), shape=shape,
-                          dtype=self.dtype, copy=False)
+        return self.getrow(row)._minor_slice(col)
 
     def _get_sliceXint(self, row, col):
         if row.step in (1, None):

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_index.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_index.py
@@ -42,9 +42,6 @@ class TestIndexing(unittest.TestCase):
 
         expected = a.get()
 
-        if compare_dense:
-            expected = expected.todense()
-
         maj_h = maj.get() if isinstance(maj, cupy.ndarray) else maj
         min_h = min.get() if isinstance(min, cupy.ndarray) else min
 
@@ -57,7 +54,8 @@ class TestIndexing(unittest.TestCase):
             expected = expected[maj_h]
 
         if compare_dense:
-            actual = actual.todense()
+            actual = actual.toarray()
+            expected = expected.toarray()
 
         if sparse.isspmatrix(actual):
             actual.sort_indices()
@@ -69,9 +67,10 @@ class TestIndexing(unittest.TestCase):
                 actual.indices, expected.indices)
             testing.assert_array_equal(
                 actual.data, expected.data)
+            actual = actual.toarray()
+            expected = expected.toarray()
         else:
-            testing.assert_array_equal(
-                actual, numpy.asarray(expected))
+            testing.assert_array_equal(actual, expected)
 
     @staticmethod
     def _get_index_combos(idx):

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_index.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_index.py
@@ -124,6 +124,7 @@ class TestIndexing(unittest.TestCase):
         self._run(slice(1, 5), 5)
         self._run(slice(5, 1), 5)
         self._run(slice(5, 1, -1), 5)
+        self._run(5, slice(5, 1, -1))
 
     def test_major_scalar_minor_slice(self):
         self._run(5, slice(1, 5))

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_index.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_index.py
@@ -69,8 +69,8 @@ class TestIndexing(unittest.TestCase):
                 actual.data, expected.data)
             actual = actual.toarray()
             expected = expected.toarray()
-        else:
-            testing.assert_array_equal(actual, expected)
+
+        testing.assert_array_equal(actual, expected)
 
     @staticmethod
     def _get_index_combos(idx):


### PR DESCRIPTION
Blocked by #3948 and #3955.