### PR TITLE
Support texture object in `cupy.ElementwiseKernel`

### DIFF
--- a/cupy/core/_kernel.pxd
+++ b/cupy/core/_kernel.pxd
@@ -5,6 +5,7 @@ from cupy.core cimport _scalar
 from cupy.core._carray cimport shape_t
 from cupy.core.core cimport ndarray
 from cupy.cuda cimport memory
+from cupy.cuda cimport texture
 
 
 cdef class ParameterInfo:
@@ -21,6 +22,7 @@ cdef enum _ArgKind:
     ARG_KIND_INDEXER
     ARG_KIND_SCALAR
     ARG_KIND_POINTER
+    ARG_KIND_TEXTURE
 
 
 cdef class _ArgInfo:
@@ -58,6 +60,9 @@ cdef class _ArgInfo:
 
     @staticmethod
     cdef _ArgInfo from_memptr(memory.MemoryPointer arg)
+
+    @staticmethod
+    cdef _ArgInfo from_texture(texture.TextureObject arg)
 
     cdef _ArgInfo as_ndarray_with_ndim(self, int ndim)
 

--- a/cupy/core/_kernel.pyx
+++ b/cupy/core/_kernel.pyx
@@ -771,7 +771,6 @@ cdef class ElementwiseKernel:
         cdef tuple in_types, out_types, types
         cdef shape_t shape
 
-        size = -1
         size = kwargs.pop('size', -1)
         stream = kwargs.pop('stream', None)
         block_size = kwargs.pop('block_size', 128)

--- a/cupy/core/_scalar.pyx
+++ b/cupy/core/_scalar.pyx
@@ -85,6 +85,9 @@ cdef _setup_type_dict():
         _typenames[t] = _typenames_base[d]
         k = ord(d.kind)
         _dtype_kind_size_dict[t] = (k, d.itemsize)
+    # CUDA types
+    for t in ('cudaTextureObject_t',):
+        _typenames[t] = t
 
 
 _setup_type_dict()

--- a/cupy/cuda/texture.pyx
+++ b/cupy/cuda/texture.pyx
@@ -489,7 +489,8 @@ cdef class CUDAarray:
 cdef class TextureObject:
     '''A class that holds a texture object. Equivalent to
     ``cudaTextureObject_t``. The returned :class:`TextureObject` instance can
-    be passed as a argument when launching :class:`~cupy.RawKernel`.
+    be passed as a argument when launching :class:`~cupy.RawKernel` or
+    :class:`~cupy.ElementwiseKernel`.
 
     Args:
         ResDesc (ResourceDescriptor): an intance of the resource descriptor.

--- a/docs/source/tutorial/kernel.rst
+++ b/docs/source/tutorial/kernel.rst
@@ -130,6 +130,11 @@ Note that raw arguments are not involved in the broadcasting.
 If you want to mark all arguments as ``raw``, you must specify the ``size`` argument on invocation, which defines the value of ``_ind.size()``.
 
 
+Texture memory
+--------------
+Texture objects (:class:`~cupy.cuda.texture.TextureObject`) can be passed to :class:`~cupy.ElementwiseKernel` with their type marked by a unique type placeholder distinct from any other types used in the same kernel, as its actual datatype is determined when populating the texture memory. The texture coordinates can be computed in the kernel by the per-thread loop index ``i``.
+
+
 Reduction kernels
 -----------------
 
@@ -166,6 +171,9 @@ For example, L2 norm along specified axes can be written as follows:
 .. note::
    ``raw`` specifier is restricted for usages that the axes to be reduced are put at the head of the shape.
    It means, if you want to use ``raw`` specifier for at least one argument, the ``axis`` argument must be ``0`` or a contiguous increasing sequence of integers starting from ``0``, like ``(0, 1)``, ``(0, 1, 2)``, etc.
+
+.. note::
+   Texture memory is not yet supported in :class:`~cupy.ReductionKernel`.
 
 
 Raw kernels

--- a/tests/cupy_tests/core_tests/test_userkernel.py
+++ b/tests/cupy_tests/core_tests/test_userkernel.py
@@ -286,7 +286,7 @@ class TestElementwiseKernelTexture(unittest.TestCase):
             'T y',
             '''
             T temp = tex1D<T>(texObj,
-                              T(i)
+                              float(i)
                               );
             y = temp + x;
             ''', name='test_tex1D')
@@ -297,8 +297,8 @@ class TestElementwiseKernelTexture(unittest.TestCase):
             'T y',
             '''
             T temp = tex2D<T>(texObj,
-                              (T)(i % width),
-                              (T)(i / width)
+                              (float)(i % width),
+                              (float)(i / width)
                               );
             y = temp + x;
             ''', name='test_tex2D')
@@ -309,9 +309,9 @@ class TestElementwiseKernelTexture(unittest.TestCase):
             'T y',
             '''
             T temp = tex3D<T>(texObj,
-                              (T)((i % (width * height)) % width),
-                              (T)((i % (width * height)) / width),
-                              (T)((i / (width * height)))
+                              (float)((i % (width * height)) % width),
+                              (float)((i % (width * height)) / width),
+                              (float)((i / (width * height)))
                               );
             y = temp + x;
             ''', name='test_tex3D')

--- a/tests/cupy_tests/core_tests/test_userkernel.py
+++ b/tests/cupy_tests/core_tests/test_userkernel.py
@@ -5,6 +5,10 @@ import pytest
 
 import cupy
 from cupy import testing
+from cupy.cuda import runtime
+from cupy.cuda.texture import (ChannelFormatDescriptor, CUDAarray,
+                               ResourceDescriptor, TextureDescriptor,
+                               TextureObject,)
 
 
 class TestUserkernel(unittest.TestCase):
@@ -237,3 +241,102 @@ class TestUserkernelManualBlockSize(unittest.TestCase):
         kernel = cupy.ElementwiseKernel('T x, T y', 'T z', 'z = x + y')
         y = kernel(x, 1, block_size=1)
         testing.assert_array_equal(y, x + 1)
+
+
+@testing.parameterize(*testing.product({
+    'dimensions': ((64, 0, 0), (64, 32, 0), (64, 32, 19)),
+}))
+@testing.gpu
+@pytest.mark.skipif(runtime.is_hip,
+                    reason='texture support on HIP is not yet implemented')
+class TestElementwiseKernelTexture(unittest.TestCase):
+
+    def _prep_texture(self):
+        width, height, depth = self.dimensions
+        dim = 3 if depth != 0 else 2 if height != 0 else 1
+
+        # generate input data and allocate output buffer
+        shape = (depth, height, width) if dim == 3 else \
+                (height, width) if dim == 2 else \
+                (width,)
+        self.shape = shape
+
+        # prepare input, output, and texture memory
+        # self.data holds the data stored in the texture memory
+        tex_data = cupy.random.random(shape, dtype=cupy.float32)
+        ch = ChannelFormatDescriptor(32, 0, 0, 0,
+                                     runtime.cudaChannelFormatKindFloat)
+        arr = CUDAarray(ch, width, height, depth)
+        arr.copy_from(tex_data)
+        self.data = tex_data
+
+        # create resource and texture descriptors
+        res = ResourceDescriptor(runtime.cudaResourceTypeArray, cuArr=arr)
+        address_mode = (runtime.cudaAddressModeClamp,
+                        runtime.cudaAddressModeClamp)
+        tex = TextureDescriptor(address_mode, runtime.cudaFilterModePoint,
+                                runtime.cudaReadModeElementType)
+
+        # create a texture object
+        return TextureObject(res, tex)
+
+    def _prep_kernel1D(self):
+        return cupy.ElementwiseKernel(
+            'T x, U texObj',
+            'T y',
+            '''
+            T temp = tex1D<T>(texObj,
+                              T(i)
+                              );
+            y = temp + x;
+            ''', name='test_tex1D')
+
+    def _prep_kernel2D(self):
+        return cupy.ElementwiseKernel(
+            'T x, U texObj, uint64 width',
+            'T y',
+            '''
+            T temp = tex2D<T>(texObj,
+                              (T)(i % width),
+                              (T)(i / width)
+                              );
+            y = temp + x;
+            ''', name='test_tex2D')
+
+    def _prep_kernel3D(self):
+        return cupy.ElementwiseKernel(
+            'T x, U texObj, uint64 width, uint64 height',
+            'T y',
+            '''
+            T temp = tex3D<T>(texObj,
+                              (T)((i % (width * height)) % width),
+                              (T)((i % (width * height)) / width),
+                              (T)((i / (width * height)))
+                              );
+            y = temp + x;
+            ''', name='test_tex3D')
+
+    def test_texture_input(self):
+        width, height, depth = self.dimensions
+        dim = 3 if depth != 0 else 2 if height != 0 else 1
+
+        texobj = self._prep_texture()
+        ker = getattr(self, f'_prep_kernel{dim}D')()
+
+        # prepare input
+        args = [None, texobj]
+        size = width
+        if height > 0:
+            size *= height
+            args.append(width)
+        if depth > 0:
+            size *= depth
+            args.append(height)
+        in_arr = cupy.arange(size, dtype=cupy.float32)
+        in_arr = in_arr.reshape(self.shape)
+        args[0] = in_arr
+
+        # compute and validate output
+        out_arr = ker(*args)
+        expected = in_arr + self.data
+        testing.assert_allclose(out_arr, expected)


### PR DESCRIPTION
Close #2550.

This PR allows users to pass a `cupy.cuda.texture.TextureObject` to `cupy.ElementwiseKernel`. The texture coordinates can be computed from the loop indexing variable `i`, see the added tests (thanks to @the-lay for pointing out this possibility which I failed to see!). 

This PR has a particular potential benefit in that since a lot of ndimage kernels are written in `cupy.ElementwiseKernel`, if someone is willing to spend time on adding texture-utlized versions of them, it is possible to use the texture hardware to accelerate some of the computations (ex: [interpolation](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#texture-fetching)), which GPUs are known very good since this is one of GPUs' primary applications.

Notes: 
- Texture objects cannot be part of output
- Texture references are not supported since they are deprecated

TODO:
- [x] Where to document this?