### PR TITLE
fix mode='opencv' case in cupyx.scipy.ndimage.affine_transform

### DIFF
--- a/cupyx/scipy/ndimage/interpolation.py
+++ b/cupyx/scipy/ndimage/interpolation.py
@@ -175,6 +175,17 @@ def affine_transform(input, matrix, offset=0.0, output_shape=None, output=None,
     if output_shape is None:
         output_shape = input.shape
 
+    if mode == 'opencv' or mode == '_opencv_edge':
+        if matrix.ndim == 1:
+            matrix = cupy.diag(matrix)
+        coordinates = cupy.indices(output_shape, dtype=cupy.float64)
+        coordinates = cupy.dot(matrix, coordinates.reshape((input.ndim, -1)))
+        coordinates += cupy.expand_dims(cupy.asarray(offset), -1)
+        ret = _util._get_output(output, input, shape=output_shape)
+        ret[:] = map_coordinates(input, coordinates, ret.dtype, order, mode,
+                                 cval, prefilter).reshape(output_shape)
+        return ret
+
     matrix = matrix.astype(cupy.float64, copy=False)
     if order is None:
         order = 1


### PR DESCRIPTION
## overview

Support for `mode='opencv'` in `cupyx.scipy.ndimage.affine_transform` seems to have been broken since CuPy 8.0 by the changes I introduced in gh-3166.

This PR [restores the code path from CuPy 7.8 for this case](https://github.com/cupy/cupy/blob/a08841a8e18d285652df0f7a2a25f5ae5bc1a897/cupyx/scipy/ndimage/interpolation.py#L237-L243).

closes #3601

## additional info

This was not detected previously when testing locally because apparently `@testing.with_requires('opencv-python')` does not pick up the conda-forge `opencv` package, so this test case was always skipped on my system. If I comment out the `with_requires` statement, the following test completes locally after this change:
https://github.com/cupy/cupy/blob/a7766076f15cbe85036960b2faa930496c1c029b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py#L190-L192


