### PR TITLE
`DeprecationWaring` on truth value on empty array

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -964,6 +964,10 @@ cdef class ndarray:
 
     def __nonzero__(self):
         if self.size == 0:
+            msg = ('The truth value of an empty array is ambiguous. Returning '
+                   'False, but in future this will result in an error. Use '
+                   '`array.size > 0` to check that an array is not empty.')
+            warnings.warn(msg, DeprecationWarning)
             return False
         elif self.size == 1:
             return bool(self.get())

--- a/tests/cupy_tests/core_tests/test_ndarray_unary_op.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_unary_op.py
@@ -13,7 +13,8 @@ class TestArrayBoolOp(unittest.TestCase):
 
     @testing.for_all_dtypes()
     def test_bool_empty(self, dtype):
-        assert not bool(cupy.array((), dtype=dtype))
+        with testing.assert_warns(DeprecationWarning):
+            assert not bool(cupy.array((), dtype=dtype))
 
     def test_bool_scalar_bool(self):
         assert bool(cupy.array(True, dtype=numpy.bool))


### PR DESCRIPTION
Close #4249.

This PR makes an empty array warn `DeprecationWarning` for its truth value as NumPy does.