### PR TITLE
Add a note in `free_all_blocks` reference

### DIFF
--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -1277,6 +1277,11 @@ cdef class MemoryPool(object):
             stream (cupy.cuda.Stream): Release free blocks in the arena
                 of the given stream. The default releases blocks in all
                 arenas.
+
+        .. note::
+            A memory pool may split a free block for space efficiency. A split
+            block is not released until all its parts are merged back into one
+            even if :meth:`free_all_blocks` is called.
         """
         mp = <SingleDeviceMemoryPool>self._pools[device.get_device_id()]
         mp.free_all_blocks(stream=stream)


### PR DESCRIPTION
Rel #4171.

This PR add a note about split free blocks in `free_all_blocks` reference.
