### PR TITLE
DOC: Add note about starting nvprof with profiling off

### DIFF
--- a/cupy/cuda/__init__.py
+++ b/cupy/cuda/__init__.py
@@ -159,6 +159,10 @@ def profile():
     ...    # do something you want to measure
     ...    pass
 
+    .. note::
+        When starting ``nvprof`` from the command line, manually setting
+        ``--profile-from-start off`` may be required for the desired behavior.
+
     """
     profiler.start()
     try:


### PR DESCRIPTION
It wasn't immediately obvious to me that I needed to start `nvprof` with profiling turned off in order only profile only the code inside the profiling context, so I added this note to the documentation to help Python users who may not be familiar with profiling compiled languages.