### PR TITLE
Fix cuFFT callback for sm_61 etc

### DIFF
--- a/cupy/fft/_callback.pyx
+++ b/cupy/fft/_callback.pyx
@@ -207,7 +207,8 @@ cdef inline str _prune(str temp_dir, str cache_dir, str _cufft_ver, str arch):
         if not os.path.isfile(cufft_lib_cached):
             p = subprocess.run([_nvprune, '-arch=sm_' + arch,
                                 cufft_lib_full, '-o', cufft_lib_temp],
-                               env=os.environ, cwd=temp_dir)
+                               env=os.environ, cwd=temp_dir,
+                               stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             p.check_returncode()
             if p.stderr:
                 # if no device code exists for sm_XX, nvprune exits normally

--- a/cupy/fft/_callback.pyx
+++ b/cupy/fft/_callback.pyx
@@ -213,7 +213,7 @@ cdef inline str _prune(str temp_dir, str cache_dir, str _cufft_ver, str arch):
             if p.stderr:
                 # if no device code exists for sm_XX, nvprune exits normally
                 # with a warning printed to stderr
-                assert 'No device code' in p.stderr
+                assert b'No device code' in p.stderr
                 cufft_lib_pruned = None
                 _cufft_static_no_device_code.append(arch)
             else:

--- a/cupy/fft/_callback.pyx
+++ b/cupy/fft/_callback.pyx
@@ -213,6 +213,7 @@ cdef inline str _prune(str temp_dir, str cache_dir, str _cufft_ver, str arch):
             if p.stderr:
                 # if no device code exists for sm_XX, nvprune exits normally
                 # with a warning printed to stderr
+                assert 'No device code' in p.stderr
                 cufft_lib_pruned = None
                 _cufft_static_no_device_code.append(arch)
             else:

--- a/cupy/fft/_callback.pyx
+++ b/cupy/fft/_callback.pyx
@@ -39,6 +39,7 @@ cdef str _cuda_include = None
 cdef str _nvprune = None
 cdef str _build_ver = None
 cdef int _cufft_ver = 0
+cdef list _cufft_static_no_device_code = []
 cdef str _cupy_root = None
 cdef str _cupy_include = None
 cdef str _source_dir = None
@@ -196,7 +197,7 @@ cdef inline void _mod_compile(str tempdir, str mod_name, str obj_host) except*:
 cdef inline str _prune(str temp_dir, str cache_dir, str _cufft_ver, str arch):
     cdef str cufft_lib_full, cufft_lib_pruned, cufft_lib_temp, cufft_lib_cached
 
-    if _nvprune:
+    if _nvprune and arch not in _cufft_static_no_device_code:
         cufft_lib_full = os.path.join(_cuda_path, 'lib64/libcufft_static.a')
         cufft_lib_pruned = 'cufft_static_' + _cufft_ver + '_sm' + arch
         cufft_lib_temp = os.path.join(temp_dir,
@@ -208,9 +209,15 @@ cdef inline str _prune(str temp_dir, str cache_dir, str _cufft_ver, str arch):
                                 cufft_lib_full, '-o', cufft_lib_temp],
                                env=os.environ, cwd=temp_dir)
             p.check_returncode()
-            # atomic move with the destination guaranteed to be overwritten;
-            # using os.replace() is also ok here
-            os.rename(cufft_lib_temp, cufft_lib_cached)
+            if p.stderr:
+                # if no device code exists for sm_XX, nvprune exits normally
+                # with a warning printed to stderr
+                cufft_lib_pruned = None
+                _cufft_static_no_device_code.append(arch)
+            else:
+                # atomic move with the destination guaranteed to be overwritten
+                # (using os.replace() is also ok here)
+                os.rename(cufft_lib_temp, cufft_lib_cached)
     else:
         # nvprune is not found, just link against the full static lib
         cufft_lib_pruned = None


### PR DESCRIPTION
Fix #5296. Thanks to @szsdk for reporting. 

We need to check if `nvprune` actually succeeds or not, as the static library does not contain device codes for certain CCs:
> Please note that the cuFFT library might not contain code for certain architectures as long as there is code for a lower architecture that is binary compatibile (e.g. SM37, SM52, SM61). 
> https://docs.nvidia.com/cuda/cufft/index.html#static-library

for example see https://github.com/cupy/cupy/issues/5296#issuecomment-851713662. 

To avoid the cost of rerunning `nvprune` for a CC known to not have any device code, we cache the CC after the first validation call. An alternative approach would be to not run `nvprune` at all (save us one long run) for a list of pre-compiled CCs, but there would be a maintenance burden on us to update the list for future CUDA releases.

