### PR TITLE
Update CUDA Array Interface to v3 - Part 2

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -194,10 +194,7 @@ cdef class ndarray:
             stream_ptr = stream_module.get_current_stream_ptr()
             # CAI v3 says setting the stream field to 0 is disallowed
             if stream_ptr == 0:
-                if _stream_module.is_ptds_enabled():
-                    stream_ptr = runtime.streamPerThread
-                else:
-                    stream_ptr = runtime.streamLegacy
+                stream_ptr = _stream_module.get_default_stream_ptr()
             desc['stream'] = stream_ptr
         elif ver == 2:
             # Old behavior (prior to CAI v3): stream sync is explicitly handled

--- a/cupy_backends/cuda/stream.pxd
+++ b/cupy_backends/cuda/stream.pxd
@@ -2,4 +2,4 @@ from libc.stdint cimport intptr_t
 
 cdef intptr_t get_current_stream_ptr()
 cdef set_current_stream_ptr(intptr_t ptr)
-cdef bint is_ptds_enabled()
+cpdef bint is_ptds_enabled()

--- a/cupy_backends/cuda/stream.pxd
+++ b/cupy_backends/cuda/stream.pxd
@@ -2,4 +2,5 @@ from libc.stdint cimport intptr_t
 
 cdef intptr_t get_current_stream_ptr()
 cdef set_current_stream_ptr(intptr_t ptr)
-cpdef bint is_ptds_enabled()
+cpdef intptr_t get_default_stream_ptr()
+cdef bint is_ptds_enabled()

--- a/cupy_backends/cuda/stream.pyx
+++ b/cupy_backends/cuda/stream.pyx
@@ -53,5 +53,8 @@ cdef set_current_stream_ptr(intptr_t ptr):
 
 # cpdef for unit testing
 cpdef bint is_ptds_enabled():
+    if runtime._is_hip_environment:
+        # HIP does not support PTDS, just ignore the env var
+        return False
     ptds = int(os.environ.get('CUPY_CUDA_PER_THREAD_DEFAULT_STREAM', '0'))
     return bool(ptds != 0)

--- a/cupy_backends/cuda/stream.pyx
+++ b/cupy_backends/cuda/stream.pyx
@@ -51,6 +51,7 @@ cdef set_current_stream_ptr(intptr_t ptr):
     tls.set_current_stream_ptr(ptr)
 
 
-cdef bint is_ptds_enabled():
+# cpdef for unit testing
+cpdef bint is_ptds_enabled():
     ptds = int(os.environ.get('CUPY_CUDA_PER_THREAD_DEFAULT_STREAM', '0'))
     return bool(ptds != 0)

--- a/cupy_backends/cuda/stream.pyx
+++ b/cupy_backends/cuda/stream.pyx
@@ -30,6 +30,12 @@ cdef class _ThreadLocal:
 
         return self.current_stream
 
+    cdef intptr_t get_default_stream_ptr(self):
+        if is_ptds_enabled():
+            return runtime.streamPerThread
+        else:  # we don't return 0 here
+            return runtime.streamLegacy
+
 
 cdef intptr_t get_current_stream_ptr():
     """C API to get current CUDA stream pointer.
@@ -52,7 +58,17 @@ cdef set_current_stream_ptr(intptr_t ptr):
 
 
 # cpdef for unit testing
-cpdef bint is_ptds_enabled():
+cpdef intptr_t get_default_stream_ptr():
+    """Get the CUDA default stream pointer.
+
+    Args:
+        ptr (intptr_t): CUDA stream pointer.
+    """
+    tls = _ThreadLocal.get()
+    return <intptr_t>tls.get_default_stream_ptr()
+
+
+cdef bint is_ptds_enabled():
     if runtime._is_hip_environment:
         # HIP does not support PTDS, just ignore the env var
         return False

--- a/tests/cupy_tests/core_tests/test_ndarray.py
+++ b/tests/cupy_tests/core_tests/test_ndarray.py
@@ -218,7 +218,7 @@ class TestNdarrayCudaInterface(unittest.TestCase):
         assert not iface['data'][1]
         assert iface['descr'] == [('', '<f8')]
         assert iface['strides'] is None
-        assert iface['stream'] == 2 if stream_module.is_ptds_enabled() else 1
+        assert iface['stream'] == stream_module.get_default_stream_ptr()
 
     def test_cuda_array_interface_view(self):
         arr = cupy.zeros(shape=(10, 20), dtype=cupy.float64)
@@ -236,7 +236,7 @@ class TestNdarrayCudaInterface(unittest.TestCase):
         assert not iface['data'][1]
         assert iface['strides'] == (320, 40)
         assert iface['descr'] == [('', '<f8')]
-        assert iface['stream'] == 2 if stream_module.is_ptds_enabled() else 1
+        assert iface['stream'] == stream_module.get_default_stream_ptr()
 
     def test_cuda_array_interface_zero_size(self):
         arr = cupy.zeros(shape=(10,), dtype=cupy.float64)
@@ -254,7 +254,7 @@ class TestNdarrayCudaInterface(unittest.TestCase):
         assert not iface['data'][1]
         assert iface['strides'] is None
         assert iface['descr'] == [('', '<f8')]
-        assert iface['stream'] == 2 if stream_module.is_ptds_enabled() else 1
+        assert iface['stream'] == stream_module.get_default_stream_ptr()
 
 
 @testing.parameterize(*testing.product({
@@ -298,10 +298,8 @@ class TestNdarrayCudaInterfaceStream(unittest.TestCase):
         assert iface['strides'] is None
         if self.ver == 3:
             if stream.ptr == 0:
-                if stream_module.is_ptds_enabled():
-                    assert iface['stream'] == 2
-                else:
-                    assert iface['stream'] == 1
+                ptr = stream_module.get_default_stream_ptr()
+                assert iface['stream'] == ptr
             else:
                 assert iface['stream'] == stream.ptr
 

--- a/tests/cupy_tests/core_tests/test_ndarray.py
+++ b/tests/cupy_tests/core_tests/test_ndarray.py
@@ -4,6 +4,7 @@ import unittest
 import numpy
 import pytest
 
+from cupy_backends.cuda import stream as stream_module
 import cupy
 from cupy import _util
 from cupy import core
@@ -217,7 +218,7 @@ class TestNdarrayCudaInterface(unittest.TestCase):
         assert not iface['data'][1]
         assert iface['descr'] == [('', '<f8')]
         assert iface['strides'] is None
-        assert iface['stream'] == 1
+        assert iface['stream'] == 2 if stream_module.is_ptds_enabled() else 1
 
     def test_cuda_array_interface_view(self):
         arr = cupy.zeros(shape=(10, 20), dtype=cupy.float64)
@@ -235,7 +236,7 @@ class TestNdarrayCudaInterface(unittest.TestCase):
         assert not iface['data'][1]
         assert iface['strides'] == (320, 40)
         assert iface['descr'] == [('', '<f8')]
-        assert iface['stream'] == 1
+        assert iface['stream'] == 2 if stream_module.is_ptds_enabled() else 1
 
     def test_cuda_array_interface_zero_size(self):
         arr = cupy.zeros(shape=(10,), dtype=cupy.float64)
@@ -253,12 +254,11 @@ class TestNdarrayCudaInterface(unittest.TestCase):
         assert not iface['data'][1]
         assert iface['strides'] is None
         assert iface['descr'] == [('', '<f8')]
-        assert iface['stream'] == 1
+        assert iface['stream'] == 2 if stream_module.is_ptds_enabled() else 1
 
 
-# TODO(leofang): test PTDS
 @testing.parameterize(*testing.product({
-    'stream': ('null', 'new'),
+    'stream': ('null', 'new', 'ptds'),
     'ver': (2, 3),
 }))
 @pytest.mark.skipif(cupy.cuda.runtime.is_hip,
@@ -269,6 +269,8 @@ class TestNdarrayCudaInterfaceStream(unittest.TestCase):
             self.stream = cuda.Stream.null
         elif self.stream == 'new':
             self.stream = cuda.Stream()
+        elif self.stream == 'ptds':
+            self.stream = cuda.Stream.ptds
 
         self.old_ver = _util.CUDA_ARRAY_INTERFACE_EXPORT_VERSION
         _util.CUDA_ARRAY_INTERFACE_EXPORT_VERSION = self.ver
@@ -295,7 +297,13 @@ class TestNdarrayCudaInterfaceStream(unittest.TestCase):
         assert iface['descr'] == [('', '<f8')]
         assert iface['strides'] is None
         if self.ver == 3:
-            assert iface['stream'] == 1 if stream.ptr == 0 else stream.ptr
+            if stream.ptr == 0:
+                if stream_module.is_ptds_enabled():
+                    assert iface['stream'] == 2
+                else:
+                    assert iface['stream'] == 1
+            else:
+                assert iface['stream'] == stream.ptr
 
 
 @pytest.mark.skipif(not cupy.cuda.runtime.is_hip,

--- a/tests/cupy_tests/core_tests/test_ndarray_cuda_array_interface.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_cuda_array_interface.py
@@ -310,7 +310,7 @@ class TestCUDAArrayInterfaceStream(unittest.TestCase):
             stream_ptr = a.__cuda_array_interface__['stream']
 
         if self.stream is cupy.cuda.Stream.null:
-            assert stream_ptr == 2 if stream_module.is_ptds_enabled() else 1
+            assert stream_ptr == stream_module.get_default_stream_ptr()
         elif self.stream is cupy.cuda.Stream.ptds:
             assert stream_ptr == 2
         else:
@@ -318,4 +318,4 @@ class TestCUDAArrayInterfaceStream(unittest.TestCase):
 
         # without a stream context, it's always the default stream
         stream_ptr = a.__cuda_array_interface__['stream']
-        assert stream_ptr == 2 if stream_module.is_ptds_enabled() else 1
+        assert stream_ptr == stream_module.get_default_stream_ptr()

--- a/tests/cupy_tests/creation_tests/test_from_data.py
+++ b/tests/cupy_tests/creation_tests/test_from_data.py
@@ -594,9 +594,10 @@ class DummyObjectWithCudaArrayInterface(object):
         # synchronization is done via calling a cpdef function, which cannot
         # be mock-tested.
         if self.stream is not None:
-            # TODO(leofang): how about PTDS?
             if self.stream is cuda.Stream.null:
-                desc['stream'] = 1  # TODO(leofang): use runtime.streamLegacy
+                desc['stream'] = cuda.runtime.streamLegacy
+            elif (not cuda.runtime.is_hip) and self.stream is cuda.Stream.ptds:
+                desc['stream'] = cuda.runtime.streamPerThread
             else:
                 desc['stream'] = self.stream.ptr
         return desc


### PR DESCRIPTION
Follow up of #4357 and #4322. This PR should ***not*** be backported.

Now that we support PTDS (#4322), we should detect if it's in use before exporting (context: https://github.com/cupy/cupy/pull/4357#issuecomment-735852102). The test suite is updated accordingly. One of the main focus is to ensure the tests pass regardless of the value of the env var `CUPY_CUDA_PER_THREAD_DEFAULT_STREAM` (verified locally). 

This PR also adds an extra safe for HIP following #4651: On HIP, `CUPY_CUDA_PER_THREAD_DEFAULT_STREAM` should be ignored as PTDS is not supported.

cc: @pentschev 