### PR TITLE
[backport] Fix comment in docs/source/reference/statistics.rst

### DIFF
--- a/docs/source/reference/statistics.rst
+++ b/docs/source/reference/statistics.rst
@@ -1,7 +1,7 @@
 Statistical Functions
 =====================
 
-.. https://docs.scipy.org/doc/scipy/reference/stats.html
+.. https://numpy.org/doc/stable/reference/routines.statistics.html
 
 Order statistics
 ----------------


### PR DESCRIPTION
Backport of cefbd7e28d39dc44a1471761e18372271c556e45

https://github.com/cupy/cupy/pull/4370/files#r533052219