### PR TITLE
Add missing sparse matrix constructors

### DIFF
--- a/cupyx/scipy/sparse/compressed.py
+++ b/cupyx/scipy/sparse/compressed.py
@@ -360,8 +360,8 @@ class _compressed_sparse_matrix(sparse_data._data_matrix,
 
         elif isinstance(arg1, tuple) and len(arg1) == 2:
             # Note: This implementation is not efficeint, as it first
-            # constructs a sparse matrix matrix with coo format, then converts
-            # it to compressed format.
+            # constructs a sparse matrix with coo format, then converts it to
+            # compressed format.
             sp_coo = coo.coo_matrix(arg1, shape=shape, dtype=dtype, copy=copy)
             sp_compressed = getattr(sp_coo, 'to' + self.format)()
             data = sp_compressed.data

--- a/cupyx/scipy/sparse/compressed.py
+++ b/cupyx/scipy/sparse/compressed.py
@@ -363,7 +363,7 @@ class _compressed_sparse_matrix(sparse_data._data_matrix,
             # constructs a sparse matrix with coo format, then converts it to
             # compressed format.
             sp_coo = coo.coo_matrix(arg1, shape=shape, dtype=dtype, copy=copy)
-            sp_compressed = getattr(sp_coo, 'to' + self.format)()
+            sp_compressed = sp_coo.asformat(self.format)
             data = sp_compressed.data
             indices = sp_compressed.indices
             indptr = sp_compressed.indptr

--- a/cupyx/scipy/sparse/compressed.py
+++ b/cupyx/scipy/sparse/compressed.py
@@ -15,6 +15,7 @@ from cupy import core
 from cupy._creation import basic
 from cupy import cusparse
 from cupyx.scipy.sparse import base
+from cupyx.scipy.sparse import coo
 from cupyx.scipy.sparse import data as sparse_data
 from cupyx.scipy.sparse import sputils
 from cupyx.scipy.sparse import _util
@@ -356,6 +357,16 @@ class _compressed_sparse_matrix(sparse_data._data_matrix,
 
             if shape is None:
                 shape = arg1.shape
+
+        elif isinstance(arg1, tuple) and len(arg1) == 2:
+            # Note: This implementation is not efficeint, as it first
+            # constructs a sparse matrix matrix with coo format, then converts
+            # it to compressed format.
+            sp_coo = coo.coo_matrix(arg1, shape=shape, dtype=dtype, copy=copy)
+            sp_compressed = getattr(sp_coo, 'to' + self.format)()
+            data = sp_compressed.data
+            indices = sp_compressed.indices
+            indptr = sp_compressed.indptr
 
         elif isinstance(arg1, tuple) and len(arg1) == 3:
             data, indices, indptr = arg1

--- a/cupyx/scipy/sparse/coo.py
+++ b/cupyx/scipy/sparse/coo.py
@@ -19,7 +19,10 @@ class coo_matrix(sparse_data._data_matrix):
 
     """COOrdinate format sparse matrix.
 
-    Now it has only one initializer format below:
+    This can be instantiated in several ways.
+
+    ``coo_matrix(D)``
+        ``D`` is a rank-2 :class:`cupy.ndarray`.
 
     ``coo_matrix(S)``
         ``S`` is another sparse matrix. It is equivalent to ``S.tocoo()``.
@@ -117,6 +120,8 @@ class coo_matrix(sparse_data._data_matrix):
             self.has_canonical_format = False
 
         elif base.isdense(arg1):
+            if arg1.ndim > 2:
+                raise TypeError('expected dimension <= 2 array or matrix')
             dense = cupy.atleast_2d(arg1)
             row, col = dense.nonzero()
             data = dense[row, col]

--- a/cupyx/scipy/sparse/coo.py
+++ b/cupyx/scipy/sparse/coo.py
@@ -116,8 +116,17 @@ class coo_matrix(sparse_data._data_matrix):
 
             self.has_canonical_format = False
 
+        elif base.isdense(arg1):
+            # Note: This implementation is not efficeint, as it first
+            # constructs a sparse matrix with csr fromat, then converts it to
+            # coo format.
+            sp_csr = csr.csr_matrix(arg1, shape=shape, dtype=dtype, copy=copy)
+            sp_coo = sp_csr.tocoo()
+            data = sp_coo.data
+            row = sp_coo.row
+            col = sp_coo.col
+
         else:
-            # TODO(leofang): support constructing from a dense matrix
             raise TypeError('invalid input format')
 
         if dtype is None:

--- a/cupyx/scipy/sparse/coo.py
+++ b/cupyx/scipy/sparse/coo.py
@@ -117,14 +117,9 @@ class coo_matrix(sparse_data._data_matrix):
             self.has_canonical_format = False
 
         elif base.isdense(arg1):
-            # Note: This implementation is not efficeint, as it first
-            # constructs a sparse matrix with csr fromat, then converts it to
-            # coo format.
-            sp_csr = csr.csr_matrix(arg1, shape=shape, dtype=dtype, copy=copy)
-            sp_coo = sp_csr.tocoo()
-            data = sp_coo.data
-            row = sp_coo.row
-            col = sp_coo.col
+            dense = cupy.atleast_2d(arg1)
+            row, col = dense.nonzero()
+            data = dense[row, col]
 
         else:
             raise TypeError('invalid input format')

--- a/cupyx/scipy/sparse/csc.py
+++ b/cupyx/scipy/sparse/csc.py
@@ -15,7 +15,7 @@ class csc_matrix(compressed._compressed_sparse_matrix):
 
     """Compressed Sparse Column matrix.
 
-    Now it has only part of initializer formats:
+    This can be instantiated in several ways.
 
     ``csc_matrix(D)``
         ``D`` is a rank-2 :class:`cupy.ndarray`.
@@ -24,6 +24,9 @@ class csc_matrix(compressed._compressed_sparse_matrix):
     ``csc_matrix((M, N), [dtype])``
         It constructs an empty matrix whose shape is ``(M, N)``. Default dtype
         is float64.
+    ``csc_matrix((data, (row, col))``
+        All ``data``, ``row`` and ``col`` are one-dimenaional
+        :class:`cupy.ndarray`.
     ``csc_matrix((data, indices, indptr))``
         All ``data``, ``indices`` and ``indptr`` are one-dimenaional
         :class:`cupy.ndarray`.

--- a/cupyx/scipy/sparse/csr.py
+++ b/cupyx/scipy/sparse/csr.py
@@ -21,7 +21,7 @@ class csr_matrix(compressed._compressed_sparse_matrix):
 
     """Compressed Sparse Row matrix.
 
-    Now it has only part of initializer formats:
+    This can be instantiated in several ways.
 
     ``csr_matrix(D)``
         ``D`` is a rank-2 :class:`cupy.ndarray`.
@@ -30,6 +30,9 @@ class csr_matrix(compressed._compressed_sparse_matrix):
     ``csr_matrix((M, N), [dtype])``
         It constructs an empty matrix whose shape is ``(M, N)``. Default dtype
         is float64.
+    ``csr_matrix((data, (row, col))``
+        All ``data``, ``row`` and ``col`` are one-dimenaional
+        :class:`cupy.ndarray`.
     ``csr_matrix((data, indices, indptr))``
         All ``data``, ``indices`` and ``indptr`` are one-dimenaional
         :class:`cupy.ndarray`.

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_coo.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_coo.py
@@ -267,6 +267,17 @@ class TestCooMatrixInit(unittest.TestCase):
         self.assertIsNot(row, x.row)
         self.assertIsNot(col, x.col)
 
+    def test_init_dense(self):
+        m = cupy.array([[0, 1, 0, 2],
+                        [0, 0, 0, 0],
+                        [0, 0, 3, 0]], dtype=self.dtype)
+        n = sparse.coo_matrix(m)
+        self.assertEqual(n.nnz, 3)
+        self.assertEqual(n.shape, (3, 4))
+        cupy.testing.assert_array_equal(n.data, [1, 2, 3])
+        cupy.testing.assert_array_equal(n.row, [0, 0, 2])
+        cupy.testing.assert_array_equal(n.col, [1, 3, 2])
+
     def test_invalid_format(self):
         for xp, sp in ((numpy, scipy.sparse), (cupy, sparse)):
             with pytest.raises(TypeError):

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
@@ -190,6 +190,14 @@ class TestCscMatrix(unittest.TestCase):
         cupy.testing.assert_array_equal(n.indices, [0])
         cupy.testing.assert_array_equal(n.indptr, [0, 1])
 
+    def test_init_data_row_col(self):
+        o = self.m.tocoo()
+        n = sparse.csc_matrix((o.data, (o.row, o.col)))
+        cupy.testing.assert_array_equal(n.data, self.m.data)
+        cupy.testing.assert_array_equal(n.indices, self.m.indices)
+        cupy.testing.assert_array_equal(n.indptr, self.m.indptr)
+        self.assertEqual(n.shape, self.m.shape)
+
     @testing.with_requires('scipy')
     def test_init_dense_invalid_ndim(self):
         for xp, sp in ((numpy, scipy.sparse), (cupy, sparse)):

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -232,6 +232,14 @@ class TestCsrMatrix(unittest.TestCase):
         cupy.testing.assert_array_equal(n.indices, [0])
         cupy.testing.assert_array_equal(n.indptr, [0, 1])
 
+    def test_init_data_row_col(self):
+        o = self.m.tocoo()
+        n = sparse.csr_matrix((o.data, (o.row, o.col)))
+        cupy.testing.assert_array_equal(n.data, self.m.data)
+        cupy.testing.assert_array_equal(n.indices, self.m.indices)
+        cupy.testing.assert_array_equal(n.indptr, self.m.indptr)
+        self.assertEqual(n.shape, self.m.shape)
+
     @testing.with_requires('scipy')
     def test_init_dense_invalid_ndim(self):
         for xp, sp in ((numpy, scipy.sparse), (cupy, sparse)):


### PR DESCRIPTION
Closes https://github.com/cupy/cupy/issues/3289

This PR adds some missing sparse matrix constructors below to improve compatibility to SciPy.
- csr/csc matrix construction from a tuple of data, row and col vectors
- coo matrix construction from dense matrix