### PR TITLE
Fix cuFFT callback compilations

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -94,13 +94,20 @@ tests_require = requirements['test']
 # - Files only needed in sdist should be added to `MANIFEST.in`.
 # - The following glob (`**`) ignores items starting with `.`.
 cupy_package_data = [
+    'cupy_backends/cuda/api/__init__.pxd',  # for cuFFT callback
+    'cupy_backends/cuda/api/driver.pxd',  # for cuFFT callback
+    'cupy_backends/cuda/api/runtime.pxd',  # for cuFFT callback
     'cupy/cuda/cupy_thrust.cu',
     'cupy/cuda/cupy_cub.cu',
+    'cupy/cuda/__init__.pxd',  # for cuFFT callback
     'cupy/cuda/cupy_cufftXt.cu',  # for cuFFT callback
     'cupy/cuda/cupy_cufftXt.h',  # for cuFFT callback
     'cupy/cuda/cupy_cufft.h',  # for cuFFT callback
     'cupy/cuda/cufft.pxd',  # for cuFFT callback
     'cupy/cuda/cufft.pyx',  # for cuFFT callback
+    'cupy/cuda/device.pxd',  # for cuFFT callback
+    'cupy/cuda/memory.pxd',  # for cuFFT callback
+    'cupy/cuda/stream.pxd',  # for cuFFT callback
     'cupy/random/cupy_distributions.cu',
     'cupy/random/cupy_distributions.cuh',
 ] + [


### PR DESCRIPTION
Address https://github.com/cupy/cupy/pull/4734#issuecomment-785392652.

This is proposal v1, and the solution is to include a few more `.pxd` files in sdist/wheel needed for compiling the callback modules.

Proposal v2 is to turn any `cimport` to `import` in the codepath, so that we only compile `cufft.pyx` and use only Python functions. I will try to put up a PR asap, but if this one is acceptable than please let me know. 