### PR TITLE
ROCm: fix rocBLAS and rocSOLVER version displays

### DIFF
--- a/cupy_backends/cuda/libs/cupy_cusolver.h
+++ b/cupy_backends/cuda/libs/cupy_cusolver.h
@@ -199,10 +199,6 @@ cusolverStatus_t cusolverSpSetStream(...) {
     return rocblas_status_not_implemented;
 }
 
-cusolverStatus_t cusolverGetProperty(...) {
-    return rocblas_status_not_implemented;
-}
-
 
 /* ---------- potrf ---------- */
 cusolverStatus_t cusolverDnCpotrf_bufferSize(...) {

--- a/cupy_backends/cuda/libs/cusolver.pxd
+++ b/cupy_backends/cuda/libs/cusolver.pxd
@@ -42,7 +42,7 @@ cpdef enum:
 # Library Attributes
 ###############################################################################
 
-cpdef int getProperty(int type)
+cpdef int getProperty(int type) except? -1
 cpdef tuple _getVersion()
 
 ###############################################################################

--- a/cupy_backends/cuda/libs/cusolver.pyx
+++ b/cupy_backends/cuda/libs/cusolver.pyx
@@ -726,7 +726,7 @@ cpdef inline check_status(int status):
 # Library Attributes
 ###############################################################################
 
-cpdef int getProperty(int type):
+cpdef int getProperty(int type) except? -1:
     cdef int value
     with nogil:
         status = cusolverGetProperty(<LibraryPropertyType>type, &value)


### PR DESCRIPTION
Follow up of #3950. For some reason I didn't catch the bug that when calling `cupy.show_info()` `CUSOLVERError` was raised (perhaps my local build was dirty):
```python
>>> import cupy as cp
>>> cp.show_config()
Traceback (most recent call last):
  File "cupy_backends/cuda/libs/cusolver.pyx", line 722, in cupy_backends.cuda.libs.cusolver.check_status
    raise CUSOLVERError(status)
cupy_backends.cuda.libs.cusolver.CUSOLVERError: rocblas_status_not_implemented
Exception ignored in: 'cupy_backends.cuda.libs.cusolver.getProperty'
Traceback (most recent call last):
  File "cupy_backends/cuda/libs/cusolver.pyx", line 722, in cupy_backends.cuda.libs.cusolver.check_status
    raise CUSOLVERError(status)
cupy_backends.cuda.libs.cusolver.CUSOLVERError: rocblas_status_not_implemented
Traceback (most recent call last):
  File "cupy_backends/cuda/libs/cusolver.pyx", line 722, in cupy_backends.cuda.libs.cusolver.check_status
    raise CUSOLVERError(status)
cupy_backends.cuda.libs.cusolver.CUSOLVERError: rocblas_status_not_implemented
Exception ignored in: 'cupy_backends.cuda.libs.cusolver.getProperty'
Traceback (most recent call last):
  File "cupy_backends/cuda/libs/cusolver.pyx", line 722, in cupy_backends.cuda.libs.cusolver.check_status
    raise CUSOLVERError(status)
cupy_backends.cuda.libs.cusolver.CUSOLVERError: rocblas_status_not_implemented
Traceback (most recent call last):
  File "cupy_backends/cuda/libs/cusolver.pyx", line 722, in cupy_backends.cuda.libs.cusolver.check_status
    raise CUSOLVERError(status)
cupy_backends.cuda.libs.cusolver.CUSOLVERError: rocblas_status_not_implemented
Exception ignored in: 'cupy_backends.cuda.libs.cusolver.getProperty'
Traceback (most recent call last):
  File "cupy_backends/cuda/libs/cusolver.pyx", line 722, in cupy_backends.cuda.libs.cusolver.check_status
    raise CUSOLVERError(status)
cupy_backends.cuda.libs.cusolver.CUSOLVERError: rocblas_status_not_implemented
CuPy Version          : 8.0.0rc1
CUDA Root             : /usr
CUDA Build Version    : 0
CUDA Driver Version   : 313700
CUDA Runtime Version  : 3137
cuBLAS Version        : CUBLASError('HIPBLAS_STATUS_NOT_SUPPORTED')
cuFFT Version         : 32673
cuRAND Version        : 201001
cuSOLVER Version      : (0, 0, 0)
cuSPARSE Version      : 0
NVRTC Version         : (9, 0)
Thrust Version        : 100902
CUB Build Version     : None
cuDNN Build Version   : None
cuDNN Version         : None
NCCL Build Version    : None
NCCL Runtime Version  : None
cuTENSOR Version      : None
```
It is now fixed in this PR. Also, the version number for rocBLAS is computed and printed:
```python
>>> import cupy as cp
>>> cp.show_config()
CuPy Version          : 8.0.0rc1
CUDA Root             : /usr
CUDA Build Version    : 0
CUDA Driver Version   : 313700
CUDA Runtime Version  : 3137
cuBLAS Version        : 22200
cuFFT Version         : 0
cuRAND Version        : 201001
cuSOLVER Version      : (3, 5, 0)
cuSPARSE Version      : 0
NVRTC Version         : (9, 0)
Thrust Version        : 100902
CUB Build Version     : None
cuDNN Build Version   : None
cuDNN Version         : None
NCCL Build Version    : None
NCCL Runtime Version  : None
cuTENSOR Version      : None
```