### PR TITLE
Skip large size test for hip

### DIFF
--- a/tests/cupy_tests/core_tests/test_carray.py
+++ b/tests/cupy_tests/core_tests/test_carray.py
@@ -67,6 +67,8 @@ class TestCArray32BitBoundary(unittest.TestCase):
         # Free huge memory for slow test
         cupy.get_default_memory_pool().free_all_blocks()
 
+    # HIP is known to fail with sizes > 2**32-1024
+    @unittest.skipIf(cupy.cuda.runtime.is_hip, 'HIP does not support this')
     def test(self):
         # Elementwise
         a = cupy.full((1, self.size), 7, dtype=cupy.int8)


### PR DESCRIPTION
There is a bug in HIP/Rocm in which grids with total size of 2**32 do not launch threads at all.

This can be reproduced with 

```python

import cupy as cp


size = 2**32

add_kernel = cp.RawKernel(r'''
extern "C" __global__
void my_add(char* y) {
    unsigned long long block_dim = blockDim.x;
    unsigned long long block_idx = blockIdx.x;
    unsigned long long tid = block_dim * block_idx + threadIdx.x;
    y[tid] = 24;
}
''', 'my_add')

y = cp.empty(size, dtype=cp.int8)
add_kernel((size//256,), (256,), (y,))  # grid, block and arguments
cp.cuda.stream.get_current_stream().synchronize()
print(y)
```

I also created a C reproducer to report this to AMD folks.

```c
#include <hip/hip_runtime.h>
#include <stdio.h>
#include <stdlib.h>
#include <iostream>

using namespace std;

__global__ void helloworld(char* out)
{
	uint64_t bdim = hipBlockDim_x;
	uint64_t bidx = hipBlockIdx_x;
	uint64_t bsize = bdim * bidx;
        uint64_t num = hipThreadIdx_x + bsize;
	out[num] = 23;
}

int main(int argc, char* argv[])
{

    //uint64_t size = 4294967296 - 1024; // 2^32 - WORKS
    uint64_t size = 4294967296; // 2^32 - FAILS, No elements sets at all between 2^32 and 2^32 + 1023
    // uint64_t size = 4294967296 + 1024; // 2^32 +1024 - FAILS, Only sets the first 1024 elements.
    char* output = new char[size];
    char* outputBuffer;
    hipMalloc((void**)&outputBuffer, (size) * sizeof(char));
    hipLaunchKernelGGL(helloworld,
    size/256,
    256,
    0, 0,
    outputBuffer);
    hipMemcpy(output, outputBuffer, (size) * sizeof(char), hipMemcpyDeviceToHost);
    hipMemcpy(output, outputBuffer, (size) * sizeof(char), hipMemcpyDeviceToHost);
    cout << (int)output[0]<<"  "<<(int)output[size-1] << endl;
    hipFree(outputBuffer);
    delete[] output;
    return 0;
}
