### PR TITLE
Always run cythonize on sdist installation

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,8 +1,8 @@
 # Contents of sdist. See also `setup.py`.
 recursive-include cupy *.h *.hpp
-recursive-exclude cupy *.pyx *.pxd *.pxi
+recursive-include cupy *.pyx *.pxd *.pxi
 recursive-include cupy_backends *.h *.hpp
-recursive-exclude cupy_backends *.pyx *.pxd *.pxi
+recursive-include cupy_backends *.pyx *.pxd *.pxi
 include cupy_setup_build.py
 recursive-include install *.py
 recursive-include tests *.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,12 +3,17 @@ recursive-include cupy *.h *.hpp
 recursive-include cupy *.pyx *.pxd *.pxi
 recursive-include cupy_backends *.h *.hpp
 recursive-include cupy_backends *.pyx *.pxd *.pxi
+
+# Fail-safe to avoid including Cythoinzed sources in sdist.
+recursive-exclude cupy *.cpp
+recursive-exclude cupy_backends *.cpp
+
+# Installers
 include cupy_setup_build.py
 recursive-include install *.py
 recursive-include tests *.py
+
+# Licenses
 include LICENSE
 include docs/LICENSE_THIRD_PARTY
 include docs/source/license.rst
-include cupy/cuda/cupy_cufftXt.cu  # for cuFFT callback
-include cupy/cuda/cufft.pxd  # for cuFFT callback
-include cupy/cuda/cufft.pyx  # for cuFFT callback

--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -13,7 +13,6 @@ import sys
 import pkg_resources
 import setuptools
 from setuptools.command import build_ext
-from setuptools.command import sdist
 
 from install import build
 from install.build import PLATFORM_LINUX
@@ -1092,18 +1091,6 @@ class _MSVCCompiler(msvccompiler.MSVCCompiler):
 
         # Return compiled object filenames.
         return other_objects + cu_objects
-
-
-class sdist_with_cython(sdist.sdist):
-
-    """Custom `sdist` command with cyhonizing."""
-
-    def __init__(self, *args, **kwargs):
-        if not cython_available:
-            raise RuntimeError('Cython is required to make sdist.')
-        ext_modules = get_ext_modules(True)  # get .pyx modules
-        cythonize(ext_modules, cupy_setup_options)
-        sdist.sdist.__init__(self, *args, **kwargs)
 
 
 class custom_build_ext(build_ext.build_ext):

--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -807,7 +807,8 @@ def cythonize(extensions, arg_options):
     cython_version = pkg_resources.parse_version(Cython.__version__)
     if (cython_version < required_cython_version or
             cython_version in ignore_cython_versions):
-        raise AssertionError('Unsupported Cython version: {}'.format(cython_version))
+        raise AssertionError(
+            'Unsupported Cython version: {}'.format(cython_version))
 
     directive_keys = ('linetrace', 'profile')
     directives = {key: arg_options[key] for key in directive_keys}

--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -807,7 +807,7 @@ def cythonize(extensions, arg_options):
     cython_version = pkg_resources.parse_version(Cython.__version__)
     if (cython_version < required_cython_version or
             cython_version in ignore_cython_versions):
-        raise AssertionError('Unsupported Cython version')
+        raise AssertionError('Unsupported Cython version: {}'.format(cython_version))
 
     directive_keys = ('linetrace', 'profile')
     directives = {key: arg_options[key] for key in directive_keys}

--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -19,6 +19,8 @@ from install.build import PLATFORM_LINUX
 from install.build import PLATFORM_WIN32
 
 
+# Cython requirements (minimum version and versions known to be broken).
+# Note: this must be in sync with setup_requires defined in setup.py.
 required_cython_version = pkg_resources.parse_version('0.28.0')
 ignore_cython_versions = [
 ]
@@ -365,14 +367,7 @@ def module_extension_name(file):
 def module_extension_sources(file, use_cython, no_cuda):
     pyx, others = ensure_module_file(file)
     base = path.join(*pyx.split('.'))
-    if use_cython:
-        pyx = base + '.pyx'
-        if not os.path.exists(pyx):
-            use_cython = False
-            print(
-                'NOTICE: Skipping cythonize as {} does not exist.'.format(pyx))
-    if not use_cython:
-        pyx = base + '.cpp'
+    pyx = base + ('.pyx' if use_cython else '.cpp')
 
     # If CUDA SDK is not available, remove CUDA C files from extension sources
     # and use stubs defined in header files.
@@ -804,18 +799,16 @@ def prepare_wheel_libs():
     return [os.path.relpath(x[1], 'cupy') for x in files_to_copy]
 
 
-try:
+def cythonize(extensions, arg_options):
+    # Delay importing Cython as it may be installed via setup_requires if
+    # the user does not have Cython installed.
     import Cython
     import Cython.Build
     cython_version = pkg_resources.parse_version(Cython.__version__)
-    cython_available = (
-        cython_version >= required_cython_version and
-        cython_version not in ignore_cython_versions)
-except ImportError:
-    cython_available = False
+    if (cython_version < required_cython_version or
+            cython_version in ignore_cython_versions):
+        raise AssertionError('Unsupported Cython version')
 
-
-def cythonize(extensions, arg_options):
     directive_keys = ('linetrace', 'profile')
     directives = {key: arg_options[key] for key in directive_keys}
 
@@ -1116,9 +1109,8 @@ class custom_build_ext(build_ext.build_ext):
             # Intentionally causes DistutilsPlatformError in
             # ccompiler.new_compiler() function to hook.
             self.compiler = 'nvidia'
-        if cython_available:
-            ext_modules = get_ext_modules(True)  # get .pyx modules
-            cythonize(ext_modules, cupy_setup_options)
+        ext_modules = get_ext_modules(True)  # get .pyx modules
+        cythonize(ext_modules, cupy_setup_options)
         check_extensions(self.extensions)
         build_ext.build_ext.run(self)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "Cython>=0.28.0", "fastrlock>=0.5"]

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,6 +1,6 @@
-name: chainer
+name: cupy
 type: sphinx
 base: docs/source
 requirements_file: docs/requirements.txt
 python:
-  setup_py_install: true
+  pip_install: true

--- a/setup.py
+++ b/setup.py
@@ -24,10 +24,13 @@ for submodule in ('cupy/core/include/cupy/cub/',
 
 
 requirements = {
+    # setup_requires remains here for pip v18 or earlier.
+    # Keep in sync with pyproject.yaml.
     'setup': [
         'Cython>=0.28.0',
         'fastrlock>=0.5',
     ],
+
     'install': [
         'numpy>=1.17',
         'fastrlock>=0.5',

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ for submodule in ('cupy/core/include/cupy/cub/',
 
 requirements = {
     'setup': [
+        'Cython>=0.28.0',
         'fastrlock>=0.5',
     ],
     'install': [

--- a/setup.py
+++ b/setup.py
@@ -117,7 +117,6 @@ package_name = cupy_setup_build.get_package_name()
 long_description = cupy_setup_build.get_long_description()
 ext_modules = cupy_setup_build.get_ext_modules()
 build_ext = cupy_setup_build.custom_build_ext
-sdist = cupy_setup_build.sdist_with_cython
 
 here = os.path.abspath(os.path.dirname(__file__))
 # Get __version__ variable
@@ -167,6 +166,5 @@ setup(
     tests_require=tests_require,
     extras_require=extras_require,
     ext_modules=ext_modules,
-    cmdclass={'build_ext': build_ext,
-              'sdist': sdist},
+    cmdclass={'build_ext': build_ext},
 )


### PR DESCRIPTION
This PR removes C++ sources from sdist and changes the CuPy installer to always run cythonize at user-side.
Cython will automatically (temporarily) be downloaded by setuptools via `setup_requires` configuration.

The primary motivation for this is to use compile-time constants in the code appropriately (closes #4597).
Besides that, cythonize at user-side  is also needed for #4395 which generates pyx during the installation.