### PR TITLE
CUDA 11.2/11.3: Support `MemoryAsyncPool` statistics and limits

### DIFF
--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -1792,7 +1792,7 @@ cdef class MemoryAsyncPool:
         """
         if size is None:
             if fraction is None:
-                size = UINT64_MAX  # ensure pool size is never shrunk
+                size = 0
             else:
                 if not 0 <= fraction <= 1:
                     raise ValueError(
@@ -1810,6 +1810,8 @@ cdef class MemoryAsyncPool:
             raise ValueError(
                 'memory limit size out of range: {}'.format(size))
 
+        if size == 0:
+            size = UINT64_MAX  # ensure pool size is never shrunk
         cdef intptr_t pool = self._pools[device.get_device_id()]
         runtime.memPoolSetAttribute(
             pool, runtime.cudaMemPoolAttrReleaseThreshold, size)

--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -1506,8 +1506,7 @@ cdef class MemoryPool:
 
         .. note::
             You can also set the limit by using ``CUPY_GPU_MEMORY_LIMIT``
-            environment variable.
-            See :ref:`environment` for the details.
+            environment variable, see :ref:`environment` for the details.
             The limit set by this method supersedes the value specified in
             the environment variable.
 
@@ -1581,12 +1580,12 @@ cdef class MemoryAsyncPool:
     # Internally (as of driver v11.3) the pool starts with size 0. The first
     # allocation will bump the size to 32n MiB to accommodate the requested
     # amount (n is integer). The size is increased only if it is not enough
-    # to meet later allocation needs. The size is decreased to 32m MiB if
-    # enough memory is returned (freed) to the pool when free_all_blocks()
-    # (that is, cudaMemPoolTrimTo()) is called (m<n is integer). This
-    # observation may vary with future driver updates, so the MemoryAsyncPool
-    # API does not rely on any internal behavior, but only on the Programming
-    # Guide and sane assumptions.
+    # to meet later allocation needs. The size is decreased to 32m MiB (m<n)
+    # if enough memory is returned (freed) to the pool when free_all_blocks()
+    # (that is, sync + cudaMemPoolTrimTo) is called. This observation may
+    # vary with future driver updates, so the MemoryAsyncPool API does not
+    # rely on any internal behavior, but only on the Programming Guide and
+    # sane assumptions.
 
     cdef:
         # A list of cudaMemPool_t to each device's mempool
@@ -1774,12 +1773,12 @@ cdef class MemoryAsyncPool:
             Unlike with :class:`MemoryPool`, :class:`MemoryAsyncPool`'s
             :meth:`set_limit` method can only impose a *soft* limit. If other
             (non-CuPy) applications are also allocating memory from the same
-            mempool, this limit may not be respected.
+            mempool, this limit may not be respected. Internally, this limit
+            is set via the ``cudaMemPoolAttrReleaseThreshold`` attribute.
 
         .. note::
             You can also set the limit by using ``CUPY_GPU_MEMORY_LIMIT``
-            environment variable.
-            See :ref:`environment` for the details.
+            environment variable, see :ref:`environment` for the details.
             The limit set by this method supersedes the value specified in
             the environment variable.
 

--- a/cupy_backends/cuda/api/runtime.pxd
+++ b/cupy_backends/cuda/api/runtime.pxd
@@ -103,6 +103,7 @@ cdef extern from *:
         char bytes[16]
 
     ctypedef void* MemPool 'cudaMemPool_t'
+    ctypedef int MemPoolAttr 'cudaMemPoolAttr'
 
     IF CUDA_VERSION >= 11000:
         # We can't use IF in the middle of structs declaration
@@ -578,6 +579,18 @@ cpdef enum:
     cudaReadModeElementType = 0
     cudaReadModeNormalizedFloat = 1
 
+    # cudaMemPoolAttr
+    # ----- added since 11.2 -----
+    cudaMemPoolReuseFollowEventDependencies = 0x1
+    cudaMemPoolReuseAllowOpportunistic = 0x2
+    cudaMemPoolReuseAllowInternalDependencies = 0x3
+    cudaMemPoolAttrReleaseThreshold = 0x4
+    # ----- added since 11.3 -----
+    cudaMemPoolAttrReservedMemCurrent = 0x5
+    cudaMemPoolAttrReservedMemHigh = 0x6
+    cudaMemPoolAttrUsedMemCurrent = 0x7
+    cudaMemPoolAttrUsedMemHigh = 0x8
+
 
 # This was a legacy mistake: the prefix "cuda" should have been removed
 # so that we can directly assign their C counterparts here. Now because
@@ -821,6 +834,11 @@ ELSE:
         # added since CUDA 11.2
         cudaDevAttrMaxTimelineSemaphoreInteropSupported = 114
         cudaDevAttrMemoryPoolsSupported = 115
+        # added since CUDA 11.3
+        cudaDevAttrGPUDirectRDMASupported
+        cudaDevAttrGPUDirectRDMAFlushWritesOptions
+        cudaDevAttrGPUDirectRDMAWritesOrdering
+        cudaDevAttrMemoryPoolSupportedHandleTypes
 
 
 ###############################################################################
@@ -934,6 +952,8 @@ cpdef intptr_t deviceGetDefaultMemPool(int) except? 0
 cpdef intptr_t deviceGetMemPool(int) except? 0
 cpdef deviceSetMemPool(int, intptr_t)
 cpdef memPoolTrimTo(intptr_t, size_t)
+cpdef memPoolGetAttribute(intptr_t, int)
+cpdef memPoolSetAttribute(intptr_t, int, object)
 
 
 ###############################################################################

--- a/cupy_backends/cuda/api/runtime.pyx
+++ b/cupy_backends/cuda/api/runtime.pyx
@@ -9,6 +9,8 @@ There are four differences compared to the original C API.
 4. The resulting values are returned directly instead of references.
 
 """
+from libc.stdint cimport uint64_t
+
 import threading
 
 cimport cpython  # NOQA
@@ -165,6 +167,8 @@ cdef extern from '../../cupy_backend_runtime.h' nogil:
     int cudaDeviceGetMemPool(MemPool*, int)
     int cudaDeviceSetMemPool(int, MemPool)
     int cudaMemPoolTrimTo(MemPool, size_t)
+    int cudaMemPoolGetAttribute(MemPool, MemPoolAttr, void*)
+    int cudaMemPoolSetAttribute(MemPool, MemPoolAttr, void*)
     int cudaPointerGetAttributes(_PointerAttributes* attributes,
                                  const void* ptr)
     Extent make_cudaExtent(size_t w, size_t h, size_t d)
@@ -270,7 +274,6 @@ cpdef int driverGetVersion() except? -1:
     status = cudaDriverGetVersion(&version)
     check_status(status)
     return version
-
 
 cpdef int runtimeGetVersion() except? -1:
     cdef int version
@@ -513,10 +516,10 @@ cpdef deviceSetLimit(int limit, size_t value):
 ###############################################################################
 # IPC operations
 ###############################################################################
+
 cpdef ipcCloseMemHandle(intptr_t devPtr):
     status = cudaIpcCloseMemHandle(<void*>devPtr)
     check_status(status)
-
 
 cpdef ipcGetEventHandle(intptr_t event):
     cdef IpcEventHandle handle
@@ -572,7 +575,6 @@ cpdef intptr_t malloc(size_t size) except? 0:
     check_status(status)
     return <intptr_t>ptr
 
-
 cpdef intptr_t mallocManaged(
         size_t size, unsigned int flags=cudaMemAttachGlobal) except? 0:
     cdef void* ptr
@@ -580,7 +582,6 @@ cpdef intptr_t mallocManaged(
         status = cudaMallocManaged(&ptr, size, flags)
     check_status(status)
     return <intptr_t>ptr
-
 
 cpdef intptr_t malloc3DArray(intptr_t descPtr, size_t width, size_t height,
                              size_t depth, unsigned int flags=0) except? 0:
@@ -592,7 +593,6 @@ cpdef intptr_t malloc3DArray(intptr_t descPtr, size_t width, size_t height,
     check_status(status)
     return <intptr_t>ptr
 
-
 cpdef intptr_t mallocArray(intptr_t descPtr, size_t width, size_t height,
                            unsigned int flags=0) except? 0:
     cdef Array ptr
@@ -601,7 +601,6 @@ cpdef intptr_t mallocArray(intptr_t descPtr, size_t width, size_t height,
                                  height, flags)
     check_status(status)
     return <intptr_t>ptr
-
 
 cpdef intptr_t mallocAsync(size_t size, intptr_t stream) except? 0:
     cdef void* ptr
@@ -612,7 +611,6 @@ cpdef intptr_t mallocAsync(size_t size, intptr_t stream) except? 0:
     check_status(status)
     return <intptr_t>ptr
 
-
 cpdef intptr_t hostAlloc(size_t size, unsigned int flags) except? 0:
     cdef void* ptr
     with nogil:
@@ -620,36 +618,30 @@ cpdef intptr_t hostAlloc(size_t size, unsigned int flags) except? 0:
     check_status(status)
     return <intptr_t>ptr
 
-
 cpdef hostRegister(intptr_t ptr, size_t size, unsigned int flags):
     with nogil:
         status = cudaHostRegister(<void*>ptr, size, flags)
     check_status(status)
-
 
 cpdef hostUnregister(intptr_t ptr):
     with nogil:
         status = cudaHostUnregister(<void*>ptr)
     check_status(status)
 
-
 cpdef free(intptr_t ptr):
     with nogil:
         status = cudaFree(<void*>ptr)
     check_status(status)
-
 
 cpdef freeHost(intptr_t ptr):
     with nogil:
         status = cudaFreeHost(<void*>ptr)
     check_status(status)
 
-
 cpdef freeArray(intptr_t ptr):
     with nogil:
         status = cudaFreeArray(<Array>ptr)
     check_status(status)
-
 
 cpdef freeAsync(intptr_t ptr, intptr_t stream):
     if CUDA_VERSION < 11020:
@@ -658,19 +650,16 @@ cpdef freeAsync(intptr_t ptr, intptr_t stream):
         status = cudaFreeAsync(<void*>ptr, <driver.Stream>stream)
     check_status(status)
 
-
 cpdef memGetInfo():
     cdef size_t free, total
     status = cudaMemGetInfo(&free, &total)
     check_status(status)
     return free, total
 
-
 cpdef memcpy(intptr_t dst, intptr_t src, size_t size, int kind):
     with nogil:
         status = cudaMemcpy(<void*>dst, <void*>src, size, <MemoryKind>kind)
     check_status(status)
-
 
 cpdef memcpyAsync(intptr_t dst, intptr_t src, size_t size, int kind,
                   intptr_t stream):
@@ -680,14 +669,12 @@ cpdef memcpyAsync(intptr_t dst, intptr_t src, size_t size, int kind,
             <driver.Stream>stream)
     check_status(status)
 
-
 cpdef memcpyPeer(intptr_t dst, int dstDevice, intptr_t src, int srcDevice,
                  size_t size):
     with nogil:
         status = cudaMemcpyPeer(<void*>dst, dstDevice, <void*>src, srcDevice,
                                 size)
     check_status(status)
-
 
 cpdef memcpyPeerAsync(intptr_t dst, int dstDevice, intptr_t src, int srcDevice,
                       size_t size, intptr_t stream):
@@ -720,7 +707,6 @@ cpdef memcpy2DFromArray(intptr_t dst, size_t dpitch, intptr_t src,
                                        <MemoryKind>kind)
     check_status(status)
 
-
 cpdef memcpy2DFromArrayAsync(intptr_t dst, size_t dpitch, intptr_t src,
                              size_t wOffset, size_t hOffset, size_t width,
                              size_t height, int kind, intptr_t stream):
@@ -731,7 +717,6 @@ cpdef memcpy2DFromArrayAsync(intptr_t dst, size_t dpitch, intptr_t src,
                                             <driver.Stream>stream)
     check_status(status)
 
-
 cpdef memcpy2DToArray(intptr_t dst, size_t wOffset, size_t hOffset,
                       intptr_t src, size_t spitch, size_t width, size_t height,
                       int kind):
@@ -739,7 +724,6 @@ cpdef memcpy2DToArray(intptr_t dst, size_t wOffset, size_t hOffset,
         status = cudaMemcpy2DToArray(<Array>dst, wOffset, hOffset, <void*>src,
                                      spitch, width, height, <MemoryKind>kind)
     check_status(status)
-
 
 cpdef memcpy2DToArrayAsync(intptr_t dst, size_t wOffset, size_t hOffset,
                            intptr_t src, size_t spitch, size_t width,
@@ -751,12 +735,10 @@ cpdef memcpy2DToArrayAsync(intptr_t dst, size_t wOffset, size_t hOffset,
                                           <driver.Stream>stream)
     check_status(status)
 
-
 cpdef memcpy3D(intptr_t Memcpy3DParmsPtr):
     with nogil:
         status = cudaMemcpy3D(<Memcpy3DParms*>Memcpy3DParmsPtr)
     check_status(status)
-
 
 cpdef memcpy3DAsync(intptr_t Memcpy3DParmsPtr, intptr_t stream):
     with nogil:
@@ -764,12 +746,10 @@ cpdef memcpy3DAsync(intptr_t Memcpy3DParmsPtr, intptr_t stream):
                                    <driver.Stream> stream)
     check_status(status)
 
-
 cpdef memset(intptr_t ptr, int value, size_t size):
     with nogil:
         status = cudaMemset(<void*>ptr, value, size)
     check_status(status)
-
 
 cpdef memsetAsync(intptr_t ptr, int value, size_t size, intptr_t stream):
     with nogil:
@@ -790,7 +770,6 @@ cpdef memAdvise(intptr_t devPtr, size_t count, int advice, int device):
                                <MemoryAdvise>advice, device)
     check_status(status)
 
-
 cpdef PointerAttributes pointerGetAttributes(intptr_t ptr):
     cdef _PointerAttributes attrs
     status = cudaPointerGetAttributes(&attrs, <void*>ptr)
@@ -799,7 +778,6 @@ cpdef PointerAttributes pointerGetAttributes(intptr_t ptr):
         attrs.device,
         <intptr_t>attrs.devicePointer,
         <intptr_t>attrs.hostPointer)
-
 
 cpdef intptr_t deviceGetDefaultMemPool(int device) except? 0:
     '''Get the default mempool on the current device.'''
@@ -812,7 +790,6 @@ cpdef intptr_t deviceGetDefaultMemPool(int device) except? 0:
     check_status(status)
     return <intptr_t>(pool)
 
-
 cpdef intptr_t deviceGetMemPool(int device) except? 0:
     '''Get the current mempool on the current device.'''
     if CUDA_VERSION < 11020:
@@ -824,7 +801,6 @@ cpdef intptr_t deviceGetMemPool(int device) except? 0:
     check_status(status)
     return <intptr_t>(pool)
 
-
 cpdef deviceSetMemPool(int device, intptr_t pool):
     '''Set the current mempool on the current device to pool.'''
     if CUDA_VERSION < 11020:
@@ -834,12 +810,43 @@ cpdef deviceSetMemPool(int device, intptr_t pool):
         status = cudaDeviceSetMemPool(device, <MemPool>pool)
     check_status(status)
 
-
 cpdef memPoolTrimTo(intptr_t pool, size_t size):
     if CUDA_VERSION < 11020:
         raise RuntimeError('memPoolTrimTo is supported since CUDA 11.2')
     with nogil:
         status = cudaMemPoolTrimTo(<MemPool>pool, size)
+    check_status(status)
+
+cpdef memPoolGetAttribute(intptr_t pool, int attr):
+    if CUDA_VERSION < 11020:
+        raise RuntimeError('memPoolGetAttribute is supported since CUDA 11.2')
+    cdef int val1
+    cdef uint64_t val2
+    cdef void* out
+    # TODO(leofang): check this hack when more cudaMemPoolAttr are added!
+    out = <void*>(&val1) if attr <= 0x3 else <void*>(&val2)
+    with nogil:
+        status = cudaMemPoolGetAttribute(<MemPool>pool, <MemPoolAttr>attr, out)
+    check_status(status)
+    # TODO(leofang): check this hack when more cudaMemPoolAttr are added!
+    # cast to Python int regardless of C types
+    return val1 if attr <= 0x3 else val2
+
+cpdef memPoolSetAttribute(intptr_t pool, int attr, object value):
+    if CUDA_VERSION < 11020:
+        raise RuntimeError('memPoolSetAttribute is supported since CUDA 11.2')
+    cdef int val1
+    cdef uint64_t val2
+    cdef void* out
+    # TODO(leofang): check this hack when more cudaMemPoolAttr are added!
+    if attr <= 0x3:
+        val1 = value
+        out = <void*>(&val1)
+    else:
+        val2 = value
+        out = <void*>(&val2)
+    with nogil:
+        status = cudaMemPoolSetAttribute(<MemPool>pool, <MemPoolAttr>attr, out)
     check_status(status)
 
 

--- a/cupy_backends/hip/cupy_hip_common.h
+++ b/cupy_backends/hip/cupy_hip_common.h
@@ -69,7 +69,7 @@ enum cudaMemoryAdvise {};
 typedef hipMemcpyKind cudaMemcpyKind;
 typedef hipDeviceProp_t cudaDeviceProp;
 typedef void* cudaMemPool_t;
-enum cudaDeviceAttr {};
+enum cudaMemPoolAttr {};
 
 typedef hipStreamCallback_t cudaStreamCallback_t;
 typedef void (*cudaHostFn_t)(void* userData);

--- a/cupy_backends/hip/cupy_hip_common.h
+++ b/cupy_backends/hip/cupy_hip_common.h
@@ -69,6 +69,7 @@ enum cudaMemoryAdvise {};
 typedef hipMemcpyKind cudaMemcpyKind;
 typedef hipDeviceProp_t cudaDeviceProp;
 typedef void* cudaMemPool_t;
+enum cudaDeviceAttr {};
 
 typedef hipStreamCallback_t cudaStreamCallback_t;
 typedef void (*cudaHostFn_t)(void* userData);

--- a/cupy_backends/hip/cupy_hip_runtime.h
+++ b/cupy_backends/hip/cupy_hip_runtime.h
@@ -258,6 +258,14 @@ cudaError_t cudaMemPoolTrimTo(...) {
     return hipErrorUnknown;
 }
 
+cudaError_t cudaMemPoolGetAttribute(...) {
+    return hipErrorUnknown;
+}
+
+cudaError_t cudaMemPoolSetAttribute(...) {
+    return hipErrorUnknown;
+}
+
 
 // Stream and Event
 cudaError_t cudaStreamCreate(cudaStream_t *stream) {

--- a/cupy_backends/stub/cupy_cuda_common.h
+++ b/cupy_backends/stub/cupy_cuda_common.h
@@ -195,6 +195,7 @@ typedef struct {
 } cudaDeviceProp;
 
 typedef void* cudaMemPool_t;
+enum cudaMemPoolAttr {};
 
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/cupy_backends/stub/cupy_cuda_runtime.h
+++ b/cupy_backends/stub/cupy_cuda_runtime.h
@@ -24,7 +24,8 @@ cudaError_t cudaGetLastError() {
 
 
 // Initialization
-cudaError_t cudaDriverGetVersion(...) {
+cudaError_t cudaDriverGetVersion(int* driverVersion) {
+    *driverVersion = 0;  // make the stub work safely without driver
     return cudaSuccess;
 }
 

--- a/cupy_backends/stub/cupy_cuda_runtime.h
+++ b/cupy_backends/stub/cupy_cuda_runtime.h
@@ -240,6 +240,14 @@ cudaError_t cudaMemPoolTrimTo(...) {
     return cudaSuccess;
 }
 
+cudaError_t cudaMemPoolGetAttribute(...) {
+    return cudaSuccess;
+}
+
+cudaError_t cudaMemPoolSetAttribute(...) {
+    return cudaSuccess;
+}
+
 
 // Stream and Event
 cudaError_t cudaStreamCreate(...) {

--- a/docs/source/user_guide/memory.rst
+++ b/docs/source/user_guide/memory.rst
@@ -139,7 +139,9 @@ which may or may not be desired.
 Stream Ordered Memory Allocator is a new feature added since CUDA 11.2. CuPy provides an *experimental* interface to it.
 Similar to CuPy's memory pool, Stream Ordered Memory Allocator also allocates/deallocates memory *asynchronously* from/to
 a memory pool in a stream-ordered fashion. The key difference is that it is a built-in feature implemented in the CUDA
-driver by NVIDIA. To enable a memory pool that manages stream ordered memory, you can construct a new :class:`~cupy.cuda.MemoryAsyncPool`
+driver by NVIDIA, so other CUDA applications in the same processs can easily allocate memory from the same pool.
+
+To enable a memory pool that manages stream ordered memory, you can construct a new :class:`~cupy.cuda.MemoryAsyncPool`
 instance:
 
 .. code-block:: py
@@ -174,8 +176,9 @@ interplay with Stream Ordered Memory Allocator. Specifically, memory freed to th
 to ``cudaMalloc``, leading to potential out-of-memory errors. In this case, you can either call :meth:`~cupy.cuda.MemoryAsyncPool.free_all_blocks()`
 or just manually perform a (event/stream/device) synchronization, and retry.
 
-Currently the :class:`~cupy.cuda.MemoryAsyncPool` interface is *experimental*. In particular, unlike :class:`~cupy.cuda.MemoryPool`
-or :class:`~cupy.cuda.PinnedMemoryPool` most of the pool's methods are not supported due to CUDA's limitation.
+Currently the :class:`~cupy.cuda.MemoryAsyncPool` interface is *experimental*. In particular, while its API is largely identical
+to that of :class:`~cupy.cuda.MemoryPool`, several of the pool's methods require a sufficiently new driver (and of course, a
+supported hardware, CUDA version, and platform) due to CUDA's limitation.
 
 You can even disable the default memory pool by the code below.
 Be sure to do this before any other CuPy operations.

--- a/tests/cupy_tests/cuda_tests/test_memory.py
+++ b/tests/cupy_tests/cuda_tests/test_memory.py
@@ -1146,7 +1146,9 @@ class TestMemoryAsyncPool(unittest.TestCase):
         assert self.pool.free_bytes() == (
             self.pool.total_bytes() - self.pool.used_bytes())  # always true
 
-        current_size = self.pool.total_bytes()  # fixed throughout this method
+        # current_size is fixed throughout this test, as no synchronization
+        # (such as free_all_blocks()) is done
+        current_size = self.pool.total_bytes()
         free_size = self.pool.free_bytes()
 
         p2 = self.pool.malloc(self.unit * 4)
@@ -1162,6 +1164,7 @@ class TestMemoryAsyncPool(unittest.TestCase):
         free_size -= self.unit * 1
         assert self.pool.free_bytes() == free_size
         del p3
+        assert self.pool.total_bytes() == current_size
 
     @pytest.mark.skipif(cupy.cuda.runtime.driverGetVersion() < 11030,
                         reason='free_bytes is supported with driver 11.3+')

--- a/tests/cupy_tests/cuda_tests/test_memory.py
+++ b/tests/cupy_tests/cuda_tests/test_memory.py
@@ -735,6 +735,13 @@ class TestMemoryPool(unittest.TestCase):
 class TestAllocator(unittest.TestCase):
 
     def setUp(self):
+        if self.mempool == 'MemoryAsyncPool':
+            if cupy.cuda.runtime.is_hip:
+                pytest.skip('HIP does not support async allocator')
+            if cupy.cuda.driver.get_build_version() < 11020:
+                pytest.skip('malloc_async is supported since CUDA 11.2')
+            if cupy.cuda.runtime.driverGetVersion() < 11030:
+                pytest.skip('pool statistics is supported with driver 11.3+')
         self.old_pool = cupy.get_default_memory_pool()
         self.pool = getattr(memory, self.mempool)()
         memory.set_allocator(self.pool.malloc)

--- a/tests/cupy_tests/cuda_tests/test_memory.py
+++ b/tests/cupy_tests/cuda_tests/test_memory.py
@@ -1233,7 +1233,7 @@ class TestMemoryAsyncPool(unittest.TestCase):
 
     def test_get_limit(self):
         # limit is disabled by default
-        assert 0 == self.pool.get_limit()
+        assert 2**64-1 == self.pool.get_limit()
 
     def test_set_limit_size(self):
         self.pool.set_limit(size=1024)

--- a/tests/cupy_tests/cuda_tests/test_memory.py
+++ b/tests/cupy_tests/cuda_tests/test_memory.py
@@ -1048,6 +1048,7 @@ class TestMemoryAsyncPool(unittest.TestCase):
         cupy.cuda.Device().synchronize()
 
     def tearDown(self):
+        self.pool.set_limit(size=0)
         self.pool.free_all_blocks()
 
     def test_zero_size_alloc(self):
@@ -1253,7 +1254,7 @@ class TestMemoryAsyncPool(unittest.TestCase):
         assert 2**33 == self.pool.get_limit()
 
         self.pool.set_limit(size=0)
-        assert 0 == self.pool.get_limit()
+        assert 2**64-1 == self.pool.get_limit()
 
         with self.assertRaises(ValueError):
             self.pool.set_limit(size=-1)
@@ -1262,7 +1263,7 @@ class TestMemoryAsyncPool(unittest.TestCase):
         _, total = cupy.cuda.runtime.memGetInfo()
 
         self.pool.set_limit(fraction=0)
-        assert 0 == self.pool.get_limit()
+        assert 2**64-1 == self.pool.get_limit()
 
         self.pool.set_limit(fraction=0.5)
         assert total * 0.5 == self.pool.get_limit()


### PR DESCRIPTION
- CUDA 11.2+: `get_limit()` and `set_limit()` 
- CUDA 11.3+: `used_bytes()`, `free_bytes()`, and `total_bytes()`