### PR TITLE
 DOC: Incorrect environment variable description

### DIFF
--- a/docs/source/reference/environment.rst
+++ b/docs/source/reference/environment.rst
@@ -101,7 +101,7 @@ These environment variables are used during installation (building CuPy from sou
 |                              | architectures in build time. When this is not set,             |
 |                              | the default is to support all architectures.                   |
 +------------------------------+----------------------------------------------------------------+
-| ``CUPY_CUPY_NUM_BUILD_JOBS`` | To enable or disable parallel build, sets the number of        |    
+| ``CUPY_NUM_BUILD_JOBS``      | To enable or disable parallel build, sets the number of        |    
 |                              | processes used to build the extensions in parallel. Defaults   |    
 |                              | to ``4``                                                       |    
 +------------------------------+----------------------------------------------------------------+


### PR DESCRIPTION
The `NUM_BUILD_JOBS` environment variable has a redundant `CUPY_` prepended to it in the docs.