### PR TITLE
Check if the accepted_error was not raised from test code

### DIFF
--- a/cupy/testing/helper.py
+++ b/cupy/testing/helper.py
@@ -149,7 +149,7 @@ def _check_cupy_numpy_error(cupy_error, numpy_error,
         raise numpy_error  # reraise SkipTest
 
     # Check if the error was not raised from test code.
-    if cupy_error is not None:
+    if os.environ.get('CUPY_CI', '') != '' and cupy_error is not None:
         frame = traceback.extract_tb(cupy_error.__traceback__)[-1]
         filename = os.path.basename(frame.filename)
         if filename == 'test_helper.py':

--- a/cupy/testing/helper.py
+++ b/cupy/testing/helper.py
@@ -148,6 +148,19 @@ def _check_cupy_numpy_error(cupy_error, numpy_error,
                 'Both numpy and cupy were skipped but with different causes.')
         raise numpy_error  # reraise SkipTest
 
+    # Check if the error was not raised from test code.
+    if cupy_error is not None:
+        frame = traceback.extract_tb(cupy_error.__traceback__)[-1]
+        filename = os.path.basename(frame.filename)
+        if filename == 'test_helper.py':
+            # Allows errors from the test code for testing helpers.
+            pass
+        elif filename.startswith('test_'):
+            _fail_test_with_unexpected_errors(
+                cupy_error.__traceback__,
+                'Error was raised from test code.\n\n{cupy_error}',
+                cupy_error, None)
+
     # For backward compatibility
     if accept_error is True:
         accept_error = Exception


### PR DESCRIPTION
When using `testing.numpy_cupy_**` testing helpers, both NumPy and CuPy raise the same error type if the test script has a bug, for example, the wrong number of parameters.

This PR avoids passing such a wrong test unexpectedly.

Rel. https://github.com/cupy/cupy/pull/3702