### PR TITLE
Fix C++ compilation error

### DIFF
--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -1858,16 +1858,19 @@ cdef bint _is_hip = runtime._is_hip_environment
 cdef int _cuda_runtime_version = -1
 cdef str _cuda_path = ''  # '' for uninitialized, None for non-existing
 
-cdef list _cupy_header_list = [
+cdef list cupy_header_list = [
     'cupy/complex.cuh',
     'cupy/carray.cuh',
     'cupy/atomics.cuh',
 ]
 if _is_hip:
-    _cupy_header_list.append('cupy/math_constants.h')
+    cupy_header_list.append('cupy/math_constants.h')
+
+# expose to Python for unit testing
+_cupy_header_list = cupy_header_list
 
 cdef str _cupy_header = ''.join(
-    ['#include <%s>\n' % i for i in _cupy_header_list])
+    ['#include <%s>\n' % i for i in cupy_header_list])
 
 # This is indirect include header list.
 # These header files are subject to a hash key.
@@ -1917,7 +1920,7 @@ cpdef str _get_header_source():
     if _header_source is None or not _header_source_map:
         source = []
         base_path = _get_header_dir_path()
-        for file_path in _cupy_extra_header_list + _cupy_header_list:
+        for file_path in _cupy_extra_header_list + cupy_header_list:
             header_path = os.path.join(base_path, file_path)
             with open(header_path) as header_file:
                 header = header_file.read()
@@ -1957,7 +1960,7 @@ cpdef function.Module compile_with_cache(
         log_stream=None, bint jitify=False):
     if translate_cucomplex:
         source = _translate_cucomplex_to_thrust(source)
-        _cupy_header_list.append('cupy/cuComplex_bridge.h')
+        cupy_header_list.append('cupy/cuComplex_bridge.h')
         prepend_cupy_headers = True
 
     if prepend_cupy_headers:

--- a/cupy/core/include/cupy/carray.cuh
+++ b/cupy/core/include/cupy/carray.cuh
@@ -1,20 +1,29 @@
 #pragma once
 
 #if __cplusplus >= 201103 || (defined(_MSC_VER) && _MSC_VER >= 1900)
-#include <type_traits>
 #ifndef __CUDACC_RTC__
 // in NVRTC std:initializer_list is pre-defined (no need to include it)
 #include <initializer_list>
 #endif
-#else
-// Basic implementation of std::conditional when not using C++11
-namespace std {
-  template<bool B, class T, class F>
-  struct conditional { typedef T type; };
-  template<class T, class F>
-  struct conditional<false, T, F> { typedef F type; };
-}
 #endif
+
+// Basic implementation of std::type_traits
+// We use this regardless when C++ is requested, as NVRTC by default lacks many
+// C++ features like this. We need to wrap in a namespace in case Jitify kicks
+// in and/or users provide custom definitions.
+namespace cupy {
+  namespace type_traits {
+    template<bool B, class T, class F>
+    struct conditional { typedef T type; };
+    template<class T, class F>
+    struct conditional<false, T, F> { typedef F type; };
+
+    template<bool B, class T = void>
+    struct enable_if {};
+    template<class T>
+    struct enable_if<true, T> { typedef T type; };
+  }
+}
 
 // math
 #ifndef M_PI
@@ -195,7 +204,7 @@ public:
   static const int ndim = _ndim;
   static const bool c_contiguous = _c_contiguous;
   static const bool use_32bit_indexing = _use_32bit_indexing;
-  typedef typename std::conditional<_use_32bit_indexing, int, ptrdiff_t>::type index_t;
+  typedef typename cupy::type_traits::conditional<_use_32bit_indexing, int, ptrdiff_t>::type index_t;
 private:
   T* data_;
   ptrdiff_t size_;
@@ -231,7 +240,7 @@ public:
 
 #if __cplusplus >= 201103 || (defined(_MSC_VER) && _MSC_VER >= 1900)
   template <typename Int, typename U=T>
-  __device__ CArray(typename std::enable_if<_c_contiguous, U>::type* data,
+  __device__ CArray(typename cupy::type_traits::enable_if<_c_contiguous, U>::type* data,
                     const Int* shape)
       : data_(data), size_(1)
   {
@@ -246,7 +255,7 @@ public:
   }
 
   template <typename Int, typename U=T>
-  __device__ CArray(typename std::enable_if<_c_contiguous, U>::type* data,
+  __device__ CArray(typename cupy::type_traits::enable_if<_c_contiguous, U>::type* data,
                     const std::initializer_list<Int> shape)
       : CArray(data, shape.begin())
   {

--- a/tests/cupy_tests/core_tests/test_core.py
+++ b/tests/cupy_tests/core_tests/test_core.py
@@ -7,7 +7,7 @@ import pytest
 import cupy
 from cupy.core import core
 from cupy import testing
-from tests.cupy_tests.core_tests import test_raw
+from cupy_tests.core_tests import test_raw
 
 
 class TestSize(unittest.TestCase):

--- a/tests/cupy_tests/core_tests/test_core.py
+++ b/tests/cupy_tests/core_tests/test_core.py
@@ -81,7 +81,7 @@ class TestCuPyHeaders(unittest.TestCase):
 
     def test_compiling_core_header(self):
         code = r'''
-        extern "C" __global__ void _test_ker_() { printf("ok!!!\n"); }
+        extern "C" __global__ void _test_ker_() { }
         '''
         code = self.header + code
         options = () if self.cxx is None else (self.cxx,)

--- a/tests/cupy_tests/core_tests/test_core.py
+++ b/tests/cupy_tests/core_tests/test_core.py
@@ -7,7 +7,7 @@ import pytest
 import cupy
 from cupy.core import core
 from cupy import testing
-from .test_raw import use_temporary_cache_dir
+from tests.cupy_tests.core_tests import test_raw
 
 
 class TestSize(unittest.TestCase):
@@ -65,13 +65,13 @@ class TestOrder(unittest.TestCase):
 
 
 @testing.parameterize(*testing.product({
-    'cxx': (None, '--std=c++11'),
+    'cxx': (None, '--std=c++03', '--std=c++11'),
 }))
 @testing.gpu
 class TestCuPyHeaders(unittest.TestCase):
 
     def setUp(self):
-        self.temporary_cache_dir_context = use_temporary_cache_dir()
+        self.temporary_cache_dir_context = test_raw.use_temporary_cache_dir()
         self.cache_dir = self.temporary_cache_dir_context.__enter__()
         self.header = '\n'.join(['#include <' + h + '>'
                                  for h in core._cupy_header_list])

--- a/tests/cupy_tests/core_tests/test_core.py
+++ b/tests/cupy_tests/core_tests/test_core.py
@@ -65,7 +65,7 @@ class TestOrder(unittest.TestCase):
 
 
 @testing.parameterize(*testing.product({
-    'cxx': (None, '--std=c++03', '--std=c++11'),
+    'cxx': (None, '--std=c++11'),
 }))
 @testing.gpu
 class TestCuPyHeaders(unittest.TestCase):

--- a/tests/cupy_tests/core_tests/test_core.py
+++ b/tests/cupy_tests/core_tests/test_core.py
@@ -1,4 +1,5 @@
 import unittest
+import sys
 
 import numpy
 import pytest
@@ -6,6 +7,7 @@ import pytest
 import cupy
 from cupy.core import core
 from cupy import testing
+from .test_raw import use_temporary_cache_dir
 
 
 class TestSize(unittest.TestCase):
@@ -60,3 +62,30 @@ class TestOrder(unittest.TestCase):
         expect_f = order_expect == 'F'
         assert a.flags.c_contiguous == expect_c
         assert a.flags.f_contiguous == expect_f
+
+
+@testing.parameterize(*testing.product({
+    'cxx': (None, '--std=c++11'),
+}))
+@testing.gpu
+class TestCuPyHeaders(unittest.TestCase):
+
+    def setUp(self):
+        self.temporary_cache_dir_context = use_temporary_cache_dir()
+        self.cache_dir = self.temporary_cache_dir_context.__enter__()
+        self.header = '\n'.join(['#include <' + h + '>'
+                                 for h in core._cupy_header_list])
+
+    def tearDown(self):
+        self.temporary_cache_dir_context.__exit__(*sys.exc_info())
+
+    def test_compiling_core_header(self):
+        code = r'''
+        extern "C" __global__ void _test_ker_() { printf("ok!!!\n"); }
+        '''
+        code = self.header + code
+        options = () if self.cxx is None else (self.cxx,)
+        ker = cupy.RawKernel(code, '_test_ker_',
+                             options=options, backend='nvrtc')
+        ker((1,), (1,), ())
+        cupy.cuda.Device().synchronize()


### PR DESCRIPTION
Close #4875.

As mentioned in the linked issue, NVRTC by default does not support many C++ features, including the offending `type_traits` header. Since it is best to not revert a feature we already supported (#3683), I choose to add a workaround patch, which in this case is still manageable though unfortunately against my earlier intention to avoid custom C++ `std` stubs (ex: #4264).

The added test ensures an error like the one reported in #4875 can be detected by the CI and prevents a regression from happening again.

cc: @takagi @coderforlife @grlee77 