### PR TITLE
[backport]  Missing `constexpr` in `cupy_thrust.cu`

### DIFF
--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -897,7 +897,11 @@ class _UnixCCompiler(unixccompiler.UnixCCompiler):
 
             cuda_version = build.get_cuda_version()
             postargs = _nvcc_gencode_options(cuda_version) + [
-                '-O2', '--compiler-options="-fPIC"', '--std=c++11']
+                '-O2', '--compiler-options="-fPIC"']
+            if cuda_version >= 11020:
+                postargs += ['--std=c++14']
+            else:
+                postargs += ['--std=c++11']
             print('NVCC options:', postargs)
 
             self.spawn(compiler_so + base_opts + cc_args + [src, '-o', obj] +


### PR DESCRIPTION
Backport of #4730