### PR TITLE
[backport] Update Python / NumPy / SciPy requirements

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -18,7 +18,7 @@ These components must be installed to use CuPy:
     * If you have multiple versions of CUDA Toolkit installed, CuPy will automatically choose one of the CUDA installations.
       See :ref:`install_cuda` for details.
 
-* `Python <https://python.org/>`_: v3.5.1+ / v3.6.0+ / v3.7.0+ / v3.8.0+
+* `Python <https://python.org/>`_: v3.5.1+ / v3.6.0+ / v3.7.0+ / v3.8.0+ / v3.9.0+
 
 .. note::
 
@@ -29,9 +29,9 @@ Python Dependencies
 
 NumPy/SciPy-compatible API in CuPy v8 is based on NumPy 1.19 and SciPy 1.5, and has been tested against the following versions:
 
-* `NumPy <https://numpy.org/>`_: v1.16 / v1.17 / v1.18 / v1.19
+* `NumPy <https://numpy.org/>`_: v1.16 / v1.17 / v1.18 / v1.19 / v1.20
 
-* `SciPy <https://scipy.org/>`_ (*optional*): v1.3 / v1.4 / v1.5
+* `SciPy <https://scipy.org/>`_ (*optional*): v1.3 / v1.4 / v1.5 / v1.6
 
     * Required only when using :doc:`reference/scipy` (``cupyx.scipy``).
 

--- a/setup.py
+++ b/setup.py
@@ -132,6 +132,7 @@ Programming Language :: Python :: 3.5
 Programming Language :: Python :: 3.6
 Programming Language :: Python :: 3.7
 Programming Language :: Python :: 3.8
+Programming Language :: Python :: 3.9
 Programming Language :: Python :: 3 :: Only
 Programming Language :: Cython
 Topic :: Software Development


### PR DESCRIPTION
Backport of #4711.

Manually made a backport as the content is different. Merge after ~#4711~ (merged).