### PR TITLE
`texture_memory` option in `affine_transform` not supported by HIP

### DIFF
--- a/cupyx/scipy/ndimage/interpolation.py
+++ b/cupyx/scipy/ndimage/interpolation.py
@@ -5,6 +5,7 @@ import cupy
 import numpy
 
 from cupy._core import internal
+from cupy.cuda import runtime
 from cupyx import _texture
 from cupyx.scipy.ndimage import _util
 from cupyx.scipy.ndimage import _interp_kernels
@@ -362,6 +363,7 @@ def affine_transform(input, matrix, offset=0.0, output_shape=None, output=None,
             - ``mode='constant'`` and ``mode='nearest'``
             - ``order=0`` (nearest neighbor) and ``order=1`` (linear
                 interpolation)
+            - NVIDIA CUDA GPUs
 
     Returns:
         cupy.ndarray or None:
@@ -372,6 +374,9 @@ def affine_transform(input, matrix, offset=0.0, output_shape=None, output=None,
     """
 
     if texture_memory:
+        if runtime.is_hip:
+            raise RuntimeError(
+                'HIP currently does not support texture acceleration')
         tm_interp = 'linear' if order > 0 else 'nearest'
         return _texture.affine_transformation(data=input,
                                               transformation_matrix=matrix,

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
@@ -312,6 +312,7 @@ class TestAffineExceptions:
                 texture_memory=True)
 
 
+@pytest.mark.skipif(runtime.is_hip, reason='texture memory not supported yet')
 @testing.parameterize(*testing.product({
     'output': [None, numpy.float32, 'empty'],
     'output_shape': [None, 10],
@@ -327,6 +328,7 @@ class TestAffineTransformTextureMemory:
     _multiprocess_can_split = True
 
     def _2d_rotation_matrix(self, theta, rotation_center):
+        import scipy.special
         c, s = scipy.special.cosdg(theta), scipy.special.sindg(theta)
         m = numpy.array([
             [1, 0, rotation_center[0]],

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
@@ -273,6 +273,9 @@ class TestAffineExceptions:
                 ndi.affine_transform(x, xp.ones((0, 3)), output=output)
 
     def test_invalid_texture_arguments(self):
+        if runtime.is_hip:
+            pytest.skip('texture memory not supported yet')
+
         aft = cupyx.scipy.ndimage.affine_transform
         x = [cupy.ones((8, ) * n, dtype=cupy.float32) for n in range(1, 5)]
 


### PR DESCRIPTION
Follow-up of #5171. 

This PR fixes the CI errors since #5171 was merged (starting at commit https://github.com/kmaehashi/cupy-rocm-ci-report/commit/af1c43d68c774fd2d80f9454f93839773c816aa5) by skipping the texture tests, as we currently do not support texture memory on ROCm/HIP (https://github.com/cupy/cupy/issues/4132#issuecomment-764890763).