### PR TITLE
Fix definition order in preamble

### DIFF
--- a/cupy/_math/rational.py
+++ b/cupy/_math/rational.py
@@ -36,7 +36,7 @@ gcd = core.create_ufunc(
 
     ''')
 
-_lcm_preamble = '''
+_lcm_preamble = _gcd_preamble + '''
 template <typename T> inline __device__ T lcm(T in0, T in1) {
   T r = gcd(in0, in1);
   if (r == 0)
@@ -46,7 +46,7 @@ template <typename T> inline __device__ T lcm(T in0, T in1) {
     return -r;
   return r;
 }
-''' + _gcd_preamble
+'''
 
 lcm = core.create_ufunc(
     'cupy_lcm',


### PR DESCRIPTION
Rel #4132 and #4484.

This PR fixes the order of definitions of `gcd` and `lcm` in the preamble as the HIP compiler requires.
