### PR TITLE
Add `spsolve_triangular` to the reference

### DIFF
--- a/docs/source/reference/sparse.rst
+++ b/docs/source/reference/sparse.rst
@@ -91,6 +91,7 @@ Linear Algebra
    :nosignatures:
 
    cupyx.scipy.sparse.linalg.norm
+   cupyx.scipy.sparse.linalg.spsolve_triangular
    cupyx.scipy.sparse.linalg.cg
    cupyx.scipy.sparse.linalg.gmres
    cupyx.scipy.sparse.linalg.lsqr


### PR DESCRIPTION
Follows up #4356. This PR add `cupyx.scipy.sparse.linalg.spsolve_triangulare` to the reference.