### PR TITLE
Avoid using `pip install -e` on Windows CI for performance

### DIFF
--- a/.pfnci/windows/test.ps1
+++ b/.pfnci/windows/test.ps1
@@ -72,7 +72,7 @@ function Main {
 
     echo "Building..."
     $build_retval = 0
-    python -m pip install -e ".[all,jenkins]" -vvv > cupy_build_log.txt
+    python -m pip install ".[all,jenkins]" -vvv > cupy_build_log.txt
     if (-not $?) {
         $build_retval = $LastExitCode
     }
@@ -84,10 +84,6 @@ function Main {
         PublishTestResults
         throw "Build failed with status $build_retval"
     }
-
-    # Import test
-    echo "CuPy Configuration:"
-    RunOrDie python -c "import cupy; cupy.show_config()"
 
     # Unit test
     if ($test -eq "build") {
@@ -106,16 +102,21 @@ function Main {
     if ($use_cache) {
         DownloadCache
     }
+
+    pushd tests
+    echo "CuPy Configuration:"
+    RunOrDie python -c "import cupy; print(cupy); cupy.show_config()"
     echo "Running test..."
     $test_retval = 0
-    python -c "import cupy; cupy.show_config()" > cupy_test_log.txt
-    python -m pytest -rfEX @pytest_opts tests >> cupy_test_log.txt
+    python -c "import cupy; cupy.show_config()" > ../cupy_test_log.txt
+    python -m pytest -rfEX @pytest_opts . >> ../cupy_test_log.txt
     if (-not $?) {
         $test_retval = $LastExitCode
     }
     if ($use_cache -And $upload_cache) {
         UploadCache
     }
+    popd
 
     echo "Last 10 lines from the test output:"
     Get-Content cupy_test_log.txt -Tail 10

--- a/.pfnci/windows/test.ps1
+++ b/.pfnci/windows/test.ps1
@@ -102,6 +102,9 @@ function Main {
     if ($use_cache) {
         DownloadCache
     }
+    if ($upload_cache) {
+        $Env:CUPY_TEST_FULL_COMBINATION = "1"
+    }
 
     pushd tests
     echo "CuPy Configuration:"

--- a/.pfnci/windows/test.ps1
+++ b/.pfnci/windows/test.ps1
@@ -113,10 +113,11 @@ function Main {
     if (-not $?) {
         $test_retval = $LastExitCode
     }
+    popd
+
     if ($use_cache -And $upload_cache) {
         UploadCache
     }
-    popd
 
     echo "Last 10 lines from the test output:"
     Get-Content cupy_test_log.txt -Tail 10

--- a/install/build.py
+++ b/install/build.py
@@ -7,7 +7,7 @@ import subprocess
 import sys
 import tempfile
 
-from install import utils
+from . import utils
 
 
 PLATFORM_LINUX = sys.platform.startswith('linux')

--- a/install/build.py
+++ b/install/build.py
@@ -1,5 +1,6 @@
 import contextlib
 import distutils.util
+import importlib
 import os
 import re
 import shutil
@@ -7,7 +8,20 @@ import subprocess
 import sys
 import tempfile
 
-from . import utils
+
+# This is done because pip is installed in no editable mode in
+# windows CI so the kernel cache gets always a deterministic path.
+def _from_install_import(name):
+    install_module_path = os.path.join(os.path.dirname(__file__))
+    original_sys_path = sys.path.copy()
+    try:
+        sys.path.append(install_module_path)
+        return importlib.import_module(name)
+    finally:
+        sys.path = original_sys_path
+
+
+utils = _from_install_import('utils')
 
 
 PLATFORM_LINUX = sys.platform.startswith('linux')


### PR DESCRIPTION
Depends on ~#4969~

See https://github.com/cupy/cupy/pull/4963#issuecomment-805927327