### PR TITLE
Improve floating point accuracy in percentile

### DIFF
--- a/cupy/_statistics/order.py
+++ b/cupy/_statistics/order.py
@@ -245,10 +245,17 @@ def _quantile_unchecked(a, q, axis=None, out=None, interpolation='linear',
             ptrdiff_t idx_below = floor(idx);
             U weight_above = idx - idx_below;
 
-            ptrdiff_t offset_i = _ind.get()[0] * offset;
             ptrdiff_t max_idx = size - 1;
-            ret = a[offset_i + idx_below] * (1.0 - weight_above)
-              + a[min(offset_i + idx_below + 1, max_idx)] * weight_above;
+            ptrdiff_t offset_bottom = _ind.get()[0] * offset + idx_below;
+            ptrdiff_t offset_top = min(offset_bottom + 1, max_idx);
+
+            U diff = a[offset_top] - a[offset_bottom];
+
+            if (weight_above < 0.5) {
+                ret = a[offset_bottom] + diff * weight_above;
+            } else {
+                ret = a[offset_top] - diff * (1 - weight_above);
+            }
             ''',
             'percentile_weightnening'
         )(indices, ap, ap.shape[-1] if ap.ndim > 1 else 0, ap.size, ret)

--- a/setup.py
+++ b/setup.py
@@ -40,9 +40,6 @@ requirements = {
     'test': [
         # 4.2 <= pytest < 6.2 is slow collecting tests and times out on CI.
         'pytest>=6.2',
-        # numpy < 1.20 demonstrates non-monotonic output in percentile results
-        # that disrupts the cupy monotonicity test. See gh-4607.
-        'numpy>=1.20',
     ],
     'doctest': [
         'matplotlib',

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,9 @@ requirements = {
     'test': [
         # 4.2 <= pytest < 6.2 is slow collecting tests and times out on CI.
         'pytest>=6.2',
+        # numpy < 1.20 demonstrates non-monotonic output in percentile results
+        # that disrupts the cupy monotonicity test. See gh-4607.
+        'numpy>=1.20',
     ],
     'doctest': [
         'matplotlib',

--- a/tests/cupy_tests/statistics_tests/test_order.py
+++ b/tests/cupy_tests/statistics_tests/test_order.py
@@ -394,6 +394,7 @@ class TestOrder(unittest.TestCase):
 @testing.gpu
 class TestPercentileMonotonic(unittest.TestCase):
 
+    @testing.with_requires('numpy>=1.20')
     @testing.for_float_dtypes(no_float16=True)
     @testing.numpy_cupy_allclose()
     def test_percentile_monotonic(self, dtype, xp):


### PR DESCRIPTION
Improve the floating point accuracy of the linear interpolation formula used in `percentile_weightnening` kernel of `cupy.percentile`
Resolve #4607