### PR TITLE
Add cupy.round

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -580,6 +580,7 @@ from cupy._math.hyperbolic import sinh  # NOQA
 from cupy._math.hyperbolic import tanh  # NOQA
 
 from cupy._math.rounding import around  # NOQA
+from cupy._math.rounding import around as round # NOQA
 from cupy._math.rounding import ceil  # NOQA
 from cupy._math.rounding import fix  # NOQA
 from cupy._math.rounding import floor  # NOQA

--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -580,12 +580,12 @@ from cupy._math.hyperbolic import sinh  # NOQA
 from cupy._math.hyperbolic import tanh  # NOQA
 
 from cupy._math.rounding import around  # NOQA
-from cupy._math.rounding import around as round # NOQA
 from cupy._math.rounding import ceil  # NOQA
 from cupy._math.rounding import fix  # NOQA
 from cupy._math.rounding import floor  # NOQA
 from cupy._math.rounding import rint  # NOQA
 from cupy._math.rounding import round_  # NOQA
+from cupy._math.rounding import round_ as round  # NOQA
 from cupy._math.rounding import trunc  # NOQA
 
 from cupy._math.sumprod import prod  # NOQA

--- a/docs/source/reference/math.rst
+++ b/docs/source/reference/math.rst
@@ -49,6 +49,7 @@ Rounding
 
    cupy.around
    cupy.round_
+   cupy.round
    cupy.rint
    cupy.fix
    cupy.floor

--- a/docs/source/reference/math.rst
+++ b/docs/source/reference/math.rst
@@ -49,7 +49,6 @@ Rounding
 
    cupy.around
    cupy.round_
-   cupy.round
    cupy.rint
    cupy.fix
    cupy.floor

--- a/tests/cupy_tests/core_tests/fusion_tests/test_routines.py
+++ b/tests/cupy_tests/core_tests/fusion_tests/test_routines.py
@@ -160,7 +160,8 @@ class TestFusionDegRad(FusionUnaryUfuncTestBase):
 
 @testing.gpu
 @testing.parameterize(*testing.product({
-    'func': ['around', 'round_', 'rint', 'floor', 'ceil', 'trunc', 'fix']
+    'func': ['around', 'round', 'round_', 'rint', 'floor', 'ceil', 'trunc',
+             'fix']
 }))
 class TestFusionRounding(FusionUnaryUfuncTestBase):
 

--- a/tests/cupy_tests/math_tests/test_rounding.py
+++ b/tests/cupy_tests/math_tests/test_rounding.py
@@ -71,7 +71,7 @@ class TestRounding(unittest.TestCase):
 
     def test_round_(self):
         self.check_unary('round_')
-        self.check_unary_complex('around')
+        self.check_unary_complex('round_')
 
     def test_round(self):
         self.check_unary('round')

--- a/tests/cupy_tests/math_tests/test_rounding.py
+++ b/tests/cupy_tests/math_tests/test_rounding.py
@@ -73,6 +73,10 @@ class TestRounding(unittest.TestCase):
         self.check_unary('round_')
         self.check_unary_complex('around')
 
+    def test_round(self):
+        self.check_unary('round')
+        self.check_unary_complex('round')
+
 
 @testing.parameterize(*testing.product({
     'decimals': [-2, -1, 0, 1, 2],


### PR DESCRIPTION
NumPy has a `round` function that is equivalent to `around`, but CuPy currently does not define this function.

When checking the proposed Array API Standard, I see that `round` rather than `around` is specified in the standard, so it would be good to support it here. See:
https://data-apis.github.io/array-api/latest/API_specification/elementwise_functions.html#round-x

