### PR TITLE
Use `testing.assert_warns`

### DIFF
--- a/tests/cupy_tests/polynomial_tests/test_polynomial.py
+++ b/tests/cupy_tests/polynomial_tests/test_polynomial.py
@@ -44,7 +44,7 @@ class TestPolynomial(unittest.TestCase):
                 xp.polynomial.polynomial.polyvander(a, 2.6)
 
     @testing.with_requires('numpy>=1.17')
-    @testing.for_all_dtypes()
+    @testing.for_all_dtypes(no_float16=True)
     @testing.numpy_cupy_allclose(rtol=1e-5)
     def test_polyvander_integral_float_degree(self, xp, dtype):
         a = testing.shaped_random((10,), xp, dtype)

--- a/tests/cupy_tests/polynomial_tests/test_polynomial.py
+++ b/tests/cupy_tests/polynomial_tests/test_polynomial.py
@@ -45,11 +45,11 @@ class TestPolynomial(unittest.TestCase):
 
     @testing.with_requires('numpy>=1.17')
     @testing.for_all_dtypes()
-    def test_polyvander_integral_float_degree(self, dtype):
-        for xp in (numpy, cupy):
-            a = testing.shaped_random((10,), xp, dtype)
-            with pytest.raises(DeprecationWarning):
-                xp.polynomial.polynomial.polyvander(a, 5.0)
+    @testing.numpy_cupy_allclose(rtol=1e-5)
+    def test_polyvander_integral_float_degree(self, xp, dtype):
+        a = testing.shaped_random((10,), xp, dtype)
+        with testing.assert_warns(DeprecationWarning):
+            return xp.polynomial.polynomial.polyvander(a, 5.0)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()


### PR DESCRIPTION
- It is not very good idea to assume `filterwarnings` in `[tool:pytest]` section contains `error::DeprecationWarning`.  See chainer/chainer#7824 for the previous discussion.
- It seems better to check results even if they are warned.  In fact, 46e5443be2c6de60a15c31f6b4e46866335a9a2a could have prevented the regression #4165.