### PR TITLE
Adjust PATH when preloading to load cuDNN v8 correctly on Windows

### DIFF
--- a/cupy/_environment.py
+++ b/cupy/_environment.py
@@ -315,8 +315,14 @@ def _preload_libraries():
                 _log('Rejected candidate (not found): {}'.format(libpath))
                 continue
 
-            _log('Trying to load {}'.format(libpath))
             try:
+                if sys.platform == 'win32':
+                    # This is needed to load cuDNN v8 on Windows.
+                    libpath_dir = os.path.dirname(libpath)
+                    _log(f'Adding to PATH: {libpath_dir}')
+                    os.environ['PATH'] = (libpath_dir + os.pathsep +
+                                          os.environ.get('PATH', ''))
+                _log(f'Trying to load {libpath}')
                 # Keep reference to the preloaded module.
                 _preload_libs[lib] = (libpath, ctypes.CDLL(libpath))
                 _log('Loaded')


### PR DESCRIPTION
Closes #5080
Unlike cuDNN v8 for Linux, cuDNN v8 for Windows requires the library path to be in the PATH.
This does not affect wheels for CUDA 10.0 or earlier as they are pinned to cuDNN v7.

I confirmed that this PR now correctly preloads cuDNN v8 on Windows with Python 3.6/3.7/3.8/3.9.