### PR TITLE
Fix `testing.helper` to work without `unittest`

### DIFF
--- a/cupy/testing/helper.py
+++ b/cupy/testing/helper.py
@@ -17,14 +17,17 @@ from cupy.testing import parameterized
 import cupyx
 import cupyx.scipy.sparse
 
-_skip_classes = unittest.SkipTest,
-_is_pytest_available = False
 try:
+    import pytest
     import _pytest.outcomes
-    _skip_classes += _pytest.outcomes.Skipped,
-    _is_pytest_available = True
 except ImportError:
-    pass
+    _is_pytest_available = False
+    _skip_classes = unittest.SkipTest,
+    _skipif = unittest.skipIf
+else:
+    _is_pytest_available = True
+    _skip_classes = unittest.SkipTest, _pytest.outcomes.Skipped
+    _skipif = pytest.mark.skipif
 
 
 def _call_func(self, impl, args, kw):
@@ -1186,7 +1189,7 @@ def with_requires(*requirements):
         skip = True
 
     msg = 'requires: {}'.format(','.join(requirements))
-    return unittest.skipIf(skip, msg)
+    return _skipif(skip, reason=msg)
 
 
 def numpy_satisfies(version_range):

--- a/cupy/testing/helper.py
+++ b/cupy/testing/helper.py
@@ -224,6 +224,12 @@ def _wraps_partial(wrapped, *names):
     return decorator
 
 
+def _wraps_partial_xp(wrapped, name, sp_name, scipy_name):
+    names = [name, sp_name, scipy_name]
+    names = [n for n in names if n is not None]
+    return _wraps_partial(wrapped, *names)
+
+
 def _make_decorator(check_func, name, type_check, contiguous_check,
                     accept_error, sp_name=None, scipy_name=None,
                     check_sparse_format=True):
@@ -232,7 +238,7 @@ def _make_decorator(check_func, name, type_check, contiguous_check,
     assert scipy_name is None or isinstance(scipy_name, str)
 
     def decorator(impl):
-        @_wraps_partial(impl, name)
+        @_wraps_partial_xp(impl, name, sp_name, scipy_name)
         def test_func(self, *args, **kw):
             # Run cupy and numpy
             (
@@ -662,7 +668,7 @@ def numpy_cupy_equal(name='xp', sp_name=None, scipy_name=None):
     even if ``xp`` is ``numpy`` or ``cupy``.
     """
     def decorator(impl):
-        @_wraps_partial(impl, name)
+        @_wraps_partial_xp(impl, name, sp_name, scipy_name)
         def test_func(self, *args, **kw):
             # Run cupy and numpy
             (
@@ -714,7 +720,7 @@ def numpy_cupy_raises(name='xp', sp_name=None, scipy_name=None,
         DeprecationWarning)
 
     def decorator(impl):
-        @_wraps_partial(impl, name)
+        @_wraps_partial_xp(impl, name, sp_name, scipy_name)
         def test_func(self, *args, **kw):
             # Run cupy and numpy
             (


### PR DESCRIPTION
The PR improves PyTest support.
- Fix `numpy_cupy_*` with `sp_name`, `scipy_name`.
- Raise `AssertionError`.
- Use `pytest.mark.skipif` instead of `unittest.skipIf`.