### PR TITLE
Add a kernel for integer GEMM

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2425,24 +2425,6 @@ cpdef ndarray dot(ndarray a, ndarray b, ndarray out=None):
     a_axis = a_ndim - 1
     b_axis = b_ndim - 2
 
-    # Do this for integer matrices so we avoid type castings
-    cdef str dtype = a.dtype.char
-    if dtype != b.dtype.char:
-        dtype = numpy.promote_types(dtype, b.dtype).char
-
-    # We call a custom kernel to avoid calculations
-    # in floating point for integers
-    if dtype not in 'efdFD':
-        m, k = a.shape
-        k, n = b.shape
-        if not input_a_is_vec:
-            ret_shape.insert(
-                ret_shape.end(), a._shape.begin(), a._shape.end()-1)
-        if not input_b_is_vec:
-            ret_shape.insert(
-                ret_shape.end(), b._shape.begin() + 1, b._shape.end())
-        return integral_tensordot_core(a, b, out, m, n, k, dtype, ret_shape)
-
     # These are mostly transformations intended for CUBLAS
     if a._shape[a_axis] != b._shape[b_axis]:
         raise ValueError('Axis dimension mismatch')
@@ -2473,7 +2455,7 @@ cpdef ndarray dot(ndarray a, ndarray b, ndarray out=None):
         if not out._c_contiguous:
             raise ValueError('Output array must be C-contiguous')
 
-    return tensordot_core(a, b, out, n, m, k, dtype, ret_shape)
+    return tensordot_core(a, b, out, n, m, k, ret_shape)
 
 
 cdef _mat_ptrs_kernel = ElementwiseKernel(
@@ -2969,32 +2951,10 @@ __global__ void _tensordot_core_int_kernel(
     return ker
 
 
-cdef _tensordot_core_mul_sum = ReductionKernel(
-    'S x, T y', 'U out',
-    'static_cast<U>(x) * static_cast<U>(y)',
-    'a + b', 'out = a', '0', '_tensordot_core_mul_sum')
-
-cdef ndarray integral_tensordot_core(
-        ndarray a, ndarray b, ndarray out, Py_ssize_t n, Py_ssize_t m,
+cdef ndarray _integral_tensordot_core(
+        ndarray a, ndarray b, ndarray out, Py_ssize_t m, Py_ssize_t n,
         Py_ssize_t k, str dtype, const shape_t& ret_shape):
-    if not a.size or not b.size:
-        if out is None:
-            out = _ndarray_init(ret_shape, dtype)
-        out.fill(0)
-        return out
 
-    # The kernel requires the output to be in F order
-    ret = cupy.empty(ret_shape, dtype=dtype, order='F')
-    if out is None:
-        out = _ndarray_init(ret_shape, dtype)
-    if m == 1 and n == 1:
-        _tensordot_single(a, b, ret)
-        elementwise_copy(ret, out)
-
-    a = a.astype(dtype, copy=False)
-    b = b.astype(dtype, copy=False)
-    m, k = a.shape
-    k, n = b.shape
     dim_x=16
     dim_y=16
     blk_m=64
@@ -3009,44 +2969,35 @@ cdef ndarray integral_tensordot_core(
               ('DIM_XA', dim_xa), ('DIM_YA', dim_ya),
               ('DIM_XB', dim_xb), ('DIM_YB', dim_yb),
               ('THR_M', blk_m // dim_x), ('THR_N', blk_n // dim_y))
-    # Inputs matrices need to be in Fortran order.
-    a = _internal_asfortranarray(a)
-    b = _internal_asfortranarray(b)
     kern = _tensordot_core_int_kernel(config, dtype)
-    args = (m, n, k, a, b, ret)
+    args = (m, n, k, a, b, out)
     grid = (int(math.ceil(m / blk_m)), int(math.ceil(n / blk_n)), 1)
     block = (dim_x, dim_y, 1)
     shared_mem = blk_k * (blk_m + 1) * 4 + blk_n * (blk_k + 1) * 4
     kern(grid, block, args=args, shared_mem=shared_mem)
 
-    elementwise_copy(ret, out)
+    # elementwise_copy(ret, out)
     return out
 
 
-cdef ndarray _tensordot_single(ndarray a, ndarray b, ndarray out):
-    for ace in _accelerator._routine_accelerators:
-        # fast path using CUB or cuTENSOR
-        if ace in (_accelerator.ACCELERATOR_CUB,
-                   _accelerator.ACCELERATOR_CUTENSOR):
-            out = (a.ravel() * b.ravel()).sum(
-                out=_manipulation._reshape(out, ()))
-            break
-    else:
-        _tensordot_core_mul_sum(
-            a.ravel(), b.ravel(),
-            out=_manipulation._reshape(out, ()))
-    return out
+cdef _tensordot_core_mul_sum = ReductionKernel(
+    'S x, T y', 'U out',
+    'static_cast<U>(x) * static_cast<U>(y)',
+    'a + b', 'out = a', '0', '_tensordot_core_mul_sum')
+
 
 cpdef ndarray tensordot_core(
         ndarray a, ndarray b, ndarray out, Py_ssize_t n, Py_ssize_t m,
-        Py_ssize_t k, str dtype, const shape_t& ret_shape):
+        Py_ssize_t k, const shape_t& ret_shape):
     cdef shape_t shape
     cdef Py_ssize_t inca, incb, transa, transb, lda, ldb
     cdef Py_ssize_t mode
     cdef intptr_t handle
     cdef bint use_sgemmEx
     cdef float one_fp32, zero_fp32
-    cdef str ret_dtype = a.dtype.char
+    cdef str dtype = a.dtype.char
+    if dtype != b.dtype.char:
+        dtype = numpy.promote_types(dtype, b.dtype).char
     if not a.size or not b.size:
         if out is None:
             out = _ndarray_init(ret_shape, dtype)
@@ -3060,7 +3011,18 @@ cpdef ndarray tensordot_core(
             out = _ndarray_init(ret_shape, dtype)
     cdef int ace
     if m == 1 and n == 1:
-        return _tensordot_single(a, b, out)
+        for ace in _accelerator._routine_accelerators:
+            # fast path using CUB or cuTENSOR
+            if ace in (_accelerator.ACCELERATOR_CUB,
+                       _accelerator.ACCELERATOR_CUTENSOR):
+                out = (a.ravel() * b.ravel()).sum(
+                    out=_manipulation._reshape(out, ()))
+                break
+        else:
+            _tensordot_core_mul_sum(
+                a.ravel(), b.ravel(),
+                out=_manipulation._reshape(out, ()))
+        return out
 
     a = a.astype(dtype, copy=False)
     b = b.astype(dtype, copy=False)
@@ -3079,12 +3041,21 @@ cpdef ndarray tensordot_core(
     if c._shape.size() != 2 or c._shape[0] != n or c._shape[1] != m:
         c = c.view()
         c.shape = (n, m)
+
     # Be careful that cuBLAS uses the FORTRAN-order matrix representation.
     # Matrix-Matrix product A^T * B
     # c is C-contiguous while cuBLAS assumes F-contiguous inputs, so we
     # compute C^T = B^T * A here.
     a, transa, lda = _mat_to_cublas_contiguous(a, 0)
     b, transb, ldb = _mat_to_cublas_contiguous(b, 1)
+
+    if dtype not in 'efdFD':
+        if transa:
+            a = a.T
+            a = _internal_ascontiguousarray(a)
+        if transb:
+            b = _internal_ascontiguousarray(b)
+        return _integral_tensordot_core(b, a, out, m, n, k, dtype, ret_shape)
 
     global _cuda_runtime_version
     if _cuda_runtime_version < 0:

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -3012,11 +3012,13 @@ cpdef ndarray tensordot_core(
     cdef int ace
     if m == 1 and n == 1:
         for ace in _accelerator._routine_accelerators:
+            ret = _ndarray_init(ret_shape, dtype)
             # fast path using CUB or cuTENSOR
             if ace in (_accelerator.ACCELERATOR_CUB,
                        _accelerator.ACCELERATOR_CUTENSOR):
-                out = (a.ravel() * b.ravel()).sum(
-                    out=_manipulation._reshape(out, ()))
+                ret = (a.ravel() * b.ravel()).sum(
+                    out=_manipulation._reshape(ret, ()))
+                elementwise_copy(ret, out)
                 break
         else:
             _tensordot_core_mul_sum(

--- a/tests/cupy_tests/math_tests/test_matmul.py
+++ b/tests/cupy_tests/math_tests/test_matmul.py
@@ -129,6 +129,19 @@ class TestMatmulLarge(unittest.TestCase):
         return xp.matmul(x1, x2)
 
 
+class TestMatmulOverflow(unittest.TestCase):
+
+    @testing.for_int_dtypes(name='dtype')
+    @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-3)  # required for uint8
+    def test_overflow(self, xp, dtype):
+        if dtype is numpy.bool_:
+            return xp.array([])
+        value = numpy.iinfo(dtype).max
+        a = xp.array([value - 10]).astype(dtype)
+        b = xp.array([value - 10]).astype(dtype)
+        return xp.matmul(a, b)
+
+
 class _TestMatmulComputeTypes(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
Fixes #3941

We rely only on cublas for the matrix multiplication and we cast the inputs to float and then back to integral types again. This causes precision issues.

This also has an speedup of 45% for a matrix product with `dtype=numpy.int32` and`shape=(5000, 5000)`