### PR TITLE
Improve the plan cache documentation

### DIFF
--- a/cupy/fft/_cache.pyx
+++ b/cupy/fft/_cache.pyx
@@ -192,7 +192,8 @@ cdef class PlanCache:
 
         2. This class can be instantiated by users, but it is discouraged.
            Instead, we expect the following canonical usage pattern to
-           retrieve a handle to the cache through :func:`get_plan_cache`:
+           retrieve a handle to the cache through
+           :func:`~cupy.fft.config.get_plan_cache`:
 
            .. code-block:: python
 
@@ -204,8 +205,8 @@ cdef class PlanCache:
                    cache = get_plan_cache()
                    cache.set_size(0)  # disable the cache
 
-           In particular, the cache for device n should be manipulated under
-           the device n's context.
+           In particular, the cache for device ``n`` should be manipulated
+           under device ``n``'s context.
 
         3. This class is thread-safe since by default it is created on a
            per-thread basis. When starting a new thread, a new cache is not
@@ -583,7 +584,7 @@ cpdef inline PlanCache get_plan_cache():
     """Get the per-thread, per-device plan cache, or create one if not found.
 
     .. seealso::
-        :class:`~cupy.fft.cache.PlanCache`
+        :class:`~cupy.fft._cache.PlanCache`
 
     """
     cdef _ThreadLocal tls = _ThreadLocal.get()
@@ -635,7 +636,7 @@ cpdef show_plan_cache_info():
     """Show all of the plan caches' info on this thread.
 
     .. seealso::
-        :class:`~cupy.fft.cache.PlanCache`
+        :class:`~cupy.fft._cache.PlanCache`
 
     """
 

--- a/docs/source/reference/fft.rst
+++ b/docs/source/reference/fft.rst
@@ -57,7 +57,6 @@ Helper routines
    cupy.fft.rfftfreq
    cupy.fft.fftshift
    cupy.fft.ifftshift
-   cupy.fft._cache.PlanCache
    cupy.fft.config.set_cufft_gpus
    cupy.fft.config.get_plan_cache
    cupy.fft.config.show_plan_cache_info
@@ -77,6 +76,8 @@ CuPy functions do not follow the behavior, they will return ``numpy.complex64`` 
 Internally, ``cupy.fft`` always generates a *cuFFT plan* (see the `cuFFT documentation`_ for detail) corresponding to the desired transform. When possible, an n-dimensional plan will be used, as opposed to applying separate 1D plans for each axis to be transformed. Using n-dimensional planning can provide better performance for multidimensional transforms, but requires more GPU memory than separable 1D planning. The user can disable n-dimensional planning by setting ``cupy.fft.config.enable_nd_planning = False``. This ability to adjust the planning type is a deviation from the NumPy API, which does not use precomputed FFT plans.
 
 Moreover, the automatic plan generation can be suppressed by using an existing plan returned by :func:`cupyx.scipy.fftpack.get_fft_plan` as a context manager. This is again a deviation from NumPy.
+
+Finally, when using the high-level NumPy-like FFT APIs as listed above, internally the cuFFT plans are cached for possible reuse. The plan cache can be retrieved by :func:`~cupy.fft.config.get_plan_cache`, and its current status can be queried by :func:`~cupy.fft.config.show_plan_cache_info`. For finer control of the plan cache, see :doc:`plan_cache`.
 
 
 Multi-GPU FFT

--- a/docs/source/reference/plan_cache.rst
+++ b/docs/source/reference/plan_cache.rst
@@ -1,0 +1,9 @@
+:orphan:
+
+
+cuFFT Plan Cache
+----------------
+
+.. autoclass:: cupy.fft._cache.PlanCache
+   :members:
+   :undoc-members:


### PR DESCRIPTION
Follow up of #3730. This PR moves `cupy.fft._cache.PlanCache` from the auto summary to a separate page, as it is meant to be a private class (for now). But, this change introduces a warning in Sphinx, which I am not quite sure how to fix, although it's certainly harmless (and intended):
```
...
pickling environment... done
checking consistency... /home/leofang/dev/cupy_rocm3.5.0/docs/source/reference/generated/cupy.fft._cache.PlanCache.rst: WARNING: document isn't included in any toctree
done
preparing documents... done
...
```
In addition, I also fixed a few hyperlink issues in the docstrings.