### PR TITLE
Add complex support to `cupyx.scipy.signal` functions

### DIFF
--- a/cupyx/scipy/signal/_signaltools_core.py
+++ b/cupyx/scipy/signal/_signaltools_core.py
@@ -32,7 +32,7 @@ def _direct_correlate(in1, in2, mode='full', output=float, convolution=False,
     if _inputs_swap_needed(mode, in1.shape, in2.shape) or (
             in2.size > in1.size and boundary == 'constant' and fillvalue == 0):
         in1, in2 = in2, in1
-        swapped_inputs = not convolution
+        swapped_inputs = True
 
     # Due to several optimizations, the second array can only be 2 GiB
     if in2.nbytes >= (1 << 31):
@@ -70,21 +70,23 @@ def _direct_correlate(in1, in2, mode='full', output=float, convolution=False,
     int_type = _util._get_inttype(in1)
     kernel = filters._get_correlate_kernel(
         boundary, in2.shape, int_type, offsets, fillvalue)
-    in2 = _reverse_and_conj(in2) if convolution else in2
-    if not swapped_inputs:
+    in2 = _reverse(in2) if convolution else in2.conj()
+    if not swapped_inputs or convolution:
         kernel(in1, in2, output)
     elif output.dtype.kind != 'c':
         # Avoids one array copy
-        kernel(in1, in2, _reverse_and_conj(output))
+        kernel(in1, in2, _reverse(output))
     else:
         kernel(in1, in2, output)
-        output = cupy.ascontiguousarray(_reverse_and_conj(output))
+        output = cupy.ascontiguousarray(_reverse(output))
+        if swapped_inputs and (mode != 'valid' or not shift):
+            cupy.conjugate(output, out=output)
     return output
 
 
-def _reverse_and_conj(x):
-    # Reverse array `x` in all dimensions and perform the complex conjugate
-    return x[(slice(None, None, -1),) * x.ndim].conj()
+def _reverse(x):
+    # Reverse array `x` in all dimensions
+    return x[(slice(None, None, -1),) * x.ndim]
 
 
 def _inputs_swap_needed(mode, shape1, shape2, axes=None):

--- a/cupyx/scipy/signal/bsplines.py
+++ b/cupyx/scipy/signal/bsplines.py
@@ -26,18 +26,14 @@ def sepfir2d(input, hrow, hcol):
         raise ValueError('hrow and hcol must be 1 dimensional and odd length')
     dtype = input.dtype
     if dtype.kind == 'c':
-        # TODO: adding support for complex types requires ndimage filters
-        # to support complex types (which they could easily if not for the
-        # scipy compatibility requirement of forbidding complex and using
-        # float64 intermediates)
-        raise TypeError("complex types not currently supported")
-    if dtype == cupy.float32 or dtype.itemsize <= 2:
+        dtype = cupy.complex64 if dtype == cupy.complex64 else cupy.complex128
+    elif dtype == cupy.float32 or dtype.itemsize <= 2:
         dtype = cupy.float32
     else:
         dtype = cupy.float64
     input = input.astype(dtype, copy=False)
     hrow = hrow.astype(dtype, copy=False)
     hcol = hcol.astype(dtype, copy=False)
-    filters = (hcol[::-1], hrow[::-1])
+    filters = (hcol[::-1].conj(), hrow[::-1].conj())
     return cupyx.scipy.ndimage.filters._run_1d_correlates(
         input, (0, 1), lambda i: filters[i], None, 'reflect', 0)

--- a/cupyx/scipy/signal/signaltools.py
+++ b/cupyx/scipy/signal/signaltools.py
@@ -121,14 +121,14 @@ def _correlate(in1, in2, mode='full', method='auto', convolution=False):
     if inputs_swapped:
         in1, in2 = in2, in1
     if not convolution:
-        in2 = _st_core._reverse_and_conj(in2)
+        in2 = _st_core._reverse(in2).conj()
     out = fftconvolve(in1, in2, mode)
     result_type = cupy.result_type(in1, in2)
     if result_type.kind in 'ui':
         out = out.round()
     out = out.astype(result_type, copy=False)
     if not convolution and inputs_swapped:
-        out = cupy.ascontiguousarray(_st_core._reverse_and_conj(out))
+        out = cupy.ascontiguousarray(_st_core._reverse(out).conj())
     return out
 
 
@@ -433,16 +433,11 @@ def wiener(im, mysize=None, noise=None):
 
     .. seealso:: :func:`scipy.signal.wiener`
     """
-    if im.dtype.kind == 'c':
-        # TODO: adding support for complex types requires ndimage filters
-        # to support complex types (which they could easily if not for the
-        # scipy compatibility requirement of forbidding complex and using
-        # float64 intermediates)
-        raise TypeError("complex types not currently supported")
     if mysize is None:
         mysize = 3
     mysize = _util._fix_sequence_arg(mysize, im.ndim, 'mysize', int)
-    im = im.astype(float, copy=False)
+    im = im.astype(cupy.complex128 if im.dtype.kind == 'c' else cupy.float64,
+                   copy=False)
 
     # Estimate the local mean
     local_mean = filters.uniform_filter(im, mysize, mode='constant')

--- a/cupyx/scipy/signal/signaltools.py
+++ b/cupyx/scipy/signal/signaltools.py
@@ -511,7 +511,6 @@ def medfilt(volume, kernel_size=None):
     """
     if volume.dtype.kind == 'c':
         # scipy doesn't support complex
-        # (and filters.rank_filter raise TypeError)
         raise ValueError("complex types not supported")
     # output is forced to float64 to match scipy
     kernel_size = _get_kernel_size(kernel_size, volume.ndim)

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_bsplines.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_bsplines.py
@@ -18,7 +18,7 @@ except ImportError:
 @testing.gpu
 @testing.with_requires('scipy')
 class TestSepFIR2d(unittest.TestCase):
-    @testing.for_all_dtypes(no_complex=True)  # TODO: support complex
+    @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
     def test_sepfir2d(self, xp, scp, dtype):
         input = testing.shaped_random(self.input, xp, dtype)


### PR DESCRIPTION
This adds support for complex values in the following functions in the `cupyx.scipy.signal` package. These functions always had support in scipy but did not have support in cupy due to lack of support for complex values in the underlying `ndimage` functions that were being used.

* `cupyx.scipy.signal.convolve` (when method wasn't 'fft')
* `cupyx.scipy.signal.correlate` (when method wasn't 'fft')
* `cupyx.scipy.signal.convolve2d`
* `cupyx.scipy.signal.correlate2d`
* `cupyx.scipy.signal.wiener`
* `cupyx.scipy.signal.sepfir2d`

This code removes intentional error messages for complex data types and a few necessary complex conjugations.