### PR TITLE
Replaced the links for NumPy docs as per issue #3418

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -88,7 +88,7 @@ from numpy import PZERO  # NOQA
 # Data types (borrowed from NumPy)
 #
 # The order of these declarations are borrowed from the NumPy document:
-# https://docs.scipy.org/doc/numpy/reference/arrays.scalars.html
+# https://numpy.org/doc/stable/reference/arrays.scalars.html
 # =============================================================================
 
 # -----------------------------------------------------------------------------
@@ -217,7 +217,7 @@ from numpy import complex128  # NOQA
 # Routines
 #
 # The order of these declarations are borrowed from the NumPy document:
-# https://docs.scipy.org/doc/numpy/reference/routines.html
+# https://numpy.org/doc/stable/reference/routines.html
 # =============================================================================
 
 # -----------------------------------------------------------------------------

--- a/cupy/_binary/__init__.py
+++ b/cupy/_binary/__init__.py
@@ -1,2 +1,2 @@
 # Functions from the following NumPy document
-# https://docs.scipy.org/doc/numpy/reference/routines.bitwise.html
+# https://numpy.org/doc/stable/reference/routines.bitwise.html

--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -114,7 +114,7 @@ cdef class ndarray:
 
             .. seealso::
                `Data type objects (dtype) \
-               <https://docs.scipy.org/doc/numpy/reference/arrays.dtypes.html>`_
+               <https://numpy.org/doc/stable/reference/arrays.dtypes.html>`_
         ~ndarray.size (int): Number of elements this array holds.
 
             This is equivalent to product over the shape tuple.
@@ -262,7 +262,7 @@ cdef class ndarray:
 
     # The definition order of attributes and methods are borrowed from the
     # order of documentation at the following NumPy document.
-    # https://docs.scipy.org/doc/numpy/reference/arrays.ndarray.html
+    # https://numpy.org/doc/stable/reference/arrays.ndarray.html
 
     # -------------------------------------------------------------------------
     # Memory layout

--- a/cupy/_creation/__init__.py
+++ b/cupy/_creation/__init__.py
@@ -1,2 +1,2 @@
 # Functions from the following NumPy document
-# https://docs.scipy.org/doc/numpy/reference/routines.array-creation.html
+# https://numpy.org/doc/stable/reference/routines.array-creation.html

--- a/cupy/_indexing/__init__.py
+++ b/cupy/_indexing/__init__.py
@@ -1,2 +1,2 @@
 # Functions from the following NumPy document
-# https://docs.scipy.org/doc/numpy/reference/routines.indexing.html
+# https://numpy.org/doc/stable/reference/routines.indexing.html

--- a/cupy/_io/__init__.py
+++ b/cupy/_io/__init__.py
@@ -1,2 +1,2 @@
 # Functions from the following NumPy document
-# https://docs.scipy.org/doc/numpy/reference/routines.io.html
+# https://numpy.org/doc/stable/reference/routines.io.html

--- a/cupy/_logic/__init__.py
+++ b/cupy/_logic/__init__.py
@@ -1,2 +1,2 @@
 # Functions from the following NumPy document
-# https://docs.scipy.org/doc/numpy/reference/routines.logic.html
+# https://numpy.org/doc/stable/reference/routines.logic.html

--- a/cupy/_manipulation/__init__.py
+++ b/cupy/_manipulation/__init__.py
@@ -1,2 +1,2 @@
 # Functions from the following NumPy document
-# https://docs.scipy.org/doc/numpy/reference/routines.array-manipulation.html
+# https://numpy.org/doc/stable/reference/routines.array-manipulation.html

--- a/cupy/_math/__init__.py
+++ b/cupy/_math/__init__.py
@@ -1,2 +1,2 @@
 # Functions from the following NumPy document
-# https://docs.scipy.org/doc/numpy/reference/routines.math.html
+# https://numpy.org/doc/stable/reference/routines.math.html

--- a/cupy/_padding/__init__.py
+++ b/cupy/_padding/__init__.py
@@ -1,2 +1,2 @@
 # Functions from the following NumPy document
-# https://docs.scipy.org/doc/numpy/reference/routines.padding.html
+# https://numpy.org/doc/stable/reference/routines.padding.html

--- a/cupy/_sorting/__init__.py
+++ b/cupy/_sorting/__init__.py
@@ -1,2 +1,2 @@
 # Functions from the following NumPy document
-# https://docs.scipy.org/doc/numpy/reference/routines.sort.html
+# https://numpy.org/doc/stable/reference/routines.sort.html

--- a/cupy/_statistics/__init__.py
+++ b/cupy/_statistics/__init__.py
@@ -1,2 +1,2 @@
 # Functions from the following NumPy document
-# https://docs.scipy.org/doc/numpy/reference/routines.statistics.html
+# https://numpy.org/doc/stable/reference/routines.statistics.html

--- a/cupy/cuda/cupy_thrust.cu
+++ b/cupy/cuda/cupy_thrust.cu
@@ -69,7 +69,7 @@ public:
  *     Complex: [R + Rj, R + nanj, nan + Rj, nan + nanj]
  * where R is a non-nan real value. Complex values with the same nan placements are sorted according to the non-nan part if
  * it exists. Non-nan values are sorted as before."
- * Ref: https://docs.scipy.org/doc/numpy/reference/generated/numpy.sort.html
+ * Ref: https://numpy.org/doc/stable/reference/generated/numpy.sort.html
  */
 
 template <typename T>

--- a/cupy/linalg/__init__.py
+++ b/cupy/linalg/__init__.py
@@ -1,5 +1,5 @@
 # Functions from the following NumPy document
-# https://docs.scipy.org/doc/numpy/reference/routines.linalg.html
+# https://numpy.org/doc/stable/reference/routines.linalg.html
 
 # -----------------------------------------------------------------------------
 # Matrix and vector products

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -12,12 +12,12 @@ interface.
 
 The following is a brief overview of supported subset of NumPy interface:
 
-- `Basic indexing <https://numpy.org/doc/stable/reference/routines.bitwise.html>`_
+- `Basic indexing <https://numpy.org/doc/stable/reference/arrays.indexing.html>`_
   (indexing by ints, slices, newaxes, and Ellipsis)
 - Most of `Advanced indexing <https://docs.scipy.org/doc/numpy/reference/arrays.indexing.html#advanced-indexing>`_
   (except for some indexing patterns with boolean masks)
 - Data types (dtypes): ``bool_``, ``int8``, ``int16``, ``int32``, ``int64``, ``uint8``, ``uint16``, ``uint32``, ``uint64``, ``float16``, ``float32``, ``float64``, ``complex64``, ``complex128``
-- Most of the `array creation routines <https://docs.scipy.org/doc/numpy/reference/routines.array-creation.html>`_ (\ ``empty``, ``ones_like``, ``diag``, etc.)
+- Most of the `array creation routines <https://numpy.org/doc/stable/reference/routines.array-creation.html>`_ (\ ``empty``, ``ones_like``, ``diag``, etc.)
 - Most of the `array manipulation routines <https://docs.scipy.org/doc/numpy/reference/routines.array-manipulation.html>`_ (\ ``reshape``, ``rollaxis``, ``concatenate``, etc.)
 - All operators with `broadcasting <https://docs.scipy.org/doc/numpy/user/basics.broadcasting.html>`_
 - All `universal functions <https://docs.scipy.org/doc/numpy/reference/ufuncs.html>`_

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -14,15 +14,15 @@ The following is a brief overview of supported subset of NumPy interface:
 
 - `Basic indexing <https://numpy.org/doc/stable/reference/arrays.indexing.html>`_
   (indexing by ints, slices, newaxes, and Ellipsis)
-- Most of `Advanced indexing <https://docs.scipy.org/doc/numpy/reference/arrays.indexing.html#advanced-indexing>`_
+- Most of `Advanced indexing <https://numpy.org/doc/stable/reference/arrays.indexing.html#advanced-indexing>`_
   (except for some indexing patterns with boolean masks)
 - Data types (dtypes): ``bool_``, ``int8``, ``int16``, ``int32``, ``int64``, ``uint8``, ``uint16``, ``uint32``, ``uint64``, ``float16``, ``float32``, ``float64``, ``complex64``, ``complex128``
 - Most of the `array creation routines <https://numpy.org/doc/stable/reference/routines.array-creation.html>`_ (\ ``empty``, ``ones_like``, ``diag``, etc.)
-- Most of the `array manipulation routines <https://docs.scipy.org/doc/numpy/reference/routines.array-manipulation.html>`_ (\ ``reshape``, ``rollaxis``, ``concatenate``, etc.)
-- All operators with `broadcasting <https://docs.scipy.org/doc/numpy/user/basics.broadcasting.html>`_
-- All `universal functions <https://docs.scipy.org/doc/numpy/reference/ufuncs.html>`_
+- Most of the `array manipulation routines <https://numpy.org/doc/stable/reference/routines.array-manipulation.html>`_ (\ ``reshape``, ``rollaxis``, ``concatenate``, etc.)
+- All operators with `broadcasting <https://numpy.org/doc/stable/user/basics.broadcasting.html>`_
+- All `universal functions <https://numpy.org/doc/stable/reference/ufuncs.html>`_
   for elementwise operations (except those for complex numbers)
-- `Linear algebra functions <https://docs.scipy.org/doc/numpy/reference/routines.linalg.html>`_, including product (\ ``dot``, ``matmul``, etc.) and decomposition (\ ``cholesky``, ``svd``, etc.), accelerated by `cuBLAS <https://developer.nvidia.com/cublas>`_ and `cuSOLVER <https://developer.nvidia.com/cusolver>`_
+- `Linear algebra functions <https://numpy.org/doc/stable/reference/routines.linalg.html>`_, including product (\ ``dot``, ``matmul``, etc.) and decomposition (\ ``cholesky``, ``svd``, etc.), accelerated by `cuBLAS <https://developer.nvidia.com/cublas>`_ and `cuSOLVER <https://developer.nvidia.com/cusolver>`_
 - Multi-dimensional `fast Fourier transform <https://numpy.org/doc/stable/reference/routines.fft.html>`_ (FFT), accelerated by `cuFFT <https://developer.nvidia.com/cufft>`_
 - Reduction along axes (``sum``, ``max``, ``argmax``, etc.)
 

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -12,7 +12,7 @@ interface.
 
 The following is a brief overview of supported subset of NumPy interface:
 
-- `Basic indexing <https://docs.scipy.org/doc/numpy/reference/arrays.indexing.html>`_
+- `Basic indexing <https://numpy.org/doc/stable/reference/routines.bitwise.html>`_
   (indexing by ints, slices, newaxes, and Ellipsis)
 - Most of `Advanced indexing <https://docs.scipy.org/doc/numpy/reference/arrays.indexing.html#advanced-indexing>`_
   (except for some indexing patterns with boolean masks)

--- a/docs/source/reference/ndarray.rst
+++ b/docs/source/reference/ndarray.rst
@@ -5,7 +5,7 @@ The N-dimensional array (:class:`ndarray <cupy.ndarray>`)
 It provides an intuitive interface for a fixed-size multidimensional array which resides
 in a CUDA device.
 
-For the basic concept of ``ndarray``\s, please refer to the `NumPy documentation <https://docs.scipy.org/doc/numpy/reference/arrays.ndarray.html>`_.
+For the basic concept of ``ndarray``\s, please refer to the `NumPy documentation <https://numpy.org/doc/stable/reference/arrays.ndarray.html>`_.
 
 
 .. TODO(kmaehashi): use currentmodule:: cupy

--- a/docs/source/reference/random.rst
+++ b/docs/source/reference/random.rst
@@ -54,7 +54,7 @@ Legacy Random Generation
 
 .. Hint::
    * `NumPy API Reference: Legacy Random Generation <https://numpy.org/doc/stable/reference/random/legacy.html>`_
-   * `NumPy 1.16 Reference <https://docs.scipy.org/doc/numpy-1.16.1/reference/routines.random.html>`_
+   * `NumPy 1.16 Reference <https://numpy.org/doc/1.16/reference/routines.random.html>`_
 
 .. autosummary::
    :toctree: generated/

--- a/docs/source/reference/sparse.rst
+++ b/docs/source/reference/sparse.rst
@@ -6,7 +6,7 @@ Sparse matrices (:mod:`cupyx.scipy.sparse`)
 .. Hint:: `SciPy API Reference: Sparse matrices (scipy.sparse) <https://docs.scipy.org/doc/scipy/reference/sparse.html>`_
 
 CuPy supports sparse matrices using `cuSPARSE <https://developer.nvidia.com/cusparse>`_.
-These matrices have the same interfaces of `SciPy's sparse matrices <https://docs.scipy.org/doc/scipy/reference/sparse.html>`_.
+These matrices have the same interfaces of `SciPy's sparse matrices <https://numpy.org/doc/stable/reference/routines.bitwise.html>`_.
 
 Conversion to/from SciPy sparse matrices
 ----------------------------------------

--- a/docs/source/reference/sparse.rst
+++ b/docs/source/reference/sparse.rst
@@ -6,7 +6,7 @@ Sparse matrices (:mod:`cupyx.scipy.sparse`)
 .. Hint:: `SciPy API Reference: Sparse matrices (scipy.sparse) <https://docs.scipy.org/doc/scipy/reference/sparse.html>`_
 
 CuPy supports sparse matrices using `cuSPARSE <https://developer.nvidia.com/cusparse>`_.
-These matrices have the same interfaces of `SciPy's sparse matrices <https://numpy.org/doc/stable/reference/routines.bitwise.html>`_.
+These matrices have the same interfaces of `SciPy's sparse matrices <https://docs.scipy.org/doc/scipy/reference/sparse.html>`_.
 
 Conversion to/from SciPy sparse matrices
 ----------------------------------------

--- a/docs/source/user_guide/basic.rst
+++ b/docs/source/user_guide/basic.rst
@@ -51,7 +51,7 @@ Using CuPy, we can perform the same calculations on GPU in a similar way:
 CuPy implements many functions on :class:`cupy.ndarray` objects.
 See the :ref:`reference <cupy_reference>` for the supported subset of NumPy API.
 Knowledge of NumPy will help you utilize most of the CuPy features.
-We, therefore, recommend you familiarize yourself with the `NumPy documentation <https://docs.scipy.org/doc/numpy/index.html>`_.
+We, therefore, recommend you familiarize yourself with the `NumPy documentation <https://numpy.org/doc/stable/index.html>`_.
 
 
 Current Device


### PR DESCRIPTION
Replaced the old Scipy links by the new NumPy doc links, in almost all the files that needed this modification, as per issue #3418 