### PR TITLE
Require SciPy 1.2 for sparse comparison

### DIFF
--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -1793,7 +1793,7 @@ class TestCsrMatrixMaximumMinimum(unittest.TestCase):
     'shape': [(6, 15), (15, 6)],
     'opt': ['_eq_', '_ne_', '_lt_', '_gt_', '_le_', '_ge_'],
 }))
-@testing.with_requires('scipy')
+@testing.with_requires('scipy>=1.2')
 @testing.gpu
 class TestCsrMatrixComparison(unittest.TestCase):
     nz_rate = 0.3


### PR DESCRIPTION
Results of `<=` and `>=` had wrong dtype (scipy/scipy#8833)