### PR TITLE
CUDA 11.2: Fix empty NVRTC program name

### DIFF
--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -364,7 +364,7 @@ def _preprocess(source, options, arch, backend):
     if backend == 'nvrtc':
         options += ('-arch=compute_{}'.format(arch),)
 
-        prog = _NVRTCProgram(source, '')
+        prog = _NVRTCProgram(source)
         try:
             result, _ = prog.compile(options)
         except CompileException as e:
@@ -699,7 +699,7 @@ def _preprocess_hiprtc(source, options):
         // hiprtc segfaults if the input code is empty
         #include <hip/hip_runtime.h>
         __global__ void _cupy_preprocess_dummy_kernel_() { }
-        ''', '')
+        ''')
     try:
         result, _ = prog.compile(options)
     except CompileException as e:

--- a/cupy_backends/cuda/libs/nvrtc.pyx
+++ b/cupy_backends/cuda/libs/nvrtc.pyx
@@ -76,7 +76,11 @@ cpdef intptr_t createProgram(unicode src, unicode name, headers,
     cdef bytes b_src = src.encode()
     cdef const char* src_ptr = b_src
     cdef bytes b_name = name.encode()
-    cdef const char* name_ptr = b_name
+    cdef const char* name_ptr
+    if len(name) > 0:
+        name_ptr = b_name
+    else:
+        name_ptr = NULL
     cdef int num_headers = len(headers)
     cdef vector.vector[const char*] header_vec
     cdef vector.vector[const char*] include_name_vec


### PR DESCRIPTION
Starting CUDA 11.2, if the program name is an empty string, the first time NVRTC is invoked it would output the following log:
```
invalid filename
!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "lgenfe: EDG 6.0", isOptimized: true, runtimeVersion: 0, emissionKind: NoDebug, enums: !2)
!1 = !DIFile(filename: "", directory: "/home/leofang/dev/cupy_cuda112")
invalid filename
!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "lgenfe: EDG 6.0", isOptimized: true, runtimeVersion: 0, emissionKind: NoDebug, enums: !2)
!1 = !DIFile(filename: "", directory: "/home/leofang/dev/cupy_cuda112")
```
It's harmless but very annoying. This PR fixes it in 2 layers:
- In the Cython layer, if an empty name is detected, we pass NULL instead. This is permitted by NVRTC and seems also working fine on hipRTC.
- In the Python layer, we ensure all preprocessing calls have a non-empty name ("default_program").