### PR TITLE
Use `CodeBlock` to generate human-readable code in JIT

### DIFF
--- a/cupy/core/_fusion_interface.py
+++ b/cupy/core/_fusion_interface.py
@@ -2,12 +2,11 @@ import numpy
 
 from cupy.core._dtype import get_dtype
 import cupy
-from cupy.core import _fusion_emit_code
 from cupy.core import _fusion_thread_local
 from cupy.core import core
+from cupyx.jit._types import dtype_to_ctype
 
 
-_dtype_to_ctype = _fusion_emit_code._dtype_to_ctype
 _thread_local = _fusion_thread_local.thread_local
 
 
@@ -29,7 +28,7 @@ def _set_dtype_to_astype_dict():
     for t in dtype_list:
         name = 'astype_{}'.format(t)
         rules = tuple(['{}->{}'.format(s.char, t.char) for s in dtype_list])
-        command = 'out0 = static_cast< {} >(in0)'.format(_dtype_to_ctype[t])
+        command = 'out0 = static_cast< {} >(in0)'.format(dtype_to_ctype[t])
         _dtype_to_astype_dict[t] = core.create_ufunc(name, rules, command)
 
 

--- a/cupy/core/_fusion_interface.py
+++ b/cupy/core/_fusion_interface.py
@@ -4,7 +4,7 @@ from cupy.core._dtype import get_dtype
 import cupy
 from cupy.core import _fusion_thread_local
 from cupy.core import core
-from cupyx.jit._types import dtype_to_ctype
+from cupy.core._scalar import get_typename
 
 
 _thread_local = _fusion_thread_local.thread_local
@@ -28,7 +28,7 @@ def _set_dtype_to_astype_dict():
     for t in dtype_list:
         name = 'astype_{}'.format(t)
         rules = tuple(['{}->{}'.format(s.char, t.char) for s in dtype_list])
-        command = 'out0 = static_cast< {} >(in0)'.format(dtype_to_ctype[t])
+        command = 'out0 = static_cast< {} >(in0)'.format(get_typename(t))
         _dtype_to_astype_dict[t] = core.create_ufunc(name, rules, command)
 
 

--- a/cupy/core/_fusion_kernel.pyx
+++ b/cupy/core/_fusion_kernel.pyx
@@ -17,12 +17,12 @@ from cupy.core cimport _reduction
 
 from cupy.core import _dtype
 from cupy import _util
-from cupy.core import _fusion_emit_code
 from cupy.core import _fusion_op
 from cupy.core._fusion_variable import _AbstractDim
 from cupy.core._fusion_variable import _TraceVariable
 from cupy.core._fusion_variable import _TraceScalar
 from cupy.core._fusion_variable import _TraceArray
+from cupyx.jit import _codeblock
 
 
 cdef Py_ssize_t _default_block_size = (
@@ -106,7 +106,7 @@ cdef class FusedKernel:
             codes.append(op.emit_code())
 
         self._submodule_code = submodule_code
-        self._cuda_body = str(_fusion_emit_code._CodeBlock('', codes))
+        self._cuda_body = str(_codeblock.CodeBlock('', codes))
 
         # Check the format of the return value.
         if return_size == 'none':

--- a/cupy/core/_fusion_op.py
+++ b/cupy/core/_fusion_op.py
@@ -8,7 +8,7 @@ from cupy.core._fusion_variable import _VariableSet
 from cupy.core import _fusion_thread_local
 from cupy.core import _kernel
 from cupy.core import _reduction
-from cupyx.jit._types import dtype_to_ctype
+from cupy.core._scalar import get_typename
 from cupyx.jit import _codeblock
 
 
@@ -57,11 +57,11 @@ class _UfuncRoutine:
         dtypes = self.compute_dtypes
         assert len(self.in_params) == len(self.compute_dtypes[:nin])
         in_params = [
-            (dtype_to_ctype[p.dtype], dtype_to_ctype[t], 'in{}'.format(i))
+            (get_typename(p.dtype), get_typename(t), 'in{}'.format(i))
             for i, (p, t) in enumerate(zip(self.in_params, dtypes[:nin]))
         ]
         out_params = [
-            (dtype_to_ctype[p.dtype], dtype_to_ctype[t], 'out{}'.format(i))
+            (get_typename(p.dtype), get_typename(t), 'out{}'.format(i))
             for i, (p, t) in enumerate(zip(self.out_params, dtypes[nin:]))
         ]
         params = in_params + out_params
@@ -217,7 +217,7 @@ class _ReductionTraceOp:
         _, self.expr, self.postmap_cast_code, self.reduce_ctype = expr
         if self.reduce_ctype is None:
             out_param, = self.out_params
-            self.reduce_ctype = dtype_to_ctype[out_param.dtype]
+            self.reduce_ctype = get_typename(out_param.dtype)
 
         self.premap_op = None
         self.postmap_op = None
@@ -305,8 +305,8 @@ __device__ void ${name}(
             name=self.name,
             op_name=op_name,
             postmap_name=postmap_name,
-            in_type=dtype_to_ctype[in_param.dtype],
-            out_type=dtype_to_ctype[out_param.dtype],
+            in_type=get_typename(in_param.dtype),
+            out_type=get_typename(out_param.dtype),
             reduce_ctype=self.reduce_ctype,
             reduce_expr=self.expr,
             identity=self.identity,

--- a/cupy/core/_fusion_variable.pyx
+++ b/cupy/core/_fusion_variable.pyx
@@ -2,8 +2,8 @@ import string
 
 import numpy
 
-from cupy.core._fusion_emit_code import _dtype_to_ctype
 from cupy.core import _fusion_interface
+from cupyx.jit._types import dtype_to_ctype
 
 
 cdef class _AbstractDim:
@@ -143,11 +143,11 @@ class _TraceVariable:
         """Returns a string following the format taken as an input.
         """
         kwargs = dict([
-            (k, _dtype_to_ctype[v] if isinstance(v, numpy.dtype) else v)
+            (k, dtype_to_ctype[v] if isinstance(v, numpy.dtype) else v)
             for k, v in kwargs.items()]
         )
         return string.Template(form).substitute(
-            type=_dtype_to_ctype[self.dtype],
+            type=dtype_to_ctype[self.dtype],
             var=self.var_name,
             lvar=self.lvar_name,
             indexer=self.indexer_name,
@@ -185,7 +185,7 @@ class _TraceScalar(_TraceVariable):
             return str(self.const_value).lower()
         if self.dtype.kind == 'c':
             return '{}({}, {})'.format(
-                _dtype_to_ctype[self.dtype],
+                dtype_to_ctype[self.dtype],
                 self.const_value.real,
                 self.const_value.imag)
         return str(self.const_value)

--- a/cupy/core/_fusion_variable.pyx
+++ b/cupy/core/_fusion_variable.pyx
@@ -3,7 +3,8 @@ import string
 import numpy
 
 from cupy.core import _fusion_interface
-from cupyx.jit._types import dtype_to_ctype
+
+from cupy.core._scalar cimport get_typename
 
 
 cdef class _AbstractDim:
@@ -143,11 +144,11 @@ class _TraceVariable:
         """Returns a string following the format taken as an input.
         """
         kwargs = dict([
-            (k, dtype_to_ctype[v] if isinstance(v, numpy.dtype) else v)
+            (k, get_typename(v) if isinstance(v, numpy.dtype) else v)
             for k, v in kwargs.items()]
         )
         return string.Template(form).substitute(
-            type=dtype_to_ctype[self.dtype],
+            type=get_typename(self.dtype),
             var=self.var_name,
             lvar=self.lvar_name,
             indexer=self.indexer_name,
@@ -185,7 +186,7 @@ class _TraceScalar(_TraceVariable):
             return str(self.const_value).lower()
         if self.dtype.kind == 'c':
             return '{}({}, {})'.format(
-                dtype_to_ctype[self.dtype],
+                get_typename(self.dtype),
                 self.const_value.real,
                 self.const_value.imag)
         return str(self.const_value)

--- a/cupyx/jit/_codeblock.py
+++ b/cupyx/jit/_codeblock.py
@@ -1,25 +1,4 @@
-import numpy
-
-
-_dtype_to_ctype = {
-    numpy.dtype('float64'): 'double',
-    numpy.dtype('float32'): 'float',
-    numpy.dtype('float16'): 'float16',
-    numpy.dtype('complex128'): 'complex<double>',
-    numpy.dtype('complex64'): 'complex<float>',
-    numpy.dtype('int64'): 'long long',
-    numpy.dtype('int32'): 'int',
-    numpy.dtype('int16'): 'short',
-    numpy.dtype('int8'): 'signed char',
-    numpy.dtype('uint64'): 'unsigned long long',
-    numpy.dtype('uint32'): 'unsigned int',
-    numpy.dtype('uint16'): 'unsigned short',
-    numpy.dtype('uint8'): 'unsigned char',
-    numpy.dtype('bool'): 'bool',
-}
-
-
-class _CodeBlock:
+class CodeBlock:
     """Code fragment for the readable format.
     """
 
@@ -34,7 +13,7 @@ class _CodeBlock:
             next_indent_width = indent_width + 2
             if isinstance(code, str):
                 codes.append(' ' * next_indent_width + code)
-            elif isinstance(code, _CodeBlock):
+            elif isinstance(code, CodeBlock):
                 codes += code._to_str_list(indent_width=next_indent_width)
             else:
                 assert False

--- a/cupyx/jit/_compile.py
+++ b/cupyx/jit/_compile.py
@@ -6,6 +6,7 @@ import warnings
 
 import numpy
 
+from cupyx.jit._codeblock import CodeBlock
 from cupy.core import _kernel
 from cupyx.jit import _types
 from cupyx.jit import _typerules
@@ -131,8 +132,10 @@ def _transpile_function(
         in_types (list of _types.TypeBase): The types of arguments.
         ret_type (_types.TypeBase): The type of return value.
 
-    Returns (str):
-        The generated CUDA code.
+    Returns:
+        code (str): The generated CUDA code.
+        env (Environment): More details of analysis result of the function,
+            which includes preambles, estimated return type and more.
     """
     if not isinstance(func, ast.FunctionDef):
         # TODO(asi1024): Support for `ast.ClassDef`.
@@ -161,11 +164,12 @@ def _transpile_function(
         dict([(k, Constant(v)) for k, v, in consts.items()]),
         dict([(x, CudaObject(x, t)) for x, t in zip(args, in_types)]),
         ret_type)
-    params = ', '.join([f'{env[a].ctype} {a}' for a in args])
     body = _transpile_stmts(func.body, env)
-    function_decl = f'{attributes} {env.ret_type} {func.name}({params})'
-    local_vars = _indent([f'{v.ctype} {n};' for n, v in env.locals.items()])
-    return '\n'.join([function_decl + ' {'] + local_vars + body + ['}']), env
+    params = ', '.join([f'{env[a].ctype} {a}' for a in args])
+    local_vars = [f'{v.ctype} {n};' for n, v in env.locals.items()]
+    head = f'{attributes} {env.ret_type} {func.name}({params})'
+    code = CodeBlock(head, local_vars + body)
+    return str(code), env
 
 
 def _eval_operand(op, args, env):
@@ -236,13 +240,16 @@ __device__ {out_type} {ufunc_name}({params}) {{
 
 
 def _transpile_stmts(stmts, env):
-    return _indent([_transpile_stmt(stmt, env) for stmt in stmts])
+    codeblocks = []
+    for stmt in stmts:
+        codeblocks.extend(_transpile_stmt(stmt, env))
+    return codeblocks
 
 
 def _transpile_stmt(stmt, env):
     """Transpile the statement.
 
-    Returns (str): The generated CUDA code.
+    Returns (list of [CodeBlock or str]): The generated CUDA code.
     """
 
     if isinstance(stmt, ast.ClassDef):
@@ -259,7 +266,7 @@ def _transpile_stmt(stmt, env):
         elif env.ret_type != t:
             raise ValueError(
                 f'Failed to infer the return type: {env.ret_type} or {t}')
-        return f'return {value.code};'
+        return [f'return {value.code};']
     if isinstance(stmt, ast.Delete):
         raise NotImplementedError('`del` is not supported currently.')
     if isinstance(stmt, ast.Assign):
@@ -274,7 +281,7 @@ def _transpile_stmt(stmt, env):
                 env[name] = CudaObject(target.id, value.ctype)
             elif env[name].ctype.dtype != value.ctype.dtype:
                 raise TypeError('dtype mismatch.')
-            return f'{target.id} = {value.code};'
+            return [f'{target.id} = {value.code};']
         raise NotImplementedError('Not implemented')
     if isinstance(stmt, ast.AugAssign):
         value = _transpile_expr(stmt.value, env)
@@ -285,7 +292,7 @@ def _transpile_stmt(stmt, env):
         if not numpy.can_cast(
                 result.ctype.dtype, target.ctype.dtype, 'same_kind'):
             raise TypeError('dtype mismatch')
-        return f'{target.code} = {result.code};'
+        return [f'{target.code} = {result.code};']
     if isinstance(stmt, ast.For):
         raise NotImplementedError('Not implemented.')
     if isinstance(stmt, ast.AsyncFor):
@@ -302,22 +309,22 @@ def _transpile_stmt(stmt, env):
         value = _transpile_expr(stmt.test, env)
         if is_constants([value]):
             assert value.obj
-            return ';'
+            return [';']
         else:
-            return 'assert(' + value + ');'
+            return ['assert(' + value + ');']
     if isinstance(stmt, (ast.Import, ast.ImportFrom)):
         raise ValueError('Cannot import modules from the target functions.')
     if isinstance(stmt, (ast.Global, ast.Nonlocal)):
         raise ValueError('Cannot use global/nonlocal in the target functions.')
     if isinstance(stmt, ast.Expr):
         value = _transpile_expr(stmt.value, env)
-        return ';' if is_constants([value]) else value + ';'
+        return [';'] if is_constants([value]) else [value + ';']
     if isinstance(stmt, ast.Pass):
-        return ';'
+        return [';']
     if isinstance(stmt, ast.Break):
-        return NotImplementedError('Not implemented.')
+        raise NotImplementedError('Not implemented.')
     if isinstance(stmt, ast.Continue):
-        return NotImplementedError('Not implemented.')
+        raise NotImplementedError('Not implemented.')
     assert False
 
 

--- a/cupyx/jit/_types.py
+++ b/cupyx/jit/_types.py
@@ -1,22 +1,5 @@
 import numpy
-
-
-dtype_to_ctype = {
-    numpy.dtype('float64'): 'double',
-    numpy.dtype('float32'): 'float',
-    numpy.dtype('float16'): 'float16',
-    numpy.dtype('complex128'): 'complex<double>',
-    numpy.dtype('complex64'): 'complex<float>',
-    numpy.dtype('int64'): 'long long',
-    numpy.dtype('int32'): 'int',
-    numpy.dtype('int16'): 'short',
-    numpy.dtype('int8'): 'signed char',
-    numpy.dtype('uint64'): 'unsigned long long',
-    numpy.dtype('uint32'): 'unsigned int',
-    numpy.dtype('uint16'): 'unsigned short',
-    numpy.dtype('uint8'): 'unsigned char',
-    numpy.dtype('bool'): 'bool',
-}
+from cupy.core._scalar import get_typename
 
 
 # Base class for cuda types.
@@ -43,4 +26,4 @@ class Scalar(TypeBase):
         if dtype == numpy.float16:
             # For the performance
             dtype = numpy.dtype('float32')
-        return dtype_to_ctype[dtype]
+        return get_typename(dtype)

--- a/cupyx/jit/_types.py
+++ b/cupyx/jit/_types.py
@@ -1,7 +1,7 @@
 import numpy
 
 
-_typenames = {
+dtype_to_ctype = {
     numpy.dtype('float64'): 'double',
     numpy.dtype('float32'): 'float',
     numpy.dtype('float16'): 'float16',
@@ -43,4 +43,4 @@ class Scalar(TypeBase):
         if dtype == numpy.float16:
             # For the performance
             dtype = numpy.dtype('float32')
-        return _typenames[dtype]
+        return dtype_to_ctype[dtype]


### PR DESCRIPTION
This PR fixes JIT code with `CodeBlock` object, which we implemented in CuPy fusion to generate human-readable CUDA code.