### PR TITLE
[backport] Support cuSparse functions for matrix conversion added in CUDA 11.2

### DIFF
--- a/cupy_backends/cuda/cupy_cusparse.h
+++ b/cupy_backends/cuda/cupy_cusparse.h
@@ -1,0 +1,611 @@
+#ifndef INCLUDE_GUARD_CUDA_CUPY_CUSPARSE_H
+#define INCLUDE_GUARD_CUDA_CUPY_CUSPARSE_H
+
+#include <cuda.h>
+#include <cusparse.h>
+
+#if !defined(CUSPARSE_VERSION)
+  // CUSPARSE_VERSION introduced in CUDA 10.1 Update 2 (10.1.243).
+  #if CUDA_VERSION < 10000
+    #define CUSPARSE_VERSION CUDA_VERSION // CUDA_VERSION used instead
+  #elif CUDA_VERSION < 10010  // CUDA 10.0.x
+    # define CUSPARSE_VERSION 10000
+  #elif CUDA_VERSION < 10020  // CUDA 10.1.x
+    // CUSPARSE_VER_MAJOR introduced in CUDA 10.1 Update 1 (10.1.168).
+    #if !defined(CUSPARSE_VER_MAJOR)
+      // CUDA 10.1 (10.1.105) contains cuSPARSE 10.1
+      #define CUSPARSE_VERSION 10010
+    #else
+      // CUDA 10.1 Update 1 (10.1.168) contains cuSPARSE 10.2.0.0
+      #define CUSPARSE_VERSION (CUSPARSE_VER_MAJOR * 1000 + \
+                                CUSPARSE_VER_MINOR *  100 + \
+                                CUSPARSE_VER_PATCH)
+    #endif
+  #endif
+#endif  // #if !defined(CUSPARSE_VERSION)
+
+/*
+ * Generic APIs are not suppoted in CUDA 10.1/10.2 on Windows.
+ * These APIs are available in headers in CUDA 10.1 and 10.1 Update 1,
+ * but hidden in 10.1 Update 2 and 10.2 on Windows.
+ */
+
+#if defined(_WIN32) && (CUSPARSE_VERSION < 11000)
+  #if 10200 < CUSPARSE_VERSION
+    #define WIN32_EXPOSE_SPMM_STUB_DECL 1
+  #else
+    #define WIN32_EXPOSE_SPMM_STUB_DECL 0
+  #endif
+  #define WIN32_EXPOSE_SPMM_STUB_IMPL 1
+#else
+  #define WIN32_EXPOSE_SPMM_STUB_DECL 0
+  #define WIN32_EXPOSE_SPMM_STUB_IMPL 0
+#endif
+
+#if CUSPARSE_VERSION < 10010
+// Added in cuSPARSE 10.1 (CUDA 10.1.105)
+
+// CSR2CSC
+typedef enum {} cusparseCsr2CscAlg_t;
+
+#endif  // #if CUSPARSE_VERSION < 10010
+
+#if CUSPARSE_VERSION < 10010 || WIN32_EXPOSE_SPMM_STUB_DECL
+// Generic API types added in cuSPARSE 10.1 (CUDA 10.1.105)
+
+typedef void* cusparseSpMatDescr_t;
+typedef void* cusparseDnMatDescr_t;
+typedef enum {} cusparseIndexType_t;
+typedef enum {} cusparseFormat_t;
+typedef enum {} cusparseOrder_t;
+typedef enum {} cusparseSpMMAlg_t;
+
+#endif  // #if CUSPARSE_VERSION < 10010 || WIN32_EXPOSE_SPMM_STUB_DECL
+
+#if CUSPARSE_VERSION < 10200
+// Added in cuSPARSE 10.2 (CUDA 10.1.168)
+
+// CSR2CSC
+cusparseStatus_t cusparseCsr2cscEx2_bufferSize(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseCsr2cscEx2(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+#endif  // #if CUSPARSE_VERSION < 10200
+
+#if CUSPARSE_VERSION < 10200 || WIN32_EXPOSE_SPMM_STUB_DECL
+// Generic API types added in cuSPARSE 10.2 (CUDA 10.1.168)
+
+typedef void* cusparseSpVecDescr_t;
+typedef void* cusparseDnVecDescr_t;
+typedef enum {} cusparseSpMVAlg_t;
+
+#endif  // #if CUSPARSE_VERSION < 10200 || WIN32_EXPOSE_SPMM_STUB_DECL
+
+#if CUSPARSE_VERSION < 10200 || WIN32_EXPOSE_SPMM_STUB_IMPL
+// Generic APIs added in cuSPARSE 10.2 (CUDA 10.1.168)
+
+/*
+ * On Windows, implementations are not exposed from DLL in CUDA 10.1/10.2
+ * although it is declared in the header. So we have to provide a stub
+ * implementation using the full signature to match with the signature
+ * declared in cusparse.h, instead of using (...).
+ */
+
+cusparseStatus_t cusparseCreateSpVec(
+    cusparseSpVecDescr_t* spVecDescr,
+    int64_t               size,
+    int64_t               nnz,
+    void*                 indices,
+    void*                 values,
+    cusparseIndexType_t   idxType,
+    cusparseIndexBase_t   idxBase,
+    cudaDataType          valueType) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDestroySpVec(cusparseSpVecDescr_t spVecDescr) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseSpVecGet(
+    const cusparseSpVecDescr_t spVecDescr,
+    int64_t*                   size,
+    int64_t*                   nnz,
+    void**                     indices,
+    void**                     values,
+    cusparseIndexType_t*       idxType,
+    cusparseIndexBase_t*       idxBase,
+    cudaDataType*              valueType) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseSpVecGetIndexBase(
+    const cusparseSpVecDescr_t spVecDescr,
+    cusparseIndexBase_t*       idxBase) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseSpVecGetValues(
+    const cusparseSpVecDescr_t spVecDescr,
+    void**                     values) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseSpVecSetValues(
+    cusparseSpVecDescr_t spVecDescr,
+    void*                values) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseCreateCoo(
+    cusparseSpMatDescr_t* spMatDescr,
+    int64_t               rows,
+    int64_t               cols,
+    int64_t               nnz,
+    void*                 cooRowInd,
+    void*                 cooColInd,
+    void*                 cooValues,
+    cusparseIndexType_t   cooIdxType,
+    cusparseIndexBase_t   idxBase,
+    cudaDataType          valueType) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseCreateCooAoS(
+    cusparseSpMatDescr_t* spMatDescr,
+    int64_t               rows,
+    int64_t               cols,
+    int64_t               nnz,
+    void*                 cooInd,
+    void*                 cooValues,
+    cusparseIndexType_t   cooIdxType,
+    cusparseIndexBase_t   idxBase,
+    cudaDataType          valueType) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+
+cusparseStatus_t cusparseCreateCsr(
+    cusparseSpMatDescr_t* spMatDescr,
+    int64_t               rows,
+    int64_t               cols,
+    int64_t               nnz,
+    void*                 csrRowOffsets,
+    void*                 csrColInd,
+    void*                 csrValues,
+    cusparseIndexType_t   csrRowOffsetsType,
+    cusparseIndexType_t   csrColIndType,
+    cusparseIndexBase_t   idxBase,
+    cudaDataType          valueType) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDestroySpMat(cusparseSpMatDescr_t spMatDescr) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseCooGet(
+    const cusparseSpMatDescr_t spMatDescr,
+    int64_t*                   rows,
+    int64_t*                   cols,
+    int64_t*                   nnz,
+    void**                     cooRowInd,  // COO row indices
+    void**                     cooColInd,  // COO column indices
+    void**                     cooValues,  // COO values
+    cusparseIndexType_t*       idxType,
+    cusparseIndexBase_t*       idxBase,
+    cudaDataType*              valueType) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseCooAoSGet(
+    const cusparseSpMatDescr_t spMatDescr,
+    int64_t*                   rows,
+    int64_t*                   cols,
+    int64_t*                   nnz,
+    void**                     cooInd,     // COO indices
+    void**                     cooValues,  // COO values
+    cusparseIndexType_t*       idxType,
+    cusparseIndexBase_t*       idxBase,
+    cudaDataType*              valueType) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseCsrGet(
+    const cusparseSpMatDescr_t spMatDescr,
+    int64_t*                   rows,
+    int64_t*                   cols,
+    int64_t*                   nnz,
+    void**                     csrRowOffsets,
+    void**                     csrColInd,
+    void**                     csrValues,
+    cusparseIndexType_t*       csrRowOffsetsType,
+    cusparseIndexType_t*       csrColIndType,
+    cusparseIndexBase_t*       idxBase,
+    cudaDataType*              valueType) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseSpMatGetFormat(
+    const cusparseSpMatDescr_t spMatDescr,
+    cusparseFormat_t*          format) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseSpMatGetIndexBase(
+    const cusparseSpMatDescr_t spMatDescr,
+    cusparseIndexBase_t*       idxBase) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseSpMatGetValues(
+    const cusparseSpMatDescr_t spMatDescr,
+    void**                     values) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseSpMatSetValues(
+    cusparseSpMatDescr_t spMatDescr,
+    void*                values) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseSpMatGetStridedBatch(
+    const cusparseSpMatDescr_t spMatDescr,
+    int*                       batchCount) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseSpMatSetStridedBatch(
+    cusparseSpMatDescr_t spMatDescr,
+    int                  batchCount) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseCreateDnVec(
+    cusparseDnVecDescr_t* dnVecDescr,
+    int64_t               size,
+    void*                 values,
+    cudaDataType          valueType) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDestroyDnVec(cusparseDnVecDescr_t dnVecDescr) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDnVecGet(
+    const cusparseDnVecDescr_t dnVecDescr,
+    int64_t*                   size,
+    void**                     values,
+    cudaDataType*              valueType) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDnVecGetValues(
+    const cusparseDnVecDescr_t dnVecDescr,
+    void**                     values) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDnVecSetValues(
+    cusparseDnVecDescr_t dnVecDescr,
+    void*                values) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseCreateDnMat(
+    cusparseDnMatDescr_t* dnMatDescr,
+    int64_t               rows,
+    int64_t               cols,
+    int64_t               ld,
+    void*                 values,
+    cudaDataType          valueType,
+    cusparseOrder_t       order) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDestroyDnMat(cusparseDnMatDescr_t dnMatDescr) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDnMatGet(
+    const cusparseDnMatDescr_t dnMatDescr,
+    int64_t*                   rows,
+    int64_t*                   cols,
+    int64_t*                   ld,
+    void**                     values,
+    cudaDataType*              type,
+    cusparseOrder_t*           order) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDnMatGetValues(
+    const cusparseDnMatDescr_t dnMatDescr,
+    void**                     values) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDnMatSetValues(
+    cusparseDnMatDescr_t dnMatDescr,
+    void*                values) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDnMatGetStridedBatch(
+    const cusparseDnMatDescr_t dnMatDescr,
+    int*                       batchCount,
+    int64_t*                   batchStride) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDnMatSetStridedBatch(
+    cusparseDnMatDescr_t dnMatDescr,
+    int                  batchCount,
+    int64_t              batchStride) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseSpVV_bufferSize(
+    cusparseHandle_t           handle,
+    cusparseOperation_t        opX,
+    const cusparseSpVecDescr_t vecX,
+    const cusparseDnVecDescr_t vecY,
+    const void*                result,
+    cudaDataType               computeType,
+    size_t*                    bufferSize) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseSpVV(
+    cusparseHandle_t           handle,
+    cusparseOperation_t        opX,
+    const cusparseSpVecDescr_t vecX,
+    const cusparseDnVecDescr_t vecY,
+    void*                      result,
+    cudaDataType               computeType,
+    void*                      externalBuffer) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseSpMV_bufferSize(
+    cusparseHandle_t           handle,
+    cusparseOperation_t        opA,
+    const void*                alpha,
+    const cusparseSpMatDescr_t matA,
+    const cusparseDnVecDescr_t vecX,
+    const void*                beta,
+    const cusparseDnVecDescr_t vecY,
+    cudaDataType               computeType,
+    cusparseSpMVAlg_t          alg,
+    size_t*                    bufferSize) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseSpMV(
+    cusparseHandle_t           handle,
+    cusparseOperation_t        opA,
+    const void*                alpha,
+    const cusparseSpMatDescr_t matA,
+    const cusparseDnVecDescr_t vecX,
+    const void*                beta,
+    const cusparseDnVecDescr_t vecY,
+    cudaDataType               computeType,
+    cusparseSpMVAlg_t          alg,
+    void*                      externalBuffer) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseSpMM_bufferSize(
+    cusparseHandle_t           handle,
+    cusparseOperation_t        opA,
+    cusparseOperation_t        opB,
+    const void*                alpha,
+    const cusparseSpMatDescr_t matA,
+    const cusparseDnMatDescr_t matB,
+    const void*                beta,
+    cusparseDnMatDescr_t       matC,
+    cudaDataType               computeType,
+    cusparseSpMMAlg_t          alg,
+    size_t*                    bufferSize) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseSpMM(
+    cusparseHandle_t           handle,
+    cusparseOperation_t        opA,
+    cusparseOperation_t        opB,
+    const void*                alpha,
+    const cusparseSpMatDescr_t matA,
+    const cusparseDnMatDescr_t matB,
+    const void*                beta,
+    cusparseDnMatDescr_t       matC,
+    cudaDataType               computeType,
+    cusparseSpMMAlg_t          alg,
+    void*                      externalBuffer) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+#endif  // #if CUSPARSE_VERSION < 10200 || WIN32_EXPOSE_SPMM_STUB_IMPL
+
+#if CUSPARSE_VERSION < 10300 || WIN32_EXPOSE_SPMM_STUB_IMPL
+// Generic APIs added in cuSPARSE 10.3 (CUDA 10.1.243)
+
+cusparseStatus_t cusparseConstrainedGeMM_bufferSize(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseConstrainedGeMM(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+#endif  // #if CUSPARSE_VERSION < 10300 || WIN32_EXPOSE_SPMM_STUB_IMPL
+
+#if CUSPARSE_VERSION >= 11000
+// Functions deleted in cuSparse 11.0
+
+// cuSPARSE Level2 Function
+cusparseStatus_t cusparseScsrmv(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDcsrmv(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseCcsrmv(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseZcsrmv(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+// cuSPARSE Level3 Function
+cusparseStatus_t cusparseScsrmm(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDcsrmm(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseCcsrmm(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseZcsrmm(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseScsrmm2(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDcsrmm2(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseCcsrmm2(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseZcsrmm2(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+// cuSPARSE Extra Function
+cusparseStatus_t cusparseXcsrgeamNnz(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseScsrgeam(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDcsrgeam(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseCcsrgeam(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseZcsrgeam(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+
+cusparseStatus_t cusparseXcsrgemmNnz(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseScsrgemm(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDcsrgemm(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseCcsrgemm(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseZcsrgemm(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+// cuSPARSE Format Convrsion
+cusparseStatus_t cusparseXcsr2coo(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseScsr2csc(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDcsr2csc(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseCcsr2csc(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseZcsr2csc(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+#endif // #if CUSPARSE_VERSION >= 11000
+
+#if CUSPARSE_VERSION < 11100
+// Functions added in cuSparse 11.1 (CUDA 11.0)
+
+cusparseStatus_t cusparseCsrSetPointers(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseSpMatGetSize(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+#endif // #if CUSPARSE_VERSION < 11100
+
+#if CUSPARSE_VERSION < 11300
+// Types, macro and functions added in cuSparse 11.3 (CUDA 11.2)
+
+typedef enum {} cusparseSparseToDenseAlg_t;
+typedef enum {} cusparseDenseToSparseAlg_t;
+
+cusparseStatus_t cusparseCreateCsc(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseSparseToDense_bufferSize(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseSparseToDense(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDenseToSparse_bufferSize(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDenseToSparse_analysis(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDenseToSparse_convert(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+#endif // CUSPARSE_VERSION < 11300
+
+
+#endif  // INCLUDE_GUARD_CUDA_CUPY_CUSPARSE_H

--- a/cupy_backends/cuda/libs/cupy_cusparse.h
+++ b/cupy_backends/cuda/libs/cupy_cusparse.h
@@ -769,6 +769,51 @@ cusparseStatus_t cusparseZcsr2csc(...) {
 }
 #endif // #if CUSPARSE_VERSION >= 11000
 
+#if CUSPARSE_VERSION < 11100
+// Functions added in cuSparse 11.1 (CUDA 11.0)
+
+cusparseStatus_t cusparseCsrSetPointers(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseSpMatGetSize(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+#endif // #if CUSPARSE_VERSION < 11100
+
+#if CUSPARSE_VERSION < 11300
+// Types, macro and functions added in cuSparse 11.3 (CUDA 11.2)
+
+typedef enum {} cusparseSparseToDenseAlg_t;
+typedef enum {} cusparseDenseToSparseAlg_t;
+
+cusparseStatus_t cusparseCreateCsc(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseSparseToDense_bufferSize(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseSparseToDense(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDenseToSparse_bufferSize(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDenseToSparse_analysis(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDenseToSparse_convert(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+#endif // CUSPARSE_VERSION < 11300
+
 #else  // #if !defined(CUPY_NO_CUDA) && !defined(CUPY_USE_HIP)
 
 #ifdef CUPY_USE_HIP
@@ -1625,6 +1670,8 @@ typedef enum {} cusparseFormat_t;
 typedef enum {} cusparseOrder_t;
 typedef enum {} cusparseSpMVAlg_t;
 typedef enum {} cusparseSpMMAlg_t;
+typedef enum {} cusparseSparseToDenseAlg_t;
+typedef enum {} cusparseDenseToSparseAlg_t;
 
 cusparseStatus_t cusparseCreateSpVec(...) {
   return CUSPARSE_STATUS_SUCCESS;
@@ -1662,6 +1709,10 @@ cusparseStatus_t cusparseCreateCsr(...) {
   return CUSPARSE_STATUS_SUCCESS;
 }
 
+cusparseStatus_t cusparseCreateCsc(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
 cusparseStatus_t cusparseDestroySpMat(...) {
   return CUSPARSE_STATUS_SUCCESS;
 }
@@ -1675,6 +1726,14 @@ cusparseStatus_t cusparseCooAoSGet(...) {
 }
 
 cusparseStatus_t cusparseCsrGet(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseCsrSetPointers(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseSpMatGetSize(...) {
   return CUSPARSE_STATUS_SUCCESS;
 }
 
@@ -1779,6 +1838,26 @@ cusparseStatus_t cusparseConstrainedGeMM_bufferSize(...) {
 }
 
 cusparseStatus_t cusparseConstrainedGeMM(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseSparseToDense_bufferSize(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseSparseToDense(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDenseToSparse_bufferSize(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDenseToSparse_analysis(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseDenseToSparse_convert(...) {
   return CUSPARSE_STATUS_SUCCESS;
 }
 

--- a/cupy_backends/cuda/libs/cusparse.pxd
+++ b/cupy_backends/cuda/libs/cusparse.pxd
@@ -50,6 +50,9 @@ cdef extern from *:
     ctypedef void* cusparseSpMatDescr_t
     ctypedef void* cusparseDnMatDescr_t
 
+    ctypedef int cusparseSparseToDenseAlg_t
+    ctypedef int cusparseDenseToSparseAlg_t
+
     # CSR2CSC
     ctypedef int Csr2CscAlg 'cusparseCsr2CscAlg_t'
 
@@ -108,6 +111,12 @@ cpdef enum:
     # CSR2CSC
     CUSPARSE_CSR2CSC_ALG1 = 1  # faster than ALG2 (in general), deterministc
     CUSPARSE_CSR2CSC_ALG2 = 2  # low memory requirement, non-deterministc
+
+    # cusparseSparseToDenseAlg_t
+    CUSPARSE_SPARSETODENSE_ALG_DEFAULT = 0
+
+    # cusparseDenseToSparseAlg_t
+    CUSPARSE_DENSETOSPARSE_ALG_DEFAULT = 0
 
 cdef class SpVecAttributes:
     cdef:

--- a/cupy_backends/cuda/libs/cusparse.pyx
+++ b/cupy_backends/cuda/libs/cusparse.pyx
@@ -1073,6 +1073,12 @@ cdef extern from 'cupy_cusparse.h' nogil:
                              IndexType csrRowOffsetsType,
                              IndexType csrColIndType, IndexBase idxBase,
                              DataType valueType)
+    Status cusparseCreateCsc(SpMatDescr* spMatDescr, int64_t rows,
+                             int64_t cols, int64_t nnz, void* cscColOffsets,
+                             void* cscRowInd, void* cscValues,
+                             IndexType cscColOffsetsType,
+                             IndexType cscRowIndType, IndexBase idxBase,
+                             DataType valueType)
     Status cusparseDestroySpMat(SpMatDescr spMatDescr)
     Status cusparseCooGet(SpMatDescr spMatDescr, int64_t* rows, int64_t* cols,
                           int64_t* nnz, void** cooRowInd, void** cooColInd,
@@ -1087,10 +1093,14 @@ cdef extern from 'cupy_cusparse.h' nogil:
                           void** csrValues, IndexType* csrRowOffsetsType,
                           IndexType* csrColIndType, IndexBase* idxBase,
                           DataType* valueType)
+    Status cusparseCsrSetPointers(SpMatDescr spMatDescr, void* csrRowOffsets,
+                                  void* csrColInd, void* csrValues)
     Status cusparseSpMatGetFormat(SpMatDescr spMatDescr, Format* format)
     Status cusparseSpMatGetIndexBase(SpMatDescr spMatDescr, IndexBase* idxBase)
     Status cusparseSpMatGetValues(SpMatDescr spMatDescr, void** values)
     Status cusparseSpMatSetValues(SpMatDescr spMatDescr, void* values)
+    Status cusparseSpMatGetSize(SpMatDescr spMatDescr, int64_t* rows,
+                                int64_t* cols, int64_t* nnz)
     Status cusparseSpMatGetStridedBatch(SpMatDescr spMatDescr, int* batchCount)
     Status cusparseSpMatSetStridedBatch(SpMatDescr spMatDescr, int batchCount)
 
@@ -1152,6 +1162,23 @@ cdef extern from 'cupy_cusparse.h' nogil:
         Handle handle, Operation opA, Operation opB, void* alpha,
         DnMatDescr matA, DnMatDescr matB, void* beta, SpMatDescr matC,
         DataType computeType, void* externalBuffer)
+
+    Status cusparseSparseToDense_bufferSize(
+        Handle handle, SpMatDescr matA, DnMatDescr matB,
+        cusparseSparseToDenseAlg_t alg, size_t* bufferSize)
+    Status cusparseSparseToDense(
+        Handle handle, SpMatDescr matA, DnMatDescr matB,
+        cusparseSparseToDenseAlg_t alg, void* buffer)
+
+    Status cusparseDenseToSparse_bufferSize(
+        Handle handle, DnMatDescr matA, SpMatDescr matB,
+        cusparseDenseToSparseAlg_t alg, size_t* bufferSize)
+    Status cusparseDenseToSparse_analysis(
+        Handle handle, DnMatDescr matA, SpMatDescr matB,
+        cusparseDenseToSparseAlg_t alg, void* buffer)
+    Status cusparseDenseToSparse_convert(
+        Handle handle, DnMatDescr matA, SpMatDescr matB,
+        cusparseDenseToSparseAlg_t alg, void* buffer)
 
     # CSR2CSC
     Status cusparseCsr2cscEx2_bufferSize(
@@ -3984,6 +4011,19 @@ cpdef size_t createCsr(int64_t rows, int64_t cols, int64_t nnz,
     check_status(status)
     return <size_t>desc
 
+cpdef size_t createCsc(int64_t rows, int64_t cols, int64_t nnz,
+                       intptr_t cscColOffsets, intptr_t cscRowInd,
+                       intptr_t cscValues, IndexType cscColOffsetsType,
+                       IndexType cscRowIndType, IndexBase idxBase,
+                       DataType valueType):
+    cdef SpMatDescr desc
+    status = cusparseCreateCsc(&desc, rows, cols, nnz,
+                               <void*>cscColOffsets, <void*>cscRowInd,
+                               <void*>cscValues, cscColOffsetsType,
+                               cscRowIndType, idxBase, valueType)
+    check_status(status)
+    return <size_t>desc
+
 cpdef destroySpMat(size_t desc):
     status = cusparseDestroySpMat(<SpMatDescr>desc)
     check_status(status)
@@ -4028,6 +4068,12 @@ cpdef csrGet(size_t desc):
     return CsrAttributes(rows, cols, nnz, rowOffsets, colInd, values,
                          rowOffsetsType, colIndType, idxBase, valueType)
 
+cpdef csrSetPointers(size_t desc, size_t csrRowOffsets, size_t csrColInd,
+                     size_t csrValues):
+    status = cusparseCsrSetPointers(<SpMatDescr>desc, <void*>csrRowOffsets,
+                                    <void*>csrColInd, <void*>csrValues)
+    check_status(status)
+
 cpdef int spMatGetFormat(size_t desc):
     cdef Format format
     status = cusparseSpMatGetFormat(<SpMatDescr>desc, &format)
@@ -4048,6 +4094,11 @@ cpdef intptr_t spMatGetValues(size_t desc):
 
 cpdef spMatSetValues(size_t desc, intptr_t values):
     status = cusparseSpMatSetValues(<SpMatDescr>desc, <void*>values)
+    check_status(status)
+
+cpdef spMatGetSize(size_t desc, size_t rows, size_t cols, size_t nnz):
+    status = cusparseSpMatGetSize(<SpMatDescr>desc, <int64_t*>rows,
+                                  <int64_t*>cols, <int64_t*>nnz)
     check_status(status)
 
 cpdef int spMatGetStridedBatch(size_t desc):
@@ -4226,6 +4277,45 @@ cpdef constrainedGeMM(intptr_t handle, Operation opA, Operation opB,
         <Handle>handle, opA, opB, <void*>alpha, <DnMatDescr>matA,
         <DnMatDescr>matB, <void*>beta, <SpMatDescr>matC, computeType,
         <void*>externalBuffer)
+    check_status(status)
+
+cpdef size_t sparseToDense_bufferSize(intptr_t handle, size_t matA,
+                                      size_t matB, int alg):
+    cpdef size_t bufferSize
+    status = cusparseSparseToDense_bufferSize(
+        <Handle>handle, <SpMatDescr>matA, <DnMatDescr>matB,
+        <cusparseSparseToDenseAlg_t>alg, &bufferSize)
+    check_status(status)
+    return bufferSize
+
+cpdef sparseToDense(intptr_t handle, size_t matA, size_t matB, int alg,
+                    intptr_t buffer):
+    status = cusparseSparseToDense(
+        <Handle>handle, <SpMatDescr>matA, <DnMatDescr>matB,
+        <cusparseSparseToDenseAlg_t>alg, <void*>buffer)
+    check_status(status)
+
+cpdef size_t denseToSparse_bufferSize(intptr_t handle, size_t matA,
+                                      size_t matB, int alg):
+    cpdef size_t bufferSize
+    status = cusparseDenseToSparse_bufferSize(
+        <Handle>handle, <DnMatDescr>matA, <SpMatDescr>matB,
+        <cusparseDenseToSparseAlg_t>alg, &bufferSize)
+    check_status(status)
+    return bufferSize
+
+cpdef denseToSparse_analysis(intptr_t handle, size_t matA, size_t matB,
+                             int alg, intptr_t buffer):
+    status = cusparseDenseToSparse_analysis(
+        <Handle>handle, <DnMatDescr>matA, <SpMatDescr>matB,
+        <cusparseDenseToSparseAlg_t>alg, <void*>buffer)
+    check_status(status)
+
+cpdef denseToSparse_convert(intptr_t handle, size_t matA, size_t matB,
+                            int alg, intptr_t buffer):
+    status = cusparseDenseToSparse_convert(
+        <Handle>handle, <DnMatDescr>matA, <SpMatDescr>matB,
+        <cusparseDenseToSparseAlg_t>alg, <void*>buffer)
     check_status(status)
 
 # CSR2CSC

--- a/cupyx/scipy/sparse/csc.py
+++ b/cupyx/scipy/sparse/csc.py
@@ -64,7 +64,10 @@ class csc_matrix(compressed._compressed_sparse_matrix):
             (data, indices, indptr), shape=self._shape)
 
     def _convert_dense(self, x):
-        m = cusparse.dense2csc(x)
+        if cusparse.check_availability('denseToSparse'):
+            m = cusparse.denseToSparse(x, format='csc')
+        else:
+            m = cusparse.dense2csc(x)
         return m.data, m.indices, m.indptr
 
     def _swap(self, x, y):
@@ -182,14 +185,23 @@ class csc_matrix(compressed._compressed_sparse_matrix):
         x = self.copy()
         x.has_canonical_format = False  # need to enforce sum_duplicates
         x.sum_duplicates()
-        # csc2dense and csr2dense returns F-contiguous array.
-        if order == 'C':
-            # To return C-contiguous array, it uses transpose.
-            return cusparse.csr2dense(x.T).T
-        elif order == 'F':
-            return cusparse.csc2dense(x)
+        if cusparse.check_availability('sparseToDense'):
+            y = cusparse.sparseToDense(x)
+            if order == 'F':
+                return y
+            elif order == 'C':
+                return cupy.ascontiguousarray(y)
+            else:
+                raise ValueError('order not understood')
         else:
-            raise ValueError('order not understood')
+            # csc2dense and csr2dense returns F-contiguous array.
+            if order == 'C':
+                # To return C-contiguous array, it uses transpose.
+                return cusparse.csr2dense(x.T).T
+            elif order == 'F':
+                return cusparse.csc2dense(x)
+            else:
+                raise ValueError('order not understood')
 
     def _add_sparse(self, other, alpha, beta):
         self.sum_duplicates()

--- a/cupyx/scipy/sparse/csr.py
+++ b/cupyx/scipy/sparse/csr.py
@@ -349,14 +349,23 @@ class csr_matrix(compressed._compressed_sparse_matrix):
         x = self.copy()
         x.has_canonical_format = False  # need to enforce sum_duplicates
         x.sum_duplicates()
-        # csr2dense returns F-contiguous array.
-        if order == 'C':
-            # To return C-contiguous array, it uses transpose.
-            return cusparse.csc2dense(x.T).T
-        elif order == 'F':
-            return cusparse.csr2dense(x)
+        if cusparse.check_availability('sparseToDense'):
+            y = cusparse.sparseToDense(x)
+            if order == 'F':
+                return y
+            elif order == 'C':
+                return cupy.ascontiguousarray(y)
+            else:
+                raise ValueError('order not understood')
         else:
-            raise ValueError('order not understood')
+            # csr2dense returns F-contiguous array.
+            if order == 'C':
+                # To return C-contiguous array, it uses transpose.
+                return cusparse.csc2dense(x.T).T
+            elif order == 'F':
+                return cusparse.csr2dense(x)
+            else:
+                raise ValueError('order not understood')
 
     def tobsr(self, blocksize=None, copy=False):
         # TODO(unno): Implement tobsr
@@ -1066,7 +1075,10 @@ def cupy_csr2dense():
 
 def dense2csr(a):
     if a.dtype.char in 'fdFD':
-        return cusparse.dense2csr(a)
+        if cusparse.check_availability('denseToSparse'):
+            return cusparse.denseToSparse(a, format='csr')
+        else:
+            return cusparse.dense2csr(a)
     m, n = a.shape
     a = cupy.ascontiguousarray(a)
     indptr = cupy.zeros(m + 1, dtype=numpy.int32)

--- a/tests/cupy_tests/test_cusparse.py
+++ b/tests/cupy_tests/test_cusparse.py
@@ -687,3 +687,38 @@ class TestErrorSpmm(unittest.TestCase):
         c = cupy.array(self.b, order='f')
         with self.assertRaises(ValueError):
             cupy.cusparse.spmm(a, b, c=c)
+
+
+@testing.parameterize(*testing.product({
+    'shape': [(3, 4), (4, 4), (4, 3)],
+    'density': [0.0, 0.5, 1.0],
+    'format': ['csr', 'csc', 'coo']
+}))
+@testing.with_requires('scipy')
+class TestSparseMatrixConversion(unittest.TestCase):
+
+    @testing.for_dtypes('fdFD')
+    def test_denseToSparse(self, dtype):
+        if not cusparse.check_availability('denseToSparse'):
+            pytest.skip('denseToSparse is not available')
+        x = cupy.random.uniform(0, 1, self.shape).astype(dtype)
+        x[x < self.density] = 0
+        y = cusparse.denseToSparse(x, format=self.format)
+        assert y.format == self.format
+        testing.assert_array_equal(x, y.todense())
+
+    @testing.for_dtypes('fdFD')
+    def test_sparseToDense(self, dtype):
+        if not cusparse.check_availability('sparseToDense'):
+            pytest.skip('sparseToDense is not available')
+        m, n = self.shape
+        x = scipy.sparse.random(m, n, density=self.density, format=self.format,
+                                dtype=dtype)
+        if self.format == 'csr':
+            x = sparse.csr_matrix(x)
+        elif self.format == 'csc':
+            x = sparse.csc_matrix(x)
+        elif self.format == 'coo':
+            x = sparse.coo_matrix(x)
+        y = cusparse.sparseToDense(x)
+        testing.assert_array_equal(x.todense(), y)


### PR DESCRIPTION
Backport of #4844