### PR TITLE
Fix Windows dll loading for Conda

### DIFF
--- a/cupy/_environment.py
+++ b/cupy/_environment.py
@@ -199,10 +199,15 @@ def _setup_win32_dll_directory():
     # Setup DLL directory to load CUDA Toolkit libs and shared libraries
     # added during the build process.
     if sys.platform.startswith('win32'):
+        is_conda = ((os.environ.get('CONDA_PREFIX') is not None)
+                    or (os.environ.get('CONDA_BUILD_STATE') is not None))
         # Path to the CUDA Toolkit binaries
         cuda_path = get_cuda_path()
         if cuda_path is not None:
-            cuda_bin_path = os.path.join(cuda_path, 'bin')
+            if is_conda:
+                cuda_bin_path = cuda_path
+            else:
+                cuda_bin_path = os.path.join(cuda_path, 'bin')
         else:
             cuda_bin_path = None
             warnings.warn(


### PR DESCRIPTION
See https://github.com/conda-forge/cupy-feedstock/pull/113#issuecomment-807010102. Without this patch, the dll loading errors at this line:
https://github.com/cupy/cupy/blob/30e004549b1862f3360b3b5922566bd6b9805bb2/cupy/_environment.py#L226
The reason is Anaconda/Conda-Forge put all dlls under the Conda env root (`$CONDA_PREFIX`), which is then assigned to `$CUDA_PATH`, so the expected dlls are just in the root dir. Also, on Windows there is no `$CONDA_PREFIX\bin` directory.