### PR TITLE
ROCm: Fix sorting bug

### DIFF
--- a/cupy/cuda/cupy_thrust.cu
+++ b/cupy/cuda/cupy_thrust.cu
@@ -197,7 +197,7 @@ constexpr
 #endif
 #endif
 bool _real_less(const T& lhs, const T& rhs) {
-    #ifdef  __CUDA_ARCH__
+    #if  (defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__))
     if (isnan(lhs)) {
         return false;
     } else if (isnan(rhs)) {
@@ -271,7 +271,7 @@ bool less< tuple<size_t, double> >::operator() (
 
 // it seems Thrust doesn't care the code path on host, so we just need a wrapper for device
 __host__ __device__ __forceinline__ bool isnan(const __half& x) {
-    #ifdef  __CUDA_ARCH__
+    #if (defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__))
     return __hisnan(x);
     #else
     return false;  // This will never be called on the host


### PR DESCRIPTION
https://github.com/cupy/cupy/commit/74c54b07a9d8a0f1c0130e6cfec989b3aa3ed867 from #4730 broke it, see https://github.com/cupy/cupy/issues/4132#issuecomment-791579731. All tests in `test_sort.py` pass now.