### PR TITLE
Support cuSPARSELt

### DIFF
--- a/cupy_backends/cuda/libs/cusparselt.pxd
+++ b/cupy_backends/cuda/libs/cusparselt.pxd
@@ -1,0 +1,25 @@
+from libc.stdint cimport int32_t, uint32_t, int64_t, uint64_t, intptr_t
+
+###############################################################################
+# Enum
+###############################################################################
+
+cpdef enum:
+      # cusparseLtSparsity_t
+      CUSPARSELT_SPARSITY_50_PERCENT = 0
+
+      # cusparseComputeType
+      CUSPARSE_COMPUTE_16F = 0
+      CUSPARSE_COMPUTE_32I = 1
+
+      # cusparseLtMatmulAlg_t
+      CUSPARSELT_MATMUL_ALG_DEFAULT = 0
+
+      # cusparseLtMatmulAlgAttribute_t
+      CUSPARSELT_MATMUL_ALG_CONFIG_ID = 0      # NOQA, READ/WRITE
+      CUSPARSELT_MATMUL_ALG_CONFIG_MAX_ID = 1  # NOQA, READ-ONLY
+      CUSPARSELT_MATMUL_SEARCH_ITERATIONS = 2  # NOQA, READ/WRITE
+
+      # cusparseLtPruneAlg_t
+      CUSPARSELT_PRUNE_SPMMA_TILE  = 0
+      CUSPARSELT_PRUNE_SPMMA_STRIP = 1

--- a/cupy_backends/cuda/libs/cusparselt.pxd
+++ b/cupy_backends/cuda/libs/cusparselt.pxd
@@ -5,21 +5,21 @@ from libc.stdint cimport int32_t, uint32_t, int64_t, uint64_t, intptr_t
 ###############################################################################
 
 cpdef enum:
-      # cusparseLtSparsity_t
-      CUSPARSELT_SPARSITY_50_PERCENT = 0
+    # cusparseLtSparsity_t
+    CUSPARSELT_SPARSITY_50_PERCENT = 0
 
-      # cusparseComputeType
-      CUSPARSE_COMPUTE_16F = 0
-      CUSPARSE_COMPUTE_32I = 1
+    # cusparseComputeType
+    CUSPARSE_COMPUTE_16F = 0
+    CUSPARSE_COMPUTE_32I = 1
 
-      # cusparseLtMatmulAlg_t
-      CUSPARSELT_MATMUL_ALG_DEFAULT = 0
+    # cusparseLtMatmulAlg_t
+    CUSPARSELT_MATMUL_ALG_DEFAULT = 0
 
-      # cusparseLtMatmulAlgAttribute_t
-      CUSPARSELT_MATMUL_ALG_CONFIG_ID = 0      # NOQA, READ/WRITE
-      CUSPARSELT_MATMUL_ALG_CONFIG_MAX_ID = 1  # NOQA, READ-ONLY
-      CUSPARSELT_MATMUL_SEARCH_ITERATIONS = 2  # NOQA, READ/WRITE
+    # cusparseLtMatmulAlgAttribute_t
+    CUSPARSELT_MATMUL_ALG_CONFIG_ID = 0      # NOQA, READ/WRITE
+    CUSPARSELT_MATMUL_ALG_CONFIG_MAX_ID = 1  # NOQA, READ-ONLY
+    CUSPARSELT_MATMUL_SEARCH_ITERATIONS = 2  # NOQA, READ/WRITE
 
-      # cusparseLtPruneAlg_t
-      CUSPARSELT_PRUNE_SPMMA_TILE  = 0
-      CUSPARSELT_PRUNE_SPMMA_STRIP = 1
+    # cusparseLtPruneAlg_t
+    CUSPARSELT_PRUNE_SPMMA_TILE = 0
+    CUSPARSELT_PRUNE_SPMMA_STRIP = 1

--- a/cupy_backends/cuda/libs/cusparselt.pyx
+++ b/cupy_backends/cuda/libs/cusparselt.pyx
@@ -1,0 +1,377 @@
+"""Thin wrapper for cuSPARSELt"""
+
+cimport cython  # NOQA
+
+from cpython.mem cimport PyMem_Malloc, PyMem_Free
+from libc.stdint cimport uint8_t, int32_t, uint32_t, int64_t, intptr_t
+
+from cupy_backends.cuda cimport stream as stream_module
+from cupy_backends.cuda.api cimport driver
+
+cdef extern from '../../cupy_cusparselt.h' nogil:
+    ctypedef int cusparseStatus_t 'cusparseStatus_t'
+    ctypedef int cusparseOrder_t 'cusparseOrder_t'
+    ctypedef int cudaDataType 'cudaDataType'
+    ctypedef int cusparseComputeType 'cusparseComputeType'
+
+    # Opaque Data Structures
+    ctypedef struct cusparseLtHandle_t 'cusparseLtHandle_t':
+        uint8_t data[1024]
+    ctypedef struct cusparseLtMatDescriptor_t 'cusparseLtMatDescriptor_t':
+        uint8_t data[1024]
+    ctypedef struct cusparseLtMatmulDescriptor_t 'cusparseLtMatmulDescriptor_t':
+        uint8_t data[1024]
+    ctypedef struct cusparseLtMatmulAlgSelection_t 'cusparseLtMatmulAlgSelection_t':
+        uint8_t data[1024]
+    ctypedef struct cusparseLtMatmulPlan_t 'cusparseLtMatmulPlan_t':
+        uint8_t data[1024]
+
+    # Enumerators
+    ctypedef int cusparseLtSparsity_t 'cusparseLtSparsity_t'
+    ctypedef int cusparseOperation_t 'cusparseOperation_t'
+    ctypedef int cusparseLtMatmulAlg_t 'cusparseLtMatmulAlg_t'
+    ctypedef int cusparseLtMatmulAlgAttribute_t 'cusparseLtMatmulAlgAttribute_t'
+    ctypedef int cusparseLtPruneAlg_t 'cusparseLtPruneAlg_t'
+
+    # Management Functions
+    cusparseStatus_t cusparseLtInit(cusparseLtHandle_t* handle)
+    cusparseStatus_t cusparseLtDestroy(const cusparseLtHandle_t* handle)
+
+    # Matmul Functions
+    cusparseStatus_t cusparseLtDenseDescriptorInit(
+        const cusparseLtHandle_t* handle,
+        cusparseLtMatDescriptor_t* matDescr,
+        int64_t rows, int64_t cols, int64_t ld, uint32_t alignment,
+        cudaDataType valueType, cusparseOrder_t order)
+    cusparseStatus_t cusparseLtStructuredDescriptorInit(
+        const cusparseLtHandle_t* handle,
+        cusparseLtMatDescriptor_t* matDescr,
+        int64_t rows, int64_t cols, int64_t ld, uint32_t alignment,
+        cudaDataType valueType, cusparseOrder_t order,
+        cusparseLtSparsity_t sparsity)
+    cusparseStatus_t cusparseLtMatmulDescriptorInit(
+        const cusparseLtHandle_t* handle,
+        cusparseLtMatmulDescriptor_t* matMulDescr,
+        cusparseOperation_t opA,
+        cusparseOperation_t opB,
+        const cusparseLtMatDescriptor_t* matA,
+        const cusparseLtMatDescriptor_t* matB,
+        const cusparseLtMatDescriptor_t* matC,
+        const cusparseLtMatDescriptor_t* matD,
+        cusparseComputeType computeType)
+    cusparseStatus_t cusparseLtMatmulAlgSelectionInit(
+        const cusparseLtHandle_t* handle,
+        cusparseLtMatmulAlgSelection_t* algSelection,
+        const cusparseLtMatmulDescriptor_t* matmulDescr,
+        cusparseLtMatmulAlg_t alg)
+    cusparseStatus_t cusparseLtMatmulAlgSetAttribute(
+        const cusparseLtHandle_t* handle,
+        cusparseLtMatmulAlgSelection_t* algSelection,
+        cusparseLtMatmulAlgAttribute_t attribute,
+        const void* data, size_t ataSize)
+    cusparseStatus_t cusparseLtMatmulGetWorkspace(
+        const cusparseLtHandle_t* handle,
+        const cusparseLtMatmulAlgSelection_t* algSelection,
+        size_t* workspaceSize);
+    cusparseStatus_t cusparseLtMatmulPlanInit(
+        const cusparseLtHandle_t* handle,
+        cusparseLtMatmulPlan_t* plan,
+        const cusparseLtMatmulDescriptor_t* matmulDescr,
+        const cusparseLtMatmulAlgSelection_t* algSelection,
+        size_t workspaceSize)
+    cusparseStatus_t cusparseLtMatmul(
+        const cusparseLtHandle_t* handle, const cusparseLtMatmulPlan_t* plan,
+        const void* alpha, const void* d_A, const void* d_B,
+        const void* beta, const void* d_C, void* d_D,
+        void* workspace, driver.Stream* streams, int32_t numStreams)
+
+    # Helper Functions
+    cusparseStatus_t cusparseLtSpMMAPrune(
+        const cusparseLtHandle_t* handle,
+        const cusparseLtMatmulDescriptor_t* matmulDescr,
+        const void* d_in, void* d_out,
+        cusparseLtPruneAlg_t pruneAlg, driver.Stream stream)
+    cusparseStatus_t cusparseLtSpMMAPruneCheck(
+        const cusparseLtHandle_t* handle,
+        const cusparseLtMatmulDescriptor_t* matmulDescr,
+        const void* d_in, int* valid, driver.Stream stream)
+    cusparseStatus_t cusparseLtSpMMACompressedSize(
+        const cusparseLtHandle_t* handle, const cusparseLtMatmulPlan_t* plan,
+        size_t* compressedSize);
+    cusparseStatus_t cusparseLtSpMMACompress(
+        const cusparseLtHandle_t* handle, const cusparseLtMatmulPlan_t* plan,
+        const void* d_dense, void* d_compressed, driver.Stream stream)
+
+
+###############################################################################
+# Classes
+###############################################################################
+
+cdef class Handle:
+    cdef void * _ptr
+
+    def __init__(self):
+        self._ptr = PyMem_Malloc(sizeof(cusparseLtHandle_t))
+
+    def __dealloc__(self):
+        PyMem_Free(self._ptr)
+        self._ptr = NULL
+
+    @property
+    def ptr(self):
+        return <intptr_t>self._ptr
+
+
+cdef class MatDescriptor:
+    cdef void * _ptr
+
+    def __init__(self):
+        self._ptr = PyMem_Malloc(sizeof(cusparseLtMatDescriptor_t))
+
+    def __dealloc__(self):
+        PyMem_Free(self._ptr)
+        self._ptr = NULL
+
+    @property
+    def ptr(self):
+        return <intptr_t>self._ptr
+
+
+cdef class MatmulDescriptor:
+    cdef void * _ptr
+
+    def __init__(self):
+        self._ptr = PyMem_Malloc(sizeof(cusparseLtMatmulDescriptor_t))
+
+    def __dealloc__(self):
+        PyMem_Free(self._ptr)
+        self._ptr = NULL
+
+    @property
+    def ptr(self):
+        return <intptr_t>self._ptr
+
+
+cdef class MatmulAlgSelection:
+    cdef void * _ptr
+
+    def __init__(self):
+        self._ptr = PyMem_Malloc(sizeof(cusparseLtMatmulAlgSelection_t))
+
+    def __dealloc__(self):
+        PyMem_Free(self._ptr)
+        self._ptr = NULL
+
+    @property
+    def ptr(self):
+        return <intptr_t>self._ptr
+
+
+cdef class MatmulPlan:
+    cdef void * _ptr
+
+    def __init__(self):
+        self._ptr = PyMem_Malloc(sizeof(cusparseLtMatmulPlan_t))
+
+    def __dealloc__(self):
+        PyMem_Free(self._ptr)
+        self._ptr = NULL
+
+    @property
+    def ptr(self):
+        return <intptr_t>self._ptr
+
+
+###############################################################################
+# Error handling
+###############################################################################
+
+cdef dict STATUS = {
+    0: 'CUSPARSE_STATUS_SUCCESS',
+    1: 'CUSPARSE_STATUS_NOT_INITIALIZED',
+    2: 'CUSPARSE_STATUS_ALLOC_FAILED',
+    3: 'CUSPARSE_STATUS_INVALID_VALUE',
+    4: 'CUSPARSE_STATUS_ARCH_MISMATCH',
+    5: 'CUSPARSE_STATUS_MAPPING_ERROR',
+    6: 'CUSPARSE_STATUS_EXECUTION_FAILED',
+    7: 'CUSPARSE_STATUS_INTERNAL_ERROR',
+    8: 'CUSPARSE_STATUS_MATRIX_TYPE_NOT_SUPPORTED',
+    9: 'CUSPARSE_STATUS_ZERO_PIVOT',
+    10: 'CUSPARSE_STATUS_NOT_SUPPORTED',
+}
+
+class CuSparseError(RuntimeError):
+
+    def __init__(self, int status):
+        self.status = status
+        super(CuSparseError, self).__init__('%s' % (STATUS[status]))
+
+    def __reduce__(self):
+        return (type(self), (self.status,))
+
+@cython.profile(False)
+cpdef inline check_status(int status):
+    if status != 0:
+        raise CuSparseError(status)
+
+###############################################################################
+# cuSPARSELt: Library Management Functions
+###############################################################################
+
+cpdef init(Handle handle):
+    """Initializes the cuSPARSELt library handle"""
+    status = cusparseLtInit(<cusparseLtHandle_t*> handle._ptr)
+    check_status(status)
+
+
+cpdef destroy(Handle handle):
+    """Releases hardware resources used by the cuSPARSELt library"""
+    status = cusparseLtDestroy(<cusparseLtHandle_t*> handle._ptr)
+    check_status(status)
+
+###############################################################################
+# cuSPARSELt: Matmul Functions
+###############################################################################
+
+cpdef denseDescriptorInit(Handle handle, MatDescriptor matDescr,
+                          rows, cols, ld, alignment, valueType, order):
+    """Initializes the descriptor of a dense matrix"""
+    status = cusparseLtDenseDescriptorInit(
+        <const cusparseLtHandle_t*> handle._ptr,
+        <cusparseLtMatDescriptor_t*> matDescr._ptr,
+        <int64_t> rows, <int64_t> cols, <int64_t> ld, <uint32_t> alignment,
+        <cudaDataType> valueType, <cusparseOrder_t> order)
+    check_status(status)
+
+cpdef structuredDescriptorInit(Handle handle, MatDescriptor matDescr,
+                               rows, cols, ld, alignment, valueType, order,
+                               sparsity):
+    """Initializes the descriptor of a structured matrix."""
+    status = cusparseLtStructuredDescriptorInit(
+        <const cusparseLtHandle_t*> handle._ptr,
+        <cusparseLtMatDescriptor_t*> matDescr._ptr,
+        <int64_t> rows, <int64_t> cols, <int64_t> ld, <uint32_t> alignment,
+        <cudaDataType> valueType, <cusparseOrder_t> order,
+        <cusparseLtSparsity_t> sparsity)
+    check_status(status)
+
+cpdef matmulDescriptorInit(Handle handle,
+                           MatmulDescriptor matMulDescr,
+                           opA, opB,
+                           MatDescriptor matA,
+                           MatDescriptor matB,
+                           MatDescriptor matC,
+                           MatDescriptor matD,
+                           computeType):
+    """Initializes the matrix multiplication descriptor."""
+    status = cusparseLtMatmulDescriptorInit(
+        <const cusparseLtHandle_t*> handle._ptr,
+        <cusparseLtMatmulDescriptor_t*> matMulDescr._ptr,
+        <cusparseOperation_t> opA,
+        <cusparseOperation_t> opB,
+        <const cusparseLtMatDescriptor_t*> matA._ptr,
+        <const cusparseLtMatDescriptor_t*> matB._ptr,
+        <const cusparseLtMatDescriptor_t*> matC._ptr,
+        <const cusparseLtMatDescriptor_t*> matD._ptr,
+        <cusparseComputeType> computeType)
+    check_status(status)
+
+cpdef matmulAlgSelectionInit(Handle handle, MatmulAlgSelection algSelection,
+                             MatmulDescriptor matmulDescr, alg):
+    """Initializes the algorithm selection descriptor."""
+    status = cusparseLtMatmulAlgSelectionInit(
+        <const cusparseLtHandle_t*> handle._ptr,
+        <cusparseLtMatmulAlgSelection_t*> algSelection._ptr,
+        <const cusparseLtMatmulDescriptor_t*> matmulDescr._ptr,
+        <cusparseLtMatmulAlg_t> alg)
+    check_status(status)
+
+cpdef matmulAlgSetAttribute(Handle handle, MatmulAlgSelection algSelection,
+                            attribute, size_t data, size_t dataSize):
+    """Sets the attribute related to algorithm selection descriptor."""
+    status = cusparseLtMatmulAlgSetAttribute(
+        <const cusparseLtHandle_t*> handle._ptr,
+        <cusparseLtMatmulAlgSelection_t*> algSelection._ptr,
+        <cusparseLtMatmulAlgAttribute_t> attribute,
+        <const void*> data, <size_t> dataSize)
+    check_status(status)
+
+cpdef size_t matmulGetWorkspace(Handle handle, MatmulAlgSelection algSelection):
+    """Determines the required workspace size"""
+    cdef size_t workspaceSize
+    status = cusparseLtMatmulGetWorkspace(
+        <const cusparseLtHandle_t*> handle._ptr,
+        <const cusparseLtMatmulAlgSelection_t*> algSelection._ptr,
+        &workspaceSize)
+    check_status(status)
+    return workspaceSize
+
+cpdef matmulPlanInit(Handle handle, MatmulPlan plan,
+                    MatmulDescriptor matmulDescr,
+                    MatmulAlgSelection algSelection,
+                    size_t workspaceSize):
+    """Initializes the plan."""
+    status = cusparseLtMatmulPlanInit(
+        <const cusparseLtHandle_t*> handle._ptr,
+        <cusparseLtMatmulPlan_t*> plan._ptr,
+        <const cusparseLtMatmulDescriptor_t*> matmulDescr._ptr,
+        <const cusparseLtMatmulAlgSelection_t*> algSelection._ptr,
+        <size_t> workspaceSize)
+    check_status(status)
+
+cpdef matmul(Handle handle, MatmulPlan plan,
+             size_t alpha, size_t d_A, size_t d_B,
+             size_t beta, size_t d_C, size_t d_D, size_t workspace):
+    """Computes the matrix multiplication"""
+    status = cusparseLtMatmul(
+        <const cusparseLtHandle_t*> handle._ptr,
+        <const cusparseLtMatmulPlan_t*> plan._ptr,
+        <const void*> alpha, <const void*> d_A, <const void*> d_B,
+        <const void*> beta, <const void*> d_C, <void*> d_D,
+        <void*> workspace, <driver.Stream*> NULL, <int32_t> 0)
+    check_status(status)
+
+###############################################################################
+# cuSPARSELt: Helper Functions
+###############################################################################
+
+cpdef spMMAPrune(Handle handle, MatmulDescriptor matmulDescr,
+                 size_t d_in, size_t d_out, pruneAlg):
+    """Prunes a dense matrix d_in"""
+    cdef intptr_t stream = stream_module.get_current_stream_ptr()
+    status = cusparseLtSpMMAPrune(
+        <const cusparseLtHandle_t*> handle._ptr,
+        <const cusparseLtMatmulDescriptor_t*> matmulDescr._ptr,
+        <const void*> d_in, <void*> d_out,
+        <cusparseLtPruneAlg_t> pruneAlg, <driver.Stream> stream)
+    check_status(status)
+
+cpdef spMMAPruneCheck(Handle handle, MatmulDescriptor matmulDescr,
+                      size_t d_in, size_t valid):
+    """checks the correctness of the pruning structure"""
+    cdef intptr_t stream = stream_module.get_current_stream_ptr()
+    status = cusparseLtSpMMAPruneCheck(
+        <const cusparseLtHandle_t*> handle._ptr,
+        <const cusparseLtMatmulDescriptor_t*> matmulDescr._ptr,
+        <const void*> d_in, <int*> valid, <driver.Stream> stream)
+    check_status(status)
+
+cpdef size_t spMMACompressedSize(Handle handle, MatmulPlan plan):
+    """Provides the size of the compressed matrix"""
+    cdef size_t compressedSize
+    status = cusparseLtSpMMACompressedSize(
+        <const cusparseLtHandle_t*> handle._ptr,
+        <const cusparseLtMatmulPlan_t*> plan._ptr,
+        &compressedSize)
+    check_status(status)
+    return compressedSize
+
+cpdef spMMACompress(Handle handle, MatmulPlan plan,
+                    size_t d_dense, size_t d_compressed):
+    """Compresses a dense matrix d_dense."""
+    cdef intptr_t stream = stream_module.get_current_stream_ptr()
+    status = cusparseLtSpMMACompress(
+        <const cusparseLtHandle_t*> handle._ptr,
+        <const cusparseLtMatmulPlan_t*> plan._ptr,
+        <const void*> d_dense, <void*> d_compressed, <driver.Stream> stream)
+    check_status(status)

--- a/cupy_backends/cuda/libs/cusparselt.pyx
+++ b/cupy_backends/cuda/libs/cusparselt.pyx
@@ -21,9 +21,9 @@ cdef extern from '../../cupy_cusparselt.h' nogil:
         uint8_t data[1024]
     ctypedef struct cusparseLtMatDescriptor_t 'cusparseLtMatDescriptor_t':
         uint8_t data[1024]
-    ctypedef struct cusparseLtMatmulDescriptor_t 'cusparseLtMatmulDescriptor_t':
+    ctypedef struct cusparseLtMatmulDescriptor_t 'cusparseLtMatmulDescriptor_t':  # NOQA
         uint8_t data[1024]
-    ctypedef struct cusparseLtMatmulAlgSelection_t 'cusparseLtMatmulAlgSelection_t':
+    ctypedef struct cusparseLtMatmulAlgSelection_t 'cusparseLtMatmulAlgSelection_t':  # NOQA
         uint8_t data[1024]
     ctypedef struct cusparseLtMatmulPlan_t 'cusparseLtMatmulPlan_t':
         uint8_t data[1024]
@@ -32,7 +32,7 @@ cdef extern from '../../cupy_cusparselt.h' nogil:
     ctypedef int cusparseLtSparsity_t 'cusparseLtSparsity_t'
     ctypedef int cusparseOperation_t 'cusparseOperation_t'
     ctypedef int cusparseLtMatmulAlg_t 'cusparseLtMatmulAlg_t'
-    ctypedef int cusparseLtMatmulAlgAttribute_t 'cusparseLtMatmulAlgAttribute_t'
+    ctypedef int cusparseLtMatmulAlgAttribute_t 'cusparseLtMatmulAlgAttribute_t'  # NOQA
     ctypedef int cusparseLtPruneAlg_t 'cusparseLtPruneAlg_t'
 
     # Management Functions
@@ -74,7 +74,7 @@ cdef extern from '../../cupy_cusparselt.h' nogil:
     cusparseStatus_t cusparseLtMatmulGetWorkspace(
         const cusparseLtHandle_t* handle,
         const cusparseLtMatmulAlgSelection_t* algSelection,
-        size_t* workspaceSize);
+        size_t* workspaceSize)
     cusparseStatus_t cusparseLtMatmulPlanInit(
         const cusparseLtHandle_t* handle,
         cusparseLtMatmulPlan_t* plan,
@@ -101,7 +101,7 @@ cdef extern from '../../cupy_cusparselt.h' nogil:
         const void* d_in, int* valid, driver.Stream stream)
     cusparseStatus_t cusparseLtSpMMACompressedSize(
         const cusparseLtHandle_t* handle, const cusparseLtMatmulPlan_t* plan,
-        size_t* compressedSize);
+        size_t* compressedSize)
     cusparseStatus_t cusparseLtSpMMACompress(
         const cusparseLtHandle_t* handle, const cusparseLtMatmulPlan_t* plan,
         const void* d_dense, void* d_compressed, driver.Stream stream)
@@ -277,7 +277,8 @@ cpdef matmulAlgSetAttribute(Handle handle, MatmulAlgSelection algSelection,
         <const void*> data, <size_t> dataSize)
     check_status(status)
 
-cpdef size_t matmulGetWorkspace(Handle handle, MatmulAlgSelection algSelection):
+cpdef size_t matmulGetWorkspace(Handle handle,
+                                MatmulAlgSelection algSelection):
     """Determines the required workspace size"""
     cdef size_t workspaceSize
     status = cusparseLtMatmulGetWorkspace(
@@ -288,9 +289,9 @@ cpdef size_t matmulGetWorkspace(Handle handle, MatmulAlgSelection algSelection):
     return workspaceSize
 
 cpdef matmulPlanInit(Handle handle, MatmulPlan plan,
-                    MatmulDescriptor matmulDescr,
-                    MatmulAlgSelection algSelection,
-                    size_t workspaceSize):
+                     MatmulDescriptor matmulDescr,
+                     MatmulAlgSelection algSelection,
+                     size_t workspaceSize):
     """Initializes the plan."""
     status = cusparseLtMatmulPlanInit(
         <const cusparseLtHandle_t*> handle._ptr,

--- a/cupy_backends/cupy_cusparselt.h
+++ b/cupy_backends/cupy_cusparselt.h
@@ -1,0 +1,19 @@
+#ifndef INCLUDE_GUARD_CUPY_CUSPARSELT_H
+#define INCLUDE_GUARD_CUPY_CUSPARSELT_H
+
+#ifdef CUPY_USE_HIP
+
+#include "stub/cupy_cusparselt.h"
+
+#elif !defined(CUPY_NO_CUDA)
+
+#include <library_types.h>
+#include <cusparseLt.h>
+
+#else
+
+#include "stub/cupy_cusparselt.h"
+
+#endif // #ifndef CUPY_NO_CUDA
+
+#endif // #ifndef INCLUDE_GUARD_CUPY_CUSPARSELT_H

--- a/cupy_backends/stub/cupy_cusparselt.h
+++ b/cupy_backends/stub/cupy_cusparselt.h
@@ -1,4 +1,4 @@
-// This file is a stub header file of cuSPARSELt for Read the Docs.
+// Stub header file for cuSPARSELt
 
 #ifndef INCLUDE_GUARD_STUB_CUPY_CUSPARSELT_H
 #define INCLUDE_GUARD_STUB_CUPY_CUSPARSELT_H
@@ -27,7 +27,7 @@ extern "C" {
     cusparseStatus_t cusparseLtInit(...) {
 	return CUSPARSE_STATUS_SUCCESS;
     }
-    
+
     cusparseStatus_t cusparseLtDestroy(...) {
 	return CUSPARSE_STATUS_SUCCESS;
     }
@@ -71,7 +71,7 @@ extern "C" {
     cusparseStatus_t cusparseLtMatmul(...) {
 	return CUSPARSE_STATUS_SUCCESS;
     }
-    
+
     cusparseStatus_t cusparseLtMatmulSearch(...) {
 	return CUSPARSE_STATUS_SUCCESS;
     }
@@ -83,11 +83,11 @@ extern "C" {
     cusparseStatus_t cusparseLtSpMMAPruneCheck(...) {
 	return CUSPARSE_STATUS_SUCCESS;
     }
-    
+
     cusparseStatus_t cusparseLtSpMMACompressedSize(...) {
 	return CUSPARSE_STATUS_SUCCESS;
     }
-	
+
     cusparseStatus_t cusparseLtSpMMACompress(...) {
 	return CUSPARSE_STATUS_SUCCESS;
     }

--- a/cupy_backends/stub/cupy_cusparselt.h
+++ b/cupy_backends/stub/cupy_cusparselt.h
@@ -1,0 +1,97 @@
+// This file is a stub header file of cuSPARSELt for Read the Docs.
+
+#ifndef INCLUDE_GUARD_STUB_CUPY_CUSPARSELT_H
+#define INCLUDE_GUARD_STUB_CUPY_CUSPARSELT_H
+
+extern "C" {
+
+    typedef enum {
+	CUSPARSE_STATUS_SUCCESS=0,
+    }  cusparseStatus_t;
+    typedef enum {} cudaDataType;
+    typedef enum {} cusparseOrder_t;
+    typedef enum {} cusparseOperation_t;
+    typedef enum {} cusparseLtSparsity_t;
+    typedef enum {} cusparseComputeType;
+    typedef enum {} cusparseLtMatmulAlg_t;
+    typedef enum {} cusparseLtMatmulAlgAttribute_t;
+    typedef enum {} cusparseLtPruneAlg_t;
+
+    typedef void* cudaStream_t;
+    typedef void* cusparseLtHandle_t;
+    typedef void* cusparseLtMatDescriptor_t;
+    typedef void* cusparseLtMatmulDescriptor_t;
+    typedef void* cusparseLtMatmulAlgSelection_t;
+    typedef void* cusparseLtMatmulPlan_t;
+
+    cusparseStatus_t cusparseLtInit(...) {
+	return CUSPARSE_STATUS_SUCCESS;
+    }
+    
+    cusparseStatus_t cusparseLtDestroy(...) {
+	return CUSPARSE_STATUS_SUCCESS;
+    }
+
+    cusparseStatus_t cusparseLtDenseDescriptorInit(...) {
+	return CUSPARSE_STATUS_SUCCESS;
+    }
+
+    cusparseStatus_t cusparseLtStructuredDescriptorInit(...) {
+	return CUSPARSE_STATUS_SUCCESS;
+    }
+
+    cusparseStatus_t cusparseLtMatmulDescriptorInit(...) {
+	return CUSPARSE_STATUS_SUCCESS;
+    }
+
+    cusparseStatus_t cusparseLtMatmulAlgSelectionInit(...) {
+	return CUSPARSE_STATUS_SUCCESS;
+    }
+
+    cusparseStatus_t cusparseLtMatmulAlgSetAttribute(...) {
+	return CUSPARSE_STATUS_SUCCESS;
+    }
+
+    cusparseStatus_t cusparseLtMatmulAlgGetAttribute(...) {
+	return CUSPARSE_STATUS_SUCCESS;
+    }
+
+    cusparseStatus_t cusparseLtMatmulGetWorkspace(...) {
+	return CUSPARSE_STATUS_SUCCESS;
+    }
+
+    cusparseStatus_t cusparseLtMatmulPlanInit(...) {
+	return CUSPARSE_STATUS_SUCCESS;
+    }
+
+    cusparseStatus_t cusparseLtMatmulPlanDestroy(...) {
+	return CUSPARSE_STATUS_SUCCESS;
+    }
+
+    cusparseStatus_t cusparseLtMatmul(...) {
+	return CUSPARSE_STATUS_SUCCESS;
+    }
+    
+    cusparseStatus_t cusparseLtMatmulSearch(...) {
+	return CUSPARSE_STATUS_SUCCESS;
+    }
+
+    cusparseStatus_t cusparseLtSpMMAPrune(...) {
+	return CUSPARSE_STATUS_SUCCESS;
+    }
+
+    cusparseStatus_t cusparseLtSpMMAPruneCheck(...) {
+	return CUSPARSE_STATUS_SUCCESS;
+    }
+    
+    cusparseStatus_t cusparseLtSpMMACompressedSize(...) {
+	return CUSPARSE_STATUS_SUCCESS;
+    }
+	
+    cusparseStatus_t cusparseLtSpMMACompress(...) {
+	return CUSPARSE_STATUS_SUCCESS;
+    }
+
+} // extern "C"
+
+#endif  // INCLUDE_GUARD_STUB_CUPY_CUSPARSE_H

--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -284,6 +284,21 @@ if not use_hip:
         ],
     })
 
+    MODULES.append({
+        'name': 'cusparselt',
+        'file': [
+            'cupy_backends.cuda.libs.cusparselt',
+        ],
+        'include': [
+            'cusparseLt.h',
+        ],
+        'libraries': [
+            'cusparseLt',
+        ],
+        'check_method': build.check_cusparselt_version,
+        'version_method': build.get_cusparselt_version,
+    })
+
 else:
     MODULES.append({
         'name': 'cub',
@@ -479,6 +494,15 @@ def preconfigure_modules(compiler, settings):
                 if os.path.exists(lib_path):
                     settings['library_dirs'].append(lib_path)
                     break
+
+        if module['name'] == 'cusparselt':
+            cusparselt_path = os.environ.get('CUSPARSELT_PATH', '')
+            inc_path = os.path.join(cusparselt_path, 'include')
+            if os.path.exists(inc_path):
+                settings['include_dirs'].append(inc_path)
+            lib_path = os.path.join(cusparselt_path, 'lib64')
+            if os.path.exists(lib_path):
+                settings['library_dirs'].append(lib_path)
 
         print('')
         print('-------- Configuring Module: {} --------'.format(

--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -495,15 +495,6 @@ def preconfigure_modules(compiler, settings):
                     settings['library_dirs'].append(lib_path)
                     break
 
-        if module['name'] == 'cusparselt':
-            cusparselt_path = os.environ.get('CUSPARSELT_PATH', '')
-            inc_path = os.path.join(cusparselt_path, 'include')
-            if os.path.exists(inc_path):
-                settings['include_dirs'].append(inc_path)
-            lib_path = os.path.join(cusparselt_path, 'lib64')
-            if os.path.exists(lib_path):
-                settings['library_dirs'].append(lib_path)
-
         print('')
         print('-------- Configuring Module: {} --------'.format(
             module['name']))

--- a/examples/cusparselt/matmul.py
+++ b/examples/cusparselt/matmul.py
@@ -1,0 +1,99 @@
+#
+# Example of matrix multiply using cuSPARSELt
+#
+# (*) https://docs.nvidia.com/cuda/cusparselt/getting_started.html#code-example
+#
+import cupy
+import numpy
+
+from cupy_backends.cuda.libs.cusparselt import Handle, MatDescriptor, MatmulDescriptor, MatmulAlgSelection, MatmulPlan
+from cupy.core import _dtype
+from cupy_backends.cuda.libs import cusparselt, cusparse
+from cupy_backends.cuda.api import runtime
+
+dtype = 'float16'
+m, n, k = 1024, 1024, 1024
+A = cupy.random.random((m, k)).astype(dtype)
+B = cupy.ones((k, n), dtype=dtype)
+C = cupy.zeros((m, n), dtype=dtype)
+
+#
+# initializes cusparselt handle and data structures
+#
+handle = Handle()
+matA = MatDescriptor()
+matB = MatDescriptor()
+matC = MatDescriptor()
+matmul = MatmulDescriptor()
+alg_sel = MatmulAlgSelection()
+plan = MatmulPlan()
+cusparselt.init(handle)
+
+#
+# initializes matrix descriptors
+#
+alignment = 128
+order = cusparse.CUSPARSE_ORDER_ROW
+cuda_dtype_A = _dtype.to_cuda_dtype(A.dtype, is_half_allowed=True)
+cuda_dtype_B = _dtype.to_cuda_dtype(B.dtype, is_half_allowed=True)
+cuda_dtype_C = _dtype.to_cuda_dtype(C.dtype, is_half_allowed=True)
+cusparselt.structuredDescriptorInit(handle, matA, A.shape[0], A.shape[1],
+                                    A.shape[1], alignment, cuda_dtype_A, order,
+                                    cusparselt.CUSPARSELT_SPARSITY_50_PERCENT)
+cusparselt.denseDescriptorInit(handle, matB, B.shape[0], B.shape[1], B.shape[1],
+                               alignment, cuda_dtype_B, order)
+cusparselt.denseDescriptorInit(handle, matC, C.shape[0], C.shape[1], C.shape[1],
+                               alignment, cuda_dtype_C, order)
+
+#
+# initializes matmul, algorithm selection and plan
+#
+opA = cusparse.CUSPARSE_OPERATION_NON_TRANSPOSE
+opB = cusparse.CUSPARSE_OPERATION_NON_TRANSPOSE
+compute_type = cusparselt.CUSPARSE_COMPUTE_16F
+cusparselt.matmulDescriptorInit(handle, matmul, opA, opB, matA, matB, matC,
+                                matC, compute_type)
+cusparselt.matmulAlgSelectionInit(handle, alg_sel, matmul,
+                                  cusparselt.CUSPARSELT_MATMUL_ALG_DEFAULT)
+alg = numpy.array(0, dtype='int32')
+cusparselt.matmulAlgSetAttribute(handle, alg_sel,
+                                 cusparselt.CUSPARSELT_MATMUL_ALG_CONFIG_ID,
+                                 alg.ctypes.data, 4)
+workspace_size = cusparselt.matmulGetWorkspace(handle, alg_sel)
+workspace = cupy.empty(workspace_size, dtype='int8')
+cusparselt.matmulPlanInit(handle, plan, matmul, alg_sel, workspace_size)
+
+#
+# prunes the matrix A in-place and checks the correstness
+#
+print('Before pruning, A[0]:\n{}'.format(A[0]))
+cusparselt.spMMAPrune(handle, matmul, A.data.ptr, A.data.ptr,
+                      cusparselt.CUSPARSELT_PRUNE_SPMMA_TILE)
+print('After pruning, A[0]:\n{}'.format(A[0]))
+is_valid = numpy.array(-1, dtype='int32')
+cusparselt.spMMAPruneCheck(handle, matmul, A.data.ptr, is_valid.ctypes.data)
+
+#
+# compresses the matrix A
+#
+compressed_size = cusparselt.spMMACompressedSize(handle, plan)
+A_compressed = cupy.zeros(compressed_size, dtype='uint8')
+cusparselt.spMMACompress(handle, plan, A.data.ptr, A_compressed.data.ptr)
+
+#
+# matmul: C = A @ B
+#
+alpha = numpy.array(1.0, dtype='float32')
+beta = numpy.array(0.0, dtype='float32')
+cusparselt.matmul(handle, plan, alpha.ctypes.data, A_compressed.data.ptr,
+                  B.data.ptr, beta.ctypes.data, C.data.ptr, C.data.ptr,
+                  workspace.data.ptr)
+
+print('A.sum(axis=1): {}'.format(A.sum(axis=1)))
+print('C[:, 0]: {}'.format(C[:, 0]))
+
+#
+# destroys plan and handle
+#
+cusparselt.matmulPlanDestroy(plan)
+cusparselt.destroy(handle)

--- a/examples/cusparselt/matmul.py
+++ b/examples/cusparselt/matmul.py
@@ -6,10 +6,9 @@
 import cupy
 import numpy
 
-from cupy_backends.cuda.libs.cusparselt import Handle, MatDescriptor, MatmulDescriptor, MatmulAlgSelection, MatmulPlan
+from cupy_backends.cuda.libs.cusparselt import Handle, MatDescriptor, MatmulDescriptor, MatmulAlgSelection, MatmulPlan  # NOQA
 from cupy.core import _dtype
 from cupy_backends.cuda.libs import cusparselt, cusparse
-from cupy_backends.cuda.api import runtime
 
 dtype = 'float16'
 m, n, k = 1024, 1024, 1024
@@ -40,10 +39,10 @@ cuda_dtype_C = _dtype.to_cuda_dtype(C.dtype, is_half_allowed=True)
 cusparselt.structuredDescriptorInit(handle, matA, A.shape[0], A.shape[1],
                                     A.shape[1], alignment, cuda_dtype_A, order,
                                     cusparselt.CUSPARSELT_SPARSITY_50_PERCENT)
-cusparselt.denseDescriptorInit(handle, matB, B.shape[0], B.shape[1], B.shape[1],
-                               alignment, cuda_dtype_B, order)
-cusparselt.denseDescriptorInit(handle, matC, C.shape[0], C.shape[1], C.shape[1],
-                               alignment, cuda_dtype_C, order)
+cusparselt.denseDescriptorInit(handle, matB, B.shape[0], B.shape[1],
+                               B.shape[1], alignment, cuda_dtype_B, order)
+cusparselt.denseDescriptorInit(handle, matC, C.shape[0], C.shape[1],
+                               C.shape[1], alignment, cuda_dtype_C, order)
 
 #
 # initializes matmul, algorithm selection and plan

--- a/install/build.py
+++ b/install/build.py
@@ -287,6 +287,7 @@ _cub_version = None
 _jitify_path = None
 _jitify_version = None
 _compute_capabilities = None
+_cusparselt_version = None
 
 
 def check_cuda_version(compiler, settings):
@@ -700,6 +701,38 @@ def get_cutensor_version(formatted=False):
         msg = 'check_cutensor_version() must be called first.'
         raise RuntimeError(msg)
     return _cutensor_version
+
+
+def check_cusparselt_version(compiler, settings):
+    global _cusparselt_version
+    try:
+        out = build_and_run(compiler, '''
+        #include <cusparseLt.h>
+        #include <stdio.h>
+        #ifndef CUSPARSELT_VERSION
+        #define CUSPARSELT_VERSION 0
+        #endif
+        int main(int argc, char* argv[]) {
+          printf("%d", CUSPARSELT_VERSION);
+          return 0;
+        }
+        ''', include_dirs=settings['include_dirs'])
+
+    except Exception as e:
+        utils.print_warning('Cannot check cuSPARSELt version\n{0}'.format(e))
+        return False
+
+    _cusparselt_version = int(out)
+    return True
+
+
+def get_cusparselt_version(formatted=False):
+    """Return cuSPARSELt version cached in check_cusparselt_version()."""
+    global _cusparselt_version
+    if _cusparselt_version is None:
+        msg = 'check_cusparselt_version() must be called first.'
+        raise RuntimeError(msg)
+    return _cusparselt_version
 
 
 def build_shlib(compiler, source, libraries=(),


### PR DESCRIPTION
This PR adds support for cuPARSELt (https://docs.nvidia.com/cuda/cusparselt/index.html).

cuSPARSELt can be downloaded from the following URL. https://developer.nvidia.com/cusparselt/downloads
cuSPARSELt can also be installed via conda as follows (thanks to @mnicely and @leofang !).

    $ conda install -c conda-forge cusparselt

To enable cuSPARSELt, when you build CuPy from source, set the environment variables CFLAGS and LDFLAGS as follows.

    $ export CUSPARSELT_PATH=/path/to/libcusparselt
    $ CFLAGS="-I ${CUSPARSELT_PATH}/include" LDFLAGS="-L ${CUSPARSELT_PATH}/lib64" python setup.py install

