### PR TITLE
Record Cython build and runtime versions

### DIFF
--- a/cupy/_util.pyx
+++ b/cupy/_util.pyx
@@ -12,6 +12,10 @@ import cupy
 from cupy.cuda cimport device
 
 
+DEF CYTHON_BUILD_VER = cython_version
+cython_build_ver = CYTHON_BUILD_VER
+
+
 ENABLE_SLICE_COPY = bool(
     int(os.environ.get('CUPY_EXPERIMENTAL_SLICE_COPY', 0)))
 

--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -766,6 +766,7 @@ def cythonize(extensions, arg_options):
         compile_time_env = {}
         cythonize_options['compile_time_env'] = compile_time_env
     compile_time_env['use_hip'] = arg_options['use_hip']
+    compile_time_env['cython_version'] = str(cython_version)
     if use_hip or arg_options['no_cuda']:
         compile_time_env['CUDA_VERSION'] = 0
     else:

--- a/cupyx/_runtime.py
+++ b/cupyx/_runtime.py
@@ -198,7 +198,7 @@ class _RuntimeInfo(object):
             ('NumPy Version', self.numpy_version),
             ('SciPy Version', self.scipy_version),
             ('Cython Build Version', self.cython_build_version),
-            ('Cython Version', self.cython_version),
+            ('Cython Runtime Version', self.cython_version),
             ('CUDA Root', self.cuda_path),
 
             ('CUDA Build Version', self.cuda_build_version),

--- a/cupyx/_runtime.py
+++ b/cupyx/_runtime.py
@@ -38,6 +38,11 @@ try:
 except ImportError:
     scipy = None
 
+try:
+    import Cython
+except ImportError:
+    Cython = None
+
 is_hip = cupy_backends.cuda.api.runtime.is_hip
 
 
@@ -113,6 +118,8 @@ class _RuntimeInfo(object):
     nccl_runtime_version = None
     cub_build_version = None
     cutensor_version = None
+    cython_build_version = None
+    cython_version = None
 
     numpy_version = None
     scipy_version = None
@@ -176,6 +183,10 @@ class _RuntimeInfo(object):
         if cutensor is not None:
             self.cutensor_version = cutensor.get_version()
 
+        self.cython_build_version = cupy._util.cython_build_ver
+        if Cython is not None:
+            self.cython_version = Cython.__version__
+
         self.numpy_version = numpy.version.full_version
         if scipy is not None:
             self.scipy_version = scipy.version.full_version
@@ -186,6 +197,8 @@ class _RuntimeInfo(object):
             ('CuPy Version', self.cupy_version),
             ('NumPy Version', self.numpy_version),
             ('SciPy Version', self.scipy_version),
+            ('Cython Build Version', self.cython_build_version),
+            ('Cython Version', self.cython_version),
             ('CUDA Root', self.cuda_path),
 
             ('CUDA Build Version', self.cuda_build_version),


### PR DESCRIPTION
The runtime version might be useful for #4141. It'd be shown as `None` if Cython is not found at runtime.

```
$ python -c "import cupy; cupy.show_config()"
OS                           : Linux-5.4.0-42-generic-x86_64-with-debian-buster-sid
CuPy Version                 : 8.0.0rc1
NumPy Version                : 1.19.1
SciPy Version                : 1.5.2
Cython Build Version         : 0.29.21
Cython Runtime Version       : 0.29.21
CUDA Root                    : /usr/local/cuda-10.2
CUDA Build Version           : 10020
CUDA Driver Version          : 11000
CUDA Runtime Version         : 10020
cuBLAS Version               : 10202
cuFFT Version                : 10102
cuRAND Version               : 10102
cuSOLVER Version             : (10, 3, 0)
cuSPARSE Version             : 10301
NVRTC Version                : (10, 2)
Thrust Version               : 100907
CUB Build Version            : 100800
cuDNN Build Version          : None
cuDNN Version                : None
NCCL Build Version           : 2507
NCCL Runtime Version         : 2507
cuTENSOR Version             : 10200
Device 0 Name                : GeForce RTX 2080 Ti
Device 0 Compute Capability  : 75
```