### PR TITLE
Fix new DLPack protocol error messages and tests

### DIFF
--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -231,7 +231,7 @@ cdef class ndarray:
             elif not isinstance(stream, int) or stream < -1 or stream == 0:
                 raise ValueError(
                     f'On CUDA, the valid stream for the DLPack protocol is -1,'
-                    ' 1, 2, or any larger value, but {stream} was provided')
+                    f' 1, 2, or any larger value, but {stream} was provided')
             if curr_stream_ptr == 0:
                 curr_stream_ptr = runtime.streamLegacy
         else:  # ROCm/HIP
@@ -241,7 +241,7 @@ cdef class ndarray:
                     or stream in (1, 2)):
                 raise ValueError(
                     f'On ROCm/HIP, the valid stream for the DLPack protocol is'
-                    ' -1, 0, or any value > 2, but {stream} was provided')
+                    f' -1, 0, or any value > 2, but {stream} was provided')
 
         # if -1, no stream order should be established; otherwise, the consumer
         # stream should wait for the work on CuPy's current stream to finish

--- a/tests/cupy_tests/core_tests/test_dlpack.py
+++ b/tests/cupy_tests/core_tests/test_dlpack.py
@@ -48,19 +48,28 @@ class TestNewDLPackConversion(unittest.TestCase):
 
     @testing.for_all_dtypes(no_bool=True)
     def test_conversion(self, dtype):
+        orig_array = _gen_array(dtype)
+        out_array = cupy.from_dlpack(orig_array)
+        testing.assert_array_equal(orig_array, out_array)
+        testing.assert_array_equal(
+            orig_array.data.ptr, out_array.data.ptr)
+
+    def test_stream(self):
         allowed_streams = ['null', True]
         if not cuda.runtime.is_hip:
             allowed_streams.append('ptds')
 
         # stream order is automatically established via DLPack protocol
-        for src in allowed_streams:
-            src_s = self._get_stream(src)
-            for dst in allowed_streams:
-                dst_s = self._get_stream(dst)
+        for src_s in [self._get_stream(s) for s in allowed_streams]:
+            for dst_s in [self._get_stream(s) for s in allowed_streams]:
                 with src_s:
-                    orig_array = _gen_array(dtype)
+                    orig_array = _gen_array(cupy.float32)
+                    # If src_s != dst_s, dst_s waits until src_s complete.
+                    # Null stream (0) must be passed as streamLegacy (1).
+                    dltensor = orig_array.__dlpack__(
+                        1 if dst_s.ptr == 0 else dst_s.ptr)
                 with dst_s:
-                    out_array = cupy.from_dlpack(orig_array)
+                    out_array = cupy.from_dlpack(dltensor)
                     testing.assert_array_equal(orig_array, out_array)
                     testing.assert_array_equal(
                         orig_array.data.ptr, out_array.data.ptr)


### PR DESCRIPTION
Follow-up: #5306

* Formatted string were broken :smile:
* Fix wrong tests. I noticed that stream consistency cannot be tested unless directly calling `__dlpack__` because the current stream in consumer (`cupy.from_dlpack`) and producer (`cupy.ndarray__dlpack__`) are always the same if both ends are CuPy.
  Test failure detected in https://github.com/chainer/chainer-test/pull/673#issuecomment-874877502