### PR TITLE
Fix thrust compilation for ROCm 4.2.0

### DIFF
--- a/.pfnci/script.sh
+++ b/.pfnci/script.sh
@@ -68,7 +68,7 @@ main() {
       python3.7 -m pip install cython numpy
 
       wget -qO - http://repo.radeon.com/rocm/rocm.gpg.key | apt-key add -
-      echo 'deb [arch=amd64] http://repo.radeon.com/rocm/apt/4.0.1/ xenial main' | tee /etc/apt/sources.list.d/rocm.list
+      echo 'deb [arch=amd64] http://repo.radeon.com/rocm/apt/debian/ xenial main' | tee /etc/apt/sources.list.d/rocm.list
 
       # Uninstall CUDA to ensure it's a clean ROCm environment
       # https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#removing-cuda-tk-and-driver

--- a/cupy/cuda/cupy_thrust.cu
+++ b/cupy/cuda/cupy_thrust.cu
@@ -6,7 +6,7 @@
 #include <thrust/sort.h>
 #include <thrust/tuple.h>
 #include <thrust/execution_policy.h>
-#if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2))
+#if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2) || HIP_VERSION >= 402)
 // This is used to avoid a problem with constexpr in functions declarations introduced in
 // cuda 11.2, MSVC 15 does not fully support it so we need a dummy constexpr declaration
 // that is provided by this header. However optional.h is only available
@@ -143,7 +143,7 @@ bool _cmp_less(const T& lhs, const T& rhs) {
 template <>
 __host__ __device__ __forceinline__
 #if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2) || HIP_VERSION >= 402)
-constexpr
+THRUST_OPTIONAL_CPP11_CONSTEXPR
 #endif
 bool less<complex<float>>::operator() (
     const complex<float>& lhs, const complex<float>& rhs) const {
@@ -155,7 +155,7 @@ bool less<complex<float>>::operator() (
 template <>
 __host__ __device__ __forceinline__
 #if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2) || HIP_VERSION >= 402)
-constexpr
+THRUST_OPTIONAL_CPP11_CONSTEXPR
 #endif
 bool less<complex<double>>::operator() (
     const complex<double>& lhs, const complex<double>& rhs) const {
@@ -167,7 +167,7 @@ bool less<complex<double>>::operator() (
 template <>
 __host__ __device__ __forceinline__
 #if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2) || HIP_VERSION >= 402)
-constexpr
+THRUST_OPTIONAL_CPP11_CONSTEXPR
 #endif
 bool less< tuple<size_t, complex<float>> >::operator() (
     const tuple<size_t, complex<float>>& lhs, const tuple<size_t, complex<float>>& rhs) const {
@@ -179,7 +179,7 @@ bool less< tuple<size_t, complex<float>> >::operator() (
 template <>
 __host__ __device__ __forceinline__
 #if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2) || HIP_VERSION >= 402)
-constexpr
+THRUST_OPTIONAL_CPP11_CONSTEXPR
 #endif
 bool less< tuple<size_t, complex<double>> >::operator() (
     const tuple<size_t, complex<double>>& lhs, const tuple<size_t, complex<double>>& rhs) const {
@@ -219,7 +219,7 @@ bool _real_less(const T& lhs, const T& rhs) {
 template <>
 __host__ __device__ __forceinline__
 #if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2) || HIP_VERSION >= 402)
-constexpr
+THRUST_OPTIONAL_CPP11_CONSTEXPR
 #endif
 bool less<float>::operator() (
     const float& lhs, const float& rhs) const {
@@ -231,7 +231,7 @@ bool less<float>::operator() (
 template <>
 __host__ __device__ __forceinline__
 #if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2) || HIP_VERSION >= 402)
-constexpr
+THRUST_OPTIONAL_CPP11_CONSTEXPR
 #endif
 bool less<double>::operator() (
     const double& lhs, const double& rhs) const {
@@ -243,7 +243,7 @@ bool less<double>::operator() (
 template <>
 __host__ __device__ __forceinline__
 #if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2) || HIP_VERSION >= 402)
-constexpr
+THRUST_OPTIONAL_CPP11_CONSTEXPR
 #endif
 bool less< tuple<size_t, float> >::operator() (
     const tuple<size_t, float>& lhs, const tuple<size_t, float>& rhs) const {
@@ -255,7 +255,7 @@ bool less< tuple<size_t, float> >::operator() (
 template <>
 __host__ __device__ __forceinline__
 #if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2) || HIP_VERSION >= 402)
-constexpr
+THRUST_OPTIONAL_CPP11_CONSTEXPR
 #endif
 bool less< tuple<size_t, double> >::operator() (
     const tuple<size_t, double>& lhs, const tuple<size_t, double>& rhs) const {
@@ -283,7 +283,7 @@ __host__ __device__ __forceinline__ bool isnan(const __half& x) {
 template <>
 __host__ __device__ __forceinline__
 #if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2) || HIP_VERSION >= 402)
-constexpr
+THRUST_OPTIONAL_CPP11_CONSTEXPR
 #endif
 bool less<__half>::operator() (const __half& lhs, const __half& rhs) const {
     return _real_less<__half>(lhs, rhs);
@@ -293,7 +293,7 @@ bool less<__half>::operator() (const __half& lhs, const __half& rhs) const {
 template <>
 __host__ __device__ __forceinline__
 #if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2) || HIP_VERSION >= 402)
-constexpr
+THRUST_OPTIONAL_CPP11_CONSTEXPR
 #endif
 bool less< tuple<size_t, __half> >::operator() (
     const tuple<size_t, __half>& lhs, const tuple<size_t, __half>& rhs) const {

--- a/cupy/cuda/cupy_thrust.cu
+++ b/cupy/cuda/cupy_thrust.cu
@@ -142,7 +142,7 @@ bool _cmp_less(const T& lhs, const T& rhs) {
 // specialize thrust::less for single complex
 template <>
 __host__ __device__ __forceinline__
-#if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2))
+#if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2) || defined(__HIPCC__))
 constexpr
 #endif
 bool less<complex<float>>::operator() (
@@ -154,7 +154,7 @@ bool less<complex<float>>::operator() (
 // specialize thrust::less for double complex
 template <>
 __host__ __device__ __forceinline__
-#if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2))
+#if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2) || defined(__HIPCC__))
 constexpr
 #endif
 bool less<complex<double>>::operator() (
@@ -166,7 +166,7 @@ bool less<complex<double>>::operator() (
 // specialize thrust::less for tuple<size_t, complex<float>>
 template <>
 __host__ __device__ __forceinline__
-#if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2))
+#if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2) || defined(__HIPCC__))
 constexpr
 #endif
 bool less< tuple<size_t, complex<float>> >::operator() (
@@ -178,7 +178,7 @@ bool less< tuple<size_t, complex<float>> >::operator() (
 // specialize thrust::less for tuple<size_t, complex<double>>
 template <>
 __host__ __device__ __forceinline__
-#if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2))
+#if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2) || defined(__HIPCC__))
 constexpr
 #endif
 bool less< tuple<size_t, complex<double>> >::operator() (
@@ -218,7 +218,7 @@ bool _real_less(const T& lhs, const T& rhs) {
 // specialize thrust::less for float
 template <>
 __host__ __device__ __forceinline__
-#if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2))
+#if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2) || defined(__HIPCC__))
 constexpr
 #endif
 bool less<float>::operator() (
@@ -230,7 +230,7 @@ bool less<float>::operator() (
 // specialize thrust::less for double
 template <>
 __host__ __device__ __forceinline__
-#if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2))
+#if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2) || defined(__HIPCC__))
 constexpr
 #endif
 bool less<double>::operator() (
@@ -242,7 +242,7 @@ bool less<double>::operator() (
 // specialize thrust::less for tuple<size_t, float>
 template <>
 __host__ __device__ __forceinline__
-#if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2))
+#if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2) || defined(__HIPCC__))
 constexpr
 #endif
 bool less< tuple<size_t, float> >::operator() (
@@ -254,7 +254,7 @@ bool less< tuple<size_t, float> >::operator() (
 // specialize thrust::less for tuple<size_t, double>
 template <>
 __host__ __device__ __forceinline__
-#if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2))
+#if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2) || defined(__HIPCC__))
 constexpr
 #endif
 bool less< tuple<size_t, double> >::operator() (
@@ -282,7 +282,7 @@ __host__ __device__ __forceinline__ bool isnan(const __half& x) {
 // specialize thrust::less for __half
 template <>
 __host__ __device__ __forceinline__
-#if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2))
+#if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2) || defined(__HIPCC__))
 constexpr
 #endif
 bool less<__half>::operator() (const __half& lhs, const __half& rhs) const {
@@ -292,7 +292,7 @@ bool less<__half>::operator() (const __half& lhs, const __half& rhs) const {
 // specialize thrust::less for tuple<size_t, __half>
 template <>
 __host__ __device__ __forceinline__
-#if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2))
+#if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2) || defined(__HIPCC__))
 constexpr
 #endif
 bool less< tuple<size_t, __half> >::operator() (

--- a/cupy/cuda/cupy_thrust.cu
+++ b/cupy/cuda/cupy_thrust.cu
@@ -142,7 +142,7 @@ bool _cmp_less(const T& lhs, const T& rhs) {
 // specialize thrust::less for single complex
 template <>
 __host__ __device__ __forceinline__
-#if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2) || defined(__HIPCC__))
+#if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2) || HIP_VERSION >= 402)
 constexpr
 #endif
 bool less<complex<float>>::operator() (
@@ -154,7 +154,7 @@ bool less<complex<float>>::operator() (
 // specialize thrust::less for double complex
 template <>
 __host__ __device__ __forceinline__
-#if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2) || defined(__HIPCC__))
+#if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2) || HIP_VERSION >= 402)
 constexpr
 #endif
 bool less<complex<double>>::operator() (
@@ -166,7 +166,7 @@ bool less<complex<double>>::operator() (
 // specialize thrust::less for tuple<size_t, complex<float>>
 template <>
 __host__ __device__ __forceinline__
-#if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2) || defined(__HIPCC__))
+#if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2) || HIP_VERSION >= 402)
 constexpr
 #endif
 bool less< tuple<size_t, complex<float>> >::operator() (
@@ -178,7 +178,7 @@ bool less< tuple<size_t, complex<float>> >::operator() (
 // specialize thrust::less for tuple<size_t, complex<double>>
 template <>
 __host__ __device__ __forceinline__
-#if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2) || defined(__HIPCC__))
+#if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2) || HIP_VERSION >= 402)
 constexpr
 #endif
 bool less< tuple<size_t, complex<double>> >::operator() (
@@ -218,7 +218,7 @@ bool _real_less(const T& lhs, const T& rhs) {
 // specialize thrust::less for float
 template <>
 __host__ __device__ __forceinline__
-#if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2) || defined(__HIPCC__))
+#if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2) || HIP_VERSION >= 402)
 constexpr
 #endif
 bool less<float>::operator() (
@@ -230,7 +230,7 @@ bool less<float>::operator() (
 // specialize thrust::less for double
 template <>
 __host__ __device__ __forceinline__
-#if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2) || defined(__HIPCC__))
+#if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2) || HIP_VERSION >= 402)
 constexpr
 #endif
 bool less<double>::operator() (
@@ -242,7 +242,7 @@ bool less<double>::operator() (
 // specialize thrust::less for tuple<size_t, float>
 template <>
 __host__ __device__ __forceinline__
-#if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2) || defined(__HIPCC__))
+#if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2) || HIP_VERSION >= 402)
 constexpr
 #endif
 bool less< tuple<size_t, float> >::operator() (
@@ -254,7 +254,7 @@ bool less< tuple<size_t, float> >::operator() (
 // specialize thrust::less for tuple<size_t, double>
 template <>
 __host__ __device__ __forceinline__
-#if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2) || defined(__HIPCC__))
+#if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2) || HIP_VERSION >= 402)
 constexpr
 #endif
 bool less< tuple<size_t, double> >::operator() (
@@ -282,7 +282,7 @@ __host__ __device__ __forceinline__ bool isnan(const __half& x) {
 // specialize thrust::less for __half
 template <>
 __host__ __device__ __forceinline__
-#if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2) || defined(__HIPCC__))
+#if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2) || HIP_VERSION >= 402)
 constexpr
 #endif
 bool less<__half>::operator() (const __half& lhs, const __half& rhs) const {
@@ -292,7 +292,7 @@ bool less<__half>::operator() (const __half& lhs, const __half& rhs) const {
 // specialize thrust::less for tuple<size_t, __half>
 template <>
 __host__ __device__ __forceinline__
-#if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2) || defined(__HIPCC__))
+#if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2) || HIP_VERSION >= 402)
 constexpr
 #endif
 bool less< tuple<size_t, __half> >::operator() (

--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -1061,7 +1061,13 @@ class _UnixCCompiler(unixccompiler.UnixCCompiler):
         rocm_path = build.get_hipcc_path()
         base_opts = build.get_compiler_base_options(rocm_path)
         compiler_so = rocm_path
+
+        hip_version = build.get_hip_version()
         postargs = ['-O2', '-fPIC', '--include', 'hip_runtime.h']
+        if hip_version >= 402:
+            postargs += ['--std=c++14']
+        else:
+            postargs += ['--std=c++11']
         print('HIPCC options:', postargs)
         try:
             self.spawn(compiler_so + base_opts + cc_args + [src, '-o', obj] +


### PR DESCRIPTION
This fixes the constexpr issue for building CuPy with ROCm 4.2.0, and also reverts https://github.com/cupy/cupy/pull/4961 to make it use the latest ROCm.