### PR TITLE
Add `cupyx.jit.atomic_add`

### DIFF
--- a/cupyx/jit/__init__.py
+++ b/cupyx/jit/__init__.py
@@ -7,6 +7,7 @@ from cupyx.jit._interface import gridDim  # NOQA
 
 from cupyx.jit._builtin_funcs import syncthreads  # NOQA
 from cupyx.jit._builtin_funcs import shared_memory  # NOQA
+from cupyx.jit._builtin_funcs import atomic_add  # NOQA
 
 
 import inspect as _inspect

--- a/cupyx/jit/_builtin_funcs.py
+++ b/cupyx/jit/_builtin_funcs.py
@@ -111,4 +111,6 @@ builtin_functions_dict = {
 
 syncthreads = SyncThreads()
 shared_memory = SharedMemory()
+
+# TODO: Add more atomic functions.
 atomic_add = AtomicOp('Add', 'iILefd')

--- a/cupyx/jit/_builtin_funcs.py
+++ b/cupyx/jit/_builtin_funcs.py
@@ -113,4 +113,4 @@ syncthreads = SyncThreads()
 shared_memory = SharedMemory()
 
 # TODO: Add more atomic functions.
-atomic_add = AtomicOp('Add', 'iILefd')
+atomic_add = AtomicOp('Add', 'iILQefd')

--- a/cupyx/jit/_builtin_funcs.py
+++ b/cupyx/jit/_builtin_funcs.py
@@ -1,3 +1,4 @@
+from cupy_backends.cuda.api import runtime
 from cupyx.jit import _cuda_types
 from cupyx.jit._internal_types import BuiltinFunc
 from cupyx.jit._internal_types import Data
@@ -102,6 +103,9 @@ class AtomicOp(BuiltinFunc):
         value = Data.init(value, env)
         if ctype.dtype.char not in self._dtypes:
             raise TypeError(f'`{name}` does not support {ctype.dtype} input.')
+        if ctype.dtype.char == 'e' and runtime.runtimeGetVersion() < 10000:
+            raise RuntimeError(
+                'float16 atomic operation is not supported this CUDA version.')
         return Data(f'{name}(&{target.code}, {value.code})', ctype)
 
 

--- a/examples/jit/reduction_atomic.py
+++ b/examples/jit/reduction_atomic.py
@@ -1,0 +1,33 @@
+import cupy
+from cupyx import jit
+
+
+@jit.rawkernel()
+def reduction(x, y, size):
+    tid = jit.blockIdx.x * jit.blockDim.x + jit.threadIdx.x
+    ntid = jit.blockDim.x * jit.gridDim.x
+
+    value = cupy.float32(0)
+    for i in range(tid, size, ntid):
+        value += x[i]
+
+    smem = jit.shared_memory(cupy.float32, 1024)
+    smem[jit.threadIdx.x] = value
+
+    jit.syncthreads()
+
+    if jit.threadIdx.x == cupy.uint32(0):
+        value = cupy.float32(0)
+        for i in range(jit.blockDim.x):
+            value += smem[i]
+        jit.atomic_add(y, 0, value)
+
+
+size = cupy.uint32(2 ** 22)
+x = cupy.random.normal(size=(size,), dtype=cupy.float32)
+y = cupy.empty((1,), dtype=cupy.float32)
+
+reduction[64, 1024](x, y, size)
+
+print(y[0])
+print(x.sum())

--- a/tests/cupyx_tests/jit_tests/test_raw.py
+++ b/tests/cupyx_tests/jit_tests/test_raw.py
@@ -132,7 +132,7 @@ class TestRaw(unittest.TestCase):
         else:
             testing.assert_allclose(a, e, rtol=1e-6, atol=1e-6)
 
-    @testing.for_dtypes('iILefd')
+    @testing.for_dtypes('iILQefd')
     def test_atomic_add(self, dtype):
         @jit.rawkernel()
         def f(x, index, out):

--- a/tests/cupyx_tests/jit_tests/test_raw.py
+++ b/tests/cupyx_tests/jit_tests/test_raw.py
@@ -128,7 +128,7 @@ class TestRaw(unittest.TestCase):
     @staticmethod
     def _check(a, e):
         if a.dtype == numpy.float16:
-            testing.assert_allclose(a, e, rtol=1e-2, atol=1e-2)
+            testing.assert_allclose(a, e, rtol=3e-2, atol=3e-2)
         else:
             testing.assert_allclose(a, e, rtol=1e-6, atol=1e-6)
 


### PR DESCRIPTION
Part of https://github.com/cupy/cupy/issues/4290.

Example:
```py
@jit.rawkernel()
def reduction(x, y, size):
    tid = jit.blockIdx.x * jit.blockDim.x + jit.threadIdx.x
    ntid = jit.blockDim.x * jit.gridDim.x

    value = cupy.float32(0)
    for i in range(tid, size, ntid):
        value += x[i]

    smem = jit.shared_memory(cupy.float32, 1024)
    smem[jit.threadIdx.x] = value

    jit.syncthreads()

    if jit.threadIdx.x == cupy.uint32(0):
        value = cupy.float32(0)
        for i in range(jit.blockDim.x):
            value += smem[i]
        jit.atomic_add(y, 0, value)
```

Generated CUDA code:
```cpp
extern "C" __global__ void reduction(CArray<float, 1, true, true> x, CArray<float, 1, true, true> y, unsigned int size) {
  unsigned int tid;
  unsigned int ntid;
  float value;
  unsigned int i;
  __shared__ float _smem1[1024];
  float* smem;
  tid = ((blockIdx.x * blockDim.x) + threadIdx.x);
  ntid = (blockDim.x * gridDim.x);
  value = 0.0f;
  for (unsigned int __it = tid, __stop = size, __step = ntid; __it < __stop; __it += __step) {
    i = __it;
    value = (value + x[i]);
  }
  smem = _smem1;
  smem[threadIdx.x] = value;
  __syncthreads();
  if ((threadIdx.x == 0u)) {
    value = 0.0f;
    for (unsigned int __it = 0, __stop = blockDim.x, __step = 1; __step >= 0 ? __it < __stop : __it > __stop; __it += __step) {
      i = __it;
      value = (value + smem[i]);
    }
    atomicAdd(&y[0], value);
  }
  else {
  }
}
```