### PR TITLE
Disable github checks annotations of Codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,6 @@
 comment: false
+github_checks:
+  annotations: false
 
 coverage:
   status:


### PR DESCRIPTION
Codecov annotations are bit cluttering when reviewing so we decided to disable it.

Confirmed the config is valid using `curl --data-binary @codecov.yml https://codecov.io/validate`.