### PR TITLE
Add cudnn and cutensor for CUDA 11.2 in `install_library`

### DIFF
--- a/cupyx/tools/install_library.py
+++ b/cupyx/tools/install_library.py
@@ -52,6 +52,10 @@ def _make_cudnn_record(
 
 # Latest cuDNN versions: https://developer.nvidia.com/rdp/cudnn-download
 _cudnn_records.append(_make_cudnn_record(
+    '11.2', '8.1.0',
+    'cudnn-11.2-linux-x64-v8.1.0.77.tgz',
+    'cudnn-11.2-windows-x64-v8.1.0.77.zip'))
+_cudnn_records.append(_make_cudnn_record(
     '11.1', '8.1.0',
     'cudnn-11.2-linux-x64-v8.1.0.77.tgz',
     'cudnn-11.2-windows-x64-v8.1.0.77.zip'))
@@ -100,6 +104,9 @@ def _make_cutensor_record(
     }
 
 
+_cutensor_records.append(_make_cutensor_record(
+    '11.2', '1.2.2',
+    'libcutensor-linux-x86_64-1.2.2.5.tar.gz', ''))
 _cutensor_records.append(_make_cutensor_record(
     '11.1', '1.2.2',
     'libcutensor-linux-x86_64-1.2.2.5.tar.gz', ''))

--- a/cupyx/tools/install_library.py
+++ b/cupyx/tools/install_library.py
@@ -106,7 +106,8 @@ def _make_cutensor_record(
 
 _cutensor_records.append(_make_cutensor_record(
     '11.2', '1.2.2',
-    'libcutensor-linux-x86_64-1.2.2.5.tar.gz', ''))
+    'libcutensor-linux-x86_64-1.2.2.5.tar.gz',
+    'libcutensor-windows-x86_64-1.2.2.5.zip'))
 _cutensor_records.append(_make_cutensor_record(
     '11.1', '1.2.2',
     'libcutensor-linux-x86_64-1.2.2.5.tar.gz', ''))


### PR DESCRIPTION
Needed by https://github.com/cupy/cupy-release-tools/pull/66