### PR TITLE
Support Numba-like `jit.gridsize()` syntax in CuPy JIT

### DIFF
--- a/cupyx/jit/__init__.py
+++ b/cupyx/jit/__init__.py
@@ -20,6 +20,7 @@ from cupyx.jit._builtin_funcs import atomic_and  # NOQA
 from cupyx.jit._builtin_funcs import atomic_or  # NOQA
 from cupyx.jit._builtin_funcs import atomic_xor  # NOQA
 from cupyx.jit._builtin_funcs import grid  # NOQA
+from cupyx.jit._builtin_funcs import gridsize  # NOQA
 from cupyx.jit._builtin_funcs import shfl_sync  # NOQA
 from cupyx.jit._builtin_funcs import shfl_up_sync  # NOQA
 from cupyx.jit._builtin_funcs import shfl_down_sync  # NOQA

--- a/cupyx/jit/_builtin_funcs.py
+++ b/cupyx/jit/_builtin_funcs.py
@@ -238,14 +238,27 @@ class AtomicOp(BuiltinFunc):
         return Data(code, ctype)
 
 
-class Grid(BuiltinFunc):
+class GridFunc(BuiltinFunc):
 
-    def __call__(self, ndim):
-        """Compute the thread index in the grid.
+    def __init__(self, mode):
+        if mode == 'grid':
+            self._desc = 'Compute the thread index in the grid.'
+            self._eq = 'jit.threadIdx.x + jit.blockIdx.x * jit.blockDim.x'
+            self._link = 'numba.cuda.grid'
+            self._code = 'threadIdx.{n} + blockIdx.{n} * blockDim.{n}'
+        elif mode == 'gridsize':
+            self._desc = 'Compute the grid size.'
+            self._eq = 'jit.blockDim.x * jit.gridDim.x'
+            self._link = 'numba.cuda.gridsize'
+            self._code = 'blockDim.{n} * gridDim.{n}'
+        else:
+            raise ValueError('unsupported function')
+
+        doc = f"""        {self._desc}
 
         Computation of the first integer is as follows::
 
-            jit.threadIdx.x + jit.blockIdx.x * jit.blockDim.x
+            {self._eq}
 
         and for the other two integers the ``y`` and ``z`` attributes are used.
 
@@ -257,12 +270,15 @@ class Grid(BuiltinFunc):
                 If ``ndim`` is 1, an integer is returned, otherwise a tuple.
 
         .. note::
-            This function follows the convention of Numba's `numba.cuda.grid`_.
+            This function follows the convention of Numba's `{self._link}`_.
 
-        .. _numba.cuda.grid:
-            https://numba.readthedocs.io/en/stable/cuda/kernels.html#absolute-positions
+        .. _{self._link}:
+            https://numba.readthedocs.io/en/stable/cuda-reference/kernel.html#{self._link}
 
         """
+        self.__doc__ = doc
+
+    def __call__(self, ndim):
         super().__call__()
 
     def call_const(self, env, ndim):
@@ -271,9 +287,8 @@ class Grid(BuiltinFunc):
 
         # Numba convention: for 1D we return a single variable,
         # otherwise a tuple
-        code = 'threadIdx.{n} + blockIdx.{n} * blockDim.{n}'
         if ndim == 1:
-            return Data(code.format(n='x'), _cuda_types.uint32)
+            return Data(self._code.format(n='x'), _cuda_types.uint32)
         elif ndim == 2:
             dims = ('x', 'y')
         elif ndim == 3:
@@ -281,7 +296,7 @@ class Grid(BuiltinFunc):
         else:
             raise ValueError('Only ndim=1,2,3 are supported')
 
-        elts_code = ', '.join(code.format(n=n) for n in dims)
+        elts_code = ', '.join(self._code.format(n=n) for n in dims)
         ctype = _cuda_types.Tuple([_cuda_types.uint32]*ndim)
         return Data(f'thrust::make_tuple({elts_code})', ctype)
 
@@ -354,7 +369,8 @@ builtin_functions_dict = {
 syncthreads = SyncThreads()
 syncwarp = SyncWarp()
 shared_memory = SharedMemory()
-grid = Grid()
+grid = GridFunc('grid')
+gridsize = GridFunc('gridsize')
 
 # atomic functions
 atomic_add = AtomicOp(

--- a/docs/source/reference/kernel.rst
+++ b/docs/source/reference/kernel.rst
@@ -23,6 +23,7 @@ JIT kernel definition
    cupyx.jit.blockIdx
    cupyx.jit.gridDim
    cupyx.jit.grid
+   cupyx.jit.gridsize
    cupyx.jit.syncthreads
    cupyx.jit.syncwarp
    cupyx.jit.shfl_sync

--- a/tests/cupyx_tests/jit_tests/test_raw.py
+++ b/tests/cupyx_tests/jit_tests/test_raw.py
@@ -80,6 +80,54 @@ class TestRaw(unittest.TestCase):
             with pytest.raises(err):
                 f((1,), (1,), ())
 
+    def test_raw_gridsize_1D(self):
+        @jit.rawkernel()
+        def f(arr):
+            x = jit.grid(1)
+            gx = jit.gridsize(1)
+            if x == 0:
+                arr[x] = gx
+
+        x = cupy.zeros(1)
+        grid = 8
+        block = 10
+        f((grid,), (block,), (x,))
+        assert x == grid * block
+
+    def test_raw_gridsize_2D(self):
+        @jit.rawkernel()
+        def f(arr):
+            x, y = jit.grid(2)
+            gx, gy = jit.gridsize(2)
+            if x == 0 and y == 0:
+                arr[0] = gx
+                arr[1] = gy
+
+        x = cupy.zeros(2)
+        grid = (2, 7)
+        block = (3, 5)
+        f(grid, block, (x,))
+        assert x[0] == grid[0] * block[0]
+        assert x[1] == grid[1] * block[1]
+
+    def test_raw_gridsize_3D(self):
+        @jit.rawkernel()
+        def f(arr):
+            x, y, z = jit.grid(3)
+            gx, gy, gz = jit.gridsize(3)
+            if x == 0 and y == 0 and z == 0:
+                arr[0] = gx
+                arr[1] = gy
+                arr[2] = gz
+
+        x = cupy.zeros(3)
+        grid = (2, 7, 4)
+        block = (3, 5, 11)
+        f(grid, block, (x,))
+        assert x[0] == grid[0] * block[0]
+        assert x[1] == grid[1] * block[1]
+        assert x[2] == grid[2] * block[2]
+
     def test_raw_one_thread(self):
         @jit.rawkernel()
         def f(x, y):


### PR DESCRIPTION
Follow-up of #5334.