### PR TITLE
[backport] Bump Cython version requirement for Python 3.9

### DIFF
--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -21,7 +21,7 @@ from install.build import PLATFORM_WIN32
 
 # Cython requirements (minimum version and versions known to be broken).
 # Note: this must be in sync with setup_requires defined in setup.py.
-required_cython_version = pkg_resources.parse_version('0.28.0')
+required_cython_version = pkg_resources.parse_version('0.29.22')
 ignore_cython_versions = [
 ]
 use_hip = bool(int(os.environ.get('CUPY_INSTALL_USE_HIP', '0')))

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -191,7 +191,7 @@ If you want to install the latest development version of CuPy from a cloned Git 
 
 .. note::
 
-   To build the source tree downloaded from GitHub, you need to install Cython 0.28.0 or later (``pip install cython``).
+   To build the source tree downloaded from GitHub, you need to install Cython 0.29.22 or later (``pip install cython``).
    You don't have to install Cython to build source packages hosted on PyPI as they include pre-generated C++ source files.
 
 


### PR DESCRIPTION
Backport of #4706