### PR TITLE
Fix to work with scheduled FlexCI job

### DIFF
--- a/.pfnci/windows/_flexci.ps1
+++ b/.pfnci/windows/_flexci.ps1
@@ -43,7 +43,7 @@ function ActivateCUDA($version) {
 }
 
 function IsPullRequestTest() {
-    return ${Env:FLEXCI_BRANCH}.StartsWith("refs/pull/")
+    return ${Env:FLEXCI_BRANCH} -ne $null -and ${Env:FLEXCI_BRANCH}.StartsWith("refs/pull/")
 }
 
 function PrioritizeFlexCIDaemon() {


### PR DESCRIPTION
FlexCI does not define `FLEXCI_BRANCH` when run as scheduled job.