### PR TITLE
Skip failing tests for `cupy.cublas` under HIP

### DIFF
--- a/tests/cupy_tests/test_cublas.py
+++ b/tests/cupy_tests/test_cublas.py
@@ -453,11 +453,22 @@ class TestDgmm(unittest.TestCase):
         cublas.dgmm(self.side, self.a, self.x, out=self.a)
         cupy.testing.assert_allclose(self.a, ref, rtol=self.tol, atol=self.tol)
 
-    @pytest.mark.skipif(cupy.cuda.runtime.is_hip,
-                        reason="HIP fails for some condition")
+    _dgmm_incx_minus_one_hip_skip_condition = [
+        ('C', 'F', (9, 10), 'R'),
+        ('C', 'F', (10, 9), 'R'),
+        ('F', 'F', (9, 10), 'L'),
+        ('F', 'F', (10, 9), 'L'),
+    ]
+
+    def _check_dgmm_incx_minus_one_hip_skip_condition(self):
+        return (self.ordera, self.orderc, self.shape, self.side) in \
+            self._dgmm_incx_minus_one_hip_skip_condition
+
     @testing.for_dtypes('fdFD')
     def test_dgmm_incx_minus_one(self, dtype):
         if self.orderc != 'F':
+            raise unittest.SkipTest()
+        if self._check_dgmm_incx_minus_one_hip_skip_condition():
             raise unittest.SkipTest()
         self._setup(dtype)
         if self.side == 'L':

--- a/tests/cupy_tests/test_cublas.py
+++ b/tests/cupy_tests/test_cublas.py
@@ -468,8 +468,9 @@ class TestDgmm(unittest.TestCase):
     def test_dgmm_incx_minus_one(self, dtype):
         if self.orderc != 'F':
             raise unittest.SkipTest()
-        if self._check_dgmm_incx_minus_one_hip_skip_condition():
-            pytest.xfail('HIP dgmm may have a bug')
+        if cupy.cuda.runtime.is_hip:
+            if self._check_dgmm_incx_minus_one_hip_skip_condition():
+                pytest.xfail('HIP dgmm may have a bug')
         self._setup(dtype)
         if self.side == 'L':
             ref = cupy.diag(self.x[::-1]) @ self.a

--- a/tests/cupy_tests/test_cublas.py
+++ b/tests/cupy_tests/test_cublas.py
@@ -1,7 +1,6 @@
 import unittest
 
 import numpy
-import pytest
 
 import cupy
 from cupy import cublas

--- a/tests/cupy_tests/test_cublas.py
+++ b/tests/cupy_tests/test_cublas.py
@@ -1,6 +1,7 @@
 import unittest
 
 import numpy
+import pytest
 
 import cupy
 from cupy import cublas
@@ -452,6 +453,8 @@ class TestDgmm(unittest.TestCase):
         cublas.dgmm(self.side, self.a, self.x, out=self.a)
         cupy.testing.assert_allclose(self.a, ref, rtol=self.tol, atol=self.tol)
 
+    @pytest.mark.skipif(cupy.cuda.runtime.is_hip,
+                        reason="HIP fails for some condition")
     @testing.for_dtypes('fdFD')
     def test_dgmm_incx_minus_one(self, dtype):
         if self.orderc != 'F':

--- a/tests/cupy_tests/test_cublas.py
+++ b/tests/cupy_tests/test_cublas.py
@@ -1,6 +1,7 @@
 import unittest
 
 import numpy
+import pytest
 
 import cupy
 from cupy import cublas
@@ -468,7 +469,7 @@ class TestDgmm(unittest.TestCase):
         if self.orderc != 'F':
             raise unittest.SkipTest()
         if self._check_dgmm_incx_minus_one_hip_skip_condition():
-            raise unittest.SkipTest()
+            pytest.xfail('HIP dgmm may have a bug')
         self._setup(dtype)
         if self.side == 'L':
             ref = cupy.diag(self.x[::-1]) @ self.a


### PR DESCRIPTION
Rel #4132, #4540.
