### PR TITLE
Tentatively hide CUPY_NUM_BUILD_JOBS option

### DIFF
--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -1088,6 +1088,8 @@ class custom_build_ext(build_ext.build_ext):
         build_ext.build_ext.run(self)
 
     def build_extensions(self):
-        num_jobs = int(os.environ.get('CUPY_NUM_BUILD_JOBS', '4'))
-        self.parallel = num_jobs
+        # TODO(kmaehashi): This option may be unstable, under investigation
+        num_jobs = int(os.environ.get('CUPY_NUM_BUILD_JOBS', '1'))
+        if num_jobs > 1:
+            self.parallel = num_jobs
         super().build_extensions()

--- a/docs/source/reference/environment.rst
+++ b/docs/source/reference/environment.rst
@@ -104,7 +104,3 @@ These environment variables are used during installation (building CuPy from sou
 |                              | architectures in build time. When this is not set,             |
 |                              | the default is to support all architectures.                   |
 +------------------------------+----------------------------------------------------------------+
-| ``CUPY_CUPY_NUM_BUILD_JOBS`` | To enable or disable parallel build, sets the number of        |
-|                              | processes used to build the extensions in parallel. Defaults   |
-|                              | to ``4``                                                       |
-+------------------------------+----------------------------------------------------------------+


### PR DESCRIPTION
During the wheel build release process (which is a very high load situation where CuPy build for all CUDA versions are run simultaneously) I found that the parallel build cause build failures for some reason.

(1) https://jenkins.preferred.jp/job/chainer/job/other_cupy_release_builder/130/CUDA=9.0,PYTHON=3.7.0,label=mn1-p100/consoleFull

```
21:13:53 /usr/local/cuda/bin/nvcc -D_FORCE_INLINES=1 -DCUPY_CUB_VERSION_CODE=100800 -DCUPY_JITIFY_VERSION_CODE=60e9e72 -I/work/cupy/install/../cupy/core/include/cupy/cub -I/work/cupy/install/../cupy/core/include -I/usr/local/cuda/include -I/opt/pyenv/versions/3.7.0/include/python3.7m -c cupy/cuda/thrust.cpp -o build/temp.linux-x86_64-3.7/cupy/cuda/thrust.o -fopenmp --std=c++11
21:13:53 nvcc fatal   : Unknown option 'fopenmp'
```

-> This issue disappeared by #4336

(2) https://jenkins.preferred.jp/job/chainer/job/other_cupy_release_builder/132/CUDA=9.0,PYTHON=3.7.0,label=mn1-p100/console

```
02:50:58 /opt/rh/devtoolset-6/root/usr/libexec/gcc/x86_64-redhat-linux/6.2.1/ld: build/temp.linux-x86_64-3.7/cupy/cuda/thrust.o: relocation R_X86_64_32S against `.rodata' can not be used when making a shared object; recompile with -fPIC
```

Setting `CUPY_NUM_BUILD_JOBS=1` resolved the issue, so I would like to disable this option for now but leave it for further investigation.