### PR TITLE
Windows: Fix cuTENSOR tests

### DIFF
--- a/tests/cupy_tests/math_tests/test_sumprod.py
+++ b/tests/cupy_tests/math_tests/test_sumprod.py
@@ -398,7 +398,7 @@ class TestCuTensorReduction(unittest.TestCase):
 
     @testing.for_contiguous_axes()
     # sum supports less dtypes; don't test float16 as it's not as accurate?
-    @testing.for_dtypes('lLfdFD')
+    @testing.for_dtypes('qQfdFD')
     @testing.numpy_cupy_allclose(rtol=1E-5, contiguous_check=False)
     def test_cutensor_sum(self, xp, dtype, axis):
         a = testing.shaped_random(self.shape, xp, dtype)
@@ -419,7 +419,7 @@ class TestCuTensorReduction(unittest.TestCase):
         return a.sum(axis=axis)
 
     # sum supports less dtypes; don't test float16 as it's not as accurate?
-    @testing.for_dtypes('lLfdFD')
+    @testing.for_dtypes('qQfdFD')
     @testing.numpy_cupy_allclose(rtol=1E-5, contiguous_check=False)
     def test_cutensor_sum_empty_axis(self, xp, dtype):
         a = testing.shaped_random(self.shape, xp, dtype)


### PR DESCRIPTION
Follow-up of #4776. It's currently not tested on the Windows CI yet, but will cause errors when we enable it.