### PR TITLE
Add cupy.nancumsum and cupy.nancumprod

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -591,6 +591,8 @@ from cupy._math.sumprod import prod  # NOQA
 from cupy._math.sumprod import sum  # NOQA
 from cupy._math.sumprod import cumprod  # NOQA
 from cupy._math.sumprod import cumsum  # NOQA
+from cupy._math.sumprod import nancumprod  # NOQA
+from cupy._math.sumprod import nancumsum  # NOQA
 from cupy._math.sumprod import nansum  # NOQA
 from cupy._math.sumprod import nanprod  # NOQA
 from cupy._math.sumprod import diff  # NOQA

--- a/cupy/_math/sumprod.py
+++ b/cupy/_math/sumprod.py
@@ -192,7 +192,7 @@ def nancumsum(a, axis=None, dtype=None, out=None):
 
     .. seealso:: :func:`numpy.nancumsum`
     """
-    a = _replace_nan(a, 0)
+    a = _replace_nan(a, 0, out=out)
     return cumsum(a, axis=axis, dtype=dtype, out=out)
 
 
@@ -212,12 +212,13 @@ def nancumprod(a, axis=None, dtype=None, out=None):
 
     .. seealso:: :func:`numpy.nancumprod`
     """
-    a = _replace_nan(a, 1)
+    a = _replace_nan(a, 1, out=out)
     return cumprod(a, axis=axis, dtype=dtype, out=out)
 
 
-def _replace_nan(a, val):
-    out = cupy.empty_like(a)
+def _replace_nan(a, val, out=None):
+    if out is None or a.dtype != out.dtype:
+        out = cupy.empty_like(a)
     cupy.core._kernel.ElementwiseKernel(
         'T a, T val', 'T out', 'if (a == a) {out = a;} else {out = val;}',
         'cupy_replace_nan')(a, val, out)

--- a/cupy/_math/sumprod.py
+++ b/cupy/_math/sumprod.py
@@ -198,7 +198,7 @@ def nancumsum(a, axis=None, dtype=None, out=None):
 
 def nancumprod(a, axis=None, dtype=None, out=None):
     """Returns the cumulative product of an array along a given axis treating
-    Not a Numbers (NaNs) as zero.
+    Not a Numbers (NaNs) as one.
 
     Args:
         a (cupy.ndarray): Input array.

--- a/cupy/_math/sumprod.py
+++ b/cupy/_math/sumprod.py
@@ -216,12 +216,15 @@ def nancumprod(a, axis=None, dtype=None, out=None):
     return cumprod(a, axis=axis, dtype=dtype, out=out)
 
 
+_replace_nan_kernel = cupy.core._kernel.ElementwiseKernel(
+    'T a, T val', 'T out', 'if (a == a) {out = a;} else {out = val;}',
+    'cupy_replace_nan')
+
+
 def _replace_nan(a, val, out=None):
     if out is None or a.dtype != out.dtype:
         out = cupy.empty_like(a)
-    cupy.core._kernel.ElementwiseKernel(
-        'T a, T val', 'T out', 'if (a == a) {out = a;} else {out = val;}',
-        'cupy_replace_nan')(a, val, out)
+    _replace_nan_kernel(a, val, out)
     return out
 
 

--- a/cupy/_math/sumprod.py
+++ b/cupy/_math/sumprod.py
@@ -176,6 +176,54 @@ def cumprod(a, axis=None, dtype=None, out=None):
     return _math.scan_core(a, axis, _math.scan_op.SCAN_PROD, dtype, out)
 
 
+def nancumsum(a, axis=None, dtype=None, out=None):
+    """Returns the cumulative sum of an array along a given axis treating Not a
+    Numbers (NaNs) as zero.
+
+    Args:
+        a (cupy.ndarray): Input array.
+        axis (int): Axis along which the cumulative sum is taken. If it is not
+            specified, the input is flattened.
+        dtype: Data type specifier.
+        out (cupy.ndarray): Output array.
+
+    Returns:
+        cupy.ndarray: The result array.
+
+    .. seealso:: :func:`numpy.nancumsum`
+    """
+    a = _replace_nan(a, 0)
+    return cumsum(a, axis=axis, dtype=dtype, out=out)
+
+
+def nancumprod(a, axis=None, dtype=None, out=None):
+    """Returns the cumulative product of an array along a given axis treating
+    Not a Numbers (NaNs) as zero.
+
+    Args:
+        a (cupy.ndarray): Input array.
+        axis (int): Axis along which the cumulative product is taken. If it is
+            not specified, the input is flattened.
+        dtype: Data type specifier.
+        out (cupy.ndarray): Output array.
+
+    Returns:
+        cupy.ndarray: The result array.
+
+    .. seealso:: :func:`numpy.nancumprod`
+    """
+    a = _replace_nan(a, 1)
+    return cumprod(a, axis=axis, dtype=dtype, out=out)
+
+
+def _replace_nan(a, val):
+    out = cupy.empty_like(a)
+    cupy.core._kernel.ElementwiseKernel(
+        'T a, T val', 'T out', 'if (a == a) {out = a;} else {out = val;}',
+        'cupy_replace_nan')(a, val, out)
+    return out
+
+
 def diff(a, n=1, axis=-1, prepend=None, append=None):
     """Calculate the n-th discrete difference along the given axis.
 

--- a/docs/source/reference/math.rst
+++ b/docs/source/reference/math.rst
@@ -69,6 +69,8 @@ Sums, products, differences
    cupy.cumsum
    cupy.nansum
    cupy.nanprod
+   cupy.nancumsum
+   cupy.nancumprod
    cupy.diff
    cupy.gradient
 

--- a/tests/cupy_tests/math_tests/test_sumprod.py
+++ b/tests/cupy_tests/math_tests/test_sumprod.py
@@ -724,7 +724,7 @@ class TestCumprod(unittest.TestCase):
 @testing.gpu
 class TestNanCumSumProd(unittest.TestCase):
 
-    density = 0.7
+    zero_density = 0.25
 
     def _make_array(self, dtype):
         dtype = numpy.dtype(dtype)
@@ -736,11 +736,11 @@ class TestNanCumSumProd(unittest.TestCase):
                 ai = a
                 aj = testing.shaped_random(self.shape, numpy, dtype=r_dtype,
                                            scale=1)
-                ai[ai > math.sqrt(self.density)] = 0
-                aj[aj > math.sqrt(self.density)] = 0
+                ai[ai < math.sqrt(self.zero_density)] = 0
+                aj[aj < math.sqrt(self.zero_density)] = 0
                 a = ai + 1j * aj
             else:
-                a[a > self.density] = 0
+                a[a < self.zero_density] = 0
             a = a / a
         else:
             a = testing.shaped_random(self.shape, numpy, dtype=dtype)
@@ -751,8 +751,8 @@ class TestNanCumSumProd(unittest.TestCase):
     def test_nancumsumprod(self, xp, dtype):
         if self.axis is not None and self.axis >= len(self.shape):
             raise unittest.SkipTest()
-        a = self._make_array(dtype)
-        out = getattr(xp, self.func)(xp.array(a), axis=self.axis)
+        a = xp.array(self._make_array(dtype))
+        out = getattr(xp, self.func)(a, axis=self.axis)
         return xp.ascontiguousarray(out)
 
     @testing.for_all_dtypes()
@@ -764,9 +764,9 @@ class TestNanCumSumProd(unittest.TestCase):
         if len(self.shape) > 1 and self.axis is None:
             # Skip the cases where np.nancum{sum|prod} raise AssertionError.
             raise unittest.SkipTest()
-        a = self._make_array(dtype)
+        a = xp.array(self._make_array(dtype))
         out = xp.empty(self.shape, dtype=dtype)
-        getattr(xp, self.func)(xp.array(a), axis=self.axis, out=out)
+        getattr(xp, self.func)(a, axis=self.axis, out=out)
         return xp.ascontiguousarray(out)
 
 

--- a/tests/cupy_tests/math_tests/test_sumprod.py
+++ b/tests/cupy_tests/math_tests/test_sumprod.py
@@ -750,7 +750,7 @@ class TestNanCumSumProd(unittest.TestCase):
     @testing.numpy_cupy_allclose()
     def test_nancumsumprod(self, xp, dtype):
         if self.axis is not None and self.axis >= len(self.shape):
-            pytest.skip()
+            raise unittest.SkipTest()
         a = self._make_array(dtype)
         out = getattr(xp, self.func)(xp.array(a), axis=self.axis)
         return xp.ascontiguousarray(out)
@@ -760,10 +760,10 @@ class TestNanCumSumProd(unittest.TestCase):
     def test_nancumsumprod_out(self, xp, dtype):
         dtype = numpy.dtype(dtype)
         if self.axis is not None and self.axis >= len(self.shape):
-            pytest.skip()
+            raise unittest.SkipTest()
         if len(self.shape) > 1 and self.axis is None:
             # Skip the cases where np.nancum{sum|prod} raise AssertionError.
-            pytest.skip()
+            raise unittest.SkipTest()
         a = self._make_array(dtype)
         out = xp.empty(self.shape, dtype=dtype)
         getattr(xp, self.func)(xp.array(a), axis=self.axis, out=out)

--- a/tests/cupy_tests/math_tests/test_sumprod.py
+++ b/tests/cupy_tests/math_tests/test_sumprod.py
@@ -761,8 +761,8 @@ class TestNanCumSumProd(unittest.TestCase):
         dtype = numpy.dtype(dtype)
         if self.axis is not None and self.axis >= len(self.shape):
             pytest.skip()
-        if len(self.shape) > 1 and dtype.char in 'd':
-            # Skip the cases as np.nancum{sum|prod} raises AssertionError.
+        if len(self.shape) > 1 and self.axis is None:
+            # Skip the cases where np.nancum{sum|prod} raise AssertionError.
             pytest.skip()
         a = self._make_array(dtype)
         out = xp.empty(self.shape, dtype=dtype)

--- a/tests/cupyx_tests/fallback_mode_tests/test_fallback.py
+++ b/tests/cupyx_tests/fallback_mode_tests/test_fallback.py
@@ -553,13 +553,13 @@ class TestInplaceSpecialMethods(unittest.TestCase):
         xp.put_along_axis(a, ai, 99, axis=1)
         return a
 
-    @unittest.skipIf(get_numpy_version() < (1, 12, 0),
-                     'nancumsum introduced in numpy v1.12.0')
+    @unittest.skipIf(get_numpy_version() < (1, 15, 0),
+                     'quantile introduced in numpy v1.15.0')
     @numpy_fallback_array_equal()
     def test_out_is_returned_when_fallbacked(self, xp):
         a = testing.shaped_random((3, 4), xp)
-        z = xp.zeros((3, 4))
-        res = xp.nancumsum(a, axis=0, out=z)
+        z = xp.zeros((4, ))
+        res = xp.quantile(a, 0.5, axis=0, out=z)
         assert res is z
         return res
 


### PR DESCRIPTION
This PR adds `cupy.nancumsum` and `cupy.nancumprod`.
The implementation is simple: it replaces the `NaN` value with `0` or `1` before calling `cumsum` or `cumprod`.

This is related to https://github.com/cupy/cupy/issues/4025.