### PR TITLE
Exclude unsupported dtypes for TestOrderFilter

### DIFF
--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
@@ -203,7 +203,7 @@ class TestWiener(unittest.TestCase):
 @testing.gpu
 @testing.with_requires('scipy')
 class TestOrderFilter(unittest.TestCase):
-    @testing.for_all_dtypes()
+    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
     @testing.numpy_cupy_allclose(atol=1e-8, rtol=1e-8, scipy_name='scp',
                                  accept_error=ValueError)  # for even kernels
     def test_order_filter(self, xp, scp, dtype):


### PR DESCRIPTION
This fixes the test variation to exclude unsupported dtypes. Errors were hidden by `accept_error=ValueError` option, but should be explicitly excluded.

I found this because the following code cause hard crash on Windows + SciPy 1.5.4.

```
import numpy, scipy.signal
scipy.signal.order_filter(numpy.ones(10, dtype=numpy.float16), numpy.ones(3, dtype=numpy.bool_), 0)
```

On Linux, this raises an exception.