### PR TITLE
Bump CUDA version for Docker images

### DIFF
--- a/docker/python3/Dockerfile
+++ b/docker/python3/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:10.2-cudnn7-devel
+FROM nvidia/cuda:11.1-cudnn7-devel
 
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
@@ -9,4 +9,4 @@ RUN apt-get update -y && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
 RUN pip3 install --no-cache-dir -U install setuptools pip
-RUN pip3 install --no-cache-dir cupy-cuda102==9.0.0b2 scipy optuna
+RUN pip3 install --no-cache-dir cupy-cuda111==9.0.0b2 scipy optuna


### PR DESCRIPTION
Closes #4593.

We may bump to more recent one in v9, if the newer CUDA version is released before CuPy v9rc release.