### PR TITLE
`testing.numpy_cupy_allclose` with per-dtype tolerance

### DIFF
--- a/cupy/testing/helper.py
+++ b/cupy/testing/helper.py
@@ -386,8 +386,13 @@ def numpy_cupy_allclose(rtol=1e-7, atol=0, err_msg='', verbose=True,
     """Decorator that checks NumPy results and CuPy ones are close.
 
     Args:
-         rtol(float): Relative tolerance.
-         atol(float): Absolute tolerance.
+         rtol(float or dict): Relative tolerance. Besides a float value, a
+             dictionary that maps a dtypes to a float value can be supplied to
+             adjust tolerance per dtype. If the dictionary has ``'default'``
+             string as its key, its value is used as the default tolerance in
+             case any dtype keys do not match.
+         atol(float or dict): Absolute tolerance. Besides a float value, a
+             dictionary can be supplied as ``rtol``.
          err_msg(str): The error message to be printed in case of failure.
          verbose(bool): If ``True``, the conflicting values are
              appended to the error message.

--- a/cupy/testing/helper.py
+++ b/cupy/testing/helper.py
@@ -450,7 +450,7 @@ def numpy_cupy_allclose(rtol=1e-7, atol=0, err_msg='', verbose=True,
     # tolerance associations.
     if not type_check:
         if isinstance(rtol, dict) or isinstance(atol, dict):
-            raise TypeError('When `type_ckeck` is `False`, `rtol` and `atol` '
+            raise TypeError('When `type_check` is `False`, `rtol` and `atol` '
                             'must be supplied as float.')
 
     def check_func(c, n):

--- a/cupy/testing/helper.py
+++ b/cupy/testing/helper.py
@@ -352,6 +352,22 @@ def _convert_output_to_ndarray(c_out, n_out, sp_name, check_sparse_format):
             type(c_out), type(n_out)))
 
 
+def _check_tolerance_keys(rtol, atol):
+    def _check(tol):
+        if isinstance(tol, dict):
+            for k in tol.keys():
+                if type(k) is type:
+                    continue
+                if type(k) is str and k == 'default':
+                    continue
+                msg = ('Keys of the tolerance dictionary need to be type '
+                       'objects as `numpy.float32` and `cupy.float32` or '
+                       '`\'default\'` string.')
+                raise TypeError(msg)
+    _check(rtol)
+    _check(atol)
+
+
 def _resolve_tolerance(type_check, result, rtol, atol):
     def _resolve(dtype, tol):
         if isinstance(tol, dict):
@@ -435,6 +451,8 @@ def numpy_cupy_allclose(rtol=1e-7, atol=0, err_msg='', verbose=True,
 
     .. seealso:: :func:`cupy.testing.assert_allclose`
     """
+    _check_tolerance_keys(rtol, atol)
+
     def check_func(c, n):
         rtol1, atol1 = _resolve_tolerance(type_check, c, rtol, atol)
         array.assert_allclose(c, n, rtol1, atol1, err_msg, verbose)

--- a/cupy/testing/helper.py
+++ b/cupy/testing/helper.py
@@ -381,14 +381,6 @@ def _resolve_tolerance(type_check, result, rtol, atol):
         else:
             return tol
 
-    # When `type_check` is `False`, cupy result and numpy result may have
-    # different dtypes so we can not determine the dtype to use from the
-    # tolerance associations.
-    if not type_check:
-        if isinstance(rtol, dict) or isinstance(atol, dict):
-            raise TypeError('When `type_ckeck` is `False`, `rtol` and `atol` '
-                            'must be supplied as float.')
-
     dtype = result.dtype
     rtol1 = _resolve(dtype, rtol)
     atol1 = _resolve(dtype, atol)
@@ -452,6 +444,14 @@ def numpy_cupy_allclose(rtol=1e-7, atol=0, err_msg='', verbose=True,
     .. seealso:: :func:`cupy.testing.assert_allclose`
     """
     _check_tolerance_keys(rtol, atol)
+
+    # When `type_check` is `False`, cupy result and numpy result may have
+    # different dtypes so we can not determine the dtype to use from the
+    # tolerance associations.
+    if not type_check:
+        if isinstance(rtol, dict) or isinstance(atol, dict):
+            raise TypeError('When `type_ckeck` is `False`, `rtol` and `atol` '
+                            'must be supplied as float.')
 
     def check_func(c, n):
         rtol1, atol1 = _resolve_tolerance(type_check, c, rtol, atol)

--- a/tests/cupy_tests/testing_tests/test_helper.py
+++ b/tests/cupy_tests/testing_tests/test_helper.py
@@ -165,6 +165,10 @@ class TestNumPyCuPyAllCloseTolPerDtype(unittest.TestCase):
     def test_rtol_fail(self, xp, dtype):
         return self._test_rtol(xp, dtype)
 
+    def test_rtol_invalid_key(self):
+        with self.assertRaises(TypeError):
+            helper.numpy_cupy_allclose(rtol={'float16': 1e-3})
+
     def _test_atol(self, xp, dtype):
         if xp is numpy:
             return numpy.array(0, dtype=dtype)
@@ -182,6 +186,10 @@ class TestNumPyCuPyAllCloseTolPerDtype(unittest.TestCase):
     @helper.numpy_cupy_allclose(atol=1e-6)
     def test_atol_fail(self, xp, dtype):
         return self._test_atol(xp, dtype)
+
+    def test_atol_invalid_key(self):
+        with self.assertRaises(TypeError):
+            helper.numpy_cupy_allclose(atol={'float16': 1e-3})
 
 
 class TestIgnoreOfNegativeValueDifferenceOnCpuAndGpu(unittest.TestCase):

--- a/tests/cupy_tests/testing_tests/test_helper.py
+++ b/tests/cupy_tests/testing_tests/test_helper.py
@@ -147,9 +147,7 @@ class TestNumPyCuPyLess(unittest.TestCase, NumPyCuPyDecoratorBase,
 
 class TestNumPyCuPyAllCloseTolPerDtype(unittest.TestCase):
 
-    @helper.for_float_dtypes()
-    @helper.numpy_cupy_allclose(rtol={numpy.float16: 1e-3, 'default': 1e-6})
-    def test_rtol_per_dtype(self, xp, dtype):
+    def _test_rtol(self, xp, dtype):
         if xp is numpy:
             return numpy.array(1, dtype=dtype)
         else:
@@ -157,13 +155,33 @@ class TestNumPyCuPyAllCloseTolPerDtype(unittest.TestCase):
             return cupy.array(1 + finfo.eps, dtype=dtype)
 
     @helper.for_float_dtypes()
-    @helper.numpy_cupy_allclose(atol={numpy.float16: 1e-3, 'default': 1e-6})
-    def test_atol_per_dtype(self, xp, dtype):
+    @helper.numpy_cupy_allclose(rtol={numpy.float16: 1e-3, 'default': 1e-6})
+    def test_rtol_per_dtype(self, xp, dtype):
+        return self._test_rtol(xp, dtype)
+
+    @pytest.mark.xfail(strict=True)
+    @helper.for_float_dtypes()
+    @helper.numpy_cupy_allclose(rtol=1e-6)
+    def test_rtol_fail(self, xp, dtype):
+        return self._test_rtol(xp, dtype)
+
+    def _test_atol(self, xp, dtype):
         if xp is numpy:
             return numpy.array(0, dtype=dtype)
         else:
             finfo = numpy.finfo(dtype)
             return cupy.array(finfo.eps, dtype=dtype)
+
+    @helper.for_float_dtypes()
+    @helper.numpy_cupy_allclose(atol={numpy.float16: 1e-3, 'default': 1e-6})
+    def test_atol_per_dtype(self, xp, dtype):
+        return self._test_atol(xp, dtype)
+
+    @pytest.mark.xfail(strict=True)
+    @helper.for_float_dtypes()
+    @helper.numpy_cupy_allclose(atol=1e-6)
+    def test_atol_fail(self, xp, dtype):
+        return self._test_atol(xp, dtype)
 
 
 class TestIgnoreOfNegativeValueDifferenceOnCpuAndGpu(unittest.TestCase):

--- a/tests/cupy_tests/testing_tests/test_helper.py
+++ b/tests/cupy_tests/testing_tests/test_helper.py
@@ -145,6 +145,27 @@ class TestNumPyCuPyLess(unittest.TestCase, NumPyCuPyDecoratorBase,
         return make_result(foo, numpy.array(2), cupy.array(1))
 
 
+class TestNumPyCuPyAllCloseTolPerDtype(unittest.TestCase):
+
+    @helper.for_float_dtypes()
+    @helper.numpy_cupy_allclose(rtol={numpy.float16: 1e-3, 'default': 1e-6})
+    def test_rtol_per_dtype(self, xp, dtype):
+        if xp is numpy:
+            return numpy.array(1, dtype=dtype)
+        else:
+            finfo = numpy.finfo(dtype)
+            return cupy.array(1 + finfo.eps, dtype=dtype)
+
+    @helper.for_float_dtypes()
+    @helper.numpy_cupy_allclose(atol={numpy.float16: 1e-3, 'default': 1e-6})
+    def test_atol_per_dtype(self, xp, dtype):
+        if xp is numpy:
+            return numpy.array(0, dtype=dtype)
+        else:
+            finfo = numpy.finfo(dtype)
+            return cupy.array(finfo.eps, dtype=dtype)
+
+
 class TestIgnoreOfNegativeValueDifferenceOnCpuAndGpu(unittest.TestCase):
 
     @helper.numpy_cupy_allclose()


### PR DESCRIPTION
Closes #4220.

This PR makes `testing.numpy_cupy_allclose` allow tolerance per dtype.
