### PR TITLE
Update to use the new CArray and CIndexer constructors

### DIFF
--- a/cupyx/scipy/ndimage/_filters_generic.py
+++ b/cupyx/scipy/ndimage/_filters_generic.py
@@ -61,6 +61,7 @@ def _get_generic_filter_red(rk, in_dtype, out_dtype, filter_size, mode,
         mode, wshape, int_type, offsets, cval, preamble=sub_kernel,
         options=getattr(rk, 'options', ()))
 
+
 def _reduction_kernel_code(rk, filter_size, out_dtype, in_dtype):
     # NOTE: differences from the code generated for real reduction kernels:
     #  * input is always 1D and always less than 2^31 elements

--- a/cupyx/scipy/ndimage/_filters_generic.py
+++ b/cupyx/scipy/ndimage/_filters_generic.py
@@ -43,10 +43,11 @@ def _get_generic_filter_red(rk, in_dtype, out_dtype, filter_size, mode,
     # Get code chunks
     setup = '''
     int iv = 0;
-    X values[{}];
-    {} val_out;'''.format(filter_size, out_ctype)
-    setup += (_carray_ctor('sub_in', 'X', 'values', (filter_size,)) + '\n' +
-              _carray_ctor('sub_out', out_ctype, '&val_out', (1,)))
+    X values[{size}];
+    CArray<X, 1, true, true> sub_in(values, {{{size}}});
+    {out_ctype} val_out;
+    CArray<{out_ctype}, 1, true, true> sub_out(&val_out, {{1}});
+    '''.format(size=filter_size, out_ctype=out_ctype)
 
     sub_call = '''reduction_kernel::{}(sub_in, sub_out);
     y = cast<Y>(val_out);'''.format(rk.name)
@@ -59,7 +60,6 @@ def _get_generic_filter_red(rk, in_dtype, out_dtype, filter_size, mode,
         setup, 'values[iv++] = {value};', sub_call,
         mode, wshape, int_type, offsets, cval, preamble=sub_kernel,
         options=getattr(rk, 'options', ()))
-
 
 def _reduction_kernel_code(rk, filter_size, out_dtype, in_dtype):
     # NOTE: differences from the code generated for real reduction kernels:
@@ -85,8 +85,8 @@ __device__
 void {name}({in_const} CArray<{in_ctype}, 1, true, true>& _raw_{in_name},
             CArray<{out_ctype}, 1, true, true>& _raw_{out_name}) {{
     // these are just provided so if they are available for the RK
-    {in_ind}
-    {out_ind}
+    CIndexer<1> _in_ind({{{size}}});
+    CIndexer<0> _out_ind;
 
     #define REDUCE(a, b) ({reduce_expr})
     #define POST_MAP(a) ({post_map_expr})
@@ -108,9 +108,7 @@ void {name}({in_const} CArray<{in_ctype}, 1, true, true>& _raw_{in_name},
         name=rk.name, type_preamble=types, preamble=rk.preamble,
         in_const='const' if in_param.is_const else '',
         in_ctype=in_ctype, in_name=in_param.name,
-        in_ind=_cindexer_ctor('_in_ind', (filter_size,)),
         out_ctype=out_ctype, out_name=out_param.name,
-        out_ind=_cindexer_ctor('_out_ind', ()),
 
         pre_map_expr=rk.map_expr,
         identity='' if rk.identity is None else rk.identity,
@@ -118,57 +116,6 @@ void {name}({in_const} CArray<{in_ctype}, 1, true, true>& _raw_{in_name},
         reduce_type=rk.reduce_type, reduce_expr=rk.reduce_expr,
         post_map_expr=rk.post_map_expr,
     )
-
-
-# No C++ constructor for CIndexer and CArray so we must manually set the fields
-def _cindexer_ctor(name, shape):
-    if len(shape) == 0:
-        return ('CIndexer<0> {name}; '
-                '((ptrdiff_t*)&{name})[0] = 1;').format(name=name)
-    return ('CIndexer<{ndim}> {name}; {{ '
-            'ptrdiff_t* _raw = (ptrdiff_t*)&{name}; '
-            '_raw[0] = {size}; {shape} }}').format(
-        name=name, ndim=len(shape), size=cupy.core.internal.prod(shape),
-        shape=_assign_array(shape, 1))
-
-
-def _carray_ctor(name, ctype, ptr, shape, strides=None, c_contig=None):
-    # TODO: assuming sizeof(T*) == sizeof(ptrdiff_t)
-    if len(shape) == 0:
-        return ('CArray<{ctype}, 0, true, true> {name}; '
-                '(({ctype}**)&{name})[0] = {ptr}; '
-                '((ptrdiff_t*)&{name})[1] = 1;'
-                ).format(name=name, ctype=ctype, ptr=ptr)
-    if c_contig is None:
-        c_contig = strides is None
-    c_contig = 'true' if c_contig else 'false'
-
-    if strides is None:
-        strides = _contig_strides(shape, 'sizeof({})'.format(ctype))
-
-    return ('CArray<{ctype}, 1, {c_contig}, true> {name}; {{ '
-            'ptrdiff_t* _raw = (ptrdiff_t*)&{name}; '
-            '(({ctype}**)_raw)[0] = {ptr}; '
-            '_raw[1] = {size}; {shape} {strides} }}'
-            ).format(name=name, ctype=ctype, ptr=ptr,
-                     size=cupy.core.internal.prod(shape),
-                     c_contig=c_contig, shape=_assign_array(shape, 2),
-                     strides=_assign_array(strides, 2+len(shape)))
-
-
-def _contig_strides(shape, itemsize):
-    strides = []
-    prod = 1
-    for x in shape[::-1]:
-        strides.append(prod*itemsize if isinstance(itemsize, int) else
-                       '{}*{}'.format(prod, itemsize))
-        prod *= x
-    return tuple(strides[::-1])
-
-
-def _assign_array(array, offset):
-    return ' '.join('_raw[{}] = {};'.format(i, x)
-                    for i, x in enumerate(array, offset))
 
 
 def _get_type_info(param, dtype, types):


### PR DESCRIPTION
This updates the ndimage scipy generic filters to use the new `CArray` and `CIndexer` constructors instead of manipulating their memory which was quite hackish.