### PR TITLE
Deprecate `cupy.bool`, `cupy.int`, `cupy.float` and `cupy.complex`

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -1,5 +1,6 @@
 import functools as _functools
 import sys as _sys
+import warnings as _warnings
 
 import numpy as _numpy
 
@@ -211,22 +212,6 @@ from numpy import complex128  # NOQA
 # -----------------------------------------------------------------------------
 # Built-in Python types
 # -----------------------------------------------------------------------------
-
-# After NumPy 1.20 is released, CuPy should mimic the DeprecationWarning
-# behavior for these types
-
-from builtins import int  # NOQA
-
-from builtins import bool  # NOQA
-
-from builtins import float  # NOQA
-
-from builtins import complex  # NOQA
-
-# Not supported by CuPy:
-# from numpy import object
-# from numpy import unicode
-# from numpy import str
 
 # =============================================================================
 # Routines
@@ -874,3 +859,24 @@ def show_config():
     """Prints the current runtime configuration to standard output."""
     _sys.stdout.write(str(_cupyx.get_runtime_info()))
     _sys.stdout.flush()
+
+
+_deprecated_attrs = {
+    'int': (int, 'cupy.int_'),
+    'bool': (bool, 'cupy.bool_'),
+    'float': (float, 'cupy.float_'),
+    'complex': (complex, 'cupy.complex_')
+}
+
+
+def __getattr__(attr_name):
+    value = _deprecated_attrs.get(attr_name)
+    if value is None:
+        raise AttributeError(
+            f"module 'cupy' has no attribute '{attr_name}'")
+    attr, eq_attr = value
+    _warnings.warn(
+        f'`cupy.{attr_name}` is deprecated. Please use `{eq_attr}` instead.',
+        DeprecationWarning, stacklevel=2
+    )
+    return attr

--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -873,7 +873,7 @@ if _sys.version_info >= (3, 7):
         value = _deprecated_attrs.get(name)
         if value is None:
             raise AttributeError(
-                f"module 'cupy' has no attribute '{name}'")
+                f"module 'cupy' has no attribute {name!r}")
         attr, eq_attr = value
         _warnings.warn(
             f'`cupy.{name}` is a deprecated alias for the Python scalar type '

--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -876,7 +876,9 @@ if _sys.version_info >= (3, 7):
                 f"module 'cupy' has no attribute '{name}'")
         attr, eq_attr = value
         _warnings.warn(
-            f'`cupy.{name}` is deprecated. Please use `{eq_attr}` instead.',
+            f'`cupy.{name}` is a deprecated alias for the Python scalar type '
+            f'`{name}`. Please use the builtin `{name}` or its corresponding '
+            f'NumPy scalar type `{eq_attr}` instead.',
             DeprecationWarning, stacklevel=2
         )
         return attr

--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -861,22 +861,28 @@ def show_config():
     _sys.stdout.flush()
 
 
-_deprecated_attrs = {
-    'int': (int, 'cupy.int_'),
-    'bool': (bool, 'cupy.bool_'),
-    'float': (float, 'cupy.float_'),
-    'complex': (complex, 'cupy.complex_')
-}
+if _sys.version_info >= (3, 7):
+    _deprecated_attrs = {
+        'int': (int, 'cupy.int_'),
+        'bool': (bool, 'cupy.bool_'),
+        'float': (float, 'cupy.float_'),
+        'complex': (complex, 'cupy.complex_'),
+    }
 
-
-def __getattr__(attr_name):
-    value = _deprecated_attrs.get(attr_name)
-    if value is None:
-        raise AttributeError(
-            f"module 'cupy' has no attribute '{attr_name}'")
-    attr, eq_attr = value
-    _warnings.warn(
-        f'`cupy.{attr_name}` is deprecated. Please use `{eq_attr}` instead.',
-        DeprecationWarning, stacklevel=2
-    )
-    return attr
+    def __getattr__(name):
+        value = _deprecated_attrs.get(name)
+        if value is None:
+            raise AttributeError(
+                f"module 'cupy' has no attribute '{name}'")
+        attr, eq_attr = value
+        _warnings.warn(
+            f'`cupy.{name}` is deprecated. Please use `{eq_attr}` instead.',
+            DeprecationWarning, stacklevel=2
+        )
+        return attr
+else:
+    # Does not emit warnings.
+    from builtins import int
+    from builtins import bool
+    from builtins import float
+    from builtins import complex


### PR DESCRIPTION
Resolve #4755