### PR TITLE
Use current device in tests

### DIFF
--- a/tests/cupy_tests/cuda_tests/test_device.py
+++ b/tests/cupy_tests/cuda_tests/test_device.py
@@ -127,6 +127,7 @@ class TestDeviceHandles(unittest.TestCase):
         handles = [func(), None, None]
 
         def _subthread():
+            cupy.cuda.Device().use()
             handles[1] = func()
             handles[2] = func()
 

--- a/tests/cupy_tests/cuda_tests/test_driver.py
+++ b/tests/cupy_tests/cuda_tests/test_driver.py
@@ -19,6 +19,7 @@ class TestDriver(unittest.TestCase):
 
         def f(self):
             self._result0 = driver.ctxGetCurrent()
+            cupy.cuda.Device().use()
             cupy.arange(1)
             self._result1 = driver.ctxGetCurrent()
 

--- a/tests/cupy_tests/cuda_tests/test_memory.py
+++ b/tests/cupy_tests/cuda_tests/test_memory.py
@@ -773,6 +773,7 @@ class TestAllocator(unittest.TestCase):
 
     def test_allocator_thread_local(self):
         def thread_body(self):
+            cupy.cuda.Device().use()
             new_pool = memory.MemoryPool()
             with cupy.cuda.using_allocator(new_pool.malloc):
                 assert memory.get_allocator() == new_pool.malloc
@@ -809,6 +810,7 @@ class TestAllocator(unittest.TestCase):
         new_pool = memory.MemoryPool()
 
         def job(stream):
+            cupy.cuda.Device().use()
             with cupy.cuda.using_allocator(new_pool.malloc):
                 with stream:
                     arr = cupy.arange(16)

--- a/tests/cupy_tests/fft_tests/test_cache.py
+++ b/tests/cupy_tests/fft_tests/test_cache.py
@@ -162,6 +162,7 @@ class TestPlanCache(unittest.TestCase):
         def thread_show_plan_cache_info(queue):
             # allow output from another thread to be accessed by the
             # main thread
+            cupy.cuda.Device().use()
             stdout = intercept_stdout(config.show_plan_cache_info)
             queue.put(stdout)
 
@@ -176,6 +177,7 @@ class TestPlanCache(unittest.TestCase):
         assert stdout.count('uninitialized') == n_devices
 
         def thread_init_caches(gpus, queue):
+            cupy.cuda.Device().use()
             init_caches(gpus)
             thread_show_plan_cache_info(queue)
 

--- a/tests/cupy_tests/fft_tests/test_fft.py
+++ b/tests/cupy_tests/fft_tests/test_fft.py
@@ -1360,6 +1360,7 @@ class TestThreading:
         from cupy.cuda.cufft import get_current_plan
 
         def thread_get_curr_plan():
+            cupy.cuda.Device().use()
             return get_current_plan()
 
         new_thread = threading.Thread(target=thread_get_curr_plan)
@@ -1371,6 +1372,7 @@ class TestThreading:
         a = cupy.arange(100, dtype=cupy.complex64).reshape(10, 10)
 
         def thread_do_fft():
+            cupy.cuda.Device().use()
             b = cupy.fft.fftn(a)
             return b
 

--- a/tests/cupy_tests/random_tests/test_generator.py
+++ b/tests/cupy_tests/random_tests/test_generator.py
@@ -1279,15 +1279,26 @@ class TestRandomStateThreadSafe(unittest.TestCase):
         cupy.random.reset_states()
 
     def test_get_random_state_thread_safe(self):
+        def _f(func, args=()):
+            cupy.cuda.Device().use()
+            func(*args)
+
         seed = 10
         threads = [
-            threading.Thread(target=lambda: cupy.random.seed(seed)),
-            threading.Thread(target=lambda: cupy.random.get_random_state()),
-            threading.Thread(target=lambda: cupy.random.get_random_state()),
-            threading.Thread(target=lambda: cupy.random.get_random_state()),
-            threading.Thread(target=lambda: cupy.random.get_random_state()),
-            threading.Thread(target=lambda: cupy.random.get_random_state()),
-            threading.Thread(target=lambda: cupy.random.get_random_state()),
+            threading.Thread(
+                target=_f, args=(cupy.random.seed, (seed,))),
+            threading.Thread(
+                target=_f, args=(cupy.random.get_random_state,)),
+            threading.Thread(
+                target=_f, args=(cupy.random.get_random_state,)),
+            threading.Thread(
+                target=_f, args=(cupy.random.get_random_state,)),
+            threading.Thread(
+                target=_f, args=(cupy.random.get_random_state,)),
+            threading.Thread(
+                target=_f, args=(cupy.random.get_random_state,)),
+            threading.Thread(
+                target=_f, args=(cupy.random.get_random_state,)),
         ]
 
         for t in threads:
@@ -1301,10 +1312,16 @@ class TestRandomStateThreadSafe(unittest.TestCase):
         assert actual == expected
 
     def test_set_random_state_thread_safe(self):
+        def _f(func, args=()):
+            cupy.cuda.Device().use()
+            func(*args)
+
         rs = cupy.random.RandomState()
         threads = [
-            threading.Thread(target=lambda: cupy.random.set_random_state(rs)),
-            threading.Thread(target=lambda: cupy.random.set_random_state(rs)),
+            threading.Thread(
+                target=_f, args=(cupy.random.set_random_state, (rs,))),
+            threading.Thread(
+                target=_f, args=(cupy.random.set_random_state, (rs,))),
         ]
 
         for t in threads:

--- a/tests/cupy_tests/random_tests/test_generator_api.py
+++ b/tests/cupy_tests/random_tests/test_generator_api.py
@@ -251,15 +251,20 @@ class TestRandom(InvalidOutsMixin, GeneratorTestCase):
 class TestRandomStateThreadSafe(unittest.TestCase):
 
     def test_default_rng_thread_safe(self):
+        def _f(func, args=()):
+            cupy.cuda.Device().use()
+            func(*args)
+
         seed = 10
         threads = [
-            threading.Thread(target=lambda: cupy.random.default_rng(seed)),
-            threading.Thread(target=lambda: cupy.random.default_rng()),
-            threading.Thread(target=lambda: cupy.random.default_rng()),
-            threading.Thread(target=lambda: cupy.random.default_rng()),
-            threading.Thread(target=lambda: cupy.random.default_rng()),
-            threading.Thread(target=lambda: cupy.random.default_rng()),
-            threading.Thread(target=lambda: cupy.random.default_rng()),
+            threading.Thread(
+                target=_f, args=(cupy.random.default_rng, (seed,))),
+            threading.Thread(target=_f, args=(cupy.random.default_rng)),
+            threading.Thread(target=_f, args=(cupy.random.default_rng)),
+            threading.Thread(target=_f, args=(cupy.random.default_rng)),
+            threading.Thread(target=_f, args=(cupy.random.default_rng)),
+            threading.Thread(target=_f, args=(cupy.random.default_rng)),
+            threading.Thread(target=_f, args=(cupy.random.default_rng)),
         ]
 
         for t in threads:


### PR DESCRIPTION
Several tests are not resetting the current device after launching a thread.
I hope this closes https://github.com/cupy/cupy/issues/5124...