### PR TITLE
Support batched `pinv`

### DIFF
--- a/cupy/linalg/_decomposition.py
+++ b/cupy/linalg/_decomposition.py
@@ -412,6 +412,7 @@ def _svd_batched(a, a_dtype, full_matrices, compute_uv):
         return s
 
 
+# TODO(leofang): support the hermitian keyword?
 def svd(a, full_matrices=True, compute_uv=True):
     """Singular Value Decomposition.
 

--- a/cupy/linalg/_solve.py
+++ b/cupy/linalg/_solve.py
@@ -390,13 +390,14 @@ def pinv(a, rcond=1e-15):
     Note that it automatically removes small singular values for stability.
 
     Args:
-        a (cupy.ndarray): The matrix with dimension ``(M, N)``
+        a (cupy.ndarray): The matrix with dimension ``(..., M, N)``
         rcond (float): Cutoff parameter for small singular values.
             For stability it computes the largest singular value denoted by
             ``s``, and sets all singular values smaller than ``s`` to zero.
 
     Returns:
-        cupy.ndarray: The pseudoinverse of ``a`` with dimension ``(N, M)``.
+        cupy.ndarray: The pseudoinverse of ``a`` with dimension
+            ``(..., N, M)``.
 
     .. warning::
         This function calls one or more cuSOLVER routine(s) which may yield
@@ -411,7 +412,7 @@ def pinv(a, rcond=1e-15):
     cutoff = rcond * s.max()
     s1 = 1 / s
     s1[s <= cutoff] = 0
-    return cupy.dot(vt.T, s1[:, None] * u.T)
+    return cupy.dot(vt.swapaxis(-2, -1), s1[..., None] * u.swapaxis(-2, -1))
 
 
 def tensorinv(a, ind=2):

--- a/cupy/linalg/_solve.py
+++ b/cupy/linalg/_solve.py
@@ -383,8 +383,7 @@ def _batched_inv(a):
 
 
 # TODO(leofang): support the hermitian keyword?
-# TODO(leofang): accept ndarray for rcond
-def pinv(a, rcond=0e-15):
+def pinv(a, rcond=1e-15):
     """Compute the Moore-Penrose pseudoinverse of a matrix.
 
     It computes a pseudoinverse of a matrix ``a``, which is a generalization
@@ -393,9 +392,10 @@ def pinv(a, rcond=0e-15):
 
     Args:
         a (cupy.ndarray): The matrix with dimension ``(..., M, N)``
-        rcond (float): Cutoff parameter for small singular values.
-            For stability it computes the largest singular value denoted by
-            ``s``, and sets all singular values smaller than ``s`` to zero.
+        rcond (float or cupy.ndarray): Cutoff parameter for small singular
+            values. For stability it computes the largest singular value
+            denoted by ``s``, and sets all singular values smaller than
+            ``s`` to zero. Broadcasts against the stack of matrices.
 
     Returns:
         cupy.ndarray: The pseudoinverse of ``a`` with dimension
@@ -416,7 +416,8 @@ def pinv(a, rcond=0e-15):
     u, s, vt = _decomposition.svd(a.conj(), full_matrices=False)
 
     # discard small singular values
-    rcond = cupy.asarray(rcond)
+    if cupy.isscalar(rcond):
+        rcond = cupy.asarray(rcond)
     cutoff = rcond[..., None] * cupy.amax(s, axis=-1, keepdims=True)
     leq = s <= cutoff
     s = 1 / s

--- a/tests/cupy_tests/linalg_tests/test_solve.py
+++ b/tests/cupy_tests/linalg_tests/test_solve.py
@@ -181,10 +181,10 @@ class TestPinv(unittest.TestCase):
         self.check_x((2, 3, 4, 5), rcond=1e-15)
 
     def test_pinv_batched_vector_rcond(self):
-        self.check_x((2, 3, 4), rcond=[0.5, 0.5])
+        self.check_x((2, 3, 4), rcond=[0.2, 0.8])
         self.check_x((2, 3, 4, 5),
-                     rcond=[[0.2, 0.2, 0.2],
-                            [0.2, 0.2, 0.2]])
+                     rcond=[[0.2, 0.9, 0.1],
+                            [0.7, 0.2, 0.5]])
 
     def test_pinv_size_0(self):
         self.check_x((3, 0), rcond=1e-15)

--- a/tests/cupy_tests/linalg_tests/test_solve.py
+++ b/tests/cupy_tests/linalg_tests/test_solve.py
@@ -163,11 +163,6 @@ class TestPinv(unittest.TestCase):
         cupy.testing.assert_allclose(result_cpu, result_gpu, atol=1e-3)
         cupy.testing.assert_array_equal(a_gpu_copy, a_gpu)
 
-    def check_shape(self, a_shape):
-        a = cupy.random.rand(*a_shape)
-        with self.assertRaises(ValueError):
-            cupy.linalg.pinv(a)
-
     def test_pinv(self):
         self.check_x((3, 3), rcond=1e-15)
         self.check_x((2, 4), rcond=1e-15)
@@ -177,11 +172,9 @@ class TestPinv(unittest.TestCase):
         self.check_x((2, 5), rcond=0.5)
         self.check_x((5, 3), rcond=0.6)
 
-    def test_invalid_shape(self):
-        # TODO(leofang): NumPy supports batched pinv. Since we now support
-        # batched svd (which is behind pinv), this should not raise
-        self.check_shape((2, 3, 4))
-        self.check_shape((4, 3, 2, 1))
+    def test_pinv_batched(self):
+        self.check_x((2, 3, 4), rcond=1e-15)
+        self.check_x((2, 3, 4, 5), rcond=1e-15)
 
 
 @testing.gpu

--- a/tests/cupy_tests/linalg_tests/test_solve.py
+++ b/tests/cupy_tests/linalg_tests/test_solve.py
@@ -156,7 +156,11 @@ class TestPinv(unittest.TestCase):
         a_gpu = testing.shaped_random(a_shape, dtype=dtype)
         a_cpu = cupy.asnumpy(a_gpu)
         a_gpu_copy = a_gpu.copy()
+        if not isinstance(rcond, float):
+            rcond = numpy.asarray(rcond)
         result_cpu = numpy.linalg.pinv(a_cpu, rcond=rcond)
+        if not isinstance(rcond, float):
+            rcond = cupy.asarray(rcond)
         result_gpu = cupy.linalg.pinv(a_gpu, rcond=rcond)
 
         assert result_cpu.dtype == result_gpu.dtype
@@ -175,6 +179,19 @@ class TestPinv(unittest.TestCase):
     def test_pinv_batched(self):
         self.check_x((2, 3, 4), rcond=1e-15)
         self.check_x((2, 3, 4, 5), rcond=1e-15)
+
+    def test_pinv_batched_vector_rcond(self):
+        self.check_x((2, 3, 4), rcond=[0.5, 0.5])
+        self.check_x((2, 3, 4, 5),
+                     rcond=[[0.2, 0.2, 0.2],
+                            [0.2, 0.2, 0.2]])
+
+    def test_pinv_size_0(self):
+        self.check_x((3, 0), rcond=1e-15)
+        self.check_x((0, 3), rcond=1e-15)
+        self.check_x((0, 0), rcond=1e-15)
+        self.check_x((0, 2, 3), rcond=1e-15)
+        self.check_x((2, 0, 3), rcond=1e-15)
 
 
 @testing.gpu


### PR DESCRIPTION
~~***Blocked by #4684*** as batched SVD is required but currently emitting random errors in the CI.~~

Close #3062.

- For supporting batched `pinv`: the original implementation already followed NumPy's, so really it's just adding `newaxis` here and there to broadcast. 
- This PR also fixes an incompatibility when the input array is of zero size