### PR TITLE
Revert "[backport] Remove `cupy-cuda112` support from documentation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Choose the right package for your CUDA Toolkit version.
 | v10.2 | `pip install cupy-cuda102`     |
 | v11.0 | `pip install cupy-cuda110`     |
 | v11.1 | `pip install cupy-cuda111`     |
+| v11.2 | `pip install cupy-cuda112` (see [#4704](https://github.com/cupy/cupy/issues/4704) for Linux instructions)     |
 
 See the [Installation Guide](https://docs.cupy.dev/en/stable/install.html) if you are using Conda/Anaconda or to build from source.
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -92,6 +92,8 @@ Package names are different depending on your CUDA Toolkit version.
      - ``$ pip install cupy-cuda110``
    * - v11.1
      - ``$ pip install cupy-cuda111``
+   * - v11.2
+     - ``$ pip install cupy-cuda112`` (see `#4704 <https://github.com/cupy/cupy/issues/4704>`_ for Linux instructions)
 
 .. note::
 


### PR DESCRIPTION
Reverts cupy/cupy#4762