### PR TITLE
Fix `argmax` and `argmin` for F-order inputs

### DIFF
--- a/cupy/core/_reduction.pxd
+++ b/cupy/core/_reduction.pxd
@@ -28,7 +28,7 @@ cdef class _AbstractReductionKernel:
         list in_args, list out_args,
         const shape_t& a_shape, axis, dtype,
         bint keepdims, bint reduce_dims, int device_id,
-        stream, bint try_use_cub=*)
+        stream, bint try_use_cub=*, bint sort_reduce_axis=*)
 
     cdef void _launch(
         self, out_block_num, block_size, block_stride,
@@ -72,4 +72,5 @@ cdef tuple _get_shape_and_strides(list in_args, list out_args)
 
 cdef _optimizer_copy_arg(a)
 
-cpdef create_reduction_func(name, ops, routine=*, identity=*, preamble=*)
+cpdef create_reduction_func(
+    name, ops, routine=*, identity=*, preamble=*, sort_reduce_axis=*)

--- a/cupy/core/_reduction.pyx
+++ b/cupy/core/_reduction.pyx
@@ -228,7 +228,7 @@ cpdef (Py_ssize_t, Py_ssize_t, Py_ssize_t) _get_block_specs(  # NOQA
     return block_size, block_stride, out_block_num
 
 
-def _sort_axis(tuple axis, tuple strides):
+cdef tuple _sort_axis(tuple axis, tuple strides):
     # Sorts axis in the decreasing order of absolute values of strides.
     return tuple(sorted(axis, key=lambda i: -abs(strides[i])))
 
@@ -285,7 +285,7 @@ cdef class _AbstractReductionKernel:
             list in_args, list out_args,
             const shape_t& a_shape, axis, dtype,
             bint keepdims, bint reduce_dims, int device_id,
-            stream, bint try_use_cub=False):
+            stream, bint try_use_cub=False, bint sort_reduce_axis=True):
         cdef tuple reduce_axis, out_axis, axis_permutes
         cdef tuple params, opt_params
         cdef tuple shape_and_strides
@@ -314,7 +314,8 @@ cdef class _AbstractReductionKernel:
                 and len(out_axis) <= 1
                 and not in_args[0]._c_contiguous):
             strides = in_args[0].strides
-            reduce_axis = _sort_axis(reduce_axis, strides)
+            if sort_reduce_axis:
+                reduce_axis = _sort_axis(reduce_axis, strides)
             out_axis = _sort_axis(out_axis, strides)
 
         out_shape = _get_out_shape(a_shape, reduce_axis, out_axis, keepdims)
@@ -498,9 +499,11 @@ cdef class _AbstractReductionKernel:
 # -----------------------------------------------------------------------------
 
 cpdef _SimpleReductionKernel create_reduction_func(
-        name, ops, routine=None, identity=None, preamble=''):
+        name, ops, routine=None, identity=None, preamble='',
+        sort_reduce_axis=True):
     ops = _kernel._Ops.from_tuples(ops, routine)
-    return _SimpleReductionKernel(name, ops, identity, preamble)
+    return _SimpleReductionKernel(
+        name, ops, identity, preamble, sort_reduce_axis)
 
 
 cdef class _SimpleReductionKernel(_AbstractReductionKernel):
@@ -513,8 +516,11 @@ cdef class _SimpleReductionKernel(_AbstractReductionKernel):
         readonly str _input_expr
         readonly str _output_expr
         readonly dict _routine_cache
+        readonly bint _sort_reduce_axis
 
-    def __init__(self, name, _kernel._Ops ops, identity, preamble):
+    def __init__(
+            self, name, _kernel._Ops ops, identity, preamble,
+            sort_reduce_axis=True):
         super().__init__(
             name,
             '' if identity is None else str(identity),
@@ -528,6 +534,7 @@ cdef class _SimpleReductionKernel(_AbstractReductionKernel):
         self._input_expr = 'const type_in0_raw in0 = _raw_in0[_in_ind.get()];'
         self._output_expr = 'type_out0_raw &out0 = _raw_out0[_out_ind.get()];'
         self._routine_cache = {}
+        self._sort_reduce_axis = sort_reduce_axis
 
     def __call__(self, object a, axis=None, dtype=None, ndarray out=None,
                  bint keepdims=False):
@@ -556,7 +563,8 @@ cdef class _SimpleReductionKernel(_AbstractReductionKernel):
         reduce_dims = True
         return self._call(
             in_args, out_args,
-            arr._shape, axis, dtype, keepdims, reduce_dims, dev_id, None, True)
+            arr._shape, axis, dtype, keepdims, reduce_dims, dev_id,
+            None, True, self._sort_reduce_axis)
 
     cdef tuple _get_expressions_and_types(
             self, list in_args, list out_args, dtype):
@@ -728,7 +736,7 @@ cdef class ReductionKernel(_AbstractReductionKernel):
         return self._call(
             in_args, out_args,
             broad_shape, axis, None,
-            keepdims, self.reduce_dims, dev_id, stream, False)
+            keepdims, self.reduce_dims, dev_id, stream, False, True)
 
     cdef tuple _get_expressions_and_types(
             self, list in_args, list out_args, dtype):

--- a/cupy/core/_routines_statistics.pyx
+++ b/cupy/core/_routines_statistics.pyx
@@ -89,6 +89,9 @@ cdef ndarray _ndarray_argmax(ndarray self, axis, out, dtype, keepdims):
     for accelerator in _accelerator._routine_accelerators:
         if accelerator == _accelerator.ACCELERATOR_CUB:
             # result will be None if the reduction is not compatible with CUB
+            if self._f_contiguous and self.dtype == numpy.bool_:
+                # temporary workaround
+                self = self.astype(numpy.int8)
             result = cub.cub_reduction(
                 self, cub.CUPY_CUB_ARGMAX, axis, dtype, out, keepdims)
             if result is not None:

--- a/cupy/core/_routines_statistics.pyx
+++ b/cupy/core/_routines_statistics.pyx
@@ -90,7 +90,9 @@ cdef ndarray _ndarray_argmax(ndarray self, axis, out, dtype, keepdims):
         if accelerator == _accelerator.ACCELERATOR_CUB:
             # result will be None if the reduction is not compatible with CUB
             if self._f_contiguous and self.dtype == numpy.bool_:
-                # temporary workaround
+                # temporary workaround casting the inputs to int8
+                # CUB argmax seems to return different values to
+                # NumPy for F-order bool array inputs
                 self = self.astype(numpy.int8)
             result = cub.cub_reduction(
                 self, cub.CUPY_CUB_ARGMAX, axis, dtype, out, keepdims)

--- a/cupy/core/_routines_statistics.pyx
+++ b/cupy/core/_routines_statistics.pyx
@@ -309,7 +309,7 @@ cdef _argmin = create_reduction_func(
         ('D->q', (None, 'my_argmin_float(a, b)', None, None))),
     ('min_max_st<type_in0_raw>(in0, _J)', 'my_argmin(a, b)', 'out0 = a.index',
      'min_max_st<type_in0_raw>'),
-    None, _min_max_preamble)
+    None, _min_max_preamble, sort_reduce_axis=False)
 
 
 cdef _argmax = create_reduction_func(
@@ -323,7 +323,7 @@ cdef _argmax = create_reduction_func(
         ('D->q', (None, 'my_argmax_float(a, b)', None, None))),
     ('min_max_st<type_in0_raw>(in0, _J)', 'my_argmax(a, b)', 'out0 = a.index',
      'min_max_st<type_in0_raw>'),
-    None, _min_max_preamble)
+    None, _min_max_preamble, sort_reduce_axis=False)
 
 
 cpdef ndarray _nanargmax(ndarray a, axis, out, dtype, keepdims):
@@ -347,7 +347,7 @@ cdef _nanargmin_func = create_reduction_func(
      ('D->q', (None, 'my_argmin_float(a, b)', None, None))),
     ('min_max_st<type_in0_raw>(in0, isnan(in0) ? -1 : _J)',
      'my_argmin(a, b)', 'out0 = a.index', 'min_max_st<type_in0_raw>'),
-    None, _min_max_preamble)
+    None, _min_max_preamble, sort_reduce_axis=False)
 
 
 cdef _nanargmax_func = create_reduction_func(
@@ -361,7 +361,7 @@ cdef _nanargmax_func = create_reduction_func(
      ('D->q', (None, 'my_argmax_float(a, b)', None, None))),
     ('min_max_st<type_in0_raw>(in0, isnan(in0) ? -1 : _J)',
      'my_argmax(a, b)', 'out0 = a.index', 'min_max_st<type_in0_raw>'),
-    None, _min_max_preamble)
+    None, _min_max_preamble, sort_reduce_axis=False)
 
 
 cpdef ndarray _median(

--- a/tests/cupy_tests/core_tests/test_ndarray_reduction.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_reduction.py
@@ -9,215 +9,218 @@ import cupy.core._accelerator as _acc
 from cupy import testing
 
 
+@testing.parameterize(*testing.product({
+    'order': ('C', 'F'),
+}))
 @testing.gpu
 class TestArrayReduction(unittest.TestCase):
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_max_all(self, xp, dtype):
-        a = testing.shaped_random((2, 3), xp, dtype)
+        a = testing.shaped_random((2, 3), xp, dtype, order=self.order)
         return a.max()
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_max_all_keepdims(self, xp, dtype):
-        a = testing.shaped_random((2, 3), xp, dtype)
+        a = testing.shaped_random((2, 3), xp, dtype, order=self.order)
         return a.max(keepdims=True)
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_max_axis_large(self, xp, dtype):
-        a = testing.shaped_random((3, 1000), xp, dtype)
+        a = testing.shaped_random((3, 1000), xp, dtype, order=self.order)
         return a.max(axis=0)
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_max_axis0(self, xp, dtype):
-        a = testing.shaped_random((2, 3, 4), xp, dtype)
+        a = testing.shaped_random((2, 3, 4), xp, dtype, order=self.order)
         return a.max(axis=0)
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_max_axis1(self, xp, dtype):
-        a = testing.shaped_random((2, 3, 4), xp, dtype)
+        a = testing.shaped_random((2, 3, 4), xp, dtype, order=self.order)
         return a.max(axis=1)
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_max_axis2(self, xp, dtype):
-        a = testing.shaped_random((2, 3, 4), xp, dtype)
+        a = testing.shaped_random((2, 3, 4), xp, dtype, order=self.order)
         return a.max(axis=2)
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_max_multiple_axes(self, xp, dtype):
-        a = testing.shaped_random((2, 3, 4), xp, dtype)
+        a = testing.shaped_random((2, 3, 4), xp, dtype, order=self.order)
         return a.max(axis=(1, 2))
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_max_multiple_axes_keepdims(self, xp, dtype):
-        a = testing.shaped_random((2, 3, 4), xp, dtype)
+        a = testing.shaped_random((2, 3, 4), xp, dtype, order=self.order)
         return a.max(axis=(1, 2), keepdims=True)
 
     @testing.for_float_dtypes()
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_max_nan(self, xp, dtype):
         if _acc.ACCELERATOR_CUTENSOR in _acc.get_routine_accelerators():
             pytest.skip()
-        a = xp.array([float('nan'), 1, -1], dtype)
+        a = xp.array([float('nan'), 1, -1], dtype, order=self.order)
         return a.max()
 
     @testing.for_complex_dtypes()
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_max_nan_real(self, xp, dtype):
-        a = xp.array([float('nan'), 1, -1], dtype)
+        a = xp.array([float('nan'), 1, -1], dtype, order=self.order)
         return a.max()
 
     @testing.for_complex_dtypes()
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_max_nan_imag(self, xp, dtype):
-        a = xp.array([float('nan')*1.j, 1.j, -1.j], dtype)
+        a = xp.array([float('nan')*1.j, 1.j, -1.j], dtype, order=self.order)
         return a.max()
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_min_all(self, xp, dtype):
-        a = testing.shaped_random((2, 3), xp, dtype)
+        a = testing.shaped_random((2, 3), xp, dtype, order=self.order)
         return a.min()
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_min_all_keepdims(self, xp, dtype):
-        a = testing.shaped_random((2, 3), xp, dtype)
+        a = testing.shaped_random((2, 3), xp, dtype, order=self.order)
         return a.min(keepdims=True)
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_min_axis_large(self, xp, dtype):
-        a = testing.shaped_random((3, 1000), xp, dtype)
+        a = testing.shaped_random((3, 1000), xp, dtype, order=self.order)
         return a.min(axis=0)
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_min_axis0(self, xp, dtype):
-        a = testing.shaped_random((2, 3, 4), xp, dtype)
+        a = testing.shaped_random((2, 3, 4), xp, dtype, order=self.order)
         return a.min(axis=0)
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_min_axis1(self, xp, dtype):
-        a = testing.shaped_random((2, 3, 4), xp, dtype)
+        a = testing.shaped_random((2, 3, 4), xp, dtype, order=self.order)
         return a.min(axis=1)
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_min_axis2(self, xp, dtype):
-        a = testing.shaped_random((2, 3, 4), xp, dtype)
+        a = testing.shaped_random((2, 3, 4), xp, dtype, order=self.order)
         return a.min(axis=2)
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_min_multiple_axes(self, xp, dtype):
-        a = testing.shaped_random((2, 3, 4), xp, dtype)
+        a = testing.shaped_random((2, 3, 4), xp, dtype, order=self.order)
         return a.min(axis=(1, 2))
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_min_multiple_axes_keepdims(self, xp, dtype):
-        a = testing.shaped_random((2, 3, 4), xp, dtype)
+        a = testing.shaped_random((2, 3, 4), xp, dtype, order=self.order)
         return a.min(axis=(1, 2), keepdims=True)
 
     @testing.for_float_dtypes()
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_min_nan(self, xp, dtype):
         if _acc.ACCELERATOR_CUTENSOR in _acc.get_routine_accelerators():
             pytest.skip()
-        a = xp.array([float('nan'), 1, -1], dtype)
+        a = xp.array([float('nan'), 1, -1], dtype, order=self.order)
         return a.min()
 
     @testing.for_complex_dtypes()
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_min_nan_real(self, xp, dtype):
-        a = xp.array([float('nan'), 1, -1], dtype)
+        a = xp.array([float('nan'), 1, -1], dtype, order=self.order)
         return a.min()
 
     @testing.for_complex_dtypes()
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_min_nan_imag(self, xp, dtype):
-        a = xp.array([float('nan')*1.j, 1.j, -1.j], dtype)
+        a = xp.array([float('nan')*1.j, 1.j, -1.j], dtype, order=self.order)
         return a.min()
 
     # skip bool: numpy's ptp raises a TypeError on bool inputs
     @testing.for_all_dtypes(no_bool=True)
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_ptp_all(self, xp, dtype):
-        a = testing.shaped_random((2, 3), xp, dtype)
+        a = testing.shaped_random((2, 3), xp, dtype, order=self.order)
         return a.ptp()
 
     @testing.with_requires('numpy>=1.15')
     @testing.for_all_dtypes(no_bool=True)
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_ptp_all_keepdims(self, xp, dtype):
-        a = testing.shaped_random((2, 3), xp, dtype)
+        a = testing.shaped_random((2, 3), xp, dtype, order=self.order)
         return a.ptp(keepdims=True)
 
     @testing.for_all_dtypes(no_bool=True)
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_ptp_axis_large(self, xp, dtype):
-        a = testing.shaped_random((3, 1000), xp, dtype)
+        a = testing.shaped_random((3, 1000), xp, dtype, order=self.order)
         return a.ptp(axis=0)
 
     @testing.for_all_dtypes(no_bool=True)
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_ptp_axis0(self, xp, dtype):
-        a = testing.shaped_random((2, 3, 4), xp, dtype)
+        a = testing.shaped_random((2, 3, 4), xp, dtype, order=self.order)
         return a.ptp(axis=0)
 
     @testing.for_all_dtypes(no_bool=True)
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_ptp_axis1(self, xp, dtype):
-        a = testing.shaped_random((2, 3, 4), xp, dtype)
+        a = testing.shaped_random((2, 3, 4), xp, dtype, order=self.order)
         return a.ptp(axis=1)
 
     @testing.for_all_dtypes(no_bool=True)
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_ptp_axis2(self, xp, dtype):
-        a = testing.shaped_random((2, 3, 4), xp, dtype)
+        a = testing.shaped_random((2, 3, 4), xp, dtype, order=self.order)
         return a.ptp(axis=2)
 
     @testing.with_requires('numpy>=1.15')
     @testing.for_all_dtypes(no_bool=True)
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_ptp_multiple_axes(self, xp, dtype):
-        a = testing.shaped_random((2, 3, 4), xp, dtype)
+        a = testing.shaped_random((2, 3, 4), xp, dtype, order=self.order)
         return a.ptp(axis=(1, 2))
 
     @testing.with_requires('numpy>=1.15')
     @testing.for_all_dtypes(no_bool=True)
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_ptp_multiple_axes_keepdims(self, xp, dtype):
-        a = testing.shaped_random((2, 3, 4), xp, dtype)
+        a = testing.shaped_random((2, 3, 4), xp, dtype, order=self.order)
         return a.ptp(axis=(1, 2), keepdims=True)
 
     @testing.for_float_dtypes()
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_ptp_nan(self, xp, dtype):
         if _acc.ACCELERATOR_CUTENSOR in _acc.get_routine_accelerators():
             pytest.skip()
-        a = xp.array([float('nan'), 1, -1], dtype)
+        a = xp.array([float('nan'), 1, -1], dtype, order=self.order)
         return a.ptp()
 
     @testing.for_complex_dtypes()
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_ptp_nan_real(self, xp, dtype):
-        a = xp.array([float('nan'), 1, -1], dtype)
+        a = xp.array([float('nan'), 1, -1], dtype, order=self.order)
         return a.ptp()
 
     @testing.for_complex_dtypes()
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_ptp_nan_imag(self, xp, dtype):
-        a = xp.array([float('nan')*1.j, 1.j, -1.j], dtype)
+        a = xp.array([float('nan')*1.j, 1.j, -1.j], dtype, order=self.order)
         return a.ptp()
 
 

--- a/tests/cupy_tests/core_tests/test_ndarray_reduction.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_reduction.py
@@ -223,6 +223,106 @@ class TestArrayReduction(unittest.TestCase):
         a = xp.array([float('nan')*1.j, 1.j, -1.j], dtype, order=self.order)
         return a.ptp()
 
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
+    def test_argmax_all(self, xp, dtype):
+        a = testing.shaped_random((2, 3), xp, dtype, order=self.order)
+        return a.argmax()
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
+    def test_argmax_axis_large(self, xp, dtype):
+        a = testing.shaped_random((3, 1000), xp, dtype, order=self.order)
+        return a.argmax(axis=0)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
+    def test_argmax_axis0(self, xp, dtype):
+        a = testing.shaped_random((2, 3, 4), xp, dtype, order=self.order)
+        return a.argmax(axis=0)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
+    def test_argmax_axis1(self, xp, dtype):
+        a = testing.shaped_random((2, 3, 4), xp, dtype, order=self.order)
+        return a.argmax(axis=1)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
+    def test_argmax_axis2(self, xp, dtype):
+        a = testing.shaped_random((2, 3, 4), xp, dtype, order=self.order)
+        return a.argmax(axis=2)
+
+    @testing.for_float_dtypes()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
+    def test_argmax_nan(self, xp, dtype):
+        if _acc.ACCELERATOR_CUTENSOR in _acc.get_routine_accelerators():
+            pytest.skip()
+        a = xp.array([float('nan'), 1, -1], dtype, order=self.order)
+        return a.argmax()
+
+    @testing.for_complex_dtypes()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
+    def test_argmax_nan_real(self, xp, dtype):
+        a = xp.array([float('nan'), 1, -1], dtype, order=self.order)
+        return a.argmax()
+
+    @testing.for_complex_dtypes()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
+    def test_argmax_nan_imag(self, xp, dtype):
+        a = xp.array([float('nan')*1.j, 1.j, -1.j], dtype, order=self.order)
+        return a.argmax()
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
+    def test_argmin_all(self, xp, dtype):
+        a = testing.shaped_random((2, 3), xp, dtype, order=self.order)
+        return a.argmin()
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
+    def test_argmin_axis_large(self, xp, dtype):
+        a = testing.shaped_random((3, 1000), xp, dtype, order=self.order)
+        return a.argmin(axis=0)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
+    def test_argmin_axis0(self, xp, dtype):
+        a = testing.shaped_random((2, 3, 4), xp, dtype, order=self.order)
+        return a.argmin(axis=0)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
+    def test_argmin_axis1(self, xp, dtype):
+        a = testing.shaped_random((2, 3, 4), xp, dtype, order=self.order)
+        return a.argmin(axis=1)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
+    def test_argmin_axis2(self, xp, dtype):
+        a = testing.shaped_random((2, 3, 4), xp, dtype, order=self.order)
+        return a.argmin(axis=2)
+
+    @testing.for_float_dtypes()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
+    def test_argmin_nan(self, xp, dtype):
+        if _acc.ACCELERATOR_CUTENSOR in _acc.get_routine_accelerators():
+            pytest.skip()
+        a = xp.array([float('nan'), 1, -1], dtype, order=self.order)
+        return a.argmin()
+
+    @testing.for_complex_dtypes()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
+    def test_argmin_nan_real(self, xp, dtype):
+        a = xp.array([float('nan'), 1, -1], dtype, order=self.order)
+        return a.argmin()
+
+    @testing.for_complex_dtypes()
+    @testing.numpy_cupy_allclose(contiguous_check=False)
+    def test_argmin_nan_imag(self, xp, dtype):
+        a = xp.array([float('nan')*1.j, 1.j, -1.j], dtype, order=self.order)
+        return a.argmin()
+
 
 # This class compares CUB results against NumPy's
 @testing.parameterize(*testing.product({


### PR DESCRIPTION
Depends on #4091.
Fix #4061.
Fix not to sort reduce axis of the input when `_J` is used.