### PR TITLE
Add `out` arg verifier in new random interface.

### DIFF
--- a/cupy/random/_generator_api.pyx
+++ b/cupy/random/_generator_api.pyx
@@ -56,6 +56,27 @@ class Generator:
     def __init__(self, bit_generator):
         self.bit_generator = bit_generator
 
+    def _check_output_array(self, dtype, size, out):
+        # Checks borrowed from NumPy
+        # https://github.com/numpy/numpy/blob/cb557b79fa0ce467c881830f8e8e042c484ccfaa/numpy/random/_common.pyx#L235-L251
+        dtype = numpy.dtype(dtype)
+        if out.dtype.char != dtype.char:
+            raise TypeError(
+                f'Supplied output array has the wrong type. '
+                f'Expected {dtype.name}, got {out.dtype.name}')
+        if not (out.flags.c_contiguous or out.flags.f_contiguous):
+            raise ValueError(
+                'Supplied output array is not contiguous,'
+                ' writable or aligned.')
+        if size is not None:
+            try:
+                tup_size = tuple(size)
+            except TypeError:
+                tup_size = tuple([size])
+            if tup_size != out.shape:
+                raise ValueError(
+                    'size must match out.shape when used together')
+
     def integers(
             self, low, high=None, size=None,
             dtype=numpy.int64, endpoint=False):
@@ -184,6 +205,9 @@ class Generator:
 
         if method == 'zig':
             raise NotImplementedError('Ziggurat method is not supported')
+
+        if out is not None:
+            self._check_output_array(dtype, size, out)
 
         y = ndarray(size if size is not None else (), numpy.float64)
         _launch_dist(self.bit_generator, exponential, y, ())

--- a/tests/cupy_tests/random_tests/test_generator_api.py
+++ b/tests/cupy_tests/random_tests/test_generator_api.py
@@ -236,7 +236,7 @@ class InvalidOutsMixin:
 @testing.with_requires('numpy>=1.17.0')
 @testing.gpu
 @testing.fix_random()
-class TestStandardExponential(GeneratorTestCase, InvalidOutsMixin):
+class TestStandardExponential(InvalidOutsMixin, GeneratorTestCase):
 
     target_method = 'standard_exponential'
 

--- a/tests/cupy_tests/random_tests/test_generator_api.py
+++ b/tests/cupy_tests/random_tests/test_generator_api.py
@@ -206,10 +206,37 @@ class TestBeta(GeneratorTestCase):
             a=self.a, b=self.b, size=2000, dtype=dtype)
 
 
+class InvalidOutsMixin:
+
+    def invalid_dtype_out(self, **kwargs):
+        out = cupy.zeros((3, 2), dtype=cupy.float32)
+        with pytest.raises(TypeError):
+            self.generate(size=(3, 2), out=out, **kwargs)
+
+    def invalid_contiguity(self, **kwargs):
+        out = cupy.zeros((4, 6), dtype=cupy.float64)[0:3:, 0:2:]
+        with pytest.raises(ValueError):
+            self.generate(size=(3, 2), out=out, **kwargs)
+
+    def invalid_shape(self, **kwargs):
+        out = cupy.zeros((3, 3), dtype=cupy.float64)
+        with pytest.raises(ValueError):
+            self.generate(size=(3, 2), out=out, **kwargs)
+
+    def test_invalid_dtype_out(self):
+        self.invalid_dtype_out()
+
+    def test_invalid_contiguity(self):
+        self.invalid_contiguity()
+
+    def test_invalid_shape(self):
+        self.invalid_shape()
+
+
 @testing.with_requires('numpy>=1.17.0')
 @testing.gpu
 @testing.fix_random()
-class TestStandardExponential(GeneratorTestCase):
+class TestStandardExponential(GeneratorTestCase, InvalidOutsMixin):
 
     target_method = 'standard_exponential'
 
@@ -226,21 +253,6 @@ class TestStandardExponential(GeneratorTestCase):
     @_condition.repeat_with_success_at_least(10, 3)
     def test_standard_exponential_ks(self, dtype):
         self.check_ks(0.05)(size=2000, dtype=dtype)
-
-    def test_standard_exponential_invalid_dtype_out(self):
-        out = cupy.zeros((3, 2), dtype=cupy.float32)
-        with pytest.raises(TypeError):
-            self.generate(size=(3, 2), out=out)
-
-    def test_standard_exponential_invalid_contiguity(self):
-        out = cupy.zeros((4, 6), dtype=cupy.float64)[0:3:, 0:2:]
-        with pytest.raises(ValueError):
-            self.generate(size=(3, 2), out=out)
-
-    def test_standard_exponential_invalid_dtype_shape(self):
-        out = cupy.zeros((3, 3), dtype=cupy.float64)
-        with pytest.raises(ValueError):
-            self.generate(size=(3, 2), out=out)
 
 
 @testing.with_requires('numpy>=1.17.0')

--- a/tests/cupy_tests/random_tests/test_generator_api.py
+++ b/tests/cupy_tests/random_tests/test_generator_api.py
@@ -227,6 +227,21 @@ class TestStandardExponential(GeneratorTestCase):
     def test_standard_exponential_ks(self, dtype):
         self.check_ks(0.05)(size=2000, dtype=dtype)
 
+    def test_standard_exponential_invalid_dtype_out(self):
+        out = cupy.zeros((3, 2), dtype=cupy.float32)
+        with pytest.raises(TypeError):
+            self.generate(size=(3, 2), out=out)
+
+    def test_standard_exponential_invalid_contiguity(self):
+        out = cupy.zeros((4, 6), dtype=cupy.float64)[0:3:, 0:2:]
+        with pytest.raises(ValueError):
+            self.generate(size=(3, 2), out=out)
+
+    def test_standard_exponential_invalid_dtype_shape(self):
+        out = cupy.zeros((3, 3), dtype=cupy.float64)
+        with pytest.raises(ValueError):
+            self.generate(size=(3, 2), out=out)
+
 
 @testing.with_requires('numpy>=1.17.0')
 @testing.gpu


### PR DESCRIPTION
Fixes #4903

BTW I want to rework the tests and add a common baseclass for distributions in the old and new API as most of them are 100% identical, right now we are duplicating code where we shouldnt.