### PR TITLE
add cupyx.scipy.stats.entropy

### DIFF
--- a/cupyx/scipy/stats/__init__.py
+++ b/cupyx/scipy/stats/__init__.py
@@ -1,0 +1,1 @@
+from cupyx.scipy.stats.distributions import entropy  # NOQA

--- a/cupyx/scipy/stats/distributions.py
+++ b/cupyx/scipy/stats/distributions.py
@@ -1,5 +1,4 @@
 import math
-import numpy
 
 import cupy
 from cupyx.scipy import special
@@ -18,19 +17,19 @@ def _normalize(x, axis):
 def entropy(pk, qk=None, base=None, axis=0):
     """Calculate the entropy of a distribution for given probability values.
 
-    If only probabilities `pk` are given, the entropy is calculated as
+    If only probabilities ``pk`` are given, the entropy is calculated as
     ``S = -sum(pk * log(pk), axis=axis)``.
 
-    If `qk` is not None, then compute the Kullback-Leibler divergence
+    If ``qk`` is not None, then compute the Kullback-Leibler divergence
     ``S = sum(pk * log(pk / qk), axis=axis)``.
 
-    This routine will normalize `pk` and `qk` if they don't sum to 1.
+    This routine will normalize ``pk`` and ``qk`` if they don't sum to 1.
 
     Args:
-        pk (sequence): Defines the (discrete) distribution. ``pk[i]`` is the
+        pk (ndarray): Defines the (discrete) distribution. ``pk[i]`` is the
             (possibly unnormalized) probability of event ``i``.
-        qk (sequence, optional): Sequence against which the relative entropy is
-            computed. Should be in the same format as `pk`.
+        qk (ndarray, optional): Sequence against which the relative entropy is
+            computed. Should be in the same format as ``pk``.
         base (float, optional): The logarithmic base to use, defaults to ``e``
             (natural logarithm).
         axis (int, optional): The axis along which the entropy is calculated.

--- a/cupyx/scipy/stats/distributions.py
+++ b/cupyx/scipy/stats/distributions.py
@@ -1,0 +1,55 @@
+import math
+import numpy
+
+import cupy
+from cupyx.scipy import special
+
+
+def entropy(pk, qk=None, base=None, axis=0):
+    """Calculate the entropy of a distribution for given probability values.
+
+    If only probabilities `pk` are given, the entropy is calculated as
+    ``S = -sum(pk * log(pk), axis=axis)``.
+
+    If `qk` is not None, then compute the Kullback-Leibler divergence
+    ``S = sum(pk * log(pk / qk), axis=axis)``.
+
+    This routine will normalize `pk` and `qk` if they don't sum to 1.
+
+    Args:
+        pk (sequence): Defines the (discrete) distribution. ``pk[i]`` is the
+            (possibly unnormalized) probability of event ``i``.
+        qk (sequence, optional): Sequence against which the relative entropy is
+            computed. Should be in the same format as `pk`.
+        base (float, optional): The logarithmic base to use, defaults to ``e``
+            (natural logarithm).
+        axis (int, optional): The axis along which the entropy is calculated.
+            Default is 0.
+
+    Returns:
+        S (cupy.ndarray): The calculated entropy.
+
+    """
+    pk = cupy.asarray(pk)
+    if pk.dtype.kind == 'f':
+        pk /= cupy.sum(pk, axis=axis, keepdims=True)
+    else:
+        pk = pk / cupy.sum(pk, axis=axis, keepdims=True)
+    if qk is None:
+        vec = special.entr(pk)
+    else:
+        qk = cupy.asarray(qk)
+        if qk.shape != pk.shape:
+            raise ValueError("qk and pk must have same shape.")
+        if qk.dtype.kind == 'f':
+            qk /= cupy.sum(qk, axis=axis, keepdims=True)
+        else:
+            qk = qk / cupy.sum(qk, axis=axis, keepdims=True)
+        vec = special.rel_entr(pk, qk)
+    s = cupy.sum(vec, axis=axis)
+    if base is not None:
+        if s.ndim == 0:
+            # required to match scipy output dtype
+            s = s.astype(numpy.float64)
+        s /= math.log(base)
+    return s

--- a/cupyx/scipy/stats/distributions.py
+++ b/cupyx/scipy/stats/distributions.py
@@ -30,21 +30,23 @@ def entropy(pk, qk=None, base=None, axis=0):
         S (cupy.ndarray): The calculated entropy.
 
     """
-    pk = cupy.asarray(pk)
+    pk = pk.astype(cupy.promote_types(pk.dtype, cupy.float32))
+    pk_sum = cupy.sum(pk, axis=axis, keepdims=True)
     if pk.dtype.kind == 'f':
-        pk /= cupy.sum(pk, axis=axis, keepdims=True)
+        pk /= pk_sum
     else:
-        pk = pk / cupy.sum(pk, axis=axis, keepdims=True)
+        pk = pk / pk_sum
     if qk is None:
         vec = special.entr(pk)
     else:
-        qk = cupy.asarray(qk)
         if qk.shape != pk.shape:
             raise ValueError("qk and pk must have same shape.")
+        qk = qk.astype(cupy.promote_types(qk.dtype, cupy.float32))
+        qk_sum = cupy.sum(qk, axis=axis, keepdims=True)
         if qk.dtype.kind == 'f':
-            qk /= cupy.sum(qk, axis=axis, keepdims=True)
+            qk /= qk_sum
         else:
-            qk = qk / cupy.sum(qk, axis=axis, keepdims=True)
+            qk = qk / qk_sum
         vec = special.rel_entr(pk, qk)
     s = cupy.sum(vec, axis=axis)
     if base is not None:

--- a/docs/source/reference/scipy.rst
+++ b/docs/source/reference/scipy.rst
@@ -19,3 +19,4 @@ These functions cover a subset of
    sparse
    special
    signal
+   stats

--- a/docs/source/reference/statistics.rst
+++ b/docs/source/reference/statistics.rst
@@ -1,7 +1,7 @@
 Statistical Functions
 =====================
 
-.. https://docs.scipy.org/doc/scipy/reference/stats.html
+.. https://numpy.org/doc/stable/reference/routines.statistics.html
 
 Order statistics
 ----------------

--- a/docs/source/reference/stats.rst
+++ b/docs/source/reference/stats.rst
@@ -1,0 +1,16 @@
+.. module:: cupyx.scipy.stats
+
+Statistical functions (``scipy.stats``)
+=======================================
+
+.. https://docs.scipy.org/doc/scipy/reference/stats.html
+
+
+Summary statistics
+------------------
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+
+   cupyx.scipy.stats.entropy

--- a/tests/cupyx_tests/scipy_tests/stats_tests/test_distributions.py
+++ b/tests/cupyx_tests/scipy_tests/stats_tests/test_distributions.py
@@ -1,0 +1,130 @@
+import math
+import unittest
+
+import numpy
+import pytest
+
+import cupy
+from cupy import testing
+import cupyx.scipy.stats  # NOQA
+from cupyx.scipy import stats
+
+try:
+    import scipy.stats  # NOQA
+except ImportError:
+    pass
+
+
+@testing.gpu
+class TestEntropyBasic(unittest.TestCase):
+    def test_entropy_positive(self):
+        # See ticket SciPy's gh-497
+        pk = cupy.asarray([0.5, 0.2, 0.3])
+        qk = cupy.asarray([0.1, 0.25, 0.65])
+        eself = stats.entropy(pk, pk)
+        edouble = stats.entropy(pk, qk)
+        assert 0.0 == eself
+        assert edouble >= 0.0
+
+    def test_entropy_base(self):
+        pk = cupy.ones(16, float)
+        s = stats.entropy(pk, base=2.0)
+        assert abs(s - 4.0) < 1.0e-5
+
+        qk = cupy.ones(16, float)
+        qk[:8] = 2.0
+        s = stats.entropy(pk, qk)
+        s2 = stats.entropy(pk, qk, base=2.0)
+        assert abs(s / s2 - math.log(2.0)) < 1.0e-5
+
+    def test_entropy_zero(self):
+        # Test for SciPy PR-479
+        s = stats.entropy(cupy.asarray([0, 1, 2]))
+        expected = 0.63651416829481278
+        assert abs(float(s) - expected) < 1e-12
+
+    def test_entropy_2d(self):
+        pk = cupy.asarray([[0.1, 0.2], [0.6, 0.3], [0.3, 0.5]])
+        qk = cupy.asarray([[0.2, 0.1], [0.3, 0.6], [0.5, 0.3]])
+        testing.assert_array_almost_equal(
+            stats.entropy(pk, qk), [0.1933259, 0.18609809]
+        )
+
+    def test_entropy_2d_zero(self):
+        pk = cupy.asarray([[0.1, 0.2], [0.6, 0.3], [0.3, 0.5]])
+        qk = cupy.asarray([[0.0, 0.1], [0.3, 0.6], [0.5, 0.3]])
+        testing.assert_array_almost_equal(stats.entropy(pk, qk),
+                                          [cupy.inf, 0.18609809])
+
+        pk[0][0] = 0.0
+        testing.assert_array_almost_equal(
+            stats.entropy(pk, qk), [0.17403988, 0.18609809]
+        )
+
+    def test_entropy_base_2d_nondefault_axis(self):
+        pk = cupy.asarray([[0.1, 0.2], [0.6, 0.3], [0.3, 0.5]])
+        testing.assert_array_almost_equal(
+            stats.entropy(pk, axis=1),
+            cupy.asarray([0.63651417, 0.63651417, 0.66156324]),
+        )
+
+    def test_entropy_2d_nondefault_axis(self):
+        pk = cupy.asarray([[0.1, 0.2], [0.6, 0.3], [0.3, 0.5]])
+        qk = cupy.asarray([[0.2, 0.1], [0.3, 0.6], [0.5, 0.3]])
+        testing.assert_array_almost_equal(
+            stats.entropy(pk, qk, axis=1),
+            cupy.asarray([0.231049, 0.231049, 0.127706]),
+        )
+
+    def test_entropy_raises_value_error(self):
+        pk = cupy.asarray([[0.1, 0.2], [0.6, 0.3], [0.3, 0.5]])
+        qk = cupy.asarray([[0.1, 0.2], [0.6, 0.3]])
+        with pytest.raises(ValueError):
+            stats.entropy(pk, qk)
+
+
+@testing.parameterize(*(
+    testing.product({
+        'shape': [(128, ), (64, 33), (16, 4, 12)],
+        'base': [None, 10],
+        'axis': [None, 0, -1],
+        'use_qk': [False, True],
+        'normalize': [False, True],
+    })
+))
+@testing.gpu
+@testing.with_requires('scipy')
+class TestEntropy(unittest.TestCase):
+
+    def _entropy(self, xp, scp, dtype, shape, use_qk, base, axis, normalize):
+        pk = testing.shaped_random(shape, xp, dtype=dtype)
+        if use_qk:
+            qk = testing.shaped_random(shape, xp, dtype=dtype)
+        else:
+            qk = None
+        if normalize:
+            # if we don't normalize pk and qk, entropy will do it internally
+            norm_axis = 0 if axis is None else axis
+            pk = pk / pk.sum(axis=norm_axis, keepdims=True)
+            if qk is not None:
+                qk = qk / qk.sum(axis=norm_axis, keepdims=True)
+        return scp.stats.entropy(pk, qk=qk, base=base, axis=axis)
+
+    @testing.for_all_dtypes(no_float16=True, no_complex=True)
+    @testing.numpy_cupy_allclose(atol=1e-6, rtol=1e-6, scipy_name='scp')
+    def test_entropy(self, xp, scp, dtype):
+        return self._entropy(xp, scp, dtype, self.shape, self.use_qk,
+                             self.base, self.axis, self.normalize)
+
+    @testing.numpy_cupy_allclose(atol=1e-3, rtol=5e-3, scipy_name='scp')
+    def test_entropy_float16(self, xp, scp):
+        dtype = numpy.float16
+        return self._entropy(xp, scp, dtype, self.shape, self.use_qk,
+                             self.base, self.axis, self.normalize)
+
+    @testing.for_complex_dtypes()
+    def test_entropy_complex(self, dtype):
+        for xp, scp in zip([numpy, cupy], [scipy, cupyx.scipy]):
+            with pytest.raises(TypeError):
+                return self._entropy(xp, scp, dtype, self.shape, self.use_qk,
+                                     self.base, self.axis, self.normalize)

--- a/tests/cupyx_tests/scipy_tests/stats_tests/test_distributions.py
+++ b/tests/cupyx_tests/scipy_tests/stats_tests/test_distributions.py
@@ -123,7 +123,7 @@ class TestEntropy(unittest.TestCase):
         res = xp.asarray(res, xp.float16 if is_float16 else float_type)
         return res
 
-    @testing.for_all_dtypes(no_float16=True, no_complex=True)
+    @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose(rtol={cupy.float16: 1e-3,
                                        cupy.float32: 1e-6,
                                        'default': 1e-15},

--- a/tests/cupyx_tests/scipy_tests/stats_tests/test_distributions.py
+++ b/tests/cupyx_tests/scipy_tests/stats_tests/test_distributions.py
@@ -110,15 +110,13 @@ class TestEntropy(unittest.TestCase):
                 qk = qk / qk.sum(axis=norm_axis, keepdims=True)
         return scp.stats.entropy(pk, qk=qk, base=base, axis=axis)
 
-    @testing.for_all_dtypes(no_float16=True, no_complex=True)
-    @testing.numpy_cupy_allclose(atol=1e-6, rtol=1e-6, scipy_name='scp')
+    #@testing.for_all_dtypes(no_float16=True, no_complex=True)
+    @cupy.testing.for_dtypes('e')
+    @testing.numpy_cupy_allclose(rtol={cupy.float16: 1e-3,
+                                       cupy.float32: 1e-6,
+                                       'default': 1e-12},
+                                 scipy_name='scp')
     def test_entropy(self, xp, scp, dtype):
-        return self._entropy(xp, scp, dtype, self.shape, self.use_qk,
-                             self.base, self.axis, self.normalize)
-
-    @testing.numpy_cupy_allclose(atol=1e-3, rtol=5e-3, scipy_name='scp')
-    def test_entropy_float16(self, xp, scp):
-        dtype = numpy.float16
         return self._entropy(xp, scp, dtype, self.shape, self.use_qk,
                              self.base, self.axis, self.normalize)
 

--- a/tests/cupyx_tests/scipy_tests/stats_tests/test_distributions.py
+++ b/tests/cupyx_tests/scipy_tests/stats_tests/test_distributions.py
@@ -115,11 +115,11 @@ class TestEntropy(unittest.TestCase):
 
         float_type = xp.float32 if pk.dtype.char in 'ef' else xp.float64
         if res.ndim > 0:
-            # get float32 output for float16 or float32 input
+            # verify expected dtype
             assert res.dtype == float_type
 
-        # we need to manually cast back to the floating precision of the
-        # input so that the correct rtol is used by numpy_cupy_allclose.
+        # Cast back to the floating precision of the input so that the
+        # correct rtol is used by numpy_cupy_allclose
         res = xp.asarray(res, xp.float16 if is_float16 else float_type)
         return res
 


### PR DESCRIPTION
This PR adds the `scipy.stats` function, `entropy`. This implementation relies on the already existing `cupyx.scipy.special.entr` and `cupyx.scipy.special.rel_entr` functions and so should be simple to review.

There is not currently a `cupyx.scipy.stats` module, so this PR has added it. However, I do not currently have plans to implement other functions within the `stats` module. This function is used within a scikit-image function we created a CUDA equivalent for in `cupyimg`. If there is not an interest in having stats functions within CuPy itself, we can just keep this implementation there.

## Benchmark with pk input only
shape | GPU time (ms) | CPU time (ms) | acceleration
------|---------------|---------------|-------------
(256,) | 0.045 +/- 0.002 | 0.019 +/- 0.001 | 0.420
(512, 512) | 0.117 +/- 0.002 | 5.334 +/- 0.067 | 45.745
(2048, 4096) | 3.266 +/- 0.213 | 181.113 +/- 1.445 | 55.447
(192, 192, 192) | 1.597 +/- 0.153 | 162.830 +/- 1.174 | 101.973

## Benchmark with pk and qk inputs
shape | GPU time (ms) | CPU time (ms) | acceleration
------|---------------|---------------|-------------
(256,) | 0.075 +/- 0.009 | 0.022 +/- 0.003 | 0.295
(512, 512) | 0.162 +/- 0.003 | 2.807 +/- 0.100 | 17.349
(2048, 4096) | 4.317 +/- 0.266 | 100.531 +/- 1.208 | 23.288
(192, 192, 192) | 1.985 +/- 0.002 | 96.379 +/- 0.544 | 48.560



<details><summary>benchmark script</summary>

import numpy
import scipy.stats

import cupy
import cupyx.scipy.stats
from cupyx.time import repeat


print("## Benchmark with pk input only")
print("shape | GPU time (ms) | CPU time (ms) | acceleration")
print("------|---------------|---------------|-------------")
for shape in [(256,), (512, 512), (2048, 4096), (192, 192, 192)]:
    pg = cupy.testing.shaped_random(shape, dtype=numpy.float32)
    perf_gpu = repeat(cupyx.scipy.stats.entropy, (pg,), n_warmup=20, n_repeat=100)
    gpu_times = perf_gpu.gpu_times * 1000

    p = cupy.asnumpy(pg)
    perf_cpu = repeat(scipy.stats.entropy, (p,), n_warmup=1, n_repeat=20)
    cpu_times = perf_cpu.gpu_times * 1000
    accel = cpu_times.mean() / gpu_times.mean()
    print(f"{shape} | {gpu_times.mean():0.3f} +/- {gpu_times.std():0.3f} | {cpu_times.mean():0.3f} +/- {cpu_times.std():0.3f} | {accel:0.3f}")


print("## Benchmark with pk and qk inputs")
print("shape | GPU time (ms) | CPU time (ms) | acceleration")
print("------|---------------|---------------|-------------")
for shape in [(256,), (512, 512), (2048, 4096), (192, 192, 192)]:
    pg = cupy.testing.shaped_random(shape, dtype=numpy.float32)
    qg = cupy.testing.shaped_random(shape, dtype=numpy.float32)
    perf_gpu = repeat(cupyx.scipy.stats.entropy, (pg, qg), n_warmup=20, n_repeat=100)
    gpu_times = perf_gpu.gpu_times * 1000

    p = cupy.asnumpy(pg)
    q = cupy.asnumpy(qg)
    perf_cpu = repeat(scipy.stats.entropy, (p, q), n_warmup=1, n_repeat=20)
    cpu_times = perf_cpu.gpu_times * 1000
    accel = cpu_times.mean() / gpu_times.mean()
    print(f"{shape} | {gpu_times.mean():0.3f} +/- {gpu_times.std():0.3f} | {cpu_times.mean():0.3f} +/- {cpu_times.std():0.3f} | {accel:0.3f}")

</details>
