### PR TITLE
[backport] Fix `cupy.take` from an empty array

### DIFF
--- a/cupy/core/_routines_indexing.pyx
+++ b/cupy/core/_routines_indexing.pyx
@@ -675,7 +675,9 @@ cpdef ndarray _getitem_mask_single(ndarray a, ndarray mask, int axis):
 
 
 cdef ndarray _take(ndarray a, indices, int li, int ri, ndarray out=None):
-    # When li + 1 == ri this function behaves similarly to np.take
+    # Take along (flattened) axes from li to ri *inclusive*.
+    # When li == ri this function behaves similarly to np.take
+    # TODO(kataoka): Use half-open interval [li, ri)
     cdef tuple out_shape, ind_shape, indices_shape
     cdef int i, ndim = a._shape.size()
     cdef Py_ssize_t ldim, cdim, rdim, index_range
@@ -717,7 +719,9 @@ cdef ndarray _take(ndarray a, indices, int li, int ri, ndarray out=None):
             ldim *= a._shape[i]
         for i in range(ri + 1, ndim):
             rdim *= a._shape[i]
-        index_range = a.size // (ldim * rdim)
+        index_range = 1
+        for i in range(li, ri + 1):
+            index_range *= a._shape[i]
 
     if out is None:
         out = ndarray(out_shape, dtype=a.dtype)

--- a/tests/cupy_tests/core_tests/test_ndarray.py
+++ b/tests/cupy_tests/core_tests/test_ndarray.py
@@ -452,8 +452,9 @@ class TestNdarrayTakeErrorTypeMismatch(unittest.TestCase):
 
 
 @testing.parameterize(
-    {'shape': (0,), 'indices': (0,)},
-    {'shape': (0,), 'indices': (0, 1)},
+    {'shape': (0,), 'indices': (0,), 'axis': None},
+    {'shape': (0,), 'indices': (0, 1), 'axis': None},
+    {'shape': (3, 0), 'indices': (2,), 'axis': 0},
 )
 @testing.gpu
 class TestZeroSizedNdarrayTake(unittest.TestCase):
@@ -462,7 +463,7 @@ class TestZeroSizedNdarrayTake(unittest.TestCase):
     def test_output_type_mismatch(self, xp):
         a = testing.shaped_arange(self.shape, xp, numpy.int32)
         i = testing.shaped_arange(self.indices, xp, numpy.int32)
-        return wrap_take(a, i)
+        return wrap_take(a, i, axis=self.axis)
 
 
 @testing.parameterize(

--- a/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
@@ -108,6 +108,8 @@ class TestArrayAdvancedIndexingGetitemPerm(unittest.TestCase):
     {'shape': (), 'indexes': numpy.zeros((), dtype=numpy.bool_)},
     {'shape': (0,), 'indexes': None},
     {'shape': (0,), 'indexes': ()},
+    {'shape': (2, 0), 'indexes': ([1],)},
+    {'shape': (0, 3), 'indexes': (slice(None), [1])},
     # TODO(niboshi): pass the following commented out tests
     # {'shape': (0,), 'indexes': (False, True, True)},
 )


### PR DESCRIPTION
Backport of #4530