### PR TITLE
Windows: fix `randint` test error

### DIFF
--- a/tests/cupy_tests/random_tests/test_generator.py
+++ b/tests/cupy_tests/random_tests/test_generator.py
@@ -1,5 +1,6 @@
 import functools
 import os
+import sys
 import threading
 import unittest
 
@@ -1215,6 +1216,13 @@ class TestRandint(RandomGeneratorTestCase):
     def test_randint_float2(self):
         self.generate(6.7, size=(2, 3))
 
+    @pytest.mark.skip(not sys.platform.startswith('win32'),
+                      reason='default int is 64 bits')
+    def test_randint_int32_1(self):
+        self.generate(2**16, 2**28, 3)
+
+    @pytest.mark.skip(sys.platform.startswith('win32'),
+                      reason='default int is 32 bits')
     def test_randint_int64_1(self):
         self.generate(2**34, 2**40, 3)
 


### PR DESCRIPTION
```
______________________ TestRandint.test_randint_int64_1 _______________________

self = <cupy_tests.random_tests.test_generator.TestRandint testMethod=test_randint_int64_1>

    def test_randint_int64_1(self):
>       self.generate(2**34, 2**40, 3)

tests\cupy_tests\random_tests\test_generator.py:1219: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
tests\cupy_tests\random_tests\test_generator.py:118: in generate
    return self._generate_check_repro(func, self.__seed)
tests\cupy_tests\random_tests\test_generator.py:106: in _generate_check_repro
    x = func()
tests\cupy_tests\random_tests\test_generator.py:101: in <lambda>
    return lambda: f(*args, **kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <cupy.random._generator.RandomState object at 0x0000023ACD31E7F0>
low = 17179869184, high = 1099511627776, size = 3, dtype = 'l'

    def randint(self, low, high=None, size=None, dtype='l'):
        """Returns a scalar or an array of integer values over ``[low, high)``.
    
        .. seealso::
            - :func:`cupy.random.randint` for full documentation
            - :meth:`numpy.random.RandomState.randint`
        """
        if high is None:
            lo = 0
            hi1 = int(low) - 1
        else:
            lo = int(low)
            hi1 = int(high) - 1
    
        if lo > hi1:
            raise ValueError('low >= high')
        if lo < cupy.iinfo(dtype).min:
            raise ValueError(
                'low is out of bounds for {}'.format(cupy.dtype(dtype).name))
        if hi1 > cupy.iinfo(dtype).max:
            raise ValueError(
>               'high is out of bounds for {}'.format(cupy.dtype(dtype).name))
E           ValueError: high is out of bounds for int32

cupy\random\_generator.py:1182: ValueError
```