### PR TITLE
Temporarily remove the async pool test from `TestAllocator`

### DIFF
--- a/tests/cupy_tests/cuda_tests/test_memory.py
+++ b/tests/cupy_tests/cuda_tests/test_memory.py
@@ -728,8 +728,11 @@ class TestMemoryPool(unittest.TestCase):
             assert 0 == self.pool.total_bytes()
 
 
+# TODO(leofang): test MemoryAsyncPool. We currently remove the test because
+# this test class requires the ability of creating a new pool, which we do
+# not support yet for MemoryAsyncPool.
 @testing.parameterize(*testing.product({
-    'mempool': ('MemoryPool', 'MemoryAsyncPool'),
+    'mempool': ('MemoryPool',),
 }))
 @testing.gpu
 class TestAllocator(unittest.TestCase):
@@ -747,6 +750,7 @@ class TestAllocator(unittest.TestCase):
         memory.set_allocator(self.pool.malloc)
 
     def tearDown(self):
+        self.pool.set_limit(size=0)
         self.pool.free_all_blocks()
         memory.set_allocator(self.old_pool.malloc)
 


### PR DESCRIPTION
Follow-up of #5177. When debugging for https://github.com/chainer/chainer-test/pull/658#issuecomment-853133782 I realized my changes in the `TestAllocator` class was not legitimate, because it requires the ability of creating a new memory pool, which we currently do not support for `MemoryAsyncPool`:
https://github.com/cupy/cupy/blob/29eb596738a612bd77e2852f1cf6be99eb391ec0/cupy/cuda/memory.pyx#L1607-L1609
I will add the support in a separate PR,  after which we can re-enable this test.

cc: @kmaehashi 