### PR TITLE
Make names of test classes start with `Test`

### DIFF
--- a/tests/cupy_tests/core_tests/fusion_tests/test_example.py
+++ b/tests/cupy_tests/core_tests/fusion_tests/test_example.py
@@ -6,7 +6,7 @@ from cupy_tests.core_tests.fusion_tests import fusion_utils
 
 @testing.gpu
 @testing.slow
-class FusionExampleTest(unittest.TestCase):
+class TestFusionExample(unittest.TestCase):
     def generate_inputs(self, xp):
         shape = (8, 64, 112, 112)
         _, chan, _, _ = shape

--- a/tests/cupy_tests/core_tests/test_ndarray_cuda_array_interface.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_cuda_array_interface.py
@@ -71,7 +71,7 @@ class TestElementwiseKernel(unittest.TestCase):
 
 
 @testing.gpu
-class SimpleReductionFunction(unittest.TestCase):
+class TestSimpleReductionFunction(unittest.TestCase):
 
     def setUp(self):
         self.my_int8_sum = core.create_reduction_func(

--- a/tests/cupy_tests/core_tests/test_reduction.py
+++ b/tests/cupy_tests/core_tests/test_reduction.py
@@ -45,7 +45,7 @@ class SimpleReductionFunctionTestBase(AbstractReductionTestBase):
 
 
 @testing.gpu
-class SimpleReductionFunctionTest(
+class TestSimpleReductionFunction(
         unittest.TestCase, SimpleReductionFunctionTestBase):
     def test_shape1(self):
         for i in range(1, 10):

--- a/tests/cupy_tests/testing_tests/test_parameterized.py
+++ b/tests/cupy_tests/testing_tests/test_parameterized.py
@@ -16,7 +16,7 @@ from cupy import testing
     {'actual': {'a': [1, 2], 'b': []}, 'expect': []},
     {'actual': {'a': []}, 'expect': []},
     {'actual': {}, 'expect': [{}]})
-class ProductTest(unittest.TestCase):
+class TestProduct(unittest.TestCase):
 
     def test_product(self):
         assert testing.product(self.actual) == self.expect
@@ -33,7 +33,7 @@ class ProductTest(unittest.TestCase):
     {'actual': [[{'a': 1}, {'a': 2}], []], 'expect': []},
     {'actual': [[]], 'expect': []},
     {'actual': [], 'expect': [{}]})
-class ProductDictTest(unittest.TestCase):
+class TestProductDict(unittest.TestCase):
 
     def test_product_dict(self):
         assert testing.product_dict(*self.actual) == self.expect

--- a/tests/cupyx_tests/fallback_mode_tests/test_fallback.py
+++ b/tests/cupyx_tests/fallback_mode_tests/test_fallback.py
@@ -249,7 +249,7 @@ class TestDocs(unittest.TestCase):
 
 
 @testing.gpu
-class FallbackArray(unittest.TestCase):
+class TestFallbackArray(unittest.TestCase):
 
     def test_ndarray_creation_compatible(self):
 

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_morphology.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_morphology.py
@@ -76,7 +76,7 @@ class TestIterateStructure(unittest.TestCase):
 )
 @testing.gpu
 @testing.with_requires('scipy')
-class BinaryErosionAndDilation1d(unittest.TestCase):
+class TestBinaryErosionAndDilation1d(unittest.TestCase):
     def _filter(self, xp, scp, x):
         filter = getattr(scp.ndimage, self.filter)
         structure = self.structure
@@ -130,7 +130,7 @@ class BinaryErosionAndDilation1d(unittest.TestCase):
 )
 @testing.gpu
 @testing.with_requires('scipy>=1.1.0')
-class BinaryOpeningAndClosing(unittest.TestCase):
+class TestBinaryOpeningAndClosing(unittest.TestCase):
     def _filter(self, xp, scp, x):
         filter = getattr(scp.ndimage, self.filter)
         structure = scp.ndimage.generate_binary_structure(x.ndim,
@@ -181,7 +181,7 @@ class BinaryOpeningAndClosing(unittest.TestCase):
 )
 @testing.gpu
 @testing.with_requires('scipy')
-class BinaryFillHoles(unittest.TestCase):
+class TestBinaryFillHoles(unittest.TestCase):
     def _filter(self, xp, scp, x):
         filter = scp.ndimage.binary_fill_holes
         structure = scp.ndimage.generate_binary_structure(x.ndim,
@@ -230,7 +230,7 @@ class BinaryFillHoles(unittest.TestCase):
 )
 @testing.gpu
 @testing.with_requires('scipy')
-class BinaryHitOrMiss(unittest.TestCase):
+class TestBinaryHitOrMiss(unittest.TestCase):
     def _filter(self, xp, scp, x):
         filter = scp.ndimage.binary_hit_or_miss
         if self.struct == 'same':
@@ -303,7 +303,7 @@ class BinaryHitOrMiss(unittest.TestCase):
 )
 @testing.gpu
 @testing.with_requires('scipy')
-class BinaryPropagation(unittest.TestCase):
+class TestBinaryPropagation(unittest.TestCase):
     def _filter(self, xp, scp, x):
         filter = scp.ndimage.binary_propagation
         structure = scp.ndimage.generate_binary_structure(x.ndim,
@@ -335,7 +335,7 @@ class BinaryPropagation(unittest.TestCase):
 )
 @testing.gpu
 @testing.with_requires('scipy')
-class BinaryErosionAndDilation(unittest.TestCase):
+class TestBinaryErosionAndDilation(unittest.TestCase):
     def _filter(self, xp, scp, x):
         filter = getattr(scp.ndimage, self.filter)
         ndim = len(self.shape)
@@ -372,7 +372,7 @@ class BinaryErosionAndDilation(unittest.TestCase):
 )
 @testing.gpu
 @testing.with_requires('scipy')
-class BinaryErosionAndDilationContiguity(unittest.TestCase):
+class TestBinaryErosionAndDilationContiguity(unittest.TestCase):
     def _filter(self, xp, scp, x):
         filter = getattr(scp.ndimage, self.filter)
         ndim = len(self.shape)
@@ -527,7 +527,7 @@ class TestGreyClosingAndOpening(unittest.TestCase):
 )
 @testing.gpu
 @testing.with_requires('scipy')
-class MorphologicalGradientAndLaplace(unittest.TestCase):
+class TestMorphologicalGradientAndLaplace(unittest.TestCase):
 
     def _filter(self, xp, scp, x):
         filter = getattr(scp.ndimage, self.filter)
@@ -590,7 +590,7 @@ class MorphologicalGradientAndLaplace(unittest.TestCase):
 )
 @testing.gpu
 @testing.with_requires('scipy')
-class WhiteTophatAndBlackTopHat(unittest.TestCase):
+class TestWhiteTophatAndBlackTopHat(unittest.TestCase):
 
     def _filter(self, xp, scp, x):
         filter = getattr(scp.ndimage, self.filter)


### PR DESCRIPTION
This coding rule will be required in order to stop inheriting `unittest.TestCase`. https://docs.pytest.org/en/stable/reference.html#confval-python_classes

- This PR overlaps with 61fe60fd479a684ff01c3f699b5d40f125c38044 in #4307.
- This PR does not fix that `cupy_tests/testing_tests/test_condition.py::MockUnitTest::runTest` is collected.