### PR TITLE
Make cuTENSOR available in cupy.einsum

### DIFF
--- a/cupy/linalg/_einsum.py
+++ b/cupy/linalg/_einsum.py
@@ -303,9 +303,6 @@ def _use_cutensor(dtype0, sub0, dtype1, sub1, batch_dims, contract_dims):
     if dtype0 not in (cupy.float32, cupy.float64,
                       cupy.complex64, cupy.complex128):
         return False
-    if (len(contract_dims) >= 1 and (sub0[-1] in batch_dims or
-                                     sub1[-1] in batch_dims)):
-        return False
     return True
 
 


### PR DESCRIPTION
This PR is to allow users to use cuTENSOR more with `cupy.einsum`.

To be more precise, we already have code in `cupy.einsum` to use cuTENSOR, but when we added that code, there was not that big performance difference compared to the einsum implementation using matmul. For this reason, we have restricted the cases where cuTENSOR is actually used, even when the environment variable `CUPY_ACCELERATORS` is set to "cutensor".

This PR removes that restriction so that `cupy.einsum` will use cuTENSOR when it is selected in the environment variable.

Although cuTENSOR is not always faster than current implementation, cuTENSOR 1.3 has improved performance considerably and has been shown to be faster in many cases, as shown below.

subscripts | x.shape | y.shape | time (asis) | time (cutensor) | speed-up
-|-|-|-|-|-
float32
ijk,ikl->ijl | (128, 129, 130) | (128, 130, 256) | 0.493 ms | 0.294 ms | 1.68x
ijk,kli->ijl | (128, 129, 130) | (130, 256, 128) | 0.520 ms | 0.353 ms | 1.47x
ijk,lik->ijl | (128, 129, 130) | (256, 128, 130) | 0.450 ms | 0.338 ms | 1.33x
ijk,jkl->il | (128, 127, 126) | (127, 126, 256) | 0.418 ms | 0.191 ms | 2.19x
ijk,ljk->kl | (128, 127, 126) | (256, 127, 126) | 0.277 ms | 0.213 ms | 1.30x
ijk,lki->lj | (128, 127, 126) | (256, 126, 128) | 0.360 ms | 0.283 ms | 1.27x
ijkl,ijm->klm | (61, 62, 63, 64) | (61, 62, 128) | 0.538 ms | 0.497 ms | 1.08x
ijkl,iml->jmk | (61, 62, 63, 64) | (61, 128, 64) | 0.873 ms | 0.572 ms | 1.53x
ijkl,mkl->mij | (61, 62, 63, 64) | (128, 63, 64) | 0.866 ms | 0.473 ms | 1.83x
ijkl,ikl->ij | (65, 64, 63, 62) | (65, 63, 62) | 0.498 ms | 0.192 ms | 2.59x
ijkl,ijl->jk | (65, 64, 63, 62) | (65, 64, 62) | 0.481 ms | 0.421 ms | 1.14x
ijkl,ijk->kl | (65, 64, 63, 62) | (65, 64, 63) | 0.484 ms | 0.206 ms | 2.34x
float64
ijk,ikl->ijl | (128, 129, 130) | (128, 130, 256) | 0.778 ms | 0.421 ms | 1.85x
ijk,kli->ijl | (128, 129, 130) | (130, 256, 128) | 0.916 ms | 0.541 ms | 1.69x
ijk,lik->ijl | (128, 129, 130) | (256, 128, 130) | 0.741 ms | 0.430 ms | 1.72x
ijk,jkl->il | (128, 127, 126) | (127, 126, 256) | 0.879 ms | 0.371 ms | 2.37x
ijk,ljk->kl | (128, 127, 126) | (256, 127, 126) | 0.363 ms | 0.290 ms | 1.25x
ijk,lki->lj | (128, 127, 126) | (256, 126, 128) | 0.818 ms | 0.719 ms | 1.14x
ijkl,ijm->klm | (61, 62, 63, 64) | (61, 62, 128) | 0.811 ms | 0.748 ms | 1.09x
ijkl,iml->jmk | (61, 62, 63, 64) | (61, 128, 64) | 1.201 ms | 0.993 ms | 1.21x
ijkl,mkl->mij | (61, 62, 63, 64) | (128, 63, 64) | 1.340 ms | 0.833 ms | 1.61x
ijkl,ikl->ij | (65, 64, 63, 62) | (65, 63, 62) | 0.755 ms | 0.288 ms | 2.62x
ijkl,ijl->jk | (65, 64, 63, 62) | (65, 64, 62) | 0.776 ms | 0.717 ms | 1.08x
ijkl,ijk->kl | (65, 64, 63, 62) | (65, 64, 63) | 0.798 ms | 0.340 ms | 2.34x
complex64
ijk,ikl->ijl | (128, 129, 130) | (128, 130, 256) | 0.885 ms | 0.572 ms | 1.55x
ijk,kli->ijl | (128, 129, 130) | (130, 256, 128) | 0.971 ms | 0.692 ms | 1.40x
ijk,lik->ijl | (128, 129, 130) | (256, 128, 130) | 0.844 ms | 0.586 ms | 1.44x
ijk,jkl->il | (128, 127, 126) | (127, 126, 256) | 0.721 ms | 0.328 ms | 2.20x
ijk,ljk->kl | (128, 127, 126) | (256, 127, 126) | 0.365 ms | 0.286 ms | 1.28x
ijk,lki->lj | (128, 127, 126) | (256, 126, 128) | 0.638 ms | 0.428 ms | 1.49x
ijkl,ijm->klm | (61, 62, 63, 64) | (61, 62, 128) | 1.355 ms | 0.987 ms | 1.37x
ijkl,iml->jmk | (61, 62, 63, 64) | (61, 128, 64) | 1.757 ms | 1.920 ms | 0.92x
ijkl,mkl->mij | (61, 62, 63, 64) | (128, 63, 64) | 1.778 ms | 0.949 ms | 1.87x
ijkl,ikl->ij | (65, 64, 63, 62) | (65, 63, 62) | 0.750 ms | 0.286 ms | 2.63x
ijkl,ijl->jk | (65, 64, 63, 62) | (65, 64, 62) | 0.774 ms | 0.843 ms | 0.92x
ijkl,ijk->kl | (65, 64, 63, 62) | (65, 64, 63) | 0.798 ms | 0.343 ms | 2.32x
complex128
ijk,ikl->ijl | (128, 129, 130) | (128, 130, 256) | 1.546 ms | 1.151 ms | 1.34x
ijk,kli->ijl | (128, 129, 130) | (130, 256, 128) | 1.733 ms | 1.385 ms | 1.25x
ijk,lik->ijl | (128, 129, 130) | (256, 128, 130) | 1.549 ms | 1.156 ms | 1.34x
ijk,jkl->il | (128, 127, 126) | (127, 126, 256) | 1.083 ms | 0.536 ms | 2.02x
ijk,ljk->kl | (128, 127, 126) | (256, 127, 126) | 0.566 ms | 0.458 ms | 1.24x
ijk,lki->lj | (128, 127, 126) | (256, 126, 128) | 1.015 ms | 0.681 ms | 1.49x
ijkl,ijm->klm | (61, 62, 63, 64) | (61, 62, 128) | 3.289 ms | 1.870 ms | 1.76x
ijkl,iml->jmk | (61, 62, 63, 64) | (61, 128, 64) | 4.133 ms | 3.144 ms | 1.31x
ijkl,mkl->mij | (61, 62, 63, 64) | (128, 63, 64) | 4.288 ms | 2.010 ms | 2.13x
ijkl,ikl->ij | (65, 64, 63, 62) | (65, 63, 62) | 1.400 ms | 0.507 ms | 2.76x
ijkl,ijl->jk | (65, 64, 63, 62) | (65, 64, 62) | 1.512 ms | 1.664 ms | 0.91x
ijkl,ijk->kl | (65, 64, 63, 62) | (65, 64, 63) | 1.515 ms | 0.641 ms | 2.37x

<details><summary>script</summary>

```python
import cupy
import cupyx

n_warmup = 1
n_repeat = 10


def benchmark_einsum(subscripts, x, y):
    cupy._core.set_routine_accelerators(())
    time_asis = cupyx.time.repeat(cupy.einsum, (subscripts, x, y),
                                  n_warmup=n_warmup, n_repeat=n_repeat)
    cupy._core.set_routine_accelerators(('cutensor',))
    time_cutensor = cupyx.time.repeat(cupy.einsum, (subscripts, x, y),
                                      n_warmup=n_warmup, n_repeat=n_repeat)
    ms_asis = time_asis.gpu_times.mean() * 1000
    ms_cutensor = time_cutensor.gpu_times.mean() * 1000
    print('{} | {} | {} | {:.3f} ms | {:.3f} ms | {:.2f}x'.format(
        subscripts, x.shape, y.shape,
        ms_asis, ms_cutensor, ms_asis / ms_cutensor))


cupy.show_config()
print()

print('subscripts | x.shape | y.shape | time (asis) | time (cutensor) | speed-up')
for dtype in ('float32', 'float64', 'complex64', 'complex128'):
    print('{}'.format(dtype))

    # x:3d, y:3d, batch;1d, contraction:1d, 
    i, j, k, l = 128, 129, 130, 256
    x = cupy.random.random((i, j, k)).astype(dtype)

    subscripts = 'ijk,ikl->ijl'
    y = cupy.random.random((i, k, l)).astype(dtype)
    benchmark_einsum(subscripts, x, y)

    subscripts = 'ijk,kli->ijl'
    y = cupy.random.random((k, l, i)).astype(dtype)
    benchmark_einsum(subscripts, x, y)

    subscripts = 'ijk,lik->ijl'
    y = cupy.random.random((l, i, k)).astype(dtype)
    benchmark_einsum(subscripts, x, y)

    # x:3d, y:3d, batch;0d, contraction:2d, 
    i, j, k, l = 128, 127, 126, 256
    x = cupy.random.random((i, j, k)).astype(dtype)

    subscripts = 'ijk,jkl->il'
    y = cupy.random.random((j, k, l)).astype(dtype)
    benchmark_einsum(subscripts, x, y)

    subscripts = 'ijk,ljk->kl'
    y = cupy.random.random((l, j, k)).astype(dtype)
    benchmark_einsum(subscripts, x, y)

    subscripts = 'ijk,lki->lj'
    y = cupy.random.random((l, k, i)).astype(dtype)
    benchmark_einsum(subscripts, x, y)

    # x:4d, y:3d, batch;0d, contraction:2d, 
    i, j, k, l, m = 61, 62, 63, 64, 128
    x = cupy.random.random((i, j, k, l)).astype(dtype)

    subscripts = 'ijkl,ijm->klm'
    y = cupy.random.random((i, j, m)).astype(dtype)
    benchmark_einsum(subscripts, x, y)

    subscripts = 'ijkl,iml->jmk'
    y = cupy.random.random((i, m, l)).astype(dtype)
    benchmark_einsum(subscripts, x, y)

    subscripts = 'ijkl,mkl->mij'
    y = cupy.random.random((m, k, l)).astype(dtype)
    benchmark_einsum(subscripts, x, y)
    
    # x:4d, y:3d, batch;1d, contraction:2d, 
    i, j, k, l = 65, 64, 63, 62
    x = cupy.random.random((i, j, k, l)).astype(dtype)

    subscripts = 'ijkl,ikl->ij'
    y = cupy.random.random((i, k, l)).astype(dtype)
    benchmark_einsum(subscripts, x, y)

    subscripts = 'ijkl,ijl->jk'
    y = cupy.random.random((i, j, l)).astype(dtype)
    benchmark_einsum(subscripts, x, y)

    subscripts = 'ijkl,ijk->kl'
    y = cupy.random.random((i, j, k)).astype(dtype)
    benchmark_einsum(subscripts, x, y)
```
</details>

<details><summary>config</summary>

```
OS                           : Linux-5.8.0-50-generic-x86_64-with-debian-bullseye-sid
CuPy Version                 : 9.0.0rc1
NumPy Version                : 1.20.2
SciPy Version                : 1.6.2
Cython Build Version         : 0.29.22
Cython Runtime Version       : 0.29.22
CUDA Root                    : /usr/local/cuda-11.3.0
CUDA Build Version           : 11030
CUDA Driver Version          : 11030
CUDA Runtime Version         : 11030
cuBLAS Version               : 11402
cuFFT Version                : 10402
cuRAND Version               : 10204
cuSOLVER Version             : (11, 1, 1)
cuSPARSE Version             : 11500
NVRTC Version                : (11, 3)
Thrust Version               : 101100
CUB Build Version            : 101100
Jitify Build Version         : 60e9e72
cuDNN Build Version          : None
cuDNN Version                : None
NCCL Build Version           : None
NCCL Runtime Version         : None
cuTENSOR Version             : 10300
cuSPARSELt Build Version     : None
Device 0 Name                : NVIDIA Quadro GV100
Device 0 Compute Capability  : 70
Device 0 PCI Bus ID          : 0000:2D:00.0
Device 1 Name                : NVIDIA Quadro GV100
Device 1 Compute Capability  : 70
Device 1 PCI Bus ID          : 0000:2E:00.0
```
</details>