### PR TITLE
Assert MT19937 not implemented in hipRAND

### DIFF
--- a/tests/cupy_tests/random_tests/test_generator.py
+++ b/tests/cupy_tests/random_tests/test_generator.py
@@ -8,6 +8,7 @@ import pytest
 
 import cupy
 from cupy import cuda
+from cupy.cuda import runtime
 from cupy.random import _generator
 from cupy import testing
 from cupy.testing import attr
@@ -239,6 +240,17 @@ class TestRandomState(unittest.TestCase):
         ]
 
         for method in methods:
+            if (runtime.is_hip and
+                    method == cupy.cuda.curand.CURAND_RNG_PSEUDO_MT19937):
+                # hipRAND fails for MT19937 with the status code 1000,
+                # HIPRAND_STATUS_NOT_IMPLEMENTED. We use `pytest.raises` here
+                # so that we will be able to find it once hipRAND implement
+                # MT19937 as the imperative `pytest.xfail` immediately rewinds
+                # the control flow and does not run the test.
+                with pytest.raises(KeyError) as e:
+                    rs = cupy.random.RandomState(method=method)
+                assert e.value.args == (1000,)
+                continue
             rs = cupy.random.RandomState(method=method)
             rs.normal()
 


### PR DESCRIPTION
Rel #4132, #4484.

Looks that MT19937 is not implemented yet in hipRAND, failing with the status code `HIPRAND_STATUS_NOT_IMPLEMENTED`.