### PR TITLE
Disable CUB SpMV on CUDA 11.x

### DIFF
--- a/cupyx/scipy/sparse/csr.py
+++ b/cupyx/scipy/sparse/csr.py
@@ -9,6 +9,7 @@ try:
 except ImportError:
     _scipy_available = False
 
+from cupy_backends.cuda.api import driver
 import cupy
 from cupy.core import _accelerator
 from cupy.cuda import cub
@@ -181,6 +182,9 @@ class csr_matrix(compressed._compressed_sparse_matrix):
                 # see cupy/cupy#3679 for discussion
                 is_cub_safe = (self.indptr.data.mem.size
                                > self.indptr.size * self.indptr.dtype.itemsize)
+                # CUB spmv is buggy since CUDA 11.0, see
+                # https://github.com/cupy/cupy/issues/3822#issuecomment-782607637
+                is_cub_safe &= (driver.get_build_version() < 11000)
                 for accelerator in _accelerator.get_routine_accelerators():
                     if (accelerator == _accelerator.ACCELERATOR_CUB
                             and is_cub_safe and other.flags.c_contiguous):

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -11,6 +11,7 @@ try:
 except ImportError:
     scipy_available = False
 
+from cupy_backends.cuda.api import driver
 import cupy
 from cupy.core import _accelerator
 from cupy import testing
@@ -1693,6 +1694,8 @@ class TestCsrMatrixGetitem2(unittest.TestCase):
 }))
 @testing.with_requires('scipy')
 @testing.gpu
+@unittest.skipIf(driver.get_build_version() >= 11000,
+                 'CUDA built-in CUB SpMV is buggy, see cupy/cupy#3822')
 @unittest.skipUnless(cupy.cuda.cub.available, 'The CUB routine is not enabled')
 class TestCubSpmv(unittest.TestCase):
 


### PR DESCRIPTION
This is a temporary workaround until we figure out a proper solution, see https://github.com/cupy/cupy/issues/3822#issuecomment-782607637.

cc: @emcastillo 