### PR TITLE
Xfail tests in polynomial roots

### DIFF
--- a/tests/cupy_tests/lib_tests/test_polynomial.py
+++ b/tests/cupy_tests/lib_tests/test_polynomial.py
@@ -4,6 +4,7 @@ import pytest
 import numpy
 
 import cupy
+from cupy.cuda import runtime
 import cupyx
 from cupy import testing
 
@@ -126,6 +127,7 @@ class TestPoly1d(unittest.TestCase):
         a = xp.array([0, 0, 1, 2, 3, 0], dtype)
         return xp.poly1d(a).order
 
+    @pytest.mark.xfail(runtime.is_hip, reason='rocBLAS not implemented')
     @testing.for_signed_dtypes()
     @testing.numpy_cupy_allclose(rtol=1e-6)
     def test_poly1d_roots(self, xp, dtype):
@@ -755,6 +757,7 @@ class TestPolyRoutinesNdim(unittest.TestCase):
 @testing.parameterize(*testing.product({
     'input': [[2, -1, -2], [-4, 10, 4]],
 }))
+@pytest.mark.xfail(runtime.is_hip, reason='rocBLAS not implemented')
 class TestRootsReal(unittest.TestCase):
 
     @testing.for_signed_dtypes()
@@ -781,6 +784,8 @@ class TestRootsComplex(unittest.TestCase):
     @testing.for_complex_dtypes()
     @testing.numpy_cupy_allclose(rtol=1e-6)
     def test_roots_array(self, xp, dtype):
+        if runtime.is_hip and self.input == [3j, 1.5j, -3j]:
+            pytest.xfail('rocBLAS not implemted')
         a = xp.array(self.input, dtype)
         out = xp.roots(a)
         return xp.sort(out)
@@ -788,6 +793,8 @@ class TestRootsComplex(unittest.TestCase):
     @testing.for_complex_dtypes()
     @testing.numpy_cupy_allclose(rtol=1e-6)
     def test_roots_poly1d(self, xp, dtype):
+        if runtime.is_hip and self.input == [3j, 1.5j, -3j]:
+            pytest.xfail('rocBLAS not implemted')
         a = xp.array(self.input, dtype)
         out = xp.roots(xp.poly1d(a))
         return xp.sort(out)

--- a/tests/cupy_tests/lib_tests/test_polynomial.py
+++ b/tests/cupy_tests/lib_tests/test_polynomial.py
@@ -785,7 +785,7 @@ class TestRootsComplex(unittest.TestCase):
     @testing.numpy_cupy_allclose(rtol=1e-6)
     def test_roots_array(self, xp, dtype):
         if runtime.is_hip and self.input == [3j, 1.5j, -3j]:
-            pytest.xfail('rocBLAS not implemted')
+            pytest.xfail('rocBLAS not implemented')
         a = xp.array(self.input, dtype)
         out = xp.roots(a)
         return xp.sort(out)

--- a/tests/cupy_tests/lib_tests/test_polynomial.py
+++ b/tests/cupy_tests/lib_tests/test_polynomial.py
@@ -794,7 +794,7 @@ class TestRootsComplex(unittest.TestCase):
     @testing.numpy_cupy_allclose(rtol=1e-6)
     def test_roots_poly1d(self, xp, dtype):
         if runtime.is_hip and self.input == [3j, 1.5j, -3j]:
-            pytest.xfail('rocBLAS not implemted')
+            pytest.xfail('rocBLAS not implemented')
         a = xp.array(self.input, dtype)
         out = xp.roots(xp.poly1d(a))
         return xp.sort(out)


### PR DESCRIPTION
Rel #4132.

`cupy_backends.cuda.libs.cusolver.CUSOLVERError: rocblas_status_not_implemented`