### PR TITLE
Xfail tests for random distribution generator under HIP/ROCm

### DIFF
--- a/tests/cupy_tests/random_tests/test_distributions.py
+++ b/tests/cupy_tests/random_tests/test_distributions.py
@@ -1,8 +1,10 @@
 import unittest
 
 import numpy
+import pytest
 
 import cupy
+from cupy.cuda import runtime
 from cupy.random import _distributions
 from cupy import testing
 
@@ -191,6 +193,8 @@ class TestDistributionsGamma(unittest.TestCase):
 
     @cupy.testing.for_dtypes_combination(
         _float_dtypes, names=['shape_dtype', 'scale_dtype'])
+    @pytest.mark.xfail(
+        runtime.is_hip, reason='Generator API not supported in HIP')
     def test_gamma_generator(self, shape_dtype, scale_dtype):
         self.check_distribution(cupy.random.default_rng().gamma,
                                 shape_dtype, scale_dtype)
@@ -634,6 +638,8 @@ class TestDistributionsStandardGamma(RandomDistributionsTestCase):
 
     @cupy.testing.for_float_dtypes('dtype', no_float16=True)
     @cupy.testing.for_float_dtypes('shape_dtype')
+    @pytest.mark.xfail(
+        runtime.is_hip, reason='Generator API not supported in HIP')
     def test_standard_gamma_generator(self, shape_dtype, dtype):
         shape = numpy.ones(self.shape_shape, dtype=shape_dtype)
         self.check_generator_distribution('standard_gamma',


### PR DESCRIPTION
Rel #4132.

This PR xfails tests for some distributions of `cupy.random.Generator` that are not supported under HIP/ROCm.

```
RuntimeError: Generator API not supported in HIP, please use the legacy one.
```