### PR TITLE
Support `nvrtcGetSupportedArchs`

### DIFF
--- a/cupy_backends/cuda/cupy_nvrtc.h
+++ b/cupy_backends/cuda/cupy_nvrtc.h
@@ -17,6 +17,16 @@ nvrtcResult nvrtcGetCUBIN(...) {
 }
 #endif
 
+#if CUDA_VERSION < 11020
+// functions added in CUDA 11.2
+nvrtcResult nvrtcGetNumSupportedArchs(...) {
+    return NVRTC_ERROR_INTERNAL_ERROR;
+}
+
+nvrtcResult nvrtcGetSupportedArchs(...) {
+    return NVRTC_ERROR_INTERNAL_ERROR;
+}
+#endif
 }
 
 #endif // #ifndef INCLUDE_GUARD_CUDA_CUPY_NVRTC_H

--- a/cupy_backends/cuda/libs/nvrtc.pxd
+++ b/cupy_backends/cuda/libs/nvrtc.pxd
@@ -14,6 +14,7 @@ cdef extern from *:
 cpdef check_status(int status)
 
 cpdef tuple getVersion()
+cpdef tuple getSupportedArchs()
 
 
 ###############################################################################

--- a/cupy_backends/cuda/libs/nvrtc.pyx
+++ b/cupy_backends/cuda/libs/nvrtc.pyx
@@ -39,7 +39,7 @@ cdef extern from '../../cupy_rtc.h' nogil:
     int nvrtcAddNameExpression(Program, const char*)
     int nvrtcGetLoweredName(Program, const char*, const char**)
     int nvrtcGetNumSupportedArchs(int* numArchs)
-    int nvrtcGetSupportedArchs (int* supportedArchs)
+    int nvrtcGetSupportedArchs(int* supportedArchs)
 
 
 ###############################################################################
@@ -80,8 +80,8 @@ cpdef tuple getSupportedArchs():
 
     with nogil:
         status = nvrtcGetNumSupportedArchs(&num_archs)
-        archs.resize(num_archs)
         if status == 0:
+            archs.resize(num_archs)
             status = nvrtcGetSupportedArchs(archs.data())
     check_status(status)
     return tuple(archs)

--- a/cupy_backends/cuda/libs/nvrtc.pyx
+++ b/cupy_backends/cuda/libs/nvrtc.pyx
@@ -38,6 +38,8 @@ cdef extern from '../../cupy_rtc.h' nogil:
     int nvrtcGetProgramLog(Program prog, char* log)
     int nvrtcAddNameExpression(Program, const char*)
     int nvrtcGetLoweredName(Program, const char*, const char**)
+    int nvrtcGetNumSupportedArchs(int* numArchs)
+    int nvrtcGetSupportedArchs (int* supportedArchs)
 
 
 ###############################################################################
@@ -68,6 +70,21 @@ cpdef tuple getVersion():
         status = nvrtcVersion(&major, &minor)
     check_status(status)
     return major, minor
+
+
+cpdef tuple getSupportedArchs():
+    cdef int status, num_archs
+    cdef vector.vector[int] archs
+    if CUDA_VERSION < 11020 or runtime._is_hip_environment:
+        raise RuntimeError("getSupportedArchs is supported since CUDA 11.2")
+
+    with nogil:
+        status = nvrtcGetNumSupportedArchs(&num_archs)
+        archs.resize(num_archs)
+        if status == 0:
+            status = nvrtcGetSupportedArchs(archs.data())
+    check_status(status)
+    return tuple(archs)
 
 
 ###############################################################################

--- a/cupy_backends/hip/cupy_hiprtc.h
+++ b/cupy_backends/hip/cupy_hiprtc.h
@@ -50,6 +50,14 @@ nvrtcResult nvrtcGetCUBIN(...) {
     return HIPRTC_ERROR_COMPILATION;
 }
 
+nvrtcResult nvrtcGetNumSupportedArchs(...) {
+    return HIPRTC_ERROR_INTERNAL_ERROR;
+}
+
+nvrtcResult nvrtcGetSupportedArchs(...) {
+    return HIPRTC_ERROR_INTERNAL_ERROR;
+}
+
 nvrtcResult nvrtcGetProgramLogSize(nvrtcProgram prog, std::size_t* logSizeRet) {
     return hiprtcGetProgramLogSize(prog, logSizeRet);
 }

--- a/cupy_backends/stub/cupy_nvrtc.h
+++ b/cupy_backends/stub/cupy_nvrtc.h
@@ -48,6 +48,14 @@ nvrtcResult nvrtcGetCUBIN(...) {
     return NVRTC_SUCCESS;
 }
 
+nvrtcResult nvrtcGetNumSupportedArchs(...) {
+    return NVRTC_SUCCESS;
+}
+
+nvrtcResult nvrtcGetSupportedArchs(...) {
+    return NVRTC_SUCCESS;
+}
+
 nvrtcResult nvrtcGetProgramLogSize(...) {
     return NVRTC_SUCCESS;
 }


### PR DESCRIPTION
Add a wrapper for the new NVRTC API (added in CUDA 11.2) to query supported architectures:
```python
>>> import cupy as cp
>>> cp.cuda.nvrtc.getSupportedArchs()
(35, 37, 50, 52, 53, 60, 61, 62, 69, 70, 72, 75, 80, 86)
```