### PR TITLE
Require SciPy >= 1.4 in `TestGmres`

### DIFF
--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
@@ -404,7 +404,7 @@ class TestCg(unittest.TestCase):
     'b_ndim': [1, 2],
     'restart': [None, 10],
 }))
-@unittest.skipUnless(scipy_available, 'requires scipy')
+@testing.with_requires('scipy>=1.4')
 @testing.gpu
 class TestGmres(unittest.TestCase):
     n = 30


### PR DESCRIPTION
scipy/scipy#10341 added the `callback_type` arg.