### PR TITLE
Revise ROCm doc

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -443,10 +443,10 @@ The following features are not available due to the limitation of ROCm or becaus
 * Atomic addition in FP16 (``cupy.ndarray.scatter_add`` and ``cupyx.scatter_add``)
 * Multi-GPU FFT and FFT callback
 * Some random number generation algorithms
+* Several options in RawKernel/RawModule APIs: Jitify, dynamic parallelism
 
 The following features are not yet supported:
 
-* Several options in RawKernel/RawModule APIs: Jitify, dynamic parallelism
 * Sparse matrices (``cupyx.scipy.sparse``)
 * cuDNN (hipDNN)
 * Hermitian/symmetric eigenvalue solver (``cupy.linalg.eigh``)


### PR DESCRIPTION
This is just a nitpick PR following #5107:
- Supporting Jitify is not possible due to hiprtc's limitation. Plus I doubt we need Jitify once hiprtc fixes its support for `-I`.
- Dynamical parallelism on ROCm is hardware-specific. There's a device attribute or property that we can query. (My recollection is gfx906 does not support it, but I could be wrong.)