### PR TITLE
Improve cupyx.scipy.sparse int x int indexing

### DIFF
--- a/cupyx/scipy/sparse/_index.py
+++ b/cupyx/scipy/sparse/_index.py
@@ -22,6 +22,24 @@ _int_scalar_types = (int, numpy.integer, numpy.int_)
 _bool_scalar_types = (bool, numpy.bool, numpy.bool_)
 
 
+_compress_getitem_kern = core.ElementwiseKernel(
+    'T d, S ind, int32 minor', 'raw T answer',
+    'if (ind == minor) atomicAdd(&answer[0], d);',
+    'compress_getitem')
+
+
+_compress_getitem_complex_kern = core.ElementwiseKernel(
+    'T real, T imag, S ind, int32 minor',
+    'raw T answer_real, raw T answer_imag',
+    '''
+    if (ind == minor) {
+    atomicAdd(&answer_real[0], real);
+    atomicAdd(&answer_imag[0], imag);
+    }
+    ''',
+    'compress_getitem_complex')
+
+
 def _get_csr_submatrix_major_axis(Ax, Aj, Ap, start, stop):
     """Return a submatrix of the input sparse matrix by slicing major axis.
 

--- a/cupyx/scipy/sparse/compressed.py
+++ b/cupyx/scipy/sparse/compressed.py
@@ -26,22 +26,6 @@ class _compressed_sparse_matrix(sparse_data._data_matrix,
                                 sparse_data._minmax_mixin,
                                 _index.IndexMixin):
 
-    _compress_getitem_kern = core.ElementwiseKernel(
-        'T d, S ind, int32 minor', 'raw T answer',
-        'if (ind == minor) atomicAdd(&answer[0], d);',
-        'compress_getitem')
-
-    _compress_getitem_complex_kern = core.ElementwiseKernel(
-        'T real, T imag, S ind, int32 minor',
-        'raw T answer_real, raw T answer_imag',
-        '''
-        if (ind == minor) {
-          atomicAdd(&answer_real[0], real);
-          atomicAdd(&answer_imag[0], imag);
-        }
-        ''',
-        'compress_getitem_complex')
-
     _max_reduction_kern = core.RawKernel(r'''
         extern "C" __global__
         void max_reduction(double* data, int* x, int* y, int length,
@@ -491,11 +475,16 @@ class _compressed_sparse_matrix(sparse_data._data_matrix,
 
     def _get_intXint(self, row, col):
         major, minor = self._swap(row, col)
-        data, indices, indptr = _index._get_csr_submatrix_major_axis(
+        data, indices, _ = _index._get_csr_submatrix_major_axis(
             self.data, self.indices, self.indptr, major, major + 1)
-        data, _, _ = _index._get_csr_submatrix_minor_axis(
-            data, indices, indptr, minor, minor + 1)
-        return data.sum(dtype=self.dtype)
+        dtype = data.dtype
+        res = cupy.zeros((), dtype=dtype)
+        if dtype.kind == 'c':
+            _index._compress_getitem_complex_kern(
+                data.real, data.imag, indices, minor, res.real, res.imag)
+        else:
+            _index._compress_getitem_kern(data, indices, minor, res)
+        return res
 
     def _get_sliceXslice(self, row, col):
         major, minor = self._swap(row, col)


### PR DESCRIPTION
Blocked by #3975 
- `master`
```
- name = major_slice, major = 30, minor = 30, format = csr, density = 0.5, dtype = float32, n_rows = 15000, n_cols = 15000
cupy.sparse         :    CPU:  347.650 us   +/-62.985 (min:  338.049 / max: 3612.037) us     GPU-0:  353.839 us   +/-63.345 (min:  344.064 / max: 3636.224) us
```
- this PR
```
- name = major_slice, major = 30, minor = 30, format = csr, density = 0.5, dtype = float32, n_rows = 15000, n_cols = 15000
cupy.sparse         :    CPU:  109.048 us   +/-39.150 (min:  105.948 / max: 3626.384) us     GPU-0:  114.418 us   +/-39.267 (min:  110.592 / max: 3641.344) us
```