### PR TITLE
Document `cupyx.time.repeat`

### DIFF
--- a/cupyx/time.py
+++ b/cupyx/time.py
@@ -70,7 +70,7 @@ def repeat(
     GPU time is properly recorded by synchronizing internal streams. As a
     result, to time a multi-GPU function all participating devices must be
     passed as the ``devices`` argument so that this helper knows which devices
-    to record. A simple example is given as follows::
+    to record. A simple example is given as follows:
 
     .. code-block:: py
 
@@ -83,6 +83,7 @@ def repeat(
         a = 0.5 - cp.random.random((100,))
         b = cp.random.random((100,))
         print(repeat(f, (a, b), n_repeat=1000))
+
 
     Args:
         func (callable): a callable object to be timed.

--- a/cupyx/time.py
+++ b/cupyx/time.py
@@ -101,7 +101,7 @@ def repeat(
             is stopped and the statistics collected up to the breakpoint is
             reported.
         devices (tuple): a tuple of device IDs (int) that will be timed during
-            the timing test.
+            the timing test. If not given, the current device is used.
 
     Returns:
         :class:`_PerfCaseResult`: an object collecting all test results.

--- a/cupyx/time.py
+++ b/cupyx/time.py
@@ -7,7 +7,17 @@ import cupy as _cupy
 from cupy import _util
 
 
-class _PerfCaseResult(object):
+class _PerfCaseResult:
+    """ An obscure object encompassing timing results recorded by
+    :func:`~cupyx.time.repeat`. Simple statistics can be obtained by converting
+    an instance of this class to a string.
+
+    .. warning::
+        This API is currently experimental and subject to change in future
+        releases.
+
+    """
+
     def __init__(self, name, ts, devices):
         assert ts.ndim == 2
         assert ts.shape[0] == len(devices) + 1
@@ -18,10 +28,12 @@ class _PerfCaseResult(object):
 
     @property
     def cpu_times(self):
+        """ Returns an array of CPU times of size ``n_repeat``. """
         return self._ts[0]
 
     @property
     def gpu_times(self):
+        """ Returns an array of GPU times of size ``n_repeat``. """
         return self._ts[1:]
 
     @staticmethod
@@ -52,6 +64,52 @@ class _PerfCaseResult(object):
 def repeat(
         func, args=(), kwargs={}, n_repeat=10000, *,
         name=None, n_warmup=10, max_duration=_math.inf, devices=None):
+    """ Timing utility for measuring time spent by both CPU and GPU.
+
+    This function is a very convenient helper for setting up a timing test. The
+    GPU time is properly recorded by synchronizing internal streams. As a
+    result, to time a multi-GPU function all participating devices must be
+    passed as the ``devices`` argument so that this helper knows which devices
+    to record. A simple example is given as follows::
+
+    .. code-block:: py
+
+        import cupy as cp
+        from cupyx.time import repeat
+
+        def f(a, b):
+            return 3 * cp.sin(-a) * b
+
+        a = 0.5 - cp.random.random((100,))
+        b = cp.random.random((100,))
+        print(repeat(f, (a, b), n_repeat=1000))
+
+    Args:
+        func (callable): a callable object to be timed.
+        args (tuple): positional argumens to be passed to the callable.
+        kwargs (dict): keyword arguments to be passed to the callable.
+        n_repeat (int): number of times the callable is called. Increasing
+            this value would improve the collected statistics at the cost
+            of longer test time.
+        name (str): the function name to be reported. If not given, the
+            callable's ``__name__`` attribute is used.
+        n_warmup (int): number of times the callable is called. The warm-up
+            runs are not timed.
+        max_duration (float): the maximum time (in seconds) that the entire
+            test can use. If the taken time is longer than this limit, the test
+            is stopped and the statistics collected up to the breakpoint is
+            reported.
+        devices (tuple): a tuple of device IDs (int) that will be timed during
+            the timing test.
+
+    Returns:
+        :class:`_PerfCaseResult`: an object collecting all test results.
+
+    .. warning::
+        This API is currently experimental and subject to change in future
+        releases.
+
+    """
 
     _util.experimental('cupyx.time.repeat')
     if name is None:
@@ -69,9 +127,11 @@ def repeat(
     if not isinstance(n_repeat, int):
         raise ValueError('`n_repeat` should be an integer.')
     if not isinstance(name, str):
-        raise ValueError('`str` should be a string.')
+        raise ValueError('`name` should be a string.')
     if not isinstance(n_warmup, int):
         raise ValueError('`n_warmup` should be an integer.')
+    if not _numpy.isreal(max_duration):
+        raise ValueError('`max_duration` should be given in seconds')
     if not isinstance(devices, tuple):
         raise ValueError('`devices` should be of tuple type')
 

--- a/docs/source/reference/ext.rst
+++ b/docs/source/reference/ext.rst
@@ -9,7 +9,6 @@ CuPy-specific functions are placed under ``cupyx`` namespace.
    :toctree: generated/
    :nosignatures:
 
-   cupyx.time.repeat
    cupyx.rsqrt
    cupyx.scatter_add
    cupyx.scatter_max

--- a/docs/source/reference/ext.rst
+++ b/docs/source/reference/ext.rst
@@ -9,6 +9,7 @@ CuPy-specific functions are placed under ``cupyx`` namespace.
    :toctree: generated/
    :nosignatures:
 
+   cupyx.time.repeat
    cupyx.rsqrt
    cupyx.scatter_add
    cupyx.scatter_max

--- a/docs/source/reference/prof.rst
+++ b/docs/source/reference/prof.rst
@@ -11,6 +11,14 @@ time range
    cupy.prof.TimeRangeDecorator
    cupy.prof.time_range
 
+timing helper
+-------------
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+
+   cupyx.time.repeat
 
 Device synchronization detection
 --------------------------------

--- a/docs/source/reference/prof.rst
+++ b/docs/source/reference/prof.rst
@@ -1,7 +1,7 @@
 Profiling
 =========
 
-time range
+Time range
 ----------
 
 .. autosummary::
@@ -11,7 +11,7 @@ time range
    cupy.prof.TimeRangeDecorator
    cupy.prof.time_range
 
-timing helper
+Timing helper
 -------------
 
 .. autosummary::


### PR DESCRIPTION
Address https://github.com/cupy/cupy/issues/4902#issuecomment-801662941. I think it's better to get this API documented sooner while we plan to expand on the tutorial. It is a very handy API that we keep referring users in the issue tracker to use, so I say we just get it on the docs to have something to refer to. As such, we should backport this PR to v9.