### PR TITLE
Fix `cutensor` import in the test

### DIFF
--- a/tests/cupy_tests/math_tests/test_sumprod.py
+++ b/tests/cupy_tests/math_tests/test_sumprod.py
@@ -6,6 +6,7 @@ import pytest
 
 import cupy
 import cupy.core._accelerator as _acc
+import cupy.cuda.cutensor
 from cupy.core import _cub_reduction
 from cupy import testing
 


### PR DESCRIPTION
Follow-up of #4920. This is needed to enable the check `cupy.cuda.cutensor.available`. Not sure how I missed this...

ref: https://github.com/cupy/cupy/pull/4920#discussion_r597873769