### PR TITLE
[backport] Update install guide with new NumPy/SciPy versions

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -25,9 +25,9 @@ Python Dependencies
 
 NumPy/SciPy-compatible API in CuPy v9 is based on NumPy 1.20 and SciPy 1.6, and has been tested against the following versions:
 
-* `NumPy <https://numpy.org/>`_: v1.17 / v1.18 / v1.19 / v1.20
+* `NumPy <https://numpy.org/>`_: v1.17 / v1.18 / v1.19 / v1.20 / v1.21
 
-* `SciPy <https://scipy.org/>`_ (*optional*): v1.4 / v1.5 / v1.6
+* `SciPy <https://scipy.org/>`_ (*optional*): v1.4 / v1.5 / v1.6 / v1.7
 
     * Required only when using :doc:`../reference/scipy` (``cupyx.scipy``).
 


### PR DESCRIPTION
Backport of #5454 