### PR TITLE
Add support for `LinearOperator` to `cg` and `gmres` in `cupyx.scipy.sparse.linalg`.

### DIFF
--- a/cupyx/scipy/sparse/linalg/_iterative.py
+++ b/cupyx/scipy/sparse/linalg/_iterative.py
@@ -7,7 +7,7 @@ from cupy.cuda import device
 from cupy_backends.cuda.libs import cusparse as _cusparse
 from cupy_backends.cuda.libs import cublas as _cublas
 from cupyx.scipy.sparse import csr
-from ._interface import aslinearoperator, LinearOperator, IdentityOperator
+from cupyx.scipy.sparse.linalg import _interface
 
 
 def cg(A, b, x0=None, tol=1e-5, maxiter=None, M=None, callback=None,
@@ -221,10 +221,10 @@ def _make_system(A, M, x0, b):
             b (cupy.ndarray): right hand side.
     """
     fast_matvec = _make_fast_matvec(A)
-    A = aslinearoperator(A)
+    A = _interface.aslinearoperator(A)
     if fast_matvec is not None:
-        A = LinearOperator(A.shape, matvec=fast_matvec, rmatvec=A.rmatvec,
-                           dtype=A.dtype)
+        A = _interface.LinearOperator(A.shape, matvec=fast_matvec,
+                                      rmatvec=A.rmatvec, dtype=A.dtype)
     if A.shape[0] != A.shape[1]:
         raise ValueError('expected square matrix (shape: {})'.format(A.shape))
     if A.dtype.char not in 'fdFD':
@@ -240,13 +240,13 @@ def _make_system(A, M, x0, b):
             raise ValueError('x0 has incompatible dimensions')
         x = x0.astype(A.dtype).ravel()
     if M is None:
-        M = IdentityOperator(shape=A.shape, dtype=A.dtype)
+        M = _interface.IdentityOperator(shape=A.shape, dtype=A.dtype)
     else:
         fast_matvec = _make_fast_matvec(M)
-        M = aslinearoperator(M)
+        M = _interface.aslinearoperator(M)
         if fast_matvec is not None:
-            M = LinearOperator(M.shape, matvec=fast_matvec, rmatvec=M.rmatvec,
-                               dtype=M.dtype)
+            M = _interface.LinearOperator(M.shape, matvec=fast_matvec,
+                                          rmatvec=M.rmatvec, dtype=M.dtype)
         if A.shape != M.shape:
             raise ValueError('matrix and preconditioner have different shapes')
     return A, M, x, b

--- a/cupyx/scipy/sparse/linalg/_iterative.py
+++ b/cupyx/scipy/sparse/linalg/_iterative.py
@@ -15,18 +15,21 @@ def cg(A, b, x0=None, tol=1e-5, maxiter=None, M=None, callback=None,
     """Uses Conjugate Gradient iteration to solve ``Ax = b``.
 
     Args:
-        A (cupy.ndarray, cupyx.scipy.sparse.spmatrix or
-            cupyx.scipy.sparse.linalg.LinearOperator): The real or complex
-            matrix of the linear system with shape ``(n, n)``. ``A`` must
-            be a hermitian, positive definitive matrix.
+        A (ndarray, spmatrix or LinearOperator): The real or complex matrix of
+            the linear system with shape ``(n, n)``. ``A`` must be a hermitian,
+            positive definitive matrix with type of :class:`cupy.ndarray`,
+            :class:`cupyx.scipy.sparse.spmatrix` or
+            :class:`cupyx.scipy.sparse.linalg.LinearOperator`.
         b (cupy.ndarray): Right hand side of the linear system with shape
             ``(n,)`` or ``(n, 1)``.
         x0 (cupy.ndarray): Starting guess for the solution.
         tol (float): Tolerance for convergence.
         maxiter (int): Maximum number of iterations.
-        M (cupy.ndarray, cupyx.scipy.sparse.spmatrix or
-            cupyx.scipy.sparse.linalg.LinearOperator): Preconditioner for
-            ``A``. The preconditioner should approximate the inverse of ``A``.
+        M (ndarray, spmatrix or LinearOperator): Preconditioner for ``A``.
+            The preconditioner should approximate the inverse of ``A``.
+            ``M`` must be :class:`cupy.ndarray`,
+            :class:`cupyx.scipy.sparse.spmatrix` or
+            :class:`cupyx.scipy.sparse.linalg.LinearOperator`.
         callback (function): User-specified function to call after each
             iteration. It is called as ``callback(xk)``, where ``xk`` is the
             current solution vector.
@@ -92,9 +95,10 @@ def gmres(A, b, x0=None, tol=1e-5, restart=None, maxiter=None, M=None,
     """Uses Generalized Minimal RESidual iteration to solve ``Ax = b``.
 
     Args:
-        A (cupy.ndarray, cupyx.scipy.sparse.spmatrix or
-            cupyx.scipy.sparse.linalg.LinearOperator): The real or complex
-            matrix of the linear system with shape ``(n, n)``.
+        A (ndarray, spmatrix or LinearOperator): The real or complex
+            matrix of the linear system with shape ``(n, n)``. ``A`` must be
+            :class:`cupy.ndarray`, :class:`cupyx.scipy.sparse.spmatrix` or
+            :class:`cupyx.scipy.sparse.linalg.LinearOperator`.
         b (cupy.ndarray): Right hand side of the linear system with shape
             ``(n,)`` or ``(n, 1)``.
         x0 (cupy.ndarray): Starting guess for the solution.
@@ -102,9 +106,11 @@ def gmres(A, b, x0=None, tol=1e-5, restart=None, maxiter=None, M=None,
         restart (int): Number of iterations between restarts. Larger values
             increase iteration cost, but may be necessary for convergence.
         maxiter (int): Maximum number of iterations.
-        M (cupy.ndarray or cupyx.scipy.sparse.spmatrixor
-            cupyx.scipy.sparse.linalg.LinearOperator): Preconditioner for
-            ``A``. The preconditioner should approximate the inverse of ``A``.
+        M (ndarray, spmatrix or LinearOperator): Preconditioner for ``A``.
+            The preconditioner should approximate the inverse of ``A``.
+            ``M`` must be :class:`cupy.ndarray`,
+            :class:`cupyx.scipy.sparse.spmatrix` or
+            :class:`cupyx.scipy.sparse.linalg.LinearOperator`.
         callback (function): User-specified function to call on every restart.
             It is called as ``callback(arg)``, where ``arg`` is selected by
             ``callback_type``.
@@ -199,9 +205,9 @@ def _make_system(A, M, x0, b):
     """Make a linear system Ax = b
 
     Args:
-        A (cupy.ndarray, cupyx.scipy.sparse.spmatrix or
+        A (cupy.ndarray or cupyx.scipy.sparse.spmatrix or
             cupyx.scipy.sparse.LinearOperator): sparse or dense matrix.
-        M (cupy.ndarray, cupyx.scipy.sparse.spmatrix or
+        M (cupy.ndarray or cupyx.scipy.sparse.spmatrix or
             cupyx.scipy.sparse.LinearOperator): preconditioner.
         x0 (cupy.ndarray): initial guess to iterative method.
         b (cupy.ndarray): right hand side.

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
@@ -252,6 +252,7 @@ class TestSvds(unittest.TestCase):
     'M': [None, 'jacobi'],
     'atol': [None, 'select-by-dtype'],
     'b_ndim': [1, 2],
+    'use_linear_operator': [False, True],
 }))
 @testing.with_requires('scipy')
 @testing.gpu
@@ -303,6 +304,10 @@ class TestCg:
     @testing.numpy_cupy_allclose(rtol=1e-5, atol=1e-5, sp_name='sp')
     def test_dense(self, dtype, xp, sp):
         a, M = self._make_matrix(dtype, xp)
+        if self.use_linear_operator:
+            a = sp.linalg.aslinearoperator(a)
+            if M is not None:
+                M = sp.linalg.aslinearoperator(M)
         return self._test_cg(dtype, xp, sp, a, M)
 
     @pytest.mark.parametrize('format', ['csr', 'csc', 'coo'])
@@ -311,14 +316,19 @@ class TestCg:
     def test_sparse(self, format, dtype, xp, sp):
         a, M = self._make_matrix(dtype, xp)
         a = sp.coo_matrix(a).asformat(format)
+        if self.use_linear_operator:
+            a = sp.linalg.aslinearoperator(a)
         if M is not None:
             M = sp.coo_matrix(M).asformat(format)
+            if self.use_linear_operator:
+                M = sp.linalg.aslinearoperator(M)
         return self._test_cg(dtype, xp, sp, a, M)
 
     @testing.for_dtypes('fdFD')
     @testing.numpy_cupy_allclose(rtol=1e-5, atol=1e-5, sp_name='sp')
     def test_empty(self, dtype, xp, sp):
-        if self.x0 is not None or self.M is not None or self.atol is not None:
+        if not (self.x0 is None and self.M is None and self.atol is None and
+                self.use_linear_operator is False):
             raise unittest.SkipTest
         a = xp.empty((0, 0), dtype=dtype)
         b = xp.empty((0,), dtype=dtype)
@@ -332,7 +342,8 @@ class TestCg:
 
     @testing.for_dtypes('fdFD')
     def test_callback(self, dtype):
-        if self.x0 is not None or self.M is not None or self.atol is not None:
+        if not (self.x0 is None and self.M is None and self.atol is None and
+                self.use_linear_operator is False):
             raise unittest.SkipTest
         xp, sp = cupy, sparse
         a, M = self._make_matrix(dtype, xp)
@@ -347,7 +358,8 @@ class TestCg:
         assert is_called
 
     def test_invalid(self):
-        if self.x0 is not None or self.M is not None or self.atol is not None:
+        if not (self.x0 is None and self.M is None and self.atol is None and
+                self.use_linear_operator is False):
             raise unittest.SkipTest
         for xp, sp in ((numpy, scipy.sparse), (cupy, sparse)):
             a, M = self._make_matrix('f', xp)
@@ -386,6 +398,7 @@ class TestCg:
     'atol': [None, 'select-by-dtype'],
     'b_ndim': [1, 2],
     'restart': [None, 10],
+    'use_linear_operator': [False, True],
 }))
 @testing.with_requires('scipy>=1.4')
 @testing.gpu
@@ -438,6 +451,10 @@ class TestGmres:
     @testing.numpy_cupy_allclose(rtol=1e-5, atol=1e-5, sp_name='sp')
     def test_dense(self, dtype, xp, sp):
         a, M = self._make_matrix(dtype, xp)
+        if self.use_linear_operator:
+            a = sp.linalg.aslinearoperator(a)
+            if M is not None:
+                M = sp.linalg.aslinearoperator(M)
         return self._test_gmres(dtype, xp, sp, a, M)
 
     @pytest.mark.parametrize('format', ['csr', 'csc', 'coo'])
@@ -446,15 +463,19 @@ class TestGmres:
     def test_sparse(self, format, dtype, xp, sp):
         a, M = self._make_matrix(dtype, xp)
         a = sp.coo_matrix(a).asformat(format)
+        if self.use_linear_operator:
+            a = sp.linalg.aslinearoperator(a)
         if M is not None:
             M = sp.coo_matrix(M).asformat(format)
+            if self.use_linear_operator:
+                M = sp.linalg.aslinearoperator(M)
         return self._test_gmres(dtype, xp, sp, a, M)
 
     @testing.for_dtypes('fdFD')
     @testing.numpy_cupy_allclose(rtol=1e-5, atol=1e-5, sp_name='sp')
     def test_empty(self, dtype, xp, sp):
-        if (self.x0 is not None or self.M is not None or self.atol is not None
-                or self.restart is not None):
+        if not (self.x0 is None and self.M is None and self.atol is None and
+                self.restart is None and self.use_linear_operator is False):
             raise unittest.SkipTest
         a = xp.empty((0, 0), dtype=dtype)
         b = xp.empty((0,), dtype=dtype)
@@ -468,8 +489,8 @@ class TestGmres:
 
     @testing.for_dtypes('fdFD')
     def test_callback(self, dtype):
-        if (self.x0 is not None or self.M is not None or self.atol is not None
-                or self.restart is not None):
+        if not (self.x0 is None and self.M is None and self.atol is None and
+                self.restart is None and self.use_linear_operator is False):
             raise unittest.SkipTest
         xp, sp = cupy, sparse
         a, M = self._make_matrix(dtype, xp)
@@ -492,8 +513,8 @@ class TestGmres:
         assert is_called
 
     def test_invalid(self):
-        if (self.x0 is not None or self.M is not None or self.atol is not None
-                or self.restart is not None):
+        if not (self.x0 is None and self.M is None and self.atol is None and
+                self.restart is None and self.use_linear_operator is False):
             raise unittest.SkipTest
         for xp, sp in ((numpy, scipy.sparse), (cupy, sparse)):
             a, M = self._make_matrix('f', xp)


### PR DESCRIPTION
This PR adds support for `LinearOperator` to `cupyx.scipy.sparse.linalg.cg` and `cupyx.scipy.sparse.linalg.gmres` to improve compatibility with SciPy.

Thanks to @venkywonka for adding `LinearOperator` (https://github.com/cupy/cupy/pull/4258)