### PR TITLE
CuPy JIT: Fix range type

### DIFF
--- a/examples/jit/reduction_simple.py
+++ b/examples/jit/reduction_simple.py
@@ -18,7 +18,7 @@ def reduction(x, y, size):
 
     if tid == cupy.uint32(0):
         value = cupy.float32(0)
-        for i in range(cupy.uint32(0), ntid, cupy.uint32(1)):  # TODO: Fix
+        for i in range(ntid):
             value += smem[i]
         y[0] = value
 

--- a/tests/cupy_tests/functional_tests/test_vectorize.py
+++ b/tests/cupy_tests/functional_tests/test_vectorize.py
@@ -392,8 +392,9 @@ class TestVectorizeStmts(unittest.TestCase):
         x = xp.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
         return f(x)
 
+    @testing.for_dtypes('qQ')
     @testing.numpy_cupy_array_equal()
-    def test_for(self, xp):
+    def test_for(self, xp, dtype):
         def func_for(x):
             y = 0
             for i in range(x):
@@ -401,7 +402,7 @@ class TestVectorizeStmts(unittest.TestCase):
             return y
 
         f = xp.vectorize(func_for)
-        x = xp.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+        x = xp.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], dtype)
         return f(x)
 
     @testing.numpy_cupy_array_equal()


### PR DESCRIPTION
Fix the iteration dtype generated from `range(start, stop, step)`.

Current master:
- `start`, `stop` and `step` must have the same integer dtype (raises `TypeError` otherwise).

This PR
- `start`, `stop` and `step` can be different integer dtype.
- iteration dtype is inferred from `stop`.