### PR TITLE
Fix cupyx.scipy.ndimage.zoom for outputs of size 1

### DIFF
--- a/cupyx/scipy/ndimage/_interp_kernels.py
+++ b/cupyx/scipy/ndimage/_interp_kernels.py
@@ -302,7 +302,7 @@ def _generate_interp_custom(coord_func, ndim, large_int, yshape, mode, cval,
                 dcoord = c_{j};''')
             else:
                 ops.append(f'''
-                {int_t} cf_{j} = ({int_t})lrint((double)c_{j});''')
+                {int_t} cf_{j} = ({int_t})floor((double)c_{j} + 0.5);''')
 
             # handle boundary
             if mode != 'constant':

--- a/cupyx/scipy/ndimage/interpolation.py
+++ b/cupyx/scipy/ndimage/interpolation.py
@@ -705,11 +705,10 @@ def zoom(input, zoom, output=None, order=3, mode='constant', cval=0.0,
 
         zoom = []
         for in_size, out_size in zip(input.shape, output_shape):
-            if out_size > 1:
-                if grid_mode:
-                    zoom.append(in_size / out_size)
-                else:
-                    zoom.append((in_size - 1) / (out_size - 1))
+            if grid_mode and out_size > 0:
+                zoom.append(in_size / out_size)
+            elif out_size > 1:
+                zoom.append((in_size - 1) / (out_size - 1))
             else:
                 zoom.append(0)
 

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
@@ -693,6 +693,26 @@ class TestZoomOrder0IntegerGrid():
         )
 
 
+@testing.parameterize(*testing.product({
+    'shape': [(5, 5, 2)],
+    'zoom': [(2, 2, 0.5)],  # selected to give output.shape[-1] == 1
+    'mode': legacy_modes + scipy16_modes,
+    'order': [0, 1, 2, 3, 4, 5],
+    'grid_mode': [False, True],
+}))
+@testing.gpu
+class TestZoomOutputSize1():
+
+    @testing.for_float_dtypes(no_float16=True)
+    @testing.numpy_cupy_allclose(atol=1e-5, scipy_name='scp')
+    @testing.with_requires('scipy>=1.6.0')
+    def test_zoom_output_size1(self, xp, scp, dtype):
+        x = xp.zeros(self.shape, dtype=dtype)
+        x[1, 1, 1] = 1
+        return scp.ndimage.zoom(x, self.zoom, order=self.order, mode=self.mode,
+                                grid_mode=self.grid_mode)
+
+
 @testing.parameterize(
     {'zoom': 3},
     {'zoom': 0.3},

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
@@ -118,6 +118,29 @@ class TestMapCoordinates:
 
 
 @testing.parameterize(*testing.product({
+    'order': [0, 1, 2, 3, 4, 5],
+    'mode': ['constant', 'nearest', 'mirror'] + scipy16_modes,
+}))
+@testing.gpu
+@testing.with_requires('scipy')
+class TestMapCoordinatesHalfInteger:
+
+    def _map_coordinates(self, xp, scp, a, coordinates):
+        _conditional_scipy_version_skip(self.mode, self.order)
+        map_coordinates = scp.ndimage.map_coordinates
+        return map_coordinates(a, coordinates, None, self.order, self.mode)
+
+    @testing.for_float_dtypes(no_float16=True)
+    @testing.numpy_cupy_allclose(atol=1e-4, scipy_name='scp')
+    def test_map_coordinates_float(self, xp, scp, dtype):
+        # Half integer coordinate rounding test case from:
+        # https://github.com/cupy/cupy/issues/4550
+        a = testing.shaped_arange((4, 3), xp, dtype)
+        coordinates = xp.array([[0.5, 2], [0.5, 1]])
+        return self._map_coordinates(xp, scp, a, coordinates)
+
+
+@testing.parameterize(*testing.product({
     'matrix_shape': [(2,), (2, 2), (2, 3), (3, 3)],
     'offset': [0.3, [-1.3, 1.3]],
     'output_shape': [None],


### PR DESCRIPTION
This PR fixes a bug in `cupyx.scipy.ndimage.zoom` when the output has any dimension of size 1 and `grid_mode=True`. The purpose of the modified code section was just to prevent any potential divide by zero when calculating the zoom factors.

This PR is built on top of #4552, otherwise the order=0 test cases added here would fail.