### PR TITLE
revise dtype handling in cupyx.scipy.ndimage.spline_filter

### DIFF
--- a/cupyx/scipy/ndimage/interpolation.py
+++ b/cupyx/scipy/ndimage/interpolation.py
@@ -37,9 +37,8 @@ def _check_parameter(func_name, order, mode):
 def _get_spline_output(input, output):
     """Create workspace array, temp, and the final dtype for the output.
 
-    Differs from SciPy by not always forcing promotion to double precision.
-    The default output dtype will be single precision for single precision
-    inputs.
+    Differs from SciPy by not always forcing the internal floating point dtype
+    to be double precision.
     """
     complex_data = input.dtype.kind == "c"
     if complex_data:
@@ -100,11 +99,6 @@ def spline_filter1d(input, order=3, axis=-1, output=cupy.float64,
         cupy.ndarray: The result of prefiltering the input.
 
     .. seealso:: :func:`scipy.spline_filter1d`
-
-    .. note::
-        This function differs from SciPy by not automatically promoting
-        all inputs to double precision. For single-precision inputs,
-        computations will be performed in single precision.
     """
     if order < 0 or order > 5:
         raise RuntimeError("spline order not supported")
@@ -182,11 +176,6 @@ def spline_filter(input, order=3, output=cupy.float64, mode="mirror"):
         cupy.ndarray: The result of prefiltering the input.
 
     .. seealso:: :func:`scipy.spline_filter1d`
-
-    .. note::
-        This function differs from SciPy by not automatically promoting
-        all inputs to double precision. For single-precision inputs,
-        computations will be performed in single precision.
     """
     if order < 2 or order > 5:
         raise RuntimeError("spline order not supported")

--- a/cupyx/scipy/ndimage/interpolation.py
+++ b/cupyx/scipy/ndimage/interpolation.py
@@ -74,7 +74,7 @@ def _get_spline_output(input, output):
     return temp, float_dtype, output_dtype
 
 
-def spline_filter1d(input, order=3, axis=-1, output=None,
+def spline_filter1d(input, order=3, axis=-1, output=cupy.float64,
                     mode="mirror"):
     """
     Calculate a 1-D spline filter along the given axis.
@@ -163,7 +163,7 @@ def spline_filter1d(input, order=3, axis=-1, output=None,
     return temp.astype(output_dtype, copy=False)
 
 
-def spline_filter(input, order=3, output=None, mode="mirror"):
+def spline_filter(input, order=3, output=cupy.float64, mode="mirror"):
     """Multidimensional spline filter.
 
     Args:

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
@@ -647,7 +647,7 @@ class TestSplineFilter:
 }))
 @testing.gpu
 @testing.with_requires('scipy')
-class TestSplineFilterComplex(unittest.TestCase):
+class TestSplineFilterComplex:
 
     @testing.with_requires('scipy>=1.6')
     @testing.numpy_cupy_allclose(atol=1e-4, rtol=1e-4, scipy_name='scp')

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
@@ -637,3 +637,37 @@ class TestSplineFilter:
         scp.ndimage.spline_filter(x, order=self.order, output=output,
                                   mode=self.mode)
         return output
+
+
+@testing.parameterize(*testing.product({
+    'mode': ['mirror', 'wrap', 'reflect'],
+    'order': [2, 3, 4, 5],
+    'dtype': [numpy.complex64, numpy.complex128],
+    'output': [numpy.complex64, numpy.complex128],
+}))
+@testing.gpu
+@testing.with_requires('scipy')
+class TestSplineFilterComplex(unittest.TestCase):
+
+    @testing.with_requires('scipy>=1.6')
+    @testing.numpy_cupy_allclose(atol=1e-4, rtol=1e-4, scipy_name='scp')
+    def test_spline_filter_complex(self, xp, scp):
+        x = testing.shaped_random((16, 12, 11), dtype=self.dtype, xp=xp)
+        return scp.ndimage.spline_filter(x, order=self.order,
+                                         output=self.output, mode=self.mode)
+
+    # the following test case is for SciPy versions lacking complex support
+    @testing.with_requires('scipy<1.6')
+    def test_spline_filter_complex2(self):
+        cpu_func = scipy.ndimage.spline_filter
+        gpu_func = cupyx.scipy.ndimage.spline_filter
+        x = testing.shaped_random((16, 12, 11), dtype=self.dtype, xp=numpy)
+        x_gpu = cupy.asarray(x)
+
+        kwargs_gpu = dict(order=self.order, output=self.output, mode=self.mode)
+        res_gpu = gpu_func(x_gpu, **kwargs_gpu)
+
+        output_real = numpy.empty((1,), dtype=self.output).real.dtype
+        kwargs = dict(order=self.order, output=output_real, mode=self.mode)
+        res_cpu = cpu_func(x.real, **kwargs) + 1j * cpu_func(x.imag, **kwargs)
+        testing.assert_allclose(res_cpu, res_gpu, atol=1e-4, rtol=1e-4)


### PR DESCRIPTION
This PR is related to #4247, but deals only with the recently implemented `spline_filter` functions from #4145.

The first commit here removes the `allow_float32` keyword-only argument which is not present in scikit-image and has not yet appeared in a released CuPy version. ~It also changes the default `output=np.float64` to `output=None` which will autoselect a floating point precision for the output. This allows computations to run in single precision by default on float16, float32 or complex64 inputs. In other words, the functionality previously provided by `allow_float32=True` becomes the default.~ **update**: restored default output to float64 for SciPy consistency. internal dtype behaves as if allow_float32=True.

If this type of single precision dtype handling seems okay, I would like to extend it to other functions in the ndimage module in a follow-up PR.

The second commit here adds tests for complex-valued inputs. These were previously supported, but were untested. Complex support was only recently merged upstream in SciPy and will be present in the upcoming 1.6.0 release, so for now a separate test class is used to allow this to also be tested on older SciPy versions.
