### PR TITLE
[backport] Fix CUB block reduction for F-order arrays with ndim > 2

### DIFF
--- a/cupy/core/_cub_reduction.pyx
+++ b/cupy/core/_cub_reduction.pyx
@@ -3,7 +3,6 @@ from cupy.core cimport _kernel
 from cupy.core cimport _optimize_config
 from cupy.core cimport _reduction
 from cupy.core cimport _scalar
-from cupy.core.core cimport _internal_asfortranarray
 from cupy.core.core cimport compile_with_cache
 from cupy.core.core cimport ndarray
 from cupy.core cimport internal
@@ -263,19 +262,23 @@ cpdef inline tuple _can_use_cub_block_reduction(
     in_arr = in_args[0]
     out_arr = out_args[0]
 
+    # the axes might not be sorted when we arrive here...
+    reduce_axis = tuple(sorted(reduce_axis))
+    out_axis = tuple(sorted(out_axis))
+
     # check reduction axes, if not contiguous then fall back to old kernel
     if in_arr._f_contiguous:
         order = 'F'
         if not cub._cub_device_segmented_reduce_axis_compatible(
                 reduce_axis, in_arr.ndim, order):
             return None
-        axis_permutes_cub = tuple(sorted(reduce_axis) + sorted(out_axis))
+        axis_permutes_cub = reduce_axis + out_axis
     elif in_arr._c_contiguous:
         order = 'C'
         if not cub._cub_device_segmented_reduce_axis_compatible(
                 reduce_axis, in_arr.ndim, order):
             return None
-        axis_permutes_cub = tuple(sorted(out_axis) + sorted(reduce_axis))
+        axis_permutes_cub = out_axis + reduce_axis
     else:
         return None
     if axis_permutes_cub != tuple(range(in_arr.ndim)):
@@ -576,8 +579,9 @@ cdef bint _try_to_call_cub_reduction(
     in_shape = _reduction._set_permuted_args(
         in_args, axis_permutes, a_shape, self.in_params)
 
-    if in_args[0].flags.f_contiguous:
-        ret = out_args[0] = _internal_asfortranarray(ret)
+    if in_args[0]._f_contiguous:
+        ret._set_contiguous_strides(ret.dtype.itemsize, False)
+        out_args[0] = ret
 
     if not full_reduction:  # just need one pass
         out_block_num = 1  # = number of segments

--- a/cupy/core/_reduction.pyx
+++ b/cupy/core/_reduction.pyx
@@ -340,10 +340,6 @@ cdef class _AbstractReductionKernel:
             key = (self.name, shape_and_strides,
                    in_types, out_types, reduce_type, device_id)
 
-        if try_use_cub and in_args[0]._f_contiguous and in_args[0].ndim > 2:
-            # TODO: fix CUB-based reduction on Fortran arrays with ndim > 2
-            try_use_cub = False
-
         # Try to use CUB
         for accelerator in _accelerator._reduction_accelerators:
             if try_use_cub and accelerator == _accelerator.ACCELERATOR_CUB:

--- a/tests/cupy_tests/math_tests/test_sumprod.py
+++ b/tests/cupy_tests/math_tests/test_sumprod.py
@@ -4,6 +4,8 @@ import numpy
 import pytest
 
 import cupy
+import cupy.core._accelerator as _acc
+from cupy.core import _cub_reduction
 from cupy import testing
 
 
@@ -202,17 +204,25 @@ class TestSumprod(unittest.TestCase):
 @testing.parameterize(*testing.product({
     'shape': [(10,), (10, 20), (10, 20, 30), (10, 20, 30, 40)],
     'order': ('C', 'F'),
+    'backend': ('device', 'block'),
 }))
 @testing.gpu
 @unittest.skipUnless(cupy.cuda.cub.available, 'The CUB routine is not enabled')
 class TestCubReduction(unittest.TestCase):
 
     def setUp(self):
-        self.old_accelerators = cupy.core.get_routine_accelerators()
-        cupy.core.set_routine_accelerators(['cub'])
+        self.old_routine_accelerators = _acc.get_routine_accelerators()
+        self.old_reduction_accelerators = _acc.get_reduction_accelerators()
+        if self.backend == 'device':
+            _acc.set_routine_accelerators(['cub'])
+            _acc.set_reduction_accelerators([])
+        elif self.backend == 'block':
+            _acc.set_routine_accelerators([])
+            _acc.set_reduction_accelerators(['cub'])
 
     def tearDown(self):
-        cupy.core.set_routine_accelerators(self.old_accelerators)
+        _acc.set_routine_accelerators(self.old_routine_accelerators)
+        _acc.set_reduction_accelerators(self.old_reduction_accelerators)
 
     @testing.for_contiguous_axes()
     # sum supports less dtypes; don't test float16 as it's not as accurate?
@@ -230,12 +240,26 @@ class TestCubReduction(unittest.TestCase):
 
         # xp is cupy, first ensure we really use CUB
         ret = cupy.empty(())  # Cython checks return type, need to fool it
-        if len(axis) == len(self.shape):
-            func = 'cupy.core._routines_math.cub.device_reduce'
-        else:
-            func = 'cupy.core._routines_math.cub.device_segmented_reduce'
-        with testing.AssertFunctionIsCalled(func, return_value=ret):
-            a.sum(axis=axis)
+        if self.backend == 'device':
+            func_name = 'cupy.core._routines_math.cub.'
+            if len(axis) == len(self.shape):
+                func_name += 'device_reduce'
+            else:
+                func_name += 'device_segmented_reduce'
+            with testing.AssertFunctionIsCalled(func_name, return_value=ret):
+                a.sum(axis=axis)
+        elif self.backend == 'block':
+            # this is the only function we can mock; the rest is cdef'd
+            func_name = 'cupy.core._cub_reduction.'
+            func_name += '_SimpleCubReductionKernel_get_cached_function'
+            func = _cub_reduction._SimpleCubReductionKernel_get_cached_function
+            if len(axis) == len(self.shape):
+                times_called = 2  # two passes
+            else:
+                times_called = 1  # one pass
+            with testing.AssertFunctionIsCalled(
+                    func_name, wraps=func, times_called=times_called):
+                a.sum(axis=axis)
         # ...then perform the actual computation
         return a.sum(axis=axis)
 
@@ -266,12 +290,26 @@ class TestCubReduction(unittest.TestCase):
 
         # xp is cupy, first ensure we really use CUB
         ret = cupy.empty(())  # Cython checks return type, need to fool it
-        if len(axis) == len(self.shape):
-            func = 'cupy.core._routines_math.cub.device_reduce'
-        else:
-            func = 'cupy.core._routines_math.cub.device_segmented_reduce'
-        with testing.AssertFunctionIsCalled(func, return_value=ret):
-            a.prod(axis=axis)
+        if self.backend == 'device':
+            func_name = 'cupy.core._routines_math.cub.'
+            if len(axis) == len(self.shape):
+                func_name += 'device_reduce'
+            else:
+                func_name += 'device_segmented_reduce'
+            with testing.AssertFunctionIsCalled(func_name, return_value=ret):
+                a.prod(axis=axis)
+        elif self.backend == 'block':
+            # this is the only function we can mock; the rest is cdef'd
+            func_name = 'cupy.core._cub_reduction.'
+            func_name += '_SimpleCubReductionKernel_get_cached_function'
+            func = _cub_reduction._SimpleCubReductionKernel_get_cached_function
+            if len(axis) == len(self.shape):
+                times_called = 2  # two passes
+            else:
+                times_called = 1  # one pass
+            with testing.AssertFunctionIsCalled(
+                    func_name, wraps=func, times_called=times_called):
+                a.prod(axis=axis)
         # ...then perform the actual computation
         return a.prod(axis=axis)
 
@@ -280,6 +318,9 @@ class TestCubReduction(unittest.TestCase):
     @testing.for_dtypes('bhilBHILfdF')
     @testing.numpy_cupy_allclose(rtol=1E-4)
     def test_cub_cumsum(self, xp, dtype):
+        if self.backend == 'block':
+            raise unittest.SkipTest('does not support')
+
         a = testing.shaped_random(self.shape, xp, dtype)
         if self.order in ('c', 'C'):
             a = xp.ascontiguousarray(a)
@@ -302,6 +343,9 @@ class TestCubReduction(unittest.TestCase):
     @testing.for_dtypes('bhilBHILfdF')
     @testing.numpy_cupy_allclose(rtol=1E-4)
     def test_cub_cumprod(self, xp, dtype):
+        if self.backend == 'block':
+            raise unittest.SkipTest('does not support')
+
         a = testing.shaped_random(self.shape, xp, dtype)
         if self.order in ('c', 'C'):
             a = xp.ascontiguousarray(a)


### PR DESCRIPTION
Backport of #4062