### PR TITLE
[WIP] Add `cupy.testing.TestThread` for unittests

### DIFF
--- a/cupy/testing/__init__.py
+++ b/cupy/testing/__init__.py
@@ -48,3 +48,4 @@ from cupy.testing._parameterized import product  # NOQA
 from cupy.testing._parameterized import product_dict  # NOQA
 from cupy.testing._random import fix_random  # NOQA
 from cupy.testing._random import generate_seed  # NOQA
+from cupy.testing._thread import TestThread  # NOQA

--- a/cupy/testing/_thread.py
+++ b/cupy/testing/_thread.py
@@ -1,0 +1,24 @@
+import threading
+
+
+class TestThread(threading.Thread):
+    """A thread that can propagate exceptions.
+
+    This class can be used as a drop-in replacement to `threading.Thread`.
+    Exception raised in the thread will be reraised upon `join()`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._exc = None
+
+    def run(self, *args, **kwargs):
+        try:
+            super().run(*args, **kwargs)
+        except Exception as e:
+            self._exc = e
+
+    def join(self, *args, **kwargs):
+        super().join(*args, **kwargs)
+        if self._exc is not None:
+            raise self._exc


### PR DESCRIPTION
pytest has a thread exception hook (`PytestUnhandledThreadExceptionWarning`) but it seems it's not always working (plus not supported in Python 3.7 or earlier).
For example, running the following code with pytest does not emit a warning in my environment (pytest 6.2.0 and 6.2.4):

```py
import threading
import pytest

def f():
    raise RuntimeError

def test_main():
    with pytest.raises(RuntimeError):
        f()

def test_thread():
    t = threading.Thread(target=f, daemon=True)
    t.start()
    t.join()
```

I'd like to have a Thread class that propagates an exception so that we can reliably detect errors in subthreads.

TODO:
- add tests
- use TestThreads in tests