### PR TITLE
Add `cudaLaunchHostFunc`

### DIFF
--- a/cupy/cuda/stream.pyx
+++ b/cupy/cuda/stream.pyx
@@ -215,15 +215,11 @@ class BaseStream(object):
             arg (object): Argument to the callback.
 
         .. note::
-            Whenever possible, using the :meth:`launch_host_func` method
+            Whenever possible, use the :meth:`launch_host_func` method
             instead of this one, as it may be deprecated and removed from
             CUDA at some point.
 
         """
-        if runtime._is_hip_environment and self.ptr == 0:
-            raise RuntimeError('HIP does not allow adding callbacks to the '
-                               'default (null) stream')
-
         def f(stream, status, dummy):
             callback(self, status, arg)
 
@@ -238,7 +234,7 @@ class BaseStream(object):
             arg (object): Argument to the callback.
 
         .. note::
-            Whenever possible, using this method is recommended over
+            Whenever possible, this method is recommended over
             :meth:`add_callback`, which may be deprecated and removed from
             CUDA at some point.
 

--- a/cupy/cuda/stream.pyx
+++ b/cupy/cuda/stream.pyx
@@ -224,6 +224,20 @@ class BaseStream(object):
 
         runtime.streamAddCallback(self.ptr, f, 0)
 
+    def launch_host_func(self, callback, arg):
+        """Launch a callback on host when all queued work is done.
+
+        Args:
+            callback (function): Callback function. It must take only one
+                argument (user data object), and returns nothing.
+            arg (object): Argument to the callback.
+
+        """
+        def f(dummy):
+            callback(arg)
+
+        runtime.launchHostFunc(self.ptr, f, 0)
+
     def record(self, event=None):
         """Records an event on the stream.
 

--- a/cupy/cuda/stream.pyx
+++ b/cupy/cuda/stream.pyx
@@ -214,6 +214,11 @@ class BaseStream(object):
                 object), and returns nothing.
             arg (object): Argument to the callback.
 
+        .. note::
+            Whenever possible, using the :meth:`launch_host_func` method
+            instead of this one, as it may be deprecated and removed from
+            CUDA at some point.
+
         """
         if runtime._is_hip_environment and self.ptr == 0:
             raise RuntimeError('HIP does not allow adding callbacks to the '
@@ -231,6 +236,16 @@ class BaseStream(object):
             callback (function): Callback function. It must take only one
                 argument (user data object), and returns nothing.
             arg (object): Argument to the callback.
+
+        .. note::
+            Whenever possible, using this method is recommended over
+            :meth:`add_callback`, which may be deprecated and removed from
+            CUDA at some point.
+
+        .. seealso:: `cudaLaunchHostFunc()`_
+
+        .. _cudaLaunchHostFunc():
+            https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__EXECUTION.html#group__CUDART__EXECUTION_1g05841eaa5f90f27124241baafb3e856f
 
         """
         def f(dummy):

--- a/cupy_backends/cuda/api/runtime.pxd
+++ b/cupy_backends/cuda/api/runtime.pxd
@@ -800,6 +800,7 @@ cpdef streamDestroy(intptr_t stream)
 cpdef streamSynchronize(intptr_t stream)
 cpdef streamAddCallback(intptr_t stream, callback, intptr_t arg,
                         unsigned int flags=*)
+cpdef launchHostFunc(intptr_t stream, callback, intptr_t arg)
 cpdef streamQuery(intptr_t stream)
 cpdef streamWaitEvent(intptr_t stream, intptr_t event, unsigned int flags=*)
 cpdef intptr_t eventCreate() except? 0

--- a/cupy_backends/cuda/api/runtime.pyx
+++ b/cupy_backends/cuda/api/runtime.pyx
@@ -61,6 +61,9 @@ cdef extern from *:
         driver.Stream stream, Error status, void* userData)
     ctypedef StreamCallbackDef* StreamCallback 'cudaStreamCallback_t'
 
+    ctypedef void HostFnDef(void* userData)
+    ctypedef HostFnDef* HostFn 'cudaHostFn_t'
+
 
 cdef extern from '../cupy_cuda_runtime.h' nogil:
 
@@ -170,6 +173,7 @@ cdef extern from '../cupy_cuda_runtime.h' nogil:
     int cudaStreamSynchronize(driver.Stream stream)
     int cudaStreamAddCallback(driver.Stream stream, StreamCallback callback,
                               void* userData, unsigned int flags)
+    int cudaLaunchHostFunc(driver.Stream stream, HostFn fn, void* userData)
     int cudaStreamQuery(driver.Stream stream)
     int cudaStreamWaitEvent(driver.Stream stream, driver.Event event,
                             unsigned int flags)
@@ -798,6 +802,13 @@ cdef _streamCallbackFunc(driver.Stream hStream, int status,
     cpython.Py_DECREF(obj)
 
 
+cdef _HostFnFunc(void* func_arg) with gil:
+    obj = <object>func_arg
+    func, arg = obj
+    func(arg)
+    cpython.Py_DECREF(obj)
+
+
 cpdef streamAddCallback(intptr_t stream, callback, intptr_t arg,
                         unsigned int flags=0):
     func_arg = (callback, arg)
@@ -806,6 +817,21 @@ cpdef streamAddCallback(intptr_t stream, callback, intptr_t arg,
         status = cudaStreamAddCallback(
             <driver.Stream>stream, <StreamCallback>_streamCallbackFunc,
             <void*>func_arg, flags)
+    check_status(status)
+
+
+cpdef launchHostFunc(intptr_t stream, callback, intptr_t arg):
+    if _is_hip_environment:
+        raise RuntimeError('This feature is not supported on HIP')
+    if CUDA_VERSION < 10000:
+        raise RuntimeError('This feature is only supported on CUDA 10.0+')
+
+    func_arg = (callback, arg)
+    cpython.Py_INCREF(func_arg)
+    with nogil:
+        status = cudaLaunchHostFunc(
+            <driver.Stream>stream, <HostFn>_HostFnFunc,
+            <void*>func_arg)
     check_status(status)
 
 

--- a/cupy_backends/cuda/api/runtime.pyx
+++ b/cupy_backends/cuda/api/runtime.pyx
@@ -811,6 +811,9 @@ cdef _HostFnFunc(void* func_arg) with gil:
 
 cpdef streamAddCallback(intptr_t stream, callback, intptr_t arg,
                         unsigned int flags=0):
+    if _is_hip_environment and stream == 0:
+        raise RuntimeError('HIP does not allow adding callbacks to the '
+                           'default (null) stream')
     func_arg = (callback, arg)
     cpython.Py_INCREF(func_arg)
     with nogil:

--- a/cupy_backends/cuda/hip/cupy_common.h
+++ b/cupy_backends/cuda/hip/cupy_common.h
@@ -69,6 +69,7 @@ typedef hipDeviceProp_t cudaDeviceProp;
 
 
 typedef hipStreamCallback_t cudaStreamCallback_t;
+typedef void (*cudaHostFn_t)(void* userData);
 typedef hipPointerAttribute_t cudaPointerAttributes;
 
 typedef hipChannelFormatKind cudaChannelFormatKind;

--- a/cupy_backends/cuda/hip/cupy_runtime.h
+++ b/cupy_backends/cuda/hip/cupy_runtime.h
@@ -256,6 +256,10 @@ cudaError_t cudaStreamAddCallback(cudaStream_t stream,
     return hipStreamAddCallback(stream, callback, userData, flags);
 }
 
+cudaError_t cudaLaunchHostFunc(cudaStream_t stream, cudaHostFn_t fn, void* userData) {
+    return hipErrorUnknown;
+}
+
 cudaError_t cudaStreamQuery(cudaStream_t stream) {
     return hipStreamQuery(stream);
 }

--- a/cupy_backends/cuda/stub/cupy_cuda_runtime.h
+++ b/cupy_backends/cuda/stub/cupy_cuda_runtime.h
@@ -237,6 +237,10 @@ cudaError_t cudaStreamAddCallback(...) {
     return cudaSuccess;
 }
 
+cudaError_t cudaLaunchHostFunc(...) {
+    return cudaSuccess;
+}
+
 cudaError_t cudaStreamQuery(...) {
     return cudaSuccess;
 }

--- a/docs/source/reference/cuda.rst
+++ b/docs/source/reference/cuda.rst
@@ -172,6 +172,7 @@ to use these functions.
    cupy.cuda.runtime.streamAddCallback
    cupy.cuda.runtime.streamQuery
    cupy.cuda.runtime.streamWaitEvent
+   cupy.cuda.runtime.launchHostFunc
    cupy.cuda.runtime.eventCreate
    cupy.cuda.runtime.eventCreateWithFlags
    cupy.cuda.runtime.eventDestroy

--- a/tests/cupy_tests/cuda_tests/test_stream.py
+++ b/tests/cupy_tests/cuda_tests/test_stream.py
@@ -61,6 +61,8 @@ class TestStream(unittest.TestCase):
 
     @attr.gpu
     @unittest.skipIf(cuda.runtime.is_hip, 'HIP does not support this')
+    @unittest.skipIf(cuda.driver.get_build_version() < 10000,
+                     'Only CUDA 10.0+ supports this')
     def test_launch_host_func(self):
         N = 100
         cupy_arrays = [testing.shaped_random((2, 3)) for _ in range(N)]
@@ -124,6 +126,8 @@ class TestExternalStream(unittest.TestCase):
 
     @attr.gpu
     @unittest.skipIf(cuda.runtime.is_hip, 'HIP does not support this')
+    @unittest.skipIf(cuda.driver.get_build_version() < 10000,
+                     'Only CUDA 10.0+ supports this')
     def test_launch_host_func(self):
         N = 100
         cupy_arrays = [testing.shaped_random((2, 3)) for _ in range(N)]

--- a/tests/cupy_tests/cuda_tests/test_stream.py
+++ b/tests/cupy_tests/cuda_tests/test_stream.py
@@ -60,6 +60,23 @@ class TestStream(unittest.TestCase):
         assert out == list(range(N))
 
     @attr.gpu
+    @unittest.skipIf(cuda.runtime.is_hip, 'HIP does not support this')
+    def test_launch_host_func(self):
+        N = 100
+        cupy_arrays = [testing.shaped_random((2, 3)) for _ in range(N)]
+
+        stream = cuda.Stream.null
+
+        out = []
+        for i in range(N):
+            numpy_array = cupy_arrays[i].get(stream=stream)
+            stream.launch_host_func(
+                lambda t: out.append(t[0]), (i, numpy_array))
+
+        stream.synchronize()
+        assert out == list(range(N))
+
+    @attr.gpu
     def test_with_statement(self):
         stream1 = cuda.Stream()
         stream2 = cuda.Stream()
@@ -93,11 +110,7 @@ class TestExternalStream(unittest.TestCase):
         N = 100
         cupy_arrays = [testing.shaped_random((2, 3)) for _ in range(N)]
 
-        if not cuda.runtime.is_hip:
-            stream = cuda.Stream.null
-        else:
-            # adding callbacks to the null stream in HIP would segfault...
-            stream = cuda.Stream()
+        stream = self.stream
 
         out = []
         for i in range(N):
@@ -105,6 +118,23 @@ class TestExternalStream(unittest.TestCase):
             stream.add_callback(
                 lambda _, __, t: out.append(t[0]),
                 (i, numpy_array))
+
+        stream.synchronize()
+        assert out == list(range(N))
+
+    @attr.gpu
+    @unittest.skipIf(cuda.runtime.is_hip, 'HIP does not support this')
+    def test_launch_host_func(self):
+        N = 100
+        cupy_arrays = [testing.shaped_random((2, 3)) for _ in range(N)]
+
+        stream = self.stream
+
+        out = []
+        for i in range(N):
+            numpy_array = cupy_arrays[i].get(stream=stream)
+            stream.launch_host_func(
+                lambda t: out.append(t[0]), (i, numpy_array))
 
         stream.synchronize()
         assert out == list(range(N))


### PR DESCRIPTION
According to the [CUDA Runtime API documentation](https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__STREAM.html#group__CUDART__STREAM_1g74aa9f4b1c2f12d994bf13876a5a2498), `cudaStreamAddCallback` will be deprecated in favor of this new function, added since CUDA 10.0:
> This function is slated for eventual deprecation and removal. If you do not require the callback to execute in case of a device error, consider using `cudaLaunchHostFunc`. Additionally, this function is not supported with `cudaStreamBeginCapture` and `cudaStreamEndCapture`, unlike `cudaLaunchHostFunc`.

TODO:
- [x] Skip tests for CUDA 9.x
- [x] Add stubs
