### PR TITLE
[backport] Make names of test classes start with `Test`

### DIFF
--- a/tests/cupy_tests/core_tests/fusion_tests/test_example.py
+++ b/tests/cupy_tests/core_tests/fusion_tests/test_example.py
@@ -6,7 +6,7 @@ from cupy_tests.core_tests.fusion_tests import fusion_utils
 
 @testing.gpu
 @testing.slow
-class FusionExampleTest(unittest.TestCase):
+class TestFusionExample(unittest.TestCase):
     def generate_inputs(self, xp):
         shape = (8, 64, 112, 112)
         _, chan, _, _ = shape

--- a/tests/cupy_tests/core_tests/test_ndarray_cuda_array_interface.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_cuda_array_interface.py
@@ -71,7 +71,7 @@ class TestElementwiseKernel(unittest.TestCase):
 
 
 @testing.gpu
-class SimpleReductionFunction(unittest.TestCase):
+class TestSimpleReductionFunction(unittest.TestCase):
 
     def setUp(self):
         self.my_int8_sum = core.create_reduction_func(

--- a/tests/cupy_tests/core_tests/test_reduction.py
+++ b/tests/cupy_tests/core_tests/test_reduction.py
@@ -45,7 +45,7 @@ class SimpleReductionFunctionTestBase(AbstractReductionTestBase):
 
 
 @testing.gpu
-class SimpleReductionFunctionTest(
+class TestSimpleReductionFunction(
         unittest.TestCase, SimpleReductionFunctionTestBase):
     def test_shape1(self):
         for i in range(1, 10):

--- a/tests/cupy_tests/testing_tests/test_parameterized.py
+++ b/tests/cupy_tests/testing_tests/test_parameterized.py
@@ -11,7 +11,7 @@ from cupy import testing
     {'actual': {'a': [1, 2], 'b': []}, 'expect': []},
     {'actual': {'a': []}, 'expect': []},
     {'actual': {}, 'expect': [{}]})
-class ProductTest(unittest.TestCase):
+class TestProduct(unittest.TestCase):
 
     def test_product(self):
         assert testing.product(self.actual) == self.expect
@@ -28,7 +28,7 @@ class ProductTest(unittest.TestCase):
     {'actual': [[{'a': 1}, {'a': 2}], []], 'expect': []},
     {'actual': [[]], 'expect': []},
     {'actual': [], 'expect': [{}]})
-class ProductDictTest(unittest.TestCase):
+class TestProductDict(unittest.TestCase):
 
     def test_product_dict(self):
         assert testing.product_dict(*self.actual) == self.expect

--- a/tests/cupyx_tests/fallback_mode_tests/test_fallback.py
+++ b/tests/cupyx_tests/fallback_mode_tests/test_fallback.py
@@ -249,7 +249,7 @@ class TestDocs(unittest.TestCase):
 
 
 @testing.gpu
-class FallbackArray(unittest.TestCase):
+class TestFallbackArray(unittest.TestCase):
 
     def test_ndarray_creation_compatible(self):
 


### PR DESCRIPTION
Backport of #4320