### PR TITLE
Detect Jitify version

### DIFF
--- a/cupy/cuda/__init__.py
+++ b/cupy/cuda/__init__.py
@@ -32,6 +32,7 @@ class _UnavailableModule():
 
 
 from cupy.cuda import cub  # NOQA
+from cupy.cuda import jitify  # NOQA
 
 try:
     from cupy.cuda import nvtx  # NOQA

--- a/cupy/cuda/__init__.py
+++ b/cupy/cuda/__init__.py
@@ -32,7 +32,11 @@ class _UnavailableModule():
 
 
 from cupy.cuda import cub  # NOQA
-from cupy.cuda import jitify  # NOQA
+
+if not runtime.is_hip and driver.get_build_version() > 0:
+    from cupy.cuda import jitify  # NOQA
+else:
+    jitify = None
 
 try:
     from cupy.cuda import nvtx  # NOQA

--- a/cupy/cuda/cupy_jitify.h
+++ b/cupy/cuda/cupy_jitify.h
@@ -1,15 +1,24 @@
 #ifndef INCLUDE_GUARD_CUPY_JITIFY_H
 #define INCLUDE_GUARD_CUPY_JITIFY_H
 
+#define _str_(s) #s
+#define _xstr_(s) _str_(s)
+
 #if !defined(CUPY_NO_CUDA) && !defined(CUPY_USE_HIP)
 
 #include <cupy/jitify/jitify.hpp>
+namespace jitify {
+namespace detail {
+const char* jitify_ver = _xstr_(CUPY_JITIFY_VERSION_CODE);
+}  // namespace detail
+}  // namespace jitify
 
 #else
 
 namespace jitify {
 namespace detail {
 
+const char* jitify_ver = _xstr_(CUPY_JITIFY_VERSION_CODE);
 std::map<std::string, std::string>& get_jitsafe_headers_map();
 const int preinclude_jitsafe_headers_count = 0;
 const char* preinclude_jitsafe_header_names[] = {};
@@ -25,5 +34,8 @@ void load_program(std::string&,
 }  // namespace jitify
 
 #endif
+
+#undef _xstr_
+#undef _str_
 
 #endif  // INCLUDE_GUARD_CUPY_JITIFY_H

--- a/cupy/cuda/jitify.pyx
+++ b/cupy/cuda/jitify.pyx
@@ -23,13 +23,7 @@ cdef extern from 'cupy_jitify.h' namespace "jitify::detail" nogil:
                       vector[cpp_str]*,
                       cpp_str*) except +
 
-cdef extern from *:
-    '''
-    #define _str_(s) #s
-    #define _xstr_(s) _str_(s)
-    #define jitify_ver _xstr_(CUPY_JITIFY_VERSION_CODE)
-    '''
-    const char* jitify_ver
+    const char* jitify_ver  # set at build time
 
 
 ###############################################################################

--- a/cupy/cuda/jitify.pyx
+++ b/cupy/cuda/jitify.pyx
@@ -23,10 +23,24 @@ cdef extern from 'cupy_jitify.h' namespace "jitify::detail" nogil:
                       vector[cpp_str]*,
                       cpp_str*) except +
 
+cdef extern from *:
+    '''
+    #define _str_(s) #s
+    #define _xstr_(s) _str_(s)
+    #define jitify_ver _xstr_(CUPY_JITIFY_VERSION_CODE)
+    '''
+    const char* jitify_ver
+
 
 ###############################################################################
 # API
 ###############################################################################
+
+def get_build_version():
+    if jitify_ver == b'-1':
+        return '<unknown>'
+    return jitify_ver.decode()
+
 
 # cache all headers; this is intialized with built-in JIT-safe headers
 cdef cpp_map[cpp_str, cpp_str] cupy_headers = get_jitsafe_headers_map()

--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -590,9 +590,11 @@ def make_extensions(options, compiler, use_cython):
             elif compiler.compiler_type == 'msvc':
                 compile_args.append('/openmp')
 
-        # this fixes RTD (no_cuda) builds...
         if module['name'] == 'jitify':
+            # this fixes RTD (no_cuda) builds...
             compile_args.append('--std=c++11')
+            # if any change is made to the Jitify header, we force recompiling
+            s['depends'] = ['./cupy/core/include/cupy/jitify/jitify.hpp']
 
         original_s = s
         for f in module['file']:

--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -255,6 +255,8 @@ if not use_hip:
             'cudart',
             'nvrtc',
         ],
+        'check_method': build.check_jitify_version,
+        'version_method': build.get_jitify_version,
     })
 else:
     MODULES.append({

--- a/cupyx/_runtime.py
+++ b/cupyx/_runtime.py
@@ -29,6 +29,11 @@ except ImportError:
     cub = None
 
 try:
+    import cupy.cuda.jitify as jitify
+except ImportError:
+    jitify = None
+
+try:
     import cupy_backends.cuda.libs.cutensor as cutensor
 except ImportError:
     cutensor = None
@@ -117,6 +122,7 @@ class _RuntimeInfo(object):
     nccl_build_version = None
     nccl_runtime_version = None
     cub_build_version = None
+    jitify_build_version = None
     cutensor_version = None
     cython_build_version = None
     cython_version = None
@@ -180,6 +186,9 @@ class _RuntimeInfo(object):
         if cub is not None:
             self.cub_build_version = cub.get_build_version()
 
+        if jitify is not None:
+            self.jitify_build_version = jitify.get_build_version()
+
         if cutensor is not None:
             self.cutensor_version = cutensor.get_version()
 
@@ -216,6 +225,7 @@ class _RuntimeInfo(object):
             ('NVRTC Version', self.nvrtc_version),
             ('Thrust Version', self.thrust_version),
             ('CUB Build Version', self.cub_build_version),
+            ('Jitify Build Version', self.jitify_build_version),
         ]
 
         records += [

--- a/install/build.py
+++ b/install/build.py
@@ -284,6 +284,7 @@ _nccl_version = None
 _cutensor_version = None
 _cub_path = None
 _cub_version = None
+_jitify_version = None
 _compute_capabilities = None
 
 
@@ -584,6 +585,45 @@ def get_cub_version(formatted=False):
             return '<unknown>'
         return str(_cub_version)
     return _cub_version
+
+
+def check_jitify_version(compiler, settings):
+    global _jitify_version
+
+    try:
+        # CuPy's bundle: by the time we arrive here, _cub_path is known
+        cupy_jitify_include = os.path.join(_cub_path, '../jitify')
+        # Unfortunately Jitify does not have any identifiable name (branch,
+        # tag, etc), so we must use the commit here
+        a = subprocess.run(' '.join(['git', 'rev-parse', '--short', 'HEAD']),
+                           stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                           shell=True, cwd=cupy_jitify_include)
+        if a.returncode == 0:
+            out = a.stdout.decode()[:-1]  # unlike elsewhere, out is a str here
+        else:
+            raise RuntimeError('Cannot determine Jitify version from git')
+    except Exception as e:
+        utils.print_warning('Cannot determine Jitify version\n{}'.format(e))
+        # 0: Jitify is not built (makes no sense), -1: built with unknown ver
+        out = -1
+
+    _jitify_version = out
+    settings['define_macros'].append(('CUPY_JITIFY_VERSION_CODE',
+                                      _jitify_version))
+    return True  # we always build Jitify
+
+
+def get_jitify_version(formatted=False):
+    """Return Jitify version cached in check_jitify_version()."""
+    global _jitify_version
+    if _jitify_version is None:
+        msg = 'check_jitify_version() must be called first.'
+        raise RuntimeError(msg)
+    if formatted:
+        if _jitify_version == -1:
+            return '<unknown>'
+        return _jitify_version
+    raise RuntimeError('Jitify version is a commit string')
 
 
 def check_cutensor_version(compiler, settings):


### PR DESCRIPTION
Unfortunately Jitify does not have any identifiable name (branch, tag, etc), so we must use the commit here. Hopefully the submodule pinning is long lasting.
```
$ python -c "import cupy; cupy.show_config()"
OS                           : Linux-5.4.0-42-generic-x86_64-with-debian-buster-sid
CuPy Version                 : 9.0.0a1
NumPy Version                : 1.19.1
SciPy Version                : 1.5.2
Cython Build Version         : 0.29.21
Cython Runtime Version       : 0.29.21
CUDA Root                    : /usr/local/cuda-10.2
CUDA Build Version           : 10020
CUDA Driver Version          : 11000
CUDA Runtime Version         : 10020
cuBLAS Version               : 10202
cuFFT Version                : 10102
cuRAND Version               : 10102
cuSOLVER Version             : (10, 3, 0)
cuSPARSE Version             : 10301
NVRTC Version                : (10, 2)
Thrust Version               : 100907
CUB Build Version            : 100800
Jitify Build Version         : 60e9e72
cuDNN Build Version          : None
cuDNN Version                : None
NCCL Build Version           : 2507
NCCL Runtime Version         : 2507
cuTENSOR Version             : 10200
Device 0 Name                : GeForce RTX 2080 Ti
Device 0 Compute Capability  : 75
```