### PR TITLE
[backport] Eliminate read past end of array in percentile_weightnening

### DIFF
--- a/cupy/_statistics/order.py
+++ b/cupy/_statistics/order.py
@@ -265,17 +265,18 @@ def percentile(a, q, axis=None, out=None, interpolation='linear',
             ret = cupy.rollaxis(out, 0, out.ndim)
 
         cupy.ElementwiseKernel(
-            'S idx, raw T a, raw int32 offset', 'U ret',
+            'S idx, raw T a, raw int32 offset, raw int32 size', 'U ret',
             '''
             ptrdiff_t idx_below = floor(idx);
             U weight_above = idx - idx_below;
 
             ptrdiff_t offset_i = _ind.get()[0] * offset;
+            ptrdiff_t max_idx = size - 1;
             ret = a[offset_i + idx_below] * (1.0 - weight_above)
-              + a[offset_i + idx_below + 1] * weight_above;
+              + a[min(offset_i + idx_below + 1, max_idx)] * weight_above;
             ''',
             'percentile_weightnening'
-        )(indices, ap, ap.shape[-1] if ap.ndim > 1 else 0, ret)
+        )(indices, ap, ap.shape[-1] if ap.ndim > 1 else 0, ap.size, ret)
         ret = cupy.rollaxis(ret, -1)  # Roll q dimension back to first axis
 
     if zerod:

--- a/tests/cupy_tests/statics_tests/test_order.py
+++ b/tests/cupy_tests/statics_tests/test_order.py
@@ -6,6 +6,7 @@ import pytest
 
 import cupy
 import cupy.core._accelerator as _acc
+from cupy import cuda
 from cupy import testing
 
 
@@ -107,6 +108,36 @@ class TestOrder(unittest.TestCase):
             q = testing.shaped_random((5,), xp, dtype=dtype, scale=100)
             with pytest.raises(ValueError):
                 xp.percentile(a, q, axis=-1, interpolation='deadbeef')
+
+    # See gh-4453
+    @testing.for_float_dtypes()
+    def test_percentile_memory_access(self, dtype):
+        # Create an allocator that guarantees array allocated in
+        # cupy.percentile call will be followed by a NaN
+        original_allocator = cuda.get_allocator()
+
+        def controlled_allocator(size):
+            memptr = original_allocator(size)
+            base_size = memptr.mem.size
+            assert base_size % 512 == 0
+            item_size = dtype().itemsize
+            shape = (base_size // item_size,)
+            x = cupy.ndarray(memptr=memptr, shape=shape, dtype=dtype)
+            x.fill(cupy.nan)
+            return memptr
+
+        # Check that percentile still returns non-NaN results
+        a = testing.shaped_random((5,), cupy, dtype)
+        q = cupy.array((0, 100), dtype=dtype)
+
+        cuda.set_allocator(controlled_allocator)
+        try:
+            percentiles = cupy.percentile(a, q, axis=None,
+                                          interpolation='linear')
+        finally:
+            cuda.set_allocator(original_allocator)
+
+        assert not cupy.any(cupy.isnan(percentiles))
 
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose()


### PR DESCRIPTION
Bring changes from PR 4453 into v8 to eliminate read past end of array in percentile calculations