### PR TITLE
Windows: Skip failing cuDNN tests

### DIFF
--- a/cupy/cudnn.pyx
+++ b/cupy/cudnn.pyx
@@ -1591,9 +1591,6 @@ cpdef _Algorithm _get_algorithm_bwd_data(
     if _cudnn_version >= 7000:
         ret = cudnn.getConvolutionBackwardDataAlgorithm_v7(
             handle, filter_desc, x_desc, conv_desc, y_desc, 10)
-        if len(ret) == 0:
-            raise RuntimeError(
-                'No conv bwd data algo is available')
         skip = False
         for perf in ret:
             if deterministic and not perf.determinism:

--- a/cupy/cudnn.pyx
+++ b/cupy/cudnn.pyx
@@ -1591,6 +1591,9 @@ cpdef _Algorithm _get_algorithm_bwd_data(
     if _cudnn_version >= 7000:
         ret = cudnn.getConvolutionBackwardDataAlgorithm_v7(
             handle, filter_desc, x_desc, conv_desc, y_desc, 10)
+        if len(ret) == 0:
+            raise RuntimeError(
+                'No conv bwd data algo is available')
         skip = False
         for perf in ret:
             if deterministic and not perf.determinism:

--- a/tests/cupy_tests/test_cudnn.py
+++ b/tests/cupy_tests/test_cudnn.py
@@ -294,7 +294,7 @@ class TestConvolutionBackwardFilter(unittest.TestCase):
     'dilate': [1, 2],
     'groups': [1, 2],
     'ndim': [2, 3],
-    'max_workspace_size': [0, 2 ** 22],
+    'max_workspace_size': [0, 2 ** 22, 2 ** 23],
     'auto_tune': [True, False],
     'deterministic': [True, False],
     'bias': [True, False],

--- a/tests/cupy_tests/test_cudnn.py
+++ b/tests/cupy_tests/test_cudnn.py
@@ -345,9 +345,10 @@ class TestConvolutionBackwardData(unittest.TestCase):
               self.dilate > 1 and self.groups > 1 and ndim > 2 and
               self.dtype == numpy.float16):
             self.err = RuntimeError
-        elif (version == 7605 and deterministic and self.dtype == numpy.float16
+        elif (7000 <= version < 8000 and deterministic
+                and self.dtype == numpy.float16
                 and self.ndim == 3 and sys.platform.startswith('win32')
-                and self.dilate == 2 and self.max_workspace_size != 0):
+                and self.dilate == 2 and self.groups == 2):
             # see https://github.com/cupy/cupy/pull/4893
             self.err = RuntimeError
         self._workspace_size = cudnn.get_max_workspace_size()

--- a/tests/cupy_tests/test_cudnn.py
+++ b/tests/cupy_tests/test_cudnn.py
@@ -334,6 +334,11 @@ class TestConvolutionBackwardData(unittest.TestCase):
         if ((self.dilate > 1 and version < 6000) or
                 (self.groups > 1 and version < 7000)):
             self.err = ValueError
+        elif (sys.platform.startswith('win32') and version == 7605
+                and deterministic and self.dtype == numpy.float16
+                and self.ndim == 3 and self.dilate == 2 and self.groups == 2):
+            # see https://github.com/cupy/cupy/pull/4893
+            self.err = RuntimeError
         elif deterministic and (
                 (self.dilate > 1 and
                  (ndim != 2 and version < 8100 or version < 7300)) or
@@ -344,12 +349,6 @@ class TestConvolutionBackwardData(unittest.TestCase):
               int(cupy.cuda.device.get_compute_capability()) < 70 and
               self.dilate > 1 and self.groups > 1 and ndim > 2 and
               self.dtype == numpy.float16):
-            self.err = RuntimeError
-        elif (7000 <= version < 8000 and deterministic
-                and self.dtype == numpy.float16
-                and self.ndim == 3 and sys.platform.startswith('win32')
-                and self.dilate == 2 and self.groups == 2):
-            # see https://github.com/cupy/cupy/pull/4893
             self.err = RuntimeError
         self._workspace_size = cudnn.get_max_workspace_size()
         cudnn.set_max_workspace_size(self.max_workspace_size)

--- a/tests/cupy_tests/test_cudnn.py
+++ b/tests/cupy_tests/test_cudnn.py
@@ -294,7 +294,7 @@ class TestConvolutionBackwardFilter(unittest.TestCase):
     'dilate': [1, 2],
     'groups': [1, 2],
     'ndim': [2, 3],
-    'max_workspace_size': [0, 2 ** 22, 2 ** 23],
+    'max_workspace_size': [0, 2 ** 22],
     'auto_tune': [True, False],
     'deterministic': [True, False],
     'bias': [True, False],
@@ -343,6 +343,11 @@ class TestConvolutionBackwardData(unittest.TestCase):
               int(cupy.cuda.device.get_compute_capability()) < 70 and
               self.dilate > 1 and self.groups > 1 and ndim > 2 and
               self.dtype == numpy.float16):
+            self.err = RuntimeError
+        elif (version == 7605 and deterministic and self.dtype == numpy.float16
+                and self.ndim == 3 and sys.platform.startswith('win32')
+                and self.dilate == 2 and self.max_workspace_size != 0):
+            # see https://github.com/cupy/cupy/pull/4893
             self.err = RuntimeError
         self._workspace_size = cudnn.get_max_workspace_size()
         cudnn.set_max_workspace_size(self.max_workspace_size)

--- a/tests/cupy_tests/test_cudnn.py
+++ b/tests/cupy_tests/test_cudnn.py
@@ -1,3 +1,4 @@
+import sys
 import unittest
 
 import numpy


### PR DESCRIPTION
Close #3872.

Another guess work. My theory is the workspace size is too stringent for the failing tests:
```
FAILED tests/cupy_tests/test_cudnn.py::TestConvolutionBackwardData_param_93_{auto_tune=True, bias=True, deterministic=True, dilate=2, dtype=float16, groups=2, max_workspace_size=4194304, ndim=3, tensor_core='always'}::test_call
FAILED tests/cupy_tests/test_cudnn.py::TestConvolutionBackwardData_param_94_{auto_tune=True, bias=True, deterministic=True, dilate=2, dtype=float16, groups=2, max_workspace_size=4194304, ndim=3, tensor_core='auto'}::test_call
FAILED tests/cupy_tests/test_cudnn.py::TestConvolutionBackwardData_param_95_{auto_tune=True, bias=True, deterministic=True, dilate=2, dtype=float16, groups=2, max_workspace_size=4194304, ndim=3, tensor_core='never'}::test_call
FAILED tests/cupy_tests/test_cudnn.py::TestConvolutionBackwardData_param_381_{auto_tune=True, bias=False, deterministic=True, dilate=2, dtype=float16, groups=2, max_workspace_size=4194304, ndim=3, tensor_core='always'}::test_call
FAILED tests/cupy_tests/test_cudnn.py::TestConvolutionBackwardData_param_382_{auto_tune=True, bias=False, deterministic=True, dilate=2, dtype=float16, groups=2, max_workspace_size=4194304, ndim=3, tensor_core='auto'}::test_call
FAILED tests/cupy_tests/test_cudnn.py::TestConvolutionBackwardData_param_383_{auto_tune=True, bias=False, deterministic=True, dilate=2, dtype=float16, groups=2, max_workspace_size=4194304, ndim=3, tensor_core='never'}::test_call
FAILED tests/cupy_tests/test_cudnn.py::TestConvolutionBackwardData_param_669_{auto_tune=False, bias=True, deterministic=True, dilate=2, dtype=float16, groups=2, max_workspace_size=4194304, ndim=3, tensor_core='always'}::test_call
FAILED tests/cupy_tests/test_cudnn.py::TestConvolutionBackwardData_param_670_{auto_tune=False, bias=True, deterministic=True, dilate=2, dtype=float16, groups=2, max_workspace_size=4194304, ndim=3, tensor_core='auto'}::test_call
FAILED tests/cupy_tests/test_cudnn.py::TestConvolutionBackwardData_param_671_{auto_tune=False, bias=True, deterministic=True, dilate=2, dtype=float16, groups=2, max_workspace_size=4194304, ndim=3, tensor_core='never'}::test_call
FAILED tests/cupy_tests/test_cudnn.py::TestConvolutionBackwardData_param_957_{auto_tune=False, bias=False, deterministic=True, dilate=2, dtype=float16, groups=2, max_workspace_size=4194304, ndim=3, tensor_core='always'}::test_call
FAILED tests/cupy_tests/test_cudnn.py::TestConvolutionBackwardData_param_958_{auto_tune=False, bias=False, deterministic=True, dilate=2, dtype=float16, groups=2, max_workspace_size=4194304, ndim=3, tensor_core='auto'}::test_call
FAILED tests/cupy_tests/test_cudnn.py::TestConvolutionBackwardData_param_959_{auto_tune=False, bias=False, deterministic=True, dilate=2, dtype=float16, groups=2, max_workspace_size=4194304, ndim=3, tensor_core='never'}::test_call
```
It doesn't seem to be a good idea to me to hardcode the workspace size in order to choose an algorithm from `cudnnGetConvolutionBackwardDataAlgorithm_v7`:
https://github.com/cupy/cupy/blob/51ac662bc02a9291bead594a29d81efb872c4b1b/cupy/cudnn.pyx#L1598-L1599
as the performance result depends on the available workspace size used by the algorithm, among other things.
But admittedly I know nothing about cuDNN so there could be other reasons doing so...