### PR TITLE
Fix mergify configuration

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -5,7 +5,6 @@ pull_request_rules:
       - label=st:test-and-merge
       - status-success=Jenkins
       - status-success=pretest  # github workflows
-      - status-success=pfn-public-ci/cupy.py3.amd
     actions:
       merge:
         method: merge


### PR DESCRIPTION
Follow-up #5224. As ROCm CI has been renamed, mergify config needs to be updated.

Actually, Mergify respects the branch protections settigns configured in GitHub (i.e., `Required` signs of pull-request statuses), so nothing needs to be listed in the configuration.
However I'd like to keep `pretest` and `Jenkins` here for fail-safe.