### PR TITLE
Exclude Cython 3 from setup_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ for submodule in ('cupy/_core/include/cupy/cub/',
 requirements = {
     # TODO(kmaehashi): migrate to pyproject.toml (see #4727, #4619)
     'setup': [
-        'Cython>=0.29.22',
+        'Cython>=0.29.22,<3',
         'fastrlock>=0.5',
     ],
 


### PR DESCRIPTION
Cython 3.0a7 causes a build failure with the current codebase:

```
    building 'cupy_backends.cuda.api.runtime' extension
    gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -D_FORCE_INLINES=1 -DCUPY_CUB_VERSION_CODE=-1 -DCUPY_JITIFY_VERSION_CODE=8f42e9a -I/home/maehashi/Development/release-20210527/cupy-10.0.0a1/install/../cupy/_core/include/cupy/cub -I/home/maehashi/Development/release-20210527/cupy-10.0.0a1/install/../cupy/_core/include -I/usr/local/cuda/include 
-I/opt/pyenv/versions/3.7.0/include/python3.7m -c cupy_backends/cuda/api/runtime.cpp -o build/temp.linux-x86_64-3.7/cupy_backends/cuda/api/runtime.o
    cupy_backends/cuda/api/runtime.cpp: In function ‘PyObject* __pyx_f_7cpython_11contextvars_get_value(PyObject*, __pyx_opt_args_7cpython_11contextvars_get_value*)’:
    cupy_backends/cuda/api/runtime.cpp:25399:67: error: cannot convert ‘PyObject* {aka _object*}’ to ‘PyContextVar* {aka _pycontextvarobject*}’ for argument ‘1’ to ‘int PyContextVar_Get(PyContextVar*, PyObject*, PyObject**)’
       __pyx_t_1 = PyContextVar_Get(__pyx_v_var, NULL, (&__pyx_v_value)); if (unlikely(__pyx_t_1 == ((int)-1))) __PYX_ERR(3, 118, __pyx_L1_error)
                                                                       ^
    cupy_backends/cuda/api/runtime.cpp: In function ‘PyObject* __pyx_f_7cpython_11contextvars_get_value_no_default(PyObject*, __pyx_opt_args_7cpython_11contextvars_get_value_no_default*)’:
    cupy_backends/cuda/api/runtime.cpp:25520:98: error: cannot convert ‘PyObject* {aka _object*}’ to ‘PyContextVar* {aka _pycontextvarobject*}’ for argument ‘1’ to ‘int PyContextVar_Get(PyContextVar*, PyObject*, PyObject**)’
       __pyx_t_1 = PyContextVar_Get(__pyx_v_var, ((PyObject *)__pyx_v_default_value), (&__pyx_v_value)); if (unlikely(__pyx_t_1 == ((int)-1))) __PYX_ERR(3, 136, __pyx_L1_error)
                                                                                                      ^
    error: command 'gcc' failed with exit status 1
```

This restriciton is a workaround for users with old setuptools.
https://github.com/cupy/cupy-release-tools/pull/126