### PR TITLE
Remove xfail in windows jitify test

### DIFF
--- a/tests/cupy_tests/core_tests/test_raw.py
+++ b/tests/cupy_tests/core_tests/test_raw.py
@@ -1270,13 +1270,13 @@ class TestRawJitify(unittest.TestCase):
         ker((1,), (N,), (a, N))
         assert cupy.allclose(a, b+100)
 
-    @pytest.mark.xfail(sys.platform.startswith('win32'),
-                       reason='macro preprocessing in NVRTC is likely buggy')
     def test_jitify1(self):
         # simply prepend an unused header
         hdr = '#include <cupy/cub/cub/block/block_reduce.cuh>\n'
 
         if self.jitify:
+            if sys.platform.startswith('win32'):
+                pytest.xfail('macro preprocessing in NVRTC is likely buggy')
             # Jitify will make it work
             self._helper(hdr)
         else:


### PR DESCRIPTION
This PR blocks #5407.

Currently, the following XFAIL is passing unexpectedly in Windows CI (cc: @leofang)

```
XPASS cupy_tests\core_tests\test_raw.py::TestRawJitify_param_0_{jitify=False}::test_jitify1 macro preprocessing in NVRTC is likely buggy
```