### PR TITLE
Use independent version of hipFFT for ROCm 4.1 and later

### DIFF
--- a/.pfnci/config.pbtxt
+++ b/.pfnci/config.pbtxt
@@ -145,6 +145,7 @@ configs {
       include_dot_git: true
     }
     environment_variables { key: "ROCM_REPO" value: "4.0.1" }
+    environment_variables { key: "ROCM_PACKAGES" value: "rocm-dev hipblas hipsparse rocsparse rocrand rocthrust rocsolver rocfft hipcub rocprim rccl" }
     command: "bash .pfnci/script.sh py37.rocm-4-0"
   }
 }
@@ -163,6 +164,7 @@ configs {
       include_dot_git: true
     }
     environment_variables { key: "ROCM_REPO" value: "debian" }
+    environment_variables { key: "ROCM_PACKAGES" value: "rocm-dev hipblas hipfft hipsparse rocsparse rocrand rocthrust rocsolver rocfft hipcub rocprim rccl" }
     command: "bash .pfnci/script.sh py37.rocm-latest"
   }
 }

--- a/.pfnci/script.sh
+++ b/.pfnci/script.sh
@@ -79,7 +79,7 @@ main() {
       apt-get autoremove -qqy
 
       apt update -qqy
-      apt install rocm-dev hipblas hipsparse rocsparse rocrand rocthrust rocsolver rocfft hipcub rocprim rccl -qqy
+      apt install rocm-dev hipblas hipfft hipsparse rocsparse rocrand rocthrust rocsolver rocfft hipcub rocprim rccl -qqy
       export HCC_AMDGPU_TARGET=gfx900
       export ROCM_HOME=/opt/rocm
       export CUPY_INSTALL_USE_HIP=1

--- a/.pfnci/script.sh
+++ b/.pfnci/script.sh
@@ -79,7 +79,11 @@ main() {
       apt-get autoremove -qqy
 
       apt update -qqy
-      apt install rocm-dev hipblas hipfft hipsparse rocsparse rocrand rocthrust rocsolver rocfft hipcub rocprim rccl -qqy
+      apt install rocm-dev hipblas hipsparse rocsparse rocrand rocthrust rocsolver rocfft hipcub rocprim rccl -qqy
+      # Also install hipfft for ROCm 4.1 or later
+      if [ "${TARGET}" == cupy.py37.rocm-latest ]; then
+          apt install hipfft -qqy
+      fi
       export HCC_AMDGPU_TARGET=gfx900
       export ROCM_HOME=/opt/rocm
       export CUPY_INSTALL_USE_HIP=1

--- a/.pfnci/script.sh
+++ b/.pfnci/script.sh
@@ -79,11 +79,7 @@ main() {
       apt-get autoremove -qqy
 
       apt update -qqy
-      apt install rocm-dev hipblas hipsparse rocsparse rocrand rocthrust rocsolver rocfft hipcub rocprim rccl -qqy
-      # Also install hipfft for ROCm 4.1 or later
-      if [ "${TARGET}" == py37.rocm-latest ]; then
-          apt install hipfft -qqy
-      fi
+      apt install $ROCM_PACKAGES -qqy
       export HCC_AMDGPU_TARGET=gfx900
       export ROCM_HOME=/opt/rocm
       export CUPY_INSTALL_USE_HIP=1

--- a/.pfnci/script.sh
+++ b/.pfnci/script.sh
@@ -81,7 +81,7 @@ main() {
       apt update -qqy
       apt install rocm-dev hipblas hipsparse rocsparse rocrand rocthrust rocsolver rocfft hipcub rocprim rccl -qqy
       # Also install hipfft for ROCm 4.1 or later
-      if [ "${TARGET}" == cupy.py37.rocm-latest ]; then
+      if [ "${TARGET}" == py37.rocm-latest ]; then
           apt install hipfft -qqy
       fi
       export HCC_AMDGPU_TARGET=gfx900

--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -546,6 +546,8 @@ def preconfigure_modules(compiler, settings):
                     rocm_path = build.get_rocm_path()
                     inc_path = os.path.join(rocm_path, 'hipfft', 'include')
                     settings['include_dirs'].insert(0, inc_path)
+                    lib_path = os.path.join(rocm_path, 'hipfft', 'lib')
+                    settings['library_dirs'].insert(0, lib_path)
                 canonicalize_hip_libraries(hip_version, module['libraries'])
 
         print('')

--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -115,6 +115,7 @@ if use_hip:
         'libraries': [
             'amdhip64',  # was hiprtc and hip_hcc before ROCm 3.8.0
             'hipblas',
+            ('hipfft', lambda hip_version: hip_version >= 401),
             'hiprand',
             'rocfft',
             'roctx64',
@@ -452,6 +453,20 @@ def check_library(compiler, includes=(), libraries=(),
     return True
 
 
+def canonicalize_hip_libraries(hip_version, libraries):
+    def ensure_tuple(x):
+        return x if isinstance(x, tuple) else (x, None)
+    new_libraries = []
+    for library in libraries:
+        lib_name, pred = ensure_tuple(library)
+        if pred is None:
+            new_libraries.append(lib_name)
+        elif pred(hip_version):
+            new_libraries.append(lib_name)
+    libraries.clear()
+    libraries.extend(new_libraries)
+
+
 def preconfigure_modules(compiler, settings):
     """Returns a list of modules buildable in given environment and settings.
 
@@ -519,6 +534,19 @@ def preconfigure_modules(compiler, settings):
             lib_path = os.path.join(cugraph_path, 'lib')
             if os.path.exists(lib_path):
                 settings['library_dirs'].append(lib_path)
+
+        # In ROCm 4.1 and later, we need to use the independent version of
+        # hipfft as well as rocfft. We configure the lists of include
+        # directories and libraries to link here depending on ROCm version
+        # before the configuration process following.
+        if use_hip and module['name'] == 'cuda':
+            if module['check_method'](compiler, settings):
+                hip_version = module['version_method']()
+                if hip_version >= 401:
+                    rocm_path = build.get_rocm_path()
+                    inc_path = os.path.join(rocm_path, 'hipfft', 'include')
+                    settings['include_dirs'].insert(0, inc_path)
+                canonicalize_hip_libraries(hip_version, module['libraries'])
 
         print('')
         print('-------- Configuring Module: {} --------'.format(


### PR DESCRIPTION
Fix #5309 and #5314.

In ROCm 4.1 and later, we need to use the independent version of hipfft as well as rocfft. The hipFFT is assumed to be located in `/opt/rocm/hipfft`.

https://github.com/ROCmSoftwarePlatform/hipFFT