### PR TITLE
Tentatively remove CUDA 11.3 from support list

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -6,7 +6,7 @@ Requirements
 
 * `NVIDIA CUDA GPU <https://developer.nvidia.com/cuda-gpus>`_ with the Compute Capability 3.0 or larger.
 
-* `CUDA Toolkit <https://developer.nvidia.com/cuda-toolkit>`_: v9.2 / v10.0 / v10.1 / v10.2 / v11.0 / v11.1 / v11.2 / v11.3
+* `CUDA Toolkit <https://developer.nvidia.com/cuda-toolkit>`_: v9.2 / v10.0 / v10.1 / v10.2 / v11.0 / v11.1 / v11.2
 
     * If you have multiple versions of CUDA Toolkit installed, CuPy will automatically choose one of the CUDA installations.
       See :ref:`install_cuda` for details.
@@ -92,8 +92,6 @@ Package names are different depending on your CUDA Toolkit version.
      - ``$ pip install cupy-cuda111``
    * - v11.2
      - ``$ pip install cupy-cuda112``
-   * - v11.3
-     - ``$ pip install cupy-cuda113``
 
 .. note::
 


### PR DESCRIPTION
We observed failure in CUDA 11.3 fft cache tests, so let's skip supporting it in this month's release.

https://github.com/chainer/chainer-test/pull/658