### PR TITLE
Fix issues when coo sparse matrix is created from dense matrix

### DIFF
--- a/cupyx/scipy/sparse/coo.py
+++ b/cupyx/scipy/sparse/coo.py
@@ -125,6 +125,9 @@ class coo_matrix(sparse_data._data_matrix):
             dense = cupy.atleast_2d(arg1)
             row, col = dense.nonzero()
             data = dense[row, col]
+            shape = dense.shape
+
+            self.has_canonical_format = True
 
         else:
             raise TypeError('invalid input format')

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_coo.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_coo.py
@@ -278,6 +278,35 @@ class TestCooMatrixInit(unittest.TestCase):
         cupy.testing.assert_array_equal(n.row, [0, 0, 2])
         cupy.testing.assert_array_equal(n.col, [1, 3, 2])
 
+    def test_init_dense_allzero(self):
+        m = cupy.array([[0, 0, 0, 0],
+                        [0, 0, 0, 0],
+                        [0, 0, 0, 0]], dtype=self.dtype)
+        n = sparse.coo_matrix(m)
+        assert n.nnz == 0
+        assert n.shape == (3, 4)
+        cupy.testing.assert_array_equal(n.data, [])
+        cupy.testing.assert_array_equal(n.row, [])
+        cupy.testing.assert_array_equal(n.col, [])
+
+    def test_init_dense_check_if_row_major(self):
+        rows, cols = 10, 9
+        for order in ('C', 'F'):
+            d = testing.shaped_random((rows, cols), dtype=self.dtype,
+                                      order=order)
+            mask = testing.shaped_random((rows, cols), scale=1.0)
+            d[mask > 0.5] = 0
+            s = sparse.coo_matrix(d)
+            for i in range(s.nnz):
+                assert 0 <= s.row[i] < rows
+                assert 0 <= s.col[i] < cols
+                assert s.data[i] == d[s.row[i], s.col[i]]
+                if i == 0:
+                    continue
+                assert ((s.row[i-1] < s.row[i]) or
+                        (s.row[i-1] == s.row[i] and s.col[i-1] < s.col[i]))
+            assert s.has_canonical_format
+
     def test_invalid_format(self):
         for xp, sp in ((numpy, scipy.sparse), (cupy, sparse)):
             with pytest.raises(TypeError):


### PR DESCRIPTION
This PR fixes issues when coo sparse matrix is created from dense matrix.

There are two issues in current implementation.
* The created coo matrix does not have an attribute `has_canonical_format`.
* The created coo matrix may have the wrong shape.

Sorry, both are my bugs.