### PR TITLE
ROCm: Support hipCUB/rocPRIM

### DIFF
--- a/.pfnci/script.sh
+++ b/.pfnci/script.sh
@@ -76,7 +76,7 @@ main() {
       #echo 'deb [arch=amd64] http://repo.radeon.com/rocm/apt/debian/ xenial main' | tee /etc/apt/sources.list.d/rocm.list
 
       apt update -qqy
-      apt install rocm-dev hipblas hipsparse rocsparse rocrand rocthrust rocsolver rocfft -qqy
+      apt install rocm-dev hipblas hipsparse rocsparse rocrand rocthrust rocsolver rocfft hipcub rocprim -qqy
       export HCC_AMDGPU_TARGET=gfx900
       export ROCM_HOME=/opt/rocm
       export CUPY_INSTALL_USE_HIP=1

--- a/cupy/_environment.py
+++ b/cupy/_environment.py
@@ -10,10 +10,14 @@ import shutil
 import sys
 import warnings
 
+from cupy_backends.cuda.api import runtime
+
 
 # '' for uninitialized, None for non-existing
 _cuda_path = ''
 _nvcc_path = ''
+_rocm_path = ''
+_hipcc_path = ''
 _cub_path = ''
 
 """
@@ -78,6 +82,22 @@ def get_nvcc_path():
     return _nvcc_path
 
 
+def get_rocm_path():
+    # Returns the ROCm installation path or None if not found.
+    global _rocm_path
+    if _rocm_path == '':
+        _rocm_path = _get_rocm_path()
+    return _rocm_path
+
+
+def get_hipcc_path():
+    # Returns the path to the nvcc command or None if not found.
+    global _hipcc_path
+    if _hipcc_path == '':
+        _hipcc_path = _get_hipcc_path()
+    return _hipcc_path
+
+
 def get_cub_path():
     # Returns the CUB header path or None if not found.
     global _cub_path
@@ -118,19 +138,58 @@ def _get_nvcc_path():
     return shutil.which('nvcc', path=os.path.join(cuda_path, 'bin'))
 
 
+def _get_rocm_path():
+    # Use environment variable
+    rocm_path = os.environ.get('ROCM_HOME', '')
+    if os.path.exists(rocm_path):
+        return rocm_path
+
+    # Use hipcc path
+    hipcc_path = shutil.which('hipcc')
+    if hipcc_path is not None:
+        return os.path.dirname(os.path.dirname(hipcc_path))
+
+    # Use typical path
+    if os.path.exists('/opt/rocm'):
+        return '/opt/rocm'
+
+    return None
+
+
+def _get_hipcc_path():
+    # TODO(leofang): Introduce an env var HIPCC?
+
+    # Lookup <ROCM>/bin
+    rocm_path = get_rocm_path()
+    if rocm_path is None:
+        return None
+
+    return shutil.which('hipcc', path=os.path.join(rocm_path, 'bin'))
+
+
 def _get_cub_path():
     # runtime discovery of CUB headers
-    cuda_path = get_cuda_path()
     current_dir = os.path.dirname(os.path.abspath(__file__))
 
-    if os.path.isdir(os.path.join(current_dir, 'core/include/cupy/cub')):
-        _cub_path = '<bundle>'
-    elif cuda_path is not None and os.path.isdir(
-            os.path.join(cuda_path, 'include/cub')):
-        # use built-in CUB for CUDA 11+
-        _cub_path = '<CUDA>'
+    if not runtime.is_hip:
+        cuda_path = get_cuda_path()
+        if os.path.isdir(os.path.join(current_dir, 'core/include/cupy/cub')):
+            _cub_path = '<bundle>'
+        elif cuda_path is not None and os.path.isdir(
+                os.path.join(cuda_path, 'include/cub')):
+            # use built-in CUB for CUDA 11+
+            _cub_path = '<CUDA>'
+        else:
+            _cub_path = None
     else:
-        _cub_path = None
+        # the bundled CUB does not work in ROCm
+        rocm_path = get_rocm_path()
+        if rocm_path is not None and os.path.isdir(
+                os.path.join(rocm_path, 'include/hipcub')):
+            # use hipCUB
+            _cub_path = '<ROCm>'
+        else:
+            _cub_path = None
     return _cub_path
 
 

--- a/cupy/_environment.py
+++ b/cupy/_environment.py
@@ -91,7 +91,7 @@ def get_rocm_path():
 
 
 def get_hipcc_path():
-    # Returns the path to the nvcc command or None if not found.
+    # Returns the path to the hipcc command or None if not found.
     global _hipcc_path
     if _hipcc_path == '':
         _hipcc_path = _get_hipcc_path()

--- a/cupy/_statistics/histogram.py
+++ b/cupy/_statistics/histogram.py
@@ -8,6 +8,8 @@ from cupy import core
 from cupy.core import _accelerator
 from cupy.cuda import cub
 from cupy.cuda import common
+from cupy.cuda import runtime
+
 
 # rename builtin range for use in functions that take a range argument
 _range = range
@@ -240,7 +242,11 @@ def histogram(x, bins=10, range=None, weights=None, density=False):
                 elif x.dtype.kind == 'f':
                     last = acc_bin_edge[-1]
                     acc_bin_edge[-1] = cupy.nextafter(last, last + 1)
+                if runtime.is_hip:
+                    y = y.astype(cupy.uint64, copy=False)
                 y = cub.device_histogram(x, acc_bin_edge, y)
+                if runtime.is_hip:
+                    y = y.astype(cupy.int64, copy=False)
                 break
         else:
             _histogram_kernel(x, bin_edges, bin_edges.size, y)

--- a/cupy/core/_cub_reduction.pyx
+++ b/cupy/core/_cub_reduction.pyx
@@ -30,6 +30,11 @@ cdef function.Function _create_cub_reduction_function(
     # static_assert needs at least C++11 in NVRTC
     options += ('--std=c++11',)
 
+    # In ROCm, we need to set the include path. This does not work for hiprtc
+    # as of ROCm 3.5.0, so we must use hipcc.
+    if runtime._is_hip_environment:
+        options += ('-I' + _rocm_path + '/include',)
+
     # TODO(leofang): try splitting the for-loop into full tiles and partial
     # tiles to utilize LoadDirectBlockedVectorized? See, for example,
     # https://github.com/NVlabs/cub/blob/c3cceac115c072fb63df1836ff46d8c60d9eb304/cub/agent/agent_reduce.cuh#L311-L346
@@ -47,6 +52,11 @@ static_assert(sizeof(_type_reduce) <= 32,
 // Compile-time constants for CUB template specializations
 #define ITEMS_PER_THREAD  ${items_per_thread}
 #define BLOCK_SIZE        ${block_size}
+
+// for hipCUB: use the hipcub namespace
+#ifdef __HIP_DEVICE_COMPILE__
+#define cub hipcub
+#endif
 
 #if defined FIRST_PASS
     typedef type_in0_raw  type_mid_in;
@@ -215,6 +225,8 @@ def _SimpleCubReductionKernel_get_cached_function(
 
 cdef str _cub_path = _environment.get_cub_path()
 cdef str _nvcc_path = _environment.get_nvcc_path()
+cdef str _rocm_path = _environment.get_rocm_path()
+cdef str _hipcc_path = _environment.get_hipcc_path()
 cdef str _cub_header = None
 
 
@@ -224,6 +236,7 @@ cdef str _get_cub_header_include():
         return _cub_header
 
     assert _cub_path is not None
+    cdef str rocm_path = None
     if _cub_path == '<bundle>':
         _cub_header = '''
 #include <cupy/cub/cub/block/block_reduce.cuh>
@@ -233,6 +246,12 @@ cdef str _get_cub_header_include():
         _cub_header = '''
 #include <cub/block/block_reduce.cuh>
 #include <cub/block/block_load.cuh>
+'''
+    elif _cub_path == '<ROCm>':
+        # As of ROCm 3.5.0, the block headers cannot be included by themselves
+        # (many macros left undefined), so we must use the master header.
+        _cub_header = '''
+#include <hipcub/hipcub.hpp>
 '''
     return _cub_header
 
@@ -290,8 +309,12 @@ cpdef inline tuple _can_use_cub_block_reduction(
             return None
 
     # rare event (mainly for conda-forge users): nvcc is not found!
-    if _nvcc_path is None:
-        return None
+    if not runtime._is_hip_environment:
+        if _nvcc_path is None:
+            return None
+    else:
+        if _hipcc_path is None:
+            return None
 
     return (axis_permutes_cub, contiguous_size, full_reduction)
 

--- a/cupy/core/_routines_math.pyx
+++ b/cupy/core/_routines_math.pyx
@@ -17,11 +17,7 @@ from cupy.core.core cimport compile_with_cache
 from cupy.core.core cimport ndarray
 from cupy.cuda cimport memory
 
-# TODO(leofang): always import cub when hipCUB is supported
-if not cupy.cuda.runtime.is_hip:
-    from cupy.cuda import cub
-else:
-    cub = None
+from cupy.cuda import cub
 
 if cupy.cuda.cutensor.available:
     import cupy_backends.cuda.libs.cutensor as cuda_cutensor

--- a/cupy/core/_routines_statistics.pyx
+++ b/cupy/core/_routines_statistics.pyx
@@ -12,11 +12,7 @@ from cupy.core cimport _accelerator
 from cupy.core cimport _routines_math as _math
 from cupy.core.core cimport ndarray
 
-# TODO(leofang): always import cub when hipCUB is supported
-if not cupy.cuda.runtime.is_hip:
-    from cupy.cuda import cub
-else:
-    cub = None
+from cupy.cuda import cub
 
 if cupy.cuda.cutensor.available:
     import cupy_backends.cuda.libs.cutensor as cuda_cutensor

--- a/cupy/cuda/__init__.py
+++ b/cupy/cuda/__init__.py
@@ -31,11 +31,7 @@ class _UnavailableModule():
         self.__name__ = name
 
 
-# TODO(leofang): always import cub (but not enable it) when hipCUB is supported
-if not runtime.is_hip:
-    from cupy.cuda import cub  # NOQA
-else:
-    cub = _UnavailableModule('cupy.cuda.cub')
+from cupy.cuda import cub  # NOQA
 
 try:
     from cupy.cuda import nvtx  # NOQA

--- a/cupy/cuda/cub.pyx
+++ b/cupy/cuda/cub.pyx
@@ -5,6 +5,7 @@
 from cpython cimport sequence
 
 from cupy_backends.cuda.api.driver cimport Stream as Stream_t
+from cupy_backends.cuda.api cimport runtime
 from cupy.core.core cimport _internal_ascontiguousarray
 from cupy.core.core cimport _internal_asfortranarray
 from cupy.core.internal cimport _contig_axes
@@ -272,6 +273,8 @@ def device_csrmv(int n_rows, int n_cols, int nnz, ndarray values,
         raise ValueError('array must be 1d')
     if x.size != n_cols:
         raise ValueError("size of array does not match the CSR matrix")
+    if runtime._is_hip_environment:
+        raise RuntimeError("hipCUB does not support SpMV")
 
     if values.dtype == x.dtype:
         dtype = values.dtype

--- a/cupy/cuda/cupy_cub.cu
+++ b/cupy/cuda/cupy_cub.cu
@@ -1,13 +1,22 @@
 #include "cupy_cub.h"  // need to make atomicAdd visible to CUB templates early
 #include <cupy/type_dispatcher.cuh>
+
+#ifndef CUPY_USE_HIP
 #include <cub/device/device_reduce.cuh>
 #include <cub/device/device_segmented_reduce.cuh>
 #include <cub/device/device_spmv.cuh>
 #include <cub/device/device_scan.cuh>
 #include <cub/device/device_histogram.cuh>
-
-
 using namespace cub;
+#else
+#include <hipcub/device/device_reduce.hpp>
+#include <hipcub/device/device_segmented_reduce.hpp>
+//#include <hipcub/device/device_spmv.hpp>  // doesn't exist
+#include <hipcub/device/device_scan.hpp>
+#include <hipcub/device/device_histogram.hpp>
+using namespace hipcub;
+#endif
+
 
 /* ------------------------------------ Minimum boilerplate to support complex numbers ------------------------------------ */
 // - This works only because all data fields in the *Traits struct are not

--- a/cupy/cuda/cupy_cub.cu
+++ b/cupy/cuda/cupy_cub.cu
@@ -8,10 +8,8 @@
 #include <cub/device/device_scan.cuh>
 #include <cub/device/device_histogram.cuh>
 #else
-#include <limits>
 #include <hipcub/device/device_reduce.hpp>
 #include <hipcub/device/device_segmented_reduce.hpp>
-//#include <hipcub/device/device_spmv.hpp>  // doesn't exist
 #include <hipcub/device/device_scan.hpp>
 #include <hipcub/device/device_histogram.hpp>
 #endif
@@ -58,6 +56,7 @@ template <> struct NumericTraits<complex<double>> : BaseTraits<FLOATING_POINT, t
 
 // hipCUB internally uses std::numeric_limits, so we should provide specializations for the complex numbers.
 // Note that there's std::complex, so to avoid name collision we must use the full decoration (thrust::complex)!
+// TODO(leofang): wrap CuPy's thrust namespace with another one (say, cupy::thrust) for safer scope resolution?
 
 namespace std {
 template <>
@@ -256,12 +255,6 @@ __host__ __device__ __forceinline__ complex<float> Min::operator()(const complex
     if (isnan(a)) {return a;}
     else if (isnan(b)) {return b;}
     else {return a < b ? a : b;}
-    //complex<float> ans;
-    //if (isnan(a)) {ans = a;}
-    //else if (isnan(b)) {ans = b;}
-    //else {ans = (a < b ? a : b);}
-    //printf("I got %f + I %f\n", ans.real(), ans.imag());
-    //return ans;
 }
 
 // specialization for complex<double> for handling NaNs
@@ -681,6 +674,7 @@ struct _cub_histogram_range {
         // TODO(leofang): CUB has a bug that when specializing n_samples with type size_t,
         // it would error out. Before the fix (thrust/cub#38) is merged we disable the code
         // path splitting for now. A type/range check must be done in the caller.
+        // TODO(leofang): check if hipCUB has the same bug or not
 
         // if (n_samples < (1ULL << 31)) {
             int num_samples = n_samples;

--- a/cupy/cuda/cupy_cub.h
+++ b/cupy/cuda/cupy_cub.h
@@ -16,7 +16,14 @@
 #endif
 
 #ifndef CUPY_NO_CUDA
-#include <cuda_runtime.h>  // for cudaStream_t
+
+// for cudaStream_t
+#ifndef CUPY_USE_HIP
+#include <cuda_runtime.h>
+#else
+#include <hip_runtime.h>
+#define cudaStream_t hipStream_t
+#endif
 
 void cub_device_reduce(void*, size_t&, void*, void*, int, cudaStream_t, int, int);
 void cub_device_segmented_reduce(void*, size_t&, void*, void*, int, void*, void*, cudaStream_t, int, int);
@@ -30,12 +37,12 @@ size_t cub_device_scan_get_workspace_size(void*, void*, int, cudaStream_t, int, 
 size_t cub_device_histogram_range_get_workspace_size(void*, void*, int, void*, size_t, cudaStream_t, int);
 
 // This is for CUB's HistogramRange
-#ifdef __CUDA_ARCH__
+#if (defined(__CUDA_ARCH__) || defined (__HIP_DEVICE_COMPILE__))
 __device__ long long atomicAdd(long long *address, long long val) {
     return atomicAdd(reinterpret_cast<unsigned long long*>(address),
                      static_cast<unsigned long long>(val));
 }
-#endif // __CUDA_ARCH__
+#endif // __CUDA_ARCH__ || __HIP_DEVICE_COMPILE__
 
 #else // CUPY_NO_CUDA
 

--- a/cupy/cuda/cupy_cub.h
+++ b/cupy/cuda/cupy_cub.h
@@ -37,12 +37,12 @@ size_t cub_device_scan_get_workspace_size(void*, void*, int, cudaStream_t, int, 
 size_t cub_device_histogram_range_get_workspace_size(void*, void*, int, void*, size_t, cudaStream_t, int);
 
 // This is for CUB's HistogramRange
-#if (defined(__CUDA_ARCH__) || defined (__HIP_DEVICE_COMPILE__))
+#ifdef __CUDA_ARCH__
 __device__ long long atomicAdd(long long *address, long long val) {
     return atomicAdd(reinterpret_cast<unsigned long long*>(address),
                      static_cast<unsigned long long>(val));
 }
-#endif // __CUDA_ARCH__ || __HIP_DEVICE_COMPILE__
+#endif // __CUDA_ARCH__
 
 #else // CUPY_NO_CUDA
 

--- a/cupy/cuda/cupy_cub.h
+++ b/cupy/cuda/cupy_cub.h
@@ -21,7 +21,7 @@
 #ifndef CUPY_USE_HIP
 #include <cuda_runtime.h>
 #else
-#include <hip_runtime.h>
+#include <hip/hip_runtime.h>
 #define cudaStream_t hipStream_t
 #endif
 
@@ -36,7 +36,7 @@ size_t cub_device_spmv_get_workspace_size(void*, void*, void*, void*, void*, int
 size_t cub_device_scan_get_workspace_size(void*, void*, int, cudaStream_t, int, int);
 size_t cub_device_histogram_range_get_workspace_size(void*, void*, int, void*, size_t, cudaStream_t, int);
 
-// This is for CUB's HistogramRange
+// This is for CUB's HistogramRange; hipCUB does not need this (see comment in cupy_cub.cu)
 #ifdef __CUDA_ARCH__
 __device__ long long atomicAdd(long long *address, long long val) {
     return atomicAdd(reinterpret_cast<unsigned long long*>(address),

--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -238,6 +238,22 @@ if not use_hip:
         'check_method': build.check_cub_version,
         'version_method': build.get_cub_version,
     })
+else:
+    MODULES.append({
+        'name': 'cub',
+        'file': [
+            ('cupy.cuda.cub', ['cupy/cuda/cupy_cub.cu']),
+        ],
+        'include': [
+            'hipcub/hipcub_version.hpp',  # dummy
+        ],
+        'libraries': [
+            'hiprtc',
+            'hip_hcc',
+        ],
+        'check_method': build.check_cub_version,
+        'version_method': build.get_cub_version,
+    })
 
 if bool(int(os.environ.get('CUPY_SETUP_ENABLE_THRUST', 1))):
     if use_hip:

--- a/docs/source/install_rocm.rst
+++ b/docs/source/install_rocm.rst
@@ -28,7 +28,7 @@ And please install ROCm libraries.
 
 ::
 
-  $ sudo apt install hipblas hipsparse rocsparse rocrand rocthrust rocsolver rocfft
+  $ sudo apt install hipblas hipsparse rocsparse rocrand rocthrust rocsolver rocfft hipcub rocprim
 
 
 Before installing CuPy, we recommend you to upgrade ``setuptools`` and ``pip``::

--- a/install/build.py
+++ b/install/build.py
@@ -149,7 +149,6 @@ def get_compiler_setting(use_hip):
         include_dirs.append(os.path.join(rocm_path, 'include', 'hip'))
         include_dirs.append(os.path.join(rocm_path, 'include', 'rocrand'))
         include_dirs.append(os.path.join(rocm_path, 'include', 'roctracer'))
-        #include_dirs.append(os.path.join(rocm_path, 'include', 'hipcub'))
         library_dirs.append(os.path.join(rocm_path, 'lib'))
 
     if use_hip:
@@ -472,24 +471,25 @@ def check_cub_version(compiler, settings):
     # - On CUDA, CUB < 1.9.9 does not provide version.cuh and would error out
     # - On ROCm, hipCUB has the same version as rocPRIM (as of ROCm 3.5.0)
     try:
-        out = build_and_run(compiler, '''
-        #ifndef CUPY_USE_HIP
-        #include <cub/version.cuh>
-        #else
-        #include <hipcub/hipcub_version.hpp>
-        #endif
-        #include <stdio.h>
+        out = build_and_run(compiler,
+                            '''
+                            #ifndef CUPY_USE_HIP
+                            #include <cub/version.cuh>
+                            #else
+                            #include <hipcub/hipcub_version.hpp>
+                            #endif
+                            #include <stdio.h>
 
-        int main() {
-          #ifndef CUPY_USE_HIP
-          printf("%d", CUB_VERSION);
-          #else
-          printf("%d", HIPCUB_VERSION);
-          #endif
-          return 0;
-        }''',
-        include_dirs=settings['include_dirs'],
-        define_macros=settings['define_macros'])
+                            int main() {
+                              #ifndef CUPY_USE_HIP
+                              printf("%d", CUB_VERSION);
+                              #else
+                              printf("%d", HIPCUB_VERSION);
+                              #endif
+                              return 0;
+                            }''',
+                            include_dirs=settings['include_dirs'],
+                            define_macros=settings['define_macros'])
     except Exception as e:
         # could be in a git submodule?
         try:

--- a/install/build.py
+++ b/install/build.py
@@ -149,6 +149,7 @@ def get_compiler_setting(use_hip):
         include_dirs.append(os.path.join(rocm_path, 'include', 'hip'))
         include_dirs.append(os.path.join(rocm_path, 'include', 'rocrand'))
         include_dirs.append(os.path.join(rocm_path, 'include', 'roctracer'))
+        #include_dirs.append(os.path.join(rocm_path, 'include', 'hipcub'))
         library_dirs.append(os.path.join(rocm_path, 'lib'))
 
     if use_hip:
@@ -167,20 +168,19 @@ def get_compiler_setting(use_hip):
 
     # For CUB, we need the complex and CUB headers. The search precedence for
     # the latter is:
-    #   1. built-in CUB (for CUDA 11+)
+    #   1. built-in CUB (for CUDA 11+ and ROCm)
     #   2. CuPy's CUB bundle
     # Note that starting CuPy v8 we no longer use CUB_PATH
 
     # for <cupy/complex.cuh>
     cupy_header = os.path.join(os.path.dirname(os.path.realpath(__file__)),
                                '../cupy/core/include')
-    # TODO(leofang): remove this detection in CuPy v9
-    old_cub_path = os.environ.get('CUB_PATH', '')
-    if old_cub_path:
-        utils.print_warning('CUB_PATH is detected: ' + old_cub_path,
-                            'It is no longer used by CuPy and will be ignored')
     if cuda_path:
         cuda_cub_path = os.path.join(cuda_path, 'include', 'cub')
+        if not os.path.exists(cuda_cub_path):
+            cuda_cub_path = None
+    elif rocm_path:
+        cuda_cub_path = os.path.join(rocm_path, 'include', 'hipcub')
         if not os.path.exists(cuda_cub_path):
             cuda_cub_path = None
     else:
@@ -188,8 +188,10 @@ def get_compiler_setting(use_hip):
     global _cub_path
     if cuda_cub_path:
         _cub_path = cuda_cub_path
-    else:
+    elif not use_hip:  # CuPy's bundle doesn't work for ROCm
         _cub_path = os.path.join(cupy_header, 'cupy', 'cub')
+    else:
+        raise Exception('Please install hipCUB and retry')
     include_dirs.insert(0, _cub_path)
     include_dirs.insert(1, cupy_header)
 
@@ -467,17 +469,27 @@ def check_cub_version(compiler, settings):
 
     # This is guaranteed to work for any CUB source because the search
     # precedence follows that of include paths.
-    # CUB < 1.9.9 does not provide version.cuh and would error out
+    # - On CUDA, CUB < 1.9.9 does not provide version.cuh and would error out
+    # - On ROCm, hipCUB has the same version as rocPRIM (as of ROCm 3.5.0)
     try:
         out = build_and_run(compiler, '''
+        #ifndef CUPY_USE_HIP
         #include <cub/version.cuh>
+        #else
+        #include <hipcub/hipcub_version.hpp>
+        #endif
         #include <stdio.h>
 
         int main() {
+          #ifndef CUPY_USE_HIP
           printf("%d", CUB_VERSION);
+          #else
+          printf("%d", HIPCUB_VERSION);
+          #endif
           return 0;
-        }
-        ''', include_dirs=settings['include_dirs'])
+        }''',
+        include_dirs=settings['include_dirs'],
+        define_macros=settings['define_macros'])
     except Exception as e:
         # could be in a git submodule?
         try:

--- a/tests/cupy_tests/core_tests/test_cub_reduction.py
+++ b/tests/cupy_tests/core_tests/test_cub_reduction.py
@@ -124,7 +124,6 @@ class TestSimpleCubReductionKernelMisc(CubReductionTestBase):
         b = cupy.empty((), dtype=cupy.int8)
         assert self.can_use([a], [b], (1,), (0,)) is None
 
-    @unittest.skipIf(cupy.cuda.runtime.is_hip, 'hip does not support CUB')
     def test_can_use_accelerator_set_unset(self):
         # ensure we use CUB block reduction and not CUB device reduction
         old_routine_accelerators = _accelerator.get_routine_accelerators()

--- a/tests/cupy_tests/core_tests/test_ndarray_reduction.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_reduction.py
@@ -237,7 +237,7 @@ class TestCubReduction(unittest.TestCase):
         _acc.set_routine_accelerators(self.old_accelerators)
 
     @testing.for_contiguous_axes()
-    @testing.for_all_dtypes(no_bool=True, no_float16=True)
+    @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose(rtol=1E-5)
     def test_cub_min(self, xp, dtype, axis):
         a = testing.shaped_random(self.shape, xp, dtype)
@@ -261,7 +261,7 @@ class TestCubReduction(unittest.TestCase):
         return a.min(axis=axis)
 
     @testing.for_contiguous_axes()
-    @testing.for_all_dtypes(no_bool=True, no_float16=True)
+    @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose(rtol=1E-5)
     def test_cub_max(self, xp, dtype, axis):
         a = testing.shaped_random(self.shape, xp, dtype)

--- a/tests/cupy_tests/core_tests/test_raw.py
+++ b/tests/cupy_tests/core_tests/test_raw.py
@@ -499,10 +499,8 @@ class TestRaw(unittest.TestCase):
                 CC=compiler._get_arch())
             code = _test_source5
         else:
-            # TODO(leofang): We currently instruct users to set up
-            # $ROCM_HOME, but perhaps it could be relaxed after we add
-            # get_hipcc_path().
-            cc = os.path.join(os.environ['ROCM_HOME'], 'bin/hipcc')
+            # TODO(leofang): expose get_hipcc_path() to cupy.cuda?
+            cc = cupy._environment.get_hipcc_path()
             arch = '-v'  # dummy
             code = compiler._convert_to_hip_source(_test_source5, None, False)
         # split() is needed because nvcc could come from the env var NVCC


### PR DESCRIPTION
Close #3893. Blocked by #3835. ~~Currently this compiles and some tests passed. Still work in progress...~~

TODO:
- [x] Fix `min`/`argmin` (`max`/`argmax` passed, why?!)
- [x] Fix CUB block reduction support

***UPDATE***:

This PR adds the support of CUB device routines (i.e. the `cupy.cuda.cub` module) and block reduction kernels (i.e. the `cupy.core._cub_reduction` module) for AMD GPUs. hipCUB is used, which under the hood is backed by rocPRIM on AMD GPUs. The existing CUDA call paths are not touched.

To support CUB block reduction, I also added `get_rocm_path()` and `get_hipcc_path()` to `cupy._environment`, which are the parallel helpers to CUDA.

Note that CuPy's CUB bundle cannot be used in ROCm.

Below is a benchmark script for performance comparison. Some routines are suboptimal, and some even have bugs (likely due to low-precision floating point arithmetics). But the bugs are irrelevant to the present PR; they also exist in CuPy's own implementation. I will create issues to track them. 

<details><summary>Script (click me):</summary>
<p>

```python
import cupy as cp
import numpy as np
from cupyx.time import repeat


#cp.show_config()
CUB_device_targets = ['sum', 'prod', 'min', 'max', 'argmax', 'argmin', 'cumsum', 'cumprod', 'mean']
full_targets = CUB_device_targets + \
                ['amin', 'amax', 'nanmin', 'nanmax', 'nanargmin', 'nanargmax',
                 'nanmean',
                 'var', 'nanvar', 'nansum', 'nanprod',
                 'all', 'any', 'count_nonzero']
dtypes = [cp.float32, cp.float64, cp.complex64, cp.complex128]
shape = (512, 512, 512)
axes = ((2,), (1, 2), (0, 1, 2))


for dtype in dtypes:
    a = cp.random.random(shape)
    if dtype in (cp.complex64, cp.complex128):
        a = a + 1j*cp.random.random(shape)
    a = a.astype(dtype)

    for target in full_targets:
        for axis in axes:
            if target in ('argmax', 'argmin', 'nanargmax', 'nanargmin', 'cumsum', 'cumprod'):
                if len(axis) != a.ndim:
                    continue
                else:
                    axis = None  # NumPy limitation
            if dtype in (cp.complex64, cp.complex128) and target in ('nanmin', 'nanmax', 'var', 'nanvar'):
                continue

            print(f"testing {target} with dtype={dtype} and axes={axis}...")
            func_cp = getattr(cp, target)
            func_np = getattr(np, target)

            cp.core.set_routine_accelerators([])
            cp.core.set_reduction_accelerators([])
            print(repeat(func_cp, (a, axis), n_repeat=20, name=f'no acce, {target}'))
            if not cp.allclose(func_cp(a, axis), func_np(cp.asnumpy(a), axis)):
                print(f"WARNING: CuPy's kernel might have a problem with {target} and {dtype}")

            if target in CUB_device_targets:
                cp.core.set_routine_accelerators(['cub'])
                cp.core.set_reduction_accelerators([])
                print(repeat(func_cp, (a, axis), n_repeat=20, name=f'CUB device, {target}'))
                if not cp.allclose(func_cp(a, axis), func_np(cp.asnumpy(a), axis)):
                    print(f"WARNING: CUB device might have a problem with {target} and {dtype}")

            cp.core.set_routine_accelerators([])
            cp.core.set_reduction_accelerators(['cub'])
            print(repeat(func_cp, (a, axis), n_repeat=20, name=f'CUB block, {target}'))
            if not cp.allclose(func_cp(a, axis), func_np(cp.asnumpy(a), axis)):
                print(f"WARNING: CUB block might have a problem with {target} and {dtype}")
```

</p>
</details>
<details><summary>Output (click me):</summary>
<p>

```
testing sum with dtype=<class 'numpy.float32'> and axes=(2,)...
no acce, sum        :    CPU:   20.839 us   +/- 6.402 (min:   16.380 / max:   38.619) us     GPU-0: 1888.348 us   +/-30.235 (min: 1836.097 / max: 1969.881) us
CUB device, sum     :    CPU:   37.470 us   +/- 2.438 (min:   35.585 / max:   46.661) us     GPU-0:  835.564 us   +/-26.268 (min:  825.489 / max:  949.134) us
CUB block, sum      :    CPU:   49.157 us   +/-34.658 (min:   28.012 / max:  178.964) us     GPU-0: 1482.211 us   +/-64.835 (min: 1403.442 / max: 1707.685) us
testing sum with dtype=<class 'numpy.float32'> and axes=(1, 2)...
no acce, sum        :    CPU:   38.931 us   +/-13.378 (min:   24.981 / max:   71.334) us     GPU-0: 1041.024 us   +/-34.384 (min: 1004.265 / max: 1098.112) us
CUB device, sum     :    CPU:   34.866 us   +/- 1.920 (min:   33.410 / max:   42.131) us     GPU-0:  732.821 us   +/- 6.088 (min:  726.568 / max:  755.878) us
CUB block, sum      :    CPU:   19.799 us   +/- 3.049 (min:   16.760 / max:   26.692) us     GPU-0: 1568.359 us   +/-23.438 (min: 1500.615 / max: 1600.395) us
testing sum with dtype=<class 'numpy.float32'> and axes=(0, 1, 2)...
no acce, sum        :    CPU:   22.059 us   +/- 4.583 (min:   14.842 / max:   33.168) us     GPU-0:205145.358 us   +/-934.987 (min:204250.565 / max:207253.052) us
CUB device, sum     :    CPU:   13.074 us   +/- 1.976 (min:   11.514 / max:   20.715) us     GPU-0:  642.154 us   +/-10.345 (min:  632.469 / max:  679.303) us
CUB block, sum      :    CPU:   28.110 us   +/- 2.052 (min:   25.603 / max:   34.632) us     GPU-0: 1502.588 us   +/-10.991 (min: 1479.115 / max: 1528.251) us
testing prod with dtype=<class 'numpy.float32'> and axes=(2,)...
no acce, prod       :    CPU:   16.813 us   +/- 2.552 (min:   14.523 / max:   24.074) us     GPU-0: 1872.290 us   +/-24.477 (min: 1822.050 / max: 1912.592) us
CUB device, prod    :    CPU:   34.543 us   +/- 0.971 (min:   33.720 / max:   37.861) us     GPU-0:  828.177 us   +/- 5.115 (min:  823.480 / max:  847.851) us
CUB block, prod     :    CPU:   18.711 us   +/- 2.647 (min:   16.057 / max:   25.538) us     GPU-0: 1431.901 us   +/-29.653 (min: 1328.079 / max: 1480.247) us
testing prod with dtype=<class 'numpy.float32'> and axes=(1, 2)...
no acce, prod       :    CPU:   18.207 us   +/- 0.976 (min:   17.458 / max:   21.758) us     GPU-0:  880.058 us   +/- 8.881 (min:  868.733 / max:  908.912) us
CUB device, prod    :    CPU:   35.447 us   +/- 1.256 (min:   34.254 / max:   38.760) us     GPU-0:  733.830 us   +/- 6.203 (min:  726.533 / max:  756.276) us
CUB block, prod     :    CPU:   20.372 us   +/- 2.914 (min:   17.412 / max:   26.070) us     GPU-0: 1569.285 us   +/-20.793 (min: 1511.185 / max: 1591.346) us
testing prod with dtype=<class 'numpy.float32'> and axes=(0, 1, 2)...
no acce, prod       :    CPU:   21.657 us   +/- 4.920 (min:   13.898 / max:   34.345) us     GPU-0:205919.058 us   +/-898.556 (min:204705.948 / max:207331.436) us
CUB device, prod    :    CPU:   13.587 us   +/- 3.547 (min:   11.885 / max:   28.392) us     GPU-0:  639.848 us   +/-13.208 (min:  632.420 / max:  693.146) us
CUB block, prod     :    CPU:   28.732 us   +/- 1.473 (min:   25.449 / max:   33.518) us     GPU-0: 1533.489 us   +/-29.504 (min: 1481.429 / max: 1578.446) us
testing min with dtype=<class 'numpy.float32'> and axes=(2,)...
no acce, min        :    CPU:   16.138 us   +/- 2.560 (min:   14.254 / max:   24.970) us     GPU-0: 2478.027 us   +/-13.406 (min: 2431.943 / max: 2508.866) us
CUB device, min     :    CPU:   35.919 us   +/- 2.118 (min:   34.017 / max:   40.849) us     GPU-0: 1185.578 us   +/-15.175 (min: 1140.394 / max: 1201.369) us
CUB block, min      :    CPU:   19.719 us   +/- 3.119 (min:   16.382 / max:   26.321) us     GPU-0: 1450.319 us   +/-21.751 (min: 1388.569 / max: 1478.902) us
testing min with dtype=<class 'numpy.float32'> and axes=(1, 2)...
no acce, min        :    CPU:   18.337 us   +/- 0.989 (min:   17.331 / max:   21.522) us     GPU-0: 1207.891 us   +/-28.245 (min: 1194.107 / max: 1327.715) us
CUB device, min     :    CPU:   35.511 us   +/- 1.212 (min:   34.279 / max:   38.937) us     GPU-0:  750.038 us   +/- 6.097 (min:  745.926 / max:  774.482) us
CUB block, min      :    CPU:   21.843 us   +/- 2.939 (min:   17.679 / max:   27.202) us     GPU-0: 1728.199 us   +/-28.015 (min: 1664.519 / max: 1762.178) us
testing min with dtype=<class 'numpy.float32'> and axes=(0, 1, 2)...
no acce, min        :    CPU:   23.132 us   +/- 4.659 (min:   14.801 / max:   34.011) us     GPU-0:242490.221 us   +/-392.019 (min:241024.170 / max:242833.755) us
CUB device, min     :    CPU:   14.011 us   +/- 1.284 (min:   12.804 / max:   18.421) us     GPU-0:  650.572 us   +/-12.966 (min:  638.117 / max:  698.665) us
CUB block, min      :    CPU:   27.852 us   +/- 1.408 (min:   26.017 / max:   32.978) us     GPU-0: 1800.935 us   +/-12.442 (min: 1780.072 / max: 1832.483) us
testing max with dtype=<class 'numpy.float32'> and axes=(2,)...
no acce, max        :    CPU:   15.894 us   +/- 2.008 (min:   14.309 / max:   22.893) us     GPU-0: 2467.922 us   +/-17.457 (min: 2415.245 / max: 2490.865) us
CUB device, max     :    CPU:   35.461 us   +/- 1.486 (min:   34.422 / max:   41.331) us     GPU-0: 1200.286 us   +/- 6.143 (min: 1176.923 / max: 1209.929) us
CUB block, max      :    CPU:   20.247 us   +/- 3.123 (min:   16.506 / max:   25.974) us     GPU-0: 1444.685 us   +/-33.212 (min: 1349.700 / max: 1480.018) us
testing max with dtype=<class 'numpy.float32'> and axes=(1, 2)...
no acce, max        :    CPU:   18.234 us   +/- 0.960 (min:   17.327 / max:   21.587) us     GPU-0: 1203.525 us   +/- 8.029 (min: 1185.935 / max: 1221.376) us
CUB device, max     :    CPU:   35.929 us   +/- 2.550 (min:   34.036 / max:   45.196) us     GPU-0:  752.291 us   +/- 7.822 (min:  744.775 / max:  783.273) us
CUB block, max      :    CPU:   20.842 us   +/- 3.140 (min:   17.540 / max:   26.626) us     GPU-0: 1732.217 us   +/-23.179 (min: 1676.807 / max: 1770.304) us
testing max with dtype=<class 'numpy.float32'> and axes=(0, 1, 2)...
no acce, max        :    CPU:   23.544 us   +/- 4.719 (min:   14.609 / max:   33.522) us     GPU-0:242316.950 us   +/-513.962 (min:240964.401 / max:243086.258) us
CUB device, max     :    CPU:   14.038 us   +/- 1.706 (min:   12.351 / max:   18.675) us     GPU-0:  652.512 us   +/-22.656 (min:  640.922 / max:  746.584) us
CUB block, max      :    CPU:   28.093 us   +/- 2.589 (min:   26.389 / max:   38.805) us     GPU-0: 1801.713 us   +/-10.905 (min: 1781.313 / max: 1818.215) us
testing argmax with dtype=<class 'numpy.float32'> and axes=None...
no acce, argmax     :    CPU:   26.935 us   +/- 6.265 (min:   23.435 / max:   53.240) us     GPU-0:396793.590 us   +/-8465.033 (min:384604.340 / max:409733.856) us
CUB device, argmax  :    CPU:   37.839 us   +/- 4.770 (min:   33.652 / max:   52.095) us     GPU-0: 3573.134 us   +/-32.957 (min: 3513.861 / max: 3635.402) us
CUB block, argmax   :    CPU:   28.364 us   +/- 1.835 (min:   26.693 / max:   34.820) us     GPU-0: 9069.121 us   +/-18.185 (min: 9043.804 / max: 9114.773) us
testing argmin with dtype=<class 'numpy.float32'> and axes=None...
no acce, argmin     :    CPU:   27.373 us   +/- 8.170 (min:   17.730 / max:   60.346) us     GPU-0:410274.600 us   +/-15169.286 (min:384187.866 / max:425385.590) us
CUB device, argmin  :    CPU:   34.710 us   +/- 2.528 (min:   32.703 / max:   44.344) us     GPU-0: 3359.927 us   +/-15.800 (min: 3313.774 / max: 3404.641) us
CUB block, argmin   :    CPU:   27.700 us   +/- 0.978 (min:   26.961 / max:   30.768) us     GPU-0: 9073.212 us   +/-14.748 (min: 9050.274 / max: 9108.343) us
testing cumsum with dtype=<class 'numpy.float32'> and axes=None...
no acce, cumsum     :    CPU:   35.909 us   +/- 2.457 (min:   34.160 / max:   44.636) us     GPU-0: 7072.557 us   +/-27.789 (min: 6981.618 / max: 7103.288) us
WARNING: CuPy's kernel might have a problem with cumsum and <class 'numpy.float32'>
CUB device, cumsum  :    CPU:   24.027 us   +/- 2.082 (min:   22.560 / max:   31.521) us     GPU-0: 3830.246 us   +/-24.132 (min: 3775.551 / max: 3883.842) us
WARNING: CUB device might have a problem with cumsum and <class 'numpy.float32'>
CUB block, cumsum   :    CPU:   36.602 us   +/- 3.590 (min:   34.193 / max:   50.843) us     GPU-0: 7114.579 us   +/-34.884 (min: 7003.457 / max: 7169.428) us
WARNING: CUB block might have a problem with cumsum and <class 'numpy.float32'>
testing cumprod with dtype=<class 'numpy.float32'> and axes=None...
no acce, cumprod    :    CPU:   35.407 us   +/- 1.295 (min:   34.118 / max:   39.858) us     GPU-0: 7065.815 us   +/-28.147 (min: 7021.571 / max: 7133.518) us
CUB device, cumprod :    CPU:   23.993 us   +/- 2.249 (min:   22.354 / max:   32.430) us     GPU-0: 3860.348 us   +/-28.382 (min: 3826.732 / max: 3933.666) us
CUB block, cumprod  :    CPU:   36.400 us   +/- 3.443 (min:   31.392 / max:   47.811) us     GPU-0: 7065.532 us   +/-27.199 (min: 7017.777 / max: 7137.313) us
testing mean with dtype=<class 'numpy.float32'> and axes=(2,)...
no acce, mean       :    CPU:   15.911 us   +/- 2.258 (min:   14.327 / max:   23.877) us     GPU-0: 2151.101 us   +/-14.831 (min: 2099.386 / max: 2168.189) us
CUB device, mean    :    CPU:   52.643 us   +/- 2.100 (min:   50.439 / max:   58.482) us     GPU-0:  843.386 us   +/- 8.715 (min:  838.048 / max:  878.971) us
CUB block, mean     :    CPU:   21.064 us   +/- 2.880 (min:   18.191 / max:   25.884) us     GPU-0: 1417.723 us   +/-30.577 (min: 1367.168 / max: 1468.289) us
testing mean with dtype=<class 'numpy.float32'> and axes=(1, 2)...
no acce, mean       :    CPU:   18.416 us   +/- 1.156 (min:   17.376 / max:   21.745) us     GPU-0:  893.248 us   +/-12.385 (min:  877.496 / max:  936.775) us
CUB device, mean    :    CPU:   50.628 us   +/- 1.894 (min:   49.269 / max:   57.765) us     GPU-0:  742.974 us   +/- 6.832 (min:  735.672 / max:  768.982) us
CUB block, mean     :    CPU:   22.810 us   +/- 2.532 (min:   18.968 / max:   26.013) us     GPU-0: 1571.532 us   +/-50.227 (min: 1491.291 / max: 1646.313) us
testing mean with dtype=<class 'numpy.float32'> and axes=(0, 1, 2)...
no acce, mean       :    CPU:   23.816 us   +/- 4.368 (min:   17.692 / max:   38.530) us     GPU-0:205499.613 us   +/-1131.125 (min:204110.779 / max:206998.459) us
CUB device, mean    :    CPU:   29.886 us   +/- 2.541 (min:   27.636 / max:   36.712) us     GPU-0:  651.482 us   +/-12.681 (min:  644.048 / max:  699.166) us
CUB block, mean     :    CPU:   30.145 us   +/- 1.039 (min:   28.415 / max:   33.368) us     GPU-0: 1546.343 us   +/-21.291 (min: 1483.880 / max: 1570.418) us
testing amin with dtype=<class 'numpy.float32'> and axes=(2,)...
no acce, amin       :    CPU:   15.713 us   +/- 1.821 (min:   14.472 / max:   22.025) us     GPU-0: 2473.243 us   +/-13.276 (min: 2423.544 / max: 2491.711) us
CUB block, amin     :    CPU:   19.511 us   +/- 2.595 (min:   16.334 / max:   25.932) us     GPU-0: 1423.732 us   +/-30.613 (min: 1367.606 / max: 1478.300) us
testing amin with dtype=<class 'numpy.float32'> and axes=(1, 2)...
no acce, amin       :    CPU:   18.443 us   +/- 1.173 (min:   17.082 / max:   22.128) us     GPU-0: 1204.715 us   +/-13.589 (min: 1186.301 / max: 1254.907) us
CUB block, amin     :    CPU:   19.022 us   +/- 2.283 (min:   17.239 / max:   24.353) us     GPU-0: 1727.881 us   +/-20.759 (min: 1674.781 / max: 1750.685) us
testing amin with dtype=<class 'numpy.float32'> and axes=(0, 1, 2)...
no acce, amin       :    CPU:   25.624 us   +/- 4.214 (min:   16.117 / max:   41.295) us     GPU-0:242379.434 us   +/-371.609 (min:241067.535 / max:242810.669) us
CUB block, amin     :    CPU:   27.316 us   +/- 0.535 (min:   26.249 / max:   28.266) us     GPU-0: 1802.748 us   +/-12.491 (min: 1779.123 / max: 1834.425) us
testing amax with dtype=<class 'numpy.float32'> and axes=(2,)...
no acce, amax       :    CPU:   16.528 us   +/- 3.001 (min:   14.393 / max:   25.706) us     GPU-0: 2502.064 us   +/-35.469 (min: 2427.099 / max: 2535.728) us
CUB block, amax     :    CPU:   18.916 us   +/- 2.356 (min:   16.323 / max:   24.008) us     GPU-0: 1451.232 us   +/-21.480 (min: 1387.403 / max: 1473.584) us
testing amax with dtype=<class 'numpy.float32'> and axes=(1, 2)...
no acce, amax       :    CPU:   18.439 us   +/- 1.208 (min:   17.568 / max:   22.560) us     GPU-0: 1202.390 us   +/-22.323 (min: 1189.402 / max: 1297.344) us
CUB block, amax     :    CPU:   19.933 us   +/- 2.454 (min:   17.402 / max:   24.044) us     GPU-0: 1725.343 us   +/-25.014 (min: 1673.789 / max: 1758.646) us
testing amax with dtype=<class 'numpy.float32'> and axes=(0, 1, 2)...
no acce, amax       :    CPU:   26.039 us   +/- 5.662 (min:   18.206 / max:   47.189) us     GPU-0:242500.581 us   +/-410.479 (min:241066.818 / max:243251.877) us
CUB block, amax     :    CPU:   27.611 us   +/- 1.254 (min:   26.072 / max:   32.080) us     GPU-0: 1801.371 us   +/-10.218 (min: 1774.936 / max: 1817.473) us
testing nanmin with dtype=<class 'numpy.float32'> and axes=(2,)...
no acce, nanmin     :    CPU: 2762.977 us   +/- 6.603 (min: 2742.807 / max: 2767.296) us     GPU-0: 2770.572 us   +/- 6.100 (min: 2757.787 / max: 2781.847) us
CUB block, nanmin   :    CPU: 1641.864 us   +/-30.079 (min: 1583.551 / max: 1668.008) us     GPU-0: 1649.772 us   +/-26.442 (min: 1598.525 / max: 1674.681) us
testing nanmin with dtype=<class 'numpy.float32'> and axes=(1, 2)...
no acce, nanmin     :    CPU: 1224.347 us   +/-10.058 (min: 1204.169 / max: 1239.699) us     GPU-0: 1231.647 us   +/-10.690 (min: 1210.740 / max: 1249.844) us
CUB block, nanmin   :    CPU: 1692.171 us   +/-27.308 (min: 1619.329 / max: 1719.562) us     GPU-0: 1699.993 us   +/-24.130 (min: 1634.157 / max: 1726.470) us
testing nanmin with dtype=<class 'numpy.float32'> and axes=(0, 1, 2)...
no acce, nanmin     :    CPU:209193.652 us   +/-977.053 (min:207686.755 / max:210587.926) us     GPU-0:209202.920 us   +/-976.144 (min:207691.650 / max:210589.661) us
CUB block, nanmin   :    CPU: 1932.369 us   +/- 8.641 (min: 1915.155 / max: 1943.157) us     GPU-0: 1939.843 us   +/- 7.872 (min: 1929.427 / max: 1959.740) us
testing nanmax with dtype=<class 'numpy.float32'> and axes=(2,)...
no acce, nanmax     :    CPU: 2762.499 us   +/- 6.546 (min: 2742.968 / max: 2767.557) us     GPU-0: 2770.085 us   +/- 6.372 (min: 2756.749 / max: 2783.777) us
CUB block, nanmax   :    CPU: 1644.771 us   +/-29.342 (min: 1583.926 / max: 1676.122) us     GPU-0: 1652.508 us   +/-26.781 (min: 1598.958 / max: 1682.439) us
testing nanmax with dtype=<class 'numpy.float32'> and axes=(1, 2)...
no acce, nanmax     :    CPU: 1231.897 us   +/-38.445 (min: 1162.584 / max: 1300.981) us     GPU-0: 1239.310 us   +/-38.527 (min: 1172.515 / max: 1308.496) us
CUB block, nanmax   :    CPU: 1686.134 us   +/-28.838 (min: 1621.217 / max: 1710.249) us     GPU-0: 1693.573 us   +/-25.031 (min: 1635.281 / max: 1716.389) us
testing nanmax with dtype=<class 'numpy.float32'> and axes=(0, 1, 2)...
no acce, nanmax     :    CPU:209161.680 us   +/-970.218 (min:207652.806 / max:210508.291) us     GPU-0:209171.199 us   +/-970.072 (min:207659.271 / max:210510.818) us
CUB block, nanmax   :    CPU: 1963.353 us   +/-29.767 (min: 1915.174 / max: 2012.563) us     GPU-0: 1971.215 us   +/-29.106 (min: 1929.157 / max: 2020.039) us
testing nanargmin with dtype=<class 'numpy.float32'> and axes=None...
no acce, nanargmin  :    CPU:   26.457 us   +/- 6.259 (min:   22.572 / max:   51.021) us     GPU-0:476695.528 us   +/-31172.037 (min:383732.300 / max:511224.243) us
CUB block, nanargmin:    CPU:   27.479 us   +/- 0.807 (min:   26.390 / max:   29.669) us     GPU-0: 9108.055 us   +/-18.184 (min: 9074.672 / max: 9140.686) us
testing nanargmax with dtype=<class 'numpy.float32'> and axes=None...
no acce, nanargmax  :    CPU:   20.569 us   +/- 5.844 (min:   15.031 / max:   40.883) us     GPU-0:479798.326 us   +/-21751.239 (min:446908.875 / max:510872.345) us
CUB block, nanargmax:    CPU:   33.307 us   +/-14.789 (min:   28.790 / max:   96.874) us     GPU-0: 9149.257 us   +/-32.631 (min: 9097.939 / max: 9242.380) us
testing nanmean with dtype=<class 'numpy.float32'> and axes=(2,)...
no acce, nanmean    :    CPU:   16.293 us   +/- 2.866 (min:   13.959 / max:   26.362) us     GPU-0: 2349.079 us   +/-23.114 (min: 2292.974 / max: 2377.644) us
CUB block, nanmean  :    CPU:   28.904 us   +/-10.298 (min:   22.148 / max:   69.714) us     GPU-0: 1546.391 us   +/-47.662 (min: 1444.827 / max: 1648.128) us
testing nanmean with dtype=<class 'numpy.float32'> and axes=(1, 2)...
no acce, nanmean    :    CPU:   19.618 us   +/- 1.230 (min:   18.535 / max:   23.029) us     GPU-0: 1239.776 us   +/-23.781 (min: 1212.681 / max: 1317.260) us
CUB block, nanmean  :    CPU:   26.403 us   +/- 7.773 (min:   17.822 / max:   46.748) us     GPU-0: 2246.543 us   +/-106.194 (min: 2083.340 / max: 2528.408) us
testing nanmean with dtype=<class 'numpy.float32'> and axes=(0, 1, 2)...
no acce, nanmean    :    CPU:   33.820 us   +/-11.581 (min:   28.202 / max:   81.496) us     GPU-0:219113.469 us   +/-391.070 (min:218273.315 / max:219592.957) us
CUB block, nanmean  :    CPU:   29.360 us   +/- 1.776 (min:   27.280 / max:   35.733) us     GPU-0: 1785.961 us   +/-29.784 (min: 1716.594 / max: 1846.010) us
testing var with dtype=<class 'numpy.float32'> and axes=(2,)...
no acce, var        :    CPU:   62.469 us   +/- 5.035 (min:   57.054 / max:   79.987) us     GPU-0: 4923.459 us   +/-37.664 (min: 4821.985 / max: 5011.245) us
CUB block, var      :    CPU:   65.899 us   +/- 2.768 (min:   63.527 / max:   76.407) us     GPU-0: 4232.114 us   +/-18.746 (min: 4187.793 / max: 4265.579) us
testing var with dtype=<class 'numpy.float32'> and axes=(1, 2)...
no acce, var        :    CPU:   69.361 us   +/-23.132 (min:   60.456 / max:  169.374) us     GPU-0:43158.663 us   +/-617.546 (min:41295.059 / max:43942.574) us
CUB block, var      :    CPU:   69.031 us   +/- 6.453 (min:   63.956 / max:   94.651) us     GPU-0:43565.933 us   +/-872.185 (min:41681.610 / max:44341.797) us
testing var with dtype=<class 'numpy.float32'> and axes=(0, 1, 2)...
no acce, var        :    CPU:  102.098 us   +/-23.160 (min:   87.661 / max:  173.847) us     GPU-0:4456865.820 us   +/-14956.996 (min:4423078.125 / max:4474668.945) us
WARNING: CuPy's kernel might have a problem with var and <class 'numpy.float32'>
CUB block, var      :    CPU:   79.929 us   +/-12.242 (min:   72.734 / max:  128.992) us     GPU-0:215064.773 us   +/-965.156 (min:213591.064 / max:216574.875) us
WARNING: CUB block might have a problem with var and <class 'numpy.float32'>
testing nanvar with dtype=<class 'numpy.float32'> and axes=(2,)...
no acce, nanvar     :    CPU:   59.247 us   +/- 3.326 (min:   56.092 / max:   71.592) us     GPU-0: 7151.242 us   +/-20.243 (min: 7092.856 / max: 7176.080) us
CUB block, nanvar   :    CPU:   66.145 us   +/- 4.593 (min:   62.736 / max:   84.212) us     GPU-0: 6148.347 us   +/-36.478 (min: 6042.068 / max: 6214.938) us
testing nanvar with dtype=<class 'numpy.float32'> and axes=(1, 2)...
no acce, nanvar     :    CPU:   61.455 us   +/- 3.482 (min:   56.319 / max:   71.168) us     GPU-0:50152.501 us   +/-122.784 (min:49924.770 / max:50377.129) us
CUB block, nanvar   :    CPU:   75.509 us   +/-31.608 (min:   63.043 / max:  211.879) us     GPU-0:52849.869 us   +/-170.685 (min:52459.850 / max:53162.224) us
testing nanvar with dtype=<class 'numpy.float32'> and axes=(0, 1, 2)...
no acce, nanvar     :    CPU:  106.683 us   +/-26.682 (min:   81.156 / max:  181.765) us     GPU-0:9175733.301 us   +/-21500.430 (min:9148618.164 / max:9216900.391) us
WARNING: CuPy's kernel might have a problem with nanvar and <class 'numpy.float32'>
CUB block, nanvar   :    CPU:  102.663 us   +/-15.567 (min:   92.060 / max:  161.769) us     GPU-0:514020.239 us   +/-180.248 (min:513877.869 / max:514460.144) us
WARNING: CUB block might have a problem with nanvar and <class 'numpy.float32'>
testing nansum with dtype=<class 'numpy.float32'> and axes=(2,)...
no acce, nansum     :    CPU:   19.467 us   +/- 4.393 (min:   16.236 / max:   34.923) us     GPU-0: 1904.191 us   +/-26.957 (min: 1850.183 / max: 1996.130) us
CUB block, nansum   :    CPU:   25.162 us   +/- 1.892 (min:   19.306 / max:   26.824) us     GPU-0: 1400.000 us   +/-21.562 (min: 1336.394 / max: 1417.082) us
testing nansum with dtype=<class 'numpy.float32'> and axes=(1, 2)...
no acce, nansum     :    CPU:   20.129 us   +/- 1.273 (min:   19.127 / max:   24.804) us     GPU-0:  923.829 us   +/-19.810 (min:  908.298 / max: 1004.314) us
CUB block, nansum   :    CPU:   25.738 us   +/- 0.521 (min:   24.887 / max:   27.335) us     GPU-0: 2490.579 us   +/-183.431 (min: 1982.854 / max: 2662.675) us
testing nansum with dtype=<class 'numpy.float32'> and axes=(0, 1, 2)...
no acce, nansum     :    CPU:   26.002 us   +/- 7.575 (min:   17.213 / max:   55.650) us     GPU-0:211617.485 us   +/-753.735 (min:209936.157 / max:212504.791) us
CUB block, nansum   :    CPU:   29.003 us   +/- 0.942 (min:   28.033 / max:   32.472) us     GPU-0: 1517.399 us   +/- 8.540 (min: 1497.394 / max: 1539.397) us
testing nanprod with dtype=<class 'numpy.float32'> and axes=(2,)...
no acce, nanprod    :    CPU:   19.964 us   +/- 3.291 (min:   16.452 / max:   25.864) us     GPU-0: 1896.236 us   +/-26.155 (min: 1843.178 / max: 1935.809) us
CUB block, nanprod  :    CPU:   64.069 us   +/-31.778 (min:   39.724 / max:  186.150) us     GPU-0: 1476.162 us   +/-59.205 (min: 1363.830 / max: 1571.390) us
testing nanprod with dtype=<class 'numpy.float32'> and axes=(1, 2)...
no acce, nanprod    :    CPU:   20.043 us   +/- 1.301 (min:   18.934 / max:   24.683) us     GPU-0:  923.864 us   +/-22.249 (min:  909.533 / max: 1017.891) us
CUB block, nanprod  :    CPU:   39.365 us   +/-25.449 (min:   19.752 / max:  128.588) us     GPU-0: 2520.409 us   +/-94.125 (min: 2308.281 / max: 2666.829) us
testing nanprod with dtype=<class 'numpy.float32'> and axes=(0, 1, 2)...
no acce, nanprod    :    CPU:   21.097 us   +/- 6.495 (min:   15.364 / max:   41.786) us     GPU-0:211747.911 us   +/-918.646 (min:209761.124 / max:212692.917) us
CUB block, nanprod  :    CPU:   34.125 us   +/- 9.491 (min:   26.326 / max:   60.091) us     GPU-0: 1567.210 us   +/-28.851 (min: 1499.604 / max: 1639.994) us
testing all with dtype=<class 'numpy.float32'> and axes=(2,)...
no acce, all        :    CPU:   17.506 us   +/- 3.385 (min:   14.517 / max:   27.272) us     GPU-0: 1950.297 us   +/-28.447 (min: 1897.882 / max: 1996.241) us
CUB block, all      :    CPU:   27.372 us   +/-17.689 (min:   17.514 / max:   90.956) us     GPU-0: 1429.005 us   +/-70.433 (min: 1336.787 / max: 1621.041) us
testing all with dtype=<class 'numpy.float32'> and axes=(1, 2)...
no acce, all        :    CPU:   19.033 us   +/- 2.637 (min:   17.541 / max:   30.186) us     GPU-0:  918.810 us   +/-18.498 (min:  905.176 / max:  993.445) us
CUB block, all      :    CPU:   25.506 us   +/- 5.117 (min:   18.193 / max:   36.523) us     GPU-0: 2440.726 us   +/-95.832 (min: 2244.219 / max: 2589.656) us
testing all with dtype=<class 'numpy.float32'> and axes=(0, 1, 2)...
no acce, all        :    CPU:   20.898 us   +/- 7.618 (min:   14.795 / max:   48.977) us     GPU-0:217573.629 us   +/-474.054 (min:216635.147 / max:218250.122) us
CUB block, all      :    CPU:   68.011 us   +/-35.151 (min:   29.652 / max:  183.790) us     GPU-0: 1575.077 us   +/-54.030 (min: 1520.706 / max: 1772.562) us
testing any with dtype=<class 'numpy.float32'> and axes=(2,)...
no acce, any        :    CPU:   18.989 us   +/- 3.414 (min:   16.264 / max:   28.469) us     GPU-0: 1955.134 us   +/-12.255 (min: 1943.151 / max: 1988.194) us
CUB block, any      :    CPU:   32.742 us   +/-10.909 (min:   19.052 / max:   62.747) us     GPU-0: 1439.985 us   +/-33.944 (min: 1382.010 / max: 1508.798) us
testing any with dtype=<class 'numpy.float32'> and axes=(1, 2)...
no acce, any        :    CPU:   20.140 us   +/- 1.691 (min:   18.872 / max:   26.263) us     GPU-0:  918.260 us   +/-20.918 (min:  899.920 / max: 1000.524) us
CUB block, any      :    CPU:   24.390 us   +/-13.117 (min:   17.625 / max:   78.221) us     GPU-0: 2176.155 us   +/-216.109 (min: 1929.621 / max: 2634.582) us
testing any with dtype=<class 'numpy.float32'> and axes=(0, 1, 2)...
no acce, any        :    CPU:   19.158 us   +/- 6.949 (min:   14.348 / max:   45.580) us     GPU-0:217913.681 us   +/-348.612 (min:217009.567 / max:218342.743) us
CUB block, any      :    CPU:   29.324 us   +/- 4.176 (min:   25.783 / max:   42.856) us     GPU-0: 1485.672 us   +/-22.695 (min: 1464.048 / max: 1550.252) us
testing count_nonzero with dtype=<class 'numpy.float32'> and axes=(2,)...
no acce, count_nonzero:    CPU:   15.113 us   +/- 2.340 (min:   13.477 / max:   23.254) us     GPU-0: 1972.309 us   +/-30.427 (min: 1895.698 / max: 2030.526) us
CUB block, count_nonzero:    CPU:   26.908 us   +/-11.645 (min:   15.321 / max:   58.705) us     GPU-0: 1435.313 us   +/-46.039 (min: 1345.970 / max: 1535.497) us
testing count_nonzero with dtype=<class 'numpy.float32'> and axes=(1, 2)...
no acce, count_nonzero:    CPU:   18.768 us   +/- 3.161 (min:   17.546 / max:   32.421) us     GPU-0:  967.198 us   +/-25.501 (min:  946.338 / max: 1043.632) us
CUB block, count_nonzero:    CPU:   28.172 us   +/-12.841 (min:   18.467 / max:   77.850) us     GPU-0: 2085.492 us   +/-90.017 (min: 1884.766 / max: 2261.376) us
testing count_nonzero with dtype=<class 'numpy.float32'> and axes=(0, 1, 2)...
no acce, count_nonzero:    CPU:   16.745 us   +/- 4.435 (min:   13.754 / max:   34.806) us     GPU-0:217479.045 us   +/-493.290 (min:216745.377 / max:218167.740) us
CUB block, count_nonzero:    CPU:   42.780 us   +/-38.060 (min:   22.847 / max:  201.475) us     GPU-0: 1541.462 us   +/-60.077 (min: 1474.761 / max: 1740.397) us
testing sum with dtype=<class 'numpy.float64'> and axes=(2,)...
no acce, sum        :    CPU:   17.537 us   +/- 2.991 (min:   15.385 / max:   25.559) us     GPU-0: 2069.368 us   +/-12.416 (min: 2029.971 / max: 2085.046) us
CUB device, sum     :    CPU:   37.460 us   +/- 1.833 (min:   36.145 / max:   44.449) us     GPU-0: 1357.152 us   +/-52.876 (min: 1260.512 / max: 1412.077) us
CUB block, sum      :    CPU:   24.764 us   +/- 2.275 (min:   18.715 / max:   26.567) us     GPU-0: 1425.716 us   +/-19.863 (min: 1361.465 / max: 1442.722) us
testing sum with dtype=<class 'numpy.float64'> and axes=(1, 2)...
no acce, sum        :    CPU:   17.723 us   +/- 2.774 (min:   15.580 / max:   25.922) us     GPU-0: 1540.368 us   +/-17.357 (min: 1484.728 / max: 1580.233) us
CUB device, sum     :    CPU:   37.214 us   +/- 1.843 (min:   34.734 / max:   43.344) us     GPU-0: 1473.142 us   +/-22.022 (min: 1435.670 / max: 1508.829) us
CUB block, sum      :    CPU:   25.283 us   +/- 1.740 (min:   21.509 / max:   29.509) us     GPU-0: 1633.722 us   +/-28.535 (min: 1569.242 / max: 1688.667) us
testing sum with dtype=<class 'numpy.float64'> and axes=(0, 1, 2)...
no acce, sum        :    CPU:   19.361 us   +/- 5.799 (min:   14.368 / max:   39.180) us     GPU-0:223956.552 us   +/-2250.289 (min:219992.432 / max:228447.769) us
CUB device, sum     :    CPU:   14.349 us   +/- 2.692 (min:   12.936 / max:   25.512) us     GPU-0: 1276.911 us   +/-28.548 (min: 1254.549 / max: 1360.305) us
CUB block, sum      :    CPU:   29.293 us   +/- 0.868 (min:   28.044 / max:   32.646) us     GPU-0: 1517.318 us   +/-20.188 (min: 1458.400 / max: 1546.780) us
testing prod with dtype=<class 'numpy.float64'> and axes=(2,)...
no acce, prod       :    CPU:   17.797 us   +/- 2.766 (min:   15.621 / max:   25.540) us     GPU-0: 2043.963 us   +/-14.793 (min: 2009.356 / max: 2067.304) us
CUB device, prod    :    CPU:   37.435 us   +/- 1.614 (min:   35.299 / max:   42.967) us     GPU-0: 1373.881 us   +/-32.650 (min: 1318.619 / max: 1399.948) us
CUB block, prod     :    CPU:   22.389 us   +/- 3.338 (min:   17.973 / max:   26.361) us     GPU-0: 1415.349 us   +/-25.574 (min: 1364.774 / max: 1450.736) us
testing prod with dtype=<class 'numpy.float64'> and axes=(1, 2)...
no acce, prod       :    CPU:   17.138 us   +/- 1.990 (min:   15.399 / max:   23.417) us     GPU-0: 1539.368 us   +/-15.629 (min: 1486.521 / max: 1572.525) us
CUB device, prod    :    CPU:   37.683 us   +/- 2.094 (min:   35.858 / max:   45.301) us     GPU-0: 1480.949 us   +/-18.157 (min: 1437.957 / max: 1506.828) us
CUB block, prod     :    CPU:   24.501 us   +/- 2.407 (min:   18.815 / max:   26.854) us     GPU-0: 1629.466 us   +/-22.104 (min: 1568.730 / max: 1656.788) us
testing prod with dtype=<class 'numpy.float64'> and axes=(0, 1, 2)...
no acce, prod       :    CPU:   17.103 us   +/- 3.706 (min:   14.561 / max:   31.539) us     GPU-0:218782.481 us   +/-2582.694 (min:215730.209 / max:224776.978) us
CUB device, prod    :    CPU:   14.304 us   +/- 2.758 (min:   12.772 / max:   25.542) us     GPU-0: 1272.992 us   +/-20.696 (min: 1253.144 / max: 1356.908) us
CUB block, prod     :    CPU:   29.145 us   +/- 0.881 (min:   27.900 / max:   32.281) us     GPU-0: 1528.311 us   +/-16.028 (min: 1466.250 / max: 1550.534) us
testing min with dtype=<class 'numpy.float64'> and axes=(2,)...
no acce, min        :    CPU:   18.913 us   +/- 3.393 (min:   16.032 / max:   25.730) us     GPU-0: 2843.896 us   +/-32.597 (min: 2774.364 / max: 2896.497) us
CUB device, min     :    CPU:   38.047 us   +/- 2.335 (min:   35.943 / max:   46.580) us     GPU-0: 1668.572 us   +/-21.054 (min: 1616.615 / max: 1714.097) us
CUB block, min      :    CPU:   24.884 us   +/- 3.420 (min:   18.324 / max:   34.457) us     GPU-0: 1544.801 us   +/-29.872 (min: 1467.983 / max: 1600.241) us
testing min with dtype=<class 'numpy.float64'> and axes=(1, 2)...
no acce, min        :    CPU:   17.996 us   +/- 2.188 (min:   15.858 / max:   23.026) us     GPU-0: 1911.032 us   +/-31.653 (min: 1854.580 / max: 1979.680) us
CUB device, min     :    CPU:   38.009 us   +/- 2.214 (min:   36.179 / max:   46.465) us     GPU-0: 1469.729 us   +/-25.483 (min: 1424.189 / max: 1494.114) us
CUB block, min      :    CPU:   25.961 us   +/- 0.579 (min:   24.729 / max:   27.623) us     GPU-0: 1912.524 us   +/-15.271 (min: 1867.757 / max: 1940.249) us
testing min with dtype=<class 'numpy.float64'> and axes=(0, 1, 2)...
no acce, min        :    CPU:   19.250 us   +/- 4.467 (min:   14.771 / max:   29.542) us     GPU-0:265835.939 us   +/-1954.364 (min:261754.333 / max:269610.596) us
CUB device, min     :    CPU:   14.818 us   +/- 2.471 (min:   12.994 / max:   24.698) us     GPU-0: 1275.240 us   +/-21.369 (min: 1254.445 / max: 1362.247) us
CUB block, min      :    CPU:   28.690 us   +/- 1.131 (min:   26.688 / max:   30.926) us     GPU-0: 1934.003 us   +/-20.973 (min: 1883.650 / max: 1962.172) us
testing max with dtype=<class 'numpy.float64'> and axes=(2,)...
no acce, max        :    CPU:   17.928 us   +/- 1.979 (min:   16.165 / max:   24.571) us     GPU-0: 2871.583 us   +/-21.000 (min: 2820.939 / max: 2925.195) us
CUB device, max     :    CPU:   38.155 us   +/- 1.782 (min:   36.437 / max:   43.535) us     GPU-0: 1678.009 us   +/-24.413 (min: 1621.469 / max: 1716.225) us
CUB block, max      :    CPU:   24.068 us   +/- 2.404 (min:   18.681 / max:   26.030) us     GPU-0: 1541.232 us   +/-31.805 (min: 1463.908 / max: 1601.685) us
testing max with dtype=<class 'numpy.float64'> and axes=(1, 2)...
no acce, max        :    CPU:   18.440 us   +/- 2.628 (min:   15.943 / max:   24.266) us     GPU-0: 1925.465 us   +/-33.788 (min: 1846.831 / max: 1961.671) us
CUB device, max     :    CPU:   38.051 us   +/- 2.075 (min:   36.035 / max:   46.144) us     GPU-0: 1477.629 us   +/-22.215 (min: 1425.358 / max: 1499.527) us
CUB block, max      :    CPU:   25.575 us   +/- 0.478 (min:   24.546 / max:   26.487) us     GPU-0: 1921.642 us   +/-14.876 (min: 1902.363 / max: 1953.068) us
testing max with dtype=<class 'numpy.float64'> and axes=(0, 1, 2)...
no acce, max        :    CPU:   18.878 us   +/- 4.411 (min:   14.925 / max:   30.280) us     GPU-0:265369.070 us   +/-3010.209 (min:261841.766 / max:270909.241) us
CUB device, max     :    CPU:   15.209 us   +/- 2.625 (min:   13.317 / max:   24.469) us     GPU-0: 1263.119 us   +/-26.965 (min: 1223.851 / max: 1356.220) us
CUB block, max      :    CPU:   29.488 us   +/- 0.981 (min:   28.459 / max:   33.058) us     GPU-0: 1960.622 us   +/-23.484 (min: 1935.592 / max: 2001.883) us
testing argmax with dtype=<class 'numpy.float64'> and axes=None...
no acce, argmax     :    CPU:   20.334 us   +/- 4.572 (min:   16.041 / max:   33.397) us     GPU-0:395996.086 us   +/-4167.646 (min:390717.621 / max:405971.619) us
CUB device, argmax  :    CPU:   39.405 us   +/- 3.275 (min:   35.238 / max:   50.355) us     GPU-0: 1307.979 us   +/-27.517 (min: 1283.108 / max: 1392.100) us
CUB block, argmax   :    CPU:   29.447 us   +/- 1.015 (min:   28.404 / max:   33.205) us     GPU-0:20883.794 us   +/-117.818 (min:20698.051 / max:21125.891) us
testing argmin with dtype=<class 'numpy.float64'> and axes=None...
no acce, argmin     :    CPU:   23.137 us   +/- 7.525 (min:   15.942 / max:   50.816) us     GPU-0:398479.991 us   +/-11754.925 (min:390525.085 / max:444659.973) us
CUB device, argmin  :    CPU:   38.962 us   +/- 3.608 (min:   35.081 / max:   50.919) us     GPU-0: 1315.005 us   +/-32.108 (min: 1287.542 / max: 1386.864) us
CUB block, argmin   :    CPU:   29.592 us   +/- 1.189 (min:   28.700 / max:   34.079) us     GPU-0:20827.362 us   +/-100.273 (min:20692.801 / max:21094.904) us
testing cumsum with dtype=<class 'numpy.float64'> and axes=None...
no acce, cumsum     :    CPU:   42.278 us   +/- 3.517 (min:   37.504 / max:   56.283) us     GPU-0: 9894.120 us   +/-27.366 (min: 9854.053 / max: 9942.805) us
CUB device, cumsum  :    CPU:   26.414 us   +/- 2.747 (min:   24.568 / max:   36.912) us     GPU-0: 5553.317 us   +/-12.748 (min: 5511.073 / max: 5579.032) us
CUB block, cumsum   :    CPU:   40.639 us   +/- 2.845 (min:   35.364 / max:   48.884) us     GPU-0: 9884.272 us   +/-35.613 (min: 9811.217 / max: 9953.904) us
testing cumprod with dtype=<class 'numpy.float64'> and axes=None...
no acce, cumprod    :    CPU:   41.110 us   +/- 3.527 (min:   35.718 / max:   53.589) us     GPU-0: 9882.791 us   +/-45.165 (min: 9791.035 / max: 9987.574) us
CUB device, cumprod :    CPU:   26.627 us   +/- 2.976 (min:   24.185 / max:   34.912) us     GPU-0: 5546.155 us   +/-12.340 (min: 5529.714 / max: 5568.620) us
CUB block, cumprod  :    CPU:   38.678 us   +/- 3.039 (min:   35.368 / max:   48.767) us     GPU-0: 9888.099 us   +/-28.808 (min: 9837.494 / max: 9957.764) us
testing mean with dtype=<class 'numpy.float64'> and axes=(2,)...
no acce, mean       :    CPU:   17.963 us   +/- 2.737 (min:   15.819 / max:   25.794) us     GPU-0: 2339.037 us   +/-13.687 (min: 2290.608 / max: 2366.284) us
CUB device, mean    :    CPU:   55.897 us   +/- 3.960 (min:   52.278 / max:   70.621) us     GPU-0: 1386.676 us   +/-33.239 (min: 1316.032 / max: 1417.976) us
CUB block, mean     :    CPU:   25.253 us   +/- 1.499 (min:   21.685 / max:   27.033) us     GPU-0: 1414.713 us   +/-33.131 (min: 1342.931 / max: 1452.835) us
testing mean with dtype=<class 'numpy.float64'> and axes=(1, 2)...
no acce, mean       :    CPU:   17.602 us   +/- 2.010 (min:   15.851 / max:   23.585) us     GPU-0: 1537.949 us   +/-26.851 (min: 1444.009 / max: 1580.827) us
CUB device, mean    :    CPU:   54.574 us   +/- 5.234 (min:   51.526 / max:   76.644) us     GPU-0: 1484.180 us   +/-18.949 (min: 1430.228 / max: 1507.024) us
CUB block, mean     :    CPU:   25.382 us   +/- 1.603 (min:   20.159 / max:   27.388) us     GPU-0: 1605.870 us   +/-29.967 (min: 1529.453 / max: 1648.489) us
testing mean with dtype=<class 'numpy.float64'> and axes=(0, 1, 2)...
no acce, mean       :    CPU:   17.543 us   +/- 3.740 (min:   14.212 / max:   30.048) us     GPU-0:219150.706 us   +/-2247.958 (min:215484.283 / max:224765.182) us
CUB device, mean    :    CPU:   34.037 us   +/- 2.320 (min:   29.162 / max:   41.465) us     GPU-0: 1255.514 us   +/-27.248 (min: 1233.165 / max: 1343.585) us
CUB block, mean     :    CPU:   29.931 us   +/- 1.025 (min:   29.067 / max:   33.923) us     GPU-0: 1519.874 us   +/-17.126 (min: 1450.967 / max: 1544.876) us
testing amin with dtype=<class 'numpy.float64'> and axes=(2,)...
no acce, amin       :    CPU:   17.891 us   +/- 2.520 (min:   15.818 / max:   25.643) us     GPU-0: 2869.487 us   +/-16.153 (min: 2826.152 / max: 2897.463) us
CUB block, amin     :    CPU:   24.192 us   +/- 2.956 (min:   18.517 / max:   26.886) us     GPU-0: 1545.428 us   +/-26.507 (min: 1514.024 / max: 1603.047) us
testing amin with dtype=<class 'numpy.float64'> and axes=(1, 2)...
no acce, amin       :    CPU:   17.088 us   +/- 1.801 (min:   15.805 / max:   22.705) us     GPU-0: 1913.536 us   +/-31.473 (min: 1859.876 / max: 1964.798) us
CUB block, amin     :    CPU:   25.339 us   +/- 1.376 (min:   21.616 / max:   26.233) us     GPU-0: 1906.965 us   +/-23.565 (min: 1840.350 / max: 1945.334) us
testing amin with dtype=<class 'numpy.float64'> and axes=(0, 1, 2)...
no acce, amin       :    CPU:   19.998 us   +/- 5.534 (min:   15.435 / max:   36.095) us     GPU-0:265886.609 us   +/-1088.717 (min:264045.807 / max:268569.092) us
CUB block, amin     :    CPU:   29.054 us   +/- 0.560 (min:   27.832 / max:   30.242) us     GPU-0: 1938.051 us   +/-24.992 (min: 1871.454 / max: 1991.083) us
testing amax with dtype=<class 'numpy.float64'> and axes=(2,)...
no acce, amax       :    CPU:   17.917 us   +/- 1.958 (min:   15.934 / max:   24.303) us     GPU-0: 2851.827 us   +/-31.911 (min: 2780.874 / max: 2875.219) us
CUB block, amax     :    CPU:   24.198 us   +/- 2.556 (min:   18.824 / max:   25.988) us     GPU-0: 1549.338 us   +/-31.256 (min: 1471.911 / max: 1618.798) us
testing amax with dtype=<class 'numpy.float64'> and axes=(1, 2)...
no acce, amax       :    CPU:   18.035 us   +/- 2.509 (min:   16.065 / max:   25.168) us     GPU-0: 1921.547 us   +/-31.960 (min: 1854.794 / max: 1982.918) us
CUB block, amax     :    CPU:   25.213 us   +/- 1.165 (min:   21.835 / max:   26.027) us     GPU-0: 1912.732 us   +/-31.731 (min: 1806.073 / max: 1962.940) us
testing amax with dtype=<class 'numpy.float64'> and axes=(0, 1, 2)...
no acce, amax       :    CPU:   20.474 us   +/- 6.400 (min:   15.112 / max:   39.575) us     GPU-0:265486.537 us   +/-2361.634 (min:262232.544 / max:270143.860) us
CUB block, amax     :    CPU:   29.351 us   +/- 0.990 (min:   28.458 / max:   33.379) us     GPU-0: 1941.951 us   +/-18.796 (min: 1877.346 / max: 1966.193) us
testing nanmin with dtype=<class 'numpy.float64'> and axes=(2,)...
no acce, nanmin     :    CPU: 2991.018 us   +/- 2.187 (min: 2985.833 / max: 2996.024) us     GPU-0: 2998.940 us   +/- 3.987 (min: 2993.038 / max: 3010.839) us
CUB block, nanmin   :    CPU: 1423.129 us   +/-31.474 (min: 1363.749 / max: 1512.531) us     GPU-0: 1447.738 us   +/-50.188 (min: 1372.155 / max: 1621.880) us
testing nanmin with dtype=<class 'numpy.float64'> and axes=(1, 2)...
no acce, nanmin     :    CPU: 1746.171 us   +/-25.362 (min: 1684.981 / max: 1785.205) us     GPU-0: 1753.234 us   +/-24.992 (min: 1698.605 / max: 1799.561) us
CUB block, nanmin   :    CPU: 1648.119 us   +/-37.621 (min: 1594.903 / max: 1723.642) us     GPU-0: 1658.619 us   +/-33.381 (min: 1599.766 / max: 1721.798) us
testing nanmin with dtype=<class 'numpy.float64'> and axes=(0, 1, 2)...
no acce, nanmin     :    CPU:235375.115 us   +/-2732.287 (min:230005.718 / max:239188.413) us     GPU-0:235383.932 us   +/-2731.914 (min:230015.274 / max:239200.012) us
CUB block, nanmin   :    CPU: 1730.994 us   +/-30.196 (min: 1674.224 / max: 1772.100) us     GPU-0: 1740.811 us   +/-25.005 (min: 1699.523 / max: 1774.945) us
testing nanmax with dtype=<class 'numpy.float64'> and axes=(2,)...
no acce, nanmax     :    CPU: 2989.513 us   +/-10.533 (min: 2947.730 / max: 3008.045) us     GPU-0: 2997.103 us   +/-11.422 (min: 2954.079 / max: 3015.244) us
CUB block, nanmax   :    CPU: 1400.868 us   +/-45.561 (min: 1336.551 / max: 1494.945) us     GPU-0: 1412.437 us   +/-47.681 (min: 1344.339 / max: 1493.256) us
testing nanmax with dtype=<class 'numpy.float64'> and axes=(1, 2)...
no acce, nanmax     :    CPU: 1795.044 us   +/-27.913 (min: 1727.366 / max: 1847.350) us     GPU-0: 1802.257 us   +/-27.378 (min: 1739.453 / max: 1849.293) us
CUB block, nanmax   :    CPU: 1693.237 us   +/-37.741 (min: 1629.346 / max: 1754.010) us     GPU-0: 1705.331 us   +/-41.583 (min: 1637.103 / max: 1803.995) us
testing nanmax with dtype=<class 'numpy.float64'> and axes=(0, 1, 2)...
no acce, nanmax     :    CPU:235693.980 us   +/-2739.801 (min:231195.540 / max:239763.166) us     GPU-0:235703.409 us   +/-2739.024 (min:231214.874 / max:239775.391) us
CUB block, nanmax   :    CPU: 1691.321 us   +/-14.088 (min: 1672.553 / max: 1719.741) us     GPU-0: 1701.379 us   +/-16.158 (min: 1679.910 / max: 1743.981) us
testing nanargmin with dtype=<class 'numpy.float64'> and axes=None...
no acce, nanargmin  :    CPU:   19.632 us   +/- 6.697 (min:   15.133 / max:   43.055) us     GPU-0:402957.716 us   +/-13657.393 (min:383768.005 / max:422299.011) us
CUB block, nanargmin:    CPU:   30.010 us   +/- 2.649 (min:   28.039 / max:   39.268) us     GPU-0:20919.462 us   +/-119.318 (min:20760.420 / max:21245.571) us
testing nanargmax with dtype=<class 'numpy.float64'> and axes=None...
no acce, nanargmax  :    CPU:   21.805 us   +/- 8.333 (min:   15.543 / max:   53.557) us     GPU-0:394420.328 us   +/-4156.415 (min:383701.721 / max:404483.307) us
CUB block, nanargmax:    CPU:   30.617 us   +/- 5.210 (min:   28.062 / max:   51.027) us     GPU-0:20950.845 us   +/-97.845 (min:20827.671 / max:21187.584) us
testing nanmean with dtype=<class 'numpy.float64'> and axes=(2,)...
no acce, nanmean    :    CPU:   18.795 us   +/- 4.288 (min:   15.768 / max:   32.484) us     GPU-0: 2543.168 us   +/-29.778 (min: 2499.170 / max: 2619.076) us
CUB block, nanmean  :    CPU:   28.526 us   +/-10.399 (min:   24.452 / max:   72.986) us     GPU-0: 2525.196 us   +/-42.101 (min: 2445.150 / max: 2634.168) us
testing nanmean with dtype=<class 'numpy.float64'> and axes=(1, 2)...
no acce, nanmean    :    CPU:   17.151 us   +/- 2.975 (min:   15.326 / max:   28.647) us     GPU-0: 1850.445 us   +/-27.604 (min: 1778.498 / max: 1886.441) us
CUB block, nanmean  :    CPU:   28.237 us   +/-12.461 (min:   17.926 / max:   80.209) us     GPU-0: 3556.239 us   +/-33.820 (min: 3503.992 / max: 3620.866) us
testing nanmean with dtype=<class 'numpy.float64'> and axes=(0, 1, 2)...
no acce, nanmean    :    CPU:   18.220 us   +/- 7.611 (min:   13.943 / max:   48.666) us     GPU-0:234724.463 us   +/-2347.542 (min:231238.235 / max:239409.103) us
CUB block, nanmean  :    CPU:   32.501 us   +/-10.720 (min:   28.735 / max:   77.761) us     GPU-0: 2667.652 us   +/-33.468 (min: 2625.017 / max: 2771.846) us
testing var with dtype=<class 'numpy.float64'> and axes=(2,)...
no acce, var        :    CPU:   64.430 us   +/- 5.766 (min:   61.695 / max:   89.062) us     GPU-0: 6111.887 us   +/-42.240 (min: 6014.966 / max: 6156.518) us
CUB block, var      :    CPU:   68.838 us   +/- 3.957 (min:   66.500 / max:   85.172) us     GPU-0: 5204.213 us   +/-18.530 (min: 5175.290 / max: 5240.361) us
testing var with dtype=<class 'numpy.float64'> and axes=(1, 2)...
no acce, var        :    CPU:   67.300 us   +/-11.748 (min:   62.110 / max:  117.188) us     GPU-0:70096.952 us   +/-1983.915 (min:68729.240 / max:76090.729) us
CUB block, var      :    CPU:   75.073 us   +/- 9.745 (min:   68.026 / max:  114.453) us     GPU-0:70282.550 us   +/-2458.220 (min:68756.317 / max:78130.875) us
testing var with dtype=<class 'numpy.float64'> and axes=(0, 1, 2)...
no acce, var        :    CPU:  112.758 us   +/-30.040 (min:   78.686 / max:  202.948) us     GPU-0:7018698.584 us   +/-19747.018 (min:6986596.191 / max:7053641.602) us
CUB block, var      :    CPU:   85.448 us   +/-11.612 (min:   78.609 / max:  132.580) us     GPU-0:235757.855 us   +/-2654.864 (min:231413.666 / max:240179.764) us
testing nanvar with dtype=<class 'numpy.float64'> and axes=(2,)...
no acce, nanvar     :    CPU:   63.060 us   +/- 4.579 (min:   60.743 / max:   82.803) us     GPU-0: 8479.529 us   +/-14.121 (min: 8450.716 / max: 8503.203) us
CUB block, nanvar   :    CPU:   71.068 us   +/-12.878 (min:   65.623 / max:  125.884) us     GPU-0: 9269.495 us   +/-27.139 (min: 9225.543 / max: 9356.213) us
testing nanvar with dtype=<class 'numpy.float64'> and axes=(1, 2)...
no acce, nanvar     :    CPU:   64.025 us   +/- 5.687 (min:   60.833 / max:   87.950) us     GPU-0:88752.429 us   +/-526.252 (min:88085.548 / max:89825.630) us
CUB block, nanvar   :    CPU:   70.791 us   +/- 7.498 (min:   65.778 / max:  101.455) us     GPU-0:91556.248 us   +/-1140.686 (min:89074.791 / max:93328.323) us
testing nanvar with dtype=<class 'numpy.float64'> and axes=(0, 1, 2)...
no acce, nanvar     :    CPU:  100.696 us   +/-29.370 (min:   68.702 / max:  195.588) us     GPU-0:14656932.031 us   +/-37082.208 (min:14575644.531 / max:14713983.398) us
CUB block, nanvar   :    CPU:   83.766 us   +/-13.577 (min:   76.820 / max:  139.130) us     GPU-0:436833.614 us   +/-7812.737 (min:420962.219 / max:445065.643) us
testing nansum with dtype=<class 'numpy.float64'> and axes=(2,)...
no acce, nansum     :    CPU:   17.517 us   +/- 5.258 (min:   14.898 / max:   38.281) us     GPU-0: 2129.449 us   +/-14.702 (min: 2101.019 / max: 2167.688) us
CUB block, nansum   :    CPU:   20.039 us   +/- 2.819 (min:   17.106 / max:   24.621) us     GPU-0: 2538.950 us   +/-15.044 (min: 2488.155 / max: 2555.021) us
testing nansum with dtype=<class 'numpy.float64'> and axes=(1, 2)...
no acce, nansum     :    CPU:   16.444 us   +/- 2.151 (min:   14.651 / max:   21.724) us     GPU-0: 1546.233 us   +/-27.432 (min: 1482.307 / max: 1601.474) us
CUB block, nansum   :    CPU:   22.073 us   +/- 3.413 (min:   17.825 / max:   26.355) us     GPU-0: 3223.459 us   +/-55.418 (min: 3082.840 / max: 3307.947) us
testing nansum with dtype=<class 'numpy.float64'> and axes=(0, 1, 2)...
no acce, nansum     :    CPU:   18.659 us   +/- 6.323 (min:   14.009 / max:   40.050) us     GPU-0:241540.778 us   +/-1829.615 (min:237897.995 / max:244022.202) us
CUB block, nansum   :    CPU:   27.980 us   +/- 0.945 (min:   27.131 / max:   30.669) us     GPU-0: 2580.772 us   +/- 6.941 (min: 2569.525 / max: 2601.741) us
testing nanprod with dtype=<class 'numpy.float64'> and axes=(2,)...
no acce, nanprod    :    CPU:   16.695 us   +/- 3.414 (min:   14.699 / max:   30.373) us     GPU-0: 2158.223 us   +/-21.023 (min: 2098.069 / max: 2198.412) us
CUB block, nanprod  :    CPU:   30.472 us   +/-20.053 (min:   17.616 / max:  103.414) us     GPU-0: 2556.757 us   +/-27.740 (min: 2493.482 / max: 2636.526) us
testing nanprod with dtype=<class 'numpy.float64'> and axes=(1, 2)...
no acce, nanprod    :    CPU:   16.922 us   +/- 2.608 (min:   14.886 / max:   22.521) us     GPU-0: 1540.280 us   +/-28.900 (min: 1452.430 / max: 1572.873) us
CUB block, nanprod  :    CPU:   23.855 us   +/- 2.985 (min:   18.157 / max:   30.413) us     GPU-0: 3206.088 us   +/-37.978 (min: 3130.168 / max: 3267.250) us
testing nanprod with dtype=<class 'numpy.float64'> and axes=(0, 1, 2)...
no acce, nanprod    :    CPU:   17.586 us   +/- 5.278 (min:   13.870 / max:   36.724) us     GPU-0:237758.390 us   +/-2737.863 (min:233766.464 / max:242436.066) us
CUB block, nanprod  :    CPU:   29.728 us   +/- 3.144 (min:   27.802 / max:   42.449) us     GPU-0: 2586.317 us   +/-14.801 (min: 2574.206 / max: 2643.498) us
testing all with dtype=<class 'numpy.float64'> and axes=(2,)...
no acce, all        :    CPU:   16.321 us   +/- 3.215 (min:   14.754 / max:   29.051) us     GPU-0: 1988.888 us   +/-13.023 (min: 1940.520 / max: 2008.287) us
CUB block, all      :    CPU:   22.251 us   +/- 5.663 (min:   17.797 / max:   38.419) us     GPU-0: 2568.290 us   +/-30.010 (min: 2462.839 / max: 2619.210) us
testing all with dtype=<class 'numpy.float64'> and axes=(1, 2)...
no acce, all        :    CPU:   16.618 us   +/- 2.430 (min:   14.757 / max:   23.028) us     GPU-0: 1542.860 us   +/-27.362 (min: 1473.210 / max: 1577.157) us
CUB block, all      :    CPU:   30.396 us   +/-18.695 (min:   18.484 / max:  101.745) us     GPU-0: 3230.313 us   +/-55.351 (min: 3140.180 / max: 3410.041) us
testing all with dtype=<class 'numpy.float64'> and axes=(0, 1, 2)...
no acce, all        :    CPU:   16.850 us   +/- 4.698 (min:   13.756 / max:   33.021) us     GPU-0:226509.975 us   +/-2445.938 (min:222335.922 / max:231614.853) us
CUB block, all      :    CPU:   40.804 us   +/-22.083 (min:   29.203 / max:  119.635) us     GPU-0: 2626.444 us   +/-36.656 (min: 2571.603 / max: 2757.845) us
testing any with dtype=<class 'numpy.float64'> and axes=(2,)...
no acce, any        :    CPU:   23.561 us   +/- 6.970 (min:   16.849 / max:   42.137) us     GPU-0: 1991.242 us   +/-12.151 (min: 1974.270 / max: 2022.446) us
CUB block, any      :    CPU:   22.059 us   +/- 4.984 (min:   17.400 / max:   35.927) us     GPU-0: 2609.662 us   +/-35.785 (min: 2522.123 / max: 2673.132) us
testing any with dtype=<class 'numpy.float64'> and axes=(1, 2)...
no acce, any        :    CPU:   15.972 us   +/- 1.825 (min:   14.494 / max:   22.175) us     GPU-0: 1543.056 us   +/-23.919 (min: 1479.604 / max: 1570.964) us
CUB block, any      :    CPU:   23.660 us   +/- 2.193 (min:   18.070 / max:   25.912) us     GPU-0: 3188.692 us   +/-40.093 (min: 3121.999 / max: 3271.593) us
testing any with dtype=<class 'numpy.float64'> and axes=(0, 1, 2)...
no acce, any        :    CPU:   17.657 us   +/- 6.686 (min:   13.715 / max:   43.501) us     GPU-0:227015.498 us   +/-2960.119 (min:222571.045 / max:231828.613) us
CUB block, any      :    CPU:   32.027 us   +/- 8.864 (min:   28.431 / max:   69.543) us     GPU-0: 2620.508 us   +/-24.639 (min: 2568.647 / max: 2710.276) us
testing count_nonzero with dtype=<class 'numpy.float64'> and axes=(2,)...
no acce, count_nonzero:    CPU:   17.610 us   +/- 3.705 (min:   15.196 / max:   30.256) us     GPU-0: 2027.076 us   +/-13.506 (min: 2009.612 / max: 2064.076) us
CUB block, count_nonzero:    CPU:   22.447 us   +/- 5.696 (min:   17.983 / max:   36.897) us     GPU-0: 2534.453 us   +/-30.463 (min: 2423.655 / max: 2591.622) us
testing count_nonzero with dtype=<class 'numpy.float64'> and axes=(1, 2)...
no acce, count_nonzero:    CPU:   16.738 us   +/- 2.612 (min:   14.743 / max:   24.708) us     GPU-0: 1540.703 us   +/-18.148 (min: 1491.474 / max: 1568.790) us
CUB block, count_nonzero:    CPU:   19.584 us   +/- 3.719 (min:   16.397 / max:   29.272) us     GPU-0: 3239.117 us   +/-47.475 (min: 3131.670 / max: 3319.409) us
testing count_nonzero with dtype=<class 'numpy.float64'> and axes=(0, 1, 2)...
no acce, count_nonzero:    CPU:   15.264 us   +/- 4.508 (min:   12.776 / max:   33.683) us     GPU-0:225969.272 us   +/-2709.470 (min:222738.754 / max:231563.858) us
CUB block, count_nonzero:    CPU:   31.839 us   +/- 9.111 (min:   27.650 / max:   70.113) us     GPU-0: 2612.914 us   +/-26.234 (min: 2567.165 / max: 2662.474) us
testing sum with dtype=<class 'numpy.complex64'> and axes=(2,)...
no acce, sum        :    CPU:   17.907 us   +/- 3.463 (min:   15.497 / max:   29.970) us     GPU-0: 2009.661 us   +/-18.104 (min: 1986.535 / max: 2072.032) us
CUB device, sum     :    CPU:   36.964 us   +/- 1.983 (min:   35.238 / max:   44.037) us     GPU-0: 1369.933 us   +/-29.589 (min: 1291.490 / max: 1396.180) us
CUB block, sum      :    CPU:   34.323 us   +/-10.471 (min:   19.806 / max:   57.646) us     GPU-0: 1416.332 us   +/-42.897 (min: 1294.328 / max: 1484.364) us
testing sum with dtype=<class 'numpy.complex64'> and axes=(1, 2)...
no acce, sum        :    CPU:   24.748 us   +/-10.084 (min:   14.635 / max:   45.438) us     GPU-0: 1585.810 us   +/-61.895 (min: 1444.886 / max: 1679.162) us
CUB device, sum     :    CPU:   33.879 us   +/- 1.229 (min:   32.746 / max:   38.409) us     GPU-0: 1470.856 us   +/-24.183 (min: 1407.834 / max: 1503.580) us
CUB block, sum      :    CPU:   18.600 us   +/- 1.973 (min:   16.415 / max:   22.862) us     GPU-0: 1579.755 us   +/-26.284 (min: 1522.277 / max: 1613.111) us
testing sum with dtype=<class 'numpy.complex64'> and axes=(0, 1, 2)...
no acce, sum        :    CPU:   15.666 us   +/- 2.868 (min:   13.197 / max:   23.861) us     GPU-0:214095.553 us   +/-2544.217 (min:208949.982 / max:219303.207) us
CUB device, sum     :    CPU:   13.686 us   +/- 2.581 (min:   12.247 / max:   24.126) us     GPU-0: 1268.259 us   +/-26.242 (min: 1224.810 / max: 1372.322) us
CUB block, sum      :    CPU:   27.304 us   +/- 0.836 (min:   25.095 / max:   29.660) us     GPU-0: 1473.712 us   +/-12.085 (min: 1448.531 / max: 1495.112) us
testing prod with dtype=<class 'numpy.complex64'> and axes=(2,)...
no acce, prod       :    CPU:   15.238 us   +/- 1.897 (min:   13.793 / max:   21.732) us     GPU-0: 2068.266 us   +/-26.027 (min: 2021.429 / max: 2100.327) us
CUB device, prod    :    CPU:   34.364 us   +/- 1.132 (min:   33.169 / max:   38.134) us     GPU-0: 1358.136 us   +/-50.292 (min: 1253.389 / max: 1413.248) us
CUB block, prod     :    CPU:   17.519 us   +/- 2.031 (min:   15.522 / max:   21.332) us     GPU-0: 1426.542 us   +/-24.974 (min: 1379.033 / max: 1453.918) us
testing prod with dtype=<class 'numpy.complex64'> and axes=(1, 2)...
no acce, prod       :    CPU:   15.066 us   +/- 2.028 (min:   13.662 / max:   21.282) us     GPU-0: 1543.172 us   +/-28.185 (min: 1477.176 / max: 1609.049) us
CUB device, prod    :    CPU:   34.335 us   +/- 1.336 (min:   32.890 / max:   39.213) us     GPU-0: 1508.972 us   +/-30.851 (min: 1442.771 / max: 1542.348) us
CUB block, prod     :    CPU:   19.982 us   +/- 2.664 (min:   16.822 / max:   24.337) us     GPU-0: 1636.755 us   +/-21.965 (min: 1574.645 / max: 1661.318) us
testing prod with dtype=<class 'numpy.complex64'> and axes=(0, 1, 2)...
no acce, prod       :    CPU:   15.164 us   +/- 2.806 (min:   13.235 / max:   24.854) us     GPU-0:222615.558 us   +/-2260.382 (min:219765.289 / max:228484.894) us
CUB device, prod    :    CPU:   13.132 us   +/- 1.611 (min:   11.560 / max:   17.948) us     GPU-0: 1281.828 us   +/-21.121 (min: 1257.991 / max: 1364.999) us
CUB block, prod     :    CPU:   27.267 us   +/- 0.850 (min:   26.550 / max:   30.712) us     GPU-0: 1473.800 us   +/-12.481 (min: 1450.532 / max: 1497.942) us
testing min with dtype=<class 'numpy.complex64'> and axes=(2,)...
no acce, min        :    CPU:   16.080 us   +/- 1.723 (min:   14.577 / max:   21.579) us     GPU-0: 5588.394 us   +/- 7.493 (min: 5566.054 / max: 5608.026) us
CUB device, min     :    CPU:   36.269 us   +/- 1.293 (min:   34.720 / max:   40.097) us     GPU-0:14129.754 us   +/-12.156 (min:14107.144 / max:14155.230) us
CUB block, min      :    CPU:   20.835 us   +/- 2.985 (min:   17.218 / max:   24.369) us     GPU-0: 7982.682 us   +/-10.241 (min: 7966.073 / max: 8005.338) us
testing min with dtype=<class 'numpy.complex64'> and axes=(1, 2)...
no acce, min        :    CPU:   15.838 us   +/- 1.943 (min:   14.559 / max:   22.587) us     GPU-0: 7608.585 us   +/-12.660 (min: 7590.962 / max: 7634.933) us
CUB device, min     :    CPU:   35.592 us   +/- 1.261 (min:   34.444 / max:   38.962) us     GPU-0: 7477.197 us   +/-31.222 (min: 7427.913 / max: 7544.408) us
CUB block, min      :    CPU:   23.504 us   +/- 1.195 (min:   18.601 / max:   24.613) us     GPU-0:13483.101 us   +/-37.916 (min:13421.162 / max:13595.663) us
testing min with dtype=<class 'numpy.complex64'> and axes=(0, 1, 2)...
no acce, min        :    CPU:   16.827 us   +/- 3.897 (min:   14.484 / max:   31.489) us     GPU-0:403235.321 us   +/-10068.958 (min:384984.619 / max:417934.723) us
CUB device, min     :    CPU:   14.343 us   +/- 2.505 (min:   13.044 / max:   24.170) us     GPU-0: 5599.005 us   +/-12.630 (min: 5583.545 / max: 5645.700) us
CUB block, min      :    CPU:   27.571 us   +/- 0.510 (min:   26.885 / max:   29.403) us     GPU-0: 5282.421 us   +/-17.468 (min: 5244.698 / max: 5314.927) us
testing max with dtype=<class 'numpy.complex64'> and axes=(2,)...
no acce, max        :    CPU:   15.764 us   +/- 1.632 (min:   14.550 / max:   21.378) us     GPU-0: 5059.546 us   +/- 6.970 (min: 5053.201 / max: 5080.249) us
CUB device, max     :    CPU:   35.783 us   +/- 1.411 (min:   34.607 / max:   40.074) us     GPU-0: 8067.887 us   +/-17.486 (min: 7996.420 / max: 8089.849) us
CUB block, max      :    CPU:   19.004 us   +/- 2.503 (min:   17.010 / max:   23.812) us     GPU-0: 4868.824 us   +/-17.257 (min: 4822.894 / max: 4889.088) us
testing max with dtype=<class 'numpy.complex64'> and axes=(1, 2)...
no acce, max        :    CPU:   16.048 us   +/- 2.012 (min:   14.879 / max:   23.358) us     GPU-0: 4638.513 us   +/-39.126 (min: 4566.070 / max: 4720.685) us
CUB device, max     :    CPU:   35.739 us   +/- 0.920 (min:   34.363 / max:   38.709) us     GPU-0: 4428.440 us   +/-10.001 (min: 4407.099 / max: 4443.797) us
CUB block, max      :    CPU:   23.610 us   +/- 1.296 (min:   18.241 / max:   24.743) us     GPU-0: 5985.256 us   +/-12.032 (min: 5959.778 / max: 6005.898) us
testing max with dtype=<class 'numpy.complex64'> and axes=(0, 1, 2)...
no acce, max        :    CPU:   21.653 us   +/- 3.902 (min:   14.469 / max:   28.827) us     GPU-0:426626.170 us   +/-30935.038 (min:398619.751 / max:482950.317) us
CUB device, max     :    CPU:   14.540 us   +/- 2.492 (min:   13.065 / max:   23.857) us     GPU-0: 5600.413 us   +/-12.791 (min: 5586.164 / max: 5639.932) us
CUB block, max      :    CPU:   27.957 us   +/- 1.489 (min:   26.501 / max:   31.852) us     GPU-0: 5307.317 us   +/-15.283 (min: 5265.061 / max: 5328.677) us
testing argmax with dtype=<class 'numpy.complex64'> and axes=None...
no acce, argmax     :    CPU:   23.700 us   +/- 3.866 (min:   22.366 / max:   40.508) us     GPU-0:504014.334 us   +/-14061.100 (min:492680.237 / max:552006.531) us
CUB device, argmax  :    CPU:   33.617 us   +/- 2.748 (min:   31.647 / max:   42.989) us     GPU-0: 1412.370 us   +/-33.137 (min: 1331.238 / max: 1457.936) us
CUB block, argmax   :    CPU:   28.324 us   +/- 2.834 (min:   26.478 / max:   38.938) us     GPU-0:14262.196 us   +/-66.108 (min:14153.831 / max:14400.622) us
testing argmin with dtype=<class 'numpy.complex64'> and axes=None...
no acce, argmin     :    CPU:   23.844 us   +/- 3.141 (min:   22.257 / max:   36.338) us     GPU-0:503607.712 us   +/-5566.162 (min:491027.191 / max:511168.823) us
CUB device, argmin  :    CPU:   34.008 us   +/- 3.444 (min:   31.720 / max:   45.930) us     GPU-0: 1387.995 us   +/-39.988 (min: 1311.455 / max: 1432.212) us
CUB block, argmin   :    CPU:   27.763 us   +/- 1.886 (min:   26.137 / max:   34.681) us     GPU-0:14232.704 us   +/-68.592 (min:14114.192 / max:14362.808) us
testing cumsum with dtype=<class 'numpy.complex64'> and axes=None...
no acce, cumsum     :    CPU:   34.612 us   +/- 2.869 (min:   32.303 / max:   43.085) us     GPU-0:10416.518 us   +/-36.987 (min:10335.697 / max:10490.309) us
WARNING: CuPy's kernel might have a problem with cumsum and <class 'numpy.complex64'>
CUB device, cumsum  :    CPU:   23.617 us   +/- 2.143 (min:   21.788 / max:   30.901) us     GPU-0: 6607.637 us   +/-17.108 (min: 6561.888 / max: 6640.215) us
WARNING: CUB device might have a problem with cumsum and <class 'numpy.complex64'>
CUB block, cumsum   :    CPU:   34.222 us   +/- 3.490 (min:   31.736 / max:   47.457) us     GPU-0:10424.994 us   +/-33.914 (min:10365.787 / max:10508.187) us
WARNING: CUB block might have a problem with cumsum and <class 'numpy.complex64'>
testing cumprod with dtype=<class 'numpy.complex64'> and axes=None...
no acce, cumprod    :    CPU:   34.188 us   +/- 2.788 (min:   31.614 / max:   38.934) us     GPU-0:10403.831 us   +/-32.387 (min:10340.471 / max:10470.698) us
CUB device, cumprod :    CPU:   23.554 us   +/- 2.707 (min:   21.681 / max:   34.094) us     GPU-0: 5860.872 us   +/-16.324 (min: 5814.530 / max: 5895.347) us
CUB block, cumprod  :    CPU:   34.225 us   +/- 3.414 (min:   31.923 / max:   47.139) us     GPU-0:10383.228 us   +/-29.458 (min:10329.093 / max:10437.995) us
testing mean with dtype=<class 'numpy.complex64'> and axes=(2,)...
no acce, mean       :    CPU:   15.851 us   +/- 2.432 (min:   14.026 / max:   23.522) us     GPU-0: 2314.575 us   +/-19.452 (min: 2268.115 / max: 2345.321) us
CUB device, mean    :    CPU:   52.196 us   +/- 2.391 (min:   50.370 / max:   61.340) us     GPU-0: 1290.962 us   +/- 9.828 (min: 1283.087 / max: 1329.936) us
CUB block, mean     :    CPU:   21.866 us   +/- 2.461 (min:   18.118 / max:   24.487) us     GPU-0: 1401.497 us   +/-30.759 (min: 1337.627 / max: 1435.118) us
testing mean with dtype=<class 'numpy.complex64'> and axes=(1, 2)...
no acce, mean       :    CPU:   15.275 us   +/- 1.927 (min:   14.013 / max:   22.167) us     GPU-0: 1543.022 us   +/-18.183 (min: 1477.080 / max: 1564.841) us
CUB device, mean    :    CPU:   49.941 us   +/- 2.229 (min:   47.596 / max:   58.856) us     GPU-0: 1468.662 us   +/-30.448 (min: 1407.597 / max: 1503.151) us
CUB block, mean     :    CPU:   22.865 us   +/- 2.049 (min:   18.268 / max:   24.921) us     GPU-0: 1587.783 us   +/-28.491 (min: 1524.776 / max: 1611.932) us
testing mean with dtype=<class 'numpy.complex64'> and axes=(0, 1, 2)...
no acce, mean       :    CPU:   19.539 us   +/- 4.120 (min:   15.363 / max:   30.154) us     GPU-0:214596.395 us   +/-2181.219 (min:210268.097 / max:218630.402) us
CUB device, mean    :    CPU:   29.811 us   +/- 2.674 (min:   27.307 / max:   37.165) us     GPU-0: 1277.092 us   +/-40.001 (min: 1236.223 / max: 1408.413) us
CUB block, mean     :    CPU:   28.024 us   +/- 1.052 (min:   26.679 / max:   30.988) us     GPU-0: 1473.370 us   +/-12.577 (min: 1448.881 / max: 1493.587) us
testing amin with dtype=<class 'numpy.complex64'> and axes=(2,)...
no acce, amin       :    CPU:   16.561 us   +/- 2.249 (min:   15.072 / max:   23.497) us     GPU-0: 5059.211 us   +/-11.176 (min: 5019.102 / max: 5082.020) us
CUB block, amin     :    CPU:   21.523 us   +/- 2.793 (min:   17.786 / max:   24.231) us     GPU-0: 4851.962 us   +/-26.281 (min: 4769.234 / max: 4891.184) us
testing amin with dtype=<class 'numpy.complex64'> and axes=(1, 2)...
no acce, amin       :    CPU:   16.328 us   +/- 2.293 (min:   14.992 / max:   23.779) us     GPU-0: 4607.597 us   +/-33.287 (min: 4553.517 / max: 4686.558) us
CUB block, amin     :    CPU:   23.529 us   +/- 1.773 (min:   18.139 / max:   24.959) us     GPU-0: 5962.806 us   +/- 7.965 (min: 5950.418 / max: 5986.383) us
testing amin with dtype=<class 'numpy.complex64'> and axes=(0, 1, 2)...
no acce, amin       :    CPU:   23.602 us   +/- 3.007 (min:   17.418 / max:   34.137) us     GPU-0:397468.147 us   +/-6069.950 (min:387705.322 / max:409179.657) us
CUB block, amin     :    CPU:   27.791 us   +/- 1.941 (min:   26.888 / max:   36.058) us     GPU-0: 5282.649 us   +/-18.024 (min: 5246.342 / max: 5311.015) us
testing amax with dtype=<class 'numpy.complex64'> and axes=(2,)...
no acce, amax       :    CPU:   15.862 us   +/- 1.643 (min:   14.888 / max:   21.386) us     GPU-0: 5053.626 us   +/-15.945 (min: 5008.565 / max: 5081.889) us
CUB block, amax     :    CPU:   21.642 us   +/- 3.148 (min:   17.369 / max:   27.298) us     GPU-0: 4871.388 us   +/-18.502 (min: 4836.424 / max: 4894.717) us
testing amax with dtype=<class 'numpy.complex64'> and axes=(1, 2)...
no acce, amax       :    CPU:   15.947 us   +/- 1.542 (min:   14.869 / max:   21.106) us     GPU-0: 4632.717 us   +/-26.358 (min: 4580.998 / max: 4694.825) us
CUB block, amax     :    CPU:   22.902 us   +/- 2.113 (min:   17.634 / max:   24.320) us     GPU-0: 5986.280 us   +/-13.708 (min: 5957.434 / max: 6003.426) us
testing amax with dtype=<class 'numpy.complex64'> and axes=(0, 1, 2)...
no acce, amax       :    CPU:   24.783 us   +/- 3.125 (min:   22.214 / max:   34.156) us     GPU-0:444526.335 us   +/-34648.556 (min:398751.038 / max:489188.477) us
CUB block, amax     :    CPU:   27.654 us   +/- 1.600 (min:   26.443 / max:   34.234) us     GPU-0: 5302.732 us   +/-17.638 (min: 5251.921 / max: 5326.203) us
testing nanargmin with dtype=<class 'numpy.complex64'> and axes=None...
no acce, nanargmin  :    CPU:   24.088 us   +/- 4.261 (min:   17.378 / max:   39.606) us     GPU-0:669297.710 us   +/-76143.730 (min:506160.553 / max:738816.895) us
CUB block, nanargmin:    CPU:   27.569 us   +/- 2.182 (min:   26.171 / max:   36.863) us     GPU-0:14257.729 us   +/-54.934 (min:14185.357 / max:14380.165) us
testing nanargmax with dtype=<class 'numpy.complex64'> and axes=None...
no acce, nanargmax  :    CPU:   18.941 us   +/- 6.830 (min:   14.283 / max:   46.260) us     GPU-0:691997.903 us   +/-31097.032 (min:598814.819 / max:730522.156) us
CUB block, nanargmax:    CPU:   27.280 us   +/- 0.720 (min:   26.503 / max:   30.205) us     GPU-0:14308.158 us   +/-65.297 (min:14152.786 / max:14451.113) us
testing nanmean with dtype=<class 'numpy.complex64'> and axes=(2,)...
no acce, nanmean    :    CPU:   15.269 us   +/- 1.600 (min:   13.908 / max:   20.571) us     GPU-0: 2668.127 us   +/-17.692 (min: 2618.194 / max: 2695.990) us
CUB block, nanmean  :    CPU:   20.332 us   +/- 3.036 (min:   17.051 / max:   24.239) us     GPU-0: 2537.642 us   +/-16.516 (min: 2486.016 / max: 2556.300) us
testing nanmean with dtype=<class 'numpy.complex64'> and axes=(1, 2)...
no acce, nanmean    :    CPU:   15.237 us   +/- 1.603 (min:   13.754 / max:   20.005) us     GPU-0: 1942.825 us   +/-32.764 (min: 1869.704 / max: 1996.847) us
CUB block, nanmean  :    CPU:   21.965 us   +/- 2.639 (min:   17.511 / max:   24.047) us     GPU-0: 3096.394 us   +/-72.991 (min: 2948.618 / max: 3217.892) us
testing nanmean with dtype=<class 'numpy.complex64'> and axes=(0, 1, 2)...
no acce, nanmean    :    CPU:   15.624 us   +/- 2.467 (min:   13.667 / max:   24.916) us     GPU-0:267283.653 us   +/-1273.270 (min:265104.889 / max:269819.336) us
CUB block, nanmean  :    CPU:   27.499 us   +/- 0.818 (min:   26.643 / max:   30.248) us     GPU-0: 2585.359 us   +/- 8.390 (min: 2570.842 / max: 2597.872) us
testing nansum with dtype=<class 'numpy.complex64'> and axes=(2,)...
no acce, nansum     :    CPU:   15.865 us   +/- 2.542 (min:   14.284 / max:   25.892) us     GPU-0: 2042.916 us   +/-18.733 (min: 1973.845 / max: 2061.617) us
CUB block, nansum   :    CPU:   34.063 us   +/-29.846 (min:   16.671 / max:  146.006) us     GPU-0: 2571.086 us   +/-49.373 (min: 2485.027 / max: 2744.308) us
testing nansum with dtype=<class 'numpy.complex64'> and axes=(1, 2)...
no acce, nansum     :    CPU:   15.839 us   +/- 2.415 (min:   13.955 / max:   22.022) us     GPU-0: 1538.892 us   +/-26.682 (min: 1479.611 / max: 1581.417) us
CUB block, nansum   :    CPU:   23.790 us   +/- 3.078 (min:   17.806 / max:   29.513) us     GPU-0: 3232.000 us   +/-49.299 (min: 3135.937 / max: 3336.755) us
testing nansum with dtype=<class 'numpy.complex64'> and axes=(0, 1, 2)...
no acce, nansum     :    CPU:   22.001 us   +/- 6.291 (min:   16.062 / max:   46.101) us     GPU-0:222058.733 us   +/-2777.832 (min:217413.773 / max:225492.050) us
CUB block, nansum   :    CPU:   41.228 us   +/-21.872 (min:   29.153 / max:  120.449) us     GPU-0: 2609.603 us   +/-47.992 (min: 2552.421 / max: 2779.969) us
testing nanprod with dtype=<class 'numpy.complex64'> and axes=(2,)...
no acce, nanprod    :    CPU:   17.867 us   +/- 3.164 (min:   15.484 / max:   28.122) us     GPU-0: 2130.118 us   +/-19.219 (min: 2073.111 / max: 2156.836) us
CUB block, nanprod  :    CPU:   27.602 us   +/-18.942 (min:   16.443 / max:   95.850) us     GPU-0: 2577.402 us   +/-42.181 (min: 2458.412 / max: 2646.956) us
testing nanprod with dtype=<class 'numpy.complex64'> and axes=(1, 2)...
no acce, nanprod    :    CPU:   15.501 us   +/- 2.293 (min:   14.130 / max:   23.678) us     GPU-0: 1564.330 us   +/-37.614 (min: 1477.644 / max: 1624.037) us
CUB block, nanprod  :    CPU:   28.077 us   +/- 8.963 (min:   24.627 / max:   66.596) us     GPU-0: 3154.834 us   +/-53.564 (min: 3067.845 / max: 3262.708) us
testing nanprod with dtype=<class 'numpy.complex64'> and axes=(0, 1, 2)...
no acce, nanprod    :    CPU:   17.768 us   +/- 4.594 (min:   14.772 / max:   33.219) us     GPU-0:227468.363 us   +/-1081.718 (min:224946.594 / max:229750.137) us
CUB block, nanprod  :    CPU:   32.441 us   +/-10.344 (min:   27.864 / max:   75.547) us     GPU-0: 2626.744 us   +/-25.042 (min: 2569.524 / max: 2715.022) us
testing all with dtype=<class 'numpy.complex64'> and axes=(2,)...
no acce, all        :    CPU:   18.359 us   +/- 5.079 (min:   15.724 / max:   37.015) us     GPU-0: 1974.487 us   +/-13.828 (min: 1927.033 / max: 2001.731) us
CUB block, all      :    CPU:   21.990 us   +/-11.071 (min:   16.467 / max:   66.976) us     GPU-0: 2612.913 us   +/-34.227 (min: 2519.316 / max: 2712.275) us
testing all with dtype=<class 'numpy.complex64'> and axes=(1, 2)...
no acce, all        :    CPU:   15.642 us   +/- 2.134 (min:   14.102 / max:   23.105) us     GPU-0: 1556.141 us   +/-26.098 (min: 1491.603 / max: 1621.506) us
CUB block, all      :    CPU:   29.715 us   +/-11.936 (min:   25.015 / max:   78.309) us     GPU-0: 3193.248 us   +/-66.394 (min: 3057.445 / max: 3293.598) us
testing all with dtype=<class 'numpy.complex64'> and axes=(0, 1, 2)...
no acce, all        :    CPU:   17.330 us   +/- 3.875 (min:   14.578 / max:   30.328) us     GPU-0:229094.849 us   +/-1546.597 (min:225477.951 / max:232111.862) us
CUB block, all      :    CPU:   37.631 us   +/-21.077 (min:   28.872 / max:  124.478) us     GPU-0: 2624.438 us   +/-37.520 (min: 2574.076 / max: 2770.970) us
testing any with dtype=<class 'numpy.complex64'> and axes=(2,)...
no acce, any        :    CPU:   18.255 us   +/- 3.160 (min:   15.940 / max:   27.849) us     GPU-0: 1975.083 us   +/-18.558 (min: 1925.220 / max: 2029.799) us
CUB block, any      :    CPU:   28.911 us   +/-11.136 (min:   24.765 / max:   77.011) us     GPU-0: 2576.050 us   +/-37.160 (min: 2477.271 / max: 2684.462) us
testing any with dtype=<class 'numpy.complex64'> and axes=(1, 2)...
no acce, any        :    CPU:   17.572 us   +/- 2.694 (min:   15.592 / max:   25.029) us     GPU-0: 1541.936 us   +/-15.615 (min: 1498.209 / max: 1576.972) us
CUB block, any      :    CPU:   26.526 us   +/- 8.686 (min:   18.822 / max:   61.696) us     GPU-0: 3206.969 us   +/-52.332 (min: 3082.611 / max: 3290.691) us
testing any with dtype=<class 'numpy.complex64'> and axes=(0, 1, 2)...
no acce, any        :    CPU:   23.146 us   +/- 6.571 (min:   16.725 / max:   45.538) us     GPU-0:228589.198 us   +/-2800.723 (min:223590.469 / max:232733.810) us
CUB block, any      :    CPU:   30.109 us   +/- 4.876 (min:   26.520 / max:   43.804) us     GPU-0: 2576.377 us   +/-14.225 (min: 2566.228 / max: 2629.418) us
testing count_nonzero with dtype=<class 'numpy.complex64'> and axes=(2,)...
no acce, count_nonzero:    CPU:   14.781 us   +/- 2.385 (min:   13.378 / max:   24.231) us     GPU-0: 2032.345 us   +/-23.566 (min: 1984.608 / max: 2071.362) us
CUB block, count_nonzero:    CPU:   21.259 us   +/-10.220 (min:   15.510 / max:   61.423) us     GPU-0: 2534.167 us   +/-30.698 (min: 2482.959 / max: 2627.954) us
testing count_nonzero with dtype=<class 'numpy.complex64'> and axes=(1, 2)...
no acce, count_nonzero:    CPU:   14.243 us   +/- 1.941 (min:   12.849 / max:   21.117) us     GPU-0: 1548.088 us   +/-21.028 (min: 1490.008 / max: 1581.828) us
CUB block, count_nonzero:    CPU:   21.763 us   +/- 9.457 (min:   16.083 / max:   59.940) us     GPU-0: 3186.278 us   +/-50.899 (min: 3121.560 / max: 3292.239) us
testing count_nonzero with dtype=<class 'numpy.complex64'> and axes=(0, 1, 2)...
no acce, count_nonzero:    CPU:   18.771 us   +/- 5.293 (min:   15.012 / max:   37.973) us     GPU-0:233765.366 us   +/-3595.456 (min:227451.797 / max:238403.259) us
CUB block, count_nonzero:    CPU:   27.950 us   +/- 2.562 (min:   25.021 / max:   38.047) us     GPU-0: 2579.533 us   +/-13.784 (min: 2552.444 / max: 2624.317) us
testing sum with dtype=<class 'numpy.complex128'> and axes=(2,)...
no acce, sum        :    CPU:   15.412 us   +/- 2.715 (min:   13.700 / max:   26.096) us     GPU-0: 2668.041 us   +/-23.319 (min: 2613.595 / max: 2729.185) us
CUB device, sum     :    CPU:   34.320 us   +/- 1.268 (min:   33.405 / max:   39.099) us     GPU-0: 2538.924 us   +/-13.827 (min: 2489.457 / max: 2556.139) us
CUB block, sum      :    CPU:   17.955 us   +/- 2.651 (min:   15.605 / max:   24.210) us     GPU-0: 2846.690 us   +/-22.213 (min: 2783.659 / max: 2883.806) us
testing sum with dtype=<class 'numpy.complex128'> and axes=(1, 2)...
no acce, sum        :    CPU:   15.150 us   +/- 1.745 (min:   13.397 / max:   21.068) us     GPU-0: 3068.007 us   +/-23.032 (min: 3014.060 / max: 3115.480) us
CUB device, sum     :    CPU:   34.426 us   +/- 1.260 (min:   32.863 / max:   38.543) us     GPU-0: 2744.924 us   +/-24.565 (min: 2652.640 / max: 2772.368) us
CUB block, sum      :    CPU:   26.440 us   +/-19.804 (min:   16.795 / max:  106.824) us     GPU-0: 3114.305 us   +/-41.389 (min: 3019.708 / max: 3260.160) us
testing sum with dtype=<class 'numpy.complex128'> and axes=(0, 1, 2)...
no acce, sum        :    CPU:   15.796 us   +/- 5.440 (min:   12.908 / max:   38.423) us     GPU-0:226288.320 us   +/-1559.942 (min:223646.255 / max:228916.336) us
CUB device, sum     :    CPU:   13.343 us   +/- 1.668 (min:   12.064 / max:   18.617) us     GPU-0: 2511.817 us   +/-21.870 (min: 2462.433 / max: 2552.413) us
CUB block, sum      :    CPU:   27.544 us   +/- 0.448 (min:   26.651 / max:   28.918) us     GPU-0: 2862.461 us   +/- 5.775 (min: 2853.061 / max: 2876.488) us
testing prod with dtype=<class 'numpy.complex128'> and axes=(2,)...
no acce, prod       :    CPU:   15.118 us   +/- 1.966 (min:   13.640 / max:   22.284) us     GPU-0: 2904.171 us   +/-39.868 (min: 2811.935 / max: 2965.789) us
CUB device, prod    :    CPU:   35.008 us   +/- 2.536 (min:   33.029 / max:   44.966) us     GPU-0: 2812.410 us   +/-34.785 (min: 2731.188 / max: 2853.618) us
CUB block, prod     :    CPU:   33.333 us   +/-30.674 (min:   15.948 / max:  147.304) us     GPU-0: 2973.391 us   +/-55.836 (min: 2889.099 / max: 3155.485) us
testing prod with dtype=<class 'numpy.complex128'> and axes=(1, 2)...
no acce, prod       :    CPU:   15.352 us   +/- 1.868 (min:   13.836 / max:   21.661) us     GPU-0: 3119.967 us   +/-38.662 (min: 3054.806 / max: 3192.605) us
CUB device, prod    :    CPU:   35.298 us   +/- 3.066 (min:   33.380 / max:   47.515) us     GPU-0: 2768.293 us   +/-12.850 (min: 2726.911 / max: 2800.606) us
CUB block, prod     :    CPU:   24.054 us   +/- 2.783 (min:   18.482 / max:   26.115) us     GPU-0: 3195.152 us   +/-16.859 (min: 3139.942 / max: 3217.538) us
testing prod with dtype=<class 'numpy.complex128'> and axes=(0, 1, 2)...
no acce, prod       :    CPU:   19.077 us   +/- 6.211 (min:   14.644 / max:   41.116) us     GPU-0:237641.563 us   +/-2061.254 (min:235140.533 / max:241965.073) us
CUB device, prod    :    CPU:   14.798 us   +/- 2.736 (min:   13.235 / max:   25.144) us     GPU-0: 2500.073 us   +/-17.678 (min: 2452.840 / max: 2540.795) us
CUB block, prod     :    CPU:   29.093 us   +/- 0.684 (min:   28.471 / max:   31.690) us     GPU-0: 2932.646 us   +/-21.851 (min: 2890.892 / max: 2962.624) us
testing min with dtype=<class 'numpy.complex128'> and axes=(2,)...
no acce, min        :    CPU:   17.638 us   +/- 3.008 (min:   15.273 / max:   27.480) us     GPU-0: 7592.535 us   +/-12.440 (min: 7553.963 / max: 7615.791) us
CUB device, min     :    CPU:   40.830 us   +/- 5.763 (min:   37.177 / max:   61.864) us     GPU-0:61387.824 us   +/-1398.549 (min:58278.820 / max:64272.095) us
CUB block, min      :    CPU:   22.772 us   +/- 8.890 (min:   16.914 / max:   58.033) us     GPU-0:15835.758 us   +/-68.422 (min:15743.766 / max:15998.127) us
testing min with dtype=<class 'numpy.complex128'> and axes=(1, 2)...
no acce, min        :    CPU:   17.569 us   +/- 3.378 (min:   15.128 / max:   27.615) us     GPU-0:29340.152 us   +/-115.045 (min:29192.808 / max:29518.541) us
CUB device, min     :    CPU:   37.090 us   +/- 3.804 (min:   34.403 / max:   50.530) us     GPU-0:31369.005 us   +/-36.247 (min:31303.446 / max:31449.530) us
CUB block, min      :    CPU:   24.750 us   +/- 2.288 (min:   22.092 / max:   33.459) us     GPU-0:50330.418 us   +/-74.571 (min:50149.761 / max:50467.430) us
testing min with dtype=<class 'numpy.complex128'> and axes=(0, 1, 2)...
no acce, min        :    CPU:   19.374 us   +/- 5.089 (min:   15.157 / max:   36.962) us     GPU-0:415793.510 us   +/-4986.756 (min:404747.803 / max:422838.226) us
CUB device, min     :    CPU:   14.499 us   +/- 2.493 (min:   13.200 / max:   24.485) us     GPU-0:13358.175 us   +/-53.633 (min:13236.376 / max:13464.117) us
CUB block, min      :    CPU:   27.736 us   +/- 1.186 (min:   26.708 / max:   32.109) us     GPU-0:10979.853 us   +/-16.775 (min:10954.471 / max:11017.317) us
testing max with dtype=<class 'numpy.complex128'> and axes=(2,)...
no acce, max        :    CPU:   16.080 us   +/- 1.835 (min:   14.946 / max:   22.840) us     GPU-0: 7676.333 us   +/-34.884 (min: 7601.273 / max: 7716.314) us
CUB device, max     :    CPU:   36.411 us   +/- 2.213 (min:   34.710 / max:   44.415) us     GPU-0:16690.122 us   +/-97.996 (min:16527.189 / max:16865.997) us
CUB block, max      :    CPU:   21.132 us   +/- 3.496 (min:   17.691 / max:   29.704) us     GPU-0: 9658.282 us   +/-13.642 (min: 9628.056 / max: 9678.068) us
testing max with dtype=<class 'numpy.complex128'> and axes=(1, 2)...
no acce, max        :    CPU:   16.449 us   +/- 2.711 (min:   14.962 / max:   24.806) us     GPU-0: 9194.987 us   +/-41.031 (min: 9110.902 / max: 9258.377) us
CUB device, max     :    CPU:   36.325 us   +/- 2.797 (min:   34.643 / max:   47.650) us     GPU-0: 8887.326 us   +/-38.106 (min: 8792.395 / max: 8961.562) us
CUB block, max      :    CPU:   24.626 us   +/- 2.944 (min:   18.616 / max:   30.903) us     GPU-0:12369.222 us   +/-40.149 (min:12286.188 / max:12421.431) us
testing max with dtype=<class 'numpy.complex128'> and axes=(0, 1, 2)...
no acce, max        :    CPU:   20.104 us   +/- 6.051 (min:   15.125 / max:   41.085) us     GPU-0:431265.764 us   +/-14561.533 (min:412321.228 / max:459688.354) us
CUB device, max     :    CPU:   14.470 us   +/- 2.240 (min:   13.289 / max:   23.485) us     GPU-0:13305.806 us   +/-60.097 (min:13179.145 / max:13393.834) us
CUB block, max      :    CPU:   27.561 us   +/- 0.855 (min:   26.905 / max:   31.016) us     GPU-0:10964.237 us   +/-16.303 (min:10921.024 / max:10988.170) us
testing argmax with dtype=<class 'numpy.complex128'> and axes=None...
no acce, argmax     :    CPU:   22.345 us   +/- 6.295 (min:   17.571 / max:   43.001) us     GPU-0:771666.452 us   +/-26483.804 (min:704104.797 / max:805764.709) us
CUB device, argmax  :    CPU:   33.292 us   +/- 2.512 (min:   31.873 / max:   42.955) us     GPU-0: 3948.813 us   +/-27.064 (min: 3902.015 / max: 3989.233) us
CUB block, argmax   :    CPU:   27.806 us   +/- 1.299 (min:   26.572 / max:   33.047) us     GPU-0:30483.302 us   +/-103.265 (min:30416.912 / max:30924.896) us
testing argmin with dtype=<class 'numpy.complex128'> and axes=None...
no acce, argmin     :    CPU:   24.872 us   +/-12.439 (min:   16.260 / max:   75.340) us     GPU-0:666502.890 us   +/-37419.777 (min:635568.665 / max:741386.780) us
CUB device, argmin  :    CPU:   33.905 us   +/- 3.017 (min:   32.090 / max:   46.055) us     GPU-0: 4019.979 us   +/-27.743 (min: 3962.197 / max: 4072.868) us
CUB block, argmin   :    CPU:   28.522 us   +/- 1.395 (min:   26.930 / max:   32.465) us     GPU-0:30486.245 us   +/-179.854 (min:30335.161 / max:30927.254) us
testing cumsum with dtype=<class 'numpy.complex128'> and axes=None...
no acce, cumsum     :    CPU:   32.830 us   +/- 2.508 (min:   30.034 / max:   42.821) us     GPU-0:19512.530 us   +/-73.994 (min:19428.476 / max:19726.524) us
CUB device, cumsum  :    CPU:   34.028 us   +/- 2.957 (min:   31.722 / max:   45.721) us     GPU-0:19491.954 us   +/-75.171 (min:19359.615 / max:19717.739) us
CUB block, cumsum   :    CPU:   32.451 us   +/- 3.514 (min:   29.976 / max:   46.611) us     GPU-0:19486.046 us   +/-73.836 (min:19377.443 / max:19602.665) us
testing cumprod with dtype=<class 'numpy.complex128'> and axes=None...
no acce, cumprod    :    CPU:   32.399 us   +/- 1.762 (min:   31.032 / max:   39.100) us     GPU-0:19576.101 us   +/-55.726 (min:19453.346 / max:19713.808) us
CUB device, cumprod :    CPU:   34.319 us   +/- 3.171 (min:   29.416 / max:   46.812) us     GPU-0:19581.983 us   +/-56.103 (min:19500.340 / max:19698.156) us
CUB block, cumprod  :    CPU:   33.321 us   +/- 2.852 (min:   30.774 / max:   43.603) us     GPU-0:19546.688 us   +/-58.310 (min:19455.788 / max:19716.076) us
testing mean with dtype=<class 'numpy.complex128'> and axes=(2,)...
no acce, mean       :    CPU:   15.405 us   +/- 2.436 (min:   13.870 / max:   24.541) us     GPU-0: 3202.871 us   +/-25.295 (min: 3165.097 / max: 3257.887) us
CUB device, mean    :    CPU:   52.076 us   +/- 3.713 (min:   49.303 / max:   65.407) us     GPU-0: 2535.337 us   +/-21.179 (min: 2475.957 / max: 2554.228) us
CUB block, mean     :    CPU:   20.565 us   +/- 2.939 (min:   17.565 / max:   26.177) us     GPU-0: 2849.593 us   +/-26.831 (min: 2779.490 / max: 2884.286) us
testing mean with dtype=<class 'numpy.complex128'> and axes=(1, 2)...
no acce, mean       :    CPU:   15.186 us   +/- 2.177 (min:   13.885 / max:   23.439) us     GPU-0: 3082.332 us   +/-36.069 (min: 3020.341 / max: 3158.367) us
CUB device, mean    :    CPU:   49.668 us   +/- 2.068 (min:   47.913 / max:   56.518) us     GPU-0: 2745.340 us   +/-21.087 (min: 2672.623 / max: 2763.975) us
CUB block, mean     :    CPU:   26.468 us   +/- 8.011 (min:   22.552 / max:   60.436) us     GPU-0: 3117.654 us   +/-28.270 (min: 3062.260 / max: 3190.825) us
testing mean with dtype=<class 'numpy.complex128'> and axes=(0, 1, 2)...
no acce, mean       :    CPU:   16.915 us   +/- 5.598 (min:   13.884 / max:   40.293) us     GPU-0:225892.741 us   +/-2697.811 (min:222344.070 / max:231239.395) us
CUB device, mean    :    CPU:   28.520 us   +/- 2.874 (min:   26.820 / max:   40.133) us     GPU-0: 2521.587 us   +/-22.400 (min: 2469.909 / max: 2579.147) us
CUB block, mean     :    CPU:   31.856 us   +/-11.336 (min:   27.048 / max:   80.391) us     GPU-0: 2882.471 us   +/-27.504 (min: 2856.954 / max: 2968.296) us
testing amin with dtype=<class 'numpy.complex128'> and axes=(2,)...
no acce, amin       :    CPU:   16.752 us   +/- 3.296 (min:   14.761 / max:   27.411) us     GPU-0:11969.920 us   +/-27.779 (min:11929.889 / max:12037.352) us
CUB block, amin     :    CPU:   20.117 us   +/- 3.459 (min:   17.219 / max:   26.017) us     GPU-0:15144.309 us   +/-32.153 (min:15087.205 / max:15201.612) us
testing amin with dtype=<class 'numpy.complex128'> and axes=(1, 2)...
no acce, amin       :    CPU:   16.358 us   +/- 2.745 (min:   14.833 / max:   26.660) us     GPU-0:16814.799 us   +/-101.855 (min:16526.625 / max:16972.509) us
CUB block, amin     :    CPU:   24.066 us   +/- 2.642 (min:   18.189 / max:   26.891) us     GPU-0:28514.398 us   +/-50.082 (min:28413.544 / max:28598.879) us
testing amin with dtype=<class 'numpy.complex128'> and axes=(0, 1, 2)...
no acce, amin       :    CPU:   20.947 us   +/- 4.963 (min:   14.882 / max:   33.636) us     GPU-0:411888.962 us   +/-8082.021 (min:402757.050 / max:423260.956) us
CUB block, amin     :    CPU:   28.862 us   +/- 1.161 (min:   26.591 / max:   30.469) us     GPU-0:16326.524 us   +/-28.956 (min:16280.785 / max:16393.484) us
testing amax with dtype=<class 'numpy.complex128'> and axes=(2,)...
no acce, amax       :    CPU:   16.210 us   +/- 1.853 (min:   15.271 / max:   23.225) us     GPU-0:11948.632 us   +/-42.061 (min:11891.016 / max:12072.068) us
CUB block, amax     :    CPU:   20.072 us   +/- 3.383 (min:   17.100 / max:   26.018) us     GPU-0:15169.597 us   +/-33.404 (min:15103.258 / max:15221.958) us
testing amax with dtype=<class 'numpy.complex128'> and axes=(1, 2)...
no acce, amax       :    CPU:   16.052 us   +/- 1.893 (min:   14.928 / max:   22.921) us     GPU-0:16927.206 us   +/-108.303 (min:16699.984 / max:17128.317) us
CUB block, amax     :    CPU:   23.967 us   +/- 2.181 (min:   18.428 / max:   26.303) us     GPU-0:28900.273 us   +/-67.118 (min:28801.493 / max:29008.396) us
testing amax with dtype=<class 'numpy.complex128'> and axes=(0, 1, 2)...
no acce, amax       :    CPU:   19.584 us   +/- 5.081 (min:   15.433 / max:   36.909) us     GPU-0:439254.919 us   +/-25065.483 (min:405516.022 / max:511218.353) us
CUB block, amax     :    CPU:   28.001 us   +/- 0.864 (min:   26.684 / max:   30.283) us     GPU-0:16164.004 us   +/-16.440 (min:16130.112 / max:16205.112) us
testing nanargmin with dtype=<class 'numpy.complex128'> and axes=None...
no acce, nanargmin  :    CPU:   22.111 us   +/- 9.788 (min:   15.614 / max:   61.405) us     GPU-0:632144.009 us   +/-7561.394 (min:619849.609 / max:645751.892) us
CUB block, nanargmin:    CPU:   29.847 us   +/- 2.463 (min:   28.164 / max:   39.999) us     GPU-0:30504.804 us   +/-40.811 (min:30404.684 / max:30575.293) us
testing nanargmax with dtype=<class 'numpy.complex128'> and axes=None...
no acce, nanargmax  :    CPU:   29.809 us   +/-17.544 (min:   18.786 / max:  105.466) us     GPU-0:634618.985 us   +/-7777.971 (min:622440.186 / max:646394.653) us
CUB block, nanargmax:    CPU:   32.035 us   +/- 7.891 (min:   27.697 / max:   61.518) us     GPU-0:30649.195 us   +/-131.174 (min:30518.641 / max:31031.551) us
testing nanmean with dtype=<class 'numpy.complex128'> and axes=(2,)...
no acce, nanmean    :    CPU:   15.492 us   +/- 2.602 (min:   13.808 / max:   25.671) us     GPU-0: 3506.782 us   +/-29.839 (min: 3457.256 / max: 3560.341) us
CUB block, nanmean  :    CPU:   20.497 us   +/- 3.805 (min:   17.033 / max:   30.800) us     GPU-0: 4864.628 us   +/-17.304 (min: 4822.919 / max: 4921.276) us
testing nanmean with dtype=<class 'numpy.complex128'> and axes=(1, 2)...
no acce, nanmean    :    CPU:   15.174 us   +/- 1.809 (min:   13.797 / max:   21.743) us     GPU-0: 3174.466 us   +/-39.523 (min: 3117.768 / max: 3302.173) us
CUB block, nanmean  :    CPU:   25.937 us   +/- 7.533 (min:   22.624 / max:   58.237) us     GPU-0: 5001.169 us   +/-29.134 (min: 4961.411 / max: 5089.445) us
testing nanmean with dtype=<class 'numpy.complex128'> and axes=(0, 1, 2)...
no acce, nanmean    :    CPU:   17.728 us   +/- 6.433 (min:   13.827 / max:   43.444) us     GPU-0:278505.794 us   +/-3078.876 (min:274386.475 / max:283477.539) us
CUB block, nanmean  :    CPU:   30.276 us   +/- 9.547 (min:   26.116 / max:   71.060) us     GPU-0: 5010.099 us   +/-38.514 (min: 4978.681 / max: 5137.839) us
testing nansum with dtype=<class 'numpy.complex128'> and axes=(2,)...
no acce, nansum     :    CPU:   15.815 us   +/- 2.495 (min:   14.164 / max:   25.153) us     GPU-0: 2743.347 us   +/-30.858 (min: 2651.882 / max: 2787.073) us
CUB block, nansum   :    CPU:   24.870 us   +/-11.034 (min:   17.652 / max:   70.611) us     GPU-0: 4984.319 us   +/-32.115 (min: 4931.073 / max: 5080.981) us
testing nansum with dtype=<class 'numpy.complex128'> and axes=(1, 2)...
no acce, nansum     :    CPU:   16.497 us   +/- 3.529 (min:   14.367 / max:   29.429) us     GPU-0: 3153.582 us   +/-52.438 (min: 3047.379 / max: 3248.215) us
CUB block, nansum   :    CPU:   22.987 us   +/- 4.401 (min:   18.081 / max:   35.250) us     GPU-0:10002.889 us   +/-106.679 (min: 9820.231 / max:10243.881) us
testing nansum with dtype=<class 'numpy.complex128'> and axes=(0, 1, 2)...
no acce, nansum     :    CPU:   19.250 us   +/- 7.260 (min:   14.176 / max:   40.546) us     GPU-0:246238.287 us   +/-2215.333 (min:243095.703 / max:251232.010) us
CUB block, nansum   :    CPU:   28.695 us   +/- 1.863 (min:   26.924 / max:   35.635) us     GPU-0: 5067.457 us   +/-25.115 (min: 5039.297 / max: 5135.992) us
testing nanprod with dtype=<class 'numpy.complex128'> and axes=(2,)...
no acce, nanprod    :    CPU:   16.214 us   +/- 3.031 (min:   14.569 / max:   28.142) us     GPU-0: 3031.721 us   +/-34.378 (min: 2929.173 / max: 3081.485) us
CUB block, nanprod  :    CPU:   21.566 us   +/- 3.352 (min:   17.829 / max:   28.900) us     GPU-0: 4993.114 us   +/-20.081 (min: 4938.281 / max: 5024.659) us
testing nanprod with dtype=<class 'numpy.complex128'> and axes=(1, 2)...
no acce, nanprod    :    CPU:   15.681 us   +/- 1.844 (min:   14.224 / max:   22.088) us     GPU-0: 3159.532 us   +/-30.979 (min: 3047.013 / max: 3200.443) us
CUB block, nanprod  :    CPU:   27.634 us   +/- 7.582 (min:   24.632 / max:   59.829) us     GPU-0: 9932.666 us   +/-143.027 (min: 9779.570 / max:10332.904) us
testing nanprod with dtype=<class 'numpy.complex128'> and axes=(0, 1, 2)...
no acce, nanprod    :    CPU:   24.063 us   +/- 8.833 (min:   16.623 / max:   56.472) us     GPU-0:257713.545 us   +/-1516.232 (min:255594.727 / max:260413.208) us
CUB block, nanprod  :    CPU:   30.838 us   +/- 8.390 (min:   26.679 / max:   66.176) us     GPU-0: 5099.509 us   +/-25.402 (min: 5066.775 / max: 5185.073) us
testing all with dtype=<class 'numpy.complex128'> and axes=(2,)...
no acce, all        :    CPU:   16.355 us   +/- 3.270 (min:   14.494 / max:   29.471) us     GPU-0: 2468.828 us   +/-17.315 (min: 2421.672 / max: 2492.175) us
CUB block, all      :    CPU:   21.415 us   +/- 3.258 (min:   17.446 / max:   27.960) us     GPU-0: 4917.895 us   +/-22.058 (min: 4871.985 / max: 4957.720) us
testing all with dtype=<class 'numpy.complex128'> and axes=(1, 2)...
no acce, all        :    CPU:   15.690 us   +/- 2.093 (min:   14.427 / max:   23.409) us     GPU-0: 2814.272 us   +/-18.749 (min: 2760.554 / max: 2846.634) us
CUB block, all      :    CPU:   27.218 us   +/- 7.291 (min:   22.625 / max:   58.274) us     GPU-0: 9361.758 us   +/-47.754 (min: 9271.422 / max: 9448.683) us
testing all with dtype=<class 'numpy.complex128'> and axes=(0, 1, 2)...
no acce, all        :    CPU:   19.869 us   +/- 5.835 (min:   14.958 / max:   40.229) us     GPU-0:233063.747 us   +/-1832.739 (min:229525.024 / max:235765.671) us
CUB block, all      :    CPU:   30.268 us   +/- 3.646 (min:   28.722 / max:   45.835) us     GPU-0: 4226.271 us   +/-356.470 (min: 3504.372 / max: 4551.433) us
testing any with dtype=<class 'numpy.complex128'> and axes=(2,)...
no acce, any        :    CPU:   18.412 us   +/- 3.602 (min:   15.864 / max:   31.304) us     GPU-0: 2459.362 us   +/-13.715 (min: 2418.655 / max: 2493.713) us
CUB block, any      :    CPU:   27.475 us   +/-21.331 (min:   17.728 / max:  110.191) us     GPU-0: 4968.779 us   +/-28.596 (min: 4946.318 / max: 5081.708) us
testing any with dtype=<class 'numpy.complex128'> and axes=(1, 2)...
no acce, any        :    CPU:   15.606 us   +/- 1.833 (min:   13.985 / max:   21.039) us     GPU-0: 2817.322 us   +/-22.841 (min: 2731.437 / max: 2851.349) us
CUB block, any      :    CPU:   25.602 us   +/- 1.408 (min:   23.843 / max:   31.155) us     GPU-0: 9382.031 us   +/-38.987 (min: 9318.216 / max: 9474.186) us
testing any with dtype=<class 'numpy.complex128'> and axes=(0, 1, 2)...
no acce, any        :    CPU:   25.015 us   +/- 8.141 (min:   17.570 / max:   57.388) us     GPU-0:234313.779 us   +/-820.290 (min:232634.109 / max:235573.700) us
CUB block, any      :    CPU:   30.207 us   +/- 2.284 (min:   28.701 / max:   39.397) us     GPU-0: 4331.955 us   +/-257.483 (min: 3609.321 / max: 4551.303) us
testing count_nonzero with dtype=<class 'numpy.complex128'> and axes=(2,)...
no acce, count_nonzero:    CPU:   16.651 us   +/- 2.868 (min:   14.741 / max:   27.859) us     GPU-0: 2489.806 us   +/-17.849 (min: 2441.878 / max: 2521.907) us
CUB block, count_nonzero:    CPU:   21.191 us   +/- 4.080 (min:   17.535 / max:   29.819) us     GPU-0: 4908.290 us   +/-23.529 (min: 4857.382 / max: 4948.393) us
testing count_nonzero with dtype=<class 'numpy.complex128'> and axes=(1, 2)...
no acce, count_nonzero:    CPU:   16.094 us   +/- 2.161 (min:   14.565 / max:   23.752) us     GPU-0: 2803.932 us   +/-16.953 (min: 2749.128 / max: 2829.644) us
CUB block, count_nonzero:    CPU:   27.034 us   +/- 7.782 (min:   18.661 / max:   59.840) us     GPU-0: 9357.588 us   +/-28.062 (min: 9311.671 / max: 9462.257) us
testing count_nonzero with dtype=<class 'numpy.complex128'> and axes=(0, 1, 2)...
no acce, count_nonzero:    CPU:   17.163 us   +/- 6.887 (min:   13.623 / max:   45.970) us     GPU-0:239522.430 us   +/-2240.105 (min:234362.411 / max:242644.241) us
CUB block, count_nonzero:    CPU:   28.768 us   +/- 1.129 (min:   26.091 / max:   31.511) us     GPU-0: 4416.846 us   +/-43.495 (min: 4332.094 / max: 4496.243) us
```

</p>
</details>