### PR TITLE
Configure Mergify to check GitHub Actions instead of Travis

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -4,7 +4,7 @@ pull_request_rules:
       - "#changes-requested-reviews-by=0"
       - label=st:test-and-merge
       - status-success=Jenkins
-      - status-success=continuous-integration/travis-ci/pr
+      - status-success=pretest  # github workflows
       - status-success=pfn-public-ci/cupy.py3.amd
     actions:
       merge:


### PR DESCRIPTION
Follow-up #4373.