### PR TITLE
Fix `TestStream` cleanup

### DIFF
--- a/tests/cupy_tests/cuda_tests/test_stream.py
+++ b/tests/cupy_tests/cuda_tests/test_stream.py
@@ -16,10 +16,15 @@ class TestStream(unittest.TestCase):
         if cuda.runtime.is_hip and self.stream_name == 'ptds':
             self.skipTest('HIP does not support PTDS')
 
+        self._prev_stream = cuda.get_current_stream()
+
         if self.stream_name == 'null':
             self.stream = cuda.Stream.null
         elif self.stream_name == 'ptds':
             self.stream = cuda.Stream.ptds
+
+    def tearDown(self):
+        self._prev_stream.use()
 
     @unittest.skipIf(cuda.runtime.is_hip, 'This test is only for CUDA')
     def test_eq_cuda(self):

--- a/tests/cupy_tests/cuda_tests/test_stream.py
+++ b/tests/cupy_tests/cuda_tests/test_stream.py
@@ -22,6 +22,7 @@ class TestStream(unittest.TestCase):
             self.stream = cuda.Stream.null
         elif self.stream_name == 'ptds':
             self.stream = cuda.Stream.ptds
+        self.stream.use()
 
     def tearDown(self):
         self._prev_stream.use()


### PR DESCRIPTION
This seems to be why the copy multigpu error is happening in the CI https://github.com/cupy/cupy/issues/4673.

In these tests, ptds is left as the default stream for the rest of the CI execution, and when the array is copied back, `asarray` ignores the ptds set https://github.com/cupy/cupy/pull/5004, and just starts copying to host before the multidevice copy is over.

If we are right, https://github.com/cupy/cupy/pull/5040 will print 2 in the current stream being used once that test fails.

#5004 fixes the root cause of the error, but this PR is needed to set the CI environment correctly.