### PR TITLE
Update PyTest

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,8 +38,8 @@ requirements = {
         'pycodestyle==2.5.0',
     ],
     'test': [
-        'pytest<4.2.0',  # 4.2.0 is slow collecting tests and times out on CI.
-        'attrs<19.2.0',  # pytest 4.1.1 does not run with attrs==19.2.0
+        # 4.2 <= pytest < 6.2 is slow collecting tests and times out on CI.
+        'pytest>=6.2',
     ],
     'doctest': [
         'matplotlib',
@@ -55,7 +55,7 @@ requirements = {
     'jenkins': [
         '-r test',
         'pytest-timeout',
-        'pytest-cov<2.10',  # pytest-cov 2.10 requires pytest>=4.6
+        'pytest-cov',
         'coveralls',
         'codecov',
         'coverage<5',  # Otherwise, Python must be built with sqlite


### PR DESCRIPTION
PyTest is no longer slow.

Do not backport this to v8, because PyTest >= 6.2 requires Python >= 3.6.