### PR TITLE
`MemoryAsyncPool`: Use the "current" mempool instead of the "default" one

### DIFF
--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -1591,7 +1591,7 @@ cdef class MemoryAsyncPool:
         # A list of cudaMemPool_t to each device's mempool
         readonly list _pools
 
-    def __init__(self, pool_handles='default'):
+    def __init__(self, pool_handles='current'):
         _util.experimental('cupy.cuda.MemoryAsyncPool')
         cdef int dev_id, dev_counts
         cdef dict limit = _parse_limit_string()


### PR DESCRIPTION
This PR proposes changing the default value of `MemoryAsyncPool`'s `pool_handles` argument from `"default"` to `"current"`.

Let me first explain the terminology as it's a bit confusing 😅 For CUDA's new Stream Ordered Memory Allocator:
- the "current" mempool refers to the async mempool set to current via `cudaDeviceSetMemPool()`
- the "default" mempool is the unique mempool instance per device that's used when `cudaMallocAsync()` is called without any prior call to `cudaDeviceSetMemPool()`

Currently, when creating a `MemoryAsyncPool` instance we use `"default"`, but I consider this as *a defect if not a bug*, even though we do allow users to provide custom mempool handles to `pool_handles`:
- If CuPy is used in conjunction with other libraries (say RMM) which set a mempool to current: I think it's best for CuPy to just pick it up without asking users to query and pass the handle.
- If CuPy is used alone and nothing else calls `cudaDeviceSetMemPool()` secretly: the current mempool would simply be the default mempool, matching the current behavior.


