### PR TITLE
Use async memcpy in `ndarray.copy`

### DIFF
--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -515,9 +515,11 @@ cdef class ndarray:
             # it is recommended to set the current device to the device
             # where the src data is physically located.
             runtime.setDevice(self.data.device_id)
-        newarray.data.copy_from_device(x.data, x.nbytes)
-        if runtime._is_hip_environment:
-            runtime.setDevice(dev_id)
+        try:
+            newarray.data.copy_from_device_async(x.data, x.nbytes)
+        finally:
+            if runtime._is_hip_environment:
+                runtime.setDevice(dev_id)
         return newarray
 
     cpdef ndarray view(self, dtype=None):

--- a/tests/cupy_tests/core_tests/test_ndarray.py
+++ b/tests/cupy_tests/core_tests/test_ndarray.py
@@ -158,7 +158,7 @@ class TestNdarrayDeepCopy(unittest.TestCase):
 
 _test_copy_multi_device_with_stream_src = r'''
 extern "C" __global__
-void f(long long *x) {
+void wait_and_write(long long *x) {
   clock_t start = clock();
   clock_t now;
   for (;;) {
@@ -198,8 +198,8 @@ class TestNdarrayCopy(unittest.TestCase):
     @testing.multi_gpu(2)
     def test_copy_multi_device_with_stream(self):
         # Kernel that takes long enough then finally writes values.
-        kern = cupy.RawKernel(_test_copy_multi_device_with_stream_src,
-                              'test_copy_multi_device_with_stream')
+        kern = cupy.RawKernel(
+            _test_copy_multi_device_with_stream_src, 'wait_and_write')
 
         # Allocates a memory and launches the kernel on a device with its
         # stream.

--- a/tests/cupy_tests/core_tests/test_ndarray.py
+++ b/tests/cupy_tests/core_tests/test_ndarray.py
@@ -173,6 +173,7 @@ void f(long long *x) {
 }
 '''
 
+
 @testing.gpu
 class TestNdarrayCopy(unittest.TestCase):
 


### PR DESCRIPTION
Fix #4988.

This PR fixes `ndarray.copy` to use async memcpy so that it respects the current stream.

I'll try to supply an appropriate testing code.