### PR TITLE
Add cuTENSOR to library download tool

### DIFF
--- a/cupy/_environment.py
+++ b/cupy/_environment.py
@@ -27,7 +27,7 @@ Wheel packages are built against specific versions of CUDA libraries
 To avoid loading wrong version, these shared libraries are manually
 preloaded.
 
-# TODO(kmaehashi) Currently cuDNN only. Support cuTENSOR and NCCL.
+# TODO(kmaehashi): Support NCCL
 
 Example of `_preload_config` is as follows:
 
@@ -53,7 +53,7 @@ _preload_config = None
 _preload_libs = {
     'cudnn': None,
     # 'nccl': None,
-    # 'cutensor': None,
+    'cutensor': None,
 }
 
 _preload_logs = []

--- a/cupyx/tools/install_library.py
+++ b/cupyx/tools/install_library.py
@@ -88,7 +88,6 @@ def _make_cutensor_url(public_version, filename):
 def _make_cutensor_record(
         cuda_version, public_version, filename_linux, filename_windows=''):
     # TODO(leofang): Support Windows when a public link becomes available
-    major_version = public_version.split('.')[0]
     return {
         'cuda': cuda_version,
         'cutensor': public_version,
@@ -118,13 +117,14 @@ library_records['cutensor'] = _cutensor_records
 
 def install_lib(cuda, prefix, library):
     record = None
-    for record in library_records[library]:
+    lib_records = library_records
+    for record in lib_records[library]:
         if record['cuda'] == cuda:
             break
     else:
         raise RuntimeError('''
 The CUDA version specified is not supported.
-Should be one of {}.'''.format(str([x['cuda'] for x in library_records[library]])))
+Should be one of {}.'''.format(str([x['cuda'] for x in lib_records[library]])))
     if prefix is None:
         prefix = os.path.expanduser('~/.cupy/cuda_lib')
     destination = calculate_destination(prefix, cuda, library, record[library])

--- a/tests/cupyx_tests/tools_tests/test_install_library.py
+++ b/tests/cupyx_tests/tools_tests/test_install_library.py
@@ -16,8 +16,18 @@ class TestInstallLibrary(unittest.TestCase):
             with tempfile.TemporaryDirectory() as d:
                 install_library.install_lib(cuda, d, 'cudnn')
 
-    def test_cudnn(self):
-        assets = [r['assets'] for r in install_library._cudnn_records]
+    @testing.slow
+    def test_install_cutensor(self):
+        # Try installing cuTENSOR for all supported CUDA versions
+        for rec in install_library._cutensor_records:
+            cuda = rec['cuda']
+            with tempfile.TemporaryDirectory() as d:
+                install_library.install_lib(cuda, d, 'cutensor')
+
+    def test_urls(self):
+        assets = [r['assets'] for r in (
+            install_library._cudnn_records
+            + install_library._cutensor_records)]
         for asset in assets:
             for platform in asset.keys():
                 url = asset[platform]['url']
@@ -28,3 +38,5 @@ class TestInstallLibrary(unittest.TestCase):
     def test_main(self):
         install_library.main(
             ['--library', 'cudnn', '--action', 'dump', '--cuda', 'null'])
+        install_library.main(
+            ['--library', 'cutensor', '--action', 'dump', '--cuda', 'null'])

--- a/tests/cupyx_tests/tools_tests/test_install_library.py
+++ b/tests/cupyx_tests/tools_tests/test_install_library.py
@@ -14,7 +14,7 @@ class TestInstallLibrary(unittest.TestCase):
         for rec in install_library._cudnn_records:
             cuda = rec['cuda']
             with tempfile.TemporaryDirectory() as d:
-                install_library.install_cudnn(cuda, d)
+                install_library.install_lib(cuda, d, 'cudnn')
 
     def test_cudnn(self):
         assets = [r['assets'] for r in install_library._cudnn_records]


### PR DESCRIPTION
I am working on making cuTENSOR available on Conda-Forge (conda-forge/staged-recipes#13576), and I realized the same convenience can also be brought to here. Currently machine-readable links are only available on Linux variants (thanks to @kkraus14's help 👍).