### PR TITLE
[backport] ndimage: coordinate rounding fix for order=0 interpolation

### DIFF
--- a/cupyx/scipy/ndimage/_interp_kernels.py
+++ b/cupyx/scipy/ndimage/_interp_kernels.py
@@ -243,7 +243,7 @@ def _generate_interp_custom(coord_func, ndim, large_int, yshape, mode, cval,
         for j in range(ndim):
             # determine nearest neighbor
             ops.append("""
-            {int_t} cf_{j} = ({int_t})floor((double)c_{j} + 0.5);''')
+            {int_t} cf_{j} = ({int_t})floor((double)c_{j} + 0.5);
             """.format(int_t=int_t, j=j))
 
             # handle boundary

--- a/cupyx/scipy/ndimage/_interp_kernels.py
+++ b/cupyx/scipy/ndimage/_interp_kernels.py
@@ -243,7 +243,7 @@ def _generate_interp_custom(coord_func, ndim, large_int, yshape, mode, cval,
         for j in range(ndim):
             # determine nearest neighbor
             ops.append("""
-            {int_t} cf_{j} = ({int_t})lrint((double)c_{j});
+            {int_t} cf_{j} = ({int_t})floor((double)c_{j} + 0.5);''')
             """.format(int_t=int_t, j=j))
 
             # handle boundary

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
@@ -89,15 +89,14 @@ class TestMapCoordinates(unittest.TestCase):
 
 
 @testing.parameterize(*testing.product({
-    'order': [0, 1, 2, 3, 4, 5],
-    'mode': ['constant', 'nearest', 'mirror'] + scipy16_modes,
+    'order': [0, 1],
+    'mode': ['constant', 'nearest', 'mirror'],
 }))
 @testing.gpu
 @testing.with_requires('scipy')
-class TestMapCoordinatesHalfInteger:
+class TestMapCoordinatesHalfInteger(unittest.TestCase):
 
     def _map_coordinates(self, xp, scp, a, coordinates):
-        _conditional_scipy_version_skip(self.mode, self.order)
         map_coordinates = scp.ndimage.map_coordinates
         return map_coordinates(a, coordinates, None, self.order, self.mode)
 


### PR DESCRIPTION
Backport of #4552