### PR TITLE
Add CuPy JIT Kernel definition

### DIFF
--- a/cupy/_functional/vectorize.py
+++ b/cupy/_functional/vectorize.py
@@ -65,14 +65,14 @@ class vectorize(object):
                 raise NotImplementedError
 
             func = _interface._CudaFunction(self.pyfunc, 'numpy', device=True)
-            code, ret_type = func._emit_code_from_types(in_types, ret_type)
+            result = func._emit_code_from_types(in_types, ret_type)
             in_params = ', '.join(
                 f'{t.dtype} in{i}' for i, t in enumerate(in_types))
-            out_params = f'{ret_type.dtype} out0'
+            out_params = str(result.return_type.dtype) + ' out0'
             body = 'out0 = {}({})'.format(
                 func.name, ', '.join([f'in{i}' for i in range(len(in_types))]))
             kern = core.ElementwiseKernel(
-                in_params, out_params, body, preamble=code)
+                in_params, out_params, body, preamble=result.code)
             self._kernel_cache[itypes] = kern
 
         return kern(*args)

--- a/cupyx/jit/__init__.py
+++ b/cupyx/jit/__init__.py
@@ -1,1 +1,6 @@
 from cupyx.jit._interface import rawkernel  # NOQA
+
+from cupyx.jit._interface import threadIdx  # NOQA
+from cupyx.jit._interface import blockDim  # NOQA
+from cupyx.jit._interface import blockIdx  # NOQA
+from cupyx.jit._interface import gridDim  # NOQA

--- a/cupyx/jit/__init__.py
+++ b/cupyx/jit/__init__.py
@@ -1,0 +1,1 @@
+from cupyx.jit._interface import rawkernel  # NOQA

--- a/cupyx/jit/_compile.py
+++ b/cupyx/jit/_compile.py
@@ -1,5 +1,6 @@
 import ast
 import builtins
+import collections
 import inspect
 import numbers
 import re
@@ -14,6 +15,8 @@ from cupyx.jit import _typerules
 
 
 _typeclasses = (bool, numpy.bool_, numbers.Number)
+
+Result = collections.namedtuple('Result', ['func_name', 'code', 'return_type'])
 
 
 def transpile(func, attributes, mode, in_types, ret_type):
@@ -48,7 +51,11 @@ def transpile(func, attributes, mode, in_types, ret_type):
     cuda_code, env = _transpile_function(
         tree.body[0], attributes, mode, consts, in_types, ret_type)
     cuda_code = ''.join([code + '\n' for code in env.preambles]) + cuda_code
-    return cuda_code, env.ret_type
+    return Result(
+        func_name=func.__name__,
+        code=cuda_code,
+        return_type=env.ret_type,
+    )
 
 
 def _indent(lines, spaces='  '):

--- a/cupyx/jit/_compile.py
+++ b/cupyx/jit/_compile.py
@@ -439,7 +439,15 @@ def _transpile_expr(expr, env):
 
     Returns (CudaObject): The CUDA code and its type of the expression.
     """
+    res = _transpile_expr_internal(expr, env)
 
+    if isinstance(res, Constant) and isinstance(res.obj, CudaObject):
+        return res.obj
+    else:
+        return res
+
+
+def _transpile_expr_internal(expr, env):
     if isinstance(expr, ast.BoolOp):
         values = [_transpile_expr(e, env) for e in expr.values]
         value = values[0]

--- a/cupyx/jit/_compile.py
+++ b/cupyx/jit/_compile.py
@@ -197,6 +197,10 @@ def _transpile_function(
     body = _transpile_stmts(func.body, True, env)
     params = ', '.join([f'{env[a].ctype} {a}' for a in args])
     local_vars = [f'{v.ctype} {n};' for n, v in env.locals.items()]
+
+    if env.ret_type is None:
+        env.ret_type = _types.Void()
+
     head = f'{attributes} {env.ret_type} {func.name}({params})'
     code = CodeBlock(head, local_vars + body)
     return str(code), env

--- a/cupyx/jit/_compile.py
+++ b/cupyx/jit/_compile.py
@@ -191,7 +191,7 @@ def _transpile_function(
     if len(args) != len(in_types):
         raise TypeError(
             f'{func.name}() takes {len(args)} positional arguments '
-            'but {len(in_types)} were given.')
+            f'but {len(in_types)} were given.')
     params = dict([(x, CudaObject(x, t)) for x, t in zip(args, in_types)])
     env = Environment(mode, consts, params, ret_type)
     body = _transpile_stmts(func.body, True, env)

--- a/cupyx/jit/_compile.py
+++ b/cupyx/jit/_compile.py
@@ -578,7 +578,7 @@ def _to_cuda_object(x, env):
         return x
     if isinstance(x, Constant):
         ctype = _typerules.get_ctype_from_scalar(env.mode, x.obj)
-        code = _typerules.get_cuda_code_from_constant(x.obj, ctype)
+        code = _types.get_cuda_code_from_constant(x.obj, ctype)
         return CudaObject(code, ctype)
     if isinstance(x, Range):
         raise TypeError('range object cannot be interpreted as a cuda object.')

--- a/cupyx/jit/_interface.py
+++ b/cupyx/jit/_interface.py
@@ -1,3 +1,5 @@
+import collections
+
 import numpy
 
 import cupy
@@ -78,3 +80,20 @@ def rawkernel(mode='cuda'):
     def wrapper(func):
         return _JitRawKernel(func, mode)
     return wrapper
+
+
+Dim3 = collections.namedtuple('dim3', ['x', 'y', 'z'])
+
+
+def _create_dim3(name):
+    return Dim3(
+        _compile.CudaObject(f'{name}.x', _types.uint32),
+        _compile.CudaObject(f'{name}.y', _types.uint32),
+        _compile.CudaObject(f'{name}.z', _types.uint32),
+    )
+
+
+threadIdx = _create_dim3('threadIdx')
+blockDim = _create_dim3('blockDim')
+blockIdx = _create_dim3('blockIdx')
+gridDim = _create_dim3('gridDim')

--- a/cupyx/jit/_interface.py
+++ b/cupyx/jit/_interface.py
@@ -69,11 +69,13 @@ class _JitRawKernel:
             self._cache[in_types] = kern
         kern(grid, block, args)
 
-    # def __getitem__(self, grid, block):
-    #     if not isinstance(grid, tuple):
-    #         grid = (grid, 1, 1)
-    #     if not isinstance(block, tuple):
-    #         block = (block, 1, 1)
+    def __getitem__(self, grid_and_block):
+        grid, block = grid_and_block
+        if not isinstance(grid, tuple):
+            grid = (grid, 1, 1)
+        if not isinstance(block, tuple):
+            block = (block, 1, 1)
+        return lambda *args: self(grid, block, args)
 
 
 def rawkernel(mode='cuda'):

--- a/cupyx/jit/_typerules.py
+++ b/cupyx/jit/_typerules.py
@@ -106,7 +106,7 @@ def get_ufunc(mode, op_type):
     if mode == 'numpy':
         return _numpy_ops[op_type]
     if mode == 'cuda':
-        raise NotImplementedError
+        return _numpy_ops[op_type]
     assert False
 
 

--- a/cupyx/jit/_typerules.py
+++ b/cupyx/jit/_typerules.py
@@ -137,30 +137,3 @@ def get_ctype_from_scalar(mode, x):
             return _types.Scalar(numpy.complex64)
 
     raise NotImplementedError(f'{x} is not scalar object.')
-
-
-_suffix_literals_dict = {
-    numpy.dtype('float64'): '',
-    numpy.dtype('float32'): 'f',
-    numpy.dtype('int64'): 'll',
-    numpy.dtype('longlong'): 'll',
-    numpy.dtype('int32'): '',
-    numpy.dtype('uint64'): 'ull',
-    numpy.dtype('ulonglong'): 'ull',
-    numpy.dtype('uint32'): 'u',
-    numpy.dtype('bool'): '',
-}
-
-
-def get_cuda_code_from_constant(x, ctype):
-    dtype = ctype.dtype
-    suffix_literal = _suffix_literals_dict.get(dtype)
-    if suffix_literal is not None:
-        s = str(x).lower()
-        return f'{s}{suffix_literal}'
-    ctype = str(ctype)
-    if dtype.kind == 'c':
-        return f'{ctype}({x.real}, {x.imag})'
-    if ' ' in ctype:
-        return f'({ctype}){x}'
-    return f'{ctype}({x})'

--- a/cupyx/jit/_types.py
+++ b/cupyx/jit/_types.py
@@ -49,6 +49,7 @@ class Array(TypeBase):
 
 
 bool_ = Scalar(numpy.bool_)
+uint32 = Scalar(numpy.uint32)
 
 
 _suffix_literals_dict = {

--- a/cupyx/jit/_types.py
+++ b/cupyx/jit/_types.py
@@ -29,6 +29,25 @@ class Scalar(TypeBase):
         return get_typename(dtype)
 
 
+class Array(TypeBase):
+
+    def __init__(self, dtype, ndim, is_c_contiguous, index_32_bits):
+        self.dtype = dtype
+        self.ndim = ndim
+        self.is_c_contiguous = is_c_contiguous
+        self.index_32_bits = index_32_bits
+
+    @classmethod
+    def from_ndarray(cls, x):
+        return Array(x.dtype, x.ndim, x._c_contiguous, x._index_32_bits)
+
+    def __str__(self):
+        ctype = get_typename(self.dtype)
+        c_contiguous = get_cuda_code_from_constant(self.is_c_contiguous, bool_)
+        index_32_bits = get_cuda_code_from_constant(self.index_32_bits, bool_)
+        return f'CArray<{ctype}, {self.ndim}, {c_contiguous}, {index_32_bits}>'
+
+
 bool_ = Scalar(numpy.bool_)
 
 

--- a/cupyx/jit/_types.py
+++ b/cupyx/jit/_types.py
@@ -30,3 +30,30 @@ class Scalar(TypeBase):
 
 
 bool_ = Scalar(numpy.bool_)
+
+
+_suffix_literals_dict = {
+    numpy.dtype('float64'): '',
+    numpy.dtype('float32'): 'f',
+    numpy.dtype('int64'): 'll',
+    numpy.dtype('longlong'): 'll',
+    numpy.dtype('int32'): '',
+    numpy.dtype('uint64'): 'ull',
+    numpy.dtype('ulonglong'): 'ull',
+    numpy.dtype('uint32'): 'u',
+    numpy.dtype('bool'): '',
+}
+
+
+def get_cuda_code_from_constant(x, ctype):
+    dtype = ctype.dtype
+    suffix_literal = _suffix_literals_dict.get(dtype)
+    if suffix_literal is not None:
+        s = str(x).lower()
+        return f'{s}{suffix_literal}'
+    ctype = str(ctype)
+    if dtype.kind == 'c':
+        return f'{ctype}({x.real}, {x.imag})'
+    if ' ' in ctype:
+        return f'({ctype}){x}'
+    return f'{ctype}({x})'

--- a/tests/cupyx_tests/jit_tests/test_raw.py
+++ b/tests/cupyx_tests/jit_tests/test_raw.py
@@ -1,0 +1,43 @@
+import unittest
+import numpy
+
+import cupy
+from cupyx import jit
+from cupy import testing
+
+
+class TestRaw(unittest.TestCase):
+
+    def test_raw_kick_one_kernel(self):
+        @jit.rawkernel()
+        def f(x, y):
+            y[0] = x[0]
+
+        x = cupy.array([10], dtype=numpy.int32)
+        y = cupy.array([20], dtype=numpy.int32)
+        f((1,), (1,), (x, y))
+        assert int(y[0]) == 10
+
+    def test_raw_elementwise_single_op(self):
+        @jit.rawkernel()
+        def f(x, y):
+            tid = jit.threadIdx.x + jit.blockDim.x * jit.blockIdx.x
+            y[tid] = x[tid]
+
+        x = testing.shaped_random((30,), dtype=numpy.int32, seed=0)
+        y = testing.shaped_random((30,), dtype=numpy.int32, seed=1)
+        f((5,), (6,), (x, y))
+        assert bool((x == y).all())
+
+    def test_raw_elementwise_loop(self):
+        @jit.rawkernel()
+        def f(x, y, size):
+            tid = jit.threadIdx.x + jit.blockDim.x * jit.blockIdx.x
+            ntid = jit.blockDim.x * jit.gridDim.x
+            for i in range(tid, size, ntid):
+                y[i] = x[i]
+
+        x = testing.shaped_random((1024,), dtype=numpy.int32, seed=0)
+        y = testing.shaped_random((1024,), dtype=numpy.int32, seed=1)
+        f((5,), (6,), (x, y, numpy.uint32(1024)))
+        assert bool((x == y).all())

--- a/tests/cupyx_tests/jit_tests/test_raw.py
+++ b/tests/cupyx_tests/jit_tests/test_raw.py
@@ -41,3 +41,16 @@ class TestRaw(unittest.TestCase):
         y = testing.shaped_random((1024,), dtype=numpy.int32, seed=1)
         f((5,), (6,), (x, y, numpy.uint32(1024)))
         assert bool((x == y).all())
+
+    def test_raw_grid_block_interface(self):
+        @jit.rawkernel()
+        def f(x, y, size):
+            tid = jit.threadIdx.x + jit.blockDim.x * jit.blockIdx.x
+            ntid = jit.blockDim.x * jit.gridDim.x
+            for i in range(tid, size, ntid):
+                y[i] = x[i]
+
+        x = testing.shaped_random((1024,), dtype=numpy.int32, seed=0)
+        y = testing.shaped_random((1024,), dtype=numpy.int32, seed=1)
+        f[5, 6](x, y, numpy.uint32(1024))
+        assert bool((x == y).all())


### PR DESCRIPTION
Part of #4290.

This PR supports a raw kernel interface like as following.
```py
from cupyx import jit

@jit.rawkernel()
def f(x, y, z, n):
    tid = jit.threadIdx.x + jit.blockIdx.x * jit.blockDim.x
    ntid = jit.blockDim.x * jit.gridDim.x
    for i in range(tid, n, ntid):
        z[i] = x[i] + y[i]

n = numpy.uint32(1024)
x = cupy.arange(n)
y = cupy.arange(n)
z = cupy.empty((n,), dtype='l')
f[16, 16](x, y, z, n)
```