### PR TITLE
Fix `poly1d`

### DIFF
--- a/cupy/lib/_polynomial.pyx
+++ b/cupy/lib/_polynomial.pyx
@@ -11,6 +11,12 @@ from cupy.lib import _routines_poly
 cdef class poly1d:
     """A one-dimensional polynomial class.
 
+    .. note::
+        This is a counterpart of an old polynomial class in NumPy.
+        Note that the new NumPy polynomial API
+        (:mod:`numpy.polynomial.polynomial`)
+        has different convention, e.g. order of coefficients is reversed.
+
     Args:
         c_or_r (array_like): The polynomial's
          coefficients in decreasing powers
@@ -19,7 +25,7 @@ cdef class poly1d:
         variable (str, optional): Changes the variable used when
             printing the polynomial from ``x`` to ``variable``
 
-    .. seealso:: :func:`numpy.poly1d`
+    .. seealso:: :class:`numpy.poly1d`
 
     """
     __hash__ = None
@@ -123,6 +129,7 @@ cdef class poly1d:
     def __pos__(self):
         return self
 
+    # TODO(kataoka): Rename `self`. It is misleading for cdef class.
     def __mul__(self, other):
         if cupy.isscalar(other):
             # case: poly1d * python scalar

--- a/cupy/lib/_polynomial.pyx
+++ b/cupy/lib/_polynomial.pyx
@@ -7,15 +7,6 @@ from cupy.core.core cimport ndarray
 import cupy
 from cupy.lib import _routines_poly
 
-cimport cython  # NOQA
-
-
-@cython.profile(False)
-cdef inline _should_use_rop(x, y):
-    xp = getattr(x, '__array_priority__', 0)
-    yp = getattr(y, '__array_priority__', 0)
-    return xp < yp and not isinstance(y, poly1d)
-
 
 cdef class poly1d:
     """A one-dimensional polynomial class.
@@ -32,7 +23,6 @@ cdef class poly1d:
 
     """
     __hash__ = None
-    __array_priority__ = 100
 
     cdef:
         readonly ndarray _coeffs
@@ -134,8 +124,6 @@ cdef class poly1d:
         return self
 
     def __mul__(self, other):
-        if _should_use_rop(self, other):
-            return other.__rmul__(self)
         if cupy.isscalar(other):
             # case: poly1d * python scalar
             # the return type of cupy.polymul output is
@@ -157,8 +145,6 @@ cdef class poly1d:
         return _routines_poly.polymul(self, other)
 
     def __add__(self, other):
-        if _should_use_rop(self, other):
-            return other.__radd__(self)
         if isinstance(self, numpy.generic):
             # for the case: numpy scalar + poly1d
             raise TypeError('Numpy scalar and poly1d '
@@ -183,8 +169,6 @@ cdef class poly1d:
         return poly1d(_routines_poly._polypow(base, val))
 
     def __sub__(self, other):
-        if _should_use_rop(self, other):
-            return other.__rsub__(self)
         if isinstance(self, numpy.generic):
             # for the case: numpy scalar - poly1d
             raise TypeError('Numpy scalar and poly1d '

--- a/tests/cupy_tests/lib_tests/test_polynomial.py
+++ b/tests/cupy_tests/lib_tests/test_polynomial.py
@@ -369,54 +369,6 @@ class TestPoly1dRoutines(Poly1dTestBase):
         return func(a1, a2)
 
 
-class UserDefinedArray:
-
-    __array_priority__ = cupy.poly1d.__array_priority__ + 10
-
-    def __init__(self):
-        self.op_count = 0
-        self.rop_count = 0
-
-    def __add__(self, other):
-        self.op_count += 1
-
-    def __radd__(self, other):
-        self.rop_count += 1
-
-    def __sub__(self, other):
-        self.op_count += 1
-
-    def __rsub__(self, other):
-        self.rop_count += 1
-
-    def __mul__(self, other):
-        self.op_count += 1
-
-    def __rmul__(self, other):
-        self.rop_count += 1
-
-
-@testing.gpu
-@testing.parameterize(*testing.product({
-    'func': [
-        lambda x, y: x + y,
-        lambda x, y: x - y,
-        lambda x, y: x * y,
-    ],
-}))
-class TestPoly1dArrayPriority(Poly1dTestBase):
-
-    def test_poly1d_array_priority_greator(self):
-        a1 = self._get_input(cupy, 'poly1d', 'int64')
-        a2 = UserDefinedArray()
-        self.func(a1, a2)
-        assert a2.op_count == 0
-        assert a2.rop_count == 1
-        self.func(a2, a1)
-        assert a2.op_count == 1
-        assert a2.rop_count == 1
-
-
 @testing.gpu
 class TestPoly1dEquality(unittest.TestCase):
 


### PR DESCRIPTION
Do not "maintain" poly1d

The semantics of NumPy's poly1d (legacy polynomial class) is not maintained.
Therefore `__array_priority__` should be removed.

