### PR TITLE
improve performance of binary morphology for fully nonzero structuring elements

### DIFF
--- a/cupyx/scipy/ndimage/morphology.py
+++ b/cupyx/scipy/ndimage/morphology.py
@@ -12,7 +12,8 @@ from cupyx.scipy.ndimage import filters
 
 @cupy.memoize(for_each_device=True)
 def _get_binary_erosion_kernel(
-    w_shape, int_type, offsets, center_is_true, border_value, invert, masked
+    w_shape, int_type, offsets, center_is_true, border_value, invert, masked,
+    all_weights_nonzero
 ):
     if invert:
         border_value = int(not border_value)
@@ -71,12 +72,13 @@ def _get_binary_erosion_kernel(
         found,
         '',
         'constant', w_shape, int_type, offsets, 0, ctype='Y', has_weights=True,
-        has_structure=False, has_mask=masked, binary_morphology=True)
+        has_structure=False, has_mask=masked, binary_morphology=True,
+        all_weights_nonzero=all_weights_nonzero)
 
 
 def _center_is_true(structure, origin):
     coor = tuple([oo + ss // 2 for ss, oo in zip(structure.shape, origin)])
-    return bool(structure[coor])  # devie synchronization
+    return bool(structure[coor])  # device synchronization
 
 
 def iterate_structure(structure, iterations, origin=None):
@@ -161,8 +163,14 @@ def _binary_erosion(input, structure, iterations, mask, output, border_value,
         raise TypeError('Complex type not supported')
     if structure is None:
         structure = generate_binary_structure(input.ndim, 1)
+        all_weights_nonzero = input.ndim == 1
+        center_is_true = True
+        default_structure = True
     else:
         structure = structure.astype(dtype=bool, copy=False)
+        # transfer to CPU for use in determining if it is fully dense
+        # structure_cpu = cupy.asnumpy(structure)
+        default_structure = False
     if structure.ndim != input.ndim:
         raise RuntimeError('structure and input must have same dimensionality')
     if not structure.flags.c_contiguous:
@@ -181,7 +189,7 @@ def _binary_erosion(input, structure, iterations, mask, output, border_value,
     else:
         masked = False
     origin = _util._fix_sequence_arg(origin, input.ndim, 'origin', int)
-    center_is_true = _center_is_true(structure, origin)  # synchronization
+
     if isinstance(output, cupy.ndarray) and output.dtype.kind == 'c':
         raise TypeError('Complex output type not supported')
     else:
@@ -202,9 +210,18 @@ def _binary_erosion(input, structure, iterations, mask, output, border_value,
     origin = tuple(origin)
     int_type = _util._get_inttype(input)
     offsets = _filters_core._origins_to_offsets(origin, structure.shape)
+    if not default_structure:
+        # synchronize required to determine if all weights are non-zero
+        nnz = int(cupy.count_nonzero(structure))
+        all_weights_nonzero = nnz == structure.size
+        if all_weights_nonzero:
+            center_is_true = True
+        else:
+            center_is_true = _center_is_true(structure, origin)
+
     erode_kernel = _get_binary_erosion_kernel(
         structure.shape, int_type, offsets, center_is_true, border_value,
-        invert, masked,
+        invert, masked, all_weights_nonzero,
     )
 
     if iterations == 1:


### PR DESCRIPTION
This PR adds a parameter that skips the check for non-zero elements when possible in the binary erosion kernel. Surprisingly, this leads to a fairly large increase in performance (It does result in an ~50 microsecond increase in CPU time, but GPU time is reduced by a factor of 2-3 for large images).

A similar change could be made for the convolution filters and rank filters as well, but I did not measure any change in performance when I tried it for those, so I have left it out of this PR.


## Benchmark Script
```Python
import cupy
import cupyx.scipy.ndimage as ndi
from cupyx.time import repeat

for shape in [(256, 256), (4096, 4096)]:
    density = 0.7
    connectivity = 2
    xp = cupy

    rstate = cupy.random.RandomState(5)
    x = rstate.randn(*shape) > density
    structure = ndi.generate_binary_structure(x.ndim, connectivity)

    print(f"**shape {shape}**")
    for func in (ndi.binary_erosion, ndi.binary_dilation):
        perf = repeat(func, (x, structure), n_warmup=100, n_repeat=100)
        print(perf)
```

## Benchmark Result

### master
```
**shape (256, 256)**
binary_erosion      :    CPU:   45.320 us   +/- 3.375 (min:   42.463 / max:   61.476) us     GPU-0:   51.205 us   +/- 3.371 (min:   48.096 / max:   67.520) us
binary_dilation     :    CPU:   68.328 us   +/- 3.717 (min:   64.392 / max:   84.751) us     GPU-0:   84.201 us   +/- 4.077 (min:   79.840 / max:  101.344) us
**shape (4096, 4096)**
binary_erosion      :    CPU:   46.791 us   +/- 4.223 (min:   43.281 / max:   64.498) us     GPU-0: 1075.381 us   +/-46.183 (min: 1006.592 / max: 1124.352) us
binary_dilation     :    CPU:   70.238 us   +/- 5.299 (min:   65.694 / max:   96.081) us     GPU-0: 3021.352 us   +/-11.456 (min: 3007.488 / max: 3049.472) us
```
### This PR
```
**shape (256, 256)**
binary_erosion      :    CPU:  109.395 us   +/-17.944 (min:   98.399 / max:  157.815) us     GPU-0:  115.403 us   +/-19.009 (min:  103.680 / max:  168.320) us
binary_dilation     :    CPU:   96.015 us   +/- 4.039 (min:   92.903 / max:  115.009) us     GPU-0:  100.732 us   +/- 4.194 (min:   97.120 / max:  119.168) us
**shape (4096, 4096)**
binary_erosion      :    CPU:   81.708 us   +/-10.644 (min:   74.575 / max:  180.727) us     GPU-0:  575.700 us   +/- 3.880 (min:  569.344 / max:  592.192) us
binary_dilation     :    CPU:  108.657 us   +/- 9.958 (min:   96.774 / max:  165.093) us     GPU-0: 1174.641 us   +/- 9.765 (min: 1163.200 / max: 1228.800) us
```
