### PR TITLE
Make parameterized dtype test skip by `pytest.skip`

### DIFF
--- a/cupy/testing/helper.py
+++ b/cupy/testing/helper.py
@@ -195,6 +195,7 @@ numpy
 def _signed_counterpart(dtype):
     return numpy.dtype(numpy.dtype(dtype).char.lower()).type
 
+
 def _make_positive_mask(self, impl, args, kw, name, sp_name, scipy_name):
     # Returns a mask of output arrays that indicates valid elements for
     # comparison. See the comment at the caller.

--- a/cupy/testing/helper.py
+++ b/cupy/testing/helper.py
@@ -718,10 +718,11 @@ def for_dtypes(dtypes, name='dtype'):
     by passing the each element of ``dtypes`` to the named
     argument.
     """
+    check_available()
+
     def decorator(impl):
         @functools.wraps(impl)
         def test_func(self, *args, **kw):
-            check_available()
             for dtype in dtypes:
                 try:
                     kw[name] = numpy.dtype(dtype).type
@@ -937,6 +938,7 @@ def for_dtypes_combination(types, names=('dtype',), full=None):
     If the value is set to ``'1'``, it behaves as if ``full=True``, and
     otherwise ``full=False``.
     """
+    check_available()
 
     types = list(types)
 
@@ -964,7 +966,6 @@ def for_dtypes_combination(types, names=('dtype',), full=None):
     def decorator(impl):
         @functools.wraps(impl)
         def test_func(self, *args, **kw):
-            check_available()
             for dtypes in combination:
                 kw_copy = kw.copy()
                 kw_copy.update(dtypes)

--- a/cupy/testing/helper.py
+++ b/cupy/testing/helper.py
@@ -8,6 +8,7 @@ import unittest
 from unittest import mock
 import warnings
 
+import _pytest
 import numpy
 
 import cupy
@@ -707,7 +708,7 @@ def for_dtypes(dtypes, name='dtype'):
                 try:
                     kw[name] = numpy.dtype(dtype).type
                     impl(self, *args, **kw)
-                except unittest.SkipTest as e:
+                except _pytest.outcomes.Skipped as e:
                     print('skipped: {} = {} ({})'.format(name, dtype, e))
                 except Exception:
                     print(name, 'is', dtype)
@@ -951,6 +952,9 @@ def for_dtypes_combination(types, names=('dtype',), full=None):
 
                 try:
                     impl(self, *args, **kw_copy)
+                except _pytest.outcomes.Skipped as e:
+                    msg = ', '.join('{} = {}'.format(name, dtype) for name, dtype in dtypes.items())
+                    print('skipped: {} ({})'.format(msg, e))
                 except Exception:
                     print(dtypes)
                     raise

--- a/cupy/testing/helper.py
+++ b/cupy/testing/helper.py
@@ -192,12 +192,15 @@ numpy
             cupy_error, cupy_tb, numpy_error, numpy_tb)
 
 
+def _signed_counterpart(dtype):
+    return numpy.dtype(numpy.dtype(dtype).char.lower()).type
+
 def _make_positive_mask(self, impl, args, kw, name, sp_name, scipy_name):
     # Returns a mask of output arrays that indicates valid elements for
     # comparison. See the comment at the caller.
     ks = [k for k, v in kw.items() if v in _unsigned_dtypes]
     for k in ks:
-        kw[k] = numpy.intp
+        kw[k] = _signed_counterpart(kw[k])
     result, error, tb = _call_func_cupy(
         self, impl, args, kw, name, sp_name, scipy_name)
     assert error is None

--- a/cupy/testing/helper.py
+++ b/cupy/testing/helper.py
@@ -953,7 +953,9 @@ def for_dtypes_combination(types, names=('dtype',), full=None):
                 try:
                     impl(self, *args, **kw_copy)
                 except _pytest.outcomes.Skipped as e:
-                    msg = ', '.join('{} = {}'.format(name, dtype) for name, dtype in dtypes.items())
+                    msg = ', '.join(
+                        '{} = {}'.format(name, dtype)
+                        for name, dtype in dtypes.items())
                     print('skipped: {} ({})'.format(msg, e))
                 except Exception:
                     print(dtypes)

--- a/cupy/testing/helper.py
+++ b/cupy/testing/helper.py
@@ -727,6 +727,8 @@ def for_dtypes(dtypes, name='dtype'):
                 try:
                     kw[name] = numpy.dtype(dtype).type
                     impl(self, *args, **kw)
+                except unittest.SkipTest as e:
+                    print('skipped: {} = {} ({})'.format(name, dtype, e))
                 except _pytest.outcomes.Skipped as e:
                     print('skipped: {} = {} ({})'.format(name, dtype, e))
                 except Exception:
@@ -912,6 +914,12 @@ def for_complex_dtypes(name='dtype'):
     return for_dtypes(_complex_dtypes, name=name)
 
 
+def _print_skipped_combination(dtypes, e):
+    msg = ', '.join(
+        '{} = {}'.format(name, dtype) for name, dtype in dtypes.items())
+    print('skipped: {} ({})'.format(msg, e))
+
+
 def for_dtypes_combination(types, names=('dtype',), full=None):
     """Decorator that checks the fixture with a product set of dtypes.
 
@@ -972,11 +980,10 @@ def for_dtypes_combination(types, names=('dtype',), full=None):
 
                 try:
                     impl(self, *args, **kw_copy)
+                except unittest.SkipTest as e:
+                    _print_skipped_combination(dtypes, e)
                 except _pytest.outcomes.Skipped as e:
-                    msg = ', '.join(
-                        '{} = {}'.format(name, dtype)
-                        for name, dtype in dtypes.items())
-                    print('skipped: {} ({})'.format(msg, e))
+                    _print_skipped_combination(dtypes, e)
                 except Exception:
                     print(dtypes)
                     raise

--- a/cupy/testing/helper.py
+++ b/cupy/testing/helper.py
@@ -8,13 +8,6 @@ import unittest
 from unittest import mock
 import warnings
 
-_skip_classes = unittest.SkipTest,
-try:
-    import _pytest.outcomes
-    _skip_classes += _pytest.outcomes.Skipped,
-except ImportError as e:
-    pass
-
 import numpy
 
 import cupy
@@ -23,6 +16,13 @@ from cupy.testing import array
 from cupy.testing import parameterized
 import cupyx
 import cupyx.scipy.sparse
+
+_skip_classes = unittest.SkipTest,
+try:
+    import _pytest.outcomes
+    _skip_classes += _pytest.outcomes.Skipped,
+except ImportError:
+    pass
 
 
 def _call_func(self, impl, args, kw):

--- a/cupy/testing/helper.py
+++ b/cupy/testing/helper.py
@@ -18,19 +18,26 @@ import cupyx
 import cupyx.scipy.sparse
 
 _skip_classes = unittest.SkipTest,
+_is_pytest_available = False
 try:
     import _pytest.outcomes
     _skip_classes += _pytest.outcomes.Skipped,
+    _is_pytest_available = True
 except ImportError:
     pass
 
 
 def _call_func(self, impl, args, kw):
+    # Note that `_pytest.outcomes.Skipped` is derived from BaseException.
+    exceptions = Exception,
+    if _is_pytest_available:
+        exceptions += _pytest.outcomes.Skipped,
+
     try:
         result = impl(self, *args, **kw)
         error = None
         tb = None
-    except Exception as e:
+    except exceptions as e:
         tb = e.__traceback__
         if tb.tb_next is None:
             # failed before impl is called, e.g. invalid kw
@@ -127,8 +134,12 @@ def _fail_test_with_unexpected_errors(
 def _check_cupy_numpy_error(self, cupy_error, cupy_tb, numpy_error,
                             numpy_tb, accept_error=False):
     # Skip the test if both raised SkipTest.
-    if (isinstance(cupy_error, unittest.SkipTest)
-            and isinstance(numpy_error, unittest.SkipTest)):
+    if (isinstance(cupy_error, _skip_classes)
+            and isinstance(numpy_error, _skip_classes)):
+        if cupy_error.__class__ is not numpy_error.__class__:
+            raise AssertionError(
+                'Both numpy and cupy were skipped but with different '
+                'exceptions.')
         if cupy_error.args != numpy_error.args:
             raise AssertionError(
                 'Both numpy and cupy were skipped but with different causes.')

--- a/tests/cupy_tests/indexing_tests/test_indexing.py
+++ b/tests/cupy_tests/indexing_tests/test_indexing.py
@@ -38,11 +38,11 @@ class TestIndexing(unittest.TestCase):
     def test_take_index_range_overflow(self, xp, dtype):
         # Skip for too large dimensions
         if numpy.dtype(dtype) in (numpy.int64, numpy.uint64):
-            return xp.array([])
+            pytest.skip()
         # Skip because NumPy actually allocates a contiguous array in the
         # `take` below to require much time.
         if dtype in (numpy.int32, numpy.uint32):
-            return xp.array([])
+            pytest.skip()
         iinfo = numpy.iinfo(dtype)
         a = xp.broadcast_to(xp.ones(1), (iinfo.max + 1,))
         b = xp.array([0], dtype=dtype)

--- a/tests/cupy_tests/indexing_tests/test_iterate.py
+++ b/tests/cupy_tests/indexing_tests/test_iterate.py
@@ -85,7 +85,7 @@ class TestFlatiterSubscript(unittest.TestCase):
     @testing.numpy_cupy_array_equal()
     def test_setitem_ndarray_1d(self, xp, dtype, order):
         if numpy.isscalar(self.index):
-            return xp.array([])  # skip
+            pytest.skip()
         a = xp.zeros(self.shape, dtype=dtype, order=order)
         v = testing.shaped_arange((3,), xp, dtype, order)
         a.flat[self.index] = v
@@ -96,7 +96,7 @@ class TestFlatiterSubscript(unittest.TestCase):
     @testing.numpy_cupy_array_equal()
     def test_setitem_ndarray_nd(self, xp, dtype, order):
         if numpy.isscalar(self.index):
-            return xp.array([])  # skip
+            pytest.skip()
         a = xp.zeros(self.shape, dtype=dtype, order=order)
         v = testing.shaped_arange((2, 3), xp, dtype, order)
         a.flat[self.index] = v
@@ -108,7 +108,7 @@ class TestFlatiterSubscript(unittest.TestCase):
     def test_setitem_ndarray_different_types(
             self, xp, a_dtype, v_dtype, order):
         if numpy.isscalar(self.index):
-            return xp.array([])  # skip
+            pytest.skip()
         a = xp.zeros(self.shape, dtype=a_dtype, order=order)
         v = testing.shaped_arange((3,), xp, v_dtype, order)
         with warnings.catch_warnings():

--- a/tests/cupy_tests/linalg_tests/test_einsum.py
+++ b/tests/cupy_tests/linalg_tests/test_einsum.py
@@ -341,9 +341,7 @@ class TestEinSumUnaryOperation(unittest.TestCase):
     @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_einsum_unary_dtype(self, xp, dtype_a, dtype_out):
         if not numpy.can_cast(dtype_a, dtype_out):
-            # skip this combination
-            return xp.array([])
-
+            pytest.skip()
         a = testing.shaped_arange(self.shape_a, xp, dtype_a)
         return xp.einsum(self.subscripts, a, dtype=dtype_out)
 

--- a/tests/cupy_tests/math_tests/test_matmul.py
+++ b/tests/cupy_tests/math_tests/test_matmul.py
@@ -112,7 +112,7 @@ class TestMatmulLarge(unittest.TestCase):
     def test_operator_matmul(self, xp, dtype1, dtype2):
         if ((dtype1, dtype2) in self.skip_dtypes or
                 (dtype2, dtype1) in self.skip_dtypes):
-            return xp.array([])
+            pytest.skip()
         x1 = testing.shaped_random(self.shape_pair[0], xp, dtype1)
         x2 = testing.shaped_random(self.shape_pair[1], xp, dtype2)
         return operator.matmul(x1, x2)
@@ -123,7 +123,7 @@ class TestMatmulLarge(unittest.TestCase):
     def test_cupy_matmul(self, xp, dtype1, dtype2):
         if ((dtype1, dtype2) in self.skip_dtypes or
                 (dtype2, dtype1) in self.skip_dtypes):
-            return xp.array([])
+            pytest.skip()
         shape1, shape2 = self.shape_pair
         x1 = testing.shaped_random(shape1, xp, dtype1)
         x2 = testing.shaped_random(shape2, xp, dtype2)
@@ -132,11 +132,9 @@ class TestMatmulLarge(unittest.TestCase):
 
 class TestMatmulOverflow(unittest.TestCase):
 
-    @testing.for_int_dtypes(name='dtype')
+    @testing.for_int_dtypes(name='dtype', no_bool=True)
     @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-3)  # required for uint8
     def test_overflow(self, xp, dtype):
-        if dtype is numpy.bool_:
-            return xp.array([])
         value = numpy.iinfo(dtype).max
         a = xp.array([value - 10]).astype(dtype)
         b = xp.array([value - 10]).astype(dtype)

--- a/tests/cupy_tests/math_tests/test_sumprod.py
+++ b/tests/cupy_tests/math_tests/test_sumprod.py
@@ -134,7 +134,7 @@ class TestSumprod(unittest.TestCase):
     @testing.numpy_cupy_allclose()
     def test_sum_dtype(self, xp, src_dtype, dst_dtype):
         if not xp.can_cast(src_dtype, dst_dtype):
-            return xp.array([])  # skip
+            pytest.skip()
         a = testing.shaped_arange((2, 3, 4), xp, src_dtype)
         return a.sum(dtype=dst_dtype)
 
@@ -142,7 +142,7 @@ class TestSumprod(unittest.TestCase):
     @testing.numpy_cupy_allclose()
     def test_sum_keepdims_and_dtype(self, xp, src_dtype, dst_dtype):
         if not xp.can_cast(src_dtype, dst_dtype):
-            return xp.array([])  # skip
+            pytest.skip()
         a = testing.shaped_arange((2, 3, 4), xp, src_dtype)
         return a.sum(axis=2, dtype=dst_dtype, keepdims=True)
 
@@ -194,7 +194,7 @@ class TestSumprod(unittest.TestCase):
     @testing.numpy_cupy_allclose()
     def test_prod_dtype(self, xp, src_dtype, dst_dtype):
         if not xp.can_cast(src_dtype, dst_dtype):
-            return xp.array([])  # skip
+            pytest.skip()
         a = testing.shaped_arange((2, 3), xp, src_dtype)
         return a.prod(dtype=dst_dtype)
 

--- a/tests/cupy_tests/testing_tests/test_helper.py
+++ b/tests/cupy_tests/testing_tests/test_helper.py
@@ -329,6 +329,23 @@ class TestSkip(unittest.TestCase):
         raise unittest.SkipTest('Test for skip with @numpy_cupy_equal')
         assert False
 
+    @testing.for_all_dtypes()
+    def test_dtypes(self, dtype):
+        if dtype is cupy.float32:
+            pytest.skip('Test for skipping a dtype in @for_all_dtypes')
+            assert False
+        else:
+            assert True
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose()
+    def test_allclose_dtypes(self, xp, dtype):
+        if dtype is xp.float32:
+            pytest.skip('Test for skipping a dtype in @for_all_dtypes')
+            assert False
+        else:
+            return xp.array(True)
+
 
 class TestSkipFail(unittest.TestCase):
 
@@ -355,3 +372,15 @@ class TestSkipFail(unittest.TestCase):
             return xp.array(True)
         else:
             raise unittest.SkipTest('skip')
+
+    @pytest.mark.xfail(strict=True)
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose()
+    def test_only_cupy_dtype(self, xp, dtype):
+        if dtype is not xp.float32:
+            return xp.array(True)
+
+        if xp is numpy:
+            return xp.array(True)
+        else:
+            pytest.skip('skip')

--- a/tests/cupy_tests/testing_tests/test_helper.py
+++ b/tests/cupy_tests/testing_tests/test_helper.py
@@ -290,78 +290,95 @@ class TestGenerateMatrixInvalid(unittest.TestCase):
                 (0, 2, 2), singular_values=numpy.ones(3))
 
 
+@testing.parameterize(*testing.product({
+    'framework': ['unittest', 'pytest']
+}))
 class TestSkip(unittest.TestCase):
+
+    def _skip(self, reason):
+        if self.framework == 'unittest':
+            raise unittest.SkipTest(reason)
+        else:
+            pytest.skip(reason)
 
     @testing.numpy_cupy_allclose()
     def test_allclose(self, xp):
-        raise unittest.SkipTest('Test for skip with @numpy_cupy_allclose')
+        self._skip('Test for skip with @numpy_cupy_allclose')
         assert False
 
     @testing.numpy_cupy_array_almost_equal()
     def test_array_almost_equal(self, xp):
-        raise unittest.SkipTest(
-            'Test for skip with @numpy_cupy_array_almost_equal')
+        raise self._skip('Test for skip with @numpy_cupy_array_almost_equal')
         assert False
 
     @testing.numpy_cupy_array_almost_equal_nulp()
     def test_array_almost_equal_nulp(self, xp):
-        raise unittest.SkipTest(
+        raise self._skip(
             'Test for skip with @numpy_cupy_array_almost_equal_nulp')
         assert False
 
     @testing.numpy_cupy_array_max_ulp()
     def test_array_max_ulp(self, xp):
-        raise unittest.SkipTest('Test for skip with @numpy_cupy_array_max_ulp')
+        raise self._skip('Test for skip with @numpy_cupy_array_max_ulp')
         assert False
 
     @testing.numpy_cupy_array_equal()
     def test_array_equal(self, xp):
-        raise unittest.SkipTest('Test for skip with @numpy_cupy_array_equal')
+        raise self._skip('Test for skip with @numpy_cupy_array_equal')
         assert False
 
     @testing.numpy_cupy_array_less()
     def test_less(self, xp):
-        raise unittest.SkipTest('Test for skip with @numpy_cupy_array_less')
+        raise self._skip('Test for skip with @numpy_cupy_array_less')
         assert False
 
     @testing.numpy_cupy_equal()
     def test_equal(self, xp):
-        raise unittest.SkipTest('Test for skip with @numpy_cupy_equal')
+        raise self._skip('Test for skip with @numpy_cupy_equal')
         assert False
 
     @testing.for_all_dtypes()
     def test_dtypes(self, dtype):
         if dtype is cupy.float32:
-            pytest.skip('Test for skipping a dtype in @for_all_dtypes')
+            raise self._skip('Test for skipping a dtype in @for_all_dtypes')
             assert False
         else:
             assert True
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
-    def test_allclose_dtypes(self, xp, dtype):
+    def test_dtypes_allclose(self, xp, dtype):
         if dtype is xp.float32:
-            pytest.skip('Test for skipping a dtype in @for_all_dtypes')
+            raise self._skip('Test for skipping a dtype in @for_all_dtypes')
             assert False
         else:
             return xp.array(True)
 
 
+@testing.parameterize(*testing.product({
+    'framework': ['unittest', 'pytest']
+}))
 class TestSkipFail(unittest.TestCase):
+
+    def _skip(self, reason):
+        if self.framework == 'unittest':
+            raise unittest.SkipTest(reason)
+        else:
+            pytest.skip(reason)
 
     @pytest.mark.xfail(strict=True)
     @testing.numpy_cupy_allclose()
     def test_different_reason(self, xp):
         if xp is numpy:
-            raise unittest.SkipTest('skip1')
+            self._skip('skip1')
         else:
-            raise unittest.SkipTest('skip2')
+            self._skip('skip2')
 
     @pytest.mark.xfail(strict=True)
     @testing.numpy_cupy_allclose()
     def test_only_numpy(self, xp):
         if xp is numpy:
-            raise unittest.SkipTest('skip')
+            self._skip('skip')
         else:
             return xp.array(True)
 
@@ -371,16 +388,16 @@ class TestSkipFail(unittest.TestCase):
         if xp is numpy:
             return xp.array(True)
         else:
-            raise unittest.SkipTest('skip')
+            self._skip('skip')
 
     @pytest.mark.xfail(strict=True)
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
-    def test_only_cupy_dtype(self, xp, dtype):
+    def test_dtype_only_cupy(self, xp, dtype):
         if dtype is not xp.float32:
             return xp.array(True)
 
         if xp is numpy:
             return xp.array(True)
         else:
-            pytest.skip('skip')
+            self._skip('skip')


### PR DESCRIPTION
This PR makes parameterized dtype test possible to skip a test for a specific dtype by `pytest.skip`. 

Once `unittest` was used as CuPy's unit test framework, and we could skip it by `raise unittest.SkipTest()`. It seems that, however, the code was not properly updated when we replaced `unittest` with `pytest` and we need to return a dummy array for that purpose.
