### PR TITLE
Fix `argwhere` for 0d inputs

### DIFF
--- a/cupy/_sorting/search.py
+++ b/cupy/_sorting/search.py
@@ -6,8 +6,6 @@ from cupy import _util
 from cupy.core import _routines_indexing as _indexing
 from cupy.core import _routines_statistics as _statistics
 
-import warnings
-
 
 def argmax(a, axis=None, dtype=None, out=None, keepdims=False):
     """Returns the indices of the maximum along an axis.

--- a/cupy/_sorting/search.py
+++ b/cupy/_sorting/search.py
@@ -118,8 +118,6 @@ def nanargmin(a, axis=None, dtype=None, out=None, keepdims=False):
 
     return _statistics._nanargmin(a, axis, dtype, out, keepdims)
 
-# TODO(okuta): Implement argwhere
-
 
 def nonzero(a):
     """Return the indices of the elements that are non-zero.
@@ -232,10 +230,6 @@ def argwhere(a):
 
     """
     _util.check_array(a, arg_name='a')
-    if a.ndim == 0:
-        warnings.warn(
-            'calling argwhere on 0d arrays is deprecated',
-            DeprecationWarning)
     return _indexing._ndarray_argwhere(a)
 
 

--- a/tests/cupy_tests/sorting_tests/test_search.py
+++ b/tests/cupy_tests/sorting_tests/test_search.py
@@ -413,8 +413,7 @@ class TestArgwhereZeroDimension(unittest.TestCase):
     @testing.numpy_cupy_array_equal()
     def test_argwhere(self, xp, dtype):
         array = xp.array(self.value, dtype=dtype)
-        with testing.assert_warns(DeprecationWarning):
-            return xp.argwhere(array)
+        return xp.argwhere(array)
 
 
 @testing.gpu

--- a/tests/cupy_tests/sorting_tests/test_search.py
+++ b/tests/cupy_tests/sorting_tests/test_search.py
@@ -402,14 +402,19 @@ class TestArgwhere(unittest.TestCase):
 
 
 @testing.parameterize(
-    {'array': cupy.array(1)},
+    {'value': 0},
+    {'value': 3},
 )
 @testing.gpu
+@testing.with_requires('numpy>=1.18')
 class TestArgwhereZeroDimension(unittest.TestCase):
 
-    def test_argwhere(self):
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_argwhere(self, xp, dtype):
+        array = xp.array(self.value, dtype=dtype)
         with testing.assert_warns(DeprecationWarning):
-            return cupy.nonzero(self.array)
+            return xp.argwhere(array)
 
 
 @testing.gpu


### PR DESCRIPTION
Fix #4166.

`argwhere` is added by #3135.