### PR TITLE
ndimage: coordinate rounding fix for order=0 interpolation

### DIFF
--- a/cupyx/scipy/ndimage/_interp_kernels.py
+++ b/cupyx/scipy/ndimage/_interp_kernels.py
@@ -302,7 +302,7 @@ def _generate_interp_custom(coord_func, ndim, large_int, yshape, mode, cval,
                 dcoord = c_{j};''')
             else:
                 ops.append(f'''
-                {int_t} cf_{j} = ({int_t})lrint((double)c_{j});''')
+                {int_t} cf_{j} = ({int_t})floor((double)c_{j} + 0.5);''')
 
             # handle boundary
             if mode != 'constant':

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
@@ -118,6 +118,29 @@ class TestMapCoordinates:
 
 
 @testing.parameterize(*testing.product({
+    'order': [0, 1, 2, 3, 4, 5],
+    'mode': ['constant', 'nearest', 'mirror'] + scipy16_modes,
+}))
+@testing.gpu
+@testing.with_requires('scipy')
+class TestMapCoordinatesHalfInteger:
+
+    def _map_coordinates(self, xp, scp, a, coordinates):
+        _conditional_scipy_version_skip(self.mode, self.order)
+        map_coordinates = scp.ndimage.map_coordinates
+        return map_coordinates(a, coordinates, None, self.order, self.mode)
+
+    @testing.for_float_dtypes(no_float16=True)
+    @testing.numpy_cupy_allclose(atol=1e-4, scipy_name='scp')
+    def test_map_coordinates_float(self, xp, scp, dtype):
+        # Half integer coordinate rounding test case from:
+        # https://github.com/cupy/cupy/issues/4550
+        a = testing.shaped_arange((4, 3), xp, dtype)
+        coordinates = xp.array([[0.5, 2], [0.5, 1]])
+        return self._map_coordinates(xp, scp, a, coordinates)
+
+
+@testing.parameterize(*testing.product({
     'matrix_shape': [(2,), (2, 2), (2, 3), (3, 3)],
     'offset': [0.3, [-1.3, 1.3]],
     'output_shape': [None],


### PR DESCRIPTION
Fix rounding behavior for `cupyx.scipy.ndimage.interpolation` functions with order=0.

closes #4550

reference line from SciPy source: 
https://github.com/scipy/scipy/blob/255d49cd63d4341c4d95b28ee8272657bf5e8e42/scipy/ndimage/src/ni_interpolation.c#L479
