### PR TITLE
Fix random errors in batched SVD

### DIFF
--- a/cupy/cusolver.pyx
+++ b/cupy/cusolver.pyx
@@ -272,10 +272,6 @@ cpdef _gesvd_batched(a, a_dtype, full_matrices, compute_uv, overwrite_a):
         raise RuntimeError("This function is disabled on HIP as "
                            "it is not needed")
 
-    if runtime.runtimeGetVersion() == 10000:
-        # see https://github.com/cupy/cupy/pull/4628#issuecomment-780311925
-        raise RuntimeError("batched gesvd is buggy on CUDA 10.0")
-
     # TODO(leofang): try overlapping using a small stream pool?
 
     cdef ndarray x, s, u, vt, dev_info
@@ -341,8 +337,8 @@ cpdef _gesvd_batched(a, a_dtype, full_matrices, compute_uv, overwrite_a):
 
     # this wrapper also sets the stream for us
     buffersize = gesvd_bufferSize(handle, m, n)
-    # we are on the same stream, so the workspace can be reused in the loop
-    workspace = memory.alloc(buffersize)
+    # allocate workspace for each matrix to avoid race condition
+    workspace = memory.alloc(buffersize * batch_size)
     w_ptr = workspace.ptr
 
     # the loop starts here, with gil released to reduce overhead

--- a/cupy/cusolver.pyx
+++ b/cupy/cusolver.pyx
@@ -339,8 +339,8 @@ cpdef _gesvd_batched(a, a_dtype, full_matrices, compute_uv, overwrite_a):
 
     # this wrapper also sets the stream for us
     buffersize = gesvd_bufferSize(handle, m, n)
-    # we are on the same stream, so the workspace can be reused in the loop
-    workspace = memory.alloc(buffersize)
+    # allocate workspace for each matrix to avoid race condition
+    workspace = memory.alloc(buffersize * batch_size)
     w_ptr = workspace.ptr
 
     # the loop starts here, with gil released to reduce overhead

--- a/cupy/cusolver.pyx
+++ b/cupy/cusolver.pyx
@@ -341,7 +341,7 @@ cpdef _gesvd_batched(a, a_dtype, full_matrices, compute_uv, overwrite_a):
 
     buffersize = gesvd_bufferSize(handle, m, n)
     # allocate workspace for each matrix to avoid race condition
-    workspace = memory.alloc(buffersize * batch_size)
+    workspace = memory.alloc(buffersize * x.dtype.itemsize * batch_size)
     w_ptr = workspace.ptr
     stream_ptr = stream_module.get_current_stream_ptr()
 

--- a/cupy/cusolver.pyx
+++ b/cupy/cusolver.pyx
@@ -12,7 +12,6 @@ from cupy_backends.cuda.libs cimport cusolver
 # due to a Cython bug (cython/cython#4000) we cannot just cimport the module
 from cupy_backends.cuda.libs.cusolver cimport (  # noqa
     sgesvd_bufferSize, dgesvd_bufferSize, cgesvd_bufferSize, zgesvd_bufferSize)
-from cupy_backends.cuda cimport stream as stream_module
 
 from cupy.cuda cimport memory
 from cupy.core.core cimport _ndarray_init, ndarray
@@ -45,11 +44,11 @@ cdef extern from '../cupy_backends/cupy_lapack.h' nogil:
         intptr_t handle, char jobu, char jobvt, int m, int n, intptr_t A,
         intptr_t s_ptr, intptr_t u_ptr, intptr_t vt_ptr,
         intptr_t w_ptr, int buffersize, intptr_t info_ptr,
-        int batch_size, intptr_t stream_ptr)
+        int batch_size)
 
 ctypedef int(*gesvd_ptr)(intptr_t, char, char, int, int, intptr_t,
                          intptr_t, intptr_t, intptr_t,
-                         intptr_t, int, intptr_t, int, intptr_t) nogil
+                         intptr_t, int, intptr_t, int) nogil
 
 
 _available_cuda_version = {
@@ -278,7 +277,6 @@ cpdef _gesvd_batched(a, a_dtype, full_matrices, compute_uv, overwrite_a):
     cdef ndarray x, s, u, vt, dev_info
     cdef int n, m, k, batch_size, i, buffersize, d_size, status
     cdef intptr_t a_ptr, s_ptr, u_ptr, vt_ptr, rwork_ptr, w_ptr, info_ptr
-    cdef intptr_t stream_ptr
     cdef str s_dtype
     cdef char job_u, job_vt
     cdef bint trans_flag
@@ -339,18 +337,18 @@ cpdef _gesvd_batched(a, a_dtype, full_matrices, compute_uv, overwrite_a):
     else:
         raise TypeError
 
+    # this wrapper also sets the stream for us
     buffersize = gesvd_bufferSize(handle, m, n)
-    # allocate workspace for each matrix to avoid race condition
-    workspace = memory.alloc(buffersize * x.dtype.itemsize * batch_size)
+    # we are on the same stream, so the workspace can be reused in the loop
+    workspace = memory.alloc(buffersize * x.dtype.itemsize)
     w_ptr = workspace.ptr
-    stream_ptr = stream_module.get_current_stream_ptr()
 
     # the loop starts here, with gil released to reduce overhead
     with nogil:
         status = gesvd(
             handle, job_u, job_vt, m, n, a_ptr,
             s_ptr, u_ptr, vt_ptr,
-            w_ptr, buffersize, info_ptr, batch_size, stream_ptr)
+            w_ptr, buffersize, info_ptr, batch_size)
     if status != 0:
         raise _cusolver.CUSOLVERError(status)
 

--- a/cupy_backends/cuda/libs/cusolver.pyx
+++ b/cupy_backends/cuda/libs/cusolver.pyx
@@ -1,5 +1,6 @@
-"""Thin wrapper of CUSOLVER."""
 # distutils: language = c++
+
+"""Thin wrapper of CUSOLVER."""
 
 cimport cython  # NOQA
 

--- a/cupy_backends/cupy_lapack.h
+++ b/cupy_backends/cupy_lapack.h
@@ -35,11 +35,11 @@ int gesvd_loop(
         intptr_t handle, char jobu, char jobvt, int m, int n, intptr_t a_ptr,
         intptr_t s_ptr, intptr_t u_ptr, intptr_t vt_ptr,
         intptr_t w_ptr, int buffersize, intptr_t info_ptr,
-        int batch_size, intptr_t stream) {
+        int batch_size) {
     /*
      * Assumptions:
      * 1. the stream is set prior to calling this function
-     * 2. each matrix in the batch has its own workspace
+     * 2. the workspace is reused in the loop
      */
 
     cusolverStatus_t status;
@@ -58,9 +58,6 @@ int gesvd_loop(
     gesvd<T, real_type> func = gesvd_func<T, real_type>().ptr;
 
     for (int i=0; i<batch_size; i++) {
-        status = cusolverDnSetStream(reinterpret_cast<cusolverDnHandle_t>(handle),
-                                     reinterpret_cast<cudaStream_t>(stream));
-        if (status != 0) break;
         // setting rwork to NULL as we don't need it
         status = func(
             reinterpret_cast<cusolverDnHandle_t>(handle), jobu, jobvt, m, n, A, m,
@@ -70,7 +67,6 @@ int gesvd_loop(
         S += k;
         U += (jobu=='A' ? m*m : (jobu=='S' ? m*k : /* 'N' */ 0));
         VT += (jobvt=='A'? n*n : (jobvt=='S' ? n*k : /* 'N' */ 0));
-        Work += buffersize;
         devInfo += 1;
     }
     return status;

--- a/cupy_backends/cupy_lapack.h
+++ b/cupy_backends/cupy_lapack.h
@@ -39,7 +39,7 @@ int gesvd_loop(
     /*
      * Assumptions:
      * 1. the stream is set prior to calling this function
-     * 2. each matrix in the batch has its own workspace
+     * 2. the workspace is reused in the loop
      */
 
     cusolverStatus_t status;
@@ -67,8 +67,6 @@ int gesvd_loop(
         S += k;
         U += m * m;
         VT += n * n;
-        w_ptr += buffersize;
-        Work = reinterpret_cast<T*>(w_ptr);
         devInfo += 1;
     }
     return status;

--- a/cupy_backends/cupy_lapack.h
+++ b/cupy_backends/cupy_lapack.h
@@ -68,8 +68,8 @@ int gesvd_loop(
         if (status != 0) break;
         A += m * n;
         S += k;
-        U += (jobu=='A' ? m*m : m*k);
-        VT += (jobvt=='A'? n*n : n*k);
+        U += (jobu=='A' ? m*m : (jobu=='S' ? m*k : /* 'N' */ 0));
+        VT += (jobvt=='A'? n*n : (jobvt=='S' ? n*k : /* 'N' */ 0));
         w_ptr += buffersize;
         Work = reinterpret_cast<T*>(w_ptr);
         devInfo += 1;

--- a/cupy_backends/cupy_lapack.h
+++ b/cupy_backends/cupy_lapack.h
@@ -39,7 +39,7 @@ int gesvd_loop(
     /*
      * Assumptions:
      * 1. the stream is set prior to calling this function
-     * 2. the workspace is reused in the loop
+     * 2. each matrix in the batch has its own workspace
      */
 
     cusolverStatus_t status;
@@ -67,6 +67,8 @@ int gesvd_loop(
         S += k;
         U += m * m;
         VT += n * n;
+        w_ptr += buffersize;
+        Work = reinterpret_cast<T*>(w_ptr);
         devInfo += 1;
     }
     return status;

--- a/cupy_backends/cupy_lapack.h
+++ b/cupy_backends/cupy_lapack.h
@@ -39,7 +39,7 @@ int gesvd_loop(
     /*
      * Assumptions:
      * 1. the stream is set prior to calling this function
-     * 2. the workspace is reused in the loop
+     * 2. each matrix in the batch has its own workspace
      */
 
     cusolverStatus_t status;
@@ -67,6 +67,8 @@ int gesvd_loop(
         S += k;
         U += (jobu=='A' ? m*m : m*k);
         VT += (jobvt=='A'? n*n : n*k);
+        w_ptr += buffersize;
+        Work = reinterpret_cast<T*>(w_ptr);
         devInfo += 1;
     }
     return status;

--- a/cupy_backends/cupy_lapack.h
+++ b/cupy_backends/cupy_lapack.h
@@ -70,8 +70,7 @@ int gesvd_loop(
         S += k;
         U += (jobu=='A' ? m*m : (jobu=='S' ? m*k : /* 'N' */ 0));
         VT += (jobvt=='A'? n*n : (jobvt=='S' ? n*k : /* 'N' */ 0));
-        w_ptr += buffersize;
-        Work = reinterpret_cast<T*>(w_ptr);
+        Work += buffersize;
         devInfo += 1;
     }
     return status;

--- a/cupy_backends/cupy_lapack.h
+++ b/cupy_backends/cupy_lapack.h
@@ -65,8 +65,8 @@ int gesvd_loop(
         if (status != 0) break;
         A += m * n;
         S += k;
-        U += m * m;
-        VT += n * n;
+        U += (jobu=='A' ? m*m : m*k);
+        VT += (jobvt=='A'? n*n : n*k);
         devInfo += 1;
     }
     return status;

--- a/cupy_backends/cupy_lapack.h
+++ b/cupy_backends/cupy_lapack.h
@@ -35,7 +35,7 @@ int gesvd_loop(
         intptr_t handle, char jobu, char jobvt, int m, int n, intptr_t a_ptr,
         intptr_t s_ptr, intptr_t u_ptr, intptr_t vt_ptr,
         intptr_t w_ptr, int buffersize, intptr_t info_ptr,
-        int batch_size) {
+        int batch_size, intptr_t stream) {
     /*
      * Assumptions:
      * 1. the stream is set prior to calling this function
@@ -58,6 +58,9 @@ int gesvd_loop(
     gesvd<T, real_type> func = gesvd_func<T, real_type>().ptr;
 
     for (int i=0; i<batch_size; i++) {
+        status = cusolverDnSetStream(reinterpret_cast<cusolverDnHandle_t>(handle),
+                                     reinterpret_cast<cudaStream_t>(stream));
+        if (status != 0) break;
         // setting rwork to NULL as we don't need it
         status = func(
             reinterpret_cast<cusolverDnHandle_t>(handle), jobu, jobvt, m, n, A, m,

--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -618,6 +618,8 @@ def make_extensions(options, compiler, use_cython):
         link_args = s.setdefault('extra_link_args', [])
 
         if module['name'] == 'cusolver':
+            # cupy_backends/cupy_lapack.h has C++ template code
+            compile_args.append('--std=c++11')
             # openmp is required for cusolver
             if use_hip:
                 pass

--- a/tests/cupy_tests/linalg_tests/test_decomposition.py
+++ b/tests/cupy_tests/linalg_tests/test_decomposition.py
@@ -257,8 +257,6 @@ class TestSVD(unittest.TestCase):
         self.check_usv((2, 32, 32))  # still use _gesvdj_batched
 
     @condition.repeat(3, 10)
-    @pytest.mark.skipif(cupy.cuda.runtime.runtimeGetVersion() == 10000,
-                        reason='cuSOLVER bug')
     def test_svd_rank3_loop(self):
         # This tests the loop-based batched gesvd on CUDA (_gesvd_batched)
         self.check_usv((2, 64, 64))
@@ -274,8 +272,6 @@ class TestSVD(unittest.TestCase):
         self.check_singular((2, 4, 3))
 
     @condition.repeat(3, 10)
-    @pytest.mark.skipif(cupy.cuda.runtime.runtimeGetVersion() == 10000,
-                        reason='cuSOLVER bug')
     def test_svd_rank3_no_uv_loop(self):
         # This tests the loop-based batched gesvd on CUDA (_gesvd_batched)
         self.check_singular((2, 64, 64))
@@ -315,8 +311,6 @@ class TestSVD(unittest.TestCase):
         self.check_usv((2, 2, 32, 32))  # still use _gesvdj_batched
 
     @condition.repeat(3, 10)
-    @pytest.mark.skipif(cupy.cuda.runtime.runtimeGetVersion() == 10000,
-                        reason='cuSOLVER bug')
     def test_svd_rank4_loop(self):
         # This tests the loop-based batched gesvd on CUDA (_gesvd_batched)
         self.check_usv((3, 2, 64, 64))
@@ -332,8 +326,6 @@ class TestSVD(unittest.TestCase):
         self.check_singular((2, 2, 4, 3))
 
     @condition.repeat(3, 10)
-    @pytest.mark.skipif(cupy.cuda.runtime.runtimeGetVersion() == 10000,
-                        reason='cuSOLVER bug')
     def test_svd_rank4_no_uv_loop(self):
         # This tests the loop-based batched gesvd on CUDA (_gesvd_batched)
         self.check_singular((3, 2, 64, 64))


### PR DESCRIPTION
Close #4684. Close #4687.

Fix 3 bugs:
- The workspace size is not large enough
- The pointer address should be computed differently based on `full_matrices`
- Force C++11 compilation to work with older gcc (like gcc 5)

Remove the skip on CUDA 10.0 to force the CI to test it out, as gesvd shouldn't be affected by the known cuSOLVER bug.