### PR TITLE
Update README and docs for unified tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 <div align="center"><img src="https://raw.githubusercontent.com/cupy/cupy/master/docs/image/cupy_logo_1000px.png" width="400"/></div>
 
-# CuPy : NumPy-like API accelerated with CUDA
+# CuPy : A NumPy-compatible array library accelerated by CUDA
 
 [![pypi](https://img.shields.io/pypi/v/cupy.svg)](https://pypi.python.org/pypi/cupy)
 [![GitHub license](https://img.shields.io/github/license/cupy/cupy.svg)](https://github.com/cupy/cupy)
 [![travis](https://img.shields.io/travis/cupy/cupy.svg)](https://travis-ci.org/cupy/cupy)
 [![coveralls](https://img.shields.io/coveralls/cupy/cupy.svg)](https://coveralls.io/github/cupy/cupy)
-[![Read the Docs](https://readthedocs.org/projects/cupy/badge/?version=stable)](https://docs.cupy.dev/en/stable/)
+[![Gitter](https://badges.gitter.im/cupy/community.svg)](https://gitter.im/cupy/community)
 [![Twitter](https://img.shields.io/twitter/follow/CuPy_Team?label=%40CuPy_Team)](https://twitter.com/CuPy_Team)
 
 [**Website**](https://cupy.dev/)
@@ -14,62 +14,41 @@
 | [**Install Guide**](https://docs.cupy.dev/en/stable/install.html)
 | [**Tutorial**](https://docs.cupy.dev/en/stable/tutorial/)
 | [**Examples**](https://github.com/cupy/cupy/tree/master/examples)
+| [**API Reference**](https://docs.cupy.dev/en/stable/reference/)
 | **Forum** ([en](https://groups.google.com/forum/#!forum/cupy), [ja](https://groups.google.com/forum/#!forum/cupy-ja))
 
 *CuPy* is an implementation of NumPy-compatible multi-dimensional array on CUDA.
-CuPy consists of the core multi-dimensional array class, `cupy.ndarray`, and many functions on it.
-It supports a subset of `numpy.ndarray` interface.
+CuPy consists of the core multi-dimensional array class, `cupy.ndarray`, and [many functions](https://docs.cupy.dev/en/stable/reference/comparison.html) on it.
 
 ## Installation
 
-For detailed instructions on installing CuPy, see [the installation guide](https://docs.cupy.dev/en/stable/install.html).
+Wheels (precompiled binary packages) are available for Linux (Python 3.5+) and Windows (Python 3.6+).
+Choose the right package for your CUDA Toolkit version.
 
-You can install CuPy using `pip`:
+| CUDA  | Command                        |
+| ----- | ------------------------------ |
+| v9.0  | `pip install cupy-cuda90`      |
+| v9.2  | `pip install cupy-cuda92`      |
+| v10.0 | `pip install cupy-cuda100`     |
+| v10.1 | `pip install cupy-cuda101`     |
+| v10.2 | `pip install cupy-cuda102`     |
+| v11.0 | `pip install cupy-cuda110`     |
 
-```sh
-(Binary Package for CUDA 9.0)
-$ pip install cupy-cuda90
+See the [Installation Guide](https://docs.cupy.dev/en/stable/install.html) if you are using Conda/Anaconda or to build from source.
 
-(Binary Package for CUDA 9.2)
-$ pip install cupy-cuda92
+## Run on Docker
 
-(Binary Package for CUDA 10.0)
-$ pip install cupy-cuda100
-
-(Binary Package for CUDA 10.1)
-$ pip install cupy-cuda101
-
-(Binary Package for CUDA 10.2)
-$ pip install cupy-cuda102
-
-(Binary Package for CUDA 11.0)
-$ pip install cupy-cuda110
-
-(Source Package)
-$ pip install cupy
-```
-
-The latest version of cuDNN and NCCL libraries are included in binary packages (wheels).
-For the source package, you will need to install cuDNN/NCCL before installing CuPy, if you want to use it.
-
-## Run with Docker
-
-We provide the official Docker image.
-Use [nvidia-docker](https://github.com/NVIDIA/nvidia-docker) command to run CuPy image with GPU.
-You can login to the environment with bash, and run the Python interpreter.
+Use [NVIDIA Container Toolkit](https://github.com/NVIDIA/nvidia-docker) to run CuPy image with GPU.
 
 ```
-$ nvidia-docker run -it cupy/cupy /bin/bash
+$ docker run --gpus all -it cupy/cupy
 ```
-
-## Development
-
-Please see [the contribution guide](https://docs.cupy.dev/en/stable/contribution.html).
 
 ## More information
 
-- [Release notes](https://github.com/cupy/cupy/releases)
+- [Release Notes](https://github.com/cupy/cupy/releases)
 - [Projects using CuPy](https://github.com/cupy/cupy/wiki/Projects-using-CuPy)
+- [Contribution Guide](https://docs.cupy.dev/en/stable/contribution.html)
 
 ## License
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,8 +1,6 @@
-============================================
-CuPy -- NumPy-like API accelerated with CUDA
-============================================
-
-This is the `CuPy <https://github.com/cupy/cupy>`_ documentation.
+============================================================
+CuPy -- A NumPy-compatible array library accelerated by CUDA
+============================================================
 
 .. module:: cupy
 

--- a/setup.py
+++ b/setup.py
@@ -154,7 +154,7 @@ Operating System :: Microsoft :: Windows
 setup(
     name=package_name,
     version=__version__,  # NOQA
-    description='CuPy: NumPy-like API accelerated with CUDA',
+    description='CuPy: A NumPy-compatible array library accelerated by CUDA',
     long_description=long_description,
     author='Seiya Tokui',
     author_email='tokui@preferred.jp',


### PR DESCRIPTION
* Use the unified tagline "A NumPy-compatible array library accelerated by CUDA" everywhere
* Add link to Gitter chat room
* Cleanup README