### PR TITLE
Fix PTDS destruction

### DIFF
--- a/cupy/cuda/stream.pyx
+++ b/cupy/cuda/stream.pyx
@@ -339,7 +339,7 @@ class Stream(BaseStream):
         if is_shutting_down():
             return
         tls = _ThreadLocal.get()
-        if self.ptr:
+        if self.ptr and self.ptr != runtime.streamPerThread:
             current_ptr = <intptr_t>tls.get_current_stream_ptr()
             if <intptr_t>self.ptr == current_ptr:
                 tls.set_current_stream(self.null)


### PR DESCRIPTION
Closes #5145 

The actual stream tests show this error, but due to [Python ignoring exceptions in `__del__`](http://docs.python.org/3/reference/datamodel.html#object.__del__) methods they never failed when they should have done it :).

> Warning: Due to the precarious circumstances under which __del__() methods are invoked, exceptions that occur during their execution are ignored, and a warning is printed to sys.stderr instead. Also, when __del__() is invoked in response to a module being deleted (e.g., when execution of the program is done), other globals referenced by the __del__() method may already have been deleted or in the process of being torn down (e.g. the import machinery shutting down). For this reason, __del__() methods should do the absolute minimum needed to maintain external invariants. Starting with version 1.5, Python guarantees that globals whose name begins with a single underscore are deleted from their module before other globals are deleted; if no other references to such globals exist, this may help in assuring that imported modules are still available at the time when the __del__() method is called.

