### PR TITLE
Support compile-time constants in CuPy JIT

### DIFF
--- a/cupyx/jit/_typerules.py
+++ b/cupyx/jit/_typerules.py
@@ -44,6 +44,33 @@ _scalar_gt = core.create_comparison('scalar_less', '>')
 _scalar_gte = core.create_comparison('scalar_less', '>=')
 
 
+_py_ops = {
+    ast.And: lambda x, y: x and y,
+    ast.Or: lambda x, y: x or y,
+    ast.Add: lambda x, y: x + y,
+    ast.Sub: lambda x, y: x - y,
+    ast.Mult: lambda x, y: x * y,
+    ast.Pow: lambda x, y: x ** y,
+    ast.Div: lambda x, y: x / y,
+    ast.FloorDiv: lambda x, y: x // y,
+    ast.Mod: lambda x, y: x % y,
+    ast.LShift: lambda x, y: x << y,
+    ast.RShift: lambda x, y: x >> y,
+    ast.BitOr: lambda x, y: x | y,
+    ast.BitAnd: lambda x, y: x & y,
+    ast.BitXor: lambda x, y: x ^ y,
+    ast.Invert: lambda x: ~x,
+    ast.Not: lambda x: not x,
+    ast.Eq: lambda x, y: x == y,
+    ast.NotEq: lambda x, y: x != y,
+    ast.Lt: lambda x, y: x < y,
+    ast.LtE: lambda x, y: x <= y,
+    ast.Gt: lambda x, y: x > y,
+    ast.GtE: lambda x, y: x >= y,
+    ast.USub: lambda x: -x,
+}
+
+
 _numpy_ops = {
     ast.And: ops.logical_and,
     ast.Or: ops.logical_or,
@@ -69,6 +96,10 @@ _numpy_ops = {
     ast.GtE: _scalar_gte,
     ast.USub: arithmetic.negative,
 }
+
+
+def get_pyfunc(op_type):
+    return _py_ops[op_type]
 
 
 def get_ufunc(mode, op_type):

--- a/tests/cupy_tests/functional_tests/test_vectorize.py
+++ b/tests/cupy_tests/functional_tests/test_vectorize.py
@@ -256,6 +256,39 @@ class TestVectorizeInstructions(unittest.TestCase):
         return f(x)
 
 
+class _MyClass:
+
+    def __init__(self, x):
+        self.x = x
+
+
+class TestVectorizeConstants(unittest.TestCase):
+
+    @testing.numpy_cupy_array_equal()
+    def test_vectorize_const_value(self, xp):
+
+        def my_func(x1, x2):
+            return x1 - x2 + const
+
+        const = 8
+        f = xp.vectorize(my_func)
+        x1 = testing.shaped_random((20, 30), xp, xp.int64, seed=1)
+        x2 = testing.shaped_random((20, 30), xp, xp.int64, seed=2)
+        return f(x1, x2)
+
+    @testing.numpy_cupy_array_equal()
+    def test_vectorize_const_attr(self, xp):
+
+        def my_func(x1, x2):
+            return x1 - x2 + const.x
+
+        const = _MyClass(10)
+        f = xp.vectorize(my_func)
+        x1 = testing.shaped_random((20, 30), xp, xp.int64, seed=1)
+        x2 = testing.shaped_random((20, 30), xp, xp.int64, seed=2)
+        return f(x1, x2)
+
+
 class TestVectorize(unittest.TestCase):
 
     @testing.for_all_dtypes(no_bool=True)


### PR DESCRIPTION
This PR supports compile-time constants in CuPy JIT. This enhancement simplifies generated code by evaluating some numerical expressions in transpile time and enables us to use Python objects of any type, even if it is a non-numerical object, in compile-time.