### PR TITLE
Fix typos in `cupy.cuda.cufft`

### DIFF
--- a/cupy/cuda/cufft.pyx
+++ b/cupy/cuda/cufft.pyx
@@ -854,10 +854,10 @@ class PlanNd(object):
                    (i == self.last_axis and size != self.last_size):
                     raise ValueError('output shape is incorrecct')
             if self.fft_type in (CUFFT_R2C, CUFFT_D2Z):
-                if out.dtype != cupy.dtype(a.dype.char.upper()):
+                if out.dtype != cupy.dtype(a.dtype.char.upper()):
                     raise ValueError('output dtype is unexpected')
             else:  # CUFFT_C2R or CUFFT_Z2D
-                if out.dtype != cupy.dtype(a.dype.char.lower()):
+                if out.dtype != cupy.dtype(a.dtype.char.lower()):
                     raise ValueError('output dtype is unexpected')
         if not ((out.flags.f_contiguous == a.flags.f_contiguous) and
                 (out.flags.c_contiguous == a.flags.c_contiguous)):


### PR DESCRIPTION
Follow up of #3102. Close #4009. Thanks to @plamenivanov257 for reporting.