### PR TITLE
add several functions to cupyx.scipy.ndimage.measurements

### DIFF
--- a/cupyx/scipy/ndimage/__init__.py
+++ b/cupyx/scipy/ndimage/__init__.py
@@ -38,6 +38,12 @@ from cupyx.scipy.ndimage.measurements import sum  # NOQA
 from cupyx.scipy.ndimage.measurements import mean  # NOQA
 from cupyx.scipy.ndimage.measurements import variance  # NOQA
 from cupyx.scipy.ndimage.measurements import standard_deviation  # NOQA
+from cupyx.scipy.ndimage.measurements import minimum  # NOQA
+from cupyx.scipy.ndimage.measurements import maximum  # NOQA
+from cupyx.scipy.ndimage.measurements import minimum_position  # NOQA
+from cupyx.scipy.ndimage.measurements import maximum_position  # NOQA
+from cupyx.scipy.ndimage.measurements import median  # NOQA
+from cupyx.scipy.ndimage.measurements import extrema  # NOQA
 
 from cupyx.scipy.ndimage.morphology import generate_binary_structure  # NOQA
 from cupyx.scipy.ndimage.morphology import iterate_structure  # NOQA

--- a/cupyx/scipy/ndimage/measurements.py
+++ b/cupyx/scipy/ndimage/measurements.py
@@ -955,17 +955,17 @@ def extrema(input, labels=None, index=None):
             If None (default), all values where non-zero `labels` are used.
 
     Returns:
-        A tuple that contains the following values.
+        A tuple that contains the following values:
 
-        minimums (cupy.ndarray): Values of minimums in each feature.
+        **minimums (cupy.ndarray)**: Values of minimums in each feature.
 
-        maximums (cupy.ndarray): Values of maximums in each feature.
+        **maximums (cupy.ndarray)**: Values of maximums in each feature.
 
-        min_positions (tuple or list of tuples):
-            Each tuple gives the N-D coordinates of the corresponding minimum.
+        **min_positions (tuple or list of tuples)**: Each tuple gives the N-D
+        coordinates of the corresponding minimum.
 
-        max_positions (tuple or list of tuples):
-            Each tuple gives the N-D coordinates of the corresponding maximum.
+        **max_positions (tuple or list of tuples)**: Each tuple gives the N-D
+        coordinates of the corresponding maximum.
 
     .. seealso:: :func:`scipy.ndimage.extrema`
     """

--- a/cupyx/scipy/ndimage/measurements.py
+++ b/cupyx/scipy/ndimage/measurements.py
@@ -510,3 +510,400 @@ def standard_deviation(input, labels=None, index=None):
     .. seealso:: :func:`scipy.ndimage.standard_deviation`
     """
     return cupy.sqrt(variance(input, labels, index))
+
+
+def _safely_castable_to_int(dt):
+    """Test whether the NumPy data type `dt` can be safely cast to an int."""
+    int_size = cupy.dtype(int).itemsize
+    safe = (
+        cupy.issubdtype(dt, cupy.signedinteger) and dt.itemsize <= int_size
+    ) or (cupy.issubdtype(dt, cupy.unsignedinteger) and dt.itemsize < int_size)
+    return safe
+
+
+def _select(
+    input,
+    labels=None,
+    index=None,
+    find_min=False,
+    find_max=False,
+    find_min_positions=False,
+    find_max_positions=False,
+    find_median=False,
+):
+    """Returns min, max, or both, plus their positions (if requested), and
+    median."""
+
+    # input = cupy.asanyarray(input)
+
+    find_positions = find_min_positions or find_max_positions
+    positions = None
+    if find_positions:
+        positions = cupy.arange(input.size).reshape(input.shape)
+
+    def single_group(vals, positions):
+        result = []
+        if find_min:
+            result += [vals.min()]
+        if find_min_positions:
+            result += [positions[vals == vals.min()][0]]
+        if find_max:
+            result += [vals.max()]
+        if find_max_positions:
+            result += [positions[vals == vals.max()][0]]
+        if find_median:
+            result += [cupy.median(vals)]
+        return result
+
+    if labels is None:
+        return single_group(input, positions)
+
+    # ensure input and labels match sizes
+    input, labels = cupy.broadcast_arrays(input, labels)
+
+    if index is None:
+        mask = labels > 0
+        masked_positions = None
+        if find_positions:
+            masked_positions = positions[mask]
+        return single_group(input[mask], masked_positions)
+
+    if cupy.isscalar(index):
+        mask = labels == index
+        masked_positions = None
+        if find_positions:
+            masked_positions = positions[mask]
+        return single_group(input[mask], masked_positions)
+
+    index = cupy.asarray(index)
+
+    # remap labels to unique integers if necessary, or if the largest
+    # label is larger than the number of values.
+    if (
+        not _safely_castable_to_int(labels.dtype)
+        or labels.min() < 0
+        or labels.max() > labels.size
+    ):
+        # remap labels, and indexes
+        unique_labels, labels = cupy.unique(labels, return_inverse=True)
+        idxs = cupy.searchsorted(unique_labels, index)
+
+        # make all of idxs valid
+        idxs[idxs >= unique_labels.size] = 0
+        found = unique_labels[idxs] == index
+    else:
+        # labels are an integer type, and there aren't too many
+        idxs = cupy.asanyarray(index, cupy.int).copy()
+        found = (idxs >= 0) & (idxs <= labels.max())
+
+    idxs[~found] = labels.max() + 1
+
+    order = cupy.lexsort(cupy.stack((input.ravel(), labels.ravel())))
+    input = input.ravel()[order]
+    labels = labels.ravel()[order]
+    if find_positions:
+        positions = positions.ravel()[order]
+
+    # Determine indices corresponding to the min or max value for each label
+    label_change_index = cupy.cumsum(cupy.bincount(labels))
+    if find_min or find_min_positions or find_median:
+        min_index = cupy.concatenate(
+            (cupy.asarray([0]), label_change_index[:-1])
+        )
+    if find_max or find_max_positions or find_median:
+        max_index = label_change_index - 1
+
+    result = []
+    if find_min:
+        mins = cupy.zeros(int(labels.max()) + 2, input.dtype)
+        mins[labels[min_index]] = input[min_index]
+        result += [mins[idxs]]
+    if find_min_positions:
+        minpos = cupy.zeros(labels.max().item() + 2, int)
+        minpos[labels[min_index]] = positions[min_index]
+        result += [minpos[idxs]]
+    if find_max:
+        maxs = cupy.zeros(int(labels.max()) + 2, input.dtype)
+        maxs[labels[max_index]] = input[max_index]
+        result += [maxs[idxs]]
+    if find_max_positions:
+        maxpos = cupy.zeros(labels.max().item() + 2, int)
+        maxpos[labels[max_index]] = positions[max_index]
+        result += [maxpos[idxs]]
+    if find_median:
+        locs = cupy.arange(len(labels))
+        lo = cupy.zeros(int(labels.max()) + 2, cupy.int)
+        lo[labels[min_index]] = locs[min_index]
+        hi = cupy.zeros(int(labels.max()) + 2, cupy.int)
+        hi[labels[max_index]] = locs[max_index]
+        lo = lo[idxs]
+        hi = hi[idxs]
+        # lo is an index to the lowest value in input for each label,
+        # hi is an index to the largest value.
+        # move them to be either the same ((hi - lo) % 2 == 0) or next
+        # to each other ((hi - lo) % 2 == 1), then average.
+        step = (hi - lo) // 2
+        lo += step
+        hi -= step
+        result += [(input[lo] + input[hi]) / 2.0]
+
+    return result
+
+
+def minimum(input, labels=None, index=None):
+    """Calculate the minimum of the values of an array over labeled regions.
+
+    Args:
+        input (cupy.ndarray):
+            Array of values. For each region specified by `labels`, the
+            minimal values of `input` over the region is computed.
+        labels (cupy.ndarray, optional): An array of integers marking different
+            regions over which the minimum value of `input` is to be computed.
+            `labels` must have the same shape as `input`. If `labels` is not
+            specified, the minimum over the whole array is returned.
+        index (array_like, optional): A list of region labels that are taken
+            into account for computing the minima. If index is None, the
+            minimum over all elements where `labels` is non-zero is returned.
+
+    Returns:
+        minimum (cupy.ndarray): Array of minima of `input` over the regions
+            determined by `labels` and whose index is in `index`. If `index` or
+            `labels` are not specified, a 0-dimensional cupy.ndarray is
+            returned: the minimal value of `input` if `labels` is None,
+            and the minimal value of elements where `labels` is greater than
+            zero if `index` is None.
+
+    .. seealso:: :func:`scipy.ndimage.minimum`
+    """
+    return _select(input, labels, index, find_min=True)[0]
+
+
+def maximum(input, labels=None, index=None):
+    """Calculate the maximum of the values of an array over labeled regions.
+
+    Args:
+        input (cupy.ndarray):
+            Array of values. For each region specified by `labels`, the
+            maximal values of `input` over the region is computed.
+        labels (cupy.ndarray, optional): An array of integers marking different
+            regions over which the maximum value of `input` is to be computed.
+            `labels` must have the same shape as `input`. If `labels` is not
+            specified, the maximum over the whole array is returned.
+        index (array_like, optional): A list of region labels that are taken
+            into account for computing the maxima. If index is None, the
+            maximum over all elements where `labels` is non-zero is returned.
+
+    Returns:
+        maximum (cupy.ndarray): Array of maxima of `input` over the regions
+            determaxed by `labels` and whose index is in `index`. If `index` or
+            `labels` are not specified, a 0-dimensional cupy.ndarray is
+            returned: the maximal value of `input` if `labels` is None,
+            and the maximal value of elements where `labels` is greater than
+            zero if `index` is None.
+
+    .. seealso:: :func:`scipy.ndimage.maximum`
+    """
+    return _select(input, labels, index, find_max=True)[0]
+
+
+def median(input, labels=None, index=None):
+    """Calculate the median of the values of an array over labeled regions.
+
+    Args:
+        input (cupy.ndarray):
+            Array of values. For each region specified by `labels`, the
+            median values of `input` over the region is computed.
+        labels (cupy.ndarray, optional): An array of integers marking different
+            regions over which the median value of `input` is to be computed.
+            `labels` must have the same shape as `input`. If `labels` is not
+            specified, the median over the whole array is returned.
+        index (array_like, optional): A list of region labels that are taken
+            into account for computing the medians. If index is None, the
+            median over all elements where `labels` is non-zero is returned.
+
+    Returns:
+        median (cupy.ndarray): Array of medians of `input` over the regions
+            determined by `labels` and whose index is in `index`. If `index` or
+            `labels` are not specified, a 0-dimensional cupy.ndarray is
+            returned: the median value of `input` if `labels` is None,
+            and the median value of elements where `labels` is greater than
+            zero if `index` is None.
+
+    .. seealso:: :func:`scipy.ndimage.median`
+    """
+    return _select(input, labels, index, find_median=True)[0]
+
+
+def minimum_position(input, labels=None, index=None):
+    """Find the positions of the minimums of the values of an array at labels.
+
+    For each region specified by `labels`, the position of the minimum
+    value of `input` within the region is returned.
+
+    Args:
+        input (cupy.ndarray):
+            Array of values. For each region specified by `labels`, the
+            minimal values of `input` over the region is computed.
+        labels (cupy.ndarray, optional): An array of integers marking different
+            regions over which the position of the minimum value of `input` is
+             to be computed. `labels` must have the same shape as `input`. If
+             `labels` is not specified, the location of the first minimum over
+             the whole array is returned.
+
+            The `labels` argument only works when `index` is specified.
+        index (array_like, optional): A list of region labels that are taken
+            into account for finding the location of the minima. If `index` is
+            None, the ``first`` minimum over all elements where `labels` is
+            non-zero is returned.
+
+            The `index` argument only works when `labels` is specified.
+
+    Returns:
+        output (list of tuples of ints): Tuple of ints or list of tuples of
+            ints that specify the location of minima of `input` over the
+            regions determined by `labels` and  whose index is in `index`.
+
+            If `index` or `labels` are not specified, a tuple of ints is
+            returned specifying the location of the first minimal value of
+            `input`.
+
+    .. note::
+        When `input` has multiple identical minima within a labeled region,
+        the coordinates returned are not guaranteed to match those returned by
+        SciPy.
+
+    .. seealso:: :func:`scipy.ndimage.minimum_position`
+    """
+    dims = numpy.asarray(input.shape)
+    # see numpy.unravel_index to understand this line.
+    dim_prod = numpy.cumprod([1] + list(dims[:0:-1]))[::-1]
+
+    result = _select(input, labels, index, find_min_positions=True)[0]
+
+    # have to transfer result back to the CPU to return index tuples
+    if result.ndim == 0:
+        result = int(result)  # synchronize
+    else:
+        result = cupy.asnumpy(result)  # synchronize
+
+    if cupy.isscalar(result):
+        return tuple((result // dim_prod) % dims)
+
+    return [tuple(v) for v in (result.reshape(-1, 1) // dim_prod) % dims]
+
+
+def maximum_position(input, labels=None, index=None):
+    """Find the positions of the maximums of the values of an array at labels.
+
+    For each region specified by `labels`, the position of the maximum
+    value of `input` within the region is returned.
+
+    Args:
+        input (cupy.ndarray):
+            Array of values. For each region specified by `labels`, the
+            maximal values of `input` over the region is computed.
+        labels (cupy.ndarray, optional): An array of integers marking different
+            regions over which the position of the maximum value of `input` is
+             to be computed. `labels` must have the same shape as `input`. If
+             `labels` is not specified, the location of the first maximum over
+             the whole array is returned.
+
+            The `labels` argument only works when `index` is specified.
+        index (array_like, optional): A list of region labels that are taken
+            into account for finding the location of the maxima. If `index` is
+            None, the ``first`` maximum over all elements where `labels` is
+            non-zero is returned.
+
+            The `index` argument only works when `labels` is specified.
+
+    Returns:
+        output (list of tuples of ints): Tuple of ints or list of tuples of
+            ints that specify the location of maxima of `input` over the
+            regions determaxed by `labels` and  whose index is in `index`.
+
+            If `index` or `labels` are not specified, a tuple of ints is
+            returned specifying the location of the first maximal value of
+            `input`.
+
+    .. note::
+        When `input` has multiple identical maxima within a labeled region,
+        the coordinates returned are not guaranteed to match those returned by
+        SciPy.
+
+    .. seealso:: :func:`scipy.ndimage.maximum_position`
+    """
+    dims = numpy.asarray(input.shape)
+    # see numpy.unravel_index to understand this line.
+    dim_prod = numpy.cumprod([1] + list(dims[:0:-1]))[::-1]
+
+    result = _select(input, labels, index, find_max_positions=True)[0]
+
+    # have to transfer result back to the CPU to return index tuples
+    if result.ndim == 0:
+        result = int(result)
+    else:
+        result = cupy.asnumpy(result)
+
+    if cupy.isscalar(result):
+        return tuple((result // dim_prod) % dims)
+
+    return [tuple(v) for v in (result.reshape(-1, 1) // dim_prod) % dims]
+
+
+def extrema(input, labels=None, index=None):
+    """Calculate the minimums and maximums of the values of an array at labels,
+    along with their positions.
+
+    Args:
+        input (cupy.ndarray) N-D image data to process.
+        labels (cupy.ndarray, optional): Labels of features in input. If not
+            None, must be same shape as `input`.
+        index (int or sequence of ints, optional): Labels to include in output.
+            If None (default), all values where non-zero `labels` are used.
+
+    Returns:
+        minimums (cupy.ndarray): Values of minimums in each feature.
+        maximums (cupy.ndarray): Values of maximums in each feature.
+        min_positions (tuple or list of tuples): Each tuple gives the N-D
+            coordinates of the corresponding minimum.
+        max_positions (tuple or list of tuples): Each tuple gives the N-D
+            coordinates of the corresponding maximum.
+
+    .. seealso:: :func:`scipy.ndimage.extrema`
+    """
+    dims = numpy.array(input.shape)
+    # see numpy.unravel_index to understand this line.
+    dim_prod = numpy.cumprod([1] + list(dims[:0:-1]))[::-1]
+
+    minimums, min_positions, maximums, max_positions = _select(
+        input,
+        labels,
+        index,
+        find_min=True,
+        find_max=True,
+        find_min_positions=True,
+        find_max_positions=True,
+    )
+
+    if min_positions.ndim == 0:
+        # scalar output case
+        min_positions = min_positions.item()
+        max_positions = max_positions.item()
+        return (
+            minimums,
+            maximums,
+            tuple((min_positions // dim_prod) % dims),
+            tuple((max_positions // dim_prod) % dims),
+        )
+
+    # convert indexes to tuples on the host
+    min_positions = cupy.asnumpy(min_positions)
+    max_positions = cupy.asnumpy(max_positions)
+    min_positions = [
+        tuple(v) for v in (min_positions.reshape(-1, 1) // dim_prod) % dims
+    ]
+    max_positions = [
+        tuple(v) for v in (max_positions.reshape(-1, 1) // dim_prod) % dims
+    ]
+
+    return minimums, maximums, min_positions, max_positions

--- a/cupyx/scipy/ndimage/measurements.py
+++ b/cupyx/scipy/ndimage/measurements.py
@@ -839,9 +839,9 @@ def minimum_position(input, labels=None, index=None):
             minimal values of `input` over the region is computed.
         labels (cupy.ndarray, optional): An array of integers marking different
             regions over which the position of the minimum value of `input` is
-             to be computed. `labels` must have the same shape as `input`. If
-             `labels` is not specified, the location of the first minimum over
-             the whole array is returned.
+            to be computed. `labels` must have the same shape as `input`. If
+            `labels` is not specified, the location of the first minimum over
+            the whole array is returned.
 
             The `labels` argument only works when `index` is specified.
         index (array_like, optional): A list of region labels that are taken
@@ -897,9 +897,9 @@ def maximum_position(input, labels=None, index=None):
             maximal values of `input` over the region is computed.
         labels (cupy.ndarray, optional): An array of integers marking different
             regions over which the position of the maximum value of `input` is
-             to be computed. `labels` must have the same shape as `input`. If
-             `labels` is not specified, the location of the first maximum over
-             the whole array is returned.
+            to be computed. `labels` must have the same shape as `input`. If
+            `labels` is not specified, the location of the first maximum over
+            the whole array is returned.
 
             The `labels` argument only works when `index` is specified.
         index (array_like, optional): A list of region labels that are taken
@@ -948,19 +948,24 @@ def extrema(input, labels=None, index=None):
     along with their positions.
 
     Args:
-        input (cupy.ndarray) N-D image data to process.
+        input (cupy.ndarray): N-D image data to process.
         labels (cupy.ndarray, optional): Labels of features in input. If not
             None, must be same shape as `input`.
         index (int or sequence of ints, optional): Labels to include in output.
             If None (default), all values where non-zero `labels` are used.
 
     Returns:
+        A tuple that contains the following values.
+
         minimums (cupy.ndarray): Values of minimums in each feature.
+
         maximums (cupy.ndarray): Values of maximums in each feature.
-        min_positions (tuple or list of tuples): Each tuple gives the N-D
-            coordinates of the corresponding minimum.
-        max_positions (tuple or list of tuples): Each tuple gives the N-D
-            coordinates of the corresponding maximum.
+
+        min_positions (tuple or list of tuples):
+            Each tuple gives the N-D coordinates of the corresponding minimum.
+
+        max_positions (tuple or list of tuples):
+            Each tuple gives the N-D coordinates of the corresponding maximum.
 
     .. seealso:: :func:`scipy.ndimage.extrema`
     """

--- a/cupyx/scipy/ndimage/measurements.py
+++ b/cupyx/scipy/ndimage/measurements.py
@@ -755,16 +755,16 @@ def minimum(input, labels=None, index=None):
             `labels` must have the same shape as `input`. If `labels` is not
             specified, the minimum over the whole array is returned.
         index (array_like, optional): A list of region labels that are taken
-            into account for computing the minima. If index is None, the
+            into account for computing the minima. If `index` is None, the
             minimum over all elements where `labels` is non-zero is returned.
 
     Returns:
-        minimum (cupy.ndarray): Array of minima of `input` over the regions
-            determined by `labels` and whose index is in `index`. If `index` or
-            `labels` are not specified, a 0-dimensional cupy.ndarray is
-            returned: the minimal value of `input` if `labels` is None,
-            and the minimal value of elements where `labels` is greater than
-            zero if `index` is None.
+        cupy.ndarray: Array of minima of `input` over the regions
+        determined by `labels` and whose index is in `index`. If `index` or
+        `labels` are not specified, a 0-dimensional cupy.ndarray is
+        returned: the minimal value of `input` if `labels` is None,
+        and the minimal value of elements where `labels` is greater than
+        zero if `index` is None.
 
     .. seealso:: :func:`scipy.ndimage.minimum`
     """
@@ -783,16 +783,16 @@ def maximum(input, labels=None, index=None):
             `labels` must have the same shape as `input`. If `labels` is not
             specified, the maximum over the whole array is returned.
         index (array_like, optional): A list of region labels that are taken
-            into account for computing the maxima. If index is None, the
+            into account for computing the maxima. If `index` is None, the
             maximum over all elements where `labels` is non-zero is returned.
 
     Returns:
-        maximum (cupy.ndarray): Array of maxima of `input` over the regions
-            determaxed by `labels` and whose index is in `index`. If `index` or
-            `labels` are not specified, a 0-dimensional cupy.ndarray is
-            returned: the maximal value of `input` if `labels` is None,
-            and the maximal value of elements where `labels` is greater than
-            zero if `index` is None.
+        cupy.ndarray: Array of maxima of `input` over the regions
+        determaxed by `labels` and whose index is in `index`. If `index` or
+        `labels` are not specified, a 0-dimensional cupy.ndarray is
+        returned: the maximal value of `input` if `labels` is None,
+        and the maximal value of elements where `labels` is greater than
+        zero if `index` is None.
 
     .. seealso:: :func:`scipy.ndimage.maximum`
     """
@@ -811,16 +811,16 @@ def median(input, labels=None, index=None):
             `labels` must have the same shape as `input`. If `labels` is not
             specified, the median over the whole array is returned.
         index (array_like, optional): A list of region labels that are taken
-            into account for computing the medians. If index is None, the
+            into account for computing the medians. If `index` is None, the
             median over all elements where `labels` is non-zero is returned.
 
     Returns:
-        median (cupy.ndarray): Array of medians of `input` over the regions
-            determined by `labels` and whose index is in `index`. If `index` or
-            `labels` are not specified, a 0-dimensional cupy.ndarray is
-            returned: the median value of `input` if `labels` is None,
-            and the median value of elements where `labels` is greater than
-            zero if `index` is None.
+        cupy.ndarray: Array of medians of `input` over the regions
+        determined by `labels` and whose index is in `index`. If `index` or
+        `labels` are not specified, a 0-dimensional cupy.ndarray is
+        returned: the median value of `input` if `labels` is None,
+        and the median value of elements where `labels` is greater than
+        zero if `index` is None.
 
     .. seealso:: :func:`scipy.ndimage.median`
     """
@@ -910,13 +910,13 @@ def maximum_position(input, labels=None, index=None):
             The `index` argument only works when `labels` is specified.
 
     Returns:
-        output (list of tuples of ints): Tuple of ints or list of tuples of
-            ints that specify the location of maxima of `input` over the
-            regions determaxed by `labels` and  whose index is in `index`.
+        list of tuples of ints: Tuple of ints or list of tuples of
+        ints that specify the location of maxima of `input` over the
+        regions determaxed by `labels` and  whose index is in `index`.
 
-            If `index` or `labels` are not specified, a tuple of ints is
-            returned specifying the location of the first maximal value of
-            `input`.
+        If `index` or `labels` are not specified, a tuple of ints is
+        returned specifying the location of the first maximal value of
+        `input`.
 
     .. note::
         When `input` has multiple identical maxima within a labeled region,
@@ -955,7 +955,7 @@ def extrema(input, labels=None, index=None):
             If None (default), all values where non-zero `labels` are used.
 
     Returns:
-        A tuple that contains the following values:
+        A tuple that contains the following values.
 
         **minimums (cupy.ndarray)**: Values of minimums in each feature.
 

--- a/cupyx/scipy/ndimage/measurements.py
+++ b/cupyx/scipy/ndimage/measurements.py
@@ -645,7 +645,12 @@ def _select(
         step = (hi - lo) // 2
         lo += step
         hi -= step
-        result += [(input[lo] + input[hi]) / 2.0]
+        if input.dtype.kind in 'iub':
+            # fix for https://github.com/scipy/scipy/issues/12836
+            result += [(input[lo].astype(float) + input[hi].astype(float)) /
+                       2.0]
+        else:
+            result += [(input[lo] + input[hi]) / 2.0]
 
     return result
 

--- a/docs/source/reference/ndimage.rst
+++ b/docs/source/reference/ndimage.rst
@@ -75,8 +75,14 @@ Measurements
    :toctree: generated/
    :nosignatures:
 
+   cupyx.scipy.ndimage.extrema
    cupyx.scipy.ndimage.label
+   cupyx.scipy.ndimage.maximum
+   cupyx.scipy.ndimage.maximum_position
    cupyx.scipy.ndimage.mean
+   cupyx.scipy.ndimage.median
+   cupyx.scipy.ndimage.minimum
+   cupyx.scipy.ndimage.minimum_position
    cupyx.scipy.ndimage.standard_deviation
    cupyx.scipy.ndimage.sum
    cupyx.scipy.ndimage.variance

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
@@ -250,10 +250,9 @@ class TestMeasurementsSelect(unittest.TestCase):
 
         if (self.op in ['minimum_position', 'maximum_position'] and
                 non_unique and self.index is not None):
-            raise unittest.SkipTest(
-                'Minimum/maximum position not guaranteed to be the same '
-                'when there are duplicate extrema and index is provided.'
-            )
+            # skip cases with non-unique min or max position
+            return xp.array([])
+
         if self.labels is None:
             labels = self.labels
         else:

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
@@ -266,7 +266,7 @@ class TestMeasurementsSelect(unittest.TestCase):
                 index = None
         elif self.index == 'subset':
             if self.labels is not None:
-                index = xp.arange(1, self.labels + 1, dtype=cupy.intp)[::2]
+                index = xp.arange(1, self.labels + 1, dtype=cupy.intp)[1::2]
             else:
                 index = None
         func = getattr(scp.ndimage, self.op)

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
@@ -247,10 +247,12 @@ class TestMeasurementsSelect(unittest.TestCase):
         # https://github.com/scipy/scipy/issues/12836
         x = testing.shaped_random(shape, xp=xp, dtype=dtype, scale=32)
         non_unique = xp.unique(x).size < x.size
-        if self.op in ['minimum_position', 'maximum_position'] and non_unique:
+
+        if (self.op in ['minimum_position', 'maximum_position'] and
+                non_unique and self.index is not None):
             raise unittest.SkipTest(
-                'minimum/maximum position not guaranteed to be the same '
-                'when there are duplicate extrema'
+                'Minimum/maximum position not guaranteed to be the same '
+                'when there are duplicate extrema and index is provided.'
             )
         if self.labels is None:
             labels = self.labels
@@ -272,7 +274,7 @@ class TestMeasurementsSelect(unittest.TestCase):
         func = getattr(scp.ndimage, self.op)
         result = func(x, labels, index)
         if self.op == 'extrema':
-            if non_unique:
+            if non_unique and self.index is not None:
                 # omit comparison of minimum_position, maximum_position
                 result = [xp.asarray(r) for r in result[:2]]
             else:


### PR DESCRIPTION
### Overview
This PR adds a series of related `cupyx.scipy.ndimage.measurement` functions: `maximum`, `maximum_position`, `minimum`, `minimum_position`, `median` and `extrema`.

### Implementation Notes

All of these rely on a single `_select` helper function that is patterned after SciPy's, but deviates in some implementation details.  Specifically, SciPy's implementation relies on NumPy-specific behavior regarding indexing with duplicate indices that is a [documented difference from CuPy behavior](https://docs.cupy.dev/en/stable/reference/difference.html#duplicate-values-in-indices)

[Example SciPy code](https://github.com/scipy/scipy/blob/48a876262d95fafbc44e7cbc7baa1ffd685ad659/scipy/ndimage/measurements.py#L867):

```Python
mins[labels[::-1]] = input[::-1]
```
For NumPy arrays, assuming `input` has already been sorted in ascending order, the line above results in storage of the minimum value at each integer values in `labels` to the corresponding index in `mins`. For CuPy, I instead relied on `lexsort` to get around the need for such repeated assignment to find the minimum or maximum (in contrast, SciPy only relies on `lexsort` for the `median` case, but only uses a simpler `argsort` of the labels for the other cases).

I later added an alternative code path (the `_select_via_looping` helper) that does not require `lexsort` and is much faster when there are relatively few labels to measure. It becomes slower than the `lexsort` approach when there are many (>30 or so) labels to measure. I think the slowdown for a larger number of labels is due to increasing numbers of kernel launches (but with relatively small work per kernel).

### One difference in behavior vs. SciPy

If there are multiple identical minima or maxima within a labeled region, the functions `minimum_position` and `maximum_position` as proposed here are not guaranteed to return the coordinates of the same extrema as the SciPy implementation. I think any of these duplicate extrema are equally valid choices, so I don't see this as a bug, but it is a deviation in behavior.

I couldn't see a very simple way to ensure we always get the same coordinate as SciPy. For that reason, `unittest.SkipTest` is used to skip cases where the input has non-unique values.

The other difference is that any global values returned by `minimum`, `maximum` and `median` are left as 0-dimensional device arrays rather than transferring to host scalars. I did choose to store the `minimum_position` and `maximum_position` values as tuples of int on the host, though I am not certain if that is preferred?

# Benchmarks 

Here are some benchmarks when CUB is enabled, showing that there is always substantial acceleration for large images, with the acceleration becoming particularly large (>100) when there are relatively few labels. Without CUB, there is reduced performance, but still an overall substantial acceleration. Results for `maximum` and `maximum_position` are not shown in the table because they should be the same as their `minimum` counterparts.


<details><summary>Benchmarks with CUB enabled</summary>

## Benchmarking functions from cupyx.scipy.ndimage.measurements

shape | GPU time (ms) | CPU time (ms) | acceleration
------|---------------|---------------|-------------
minimum, (128, 128), 1 label(s), uint8 | 0.018 +/- 0.002 | 0.017 +/- 0.002 | 0.978
minimum, (128, 128), 3 label(s), uint8 | 0.475 +/- 0.019 | 0.312 +/- 0.011 | 0.656
minimum, (128, 128), 10 label(s), uint8 | 0.966 +/- 0.035 | 0.324 +/- 0.018 | 0.335
minimum, (128, 128), 20 label(s), uint8 | 1.627 +/- 0.057 | 0.317 +/- 0.016 | 0.195
minimum, (128, 128), 50 label(s), uint8 | 0.728 +/- 0.023 | 0.310 +/- 0.010 | 0.426
minimum, (128, 128), 250 label(s), uint8 | 0.731 +/- 0.023 | 0.329 +/- 0.020 | 0.451
minimum, (512, 512), 1 label(s), uint8 | 0.017 +/- 0.001 | 0.194 +/- 0.012 | 11.212
minimum, (512, 512), 3 label(s), uint8 | 0.513 +/- 0.020 | 5.230 +/- 0.144 | 10.188
minimum, (512, 512), 10 label(s), uint8 | 1.115 +/- 0.034 | 5.325 +/- 0.096 | 4.778
minimum, (512, 512), 20 label(s), uint8 | 1.898 +/- 0.035 | 4.956 +/- 0.109 | 2.612
minimum, (512, 512), 50 label(s), uint8 | 1.703 +/- 0.071 | 5.204 +/- 0.066 | 3.056
minimum, (512, 512), 250 label(s), uint8 | 1.653 +/- 0.019 | 5.287 +/- 0.043 | 3.198
minimum, (4096, 4096), 1 label(s), uint8 | 0.059 +/- 0.000 | 11.834 +/- 0.166 | 199.192
minimum, (4096, 4096), 3 label(s), uint8 | 6.818 +/- 0.009 | 505.614 +/- 1.543 | 74.157
minimum, (4096, 4096), 10 label(s), uint8 | 20.095 +/- 0.016 | 503.091 +/- 1.499 | 25.036
minimum, (4096, 4096), 20 label(s), uint8 | 38.654 +/- 0.086 | 508.068 +/- 3.233 | 13.144
minimum, (4096, 4096), 50 label(s), uint8 | 100.349 +/- 0.080 | 492.171 +/- 1.988 | 4.905
minimum, (4096, 4096), 250 label(s), uint8 | 137.852 +/- 0.104 | 506.915 +/- 3.613 | 3.677
minimum_position, (128, 128), 1 label(s), uint8 | 0.160 +/- 0.009 | 0.086 +/- 0.007 | 0.538
minimum_position, (128, 128), 3 label(s), uint8 | 0.822 +/- 0.035 | 0.377 +/- 0.021 | 0.459
minimum_position, (128, 128), 10 label(s), uint8 | 1.844 +/- 0.062 | 0.366 +/- 0.018 | 0.199
minimum_position, (128, 128), 20 label(s), uint8 | 0.825 +/- 0.028 | 0.402 +/- 0.019 | 0.487
minimum_position, (128, 128), 50 label(s), uint8 | 0.849 +/- 0.028 | 0.400 +/- 0.016 | 0.471
minimum_position, (128, 128), 250 label(s), uint8 | 1.017 +/- 0.035 | 0.616 +/- 0.037 | 0.606
minimum_position, (512, 512), 1 label(s), uint8 | 0.171 +/- 0.006 | 1.069 +/- 0.011 | 6.265
minimum_position, (512, 512), 3 label(s), uint8 | 0.873 +/- 0.031 | 5.949 +/- 0.071 | 6.816
minimum_position, (512, 512), 10 label(s), uint8 | 2.046 +/- 0.055 | 5.764 +/- 0.144 | 2.818
minimum_position, (512, 512), 20 label(s), uint8 | 1.691 +/- 0.026 | 5.992 +/- 0.147 | 3.543
minimum_position, (512, 512), 50 label(s), uint8 | 1.749 +/- 0.027 | 5.941 +/- 0.119 | 3.396
minimum_position, (512, 512), 250 label(s), uint8 | 1.986 +/- 0.032 | 6.278 +/- 0.135 | 3.161
minimum_position, (4096, 4096), 1 label(s), uint8 | 2.843 +/- 0.006 | 80.222 +/- 0.158 | 28.216
minimum_position, (4096, 4096), 3 label(s), uint8 | 12.901 +/- 0.017 | 578.653 +/- 6.262 | 44.852
minimum_position, (4096, 4096), 10 label(s), uint8 | 36.639 +/- 0.044 | 583.947 +/- 1.371 | 15.938
minimum_position, (4096, 4096), 20 label(s), uint8 | 91.556 +/- 0.085 | 583.709 +/- 3.047 | 6.375
minimum_position, (4096, 4096), 50 label(s), uint8 | 105.014 +/- 0.075 | 581.576 +/- 1.129 | 5.538
minimum_position, (4096, 4096), 250 label(s), uint8 | 145.823 +/- 0.125 | 591.455 +/- 2.131 | 4.056
median, (128, 128), 1 label(s), uint8 | 0.074 +/- 0.004 | 0.068 +/- 0.004 | 0.927
median, (128, 128), 3 label(s), uint8 | 0.655 +/- 0.028 | 0.596 +/- 0.029 | 0.910
median, (128, 128), 10 label(s), uint8 | 1.515 +/- 0.053 | 0.723 +/- 0.033 | 0.477
median, (128, 128), 20 label(s), uint8 | 0.963 +/- 0.027 | 0.767 +/- 0.035 | 0.796
median, (128, 128), 50 label(s), uint8 | 0.997 +/- 0.035 | 0.848 +/- 0.031 | 0.851
median, (128, 128), 250 label(s), uint8 | 0.991 +/- 0.035 | 1.020 +/- 0.049 | 1.029
median, (512, 512), 1 label(s), uint8 | 0.078 +/- 0.005 | 0.877 +/- 0.032 | 11.238
median, (512, 512), 3 label(s), uint8 | 0.702 +/- 0.027 | 10.523 +/- 0.108 | 14.999
median, (512, 512), 10 label(s), uint8 | 1.669 +/- 0.042 | 13.817 +/- 0.219 | 8.276
median, (512, 512), 20 label(s), uint8 | 1.949 +/- 0.025 | 15.055 +/- 0.258 | 7.725
median, (512, 512), 50 label(s), uint8 | 1.910 +/- 0.025 | 16.291 +/- 0.334 | 8.528
median, (512, 512), 250 label(s), uint8 | 1.991 +/- 0.034 | 18.728 +/- 0.211 | 9.406
median, (4096, 4096), 1 label(s), uint8 | 0.799 +/- 0.002 | 49.111 +/- 0.503 | 61.431
median, (4096, 4096), 3 label(s), uint8 | 8.047 +/- 0.189 | 1090.444 +/- 3.095 | 135.516
median, (4096, 4096), 10 label(s), uint8 | 21.152 +/- 0.012 | 1720.172 +/- 2.107 | 81.324
median, (4096, 4096), 20 label(s), uint8 | 89.071 +/- 0.060 | 2001.175 +/- 3.524 | 22.467
median, (4096, 4096), 50 label(s), uint8 | 101.176 +/- 0.093 | 2250.323 +/- 0.313 | 22.242
median, (4096, 4096), 250 label(s), uint8 | 138.733 +/- 0.121 | 2763.532 +/- 5.008 | 19.920
extrema, (128, 128), 1 label(s), uint8 | 0.292 +/- 0.014 | 0.131 +/- 0.010 | 0.450
extrema, (128, 128), 3 label(s), uint8 | 1.198 +/- 0.047 | 0.495 +/- 0.027 | 0.414
extrema, (128, 128), 10 label(s), uint8 | 2.727 +/- 0.079 | 0.508 +/- 0.026 | 0.186
extrema, (128, 128), 20 label(s), uint8 | 1.183 +/- 0.041 | 0.521 +/- 0.026 | 0.440
extrema, (128, 128), 50 label(s), uint8 | 1.248 +/- 0.043 | 0.564 +/- 0.026 | 0.452
extrema, (128, 128), 250 label(s), uint8 | 1.587 +/- 0.062 | 0.871 +/- 0.039 | 0.549
extrema, (512, 512), 1 label(s), uint8 | 0.305 +/- 0.012 | 1.534 +/- 0.077 | 5.024
extrema, (512, 512), 3 label(s), uint8 | 1.280 +/- 0.056 | 7.910 +/- 0.149 | 6.179
extrema, (512, 512), 10 label(s), uint8 | 3.087 +/- 0.088 | 7.719 +/- 0.125 | 2.501
extrema, (512, 512), 20 label(s), uint8 | 2.147 +/- 0.041 | 7.856 +/- 0.193 | 3.659
extrema, (512, 512), 50 label(s), uint8 | 2.177 +/- 0.040 | 7.654 +/- 0.187 | 3.516
extrema, (512, 512), 250 label(s), uint8 | 2.560 +/- 0.048 | 8.130 +/- 0.135 | 3.176
extrema, (4096, 4096), 1 label(s), uint8 | 4.730 +/- 0.006 | 113.399 +/- 0.785 | 23.975
extrema, (4096, 4096), 3 label(s), uint8 | 13.186 +/- 0.013 | 728.799 +/- 1.005 | 55.270
extrema, (4096, 4096), 10 label(s), uint8 | 37.629 +/- 0.054 | 711.222 +/- 2.649 | 18.901
extrema, (4096, 4096), 20 label(s), uint8 | 92.882 +/- 0.079 | 720.253 +/- 1.142 | 7.754
extrema, (4096, 4096), 50 label(s), uint8 | 106.381 +/- 0.113 | 710.205 +/- 0.266 | 6.676
extrema, (4096, 4096), 250 label(s), uint8 | 147.412 +/- 0.154 | 714.508 +/- 1.868 | 4.847
minimum, (128, 128), 1 label(s), float32 | 0.018 +/- 0.001 | 0.008 +/- 0.001 | 0.451
minimum, (128, 128), 3 label(s), float32 | 0.482 +/- 0.022 | 0.997 +/- 0.041 | 2.067
minimum, (128, 128), 10 label(s), float32 | 0.970 +/- 0.036 | 1.003 +/- 0.032 | 1.034
minimum, (128, 128), 20 label(s), float32 | 1.671 +/- 0.077 | 1.028 +/- 0.046 | 0.615
minimum, (128, 128), 50 label(s), float32 | 0.831 +/- 0.028 | 1.026 +/- 0.043 | 1.235
minimum, (128, 128), 250 label(s), float32 | 0.817 +/- 0.022 | 1.008 +/- 0.038 | 1.234
minimum, (512, 512), 1 label(s), float32 | 0.019 +/- 0.002 | 0.053 +/- 0.007 | 2.776
minimum, (512, 512), 3 label(s), float32 | 0.509 +/- 0.016 | 22.238 +/- 0.586 | 43.678
minimum, (512, 512), 10 label(s), float32 | 1.094 +/- 0.035 | 21.659 +/- 0.510 | 19.795
minimum, (512, 512), 20 label(s), float32 | 1.918 +/- 0.054 | 22.247 +/- 0.436 | 11.601
minimum, (512, 512), 50 label(s), float32 | 1.896 +/- 0.023 | 21.894 +/- 0.145 | 11.549
minimum, (512, 512), 250 label(s), float32 | 1.919 +/- 0.019 | 22.592 +/- 0.425 | 11.773
minimum, (4096, 4096), 1 label(s), float32 | 0.187 +/- 0.001 | 4.870 +/- 0.036 | 26.077
minimum, (4096, 4096), 3 label(s), float32 | 7.438 +/- 0.013 | 2877.343 +/- 8.354 | 386.847
minimum, (4096, 4096), 10 label(s), float32 | 21.427 +/- 0.655 | 2910.766 +/- 28.887 | 135.846
minimum, (4096, 4096), 20 label(s), float32 | 39.499 +/- 0.018 | 2893.668 +/- 4.711 | 73.259
minimum, (4096, 4096), 50 label(s), float32 | 629.817 +/- 0.106 | 2916.307 +/- 7.256 | 4.630
minimum, (4096, 4096), 250 label(s), float32 | 709.433 +/- 0.189 | 2901.913 +/- 10.150 | 4.090
minimum_position, (128, 128), 1 label(s), float32 | 0.162 +/- 0.008 | 0.042 +/- 0.002 | 0.258
minimum_position, (128, 128), 3 label(s), float32 | 0.838 +/- 0.038 | 1.096 +/- 0.057 | 1.308
minimum_position, (128, 128), 10 label(s), float32 | 1.872 +/- 0.070 | 1.075 +/- 0.044 | 0.574
minimum_position, (128, 128), 20 label(s), float32 | 0.940 +/- 0.027 | 1.135 +/- 0.046 | 1.208
minimum_position, (128, 128), 50 label(s), float32 | 0.965 +/- 0.029 | 1.120 +/- 0.046 | 1.161
minimum_position, (128, 128), 250 label(s), float32 | 1.133 +/- 0.033 | 1.271 +/- 0.050 | 1.122
minimum_position, (512, 512), 1 label(s), float32 | 0.166 +/- 0.009 | 0.309 +/- 0.012 | 1.859
minimum_position, (512, 512), 3 label(s), float32 | 0.864 +/- 0.025 | 26.216 +/- 0.662 | 30.328
minimum_position, (512, 512), 10 label(s), float32 | 2.069 +/- 0.058 | 23.672 +/- 0.578 | 11.440
minimum_position, (512, 512), 20 label(s), float32 | 1.990 +/- 0.025 | 26.362 +/- 1.151 | 13.249
minimum_position, (512, 512), 50 label(s), float32 | 2.039 +/- 0.025 | 23.454 +/- 0.348 | 11.502
minimum_position, (512, 512), 250 label(s), float32 | 2.236 +/- 0.033 | 27.057 +/- 0.741 | 12.101
minimum_position, (4096, 4096), 1 label(s), float32 | 2.319 +/- 0.008 | 30.337 +/- 0.101 | 13.081
minimum_position, (4096, 4096), 3 label(s), float32 | 13.452 +/- 0.013 | 3171.381 +/- 0.756 | 235.756
minimum_position, (4096, 4096), 10 label(s), float32 | 37.621 +/- 0.704 | 3147.102 +/- 5.356 | 83.652
minimum_position, (4096, 4096), 20 label(s), float32 | 593.088 +/- 0.142 | 3155.058 +/- 3.491 | 5.320
minimum_position, (4096, 4096), 50 label(s), float32 | 639.306 +/- 0.180 | 3171.415 +/- 6.609 | 4.961
minimum_position, (4096, 4096), 250 label(s), float32 | 718.998 +/- 0.168 | 3160.760 +/- 2.034 | 4.396
median, (128, 128), 1 label(s), float32 | 0.201 +/- 0.005 | 0.181 +/- 0.007 | 0.899
median, (128, 128), 3 label(s), float32 | 1.004 +/- 0.034 | 1.480 +/- 0.051 | 1.474
median, (128, 128), 10 label(s), float32 | 1.594 +/- 0.060 | 1.604 +/- 0.062 | 1.006
median, (128, 128), 20 label(s), float32 | 1.044 +/- 0.032 | 1.674 +/- 0.060 | 1.604
median, (128, 128), 50 label(s), float32 | 1.041 +/- 0.029 | 1.797 +/- 0.075 | 1.726
median, (128, 128), 250 label(s), float32 | 1.047 +/- 0.032 | 1.943 +/- 0.082 | 1.856
median, (512, 512), 1 label(s), float32 | 0.245 +/- 0.004 | 1.743 +/- 0.070 | 7.126
median, (512, 512), 3 label(s), float32 | 1.060 +/- 0.024 | 34.959 +/- 0.557 | 32.991
median, (512, 512), 10 label(s), float32 | 2.759 +/- 0.050 | 36.162 +/- 0.757 | 13.105
median, (512, 512), 20 label(s), float32 | 2.131 +/- 0.029 | 40.135 +/- 0.533 | 18.832
median, (512, 512), 50 label(s), float32 | 2.155 +/- 0.031 | 38.523 +/- 0.511 | 17.873
median, (512, 512), 250 label(s), float32 | 2.190 +/- 0.033 | 44.976 +/- 0.728 | 20.537
median, (4096, 4096), 1 label(s), float32 | 3.926 +/- 0.010 | 148.208 +/- 0.298 | 37.750
median, (4096, 4096), 3 label(s), float32 | 11.785 +/- 0.019 | 5273.267 +/- 2.724 | 447.440
median, (4096, 4096), 10 label(s), float32 | 27.148 +/- 0.031 | 6353.917 +/- 4.015 | 234.044
median, (4096, 4096), 20 label(s), float32 | 584.610 +/- 0.110 | 6627.063 +/- 11.670 | 11.336
median, (4096, 4096), 50 label(s), float32 | 630.643 +/- 0.158 | 6860.015 +/- 104.333 | 10.878
median, (4096, 4096), 250 label(s), float32 | 710.216 +/- 0.174 | 7256.596 +/- 231.432 | 10.217
extrema, (128, 128), 1 label(s), float32 | 0.295 +/- 0.014 | 0.057 +/- 0.002 | 0.194
extrema, (128, 128), 3 label(s), float32 | 1.215 +/- 0.048 | 1.168 +/- 0.029 | 0.961
extrema, (128, 128), 10 label(s), float32 | 2.822 +/- 0.098 | 1.194 +/- 0.044 | 0.423
extrema, (128, 128), 20 label(s), float32 | 1.309 +/- 0.034 | 1.219 +/- 0.041 | 0.931
extrema, (128, 128), 50 label(s), float32 | 1.375 +/- 0.043 | 1.331 +/- 0.064 | 0.968
extrema, (128, 128), 250 label(s), float32 | 1.680 +/- 0.055 | 1.557 +/- 0.040 | 0.926
extrema, (512, 512), 1 label(s), float32 | 0.308 +/- 0.010 | 0.512 +/- 0.013 | 1.663
extrema, (512, 512), 3 label(s), float32 | 1.257 +/- 0.039 | 27.419 +/- 0.626 | 21.814
extrema, (512, 512), 10 label(s), float32 | 3.169 +/- 0.103 | 24.431 +/- 0.316 | 7.710
extrema, (512, 512), 20 label(s), float32 | 2.511 +/- 0.038 | 28.057 +/- 0.647 | 11.172
extrema, (512, 512), 50 label(s), float32 | 2.476 +/- 0.037 | 24.880 +/- 0.800 | 10.049
extrema, (512, 512), 250 label(s), float32 | 2.732 +/- 0.053 | 27.903 +/- 0.232 | 10.215
extrema, (4096, 4096), 1 label(s), float32 | 4.616 +/- 0.006 | 53.373 +/- 0.161 | 11.562
extrema, (4096, 4096), 3 label(s), float32 | 14.073 +/- 0.008 | 3314.508 +/- 9.384 | 235.527
extrema, (4096, 4096), 10 label(s), float32 | 38.322 +/- 0.056 | 3298.009 +/- 8.586 | 86.061
extrema, (4096, 4096), 20 label(s), float32 | 594.268 +/- 0.121 | 3305.532 +/- 4.206 | 5.562
extrema, (4096, 4096), 50 label(s), float32 | 640.676 +/- 0.195 | 3284.168 +/- 5.674 | 5.126
extrema, (4096, 4096), 250 label(s), float32 | 720.301 +/- 0.148 | 3443.132 +/- 195.759 | 4.780
minimum, (128, 128), 1 label(s), float64 | 0.019 +/- 0.003 | 0.011 +/- 0.001 | 0.558
minimum, (128, 128), 3 label(s), float64 | 0.487 +/- 0.024 | 1.061 +/- 0.050 | 2.181
minimum, (128, 128), 10 label(s), float64 | 0.989 +/- 0.038 | 1.012 +/- 0.038 | 1.023
minimum, (128, 128), 20 label(s), float64 | 1.686 +/- 0.064 | 1.046 +/- 0.056 | 0.620
minimum, (128, 128), 50 label(s), float64 | 0.868 +/- 0.025 | 1.032 +/- 0.053 | 1.189
minimum, (128, 128), 250 label(s), float64 | 0.847 +/- 0.026 | 1.059 +/- 0.052 | 1.251
minimum, (512, 512), 1 label(s), float64 | 0.021 +/- 0.001 | 0.120 +/- 0.015 | 5.628
minimum, (512, 512), 3 label(s), float64 | 0.521 +/- 0.018 | 25.987 +/- 0.405 | 49.884
minimum, (512, 512), 10 label(s), float64 | 1.110 +/- 0.036 | 21.769 +/- 0.309 | 19.613
minimum, (512, 512), 20 label(s), float64 | 1.915 +/- 0.057 | 22.944 +/- 0.506 | 11.980
minimum, (512, 512), 50 label(s), float64 | 1.918 +/- 0.022 | 25.340 +/- 0.338 | 13.213
minimum, (512, 512), 250 label(s), float64 | 1.939 +/- 0.021 | 21.618 +/- 0.431 | 11.149
minimum, (4096, 4096), 1 label(s), float64 | 0.395 +/- 0.003 | 9.690 +/- 0.027 | 24.525
minimum, (4096, 4096), 3 label(s), float64 | 8.191 +/- 0.014 | 3183.131 +/- 11.774 | 388.610
minimum, (4096, 4096), 10 label(s), float64 | 21.647 +/- 0.015 | 3160.413 +/- 9.960 | 145.999
minimum, (4096, 4096), 20 label(s), float64 | 40.058 +/- 0.024 | 3139.683 +/- 8.620 | 78.378
minimum, (4096, 4096), 50 label(s), float64 | 630.422 +/- 0.120 | 3167.822 +/- 13.648 | 5.025
minimum, (4096, 4096), 250 label(s), float64 | 710.062 +/- 0.161 | 3157.583 +/- 8.000 | 4.447
minimum_position, (128, 128), 1 label(s), float64 | 0.164 +/- 0.009 | 0.044 +/- 0.003 | 0.269
minimum_position, (128, 128), 3 label(s), float64 | 0.832 +/- 0.033 | 1.092 +/- 0.049 | 1.312
minimum_position, (128, 128), 10 label(s), float64 | 1.951 +/- 0.084 | 1.153 +/- 0.049 | 0.591
minimum_position, (128, 128), 20 label(s), float64 | 0.990 +/- 0.025 | 1.109 +/- 0.049 | 1.120
minimum_position, (128, 128), 50 label(s), float64 | 1.013 +/- 0.058 | 1.144 +/- 0.050 | 1.129
minimum_position, (128, 128), 250 label(s), float64 | 1.180 +/- 0.034 | 1.274 +/- 0.036 | 1.080
minimum_position, (512, 512), 1 label(s), float64 | 0.174 +/- 0.018 | 0.425 +/- 0.013 | 2.437
minimum_position, (512, 512), 3 label(s), float64 | 0.894 +/- 0.034 | 27.082 +/- 0.457 | 30.278
minimum_position, (512, 512), 10 label(s), float64 | 2.118 +/- 0.090 | 26.677 +/- 0.739 | 12.597
minimum_position, (512, 512), 20 label(s), float64 | 2.151 +/- 0.047 | 27.846 +/- 0.509 | 12.943
minimum_position, (512, 512), 50 label(s), float64 | 2.100 +/- 0.021 | 27.802 +/- 0.857 | 13.238
minimum_position, (512, 512), 250 label(s), float64 | 2.238 +/- 0.027 | 26.308 +/- 0.536 | 11.754
minimum_position, (4096, 4096), 1 label(s), float64 | 2.591 +/- 0.007 | 40.396 +/- 0.622 | 15.593
minimum_position, (4096, 4096), 3 label(s), float64 | 14.267 +/- 0.029 | 3390.595 +/- 11.354 | 237.647
minimum_position, (4096, 4096), 10 label(s), float64 | 38.180 +/- 0.026 | 3420.956 +/- 5.685 | 89.600
minimum_position, (4096, 4096), 20 label(s), float64 | 593.677 +/- 0.153 | 3482.196 +/- 5.058 | 5.865
minimum_position, (4096, 4096), 50 label(s), float64 | 639.859 +/- 0.122 | 3492.002 +/- 11.419 | 5.457
minimum_position, (4096, 4096), 250 label(s), float64 | 719.533 +/- 0.166 | 3617.449 +/- 17.395 | 5.027
median, (128, 128), 1 label(s), float64 | 0.365 +/- 0.002 | 0.155 +/- 0.008 | 0.424
median, (128, 128), 3 label(s), float64 | 1.325 +/- 0.062 | 1.542 +/- 0.048 | 1.164
median, (128, 128), 10 label(s), float64 | 1.706 +/- 0.043 | 1.608 +/- 0.034 | 0.943
median, (128, 128), 20 label(s), float64 | 1.059 +/- 0.055 | 1.669 +/- 0.035 | 1.576
median, (128, 128), 50 label(s), float64 | 1.064 +/- 0.032 | 1.778 +/- 0.028 | 1.671
median, (128, 128), 250 label(s), float64 | 1.047 +/- 0.018 | 1.973 +/- 0.091 | 1.883
median, (512, 512), 1 label(s), float64 | 0.625 +/- 0.003 | 1.868 +/- 0.072 | 2.992
median, (512, 512), 3 label(s), float64 | 1.401 +/- 0.012 | 38.262 +/- 1.137 | 27.311
median, (512, 512), 10 label(s), float64 | 3.807 +/- 0.021 | 39.979 +/- 0.675 | 10.503
median, (512, 512), 20 label(s), float64 | 2.105 +/- 0.022 | 39.652 +/- 1.041 | 18.841
median, (512, 512), 50 label(s), float64 | 2.134 +/- 0.023 | 47.395 +/- 1.214 | 22.205
median, (512, 512), 250 label(s), float64 | 2.161 +/- 0.023 | 45.742 +/- 2.083 | 21.170
median, (4096, 4096), 1 label(s), float64 | 13.585 +/- 0.029 | 117.393 +/- 0.686 | 8.641
median, (4096, 4096), 3 label(s), float64 | 22.211 +/- 0.043 | 5678.912 +/- 65.777 | 255.684
median, (4096, 4096), 10 label(s), float64 | 38.768 +/- 0.073 | 6775.513 +/- 108.016 | 174.769
median, (4096, 4096), 20 label(s), float64 | 585.379 +/- 0.163 | 7219.004 +/- 66.142 | 12.332
median, (4096, 4096), 50 label(s), float64 | 631.470 +/- 0.181 | 7219.726 +/- 46.216 | 11.433
median, (4096, 4096), 250 label(s), float64 | 710.896 +/- 0.173 | 7668.915 +/- 41.181 | 10.788
extrema, (128, 128), 1 label(s), float64 | 0.303 +/- 0.010 | 0.070 +/- 0.002 | 0.232
extrema, (128, 128), 3 label(s), float64 | 1.250 +/- 0.032 | 1.252 +/- 0.040 | 1.001
extrema, (128, 128), 10 label(s), float64 | 3.030 +/- 0.063 | 1.300 +/- 0.031 | 0.429
extrema, (128, 128), 20 label(s), float64 | 1.371 +/- 0.028 | 1.315 +/- 0.039 | 0.959
extrema, (128, 128), 50 label(s), float64 | 1.415 +/- 0.030 | 1.319 +/- 0.042 | 0.933
extrema, (128, 128), 250 label(s), float64 | 1.731 +/- 0.036 | 1.644 +/- 0.035 | 0.949
extrema, (512, 512), 1 label(s), float64 | 0.314 +/- 0.010 | 0.925 +/- 0.024 | 2.949
extrema, (512, 512), 3 label(s), float64 | 1.308 +/- 0.028 | 30.702 +/- 0.720 | 23.479
extrema, (512, 512), 10 label(s), float64 | 3.231 +/- 0.048 | 29.472 +/- 0.903 | 9.122
extrema, (512, 512), 20 label(s), float64 | 2.555 +/- 0.024 | 32.602 +/- 0.434 | 12.761
extrema, (512, 512), 50 label(s), float64 | 2.446 +/- 0.026 | 31.301 +/- 1.149 | 12.798
extrema, (512, 512), 250 label(s), float64 | 2.813 +/- 0.030 | 29.488 +/- 0.676 | 10.481
extrema, (4096, 4096), 1 label(s), float64 | 5.585 +/- 0.009 | 83.510 +/- 0.195 | 14.951
extrema, (4096, 4096), 3 label(s), float64 | 15.609 +/- 0.015 | 3624.759 +/- 2.386 | 232.227
extrema, (4096, 4096), 10 label(s), float64 | 40.461 +/- 0.747 | 3596.510 +/- 8.781 | 88.888
extrema, (4096, 4096), 20 label(s), float64 | 595.259 +/- 0.177 | 3632.189 +/- 27.802 | 6.102
extrema, (4096, 4096), 50 label(s), float64 | 641.282 +/- 0.112 | 3735.056 +/- 136.146 | 5.824
extrema, (4096, 4096), 250 label(s), float64 | 721.172 +/- 0.150 | 3919.400 +/- 67.531 | 5.435

</details>


<details><summary>Benchmarks with CUB disabled</summary>

## Benchmarking functions from cupyx.scipy.ndimage.measurements
shape | GPU time (ms) | CPU time (ms) | acceleration
------|---------------|---------------|-------------
minimum, (128, 128), 1 label(s), uint8 | 0.062 +/- 0.019 | 0.026 +/- 0.001 | 0.426
minimum, (128, 128), 3 label(s), uint8 | 0.789 +/- 0.020 | 0.332 +/- 0.010 | 0.421
minimum, (128, 128), 10 label(s), uint8 | 0.787 +/- 0.017 | 0.333 +/- 0.012 | 0.424
minimum, (128, 128), 20 label(s), uint8 | 0.796 +/- 0.017 | 0.334 +/- 0.010 | 0.420
minimum, (128, 128), 50 label(s), uint8 | 0.785 +/- 0.016 | 0.300 +/- 0.007 | 0.383
minimum, (128, 128), 250 label(s), uint8 | 0.796 +/- 0.021 | 0.331 +/- 0.011 | 0.415
minimum, (512, 512), 1 label(s), uint8 | 0.029 +/- 0.001 | 0.202 +/- 0.002 | 6.968
minimum, (512, 512), 3 label(s), uint8 | 1.612 +/- 0.011 | 5.575 +/- 0.122 | 3.459
minimum, (512, 512), 10 label(s), uint8 | 1.563 +/- 0.014 | 5.461 +/- 0.080 | 3.495
minimum, (512, 512), 20 label(s), uint8 | 1.605 +/- 0.016 | 5.777 +/- 0.093 | 3.601
minimum, (512, 512), 50 label(s), uint8 | 1.666 +/- 0.023 | 5.503 +/- 0.186 | 3.302
minimum, (512, 512), 250 label(s), uint8 | 1.708 +/- 0.015 | 5.607 +/- 0.089 | 3.283
minimum, (4096, 4096), 1 label(s), uint8 | 0.207 +/- 0.004 | 12.131 +/- 0.131 | 58.609
minimum, (4096, 4096), 3 label(s), uint8 | 70.457 +/- 0.047 | 509.351 +/- 1.599 | 7.229
minimum, (4096, 4096), 10 label(s), uint8 | 81.531 +/- 0.055 | 517.564 +/- 0.549 | 6.348
minimum, (4096, 4096), 20 label(s), uint8 | 88.300 +/- 0.073 | 516.102 +/- 1.295 | 5.845
minimum, (4096, 4096), 50 label(s), uint8 | 100.484 +/- 0.153 | 519.178 +/- 0.907 | 5.167
minimum, (4096, 4096), 250 label(s), uint8 | 138.271 +/- 0.107 | 531.120 +/- 0.289 | 3.841
minimum_position, (128, 128), 1 label(s), uint8 | 0.187 +/- 0.006 | 0.095 +/- 0.005 | 0.509
minimum_position, (128, 128), 3 label(s), uint8 | 0.871 +/- 0.021 | 0.403 +/- 0.009 | 0.462
minimum_position, (128, 128), 10 label(s), uint8 | 0.872 +/- 0.045 | 0.373 +/- 0.015 | 0.428
minimum_position, (128, 128), 20 label(s), uint8 | 0.876 +/- 0.020 | 0.390 +/- 0.013 | 0.446
minimum_position, (128, 128), 50 label(s), uint8 | 0.934 +/- 0.114 | 0.425 +/- 0.013 | 0.455
minimum_position, (128, 128), 250 label(s), uint8 | 1.072 +/- 0.046 | 0.586 +/- 0.016 | 0.546
minimum_position, (512, 512), 1 label(s), uint8 | 0.182 +/- 0.008 | 1.034 +/- 0.018 | 5.689
minimum_position, (512, 512), 3 label(s), uint8 | 1.575 +/- 0.015 | 6.183 +/- 0.153 | 3.926
minimum_position, (512, 512), 10 label(s), uint8 | 1.689 +/- 0.019 | 6.139 +/- 0.108 | 3.635
minimum_position, (512, 512), 20 label(s), uint8 | 1.737 +/- 0.021 | 6.225 +/- 0.204 | 3.583
minimum_position, (512, 512), 50 label(s), uint8 | 1.809 +/- 0.019 | 6.317 +/- 0.217 | 3.493
minimum_position, (512, 512), 250 label(s), uint8 | 2.043 +/- 0.030 | 6.371 +/- 0.231 | 3.119
minimum_position, (4096, 4096), 1 label(s), uint8 | 2.986 +/- 0.004 | 82.225 +/- 0.638 | 27.535
minimum_position, (4096, 4096), 3 label(s), uint8 | 73.000 +/- 0.073 | 603.841 +/- 3.270 | 8.272
minimum_position, (4096, 4096), 10 label(s), uint8 | 84.749 +/- 0.092 | 583.467 +/- 0.348 | 6.885
minimum_position, (4096, 4096), 20 label(s), uint8 | 91.916 +/- 0.073 | 602.104 +/- 1.646 | 6.551
minimum_position, (4096, 4096), 50 label(s), uint8 | 105.420 +/- 0.080 | 598.163 +/- 1.365 | 5.674
minimum_position, (4096, 4096), 250 label(s), uint8 | 146.154 +/- 0.102 | 602.782 +/- 0.677 | 4.124
median, (128, 128), 1 label(s), uint8 | 0.076 +/- 0.005 | 0.079 +/- 0.003 | 1.040
median, (128, 128), 3 label(s), uint8 | 1.017 +/- 0.026 | 0.623 +/- 0.016 | 0.613
median, (128, 128), 10 label(s), uint8 | 1.044 +/- 0.022 | 0.733 +/- 0.021 | 0.702
median, (128, 128), 20 label(s), uint8 | 1.052 +/- 0.025 | 0.780 +/- 0.020 | 0.742
median, (128, 128), 50 label(s), uint8 | 1.046 +/- 0.024 | 0.894 +/- 0.036 | 0.855
median, (128, 128), 250 label(s), uint8 | 1.073 +/- 0.020 | 1.054 +/- 0.037 | 0.983
median, (512, 512), 1 label(s), uint8 | 0.076 +/- 0.004 | 0.962 +/- 0.020 | 12.668
median, (512, 512), 3 label(s), uint8 | 1.852 +/- 0.021 | 10.818 +/- 0.271 | 5.841
median, (512, 512), 10 label(s), uint8 | 1.891 +/- 0.019 | 13.819 +/- 0.173 | 7.308
median, (512, 512), 20 label(s), uint8 | 1.944 +/- 0.035 | 15.229 +/- 0.183 | 7.835
median, (512, 512), 50 label(s), uint8 | 1.907 +/- 0.018 | 16.650 +/- 0.270 | 8.729
median, (512, 512), 250 label(s), uint8 | 1.984 +/- 0.030 | 19.276 +/- 0.229 | 9.715
median, (4096, 4096), 1 label(s), uint8 | 0.746 +/- 0.002 | 49.891 +/- 0.886 | 66.889
median, (4096, 4096), 3 label(s), uint8 | 71.731 +/- 0.075 | 1106.967 +/- 0.743 | 15.432
median, (4096, 4096), 10 label(s), uint8 | 82.884 +/- 0.044 | 1750.780 +/- 1.801 | 21.123
median, (4096, 4096), 20 label(s), uint8 | 89.678 +/- 0.068 | 2033.212 +/- 1.125 | 22.672
median, (4096, 4096), 50 label(s), uint8 | 101.813 +/- 0.070 | 2307.480 +/- 3.257 | 22.664
median, (4096, 4096), 250 label(s), uint8 | 139.470 +/- 0.121 | 2804.701 +/- 2.290 | 20.110
extrema, (128, 128), 1 label(s), uint8 | 0.349 +/- 0.012 | 0.139 +/- 0.006 | 0.397
extrema, (128, 128), 3 label(s), uint8 | 1.247 +/- 0.028 | 0.518 +/- 0.018 | 0.415
extrema, (128, 128), 10 label(s), uint8 | 1.263 +/- 0.029 | 0.524 +/- 0.018 | 0.415
extrema, (128, 128), 20 label(s), uint8 | 1.285 +/- 0.030 | 0.554 +/- 0.021 | 0.431
extrema, (128, 128), 50 label(s), uint8 | 1.335 +/- 0.032 | 0.599 +/- 0.024 | 0.449
extrema, (128, 128), 250 label(s), uint8 | 1.661 +/- 0.039 | 0.915 +/- 0.031 | 0.551
extrema, (512, 512), 1 label(s), uint8 | 0.354 +/- 0.009 | 1.594 +/- 0.021 | 4.498
extrema, (512, 512), 3 label(s), uint8 | 2.061 +/- 0.031 | 8.148 +/- 0.268 | 3.954
extrema, (512, 512), 10 label(s), uint8 | 2.114 +/- 0.029 | 7.972 +/- 0.138 | 3.770
extrema, (512, 512), 20 label(s), uint8 | 2.177 +/- 0.024 | 8.002 +/- 0.148 | 3.676
extrema, (512, 512), 50 label(s), uint8 | 2.207 +/- 0.026 | 7.958 +/- 0.183 | 3.606
extrema, (512, 512), 250 label(s), uint8 | 2.584 +/- 0.039 | 8.370 +/- 0.175 | 3.239
extrema, (4096, 4096), 1 label(s), uint8 | 5.311 +/- 0.006 | 116.425 +/- 0.326 | 21.920
extrema, (4096, 4096), 3 label(s), uint8 | 74.785 +/- 0.055 | 746.252 +/- 1.281 | 9.979
extrema, (4096, 4096), 10 label(s), uint8 | 86.481 +/- 0.074 | 745.931 +/- 1.953 | 8.625
extrema, (4096, 4096), 20 label(s), uint8 | 93.721 +/- 0.050 | 719.261 +/- 2.581 | 7.674
extrema, (4096, 4096), 50 label(s), uint8 | 107.204 +/- 0.106 | 744.951 +/- 2.016 | 6.949
extrema, (4096, 4096), 250 label(s), uint8 | 148.176 +/- 0.093 | 739.215 +/- 1.904 | 4.989
minimum, (128, 128), 1 label(s), float32 | 0.028 +/- 0.002 | 0.009 +/- 0.001 | 0.327
minimum, (128, 128), 3 label(s), float32 | 0.866 +/- 0.017 | 1.059 +/- 0.025 | 1.223
minimum, (128, 128), 10 label(s), float32 | 0.865 +/- 0.017 | 1.066 +/- 0.033 | 1.232
minimum, (128, 128), 20 label(s), float32 | 0.866 +/- 0.016 | 1.049 +/- 0.027 | 1.212
minimum, (128, 128), 50 label(s), float32 | 0.864 +/- 0.016 | 1.055 +/- 0.024 | 1.221
minimum, (128, 128), 250 label(s), float32 | 0.869 +/- 0.016 | 1.059 +/- 0.024 | 1.218
minimum, (512, 512), 1 label(s), float32 | 0.030 +/- 0.004 | 0.053 +/- 0.007 | 1.804
minimum, (512, 512), 3 label(s), float32 | 1.857 +/- 0.016 | 22.961 +/- 0.212 | 12.364
minimum, (512, 512), 10 label(s), float32 | 1.903 +/- 0.017 | 22.922 +/- 0.295 | 12.045
minimum, (512, 512), 20 label(s), float32 | 1.914 +/- 0.014 | 22.599 +/- 0.330 | 11.805
minimum, (512, 512), 50 label(s), float32 | 1.940 +/- 0.014 | 22.946 +/- 0.328 | 11.828
minimum, (512, 512), 250 label(s), float32 | 1.978 +/- 0.021 | 22.461 +/- 0.225 | 11.357
minimum, (4096, 4096), 1 label(s), float32 | 0.266 +/- 0.001 | 4.990 +/- 0.035 | 18.750
minimum, (4096, 4096), 3 label(s), float32 | 478.461 +/- 0.114 | 2935.406 +/- 8.907 | 6.135
minimum, (4096, 4096), 10 label(s), float32 | 548.396 +/- 0.151 | 2977.433 +/- 11.044 | 5.429
minimum, (4096, 4096), 20 label(s), float32 | 584.215 +/- 0.149 | 2935.385 +/- 3.199 | 5.024
minimum, (4096, 4096), 50 label(s), float32 | 630.434 +/- 0.133 | 3026.772 +/- 95.486 | 4.801
minimum, (4096, 4096), 250 label(s), float32 | 709.735 +/- 0.141 | 2947.944 +/- 3.468 | 4.154
minimum_position, (128, 128), 1 label(s), float32 | 0.181 +/- 0.007 | 0.041 +/- 0.003 | 0.229
minimum_position, (128, 128), 3 label(s), float32 | 1.028 +/- 0.020 | 1.174 +/- 0.022 | 1.141
minimum_position, (128, 128), 10 label(s), float32 | 1.041 +/- 0.020 | 1.123 +/- 0.024 | 1.079
minimum_position, (128, 128), 20 label(s), float32 | 1.038 +/- 0.016 | 1.155 +/- 0.034 | 1.113
minimum_position, (128, 128), 50 label(s), float32 | 1.074 +/- 0.021 | 1.186 +/- 0.033 | 1.105
minimum_position, (128, 128), 250 label(s), float32 | 1.236 +/- 0.023 | 1.346 +/- 0.043 | 1.089
minimum_position, (512, 512), 1 label(s), float32 | 0.183 +/- 0.008 | 0.325 +/- 0.012 | 1.777
minimum_position, (512, 512), 3 label(s), float32 | 2.122 +/- 0.039 | 27.382 +/- 0.761 | 12.902
minimum_position, (512, 512), 10 label(s), float32 | 2.108 +/- 0.017 | 27.460 +/- 0.942 | 13.028
minimum_position, (512, 512), 20 label(s), float32 | 2.044 +/- 0.018 | 26.858 +/- 0.583 | 13.141
minimum_position, (512, 512), 50 label(s), float32 | 2.089 +/- 0.017 | 27.560 +/- 0.735 | 13.193
minimum_position, (512, 512), 250 label(s), float32 | 2.288 +/- 0.022 | 26.540 +/- 0.306 | 11.599
minimum_position, (4096, 4096), 1 label(s), float32 | 2.390 +/- 0.004 | 30.963 +/- 0.076 | 12.958
minimum_position, (4096, 4096), 3 label(s), float32 | 487.839 +/- 0.077 | 3254.241 +/- 4.620 | 6.671
minimum_position, (4096, 4096), 10 label(s), float32 | 557.708 +/- 0.115 | 3231.190 +/- 3.147 | 5.794
minimum_position, (4096, 4096), 20 label(s), float32 | 593.588 +/- 0.137 | 3233.457 +/- 43.831 | 5.447
minimum_position, (4096, 4096), 50 label(s), float32 | 639.394 +/- 0.096 | 3302.676 +/- 113.337 | 5.165
minimum_position, (4096, 4096), 250 label(s), float32 | 719.251 +/- 0.125 | 3184.996 +/- 7.010 | 4.428
median, (128, 128), 1 label(s), float32 | 0.178 +/- 0.005 | 0.195 +/- 0.011 | 1.097
median, (128, 128), 3 label(s), float32 | 1.076 +/- 0.034 | 1.487 +/- 0.067 | 1.383
median, (128, 128), 10 label(s), float32 | 1.072 +/- 0.030 | 1.639 +/- 0.072 | 1.529
median, (128, 128), 20 label(s), float32 | 1.079 +/- 0.035 | 1.676 +/- 0.070 | 1.553
median, (128, 128), 50 label(s), float32 | 1.075 +/- 0.034 | 1.748 +/- 0.071 | 1.626
median, (128, 128), 250 label(s), float32 | 1.078 +/- 0.035 | 1.899 +/- 0.061 | 1.761
median, (512, 512), 1 label(s), float32 | 0.233 +/- 0.003 | 2.617 +/- 0.109 | 11.235
median, (512, 512), 3 label(s), float32 | 2.059 +/- 0.027 | 35.018 +/- 0.804 | 17.006
median, (512, 512), 10 label(s), float32 | 2.108 +/- 0.034 | 36.337 +/- 0.430 | 17.239
median, (512, 512), 20 label(s), float32 | 2.114 +/- 0.027 | 40.095 +/- 1.064 | 18.963
median, (512, 512), 50 label(s), float32 | 2.140 +/- 0.031 | 39.660 +/- 0.501 | 18.530
median, (512, 512), 250 label(s), float32 | 2.184 +/- 0.028 | 45.479 +/- 1.014 | 20.828
median, (4096, 4096), 1 label(s), float32 | 3.917 +/- 0.008 | 165.721 +/- 0.851 | 42.308
median, (4096, 4096), 3 label(s), float32 | 479.506 +/- 0.132 | 5269.632 +/- 15.430 | 10.990
median, (4096, 4096), 10 label(s), float32 | 549.200 +/- 0.147 | 6350.075 +/- 3.873 | 11.562
median, (4096, 4096), 20 label(s), float32 | 585.189 +/- 0.156 | 6608.177 +/- 6.398 | 11.292
median, (4096, 4096), 50 label(s), float32 | 631.149 +/- 0.131 | 6842.523 +/- 8.818 | 10.841
median, (4096, 4096), 250 label(s), float32 | 710.840 +/- 0.117 | 7027.807 +/- 8.522 | 9.887
extrema, (128, 128), 1 label(s), float32 | 0.335 +/- 0.017 | 0.057 +/- 0.002 | 0.170
extrema, (128, 128), 3 label(s), float32 | 1.351 +/- 0.038 | 1.215 +/- 0.046 | 0.900
extrema, (128, 128), 10 label(s), float32 | 1.366 +/- 0.039 | 1.235 +/- 0.066 | 0.904
extrema, (128, 128), 20 label(s), float32 | 1.382 +/- 0.038 | 1.227 +/- 0.039 | 0.887
extrema, (128, 128), 50 label(s), float32 | 1.433 +/- 0.039 | 1.304 +/- 0.056 | 0.910
extrema, (128, 128), 250 label(s), float32 | 1.757 +/- 0.059 | 1.630 +/- 0.064 | 0.928
extrema, (512, 512), 1 label(s), float32 | 0.359 +/- 0.014 | 0.536 +/- 0.019 | 1.493
extrema, (512, 512), 3 label(s), float32 | 2.495 +/- 0.054 | 28.378 +/- 0.860 | 11.373
extrema, (512, 512), 10 label(s), float32 | 2.444 +/- 0.039 | 27.749 +/- 0.493 | 11.352
extrema, (512, 512), 20 label(s), float32 | 2.393 +/- 0.037 | 28.575 +/- 1.046 | 11.941
extrema, (512, 512), 50 label(s), float32 | 2.457 +/- 0.036 | 28.049 +/- 0.449 | 11.418
extrema, (512, 512), 250 label(s), float32 | 2.798 +/- 0.049 | 28.723 +/- 0.395 | 10.265
extrema, (4096, 4096), 1 label(s), float32 | 4.906 +/- 0.005 | 53.857 +/- 0.428 | 10.977
extrema, (4096, 4096), 3 label(s), float32 | 489.514 +/- 0.130 | 3284.738 +/- 4.903 | 6.710
extrema, (4096, 4096), 10 label(s), float32 | 559.327 +/- 0.156 | 3285.103 +/- 3.156 | 5.873
extrema, (4096, 4096), 20 label(s), float32 | 595.260 +/- 0.168 | 3293.480 +/- 5.269 | 5.533
extrema, (4096, 4096), 50 label(s), float32 | 641.127 +/- 0.131 | 3296.862 +/- 1.286 | 5.142
extrema, (4096, 4096), 250 label(s), float32 | 721.043 +/- 0.152 | 3316.078 +/- 4.053 | 4.599
minimum, (128, 128), 1 label(s), float64 | 0.028 +/- 0.003 | 0.011 +/- 0.002 | 0.401
minimum, (128, 128), 3 label(s), float64 | 0.846 +/- 0.024 | 1.019 +/- 0.033 | 1.205
minimum, (128, 128), 10 label(s), float64 | 0.851 +/- 0.024 | 1.098 +/- 0.032 | 1.289
minimum, (128, 128), 20 label(s), float64 | 0.860 +/- 0.031 | 1.006 +/- 0.034 | 1.170
minimum, (128, 128), 50 label(s), float64 | 0.843 +/- 0.021 | 1.028 +/- 0.040 | 1.220
minimum, (128, 128), 250 label(s), float64 | 0.856 +/- 0.025 | 1.070 +/- 0.045 | 1.249
minimum, (512, 512), 1 label(s), float64 | 0.035 +/- 0.001 | 0.124 +/- 0.014 | 3.557
minimum, (512, 512), 3 label(s), float64 | 1.848 +/- 0.022 | 24.768 +/- 0.354 | 13.406
minimum, (512, 512), 10 label(s), float64 | 1.881 +/- 0.023 | 21.841 +/- 0.564 | 11.610
minimum, (512, 512), 20 label(s), float64 | 1.902 +/- 0.022 | 23.530 +/- 0.356 | 12.372
minimum, (512, 512), 50 label(s), float64 | 1.928 +/- 0.026 | 24.892 +/- 1.034 | 12.913
minimum, (512, 512), 250 label(s), float64 | 1.950 +/- 0.021 | 22.834 +/- 0.371 | 11.712
minimum, (4096, 4096), 1 label(s), float64 | 0.711 +/- 0.003 | 9.792 +/- 0.028 | 13.772
minimum, (4096, 4096), 3 label(s), float64 | 479.107 +/- 0.100 | 3149.443 +/- 7.022 | 6.574
minimum, (4096, 4096), 10 label(s), float64 | 548.869 +/- 0.132 | 3140.737 +/- 1.931 | 5.722
minimum, (4096, 4096), 20 label(s), float64 | 584.924 +/- 0.155 | 3140.433 +/- 4.931 | 5.369
minimum, (4096, 4096), 50 label(s), float64 | 630.915 +/- 0.133 | 3148.790 +/- 8.580 | 4.991
minimum, (4096, 4096), 250 label(s), float64 | 710.445 +/- 0.136 | 3143.795 +/- 1.151 | 4.425
minimum_position, (128, 128), 1 label(s), float64 | 0.176 +/- 0.009 | 0.043 +/- 0.004 | 0.245
minimum_position, (128, 128), 3 label(s), float64 | 1.014 +/- 0.029 | 1.141 +/- 0.047 | 1.125
minimum_position, (128, 128), 10 label(s), float64 | 1.023 +/- 0.029 | 1.170 +/- 0.014 | 1.144
minimum_position, (128, 128), 20 label(s), float64 | 1.024 +/- 0.027 | 1.095 +/- 0.050 | 1.070
minimum_position, (128, 128), 50 label(s), float64 | 1.049 +/- 0.030 | 1.208 +/- 0.020 | 1.151
minimum_position, (128, 128), 250 label(s), float64 | 1.210 +/- 0.036 | 1.300 +/- 0.059 | 1.074
minimum_position, (512, 512), 1 label(s), float64 | 0.184 +/- 0.008 | 0.421 +/- 0.010 | 2.285
minimum_position, (512, 512), 3 label(s), float64 | 2.131 +/- 0.023 | 28.276 +/- 0.514 | 13.271
minimum_position, (512, 512), 10 label(s), float64 | 2.072 +/- 0.046 | 26.877 +/- 0.680 | 12.970
minimum_position, (512, 512), 20 label(s), float64 | 2.031 +/- 0.025 | 27.607 +/- 0.654 | 13.593
minimum_position, (512, 512), 50 label(s), float64 | 2.087 +/- 0.027 | 27.556 +/- 0.548 | 13.206
minimum_position, (512, 512), 250 label(s), float64 | 2.260 +/- 0.029 | 26.806 +/- 0.642 | 11.861
minimum_position, (4096, 4096), 1 label(s), float64 | 2.898 +/- 0.008 | 40.329 +/- 0.561 | 13.914
minimum_position, (4096, 4096), 3 label(s), float64 | 488.189 +/- 0.109 | 3402.613 +/- 4.892 | 6.970
minimum_position, (4096, 4096), 10 label(s), float64 | 558.031 +/- 0.141 | 3405.161 +/- 6.970 | 6.102
minimum_position, (4096, 4096), 20 label(s), float64 | 594.274 +/- 0.132 | 3397.838 +/- 13.272 | 5.718
minimum_position, (4096, 4096), 50 label(s), float64 | 640.188 +/- 0.112 | 3389.150 +/- 3.211 | 5.294
minimum_position, (4096, 4096), 250 label(s), float64 | 720.060 +/- 0.122 | 3397.430 +/- 7.910 | 4.718
median, (128, 128), 1 label(s), float64 | 0.310 +/- 0.003 | 0.155 +/- 0.007 | 0.501
median, (128, 128), 3 label(s), float64 | 1.067 +/- 0.031 | 1.438 +/- 0.052 | 1.347
median, (128, 128), 10 label(s), float64 | 1.083 +/- 0.035 | 1.608 +/- 0.066 | 1.485
median, (128, 128), 20 label(s), float64 | 1.079 +/- 0.034 | 1.612 +/- 0.063 | 1.494
median, (128, 128), 50 label(s), float64 | 1.075 +/- 0.036 | 1.726 +/- 0.067 | 1.605
median, (128, 128), 250 label(s), float64 | 1.069 +/- 0.029 | 1.849 +/- 0.053 | 1.729
median, (512, 512), 1 label(s), float64 | 0.625 +/- 0.003 | 2.512 +/- 0.105 | 4.022
median, (512, 512), 3 label(s), float64 | 2.092 +/- 0.044 | 34.876 +/- 0.442 | 16.670
median, (512, 512), 10 label(s), float64 | 2.106 +/- 0.030 | 37.116 +/- 0.268 | 17.621
median, (512, 512), 20 label(s), float64 | 2.147 +/- 0.036 | 38.251 +/- 0.846 | 17.813
median, (512, 512), 50 label(s), float64 | 2.177 +/- 0.038 | 43.476 +/- 0.987 | 19.966
median, (512, 512), 250 label(s), float64 | 2.202 +/- 0.028 | 43.599 +/- 0.674 | 19.802
median, (4096, 4096), 1 label(s), float64 | 13.561 +/- 0.026 | 161.115 +/- 0.893 | 11.881
median, (4096, 4096), 3 label(s), float64 | 480.065 +/- 0.114 | 5532.959 +/- 47.214 | 11.525
median, (4096, 4096), 10 label(s), float64 | 550.025 +/- 0.147 | 6756.991 +/- 32.754 | 12.285
median, (4096, 4096), 20 label(s), float64 | 585.900 +/- 0.120 | 6942.795 +/- 27.466 | 11.850
median, (4096, 4096), 50 label(s), float64 | 631.976 +/- 0.159 | 7134.392 +/- 48.028 | 11.289
median, (4096, 4096), 250 label(s), float64 | 711.436 +/- 0.120 | 7414.999 +/- 31.842 | 10.423
extrema, (128, 128), 1 label(s), float64 | 0.354 +/- 0.008 | 0.076 +/- 0.004 | 0.213
extrema, (128, 128), 3 label(s), float64 | 1.515 +/- 0.245 | 1.276 +/- 0.026 | 0.842
extrema, (128, 128), 10 label(s), float64 | 1.430 +/- 0.032 | 1.298 +/- 0.018 | 0.907
extrema, (128, 128), 20 label(s), float64 | 1.435 +/- 0.049 | 1.271 +/- 0.055 | 0.886
extrema, (128, 128), 50 label(s), float64 | 1.448 +/- 0.047 | 1.299 +/- 0.058 | 0.897
extrema, (128, 128), 250 label(s), float64 | 1.737 +/- 0.048 | 1.583 +/- 0.061 | 0.911
extrema, (512, 512), 1 label(s), float64 | 0.349 +/- 0.010 | 0.917 +/- 0.021 | 2.627
extrema, (512, 512), 3 label(s), float64 | 2.476 +/- 0.031 | 29.470 +/- 0.534 | 11.903
extrema, (512, 512), 10 label(s), float64 | 2.468 +/- 0.068 | 28.377 +/- 0.463 | 11.499
extrema, (512, 512), 20 label(s), float64 | 2.387 +/- 0.040 | 30.839 +/- 0.950 | 12.917
extrema, (512, 512), 50 label(s), float64 | 2.505 +/- 0.044 | 31.942 +/- 1.889 | 12.753
extrema, (512, 512), 250 label(s), float64 | 2.891 +/- 0.040 | 31.087 +/- 0.783 | 10.754
extrema, (4096, 4096), 1 label(s), float64 | 6.823 +/- 0.010 | 82.669 +/- 0.223 | 12.117
extrema, (4096, 4096), 3 label(s), float64 | 489.998 +/- 0.105 | 3602.180 +/- 16.469 | 7.351
extrema, (4096, 4096), 10 label(s), float64 | 559.752 +/- 0.091 | 3593.659 +/- 14.911 | 6.420
extrema, (4096, 4096), 20 label(s), float64 | 595.850 +/- 0.104 | 3596.999 +/- 29.365 | 6.037
extrema, (4096, 4096), 50 label(s), float64 | 642.150 +/- 0.172 | 3811.386 +/- 84.474 | 5.935
extrema, (4096, 4096), 250 label(s), float64 | 721.902 +/- 0.208 | 3668.821 +/- 27.579 | 5.082

</details>



<details><summary>Benchmark script</summary>

```Python
import numpy as np
import scipy.stats

import cupy
import cupyx.scipy.ndimage
import scipy.ndimage
from cupyx.time import repeat

use_cub = True
if use_cub:
    cupy.core.set_routine_accelerators(['cub'])
else:
    cupy.core.set_routine_accelerators([])

print("## Benchmarking functions from cupyx.scipy.ndimage.measurements")
print("shape | GPU time (ms) | CPU time (ms) | acceleration")
print("------|---------------|---------------|-------------")

for dtype in [np.uint8, np.float32, np.float64]:
    for func in ['minimum', 'minimum_position', 'median', 'extrema']:
        for shape in [(128, 128), (512, 512), (4096, 4096)]:
            for nlabels in [1, 3, 10, 20, 50, 250]:
                # shape = (1024, 1024)
                size = np.prod(shape)
                image = cupy.random.standard_normal(shape).astype(dtype)
                image_cpu = image.get()
                if nlabels == 1:
                    labels = index = None
                    labels_cpu = index_cpu = None
                else:
                    labels = cupy.random.choice(nlabels, shape) + 1
                    index = cupy.arange(1, nlabels + 1, dtype=np.intp)

                    labels_cpu = labels.get()
                    index_cpu = index.get()
                if size < 20000:
                    n_base = 32
                elif size < 1000000:
                    n_base = 8
                else:
                    n_base = 3

                func_gpu = getattr(cupyx.scipy.ndimage, func)
                perf_gpu = repeat(func_gpu, (image, labels, index), n_warmup=n_base, n_repeat=8*n_base)
                gpu_times = perf_gpu.gpu_times * 1000

                func_cpu = getattr(scipy.ndimage, func)
                perf_cpu = repeat(func_cpu, (image_cpu, labels_cpu, index_cpu), n_warmup=1, n_repeat=n_base)
                cpu_times = perf_cpu.gpu_times * 1000
                accel = cpu_times.mean() / gpu_times.mean()
                print(f"{func}, {shape}, {nlabels} label(s), {np.dtype(dtype).name} | {gpu_times.mean():0.3f} +/- {gpu_times.std():0.3f} | {cpu_times.mean():0.3f} +/- {cpu_times.std():0.3f} | {accel:0.3f}")
```

</details>
