### PR TITLE
Fix overwritten issue in `cumsum` and `cumprod`

### DIFF
--- a/cupy/core/_routines_math.pyx
+++ b/cupy/core/_routines_math.pyx
@@ -739,7 +739,7 @@ cpdef scan_core(ndarray a, axis, scan_op op, dtype=None, ndarray out=None):
                 scan(result, op, dtype=dtype, out=result)
     else:
         if result is None:
-            result = a.astype(dtype, copy=False, order='C',
+            result = a.astype(dtype, copy=True, order='C',
                               casting=None, subok=None)
         axis = internal._normalize_axis_index(axis, a.ndim)
         result = _proc_as_batch(result, axis, dtype, op)

--- a/cupy/core/_routines_math.pyx
+++ b/cupy/core/_routines_math.pyx
@@ -715,15 +715,13 @@ cpdef scan_core(ndarray a, axis, scan_op op, dtype=None, ndarray out=None):
             result = out
             result[...] = a
         else:
-            result = a.astype(out.dtype, copy=True, order='C',
-                              casting=None, subok=None)
+            result = a.astype(out.dtype, order='C')
 
     if axis is None:
         for accelerator in _accelerator._routine_accelerators:
             if accelerator == _accelerator.ACCELERATOR_CUB:
                 if result is None:
-                    result = a.astype(dtype, copy=False, order='C',
-                                      casting=None, subok=None).ravel()
+                    result = a.astype(dtype, order='C').ravel()
                 # result will be None if the scan is not compatible with CUB
                 if op == scan_op.SCAN_SUM:
                     cub_op = cub.CUPY_CUB_CUMSUM
@@ -739,8 +737,7 @@ cpdef scan_core(ndarray a, axis, scan_op op, dtype=None, ndarray out=None):
                 scan(result, op, dtype=dtype, out=result)
     else:
         if result is None:
-            result = a.astype(dtype, copy=True, order='C',
-                              casting=None, subok=None)
+            result = a.astype(dtype, order='C')
         axis = internal._normalize_axis_index(axis, a.ndim)
         result = _proc_as_batch(result, axis, dtype, op)
     # This is for when the original out param was not contiguous

--- a/tests/cupy_tests/math_tests/test_sumprod.py
+++ b/tests/cupy_tests/math_tests/test_sumprod.py
@@ -560,18 +560,24 @@ axes = [0, 1, 2]
 @testing.gpu
 class TestCumsum(unittest.TestCase):
 
+    def _cumsum(self, xp, a, *args, **kwargs):
+        b = a.copy()
+        res = xp.cumsum(a, *args, **kwargs)
+        testing.assert_array_equal(a, b)  # Check if input array is overwritten
+        return res
+
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_cumsum(self, xp, dtype):
         a = testing.shaped_arange((5,), xp, dtype)
-        return xp.cumsum(a)
+        return self._cumsum(xp, a)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_cumsum_out(self, xp, dtype):
         a = testing.shaped_arange((5,), xp, dtype)
         out = xp.zeros((5,), dtype=dtype)
-        xp.cumsum(a, out=out)
+        self._cumsum(xp, a, out=out)
         return out
 
     @testing.for_all_dtypes()
@@ -579,21 +585,21 @@ class TestCumsum(unittest.TestCase):
     def test_cumsum_out_noncontiguous(self, xp, dtype):
         a = testing.shaped_arange((5,), xp, dtype)
         out = xp.zeros((10,), dtype=dtype)[::2]  # Non contiguous view
-        xp.cumsum(a, out=out)
+        self._cumsum(xp, a, out=out)
         return out
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_cumsum_2dim(self, xp, dtype):
         a = testing.shaped_arange((4, 5), xp, dtype)
-        return xp.cumsum(a)
+        return self._cumsum(xp, a)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(contiguous_check=False)
     def test_cumsum_axis(self, xp, dtype):
         n = len(axes)
         a = testing.shaped_arange(tuple(range(4, 4 + n)), xp, dtype)
-        return xp.cumsum(a, axis=self.axis)
+        return self._cumsum(xp, a, axis=self.axis)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
@@ -602,7 +608,7 @@ class TestCumsum(unittest.TestCase):
         shape = tuple(range(4, 4 + n))
         a = testing.shaped_arange(shape, xp, dtype)
         out = xp.zeros(shape, dtype=dtype)
-        xp.cumsum(a, axis=self.axis, out=out)
+        self._cumsum(xp, a, axis=self.axis, out=out)
         return out
 
     @testing.for_all_dtypes()
@@ -612,7 +618,7 @@ class TestCumsum(unittest.TestCase):
         shape = tuple(range(4, 4 + n))
         a = testing.shaped_arange(shape, xp, dtype)
         out = xp.zeros((8,)+shape[1:], dtype=dtype)[::2]  # Non contiguous view
-        xp.cumsum(a, axis=self.axis, out=out)
+        self._cumsum(xp, a, axis=self.axis, out=out)
         return out
 
     @testing.for_all_dtypes()
@@ -627,7 +633,7 @@ class TestCumsum(unittest.TestCase):
     def test_cumsum_axis_empty(self, xp, dtype):
         n = len(axes)
         a = testing.shaped_arange(tuple(range(0, n)), xp, dtype)
-        return xp.cumsum(a, axis=self.axis)
+        return self._cumsum(xp, a, axis=self.axis)
 
     @testing.for_all_dtypes()
     def test_invalid_axis_lower1(self, dtype):
@@ -669,18 +675,24 @@ class TestCumsum(unittest.TestCase):
 @testing.gpu
 class TestCumprod(unittest.TestCase):
 
+    def _cumprod(self, xp, a, *args, **kwargs):
+        b = a.copy()
+        res = xp.cumprod(a, *args, **kwargs)
+        testing.assert_array_equal(a, b)  # Check if input array is overwritten
+        return res
+
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_cumprod_1dim(self, xp, dtype):
         a = testing.shaped_arange((5,), xp, dtype)
-        return xp.cumprod(a)
+        return self._cumprod(xp, a)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_cumprod_out(self, xp, dtype):
         a = testing.shaped_arange((5,), xp, dtype)
         out = xp.zeros((5,), dtype=dtype)
-        xp.cumprod(a, out=out)
+        self._cumprod(xp, a, out=out)
         return out
 
     @testing.for_all_dtypes()
@@ -688,20 +700,20 @@ class TestCumprod(unittest.TestCase):
     def test_cumprod_out_noncontiguous(self, xp, dtype):
         a = testing.shaped_arange((5,), xp, dtype)
         out = xp.zeros((10,), dtype=dtype)[::2]  # Non contiguous view
-        xp.cumprod(a, out=out)
+        self._cumprod(xp, a, out=out)
         return out
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(rtol=1e-6)
     def test_cumprod_2dim_without_axis(self, xp, dtype):
         a = testing.shaped_arange((4, 5), xp, dtype)
-        return xp.cumprod(a)
+        return self._cumprod(xp, a)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_cumprod_2dim_with_axis(self, xp, dtype):
         a = testing.shaped_arange((4, 5), xp, dtype)
-        return xp.cumprod(a, axis=1)
+        return self._cumprod(xp, a, axis=1)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()


### PR DESCRIPTION
Closes https://github.com/cupy/cupy/issues/4456.

This PR fixes the issue of input arrays being overwritten when `axis` is specified in `cumsum` and `cumprod`. This issue was caused by the code change in https://github.com/cupy/cupy/pull/4316 as @grlee77 and @leofang pointed out.