### PR TITLE
Compile with SASS for CUDA versions >= 11.1

### DIFF
--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -490,7 +490,8 @@ def _compile_with_cache_cuda(
 
     # For hipRTC, arch is ignored
     # Get it here to invalidate previously generated cache
-    options += (_get_arch_for_options(arch=arch, jitify=jitify),)
+    if backend == 'nvrtc':
+        options += (_get_arch_for_options(arch=arch, jitify=jitify),)
 
     key_src = '%s %s %s %s' % (env, base, source, extra_source)
     key_src = key_src.encode('utf-8')

--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -265,8 +265,9 @@ def compile_using_nvrtc(source, options=(), arch=None, filename='kern.cu',
         else:
             headers = include_names = ()
 
-        arch_opt, method = _get_arch_for_options_for_nvrtc(arch, jitify)
-        options += (arch_opt,)
+        if not runtime.is_hip:
+            arch_opt, method = _get_arch_for_options_for_nvrtc(arch, jitify)
+            options += (arch_opt,)
 
         prog = _NVRTCProgram(source, cu_path, headers, include_names,
                              name_expressions=name_expressions, method=method)

--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -151,7 +151,7 @@ def _get_arch():
         return min(arch, nvrtc_max_compute_capability)
 
 
-def _get_arch_for_options_for_nvrtc(arch=None, jitify=False):
+def _get_arch_for_options_for_nvrtc(arch=None):
     # NVRTC in CUDA 11.3+ generates PTX that cannot be run an earlier driver
     # version than the one included in the used CUDA version, as
     # documented in:
@@ -266,7 +266,7 @@ def compile_using_nvrtc(source, options=(), arch=None, filename='kern.cu',
             headers = include_names = ()
 
         if not runtime.is_hip:
-            arch_opt, method = _get_arch_for_options_for_nvrtc(arch, jitify)
+            arch_opt, method = _get_arch_for_options_for_nvrtc(arch)
             options += (arch_opt,)
 
         prog = _NVRTCProgram(source, cu_path, headers, include_names,
@@ -490,7 +490,7 @@ def _compile_with_cache_cuda(
         raise ValueError('jitify only works with NVRTC')
 
     env = ((arch, options, _get_nvrtc_version(), backend)
-           + _get_arch_for_options_for_nvrtc(arch, jitify))
+           + _get_arch_for_options_for_nvrtc(arch))
     base = _empty_file_preprocess_cache.get(env, None)
     if base is None:
         # This is for checking NVRTC/NVCC compiler internal version

--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -273,6 +273,8 @@ def compile_using_nvrtc(source, options=(), arch=None, filename='kern.cu',
             raise
         return ptx, mapping
 
+    options += (_get_arch_for_options(arch=arch, jitify=jitify),)
+
     if not cache_in_memory:
         with tempfile.TemporaryDirectory() as root_dir:
             cu_path = os.path.join(root_dir, filename)
@@ -487,11 +489,6 @@ def _compile_with_cache_cuda(
         # This is for checking NVRTC/NVCC compiler internal version
         base = _preprocess('', options, arch, backend)
         _empty_file_preprocess_cache[env] = base
-
-    # For hipRTC, arch is ignored
-    # Get it here to invalidate previously generated cache
-    if backend == 'nvrtc':
-        options += (_get_arch_for_options(arch=arch, jitify=jitify),)
 
     key_src = '%s %s %s %s' % (env, base, source, extra_source)
     key_src = key_src.encode('utf-8')

--- a/tests/cupy_tests/core_tests/test_raw.py
+++ b/tests/cupy_tests/core_tests/test_raw.py
@@ -16,6 +16,7 @@ from cupy import _util
 from cupy._core import _accelerator
 from cupy.cuda import compiler
 from cupy.cuda import memory
+from cupy_backends.cuda.api import driver
 
 
 _test_source1 = r'''
@@ -633,7 +634,8 @@ class TestRaw(unittest.TestCase):
         N = 10
         inner_chunk = 2
         x = cupy.zeros((N,), dtype=cupy.float32)
-        if self.backend == 'nvrtc' and not cupy.cuda.runtime.is_hip:
+        if (self.backend == 'nvrtc' and not cupy.cuda.runtime.is_hip
+                and driver.get_build_version() < 11010):
             # raised when calling ls.complete()
             error = cupy.cuda.driver.CUDADriverError
         else:  # nvcc, hipcc, hiprtc


### PR DESCRIPTION
This is needed to allow things like running code generated with cuda 11.3 and run it in an older driver although the driver is marked as  "supported" by [nvidia](https://docs.nvidia.com/cuda/nvrtc/index.html#versioning):

> the more recent NVRTC library1. However, the more recent NVRTC library may generate PTX with a version that is not accepted by the CUDA Driver API functions of an older CUDA driver, as explained in the CUDA Compatibility document. 
Some approaches to resolving this issue:
Install a more recent CUDA driver that is compatible with the CUDA toolkit containing the NVRTC library being used.
Compile directly to SASS instead of PTX with NVRTC (see CUDA Compatibility document).

If we compile CuPy with cuda 11.3 and run it with an old driver, we will get the invalid PTX errors. 
by compiling using cubins everything will work fine.

Thanks to @leofang for implementing the initial support

Closes #4591 