### PR TITLE
ROCm: remove the need to set `HCC_AMDGPU_TARGET` at runtime

### DIFF
--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -759,10 +759,9 @@ def _compile_with_cache_hip(source, options, arch, cache_dir, extra_source,
     # to tell the compiler which arch we are targeting. But, we still
     # need to know arch as part of the cache key:
     if arch is None:
-        if arch is None:
-            # On HIP, gcnArch is computed from "compute capability":
-            # https://github.com/ROCm-Developer-Tools/HIP/blob/2080cc113a2d767352b512b9d24c0620b6dee790/rocclr/hip_device.cpp#L202
-            arch = device.Device().compute_capability
+        # On HIP, gcnArch is computed from "compute capability":
+        # https://github.com/ROCm-Developer-Tools/HIP/blob/2080cc113a2d767352b512b9d24c0620b6dee790/rocclr/hip_device.cpp#L202
+        arch = device.Device().compute_capability
     if use_converter:
         source = _convert_to_hip_source(source, extra_source,
                                         is_hiprtc=(backend == 'hiprtc'))

--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -760,7 +760,7 @@ def _compile_with_cache_hip(source, options, arch, cache_dir, extra_source,
     # need to know arch as part of the cache key:
     if arch is None:
         # On HIP, gcnArch is computed from "compute capability":
-        # https://github.com/ROCm-Developer-Tools/HIP/blob/2080cc113a2d767352b512b9d24c0620b6dee790/rocclr/hip_device.cpp#L202
+        # https://github.com/ROCm-Developer-Tools/HIP/blob/rocm-4.0.0/rocclr/hip_device.cpp#L202
         arch = device.Device().compute_capability
     if use_converter:
         source = _convert_to_hip_source(source, extra_source,

--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -759,12 +759,10 @@ def _compile_with_cache_hip(source, options, arch, cache_dir, extra_source,
     # to tell the compiler which arch we are targeting. But, we still
     # need to know arch as part of the cache key:
     if arch is None:
-        arch = os.environ.get('HCC_AMDGPU_TARGET')
         if arch is None:
             # On HIP, gcnArch is computed from "compute capability":
             # https://github.com/ROCm-Developer-Tools/HIP/blob/2080cc113a2d767352b512b9d24c0620b6dee790/rocclr/hip_device.cpp#L202
-            arch = int(device.Device().compute_capability)
-            arch = (arch // 100) * 100 + (arch % 100)
+            arch = device.Device().compute_capability
     if use_converter:
         source = _convert_to_hip_source(source, extra_source,
                                         is_hiprtc=(backend == 'hiprtc'))

--- a/docs/source/install_rocm.rst
+++ b/docs/source/install_rocm.rst
@@ -22,16 +22,7 @@ Environment Variables
 
 When building or running CuPy for ROCm, the following environment variables are effective.
 
-* ``HCC_AMDGPU_TARGET``: ISA name supported by your GPU.
-  Run ``rocminfo`` and use the value displayed in ``Name:`` line (e.g., ``gfx900``).
-  You can specify a comma-separated list of ISAs if you have multiple GPUs of different architectures.
-
 * ``ROCM_HOME``: directory containing the ROCm software (e.g., ``/opt/rocm``).
-
-.. note::
-
-  In this version of CuPy, you must specify ``HCC_AMDGPU_TARGET`` at runtime.
-  This restriction will be removed in the future release.
 
 Docker
 ------
@@ -40,7 +31,7 @@ You can try running CuPy for ROCm using Docker.
 
 ::
 
-  $ docker run -it --device=/dev/kfd --device=/dev/dri --group-add video --env HCC_AMDGPU_TARGET=gfx900 cupy/cupy-rocm
+  $ docker run -it --device=/dev/kfd --device=/dev/dri --group-add video cupy/cupy-rocm
 
 .. _install_hip:
 
@@ -54,17 +45,20 @@ Currently we only offer wheels for ROCm v4.0.x.
 ::
 
   $ pip install --pre cupy-rocm-4-0
-  $ export HCC_AMDGPU_TARGET=gfx900
 
-Building CuPy for ROCm
------------------------
+Building CuPy for ROCm From Source
+----------------------------------
 
-To build CuPy from source, set ``CUPY_INSTALL_USE_HIP`` and ``ROCM_HOME`` environment variables.
+To build CuPy from source, set the ``CUPY_INSTALL_USE_HIP``, ``ROCM_HOME``, and ``HCC_AMDGPU_TARGET`` environment variables.
+(``HCC_AMDGPU_TARGET`` is the ISA name supported by your GPU.
+Run ``rocminfo`` and use the value displayed in ``Name:`` line (e.g., ``gfx900``).
+You can specify a comma-separated list of ISAs if you have multiple GPUs of different architectures.)
 
 ::
 
   $ export CUPY_INSTALL_USE_HIP=1
   $ export ROCM_HOME=/opt/rocm
+  $ export HCC_AMDGPU_TARGET=gfx906
   $ pip install --pre cupy
 
 .. note::


### PR DESCRIPTION
Close #4719. Both hiprtc and hipcc can pick up the right device, so no need to set `HCC_AMDGPU_TARGET` at runtime.