### PR TITLE
Disable cuFFT plan cache on CUDA 11.1

### DIFF
--- a/cupy/fft/_cache.pyx
+++ b/cupy/fft/_cache.pyx
@@ -1,6 +1,7 @@
 # distutils: language = c++
 
 import gc
+import warnings
 import weakref
 
 from cupy_backends.cuda.api cimport runtime
@@ -263,6 +264,11 @@ cdef class PlanCache:
     # ---------------------- Python methods ---------------------- #
 
     def __init__(self, Py_ssize_t size=16, Py_ssize_t memsize=-1, int dev=-1):
+        if runtime.runtimeGetVersion() == 11010:
+            warnings.warn('cuFFT plan cache is disabled on CUDA 11.1 due to a '
+                          'known bug, so performance may be degraded. The bug '
+                          'is fixed on CUDA 11.2+.')
+            size = 0
         self._validate_size_memsize(size, memsize)
         self._set_size_memsize(size, memsize)
         self._reset()


### PR DESCRIPTION
Close #5022.

This is a band-aid fix to avoid reusing cuFFT plans on CUDA 11.1 that introduces this regression:

> Plans with primes larger than 127 in FFT size decomposition or FFT size being a prime number bigger than 4093 do not perform calculations on second and subsequent cufftExecute* calls. Regression was introduced in cuFFT 11.1

https://docs.nvidia.com/cuda/archive/11.2.0/cuda-toolkit-release-notes/index.html#cufft-resolved-issues

Thanks @michaelmarty for reporting and @mnicely for pointing out the issue!