### PR TITLE
Support nested tuple unpack in CuPy JIT

### DIFF
--- a/cupyx/jit/_compile.py
+++ b/cupyx/jit/_compile.py
@@ -345,8 +345,7 @@ def _transpile_stmt(stmt, is_toplevel, env):
                         'Cannot assign constant value not at top-level.')
 
         value = Data.init(value, env)
-        target = _transpile_lvalue(target, env, value.ctype)
-        return [f'{target.code} = {value.code};']
+        return _transpile_assign_stmt(target, env, value)
 
     if isinstance(stmt, ast.AugAssign):
         value = _transpile_expr(stmt.value, env)
@@ -585,35 +584,43 @@ def _transpile_expr_internal(expr, env):
     raise ValueError('Not supported: type {}'.format(type(expr)))
 
 
-def _transpile_lvalue(target, env, ctype):
+def _emit_assign_stmt(lvalue, rvalue):
+    if is_constants(lvalue):
+        raise TypeError('lvalue of assignment must not be constant value')
+    if lvalue.ctype != rvalue.ctype:
+        raise TypeError(
+            f'Data type mismatch of variable: `{lvalue.code}`: '
+            f'{lvalue.ctype} != {rvalue.ctype}')
+    return [f'{lvalue.code} = {rvalue.code};']
+
+
+def _transpile_assign_stmt(target, env, value, depth=0):
     if isinstance(target, ast.Name):
         name = target.id
         if env[name] is None:
-            env[name] = Data(name, ctype)
-        elif is_constants(env[name]):
-            raise TypeError('Type mismatch of variable: `{name}`')
-        elif env[name].ctype != ctype:
-            raise TypeError(
-                f'Data type mismatch of variable: `{name}`: '
-                f'{env[name].ctype} != {ctype}')
-        return env[name]
+            env[name] = Data(name, value.ctype)
+        return _emit_assign_stmt(env[name], value)
 
     if isinstance(target, ast.Subscript):
-        return _transpile_expr(target, env)
+        target = _transpile_expr(target, env)
+        return _emit_assign_stmt(target, value)
 
     if isinstance(target, ast.Tuple):
-        if not isinstance(ctype, _cuda_types.Tuple):
-            raise ValueError(f'{ctype} cannot be unpack')
+        if not isinstance(value.ctype, _cuda_types.Tuple):
+            raise ValueError(f'{value.ctype} cannot be unpack')
         size = len(target.elts)
-        if len(ctype.types) > size:
+        if len(value.ctype.types) > size:
             raise ValueError(f'too many values to unpack (expected {size})')
-        if len(ctype.types) < size:
+        if len(value.ctype.types) < size:
             raise ValueError(f'not enough values to unpack (expected {size})')
-        elts = [_transpile_lvalue(x, env, t)
-                for x, t in zip(target.elts, ctype.types)]
-        # TODO: Support compile time constants.
-        elts_code = ', '.join([x.code for x in elts])
-        return Data(f'thrust::tie({elts_code})', ctype)
+        codes = [f'{value.ctype} _temp{depth} = {value.code};']
+        for i in range(size):
+            code = f'thrust::get<{i}>(_temp{depth})'
+            ctype = value.ctype.types[i]
+            stmt = _transpile_assign_stmt(
+                target.elts[i], env, Data(code, ctype), depth + 1)
+            codes.extend(stmt)
+        return [CodeBlock('', codes)]
 
 
 def _indexing(array, index, env):

--- a/cupyx/jit/_compile.py
+++ b/cupyx/jit/_compile.py
@@ -595,7 +595,7 @@ def _transpile_lvalue(target, env, ctype):
         elif env[name].ctype != ctype:
             raise TypeError(
                 f'Data type mismatch of variable: `{name}`: '
-                f'{env[name].ctype.dtype} != {ctype.dtype}')
+                f'{env[name].ctype} != {ctype}')
         return env[name]
 
     if isinstance(target, ast.Subscript):

--- a/cupyx/jit/_cuda_types.py
+++ b/cupyx/jit/_cuda_types.py
@@ -112,7 +112,7 @@ class Tuple(TypeBase):
         return f'thrust::tuple<{types}>'
 
     def __eq__(self, other):
-        return self.types == other.types
+        return isinstance(other, Tuple) and self.types == other.types
 
 
 void = Void()

--- a/tests/cupy_tests/functional_tests/test_vectorize.py
+++ b/tests/cupy_tests/functional_tests/test_vectorize.py
@@ -492,6 +492,32 @@ class TestVectorizeStmts(unittest.TestCase):
         return f(x, y)
 
     @testing.numpy_cupy_array_equal()
+    def test_tuple_pattern_match(self, xp):
+        def func_pattern_match(x, y):
+            x, y = y, x
+            z = x, y
+            (a, b), y = z, x
+            return a * a + b + y
+
+        f = xp.vectorize(func_pattern_match)
+        x = xp.array([0, 1, 2, 3, 4])
+        y = xp.array([5, 6, 7, 8, 9])
+        return f(x, y)
+
+    def test_tuple_pattern_match_type_error(self):
+        def func_pattern_match(x, y):
+            x, y = y, x
+            z = x, y
+            (a, b), z = z, x
+            return a * a + b
+
+        f = cupy.vectorize(func_pattern_match)
+        x = cupy.array([0, 1, 2, 3, 4])
+        y = cupy.array([5, 6, 7, 8, 9])
+        with pytest.raises(TypeError, match='Data type mismatch of variable:'):
+            return f(x, y)
+
+    @testing.numpy_cupy_array_equal()
     def test_return_tuple(self, xp):
         def func_tuple(x, y):
             return x + y, x / y


### PR DESCRIPTION
This PR supports nested tuple unpack in CuPy JIT.

Example:
```py
@cupyx.jit.rawkernel()
def f(x, y, z):
    i = cupyx.jit.threadIdx.x
    (x[i], y[i]), z[i] = (z[i], x[i]), y[i]

x = cupy.full((5), 10, dtype=cupy.int32)
y = cupy.full((5), 20, dtype=cupy.int32)
z = cupy.full((5), 30, dtype=cupy.int32)
f((1,), (5,), (x, y, z))
```

Generated kernel:
```cpp
extern "C" __global__ void f(CArray<int, 1, true, true> x, CArray<int, 1, true, true> y, CArray<int, 1, true, true> z) {
  unsigned int i;
  i = threadIdx.x;
  {
    thrust::tuple<thrust::tuple<int, int>, int> _temp0 = thrust::make_tuple(thrust::make_tuple(z[i], x[i]), y[i]);
    {
      thrust::tuple<int, int> _temp1 = thrust::get<0>(_temp0);
      x[i] = thrust::get<0>(_temp1);
      y[i] = thrust::get<1>(_temp1);
    }
    z[i] = thrust::get<1>(_temp0);
  }
}
```

Related discussion: https://github.com/cupy/cupy/pull/5293#discussion_r646159568 (cc/ @eternalphane)
