### PR TITLE
Fix broadcasting error in cupy roll if shift argument is an array

### DIFF
--- a/cupy/_manipulation/rearrange.py
+++ b/cupy/_manipulation/rearrange.py
@@ -1,4 +1,5 @@
 import itertools
+import warnings
 
 import numpy
 
@@ -105,6 +106,10 @@ def roll(a, shift, axis=None):
         # Force shift array to be numpy based on numpy broadcasting
         if isinstance(shift, cupy.ndarray):
             shift = cupy.asnumpy(shift)
+            warnings.warn(
+                'current implementation of roll leverages '
+                'numpy broadcast; shift array migrating to CPU',
+                RuntimeWarning)
 
         broadcasted = numpy.broadcast(shift, axis)
         if broadcasted.nd > 1:

--- a/cupy/_manipulation/rearrange.py
+++ b/cupy/_manipulation/rearrange.py
@@ -102,6 +102,10 @@ def roll(a, shift, axis=None):
     else:
         axis = _reduction._get_axis(axis, a.ndim)[0]
 
+        # Force shift array to be numpy based on numpy broadcasting
+        if isinstance(shift, cupy.ndarray):
+            shift = cupy.asnumpy(shift)
+
         broadcasted = numpy.broadcast(shift, axis)
         if broadcasted.nd > 1:
             raise ValueError(


### PR DESCRIPTION
Closes https://github.com/cupy/cupy/issues/4476

CuPy's roll function relies on Numpy's broadcasting function. This is all fine and good if the shift parameter is either a scalar or tuple, but if the shift parameter is an array, the user receives a cupy/numpy conversion error. Since CuPy's broadcast function doesn't yield an iterable object, we can't simply replace `numpy.broadcast` with `cupy.broadcast`.

I've submitted a PR to check if the shift argument is a `cupy.ndarray` object. If so, we migrate to the CPU and let `numpy.broadcast` do its thing with a numpy shift array.

The following code now works as expected:

```python
import cupy as cp
a = cp.arange(12).reshape(4,3)
shift = cp.array([1,2,3,4])
rolled = cp.roll(a, shift)
```