### PR TITLE
Support pickling `cupy.RawKernel`

### DIFF
--- a/cupy/core/raw.pxd
+++ b/cupy/core/raw.pxd
@@ -12,7 +12,7 @@ cdef class RawKernel:
         bint translate_cucomplex
         list _kernel_cache
         readonly str __name__
-        readonly int raw_ver
+        int raw_ver
 
 
 cdef class RawModule:

--- a/cupy/core/raw.pxd
+++ b/cupy/core/raw.pxd
@@ -12,6 +12,7 @@ cdef class RawKernel:
         bint translate_cucomplex
         list _kernel_cache
         readonly str __name__
+        readonly int raw_ver
 
 
 cdef class RawModule:

--- a/cupy/core/raw.pyx
+++ b/cupy/core/raw.pyx
@@ -114,14 +114,15 @@ cdef class RawKernel:
     # functions, which is in fact preferred over __reduce__.
 
     def __getstate__(self):
-        cdef dict args = {'code': self.code,
-                          'name': self.name,
-                          'options': self.options,
-                          'backend': self.backend,
-                          'translate_cucomplex': self.translate_cucomplex,
-                          'file_path': self.file_path,
-                          'name_expressions': self.name_expressions}
-        args['enable_cooperative_groups'] = self.enable_cooperative_groups
+        cdef dict args
+        args = {'code': self.code,
+                'name': self.name,
+                'options': self.options,
+                'backend': self.backend,
+                'translate_cucomplex': self.translate_cucomplex,
+                'file_path': self.file_path,
+                'name_expressions': self.name_expressions,
+                'enable_cooperative_groups': self.enable_cooperative_groups}
         return args
 
     def __setstate__(self, dict args):

--- a/tests/cupy_tests/core_tests/test_raw.py
+++ b/tests/cupy_tests/core_tests/test_raw.py
@@ -1107,6 +1107,8 @@ assert ker.enable_cooperative_groups
     'compile': (False, True),
     'raw': ('ker', 'mod'),
 }))
+@unittest.skipIf(cupy.cuda.runtime.is_hip,
+                 'HIP does not support enable_cooperative_groups')
 class TestRawPicklable(unittest.TestCase):
 
     def setUp(self):

--- a/tests/cupy_tests/core_tests/test_raw.py
+++ b/tests/cupy_tests/core_tests/test_raw.py
@@ -1,6 +1,9 @@
 import contextlib
 import io
 import os
+import pickle
+import string
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -1078,3 +1081,156 @@ class TestRawGridSync(unittest.TestCase):
             grid = (n * n + block - 1) // block
             kern((grid,), (block,), (x1, x2, y, n ** 2))
             assert cupy.allclose(y, x1 + x2)
+
+
+_test_ker = r'''
+import pickle
+import cupy as cp
+
+N = 100
+a = cp.random.random(N, dtype=cp.float32)
+b = cp.random.random(N, dtype=cp.float32)
+c = cp.empty_like(a)
+with open('${temp_dir}' + '/TestRawPicklable_ker', 'rb') as f:
+    ker = pickle.load(f)
+ker((1,), (100,), (a, b, c, N))
+assert ker.enable_cooperative_groups
+'''
+
+_test_mod = r'''
+import pickle
+import cupy as cp
+
+N = 100
+a = cp.random.random(N, dtype=cp.float32)
+b = cp.random.random(N, dtype=cp.float32)
+c = cp.empty_like(a)
+with open('${temp_dir}' + '/TestRawPicklable_mod', 'rb') as f:
+    mod = pickle.load(f)
+ker = mod.get_function('test_multiply')
+ker((1,), (100,), (a, b, c, N))
+assert ker.enable_cooperative_groups
+'''
+
+
+class TestRawPicklable(unittest.TestCase):
+
+    def setUp(self):
+        self.temporary_dir_context = use_temporary_cache_dir()
+        self.temp_dir = self.temporary_dir_context.__enter__()
+
+    def tearDown(self):
+        self.temporary_dir_context.__exit__(*sys.exc_info())
+
+    def test_raw_kernel_picklable1(self):
+        '''
+        Test pickling a RawKernel before it's called/compiled. This should
+        always success.
+        '''
+
+        # pickle a RawKernel (and test if kw-only arguments are
+        # properly handled)
+        ker = cupy.RawKernel(_test_source1, 'test_sum',
+                             backend='nvcc',
+                             enable_cooperative_groups=True)
+        with open(self.temp_dir + '/TestRawPicklable_ker', 'wb') as f:
+            pickle.dump(ker, f)
+
+        # dump test script to temp dir
+        test_ker = string.Template(_test_ker).substitute(
+            temp_dir=self.temp_dir)
+        with open(self.temp_dir + '/TestRawPicklable_ker.py', 'w') as f:
+            f.write(test_ker)
+
+        # run another process to check the pickle
+        s = subprocess.run([sys.executable,
+                            self.temp_dir + '/TestRawPicklable_ker.py'])
+        s.check_returncode()  # raise if unsuccess
+
+    def test_raw_kernel_picklable2(self):
+        '''
+        Test pickling a RawKernel after it's called/compiled. This would fail
+        if RawKernel does not support a proper __reduce__ that clears out the
+        cache before pickling.
+        '''
+
+        # run the kernel once
+        ker = cupy.RawKernel(_test_source1, 'test_sum',
+                             backend='nvcc',
+                             enable_cooperative_groups=True)
+        a = cupy.random.random(64, dtype=cupy.float32)
+        b = cupy.random.random(64, dtype=cupy.float32)
+        c = cupy.empty_like(a)
+        ker((1,), (64,), (a, b, c, 64))
+        assert cupy.allclose(c, a + b)
+
+        # pickle the RawKernel
+        with open(self.temp_dir + '/TestRawPicklable_ker', 'wb') as f:
+            pickle.dump(ker, f)
+
+        # dump test script to temp dir
+        test_ker = string.Template(_test_ker).substitute(
+            temp_dir=self.temp_dir)
+        with open(self.temp_dir + '/TestRawPicklable_ker.py', 'w') as f:
+            f.write(test_ker)
+
+        # run another process to check the pickle
+        s = subprocess.run([sys.executable,
+                            self.temp_dir + '/TestRawPicklable_ker.py'])
+        s.check_returncode()  # raise if unsuccess
+
+    def test_raw_module_picklable1(self):
+        '''
+        Test pickling a RawModule before it's compiled. This should
+        always success.
+        '''
+
+        # pickle a RawModule
+        mod = cupy.RawModule(code=_test_source2,
+                             backend='nvcc',
+                             enable_cooperative_groups=True)
+        with open(self.temp_dir + '/TestRawPicklable_mod', 'wb') as f:
+            pickle.dump(mod, f)
+
+        # dump test script to temp dir
+        test_mod = string.Template(_test_mod).substitute(
+            temp_dir=self.temp_dir)
+        with open(self.temp_dir + '/TestRawPicklable_mod.py', 'w') as f:
+            f.write(test_mod)
+
+        # run another process to check the pickle
+        s = subprocess.run([sys.executable,
+                            self.temp_dir + '/TestRawPicklable_mod.py'])
+        s.check_returncode()  # raise if unsuccess
+
+    def test_raw_module_picklable2(self):
+        '''
+        Test pickling a RawModule after it's compiled. This should
+        always success.
+        '''
+
+        # compile and run the kernel once
+        mod = cupy.RawModule(code=_test_source2,
+                             backend='nvcc',
+                             enable_cooperative_groups=True)
+        ker = mod.get_function('test_multiply')
+        a = cupy.random.random(64, dtype=cupy.float32)
+        b = cupy.random.random(64, dtype=cupy.float32)
+        c = cupy.empty_like(a)
+        ker((1,), (64,), (a, b, c, 64))
+        assert cupy.allclose(c, a * b)
+
+        # pickle the RawModule
+        with open(self.temp_dir + '/TestRawPicklable_mod', 'wb') as f:
+            pickle.dump(mod, f)
+
+        # dump test script to temp dir
+        test_mod = string.Template(_test_mod).substitute(
+            temp_dir=self.temp_dir)
+        with open(self.temp_dir + '/TestRawPicklable_mod.py', 'w') as f:
+            f.write(test_mod)
+
+        # run another process to check the pickle
+        s = subprocess.run([sys.executable,
+                            self.temp_dir + '/TestRawPicklable_mod.py'])
+        s.check_returncode()  # raise if unsuccess


### PR DESCRIPTION
Fix #4044. We need to ensure a `RawKernel` is recompiled after unpickling. `RawModule` does not have this problem, because when calling `get_function` the recompiling will be triggered if the compiled module is not found in CuPy's internal cache (`_util.memoize()`).

@jglaser @pentschev @jakirkham Is it possible for any of you to test this PR? I think this is the root cause for the failure, but just wanna be 100% sure. 🙂