### PR TITLE
Document `CFunctionAllocator` and `ManagedMemory`

### DIFF
--- a/cupy/cuda/__init__.py
+++ b/cupy/cuda/__init__.py
@@ -108,6 +108,7 @@ from cupy.cuda.memory import MemoryAsync  # NOQA
 from cupy.cuda.memory import MemoryPointer  # NOQA
 from cupy.cuda.memory import MemoryPool  # NOQA
 from cupy.cuda.memory import PythonFunctionAllocator  # NOQA
+from cupy.cuda.memory import CFunctionAllocator  # NOQA
 from cupy.cuda.memory import set_allocator  # NOQA
 from cupy.cuda.memory import get_allocator  # NOQA
 from cupy.cuda.memory import UnownedMemory  # NOQA

--- a/docs/source/reference/cuda.rst
+++ b/docs/source/reference/cuda.rst
@@ -22,6 +22,7 @@ Memory management
    cupy.get_default_pinned_memory_pool
    cupy.cuda.Memory
    cupy.cuda.MemoryAsync
+   cupy.cuda.ManagedMemory
    cupy.cuda.UnownedMemory
    cupy.cuda.PinnedMemory
    cupy.cuda.MemoryPointer
@@ -37,6 +38,7 @@ Memory management
    cupy.cuda.MemoryPool
    cupy.cuda.PinnedMemoryPool
    cupy.cuda.PythonFunctionAllocator
+   cupy.cuda.CFunctionAllocator
 
 
 Memory hook


### PR DESCRIPTION
I think it'd be good to expand the memory management documentation, but before that let's make them appear in the index first.