### PR TITLE
Fix mergify condition

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -12,7 +12,7 @@ pull_request_rules:
   - name: Notify conflict
     conditions:
       - conflict
-      - closed=false
+      - -closed
     actions:
       comment:
         message: This pull request is now in conflicts. Could you fix it @{{author}}? 🙏


### PR DESCRIPTION
With the change of #5439, mergify complains its configuration is invalid:

> Invalid condition 'closed=false'. Expected end of text, found '=' (at char 6), (line:1, col:7) @ pull_request_rules → item 1 → conditions → item 1

~~I can read that we have to use '-' prefix instead of '=' operator for negating a boolean condition:~~ 🤔 
https://docs.mergify.io/conditions/#grammar
