### PR TITLE
ndimage: implement higher order spline interpolation

### DIFF
--- a/cupyx/scipy/ndimage/_interp_kernels.py
+++ b/cupyx/scipy/ndimage/_interp_kernels.py
@@ -3,6 +3,8 @@ import numpy
 import cupy
 import cupy.core.internal
 
+from cupyx.scipy.ndimage import _spline_prefilter_core
+from cupyx.scipy.ndimage import _spline_kernel_weights
 from cupyx.scipy.ndimage import _util
 
 math_constants_preamble = r'''
@@ -10,8 +12,10 @@ math_constants_preamble = r'''
 #include <cupy/math_constants.h>
 '''
 
+spline_weights_inline = _spline_kernel_weights.spline_weights_inline
 
-def _get_coord_map(ndim):
+
+def _get_coord_map(ndim, nprepad=0):
     """Extract target coordinate from coords array (for map_coordinates).
 
     Notes
@@ -33,13 +37,13 @@ def _get_coord_map(ndim):
     """
     ops = []
     ops.append('ptrdiff_t ncoords = _ind.size();')
+    pre = f" + (W){nprepad}" if nprepad > 0 else ''
     for j in range(ndim):
         ops.append(f'''
-    W c_{j} = coords[i + {j} * ncoords];''')
-    return ops
+    W c_{j} = coords[i + {j} * ncoords]{pre};''')
 
 
-def _get_coord_zoom_and_shift(ndim):
+def _get_coord_zoom_and_shift(ndim, nprepad=0):
     """Compute target coordinate based on a shift followed by a zoom.
 
     This version zooms from the center of the edge pixels.
@@ -58,13 +62,14 @@ def _get_coord_zoom_and_shift(ndim):
 
     """
     ops = []
+    pre = f" + (W){nprepad}" if nprepad > 0 else ''
     for j in range(ndim):
         ops.append(f'''
-    W c_{j} = zoom[{j}] * ((W)in_coord[{j}] - shift[{j}]);''')
+    W c_{j} = zoom[{j}] * ((W)in_coord[{j}] - shift[{j}]){pre};''')
     return ops
 
 
-def _get_coord_zoom_and_shift_grid(ndim):
+def _get_coord_zoom_and_shift_grid(ndim, nprepad=0):
     """Compute target coordinate based on a shift followed by a zoom.
 
     This version zooms from the outer edges of the grid pixels.
@@ -83,10 +88,12 @@ def _get_coord_zoom_and_shift_grid(ndim):
 
     """
     ops = []
+    pre = f" + (W){nprepad}" if nprepad > 0 else ''
     for j in range(ndim):
         ops.append(f'''
-    W c_{j} = zoom[{j}] * ((W)in_coord[{j}] - shift[j] + 0.5) - 0.5;''')
+    W c_{j} = zoom[{j}] * ((W)in_coord[{j}] - shift[j] + 0.5) - 0.5{pre};''')
     return ops
+
 
 
 def _get_coord_zoom(ndim, nprepad=0):
@@ -107,9 +114,10 @@ def _get_coord_zoom(ndim, nprepad=0):
 
     """
     ops = []
+    pre = f" + (W){nprepad}" if nprepad > 0 else ''
     for j in range(ndim):
         ops.append(f'''
-    W c_{j} = zoom[{j}] * (W)in_coord[{j}];''')
+    W c_{j} = zoom[{j}] * (W)in_coord[{j}]{pre};''')
     return ops
 
 
@@ -131,9 +139,10 @@ def _get_coord_zoom_grid(ndim, nprepad=0):
 
     """
     ops = []
+    pre = f" + (W){nprepad}" if nprepad > 0 else ''
     for j in range(ndim):
         ops.append(f'''
-    W c_{j} = zoom[{j}] * ((W)in_coord[{j}] + 0.5) - 0.5;''')
+    W c_{j} = zoom[{j}] * ((W)in_coord[{j}] + 0.5) - 0.5{pre};''')
     return ops
 
 
@@ -153,13 +162,14 @@ def _get_coord_shift(ndim, nprepad=0):
 
     """
     ops = []
+    pre = f" + (W){nprepad}" if nprepad > 0 else ''
     for j in range(ndim):
         ops.append(f'''
-    W c_{j} = (W)in_coord[{j}] - shift[{j}];''')
+    W c_{j} = (W)in_coord[{j}] - shift[{j}]{pre};''')
     return ops
 
 
-def _get_coord_affine(ndim):
+def _get_coord_affine(ndim, nprepad=0):
     """Compute target coordinate based on a homogeneous transformation matrix.
 
     The homogeneous matrix has shape (ndim, ndim + 1). It corresponds to
@@ -180,6 +190,7 @@ def _get_coord_affine(ndim):
 
     """
     ops = []
+    pre = f" + (W){nprepad}" if nprepad > 0 else ''
     ncol = ndim + 1
     for j in range(ndim):
         ops.append(f'''
@@ -188,7 +199,7 @@ def _get_coord_affine(ndim):
             ops.append(f'''
             c_{j} += mat[{ncol * j + k}] * (W)in_coord[{k}];''')
         ops.append(f'''
-            c_{j} += mat[{ncol * j + ndim}];''')
+            c_{j} += mat[{ncol * j + ndim}]{pre};''')
     return ops
 
 
@@ -213,7 +224,7 @@ def _unravel_loop_index(shape, uint_t='unsigned int'):
 
 
 def _generate_interp_custom(coord_func, ndim, large_int, yshape, mode, cval,
-                            order, name='', integer_output=False):
+                            order, name='', integer_output=False, nprepad=0,):
     """
     Args:
         coord_func (function): generates code to do the coordinate
@@ -226,6 +237,8 @@ def _generate_interp_custom(coord_func, ndim, large_int, yshape, mode, cval,
         name (str): base name for the interpolation kernel
         integer_output (bool): boolean indicating whether the output has an
             integer type.
+        nprepad (int): integer indicating the amount of prepadding at the
+            boundaries.
 
     Returns:
         operation (str): code body for the ElementwiseKernel
@@ -253,7 +266,7 @@ def _generate_interp_custom(coord_func, ndim, large_int, yshape, mode, cval,
     ops.append(_unravel_loop_index(yshape, uint_t))
 
     # compute the transformed (target) coordinates, c_j
-    ops = ops + coord_func(ndim)
+    ops = ops + coord_func(ndim, nprepad)
 
     if cval is numpy.nan:
         cval = 'CUDART_NAN'
@@ -374,6 +387,64 @@ def _generate_interp_custom(coord_func, ndim, large_int, yshape, mode, cval,
                         w_{j} = c_{j} - (W)cf_{j};
                         ic_{j} = cc_bounded_{j} * sx_{j};
                     }}''')
+    elif order > 1:
+        if mode == 'grid-constant':
+            spline_mode = 'constant'
+        elif mode == 'nearest':
+            spline_mode = 'nearest'
+        else:
+            spline_mode = _spline_prefilter_core._get_spline_mode(mode)
+
+        # wx, wy are temporary variables used during spline weight computation
+        ops.append(f'''
+            W wx, wy;
+            {int_t} start;''')
+        for j in range(ndim):
+            # determine weights along the current axis
+            ops.append(f'''
+            W weights_{j}[{order + 1}];''')
+            ops.append(spline_weights_inline[order].format(j=j, order=order))
+
+            # get starting coordinate for spline interpolation along axis j
+            if mode in ['wrap']:
+                ops.append(f'double dcoord = c_{j};')
+                coord_var = 'dcoord'
+                ops.append(
+                    _util._generate_boundary_condition_ops(
+                        mode, coord_var, f'xsize_{j}', int_t, True))
+            else:
+                coord_var = f'(double)c_{j}'
+
+            if order & 1:
+                op_str = '''
+                start = ({int_t})floor({coord_var}) - {order_2};'''
+            else:
+                op_str = '''
+                start = ({int_t})floor({coord_var} + 0.5) - {order_2};'''
+            ops.append(
+                op_str.format(
+                    int_t=int_t, coord_var=coord_var, order_2=order // 2
+                ))
+
+            # set of coordinate values within spline footprint along axis j
+            ops.append(f'''{int_t} ci_{j}[{order + 1}];''')
+            for k in range(order + 1):
+                ixvar = f'ci_{j}[{k}]'
+                ops.append(f'''
+                {ixvar} = start + {k};''')
+                ops.append(
+                    _util._generate_boundary_condition_ops(
+                        spline_mode, ixvar, f'xsize_{j}', int_t))
+
+            # loop over the order + 1 values in the spline filter
+            ops.append(f'''
+            W w_{j};
+            {int_t} ic_{j};
+            for (int k_{j} = 0; k_{j} <= {order}; k_{j}++)
+                {{
+                    w_{j} = weights_{j}[k_{j}];
+                    ic_{j} = ci_{j}[k_{j}] * sx_{j};
+            ''')
 
     if order > 0:
 
@@ -415,7 +486,7 @@ def _generate_interp_custom(coord_func, ndim, large_int, yshape, mode, cval,
 
 @cupy._util.memoize(for_each_device=True)
 def _get_map_kernel(ndim, large_int, yshape, mode, cval=0.0, order=1,
-                    integer_output=False):
+                    integer_output=False, nprepad=0):
     in_params = 'raw X x, raw W coords'
     out_params = 'Y y'
     operation, name = _generate_interp_custom(
@@ -428,6 +499,7 @@ def _get_map_kernel(ndim, large_int, yshape, mode, cval=0.0, order=1,
         order=order,
         name='shift',
         integer_output=integer_output,
+        nprepad=nprepad,
     )
     return cupy.ElementwiseKernel(in_params, out_params, operation, name,
                                   preamble=math_constants_preamble)
@@ -435,7 +507,7 @@ def _get_map_kernel(ndim, large_int, yshape, mode, cval=0.0, order=1,
 
 @cupy._util.memoize(for_each_device=True)
 def _get_shift_kernel(ndim, large_int, yshape, mode, cval=0.0, order=1,
-                      integer_output=False):
+                      integer_output=False, nprepad=0):
     in_params = 'raw X x, raw W shift'
     out_params = 'Y y'
     operation, name = _generate_interp_custom(
@@ -448,6 +520,7 @@ def _get_shift_kernel(ndim, large_int, yshape, mode, cval=0.0, order=1,
         order=order,
         name='shift',
         integer_output=integer_output,
+        nprepad=nprepad,
     )
     return cupy.ElementwiseKernel(in_params, out_params, operation, name,
                                   preamble=math_constants_preamble)
@@ -455,7 +528,7 @@ def _get_shift_kernel(ndim, large_int, yshape, mode, cval=0.0, order=1,
 
 @cupy._util.memoize(for_each_device=True)
 def _get_zoom_shift_kernel(ndim, large_int, yshape, mode, cval=0.0, order=1,
-                           integer_output=False, grid_mode=False):
+                           integer_output=False, grid_mode=False, nprepad=0):
     in_params = 'raw X x, raw W shift, raw W zoom'
     out_params = 'Y y'
     if grid_mode:
@@ -472,6 +545,7 @@ def _get_zoom_shift_kernel(ndim, large_int, yshape, mode, cval=0.0, order=1,
         order=order,
         name="zoom_shift_grid" if grid_mode else "zoom_shift",
         integer_output=integer_output,
+        nprepad=nprepad,
     )
     return cupy.ElementwiseKernel(in_params, out_params, operation, name,
                                   preamble=math_constants_preamble)
@@ -492,6 +566,7 @@ def _get_zoom_kernel(ndim, large_int, yshape, mode, cval=0.0, order=1,
         order=order,
         name="zoom_grid" if grid_mode else "zoom",
         integer_output=integer_output,
+        nprepad=nprepad,
     )
     return cupy.ElementwiseKernel(in_params, out_params, operation, name,
                                   preamble=math_constants_preamble)
@@ -499,7 +574,7 @@ def _get_zoom_kernel(ndim, large_int, yshape, mode, cval=0.0, order=1,
 
 @cupy._util.memoize(for_each_device=True)
 def _get_affine_kernel(ndim, large_int, yshape, mode, cval=0.0, order=1,
-                       integer_output=False):
+                       integer_output=False, nprepad=0):
     in_params = 'raw X x, raw W mat'
     out_params = 'Y y'
     operation, name = _generate_interp_custom(
@@ -512,6 +587,7 @@ def _get_affine_kernel(ndim, large_int, yshape, mode, cval=0.0, order=1,
         order=order,
         name='affine',
         integer_output=integer_output,
+        nprepad=nprepad,
     )
     return cupy.ElementwiseKernel(in_params, out_params, operation, name,
                                   preamble=math_constants_preamble)

--- a/cupyx/scipy/ndimage/_interp_kernels.py
+++ b/cupyx/scipy/ndimage/_interp_kernels.py
@@ -553,7 +553,7 @@ def _get_zoom_shift_kernel(ndim, large_int, yshape, mode, cval=0.0, order=1,
 
 @cupy._util.memoize(for_each_device=True)
 def _get_zoom_kernel(ndim, large_int, yshape, mode, cval=0.0, order=1,
-                     integer_output=False, grid_mode=False):
+                     integer_output=False, grid_mode=False, nprepad=0):
     in_params = 'raw X x, raw W zoom'
     out_params = 'Y y'
     operation, name = _generate_interp_custom(

--- a/cupyx/scipy/ndimage/_interp_kernels.py
+++ b/cupyx/scipy/ndimage/_interp_kernels.py
@@ -41,6 +41,7 @@ def _get_coord_map(ndim, nprepad=0):
     for j in range(ndim):
         ops.append(f'''
     W c_{j} = coords[i + {j} * ncoords]{pre};''')
+    return ops
 
 
 def _get_coord_zoom_and_shift(ndim, nprepad=0):
@@ -93,7 +94,6 @@ def _get_coord_zoom_and_shift_grid(ndim, nprepad=0):
         ops.append(f'''
     W c_{j} = zoom[{j}] * ((W)in_coord[{j}] - shift[j] + 0.5) - 0.5{pre};''')
     return ops
-
 
 
 def _get_coord_zoom(ndim, nprepad=0):
@@ -224,7 +224,7 @@ def _unravel_loop_index(shape, uint_t='unsigned int'):
 
 
 def _generate_interp_custom(coord_func, ndim, large_int, yshape, mode, cval,
-                            order, name='', integer_output=False, nprepad=0,):
+                            order, name='', integer_output=False, nprepad=0):
     """
     Args:
         coord_func (function): generates code to do the coordinate

--- a/cupyx/scipy/ndimage/_spline_kernel_weights.py
+++ b/cupyx/scipy/ndimage/_spline_kernel_weights.py
@@ -1,0 +1,73 @@
+"""Determination of spline kernel weights (adapted from SciPy)
+
+See more verbose comments for each case there:
+https://github.com/scipy/scipy/blob/eba29d69846ab1299976ff4af71c106188397ccc/scipy/ndimage/src/ni_splines.c#L7   # NOQA
+
+``spline_weights_inline`` is a dict where the key is the spline order and the
+value is the spline weight initialization code.
+"""
+
+spline_weights_inline = {}
+
+# Note: This order = 1 case is currently unused (order = 1 has a different code
+# path in _interp_kernels.py). I think that existing code is a bit more
+# efficient.
+spline_weights_inline[1] = '''
+wx = c_{j} - floor({order} & 1 ? c_{j} : c_{j} + 0.5);
+weights_{j}[0] = 1.0 - wx;
+weights_{j}[1] = wx;
+'''
+
+spline_weights_inline[2] = '''
+wx = c_{j} - floor({order} & 1 ? c_{j} : c_{j} + 0.5);
+weights_{j}[1] = 0.75 - wx * wx;
+wy = 0.5 - wx;
+weights_{j}[0] = 0.5 * wy * wy;
+weights_{j}[2] = 1.0 - weights_{j}[0] - weights_{j}[1];
+'''
+
+spline_weights_inline[3] = '''
+wx = c_{j} - floor({order} & 1 ? c_{j} : c_{j} + 0.5);
+wy = 1.0 - wx;
+weights_{j}[1] = (wx * wx * (wx - 2.0) * 3.0 + 4.0) / 6.0;
+weights_{j}[2] = (wy * wy * (wy - 2.0) * 3.0 + 4.0) / 6.0;
+weights_{j}[0] = wy * wy * wy / 6.0;
+weights_{j}[3] = 1.0 - weights_{j}[0] - weights_{j}[1] - weights_{j}[2];
+'''
+
+spline_weights_inline[4] = '''
+wx = c_{j} - floor({order} & 1 ? c_{j} : c_{j} + 0.5);
+wy = wx * wx;
+weights_{j}[2] = wy * (wy * 0.25 - 0.625) + 115.0 / 192.0;
+wy = 1.0 + wx;
+weights_{j}[1] = wy * (wy * (wy * (5.0 - wy) / 6.0 - 1.25) + 5.0 / 24.0) +
+             55.0 / 96.0;
+wy = 1.0 - wx;
+weights_{j}[3] = wy * (wy * (wy * (5.0 - wy) / 6.0 - 1.25) + 5.0 / 24.0) +
+             55.0 / 96.0;
+wy = 0.5 - wx;
+wy = wy * wy;
+weights_{j}[0] = wy * wy / 24.0;
+weights_{j}[4] = 1.0 - weights_{j}[0] - weights_{j}[1]
+                     - weights_{j}[2] - weights_{j}[3];
+'''
+
+spline_weights_inline[5] = '''
+wx = c_{j} - floor({order} & 1 ? c_{j} : c_{j} + 0.5);
+wy = wx * wx;
+weights_{j}[2] = wy * (wy * (0.25 - wx / 12.0) - 0.5) + 0.55;
+wy = 1.0 - wx;
+wy = wy * wy;
+weights_{j}[3] = wy * (wy * (0.25 - (1.0 - wx) / 12.0) - 0.5) + 0.55;
+wy = wx + 1.0;
+weights_{j}[1] = wy * (wy * (wy * (wy * (wy / 24.0 - 0.375) + 1.25) - 1.75)
+                   + 0.625) + 0.425;
+wy = 2.0 - wx;
+weights_{j}[4] = wy * (wy * (wy * (wy * (wy / 24.0 - 0.375) + 1.25) - 1.75)
+                  + 0.625) + 0.425;
+wy = 1.0 - wx;
+wy = wy * wy;
+weights_{j}[0] = (1.0 - wx) * wy * wy / 120.0;
+weights_{j}[5] = 1.0 - weights_{j}[0] - weights_{j}[1] - weights_{j}[2]
+                     - weights_{j}[3] - weights_{j}[4];
+'''

--- a/cupyx/scipy/ndimage/interpolation.py
+++ b/cupyx/scipy/ndimage/interpolation.py
@@ -79,9 +79,8 @@ def spline_filter1d(input, order=3, axis=-1, output=cupy.float64,
 
     Args:
         input (cupy.ndarray): The input array.
-        order (int): The order of the spline interpolation. If it is not given,
-            order 1 is used. It is different from :mod:`scipy.ndimage` and can
-            change in the future. Currently it supports only order 0 and 1.
+        order (int): The order of the spline interpolation, default is 3. Must
+            be in the range 0-5.
         axis (int): The axis along which the spline filter is applied. Default
             is the last axis.
         output (cupy.ndarray or dtype, optional): The array in which to place
@@ -159,9 +158,8 @@ def spline_filter(input, order=3, output=cupy.float64, mode='mirror'):
 
     Args:
         input (cupy.ndarray): The input array.
-        order (int): The order of the spline interpolation. If it is not given,
-            order 1 is used. It is different from :mod:`scipy.ndimage` and can
-            change in the future. Currently it supports only order 0 and 1.
+        order (int): The order of the spline interpolation, default is 3. Must
+            be in the range 0-5.
         output (cupy.ndarray or dtype, optional): The array in which to place
             the output, or the dtype of the returned array. Default is
             ``numpy.float64``.
@@ -252,7 +250,7 @@ def _filter_input(image, prefilter, mode, cval, order):
     return cupy.ascontiguousarray(filtered), npad
 
 
-def map_coordinates(input, coordinates, output=None, order=None,
+def map_coordinates(input, coordinates, output=None, order=3,
                     mode='constant', cval=0.0, prefilter=True):
     """Map the input array to new coordinates by interpolation.
 
@@ -270,9 +268,8 @@ def map_coordinates(input, coordinates, output=None, order=None,
             evaluated.
         output (cupy.ndarray or ~cupy.dtype): The array in which to place the
             output, or the dtype of the returned array.
-        order (int): The order of the spline interpolation. If it is not given,
-            order 1 is used. It is different from :mod:`scipy.ndimage` and can
-            change in the future. Currently it supports only order 0 and 1.
+        order (int): The order of the spline interpolation, default is 3. Must
+            be in the range 0-5.
         mode (str): Points outside the boundaries of the input are filled
             according to the given mode (``'constant'``, ``'nearest'``,
             ``'mirror'``, ``'reflect'``, ``'wrap'``, ``'grid-mirror'``,
@@ -292,8 +289,6 @@ def map_coordinates(input, coordinates, output=None, order=None,
     """
 
     _check_parameter('map_coordinates', order, mode)
-    if order is None:
-        order = 1
 
     if mode == 'opencv' or mode == '_opencv_edge':
         input = cupy.pad(input, [(1, 1)] * input.ndim, 'constant',
@@ -318,7 +313,7 @@ def map_coordinates(input, coordinates, output=None, order=None,
 
 
 def affine_transform(input, matrix, offset=0.0, output_shape=None, output=None,
-                     order=None, mode='constant', cval=0.0, prefilter=True):
+                     order=3, mode='constant', cval=0.0, prefilter=True):
     """Apply an affine transformation.
 
     Given an output image pixel index vector ``o``, the pixel value is
@@ -350,9 +345,8 @@ def affine_transform(input, matrix, offset=0.0, output_shape=None, output=None,
         output_shape (tuple of ints): Shape tuple.
         output (cupy.ndarray or ~cupy.dtype): The array in which to place the
             output, or the dtype of the returned array.
-        order (int): The order of the spline interpolation. If it is not given,
-            order 1 is used. It is different from :mod:`scipy.ndimage` and can
-            change in the future. Currently it supports only order 0 and 1.
+        order (int): The order of the spline interpolation, default is 3. Must
+            be in the range 0-5.
         mode (str): Points outside the boundaries of the input are filled
             according to the given mode (``'constant'``, ``'nearest'``,
             ``'mirror'``, ``'reflect'``, ``'wrap'``, ``'grid-mirror'``,
@@ -413,8 +407,6 @@ def affine_transform(input, matrix, offset=0.0, output_shape=None, output=None,
         return ret
 
     matrix = matrix.astype(cupy.float64, copy=False)
-    if order is None:
-        order = 1
     ndim = input.ndim
     output = _util._get_output(output, input, shape=output_shape)
     if input.dtype.kind in 'iu':
@@ -454,7 +446,7 @@ def _minmax(coor, minc, maxc):
     return minc, maxc
 
 
-def rotate(input, angle, axes=(1, 0), reshape=True, output=None, order=None,
+def rotate(input, angle, axes=(1, 0), reshape=True, output=None, order=3,
            mode='constant', cval=0.0, prefilter=True):
     """Rotate an array.
 
@@ -471,9 +463,8 @@ def rotate(input, angle, axes=(1, 0), reshape=True, output=None, order=None,
             is True.
         output (cupy.ndarray or ~cupy.dtype): The array in which to place the
             output, or the dtype of the returned array.
-        order (int): The order of the spline interpolation. If it is not given,
-            order 1 is used. It is different from :mod:`scipy.ndimage` and can
-            change in the future. Currently it supports only order 0 and 1.
+        order (int): The order of the spline interpolation, default is 3. Must
+            be in the range 0-5.
         mode (str): Points outside the boundaries of the input are filled
             according to the given mode (``'constant'``, ``'nearest'``,
             ``'mirror'``, ``'reflect'``, ``'wrap'``, ``'grid-mirror'``,
@@ -551,7 +542,7 @@ def rotate(input, angle, axes=(1, 0), reshape=True, output=None, order=None,
                             mode, cval, prefilter)
 
 
-def shift(input, shift, output=None, order=None, mode='constant', cval=0.0,
+def shift(input, shift, output=None, order=3, mode='constant', cval=0.0,
           prefilter=True):
     """Shift an array.
 
@@ -566,9 +557,8 @@ def shift(input, shift, output=None, order=None, mode='constant', cval=0.0,
             should contain one value for each axis.
         output (cupy.ndarray or ~cupy.dtype): The array in which to place the
             output, or the dtype of the returned array.
-        order (int): The order of the spline interpolation. If it is not given,
-            order 1 is used. It is different from :mod:`scipy.ndimage` and can
-            change in the future. Currently it supports only order 0 and 1.
+        order (int): The order of the spline interpolation, default is 3. Must
+            be in the range 0-5.
         mode (str): Points outside the boundaries of the input are filled
             according to the given mode (``'constant'``, ``'nearest'``,
             ``'mirror'``, ``'reflect'``, ``'wrap'``, ``'grid-mirror'``,
@@ -605,8 +595,6 @@ def shift(input, shift, output=None, order=None, mode='constant', cval=0.0,
             prefilter,
         )
     else:
-        if order is None:
-            order = 1
         output = _util._get_output(output, input)
         if input.dtype.kind in 'iu':
             input = input.astype(cupy.float32)
@@ -626,7 +614,7 @@ def shift(input, shift, output=None, order=None, mode='constant', cval=0.0,
     return output
 
 
-def zoom(input, zoom, output=None, order=None, mode='constant', cval=0.0,
+def zoom(input, zoom, output=None, order=3, mode='constant', cval=0.0,
          prefilter=True, *, grid_mode=False):
     """Zoom an array.
 
@@ -639,9 +627,8 @@ def zoom(input, zoom, output=None, order=None, mode='constant', cval=0.0,
             contain one value for each axis.
         output (cupy.ndarray or ~cupy.dtype): The array in which to place the
             output, or the dtype of the returned array.
-        order (int): The order of the spline interpolation. If it is not given,
-            order 1 is used. It is different from :mod:`scipy.ndimage` and can
-            change in the future. Currently it supports only order 0 and 1.
+        order (int): The order of the spline interpolation, default is 3. Must
+            be in the range 0-5.
         mode (str): Points outside the boundaries of the input are filled
             according to the given mode (``'constant'``, ``'nearest'``,
             ``'mirror'``, ``'reflect'``, ``'wrap'``, ``'grid-mirror'``,
@@ -707,9 +694,6 @@ def zoom(input, zoom, output=None, order=None, mode='constant', cval=0.0,
             prefilter,
         )
     else:
-        if order is None:
-            order = 1
-
         if grid_mode:
             cupy._util.experimental("grid_mode=True")
 

--- a/cupyx/scipy/ndimage/interpolation.py
+++ b/cupyx/scipy/ndimage/interpolation.py
@@ -234,7 +234,7 @@ def _prepad_for_spline_filter(input, mode, cval):
     return padded, npad
 
 
-def _filter_input(image, prefilter, mode, cval, order, allow_float32=True):
+def _filter_input(image, prefilter, mode, cval, order):
     """Perform spline prefiltering when needed.
 
     Spline orders > 1 need a prefiltering stage to preserve resolution.
@@ -247,8 +247,8 @@ def _filter_input(image, prefilter, mode, cval, order, allow_float32=True):
     if not prefilter or order < 2:
         return (cupy.ascontiguousarray(image), 0)
     padded, npad = _prepad_for_spline_filter(image, mode, cval)
-    filtered = spline_filter(padded, order, output=image.dtype,
-                             mode=mode, allow_float32=True)
+    float_dtype = cupy.promote_types(image.dtype, cupy.float32)
+    filtered = spline_filter(padded, order, output=float_dtype, mode=mode)
     return cupy.ascontiguousarray(filtered), npad
 
 

--- a/cupyx/scipy/ndimage/interpolation.py
+++ b/cupyx/scipy/ndimage/interpolation.py
@@ -292,6 +292,8 @@ def map_coordinates(input, coordinates, output=None, order=None,
     """
 
     _check_parameter('map_coordinates', order, mode)
+    if order is None:
+        order = 1
 
     if mode == 'opencv' or mode == '_opencv_edge':
         input = cupy.pad(input, [(1, 1)] * input.ndim, 'constant',


### PR DESCRIPTION
closes #1523

blocked by #4400 and #4401

### Overview

This PR implements spline interpolation orders 2-5. Spline interpolation was substantially improved in SciPy 1.6, with all boundary modes now being handled correctly. Only the `mode='mirror'` cases can be compared tested against older SciPy.

**To decide**: How do we want to handle the order argument to these functions. Should we change the default back from None to 3 so that it matches SciPy? For now, I have left it as it was in CuPy 8.0.

### Performance

I will post some benchmark results when I get a chance. This is still fast relative to SciPy, but the acceleration is worse than that seen for orders 0 and 1. I would like to see if there is a way to refactor this a bit to reduce register usage, as I suspect that is part of the reason for the performance difference. 
