### PR TITLE
Fix TestEntropy: Requires scipy>=1.4.0 for `axis` parameter

### DIFF
--- a/tests/cupyx_tests/scipy_tests/stats_tests/test_distributions.py
+++ b/tests/cupyx_tests/scipy_tests/stats_tests/test_distributions.py
@@ -94,7 +94,7 @@ class TestEntropyBasic(unittest.TestCase):
     })
 ))
 @testing.gpu
-@testing.with_requires('scipy')
+@testing.with_requires('scipy>=1.4.0')
 class TestEntropy(unittest.TestCase):
 
     def _entropy(self, xp, scp, dtype, shape, use_qk, base, axis, normalize):


### PR DESCRIPTION
cherry-picked 426e6b471273a57deab5c5db9b070b683c3f36fe.