### PR TITLE
Add support for cuTENSOR 1.2.2

### DIFF
--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -425,16 +425,19 @@ def preconfigure_modules(compiler, settings):
         errmsg = []
 
         if module['name'] == 'cutensor':
-            cuda_version = build.get_cuda_version()
-            cuda_version = str(cuda_version // 1000) + '.' + \
-                str((cuda_version // 10) % 100)
             cutensor_path = os.environ.get('CUTENSOR_PATH', '')
             inc_path = os.path.join(cutensor_path, 'include')
             if os.path.exists(inc_path):
                 settings['include_dirs'].append(inc_path)
-            lib_path = os.path.join(cutensor_path, 'lib', cuda_version)
-            if os.path.exists(lib_path):
-                settings['library_dirs'].append(lib_path)
+            cuda_version = build.get_cuda_version()
+            cuda_major = str(cuda_version // 1000)
+            cuda_major_minor = cuda_major + '.' + \
+                str((cuda_version // 10) % 100)
+            for cuda_ver in (cuda_major_minor, cuda_major):
+                lib_path = os.path.join(cutensor_path, 'lib', cuda_ver)
+                if os.path.exists(lib_path):
+                    settings['library_dirs'].append(lib_path)
+                    break
 
         print('')
         print('-------- Configuring Module: {} --------'.format(


### PR DESCRIPTION
This PR adds support for cuTENSOR 1.2.2.

There is no API change from version 1.2.1, so there is no need to change any compute routines.
As of 1.2.2, the cuTENSOR's library files for CUDA 11.x are now common, and this PR just adds changes to accommodate it. 