### PR TITLE
Ensure source array is C-contiguous before copying to `CUDAArray`

### DIFF
--- a/cupy/cuda/texture.pxd
+++ b/cupy/cuda/texture.pxd
@@ -31,6 +31,7 @@ cdef class CUDAarray:
 
         int _get_memory_kind(self, src, dst)
         void* _make_cudaMemcpy3DParms(self, src, dst)
+        void _prepare_copy(self, arr, stream, direction) except*
 
 
 cdef class TextureObject:

--- a/cupy/cuda/texture.pyx
+++ b/cupy/cuda/texture.pyx
@@ -472,7 +472,10 @@ cdef class CUDAarray:
         '''
         # ensure the array is C-contiguous
         if isinstance(in_arr, ndarray):
-            s = stream_module.get_current_stream() if stream is None else stream
+            if stream is None:
+                s = stream_module.get_current_stream()
+            else:
+                s = stream
             with s:
                 in_arr = _internal_ascontiguousarray(in_arr)
         elif isinstance(in_arr, numpy.ndarray):

--- a/cupy/cuda/texture.pyx
+++ b/cupy/cuda/texture.pyx
@@ -4,6 +4,7 @@ from libc.string cimport memset as c_memset
 import numpy
 
 from cupy._core.core cimport ndarray
+from cupy._core.core cimport _internal_ascontiguousarray
 from cupy_backends.cuda.api cimport driver
 from cupy_backends.cuda.api cimport runtime
 from cupy_backends.cuda.api.runtime cimport Array,\
@@ -378,7 +379,7 @@ cdef class CUDAarray:
 
         return <void*>param
 
-    def _prepare_copy(self, arr, stream, direction):
+    cdef void _prepare_copy(self, arr, stream, direction) except*:
         cdef dict ch = self.desc.get_channel_format()
 
         # sanity checks:
@@ -469,13 +470,20 @@ cdef class CUDAarray:
             where ``nch`` is the number of channels specified in
             :attr:`~CUDAarray.desc`.
         '''
+        # ensure the array is C-contiguous
+        if isinstance(in_arr, ndarray):
+            s = stream_module.get_current_stream() if stream is None else stream
+            with s:
+                in_arr = _internal_ascontiguousarray(in_arr)
+        elif isinstance(in_arr, numpy.ndarray):
+            in_arr = numpy.ascontiguousarray(in_arr)
         self._prepare_copy(in_arr, stream, direction='in')
 
     def copy_to(self, out_arr, stream=None):
         '''Copy data from CUDA array to device or host array.
 
         Args:
-            out_arr (cupy.ndarray or numpy.ndarray)
+            out_arr (cupy.ndarray or numpy.ndarray): must be C-contiguous
             stream (cupy.cuda.Stream): if not ``None``, an asynchronous copy is
                 performed.
 
@@ -490,6 +498,8 @@ cdef class CUDAarray:
             where ``nch`` is the number of channels specified in
             :attr:`~CUDAarray.desc`.
         '''
+        if not out_arr.flags.c_contiguous:
+            raise ValueError('The output array must be C-contiguous')
         self._prepare_copy(out_arr, stream, direction='out')
 
 

--- a/tests/cupy_tests/cuda_tests/test_texture.py
+++ b/tests/cupy_tests/cuda_tests/test_texture.py
@@ -48,14 +48,14 @@ class TestCUDAarray(unittest.TestCase):
                 kind = runtime.cudaChannelFormatKindSigned
             else:
                 kind = runtime.cudaChannelFormatKindUnsigned
-        arr2 = xp.zeros_like(arr)
 
         if self.c_contiguous:
+            arr2 = xp.zeros_like(arr)
             assert arr.flags.c_contiguous
             assert arr2.flags.c_contiguous
         else:
             arr = arr[..., ::2]
-            arr2 = xp.ascontiguousarray(arr2[..., ::2])
+            arr2 = xp.zeros_like(arr)
             width = arr.shape[-1] // n_channel
             assert not arr.flags.c_contiguous
             assert arr2.flags.c_contiguous

--- a/tests/cupy_tests/cuda_tests/test_texture.py
+++ b/tests/cupy_tests/cuda_tests/test_texture.py
@@ -20,10 +20,11 @@ if cupy.cuda.runtime.is_hip:
 @testing.parameterize(*testing.product({
     'xp': ('numpy', 'cupy'),
     'stream': (True, False),
-    'dimensions': ((67, 0, 0), (67, 19, 0), (67, 19, 31)),
+    'dimensions': ((68, 0, 0), (68, 19, 0), (68, 19, 31)),
     'n_channels': (1, 2, 4),
     'dtype': (numpy.float16, numpy.float32, numpy.int8, numpy.int16,
               numpy.int32, numpy.uint8, numpy.uint16, numpy.uint32),
+    'c_contiguous': (True, False),
 }))
 class TestCUDAarray(unittest.TestCase):
     def test_array_gen_cpy(self):
@@ -49,8 +50,16 @@ class TestCUDAarray(unittest.TestCase):
                 kind = runtime.cudaChannelFormatKindUnsigned
         arr2 = xp.zeros_like(arr)
 
-        assert arr.flags['C_CONTIGUOUS']
-        assert arr2.flags['C_CONTIGUOUS']
+        if self.c_contiguous:
+            assert arr.flags.c_contiguous
+            assert arr2.flags.c_contiguous
+        else:
+            arr = arr[..., ::2]
+            arr2 = xp.ascontiguousarray(arr2[..., ::2])
+            width = arr.shape[-1] // n_channel
+            assert not arr.flags.c_contiguous
+            assert arr2.flags.c_contiguous
+            assert arr.shape[-1] == n_channel*width
 
         # create a CUDA array
         ch_bits = [0, 0, 0, 0]


### PR DESCRIPTION
Close #5341. For `copy_from` we can make a copy internally for handling non-contiguous inputs, but for `copy_to` we must require the input to be contiguous, otherwise it's not supported by `memcpy3DAsync`. 

The added tests fail on the current master.

cc: @the-lay