### PR TITLE
Fix DLPack header version

### DIFF
--- a/cupy/core/dlpack.pyx
+++ b/cupy/core/dlpack.pyx
@@ -16,6 +16,16 @@ import cupy
 
 
 cdef extern from './include/cupy/dlpack/dlpack.h' nogil:
+    '''
+    // stringification is currently needed as the version is "030"...
+    #define _stringify_(s) #s
+    #define _xstringify_(s) _stringify_(s)
+    const char* DLPACK_VER_STR = _xstringify_(DLPACK_VERSION);
+    #undef _xstringify_
+    #undef _stringify_
+    '''
+    const char* DLPACK_VER_STR
+
     cdef enum DLDeviceType:
         kDLCPU
         kDLGPU
@@ -57,9 +67,7 @@ cdef extern from './include/cupy/dlpack/dlpack.h' nogil:
 
 
 def get_build_version():
-    # We use the commit ID here because DLPACK_VERSION is not reliable...
-    # The commit ID is from the latest change made to dlpack.h.
-    return '3efc489'
+    return DLPACK_VER_STR.decode()
 
 
 cdef void pycapsule_deleter(object dltensor):

--- a/cupy/core/include/cupy/dlpack/README.md
+++ b/cupy/core/include/cupy/dlpack/README.md
@@ -1,4 +1,4 @@
 ## DLPack header
 
 The header `dlpack.h` is downloaded from https://github.com/dmlc/dlpack/blob/main/include/dlpack/dlpack.h.
-The commit is [`3efc489`](https://github.com/dmlc/dlpack/commit/3efc489b55385936531a06ff83425b719387ec63).
+The commit is [`e1e11e0`](https://github.com/dmlc/dlpack/commit/e1e11e0d555c08bec08a6c7773aa777dfcaae9da).

--- a/cupy/core/include/cupy/dlpack/dlpack.h
+++ b/cupy/core/include/cupy/dlpack/dlpack.h
@@ -13,7 +13,7 @@
 #endif
 
 /*! \brief The current version of dlpack */
-#define DLPACK_VERSION 020
+#define DLPACK_VERSION 030
 
 /*! \brief DLPACK_DLL prefix for windows */
 #ifdef _WIN32


### PR DESCRIPTION
Follow-up of #4517. @tqchen kindly fixed this issue in upstream right after I reported it, so given that we manually bundle the header we can just apply the same fix ourselves.

This PR should be backported (after #4535).