### PR TITLE
Support cuSparse functions for matrix conversion added in CUDA 11.2

### DIFF
--- a/cupy/cusparse.py
+++ b/cupy/cusparse.py
@@ -1667,12 +1667,14 @@ def denseToSparse(x, format='csr'):
         indptr = y.indptr
         indices = _cupy.empty(nnz, 'i')
         data = _cupy.empty(nnz, x.dtype)
-        y = cupyx.scipy.sparse.csr_matrix((data, indices, indptr), shape=x.shape)
+        y = cupyx.scipy.sparse.csr_matrix((data, indices, indptr),
+                                          shape=x.shape)
     elif format == 'csc':
         indptr = y.indptr
         indices = _cupy.empty(nnz, 'i')
         data = _cupy.empty(nnz, x.dtype)
-        y = cupyx.scipy.sparse.csc_matrix((data, indices, indptr), shape=x.shape)
+        y = cupyx.scipy.sparse.csc_matrix((data, indices, indptr),
+                                          shape=x.shape)
     elif format == 'coo':
         row = _cupy.empty(nnz, 'i')
         col = _cupy.empty(nnz, 'i')

--- a/cupy/cusparse.py
+++ b/cupy/cusparse.py
@@ -1234,7 +1234,7 @@ class SpMatDescriptor(BaseDescriptor):
                 _dtype_to_IndexType(a.indices.dtype), idx_base, cuda_dtype)
             get = None
         else:
-            raise ValueError('csr and coo format are supported '
+            raise ValueError('csr, csc and coo format are supported '
                              '(actual: {}).'.format(a.format))
         destroy = _cusparse.destroySpMat
         return SpMatDescriptor(desc, get, destroy)
@@ -1639,6 +1639,7 @@ def denseToSparse(x, format='csr'):
         raise RuntimeError('denseToSparse is not available.')
 
     assert x.ndim == 2
+    assert x.dtype.char in 'fdFD'
     x = _cupy.asfortranarray(x)
     desc_x = DnMatDescriptor.create(x)
     if format == 'csr':

--- a/cupy/cusparse.py
+++ b/cupy/cusparse.py
@@ -1663,6 +1663,7 @@ def denseToSparse(x, format='csr'):
     _cusparse.spMatGetSize(desc_y.desc, num_rows_tmp.ctypes.data,
                            num_cols_tmp.ctypes.data, nnz.ctypes.data)
     nnz = int(nnz)
+    print('# nnz: {}'.format(nnz))
     if format == 'csr':
         indptr = y.indptr
         indices = _cupy.empty(nnz, 'i')
@@ -1676,8 +1677,11 @@ def denseToSparse(x, format='csr'):
         y = cupyx.scipy.sparse.csc_matrix((data, indices, indptr),
                                           shape=x.shape)
     elif format == 'coo':
-        row = _cupy.empty(nnz, 'i')
-        col = _cupy.empty(nnz, 'i')
+        row = _cupy.zeros(nnz, 'i')
+        col = _cupy.zeros(nnz, 'i')
+        # Note: I would like to use empty() here, but that might cause an
+        # exeption in the row/col number check when creating the coo_matrix,
+        # so I used zeros() instead.
         data = _cupy.empty(nnz, x.dtype)
         y = cupyx.scipy.sparse.coo_matrix((data, (row, col)), shape=x.shape)
     desc_y = SpMatDescriptor.create(y)

--- a/cupy_backends/cuda/cupy_cusparse.h
+++ b/cupy_backends/cuda/cupy_cusparse.h
@@ -562,4 +562,33 @@ cusparseStatus_t cusparseZcsr2csc(...) {
 }
 #endif // #if CUSPARSE_VERSION >= 11000
 
+#if CUSPARSE_VERSION < 11300
+// Types, macro and functions added in cuSparse 11.3 (CUDA 11.2)
+
+typedef enum {} cusparseSparseToDenseAlg_t;
+typedef enum {} cusparseDenseToSparseAlg_t;
+
+cusparseStatus_t cusparseSparseToDense_bufferSize(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseSparseToDense(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDenseToSparse_bufferSize(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDenseToSparse_analysis(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDenseToSparse_convert(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+#endif // CUSPARSE_VERSION < 11300
+
+
 #endif  // INCLUDE_GUARD_CUDA_CUPY_CUSPARSE_H

--- a/cupy_backends/cuda/cupy_cusparse.h
+++ b/cupy_backends/cuda/cupy_cusparse.h
@@ -581,6 +581,10 @@ cusparseStatus_t cusparseSpMatGetSize(...) {
 typedef enum {} cusparseSparseToDenseAlg_t;
 typedef enum {} cusparseDenseToSparseAlg_t;
 
+cusparseStatus_t cusparseCreateCsc(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
 cusparseStatus_t cusparseSparseToDense_bufferSize(...) {
   return CUSPARSE_STATUS_SUCCESS;
 }

--- a/cupy_backends/cuda/cupy_cusparse.h
+++ b/cupy_backends/cuda/cupy_cusparse.h
@@ -562,6 +562,19 @@ cusparseStatus_t cusparseZcsr2csc(...) {
 }
 #endif // #if CUSPARSE_VERSION >= 11000
 
+#if CUSPARSE_VERSION < 11100
+// Functions added in cuSparse 11.1 (CUDA 11.0)
+
+cusparseStatus_t cusparseCsrSetPointers(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseSpMatGetSize(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+#endif // #if CUSPARSE_VERSION < 11100
+
 #if CUSPARSE_VERSION < 11300
 // Types, macro and functions added in cuSparse 11.3 (CUDA 11.2)
 

--- a/cupy_backends/cuda/libs/cusparse.pxd
+++ b/cupy_backends/cuda/libs/cusparse.pxd
@@ -54,6 +54,9 @@ cdef extern from *:
     ctypedef void* cusparseSpMatDescr_t
     ctypedef void* cusparseDnMatDescr_t
 
+    ctypedef int cusparseSparseToDenseAlg_t
+    ctypedef int cusparseDenseToSparseAlg_t
+
     # CSR2CSC
     ctypedef int Csr2CscAlg 'cusparseCsr2CscAlg_t'
 
@@ -120,6 +123,12 @@ cpdef enum:
     # CSR2CSC
     CUSPARSE_CSR2CSC_ALG1 = 1  # faster than ALG2 (in general), deterministc
     CUSPARSE_CSR2CSC_ALG2 = 2  # low memory requirement, non-deterministc
+
+    # cusparseSparseToDenseAlg_t
+    CUSPARSE_SPARSETODENSE_ALG_DEFAULT = 0
+
+    # cusparseDenseToSparseAlg_t
+    CUSPARSE_DENSETOSPARSE_ALG_DEFAULT = 0
 
 cdef class SpVecAttributes:
     cdef:

--- a/cupy_backends/cuda/libs/cusparse.pyx
+++ b/cupy_backends/cuda/libs/cusparse.pyx
@@ -1259,10 +1259,14 @@ cdef extern from '../../cupy_sparse.h' nogil:
                           void** csrValues, IndexType* csrRowOffsetsType,
                           IndexType* csrColIndType, IndexBase* idxBase,
                           DataType* valueType)
+    Status cusparseCsrSetPointers(SpMatDescr spMatDescr, void* csrRowOffsets,
+                                  void* csrColInd, void* csrValues)
     Status cusparseSpMatGetFormat(SpMatDescr spMatDescr, Format* format)
     Status cusparseSpMatGetIndexBase(SpMatDescr spMatDescr, IndexBase* idxBase)
     Status cusparseSpMatGetValues(SpMatDescr spMatDescr, void** values)
     Status cusparseSpMatSetValues(SpMatDescr spMatDescr, void* values)
+    Status cusparseSpMatGetSize(SpMatDescr spMatDescr, int64_t* rows,
+                                int64_t* cols, int64_t* nnz)
     Status cusparseSpMatGetStridedBatch(SpMatDescr spMatDescr, int* batchCount)
     Status cusparseSpMatSetStridedBatch(SpMatDescr spMatDescr, int batchCount)
 
@@ -4590,6 +4594,12 @@ cpdef csrGet(size_t desc):
     return CsrAttributes(rows, cols, nnz, rowOffsets, colInd, values,
                          rowOffsetsType, colIndType, idxBase, valueType)
 
+cpdef csrSetPointers(size_t desc, size_t csrRowOffsets, size_t csrColInd,
+                     size_t csrValues):
+    status = cusparseCsrSetPointers(<SpMatDescr>desc, <void*>csrRowOffsets,
+                                    <void*>csrColInd, <void*>csrValues)
+    check_status(status)
+
 cpdef int spMatGetFormat(size_t desc):
     cdef Format format
     status = cusparseSpMatGetFormat(<SpMatDescr>desc, &format)
@@ -4610,6 +4620,11 @@ cpdef intptr_t spMatGetValues(size_t desc):
 
 cpdef spMatSetValues(size_t desc, intptr_t values):
     status = cusparseSpMatSetValues(<SpMatDescr>desc, <void*>values)
+    check_status(status)
+
+cpdef spMatGetSize(size_t desc, size_t rows, size_t cols, size_t nnz):
+    status = cusparseSpMatGetSize(<SpMatDescr>desc, <int64_t*>rows,
+                                  <int64_t*>cols, <int64_t*>nnz)
     check_status(status)
 
 cpdef int spMatGetStridedBatch(size_t desc):

--- a/cupy_backends/cuda/libs/cusparse.pyx
+++ b/cupy_backends/cuda/libs/cusparse.pyx
@@ -1325,6 +1325,23 @@ cdef extern from '../../cupy_sparse.h' nogil:
         DnMatDescr matA, DnMatDescr matB, void* beta, SpMatDescr matC,
         DataType computeType, void* externalBuffer)
 
+    Status cusparseSparseToDense_bufferSize(
+        Handle handle, SpMatDescr matA, DnMatDescr matB,
+        cusparseSparseToDenseAlg_t alg, size_t* bufferSize)
+    Status cusparseSparseToDense(
+        Handle handle, SpMatDescr matA, DnMatDescr matB,
+        cusparseSparseToDenseAlg_t alg, void* buffer)
+
+    Status cusparseDenseToSparse_bufferSize(
+        Handle handle, DnMatDescr matA, SpMatDescr matB,
+        cusparseDenseToSparseAlg_t alg, size_t* bufferSize)
+    Status cusparseDenseToSparse_analysis(
+        Handle handle, DnMatDescr matA, SpMatDescr matB,
+        cusparseDenseToSparseAlg_t alg, void* buffer)
+    Status cusparseDenseToSparse_convert(
+        Handle handle, DnMatDescr matA, SpMatDescr matB,
+        cusparseDenseToSparseAlg_t alg, void* buffer)
+
     # CSR2CSC
     Status cusparseCsr2cscEx2_bufferSize(
         Handle handle, int m, int n, int nnz, const void* csrVal,
@@ -4771,6 +4788,45 @@ cpdef constrainedGeMM(intptr_t handle, Operation opA, Operation opB,
         <Handle>handle, opA, opB, <void*>alpha, <DnMatDescr>matA,
         <DnMatDescr>matB, <void*>beta, <SpMatDescr>matC, computeType,
         <void*>externalBuffer)
+    check_status(status)
+
+cpdef size_t sparseToDense_bufferSize(intptr_t handle, size_t matA,
+                                      size_t matB, int alg):
+    cpdef size_t bufferSize
+    status = cusparseSparseToDense_bufferSize(
+        <Handle>handle, <SpMatDescr>matA, <DnMatDescr>matB,
+        <cusparseSparseToDenseAlg_t>alg, &bufferSize)
+    check_status(status)
+    return bufferSize
+
+cpdef sparseToDense(intptr_t handle, size_t matA, size_t matB, int alg,
+                    intptr_t buffer):
+    status = cusparseSparseToDense(
+        <Handle>handle, <SpMatDescr>matA, <DnMatDescr>matB,
+        <cusparseSparseToDenseAlg_t>alg, <void*>buffer)
+    check_status(status)
+
+cpdef size_t denseToSparse_bufferSize(intptr_t handle, size_t matA,
+                                      size_t matB, int alg):
+    cpdef size_t bufferSize
+    status = cusparseDenseToSparse_bufferSize(
+        <Handle>handle, <DnMatDescr>matA, <SpMatDescr>matB,
+        <cusparseDenseToSparseAlg_t>alg, &bufferSize)
+    check_status(status)
+    return bufferSize
+
+cpdef denseToSparse_analysis(intptr_t handle, size_t matA, size_t matB,
+                             int alg, intptr_t buffer):
+    status = cusparseDenseToSparse_analysis(
+        <Handle>handle, <DnMatDescr>matA, <SpMatDescr>matB,
+        <cusparseDenseToSparseAlg_t>alg, <void*>buffer)
+    check_status(status)
+
+cpdef denseToSparse_convert(intptr_t handle, size_t matA, size_t matB,
+                            int alg, intptr_t buffer):
+    status = cusparseDenseToSparse_convert(
+        <Handle>handle, <DnMatDescr>matA, <SpMatDescr>matB,
+        <cusparseDenseToSparseAlg_t>alg, <void*>buffer)
     check_status(status)
 
 # CSR2CSC

--- a/cupy_backends/cuda/libs/cusparse.pyx
+++ b/cupy_backends/cuda/libs/cusparse.pyx
@@ -1245,6 +1245,12 @@ cdef extern from '../../cupy_sparse.h' nogil:
                              IndexType csrRowOffsetsType,
                              IndexType csrColIndType, IndexBase idxBase,
                              DataType valueType)
+    Status cusparseCreateCsc(SpMatDescr* spMatDescr, int64_t rows,
+                             int64_t cols, int64_t nnz, void* cscColOffsets,
+                             void* cscRowInd, void* cscValues,
+                             IndexType cscColOffsetsType,
+                             IndexType cscRowIndType, IndexBase idxBase,
+                             DataType valueType)
     Status cusparseDestroySpMat(SpMatDescr spMatDescr)
     Status cusparseCooGet(SpMatDescr spMatDescr, int64_t* rows, int64_t* cols,
                           int64_t* nnz, void** cooRowInd, void** cooColInd,
@@ -4547,6 +4553,19 @@ cpdef size_t createCsr(int64_t rows, int64_t cols, int64_t nnz,
                                <void*>csrRowOffsets, <void*>csrColind,
                                <void*>csrValues, csrRowOffsetsType,
                                csrColIndType, idxBase, valueType)
+    check_status(status)
+    return <size_t>desc
+
+cpdef size_t createCsc(int64_t rows, int64_t cols, int64_t nnz,
+                       intptr_t cscColOffsets, intptr_t cscRowInd,
+                       intptr_t cscValues, IndexType cscColOffsetsType,
+                       IndexType cscRowIndType, IndexBase idxBase,
+                       DataType valueType):
+    cdef SpMatDescr desc
+    status = cusparseCreateCsc(&desc, rows, cols, nnz,
+                               <void*>cscColOffsets, <void*>cscRowInd,
+                               <void*>cscValues, cscColOffsetsType,
+                               cscRowIndType, idxBase, valueType)
     check_status(status)
     return <size_t>desc
 

--- a/cupy_backends/stub/cupy_cusparse.h
+++ b/cupy_backends/stub/cupy_cusparse.h
@@ -1027,6 +1027,14 @@ cusparseStatus_t cusparseCsrGet(...) {
   return CUSPARSE_STATUS_SUCCESS;
 }
 
+cusparseStatus_t cusparseCsrSetPointers(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseSpMatGetSize(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
 cusparseStatus_t cusparseSpMatGetFormat(...) {
   return CUSPARSE_STATUS_SUCCESS;
 }

--- a/cupy_backends/stub/cupy_cusparse.h
+++ b/cupy_backends/stub/cupy_cusparse.h
@@ -972,6 +972,8 @@ typedef enum {} cusparseFormat_t;
 typedef enum {} cusparseOrder_t;
 typedef enum {} cusparseSpMVAlg_t;
 typedef enum {} cusparseSpMMAlg_t;
+typedef enum {} cusparseSparseToDenseAlg_t;
+typedef enum {} cusparseDenseToSparseAlg_t;
 
 cusparseStatus_t cusparseCreateSpVec(...) {
   return CUSPARSE_STATUS_SUCCESS;
@@ -1126,6 +1128,26 @@ cusparseStatus_t cusparseConstrainedGeMM_bufferSize(...) {
 }
 
 cusparseStatus_t cusparseConstrainedGeMM(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseSparseToDense_bufferSize(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseSparseToDense(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDenseToSparse_bufferSize(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDenseToSparse_analysis(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDenseToSparse_convert(...) {
   return CUSPARSE_STATUS_SUCCESS;
 }
 

--- a/cupy_backends/stub/cupy_cusparse.h
+++ b/cupy_backends/stub/cupy_cusparse.h
@@ -1011,6 +1011,10 @@ cusparseStatus_t cusparseCreateCsr(...) {
   return CUSPARSE_STATUS_SUCCESS;
 }
 
+cusparseStatus_t cusparseCreateCsc(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
 cusparseStatus_t cusparseDestroySpMat(...) {
   return CUSPARSE_STATUS_SUCCESS;
 }


### PR DESCRIPTION
This PR adds support for new cuSparse functions for matrix conversion, [cusparseDenseToSparse()](https://docs.nvidia.com/cuda/cusparse/index.html#cusparse-generic-function-dense2sparse) and [cusparseSparseToDense()](https://docs.nvidia.com/cuda/cusparse/index.html#cusparse-generic-function-sparse2dense), added in CUDA 11.2. The cuSparse function, [cusparseXdense2csr()](https://docs.nvidia.com/cuda/cusparse/index.html#dense2csr), used in CuPy currently have a problem with incorrect results for some matrix sizes. The new functions solve that problem.

This is related to https://github.com/cupy/cupy/issues/3223

- [x] support CSC and COO format
- [x] add tests
- [x] change code using traditional APIs with `DenseToSparse` and `SparseToDense`