### PR TITLE
Skip sparse svd `test_dense` for older scipy and complex64

### DIFF
--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
@@ -50,7 +50,7 @@ class TestConvolveCorrelate(unittest.TestCase):
     'mode': ['full', 'same', 'valid'],
 }))
 @testing.gpu
-@testing.with_requires('scipy')
+@testing.with_requires('scipy>=1.4.0')
 class TestFFTConvolve(unittest.TestCase):
     def _filter(self, func, dtype, xp, scp, **kwargs):
         in1 = testing.shaped_random(self.size1, xp, dtype)
@@ -85,7 +85,7 @@ class TestFFTConvolve(unittest.TestCase):
     'mode': ['full', 'same', 'valid'],
 }))
 @testing.gpu
-@testing.with_requires('scipy')
+@testing.with_requires('scipy>=1.4.0')
 class TestOAConvolve(unittest.TestCase):
     tols = {np.float32: 1e-3, np.complex64: 1e-3,
             np.float16: 1e-3, 'default': 1e-8}

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
@@ -123,7 +123,7 @@ class TestEigsh:
     n = 30
     density = 0.33
     tol = {numpy.float32: 1e-5, numpy.complex64: 1e-5, 'default': 1e-12}
-    res_tol = {'f': 1e-5, 'd': 1e-12}
+    res_tol = {'f': 1e-5, 'd': 1e-12, 'F': 1e-2}
 
     def _make_matrix(self, dtype, xp):
         shape = (self.n, self.n)
@@ -229,6 +229,9 @@ class TestSvds:
     @testing.for_dtypes('fdFD')
     @testing.numpy_cupy_allclose(rtol=tol, atol=tol, sp_name='sp')
     def test_dense(self, dtype, xp, sp):
+        if (dtype == numpy.complex64
+                and numpy.lib.NumpyVersion(scipy.__version__) < '1.4.0'):
+            pytest.skip('Complex types have tolerance issues in scipy<1.4')
         a = self._make_matrix(dtype, xp)
         if self.use_linear_operator:
             a = sp.linalg.aslinearoperator(a)


### PR DESCRIPTION
This test fails in the daily shuffles requiring a tolerance of 1e-2.
This tolerance is too low, so it's better to just skip it if scipy is < 1.4