### PR TITLE
Avoid using CUlinkState unless absolutely necessary

### DIFF
--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -402,13 +402,15 @@ def _compile_with_cache_cuda(
         ptx, mapping = compile_using_nvrtc(
             source, options, arch, cu_name, name_expressions,
             log_stream, cache_in_memory)
-        ls = function.LinkState()
-        ls.add_ptr_data(ptx, 'cupy.ptx')
-        # for separate compilation
         if _is_cudadevrt_needed(options):
+            # for separate compilation
+            ls = function.LinkState()
+            ls.add_ptr_data(ptx, 'cupy.ptx')
             _cudadevrt = _get_cudadevrt_path()
             ls.add_ptr_file(_cudadevrt)
-        cubin = ls.complete()
+            cubin = ls.complete()
+        else:
+            cubin = ptx
         mod._set_mapping(mapping)
     elif backend == 'nvcc':
         rdc = _is_cudadevrt_needed(options)


### PR DESCRIPTION
I noticed `ls.add_ptr_data()` took about 20% of time in `_compile_with_cache_cuda()`, but it's actually not needed unless we are doing separate compilation and need to link with other input files/data. Otherwise, we can just pass the generated PTX to `cuModuleLoad()` which should work just fine.