### PR TITLE
Reset extra_compile_args for each module

### DIFF
--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -596,16 +596,15 @@ def make_extensions(options, compiler, use_cython):
             # if any change is made to the Jitify header, we force recompiling
             s['depends'] = ['./cupy/core/include/cupy/jitify/jitify.hpp']
 
-        original_s = s
         for f in module['file']:
-            s = copy.deepcopy(original_s)
+            s_file = copy.deepcopy(s)
             name = module_extension_name(f)
 
             rpath = []
             if not options['no_rpath']:
                 # Add library directories (e.g., `/usr/local/cuda/lib64`) to
                 # RPATH.
-                rpath += s['library_dirs']
+                rpath += s_file['library_dirs']
 
             if use_wheel_libs_rpath:
                 # Add `cupy/.data/lib` (where shared libraries included in
@@ -619,13 +618,13 @@ def make_extensions(options, compiler, use_cython):
                     '{}{}/cupy/.data/lib'.format(_rpath_base(), '/..' * depth))
 
             if not PLATFORM_WIN32 and not PLATFORM_LINUX:
-                s['runtime_library_dirs'] = rpath
-            if (PLATFORM_LINUX and s['library_dirs']) or PLATFORM_DARWIN:
+                s_file['runtime_library_dirs'] = rpath
+            if (PLATFORM_LINUX and s_file['library_dirs']) or PLATFORM_DARWIN:
                 ldflag = '-Wl,'
                 if PLATFORM_LINUX:
                     ldflag += '--disable-new-dtags,'
                 ldflag += ','.join('-rpath,' + p for p in rpath)
-                args = s.setdefault('extra_link_args', [])
+                args = s_file.setdefault('extra_link_args', [])
                 args.append(ldflag)
                 if PLATFORM_DARWIN:
                     # -rpath is only supported when targeting Mac OS X 10.5 or
@@ -633,7 +632,7 @@ def make_extensions(options, compiler, use_cython):
                     args.append('-mmacosx-version-min=10.5')
 
             sources = module_extension_sources(f, use_cython, no_cuda)
-            extension = setuptools.Extension(name, sources, **s)
+            extension = setuptools.Extension(name, sources, **s_file)
             ret.append(extension)
 
     return ret

--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -572,7 +572,7 @@ def make_extensions(options, compiler, use_cython):
         if module['name'] not in available_modules:
             continue
 
-        s = settings.copy()
+        s = copy.deepcopy(settings)
         if not no_cuda:
             s['libraries'] = module['libraries']
 


### PR DESCRIPTION
Currently, extra_compile_args is reused between module builds (e.g. `'-fopenmp'` is added for every module built after `cusolver` module), because it manipulates on shallow copy of the original settings dict, which is returned from `build.get_compiler_setting()`.