### PR TITLE
Use `pull_request_target` instead for auto notify bot

### DIFF
--- a/.github/workflows/auto-cc.yml
+++ b/.github/workflows/auto-cc.yml
@@ -3,7 +3,7 @@ name: "Auto Notify"
 on:
   issues:
     types: [labeled]
-  pull_request:
+  pull_request_target:
     types: [labeled]
 
 jobs:


### PR DESCRIPTION
https://github.com/peter-evans/create-or-update-comment

> Note: In public repositories this action does not work in pull_request workflows when triggered by forks. Any attempt will be met with the error, Resource not accessible by integration. This is due to token restrictions put in place by GitHub Actions. Private repositories can be configured to enable workflows from forks to run without restriction. See here for further explanation. Alternatively, use the pull_request_target event to comment on pull requests.

