### PR TITLE
add sum_labels to cupyx.scipy.ndimage.measure

### DIFF
--- a/cupyx/scipy/ndimage/__init__.py
+++ b/cupyx/scipy/ndimage/__init__.py
@@ -38,6 +38,7 @@ from cupyx.scipy.ndimage.interpolation import zoom  # NOQA
 
 from cupyx.scipy.ndimage.measurements import label  # NOQA
 from cupyx.scipy.ndimage.measurements import sum  # NOQA
+from cupyx.scipy.ndimage.measurements import sum_labels  # NOQA
 from cupyx.scipy.ndimage.measurements import mean  # NOQA
 from cupyx.scipy.ndimage.measurements import variance  # NOQA
 from cupyx.scipy.ndimage.measurements import standard_deviation  # NOQA

--- a/cupyx/scipy/ndimage/measurements.py
+++ b/cupyx/scipy/ndimage/measurements.py
@@ -361,7 +361,7 @@ def variance(input, labels=None, index=None):
                                     out) / count
 
 
-def sum(input, labels=None, index=None):
+def sum_labels(input, labels=None, index=None):
     """Calculates the sum of the values of an n-D image array, optionally
        at specified sub-regions.
 
@@ -376,7 +376,7 @@ def sum(input, labels=None, index=None):
        sum (cupy.ndarray): sum of values, for each sub-region if
        `labels` and `index` are specified.
 
-    .. seealso:: :func:`scipy.ndimage.sum`
+    .. seealso:: :func:`scipy.ndimage.sum_labels`
     """
     if not isinstance(input, cupy.ndarray):
         raise TypeError('input must be cupy.ndarray')
@@ -423,6 +423,31 @@ def sum(input, labels=None, index=None):
     if (input.size >= 262144 and index.size <= 4) or use_kern:
         return _ndimage_sum_kernel_2(input, labels, index, out)
     return _ndimage_sum_kernel(input, labels, index, index.size, out)
+
+
+def sum(input, labels=None, index=None):
+    """Calculates the sum of the values of an n-D image array, optionally
+       at specified sub-regions.
+
+    Args:
+        input (cupy.ndarray): Nd-image data to process.
+        labels (cupy.ndarray or None): Labels defining sub-regions in `input`.
+            If not None, must be same shape as `input`.
+        index (cupy.ndarray or None): `labels` to include in output. If None
+            (default), all values where `labels` is non-zero are used.
+
+    Returns:
+       sum (cupy.ndarray): sum of values, for each sub-region if
+       `labels` and `index` are specified.
+
+    Notes:
+        This is an alias for `cupyx.scipy.ndimage.sum_labels` kept for
+        backwards compatibility reasons. For new code please prefer
+        `sum_labels`.
+
+    .. seealso:: :func:`scipy.ndimage.sum`
+    """
+    return sum_labels(input, labels, index)
 
 
 def mean(input, labels=None, index=None):

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
@@ -15,6 +15,7 @@ try:
     import scipy.ndimage  # NOQA
     scipy_version = numpy.lib.NumpyVersion(scipy.__version__)
 except ImportError:
+    scipy_version = numpy.lib.NumpyVersion('0.0.0')
     pass
 
 stats_ops = ['sum', 'mean', 'variance', 'standard_deviation', 'center_of_mass']

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
@@ -11,9 +11,16 @@ from cupy._core import _accelerator
 import cupyx.scipy.ndimage  # NOQA
 
 try:
+    import scipy
     import scipy.ndimage  # NOQA
+    scipy_version = numpy.lib.NumpyVersion(scipy.__version__)
 except ImportError:
     pass
+
+stats_ops = ['sum', 'mean', 'variance', 'standard_deviation', 'center_of_mass']
+if scipy_version >= '1.6.0':
+    # 'scipy 1.6 added a copy of sum under the name sum_labels'
+    stats_ops += ['sum_labels']
 
 
 def _generate_binary_structure(rank, connectivity):
@@ -105,8 +112,7 @@ class TestLabelSpecialCases:
 
 @testing.gpu
 @testing.parameterize(*testing.product({
-    'op': ['sum', 'sum_labels', 'mean', 'variance', 'standard_deviation',
-           'center_of_mass'],
+    'op': stats_ops,
 }))
 @testing.with_requires('scipy')
 class TestStats:

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
@@ -105,7 +105,8 @@ class TestLabelSpecialCases:
 
 @testing.gpu
 @testing.parameterize(*testing.product({
-    'op': ['sum', 'mean', 'variance', 'standard_deviation', 'center_of_mass'],
+    'op': ['sum', 'sum_labels', 'mean', 'variance', 'standard_deviation',
+           'center_of_mass'],
 }))
 @testing.with_requires('scipy')
 class TestStats:


### PR DESCRIPTION
closes #5111

This PR renames `sum` to `sum_labels`, but leaves the old function name available as well. This follows what was done upstream in SciPy 1.6.0. I was initially going to add a warning if the old name was used, but it doesn't look like SciPy has one, so I followed the same approach here.

I think this can be backported to 9.x as well since it is not really a new feature, but an API fix.
