### PR TITLE
Fix docs of scatter_add

### DIFF
--- a/cupyx/_scatter.py
+++ b/cupyx/_scatter.py
@@ -45,11 +45,6 @@ def scatter_add(a, slices, value):
         :func:`scatter_add` does not raise an error when indices exceed size of
         axes. Instead, it wraps indices.
 
-    .. note::
-        As of v4, this function is moved from ``cupy`` package to ``cupyx``
-        package.
-        ``cupy.scatter_add`` is still available for backward compatibility.
-
     .. seealso:: :meth:`numpy.ufunc.at`.
 
     """


### PR DESCRIPTION
`cupy.scatter_add` has been removed in CuPy v8 but docs were not updated.