### PR TITLE
Improve `cupy.argwhere`

### DIFF
--- a/cupy/core/_routines_math.pxd
+++ b/cupy/core/_routines_math.pxd
@@ -19,7 +19,8 @@ cpdef enum scan_op:
     SCAN_SUM = 0
     SCAN_PROD = 1
 
-cdef ndarray scan(ndarray a, op, dtype=*, ndarray out=*)
+cdef ndarray scan(ndarray a, op, dtype=*, ndarray out=*, blk_size=*,
+                  imcomplete=*)
 cdef object _sum_auto_dtype
 cdef object _add
 cdef object _conj

--- a/cupy/core/_routines_math.pxd
+++ b/cupy/core/_routines_math.pxd
@@ -20,7 +20,7 @@ cpdef enum scan_op:
     SCAN_PROD = 1
 
 cdef ndarray scan(ndarray a, op, dtype=*, ndarray out=*, blk_size=*,
-                  imcomplete=*)
+                  incomplete=*)
 cdef object _sum_auto_dtype
 cdef object _add
 cdef object _conj

--- a/cupy/core/_routines_math.pyx
+++ b/cupy/core/_routines_math.pyx
@@ -399,7 +399,7 @@ def _add_scan_blocked_sum_kernel(dtype, op, c_cont):
 
 
 cdef ndarray scan(ndarray a, op, dtype=None, ndarray out=None, blk_size=256,
-                  imcomplete=False):
+                  incomplete=False):
     """Return the prefix sum(scan) of the elements.
 
     Args:
@@ -434,7 +434,7 @@ cdef ndarray scan(ndarray a, op, dtype=None, ndarray out=None, blk_size=256,
     if (a.size - 1) // (block_size * 2) > 0:
         blocked_sum = out[block_size * 2 - 1:None:block_size * 2]
         scan(blocked_sum, op, dtype, blocked_sum)
-        if imcomplete:
+        if incomplete:
             return out
         kern_add = _add_scan_blocked_sum_kernel(
             dtype, op, out_cont)


### PR DESCRIPTION
This PR improves the performance of `cupy.argwhere` (and `cupy.nonzero`) when array size is large.

`argwhere` first performs an inclusive scan and generates an index array based on the results. If the input array is large, the inclusive scan accounts for more than 60% of the total execution time of `argwhere`. To improve the performance of `argwhere`, the execution time of an inclusive scan has to be reduced.

The current implementation of inclusive scan used in CuPy is structured to run `kern_scan` and `kern_add` recursively, but `argwhere` can be accomplished without running the final `kern_add`. Instead, the `nonzero_kernel` in `argwhere` needs to be modified slightly, but overall it reduces the amount of memory access.

The followings are the measured results of `argwhere` of NumPy, current CuPy and this PR. It shows that the larger the size of the array, the better the performance improvement is.

shape | density | NumPy | CuPy (current) | CuPy (this PR)
------|---------|-------|-----|-----
(1000000,) | 0.1 | 1.637 ms | 0.102 ms | 0.103 ms
(1000000,) | 0.5 | 3.872 ms | 0.105 ms | 0.106 ms
(1000, 1000) | 0.1 | 3.885 ms | 0.132 ms | 0.112 ms
(1000, 1000) | 0.5 | 8.551 ms | 0.107 ms | 0.111 ms
(4000000,) | 0.1 | 5.990 ms | 0.224 ms | 0.174 ms
(4000000,) | 0.5 | 15.215 ms | 0.223 ms | 0.173 ms
(2000, 2000) | 0.1 | 13.584 ms | 0.227 ms | 0.179 ms
(2000, 2000) | 0.5 | 32.172 ms | 0.228 ms | 0.177 ms
(16000000,) | 0.1 | 24.672 ms | 0.666 ms | 0.448 ms
(16000000,) | 0.5 | 66.100 ms | 0.666 ms | 0.447 ms
(4000, 4000) | 0.1 | 61.311 ms | 0.675 ms | 0.455 ms
(4000, 4000) | 0.5 | 140.481 ms | 0.671 ms | 0.453 ms
(64000000,) | 0.1 | 102.685 ms | 2.508 ms | 1.628 ms
(64000000,) | 0.5 | 266.041 ms | 2.503 ms | 1.630 ms
(8000, 8000) | 0.1 | 229.633 ms | 2.513 ms | 1.634 ms
(8000, 8000) | 0.5 | 543.749 ms | 2.513 ms | 1.635 ms

<details>
<summary> Click to see the script </summary>

```python
import math
import numpy
import cupy
from cupy import testing
from cupyx.time import repeat

routine_list = ('argwhere', )
# routine_list = ('argwhere', 'nonzero')

size_list = (1000000, 4000000, 16000000, 64000000)
ndim_list = (1, 2)
density_list = (0.1, 0.5)

n_warmup = 1
n_repeat = 10


def get_mean_time(perf):
    cpu_time = perf.cpu_times.mean()
    gpu_time = perf.cpu_times.mean()
    return max(cpu_time, gpu_time) * 1000  # ms


def time_nonzero(a):
    cp_a = cupy.array(a)
    ref = numpy.nonzero(a)
    ret = cupy.nonzero(cp_a)
    for _ref, _ret in zip(ref, ret):
        testing.assert_allclose(_ret, _ref)

    times = []
    perf = repeat(numpy.nonzero, (a,),
                  n_repeat=n_repeat, n_warmup=n_warmup)
    times.append(get_mean_time(perf))

    perf = repeat(cupy.nonzero, (cp_a,),
                  n_repeat=n_repeat, n_warmup=n_warmup)
    times.append(get_mean_time(perf))
    return times


def time_argwhere(a):
    cp_a = cupy.array(a)
    ref = numpy.argwhere(a > 0)
    ret = cupy.argwhere(cp_a > 0)
    testing.assert_allclose(ret, ref)
    
    times = []
    perf = repeat(numpy.nonzero, (a > 0,),
                  n_repeat=n_repeat, n_warmup=n_warmup)
    times.append(get_mean_time(perf))

    perf = repeat(cupy.nonzero, (cp_a > 0,),
                  n_repeat=n_repeat, n_warmup=n_warmup)
    times.append(get_mean_time(perf))
    return times


def decide_shape(size, ndim):
    shape = []
    for i in range(ndim, 0, -1):
        s = int(math.pow(size, 1 / i) + .5)
        size /= s
        shape.append(s)
    return tuple(shape)


for routine in routine_list:
    print('routine: {}'.format(routine))
    print('shape | density | NumPy | CuPy')
    print('------|---------|-------|-----')
    for size in size_list:
        for ndim in ndim_list:
            for density in density_list:
                shape = decide_shape(size, ndim)
                a = numpy.random.random(shape)
                a[a < 1 - density] = 0
                if routine == 'nonzero':
                    ret = time_nonzero(a)
                elif routine == 'argwhere':
                    ret = time_argwhere(a)
                print('{} | {} | {:.3f} ms | {:.3f} ms'.
                      format(shape, density, ret[0], ret[1]))
    print()
```
</details>

