### PR TITLE
Xfail some conditions of signal tests under ROCm/HIP

### DIFF
--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
@@ -62,9 +62,10 @@ class TestFFTConvolve(unittest.TestCase):
             np.float16: 1e-3, 'default': 1e-8}
 
     def _hip_skip_invalid_condition(self):
-        invalid_condition = [('full', 4), ('full', 5), ('full', 10),
-                             ('same', 3), ('same', 4), ('same', 5), ('same', 10),
-                             ('valid', 10)]
+        invalid_condition = [
+            ('full', 4), ('full', 5), ('full', 10),
+            ('same', 3), ('same', 4), ('same', 5), ('same', 10),
+            ('valid', 10)]
         if (runtime.is_hip and self.size1 == (3, 4, 10)
                 and (self.mode, self.size2) in invalid_condition):
             pytest.xfail('ROCm/HIP may have a bug')

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
@@ -5,6 +5,7 @@ import pytest
 import numpy as np
 
 import cupy
+from cupy.cuda import runtime
 from cupy import testing
 
 import cupyx.scipy.signal
@@ -60,22 +61,33 @@ class TestFFTConvolve(unittest.TestCase):
     tols = {np.float32: 1e-3, np.complex64: 1e-3,
             np.float16: 1e-3, 'default': 1e-8}
 
+    def _hip_skip_invalid_condition(self):
+        invalid_condition = [('full', 4), ('full', 5), ('full', 10),
+                             ('same', 3), ('same', 4), ('same', 5), ('same', 10),
+                             ('valid', 10)]
+        if (runtime.is_hip and self.size1 == (3, 4, 10)
+                and (self.mode, self.size2) in invalid_condition):
+            pytest.xfail('ROCm/HIP may have a bug')
+
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(atol=tols, rtol=tols, scipy_name='scp',
                                  accept_error=ValueError)
     def test_fftconvolve(self, xp, scp, dtype):
+        self._hip_skip_invalid_condition()
         return self._filter('fftconvolve', dtype, xp, scp)
 
     @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose(atol=tols, rtol=tols, scipy_name='scp',
                                  accept_error=ValueError)
     def test_convolve_fft(self, xp, scp, dtype):
+        self._hip_skip_invalid_condition()
         return self._filter('convolve', dtype, xp, scp, method='fft')
 
     @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose(atol=tols, rtol=tols, scipy_name='scp',
                                  accept_error=ValueError)
     def test_correlate_fft(self, xp, scp, dtype):
+        self._hip_skip_invalid_condition()
         return self._filter('correlate', dtype, xp, scp, method='fft')
 
 
@@ -94,6 +106,8 @@ class TestOAConvolve(unittest.TestCase):
     @testing.numpy_cupy_allclose(atol=tols, rtol=tols, scipy_name='scp',
                                  accept_error=ValueError)
     def test_oaconvolve(self, xp, scp, dtype):
+        if runtime.is_hip and self.size2 in [5, None]:
+            pytest.xfail('ROCm/HIP may have a bug')
         in1 = testing.shaped_random(self.size1, xp, dtype)
         shape2 = self.size1 if self.size2 is None else (self.size2,)*in1.ndim
         in2 = testing.shaped_random(shape2, xp, dtype)


### PR DESCRIPTION
Rel #4132, #4484.

Including fairly larger errors.

```
E       AssertionError: 
E       Not equal to tolerance rtol=0.001, atol=0.001
E       
E       Mismatched elements: 784 / 784 (100%)
E       Max absolute difference: 1333.3907
E       Max relative difference: 8.11097
E        x: array([[[ 1.132499e+02,  8.041714e+01,  1.015153e+02,  6.432927e+01,
E                 1.203019e+02,  1.354613e+01,  2.911143e+01, -2.381061e+01,
E                 2.635724e+01, -3.767127e+01,  1.562032e+01,  6.885651e+01,...
E        y: array([[[  30.119678,   78.50118 ,  117.3106  ,  146.02594 ,
E                 160.77292 ,  161.73344 ,  150.97159 ,  165.33815 ,
E                 196.18398 ,  194.92374 ,  152.63922 ,  113.40126 ,...
```