### PR TITLE
Support passing pointers as integers in memory copy routines

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -7,7 +7,6 @@ import re
 import sys
 import warnings
 
-import ctypes
 import numpy
 
 import cupy
@@ -1361,7 +1360,7 @@ cdef class ndarray:
                     and (self._f_contiguous or self._c_contiguous)):
                 order = 'F' if self._f_contiguous else 'C'
                 tmp = value.ravel(order)
-                ptr = ctypes.c_void_p(tmp.__array_interface__['data'][0])
+                ptr = tmp.ctypes.data
                 stream_ptr = stream_module.get_current_stream_ptr()
                 if stream_ptr == 0:
                     self.data.copy_from_host(ptr, self.nbytes)
@@ -1600,7 +1599,7 @@ cdef class ndarray:
             a_cpu = numpy.empty(self._shape, dtype=self.dtype, order=order)
 
         syncdetect._declare_synchronize()
-        ptr = ctypes.c_void_p(a_cpu.__array_interface__['data'][0])
+        ptr = a_cpu.ctypes.data
         with self.device:
             if stream is not None:
                 a_gpu.data.copy_to_host_async(ptr, a_gpu.nbytes, stream)
@@ -1638,7 +1637,7 @@ cdef class ndarray:
         else:
             raise RuntimeError('Cannot set to non-contiguous array')
 
-        ptr = ctypes.c_void_p(arr.__array_interface__['data'][0])
+        ptr = arr.ctypes.data
         with self.device:
             if stream is not None:
                 self.data.copy_from_host_async(ptr, self.nbytes, stream)
@@ -2293,12 +2292,10 @@ cdef ndarray _send_object_to_gpu(obj, dtype, order, Py_ssize_t ndmin):
     if mem is not None:
         src_cpu = numpy.frombuffer(mem, a_dtype, a_cpu.size)
         src_cpu[:] = a_cpu.ravel(order)
-        a.data.copy_from_host_async(ctypes.c_void_p(mem.ptr), nbytes)
+        a.data.copy_from_host_async(mem.ptr, nbytes)
         pinned_memory._add_to_watch_list(stream.record(), mem)
     else:
-        a.data.copy_from_host(
-            ctypes.c_void_p(a_cpu.__array_interface__['data'][0]),
-            nbytes)
+        a.data.copy_from_host(a_cpu.ctypes.data, nbytes)
 
     return a
 
@@ -2331,7 +2328,7 @@ cdef ndarray _send_numpy_array_list_to_gpu(
             a_dtype,
             src_cpu)
         a = ndarray(shape, dtype=a_dtype, order=order)
-        a.data.copy_from_host_async(ctypes.c_void_p(mem.ptr), nbytes)
+        a.data.copy_from_host_async(mem.ptr, nbytes)
         pinned_memory._add_to_watch_list(stream.record(), mem)
     else:
         # fallback to numpy array and send it to GPU
@@ -2339,9 +2336,7 @@ cdef ndarray _send_numpy_array_list_to_gpu(
         a_cpu = numpy.array(arrays, dtype=a_dtype, copy=False, order=order,
                             ndmin=ndmin)
         a = ndarray(shape, dtype=a_dtype, order=order)
-        a.data.copy_from_host(
-            ctypes.c_void_p(a_cpu.__array_interface__['data'][0]),
-            nbytes)
+        a.data.copy_from_host(a_cpu.ctypes.data, nbytes)
 
     return a
 

--- a/cupy/cuda/device.pyx
+++ b/cupy/cuda/device.pyx
@@ -305,7 +305,7 @@ def from_pointer(ptr):
     """Extracts a Device object from a device pointer.
 
     Args:
-        ptr (ctypes.c_void_p): Pointer to the device memory.
+        ptr (int): Pointer to the device memory.
 
     Returns:
         Device: The device whose memory the pointer refers to.

--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -369,31 +369,33 @@ cdef class MemoryPointer:
         """Copies a memory sequence from the host memory.
 
         Args:
-            mem (ctypes.c_void_p): Source memory pointer.
+            mem (int or ctypes.c_void_p): Source memory pointer.
             size (int): Size of the sequence in bytes.
 
         """
         if size > 0:
-            runtime.memcpy(self.ptr, mem.value, size,
+            ptr = mem if isinstance(mem, int) else mem.value
+            runtime.memcpy(self.ptr, ptr, size,
                            runtime.memcpyHostToDevice)
 
     cpdef copy_from_host_async(self, mem, size_t size, stream=None):
         """Copies a memory sequence from the host memory asynchronously.
 
         Args:
-            mem (ctypes.c_void_p): Source memory pointer. It must be a pinned
-                memory.
+            mem (int or ctypes.c_void_p): Source memory pointer. It must point
+                to pinned memory.
             size (int): Size of the sequence in bytes.
             stream (cupy.cuda.Stream): CUDA stream.
                 The default uses CUDA stream of the current context.
 
         """
         if stream is None:
+            ptr = mem if isinstance(mem, int) else mem.value
             stream_ptr = stream_module.get_current_stream_ptr()
         else:
             stream_ptr = stream.ptr
         if size > 0:
-            runtime.memcpyAsync(self.ptr, mem.value, size,
+            runtime.memcpyAsync(self.ptr, ptr, size,
                                 runtime.memcpyHostToDevice, stream_ptr)
 
     cpdef copy_from(self, mem, size_t size):
@@ -404,8 +406,8 @@ cdef class MemoryPointer:
         :meth:`~cupy.cuda.MemoryPointer.copy_from_host`.
 
         Args:
-            mem (ctypes.c_void_p or cupy.cuda.MemoryPointer): Source memory
-                pointer.
+            mem (int or ctypes.c_void_p or cupy.cuda.MemoryPointer):
+                Source memory pointer.
             size (int): Size of the sequence in bytes.
 
         """
@@ -422,8 +424,8 @@ cdef class MemoryPointer:
         :meth:`~cupy.cuda.MemoryPointer.copy_from_host_async`.
 
         Args:
-            mem (ctypes.c_void_p or cupy.cuda.MemoryPointer): Source memory
-                pointer.
+            mem (int or ctypes.c_void_p or cupy.cuda.MemoryPointer):
+                Source memory pointer.
             size (int): Size of the sequence in bytes.
             stream (cupy.cuda.Stream): CUDA stream.
                 The default uses CUDA stream of the current context.
@@ -438,12 +440,13 @@ cdef class MemoryPointer:
         """Copies a memory sequence to the host memory.
 
         Args:
-            mem (ctypes.c_void_p): Target memory pointer.
+            mem (int or ctypes.c_void_p): Target memory pointer.
             size (int): Size of the sequence in bytes.
 
         """
         if size > 0:
-            runtime.memcpy(mem.value, self.ptr, size,
+            ptr = mem if isinstance(mem, int) else mem.value
+            runtime.memcpy(ptr, self.ptr, size,
                            runtime.memcpyDeviceToHost)
 
     cpdef copy_to_host_async(self, mem, size_t size, stream=None):

--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -453,8 +453,8 @@ cdef class MemoryPointer:
         """Copies a memory sequence to the host memory asynchronously.
 
         Args:
-            mem (ctypes.c_void_p): Target memory pointer. It must be a pinned
-                memory.
+            mem (int or ctypes.c_void_p): Target memory pointer. It must point
+                to pinned memory.
             size (int): Size of the sequence in bytes.
             stream (cupy.cuda.Stream): CUDA stream.
                 The default uses CUDA stream of the current context.
@@ -465,7 +465,8 @@ cdef class MemoryPointer:
         else:
             stream_ptr = stream.ptr
         if size > 0:
-            runtime.memcpyAsync(mem.value, self.ptr, size,
+            ptr = mem if isinstance(mem, int) else mem.value
+            runtime.memcpyAsync(ptr, self.ptr, size,
                                 runtime.memcpyDeviceToHost, stream_ptr)
 
     cpdef memset(self, int value, size_t size):

--- a/tests/cupy_tests/cuda_tests/test_memory.py
+++ b/tests/cupy_tests/cuda_tests/test_memory.py
@@ -124,6 +124,7 @@ class TestMemoryPointer(unittest.TestCase):
         a_gpu = memory.alloc(4)
         a_cpu = ctypes.c_int(100)
         a_gpu.copy_from(ctypes.cast(ctypes.byref(a_cpu), ctypes.c_void_p), 4)
+
         b_cpu = ctypes.c_int()
         a_gpu.copy_to_host(
             ctypes.cast(ctypes.byref(b_cpu), ctypes.c_void_p), 4)
@@ -139,6 +140,30 @@ class TestMemoryPointer(unittest.TestCase):
         b_cpu = ctypes.c_int()
         b_gpu.copy_to_host(
             ctypes.cast(ctypes.byref(b_cpu), ctypes.c_void_p), 4)
+        assert b_cpu.value == a_cpu.value
+
+    def test_copy_to_and_from_host_using_raw_ptr(self):
+        a_gpu = memory.alloc(4)
+        a_cpu = ctypes.c_int(100)
+        a_cpu_ptr = ctypes.cast(ctypes.byref(a_cpu), ctypes.c_void_p)
+        a_gpu.copy_from(a_cpu_ptr.value, 4)
+
+        b_cpu = ctypes.c_int()
+        b_cpu_ptr = ctypes.cast(ctypes.byref(b_cpu), ctypes.c_void_p)
+        a_gpu.copy_to_host(b_cpu_ptr.value, 4)
+        assert b_cpu.value == a_cpu.value
+
+    def test_copy_from_device_using_raw_ptr(self):
+        a_gpu = memory.alloc(4)
+        a_cpu = ctypes.c_int(100)
+        a_cpu_ptr = ctypes.cast(ctypes.byref(a_cpu), ctypes.c_void_p)
+        a_gpu.copy_from(a_cpu_ptr.value, 4)
+
+        b_gpu = memory.alloc(4)
+        b_gpu.copy_from(a_gpu, 4)
+        b_cpu = ctypes.c_int()
+        b_cpu_ptr = ctypes.cast(ctypes.byref(b_cpu), ctypes.c_void_p)
+        b_gpu.copy_to_host(b_cpu_ptr.value, 4)
         assert b_cpu.value == a_cpu.value
 
     def test_memset(self):


### PR DESCRIPTION
Close #4317. Wrapping pointers using `ctypes.c_void_p()` is still accepted, but it's not required.

TODO:
- [x] Add test