### PR TITLE
Use pull_request_target trigger

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,11 +1,15 @@
 on:
-  push:
+  pull_request_target:
+    types: [closed, labeled]
     branches:
        - master
 
 jobs:
   backport:
-    if: github.repository_owner == 'cupy'
+    if: |
+        github.repository_owner == 'cupy' &&
+        github.event.pull_request.merged == true &&
+        contains(github.event.pull_request.labels.*.name, 'to-be-backported')
     runs-on: ubuntu-18.04
     env:
       CUPY_CI: GitHub
@@ -33,4 +37,4 @@ jobs:
       run: |
         cd backport
         echo -e "machine github.com\nlogin chainer-ci\npassword ${{secrets.BACKPORT_TOKEN}}" > ~/.netrc
-        python backport.py --repo cupy --sha ${{github.event.after}} --https
+        python backport.py --repo cupy --pr ${{github.event.number}} --https


### PR DESCRIPTION
Use `pull_request_target` so that we can also use `labeled` trigger (when we notice the PR needs to be backported after merging the pull-request, we can just label it to trigger the workflow).
Note that `pull_request` does not work as this workflow requires the secret access.