### PR TITLE
Add auto notify bot for `hip` label

### DIFF
--- a/.github/workflows/auto-cc.yml
+++ b/.github/workflows/auto-cc.yml
@@ -1,0 +1,32 @@
+name: "Auto Notify"
+
+on:
+  issues:
+    types: [labeled]
+  pull_request:
+    types: [labeled]
+
+jobs:
+  auto-notify:
+    if: |
+        github.repository_owner == 'cupy' &&
+        github.event.label.name == 'hip'
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Find comment
+        uses: peter-evans/find-comment@v1
+        id: fc
+        with:
+            issue-number: ${{github.event.number}}
+            body-includes: "<!-- Added by CuPy Auto Notify Bot -->"
+
+      - name: Create comment
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+            issue-number: ${{github.event.number}}
+            comment-id: ${{steps.fc.outputs.comment-id}}
+            edit-mode: replace
+            body: |
+                <!-- Added by CuPy Auto Notify Bot -->
+                cc/ @amathews-amd


### PR DESCRIPTION
Automatically leave `cc/ someone` comment when specific label is set.
If we later need to support multiple labels, we can use `fromJSON` to define label-to-users mappings in JSON.

`peter-evans/*` is a third-party action, but I think it's quite stable as it's documented on GitHub's official website.
https://docs.github.com/en/actions/guides/commenting-on-an-issue-when-a-label-is-added
