### PR TITLE
Give gufunc a name

### DIFF
--- a/cupy/_core/_gufuncs.py
+++ b/cupy/_core/_gufuncs.py
@@ -177,6 +177,7 @@ class _GUFunc:
         self._func = func
         self._signature = signature
         self._default_casting = 'same_kind'
+        self.__name__ = func.__name__
 
         # The following are attributes to avoid applying certain steps
         # when wrapping cupy functions that do some of the gufunc

--- a/cupy/_core/_gufuncs.py
+++ b/cupy/_core/_gufuncs.py
@@ -169,6 +169,9 @@ class _GUFunc:
         supports_out (bool, optional):
             If the wrapped function supports out as one of its kwargs.
             Defaults to `False`.
+        name (str, optional):
+            Name for the GUFunc object. If not specified, ``func``'s name
+            is used.
     '''
 
     def __init__(self, func, signature, **kwargs):
@@ -177,7 +180,7 @@ class _GUFunc:
         self._func = func
         self._signature = signature
         self._default_casting = 'same_kind'
-        self.__name__ = func.__name__
+        self.__name__ = kwargs.get('name', func.__name__)
 
         # The following are attributes to avoid applying certain steps
         # when wrapping cupy functions that do some of the gufunc


### PR DESCRIPTION
Currently if we throw `_GUFunc` to `cupyx.time.repeat` we get this error:
```
AttributeError: '_GUFunc' object has no attribute '__name__'
```
So this PR fixes it. Though, I am not sure if assigning the name of the wrapped function to the `_GUFunc` object is a good idea. Suggestions welcome!