### PR TITLE
Fix TypeError in `svds`

### DIFF
--- a/cupyx/scipy/sparse/linalg/_eigen.py
+++ b/cupyx/scipy/sparse/linalg/_eigen.py
@@ -344,7 +344,7 @@ def svds(a, k=6, *, ncv=None, tol=0, which='LM', maxiter=None,
     cond = factor[t] * numpy.finfo(t).eps
     cutoff = cond * cupy.max(w)
     above_cutoff = (w > cutoff)
-    n_large = above_cutoff.sum()
+    n_large = above_cutoff.sum().item()
     s = cupy.zeros_like(w)
     s[:n_large] = cupy.sqrt(w[above_cutoff])
     if not return_singular_vectors:

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
@@ -169,6 +169,10 @@ class TestEigsh:
             a = sp.linalg.aslinearoperator(a)
         return self._test_eigsh(a, xp, sp)
 
+    @pytest.mark.xfail(
+        reason='eigsh works wrong (#5001)',
+        raises=AssertionError,
+    )
     @testing.for_dtypes('fdFD')
     @testing.numpy_cupy_allclose(rtol=tol, atol=tol, sp_name='sp')
     def test_dense_low_rank(self, dtype, xp, sp):
@@ -250,6 +254,10 @@ class TestSvds:
             a = sp.linalg.aslinearoperator(a)
         return self._test_svds(a, xp, sp)
 
+    @pytest.mark.xfail(
+        reason='eigsh works wrong (#5001)',
+        raises=AssertionError,
+    )
     @testing.for_dtypes('fdFD')
     @testing.numpy_cupy_allclose(rtol=tol, atol=tol, sp_name='sp')
     def test_dense_low_rank(self, dtype, xp, sp):

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
@@ -238,6 +238,18 @@ class TestSvds:
             a = sp.linalg.aslinearoperator(a)
         return self._test_svds(a, xp, sp)
 
+    @testing.for_dtypes('fdFD')
+    @testing.numpy_cupy_allclose(rtol=tol, atol=tol, sp_name='sp')
+    def test_dense_low_rank(self, dtype, xp, sp):
+        m, n = self.shape
+        rank = 5
+        # density is ignored.
+        a = testing.shaped_random((m, rank), xp, dtype=dtype, scale=1).dot(
+            testing.shaped_random((rank, n), xp, dtype=dtype, scale=1))
+        if self.use_linear_operator:
+            a = sp.linalg.aslinearoperator(a)
+        return self._test_svds(a, xp, sp)
+
     def test_invalid(self):
         if self.use_linear_operator is True:
             raise unittest.SkipTest

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
@@ -169,6 +169,18 @@ class TestEigsh:
             a = sp.linalg.aslinearoperator(a)
         return self._test_eigsh(a, xp, sp)
 
+    @testing.for_dtypes('fdFD')
+    @testing.numpy_cupy_allclose(rtol=tol, atol=tol, sp_name='sp')
+    def test_dense_low_rank(self, dtype, xp, sp):
+        n = self.n
+        rank = 5
+        # density is ignored.
+        a = testing.shaped_random((n, rank), xp, dtype=dtype, scale=1).dot(
+            testing.shaped_random((rank, n), xp, dtype=dtype, scale=1))
+        if self.use_linear_operator:
+            a = sp.linalg.aslinearoperator(a)
+        return self._test_eigsh(a, xp, sp)
+
     def test_invalid(self):
         if self.use_linear_operator is True:
             raise unittest.SkipTest


### PR DESCRIPTION
Fix TypeError reported at #5000.  Because of inaccurate `eigsh`, the added tests fail at `numpy_cupy_allclose`.