### PR TITLE
ndimage: add grid_mode option to zoom

### DIFF
--- a/cupyx/scipy/ndimage/_filters_core.py
+++ b/cupyx/scipy/ndimage/_filters_core.py
@@ -303,7 +303,7 @@ def _generate_nd_kernel(name, pre, found, post, mode, w_shape, int_type,
                ws_init=ws_init, ws_pre=ws_pre, ws_post=ws_post,
                loops='\n'.join(loops), found=found, end_loops='}'*ndim)
 
-    mode_str = mode.replace('-', '_') # avoid potential hyphen in kernel name
+    mode_str = mode.replace('-', '_')  # avoid potential hyphen in kernel name
     name = 'cupy_ndimage_{}_{}d_{}_w{}'.format(
         name, ndim, mode_str, '_'.join(['{}'.format(x) for x in w_shape]))
     if all_weights_nonzero:

--- a/cupyx/scipy/ndimage/_filters_core.py
+++ b/cupyx/scipy/ndimage/_filters_core.py
@@ -82,6 +82,8 @@ def _run_1d_filters(filters, input, args, output, mode, cval, origin=0):
     output = _util._get_output(output, input)
     modes = _util._fix_sequence_arg(mode, input.ndim, 'mode',
                                     _util._check_mode)
+    # for filters, "wrap" is a synonym for "grid-wrap".
+    modes = ['grid-wrap' if m == 'wrap' else m for m in modes]
     origins = _util._fix_sequence_arg(origin, input.ndim, 'origin', int)
     n_filters = sum(filter is not None for filter in filters)
     if n_filters == 0:
@@ -219,6 +221,9 @@ def _generate_nd_kernel(name, pre, found, post, mode, w_shape, int_type,
         in_params += ', raw M mask'
     out_params = 'Y y'
 
+    # for filters, "wrap" is a synonym for "grid-wrap"
+    mode = 'grid-wrap' if mode == 'wrap' else mode
+
     # CArray: remove xstride_{j}=... from string
     size = ('%s xsize_{j}=x.shape()[{j}], ysize_{j} = _raw_y.shape()[{j}]'
             ', xstride_{j}=x.strides()[{j}];' % int_type)
@@ -298,8 +303,9 @@ def _generate_nd_kernel(name, pre, found, post, mode, w_shape, int_type,
                ws_init=ws_init, ws_pre=ws_pre, ws_post=ws_post,
                loops='\n'.join(loops), found=found, end_loops='}'*ndim)
 
+    mode_str = mode.replace('-', '_') # avoid potential hyphen in kernel name
     name = 'cupy_ndimage_{}_{}d_{}_w{}'.format(
-        name, ndim, mode, '_'.join(['{}'.format(x) for x in w_shape]))
+        name, ndim, mode_str, '_'.join(['{}'.format(x) for x in w_shape]))
     if all_weights_nonzero:
         name += '_all_nonzero'
     if int_type == 'ptrdiff_t':

--- a/cupyx/scipy/ndimage/_interp_kernels.py
+++ b/cupyx/scipy/ndimage/_interp_kernels.py
@@ -264,7 +264,16 @@ def _generate_interp_custom(coord_func, ndim, large_int, yshape, mode, cval,
             ops.append(f'''
             {int_t} ic_{j} = cf_{j} * sx_{j};''')
         _coord_idx = ' + '.join([f'ic_{j}' for j in range(ndim)])
-        ops.append(f'''
+        if mode == 'grid-constant':
+            _cond = ' || '.join([f'(ic_{j} < 0)' for j in range(ndim)])
+            ops.append(f'''
+            if ({_cond}) {{
+                out = (double){cval};
+            }} else {{
+                out = x[{_coord_idx}];
+            }}''')
+        else:
+            ops.append(f'''
             out = x[{_coord_idx}];''')
 
     elif order == 1:

--- a/cupyx/scipy/ndimage/_interp_kernels.py
+++ b/cupyx/scipy/ndimage/_interp_kernels.py
@@ -35,8 +35,8 @@ def _get_coord_map(ndim):
     ops.append('ptrdiff_t ncoords = _ind.size();')
     for j in range(ndim):
         ops.append(
-            """
-    W c_{j} = coords[i + {j} * ncoords];""".format(j=j))
+            '''
+    W c_{j} = coords[i + {j} * ncoords];'''.format(j=j))
     return ops
 
 
@@ -59,8 +59,8 @@ def _get_coord_zoom_and_shift(ndim):
     ops = []
     for j in range(ndim):
         ops.append(
-            """
-    W c_{j} = zoom[{j}] * ((W)in_coord[{j}] - shift[{j}]);""".format(j=j))
+            '''
+    W c_{j} = zoom[{j}] * ((W)in_coord[{j}] - shift[{j}]);'''.format(j=j))
     return ops
 
 
@@ -82,8 +82,8 @@ def _get_coord_zoom(ndim):
     ops = []
     for j in range(ndim):
         ops.append(
-            """
-    W c_{j} = zoom[{j}] * (W)in_coord[{j}];""".format(j=j))
+            '''
+    W c_{j} = zoom[{j}] * (W)in_coord[{j}];'''.format(j=j))
     return ops
 
 
@@ -105,8 +105,8 @@ def _get_coord_shift(ndim):
     ops = []
     for j in range(ndim):
         ops.append(
-            """
-    W c_{j} = (W)in_coord[{j}] - shift[{j}];""".format(j=j))
+            '''
+    W c_{j} = (W)in_coord[{j}] - shift[{j}];'''.format(j=j))
     return ops
 
 
@@ -133,18 +133,18 @@ def _get_coord_affine(ndim):
     ops = []
     ncol = ndim + 1
     for j in range(ndim):
-        ops.append("""
+        ops.append('''
             W c_{j} = (W)0.0;
-            """.format(j=j))
+            '''.format(j=j))
         for k in range(ndim):
             m_index = ncol * j + k
             ops.append(
-                """
-            c_{j} += mat[{m_index}] * (W)in_coord[{k}];""".format(
+                '''
+            c_{j} += mat[{m_index}] * (W)in_coord[{k}];'''.format(
                     j=j, k=k, m_index=m_index))
         ops.append(
-            """
-            c_{j} += mat[{m_index}];""".format(
+            '''
+            c_{j} += mat[{m_index}];'''.format(
                 j=j, m_index=ncol * j + ndim))
     return ops
 
@@ -156,17 +156,17 @@ def _unravel_loop_index(shape, uint_t='unsigned int'):
     """
     ndim = len(shape)
     code = [
-        """
+        '''
         {uint_t} in_coord[{ndim}];
-        {uint_t} s, t, idx = i;""".format(uint_t=uint_t, ndim=ndim)]
+        {uint_t} s, t, idx = i;'''.format(uint_t=uint_t, ndim=ndim)]
     for j in range(ndim - 1, 0, -1):
-        code.append("""
+        code.append('''
         s = {size};
         t = idx / s;
         in_coord[{j}] = idx - t * s;
-        idx = t;""".format(j=j, size=shape[j]))
-    code.append("""
-        in_coord[0] = idx;""")
+        idx = t;'''.format(j=j, size=shape[j]))
+    code.append('''
+        in_coord[0] = idx;''')
     return '\n'.join(code)
 
 
@@ -226,24 +226,24 @@ def _generate_interp_custom(coord_func, ndim, large_int, yshape, mode, cval,
         # use cval if coordinate is outside the bounds of x
         _cond = ' || '.join(
             [f'(c_{j} < 0) || (c_{j} > xsize_{j} - 1)' for j in range(ndim)])
-        ops.append(f"""
+        ops.append(f'''
         if ({_cond})
         {{
             out = {cval};
         }}
         else
-        {{""")
+        {{''')
 
     if order == 0:
-        ops.append("double dcoord;")  # mode 'wrap' requires this to work
+        ops.append('double dcoord;')  # mode 'wrap' requires this to work
         for j in range(ndim):
             # determine nearest neighbor
             if mode == 'wrap':
-                ops.append(f"""
-                dcoord = c_{j};""")
+                ops.append(f'''
+                dcoord = c_{j};''')
             else:
-                ops.append(f"""
-                {int_t} cf_{j} = ({int_t})lrint((double)c_{j});""")
+                ops.append(f'''
+                {int_t} cf_{j} = ({int_t})lrint((double)c_{j});''')
 
             # handle boundary
             if mode != 'constant':
@@ -261,37 +261,37 @@ def _generate_interp_custom(coord_func, ndim, large_int, yshape, mode, cval,
                 {int_t} cf_{j} = ({int_t})floor(dcoord + 0.5);''')
 
             # sum over ic_j will give the raveled coordinate in the input
-            ops.append(f"""
-            {int_t} ic_{j} = cf_{j} * sx_{j};""")
+            ops.append(f'''
+            {int_t} ic_{j} = cf_{j} * sx_{j};''')
         _coord_idx = ' + '.join([f'ic_{j}' for j in range(ndim)])
-        ops.append(f"""
-            out = x[{_coord_idx}];""")
+        ops.append(f'''
+            out = x[{_coord_idx}];''')
 
     elif order == 1:
         for j in range(ndim):
             # get coordinates for linear interpolation along axis j
-            ops.append(f"""
+            ops.append(f'''
             {int_t} cf_{j} = ({int_t})floor((double)c_{j});
             {int_t} cc_{j} = cf_{j} + 1;
             {int_t} n_{j} = (c_{j} == cf_{j}) ? 1 : 2;  // points needed
-            """)
+            ''')
 
-            if mode == "wrap":
-                ops.append(f"""
+            if mode == 'wrap':
+                ops.append(f'''
                 double dcoordf = c_{j};
-                double dcoordc = c_{j} + 1;""")
+                double dcoordc = c_{j} + 1;''')
             else:
                 # handle boundaries for extension modes.
-                ops.append(f"""
+                ops.append(f'''
                 {int_t} cf_bounded_{j} = cf_{j};
-                {int_t} cc_bounded_{j} = cc_{j};""")
+                {int_t} cc_bounded_{j} = cc_{j};''')
 
             if mode != 'constant':
-                if mode == "wrap":
-                    ixvar = "dcoordf"
+                if mode == 'wrap':
+                    ixvar = 'dcoordf'
                     float_ix = True
                 else:
-                    ixvar = f"cf_bounded_{j}"
+                    ixvar = f'cf_bounded_{j}'
                     float_ix = False
                 ops.append(
                     _util._generate_boundary_condition_ops(
@@ -301,15 +301,15 @@ def _generate_interp_custom(coord_func, ndim, large_int, yshape, mode, cval,
                 ops.append(
                     _util._generate_boundary_condition_ops(
                         mode, ixvar, f'xsize_{j}', int_t, float_ix))
-                if mode == "wrap":
+                if mode == 'wrap':
                     ops.append(
-                        f"""
+                        f'''
                     {int_t} cf_bounded_{j} = ({int_t})floor(dcoordf);;
                     {int_t} cc_bounded_{j} = ({int_t})floor(dcoordf + 1);;
-                    """
+                    '''
                     )
 
-            ops.append(f"""
+            ops.append(f'''
             for (int s_{j} = 0; s_{j} < n_{j}; s_{j}++)
                 {{
                     W w_{j};
@@ -322,29 +322,27 @@ def _generate_interp_custom(coord_func, ndim, large_int, yshape, mode, cval,
                     {{
                         w_{j} = c_{j} - (W)cf_{j};
                         ic_{j} = cc_bounded_{j} * sx_{j};
-                    }}""")
+                    }}''')
 
     if order > 0:
 
-        _weight = " * ".join([f"w_{j}" for j in range(ndim)])
-        _coord_idx = " + ".join([f"ic_{j}" for j in range(ndim)])
-        if mode == "grid-constant" or (order > 1 and mode == "constant"):
-            _cond = " || ".join([f"(ic_{j} < 0)" for j in range(ndim)])
-            ops.append(f"""
+        _weight = ' * '.join([f'w_{j}' for j in range(ndim)])
+        _coord_idx = ' + '.join([f'ic_{j}' for j in range(ndim)])
+        if mode == 'grid-constant' or (order > 1 and mode == 'constant'):
+            _cond = ' || '.join([f'(ic_{j} < 0)' for j in range(ndim)])
+            ops.append(f'''
             if ({_cond}) {{
                 out += (X){cval} * ({_weight});
             }} else {{
                 X val = x[{_coord_idx}];
                 out += val * ({_weight});
-            }}""")
+            }}''')
         else:
-            ops.append(f"""
+            ops.append(f'''
             X val = x[{_coord_idx}];
-            out += val * ({_weight});""")
+            out += val * ({_weight});''')
 
-        ops.append("}" * ndim)
-
-
+        ops.append('}' * ndim)
 
     if mode == 'constant':
         ops.append('}')
@@ -355,9 +353,9 @@ def _generate_interp_custom(coord_func, ndim, large_int, yshape, mode, cval,
         ops.append('y = (Y)out;')
     operation = '\n'.join(ops)
 
-    mode_str = mode.replace("-", "_")  # avoid hyphen in kernel name
+    mode_str = mode.replace('-', '_')  # avoid hyphen in kernel name
     name = 'interpolate_{}_order{}_{}_{}d_y{}'.format(
-        name, order, mode_str, ndim, "_".join([f"{j}" for j in yshape]),
+        name, order, mode_str, ndim, '_'.join([f'{j}' for j in yshape]),
     )
     if uint_t == 'size_t':
         name += '_i64'

--- a/cupyx/scipy/ndimage/_util.py
+++ b/cupyx/scipy/ndimage/_util.py
@@ -45,7 +45,8 @@ def _check_origin(origin, width):
 
 
 def _check_mode(mode):
-    if mode not in ('reflect', 'constant', 'nearest', 'mirror', 'wrap'):
+    if mode not in ('reflect', 'constant', 'nearest', 'mirror', 'wrap',
+                    'grid-mirror', 'grid-wrap', 'grid-reflect'):
         msg = 'boundary mode not supported (actual: {})'.format(mode)
         raise RuntimeError(msg)
     return mode
@@ -61,14 +62,18 @@ def _get_inttype(input):
     return 'int' if nbytes < (1 << 31) else 'ptrdiff_t'
 
 
-def _generate_boundary_condition_ops(mode, ix, xsize):
-    if mode == 'reflect':
+def _generate_boundary_condition_ops(mode, ix, xsize, int_t="int",
+                                     float_ix=False):
+    min_func = "fmin" if float_ix else "min"
+    max_func = "fmax" if float_ix else "max"
+    if mode in ['reflect', 'grid-mirror']:
         ops = '''
         if ({ix} < 0) {{
             {ix} = - 1 -{ix};
         }}
         {ix} %= {xsize} * 2;
-        {ix} = min({ix}, 2 * {xsize} - 1 - {ix});'''.format(ix=ix, xsize=xsize)
+        {ix} = {min}({ix}, 2 * {xsize} - 1 - {ix});'''.format(
+            ix=ix, xsize=xsize, min=min_func)
     elif mode == 'mirror':
         ops = '''
         if ({xsize} == 1) {{
@@ -78,20 +83,28 @@ def _generate_boundary_condition_ops(mode, ix, xsize):
                 {ix} = -{ix};
             }}
             {ix} = 1 + ({ix} - 1) % (({xsize} - 1) * 2);
-            {ix} = min({ix}, 2 * {xsize} - 2 - {ix});
-        }}'''.format(ix=ix, xsize=xsize)
+            {ix} = {min}({ix}, 2 * {xsize} - 2 - {ix});
+        }}'''.format(ix=ix, xsize=xsize, min=min_func)
     elif mode == 'nearest':
         ops = '''
-        {ix} = min(max({ix}, 0), {xsize} - 1);'''.format(ix=ix, xsize=xsize)
-    elif mode == 'wrap':
+        {ix} = {min}({max}({ix}, 0), {xsize} - 1);'''.format(
+            ix=ix, xsize=xsize, min=min_func, max=max_func)
+    elif mode == 'grid-wrap':
         ops = '''
         {ix} %= {xsize};
         if ({ix} < 0) {{
             {ix} += {xsize};
         }}'''.format(ix=ix, xsize=xsize)
-    elif mode == 'constant':
+    elif mode == 'wrap':
         ops = '''
-        if ({ix} >= {xsize}) {{
+        if ({ix} < 0) {{
+            {ix} += ({sz} - 1) * (({int_t})(-{ix} / ({sz} - 1)) + 1);
+        }} else if ({ix} > ({sz} - 1)) {{
+            {ix} -= ({sz} - 1) * ({int_t})({ix} / ({sz} - 1));
+        }};'''.format(ix=ix, sz=xsize, int_t=int_t)
+    elif mode in ['constant', 'grid-constant']:
+        ops = '''
+        if (({ix} < 0) || {ix} >= {xsize}) {{
             {ix} = -1;
         }}'''.format(ix=ix, xsize=xsize)
     return ops

--- a/cupyx/scipy/ndimage/_util.py
+++ b/cupyx/scipy/ndimage/_util.py
@@ -1,4 +1,5 @@
 import cupy
+import cupy._util
 
 
 def _is_integer_output(output, input):
@@ -45,9 +46,11 @@ def _check_origin(origin, width):
 
 
 def _check_mode(mode):
+    if mode in ['grid-mirror', 'grid-wrap', 'grid-reflect']:
+        cupy._util.experimental(f"mode '{mode}' is currently experimental")
     if mode not in ('reflect', 'constant', 'nearest', 'mirror', 'wrap',
                     'grid-mirror', 'grid-wrap', 'grid-reflect'):
-        msg = 'boundary mode not supported (actual: {})'.format(mode)
+        msg = f'boundary mode not supported (actual: {mode})'
         raise RuntimeError(msg)
     return mode
 

--- a/cupyx/scipy/ndimage/interpolation.py
+++ b/cupyx/scipy/ndimage/interpolation.py
@@ -90,7 +90,8 @@ def spline_filter1d(input, order=3, axis=-1, output=cupy.float64,
             ``numpy.float64``.
         mode (str): Points outside the boundaries of the input are filled
             according to the given mode (``'constant'``, ``'nearest'``,
-            ``'mirror'`` or ``'opencv'``). Default is ``'constant'``.
+            ``'mirror'``, ``'reflect'``, ``'wrap'``, ``'grid-mirror'``,
+            ``'grid-wrap'``, ``'grid-constant'`` or ``'opencv'``).
 
     Returns:
         cupy.ndarray: The result of prefiltering the input.
@@ -167,7 +168,8 @@ def spline_filter(input, order=3, output=cupy.float64, mode='mirror'):
             ``numpy.float64``.
         mode (str): Points outside the boundaries of the input are filled
             according to the given mode (``'constant'``, ``'nearest'``,
-            ``'mirror'`` or ``'opencv'``). Default is ``'constant'``.
+            ``'mirror'``, ``'reflect'``, ``'wrap'``, ``'grid-mirror'``,
+            ``'grid-wrap'``, ``'grid-constant'`` or ``'opencv'``).
 
     Returns:
         cupy.ndarray: The result of prefiltering the input.
@@ -215,7 +217,8 @@ def map_coordinates(input, coordinates, output=None, order=None,
             change in the future. Currently it supports only order 0 and 1.
         mode (str): Points outside the boundaries of the input are filled
             according to the given mode (``'constant'``, ``'nearest'``,
-            ``'mirror'`` or ``'opencv'``). Default is ``'constant'``.
+            ``'mirror'``, ``'reflect'``, ``'wrap'``, ``'grid-mirror'``,
+            ``'grid-wrap'``, ``'grid-constant'`` or ``'opencv'``).
         cval (scalar): Value used for points outside the boundaries of
             the input if ``mode='constant'`` or ``mode='opencv'``. Default is
             0.0
@@ -291,7 +294,8 @@ def affine_transform(input, matrix, offset=0.0, output_shape=None, output=None,
             change in the future. Currently it supports only order 0 and 1.
         mode (str): Points outside the boundaries of the input are filled
             according to the given mode (``'constant'``, ``'nearest'``,
-            ``'mirror'`` or ``'opencv'``). Default is ``'constant'``.
+            ``'mirror'``, ``'reflect'``, ``'wrap'``, ``'grid-mirror'``,
+            ``'grid-wrap'``, ``'grid-constant'`` or ``'opencv'``).
         cval (scalar): Value used for points outside the boundaries of
             the input if ``mode='constant'`` or ``mode='opencv'``. Default is
             0.0
@@ -410,7 +414,8 @@ def rotate(input, angle, axes=(1, 0), reshape=True, output=None, order=None,
             change in the future. Currently it supports only order 0 and 1.
         mode (str): Points outside the boundaries of the input are filled
             according to the given mode (``'constant'``, ``'nearest'``,
-            ``'mirror'`` or ``'opencv'``). Default is ``'constant'``.
+            ``'mirror'``, ``'reflect'``, ``'wrap'``, ``'grid-mirror'``,
+            ``'grid-wrap'``, ``'grid-constant'`` or ``'opencv'``).
         cval (scalar): Value used for points outside the boundaries of
             the input if ``mode='constant'`` or ``mode='opencv'``. Default is
             0.0
@@ -505,7 +510,8 @@ def shift(input, shift, output=None, order=None, mode='constant', cval=0.0,
             change in the future. Currently it supports only order 0 and 1.
         mode (str): Points outside the boundaries of the input are filled
             according to the given mode (``'constant'``, ``'nearest'``,
-            ``'mirror'`` or ``'opencv'``). Default is ``'constant'``.
+            ``'mirror'``, ``'reflect'``, ``'wrap'``, ``'grid-mirror'``,
+            ``'grid-wrap'``, ``'grid-constant'`` or ``'opencv'``).
         cval (scalar): Value used for points outside the boundaries of
             the input if ``mode='constant'`` or ``mode='opencv'``. Default is
             0.0
@@ -572,7 +578,8 @@ def zoom(input, zoom, output=None, order=None, mode='constant', cval=0.0,
             change in the future. Currently it supports only order 0 and 1.
         mode (str): Points outside the boundaries of the input are filled
             according to the given mode (``'constant'``, ``'nearest'``,
-            ``'mirror'`` or ``'opencv'``). Default is ``'constant'``.
+            ``'mirror'``, ``'reflect'``, ``'wrap'``, ``'grid-mirror'``,
+            ``'grid-wrap'``, ``'grid-constant'`` or ``'opencv'``).
         cval (scalar): Value used for points outside the boundaries of
             the input if ``mode='constant'`` or ``mode='opencv'``. Default is
             0.0

--- a/cupyx/scipy/ndimage/interpolation.py
+++ b/cupyx/scipy/ndimage/interpolation.py
@@ -25,13 +25,10 @@ def _check_parameter(func_name, order, mode):
         # instead of ValueError.
         raise NotImplementedError('spline order is not supported')
 
-    if mode in ('reflect', 'wrap'):
-        raise NotImplementedError('\'{}\' mode is not supported. See '
-                                  'https://github.com/scipy/scipy/issues/8465'
-                                  .format(mode))
-    elif mode not in ('constant', 'nearest', 'mirror', 'opencv',
+    if mode not in ('constant', 'grid-constant', 'nearest', 'mirror',
+                      'reflect', 'grid-mirror', 'wrap', 'grid-wrap', 'opencv',
                       '_opencv_edge'):
-        raise ValueError('boundary mode is not supported')
+        raise ValueError('boundary mode ({}) is not supported'.format(mode))
 
 
 def _get_spline_output(input, output):

--- a/cupyx/scipy/ndimage/interpolation.py
+++ b/cupyx/scipy/ndimage/interpolation.py
@@ -26,8 +26,8 @@ def _check_parameter(func_name, order, mode):
         raise NotImplementedError('spline order is not supported')
 
     if mode not in ('constant', 'grid-constant', 'nearest', 'mirror',
-                      'reflect', 'grid-mirror', 'wrap', 'grid-wrap', 'opencv',
-                      '_opencv_edge'):
+                    'reflect', 'grid-mirror', 'wrap', 'grid-wrap', 'opencv',
+                    '_opencv_edge'):
         raise ValueError('boundary mode ({}) is not supported'.format(mode))
 
 
@@ -37,15 +37,15 @@ def _get_spline_output(input, output):
     Differs from SciPy by not always forcing the internal floating point dtype
     to be double precision.
     """
-    complex_data = input.dtype.kind == "c"
+    complex_data = input.dtype.kind == 'c'
     if complex_data:
         min_float_dtype = cupy.complex64
     else:
         min_float_dtype = cupy.float32
     if isinstance(output, cupy.ndarray):
-        if complex_data and output.dtype.kind != "c":
+        if complex_data and output.dtype.kind != 'c':
             raise ValueError(
-                "output must have complex dtype for complex inputs"
+                'output must have complex dtype for complex inputs'
             )
         float_dtype = cupy.promote_types(output.dtype, min_float_dtype)
         output_dtype = output.dtype
@@ -71,7 +71,7 @@ def _get_spline_output(input, output):
 
 
 def spline_filter1d(input, order=3, axis=-1, output=cupy.float64,
-                    mode="mirror"):
+                    mode='mirror'):
     """
     Calculate a 1-D spline filter along the given axis.
 
@@ -98,7 +98,7 @@ def spline_filter1d(input, order=3, axis=-1, output=cupy.float64,
     .. seealso:: :func:`scipy.spline_filter1d`
     """
     if order < 0 or order > 5:
-        raise RuntimeError("spline order not supported")
+        raise RuntimeError('spline order not supported')
     x = input
     ndim = x.ndim
     axis = internal._normalize_axis_index(axis, ndim)
@@ -154,7 +154,7 @@ def spline_filter1d(input, order=3, axis=-1, output=cupy.float64,
     return temp.astype(output_dtype, copy=False)
 
 
-def spline_filter(input, order=3, output=cupy.float64, mode="mirror"):
+def spline_filter(input, order=3, output=cupy.float64, mode='mirror'):
     """Multidimensional spline filter.
 
     Args:
@@ -175,7 +175,7 @@ def spline_filter(input, order=3, output=cupy.float64, mode="mirror"):
     .. seealso:: :func:`scipy.spline_filter1d`
     """
     if order < 2 or order > 5:
-        raise RuntimeError("spline order not supported")
+        raise RuntimeError('spline order not supported')
 
     x = input
     temp, data_dtype, output_dtype = _get_spline_output(x, output)
@@ -320,7 +320,7 @@ def affine_transform(input, matrix, offset=0.0, output_shape=None, output=None,
             offset = matrix[:-1, -1]
             matrix = matrix[:-1, :-1]
         if matrix.shape != (input.ndim, input.ndim):
-            raise RuntimeError("improper affine shape")
+            raise RuntimeError('improper affine shape')
 
     if mode == 'opencv':
         m = cupy.zeros((input.ndim + 1, input.ndim + 1))

--- a/cupyx/scipy/ndimage/interpolation.py
+++ b/cupyx/scipy/ndimage/interpolation.py
@@ -4,6 +4,7 @@ import warnings
 import cupy
 import numpy
 
+import cupy._util
 from cupy.core import internal
 from cupyx.scipy.ndimage import _util
 from cupyx.scipy.ndimage import _interp_kernels
@@ -24,6 +25,9 @@ def _check_parameter(func_name, order, mode):
         # orders will be implemented, therefore it raises NotImplementedError
         # instead of ValueError.
         raise NotImplementedError('spline order is not supported')
+
+    if mode in ['grid-mirror', 'grid-wrap', 'grid-reflect', 'wrap', 'reflect']:
+        cupy._util.experimental(f"mode '{mode}' is currently experimental")
 
     if mode not in ('constant', 'grid-constant', 'nearest', 'mirror',
                     'reflect', 'grid-mirror', 'wrap', 'grid-wrap', 'opencv',

--- a/cupyx/scipy/ndimage/interpolation.py
+++ b/cupyx/scipy/ndimage/interpolation.py
@@ -649,6 +649,8 @@ def zoom(input, zoom, output=None, order=None, mode='constant', cval=0.0,
             order = 1
 
         if grid_mode:
+            cupy._util.experimental("grid_mode=True is currently experimental")
+
             # warn about modes that may have surprising behavior
             suggest_mode = None
             if mode == 'constant':

--- a/cupyx/scipy/ndimage/interpolation.py
+++ b/cupyx/scipy/ndimage/interpolation.py
@@ -649,7 +649,7 @@ def zoom(input, zoom, output=None, order=None, mode='constant', cval=0.0,
             order = 1
 
         if grid_mode:
-            cupy._util.experimental("grid_mode=True is currently experimental")
+            cupy._util.experimental("grid_mode=True")
 
             # warn about modes that may have surprising behavior
             suggest_mode = None

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
@@ -579,6 +579,28 @@ class TestZoom:
         return out
 
 
+@testing.parameterize(*testing.product({
+    'shape': [(2, 3), (4, 4)],
+    'zoom': [(1, 1), (3, 5), (8, 2), (8, 8)],
+    'mode': ['nearest', 'reflect', 'mirror', 'grid-wrap', 'grid-constant'],
+}))
+@testing.gpu
+class TestZoomIntegerGrid():
+
+    def test_zoom_grid_by_int_order0(self):
+        # When grid_mode is True,  order 0 zoom should be the same as
+        # replication via a Kronecker product. The only exceptions to this are
+        # the non-grid modes 'constant' and 'wrap'.
+        size = numpy.prod(self.shape)
+        x = cupy.arange(size, dtype=float).reshape(self.shape)
+        testing.assert_array_almost_equal(
+            cupyx.scipy.ndimage.zoom(
+                x, self.zoom, order=0, mode=self.mode, grid_mode=True
+            ),
+            cupy.kron(x, cupy.ones(self.zoom)),
+        )
+
+
 @testing.parameterize(
     {'zoom': 3},
     {'zoom': 0.3},

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
@@ -615,7 +615,7 @@ class TestSplineFilter1d:
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
     def test_spline_filter1d(self, xp, scp):
         if self.mode == 'grid-wrap' and scipy_version < '1.6.0':
-            pytest.skip("testing mode grid-wrap requires scipy >= 1.6.0")
+            pytest.skip('testing mode grid-wrap requires scipy >= 1.6.0')
         x = testing.shaped_random((16, 12, 11), dtype=self.dtype, xp=xp)
         return scp.ndimage.spline_filter1d(x, order=self.order, axis=self.axis,
                                            output=self.output, mode=self.mode)
@@ -624,7 +624,7 @@ class TestSplineFilter1d:
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
     def test_spline_filter1d_output(self, xp, scp, array_order):
         if self.mode == 'grid-wrap' and scipy_version < '1.6.0':
-            pytest.skip("testing mode grid-wrap requires scipy >= 1.6.0")
+            pytest.skip('testing mode grid-wrap requires scipy >= 1.6.0')
         x = testing.shaped_random((16, 12, 11), dtype=self.dtype, xp=xp,
                                   order=array_order)
         output = xp.empty(x.shape, dtype=self.output, order=array_order)
@@ -646,7 +646,7 @@ class TestSplineFilter:
     @testing.numpy_cupy_allclose(atol=1e-4, rtol=1e-4, scipy_name='scp')
     def test_spline_filter(self, xp, scp):
         if self.mode == 'grid-wrap' and scipy_version < '1.6.0':
-            pytest.skip("testing mode grid-wrap requires scipy >= 1.6.0")
+            pytest.skip('testing mode grid-wrap requires scipy >= 1.6.0')
         x = testing.shaped_random((16, 12, 11), dtype=self.dtype, xp=xp)
         if self.order < 2:
             with pytest.raises(RuntimeError):
@@ -660,7 +660,7 @@ class TestSplineFilter:
     @testing.numpy_cupy_allclose(atol=1e-4, rtol=1e-4, scipy_name='scp')
     def test_spline_filter_with_output(self, xp, scp, array_order):
         if self.mode == 'grid-wrap' and scipy_version < '1.6.0':
-            pytest.skip("testing mode grid-wrap requires scipy >= 1.6.0")
+            pytest.skip('testing mode grid-wrap requires scipy >= 1.6.0')
         x = testing.shaped_random((16, 12, 11), dtype=self.dtype, xp=xp,
                                   order=array_order)
         output = xp.empty(x.shape, dtype=self.output, order=array_order)

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
@@ -694,6 +694,8 @@ class TestSplineFilterComplex:
     # the following test case is for SciPy versions lacking complex support
     @testing.with_requires('scipy<1.6')
     def test_spline_filter_complex2(self):
+        if self.mode == 'wrap':
+            pytest.skip('mode cannot be tested against SciPy < 1.6')
         cpu_func = scipy.ndimage.spline_filter
         gpu_func = cupyx.scipy.ndimage.spline_filter
         x = testing.shaped_random((16, 12, 11), dtype=self.dtype, xp=numpy)


### PR DESCRIPTION
blocked by #4400 (This PR builds on that one. Only the final "ENH: implement grid_mode parameter for zoom" commit here is new)

This PR implements zooming in a manner consistent with scikit-image's `resize` and OpenCV's `cv2.resize`. See further explanation in the corresponding SciPy PR scipy/scipy#13095 (to be released in SciPy 1.6).

Basically the issue relates to whether coordinate (0, 0) is at the center or corner of a pixel. In the kernel, this translates into computing coordinates via: 
`c = zoom * (in_coord + 0.5) - 0.5` (for grid_mode=True)
 vs.
`c = zoom * in_coord` (for grid_mode=False)


