### PR TITLE
[backport] Fix `nonzero` for 0d inputs

### DIFF
--- a/cupy/core/_routines_indexing.pyx
+++ b/cupy/core/_routines_indexing.pyx
@@ -1,5 +1,6 @@
 # distutils: language = c++
 import sys
+import warnings
 
 import numpy
 
@@ -58,7 +59,10 @@ cdef tuple _ndarray_nonzero(ndarray self):
     if ndim >= 1:
         return tuple([dst[:, i] for i in range(ndim)])
     else:
-        return ndarray((0,), dtype=numpy.int64),
+        warnings.warn(
+            'calling nonzero on 0d arrays is deprecated',
+            DeprecationWarning)
+        return cupy.zeros(dst.shape[0], numpy.int64),
 
 
 # TODO(kataoka): Rename the function because `ndarray` does not have

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -728,11 +728,6 @@ cdef class ndarray:
             :func:`numpy.nonzero`
 
         """
-        if self.ndim == 0:
-            warnings.warn(
-                'calling nonzero on 0d arrays is deprecated',
-                DeprecationWarning)
-
         return _indexing._ndarray_nonzero(self)
 
     cpdef ndarray compress(self, condition, axis=None, out=None):

--- a/tests/cupy_tests/sorting_tests/test_search.py
+++ b/tests/cupy_tests/sorting_tests/test_search.py
@@ -358,11 +358,11 @@ class TestNonzero(unittest.TestCase):
 class TestNonzeroZeroDimension(unittest.TestCase):
 
     @testing.for_all_dtypes()
-    def test_nonzero(self, dtype):
-        for xp in (numpy, cupy):
-            array = xp.array(self.array, dtype=dtype)
-            with pytest.raises(DeprecationWarning):
-                xp.nonzero(array)
+    @testing.numpy_cupy_array_equal()
+    def test_nonzero(self, xp, dtype):
+        array = xp.array(self.array, dtype=dtype)
+        with testing.assert_warns(DeprecationWarning):
+            return xp.nonzero(array)
 
 
 @testing.parameterize(


### PR DESCRIPTION
Backport of #4168