### PR TITLE
Enable strict xfail in pytest

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ filterwarnings =
     ignore::PendingDeprecationWarning:numpy\.matrixlib\.defmatrix
     # pyreadline (dependency from optuna -> cliff -> cmd2) uses deprecated ABCs
     ignore:Using or importing the ABCs from:DeprecationWarning:pyreadline
+xfail_strict=true
 
 [metadata]
 license_file = docs/source/license.rst


### PR DESCRIPTION
pytest does not fail when XFAIL tests passes unexpectedly, unless strict mode is set.

Currently the following XFAIL is passing unexpectedly in Windows CI:

```
XPASS cupy_tests\core_tests\test_raw.py::TestRawJitify_param_0_{jitify=False}::test_jitify1 macro preprocessing in NVRTC is likely buggy
```

Retest and merge after https://github.com/cupy/cupy/pull/5409.