### PR TITLE
Disentangle HIP from CUDA in the build script

### DIFF
--- a/.pfnci/script.sh
+++ b/.pfnci/script.sh
@@ -70,6 +70,11 @@ main() {
       wget -qO - http://repo.radeon.com/rocm/rocm.gpg.key | apt-key add -
       echo 'deb [arch=amd64] http://repo.radeon.com/rocm/apt/debian/ xenial main' | tee /etc/apt/sources.list.d/rocm.list
 
+      # Uninstall CUDA to ensure it's a clean ROCm environment
+      # https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#removing-cuda-tk-and-driver
+      apt-get --purge remove "*cublas*" "*cufft*" "*curand*" "*cusolver*" "*cusparse*" "*npp*" "*nvjpeg*" "cuda*" "nsight*"
+      apt-get autoremove
+
       apt update -qqy
       apt install rocm-dev hipblas hipsparse rocsparse rocrand rocthrust rocsolver rocfft hipcub rocprim rccl -qqy
       apt list --installed | grep cuda  # TODO(leofang): remove cuda toolkit

--- a/.pfnci/script.sh
+++ b/.pfnci/script.sh
@@ -72,8 +72,8 @@ main() {
 
       # Uninstall CUDA to ensure it's a clean ROCm environment
       # https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#removing-cuda-tk-and-driver
-      apt-get --purge remove "*cublas*" "*cufft*" "*curand*" "*cusolver*" "*cusparse*" "*npp*" "*nvjpeg*" "cuda*" "nsight*"
-      apt-get autoremove
+      apt-get --purge remove "*cublas*" "*cufft*" "*curand*" "*cusolver*" "*cusparse*" "*npp*" "*nvjpeg*" "cuda*" "nsight*" -qqy
+      apt-get autoremove -qqy
 
       apt update -qqy
       apt install rocm-dev hipblas hipsparse rocsparse rocrand rocthrust rocsolver rocfft hipcub rocprim rccl -qqy

--- a/.pfnci/script.sh
+++ b/.pfnci/script.sh
@@ -72,6 +72,7 @@ main() {
 
       apt update -qqy
       apt install rocm-dev hipblas hipsparse rocsparse rocrand rocthrust rocsolver rocfft hipcub rocprim rccl -qqy
+      apt list --installed | grep cuda  # TODO(leofang): remove cuda toolkit
       export HCC_AMDGPU_TARGET=gfx900
       export ROCM_HOME=/opt/rocm
       export CUPY_INSTALL_USE_HIP=1

--- a/.pfnci/script.sh
+++ b/.pfnci/script.sh
@@ -72,7 +72,7 @@ main() {
 
       # Uninstall CUDA to ensure it's a clean ROCm environment
       # https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#removing-cuda-tk-and-driver
-      apt-get --purge remove "*cublas*" "*cufft*" "*curand*" "*cusolver*" "*cusparse*" "*npp*" "*nvjpeg*" "cuda*" "nsight*" -qqy
+      apt-get --purge remove "*cublas*" "*cufft*" "*curand*" "*cusolver*" "*cusparse*" "*npp*" "*nvjpeg*" "cuda*" "nsight*" "*cudnn*" -qqy
       apt-get autoremove -qqy
 
       apt update -qqy

--- a/.pfnci/script.sh
+++ b/.pfnci/script.sh
@@ -77,7 +77,6 @@ main() {
 
       apt update -qqy
       apt install rocm-dev hipblas hipsparse rocsparse rocrand rocthrust rocsolver rocfft hipcub rocprim rccl -qqy
-      apt list --installed | grep cuda  # TODO(leofang): remove cuda toolkit
       export HCC_AMDGPU_TARGET=gfx900
       export ROCM_HOME=/opt/rocm
       export CUPY_INSTALL_USE_HIP=1

--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -496,7 +496,8 @@ def preconfigure_modules(compiler, settings):
                 break
 
     # Get a list of the CC of the devices connected to this node
-    build.check_compute_capabilities(compiler, settings)
+    if not use_hip:
+        build.check_compute_capabilities(compiler, settings)
 
     if len(ret) != len(MODULES):
         if 'cuda' in ret:
@@ -1010,9 +1011,6 @@ class _MSVCCompiler(msvccompiler.MSVCCompiler):
                     include_dirs=None, debug=0, extra_preargs=None,
                     extra_postargs=None, depends=None):
         # Compile CUDA C files, mainly derived from UnixCCompiler._compile().
-        if use_hip:
-            raise RuntimeError('ROCm is not supported on Windows')
-
         macros, objects, extra_postargs, pp_opts, _build = \
             self._setup_compile(output_dir, macros, include_dirs, sources,
                                 depends, extra_postargs)
@@ -1038,6 +1036,9 @@ class _MSVCCompiler(msvccompiler.MSVCCompiler):
 
     def compile(self, sources, **kwargs):
         # Split CUDA C sources and others.
+        if use_hip:
+            raise RuntimeError('ROCm is not supported on Windows')
+
         cu_sources = []
         other_sources = []
         for source in sources:

--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -96,6 +96,7 @@ if use_hip:
     # to leak into all these modules even if unused. It's easier for all of
     # them to link to the same set of shared libraries.
     MODULES.append({
+        # TODO(leofang): call this "rocm" or "hip" to avoid confusion?
         'name': 'cuda',
         'file': cuda_files + [
             'cupy.cuda.nvtx',
@@ -119,6 +120,8 @@ if use_hip:
             'rocblas',
             'rocsolver',
         ],
+        'check_method': build.check_hip_version,
+        'version_method': build.get_hip_version,
     })
 else:
     MODULES.append({

--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -473,7 +473,8 @@ def preconfigure_modules(compiler, settings):
         elif (module['name'] in ('thrust', 'cub')
                 and (nvcc_path is None and hipcc_path is None)):
             installed = True
-            errmsg = ['nvcc command could not be found in PATH.',
+            cmd = 'nvcc' if not use_hip else 'hipcc'
+            errmsg = ['{} command could not be found in PATH.'.format(cmd),
                       'Check your PATH environment variable.']
         else:
             installed = True
@@ -953,7 +954,7 @@ class _UnixCCompiler(unixccompiler.UnixCCompiler):
                            obj, src, ext, cc_args, extra_postargs, pp_opts):
         # For CUDA C source files, compile them with NVCC.
         nvcc_path = build.get_nvcc_path()
-        base_opts = build.get_compiler_base_options(False)
+        base_opts = build.get_compiler_base_options(nvcc_path)
         compiler_so = nvcc_path
 
         cuda_version = build.get_cuda_version()
@@ -970,7 +971,7 @@ class _UnixCCompiler(unixccompiler.UnixCCompiler):
                             obj, src, ext, cc_args, extra_postargs, pp_opts):
         # For CUDA C source files, compile them with HIPCC.
         rocm_path = build.get_hipcc_path()
-        base_opts = build.get_compiler_base_options(True)
+        base_opts = build.get_compiler_base_options(rocm_path)
         compiler_so = rocm_path
         postargs = ['-O2', '-fPIC', '--include', 'hip_runtime.h']
         print('HIPCC options:', postargs)

--- a/install/build.py
+++ b/install/build.py
@@ -230,28 +230,28 @@ def _match_output_lines(output_lines, regexs):
     return None
 
 
-def get_compiler_base_options(use_hip=False):
+def get_compiler_base_options(compiler_path):
     """Returns base options for nvcc compiler.
 
     """
     global _compiler_base_options
     if _compiler_base_options is None:
-        _compiler_base_options = _get_compiler_base_options(use_hip)
+        _compiler_base_options = _get_compiler_base_options(compiler_path)
     return _compiler_base_options
 
 
-def _get_compiler_base_options(use_hip=False):
+def _get_compiler_base_options(compiler_path):
     # Try compiling a dummy code.
     # If the compilation fails, try to parse the output of compilation
     # and try to compose base options according to it.
-    nvcc_path = get_nvcc_path() if not use_hip else get_hipcc_path()
+    # compiler_path is the path to nvcc (CUDA) or hipcc (ROCm/HIP)
     with _tempdir() as temp_dir:
         test_cu_path = os.path.join(temp_dir, 'test.cu')
         test_out_path = os.path.join(temp_dir, 'test.out')
         with open(test_cu_path, 'w') as f:
             f.write('int main() { return 0; }')
         proc = subprocess.Popen(
-            nvcc_path + ['-o', test_out_path, test_cu_path],
+            compiler_path + ['-o', test_out_path, test_cu_path],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE)
         stdoutdata, stderrdata = proc.communicate()

--- a/install/build.py
+++ b/install/build.py
@@ -18,6 +18,8 @@ minimum_cuda_version = 9000
 minimum_cudnn_version = 7000
 maximum_cudnn_version = 8099
 
+minimum_hip_version = 305  # for ROCm 3.5.0+
+
 _cuda_path = 'NOT_INITIALIZED'
 _rocm_path = 'NOT_INITIALIZED'
 _compiler_base_options = None
@@ -278,6 +280,7 @@ def _get_compiler_base_options():
 
 
 _cuda_version = None
+_hip_version = None
 _thrust_version = None
 _cudnn_version = None
 _nccl_version = None
@@ -315,10 +318,6 @@ def check_cuda_version(compiler, settings):
     return True
 
 
-def _format_cuda_version(version):
-    return str(version)
-
-
 def get_cuda_version(formatted=False):
     """Return CUDA Toolkit version cached in check_cuda_version()."""
     global _cuda_version
@@ -326,8 +325,46 @@ def get_cuda_version(formatted=False):
         msg = 'check_cuda_version() must be called first.'
         raise RuntimeError(msg)
     if formatted:
-        return _format_cuda_version(_cuda_version)
+        return str(_cuda_version)
     return _cuda_version
+
+
+def check_hip_version(compiler, settings):
+    global _hip_version
+    try:
+        out = build_and_run(compiler, '''
+        #include <hip/hip_version.h>
+        #include <stdio.h>
+        int main() {
+          printf("%d", HIP_VERSION);
+          return 0;
+        }
+        ''', include_dirs=settings['include_dirs'])
+
+    except Exception as e:
+        utils.print_warning('Cannot check HIP version', str(e))
+        return False
+
+    _hip_version = int(out)
+
+    if _hip_version < minimum_hip_version:
+        utils.print_warning(
+            'ROCm/HIP version is too old: %d' % _hip_version,
+            'ROCm 3.5.0 or newer is required')
+        return False
+
+    return True
+
+
+def get_hip_version(formatted=False):
+    """Return ROCm version cached in check_hip_version()."""
+    global _hip_version
+    if _hip_version is None:
+        msg = 'check_hip_version() must be called first.'
+        raise RuntimeError(msg)
+    if formatted:
+        return str(_hip_version)
+    return _hip_version
 
 
 def check_compute_capabilities(compiler, settings):
@@ -417,11 +454,11 @@ def check_cudnn_version(compiler, settings):
     _cudnn_version = int(out)
 
     if not minimum_cudnn_version <= _cudnn_version <= maximum_cudnn_version:
-        min_major = _format_cuda_version(minimum_cudnn_version)
-        max_major = _format_cuda_version(maximum_cudnn_version)
+        min_major = str(minimum_cudnn_version)
+        max_major = str(maximum_cudnn_version)
         utils.print_warning(
             'Unsupported cuDNN version: {}'.format(
-                _format_cuda_version(_cudnn_version)),
+                str(_cudnn_version)),
             'cuDNN v{}= and <=v{} is required'.format(min_major, max_major))
         return False
 
@@ -435,7 +472,7 @@ def get_cudnn_version(formatted=False):
         msg = 'check_cudnn_version() must be called first.'
         raise RuntimeError(msg)
     if formatted:
-        return _format_cuda_version(_cudnn_version)
+        return str(_cudnn_version)
     return _cudnn_version
 
 
@@ -486,7 +523,7 @@ def get_nccl_version(formatted=False):
     if formatted:
         if _nccl_version == 0:
             return '1.x'
-        return _format_cuda_version(_nccl_version)
+        return str(_nccl_version)
     return _nccl_version
 
 


### PR DESCRIPTION
Close #4415. Thanks to @ipe-zhangyz for reporting and helping debug the issue 🙏

**UPDATE**: This PR addresses the following things:
- Ensure pfnCI has a pure ROCm environment (by removing all CUDA related stuff)
- Print HIPCC path at build time, if found
- Ensure wherever NVCC is asked, HIPCC can also be used if `use_hip` is set
- Add a version check for HIP, though currently we only detect its version at build time but do not burn it into any module (we should revisit this in a later PR)
- Don't check compute capability on HIP
- Ensure Windows does not have ROCm support
- Remove the internal helper `_format_cuda_version()` as it's just a alias of `str()`