### PR TITLE
Per device stream

### DIFF
--- a/cupy/cuda/stream.pyx
+++ b/cupy/cuda/stream.pyx
@@ -205,11 +205,7 @@ class BaseStream(object):
         # This operator is implemented to compare the singleton instance
         # of null stream (Stream.null) can safely be compared with null
         # stream instance created by a user.
-        if self.device_id == -1 or other.device_id == -1:
-            return self.ptr == other.ptr
-        else:
-            return (self.device_id == other.device_id
-                    and self.ptr == other.ptr)
+        return self.ptr == other.ptr
 
     def __enter__(self):
         tls = _ThreadLocal.get()
@@ -376,7 +372,7 @@ class Stream(BaseStream):
         if is_shutting_down():
             return
         tls = _ThreadLocal.get()
-        if self.ptr not in (0, 1, 2):
+        if self.ptr not in (0, runtime.streamLegacy, runtime.streamPerThread):
             current_ptr = tls.get_current_stream_ptr()
             if <intptr_t>self.ptr == current_ptr:
                 tls.set_current_stream(get_default_stream())

--- a/cupy/cuda/stream.pyx
+++ b/cupy/cuda/stream.pyx
@@ -12,15 +12,25 @@ cdef object _thread_local = threading.local()
 
 
 cdef class _ThreadLocal:
+    # We keep both current_stream_ref and current_stream_stack because the
+    # former is also used when calling stream.use(). This bookkeeping enables
+    # correct rewinding when "with" blocks are mixed with ".use()" (though
+    # this is considered an anti-pattern). As the name suggested, stream
+    # lifetime is not tracked in current_stream_ref.
+
     cdef list current_stream_ref  # list of object
     cdef list current_device_id_stack  # list of int
-    cdef list prev_stream_stack  # list of list
+    cdef list current_stream_stack  # list of list
 
     def __init__(self):
         cdef int i, num_devices = runtime.getDeviceCount()
-        self.current_stream_ref = [None for i in range(num_devices)]
-        self.prev_stream_stack = [[] for i in range(num_devices)]
+        self.current_stream_ref = []
         self.current_device_id_stack = []
+        self.current_stream_stack = []
+        for i in range(num_devices):
+            default_stream = get_default_stream()
+            self.current_stream_ref.append(weakref.ref(default_stream))
+            self.current_stream_stack.append([default_stream])
 
     @staticmethod
     cdef _ThreadLocal get():
@@ -31,16 +41,18 @@ cdef class _ThreadLocal:
         return <_ThreadLocal>tls
 
     cdef void push_stream(self, stream, int device_id) except*:
-        prev_stream = self.get_current_stream(device_id)
-        self.prev_stream_stack[device_id].append(prev_stream)
+        assert device_id >= 0
+        self.current_stream_stack[device_id].append(stream)
         # record device_id to prevent from popping the wrong stream at exit
         self.current_device_id_stack.append(device_id)
         self.set_current_stream(stream)
 
     cdef void pop_stream(self) except*:
         cdef int device_id = self.current_device_id_stack.pop()
-        prev_stream = self.prev_stream_stack[device_id].pop()
+        self.current_stream_stack[device_id].pop()
+        prev_stream = self.current_stream_stack[device_id][-1]
         self.set_current_stream(prev_stream)
+        assert len(self.current_stream_stack[device_id]) >= 1
 
     cdef set_current_stream(self, stream):
         cdef intptr_t ptr = <intptr_t>stream.ptr
@@ -54,9 +66,6 @@ cdef class _ThreadLocal:
         if device_id == -1:
             device_id = runtime.getDevice()
         stream_ref = self.current_stream_ref[device_id]
-        if stream_ref is None:
-            stream_ref = weakref.ref(get_default_stream())
-            self.current_stream_ref[device_id] = stream_ref
         return stream_ref()
 
     cdef intptr_t get_current_stream_ptr(self):

--- a/cupy/cuda/stream.pyx
+++ b/cupy/cuda/stream.pyx
@@ -339,9 +339,7 @@ class Stream(BaseStream):
     Attributes:
         ~Stream.ptr (intptr_t): Raw stream handle.
         ~Stream.dev (int): The ID of the device that the stream was created on.
-            The value ``-1`` is used to indicate either it's unknown or does
-            not matter (such as in the cases of the singleton legacy/per-thread
-            default streams).
+            The value ``-1`` is used for the singleton stream objects.
 
     """
 
@@ -394,25 +392,30 @@ class ExternalStream(BaseStream):
 
     Args:
         ptr (intptr_t): Address of the `cudaStream_t` object.
+        dev (int): The ID of the device that the stream was created on. Default
+            is ``-1``, indicating it is unknown.
 
     Attributes:
         ~Stream.ptr (intptr_t): Raw stream handle.
         ~Stream.dev (int): The ID of the device that the stream was created on.
-            The value ``-1`` is used to indicate either it's unknown or does
-            not matter (such as in the cases of legacy/per-thread default
-            streams).
+            The value ``-1`` is used to indicate it is unknown.
+
+    .. warning::
+        If ``dev`` is not specified, the user is required to ensure legal
+        operations of the stream. Specifically, the stream must be used on the
+        device that it was created on.
 
     """
 
-    def __init__(self, ptr):
+    def __init__(self, ptr, dev=-1):
         self.ptr = ptr
         # It is in theory unsafe to just call runtime.getDevice() here, as the
         # stream pointer could come from a different device (although
         # unlikely). While we could use driver API combos cuStreamGetCtx ->
-        # cuCtxSetCurrent -> cuCtxGetDevice to retrieve the device ID
+        # cuCtxSetCurrent -> cuCtxGetDevice -> ... to retrieve the device ID
         # associated with the stream, it is way too complicated. Let us keep
         # this as thin as possible.
-        self.dev = -1
+        self.dev = dev
 
 
 Stream.null = Stream(null=True)

--- a/cupy/cuda/stream.pyx
+++ b/cupy/cuda/stream.pyx
@@ -30,7 +30,7 @@ cdef class _ThreadLocal:
             tls = _thread_local.tls = _ThreadLocal()
         return <_ThreadLocal>tls
 
-    cdef void push_stream(self, stream, int device_id) except *:
+    cdef void push_stream(self, stream, int device_id) except*:
         if self.prev_stream_ref_stack[device_id] is None:
             self.prev_stream_ref_stack[device_id] = []
         prev_stream_ref = self.get_current_stream_ref(device_id)
@@ -39,7 +39,7 @@ cdef class _ThreadLocal:
         self.current_device_id_stack.append(device_id)
         self.set_current_stream(stream)
 
-    cdef pop_stream(self):
+    cdef void pop_stream(self) except*:
         cdef int device_id = self.current_device_id_stack.pop()
         prev_stream_ref = self.prev_stream_ref_stack[device_id].pop()
         self.set_current_stream_ref(prev_stream_ref)

--- a/cupy_backends/cuda/stream.pxd
+++ b/cupy_backends/cuda/stream.pxd
@@ -1,6 +1,6 @@
 from libc.stdint cimport intptr_t
 
 cdef intptr_t get_current_stream_ptr()
-cdef set_current_stream_ptr(intptr_t ptr, int dev=*)
+cdef set_current_stream_ptr(intptr_t ptr, int device_id=*)
 cpdef intptr_t get_default_stream_ptr()
 cdef bint is_ptds_enabled()

--- a/cupy_backends/cuda/stream.pxd
+++ b/cupy_backends/cuda/stream.pxd
@@ -1,6 +1,6 @@
 from libc.stdint cimport intptr_t
 
 cdef intptr_t get_current_stream_ptr()
-cdef set_current_stream_ptr(intptr_t ptr)
+cdef set_current_stream_ptr(intptr_t ptr, int dev=*)
 cpdef intptr_t get_default_stream_ptr()
 cdef bint is_ptds_enabled()

--- a/cupy_backends/cuda/stream.pyx
+++ b/cupy_backends/cuda/stream.pyx
@@ -25,18 +25,18 @@ cdef class _ThreadLocal:
             tls = _thread_local.tls = _ThreadLocal()
         return <_ThreadLocal>tls
 
-    cdef set_current_stream_ptr(self, intptr_t ptr, int dev=-1):
-        if dev == -1:
-            dev = runtime.getDevice()
-        self.current_stream[dev] = ptr
+    cdef set_current_stream_ptr(self, intptr_t ptr, int device_id=-1):
+        if device_id == -1:
+            device_id = runtime.getDevice()
+        self.current_stream[device_id] = ptr
 
-    cdef intptr_t get_current_stream_ptr(self, int dev=-1):
+    cdef intptr_t get_current_stream_ptr(self, int device_id=-1):
         # Returns the stream previously set, otherwise returns
         # nullptr or runtime.streamPerThread when
         # CUPY_CUDA_PER_THREAD_DEFAULT_STREAM=1.
-        if dev == -1:
-            dev = runtime.getDevice()
-        cdef intptr_t curr_stream = self.current_stream[dev]
+        if device_id == -1:
+            device_id = runtime.getDevice()
+        cdef intptr_t curr_stream = self.current_stream[device_id]
         if curr_stream == 0 and is_ptds_enabled():
             return runtime.streamPerThread
         return curr_stream
@@ -52,12 +52,12 @@ cdef intptr_t get_current_stream_ptr():
     return <intptr_t>tls.get_current_stream_ptr()
 
 
-cdef set_current_stream_ptr(intptr_t ptr, int dev=-1):
+cdef set_current_stream_ptr(intptr_t ptr, int device_id=-1):
     """C API to set current CUDA stream pointer.
 
     Args:
         ptr (intptr_t): CUDA stream pointer.
-        dev (int): device ID. Look up the current device if -1.
+        device_id (int): device ID. Look up the current device if -1.
 
     .. warning::
 
@@ -68,7 +68,7 @@ cdef set_current_stream_ptr(intptr_t ptr, int dev=-1):
 
     """
     tls = _ThreadLocal.get()
-    tls.set_current_stream_ptr(ptr, dev)
+    tls.set_current_stream_ptr(ptr, device_id)
 
 
 # cpdef for unit testing

--- a/cupy_backends/cuda/stream.pyx
+++ b/cupy_backends/cuda/stream.pyx
@@ -34,11 +34,12 @@ cdef class _ThreadLocal:
         # Returns the stream previously set, otherwise returns
         # nullptr or runtime.streamPerThread when
         # CUPY_CUDA_PER_THREAD_DEFAULT_STREAM=1.
-        if self.current_stream == 0 and is_ptds_enabled():
-            return runtime.streamPerThread
         if dev == -1:
             dev = runtime.getDevice()
-        return self.current_stream[dev]
+        cdef intptr_t curr_stream = self.current_stream[dev]
+        if curr_stream == 0 and is_ptds_enabled():
+            return runtime.streamPerThread
+        return curr_stream
 
 
 cdef intptr_t get_current_stream_ptr():

--- a/docs/source/user_guide/basic.rst
+++ b/docs/source/user_guide/basic.rst
@@ -124,8 +124,8 @@ default stream, which is unique per device. However, it is possible to change th
 :class:`cupy.cuda.Stream` API, please see :doc:`cuda_api` for example. The current stream in CuPy can be
 retrieved using :func:`cupy.cuda.get_current_stream`.
 
-It is worth noting that CuPy's current stream is managed on a *per thread* basis, meaning that on different Python
-threads the current stream (if not the null stream) can be different.
+It is worth noting that CuPy's current stream is managed on a *per thread, per device* basis, meaning that on different
+Python threads or different devices the current stream (if not the null stream) can be different.
 
 
 Data Transfer

--- a/tests/cupy_tests/cuda_tests/test_stream.py
+++ b/tests/cupy_tests/cuda_tests/test_stream.py
@@ -166,6 +166,22 @@ class TestStream(unittest.TestCase):
             with pytest.raises(RuntimeError):
                 stream0.use()
 
+    def test_mix_use_context(self):
+        # See cupy/cupy#5143
+        s1 = cuda.Stream()
+        s2 = cuda.Stream()
+        s3 = cuda.Stream()
+        assert cuda.get_current_stream() == self.stream
+        with s1:
+            assert cuda.get_current_stream() == s1
+            s2.use()
+            assert cuda.get_current_stream() == s2
+            with s3:
+                assert cuda.get_current_stream() == s3
+                del s2
+            assert cuda.get_current_stream() == cuda.Stream.null
+        assert cuda.get_current_stream() == self.stream
+
 
 @testing.gpu
 class TestExternalStream(unittest.TestCase):

--- a/tests/cupy_tests/cuda_tests/test_stream.py
+++ b/tests/cupy_tests/cuda_tests/test_stream.py
@@ -142,6 +142,17 @@ class TestStream(unittest.TestCase):
         self.stream.use()
         assert self.stream == cuda.get_current_stream()
 
+    @testing.multi_gpu(2)
+    def test_per_device(self):
+        with cuda.Device(0):
+            stream0 = cuda.Stream()
+            with stream0:
+                assert stream0 == cuda.get_current_stream()
+                with cuda.Device(1):
+                    assert stream0 != cuda.get_current_stream()
+                    assert cuda.Stream.null == cuda.get_current_stream()
+                assert stream0 == cuda.get_current_stream()
+
 
 @testing.gpu
 class TestExternalStream(unittest.TestCase):

--- a/tests/cupy_tests/cuda_tests/test_stream.py
+++ b/tests/cupy_tests/cuda_tests/test_stream.py
@@ -1,5 +1,7 @@
 import unittest
 
+import pytest
+
 from cupy._creation import from_data
 from cupy import cuda
 from cupy import testing
@@ -152,6 +154,17 @@ class TestStream(unittest.TestCase):
                     assert stream0 != cuda.get_current_stream()
                     assert cuda.Stream.null == cuda.get_current_stream()
                 assert stream0 == cuda.get_current_stream()
+
+    @testing.multi_gpu(2)
+    def test_per_device_failure(self):
+        with cuda.Device(0):
+            stream0 = cuda.Stream()
+        with cuda.Device(1):
+            with pytest.raises(RuntimeError):
+                with stream0:
+                    pass
+            with pytest.raises(RuntimeError):
+                stream0.use()
 
 
 @testing.gpu

--- a/tests/cupy_tests/cuda_tests/test_stream.py
+++ b/tests/cupy_tests/cuda_tests/test_stream.py
@@ -136,7 +136,8 @@ class TestStream(unittest.TestCase):
             with stream2:
                 assert stream2 == cuda.get_current_stream()
             assert stream1 == cuda.get_current_stream()
-        assert self.stream == cuda.get_current_stream()
+        # self.stream is "forgotten"!
+        assert cuda.Stream.null == cuda.get_current_stream()
 
     def test_use(self):
         stream1 = cuda.Stream().use()
@@ -179,8 +180,9 @@ class TestStream(unittest.TestCase):
             with s3:
                 assert cuda.get_current_stream() == s3
                 del s2
-            assert cuda.get_current_stream() == cuda.Stream.null
-        assert cuda.get_current_stream() == self.stream
+            assert cuda.get_current_stream() == s1
+        # self.stream is "forgotten"!
+        assert cuda.get_current_stream() == cuda.Stream.null
 
 
 @testing.gpu


### PR DESCRIPTION
Close #3980. Fix #5143. Fix #5145.

For the reason in https://github.com/cupy/cupy/issues/3980#issuecomment-831487066, we call `getDevice()` every time we need to look up the device.

***UPDATE:*** major changes:
- Stream references are kept when entering the `with stream` context to avoid dead references, but not when calling `stream.use()` (which still keeps only the stream weakref)
- The stream stack now also records the *current* stream so that if a stream is deleted it can fall back correctly.

TODO:
- [x] Add tests