### PR TITLE
Fix to use current stream properly with CUDA-related libraries

### DIFF
--- a/cupy_backends/cuda/stream.pyx
+++ b/cupy_backends/cuda/stream.pyx
@@ -40,6 +40,7 @@ cdef set_current_stream_ptr(intptr_t ptr):
     Args:
         ptr (intptr_t): CUDA stream pointer.
     """
+    global enable_current_stream
     enable_current_stream = True
     tls = _ThreadLocal.get()
     tls.set_current_stream_ptr(ptr)


### PR DESCRIPTION
Close #4136.

Currently, the current stream does not work with the following CUDA-related libraries as `enable_current_stream` flag is mistakenly updated as a local variable:

```
~/cupy$ git grep -i enable_current_stream
cupy_backends/cuda/libs/cublas.pyx:    """Set current stream when enable_current_stream is True
cupy_backends/cuda/libs/cublas.pyx:    if stream_module.enable_current_stream:
cupy_backends/cuda/libs/cudnn.pyx:    """Set current stream when enable_current_stream is True
cupy_backends/cuda/libs/cudnn.pyx:    if stream_module.enable_current_stream:
cupy_backends/cuda/libs/curand.pyx:    """Set current stream when enable_current_stream is True
cupy_backends/cuda/libs/curand.pyx:    if stream_module.enable_current_stream:
cupy_backends/cuda/libs/cusolver.pyx:    """Set current stream when enable_current_stream is True
cupy_backends/cuda/libs/cusolver.pyx:    if stream_module.enable_current_stream:
cupy_backends/cuda/libs/cusolver.pyx:    """Set current stream when enable_current_stream is True
cupy_backends/cuda/libs/cusolver.pyx:    if stream_module.enable_current_stream:
cupy_backends/cuda/libs/cusparse.pyx:    """Set current stream when enable_current_stream is True
cupy_backends/cuda/libs/cusparse.pyx:    if stream_module.enable_current_stream:
cupy_backends/cuda/stream.pxd:cdef bint enable_current_stream
cupy_backends/cuda/stream.pyx:    global enable_current_stream
cupy_backends/cuda/stream.pyx:    enable_current_stream = True
```

This PR fixes the issue to update the flag properly as a global variable.
