### PR TITLE
Support cuSPARSELt v0.1.0

### DIFF
--- a/cupy_backends/cuda/cupy_cusparselt.h
+++ b/cupy_backends/cuda/cupy_cusparselt.h
@@ -1,0 +1,32 @@
+#ifndef INCLUDE_GUARD_CUDA_CUPY_CUSPARSELT_H
+#define INCLUDE_GUARD_CUDA_CUPY_CUSPARSELT_H
+
+#include <library_types.h>
+#include <cusparseLt.h>
+
+#if CUSPARSELT_VERSION < 100
+// Added in cuSPARSELt 0.1.0
+
+cusparseStatus_t cusparseLtMatDescriptorDestroy(...) {
+    return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseLtSpMMAPrune2(...) {
+    return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseLtSpMMAPruneCheck2(...) {
+    return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseLtSpMMACompressedSize2(...) {
+    return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseLtSpMMACompress2(...) {
+    return CUSPARSE_STATUS_SUCCESS;
+}
+
+#endif  // CUSPARSELT_VERSION < 100
+
+#endif  // INCLUDE_GUARD_CUDA_CUPY_CUSPARSELT_H

--- a/cupy_backends/cuda/cupy_cusparselt.h
+++ b/cupy_backends/cuda/cupy_cusparselt.h
@@ -8,23 +8,23 @@
 // Added in cuSPARSELt 0.1.0
 
 cusparseStatus_t cusparseLtMatDescriptorDestroy(...) {
-    return CUSPARSE_STATUS_SUCCESS;
+    return CUSPARSE_STATUS_NOT_SUPPORTED;
 }
 
 cusparseStatus_t cusparseLtSpMMAPrune2(...) {
-    return CUSPARSE_STATUS_SUCCESS;
+    return CUSPARSE_STATUS_NOT_SUPPORTED;
 }
 
 cusparseStatus_t cusparseLtSpMMAPruneCheck2(...) {
-    return CUSPARSE_STATUS_SUCCESS;
+    return CUSPARSE_STATUS_NOT_SUPPORTED;
 }
 
 cusparseStatus_t cusparseLtSpMMACompressedSize2(...) {
-    return CUSPARSE_STATUS_SUCCESS;
+    return CUSPARSE_STATUS_NOT_SUPPORTED;
 }
 
 cusparseStatus_t cusparseLtSpMMACompress2(...) {
-    return CUSPARSE_STATUS_SUCCESS;
+    return CUSPARSE_STATUS_NOT_SUPPORTED;
 }
 
 #endif  // CUSPARSELT_VERSION < 100

--- a/cupy_backends/cuda/libs/cusparselt.pxd
+++ b/cupy_backends/cuda/libs/cusparselt.pxd
@@ -11,6 +11,8 @@ cpdef enum:
     # cusparseComputeType
     CUSPARSE_COMPUTE_16F = 0
     CUSPARSE_COMPUTE_32I = 1
+    CUSPARSE_COMPUTE_TF32 = 2
+    CUSPARSE_COMPUTE_TF32_FAST = 3
 
     # cusparseLtMatmulAlg_t
     CUSPARSELT_MATMUL_ALG_DEFAULT = 0

--- a/cupy_backends/cuda/libs/cusparselt.pyx
+++ b/cupy_backends/cuda/libs/cusparselt.pyx
@@ -263,7 +263,7 @@ cpdef structuredDescriptorInit(Handle handle, MatDescriptor matDescr,
 cpdef matDescriptorDestroy(MatDescriptor matDescr):
     """Releases the resources used by an instance of a matrix descriptor."""
     status = cusparseLtMatDescriptorDestroy(
-        <const cusparseLtMatDescriptor_t*> matDescr._ptr);
+        <const cusparseLtMatDescriptor_t*> matDescr._ptr)
     check_status(status)
 
 cpdef matmulDescriptorInit(Handle handle,
@@ -436,6 +436,7 @@ cpdef spMMACompress2(Handle handle, MatDescriptor sparseMatDescr,
         <int> isSparseA, <cusparseOperation_t> op, <const void*> d_dense,
         <void*> d_compressed, <driver.Stream> stream)
     check_status(status)
+
 
 def get_build_version():
     return CUSPARSELT_VERSION

--- a/cupy_backends/cuda/libs/cusparselt.pyx
+++ b/cupy_backends/cuda/libs/cusparselt.pyx
@@ -262,6 +262,9 @@ cpdef structuredDescriptorInit(Handle handle, MatDescriptor matDescr,
 
 cpdef matDescriptorDestroy(MatDescriptor matDescr):
     """Releases the resources used by an instance of a matrix descriptor."""
+    if CUSPARSELT_VERSION < 100:
+        raise RuntimeError(
+            'matDescriptorDestroy is supported since cuSPARSELt 0.1.0')
     status = cusparseLtMatDescriptorDestroy(
         <const cusparseLtMatDescriptor_t*> matDescr._ptr)
     check_status(status)

--- a/cupy_backends/cupy_cusparselt.h
+++ b/cupy_backends/cupy_cusparselt.h
@@ -7,8 +7,7 @@
 
 #elif !defined(CUPY_NO_CUDA)
 
-#include <library_types.h>
-#include <cusparseLt.h>
+#include "cuda/cupy_cusparselt.h"
 
 #else
 

--- a/cupy_backends/stub/cupy_cusparselt.h
+++ b/cupy_backends/stub/cupy_cusparselt.h
@@ -42,6 +42,10 @@ cusparseStatus_t cusparseLtStructuredDescriptorInit(...) {
     return CUSPARSE_STATUS_SUCCESS;
 }
 
+cusparseStatus_t cusparseLtMatDescriptorDestroy(...) {
+    return CUSPARSE_STATUS_SUCCESS;
+}
+
 cusparseStatus_t cusparseLtMatmulDescriptorInit(...) {
     return CUSPARSE_STATUS_SUCCESS;
 }
@@ -86,11 +90,27 @@ cusparseStatus_t cusparseLtSpMMAPruneCheck(...) {
     return CUSPARSE_STATUS_SUCCESS;
 }
 
+cusparseStatus_t cusparseLtSpMMAPrune2(...) {
+    return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseLtSpMMAPruneCheck2(...) {
+    return CUSPARSE_STATUS_SUCCESS;
+}
+
 cusparseStatus_t cusparseLtSpMMACompressedSize(...) {
     return CUSPARSE_STATUS_SUCCESS;
 }
 
 cusparseStatus_t cusparseLtSpMMACompress(...) {
+    return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseLtSpMMACompressedSize2(...) {
+    return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseLtSpMMACompress2(...) {
     return CUSPARSE_STATUS_SUCCESS;
 }
 

--- a/examples/cusparselt/matmul.py
+++ b/examples/cusparselt/matmul.py
@@ -92,8 +92,10 @@ print('C[:, 0]: {}'.format(C[:, 0]))
 #
 # destroys plan and handle
 #
-cusparselt.matDescriptorDestroy(matA)
-cusparselt.matDescriptorDestroy(matB)
-cusparselt.matDescriptorDestroy(matC)
+if cusparselt.get_build_version() >= 100:
+    # You need to call matDescriptorDestroy for cuSPARSELt v0.1.0 and later
+    cusparselt.matDescriptorDestroy(matA)
+    cusparselt.matDescriptorDestroy(matB)
+    cusparselt.matDescriptorDestroy(matC)
 cusparselt.matmulPlanDestroy(plan)
 cusparselt.destroy(handle)

--- a/examples/cusparselt/matmul.py
+++ b/examples/cusparselt/matmul.py
@@ -92,5 +92,8 @@ print('C[:, 0]: {}'.format(C[:, 0]))
 #
 # destroys plan and handle
 #
+cusparselt.matDescriptorDestroy(matA)
+cusparselt.matDescriptorDestroy(matB)
+cusparselt.matDescriptorDestroy(matC)
 cusparselt.matmulPlanDestroy(plan)
 cusparselt.destroy(handle)


### PR DESCRIPTION
Close https://github.com/cupy/cupy/issues/5136. Merge https://github.com/cupy/cupy/pull/5149 first. 

Note that it's CUDA 11.2+ only. Rel https://github.com/cupy/cupy/pull/5050.

I've locally confirmed that it successfully builds and cusparselt example runs.