### PR TITLE
Fix automated backport workflow

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   backport:
+    if: github.repository_owner == 'cupy'
     runs-on: ubuntu-18.04
     env:
       CUPY_CI: GitHub

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -4,7 +4,7 @@ on:
        - master
 
 jobs:
-  pretest:
+  backport:
     runs-on: ubuntu-18.04
     env:
       CUPY_CI: GitHub
@@ -31,5 +31,5 @@ jobs:
         BACKPORT_GITHUB_TOKEN: ${{secrets.BACKPORT_TOKEN}}
       run: |
         cd backport
-        echo "machine github.com\nuser chainer-ci\npassword ${{secrets.BACKPORT_TOKEN}}" > ~/.netrc
+        echo -e "machine github.com\nlogin chainer-ci\npassword ${{secrets.BACKPORT_TOKEN}}" > ~/.netrc
         python backport.py --repo cupy --sha ${{github.event.after}} --https


### PR DESCRIPTION
* Fix broken netrc configuration (Sorry it was my mistake in #4833...)
  I confirmed in my fork that `git clone` to private repo working.
  https://github.com/kmaehashi/cupy/runs/2057137229?check_suite_focus=true#step:5:4
* Improve the workflow to skip in forks.
  example: https://github.com/kmaehashi/cupy/actions/runs/632585230
  https://github.community/t/have-github-action-only-run-on-master-repo-and-not-on-forks/140840
* Change name from `pretest` to `backport`.