### PR TITLE
fix: respect user-supplied output array in all binary morphology functions

### DIFF
--- a/cupyx/scipy/ndimage/morphology.py
+++ b/cupyx/scipy/ndimage/morphology.py
@@ -185,8 +185,9 @@ def _binary_erosion(input, structure, iterations, mask, output, border_value,
         masked = False
     origin = _util._fix_sequence_arg(origin, input.ndim, 'origin', int)
 
-    if isinstance(output, cupy.ndarray) and output.dtype.kind == 'c':
-        raise TypeError('Complex output type not supported')
+    if isinstance(output, cupy.ndarray):
+        if output.dtype.kind == 'c':
+            raise TypeError('Complex output type not supported')
     else:
         output = bool
     output = _util._get_output(output, input)

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_morphology.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_morphology.py
@@ -71,7 +71,7 @@ class TestIterateStructure(unittest.TestCase):
         'origin': [-1, 0, 1],
         'data': [[], [1, 1, 0, 1, 1]],
         'filter': ['binary_erosion', 'binary_dilation'],
-        'output': [None, numpy.float32, numpy.int8]}
+        'output': [None, numpy.float32, numpy.int8, 'array']}
     ))
 )
 @testing.gpu
@@ -82,6 +82,12 @@ class BinaryErosionAndDilation1d(unittest.TestCase):
         structure = self.structure
         if structure is not None:
             structure = xp.asarray(structure)
+        if self.output == 'array':
+            output = xp.zeros_like(x)
+            filter(x, structure, iterations=1, mask=None,
+                   output=output, border_value=self.border_value,
+                   origin=self.origin, brute_force=True)
+            return output
         return filter(x, structure, iterations=1, mask=None,
                       output=self.output, border_value=self.border_value,
                       origin=self.origin, brute_force=True)
@@ -92,6 +98,7 @@ class BinaryErosionAndDilation1d(unittest.TestCase):
             raise unittest.SkipTest('redundant')
         x = xp.asarray(self.data, dtype=self.x_dtype)
         return self._filter(xp, scp, x)
+
 
 
 @testing.parameterize(*(
@@ -324,7 +331,7 @@ class BinaryPropagation(unittest.TestCase):
         'density': [0.1, 0.5, 0.9],
         'filter': ['binary_erosion', 'binary_dilation'],
         'iterations': [1, 2, 0],
-        'output': [None, numpy.float32]}
+        'output': [None, numpy.float32, 'array']}
     ))
 )
 @testing.gpu
@@ -335,6 +342,12 @@ class BinaryErosionAndDilation(unittest.TestCase):
         ndim = len(self.shape)
         structure = scp.ndimage.generate_binary_structure(ndim,
                                                           self.connectivity)
+        if self.output == 'array':
+            output = xp.zeros_like(x)
+            filter(x, structure, iterations=self.iterations, mask=None,
+                   output=output, border_value=self.border_value,
+                   origin=self.origin, brute_force=True)
+            return output
         return filter(x, structure, iterations=self.iterations, mask=None,
                       output=self.output, border_value=self.border_value,
                       origin=self.origin, brute_force=True)

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_morphology.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_morphology.py
@@ -100,7 +100,6 @@ class BinaryErosionAndDilation1d(unittest.TestCase):
         return self._filter(xp, scp, x)
 
 
-
 @testing.parameterize(*(
     testing.product({
         'x_dtype': [numpy.bool, numpy.float64],


### PR DESCRIPTION
This PR fixes a one line bug fix in `binary_erosion`. The current code was causing the output to always be stored in a new array even when the user supplied an output array. Test cases using a user-provided array were added.
