### PR TITLE
Fix mergify to only comment when pull-request is open

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -12,6 +12,7 @@ pull_request_rules:
   - name: Notify conflict
     conditions:
       - conflict
+      - closed=false
     actions:
       comment:
         message: This pull request is now in conflicts. Could you fix it @{{author}}? 🙏


### PR DESCRIPTION
Maybe `closed=false` condition is needed to avoid this: https://github.com/cupy/cupy/pull/5426#issuecomment-873896502
Just a wild guess.