### PR TITLE
Remove duplicated typedef in example when HIP

### DIFF
--- a/examples/finance/monte_carlo.py
+++ b/examples/finance/monte_carlo.py
@@ -43,6 +43,10 @@ monte_carlo_kernel = cupy.ElementwiseKernel(
     call = discount_factor * call_sum / n_samples;
     ''',
     preamble='''
+    #ifndef __HIPCC__
+    typedef unsigned long long uint64_t;
+    #endif
+
     __device__
     inline T get_call_value(T s, T x, T p, T mu_by_t, T v_by_sqrt_t) {
         const T call_value = s * exp(mu_by_t + v_by_sqrt_t * p) - x;

--- a/examples/finance/monte_carlo.py
+++ b/examples/finance/monte_carlo.py
@@ -43,8 +43,6 @@ monte_carlo_kernel = cupy.ElementwiseKernel(
     call = discount_factor * call_sum / n_samples;
     ''',
     preamble='''
-    typedef unsigned long long uint64_t;
-
     __device__
     inline T get_call_value(T s, T x, T p, T mu_by_t, T v_by_sqrt_t) {
         const T call_value = s * exp(mu_by_t + v_by_sqrt_t * p) - x;


### PR DESCRIPTION
Rel #4132, #4484.

hipRTC fails with the conflicting typedef.

```
cupy.cuda.compiler.CompileException: /tmp/comgr-17edf0/input/CompileSource:5358:32: error: typedef redefinition with different types ('unsigned long long' vs '__uint64_t' (aka 'unsigned long'))
    typedef unsigned long long uint64_t;
                               ^
/usr/include/x86_64-linux-gnu/bits/stdint-uintn.h:27:20: note: previous definition is here
typedef __uint64_t uint64_t;
                   ^
```