### PR TITLE
[backport] Avoid test discovery failure in NumPy 1.20

### DIFF
--- a/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
@@ -308,7 +308,7 @@ class TestArrayAdvancedIndexingOverflow(unittest.TestCase):
     {'shape': (0,), 'indexes': numpy.array([False, True, True])},
     {'shape': (0, 1), 'indexes': (0, Ellipsis)},
     {'shape': (2, 3), 'indexes': (slice(None), [1, 2], slice(None))},
-    {'shape': (2, 3), 'indexes': numpy.array([], dtype=numpy.float)},
+    {'shape': (2, 3), 'indexes': numpy.array([], dtype=numpy.float64)},
 )
 @testing.gpu
 class TestArrayInvalidIndexAdvGetitem(unittest.TestCase):

--- a/tests/cupy_tests/logic_tests/test_type_test.py
+++ b/tests/cupy_tests/logic_tests/test_type_test.py
@@ -19,7 +19,8 @@ class TestIsScalar(testing.NumpyAliasBasicTestBase):
         'value': [
             0, 0.0, True,
             numpy.int32(1), numpy.array([1, 2], numpy.int32),
-            numpy.complex(1), numpy.complex(1j), numpy.complex(1 + 1j),
+            numpy.complex128(1), numpy.complex128(1j),
+            numpy.complex128(1 + 1j),
             None, object(), 'abc', '', int, numpy.int32]}))
 class TestIsScalarValues(testing.NumpyAliasValuesTestBase):
 

--- a/tests/cupy_tests/math_tests/test_arithmetic.py
+++ b/tests/cupy_tests/math_tests/test_arithmetic.py
@@ -9,7 +9,7 @@ from cupy import testing
 
 
 float_types = [numpy.float16, numpy.float32, numpy.float64]
-complex_types = [numpy.complex, numpy.complex64, numpy.complex128]
+complex_types = [numpy.complex64, numpy.complex128]
 signed_int_types = [numpy.int8, numpy.int16, numpy.int32, numpy.int64]
 unsigned_int_types = [numpy.uint8, numpy.uint16, numpy.uint32, numpy.uint64]
 int_types = signed_int_types + unsigned_int_types


### PR DESCRIPTION
Backport of #4598