### PR TITLE
Fix `polyfit` tests tolerance

### DIFF
--- a/tests/cupy_tests/lib_tests/test_polynomial.py
+++ b/tests/cupy_tests/lib_tests/test_polynomial.py
@@ -511,6 +511,9 @@ class TestPolyArithmeticDiffTypes(unittest.TestCase):
     'rcond': [None, 0.5, 1e-15],
     'weighted': [True, False]
 }))
+@pytest.mark.skipif(
+    cupy.cuda.runtime.runtimeGetVersion() < 10000,
+    reason='polyfit has issues with CUDA 9.x')
 class TestPolyfitParametersCombinations(unittest.TestCase):
 
     def _full_fit(self, xp, dtype):

--- a/tests/cupy_tests/lib_tests/test_polynomial.py
+++ b/tests/cupy_tests/lib_tests/test_polynomial.py
@@ -511,9 +511,6 @@ class TestPolyArithmeticDiffTypes(unittest.TestCase):
     'rcond': [None, 0.5, 1e-15],
     'weighted': [True, False]
 }))
-@pytest.mark.skipif(
-    cupy.cuda.runtime.runtimeGetVersion() < 10000,
-    reason='polyfit has issues with CUDA 9.x')
 class TestPolyfitParametersCombinations(unittest.TestCase):
 
     def _full_fit(self, xp, dtype):
@@ -538,7 +535,7 @@ class TestPolyfitParametersCombinations(unittest.TestCase):
 
         testing.assert_allclose(cp_c, np_c, atol=1e-9)
         testing.assert_allclose(cp_resids, np_resids, atol=1e-9)
-        testing.assert_allclose(cp_s, np_s)
+        testing.assert_allclose(cp_s, np_s, atol=1e-9)
         assert cp_rank == np_rank
         if self.rcond is not None:
             assert cp_rcond == np_rcond


### PR DESCRIPTION
In the CuPy combination tests, when using Numpy 1.19.2 and CUDA 9.2 polyfit fails when weights are set to other than `None`. Because of a e-16 difference in one result.
```
actual     = array([3.21811551e+00, 8.02329466e-01, 2.14338135e-16])
atol       = 0
desired    = array([3.21811551, 0.80232947, 0.        ])
```
https://jenkins.preferred.jp/job/chainer/job/chainer-test_pr/220/
