### PR TITLE
add cupy.quantile

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -712,6 +712,7 @@ from cupy._statistics.order import nanmax  # NOQA
 from cupy._statistics.order import nanmin  # NOQA
 from cupy._statistics.order import percentile  # NOQA
 from cupy._statistics.order import ptp  # NOQA
+from cupy._statistics.order import quantile  # NOQA
 
 from cupy._statistics.meanvar import median  # NOQA
 from cupy._statistics.meanvar import average  # NOQA

--- a/cupy/_statistics/order.py
+++ b/cupy/_statistics/order.py
@@ -306,8 +306,8 @@ def quantile(a, q, axis=None, out=None, interpolation='linear',
     """Computes the q-th quantile of the data along the specified axis.
 
     Args:
-        a (cupy.ndarray): Array for which to compute percentiles.
-        q (float, tuple of floats or cupy.ndarray): Percentiles to compute
+        a (cupy.ndarray): Array for which to compute quantiles.
+        q (float, tuple of floats or cupy.ndarray): Quantiles to compute
             in the range between 0 and 1 inclusive.
         axis (int or tuple of ints): Along which axis or axes to compute the
             quantiles. The flattened array is used by default.

--- a/cupy/_statistics/order.py
+++ b/cupy/_statistics/order.py
@@ -174,32 +174,8 @@ def ptp(a, axis=None, out=None, keepdims=False):
     return a.ptp(axis=axis, out=out, keepdims=keepdims)
 
 
-def percentile(a, q, axis=None, out=None, interpolation='linear',
-               keepdims=False):
-    """Computes the q-th percentile of the data along the specified axis.
-
-    Args:
-        a (cupy.ndarray): Array for which to compute percentiles.
-        q (float, tuple of floats or cupy.ndarray): Percentiles to compute
-            in the range between 0 and 100 inclusive.
-        axis (int or tuple of ints): Along which axis or axes to compute the
-            percentiles. The flattened array is used by default.
-        out (cupy.ndarray): Output array.
-        interpolation (str): Interpolation method when a quantile lies between
-            two data points. ``linear`` interpolation is used by default.
-            Supported interpolations are``lower``, ``higher``, ``midpoint``,
-            ``nearest`` and ``linear``.
-        keepdims (bool): If ``True``, the axis is remained as an axis of
-            size one.
-
-    Returns:
-        cupy.ndarray: The percentiles of ``a``, along the axis if specified.
-
-    .. seealso:: :func:`numpy.percentile`
-
-    """
-    if not isinstance(q, cupy.ndarray):
-        q = cupy.asarray(q, dtype='d')
+def _quantile_unchecked(a, q, axis=None, out=None, interpolation='linear',
+                        keepdims=False):
     if q.ndim == 0:
         q = q[None]
         zerod = True
@@ -208,7 +184,6 @@ def percentile(a, q, axis=None, out=None, interpolation='linear',
     if q.ndim > 1:
         raise ValueError('Expected q to have a dimension of 1.\n'
                          'Actual: {0} != 1'.format(q.ndim))
-
     if keepdims:
         if axis is None:
             keepdim = (1,) * a.ndim
@@ -236,7 +211,7 @@ def percentile(a, q, axis=None, out=None, interpolation='linear',
     axis = -1
     ap.sort(axis=axis)
     Nx = ap.shape[axis]
-    indices = q * 0.01 * (Nx - 1.)  # percents to decimals
+    indices = q * (Nx - 1.)
 
     if interpolation == 'lower':
         indices = cupy.floor(indices).astype(cupy.int32)
@@ -286,3 +261,72 @@ def percentile(a, q, axis=None, out=None, interpolation='linear',
         ret = ret.reshape(keepdim)
 
     return core._internal_ascontiguousarray(ret)
+
+
+def _quantile_is_valid(q):
+    if cupy.count_nonzero(q < 0.0) or cupy.count_nonzero(q > 1.0):
+        return False
+    return True
+
+
+def percentile(a, q, axis=None, out=None, interpolation='linear',
+               keepdims=False):
+    """Computes the q-th percentile of the data along the specified axis.
+
+    Args:
+        a (cupy.ndarray): Array for which to compute percentiles.
+        q (float, tuple of floats or cupy.ndarray): Percentiles to compute
+            in the range between 0 and 100 inclusive.
+        axis (int or tuple of ints): Along which axis or axes to compute the
+            percentiles. The flattened array is used by default.
+        out (cupy.ndarray): Output array.
+        interpolation (str): Interpolation method when a quantile lies between
+            two data points. ``linear`` interpolation is used by default.
+            Supported interpolations are``lower``, ``higher``, ``midpoint``,
+            ``nearest`` and ``linear``.
+        keepdims (bool): If ``True``, the axis is remained as an axis of
+            size one.
+
+    Returns:
+        cupy.ndarray: The percentiles of ``a``, along the axis if specified.
+
+    .. seealso:: :func:`numpy.percentile`
+    """
+    if not isinstance(q, cupy.ndarray):
+        q = cupy.asarray(q, dtype='d')
+    q = cupy.true_divide(q, 100)
+    if not _quantile_is_valid(q):  # synchronize
+        raise ValueError('Percentiles must be in the range [0, 100]')
+    return _quantile_unchecked(a, q, axis=axis, out=out,
+                               interpolation=interpolation, keepdims=keepdims)
+
+
+def quantile(a, q, axis=None, out=None, interpolation='linear',
+             keepdims=False):
+    """Computes the q-th quantile of the data along the specified axis.
+
+    Args:
+        a (cupy.ndarray): Array for which to compute percentiles.
+        q (float, tuple of floats or cupy.ndarray): Percentiles to compute
+            in the range between 0 and 1 inclusive.
+        axis (int or tuple of ints): Along which axis or axes to compute the
+            quantiles. The flattened array is used by default.
+        out (cupy.ndarray): Output array.
+        interpolation (str): Interpolation method when a quantile lies between
+            two data points. ``linear`` interpolation is used by default.
+            Supported interpolations are``lower``, ``higher``, ``midpoint``,
+            ``nearest`` and ``linear``.
+        keepdims (bool): If ``True``, the axis is remained as an axis of
+            size one.
+
+    Returns:
+        cupy.ndarray: The quantiles of ``a``, along the axis if specified.
+
+    .. seealso:: :func:`numpy.quantile`
+    """
+    if not isinstance(q, cupy.ndarray):
+        q = cupy.asarray(q, dtype='d')
+    if not _quantile_is_valid(q):  # synchronize
+        raise ValueError('Quantiles must be in the range [0, 1]')
+    return _quantile_unchecked(a, q, axis=axis, out=out,
+                               interpolation=interpolation, keepdims=keepdims)

--- a/docs/source/reference/statistics.rst
+++ b/docs/source/reference/statistics.rst
@@ -1,7 +1,7 @@
 Statistical Functions
 =====================
 
-.. https://docs.scipy.org/doc/scipy/reference/stats.html
+.. https://numpy.org/doc/stable/reference/routines.statistics.html
 
 Order statistics
 ----------------
@@ -16,6 +16,7 @@ Order statistics
    cupy.nanmax
    cupy.percentile
    cupy.ptp
+   cupy.quantile
 
 
 Means and variances

--- a/tests/cupy_tests/statistics_tests/test_order.py
+++ b/tests/cupy_tests/statistics_tests/test_order.py
@@ -100,8 +100,17 @@ class TestOrder(unittest.TestCase):
             with pytest.raises(ValueError):
                 xp.percentile(a, q, axis=-1, interpolation=interpolation)
 
+    @for_all_interpolations()
     @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
-    def test_percentile_uxpected_interpolation(self, dtype):
+    def test_percentile_out_of_range_q(self, dtype, interpolation):
+        for xp in (numpy, cupy):
+            a = testing.shaped_random((4, 2, 3, 2), xp, dtype)
+            for q in [[-0.1], [100.1]]:
+                with pytest.raises(ValueError):
+                    xp.percentile(a, q, axis=-1, interpolation=interpolation)
+
+    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
+    def test_percentile_unexpected_interpolation(self, dtype):
         for xp in (numpy, cupy):
             a = testing.shaped_random((4, 2, 3, 2), xp, dtype)
             q = testing.shaped_random((5,), xp, dtype=dtype, scale=100)
@@ -109,6 +118,100 @@ class TestOrder(unittest.TestCase):
                 xp.percentile(a, q, axis=-1, interpolation='deadbeef')
 
     @testing.for_all_dtypes()
+    @for_all_interpolations()
+    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
+    @testing.numpy_cupy_allclose()
+    def test_quantile_defaults(self, xp, dtype, interpolation):
+        a = testing.shaped_random((2, 3, 8), xp, dtype)
+        q = testing.shaped_random((3,), xp, scale=1)
+        return xp.quantile(a, q, interpolation=interpolation)
+
+    @for_all_interpolations()
+    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
+    @testing.numpy_cupy_allclose()
+    def test_quantile_q_list(self, xp, dtype, interpolation):
+        a = testing.shaped_arange((1001,), xp, dtype)
+        q = [.99, .999]
+        return xp.quantile(a, q, interpolation=interpolation)
+
+    @for_all_interpolations()
+    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
+    @testing.numpy_cupy_allclose(rtol=1e-5)
+    def test_quantile_no_axis(self, xp, dtype, interpolation):
+        a = testing.shaped_random((10, 2, 4, 8), xp, dtype)
+        q = testing.shaped_random((5,), xp, scale=1)
+        return xp.quantile(a, q, axis=None, interpolation=interpolation)
+
+    @for_all_interpolations()
+    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
+    @testing.numpy_cupy_allclose(rtol=1e-6)
+    def test_quantile_neg_axis(self, xp, dtype, interpolation):
+        a = testing.shaped_random((4, 3, 10, 2, 8), xp, dtype)
+        q = testing.shaped_random((5,), xp, scale=1)
+        return xp.quantile(a, q, axis=-1, interpolation=interpolation)
+
+    @for_all_interpolations()
+    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
+    @testing.numpy_cupy_allclose(rtol=1e-6)
+    def test_quantile_tuple_axis(self, xp, dtype, interpolation):
+        a = testing.shaped_random((1, 6, 3, 2), xp, dtype)
+        q = testing.shaped_random((5,), xp, scale=1)
+        return xp.quantile(a, q, axis=(0, 1, 2), interpolation=interpolation)
+
+    @for_all_interpolations()
+    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
+    @testing.numpy_cupy_allclose()
+    def test_quantile_scalar_q(self, xp, dtype, interpolation):
+        a = testing.shaped_random((2, 3, 8), xp, dtype)
+        q = .1337
+        return xp.quantile(a, q, interpolation=interpolation)
+
+    @for_all_interpolations()
+    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
+    @testing.numpy_cupy_allclose(rtol=1e-5)
+    def test_quantile_keepdims(self, xp, dtype, interpolation):
+        a = testing.shaped_random((7, 2, 9, 2), xp, dtype)
+        q = testing.shaped_random((5,), xp, scale=1)
+        return xp.quantile(
+            a, q, axis=None, keepdims=True, interpolation=interpolation)
+
+    @for_all_interpolations()
+    @testing.for_float_dtypes(no_float16=True)  # NumPy raises error on int8
+    @testing.numpy_cupy_allclose(rtol=1e-6)
+    def test_quantile_out(self, xp, dtype, interpolation):
+        a = testing.shaped_random((10, 2, 3, 2), xp, dtype)
+        q = testing.shaped_random((5,), xp, dtype=dtype, scale=1)
+        out = testing.shaped_random((5, 10, 2, 3), xp, dtype)
+        return xp.quantile(
+            a, q, axis=-1, interpolation=interpolation, out=out)
+
+    @for_all_interpolations()
+    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
+    def test_quantile_bad_q(self, dtype, interpolation):
+        for xp in (numpy, cupy):
+            a = testing.shaped_random((4, 2, 3, 2), xp, dtype)
+            q = testing.shaped_random((1, 2, 3), xp, dtype=dtype, scale=1)
+            with pytest.raises(ValueError):
+                xp.quantile(a, q, axis=-1, interpolation=interpolation)
+
+    @for_all_interpolations()
+    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
+    def test_quantile_out_of_range_q(self, dtype, interpolation):
+        for xp in (numpy, cupy):
+            a = testing.shaped_random((4, 2, 3, 2), xp, dtype)
+            for q in [[-0.1], [1.1]]:
+                with pytest.raises(ValueError):
+                    xp.quantile(a, q, axis=-1, interpolation=interpolation)
+
+    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
+    def test_quantile_unexpected_interpolation(self, dtype):
+        for xp in (numpy, cupy):
+            a = testing.shaped_random((4, 2, 3, 2), xp, dtype)
+            q = testing.shaped_random((5,), xp, dtype=dtype, scale=1)
+            with pytest.raises(ValueError):
+                xp.quantile(a, q, axis=-1, interpolation='deadbeef')
+
+    @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose()
     def test_nanmax_all(self, xp, dtype):
         a = testing.shaped_random((2, 3), xp, dtype)


### PR DESCRIPTION
This is a simple PR to add `cupy.quantile` which is the same as `cupy.percentile` but with q in the range [0, 1] rather than [0, 100].

This just reuses the existing `cupy.percentile` implementation, so there is not much new to review. The test cases are also copies of the tests for percentile, but using floating point `q` in the range [0, 1].

`numpy.quantile` was introduced in NumPy 1.15 which I think CuPy now requires, so I didn't do any `with_requires` checks in the tests.

**One area to consider**
I added range checks on `q` as in NumPy, but these require device synchronization, so it may not be desirable. If we don't want this, I can just remove use of `_quantile_is_valid` and the two `*_out_of_range_q` tests.
