### PR TITLE
Make `normal` and `lognormal` support array args

### DIFF
--- a/cupy/random/_distributions.py
+++ b/cupy/random/_distributions.py
@@ -476,9 +476,8 @@ def multivariate_normal(mean, cov, size=None, check_valid='ignore',
     """
     _util.experimental('cupy.random.multivariate_normal')
     rs = _generator.get_random_state()
-    x = rs.multivariate_normal(mean, cov, size, check_valid, tol, method,
-                               dtype)
-    return x
+    return rs.multivariate_normal(
+        mean, cov, size, check_valid, tol, method, dtype)
 
 
 def normal(loc=0.0, scale=1.0, size=None, dtype=float):
@@ -526,8 +525,7 @@ def pareto(a, size=None, dtype=float):
     .. seealso:: :func:`numpy.random.pareto`
     """
     rs = _generator.get_random_state()
-    x = rs.pareto(a, size, dtype)
-    return x
+    return rs.pareto(a, size, dtype)
 
 
 def noncentral_chisquare(df, nonc, size=None, dtype=float):
@@ -613,8 +611,7 @@ def poisson(lam=1.0, size=None, dtype=int):
     .. seealso:: :func:`numpy.random.poisson`
     """
     rs = _generator.get_random_state()
-    x = rs.poisson(lam, size, dtype)
-    return x
+    return rs.poisson(lam, size, dtype)
 
 
 def power(a, size=None, dtype=float):
@@ -665,8 +662,7 @@ def rayleigh(scale=1.0, size=None, dtype=float):
     .. seealso:: :func:`numpy.random.rayleigh`
     """
     rs = _generator.get_random_state()
-    x = rs.rayleigh(scale, size, dtype)
-    return x
+    return rs.rayleigh(scale, size, dtype)
 
 
 def standard_cauchy(size=None, dtype=float):
@@ -690,8 +686,7 @@ def standard_cauchy(size=None, dtype=float):
     .. seealso:: :func:`numpy.random.standard_cauchy`
     """
     rs = _generator.get_random_state()
-    x = rs.standard_cauchy(size, dtype)
-    return x
+    return rs.standard_cauchy(size, dtype)
 
 
 def standard_exponential(size=None, dtype=float):

--- a/cupy/random/_distributions.py
+++ b/cupy/random/_distributions.py
@@ -1,4 +1,3 @@
-import cupy
 from cupy.random import _generator
 from cupy import _util
 

--- a/cupy/random/_distributions.py
+++ b/cupy/random/_distributions.py
@@ -500,13 +500,7 @@ def normal(loc=0.0, scale=1.0, size=None, dtype=float):
 
     """
     rs = _generator.get_random_state()
-    if size is None and any(isinstance(arg, cupy.ndarray)
-                            for arg in [scale, loc]):
-        size = cupy.broadcast_arrays(loc, scale)[0].shape
-    x = rs.normal(0, 1, size, dtype)
-    cupy.multiply(x, scale, out=x)
-    cupy.add(x, loc, out=x)
-    return x
+    return rs.normal(loc, scale, size, dtype)
 
 
 def pareto(a, size=None, dtype=float):
@@ -766,7 +760,8 @@ def standard_normal(size=None, dtype=float):
     .. seealso:: :func:`numpy.random.standard_normal`
 
     """
-    return normal(size=size, dtype=dtype)
+    rs = _generator.get_random_state()
+    return rs.standard_normal(size, dtype)
 
 
 def standard_t(df, size=None, dtype=float):

--- a/cupy/random/_generator.py
+++ b/cupy/random/_generator.py
@@ -75,7 +75,7 @@ class RandomState(object):
         # * curand.generateLogNormal
         # * curand.generateLogNormalDouble
         size = core.get_size(size)
-        element_size = functools.reduce(operator.mul, size, 1)
+        element_size = core.internal.prod(size)
         if element_size % 2 == 0:
             out = cupy.empty(size, dtype=dtype)
             func(self._generator, out.data.ptr, out.size, *args)

--- a/tests/cupy_tests/random_tests/test_distributions.py
+++ b/tests/cupy_tests/random_tests/test_distributions.py
@@ -282,9 +282,9 @@ class TestDistributionsLogistic(RandomDistributionsTestCase):
 
 
 @testing.parameterize(*testing.product({
-    'shape': [(4, 3, 2), (3, 2)],
-    'mean_shape': [()],
-    'sigma_shape': [()],
+    'shape': [(4, 3, 2), (3, 2), None],
+    'mean_shape': [(), (3, 2)],
+    'sigma_shape': [(), (3, 2)],
 })
 )
 @testing.gpu
@@ -612,7 +612,7 @@ class TestDistributionsStandardGamma(RandomDistributionsTestCase):
 
 
 @testing.parameterize(*testing.product({
-    'shape': [(4, 3, 2), (3, 2)],
+    'shape': [(4, 3, 2), (3, 2), None],
 })
 )
 @testing.gpu


### PR DESCRIPTION
- `cupy.random.RandomState.normal`
- `cupy.random.lognormal`
- `cupy.random.RandomState.lognormal`

were broken.

Fix #4613.
