### PR TITLE
[backport] Deprecate passing shape=None to mean shape=()

### DIFF
--- a/cupy/core/internal.pyx
+++ b/cupy/core/internal.pyx
@@ -6,6 +6,7 @@ from libcpp cimport bool as cpp_bool
 from libc.stdint cimport uint32_t
 
 import sys
+import warnings
 
 import numpy
 
@@ -48,6 +49,11 @@ cpdef inline bint is_in(const vector.vector[Py_ssize_t]& args, Py_ssize_t x):
 @cython.profile(False)
 cpdef inline tuple get_size(object size):
     if size is None:
+        warnings.warn(
+            'Passing None into shape arguments as an alias for () is '
+            'deprecated.',
+            DeprecationWarning,
+        )
         return ()
     if cpython.PySequence_Check(size):
         return tuple(size)

--- a/cupy/random/_generator.py
+++ b/cupy/random/_generator.py
@@ -74,6 +74,8 @@ class RandomState(object):
         # * curand.generateNormalDouble
         # * curand.generateLogNormal
         # * curand.generateLogNormalDouble
+        if size is None:
+            size = ()  # TODO(kataoka): Remove this after #4615 is merged
         size = core.get_size(size)
         element_size = functools.reduce(operator.mul, size, 1)
         if element_size % 2 == 0:
@@ -576,6 +578,8 @@ class RandomState(object):
 
     def _random_sample_raw(self, size, dtype):
         dtype = _check_and_get_dtype(dtype)
+        if size is None:
+            size = ()  # TODO(kataoka): Remove this after #4615 is merged
         out = cupy.empty(size, dtype=dtype)
         if dtype.char == 'f':
             func = curand.generateUniform

--- a/tests/cupy_tests/core_tests/test_internal.py
+++ b/tests/cupy_tests/core_tests/test_internal.py
@@ -1,6 +1,7 @@
 import math
-
 import unittest
+
+import pytest
 
 from cupy.core import internal
 from cupy import testing
@@ -33,7 +34,8 @@ class TestProdSequence(unittest.TestCase):
 class TestGetSize(unittest.TestCase):
 
     def test_none(self):
-        assert internal.get_size(None) == ()
+        with testing.assert_warns(DeprecationWarning):
+            assert internal.get_size(None) == ()
 
     def check_collection(self, a):
         assert internal.get_size(a) == tuple(a)
@@ -47,8 +49,8 @@ class TestGetSize(unittest.TestCase):
     def test_int(self):
         assert internal.get_size(1) == (1,)
 
-    def test_invalid(self):
-        with self.assertRaises(ValueError):
+    def test_float(self):
+        with pytest.raises(ValueError):
             internal.get_size(1.0)
 
 

--- a/tests/cupy_tests/core_tests/test_ndarray.py
+++ b/tests/cupy_tests/core_tests/test_ndarray.py
@@ -12,28 +12,6 @@ from cupy import get_array_module
 from cupy import testing
 
 
-class TestGetSize(unittest.TestCase):
-
-    def test_none(self):
-        assert core.get_size(None) == ()
-
-    def check_collection(self, a):
-        assert core.get_size(a) == tuple(a)
-
-    def test_list(self):
-        self.check_collection([1, 2, 3])
-
-    def test_tuple(self):
-        self.check_collection((1, 2, 3))
-
-    def test_int(self):
-        assert core.get_size(1) == (1,)
-
-    def test_float(self):
-        with pytest.raises(ValueError):
-            core.get_size(1.0)
-
-
 def wrap_take(array, *args, **kwargs):
     if get_array_module(array) == numpy:
         kwargs['mode'] = 'wrap'
@@ -45,7 +23,8 @@ def wrap_take(array, *args, **kwargs):
 class TestNdarrayInit(unittest.TestCase):
 
     def test_shape_none(self):
-        a = cupy.ndarray(None)
+        with testing.assert_warns(DeprecationWarning):
+            a = cupy.ndarray(None)
         assert a.shape == ()
 
     def test_shape_int(self):

--- a/tests/cupy_tests/creation_tests/test_basic.py
+++ b/tests/cupy_tests/creation_tests/test_basic.py
@@ -39,7 +39,17 @@ class TestBasic(unittest.TestCase):
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_empty_scalar(self, xp, dtype, order):
-        a = xp.empty(None, dtype=dtype, order=order)
+        a = xp.empty((), dtype=dtype, order=order)
+        a.fill(0)
+        return a
+
+    @testing.with_requires('numpy>=1.20')
+    @testing.for_CF_orders()
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_empty_scalar_none(self, xp, dtype, order):
+        with testing.assert_warns(DeprecationWarning):
+            a = xp.empty(None, dtype=dtype, order=order)
         a.fill(0)
         return a
 
@@ -183,7 +193,15 @@ class TestBasic(unittest.TestCase):
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_zeros_scalar(self, xp, dtype, order):
-        return xp.zeros(None, dtype=dtype, order=order)
+        return xp.zeros((), dtype=dtype, order=order)
+
+    @testing.with_requires('numpy>=1.20')
+    @testing.for_CF_orders()
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_zeros_scalar_none(self, xp, dtype, order):
+        with testing.assert_warns(DeprecationWarning):
+            return xp.zeros(None, dtype=dtype, order=order)
 
     @testing.for_CF_orders()
     @testing.for_all_dtypes()

--- a/tests/cupy_tests/random_tests/test_generator.py
+++ b/tests/cupy_tests/random_tests/test_generator.py
@@ -7,7 +7,6 @@ import numpy
 import pytest
 
 import cupy
-from cupy import core
 from cupy import cuda
 from cupy.random import _generator
 from cupy import testing
@@ -76,6 +75,14 @@ def two_sample_Kolmogorov_Smirnov_test(observed1, observed2):
     # Approximate p = special.kolmogorov(d * numpy.sqrt(n1 * n2 / (n1 + n2)))
     p = min(1.0, 2.0 * numpy.exp(-2.0 * d**2 * n1 * n2 / (n1 + n2)))
     return d_plus, d_minus, p
+
+
+def _get_size(size):
+    # CuPy returns an ndarray of shape () even if size=None.
+    # cf. NumPy returns a Python scalar if size=None.
+    if size is None:
+        return ()
+    return cupy.core.get_size(size)
 
 
 class RandomGeneratorTestCase(unittest.TestCase):
@@ -497,7 +504,7 @@ class TestLogNormal(RandomGeneratorTestCase):
         vals = self.generate_many(
             self.args[0], self.args[1], self.size, dtype, _count=10)
 
-        shape = core.get_size(self.size)
+        shape = _get_size(self.size)
         for val in vals:
             assert isinstance(val, cupy.ndarray)
             assert val.dtype == dtype
@@ -558,7 +565,7 @@ class TestMultivariateNormal(RandomGeneratorTestCase):
             mean=self.args[0], cov=self.args[1], size=self.size, tol=self.tol,
             dtype=dtype, _count=10)
 
-        shape = core.get_size(self.size)
+        shape = _get_size(self.size)
         for val in vals:
             assert isinstance(val, cupy.ndarray)
             assert val.dtype == dtype
@@ -647,7 +654,7 @@ class TestNormal(RandomGeneratorTestCase):
         vals = self.generate_many(
             self.args[0], self.args[1], self.size, dtype, _count=10)
 
-        shape = core.get_size(self.size)
+        shape = _get_size(self.size)
         for val in vals:
             assert isinstance(val, cupy.ndarray)
             assert val.dtype == dtype
@@ -742,7 +749,7 @@ class TestRandomSample(unittest.TestCase):
     def check_random_sample(self, dtype):
         vals = [self.rs.random_sample(self.size, dtype) for _ in range(10)]
 
-        shape = core.get_size(self.size)
+        shape = _get_size(self.size)
         for val in vals:
             assert isinstance(val, cupy.ndarray)
             assert val.dtype == dtype


### PR DESCRIPTION
Backport of #4616