### PR TITLE
CUDA 11.1: Wrap the new `nvrtcGetCUBIN` API

### DIFF
--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -238,7 +238,7 @@ def compile_using_nvrtc(source, options=(), arch=None, filename='kern.cu',
             if _cuda_version >= 11010 and jitify:
                 # Convert the virtual arch to a real arch
                 options = [f'-arch=sm_{arch}' if opt.startswith('-arch=')
-                    else opt for opt in options]
+                           else opt for opt in options]
                 options = tuple(options)
             ptx, mapping = prog.compile(options, log_stream)
         except CompileException as e:

--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -235,7 +235,7 @@ def compile_using_nvrtc(source, options=(), arch=None, filename='kern.cu',
     if not arch:
         arch = _get_arch()
 
-    options += ('-arch=compute_{}'.format(arch),)
+    options += ('-arch=sm_{}'.format(arch),)
 
     def _compile(
             source, options, cu_path, name_expressions, log_stream, jitify):
@@ -362,7 +362,7 @@ def compile_using_nvcc(source, options=(), arch=None,
 
 def _preprocess(source, options, arch, backend):
     if backend == 'nvrtc':
-        options += ('-arch=compute_{}'.format(arch),)
+        options += ('-arch=sm_{}'.format(arch),)
 
         prog = _NVRTCProgram(source, '')
         try:
@@ -627,7 +627,7 @@ class _NVRTCProgram(object):
                     mapping[ker] = nvrtc.getLoweredName(self.ptr, ker)
             if log_stream is not None:
                 log_stream.write(nvrtc.getProgramLog(self.ptr))
-            return nvrtc.getPTX(self.ptr), mapping
+            return nvrtc.getCUBIN(self.ptr), mapping
         except nvrtc.NVRTCError:
             log = nvrtc.getProgramLog(self.ptr)
             raise CompileException(log, self.src, self.name, options,

--- a/cupy_backends/cuda/cupy_nvrtc.h
+++ b/cupy_backends/cuda/cupy_nvrtc.h
@@ -1,0 +1,22 @@
+#ifndef INCLUDE_GUARD_CUDA_CUPY_NVRTC_H
+#define INCLUDE_GUARD_CUDA_CUPY_NVRTC_H
+
+#include <cuda.h>  // for CUDA_VERSION
+#include <nvrtc.h>
+
+extern "C" {
+
+#if CUDA_VERSION < 11010
+// functions added in CUDA 11.1
+nvrtcResult nvrtcGetCUBINSize(...) {
+    return NVRTC_ERROR_COMPILATION;
+}
+
+nvrtcResult nvrtcGetCUBIN(...) {
+    return NVRTC_ERROR_COMPILATION;
+}
+#endif
+
+}
+
+#endif // #ifndef INCLUDE_GUARD_CUDA_CUPY_NVRTC_H

--- a/cupy_backends/cuda/libs/nvrtc.pxd
+++ b/cupy_backends/cuda/libs/nvrtc.pxd
@@ -15,6 +15,7 @@ cpdef check_status(int status)
 
 cpdef tuple getVersion()
 
+
 ###############################################################################
 # Program
 ###############################################################################
@@ -24,6 +25,7 @@ cpdef intptr_t createProgram(unicode src, unicode name, headers,
 cpdef destroyProgram(intptr_t prog)
 cpdef compileProgram(intptr_t prog, options)
 cpdef bytes getPTX(intptr_t prog)
+cpdef bytes getCUBIN(intptr_t prog)
 cpdef unicode getProgramLog(intptr_t prog)
 cpdef addAddNameExpression(intptr_t prog, str name)
 cpdef str getLoweredName(intptr_t prog, str name)

--- a/cupy_backends/cuda/libs/nvrtc.pyx
+++ b/cupy_backends/cuda/libs/nvrtc.pyx
@@ -14,6 +14,8 @@ There are four differences compared to the original C API.
 cimport cython  # NOQA
 from libcpp cimport vector
 
+from cupy_backends.cuda.api cimport runtime
+
 
 ###############################################################################
 # Extern
@@ -145,6 +147,8 @@ cpdef bytes getCUBIN(intptr_t prog):
     cdef size_t cubinSizeRet = 0
     cdef vector.vector[char] cubin
     cdef char* cubin_ptr = NULL
+    if CUDA_VERSION < 11010 or runtime._is_hip_environment:
+        raise RuntimeError("getCUBIN is supported since CUDA 11.1")
     with nogil:
         status = nvrtcGetCUBINSize(<Program>prog, &cubinSizeRet)
     check_status(status)

--- a/cupy_backends/cupy_rtc.h
+++ b/cupy_backends/cupy_rtc.h
@@ -7,7 +7,7 @@
 
 #elif !defined(CUPY_NO_CUDA)
 
-#include <nvrtc.h>
+#include "cuda/cupy_nvrtc.h"
 
 #else
 

--- a/cupy_backends/hip/cupy_hiprtc.h
+++ b/cupy_backends/hip/cupy_hiprtc.h
@@ -42,6 +42,14 @@ nvrtcResult nvrtcGetPTX(nvrtcProgram prog, char* code) {
     return hiprtcGetCode(prog, code);
 }
 
+nvrtcResult nvrtcGetCUBINSize(...) {
+    return HIPRTC_ERROR_COMPILATION;
+}
+
+nvrtcResult nvrtcGetCUBIN(...) {
+    return HIPRTC_ERROR_COMPILATION;
+}
+
 nvrtcResult nvrtcGetProgramLogSize(nvrtcProgram prog, std::size_t* logSizeRet) {
     return hiprtcGetProgramLogSize(prog, logSizeRet);
 }

--- a/cupy_backends/stub/cupy_nvrtc.h
+++ b/cupy_backends/stub/cupy_nvrtc.h
@@ -40,6 +40,14 @@ nvrtcResult nvrtcGetPTX(...) {
     return NVRTC_SUCCESS;
 }
 
+nvrtcResult nvrtcGetCUBINSize(...) {
+    return NVRTC_SUCCESS;
+}
+
+nvrtcResult nvrtcGetCUBIN(...) {
+    return NVRTC_SUCCESS;
+}
+
 nvrtcResult nvrtcGetProgramLogSize(...) {
     return NVRTC_SUCCESS;
 }

--- a/tests/cupy_tests/core_tests/test_raw.py
+++ b/tests/cupy_tests/core_tests/test_raw.py
@@ -16,6 +16,7 @@ from cupy import _util
 from cupy.core import _accelerator
 from cupy.cuda import compiler
 from cupy.cuda import memory
+from cupy_backends.cuda.api import driver
 
 
 _test_source1 = r'''
@@ -632,10 +633,13 @@ class TestRaw(unittest.TestCase):
         N = 10
         inner_chunk = 2
         x = cupy.zeros((N,), dtype=cupy.float32)
-        if self.backend == 'nvrtc' and not cupy.cuda.runtime.is_hip:
+        if (self.backend == 'nvrtc'
+                and not cupy.cuda.runtime.is_hip
+                and driver.get_build_version() < 11010):
             # raised when calling ls.complete()
             error = cupy.cuda.driver.CUDADriverError
-        else:  # nvcc, hipcc, hiprtc
+        else:  # nvcc, hipcc, hiprtc, or nvrtc on CUDA 11.1+
+            # On CUDA 11.1+, nvrtc fails due to unresolved symbols
             error = cupy.cuda.compiler.CompileException
         with pytest.raises(error):
             ker((1,), (N//inner_chunk,), (x, N, inner_chunk))

--- a/tests/cupy_tests/core_tests/test_raw.py
+++ b/tests/cupy_tests/core_tests/test_raw.py
@@ -16,7 +16,6 @@ from cupy import _util
 from cupy.core import _accelerator
 from cupy.cuda import compiler
 from cupy.cuda import memory
-from cupy_backends.cuda.api import driver
 
 
 _test_source1 = r'''
@@ -633,13 +632,10 @@ class TestRaw(unittest.TestCase):
         N = 10
         inner_chunk = 2
         x = cupy.zeros((N,), dtype=cupy.float32)
-        if (self.backend == 'nvrtc'
-                and not cupy.cuda.runtime.is_hip
-                and driver.get_build_version() < 11010):
+        if self.backend == 'nvrtc' and not cupy.cuda.runtime.is_hip:
             # raised when calling ls.complete()
             error = cupy.cuda.driver.CUDADriverError
-        else:  # nvcc, hipcc, hiprtc, or nvrtc on CUDA 11.1+
-            # On CUDA 11.1+, nvrtc fails due to unresolved symbols
+        else:  # nvcc, hipcc, hiprtc
             error = cupy.cuda.compiler.CompileException
         with pytest.raises(error):
             ker((1,), (N//inner_chunk,), (x, N, inner_chunk))


### PR DESCRIPTION
**UPDATE**: this PR only adds Cython wrappers for `nvrtcGetCUBIN`, and the migration strategy to this new API is to be discussed.

This PR changes the NVRTC default for CUDA 11.1+ from compiling PTX to compiling CUBIN, bypassing the driver JIT step when the module is loaded. This could potentially improve the overall performance (to be verified) in terms of both reducing overall time and enabling better code generation.

For CUDA 9.2 - 11.0, this PR does not do anything.

TODO:
- [x] Run some benchmarks to see if we get some speedup.