### PR TITLE
Fix cuFFT callback compilations - v2

### DIFF
--- a/cupy/cuda/cufft.pxd
+++ b/cupy/cuda/cufft.pxd
@@ -1,5 +1,8 @@
-from libc.stdint cimport intptr_t
+# Note: nothing exposed in this pxd header is considered public API;
+# we copy this to sdist only because it's needed at runtime to support
+# cuFFT callbacks
 
+from libc.stdint cimport intptr_t
 
 cdef extern from *:
     ctypedef float Float 'cufftReal'

--- a/cupy/cuda/cufft.pxd
+++ b/cupy/cuda/cufft.pxd
@@ -1,7 +1,5 @@
 from libc.stdint cimport intptr_t
 
-from cupy.cuda cimport memory
-
 
 cdef extern from *:
     ctypedef float Float 'cufftReal'
@@ -71,7 +69,7 @@ cdef class Plan1d:
 cdef class PlanNd:
     cdef:
         readonly intptr_t handle
-        readonly memory.MemoryPointer work_area
+        readonly object work_area  # memory.MemoryPointer
         readonly tuple shape
         readonly Type fft_type
         readonly str order
@@ -85,7 +83,7 @@ cdef class PlanNd:
 cdef class XtPlanNd:
     cdef:
         readonly intptr_t handle
-        readonly memory.MemoryPointer work_area
+        readonly object work_area  # memory.MemoryPointer
         readonly tuple shape
         readonly int itype
         readonly int otype

--- a/cupy/cuda/cufft.pyx
+++ b/cupy/cuda/cufft.pyx
@@ -409,12 +409,12 @@ cdef class Plan1d:
         for i in range(nGPUs):
             with device.Device(gpus[i]):
                 buf = memory.alloc(work_size[i])
-                stream = stream.Stream()
-                event = stream.Event()
+                s = stream.Stream()
+                e = stream.Event()
             work_area.append(buf)
             work_area_ptr.push_back(<void*>buf.ptr)
-            gather_streams.append(stream)
-            gather_events.append(event)
+            gather_streams.append(s)
+            gather_events.append(e)
         with nogil:
             result = cufftXtSetWorkArea(plan, work_area_ptr.data())
         check_result(result)

--- a/cupy/cuda/cupy_cufft.h
+++ b/cupy/cuda/cupy_cufft.h
@@ -1,7 +1,11 @@
-// This file is a stub header file of cufft for Read the Docs.
-
 #ifndef INCLUDE_GUARD_CUPY_CUFFT_H
 #define INCLUDE_GUARD_CUPY_CUFFT_H
+
+/*
+ * Note: this file should *not* be split into 3 and moved under cupy_backends/,
+ * because we need to copy this header to sdist and use it at runtime for cuFFT
+ * callbacks.
+ */
 
 #if !defined(CUPY_NO_CUDA) && !defined(CUPY_USE_HIP)
 #include <cufft.h>

--- a/cupy/fft/_cache.pyx
+++ b/cupy/fft/_cache.pyx
@@ -106,7 +106,7 @@ cdef class _Node:
         return output
 
 
-cpdef void _clear_LinkedList(_LinkedList ll) except*:
+cpdef void _clear_LinkedList(_LinkedList ll):
     """ Delete all the nodes to ensure they are cleaned up.
 
     This serves for the purpose of destructor and is invoked by weakref's

--- a/cupy/fft/_cache.pyx
+++ b/cupy/fft/_cache.pyx
@@ -5,7 +5,6 @@ import weakref
 
 from cupy_backends.cuda.api cimport runtime
 from cupy.cuda cimport device
-from cupy.cuda cimport memory
 
 import threading
 
@@ -41,7 +40,6 @@ cdef class _ThreadLocal:
 
 cdef inline Py_ssize_t _get_plan_memsize(plan, int curr_dev=-1) except -1:
     cdef Py_ssize_t memsize = 0
-    cdef memory.MemoryPointer ptr
     cdef int dev
 
     # work_area could be None for "empty" plans...
@@ -50,6 +48,7 @@ cdef inline Py_ssize_t _get_plan_memsize(plan, int curr_dev=-1) except -1:
             # multi-GPU plan
             if curr_dev == -1:
                 curr_dev = runtime.getDevice()
+            # ptr is memory.MemoryPointer, but we can't type it here
             for dev, ptr in zip(plan.gpus, plan.work_area):
                 if dev == curr_dev:
                     memsize = <Py_ssize_t>(ptr.mem.size)
@@ -107,7 +106,7 @@ cdef class _Node:
         return output
 
 
-cpdef void _clear_LinkedList(_LinkedList ll):
+cpdef void _clear_LinkedList(_LinkedList ll) except*:
     """ Delete all the nodes to ensure they are cleaned up.
 
     This serves for the purpose of destructor and is invoked by weakref's

--- a/cupy/fft/_callback.pyx
+++ b/cupy/fft/_callback.pyx
@@ -1,5 +1,10 @@
 from libc.stdint cimport intptr_t
 
+from cupy_backends.cuda.api.driver cimport get_build_version
+from cupy_backends.cuda.api.runtime cimport _is_hip_environment
+from cupy.core.core cimport ndarray
+from cupy.cuda.device cimport get_compute_capability
+
 import hashlib
 import importlib
 import os
@@ -12,9 +17,6 @@ import tempfile
 import threading
 import warnings
 
-from cupy_backends.cuda.api.driver import get_build_version
-from cupy_backends.cuda.api.runtime import is_hip
-import cupy
 from cupy import __version__ as _cupy_ver
 from cupy._environment import (get_nvcc_path, get_cuda_path)
 from cupy.cuda.compiler import (_get_bool_env_variable, CompileException)
@@ -26,7 +28,6 @@ from cupy.cuda.cufft import (CUFFT_C2C, CUFFT_C2R, CUFFT_R2C,
                              CUFFT_CB_ST_COMPLEX, CUFFT_CB_ST_COMPLEX_DOUBLE,
                              CUFFT_CB_ST_REAL, CUFFT_CB_ST_REAL_DOUBLE,)
 from cupy.cuda.cufft import getVersion as get_cufft_version
-from cupy.cuda.device import get_compute_capability
 
 
 # information needed for building an external module
@@ -132,8 +133,8 @@ cdef inline void _set_nvcc_path() except*:
 
 cdef inline void _sanity_checks(
         str cb_load, str cb_store,
-        cb_load_aux_arr, cb_store_aux_arr) except*:
-    if is_hip:
+        ndarray cb_load_aux_arr, ndarray cb_store_aux_arr) except*:
+    if _is_hip_environment:
         raise RuntimeError('hipFFT does not support callbacks')
     if not sys.platform.startswith('linux'):
         raise RuntimeError('cuFFT callbacks are only available on Linux')
@@ -154,13 +155,9 @@ cdef inline void _sanity_checks(
     if _nvprune is None:
         warnings.warn('nvprune is not found', RuntimeWarning)
     if cb_load_aux_arr is not None:
-        if not isinstance(cb_load_aux_arr, cupy.ndarray):
-            raise TypeError('cb_load_aux_arr must be cupy.ndarray')
         if not cb_load:
             raise ValueError('load callback is not given')
     if cb_store_aux_arr is not None:
-        if not isinstance(cb_store_aux_arr, cupy.ndarray):
-            raise TypeError('cb_store_aux_arr must be cupy.ndarray')
         if not cb_store:
             raise ValueError('store callback is not given')
 
@@ -306,15 +303,15 @@ cdef class _CallbackManager:
     cdef:
         readonly str cb_load
         readonly str cb_store
-        readonly object cb_load_aux_arr
-        readonly object cb_store_aux_arr
+        readonly ndarray cb_load_aux_arr
+        readonly ndarray cb_store_aux_arr
         object mod
 
     def __init__(self,
                  str cb_load='',
                  str cb_store='',
-                 cb_load_aux_arr=None,
-                 cb_store_aux_arr=None):
+                 ndarray cb_load_aux_arr=None,
+                 ndarray cb_store_aux_arr=None):
         if not _is_init:
             _set_vars()
         _sanity_checks(cb_load, cb_store,
@@ -413,8 +410,8 @@ cdef class _CallbackManager:
             follow.
 
         '''
-        cb_load_aux_arr = self.cb_load_aux_arr
-        cb_store_aux_arr = self.cb_store_aux_arr
+        cdef ndarray cb_load_aux_arr = self.cb_load_aux_arr
+        cdef ndarray cb_store_aux_arr = self.cb_store_aux_arr
         cdef intptr_t cb_load_ptr=0, cb_store_ptr=0
 
         fft_type = plan.fft_type
@@ -451,8 +448,8 @@ cdef class _CallbackManager:
                 plan.handle, cb_store_type, False, cb_store_ptr)
 
     cdef set_caller_infos(self,
-                          cb_load_aux_arr=None,
-                          cb_store_aux_arr=None):
+                          ndarray cb_load_aux_arr=None,
+                          ndarray cb_store_aux_arr=None):
         '''Set the auxilliary arrays to be used by the load/store callbacks.
         Corresponding to the ``callerInfo`` field in cuFFT's callback API.
 
@@ -551,8 +548,8 @@ cdef class set_cufft_callbacks:
                  str cb_load='',
                  str cb_store='',
                  *,
-                 cb_load_aux_arr=None,
-                 cb_store_aux_arr=None):
+                 ndarray cb_load_aux_arr=None,
+                 ndarray cb_store_aux_arr=None):
         # For every distinct pair of load & store callbacks, we compile an
         # external Python module and cache it.
         cdef tuple key = (cb_load, cb_store)

--- a/tests/cupy_tests/fft_tests/test_callback.py
+++ b/tests/cupy_tests/fft_tests/test_callback.py
@@ -1,11 +1,22 @@
+import contextlib
 import string
 import sys
+import tempfile
+from unittest import mock
 
 import numpy as np
 import pytest
 
 import cupy
 from cupy import testing
+
+
+@contextlib.contextmanager
+def use_temporary_cache_dir():
+    target = 'cupy.fft._callback.get_cache_dir'
+    with tempfile.TemporaryDirectory() as path:
+        with mock.patch(target, lambda: path):
+            yield path
 
 
 _load_callback = r'''
@@ -123,8 +134,9 @@ class Test1dCallbacks:
                 else:
                     out = out.astype(np.float32)
         else:
-            with xp.fft.config.set_cufft_callbacks(cb_load=cb_load):
-                out = fft(a, n=self.n, norm=self.norm)
+            with use_temporary_cache_dir():
+                with xp.fft.config.set_cufft_callbacks(cb_load=cb_load):
+                    out = fft(a, n=self.n, norm=self.norm)
 
         return out
 
@@ -179,8 +191,9 @@ class Test1dCallbacks:
                 if dtype in (np.float32, np.complex64):
                     out = out.astype(np.float32)
         else:
-            with xp.fft.config.set_cufft_callbacks(cb_store=cb_store):
-                out = fft(a, n=self.n, norm=self.norm)
+            with use_temporary_cache_dir():
+                with xp.fft.config.set_cufft_callbacks(cb_store=cb_store):
+                    out = fft(a, n=self.n, norm=self.norm)
 
         return out
 
@@ -249,9 +262,10 @@ class Test1dCallbacks:
                 if dtype in (np.float32, np.complex64):
                     out = out.astype(np.float32)
         else:
-            with xp.fft.config.set_cufft_callbacks(
-                    cb_load=cb_load, cb_store=cb_store):
-                out = fft(a, n=self.n, norm=self.norm)
+            with use_temporary_cache_dir():
+                with xp.fft.config.set_cufft_callbacks(
+                        cb_load=cb_load, cb_store=cb_store):
+                    out = fft(a, n=self.n, norm=self.norm)
 
         return out
 
@@ -302,9 +316,10 @@ class Test1dCallbacks:
             if dtype in (np.float32, np.complex64):
                 out = out.astype(np.complex64)
         else:
-            with xp.fft.config.set_cufft_callbacks(
-                    cb_load=cb_load, cb_load_aux_arr=b):
-                out = fft(a, n=self.n, norm=self.norm)
+            with use_temporary_cache_dir():
+                with xp.fft.config.set_cufft_callbacks(
+                        cb_load=cb_load, cb_load_aux_arr=b):
+                    out = fft(a, n=self.n, norm=self.norm)
 
         return out
 
@@ -365,10 +380,11 @@ class Test1dCallbacks:
                 if dtype in (np.float32, np.complex64):
                     out = out.astype(np.float32)
         else:
-            with xp.fft.config.set_cufft_callbacks(
-                    cb_load=cb_load, cb_store=cb_store,
-                    cb_load_aux_arr=load_aux, cb_store_aux_arr=store_aux):
-                out = fft(a, n=self.n, norm=self.norm)
+            with use_temporary_cache_dir():
+                with xp.fft.config.set_cufft_callbacks(
+                        cb_load=cb_load, cb_store=cb_store,
+                        cb_load_aux_arr=load_aux, cb_store_aux_arr=store_aux):
+                    out = fft(a, n=self.n, norm=self.norm)
 
         return out
 
@@ -437,8 +453,9 @@ class TestNdCallbacks:
                 else:
                     out = out.astype(np.float32)
         else:
-            with xp.fft.config.set_cufft_callbacks(cb_load=cb_load):
-                out = fft(a, s=self.s, axes=self.axes, norm=self.norm)
+            with use_temporary_cache_dir():
+                with xp.fft.config.set_cufft_callbacks(cb_load=cb_load):
+                    out = fft(a, s=self.s, axes=self.axes, norm=self.norm)
 
         return out
 
@@ -497,8 +514,9 @@ class TestNdCallbacks:
                 if dtype in (np.float32, np.complex64):
                     out = out.astype(np.float32)
         else:
-            with xp.fft.config.set_cufft_callbacks(cb_store=cb_store):
-                out = fft(a, s=self.s, axes=self.axes, norm=self.norm)
+            with use_temporary_cache_dir():
+                with xp.fft.config.set_cufft_callbacks(cb_store=cb_store):
+                    out = fft(a, s=self.s, axes=self.axes, norm=self.norm)
 
         return out
 
@@ -571,9 +589,10 @@ class TestNdCallbacks:
                 if dtype in (np.float32, np.complex64):
                     out = out.astype(np.float32)
         else:
-            with xp.fft.config.set_cufft_callbacks(
-                    cb_load=cb_load, cb_store=cb_store):
-                out = fft(a, s=self.s, axes=self.axes, norm=self.norm)
+            with use_temporary_cache_dir():
+                with xp.fft.config.set_cufft_callbacks(
+                        cb_load=cb_load, cb_store=cb_store):
+                    out = fft(a, s=self.s, axes=self.axes, norm=self.norm)
 
         return out
 
@@ -658,10 +677,11 @@ class TestNdCallbacks:
                 if dtype in (np.float32, np.complex64):
                     out = out.astype(np.float32)
         else:
-            with xp.fft.config.set_cufft_callbacks(
-                    cb_load=cb_load, cb_store=cb_store,
-                    cb_load_aux_arr=load_aux, cb_store_aux_arr=store_aux):
-                out = fft(a, s=self.s, axes=self.axes, norm=self.norm)
+            with use_temporary_cache_dir():
+                with xp.fft.config.set_cufft_callbacks(
+                        cb_load=cb_load, cb_store=cb_store,
+                        cb_load_aux_arr=load_aux, cb_store_aux_arr=store_aux):
+                    out = fft(a, s=self.s, axes=self.axes, norm=self.norm)
 
         return out
 

--- a/tests/cupy_tests/fft_tests/test_callback.py
+++ b/tests/cupy_tests/fft_tests/test_callback.py
@@ -105,6 +105,7 @@ def _set_store_cb(code, element, data_type, callback_type, aux_type=None):
 }))
 @testing.with_requires('cython>=0.29.0')
 @testing.gpu
+@testing.slow
 @pytest.mark.skipif(not sys.platform.startswith('linux'),
                     reason='callbacks are only supported on Linux')
 @pytest.mark.skipif(cupy.cuda.runtime.is_hip,
@@ -424,6 +425,7 @@ class Test1dCallbacks:
 )
 @testing.with_requires('cython>=0.29.0')
 @testing.gpu
+@testing.slow
 @pytest.mark.skipif(not sys.platform.startswith('linux'),
                     reason='callbacks are only supported on Linux')
 @pytest.mark.skipif(cupy.cuda.runtime.is_hip,

--- a/tests/cupy_tests/fft_tests/test_callback.py
+++ b/tests/cupy_tests/fft_tests/test_callback.py
@@ -105,7 +105,6 @@ def _set_store_cb(code, element, data_type, callback_type, aux_type=None):
 }))
 @testing.with_requires('cython>=0.29.0')
 @testing.gpu
-@testing.slow
 @pytest.mark.skipif(not sys.platform.startswith('linux'),
                     reason='callbacks are only supported on Linux')
 @pytest.mark.skipif(cupy.cuda.runtime.is_hip,
@@ -425,7 +424,6 @@ class Test1dCallbacks:
 )
 @testing.with_requires('cython>=0.29.0')
 @testing.gpu
-@testing.slow
 @pytest.mark.skipif(not sys.platform.startswith('linux'),
                     reason='callbacks are only supported on Linux')
 @pytest.mark.skipif(cupy.cuda.runtime.is_hip,

--- a/tests/cupy_tests/fft_tests/test_callback.py
+++ b/tests/cupy_tests/fft_tests/test_callback.py
@@ -94,7 +94,6 @@ def _set_store_cb(code, element, data_type, callback_type, aux_type=None):
 }))
 @testing.with_requires('cython>=0.29.0')
 @testing.gpu
-@pytest.mark.skip(reason='Need to address Cython bundling issues')
 @pytest.mark.skipif(not sys.platform.startswith('linux'),
                     reason='callbacks are only supported on Linux')
 @pytest.mark.skipif(cupy.cuda.runtime.is_hip,
@@ -409,7 +408,6 @@ class Test1dCallbacks:
 )
 @testing.with_requires('cython>=0.29.0')
 @testing.gpu
-@pytest.mark.skip(reason='Need to address Cython bundling issues')
 @pytest.mark.skipif(not sys.platform.startswith('linux'),
                     reason='callbacks are only supported on Linux')
 @pytest.mark.skipif(cupy.cuda.runtime.is_hip,


### PR DESCRIPTION
Close #4746.

This is an alternative of #4743 (proposal v2 mentioned there). The solution here is to avoid cimporting any CuPy modules so that we don't expose Cython-level APIs. The incurred overhead is OK ~~(which I will post later)~~: about +/- 5 us (yes, it can be faster in some cases, which I didn't expect), see https://github.com/cupy/cupy/pull/4853#issuecomment-794903196.

TODO:
- [x] Fix https://github.com/cupy/cupy/issues/4746#issuecomment-785543235