### PR TITLE
Fix cusparseLt not covered in docs

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -62,6 +62,10 @@ Part of the CUDA features in CuPy will be activated only when the corresponding 
 
     * The library to accelerate deep neural network computations.
 
+* `cuSPARSELt <https://docs.nvidia.com/cuda/cusparselt/>`_: v0.1.0
+
+    * The library to accelerate sparse matrix-matrix multiplication.
+
 
 Installing CuPy
 ---------------


### PR DESCRIPTION
Blocked by https://github.com/cupy/cupy/pull/5158
When backporting v0.0.1 needs to be added.