### PR TITLE
Support int argument for Dirichlet shape

### DIFF
--- a/cupy/random/_generator.py
+++ b/cupy/random/_generator.py
@@ -143,7 +143,7 @@ class RandomState(object):
         if size is None:
             size = alpha.shape
         elif isinstance(size, (int, cupy.integer)):
-            size = [size]
+            size = [size] + alpha.shape
         else:
             size += alpha.shape
         y = cupy.empty(shape=size, dtype=dtype)

--- a/cupy/random/_generator.py
+++ b/cupy/random/_generator.py
@@ -143,6 +143,7 @@ class RandomState(object):
         if size is None:
             size = alpha.shape
         else:
+            size = list(size)  # In case size is an int
             size += alpha.shape
         y = cupy.empty(shape=size, dtype=dtype)
         _kernels.standard_gamma_kernel(alpha, self._rk_seed, y)

--- a/cupy/random/_generator.py
+++ b/cupy/random/_generator.py
@@ -143,7 +143,7 @@ class RandomState(object):
         if size is None:
             size = alpha.shape
         elif isinstance(size, (int, cupy.integer)):
-            size = [size] + alpha.shape
+            size = (size,) + alpha.shape
         else:
             size += alpha.shape
         y = cupy.empty(shape=size, dtype=dtype)

--- a/cupy/random/_generator.py
+++ b/cupy/random/_generator.py
@@ -142,8 +142,9 @@ class RandomState(object):
         alpha = cupy.asarray(alpha)
         if size is None:
             size = alpha.shape
+        elif isinstance(size, (int, cupy.integer)):
+            size = [size]
         else:
-            size = list(size)  # In case size is an int
             size += alpha.shape
         y = cupy.empty(shape=size, dtype=dtype)
         _kernels.standard_gamma_kernel(alpha, self._rk_seed, y)

--- a/tests/cupy_tests/random_tests/test_generator.py
+++ b/tests/cupy_tests/random_tests/test_generator.py
@@ -316,6 +316,9 @@ class TestDirichlet(RandomGeneratorTestCase):
     def test_dirichlet(self):
         self.generate(alpha=self.alpha, size=(3, 2, 3))
 
+    def test_dirichlet_int_shape(self):
+        self.generate(alpha=self.alpha, size=5)
+
     # TODO(kataoka): add distribution test
 
 


### PR DESCRIPTION
Currently, cupy's Dirichlet distribution does not support an integer argument a a shape. Only tuples are allowed; ints lead to a `TypeError`. This differs from the behavior of numpy and is not a necessary restriction. It also does not match the [documented parameters](https://docs.cupy.dev/en/stable/reference/generated/cupy.random.dirichlet.html).

The issue has been [detailed on Stack Overflow recently](https://stackoverflow.com/a/66405505/7802200). A workaround is for the user to provide the size as a tuple, but they shouldn't have to.

I address this by turning the provided argument into a list. (If it's already a list or tuple, this won't affect anything.) I provide a test case as well.

Note that cupy's multivariate normal distribution supports both integer and tuple arguments.