### PR TITLE
[WIP] Add `cupy.complex32`

### DIFF
--- a/note_for_complex32
+++ b/note_for_complex32
@@ -1,0 +1,15 @@
+Follow this file
+https://github.com/numpy/numpy/blob/master/numpy/core/src/umath/_rational_tests.c.src
+to define a customized Python type complex32 and then dtype
+
+All numpy built-in types are defined in this file:
+https://github.com/numpy/numpy/blob/master/numpy/core/src/multiarray/arraytypes.c.src
+
+Refs:
+https://github.com/numpy/numpy/blob/master/numpy/core/src/multiarray/_multiarray_tests.c.src
+https://docs.python.org/3/extending/newtypes_tutorial.html
+https://github.com/rainwoodman/gaepsi/blob/860b662d7a4f99acdfd44c0862cf93b4d5bc777a/gaepsi/compiledbase/npydtype.pxd
+https://github.com/gidden/cyclopts/blob/e346b1721c8d8722af2862823844ab2e7864141b/cyclopts/dtypes.pyx
+https://github.com/sglyon/SGLcapstone/blob/3c15048ca01b53cc302d83fa72345de8a85ef54c/code/xdress/hsfpy/stlcontainers.pyx
+
+

--- a/test_dtype.py
+++ b/test_dtype.py
@@ -1,0 +1,3 @@
+import test_dtype
+test_dtype.init()
+type(test_dtype.complex32)

--- a/test_dtype.py
+++ b/test_dtype.py
@@ -1,5 +1,23 @@
 import test_dtype
+
+
 test_dtype.init()
 print(type(test_dtype.complex32))
 print(test_dtype.complex32)
 print(test_dtype.complex32_dtype)
+
+
+x = test_dtype.complex32_dtype
+assert x.base.__repr__() == "dtype('complex32')"
+assert x.byteorder == '='
+assert x.char == 'E'
+assert x.descr == [('', '<c4')]
+assert x.fields is None
+assert not x.hasobject
+assert x.isnative
+assert x.itemsize == 4
+assert x.kind == 'c'
+assert x.name == str(x) == 'complex32'
+assert x.ndim == 0
+assert x.str == '<c4'
+assert str(x.type).endswith(".complex32'>")

--- a/test_dtype.py
+++ b/test_dtype.py
@@ -1,3 +1,5 @@
 import test_dtype
 test_dtype.init()
 print(type(test_dtype.complex32))
+print(test_dtype.complex32)
+print(test_dtype.complex32_dtype)

--- a/test_dtype.py
+++ b/test_dtype.py
@@ -1,3 +1,3 @@
 import test_dtype
 test_dtype.init()
-type(test_dtype.complex32)
+print(type(test_dtype.complex32))

--- a/test_dtype.pyx
+++ b/test_dtype.pyx
@@ -130,6 +130,10 @@ cdef extern from *:
     PyArray_Descr _complex32_dtype
     int register_dtype()
 
+    ctypedef class numpy.complexfloating [object PyObject]:
+        pass
+    #cpython.PyTypeObject PyComplexFloatingArrType_Type
+
 
 #import_ufunc()
 
@@ -174,3 +178,17 @@ def init():
     #print(x)
     #print(<intptr_t>PyArray_DescrFromType(_complex32_num))
     #print(complex32)
+
+
+#cdef class Complex32(PyComplexFloatingArrType_Type):
+cdef class Complex32:
+    '''cdef class implementation of complex32'''
+
+    cdef:
+        unsigned int x, y
+
+    def __init__(self):
+        pass
+
+
+cdef cpython.PyTypeObject* type_to_Complex32 = <cpython.PyTypeObject*>Complex32

--- a/test_dtype.pyx
+++ b/test_dtype.pyx
@@ -1,0 +1,151 @@
+#from libc.string cimport memcpy
+cimport cpython
+from numpy cimport (#dtype, PyArray_ArrFuncs,
+                    PyArray_Descr, PyArray_DescrFromType)# PyArray_RegisterDataType)
+cimport numpy
+
+from numpy cimport import_array
+
+import_array()
+
+
+cdef extern from *:
+    '''
+    typedef struct {
+        unsigned short x;
+        unsigned short y;
+    } _complex32;
+
+    typedef struct {
+        PyObject_HEAD
+        _complex32 x;
+    } _complex32_obj;
+
+    static PyTypeObject _complex32_type = {
+        PyVarObject_HEAD_INIT(NULL, 0)
+        .tp_name = "cupy.complex32",
+        .tp_basicsize = sizeof(_complex32_obj),
+        .tp_doc = "a complex number consisting of two float16",
+    };
+
+    static PyObject* PyComplex32_FromComplex32(_complex32 c) {
+        printf("\\n\\n\\nI am here!!!!\\n\\n\\n"); fflush(stdout);
+        _complex32_obj* p = (_complex32_obj*)_complex32_type.tp_alloc(&_complex32_type, 0);
+        if (p) {
+            p->x.x = c.x;
+            p->x.y = c.y;
+        }
+        return (PyObject*)p;
+    }
+    
+    static PyObject* complex32_getitem(void* data, void* arr) {
+        printf("\\n\\n\\n getitem !!!!\\n\\n\\n");  fflush(stdout);
+        _complex32 c;
+        memcpy(&c, data, sizeof(_complex32));
+        return PyComplex32_FromComplex32(c);
+    }
+
+    static int complex32_setitem(PyObject* item, void* data, void* arr) {
+        printf("\\n\\n\\n setitem !!!!\\n\\n\\n");  fflush(stdout);
+        _complex32 c;
+        memcpy(data, &c, sizeof(_complex32));
+        return 0;
+    }
+
+    static NPY_INLINE void byteswap(npy_half* x) {
+        char* p = (char*)x;
+        for (size_t i = 0; i < sizeof(*x)/2; i++) {
+            size_t j = sizeof(*x)-1-i;
+            char t = p[i];
+            p[i] = p[j];
+            p[j] = t;
+        }
+    }
+
+    static void complex32_copyswap(void* dst, void* src, int swap, void* arr) {
+        _complex32* c;
+        if (!src) {
+            return;
+        }
+        c = (_complex32*)dst;
+        memcpy(c, src, sizeof(_complex32));
+        if (swap) {
+            byteswap(&c->x);
+            byteswap(&c->y);
+        }
+    }
+
+    // minimal requirement to make dtype registration work
+    // TODO: use PyArray_InitArrFuncs to initialize the struct
+    static PyArray_ArrFuncs _complex32_arrfuncs = {
+        .getitem = complex32_getitem,
+        .setitem = complex32_setitem,
+        .copyswap = complex32_copyswap,
+    };
+
+    static PyArray_Descr _complex32_dtype = {
+        PyObject_HEAD_INIT(0)
+        .typeobj = &_complex32_type,  // (PyTypeObject*)(&_complex32_type),
+        .kind = 'c',
+        .type = 'E',  // lowercase for fp16
+        .byteorder = '=',  // native order
+        .flags = NPY_NEEDS_PYAPI | NPY_USE_GETITEM | NPY_USE_SETITEM,
+        .elsize = 4,
+        .alignment = 4,
+        //.names = {'real', 'imag'},
+        .f = &_complex32_arrfuncs,
+    };
+
+    int register_dtype (void) {
+        int is_ready = PyType_Ready((PyTypeObject*)(&_complex32_type));
+        printf("is _complex32_type ready? %i\\n", is_ready);
+
+        //((PyObject*)(&_complex32_dtype)) -> ob_refcnt = 1;
+        //((PyObject*)(&_complex32_dtype)) -> ob_type = PyArray_Descr*;
+        int _complex32_num = PyArray_RegisterDataType(&_complex32_dtype);
+        return _complex32_num;
+    }
+    '''
+
+    #ctypedef struct _complex32:
+    #    pass
+    #ctypedef struct _complex32_obj:
+    #    pass
+    cpython.PyTypeObject _complex32_type
+    #PyArray_ArrFuncs _complex32_arrfuncs
+    PyArray_Descr _complex32_dtype
+    int register_dtype()
+
+
+#import_ufunc()
+
+#    struct _complex32_obj:
+#        pass
+#
+#    cpython.PyTypeObject _complex32_type
+#
+#
+#cdef class _complex32(dtype):
+#
+#    def __cinit__(self):
+#        self.typeobj = <cpython.PyTypeObject*>(&_complex32_type)
+#        self.kind = b'c'
+#        self.type = b'E'  # lowercase for fp16
+#        self.byteorder = b'='  # native order
+#        self.itemsize = 4
+#        self.subarray = NULL
+#        self.names = (b'real', b'imag')
+
+complex32_num = None
+complex32 = None  #_complex32_type
+
+
+def init():
+    global complex32, complex32_num
+
+    print("before registering...", flush=True)
+    cdef int _complex32_num = register_dtype()
+    print("after registering...", flush=True)
+    complex32_num = _complex32_num
+    print(_complex32_num)
+    complex32 = PyArray_DescrFromType(_complex32_num)

--- a/test_dtype.pyx
+++ b/test_dtype.pyx
@@ -39,9 +39,25 @@ cdef extern from *:
         return (PyObject*)p;
     }
     
-    //static PyObject* _complex32_obj_new(PyTypeObject* type, PyObject* args, PyObject* kwds) {
-    //    _complex32 c = { 0 };
-    //    return PyComplex32_FromComplex32(c);
+    static PyObject* _complex32_obj_new(PyTypeObject* type, PyObject* args, PyObject* kwds) {
+        _complex32_obj* self;
+        self = (_complex32_obj*)type->tp_alloc(type, 0);
+        if (self != NULL) {
+            self->obval.real = 0.;
+            self->obval.imag = 0.;
+        }
+        return (PyObject*)self;
+    }
+
+    static void _complex32_obj_dealloc(_complex32_obj* self) {
+        Py_TYPE(self)->tp_free((PyObject*)self);
+    }
+
+    //static int _complex32_obj_init(_complex32_obj* self, PyObject* args, PyObject* kwds) {
+    //    if (PyList_Type.tp_init((PyObject *) self, args, kwds) < 0)
+    //        return -1;
+    //    self->state = 0;
+    //    return 0;
     //}
 
     static PyTypeObject _complex32_type = {
@@ -50,7 +66,8 @@ cdef extern from *:
         .tp_basicsize = sizeof(_complex32_obj),
         .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
         .tp_doc = "a complex number consisting of two float16",
-        .tp_new = PyType_GenericNew,  //_complex32_obj_new,
+        .tp_new = _complex32_obj_new, // PyType_GenericNew,
+        .tp_dealloc = (destructor)_complex32_obj_dealloc,
     };
 
     static PyObject* complex32_getitem(void* data, void* arr) {
@@ -175,12 +192,12 @@ def init():
     print(complex32.__doc__)
     #print(_complex32_num)
     #d = PyArray_DescrFromType(_complex32_num)
-    ##print(type(d), flush=True)
+    #print(type(d), flush=True)
     #import numpy
     #print("before numpy dtype")
     #x = numpy.dtype(complex32)
     #print(x)
-    #print(<intptr_t>PyArray_DescrFromType(_complex32_num))
+    #print(type(PyArray_DescrFromType(_complex32_num)))  # <--- <NULL> ?!
     #print(complex32)
 
     global complex32_dtype

--- a/test_dtype.pyx
+++ b/test_dtype.pyx
@@ -157,6 +157,8 @@ cdef extern from *:
         _complex32_arrfuncs.copyswap = complex32_copyswap;
         _complex32_arrfuncs.nonzero = complex32_nonzero;
 
+        // Py_SET_TYPE(&_complex32_dtype, &PyArrayDescr_Type);  // Python 3.9+ ...
+        ((PyObject*)(&_complex32_dtype)) -> ob_type = &PyArrayDescr_Type;
         int _complex32_num = PyArray_RegisterDataType(&_complex32_dtype);
         printf("got type num, get a new one...\\n");
         PyArray_Descr* c_dtype = PyArray_DescrNewFromType(_complex32_num);

--- a/test_dtype.pyx
+++ b/test_dtype.pyx
@@ -224,8 +224,16 @@ def init():
     #print(type(PyArray_DescrFromType(_complex32_num)))  # <--- <NULL> ?!
     #print(complex32)
 
-    global complex32_dtype
+    global complex32_dtype, complex32_dtype2
     complex32_dtype = PyArray_DescrNewFromType(_complex32_num)
+    complex32_dtype2 = PyArray_DescrFromType(_complex32_num)
+
+    # make numpy.dtype() recognize the aliases
+    import numpy
+    numpy.typeDict['c4'] = complex32
+    numpy.typeDict['chalf'] = complex32
+    numpy.typeDict['complex32'] = complex32
+    numpy.typeDict['E'] = complex32
 
 
 #cdef class Complex32(PyComplexFloatingArrType_Type):

--- a/test_dtype2.py
+++ b/test_dtype2.py
@@ -3,12 +3,15 @@ import test_dtype
 
 
 test_dtype.init()
-# a = np.empty(10, dtype=test_dtype.complex32)  # this would segfault...
-# np.dtype(test_dtype.complex32)  # this segfaults too...
-a = np.empty(10, dtype=test_dtype.complex32_dtype)
+a = np.empty(10, dtype=test_dtype.complex32)
+x = np.dtype(test_dtype.complex32)
+y = a[0]
+print(type(y))
+print(y)
 print(a.dtype)
 print(a.size)
 print(a.shape)
 print(a.ndim)
-a[0] = 3
+# a[0] = 3
+#a * 3
 print(a)

--- a/test_dtype2.py
+++ b/test_dtype2.py
@@ -1,0 +1,14 @@
+import numpy as np
+import test_dtype
+
+
+test_dtype.init()
+# a = np.empty(10, dtype=test_dtype.complex32)  # this would segfault...
+# np.dtype(test_dtype.complex32)  # this segfaults too...
+a = np.empty(10, dtype=test_dtype.complex32_dtype)
+print(a.dtype)
+print(a.size)
+print(a.shape)
+print(a.ndim)
+a[0] = 3
+print(a)


### PR DESCRIPTION
First step toward #3370. Related to #4407. **DECISION NEEDED BEFORE ANY CODE REVIEW**

This is a working prototype to demonstrate that we can define a new Python type (`cupy.complex32`) and the associated NumPy dtype (`np.dtype(cupy.complex32)`) so that this type object can be used to hint that the input array consists of half-precision complex numbers, to be used internally wherever its siblings `cupy.complex64` and `cupy.complex128` are applicable. The subsequent GPU operations is out of scope in this PR and will be addressed when this is merged.

Currently it works for:
- Type identification
- Correct inheritance (ex: `cupy.complex32` inherits from `numpy.complexfloating`, same as other complex types)
- Correct itemsize (4 bytes) for the purpose of array allocation and indexing
- Correct type kind (`'c'` for complex) 
- Meaningful type character (uppercase `'E'` for 2 float16 as complex, as oppose to lowercase `'e'` for 1 float16 as real)
- 4-byte alignment
- Very limited functionalities (see below)

***Critical decision to make before moving on***: I incline to consider it acceptable that it has very limited functionality when used as a dtype. In particular, I do not wish to support all kinds of CPU ufuncs or array funcs (as defined in [this section](https://numpy.org/doc/1.19/reference/c-api/types-and-structures.html#c.PyArray_ArrFuncs)) when manipulated as a NumPy complex32 array, because it would then be more suitable for a PR to NumPy, not to CuPy, and as far as I know NumPy folks do not want to add more new built-in types (numpy/numpy#14753), nor do I have the bandwidth to do so. I think having this type object defined is already enough for GPU needs. If it's acceptable then I will work on polishing this. 