### PR TITLE
Add `cudaDeviceDisablePeerAccess` wrapper

### DIFF
--- a/cupy_backends/cuda/api/runtime.pyx
+++ b/cupy_backends/cuda/api/runtime.pyx
@@ -97,6 +97,7 @@ cdef extern from '../../cupy_backend_runtime.h' nogil:
     int cudaDeviceCanAccessPeer(int* canAccessPeer, int device,
                                 int peerDevice)
     int cudaDeviceEnablePeerAccess(int peerDevice, unsigned int flags)
+    int cudaDeviceDisablePeerAccess(int peerDevice)
 
     int cudaDeviceGetLimit(size_t* value, Limit limit)
     int cudaDeviceSetLimit(Limit limit, size_t value)
@@ -500,6 +501,10 @@ cpdef int deviceCanAccessPeer(int device, int peerDevice) except? -1:
 
 cpdef deviceEnablePeerAccess(int peerDevice):
     status = cudaDeviceEnablePeerAccess(peerDevice, 0)
+    check_status(status)
+
+cpdef deviceDisablePeerAccess(int peerDevice):
+    status = cudaDeviceDisablePeerAccess(peerDevice)
     check_status(status)
 
 cpdef size_t deviceGetLimit(int limit) except? -1:

--- a/cupy_backends/hip/cupy_hip_runtime.h
+++ b/cupy_backends/hip/cupy_hip_runtime.h
@@ -71,6 +71,10 @@ cudaError_t cudaDeviceEnablePeerAccess(int peerDeviceId, unsigned int flags) {
     return hipDeviceEnablePeerAccess(peerDeviceId, flags);
 }
 
+cudaError_t cudaDeviceDisablePeerAccess(int peerDeviceId) {
+    return hipDeviceDisablePeerAccess(peerDeviceId);
+}
+
 cudaError_t cudaDeviceGetLimit(size_t* pValue, cudaLimit limit) {
     return hipDeviceGetLimit(pValue, limit);
 }

--- a/cupy_backends/stub/cupy_cuda_runtime.h
+++ b/cupy_backends/stub/cupy_cuda_runtime.h
@@ -75,6 +75,10 @@ cudaError_t cudaDeviceEnablePeerAccess(...) {
     return cudaSuccess;
 }
 
+cudaError_t cudaDeviceDisablePeerAccess(...) {
+    return cudaSuccess;
+}
+
 cudaError_t cudaDeviceGetLimit(...) {
     return cudaSuccess;
 }


### PR DESCRIPTION
I'm experimenting with peer access. It's handy if this is available in CuPy.