### PR TITLE
ndimage: complex dtype support in filters and interpolation

### DIFF
--- a/cupyx/scipy/ndimage/_filters_core.py
+++ b/cupyx/scipy/ndimage/_filters_core.py
@@ -127,13 +127,15 @@ def _call_kernel(kernel, input, weights, output, structure=None,
     dtype conversion will occur. The input and output are never converted.
     """
     args = [input]
+    complex_output = input.dtype.kind == 'c'
     if weights is not None:
         weights = cupy.ascontiguousarray(weights, weights_dtype)
+        complex_output = complex_output or weights.dtype.kind == 'c'
         args.append(weights)
     if structure is not None:
         structure = cupy.ascontiguousarray(structure, structure_dtype)
         args.append(structure)
-    output = _util._get_output(output, input)
+    output = _util._get_output(output, input, None, complex_output)
     needs_temp = cupy.shares_memory(output, input, 'MAY_SHARE_BOUNDS')
     if needs_temp:
         output, temp = _util._get_output(output.dtype, input), output

--- a/cupyx/scipy/ndimage/_filters_core.py
+++ b/cupyx/scipy/ndimage/_filters_core.py
@@ -175,7 +175,9 @@ template <class T>
 __device__ __forceinline__ bool nonzero(T x) { return x!=0; }
 
 template <typename T>
-__device__ __forceinline__ bool nonzero(complex<T> x){ return x.real() || x.imag(); }
+__device__ __forceinline__ bool nonzero(complex<T> x) {
+    return x.real() || x.imag();
+}
 """
 
 

--- a/cupyx/scipy/ndimage/_filters_core.py
+++ b/cupyx/scipy/ndimage/_filters_core.py
@@ -56,8 +56,6 @@ def _convert_1d_args(ndim, weights, origin, axis):
 
 
 def _check_nd_args(input, weights, mode, origin, wghts_name='filter weights'):
-    if input.dtype.kind == 'c':
-        raise TypeError('Complex type not supported')
     _util._check_mode(mode)
     # Weights must always be less than 2 GiB
     if weights.nbytes >= (1 << 31):
@@ -176,6 +174,8 @@ cast(A a) { return (a >= 0) ? (B)a : -(B)(-a); }
 template <class T>
 __device__ __forceinline__ bool nonzero(T x) { return x!=0; }
 
+template <typename T>
+__device__ __forceinline__ bool nonzero(complex<T> x){ return x.real() || x.imag(); }
 """
 
 

--- a/cupyx/scipy/ndimage/_filters_core.py
+++ b/cupyx/scipy/ndimage/_filters_core.py
@@ -172,12 +172,7 @@ typename std::enable_if<(std::is_floating_point<A>::value
 cast(A a) { return (a >= 0) ? (B)a : -(B)(-a); }
 
 template <class T>
-__device__ __forceinline__ bool nonzero(T x) { return x!=0; }
-
-template <typename T>
-__device__ __forceinline__ bool nonzero(complex<T> x) {
-    return x.real() || x.imag();
-}
+__device__ __forceinline__ bool nonzero(T x) { return x != static_cast<T>(0); }
 """
 
 

--- a/cupyx/scipy/ndimage/_interp_kernels.py
+++ b/cupyx/scipy/ndimage/_interp_kernels.py
@@ -282,7 +282,6 @@ def _generate_interp_custom(coord_func, ndim, large_int, yshape, mode, cval,
     else:
         cval = f'({internal_dtype}){cval}'
 
-
     if mode == 'constant':
         # use cval if coordinate is outside the bounds of x
         _cond = ' || '.join(

--- a/cupyx/scipy/ndimage/_interp_kernels.py
+++ b/cupyx/scipy/ndimage/_interp_kernels.py
@@ -225,7 +225,7 @@ def _unravel_loop_index(shape, uint_t='unsigned int'):
 
 def _generate_interp_custom(coord_func, ndim, large_int, yshape, mode, cval,
                             order, name='', integer_output=False, nprepad=0,
-                            omit_in_coord=False, real_output=True):
+                            omit_in_coord=False):
     """
     Args:
         coord_func (function): generates code to do the coordinate
@@ -247,9 +247,7 @@ def _generate_interp_custom(coord_func, ndim, large_int, yshape, mode, cval,
     """
 
     ops = []
-    # TODO: Y (allowing single precison) or complex<double> for internal dtype
-    internal_dtype = 'double' if real_output else 'complex<double>'
-    # internal_dtype = 'double' if integer_output else 'Y'
+    internal_dtype = 'double' if integer_output else 'Y'
     ops.append(f'{internal_dtype} out = 0.0;')
 
     if large_int:
@@ -274,11 +272,11 @@ def _generate_interp_custom(coord_func, ndim, large_int, yshape, mode, cval,
     ops = ops + coord_func(ndim, nprepad)
 
     if cval is numpy.nan:
-        cval = 'CUDART_NAN'
+        cval = '(Y)CUDART_NAN'
     elif cval == numpy.inf:
-        cval = 'CUDART_INF'
+        cval = '(Y)CUDART_INF'
     elif cval == -numpy.inf:
-        cval = '-CUDART_INF'
+        cval = '(Y)(-CUDART_INF)'
     else:
         cval = f'({internal_dtype}){cval}'
 
@@ -462,12 +460,12 @@ def _generate_interp_custom(coord_func, ndim, large_int, yshape, mode, cval,
             if ({_cond}) {{
                 out += {cval} * ({internal_dtype})({_weight});
             }} else {{
-                {internal_dtype} val = x[{_coord_idx}];
+                {internal_dtype} val = ({internal_dtype})x[{_coord_idx}];
                 out += val * ({internal_dtype})({_weight});
             }}''')
         else:
             ops.append(f'''
-            {internal_dtype} val = x[{_coord_idx}];
+            {internal_dtype} val = ({internal_dtype})x[{_coord_idx}];
             out += val * ({internal_dtype})({_weight});''')
 
         ops.append('}' * ndim)
@@ -492,7 +490,7 @@ def _generate_interp_custom(coord_func, ndim, large_int, yshape, mode, cval,
 
 @cupy._util.memoize(for_each_device=True)
 def _get_map_kernel(ndim, large_int, yshape, mode, cval=0.0, order=1,
-                    integer_output=False, nprepad=0, real_output=True):
+                    integer_output=False, nprepad=0):
     in_params = 'raw X x, raw W coords'
     out_params = 'Y y'
     operation, name = _generate_interp_custom(
@@ -507,7 +505,6 @@ def _get_map_kernel(ndim, large_int, yshape, mode, cval=0.0, order=1,
         integer_output=integer_output,
         nprepad=nprepad,
         omit_in_coord=True,  # input image coordinates are not needed
-        real_output=real_output,
     )
     return cupy.ElementwiseKernel(in_params, out_params, operation, name,
                                   preamble=math_constants_preamble)
@@ -515,7 +512,7 @@ def _get_map_kernel(ndim, large_int, yshape, mode, cval=0.0, order=1,
 
 @cupy._util.memoize(for_each_device=True)
 def _get_shift_kernel(ndim, large_int, yshape, mode, cval=0.0, order=1,
-                      integer_output=False, nprepad=0, real_output=True):
+                      integer_output=False, nprepad=0):
     in_params = 'raw X x, raw W shift'
     out_params = 'Y y'
     operation, name = _generate_interp_custom(
@@ -529,7 +526,6 @@ def _get_shift_kernel(ndim, large_int, yshape, mode, cval=0.0, order=1,
         name='shift',
         integer_output=integer_output,
         nprepad=nprepad,
-        real_output=real_output,
     )
     return cupy.ElementwiseKernel(in_params, out_params, operation, name,
                                   preamble=math_constants_preamble)
@@ -537,8 +533,7 @@ def _get_shift_kernel(ndim, large_int, yshape, mode, cval=0.0, order=1,
 
 @cupy._util.memoize(for_each_device=True)
 def _get_zoom_shift_kernel(ndim, large_int, yshape, mode, cval=0.0, order=1,
-                           integer_output=False, grid_mode=False, nprepad=0,
-                           real_output=True):
+                           integer_output=False, grid_mode=False, nprepad=0):
     in_params = 'raw X x, raw W shift, raw W zoom'
     out_params = 'Y y'
     if grid_mode:
@@ -556,7 +551,6 @@ def _get_zoom_shift_kernel(ndim, large_int, yshape, mode, cval=0.0, order=1,
         name="zoom_shift_grid" if grid_mode else "zoom_shift",
         integer_output=integer_output,
         nprepad=nprepad,
-        real_output=real_output,
     )
     return cupy.ElementwiseKernel(in_params, out_params, operation, name,
                                   preamble=math_constants_preamble)
@@ -564,8 +558,7 @@ def _get_zoom_shift_kernel(ndim, large_int, yshape, mode, cval=0.0, order=1,
 
 @cupy._util.memoize(for_each_device=True)
 def _get_zoom_kernel(ndim, large_int, yshape, mode, cval=0.0, order=1,
-                     integer_output=False, grid_mode=False, nprepad=0,
-                     real_output=True):
+                     integer_output=False, grid_mode=False, nprepad=0):
     in_params = 'raw X x, raw W zoom'
     out_params = 'Y y'
     operation, name = _generate_interp_custom(
@@ -579,7 +572,6 @@ def _get_zoom_kernel(ndim, large_int, yshape, mode, cval=0.0, order=1,
         name="zoom_grid" if grid_mode else "zoom",
         integer_output=integer_output,
         nprepad=nprepad,
-        real_output=real_output,
     )
     return cupy.ElementwiseKernel(in_params, out_params, operation, name,
                                   preamble=math_constants_preamble)
@@ -587,7 +579,7 @@ def _get_zoom_kernel(ndim, large_int, yshape, mode, cval=0.0, order=1,
 
 @cupy._util.memoize(for_each_device=True)
 def _get_affine_kernel(ndim, large_int, yshape, mode, cval=0.0, order=1,
-                       integer_output=False, nprepad=0, real_output=True):
+                       integer_output=False, nprepad=0):
     in_params = 'raw X x, raw W mat'
     out_params = 'Y y'
     operation, name = _generate_interp_custom(
@@ -601,7 +593,6 @@ def _get_affine_kernel(ndim, large_int, yshape, mode, cval=0.0, order=1,
         name='affine',
         integer_output=integer_output,
         nprepad=nprepad,
-        real_output=real_output,
     )
     return cupy.ElementwiseKernel(in_params, out_params, operation, name,
                                   preamble=math_constants_preamble)

--- a/cupyx/scipy/ndimage/_interp_kernels.py
+++ b/cupyx/scipy/ndimage/_interp_kernels.py
@@ -224,7 +224,8 @@ def _unravel_loop_index(shape, uint_t='unsigned int'):
 
 
 def _generate_interp_custom(coord_func, ndim, large_int, yshape, mode, cval,
-                            order, name='', integer_output=False, nprepad=0):
+                            order, name='', integer_output=False, nprepad=0,
+                            omit_in_coord=False, real_output=True):
     """
     Args:
         coord_func (function): generates code to do the coordinate
@@ -246,7 +247,10 @@ def _generate_interp_custom(coord_func, ndim, large_int, yshape, mode, cval,
     """
 
     ops = []
-    ops.append('double out = 0.0;')
+    # TODO: Y (allowing single precison) or complex<double> for internal dtype
+    internal_dtype = 'double' if real_output else 'complex<double>'
+    # internal_dtype = 'double' if integer_output else 'Y'
+    ops.append(f'{internal_dtype} out = 0.0;')
 
     if large_int:
         uint_t = 'size_t'
@@ -262,8 +266,9 @@ def _generate_interp_custom(coord_func, ndim, large_int, yshape, mode, cval,
     for j in range(ndim - 1, 0, -1):
         ops.append(f'const {uint_t} sx_{j - 1} = sx_{j} * xsize_{j};')
 
-    # create in_coords array to store the unraveled indices
-    ops.append(_unravel_loop_index(yshape, uint_t))
+    if not omit_in_coord:
+        # create in_coords array to store the unraveled indices
+        ops.append(_unravel_loop_index(yshape, uint_t))
 
     # compute the transformed (target) coordinates, c_j
     ops = ops + coord_func(ndim, nprepad)
@@ -275,7 +280,8 @@ def _generate_interp_custom(coord_func, ndim, large_int, yshape, mode, cval,
     elif cval == -numpy.inf:
         cval = '-CUDART_INF'
     else:
-        cval = f'(double){cval}'
+        cval = f'({internal_dtype}){cval}'
+
 
     if mode == 'constant':
         # use cval if coordinate is outside the bounds of x
@@ -290,7 +296,8 @@ def _generate_interp_custom(coord_func, ndim, large_int, yshape, mode, cval,
         {{''')
 
     if order == 0:
-        ops.append('double dcoord;')  # mode 'wrap' requires this to work
+        if mode == 'wrap':
+            ops.append('double dcoord;')  # mode 'wrap' requires this to work
         for j in range(ndim):
             # determine nearest neighbor
             if mode == 'wrap':
@@ -323,13 +330,13 @@ def _generate_interp_custom(coord_func, ndim, large_int, yshape, mode, cval,
             _cond = ' || '.join([f'(ic_{j} < 0)' for j in range(ndim)])
             ops.append(f'''
             if ({_cond}) {{
-                out = (double){cval};
+                out = {cval};
             }} else {{
-                out = x[{_coord_idx}];
+                out = ({internal_dtype})x[{_coord_idx}];
             }}''')
         else:
             ops.append(f'''
-            out = x[{_coord_idx}];''')
+            out = ({internal_dtype})x[{_coord_idx}];''')
 
     elif order == 1:
         for j in range(ndim):
@@ -454,15 +461,15 @@ def _generate_interp_custom(coord_func, ndim, large_int, yshape, mode, cval,
             _cond = ' || '.join([f'(ic_{j} < 0)' for j in range(ndim)])
             ops.append(f'''
             if ({_cond}) {{
-                out += (X){cval} * ({_weight});
+                out += {cval} * ({internal_dtype})({_weight});
             }} else {{
-                X val = x[{_coord_idx}];
-                out += val * ({_weight});
+                {internal_dtype} val = x[{_coord_idx}];
+                out += val * ({internal_dtype})({_weight});
             }}''')
         else:
             ops.append(f'''
-            X val = x[{_coord_idx}];
-            out += val * ({_weight});''')
+            {internal_dtype} val = x[{_coord_idx}];
+            out += val * ({internal_dtype})({_weight});''')
 
         ops.append('}' * ndim)
 
@@ -486,7 +493,7 @@ def _generate_interp_custom(coord_func, ndim, large_int, yshape, mode, cval,
 
 @cupy._util.memoize(for_each_device=True)
 def _get_map_kernel(ndim, large_int, yshape, mode, cval=0.0, order=1,
-                    integer_output=False, nprepad=0):
+                    integer_output=False, nprepad=0, real_output=True):
     in_params = 'raw X x, raw W coords'
     out_params = 'Y y'
     operation, name = _generate_interp_custom(
@@ -500,6 +507,8 @@ def _get_map_kernel(ndim, large_int, yshape, mode, cval=0.0, order=1,
         name='shift',
         integer_output=integer_output,
         nprepad=nprepad,
+        omit_in_coord=True,  # input image coordinates are not needed
+        real_output=real_output,
     )
     return cupy.ElementwiseKernel(in_params, out_params, operation, name,
                                   preamble=math_constants_preamble)
@@ -507,7 +516,7 @@ def _get_map_kernel(ndim, large_int, yshape, mode, cval=0.0, order=1,
 
 @cupy._util.memoize(for_each_device=True)
 def _get_shift_kernel(ndim, large_int, yshape, mode, cval=0.0, order=1,
-                      integer_output=False, nprepad=0):
+                      integer_output=False, nprepad=0, real_output=True):
     in_params = 'raw X x, raw W shift'
     out_params = 'Y y'
     operation, name = _generate_interp_custom(
@@ -521,6 +530,7 @@ def _get_shift_kernel(ndim, large_int, yshape, mode, cval=0.0, order=1,
         name='shift',
         integer_output=integer_output,
         nprepad=nprepad,
+        real_output=real_output,
     )
     return cupy.ElementwiseKernel(in_params, out_params, operation, name,
                                   preamble=math_constants_preamble)
@@ -528,7 +538,8 @@ def _get_shift_kernel(ndim, large_int, yshape, mode, cval=0.0, order=1,
 
 @cupy._util.memoize(for_each_device=True)
 def _get_zoom_shift_kernel(ndim, large_int, yshape, mode, cval=0.0, order=1,
-                           integer_output=False, grid_mode=False, nprepad=0):
+                           integer_output=False, grid_mode=False, nprepad=0,
+                           real_output=True):
     in_params = 'raw X x, raw W shift, raw W zoom'
     out_params = 'Y y'
     if grid_mode:
@@ -546,6 +557,7 @@ def _get_zoom_shift_kernel(ndim, large_int, yshape, mode, cval=0.0, order=1,
         name="zoom_shift_grid" if grid_mode else "zoom_shift",
         integer_output=integer_output,
         nprepad=nprepad,
+        real_output=real_output,
     )
     return cupy.ElementwiseKernel(in_params, out_params, operation, name,
                                   preamble=math_constants_preamble)
@@ -553,7 +565,8 @@ def _get_zoom_shift_kernel(ndim, large_int, yshape, mode, cval=0.0, order=1,
 
 @cupy._util.memoize(for_each_device=True)
 def _get_zoom_kernel(ndim, large_int, yshape, mode, cval=0.0, order=1,
-                     integer_output=False, grid_mode=False, nprepad=0):
+                     integer_output=False, grid_mode=False, nprepad=0,
+                     real_output=True):
     in_params = 'raw X x, raw W zoom'
     out_params = 'Y y'
     operation, name = _generate_interp_custom(
@@ -567,6 +580,7 @@ def _get_zoom_kernel(ndim, large_int, yshape, mode, cval=0.0, order=1,
         name="zoom_grid" if grid_mode else "zoom",
         integer_output=integer_output,
         nprepad=nprepad,
+        real_output=real_output,
     )
     return cupy.ElementwiseKernel(in_params, out_params, operation, name,
                                   preamble=math_constants_preamble)
@@ -574,7 +588,7 @@ def _get_zoom_kernel(ndim, large_int, yshape, mode, cval=0.0, order=1,
 
 @cupy._util.memoize(for_each_device=True)
 def _get_affine_kernel(ndim, large_int, yshape, mode, cval=0.0, order=1,
-                       integer_output=False, nprepad=0):
+                       integer_output=False, nprepad=0, real_output=True):
     in_params = 'raw X x, raw W mat'
     out_params = 'Y y'
     operation, name = _generate_interp_custom(
@@ -588,6 +602,7 @@ def _get_affine_kernel(ndim, large_int, yshape, mode, cval=0.0, order=1,
         name='affine',
         integer_output=integer_output,
         nprepad=nprepad,
+        real_output=real_output,
     )
     return cupy.ElementwiseKernel(in_params, out_params, operation, name,
                                   preamble=math_constants_preamble)

--- a/cupyx/scipy/ndimage/_util.py
+++ b/cupyx/scipy/ndimage/_util.py
@@ -1,3 +1,5 @@
+import warnings
+
 import cupy
 import cupy._util
 
@@ -19,6 +21,9 @@ def _check_cval(mode, cval, integer_output):
 def _get_weights_dtype(input, weights):
     if weights.dtype.kind == "c" or input.dtype.kind == "c":
         return cupy.promote_types(input.real.dtype, cupy.complex64)
+    elif weights.dtype.kind in 'iub':
+        # convert integer dtype weights to double as in SciPy
+        return cupy.float64
     return cupy.promote_types(input.real.dtype, cupy.float32)
 
 

--- a/cupyx/scipy/ndimage/_util.py
+++ b/cupyx/scipy/ndimage/_util.py
@@ -6,7 +6,6 @@ import cupy
 import cupy._util
 
 
-
 def _is_integer_output(output, input):
     if output is None:
         return input.dtype.kind in 'iu'

--- a/cupyx/scipy/ndimage/_util.py
+++ b/cupyx/scipy/ndimage/_util.py
@@ -1,7 +1,10 @@
 import warnings
 
+import numpy
+
 import cupy
 import cupy._util
+
 
 
 def _is_integer_output(output, input):
@@ -41,7 +44,7 @@ def _get_output(output, input, shape=None, complex_output=False):
             output = cupy.promote_types(output, cupy.complex64)
         output = cupy.zeros(shape, dtype=output)
     elif isinstance(output, str):
-        output = cupy.typeDict[output]
+        output = numpy.typeDict[output]
         if complex_output and cupy.dtype(output).kind != 'c':
             raise RuntimeError("output must have complex dtype")
         output = cupy.zeros(shape, dtype=output)

--- a/cupyx/scipy/ndimage/_util.py
+++ b/cupyx/scipy/ndimage/_util.py
@@ -16,11 +16,34 @@ def _check_cval(mode, cval, integer_output):
                                   "outputs with integer dtype.")
 
 
-def _get_output(output, input, shape=None):
-    if not isinstance(output, cupy.ndarray):
-        return cupy.zeros_like(input, shape=shape, dtype=output, order='C')
-    if output.shape != (input.shape if shape is None else tuple(shape)):
-        raise ValueError('output shape is not correct')
+def _get_weights_dtype(input, weights):
+    if weights.dtype.kind == "c" or input.dtype.kind == "c":
+        return cupy.promote_types(input.real.dtype, cupy.complex64)
+    return cupy.promote_types(input.real.dtype, cupy.float32)
+
+
+def _get_output(output, input, shape=None, complex_output=False):
+    shape = input.shape if shape is None else shape
+    if output is None:
+        if complex_output:
+            _dtype = cupy.promote_types(input.dtype, cupy.complex64)
+        else:
+            _dtype = input.dtype
+        output = cupy.zeros(shape, dtype=_dtype)
+    elif isinstance(output, (type, cupy.dtype)):
+        if complex_output and cupy.dtype(output).kind != 'c':
+            warnings.warn("promoting specified output dtype to complex")
+            output = cupy.promote_types(output, cupy.complex64)
+        output = cupy.zeros(shape, dtype=output)
+    elif isinstance(output, str):
+        output = cupy.typeDict[output]
+        if complex_output and cupy.dtype(output).kind != 'c':
+            raise RuntimeError("output must have complex dtype")
+        output = cupy.zeros(shape, dtype=output)
+    elif output.shape != shape:
+        raise RuntimeError("output shape not correct")
+    elif complex_output and output.dtype.kind != 'c':
+        raise RuntimeError("output must have complex dtype")
     return output
 
 

--- a/cupyx/scipy/ndimage/filters.py
+++ b/cupyx/scipy/ndimage/filters.py
@@ -143,13 +143,10 @@ def convolve1d(input, weights, axis=-1, output=None, mode="reflect", cval=0.0,
         and input is integral) the results may not perfectly match the results
         from SciPy due to floating-point rounding of intermediate results.
     """
-    weights = weights[::-1]
-    origin = -origin
-    if not len(weights) & 1:
-        origin -= 1
     weights, origins = _filters_core._convert_1d_args(input.ndim, weights,
                                                       origin, axis)
-    return _correlate_or_convolve(input, weights, output, mode, cval, origins)
+    return _correlate_or_convolve(input, weights, output, mode, cval, origins,
+                                  True)
 
 
 def _correlate_or_convolve(input, weights, output, mode, cval, origin,
@@ -169,6 +166,9 @@ def _correlate_or_convolve(input, weights, output, mode, cval, origin,
             if wsize % 2 == 0:
                 origins[i] -= 1
         origins = tuple(origins)
+    elif weights.dtype.kind == "c":
+        # numpy.correlate conjugates weights rather than input.
+        weights = weights.conj()
     weights_dtype = _util._get_weights_dtype(input, weights)
     offsets = _filters_core._origins_to_offsets(origins, weights.shape)
     kernel = _get_correlate_kernel(mode, weights.shape, int_type,

--- a/cupyx/scipy/ndimage/filters.py
+++ b/cupyx/scipy/ndimage/filters.py
@@ -169,10 +169,12 @@ def _correlate_or_convolve(input, weights, output, mode, cval, origin,
             if wsize % 2 == 0:
                 origins[i] -= 1
         origins = tuple(origins)
+    weights_dtype = _util._get_weights_dtype(input, weights)
     offsets = _filters_core._origins_to_offsets(origins, weights.shape)
     kernel = _get_correlate_kernel(mode, weights.shape, int_type,
                                    offsets, cval)
-    output = _filters_core._call_kernel(kernel, input, weights, output)
+    output = _filters_core._call_kernel(kernel, input, weights, output,
+                                        weights_dtype=weights_dtype)
     return output
 
 

--- a/cupyx/scipy/ndimage/interpolation.py
+++ b/cupyx/scipy/ndimage/interpolation.py
@@ -307,8 +307,7 @@ def map_coordinates(input, coordinates, output=None, order=3,
     large_int = max(_prod(input.shape), coordinates.shape[0]) > 1 << 31
     kern = _interp_kernels._get_map_kernel(
         input.ndim, large_int, yshape=coordinates.shape, mode=mode, cval=cval,
-        order=order, integer_output=integer_output, nprepad=nprepad,
-        real_output=ret.dtype.kind != 'c')
+        order=order, integer_output=integer_output, nprepad=nprepad)
     kern(filtered, coordinates, ret)
     return ret
 
@@ -422,14 +421,12 @@ def affine_transform(input, matrix, offset=0.0, output_shape=None, output=None,
         offset = -offset / matrix
         kern = _interp_kernels._get_zoom_shift_kernel(
             ndim, large_int, output_shape, mode, cval=cval, order=order,
-            integer_output=integer_output, nprepad=nprepad,
-            real_output=output.dtype.kind != 'c')
+            integer_output=integer_output, nprepad=nprepad)
         kern(filtered, offset, matrix, output)
     else:
         kern = _interp_kernels._get_affine_kernel(
             ndim, large_int, output_shape, mode, cval=cval, order=order,
-            integer_output=integer_output, nprepad=nprepad,
-            real_output=output.dtype.kind != 'c')
+            integer_output=integer_output, nprepad=nprepad)
         m = cupy.zeros((ndim, ndim + 1), dtype=cupy.float64)
         m[:, :-1] = matrix
         m[:, -1] = cupy.asarray(offset, dtype=cupy.float64)
@@ -607,8 +604,7 @@ def shift(input, shift, output=None, order=3, mode='constant', cval=0.0,
         large_int = _prod(input.shape) > 1 << 31
         kern = _interp_kernels._get_shift_kernel(
             input.ndim, large_int, input.shape, mode, cval=cval, order=order,
-            integer_output=integer_output, nprepad=nprepad,
-            real_output=output.dtype.kind != 'c')
+            integer_output=integer_output, nprepad=nprepad)
         shift = cupy.asarray(shift, dtype=cupy.float64, order='C')
         if shift.ndim != 1:
             raise ValueError('shift must be 1d')
@@ -732,7 +728,7 @@ def zoom(input, zoom, output=None, order=3, mode='constant', cval=0.0,
         kern = _interp_kernels._get_zoom_kernel(
             input.ndim, large_int, output_shape, mode, order=order,
             integer_output=integer_output, grid_mode=grid_mode,
-            nprepad=nprepad, real_output=output.dtype.kind != 'c')
+            nprepad=nprepad)
         zoom = cupy.asarray(zoom, dtype=cupy.float64)
         kern(filtered, zoom, output)
     return output

--- a/cupyx/scipy/ndimage/interpolation.py
+++ b/cupyx/scipy/ndimage/interpolation.py
@@ -307,7 +307,8 @@ def map_coordinates(input, coordinates, output=None, order=3,
     large_int = max(_prod(input.shape), coordinates.shape[0]) > 1 << 31
     kern = _interp_kernels._get_map_kernel(
         input.ndim, large_int, yshape=coordinates.shape, mode=mode, cval=cval,
-        order=order, integer_output=integer_output, nprepad=nprepad)
+        order=order, integer_output=integer_output, nprepad=nprepad,
+        real_output=ret.dtype.kind != 'c')
     kern(filtered, coordinates, ret)
     return ret
 
@@ -421,12 +422,14 @@ def affine_transform(input, matrix, offset=0.0, output_shape=None, output=None,
         offset = -offset / matrix
         kern = _interp_kernels._get_zoom_shift_kernel(
             ndim, large_int, output_shape, mode, cval=cval, order=order,
-            integer_output=integer_output, nprepad=nprepad)
+            integer_output=integer_output, nprepad=nprepad,
+            real_output=output.dtype.kind != 'c')
         kern(filtered, offset, matrix, output)
     else:
         kern = _interp_kernels._get_affine_kernel(
             ndim, large_int, output_shape, mode, cval=cval, order=order,
-            integer_output=integer_output, nprepad=nprepad)
+            integer_output=integer_output, nprepad=nprepad,
+            real_output=output.dtype.kind != 'c')
         m = cupy.zeros((ndim, ndim + 1), dtype=cupy.float64)
         m[:, :-1] = matrix
         m[:, -1] = cupy.asarray(offset, dtype=cupy.float64)
@@ -604,7 +607,8 @@ def shift(input, shift, output=None, order=3, mode='constant', cval=0.0,
         large_int = _prod(input.shape) > 1 << 31
         kern = _interp_kernels._get_shift_kernel(
             input.ndim, large_int, input.shape, mode, cval=cval, order=order,
-            integer_output=integer_output, nprepad=nprepad)
+            integer_output=integer_output, nprepad=nprepad,
+            real_output=output.dtype.kind != 'c')
         shift = cupy.asarray(shift, dtype=cupy.float64, order='C')
         if shift.ndim != 1:
             raise ValueError('shift must be 1d')
@@ -728,7 +732,7 @@ def zoom(input, zoom, output=None, order=3, mode='constant', cval=0.0,
         kern = _interp_kernels._get_zoom_kernel(
             input.ndim, large_int, output_shape, mode, order=order,
             integer_output=integer_output, grid_mode=grid_mode,
-            nprepad=nprepad)
+            nprepad=nprepad, real_output=output.dtype.kind != 'c')
         zoom = cupy.asarray(zoom, dtype=cupy.float64)
         kern(filtered, zoom, output)
     return output

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
@@ -316,7 +316,9 @@ class TestFilterFast(FilterTestCaseBase):
 @testing.gpu
 @testing.with_requires('scipy')
 class TestFilterComplexFast(FilterTestCaseBase):
+
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
+    @testing.with_requires('scipy>=1.6.0')
     def test_filter(self, xp, scp):
         return self._filter(xp, scp)
 
@@ -592,15 +594,17 @@ class TestWeightComplexDtype(FilterTestCaseBase):
             pytest.skip("non-complex")
 
     def _get_array_and_weights(self, xp):
-            arr = testing.shaped_random(self.shape, xp, self.dtype)
-            weights = self._get_weights(xp)
-            return arr, weights
+        arr = testing.shaped_random(self.shape, xp, self.dtype)
+        weights = self._get_weights(xp)
+        return arr, weights
 
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
+    @testing.with_requires('scipy>=1.6.0')
     def test_filter_complex(self, xp, scp):
         self._skip_noncomplex()
         return self._filter(xp, scp)
 
+    @testing.with_requires('scipy>=1.6.0')
     def test_filter_complex_output_dtype_error(self):
         # raises RuntimeError if provided a real-valued output array
         self._skip_noncomplex()
@@ -612,6 +616,7 @@ class TestWeightComplexDtype(FilterTestCaseBase):
                 func(arr, weights, output=output)
         return
 
+    @testing.with_requires('scipy>=1.6.0')
     def test_filter_complex_output_dtype_warns(self):
         # warns if a real-valued dtype is specified for the output
         self._skip_noncomplex()

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
@@ -66,6 +66,20 @@ class TestMapCoordinates:
         coordinates = testing.shaped_random((a.ndim, 100), xp, dtype)
         return self._map_coordinates(xp, scp, a, coordinates)
 
+    @testing.for_complex_dtypes()
+    @testing.numpy_cupy_allclose(atol=1e-4, scipy_name='scp')
+    def test_map_coordinates_complex_float(self, xp, scp, dtype):
+        # promote output to a complex dtype
+        if self.output == numpy.float64:
+            self.output = numpy.complex128
+        elif self.output == float:
+            self.output = complex
+        elif self.output == 'f':
+            self.output = 'F'
+        a = testing.shaped_random((100, 100), xp, dtype)
+        coordinates = testing.shaped_random((a.ndim, 100), xp, xp.float64)
+        return self._map_coordinates(xp, scp, a, coordinates)
+
     @testing.for_float_dtypes(no_float16=True)
     @testing.numpy_cupy_allclose(atol=1e-4, scipy_name='scp')
     def test_map_coordinates_fortran_order(self, xp, scp, dtype):
@@ -148,6 +162,16 @@ class TestAffineTransform:
         matrix = testing.shaped_random(self.matrix_shape, xp, dtype)
         return self._affine_transform(xp, scp, a, matrix)
 
+    @testing.for_complex_dtypes()
+    @testing.numpy_cupy_allclose(atol=1e-5, scipy_name='scp')
+    def test_affine_transform_complex_float(self, xp, scp, dtype):
+        if self.output == numpy.float64:
+            # must promote output to a complex dtype
+            self.output = numpy.complex128
+        a = testing.shaped_random((100, 100), xp, dtype)
+        matrix = testing.shaped_random(self.matrix_shape, xp, xp.float64)
+        return self._affine_transform(xp, scp, a, matrix)
+
     @testing.for_float_dtypes(no_float16=True)
     @testing.numpy_cupy_allclose(atol=1e-5, scipy_name='scp')
     def test_affine_transform_fortran_order(self, xp, scp, dtype):
@@ -202,6 +226,14 @@ class TestAffineExceptions:
             with pytest.raises(RuntimeError):
                 ndi.affine_transform(x, xp.eye(x.ndim)[:, :-1])
 
+    def test_invalid_output_dtype(self):
+        # real output array with complex input is not allowed
+        ndimage_modules = (scipy.ndimage, cupyx.scipy.ndimage)
+        for (xp, ndi) in zip((numpy, cupy), ndimage_modules):
+            x = xp.ones((8, 8, 8), dtype=numpy.complex128)
+            output = xp.ones_like(x, dtype=x.real.dtype)
+            with pytest.raises(RuntimeError):
+                ndi.affine_transform(x, xp.ones((0, 3)), output=output)
 
 @testing.gpu
 @testing.with_requires('opencv-python')
@@ -270,6 +302,14 @@ class TestRotate:
     @testing.for_float_dtypes(no_float16=True)
     @testing.numpy_cupy_allclose(atol=1e-5, scipy_name='scp')
     def test_rotate_float(self, xp, scp, dtype):
+        a = testing.shaped_random((10, 10), xp, dtype)
+        return self._rotate(xp, scp, a)
+
+    @testing.for_complex_dtypes()
+    @testing.numpy_cupy_allclose(atol=1e-5, scipy_name='scp')
+    def test_rotate_complex_float(self, xp, scp, dtype):
+        if self.output == numpy.float64:
+            self.output = numpy.complex128
         a = testing.shaped_random((10, 10), xp, dtype)
         return self._rotate(xp, scp, a)
 
@@ -390,6 +430,15 @@ class TestShift:
     @testing.for_float_dtypes(no_float16=True)
     @testing.numpy_cupy_allclose(atol=1e-5, scipy_name='scp')
     def test_shift_float(self, xp, scp, dtype):
+        a = testing.shaped_random((100, 100), xp, dtype)
+        return self._shift(xp, scp, a)
+
+
+    @testing.for_complex_dtypes()
+    @testing.numpy_cupy_allclose(atol=1e-5, scipy_name='scp')
+    def test_shift_complex_float(self, xp, scp, dtype):
+        if self.output == numpy.float64:
+            self.output = numpy.complex128
         a = testing.shaped_random((100, 100), xp, dtype)
         return self._shift(xp, scp, a)
 
@@ -558,6 +607,14 @@ class TestZoom:
     @testing.for_float_dtypes(no_float16=True)
     @testing.numpy_cupy_allclose(atol=1e-5, scipy_name='scp')
     def test_zoom_float(self, xp, scp, dtype):
+        a = testing.shaped_random((100, 100), xp, dtype)
+        return self._zoom(xp, scp, a)
+
+    @testing.for_complex_dtypes()
+    @testing.numpy_cupy_allclose(atol=1e-5, scipy_name='scp')
+    def test_zoom_complex_float(self, xp, scp, dtype):
+        if self.output == numpy.float64:
+            self.output = numpy.complex128
         a = testing.shaped_random((100, 100), xp, dtype)
         return self._zoom(xp, scp, a)
 

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
@@ -68,6 +68,7 @@ class TestMapCoordinates:
 
     @testing.for_complex_dtypes()
     @testing.numpy_cupy_allclose(atol=1e-4, scipy_name='scp')
+    @testing.with_requires('scipy>=1.6.0')
     def test_map_coordinates_complex_float(self, xp, scp, dtype):
         # promote output to a complex dtype
         if self.output == numpy.float64:
@@ -164,6 +165,7 @@ class TestAffineTransform:
 
     @testing.for_complex_dtypes()
     @testing.numpy_cupy_allclose(atol=1e-5, scipy_name='scp')
+    @testing.with_requires('scipy>=1.6.0')
     def test_affine_transform_complex_float(self, xp, scp, dtype):
         if self.output == numpy.float64:
             # must promote output to a complex dtype
@@ -226,6 +228,7 @@ class TestAffineExceptions:
             with pytest.raises(RuntimeError):
                 ndi.affine_transform(x, xp.eye(x.ndim)[:, :-1])
 
+    @testing.with_requires('scipy>=1.6.0')
     def test_invalid_output_dtype(self):
         # real output array with complex input is not allowed
         ndimage_modules = (scipy.ndimage, cupyx.scipy.ndimage)
@@ -234,6 +237,7 @@ class TestAffineExceptions:
             output = xp.ones_like(x, dtype=x.real.dtype)
             with pytest.raises(RuntimeError):
                 ndi.affine_transform(x, xp.ones((0, 3)), output=output)
+
 
 @testing.gpu
 @testing.with_requires('opencv-python')
@@ -307,6 +311,7 @@ class TestRotate:
 
     @testing.for_complex_dtypes()
     @testing.numpy_cupy_allclose(atol=1e-5, scipy_name='scp')
+    @testing.with_requires('scipy>=1.6.0')
     def test_rotate_complex_float(self, xp, scp, dtype):
         if self.output == numpy.float64:
             self.output = numpy.complex128
@@ -433,9 +438,9 @@ class TestShift:
         a = testing.shaped_random((100, 100), xp, dtype)
         return self._shift(xp, scp, a)
 
-
     @testing.for_complex_dtypes()
     @testing.numpy_cupy_allclose(atol=1e-5, scipy_name='scp')
+    @testing.with_requires('scipy>=1.6.0')
     def test_shift_complex_float(self, xp, scp, dtype):
         if self.output == numpy.float64:
             self.output = numpy.complex128
@@ -612,6 +617,7 @@ class TestZoom:
 
     @testing.for_complex_dtypes()
     @testing.numpy_cupy_allclose(atol=1e-5, scipy_name='scp')
+    @testing.with_requires('scipy>=1.6.0')
     def test_zoom_complex_float(self, xp, scp, dtype):
         if self.output == numpy.float64:
             self.output = numpy.complex128


### PR DESCRIPTION
~blocked by #4402~

This PR enables interpolation (scipy/scipy#12812) and convolution/correlation of complex-valued data (scipy/scipy#12725). It is created starting from #4401, so most commits here are duplicate with that PR. The new ones start from 87872b7.

Work on this PR resulted in a bug fix PR to SciPy 1.6.0rc1 (scipy/scipy#13249) for constant boundary modes with `cval` != 0.




