### PR TITLE
ROCm: fix ndimage interpolation

### DIFF
--- a/cupyx/scipy/ndimage/_interp_kernels.py
+++ b/cupyx/scipy/ndimage/_interp_kernels.py
@@ -5,7 +5,10 @@ import cupy.core.internal
 
 from cupyx.scipy.ndimage import _util
 
-math_constants_preamble = "#include <cupy/math_constants.h>\n"
+math_constants_preamble = r'''
+// workaround for HIP: line begins with #include
+#include <cupy/math_constants.h>
+'''
 
 
 def _get_coord_map(ndim):


### PR DESCRIPTION
Follow-up of #4271. With this small change all tests in `tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py` pass with ROCm 3.5.0 + Radeon VII.