### PR TITLE
Support `len`, `min`, `max`, `.ndim`, `.size` in jit

### DIFF
--- a/cupyx/jit/_builtin_funcs.py
+++ b/cupyx/jit/_builtin_funcs.py
@@ -54,7 +54,7 @@ class RangeFunc(BuiltinFunc):
         return Range(start, stop, step, ctype, step_is_positive)
 
 
-class Len(BuiltinFunc):
+class LenFunc(BuiltinFunc):
     def call(self, env, *args, **kwds):
         if len(args) != 1:
             raise TypeError(f'len() expects only 1 argument, got {len(args)}')
@@ -69,7 +69,7 @@ class Len(BuiltinFunc):
                     _cuda_types.Scalar('q'))
 
 
-class Min(BuiltinFunc):
+class MinFunc(BuiltinFunc):
     def call(self, env, *args, **kwds):
         if len(args) < 2:
             raise TypeError(
@@ -80,7 +80,7 @@ class Min(BuiltinFunc):
             cupy.minimum, (a, b), None, env), args)
 
 
-class Max(BuiltinFunc):
+class MaxFunc(BuiltinFunc):
     def call(self, env, *args, **kwds):
         if len(args) < 2:
             raise TypeError(
@@ -152,9 +152,9 @@ class AtomicOp(BuiltinFunc):
 
 builtin_functions_dict = {
     range: RangeFunc(),
-    len: Len(),
-    min: Min(),
-    max: Max(),
+    len: LenFunc(),
+    min: MinFunc(),
+    max: MaxFunc(),
 }
 
 syncthreads = SyncThreads()

--- a/cupyx/jit/_builtin_funcs.py
+++ b/cupyx/jit/_builtin_funcs.py
@@ -65,7 +65,8 @@ class Len(BuiltinFunc):
             raise TypeError('len() supports only array type')
         if not arg.ctype.ndim:
             raise TypeError('len() of unsized array')
-        return Data(f'{arg.code}.shape()[0]', _cuda_types.PtrDiff())
+        return Data(f'static_cast<long long>({arg.code}.shape()[0])',
+                    _cuda_types.Scalar('q'))
 
 
 class Min(BuiltinFunc):

--- a/cupyx/jit/_compile.py
+++ b/cupyx/jit/_compile.py
@@ -343,8 +343,8 @@ def _transpile_stmt(stmt, is_toplevel, env):
                 else:
                     raise TypeError(
                         'Cannot assign constant value not at top-level.')
-            value = Data.init(value, env)
 
+        value = Data.init(value, env)
         target = _transpile_lvalue(target, env, value.ctype)
         return [f'{target.code} = {value.code};']
 
@@ -567,7 +567,8 @@ def _transpile_expr_internal(expr, env):
                 return Constant(value.ctype.ndim)
         if isinstance(value.ctype, _cuda_types.CArray):
             if 'size' == expr.attr:
-                return Data(f'{value.code}.size()', _cuda_types.PtrDiff())
+                return Data(f'static_cast<long long>({value.code}.size())',
+                            _cuda_types.Scalar('q'))
         raise NotImplementedError('Not implemented: __getattr__')
 
     if isinstance(expr, ast.Tuple):

--- a/cupyx/jit/_cuda_typerules.py
+++ b/cupyx/jit/_cuda_typerules.py
@@ -1,6 +1,7 @@
 import ast
 
 import numpy
+import operator
 
 from cupy._logic import ops
 from cupy._math import arithmetic
@@ -47,27 +48,27 @@ _scalar_gte = _core.create_comparison('scalar_less', '>=')
 _py_ops = {
     ast.And: lambda x, y: x and y,
     ast.Or: lambda x, y: x or y,
-    ast.Add: lambda x, y: x + y,
-    ast.Sub: lambda x, y: x - y,
-    ast.Mult: lambda x, y: x * y,
-    ast.Pow: lambda x, y: x ** y,
-    ast.Div: lambda x, y: x / y,
-    ast.FloorDiv: lambda x, y: x // y,
-    ast.Mod: lambda x, y: x % y,
-    ast.LShift: lambda x, y: x << y,
-    ast.RShift: lambda x, y: x >> y,
-    ast.BitOr: lambda x, y: x | y,
-    ast.BitAnd: lambda x, y: x & y,
-    ast.BitXor: lambda x, y: x ^ y,
-    ast.Invert: lambda x: ~x,
-    ast.Not: lambda x: not x,
-    ast.Eq: lambda x, y: x == y,
-    ast.NotEq: lambda x, y: x != y,
-    ast.Lt: lambda x, y: x < y,
-    ast.LtE: lambda x, y: x <= y,
-    ast.Gt: lambda x, y: x > y,
-    ast.GtE: lambda x, y: x >= y,
-    ast.USub: lambda x: -x,
+    ast.Add: operator.add,
+    ast.Sub: operator.sub,
+    ast.Mult: operator.mul,
+    ast.Pow: operator.pow,
+    ast.Div: operator.truediv,
+    ast.FloorDiv: operator.floordiv,
+    ast.Mod: operator.mod,
+    ast.LShift: operator.lshift,
+    ast.RShift: operator.rshift,
+    ast.BitOr: operator.or_,
+    ast.BitAnd: operator.and_,
+    ast.BitXor: operator.xor,
+    ast.Invert: operator.invert,
+    ast.Not: operator.not_,
+    ast.Eq: operator.eq,
+    ast.NotEq: operator.ne,
+    ast.Lt: operator.lt,
+    ast.LtE: operator.le,
+    ast.Gt: operator.gt,
+    ast.GtE: operator.ge,
+    ast.USub: operator.neg,
 }
 
 

--- a/cupyx/jit/_cuda_typerules.py
+++ b/cupyx/jit/_cuda_typerules.py
@@ -140,7 +140,7 @@ def get_ctype_from_scalar(mode, x):
     raise NotImplementedError(f'{x} is not scalar object.')
 
 
-_typechars = '?bBhHiIlLefdFD'
+_typechars = '?bBhHiIlLqQefdFD'
 
 
 def _cuda_can_cast(from_dtype, to_dtype):

--- a/cupyx/jit/_cuda_types.py
+++ b/cupyx/jit/_cuda_types.py
@@ -40,6 +40,14 @@ class Scalar(TypeBase):
         return hash(self.dtype)
 
 
+class PtrDiff(Scalar):
+    def __init__(self):
+        super().__init__('q')
+
+    def __str__(self):
+        return 'ptrdiff_t'
+
+
 class ArrayBase(TypeBase):
 
     def __init__(self, child_type: TypeBase, ndim: int):

--- a/cupyx/jit/_cuda_types.py
+++ b/cupyx/jit/_cuda_types.py
@@ -40,14 +40,6 @@ class Scalar(TypeBase):
         return hash(self.dtype)
 
 
-class PtrDiff(Scalar):
-    def __init__(self):
-        super().__init__('q')
-
-    def __str__(self):
-        return 'ptrdiff_t'
-
-
 class ArrayBase(TypeBase):
 
     def __init__(self, child_type: TypeBase, ndim: int):


### PR DESCRIPTION
Updated version of #5293.
- Built-in functions
  - [x] len
  - [x] min
  - [x] max
- Array size functions
  - [x] `ArrayBase.ndim`
  - [x] `CArray.size`
- Misc
  - [x] const-indexing of tuple