### PR TITLE
Support warp shuffle and sync functions in CuPy JIT

### DIFF
--- a/cupyx/jit/__init__.py
+++ b/cupyx/jit/__init__.py
@@ -6,6 +6,7 @@ from cupyx.jit._interface import blockIdx  # NOQA
 from cupyx.jit._interface import gridDim  # NOQA
 
 from cupyx.jit._builtin_funcs import syncthreads  # NOQA
+from cupyx.jit._builtin_funcs import syncwarp  # NOQA
 from cupyx.jit._builtin_funcs import shared_memory  # NOQA
 from cupyx.jit._builtin_funcs import atomic_add  # NOQA
 from cupyx.jit._builtin_funcs import grid  # NOQA

--- a/cupyx/jit/__init__.py
+++ b/cupyx/jit/__init__.py
@@ -8,7 +8,10 @@ from cupyx.jit._interface import gridDim  # NOQA
 from cupyx.jit._builtin_funcs import syncthreads  # NOQA
 from cupyx.jit._builtin_funcs import shared_memory  # NOQA
 from cupyx.jit._builtin_funcs import atomic_add  # NOQA
-
+from cupyx.jit._builtin_funcs import shfl_sync  # NOQA
+from cupyx.jit._builtin_funcs import shfl_up_sync  # NOQA
+from cupyx.jit._builtin_funcs import shfl_down_sync  # NOQA
+from cupyx.jit._builtin_funcs import shfl_xor_sync  # NOQA
 
 import inspect as _inspect
 

--- a/cupyx/jit/_builtin_funcs.py
+++ b/cupyx/jit/_builtin_funcs.py
@@ -267,7 +267,7 @@ class WarpShuffleOp(BuiltinFunc):
             raise TypeError('mask must be an integer')
         if runtime.is_hip:
             warnings.warn(f'mask {mask} is ignored on HIP', RuntimeWarning)
-        if not (0x0 <= mask <= 0xffffffff):
+        elif not (0x0 <= mask <= 0xffffffff):
             raise ValueError('mask is out of range')
 
         # val_id refers to "delta" for shfl_{up, down}, "srcLane" for shfl, and
@@ -283,9 +283,6 @@ class WarpShuffleOp(BuiltinFunc):
             if isinstance(width, Constant):
                 if width.obj not in (2, 4, 8, 16, 32):
                     raise ValueError('width needs to be power of 2')
-            if runtime.is_hip:
-                warnings.warn(
-                    f'width ({width}) is ignored on HIP', RuntimeWarning)
             width = _compile._astype_scalar(
                 width, _cuda_types.int32, 'same_kind', env)
             width = Data.init(width, env)

--- a/cupyx/jit/_builtin_funcs.py
+++ b/cupyx/jit/_builtin_funcs.py
@@ -125,10 +125,7 @@ class SyncWarp(BuiltinFunc):
         super().__call__()
 
     def call(self, env, *, mask=None):
-        if kwargs:
-            mask = kwargs.pop('mask')
-            if len(kwargs):
-                raise ValueError('keyword arguments not supported')
+        if mask:
             if isinstance(mask, Constant):
                 if not (0x0 <= mask.obj <= 0xffffffff):
                     raise ValueError('mask is out of range')
@@ -253,10 +250,10 @@ class WarpShuffleOp(BuiltinFunc):
         """
         self.__doc__ = doc
 
-    def __call__(self, mask, var, val_id, width=32):
+    def __call__(self, mask, var, val_id, *, width=32):
         super().__call__()
 
-    def call(self, env, mask, var, val_id, **kwargs):
+    def call(self, env, mask, var, val_id, *, width=None):
         name = self._name
 
         var = Data.init(var, env)
@@ -282,10 +279,7 @@ class WarpShuffleOp(BuiltinFunc):
         val_id = _compile._astype_scalar(val_id, val_id_t, 'same_kind', env)
         val_id = Data.init(val_id, env)
 
-        if kwargs:
-            width = kwargs.pop('width')
-            if len(kwargs):
-                raise ValueError('keyword arguments not supported')
+        if width:
             if isinstance(width, Constant):
                 if width.obj not in (2, 4, 8, 16, 32):
                     raise ValueError('width needs to be power of 2')
@@ -295,8 +289,6 @@ class WarpShuffleOp(BuiltinFunc):
             width = _compile._astype_scalar(
                 width, _cuda_types.int32, 'same_kind', env)
             width = Data.init(width, env)
-        else:
-            width = None
 
         code = f'{name}({hex(mask)}, {var.code}, {val_id.code}'
         code += f', {width.code})' if width else ')'

--- a/cupyx/jit/_builtin_funcs.py
+++ b/cupyx/jit/_builtin_funcs.py
@@ -122,7 +122,7 @@ class SyncWarp(BuiltinFunc):
         .. _Synchronization functions:
             https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#synchronization-functions
         """
-        super.__call__(self)
+        super().__call__()
 
     def call(self, env, **kwargs):
         if kwargs:
@@ -245,7 +245,16 @@ class WarpShuffleOp(BuiltinFunc):
         self._op = op
         self._name = '__shfl_' + (op + '_' if op else '') + 'sync'
         self._dtypes = dtypes
-        super().__init__()
+        doc = f"""Call the {self._name} function. Please refer to
+        `Warp Shuffle Functions`_ for detail explanation.
+
+        .. _Warp Shuffle Functions:
+            https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#warp-shuffle-functions
+        """
+        self.__doc__ = doc
+
+    def __call__(self, mask, var, val_id, width=32):
+        super().__call__()
 
     def call(self, env, mask, var, val_id, **kwargs):
         name = self._name

--- a/cupyx/jit/_builtin_funcs.py
+++ b/cupyx/jit/_builtin_funcs.py
@@ -111,7 +111,7 @@ class SyncThreads(BuiltinFunc):
 
 class SyncWarp(BuiltinFunc):
 
-    def __call__(self, mask=0xffffffff):
+    def __call__(self, *, mask=0xffffffff):
         """Calls ``__syncwarp()``.
 
         Args:
@@ -124,7 +124,7 @@ class SyncWarp(BuiltinFunc):
         """
         super().__call__()
 
-    def call(self, env, **kwargs):
+    def call(self, env, *, mask=None):
         if kwargs:
             mask = kwargs.pop('mask')
             if len(kwargs):

--- a/cupyx/jit/_cuda_types.py
+++ b/cupyx/jit/_cuda_types.py
@@ -117,6 +117,7 @@ class Tuple(TypeBase):
 
 void = Void()
 bool_ = Scalar(numpy.bool_)
+int32 = Scalar(numpy.int32)
 uint32 = Scalar(numpy.uint32)
 
 

--- a/docs/source/reference/kernel.rst
+++ b/docs/source/reference/kernel.rst
@@ -24,6 +24,11 @@ JIT kernel definition
    cupyx.jit.gridDim
    cupyx.jit.grid
    cupyx.jit.syncthreads
+   cupyx.jit.syncwarp
+   cupyx.jit.shfl_sync
+   cupyx.jit.shfl_up_sync
+   cupyx.jit.shfl_down_sync
+   cupyx.jit.shfl_xor_sync
    cupyx.jit.shared_memory
    cupyx.jit._interface._JitRawKernel
 

--- a/tests/cupyx_tests/jit_tests/test_raw.py
+++ b/tests/cupyx_tests/jit_tests/test_raw.py
@@ -290,7 +290,7 @@ class TestRaw(unittest.TestCase):
         else:
             testing.assert_allclose(a, e, rtol=1e-5, atol=1e-5)
 
-    @testing.for_dtypes('iILQefd')
+    @testing.for_dtypes('iILQfd' if runtime.is_hip else 'iILQefd')
     def test_atomic_add(self, dtype):
         @jit.rawkernel()
         def f(x, index, out):
@@ -323,7 +323,7 @@ class TestRaw(unittest.TestCase):
     # TODO(leofang): enable HIP when cupy/cupy#5348 is resolved
     @unittest.skipIf(runtime.is_hip, 'HIP is not yet supported')
     # TODO(leofang): test float16 ('e') once cupy/cupy#5346 is resolved
-    @testing.for_dtypes('iILQfd')
+    @testing.for_dtypes('iIlqfd' if runtime.is_hip else 'iIlLqQfd')
     def test_shfl(self, dtype):
         # strictly speaking this function is invalid in Python (see the
         # discussion in cupy/cupy#5340), but it serves for our purpose
@@ -360,7 +360,7 @@ class TestRaw(unittest.TestCase):
     # TODO(leofang): enable HIP when cupy/cupy#5348 is resolved
     @unittest.skipIf(runtime.is_hip, 'HIP is not yet supported')
     # TODO(leofang): test float16 ('e') once cupy/cupy#5346 is resolved
-    @testing.for_dtypes('iILQfd')
+    @testing.for_dtypes('iIlqfd' if runtime.is_hip else 'iIlLqQfd')
     def test_shfl_up(self, dtype):
         N = 5
 
@@ -377,7 +377,7 @@ class TestRaw(unittest.TestCase):
     # TODO(leofang): enable HIP when cupy/cupy#5348 is resolved
     @unittest.skipIf(runtime.is_hip, 'HIP is not yet supported')
     # TODO(leofang): test float16 ('e') once cupy/cupy#5346 is resolved
-    @testing.for_dtypes('iILQfd')
+    @testing.for_dtypes('iIlqfd' if runtime.is_hip else 'iIlLqQfd')
     def test_shfl_down(self, dtype):
         N = 5
 
@@ -394,7 +394,7 @@ class TestRaw(unittest.TestCase):
     # TODO(leofang): enable HIP when cupy/cupy#5348 is resolved
     @unittest.skipIf(runtime.is_hip, 'HIP is not yet supported')
     # TODO(leofang): test float16 ('e') once cupy/cupy#5346 is resolved
-    @testing.for_dtypes('iILQfd')
+    @testing.for_dtypes('iIlqfd' if runtime.is_hip else 'iIlLqQfd')
     def test_shfl_xor(self, dtype):
         @jit.rawkernel()
         def f_shfl_xor(a):

--- a/tests/cupyx_tests/jit_tests/test_raw.py
+++ b/tests/cupyx_tests/jit_tests/test_raw.py
@@ -325,6 +325,8 @@ class TestRaw(unittest.TestCase):
     # TODO(leofang): test float16 ('e') once cupy/cupy#5346 is resolved
     @testing.for_dtypes('iILQfd')
     def test_shfl(self, dtype):
+        # strictly speaking this function is invalid in Python (see the
+        # discussion in cupy/cupy#5340), but it serves for our purpose
         @jit.rawkernel()
         def f(a, b):
             laneId = jit.threadIdx.x & 0x1f
@@ -352,7 +354,7 @@ class TestRaw(unittest.TestCase):
             a = cupy.int32(100)
             b = cupy.arange(32, dtype=cupy.int32)
             f[1, 32](a, b, w)
-            c[c%w!=0] = c[c%w==0]
+            c[c % w != 0] = c[c % w == 0]
             assert (b == c).all()
 
     # TODO(leofang): enable HIP when cupy/cupy#5348 is resolved

--- a/tests/cupyx_tests/jit_tests/test_raw.py
+++ b/tests/cupyx_tests/jit_tests/test_raw.py
@@ -7,6 +7,7 @@ import cupy
 import cupyx
 from cupyx import jit
 from cupy import testing
+from cupy.cuda import runtime
 
 
 class TestRaw(unittest.TestCase):
@@ -283,6 +284,93 @@ class TestRaw(unittest.TestCase):
         y = testing.shaped_random((1024,), dtype=numpy.int32, seed=1)
         f[5, 6](x, y, numpy.uint32(1024))
         assert bool((x == y).all())
+
+    # TODO(leofang): enable HIP when cupy/cupy#5348 is resolved
+    @unittest.skipIf(runtime.is_hip, 'HIP is not yet supported')
+    # TODO(leofang): test float16 ('e') once cupy/cupy#5346 is resolved
+    @testing.for_dtypes('iILQfd')
+    def test_shfl(self, dtype):
+        @jit.rawkernel()
+        def f(a, b):
+            laneId = jit.threadIdx.x & 0x1f
+            if laneId == 0:
+                value = a
+            value = jit.shfl_sync(0xffffffff, value, 0)
+            b[laneId] = value
+
+        a = dtype(100)
+        b = cupy.empty((32,), dtype=dtype)
+        f[1, 32](a, b)
+        assert (b == a * cupy.ones((32,), dtype=dtype)).all()
+
+    # TODO(leofang): enable HIP when cupy/cupy#5348 is resolved
+    @unittest.skipIf(runtime.is_hip, 'HIP is not yet supported')
+    def test_shfl_width(self):
+        @jit.rawkernel()
+        def f(a, b, w):
+            laneId = jit.threadIdx.x & 0x1f
+            value = jit.shfl_sync(0xffffffff, b[jit.threadIdx.x], 0, width=w)
+            b[laneId] = value
+
+        c = cupy.arange(32, dtype=cupy.int32)
+        for w in (2, 4, 8, 16, 32):
+            a = cupy.int32(100)
+            b = cupy.arange(32, dtype=cupy.int32)
+            f[1, 32](a, b, w)
+            c[c%w!=0] = c[c%w==0]
+            assert (b == c).all()
+
+    # TODO(leofang): enable HIP when cupy/cupy#5348 is resolved
+    @unittest.skipIf(runtime.is_hip, 'HIP is not yet supported')
+    # TODO(leofang): test float16 ('e') once cupy/cupy#5346 is resolved
+    @testing.for_dtypes('iILQfd')
+    def test_shfl_up(self, dtype):
+        N = 5
+
+        @jit.rawkernel()
+        def f(a):
+            value = jit.shfl_up_sync(0xffffffff, a[jit.threadIdx.x], N)
+            a[jit.threadIdx.x] = value
+
+        a = cupy.arange(32, dtype=dtype)
+        f[1, 32](a)
+        expected = [i for i in range(N)] + [i for i in range(32-N)]
+        assert(a == cupy.asarray(expected, dtype=dtype)).all()
+
+    # TODO(leofang): enable HIP when cupy/cupy#5348 is resolved
+    @unittest.skipIf(runtime.is_hip, 'HIP is not yet supported')
+    # TODO(leofang): test float16 ('e') once cupy/cupy#5346 is resolved
+    @testing.for_dtypes('iILQfd')
+    def test_shfl_down(self, dtype):
+        N = 5
+
+        @jit.rawkernel()
+        def f(a):
+            value = jit.shfl_down_sync(0xffffffff, a[jit.threadIdx.x], N)
+            a[jit.threadIdx.x] = value
+
+        a = cupy.arange(32, dtype=dtype)
+        f[1, 32](a)
+        expected = [i for i in range(N, 32)] + [(32-N+i) for i in range(N)]
+        assert(a == cupy.asarray(expected, dtype=dtype)).all()
+
+    # TODO(leofang): test float16 ('e') once cupy/cupy#5346 is resolved
+    @testing.for_dtypes('iILQfd')
+    def test_shfl_xor(self, dtype):
+        @jit.rawkernel()
+        def f_shfl_xor(a):
+            laneId = jit.threadIdx.x & 0x1f
+            value = 31 - laneId
+            i = 16
+            while i >= 1:
+                value += jit.shfl_xor_sync(0xffffffff, value, i)
+                i //= 2
+            a[jit.threadIdx.x] = value
+
+        a = cupy.arange(32, dtype=dtype)
+        b = a.copy()
+        f_shfl_xor[1, 32](a)
+        assert (a == b.sum() * cupy.ones(32, dtype=dtype)).all()
 
     def test_error_msg(self):
         @jit.rawkernel()


### PR DESCRIPTION
Part of #5280.

Example:
```python
import cupy as cp
from cupyx import jit

@jit.rawkernel()
def f_shfl(a, b):
    laneId = jit.threadIdx.x & 0x1f
    if laneId == 0:
        value = a
    value = jit.shfl_sync(0xffffffff, value, 0)
    b[laneId] = value


a = cp.int64(100)
b = cp.empty((32,), dtype=cp.int64)
f_shfl[1, 32](a, b)
print(b)


@jit.rawkernel()
def f_shfl_up(a):
    value = jit.shfl_up_sync(0xffffffff, a[jit.threadIdx.x], 5)
    a[jit.threadIdx.x] = value

a = cp.arange(32, dtype=cp.int64)
f_shfl_up[1, 32](a)
print(a)
```
Output:
```
[100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100
 100 100 100 100 100 100 100 100 100 100 100 100 100 100]
[ 0  1  2  3  4  0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18
 19 20 21 22 23 24 25 26]
```

TODO:
- [x] Support `__syncwarp()`
- [x] Add docs
- [x] Add tests