### PR TITLE
Document `random.uniform` may return high

### DIFF
--- a/cupy/random/_distributions.py
+++ b/cupy/random/_distributions.py
@@ -834,7 +834,8 @@ def uniform(low=0.0, high=1.0, size=None, dtype=float):
     """Returns an array of uniformly-distributed samples over an interval.
 
     Samples are drawn from a uniform distribution over the half-open interval
-    ``[low, high)``.
+    ``[low, high)``. The samples may contain the ``high`` limit due to
+    floating-point rounding.
 
     Args:
         low (float): Lower end of the interval.


### PR DESCRIPTION
Close #4139.