### PR TITLE
Don't set FFT work area when gained work area size is zero

### DIFF
--- a/cupy/cuda/cufft.pyx
+++ b/cupy/cuda/cufft.pyx
@@ -799,6 +799,8 @@ cdef class PlanNd:
                 result = cufftSetWorkArea(plan, <void*>(ptr))
             check_result(result)
             self.work_area = work_area
+        else:
+            self.work_area = None
 
         self.shape = tuple(shape)
         self.fft_type = <Type>fft_type

--- a/cupy/cuda/cufft.pyx
+++ b/cupy/cuda/cufft.pyx
@@ -337,13 +337,14 @@ cdef class Plan1d:
                                          &work_size)
         check_result(result)
 
-        work_area = memory.alloc(work_size)
-        ptr = <intptr_t>(work_area.ptr)
-        with nogil:
-            result = cufftSetWorkArea(plan, <void*>(ptr))
-        check_result(result)
+        if work_size > 0:
+            work_area = memory.alloc(work_size)
+            ptr = <intptr_t>(work_area.ptr)
+            with nogil:
+                result = cufftSetWorkArea(plan, <void*>(ptr))
+            check_result(result)
 
-        self.work_area = work_area  # this is for cuFFT plan
+            self.work_area = work_area  # this is for cuFFT plan
 
     cdef void _multi_gpu_get_plan(self, Handle plan, int nx, int fft_type,
                                   int batch, devices, out) except*:
@@ -789,18 +790,18 @@ cdef class PlanNd:
                                                &work_size)
             check_result(result)
 
-        # TODO: for CUDA>=9.2 could also allow setting a work area policy
-        # result = cufftXtSetWorkAreaPolicy(plan, policy, &work_size)
-
-        work_area = memory.alloc(work_size)
-        ptr = <intptr_t>(work_area.ptr)
-        with nogil:
-            result = cufftSetWorkArea(plan, <void*>(ptr))
-        check_result(result)
+        if work_size > 0:
+            # TODO: for CUDA>=9.2 could also allow setting a work area policy
+            # result = cufftXtSetWorkAreaPolicy(plan, policy, &work_size)
+            work_area = memory.alloc(work_size)
+            ptr = <intptr_t>(work_area.ptr)
+            with nogil:
+                result = cufftSetWorkArea(plan, <void*>(ptr))
+            check_result(result)
+            self.work_area = work_area
 
         self.shape = tuple(shape)
         self.fft_type = <Type>fft_type
-        self.work_area = work_area
         self.order = order  # either 'C' or 'F'
         self.last_axis = last_axis  # ignored for C2C
         self.last_size = last_size  # = None (and ignored) for C2C


### PR DESCRIPTION
(Replace #5309)

`hipfftMakePlan1d` can output zero for the work area size, and given a null pointer returned by the allocator that supplied zero for the size, `hipfftSetWorkArea` (internally calls `rocfft_execution_info_set_work_buffer`) returns `HIPFFT_INVALID_VALUE`.

This PR fixes `Plan1d` not to set the work area pointer if the computed work area size is zero. Also `PlanNd` has the same fix.
