### PR TITLE
Add tests for num_to_num's optional parameters

### DIFF
--- a/cupy/testing/_helper.py
+++ b/cupy/testing/_helper.py
@@ -1,3 +1,4 @@
+from collections import abc
 import contextlib
 import functools
 import inspect
@@ -226,7 +227,7 @@ def _make_positive_mask(self, impl, args, kw, name, sp_name, scipy_name):
 
 
 def _contains_signed_and_unsigned(kw):
-    vs = set(kw.values())
+    vs = set(filter(lambda x: isinstance(x, abc.Hashable), kw.values()))
     return any(d in vs for d in _unsigned_dtypes) and \
         any(d in vs for d in _float_dtypes + _signed_dtypes)
 

--- a/cupy/testing/_helper.py
+++ b/cupy/testing/_helper.py
@@ -1,4 +1,3 @@
-from collections import abc
 import contextlib
 import functools
 import inspect
@@ -227,7 +226,7 @@ def _make_positive_mask(self, impl, args, kw, name, sp_name, scipy_name):
 
 
 def _contains_signed_and_unsigned(kw):
-    vs = set(filter(lambda x: isinstance(x, abc.Hashable), kw.values()))
+    vs = set(kw.values())
     return any(d in vs for d in _unsigned_dtypes) and \
         any(d in vs for d in _float_dtypes + _signed_dtypes)
 

--- a/tests/cupy_tests/math_tests/test_misc.py
+++ b/tests/cupy_tests/math_tests/test_misc.py
@@ -41,7 +41,7 @@ class TestMisc(unittest.TestCase):
 
     @testing.for_dtypes(['e', 'f', 'd', 'F', 'D'])
     @testing.numpy_cupy_allclose(atol=1e-5)
-    def check_unary_inf(self, name, xp, dtype):
+    def check_unary_inf(self, name, xp, dtype, kwargs={}):
         inf = numpy.inf
         if numpy.dtype(dtype).kind != 'c':
             a = xp.array([0, -1, 1, -inf, inf], dtype=dtype)
@@ -50,11 +50,11 @@ class TestMisc(unittest.TestCase):
                           for x in [0, -1, 1, -inf, inf]
                           for y in [0, -1, 1, -inf, inf]],
                          dtype=dtype)
-        return getattr(xp, name)(a)
+        return getattr(xp, name)(a, **kwargs)
 
     @testing.for_dtypes(['e', 'f', 'd', 'F', 'D'])
     @testing.numpy_cupy_allclose(atol=1e-5)
-    def check_unary_nan(self, name, xp, dtype):
+    def check_unary_nan(self, name, xp, dtype, kwargs={}):
         nan = numpy.nan
         if numpy.dtype(dtype).kind != 'c':
             a = xp.array([0, -1, 1, -nan, nan], dtype=dtype)
@@ -63,7 +63,7 @@ class TestMisc(unittest.TestCase):
                           for x in [0, -1, 1, -nan, nan]
                           for y in [0, -1, 1, -nan, nan]],
                          dtype=dtype)
-        return getattr(xp, name)(a)
+        return getattr(xp, name)(a, **kwargs)
 
     @testing.for_dtypes(['e', 'f', 'd', 'F', 'D'])
     @testing.numpy_cupy_allclose(atol=1e-5)
@@ -211,6 +211,13 @@ class TestMisc(unittest.TestCase):
 
     def test_nan_to_num_inf_nan(self):
         self.check_unary_inf_nan('nan_to_num')
+
+    def test_nan_to_num_nan_arg(self):
+        self.check_unary_nan('nan_to_num', kwargs={'nan': 1.0})
+
+    def test_nan_to_num_inf_arg(self):
+        self.check_unary_inf(
+            'nan_to_num', kwargs={'posinf': 1.0, 'neginf': -1.0})
 
     @testing.for_all_dtypes(name='dtype_x', no_bool=True, no_complex=True)
     @testing.for_all_dtypes(name='dtype_y', no_bool=True)

--- a/tests/cupy_tests/math_tests/test_misc.py
+++ b/tests/cupy_tests/math_tests/test_misc.py
@@ -41,7 +41,7 @@ class TestMisc(unittest.TestCase):
 
     @testing.for_dtypes(['e', 'f', 'd', 'F', 'D'])
     @testing.numpy_cupy_allclose(atol=1e-5)
-    def check_unary_inf(self, name, xp, dtype, kwargs={}):
+    def check_unary_inf(self, name, xp, dtype, **kwargs):
         inf = numpy.inf
         if numpy.dtype(dtype).kind != 'c':
             a = xp.array([0, -1, 1, -inf, inf], dtype=dtype)
@@ -54,7 +54,7 @@ class TestMisc(unittest.TestCase):
 
     @testing.for_dtypes(['e', 'f', 'd', 'F', 'D'])
     @testing.numpy_cupy_allclose(atol=1e-5)
-    def check_unary_nan(self, name, xp, dtype, kwargs={}):
+    def check_unary_nan(self, name, xp, dtype, **kwargs):
         nan = numpy.nan
         if numpy.dtype(dtype).kind != 'c':
             a = xp.array([0, -1, 1, -nan, nan], dtype=dtype)
@@ -213,11 +213,10 @@ class TestMisc(unittest.TestCase):
         self.check_unary_inf_nan('nan_to_num')
 
     def test_nan_to_num_nan_arg(self):
-        self.check_unary_nan('nan_to_num', kwargs={'nan': 1.0})
+        self.check_unary_nan('nan_to_num', nan=1.0)
 
     def test_nan_to_num_inf_arg(self):
-        self.check_unary_inf(
-            'nan_to_num', kwargs={'posinf': 1.0, 'neginf': -1.0})
+        self.check_unary_inf('nan_to_num', posinf=1.0, neginf=-1.0)
 
     @testing.for_all_dtypes(name='dtype_x', no_bool=True, no_complex=True)
     @testing.for_all_dtypes(name='dtype_y', no_bool=True)


### PR DESCRIPTION
Follows up #5295.

This PR adds tests for `nan_to_num`'s `nan`, `posinf`, and `neginf` parameters.