### PR TITLE
Refactor `AssertFunctionIsCalled`

### DIFF
--- a/cupy/testing/helper.py
+++ b/cupy/testing/helper.py
@@ -1417,10 +1417,8 @@ class NumpyAliasValuesTestBase(NumpyAliasTestBase):
 @contextlib.contextmanager
 def _assert_function_is_called(*args, times_called=1, **kwargs):
     with mock.patch(*args, **kwargs) as handle:
-        assert handle.call_count == 0
-        yield handle
-        assert handle.call_count == int(times_called)
-        del handle
+        yield
+        assert handle.call_count == times_called
 
 
 class AssertFunctionIsCalled:

--- a/cupy/testing/helper.py
+++ b/cupy/testing/helper.py
@@ -1415,29 +1415,20 @@ class NumpyAliasValuesTestBase(NumpyAliasTestBase):
 
 
 @contextlib.contextmanager
-def _assert_function_is_called(*args, times_called=1, **kwargs):
+def assert_function_is_called(*args, times_called=1, **kwargs):
+    """A handy wrapper for unittest.mock to check if a function is called.
+
+    Args:
+        *args: Arguments of `mock.patch`.
+        times_called (int): The number of times the function should be
+            called. Default is ``1``.
+        **kwargs: Keyword arguments of `mock.patch`.
+
+    """
     with mock.patch(*args, **kwargs) as handle:
         yield
         assert handle.call_count == times_called
 
 
-class AssertFunctionIsCalled:
-
-    def __init__(self, mock_mod, **kwargs):
-        """A handy wrapper for unittest.mock to check if a function is called.
-
-        This class should be used as a context manager.
-
-        Args:
-            mock_mod (str): the function to be mocked.
-            times_called (int): the number of times the function should be
-                called. Default is ``1``.
-
-        """
-        self._ctx = _assert_function_is_called(mock_mod, **kwargs)
-
-    def __enter__(self):
-        return self._ctx.__enter__()
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        return self._ctx.__exit__(exc_type, exc_value, traceback)
+# TODO(kataoka): remove this alias
+AssertFunctionIsCalled = assert_function_is_called

--- a/tests/cupy_tests/testing_tests/test_helper.py
+++ b/tests/cupy_tests/testing_tests/test_helper.py
@@ -290,6 +290,54 @@ class TestGenerateMatrixInvalid(unittest.TestCase):
                 (0, 2, 2), singular_values=numpy.ones(3))
 
 
+class TestAssertFunctionIsCalled(unittest.TestCase):
+
+    def test_patch_ndarray(self):
+        orig = cupy.ndarray
+        with testing.AssertFunctionIsCalled('cupy.ndarray'):
+            a = cupy.ndarray((2, 3), numpy.float32)
+        assert cupy.ndarray is orig
+        assert not isinstance(a, cupy.ndarray)
+
+    def test_spy_ndarray(self):
+        orig = cupy.ndarray
+        with testing.AssertFunctionIsCalled(
+                'cupy.ndarray', wraps=cupy.ndarray):
+            a = cupy.ndarray((2, 3), numpy.float32)
+        assert cupy.ndarray is orig
+        assert isinstance(a, cupy.ndarray)
+
+    def test_fail_not_called(self):
+        orig = cupy.ndarray
+        with pytest.raises(AssertionError):
+            with testing.AssertFunctionIsCalled('cupy.ndarray'):
+                pass
+        assert cupy.ndarray is orig
+
+    def test_fail_called_twice(self):
+        orig = cupy.ndarray
+        with pytest.raises(AssertionError):
+            with testing.AssertFunctionIsCalled('cupy.ndarray'):
+                cupy.ndarray((2, 3), numpy.float32)
+                cupy.ndarray((2, 3), numpy.float32)
+        assert cupy.ndarray is orig
+
+    def test_times_called(self):
+        orig = cupy.ndarray
+        with testing.AssertFunctionIsCalled('cupy.ndarray', times_called=2):
+            cupy.ndarray((2, 3), numpy.float32)
+            cupy.ndarray((2, 3), numpy.float32)
+        assert cupy.ndarray is orig
+
+    def test_inner_error(self):
+        orig = cupy.ndarray
+        with pytest.raises(numpy.AxisError):
+            with testing.AssertFunctionIsCalled('cupy.ndarray'):
+                cupy.ndarray((2, 3), numpy.float32)
+                raise numpy.AxisError('foo')
+        assert cupy.ndarray is orig
+
+
 @testing.parameterize(*testing.product({
     'framework': ['unittest', 'pytest']
 }))


### PR DESCRIPTION
Fixed issues:
- assertion failure leaves the target unpatched
- `times_called` is also passed to `mock.patch`

(close #4232)