### PR TITLE
[backport] Use NVRTC for grid synchronization in `cupy.fuse`

### DIFF
--- a/cupy/core/_fusion_kernel.pyx
+++ b/cupy/core/_fusion_kernel.pyx
@@ -49,12 +49,8 @@ def _cuda_compile(preamble, name, cuda_params, cuda_body, use_grid_sync):
     # by uncommenting the following line.
     # print(code)
 
-    if use_grid_sync:
-        module = compile_with_cache(
-            code, (), None, None, True, 'nvcc', False, True)
-    else:
-        module = compile_with_cache(code)
-
+    module = compile_with_cache(
+        code, (), None, None, True, 'nvrtc', False, use_grid_sync)
     return module.get_function(name)
 
 

--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -348,9 +348,6 @@ def compile_with_cache(
         name_expressions=None, log_stream=None):
 
     if enable_cooperative_groups:
-        if backend != 'nvcc':
-            raise ValueError(
-                'Cooperative groups is supported only in NVCC backend.')
         if runtime.is_hip:
             raise ValueError(
                 'Cooperative groups is not supported in HIP.')


### PR DESCRIPTION
Backport of #4492