### PR TITLE
Support detecting cl.exe in vs2019

### DIFF
--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -96,6 +96,7 @@ def _get_extra_path_for_msvc():
         return None
 
     from setuptools import msvc
+    import platform
     try:
         vctools = msvc.EnvironmentInfo(platform.machine().lower()).VCTools
     except distutils.errors.DistutilsPlatformError:

--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -89,22 +89,23 @@ def _run_cc(cmd, cwd, backend, log_stream=None):
 
 @_util.memoize()
 def _get_extra_path_for_msvc():
-    import distutils.spawn
-    cl_exe = distutils.spawn.find_executable('cl.exe')
+    import shutil
+    cl_exe = shutil.which('cl.exe')
     if cl_exe:
         # The compiler is already on PATH, no extra path needed.
         return None
 
     from setuptools import msvc
+    from setuptools.errors import DistutilsError
     import platform
     try:
         vctools = msvc.EnvironmentInfo(platform.machine().lower()).VCTools
-    except distutils.errors.DistutilsPlatformError:
+    except DistutilsError:
         # Failed to find VC.
         return None
 
     path = vctools[-1]
-    if not distutils.spawn.find_executable('cl.exe', path):
+    if not shutil.which('cl.exe', path):
         # The compiler could not be found.
         return None
     return path

--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -95,14 +95,14 @@ def _get_extra_path_for_msvc():
         # The compiler is already on PATH, no extra path needed.
         return None
 
-    from distutils import msvc9compiler
-    vcvarsall_bat = msvc9compiler.find_vcvarsall(
-        msvc9compiler.get_build_version())
-    if not vcvarsall_bat:
+    from setuptools import msvc
+    try:
+        vctools = msvc.EnvironmentInfo(platform.machine().lower()).VCTools
+    except distutils.errors.DistutilsPlatformError:
         # Failed to find VC.
         return None
 
-    path = os.path.join(os.path.dirname(vcvarsall_bat), 'bin')
+    path = vctools[-1]
     if not distutils.spawn.find_executable('cl.exe', path):
         # The compiler could not be found.
         return None


### PR DESCRIPTION
Use `setuptools.msvc` instead of `distutils.msvc9compiler` to detect cl.exe