### PR TITLE
ROCm: Support RCCL

### DIFF
--- a/.pfnci/script.sh
+++ b/.pfnci/script.sh
@@ -76,7 +76,7 @@ main() {
       #echo 'deb [arch=amd64] http://repo.radeon.com/rocm/apt/debian/ xenial main' | tee /etc/apt/sources.list.d/rocm.list
 
       apt update -qqy
-      apt install rocm-dev hipblas hipsparse rocsparse rocrand rocthrust rocsolver rocfft hipcub rocprim -qqy
+      apt install rocm-dev hipblas hipsparse rocsparse rocrand rocthrust rocsolver rocfft hipcub rocprim rccl -qqy
       export HCC_AMDGPU_TARGET=gfx900
       export ROCM_HOME=/opt/rocm
       export CUPY_INSTALL_USE_HIP=1

--- a/cupy/cuda/cupy_nccl.h
+++ b/cupy/cuda/cupy_nccl.h
@@ -5,7 +5,7 @@
 
 #define UNUSED(x) ((void)x)
 
-#ifndef CUPY_NO_CUDA
+#if !defined(CUPY_NO_CUDA) && !defined(CUPY_USE_HIP)
 
 #include <nccl.h>
 
@@ -14,6 +14,11 @@
 #define ncclHalf ((ncclDataType_t)2)
 #endif
 #endif
+
+#elif defined(CUPY_USE_HIP)
+
+#include <rccl.h>
+typedef hipStream_t cudaStream_t;
 
 #else // #ifndef CUPY_NO_CUDA
 

--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -256,6 +256,21 @@ else:
         'version_method': build.get_cub_version,
     })
 
+    MODULES.append({
+        'name': 'nccl',
+        'file': [
+            'cupy.cuda.nccl',
+        ],
+        'include': [
+            'rccl.h',
+        ],
+        'libraries': [
+            'rccl',
+        ],
+        'check_method': build.check_nccl_version,
+        'version_method': build.get_nccl_version,
+    })
+
 if bool(int(os.environ.get('CUPY_SETUP_ENABLE_THRUST', 1))):
     if use_hip:
         MODULES.append({

--- a/docs/source/install_rocm.rst
+++ b/docs/source/install_rocm.rst
@@ -28,7 +28,7 @@ And please install ROCm libraries.
 
 ::
 
-  $ sudo apt install hipblas hipsparse rocsparse rocrand rocthrust rocsolver rocfft hipcub rocprim
+  $ sudo apt install hipblas hipsparse rocsparse rocrand rocthrust rocsolver rocfft hipcub rocprim rccl
 
 
 Before installing CuPy, we recommend you to upgrade ``setuptools`` and ``pip``::


### PR DESCRIPTION
Close #3927. All tests in `tests/cupy_tests/cuda_tests/test_nccl.py` passed locally, but I only have 1 GPU, so we might need further tests to ensure it's working with multi-GPUs.

This works because RCCL uses exactly the same API names as in NCCL, so we don't even need a shim layer to wrap the names!