### PR TITLE
Enhance dtype error message in testing helpers

### DIFF
--- a/cupy/testing/helper.py
+++ b/cupy/testing/helper.py
@@ -236,7 +236,11 @@ def _make_decorator(check_func, name, type_check, contiguous_check,
             # Check dtypes
             if type_check:
                 for cupy_r, numpy_r in cupy_numpy_result_ndarrays:
-                    assert cupy_r.dtype == numpy_r.dtype
+                    if cupy_r.dtype != numpy_r.dtype:
+                        raise AssertionError(
+                            '''ndarrays of different dtypes are returned.
+cupy: {}
+numpy: {}'''.format(cupy_r.dtype, numpy_r.dtype))
 
             # Check contiguities
             if contiguous_check:


### PR DESCRIPTION
Previous:
```py
        # Check dtypes
        if type_check:
            for cupy_r, numpy_r in cupy_numpy_result_ndarrays:
>               assert cupy_r.dtype == numpy_r.dtype
E               AssertionError
```

This PR:
```py
                # Check dtypes
                if type_check:
                    for cupy_r, numpy_r in cupy_numpy_result_ndarrays:
                        if cupy_r.dtype != numpy_r.dtype:
>                           raise AssertionError(
                                '''ndarrays of different dtypes are returned.
    cupy: {}
    numpy: {}'''.format(cupy_r.dtype, numpy_r.dtype))
E   AssertionError: ndarrays of different dtypes are returned.
E   cupy: float64
E   numpy: float32
```