### PR TITLE
[backport] Fix cupyx.seterr() when `linalg` not supplied

### DIFF
--- a/cupyx/_ufunc_config.py
+++ b/cupyx/_ufunc_config.py
@@ -88,7 +88,9 @@ def seterr(*, divide=None, over=None, under=None,
     if invalid is not None:
         raise NotImplementedError()
     if linalg is not None:
-        if linalg not in ('ignore', 'raise'):
+        if linalg in ('ignore', 'raise'):
+            _config.linalg = linalg
+        else:
             raise NotImplementedError()
     if fallback_mode is not None:
         if fallback_mode in ['print', 'warn', 'ignore', 'raise']:
@@ -103,7 +105,6 @@ def seterr(*, divide=None, over=None, under=None,
     _config.under = under
     _config.over = over
     _config.invalid = invalid
-    _config.linalg = linalg
 
     return old_state
 

--- a/tests/cupyx_tests/test_cupyx.py
+++ b/tests/cupyx_tests/test_cupyx.py
@@ -10,9 +10,12 @@ from cupy import testing
 class TestErrState(unittest.TestCase):
 
     def test_errstate(self):
+        orig = cupyx.geterr()
         with cupyx.errstate(divide=self.divide):
             state = cupyx.geterr()
-            assert state['divide'] == self.divide
+            assert state.pop('divide') == self.divide
+            orig.pop('divide')
+            assert state == orig
 
     def test_seterr(self):
         pass


### PR DESCRIPTION
Backport of #4150