### PR TITLE
[backport] Fix `cupy.array` from nested list of zero-dim ndarray

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -2069,9 +2069,9 @@ cpdef ndarray array(obj, dtype=None, bint copy=True, order='K',
         # obj is Seq[cupy.ndarray]
         assert issubclass(elem_type, ndarray), elem_type
         lst = _flatten_list(obj)
-        if len(shape) == 1:
-            # convert each scalar (0-dim) ndarray to 1-dim
-            lst = [cupy.expand_dims(x, 0) for x in lst]
+
+        # convert each scalar (0-dim) ndarray to 1-dim
+        lst = [cupy.expand_dims(x, 0) if x.ndim == 0 else x for x in lst]
 
         a =_manipulation.concatenate_method(lst, 0)
         a = a.reshape(shape)

--- a/tests/cupy_tests/creation_tests/test_from_data.py
+++ b/tests/cupy_tests/creation_tests/test_from_data.py
@@ -158,6 +158,15 @@ class TestFromData(unittest.TestCase):
     @testing.for_orders('CFAK')
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
+    def test_array_from_nested_list_of_cupy_scalar(self, xp, dtype, order):
+        # compares numpy.array(<list of numpy.ndarray>) with
+        # cupy.array(<list of cupy.ndarray>)
+        a = [[xp.array(i, dtype=dtype)] for i in range(2)]
+        return xp.array(a, order=order)
+
+    @testing.for_orders('CFAK')
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
     def test_array_copy(self, xp, dtype, order):
         a = testing.shaped_arange((2, 3, 4), xp, dtype)
         return xp.array(a, order=order)


### PR DESCRIPTION
Backport of #4569