### PR TITLE
Fix undefined symbols in `cupy.fft._callback`

### DIFF
--- a/cupy/fft/_callback.pyx
+++ b/cupy/fft/_callback.pyx
@@ -95,12 +95,11 @@ cdef inline void _set_nvcc_path() except*:
         nvcc = get_nvcc_path()
         if nvcc is not None:
             _nvcc = nvcc.split(' ')
-            # if the host compiler is set in NVCC, we use it to compile the
-            # Python module; if the host compiler is not set, then we use
+            # if the host compiler is set in NVCC, we force it to align with
             # the one reported by sysconfig
             for i, f in enumerate(_nvcc):
                 if f in ('-ccbin', '--compiler-bindir'):
-                    _cc[0] = _nvcc[i+1]
+                    _nvcc[i+1] = _cc[0]
                     break
             else:
                 _nvcc += ['-ccbin', _cc[0]]


### PR DESCRIPTION
Fix https://github.com/cupy/cupy/issues/4105#issuecomment-727633420. This reverts commit 30a620db38889692694745f5e738e86f080fe524. It seems when linking all callback objects, a C++ compiler must be used (ex: g++ instead of gcc) in order to resolve undefined symbols (ex: `__cxa_pure_virtual`).

cc: @llukas @mnicely @emcastillo 