### PR TITLE
Windows: Fix csc/csr argmax/argmin tests

### DIFF
--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
@@ -1,4 +1,5 @@
 import pickle
+import sys
 import unittest
 
 import numpy
@@ -1157,7 +1158,10 @@ class TestCscMatrixScipyCompressedMinMax(unittest.TestCase):
         if self.axis is None:
             pytest.skip()
         data = self._make_data_min(xp, sp, dense=self.dense)
-        return data.argmin(axis=self.axis)
+        out = data.argmin(axis=self.axis)
+        if sys.platform.startswith('win32'):
+            out = out.astype(xp.int32)
+        return out
 
     @testing.numpy_cupy_array_equal(sp_name='sp')
     def test_argmax(self, xp, sp):
@@ -1165,7 +1169,10 @@ class TestCscMatrixScipyCompressedMinMax(unittest.TestCase):
         if self.axis is None:
             pytest.skip()
         data = self._make_data_max(xp, sp, dense=self.dense)
-        return data.argmax(axis=self.axis)
+        out = data.argmax(axis=self.axis)
+        if sys.platform.startswith('win32'):
+            out = out.astype(xp.int32)
+        return out
 
 
 @testing.parameterize(*testing.product({

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -1,5 +1,6 @@
 import contextlib
 import pickle
+import sys
 import unittest
 import warnings
 
@@ -1398,7 +1399,10 @@ class TestCsrMatrixScipyCompressedMinMax(unittest.TestCase):
         if self.axis is None:
             pytest.skip()
         data = self._make_data_min(xp, sp, dense=self.dense)
-        return data.argmin(axis=self.axis)
+        out = data.argmin(axis=self.axis)
+        if sys.platform.startswith('win32'):
+            out = out.astype(xp.int32)
+        return out
 
     @testing.numpy_cupy_array_equal(sp_name='sp')
     def test_argmax(self, xp, sp):
@@ -1406,7 +1410,10 @@ class TestCsrMatrixScipyCompressedMinMax(unittest.TestCase):
         if self.axis is None:
             pytest.skip()
         data = self._make_data_max(xp, sp, dense=self.dense)
-        return data.argmax(axis=self.axis)
+        out = data.argmax(axis=self.axis)
+        if sys.platform.startswith('win32'):
+            out = out.astype(xp.int32)
+        return out
 
 
 @testing.parameterize(*testing.product({


### PR DESCRIPTION
CuPy always returns in `int64`, but on Windows the default int type is `int32`.

```
FAILED tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py::TestCscMatrixScipyCompressedMinMax_param_2_{axis=-2, dense=False}::test_argmax
FAILED tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py::TestCscMatrixScipyCompressedMinMax_param_2_{axis=-2, dense=False}::test_argmin
FAILED tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py::TestCscMatrixScipyCompressedMinMax_param_3_{axis=-2, dense=True}::test_argmax
FAILED tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py::TestCscMatrixScipyCompressedMinMax_param_3_{axis=-2, dense=True}::test_argmin
FAILED tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py::TestCscMatrixScipyCompressedMinMax_param_4_{axis=-1, dense=False}::test_argmax
FAILED tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py::TestCscMatrixScipyCompressedMinMax_param_4_{axis=-1, dense=False}::test_argmin
FAILED tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py::TestCscMatrixScipyCompressedMinMax_param_5_{axis=-1, dense=True}::test_argmax
FAILED tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py::TestCscMatrixScipyCompressedMinMax_param_5_{axis=-1, dense=True}::test_argmin
FAILED tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py::TestCscMatrixScipyCompressedMinMax_param_6_{axis=0, dense=False}::test_argmax
FAILED tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py::TestCscMatrixScipyCompressedMinMax_param_6_{axis=0, dense=False}::test_argmin
FAILED tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py::TestCscMatrixScipyCompressedMinMax_param_7_{axis=0, dense=True}::test_argmax
FAILED tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py::TestCscMatrixScipyCompressedMinMax_param_7_{axis=0, dense=True}::test_argmin
FAILED tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py::TestCscMatrixScipyCompressedMinMax_param_8_{axis=1, dense=False}::test_argmax
FAILED tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py::TestCscMatrixScipyCompressedMinMax_param_8_{axis=1, dense=False}::test_argmin
FAILED tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py::TestCscMatrixScipyCompressedMinMax_param_9_{axis=1, dense=True}::test_argmax
FAILED tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py::TestCscMatrixScipyCompressedMinMax_param_9_{axis=1, dense=True}::test_argmin
FAILED tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py::TestCsrMatrixScipyCompressedMinMax_param_2_{axis=-2, dense=False}::test_argmax
FAILED tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py::TestCsrMatrixScipyCompressedMinMax_param_2_{axis=-2, dense=False}::test_argmin
FAILED tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py::TestCsrMatrixScipyCompressedMinMax_param_3_{axis=-2, dense=True}::test_argmax
FAILED tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py::TestCsrMatrixScipyCompressedMinMax_param_3_{axis=-2, dense=True}::test_argmin
FAILED tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py::TestCsrMatrixScipyCompressedMinMax_param_4_{axis=-1, dense=False}::test_argmax
FAILED tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py::TestCsrMatrixScipyCompressedMinMax_param_4_{axis=-1, dense=False}::test_argmin
FAILED tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py::TestCsrMatrixScipyCompressedMinMax_param_5_{axis=-1, dense=True}::test_argmax
FAILED tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py::TestCsrMatrixScipyCompressedMinMax_param_5_{axis=-1, dense=True}::test_argmin
FAILED tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py::TestCsrMatrixScipyCompressedMinMax_param_6_{axis=0, dense=False}::test_argmax
FAILED tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py::TestCsrMatrixScipyCompressedMinMax_param_6_{axis=0, dense=False}::test_argmin
FAILED tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py::TestCsrMatrixScipyCompressedMinMax_param_7_{axis=0, dense=True}::test_argmax
FAILED tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py::TestCsrMatrixScipyCompressedMinMax_param_7_{axis=0, dense=True}::test_argmin
FAILED tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py::TestCsrMatrixScipyCompressedMinMax_param_8_{axis=1, dense=False}::test_argmax
FAILED tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py::TestCsrMatrixScipyCompressedMinMax_param_8_{axis=1, dense=False}::test_argmin
FAILED tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py::TestCsrMatrixScipyCompressedMinMax_param_9_{axis=1, dense=True}::test_argmax
FAILED tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py::TestCsrMatrixScipyCompressedMinMax_param_9_{axis=1, dense=True}::test_argmin
```