### PR TITLE
Fix out-of-bound access in ndimage rank filters

### DIFF
--- a/cupyx/scipy/ndimage/filters.py
+++ b/cupyx/scipy/ndimage/filters.py
@@ -1065,7 +1065,7 @@ def _get_rank_kernel(filter_size, rank, mode, w_shape, offsets, cval,
             comp_op = '<'
         else:
             comp_op = '>'
-        array_size = s_rank + 1
+        array_size = s_rank + 2
         found_post = '''
             if (iv > {rank} + 1) {{{{
                 int target_iv = 0;
@@ -1099,7 +1099,7 @@ def _get_rank_kernel(filter_size, rank, mode, w_shape, offsets, cval,
 
     return _filters_core._generate_nd_kernel(
         'rank_{}_{}'.format(filter_size, rank),
-        'int iv = 0;\nX values[{}+1];'.format(array_size),
+        'int iv = 0;\nX values[{}];'.format(array_size),
         'values[iv++] = {value};' + found_post, post,
         mode, w_shape, int_type, offsets, cval, preamble=sorter)
 

--- a/cupyx/scipy/ndimage/filters.py
+++ b/cupyx/scipy/ndimage/filters.py
@@ -1057,6 +1057,10 @@ def _get_shell_gap(filter_size):
 def _get_rank_kernel(filter_size, rank, mode, w_shape, offsets, cval,
                      int_type):
     s_rank = min(rank, filter_size - rank - 1)
+    # The threshold was set based on the measurements on a V100
+    # TODO(leofang, anaruse): Use Optuna to automatically tune the threshold,
+    # as it may vary depending on the GPU in use, compiler version, dtype,
+    # filter size, etc.
     if s_rank <= 80:
         # When s_rank is small and register usage is low, this partial
         # selection sort approach is faster than general sorting approach

--- a/cupyx/scipy/ndimage/filters.py
+++ b/cupyx/scipy/ndimage/filters.py
@@ -1099,7 +1099,7 @@ def _get_rank_kernel(filter_size, rank, mode, w_shape, offsets, cval,
 
     return _filters_core._generate_nd_kernel(
         'rank_{}_{}'.format(filter_size, rank),
-        'int iv = 0;\nX values[{}];'.format(array_size),
+        'int iv = 0;\nX values[{}+1];'.format(array_size),
         'values[iv++] = {value};' + found_post, post,
         mode, w_shape, int_type, offsets, cval, preamble=sorter)
 


### PR DESCRIPTION
Close #4272. 

Turns out this is a bug in the partial selection sort introduced in #3813, but for some reason *on CUDA this is not caught at all*, and led to erroneous results only on HIP. All tests in `tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py` passed on ROCm 3.5.0 + Radeon VII.

@anaruse I didn't realize it's from your #3813 until now 😅 Could you comment on
- whether this fix is the intended usage?
- why it works well on CUDA? 

cc: @grlee77 