### PR TITLE
 Missing `constexpr` in `cupy_thrust.cu`

### DIFF
--- a/cupy/cuda/cupy_thrust.cu
+++ b/cupy/cuda/cupy_thrust.cu
@@ -87,7 +87,11 @@ __host__ __device__ __forceinline__ bool _tuple_less(const tuple<size_t, T>& lhs
  */
 
 template <typename T>
-__host__ __device__ __forceinline__ bool _cmp_less(const T& lhs, const T& rhs) {
+__host__ __device__ __forceinline__
+#if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2))
+constexpr
+#endif
+bool _cmp_less(const T& lhs, const T& rhs) {
     bool lhsRe = isnan(lhs.real());
     bool lhsIm = isnan(lhs.imag());
     bool rhsRe = isnan(rhs.real());

--- a/cupy/cuda/cupy_thrust.cu
+++ b/cupy/cuda/cupy_thrust.cu
@@ -191,6 +191,7 @@ __host__ __device__ __forceinline__
 constexpr
 #endif
 bool _real_less(const T& lhs, const T& rhs) {
+    #ifdef  __CUDA_ARCH__
     if (isnan(lhs)) {
         return false;
     } else if (isnan(rhs)) {
@@ -198,6 +199,9 @@ bool _real_less(const T& lhs, const T& rhs) {
     } else {
         return lhs < rhs;
     }
+    #else
+    return false;  // This will be never executed in the host
+    #endif
 }
 
 /*
@@ -260,8 +264,12 @@ bool less< tuple<size_t, double> >::operator() (
      && (__CUDA_ARCH__ >= 530 || !defined(__CUDA_ARCH__))) || (defined(__HIPCC__) || defined(CUPY_USE_HIP))
 
 // it seems Thrust doesn't care the code path on host, so we just need a wrapper for device
-__device__ __forceinline__ bool isnan(const __half& x) {
+__host__ __device__ __forceinline__ bool isnan(const __half& x) {
+    #ifdef  __CUDA_ARCH__
     return __hisnan(x);
+    #else
+    return false;  // This will never be called on the host
+    #endif
 }
 
 // specialize thrust::less for __half

--- a/cupy/cuda/cupy_thrust.cu
+++ b/cupy/cuda/cupy_thrust.cu
@@ -59,7 +59,11 @@ public:
  */
 
 template <typename T>
-__host__ __device__ __forceinline__ bool _tuple_less(const tuple<size_t, T>& lhs,
+__host__ __device__ __forceinline__ 
+#if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2))
+constexpr
+#endif
+bool _tuple_less(const tuple<size_t, T>& lhs,
                                                      const tuple<size_t, T>& rhs) {
     const size_t& lhs_k = lhs.template get<0>();
     const size_t& rhs_k = rhs.template get<0>();
@@ -182,7 +186,11 @@ bool less< tuple<size_t, complex<double>> >::operator() (
  */
 
 template <typename T>
-__host__ __device__ __forceinline__ bool _real_less(const T& lhs, const T& rhs) {
+__host__ __device__ __forceinline__
+#if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2))
+constexpr
+#endif
+bool _real_less(const T& lhs, const T& rhs) {
     if (isnan(lhs)) {
         return false;
     } else if (isnan(rhs)) {

--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -982,7 +982,11 @@ class _UnixCCompiler(unixccompiler.UnixCCompiler):
 
         cuda_version = build.get_cuda_version()
         postargs = _nvcc_gencode_options(cuda_version) + [
-            '-O2', '--compiler-options="-fPIC"', '--std=c++11']
+            '-O2', '--compiler-options="-fPIC"']
+        if cuda_version >= 11020:
+            postargs += ['--std=c++14']
+        else:
+            postargs += ['--std=c++11']
         print('NVCC options:', postargs)
         try:
             self.spawn(compiler_so + base_opts + cc_args + [src, '-o', obj] +


### PR DESCRIPTION
Windows ate it, but linux doesn't.
also when declaring some functions as constexpr other stuff started to blow up.
I built it locally and confirmed that now cuda 11.2 can be built.