### PR TITLE
[backport] Stop using deprecated `numpy.complex`

### DIFF
--- a/cupyx/scipy/fftpack/_fft.py
+++ b/cupyx/scipy/fftpack/_fft.py
@@ -42,7 +42,7 @@ def get_fft_plan(a, shape=None, axes=None, value_type='C2C'):
 
         .. code-block:: python
 
-            x = cupy.random.random(16).reshape(4, 4).astype(cupy.complex)
+            x = cupy.random.random(16).reshape(4, 4).astype(complex)
             plan = cupyx.scipy.fftpack.get_fft_plan(x)
             with plan:
                 y = cupy.fft.fftn(x)

--- a/tests/cupy_tests/math_tests/test_arithmetic.py
+++ b/tests/cupy_tests/math_tests/test_arithmetic.py
@@ -86,9 +86,9 @@ class TestArithmeticUnary(unittest.TestCase):
 
             # TODO(niboshi): Fix this
             # numpy.real and numpy.imag return Python int if the input is
-            # Python bool. CuPy should return an array of dtype.int32 or
-            # dtype.int64 (depending on the platform) in such cases, instead
-            # of an array of dtype.bool.
+            # Python bool. CuPy should return an array of dtype=int32 or
+            # dtype=int64 (depending on the platform) in such cases, instead
+            # of an array of dtype=bool.
             if xp is cupy and isinstance(arg1, bool):
                 y = y.astype(int)
 

--- a/tests/cupy_tests/statics_tests/test_histogram.py
+++ b/tests/cupy_tests/statics_tests/test_histogram.py
@@ -456,8 +456,8 @@ class TestDigitizeInvalid(unittest.TestCase):
 
     def test_digitize_complex(self):
         for xp in (numpy, cupy):
-            x = testing.shaped_arange((14,), xp, xp.complex)
-            bins = xp.array([1.0, 3.0, 5.0, 8.0, 12.0], xp.complex)
+            x = testing.shaped_arange((14,), xp, complex)
+            bins = xp.array([1.0, 3.0, 5.0, 8.0, 12.0], complex)
             with pytest.raises(TypeError):
                 xp.digitize(x, bins)
 


### PR DESCRIPTION
Backport of #4620