### PR TITLE
Stop using deprecated type aliases

### DIFF
--- a/cupy/_statistics/histogram.py
+++ b/cupy/_statistics/histogram.py
@@ -227,7 +227,7 @@ def histogram(x, bins=10, range=None, weights=None, density=False):
                 # the CUB call and the correction later
                 assert isinstance(bin_edges, cupy.ndarray)
                 if numpy.issubdtype(x.dtype, numpy.integer):
-                    bin_type = numpy.float
+                    bin_type = float
                 else:
                     bin_type = numpy.result_type(bin_edges.dtype, x.dtype)
                     if (bin_type == numpy.float16 and

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1341,7 +1341,7 @@ cdef class ndarray:
             >>> import cupy
             >>> a = cupy.zeros((2,))
             >>> i = cupy.arange(10000) % 2
-            >>> v = cupy.arange(10000).astype(cupy.float)
+            >>> v = cupy.arange(10000).astype(cupy.float_)
             >>> a[i] = v
             >>> a  # doctest: +SKIP
             array([9150., 9151.])
@@ -1352,7 +1352,7 @@ cdef class ndarray:
             >>> import numpy
             >>> a_cpu = numpy.zeros((2,))
             >>> i_cpu = numpy.arange(10000) % 2
-            >>> v_cpu = numpy.arange(10000).astype(numpy.float)
+            >>> v_cpu = numpy.arange(10000).astype(numpy.float_)
             >>> a_cpu[i_cpu] = v_cpu
             >>> a_cpu
             array([9998., 9999.])

--- a/cupyx/scipy/ndimage/measurements.py
+++ b/cupyx/scipy/ndimage/measurements.py
@@ -655,7 +655,7 @@ def _select(input, labels=None, index=None, find_min=False, find_max=False,
         found = unique_labels[idxs] == index
     else:
         # Labels are an integer type, and there aren't too many
-        idxs = cupy.asanyarray(index, cupy.int).copy()
+        idxs = cupy.asanyarray(index, int).copy()
         found = (idxs >= 0) & (idxs <= max_label)
 
     idxs[~found] = max_label + 1
@@ -720,9 +720,9 @@ def _select(input, labels=None, index=None, find_min=False, find_max=False,
         result += [maxpos[idxs]]
     if find_median:
         locs = cupy.arange(len(labels))
-        lo = cupy.zeros(int(labels.max()) + 2, cupy.int)
+        lo = cupy.zeros(int(labels.max()) + 2, int)
         lo[labels[min_index]] = locs[min_index]
-        hi = cupy.zeros(int(labels.max()) + 2, cupy.int)
+        hi = cupy.zeros(int(labels.max()) + 2, int)
         hi[labels[max_index]] = locs[max_index]
         lo = lo[idxs]
         hi = hi[idxs]

--- a/tests/cupy_tests/indexing_tests/test_insert.py
+++ b/tests/cupy_tests/indexing_tests/test_insert.py
@@ -42,7 +42,7 @@ class TestPlaceRaises(unittest.TestCase):
     def test_place_empty_value_error(self, dtype):
         for xp in (numpy, cupy):
             a = testing.shaped_arange(self.shape, xp, dtype)
-            mask = testing.shaped_arange(self.shape, xp, numpy.int) % 2 == 0
+            mask = testing.shaped_arange(self.shape, xp, int) % 2 == 0
             vals = testing.shaped_random((0,), xp, dtype)
             with pytest.raises(ValueError):
                 xp.place(a, mask, vals)

--- a/tests/cupy_tests/testing_tests/test_helper.py
+++ b/tests/cupy_tests/testing_tests/test_helper.py
@@ -30,7 +30,7 @@ class TestContainsSignedAndUnsigned(unittest.TestCase):
         kw = {'x': numpy.int32}
         assert not helper._contains_signed_and_unsigned(kw)
 
-        kw = {'x': numpy.float}
+        kw = {'x': numpy.float32}
         assert not helper._contains_signed_and_unsigned(kw)
 
     def test_unsigned_only(self):

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_index.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_index.py
@@ -231,7 +231,7 @@ class TestSetitemIndexing(unittest.TestCase):
         self._run([1, 5, 4], slice(5, 1, -1))
 
     def test_major_bool_fancy(self):
-        rand_bool = cupy.random.random(self.n_rows).astype(cupy.bool)
+        rand_bool = testing.shaped_random(self.n_rows, dtype=bool)
         self._run(rand_bool)
 
     def test_major_slice_with_step(self):


### PR DESCRIPTION
`np.float`, `np.int`, `np.bool` are deprecated since NumPy 1.20.