### PR TITLE
Bugfix for typing rule of CuPy JIT

### DIFF
--- a/cupyx/jit/_typerules.py
+++ b/cupyx/jit/_typerules.py
@@ -140,7 +140,7 @@ def get_ctype_from_scalar(mode, x):
     raise NotImplementedError(f'{x} is not scalar object.')
 
 
-_cuda_types = '?bhilBHILefdFD'
+_cuda_types = '?bBhHiIlLefdFD'
 
 
 def _cuda_can_cast(from_dtype, to_dtype):


### PR DESCRIPTION
`cupy.add(int64, int64)` unexpectedly outputs `uint8` value in CuPy JIT `cuda` mode.

Reproducer:
```py
import numpy
import cupy
from cupyx import jit


size = 256

@jit.rawkernel()
def f(x, z):
    tid = jit.threadIdx.x + jit.blockIdx.x * jit.blockDim.x
    partial_sum = jit.shared_memory(numpy.int64, size)
    partial_sum[jit.threadIdx.x] = x[tid]
    jit.syncthreads()
    s = jit.blockDim.x >> 1
    while s > 0:
        if jit.threadIdx.x < s:
            partial_sum[jit.threadIdx.x] += partial_sum[jit.threadIdx.x + s]
        jit.syncthreads()
        s = s >> 1

    if jit.threadIdx.x == 0:
        z[jit.blockIdx.x] = partial_sum[0]


x = cupy.arange(32 * size)
z = cupy.arange(32)
f[32, size](x, z)
print(z)
```

master:
```py
[128 128 128 128 128 128 128 128 128 128 128 128 128 128 128 128 128 128
 128 128 128 128 128 128 128 128 128 128 128 128 128 128]
```

This PR:
```py
[  32640   98176  163712  229248  294784  360320  425856  491392  556928
  622464  688000  753536  819072  884608  950144 1015680 1081216 1146752
 1212288 1277824 1343360 1408896 1474432 1539968 1605504 1671040 1736576
 1802112 1867648 1933184 1998720 2064256]
```