### PR TITLE
[backport]  Fix `cupy.concatenate` typecheck for out with different dtype

### DIFF
--- a/cupy/core/_routines_manipulation.pyx
+++ b/cupy/core/_routines_manipulation.pyx
@@ -576,22 +576,17 @@ cpdef ndarray concatenate_method(tup, int axis, ndarray out=None):
     if ndim == -1:
         raise ValueError('Cannot concatenate from empty tuple')
 
-    if not have_same_types:
-        dtype = functools.reduce(numpy.promote_types,
-                                 set([a.dtype for a in arrays]))
-
     shape_t = tuple(shape)
     if out is None:
+        if not have_same_types:
+            dtype = functools.reduce(numpy.promote_types,
+                                     set([a.dtype for a in arrays]))
         out = ndarray(shape_t, dtype=dtype)
     else:
         if len(out.shape) != len(shape_t):
             raise ValueError('Output array has wrong dimensionality')
         if out.shape != shape_t:
             raise ValueError('Output array is the wrong shape')
-        if out.dtype.kind != dtype.kind:
-            raise TypeError('Cannot cast scalar from dtype(\'{}\')'
-                            ' to dtype(\'{}\') according to the'
-                            ' rule \'same_kind\''.format(dtype, out.dtype))
 
     return _concatenate(arrays, axis, shape_t, out)
 
@@ -630,7 +625,8 @@ cpdef ndarray _concatenate(
     for a in arrays:
         aw = a._shape[axis]
         slice_list[axis] = slice(i, i + aw)
-        elementwise_copy(a, _indexing._simple_getitem(out, slice_list))
+        elementwise_copy(
+            a, _indexing._simple_getitem(out, slice_list), casting='same_kind')
         i += aw
     return out
 

--- a/tests/cupy_tests/manipulation_tests/test_join.py
+++ b/tests/cupy_tests/manipulation_tests/test_join.py
@@ -196,6 +196,21 @@ class TestJoin(unittest.TestCase):
             with pytest.raises(TypeError):
                 xp.concatenate((a, b, c), axis=1, out=out)
 
+    @testing.for_all_dtypes_combination(names=['dtype1', 'dtype2'])
+    @testing.numpy_cupy_array_equal()
+    def test_concatenate_different_dtype(self, xp, dtype1, dtype2):
+        a = testing.shaped_arange((3, 4), xp, dtype1)
+        b = testing.shaped_arange((3, 4), xp, dtype2)
+        return xp.concatenate((a, b))
+
+    @testing.for_all_dtypes_combination(names=['dtype1', 'dtype2'])
+    @testing.numpy_cupy_array_equal(accept_error=TypeError)
+    def test_concatenate_out_different_dtype(self, xp, dtype1, dtype2):
+        a = testing.shaped_arange((3, 4), xp, dtype1)
+        b = testing.shaped_arange((3, 4), xp, dtype1)
+        out = xp.zeros((6, 4), dtype=dtype2)
+        return xp.concatenate((a, b), out=out)
+
     @testing.numpy_cupy_array_equal()
     def test_dstack(self, xp):
         a = testing.shaped_arange((1, 3, 2), xp)


### PR DESCRIPTION
Backport of #4527