### PR TITLE
Fix `license_file` option in `setup.cfg`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,4 +31,4 @@ filterwarnings =
     ignore:Using or importing the ABCs from:DeprecationWarning:pyreadline
 
 [metadata]
-license_file = docs/source/license.rst
+license_files = docs/source/license.rst


### PR DESCRIPTION
`license_file` has been deprecated in setuptools v56.0.0.
`license_files` introduced in v42.0.0 needs to be used instead.

https://setuptools.readthedocs.io/en/latest/history.html#v42-0-0
https://setuptools.readthedocs.io/en/latest/history.html#v56-0-0