### PR TITLE
Support custom getsource option in CuPy JIT

### DIFF
--- a/cupyx/jit/__init__.py
+++ b/cupyx/jit/__init__.py
@@ -6,3 +6,8 @@ from cupyx.jit._interface import blockIdx  # NOQA
 from cupyx.jit._interface import gridDim  # NOQA
 from cupyx.jit._interface import syncthreads  # NOQA
 from cupyx.jit._interface import shared_memory  # NOQA
+
+
+import inspect as _inspect
+
+_getsource_func = _inspect.getsource  # NOQA

--- a/cupyx/jit/_compile.py
+++ b/cupyx/jit/_compile.py
@@ -8,6 +8,7 @@ import warnings
 
 import numpy
 
+from cupyx import jit
 from cupyx.jit._codeblock import CodeBlock
 from cupy._core import _kernel
 from cupyx.jit import _types
@@ -66,7 +67,7 @@ def transpile(func, attributes, mode, in_types, ret_type):
         raise NotImplementedError('Lambda function is not supported.')
 
     attributes = ' '.join(attributes)
-    source = inspect.getsource(func)
+    source = jit._getsource_func(func)
     lines = source.split('\n')
     num_indent = len(lines[0]) - len(lines[0].lstrip())
     source = '\n'.join([


### PR DESCRIPTION
`inspect.getsource` does not work in Python REPL.
This PR support `cupyx.jit._getsource_func` to set a third-party alternative function of `inspect.getsource`.

Here is a example using `dill.source.getsource` as the `getsource` function.

```py
>>> import cupy
>>> from cupyx import jit
>>> import dill
>>>
>>> jit._getsource_func = dill.source.getsource
>>>
>>> @jit.rawkernel()
... def elementwise_copy(x, y, size):
...     tid = jit.blockIdx.x * jit.blockDim.x + jit.threadIdx.x
...     ntid = jit.gridDim.x * jit.blockDim.x
...     for i in range(tid, size, ntid):
...         y[i] = x[i]
...
/home/asi1024/cupy/cupyx/jit/_interface.py:149: FutureWarning: cupyx.jit.rawkernel is experimental. The interface can change in the future.
  cupy._util.experimental('cupyx.jit.rawkernel')
>>> size = cupy.uint32(2 ** 22)
>>> x = cupy.random.normal(size=(size,), dtype=cupy.float32)
>>> y = cupy.empty((size,), dtype=cupy.float32)
>>>
>>> elementwise_copy((128,), (1024,), (x, y, size))
>>> assert (x == y).all()
>>> print(elementwise_copy.cached_code)

extern "C" __global__ void elementwise_copy(CArray<float, 1, true, true> x, CArray<float, 1, true, true> y, unsigned int size) {
  unsigned int tid;
  unsigned int ntid;
  unsigned int i;
  tid = ((blockIdx.x * blockDim.x) + threadIdx.x);
  ntid = (gridDim.x * blockDim.x);
  for (unsigned int __it = tid, __stop = size, __step = ntid; __step >= 0 ? __it < __stop : __it > __stop; __it += __step) {
    i = __it;
    y[i] = x[i];
  }
}
```