### PR TITLE
Add `cupy.random.Generator.standard_normal`

### DIFF
--- a/cupy/random/_generator_api.pyx
+++ b/cupy/random/_generator_api.pyx
@@ -30,6 +30,9 @@ cdef extern from 'cupy_distributions.cuh' nogil:
     void exponential(
         int generator, intptr_t state, intptr_t out,
         ssize_t size, intptr_t stream)
+    void standard_normal(
+        int generator, intptr_t state, intptr_t out,
+        ssize_t size, intptr_t stream)
 
 
 class Generator:
@@ -218,6 +221,37 @@ class Generator:
         # cython cant call astype with the default values for
         # omitted args.
         return (<object>y).astype(dtype, copy=False)
+
+
+    def standard_normal(self, size=None, dtype=numpy.float64, out=None):
+        """Returns an array of samples drawn from the standard normal distribution.
+    
+        Args:
+            size (int or tuple of ints): The shape of the array. If ``None``, a
+                zero-dimensional array is generated.
+            dtype: Data type specifier.
+
+            out (cupy.ndarray, optional): If specified, values will be written
+                to this array
+    
+        Returns:
+            cupy.ndarray: Samples drawn from the standard normal distribution.
+    
+        .. seealso:: :func:`numpy.random.standard_normal`
+    
+        """
+        cdef ndarray y
+
+        y = ndarray(size if size is not None else (), numpy.float64)
+        _launch_dist(self.bit_generator, standard_normal, y, ())
+        if out is not None:
+            out[...] = y
+            y = out
+        # we cast the array to a python object because
+        # cython cant call astype with the default values for
+        # omitted args.
+        return (<object>y).astype(dtype, copy=False)
+
 
 
 def init_curand(generator, state, seed, size):

--- a/cupy/random/_generator_api.pyx
+++ b/cupy/random/_generator_api.pyx
@@ -222,10 +222,9 @@ class Generator:
         # omitted args.
         return (<object>y).astype(dtype, copy=False)
 
-
     def standard_normal(self, size=None, dtype=numpy.float64, out=None):
         """Returns an array of samples drawn from the standard normal distribution.
-    
+
         Args:
             size (int or tuple of ints): The shape of the array. If ``None``, a
                 zero-dimensional array is generated.
@@ -233,12 +232,12 @@ class Generator:
 
             out (cupy.ndarray, optional): If specified, values will be written
                 to this array
-    
+
         Returns:
             cupy.ndarray: Samples drawn from the standard normal distribution.
-    
+
         .. seealso:: :func:`numpy.random.standard_normal`
-    
+
         """
         cdef ndarray y
 

--- a/cupy/random/_generator_api.pyx
+++ b/cupy/random/_generator_api.pyx
@@ -246,27 +246,20 @@ class Generator:
 
         if out is not None:
             self._check_output_array(dtype, size, out)
-
-        dtype = numpy.dtype(dtype)
-
-        if out is not None and out.dtype.char in ('f', 'd'):
-            y = (<ndarray>out)
+            y = out
         else:
-            if dtype.char in ('f', 'd'):
-                y = ndarray(size if size is not None else (), dtype)
-            else:
-                raise TypeError(
-                    f'Unsupported dtype {dtype.name} for standard_normal')
+            y = ndarray(size if size is not None else (), dtype)
 
-        if dtype.char == 'd': 
+        if y.dtype.char not in ('f', 'd'):
+            raise TypeError(
+                f'Unsupported dtype {y.dtype.name} for standard_normal')
+
+        if y.dtype.char == 'd':
             _launch_dist(self.bit_generator, standard_normal, y, ())
         else:
             _launch_dist(self.bit_generator, standard_normal_float, y, ())
 
-        # we cast the array to a python object because
-        # cython cant call astype with the default values for
-        # omitted args.
-        return (<object>y).astype(dtype, copy=False)
+        return y
 
 
 def init_curand(generator, state, seed, size):

--- a/cupy/random/_generator_api.pyx
+++ b/cupy/random/_generator_api.pyx
@@ -253,7 +253,6 @@ class Generator:
         return (<object>y).astype(dtype, copy=False)
 
 
-
 def init_curand(generator, state, seed, size):
     init_curand_generator(
         <int>generator,

--- a/cupy/random/cupy_distributions.cuh
+++ b/cupy/random/cupy_distributions.cuh
@@ -30,6 +30,7 @@ void interval_64(int generator, intptr_t state, intptr_t out, ssize_t size, intp
 void beta(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream, double a, double b);
 void exponential(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream);
 void standard_normal(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream);
+void standard_normal_float(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream);
 
 # else 
 
@@ -45,5 +46,7 @@ void interval_64(int generator, intptr_t state, intptr_t out, ssize_t size, intp
 void beta(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream, double a, double b) {}
 void exponential(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream) {}
 void standard_normal(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream) {}
+void standard_normal_float(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream){}
+
 #endif
 #endif

--- a/cupy/random/cupy_distributions.cuh
+++ b/cupy/random/cupy_distributions.cuh
@@ -11,6 +11,8 @@ typedef SSIZE_T ssize_t;
 // This enum holds the generators, we can't fully templatize the generators
 // because the dynamic design of BitGenerators in the python side does not allow us
 // to determine the correct type at compile time
+// We could use Jitify to avoid this code, but cuRAND EULA does not allow us to 
+// redistribute cuRAND header
 enum RandGenerators{
    CURAND_XOR_WOW,
    CURAND_MRG32k3a,
@@ -27,6 +29,7 @@ void interval_32(int generator, intptr_t state, intptr_t out, ssize_t size, intp
 void interval_64(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream, int64_t mx, int64_t mask);
 void beta(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream, double a, double b);
 void exponential(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream);
+void standard_normal(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream);
 
 # else 
 

--- a/cupy/random/cupy_distributions.cuh
+++ b/cupy/random/cupy_distributions.cuh
@@ -44,5 +44,6 @@ void interval_32(int generator, intptr_t state, intptr_t out, ssize_t size, intp
 void interval_64(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream, int64_t mx, int64_t mask) {}
 void beta(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream, double a, double b) {}
 void exponential(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream) {}
+void standard_normal(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream) {}
 #endif
 #endif

--- a/tests/cupy_tests/random_tests/test_generator_api.py
+++ b/tests/cupy_tests/random_tests/test_generator_api.py
@@ -257,6 +257,26 @@ class TestStandardExponential(InvalidOutsMixin, GeneratorTestCase):
 
 @testing.with_requires('numpy>=1.17.0')
 @testing.gpu
+@testing.parameterize(*[
+    {'size': None},
+    {'size': (1, 2, 3)},
+    {'size': 3},
+    {'size': (3, 3)},
+    {'size': ()},
+])
+@testing.fix_random()
+class TestStandardNormal(GeneratorTestCase):
+
+    target_method = 'standard_normal'
+
+    @testing.for_dtypes('fd')
+    @condition.repeat_with_success_at_least(10, 3)
+    def test_normal_ks(self, dtype):
+        self.check_ks(0.05)(size=self.size, dtype=dtype)
+
+
+@testing.with_requires('numpy>=1.17.0')
+@testing.gpu
 @testing.fix_random()
 class TestIntegers(GeneratorTestCase):
     # TODO(niboshi):

--- a/tests/cupy_tests/random_tests/test_generator_api.py
+++ b/tests/cupy_tests/random_tests/test_generator_api.py
@@ -257,13 +257,13 @@ class TestStandardExponential(InvalidOutsMixin, GeneratorTestCase):
 
 @testing.with_requires('numpy>=1.17.0')
 @testing.gpu
-@testing.parameterize(*[
+@testing.parameterize(
     {'size': None},
     {'size': (1, 2, 3)},
     {'size': 3},
     {'size': (3, 3)},
     {'size': ()},
-])
+)
 @testing.fix_random()
 class TestStandardNormal(GeneratorTestCase):
 

--- a/tests/cupy_tests/random_tests/test_generator_api.py
+++ b/tests/cupy_tests/random_tests/test_generator_api.py
@@ -278,6 +278,19 @@ class TestStandardNormal(GeneratorTestCase):
 @testing.with_requires('numpy>=1.17.0')
 @testing.gpu
 @testing.fix_random()
+class TestStandardNormalInvalid(InvalidOutsMixin, GeneratorTestCase):
+
+    target_method = 'standard_normal'
+
+    def test_invalid_dtypes(self):
+        for dtype in 'bhiqleFD':
+            with pytest.raises(TypeError):
+                self.generate(size=(3, 2), dtype=dtype)
+
+
+@testing.with_requires('numpy>=1.17.0')
+@testing.gpu
+@testing.fix_random()
 class TestIntegers(GeneratorTestCase):
     # TODO(niboshi):
     #   Test soundness of distribution.

--- a/tests/cupy_tests/random_tests/test_generator_api.py
+++ b/tests/cupy_tests/random_tests/test_generator_api.py
@@ -270,7 +270,7 @@ class TestStandardNormal(GeneratorTestCase):
     target_method = 'standard_normal'
 
     @testing.for_dtypes('fd')
-    @condition.repeat_with_success_at_least(10, 3)
+    @_condition.repeat_with_success_at_least(10, 3)
     def test_normal_ks(self, dtype):
         self.check_ks(0.05)(size=self.size, dtype=dtype)
 


### PR DESCRIPTION
This is a example PR on how to add distributions to the new random API (#4557)

https://numpy.org/doc/stable/reference/random/generator.html#distributions

The process is to create a CUDA kernel from the code in `cupy/random/_distributions.py` that uses the corresponding cuRAND generator and call it from `_generator_api.pyx`

Tests are obtained from `tests/cupy_tests/random_tests/test_generator.py` and modified accordingly