### PR TITLE
Support CUB-backed `cupy.ReductionKernel` and `@cupy.fuse`

### DIFF
--- a/cupy/core/_cub_reduction.pxd
+++ b/cupy/core/_cub_reduction.pxd
@@ -1,10 +1,12 @@
 from cupy.core._carray cimport shape_t
+from cupy.core._kernel cimport _TypeMap
 from cupy.core.core cimport ndarray
 
 
 cdef bint _try_to_call_cub_reduction(
     self, list in_args, list out_args, const shape_t& a_shape,
     stream, optimize_context, tuple key,
-    map_expr, reduce_expr, post_map_expr, reduce_type, type_map,
+    map_expr, reduce_expr, post_map_expr,
+    reduce_type, _TypeMap type_map,
     tuple reduce_axis, tuple out_axis, const shape_t& out_shape,
     ndarray ret) except *

--- a/cupy/core/_cub_reduction.pyx
+++ b/cupy/core/_cub_reduction.pyx
@@ -25,6 +25,7 @@ cdef function.Function _create_cub_reduction_function(
         reduce_type, params, arginfos, identity,
         pre_map_expr, reduce_expr, post_map_expr,
         _kernel._TypeMap type_map, preamble, options):
+    print(type_map)
     # A (incomplete) list of internal variables:
     # _J            : the index of an element in the array
 
@@ -591,7 +592,8 @@ def _get_cub_optimized_params(
 cdef bint _try_to_call_cub_reduction(
         self, list in_args, list out_args, const shape_t& a_shape,
         stream, optimize_context, tuple key,
-        map_expr, reduce_expr, post_map_expr, reduce_type, type_map,
+        map_expr, reduce_expr, post_map_expr,
+        reduce_type, _kernel._TypeMap type_map,
         tuple reduce_axis, tuple out_axis, const shape_t& out_shape,
         ndarray ret) except *:
     """Try to use cub.
@@ -618,6 +620,11 @@ cdef bint _try_to_call_cub_reduction(
 
     in_shape = _reduction._set_permuted_args(
         in_args, axis_permutes, a_shape, self.in_params)
+
+    # When coming from ReductionKernel, type_map does not contain the expected
+    # names (type_in0_raw and type_out0_raw), so we must append them
+    type_map._pairs += (('type_in0_raw', in_args[0].dtype.type),
+                        ('type_out0_raw', out_args[0].dtype.type),)
 
     if in_args[0]._f_contiguous:
         ret._set_contiguous_strides(ret.dtype.itemsize, False)

--- a/cupy/core/_cub_reduction.pyx
+++ b/cupy/core/_cub_reduction.pyx
@@ -25,24 +25,8 @@ cdef function.Function _create_cub_reduction_function(
         reduce_type, params, arginfos, identity,
         pre_map_expr, reduce_expr, post_map_expr,
         _kernel._TypeMap type_map, preamble, options):
-    print(params)
-    print(type_map)
-    print(arginfos)
     # A (incomplete) list of internal variables:
     # _J            : the index of an element in the array
-
-#    # TODO(leofang): handle _raw_in0 and _raw_out0 better when we support
-#    # multiple inputs/outputs from ReductionKernel
-#    cdef _kernel._ArgInfo arginfo
-#    cdef str in_var, out_var
-#    if params[0].name == 'in0' and params[1].name == 'out0':
-#        # from create_reduction_func
-#        in_var = '_raw_' + params[0].name
-#        out_var = '_raw_' + params[1].name
-#    else:
-#        # from ReductionKernel (names supplied by the user)
-#        in_var = params[0].name
-#        out_var = params[1].name
 
     # static_assert needs at least C++11 in NVRTC
     options += ('--std=c++11',)
@@ -57,10 +41,8 @@ cdef function.Function _create_cub_reduction_function(
         # use jitify + nvrtc
         # TODO(leofang): how about simply specifying jitify=True when calling
         # compile_with_cache()?
-        #options += ('-DCUPY_USE_JITIFY',)
-        #backend = 'nvrtc'
-        options += ('-O2',)
-        backend = 'nvcc'
+        options += ('-DCUPY_USE_JITIFY',)
+        backend = 'nvrtc'
 
     # TODO(leofang): try splitting the for-loop into full tiles and partial
     # tiles to utilize LoadDirectBlockedVectorized? See, for example,
@@ -131,8 +113,7 @@ __global__ void ${name}(${params}) {
   // Declare reduction operation
   _reduction_op op;
 
-  // input & output raw pointers; they might not be called as "_raw_in0" or
-  // "_raw_out0" if ReductionKernel is in use
+  // input & output raw pointers
   const type_mid_in* _in0 = static_cast<const type_mid_in*>(_raw_in0);
   type_mid_out* _out0 = static_cast<type_mid_out*>(_raw_out0);
 
@@ -218,8 +199,6 @@ __global__ void ${name}(${params}) {
         items_per_thread=items_per_thread,
         reduce_type=reduce_type,
         params=_get_cub_kernel_params(params, arginfos),
-#        _raw_in0=in_var,
-#        _raw_out0=out_var,
         identity=identity,
         reduce_expr=reduce_expr,
         pre_map_expr=pre_map_expr,
@@ -370,20 +349,10 @@ cdef str _get_cub_kernel_params(tuple params, tuple arginfos):
     cdef int i
     assert len(params) == len(arginfos)
 
-    # For params coming from ReductionKernel, we rename the variable
-    # names to make it work with the CUB kernel
     for i, (p, arginfo) in enumerate(zip(params, arginfos)):
         c_name = arginfo.get_c_var_name(p)
-        if i == 0:
-            c_type = 'const void*'
-            if p.name != 'in0':
-                p.name = 'in0'
-                c_name = '_raw_in0'
-        elif i == 1:
-            c_type = 'void*'
-            if p.name != 'out0':
-                p.name = 'out0'
-                c_name = '_raw_out0'
+        if i < len(params) - 2:
+            c_type = 'const void*' if p.is_const else 'void*'
         else:
             # for segment size and array size
             c_type = arginfo.get_param_c_type(p)
@@ -643,7 +612,6 @@ cdef bint _try_to_call_cub_reduction(
     if can_use_cub is None:
         return False
 
-    print("\n\n\npreparing CUB...\n\n\n")
     axis_permutes, contiguous_size, full_reduction = can_use_cub
 
     in_shape = _reduction._set_permuted_args(
@@ -680,16 +648,16 @@ cdef bint _try_to_call_cub_reduction(
     #    type_out0_raw)
     cdef str old_in0 = params[0].name, old_out0 = params[1].name
     if old_in0 != 'in0' or old_out0 != 'out0':
-        type_map._pairs += (('type_in0_raw', in_args[0].dtype.type),
-                            ('type_out0_raw', out_args[0].dtype.type),)
-        print("old:", old_in0, old_out0)
-        map_expr = map_expr.replace(old_in0, 'in0')
-        post_map_expr = post_map_expr.replace(old_out0, 'out0')
-        print(map_expr, '\n', post_map_expr)
         # avoid overwriting self's attributes
         params = (_get_param_info('T in0', True)
                   + _get_param_info('T out0', False)
                   + params[2:])
+        map_expr = map_expr.replace(old_in0, 'in0')
+        post_map_expr = post_map_expr.replace(old_out0, 'out0')
+        type_map = _kernel._TypeMap(type_map._pairs + (
+            ('type_in0_raw', in_args[0].dtype.type),
+            ('type_out0_raw', out_args[0].dtype.type),
+        ))
 
     # Calculate the reduction block dimensions.
     optimize_context = _optimize_config.get_current_context()

--- a/cupy/core/_cub_reduction.pyx
+++ b/cupy/core/_cub_reduction.pyx
@@ -50,9 +50,9 @@ cdef function.Function _create_cub_reduction_function(
 
     cdef str module_code = _get_cub_header_include()
     module_code += '''
+${type_preamble}
 ${preamble}
 
-${type_preamble}
 typedef ${reduce_type} _type_reduce;
 
 static_assert(sizeof(_type_reduce) <= 32,
@@ -193,11 +193,10 @@ __global__ void ${name}(${params}) {
 }
 '''
 
-    module_code = string.Template(module_code).substitute(
+    module_code = string.Template(module_code).safe_substitute(
         name=name,
         block_size=block_size,
         items_per_thread=items_per_thread,
-        reduce_type=reduce_type,
         params=_get_cub_kernel_params(params, arginfos),
         identity=identity,
         reduce_expr=reduce_expr,
@@ -205,6 +204,12 @@ __global__ void ${name}(${params}) {
         post_map_expr=post_map_expr,
         type_preamble=type_map.get_typedef_code(),
         preamble=preamble)
+
+    # When fusing, preamble could also contain ${reduce_type}, so we resolve
+    # in the end
+        #reduce_type=reduce_type,
+    module_code = string.Template(module_code).substitute(
+        reduce_type=reduce_type)
 
     # To specify the backend, we have to explicitly spell out the default
     # values for arch, cachd, and prepend_cupy_headers to bypass cdef/cpdef

--- a/cupy/core/_cub_reduction.pyx
+++ b/cupy/core/_cub_reduction.pyx
@@ -193,10 +193,11 @@ __global__ void ${name}(${params}) {
 }
 '''
 
-    module_code = string.Template(module_code).safe_substitute(
+    module_code = string.Template(module_code).substitute(
         name=name,
         block_size=block_size,
         items_per_thread=items_per_thread,
+        reduce_type=reduce_type,
         params=_get_cub_kernel_params(params, arginfos),
         identity=identity,
         reduce_expr=reduce_expr,
@@ -204,12 +205,6 @@ __global__ void ${name}(${params}) {
         post_map_expr=post_map_expr,
         type_preamble=type_map.get_typedef_code(),
         preamble=preamble)
-
-    # When fusing, preamble could also contain ${reduce_type}, so we resolve
-    # in the end
-        #reduce_type=reduce_type,
-    module_code = string.Template(module_code).substitute(
-        reduce_type=reduce_type)
 
     # To specify the backend, we have to explicitly spell out the default
     # values for arch, cachd, and prepend_cupy_headers to bypass cdef/cpdef

--- a/cupy/core/_fusion_op.py
+++ b/cupy/core/_fusion_op.py
@@ -205,7 +205,7 @@ class _ReductionTraceOp:
         assert all([0 <= x < in_param.ndim for x in axis])
 
         self.name = name
-        self.preamble = reduce_func._preamble
+        self.preamble = reduce_func.preamble
         self.in_params = _VariableSet(in_param)
         self.out_params = _VariableSet(out_param)
         self.block_stride_name = 'block_stride_' + name

--- a/cupy/core/_reduction.pyx
+++ b/cupy/core/_reduction.pyx
@@ -507,7 +507,6 @@ cdef class _SimpleReductionKernel(_AbstractReductionKernel):
     cdef:
         readonly _kernel._Ops _ops
         readonly str preamble
-        readonly str _preamble
         readonly int nin
         readonly int nout
         readonly str _input_expr
@@ -525,7 +524,7 @@ cdef class _SimpleReductionKernel(_AbstractReductionKernel):
             'T out0',
         )
         self._ops = ops
-        self.preamble = self._preamble = preamble
+        self.preamble = preamble
         self.nin = 1
         self.nout = 1
         self._input_expr = 'const type_in0_raw in0 = _raw_in0[_in_ind.get()];'

--- a/cupy/core/_reduction.pyx
+++ b/cupy/core/_reduction.pyx
@@ -509,6 +509,8 @@ cdef class _SimpleReductionKernel(_AbstractReductionKernel):
         readonly str preamble
         readonly int nin
         readonly int nout
+        readonly str _input_expr
+        readonly str _output_expr
         readonly dict _routine_cache
         readonly bint _sort_reduce_axis
 
@@ -525,6 +527,8 @@ cdef class _SimpleReductionKernel(_AbstractReductionKernel):
         self.preamble = preamble
         self.nin = 1
         self.nout = 1
+        self._input_expr = 'const type_in0_raw in0 = _raw_in0[_in_ind.get()];'
+        self._output_expr = 'type_out0_raw &out0 = _raw_out0[_out_ind.get()];'
         self._routine_cache = {}
         self._sort_reduce_axis = sort_reduce_axis
 
@@ -594,14 +598,11 @@ cdef class _SimpleReductionKernel(_AbstractReductionKernel):
             tuple params, tuple arginfos, _kernel._TypeMap type_map,
             str map_expr, str reduce_expr, str post_map_expr, str reduce_type,
             Py_ssize_t block_size):
-        cdef str input_expr, output_expr
-        input_expr = 'const type_in0_raw in0 = _raw_in0[_in_ind.get()];'
-        output_expr = 'type_out0_raw &out0 = _raw_out0[_out_ind.get()];'
         return _SimpleReductionKernel_get_cached_function(
             map_expr, reduce_expr, post_map_expr, reduce_type,
             params, arginfos, type_map,
             self.name, block_size, self.identity,
-            input_expr, output_expr, self.preamble, ())
+            self._input_expr, self._output_expr, self.preamble, ())
 
 
 @_util.memoize(for_each_device=True)

--- a/cupy/core/_reduction.pyx
+++ b/cupy/core/_reduction.pyx
@@ -507,6 +507,7 @@ cdef class _SimpleReductionKernel(_AbstractReductionKernel):
     cdef:
         readonly _kernel._Ops _ops
         readonly str preamble
+        readonly str _preamble
         readonly int nin
         readonly int nout
         readonly str _input_expr
@@ -524,7 +525,7 @@ cdef class _SimpleReductionKernel(_AbstractReductionKernel):
             'T out0',
         )
         self._ops = ops
-        self.preamble = preamble
+        self.preamble = self._preamble = preamble
         self.nin = 1
         self.nout = 1
         self._input_expr = 'const type_in0_raw in0 = _raw_in0[_in_ind.get()];'

--- a/cupy/core/fusion.pyx
+++ b/cupy/core/fusion.pyx
@@ -511,7 +511,7 @@ class _FusionHistory(object):
                 self.reduce_op = op
                 self.reduce_identity = raw.identity
                 self.reduce_kwargs = kwargs
-                self._add_preamble(raw._preamble)
+                self._add_preamble(raw.preamble)
                 return self._fresh_postmap_param(return_dtype)
         raise TypeError('Type is mismatched. {}(...), {}'.format(
             self.raw._ops.name, arg.dtype.type))


### PR DESCRIPTION
Close #3983. Follow-up of #3244. Currently this only supports 1 in + 1 out for efficiently accessing the global memory. N in + 1 out could be revisited in the future; IIUC `ReductionKernel` does not support multiple outputs.

New changes:
- `cupy.ReductionKernel` can be backed by CUB (from `cupy.core._cub_reduction`)
- Fusion (`@cupy.fuse`) with reduction can also use CUB now; this again assumes 1 in + 1 out, which holds IIUC
- No user code change is required other than the need of setting `CUPY_ACCELERATORS=cub`.

Taking the example code from the tutorial:
```python
import cupy as cp
import numpy as np
from cupyx.time import repeat


l2norm_kernel = cp.ReductionKernel(
    'T x',  # input params
    'T y',  # output params
    'x * x',  # map
    'a + b',  # reduce
    'y = sqrt(a)',  # post-reduction map
    '0',  # identity value
    'l2norm'  # kernel name
)

x_cp = cp.random.random(1000000, dtype=cp.float64)

cp.core.set_reduction_accelerators([])
print(repeat(l2norm_kernel, (x_cp,), n_repeat=100))
cp.core.set_reduction_accelerators(['cub'])
print(repeat(l2norm_kernel, (x_cp,), n_repeat=100))

y_cp = l2norm_kernel(x_cp)
x_np = cp.asnumpy(x_cp)
y_np = np.sqrt(np.sum(x_np**2))
print(cp.allclose(y_cp, y_np))
```
Output:
```
l2norm              :    CPU:   12.386 us   +/- 0.652 (min:   11.617 / max:   15.534) us     GPU-0:  701.201 us   +/- 1.012 (min:  699.232 / max:  705.760) us
l2norm              :    CPU:   24.327 us   +/- 0.496 (min:   23.527 / max:   27.277) us     GPU-0:   54.900 us   +/- 0.478 (min:   54.208 / max:   57.376) us
True
```

***UPDATE***: fusion example
```python
import cupy as cp
import numpy as np
from cupyx.time import repeat

cp.core._accelerator.set_routine_accelerators([])

shape = (512, 512, 512)

a = cp.random.random(shape, dtype=cp.float32)
a_np = cp.asnumpy(a)


def my_op(x, sum_axes):
    # make the fuse function internal so that sum_axes can be varied
    @cp.fuse()
    def _my_op(x):
        y = cp.sin(x)
        y = cp.sum(y**2, axis=sum_axes)
        return y
    return _my_op(x)


for sum_axes in [(2,), (1,2), (0,1,2)]:
    print(f"axes={sum_axes}")
    cp.core._accelerator.set_reduction_accelerators([])
    print(repeat(my_op, (a, sum_axes), n_repeat=100))
    cp.core._accelerator.set_reduction_accelerators(['cub'])
    print(repeat(my_op, (a, sum_axes), n_repeat=100))
    out_cp = my_op(a, sum_axes)
    out_np = np.sum(np.sin(a_np)**2, axis=sum_axes)
    if not np.allclose(cp.asnumpy(out_cp), out_np, rtol=1E-4):
        print("cupy:", out_cp)
        print("numpy:", out_np)
    print()
```
Output:
```
axes=(2,)
my_op               :    CPU:  219.712 us   +/-10.059 (min:  213.884 / max:  303.909) us     GPU-0: 4580.685 us   +/-459.435 (min: 4371.840 / max: 5942.080) us
my_op               :    CPU:  220.783 us   +/- 3.813 (min:  216.017 / max:  237.544) us     GPU-0: 1743.457 us   +/-69.232 (min: 1566.688 / max: 1823.744) us

axes=(1, 2)
my_op               :    CPU:  217.272 us   +/- 4.960 (min:  211.869 / max:  243.187) us     GPU-0: 2183.468 us   +/-23.620 (min: 2097.472 / max: 2217.088) us
my_op               :    CPU:  220.258 us   +/- 3.579 (min:  216.138 / max:  239.502) us     GPU-0: 1948.207 us   +/- 7.690 (min: 1930.272 / max: 1974.240) us

axes=(0, 1, 2)
my_op               :    CPU:  224.835 us   +/- 5.922 (min:  214.166 / max:  253.125) us     GPU-0:138661.313 us   +/-26.385 (min:138596.954 / max:138738.693) us
my_op               :    CPU:  233.950 us   +/- 5.803 (min:  228.622 / max:  261.253) us     GPU-0: 1842.682 us   +/-46.423 (min: 1708.256 / max: 1912.768) us
```