### PR TITLE
Remove experimental warnings from cupyx.scipy.ndimage

### DIFF
--- a/cupyx/scipy/ndimage/_util.py
+++ b/cupyx/scipy/ndimage/_util.py
@@ -1,5 +1,4 @@
 import cupy
-import cupy._util
 
 
 def _is_integer_output(output, input):

--- a/cupyx/scipy/ndimage/_util.py
+++ b/cupyx/scipy/ndimage/_util.py
@@ -46,8 +46,6 @@ def _check_origin(origin, width):
 
 
 def _check_mode(mode):
-    if mode in ['grid-mirror', 'grid-wrap', 'grid-reflect']:
-        cupy._util.experimental(f"mode '{mode}'")
     if mode not in ('reflect', 'constant', 'nearest', 'mirror', 'wrap',
                     'grid-mirror', 'grid-wrap', 'grid-reflect'):
         msg = f'boundary mode not supported (actual: {mode})'

--- a/cupyx/scipy/ndimage/interpolation.py
+++ b/cupyx/scipy/ndimage/interpolation.py
@@ -4,7 +4,6 @@ import warnings
 import cupy
 import numpy
 
-import cupy._util
 from cupy.core import internal
 from cupyx.scipy.ndimage import _util
 from cupyx.scipy.ndimage import _interp_kernels

--- a/cupyx/scipy/ndimage/interpolation.py
+++ b/cupyx/scipy/ndimage/interpolation.py
@@ -21,9 +21,6 @@ def _check_parameter(func_name, order, mode):
     elif order < 0 or 5 < order:
         raise ValueError('spline order is not supported')
 
-    if mode in ['grid-mirror', 'grid-wrap', 'grid-reflect', 'wrap', 'reflect']:
-        cupy._util.experimental(f"mode '{mode}'")
-
     if mode not in ('constant', 'grid-constant', 'nearest', 'mirror',
                     'reflect', 'grid-mirror', 'wrap', 'grid-wrap', 'opencv',
                     '_opencv_edge'):
@@ -695,7 +692,6 @@ def zoom(input, zoom, output=None, order=3, mode='constant', cval=0.0,
         )
     else:
         if grid_mode:
-            cupy._util.experimental("grid_mode=True")
 
             # warn about modes that may have surprising behavior
             suggest_mode = None


### PR DESCRIPTION
These should no longer be needed now that SciPy 1.6.0 [has been released](https://github.com/scipy/scipy/releases/tag/v1.6.0)

[edit by @toslunar] Close #4467.