### PR TITLE
Fix invalid command line generated when rpath is empty

### DIFF
--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -665,7 +665,7 @@ def make_extensions(options, compiler, use_cython):
 
             if not PLATFORM_WIN32 and not PLATFORM_LINUX:
                 assert False, "macOS is no longer supported"
-            if (PLATFORM_LINUX and s_file['library_dirs']):
+            if (PLATFORM_LINUX and len(rpath) != 0):
                 ldflag = '-Wl,'
                 if PLATFORM_LINUX:
                     ldflag += '--disable-new-dtags,'


### PR DESCRIPTION
When no rpath is needed, `-Wl,--disable-new-dtags,` is added to the command line, but the trailing comma is invalid.

This will be needed for ROCm packaging.