### PR TITLE
Remove unused features in `testing.parameterized`

### DIFF
--- a/cupy/testing/__init__.py
+++ b/cupy/testing/__init__.py
@@ -50,9 +50,7 @@ from cupy.testing.helper import shaped_random  # NOQA
 from cupy.testing.helper import generate_matrix  # NOQA
 from cupy.testing.helper import shaped_reverse_arange  # NOQA
 from cupy.testing.helper import with_requires  # NOQA
-from cupy.testing.parameterized import from_pytest_parameterize  # NOQA
 from cupy.testing.parameterized import parameterize  # NOQA
-from cupy.testing.parameterized import parameterize_pytest  # NOQA
 from cupy.testing.parameterized import product  # NOQA
 from cupy.testing.parameterized import product_dict  # NOQA
 from cupy.testing.random import fix_random  # NOQA

--- a/cupy/testing/_bundle.py
+++ b/cupy/testing/_bundle.py
@@ -1,4 +1,3 @@
-import collections
 import inspect
 import sys
 

--- a/cupy/testing/_bundle.py
+++ b/cupy/testing/_bundle.py
@@ -3,24 +3,6 @@ import inspect
 import sys
 
 
-# A tuple that represents a test case.
-# For bare (non-generated) test cases, [1] and [2] are None.
-# [0] Test case class
-# [1] Module name in whicn the class is defined
-# [2] Class name
-_TestCaseTuple = collections.namedtuple(
-    '_TestCaseTuple', ('klass', 'module_name', 'class_name'))
-
-
-class _ParameterizedTestCaseBundle(object):
-    def __init__(self, cases):
-        # cases is a list of _TestCaseTuple's
-        assert isinstance(cases, list)
-        assert all(isinstance(tup, _TestCaseTuple) for tup in cases)
-
-        self.cases = cases
-
-
 def make_decorator(test_case_generator):
     # `test_case_generator` is a callable that receives the source test class
     # (typically a subclass of unittest.TestCase) and returns an iterable of
@@ -32,42 +14,24 @@ def make_decorator(test_case_generator):
     # The method generator is also a callable that receives an original test
     # method and returns a new test method.
 
-    def f(cases):
-        if isinstance(cases, _ParameterizedTestCaseBundle):
-            # The input is a parameterized test case.
-            cases = cases.cases
-        else:
-            # Input is a bare test case, i.e. not one generated from another
-            # parameterize.
-            cases = [_TestCaseTuple(cases, None, None)]
+    def f(cls):
+        # The input is a bare test case
+        module_name = cls.__module__
 
-        generated_cases = []
-        for klass, mod_name, cls_name in cases:
-            if mod_name is not None:
-                # The input is a parameterized test case.
-                # Remove it from its module.
-                delattr(sys.modules[mod_name], cls_name)
-            else:
-                # The input is a bare test case
-                mod_name = klass.__module__
+        # Generate parameterized test cases out of the input test case.
+        module = sys.modules[module_name]
+        for cls_name, members, method_generator in test_case_generator(cls):
+            _generate_case(
+                cls, module, cls_name, members, method_generator)
 
-            # Generate parameterized test cases out of the input test case.
-            c = _generate_test_cases(mod_name, klass, test_case_generator)
-            generated_cases += c
-
-        # Return the bundle of generated cases to allow repeated application of
-        # parameterize decorators.
-        return _ParameterizedTestCaseBundle(generated_cases)
+        # Remove original base class
+        return None
     return f
 
 
 def _generate_case(base, module, cls_name, mb, method_generator):
-    # Returns a _TestCaseTuple.
-
     members = mb.copy()
-    # ismethod for Python 2 and isfunction for Python 3
-    base_methods = inspect.getmembers(
-        base, predicate=lambda m: inspect.ismethod(m) or inspect.isfunction(m))
+    base_methods = inspect.getmembers(base, predicate=inspect.isfunction)
     for name, value in base_methods:
         if not name.startswith('test_'):
             continue
@@ -80,19 +44,3 @@ def _generate_case(base, module, cls_name, mb, method_generator):
 
     # Add new test class to module
     setattr(module, cls_name, cls)
-
-    return _TestCaseTuple(cls, module.__name__, cls_name)
-
-
-def _generate_test_cases(module_name, base_class, test_case_generator):
-    # Returns a list of _TestCaseTuple's holding generated test cases.
-    module = sys.modules[module_name]
-
-    generated_cases = []
-    for cls_name, members, method_generator in (
-            test_case_generator(base_class)):
-        c = _generate_case(
-            base_class, module, cls_name, members, method_generator)
-        generated_cases.append(c)
-
-    return generated_cases

--- a/cupy/testing/parameterized.py
+++ b/cupy/testing/parameterized.py
@@ -101,7 +101,20 @@ def _parameterize_test_case(base, i, param):
 
 
 def parameterize(*params):
-    # TODO(kataoka): Add documentation
+    """Generates test classes with given sets of additional attributes
+
+    >>> @parameterize({"a": 1}, {"b": 2, "c": 3})
+    ... class TestX(unittest.TestCase):
+    ...     def test_y(self):
+    ...         pass
+
+    generates two classes `TestX_param_0_...`, `TestX_param_1_...` and
+    removes the original class `TestX`.
+
+    The specification is subject to change, which applies to all the non-NumPy
+    `testing` features.
+
+    """
     return _bundle.make_decorator(
         lambda base: _parameterize_test_case_generator(base, params))
 

--- a/cupy/testing/parameterized.py
+++ b/cupy/testing/parameterized.py
@@ -74,8 +74,8 @@ def _parameterize_test_case(base, i, param):
         else:
             mb[k] = v
 
+    # Wrap test methods to generate useful error message
     def method_generator(base_method):
-        # Generates a wrapped test method
 
         @functools.wraps(base_method)
         def new_method(self, *args, **kwargs):
@@ -101,7 +101,7 @@ def _parameterize_test_case(base, i, param):
 
 
 def parameterize(*params):
-    # TODO(niboshi): Add documentation
+    # TODO(kataoka): Add documentation
     return _bundle.make_decorator(
         lambda base: _parameterize_test_case_generator(base, params))
 

--- a/cupy/testing/parameterized.py
+++ b/cupy/testing/parameterized.py
@@ -106,56 +106,17 @@ def parameterize(*params):
         lambda base: _parameterize_test_case_generator(base, params))
 
 
-def _values_to_dicts(names, values):
-    assert isinstance(names, str)
-    assert isinstance(values, (tuple, list))
-
-    def safe_zip(ns, vs):
-        if len(ns) == 1:
-            return [(ns[0], vs)]
-        assert isinstance(vs, (tuple, list)) and len(ns) == len(vs)
-        return zip(ns, vs)
-
-    names = names.split(',')
-    params = [dict(safe_zip(names, value_list)) for value_list in values]
-    return params
-
-
-def from_pytest_parameterize(names, values):
-    # Pytest-style parameterization.
-    # TODO(niboshi): Add documentation
-    return _values_to_dicts(names, values)
-
-
-def parameterize_pytest(names, values):
-    # Pytest-style parameterization.
-    # TODO(niboshi): Add documentation
-    return parameterize(*from_pytest_parameterize(names, values))
-
-
 def product(parameter):
-    # TODO(niboshi): Add documentation
-    if isinstance(parameter, dict):
-        return product_dict(*[
-            _values_to_dicts(names, values)
-            for names, values in sorted(parameter.items())])
-
-    elif isinstance(parameter, list):
-        # list of lists of dicts
-        if not all(isinstance(_, list) for _ in parameter):
-            raise TypeError('parameter must be list of lists of dicts')
-        if not all(isinstance(_, dict) for l in parameter for _ in l):
-            raise TypeError('parameter must be list of lists of dicts')
-        return product_dict(*parameter)
-
-    else:
-        raise TypeError(
-            'parameter must be either dict or list. Actual: {}'.format(
-                type(parameter)))
+    # TODO(kataoka): Add documentation
+    assert isinstance(parameter, dict)
+    keys = sorted(parameter)
+    values = [parameter[key] for key in keys]
+    values_product = itertools.product(*values)
+    return [dict(zip(keys, vals)) for vals in values_product]
 
 
 def product_dict(*parameters):
-    # TODO(niboshi): Add documentation
+    # TODO(kataoka): Add documentation
     return [
         {k: v for dic in dicts for k, v in dic.items()}
         for dicts in itertools.product(*parameters)]

--- a/tests/cupy_tests/testing_tests/test_parameterized.py
+++ b/tests/cupy_tests/testing_tests/test_parameterized.py
@@ -62,25 +62,3 @@ class TestParameterize(unittest.TestCase):
     def test_skip(self):
         # Skipping the test case should not report error.
         self.skipTest('skip')
-
-
-@testing.parameterize(
-    {'param1': 1},
-    {'param1': 2})
-@testing.parameterize(
-    {'param2': 3},
-    {'param2': 4})
-class TestParameterizeTwice(unittest.TestCase):
-    # This test only checks if each of the parameterized combinations is a
-    # member of the expected combinations. This test does not check if each
-    # of the expected combinations is actually visited by the parameterization,
-    # as there are no way to test that in a robust manner.
-
-    def test_twice(self):
-        assert hasattr(self, 'param1')
-        assert hasattr(self, 'param2')
-        assert (self.param1, self.param2) in (
-            (1, 3),
-            (1, 4),
-            (2, 3),
-            (2, 4))

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
@@ -155,7 +155,7 @@ COMMON_FLOAT_PARAMS['dtype'] = [numpy.float32, numpy.float64]
 
 # The bulk of the tests are done with this class
 @testing.parameterize(*(
-    testing.product([
+    testing.product_dict(
         # Filter-function specific params
         testing.product({
             'filter': ['convolve', 'correlate'],
@@ -188,7 +188,7 @@ COMMON_FLOAT_PARAMS['dtype'] = [numpy.float32, numpy.float64]
             'shape': [(4, 5), (3, 4, 5)],  # no (1,3,4,5) due to scipy bug
             'mode': ['mirror'],
         })
-    ])
+    )
 ))
 @testing.gpu
 @testing.with_requires('scipy')
@@ -214,7 +214,7 @@ def dummy_deriv_func(input, axis, output, mode, cval, *args, **kwargs):
 # This tests filters that are very similar to other filters so we only check
 # the basics with them.
 @testing.parameterize(*(
-    testing.product([
+    testing.product_dict(
         testing.product({
             'filter': ['maximum_filter1d', 'maximum_filter'],
         }) + testing.product({
@@ -225,7 +225,7 @@ def dummy_deriv_func(input, axis, output, mode, cval, *args, **kwargs):
             'rank': [0, 1, -1],
         }),
         testing.product(COMMON_PARAMS)
-    ]) + testing.product([
+    ) + testing.product_dict(
         # All of these filters have no ksize and evoke undef behavior
         # outputting to uint8
         testing.product({
@@ -249,7 +249,7 @@ def dummy_deriv_func(input, axis, output, mode, cval, *args, **kwargs):
             'dtype': [numpy.uint8, numpy.float64],
             'output': [numpy.float64],
         })
-    ]) + testing.product([
+    ) + testing.product_dict(
         # These take derivative functions to compute part of the process
         testing.product({
             'filter': ['generic_laplace'],
@@ -262,7 +262,7 @@ def dummy_deriv_func(input, axis, output, mode, cval, *args, **kwargs):
             'shape': [(4, 5), (3, 4, 5), (1, 3, 4, 5)],
             'dtype': [numpy.uint8, numpy.float64],
         })
-    ])
+    )
 ))
 @testing.gpu
 @testing.with_requires('scipy')
@@ -304,7 +304,7 @@ def lt_pyfunc(x):
 
 # This tests generic_filter.
 @testing.parameterize(*(
-    testing.product([
+    testing.product_dict(
         testing.product({
             'filter': ['generic_filter'],
             'func_or_kernel': [(rms_raw, rms_pyfunc), (lt_red, lt_pyfunc)],
@@ -329,7 +329,7 @@ def lt_pyfunc(x):
             'shape': [(4, 5), (3, 4, 5)],
             'mode': ['mirror'],
         })
-    ]) + testing.product({
+    ) + testing.product({
         'filter': ['generic_filter'],
         'func_or_kernel': [(rms_red, rms_pyfunc), (lt_raw, lt_pyfunc)],
         'footprint': [False, True],
@@ -362,7 +362,7 @@ void shift(const double* in, ptrdiff_t in_length,
 
 # This tests generic_filter1d.
 @testing.parameterize(*(
-    testing.product([
+    testing.product_dict(
         testing.product({
             'filter': ['generic_filter1d'],
             'func_or_kernel': [(shift_raw, shift_pyfunc)],
@@ -387,7 +387,7 @@ void shift(const double* in, ptrdiff_t in_length,
             'shape': [(4, 5), (3, 4, 5)],
             'mode': ['mirror'],
         })
-    ])
+    )
 ))
 @testing.gpu
 @testing.with_requires('scipy')
@@ -402,7 +402,7 @@ class TestGeneric1DFilter(FilterTestCaseBase):
 
 # Tests things requiring scipy >= 1.5.0
 @testing.parameterize(*(
-    testing.product([
+    testing.product_dict(
         # Filter-function specific params
         testing.product({
             'filter': ['convolve', 'correlate',
@@ -419,7 +419,7 @@ class TestGeneric1DFilter(FilterTestCaseBase):
             'shape': [(1, 3, 4, 5)],
             'mode': ['mirror'],
         })
-    ])
+    )
 ))
 @testing.gpu
 # SciPy behavior fixed in 1.5.0: https://github.com/scipy/scipy/issues/11661
@@ -432,7 +432,7 @@ class TestMirrorWithDim1(FilterTestCaseBase):
 
 # Tests kernels large enough to trigger shell sort in rank-based filters
 @testing.parameterize(*(
-    testing.product([
+    testing.product_dict(
         testing.product({
             'filter': ['median_filter'],
         }) + testing.product({
@@ -447,7 +447,7 @@ class TestMirrorWithDim1(FilterTestCaseBase):
             'ksize': [16, 17],
             'shape': [(20, 21)],
         })
-    ])
+    )
 ))
 @testing.gpu
 @testing.with_requires('scipy')
@@ -459,7 +459,7 @@ class TestShellSort(FilterTestCaseBase):
 
 # Tests with Fortran-ordered arrays
 @testing.parameterize(*(
-    testing.product([
+    testing.product_dict(
         testing.product({
             'filter': ['convolve', 'correlate',
                        'minimum_filter', 'maximum_filter'],
@@ -473,7 +473,7 @@ class TestShellSort(FilterTestCaseBase):
             'shape': [(4, 5), (3, 4, 5)],
             'order': ['F'],
         })
-    ])
+    )
 ))
 @testing.gpu
 @testing.with_requires('scipy')
@@ -485,7 +485,7 @@ class TestFortranOrder(FilterTestCaseBase):
 
 # Tests with weight dtypes that are distinct from the input and output dtypes
 @testing.parameterize(*(
-    testing.product([
+    testing.product_dict(
         testing.product({
             'filter': ['convolve', 'correlate'],
         }) + testing.product({
@@ -500,7 +500,7 @@ class TestFortranOrder(FilterTestCaseBase):
                       numpy.float32, numpy.float64],
             'wdtype': [numpy.uint8, numpy.float64],
         })
-    ])
+    )
 ))
 @testing.gpu
 @testing.with_requires('scipy')


### PR DESCRIPTION
#2633 copied almost all the features in `chainer.testing.parameterized`, but some of them are unused.  For further refactoring, this PR removes unused / rarely used features.