### PR TITLE
Xfail some conditions of ndimage filter under ROCm/HIP

### DIFF
--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
@@ -295,8 +295,23 @@ def dummy_deriv_func(input, axis, output, mode, cval, *args, **kwargs):
 @testing.gpu
 @testing.with_requires('scipy')
 class TestFilterFast(FilterTestCaseBase):
+
+    def _hip_skip_invalid_condition(self):
+        if not runtime.is_hip:
+            return
+        if self.filter != 'percentile_filter':
+            return
+        if self.ksize != 3:
+            return
+        invalids = [(25, (1, 3, 4, 5)),
+                    (50, (3, 4, 5)),
+                    (-25, (1, 3, 4, 5))]
+        if (self.percentile, self.shape) in invalids:
+            pytest.xfail('ROCm/HIP may have a bug')
+
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
     def test_filter(self, xp, scp):
+        self._hip_skip_invalid_condition()
         return self._filter(xp, scp)
 
 


### PR DESCRIPTION
Rel #4132, #4484.

Larger errors to say the matter of tolerance.

```
E       AssertionError: 
E       Not equal to tolerance rtol=1e-05, atol=1e-05
E       
E       Mismatched elements: 17 / 20 (85%)
E       Max absolute difference: 4.46357349
E       Max relative difference: 0.51304726
E        x: array([[4.375872, 5.488135, 5.448832, 4.236546, 4.236548],
E              [5.288949, 6.027634, 5.288949, 4.236548, 4.236548],
E              [4.375872, 4.37587 , 5.288949, 4.236546, 4.236548],
E              [5.288949, 5.288948, 5.288949, 4.236546, 4.236548]])
E        y: array([[5.488135, 6.458941, 7.151894, 6.027634, 5.448832],
E              [5.488135, 6.027634, 6.027634, 5.680446, 5.448832],
E              [4.375872, 5.680446, 7.781568, 8.326198, 8.700121],
E              [5.288949, 5.680446, 5.680446, 7.781568, 8.700121]])
```

Makes the interpreter abort under some environment.
https://github.com/kmaehashi/cupy-rocm-ci-report/blob/09d91bb595b33e3c2b431dafc1430114d7f3afad/docs/output_test.log
