### PR TITLE
Add `apply_along_axis`

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -281,6 +281,7 @@ from cupy._creation.matrix import triu  # NOQA
 # Functional routines
 # -----------------------------------------------------------------------------
 from cupy._functional.piecewise import piecewise  # NOQA
+from cupy.lib.shape_base import apply_along_axis  # NOQA
 
 # -----------------------------------------------------------------------------
 # Array manipulation routines

--- a/cupy/core/_routines_manipulation.pxd
+++ b/cupy/core/_routines_manipulation.pxd
@@ -25,6 +25,8 @@ cdef ndarray _ndarray_repeat(ndarray self, repeats, axis)
 
 cpdef ndarray _expand_dims(ndarray a, tuple axis)
 cpdef ndarray moveaxis(ndarray a, source, destination)
+cpdef ndarray _move_single_axis(ndarray a, Py_ssize_t source,
+                                Py_ssize_t destination)
 cpdef ndarray rollaxis(ndarray a, Py_ssize_t axis, Py_ssize_t start=*)
 cpdef ndarray broadcast_to(ndarray array, shape)
 cpdef ndarray _reshape(ndarray self, const shape_t &shape_spec)

--- a/cupy/core/_routines_manipulation.pyx
+++ b/cupy/core/_routines_manipulation.pyx
@@ -240,24 +240,55 @@ cpdef ndarray _expand_dims(ndarray a, tuple axis):
 
 cpdef ndarray moveaxis(ndarray a, source, destination):
     cdef shape_t src, dest
-    _normalize_axis_tuple(source, a.ndim, src)
-    _normalize_axis_tuple(destination, a.ndim, dest)
+    cdef Py_ssize_t ndim = a.ndim
+    _normalize_axis_tuple(source, ndim, src)
+    _normalize_axis_tuple(destination, ndim, dest)
 
     if src.size() != dest.size():
         raise ValueError('`source` and `destination` arguments must have '
                          'the same number of elements')
 
     cdef vector.vector[Py_ssize_t] order
-    cdef Py_ssize_t n = 0
-    for i in range(a.ndim):
-        n = <Py_ssize_t>i
-        if not _has_element(src, n):
-            order.push_back(n)
+    cdef Py_ssize_t i
+    for i in range(ndim):
+        if not _has_element(src, i):
+            order.push_back(i)
 
     cdef Py_ssize_t d, s
     for d, s in sorted(zip(dest, src)):
         order.insert(order.begin() + d, s)
 
+    return _transpose(a, order)
+
+
+cdef Py_ssize_t _normalize_axis_index(Py_ssize_t axis,
+                                      Py_ssize_t ndim) except -1:
+    if axis < 0:
+        axis += ndim
+    if not (0 <= axis < ndim):
+        raise numpy.AxisError(
+            'axis {} is out of bounds for array of dimension {}'.format(
+                axis, ndim))
+    return axis
+
+
+cpdef ndarray _move_single_axis(ndarray a, Py_ssize_t source,
+                                Py_ssize_t destination):
+    """Like moveaxis, but supporting only integer source and destination."""
+    cdef Py_ssize_t ndim = a.ndim
+    source = _normalize_axis_index(source, ndim)
+    destination = _normalize_axis_index(destination, ndim)
+
+    if source == destination:
+        return a
+
+    cdef vector.vector[Py_ssize_t] order
+    cdef Py_ssize_t i
+    for i in range(ndim):
+        if i != source:
+            order.push_back(i)
+
+    order.insert(order.begin() + destination, source)
     return _transpose(a, order)
 
 

--- a/cupy/lib/shape_base.py
+++ b/cupy/lib/shape_base.py
@@ -48,7 +48,7 @@ def apply_along_axis(func1d, axis, arr, *args, **kwargs):
     # remove the requested axis, and add the new ones on the end.
     # laid out so that each write is contiguous.
     # for a tuple index inds, buff[inds] = func1d(inarr_view[inds])
-    buff = cupy.zeros(inarr_view.shape[:-1] + res.shape, res.dtype)
+    buff = cupy.empty(inarr_view.shape[:-1] + res.shape, res.dtype)
 
     # permutation of axes such that out = buff.transpose(buff_permute)
     buff_dims = list(range(buff.ndim))

--- a/cupy/lib/shape_base.py
+++ b/cupy/lib/shape_base.py
@@ -1,0 +1,72 @@
+from numpy.lib import index_tricks
+
+import cupy
+from cupy import _util
+
+
+def apply_along_axis(func1d, axis, arr, *args, **kwargs):
+    """Apply a function to 1-D slices along the given axis.
+
+    Args:
+        func1d (function (M,) -> (Nj...)): This function should accept 1-D
+            arrays. It is applied to 1-D slices of ``arr`` along the specified
+            axis. It must return a 1-D ``cupy.ndarray``.
+        axis (integer): Axis along which ``arr`` is sliced.
+        arr (cupy.ndarray (Ni..., M, Nk...)): Input array.
+        args: Additional arguments for `f`unc1d``.
+        kwargs: Additional keyword arguments for ``func1d``.
+
+    Returns:
+        cupy.ndarray: The output array. The shape of ``out`` is identical to
+            the shape of ``arr``, except along the ``axis`` dimension. This
+            axis is removed, and replaced with new dimensions equal to the
+            shape of the return value of ``func1d``. So if ``func1d`` returns a
+            scalar ``out`` will have one fewer dimensions than ``arr``.
+
+    .. seealso:: :func:`numpy.apply_over_axes`
+    """
+    ndim = arr.ndim
+    axis = _util._normalize_axis_index(axis, ndim)
+
+    # arr, with the iteration axis at the end
+    in_dims = list(range(ndim))
+    inarr_view = cupy.transpose(
+        arr, in_dims[:axis] + in_dims[axis + 1:] + [axis]
+    )
+
+    # compute indices for the iteration axes, and append a trailing ellipsis to
+    # prevent 0d arrays decaying to scalars
+    inds = index_tricks.ndindex(inarr_view.shape[:-1])
+    inds = (ind + (Ellipsis,) for ind in inds)
+
+    # invoke the function on the first item
+    try:
+        ind0 = next(inds)
+    except StopIteration:
+        raise ValueError(
+            'Cannot apply_along_axis when any iteration dimensions are 0'
+        )
+    # cupy.asarray needed in case func1d returns a scalar
+    res = cupy.asarray(func1d(inarr_view[ind0], *args, **kwargs))
+
+    # build a buffer for storing evaluations of func1d.
+    # remove the requested axis, and add the new ones on the end.
+    # laid out so that each write is contiguous.
+    # for a tuple index inds, buff[inds] = func1d(inarr_view[inds])
+    buff = cupy.zeros(inarr_view.shape[:-1] + res.shape, res.dtype)
+
+    # permutation of axes such that out = buff.transpose(buff_permute)
+    buff_dims = list(range(buff.ndim))
+    buff_permute = (
+        buff_dims[0:axis] +
+        buff_dims[buff.ndim - res.ndim:buff.ndim] +
+        buff_dims[axis:buff.ndim - res.ndim]
+    )
+
+    # save the first result, then compute and save all remaining results
+    buff[ind0] = res
+    for ind in inds:
+        buff[ind] = func1d(inarr_view[ind], *args, **kwargs)
+
+    # finally, rotate the inserted axes back to where they belong
+    return cupy.transpose(buff, buff_permute)

--- a/cupy/lib/shape_base.py
+++ b/cupy/lib/shape_base.py
@@ -2,6 +2,7 @@ from numpy.lib import index_tricks
 
 import cupy
 from cupy import _util
+from cupy.core import _routines_manipulation
 
 
 def apply_along_axis(func1d, axis, arr, *args, **kwargs):
@@ -13,7 +14,7 @@ def apply_along_axis(func1d, axis, arr, *args, **kwargs):
             axis. It must return a 1-D ``cupy.ndarray``.
         axis (integer): Axis along which ``arr`` is sliced.
         arr (cupy.ndarray (Ni..., M, Nk...)): Input array.
-        args: Additional arguments for `f`unc1d``.
+        args: Additional arguments for ``func1d``.
         kwargs: Additional keyword arguments for ``func1d``.
 
     Returns:
@@ -27,12 +28,7 @@ def apply_along_axis(func1d, axis, arr, *args, **kwargs):
     """
     ndim = arr.ndim
     axis = _util._normalize_axis_index(axis, ndim)
-
-    # arr, with the iteration axis at the end
-    in_dims = list(range(ndim))
-    inarr_view = cupy.transpose(
-        arr, in_dims[:axis] + in_dims[axis + 1:] + [axis]
-    )
+    inarr_view = cupy.moveaxis(arr, axis, -1)
 
     # compute indices for the iteration axes, and append a trailing ellipsis to
     # prevent 0d arrays decaying to scalars

--- a/cupy/lib/shape_base.py
+++ b/cupy/lib/shape_base.py
@@ -41,8 +41,10 @@ def apply_along_axis(func1d, axis, arr, *args, **kwargs):
         raise ValueError(
             'Cannot apply_along_axis when any iteration dimensions are 0'
         )
-    # cupy.asarray needed in case func1d returns a scalar
-    res = cupy.asarray(func1d(inarr_view[ind0], *args, **kwargs))
+    res = func1d(inarr_view[ind0], *args, **kwargs)
+    if cupy.isscalar(res):
+        # scalar outputs need to be transfered to a device ndarray
+        res = cupy.asarray(res)
 
     # build a buffer for storing evaluations of func1d.
     # remove the requested axis, and add the new ones on the end.

--- a/cupy/lib/shape_base.py
+++ b/cupy/lib/shape_base.py
@@ -2,7 +2,6 @@ from numpy.lib import index_tricks
 
 import cupy
 from cupy import _util
-from cupy.core import _routines_manipulation
 
 
 def apply_along_axis(func1d, axis, arr, *args, **kwargs):

--- a/cupy/manipulation/transpose.py
+++ b/cupy/manipulation/transpose.py
@@ -1,4 +1,5 @@
 from cupy import core
+from cupy.core import _routines_manipulation
 
 
 def rollaxis(a, axis, start=0):
@@ -57,6 +58,9 @@ def moveaxis(a, source, destination):
 
     """
     # TODO(fukatani): check type
+    # checking __len__ attribute is faster than cupy.isscalar or isinstance
+    if not (hasattr(source, '__len__') or hasattr(destination, '__len__')):
+        return _routines_manipulation._move_single_axis(a, source, destination)
     return core.moveaxis(a, source, destination)
 
 

--- a/docs/source/reference/functional.rst
+++ b/docs/source/reference/functional.rst
@@ -7,4 +7,5 @@ Functional programming
    :toctree: generated/
    :nosignatures:
 
+   cupy.apply_along_axis
    cupy.piecewise

--- a/tests/cupy_tests/lib_tests/test_shape_base.py
+++ b/tests/cupy_tests/lib_tests/test_shape_base.py
@@ -1,0 +1,102 @@
+import unittest
+
+import numpy
+import pytest
+
+import cupy
+from cupy import testing
+
+
+@testing.parameterize(*(testing.product({'axis': [0, 1, -1]})))
+@testing.gpu
+class TestApplyAlongAxis(unittest.TestCase):
+
+    @testing.numpy_cupy_array_equal()
+    def test_simple(self, xp):
+        a = xp.ones((20, 10), 'd')
+        return xp.apply_along_axis(len, self.axis, a)
+
+    @testing.for_all_dtypes(no_bool=True)
+    @testing.numpy_cupy_array_equal()
+    def test_3d(self, xp, dtype):
+        a = xp.arange(27, dtype=dtype).reshape((3, 3, 3))
+        return xp.apply_along_axis(xp.sum, self.axis, a)
+
+    @testing.numpy_cupy_array_equal()
+    def test_0d_array(self, xp):
+
+        def sum_to_0d(x):
+            """ Sum x, returning a 0d array of the same class """
+            assert x.ndim == 1
+            return xp.squeeze(xp.sum(x, keepdims=True))
+
+        a = xp.ones((6, 3))
+        return xp.apply_along_axis(sum_to_0d, self.axis, a)
+
+    @testing.numpy_cupy_array_equal()
+    def test_axis_insertion_2d(self, xp):
+
+        def f1to2(x):
+            """produces an asymmetric non-square matrix from x"""
+            assert x.ndim == 1
+            return (x[::-1] * x[1:, None])
+
+        # 2d insertion
+        a2d = xp.arange(6 * 3).reshape((6, 3))
+        return xp.apply_along_axis(f1to2, self.axis, a2d)
+
+    @testing.numpy_cupy_array_equal()
+    def test_axis_insertion_3d(self, xp):
+
+        def f1to2(x):
+            """produces an asymmetric non-square matrix from x"""
+            assert x.ndim == 1
+            return (x[::-1] * x[1:, None])
+
+        # 3d insertion
+        a3d = xp.arange(6 * 5 * 3).reshape((6, 5, 3))
+        return xp.apply_along_axis(f1to2, self.axis, a3d)
+
+    def test_empty1(self):
+        # can't apply_along_axis when there's no chance to call the function
+        def never_call(x):
+            assert False  # should never be reached
+
+        for xp in [numpy, cupy]:
+            a = xp.empty((0, 0))
+            with pytest.raises(ValueError):
+                xp.apply_along_axis(never_call, self.axis, a)
+
+    def test_empty2(self):
+        # but it's sometimes ok with some non-zero dimensions
+        def empty_to_1(x):
+            assert len(x) == 0
+            return 1
+
+        for xp in [numpy, cupy]:
+            shape = [10, 10]
+            shape[self.axis] = 0
+            shape = tuple(shape)
+            a = xp.empty(shape)
+            if self.axis == 0:
+                other_axis = 1
+            else:
+                other_axis = 0
+            with pytest.raises(ValueError):
+                xp.apply_along_axis(empty_to_1, other_axis, a)
+
+            # okay to call along the shape 0 axis
+            testing.assert_array_equal(
+                xp.apply_along_axis(empty_to_1, self.axis, a),
+                xp.ones((10,))
+            )
+
+
+@testing.gpu
+@testing.with_requires('numpy>=1.16')
+def test_apply_along_axis_invalid_axis():
+    for xp in [numpy, cupy]:
+        a = xp.ones((8, 4))
+        for axis in [-3, 2]:
+            with pytest.raises(numpy.AxisError):
+                xp.apply_along_axis(xp.sum, axis, a)

--- a/tests/cupy_tests/manipulation_tests/test_transpose.py
+++ b/tests/cupy_tests/manipulation_tests/test_transpose.py
@@ -53,6 +53,12 @@ class TestTranspose(unittest.TestCase):
             with pytest.raises(numpy.AxisError):
                 xp.moveaxis(a, [0, 1], [1, 3])
 
+    def test_moveaxis_invalid1_3(self):
+        for xp in (numpy, cupy):
+            a = testing.shaped_arange((2, 3, 4), xp)
+            with pytest.raises(numpy.AxisError):
+                xp.moveaxis(a, 0, 3)
+
     # dim is too small
     def test_moveaxis_invalid2_1(self):
         for xp in (numpy, cupy):
@@ -66,19 +72,37 @@ class TestTranspose(unittest.TestCase):
             with pytest.raises(numpy.AxisError):
                 xp.moveaxis(a, [0, -4], [1, 2])
 
+    def test_moveaxis_invalid2_3(self):
+        for xp in (numpy, cupy):
+            a = testing.shaped_arange((2, 3, 4), xp)
+            with pytest.raises(numpy.AxisError):
+                xp.moveaxis(a, -4, 0)
+
     # len(source) != len(destination)
-    def test_moveaxis_invalid3(self):
+    def test_moveaxis_invalid3_1(self):
         for xp in (numpy, cupy):
             a = testing.shaped_arange((2, 3, 4), xp)
             with pytest.raises(ValueError):
                 xp.moveaxis(a, [0, 1, 2], [1, 2])
 
+    def test_moveaxis_invalid3_2(self):
+        for xp in (numpy, cupy):
+            a = testing.shaped_arange((2, 3, 4), xp)
+            with pytest.raises(ValueError):
+                xp.moveaxis(a, 0, [1, 2])
+
     # len(source) != len(destination)
-    def test_moveaxis_invalid4(self):
+    def test_moveaxis_invalid4_1(self):
         for xp in (numpy, cupy):
             a = testing.shaped_arange((2, 3, 4), xp)
             with pytest.raises(ValueError):
                 xp.moveaxis(a, [0, 1], [1, 2, 0])
+
+    def test_moveaxis_invalid4_2(self):
+        for xp in (numpy, cupy):
+            a = testing.shaped_arange((2, 3, 4), xp)
+            with pytest.raises(ValueError):
+                xp.moveaxis(a, [0, 1], 1)
 
     # Use the same axis twice
     def test_moveaxis_invalid5_1(self):


### PR DESCRIPTION

This PR implements `apply_along_axis` which is a utility to repeatedly apply a 1d function along a given axis, looping over all other axes.

This function is slightly simplified from [NumPy's](https://github.com/numpy/numpy/blob/c6853c7c27bb8352ab498848439d4fee9eb79a33/numpy/lib/shape_base.py#L268) because it doesn't support a separate `matrix` class and doesn't try to preserve array subclasses like `numpy.ma.core.MaskedArray` via `__array_wrap__` (neither masked arrays or `__array_wrap__` are currently implemented by CuPy)
