### PR TITLE
Update coo.py

### DIFF
--- a/cupyx/scipy/sparse/coo.py
+++ b/cupyx/scipy/sparse/coo.py
@@ -31,7 +31,7 @@ class coo_matrix(sparse_data._data_matrix):
         It constructs an empty matrix whose shape is ``(M, N)``. Default dtype
         is float64.
 
-    ``coo_matrix((data, (row, col))``
+    ``coo_matrix((data, (row, col)))``
         All ``data``, ``row`` and ``col`` are one-dimenaional
         :class:`cupy.ndarray`.
 

--- a/cupyx/scipy/sparse/csc.py
+++ b/cupyx/scipy/sparse/csc.py
@@ -24,7 +24,7 @@ class csc_matrix(compressed._compressed_sparse_matrix):
     ``csc_matrix((M, N), [dtype])``
         It constructs an empty matrix whose shape is ``(M, N)``. Default dtype
         is float64.
-    ``csc_matrix((data, (row, col))``
+    ``csc_matrix((data, (row, col)))``
         All ``data``, ``row`` and ``col`` are one-dimenaional
         :class:`cupy.ndarray`.
     ``csc_matrix((data, indices, indptr))``

--- a/cupyx/scipy/sparse/csr.py
+++ b/cupyx/scipy/sparse/csr.py
@@ -34,7 +34,7 @@ class csr_matrix(compressed._compressed_sparse_matrix):
     ``csr_matrix((M, N), [dtype])``
         It constructs an empty matrix whose shape is ``(M, N)``. Default dtype
         is float64.
-    ``csr_matrix((data, (row, col))``
+    ``csr_matrix((data, (row, col)))``
         All ``data``, ``row`` and ``col`` are one-dimenaional
         :class:`cupy.ndarray`.
     ``csr_matrix((data, indices, indptr))``


### PR DESCRIPTION
The documentation shows an inconsistent number of brackets in the dimensionality section of sparse matrix formation.