### PR TITLE
Fix indent of `Returns` section

### DIFF
--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -1826,7 +1826,7 @@ cdef class ndarray:
 
         Returns:
             dltensor (:class:`PyCapsule`): Output DLPack tensor which is
-                encapsulated in a :class:`PyCapsule` object.
+            encapsulated in a :class:`PyCapsule` object.
 
         .. seealso::
 

--- a/cupy/_core/dlpack.pyx
+++ b/cupy/_core/dlpack.pyx
@@ -333,7 +333,7 @@ cpdef from_dlpack(array):
 
     Returns:
         cupy.ndarray: a CuPy array that can be safely accessed on CuPy's
-            current stream.
+        current stream.
 
     .. note::
         This function is different from CuPy's legacy :func:`~cupy.fromDlpack`

--- a/cupy/_functional/piecewise.py
+++ b/cupy/_functional/piecewise.py
@@ -24,7 +24,7 @@ def piecewise(x, condlist, funclist):
 
         Returns:
             cupy.ndarray: the scalar values in funclist on portions of x
-                defined by condlist.
+            defined by condlist.
 
         .. warning::
 

--- a/cupy/_indexing/generate.py
+++ b/cupy/_indexing/generate.py
@@ -275,7 +275,7 @@ def ravel_multi_index(multi_index, dims, mode='wrap', order='C'):
 
     Returns:
         raveled_indices (cupy.ndarray): An array of indices into the flattened
-            version of an array of dimensions ``dims``.
+        version of an array of dimensions ``dims``.
 
     .. warning::
 

--- a/cupy/_indexing/indexing.py
+++ b/cupy/_indexing/indexing.py
@@ -88,7 +88,7 @@ def compress(condition, a, axis=None, out=None):
 
     Returns:
         cupy.ndarray: A copy of a without the slices along axis for which
-            condition is false.
+        condition is false.
 
     .. warning::
 

--- a/cupy/_logic/comparison.py
+++ b/cupy/_logic/comparison.py
@@ -50,7 +50,7 @@ def array_equal(a1, a2, equal_nan=False):
 
     Returns:
         cupy.ndarray: A boolean 0-dim array.
-            If its value is ``True``, two arrays are element-wise equal.
+        If its value is ``True``, two arrays are element-wise equal.
 
     .. seealso:: :func:`numpy.array_equal`
 
@@ -88,8 +88,8 @@ def allclose(a, b, rtol=1.e-5, atol=1.e-8, equal_nan=False):
 
     Returns:
         cupy.ndarray: A boolean 0-dim array.
-            If its value is ``True``, two arrays are element-wise equal within
-            a tolerance.
+        If its value is ``True``, two arrays are element-wise equal within
+        a tolerance.
 
     .. seealso:: :func:`numpy.allclose`
 

--- a/cupy/_manipulation/add_remove.py
+++ b/cupy/_manipulation/add_remove.py
@@ -27,7 +27,7 @@ def append(arr, values, axis=None):
             given, both ``arr`` and ``values`` are flattened before use.
 
     Returns:
-        cupy.ndarray
+        cupy.ndarray:
             A copy of ``arr`` with ``values`` appended to ``axis``.  Note that
             ``append`` does not occur in-place: a new array is allocated and
             filled.  If ``axis`` is None, ``out`` is a flattened array.

--- a/cupy/_manipulation/dims.py
+++ b/cupy/_manipulation/dims.py
@@ -138,7 +138,7 @@ def expand_dims(a, axis):
 
     Returns:
         cupy.ndarray: The number of dimensions is one greater than that of
-            the input array.
+        the input array.
 
     .. seealso:: :func:`numpy.expand_dims`
 

--- a/cupy/_manipulation/kind.py
+++ b/cupy/_manipulation/kind.py
@@ -44,7 +44,7 @@ def require(a, dtype=None, requirements=None):
 
     Returns:
         ~cupy.ndarray: The input array ``a`` with specified requirements and
-            type if provided.
+        type if provided.
 
     .. seealso:: :func:`numpy.require`
 

--- a/cupy/_math/sumprod.py
+++ b/cupy/_math/sumprod.py
@@ -329,9 +329,9 @@ def gradient(f, *varargs, axis=None, edge_order=1):
 
     Returns:
         gradient (cupy.ndarray or list of cupy.ndarray): A set of ndarrays
-            (or a single ndarray if there is only one dimension) corresponding
-            to the derivatives of f with respect to each dimension. Each
-            derivative has the same shape as f.
+        (or a single ndarray if there is only one dimension) corresponding
+        to the derivatives of f with respect to each dimension. Each
+        derivative has the same shape as f.
 
     .. seealso:: :func:`numpy.gradient`
     """

--- a/cupy/_sorting/count.py
+++ b/cupy/_sorting/count.py
@@ -17,8 +17,8 @@ def count_nonzero(a, axis=None):
             counted along a flattened version of ``a``
     Returns:
         cupy.ndarray of int: Number of non-zero values in the array
-            along a given axis. Otherwise, the total number of non-zero values
-            in the array is returned.
+        along a given axis. Otherwise, the total number of non-zero values
+        in the array is returned.
     """
 
     return _count_nonzero(a, axis=axis)

--- a/cupy/_sorting/search.py
+++ b/cupy/_sorting/search.py
@@ -49,7 +49,7 @@ def nanargmax(a, axis=None, dtype=None, out=None, keepdims=False):
 
     Returns:
         cupy.ndarray: The indices of the maximum of ``a``
-            along an axis ignoring NaN values.
+        along an axis ignoring NaN values.
 
     .. note:: For performance reasons, ``cupy.nanargmax`` returns
             ``out of range values`` for all-NaN slice
@@ -104,7 +104,7 @@ def nanargmin(a, axis=None, dtype=None, out=None, keepdims=False):
 
     Returns:
         cupy.ndarray: The indices of the minimum of ``a``
-            along an axis ignoring NaN values.
+        along an axis ignoring NaN values.
 
     .. note:: For performance reasons, ``cupy.nanargmin`` returns
             ``out of range values`` for all-NaN slice
@@ -186,9 +186,9 @@ def where(condition, x=None, y=None):
 
     Returns:
         cupy.ndarray: Each element of output contains elements of ``x`` when
-            ``condition`` is ``True``, otherwise elements of ``y``. If only
-            ``condition`` is given, return the tuple ``condition.nonzero()``,
-            the indices where ``condition`` is True.
+        ``condition`` is ``True``, otherwise elements of ``y``. If only
+        ``condition`` is given, return the tuple ``condition.nonzero()``,
+        the indices where ``condition`` is True.
 
     .. warning::
 

--- a/cupy/_statistics/histogram.py
+++ b/cupy/_statistics/histogram.py
@@ -512,7 +512,7 @@ def bincount(x, weights=None, minlength=None):
 
     Returns:
         cupy.ndarray: The result of binning the input array. The length of
-            output is equal to ``max(cupy.max(x) + 1, minlength)``.
+        output is equal to ``max(cupy.max(x) + 1, minlength)``.
 
     .. warning::
 

--- a/cupy/_statistics/histogram.py
+++ b/cupy/_statistics/histogram.py
@@ -316,9 +316,12 @@ def histogramdd(sample, bins=10, range=None, weights=None, density=False):
             function at the bin, ``bin_count / sample_count / bin_volume``.
 
     Returns:
-        H (cupy.ndarray): The multidimensional histogram of sample x. See
+        tuple:
+        H (cupy.ndarray):
+            The multidimensional histogram of sample x. See
             normed and weights for the different possible semantics.
-        edges (list of cupy.ndarray): A list of D arrays describing the bin
+        edges (list of cupy.ndarray):
+            A list of D arrays describing the bin
             edges for each dimension.
 
     .. warning::
@@ -460,11 +463,15 @@ def histogram2d(x, y, bins=10, range=None, weights=None, density=None):
             function at the bin, ``bin_count / sample_count / bin_volume``.
 
     Returns:
-        H (cupy.ndarray): The multidimensional histogram of sample x. See
+        tuple:
+        H (cupy.ndarray):
+            The multidimensional histogram of sample x. See
             normed and weights for the different possible semantics.
-        edges0 (tuple of cupy.ndarray): A list of D arrays describing the bin
+        edges0 (tuple of cupy.ndarray):
+            A list of D arrays describing the bin
             edges for the first dimension.
-        edges1 (tuple of cupy.ndarray): A list of D arrays describing the bin
+        edges1 (tuple of cupy.ndarray):
+            A list of D arrays describing the bin
             edges for the second dimension.
 
     .. warning::

--- a/cupy/_statistics/meanvar.py
+++ b/cupy/_statistics/meanvar.py
@@ -82,7 +82,7 @@ def average(a, axis=None, weights=None, returned=False):
 
     Returns:
         cupy.ndarray or tuple of cupy.ndarray: The average of the input array
-            along the axis and the sum of weights.
+        along the axis and the sum of weights.
 
     .. warning::
 

--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -936,8 +936,8 @@ cdef class _Arena:
 
         Returns:
             bool: ``True`` if the chunk can successfully be removed from
-                the free list. ``False`` otherwise (e.g., the chunk could not
-                be found in the free list as the chunk is allocated.)
+            the free list. ``False`` otherwise (e.g., the chunk could not
+            be found in the free list as the chunk is allocated.)
         """
 
         cdef size_t index, bin_index

--- a/cupy/cusparse.py
+++ b/cupy/cusparse.py
@@ -194,8 +194,9 @@ def csrmvExIsAligned(a, x, y=None):
         required by csrmvEx.
 
     Returns:
-        bool: ``True`` if all pointers are aligned.
-              ``False`` if otherwise.
+        bool:
+        ``True`` if all pointers are aligned.
+        ``False`` if otherwise.
 
     """
 

--- a/cupy/cutensor.pyx
+++ b/cupy/cutensor.pyx
@@ -231,7 +231,7 @@ cpdef TensorDescriptor create_tensor_descriptor(
 
     Returns:
         (Descriptor): A instance of class Descriptor which holds a pointer to
-            tensor descriptor and its destructor.
+        tensor descriptor and its destructor.
     """
     if handle is None:
         handle = _get_handle()

--- a/cupy/lib/_routines_poly.py
+++ b/cupy/lib/_routines_poly.py
@@ -140,14 +140,16 @@ def polyfit(x, y, deg, rcond=None, full=False, w=None, cov=False):
             along with the covariance matrix.
 
     Returns:
-        cupy.ndarray: of shape (deg + 1,) or (deg + 1, K).
+        cupy.ndarray or tuple:
+        p (cupy.ndarray of shape (deg + 1,) or (deg + 1, K)):
             Polynomial coefficients from highest to lowest degree
-        tuple (cupy.ndarray, int, cupy.ndarray, float):
+        residuals, rank, singular_values, rcond
+        (cupy.ndarray, int, cupy.ndarray, float):
             Present only if ``full=True``.
             Sum of squared residuals of the least-squares fit,
             rank of the scaled Vandermonde coefficient matrix,
             its singular values, and the specified value of ``rcond``.
-        cupy.ndarray: of shape (M, M) or (M, M, K).
+        V (cupy.ndarray of shape (M, M) or (M, M, K)):
             Present only if ``full=False`` and ``cov=True``.
             The covariance matrix of the polynomial coefficient estimates.
 

--- a/cupy/lib/_routines_poly.py
+++ b/cupy/lib/_routines_poly.py
@@ -143,7 +143,7 @@ def polyfit(x, y, deg, rcond=None, full=False, w=None, cov=False):
         cupy.ndarray or tuple:
         p (cupy.ndarray of shape (deg + 1,) or (deg + 1, K)):
             Polynomial coefficients from highest to lowest degree
-        residuals, rank, singular_values, rcond
+        residuals, rank, singular_values, rcond \
         (cupy.ndarray, int, cupy.ndarray, float):
             Present only if ``full=True``.
             Sum of squared residuals of the least-squares fit,

--- a/cupy/lib/_shape_base.py
+++ b/cupy/lib/_shape_base.py
@@ -18,10 +18,10 @@ def apply_along_axis(func1d, axis, arr, *args, **kwargs):
 
     Returns:
         cupy.ndarray: The output array. The shape of ``out`` is identical to
-            the shape of ``arr``, except along the ``axis`` dimension. This
-            axis is removed, and replaced with new dimensions equal to the
-            shape of the return value of ``func1d``. So if ``func1d`` returns a
-            scalar ``out`` will have one fewer dimensions than ``arr``.
+        the shape of ``arr``, except along the ``axis`` dimension. This
+        axis is removed, and replaced with new dimensions equal to the
+        shape of the return value of ``func1d``. So if ``func1d`` returns a
+        scalar ``out`` will have one fewer dimensions than ``arr``.
 
     .. seealso:: :func:`numpy.apply_over_axes`
     """

--- a/cupy/linalg/_decomposition.py
+++ b/cupy/linalg/_decomposition.py
@@ -23,11 +23,15 @@ def _lu_factor(a_t, dtype):
         dtype (numpy.dtype): float32, float64, complex64, or complex128.
 
     Returns:
-        lu_t (cupy.ndarray): ``L`` without its unit diagonal and ``U`` with
+        tuple:
+        lu_t (cupy.ndarray):
+            ``L`` without its unit diagonal and ``U`` with
             dimension ``(..., N, N)``.
-        piv (cupy.ndarray): 1-origin pivot indices with dimension
+        piv (cupy.ndarray):
+            1-origin pivot indices with dimension
             ``(..., N)``.
-        dev_info (cupy.ndarray): ``getrf`` info with dimension ``(...)``.
+        dev_info (cupy.ndarray):
+            ``getrf`` info with dimension ``(...)``.
 
     .. seealso:: :func:`scipy.linalg.lu_factor`
 

--- a/cupy/linalg/_einsum.py
+++ b/cupy/linalg/_einsum.py
@@ -34,8 +34,8 @@ def _transpose_ex(a, axeses):
         axeses (sequence of sequences of ints)
 
     Returns:
-        p: a with its axes permutated. A writeable view is returned whenever
-            possible.
+        ndarray: a with its axes permutated. A writeable view is returned
+        whenever possible.
     """
 
     shape = []

--- a/cupy/linalg/_solve.py
+++ b/cupy/linalg/_solve.py
@@ -399,7 +399,7 @@ def pinv(a, rcond=1e-15):
 
     Returns:
         cupy.ndarray: The pseudoinverse of ``a`` with dimension
-            ``(..., N, M)``.
+        ``(..., N, M)``.
 
     .. warning::
         This function calls one or more cuSOLVER routine(s) which may yield

--- a/cupy/polynomial/polyutils.py
+++ b/cupy/polynomial/polyutils.py
@@ -34,7 +34,7 @@ def trimseq(seq):
 
     Returns:
         cupy.ndarray: input array with trailing zeros removed. If the
-            resulting output is empty, it returns the first element
+        resulting output is empty, it returns the first element.
 
     .. seealso:: :func:`numpy.polynomial.polyutils.trimseq`
 

--- a/cupy/random/_generator_api.pyx
+++ b/cupy/random/_generator_api.pyx
@@ -284,7 +284,7 @@ class Generator:
                 to this array
         Returns:
             cupy.ndarray: Samples drawn from the standard exponential
-                distribution.
+            distribution.
 
         .. seealso::
             :meth:`numpy.random.Generator.standard_exponential`

--- a/cupy/random/_sample.py
+++ b/cupy/random/_sample.py
@@ -181,7 +181,7 @@ def choice(a, size=None, replace=True, p=None):
 
     Returns:
         cupy.ndarray: An array of ``a`` values distributed according to
-                      ``p`` or uniformly.
+        ``p`` or uniformly.
 
     .. seealso:: :meth:`numpy.random.choice`
 

--- a/cupy/testing/_helper.py
+++ b/cupy/testing/_helper.py
@@ -1348,7 +1348,7 @@ def shaped_random(
 
     Returns:
          numpy.ndarray or cupy.ndarray: The array with
-             given shape, array module,
+         given shape, array module,
 
     If ``dtype`` is ``numpy.bool_``, the elements are
     independently drawn from ``True`` and ``False``

--- a/cupy_backends/cuda/libs/cutensor.pyx
+++ b/cupy_backends/cuda/libs/cutensor.pyx
@@ -727,7 +727,7 @@ cpdef int32_t contractionMaxAlgos():
 
     Returns:
         maxNumAlgos (int32_t): The maximum number of algorithms available for
-            cutensorContraction().
+        cutensorContraction().
     """
     cdef int32_t maxNumAlgos = 0
     status = cutensorContractionMaxAlgos(&maxNumAlgos)
@@ -837,7 +837,7 @@ cpdef uint64_t reductionGetWorkspace(
 
     Returns:
         workspaceSize (uint64_t): The workspace size (in bytes) that is
-            required for the given tensor reduction.
+        required for the given tensor reduction.
     """
     cdef uint64_t workspaceSize = 0
     status = cutensorReductionGetWorkspace(

--- a/cupyx/scipy/linalg/special_matrices.py
+++ b/cupyx/scipy/linalg/special_matrices.py
@@ -100,7 +100,7 @@ def toeplitz(c, r=None):
 
     Returns:
         cupy.ndarray: The Toeplitz matrix. Dtype is the same as
-            ``(c[0] + r[0]).dtype``.
+        ``(c[0] + r[0]).dtype``.
 
     .. seealso:: :func:`cupyx.scipy.linalg.circulant`
     .. seealso:: :func:`cupyx.scipy.linalg.hankel`
@@ -149,7 +149,7 @@ def hankel(c, r=None):
 
     Returns:
         cupy.ndarray: The Hankel matrix. Dtype is the same as
-            ``(c[0] + r[0]).dtype``.
+        ``(c[0] + r[0]).dtype``.
 
     .. seealso:: :func:`cupyx.scipy.linalg.toeplitz`
     .. seealso:: :func:`cupyx.scipy.linalg.circulant`
@@ -211,8 +211,8 @@ def leslie(f, s):
 
     Returns:
         cupy.ndarray: The array is zero except for the first row, which is
-            ``f``, and the first sub-diagonal, which is ``s``. The data-type of
-            the array will be the data-type of ``f[0]+s[0]``.
+        ``f``, and the first sub-diagonal, which is ``s``. The data-type of
+        the array will be the data-type of ``f[0]+s[0]``.
 
     .. seealso:: :func:`scipy.linalg.leslie`
     """
@@ -270,7 +270,7 @@ def block_diag(*arrs):
 
     Returns:
         (cupy.ndarray): Array with ``A``, ``B``, ``C``, ... on the diagonal.
-            Output has the same dtype as ``A``.
+        Output has the same dtype as ``A``.
 
     .. seealso:: :func:`scipy.linalg.block_diag`
     """
@@ -312,8 +312,8 @@ def companion(a):
 
     Returns:
         (cupy.ndarray): The first row of the output is ``-a[1:]/a[0]``, and the
-            first sub-diagonal is all ones. The data-type of the array is the
-            same as the data-type of ``-a[1:]/a[0]``.
+        first sub-diagonal is all ones. The data-type of the array is the
+        same as the data-type of ``-a[1:]/a[0]``.
 
     .. seealso:: :func:`cupyx.scipy.linalg.fiedler_companion`
     .. seealso:: :func:`scipy.linalg.companion`
@@ -348,7 +348,7 @@ def helmert(n, full=False):
 
     Returns:
         cupy.ndarray: The Helmert matrix. The shape is (n, n) or (n-1, n)
-            depending on the ``full`` argument.
+        depending on the ``full`` argument.
 
     .. seealso:: :func:`scipy.linalg.helmert`
     """
@@ -515,10 +515,10 @@ def convolution_matrix(a, n, mode='full'):
 
     Returns:
         cupy.ndarray: The convolution matrix whose row count depends on
-            ``mode``:
-                ``'full'   m + n -1``
-                ``'same'   max(m, n)``
-                ``'valid'  max(m, n) - min(m, n) + 1``
+        ``mode``:
+            ``'full'   m + n -1``
+            ``'same'   max(m, n)``
+            ``'valid'  max(m, n) - min(m, n) + 1``
 
     .. seealso:: :func:`cupyx.scipy.linalg.toeplitz`
     .. seealso:: :func:`scipy.linalg.convolution_matrix`

--- a/cupyx/scipy/linalg/special_matrices.py
+++ b/cupyx/scipy/linalg/special_matrices.py
@@ -514,11 +514,16 @@ def convolution_matrix(a, n, mode='full'):
             This is analogous to ``mode`` in ``numpy.convolve(v, a, mode)``.
 
     Returns:
-        cupy.ndarray: The convolution matrix whose row count depends on
+        cupy.ndarray: The convolution matrix whose row count k depends on
         ``mode``:
-            ``'full'   m + n -1``
-            ``'same'   max(m, n)``
-            ``'valid'  max(m, n) - min(m, n) + 1``
+
+        =========== =========================
+        ``mode``    k
+        =========== =========================
+        ``'full'``  m + n - 1
+        ``'same'``  max(m, n)
+        ``'valid'`` max(m, n) - min(m, n) + 1
+        =========== =========================
 
     .. seealso:: :func:`cupyx.scipy.linalg.toeplitz`
     .. seealso:: :func:`scipy.linalg.convolution_matrix`

--- a/cupyx/scipy/ndimage/measurements.py
+++ b/cupyx/scipy/ndimage/measurements.py
@@ -298,8 +298,8 @@ def variance(input, labels=None, index=None):
             (default), all values where `labels` is non-zero are used.
 
     Returns:
-        variance (cupy.ndarray): Values of variance, for each sub-region if
-            `labels` and `index` are specified.
+        cupy.ndarray: Values of variance, for each sub-region if
+        `labels` and `index` are specified.
 
     .. seealso:: :func:`scipy.ndimage.variance`
     """

--- a/cupyx/scipy/ndimage/morphology.py
+++ b/cupyx/scipy/ndimage/morphology.py
@@ -95,7 +95,7 @@ def iterate_structure(structure, iterations, origin=None):
 
     Returns:
         cupy.ndarray: A new structuring element obtained by dilating
-             ``structure`` (``iterations`` - 1) times with itself.
+        ``structure`` (``iterations`` - 1) times with itself.
 
     .. seealso:: :func:`scipy.ndimage.iterate_structure`
     """
@@ -134,8 +134,8 @@ def generate_binary_structure(rank, connectivity):
 
     Returns:
         cupy.ndarray: Structuring element which may be used for binary
-            morphological operations, with ``rank`` dimensions and all
-            dimensions equal to 3.
+        morphological operations, with ``rank`` dimensions and all
+        dimensions equal to 3.
 
     .. seealso:: :func:`scipy.ndimage.generate_binary_structure`
     """
@@ -492,7 +492,7 @@ def binary_hit_or_miss(input, structure1=None, structure2=None, output=None,
 
     Returns:
         cupy.ndarray: Hit-or-miss transform of ``input`` with the given
-            structuring element (``structure1``, ``structure2``).
+        structuring element (``structure1``, ``structure2``).
 
     .. warning::
 
@@ -574,7 +574,7 @@ def binary_fill_holes(input, structure=None, output=None, origin=0):
 
     Returns:
         cupy.ndarray: Transformation of the initial image ``input`` where holes
-            have been filled.
+        have been filled.
 
     .. warning::
 

--- a/cupyx/scipy/signal/signaltools.py
+++ b/cupyx/scipy/signal/signaltools.py
@@ -335,7 +335,7 @@ def convolve2d(in1, in2, mode='full', boundary='fill', fillvalue=0):
 
     Returns:
         cupy.ndarray: A 2-dimensional array containing a subset of the discrete
-            linear convolution of ``in1`` with ``in2``.
+        linear convolution of ``in1`` with ``in2``.
 
     .. seealso:: :func:`cupyx.scipy.signal.convolve`
     .. seealso:: :func:`cupyx.scipy.signal.fftconvolve`
@@ -378,7 +378,7 @@ def correlate2d(in1, in2, mode='full', boundary='fill', fillvalue=0):
 
     Returns:
         cupy.ndarray: A 2-dimensional array containing a subset of the discrete
-            linear cross-correlation of ``in1`` with ``in2``.
+        linear cross-correlation of ``in1`` with ``in2``.
 
     Note:
         When using ``"same"`` mode with even-length inputs, the outputs of
@@ -475,7 +475,7 @@ def order_filter(a, domain, rank):
 
     Returns:
         cupy.ndarray: The results of the order filter in an array with the same
-            shape as `a`.
+        shape as `a`.
 
     .. seealso:: :func:`cupyx.scipy.ndimage.rank_filter`
     .. seealso:: :func:`scipy.signal.order_filter`
@@ -539,7 +539,8 @@ def medfilt2d(input, kernel_size=3):
 
     Returns:
         cupy.ndarray: An array the same size as input containing the median
-            filtered result.
+        filtered result.
+
     See also
     --------
     .. seealso:: :func:`cupyx.scipy.ndimage.median_filter`

--- a/cupyx/scipy/sparse/base.py
+++ b/cupyx/scipy/sparse/base.py
@@ -172,7 +172,7 @@ class spmatrix(object):
 
         Returns:
             cupyx.scipy.sparse.spmatrix: A sparse matrix representing n-th
-                power of this matrix.
+            power of this matrix.
 
         """
         m, n = self.shape

--- a/cupyx/scipy/sparse/base.py
+++ b/cupyx/scipy/sparse/base.py
@@ -568,7 +568,7 @@ def issparse(x):
 
     Returns:
         bool: Returns if ``x`` is :class:`cupyx.scipy.sparse.spmatrix` that is
-            a base class of all sparse matrix classes.
+        a base class of all sparse matrix classes.
 
     """
     return isinstance(x, spmatrix)

--- a/cupyx/scipy/sparse/compressed.py
+++ b/cupyx/scipy/sparse/compressed.py
@@ -798,7 +798,7 @@ class _compressed_sparse_matrix(sparse_data._data_matrix,
 
         Returns:
             (cupy.ndarray): Reduce result for nonzeros in each
-                major_index.
+            major_index.
 
         """
         out_shape = self.shape[1 - axis]
@@ -832,7 +832,7 @@ class _compressed_sparse_matrix(sparse_data._data_matrix,
 
         Returns:
             (cupy.ndarray): Reduce result for nonzeros in each
-                major_index
+            major_index
 
         """
 

--- a/cupyx/scipy/sparse/data.py
+++ b/cupyx/scipy/sparse/data.py
@@ -274,9 +274,9 @@ class _minmax_mixin(object):
 
         Returns:
             (cupy.ndarray or float): Maximum of ``a``. If ``axis`` is
-                ``None``, the result is a scalar value. If ``axis`` is given,
-                the result is an array of dimension ``a.ndim - 1``. This
-                differs from numpy for computational efficiency.
+            ``None``, the result is a scalar value. If ``axis`` is given,
+            the result is an array of dimension ``a.ndim - 1``. This
+            differs from numpy for computational efficiency.
 
         .. seealso:: min : The minimum value of a sparse matrix along a given
           axis.
@@ -310,9 +310,9 @@ class _minmax_mixin(object):
 
         Returns:
             (cupy.ndarray or float): Minimum of ``a``. If ``axis`` is
-                None, the result is a scalar value. If ``axis`` is given, the
-                result is an array of dimension ``a.ndim - 1``. This differs
-                from numpy for computational efficiency.
+            None, the result is a scalar value. If ``axis`` is given, the
+            result is an array of dimension ``a.ndim - 1``. This differs
+            from numpy for computational efficiency.
 
         .. seealso:: max : The maximum value of a sparse matrix along a given
           axis.
@@ -345,7 +345,7 @@ class _minmax_mixin(object):
 
         Returns:
             (cupy.narray or int): Indices of maximum elements. If array,
-                its size along ``axis`` is 1.
+            its size along ``axis`` is 1.
 
         """
         return self._arg_min_or_max(axis, out, cupy.argmax, cupy.greater)
@@ -370,7 +370,7 @@ class _minmax_mixin(object):
 
         Returns:
             (cupy.narray or int): Indices of minimum elements. If matrix,
-                its size along ``axis`` is 1.
+            its size along ``axis`` is 1.
 
         """
         return self._arg_min_or_max(axis, out, cupy.argmin, cupy.less)

--- a/cupyx/scipy/sparse/linalg/_solve.py
+++ b/cupyx/scipy/sparse/linalg/_solve.py
@@ -286,7 +286,7 @@ def factorized(A):
 
     Returns:
         callable: a function to solve the linear system of equations given in
-            ``A``.
+        ``A``.
 
     Note:
         This function computes LU decomposition of a sparse matrix on the CPU


### PR DESCRIPTION
In Google style, the `Returns` section
- cannot have multiple return values (while NumPy style can), and
- uses block indentation (while each of `Args` uses hanging indentation) https://en.wikipedia.org/wiki/Indentation_(typesetting)

https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html

The targets in the PR are collected by
```
git ls-files | xargs grep -Pzo '\n {4}Returns:\n {8}.*[^:]\n {12}.*\n'  # functions
git ls-files | xargs grep -Pzo '\n {8}Returns:\n {12}.*[^:]\n {16}.*\n'  # methods
```