### PR TITLE
[backport] Fix `numpy_cupy_equal` for case that both numpy cupy raise errors

### DIFF
--- a/cupy/testing/helper.py
+++ b/cupy/testing/helper.py
@@ -652,6 +652,12 @@ def numpy_cupy_equal(name='xp', sp_name=None, scipy_name=None):
                     _call_func_numpy_cupy(
                         self, impl, args, kw, name, sp_name, scipy_name))
 
+            if cupy_error or numpy_error:
+                _check_cupy_numpy_error(
+                    self, cupy_error, cupy_tb, numpy_error, numpy_tb,
+                    accept_error=False)
+                return
+
             if cupy_result != numpy_result:
                 message = '''Results are not equal:
 cupy: %s

--- a/tests/cupy_tests/sorting_tests/test_sort.py
+++ b/tests/cupy_tests/sorting_tests/test_sort.py
@@ -624,9 +624,9 @@ class TestArgpartition(unittest.TestCase):
         a = testing.shaped_random((10,), xp, dtype, 100)
         kth = 2
         idx = self.argpartition(a, kth)
-        self.assertTrue((a[idx[:kth]] < a[idx[kth]]).all())
-        self.assertTrue((a[idx[kth]] < a[idx[kth + 1:]]).all())
-        return idx[kth]
+        self.assertTrue((a[idx[:kth]] <= a[idx[kth]]).all())
+        self.assertTrue((a[idx[kth]] <= a[idx[kth + 1:]]).all())
+        return a[idx[kth]]
 
     # TODO(leofang): test all dtypes -- this workaround needs to be kept,
     # likely due to #3287? Need investigation.


### PR DESCRIPTION
Backport of #4244