### PR TITLE
Point to the correct numpy random docs

### DIFF
--- a/cupy/random/_generator_api.pyx
+++ b/cupy/random/_generator_api.pyx
@@ -117,8 +117,7 @@ class Generator:
             cupy.ndarray: Samples uniformly drawn from the [0, 1) interval
 
         .. seealso::
-            - :meth:`numpy.random.Generator.random
-              <numpy.random.Generator.random>`
+            - :meth:`numpy.random.Generator.random`
         """
         cdef ndarray y
 
@@ -162,8 +161,7 @@ class Generator:
             Otherwise, it is the array whose shape specified by ``size``.
 
         .. seealso::
-            - :meth:`numpy.random.Generator.integers
-              <numpy.random.Generator.integers>`
+            - :meth:`numpy.random.Generator.integers`
         """
         cdef ndarray y
         if high is None:
@@ -225,8 +223,7 @@ class Generator:
             cupy.ndarray: Samples drawn from the beta distribution.
 
         .. seealso::
-            :meth:`numpy.random.Generator.beta
-            <numpy.random.generator.Generator.beta>`
+            :meth:`numpy.random.Generator.beta`
         """
         cdef ndarray y
         y = ndarray(size if size is not None else (), numpy.float64)
@@ -255,8 +252,7 @@ class Generator:
             cupy.ndarray: Samples drawn from the exponential distribution.
 
         .. seealso::
-            :meth:`numpy.random.Generator.exponential
-            <numpy.random.generator.Generator.exponential>`
+            :meth:`numpy.random.Generator.exponential`
         """
         return self.standard_exponential(size) * scale
 
@@ -285,8 +281,7 @@ class Generator:
                 distribution.
 
         .. seealso::
-            :meth:`numpy.random.Generator.standard_exponential
-            <numpy.random.generator.Generator.standard_exponential>`
+            :meth:`numpy.random.Generator.standard_exponential`
         """
         cdef ndarray y
 
@@ -325,8 +320,7 @@ class Generator:
             cupy.ndarray: Samples drawn from the poisson distribution.
 
         .. seealso::
-            :meth:`numpy.random.Generator.poisson
-            <numpy.random.generator.Generator.poisson>`
+            :meth:`numpy.random.Generator.poisson`
         """
         cdef ndarray y
         y = ndarray(size if size is not None else (), numpy.int64)
@@ -351,9 +345,7 @@ class Generator:
             cupy.ndarray: Samples drawn from the standard normal distribution.
 
         .. seealso::
-            - :meth:`numpy.random.Generator.standard_normal
-              <numpy.random.Generator.standard_normal>`
-
+            - :meth:`numpy.random.Generator.standard_normal`
         """
         cdef ndarray y
 
@@ -394,8 +386,7 @@ class Generator:
                 If ``None``, a zero-dimensional array is generated.
 
         .. seealso::
-            - :meth:`numpy.random.Generator.gamma
-              <numpy.random.Generator.gamma>`
+            - :meth:`numpy.random.Generator.gamma`
         """
         if size is None:
             size = cupy.broadcast(shape, scale).shape
@@ -423,8 +414,7 @@ class Generator:
                 to this array
 
         .. seealso::
-            - :meth:`numpy.random.Generator.standard_gamma
-              <numpy.random.Generator.standard_gamma>`
+            - :meth:`numpy.random.Generator.standard_gamma`
         """
         cdef ndarray y
         cdef ndarray shape_arr

--- a/cupy/random/_generator_api.pyx
+++ b/cupy/random/_generator_api.pyx
@@ -115,6 +115,10 @@ class Generator:
 
         Returns:
             cupy.ndarray: Samples uniformly drawn from the [0, 1) interval
+
+        .. seealso::
+            - :meth:`numpy.random.Generator.random
+              <numpy.random.Generator.random>`
         """
         cdef ndarray y
 
@@ -156,6 +160,10 @@ class Generator:
             it is single integer sampled.
             If size is integer, it is the 1D-array of length ``size`` element.
             Otherwise, it is the array whose shape specified by ``size``.
+
+        .. seealso::
+            - :meth:`numpy.random.Generator.integers
+              <numpy.random.Generator.integers>`
         """
         cdef ndarray y
         if high is None:
@@ -326,7 +334,10 @@ class Generator:
         return y
 
     def standard_normal(self, size=None, dtype=numpy.float64, out=None):
-        """Returns an array of samples drawn from the standard normal distribution.
+        """Standard normal distribution.
+
+        Returns an array of samples drawn from the standard normal
+        distribution.
 
         Args:
             size (int or tuple of ints): The shape of the array. If ``None``, a
@@ -339,7 +350,9 @@ class Generator:
         Returns:
             cupy.ndarray: Samples drawn from the standard normal distribution.
 
-        .. seealso:: :func:`numpy.random.standard_normal`
+        .. seealso::
+            - :meth:`numpy.random.Generator.standard_normal
+              <numpy.random.Generator.standard_normal>`
 
         """
         cdef ndarray y
@@ -362,7 +375,14 @@ class Generator:
         return y
 
     def gamma(self, shape, scale=1.0, size=None):
-        """Returns an array of samples drawn from a gamma distribution.
+        """Gamma distribution.
+
+        Returns an array of samples drawn from the gamma distribution. Its
+        probability density function is defined as
+
+        .. math::
+           f(x) = \\frac{1}{\\Gamma(k)\\theta^k}x^{k-1}e^{-x/\\theta}.
+
 
         Args:
             shape (float or array_like of float): The shape of the
@@ -374,8 +394,8 @@ class Generator:
                 If ``None``, a zero-dimensional array is generated.
 
         .. seealso::
-            - :func:`cupy.random.gamma` for full documentation
-            - :meth:`numpy.random.Generator.gamma`
+            - :meth:`numpy.random.Generator.gamma
+              <numpy.random.Generator.gamma>`
         """
         if size is None:
             size = cupy.broadcast(shape, scale).shape
@@ -384,7 +404,14 @@ class Generator:
         return y
 
     def standard_gamma(self, shape, size=None, dtype=numpy.float64, out=None):
-        """Returns an array of samples drawn from a standard gamma distribution.
+        """Standard gamma distribution.
+
+        Returns an array of samples drawn from the standard gamma distribution.
+        Its probability density function is defined as
+
+        .. math::
+           f(x) = \\frac{1}{\\Gamma(k)}x^{k-1}e^{-x}.
+
 
         Args:
             shape (float or array_like of float): The shape of the
@@ -396,8 +423,8 @@ class Generator:
                 to this array
 
         .. seealso::
-            - :func:`cupy.random.standard_gamma` for full documentation
-            - :meth:`numpy.random.Generator.standard_gamma`
+            - :meth:`numpy.random.Generator.standard_gamma
+              <numpy.random.Generator.standard_gamma>`
         """
         cdef ndarray y
         cdef ndarray shape_arr

--- a/cupy/random/_generator_api.pyx
+++ b/cupy/random/_generator_api.pyx
@@ -276,8 +276,9 @@ class Generator:
             cupy.ndarray: Samples drawn from the standard exponential
                 distribution.
 
-        .. seealso:: :meth:`numpy.random.standard_exponential
-                     <numpy.random.mtrand.RandomState.standard_exponential>`
+        .. seealso::
+            :meth:`numpy.random.Generator.standard_exponential
+            <numpy.random.generator.Generator.standard_exponential>`
         """
         cdef ndarray y
 


### PR DESCRIPTION
By just copy-pasting the docstrings of random functions, the reference pointers were to the legacy API ...