### PR TITLE
Fix output dtype of `linalg.norm`

### DIFF
--- a/cupy/linalg/_norms.py
+++ b/cupy/linalg/_norms.py
@@ -24,7 +24,7 @@ _norm_ord2 = core.create_reduction_func(
     ('in0 * in0', 'a + b', 'out0 = sqrt(type_out0_raw(a))', None), 0)
 _norm_ord2_complex = core.create_reduction_func(
     '_norm_ord2_complex',
-    ('F->F', 'D->D'),
+    ('F->f', 'D->d'),
     ('in0.real() * in0.real() + in0.imag() * in0.imag()',
      'a + b', 'out0 = sqrt(type_out0_raw(a))', None), 0)
 

--- a/tests/cupy_tests/linalg_tests/test_norms.py
+++ b/tests/cupy_tests/linalg_tests/test_norms.py
@@ -53,7 +53,13 @@ class TestNorm(unittest.TestCase):
     @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-4)
     def test_norm(self, xp, dtype):
         a = testing.shaped_arange(self.shape, xp, dtype)
-        return xp.linalg.norm(a, self.ord, self.axis, self.keepdims)
+        res = xp.linalg.norm(a, self.ord, self.axis, self.keepdims)
+        if xp == numpy and not isinstance(res, numpy.ndarray):
+            real_dtype = a.real.dtype
+            if issubclass(real_dtype.type, numpy.inexact):
+                # Avoid numpy bug. See numpy/numpy#10667
+                res = res.astype(a.real.dtype)
+        return res
 
 
 @testing.parameterize(*testing.product({

--- a/tests/cupy_tests/linalg_tests/test_norms.py
+++ b/tests/cupy_tests/linalg_tests/test_norms.py
@@ -49,11 +49,8 @@ class TestTrace(unittest.TestCase):
 @testing.gpu
 class TestNorm(unittest.TestCase):
 
-    # TODO(kmaehashi) Currently dtypes returned from CuPy is not compatible
-    # with NumPy. We should remove `type_check=False` once NumPy is fixed.
-    # See https://github.com/cupy/cupy/pull/875 for details.
     @testing.for_all_dtypes(no_float16=True)
-    @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-4, type_check=False)
+    @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-4)
     def test_norm(self, xp, dtype):
         a = testing.shaped_arange(self.shape, xp, dtype)
         return xp.linalg.norm(a, self.ord, self.axis, self.keepdims)


### PR DESCRIPTION
ref: #875