### PR TITLE
Add complex dtype support to cupyx.scipy.linalg.lu_factor/solve

### DIFF
--- a/cupyx/scipy/linalg/decomp_lu.py
+++ b/cupyx/scipy/linalg/decomp_lu.py
@@ -71,8 +71,15 @@ dtype=cp.float32))
     elif dtype.char == 'd':
         getrf = cusolver.dgetrf
         getrf_bufferSize = cusolver.dgetrf_bufferSize
+    elif dtype.char == 'F':
+        getrf = cusolver.cgetrf
+        getrf_bufferSize = cusolver.cgetrf_bufferSize
+    elif dtype.char == 'D':
+        getrf = cusolver.zgetrf
+        getrf_bufferSize = cusolver.zgetrf_bufferSize
     else:
-        raise NotImplementedError('Only float32 and float64 are supported.')
+        msg = 'Only float32, float64, complex64 and complex128 are supported.'
+        raise NotImplementedError(msg)
 
     a = a.astype(dtype, order='F', copy=(not overwrite_a))
 
@@ -154,8 +161,13 @@ def lu_solve(lu_and_piv, b, trans=0, overwrite_b=False, check_finite=True):
         getrs = cusolver.sgetrs
     elif dtype.char == 'd':
         getrs = cusolver.dgetrs
+    elif dtype.char == 'F':
+        getrs = cusolver.cgetrs
+    elif dtype.char == 'D':
+        getrs = cusolver.zgetrs
     else:
-        raise NotImplementedError('Only float32 and float64 are supported.')
+        msg = 'Only float32, float64, complex64 and complex128 are supported.'
+        raise NotImplementedError(msg)
 
     if trans == 0:
         trans = cublas.CUBLAS_OP_N

--- a/tests/cupyx_tests/scipy_tests/linalg_tests/test_decomp_lu.py
+++ b/tests/cupyx_tests/scipy_tests/linalg_tests/test_decomp_lu.py
@@ -16,14 +16,14 @@ if cupyx.scipy._scipy_available:
 @testing.with_requires('scipy')
 class TestLUFactor(unittest.TestCase):
 
-    @testing.for_float_dtypes(no_float16=True)
+    @testing.for_dtypes('fdFD')
     def test_lu_factor(self, dtype):
         if self.shape[0] != self.shape[1]:
             # skip non-square tests since scipy.lu_factor requires square
             return unittest.SkipTest()
-        array = numpy.random.randn(*self.shape)
-        a_cpu = numpy.asarray(array, dtype=dtype)
-        a_gpu = cupy.asarray(array, dtype=dtype)
+        a = testing.shaped_random(self.shape, numpy, dtype=dtype)
+        a_cpu = numpy.asarray(a)
+        a_gpu = cupy.asarray(a)
         result_cpu = scipy.linalg.lu_factor(a_cpu)
         result_gpu = cupyx.scipy.linalg.lu_factor(a_gpu)
         self.assertEqual(len(result_cpu), len(result_gpu))
@@ -32,10 +32,10 @@ class TestLUFactor(unittest.TestCase):
         cupy.testing.assert_allclose(result_cpu[0], result_gpu[0], atol=1e-5)
         cupy.testing.assert_array_equal(result_cpu[1], result_gpu[1])
 
-    @testing.for_float_dtypes(no_float16=True)
+    @testing.for_dtypes('fdFD')
     def test_lu_factor_reconstruction(self, dtype):
         m, n = self.shape
-        A = cupy.random.randn(m, n, dtype=dtype)
+        A = testing.shaped_random(self.shape, numpy, dtype=dtype)
         lu, piv = cupyx.scipy.linalg.lu_factor(A)
         # extract ``L`` and ``U`` from ``lu``
         L = cupy.tril(lu, k=-1)
@@ -69,7 +69,7 @@ class TestLUFactor(unittest.TestCase):
 @testing.with_requires('scipy')
 class TestLUSolve(unittest.TestCase):
 
-    @testing.for_float_dtypes(no_float16=True)
+    @testing.for_dtypes('fdFD')
     @testing.numpy_cupy_allclose(atol=1e-5, scipy_name='scp')
     def test_lu_solve(self, xp, scp, dtype):
         a_shape, b_shape = self.shapes

--- a/tests/cupyx_tests/scipy_tests/linalg_tests/test_decomp_lu.py
+++ b/tests/cupyx_tests/scipy_tests/linalg_tests/test_decomp_lu.py
@@ -21,9 +21,8 @@ class TestLUFactor(unittest.TestCase):
         if self.shape[0] != self.shape[1]:
             # skip non-square tests since scipy.lu_factor requires square
             return unittest.SkipTest()
-        a = testing.shaped_random(self.shape, numpy, dtype=dtype)
-        a_cpu = numpy.asarray(a)
-        a_gpu = cupy.asarray(a)
+        a_cpu = testing.shaped_random(self.shape, numpy, dtype=dtype)
+        a_gpu = cupy.asarray(a_cpu)
         result_cpu = scipy.linalg.lu_factor(a_cpu)
         result_gpu = cupyx.scipy.linalg.lu_factor(a_gpu)
         self.assertEqual(len(result_cpu), len(result_gpu))
@@ -35,7 +34,7 @@ class TestLUFactor(unittest.TestCase):
     @testing.for_dtypes('fdFD')
     def test_lu_factor_reconstruction(self, dtype):
         m, n = self.shape
-        A = testing.shaped_random(self.shape, numpy, dtype=dtype)
+        A = testing.shaped_random(self.shape, cupy, dtype=dtype)
         lu, piv = cupyx.scipy.linalg.lu_factor(A)
         # extract ``L`` and ``U`` from ``lu``
         L = cupy.tril(lu, k=-1)


### PR DESCRIPTION
This PR adds support for complex dtypes to `cupyx.scipy.linalg.lu_factor` and `cupyx.scipy.linalg.lu_solve`.

This is related to https://github.com/cupy/cupy/pull/3995.