### PR TITLE
Xfail some conditions of ndimage measurements under ROCm/HIP

### DIFF
--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
@@ -305,10 +305,10 @@ class TestMeasurementsSelect:
     def _hip_skip_invalid_condition(self):
         if (runtime.is_hip
                 and self.op == 'extrema'
-                and (self.index == None
+                and (self.index is None
                      or (self.index == 1 and self.labels in [None, 5])
                      or (self.index in ['all', 'subset']
-                         and self.labels == None))):
+                         and self.labels is None))):
             pytest.xfail('ROCm/HIP may have a bug')
 
     # no_bool=True due to https://github.com/scipy/scipy/issues/12836

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
@@ -4,6 +4,7 @@ import numpy
 import pytest
 
 import cupy
+from cupy.cuda import runtime
 from cupy import testing
 from cupy import _util
 from cupy.core import _accelerator
@@ -301,10 +302,21 @@ class TestMeasurementsSelect:
         yield
         _accelerator.set_routine_accelerators(old_accelerators)
 
+    def _hip_skip_invalid_condition(self):
+        if (runtime.is_hip
+                and self.op == 'extrema'
+                and (self.index == None
+                     or (self.index == 1 and self.labels in [None, 5])
+                     or (self.index in ['all', 'subset']
+                         and self.labels == None))):
+            pytest.xfail('ROCm/HIP may have a bug')
+
     # no_bool=True due to https://github.com/scipy/scipy/issues/12836
     @testing.for_all_dtypes(no_complex=True, no_bool=True)
     @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_measurements_select(self, xp, scp, dtype):
+        self._hip_skip_invalid_condition()
+
         shape = self.shape
         rstate = numpy.random.RandomState(0)
         # scale must be small enough to avoid potential integer overflow due to


### PR DESCRIPTION
Rel #4132, #4484.

Including fairly larger errors.

```
E       AssertionError: 
E       Not equal to tolerance rtol=1e-07, atol=0
E       
E       Mismatched elements: 1 / 2 (50%)
E       Max absolute difference: 1608
E       Max relative difference: 64.32
E        x: array([1633,   33])
E        y: array([25, 33])
```