### PR TITLE
[backport] Fix `cupy.random.bytes` not working

### DIFF
--- a/cupy/random/__init__.py
+++ b/cupy/random/__init__.py
@@ -4,10 +4,14 @@ import numpy as _numpy
 def bytes(length):
     """Returns random bytes.
 
+    .. note:: This function is just a wrapper for :obj:`numpy.random.bytes`.
+        The resulting bytes are generated on the host (NumPy), not GPU.
+
     .. seealso:: :meth:`numpy.random.bytes
                  <numpy.random.mtrand.RandomState.bytes>`
     """
-    return _numpy.bytes(length)
+    # TODO(kmaehashi): should it be provided in CuPy?
+    return _numpy.random.bytes(length)
 
 
 # import class and function

--- a/tests/cupy_tests/random_tests/test_init.py
+++ b/tests/cupy_tests/random_tests/test_init.py
@@ -1,0 +1,6 @@
+import cupy
+
+
+def test_bytes():
+    out = cupy.random.bytes(10)
+    assert isinstance(out, bytes)


### PR DESCRIPTION
Backport of #4318