### PR TITLE
[backport] JIT: Fix `__call__()` for built-in functions

### DIFF
--- a/cupyx/jit/_builtin_funcs.py
+++ b/cupyx/jit/_builtin_funcs.py
@@ -55,7 +55,7 @@ class SyncThreads(BuiltinFunc):
     def __call__(self):
         """Calls ``__syncthreads()``
         """
-        super.__call__(self)
+        super().__call__()
 
     def call_const(self, env):
         return Data('__syncthreads()', _cuda_types.void)
@@ -73,7 +73,7 @@ class SharedMemory(BuiltinFunc):
                 If ``int`` type, the size of static shared memory.
                 If ``None``, declares the shared memory with extern specifier.
         """
-        super.__call__(self)
+        super().__call__()
 
     def call_const(self, env, dtype, size):
         name = env.get_fresh_variable_name(prefix='_smem')


### PR DESCRIPTION
Backport of #5361 by @leofang