### PR TITLE
Update DLPack support

### DIFF
--- a/cupy/core/include/cupy/dlpack/README.md
+++ b/cupy/core/include/cupy/dlpack/README.md
@@ -1,4 +1,4 @@
 ## DLPack header
 
 The header `dlpack.h` is downloaded from https://github.com/dmlc/dlpack/blob/main/include/dlpack/dlpack.h.
-The commit is [`e1e11e0`](https://github.com/dmlc/dlpack/commit/e1e11e0d555c08bec08a6c7773aa777dfcaae9da).
+The commit is [`a07f962`](https://github.com/dmlc/dlpack/commit/a07f962d446b577adf4baef2b347a0f3a2a20617).

--- a/cupy/core/include/cupy/dlpack/dlpack.h
+++ b/cupy/core/include/cupy/dlpack/dlpack.h
@@ -13,7 +13,7 @@
 #endif
 
 /*! \brief The current version of dlpack */
-#define DLPACK_VERSION 030
+#define DLPACK_VERSION 040
 
 /*! \brief DLPACK_DLL prefix for windows */
 #ifdef _WIN32
@@ -33,7 +33,7 @@
 extern "C" {
 #endif
 /*!
- * \brief The device type in DLContext.
+ * \brief The device type in DLDevice.
  */
 typedef enum {
   /*! \brief CPU device */
@@ -64,23 +64,42 @@ typedef enum {
 } DLDeviceType;
 
 /*!
- * \brief A Device context for Tensor and operator.
+ * \brief A Device for Tensor and operator.
  */
 typedef struct {
   /*! \brief The device type used in the device. */
   DLDeviceType device_type;
   /*! \brief The device index */
   int device_id;
-} DLContext;
+} DLDevice;
+
+/*!
+ * \brief This is an alias for DLDevice. Notice that this will be removed in the next release.
+ */
+typedef DLDevice DLContext;
 
 /*!
  * \brief The type code options DLDataType.
  */
 typedef enum {
+  /*! \brief signed integer */
   kDLInt = 0U,
+  /*! \brief unsigned integer */
   kDLUInt = 1U,
+  /*! \brief IEEE floating point */
   kDLFloat = 2U,
+  /*!
+   * \brief Opaque handle type, reserved for testing purposes.
+   * Frameworks need to agree on the handle data type for the exchange to be well-defined.
+   */
+  kDLOpaqueHandle = 3U,
+  /*! \brief bfloat16 */
   kDLBfloat = 4U,
+  /*!
+   * \brief complex number
+   * (C/C++/Python layout: compact struct per complex number)
+   */
+  kDLComplex = 5U,
 } DLDataTypeCode;
 
 /*!
@@ -130,8 +149,8 @@ typedef struct {
    * \endcode
    */
   void* data;
-  /*! \brief The device context of the tensor */
-  DLContext ctx;
+  /*! \brief The device of the tensor */
+  DLDevice device;
   /*! \brief Number of dimensions */
   int ndim;
   /*! \brief The data type of the pointer*/

--- a/tests/cupy_tests/core_tests/test_dlpack.py
+++ b/tests/cupy_tests/core_tests/test_dlpack.py
@@ -6,15 +6,11 @@ import cupy
 from cupy import testing
 
 
-@testing.parameterize(*testing.product({
-    'dtype': [
-        cupy.uint8, cupy.uint16, cupy.uint32, cupy.uint64,
-        cupy.int8, cupy.int16, cupy.int32, cupy.int64,
-        cupy.float16, cupy.float32, cupy.float64],
-}))
 class TestDLPackConversion(unittest.TestCase):
 
-    def setUp(self):
+    @testing.for_all_dtypes(no_bool=True)
+    def test_conversion(self, dtype):
+        self.dtype = dtype
         if cupy.issubdtype(self.dtype, cupy.unsignedinteger):
             self.array = cupy.random.randint(
                 0, 10, size=(2, 3)).astype(self.dtype)
@@ -25,7 +21,6 @@ class TestDLPackConversion(unittest.TestCase):
             self.array = cupy.random.rand(
                 2, 3).astype(self.dtype)
 
-    def test_conversion(self):
         tensor = self.array.toDlpack()
         array = cupy.fromDlpack(tensor)
         testing.assert_array_equal(self.array, array)


### PR DESCRIPTION
~~**DO NOT MERGE** until the upstream is tagged!~~ 

The new v0.4 has the following change:
- Support complex numbers
- Rename the struct `DLContext` to `DLDevice`

Prepare for Array API adoption (https://github.com/data-apis/array-api/pull/106). 