### PR TITLE
Add `len`, `min`, `max`, `.ndim`, `.size`, `.shape` and `.strides` to jit

### DIFF
--- a/cupyx/jit/_builtin_funcs.py
+++ b/cupyx/jit/_builtin_funcs.py
@@ -53,7 +53,7 @@ class RangeFunc(BuiltinFunc):
 
 class Len(BuiltinFunc):
     def call(self, env, *args, **kwds):
-        if len(args) > 1:
+        if len(args) != 1:
             raise TypeError(f'len expects only 1 argument, got {len(args)}')
         arg = args[0]
         if isinstance(arg.ctype, _cuda_types.CArray):

--- a/cupyx/jit/_builtin_funcs.py
+++ b/cupyx/jit/_builtin_funcs.py
@@ -56,13 +56,9 @@ class Len(BuiltinFunc):
         if len(args) != 1:
             raise TypeError(f'len expects only 1 argument, got {len(args)}')
         arg = args[0]
-        if isinstance(arg.ctype, _cuda_types.CArray):
-            return Data(f'{arg.code}.size()', _cuda_types.PtrDiff())
-        if isinstance(arg.ctype, _cuda_types.SharedMem):
-            if arg.ctype._size is None:
-                raise TypeError('unsized shared memory is not supported')
-            return Constant(arg.ctype._size)
-        raise TypeError('len supports only array type')
+        if not isinstance(arg.ctype, _cuda_types.CArray):
+            raise TypeError('len supports only array type')
+        return Data(f'{arg.code}.size()', _cuda_types.PtrDiff())
 
 
 class Min(BuiltinFunc):

--- a/cupyx/jit/_builtin_funcs.py
+++ b/cupyx/jit/_builtin_funcs.py
@@ -59,6 +59,8 @@ class Len(BuiltinFunc):
         if isinstance(arg.ctype, _cuda_types.CArray):
             return Data(f'{arg.code}.size()', _cuda_types.PtrDiff())
         if isinstance(arg.ctype, _cuda_types.SharedMem):
+            if arg.ctype._size is None:
+                raise TypeError('unsized shared memory is not supported')
             return Constant(arg.ctype._size)
         raise TypeError('len supports only array type')
 

--- a/cupyx/jit/_builtin_funcs.py
+++ b/cupyx/jit/_builtin_funcs.py
@@ -23,6 +23,13 @@ class RangeFunc(BuiltinFunc):
             raise TypeError(
                 f'range expected at most 3 argument, got {len(args)}')
 
+        if isinstance(step, Constant):
+            step_is_positive = step.obj >= 0
+        elif step.ctype.dtype.kind == 'u':
+            step_is_positive = True
+        else:
+            step_is_positive = None
+
         stop = Data.init(stop, env)
         start = Data.init(start, env)
         step = Data.init(step, env)
@@ -33,13 +40,6 @@ class RangeFunc(BuiltinFunc):
             raise TypeError('range supports only for integer type.')
         if step.ctype.dtype.kind not in 'iu':
             raise TypeError('range supports only for integer type.')
-
-        if isinstance(step, Constant):
-            step_is_positive = step.obj >= 0
-        elif step.ctype.dtype.kind == 'u':
-            step_is_positive = True
-        else:
-            step_is_positive = None
 
         if env.mode == 'numpy':
             ctype = _cuda_types.Scalar(int)

--- a/cupyx/jit/_compile.py
+++ b/cupyx/jit/_compile.py
@@ -565,9 +565,6 @@ def _transpile_expr_internal(expr, env):
         if isinstance(value.ctype, _cuda_types.ArrayBase):
             if 'ndim' == expr.attr:
                 return Constant(value.ctype.ndim)
-        if isinstance(value.ctype, _cuda_types.SharedMem):
-            if 'size' == expr.attr:
-                return _builtin_funcs.Len().call(value)
         if isinstance(value.ctype, _cuda_types.CArray):
             if 'size' == expr.attr:
                 return _builtin_funcs.Len().call(value)

--- a/cupyx/jit/_compile.py
+++ b/cupyx/jit/_compile.py
@@ -567,7 +567,7 @@ def _transpile_expr_internal(expr, env):
                 return Constant(value.ctype.ndim)
         if isinstance(value.ctype, _cuda_types.CArray):
             if 'size' == expr.attr:
-                return _builtin_funcs.Len().call(value)
+                return _builtin_funcs.Len().call(env, value)
             if 'shape' == expr.attr:
                 ctype = _cuda_types.Ptr(_cuda_types.PtrDiff(), cv='c')
                 return Data(f'{value.code}.shape()', ctype)

--- a/cupyx/jit/_cuda_typerules.py
+++ b/cupyx/jit/_cuda_typerules.py
@@ -154,3 +154,8 @@ def guess_routine(ufunc, in_types, dtype, mode):
         return ufunc._ops._guess_routine_from_dtype(dtype)
     can_cast = numpy.can_cast if mode == 'numpy' else _cuda_can_cast
     return ufunc._ops._guess_routine_from_in_types(tuple(in_types), can_cast)
+
+
+def implicit_conversion(*ctypes):
+    return _cuda_types.Scalar(_typechars[
+        max(_typechars.find(ctype.dtype.char) for ctype in ctypes)])

--- a/cupyx/jit/_cuda_typerules.py
+++ b/cupyx/jit/_cuda_typerules.py
@@ -140,7 +140,7 @@ def get_ctype_from_scalar(mode, x):
     raise NotImplementedError(f'{x} is not scalar object.')
 
 
-_typechars = '?bBhHiIlLefdFD'
+_typechars = '?bBhHiIlLqQefdFD'
 
 
 def _cuda_can_cast(from_dtype, to_dtype):

--- a/cupyx/jit/_cuda_typerules.py
+++ b/cupyx/jit/_cuda_typerules.py
@@ -154,8 +154,3 @@ def guess_routine(ufunc, in_types, dtype, mode):
         return ufunc._ops._guess_routine_from_dtype(dtype)
     can_cast = numpy.can_cast if mode == 'numpy' else _cuda_can_cast
     return ufunc._ops._guess_routine_from_in_types(tuple(in_types), can_cast)
-
-
-def implicit_conversion(*ctypes):
-    return _cuda_types.Scalar(_typechars[
-        max(_typechars.find(ctype.dtype.char) for ctype in ctypes)])

--- a/cupyx/jit/_cuda_types.py
+++ b/cupyx/jit/_cuda_types.py
@@ -40,6 +40,14 @@ class Scalar(TypeBase):
         return hash(self.dtype)
 
 
+class PtrDiff(Scalar):
+    def __init__(self):
+        super().__init__('q')
+
+    def __str__(self):
+        return 'ptrdiff_t'
+
+
 class ArrayBase(TypeBase):
 
     def __init__(self, child_type: TypeBase, ndim: int):

--- a/cupyx/jit/_cuda_types.py
+++ b/cupyx/jit/_cuda_types.py
@@ -103,11 +103,15 @@ class SharedMem(ArrayBase):
 
 class Ptr(ArrayBase):
 
-    def __init__(self, child_type):
+    def __init__(self, child_type, cv=''):
         super().__init__(child_type, 1)
+        self.qualifiers = ''.join([
+            'const ' if 'c' in cv else '',
+            'volatile ' if 'v' in cv else ''
+        ])
 
     def __str__(self):
-        return f'{self.child_type}*'
+        return f'{self.qualifiers}{self.child_type}*'
 
 
 class Tuple(TypeBase):

--- a/cupyx/jit/_cuda_types.py
+++ b/cupyx/jit/_cuda_types.py
@@ -103,15 +103,13 @@ class SharedMem(ArrayBase):
 
 class Ptr(ArrayBase):
 
-    def __init__(self, child_type, cv=''):
+    def __init__(self, child_type, writable=True, size=None):
         super().__init__(child_type, 1)
-        self.qualifiers = ''.join([
-            'const ' if 'c' in cv else '',
-            'volatile ' if 'v' in cv else ''
-        ])
+        self.writable = writable
+        self.size = size
 
     def __str__(self):
-        return f'{self.qualifiers}{self.child_type}*'
+        return f'{"" if self.writable else "const "}{self.child_type}*'
 
 
 class Tuple(TypeBase):

--- a/tests/cupyx_tests/jit_tests/test_raw.py
+++ b/tests/cupyx_tests/jit_tests/test_raw.py
@@ -62,6 +62,23 @@ class TestRaw(unittest.TestCase):
         f((5,), (6,), (x, y, n, m))
         assert bool((x == y).all())
 
+    def test_raw_multidimensional_array_with_attr(self):
+        @jit.rawkernel()
+        def f(x, y):
+            tid = jit.threadIdx.x + jit.blockDim.x * jit.blockIdx.x
+            ntid = jit.blockDim.x * jit.gridDim.x
+            n_col = x.shape[1]
+            for i in range(tid, x.size, ntid):
+                i_row = i // n_col
+                i_col = i % n_col
+                y[i_row, i_col] = x[i_row, i_col]
+
+        n, m = numpy.uint32(12), numpy.uint32(13)
+        x = testing.shaped_random((n, m), dtype=numpy.int32, seed=0)
+        y = testing.shaped_random((n, m), dtype=numpy.int32, seed=1)
+        f((5,), (6,), (x, y))
+        assert bool((x == y).all())
+
     def test_raw_0dim_array(self):
         @jit.rawkernel()
         def f(x, y):
@@ -71,6 +88,20 @@ class TestRaw(unittest.TestCase):
         y = testing.shaped_random((), dtype=numpy.int32, seed=1)
         f((1,), (1,), (x, y))
         assert bool((x == y).all())
+
+    def test_min_max(self):
+        @jit.rawkernel()
+        def f(x, y, z, r):
+            tid = jit.blockDim.x * jit.blockIdx.x + jit.threadIdx.x
+            r[tid] = min(x[tid], max(y[tid], z[tid]))
+
+        x = testing.shaped_random((1024,), dtype=numpy.int32, seed=0)
+        y = testing.shaped_random((1024,), dtype=numpy.int32, seed=1)
+        z = testing.shaped_random((1024,), dtype=numpy.int32, seed=2)
+        r = testing.shaped_random((1024,), dtype=numpy.int32, seed=3)
+        f((8,), (128,), (x, y, z, r))
+        expected = cupy.minimum(x, cupy.maximum(y, z))
+        assert bool((r == expected).all())
 
     def test_syncthreads(self):
         @jit.rawkernel()


### PR DESCRIPTION
Part of #4290 and #5280
- Built-in functions
  - [x] len
- CUDA Math API
  - [x] min
  - [x] max
- Array size functions
  - [x] `ArrayBase.ndim`
  - [x] `CArray.size`
  - [x] `CArray.shape`
  - [x] `CArray.strides`
- Misc
  - [x] support tuple indexing
  - [x] support unpacking `Ptr` (like `n_rows, n_cols = x.shape`)