### PR TITLE
Fix ndarray binary operations with non-CuPy arrays to return `NotImplemented`

### DIFF
--- a/cupy/core/_scalar.pxd
+++ b/cupy/core/_scalar.pxd
@@ -31,5 +31,6 @@ cdef class CScalar(CPointer):
 
 cpdef str get_typename(dtype)
 
+cdef set scalar_type_set
 cdef CScalar scalar_to_c_scalar(object x)
 cdef object scalar_to_numpy_scalar(object x)

--- a/cupy/core/_scalar.pyx
+++ b/cupy/core/_scalar.pyx
@@ -92,6 +92,7 @@ _setup_type_dict()
 
 cdef set _python_scalar_type_set = {int, float, bool, complex}
 cdef set _numpy_scalar_type_set = set(_typenames.keys())
+cdef set scalar_type_set = _python_scalar_type_set | _numpy_scalar_type_set
 
 
 _int_iinfo = numpy.iinfo(int)

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -994,92 +994,92 @@ cdef class ndarray:
 
     def __add__(x, y):
         if _should_use_rop(x, y):
-            return y.__radd__(x)
+            return NotImplemented
         else:
             return _math._add(x, y)
 
     def __sub__(x, y):
         if _should_use_rop(x, y):
-            return y.__rsub__(x)
+            return NotImplemented
         else:
             return _math._subtract(x, y)
 
     def __mul__(x, y):
         if _should_use_rop(x, y):
-            return y.__rmul__(x)
+            return NotImplemented
         else:
             return _math._multiply(x, y)
 
     def __matmul__(x, y):
         if _should_use_rop(x, y):
-            return y.__rmatmul__(x)
+            return NotImplemented
         else:
             return _linalg.matmul(x, y)
 
     def __div__(x, y):
         if _should_use_rop(x, y):
-            return y.__rdiv__(x)
+            return NotImplemented
         else:
             return _math._divide(x, y)
 
     def __truediv__(x, y):
         if _should_use_rop(x, y):
-            return y.__rtruediv__(x)
+            return NotImplemented
         else:
             return _math._true_divide(x, y)
 
     def __floordiv__(x, y):
         if _should_use_rop(x, y):
-            return y.__rfloordiv__(x)
+            return NotImplemented
         else:
             return _math._floor_divide(x, y)
 
     def __mod__(x, y):
         if _should_use_rop(x, y):
-            return y.__rmod__(x)
+            return NotImplemented
         else:
             return _math._remainder(x, y)
 
     def __divmod__(x, y):
         if _should_use_rop(x, y):
-            return y.__rdivmod__(x)
+            return NotImplemented
         else:
             return divmod(x, y)
 
     def __pow__(x, y, modulo):
         # Note that we ignore the modulo argument as well as NumPy.
         if _should_use_rop(x, y):
-            return y.__rpow__(x)
+            return NotImplemented
         else:
             return _math._power(x, y)
 
     def __lshift__(x, y):
         if _should_use_rop(x, y):
-            return y.__rlshift__(x)
+            return NotImplemented
         else:
             return _binary._left_shift(x, y)
 
     def __rshift__(x, y):
         if _should_use_rop(x, y):
-            return y.__rrshift__(x)
+            return NotImplemented
         else:
             return _binary._right_shift(x, y)
 
     def __and__(x, y):
         if _should_use_rop(x, y):
-            return y.__rand__(x)
+            return NotImplemented
         else:
             return _binary._bitwise_and(x, y)
 
     def __or__(x, y):
         if _should_use_rop(x, y):
-            return y.__ror__(x)
+            return NotImplemented
         else:
             return _binary._bitwise_or(x, y)
 
     def __xor__(x, y):
         if _should_use_rop(x, y):
-            return y.__rxor__(x)
+            return NotImplemented
         else:
             return _binary._bitwise_xor(x, y)
 

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1,6 +1,7 @@
 # distutils: language = c++
 
 import functools
+import numbers
 import os
 import pickle
 import re
@@ -55,7 +56,7 @@ from cupy_backends.cuda.libs cimport cublas
 
 @cython.profile(False)
 cdef inline _should_use_rop(x, y):
-    return hasattr(y, '__array_ufunc__') and not isinstance(y, _KNOWN_TYPES)
+    return not isinstance(y, _KNOWN_TYPES) and hasattr(y, '__array_ufunc__')
 
 
 cdef tuple _HANDLED_TYPES, _KNOWN_TYPES
@@ -1725,7 +1726,7 @@ cpdef strides_t _get_strides_for_order_K(ndarray x, dtype, shape=None):
 
 
 _HANDLED_TYPES = (ndarray, numpy.ndarray)
-_KNOWN_TYPES = (ndarray, numpy.generic, bool, int, float, complex)
+_KNOWN_TYPES = (ndarray, numbers.Number)
 
 
 # =============================================================================

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1,7 +1,6 @@
 # distutils: language = c++
 
 import functools
-import numbers
 import os
 import pickle
 import re
@@ -15,7 +14,6 @@ import cupy
 from cupy.core._kernel import create_ufunc
 from cupy.core._kernel import ElementwiseKernel
 from cupy.core._kernel import ufunc  # NOQA
-from cupy.core cimport _scalar
 from cupy.core._ufuncs import elementwise_copy
 from cupy.core._ufuncs import elementwise_copy_where
 from cupy.core import flags
@@ -44,6 +42,7 @@ from cupy.core cimport _routines_manipulation as _manipulation
 from cupy.core cimport _routines_math as _math
 from cupy.core cimport _routines_sorting as _sorting
 from cupy.core cimport _routines_statistics as _statistics
+from cupy.core cimport _scalar
 from cupy.core cimport dlpack
 from cupy.core cimport internal
 from cupy.cuda cimport device

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1800,7 +1800,7 @@ cpdef strides_t _get_strides_for_order_K(ndarray x, dtype, shape=None):
     return strides
 
 
-_HANDLED_TYPES = (ndarray, numpy.ndarray, numbers.Number)
+_HANDLED_TYPES = (ndarray, numpy.ndarray, numpy.bool_, numbers.Number)
 
 
 # =============================================================================

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1,6 +1,7 @@
 # distutils: language = c++
 
 import functools
+import numbers
 import os
 import pickle
 import re
@@ -1356,12 +1357,14 @@ cdef class ndarray:
         numpy array.
         """
         import cupy  # top-level ufuncs
+        inout = inputs
         if 'out' in kwargs:
             # need to unfold tuple argument in kwargs
             out = kwargs['out']
             if len(out) != 1:
                 raise ValueError('The \'out\' parameter must have exactly one '
                                  'array value')
+            inout += out
             kwargs['out'] = out[0]
 
         if method == '__call__':
@@ -1373,6 +1376,9 @@ cdef class ndarray:
                 cp_ufunc = getattr(cupy, name)
             except AttributeError:
                 return NotImplemented
+            for x in inout:
+                if not isinstance(x, _HANDLED_TYPES):
+                    return NotImplemented
             if name in [
                     'greater', 'greater_equal', 'less', 'less_equal',
                     'equal', 'not_equal']:
@@ -1759,7 +1765,7 @@ cpdef strides_t _get_strides_for_order_K(ndarray x, dtype, shape=None):
     return strides
 
 
-_HANDLED_TYPES = (ndarray, numpy.ndarray)
+_HANDLED_TYPES = (ndarray, numpy.ndarray, numbers.Number)
 
 
 # =============================================================================

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -970,20 +970,34 @@ cdef class ndarray:
     # Comparison operators:
 
     def __richcmp__(object self, object other, int op):
-        if isinstance(other, numpy.ndarray) and other.ndim == 0:
-            other = other.item()  # Workaround for numpy<1.13
-        if op == 0:
-            return _logic._ndarray_less(self, other)
-        if op == 1:
-            return _logic._ndarray_less_equal(self, other)
-        if op == 2:
-            return _logic._ndarray_equal(self, other)
-        if op == 3:
-            return _logic._ndarray_not_equal(self, other)
-        if op == 4:
-            return _logic._ndarray_greater(self, other)
-        if op == 5:
-            return _logic._ndarray_greater_equal(self, other)
+        if isinstance(other, ndarray):
+            if op == 0:
+                return _logic._ndarray_less(self, other)
+            if op == 1:
+                return _logic._ndarray_less_equal(self, other)
+            if op == 2:
+                return _logic._ndarray_equal(self, other)
+            if op == 3:
+                return _logic._ndarray_not_equal(self, other)
+            if op == 4:
+                return _logic._ndarray_greater(self, other)
+            if op == 5:
+                return _logic._ndarray_greater_equal(self, other)
+        elif not _should_use_rop(self, other):
+            if isinstance(other, numpy.ndarray) and other.ndim == 0:
+                other = other.item()  # Workaround for numpy<1.13
+            if op == 0:
+                return numpy.less(self, other)
+            if op == 1:
+                return numpy.less_equal(self, other)
+            if op == 2:
+                return numpy.equal(self, other)
+            if op == 3:
+                return numpy.not_equal(self, other)
+            if op == 4:
+                return numpy.greater(self, other)
+            if op == 5:
+                return numpy.greater_equal(self, other)
         return NotImplemented
 
     # Truth value of an array (bool):

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -55,12 +55,10 @@ from cupy_backends.cuda.libs cimport cublas
 
 @cython.profile(False)
 cdef inline _should_use_rop(x, y):
-    xp = getattr(x, '__array_priority__', 0)
-    yp = getattr(y, '__array_priority__', 0)
-    return xp < yp and not isinstance(y, ndarray)
+    return hasattr(y, '__array_ufunc__') and not isinstance(y, _KNOWN_TYPES)
 
 
-cdef tuple _HANDLED_TYPES
+cdef tuple _HANDLED_TYPES, _KNOWN_TYPES
 
 
 cdef class ndarray:
@@ -1727,6 +1725,7 @@ cpdef strides_t _get_strides_for_order_K(ndarray x, dtype, shape=None):
 
 
 _HANDLED_TYPES = (ndarray, numpy.ndarray)
+_KNOWN_TYPES = (ndarray, numpy.generic, bool, int, float, complex)
 
 
 # =============================================================================

--- a/tests/cupy_tests/test_numpy_interop.py
+++ b/tests/cupy_tests/test_numpy_interop.py
@@ -86,6 +86,12 @@ class TestArrayUfunc:
         with pytest.raises(TypeError):
             x @= y
 
+    def test_lt(self):
+        x = cupy.array([3, 7])
+        y = MockArray()
+        assert (x < y) == ('less', (x, y), {})
+        assert (y < x) == ('less', (y, x), {})
+
 
 class MockArray2:
     __array_ufunc__ = None
@@ -102,6 +108,12 @@ class MockArray2:
     def __rmatmul__(self, other):
         return 'rmatmul'
 
+    def __lt__(self, other):
+        return 'lt'
+
+    def __gt__(self, other):
+        return 'gt'
+
 
 @testing.gpu
 class TestArrayUfuncOptout:
@@ -117,3 +129,9 @@ class TestArrayUfuncOptout:
         y = MockArray2()
         assert x @ y == 'rmatmul'
         assert y @ x == 'matmul'
+
+    def test_lt(self):
+        x = cupy.array([3, 7])
+        y = MockArray2()
+        assert (x < y) == 'gt'
+        assert (y < x) == 'lt'


### PR DESCRIPTION
Fix #4118.