### PR TITLE
Fix potential segfault when reduction axis is empty

### DIFF
--- a/cupy/core/_cub_reduction.pyx
+++ b/cupy/core/_cub_reduction.pyx
@@ -265,13 +265,13 @@ cpdef inline tuple _can_use_cub_block_reduction(
 
     # check reduction axes, if not contiguous then fall back to old kernel
     if in_arr._f_contiguous:
-        order = 'f'
+        order = 'F'
         if not cub._cub_device_segmented_reduce_axis_compatible(
                 reduce_axis, in_arr.ndim, order):
             return None
         axis_permutes_cub = tuple(sorted(reduce_axis) + sorted(out_axis))
     elif in_arr._c_contiguous:
-        order = 'c'
+        order = 'C'
         if not cub._cub_device_segmented_reduce_axis_compatible(
                 reduce_axis, in_arr.ndim, order):
             return None

--- a/cupy/core/_cub_reduction.pyx
+++ b/cupy/core/_cub_reduction.pyx
@@ -271,6 +271,10 @@ cpdef inline tuple _can_use_cub_block_reduction(
             return None
         axis_permutes_cub = tuple(sorted(reduce_axis) + sorted(out_axis))
     elif in_arr._c_contiguous:
+        order = 'c'
+        if not cub._cub_device_segmented_reduce_axis_compatible(
+                reduce_axis, in_arr.ndim, order):
+            return None
         axis_permutes_cub = tuple(sorted(out_axis) + sorted(reduce_axis))
     else:
         return None

--- a/cupy/core/_cub_reduction.pyx
+++ b/cupy/core/_cub_reduction.pyx
@@ -263,6 +263,8 @@ cpdef inline tuple _can_use_cub_block_reduction(
 
     # check reduction axes, if not contiguous then fall back to old kernel
     if in_arr._f_contiguous:
+        if reduce_axis is () and not in_arr._c_contiguous:
+            return None
         axis_permutes_cub = tuple(sorted(reduce_axis) + sorted(out_axis))
     elif in_arr._c_contiguous:
         axis_permutes_cub = tuple(sorted(out_axis) + sorted(reduce_axis))

--- a/cupy/core/_reduction.pyx
+++ b/cupy/core/_reduction.pyx
@@ -339,6 +339,10 @@ cdef class _AbstractReductionKernel:
             key = (self.name, shape_and_strides,
                    in_types, out_types, reduce_type, device_id)
 
+        if try_use_cub and in_args[0]._f_contiguous and in_args[0].ndim > 2:
+            # TODO: fix CUB-based reduction on Fortran arrays with ndim > 2
+            try_use_cub = False
+
         # Try to use CUB
         for accelerator in _accelerator._reduction_accelerators:
             if try_use_cub and accelerator == _accelerator.ACCELERATOR_CUB:

--- a/cupy/core/internal.pyx
+++ b/cupy/core/internal.pyx
@@ -363,8 +363,9 @@ cdef _broadcast_core(list arrays, shape_t& shape):
 cpdef bint _contig_axes(tuple axes):
     # Indicate if the specified axes are in ascending order without gaps.
     cdef Py_ssize_t n
-    cdef bint contig = True
-    for n in range(1, len(axes)):
+    cdef int n_ax = len(axes)
+    cdef bint contig = n_ax > 0
+    for n in range(1, n_ax):
         contig = (axes[n] - axes[n - 1]) == 1
         if not contig:
             break

--- a/cupy/cuda/cub.pxd
+++ b/cupy/cuda/cub.pxd
@@ -16,3 +16,5 @@ cpdef enum cupy_cub_op:
 cpdef cub_reduction(ndarray arr, op,
                     axis=*, dtype=*, ndarray out=*, keepdims=*)
 cpdef cub_scan(ndarray arr, op)
+
+cpdef bint _cub_device_segmented_reduce_axis_compatible(tuple, Py_ssize_t, str)

--- a/cupy/cuda/cub.pyx
+++ b/cupy/cuda/cub.pyx
@@ -375,7 +375,7 @@ def device_histogram(ndarray x, ndarray bins, ndarray y):
     return y
 
 
-cdef bint _cub_device_segmented_reduce_axis_compatible(
+cpdef bint _cub_device_segmented_reduce_axis_compatible(
         tuple cub_axis, Py_ssize_t ndim, str order):
     # This function checks if the reduced axes are C- or F- contiguous.
     if _contig_axes(cub_axis):

--- a/cupy/cutensor.pyx
+++ b/cupy/cutensor.pyx
@@ -740,6 +740,8 @@ def _try_reduction_routine(
     in_arg = x
 
     reduce_axis, out_axis = _reduction._get_axis(axis, x.ndim)
+    if len(reduce_axis) == 0:
+        return None
     out_shape = _reduction._get_out_shape(
         x._shape, reduce_axis, out_axis, keepdims)
     if out is None:

--- a/tests/cupy_tests/core_tests/test_ndarray_reduction.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_reduction.py
@@ -329,7 +329,7 @@ class TestUnacceleratedReduction(unittest.TestCase):
             a = xp.ascontiguousarray(a)
         elif self.order in ('f', 'F'):
             a = xp.asfortranarray(a)
-        return a.max(axis=axis)
+        return a.min(axis=axis)
 
     @testing.for_all_dtypes(no_bool=True, no_float16=True)
     @testing.numpy_cupy_allclose(rtol=1E-5, contiguous_check=False)

--- a/tests/cupy_tests/core_tests/test_ndarray_reduction.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_reduction.py
@@ -305,66 +305,6 @@ class TestCubReduction(unittest.TestCase):
         return a.max(axis=())
 
 
-# This class compares cuTensor-based reduction results against NumPy's
-@testing.parameterize(*testing.product({
-    'shape': [(10,), (10, 20), (10, 20, 30), (10, 20, 30, 40)],
-    'order': ('C', 'F'),
-}))
-@testing.gpu
-@unittest.skipUnless(cupy.cuda.cutensor.available,
-                     'The cuTENSOR routine is not enabled')
-class TestCutensorReduction(unittest.TestCase):
-
-    def setUp(self):
-        self.old_accelerators = _accelerator.get_routine_accelerators()
-        _accelerator.set_routine_accelerators(['cutensor'])
-
-    def tearDown(self):
-        _accelerator.set_routine_accelerators(self.old_accelerators)
-
-    @testing.for_contiguous_axes()
-    @testing.for_all_dtypes(no_bool=True, no_float16=True)
-    @testing.numpy_cupy_allclose(rtol=1E-5, contiguous_check=False)
-    def test_cutensor_min(self, xp, dtype, axis):
-        a = testing.shaped_random(self.shape, xp, dtype)
-        if self.order in ('c', 'C'):
-            a = xp.ascontiguousarray(a)
-        elif self.order in ('f', 'F'):
-            a = xp.asfortranarray(a)
-        return a.min(axis=axis)
-
-    @testing.for_all_dtypes(no_bool=True, no_float16=True)
-    @testing.numpy_cupy_allclose(rtol=1E-5, contiguous_check=False)
-    def test_cutensor_min_empty_axis(self, xp, dtype):
-        a = testing.shaped_random(self.shape, xp, dtype)
-        if self.order in ('c', 'C'):
-            a = xp.ascontiguousarray(a)
-        elif self.order in ('f', 'F'):
-            a = xp.asfortranarray(a)
-        return a.min(axis=())
-
-    @testing.for_contiguous_axes()
-    @testing.for_all_dtypes(no_bool=True, no_float16=True)
-    @testing.numpy_cupy_allclose(rtol=1E-5, contiguous_check=False)
-    def test_cutensor_max(self, xp, dtype, axis):
-        a = testing.shaped_random(self.shape, xp, dtype)
-        if self.order in ('c', 'C'):
-            a = xp.ascontiguousarray(a)
-        elif self.order in ('f', 'F'):
-            a = xp.asfortranarray(a)
-        return a.max(axis=axis)
-
-    @testing.for_all_dtypes(no_bool=True, no_float16=True)
-    @testing.numpy_cupy_allclose(rtol=1E-5, contiguous_check=False)
-    def test_cutensor_max_empty_axis(self, xp, dtype):
-        a = testing.shaped_random(self.shape, xp, dtype)
-        if self.order in ('c', 'C'):
-            a = xp.ascontiguousarray(a)
-        elif self.order in ('f', 'F'):
-            a = xp.asfortranarray(a)
-        return a.max(axis=())
-
-
 # This class compares unaccelerated reduction results against NumPy's
 @testing.parameterize(*testing.product({
     'shape': [(10,), (10, 20), (10, 20, 30), (10, 20, 30, 40)],

--- a/tests/cupy_tests/core_tests/test_ndarray_reduction.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_reduction.py
@@ -260,6 +260,16 @@ class TestCubReduction(unittest.TestCase):
         # ...then perform the actual computation
         return a.min(axis=axis)
 
+    @testing.for_all_dtypes(no_bool=True, no_float16=True)
+    @testing.numpy_cupy_allclose(rtol=1E-5)
+    def test_cub_min_empty_axis(self, xp, dtype, contiguous_check=False):
+        a = testing.shaped_random(self.shape, xp, dtype)
+        if self.order in ('c', 'C'):
+            a = xp.ascontiguousarray(a)
+        elif self.order in ('f', 'F'):
+            a = xp.asfortranarray(a)
+        return a.min(axis=())
+
     @testing.for_contiguous_axes()
     @testing.for_all_dtypes(no_bool=True, no_float16=True)
     @testing.numpy_cupy_allclose(rtol=1E-5)
@@ -283,3 +293,131 @@ class TestCubReduction(unittest.TestCase):
             a.max(axis=axis)
         # ...then perform the actual computation
         return a.max(axis=axis)
+
+    @testing.for_all_dtypes(no_bool=True, no_float16=True)
+    @testing.numpy_cupy_allclose(rtol=1E-5, contiguous_check=False)
+    def test_cub_max_empty_axis(self, xp, dtype):
+        a = testing.shaped_random(self.shape, xp, dtype)
+        if self.order in ('c', 'C'):
+            a = xp.ascontiguousarray(a)
+        elif self.order in ('f', 'F'):
+            a = xp.asfortranarray(a)
+        return a.max(axis=())
+
+
+# This class compares CUB results against NumPy's
+@testing.parameterize(*testing.product({
+    'shape': [(10,), (10, 20), (10, 20, 30), (10, 20, 30, 40)],
+    'order': ('C', 'F'),
+}))
+@testing.gpu
+@unittest.skipUnless(cupy.cuda.cub.available, 'The CUB routine is not enabled')
+class TestCutensorReduction(unittest.TestCase):
+
+    def setUp(self):
+        self.old_accelerators = _accelerator.get_routine_accelerators()
+        _accelerator.set_routine_accelerators(['cutensor'])
+
+    def tearDown(self):
+        _accelerator.set_routine_accelerators(self.old_accelerators)
+
+    @testing.for_contiguous_axes()
+    @testing.for_all_dtypes(no_bool=True, no_float16=True)
+    @testing.numpy_cupy_allclose(rtol=1E-5)
+    def test_cutensor_min(self, xp, dtype, axis):
+        a = testing.shaped_random(self.shape, xp, dtype)
+        if self.order in ('c', 'C'):
+            a = xp.ascontiguousarray(a)
+        elif self.order in ('f', 'F'):
+            a = xp.asfortranarray(a)
+        return a.min(axis=axis)
+
+    @testing.for_all_dtypes(no_bool=True, no_float16=True)
+    @testing.numpy_cupy_allclose(rtol=1E-5, contiguous_check=False)
+    def test_cutensor_min_empty_axis(self, xp, dtype):
+        a = testing.shaped_random(self.shape, xp, dtype)
+        if self.order in ('c', 'C'):
+            a = xp.ascontiguousarray(a)
+        elif self.order in ('f', 'F'):
+            a = xp.asfortranarray(a)
+        return a.min(axis=())
+
+    @testing.for_contiguous_axes()
+    @testing.for_all_dtypes(no_bool=True, no_float16=True)
+    @testing.numpy_cupy_allclose(rtol=1E-5)
+    def test_cutensor_max(self, xp, dtype, axis):
+        a = testing.shaped_random(self.shape, xp, dtype)
+        if self.order in ('c', 'C'):
+            a = xp.ascontiguousarray(a)
+        elif self.order in ('f', 'F'):
+            a = xp.asfortranarray(a)
+        return a.max(axis=axis)
+
+    @testing.for_all_dtypes(no_bool=True, no_float16=True)
+    @testing.numpy_cupy_allclose(rtol=1E-5, contiguous_check=False)
+    def test_cutensor_max_empty_axis(self, xp, dtype):
+        a = testing.shaped_random(self.shape, xp, dtype)
+        if self.order in ('c', 'C'):
+            a = xp.ascontiguousarray(a)
+        elif self.order in ('f', 'F'):
+            a = xp.asfortranarray(a)
+        return a.max(axis=())
+
+
+# This class compares CUB results against NumPy's
+@testing.parameterize(*testing.product({
+    'shape': [(10,), (10, 20), (10, 20, 30), (10, 20, 30, 40)],
+    'order': ('C', 'F'),
+}))
+@testing.gpu
+@unittest.skipUnless(cupy.cuda.cub.available, 'The CUB routine is not enabled')
+class TestUnacceleratedReduction(unittest.TestCase):
+
+    def setUp(self):
+        self.old_accelerators = _accelerator.get_routine_accelerators()
+        _accelerator.set_routine_accelerators([])
+
+    def tearDown(self):
+        _accelerator.set_routine_accelerators(self.old_accelerators)
+
+    @testing.for_contiguous_axes()
+    @testing.for_all_dtypes(no_bool=True, no_float16=True)
+    @testing.numpy_cupy_allclose(rtol=1E-5, contiguous_check=False)
+    def test_unaccelerated_min(self, xp, dtype, axis):
+        a = testing.shaped_random(self.shape, xp, dtype)
+        if self.order in ('c', 'C'):
+            a = xp.ascontiguousarray(a)
+        elif self.order in ('f', 'F'):
+            a = xp.asfortranarray(a)
+        return a.max(axis=axis)
+
+    @testing.for_all_dtypes(no_bool=True, no_float16=True)
+    @testing.numpy_cupy_allclose(rtol=1E-5, contiguous_check=False)
+    def test_unaccelerated_min_empty_axis(self, xp, dtype):
+        a = testing.shaped_random(self.shape, xp, dtype)
+        if self.order in ('c', 'C'):
+            a = xp.ascontiguousarray(a)
+        elif self.order in ('f', 'F'):
+            a = xp.asfortranarray(a)
+        return a.min(axis=())
+
+    @testing.for_contiguous_axes()
+    @testing.for_all_dtypes(no_bool=True, no_float16=True)
+    @testing.numpy_cupy_allclose(rtol=1E-5, contiguous_check=False)
+    def test_unaccelerated_max(self, xp, dtype, axis):
+        a = testing.shaped_random(self.shape, xp, dtype)
+        if self.order in ('c', 'C'):
+            a = xp.ascontiguousarray(a)
+        elif self.order in ('f', 'F'):
+            a = xp.asfortranarray(a)
+        return a.max(axis=axis)
+
+    @testing.for_all_dtypes(no_bool=True, no_float16=True)
+    @testing.numpy_cupy_allclose(rtol=1E-5, contiguous_check=False)
+    def test_unaccelerated_max_empty_axis(self, xp, dtype):
+        a = testing.shaped_random(self.shape, xp, dtype)
+        if self.order in ('c', 'C'):
+            a = xp.ascontiguousarray(a)
+        elif self.order in ('f', 'F'):
+            a = xp.asfortranarray(a)
+        return a.max(axis=())

--- a/tests/cupy_tests/core_tests/test_ndarray_reduction.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_reduction.py
@@ -317,9 +317,13 @@ class TestUnacceleratedReduction(unittest.TestCase):
     def setUp(self):
         self.old_accelerators = _acc.get_routine_accelerators()
         _acc.set_routine_accelerators([])
+        # also avoid fallback to CUB via the general reduction kernel
+        self.old_reduction_accelerators = _acc.get_reduction_accelerators()
+        _acc.set_reduction_accelerators([])
 
     def tearDown(self):
         _acc.set_routine_accelerators(self.old_accelerators)
+        _acc.set_reduction_accelerators(self.old_reduction_accelerators)
 
     @testing.for_contiguous_axes()
     @testing.for_all_dtypes(no_bool=True, no_float16=True)

--- a/tests/cupy_tests/core_tests/test_ndarray_reduction.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_reduction.py
@@ -5,6 +5,7 @@ import pytest
 
 import cupy
 import cupy.core._accelerator as _acc
+
 from cupy import testing
 
 
@@ -314,11 +315,11 @@ class TestCubReduction(unittest.TestCase):
 class TestUnacceleratedReduction(unittest.TestCase):
 
     def setUp(self):
-        self.old_accelerators = _accelerator.get_routine_accelerators()
-        _accelerator.set_routine_accelerators([])
+        self.old_accelerators = _acc.get_routine_accelerators()
+        _acc.set_routine_accelerators([])
 
     def tearDown(self):
-        _accelerator.set_routine_accelerators(self.old_accelerators)
+        _acc.set_routine_accelerators(self.old_accelerators)
 
     @testing.for_contiguous_axes()
     @testing.for_all_dtypes(no_bool=True, no_float16=True)

--- a/tests/cupy_tests/core_tests/test_ndarray_reduction.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_reduction.py
@@ -261,7 +261,7 @@ class TestCubReduction(unittest.TestCase):
         return a.min(axis=axis)
 
     @testing.for_all_dtypes(no_bool=True, no_float16=True)
-    @testing.numpy_cupy_allclose(rtol=1E-5)
+    @testing.numpy_cupy_allclose(rtol=1E-5, contiguous_check=False)
     def test_cub_min_empty_axis(self, xp, dtype, contiguous_check=False):
         a = testing.shaped_random(self.shape, xp, dtype)
         if self.order in ('c', 'C'):
@@ -323,7 +323,7 @@ class TestCutensorReduction(unittest.TestCase):
 
     @testing.for_contiguous_axes()
     @testing.for_all_dtypes(no_bool=True, no_float16=True)
-    @testing.numpy_cupy_allclose(rtol=1E-5)
+    @testing.numpy_cupy_allclose(rtol=1E-5, contiguous_check=False)
     def test_cutensor_min(self, xp, dtype, axis):
         a = testing.shaped_random(self.shape, xp, dtype)
         if self.order in ('c', 'C'):
@@ -344,7 +344,7 @@ class TestCutensorReduction(unittest.TestCase):
 
     @testing.for_contiguous_axes()
     @testing.for_all_dtypes(no_bool=True, no_float16=True)
-    @testing.numpy_cupy_allclose(rtol=1E-5)
+    @testing.numpy_cupy_allclose(rtol=1E-5, contiguous_check=False)
     def test_cutensor_max(self, xp, dtype, axis):
         a = testing.shaped_random(self.shape, xp, dtype)
         if self.order in ('c', 'C'):

--- a/tests/cupy_tests/core_tests/test_ndarray_reduction.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_reduction.py
@@ -305,13 +305,14 @@ class TestCubReduction(unittest.TestCase):
         return a.max(axis=())
 
 
-# This class compares CUB results against NumPy's
+# This class compares cuTensor-based reduction results against NumPy's
 @testing.parameterize(*testing.product({
     'shape': [(10,), (10, 20), (10, 20, 30), (10, 20, 30, 40)],
     'order': ('C', 'F'),
 }))
 @testing.gpu
-@unittest.skipUnless(cupy.cuda.cutensor.available, 'The CUB routine is not enabled')
+@unittest.skipUnless(cupy.cuda.cutensor.available,
+                     'The cuTENSOR routine is not enabled')
 class TestCutensorReduction(unittest.TestCase):
 
     def setUp(self):
@@ -364,7 +365,7 @@ class TestCutensorReduction(unittest.TestCase):
         return a.max(axis=())
 
 
-# This class compares CUB results against NumPy's
+# This class compares unaccelerated reduction results against NumPy's
 @testing.parameterize(*testing.product({
     'shape': [(10,), (10, 20), (10, 20, 30), (10, 20, 30, 40)],
     'order': ('C', 'F'),

--- a/tests/cupy_tests/core_tests/test_ndarray_reduction.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_reduction.py
@@ -311,7 +311,7 @@ class TestCubReduction(unittest.TestCase):
     'order': ('C', 'F'),
 }))
 @testing.gpu
-@unittest.skipUnless(cupy.cuda.cub.available, 'The CUB routine is not enabled')
+@unittest.skipUnless(cupy.cuda.cutensor.available, 'The CUB routine is not enabled')
 class TestCutensorReduction(unittest.TestCase):
 
     def setUp(self):
@@ -370,7 +370,6 @@ class TestCutensorReduction(unittest.TestCase):
     'order': ('C', 'F'),
 }))
 @testing.gpu
-@unittest.skipUnless(cupy.cuda.cub.available, 'The CUB routine is not enabled')
 class TestUnacceleratedReduction(unittest.TestCase):
 
     def setUp(self):

--- a/tests/cupy_tests/math_tests/test_sumprod.py
+++ b/tests/cupy_tests/math_tests/test_sumprod.py
@@ -5,7 +5,6 @@ import pytest
 
 import cupy
 import cupy._util
-from cupy.core import _accelerator
 from cupy import testing
 
 
@@ -210,11 +209,11 @@ class TestSumprod(unittest.TestCase):
 class TestCubReduction(unittest.TestCase):
 
     def setUp(self):
-        self.old_accelerators = _accelerator.get_routine_accelerators()
-        _accelerator.set_routine_accelerators(['cub'])
+        self.old_accelerators = cupy.core.get_routine_accelerators()
+        cupy.core.set_routine_accelerators(['cub'])
 
     def tearDown(self):
-        _accelerator.set_routine_accelerators(self.old_accelerators)
+        cupy.core.set_routine_accelerators(self.old_accelerators)
 
     @testing.for_contiguous_axes()
     # sum supports less dtypes; don't test float16 as it's not as accurate?
@@ -347,11 +346,11 @@ class TestCubReduction(unittest.TestCase):
 class TestCuTensorReduction(unittest.TestCase):
 
     def setUp(self):
-        self.old_accelerators = _accelerator.get_routine_accelerators()
-        _accelerator.set_routine_accelerators(['cutensor'])
+        self.old_accelerators = cupy.core.get_routine_accelerators()
+        cupy.core.set_routine_accelerators(['cutensor'])
 
     def tearDown(self):
-        _accelerator.set_routine_accelerators(self.old_accelerators)
+        cupy.core.set_routine_accelerators(self.old_accelerators)
 
     @testing.for_contiguous_axes()
     # sum supports less dtypes; don't test float16 as it's not as accurate?

--- a/tests/cupy_tests/math_tests/test_sumprod.py
+++ b/tests/cupy_tests/math_tests/test_sumprod.py
@@ -125,6 +125,12 @@ class TestSumprod(unittest.TestCase):
         a = testing.shaped_arange((20, 30, 40, 50), xp, dtype)
         return a.sum(axis=(0, 2, 3))
 
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose()
+    def test_sum_empty_axis(self, xp, dtype):
+        a = testing.shaped_arange((2, 3, 4, 5), xp, dtype)
+        return a.sum(axis=())
+
     @testing.for_all_dtypes_combination(names=['src_dtype', 'dst_dtype'])
     @testing.numpy_cupy_allclose()
     def test_sum_dtype(self, xp, src_dtype, dst_dtype):
@@ -235,6 +241,17 @@ class TestCubReduction(unittest.TestCase):
         # ...then perform the actual computation
         return a.sum(axis=axis)
 
+    # sum supports less dtypes; don't test float16 as it's not as accurate?
+    @testing.for_dtypes('lLfdFD')
+    @testing.numpy_cupy_allclose(rtol=1E-5, contiguous_check=False)
+    def test_cub_sum_empty_axis(self, xp, dtype):
+        a = testing.shaped_random(self.shape, xp, dtype)
+        if self.order in ('c', 'C'):
+            a = xp.ascontiguousarray(a)
+        elif self.order in ('f', 'F'):
+            a = xp.asfortranarray(a)
+        return a.sum(axis=())
+
     @testing.for_contiguous_axes()
     # prod supports less dtypes; don't test float16 as it's not as accurate?
     @testing.for_dtypes('lLfdFD')
@@ -317,6 +334,57 @@ class TestCubReduction(unittest.TestCase):
             pos = xp.where(xp.isinf(result))
             result[pos] = xp.nan + 1j * xp.nan
         return result
+
+
+# This class compares cuTENSOR results against NumPy's
+@testing.parameterize(*testing.product({
+    'shape': [(10,), (10, 20), (10, 20, 30), (10, 20, 30, 40)],
+    'order': ('C', 'F'),
+}))
+@testing.gpu
+@unittest.skipUnless(cupy.cuda.cutensor.available,
+                     'The cuTENSOR routine is not enabled')
+class TestCuTensorReduction(unittest.TestCase):
+
+    def setUp(self):
+        self.old_accelerators = _accelerator.get_routine_accelerators()
+        _accelerator.set_routine_accelerators(['cutensor'])
+
+    def tearDown(self):
+        _accelerator.set_routine_accelerators(self.old_accelerators)
+
+    @testing.for_contiguous_axes()
+    # sum supports less dtypes; don't test float16 as it's not as accurate?
+    @testing.for_dtypes('lLfdFD')
+    @testing.numpy_cupy_allclose(rtol=1E-5, contiguous_check=False)
+    def test_cutensor_sum(self, xp, dtype, axis):
+        a = testing.shaped_random(self.shape, xp, dtype)
+        if self.order in ('c', 'C'):
+            a = xp.ascontiguousarray(a)
+        elif self.order in ('f', 'F'):
+            a = xp.asfortranarray(a)
+
+        if xp is numpy:
+            return a.sum(axis=axis)
+
+        # xp is cupy, first ensure we really use CUB
+        ret = cupy.empty(())  # Cython checks return type, need to fool it
+        func = 'cupy.cutensor._try_reduction_routine'
+        with testing.AssertFunctionIsCalled(func, return_value=ret):
+            a.sum(axis=axis)
+        # ...then perform the actual computation
+        return a.sum(axis=axis)
+
+    # sum supports less dtypes; don't test float16 as it's not as accurate?
+    @testing.for_dtypes('lLfdFD')
+    @testing.numpy_cupy_allclose(rtol=1E-5, contiguous_check=False)
+    def test_cutensor_sum_empty_axis(self, xp, dtype):
+        a = testing.shaped_random(self.shape, xp, dtype)
+        if self.order in ('c', 'C'):
+            a = xp.ascontiguousarray(a)
+        elif self.order in ('f', 'F'):
+            a = xp.asfortranarray(a)
+        return a.sum(axis=())
 
 
 @testing.parameterize(

--- a/tests/cupy_tests/math_tests/test_sumprod.py
+++ b/tests/cupy_tests/math_tests/test_sumprod.py
@@ -367,7 +367,7 @@ class TestCuTensorReduction(unittest.TestCase):
         if xp is numpy:
             return a.sum(axis=axis)
 
-        # xp is cupy, first ensure we really use CUB
+        # xp is cupy, first ensure we really use cuTENSOR
         ret = cupy.empty(())  # Cython checks return type, need to fool it
         func = 'cupy.cutensor._try_reduction_routine'
         with testing.AssertFunctionIsCalled(func, return_value=ret):


### PR DESCRIPTION
closes #4023

~TODO: The test cases here no longer segfault, but many of the Fortran-contiguous cases do not pass. This seems to be a separate bug somewhere in reductions on F-ordered arrays when CUB is disabled.~

After a clean rebuild, the only difference is that sometimes unaccelerated or cuTENSOR reductions reductions return a result with different contiguity. The actual values seem to be fine and the tests here all pass for me now.


