### PR TITLE
[backport] CUDA 11.2: Fix empty NVRTC program name

### DIFF
--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -306,7 +306,7 @@ def _preprocess(source, options, arch, backend):
     if backend == 'nvrtc':
         options += ('-arch=compute_{}'.format(arch),)
 
-        prog = _NVRTCProgram(source, '')
+        prog = _NVRTCProgram(source)
         try:
             result, _ = prog.compile(options)
         except CompileException as e:

--- a/cupy_backends/cuda/libs/nvrtc.pyx
+++ b/cupy_backends/cuda/libs/nvrtc.pyx
@@ -76,7 +76,11 @@ cpdef intptr_t createProgram(unicode src, unicode name, headers,
     cdef bytes b_src = src.encode()
     cdef const char* src_ptr = b_src
     cdef bytes b_name = name.encode()
-    cdef const char* name_ptr = b_name
+    cdef const char* name_ptr
+    if len(name) > 0:
+        name_ptr = b_name
+    else:
+        name_ptr = NULL
     cdef int num_headers = len(headers)
     cdef vector.vector[const char*] header_vec
     cdef vector.vector[const char*] include_name_vec


### PR DESCRIPTION
Backport of #4538