### PR TITLE
Make `uniform`-based random distributions support array args

### DIFF
--- a/cupy/random/_generator.py
+++ b/cupy/random/_generator.py
@@ -74,8 +74,6 @@ class RandomState(object):
         # * curand.generateNormalDouble
         # * curand.generateLogNormal
         # * curand.generateLogNormalDouble
-        if size is None:
-            size = ()  # TODO(kataoka): Remove this after #4615 is merged
         size = core.get_size(size)
         element_size = core.internal.prod(size)
         if element_size % 2 == 0:
@@ -597,8 +595,6 @@ class RandomState(object):
 
     def _random_sample_raw(self, size, dtype):
         dtype = _check_and_get_dtype(dtype)
-        if size is None:
-            size = ()  # TODO(kataoka): Remove this after #4615 is merged
         out = cupy.empty(size, dtype=dtype)
         if dtype.char == 'f':
             func = curand.generateUniform

--- a/cupy/random/_generator.py
+++ b/cupy/random/_generator.py
@@ -470,6 +470,8 @@ class RandomState(object):
             - :meth:`numpy.random.RandomState.pareto`
         """
         a = cupy.asarray(a)
+        if size is None:
+            size = a.shape
         x = self._random_sample_raw(size, dtype)
         cupy.log(x, out=x)
         cupy.exp(-x/a, out=x)
@@ -613,6 +615,8 @@ class RandomState(object):
             - :meth:`numpy.random.RandomState.random_sample`
 
         """
+        if size is None:
+            size = ()
         out = self._random_sample_raw(size, dtype)
         RandomState._mod1_kernel(out)
         return out
@@ -780,6 +784,8 @@ class RandomState(object):
             - :func:`cupy.random.standard_exponential` for full documentation
             - :meth:`numpy.random.RandomState.standard_exponential`
         """
+        if size is None:
+            size = ()
         x = self._random_sample_raw(size, dtype)
         return -cupy.log(x, out=x)
 
@@ -1144,11 +1150,13 @@ class RandomState(object):
             - :func:`cupy.random.gumbel` for full documentation
             - :meth:`numpy.random.RandomState.gumbel`
         """
-        x = self._random_sample_raw(size=size, dtype=dtype)
         if not numpy.isscalar(loc):
             loc = cupy.asarray(loc, dtype)
         if not numpy.isscalar(scale):
             scale = cupy.asarray(scale, dtype)
+        if size is None:
+            size = cupy.broadcast(loc, scale).shape
+        x = self._random_sample_raw(size=size, dtype=dtype)
         RandomState._gumbel_kernel(x, loc, scale, x)
         return x
 

--- a/tests/cupy_tests/random_tests/test_distributions.py
+++ b/tests/cupy_tests/random_tests/test_distributions.py
@@ -197,7 +197,7 @@ class TestDistributionsGeometric(unittest.TestCase):
 
 
 @testing.parameterize(*testing.product({
-    'shape': [(4, 3, 2), (3, 2)],
+    'shape': [(4, 3, 2), (3, 2), None],
     'loc_shape': [(), (3, 2)],
     'scale_shape': [(), (3, 2)],
 })
@@ -244,7 +244,7 @@ class TestDistributionsHyperGeometric(unittest.TestCase):
 
 
 @testing.parameterize(*testing.product({
-    'shape': [(4, 3, 2), (3, 2)],
+    'shape': [(4, 3, 2), (3, 2), None],
     'loc_shape': [(), (3, 2)],
     'scale_shape': [(), (3, 2)],
 })
@@ -476,7 +476,7 @@ class TestDistributionsNormal(RandomDistributionsTestCase):
 
 
 @testing.parameterize(*testing.product({
-    'shape': [(4, 3, 2), (3, 2)],
+    'shape': [(4, 3, 2), (3, 2), None],
     'a_shape': [(), (3, 2)],
 })
 )
@@ -486,7 +486,8 @@ class TestDistributionsPareto(unittest.TestCase):
     def check_distribution(self, dist_func, a_dtype, dtype):
         a = cupy.ones(self.a_shape, dtype=a_dtype)
         out = dist_func(a, self.shape, dtype)
-        assert self.shape == out.shape
+        if self.shape is not None:
+            assert self.shape == out.shape
         assert out.dtype == dtype
 
     @cupy.testing.for_float_dtypes('dtype', no_float16=True)
@@ -541,7 +542,7 @@ class TestDistributionsPower(RandomDistributionsTestCase):
 
 
 @testing.parameterize(*testing.product({
-    'shape': [(4, 3, 2), (3, 2)],
+    'shape': [(4, 3, 2), (3, 2), None],
     'scale_shape': [(), (3, 2)],
 })
 )
@@ -584,7 +585,7 @@ class TestDistributionsStandardCauchy(RandomDistributionsTestCase):
 
 
 @testing.parameterize(*testing.product({
-    'shape': [(4, 3, 2), (3, 2)],
+    'shape': [(4, 3, 2), (3, 2), None],
 })
 )
 @testing.gpu


### PR DESCRIPTION
#4615 and this PR fix #4613.