### PR TITLE
[WIP] Do not use weakref to hold current stream

### DIFF
--- a/cupy/cuda/stream.pyx
+++ b/cupy/cuda/stream.pyx
@@ -365,7 +365,6 @@ class Stream(BaseStream):
         self._weakref = weakref.ref(self)
 
     def __del__(self, is_shutting_down=_util.is_shutting_down):
-        cdef intptr_t current_ptr
         if is_shutting_down():
             return
         if self.ptr not in (0, runtime.streamLegacy, runtime.streamPerThread):


### PR DESCRIPTION
The problem in the current implementation using `weakref` is that when a stream instance is shared between threads, the current stream ptr set in one thread can be discarded in a destructor that runs in another thread.

ref: #5237 #5172

TODO: add tests.