### PR TITLE
Fix DLPack lanes

### DIFF
--- a/cupy/_core/include/cupy/dlpack/README.md
+++ b/cupy/_core/include/cupy/dlpack/README.md
@@ -1,4 +1,4 @@
 ## DLPack header
 
 The header `dlpack.h` is downloaded from https://github.com/dmlc/dlpack/blob/main/include/dlpack/dlpack.h.
-The commit is [`a07f962`](https://github.com/dmlc/dlpack/commit/a07f962d446b577adf4baef2b347a0f3a2a20617).
+The commit is [`0ce5e39`](https://github.com/dmlc/dlpack/commit/0ce5e39e741115e32f7ae6914338d3a71a058c2e).

--- a/cupy/_core/include/cupy/dlpack/dlpack.h
+++ b/cupy/_core/include/cupy/dlpack/dlpack.h
@@ -109,6 +109,7 @@ typedef enum {
  *   - float: type_code = 2, bits = 32, lanes=1
  *   - float4(vectorized 4 float): type_code = 2, bits = 32, lanes=4
  *   - int8: type_code = 0, bits = 8, lanes=1
+ *   - std::complex<float>: type_code = 5, bits = 64, lanes = 1
  */
 typedef struct {
   /*!


### PR DESCRIPTION
Follow-up of #4695. This PR contains two fixes:
1.  We need to set `lanes=1` for complex numbers to match the `bits` field (which was set correctly in #4695).
2. We need to reject `lanes>1` following what PyTorch has been doing; the reason our round-trip test passed for the No.1 bug is because we allowed any `lanes` but actually ignored it

related: pytorch/pytorch#55365, https://github.com/dmlc/dlpack/pull/66

cc: @emcastillo @rgommers