### PR TITLE
Fix flaky `CUDAarray` tests

### DIFF
--- a/cupy/cuda/texture.pyx
+++ b/cupy/cuda/texture.pyx
@@ -10,6 +10,8 @@ from cupy_backends.cuda.api.runtime cimport Array,\
     ChannelFormatDesc, ChannelFormatKind,\
     Memcpy3DParms, MemoryKind, PitchedPtr, ResourceDesc, ResourceType, \
     TextureAddressMode, TextureDesc, TextureFilterMode, TextureReadMode
+from cupy.cuda cimport stream as stream_module
+
 from cupy_backends.cuda.api.runtime import CUDARuntimeError
 
 
@@ -426,11 +428,16 @@ cdef class CUDAarray:
             param = <Memcpy3DParms*>self._make_cudaMemcpy3DParms(arr, self)
         elif direction == 'out':
             param = <Memcpy3DParms*>self._make_cudaMemcpy3DParms(self, arr)
+
+        # we need to serialize on the current or given stream to ensure
+        # data is ready
+        cdef intptr_t stream_ptr
         try:
             if stream is None:
-                runtime.memcpy3D(<intptr_t>param)
+                stream_ptr = stream_module.get_current_stream_ptr()
             else:
-                runtime.memcpy3DAsync(<intptr_t>param, stream.ptr)
+                stream_ptr = <intptr_t>(stream.ptr)
+            runtime.memcpy3DAsync(<intptr_t>param, stream_ptr)
         except CUDARuntimeError as ex:
             raise ex
         finally:

--- a/tests/cupy_tests/cuda_tests/test_texture.py
+++ b/tests/cupy_tests/cuda_tests/test_texture.py
@@ -14,7 +14,6 @@ from cupy.cuda.texture import (ChannelFormatDescriptor, CUDAarray,
 if cupy.cuda.runtime.is_hip:
     pytest.skip('HIP texture support is not yet ready',
                 allow_module_level=True)
-dev = cupy.cuda.Device(runtime.getDevice())
 
 
 @testing.gpu
@@ -43,8 +42,7 @@ class TestCUDAarray(unittest.TestCase):
             arr = xp.random.random(shape).astype(self.dtype)
             kind = runtime.cudaChannelFormatKindFloat
         else:  # int
-            # randint() in NumPy <= 1.10 does not have the dtype argument...
-            arr = xp.random.randint(100, size=shape).astype(self.dtype)
+            arr = xp.random.randint(100, size=shape, dtype=self.dtype)
             if self.dtype in (numpy.int8, numpy.int16, numpy.int32):
                 kind = runtime.cudaChannelFormatKindSigned
             else:
@@ -58,10 +56,14 @@ class TestCUDAarray(unittest.TestCase):
         ch_bits = [0, 0, 0, 0]
         for i in range(n_channel):
             ch_bits[i] = arr.dtype.itemsize*8
-        # unpacking arguments using *ch_bits is not supported before PY35...
-        ch = ChannelFormatDescriptor(ch_bits[0], ch_bits[1], ch_bits[2],
-                                     ch_bits[3], kind)
+        ch = ChannelFormatDescriptor(*ch_bits, kind)
         cu_arr = CUDAarray(ch, width, height, depth)
+
+        # need to wait for the current stream to finish initialization
+        if stream is not None:
+            s = cupy.cuda.get_current_stream()
+            e = s.record()
+            stream.wait_event(e)
 
         # copy from input to CUDA array, and back to output
         cu_arr.copy_from(arr, stream)
@@ -69,7 +71,7 @@ class TestCUDAarray(unittest.TestCase):
 
         # check input and output are identical
         if stream is not None:
-            dev.synchronize()
+            stream.synchronize()
         assert (arr == arr2).all()
 
 


### PR DESCRIPTION
Close #4865. This patch is verified using the stress test (https://github.com/cupy/cupy/issues/4865#issuecomment-804272731).

There are two separate bugs fixed in this PR:
1. The copy routine in `texture.pyx` does not respect the current stream, leading to surprises.
2. The tests in `test_texture.py` generate input data on the default stream, but run the copy routine on a separate stream without first establishing a proper stream order.

Both have to be fixed to make the stress test pass.

I also did a few cosmetic changes in `test_texture.py` that were not possible with older dependencies. Should be obvious ones.