### PR TITLE
Fix `check_availablity` for `cupy.cusolver`

### DIFF
--- a/cupy/cusolver.pyx
+++ b/cupy/cusolver.pyx
@@ -84,7 +84,7 @@ _available_compute_capability = {
 }
 
 
-@_util.memoize()
+@_util.memoize(for_each_device=True)
 def check_availability(name):
     if not _runtime.is_hip:
         available_version = _available_cuda_version


### PR DESCRIPTION
Found in discusson of #5204.
Functions that return per-device results should be memorized for each device.