### PR TITLE
ROCm: Build on latest ROCm  

### DIFF
--- a/.pfnci/script.sh
+++ b/.pfnci/script.sh
@@ -67,13 +67,8 @@ main() {
       apt install python3.7-dev python3-apt python3-pip python3-setuptools -qqy
       python3.7 -m pip install cython numpy
 
-      # We lock to ROCm v3.5.0 to focus on improving CuPy's support, because many
-      # symlinks (such as libhiprtc.so) are missing in newer versions...
-      wget -qO - http://repo.radeon.com/rocm/apt/3.5/rocm.gpg.key | apt-key add -
-      echo 'deb [arch=amd64] http://repo.radeon.com/rocm/apt/3.5/ xenial main' | tee /etc/apt/sources.list.d/rocm.list
-      # TODO(leofang): revisit this when supporting newer ROCm
-      #wget -qO - http://repo.radeon.com/rocm/apt/debian/rocm.gpg.key | apt-key add -
-      #echo 'deb [arch=amd64] http://repo.radeon.com/rocm/apt/debian/ xenial main' | tee /etc/apt/sources.list.d/rocm.list
+      wget -qO - http://repo.radeon.com/rocm/apt/debian/rocm.gpg.key | apt-key add -
+      echo 'deb [arch=amd64] http://repo.radeon.com/rocm/apt/debian/ xenial main' | tee /etc/apt/sources.list.d/rocm.list
 
       apt update -qqy
       apt install rocm-dev hipblas hipsparse rocsparse rocrand rocthrust rocsolver rocfft hipcub rocprim -qqy

--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -110,8 +110,7 @@ if use_hip:
             'rocsolver.h',
         ],
         'libraries': [
-            'hiprtc',
-            'hip_hcc',
+            'amdhip64',  # was hiprtc and hip_hcc before ROCm 3.8.0
             'hipblas',
             'hiprand',
             'rocfft',
@@ -249,8 +248,7 @@ else:
             'hipcub/hipcub_version.hpp',  # dummy
         ],
         'libraries': [
-            'hiprtc',
-            'hip_hcc',
+            'amdhip64',  # was hiprtc and hip_hcc before ROCm 3.8.0
         ],
         'check_method': build.check_cub_version,
         'version_method': build.get_cub_version,
@@ -267,8 +265,7 @@ if bool(int(os.environ.get('CUPY_SETUP_ENABLE_THRUST', 1))):
                 'thrust/version.h',
             ],
             'libraries': [
-                'hiprtc',
-                'hip_hcc',
+                'amdhip64',  # was hiprtc and hip_hcc before ROCm 3.8.0
             ],
         })
     else:


### PR DESCRIPTION
The symlinks `libhiprtc.so` and `libhip_hcc.so` are gone starting ROCm 3.7.0. We should just use the actual shared library that they point to. I tested locally that this is backward compatible with 3.5.0.

This PR also changes the Debian repo to the latest one so that the pfnCI can always target the latest ROCm release.