### PR TITLE
Fix Windows CI test script to avoid caching kernel when in pull-request test

### DIFF
--- a/.pfnci/windows/_flexci.ps1
+++ b/.pfnci/windows/_flexci.ps1
@@ -41,3 +41,7 @@ function ActivateCUDA($version) {
     }
     $Env:PATH = "$Env:CUDA_PATH\bin;$Env:ProgramFiles\NVIDIA Corporation\NvToolsExt\bin\x64;" + $Env:PATH
 }
+
+function IsPullRequestTest() {
+    return ${Env:FLEXCI_BRANCH}.StartsWith("refs/pull/")
+}

--- a/.pfnci/windows/test.ps1
+++ b/.pfnci/windows/test.ps1
@@ -79,6 +79,7 @@ function Main {
     }
 
     $use_cache = ($Env:CUPY_CI_CACHE_KERNEL -eq "1")
+    $upload_cache = -Not (IsPullRequestTest)
 
     if ($use_cache) {
         DownloadCache
@@ -88,7 +89,7 @@ function Main {
     if (-not $?) {
         $test_retval = $LastExitCode
     }
-    if ($use_cache) {
+    if ($use_cache -And $upload_cache) {
         UploadCache
     }
 

--- a/.pfnci/windows/test.ps1
+++ b/.pfnci/windows/test.ps1
@@ -85,6 +85,7 @@ function Main {
         DownloadCache
     }
     echo "Running test..."
+    $test_retval = 0
     python -m pytest -rfEX $Env:PYTEST_OPTS tests > cupy_test_log.txt
     if (-not $?) {
         $test_retval = $LastExitCode


### PR DESCRIPTION
https://github.com/cupy/cupy/pull/4362#discussion_r572536881

This PR also fixes the issue that test script fails when all tests pass 😅 