### PR TITLE
Eliminate read past end of array in percentile_weightnening

### DIFF
--- a/tests/cupy_tests/statistics_tests/test_order.py
+++ b/tests/cupy_tests/statistics_tests/test_order.py
@@ -127,7 +127,7 @@ class TestOrder(unittest.TestCase):
 
         # Check that percentile still returns non-NaN results
         a = testing.shaped_random((5,), cupy, dtype)
-        q = cupy.array((0,100,), dtype=dtype)
+        q = cupy.array((0, 100), dtype=dtype)
         percentiles = cupy.percentile(a, q, axis=None, interpolation='linear')
         assert not cupy.any(cupy.isnan(percentiles))
 

--- a/tests/cupy_tests/statistics_tests/test_order.py
+++ b/tests/cupy_tests/statistics_tests/test_order.py
@@ -6,7 +6,8 @@ import pytest
 
 import cupy
 import cupy.core._accelerator as _acc
-from cupy import cuda, testing
+from cupy import cuda
+from cupy import testing
 
 
 _all_interpolations = (

--- a/tests/cupy_tests/statistics_tests/test_order.py
+++ b/tests/cupy_tests/statistics_tests/test_order.py
@@ -1,4 +1,3 @@
-import gc
 import unittest
 import warnings
 
@@ -123,6 +122,7 @@ class TestOrder(unittest.TestCase):
         # Create an allocator that guarantees array allocated in
         # cupy.percentile call will be followed by a NaN
         original_allocator = cuda.get_allocator()
+
         def controlled_allocator(size):
             memptr = original_allocator(size)
             base_size = memptr.mem.size
@@ -139,7 +139,8 @@ class TestOrder(unittest.TestCase):
 
         cuda.set_allocator(controlled_allocator)
         try:
-            percentiles = cupy.percentile(a, q, axis=None, interpolation='linear')
+            percentiles = cupy.percentile(a, q, axis=None,
+                                          interpolation='linear')
         finally:
             cuda.set_allocator(original_allocator)
 

--- a/tests/cupy_tests/statistics_tests/test_order.py
+++ b/tests/cupy_tests/statistics_tests/test_order.py
@@ -126,7 +126,7 @@ class TestOrder(unittest.TestCase):
         def controlled_allocator(size):
             memptr = original_allocator(size)
             base_size = memptr.mem.size
-            assert base_size == 512
+            assert base_size % 512 == 0
             item_size = dtype().itemsize
             shape = (base_size // item_size,)
             x = cupy.ndarray(memptr=memptr, shape=shape, dtype=dtype)

--- a/tests/cupy_tests/statistics_tests/test_order.py
+++ b/tests/cupy_tests/statistics_tests/test_order.py
@@ -118,6 +118,7 @@ class TestOrder(unittest.TestCase):
             with pytest.raises(ValueError):
                 xp.percentile(a, q, axis=-1, interpolation='deadbeef')
 
+    # See gh-4453
     @testing.for_float_dtypes()
     def test_percentile_memory_access(self, dtype):
         # Create an allocator that guarantees array allocated in

--- a/tests/cupy_tests/statistics_tests/test_order.py
+++ b/tests/cupy_tests/statistics_tests/test_order.py
@@ -7,7 +7,7 @@ import pytest
 
 import cupy
 import cupy.core._accelerator as _acc
-from cupy import testing
+from cupy import cuda, testing
 
 
 _all_interpolations = (
@@ -120,15 +120,29 @@ class TestOrder(unittest.TestCase):
 
     @testing.for_float_dtypes()
     def test_percentile_memory_access(self, dtype):
-        # Fill a large chunk of memory with NaNs
-        nans = cupy.full((1000,), cupy.nan, dtype=dtype)
-        del nans
-        gc.collect()
+        # Create an allocator that guarantees array allocated in
+        # cupy.percentile call will be followed by a NaN
+        original_allocator = cuda.get_allocator()
+        def controlled_allocator(size):
+            memptr = original_allocator(size)
+            base_size = memptr.mem.size
+            assert base_size == 512
+            item_size = dtype().itemsize
+            shape = (base_size // item_size,)
+            x = cupy.ndarray(memptr=memptr, shape=shape, dtype=dtype)
+            x.fill(cupy.nan)
+            return memptr
 
         # Check that percentile still returns non-NaN results
         a = testing.shaped_random((5,), cupy, dtype)
         q = cupy.array((0, 100), dtype=dtype)
-        percentiles = cupy.percentile(a, q, axis=None, interpolation='linear')
+
+        cuda.set_allocator(controlled_allocator)
+        try:
+            percentiles = cupy.percentile(a, q, axis=None, interpolation='linear')
+        finally:
+            cuda.set_allocator(original_allocator)
+
         assert not cupy.any(cupy.isnan(percentiles))
 
     @testing.for_all_dtypes()


### PR DESCRIPTION
Because the existing percentile_weightnening kernel reads past the end of the input array, the 100th quantile returned by `cupy.percentile` can (incorrectly) be a NaN if that extra read returns a NaN as described in #4451. This PR ensures that the kernel does not read past the end of the array by passing in the size of the array and ensuring that the index is at most `size - 1`.

While the fix is straightforward, the associated test is somewhat trickier. The unit test provided as part of this PR allocates a large array of NaNs, deletes that array, and then calls `cupy.percentile` in order to maximize the likelihood that arrays newly-allocated during the computation will have a NaN in device memory just past their end.

I'm currently leaving this PR as WIP because I would appreciate feedback on the included test. While this test consistently fails for me without the described fix, I don't have a good theoretical justification that this would correctly fail every time. More specifically, the size of the allocated array of NaNs is somewhat arbitrary. 1000 produced consistent failures on my system, but 100 did not.

At a higher level, is this unit test worth having? It demonstrates the very specific issue in the initial `percentile_weightnening` kernel, but `cuda-memcheck` is probably better suited to finding this class of errors than trying to guard against them in tests.

Resolve #4451