### PR TITLE
Mark `cupyx.jit.rawkernel` as experimental

### DIFF
--- a/cupyx/jit/_compile.py
+++ b/cupyx/jit/_compile.py
@@ -252,7 +252,8 @@ def _transpile_function_internal(
             # Code path for Python versions that support `ast.unparse`.
             for deco in func.decorator_list:
                 deco_code = ast.unparse(deco)
-                if deco_code not in ['rawkernel', 'vectorize']:
+                if not any(word in deco_code
+                           for word in ['rawkernel', 'vectorize']):
                     warnings.warn(
                         f'Decorator {deco_code} may not supported in JIT.',
                         RuntimeWarning)

--- a/cupyx/jit/_interface.py
+++ b/cupyx/jit/_interface.py
@@ -114,6 +114,10 @@ class _JitRawKernel:
 
 
 def rawkernel(mode='cuda'):
+    """A decorator compiles a Python function into CUDA kernel.
+    """
+    cupy._util.experimental('cupyx.jit.rawkernel')
+
     def wrapper(func):
         return _JitRawKernel(func, mode)
     return wrapper

--- a/cupyx/jit/_interface.py
+++ b/cupyx/jit/_interface.py
@@ -1,4 +1,5 @@
 import collections
+import functools
 import warnings
 
 import numpy
@@ -119,7 +120,7 @@ def rawkernel(mode='cuda'):
     cupy._util.experimental('cupyx.jit.rawkernel')
 
     def wrapper(func):
-        return _JitRawKernel(func, mode)
+        return functools.update_wrapper(_JitRawKernel(func, mode), func)
     return wrapper
 
 


### PR DESCRIPTION
Marks `cupyx.jit.rawkernel` as experimental because its interface may change in the future.