### PR TITLE
Remove solved xfail mark for msort

### DIFF
--- a/tests/cupy_tests/sorting_tests/test_sort.py
+++ b/tests/cupy_tests/sorting_tests/test_sort.py
@@ -395,8 +395,6 @@ class TestMsort(unittest.TestCase):
 
     # Test base cases
 
-    # TODO(niboshi): Fix xfail
-    @pytest.mark.xfail(reason='Explicit error types required')
     def test_msort_zero_dim(self):
         for xp in (numpy, cupy):
             a = testing.shaped_random((), xp)


### PR DESCRIPTION
This PR removes an `xfail` mark as it is already fixed and leaves XPASS on pytest output.