### PR TITLE
CuPy JIT: Readable compile error messages

### DIFF
--- a/cupyx/jit/_compile.py
+++ b/cupyx/jit/_compile.py
@@ -21,7 +21,7 @@ _typeclasses = (bool, numpy.bool_, numbers.Number)
 Result = collections.namedtuple('Result', ['func_name', 'code', 'return_type'])
 
 
-class JitCompileError(Exception):
+class _JitCompileError(Exception):
 
     def __init__(self, e, node):
         self.error_type = type(e)
@@ -41,10 +41,10 @@ def transpile_function_wrapper(func):
     def new_func(node, *args, **kwargs):
         try:
             return func(node, *args, **kwargs)
-        except JitCompileError:
+        except _JitCompileError:
             raise
         except Exception as e:
-            raise JitCompileError(e, node)
+            raise _JitCompileError(e, node)
 
     return new_func
 
@@ -230,7 +230,7 @@ def _transpile_function(
     try:
         return _transpile_function_internal(
             func, attributes, mode, consts, in_types, ret_type)
-    except JitCompileError as e:
+    except _JitCompileError as e:
         exc = e
         if _is_debug_mode:
             exc.reraise(source)


### PR DESCRIPTION
Indicates on which line of the target Python function the compile error occurred.

If an error is raised while the compilation, the type of error is immediately converted to `_JitCompileError` class temporarily.
The attributes of `_JitCompileError` object include 1. the type and message of the original error and 2. On which line of the original python function the error is raised.
Just before exiting the top level of the compilation function, the error type is restored to the original error type, and "Where in the Python function the compilation error occurred" is shown as the error message.