### PR TITLE
Update install requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,9 +28,14 @@ requirements = {
         'fastrlock>=0.3',
     ],
     'install': [
-        'numpy>=1.15',
+        'numpy>=1.17',
         'fastrlock>=0.3',
     ],
+    'all': [
+        'scipy>=1.4',
+        'optuna>=2.0',
+    ],
+
     'stylecheck': [
         'autopep8==1.4.4',
         'flake8==3.7.9',


### PR DESCRIPTION
- Update NumPy requirement. (Actually this had to be done when we decided to drop NumPy 1.16 or earlier in v9 releases)
- Add `all` extra specifier to install all optional dependencies

c.f. https://docs.cupy.dev/en/latest/install.html#python-dependencies