### PR TITLE
cupyx.ndimage.measurements: add center_of_mass, histogram, labeled_comprehension

### DIFF
--- a/cupyx/scipy/ndimage/__init__.py
+++ b/cupyx/scipy/ndimage/__init__.py
@@ -46,6 +46,7 @@ from cupyx.scipy.ndimage.measurements import minimum_position  # NOQA
 from cupyx.scipy.ndimage.measurements import maximum_position  # NOQA
 from cupyx.scipy.ndimage.measurements import median  # NOQA
 from cupyx.scipy.ndimage.measurements import extrema  # NOQA
+from cupyx.scipy.ndimage.measurements import center_of_mass  # NOQA
 
 from cupyx.scipy.ndimage.morphology import generate_binary_structure  # NOQA
 from cupyx.scipy.ndimage.morphology import iterate_structure  # NOQA

--- a/cupyx/scipy/ndimage/__init__.py
+++ b/cupyx/scipy/ndimage/__init__.py
@@ -47,6 +47,8 @@ from cupyx.scipy.ndimage.measurements import maximum_position  # NOQA
 from cupyx.scipy.ndimage.measurements import median  # NOQA
 from cupyx.scipy.ndimage.measurements import extrema  # NOQA
 from cupyx.scipy.ndimage.measurements import center_of_mass  # NOQA
+from cupyx.scipy.ndimage.measurements import histogram  # NOQA
+from cupyx.scipy.ndimage.measurements import labeled_comprehension  # NOQA
 
 from cupyx.scipy.ndimage.morphology import generate_binary_structure  # NOQA
 from cupyx.scipy.ndimage.morphology import iterate_structure  # NOQA

--- a/docs/source/reference/ndimage.rst
+++ b/docs/source/reference/ndimage.rst
@@ -77,6 +77,7 @@ Measurements
    :toctree: generated/
    :nosignatures:
 
+   cupyx.scipy.ndimage.center_of_mass
    cupyx.scipy.ndimage.extrema
    cupyx.scipy.ndimage.label
    cupyx.scipy.ndimage.maximum

--- a/docs/source/reference/ndimage.rst
+++ b/docs/source/reference/ndimage.rst
@@ -79,7 +79,9 @@ Measurements
 
    cupyx.scipy.ndimage.center_of_mass
    cupyx.scipy.ndimage.extrema
+   cupyx.scipy.ndimage.histogram
    cupyx.scipy.ndimage.label
+   cupyx.scipy.ndimage.labeled_comprehension
    cupyx.scipy.ndimage.maximum
    cupyx.scipy.ndimage.maximum_position
    cupyx.scipy.ndimage.mean

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
@@ -1,4 +1,3 @@
-import unittest
 import warnings
 
 import numpy
@@ -353,11 +352,11 @@ class TestMeasurementsSelect:
 @testing.gpu
 @testing.parameterize(*testing.product({
     'labels': [None, 4, 6],
-    'index' : [None, [0, 2], [3, 1, 0], [1]],
-    'shape' : [(200,), (16, 20)],
+    'index': [None, [0, 2], [3, 1, 0], [1]],
+    'shape': [(200,), (16, 20)],
 }))
 @testing.with_requires('scipy')
-class TestHistogram(unittest.TestCase):
+class TestHistogram():
 
     def _make_image(self, shape, xp, dtype, scale):
         return testing.shaped_random(shape, xp, dtype=dtype, scale=scale)
@@ -365,9 +364,9 @@ class TestHistogram(unittest.TestCase):
     @testing.for_all_dtypes(no_bool=True, no_complex=True)
     @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_histogram(self, xp, scp, dtype):
+        nbins = 5
         minval = 0
         maxval = 10
-        nbins = 5
         image = self._make_image(self.shape, xp, dtype, scale=maxval)
         labels = self.labels
         index = self.index
@@ -392,14 +391,14 @@ class TestHistogram(unittest.TestCase):
 @testing.gpu
 @testing.parameterize(*testing.product({
     'labels': [None, 4],
-    'index' : [None, [0, 2], [3, 1, 0], [1]],
-    'shape' : [(200,), (16, 20)],
-    'dtype' : [numpy.float64, 'same'],
-    'default' : [0, 3],
-    'pass_positions' : [True, False],
+    'index': [None, [0, 2], [3, 1, 0], [1]],
+    'shape': [(200,), (16, 20)],
+    'dtype': [numpy.float64, 'same'],
+    'default': [0, 3],
+    'pass_positions': [True, False],
 }))
 @testing.with_requires('scipy')
-class TestLabeledComprehension(unittest.TestCase):
+class TestLabeledComprehension():
 
     def _make_image(self, shape, xp, dtype, scale):
         if dtype == xp.bool_:
@@ -410,10 +409,7 @@ class TestLabeledComprehension(unittest.TestCase):
     @testing.for_all_dtypes(no_bool=True, no_complex=True, no_float16=True)
     @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-4, atol=1e-4)
     def test_labeled_comprehension(self, xp, scp, dtype):
-        minval = 0
-        maxval = 10
-        nbins = 5
-        image = self._make_image(self.shape, xp, dtype, scale=maxval)
+        image = self._make_image(self.shape, xp, dtype, scale=101)
         labels = self.labels
         index = self.index
         if labels is not None:
@@ -439,4 +435,4 @@ class TestLabeledComprehension(unittest.TestCase):
                    self.pass_positions)
             return xp.asarray([])
         return op(image, labels, index, func, dtype, self.default,
-                    self.pass_positions)
+                  self.pass_positions)


### PR DESCRIPTION
This PR adds three functions to `cupyx.scipy.ndimage.measurements`

- `center_of_mass`
- `labeled_comprehension`  (applies an arbitrary function over each labeled region)
- `histogram` (implemented via `labeled_comprehension`)

One difference in behavior was made to avoid the need for object arrays (in this case, an arrays where each element is an array). This is used for histogram which calls `labeled_comprehension` using `dtype=object` so that each element of the object array is the histogram over a particular label. For the CuPy implementation, a list of arrays is returned instead of an object array.

If the return value is a scalar in the scipy implementation, a 0-dimensional device array is returned instead here to avoid device->host transfers as much as possible.

I also suppressed all instances of `cupy._util.PerformanceWarning` occuring in the tests of this module that existed prior to this PR.