### PR TITLE
Prioritize FlexCI daemon in Windows CI

### DIFF
--- a/.pfnci/windows/_flexci.ps1
+++ b/.pfnci/windows/_flexci.ps1
@@ -45,3 +45,11 @@ function ActivateCUDA($version) {
 function IsPullRequestTest() {
     return ${Env:FLEXCI_BRANCH}.StartsWith("refs/pull/")
 }
+
+function PrioritizeFlexCIDaemon() {
+    echo "Prioritizing FlexCI daemon process..."
+    wmic.exe process where 'name="imosci.exe"' CALL setpriority realtime
+    if (-not $?) {
+        throw "Failed to change priority of daemon (exit code = $LastExitCode)"
+    }
+}

--- a/.pfnci/windows/test.ps1
+++ b/.pfnci/windows/test.ps1
@@ -51,6 +51,8 @@ function PublishTestResults {
 }
 
 function Main {
+    PrioritizeFlexCIDaemon
+
     # Setup environment
     echo "Using CUDA $cuda and Python $python"
     ActivateCUDA $cuda


### PR DESCRIPTION
This fix intends to prevent test insntace termination caused by watchdog process not responding.
I'm not 100% sure how priority improves the situation though.

Examples of instance termination (multiple Execution tab):
https://ci.preferred.jp/cupy.experimental.win.cuda100/70115/
https://ci.preferred.jp/cupy.experimental.win.cuda100/70105/
https://ci.preferred.jp/cupy.experimental.win.cuda100/70103/