### PR TITLE
Revert "Add debug print for flaky test"

### DIFF
--- a/tests/cupy_tests/manipulation_tests/test_basic.py
+++ b/tests/cupy_tests/manipulation_tests/test_basic.py
@@ -79,9 +79,6 @@ class TestBasic(unittest.TestCase):
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_copyto_multigpu(self, xp, dtype):
-        # TODO(kmaehashi): tentatively add print for debug (#4673)
-        print('current stream:', cuda.get_current_stream())
-        print('current device:', cuda.runtime.getDevice())
         with cuda.Device(0):
             a = testing.shaped_arange((2, 3, 4), xp, dtype)
         with cuda.Device(1):


### PR DESCRIPTION
Reverts cupy/cupy#5040

Confirmed that the per thread default stream was accidentally set as the current stream, causing the test to expose a known bug:

```
----------------------------- Captured stdout call -----------------------------
12:57:49 current stream: <Stream 2>
12:57:49 current device: 0
```

