### PR TITLE
Declare `CArray._indexing()` only in CuPy JIT mode

### DIFF
--- a/cupy/_functional/vectorize.py
+++ b/cupy/_functional/vectorize.py
@@ -91,7 +91,8 @@ class vectorize(object):
             out_params, out_lval = self._parse_out_param(result.return_type)
             body = '{} = {}({})'.format(out_lval, func.name, in_args)
             kern = core.ElementwiseKernel(
-                in_params, out_params, body, preamble=result.code)
+                in_params, out_params, body, preamble=result.code,
+                options=('-D CUPY_JIT_MODE',))
             self._kernel_cache[itypes] = kern
 
         return kern(*args)

--- a/cupy/core/include/cupy/carray.cuh
+++ b/cupy/core/include/cupy/carray.cuh
@@ -198,10 +198,14 @@ __device__ int signbit(float16 x) {return x.signbit();}
          i < (n); \
          i += static_cast<ptrdiff_t>(blockDim.x) * gridDim.x)
 
+#ifdef CUPY_JIT_MODE
+#include <cupy/tuple.cuh>
+
 template <int dim>
 struct Dim {
   __device__ Dim() {}
 };
+#endif
 
 template <typename T, int _ndim, bool _c_contiguous=false, bool _use_32bit_indexing=false>
 class CArray {
@@ -333,6 +337,7 @@ public:
     return const_cast<T&>(const_cast<const CArray&>(*this)[i]);
   }
 
+#ifdef CUPY_JIT_MODE
   template <typename Tuple, int dim>
   __forceinline__ __device__ const T& _indexing(const Tuple &idx, Dim<dim>, const char* ptr) const {
     index_t i = static_cast<index_t>(thrust::get<dim>(idx));
@@ -355,6 +360,7 @@ public:
   __forceinline__ __device__ T& _indexing(const Tuple &idx) {
     return const_cast<T&>(const_cast<const CArray&>(*this)._indexing(idx));
   }
+#endif
 
   __device__ const T& operator[](ptrdiff_t idx) const {
     if (c_contiguous) {

--- a/cupyx/jit/_compile.py
+++ b/cupyx/jit/_compile.py
@@ -19,11 +19,6 @@ _typeclasses = (bool, numpy.bool_, numbers.Number)
 Result = collections.namedtuple('Result', ['func_name', 'code', 'return_type'])
 
 
-_global_header = '''
-#include <cupy/tuple.cuh>
-'''
-
-
 def transpile(func, attributes, mode, in_types, ret_type):
     """Transpile the target function
     Args:
@@ -54,11 +49,7 @@ def transpile(func, attributes, mode, in_types, ret_type):
     assert len(tree.body) == 1
     cuda_code, env = _transpile_function(
         tree.body[0], attributes, mode, consts, in_types, ret_type)
-    cuda_code = (
-        _global_header +
-        ''.join([code + '\n' for code in env.preambles]) +
-        cuda_code
-    )
+    cuda_code = ''.join([code + '\n' for code in env.preambles]) + cuda_code
     return Result(
         func_name=func.__name__,
         code=cuda_code,

--- a/cupyx/jit/_interface.py
+++ b/cupyx/jit/_interface.py
@@ -64,7 +64,9 @@ class _JitRawKernel:
                 _types.Void(),
             )
             fname = result.func_name
-            module = cupy.core.core.compile_with_cache(result.code)
+            module = cupy.core.core.compile_with_cache(
+                source=result.code,
+                options=('-D CUPY_JIT_MODE',))
             kern = module.get_function(fname)
             self._cache[in_types] = kern
         kern(grid, block, args)


### PR DESCRIPTION
Enclosed the `CArray._indexing` declarations with `#ifdef CUPY_JIT_MODE`, because ROCm tries to find `thrust::get` before the expansion of template member functions whereas CUDA does not.