### PR TITLE
Disable windows tests per PR

### DIFF
--- a/.pfnci/config.pbtxt
+++ b/.pfnci/config.pbtxt
@@ -36,27 +36,6 @@ configs {
     command: "bash .pfnci/script.sh py37"
   }
 }
-configs {
-  key: "cupy.experimental.win.cuda100"
-  value {
-    requirement {
-      cpu: 8
-      memory: 24
-      disk: 10
-      gpu: 2
-      image: "windows"
-    }
-    time_limit {
-      seconds: 36000
-    }
-    checkout_strategy {
-      include_dot_git: true
-    }
-    environment_variables { key: "GPU" value: "2" }
-    environment_variables { key: "CUPY_CI_CACHE_KERNEL" value: "1" }
-    command: ".pfnci\\windows\\run.bat 10.0 3.7 test"
-  }
-}
 
 
 # CuPy CI related targets: cupy.docker.{version}.{action}.


### PR DESCRIPTION
We will run only the test suite on the master branch every midnight due to several constraints.