### PR TITLE
Fix Travis CI warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,5 +27,3 @@ script:
   - pushd docs
   - SPHINXOPTS=-W make html
   - popd
-
-sudo: false


### PR DESCRIPTION
```
root: deprecated key sudo (The key `sudo` has no effect anymore.)
```