### PR TITLE
Fix windows constexpr

### DIFF
--- a/cupy/cuda/cupy_thrust.cu
+++ b/cupy/cuda/cupy_thrust.cu
@@ -15,6 +15,8 @@
 
 #if (defined(_MSC_VER)
 #define THRUST_OPTIONAL_CPP11_CONSTEXPR constexpr
+#else
+#define THRUST_OPTIONAL_CPP11_CONSTEXPR_LESS THRUST_OPTIONAL_CPP11_CONSTEXPR
 #endif
 
 #endif
@@ -148,7 +150,7 @@ bool _cmp_less(const T& lhs, const T& rhs) {
 template <>
 __host__ __device__ __forceinline__
 #if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2) || HIP_VERSION >= 402)
-THRUST_OPTIONAL_CPP11_CONSTEXPR
+THRUST_OPTIONAL_CPP11_CONSTEXPR_LESS
 #endif
 bool less<complex<float>>::operator() (
     const complex<float>& lhs, const complex<float>& rhs) const {
@@ -160,7 +162,7 @@ bool less<complex<float>>::operator() (
 template <>
 __host__ __device__ __forceinline__
 #if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2) || HIP_VERSION >= 402)
-THRUST_OPTIONAL_CPP11_CONSTEXPR
+THRUST_OPTIONAL_CPP11_CONSTEXPR_LESS
 #endif
 bool less<complex<double>>::operator() (
     const complex<double>& lhs, const complex<double>& rhs) const {
@@ -172,7 +174,7 @@ bool less<complex<double>>::operator() (
 template <>
 __host__ __device__ __forceinline__
 #if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2) || HIP_VERSION >= 402)
-THRUST_OPTIONAL_CPP11_CONSTEXPR
+THRUST_OPTIONAL_CPP11_CONSTEXPR_LESS
 #endif
 bool less< tuple<size_t, complex<float>> >::operator() (
     const tuple<size_t, complex<float>>& lhs, const tuple<size_t, complex<float>>& rhs) const {
@@ -184,7 +186,7 @@ bool less< tuple<size_t, complex<float>> >::operator() (
 template <>
 __host__ __device__ __forceinline__
 #if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2) || HIP_VERSION >= 402)
-THRUST_OPTIONAL_CPP11_CONSTEXPR
+THRUST_OPTIONAL_CPP11_CONSTEXPR_LESS
 #endif
 bool less< tuple<size_t, complex<double>> >::operator() (
     const tuple<size_t, complex<double>>& lhs, const tuple<size_t, complex<double>>& rhs) const {
@@ -224,7 +226,7 @@ bool _real_less(const T& lhs, const T& rhs) {
 template <>
 __host__ __device__ __forceinline__
 #if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2) || HIP_VERSION >= 402)
-THRUST_OPTIONAL_CPP11_CONSTEXPR
+THRUST_OPTIONAL_CPP11_CONSTEXPR_LESS
 #endif
 bool less<float>::operator() (
     const float& lhs, const float& rhs) const {
@@ -236,7 +238,7 @@ bool less<float>::operator() (
 template <>
 __host__ __device__ __forceinline__
 #if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2) || HIP_VERSION >= 402)
-THRUST_OPTIONAL_CPP11_CONSTEXPR
+THRUST_OPTIONAL_CPP11_CONSTEXPR_LESS
 #endif
 bool less<double>::operator() (
     const double& lhs, const double& rhs) const {
@@ -248,7 +250,7 @@ bool less<double>::operator() (
 template <>
 __host__ __device__ __forceinline__
 #if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2) || HIP_VERSION >= 402)
-THRUST_OPTIONAL_CPP11_CONSTEXPR
+THRUST_OPTIONAL_CPP11_CONSTEXPR_LESS
 #endif
 bool less< tuple<size_t, float> >::operator() (
     const tuple<size_t, float>& lhs, const tuple<size_t, float>& rhs) const {
@@ -260,7 +262,7 @@ bool less< tuple<size_t, float> >::operator() (
 template <>
 __host__ __device__ __forceinline__
 #if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2) || HIP_VERSION >= 402)
-THRUST_OPTIONAL_CPP11_CONSTEXPR
+THRUST_OPTIONAL_CPP11_CONSTEXPR_LESS
 #endif
 bool less< tuple<size_t, double> >::operator() (
     const tuple<size_t, double>& lhs, const tuple<size_t, double>& rhs) const {
@@ -288,7 +290,7 @@ __host__ __device__ __forceinline__ bool isnan(const __half& x) {
 template <>
 __host__ __device__ __forceinline__
 #if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2) || HIP_VERSION >= 402)
-THRUST_OPTIONAL_CPP11_CONSTEXPR
+THRUST_OPTIONAL_CPP11_CONSTEXPR_LESS
 #endif
 bool less<__half>::operator() (const __half& lhs, const __half& rhs) const {
     return _real_less<__half>(lhs, rhs);
@@ -298,7 +300,7 @@ bool less<__half>::operator() (const __half& lhs, const __half& rhs) const {
 template <>
 __host__ __device__ __forceinline__
 #if (__CUDACC_VER_MAJOR__ >11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2) || HIP_VERSION >= 402)
-THRUST_OPTIONAL_CPP11_CONSTEXPR
+THRUST_OPTIONAL_CPP11_CONSTEXPR_LESS
 #endif
 bool less< tuple<size_t, __half> >::operator() (
     const tuple<size_t, __half>& lhs, const tuple<size_t, __half>& rhs) const {

--- a/cupy/cuda/cupy_thrust.cu
+++ b/cupy/cuda/cupy_thrust.cu
@@ -12,6 +12,11 @@
 // that is provided by this header. However optional.h is only available
 // starting CUDA 10.1
 #include <thrust/optional.h>
+
+#if (defined(_MSC_VER)
+#define THRUST_OPTIONAL_CPP11_CONSTEXPR constexpr
+#endif
+
 #endif
 #include "cupy_thrust.h"
 

--- a/cupy/cuda/cupy_thrust.cu
+++ b/cupy/cuda/cupy_thrust.cu
@@ -13,7 +13,7 @@
 // starting CUDA 10.1
 #include <thrust/optional.h>
 
-#if (defined(_MSC_VER)
+#ifdef _MSC_VER
 #define THRUST_OPTIONAL_CPP11_CONSTEXPR_LESS constexpr
 #else
 #define THRUST_OPTIONAL_CPP11_CONSTEXPR_LESS THRUST_OPTIONAL_CPP11_CONSTEXPR

--- a/cupy/cuda/cupy_thrust.cu
+++ b/cupy/cuda/cupy_thrust.cu
@@ -14,7 +14,7 @@
 #include <thrust/optional.h>
 
 #if (defined(_MSC_VER)
-#define THRUST_OPTIONAL_CPP11_CONSTEXPR constexpr
+#define THRUST_OPTIONAL_CPP11_CONSTEXPR_LESS constexpr
 #else
 #define THRUST_OPTIONAL_CPP11_CONSTEXPR_LESS THRUST_OPTIONAL_CPP11_CONSTEXPR
 #endif


### PR DESCRIPTION
constexpr does not work the same way in c++11 and 14 and mscv 15 has no full c++14 support
so we need hacks like this 😭😭