### PR TITLE
Fix astype from boolean

### DIFF
--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -462,6 +462,14 @@ cdef class ndarray:
                 'Casting complex values to real discards the imaginary part',
                 numpy.ComplexWarning)
             elementwise_copy(self.real, newarray)
+        elif self.dtype.kind == 'b':
+            # See #4354. The result of `astype` from a ndarray whose dtype is
+            # boolean to another dtype is expected to be zero or one. However,
+            # its underlying representation is not necessarily zero or one
+            # (i.g. a view). In such a case,`elementwise_copy` copies the data
+            # as it is, resulting in an undesirable output. To keep it off, we
+            # give a special path for a boolean ndarray.
+            cupy.not_equal(self, 0, out=newarray)
         else:
             elementwise_copy(self, newarray)
         return newarray

--- a/tests/cupy_tests/core_tests/test_ndarray_copy_and_view.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_copy_and_view.py
@@ -155,6 +155,12 @@ class TestArrayCopyAndView(unittest.TestCase):
                                      xp.empty((2, 3, 2), dtype=src_dtype))
         return astype_without_warning(src, dst_dtype, order='K').strides
 
+    @testing.numpy_cupy_array_equal()
+    def test_astype_boolean_view(self, xp):
+        # See #4354
+        a = xp.array([0, 1, 2], dtype=numpy.int8).view(dtype=numpy.bool_)
+        return a.astype(numpy.int8)
+
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_diagonal1(self, xp, dtype):


### PR DESCRIPTION
Fix #4354.

The result of `astype` from a ndarray whose dtype is boolean to another dtype is expected to be zero or one. However, its underlying representation is not necessarily zero or one (i.g. a view). And in such a case, `astype` returns a ndarray with values other than zero or one. This PR fixes `astype` from boolean ndarray to return the proper value.
