### PR TITLE
handle np.nan and np.inf constant values properly in ndimage functions

### DIFF
--- a/cupyx/scipy/ndimage/_interp_kernels.py
+++ b/cupyx/scipy/ndimage/_interp_kernels.py
@@ -1,7 +1,11 @@
+import numpy
+
 import cupy
 import cupy.core.internal
 
 from cupyx.scipy.ndimage import _util
+
+math_constants_preamble = "#include <math_constants.h>\n"
 
 
 def _get_coord_map(ndim):
@@ -213,6 +217,15 @@ def _generate_interp_custom(coord_func, ndim, large_int, yshape, mode, cval,
     # compute the transformed (target) coordinates, c_j
     ops = ops + coord_func(ndim)
 
+    if cval is numpy.nan:
+        cval = 'CUDART_NAN'
+    elif cval == numpy.inf:
+        cval = 'CUDART_INF'
+    elif cval == -numpy.inf:
+        cval = '-CUDART_INF'
+    else:
+        cval = '(double){cval}'.format(cval=cval)
+
     if mode == 'constant':
         # use cval if coordinate is outside the bounds of x
         _cond = ' || '.join(
@@ -221,7 +234,7 @@ def _generate_interp_custom(coord_func, ndim, large_int, yshape, mode, cval,
         ops.append("""
         if ({cond})
         {{
-            out = (double){cval};
+            out = {cval};
         }}
         else
         {{""".format(cond=_cond, cval=cval))
@@ -328,7 +341,8 @@ def _get_map_kernel(ndim, large_int, yshape, mode, cval=0.0, order=1,
         name='shift',
         integer_output=integer_output,
     )
-    return cupy.ElementwiseKernel(in_params, out_params, operation, name)
+    return cupy.ElementwiseKernel(in_params, out_params, operation, name,
+                                  preamble=math_constants_preamble)
 
 
 @cupy._util.memoize(for_each_device=True)
@@ -347,7 +361,8 @@ def _get_shift_kernel(ndim, large_int, yshape, mode, cval=0.0, order=1,
         name='shift',
         integer_output=integer_output,
     )
-    return cupy.ElementwiseKernel(in_params, out_params, operation, name)
+    return cupy.ElementwiseKernel(in_params, out_params, operation, name,
+                                  preamble=math_constants_preamble)
 
 
 @cupy._util.memoize(for_each_device=True)
@@ -366,7 +381,8 @@ def _get_zoom_shift_kernel(ndim, large_int, yshape, mode, cval=0.0, order=1,
         name='zoom_shift',
         integer_output=integer_output,
     )
-    return cupy.ElementwiseKernel(in_params, out_params, operation, name)
+    return cupy.ElementwiseKernel(in_params, out_params, operation, name,
+                                  preamble=math_constants_preamble)
 
 
 @cupy._util.memoize(for_each_device=True)
@@ -385,7 +401,8 @@ def _get_zoom_kernel(ndim, large_int, yshape, mode, cval=0.0, order=1,
         name='zoom',
         integer_output=integer_output,
     )
-    return cupy.ElementwiseKernel(in_params, out_params, operation, name)
+    return cupy.ElementwiseKernel(in_params, out_params, operation, name,
+                                  preamble=math_constants_preamble)
 
 
 @cupy._util.memoize(for_each_device=True)
@@ -404,4 +421,5 @@ def _get_affine_kernel(ndim, large_int, yshape, mode, cval=0.0, order=1,
         name='affine',
         integer_output=integer_output,
     )
-    return cupy.ElementwiseKernel(in_params, out_params, operation, name)
+    return cupy.ElementwiseKernel(in_params, out_params, operation, name,
+                                  preamble=math_constants_preamble)

--- a/cupyx/scipy/ndimage/_util.py
+++ b/cupyx/scipy/ndimage/_util.py
@@ -1,6 +1,20 @@
 import cupy
 
 
+def _is_integer_output(output, input):
+    if output is None:
+        return input.dtype.kind in 'iu'
+    elif isinstance(output, cupy.ndarray):
+        return output.dtype.kind in 'iu'
+    return cupy.dtype(output).kind in 'iu'
+
+
+def _check_cval(mode, cval, integer_output):
+    if mode == 'constant' and integer_output and not cupy.isfinite(cval):
+        raise NotImplementedError("Non-finite cval is not supported for "
+                                  "outputs with integer dtype.")
+
+
 def _get_output(output, input, shape=None):
     if not isinstance(output, cupy.ndarray):
         return cupy.zeros_like(input, shape=shape, dtype=output, order='C')

--- a/cupyx/scipy/ndimage/interpolation.py
+++ b/cupyx/scipy/ndimage/interpolation.py
@@ -80,6 +80,7 @@ def map_coordinates(input, coordinates, output=None, order=None,
 
     ret = _util._get_output(output, input, coordinates.shape[1:])
     integer_output = ret.dtype.kind in 'iu'
+    _util._check_cval(mode, cval, integer_output)
 
     if input.dtype.kind in 'iu':
         input = input.astype(cupy.float32)
@@ -184,6 +185,7 @@ def affine_transform(input, matrix, offset=0.0, output_shape=None, output=None,
         input = input.astype(cupy.float32)
 
     integer_output = output.dtype.kind in 'iu'
+    _util._check_cval(mode, cval, integer_output)
     large_int = max(_prod(input.shape), _prod(output_shape)) > 1 << 31
     if matrix.ndim == 1:
         offset = cupy.asarray(offset, dtype=cupy.float64)
@@ -371,6 +373,7 @@ def shift(input, shift, output=None, order=None, mode='constant', cval=0.0,
         if input.dtype.kind in 'iu':
             input = input.astype(cupy.float32)
         integer_output = output.dtype.kind in 'iu'
+        _util._check_cval(mode, cval, integer_output)
         large_int = _prod(input.shape) > 1 << 31
         kern = _interp_kernels._get_shift_kernel(
             input.ndim, large_int, input.shape, mode, cval=cval, order=order,
@@ -459,6 +462,7 @@ def zoom(input, zoom, output=None, order=None, mode='constant', cval=0.0,
         if input.dtype.kind in 'iu':
             input = input.astype(cupy.float32)
         integer_output = output.dtype.kind in 'iu'
+        _util._check_cval(mode, cval, integer_output)
         large_int = max(_prod(input.shape), _prod(output_shape)) > 1 << 31
         kern = _interp_kernels._get_zoom_kernel(
             input.ndim, large_int, output_shape, mode, order=order,


### PR DESCRIPTION
SciPy's interpolation routines with mode='constant' allow the constant value to be `np.nan`, `np.inf` or `-np.inf`, but these currently cause compilation failure in CuPy. 

closes #4082

I will add test cases in a bit and look into whether we might want to have a similar change for ndimage filters, etc.

