### PR TITLE
Fix FlexCI Linux tests

### DIFF
--- a/.pfnci/linux/main-flexci.sh
+++ b/.pfnci/linux/main-flexci.sh
@@ -5,7 +5,6 @@
 set -ue
 
 TARGET="${1}"
-export CACHE_DIR=/tmp/cupy_cache
 
 echo "Environment Variables:"
 env
@@ -16,8 +15,15 @@ if [[ "${FLEXCI_BRANCH:-}" != refs/pull/* ]]; then
     stages+=(cache_put)
 fi
 
+pull_req=""
+if [[ "${FLEXCI_BRANCH:-}" == refs/pull/* ]]; then
+    # Extract pull-request ID
+    pull_req="$(echo "${FLEXCI_BRANCH}" | cut -d/ -f3)"
+    echo "Testing Pull-Request: #${pull_req}"
+fi
+
 echo "Starting: "${TARGET}" "${stages[@]}""
-"$(dirname ${0})/run.sh" "${TARGET}" "${stages[@]}" > /tmp/log.txt 2>&1 && echo Test succeeded!
+CACHE_DIR=/tmp/cupy_cache PULL_REQUEST="${pull_req}" "$(dirname ${0})/run.sh" "${TARGET}" "${stages[@]}" > /tmp/log.txt 2>&1 && echo Test succeeded!
 test_retval=$?
 echo "Exit with status ${test_retval}"
 

--- a/.pfnci/linux/run.sh
+++ b/.pfnci/linux/run.sh
@@ -16,6 +16,8 @@ Arguments:
 
 Environment variables:
 
+- PULL_REQUEST: ID of the pull-request to test; should be empty when testing
+                a branch.
 - GPU: Number of GPUs available for testing.
 - CACHE_DIR: Path to the local directory to store cache files.
 - CACHE_GCS_DIR: Path to the GCS directory to store a cache archive.
@@ -50,6 +52,7 @@ main() {
     =====================================================================
     Target              : ${TARGET}
     Stages              : ${STAGES}
+    Pull-Request        : ${PULL_REQUEST:-no}
     GPUs                : ${GPU:-(not set)}
     Repository Root     : ${repo_root}
     Base Branch         : ${base_branch}
@@ -107,12 +110,16 @@ main() {
         --name "${container_name}"
         --volume="${repo_root}:/src:ro"
         --workdir "/src"
+        --env "BASE_BRANCH=${base_branch}"
       )
       if [[ -t 1 ]]; then
         docker_args+=(--interactive)
       fi
       if [[ "${CACHE_DIR:-}" != "" ]]; then
         docker_args+=(--volume="${CACHE_DIR}:${CACHE_DIR}" --env "CACHE_DIR=${CACHE_DIR}")
+      fi
+      if [[ "${PULL_REQUEST:-}" != "" ]]; then
+        docker_args+=(--env "PULL_REQUEST=${PULL_REQUEST}")
       fi
       if [[ "${GPU:-}" != "" ]]; then
         docker_args+=(--env "GPU=${GPU}")

--- a/.pfnci/linux/run.sh
+++ b/.pfnci/linux/run.sh
@@ -95,7 +95,7 @@ main() {
         exit 1
       fi
       tar -c -f "${cache_archive}" -C "${CACHE_DIR}" .
-      gsutil -m -q cp "${cache_archive}" "${cache_gcs_dir}"
+      gsutil -m -q cp "${cache_archive}" "${cache_gcs_dir}/"
       rm -f "${cache_archive}"
       ;;
 

--- a/.pfnci/linux/tests/_environment.sh
+++ b/.pfnci/linux/tests/_environment.sh
@@ -5,8 +5,15 @@ export CUDA_CACHE_PATH="${CACHE_DIR}/.nv"
 export CUPY_CACHE_DIR="${CACHE_DIR}/.cupy/kernel_cache"
 
 export CUPY_TEST_GPU_LIMIT="${GPU:--1}"
-export CUPY_TEST_FULL_COMBINATION="0"
 export CUPY_DUMP_CUDA_SOURCE_ON_ERROR="1"
+
+if [[ "${PULL_REQUEST:-}" == "" ]]; then
+    # When testing branches, test full matrix to generate caches for all combinations.
+    export CUPY_TEST_FULL_COMBINATION="1"
+else
+    # When testing pull-requests, make test combinations sparse.
+    export CUPY_TEST_FULL_COMBINATION="0"
+fi
 
 # For compatibility with Jenkins with docker wrapper
 if [[ "${UID}" != "0" && "${HOME:-/}" == "/" ]]; then


### PR DESCRIPTION
* Linux tests were not caching ccache/kernel binaries correctly.
* Fixes the branch tests to test full matrix, like as done in FlexCI Windows tests.