### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @cupy/code-owners


### PR DESCRIPTION
To prevent Mergify merging pull-requests without explicit review from core dev members, we are going to introduce branch protection settings.

https://docs.github.com/en/github/administering-a-repository/about-protected-branches#require-pull-request-reviews-before-merging

By adding a branch protection, Mergify won't merge the PR without explicit approval review to the latest commit from @cupy/code-owners members, even if the PR is labelled `test-and-merge`.