### PR TITLE
[backport] Exclude unsupported dtypes for TestOrderFilter

### DIFF
--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
@@ -192,6 +192,7 @@ class TestWiener(unittest.TestCase):
 @testing.gpu
 @testing.with_requires('scipy')
 class TestOrderFilter(unittest.TestCase):
+    @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp',
                                  accept_error=ValueError)  # for even kernels


### PR DESCRIPTION
Backport of #4477