### PR TITLE
Xfail TestInvh under ROCm/HIP

### DIFF
--- a/tests/cupyx_tests/linalg_tests/test_solve.py
+++ b/tests/cupyx_tests/linalg_tests/test_solve.py
@@ -4,6 +4,7 @@ import numpy
 import pytest
 
 import cupy
+from cupy.cuda import runtime
 from cupy import cusolver
 from cupy import testing
 import cupyx
@@ -14,6 +15,8 @@ import cupyx
     'dtype': [numpy.float32, numpy.float64, numpy.complex64, numpy.complex128],
 }))
 @testing.gpu
+@pytest.mark.xfail(runtime.is_hip,
+                   reason='rocSOLVER does not implement potrs yet.')
 class TestInvh(unittest.TestCase):
 
     @testing.numpy_cupy_allclose(atol=1e-5)


### PR DESCRIPTION
Rel #4132, #4484.

Looks that rocSOLVER does not implement `potrs` yet.

https://rocsolver.readthedocs.io/en/latest/userguide_intro.html#brief-description-and-functionality