### PR TITLE
Fix compilation error due to invalid complex-to-real casting in `_SimpleReductionKernel`

### DIFF
--- a/cupy/core/_reduction.pyx
+++ b/cupy/core/_reduction.pyx
@@ -33,6 +33,7 @@ from cupy_backends.cuda.api cimport runtime
 
 import math
 import string
+import warnings
 
 import numpy
 
@@ -496,7 +497,11 @@ cdef class _AbstractReductionKernel:
 cpdef _SimpleReductionKernel create_reduction_func(
         name, ops, routine=None, identity=None, preamble='',
         sort_reduce_axis=True):
+    print(ops)
+    print(routine)
     ops = _kernel._Ops.from_tuples(ops, routine)
+    for op in ops.ops:
+        print(op.in_types, op.out_types, op.routine)
     return _SimpleReductionKernel(
         name, ops, identity, preamble, sort_reduce_axis)
 
@@ -544,6 +549,16 @@ cdef class _SimpleReductionKernel(_AbstractReductionKernel):
             raise TypeError(
                 'Argument \'a\' has incorrect type (expected %s, got %s)' %
                 (ndarray, type(a)))
+
+        in_dtype = arr.dtype
+        print("\n\n\n I AM CALLED \n\n\n")
+        if (in_dtype.kind == 'c'
+                and numpy.dtype(dtype).kind == 'f'):
+            warnings.warn(
+                'Casting complex values to real discards the imaginary part',
+                numpy.ComplexWarning)
+            arr = arr.real
+
         in_args = [arr]
 
         dev_id = device.get_device_id()

--- a/cupy/core/_reduction.pyx
+++ b/cupy/core/_reduction.pyx
@@ -550,14 +550,14 @@ cdef class _SimpleReductionKernel(_AbstractReductionKernel):
                 'Argument \'a\' has incorrect type (expected %s, got %s)' %
                 (ndarray, type(a)))
 
-        in_dtype = arr.dtype
-        print("\n\n\n I AM CALLED \n\n\n")
-        if (in_dtype.kind == 'c'
-                and numpy.dtype(dtype).kind == 'f'):
-            warnings.warn(
-                'Casting complex values to real discards the imaginary part',
-                numpy.ComplexWarning)
-            arr = arr.real
+       # in_dtype = arr.dtype
+       # print("\n\n\n I AM CALLED \n\n\n")
+       # if (in_dtype.kind == 'c'
+       #         and numpy.dtype(dtype).kind == 'f'):
+       #     warnings.warn(
+       #         'Casting complex values to real discards the imaginary part',
+       #         numpy.ComplexWarning)
+       #     arr = arr.real
 
         in_args = [arr]
 
@@ -591,6 +591,13 @@ cdef class _SimpleReductionKernel(_AbstractReductionKernel):
             out_type = out_args[0].dtype.type
         else:
             out_type = op.out_types[0]
+
+        if (in_args[0].dtype.kind == 'c'
+                and numpy.dtype(op.in_types[0]).kind == 'f'):
+            warnings.warn(
+                'Casting complex values to real discards the imaginary part',
+                numpy.ComplexWarning)
+            in_args[0] = in_args[0].real
 
         type_map = _kernel._TypeMap((
             ('type_in0_raw', in_args[0].dtype.type),

--- a/cupy/core/_reduction.pyx
+++ b/cupy/core/_reduction.pyx
@@ -497,11 +497,7 @@ cdef class _AbstractReductionKernel:
 cpdef _SimpleReductionKernel create_reduction_func(
         name, ops, routine=None, identity=None, preamble='',
         sort_reduce_axis=True):
-    print(ops)
-    print(routine)
     ops = _kernel._Ops.from_tuples(ops, routine)
-    for op in ops.ops:
-        print(op.in_types, op.out_types, op.routine)
     return _SimpleReductionKernel(
         name, ops, identity, preamble, sort_reduce_axis)
 
@@ -549,16 +545,6 @@ cdef class _SimpleReductionKernel(_AbstractReductionKernel):
             raise TypeError(
                 'Argument \'a\' has incorrect type (expected %s, got %s)' %
                 (ndarray, type(a)))
-
-       # in_dtype = arr.dtype
-       # print("\n\n\n I AM CALLED \n\n\n")
-       # if (in_dtype.kind == 'c'
-       #         and numpy.dtype(dtype).kind == 'f'):
-       #     warnings.warn(
-       #         'Casting complex values to real discards the imaginary part',
-       #         numpy.ComplexWarning)
-       #     arr = arr.real
-
         in_args = [arr]
 
         dev_id = device.get_device_id()
@@ -592,6 +578,7 @@ cdef class _SimpleReductionKernel(_AbstractReductionKernel):
         else:
             out_type = op.out_types[0]
 
+        # We guessed a routine that requires a C2R casting for the input
         if (in_args[0].dtype.kind == 'c'
                 and numpy.dtype(op.in_types[0]).kind == 'f'):
             warnings.warn(


### PR DESCRIPTION
Close #4405.

The compiler error was due to the absence of a guard that raises `ComplexWarning` and casts a complex array to real. Not sure if there is a better solution...But this patch seems to work fine.

I do not touch `ReductionKernel` as I am not sure if such an error-prone usage is even possible there. 