### PR TITLE
Fix cuDNN preloading

### DIFF
--- a/cupyx/tools/install_library.py
+++ b/cupyx/tools/install_library.py
@@ -35,17 +35,31 @@ def _make_cudnn_url(public_version, filename):
 def _make_cudnn_record(
         cuda_version, public_version, filename_linux, filename_windows):
     major_version = public_version.split('.')[0]
+
+    if major_version == '7':
+        suffix_list = ['']
+    elif major_version == '8':
+        # Dependency order is documented at:
+        # https://docs.nvidia.com/deeplearning/cudnn/api/index.html
+        suffix_list = ['', '_ops_infer', '_ops_train',
+                       '_cnn_infer', '_cnn_train',
+                       '_adv_infer', '_adv_train']
+    else:
+        raise AssertionError
+
     return {
         'cuda': cuda_version,
         'cudnn': public_version,
         'assets': {
             'Linux': {
                 'url': _make_cudnn_url(public_version, filename_linux),
-                'filename': 'libcudnn.so.{}'.format(public_version),
+                'filenames': [f'libcudnn{suffix}.so.{public_version}'
+                              for suffix in suffix_list]
             },
             'Windows': {
                 'url': _make_cudnn_url(public_version, filename_windows),
-                'filename': 'cudnn64_{}.dll'.format(major_version),
+                'filenames': [f'cudnn{suffix}64_{major_version}.dll'
+                              for suffix in suffix_list]
             },
         }
     }
@@ -102,11 +116,11 @@ def _make_cutensor_record(
         'assets': {
             'Linux': {
                 'url': _make_cutensor_url(public_version, filename_linux),
-                'filename': 'libcutensor.so.{}'.format(public_version),
+                'filenames': ['libcutensor.so.{}'.format(public_version)],
             },
             'Windows': {
                 'url': _make_cutensor_url(public_version, filename_windows),
-                'filename': 'cutensor.dll',
+                'filenames': ['cutensor.dll'],
             },
         }
     }
@@ -154,7 +168,7 @@ def _make_nccl_record(
         'assets': {
             'Linux': {
                 'url': _make_nccl_url(public_version, filename_linux),
-                'filename': 'libnccl.so.{}'.format(full_version),
+                'filenames': ['libnccl.so.{}'.format(full_version)],
             },
         },
     }


### PR DESCRIPTION
Currently some of features in cuDNN v8 is not working when installed via wheels.

```py
import ctypes
import cupy
import cupy.cuda.cudnn as libcudnn
import cupy.cudnn
x = cupy.arange(12, dtype=cupy.float32).reshape(3, 4)

# This is implemented in cudnn_ops_infer:
cupy.cudnn.activation_forward(x, libcudnn.CUDNN_ACTIVATION_RELU)
# This is implemented in cudnn_cnn_train (error)
cupy.cudnn.create_fused_ops_plan(0)  # CUDNN_FUSED_SCALE_BIAS_ACTIVATION_CONV_BNSTATS
```

The above example fails because `cudnn_cnn_train` depends on `cudnn_ops_infer`, `cudnn_ops_train`, and `cudnn_cnn_infer`, but `cudnn_ops_train` and `cudnn_cnn_infer` are not loaded and could not be discovered automatically by cuDNN.
This issue only occurs when chain-loading dependencies (i.e., loading a split module from another split module).
`libcudnn.so.8` has a `$ORIGIN` in RUNPATH, so `libcudnn.so.8` can find split modules in the same directory and load them.

```
~/.cupy/cuda_lib/11.2/cudnn/8.2.0/lib64 % for FILE in libcudnn*8.2.0; do echo $FILE; readelf -d $FILE | grep RUNPATH; done
libcudnn_adv_infer.so.8.2.0
libcudnn_adv_train.so.8.2.0
libcudnn_cnn_infer.so.8.2.0
libcudnn_cnn_train.so.8.2.0
libcudnn_ops_infer.so.8.2.0
libcudnn_ops_train.so.8.2.0
libcudnn.so.8.2.0
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN]
```

This PR fixes the preload system to load all split modules.

This changes the wheel metadata structure but does not affect conda-forge distributions.

xref: #5103

TODO:
- [x] verify this works on Windows