### PR TITLE
Fix `rcond` arg of `linalg.lstsq`

### DIFF
--- a/cupy/linalg/_solve.py
+++ b/cupy/linalg/_solve.py
@@ -251,6 +251,9 @@ def lstsq(a, b, rcond='warn'):
 
     if rcond is None:
         rcond = numpy.finfo(s.dtype).eps * max(m, n)
+    elif rcond <= 0 or rcond >= 1:
+        # some doc of gelss/gelsd says "rcond < 0", but it's not true!
+        rcond = numpy.finfo(s.dtype).eps
 
     # number of singular values and matrix rank
     cutoff = rcond * s.max()

--- a/cupy/linalg/_solve.py
+++ b/cupy/linalg/_solve.py
@@ -259,7 +259,7 @@ def lstsq(a, b, rcond='warn'):
     s1 = 1 / s
     sing_vals = s <= cutoff
     s1[sing_vals] = 0
-    rank = s.size - sing_vals.sum()
+    rank = s.size - sing_vals.sum(dtype=numpy.int32)
 
     if b.ndim == 2:
         s1 = cupy.repeat(s1.reshape(-1, 1), b.shape[1], axis=1)

--- a/cupy/linalg/_solve.py
+++ b/cupy/linalg/_solve.py
@@ -231,11 +231,10 @@ def lstsq(a, b, rcond='warn'):
             'machine precision times ``max(M, N)`` where M and N '
             'are the input matrix dimensions.\n'
             'To use the future default and silence this warning '
-            'we advise to pass `rcond=None`.\n'
-            'Using the old CuPy default: `rcond=1e-15`, which is '
-            'neither the same as the old NumPy default (`rcond=-1`).',
+            'we advise to pass `rcond=None`, to keep using the old, '
+            'explicitly pass `rcond=-1`.',
             FutureWarning)
-        rcond = 1e-15
+        rcond = -1
 
     _util._assert_cupy_array(a, b)
     _util._assert_rank2(a)

--- a/tests/cupy_tests/linalg_tests/test_solve.py
+++ b/tests/cupy_tests/linalg_tests/test_solve.py
@@ -264,10 +264,7 @@ class TestLstsq(unittest.TestCase):
         a = testing.shaped_random((3, 3), xp, dtype)
         b = testing.shaped_random((3,), xp, dtype)
         with testing.assert_warns(FutureWarning):
-            x, residuals, rank, s = xp.linalg.lstsq(a, b)
-        # ignore dtype of rank
-        rank = rank.astype(xp.int64)
-        return x, residuals, rank, s
+            return xp.linalg.lstsq(a, b)
 
 
 @testing.gpu

--- a/tests/cupy_tests/linalg_tests/test_solve.py
+++ b/tests/cupy_tests/linalg_tests/test_solve.py
@@ -235,13 +235,16 @@ class TestLstsq(unittest.TestCase):
                     seed = i + j + k
                     # check when b has shape (i, k)
                     self.check_lstsq_solution((i, j), (i, k), seed,
+                                              rcond=-1)
+                    self.check_lstsq_solution((i, j), (i, k), seed,
                                               rcond=None)
                     self.check_lstsq_solution((i, j), (i, k), seed,
                                               rcond=0.5)
                     self.check_lstsq_solution((i, j), (i, k), seed,
                                               rcond=1e-7, singular=True)
                 # check when b has shape (i, )
-                self.check_lstsq_solution((i, j), (i, ), seed+1, rcond=1e-15)
+                self.check_lstsq_solution((i, j), (i, ), seed+1, rcond=-1)
+                self.check_lstsq_solution((i, j), (i, ), seed+1, rcond=None)
                 self.check_lstsq_solution((i, j), (i, ), seed+1, rcond=0.5)
                 self.check_lstsq_solution((i, j), (i, ), seed+1, rcond=1e-7,
                                           singular=True)

--- a/tests/cupy_tests/linalg_tests/test_solve.py
+++ b/tests/cupy_tests/linalg_tests/test_solve.py
@@ -222,7 +222,7 @@ class TestLstsq(unittest.TestCase):
         a = cupy.random.rand(*a_shape)
         b = cupy.random.rand(*b_shape)
         with self.assertRaises(numpy.linalg.LinAlgError):
-            cupy.linalg.lstsq(a, b)
+            cupy.linalg.lstsq(a, b, rcond=None)
 
     def test_lstsq_solutions(self):
         # Comapres numpy.linalg.lstsq and cupy.linalg.lstsq solutions for:
@@ -235,7 +235,7 @@ class TestLstsq(unittest.TestCase):
                     seed = i + j + k
                     # check when b has shape (i, k)
                     self.check_lstsq_solution((i, j), (i, k), seed,
-                                              rcond=1e-15)
+                                              rcond=None)
                     self.check_lstsq_solution((i, j), (i, k), seed,
                                               rcond=0.5)
                     self.check_lstsq_solution((i, j), (i, k), seed,
@@ -254,6 +254,17 @@ class TestLstsq(unittest.TestCase):
         self.check_invalid_shapes((2, 2), (10, ))
         self.check_invalid_shapes((3, 3), (2, 2))
         self.check_invalid_shapes((4, 3), (10, 3, 3))
+
+    @testing.for_float_dtypes(no_float16=True)
+    @testing.numpy_cupy_allclose(atol=1e-3)
+    def test_warn_rcond(self, xp, dtype):
+        a = testing.shaped_random((3, 3), xp, dtype)
+        b = testing.shaped_random((3,), xp, dtype)
+        with testing.assert_warns(FutureWarning):
+            x, residuals, rank, s = xp.linalg.lstsq(a, b)
+        # ignore dtype of rank
+        rank = rank.astype(xp.int64)
+        return x, residuals, rank, s
 
 
 @testing.gpu


### PR DESCRIPTION
- The default is `rcond='warn'`, which fallbacks to `rcond=-1`.
- Negative `rcond` should be treated as the machine precision.
- NumPy's future default `rcond=None` is max(m, n) times machine precision.
