### PR TITLE
ROCm: Fix `getDeviceProperties` for HIP

### DIFF
--- a/cupy_backends/cuda/api/runtime.pxd
+++ b/cupy_backends/cuda/api/runtime.pxd
@@ -415,8 +415,29 @@ cdef extern from *:
             int          cooperativeMultiDeviceLaunch
             size_t       sharedMemPerBlockOptin
     ELIF use_hip:
-        ctypedef struct hipDeviceArch_t 'hipDeviceArch_t':
-            pass
+        ctypedef struct deviceArch 'hipDeviceArch_t':
+            unsigned hasGlobalInt32Atomics
+            unsigned hasGlobalFloatAtomicExch
+            unsigned hasSharedInt32Atomics
+            unsigned hasSharedFloatAtomicExch
+            unsigned hasFloatAtomicAdd
+
+            unsigned hasGlobalInt64Atomics
+            unsigned hasSharedInt64Atomics
+
+            unsigned hasDoubles
+
+            unsigned hasWarpVote
+            unsigned hasWarpBallot
+            unsigned hasWarpShuffle
+            unsigned hasFunnelShift
+
+            unsigned hasThreadFenceSystem
+            unsigned hasSyncThreadsExt
+
+            unsigned hasSurfaceFuncs
+            unsigned has3dGrid
+            unsigned hasDynamicParallelism
 
         ctypedef struct cudaDeviceProp 'cudaDeviceProp':
             char name[256]
@@ -438,7 +459,7 @@ cdef extern from *:
             int maxThreadsPerMultiProcessor
             int computeMode
             int clockInstructionRate
-            hipDeviceArch_t arch
+            deviceArch arch
             int concurrentKernels
             int pciDomainID
             int pciBusID

--- a/cupy_backends/cuda/api/runtime.pxd
+++ b/cupy_backends/cuda/api/runtime.pxd
@@ -466,6 +466,9 @@ cdef extern from *:
             int cooperativeMultiDeviceUnmatchedBlockDim
             int cooperativeMultiDeviceUnmatchedSharedMem
             int isLargeBar
+    ELSE:  # for RTD
+        ctypedef struct cudaDeviceProp 'cudaDeviceProp':
+            char         name[256]
 
 
 ###############################################################################

--- a/cupy_backends/cuda/api/runtime.pxd
+++ b/cupy_backends/cuda/api/runtime.pxd
@@ -340,7 +340,7 @@ cdef extern from *:
             size_t       sharedMemPerBlockOptin
             int          pageableMemoryAccessUsesHostPageTables
             int          directManagedMemAccessFromHost
-    ELSE:
+    ELIF CUDA_VERSION == 9000:
         # CUDA 9.0
         ctypedef struct cudaDeviceProp 'cudaDeviceProp':
             char         name[256]
@@ -414,6 +414,59 @@ cdef extern from *:
             int          cooperativeLaunch
             int          cooperativeMultiDeviceLaunch
             size_t       sharedMemPerBlockOptin
+    ELIF use_hip:
+        ctypedef struct hipDeviceArch_t 'hipDeviceArch_t':
+            pass
+
+        ctypedef struct cudaDeviceProp 'cudaDeviceProp':
+            char name[256]
+            size_t totalGlobalMem
+            size_t sharedMemPerBlock
+            int regsPerBlock
+            int warpSize
+            int maxThreadsPerBlock
+            int maxThreadsDim[3]
+            int maxGridSize[3]
+            int clockRate
+            int memoryClockRate
+            int memoryBusWidth
+            size_t totalConstMem
+            int major
+            int minor
+            int multiProcessorCount
+            int l2CacheSize
+            int maxThreadsPerMultiProcessor
+            int computeMode
+            int clockInstructionRate
+            hipDeviceArch_t arch
+            int concurrentKernels
+            int pciDomainID
+            int pciBusID
+            int pciDeviceID
+            size_t maxSharedMemoryPerMultiProcessor
+            int isMultiGpuBoard
+            int canMapHostMemory
+            int gcnArch
+            int integrated
+            int cooperativeLaunch
+            int cooperativeMultiDeviceLaunch
+            int maxTexture1D
+            int maxTexture2D[2]
+            int maxTexture3D[3]
+            unsigned int* hdpMemFlushCntl
+            unsigned int* hdpRegFlushCntl
+            size_t memPitch
+            size_t textureAlignment
+            size_t texturePitchAlignment
+            int kernelExecTimeoutEnabled
+            int ECCEnabled
+            int tccDriver
+            int cooperativeMultiDeviceUnmatchedFunc
+            int cooperativeMultiDeviceUnmatchedGridDim
+            int cooperativeMultiDeviceUnmatchedBlockDim
+            int cooperativeMultiDeviceUnmatchedSharedMem
+            int isLargeBar
+
 
 ###############################################################################
 # Enum

--- a/cupy_backends/cuda/api/runtime.pyx
+++ b/cupy_backends/cuda/api/runtime.pyx
@@ -286,8 +286,9 @@ cpdef getDeviceProperties(int device):
     cdef int status = cudaGetDeviceProperties(&props, device)
     check_status(status)
 
-    # Common properties to CUDA 9.0, 9.2, 10.x and 11.x
-    properties = {'name': 'UNAVAILABLE'}  # for RTD
+    cdef dict properties = {'name': 'UNAVAILABLE'}  # for RTD
+
+    # Common properties to CUDA 9.0, 9.2, 10.x, 11.x, and HIP
     IF CUDA_VERSION > 0 or use_hip:
         properties = {
             'name': props.name,
@@ -337,25 +338,30 @@ cpdef getDeviceProperties(int device):
         properties['maxTexture2DGather'] = tuple(props.maxTexture2DGather)
         properties['maxTexture3DAlt'] = tuple(props.maxTexture3DAlt)
         properties['maxTextureCubemap'] = props.maxTextureCubemap
-        properties['maxTextureCubemapLayered'] = tuple(props.maxTextureCubemapLayered)
+        properties['maxTextureCubemapLayered'] = tuple(
+            props.maxTextureCubemapLayered)
         properties['maxSurface1D'] = props.maxSurface1D
         properties['maxSurface1DLayered'] = tuple(props.maxSurface1DLayered)
         properties['maxSurface2D'] = tuple(props.maxSurface2D)
         properties['maxSurface2DLayered'] = tuple(props.maxSurface2DLayered)
         properties['maxSurface3D'] = tuple(props.maxSurface3D)
         properties['maxSurfaceCubemap'] = props.maxSurfaceCubemap
-        properties['maxSurfaceCubemapLayered'] = tuple(props.maxSurfaceCubemapLayered)
+        properties['maxSurfaceCubemapLayered'] = tuple(
+            props.maxSurfaceCubemapLayered)
         properties['surfaceAlignment'] = props.surfaceAlignment
         properties['asyncEngineCount'] = props.asyncEngineCount
         properties['unifiedAddressing'] = props.unifiedAddressing
-        properties['streamPrioritiesSupported'] = props.streamPrioritiesSupported
+        properties['streamPrioritiesSupported'] = (
+            props.streamPrioritiesSupported)
         properties['globalL1CacheSupported'] = props.globalL1CacheSupported
         properties['localL1CacheSupported'] = props.localL1CacheSupported
-        properties['sharedMemPerMultiprocessor'] = props.sharedMemPerMultiprocessor
+        properties['sharedMemPerMultiprocessor'] = (
+            props.sharedMemPerMultiprocessor)
         properties['regsPerMultiprocessor'] = props.regsPerMultiprocessor
         properties['managedMemory'] = props.managedMemory
         properties['multiGpuBoardGroupID'] = props.multiGpuBoardGroupID
-        properties['hostNativeAtomicSupported'] = props.hostNativeAtomicSupported
+        properties['hostNativeAtomicSupported'] = (
+            props.hostNativeAtomicSupported)
         properties['singleToDoublePrecisionPerfRatio'] = (
             props.singleToDoublePrecisionPerfRatio)
         properties['pageableMemoryAccess'] = props.pageableMemoryAccess
@@ -381,7 +387,6 @@ cpdef getDeviceProperties(int device):
         properties['reservedSharedMemPerBlock'] = (
             props.reservedSharedMemPerBlock)
     IF use_hip:
-        # TODO(leofang): support hipDeviceArch_t
         properties['clockInstructionRate'] = props.clockInstructionRate
         properties['maxSharedMemoryPerMultiProcessor'] = (
             props.maxSharedMemoryPerMultiProcessor)
@@ -398,6 +403,28 @@ cpdef getDeviceProperties(int device):
         properties['cooperativeMultiDeviceUnmatchedSharedMem'] = (
             props.cooperativeMultiDeviceUnmatchedSharedMem)
         properties['isLargeBar'] = props.isLargeBar
+
+        # flatten "hipDeviceArch_t" into properties
+        # TODO(leofang): this might not be desired in some occasions?
+        properties['hasGlobalInt32Atomics'] = props.arch.hasGlobalInt32Atomics
+        properties['hasGlobalFloatAtomicExch'] = (
+            props.arch.hasGlobalFloatAtomicExch)
+        properties['hasSharedInt32Atomics'] = props.arch.hasSharedInt32Atomics
+        properties['hasSharedFloatAtomicExch'] = (
+            props.arch.hasSharedFloatAtomicExch)
+        properties['hasFloatAtomicAdd'] = props.arch.hasFloatAtomicAdd
+        properties['hasGlobalInt64Atomics'] = props.arch.hasGlobalInt64Atomics
+        properties['hasSharedInt64Atomics'] = props.arch.hasSharedInt64Atomics
+        properties['hasDoubles'] = props.arch.hasDoubles
+        properties['hasWarpVote'] = props.arch.hasWarpVote
+        properties['hasWarpBallot'] = props.arch.hasWarpBallot
+        properties['hasWarpShuffle'] = props.arch.hasWarpShuffle
+        properties['hasFunnelShift'] = props.arch.hasFunnelShift
+        properties['hasThreadFenceSystem'] = props.arch.hasThreadFenceSystem
+        properties['hasSyncThreadsExt'] = props.arch.hasSyncThreadsExt
+        properties['hasSurfaceFuncs'] = props.arch.hasSurfaceFuncs
+        properties['has3dGrid'] = props.arch.has3dGrid
+        properties['hasDynamicParallelism'] = props.arch.hasDynamicParallelism
     return properties
 
 cpdef int deviceGetByPCIBusId(str pci_bus_id) except? -1:

--- a/cupy_backends/cuda/api/runtime.pyx
+++ b/cupy_backends/cuda/api/runtime.pyx
@@ -283,10 +283,12 @@ cpdef int deviceGetAttribute(int attrib, int device) except? -1:
 
 cpdef getDeviceProperties(int device):
     cdef cudaDeviceProp props
-    status = cudaGetDeviceProperties(&props, device)
+    cdef int status = cudaGetDeviceProperties(&props, device)
+    check_status(status)
+
     # Common properties to CUDA 9.0, 9.2, 10.x and 11.x
-    properties = {'name': 'UNAVAILABLE'}
-    IF CUDA_VERSION >= 9020:
+    properties = {'name': 'UNAVAILABLE'}  # for RTD
+    IF CUDA_VERSION > 0 or use_hip:
         properties = {
             'name': props.name,
             'totalGlobalMem': props.totalGlobalMem,
@@ -302,67 +304,67 @@ cpdef getDeviceProperties(int device):
             'minor': props.minor,
             'textureAlignment': props.textureAlignment,
             'texturePitchAlignment': props.texturePitchAlignment,
-            'deviceOverlap': props.deviceOverlap,
             'multiProcessorCount': props.multiProcessorCount,
             'kernelExecTimeoutEnabled': props.kernelExecTimeoutEnabled,
             'integrated': props.integrated,
             'canMapHostMemory': props.canMapHostMemory,
             'computeMode': props.computeMode,
             'maxTexture1D': props.maxTexture1D,
-            'maxTexture1DMipmap': props.maxTexture1DMipmap,
-            'maxTexture1DLinear': props.maxTexture1DLinear,
             'maxTexture2D': tuple(props.maxTexture2D),
-            'maxTexture2DMipmap': tuple(props.maxTexture2DMipmap),
-            'maxTexture2DLinear': tuple(props.maxTexture2DLinear),
-            'maxTexture2DGather': tuple(props.maxTexture2DGather),
             'maxTexture3D': tuple(props.maxTexture3D),
-            'maxTexture3DAlt': tuple(props.maxTexture3DAlt),
-            'maxTextureCubemap': props.maxTextureCubemap,
-            'maxTexture1DLayered': tuple(props.maxTexture1DLayered),
-            'maxTexture2DLayered': tuple(props.maxTexture2DLayered),
-            'maxTextureCubemapLayered': tuple(props.maxTextureCubemapLayered),
-            'maxSurface1D': props.maxSurface1D,
-            'maxSurface2D': tuple(props.maxSurface2D),
-            'maxSurface3D': tuple(props.maxSurface3D),
-            'maxSurface1DLayered': tuple(props.maxSurface1DLayered),
-            'maxSurface2DLayered': tuple(props.maxSurface2DLayered),
-            'maxSurfaceCubemap': props.maxSurfaceCubemap,
-            'maxSurfaceCubemapLayered': tuple(props.maxSurfaceCubemapLayered),
-            'surfaceAlignment': props.surfaceAlignment,
             'concurrentKernels': props.concurrentKernels,
             'ECCEnabled': props.ECCEnabled,
             'pciBusID': props.pciBusID,
             'pciDeviceID': props.pciDeviceID,
             'pciDomainID': props.pciDomainID,
             'tccDriver': props.tccDriver,
-            'asyncEngineCount': props.asyncEngineCount,
-            'unifiedAddressing': props.unifiedAddressing,
             'memoryClockRate': props.memoryClockRate,
             'memoryBusWidth': props.memoryBusWidth,
             'l2CacheSize': props.l2CacheSize,
             'maxThreadsPerMultiProcessor': props.maxThreadsPerMultiProcessor,
-            'streamPrioritiesSupported': props.streamPrioritiesSupported,
-            'globalL1CacheSupported': props.globalL1CacheSupported,
-            'localL1CacheSupported': props.localL1CacheSupported,
-            'sharedMemPerMultiprocessor': props.sharedMemPerMultiprocessor,
-            'regsPerMultiprocessor': props.regsPerMultiprocessor,
-            'managedMemory': props.managedMemory,
             'isMultiGpuBoard': props.isMultiGpuBoard,
-            'multiGpuBoardGroupID': props.multiGpuBoardGroupID,
-            'hostNativeAtomicSupported': props.hostNativeAtomicSupported,
-            'singleToDoublePrecisionPerfRatio':
-                props.singleToDoublePrecisionPerfRatio,
-            'pageableMemoryAccess': props.pageableMemoryAccess,
-            'concurrentManagedAccess': props.concurrentManagedAccess,
-            'computePreemptionSupported':
-                props.computePreemptionSupported,
-            'canUseHostPointerForRegisteredMem':
-                props.canUseHostPointerForRegisteredMem,
             'cooperativeLaunch': props.cooperativeLaunch,
             'cooperativeMultiDeviceLaunch': props.cooperativeMultiDeviceLaunch,
-            'sharedMemPerBlockOptin': props.sharedMemPerBlockOptin,
         }
     IF CUDA_VERSION >= 9020:
+        properties['deviceOverlap'] = props.deviceOverlap
+        properties['maxTexture1DMipmap'] = props.maxTexture1DMipmap
+        properties['maxTexture1DLinear'] = props.maxTexture1DLinear
+        properties['maxTexture1DLayered'] = tuple(props.maxTexture1DLayered)
+        properties['maxTexture2DMipmap'] = tuple(props.maxTexture2DMipmap)
+        properties['maxTexture2DLinear'] = tuple(props.maxTexture2DLinear)
+        properties['maxTexture2DLayered'] = tuple(props.maxTexture2DLayered)
+        properties['maxTexture2DGather'] = tuple(props.maxTexture2DGather)
+        properties['maxTexture3DAlt'] = tuple(props.maxTexture3DAlt)
+        properties['maxTextureCubemap'] = props.maxTextureCubemap
+        properties['maxTextureCubemapLayered'] = tuple(props.maxTextureCubemapLayered)
+        properties['maxSurface1D'] = props.maxSurface1D
+        properties['maxSurface1DLayered'] = tuple(props.maxSurface1DLayered)
+        properties['maxSurface2D'] = tuple(props.maxSurface2D)
+        properties['maxSurface2DLayered'] = tuple(props.maxSurface2DLayered)
+        properties['maxSurface3D'] = tuple(props.maxSurface3D)
+        properties['maxSurfaceCubemap'] = props.maxSurfaceCubemap
+        properties['maxSurfaceCubemapLayered'] = tuple(props.maxSurfaceCubemapLayered)
+        properties['surfaceAlignment'] = props.surfaceAlignment
+        properties['asyncEngineCount'] = props.asyncEngineCount
+        properties['unifiedAddressing'] = props.unifiedAddressing
+        properties['streamPrioritiesSupported'] = props.streamPrioritiesSupported
+        properties['globalL1CacheSupported'] = props.globalL1CacheSupported
+        properties['localL1CacheSupported'] = props.localL1CacheSupported
+        properties['sharedMemPerMultiprocessor'] = props.sharedMemPerMultiprocessor
+        properties['regsPerMultiprocessor'] = props.regsPerMultiprocessor
+        properties['managedMemory'] = props.managedMemory
+        properties['multiGpuBoardGroupID'] = props.multiGpuBoardGroupID
+        properties['hostNativeAtomicSupported'] = props.hostNativeAtomicSupported
+        properties['singleToDoublePrecisionPerfRatio'] = (
+            props.singleToDoublePrecisionPerfRatio)
+        properties['pageableMemoryAccess'] = props.pageableMemoryAccess
+        properties['concurrentManagedAccess'] = props.concurrentManagedAccess
+        properties['computePreemptionSupported'] = (
+            props.computePreemptionSupported)
+        properties['canUseHostPointerForRegisteredMem'] = (
+            props.canUseHostPointerForRegisteredMem)
+        properties['sharedMemPerBlockOptin'] = props.sharedMemPerBlockOptin
         properties['uuid'] = props.uuid.bytes
         properties['luid'] = props.luid
         properties['luidDeviceNodeMask'] = props.luidDeviceNodeMask
@@ -378,7 +380,24 @@ cpdef getDeviceProperties(int device):
             props.accessPolicyMaxWindowSize)
         properties['reservedSharedMemPerBlock'] = (
             props.reservedSharedMemPerBlock)
-    check_status(status)
+    IF use_hip:
+        # TODO(leofang): support hipDeviceArch_t
+        properties['clockInstructionRate'] = props.clockInstructionRate
+        properties['maxSharedMemoryPerMultiProcessor'] = (
+            props.maxSharedMemoryPerMultiProcessor)
+        properties['gcnArch'] = props.gcnArch
+        properties['hdpMemFlushCntl'] = <intptr_t>(props.hdpMemFlushCntl)
+        properties['hdpRegFlushCntl'] = <intptr_t>(props.hdpRegFlushCntl)
+        properties['memPitch'] = props.memPitch
+        properties['cooperativeMultiDeviceUnmatchedFunc'] = (
+            props.cooperativeMultiDeviceUnmatchedFunc)
+        properties['cooperativeMultiDeviceUnmatchedGridDim'] = (
+            props.cooperativeMultiDeviceUnmatchedGridDim)
+        properties['cooperativeMultiDeviceUnmatchedBlockDim'] = (
+            props.cooperativeMultiDeviceUnmatchedBlockDim)
+        properties['cooperativeMultiDeviceUnmatchedSharedMem'] = (
+            props.cooperativeMultiDeviceUnmatchedSharedMem)
+        properties['isLargeBar'] = props.isLargeBar
     return properties
 
 cpdef int deviceGetByPCIBusId(str pci_bus_id) except? -1:

--- a/cupyx/_runtime.py
+++ b/cupyx/_runtime.py
@@ -6,6 +6,7 @@ import platform
 import numpy
 
 import cupy
+import cupy_backends
 
 try:
     import cupy.cuda.thrust as thrust
@@ -36,6 +37,8 @@ try:
     import scipy
 except ImportError:
     scipy = None
+
+is_hip = cupy_backends.cuda.api.runtime.is_hip
 
 
 def _eval_or_error(func, errors):
@@ -117,7 +120,10 @@ class _RuntimeInfo(object):
     def __init__(self):
         self.cupy_version = cupy.__version__
 
-        self.cuda_path = cupy.cuda.get_cuda_path()
+        if not is_hip:
+            self.cuda_path = cupy.cuda.get_cuda_path()
+        else:
+            self.cuda_path = cupy._environment.get_rocm_path()
 
         self.cuda_build_version = cupy.cuda.driver.get_build_version()
         self.cuda_driver_version = _eval_or_error(


### PR DESCRIPTION
Close #4107. Follow-up of #3858, so **this PR needs to be backported**.

Output without any error:
```
$ python -c "import cupy; cupy.show_config()"
OS                           : Linux-5.4.0-42-generic-x86_64-with-debian-buster-sid
CuPy Version                 : 8.0.0rc1
NumPy Version                : 1.19.1
SciPy Version                : 1.5.2
CUDA Root                    : /opt/rocm
CUDA Build Version           : 0
CUDA Driver Version          : 313700
CUDA Runtime Version         : 3137
cuBLAS Version               : 22200
cuFFT Version                : 10003839
cuRAND Version               : 201001
cuSOLVER Version             : (3, 5, 0)
cuSPARSE Version             : 0
NVRTC Version                : (9, 0)
Thrust Version               : 100902
CUB Build Version            : 201001
cuDNN Build Version          : None
cuDNN Version                : None
NCCL Build Version           : None
NCCL Runtime Version         : None
cuTENSOR Version             : None
Device 0 Name                : Vega 20
Device 0 Compute Capability  : 96
```