### PR TITLE
[backport] Workaround cudaPointerGetAttributes error in CUDA 10.2+

### DIFF
--- a/cupy/cuda/device.pyx
+++ b/cupy/cuda/device.pyx
@@ -311,5 +311,7 @@ def from_pointer(ptr):
         Device: The device whose memory the pointer refers to.
 
     """
+    # Initialize a context to workaround a bug in CUDA 10.2+. (#3991)
+    runtime._ensure_context()
     attrs = runtime.pointerGetAttributes(ptr)
     return Device(attrs.device)

--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -129,6 +129,8 @@ cdef class UnownedMemory(BaseMemory):
             if ptr == 0:
                 raise RuntimeError('UnownedMemory requires explicit'
                                    ' device ID for a null pointer.')
+            # Initialize a context to workaround a bug in CUDA 10.2+. (#3991)
+            runtime._ensure_context()
             ptr_attrs = runtime.pointerGetAttributes(ptr)
             device_id = ptr_attrs.device
         self.size = size

--- a/tests/cupy_tests/cuda_tests/test_device.py
+++ b/tests/cupy_tests/cuda_tests/test_device.py
@@ -4,6 +4,7 @@ import unittest
 
 import pytest
 
+import cupy
 from cupy import cuda
 from cupy import testing
 
@@ -146,3 +147,8 @@ class TestDeviceHandles(unittest.TestCase):
 
     def test_cusparse_handle(self):
         self._check_handle(cuda.device.get_cusparse_handle)
+
+
+class TestDeviceFromPointer(unittest.TestCase):
+    def test_from_pointer(self):
+        assert cuda.device.from_pointer(cupy.empty(1).data.ptr).id == 0


### PR DESCRIPTION
Backport of #4085