### PR TITLE
fix broadcasting behavior in ndimage.measurements functions

### DIFF
--- a/cupyx/scipy/ndimage/measurements.py
+++ b/cupyx/scipy/ndimage/measurements.py
@@ -335,13 +335,13 @@ def variance(input, labels=None, index=None):
     if not isinstance(labels, cupy.ndarray):
         raise TypeError('label must be cupy.ndarray')
 
+    input, labels = cupy.broadcast_arrays(input, labels)
+
     if index is None:
         return calc_var_with_intermediate_float(input[labels > 0])
 
     if cupy.isscalar(index):
         return calc_var_with_intermediate_float(input[labels == index])
-
-    input, labels = cupy.broadcast_arrays(input, labels)
 
     if not isinstance(index, cupy.ndarray):
         if not isinstance(index, int):
@@ -403,10 +403,10 @@ def sum(input, labels=None, index=None):
     if not isinstance(labels, cupy.ndarray):
         raise TypeError('label must be cupy.ndarray')
 
+    input, labels = cupy.broadcast_arrays(input, labels)
+
     if index is None:
         return input[labels != 0].sum()
-
-    input, labels = cupy.broadcast_arrays(input, labels)
 
     if not isinstance(index, cupy.ndarray):
         if not isinstance(index, int):
@@ -475,13 +475,13 @@ def mean(input, labels=None, index=None):
     if not isinstance(labels, cupy.ndarray):
         raise TypeError('label must be cupy.ndarray')
 
+    input, labels = cupy.broadcast_arrays(input, labels)
+
     if index is None:
         return calc_mean_with_intermediate_float(input[labels > 0])
 
     if cupy.isscalar(index):
         return calc_mean_with_intermediate_float(input[labels == index])
-
-    input, labels = cupy.broadcast_arrays(input, labels)
 
     if not isinstance(index, cupy.ndarray):
         if not isinstance(index, int):

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
@@ -134,6 +134,25 @@ class TestStats(unittest.TestCase):
 
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_broadcast_labels(self, xp, scp, dtype):
+        # 1d label will be broadcast to 2d
+        image = self._make_image((16, 6), xp, dtype)
+        labels = xp.asarray([1, 0, 2, 2, 2, 0], dtype=xp.int32)
+        op = getattr(scp.ndimage, self.op)
+        return op(image, labels)
+
+    @testing.for_all_dtypes(no_complex=True)
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_broadcast_labels2(self, xp, scp, dtype):
+        # 1d label will be broadcast to 2d
+        image = self._make_image((16, 6), xp, dtype)
+        labels = xp.asarray([1, 0, 2, 2, 2, 0], dtype=xp.int32)
+        index = 2
+        op = getattr(scp.ndimage, self.op)
+        return op(image, labels, index)
+
+    @testing.for_all_dtypes(no_complex=True)
+    @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_zero_dim(self, xp, scp, dtype):
         image = self._make_image((), xp, dtype)
         labels = testing.shaped_random((), xp, dtype=xp.int32, scale=4)


### PR DESCRIPTION
The `cupyx.scipy.ndimage.measurements` functions `sum`, `mean`, `variance` and `standard_deviation` currently do not broadcast the labels argument properly in all cases.

The call to `cupy.broadcast_arrays` just needs to precede any calls like `input[labels > 0]` or `input[labels == index]` as proposed here.

The test cases added here fail on master, but pass after the changes in this PR.
