### PR TITLE
Use cdef instead of cpdef where appropraite

### DIFF
--- a/cupy/_core/internal.pyx
+++ b/cupy/_core/internal.pyx
@@ -187,8 +187,8 @@ cpdef inline Py_ssize_t _extract_slice_element(x) except? 0:
 
 @cython.profile(False)
 cpdef slice complete_slice(slice slc, Py_ssize_t dim):
-    cpdef Py_ssize_t start=0, stop=0, step=0
-    cpdef bint start_none, stop_none
+    cdef Py_ssize_t start=0, stop=0, step=0
+    cdef bint start_none, stop_none
     if slc.step is None:
         step = 1
     else:

--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -711,7 +711,7 @@ cdef inline intptr_t _get_stream_identifier(intptr_t stream_ptr):
     if stream_ptr != runtime.streamPerThread:
         return stream_ptr
 
-    cpdef intptr_t tid
+    cdef intptr_t tid
     try:
         tid = _thread_local._tid
     except AttributeError:

--- a/cupy_backends/cuda/api/driver.pyx
+++ b/cupy_backends/cuda/api/driver.pyx
@@ -192,7 +192,7 @@ cpdef ctxDestroy(intptr_t ctx):
 ###############################################################################
 
 cpdef intptr_t linkCreate() except? 0:
-    cpdef LinkState state
+    cdef LinkState state
     with nogil:
         status = cuLinkCreate(0, <CUjit_option*>0, <void**>0, &state)
     check_status(status)

--- a/cupy_backends/cuda/api/runtime.pxd
+++ b/cupy_backends/cuda/api/runtime.pxd
@@ -856,9 +856,9 @@ cdef int errorInvalidResourceHandle
 # Const value
 ###############################################################################
 
-cpdef bint _is_hip_environment
-cpdef int deviceAttributeComputeCapabilityMajor
-cpdef int deviceAttributeComputeCapabilityMinor
+cdef bint _is_hip_environment
+cdef int deviceAttributeComputeCapabilityMajor
+cdef int deviceAttributeComputeCapabilityMinor
 
 
 ###############################################################################

--- a/cupy_backends/cuda/api/runtime.pyx
+++ b/cupy_backends/cuda/api/runtime.pyx
@@ -493,7 +493,7 @@ cpdef deviceSynchronize():
     check_status(status)
 
 cpdef int deviceCanAccessPeer(int device, int peerDevice) except? -1:
-    cpdef int ret
+    cdef int ret
     status = cudaDeviceCanAccessPeer(&ret, device, peerDevice)
     check_status(status)
     return ret

--- a/cupy_backends/cuda/libs/cusparse.pyx
+++ b/cupy_backends/cuda/libs/cusparse.pyx
@@ -4647,7 +4647,7 @@ cpdef spMatGetSize(size_t desc, size_t rows, size_t cols, size_t nnz):
     check_status(status)
 
 cpdef int spMatGetStridedBatch(size_t desc):
-    cpdef int batchCount
+    cdef int batchCount
     status = cusparseSpMatGetStridedBatch(<SpMatDescr>desc, &batchCount)
     check_status(status)
     return batchCount
@@ -4725,8 +4725,8 @@ cpdef dnMatSetValues(size_t desc, intptr_t values):
     check_status(status)
 
 cpdef DnMatBatchAttributes dnMatGetStridedBatch(size_t desc):
-    cpdef int batchCount
-    cpdef int64_t batchStride
+    cdef int batchCount
+    cdef int64_t batchStride
     status = cusparseDnMatGetStridedBatch(<DnMatDescr>desc, &batchCount,
                                           &batchStride)
     check_status(status)
@@ -4743,7 +4743,7 @@ cpdef dnMatSetStridedBatch(size_t desc, int batchCount, int64_t batchStride):
 cpdef size_t spVV_bufferSize(intptr_t handle, Operation opX,
                              size_t vecX, size_t vecY,
                              intptr_t result, DataType computeType):
-    cpdef size_t bufferSize
+    cdef size_t bufferSize
     status = cusparseSpVV_bufferSize(<Handle>handle, opX,
                                      <SpVecDescr>vecX, <DnVecDescr>vecY,
                                      <void*>result, computeType, &bufferSize)
@@ -4761,7 +4761,7 @@ cpdef spVV(intptr_t handle, Operation opX, size_t vecX, size_t vecY,
 cpdef size_t spMV_bufferSize(intptr_t handle, Operation opA, intptr_t alpha,
                              size_t matA, size_t vecX, intptr_t beta,
                              size_t vecY, DataType computeType, SpMVAlg alg):
-    cpdef size_t bufferSize
+    cdef size_t bufferSize
     status = cusparseSpMV_bufferSize(<Handle>handle, opA, <void*>alpha,
                                      <SpMatDescr>matA, <DnVecDescr>vecX,
                                      <void*>beta, <DnVecDescr>vecY,
@@ -4782,7 +4782,7 @@ cpdef size_t spMM_bufferSize(intptr_t handle, Operation opA, Operation opB,
                              intptr_t alpha, size_t matA, size_t matB,
                              intptr_t beta, size_t matC, DataType computeType,
                              SpMMAlg alg):
-    cpdef size_t bufferSize
+    cdef size_t bufferSize
     status = cusparseSpMM_bufferSize(<Handle>handle, opA, opB, <void*>alpha,
                                      <SpMatDescr>matA, <DnMatDescr>matB,
                                      <void*>beta, <DnMatDescr>matC,
@@ -4805,7 +4805,7 @@ cpdef size_t constrainedGeMM_bufferSize(intptr_t handle, Operation opA,
                                         size_t matA, size_t matB,
                                         intptr_t beta, size_t matC,
                                         DataType computeType):
-    cpdef size_t bufferSize
+    cdef size_t bufferSize
     status = cusparseConstrainedGeMM_bufferSize(
         <Handle>handle, opA, opB, <void*>alpha, <DnMatDescr>matA,
         <DnMatDescr>matB, <void*>beta, <SpMatDescr>matC, computeType,
@@ -4826,7 +4826,7 @@ cpdef constrainedGeMM(intptr_t handle, Operation opA, Operation opB,
 
 cpdef size_t sparseToDense_bufferSize(intptr_t handle, size_t matA,
                                       size_t matB, int alg):
-    cpdef size_t bufferSize
+    cdef size_t bufferSize
     status = cusparseSparseToDense_bufferSize(
         <Handle>handle, <SpMatDescr>matA, <DnMatDescr>matB,
         <cusparseSparseToDenseAlg_t>alg, &bufferSize)
@@ -4842,7 +4842,7 @@ cpdef sparseToDense(intptr_t handle, size_t matA, size_t matB, int alg,
 
 cpdef size_t denseToSparse_bufferSize(intptr_t handle, size_t matA,
                                       size_t matB, int alg):
-    cpdef size_t bufferSize
+    cdef size_t bufferSize
     status = cusparseDenseToSparse_bufferSize(
         <Handle>handle, <DnMatDescr>matA, <SpMatDescr>matB,
         <cusparseDenseToSparseAlg_t>alg, &bufferSize)
@@ -4869,7 +4869,7 @@ cpdef size_t csr2cscEx2_bufferSize(
         intptr_t csrRowPtr, intptr_t csrColInd, intptr_t cscVal,
         intptr_t cscColPtr, intptr_t cscRowInd, DataType valType,
         Action copyValues, IndexBase idxBase, Csr2CscAlg alg):
-    cpdef size_t bufferSize
+    cdef size_t bufferSize
     status = cusparseCsr2cscEx2_bufferSize(
         <Handle>handle, m, n, nnz, <const void*>csrVal, <const int*>csrRowPtr,
         <const int*>csrColInd, <void*>cscVal, <int*>cscColPtr, <int*>cscRowInd,


### PR DESCRIPTION
This eliminates the following warnings:

```
cpdef variables will not be supported in Cython 3; currently they are no different from cdef variables
```