### PR TITLE
[backport] Add `order` option in `cupy.testing.shaped_random`

### DIFF
--- a/cupy/testing/helper.py
+++ b/cupy/testing/helper.py
@@ -1210,7 +1210,8 @@ def shaped_reverse_arange(shape, xp=cupy, dtype=numpy.float32):
     return xp.array(a.astype(dtype).reshape(shape))
 
 
-def shaped_random(shape, xp=cupy, dtype=numpy.float32, scale=10, seed=0):
+def shaped_random(
+        shape, xp=cupy, dtype=numpy.float32, scale=10, seed=0, order='C'):
     """Returns an array filled with random values.
 
     Args:
@@ -1235,12 +1236,13 @@ def shaped_random(shape, xp=cupy, dtype=numpy.float32, scale=10, seed=0):
     numpy.random.seed(seed)
     dtype = numpy.dtype(dtype)
     if dtype == '?':
-        return xp.asarray(numpy.random.randint(2, size=shape), dtype=dtype)
+        a = numpy.random.randint(2, size=shape)
     elif dtype.kind == 'c':
         a = numpy.random.rand(*shape) + 1j * numpy.random.rand(*shape)
-        return xp.asarray(a * scale, dtype=dtype)
+        a *= scale
     else:
-        return xp.asarray(numpy.random.rand(*shape) * scale, dtype=dtype)
+        a = numpy.random.rand(*shape) * scale
+    return xp.asarray(a, dtype=dtype, order=order)
 
 
 def shaped_sparse_random(

--- a/tests/cupy_tests/core_tests/test_ndarray_reduction.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_reduction.py
@@ -241,11 +241,7 @@ class TestCubReduction(unittest.TestCase):
     @testing.for_all_dtypes(no_bool=True, no_float16=True)
     @testing.numpy_cupy_allclose(rtol=1E-5)
     def test_cub_min(self, xp, dtype, axis):
-        a = testing.shaped_random(self.shape, xp, dtype)
-        if self.order in ('c', 'C'):
-            a = xp.ascontiguousarray(a)
-        elif self.order in ('f', 'F'):
-            a = xp.asfortranarray(a)
+        a = testing.shaped_random(self.shape, xp, dtype, order=self.order)
 
         if xp is numpy:
             return a.min(axis=axis)
@@ -264,22 +260,14 @@ class TestCubReduction(unittest.TestCase):
     @testing.for_all_dtypes(no_bool=True, no_float16=True)
     @testing.numpy_cupy_allclose(rtol=1E-5, contiguous_check=False)
     def test_cub_min_empty_axis(self, xp, dtype, contiguous_check=False):
-        a = testing.shaped_random(self.shape, xp, dtype)
-        if self.order in ('c', 'C'):
-            a = xp.ascontiguousarray(a)
-        elif self.order in ('f', 'F'):
-            a = xp.asfortranarray(a)
+        a = testing.shaped_random(self.shape, xp, dtype, order=self.order)
         return a.min(axis=())
 
     @testing.for_contiguous_axes()
     @testing.for_all_dtypes(no_bool=True, no_float16=True)
     @testing.numpy_cupy_allclose(rtol=1E-5)
     def test_cub_max(self, xp, dtype, axis):
-        a = testing.shaped_random(self.shape, xp, dtype)
-        if self.order in ('c', 'C'):
-            a = xp.ascontiguousarray(a)
-        elif self.order in ('f', 'F'):
-            a = xp.asfortranarray(a)
+        a = testing.shaped_random(self.shape, xp, dtype, order=self.order)
 
         if xp is numpy:
             return a.max(axis=axis)
@@ -298,11 +286,7 @@ class TestCubReduction(unittest.TestCase):
     @testing.for_all_dtypes(no_bool=True, no_float16=True)
     @testing.numpy_cupy_allclose(rtol=1E-5, contiguous_check=False)
     def test_cub_max_empty_axis(self, xp, dtype):
-        a = testing.shaped_random(self.shape, xp, dtype)
-        if self.order in ('c', 'C'):
-            a = xp.ascontiguousarray(a)
-        elif self.order in ('f', 'F'):
-            a = xp.asfortranarray(a)
+        a = testing.shaped_random(self.shape, xp, dtype, order=self.order)
         return a.max(axis=())
 
 
@@ -329,40 +313,24 @@ class TestUnacceleratedReduction(unittest.TestCase):
     @testing.for_all_dtypes(no_bool=True, no_float16=True)
     @testing.numpy_cupy_allclose(rtol=1E-5, contiguous_check=False)
     def test_unaccelerated_min(self, xp, dtype, axis):
-        a = testing.shaped_random(self.shape, xp, dtype)
-        if self.order in ('c', 'C'):
-            a = xp.ascontiguousarray(a)
-        elif self.order in ('f', 'F'):
-            a = xp.asfortranarray(a)
+        a = testing.shaped_random(self.shape, xp, dtype, order=self.order)
         return a.min(axis=axis)
 
     @testing.for_all_dtypes(no_bool=True, no_float16=True)
     @testing.numpy_cupy_allclose(rtol=1E-5, contiguous_check=False)
     def test_unaccelerated_min_empty_axis(self, xp, dtype):
-        a = testing.shaped_random(self.shape, xp, dtype)
-        if self.order in ('c', 'C'):
-            a = xp.ascontiguousarray(a)
-        elif self.order in ('f', 'F'):
-            a = xp.asfortranarray(a)
+        a = testing.shaped_random(self.shape, xp, dtype, order=self.order)
         return a.min(axis=())
 
     @testing.for_contiguous_axes()
     @testing.for_all_dtypes(no_bool=True, no_float16=True)
     @testing.numpy_cupy_allclose(rtol=1E-5, contiguous_check=False)
     def test_unaccelerated_max(self, xp, dtype, axis):
-        a = testing.shaped_random(self.shape, xp, dtype)
-        if self.order in ('c', 'C'):
-            a = xp.ascontiguousarray(a)
-        elif self.order in ('f', 'F'):
-            a = xp.asfortranarray(a)
+        a = testing.shaped_random(self.shape, xp, dtype, order=self.order)
         return a.max(axis=axis)
 
     @testing.for_all_dtypes(no_bool=True, no_float16=True)
     @testing.numpy_cupy_allclose(rtol=1E-5, contiguous_check=False)
     def test_unaccelerated_max_empty_axis(self, xp, dtype):
-        a = testing.shaped_random(self.shape, xp, dtype)
-        if self.order in ('c', 'C'):
-            a = xp.ascontiguousarray(a)
-        elif self.order in ('f', 'F'):
-            a = xp.asfortranarray(a)
+        a = testing.shaped_random(self.shape, xp, dtype, order=self.order)
         return a.max(axis=())


### PR DESCRIPTION
Backport of #4091