### PR TITLE
ROCm: Cover more new BLAS/SOLVER functions

### DIFF
--- a/cupy/cusolver.py
+++ b/cupy/cusolver.py
@@ -25,6 +25,15 @@ _available_cuda_version = {
 
 _available_hip_version = {
     'potrfBatched': (306, None),
+    # Below are APIs supported by CUDA but not yet by HIP. We need them here
+    # so that our test suite can cover both platforms.
+    'gesvdj': (_numpy.inf, None),
+    'gesvda': (_numpy.inf, None),
+    'potrsBatched': (_numpy.inf, None),
+    'syevj': (_numpy.inf, None),
+    'gesv': (_numpy.inf, None),
+    'gels': (_numpy.inf, None),
+    'csrlsvqr': (_numpy.inf, None),
 }
 
 _available_compute_capability = {

--- a/cupy/linalg/_decomposition.py
+++ b/cupy/linalg/_decomposition.py
@@ -464,7 +464,7 @@ def svd(a, full_matrices=True, compute_uv=True):
         # TODO(leofang): WHY????
         rwork_ptr = 0
     else:
-        rwork = cupy.empty(min(m,n)-1, dtype=s_dtype)
+        rwork = cupy.empty(min(m, n)-1, dtype=s_dtype)
         rwork_ptr = rwork.data.ptr
     gesvd(
         handle, job_u, job_vt, m, n, x.data.ptr, m, s.data.ptr, u_ptr, m,

--- a/cupy/linalg/_decomposition.py
+++ b/cupy/linalg/_decomposition.py
@@ -461,7 +461,8 @@ def svd(a, full_matrices=True, compute_uv=True):
     buffersize = gesvd_bufferSize(handle, m, n)
     workspace = cupy.empty(buffersize, dtype=a_dtype)
     if not runtime.is_hip:
-        # TODO(leofang): WHY????
+        # rwork can be NULL if the information from supperdiagonal isn't needed
+        # https://docs.nvidia.com/cuda/cusolver/index.html#cuSolverDN-lt-t-gt-gesvd  # noqa
         rwork_ptr = 0
     else:
         rwork = cupy.empty(min(m, n)-1, dtype=s_dtype)

--- a/cupy/linalg/_decomposition.py
+++ b/cupy/linalg/_decomposition.py
@@ -1,6 +1,7 @@
 import numpy
 
 import cupy
+from cupy_backends.cuda.api import runtime
 from cupy_backends.cuda.libs import cublas
 from cupy_backends.cuda.libs import cusolver
 from cupy.cuda import device
@@ -459,9 +460,16 @@ def svd(a, full_matrices=True, compute_uv=True):
 
     buffersize = gesvd_bufferSize(handle, m, n)
     workspace = cupy.empty(buffersize, dtype=a_dtype)
+    if not runtime.is_hip:
+        # TODO(leofang): WHY????
+        rwork_ptr = 0
+    else:
+        rwork = cupy.empty(min(m,n)-1, dtype=s_dtype)
+        rwork_ptr = rwork.data.ptr
     gesvd(
         handle, job_u, job_vt, m, n, x.data.ptr, m, s.data.ptr, u_ptr, m,
-        vt_ptr, n, workspace.data.ptr, buffersize, 0, dev_info.data.ptr)
+        vt_ptr, n, workspace.data.ptr, buffersize, rwork_ptr,
+        dev_info.data.ptr)
     cupy.linalg._util._check_cusolver_dev_info_if_synchronization_allowed(
         gesvd, dev_info)
 

--- a/cupy_backends/cuda/libs/cublas.pyx
+++ b/cupy_backends/cuda/libs/cublas.pyx
@@ -340,23 +340,6 @@ cdef extern from '../../cupy_blas.h' nogil:
         Handle handle, FillMode uplo, int n, const double *A, int lda,
         double *AP)
 
-###############################################################################
-# Util
-###############################################################################
-
-cdef cuComplex get_cu_complex(float complex a):
-    cdef cuComplex ret
-    ret.x = a.real
-    ret.y = a.imag
-    return ret
-
-
-cdef cuDoubleComplex get_cu_double_complex(double complex a):
-    cdef cuDoubleComplex ret
-    ret.x = a.real
-    ret.y = a.imag
-    return ret
-
 
 ###############################################################################
 # Error handling

--- a/cupy_backends/cuda/libs/cusolver.pyx
+++ b/cupy_backends/cuda/libs/cusolver.pyx
@@ -6,6 +6,7 @@ from cupy_backends.cuda.api cimport driver
 from cupy_backends.cuda.api cimport runtime
 from cupy_backends.cuda cimport stream as stream_module
 
+
 ###############################################################################
 # Extern
 ###############################################################################

--- a/cupy_backends/hip/cupy_hipblas.h
+++ b/cupy_backends/hip/cupy_hipblas.h
@@ -572,9 +572,9 @@ cublasStatus_t cublasCgeam(
         int m, int n, const cuComplex *alpha,
         const cuComplex *A, int lda, const cuComplex *beta, const cuComplex *B, int ldb,
         cuComplex *C, int ldc) {
-    if (HIP_VERSION < 307) {
-        return HIPBLAS_STATUS_NOT_SUPPORTED;
-    }
+    #if HIP_VERSION < 307
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+    #else
     return hipblasCgeam(handle, convert_hipblasOperation_t(transa), convert_hipblasOperation_t(transb), m, n,
                         reinterpret_cast<const hipblasComplex*>(alpha),
                         reinterpret_cast<const hipblasComplex*>(A),
@@ -584,6 +584,7 @@ cublasStatus_t cublasCgeam(
                         ldb,
                         reinterpret_cast<hipblasComplex*>(C),
                         ldc);
+    #endif
 }
 
 cublasStatus_t cublasZgeam(
@@ -592,9 +593,9 @@ cublasStatus_t cublasZgeam(
         int m, int n, const cuDoubleComplex *alpha,
         const cuDoubleComplex *A, int lda, const cuDoubleComplex *beta, const cuDoubleComplex *B, int ldb,
 	    cuDoubleComplex *C, int ldc) {
-    if (HIP_VERSION < 307) {
-        return HIPBLAS_STATUS_NOT_SUPPORTED;
-    }
+    #if HIP_VERSION < 307
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+    #else
     return hipblasZgeam(handle, convert_hipblasOperation_t(transa), convert_hipblasOperation_t(transb), m, n,
                         reinterpret_cast<const hipblasDoubleComplex*>(alpha),
                         reinterpret_cast<const hipblasDoubleComplex*>(A),
@@ -604,52 +605,57 @@ cublasStatus_t cublasZgeam(
                         ldb,
                         reinterpret_cast<hipblasDoubleComplex*>(C),
                         ldc);
+    #endif
 }
 
 cublasStatus_t cublasSdgmm(cublasHandle_t handle, cublasSideMode_t mode, int m, int n,
                            const float *A, int lda,
                            const float *x, int incx,
                            float *C, int ldc) {
-    if (HIP_VERSION < 306) {
-        return HIPBLAS_STATUS_NOT_SUPPORTED;
-    }
+    #if HIP_VERSION < 306
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+    #else
     return hipblasSdgmm(handle, convert_hipblasSideMode_t(mode), m, n, A, lda, x, incx, C, ldc);
+    #endif
 }
 
 cublasStatus_t cublasDdgmm(cublasHandle_t handle, cublasSideMode_t mode, int m, int n,
                            const double *A, int lda,
                            const double *x, int incx,
                            double *C, int ldc) {
-    if (HIP_VERSION < 306) {
-        return HIPBLAS_STATUS_NOT_SUPPORTED;
-    }
+    #if HIP_VERSION < 306
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+    #else
     return hipblasDdgmm(handle, convert_hipblasSideMode_t(mode), m, n, A, lda, x, incx, C, ldc);
+    #endif
 }
 
 cublasStatus_t cublasCdgmm(cublasHandle_t handle, cublasSideMode_t mode, int m, int n,
                            const cuComplex *A, int lda,
                            const cuComplex *x, int incx,
                            cuComplex *C, int ldc) {
-    if (HIP_VERSION < 306) {
-        return HIPBLAS_STATUS_NOT_SUPPORTED;
-    }
+    #if HIP_VERSION < 306
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+    #else
     return hipblasCdgmm(handle, convert_hipblasSideMode_t(mode), m, n,
                         reinterpret_cast<const hipblasComplex*>(A), lda,
                         reinterpret_cast<const hipblasComplex*>(x), incx,
                         reinterpret_cast<hipblasComplex*>(C), ldc);
+    #endif
 }
 
 cublasStatus_t cublasZdgmm(cublasHandle_t handle, cublasSideMode_t mode, int m, int n,
                            const cuDoubleComplex *A, int lda,
                            const cuDoubleComplex *x, int incx,
                            cuDoubleComplex *C, int ldc) {
-    if (HIP_VERSION < 306) {
-        return HIPBLAS_STATUS_NOT_SUPPORTED;
-    }
+    #if HIP_VERSION < 306
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+    #else
     return hipblasZdgmm(handle, convert_hipblasSideMode_t(mode), m, n,
                         reinterpret_cast<const hipblasDoubleComplex*>(A), lda,
                         reinterpret_cast<const hipblasDoubleComplex*>(x), incx,
                         reinterpret_cast<hipblasDoubleComplex*>(C), ldc);
+    #endif
 }
 
 cublasStatus_t cublasSgetriBatched(cublasHandle_t handle,
@@ -661,10 +667,11 @@ cublasStatus_t cublasSgetriBatched(cublasHandle_t handle,
                                    int ldc,
                                    int *info,
                                    int batchSize) {
-    if (HIP_VERSION <= 307) {
-        return HIPBLAS_STATUS_NOT_SUPPORTED;
-    }
+    #if HIP_VERSION < 308
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+    #else
     return hipblasSgetriBatched(handle, n, const_cast<float* const*>(A), lda, const_cast<int*>(P), C, ldc, info, batchSize);
+    #endif
 }
 
 cublasStatus_t cublasDgetriBatched(cublasHandle_t handle,
@@ -676,10 +683,11 @@ cublasStatus_t cublasDgetriBatched(cublasHandle_t handle,
                                    int ldc,
                                    int *info,
                                    int batchSize) {
-    if (HIP_VERSION <= 307) {
-        return HIPBLAS_STATUS_NOT_SUPPORTED;
-    }
+    #if HIP_VERSION < 308
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+    #else
     return hipblasDgetriBatched(handle, n, const_cast<double* const*>(A), lda, const_cast<int*>(P), C, ldc, info, batchSize);
+    #endif
 }
 
 cublasStatus_t cublasCgetriBatched(cublasHandle_t handle,
@@ -691,14 +699,15 @@ cublasStatus_t cublasCgetriBatched(cublasHandle_t handle,
                                    int ldc,
                                    int *info,
                                    int batchSize) {
-    if (HIP_VERSION <= 307) {
-        return HIPBLAS_STATUS_NOT_SUPPORTED;
-    }
+    #if HIP_VERSION < 308
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+    #else
     return hipblasCgetriBatched(handle, n,
                                 reinterpret_cast<hipblasComplex* const*>(const_cast<cuComplex* const*>(A)),
                                 lda, const_cast<int*>(P),
                                 reinterpret_cast<hipblasComplex* const*>(C),
                                 ldc, info, batchSize);
+    #endif
 }
 
 cublasStatus_t cublasZgetriBatched(cublasHandle_t handle,
@@ -710,14 +719,15 @@ cublasStatus_t cublasZgetriBatched(cublasHandle_t handle,
                                    int ldc,
                                    int *info,
                                    int batchSize) {
-    if (HIP_VERSION <= 307) {
-        return HIPBLAS_STATUS_NOT_SUPPORTED;
-    }
+    #if HIP_VERSION < 308
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+    #else
     return hipblasZgetriBatched(handle, n,
                                 reinterpret_cast<hipblasDoubleComplex* const*>(const_cast<cuDoubleComplex* const*>(A)),
                                 lda, const_cast<int*>(P),
                                 reinterpret_cast<hipblasDoubleComplex* const*>(C),
                                 ldc, info, batchSize);
+    #endif
 }
 
 cublasStatus_t cublasSgemmStridedBatched(

--- a/cupy_backends/hip/cupy_hipblas.h
+++ b/cupy_backends/hip/cupy_hipblas.h
@@ -572,7 +572,18 @@ cublasStatus_t cublasCgeam(
         int m, int n, const cuComplex *alpha,
         const cuComplex *A, int lda, const cuComplex *beta, const cuComplex *B, int ldb,
         cuComplex *C, int ldc) {
-    return HIPBLAS_STATUS_NOT_SUPPORTED;
+    if (HIP_VERSION < 307) {
+        return HIPBLAS_STATUS_NOT_SUPPORTED;
+    }
+    return hipblasCgeam(handle, convert_hipblasOperation_t(transa), convert_hipblasOperation_t(transb), m, n,
+                        reinterpret_cast<const hipblasComplex*>(alpha),
+                        reinterpret_cast<const hipblasComplex*>(A),
+                        lda,
+                        reinterpret_cast<const hipblasComplex*>(beta),
+                        reinterpret_cast<const hipblasComplex*>(B),
+                        ldb,
+                        reinterpret_cast<hipblasComplex*>(C),
+                        ldc);
 }
 
 cublasStatus_t cublasZgeam(
@@ -580,8 +591,19 @@ cublasStatus_t cublasZgeam(
         cublasOperation_t transa, cublasOperation_t transb,
         int m, int n, const cuDoubleComplex *alpha,
         const cuDoubleComplex *A, int lda, const cuDoubleComplex *beta, const cuDoubleComplex *B, int ldb,
-	cuDoubleComplex *C, int ldc) {
-    return HIPBLAS_STATUS_NOT_SUPPORTED;
+	    cuDoubleComplex *C, int ldc) {
+    if (HIP_VERSION < 307) {
+        return HIPBLAS_STATUS_NOT_SUPPORTED;
+    }
+    return hipblasZgeam(handle, convert_hipblasOperation_t(transa), convert_hipblasOperation_t(transb), m, n,
+                        reinterpret_cast<const hipblasDoubleComplex*>(alpha),
+                        reinterpret_cast<const hipblasDoubleComplex*>(A),
+                        lda,
+                        reinterpret_cast<const hipblasDoubleComplex*>(beta),
+                        reinterpret_cast<const hipblasDoubleComplex*>(B),
+                        ldb,
+                        reinterpret_cast<hipblasDoubleComplex*>(C),
+                        ldc);
 }
 
 cublasStatus_t cublasSdgmm(...) {

--- a/cupy_backends/hip/cupy_hipblas.h
+++ b/cupy_backends/hip/cupy_hipblas.h
@@ -3,6 +3,8 @@
 
 #include "cupy_hip_common.h"
 #include <hipblas.h>
+#include <hip/hip_version.h>  // for HIP_VERSION
+
 
 extern "C" {
 
@@ -607,8 +609,10 @@ cublasStatus_t cublasSgetriBatched(cublasHandle_t handle,
                                    int ldc,
                                    int *info,
                                    int batchSize) {
-    // TODO(leofang): getri seems to be supported in ROCm 3.7.0
-    return HIPBLAS_STATUS_NOT_SUPPORTED;
+    if (HIP_VERSION <= 307) {
+        return HIPBLAS_STATUS_NOT_SUPPORTED;
+    }
+    return hipblasSgetriBatched(handle, n, const_cast<float* const*>(A), lda, const_cast<int*>(P), C, ldc, info, batchSize);
 }
 
 cublasStatus_t cublasDgetriBatched(cublasHandle_t handle,
@@ -620,8 +624,10 @@ cublasStatus_t cublasDgetriBatched(cublasHandle_t handle,
                                    int ldc,
                                    int *info,
                                    int batchSize) {
-    // TODO(leofang): getri seems to be supported in ROCm 3.7.0
-    return HIPBLAS_STATUS_NOT_SUPPORTED;
+    if (HIP_VERSION <= 307) {
+        return HIPBLAS_STATUS_NOT_SUPPORTED;
+    }
+    return hipblasDgetriBatched(handle, n, const_cast<double* const*>(A), lda, const_cast<int*>(P), C, ldc, info, batchSize);
 }
 
 cublasStatus_t cublasCgetriBatched(cublasHandle_t handle,
@@ -633,8 +639,14 @@ cublasStatus_t cublasCgetriBatched(cublasHandle_t handle,
                                    int ldc,
                                    int *info,
                                    int batchSize) {
-    // TODO(leofang): getri seems to be supported in ROCm 3.7.0
-    return HIPBLAS_STATUS_NOT_SUPPORTED;
+    if (HIP_VERSION <= 307) {
+        return HIPBLAS_STATUS_NOT_SUPPORTED;
+    }
+    return hipblasCgetriBatched(handle, n,
+                                reinterpret_cast<hipblasComplex* const*>(const_cast<cuComplex* const*>(A)),
+                                lda, const_cast<int*>(P),
+                                reinterpret_cast<hipblasComplex* const*>(C),
+                                ldc, info, batchSize);
 }
 
 cublasStatus_t cublasZgetriBatched(cublasHandle_t handle,
@@ -646,8 +658,14 @@ cublasStatus_t cublasZgetriBatched(cublasHandle_t handle,
                                    int ldc,
                                    int *info,
                                    int batchSize) {
-    // TODO(leofang): getri seems to be supported in ROCm 3.7.0
-    return HIPBLAS_STATUS_NOT_SUPPORTED;
+    if (HIP_VERSION <= 307) {
+        return HIPBLAS_STATUS_NOT_SUPPORTED;
+    }
+    return hipblasZgetriBatched(handle, n,
+                                reinterpret_cast<hipblasDoubleComplex* const*>(const_cast<cuDoubleComplex* const*>(A)),
+                                lda, const_cast<int*>(P),
+                                reinterpret_cast<hipblasDoubleComplex* const*>(C),
+                                ldc, info, batchSize);
 }
 
 cublasStatus_t cublasSgemmStridedBatched(

--- a/cupy_backends/hip/cupy_hipblas.h
+++ b/cupy_backends/hip/cupy_hipblas.h
@@ -606,20 +606,50 @@ cublasStatus_t cublasZgeam(
                         ldc);
 }
 
-cublasStatus_t cublasSdgmm(...) {
-    return HIPBLAS_STATUS_NOT_SUPPORTED;
+cublasStatus_t cublasSdgmm(cublasHandle_t handle, cublasSideMode_t mode, int m, int n,
+                           const float *A, int lda,
+                           const float *x, int incx,
+                           float *C, int ldc) {
+    if (HIP_VERSION < 306) {
+        return HIPBLAS_STATUS_NOT_SUPPORTED;
+    }
+    return hipblasSdgmm(handle, convert_hipblasSideMode_t(mode), m, n, A, lda, x, incx, C, ldc);
 }
 
-cublasStatus_t cublasDdgmm(...) {
-    return HIPBLAS_STATUS_NOT_SUPPORTED;
+cublasStatus_t cublasDdgmm(cublasHandle_t handle, cublasSideMode_t mode, int m, int n,
+                           const double *A, int lda,
+                           const double *x, int incx,
+                           double *C, int ldc) {
+    if (HIP_VERSION < 306) {
+        return HIPBLAS_STATUS_NOT_SUPPORTED;
+    }
+    return hipblasDdgmm(handle, convert_hipblasSideMode_t(mode), m, n, A, lda, x, incx, C, ldc);
 }
 
-cublasStatus_t cublasCdgmm(...) {
-    return HIPBLAS_STATUS_NOT_SUPPORTED;
+cublasStatus_t cublasCdgmm(cublasHandle_t handle, cublasSideMode_t mode, int m, int n,
+                           const cuComplex *A, int lda,
+                           const cuComplex *x, int incx,
+                           cuComplex *C, int ldc) {
+    if (HIP_VERSION < 306) {
+        return HIPBLAS_STATUS_NOT_SUPPORTED;
+    }
+    return hipblasCdgmm(handle, convert_hipblasSideMode_t(mode), m, n,
+                        reinterpret_cast<const hipblasComplex*>(A), lda,
+                        reinterpret_cast<const hipblasComplex*>(x), incx,
+                        reinterpret_cast<hipblasComplex*>(C), ldc);
 }
 
-cublasStatus_t cublasZdgmm(...) {
-    return HIPBLAS_STATUS_NOT_SUPPORTED;
+cublasStatus_t cublasZdgmm(cublasHandle_t handle, cublasSideMode_t mode, int m, int n,
+                           const cuDoubleComplex *A, int lda,
+                           const cuDoubleComplex *x, int incx,
+                           cuDoubleComplex *C, int ldc) {
+    if (HIP_VERSION < 306) {
+        return HIPBLAS_STATUS_NOT_SUPPORTED;
+    }
+    return hipblasZdgmm(handle, convert_hipblasSideMode_t(mode), m, n,
+                        reinterpret_cast<const hipblasDoubleComplex*>(A), lda,
+                        reinterpret_cast<const hipblasDoubleComplex*>(x), incx,
+                        reinterpret_cast<hipblasDoubleComplex*>(C), ldc);
 }
 
 cublasStatus_t cublasSgetriBatched(cublasHandle_t handle,

--- a/cupy_backends/hip/cupy_rocsolver.h
+++ b/cupy_backends/hip/cupy_rocsolver.h
@@ -79,6 +79,28 @@ cusolverStatus_t cusolverDnDpotrf_bufferSize(cusolverDnHandle_t handle,
     return rocblas_status_success;
 }
 
+cusolverStatus_t cusolverDnCpotrf_bufferSize(cusolverDnHandle_t handle,
+                                             cublasFillMode_t uplo,
+                                             int n,
+                                             cuComplex *A,
+                                             int lda,
+                                             int *Lwork) {
+    // this needs to return 0 because rocSolver does not rely on it
+    *Lwork = 0;
+    return rocblas_status_success;
+}
+
+cusolverStatus_t cusolverDnZpotrf_bufferSize(cusolverDnHandle_t handle,
+                                             cublasFillMode_t uplo,
+                                             int n,
+                                             cuDoubleComplex *A,
+                                             int lda,
+                                             int *Lwork) {
+    // this needs to return 0 because rocSolver does not rely on it
+    *Lwork = 0;
+    return rocblas_status_success;
+}
+
 cusolverStatus_t cusolverDnSpotrf(cusolverDnHandle_t handle,
                                   cublasFillMode_t uplo,
                                   int n,
@@ -105,6 +127,38 @@ cusolverStatus_t cusolverDnDpotrf(cusolverDnHandle_t handle,
                             n, A, lda, devInfo);
 }
 
+cusolverStatus_t cusolverDnCpotrf(cusolverDnHandle_t handle,
+                                  cublasFillMode_t uplo,
+                                  int n,
+                                  cuComplex *A,
+                                  int lda,
+                                  cuComplex *Workspace,
+                                  int Lwork,
+                                  int *devInfo) {
+    if (HIP_VERSION < 306) {
+        return rocblas_status_not_implemented;
+    }
+    // ignore Workspace and Lwork as rocSOLVER does not need them
+    return rocsolver_cpotrf(handle, convert_rocblas_fill(uplo), n,
+                            reinterpret_cast<rocblas_float_complex*>(A), lda, devInfo);
+}
+
+cusolverStatus_t cusolverDnZpotrf(cusolverDnHandle_t handle,
+                                  cublasFillMode_t uplo,
+                                  int n,
+                                  cuDoubleComplex *A,
+                                  int lda,
+                                  cuDoubleComplex *Workspace,
+                                  int Lwork,
+                                  int *devInfo) {
+    if (HIP_VERSION < 306) {
+        return rocblas_status_not_implemented;
+    }
+    // ignore Workspace and Lwork as rocSOLVER does not need them
+    return rocsolver_zpotrf(handle, convert_rocblas_fill(uplo), n,
+                            reinterpret_cast<rocblas_double_complex*>(A), lda, devInfo);
+}
+
 cusolverStatus_t cusolverDnSpotrfBatched(cusolverDnHandle_t handle,
                                          cublasFillMode_t uplo,
                                          int n,
@@ -125,6 +179,36 @@ cusolverStatus_t cusolverDnDpotrfBatched(cusolverDnHandle_t handle,
                                          int batchSize) {
     return rocsolver_dpotrf_batched(handle, convert_rocblas_fill(uplo),
                                     n, Aarray, lda, infoArray, batchSize);
+}
+
+cusolverStatus_t cusolverDnCpotrfBatched(cusolverDnHandle_t handle,
+                                         cublasFillMode_t uplo,
+                                         int n,
+                                         cuComplex *Aarray[],
+                                         int lda,
+                                         int *infoArray,
+                                         int batchSize) {
+    if (HIP_VERSION < 306) {
+        return rocblas_status_not_implemented;
+    }
+    return rocsolver_cpotrf_batched(handle, convert_rocblas_fill(uplo), n,
+                                    reinterpret_cast<rocblas_float_complex* const*>(Aarray), lda,
+                                    infoArray, batchSize);
+}
+
+cusolverStatus_t cusolverDnZpotrfBatched(cusolverDnHandle_t handle,
+                                         cublasFillMode_t uplo,
+                                         int n,
+                                         cuDoubleComplex *Aarray[],
+                                         int lda,
+                                         int *infoArray,
+                                         int batchSize) {
+    if (HIP_VERSION < 306) {
+        return rocblas_status_not_implemented;
+    }
+    return rocsolver_zpotrf_batched(handle, convert_rocblas_fill(uplo), n,
+                                    reinterpret_cast<rocblas_double_complex* const*>(Aarray), lda,
+                                    infoArray, batchSize);
 }
 
 
@@ -540,7 +624,7 @@ cusolverStatus_t cusolverDnDormqr(cusolverDnHandle_t handle,
 }
 
 
-/* all of the stubs here are unsupported functions; the supported ones are in cupy_hip.h */
+/* all of the stubs below are unsupported functions; the supported ones are moved to above */
 
 typedef enum{} cusolverEigType_t;
 typedef enum{} cusolverEigMode_t;
@@ -557,31 +641,6 @@ cusolverStatus_t cusolverSpSetStream(...) {
     return rocblas_status_not_implemented;
 }
 
-
-/* ---------- potrf ---------- */
-cusolverStatus_t cusolverDnCpotrf_bufferSize(...) {
-    return rocblas_status_not_implemented;
-}
-
-cusolverStatus_t cusolverDnZpotrf_bufferSize(...) {
-    return rocblas_status_not_implemented;
-}
-
-cusolverStatus_t cusolverDnCpotrf(...) {
-    return rocblas_status_not_implemented;
-}
-
-cusolverStatus_t cusolverDnZpotrf(...) {
-    return rocblas_status_not_implemented;
-}
-
-cusolverStatus_t cusolverDnCpotrfBatched(...) {
-    return rocblas_status_not_implemented;
-}
-
-cusolverStatus_t cusolverDnZpotrfBatched(...) {
-    return rocblas_status_not_implemented;
-}
 
 
 /* ---------- potrs ---------- */

--- a/cupy_backends/hip/cupy_rocsolver.h
+++ b/cupy_backends/hip/cupy_rocsolver.h
@@ -23,6 +23,7 @@ static rocblas_side convert_rocblas_side(cublasSideMode_t mode) {
     return static_cast<rocblas_side>(static_cast<int>(mode) + 141);
 }
 
+#if HIP_VERSION >= 309
 static rocblas_svect convert_rocblas_svect(signed char mode) {
     switch(mode) {
         case 'A': return rocblas_svect_all;
@@ -32,6 +33,7 @@ static rocblas_svect convert_rocblas_svect(signed char mode) {
         default: throw std::runtime_error("unrecognized mode");
     }
 }
+#endif
 
 
 // rocSOLVER
@@ -145,12 +147,13 @@ cusolverStatus_t cusolverDnCpotrf(cusolverDnHandle_t handle,
                                   cuComplex *Workspace,
                                   int Lwork,
                                   int *devInfo) {
-    if (HIP_VERSION < 306) {
-        return rocblas_status_not_implemented;
-    }
+    #if HIP_VERSION < 306
+    return rocblas_status_not_implemented;
+    #else
     // ignore Workspace and Lwork as rocSOLVER does not need them
     return rocsolver_cpotrf(handle, convert_rocblas_fill(uplo), n,
                             reinterpret_cast<rocblas_float_complex*>(A), lda, devInfo);
+    #endif
 }
 
 cusolverStatus_t cusolverDnZpotrf(cusolverDnHandle_t handle,
@@ -161,12 +164,13 @@ cusolverStatus_t cusolverDnZpotrf(cusolverDnHandle_t handle,
                                   cuDoubleComplex *Workspace,
                                   int Lwork,
                                   int *devInfo) {
-    if (HIP_VERSION < 306) {
-        return rocblas_status_not_implemented;
-    }
+    #if HIP_VERSION < 306
+    return rocblas_status_not_implemented;
+    #else
     // ignore Workspace and Lwork as rocSOLVER does not need them
     return rocsolver_zpotrf(handle, convert_rocblas_fill(uplo), n,
                             reinterpret_cast<rocblas_double_complex*>(A), lda, devInfo);
+    #endif
 }
 
 cusolverStatus_t cusolverDnSpotrfBatched(cusolverDnHandle_t handle,
@@ -198,12 +202,13 @@ cusolverStatus_t cusolverDnCpotrfBatched(cusolverDnHandle_t handle,
                                          int lda,
                                          int *infoArray,
                                          int batchSize) {
-    if (HIP_VERSION < 306) {
-        return rocblas_status_not_implemented;
-    }
+    #if HIP_VERSION < 306
+    return rocblas_status_not_implemented;
+    #else
     return rocsolver_cpotrf_batched(handle, convert_rocblas_fill(uplo), n,
                                     reinterpret_cast<rocblas_float_complex* const*>(Aarray), lda,
                                     infoArray, batchSize);
+    #endif
 }
 
 cusolverStatus_t cusolverDnZpotrfBatched(cusolverDnHandle_t handle,
@@ -213,12 +218,13 @@ cusolverStatus_t cusolverDnZpotrfBatched(cusolverDnHandle_t handle,
                                          int lda,
                                          int *infoArray,
                                          int batchSize) {
-    if (HIP_VERSION < 306) {
-        return rocblas_status_not_implemented;
-    }
+    #if HIP_VERSION < 306
+    return rocblas_status_not_implemented;
+    #else
     return rocsolver_zpotrf_batched(handle, convert_rocblas_fill(uplo), n,
                                     reinterpret_cast<rocblas_double_complex* const*>(Aarray), lda,
                                     infoArray, batchSize);
+    #endif
 }
 
 
@@ -587,13 +593,14 @@ cusolverStatus_t cusolverDnCungqr(cusolverDnHandle_t handle,
                                   cuComplex *work,
                                   int lwork,
                                   int *info) {
-    if (HIP_VERSION < 306) {
-        return rocblas_status_not_implemented;
-    }
+    #if HIP_VERSION < 306
+    return rocblas_status_not_implemented;
+    #else
     // ignore work, lwork and info as rocSOLVER does not need them
     return rocsolver_cungqr(handle, m, n, k,
                             reinterpret_cast<rocblas_float_complex*>(A), lda,
                             reinterpret_cast<rocblas_float_complex*>(const_cast<cuComplex*>(tau)));
+    #endif
 }
 
 cusolverStatus_t cusolverDnZungqr(cusolverDnHandle_t handle,
@@ -606,13 +613,14 @@ cusolverStatus_t cusolverDnZungqr(cusolverDnHandle_t handle,
                                   cuDoubleComplex *work,
                                   int lwork,
                                   int *info) {
-    if (HIP_VERSION < 306) {
-        return rocblas_status_not_implemented;
-    }
+    #if HIP_VERSION < 306
+    return rocblas_status_not_implemented;
+    #else
     // ignore work, lwork and info as rocSOLVER does not need them
     return rocsolver_zungqr(handle, m, n, k,
                             reinterpret_cast<rocblas_double_complex*>(A), lda,
                             reinterpret_cast<rocblas_double_complex*>(const_cast<cuDoubleComplex*>(tau)));
+    #endif
 }
 
 
@@ -749,14 +757,15 @@ cusolverStatus_t cusolverDnCunmqr(cusolverDnHandle_t handle,
                                   cuComplex *work,
                                   int lwork,
                                   int *devInfo) {
-    if (HIP_VERSION < 306) {
-        return rocblas_status_not_implemented;
-    }
+    #if HIP_VERSION < 306
+    return rocblas_status_not_implemented;
+    #else
     // ignore work, lwork and devInfo as rocSOLVER does not need them
     return rocsolver_cunmqr(handle, convert_rocblas_side(side), convert_rocblas_operation(trans),
                             m, n, k, reinterpret_cast<rocblas_float_complex*>(const_cast<cuComplex*>(A)),
                             lda, reinterpret_cast<rocblas_float_complex*>(const_cast<cuComplex*>(tau)),
                             reinterpret_cast<rocblas_float_complex*>(C), ldc);
+    #endif
 }
 
 cusolverStatus_t cusolverDnZunmqr(cusolverDnHandle_t handle,
@@ -773,14 +782,15 @@ cusolverStatus_t cusolverDnZunmqr(cusolverDnHandle_t handle,
                                   cuDoubleComplex *work,
                                   int lwork,
                                   int *devInfo) {
-    if (HIP_VERSION < 306) {
-        return rocblas_status_not_implemented;
-    }
+    #if HIP_VERSION < 306
+    return rocblas_status_not_implemented;
+    #else
     // ignore work, lwork and devInfo as rocSOLVER does not need them
     return rocsolver_zunmqr(handle, convert_rocblas_side(side), convert_rocblas_operation(trans),
                             m, n, k, reinterpret_cast<rocblas_double_complex*>(const_cast<cuDoubleComplex*>(A)),
                             lda, reinterpret_cast<rocblas_double_complex*>(const_cast<cuDoubleComplex*>(tau)),
                             reinterpret_cast<rocblas_double_complex*>(C), ldc);
+    #endif
 }
 
 
@@ -837,13 +847,14 @@ cusolverStatus_t cusolverDnSgesvd(cusolverDnHandle_t handle,
                                   int lwork,
                                   float *rwork,
                                   int *info) {
-    if (HIP_VERSION < 309) {
-        return rocblas_status_not_implemented;
-    }
+    #if HIP_VERSION < 309
+    return rocblas_status_not_implemented;
+    #else
     // ignore work and lwork as rocSOLVER does not need them
     return rocsolver_sgesvd(handle, convert_rocblas_svect(jobu), convert_rocblas_svect(jobvt),
                             m, n, A, lda, S, U, ldu, VT, ldvt, rwork, rocblas_outofplace,  // always out-of-place
                             info);
+    #endif
 }
 
 cusolverStatus_t cusolverDnDgesvd(cusolverDnHandle_t handle,
@@ -862,13 +873,14 @@ cusolverStatus_t cusolverDnDgesvd(cusolverDnHandle_t handle,
                                   int lwork,
                                   double *rwork,
                                   int *info) {
-    if (HIP_VERSION < 309) {
-        return rocblas_status_not_implemented;
-    }
+    #if HIP_VERSION < 309
+    return rocblas_status_not_implemented;
+    #else
     // ignore work and lwork as rocSOLVER does not need them
     return rocsolver_dgesvd(handle, convert_rocblas_svect(jobu), convert_rocblas_svect(jobvt),
                             m, n, A, lda, S, U, ldu, VT, ldvt, rwork, rocblas_outofplace,  // always out-of-place
                             info);
+    #endif
 }
 
 cusolverStatus_t cusolverDnCgesvd(cusolverDnHandle_t handle,
@@ -887,9 +899,9 @@ cusolverStatus_t cusolverDnCgesvd(cusolverDnHandle_t handle,
                                   int lwork,
                                   float *rwork,
                                   int *info) {
-    if (HIP_VERSION < 309) {
-        return rocblas_status_not_implemented;
-    }
+    #if HIP_VERSION < 309
+    return rocblas_status_not_implemented;
+    #else
     // ignore work and lwork as rocSOLVER does not need them
     return rocsolver_cgesvd(handle, convert_rocblas_svect(jobu), convert_rocblas_svect(jobvt),
                             m, n, reinterpret_cast<rocblas_float_complex*>(A), lda,
@@ -897,6 +909,7 @@ cusolverStatus_t cusolverDnCgesvd(cusolverDnHandle_t handle,
                             reinterpret_cast<rocblas_float_complex*>(VT), ldvt, rwork,
                             rocblas_outofplace,  // always out-of-place
                             info);
+    #endif
 }
 
 cusolverStatus_t cusolverDnZgesvd(cusolverDnHandle_t handle,
@@ -915,9 +928,9 @@ cusolverStatus_t cusolverDnZgesvd(cusolverDnHandle_t handle,
                                   int lwork,
                                   double *rwork,
                                   int *info) {
-    if (HIP_VERSION < 309) {
-        return rocblas_status_not_implemented;
-    }
+    #if HIP_VERSION < 309
+    return rocblas_status_not_implemented;
+    #else
     // ignore work and lwork as rocSOLVER does not need them
     return rocsolver_zgesvd(handle, convert_rocblas_svect(jobu), convert_rocblas_svect(jobvt),
                             m, n, reinterpret_cast<rocblas_double_complex*>(A), lda,
@@ -925,6 +938,7 @@ cusolverStatus_t cusolverDnZgesvd(cusolverDnHandle_t handle,
                             reinterpret_cast<rocblas_double_complex*>(VT), ldvt, rwork,
                             rocblas_outofplace,  // always out-of-place
                             info);
+    #endif
 }
 
 
@@ -977,11 +991,12 @@ cusolverStatus_t cusolverDnSgebrd(cusolverDnHandle_t handle,
                                   float *Work,
                                   int Lwork,
                                   int *devInfo) {
-    if (HIP_VERSION < 306) {
-        return rocblas_status_not_implemented;
-    }
+    #if HIP_VERSION < 306
+    return rocblas_status_not_implemented;
+    #else
     // ignore work, lwork and devinfo as rocSOLVER does not need them
     return rocsolver_sgebrd(handle, m, n, A, lda, D, E, TAUQ, TAUP);
+    #endif
 }
 
 cusolverStatus_t cusolverDnDgebrd(cusolverDnHandle_t handle,
@@ -996,11 +1011,12 @@ cusolverStatus_t cusolverDnDgebrd(cusolverDnHandle_t handle,
                                   double *Work,
                                   int Lwork,
                                   int *devInfo) {
-    if (HIP_VERSION < 306) {
-        return rocblas_status_not_implemented;
-    }
+    #if HIP_VERSION < 306
+    return rocblas_status_not_implemented;
+    #else
     // ignore work, lwork and devinfo as rocSOLVER does not need them
     return rocsolver_dgebrd(handle, m, n, A, lda, D, E, TAUQ, TAUP);
+    #endif
 }
 
 cusolverStatus_t cusolverDnCgebrd(cusolverDnHandle_t handle,
@@ -1015,13 +1031,14 @@ cusolverStatus_t cusolverDnCgebrd(cusolverDnHandle_t handle,
                                   cuComplex *Work,
                                   int Lwork,
                                   int *devInfo) {
-    if (HIP_VERSION < 306) {
-        return rocblas_status_not_implemented;
-    }
+    #if HIP_VERSION < 306
+    return rocblas_status_not_implemented;
+    #else
     // ignore work, lwork and devinfo as rocSOLVER does not need them
     return rocsolver_cgebrd(handle, m, n, reinterpret_cast<rocblas_float_complex*>(A),
                             lda, D, E, reinterpret_cast<rocblas_float_complex*>(TAUQ),
                             reinterpret_cast<rocblas_float_complex*>(TAUP));
+    #endif
 }
 
 cusolverStatus_t cusolverDnZgebrd(cusolverDnHandle_t handle,
@@ -1036,13 +1053,14 @@ cusolverStatus_t cusolverDnZgebrd(cusolverDnHandle_t handle,
                                   cuDoubleComplex *Work,
                                   int Lwork,
                                   int *devInfo) {
-    if (HIP_VERSION < 306) {
-        return rocblas_status_not_implemented;
-    }
+    #if HIP_VERSION < 306
+    return rocblas_status_not_implemented;
+    #else
     // ignore work, lwork and devinfo as rocSOLVER does not need them
     return rocsolver_zgebrd(handle, m, n, reinterpret_cast<rocblas_double_complex*>(A),
                             lda, D, E, reinterpret_cast<rocblas_double_complex*>(TAUQ),
                             reinterpret_cast<rocblas_double_complex*>(TAUP));
+    #endif
 }
 
 

--- a/cupy_backends/hip/cupy_rocsolver.h
+++ b/cupy_backends/hip/cupy_rocsolver.h
@@ -928,6 +928,124 @@ cusolverStatus_t cusolverDnZgesvd(cusolverDnHandle_t handle,
 }
 
 
+/* ---------- gebrd ---------- */
+cusolverStatus_t cusolverDnSgebrd_bufferSize(cusolverDnHandle_t handle,
+                                             int m,
+                                             int n,
+                                             int *Lwork) {
+    // this needs to return 0 because rocSolver does not rely on it
+    *Lwork = 0;
+    return rocblas_status_success;
+}
+
+cusolverStatus_t cusolverDnDgebrd_bufferSize(cusolverDnHandle_t handle,
+                                             int m,
+                                             int n,
+                                             int *Lwork) {
+    // this needs to return 0 because rocSolver does not rely on it
+    *Lwork = 0;
+    return rocblas_status_success;
+}
+
+cusolverStatus_t cusolverDnCgebrd_bufferSize(cusolverDnHandle_t handle,
+                                             int m,
+                                             int n,
+                                             int *Lwork) {
+    // this needs to return 0 because rocSolver does not rely on it
+    *Lwork = 0;
+    return rocblas_status_success;
+}
+
+cusolverStatus_t cusolverDnZgebrd_bufferSize(cusolverDnHandle_t handle,
+                                             int m,
+                                             int n,
+                                             int *Lwork) {
+    // this needs to return 0 because rocSolver does not rely on it
+    *Lwork = 0;
+    return rocblas_status_success;
+}
+
+cusolverStatus_t cusolverDnSgebrd(cusolverDnHandle_t handle,
+                                  int m,
+                                  int n,
+                                  float *A,
+                                  int lda,
+                                  float *D,
+                                  float *E,
+                                  float *TAUQ,
+                                  float *TAUP,
+                                  float *Work,
+                                  int Lwork,
+                                  int *devInfo) {
+    if (HIP_VERSION < 306) {
+        return rocblas_status_not_implemented;
+    }
+    // ignore work, lwork and devinfo as rocSOLVER does not need them
+    return rocsolver_sgebrd(handle, m, n, A, lda, D, E, TAUQ, TAUP);
+}
+
+cusolverStatus_t cusolverDnDgebrd(cusolverDnHandle_t handle,
+                                  int m,
+                                  int n,
+                                  double *A,
+                                  int lda,
+                                  double *D,
+                                  double *E,
+                                  double *TAUQ,
+                                  double *TAUP,
+                                  double *Work,
+                                  int Lwork,
+                                  int *devInfo) {
+    if (HIP_VERSION < 306) {
+        return rocblas_status_not_implemented;
+    }
+    // ignore work, lwork and devinfo as rocSOLVER does not need them
+    return rocsolver_dgebrd(handle, m, n, A, lda, D, E, TAUQ, TAUP);
+}
+
+cusolverStatus_t cusolverDnCgebrd(cusolverDnHandle_t handle,
+                                  int m,
+                                  int n,
+                                  cuComplex *A,
+                                  int lda,
+                                  float *D,
+                                  float *E,
+                                  cuComplex *TAUQ,
+                                  cuComplex *TAUP,
+                                  cuComplex *Work,
+                                  int Lwork,
+                                  int *devInfo) {
+    if (HIP_VERSION < 306) {
+        return rocblas_status_not_implemented;
+    }
+    // ignore work, lwork and devinfo as rocSOLVER does not need them
+    return rocsolver_cgebrd(handle, m, n, reinterpret_cast<rocblas_float_complex*>(A),
+                            lda, D, E, reinterpret_cast<rocblas_float_complex*>(TAUQ),
+                            reinterpret_cast<rocblas_float_complex*>(TAUP));
+}
+
+cusolverStatus_t cusolverDnZgebrd(cusolverDnHandle_t handle,
+                                  int m,
+                                  int n,
+                                  cuDoubleComplex *A,
+                                  int lda,
+                                  double *D,
+                                  double *E,
+                                  cuDoubleComplex *TAUQ,
+                                  cuDoubleComplex *TAUP,
+                                  cuDoubleComplex *Work,
+                                  int Lwork,
+                                  int *devInfo) {
+    if (HIP_VERSION < 306) {
+        return rocblas_status_not_implemented;
+    }
+    // ignore work, lwork and devinfo as rocSOLVER does not need them
+    return rocsolver_zgebrd(handle, m, n, reinterpret_cast<rocblas_double_complex*>(A),
+                            lda, D, E, reinterpret_cast<rocblas_double_complex*>(TAUQ),
+                            reinterpret_cast<rocblas_double_complex*>(TAUP));
+}
+
+
 /* all of the stubs below are unsupported functions; the supported ones are moved to above */
 
 typedef enum{} cusolverEigType_t;
@@ -944,7 +1062,6 @@ cusolverStatus_t cusolverSpGetStream(...) {
 cusolverStatus_t cusolverSpSetStream(...) {
     return rocblas_status_not_implemented;
 }
-
 
 
 /* ---------- potrs ---------- */
@@ -981,6 +1098,7 @@ cusolverStatus_t cusolverDnZpotrsBatched(...) {
 }
 
 
+/* ---------- sytrf ---------- */
 cusolverStatus_t cusolverDnSsytrf_bufferSize(...) {
     return rocblas_status_not_implemented;
 }
@@ -1013,37 +1131,6 @@ cusolverStatus_t cusolverDnZsytrf(...) {
     return rocblas_status_not_implemented;
 }
 
-cusolverStatus_t cusolverDnSgebrd_bufferSize(...) {
-    return rocblas_status_not_implemented;
-}
-
-cusolverStatus_t cusolverDnDgebrd_bufferSize(...) {
-    return rocblas_status_not_implemented;
-}
-
-cusolverStatus_t cusolverDnCgebrd_bufferSize(...) {
-    return rocblas_status_not_implemented;
-}
-
-cusolverStatus_t cusolverDnZgebrd_bufferSize(...) {
-    return rocblas_status_not_implemented;
-}
-
-cusolverStatus_t cusolverDnSgebrd(...) {
-    return rocblas_status_not_implemented;
-}
-
-cusolverStatus_t cusolverDnDgebrd(...) {
-    return rocblas_status_not_implemented;
-}
-
-cusolverStatus_t cusolverDnCgebrd(...) {
-    return rocblas_status_not_implemented;
-}
-
-cusolverStatus_t cusolverDnZgebrd(...) {
-    return rocblas_status_not_implemented;
-}
 
 cusolverStatus_t cusolverDnCreateGesvdjInfo(...) {
     return rocblas_status_not_implemented;

--- a/cupy_backends/hip/cupy_rocsolver.h
+++ b/cupy_backends/hip/cupy_rocsolver.h
@@ -540,6 +540,72 @@ cusolverStatus_t cusolverDnDorgqr(cusolverDnHandle_t handle,
 }
 
 
+/* ---------- ungqr ---------- */
+cusolverStatus_t cusolverDnCungqr_bufferSize(cusolverDnHandle_t handle,
+                                             int m,
+                                             int n,
+                                             int k,
+                                             const cuComplex *A,
+                                             int lda,
+                                             const cuComplex *tau,
+                                             int *lwork) {
+    // this needs to return 0 because rocSolver does not rely on it
+    *lwork = 0;
+    return rocblas_status_success;
+}
+
+cusolverStatus_t cusolverDnZungqr_bufferSize(cusolverDnHandle_t handle,
+                                             int m,
+                                             int n,
+                                             int k,
+                                             const cuDoubleComplex *A,
+                                             int lda,
+                                             const cuDoubleComplex *tau,
+                                             int *lwork) {
+    // this needs to return 0 because rocSolver does not rely on it
+    *lwork = 0;
+    return rocblas_status_success;
+}
+
+cusolverStatus_t cusolverDnCungqr(cusolverDnHandle_t handle,
+                                  int m,
+                                  int n,
+                                  int k,
+                                  cuComplex *A,
+                                  int lda,
+                                  const cuComplex *tau,
+                                  cuComplex *work,
+                                  int lwork,
+                                  int *info) {
+    if (HIP_VERSION < 306) {
+        return rocblas_status_not_implemented;
+    }
+    // ignore work, lwork and info as rocSOLVER does not need them
+    return rocsolver_cungqr(handle, m, n, k,
+                            reinterpret_cast<rocblas_float_complex*>(A), lda,
+                            reinterpret_cast<rocblas_float_complex*>(const_cast<cuComplex*>(tau)));
+}
+
+cusolverStatus_t cusolverDnZungqr(cusolverDnHandle_t handle,
+                                  int m,
+                                  int n,
+                                  int k,
+                                  cuDoubleComplex *A,
+                                  int lda,
+                                  const cuDoubleComplex *tau,
+                                  cuDoubleComplex *work,
+                                  int lwork,
+                                  int *info) {
+    if (HIP_VERSION < 306) {
+        return rocblas_status_not_implemented;
+    }
+    // ignore work, lwork and info as rocSOLVER does not need them
+    return rocsolver_zungqr(handle, m, n, k,
+                            reinterpret_cast<rocblas_double_complex*>(A), lda,
+                            reinterpret_cast<rocblas_double_complex*>(const_cast<cuDoubleComplex*>(tau)));
+}
+
+
 /* ---------- ormqr ---------- */
 cusolverStatus_t cusolverDnSormqr_bufferSize(cusolverDnHandle_t handle,
                                              cublasSideMode_t side,
@@ -624,6 +690,7 @@ cusolverStatus_t cusolverDnDormqr(cusolverDnHandle_t handle,
 }
 
 
+
 /* all of the stubs below are unsupported functions; the supported ones are moved to above */
 
 typedef enum{} cusolverEigType_t;
@@ -673,24 +740,6 @@ cusolverStatus_t cusolverDnCpotrsBatched(...) {
 }
 
 cusolverStatus_t cusolverDnZpotrsBatched(...) {
-    return rocblas_status_not_implemented;
-}
-
-
-/* ---------- ungqr ---------- */
-cusolverStatus_t cusolverDnCungqr_bufferSize(...) {
-    return rocblas_status_not_implemented;
-}
-
-cusolverStatus_t cusolverDnZungqr_bufferSize(...) {
-    return rocblas_status_not_implemented;
-}
-
-cusolverStatus_t cusolverDnCungqr(...) {
-    return rocblas_status_not_implemented;
-}
-
-cusolverStatus_t cusolverDnZungqr(...) {
     return rocblas_status_not_implemented;
 }
 

--- a/cupy_backends/hip/cupy_rocsolver.h
+++ b/cupy_backends/hip/cupy_rocsolver.h
@@ -23,6 +23,16 @@ static rocblas_side convert_rocblas_side(cublasSideMode_t mode) {
     return static_cast<rocblas_side>(static_cast<int>(mode) + 141);
 }
 
+static rocblas_svect convert_rocblas_svect(signed char mode) {
+    switch(mode) {
+        case 'A': return rocblas_svect_all;
+        case 'S': return rocblas_svect_singular;
+        case 'O': return rocblas_svect_overwrite;
+        case 'N': return rocblas_svect_none;
+        default: throw std::runtime_error("unrecognized mode");
+    }
+}
+
 
 // rocSOLVER
 /* ---------- helpers ---------- */
@@ -690,6 +700,149 @@ cusolverStatus_t cusolverDnDormqr(cusolverDnHandle_t handle,
 }
 
 
+/* ---------- gesvd ---------- */
+cusolverStatus_t cusolverDnSgesvd_bufferSize(cusolverDnHandle_t handle,
+                                             int m,
+                                             int n,
+                                             int *lwork) {
+    // this needs to return 0 because rocSolver does not rely on it
+    *lwork = 0;
+    return rocblas_status_success;
+}
+
+cusolverStatus_t cusolverDnDgesvd_bufferSize(cusolverDnHandle_t handle,
+                                             int m,
+                                             int n,
+                                             int *lwork) {
+    // this needs to return 0 because rocSolver does not rely on it
+    *lwork = 0;
+    return rocblas_status_success;
+}
+
+cusolverStatus_t cusolverDnCgesvd_bufferSize(cusolverDnHandle_t handle,
+                                             int m,
+                                             int n,
+                                             int *lwork) {
+    // this needs to return 0 because rocSolver does not rely on it
+    *lwork = 0;
+    return rocblas_status_success;
+}
+
+cusolverStatus_t cusolverDnZgesvd_bufferSize(cusolverDnHandle_t handle,
+                                             int m,
+                                             int n,
+                                             int *lwork) {
+    // this needs to return 0 because rocSolver does not rely on it
+    *lwork = 0;
+    return rocblas_status_success;
+}
+
+cusolverStatus_t cusolverDnSgesvd(cusolverDnHandle_t handle,
+                                  signed char jobu,
+                                  signed char jobvt,
+                                  int m,
+                                  int n,
+                                  float *A,
+                                  int lda,
+                                  float *S,
+                                  float *U,
+                                  int ldu,
+                                  float *VT,
+                                  int ldvt,
+                                  float *work,
+                                  int lwork,
+                                  float *rwork,
+                                  int *info) {
+    if (HIP_VERSION < 309) {
+        return rocblas_status_not_implemented;
+    }
+    // ignore work and lwork as rocSOLVER does not need them
+    return rocsolver_sgesvd(handle, convert_rocblas_svect(jobu), convert_rocblas_svect(jobvt),
+                            m, n, A, lda, S, U, ldu, VT, ldvt, rwork, rocblas_outofplace,  // always out-of-place
+                            info);
+}
+
+cusolverStatus_t cusolverDnDgesvd(cusolverDnHandle_t handle,
+                                  signed char jobu,
+                                  signed char jobvt,
+                                  int m,
+                                  int n,
+                                  double *A,
+                                  int lda,
+                                  double *S,
+                                  double *U,
+                                  int ldu,
+                                  double *VT,
+                                  int ldvt,
+                                  double *work,
+                                  int lwork,
+                                  double *rwork,
+                                  int *info) {
+    if (HIP_VERSION < 309) {
+        return rocblas_status_not_implemented;
+    }
+    // ignore work and lwork as rocSOLVER does not need them
+    return rocsolver_dgesvd(handle, convert_rocblas_svect(jobu), convert_rocblas_svect(jobvt),
+                            m, n, A, lda, S, U, ldu, VT, ldvt, rwork, rocblas_outofplace,  // always out-of-place
+                            info);
+}
+
+cusolverStatus_t cusolverDnCgesvd(cusolverDnHandle_t handle,
+                                  signed char jobu,
+                                  signed char jobvt,
+                                  int m,
+                                  int n,
+                                  cuComplex *A,
+                                  int lda,
+                                  float *S,
+                                  cuComplex *U,
+                                  int ldu,
+                                  cuComplex *VT,
+                                  int ldvt,
+                                  cuComplex *work,
+                                  int lwork,
+                                  float *rwork,
+                                  int *info) {
+    if (HIP_VERSION < 309) {
+        return rocblas_status_not_implemented;
+    }
+    // ignore work and lwork as rocSOLVER does not need them
+    return rocsolver_cgesvd(handle, convert_rocblas_svect(jobu), convert_rocblas_svect(jobvt),
+                            m, n, reinterpret_cast<rocblas_float_complex*>(A), lda,
+                            S, reinterpret_cast<rocblas_float_complex*>(U), ldu,
+                            reinterpret_cast<rocblas_float_complex*>(VT), ldvt, rwork,
+                            rocblas_outofplace,  // always out-of-place
+                            info);
+}
+
+cusolverStatus_t cusolverDnZgesvd(cusolverDnHandle_t handle,
+                                  signed char jobu,
+                                  signed char jobvt,
+                                  int m,
+                                  int n,
+                                  cuDoubleComplex *A,
+                                  int lda,
+                                  double *S,
+                                  cuDoubleComplex *U,
+                                  int ldu,
+                                  cuDoubleComplex *VT,
+                                  int ldvt,
+                                  cuDoubleComplex *work,
+                                  int lwork,
+                                  double *rwork,
+                                  int *info) {
+    if (HIP_VERSION < 309) {
+        return rocblas_status_not_implemented;
+    }
+    // ignore work and lwork as rocSOLVER does not need them
+    return rocsolver_zgesvd(handle, convert_rocblas_svect(jobu), convert_rocblas_svect(jobvt),
+                            m, n, reinterpret_cast<rocblas_double_complex*>(A), lda,
+                            S, reinterpret_cast<rocblas_double_complex*>(U), ldu,
+                            reinterpret_cast<rocblas_double_complex*>(VT), ldvt, rwork,
+                            rocblas_outofplace,  // always out-of-place
+                            info);
+}
+
 
 /* all of the stubs below are unsupported functions; the supported ones are moved to above */
 
@@ -822,38 +975,6 @@ cusolverStatus_t cusolverDnCgebrd(...) {
 }
 
 cusolverStatus_t cusolverDnZgebrd(...) {
-    return rocblas_status_not_implemented;
-}
-
-cusolverStatus_t cusolverDnSgesvd_bufferSize(...) {
-    return rocblas_status_not_implemented;
-}
-
-cusolverStatus_t cusolverDnDgesvd_bufferSize(...) {
-    return rocblas_status_not_implemented;
-}
-
-cusolverStatus_t cusolverDnCgesvd_bufferSize(...) {
-    return rocblas_status_not_implemented;
-}
-
-cusolverStatus_t cusolverDnZgesvd_bufferSize(...) {
-    return rocblas_status_not_implemented;
-}
-
-cusolverStatus_t cusolverDnSgesvd(...) {
-    return rocblas_status_not_implemented;
-}
-
-cusolverStatus_t cusolverDnDgesvd(...) {
-    return rocblas_status_not_implemented;
-}
-
-cusolverStatus_t cusolverDnCgesvd(...) {
-    return rocblas_status_not_implemented;
-}
-
-cusolverStatus_t cusolverDnZgesvd(...) {
     return rocblas_status_not_implemented;
 }
 

--- a/cupy_backends/hip/cupy_rocsolver.h
+++ b/cupy_backends/hip/cupy_rocsolver.h
@@ -6,7 +6,6 @@
 
 
 extern "C" {
-/* ---------- helpers ---------- */
 // TODO(leofang): perhaps these should be merged with the support of hipBLAS?
 static rocblas_fill convert_rocblas_fill(cublasFillMode_t mode) {
     switch(static_cast<int>(mode)) {

--- a/cupy_backends/hip/cupy_rocsolver.h
+++ b/cupy_backends/hip/cupy_rocsolver.h
@@ -700,6 +700,90 @@ cusolverStatus_t cusolverDnDormqr(cusolverDnHandle_t handle,
 }
 
 
+/* ---------- unmqr ---------- */
+cusolverStatus_t cusolverDnCunmqr_bufferSize(cusolverDnHandle_t handle,
+                                             cublasSideMode_t side,
+                                             cublasOperation_t trans,
+                                             int m,
+                                             int n,
+                                             int k,
+                                             const cuComplex *A,
+                                             int lda,
+                                             const cuComplex *tau,
+                                             const cuComplex *C,
+                                             int ldc,
+                                             int *lwork) {
+    // this needs to return 0 because rocSolver does not rely on it
+    *lwork = 0;
+    return rocblas_status_success;
+}
+
+cusolverStatus_t cusolverDnZunmqr_bufferSize(cusolverDnHandle_t handle,
+                                             cublasSideMode_t side,
+                                             cublasOperation_t trans,
+                                             int m,
+                                             int n,
+                                             int k,
+                                             const cuDoubleComplex *A,
+                                             int lda,
+                                             const cuDoubleComplex *tau,
+                                             const cuDoubleComplex *C,
+                                             int ldc,
+                                             int *lwork) {
+    // this needs to return 0 because rocSolver does not rely on it
+    *lwork = 0;
+    return rocblas_status_success;
+}
+
+cusolverStatus_t cusolverDnCunmqr(cusolverDnHandle_t handle,
+                                  cublasSideMode_t side,
+                                  cublasOperation_t trans,
+                                  int m,
+                                  int n,
+                                  int k,
+                                  const cuComplex *A,
+                                  int lda,
+                                  const cuComplex *tau,
+                                  cuComplex *C,
+                                  int ldc,
+                                  cuComplex *work,
+                                  int lwork,
+                                  int *devInfo) {
+    if (HIP_VERSION < 306) {
+        return rocblas_status_not_implemented;
+    }
+    // ignore work, lwork and devInfo as rocSOLVER does not need them
+    return rocsolver_cunmqr(handle, convert_rocblas_side(side), convert_rocblas_operation(trans),
+                            m, n, k, reinterpret_cast<rocblas_float_complex*>(const_cast<cuComplex*>(A)),
+                            lda, reinterpret_cast<rocblas_float_complex*>(const_cast<cuComplex*>(tau)),
+                            reinterpret_cast<rocblas_float_complex*>(C), ldc);
+}
+
+cusolverStatus_t cusolverDnZunmqr(cusolverDnHandle_t handle,
+                                  cublasSideMode_t side,
+                                  cublasOperation_t trans,
+                                  int m,
+                                  int n,
+                                  int k,
+                                  const cuDoubleComplex *A,
+                                  int lda,
+                                  const cuDoubleComplex *tau,
+                                  cuDoubleComplex *C,
+                                  int ldc,
+                                  cuDoubleComplex *work,
+                                  int lwork,
+                                  int *devInfo) {
+    if (HIP_VERSION < 306) {
+        return rocblas_status_not_implemented;
+    }
+    // ignore work, lwork and devInfo as rocSOLVER does not need them
+    return rocsolver_zunmqr(handle, convert_rocblas_side(side), convert_rocblas_operation(trans),
+                            m, n, k, reinterpret_cast<rocblas_double_complex*>(const_cast<cuDoubleComplex*>(A)),
+                            lda, reinterpret_cast<rocblas_double_complex*>(const_cast<cuDoubleComplex*>(tau)),
+                            reinterpret_cast<rocblas_double_complex*>(C), ldc);
+}
+
+
 /* ---------- gesvd ---------- */
 cusolverStatus_t cusolverDnSgesvd_bufferSize(cusolverDnHandle_t handle,
                                              int m,
@@ -896,23 +980,6 @@ cusolverStatus_t cusolverDnZpotrsBatched(...) {
     return rocblas_status_not_implemented;
 }
 
-
-/* ---------- unmqr ---------- */
-cusolverStatus_t cusolverDnCunmqr_bufferSize(...) {
-    return rocblas_status_not_implemented;
-}
-
-cusolverStatus_t cusolverDnZunmqr_bufferSize(...) {
-    return rocblas_status_not_implemented;
-}
-
-cusolverStatus_t cusolverDnCunmqr(...) {
-    return rocblas_status_not_implemented;
-}
-
-cusolverStatus_t cusolverDnZunmqr(...) {
-    return rocblas_status_not_implemented;
-}
 
 cusolverStatus_t cusolverDnSsytrf_bufferSize(...) {
     return rocblas_status_not_implemented;

--- a/tests/cupy_tests/linalg_tests/test_decomposition.py
+++ b/tests/cupy_tests/linalg_tests/test_decomposition.py
@@ -159,23 +159,6 @@ class TestSVD(unittest.TestCase):
         cupy.testing.assert_allclose(s_gpu, s_cpu, atol=1e-4)
 
         k, = s_cpu.shape
-        for j in range(k):
-            # assert corresponding vectors are equal up to rotation (`sign`)
-            uj_cpu = u_cpu[:, j]
-            vj_cpu = vh_cpu[j, :].conj()
-            uj_gpu = cupy.asnumpy(u_gpu[:, j])
-            vj_gpu = cupy.asnumpy(vh_gpu[j, :]).conj()
-            # Use least-squares estimation to compute rotation from cpu result
-            # to gpu result. We know norms of uj_cpu, vj_cpu are 1.
-            u_sign = numpy.vdot(uj_cpu, uj_gpu)
-            v_sign = numpy.vdot(vj_cpu, vj_gpu)
-            numpy.testing.assert_allclose(uj_gpu, u_sign * uj_cpu, atol=1e-4)
-            numpy.testing.assert_allclose(vj_gpu, v_sign * vj_cpu, atol=1e-4)
-            numpy.testing.assert_allclose(abs(u_sign), 1, atol=1e-4)
-            numpy.testing.assert_allclose(abs(v_sign), 1, atol=1e-4)
-            # we don't compare u_sign with v_sign directly, as the sign
-            # convention is implementation dependent
-
         # reconstruct the matrix
         if self.full_matrices:
             a_gpu_usv = cupy.dot(u_gpu[:, :k] * s_gpu, vh_gpu[:k, :])

--- a/tests/cupy_tests/linalg_tests/test_decomposition.py
+++ b/tests/cupy_tests/linalg_tests/test_decomposition.py
@@ -177,7 +177,15 @@ class TestSVD(unittest.TestCase):
             numpy.testing.assert_allclose(vj_gpu, v_sign * vj_cpu, atol=1e-4)
             numpy.testing.assert_allclose(abs(u_sign), 1, atol=1e-4)
             numpy.testing.assert_allclose(abs(v_sign), 1, atol=1e-4)
-            numpy.testing.assert_allclose(u_sign, v_sign, atol=1e-4)
+            # we don't compare u_sign with v_sign directly, as the sign
+            # convention is implementation dependent
+
+        # reconstruct the matrix
+        if self.full_matrices:
+            a_gpu_usv = cupy.dot(u_gpu[:, :k] * s_gpu, vh_gpu[:k, :])
+        else:
+            a_gpu_usv = cupy.dot(u_gpu * s_gpu, vh_gpu)
+        cupy.testing.assert_allclose(a_gpu, a_gpu_usv, atol=1e-4)
 
         # assert unitary
         cupy.testing.assert_allclose(

--- a/tests/cupy_tests/linalg_tests/test_decomposition.py
+++ b/tests/cupy_tests/linalg_tests/test_decomposition.py
@@ -51,10 +51,6 @@ class TestCholeskyDecomposition(unittest.TestCase):
     @testing.numpy_cupy_allclose(atol=1e-3)
     def check_L(self, array, xp):
         a = xp.asarray(array)
-        if (a.dtype in (numpy.complex64, numpy.complex128)
-                and cupy.cuda.runtime.is_hip):
-            raise unittest.SkipTest('ROCm does not yet support complex '
-                                    'Cholesky decomposition')
         return xp.linalg.cholesky(a)
 
     @testing.for_dtypes([

--- a/tests/cupy_tests/test_cublas.py
+++ b/tests/cupy_tests/test_cublas.py
@@ -396,7 +396,7 @@ class TestGemmAndGeam(unittest.TestCase):
     'orderc': ['C', 'F'],
 }))
 @attr.gpu
-class TestGdmm(unittest.TestCase):
+class TestDgmm(unittest.TestCase):
     _tol = {'f': 1e-5, 'd': 1e-12}
 
     def _setup(self, dtype, xdim=1):

--- a/tests/cupy_tests/test_cublas.py
+++ b/tests/cupy_tests/test_cublas.py
@@ -418,7 +418,7 @@ class TestGdmm(unittest.TestCase):
                 (xlen, xlen), cupy, dtype=dtype, scale=1.0)
 
     @testing.for_dtypes('fdFD')
-    def test_gdmm(self, dtype):
+    def test_dgmm(self, dtype):
         if self.orderc != 'F':
             raise unittest.SkipTest()
         self._setup(dtype)
@@ -430,7 +430,7 @@ class TestGdmm(unittest.TestCase):
         cupy.testing.assert_allclose(c, ref, rtol=self.tol, atol=self.tol)
 
     @testing.for_dtypes('fdFD')
-    def test_gdmm_out(self, dtype):
+    def test_dgmm_out(self, dtype):
         self._setup(dtype)
         if self.side == 'L':
             ref = cupy.diag(self.x) @ self.a
@@ -441,7 +441,7 @@ class TestGdmm(unittest.TestCase):
         cupy.testing.assert_allclose(c, ref, rtol=self.tol, atol=self.tol)
 
     @testing.for_dtypes('fdFD')
-    def test_gdmm_inplace(self, dtype):
+    def test_dgmm_inplace(self, dtype):
         if self.orderc != 'F':
             raise unittest.SkipTest()
         self._setup(dtype)
@@ -453,7 +453,7 @@ class TestGdmm(unittest.TestCase):
         cupy.testing.assert_allclose(self.a, ref, rtol=self.tol, atol=self.tol)
 
     @testing.for_dtypes('fdFD')
-    def test_gdmm_incx_minus_one(self, dtype):
+    def test_dgmm_incx_minus_one(self, dtype):
         if self.orderc != 'F':
             raise unittest.SkipTest()
         self._setup(dtype)
@@ -465,7 +465,7 @@ class TestGdmm(unittest.TestCase):
         cupy.testing.assert_allclose(c, ref, rtol=self.tol, atol=self.tol)
 
     @testing.for_dtypes('fdFD')
-    def test_gdmm_x_scalar(self, dtype):
+    def test_dgmm_x_scalar(self, dtype):
         if self.orderc != 'F':
             raise unittest.SkipTest()
         self._setup(dtype, xdim=0)
@@ -474,7 +474,7 @@ class TestGdmm(unittest.TestCase):
         cupy.testing.assert_allclose(c, ref, rtol=self.tol, atol=self.tol)
 
     @testing.for_dtypes('fdFD')
-    def test_gdmm_x_matrix(self, dtype):
+    def test_dgmm_x_matrix(self, dtype):
         if self.orderc != 'F':
             raise unittest.SkipTest()
         self._setup(dtype, xdim=2)

--- a/tests/cupy_tests/test_cusolver.py
+++ b/tests/cupy_tests/test_cusolver.py
@@ -285,6 +285,10 @@ class TestCsrlsvqr(unittest.TestCase):
     density = 0.75
     _test_tol = {'f': 1e-5, 'd': 1e-12}
 
+    def setUp(self):
+        if not cusolver.check_availability('csrlsvqr'):
+            pytest.skip('csrlsvqr is not available')
+
     def _setup(self, dtype):
         dtype = numpy.dtype(dtype)
         a_shape = (self.n, self.n)
@@ -299,8 +303,6 @@ class TestCsrlsvqr(unittest.TestCase):
 
     @testing.for_dtypes('fdFD')
     def test_csrlsvqr(self, dtype):
-        if not cusolver.check_availability('csrlsvqr'):
-            unittest.SkipTest('csrlsvqr is not available')
         a, b, test_tol = self._setup(dtype)
         ref_x = numpy.linalg.solve(a, b)
         cp_a = cupy.array(a)

--- a/tests/cupyx_tests/test_lapack.py
+++ b/tests/cupyx_tests/test_lapack.py
@@ -114,6 +114,10 @@ class TestGels(unittest.TestCase):
 @attr.gpu
 class TestPosv(unittest.TestCase):
 
+    def setUp(self):
+        if not cupy.cusolver.check_availability('potrsBatched'):
+            pytest.skip('potrsBatched is not available')
+
     @testing.for_dtypes('fdFD')
     @testing.numpy_cupy_allclose(atol=1e-5)
     def test_posv(self, xp, dtype):


### PR DESCRIPTION
Related to #4132. ~~Blocked by #4205~~. 

TODO:
- [x] Add SVD (gesvd) from ROCm 3.9.0
- [x] Add  (`*geam` and `*dgmm`) (#4263) from ROCm 3.7.0+
- [ ] ~~Update the stubs from #4073?~~
**UPDATE**: `gels` was just recently added upstream (https://github.com/ROCmSoftwarePlatform/rocSOLVER/pull/164) and is not included in any official ROCm release yet
- [x] Force push