### PR TITLE
Xfail TestPolyfitCovMode when deg == 0 under ROCm/HIP

### DIFF
--- a/tests/cupy_tests/lib_tests/test_polynomial.py
+++ b/tests/cupy_tests/lib_tests/test_polynomial.py
@@ -520,6 +520,8 @@ class TestPolyfitCovMode(unittest.TestCase):
 
     @testing.for_float_dtypes(no_float16=True)
     def test_polyfit_cov(self, dtype):
+        if runtime.is_hip and self.deg == 0:
+            pytest.xfail('ROCm/HIP may have a bug')
         cp_c, cp_cov = self._cov_fit(cupy, dtype)
         np_c, np_cov = self._cov_fit(numpy, dtype)
         testing.assert_allclose(cp_c, np_c, rtol=1e-5)


### PR DESCRIPTION
Rel #4132, #4484, #4758.

Looks that polyfit returns negated value when deg == 0.