### PR TITLE
Windows: fix vectorize tests

### DIFF
--- a/cupyx/jit/_typerules.py
+++ b/cupyx/jit/_typerules.py
@@ -118,7 +118,8 @@ def get_ctype_from_scalar(mode, x):
         if isinstance(x, bool):
             return _types.Scalar(numpy.bool_)
         if isinstance(x, int):
-            return _types.Scalar(numpy.int64)
+            # use plain int here for cross-platform portability
+            return _types.Scalar(int)
         if isinstance(x, float):
             return _types.Scalar(numpy.float64)
         if isinstance(x, complex):

--- a/tests/cupy_tests/functional_tests/test_vectorize.py
+++ b/tests/cupy_tests/functional_tests/test_vectorize.py
@@ -554,11 +554,11 @@ class TestVectorizeBroadcast(unittest.TestCase):
 
 class TestVectorize(unittest.TestCase):
 
-    @testing.for_all_dtypes(no_bool=True)
+    @testing.for_dtypes('qQhfdFD')
     @testing.numpy_cupy_allclose(rtol=1e-5)
     def test_vectorize_arithmetic_ops(self, xp, dtype):
         def my_func(x1, x2, x3):
-            y = x1 + x2 * x3
+            y = x1 + x2 * x3 ** x1
             x2 = y + x3 * x1
             return x1 + x2 + x3
 

--- a/tests/cupy_tests/functional_tests/test_vectorize.py
+++ b/tests/cupy_tests/functional_tests/test_vectorize.py
@@ -368,7 +368,11 @@ class TestVectorizeStmts(unittest.TestCase):
 
         f = xp.vectorize(func_if)
         x = xp.array([1, 2, 3, 4, 5], dtype=xp.int64)
-        return f(x)
+        out = f(x)
+        # On Windows, NumPy's default int type is int32, not int64
+        if sys.platform.startswith('win32') and out.dtype == xp.int32:
+            out = out.astype(xp.int64)
+        return out
 
     @testing.numpy_cupy_array_equal()
     def test_elif(self, xp):
@@ -382,7 +386,11 @@ class TestVectorizeStmts(unittest.TestCase):
 
         f = xp.vectorize(func_if)
         x = xp.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], dtype=xp.int64)
-        return f(x)
+        out = f(x)
+        # On Windows, NumPy's default int type is int32, not int64
+        if sys.platform.startswith('win32') and out.dtype == xp.int32:
+            out = out.astype(xp.int64)
+        return out
 
     @testing.numpy_cupy_array_equal()
     def test_while(self, xp):
@@ -407,7 +415,11 @@ class TestVectorizeStmts(unittest.TestCase):
 
         f = xp.vectorize(func_for)
         x = xp.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], dtype=xp.int64)
-        return f(x)
+        out = f(x)
+        # On Windows, NumPy's default int type is int32, not int64
+        if sys.platform.startswith('win32') and out.dtype == xp.int32:
+            out = out.astype(xp.int64)
+        return out
 
     @testing.numpy_cupy_array_equal()
     def test_for_const_range(self, xp):
@@ -467,7 +479,11 @@ class TestVectorizeStmts(unittest.TestCase):
 
         f = xp.vectorize(func_for)
         x = xp.array([0, 1, 2, 3, 4], dtype=xp.int64)
-        return f(x, x)
+        out = f(x, x)
+        # On Windows, NumPy's default int type is int32, not int64
+        if sys.platform.startswith('win32') and out.dtype == xp.int32:
+            out = out.astype(xp.int64)
+        return out
 
     @testing.numpy_cupy_array_equal()
     def test_for_update_loop_condition(self, xp):
@@ -480,7 +496,11 @@ class TestVectorizeStmts(unittest.TestCase):
 
         f = xp.vectorize(func_for)
         x = xp.array([0, 1, 2, 3, 4], dtype=xp.int64)
-        return f(x)
+        out = f(x)
+        # On Windows, NumPy's default int type is int32, not int64
+        if sys.platform.startswith('win32') and out.dtype == xp.int32:
+            out = out.astype(xp.int64)
+        return out
 
 
 class _MyClass:
@@ -554,7 +574,7 @@ class TestVectorizeBroadcast(unittest.TestCase):
 
 class TestVectorize(unittest.TestCase):
 
-    @testing.for_dtypes('qQhfdFD')
+    @testing.for_dtypes('qQefdFD')
     @testing.numpy_cupy_allclose(rtol=1e-5)
     def test_vectorize_arithmetic_ops(self, xp, dtype):
         def my_func(x1, x2, x3):

--- a/tests/cupy_tests/functional_tests/test_vectorize.py
+++ b/tests/cupy_tests/functional_tests/test_vectorize.py
@@ -549,7 +549,7 @@ class TestVectorizeBroadcast(unittest.TestCase):
 
 class TestVectorize(unittest.TestCase):
 
-    @testing.for_all_dtypes(no_bool=True)
+    @testing.for_dtypes('qQefdFD')
     @testing.numpy_cupy_allclose(rtol=1e-5)
     def test_vectorize_arithmetic_ops(self, xp, dtype):
         def my_func(x1, x2, x3):

--- a/tests/cupy_tests/functional_tests/test_vectorize.py
+++ b/tests/cupy_tests/functional_tests/test_vectorize.py
@@ -1,3 +1,4 @@
+import sys
 import unittest
 
 import numpy
@@ -221,7 +222,11 @@ class TestVectorizeExprs(unittest.TestCase):
 
         f = xp.vectorize(my_incr)
         x = testing.shaped_random((20, 30), xp, dtype, seed=0)
-        return f(x)
+        out = f(x)
+        # On Windows, NumPy's default int type is int32, not int64
+        if sys.platform.startswith('win32') and out.dtype == xp.int32:
+            out = out.astype(xp.int64)
+        return out
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal(accept_error=TypeError)

--- a/tests/cupy_tests/functional_tests/test_vectorize.py
+++ b/tests/cupy_tests/functional_tests/test_vectorize.py
@@ -1,4 +1,3 @@
-import sys
 import unittest
 
 import numpy
@@ -222,11 +221,7 @@ class TestVectorizeExprs(unittest.TestCase):
 
         f = xp.vectorize(my_incr)
         x = testing.shaped_random((20, 30), xp, dtype, seed=0)
-        out = f(x)
-        # On Windows, NumPy's default int type is int32, not int64
-        if sys.platform.startswith('win32') and out.dtype == xp.int32:
-            out = out.astype(xp.int64)
-        return out
+        return f(x)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal(accept_error=TypeError)
@@ -355,7 +350,7 @@ class TestVectorizeStmts(unittest.TestCase):
             return y
 
         f = xp.vectorize(func_if)
-        x = xp.array([1, 2, 3, 4, 5], dtype=xp.int64)
+        x = xp.array([1, 2, 3, 4, 5])
         return f(x)
 
     @testing.numpy_cupy_array_equal()
@@ -367,12 +362,8 @@ class TestVectorizeStmts(unittest.TestCase):
             return y
 
         f = xp.vectorize(func_if)
-        x = xp.array([1, 2, 3, 4, 5], dtype=xp.int64)
-        out = f(x)
-        # On Windows, NumPy's default int type is int32, not int64
-        if sys.platform.startswith('win32') and out.dtype == xp.int32:
-            out = out.astype(xp.int64)
-        return out
+        x = xp.array([1, 2, 3, 4, 5])
+        return f(x)
 
     @testing.numpy_cupy_array_equal()
     def test_elif(self, xp):
@@ -385,12 +376,8 @@ class TestVectorizeStmts(unittest.TestCase):
             return y
 
         f = xp.vectorize(func_if)
-        x = xp.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], dtype=xp.int64)
-        out = f(x)
-        # On Windows, NumPy's default int type is int32, not int64
-        if sys.platform.startswith('win32') and out.dtype == xp.int32:
-            out = out.astype(xp.int64)
-        return out
+        x = xp.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+        return f(x)
 
     @testing.numpy_cupy_array_equal()
     def test_while(self, xp):
@@ -402,7 +389,7 @@ class TestVectorizeStmts(unittest.TestCase):
             return y
 
         f = xp.vectorize(func_while)
-        x = xp.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], dtype=xp.int64)
+        x = xp.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
         return f(x)
 
     @testing.numpy_cupy_array_equal()
@@ -414,12 +401,8 @@ class TestVectorizeStmts(unittest.TestCase):
             return y
 
         f = xp.vectorize(func_for)
-        x = xp.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], dtype=xp.int64)
-        out = f(x)
-        # On Windows, NumPy's default int type is int32, not int64
-        if sys.platform.startswith('win32') and out.dtype == xp.int32:
-            out = out.astype(xp.int64)
-        return out
+        x = xp.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+        return f(x)
 
     @testing.numpy_cupy_array_equal()
     def test_for_const_range(self, xp):
@@ -466,7 +449,7 @@ class TestVectorizeStmts(unittest.TestCase):
             return x + i
 
         f = xp.vectorize(func_for)
-        x = xp.array([0, 1, 2, 3, 4], dtype=xp.int64)
+        x = xp.array([0, 1, 2, 3, 4])
         return f(x)
 
     @testing.numpy_cupy_array_equal()
@@ -478,12 +461,8 @@ class TestVectorizeStmts(unittest.TestCase):
             return res
 
         f = xp.vectorize(func_for)
-        x = xp.array([0, 1, 2, 3, 4], dtype=xp.int64)
-        out = f(x, x)
-        # On Windows, NumPy's default int type is int32, not int64
-        if sys.platform.startswith('win32') and out.dtype == xp.int32:
-            out = out.astype(xp.int64)
-        return out
+        x = xp.array([0, 1, 2, 3, 4])
+        return f(x, x)
 
     @testing.numpy_cupy_array_equal()
     def test_for_update_loop_condition(self, xp):
@@ -495,12 +474,8 @@ class TestVectorizeStmts(unittest.TestCase):
             return res
 
         f = xp.vectorize(func_for)
-        x = xp.array([0, 1, 2, 3, 4], dtype=xp.int64)
-        out = f(x)
-        # On Windows, NumPy's default int type is int32, not int64
-        if sys.platform.startswith('win32') and out.dtype == xp.int32:
-            out = out.astype(xp.int64)
-        return out
+        x = xp.array([0, 1, 2, 3, 4])
+        return f(x)
 
 
 class _MyClass:
@@ -574,7 +549,7 @@ class TestVectorizeBroadcast(unittest.TestCase):
 
 class TestVectorize(unittest.TestCase):
 
-    @testing.for_dtypes('qQefdFD')
+    @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose(rtol=1e-5)
     def test_vectorize_arithmetic_ops(self, xp, dtype):
         def my_func(x1, x2, x3):

--- a/tests/cupy_tests/functional_tests/test_vectorize.py
+++ b/tests/cupy_tests/functional_tests/test_vectorize.py
@@ -350,7 +350,7 @@ class TestVectorizeStmts(unittest.TestCase):
             return y
 
         f = xp.vectorize(func_if)
-        x = xp.array([1, 2, 3, 4, 5])
+        x = xp.array([1, 2, 3, 4, 5], dtype=xp.int64)
         return f(x)
 
     @testing.numpy_cupy_array_equal()
@@ -362,7 +362,7 @@ class TestVectorizeStmts(unittest.TestCase):
             return y
 
         f = xp.vectorize(func_if)
-        x = xp.array([1, 2, 3, 4, 5])
+        x = xp.array([1, 2, 3, 4, 5], dtype=xp.int64)
         return f(x)
 
     @testing.numpy_cupy_array_equal()
@@ -376,7 +376,7 @@ class TestVectorizeStmts(unittest.TestCase):
             return y
 
         f = xp.vectorize(func_if)
-        x = xp.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+        x = xp.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], dtype=xp.int64)
         return f(x)
 
     @testing.numpy_cupy_array_equal()
@@ -389,7 +389,7 @@ class TestVectorizeStmts(unittest.TestCase):
             return y
 
         f = xp.vectorize(func_while)
-        x = xp.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+        x = xp.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], dtype=xp.int64)
         return f(x)
 
     @testing.numpy_cupy_array_equal()
@@ -401,7 +401,7 @@ class TestVectorizeStmts(unittest.TestCase):
             return y
 
         f = xp.vectorize(func_for)
-        x = xp.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+        x = xp.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], dtype=xp.int64)
         return f(x)
 
     @testing.numpy_cupy_array_equal()
@@ -449,7 +449,7 @@ class TestVectorizeStmts(unittest.TestCase):
             return x + i
 
         f = xp.vectorize(func_for)
-        x = xp.array([0, 1, 2, 3, 4])
+        x = xp.array([0, 1, 2, 3, 4], dtype=xp.int64)
         return f(x)
 
     @testing.numpy_cupy_array_equal()
@@ -461,7 +461,7 @@ class TestVectorizeStmts(unittest.TestCase):
             return res
 
         f = xp.vectorize(func_for)
-        x = xp.array([0, 1, 2, 3, 4])
+        x = xp.array([0, 1, 2, 3, 4], dtype=xp.int64)
         return f(x, x)
 
     @testing.numpy_cupy_array_equal()
@@ -474,7 +474,7 @@ class TestVectorizeStmts(unittest.TestCase):
             return res
 
         f = xp.vectorize(func_for)
-        x = xp.array([0, 1, 2, 3, 4])
+        x = xp.array([0, 1, 2, 3, 4], dtype=xp.int64)
         return f(x)
 
 
@@ -553,7 +553,7 @@ class TestVectorize(unittest.TestCase):
     @testing.numpy_cupy_allclose(rtol=1e-5)
     def test_vectorize_arithmetic_ops(self, xp, dtype):
         def my_func(x1, x2, x3):
-            y = x1 + x2 * x3 ** x1
+            y = x1 + x2 * x3
             x2 = y + x3 * x1
             return x1 + x2 + x3
 


### PR DESCRIPTION
For `a = np.array([1, 2, 3, 4])`, on Linux `a.dtype == np.int64`, but on Windows `a.dtype == np.int32`.