### PR TITLE
Fix cupy.nanmedian's axis parameter to accept a sequence other than a tuple

### DIFF
--- a/cupy/_core/_routines_statistics.pyx
+++ b/cupy/_core/_routines_statistics.pyx
@@ -443,7 +443,7 @@ cpdef ndarray _nanmedian(
 
     if axis is None:
         axis = tuple(range(a.ndim))
-    if not isinstance(axis, tuple):
+    if not sequence.PySequence_Check(axis):
         axis = (axis,)
 
     reduce_axis = []

--- a/cupy/_statistics/meanvar.py
+++ b/cupy/_statistics/meanvar.py
@@ -12,8 +12,8 @@ def median(a, axis=None, out=None, overwrite_input=False, keepdims=False):
 
     Args:
         a (cupy.ndarray): Array to compute the median.
-        axis (int): Axis along which the medians are computed. The flattened
-            array is used by default.
+        axis (int, sequence of int or None): Axis along which the medians are
+             computed. The flattened array is used by default.
         out (cupy.ndarray): Output array.
         overwrite_input (bool): If ``True``, then allow use of memory of input
             array a for calculations. The input array will be modified by the
@@ -41,8 +41,8 @@ def nanmedian(a, axis=None, out=None, overwrite_input=False, keepdims=False):
 
     Args:
         a (cupy.ndarray): Array to compute the median.
-        axis (int): Axis along which the medians are computed. The flattened
-            array is used by default.
+        axis (int, sequence of int or None): Axis along which the medians are
+            computed. The flattened array is used by default.
         out (cupy.ndarray): Output array.
         overwrite_input (bool): If ``True``, then allow use of memory of input
             array a for calculations. The input array will be modified by the
@@ -142,8 +142,8 @@ def mean(a, axis=None, dtype=None, out=None, keepdims=False):
 
     Args:
         a (cupy.ndarray): Array to compute mean.
-        axis (int): Along which axis to compute mean. The flattened array is
-            used by default.
+        axis (int, sequence of int or None): Along which axis to compute mean.
+            The flattened array is used by default.
         dtype: Data type specifier.
         out (cupy.ndarray): Output array.
         keepdims (bool): If ``True``, the axis is remained as an axis of
@@ -210,8 +210,8 @@ def nanmean(a, axis=None, dtype=None, out=None, keepdims=False):
 
     Args:
         a (cupy.ndarray): Array to compute mean.
-        axis (int): Along which axis to compute mean. The flattened array is
-            used by default.
+        axis (int, sequence of int or None): Along which axis to compute mean.
+            The flattened array is used by default.
         dtype: Data type specifier.
         out (cupy.ndarray): Output array.
         keepdims (bool): If ``True``, the axis is remained as an axis of

--- a/tests/cupy_tests/statistics_tests/test_meanvar.py
+++ b/tests/cupy_tests/statistics_tests/test_meanvar.py
@@ -86,7 +86,7 @@ class TestMedianAxis(unittest.TestCase):
 @testing.parameterize(
     *testing.product({
         'shape': [(3, 4, 5)],
-        'axis': [None, 0, 1, -1, (0, 1), (0, 2), (-1, -2)],
+        'axis': [None, 0, 1, -1, (0, 1), (0, 2), (-1, -2), [0, 1]],
         'keepdims': [True, False],
         'overwrite_input': [True, False]
     })


### PR DESCRIPTION
Close #5315.

This PR fixes `cupy.nanmedian`'s `axis` parameter to accept a sequence of axes other than a tuple. Also, it updates `axis` parameter's description in `cupy.nanmean`, `cupy.median` and `cupy.mean`.

