### PR TITLE
FIX #5001 bug with low-rank matrices

### DIFF
--- a/cupyx/scipy/sparse/linalg/_eigen.py
+++ b/cupyx/scipy/sparse/linalg/_eigen.py
@@ -148,7 +148,7 @@ def _lanczos_asis(a, V, u, alpha, beta, i_start, i_end):
         if i >= i_end - 1:
             break
         
-        if beta[i] < beta_eps:
+        if cupy.abs(beta[i]) < beta_eps:
             V[i+1:i_end,:] = 0
             u[...] = 0
             break
@@ -259,7 +259,7 @@ def _lanczos_fast(A, n, ncv):
             if i >= i_end - 1:
                 break
           
-            if beta[i] < beta_eps:
+            if cupy.abs(beta[i]) < beta_eps:
                 V[i+1:i_end,:] = 0
                 u[...] = 0
                 v[...] = 0

--- a/cupyx/scipy/sparse/linalg/_eigen.py
+++ b/cupyx/scipy/sparse/linalg/_eigen.py
@@ -148,7 +148,7 @@ def _lanczos_asis(a, V, u, alpha, beta, i_start, i_end):
         if i >= i_end - 1:
             break
         
-        if cupy.abs(beta[i]) < beta_eps:
+        if beta[i] < beta_eps:
             V[i+1:i_end,:] = 0
             u[...] = 0
             break
@@ -259,7 +259,7 @@ def _lanczos_fast(A, n, ncv):
             if i >= i_end - 1:
                 break
           
-            if cupy.abs(beta[i]) < beta_eps:
+            if beta[i] < beta_eps:
                 V[i+1:i_end,:] = 0
                 u[...] = 0
                 v[...] = 0

--- a/cupyx/scipy/sparse/linalg/_eigen.py
+++ b/cupyx/scipy/sparse/linalg/_eigen.py
@@ -129,8 +129,17 @@ def eigsh(a, k=6, *, which='LM', ncv=None, maxiter=None, tol=0,
     else:
         return cupy.sort(w)
 
+def inversion_eps(dt):
+  '''
+  Inversion epsilon for type `dt`. 
+  Adopted from scipy.sparse.linalg.svds.
+  '''
+  t = dt.char.lower()
+  factor = {'f': 1E3, 'd': 1E6}
+  return factor[t] * cupy.finfo(t).eps
 
 def _lanczos_asis(a, V, u, alpha, beta, i_start, i_end):
+    beta_eps = inversion_eps(a.dtype)
     for i in range(i_start, i_end):
         u[...] = a @ V[i]
         cublas.dotc(V[i], u, out=alpha[i])
@@ -138,6 +147,14 @@ def _lanczos_asis(a, V, u, alpha, beta, i_start, i_end):
         cublas.nrm2(u, out=beta[i])
         if i >= i_end - 1:
             break
+        
+        if beta[i] < beta_eps:
+            V[i+1:i_end,:] = 0
+            u[...] = 0
+            break
+        if i == i_start:
+            beta_eps *= beta[i] # scale eps to largest beta
+        
         V[i+1] = u / beta[i]
 
 
@@ -182,6 +199,7 @@ def _lanczos_fast(A, n, ncv):
 
     def aux(A, V, u, alpha, beta, i_start, i_end):
         assert A is outer_A
+        beta_eps = inversion_eps(A.dtype)
 
         # Get ready for spmv if enabled
         if cusparse_handle is not None:
@@ -240,7 +258,15 @@ def _lanczos_fast(A, n, ncv):
             # Break here as the normalization below touches V[i+1]
             if i >= i_end - 1:
                 break
-
+          
+            if beta[i] < beta_eps:
+                V[i+1:i_end,:] = 0
+                u[...] = 0
+                v[...] = 0
+                break
+            if i == i_start:
+                beta_eps *= beta[i] # scale eps to largest beta
+          
             # Normalize
             _kernel_normalize(u, beta, i, n, v, V)
 

--- a/cupyx/scipy/sparse/linalg/_eigen.py
+++ b/cupyx/scipy/sparse/linalg/_eigen.py
@@ -129,14 +129,16 @@ def eigsh(a, k=6, *, which='LM', ncv=None, maxiter=None, tol=0,
     else:
         return cupy.sort(w)
 
+
 def inversion_eps(dt):
-  '''
-  Inversion epsilon for type `dt`. 
-  Adopted from scipy.sparse.linalg.svds.
-  '''
-  t = dt.char.lower()
-  factor = {'f': 1E3, 'd': 1E6}
-  return factor[t] * cupy.finfo(t).eps
+    '''
+    Inversion epsilon for type `dt`.
+    Adopted from scipy.sparse.linalg.svds.
+    '''
+    t = dt.char.lower()
+    factor = {'f': 1E3, 'd': 1E6}
+    return factor[t] * cupy.finfo(t).eps
+
 
 def _lanczos_asis(a, V, u, alpha, beta, i_start, i_end):
     beta_eps = inversion_eps(a.dtype)
@@ -147,14 +149,14 @@ def _lanczos_asis(a, V, u, alpha, beta, i_start, i_end):
         cublas.nrm2(u, out=beta[i])
         if i >= i_end - 1:
             break
-        
+
         if beta[i] < beta_eps:
-            V[i+1:i_end,:] = 0
+            V[i+1:i_end, :] = 0
             u[...] = 0
             break
         if i == i_start:
-            beta_eps *= beta[i] # scale eps to largest beta
-        
+            beta_eps *= beta[i]  # scale eps to largest beta
+
         V[i+1] = u / beta[i]
 
 
@@ -258,15 +260,15 @@ def _lanczos_fast(A, n, ncv):
             # Break here as the normalization below touches V[i+1]
             if i >= i_end - 1:
                 break
-          
+
             if beta[i] < beta_eps:
-                V[i+1:i_end,:] = 0
+                V[i+1:i_end, :] = 0
                 u[...] = 0
                 v[...] = 0
                 break
             if i == i_start:
-                beta_eps *= beta[i] # scale eps to largest beta
-          
+                beta_eps *= beta[i]  # scale eps to largest beta
+
             # Normalize
             _kernel_normalize(u, beta, i, n, v, V)
 

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
@@ -169,10 +169,6 @@ class TestEigsh:
             a = sp.linalg.aslinearoperator(a)
         return self._test_eigsh(a, xp, sp)
 
-    @pytest.mark.xfail(
-        reason='eigsh works wrong (#5001)',
-        raises=AssertionError,
-    )
     @testing.for_dtypes('fdFD')
     @testing.numpy_cupy_allclose(rtol=tol, atol=tol, sp_name='sp')
     def test_dense_low_rank(self, dtype, xp, sp):

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
@@ -175,8 +175,8 @@ class TestEigsh:
         n = self.n
         rank = 5
         # density is ignored.
-        a = testing.shaped_random((n, rank), xp, dtype=dtype, scale=1).dot(
-            testing.shaped_random((rank, n), xp, dtype=dtype, scale=1))
+        a = testing.shaped_random((n, rank), xp, dtype=dtype, scale=1)
+        a = a @ a.T
         if self.use_linear_operator:
             a = sp.linalg.aslinearoperator(a)
         return self._test_eigsh(a, xp, sp)

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
@@ -176,7 +176,7 @@ class TestEigsh:
         rank = 5
         # density is ignored.
         a = testing.shaped_random((n, rank), xp, dtype=dtype, scale=1)
-        a = a @ a.T
+        a = a @ a.conj().T
         if self.use_linear_operator:
             a = sp.linalg.aslinearoperator(a)
         return self._test_eigsh(a, xp, sp)


### PR DESCRIPTION
Throw away too small beta's, that caused numerical instability ( Issued #5001 ). Beta cutoff computed with the method adopted from scipy.sparse.linalg.svds (that adopted it from pinv).