### PR TITLE
Add `cupy.vectorize`

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -279,6 +279,7 @@ from cupy._creation.matrix import triu  # NOQA
 # Functional routines
 # -----------------------------------------------------------------------------
 from cupy._functional.piecewise import piecewise  # NOQA
+from cupy._functional.vectorize import vectorize  # NOQA
 from cupy.lib.shape_base import apply_along_axis  # NOQA
 
 # -----------------------------------------------------------------------------

--- a/cupy/_functional/vectorize.py
+++ b/cupy/_functional/vectorize.py
@@ -1,0 +1,78 @@
+import numpy
+
+from cupy import core
+from cupyx.jit import _interface
+from cupyx.jit import _types
+
+
+def _get_input_type(arg):
+    if isinstance(arg, int):
+        return 'l'
+    if isinstance(arg, float):
+        return 'd'
+    if isinstance(arg, complex):
+        return 'D'
+    return arg.dtype.char
+
+
+class vectorize(object):
+    """Generalized function class.
+
+    .. seealso:: :func:`numpy.vectorize`
+    """
+
+    def __init__(
+            self, pyfunc, otypes=None, doc=None, excluded=None,
+            cache=False, signature=None):
+        """
+        Args:
+            pyfunc (callable): The target python funciton.
+            otypes (str or list of dtypes, optional): The output data type.
+            doc (str or None): The docstring for the function.
+            excluded: Currently not supported.
+            cache: Currently Ignored.
+            signature: Currently not supported.
+        """
+
+        self.pyfunc = pyfunc
+        self.__doc__ = doc or pyfunc.__doc__
+        self.excluded = excluded
+        self.cache = cache
+        self.signature = signature
+        self._kernel_cache = {}
+
+        self.otypes = None
+        if otypes is not None:
+            self.otypes = ''.join([numpy.dtype(t).char for t in otypes])
+
+        if excluded is not None:
+            raise NotImplementedError(
+                'cupy.vectorize does not support `excluded` option currently.')
+
+        if signature is not None:
+            raise NotImplementedError(
+                'cupy.vectorize does not support `excluded` option currently.')
+
+    def __call__(self, *args):
+        itypes = ''.join([_get_input_type(x) for x in args])
+        kern = self._kernel_cache.get(itypes, None)
+
+        if kern is None:
+            in_types = [_types.Scalar(t) for t in itypes]
+            ret_type = None
+            if self.otypes is not None:
+                # TODO(asi1024): Implement
+                raise NotImplementedError
+
+            func = _interface._CudaFunction(self.pyfunc, 'numpy', device=True)
+            code, ret_type = func._emit_code_from_types(in_types, ret_type)
+            in_params = ', '.join(
+                f'{t.dtype} in{i}' for i, t in enumerate(in_types))
+            out_params = f'{ret_type.dtype} out0'
+            body = 'out0 = {}({})'.format(
+                func.name, ', '.join([f'in{i}' for i in range(len(in_types))]))
+            kern = core.ElementwiseKernel(
+                in_params, out_params, body, preamble=code)
+            self._kernel_cache[itypes] = kern
+
+        return kern(*args)

--- a/cupy/core/_kernel.pxd
+++ b/cupy/core/_kernel.pxd
@@ -134,9 +134,9 @@ cdef class _Ops:
     cpdef _Op guess_routine(
         self, str name, dict cache, list in_args, dtype, _Ops out_ops)
 
-    cdef _Op _guess_routine_from_in_types(self, tuple in_types)
+    cpdef _Op _guess_routine_from_in_types(self, tuple in_types)
 
-    cdef _Op _guess_routine_from_dtype(self, object dtype)
+    cpdef _Op _guess_routine_from_dtype(self, object dtype)
 
 
 cpdef create_ufunc(name, ops, routine=*, preamble=*, doc=*,

--- a/cupy/core/_kernel.pyx
+++ b/cupy/core/_kernel.pyx
@@ -1223,7 +1223,7 @@ cdef class _Ops:
         raise TypeError('Wrong type (%s) of arguments for %s' %
                         (dtype, name))
 
-    cdef _Op _guess_routine_from_in_types(self, tuple in_types):
+    cpdef _Op _guess_routine_from_in_types(self, tuple in_types):
         cdef _Op op
         cdef tuple op_types
         cdef Py_ssize_t n = len(in_types)
@@ -1243,7 +1243,7 @@ cdef class _Ops:
                 return op
         return None
 
-    cdef _Op _guess_routine_from_dtype(self, object dtype):
+    cpdef _Op _guess_routine_from_dtype(self, object dtype):
         cdef _Op op
         cdef tuple op_types
         for op in self.ops:

--- a/cupyx/jit/_compile.py
+++ b/cupyx/jit/_compile.py
@@ -292,7 +292,7 @@ def _transpile_expr(expr, env):
         return _emit_cuda_object_from_constants(expr.value, env)
     if isinstance(expr, ast.Num):
         # Deprecated since py3.8
-        return _emit_cuda_object_from_constants(expr.n)
+        return _emit_cuda_object_from_constants(expr.n, env)
     if isinstance(expr, ast.Subscript):
         # # TODO(asi1024): Fix.
         # value = _transpile_expr(expr.value, env)

--- a/cupyx/jit/_compile.py
+++ b/cupyx/jit/_compile.py
@@ -1,0 +1,323 @@
+import ast
+import inspect
+
+import numpy
+
+from cupyx.jit import _types
+from cupyx.jit import _typerules
+
+
+def transpile(func, attributes, mode, in_types, ret_type):
+    """Transpile the target function
+    Args:
+        func (function): Target function.
+        attributes (list of str): Attributes of the generated CUDA function.
+        mode ('numpy' or 'cuda'): The rule for typecast.
+        in_types (list of _types.TypeBase): Types of the arguments.
+        ret_type (_types.TypeBase or None): Type of the return value.
+    """
+
+    if not callable(func):
+        raise ValueError('`func` must be a callable object.')
+
+    if func.__name__ == '<lambda>':
+        raise NotImplementedError('Lambda function is not supported.')
+
+    attributes = ' '.join(attributes)
+    source = inspect.getsource(func)
+    lines = source.split('\n')
+    num_indent = len(lines[0]) - len(lines[0].lstrip())
+    source = '\n'.join([
+        line.replace(' ' * num_indent, '', 1) for line in lines])
+
+    global_mems = dict(inspect.getclosurevars(func).globals)
+    tree = ast.parse(source)
+    assert isinstance(tree, ast.Module)
+    assert len(tree.body) == 1
+    cuda_code, env = _transpile_function(
+        tree.body[0], attributes, mode, global_mems, in_types, ret_type)
+    cuda_code = ''.join([code + '\n' for code in env.preambles]) + cuda_code
+    print(cuda_code)
+    return cuda_code, env.ret_type
+
+
+def _indent(lines, spaces='  '):
+    return [spaces + line for line in lines]
+
+
+class CudaObject:
+    def __init__(self, code, ctype):
+        self.code = code
+        self.ctype = ctype
+
+    def __repr__(self):
+        return f'<CudaObject code = "{self.code}", type = {self.ctype}>'
+
+
+class Environment:
+    """Environment of the scope
+
+    Attributes:
+        mode ('numpy' or 'cuda'): The rule for typecast.
+        global_mems (dict): The dictionary with keys as the variable names and
+            the values as the data stored at the global scopes.
+        params (dict): The dictionary of function arguments with keys as
+            the variable names and the values as the CudaObject.
+        values (dict): The dictionary with keys as the variable names and the
+            values as the CudaObject stored at the local scope of the function.
+        ret_type (_types.TypeBase): The type of return value of the function.
+            If it is initialized to be ``None``, the return type must be
+            inferred until the end of transpilation of the function.
+    """
+
+    def __init__(self, mode, global_mems, params, ret_type):
+        self.mode = mode
+        self.global_mems = global_mems
+        self.params = params
+        self.values = {}
+        self.ret_type = ret_type
+        self.preambles = set()
+
+    def __getitem__(self, key):
+        if key in self.values:
+            return self.values[key]
+        if key in self.params:
+            return self.params[key]
+        if key in self.global_mems:
+            return self.global_mems[key]
+        return None
+
+    def __setitem__(self, key, value):
+        self.values[key] = value
+
+
+def _transpile_function(
+        func, attributes, mode, global_mems, in_types, ret_type):
+    """Transpile the function
+    Args:
+        func (ast.FunctionDef): Target function.
+        attributes (str): The attributes of target function.
+        mode ('numpy' or 'cuda'): The rule for typecast.
+        global_mems (dict): The dictionary with keys as variable names and
+            values as concrete data object.
+        in_types (list of _types.TypeBase): The types of arguments.
+        ret_type (_types.TypeBase): The type of return value.
+
+    Returns (str):
+        The generated CUDA code.
+    """
+    if not isinstance(func, ast.FunctionDef):
+        # TODO(asi1024): Support for `ast.ClassDef`.
+        raise NotImplementedError('Not supported: {}'.format(type(func)))
+    if len(func.decorator_list) > 0:
+        raise NotImplementedError('Decorator is not supported')
+    arguments = func.args
+    if arguments.vararg is not None:
+        raise NotImplementedError('`*args` is not supported currently.')
+    if len(arguments.kwonlyargs) > 0:  # same length with `kw_defaults`.
+        raise NotImplementedError(
+            'keyword only arguments are not supported currently .')
+    if arguments.kwarg is not None:
+        raise NotImplementedError('`**kwargs` is not supported currently.')
+    if len(arguments.defaults) > 0:
+        raise NotImplementedError(
+            'Default values are not supported currently.')
+
+    args = [arg.arg for arg in arguments.args]
+    if len(args) != len(in_types):
+        raise TypeError(
+            f'{func.name}() takes {len(args)} positional arguments '
+            'but {len(in_types)} were given.')
+    env = Environment(
+        mode, global_mems,
+        dict([(x, CudaObject(x, t)) for x, t in zip(args, in_types)]),
+        ret_type)
+    params = ', '.join([f'{env[a].ctype} {a}' for a in args])
+    body = _transpile_stmts(func.body, env)
+    function_decl = f'{attributes} {env.ret_type} {func.name}({params})'
+    local_vars = _indent([f'{v.ctype} {n};' for n, v in env.values.items()])
+    return '\n'.join([function_decl + ' {'] + local_vars + body + ['}']), env
+
+
+def _eval_operand(op, args, env, dtype=None):
+    ufunc = _typerules.get_ufunc(env.mode, type(op))
+    assert ufunc.nin == len(args)
+    assert ufunc.nout == 1
+    for x in args:
+        if not isinstance(x.ctype, _types.Scalar):
+            raise NotImplementedError
+
+    in_types = tuple([x.ctype.dtype for x in args])
+    if dtype is None:
+        op = ufunc._ops._guess_routine_from_in_types(in_types)
+    else:
+        op = ufunc._ops._guess_routine_from_dtype(dtype)
+
+    if op is None:
+        raise TypeError(
+            f'"{ufunc.name}" does not support for the input types: {in_types}')
+    if op.routine is None:
+        op.error_func()
+
+    assert op.routine.startswith('out0 = ')
+    out_type = _types.Scalar(op.out_types[0])
+    expr = op.routine[7:]
+    for i, x in enumerate(args):
+        x = astype_scalar(x, _types.Scalar(op.in_types[i]))
+        expr = expr.replace(f'in{i}', x.code)
+    expr = expr.replace('out0_type', str(out_type))
+    env.preambles.add(ufunc._preamble)
+
+    return CudaObject('(' + expr + ')', out_type)
+
+
+def _transpile_stmts(stmts, env):
+    return _indent([_transpile_stmt(stmt, env) for stmt in stmts])
+
+
+def _transpile_stmt(stmt, env):
+    """Transpile the statement.
+
+    Returns (str): The generated CUDA code.
+    """
+
+    if isinstance(stmt, ast.ClassDef):
+        raise NotImplementedError('class is not supported currently.')
+    if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef)):
+        raise NotImplementedError(
+            'Nested functions are not supported currently.')
+    if isinstance(stmt, ast.Return):
+        value = _transpile_expr(stmt.value, env)
+        t = value.ctype
+        if env.ret_type is None:
+            env.ret_type = t
+        elif env.ret_type != t:
+            raise ValueError(
+                f'Failed to infer the return type: {env.ret_type} or {t}')
+        return f'return {value.code};'
+    if isinstance(stmt, ast.Delete):
+        raise NotImplementedError('`del` is not supported currently.')
+    if isinstance(stmt, ast.Assign):
+        if len(stmt.targets) != 1:
+            raise NotImplementedError('Not implemented.')
+        target = stmt.targets[0]
+        name = target.id
+        value = _transpile_expr(stmt.value, env)
+        if isinstance(target, ast.Name):
+            if env[name] is None:
+                env[name] = CudaObject(target.id, value.ctype)
+            elif env[name].ctype.dtype != value.ctype.dtype:
+                raise TypeError('dtype mismatch.')
+            return f'{target.id} = {value.code};'
+        raise NotImplementedError('Not implemented')
+    if isinstance(stmt, ast.AugAssign):
+        value = _transpile_expr(stmt.value, env)
+        target = _transpile_expr(stmt.target, env)
+        result = _eval_operand(stmt.op, (target, value), env)
+        if not numpy.can_cast(
+                result.ctype.dtype, target.ctype.dtype, 'same_kind'):
+            raise TypeError('dtype mismatch')
+        return f'{target.code} = {result.code};'
+    if isinstance(stmt, ast.For):
+        raise NotImplementedError('Not implemented.')
+    if isinstance(stmt, ast.AsyncFor):
+        raise ValueError('`async for` is not allowed.')
+    if isinstance(stmt, ast.While):
+        raise NotImplementedError('Not implemented.')
+    if isinstance(stmt, ast.If):
+        raise NotImplementedError('Not implemented.')
+    if isinstance(stmt, (ast.With, ast.AsyncWith)):
+        raise ValueError('Switching contexts are not allowed.')
+    if isinstance(stmt, (ast.Raise, ast.Try)):
+        raise ValueError('throw/catch are not allowed.')
+    if isinstance(stmt, ast.Assert):
+        return 'assert(' + _transpile_expr(stmt.test, env) + ')'
+    if isinstance(stmt, (ast.Import, ast.ImportFrom)):
+        raise ValueError('Cannot import modules from the target functions.')
+    if isinstance(stmt, (ast.Global, ast.Nonlocal)):
+        raise ValueError('Cannot use global/nonlocal in the target functions.')
+    if isinstance(stmt, ast.Expr):
+        return _transpile_expr(stmt.value, env)
+    if isinstance(stmt, ast.Pass):
+        return ';'
+    if isinstance(stmt, ast.Break):
+        return NotImplementedError('Not implemented.')
+    if isinstance(stmt, ast.Continue):
+        return NotImplementedError('Not implemented.')
+    assert False
+
+
+def _transpile_expr(expr, env):
+    """Transpile the statement.
+
+    Returns (CudaObject): The CUDA code and its type of the expression.
+    """
+
+    if isinstance(expr, ast.BoolOp):
+        values = [_transpile_expr(e, env) for e in expr.values]
+        value = values[0]
+        for rhs in values[1:]:
+            value = _eval_operand(expr.op, (value, rhs), env)
+        return value
+    if isinstance(expr, ast.BinOp):
+        left = _transpile_expr(expr.left, env)
+        right = _transpile_expr(expr.right, env)
+        return _eval_operand(expr.op, (left, right), env)
+    if isinstance(expr, ast.UnaryOp):
+        value = _transpile_expr(expr.operand, env)
+        return _eval_operand(expr.op, (value,), env)
+    if isinstance(expr, ast.Lambda):
+        raise NotImplementedError('Not implemented.')
+    if isinstance(expr, ast.Compare):
+        values = [expr.left] + expr.comparators
+        if len(values) != 2:
+            raise NotImplementedError(
+                'Comparison of 3 or more values is not implemented.')
+        values = [_transpile_expr(e, env) for e in values]
+        return _eval_operand(expr.ops[0], values, env)
+    if isinstance(expr, ast.IfExp):
+        cond = _transpile_expr(expr.test, env)
+        x = _transpile_expr(expr.body, env)
+        y = _transpile_expr(expr.orelse, env)
+        if cond.ctype.dtype.kind == 'c':
+            raise NotImplementedError('')
+        if x.ctype.dtype != y.ctype.dtype:
+            raise TypeError(
+                f'Type mismatch in conditional expression.: '
+                '{x.ctype.dtype} != {y.ctype.dtype}')
+        cond = astype_scalar(cond, _types.Scalar(numpy.bool_))
+        return CudaObject(f'({cond.code} ? {x.code} : {y.code})', x.ctype)
+    if isinstance(expr, ast.Call):
+        raise NotImplementedError('Not implemented.')
+    if isinstance(expr, ast.Constant):
+        return _emit_cuda_object_from_constants(expr.value, env)
+    if isinstance(expr, ast.Num):
+        # Deprecated since py3.8
+        return _emit_cuda_object_from_constants(expr.n)
+    if isinstance(expr, ast.Subscript):
+        # # TODO(asi1024): Fix.
+        # value = _transpile_expr(expr.value, env)
+        # if isinstance(expr.slice, ast.Index):
+        #     index = _transpile_expr(expr.slice.value, env)
+        #     return value + '[' + index + ']'
+        raise NotImplementedError('Not implemented.')
+    if isinstance(expr, ast.Name):
+        value = env[expr.id]
+        if value is None:
+            raise NameError(
+                'Unbound name: {} in L{}'.format(expr.id, expr.lineno))
+        return env[expr.id]
+    if isinstance(expr, ast.Attribute):
+        raise NotImplementedError('Not implemented')
+    raise ValueError('Not supported: type {}'.format(type(expr)))
+
+
+def astype_scalar(x, ctype):
+    if x.ctype.dtype == ctype.dtype:
+        return x
+    return CudaObject(f'({ctype})({x.code})', ctype)
+
+
+def _emit_cuda_object_from_constants(x, env):
+    ctype = _typerules.get_ctype_from_scalar(env.mode, x)
+    return CudaObject(str(x), ctype)

--- a/cupyx/jit/_compile.py
+++ b/cupyx/jit/_compile.py
@@ -37,7 +37,6 @@ def transpile(func, attributes, mode, in_types, ret_type):
     cuda_code, env = _transpile_function(
         tree.body[0], attributes, mode, global_mems, in_types, ret_type)
     cuda_code = ''.join([code + '\n' for code in env.preambles]) + cuda_code
-    print(cuda_code)
     return cuda_code, env.ret_type
 
 

--- a/cupyx/jit/_interface.py
+++ b/cupyx/jit/_interface.py
@@ -1,0 +1,28 @@
+from cupyx.jit import _compile
+
+
+class _CudaFunction:
+    """JIT cupy function object
+    """
+
+    def __init__(self, func, mode, device=False, inline=False):
+        self.attributes = []
+
+        if device:
+            self.attributes.append('__device__')
+        else:
+            self.attributes.append('__global__')
+
+        if inline:
+            self.attributes.append('inline')
+
+        self.name = getattr(func, 'name', func.__name__)
+        self.func = func
+        self.mode = mode
+
+    def __call__(self, *args, **kwargs):
+        raise NotImplementedError
+
+    def _emit_code_from_types(self, in_types, ret_type=None):
+        return _compile.transpile(
+            self.func, self.attributes, self.mode, in_types, ret_type)

--- a/cupyx/jit/_typerules.py
+++ b/cupyx/jit/_typerules.py
@@ -1,0 +1,104 @@
+import ast
+
+import numpy
+
+from cupy._logic import ops
+from cupy._math import arithmetic
+from cupy._logic import comparison
+from cupy._binary import elementwise
+from cupy import core
+
+from cupyx.jit import _types
+
+
+_numpy_scalar_true_divide = core.create_ufunc(
+    'numpy_scalar_true_divide',
+    ('??->d', '?i->d', 'i?->d', 'bb->f', 'bi->d', 'BB->f', 'Bi->d',
+     'hh->f', 'HH->f', 'ii->d', 'II->d', 'll->d', 'LL->d', 'qq->d', 'QQ->d',
+     'ee->e', 'ff->f', 'dd->d', 'FF->F', 'DD->D'),
+    'out0 = (out0_type)in0 / (out0_type)in1',
+)
+
+
+_numpy_scalar_invert = core.create_ufunc(
+    'numpy_scalar_invert',
+    ('?->?', 'b->b', 'B->B', 'h->h', 'H->H', 'i->i', 'I->I',
+     'l->l', 'L->L', 'q->q', 'Q->Q'),
+    'out0 = ~in0',
+)
+
+
+_numpy_scalar_logical_not = core.create_ufunc(
+    'numpy_scalar_logical_not',
+    ('?->?', 'b->?', 'B->?', 'h->?', 'H->?', 'i->?', 'I->?', 'l->?', 'L->?',
+     'q->?', 'Q->?', 'e->?', 'f->?', 'd->?',
+     ('F->?', 'out0 = !in0.real() && !in0.imag()'),
+     ('D->?', 'out0 = !in0.real() && !in0.imag()')),
+    'out0 = !in0',
+)
+
+
+_scalar_lt = core.create_comparison('scalar_less', '<')
+_scalar_lte = core.create_comparison('scalar_less', '<=')
+_scalar_gt = core.create_comparison('scalar_less', '>')
+_scalar_gte = core.create_comparison('scalar_less', '>=')
+
+
+_numpy_ops = {
+    ast.And: ops.logical_and,
+    ast.Or: ops.logical_or,
+    ast.Add: arithmetic.add,
+    ast.Sub: arithmetic.subtract,
+    ast.Mult: arithmetic.multiply,
+    ast.Pow: arithmetic.power,
+    ast.Div: _numpy_scalar_true_divide,
+    ast.FloorDiv: arithmetic.floor_divide,
+    ast.Mod: arithmetic.remainder,
+    ast.LShift: elementwise.left_shift,
+    ast.RShift: elementwise.right_shift,
+    ast.BitOr: elementwise.bitwise_or,
+    ast.BitAnd: elementwise.bitwise_and,
+    ast.BitXor: elementwise.bitwise_xor,
+    ast.Invert: _numpy_scalar_invert,
+    ast.Not: _numpy_scalar_logical_not,
+    ast.Eq: comparison.equal,
+    ast.NotEq: comparison.not_equal,
+    ast.Lt: _scalar_lt,
+    ast.LtE: _scalar_lte,
+    ast.Gt: _scalar_gt,
+    ast.GtE: _scalar_gte,
+    ast.USub: arithmetic.negative,
+}
+
+
+def get_ufunc(mode, op_type):
+    if mode == 'numpy':
+        return _numpy_ops[op_type]
+    if mode == 'cuda':
+        raise NotImplementedError
+    assert False
+
+
+def get_ctype_from_scalar(mode, x):
+    if isinstance(x, numpy.generic):
+        return _types.Scalar(x.dtype)
+
+    if mode == 'numpy':
+        if isinstance(x, int):
+            return _types.Scalar(numpy.int64)
+        if isinstance(x, float):
+            return _types.Scalar(numpy.float64)
+        if isinstance(x, complex):
+            return _types.Scalar(numpy.complex128)
+
+    if mode == 'cuda':
+        if isinstance(x, int):
+            if -(1 << 31) <= x < (1 << 31):
+                return _types.Scalar(numpy.int32)
+            return _types.Scalar(numpy.int64)
+        if isinstance(x, float):
+            return _types.Scalar(numpy.float32)
+        if isinstance(x, complex):
+            return _types.Scalar(numpy.complex64)
+
+    raise NotImplementedError(f'{x} is not supported as a constant.')

--- a/cupyx/jit/_types.py
+++ b/cupyx/jit/_types.py
@@ -1,0 +1,45 @@
+import numpy
+
+
+_typenames = {
+    numpy.dtype('float64'): 'double',
+    numpy.dtype('float32'): 'float',
+    numpy.dtype('float16'): 'float16',
+    numpy.dtype('complex128'): 'complex<double>',
+    numpy.dtype('complex64'): 'complex<float>',
+    numpy.dtype('int64'): 'long long',
+    numpy.dtype('int32'): 'int',
+    numpy.dtype('int16'): 'short',
+    numpy.dtype('int8'): 'signed char',
+    numpy.dtype('uint64'): 'unsigned long long',
+    numpy.dtype('uint32'): 'unsigned int',
+    numpy.dtype('uint16'): 'unsigned short',
+    numpy.dtype('uint8'): 'unsigned char',
+    numpy.dtype('bool'): 'bool',
+}
+
+
+class TypeBase:
+    pass
+
+
+class Void(TypeBase):
+
+    def __init__(self):
+        pass
+
+    def __str__(self):
+        return 'void'
+
+
+class Scalar(TypeBase):
+
+    def __init__(self, dtype):
+        self.dtype = numpy.dtype(dtype)
+
+    def __str__(self):
+        dtype = self.dtype
+        if dtype == numpy.float16:
+            # For the performance
+            dtype = numpy.dtype('float32')
+        return _typenames[dtype]

--- a/tests/cupy_tests/functional_tests/test_vectorize.py
+++ b/tests/cupy_tests/functional_tests/test_vectorize.py
@@ -1,0 +1,256 @@
+import unittest
+
+from cupy import testing
+
+
+class TestVectorizeOps(unittest.TestCase):
+
+    def _run(self, func, xp, dtypes):
+        f = xp.vectorize(func)
+        args = [
+            testing.shaped_random((20, 30), xp, dtype, seed=seed)
+            for seed, dtype in enumerate(dtypes)
+        ]
+        return f(*args)
+
+    @testing.for_all_dtypes_combination(names=('dtype1', 'dtype2'))
+    @testing.numpy_cupy_array_equal()
+    def test_vectorize_add(self, xp, dtype1, dtype2):
+        def my_add(x, y):
+            return x + y
+
+        return self._run(my_add, xp, [dtype1, dtype2])
+
+    @testing.for_all_dtypes_combination(names=('dtype1', 'dtype2'))
+    @testing.numpy_cupy_array_equal(accept_error=TypeError)
+    def test_vectorize_sub(self, xp, dtype1, dtype2):
+        def my_sub(x, y):
+            return x - y
+
+        return self._run(my_sub, xp, [dtype1, dtype2])
+
+    @testing.for_all_dtypes_combination(names=('dtype1', 'dtype2'))
+    @testing.numpy_cupy_allclose(rtol=1e-6)
+    def test_vectorize_mul(self, xp, dtype1, dtype2):
+        def my_mul(x, y):
+            return x * y
+
+        return self._run(my_mul, xp, [dtype1, dtype2])
+
+    @testing.for_all_dtypes_combination(names=('dtype1', 'dtype2'))
+    @testing.numpy_cupy_allclose(rtol=1e-5)
+    def test_vectorize_pow(self, xp, dtype1, dtype2):
+        def my_pow(x, y):
+            return x ** y
+
+        f = xp.vectorize(my_pow)
+        x1 = testing.shaped_random((20, 30), xp, dtype1, seed=0)
+        x2 = testing.shaped_random((20, 30), xp, dtype2, seed=1)
+        x1[x1 == 0] = 1
+        return f(x1, x2)
+
+    def run_div(self, func, xp, dtypes):
+        dtype1, dtype2 = dtypes
+        f = xp.vectorize(func)
+        x1 = testing.shaped_random((20, 30), xp, dtype1, seed=0)
+        x2 = testing.shaped_random((20, 30), xp, dtype2, seed=1)
+        x2[x2 == 0] = 1
+        return f(x1, x2)
+
+    @testing.for_all_dtypes_combination(names=('dtype1', 'dtype2'))
+    @testing.numpy_cupy_allclose(rtol=1e-6)
+    def test_vectorize_div(self, xp, dtype1, dtype2):
+        def my_div(x, y):
+            return x / y
+
+        return self.run_div(my_div, xp, [dtype1, dtype2])
+
+    @testing.for_all_dtypes_combination(names=('dtype1', 'dtype2'))
+    @testing.numpy_cupy_allclose(accept_error=TypeError)
+    def test_vectorize_floor_div(self, xp, dtype1, dtype2):
+        def my_floor_div(x, y):
+            return x // y
+
+        return self.run_div(my_floor_div, xp, [dtype1, dtype2])
+
+    @testing.for_all_dtypes_combination(names=('dtype1', 'dtype2'))
+    @testing.numpy_cupy_allclose(accept_error=TypeError)
+    def test_vectorize_mod(self, xp, dtype1, dtype2):
+        def my_mod(x, y):
+            return x % y
+
+        return self.run_div(my_mod, xp, [dtype1, dtype2])
+
+    @testing.for_all_dtypes_combination(names=('dtype1', 'dtype2'))
+    @testing.numpy_cupy_array_equal(accept_error=TypeError)
+    def test_vectorize_lshift(self, xp, dtype1, dtype2):
+        def my_lshift(x, y):
+            return x << y
+
+        return self._run(my_lshift, xp, [dtype1, dtype2])
+
+    @testing.for_all_dtypes_combination(names=('dtype1', 'dtype2'))
+    @testing.numpy_cupy_array_equal(accept_error=TypeError)
+    def test_vectorize_rshift(self, xp, dtype1, dtype2):
+        def my_lshift(x, y):
+            return x >> y
+
+        return self._run(my_lshift, xp, [dtype1, dtype2])
+
+    @testing.for_all_dtypes_combination(names=('dtype1', 'dtype2'))
+    @testing.numpy_cupy_array_equal(accept_error=TypeError)
+    def test_vectorize_bit_or(self, xp, dtype1, dtype2):
+        def my_bit_or(x, y):
+            return x | y
+
+        return self._run(my_bit_or, xp, [dtype1, dtype2])
+
+    @testing.for_all_dtypes_combination(names=('dtype1', 'dtype2'))
+    @testing.numpy_cupy_array_equal(accept_error=TypeError)
+    def test_vectorize_bit_and(self, xp, dtype1, dtype2):
+        def my_bit_and(x, y):
+            return x & y
+
+        return self._run(my_bit_and, xp, [dtype1, dtype2])
+
+    @testing.for_all_dtypes_combination(names=('dtype1', 'dtype2'))
+    @testing.numpy_cupy_array_equal(accept_error=TypeError)
+    def test_vectorize_bit_xor(self, xp, dtype1, dtype2):
+        def my_bit_xor(x, y):
+            return x ^ y
+
+        return self._run(my_bit_xor, xp, [dtype1, dtype2])
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal(accept_error=TypeError)
+    def test_vectorize_bit_invert(self, xp, dtype):
+        def my_bit_invert(x):
+            return ~x
+
+        return self._run(my_bit_invert, xp, [dtype])
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal(accept_error=TypeError)
+    def test_vectorize_logical_not(self, xp, dtype):
+        def my_logical_not(x):
+            return not x
+
+        return self._run(my_logical_not, xp, [dtype])
+
+    @testing.for_all_dtypes_combination(names=('dtype1', 'dtype2'))
+    @testing.numpy_cupy_array_equal(accept_error=TypeError)
+    def test_vectorize_eq(self, xp, dtype1, dtype2):
+        def my_eq(x, y):
+            return x == y
+
+        return self._run(my_eq, xp, [dtype1, dtype2])
+
+    @testing.for_all_dtypes_combination(names=('dtype1', 'dtype2'))
+    @testing.numpy_cupy_array_equal(accept_error=TypeError)
+    def test_vectorize_neq(self, xp, dtype1, dtype2):
+        def my_neq(x, y):
+            return x != y
+
+        return self._run(my_neq, xp, [dtype1, dtype2])
+
+    @testing.for_all_dtypes_combination(names=('dtype1', 'dtype2'))
+    @testing.numpy_cupy_array_equal(accept_error=TypeError)
+    def test_vectorize_lt(self, xp, dtype1, dtype2):
+        def my_lt(x, y):
+            return x < y
+
+        return self._run(my_lt, xp, [dtype1, dtype2])
+
+    @testing.for_all_dtypes_combination(names=('dtype1', 'dtype2'))
+    @testing.numpy_cupy_array_equal(accept_error=TypeError)
+    def test_vectorize_le(self, xp, dtype1, dtype2):
+        def my_le(x, y):
+            return x <= y
+
+        return self._run(my_le, xp, [dtype1, dtype2])
+
+    @testing.for_all_dtypes_combination(names=('dtype1', 'dtype2'))
+    @testing.numpy_cupy_array_equal(accept_error=TypeError)
+    def test_vectorize_gt(self, xp, dtype1, dtype2):
+        def my_gt(x, y):
+            return x > y
+
+        return self._run(my_gt, xp, [dtype1, dtype2])
+
+    @testing.for_all_dtypes_combination(names=('dtype1', 'dtype2'))
+    @testing.numpy_cupy_array_equal(accept_error=TypeError)
+    def test_vectorize_ge(self, xp, dtype1, dtype2):
+        def my_ge(x, y):
+            return x >= y
+
+        return self._run(my_ge, xp, [dtype1, dtype2])
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal(accept_error=TypeError)
+    def test_vectorize_usub(self, xp, dtype):
+        def my_usub(x):
+            return -x
+
+        return self._run(my_usub, xp, [dtype])
+
+
+class TestVectorizeExprs(unittest.TestCase):
+
+    @testing.for_all_dtypes(name='cond_dtype', no_complex=True)
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose()
+    def test_vectorize_ifexp(self, xp, dtype, cond_dtype):
+        def my_ifexp(c, x, y):
+            return x if c else y
+
+        f = xp.vectorize(my_ifexp)
+        cond = testing.shaped_random((20, 30), xp, cond_dtype, seed=0)
+        x = testing.shaped_random((20, 30), xp, dtype, seed=1)
+        y = testing.shaped_random((20, 30), xp, dtype, seed=2)
+        return f(cond, x, y)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose()
+    def test_vectorize_incr(self, xp, dtype):
+        def my_incr(x):
+            return x + 1
+
+        f = xp.vectorize(my_incr)
+        x = testing.shaped_random((20, 30), xp, dtype, seed=0)
+        return f(x)
+
+
+class TestVectorizeInstructions(unittest.TestCase):
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose()
+    def test_vectorize_assign_new(self, xp, dtype):
+        def my_assign(x):
+            y = x + x
+            return x + y
+
+        f = xp.vectorize(my_assign)
+        x = testing.shaped_random((20, 30), xp, dtype, seed=1)
+        return f(x)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose()
+    def test_vectorize_assign_update(self, xp, dtype):
+        def my_assign(x):
+            x = x + x
+            return x + x
+
+        f = xp.vectorize(my_assign)
+        x = testing.shaped_random((20, 30), xp, dtype, seed=1)
+        return f(x)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose()
+    def test_vectorize_augassign(self, xp, dtype):
+        def my_augassign(x):
+            x += x
+            return x + x
+
+        f = xp.vectorize(my_augassign)
+        x = testing.shaped_random((20, 30), xp, dtype, seed=1)
+        return f(x)

--- a/tests/cupy_tests/functional_tests/test_vectorize.py
+++ b/tests/cupy_tests/functional_tests/test_vectorize.py
@@ -254,3 +254,20 @@ class TestVectorizeInstructions(unittest.TestCase):
         f = xp.vectorize(my_augassign)
         x = testing.shaped_random((20, 30), xp, dtype, seed=1)
         return f(x)
+
+
+class TestVectorize(unittest.TestCase):
+
+    @testing.for_all_dtypes(no_bool=True)
+    @testing.numpy_cupy_allclose(rtol=1e-5)
+    def test_vectorize_arithmetic_ops(self, xp, dtype):
+        def my_func(x1, x2, x3):
+            y = x1 + x2 * x3 ** x1
+            x2 = y + x3 * x1
+            return x1 + x2 + x3
+
+        f = xp.vectorize(my_func)
+        x1 = testing.shaped_random((20, 30), xp, dtype, seed=1)
+        x2 = testing.shaped_random((20, 30), xp, dtype, seed=2)
+        x3 = testing.shaped_random((20, 30), xp, dtype, seed=3)
+        return f(x1, x2, x3)


### PR DESCRIPTION
First step of #3392.

This PR adds `cupy.vectorize`.
Currently, only primitive arithmetic operations are supported, but I'm planning to cover more features in the future.

Future works:
- `vectorize.__init__` options: (`otypes`, `excluded`, ... etc.)
- Compile-time constants
- python math library / cupy ufunc function calls.
- Control statements (for, while, ... etc.)