### PR TITLE
[DO NOT MERGE] Windows CI Test Branch

### DIFF
--- a/.pfnci/config.pbtxt
+++ b/.pfnci/config.pbtxt
@@ -53,7 +53,7 @@ configs {
       include_dot_git: true
     }
     environment_variables { key: "GPU" value: "2" }
-    command: ".pfnci/windows/main.bat 10.0 3.7"
+    command: ".pfnci\\windows\\main.bat 10.0 3.7"
   }
 }
 

--- a/.pfnci/config.pbtxt
+++ b/.pfnci/config.pbtxt
@@ -36,6 +36,26 @@ configs {
     command: "bash .pfnci/script.sh py37"
   }
 }
+configs {
+  key: "cupy.win.cuda100"
+  value {
+    requirement {
+      cpu: 8
+      memory: 24
+      disk: 10
+      gpu: 2
+    }
+    time_limit {
+      seconds: 3600
+    }
+    checkout_strategy {
+      include_dot_git: true
+    }
+    environment_variables { key: "GPU" value: "2" }
+    command: ".pfnci/windows/main.bat 10.0 3.7"
+  }
+}
+
 
 # CuPy CI related targets: cupy.docker.{version}.{action}.
 # - version should be either "py37" or "py27and35".

--- a/.pfnci/config.pbtxt
+++ b/.pfnci/config.pbtxt
@@ -44,6 +44,7 @@ configs {
       memory: 24
       disk: 10
       gpu: 2
+      image: "windows"
     }
     time_limit {
       seconds: 3600

--- a/.pfnci/config.pbtxt
+++ b/.pfnci/config.pbtxt
@@ -47,7 +47,7 @@ configs {
       image: "windows"
     }
     time_limit {
-      seconds: 3600
+      seconds: 36000
     }
     checkout_strategy {
       include_dot_git: true

--- a/.pfnci/trim_cupy_kernel_cache.py
+++ b/.pfnci/trim_cupy_kernel_cache.py
@@ -25,13 +25,21 @@ def main():
 
     expiry = datetime.datetime.now() - datetime.timedelta(
                 seconds=options.expiry)
-    sys.stderr.write('Expiring cache unused since {}\n'.format(expiry))
+    sys.stderr.write('Looking for cache unused since {}\n'.format(expiry))
     expiry_ts = expiry.timestamp()
+
+    total_size = 0
+    trim_size = 0
     for f in glob.glob(os.path.expanduser('~/.cupy/kernel_cache/*.cubin')):
-        if os.lstat(f).st_atime < expiry_ts:
+        stat = os.lstat(f)
+        total_size += stat.st_size
+        if stat.st_atime < expiry_ts:
             print(f)
+            trim_size += stat.st_size
             if options.rm:
                 os.unlink(f)
+    sys.stderr.write('Total: {} bytes\n'.format(total_size))
+    sys.stderr.write('Expired: {} bytes\n'.format(trim_size))
 
 
 if __name__ == '__main__':

--- a/.pfnci/trim_cupy_kernel_cache.py
+++ b/.pfnci/trim_cupy_kernel_cache.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+
+"""
+A tool to clean-up unused CuPy kernel caches.
+
+The expiry is the length to invalidate unused CuPy cache, in seconds.
+For example, setting the expiry to 3,600 will trim all kernel caches
+not being used within an hour.
+
+Note that this code relies on atime support of the filesystem.
+"""
+
+import argparse
+import datetime
+import glob
+import os
+import sys
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--expiry', type=int, required=True)
+    parser.add_argument('--rm', default=False, action='store_true')
+    options = parser.parse_args()
+
+    expiry = datetime.datetime.now() - datetime.timedelta(
+                seconds=options.expiry)
+    sys.stderr.write('Expiring cache unused since {}\n'.format(expiry))
+    expiry_ts = expiry.timestamp()
+    for f in glob.glob(os.path.expanduser('~/.cupy/kernel_cache/*.cubin')):
+        if os.lstat(f).st_atime < expiry_ts:
+            print(f)
+            if options.rm:
+                os.unlink(f)
+
+
+if __name__ == '__main__':
+    main()

--- a/.pfnci/windows/_cache_download.bat
+++ b/.pfnci/windows/_cache_download.bat
@@ -2,7 +2,9 @@ if "%CUPY_CI_NO_CACHE%" == "1" (
     goto :eof
 )
 
+set ORIG_CD=%CD%
 cd %USERPROFILE%
 gsutil -m cp gs://tmp-asia-pfn-public-ci/cupy-ci/cupy_kernel_cache_windows.zip .
 7z x cupy_kernel_cache_windows.zip
 del cupy_kernel_cache_windows.zip
+cd %ORIG_CD%

--- a/.pfnci/windows/_cache_download.bat
+++ b/.pfnci/windows/_cache_download.bat
@@ -4,7 +4,7 @@ if "%CUPY_CI_NO_CACHE%" == "1" (
 
 set ORIG_CD=%CD%
 cd %USERPROFILE%
-gsutil -m cp gs://tmp-asia-pfn-public-ci/cupy-ci/cupy_kernel_cache_windows.zip .
+call gsutil -m cp gs://tmp-asia-pfn-public-ci/cupy-ci/cupy_kernel_cache_windows.zip .
 7z x cupy_kernel_cache_windows.zip
 del cupy_kernel_cache_windows.zip
 cd %ORIG_CD%

--- a/.pfnci/windows/_cache_download.bat
+++ b/.pfnci/windows/_cache_download.bat
@@ -1,0 +1,8 @@
+if "%CUPY_CI_NO_CACHE%" == "1" (
+    goto :eof
+)
+
+cd %USERPROFILE%
+gsutil -m cp gs://tmp-asia-pfn-public-ci/cupy-ci/cupy_kernel_cache_windows.zip .
+7z x cupy_kernel_cache_windows.zip
+del cupy_kernel_cache_windows.zip

--- a/.pfnci/windows/_cache_download.bat
+++ b/.pfnci/windows/_cache_download.bat
@@ -4,7 +4,8 @@ if "%CUPY_CI_NO_CACHE%" == "1" (
 
 set ORIG_CD=%CD%
 cd %USERPROFILE%
-call gsutil -m cp gs://tmp-asia-pfn-public-ci/cupy-ci/cupy_kernel_cache_windows.zip .
-7z x cupy_kernel_cache_windows.zip
-del cupy_kernel_cache_windows.zip
+set CACHE_FILE=cupy_kernel_cache_windows.zip
+call gsutil -m cp gs://tmp-asia-pfn-public-ci/cupy-ci/%CACHE_FILE% .
+7z x %CACHE_FILE%
+del %CACHE_FILE%
 cd %ORIG_CD%

--- a/.pfnci/windows/_cache_upload.bat
+++ b/.pfnci/windows/_cache_upload.bat
@@ -4,7 +4,9 @@ if "%CUPY_CI_NO_CACHE%" == "1" (
 
 python .pfnci\trim_cupy_kernel_cache.py --expiry 259200 --rm
 
+set ORIG_CD=%CD%
 cd %USERPROFILE%
 7z a -tzip cupy_kernel_cache.zip .cupy
 gsutil -m cp cupy_kernel_cache_windows.zip gs://tmp-asia-pfn-public-ci/cupy-ci/
 del cupy_kernel_cache_windows.zip
+cd %ORIG_CD%

--- a/.pfnci/windows/_cache_upload.bat
+++ b/.pfnci/windows/_cache_upload.bat
@@ -7,6 +7,6 @@ python .pfnci\trim_cupy_kernel_cache.py --expiry 259200 --rm
 set ORIG_CD=%CD%
 cd %USERPROFILE%
 7z a -tzip cupy_kernel_cache.zip .cupy
-gsutil -m cp cupy_kernel_cache_windows.zip gs://tmp-asia-pfn-public-ci/cupy-ci/
+call gsutil -m cp cupy_kernel_cache_windows.zip gs://tmp-asia-pfn-public-ci/cupy-ci/
 del cupy_kernel_cache_windows.zip
 cd %ORIG_CD%

--- a/.pfnci/windows/_cache_upload.bat
+++ b/.pfnci/windows/_cache_upload.bat
@@ -6,7 +6,8 @@ python .pfnci\trim_cupy_kernel_cache.py --expiry 259200 --rm
 
 set ORIG_CD=%CD%
 cd %USERPROFILE%
-7z a -tzip cupy_kernel_cache.zip .cupy
-call gsutil -m cp cupy_kernel_cache_windows.zip gs://tmp-asia-pfn-public-ci/cupy-ci/
-del cupy_kernel_cache_windows.zip
+set CACHE_FILE=cupy_kernel_cache_windows.zip
+7z a -tzip -mx=0 -mtc=on %CACHE_FILE% .cupy
+call gsutil -m cp %CACHE_FILE% gs://tmp-asia-pfn-public-ci/cupy-ci/
+del %CACHE_FILE%
 cd %ORIG_CD%

--- a/.pfnci/windows/_cache_upload.bat
+++ b/.pfnci/windows/_cache_upload.bat
@@ -7,6 +7,9 @@ python .pfnci\trim_cupy_kernel_cache.py --expiry 259200 --rm
 set ORIG_CD=%CD%
 cd %USERPROFILE%
 set CACHE_FILE=cupy_kernel_cache_windows.zip
+
+:: -mx=0 ... no compression
+:: -mtc=on ... preserve timestamp
 7z a -tzip -mx=0 -mtc=on %CACHE_FILE% .cupy
 call gsutil -m cp %CACHE_FILE% gs://tmp-asia-pfn-public-ci/cupy-ci/
 del %CACHE_FILE%

--- a/.pfnci/windows/_cache_upload.bat
+++ b/.pfnci/windows/_cache_upload.bat
@@ -1,0 +1,10 @@
+if "%CUPY_CI_NO_CACHE%" == "1" (
+    goto :eof
+)
+
+python .pfnci\trim_cupy_kernel_cache.py --expiry 259200 --rm
+
+cd %USERPROFILE%
+7z a -tzip cupy_kernel_cache.zip .cupy
+gsutil -m cp cupy_kernel_cache_windows.zip gs://tmp-asia-pfn-public-ci/cupy-ci/
+del cupy_kernel_cache_windows.zip

--- a/.pfnci/windows/_use_cuda.bat
+++ b/.pfnci/windows/_use_cuda.bat
@@ -22,8 +22,8 @@ if %VERSION% == 8.0 (
     set CUDA_PATH=%CUDA_PATH_V11_1%
 ) else (
     echo Unsupported CUDA version: %VERSION%
-    exit 1
-}
+    exit /b 1
+)
 
 set PATH=%CUDA_PATH%\bin;%ProgramFiles%\NVIDIA Corporation\NvToolsExt\bin\x64;%PATH%
 

--- a/.pfnci/windows/_use_cuda.bat
+++ b/.pfnci/windows/_use_cuda.bat
@@ -1,0 +1,31 @@
+:: This file must be invoked via "call" from another batch.
+
+set VERSION=%1
+
+if %VERSION% == 8.0 (
+    set CUDA_PATH=%CUDA_PATH_V8_0%
+) else if %VERSION% == 9.0 (
+    set CUDA_PATH=%CUDA_PATH_V9_0%
+) else if %VERSION% == 9.1 (
+    set CUDA_PATH=%CUDA_PATH_V9_1%
+) else if %VERSION% == 9.2 (
+    set CUDA_PATH=%CUDA_PATH_V9_2%
+) else if %VERSION% == 10.0 (
+    set CUDA_PATH=%CUDA_PATH_V10_0%
+) else if %VERSION% == 10.1 (
+    set CUDA_PATH=%CUDA_PATH_V10_1%
+) else if %VERSION% == 10.2 (
+    set CUDA_PATH=%CUDA_PATH_V10_2%
+) else if %VERSION% == 11.0 (
+    set CUDA_PATH=%CUDA_PATH_V11_0%
+) else if %VERSION% == 11.1 (
+    set CUDA_PATH=%CUDA_PATH_V11_1%
+) else (
+    echo Unsupported CUDA version: %VERSION%
+    exit 1
+}
+
+set PATH=%CUDA_PATH%\bin;%ProgramFiles%\NVIDIA Corporation\NvToolsExt\bin\x64;%PATH%
+
+:: Unset
+set VERSION=

--- a/.pfnci/windows/_use_python.bat
+++ b/.pfnci/windows/_use_python.bat
@@ -1,0 +1,20 @@
+:: This file must be invoked via "call" from another batch.
+
+set VERSION=%1
+
+if %VERSION% == 3.6 (
+    set PYTHON_ROOT=C:\Development\Python\Python36
+) else if %VERSION% == 3.7 (
+    set PYTHON_ROOT=C:\Development\Python\Python37
+) else if %VERSION% == 3.8 (
+    set PYTHON_ROOT=C:\Development\Python\Python38
+) else (
+    echo Unsupported Python version: %VERSION%
+    exit 1
+}
+
+set PATH=%PYTHON_ROOT%;%PYTHON_ROOT%\Scripts;%PATH%
+
+:: Unset
+set VERSION=
+set PYTHON_ROOT=

--- a/.pfnci/windows/_use_python.bat
+++ b/.pfnci/windows/_use_python.bat
@@ -10,8 +10,8 @@ if %VERSION% == 3.6 (
     set PYTHON_ROOT=C:\Development\Python\Python38
 ) else (
     echo Unsupported Python version: %VERSION%
-    exit 1
-}
+    exit /b 1
+)
 
 set PATH=%PYTHON_ROOT%;%PYTHON_ROOT%\Scripts;%PATH%
 

--- a/.pfnci/windows/main.bat
+++ b/.pfnci/windows/main.bat
@@ -24,9 +24,9 @@ python -m pip install -e ".[jenkins]" -vvv || goto :error
 python -c "import cupy; cupy.show_config()" || goto :error
 
 :: Run unit tests
-.pfnci\windows\_cache_download.bat
+call .pfnci\windows\_cache_download.bat
 python -m pytest tests || goto :error
-.pfnci\windows\_cache_upload.bat
+call .pfnci\windows\_cache_upload.bat
 
 
 goto :EOF

--- a/.pfnci/windows/main.bat
+++ b/.pfnci/windows/main.bat
@@ -4,23 +4,30 @@ set PYTHON=%1
 set CUDA=%2
 
 :: Set environment variables
-call _use_cuda.bat %CUDA%
-call _use_python.bat %PYTHON%
+call .pfnci\windows\_use_cuda.bat %CUDA% || goto :error
+call .pfnci\windows\_use_python.bat %PYTHON% || goto :error
 
 :: Show environment variables
-set
-python -V
-
+set || goto :error
+python -V || goto :error
 
 :: Install dependencies
-python -m pip install -U Cython
-python -m pip list
+python -m pip install -U Cython || goto :error
+python -m pip list || goto :error
 
 :: Build
-python -m pip install -e ".[jenkins]" -vvv
+python -m pip install -e ".[jenkins]" -vvv || goto :error
 
 :: Test import
-python -c "import cupy; cupy.show_config()"
+python -c "import cupy; cupy.show_config()" || goto :error
 
 :: Run unit tests
-python -m pytest tests
+python -m pytest tests || goto :error
+
+
+goto :EOF
+
+:: Error handling
+:error
+echo Failed with status %errorlevel%.
+exit /b %errorlevel%

--- a/.pfnci/windows/main.bat
+++ b/.pfnci/windows/main.bat
@@ -17,7 +17,6 @@ python -m pip install -U Cython
 python -m pip list
 
 :: Build
-cd cupy
 python -m pip install -e ".[jenkins]" -vvv
 
 :: Test import

--- a/.pfnci/windows/main.bat
+++ b/.pfnci/windows/main.bat
@@ -16,13 +16,17 @@ python -m pip install -U Cython || goto :error
 python -m pip list || goto :error
 
 :: Build
+set CUPY_NUM_BUILD_JOBS=16
+set CUPY_NVCC_GENERATE_CODE=current
 python -m pip install -e ".[jenkins]" -vvv || goto :error
 
 :: Test import
 python -c "import cupy; cupy.show_config()" || goto :error
 
 :: Run unit tests
+.pfnci\windows\_cache_download.bat
 python -m pytest tests || goto :error
+.pfnci\windows\_cache_upload.bat
 
 
 goto :EOF

--- a/.pfnci/windows/main.bat
+++ b/.pfnci/windows/main.bat
@@ -25,13 +25,13 @@ python -m pip install -e ".[jenkins]" -vvv || goto :error
 python -c "import cupy; cupy.show_config()" || goto :error
 
 :: Exit if build only mode
-if "%TARGET%" = "build" (
+if "%TARGET%" == "build" (
   goto :eof
 )
 
 :: Run unit tests
 set PYTEST_OPTS=-m "not slow"
-if "%TARGET%" = "slow" (
+if "%TARGET%" == "slow" (
   set PYTEST_OPTS=-m "slow"
 )
 call .pfnci\windows\_cache_download.bat

--- a/.pfnci/windows/main.bat
+++ b/.pfnci/windows/main.bat
@@ -35,7 +35,7 @@ if "%TARGET%" == "slow" (
   set PYTEST_OPTS=-m "slow"
 )
 call .pfnci\windows\_cache_download.bat
-python -m pytest %PYTEST_OPTS% tests || goto :error
+python -m pytest -rfEX %PYTEST_OPTS% tests || goto :error
 call .pfnci\windows\_cache_upload.bat
 
 

--- a/.pfnci/windows/main.bat
+++ b/.pfnci/windows/main.bat
@@ -2,6 +2,7 @@
 
 set CUDA=%1
 set PYTHON=%2
+set TARGET=%3
 
 :: Set environment variables
 call .pfnci\windows\_use_cuda.bat %CUDA% || goto :error
@@ -23,9 +24,18 @@ python -m pip install -e ".[jenkins]" -vvv || goto :error
 :: Test import
 python -c "import cupy; cupy.show_config()" || goto :error
 
+:: Exit if build only mode
+if "%TARGET%" = "build" (
+  goto :eof
+)
+
 :: Run unit tests
+set PYTEST_OPTS=-m "not slow"
+if "%TARGET%" = "slow" (
+  set PYTEST_OPTS=-m "slow"
+)
 call .pfnci\windows\_cache_download.bat
-python -m pytest tests || goto :error
+python -m pytest %PYTEST_OPTS% tests || goto :error
 call .pfnci\windows\_cache_upload.bat
 
 

--- a/.pfnci/windows/main.bat
+++ b/.pfnci/windows/main.bat
@@ -1,7 +1,7 @@
-:: Example: main.bat 3.7.0 9.0 master
+:: Example: main.bat 10.0 3.7
 
-set PYTHON=%1
-set CUDA=%2
+set CUDA=%1
+set PYTHON=%2
 
 :: Set environment variables
 call .pfnci\windows\_use_cuda.bat %CUDA% || goto :error

--- a/.pfnci/windows/main.bat
+++ b/.pfnci/windows/main.bat
@@ -13,7 +13,7 @@ set || goto :error
 python -V || goto :error
 
 :: Install dependencies
-python -m pip install -U Cython || goto :error
+python -m pip install -U Cython scipy optuna || goto :error
 python -m pip list || goto :error
 
 :: Build

--- a/.pfnci/windows/main.bat
+++ b/.pfnci/windows/main.bat
@@ -1,0 +1,27 @@
+:: Example: main.bat 3.7.0 9.0 master
+
+set PYTHON=%1
+set CUDA=%2
+
+:: Set environment variables
+call _use_cuda.bat %CUDA%
+call _use_python.bat %PYTHON%
+
+:: Show environment variables
+set
+python -V
+
+
+:: Install dependencies
+python -m pip install -U Cython
+python -m pip list
+
+:: Build
+cd cupy
+python -m pip install -e ".[jenkins]" -vvv
+
+:: Test import
+python -c "import cupy; cupy.show_config()"
+
+:: Run unit tests
+python -m pytest tests

--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -448,10 +448,8 @@ def _compile_with_cache_cuda(
     options += ('-ftz=true',)
 
     if enable_cooperative_groups:
-        # `cooperative_groups` requires `-rdc=true`.
-        # The three latter flags are to resolve linker error.
-        # (https://devtalk.nvidia.com/default/topic/1023604/linker-error/)
-        options += ('-rdc=true', '-Xcompiler', '-fPIC', '-shared')
+        # `cooperative_groups` requires relocatable device code.
+        options += ('--device-c',)
 
     if _get_bool_env_variable('CUPY_CUDA_COMPILE_WITH_DEBUG', False):
         options += ('--device-debug', '--generate-line-info')

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
@@ -203,7 +203,7 @@ class TestWiener(unittest.TestCase):
 @testing.gpu
 @testing.with_requires('scipy')
 class TestOrderFilter(unittest.TestCase):
-    @testing.for_all_dtypes()
+    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
     @testing.numpy_cupy_allclose(atol=1e-8, rtol=1e-8, scipy_name='scp',
                                  accept_error=ValueError)  # for even kernels
     def test_order_filter(self, xp, scp, dtype):


### PR DESCRIPTION
This PR is to test Windows CI fix.

This branch includes:

- #4362
- #4470
- https://github.com/cupy/cupy/pull/4472
- #4477 (merged)

Known failures:
* #3872 cudnn errors

Test environment:

```
>>> cupy.show_config()
OS                           : Windows-10-10.0.14393-SP0
CuPy Version                 : 9.0.0a3
NumPy Version                : 1.19.4
SciPy Version                : None
Cython Build Version         : 0.29.21
Cython Runtime Version       : 0.29.21
CUDA Root                    : C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v10.0
CUDA Build Version           : 10000
CUDA Driver Version          : 11010
CUDA Runtime Version         : 10000
cuBLAS Version               : 10000
cuFFT Version                : 10000
cuRAND Version               : 10000
cuSOLVER Version             : (10, 0, 0)
cuSPARSE Version             : 10000
NVRTC Version                : (10, 0)
Thrust Version               : 100903
CUB Build Version            : 100800
Jitify Build Version         : 60e9e72
cuDNN Build Version          : 7605
cuDNN Version                : 7605
NCCL Build Version           : None
NCCL Runtime Version         : None
cuTENSOR Version             : None
Device 0 Name                : Tesla T4
Device 0 Compute Capability  : 75
Device 1 Name                : Tesla T4
Device 1 Compute Capability  : 75
```