### PR TITLE
Doc: Add links to Anaconda, Gitter, StackOverflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 # CuPy : A NumPy-compatible array library accelerated by CUDA
 
 [![pypi](https://img.shields.io/pypi/v/cupy.svg)](https://pypi.python.org/pypi/cupy)
+[![Anaconda-Server Badge](https://anaconda.org/conda-forge/cupy/badges/version.svg)](https://anaconda.org/conda-forge/cupy)
 [![GitHub license](https://img.shields.io/github/license/cupy/cupy.svg)](https://github.com/cupy/cupy)
 [![coveralls](https://img.shields.io/coveralls/cupy/cupy.svg)](https://coveralls.io/github/cupy/cupy)
 [![Gitter](https://badges.gitter.im/cupy/community.svg)](https://gitter.im/cupy/community)
@@ -36,7 +37,7 @@ Choose the right package for your platform.
 | CUDA 11.2 | `pip install cupy-cuda112`     |
 | ROCm 4.0  | `pip install cupy-rocm-4-0` (experimental; see [docs](https://docs.cupy.dev/en/latest/install.html#using-cupy-on-amd-gpu-experimental) for details) |
 
-See the [Installation Guide](https://docs.cupy.dev/en/stable/install.html) if you are using Conda/Anaconda or to build from source.
+See the [Installation Guide](https://docs.cupy.dev/en/stable/install.html) if you are using Conda/Anaconda or building from source.
 
 ## Run on Docker
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # CuPy : A NumPy-compatible array library accelerated by CUDA
 
 [![pypi](https://img.shields.io/pypi/v/cupy.svg)](https://pypi.python.org/pypi/cupy)
-[![Anaconda-Server Badge](https://anaconda.org/conda-forge/cupy/badges/version.svg)](https://anaconda.org/conda-forge/cupy)
+[![Conda Version](https://img.shields.io/conda/vn/conda-forge/cupy.svg)](https://anaconda.org/conda-forge/cupy)
 [![GitHub license](https://img.shields.io/github/license/cupy/cupy.svg)](https://github.com/cupy/cupy)
 [![coveralls](https://img.shields.io/coveralls/cupy/cupy.svg)](https://coveralls.io/github/cupy/cupy)
 [![Gitter](https://badges.gitter.im/cupy/community.svg)](https://gitter.im/cupy/community)

--- a/docs/source/contribution.rst
+++ b/docs/source/contribution.rst
@@ -15,7 +15,7 @@ There are several ways to contribute to CuPy community:
 
 1. Registering an issue
 2. Sending a pull request (PR)
-3. Sending a question to `CuPy User Group <https://groups.google.com/forum/#!forum/cupy>`_
+3. Sending a question to `CuPy's Gitter channel <https://gitter.im/cupy/community>`_ or `CuPy User Group <https://groups.google.com/forum/#!forum/cupy>`_
 4. Open-sourcing an external example
 5. Writing a post about CuPy
 
@@ -154,7 +154,7 @@ You can contain your thoughts on **how** to realize it into the feature requests
 
 .. warning::
 
-   If you have a question on usages of CuPy, it is highly recommended to send a post to `CuPy User Group <https://groups.google.com/forum/#!forum/cupy>`_ instead of the issue tracker.
+   If you have a question on usages of CuPy, it is highly recommended to send a post to `CuPy's Gitter channel <https://gitter.im/cupy/community>`_ or `CuPy User Group <https://groups.google.com/forum/#!forum/cupy>`_ instead of the issue tracker.
    The issue tracker is not a place to share knowledge on practices.
    We may suggest these places and immediately close how-to question issues.
 

--- a/docs/source/contribution.rst
+++ b/docs/source/contribution.rst
@@ -15,7 +15,7 @@ There are several ways to contribute to CuPy community:
 
 1. Registering an issue
 2. Sending a pull request (PR)
-3. Sending a question to `CuPy's Gitter channel <https://gitter.im/cupy/community>`_ or `CuPy User Group <https://groups.google.com/forum/#!forum/cupy>`_
+3. Sending a question to `CuPy's Gitter channel <https://gitter.im/cupy/community>`_, `CuPy User Group <https://groups.google.com/forum/#!forum/cupy>`_, or `StackOverflow <https://stackoverflow.com/questions/tagged/cupy>`_
 4. Open-sourcing an external example
 5. Writing a post about CuPy
 
@@ -154,7 +154,7 @@ You can contain your thoughts on **how** to realize it into the feature requests
 
 .. warning::
 
-   If you have a question on usages of CuPy, it is highly recommended to send a post to `CuPy's Gitter channel <https://gitter.im/cupy/community>`_ or `CuPy User Group <https://groups.google.com/forum/#!forum/cupy>`_ instead of the issue tracker.
+   If you have a question on usages of CuPy, it is highly recommended to send a post to `CuPy's Gitter channel <https://gitter.im/cupy/community>`_, `CuPy User Group <https://groups.google.com/forum/#!forum/cupy>`_ or `StackOverflow <https://stackoverflow.com/questions/tagged/cupy>`_ instead of the issue tracker.
    The issue tracker is not a place to share knowledge on practices.
    We may suggest these places and immediately close how-to question issues.
 


### PR DESCRIPTION
The Anaconda badge is copied from https://anaconda.org/conda-forge/cupy/badges.

Close #3696.