### PR TITLE
Add repr of parameterized test and stop adding error message

### DIFF
--- a/cupy/testing/parameterized.py
+++ b/cupy/testing/parameterized.py
@@ -1,13 +1,8 @@
-import functools
 import itertools
-import io
 import types
 import typing as tp  # NOQA
-import unittest
 
 from cupy.testing import _bundle
-from cupy.cuda import cufft
-from cupy.cuda import driver
 
 
 def _param_to_str(obj):
@@ -55,11 +50,11 @@ def _parameterize_test_case_generator(base, params):
 def _parameterize_test_case(base, i, param):
     cls_name = _make_class_name(base.__name__, i, param)
 
-    def __str__(self):
-        name = base.__str__(self)
-        return '%s  parameter: %s' % (name, param)
+    def __repr__(self):
+        name = base.__repr__(self)
+        return '<%s  parameter: %s>' % (name, param)
 
-    mb = {'__str__': __str__}
+    mb = {'__repr__': __repr__}
     for k, v in sorted(param.items()):
         if isinstance(v, types.FunctionType):
 
@@ -74,30 +69,7 @@ def _parameterize_test_case(base, i, param):
         else:
             mb[k] = v
 
-    def method_generator(base_method):
-        # Generates a wrapped test method
-
-        @functools.wraps(base_method)
-        def new_method(self, *args, **kwargs):
-            try:
-                return base_method(self, *args, **kwargs)
-            except unittest.SkipTest:
-                raise
-            except Exception as e:
-                s = io.StringIO()
-                s.write('Parameterized test failed.\n\n')
-                s.write('Base test method: {}.{}\n'.format(
-                    base.__name__, base_method.__name__))
-                s.write('Test parameters:\n')
-                for k, v in sorted(param.items()):
-                    s.write('  {}: {}\n'.format(k, v))
-                err_class = e.__class__
-                if isinstance(e, (driver.CUDADriverError, cufft.CuFFTError)):
-                    err_class, = err_class.__bases__
-                raise err_class(s.getvalue()).with_traceback(e.__traceback__)
-        return new_method
-
-    return (cls_name, mb, method_generator)
+    return (cls_name, mb, lambda method: method)
 
 
 def parameterize(*params):


### PR DESCRIPTION
chainer/chainer#3661 started editing exceptions of test failures because PyTest does not print str(self), while Nosetests does. However, it should have been utilized that PyTest shows repr of local variables.

Fixes #3915.

<details><summary>before</summary>

```
__________________________ TestA_param_0_{x=1}.test_a __________________________

self = <cupy.testing._bundle.TestA_param_0_{x=1} testMethod=test_a>, args = ()
kwargs = {}, s = <_io.StringIO object at 0x7fdb15dc5ee0>, k = 'x', v = 1
err_class = <class 'AssertionError'>

    @functools.wraps(base_method)
    def new_method(self, *args, **kwargs):
        try:
>           return base_method(self, *args, **kwargs)

../cupy/testing/parameterized.py:83:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <cupy.testing._bundle.TestA_param_0_{x=1} testMethod=test_a>

    def test_a(self):
        """This is test_a"""
>       assert self.x == 2
E       AssertionError: assert 1 == 2
E        +  where 1 = <cupy.testing._bundle.TestA_param_0_{x=1} testMethod=test_a>.x

test_tmp.py:11: AssertionError

During handling of the above exception, another exception occurred:

self = <cupy.testing._bundle.TestA_param_0_{x=1} testMethod=test_a>

    def test_a(self):
        """This is test_a"""
>       assert self.x == 2
E       AssertionError: Parameterized test failed.
E
E       Base test method: TestA.test_a
E       Test parameters:
E         x: 1

test_tmp.py:11: AssertionError
```
</details>
<details><summary>after</summary>

```
__________________________ TestA_param_0_{x=1}.test_a __________________________

self = <<cupy.testing._bundle.TestA_param_0_{x=1} testMethod=test_a>  parameter: {'x': 1}>

    def test_a(self):
        """This is test_a"""
>       assert self.x == 2
E       AssertionError: assert 1 == 2
E        +  where 1 = <<cupy.testing._bundle.TestA_param_0_{x=1} testMethod=test_a>  parameter: {'x': 1}>.x

test_tmp.py:11: AssertionError
```
</details>
