### PR TITLE
Implementing cupyx.scipy.signal.oaconvolve

### DIFF
--- a/cupy/core/internal.pyx
+++ b/cupy/core/internal.pyx
@@ -6,7 +6,6 @@ from libcpp cimport bool as cpp_bool
 from libc.stdint cimport uint32_t
 
 import sys
-import collections.abc
 
 import numpy
 
@@ -421,7 +420,7 @@ cpdef tuple _normalize_axis_indices(
     """
     if axes is None:
         axes = tuple(range(ndim))
-    elif not isinstance(axes, collections.abc.Iterable):
+    elif not isinstance(axes, tuple):
         axes = axes,
 
     res = []

--- a/cupy/core/internal.pyx
+++ b/cupy/core/internal.pyx
@@ -6,6 +6,7 @@ from libcpp cimport bool as cpp_bool
 from libc.stdint cimport uint32_t
 
 import sys
+import collections.abc
 
 import numpy
 
@@ -420,7 +421,7 @@ cpdef tuple _normalize_axis_indices(
     """
     if axes is None:
         axes = tuple(range(ndim))
-    elif not isinstance(axes, tuple):
+    elif not isinstance(axes, collections.abc.Iterable):
         axes = axes,
 
     res = []

--- a/cupyx/scipy/signal/__init__.py
+++ b/cupyx/scipy/signal/__init__.py
@@ -2,6 +2,7 @@ from cupyx.scipy.signal.signaltools import convolve  # NOQA
 from cupyx.scipy.signal.signaltools import correlate  # NOQA
 from cupyx.scipy.signal.signaltools import fftconvolve  # NOQA
 from cupyx.scipy.signal.signaltools import choose_conv_method  # NOQA
+from cupyx.scipy.signal.signaltools import oaconvolve  # NOQA
 from cupyx.scipy.signal.signaltools import convolve2d  # NOQA
 from cupyx.scipy.signal.signaltools import correlate2d  # NOQA
 from cupyx.scipy.signal.signaltools import wiener  # NOQA

--- a/cupyx/scipy/signal/_signaltools_core.py
+++ b/cupyx/scipy/signal/_signaltools_core.py
@@ -163,7 +163,7 @@ def _apply_conv_mode(full, s1, s2, mode, axes):
     return cupy.ascontiguousarray(full[slices])
 
 
-__EXP_N1 = 0.36787944117144232159553 # exp(-1)
+__EXP_N1 = 0.36787944117144232159553  # exp(-1)
 
 
 def _optimal_oa_block_size(overlap):
@@ -173,7 +173,7 @@ def _optimal_oa_block_size(overlap):
     Computed as ``ceil(-overlap*W(-1/(2*e*overlap)))`` where ``W(z)`` is the
     Lambert W function solved as per ``scipy.special.lambertw(z, -1)`` with a
     fixed 4 iterations.
-    
+
     Returned size should still be given to ``cupyx.scipy.fft.next_fast_len()``.
     """
 
@@ -189,8 +189,8 @@ def _optimal_oa_block_size(overlap):
     #      cdef int i
 
     # Compute W(-1/(2*e*overlap))
-    z = -__EXP_N1/(2*overlap) # value to compute for
-    w = -1 - math.log(2*overlap) # initial guess
+    z = -__EXP_N1/(2*overlap)  # value to compute for
+    w = -1 - math.log(2*overlap)  # initial guess
     for i in range(4):
         ew = math.exp(w)
         wew = w*ew

--- a/cupyx/scipy/signal/_signaltools_core.py
+++ b/cupyx/scipy/signal/_signaltools_core.py
@@ -92,7 +92,7 @@ def _inputs_swap_needed(mode, shape1, shape2, axes=None):
     if mode != 'valid' or not shape1:
         return False
     if axes is None:
-        axes = range(len(shape1))
+        axes = tuple(range(len(shape1)))
     not_ok1 = any(shape1[i] < shape2[i] for i in axes)
     not_ok2 = any(shape1[i] > shape2[i] for i in axes)
     if not_ok1 and not_ok2:
@@ -121,15 +121,12 @@ def _init_freq_conv_axes(in1, in2, mode, axes, sorted_axes=False):
         # Convolution is commutative
         in1, in2 = in2, in1
 
-    return in1, in2, axes
+    return in1, in2, tuple(axes)
 
 
 def _init_nd_and_axes(x, axes):
     # See documentation in scipy.fft._helper._init_nd_shape_and_axes
     # except shape argument is always None and doesn't return new shape
-    #if axes is not None and not isinstance(axes, tuple):
-    #    try: axes = tuple(axes)
-    #    except TypeError: pass
     axes = internal._normalize_axis_indices(axes, x.ndim, sort_axes=False)
     if not len(axes):
         raise ValueError('when provided, axes cannot be empty')

--- a/cupyx/scipy/signal/signaltools.py
+++ b/cupyx/scipy/signal/signaltools.py
@@ -220,7 +220,7 @@ def oaconvolve(in1, in2, mode="full", axes=None):
         in2 (cupy.ndarray): Second input. Should have the same number of
             dimensions as ``in1``.
         mode (str): Indicates the size of the output:
-            
+
             - ``'full'``: output is the full discrete linear \
                           cross-correlation (default)
             - ``'valid'``: output consists only of those elements that do \

--- a/cupyx/scipy/signal/signaltools.py
+++ b/cupyx/scipy/signal/signaltools.py
@@ -258,7 +258,6 @@ def oaconvolve(in1, in2, mode="full", axes=None):
 
     # Fall back to fftconvolve if there is only one block in every dimension
     if in1_step == s1 and in2_step == s2:
-        print(axes)
         return fftconvolve(in1, in2, mode=mode, axes=axes)
 
     # Pad and reshape the inputs for overlapping and adding

--- a/cupyx/scipy/signal/signaltools.py
+++ b/cupyx/scipy/signal/signaltools.py
@@ -1,6 +1,7 @@
 import warnings
 
 import cupy
+from cupy.core import internal
 
 from cupyx.scipy.ndimage import _util
 from cupyx.scipy.ndimage import filters
@@ -199,6 +200,106 @@ def choose_conv_method(in1, in2, mode='full'):
 
     """
     return cupy._math.misc._choose_conv_method(in1, in2, mode)
+
+
+def oaconvolve(in1, in2, mode="full", axes=None):
+    """Convolve two N-dimensional arrays using the overlap-add method.
+
+    Convolve ``in1`` and ``in2`` using the overlap-add method, with the output
+    size determined by the ``mode`` argument. This is generally faster than
+    ``convolve`` for large arrays, and generally faster than ``fftconvolve``
+    when one array is much larger than the other, but can be slower when only a
+    few output values are needed or when the arrays are very similar in shape,
+    and can only output float arrays (int or object array inputs will be cast
+    to float).
+
+    Args:
+        in1 (cupy.ndarray): First input.
+        in2 (cupy.ndarray): Second input. Should have the same number of
+            dimensions as ``in1``.
+        mode (str): Indicates the size of the output:
+            ``'full'``: output is the full discrete linear cross-correlation
+                        (default)
+            ``'valid'``: output consists only of those elements that do not
+                         rely on the zero-padding. Either ``in1`` or ``in2``
+                         must be at least as large as the other in every
+                         dimension.
+            ``'same'``: output is the same size as ``in1``, centered
+                        with respect to the ``'full'`` output
+        axes (scalar or tuple of scalar or None): Axes over which to compute
+            the convolution. The default is over all axes.
+
+    Returns:
+        cupy.ndarray: the result of convolution
+
+    .. seealso:: :func:`cupyx.scipy.signal.convolve`
+    .. seealso:: :func:`cupyx.scipy.signal.fftconvolve`
+    .. seealso:: :func:`cupyx.scipy.ndimage.convolve`
+    .. seealso:: :func:`scipy.signal.oaconvolve`
+    """
+    out = _st_core._check_conv_inputs(in1, in2, mode)
+    if out is not None:
+        return out
+    if in1.shape == in2.shape:  # Equivalent to fftconvolve
+        return fftconvolve(in1, in2, mode=mode, axes=axes)
+
+    in1, in2, axes = _st_core._init_freq_conv_axes(in1, in2, mode, axes,
+                                                   sorted_axes=True)
+    s1, s2 = in1.shape, in2.shape
+    if not axes:
+        return _st_core._apply_conv_mode(in1*in2, s1, s2, mode, axes)
+
+    # Calculate the block sizes for the output, steps, first and second inputs.
+    # It is simpler to calculate them all together than doing them in separate
+    # loops due to all the special cases that need to be handled.
+    optimal_sizes = (_st_core._calc_oa_lens(s1[i], s2[i]) if i in axes else
+                     (-1, -1, s1[i], s2[i]) for i in range(in1.ndim))
+    block_size, overlaps, in1_step, in2_step = zip(*optimal_sizes)
+
+    # Fall back to fftconvolve if there is only one block in every dimension
+    if in1_step == s1 and in2_step == s2:
+        print(axes)
+        return fftconvolve(in1, in2, mode=mode, axes=axes)
+
+    # Pad and reshape the inputs for overlapping and adding
+    shape_final = [s1[i]+s2[i]-1 if i in axes else None
+                   for i in range(in1.ndim)]
+    in1, in2 = _st_core._oa_reshape_inputs(in1, in2, axes, shape_final,
+                                           block_size, overlaps,
+                                           in1_step, in2_step)
+
+    # Reshape the overlap-add parts to input block sizes
+    split_axes = [iax+i for i, iax in enumerate(axes)]
+    fft_axes = [iax+1 for iax in split_axes]
+
+    # Do the convolution
+    fft_shape = [block_size[i] for i in axes]
+    ret = _st_core._freq_domain_conv(in1, in2, fft_axes, fft_shape,
+                                     calc_fast_len=False)
+
+    # Do the overlap-add
+    for ax, ax_fft, ax_split in zip(axes, fft_axes, split_axes):
+        overlap = overlaps[ax]
+        if overlap is None:
+            continue
+
+        ret, overpart = cupy.split(ret, [-overlap], ax_fft)
+        overpart = cupy.split(overpart, [-1], ax_split)[0]
+
+        ret_overpart = cupy.split(ret, [overlap], ax_fft)[0]
+        ret_overpart = cupy.split(ret_overpart, [1], ax_split)[1]
+        ret_overpart += overpart
+
+    # Reshape back to the correct dimensionality
+    shape_ret = [ret.shape[i] if i not in fft_axes else
+                 ret.shape[i]*ret.shape[i-1]
+                 for i in range(ret.ndim) if i not in split_axes]
+    ret = ret.reshape(*shape_ret)
+
+    # Slice to the correct size
+    ret = ret[tuple([slice(islice) for islice in shape_final])]
+
+    return _st_core._apply_conv_mode(ret, s1, s2, mode, axes)
 
 
 def convolve2d(in1, in2, mode='full', boundary='fill', fillvalue=0):
@@ -420,7 +521,7 @@ def medfilt(volume, kernel_size=None):
         warnings.warn('kernel_size exceeds volume extent: '
                       'volume will be zero-padded')
 
-    size = cupy.core.internal.prod(kernel_size)
+    size = internal.prod(kernel_size)
     return filters.rank_filter(volume, size // 2, size=kernel_size,
                                output=float, mode='constant')
 

--- a/cupyx/scipy/signal/signaltools.py
+++ b/cupyx/scipy/signal/signaltools.py
@@ -229,6 +229,7 @@ def oaconvolve(in1, in2, mode="full", axes=None):
                            every dimension.
             - ``'same'``: output is the same size as ``in1``, centered \
                           with respect to the ``'full'`` output
+
         axes (scalar or tuple of scalar or None): Axes over which to compute
             the convolution. The default is over all axes.
 

--- a/cupyx/scipy/signal/signaltools.py
+++ b/cupyx/scipy/signal/signaltools.py
@@ -148,14 +148,16 @@ def fftconvolve(in1, in2, mode='full', axes=None):
         in2 (cupy.ndarray): Second input. Should have the same number of
             dimensions as ``in1``.
         mode (str): Indicates the size of the output:
-            ``'full'``: output is the full discrete linear cross-correlation
-                        (default)
-            ``'valid'``: output consists only of those elements that do not
-                         rely on the zero-padding. Either ``in1`` or ``in2``
-                         must be at least as large as the other in every
-                         dimension.
-            ``'same'``: output is the same size as ``in1``, centered
-                        with respect to the 'full' output
+
+            - ``'full'``: output is the full discrete linear \
+                          cross-correlation (default)
+            - ``'valid'``: output consists only of those elements that do \
+                           not rely on the zero-padding. Either ``in1`` or \
+                           ``in2`` must be at least as large as the other in \
+                           every dimension.
+            - ``'same'``: output is the same size as ``in1``, centered \
+                          with respect to the 'full' output
+
         axes (scalar or tuple of scalar or None): Axes over which to compute
             the convolution. The default is over all axes.
 
@@ -218,14 +220,15 @@ def oaconvolve(in1, in2, mode="full", axes=None):
         in2 (cupy.ndarray): Second input. Should have the same number of
             dimensions as ``in1``.
         mode (str): Indicates the size of the output:
-            ``'full'``: output is the full discrete linear cross-correlation
-                        (default)
-            ``'valid'``: output consists only of those elements that do not
-                         rely on the zero-padding. Either ``in1`` or ``in2``
-                         must be at least as large as the other in every
-                         dimension.
-            ``'same'``: output is the same size as ``in1``, centered
-                        with respect to the ``'full'`` output
+            
+            - ``'full'``: output is the full discrete linear \
+                          cross-correlation (default)
+            - ``'valid'``: output consists only of those elements that do \
+                           not rely on the zero-padding. Either ``in1`` or \
+                           ``in2`` must be at least as large as the other in \
+                           every dimension.
+            - ``'same'``: output is the same size as ``in1``, centered \
+                          with respect to the ``'full'`` output
         axes (scalar or tuple of scalar or None): Axes over which to compute
             the convolution. The default is over all axes.
 

--- a/docs/source/reference/signal.rst
+++ b/docs/source/reference/signal.rst
@@ -15,6 +15,8 @@ Convolution
     cupyx.scipy.signal.convolve2d
     cupyx.scipy.signal.correlate
     cupyx.scipy.signal.correlate2d
+    cupyx.scipy.signal.fftconvolve
+    cupyx.scipy.signal.oaconvolve
 
 
 Filtering


### PR DESCRIPTION
This implements `cupyx.scipy.signal.oaconvolve` which uses the recently merged `cupyx.scipy.signal.fftconvolve` to do most of the work by breaking the larger data into smaller blocks to make the FFTs faster. Nearly all of the other logic comes from scipy with some simplifications.

A custom version of scipy's `special.lambertw` function is provided that only works for the situation needed to determine the block size (called `_optimal_oa_block_size`). This function is only called once per call to `oaconvolve` and takes a 1-2 microseconds in my tests, if necessary this can be moved to Cython which is 10x faster.