### PR TITLE
Add hfft2, ihfft2, hfftn, and ihfftn to cupyx.scipy.fft

### DIFF
--- a/cupyx/scipy/fft/_fft.py
+++ b/cupyx/scipy/fft/_fft.py
@@ -590,7 +590,7 @@ def hfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, *,
     """Compute the FFT of a two-dimensional signal that has Hermitian symmetry.
 
     Args:
-        a (cupy.ndarray): Array to be transformed.
+        x (cupy.ndarray): Array to be transformed.
         s (None or tuple of ints): Shape of the real output.
         axes (tuple of ints): Axes over which to compute the FFT.
         norm (``"backward"``, ``"ortho"``, or ``"forward"``): Optional keyword

--- a/cupyx/scipy/fft/_fft.py
+++ b/cupyx/scipy/fft/_fft.py
@@ -587,7 +587,7 @@ def hfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, *,
             to specify the normalization mode. Default is ``None``, which is
             an alias of ``"backward"``.
         overwrite_x (bool): If True, the contents of ``x`` can be destroyed.
-        (This argument is currently not supported)
+            (This argument is currently not supported)
         plan (None): This argument is currently not supported.
 
     Returns:
@@ -615,7 +615,7 @@ def ihfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, *,
             to specify the normalization mode. Default is ``None``, which is
             an alias of ``"backward"``.
         overwrite_x (bool): If True, the contents of ``x`` can be destroyed.
-        (This argument is currently not supported)
+            (This argument is currently not supported)
         plan (None): This argument is currently not supported.
 
     Returns:
@@ -642,7 +642,7 @@ def hfftn(x, s=None, axes=None, norm=None, overwrite_x=False, *,
             to specify the normalization mode. Default is ``None``, which is
             an alias of ``"backward"``.
         overwrite_x (bool): If True, the contents of ``x`` can be destroyed.
-        (This argument is currently not supported)
+            (This argument is currently not supported)
         plan (None): This argument is currently not supported.
 
     Returns:
@@ -670,7 +670,7 @@ def ihfftn(x, s=None, axes=None, norm=None, overwrite_x=False, *,
             to specify the normalization mode. Default is ``None``, which is
             an alias of ``"backward"``.
         overwrite_x (bool): If True, the contents of ``x`` can be destroyed.
-        (This argument is currently not supported)
+            (This argument is currently not supported)
         plan (None): This argument is currently not supported.
 
     Returns:

--- a/cupyx/scipy/fft/_fft.py
+++ b/cupyx/scipy/fft/_fft.py
@@ -7,7 +7,8 @@ import cupy
 
 from cupy.cuda import cufft
 from cupy.fft._fft import (_fft, _default_fft_func, hfft as _hfft,
-                           ihfft as _ihfft, _size_last_transform_axis)
+                           ihfft as _ihfft, _size_last_transform_axis,
+                           _swap_direction)
 from cupy.fft import fftshift, ifftshift, fftfreq, rfftfreq
 
 from cupyx.scipy.fftpack import get_fft_plan
@@ -571,17 +572,6 @@ def ihfft(x, n=None, axis=-1, norm=None, overwrite_x=False, *, plan=None):
     if plan is not None:
         raise NotImplementedError('ihfft plan is currently not yet supported')
     return _ihfft(x, n, axis, norm)
-
-
-def _swap_direction(norm):
-    if norm in (None, 'backward'):
-        norm = 'forward'
-    elif norm == 'forward':
-        norm = 'backward'
-    elif norm != 'ortho':
-        raise ValueError('Invalid norm value %s; should be "backward", '
-                         '"ortho", or "forward".' % norm)
-    return norm
 
 
 @_implements(_scipy_fft.hfft2)

--- a/cupyx/scipy/fft/_fft.py
+++ b/cupyx/scipy/fft/_fft.py
@@ -587,6 +587,7 @@ def hfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, *,
             to specify the normalization mode. Default is ``None``, which is
             an alias of ``"backward"``.
         overwrite_x (bool): If True, the contents of ``x`` can be destroyed.
+        (This argument is currently not supported)
         plan (None): This argument is currently not supported.
 
     Returns:
@@ -614,6 +615,7 @@ def ihfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, *,
             to specify the normalization mode. Default is ``None``, which is
             an alias of ``"backward"``.
         overwrite_x (bool): If True, the contents of ``x`` can be destroyed.
+        (This argument is currently not supported)
         plan (None): This argument is currently not supported.
 
     Returns:
@@ -640,6 +642,7 @@ def hfftn(x, s=None, axes=None, norm=None, overwrite_x=False, *,
             to specify the normalization mode. Default is ``None``, which is
             an alias of ``"backward"``.
         overwrite_x (bool): If True, the contents of ``x`` can be destroyed.
+        (This argument is currently not supported)
         plan (None): This argument is currently not supported.
 
     Returns:
@@ -667,6 +670,7 @@ def ihfftn(x, s=None, axes=None, norm=None, overwrite_x=False, *,
             to specify the normalization mode. Default is ``None``, which is
             an alias of ``"backward"``.
         overwrite_x (bool): If True, the contents of ``x`` can be destroyed.
+        (This argument is currently not supported)
         plan (None): This argument is currently not supported.
 
     Returns:

--- a/cupyx/scipy/fft/_fft.py
+++ b/cupyx/scipy/fft/_fft.py
@@ -590,7 +590,7 @@ def hfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, *,
     """Compute the FFT of a two-dimensional signal that has Hermitian symmetry.
 
     Args:
-        a (cupy.ndarray): Array to be transform.
+        a (cupy.ndarray): Array to be transformed.
         s (None or tuple of ints): Shape of the real output.
         axes (tuple of ints): Axes over which to compute the FFT.
         norm (``"backward"``, ``"ortho"``, or ``"forward"``): Optional keyword
@@ -601,10 +601,7 @@ def hfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, *,
 
     Returns:
         cupy.ndarray:
-            The transformed array which shape is specified by ``n`` and type
-            will convert to complex if the input is other. If ``n`` is not
-            given, the length of the transformed axis is ``2*(m-1)`` where `m`
-            is the length of the transformed axis of the input.
+            The real result of the 2-D Hermitian complex real FFT.
 
     .. seealso:: :func:`scipy.fft.hfft2`
     """

--- a/cupyx/scipy/fft/_fft.py
+++ b/cupyx/scipy/fft/_fft.py
@@ -14,7 +14,7 @@ from cupyx.scipy.fftpack import get_fft_plan
 
 __all__ = ['fft', 'ifft', 'fft2', 'ifft2', 'fftn', 'ifftn',
            'rfft', 'irfft', 'rfft2', 'irfft2', 'rfftn', 'irfftn',
-           'hfft', 'ihfft',
+           'hfft', 'ihfft', 'hfft2',
            'fftshift', 'ifftshift', 'fftfreq', 'rfftfreq',
            'get_fft_plan']
 
@@ -571,3 +571,43 @@ def ihfft(x, n=None, axis=-1, norm=None, overwrite_x=False, *, plan=None):
     if plan is not None:
         raise NotImplementedError('ihfft plan is currently not yet supported')
     return _ihfft(x, n, axis, norm)
+
+
+def _swap_direction(norm):
+    if norm in (None, 'backward'):
+        norm = 'forward'
+    elif norm == 'forward':
+        norm = 'backward'
+    elif norm != 'ortho':
+        raise ValueError('Invalid norm value %s; should be "backward", '
+                         '"ortho", or "forward".' % norm)
+    return norm
+
+
+@_implements(_scipy_fft.hfft2)
+def hfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, *,
+          plan=None):
+    """Compute the FFT of a two-dimensional signal that has Hermitian symmetry.
+
+    Args:
+        a (cupy.ndarray): Array to be transform.
+        s (None or tuple of ints): Shape of the real output.
+        axes (tuple of ints): Axes over which to compute the FFT.
+        norm (``"backward"``, ``"ortho"``, or ``"forward"``): Optional keyword
+            to specify the normalization mode. Default is ``None``, which is
+            an alias of ``"backward"``.
+        overwrite_x (bool): If True, the contents of ``x`` can be destroyed.
+        plan (None): This argument is currently not supported.
+
+    Returns:
+        cupy.ndarray:
+            The transformed array which shape is specified by ``n`` and type
+            will convert to complex if the input is other. If ``n`` is not
+            given, the length of the transformed axis is ``2*(m-1)`` where `m`
+            is the length of the transformed axis of the input.
+
+    .. seealso:: :func:`scipy.fft.hfft2`
+    """
+    if plan is not None:
+        raise NotImplementedError('hfft2 plan is currently not yet supported')
+    return irfft2(x.conj(), s, axes, _swap_direction(norm))

--- a/cupyx/scipy/fft/_fft.py
+++ b/cupyx/scipy/fft/_fft.py
@@ -628,7 +628,7 @@ def ihfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, *,
 
 
 @_implements(_scipy_fft.hfftn)
-def hfftn(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, *,
+def hfftn(x, s=None, axes=None, norm=None, overwrite_x=False, *,
           plan=None):
     """Compute the FFT of a N-dimensional signal that has Hermitian symmetry.
 
@@ -654,7 +654,7 @@ def hfftn(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, *,
 
 
 @_implements(_scipy_fft.ihfftn)
-def ihfftn(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, *,
+def ihfftn(x, s=None, axes=None, norm=None, overwrite_x=False, *,
            plan=None):
     """Compute the Inverse FFT of a N-dimensional signal that has Hermitian
     symmetry.

--- a/cupyx/scipy/fft/_fft.py
+++ b/cupyx/scipy/fft/_fft.py
@@ -14,7 +14,7 @@ from cupyx.scipy.fftpack import get_fft_plan
 
 __all__ = ['fft', 'ifft', 'fft2', 'ifft2', 'fftn', 'ifftn',
            'rfft', 'irfft', 'rfft2', 'irfft2', 'rfftn', 'irfftn',
-           'hfft', 'ihfft', 'hfft2',
+           'hfft', 'ihfft', 'hfft2', 'ihfft2',
            'fftshift', 'ifftshift', 'fftfreq', 'rfftfreq',
            'get_fft_plan']
 
@@ -608,3 +608,30 @@ def hfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, *,
     if plan is not None:
         raise NotImplementedError('hfft2 plan is currently not yet supported')
     return irfft2(x.conj(), s, axes, _swap_direction(norm))
+
+
+@_implements(_scipy_fft.ihfft2)
+def ihfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, *,
+           plan=None):
+    """Compute the Inverse FFT of a two-dimensional signal that has Hermitian
+    symmetry.
+
+    Args:
+        x (cupy.ndarray): Array to be transformed.
+        s (None or tuple of ints): Shape of the real output.
+        axes (tuple of ints): Axes over which to compute the FFT.
+        norm (``"backward"``, ``"ortho"``, or ``"forward"``): Optional keyword
+            to specify the normalization mode. Default is ``None``, which is
+            an alias of ``"backward"``.
+        overwrite_x (bool): If True, the contents of ``x`` can be destroyed.
+        plan (None): This argument is currently not supported.
+
+    Returns:
+        cupy.ndarray:
+            The real result of the 2-D Hermitian inverse complex real FFT.
+
+    .. seealso:: :func:`scipy.fft.ihfft2`
+    """
+    if plan is not None:
+        raise NotImplementedError('ihfft2 plan is currently not yet supported')
+    return rfft2(x, s, axes, _swap_direction(norm)).conj()

--- a/cupyx/scipy/fft/_fft.py
+++ b/cupyx/scipy/fft/_fft.py
@@ -14,7 +14,7 @@ from cupyx.scipy.fftpack import get_fft_plan
 
 __all__ = ['fft', 'ifft', 'fft2', 'ifft2', 'fftn', 'ifftn',
            'rfft', 'irfft', 'rfft2', 'irfft2', 'rfftn', 'irfftn',
-           'hfft', 'ihfft', 'hfft2', 'ihfft2',
+           'hfft', 'ihfft', 'hfft2', 'ihfft2', 'hfftn', 'ihfftn',
            'fftshift', 'ifftshift', 'fftfreq', 'rfftfreq',
            'get_fft_plan']
 
@@ -635,3 +635,56 @@ def ihfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, *,
     if plan is not None:
         raise NotImplementedError('ihfft2 plan is currently not yet supported')
     return rfft2(x, s, axes, _swap_direction(norm)).conj()
+
+
+@_implements(_scipy_fft.hfftn)
+def hfftn(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, *,
+          plan=None):
+    """Compute the FFT of a N-dimensional signal that has Hermitian symmetry.
+
+    Args:
+        x (cupy.ndarray): Array to be transformed.
+        s (None or tuple of ints): Shape of the real output.
+        axes (tuple of ints): Axes over which to compute the FFT.
+        norm (``"backward"``, ``"ortho"``, or ``"forward"``): Optional keyword
+            to specify the normalization mode. Default is ``None``, which is
+            an alias of ``"backward"``.
+        overwrite_x (bool): If True, the contents of ``x`` can be destroyed.
+        plan (None): This argument is currently not supported.
+
+    Returns:
+        cupy.ndarray:
+            The real result of the N-D Hermitian complex real FFT.
+
+    .. seealso:: :func:`scipy.fft.hfftn`
+    """
+    if plan is not None:
+        raise NotImplementedError('hfftn plan is currently not yet supported')
+    return irfftn(x.conj(), s, axes, _swap_direction(norm))
+
+
+@_implements(_scipy_fft.ihfftn)
+def ihfftn(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, *,
+           plan=None):
+    """Compute the Inverse FFT of a N-dimensional signal that has Hermitian
+    symmetry.
+
+    Args:
+        x (cupy.ndarray): Array to be transformed.
+        s (None or tuple of ints): Shape of the real output.
+        axes (tuple of ints): Axes over which to compute the FFT.
+        norm (``"backward"``, ``"ortho"``, or ``"forward"``): Optional keyword
+            to specify the normalization mode. Default is ``None``, which is
+            an alias of ``"backward"``.
+        overwrite_x (bool): If True, the contents of ``x`` can be destroyed.
+        plan (None): This argument is currently not supported.
+
+    Returns:
+        cupy.ndarray:
+            The real result of the N-D Hermitian inverse complex real FFT.
+
+    .. seealso:: :func:`scipy.fft.ihfftn`
+    """
+    if plan is not None:
+        raise NotImplementedError('ihfftn plan is currently not yet supported')
+    return rfftn(x, s, axes, _swap_direction(norm)).conj()

--- a/docs/source/reference/scipy_fft.rst
+++ b/docs/source/reference/scipy_fft.rst
@@ -25,6 +25,7 @@ Fast Fourier Transforms
    cupyx.scipy.fft.irfftn
    cupyx.scipy.fft.hfft
    cupyx.scipy.fft.ihfft
+   cupyx.scipy.fft.hfft2
 
 
 Helper functions for FFT

--- a/docs/source/reference/scipy_fft.rst
+++ b/docs/source/reference/scipy_fft.rst
@@ -27,6 +27,8 @@ Fast Fourier Transforms
    cupyx.scipy.fft.ihfft
    cupyx.scipy.fft.hfft2
    cupyx.scipy.fft.ihfft2
+   cupyx.scipy.fft.hfftn
+   cupyx.scipy.fft.ihfftn
 
 
 Helper functions for FFT

--- a/docs/source/reference/scipy_fft.rst
+++ b/docs/source/reference/scipy_fft.rst
@@ -26,6 +26,7 @@ Fast Fourier Transforms
    cupyx.scipy.fft.hfft
    cupyx.scipy.fft.ihfft
    cupyx.scipy.fft.hfft2
+   cupyx.scipy.fft.ihfft2
 
 
 Helper functions for FFT

--- a/tests/cupyx_tests/scipy_tests/fft_tests/test_fft.py
+++ b/tests/cupyx_tests/scipy_tests/fft_tests/test_fft.py
@@ -1627,6 +1627,59 @@ class TestHfft(unittest.TestCase):
         return _correct_np_dtype(xp, dtype, out)
 
 
+@testing.parameterize(*(
+    testing.product_dict([
+        {'shape': (2, 5), 's': None, 'axes': None},
+        {'shape': (2, 10), 's': (1, 5), 'axes': None},
+        {'shape': (2, 30), 's': None, 'axes': (-2, -1)},
+        {'shape': (2, 50), 's': None, 'axes': (-1, -2)},
+        {'shape': (2, 100), 's': None, 'axes': (0,)}
+    ],
+        testing.product({'norm': [None, 'backward', 'ortho', 'forward']})
+    )
+))
+@testing.gpu
+@testing.gpu
+class TestHfft2(unittest.TestCase):
+
+    def setUp(self):
+        _skip_forward_backward(self.norm)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose(rtol=4e-4, atol=1e-7, accept_error=ValueError,
+                                 contiguous_check=False)
+    def test_hfft2(self, xp, dtype):
+        x = testing.shaped_random(self.shape, xp, dtype)
+        x_orig = x.copy()
+        out = _fft_module(xp).hfft2(x, s=self.s, axes=self.axes,
+                                    norm=self.norm)
+        testing.assert_array_equal(x, x_orig)
+        return _correct_np_dtype(xp, dtype, out)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose(rtol=4e-4, atol=1e-7, accept_error=ValueError,
+                                 contiguous_check=False)
+    def test_hfft2_overwrite(self, xp, dtype):
+        x = testing.shaped_random(self.shape, xp, dtype)
+        overwrite_kw = {} if xp is np else {'overwrite_x': True}
+        out = _fft_module(xp).hfft2(x, s=self.s, axes=self.axes,
+                                    norm=self.norm, **overwrite_kw)
+        return _correct_np_dtype(xp, dtype, out)
+
+    @testing.with_requires('scipy>=1.4.0')
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose(rtol=4e-4, atol=1e-7, accept_error=ValueError,
+                                 contiguous_check=False)
+    def test_hfft2_backend(self, xp, dtype):
+        x = testing.shaped_random(self.shape, xp, dtype)
+        x_orig = x.copy()
+        backend = 'scipy' if xp is np else cp_fft
+        with scipy_fft.set_backend(backend):
+            out = scipy_fft.hfft2(x, s=self.s, axes=self.axes, norm=self.norm)
+        testing.assert_array_equal(x, x_orig)
+        return _correct_np_dtype(xp, dtype, out)
+
+
 @testing.gpu
 @pytest.mark.parametrize('func', [
     cp_fft.fft2, cp_fft.ifft2, cp_fft.rfft2, cp_fft.irfft2,

--- a/tests/cupyx_tests/scipy_tests/fft_tests/test_fft.py
+++ b/tests/cupyx_tests/scipy_tests/fft_tests/test_fft.py
@@ -1639,6 +1639,7 @@ class TestHfft(unittest.TestCase):
     )
 ))
 @testing.gpu
+@testing.with_requires('scipy>=1.4.0')
 class TestHfft2(unittest.TestCase):
 
     def setUp(self):
@@ -1665,7 +1666,6 @@ class TestHfft2(unittest.TestCase):
                                     norm=self.norm, **overwrite_kw)
         return _correct_np_dtype(xp, dtype, out)
 
-    @testing.with_requires('scipy>=1.4.0')
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(rtol=4e-4, atol=1e-7, accept_error=ValueError,
                                  contiguous_check=False)
@@ -1699,7 +1699,6 @@ class TestHfft2(unittest.TestCase):
                                      axes=self.axes, **overwrite_kw)
         return _correct_np_dtype(xp, dtype, out)
 
-    @testing.with_requires('scipy>=1.4.0')
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
                                  contiguous_check=False)
@@ -1725,6 +1724,7 @@ class TestHfft2(unittest.TestCase):
     )
 ))
 @testing.gpu
+@testing.with_requires('scipy>=1.4.0')
 class TestHfftn(unittest.TestCase):
 
     def setUp(self):
@@ -1751,7 +1751,6 @@ class TestHfftn(unittest.TestCase):
                                     norm=self.norm, **overwrite_kw)
         return _correct_np_dtype(xp, dtype, out)
 
-    @testing.with_requires('scipy>=1.4.0')
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(rtol=4e-4, atol=1e-7, accept_error=ValueError,
                                  contiguous_check=False)
@@ -1785,7 +1784,6 @@ class TestHfftn(unittest.TestCase):
                                      axes=self.axes, **overwrite_kw)
         return _correct_np_dtype(xp, dtype, out)
 
-    @testing.with_requires('scipy>=1.4.0')
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
                                  contiguous_check=False)

--- a/tests/cupyx_tests/scipy_tests/fft_tests/test_fft.py
+++ b/tests/cupyx_tests/scipy_tests/fft_tests/test_fft.py
@@ -1633,7 +1633,13 @@ class TestHfft(unittest.TestCase):
         {'shape': (2, 10), 's': (1, 5), 'axes': None},
         {'shape': (2, 30), 's': None, 'axes': (-2, -1)},
         {'shape': (2, 50), 's': None, 'axes': (-1, -2)},
-        {'shape': (2, 100), 's': (2, 50), 'axes': (0,)}
+        {'shape': (2, 100), 's': (2, 50), 'axes': (0,)},
+        {'shape': (2, 3, 10), 's': None, 'axes': None},
+        {'shape': (2, 5, 20), 's': None, 'axes': (0, 1, 2)},
+        {'shape': (2, 10, 100), 's': (2, 10), 'axes': (0, -1, -2)},
+        {'shape': (2, 5, 10), 's': None, 'axes': (-2, -1, 0)},
+        {'shape': (2, 10, 50, 100), 's': (2, 10, 50), 'axes': (0,)},
+
     ],
         testing.product({'norm': [None, 'backward', 'ortho', 'forward']})
     )
@@ -1715,10 +1721,16 @@ class TestHfft2(unittest.TestCase):
 @testing.parameterize(*(
     testing.product_dict([
         {'shape': (2, 5), 's': None, 'axes': None},
-        {'shape': (3, 10), 's': (2, 5), 'axes': None},
-        {'shape': (4, 30), 's': None, 'axes': (-2, -1)},
-        {'shape': (5, 50), 's': None, 'axes': (-1, -2)},
-        {'shape': (6, 100), 's': (5, 50), 'axes': (0,)}
+        {'shape': (2, 10), 's': (1, 5), 'axes': None},
+        {'shape': (2, 30), 's': None, 'axes': (-2, -1)},
+        {'shape': (2, 50), 's': None, 'axes': (-1, -2)},
+        {'shape': (3, 100), 's': (2, 50), 'axes': (0,)},
+        {'shape': (3, 3, 10), 's': None, 'axes': None},
+        {'shape': (3, 5, 20), 's': None, 'axes': (0, 1, 2)},
+        {'shape': (5, 10, 100), 's': (2, 10), 'axes': (0, -1, -2)},
+        {'shape': (6, 5, 10), 's': None, 'axes': (-2, -1, 0)},
+        {'shape': (7, 10, 50, 100), 's': (2, 10, 50), 'axes': (0,)},
+
     ],
         testing.product({'norm': [None, 'backward', 'ortho', 'forward']})
     )

--- a/tests/cupyx_tests/scipy_tests/fft_tests/test_fft.py
+++ b/tests/cupyx_tests/scipy_tests/fft_tests/test_fft.py
@@ -1665,16 +1665,6 @@ class TestHfft2(unittest.TestCase):
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(rtol=4e-4, atol=1e-7, accept_error=ValueError,
                                  contiguous_check=False)
-    def test_hfft2_overwrite(self, xp, dtype):
-        x = testing.shaped_random(self.shape, xp, dtype)
-        overwrite_kw = {} if xp is np else {'overwrite_x': True}
-        out = _fft_module(xp).hfft2(x, s=self.s, axes=self.axes,
-                                    norm=self.norm, **overwrite_kw)
-        return _correct_np_dtype(xp, dtype, out)
-
-    @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose(rtol=4e-4, atol=1e-7, accept_error=ValueError,
-                                 contiguous_check=False)
     def test_hfft2_backend(self, xp, dtype):
         x = testing.shaped_random(self.shape, xp, dtype)
         x_orig = x.copy()
@@ -1693,16 +1683,6 @@ class TestHfft2(unittest.TestCase):
         out = _fft_module(xp).ihfft2(x, s=self.s, axes=self.axes,
                                      norm=self.norm)
         testing.assert_array_equal(x, x_orig)
-        return _correct_np_dtype(xp, dtype, out)
-
-    @testing.for_all_dtypes(no_complex=True)
-    @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
-                                 contiguous_check=False)
-    def test_ihfft2_overwrite(self, xp, dtype):
-        x = testing.shaped_random(self.shape, xp, dtype)
-        overwrite_kw = {} if xp is np else {'overwrite_x': True}
-        out = _fft_module(xp).ihfft2(x, s=self.s, norm=self.norm,
-                                     axes=self.axes, **overwrite_kw)
         return _correct_np_dtype(xp, dtype, out)
 
     @testing.for_all_dtypes(no_complex=True)
@@ -1756,16 +1736,6 @@ class TestHfftn(unittest.TestCase):
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(rtol=4e-4, atol=1e-7, accept_error=ValueError,
                                  contiguous_check=False)
-    def test_hfftn_overwrite(self, xp, dtype):
-        x = testing.shaped_random(self.shape, xp, dtype)
-        overwrite_kw = {} if xp is np else {'overwrite_x': True}
-        out = _fft_module(xp).hfftn(x, s=self.s, axes=self.axes,
-                                    norm=self.norm, **overwrite_kw)
-        return _correct_np_dtype(xp, dtype, out)
-
-    @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose(rtol=4e-4, atol=1e-7, accept_error=ValueError,
-                                 contiguous_check=False)
     def test_hfftn_backend(self, xp, dtype):
         x = testing.shaped_random(self.shape, xp, dtype)
         x_orig = x.copy()
@@ -1784,16 +1754,6 @@ class TestHfftn(unittest.TestCase):
         out = _fft_module(xp).ihfftn(x, s=self.s, axes=self.axes,
                                      norm=self.norm)
         testing.assert_array_equal(x, x_orig)
-        return _correct_np_dtype(xp, dtype, out)
-
-    @testing.for_all_dtypes(no_complex=True)
-    @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
-                                 contiguous_check=False)
-    def test_ihfftn_overwrite(self, xp, dtype):
-        x = testing.shaped_random(self.shape, xp, dtype)
-        overwrite_kw = {} if xp is np else {'overwrite_x': True}
-        out = _fft_module(xp).ihfftn(x, s=self.s, norm=self.norm,
-                                     axes=self.axes, **overwrite_kw)
         return _correct_np_dtype(xp, dtype, out)
 
     @testing.for_all_dtypes(no_complex=True)

--- a/tests/cupyx_tests/scipy_tests/fft_tests/test_fft.py
+++ b/tests/cupyx_tests/scipy_tests/fft_tests/test_fft.py
@@ -1678,6 +1678,40 @@ class TestHfft2(unittest.TestCase):
         testing.assert_array_equal(x, x_orig)
         return _correct_np_dtype(xp, dtype, out)
 
+    @testing.for_all_dtypes(no_complex=True)
+    @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
+                                 contiguous_check=False)
+    def test_ihfft2(self, xp, dtype):
+        x = testing.shaped_random(self.shape, xp, dtype)
+        x_orig = x.copy()
+        out = _fft_module(xp).ihfft2(x, s=self.s, axes=self.axes,
+                                     norm=self.norm)
+        testing.assert_array_equal(x, x_orig)
+        return _correct_np_dtype(xp, dtype, out)
+
+    @testing.for_all_dtypes(no_complex=True)
+    @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
+                                 contiguous_check=False)
+    def test_ihfft2_overwrite(self, xp, dtype):
+        x = testing.shaped_random(self.shape, xp, dtype)
+        overwrite_kw = {} if xp is np else {'overwrite_x': True}
+        out = _fft_module(xp).ihfft2(x, s=self.s, norm=self.norm,
+                                     axes=self.axes, **overwrite_kw)
+        return _correct_np_dtype(xp, dtype, out)
+
+    @testing.with_requires('scipy>=1.4.0')
+    @testing.for_all_dtypes(no_complex=True)
+    @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
+                                 contiguous_check=False)
+    def test_ihfft2_backend(self, xp, dtype):
+        x = testing.shaped_random(self.shape, xp, dtype)
+        x_orig = x.copy()
+        backend = 'scipy' if xp is np else cp_fft
+        with scipy_fft.set_backend(backend):
+            out = scipy_fft.ihfft2(x, s=self.s, axes=self.axes, norm=self.norm)
+        testing.assert_array_equal(x, x_orig)
+        return _correct_np_dtype(xp, dtype, out)
+
 
 @testing.gpu
 @pytest.mark.parametrize('func', [

--- a/tests/cupyx_tests/scipy_tests/fft_tests/test_fft.py
+++ b/tests/cupyx_tests/scipy_tests/fft_tests/test_fft.py
@@ -1713,6 +1713,92 @@ class TestHfft2(unittest.TestCase):
         return _correct_np_dtype(xp, dtype, out)
 
 
+@testing.parameterize(*(
+    testing.product_dict([
+        {'shape': (2, 5), 's': None, 'axes': None},
+        {'shape': (3, 10), 's': (2, 5), 'axes': None},
+        {'shape': (4, 30), 's': None, 'axes': (-2, -1)},
+        {'shape': (5, 50), 's': None, 'axes': (-1, -2)},
+        {'shape': (6, 100), 's': (5, 50), 'axes': (0,)}
+    ],
+        testing.product({'norm': [None, 'backward', 'ortho', 'forward']})
+    )
+))
+@testing.gpu
+class TestHfftn(unittest.TestCase):
+
+    def setUp(self):
+        _skip_forward_backward(self.norm)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose(rtol=4e-4, atol=1e-7, accept_error=ValueError,
+                                 contiguous_check=False)
+    def test_hfftn(self, xp, dtype):
+        x = testing.shaped_random(self.shape, xp, dtype)
+        x_orig = x.copy()
+        out = _fft_module(xp).hfftn(x, s=self.s, axes=self.axes,
+                                    norm=self.norm)
+        testing.assert_array_equal(x, x_orig)
+        return _correct_np_dtype(xp, dtype, out)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose(rtol=4e-4, atol=1e-7, accept_error=ValueError,
+                                 contiguous_check=False)
+    def test_hfftn_overwrite(self, xp, dtype):
+        x = testing.shaped_random(self.shape, xp, dtype)
+        overwrite_kw = {} if xp is np else {'overwrite_x': True}
+        out = _fft_module(xp).hfftn(x, s=self.s, axes=self.axes,
+                                    norm=self.norm, **overwrite_kw)
+        return _correct_np_dtype(xp, dtype, out)
+
+    @testing.with_requires('scipy>=1.4.0')
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose(rtol=4e-4, atol=1e-7, accept_error=ValueError,
+                                 contiguous_check=False)
+    def test_hfftn_backend(self, xp, dtype):
+        x = testing.shaped_random(self.shape, xp, dtype)
+        x_orig = x.copy()
+        backend = 'scipy' if xp is np else cp_fft
+        with scipy_fft.set_backend(backend):
+            out = scipy_fft.hfftn(x, s=self.s, axes=self.axes, norm=self.norm)
+        testing.assert_array_equal(x, x_orig)
+        return _correct_np_dtype(xp, dtype, out)
+
+    @testing.for_all_dtypes(no_complex=True)
+    @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
+                                 contiguous_check=False)
+    def test_ihfftn(self, xp, dtype):
+        x = testing.shaped_random(self.shape, xp, dtype)
+        x_orig = x.copy()
+        out = _fft_module(xp).ihfftn(x, s=self.s, axes=self.axes,
+                                     norm=self.norm)
+        testing.assert_array_equal(x, x_orig)
+        return _correct_np_dtype(xp, dtype, out)
+
+    @testing.for_all_dtypes(no_complex=True)
+    @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
+                                 contiguous_check=False)
+    def test_ihfftn_overwrite(self, xp, dtype):
+        x = testing.shaped_random(self.shape, xp, dtype)
+        overwrite_kw = {} if xp is np else {'overwrite_x': True}
+        out = _fft_module(xp).ihfftn(x, s=self.s, norm=self.norm,
+                                     axes=self.axes, **overwrite_kw)
+        return _correct_np_dtype(xp, dtype, out)
+
+    @testing.with_requires('scipy>=1.4.0')
+    @testing.for_all_dtypes(no_complex=True)
+    @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
+                                 contiguous_check=False)
+    def test_ihfftn_backend(self, xp, dtype):
+        x = testing.shaped_random(self.shape, xp, dtype)
+        x_orig = x.copy()
+        backend = 'scipy' if xp is np else cp_fft
+        with scipy_fft.set_backend(backend):
+            out = scipy_fft.ihfftn(x, s=self.s, axes=self.axes, norm=self.norm)
+        testing.assert_array_equal(x, x_orig)
+        return _correct_np_dtype(xp, dtype, out)
+
+
 @testing.gpu
 @pytest.mark.parametrize('func', [
     cp_fft.fft2, cp_fft.ifft2, cp_fft.rfft2, cp_fft.irfft2,

--- a/tests/cupyx_tests/scipy_tests/fft_tests/test_fft.py
+++ b/tests/cupyx_tests/scipy_tests/fft_tests/test_fft.py
@@ -1633,12 +1633,11 @@ class TestHfft(unittest.TestCase):
         {'shape': (2, 10), 's': (1, 5), 'axes': None},
         {'shape': (2, 30), 's': None, 'axes': (-2, -1)},
         {'shape': (2, 50), 's': None, 'axes': (-1, -2)},
-        {'shape': (2, 100), 's': None, 'axes': (0,)}
+        {'shape': (2, 100), 's': (2, 50), 'axes': (0,)}
     ],
         testing.product({'norm': [None, 'backward', 'ortho', 'forward']})
     )
 ))
-@testing.gpu
 @testing.gpu
 class TestHfft2(unittest.TestCase):
 


### PR DESCRIPTION
Added hfft2, ihfft2, hfftn, and ihfftn from SciPy. Let me know if a conclusive benchmark comparing the performance of `cupyx.scipy.fft.hfft2()`, `cupyx.scipy.fft.ihfft2()`, `cupyx.scipy.fft.hfftn()`, and `cupyx.scipy.fft.ihfftn()` with `scipy.fft.hfft2()`, `scipy.fft.ihfft2()`, `scipy.fft.hfftn()`, and  `scipy.fft.ihfftn()` is necessary