### PR TITLE
Fix casts from bool in ufunc inputs

### DIFF
--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -881,13 +881,17 @@ cdef function.Function _get_ufunc_kernel(
 
     types = []
     op = []
+    bool_ = numpy.bool_
     for i, x in enumerate(in_types):
         types.append(('in%d_type' % i, x))
         arginfo = arginfos[i]
         if arginfo.is_ndarray():
             op.append(
-                'const in{0}_type in{0}(_raw_in{0}[_ind.get()]);'
-                .format(i))
+                'const in{0}_type in{0}(_raw_in{0}[_ind.get()]{1});'
+                .format(
+                    i,
+                    ' ? 1 : 0' if arginfo.dtype == bool_ and x != bool_ else ''
+                ))
 
     for i, x in enumerate(out_types):
         arginfo = arginfos[i + len(in_types)]

--- a/tests/cupy_tests/core_tests/test_ndarray_elementwise_op.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_elementwise_op.py
@@ -469,7 +469,6 @@ class TestArrayElementwiseOp(unittest.TestCase):
     @testing.for_all_dtypes(name='x_type', no_float16=True)
     @testing.numpy_cupy_allclose()
     def check_array_boolarray_op(self, op, xp, x_type):
-        x_dtype = numpy.dtype(x_type)
         a = xp.array([[2, 7, 1], [8, 2, 8]], x_type)
         # Cast from np.bool8 array should not read bytes
         b = xp.array([[3, 1, 4], [-1, -5, -9]], numpy.int8).view(bool)

--- a/tests/cupy_tests/core_tests/test_ndarray_elementwise_op.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_elementwise_op.py
@@ -465,6 +465,22 @@ class TestArrayElementwiseOp(unittest.TestCase):
     def test_typecast_float2(self):
         self.check_typecast(100000.0)
 
+    # Skip float16 because of NumPy #19514
+    @testing.for_all_dtypes(name='x_type', no_float16=True)
+    @testing.numpy_cupy_allclose()
+    def check_array_boolarray_op(self, op, xp, x_type):
+        x_dtype = numpy.dtype(x_type)
+        a = xp.array([[2, 7, 1], [8, 2, 8]], x_type)
+        # Cast from np.bool8 array should not read bytes
+        b = xp.array([[3, 1, 4], [-1, -5, -9]], numpy.int8).view(bool)
+        return op(a, b)
+
+    def test_add_array_boolarray(self):
+        self.check_array_boolarray_op(operator.add)
+
+    def test_iadd_array_boolarray(self):
+        self.check_array_boolarray_op(operator.iadd)
+
 
 @testing.gpu
 class TestArrayIntElementwiseOp(unittest.TestCase):


### PR DESCRIPTION
Addresses https://github.com/cupy/cupy/pull/5410#issuecomment-871166101.

For example, `xp.arange(3, dtype=xp.int8).view(bool) + 4.5` matches `'dd->d'` in `xp.add.types` and generates
```diff
     typedef double in0_type;
 typedef double in1_type;
 typedef double out0_type;
 
 
     extern "C" __global__ void cupy_add__bool_float_float64(const CArray<bool, 1, 1, 1> _raw_in0, const double in1, CArray<double, 1, 1, 1> _raw_out0, CIndexer<1> _ind) {
       ;
       CUPY_FOR(i, _ind.size()) {
         _ind.set(i);
-        const in0_type in0(_raw_in0[_ind.get()]);
+        const in0_type in0(_raw_in0[_ind.get()] ? 1 : 0);
 out0_type &out0 = _raw_out0[_ind.get()];
 out0 = in0 + in1;
       }
       ;
     }
```

, where the cast of `in0` (from `'?'` to `'d'`) is fixed to return 0/1 value.

This PR does not change casts in ufunc outputs.  A workaround for the `astype` method is already added in #5410.  The issue #5527 also involves casts in ufunc outputs.