### PR TITLE
Fix bug on bad interaction between `__cuda_array_interface__` and `__array_ufunc__` on HIP

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -180,7 +180,7 @@ cdef class ndarray:
     @property
     def __cuda_array_interface__(self):
         if runtime._is_hip_environment:
-            raise RuntimeError(
+            raise AttributeError(
                 'HIP/ROCm does not support cuda array interface')
         cdef dict desc = {
             'shape': self.shape,
@@ -1439,11 +1439,12 @@ cdef class ndarray:
                 # implicit host-to-device conversion.
                 # Except for numpy.ndarray, types should be supported by
                 # `_kernel._preprocess_args`.
-                if (
-                        not hasattr(x, '__cuda_array_interface__')
+                check = hasattr(x, '__cuda_array_interface__')
+                if runtime._is_hip_environment and isinstance(x, ndarray):
+                    check = True
+                if (not check
                         and not type(x) in _scalar.scalar_type_set
-                        and not isinstance(x, numpy.ndarray)
-                ):
+                        and not isinstance(x, numpy.ndarray)):
                     return NotImplemented
             if name in [
                     'greater', 'greater_equal', 'less', 'less_equal',

--- a/tests/cupy_tests/core_tests/test_ndarray.py
+++ b/tests/cupy_tests/core_tests/test_ndarray.py
@@ -315,6 +315,22 @@ class TestNdarrayCudaInterfaceStream(unittest.TestCase):
             assert iface['stream'] == 1 if stream.ptr == 0 else stream.ptr
 
 
+@pytest.mark.skipif(not cupy.cuda.runtime.is_hip,
+                    reason='This is supported on CUDA')
+class TestNdarrayCudaInterfaceNoneCUDA(unittest.TestCase):
+
+    def setUp(self):
+        self.arr = cupy.zeros(shape=(2, 3), dtype=cupy.float64)
+
+    def test_cuda_array_interface_hasattr(self):
+        assert not hasattr(self.arr, '__cuda_array_interface__')
+
+    def test_cuda_array_interface_getattr(self):
+        with pytest.raises(AttributeError) as e:
+            getattr(self.arr, '__cuda_array_interface__')
+        assert 'HIP' in str(e.value)
+
+
 @testing.parameterize(
     *testing.product({
         'indices_shape': [(2,), (2, 3)],


### PR DESCRIPTION
Follow-up of #4198, #4458, #4482. **Merge after #4485.**

Close #4515. 

Fix two issues:
1. `hasattr` has side effect, so on HIP `hasattr(a, '__cuda_array_interface__')`  raises `RuntimeError`. This is fixed by simply raising `AttributeError` instead so that `hasattr(a, '__cuda_array_interface__') == False`, which also matches the original intension (#4482).
2. In `__array_ufunc__`, when on HIP instead of testing if the array has `__cuda_array_interface__ ` we test if the participating object is a `cupy.ndarray` since `__cuda_array_interface__` is disabled.