### PR TITLE
Simplify `cupy.linalg.inv`

### DIFF
--- a/cupy/linalg/_solve.py
+++ b/cupy/linalg/_solve.py
@@ -50,14 +50,10 @@ def solve(a, b):
             'a must have (..., M, M) shape and b must have (..., M) '
             'or (..., M, K)')
 
-    # Cast to float32 or float64
-    if a.dtype.char == 'f' or a.dtype.char == 'd':
-        dtype = a.dtype
-    else:
-        dtype = numpy.promote_types(a.dtype.char, 'f')
-
-    a = a.astype(dtype)
-    b = b.astype(dtype)
+    dtype = numpy.promote_types(a.dtype, b.dtype)
+    dtype = numpy.promote_types(dtype, 'f')
+    a = a.astype(dtype, copy=True)  # prevent 'a' to be overwritten
+    b = b.astype(dtype, copy=True)  # prevent 'b' to be overwritten
     if a.ndim == 2:
         return cupyx.lapack.gesv(a, b)
 
@@ -283,14 +279,8 @@ def inv(a):
     _util._assert_rank2(a)
     _util._assert_nd_squareness(a)
 
-    # support float32, float64, complex64, and complex128
-    if a.dtype.char in 'fdFD':
-        dtype = a.dtype.char
-    else:
-        msg = ('dtype must be float32, float64, complex64 or complex128'
-               ' (actual: {})'.format(a.dtype))
-        raise ValueError(msg)
-
+    dtype = numpy.promote_types(a.dtype, 'f')
+    a = a.astype(dtype, copy=True)  # prevent 'a' to be overwritten
     b = cupy.eye(a.shape[0], dtype=dtype)
     return cupyx.lapack.gesv(a, b)
 

--- a/cupy/linalg/_solve.py
+++ b/cupy/linalg/_solve.py
@@ -287,10 +287,14 @@ def inv(a):
     _util._assert_nd_squareness(a)
 
     dtype = numpy.promote_types(a.dtype, 'f')
+    order = 'F' if a._f_contiguous else 'C'
     # prevent 'a' to be overwritten
-    a = a.astype(dtype, copy=True, order='F')
-    b = cupy.eye(a.shape[0], dtype=dtype, order='F')
-    cupyx.lapack.gesv(a, b)
+    a = a.astype(dtype, copy=True, order=order)
+    b = cupy.eye(a.shape[0], dtype=dtype, order=order)
+    if order == 'F':
+        cupyx.lapack.gesv(a, b)
+    else:
+        cupyx.lapack.gesv(a.T, b.T)
     return b
 
 

--- a/cupyx/lapack.py
+++ b/cupyx/lapack.py
@@ -18,6 +18,8 @@ def gesv(a, b):
     Returns:
         cupy.ndarray:
             The matrix with dimension ``(M)`` or ``(M, K)``.
+
+    Note: ``a`` and ``b`` will be overwritten.
     """
     if a.ndim != 2:
         raise ValueError('a.ndim must be 2 (actual: {})'.format(a.ndim))
@@ -28,8 +30,10 @@ def gesv(a, b):
     if a.shape[0] != b.shape[0]:
         raise ValueError('shape mismatch (a: {}, b: {}).'.
                          format(a.shape, b.shape))
-
-    dtype = _numpy.promote_types(a.dtype.char, 'f')
+    if a.dtype != b.dtype:
+        raise TypeError('dtype mismatch (a: {}, b: {})'.
+                        format(a.dtype, b.dtype))
+    dtype = a.dtype
     if dtype == 'f':
         t = 's'
     elif dtype == 'd':
@@ -39,21 +43,22 @@ def gesv(a, b):
     elif dtype == 'D':
         t = 'z'
     else:
-        raise ValueError('unsupported dtype (actual:{})'.format(a.dtype))
+        raise TypeError('unsupported dtype (actual:{})'.format(a.dtype))
     helper = getattr(_cusolver, t + 'getrf_bufferSize')
     getrf = getattr(_cusolver, t + 'getrf')
     getrs = getattr(_cusolver, t + 'getrs')
 
     n = b.shape[0]
     nrhs = b.shape[1] if b.ndim == 2 else 1
-    a_data_ptr = a.data.ptr
-    b_data_ptr = b.data.ptr
-    a = _cupy.asfortranarray(a, dtype=dtype)
-    b = _cupy.asfortranarray(b, dtype=dtype)
-    if a.data.ptr == a_data_ptr:
-        a = a.copy()
-    if b.data.ptr == b_data_ptr:
-        b = b.copy()
+    if a._c_contiguous:
+        trans = _cublas.CUBLAS_OP_T
+    else:
+        trans = _cublas.CUBLAS_OP_N
+        if not a._f_contiguous:
+            a = a.copy(order='F')
+    ret_b = b
+    if nrhs > 1 and not ret_b._f_contiguous:
+        b = ret_b.copy(order='F')
 
     handle = _device.get_cusolver_handle()
     dipiv = _cupy.empty(n, dtype=_numpy.int32)
@@ -66,11 +71,13 @@ def gesv(a, b):
     _cupy.linalg._util._check_cusolver_dev_info_if_synchronization_allowed(
         getrf, dinfo)
     # Solves Ax = b
-    getrs(handle, _cublas.CUBLAS_OP_N, n, nrhs, a.data.ptr, n,
+    getrs(handle, trans, n, nrhs, a.data.ptr, n,
           dipiv.data.ptr, b.data.ptr, n, dinfo.data.ptr)
     _cupy.linalg._util._check_cusolver_dev_info_if_synchronization_allowed(
         getrs, dinfo)
-    return b
+    if nrhs > 1 and not ret_b._f_contiguous:
+        ret_b[...] = b
+    return ret_b
 
 
 def gels(a, b):

--- a/cupyx/lapack.py
+++ b/cupyx/lapack.py
@@ -56,9 +56,8 @@ def gesv(a, b):
         trans = _cublas.CUBLAS_OP_T
     else:
         raise ValueError('a must be F-contiguous or C-contiguous.')
-    if not (b._f_contiguous or (b._c_contiguous and nrhs == 1)):
-        raise ValueError('b must be F-contiguous '
-                         '(or C-contiguous if nrhs == 1).')
+    if not b._f_contiguous:
+        raise ValueError('b must be F-contiguous.')
 
     handle = _device.get_cusolver_handle()
     dipiv = _cupy.empty(n, dtype=_numpy.int32)

--- a/tests/cupy_tests/linalg_tests/test_solve.py
+++ b/tests/cupy_tests/linalg_tests/test_solve.py
@@ -87,14 +87,18 @@ class TestTensorSolve(unittest.TestCase):
         return xp.linalg.tensorsolve(a, b, axes=self.axes)
 
 
+@testing.parameterize(*testing.product({
+    'order': ['C', 'F'],
+}))
 @testing.gpu
 class TestInv(unittest.TestCase):
 
     @testing.for_dtypes('fdFD')
     @condition.retry(10)
     def check_x(self, a_shape, dtype):
-        a_cpu = numpy.random.randint(0, 10, size=a_shape).astype(dtype)
-        a_gpu = cupy.asarray(a_cpu)
+        a_cpu = numpy.random.randint(0, 10, size=a_shape)
+        a_cpu = a_cpu.astype(dtype, order=self.order)
+        a_gpu = cupy.asarray(a_cpu, order=self.order)
         a_gpu_copy = a_gpu.copy()
         result_cpu = numpy.linalg.inv(a_cpu)
         result_gpu = cupy.linalg.inv(a_gpu)

--- a/tests/cupy_tests/linalg_tests/test_solve.py
+++ b/tests/cupy_tests/linalg_tests/test_solve.py
@@ -12,6 +12,7 @@ from cupy.cublas import get_batched_gesv_limit, set_batched_gesv_limit
 
 @testing.parameterize(*testing.product({
     'batched_gesv_limit': [None, 0],
+    'order': ['C', 'F'],
 }))
 @testing.gpu
 @testing.fix_random()
@@ -32,6 +33,8 @@ class TestSolve(unittest.TestCase):
     def check_x(self, a_shape, b_shape, xp, dtype):
         a = testing.shaped_random(a_shape, xp, dtype=dtype, seed=0)
         b = testing.shaped_random(b_shape, xp, dtype=dtype, seed=1)
+        a = a.copy(order=self.order)
+        b = b.copy(order=self.order)
         a_copy = a.copy()
         b_copy = b.copy()
         result = xp.linalg.solve(a, b)

--- a/tests/cupyx_tests/test_lapack.py
+++ b/tests/cupyx_tests/test_lapack.py
@@ -12,14 +12,15 @@ from cupyx import lapack
     'dtype': [numpy.float32, numpy.float64, numpy.complex64, numpy.complex128],
     'n': [3],
     'nrhs': [None, 1, 4],
+    'order': ['C', 'F'],
 }))
 @attr.gpu
 class TestGesv(unittest.TestCase):
     _tol = {'f': 1e-5, 'd': 1e-12}
 
     def _make_array(self, shape, alpha, beta):
-        a = testing.shaped_random(shape, cupy, dtype=self.r_dtype,
-                                  scale=alpha) + beta
+        a = testing.shaped_random(shape, cupy, dtype=self.dtype.char.lower(),
+                                  order=self.order, scale=alpha) + beta
         return a
 
     def _make_matrix(self, shape, alpha, beta):
@@ -30,16 +31,12 @@ class TestGesv(unittest.TestCase):
 
     def setUp(self):
         self.dtype = numpy.dtype(self.dtype)
-        if self.dtype.char in 'fF':
-            self.r_dtype = numpy.float32
-        else:
-            self.r_dtype = numpy.float64
         n = self.n
         nrhs = 1 if self.nrhs is None else self.nrhs
         # Diagonally dominant matrix is used as it is stable
         alpha = 2.0 / n
         a = self._make_matrix((n, n), alpha, -alpha / 2)
-        diag = cupy.diag(cupy.ones((n,), dtype=self.r_dtype))
+        diag = cupy.diag(cupy.ones((n,), dtype=self.dtype.char.lower()))
         a[diag > 0] = 0
         a += diag
         x = self._make_matrix((n, nrhs), 0.2, 0.9)
@@ -50,10 +47,7 @@ class TestGesv(unittest.TestCase):
         self.a = a
         self.b = b.reshape(b_shape)
         self.x_ref = x.reshape(b_shape)
-        if self.r_dtype == numpy.float32:
-            self.tol = self._tol['f']
-        elif self.r_dtype == numpy.float64:
-            self.tol = self._tol['d']
+        self.tol = self._tol[self.dtype.char.lower()]
 
     def test_gesv(self):
         x = lapack.gesv(self.a, self.b)

--- a/tests/cupyx_tests/test_lapack.py
+++ b/tests/cupyx_tests/test_lapack.py
@@ -62,27 +62,26 @@ class TestGesv(unittest.TestCase):
     def test_invalid_cases(self):
         if self.nrhs is None or self.nrhs == 1:
             raise unittest.SkipTest()
+        ng_a = self.a.reshape(1, self.n, self.n)
         with pytest.raises(ValueError):
-            ng_a = self.a.reshape(1, self.n, self.n)
             lapack.gesv(ng_a, self.b)
+        ng_b = self.b.reshape(1, self.n, self.nrhs)
         with pytest.raises(ValueError):
-            ng_b = self.b.reshape(1, self.n, self.nrhs)
             lapack.gesv(self.a, ng_b)
+        ng_a = cupy.ones((self.n, self.n+1), dtype=self.dtype)
         with pytest.raises(ValueError):
-            ng_a = cupy.ones((self.n, self.n+1), dtype=self.dtype)
             lapack.gesv(ng_a, self.b)
+        ng_a = cupy.ones((self.n+1, self.n+1), dtype=self.dtype)
         with pytest.raises(ValueError):
-            ng_a = cupy.ones((self.n+1, self.n+1), dtype=self.dtype)
             lapack.gesv(ng_a, self.b)
+        ng_a = cupy.ones(self.a.shape, dtype='i')
         with pytest.raises(TypeError):
-            ng_a = cupy.ones(self.a.shape, dtype='i')
             lapack.gesv(ng_a, self.b)
+        ng_a = cupy.ones((2, self.n, self.n), dtype=self.dtype, order='F')[0]
         with pytest.raises(ValueError):
-            ng_a = cupy.ones((2, self.n, self.n), dtype=self.dtype,
-                             order='F')[0]
             lapack.gesv(ng_a, self.b)
+        ng_b = self.b.copy(order='C')
         with pytest.raises(ValueError):
-            ng_b = self.b.copy(order='C')
             lapack.gesv(self.a, ng_b)
 
 


### PR DESCRIPTION
This PR uses `cupyx.lapack.gesv` in `cupy.linalg.inv` and reduce code duplication.