### PR TITLE
Document that cuDNN and NCCL are no longer included

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -91,13 +91,10 @@ Package names are different depending on your CUDA Toolkit version.
 
 .. note::
 
-   Wheel packages are built with NCCL (Linux only) and cuDNN support enabled.
+   To enable features provided by additional CUDA libraries (cuTENSOR / NCCL / cuDNN), you need to install them manually.
+   If you installed CuPy via wheels, you can use the installer command below to setup these libraries.
 
-   * NCCL library is bundled with these packages.
-     You don't have to install it manually.
-
-   * cuDNN library is bundled with these packages except for CUDA 10.1+.
-     For CUDA 10.1+, you need to manually download and install cuDNN v8.x library to use cuDNN features.
+     $ python -m cupyx.tools.install_library --cuda 11.2 --library cutensor
 
 .. note::
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -92,7 +92,7 @@ Package names are different depending on your CUDA Toolkit version.
 .. note::
 
    To enable features provided by additional CUDA libraries (cuTENSOR / NCCL / cuDNN), you need to install them manually.
-   If you installed CuPy via wheels, you can use the installer command below to setup these libraries.
+   If you installed CuPy via wheels, you can use the installer command below to setup these libraries in case you don't have a previous installation.
 
      $ python -m cupyx.tools.install_library --cuda 11.2 --library cutensor
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -92,9 +92,9 @@ Package names are different depending on your CUDA Toolkit version.
 .. note::
 
    To enable features provided by additional CUDA libraries (cuTENSOR / NCCL / cuDNN), you need to install them manually.
-   If you installed CuPy via wheels, you can use the installer command below to setup these libraries in case you don't have a previous installation.
+   If you installed CuPy via wheels, you can use the installer command below to setup these libraries in case you don't have a previous installation::
 
-     $ python -m cupyx.tools.install_library --cuda 11.2 --library cutensor
+    $ python -m cupyx.tools.install_library --cuda 11.2 --library cutensor
 
 .. note::
 

--- a/docs/source/upgrade.rst
+++ b/docs/source/upgrade.rst
@@ -30,6 +30,11 @@ Dropping Support of Python 3.5
 
 Python 3.5 is no longer supported in CuPy v9.
 
+NCCL and cuDNN No Longer Included in Wheels
+-------------------------------------------
+
+NCCL and cuDNN shared libraires are no longer included in wheels (see `#4850 <https://github.com/cupy/cupy/issues/4850>`_ for discussions). 
+You can manually install them after installing wheel; see :doc:`install/install` for details.
 
 CuPy v8
 =======

--- a/docs/source/upgrade.rst
+++ b/docs/source/upgrade.rst
@@ -34,7 +34,7 @@ NCCL and cuDNN No Longer Included in Wheels
 -------------------------------------------
 
 NCCL and cuDNN shared libraires are no longer included in wheels (see `#4850 <https://github.com/cupy/cupy/issues/4850>`_ for discussions). 
-You can manually install them after installing wheel; see :doc:`install/install` for details.
+You can manually install them after installing wheel if you don't have a previous installation; see :doc:`install/install` for details.
 
 CuPy v8
 =======

--- a/docs/source/upgrade.rst
+++ b/docs/source/upgrade.rst
@@ -34,7 +34,7 @@ NCCL and cuDNN No Longer Included in Wheels
 -------------------------------------------
 
 NCCL and cuDNN shared libraires are no longer included in wheels (see `#4850 <https://github.com/cupy/cupy/issues/4850>`_ for discussions). 
-You can manually install them after installing wheel if you don't have a previous installation; see :doc:`install/install` for details.
+You can manually install them after installing wheel if you don't have a previous installation; see :doc:`install` for details.
 
 CuPy v8
 =======


### PR DESCRIPTION
Closes #4850
Blocked by https://github.com/cupy/cupy-release-tools/pull/81, #4848, #4852