### PR TITLE
Make install_tests runnable without depending on current path

### DIFF
--- a/tests/install_tests/__init__.py
+++ b/tests/install_tests/__init__.py
@@ -1,0 +1,14 @@
+import importlib
+import os
+import sys
+
+
+def _from_install_import(name):
+    install_module_path = os.path.join(
+        os.path.dirname(__file__), '..', '..', 'install')
+    original_sys_path = sys.path.copy()
+    try:
+        sys.path.append(install_module_path)
+        return importlib.import_module(name)
+    finally:
+        sys.path = original_sys_path

--- a/tests/install_tests/test_build.py
+++ b/tests/install_tests/test_build.py
@@ -4,7 +4,10 @@ import unittest
 
 import pytest
 
-from install import build
+from . import _from_install_import
+
+
+build = _from_install_import('build')
 
 
 class TestCheckVersion(unittest.TestCase):

--- a/tests/install_tests/test_utils.py
+++ b/tests/install_tests/test_utils.py
@@ -1,6 +1,9 @@
 import unittest
 
-from install import utils
+from . import _from_install_import
+
+
+utils = _from_install_import('utils')
 
 
 class TestPrintWarning(unittest.TestCase):


### PR DESCRIPTION
Currently install_tests expects that the current directory is at `cupy/` source root.
Due to this limitation we have to run tests separately, in two step (install_tests and other tests).

https://github.com/chainer/chainer-test/blob/master/test_cupy.sh#L28-L34