### PR TITLE
[WIP] Generate kernel cache for all combinations in Windows CI

### DIFF
--- a/.pfnci/windows/test.ps1
+++ b/.pfnci/windows/test.ps1
@@ -106,6 +106,10 @@ function Main {
     if ($use_cache) {
         DownloadCache
     }
+    if ($upload_cache) {
+        # Generate kernel cache for all combinations.
+        $Env:CUPY_TEST_FULL_COMBINATION = "1"
+    }
     echo "Running test..."
     $test_retval = 0
     python -c "import cupy; cupy.show_config()" > cupy_test_log.txt


### PR DESCRIPTION
I noticed that cache hit ratio is worse than I expected. This was because we are making dtype test combination randomly sparse during the test run.

When running test with `CUPY_TEST_FULL_COMBINATION=1` set, test took 20898.77s and 58,464 cubins (654 MB) are generated.
After populating the full cache, test time with `CUPY_TEST_FULL_COMBINATION=0` reduced to 3504.59s.

WIP: merge after confirming that test time actually reduced.