### PR TITLE
Fix docs of `cupy.random` functions/methods

### DIFF
--- a/cupy/random/_distributions.py
+++ b/cupy/random/_distributions.py
@@ -27,8 +27,7 @@ def beta(a, b, size=None, dtype=float):
         cupy.ndarray: Samples drawn from the beta distribution.
 
     .. seealso::
-        :meth:`numpy.random.beta
-        <numpy.random.mtrand.RandomState.beta>`
+        :func:`numpy.random.beta`
     """
     rs = _generator.get_random_state()
     return rs.beta(a, b, size, dtype)
@@ -55,8 +54,7 @@ def binomial(n, p, size=None, dtype=int):
         cupy.ndarray: Samples drawn from the binomial distribution.
 
     .. seealso::
-        :meth:`numpy.random.binomial
-        <numpy.random.mtrand.RandomState.binomial>`
+        :func:`numpy.random.binomial`
     """
     rs = _generator.get_random_state()
     return rs.binomial(n, p, size, dtype)
@@ -82,8 +80,7 @@ def chisquare(df, size=None, dtype=float):
         cupy.ndarray: Samples drawn from the chi-square distribution.
 
     .. seealso::
-        :meth:`numpy.random.chisquare
-        <numpy.random.mtrand.RandomState.chisquare>`
+        :func:`numpy.random.chisquare`
     """
     rs = _generator.get_random_state()
     return rs.chisquare(df, size, dtype)
@@ -112,8 +109,7 @@ def dirichlet(alpha, size=None, dtype=float):
         cupy.ndarray: Samples drawn from the dirichlet distribution.
 
     .. seealso::
-        :meth:`numpy.random.dirichlet
-        <numpy.random.mtrand.RandomState.dirichlet>`
+        :func:`numpy.random.dirichlet`
     """
     rs = _generator.get_random_state()
     return rs.dirichlet(alpha, size, dtype)
@@ -140,8 +136,7 @@ def exponential(scale, size=None, dtype=float):
         cupy.ndarray: Samples drawn from the exponential distribution.
 
     .. seealso::
-        :meth:`numpy.random.exponential
-        <numpy.random.mtrand.RandomState.exponential>`
+        :func:`numpy.random.exponential`
     """
     rs = _generator.get_random_state()
     return rs.exponential(scale, size, dtype)
@@ -174,8 +169,7 @@ def f(dfnum, dfden, size=None, dtype=float):
         cupy.ndarray: Samples drawn from the f distribution.
 
     .. seealso::
-        :meth:`numpy.random.f
-        <numpy.random.mtrand.RandomState.f>`
+        :func:`numpy.random.f`
     """
     rs = _generator.get_random_state()
     return rs.f(dfnum, dfden, size, dtype)
@@ -201,8 +195,7 @@ def gamma(shape, scale=1.0, size=None, dtype=float):
     Returns:cupy.ndarray: Samples drawn from the gamma distribution.
 
     .. seealso::
-        :meth:`numpy.random.gamma
-        <numpy.random.mtrand.RandomState.gamma>`
+        :func:`numpy.random.gamma`
     """
     rs = _generator.get_random_state()
     return rs.gamma(shape, scale, size, dtype)
@@ -228,9 +221,7 @@ def geometric(p, size=None, dtype=int):
         cupy.ndarray: Samples drawn from the geometric distribution.
 
     .. seealso::
-        :func:`cupy.random.RandomState.geometric`
-        :meth:`numpy.random.geometric
-        <numpy.random.mtrand.RandomState.geometric>`
+        :func:`numpy.random.geometric`
     """
     rs = _generator.get_random_state()
     return rs.geometric(p, size, dtype)
@@ -263,8 +254,7 @@ def gumbel(loc=0.0, scale=1.0, size=None, dtype=float):
         cupy.ndarray: Samples drawn from the Gumbel distribution.
 
     .. seealso::
-        :meth:`numpy.random.gumbel
-        <numpy.random.mtrand.RandomState.gumbel>`
+        :func:`numpy.random.gumbel`
     """
     rs = _generator.get_random_state()
     return rs.gumbel(loc, scale, size, dtype)
@@ -295,8 +285,7 @@ def hypergeometric(ngood, nbad, nsample, size=None, dtype=int):
         cupy.ndarray: Samples drawn from the hypergeometric distribution.
 
     .. seealso::
-        :meth:`numpy.random.hypergeometric
-        <numpy.random.mtrand.RandomState.hypergeometric>`
+        :func:`numpy.random.hypergeometric`
     """
     rs = _generator.get_random_state()
     return rs.hypergeometric(ngood, nbad, nsample, size, dtype)
@@ -323,8 +312,7 @@ def logistic(loc=0.0, scale=1.0, size=None, dtype=float):
         cupy.ndarray: Samples drawn from the logistic distribution.
 
     .. seealso::
-        :meth:`numpy.random.logistic
-        <numpy.random.mtrand.RandomState.logistic>`
+        :func:`numpy.random.logistic`
     """
     rs = _generator.get_random_state()
     return rs.logistic(loc, scale, size, dtype)
@@ -351,8 +339,7 @@ def laplace(loc=0.0, scale=1.0, size=None, dtype=float):
         cupy.ndarray: Samples drawn from the laplace distribution.
 
     .. seealso::
-        :meth:`numpy.random.laplace
-        <numpy.random.mtrand.RandomState.laplace>`
+        :func:`numpy.random.laplace`
     """
     rs = _generator.get_random_state()
     return rs.laplace(loc, scale, size, dtype)
@@ -375,8 +362,7 @@ def lognormal(mean=0.0, sigma=1.0, size=None, dtype=float):
     Returns:
         cupy.ndarray: Samples drawn from the log normal distribution.
 
-    .. seealso:: :meth:`numpy.random.lognormal
-                 <numpy.random.mtrand.RandomState.lognormal>`
+    .. seealso:: :func:`numpy.random.lognormal`
 
     """
     rs = _generator.get_random_state()
@@ -402,8 +388,7 @@ def logseries(p, size=None, dtype=int):
     Returns:
         cupy.ndarray: Samples drawn from the log series distribution.
 
-    .. seealso:: :meth:`numpy.random.logseries
-                 <numpy.random.mtrand.RandomState.logseries>`
+    .. seealso:: :func:`numpy.random.logseries`
 
     """
     rs = _generator.get_random_state()
@@ -431,8 +416,7 @@ def negative_binomial(n, p, size=None, dtype=int):
         cupy.ndarray: Samples drawn from the negative binomial distribution.
 
     .. seealso::
-        :meth:`numpy.random.negative_binomial
-        <numpy.random.mtrand.RandomState.negative_binomial>`
+        :func:`numpy.random.negative_binomial`
     """
     rs = _generator.get_random_state()
     return rs.negative_binomial(n, p, size=size, dtype=dtype)
@@ -487,8 +471,7 @@ def multivariate_normal(mean, cov, size=None, check_valid='ignore',
         the specified `method` for other matrices (i.e., not positive
         semi-definite), and will warn if decomposition is suspect.
 
-    .. seealso:: :meth:`numpy.random.multivariate_normal
-                 <numpy.random.mtrand.RandomState.multivariate_normal>`
+    .. seealso:: :func:`numpy.random.multivariate_normal`
 
     """
     _util.experimental('cupy.random.multivariate_normal')
@@ -513,8 +496,7 @@ def normal(loc=0.0, scale=1.0, size=None, dtype=float):
     Returns:
         cupy.ndarray: Normally distributed samples.
 
-    .. seealso:: :meth:`numpy.random.normal
-                 <numpy.random.mtrand.RandomState.normal>`
+    .. seealso:: :func:`numpy.random.normal`
 
     """
     rs = _generator.get_random_state()
@@ -544,8 +526,7 @@ def pareto(a, size=None, dtype=float):
     Returns:
         cupy.ndarray: Samples drawn from the Pareto II distribution.
 
-    .. seealso:: :meth:`numpy.random.pareto
-                 <numpy.random.mtrand.RandomState.pareto>`
+    .. seealso:: :func:`numpy.random.pareto`
     """
     rs = _generator.get_random_state()
     x = rs.pareto(a, size, dtype)
@@ -579,8 +560,7 @@ def noncentral_chisquare(df, nonc, size=None, dtype=float):
         cupy.ndarray: Samples drawn from the noncentral chisquare distribution.
 
     .. seealso::
-        :meth:`numpy.random.noncentral_chisquare
-        <numpy.random.mtrand.RandomState.noncentral_chisquare>`
+        :func:`numpy.random.noncentral_chisquare`
     """
     rs = _generator.get_random_state()
     return rs.noncentral_chisquare(df, nonc, size=size, dtype=dtype)
@@ -607,8 +587,7 @@ def noncentral_f(dfnum, dfden, nonc, size=None, dtype=float):
         cupy.ndarray: Samples drawn from the noncentral F distribution.
 
     .. seealso::
-        :meth:`numpy.random.noncentral_f
-        <numpy.random.mtrand.RandomState.noncentral_f>`
+        :func:`numpy.random.noncentral_f`
     """
     rs = _generator.get_random_state()
     return rs.noncentral_f(dfnum, dfden, nonc, size=size, dtype=dtype)
@@ -634,8 +613,7 @@ def poisson(lam=1.0, size=None, dtype=int):
     Returns:
         cupy.ndarray: Samples drawn from the poisson distribution.
 
-    .. seealso:: :meth:`numpy.random.poisson
-                 <numpy.random.mtrand.RandomState.poisson>`
+    .. seealso:: :func:`numpy.random.poisson`
     """
     rs = _generator.get_random_state()
     x = rs.poisson(lam, size, dtype)
@@ -662,8 +640,7 @@ def power(a, size=None, dtype=float):
         cupy.ndarray: Samples drawn from the power distribution.
 
     .. seealso::
-        :meth:`numpy.random.power
-        <numpy.random.mtrand.RandomState.power>`
+        :func:`numpy.random.power`
     """
     rs = _generator.get_random_state()
     return rs.power(a, size, dtype)
@@ -688,8 +665,7 @@ def rayleigh(scale=1.0, size=None, dtype=float):
     Returns:
         cupy.ndarray: Samples drawn from the rayleigh distribution.
 
-    .. seealso:: :meth:`numpy.random.rayleigh
-                 <numpy.random.mtrand.RandomState.rayleigh>`
+    .. seealso:: :func:`numpy.random.rayleigh`
     """
     rs = _generator.get_random_state()
     x = rs.rayleigh(scale, size, dtype)
@@ -714,8 +690,7 @@ def standard_cauchy(size=None, dtype=float):
     Returns:
         cupy.ndarray: Samples drawn from the standard cauchy distribution.
 
-    .. seealso:: :meth:`numpy.random.standard_cauchy
-                 <numpy.random.mtrand.RandomState.standard_cauchy>`
+    .. seealso:: :func:`numpy.random.standard_cauchy`
     """
     rs = _generator.get_random_state()
     x = rs.standard_cauchy(size, dtype)
@@ -740,8 +715,7 @@ def standard_exponential(size=None, dtype=float):
     Returns:
         cupy.ndarray: Samples drawn from the standard exponential distribution.
 
-    .. seealso:: :meth:`numpy.random.standard_exponential
-                 <numpy.random.mtrand.RandomState.standard_exponential>`
+    .. seealso:: :func:`numpy.random.standard_exponential`
     """
     rs = _generator.get_random_state()
     return rs.standard_exponential(size, dtype)
@@ -767,8 +741,7 @@ def standard_gamma(shape, size=None, dtype=float):
         cupy.ndarray: Samples drawn from the standard gamma distribution.
 
     .. seealso::
-        :meth:`numpy.random.standard_gamma
-        <numpy.random.mtrand.RandomState.standard_gamma>`
+        :func:`numpy.random.standard_gamma`
     """
     rs = _generator.get_random_state()
     return rs.standard_gamma(shape, size, dtype)
@@ -787,8 +760,7 @@ def standard_normal(size=None, dtype=float):
     Returns:
         cupy.ndarray: Samples drawn from the standard normal distribution.
 
-    .. seealso:: :meth:`numpy.random.standard_normal
-                 <numpy.random.mtrand.RandomState.standard_normal>`
+    .. seealso:: :func:`numpy.random.standard_normal`
 
     """
     return normal(size=size, dtype=dtype)
@@ -816,8 +788,7 @@ def standard_t(df, size=None, dtype=float):
         cupy.ndarray: Samples drawn from the standard Student's t distribution.
 
     .. seealso::
-        :meth:`numpy.random.standard_t
-        <numpy.random.mtrand.RandomState.standard_t>`
+        :func:`numpy.random.standard_t`
     """
     rs = _generator.get_random_state()
     return rs.standard_t(df, size, dtype)
@@ -850,9 +821,7 @@ def triangular(left, mode, right, size=None, dtype=float):
         cupy.ndarray: Samples drawn from the triangular distribution.
 
     .. seealso::
-        :func:`cupy.random.RandomState.triangular`
-        :meth:`numpy.random.triangular
-        <numpy.random.mtrand.RandomState.triangular>`
+        :func:`numpy.random.triangular`
     """
     rs = _generator.get_random_state()
     return rs.triangular(left, mode, right, size, dtype)
@@ -874,8 +843,7 @@ def uniform(low=0.0, high=1.0, size=None, dtype=float):
     Returns:
         cupy.ndarray: Samples drawn from the uniform distribution.
 
-    .. seealso:: :meth:`numpy.random.uniform
-                 <numpy.random.mtrand.RandomState.uniform>`
+    .. seealso:: :func:`numpy.random.uniform`
 
     """
     rs = _generator.get_random_state()
@@ -903,8 +871,7 @@ def vonmises(mu, kappa, size=None, dtype=float):
         cupy.ndarray: Samples drawn from the von Mises distribution.
 
     .. seealso::
-        :meth:`numpy.random.vonmises
-        <numpy.random.mtrand.RandomState.vonmises>`
+        :func:`numpy.random.vonmises`
     """
     rs = _generator.get_random_state()
     return rs.vonmises(mu, kappa, size=size, dtype=dtype)
@@ -932,9 +899,7 @@ def wald(mean, scale, size=None, dtype=float):
         cupy.ndarray: Samples drawn from the wald distribution.
 
     .. seealso::
-        :func:`cupy.random.RandomState.wald`
-        :meth:`numpy.random.wald
-        <numpy.random.mtrand.RandomState.wald>`
+        :func:`numpy.random.wald`
     """
     rs = _generator.get_random_state()
     return rs.wald(mean, scale, size, dtype)
@@ -960,8 +925,7 @@ def weibull(a, size=None, dtype=float):
         cupy.ndarray: Samples drawn from the weibull distribution.
 
     .. seealso::
-        :meth:`numpy.random.weibull
-        <numpy.random.mtrand.RandomState.weibull>`
+        :func:`numpy.random.weibull`
     """
     rs = _generator.get_random_state()
     return rs.weibull(a, size=size, dtype=dtype)
@@ -989,8 +953,7 @@ def zipf(a, size=None, dtype=int):
         cupy.ndarray: Samples drawn from the Zipf distribution.
 
     .. seealso::
-        :meth:`numpy.random.zipf
-        <numpy.random.mtrand.RandomState.zipf>`
+        :func:`numpy.random.zipf`
     """
     rs = _generator.get_random_state()
     return rs.zipf(a, size=size, dtype=dtype)

--- a/cupy/random/_generator.py
+++ b/cupy/random/_generator.py
@@ -91,9 +91,8 @@ class RandomState(object):
         """Returns an array of samples drawn from the beta distribution.
 
         .. seealso::
-            :func:`cupy.random.beta` for full documentation,
-            :meth:`numpy.random.RandomState.beta
-            <numpy.random.mtrand.RandomState.beta>`
+            - :func:`cupy.random.beta` for full documentation
+            - :meth:`numpy.random.RandomState.beta`
         """
         a, b = cupy.asarray(a), cupy.asarray(b)
         if size is None:
@@ -107,9 +106,8 @@ class RandomState(object):
         """Returns an array of samples drawn from the binomial distribution.
 
         .. seealso::
-            :func:`cupy.random.binomial` for full documentation,
-            :meth:`numpy.random.RandomState.binomial
-            <numpy.random.mtrand.RandomState.binomial>`
+            - :func:`cupy.random.binomial` for full documentation
+            - :meth:`numpy.random.RandomState.binomial`
         """
         n, p = cupy.asarray(n), cupy.asarray(p)
         if size is None:
@@ -123,9 +121,8 @@ class RandomState(object):
         """Returns an array of samples drawn from the chi-square distribution.
 
         .. seealso::
-            :func:`cupy.random.chisquare` for full documentation,
-            :meth:`numpy.random.RandomState.chisquare
-            <numpy.random.mtrand.RandomState.chisquare>`
+            - :func:`cupy.random.chisquare` for full documentation
+            - :meth:`numpy.random.RandomState.chisquare`
         """
         df = cupy.asarray(df)
         if size is None:
@@ -139,9 +136,8 @@ class RandomState(object):
         """Returns an array of samples drawn from the dirichlet distribution.
 
         .. seealso::
-            :func:`cupy.random.dirichlet` for full documentation,
-            :meth:`numpy.random.RandomState.dirichlet
-            <numpy.random.mtrand.RandomState.dirichlet>`
+            - :func:`cupy.random.dirichlet` for full documentation
+            - :meth:`numpy.random.RandomState.dirichlet`
         """
         alpha = cupy.asarray(alpha)
         if size is None:
@@ -162,9 +158,8 @@ class RandomState(object):
             This function may synchronize the device.
 
         .. seealso::
-            :func:`cupy.random.exponential` for full documentation,
-            :meth:`numpy.random.RandomState.exponential
-            <numpy.random.mtrand.RandomState.exponential>`
+            - :func:`cupy.random.exponential` for full documentation
+            - :meth:`numpy.random.RandomState.exponential`
         """
         scale = cupy.asarray(scale, dtype)
         if (scale < 0).any():  # synchronize!
@@ -179,9 +174,8 @@ class RandomState(object):
         """Returns an array of samples drawn from the f distribution.
 
         .. seealso::
-            :func:`cupy.random.f` for full documentation,
-            :meth:`numpy.random.RandomState.f
-            <numpy.random.mtrand.RandomState.f>`
+            - :func:`cupy.random.f` for full documentation
+            - :meth:`numpy.random.RandomState.f`
         """
         dfnum, dfden = cupy.asarray(dfnum), cupy.asarray(dfden)
         if size is None:
@@ -195,9 +189,8 @@ class RandomState(object):
         """Returns an array of samples drawn from a gamma distribution.
 
         .. seealso::
-            :func:`cupy.random.gamma` for full documentation,
-            :meth:`numpy.random.RandomState.gamma
-            <numpy.random.mtrand.RandomState.gamma>`
+            - :func:`cupy.random.gamma` for full documentation
+            - :meth:`numpy.random.RandomState.gamma`
         """
         shape, scale = cupy.asarray(shape), cupy.asarray(scale)
         if size is None:
@@ -212,9 +205,8 @@ class RandomState(object):
         """Returns an array of samples drawn from the geometric distribution.
 
         .. seealso::
-            :func:`cupy.random.geometric` for full documentation,
-            :meth:`numpy.random.RandomState.geometric
-            <numpy.random.mtrand.RandomState.geometric>`
+            - :func:`cupy.random.geometric` for full documentation
+            - :meth:`numpy.random.RandomState.geometric`
         """
         p = cupy.asarray(p)
         if size is None:
@@ -228,9 +220,8 @@ class RandomState(object):
         """Returns an array of samples drawn from the hypergeometric distribution.
 
         .. seealso::
-            :func:`cupy.random.hypergeometric` for full documentation,
-            :meth:`numpy.random.RandomState.hypergeometric
-            <numpy.random.mtrand.RandomState.hypergeometric>`
+            - :func:`cupy.random.hypergeometric` for full documentation
+            - :meth:`numpy.random.RandomState.hypergeometric`
         """
         ngood, nbad, nsample = \
             cupy.asarray(ngood), cupy.asarray(nbad), cupy.asarray(nsample)
@@ -250,9 +241,8 @@ class RandomState(object):
         """Returns an array of samples drawn from the laplace distribution.
 
         .. seealso::
-            :func:`cupy.random.laplace` for full documentation,
-            :meth:`numpy.random.RandomState.laplace
-            <numpy.random.mtrand.RandomState.laplace>`
+            - :func:`cupy.random.laplace` for full documentation
+            - :meth:`numpy.random.RandomState.laplace`
         """
         loc = cupy.asarray(loc, dtype)
         scale = cupy.asarray(scale, dtype)
@@ -266,9 +256,8 @@ class RandomState(object):
         """Returns an array of samples drawn from the logistic distribution.
 
         .. seealso::
-            :func:`cupy.random.logistic` for full documentation,
-            :meth:`numpy.random.RandomState.logistic
-            <numpy.random.mtrand.RandomState.logistic>`
+            - :func:`cupy.random.logistic` for full documentation
+            - :meth:`numpy.random.RandomState.logistic`
         """
         loc, scale = cupy.asarray(loc), cupy.asarray(scale)
         if size is None:
@@ -286,9 +275,8 @@ class RandomState(object):
         """Returns an array of samples drawn from a log normal distribution.
 
         .. seealso::
-            :func:`cupy.random.lognormal` for full documentation,
-            :meth:`numpy.random.RandomState.lognormal
-            <numpy.random.mtrand.RandomState.lognormal>`
+            - :func:`cupy.random.lognormal` for full documentation
+            - :meth:`numpy.random.RandomState.lognormal`
 
         """
         dtype = _check_and_get_dtype(dtype)
@@ -306,9 +294,8 @@ class RandomState(object):
             This function may synchronize the device.
 
         .. seealso::
-            :func:`cupy.random.logseries` for full documentation,
-            :meth:`numpy.random.RandomState.logseries
-            <numpy.random.mtrand.RandomState.logseries>`
+            - :func:`cupy.random.logseries` for full documentation
+            - :meth:`numpy.random.RandomState.logseries`
 
         """
         p = cupy.asarray(p)
@@ -336,9 +323,8 @@ class RandomState(object):
             :func:`cupyx.errstate` or :func:`cupyx.seterr`.
 
         .. seealso::
-            :func:`cupy.random.multivariate_normal` for full documentation,
-            :meth:`numpy.random.RandomState.multivariate_normal
-            <numpy.random.mtrand.RandomState.multivariate_normal>`
+            - :func:`cupy.random.multivariate_normal` for full documentation
+            - :meth:`numpy.random.RandomState.multivariate_normal`
         """
         _util.experimental('cupy.random.RandomState.multivariate_normal')
         mean = cupy.asarray(mean, dtype=dtype)
@@ -428,9 +414,8 @@ class RandomState(object):
             This function may synchronize the device.
 
         .. seealso::
-            :func:`cupy.random.negative_binomial` for full documentation,
-            :meth:`numpy.random.RandomState.negative_binomial
-            <numpy.random.mtrand.RandomState.negative_binomial>`
+            - :func:`cupy.random.negative_binomial` for full documentation
+            - :meth:`numpy.random.RandomState.negative_binomial`
         """
         n = cupy.asarray(n)
         p = cupy.asarray(p)
@@ -447,9 +432,8 @@ class RandomState(object):
         """Returns an array of normally distributed samples.
 
         .. seealso::
-            :func:`cupy.random.normal` for full documentation,
-            :meth:`numpy.random.RandomState.normal
-            <numpy.random.mtrand.RandomState.normal>`
+            - :func:`cupy.random.normal` for full documentation
+            - :meth:`numpy.random.RandomState.normal`
 
         """
         dtype = _check_and_get_dtype(dtype)
@@ -463,9 +447,8 @@ class RandomState(object):
         """Returns an array of samples drawn from the pareto II distribution.
 
         .. seealso::
-            :func:`cupy.random.pareto_kernel` for full documentation,
-            :meth:`numpy.random.RandomState.pareto
-            <numpy.random.mtrand.RandomState.pareto>`
+            - :func:`cupy.random.pareto` for full documentation
+            - :meth:`numpy.random.RandomState.pareto`
         """
         a = cupy.asarray(a)
         x = self._random_sample_raw(size, dtype)
@@ -482,9 +465,8 @@ class RandomState(object):
             This function may synchronize the device.
 
         .. seealso::
-            :func:`cupy.random.noncentral_chisquare` for full documentation,
-            :meth:`numpy.random.RandomState.noncentral_chisquare
-            <numpy.random.mtrand.RandomState.noncentral_chisquare>`
+            - :func:`cupy.random.noncentral_chisquare` for full documentation
+            - :meth:`numpy.random.RandomState.noncentral_chisquare`
         """
         df, nonc = cupy.asarray(df), cupy.asarray(nonc)
         if cupy.any(df <= 0):  # synchronize!
@@ -506,9 +488,8 @@ class RandomState(object):
             This function may synchronize the device.
 
         .. seealso::
-            :func:`cupy.random.noncentral_f` for full documentation,
-            :meth:`numpy.random.RandomState.noncentral_f
-            <numpy.random.mtrand.RandomState.noncentral_f>`
+            - :func:`cupy.random.noncentral_f` for full documentation
+            - :meth:`numpy.random.RandomState.noncentral_f`
         """
         dfnum, dfden, nonc = \
             cupy.asarray(dfnum), cupy.asarray(dfden), cupy.asarray(nonc)
@@ -529,9 +510,8 @@ class RandomState(object):
         """Returns an array of samples drawn from the poisson distribution.
 
         .. seealso::
-            :func:`cupy.random.poisson` for full documentation,
-            :meth:`numpy.random.RandomState.poisson
-            <numpy.random.mtrand.RandomState.poisson>`
+            - :func:`cupy.random.poisson` for full documentation
+            - :meth:`numpy.random.RandomState.poisson`
         """
         lam = cupy.asarray(lam)
         if size is None:
@@ -549,9 +529,8 @@ class RandomState(object):
             This function may synchronize the device.
 
         .. seealso::
-            :func:`cupy.random.power` for full documentation,
-            :meth:`numpy.random.RandomState.power
-            <numpy.random.mtrand.RandomState.power>`
+            - :func:`cupy.random.power` for full documentation
+            - :meth:`numpy.random.RandomState.power`
         """
         a = cupy.asarray(a)
         if cupy.any(a < 0):  # synchronize!
@@ -568,9 +547,8 @@ class RandomState(object):
         """Returns uniform random values over the interval ``[0, 1)``.
 
         .. seealso::
-            :func:`cupy.random.rand` for full documentation,
-            :meth:`numpy.random.RandomState.rand
-            <numpy.random.mtrand.RandomState.rand>`
+            - :func:`cupy.random.rand` for full documentation
+            - :meth:`numpy.random.RandomState.rand`
 
         """
         dtype = kwarg.pop('dtype', float)
@@ -583,9 +561,8 @@ class RandomState(object):
         """Returns an array of standard normal random values.
 
         .. seealso::
-            :func:`cupy.random.randn` for full documentation,
-            :meth:`numpy.random.RandomState.randn
-            <numpy.random.mtrand.RandomState.randn>`
+            - :func:`cupy.random.randn` for full documentation
+            - :meth:`numpy.random.RandomState.randn`
 
         """
         dtype = kwarg.pop('dtype', float)
@@ -611,9 +588,8 @@ class RandomState(object):
         """Returns an array of random values over the interval ``[0, 1)``.
 
         .. seealso::
-            :func:`cupy.random.random_sample` for full documentation,
-            :meth:`numpy.random.RandomState.random_sample
-            <numpy.random.mtrand.RandomState.random_sample>`
+            - :func:`cupy.random.random_sample` for full documentation
+            - :meth:`numpy.random.RandomState.random_sample`
 
         """
         out = self._random_sample_raw(size, dtype)
@@ -628,9 +604,8 @@ class RandomState(object):
             This function may synchronize the device.
 
         .. seealso::
-            :func:`cupy.random.rayleigh` for full documentation,
-            :meth:`numpy.random.RandomState.rayleigh
-            <numpy.random.mtrand.RandomState.rayleigh>`
+            - :func:`cupy.random.rayleigh` for full documentation
+            - :meth:`numpy.random.RandomState.rayleigh`
         """
         scale = cupy.asarray(scale)
         if size is None:
@@ -743,9 +718,8 @@ class RandomState(object):
         """Resets the state of the random number generator with a seed.
 
         .. seealso::
-            :func:`cupy.random.seed` for full documentation,
-            :meth:`numpy.random.RandomState.seed
-            <numpy.random.mtrand.RandomState.seed>`
+            - :func:`cupy.random.seed` for full documentation
+            - :meth:`numpy.random.RandomState.seed`
 
         """
         if seed is None:
@@ -772,9 +746,8 @@ class RandomState(object):
         """Returns an array of samples drawn from the standard cauchy distribution.
 
         .. seealso::
-            :func:`cupy.random.standard_cauchy` for full documentation,
-            :meth:`numpy.random.RandomState.standard_cauchy
-            <numpy.random.mtrand.RandomState.standard_cauchy>`
+            - :func:`cupy.random.standard_cauchy` for full documentation
+            - :meth:`numpy.random.RandomState.standard_cauchy`
         """
         x = self.uniform(size=size, dtype=dtype)
         return cupy.tan(cupy.pi * (x - 0.5))
@@ -783,9 +756,8 @@ class RandomState(object):
         """Returns an array of samples drawn from the standard exp distribution.
 
          .. seealso::
-            :func:`cupy.random.standard_exponential` for full documentation,
-            :meth:`numpy.random.RandomState.standard_exponential
-            <numpy.random.mtrand.RandomState.standard_exponential>`
+            - :func:`cupy.random.standard_exponential` for full documentation
+            - :meth:`numpy.random.RandomState.standard_exponential`
         """
         x = self._random_sample_raw(size, dtype)
         return -cupy.log(x, out=x)
@@ -794,9 +766,8 @@ class RandomState(object):
         """Returns an array of samples drawn from a standard gamma distribution.
 
         .. seealso::
-            :func:`cupy.random.standard_gamma` for full documentation,
-            :meth:`numpy.random.RandomState.standard_gamma
-            <numpy.random.mtrand.RandomState.standard_gamma>`
+            - :func:`cupy.random.standard_gamma` for full documentation
+            - :meth:`numpy.random.RandomState.standard_gamma`
         """
         shape = cupy.asarray(shape)
         if size is None:
@@ -810,9 +781,8 @@ class RandomState(object):
         """Returns samples drawn from the standard normal distribution.
 
         .. seealso::
-            :func:`cupy.random.standard_normal` for full documentation,
-            :meth:`numpy.random.RandomState.standard_normal
-            <numpy.random.mtrand.RandomState.standard_normal>`
+            - :func:`cupy.random.standard_normal` for full documentation
+            - :meth:`numpy.random.RandomState.standard_normal`
 
         """
         return self.normal(size=size, dtype=dtype)
@@ -821,9 +791,8 @@ class RandomState(object):
         """Returns an array of samples drawn from the standard t distribution.
 
         .. seealso::
-            :func:`cupy.random.standard_t` for full documentation,
-            :meth:`numpy.random.RandomState.standard_t
-            <numpy.random.mtrand.RandomState.standard_t>`
+            - :func:`cupy.random.standard_t` for full documentation
+            - :meth:`numpy.random.RandomState.standard_t`
         """
         df = cupy.asarray(df)
         if size is None:
@@ -836,6 +805,10 @@ class RandomState(object):
     def tomaxint(self, size=None):
         """Draws integers between 0 and max integer inclusive.
 
+        Return a sample of uniformly distributed random integers in the
+        interval [0, ``np.iinfo(np.int_).max``]. The `np.int_` type translates
+        to the C long integer type and its precision is platform dependent.
+
         Args:
             size (int or tuple of ints): Output shape.
 
@@ -843,8 +816,7 @@ class RandomState(object):
             cupy.ndarray: Drawn samples.
 
         .. seealso::
-            :meth:`numpy.random.RandomState.tomaxint
-            <numpy.random.mtrand.RandomState.tomaxint>`
+            :meth:`numpy.random.RandomState.tomaxint`
 
         """
         if size is None:
@@ -889,9 +861,8 @@ class RandomState(object):
             This function may synchronize the device.
 
         .. seealso::
-            :func:`cupy.random.triangular` for full documentation,
-            :meth:`numpy.random.RandomState.triangular
-            <numpy.random.mtrand.RandomState.triangular>`
+            - :func:`cupy.random.triangular` for full documentation
+            - :meth:`numpy.random.RandomState.triangular`
         """
         left, mode, right = \
             cupy.asarray(left), cupy.asarray(mode), cupy.asarray(right)
@@ -915,9 +886,8 @@ class RandomState(object):
         """Returns an array of uniformly-distributed samples over an interval.
 
         .. seealso::
-            :func:`cupy.random.uniform` for full documentation,
-            :meth:`numpy.random.RandomState.uniform
-            <numpy.random.mtrand.RandomState.uniform>`
+            - :func:`cupy.random.uniform` for full documentation
+            - :meth:`numpy.random.RandomState.uniform`
 
         """
         dtype = numpy.dtype(dtype)
@@ -932,9 +902,8 @@ class RandomState(object):
         """Returns an array of samples drawn from the von Mises distribution.
 
         .. seealso::
-            :func:`cupy.random.vonmises` for full documentation,
-            :meth:`numpy.random.RandomState.vonmises
-            <numpy.random.mtrand.RandomState.vonmises>`
+            - :func:`cupy.random.vonmises` for full documentation
+            - :meth:`numpy.random.RandomState.vonmises`
         """
         mu, kappa = cupy.asarray(mu), cupy.asarray(kappa)
         if size is None:
@@ -963,9 +932,8 @@ class RandomState(object):
         """Returns an array of samples drawn from the Wald distribution.
 
          .. seealso::
-            :func:`cupy.random.wald` for full documentation,
-            :meth:`numpy.random.RandomState.wald
-            <numpy.random.mtrand.RandomState.wald>`
+            - :func:`cupy.random.wald` for full documentation
+            - :meth:`numpy.random.RandomState.wald`
         """
         mean, scale = \
             cupy.asarray(mean, dtype=dtype), cupy.asarray(scale, dtype=dtype)
@@ -983,9 +951,8 @@ class RandomState(object):
             This function may synchronize the device.
 
         .. seealso::
-            :func:`cupy.random.weibull` for full documentation,
-            :meth:`numpy.random.RandomState.weibull
-            <numpy.random.mtrand.RandomState.weibull>`
+            - :func:`cupy.random.weibull` for full documentation
+            - :meth:`numpy.random.RandomState.weibull`
         """
         a = cupy.asarray(a)
         if cupy.any(a < 0):  # synchronize!
@@ -1002,9 +969,8 @@ class RandomState(object):
             This function may synchronize the device.
 
         .. seealso::
-            :func:`cupy.random.zipf` for full documentation,
-            :meth:`numpy.random.RandomState.zipf
-            <numpy.random.mtrand.RandomState.zipf>`
+            - :func:`cupy.random.zipf` for full documentation
+            - :meth:`numpy.random.RandomState.zipf`
         """
         a = cupy.asarray(a)
         if cupy.any(a <= 1.0):  # synchronize!
@@ -1020,9 +986,8 @@ class RandomState(object):
         """Returns an array of random values from a given 1-D array.
 
         .. seealso::
-            :func:`cupy.random.choice` for full document,
-            :meth:`numpy.random.choice
-            <numpy.random.mtrand.RandomState.choice>`
+            - :func:`cupy.random.choice` for full documentation
+            - :meth:`numpy.random.choice`
 
         """
         if a is None:
@@ -1098,9 +1063,8 @@ class RandomState(object):
         """Returns a shuffled array.
 
         .. seealso::
-            :func:`cupy.random.shuffle` for full document,
-            :meth:`numpy.random.shuffle
-            <numpy.random.mtrand.RandomState.shuffle>`
+            - :func:`cupy.random.shuffle` for full documentation
+            - :meth:`numpy.random.shuffle`
 
         """
         if not isinstance(a, cupy.ndarray):
@@ -1156,9 +1120,8 @@ class RandomState(object):
         """Returns an array of samples drawn from a Gumbel distribution.
 
         .. seealso::
-            :func:`cupy.random.gumbel` for full documentation,
-            :meth:`numpy.random.RandomState.gumbel
-            <numpy.random.mtrand.RandomState.gumbel>`
+            - :func:`cupy.random.gumbel` for full documentation
+            - :meth:`numpy.random.RandomState.gumbel`
         """
         x = self._random_sample_raw(size=size, dtype=dtype)
         if not numpy.isscalar(loc):
@@ -1172,9 +1135,8 @@ class RandomState(object):
         """Returns a scalar or an array of integer values over ``[low, high)``.
 
         .. seealso::
-            :func:`cupy.random.randint` for full documentation,
-            :meth:`numpy.random.RandomState.randint
-            <numpy.random.mtrand.RandomState.randint>`
+            - :func:`cupy.random.randint` for full documentation
+            - :meth:`numpy.random.RandomState.randint`
         """
         if high is None:
             lo = 0

--- a/cupy/random/_permutations.py
+++ b/cupy/random/_permutations.py
@@ -7,8 +7,7 @@ def shuffle(a):
     Args:
         a (cupy.ndarray): The array to be shuffled.
 
-    .. seealso:: :meth:`numpy.random.shuffle
-                 <numpy.random.mtrand.RandomState.shuffle>`
+    .. seealso:: :meth:`numpy.random.shuffle`
 
     """
     rs = _generator.get_random_state()
@@ -26,8 +25,7 @@ def permutation(a):
         and `a` - 1.
         Otherwise, it is a permutation of `a`.
 
-    .. seealso:: :meth:`numpy.random.permutation
-                 <numpy.random.mtrand.RandomState.permutation>`
+    .. seealso:: :meth:`numpy.random.permutation`
     """
     rs = _generator.get_random_state()
     return rs.permutation(a)

--- a/cupy/random/_sample.py
+++ b/cupy/random/_sample.py
@@ -20,8 +20,7 @@ def rand(*size, **kwarg):
     Returns:
         cupy.ndarray: A random array.
 
-    .. seealso:: :meth:`numpy.random.rand
-                 <numpy.random.mtrand.RandomState.rand>`
+    .. seealso:: :meth:`numpy.random.rand`
 
     .. admonition:: Example
 
@@ -61,8 +60,7 @@ def randn(*size, **kwarg):
     Returns:
         cupy.ndarray: An array of standard normal random values.
 
-    .. seealso:: :meth:`numpy.random.randn
-                 <numpy.random.mtrand.RandomState.randn>`
+    .. seealso:: :meth:`numpy.random.randn`
 
     .. admonition:: Example
 
@@ -151,8 +149,7 @@ def random_sample(size=None, dtype=float):
     Returns:
         cupy.ndarray: An array of uniformly distributed random values.
 
-    .. seealso:: :meth:`numpy.random.random_sample
-                 <numpy.random.mtrand.RandomState.random_sample>`
+    .. seealso:: :meth:`numpy.random.random_sample`
 
     """
     rs = _generator.get_random_state()
@@ -186,8 +183,7 @@ def choice(a, size=None, replace=True, p=None):
         cupy.ndarray: An array of ``a`` values distributed according to
                       ``p`` or uniformly.
 
-    .. seealso:: :meth:`numpy.random.choice
-                 <numpy.random.mtrand.RandomState.choice>`
+    .. seealso:: :meth:`numpy.random.choice`
 
     """
     rs = _generator.get_random_state()
@@ -219,8 +215,7 @@ def multinomial(n, pvals, size=None):
     .. note::
        It does not support ``sum(pvals) < 1`` case.
 
-    .. seealso:: :meth:`numpy.random.multinomial
-                 <numpy.random.mtrand.RandomState.multinomial>`
+    .. seealso:: :meth:`numpy.random.multinomial`
     """
 
     if size is None:


### PR DESCRIPTION
Now NumPy has the docs for Legacy Random Generation (https://numpy.org/doc/stable/reference/random/legacy.html).  This PR fixes the broken hack.