### PR TITLE
Xfail cuDNN version check test under ROCm/HIP

### DIFF
--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -24,7 +24,7 @@ from install.build import PLATFORM_WIN32
 required_cython_version = pkg_resources.parse_version('0.29.22')
 ignore_cython_versions = [
 ]
-use_hip = bool(int(os.environ.get('CUPY_INSTALL_USE_HIP', '0')))
+use_hip = build.use_hip
 
 
 # The value of the key 'file' is a list that contains extension names

--- a/install/build.py
+++ b/install/build.py
@@ -22,6 +22,8 @@ _cuda_path = 'NOT_INITIALIZED'
 _rocm_path = 'NOT_INITIALIZED'
 _compiler_base_options = None
 
+use_hip = bool(int(os.environ.get('CUPY_INSTALL_USE_HIP', '0')))
+
 
 # Using tempfile.TemporaryDirectory would cause an error during cleanup
 # due to a bug: https://bugs.python.org/issue26660

--- a/tests/install_tests/test_build.py
+++ b/tests/install_tests/test_build.py
@@ -25,6 +25,8 @@ class TestCheckVersion(unittest.TestCase):
 
     @pytest.mark.gpu
     @pytest.mark.cudnn
+    @pytest.mark.xfail(build.use_hip,
+                       reason='ROCm/HIP DNN support is not ready')
     def test_check_cudnn_version(self):
         with self.assertRaises(RuntimeError):
             build.get_cudnn_version()


### PR DESCRIPTION
Rel #4132, #4484.

No cuDNN counterpart in ROCm/HIP. 