### PR TITLE
[backport] JIT: Fix supported dtype of `atomic_add` on HIP

### DIFF
--- a/cupyx/jit/_builtin_funcs.py
+++ b/cupyx/jit/_builtin_funcs.py
@@ -117,4 +117,5 @@ syncthreads = SyncThreads()
 shared_memory = SharedMemory()
 
 # TODO: Add more atomic functions.
-atomic_add = AtomicOp('Add', 'iILQefd')
+atomic_add = AtomicOp(
+    'Add', 'iILQfd' if runtime.is_hip else 'iILQefd')


### PR DESCRIPTION
Backport of #5383