### PR TITLE
Windows: Fix `test_poly1d_pow_scalar`

### DIFF
--- a/cupy/lib/_polynomial.pyx
+++ b/cupy/lib/_polynomial.pyx
@@ -172,7 +172,8 @@ cdef class poly1d:
         elif dtype.kind == 'f' or dtype == numpy.uint64:
             base = base.astype(numpy.float64, copy=False)
         else:
-            base = base.astype(numpy.int64, copy=False)
+            # use Python int here for cross-platform portability
+            base = base.astype(int, copy=False)
         return poly1d(_routines_poly._polypow(base, val))
 
     def __sub__(self, other):

--- a/cupy/lib/_polynomial.pyx
+++ b/cupy/lib/_polynomial.pyx
@@ -173,7 +173,8 @@ cdef class poly1d:
             base = base.astype(numpy.float64, copy=False)
         else:
             # use Python int here for cross-platform portability
-            base = base.astype(int, copy=False)
+            int_dtype = numpy.promote_types(dtype, int)
+            base = base.astype(int_dtype, copy=False)
         return poly1d(_routines_poly._polypow(base, val))
 
     def __sub__(self, other):


### PR DESCRIPTION
Again, pure guess work here...

```
_______ TestPoly1dPow_param_3_{exp=4, shape=()}.test_poly1d_pow_scalar ________
cupy\testing\helper.py:825: in test_func
    impl(self, *args, **kw)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <<cupy_tests.lib_tests.test_polynomial.TestPoly1dPow_param_3_{exp=4, shape=()} testMethod=test_poly1d_pow_scalar>  parameter: {'exp': 4, 'shape': ()}>
args = (), kw = {'dtype': <class 'numpy.int8'>}
cupy_result = (poly1d([1], dtype=int64),), cupy_error = None
numpy_result = (poly1d([1]),), numpy_error = None
cupy_numpy_result_ndarrays = [(array([1], dtype=int64), array([1]))]
cupy_r = array([1], dtype=int64), numpy_r = array([1])

            @_wraps_partial_xp(impl, name, sp_name, scipy_name)
            def test_func(self, *args, **kw):
                # Run cupy and numpy
                (
                    cupy_result, cupy_error,
                    numpy_result, numpy_error) = (
                        _call_func_numpy_cupy(
                            self, impl, args, kw, name, sp_name, scipy_name))
                assert cupy_result is not None or cupy_error is not None
                assert numpy_result is not None or numpy_error is not None
    
                # Check errors raised
                if cupy_error or numpy_error:
                    _check_cupy_numpy_error(cupy_error,
                                            numpy_error,
                                            accept_error=accept_error)
                    return
    
                # Check returned arrays
    
                if not isinstance(cupy_result, (tuple, list)):
                    cupy_result = cupy_result,
                if not isinstance(numpy_result, (tuple, list)):
                    numpy_result = numpy_result,
    
                assert len(cupy_result) == len(numpy_result)
    
                # Check types
                cupy_numpy_result_ndarrays = [
                    _convert_output_to_ndarray(
                        cupy_r, numpy_r, sp_name, check_sparse_format)
                    for cupy_r, numpy_r in zip(cupy_result, numpy_result)]
    
                # Check dtypes
                if type_check:
                    for cupy_r, numpy_r in cupy_numpy_result_ndarrays:
                        if cupy_r.dtype != numpy_r.dtype:
                            raise AssertionError(
                                '''ndarrays of different dtypes are returned.
    cupy: {}
>   numpy: {}'''.format(cupy_r.dtype, numpy_r.dtype))
E   AssertionError: ndarrays of different dtypes are returned.
E   cupy: int64
E   numpy: int32

cupy\testing\helper.py:298: AssertionError
---------------------------- Captured stdout call -----------------------------
dtype is <class 'numpy.int8'>
```