### PR TITLE
cuTENSOR v1.3.0 for library installer

### DIFF
--- a/cupyx/tools/install_library.py
+++ b/cupyx/tools/install_library.py
@@ -225,7 +225,7 @@ The current platform ({}) is not supported.'''.format(target_platform))
             shutil.move(
                 os.path.join(outdir, 'libcutensor', 'lib', cuda),
                 os.path.join(destination, 'lib'))
-            if cuda == '10.2':
+            if cuda == '10.1':
                 license = 'license.pdf'  # v1.2.2
             else:
                 license = 'license.txt'  # v1.3.0

--- a/cupyx/tools/install_library.py
+++ b/cupyx/tools/install_library.py
@@ -109,21 +109,21 @@ def _make_cutensor_record(
 
 
 _cutensor_records.append(_make_cutensor_record(
-    '11.2', '1.2.2',
-    'libcutensor-linux-x86_64-1.2.2.5.tar.gz',
-    'libcutensor-windows-x86_64-1.2.2.5.zip'))
+    '11.2', '1.3.0',
+    'libcutensor-linux-x86_64-1.3.0.3.tar.gz',
+    'libcutensor-windows-x86_64-1.3.0.3.zip'))
 _cutensor_records.append(_make_cutensor_record(
-    '11.1', '1.2.2',
-    'libcutensor-linux-x86_64-1.2.2.5.tar.gz',
-    'libcutensor-windows-x86_64-1.2.2.5.zip'))
+    '11.1', '1.3.0',
+    'libcutensor-linux-x86_64-1.3.0.3.tar.gz',
+    'libcutensor-windows-x86_64-1.3.0.3.zip'))
 _cutensor_records.append(_make_cutensor_record(
-    '11.0', '1.2.2',
-    'libcutensor-linux-x86_64-1.2.2.5.tar.gz',
-    'libcutensor-windows-x86_64-1.2.2.5.zip'))
+    '11.0', '1.3.0',
+    'libcutensor-linux-x86_64-1.3.0.3.tar.gz',
+    'libcutensor-windows-x86_64-1.3.0.3.zip'))
 _cutensor_records.append(_make_cutensor_record(
-    '10.2', '1.2.2',
-    'libcutensor-linux-x86_64-1.2.2.5.tar.gz',
-    'libcutensor-windows-x86_64-1.2.2.5.zip'))
+    '10.2', '1.3.0',
+    'libcutensor-linux-x86_64-1.3.0.3.tar.gz',
+    'libcutensor-windows-x86_64-1.3.0.3.zip'))
 _cutensor_records.append(_make_cutensor_record(
     '10.1', '1.2.2',
     'libcutensor-linux-x86_64-1.2.2.5.tar.gz',
@@ -217,7 +217,7 @@ The current platform ({}) is not supported.'''.format(target_platform))
         if library == 'cudnn':
             shutil.move(os.path.join(outdir, 'cuda'), destination)
         elif library == 'cutensor':
-            if cuda.startswith('11.'):
+            if cuda.startswith('11.') and cuda != '11.0':
                 cuda = '11'
             shutil.move(
                 os.path.join(outdir, 'libcutensor', 'include'),
@@ -225,9 +225,12 @@ The current platform ({}) is not supported.'''.format(target_platform))
             shutil.move(
                 os.path.join(outdir, 'libcutensor', 'lib', cuda),
                 os.path.join(destination, 'lib'))
+            if cuda == '10.2':
+                license = 'license.pdf'  # v1.2.2
+            else:
+                license = 'license.txt'  # v1.3.0
             shutil.move(
-                os.path.join(outdir, 'libcutensor', 'license.pdf'),
-                destination)
+                os.path.join(outdir, 'libcutensor', license), destination)
         elif library == 'nccl':
             subdir = os.listdir(outdir)  # ['nccl_2.8.4-1+cuda11.2_x86_64']
             assert len(subdir) == 1


### PR DESCRIPTION
~~We may need an option to switch cuTENSOR v1.3.0 and v1.2.2 to install if v1.3.0 support is not to be backported to v9 as v1.3.0 is not binary compatible with previous versions. https://github.com/cupy/cupy/issues/5165#issuecomment-831001486~~

Just not backporting this PR is enough to leave v9 supporting v1.2.2. No additional switch is needed and we can use v9 `install_library.py`.