### PR TITLE
Xfail some tests for `cupyx.scipy.statistics.correlation` under ROCm/HIP

### DIFF
--- a/tests/cupy_tests/statistics_tests/test_correlation.py
+++ b/tests/cupy_tests/statistics_tests/test_correlation.py
@@ -4,6 +4,7 @@ import numpy
 import pytest
 
 import cupy
+from cupy.cuda import runtime
 from cupy import testing
 
 
@@ -116,6 +117,8 @@ class TestCorrelate(unittest.TestCase):
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(rtol=1e-5)
     def test_correlate_non_contiguous(self, xp, dtype):
+        if runtime.is_hip and self.mode == 'full':
+            pytest.xfail(reason='ROCm/HIP may have a bug')
         a = testing.shaped_arange((300,), xp, dtype)
         b = testing.shaped_arange((100,), xp, dtype)
         return xp.correlate(a[::200], b[10::70], mode=self.mode)
@@ -129,6 +132,7 @@ class TestCorrelate(unittest.TestCase):
 
     @testing.for_all_dtypes_combination(names=['dtype1', 'dtype2'])
     @testing.numpy_cupy_allclose(rtol=1e-2)
+    @pytest.mark.xfail(runtime.is_hip, reason='ROCm/HIP may have a bug')
     def test_correlate_diff_types(self, xp, dtype1, dtype2):
         a = testing.shaped_random((200,), xp, dtype1)
         b = testing.shaped_random((100,), xp, dtype2)


### PR DESCRIPTION
Rel #4132, #4484.

Assertion errors like below:
```
E       AssertionError:
E       Not equal to tolerance rtol=0.01, atol=0
E
E       Mismatched elements: 101 / 101 (100%)
E       Max absolute difference: 64847
E       Max relative difference: 42.19661458
E        x: array([1191,  651,  779,  562,  751,  745,  693,  862,  864,  936, 1027,
E               988,  962,  827,  937,  817,  832,  837,  814,  740,  794,  842,
E               771,  822,  895,  956,  943,  996,  946,  983,  890,  912,  824,...
E        y: array([2592, 1718, 1987, 1649, 1849, 1731, 1795, 1760, 1768, 1660, 1897,
E              1677, 1809, 1717, 1837, 1735, 1847, 1829, 1986, 1817, 1897, 1825,
E              1697, 1752, 1698, 1794, 1725, 1754, 1791, 1757, 1813, 1836, 1871,...
```