### PR TITLE
Add parallel build feature

### DIFF
--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -1,5 +1,6 @@
 import argparse
 import copy
+import multiprocessing
 from distutils import ccompiler
 from distutils import errors
 from distutils import msvccompiler
@@ -1049,3 +1050,9 @@ class custom_build_ext(build_ext.build_ext):
             cythonize(ext_modules, cupy_setup_options)
         check_extensions(self.extensions)
         build_ext.build_ext.run(self)
+
+    def build_extensions(self):
+        self.check_extensions_list(self.extensions)
+        num_jobs = int(os.environ.get('CUPY_NUM_BUILD_JOBS', '4'))
+        with multiprocessing.Pool(num_jobs) as pool:
+            pool.map(self.build_extension, self.extensions)

--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -1,6 +1,5 @@
 import argparse
 import copy
-import multiprocessing
 from distutils import ccompiler
 from distutils import errors
 from distutils import msvccompiler
@@ -1052,7 +1051,6 @@ class custom_build_ext(build_ext.build_ext):
         build_ext.build_ext.run(self)
 
     def build_extensions(self):
-        self.check_extensions_list(self.extensions)
         num_jobs = int(os.environ.get('CUPY_NUM_BUILD_JOBS', '4'))
-        with multiprocessing.Pool(num_jobs) as pool:
-            pool.map(self.build_extension, self.extensions)
+        self.parallel = num_jobs
+        super().build_extensions()


### PR DESCRIPTION
Use the `CUPY_NUM_BUILD_JOBS` to control the number of modules being built in parallel.

This PR enables the parallel compilation of thrust and cub, which are the modules that takes most of the time.
When building for all the compute archs, the master branch buiold time is 18 minutes, with this PR it becomes 9 minutes.
Moreover, if we limit to a single compute capability with something like `CUPY_NVCC_GENERATE_CODE=arch=compute_62,code=sm_62` , we get a build time of 3 minutes, which is enough for the majority of the users.

Currently, the default is 4 processes because as long as we ensure that there are two threads, cub and thrust will be built independently.

Cub and Thrust are a single .cu file that is built for all the compute archs, and this is what takes the majority of the compile time. Unfortunately this process can't be parallelized unless we run `nvcc ... --dryrun` and run these commands in a different thread by ourselves.

Credit goes to this SO post:
https://stackoverflow.com/questions/11013851/speeding-up-build-process-with-distutils