### PR TITLE
[v8] Fix `linalg.pinv` on empty matrices

### DIFF
--- a/cupy/linalg/_solve.py
+++ b/cupy/linalg/_solve.py
@@ -450,6 +450,11 @@ def pinv(a, rcond=1e-15):
 
     .. seealso:: :func:`numpy.linalg.pinv`
     """
+    _util._assert_cupy_array(a)
+    # v8 does not support batched SVD
+    _util._assert_rank2(a)
+    if a.size == 0:
+        return cupy.empty_like(a.T)
     u, s, vt = _decomposition.svd(a.conj(), full_matrices=False)
     cutoff = rcond * s.max()
     s1 = 1 / s

--- a/cupy/linalg/_solve.py
+++ b/cupy/linalg/_solve.py
@@ -436,7 +436,8 @@ def pinv(a, rcond=1e-15):
         a (cupy.ndarray): The matrix with dimension ``(M, N)``
         rcond (float): Cutoff parameter for small singular values.
             For stability it computes the largest singular value denoted by
-            ``s``, and sets all singular values smaller than ``s`` to zero.
+            ``rcond * s``, and sets all singular values smaller than ``s``
+            to zero.
 
     Returns:
         cupy.ndarray: The pseudoinverse of ``a`` with dimension ``(N, M)``.

--- a/tests/cupy_tests/linalg_tests/test_solve.py
+++ b/tests/cupy_tests/linalg_tests/test_solve.py
@@ -157,6 +157,11 @@ class TestPinv(unittest.TestCase):
         self.check_x((2, 5), rcond=0.5)
         self.check_x((5, 3), rcond=0.6)
 
+    def test_pinv_size_0(self):
+        self.check_x((3, 0), rcond=1e-15)
+        self.check_x((0, 3), rcond=1e-15)
+        self.check_x((0, 0), rcond=1e-15)
+
     def test_invalid_shape(self):
         self.check_shape((2, 3, 4), rcond=1e-15)
         self.check_shape((2, 3, 4), rcond=0.5)


### PR DESCRIPTION
Manual backport of #4686.