### PR TITLE
cupy.random.normal: fix broadcasting of scale and loc arguments

### DIFF
--- a/cupy/random/_distributions.py
+++ b/cupy/random/_distributions.py
@@ -518,6 +518,9 @@ def normal(loc=0.0, scale=1.0, size=None, dtype=float):
 
     """
     rs = _generator.get_random_state()
+    if size is None and any(isinstance(arg, cupy.ndarray)
+                            for arg in [scale, loc]):
+        size = cupy.broadcast_arrays(loc, scale)[0].shape
     x = rs.normal(0, 1, size, dtype)
     cupy.multiply(x, scale, out=x)
     cupy.add(x, loc, out=x)

--- a/tests/cupy_tests/random_tests/test_distributions.py
+++ b/tests/cupy_tests/random_tests/test_distributions.py
@@ -457,7 +457,7 @@ class TestDistributionsNoncentralF(RandomDistributionsTestCase):
 
 
 @testing.parameterize(*testing.product({
-    'shape': [(4, 3, 2), (3, 2)],
+    'shape': [(4, 3, 2), (3, 2), None],
     'loc_shape': [(), (3, 2)],
     'scale_shape': [(), (3, 2)],
 })


### PR DESCRIPTION
Currently `cupy.random.normal` does not work with array arguments for `scale` or `loc` unless `size` is also specified. This contradicts with the behavior of NumPy.

This PR broadcasts the scale and loc arguments to determine size.

The following examples now work without requiring the user to provide the size:

```Python
cupy.random.normal(cp.arange(8), 5)
cupy.random.normal(5, cp.arange(8))
cupy.random.normal(cp.arange(8)[:, cp.newaxis], cp.arange(8)[cp.newaxis, :])
```
Prior to this PR, all of the above would fail with: `ValueError: Out shape is mismatched`

There may be other distributions that also need a similar fix, but this is the one I encountered in an application.