### PR TITLE
add cupyx.scipy.ndimage.fourier_ellipsoid

### DIFF
--- a/cupyx/scipy/ndimage/__init__.py
+++ b/cupyx/scipy/ndimage/__init__.py
@@ -23,6 +23,7 @@ from cupyx.scipy.ndimage.filters import percentile_filter  # NOQA
 from cupyx.scipy.ndimage.filters import generic_filter  # NOQA
 from cupyx.scipy.ndimage.filters import generic_filter1d  # NOQA
 
+from cupyx.scipy.ndimage.fourier import fourier_ellipsoid  # NOQA
 from cupyx.scipy.ndimage.fourier import fourier_gaussian  # NOQA
 from cupyx.scipy.ndimage.fourier import fourier_shift  # NOQA
 from cupyx.scipy.ndimage.fourier import fourier_uniform  # NOQA

--- a/cupyx/scipy/ndimage/fourier.py
+++ b/cupyx/scipy/ndimage/fourier.py
@@ -3,6 +3,7 @@ import numpy
 import cupy
 from cupy.core import internal
 from cupyx.scipy.ndimage import _util
+from cupyx.scipy import special
 
 
 def _get_output_fourier(output, input, complex_only=False):
@@ -17,10 +18,10 @@ def _get_output_fourier(output, input, complex_only=False):
             output = cupy.zeros(input.shape, dtype=types[-1])
     elif type(output) is type:
         if output not in types:
-            raise RuntimeError("output type not supported")
+            raise RuntimeError('output type not supported')
         output = cupy.zeros(input.shape, dtype=output)
     elif output.shape != input.shape:
-        raise RuntimeError("output shape not correct")
+        raise RuntimeError('output shape not correct')
     return output
 
 
@@ -178,5 +179,74 @@ def fourier_shift(input, shift, n=-1, axis=-1, output=None):
         # reshape for broadcasting
         arr = _reshape_nd(arr, ndim=ndim, axis=ax)
         output *= arr
+
+    return output
+
+
+def fourier_ellipsoid(input, size, n=-1, axis=-1, output=None):
+    """Multidimensional ellipsoid Fourier filter.
+
+    The array is multiplied with the fourier transform of a ellipsoid of
+    given sizes.
+
+    Args:
+        input (cupy.ndarray): The input array.
+        size (float or sequence of float):  The size of the box used for
+            filtering. If a float, `size` is the same for all axes. If a
+            sequence, `size` has to contain one value for each axis.
+        n (int, optional):  If `n` is negative (default), then the input is
+            assumed to be the result of a complex fft. If `n` is larger than or
+            equal to zero, the input is assumed to be the result of a real fft,
+            and `n` gives the length of the array before transformation along
+            the real transform direction.
+        axis (int, optional): The axis of the real transform (only used when
+            ``n > -1``).
+        output (cupy.ndarray, optional):
+            If given, the result of shifting the input is placed in this array.
+
+    Returns:
+        output (cupy.ndarray): The filtered output.
+    """
+    ndim = input.ndim
+    if ndim == 1:
+        return fourier_uniform(input, size, n, axis, output)
+
+    if ndim > 3:
+        # Note: SciPy currently does not do any filtering on >=4d inputs, but
+        #       does not warn about this!
+        raise NotImplementedError('Only 1d, 2d and 3d inputs are supported')
+    output = _get_output_fourier(output, input)
+    axis = internal._normalize_axis_index(axis, ndim)
+    sizes = _util._fix_sequence_arg(size, ndim, 'size')
+
+    output[...] = input
+
+    # compute the distance from the origin for all samples in Fourier space
+    distance = 0
+    for ax, (size, ax_size) in enumerate(zip(sizes, output.shape)):
+        # compute the frequency grid in Hz
+        if ax == axis and n > 0:
+            arr = cupy.arange(ax_size, dtype=output.real.dtype)
+            arr *= numpy.pi * size / n
+        else:
+            arr = cupy.fft.fftfreq(ax_size)
+            arr *= numpy.pi * size
+        arr = arr.astype(output.real.dtype, copy=False)
+        arr *= arr
+        arr = _reshape_nd(arr, ndim=ndim, axis=ax)
+        distance = distance + arr
+    cupy.sqrt(distance, out=distance)
+
+    if ndim == 2:
+        special.j1(distance, out=output)
+        output *= 2
+        output /= distance
+    elif ndim == 3:
+        cupy.sin(distance, out=output)
+        output -= distance * cupy.cos(distance)
+        output *= 3
+        output /= distance ** 3
+    output[(0,) * ndim] = 1.0  # avoid NaN in corner at frequency=0 location
+    output *= input
 
     return output

--- a/docs/source/reference/ndimage.rst
+++ b/docs/source/reference/ndimage.rst
@@ -49,6 +49,7 @@ Fourier Filters
    :toctree: generated/
    :nosignatures:
 
+   cupyx.scipy.ndimage.fourier_ellipsoid
    cupyx.scipy.ndimage.fourier_gaussian
    cupyx.scipy.ndimage.fourier_shift
    cupyx.scipy.ndimage.fourier_uniform

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_fourier.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_fourier.py
@@ -305,7 +305,7 @@ class TestFourierUniform:
 )
 @testing.gpu
 @testing.with_requires('scipy')
-class TestFourierEllipsoid(unittest.TestCase):
+class TestFourierEllipsoid():
     def _test_real_nd(self, xp, scp, x, real_axis):
         if x.ndim == 1 and scipy_version < '1.5.3':
             # 1D case gives an incorrect result in SciPy < 1.5.3
@@ -374,7 +374,7 @@ class TestFourierEllipsoid(unittest.TestCase):
         return xp.ascontiguousarray(a)
 
 
-class TestFourierEllipsoidInvalid(unittest.TestCase):
+class TestFourierEllipsoidInvalid():
 
     def test_0d_input(self):
         for xp, scp in zip((numpy, cupy), (scipy, cupyx.scipy)):

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_fourier.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_fourier.py
@@ -1,6 +1,7 @@
 import cupy
 import numpy
 import pytest
+import scipy
 
 from cupy import testing
 # TODO (grlee77): use fft instead of fftpack once min. supported scipy >= 1.4

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_fourier.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_fourier.py
@@ -1,7 +1,6 @@
 import cupy
 import numpy
 import pytest
-import scipy
 
 from cupy import testing
 # TODO (grlee77): use fft instead of fftpack once min. supported scipy >= 1.4
@@ -10,13 +9,19 @@ import cupyx.scipy.fftpack  # NOQA
 import cupyx.scipy.ndimage  # NOQA
 
 try:
+    # scipy.fft only available since SciPy 1.4.0
     import scipy.fft  # NOQA
 except ImportError:
     pass
-finally:
+
+try:
+    # These modules will be present in all supported SciPy versions
+    import scipy
     import scipy.fftpack  # NOQA
     import scipy.ndimage  # NOQA
     scipy_version = numpy.lib.NumpyVersion(scipy.__version__)
+except ImportError:
+    pass
 
 
 @testing.parameterize(
@@ -376,6 +381,8 @@ class TestFourierEllipsoid():
         return xp.ascontiguousarray(a)
 
 
+@testing.gpu
+@testing.with_requires('scipy')
 class TestFourierEllipsoidInvalid():
 
     # SciPy < 1.5 raises ValueError instead of AxisError

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_fourier.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_fourier.py
@@ -11,11 +11,12 @@ import cupyx.scipy.ndimage  # NOQA
 
 try:
     import scipy.fft  # NOQA
+except ImportError:
+    pass
+finally:
     import scipy.fftpack  # NOQA
     import scipy.ndimage  # NOQA
     scipy_version = numpy.lib.NumpyVersion(scipy.__version__)
-except ImportError:
-    pass
 
 
 @testing.parameterize(
@@ -377,6 +378,8 @@ class TestFourierEllipsoid():
 
 class TestFourierEllipsoidInvalid():
 
+    # SciPy < 1.5 raises ValueError instead of AxisError
+    @testing.with_requires('scipy>=1.5.0')
     def test_0d_input(self):
         for xp, scp in zip((numpy, cupy), (scipy, cupyx.scipy)):
             with pytest.raises(numpy.AxisError):
@@ -392,6 +395,8 @@ class TestFourierEllipsoidInvalid():
                 scp.ndimage.fourier_ellipsoid(xp.ones(shape), size=2)
         return
 
+    # SciPy < 1.5 raises ValueError instead of AxisError
+    @testing.with_requires('scipy>=1.5.0')
     def test_invalid_axis(self):
         # SciPy should raise here too because >3d isn't implemented, but
         # as of 1.5.4, it does not.

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_fourier.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_fourier.py
@@ -1,4 +1,6 @@
+import cupy
 import numpy
+import pytest
 
 from cupy import testing
 # TODO (grlee77): use fft instead of fftpack once min. supported scipy >= 1.4
@@ -10,6 +12,7 @@ try:
     import scipy.fft  # NOQA
     import scipy.fftpack  # NOQA
     import scipy.ndimage  # NOQA
+    scipy_version = numpy.lib.NumpyVersion(scipy.__version__)
 except ImportError:
     pass
 
@@ -276,3 +279,135 @@ class TestFourierUniform:
         if not x.dtype.kind == 'c':
             a = a.real
         return xp.ascontiguousarray(a)
+
+
+@testing.parameterize(
+    *(
+        testing.product(
+            {
+                'shape': [(32, 16), (31, 15)],
+                'size': [1, (5, 5), (3, 5)],
+            }
+        )
+        + testing.product(
+            {
+                'shape': [(5, 16, 7)],
+                'size': [3, (1, 2, 4)],
+            }
+        )
+        + testing.product(
+            {
+                'shape': [(15, ), ],
+                'size': [8, (5,)],
+            }
+        )
+    )
+)
+@testing.gpu
+@testing.with_requires('scipy')
+class TestFourierEllipsoid(unittest.TestCase):
+    def _test_real_nd(self, xp, scp, x, real_axis):
+        if x.ndim == 1 and scipy_version < '1.5.3':
+            # 1D case gives an incorrect result in SciPy < 1.5.3
+            pytest.skip('scipy version to old')
+
+        a = scp.fft.rfft(x, axis=real_axis)
+        # complex-valued FFTs on all other axes
+        complex_axes = tuple([ax for ax in range(x.ndim) if ax != real_axis])
+        if complex_axes:
+            a = scp.fft.fftn(a, axes=complex_axes)
+
+        a = scp.ndimage.fourier_ellipsoid(
+            a, self.size, n=x.shape[real_axis], axis=real_axis
+        )
+
+        if complex_axes:
+            a = scp.fft.ifftn(a, axes=complex_axes)
+        a = scp.fft.irfft(a, axis=real_axis)
+        if not x.dtype.kind == 'c':
+            a = a.real
+        return xp.ascontiguousarray(a)
+
+    @testing.with_requires('scipy>=1.4.0')
+    @testing.for_all_dtypes(no_complex=True)
+    @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
+    def test_real_fft_axis0(self, xp, scp, dtype):
+        x = testing.shaped_random(self.shape, xp, dtype)
+        return self._test_real_nd(xp, scp, x, 0)
+
+    @testing.with_requires('scipy>=1.4.0')
+    @testing.for_all_dtypes(no_complex=True)
+    @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
+    def test_real_fft_axis1(self, xp, scp, dtype):
+        x = testing.shaped_random(self.shape, xp, dtype)
+        if x.ndim < 2:
+            # skip: there is no axis=1 on 1d arrays
+            return x
+        return self._test_real_nd(xp, scp, x, 1)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
+    def test_complex_fft(self, xp, scp, dtype):
+        x = testing.shaped_random(self.shape, xp, dtype)
+        if x.ndim == 1 and scipy_version < '1.5.3':
+            # 1D case gives an incorrect result in SciPy < 1.5.3
+            pytest.skip('scipy version to old')
+        a = scp.fftpack.fftn(x)
+        a = scp.ndimage.fourier_ellipsoid(a, self.size)
+        a = scp.fftpack.ifftn(a)
+        if not x.dtype.kind == 'c':
+            a = a.real
+        return xp.ascontiguousarray(a)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
+    def test_complex_fft_with_output(self, xp, scp, dtype):
+        x = testing.shaped_random(self.shape, xp, dtype)
+        if x.ndim == 1 and scipy_version < '1.5.3':
+            # 1D case gives an incorrect result in SciPy < 1.5.3
+            pytest.skip('scipy version to old')
+        a = scp.fftpack.fftn(x)
+        scp.ndimage.fourier_ellipsoid(a.copy(), self.size, output=a)
+        a = scp.fftpack.ifftn(a)
+        if not x.dtype.kind == 'c':
+            a = a.real
+        return xp.ascontiguousarray(a)
+
+
+class TestFourierEllipsoidInvalid(unittest.TestCase):
+
+    def test_0d_input(self):
+        for xp, scp in zip((numpy, cupy), (scipy, cupyx.scipy)):
+            with pytest.raises(numpy.AxisError):
+                scp.ndimage.fourier_ellipsoid(xp.asarray(5.0), size=2)
+        return
+
+    def test_4d_input(self):
+        # SciPy should raise here too because >3d isn't implemented, but
+        # as of 1.5.4, it does not.
+        shape = (4, 6, 8, 10)
+        for xp, scp in zip((cupy,), (cupyx.scipy,)):
+            with pytest.raises(NotImplementedError):
+                scp.ndimage.fourier_ellipsoid(xp.ones(shape), size=2)
+        return
+
+    def test_invalid_axis(self):
+        # SciPy should raise here too because >3d isn't implemented, but
+        # as of 1.5.4, it does not.
+        shape = (6, 8)
+        for xp, scp in zip((numpy, cupy), (scipy, cupyx.scipy)):
+            with pytest.raises(numpy.AxisError):
+                scp.ndimage.fourier_ellipsoid(xp.ones(shape), 2, axis=2)
+            with pytest.raises(numpy.AxisError):
+                scp.ndimage.fourier_ellipsoid(xp.ones(shape), 2, axis=-3)
+        return
+
+    def test_invalid_size(self):
+        # test size length mismatch
+        shape = (6, 8)
+        for xp, scp in zip((numpy, cupy), (scipy, cupyx.scipy)):
+            with pytest.raises(RuntimeError):
+                scp.ndimage.fourier_ellipsoid(xp.ones(shape), size=(2, 3, 4))
+            with pytest.raises(RuntimeError):
+                scp.ndimage.fourier_ellipsoid(xp.ones(shape), size=(4,))
+        return


### PR DESCRIPTION
This adds the `fourier_ellipsoid` filter, completing the `cupyx.scipy.ndimage.fourier` module. Unlike the other Fourier filters, this one is not separable and is not truly n-dimensional (as in SciPy itself, only 1d, 2d and 3d cases are implemented).