### PR TITLE
add spline_filter1d and spline_filter to cupyx.scipy.ndimage.interpolation

### DIFF
--- a/cupy/_misc/memory_ranges.py
+++ b/cupy/_misc/memory_ranges.py
@@ -28,7 +28,7 @@ def _get_memory_ptrs(x):
 
 
 def shares_memory(a, b, max_work=None):
-    if a is b:
+    if a is b and a.size != 0:
         return True
     if max_work == 'MAY_SHARE_BOUNDS':
         return _memory_range.may_share_bounds(a, b)

--- a/cupy/_misc/memory_ranges.py
+++ b/cupy/_misc/memory_ranges.py
@@ -28,6 +28,8 @@ def _get_memory_ptrs(x):
 
 
 def shares_memory(a, b, max_work=None):
+    if a is b:
+        return True
     if max_work == 'MAY_SHARE_BOUNDS':
         return _memory_range.may_share_bounds(a, b)
 

--- a/cupyx/scipy/ndimage/__init__.py
+++ b/cupyx/scipy/ndimage/__init__.py
@@ -31,6 +31,8 @@ from cupyx.scipy.ndimage.interpolation import affine_transform  # NOQA
 from cupyx.scipy.ndimage.interpolation import map_coordinates  # NOQA
 from cupyx.scipy.ndimage.interpolation import rotate  # NOQA
 from cupyx.scipy.ndimage.interpolation import shift  # NOQA
+from cupyx.scipy.ndimage.interpolation import spline_filter  # NOQA
+from cupyx.scipy.ndimage.interpolation import spline_filter1d  # NOQA
 from cupyx.scipy.ndimage.interpolation import zoom  # NOQA
 
 from cupyx.scipy.ndimage.measurements import label  # NOQA

--- a/cupyx/scipy/ndimage/_spline_prefilter_core.py
+++ b/cupyx/scipy/ndimage/_spline_prefilter_core.py
@@ -220,7 +220,6 @@ void cupyx_spline_filter(T* __restrict__ y, const idx_t* __restrict__ info) {{
 def get_raw_spline1d_kernel(axis, ndim, mode, order, index_type="int",
                             data_type="double", pole_type="double",
                             block_size=128):
-
     """Generate a kernel for applying a spline prefilter along a given axis."""
     poles = get_poles(order)
 

--- a/cupyx/scipy/ndimage/_spline_prefilter_core.py
+++ b/cupyx/scipy/ndimage/_spline_prefilter_core.py
@@ -182,7 +182,8 @@ typedef {data_type} T;
 typedef {pole_type} P;
 typedef {index_type} idx_t;
 template <typename T>
-__device__ T* row(T* ptr, idx_t i, idx_t axis, idx_t ndim, const idx_t* shape) {{
+__device__ T* row(
+        T* ptr, idx_t i, idx_t axis, idx_t ndim, const idx_t* shape) {{
     idx_t index = 0, stride = 1;
     for (idx_t a = ndim - 1; a > 0; --a) {{
         if (a != axis) {{

--- a/cupyx/scipy/ndimage/_spline_prefilter_core.py
+++ b/cupyx/scipy/ndimage/_spline_prefilter_core.py
@@ -1,0 +1,221 @@
+"""
+Spline poles and boundary handling implemented as in SciPy
+
+https://github.com/scipy/scipy/blob/master/scipy/ndimage/src/ni_splines.c
+"""
+import functools
+import operator
+
+import cupy
+
+
+def get_poles(order):
+    if order == 2:
+        # sqrt(8.0) - 3.0
+        return (-0.171572875253809902396622551580603843,)
+    elif order == 3:
+        # sqrt(3.0) - 2.0
+        return (-0.267949192431122706472553658494127633,)
+    elif order == 4:
+        # sqrt(664.0 - sqrt(438976.0)) + sqrt(304.0) - 19.0
+        # sqrt(664.0 + sqrt(438976.0)) - sqrt(304.0) - 19.0
+        return (-0.361341225900220177092212841325675255,
+                -0.013725429297339121360331226939128204)
+    elif order == 5:
+        # sqrt(67.5 - sqrt(4436.25)) + sqrt(26.25) - 6.5
+        # sqrt(67.5 + sqrt(4436.25)) - sqrt(26.25) - 6.5
+        return (-0.430575347099973791851434783493520110,
+                -0.043096288203264653822712376822550182)
+    else:
+        raise ValueError("only order 2-5 supported")
+
+
+def get_gain(poles):
+    return functools.reduce(operator.mul,
+                            [(1.0 - z) * (1.0 - 1.0 / z) for z in poles])
+
+
+def _causal_init_code(mode):
+    """Code for causal initialization step of IIR filtering.
+
+    c is a 1d array of length n and z is a filter pole
+    """
+    if mode in ["nearest", "constant"]:
+        mode = "mirror"
+    code = """
+        // causal init for mode={mode}""".format(
+        mode=mode
+    )
+    if mode == "mirror":
+        code += """
+        z_i = z;
+        z_n_1 = pow(z, ({dtype_pole})(n - 1));
+
+        c[0] = c[0] + z_n_1 * c[n - 1];
+        for (i = 1; i < n - 1; ++i) {{
+            c[0] += z_i * (c[i] + z_n_1 * c[n - 1 - i]);
+            z_i *= z;
+        }}
+        c[0] /= 1 - z_n_1 * z_n_1;"""
+    elif mode == "wrap":
+        code += """
+        z_i = z;
+
+        for (i = 1; i < n; ++i) {{
+            c[0] += z_i * c[n - i];
+            z_i *= z;
+        }}
+        c[0] /= 1 - z_i; /* z_i = pow(z, n) */"""
+    elif mode == "reflect":
+        code += """
+        z_i = z;
+        z_n = pow(z, ({dtype_pole})n);
+        c0 = c[0];
+
+        c[0] = c[0] + z_n * c[n - 1];
+        for (i = 1; i < n; ++i) {{
+            c[0] += z_i * (c[i] + z_n * c[n - 1 - i]);
+            z_i *= z;
+        }}
+        c[0] *= z / (1 - z_n * z_n);
+        c[0] += c0;"""
+    else:
+        raise ValueError("invalid mode: {}".format(mode))
+    return code
+
+
+def _anticausal_init_code(mode):
+    """Code for the anti-causal initialization step of IIR filtering.
+
+    c is a 1d array of length n and z is a filter pole
+    """
+    if mode in ["nearest", "constant"]:
+        mode = "mirror"
+    code = """
+        // anti-causal init for mode={mode}""".format(
+        mode=mode
+    )
+    if mode == "mirror":
+        code += """
+        c[n - 1] = (z * c[n - 2] + c[n - 1]) * z / (z * z - 1);"""
+    elif mode == "wrap":
+        code += """
+        z_i = z;
+
+        for (i = 0; i < n - 1; ++i) {{
+            c[n - 1] += z_i * c[i];
+            z_i *= z;
+        }}
+        c[n - 1] *= z / (z_i - 1); /* z_i = pow(z, n) */"""
+    elif mode == "reflect":
+        code += """
+        c[n - 1] *= z / (z - 1);"""
+    else:
+        raise ValueError("invalid mode: {}".format(mode))
+    return code
+
+
+def get_spline1d_code(mode, poles):
+    """Generates the code required for IIR filtering of a single 1d signal.
+
+    Prefiltering is done by causal filtering followed by anti-causal filtering.
+
+    Currently this filtering can only be applied along the axis which is
+    contiguous in memory (e.g. the last axis for C-contiguous arrays). This
+    function will be applied in a batched fashion (see
+    ``batch_spline1d_template``).
+    """
+    code = ["""
+    #include <cupy/complex.cuh>
+
+    __device__ void spline_prefilter1d(
+        {dtype_data}* __restrict__ c, {dtype_index} signal_length)
+    {{"""]
+
+    # variables common to all boundary modes
+    code.append("""
+        {dtype_index} i, n = signal_length;
+        {dtype_pole} z, z_i;""")
+
+    if mode in ["mirror", "constant", "nearest"]:
+        # variables specific to these modes
+        code.append("""
+        {dtype_pole} z_n_1;""")
+    elif mode == "reflect":
+        # variables specific to this modes
+        code.append("""
+        {dtype_pole} z_n;
+        {dtype_data} c0;""")
+
+    for pole in poles:
+
+        code.append("""
+        // select the current pole
+        z = {pole};""".format(pole=pole))
+
+        # initialize and apply the causal filter
+        code.append(_causal_init_code(mode))
+        code.append("""
+        // apply the causal filter for the current pole
+        for (i = 1; i < n; ++i) {{
+            c[i] += z * c[i - 1];
+        }}""")
+
+        # initialize and apply the anti-causal filter
+        code.append(_anticausal_init_code(mode))
+        code.append("""
+        // apply the anti-causal filter for the current pole
+        for (i = n - 2; i >= 0; --i) {{
+            c[i] = z * (c[i + 1] - c[i]);
+        }}""")
+
+    code += ["""
+    }}"""]
+    return "\n".join(code)
+
+
+batch_spline1d_template = """
+
+    extern "C" {{
+    __global__ void batch_spline_prefilter(
+        {dtype_data}* __restrict__ x,
+        {dtype_index} len_x,
+        {dtype_index} n_batch)
+    {{
+        {dtype_index} unraveled_idx = blockDim.x * blockIdx.x + threadIdx.x;
+        {dtype_index} batch_idx = unraveled_idx;
+        if (batch_idx < n_batch)
+        {{
+            {dtype_index} offset_x = batch_idx * len_x;  // current line offset
+            spline_prefilter1d(&x[offset_x], len_x);
+        }}
+    }}
+    }}
+"""
+
+
+@cupy.memoize(for_each_device=True)
+def get_raw_spline1d_code(
+    mode, order=3, dtype_index="int", dtype_data="double", dtype_pole="double"
+):
+    """Get kernel code for a spline prefilter.
+
+    The kernels assume the data has been reshaped to shape (n_batch, size) and
+    filtering is to be performed along the last axis.
+
+    See cupyimg.scipy.ndimage.interpolation.spline_filter1d for how this can
+    be used to filter along any axis of an array via swapping axes and
+    reshaping. For n-dimensional filtering, the prefilter is seperable across
+    axes and thus a 1d filter is applied along each axis in turn.
+    """
+    poles = get_poles(order)
+
+    # generate source for a 1d function for a given boundary mode and poles
+    code = get_spline1d_code(mode, poles)
+
+    # generate code handling batch operation of the 1d filter
+    code += batch_spline1d_template
+    code = code.format(
+        dtype_index=dtype_index, dtype_data=dtype_data, dtype_pole=dtype_pole
+    )
+    return code

--- a/cupyx/scipy/ndimage/_spline_prefilter_core.py
+++ b/cupyx/scipy/ndimage/_spline_prefilter_core.py
@@ -214,8 +214,8 @@ void cupyx_spline_filter(T* __restrict__ y, const idx_t* __restrict__ info) {{
 
 
 @cupy.memoize(for_each_device=True)
-def get_raw_spline1d_kernel(axis, ndim, mode, order=3, index_type="int",
-                             data_type="double"):
+def get_raw_spline1d_kernel(axis, ndim, mode, order, index_type="int",
+                            data_type="double"):
     """Generate a kernel for applying a spline prefilter along a given axis."""
     poles = get_poles(order)
 

--- a/cupyx/scipy/ndimage/interpolation.py
+++ b/cupyx/scipy/ndimage/interpolation.py
@@ -33,6 +33,7 @@ def _check_parameter(func_name, order, mode):
                       '_opencv_edge'):
         raise ValueError('boundary mode is not supported')
 
+
 def _get_spline_output(input, output, allow_float32=False):
     """Create workspace array, temp, and the final dtype for the output.
 
@@ -120,7 +121,8 @@ def spline_filter1d(
         output[...] = x[...]
         return output
 
-    temp, data_dtype, output_dtype = _get_spline_output(x, output, allow_float32)
+    temp, data_dtype, output_dtype = _get_spline_output(x, output,
+                                                        allow_float32)
     data_type = cupy.core._scalar.get_typename(temp.dtype)
     pole_type = cupy.core._scalar.get_typename(temp.real.dtype)
 

--- a/cupyx/scipy/ndimage/interpolation.py
+++ b/cupyx/scipy/ndimage/interpolation.py
@@ -74,10 +74,8 @@ def _get_spline_output(input, output, allow_float32=False):
     return temp, float_dtype, output_dtype
 
 
-def spline_filter1d(
-    input, order=3, axis=-1, output=cupy.float64, mode="mirror", *,
-    allow_float32=False,
-):
+def spline_filter1d(input, order=3, axis=-1, output=cupy.float64,
+                    mode="mirror", *, allow_float32=False):
     """
     Calculate a 1-D spline filter along the given axis.
 
@@ -165,10 +163,8 @@ def spline_filter1d(
     return temp.astype(output_dtype, copy=False)
 
 
-def spline_filter(
-    input, order=3, output=numpy.float64, mode="mirror", *,
-    allow_float32=False
-):
+def spline_filter(input, order=3, output=numpy.float64, mode="mirror", *,
+                  allow_float32=False):
     """Multidimensional spline filter.
 
     Args:

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
@@ -576,3 +576,66 @@ class TestZoomOpenCV(unittest.TestCase):
         else:
             output_shape = numpy.rint(numpy.multiply(a.shape, self.zoom))
             return cv2.resize(a, tuple(output_shape.astype(int)))
+
+
+@testing.parameterize(*testing.product({
+    'mode': ['mirror', 'wrap', 'reflect'],
+    'order': [0, 1, 2, 3, 4, 5],
+    'dtype': [numpy.uint8, numpy.float64],
+    'output': [numpy.float64, numpy.float32],
+    'axis': [0, 1, 2, -1],
+}))
+@testing.gpu
+@testing.with_requires('scipy')
+class TestSplineFilter1d(unittest.TestCase):
+    @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
+    def test_spline_filter1d(self, xp, scp):
+        x = testing.shaped_random((16, 12, 11), dtype=self.dtype, xp=xp)
+        return scp.ndimage.spline_filter1d(x, order=self.order, axis=self.axis,
+                                           output=self.output, mode=self.mode)
+
+    @testing.for_CF_orders(name='array_order')
+    @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
+    def test_spline_filter1d_output(self, xp, scp, array_order):
+        x = testing.shaped_random((16, 12, 11), dtype=self.dtype, xp=xp,
+                                  order=array_order)
+        output = xp.empty(x.shape, dtype=self.output, order=array_order)
+        scp.ndimage.spline_filter1d(x, order=self.order, axis=self.axis,
+                                    output=output, mode=self.mode)
+        return output
+
+
+@testing.parameterize(*testing.product({
+    'mode': ['mirror', 'wrap', 'reflect'],
+    'order': [0, 1, 2, 3, 4, 5],
+    'dtype': [numpy.uint8, numpy.float64],
+    'output': [numpy.float64, numpy.float32],
+}))
+@testing.gpu
+@testing.with_requires('scipy')
+class TestSplineFilter(unittest.TestCase):
+    @testing.numpy_cupy_allclose(atol=1e-4, rtol=1e-4, scipy_name='scp')
+    def test_spline_filter(self, xp, scp):
+        x = testing.shaped_random((16, 12, 11), dtype=self.dtype, xp=xp)
+        if self.order < 2:
+            with pytest.raises(RuntimeError):
+               scp.ndimage.spline_filter(x, order=self.order,
+                                         output=self.output, mode=self.mode)
+            return xp.asarray([])
+        return scp.ndimage.spline_filter(x, order=self.order,
+                                         output=self.output, mode=self.mode)
+
+    @testing.for_CF_orders(name='array_order')
+    @testing.numpy_cupy_allclose(atol=1e-4, rtol=1e-4, scipy_name='scp')
+    def test_spline_filter_with_output(self, xp, scp, array_order):
+        x = testing.shaped_random((16, 12, 11), dtype=self.dtype, xp=xp,
+                                  order=array_order)
+        output = xp.empty(x.shape, dtype=self.output, order=array_order)
+        if self.order < 2:
+            with pytest.raises(RuntimeError):
+                scp.ndimage.spline_filter(x, order=self.order, output=output,
+                                          mode=self.mode)
+            return xp.asarray([])
+        scp.ndimage.spline_filter(x, order=self.order, output=output,
+                                  mode=self.mode)
+        return output

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
@@ -619,8 +619,8 @@ class TestSplineFilter(unittest.TestCase):
         x = testing.shaped_random((16, 12, 11), dtype=self.dtype, xp=xp)
         if self.order < 2:
             with pytest.raises(RuntimeError):
-               scp.ndimage.spline_filter(x, order=self.order,
-                                         output=self.output, mode=self.mode)
+                scp.ndimage.spline_filter(x, order=self.order,
+                                          output=self.output, mode=self.mode)
             return xp.asarray([])
         return scp.ndimage.spline_filter(x, order=self.order,
                                          output=self.output, mode=self.mode)


### PR DESCRIPTION
### Overview

This adds the functions `spline_filter1d` and `spline_filter`. These are used for the prefiltering stage for all interpolation functions in `scipy.ndimage` when order >= 2. I will make a follow-up PR later with the actual spline interpolation support.


### Additional Details

The `ElementwiseKernel` approach used for convolutions in `cupyx.scipy.ndimage.filters` is not applicable for these spline prefilters because they are infinite impulse response (IIR) filters. Instead, a `RawKernel` is used that follows the SciPy implementation closely. The implementation was originally only for batched operation along the last axis (commit c5ab0f5), but I later refactored it (8f6223b) to use strided operation instead as that ends up being faster.

For the strided operation, I borrowed the `row` function and some stride calculation code from @coderforlife's [gist for cupyx.scipy.signal.lfilter](https://gist.github.com/coderforlife/17bf471a519a7d092e82f95f10e8f6e4), so I added a co-author credit to @coderforlife here.

The only departures from the SciPy API should be as follows:
1.) There is an additional keyword-only argument `allow_float32` that allows the kernels to operate in single precision. This defaults to False so that the behavior matches SciPy's double-precision implementation. There is performance and memory benefit to allowing single precision, so I would like to provide the option (I would actually like to do that more broadly in cupyx.scipy.ndimage and can open a separate issue regarding whether to do this and whether it should be enabled by a keyword-only argument or perhaps instead by a global/environment variable).

2.) This function allows operation on complex-valued images while SciPy currently does not. I do have an open PR at SciPy to support this (scipy/scipy#12812), but it has not yet been reviewed. If this is acceptable, I can expand the tests here to include complex-valued inputs as well.

The changes made in 347c8c6 truncate the terms z**N for values of N less than the full array size in order to reduce computation time (here, `z`, are the filter poles which are typically < 0.5 so that z**N rapidly approaches zero for large N). I may make a corresponding change upstream in SciPy to improve the efficiency there as well.

### Benchmark Results
<details>
 <summary>Benchmark Script</summary>

```Python
import numpy as np
import scipy.ndimage as ndi

import cupy as cp
import cupyx.scipy.ndimage as cndi
from cupyx.time import repeat

print("dtype | shape | order | SciPy Time | CuPy Time | Acceleration")
print("------|-------|-------|------------|-----------|-------------")
for shape in [(512, 512), (4096, 4096), (256, 256, 256), (48, 48, 48, 48)]:
    for order in [2, 3, 4, 5]:
        for dtype in [np.float64, np.float32]:

            if dtype == np.float32:
                allow_cases = [False, True]
            else:
                allow_cases = [False]

            x = cp.testing.shaped_random(shape, xp=np, dtype=dtype)
            perf_cpu = repeat(ndi.spline_filter, (x, order), kwargs=dict(output=dtype), n_warmup=1,
                              n_repeat=4)
            cpu_mean = perf_cpu.cpu_times.mean()
            cpu_std = perf_cpu.cpu_times.std()

            xg = cp.testing.shaped_random(shape, xp=cp, dtype=dtype)
            for allow_float32 in allow_cases:
                perf_gpu = repeat(cndi.spline_filter, (xg, order), kwargs=dict(output=dtype, allow_float32=allow_float32), n_warmup=20,
                                  n_repeat=20)
                gpu_mean = perf_gpu.gpu_times.mean()
                gpu_std = perf_gpu.gpu_times.std()

                dtype_name = np.dtype(dtype).name
                if allow_float32:
                    dtype_name += "+"
                print(f"{dtype_name} | {shape} | {order} | {cpu_mean:0.4f} +/- {cpu_std:0.4f} | {gpu_mean:0.4f} +/- {gpu_std:0.4f} | {cpu_mean/gpu_mean:0.4f}")
```

</details>

In the benchmarks below, `float32` indicates float32 input with `allow_float32=False` while `float32+` indicates `allow_float32=True`. So comparing float32+ vs float32 indicates the relative benefit of allowing the kernel to operate in single precision. In some cases it gives nearly a factor of two performance improvement (on as GTX 1080 Ti).

The results below are with some empirically determined tuning of block sizes (see 3665dcf). This is likely not fully optimal and may vary based on hardware, but I found this was up to a factor of 4 faster for some cases in the table below as compared to just using a fixed block size of 128.

<details>
 <summary>Benchmark Results</summary>

dtype | shape | order | SciPy Time | CuPy Time | Acceleration
------|-------|-------|------------|-----------|-------------
float64 | (512, 512) | 2 | 0.0078 +/- 0.0000 | 0.0005 +/- 0.0000 | 17.1429
float32 | (512, 512) | 2 | 0.0069 +/- 0.0001 | 0.0005 +/- 0.0000 | 14.8155
float32+ | (512, 512) | 2 | 0.0069 +/- 0.0001 | 0.0004 +/- 0.0000 | 18.0272
float64 | (512, 512) | 3 | 0.0059 +/- 0.0001 | 0.0005 +/- 0.0000 | 12.9459
float32 | (512, 512) | 3 | 0.0052 +/- 0.0001 | 0.0005 +/- 0.0000 | 11.1037
float32+ | (512, 512) | 3 | 0.0052 +/- 0.0001 | 0.0004 +/- 0.0000 | 13.7612
float64 | (512, 512) | 4 | 0.0100 +/- 0.0002 | 0.0008 +/- 0.0000 | 12.2343
float32 | (512, 512) | 4 | 0.0096 +/- 0.0001 | 0.0008 +/- 0.0000 | 11.5478
float32+ | (512, 512) | 4 | 0.0096 +/- 0.0001 | 0.0006 +/- 0.0000 | 14.8777
float64 | (512, 512) | 5 | 0.0105 +/- 0.0001 | 0.0008 +/- 0.0000 | 12.5838
float32 | (512, 512) | 5 | 0.0100 +/- 0.0003 | 0.0008 +/- 0.0000 | 12.0317
float32+ | (512, 512) | 5 | 0.0100 +/- 0.0003 | 0.0007 +/- 0.0000 | 15.3600
float64 | (4096, 4096) | 2 | 0.6320 +/- 0.0033 | 0.0115 +/- 0.0002 | 55.1890
float32 | (4096, 4096) | 2 | 0.5955 +/- 0.0032 | 0.0116 +/- 0.0001 | 51.3433
float32+ | (4096, 4096) | 2 | 0.5955 +/- 0.0032 | 0.0079 +/- 0.0000 | 74.9288
float64 | (4096, 4096) | 3 | 0.6506 +/- 0.0029 | 0.0113 +/- 0.0000 | 57.5441
float32 | (4096, 4096) | 3 | 0.5954 +/- 0.0025 | 0.0115 +/- 0.0000 | 51.7527
float32+ | (4096, 4096) | 3 | 0.5954 +/- 0.0025 | 0.0080 +/- 0.0000 | 74.7751
float64 | (4096, 4096) | 4 | 0.8933 +/- 0.0015 | 0.0258 +/- 0.0001 | 34.5646
float32 | (4096, 4096) | 4 | 0.8544 +/- 0.0073 | 0.0260 +/- 0.0000 | 32.7994
float32+ | (4096, 4096) | 4 | 0.8544 +/- 0.0073 | 0.0146 +/- 0.0000 | 58.6961
float64 | (4096, 4096) | 5 | 0.9024 +/- 0.0022 | 0.0260 +/- 0.0001 | 34.7707
float32 | (4096, 4096) | 5 | 0.8635 +/- 0.0076 | 0.0262 +/- 0.0001 | 33.0032
float32+ | (4096, 4096) | 5 | 0.8635 +/- 0.0076 | 0.0146 +/- 0.0000 | 59.2901
float64 | (256, 256, 256) | 2 | 0.7596 +/- 0.0008 | 0.0171 +/- 0.0000 | 44.4308
float32 | (256, 256, 256) | 2 | 0.7070 +/- 0.0009 | 0.0173 +/- 0.0000 | 40.8533
float32+ | (256, 256, 256) | 2 | 0.7070 +/- 0.0009 | 0.0109 +/- 0.0000 | 64.7445
float64 | (256, 256, 256) | 3 | 0.7565 +/- 0.0006 | 0.0173 +/- 0.0001 | 43.6464
float32 | (256, 256, 256) | 3 | 0.7138 +/- 0.0021 | 0.0175 +/- 0.0000 | 40.7796
float32+ | (256, 256, 256) | 3 | 0.7138 +/- 0.0021 | 0.0110 +/- 0.0000 | 65.0602
float64 | (256, 256, 256) | 4 | 1.2377 +/- 0.0042 | 0.0319 +/- 0.0000 | 38.7723
float32 | (256, 256, 256) | 4 | 1.1898 +/- 0.0009 | 0.0322 +/- 0.0000 | 37.0058
float32+ | (256, 256, 256) | 4 | 1.1898 +/- 0.0009 | 0.0200 +/- 0.0000 | 59.4640
float64 | (256, 256, 256) | 5 | 1.2767 +/- 0.0008 | 0.0328 +/- 0.0001 | 38.9143
float32 | (256, 256, 256) | 5 | 1.2286 +/- 0.0015 | 0.0330 +/- 0.0001 | 37.2210
float32+ | (256, 256, 256) | 5 | 1.2286 +/- 0.0015 | 0.0201 +/- 0.0000 | 61.0218
float64 | (48, 48, 48, 48) | 2 | 0.2546 +/- 0.0010 | 0.0053 +/- 0.0000 | 47.7702
float32 | (48, 48, 48, 48) | 2 | 0.2277 +/- 0.0027 | 0.0054 +/- 0.0000 | 42.3401
float32+ | (48, 48, 48, 48) | 2 | 0.2277 +/- 0.0027 | 0.0036 +/- 0.0000 | 62.6256
float64 | (48, 48, 48, 48) | 3 | 0.2545 +/- 0.0003 | 0.0056 +/- 0.0000 | 45.8356
float32 | (48, 48, 48, 48) | 3 | 0.2307 +/- 0.0016 | 0.0056 +/- 0.0000 | 41.2424
float32+ | (48, 48, 48, 48) | 3 | 0.2307 +/- 0.0016 | 0.0035 +/- 0.0000 | 65.1985
float64 | (48, 48, 48, 48) | 4 | 0.4512 +/- 0.0055 | 0.0103 +/- 0.0003 | 43.9387
float32 | (48, 48, 48, 48) | 4 | 0.4248 +/- 0.0044 | 0.0097 +/- 0.0000 | 43.9879
float32+ | (48, 48, 48, 48) | 4 | 0.4248 +/- 0.0044 | 0.0053 +/- 0.0000 | 79.8143
float64 | (48, 48, 48, 48) | 5 | 0.4347 +/- 0.0042 | 0.0100 +/- 0.0000 | 43.4595
float32 | (48, 48, 48, 48) | 5 | 0.4089 +/- 0.0029 | 0.0100 +/- 0.0000 | 40.7602
float32+ | (48, 48, 48, 48) | 5 | 0.4089 +/- 0.0029 | 0.0054 +/- 0.0000 | 76.2883

</details>