### PR TITLE
Use `dtype.name` instead `dtype.char`

### DIFF
--- a/cupyx/jit/_builtin_funcs.py
+++ b/cupyx/jit/_builtin_funcs.py
@@ -1,4 +1,3 @@
-import sys
 import warnings
 
 import cupy
@@ -173,11 +172,6 @@ class AtomicOp(BuiltinFunc):
     def __init__(self, op, dtypes):
         self._op = op
         self._name = 'atomic' + op
-        if sys.platform.startswith('win'):
-            extra = {'i': 'l', 'I': 'L'}
-            for k, v in extra.items():
-                if k in dtypes:
-                    dtypes += v
         self._dtypes = dtypes
         doc = f"""Call the ``{self._name}`` function to operate atomically on
         ``array[index]``. Please refer to `Atomic Functions`_ for detailed

--- a/cupyx/jit/_cuda_types.py
+++ b/cupyx/jit/_cuda_types.py
@@ -122,21 +122,19 @@ uint32 = Scalar(numpy.uint32)
 
 
 _suffix_literals_dict = {
-    numpy.dtype('float64'): '',
-    numpy.dtype('float32'): 'f',
-    numpy.dtype('int64'): 'll',
-    numpy.dtype('longlong'): 'll',
-    numpy.dtype('int32'): '',
-    numpy.dtype('uint64'): 'ull',
-    numpy.dtype('ulonglong'): 'ull',
-    numpy.dtype('uint32'): 'u',
-    numpy.dtype('bool'): '',
+    'float64': '',
+    'float32': 'f',
+    'int64': 'll',
+    'int32': '',
+    'uint64': 'ull',
+    'uint32': 'u',
+    'bool': '',
 }
 
 
 def get_cuda_code_from_constant(x, ctype):
     dtype = ctype.dtype
-    suffix_literal = _suffix_literals_dict.get(dtype)
+    suffix_literal = _suffix_literals_dict.get(dtype.name)
     if suffix_literal is not None:
         s = str(x).lower()
         return f'{s}{suffix_literal}'

--- a/tests/cupy_tests/functional_tests/test_vectorize.py
+++ b/tests/cupy_tests/functional_tests/test_vectorize.py
@@ -599,7 +599,7 @@ class TestVectorizeBroadcast(unittest.TestCase):
 
 class TestVectorize(unittest.TestCase):
 
-    @testing.for_dtypes('qQefdFD')
+    @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose(rtol=1e-5)
     def test_vectorize_arithmetic_ops(self, xp, dtype):
         def my_func(x1, x2, x3):
@@ -608,7 +608,7 @@ class TestVectorize(unittest.TestCase):
             return x1 + x2 + x3
 
         f = xp.vectorize(my_func)
-        x1 = testing.shaped_random((20, 30), xp, dtype, seed=1)
+        x1 = testing.shaped_random((20, 30), xp, dtype, seed=1, scale=5)
         x2 = testing.shaped_random((20, 30), xp, dtype, seed=2)
         x3 = testing.shaped_random((20, 30), xp, dtype, seed=3)
         return f(x1, x2, x3)


### PR DESCRIPTION
Fix to use `dtype.name` instead `dtype.char` and remove workaround from Windows behavior difference.
https://github.com/cupy/cupy/pull/5387#issuecomment-872319018