### PR TITLE
Skip `scipy.sparse.linalg.eighs` tests for CUDA 9.2

### DIFF
--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
@@ -117,6 +117,9 @@ class TestVectorNorm(unittest.TestCase):
     'return_eigenvectors': [True, False],
 }))
 @unittest.skipUnless(scipy_available, 'requires scipy')
+@unittest.skipUnless(
+    cupy.cuda.runtime.runtimeGetVersion() > 9200, 'requires CUDA > 9.2'
+)
 class TestEigsh(unittest.TestCase):
     n = 30
     density = 0.33


### PR DESCRIPTION
In the cupy daily combination tests, the recent PR #4138 makes use of a call that returns nan arrays in CUDA 9.2

With the provided [t.npy.zip](https://github.com/cupy/cupy/files/5492771/t.npy.zip), cusolver syevd fails in CUDA 9.2
```python
import cupy
a = cupy.load('t.npy')
cupy.linalg.eigh(a)  # nans
```

We will skip these tests since there is no easy way to fix this in our side, as this is an older cusolver internal problem.
@anaruse any thoughts about this? thanks!







