### PR TITLE
Support Numba-like `jit.grid()` syntax in CuPy JIT

### DIFF
--- a/cupyx/jit/__init__.py
+++ b/cupyx/jit/__init__.py
@@ -8,6 +8,7 @@ from cupyx.jit._interface import gridDim  # NOQA
 from cupyx.jit._builtin_funcs import syncthreads  # NOQA
 from cupyx.jit._builtin_funcs import shared_memory  # NOQA
 from cupyx.jit._builtin_funcs import atomic_add  # NOQA
+from cupyx.jit._builtin_funcs import grid  # NOQA
 
 
 import inspect as _inspect

--- a/cupyx/jit/_builtin_funcs.py
+++ b/cupyx/jit/_builtin_funcs.py
@@ -162,7 +162,8 @@ class Grid(BuiltinFunc):
         if not isinstance(ndim, int):
             raise TypeError('not int')
 
-        # Numba convention: for 1D we return a single variable, otherwise a tuple
+        # Numba convention: for 1D we return a single variable,
+        # otherwise a tuple
         code = 'threadIdx.{n} + blockIdx.{n} * blockDim.{n}'
         if ndim == 1:
             return Data(code.format(n='x'), _cuda_types.uint32)

--- a/cupyx/jit/_builtin_funcs.py
+++ b/cupyx/jit/_builtin_funcs.py
@@ -165,8 +165,8 @@ class Grid(BuiltinFunc):
             ndim (int): The dimension of the grid. Only 1, 2, or 3 is allowed.
 
         Returns:
-            int or tuple: If ``ndim`` is 1, an integer is returned, otherwise
-                a tuple.
+            int or tuple:
+                If ``ndim`` is 1, an integer is returned, otherwise a tuple.
 
         .. note::
             This function follows the convention of Numba's `numba.cuda.grid`_.

--- a/docs/source/reference/kernel.rst
+++ b/docs/source/reference/kernel.rst
@@ -22,6 +22,7 @@ JIT kernel definition
    cupyx.jit.blockDim
    cupyx.jit.blockIdx
    cupyx.jit.gridDim
+   cupyx.jit.grid
    cupyx.jit.syncthreads
    cupyx.jit.shared_memory
    cupyx.jit._interface._JitRawKernel


### PR DESCRIPTION
This PR adds a convenience helper to make it easier to port existing Numba codes to CuPy JIT. The purpose of `jit.grid()` is to compute the absolute index of a thread in the grid. 

Note that `grid(n)` returns a tuple for n=2, 3. Calling `thrust::make_tuple()` would indeed incur a bit of overhead for such a simple operation, but to retain the Numba convention I am not sure if there's a better solution. Suggestions are more than welcome, as always!

The below snippet shows the generated CUDA code:
```python
import cupy as cp
from cupyx import jit

@jit.rawkernel()
def grid_1d():
    x = jit.grid(1)

grid_1d[1, 1]()
print(grid_1d.cached_code)


@jit.rawkernel()
def grid_2d():
    x, y = jit.grid(2)

grid_2d[1, 1]()
print(grid_2d.cached_code)


@jit.rawkernel()
def grid_3d():
    x, y, z = jit.grid(3)

grid_3d[1, 1]()
print(grid_3d.cached_code)
```
Output: 
```
extern "C" __global__ void grid_1d() {
  unsigned int x;
  x = threadIdx.x + blockIdx.x * blockDim.x;
}
extern "C" __global__ void grid_2d() {
  unsigned int x;
  unsigned int y;
  thrust::tie(x, y) = thrust::make_tuple(threadIdx.x + blockIdx.x * blockDim.x, threadIdx.y + blockIdx.y * blockDim.y);
}
extern "C" __global__ void grid_3d() {
  unsigned int x;
  unsigned int y;
  unsigned int z;
  thrust::tie(x, y, z) = thrust::make_tuple(threadIdx.x + blockIdx.x * blockDim.x, threadIdx.y + blockIdx.y * blockDim.y, threadIdx.z + blockIdx.z * blockDim.z);
}
```

TODO:
- [x] Add error messages
- [x] Add tests
- [x] Add docs