### PR TITLE
Apply fixes to the FFT callback module

### DIFF
--- a/cupy/fft/config.py
+++ b/cupy/fft/config.py
@@ -9,9 +9,12 @@ from cupy.fft._cache import get_plan_cache_max_memsize  # NOQA
 from cupy.fft._cache import set_plan_cache_max_memsize  # NOQA
 from cupy.fft._cache import show_plan_cache_info  # NOQA
 
-# expose callback handles to this module
-from cupy.fft._callback import get_current_callback_manager  # NOQA
-from cupy.fft._callback import set_cufft_callbacks  # NOQA
+# on Linux, expose callback handles to this module
+import sys
+if sys.platform.startswith('linux'):
+    from cupy.fft._callback import get_current_callback_manager  # NOQA
+    from cupy.fft._callback import set_cufft_callbacks  # NOQA
+del sys
 
 
 enable_nd_planning = True

--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -600,6 +600,9 @@ def make_extensions(options, compiler, use_cython):
             s_file = copy.deepcopy(s)
             name = module_extension_name(f)
 
+            if name.endswith('fft._callback') and not PLATFORM_LINUX:
+                continue
+
             rpath = []
             if not options['no_rpath']:
                 # Add library directories (e.g., `/usr/local/cuda/lib64`) to


### PR DESCRIPTION
Close #4352. This PR adds a few extra safes:
1. For Windows, we do not build the module `cupy.fft._callback` as it cannot be used on Windows anyway 
2. We defer the initialization of the module-level variables, so even if there's any error it won't happen at import time
3. We honor the `CXX` environment variable if `sysconfig` cannot find `CXX` (I don't understand how's that possible, but at least it's the root cause of the reported error).