### PR TITLE
[backport] Windows: fix sparse matrix indexing type

### DIFF
--- a/cupyx/scipy/sparse/sputils.py
+++ b/cupyx/scipy/sparse/sputils.py
@@ -37,7 +37,7 @@ def get_index_dtype(arrays=(), maxval=None, check_contents=False):
     int32min = cupy.iinfo(cupy.int32).min
     int32max = cupy.iinfo(cupy.int32).max
 
-    dtype = cupy.intc
+    dtype = cupy.int32
     if maxval is not None:
         if maxval > int32max:
             dtype = cupy.int64


### PR DESCRIPTION
Backport of #4778