### PR TITLE
Fix matmul for input with relaxed strides

### DIFF
--- a/cupy/_core/_routines_linalg.pyx
+++ b/cupy/_core/_routines_linalg.pyx
@@ -647,7 +647,8 @@ cpdef ndarray tensordot_core_v11(
 cdef Py_ssize_t _get_stride_for_strided_batched_gemm(ndarray a) except? 0:
     cdef int ndim = a._shape.size()
     assert ndim > 2
-    return a._strides[ndim - 3] // <Py_ssize_t>a.itemsize
+    assert a._c_contiguous
+    return a._shape[ndim - 2] * a._shape[ndim - 1]
 
 
 cdef _mat_ptrs_kernel = ElementwiseKernel(

--- a/tests/cupy_tests/math_tests/test_matmul.py
+++ b/tests/cupy_tests/math_tests/test_matmul.py
@@ -75,6 +75,16 @@ class TestMatmul(unittest.TestCase):
         return xp.matmul(x1, x2)
 
 
+class TestMatmulStrides:
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-3)  # required for uint8
+    def test_relaxed_c_contiguous_input(self, xp, dtype):
+        x1 = testing.shaped_arange((2, 2, 3), xp, dtype)[:, None, :, :]
+        x2 = testing.shaped_arange((2, 1, 3, 1), xp, dtype)
+        return x1 @ x2
+
+
 @testing.parameterize(
     *testing.product({
         'shape_pair': [


### PR DESCRIPTION
`_get_stride_for_strided_batched_gemm` assumed that the input `a` has the canonical strides at least in the batch dimensions (`a.shape[:-2]`), which was not true.

This PR computes stride for `<t>gemmStridedBatched` from `a.shape[-2:]` by assuming `a` is C-contiguous in the sense of NumPy>=1.10 (see https://numpy.org/doc/stable/reference/arrays.ndarray.html#index-3 for `NPY_RELAXED_STRIDES_CHECKING`).