### PR TITLE
Fix "Revert test decorators order"

### DIFF
--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
@@ -255,9 +255,9 @@ class TestOrderFilter(unittest.TestCase):
 @testing.gpu
 @testing.with_requires('scipy>=1.7.0')
 class TestMedFilt(unittest.TestCase):
+    @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(atol=1e-8, rtol=1e-8, scipy_name='scp',
                                  accept_error=ValueError)  # for even kernels
-    @testing.for_all_dtypes()
     def test_medfilt(self, xp, scp, dtype):
         if sys.platform == 'win32':
             pytest.xfail('medfilt broken for Scipy 1.7.0 in windows')
@@ -275,9 +275,9 @@ class TestMedFilt(unittest.TestCase):
 @testing.gpu
 @testing.with_requires('scipy>=1.7.0')
 class TestMedFilt2d(unittest.TestCase):
+    @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(atol=1e-8, rtol=1e-8, scipy_name='scp',
                                  accept_error=ValueError)  # for even kernels
-    @testing.for_all_dtypes()
     def test_medfilt2d(self, xp, scp, dtype):
         if sys.platform == 'win32':
             pytest.xfail('medfilt2d broken for Scipy 1.7.0 in windows')


### PR DESCRIPTION
This reverts commit dad44ee7b7bbd410882ea0a9e6c48d5e6e6f6c99 in #5386.
The commit applied a part of
a012034c6c04331e1f7f3533cd3964d0ea05a25a in #5368
instead of reverting the part.