### PR TITLE
Add diagonal and setdiag methods for COO sparse matrices

### DIFF
--- a/cupyx/scipy/sparse/coo.py
+++ b/cupyx/scipy/sparse/coo.py
@@ -183,6 +183,34 @@ class coo_matrix(sparse_data._data_matrix):
                 (data, (self.row, self.col)), shape=self.shape,
                 dtype=data.dtype)
 
+    def diagonal(self, k=0):
+        """Returns the k-th diagonal of the matrix.
+
+        Args:
+            k (int, optional): Which diagonal to get, corresponding to elements
+            a[i, i+k]. Default: 0 (the main diagonal).
+
+        Returns:
+            cupy.ndarray : The k-th diagonal.
+        """
+        rows, cols = self.shape
+        if k <= -rows or k >= cols:
+            return cupy.empty(0, dtype=self.data.dtype)
+        diag = cupy.zeros(min(rows + min(k, 0), cols - max(k, 0)),
+                        dtype=self.dtype)
+        diag_mask = (self.row + k) == self.col
+
+        if self.has_canonical_format:
+            row = self.row[diag_mask]
+            data = self.data[diag_mask]
+        else:
+            row, _, data = self._sum_duplicates(self.row[diag_mask],
+                                                self.col[diag_mask],
+                                                self.data[diag_mask])
+        diag[row + min(k, 0)] = data
+
+        return diag
+
     def setdiag(self, values, k=0):
         """Set diagonal or off-diagonal elements of the array.
 

--- a/cupyx/scipy/sparse/coo.py
+++ b/cupyx/scipy/sparse/coo.py
@@ -183,6 +183,57 @@ class coo_matrix(sparse_data._data_matrix):
                 (data, (self.row, self.col)), shape=self.shape,
                 dtype=data.dtype)
 
+    def setdiag(self, values, k=0):
+        """Set diagonal or off-diagonal elements of the array.
+
+        Args:
+            values (ndarray): New values of the diagonal elements. Values may
+                have any length. If the diagonal is longer than values, then
+                the remaining diagonal entries will not be set. If values are
+                longer than the diagonal, then the remaining values are
+                ignored. If a scalar value is given, all of the diagonal is set
+                to it.
+            k (int, optional): Which off-diagonal to set, corresponding to
+                elements a[i,i+k]. Default: 0 (the main diagonal).
+
+        """
+        M, N = self.shape
+        if (k > 0 and k >= N) or (k < 0 and -k >= M):
+            raise ValueError("k exceeds matrix dimensions")
+        if values.ndim and not len(values):
+            return
+        idx_dtype = self.row.dtype
+
+        # Determine which triples to keep and where to put the new ones.
+        full_keep = self.col - self.row != k
+        if k < 0:
+            max_index = min(M + k, N)
+            if values.ndim:
+                max_index = min(max_index, len(values))
+            keep = cupy.logical_or(full_keep, self.col >= max_index)
+            new_row = cupy.arange(-k, -k + max_index, dtype=idx_dtype)
+            new_col = cupy.arange(max_index, dtype=idx_dtype)
+        else:
+            max_index = min(M, N - k)
+            if values.ndim:
+                max_index = min(max_index, len(values))
+            keep = cupy.logical_or(full_keep, self.row >= max_index)
+            new_row = cupy.arange(max_index, dtype=idx_dtype)
+            new_col = cupy.arange(k, k + max_index, dtype=idx_dtype)
+
+        # Define the array of data consisting of the entries to be added.
+        if values.ndim:
+            new_data = values[:max_index]
+        else:
+            new_data = cupy.empty(max_index, dtype=self.dtype)
+            new_data[:] = values
+
+        # Update the internal structure.
+        self.row = cupy.concatenate((self.row[keep], new_row))
+        self.col = cupy.concatenate((self.col[keep], new_col))
+        self.data = cupy.concatenate((self.data[keep], new_data))
+        self.has_canonical_format = False
+
     def eliminate_zeros(self):
         """Removes zero entories in place."""
         ind = self.data != 0

--- a/cupyx/scipy/sparse/coo.py
+++ b/cupyx/scipy/sparse/coo.py
@@ -197,7 +197,7 @@ class coo_matrix(sparse_data._data_matrix):
         if k <= -rows or k >= cols:
             return cupy.empty(0, dtype=self.data.dtype)
         diag = cupy.zeros(min(rows + min(k, 0), cols - max(k, 0)),
-                        dtype=self.dtype)
+                          dtype=self.dtype)
         diag_mask = (self.row + k) == self.col
 
         if self.has_canonical_format:

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_coo.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_coo.py
@@ -1061,3 +1061,70 @@ class TestIsspmatrixCoo(unittest.TestCase):
              cupy.array([0], 'i')),
             shape=(0, 0), dtype='f')
         assert sparse.isspmatrix_coo(x) is False
+
+
+@testing.parameterize(*testing.product({
+    'shape': [(8, 5), (5, 5), (5, 8)],
+}))
+@testing.with_requires('scipy>=1.5.0')
+@testing.gpu
+class TestCooMatrixDiagonal(unittest.TestCase):
+    density = 0.5
+
+    def _make_matrix(self, dtype):
+        a = testing.shaped_random(self.shape, numpy, dtype=dtype)
+        mask = testing.shaped_random(self.shape, numpy, dtype='f', scale=1.0)
+        a[mask > self.density] = 0
+        scipy_a = scipy.sparse.coo_matrix(a)
+        cupyx_a = sparse.coo_matrix(cupy.array(a))
+        return scipy_a, cupyx_a
+
+    @testing.for_dtypes('fdFD')
+    def test_diagonal(self, dtype):
+        scipy_a, cupyx_a = self._make_matrix(dtype)
+        m, n = self.shape
+        for k in range(-m, n+1):
+            scipy_diag = scipy_a.diagonal(k=k)
+            cupyx_diag = cupyx_a.diagonal(k=k)
+            testing.assert_allclose(scipy_diag, cupyx_diag)
+
+    def _test_setdiag(self, scipy_a, cupyx_a, x, k):
+        scipy_a = scipy_a.copy()
+        cupyx_a = cupyx_a.copy()
+        scipy_a.setdiag(x, k=k)
+        cupyx_a.setdiag(cupy.array(x), k=k)
+        testing.assert_allclose(scipy_a.data, cupyx_a.data)
+        testing.assert_array_equal(scipy_a.row, cupyx_a.row)
+        testing.assert_array_equal(scipy_a.col, cupyx_a.col)
+
+    @testing.for_dtypes('fdFD')
+    def test_setdiag(self, dtype):
+        scipy_a, cupyx_a = self._make_matrix(dtype)
+        m, n = self.shape
+        for k in range(-m+1, n):
+            m_st, n_st = max(0, -k), max(0, k)
+            for l in (-1, 0, 1):
+                x_len = min(m - m_st, n - n_st) + l
+                if x_len <= 0:
+                    continue
+                x = numpy.ones((x_len,), dtype=dtype)
+                self._test_setdiag(scipy_a, cupyx_a, x, k)
+
+    @testing.for_dtypes('fdFD')
+    def test_setdiag_scalar(self, dtype):
+        scipy_a, cupyx_a = self._make_matrix(dtype)
+        x = numpy.array(1.0, dtype=dtype)
+        m, n = self.shape
+        for k in range(-m+1, n):
+            self._test_setdiag(scipy_a, cupyx_a, x, k)
+
+    def test_setdiag_invalid(self):
+        dtype = 'f'
+        scipy_a, cupyx_a = self._make_matrix(dtype)
+        x = numpy.array(1.0, dtype=dtype)
+        m, n = self.shape
+        for k in (-m, n):
+            with self.assertRaises(ValueError):
+                scipy_a.setdiag(x, k=k)
+            with self.assertRaises(ValueError):
+                cupyx_a.setdiag(x, k=k)


### PR DESCRIPTION
The functions added here are direct copies of the SciPy methods, only switching out `np`->`cupy`.

`diagonal` worked okay prior to this PR via the base class `diagonal ` method which first converted to CSR. 

The `TestCooMatrixDiagonal` class here is modification of the existing `TestCsrMatrixDiagonal` class. The only methods that needed to be modified for the COO case were `_make_matrix` and `_test_setdiag`.

