### PR TITLE
Improve `cupy.cuda.cub.device_segmented_reduce()`

### DIFF
--- a/cupy/cuda/cub.pyx
+++ b/cupy/cuda/cub.pyx
@@ -386,7 +386,7 @@ cdef bint can_use_device_reduce(ndarray x, int op, tuple out_axis, dtype=None):
         and x.size <= 0x7fffffff)  # until we resolve cupy/cupy#3309
 
 
-cdef (bint, Py_ssize_t) can_use_device_segmented_reduce(
+cdef (bint, Py_ssize_t) can_use_device_segmented_reduce(  # noqa: E211
         ndarray x, int op, tuple reduce_axis, tuple out_axis,
         dtype=None, str order='C'):
     if not _cub_reduce_dtype_compatible(x.dtype, op, dtype):

--- a/cupy/cuda/cub.pyx
+++ b/cupy/cuda/cub.pyx
@@ -379,7 +379,8 @@ cpdef bint _cub_device_segmented_reduce_axis_compatible(
     return False
 
 
-cdef bint can_use_device_reduce(ndarray x, int op, tuple out_axis, dtype=None):
+cdef bint can_use_device_reduce(
+        ndarray x, int op, tuple out_axis, dtype=None) except*:
     return (
         out_axis is ()
         and _cub_reduce_dtype_compatible(x.dtype, op, dtype)
@@ -388,7 +389,7 @@ cdef bint can_use_device_reduce(ndarray x, int op, tuple out_axis, dtype=None):
 
 cdef (bint, Py_ssize_t) can_use_device_segmented_reduce(  # noqa: E211
         ndarray x, int op, tuple reduce_axis, tuple out_axis,
-        dtype=None, str order='C'):
+        dtype=None, str order='C') except*:
     if not _cub_reduce_dtype_compatible(x.dtype, op, dtype):
         return (False, 0)
     if not _cub_device_segmented_reduce_axis_compatible(
@@ -397,7 +398,7 @@ cdef (bint, Py_ssize_t) can_use_device_segmented_reduce(  # noqa: E211
     # until we resolve cupy/cupy#3309
     cdef Py_ssize_t contiguous_size = _preprocess_array(
         x.shape, reduce_axis, out_axis, order)
-    return contiguous_size <= 0x7fffffff, contiguous_size
+    return (contiguous_size <= 0x7fffffff, contiguous_size)
 
 
 cdef _cub_support_dtype(bint sum_mode, int dev_id):

--- a/cupy/cuda/cub.pyx
+++ b/cupy/cuda/cub.pyx
@@ -182,7 +182,8 @@ def device_reduce(ndarray x, op, tuple out_axis, out=None,
 
 
 def device_segmented_reduce(ndarray x, op, tuple reduce_axis,
-                            tuple out_axis, out=None, bint keepdims=False):
+                            tuple out_axis, out=None, bint keepdims=False,
+                            Py_ssize_t contiguous_size=0):
     # if import at the top level, a segfault would happen when import cupy!
     from cupy._creation.ranges import arange
 
@@ -195,7 +196,6 @@ def device_segmented_reduce(ndarray x, op, tuple reduce_axis,
     cdef void* offset_start_ptr
     cdef int dtype_id, n_segments, op_code
     cdef size_t ws_size
-    cdef Py_ssize_t contiguous_size
     cdef tuple out_shape
     cdef Stream_t s
 
@@ -213,7 +213,6 @@ def device_segmented_reduce(ndarray x, op, tuple reduce_axis,
         raise RuntimeError('input is neither C- nor F- contiguous.')
 
     # prepare input
-    contiguous_size = _preprocess_array(x.shape, reduce_axis, out_axis, order)
     out_shape = _get_output_shape(x, out_axis, keepdims)
     x_ptr = <void*>x.data.ptr
     y = ndarray(out_shape, dtype=x.dtype, order=order)
@@ -396,18 +395,18 @@ cdef bint can_use_device_reduce(ndarray x, int op, tuple out_axis, dtype=None):
         and x.size <= 0x7fffffff)  # until we resolve cupy/cupy#3309
 
 
-cdef bint can_use_device_segmented_reduce(
+cdef (bint, Py_ssize_t) can_use_device_segmented_reduce(
         ndarray x, int op, tuple reduce_axis, tuple out_axis,
         dtype=None, str order='C'):
     if not _cub_reduce_dtype_compatible(x.dtype, op, dtype):
-        return False
+        return (False, 0)
     if not _cub_device_segmented_reduce_axis_compatible(
             reduce_axis, x.ndim, order):
-        return False
+        return (False, 0)
     # until we resolve cupy/cupy#3309
     cdef Py_ssize_t contiguous_size = _preprocess_array(
         x.shape, reduce_axis, out_axis, order)
-    return contiguous_size <= 0x7fffffff
+    return contiguous_size <= 0x7fffffff, contiguous_size
 
 
 cdef _cub_support_dtype(bint sum_mode, int dev_id):
@@ -462,9 +461,10 @@ cpdef cub_reduction(
     """
     # if import at the top level, a segfault would happen when import cupy!
     from cupy.core._reduction import _get_axis
-    cdef bint enforce_numpy_API = False
+    cdef bint enforce_numpy_API = False, is_ok
     cdef str order
     cdef tuple reduce_axis, out_axis
+    cdef Py_ssize_t contiguous_size
 
     if op in (CUPY_CUB_ARGMIN, CUPY_CUB_ARGMAX):
         # For argmin and argmax, NumPy does not allow a tuple for axis.
@@ -507,10 +507,11 @@ cpdef cub_reduction(
         # segmented reduction not currently implemented for argmax, argmin
         return None
 
-    if can_use_device_segmented_reduce(arr, op, reduce_axis, out_axis,
-                                       dtype, order):
+    is_ok, contiguous_size = can_use_device_segmented_reduce(
+        arr, op, reduce_axis, out_axis, dtype, order)
+    if is_ok and contiguous_size > 0:
         return device_segmented_reduce(arr, op, reduce_axis, out_axis,
-                                       out, keepdims)
+                                       out, keepdims, contiguous_size)
     return None
 
 

--- a/cupy/cuda/cupy_cub.cu
+++ b/cupy/cuda/cupy_cub.cu
@@ -7,11 +7,15 @@
 #include <cub/device/device_spmv.cuh>
 #include <cub/device/device_scan.cuh>
 #include <cub/device/device_histogram.cuh>
+#include <cub/iterator/counting_input_iterator.cuh>
+#include <cub/iterator/transform_input_iterator.cuh>
 #else
 #include <hipcub/device/device_reduce.hpp>
 #include <hipcub/device/device_segmented_reduce.hpp>
 #include <hipcub/device/device_scan.hpp>
 #include <hipcub/device/device_histogram.hpp>
+#include <rocprim/iterator/counting_iterator.hpp>
+#include <hipcub/iterator/transform_input_iterator.hpp>
 #endif
 
 
@@ -124,6 +128,23 @@ struct _multiply
         return a * b;
     }
 };
+
+//
+// arange functor: arange(0, n+1) -> arange(0, n+1, step_size)
+//
+struct _arange
+{
+    private:
+        int step_size;
+
+    public:
+    __host__ __device__ __forceinline__ _arange(int i): step_size(i) {}
+    __host__ __device__ __forceinline__ int operator()(const int &in) const {
+        return step_size * in;
+    }
+};
+
+typedef TransformInputIterator<int, _arange, CountingInputIterator<int>> seg_offset_itr;
 
 /*
    These stubs are needed because CUB does not handle NaNs properly, while NumPy has certain
@@ -477,12 +498,11 @@ struct _cub_reduce_sum {
 struct _cub_segmented_reduce_sum {
     template <typename T>
     void operator()(void* workspace, size_t& workspace_size, void* x, void* y,
-        int num_segments, void* offset_start, void* offset_end, cudaStream_t s)
+        int num_segments, seg_offset_itr offset_start, cudaStream_t s)
     {
         DeviceSegmentedReduce::Sum(workspace, workspace_size,
             static_cast<T*>(x), static_cast<T*>(y), num_segments,
-            static_cast<int*>(offset_start),
-            static_cast<int*>(offset_end), s);
+            offset_start, offset_start+1, s);
     }
 };
 
@@ -505,15 +525,14 @@ struct _cub_reduce_prod {
 struct _cub_segmented_reduce_prod {
     template <typename T>
     void operator()(void* workspace, size_t& workspace_size, void* x, void* y,
-        int num_segments, void* offset_start, void* offset_end, cudaStream_t s)
+        int num_segments, seg_offset_itr offset_start, cudaStream_t s)
     {
         _multiply product_op;
         // the init value is cast from 1.0f because on host __half can only be
         // initialized by float or double; static_cast<__half>(1) = 0 on host.
         DeviceSegmentedReduce::Reduce(workspace, workspace_size,
             static_cast<T*>(x), static_cast<T*>(y), num_segments,
-            static_cast<int*>(offset_start),
-            static_cast<int*>(offset_end),
+            offset_start, offset_start+1,
             product_op, static_cast<T>(1.0f), s);
     }
 };
@@ -534,12 +553,11 @@ struct _cub_reduce_min {
 struct _cub_segmented_reduce_min {
     template <typename T>
     void operator()(void* workspace, size_t& workspace_size, void* x, void* y,
-        int num_segments, void* offset_start, void* offset_end, cudaStream_t s)
+        int num_segments, seg_offset_itr offset_start, cudaStream_t s)
     {
         DeviceSegmentedReduce::Min(workspace, workspace_size,
             static_cast<T*>(x), static_cast<T*>(y), num_segments,
-            static_cast<int*>(offset_start),
-            static_cast<int*>(offset_end), s);
+            offset_start, offset_start+1, s);
     }
 };
 
@@ -559,12 +577,11 @@ struct _cub_reduce_max {
 struct _cub_segmented_reduce_max {
     template <typename T>
     void operator()(void* workspace, size_t& workspace_size, void* x, void* y,
-        int num_segments, void* offset_start, void* offset_end, cudaStream_t s)
+        int num_segments, seg_offset_itr offset_start, cudaStream_t s)
     {
         DeviceSegmentedReduce::Max(workspace, workspace_size,
             static_cast<T*>(x), static_cast<T*>(y), num_segments,
-            static_cast<int*>(offset_start),
-            static_cast<int*>(offset_end), s);
+            offset_start, offset_start+1, s);
     }
 };
 
@@ -733,38 +750,40 @@ size_t cub_device_reduce_get_workspace_size(void* x, void* y, int num_items,
 /* -------- device segmented reduce -------- */
 
 void cub_device_segmented_reduce(void* workspace, size_t& workspace_size,
-    void* x, void* y, int num_segments, void* offset_start, void* offset_end,
+    void* x, void* y, int num_segments, int segment_size,
     cudaStream_t stream, int op, int dtype_id)
 {
+    // CUB internally use int for offset...
+    // This iterates over [0, segment_size, 2*segment_size, 3*segment_size, ...]
+    CountingInputIterator<int> count_itr(0);
+    _arange scaling(segment_size);
+    seg_offset_itr itr(count_itr, scaling);
+
     switch(op) {
     case CUPY_CUB_SUM:
         return dtype_dispatcher(dtype_id, _cub_segmented_reduce_sum(),
-                   workspace, workspace_size, x, y, num_segments, offset_start,
-                   offset_end, stream);
+                   workspace, workspace_size, x, y, num_segments, itr, stream);
     case CUPY_CUB_MIN:
         return dtype_dispatcher(dtype_id, _cub_segmented_reduce_min(),
-                   workspace, workspace_size, x, y, num_segments, offset_start,
-                   offset_end, stream);
+                   workspace, workspace_size, x, y, num_segments, itr, stream);
     case CUPY_CUB_MAX:
         return dtype_dispatcher(dtype_id, _cub_segmented_reduce_max(),
-                   workspace, workspace_size, x, y, num_segments, offset_start,
-                   offset_end, stream);
+                   workspace, workspace_size, x, y, num_segments, itr, stream);
     case CUPY_CUB_PROD:
         return dtype_dispatcher(dtype_id, _cub_segmented_reduce_prod(),
-                   workspace, workspace_size, x, y, num_segments, offset_start,
-                   offset_end, stream);
+                   workspace, workspace_size, x, y, num_segments, itr, stream);
     default:
         throw std::runtime_error("Unsupported operation");
     }
 }
 
 size_t cub_device_segmented_reduce_get_workspace_size(void* x, void* y,
-    int num_segments, void* offset_start, void* offset_end,
+    int num_segments, int segment_size,
     cudaStream_t stream, int op, int dtype_id)
 {
     size_t workspace_size = 0;
-    cub_device_segmented_reduce(NULL, workspace_size, x, y, num_segments,
-                                offset_start, offset_end, stream,
+    cub_device_segmented_reduce(NULL, workspace_size, x, y,
+                                num_segments, segment_size, stream,
                                 op, dtype_id);
     return workspace_size;
 }

--- a/cupy/cuda/cupy_cub.cu
+++ b/cupy/cuda/cupy_cub.cu
@@ -144,7 +144,11 @@ struct _arange
     }
 };
 
+#ifndef CUPY_USE_HIP
 typedef TransformInputIterator<int, _arange, CountingInputIterator<int>> seg_offset_itr;
+#else
+typedef TransformInputIterator<int, _arange, rocprim::counting_iterator<int>> seg_offset_itr;
+#endif
 
 /*
    These stubs are needed because CUB does not handle NaNs properly, while NumPy has certain
@@ -755,7 +759,11 @@ void cub_device_segmented_reduce(void* workspace, size_t& workspace_size,
 {
     // CUB internally use int for offset...
     // This iterates over [0, segment_size, 2*segment_size, 3*segment_size, ...]
+    #ifndef CUPY_USE_HIP
     CountingInputIterator<int> count_itr(0);
+    #else
+    rocprim::counting_iterator<int> count_itr(0);
+    #endif
     _arange scaling(segment_size);
     seg_offset_itr itr(count_itr, scaling);
 

--- a/cupy/cuda/cupy_cub.h
+++ b/cupy/cuda/cupy_cub.h
@@ -26,12 +26,12 @@
 #endif
 
 void cub_device_reduce(void*, size_t&, void*, void*, int, cudaStream_t, int, int);
-void cub_device_segmented_reduce(void*, size_t&, void*, void*, int, void*, void*, cudaStream_t, int, int);
+void cub_device_segmented_reduce(void*, size_t&, void*, void*, int, int, cudaStream_t, int, int);
 void cub_device_spmv(void*, size_t&, void*, void*, void*, void*, void*, int, int, int, cudaStream_t, int);
 void cub_device_scan(void*, size_t&, void*, void*, int, cudaStream_t, int, int);
 void cub_device_histogram_range(void*, size_t&, void*, void*, int, void*, size_t, cudaStream_t, int);
 size_t cub_device_reduce_get_workspace_size(void*, void*, int, cudaStream_t, int, int);
-size_t cub_device_segmented_reduce_get_workspace_size(void*, void*, int, void*, void*, cudaStream_t, int, int);
+size_t cub_device_segmented_reduce_get_workspace_size(void*, void*, int, int, cudaStream_t, int, int);
 size_t cub_device_spmv_get_workspace_size(void*, void*, void*, void*, void*, int, int, int, cudaStream_t, int);
 size_t cub_device_scan_get_workspace_size(void*, void*, int, cudaStream_t, int, int);
 size_t cub_device_histogram_range_get_workspace_size(void*, void*, int, void*, size_t, cudaStream_t, int);


### PR DESCRIPTION
This PR eliminates the need of allocating a temporary array for offsets, and instead uses iterator combos to generate the offset on the fly. Both CPU and GPU times are improved! Thanks to @allisonvacanti's kind suggestion (https://github.com/NVIDIA/cub/issues/143#issuecomment-713162542) 🙂

Script:
```python
import cupy as cp
import numpy as np
from cupyx.time import repeat


cp.core._accelerator.set_routine_accelerators(['cub'])
cp.core._accelerator.set_reduction_accelerators([])

a = cp.random.random((512, 512, 512), dtype=cp.float32)

print(repeat(cp.min, (a, (2,)), n_repeat=500))
assert cp.allclose(cp.min(a, (2,)), np.min(cp.asnumpy(a), (2,)))
print(repeat(cp.min, (a, (1,2)), n_repeat=500))
assert cp.allclose(cp.min(a, (1,2,)), np.min(cp.asnumpy(a), (1,2,)))

print(repeat(cp.sum, (a, (2,)), n_repeat=500))
assert cp.allclose(cp.sum(a, (2,)), np.sum(cp.asnumpy(a), (2,)))
print(repeat(cp.sum, (a, (1,2)), n_repeat=500))
assert cp.allclose(cp.sum(a, (1,2,)), np.sum(cp.asnumpy(a), (1,2,)))
```

Before this change (CUDA 10.2 + GTX 2080 Ti + CuPy master):
```
amin                :    CPU:   36.052 us   +/- 1.225 (min:   34.683 / max:   47.770) us     GPU-0: 1813.325 us   +/-184.239 (min: 1726.816 / max: 2249.280) us
amin                :    CPU:   37.207 us   +/- 1.250 (min:   36.042 / max:   48.247) us     GPU-0:  953.375 us   +/- 1.494 (min:  950.720 / max:  964.512) us
sum                 :    CPU:   35.829 us   +/- 1.426 (min:   34.520 / max:   54.004) us     GPU-0: 1248.015 us   +/- 3.241 (min: 1237.888 / max: 1264.544) us
sum                 :    CPU:   36.759 us   +/- 1.182 (min:   35.576 / max:   48.580) us     GPU-0:  952.796 us   +/- 1.704 (min:  949.728 / max:  964.384) us
```
After:
```
amin                :    CPU:   15.956 us   +/- 0.847 (min:   15.113 / max:   27.030) us     GPU-0: 1610.127 us   +/-190.733 (min: 1506.112 / max: 2063.136) us
amin                :    CPU:   16.144 us   +/- 0.542 (min:   15.381 / max:   21.724) us     GPU-0:  932.887 us   +/- 0.897 (min:  930.816 / max:  936.768) us
sum                 :    CPU:   15.314 us   +/- 1.511 (min:   14.541 / max:   32.463) us     GPU-0:  974.946 us   +/- 3.985 (min:  961.056 / max:  994.176) us
sum                 :    CPU:   15.677 us   +/- 0.495 (min:   15.050 / max:   21.696) us     GPU-0:  931.743 us   +/- 1.103 (min:  929.728 / max:  935.648) us
```

TODO:
- [x] Check HIP.

Before (ROCm 3.5.0 + Radeon VII + CuPy master):
```
amin                :    CPU:   35.300 us   +/- 1.239 (min:   33.776 / max:   49.342) us     GPU-0: 1211.541 us   +/-10.813 (min: 1151.341 / max: 1242.492) us
amin                :    CPU:   35.665 us   +/- 0.951 (min:   34.425 / max:   42.835) us     GPU-0:  747.350 us   +/- 3.554 (min:  738.482 / max:  770.434) us
sum                 :    CPU:   34.583 us   +/- 0.809 (min:   32.973 / max:   40.837) us     GPU-0:  831.739 us   +/- 6.369 (min:  821.984 / max:  867.237) us
sum                 :    CPU:   35.261 us   +/- 0.958 (min:   33.696 / max:   42.570) us     GPU-0:  728.757 us   +/- 2.686 (min:  723.183 / max:  750.077) us
```

After:
```
amin                :    CPU:   11.638 us   +/- 1.156 (min:   10.818 / max:   21.508) us     GPU-0: 1129.634 us   +/-30.620 (min: 1059.580 / max: 1206.197) us
amin                :    CPU:   11.924 us   +/- 0.732 (min:   11.307 / max:   18.275) us     GPU-0:  725.122 us   +/- 3.979 (min:  714.306 / max:  751.795) us
sum                 :    CPU:   10.841 us   +/- 0.735 (min:   10.203 / max:   20.386) us     GPU-0:  802.274 us   +/- 6.512 (min:  787.351 / max:  831.245) us
sum                 :    CPU:   11.476 us   +/- 0.706 (min:   10.916 / max:   19.263) us     GPU-0:  700.614 us   +/- 2.587 (min:  695.497 / max:  723.329) us
```