### PR TITLE
Fix casts in ufunc outputs

### DIFF
--- a/cupy/_core/__init__.py
+++ b/cupy/_core/__init__.py
@@ -48,11 +48,9 @@ from cupy._core._routines_math import angle  # NOQA
 from cupy._core._routines_math import conjugate  # NOQA
 from cupy._core._routines_math import divide  # NOQA
 from cupy._core._routines_math import floor_divide  # NOQA
-from cupy._core._routines_math import imag  # NOQA
 from cupy._core._routines_math import multiply  # NOQA
 from cupy._core._routines_math import negative  # NOQA
 from cupy._core._routines_math import power  # NOQA
-from cupy._core._routines_math import real  # NOQA
 from cupy._core._routines_math import remainder  # NOQA
 from cupy._core._routines_math import sqrt  # NOQA
 from cupy._core._routines_math import subtract  # NOQA

--- a/cupy/_core/__init__.py
+++ b/cupy/_core/__init__.py
@@ -66,7 +66,6 @@ from cupy._core.core import ascontiguousarray  # NOQA
 from cupy._core.core import asfortranarray  # NOQA
 from cupy._core.core import divmod  # NOQA
 from cupy._core.core import elementwise_copy  # NOQA
-from cupy._core.core import elementwise_copy_where  # NOQA
 from cupy._core.core import ndarray  # NOQA
 from cupy._core.dlpack import fromDlpack  # NOQA
 from cupy._core.dlpack import from_dlpack  # NOQA

--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -882,7 +882,10 @@ cdef str fix_cast_expr(src_type, dst_type, str expr):
     if src_kind == 'b':
         return f'({expr}) ? 1 : 0'
     if src_kind == 'c':
-        return f'({expr}).real()'
+        if dst_kind == 'b':
+            return f'({expr}) != {_scalar.get_typename(src_type)}()'
+        else:  # dst_kind in 'iuf' (int, uint, float)
+            return f'({expr}).real()'
     return expr
 
 

--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -874,7 +874,7 @@ cdef class ElementwiseKernel:
         return kern
 
 
-cdef str fix_cast_expr(src_type, dst_type, expr):
+cdef str fix_cast_expr(src_type, dst_type, str expr):
     src_kind = get_dtype(src_type).kind
     dst_kind = get_dtype(dst_type).kind
     if src_kind == dst_kind:

--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -885,6 +885,7 @@ cdef str fix_cast_expr(src_type, dst_type, str expr):
         return f'({expr}).real()'
     return expr
 
+
 cdef function.Function _get_ufunc_kernel(
         tuple in_types, tuple out_types, routine, tuple arginfos,
         bint has_where, params,

--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -1163,7 +1163,10 @@ cdef class ufunc:
         kern.linear_launch(indexer.size, inout_args)
         return ret
 
-    cdef str _get_name_with_type(self, tuple arginfos):
+    cdef str _get_name_with_type(self, tuple arginfos, bint has_where):
+        cdef str name = self.name
+        if has_where:
+            name += '_where'
         cdef _ArgInfo arginfo
         inout_type_words = []
         for arginfo in arginfos:
@@ -1172,7 +1175,7 @@ cdef class ufunc:
                 inout_type_words.append(dtype)
             elif arginfo.is_scalar():
                 inout_type_words.append(dtype.rstrip('0123456789'))
-        return '{}__{}'.format(self.name, '_'.join(inout_type_words))
+        return '{}__{}'.format(name, '_'.join(inout_type_words))
 
     cdef function.Function _get_ufunc_kernel(
             self, int dev_id, _Op op, tuple arginfos, bint has_where):
@@ -1180,7 +1183,7 @@ cdef class ufunc:
         key = (dev_id, op, arginfos, has_where)
         kern = self._kernel_memo.get(key, None)
         if kern is None:
-            name = self._get_name_with_type(arginfos)
+            name = self._get_name_with_type(arginfos, has_where)
             params = self._params_with_where if has_where else self._params
             kern = _get_ufunc_kernel(
                 op.in_types, op.out_types, op.routine, arginfos, has_where,

--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -909,7 +909,8 @@ cdef function.Function _get_ufunc_kernel(
         arginfo = arginfos[i + len(in_types)]
         types.append(('out%d_type' % i, x))
         if arginfo.dtype == x:
-            op.append('out{0}_type &out{0} = _raw_out{0}[_ind.get()];'.format(i))
+            op.append(
+                'out{0}_type &out{0} = _raw_out{0}[_ind.get()];'.format(i))
         else:
             op.append(
                 'out{0}_type out{0}({1});'

--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -916,22 +916,13 @@ cdef function.Function _get_ufunc_kernel(
     for i, x in enumerate(out_types):
         arginfo = arginfos[i + offset_out]
         types.append(('out%d_type' % i, x))
-        if arginfo.dtype == x:
-            op.append(
-                'out{0}_type &out{0} = _raw_out{0}[_ind.get()];'.format(i))
-        else:
-            op.append(
-                'out{0}_type out{0}({1});'
-                .format(
-                    i,
-                    fix_cast_expr(arginfo.dtype, x, f'_raw_out{i}[_ind.get()]')
-                ))
-            out_op.append(
-                '_raw_out{0}[_ind.get()] = {1};'.format(
-                    i,
-                    fix_cast_expr(x, arginfo.dtype, f'out{i}')
-                )
+        op.append('out{0}_type out{0};'.format(i))
+        out_op.append(
+            '_raw_out{0}[_ind.get()] = {1};'.format(
+                i,
+                fix_cast_expr(x, arginfo.dtype, f'out{i}')
             )
+        )
 
     type_map = _TypeMap(tuple(types))
 

--- a/cupy/_core/_routines_math.pxd
+++ b/cupy/_core/_routines_math.pxd
@@ -25,8 +25,6 @@ cdef object _sum_auto_dtype
 cdef object _add
 cdef object _conj
 cdef object _angle
-cdef object _real
-cdef object _imag
 cdef object _negative
 cdef object _multiply
 cdef object _divide

--- a/cupy/_core/_routines_math.pyx
+++ b/cupy/_core/_routines_math.pyx
@@ -50,10 +50,7 @@ cdef ndarray _ndarray_real_getter(ndarray self):
 
 
 cdef ndarray _ndarray_real_setter(ndarray self, value):
-    if self.dtype.kind == 'c':
-        _real_setter(value, self)
-    else:
-        elementwise_copy(value, self)
+    elementwise_copy(value, _ndarray_real_getter(self))
 
 
 cdef ndarray _ndarray_imag_getter(ndarray self):
@@ -79,7 +76,7 @@ cdef ndarray _ndarray_imag_getter(ndarray self):
 
 cdef ndarray _ndarray_imag_setter(ndarray self, value):
     if self.dtype.kind == 'c':
-        _imag_setter(value, self)
+        elementwise_copy(value, _ndarray_imag_getter(self))
     else:
         raise TypeError('cupy.ndarray does not have imaginary part to set')
 
@@ -905,49 +902,6 @@ _angle = create_ufunc(
     ''')
 
 
-_real = create_ufunc(
-    'cupy_real',
-    ('?->?', 'b->b', 'B->B', 'h->h', 'H->H', 'i->i', 'I->I', 'l->l', 'L->L',
-     'q->q', 'Q->Q', 'e->e', 'f->f', 'd->d',
-     ('F->f', 'out0 = in0.real()'),
-     ('D->d', 'out0 = in0.real()')),
-    'out0 = in0',
-    doc='''Returns the real part of the elements of the array.
-
-    .. seealso:: :func:`numpy.real`
-
-    ''')
-
-_real_setter = create_ufunc(
-    'cupy_real_setter',
-    ('f->F', 'd->D'),
-    'out0.real(in0)',
-    doc='''Sets the real part of the elements of the array.
-    ''')
-
-
-_imag = create_ufunc(
-    'cupy_imag',
-    ('?->?', 'b->b', 'B->B', 'h->h', 'H->H', 'i->i', 'I->I', 'l->l', 'L->L',
-     'q->q', 'Q->Q', 'e->e', 'f->f', 'd->d',
-     ('F->f', 'out0 = in0.imag()'),
-     ('D->d', 'out0 = in0.imag()')),
-    'out0 = 0',
-    doc='''Returns the imaginary part of the elements of the array.
-
-    .. seealso:: :func:`numpy.imag`
-
-    ''')
-
-
-_imag_setter = create_ufunc(
-    'cupy_imag_setter',
-    ('f->F', 'd->D'),
-    'out0.imag(in0)',
-    doc='''Sets the imaginary part of the elements of the array.
-    ''')
-
-
 def _negative_boolean_error():
     raise TypeError(
         'The cupy boolean negative, the `-` operator, is not supported, '
@@ -1124,8 +1078,6 @@ _clip = create_ufunc(
 add = _add
 conjugate = _conjugate
 angle = _angle
-real = _real
-imag = _imag
 negative = _negative
 multiply = _multiply
 divide = _divide

--- a/cupy/_core/_ufuncs.py
+++ b/cupy/_core/_ufuncs.py
@@ -1,30 +1,17 @@
 from cupy._core._kernel import create_ufunc
 
 
-_complex_cast_copy = '''
-template<typename T, typename U>
-__device__ void cast_copy(const U& x, T& y) {y = T(x);}
-template<typename T, typename U>
-__device__ void cast_copy(const complex<U>& x, complex<T>& y) {
-    y = complex<T>(x);
-}
-template<typename T, typename U>
-__device__ void cast_copy(const complex<U>& x, T& y) {y = T(x.real());}
-'''
-
-
 elementwise_copy = create_ufunc(
     'cupy_copy',
     ('?->?', 'b->b', 'B->B', 'h->h', 'H->H', 'i->i', 'I->I', 'l->l', 'L->L',
      'q->q', 'Q->Q', 'e->e', 'f->f', 'd->d', 'F->F', 'D->D'),
-    'cast_copy(in0, out0)',
-    preamble=_complex_cast_copy, default_casting='unsafe')
+    'out0 = in0',
+    default_casting='unsafe')
 
 
 elementwise_copy_where = create_ufunc(
     'cupy_copy_where',
     ('??->?', 'b?->b', 'B?->B', 'h?->h', 'H?->H', 'i?->i', 'I?->I', 'l?->l',
      'L?->L', 'q?->q', 'Q?->Q', 'e?->e', 'f?->f', 'd?->d', 'F?->F', 'D?->D'),
-    'if (in1) cast_copy(in0, out0)',
-    preamble=_complex_cast_copy, default_casting='unsafe')
-# complex numbers requires out0 = complex<T>(in0)
+    'if (in1) out0 = in0',
+    default_casting='unsafe')

--- a/cupy/_core/_ufuncs.py
+++ b/cupy/_core/_ufuncs.py
@@ -7,11 +7,3 @@ elementwise_copy = create_ufunc(
      'q->q', 'Q->Q', 'e->e', 'f->f', 'd->d', 'F->F', 'D->D'),
     'out0 = in0',
     default_casting='unsafe')
-
-
-elementwise_copy_where = create_ufunc(
-    'cupy_copy_where',
-    ('??->?', 'b?->b', 'B?->B', 'h?->h', 'H?->H', 'i?->i', 'I?->I', 'l?->l',
-     'L?->L', 'q?->q', 'Q?->Q', 'e?->e', 'f?->f', 'd?->d', 'F?->F', 'D?->D'),
-    'if (in1) out0 = in0',
-    default_casting='unsafe')

--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -493,16 +493,15 @@ cdef class ndarray:
         else:
             newarray = ndarray(self.shape, dtype=dtype, order=chr(order_char))
 
-        if self.size == 0:
-            # skip copy
-            pass
-        elif self.dtype.kind == 'c' and newarray.dtype.kind == 'b':
-            cupy.not_equal(self, 0j, out=newarray)
-        elif self.dtype.kind == 'c' and newarray.dtype.kind != 'c':
+        # TODO(kataoka): move warning to ufunc
+        if self.dtype.kind == 'c' and newarray.dtype.kind not in 'bc':
             warnings.warn(
                 'Casting complex values to real discards the imaginary part',
                 numpy.ComplexWarning)
-            elementwise_copy(self.real, newarray)
+
+        if self.size == 0:
+            # skip copy
+            pass
         else:
             elementwise_copy(self, newarray)
         return newarray

--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -493,15 +493,13 @@ cdef class ndarray:
         else:
             newarray = ndarray(self.shape, dtype=dtype, order=chr(order_char))
 
-        # TODO(kataoka): move warning to ufunc
-        if self.dtype.kind == 'c' and newarray.dtype.kind not in 'bc':
-            warnings.warn(
-                'Casting complex values to real discards the imaginary part',
-                numpy.ComplexWarning)
-
         if self.size == 0:
             # skip copy
-            pass
+            if self.dtype.kind == 'c' and newarray.dtype.kind not in 'bc':
+                warnings.warn(
+                    'Casting complex values to real discards the imaginary '
+                    'part',
+                    numpy.ComplexWarning)
         else:
             elementwise_copy(self, newarray)
         return newarray

--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -504,14 +504,6 @@ cdef class ndarray:
                 'Casting complex values to real discards the imaginary part',
                 numpy.ComplexWarning)
             elementwise_copy(self.real, newarray)
-        elif self.dtype.kind == 'b':
-            # See #4354. The result of `astype` from a ndarray whose dtype is
-            # boolean to another dtype is expected to be zero or one. However,
-            # its underlying representation is not necessarily zero or one
-            # (i.g. a view). In such a case,`elementwise_copy` copies the data
-            # as it is, resulting in an undesirable output. To keep it off, we
-            # give a special path for a boolean ndarray.
-            cupy.not_equal(self, 0, out=newarray)
         else:
             elementwise_copy(self, newarray)
         return newarray

--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -14,7 +14,6 @@ from cupy._core._kernel import create_ufunc
 from cupy._core._kernel import ElementwiseKernel
 from cupy._core._kernel import ufunc  # NOQA
 from cupy._core._ufuncs import elementwise_copy
-from cupy._core._ufuncs import elementwise_copy_where
 from cupy._core import flags
 from cupy._core import syncdetect
 from cupy import cuda

--- a/cupy/_manipulation/basic.py
+++ b/cupy/_manipulation/basic.py
@@ -63,7 +63,7 @@ def copyto(dst, src, casting='same_kind', where=None):
                     src = src.copy()
                 _core.elementwise_copy(src, dst)
     else:
-        _core.elementwise_copy_where(src, where, dst)
+        _core.elementwise_copy(src, dst, _where=where)
 
 
 def _can_memcpy(dst, src):

--- a/cupy/_manipulation/basic.py
+++ b/cupy/_manipulation/basic.py
@@ -46,24 +46,26 @@ def copyto(dst, src, casting='same_kind', where=None):
             fusion._call_ufunc(search._where_ufunc, where, src, dst, dst)
         return
 
+    if where is not None:
+        _core.elementwise_copy(src, dst, _where=where)
+        return
+
     if dst.size == 0:
         return
 
-    if src_is_python_scalar and where is None:
+    if src_is_python_scalar:
         dst.fill(src)
         return
 
-    if where is None:
-        if _can_memcpy(dst, src):
-            dst.data.copy_from_async(src.data, src.nbytes)
-        else:
-            device = dst.device
-            with device:
-                if src.device != device:
-                    src = src.copy()
-                _core.elementwise_copy(src, dst)
-    else:
-        _core.elementwise_copy(src, dst, _where=where)
+    if _can_memcpy(dst, src):
+        dst.data.copy_from_async(src.data, src.nbytes)
+        return
+
+    device = dst.device
+    with device:
+        if src.device != device:
+            src = src.copy()
+        _core.elementwise_copy(src, dst)
 
 
 def _can_memcpy(dst, src):

--- a/cupy/_math/arithmetic.py
+++ b/cupy/_math/arithmetic.py
@@ -30,6 +30,38 @@ conjugate = _core.conjugate
 angle = _core.angle
 
 
+# cupy.real is not a ufunc because it returns a view.
+# The ufunc implementation is used by fusion.
+_real_ufunc = _core.create_ufunc(
+    'cupy_real',
+    ('?->?', 'b->b', 'B->B', 'h->h', 'H->H', 'i->i', 'I->I', 'l->l', 'L->L',
+     'q->q', 'Q->Q', 'e->e', 'f->f', 'd->d',
+     ('F->f', 'out0 = in0.real()'),
+     ('D->d', 'out0 = in0.real()')),
+    'out0 = in0',
+    doc='''Returns the real part of the elements of the array.
+
+    .. seealso:: :func:`numpy.real`
+
+    ''')
+
+
+# cupy.imag is not a ufunc because it may return a view.
+# The ufunc implementation is used by fusion.
+_imag_ufunc = _core.create_ufunc(
+    'cupy_imag',
+    ('?->?', 'b->b', 'B->B', 'h->h', 'H->H', 'i->i', 'I->I', 'l->l', 'L->L',
+     'q->q', 'Q->Q', 'e->e', 'f->f', 'd->d',
+     ('F->f', 'out0 = in0.imag()'),
+     ('D->d', 'out0 = in0.imag()')),
+    'out0 = 0',
+    doc='''Returns the imaginary part of the elements of the array.
+
+    .. seealso:: :func:`numpy.imag`
+
+    ''')
+
+
 def real(val):
     '''Returns the real part of the elements of the array.
 
@@ -37,7 +69,7 @@ def real(val):
 
     '''
     if fusion._is_fusing():
-        return fusion._call_ufunc(_core.real, val)
+        return fusion._call_ufunc(_real_ufunc, val)
     if not isinstance(val, _core.ndarray):
         val = _core.array(val)
     return val.real
@@ -50,7 +82,7 @@ def imag(val):
 
     '''
     if fusion._is_fusing():
-        return fusion._call_ufunc(_core.imag, val)
+        return fusion._call_ufunc(_imag_ufunc, val)
     if not isinstance(val, _core.ndarray):
         val = _core.array(val)
     return val.imag

--- a/cupy/testing/_helper.py
+++ b/cupy/testing/_helper.py
@@ -213,7 +213,7 @@ def _signed_counterpart(dtype):
     return numpy.dtype(numpy.dtype(dtype).char.lower()).type
 
 
-def _make_positive_mask(self, impl, args, kw, name, sp_name, scipy_name):
+def _make_positive_masks(self, impl, args, kw, name, sp_name, scipy_name):
     # Returns a mask of output arrays that indicates valid elements for
     # comparison. See the comment at the caller.
     ks = [k for k, v in kw.items() if v in _unsigned_dtypes]
@@ -222,7 +222,9 @@ def _make_positive_mask(self, impl, args, kw, name, sp_name, scipy_name):
     result, error = _call_func_cupy(
         self, impl, args, kw, name, sp_name, scipy_name)
     assert error is None
-    return cupy.asnumpy(result) >= 0
+    if not isinstance(result, (tuple, list)):
+        result = result,
+    return [cupy.asnumpy(r) >= 0 for r in result]
 
 
 def _contains_signed_and_unsigned(kw):
@@ -320,8 +322,21 @@ numpy: {}'''.format(cupy_r.dtype, numpy_r.dtype))
             for cupy_r, numpy_r in cupy_numpy_result_ndarrays:
                 assert cupy_r.shape == numpy_r.shape
 
+            masks = [None] * len(cupy_result)
+            if _contains_signed_and_unsigned(kw):
+                needs_mask = [
+                    cupy_r.dtype in _unsigned_dtypes
+                    for cupy_r in cupy_result]
+                if any(needs_mask):
+                    masks = _make_positive_masks(
+                        self, impl, args, kw, name, sp_name, scipy_name)
+                    for i, flag in enumerate(needs_mask):
+                        if not flag:
+                            masks[i] = None
+
             # Check item values
-            for cupy_r, numpy_r in cupy_numpy_result_ndarrays:
+            for (cupy_r, numpy_r), mask in zip(
+                    cupy_numpy_result_ndarrays, masks):
                 # Behavior of assigning a negative value to an unsigned integer
                 # variable is undefined.
                 # nVidia GPUs and Intel CPUs behave differently.
@@ -329,10 +344,7 @@ numpy: {}'''.format(cupy_r.dtype, numpy_r.dtype))
                 # values are negative.
 
                 skip = False
-                if (_contains_signed_and_unsigned(kw)
-                        and cupy_r.dtype in _unsigned_dtypes):
-                    mask = _make_positive_mask(
-                        self, impl, args, kw, name, sp_name, scipy_name)
+                if mask is not None:
                     if cupy_r.shape == ():
                         skip = (mask == 0).all()
                     else:

--- a/tests/cupy_tests/core_tests/test_ndarray_copy_and_view.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_copy_and_view.py
@@ -163,6 +163,13 @@ class TestArrayCopyAndView:
         a = testing.shaped_arange((2, 3, 4), xp, src_dtype)
         return astype_without_warning(a, dst_dtype, order=order)
 
+    @testing.for_orders(['C', 'F', 'A', 'K', None])
+    @testing.for_all_dtypes_combination(('src_dtype', 'dst_dtype'))
+    @testing.numpy_cupy_array_equal()
+    def test_astype_empty(self, xp, src_dtype, dst_dtype, order):
+        a = testing.shaped_arange((2, 0, 4), xp, src_dtype)
+        return astype_without_warning(a, dst_dtype, order=order)
+
     @testing.for_orders('CFAK')
     @testing.for_all_dtypes_combination(('src_dtype', 'dst_dtype'))
     def test_astype_type(self, src_dtype, dst_dtype, order):

--- a/tests/cupy_tests/manipulation_tests/test_basic.py
+++ b/tests/cupy_tests/manipulation_tests/test_basic.py
@@ -1,7 +1,7 @@
 import itertools
-import unittest
 
 import numpy
+import pytest
 
 import cupy
 from cupy import cuda
@@ -9,7 +9,7 @@ from cupy import testing
 
 
 @testing.gpu
-class TestBasic(unittest.TestCase):
+class TestBasic:
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
@@ -44,6 +44,16 @@ class TestBasic(unittest.TestCase):
         xp.copyto(a, b, where=c)
         return a
 
+    @pytest.mark.parametrize('shape', [(2, 3, 4), (0,)])
+    @testing.for_all_dtypes(no_bool=True)
+    def test_copyto_where_raises(self, dtype, shape):
+        for xp in (numpy, cupy):
+            a = testing.shaped_arange(shape, xp, 'i')
+            b = testing.shaped_reverse_arange(shape, xp, 'i')
+            c = testing.shaped_arange(shape, xp, dtype)
+            with pytest.raises(TypeError):
+                xp.copyto(a, b, where=c)
+
     def _check_copyto_where_multigpu_raises(self, dtype, ngpus):
         def get_numpy():
             a = testing.shaped_arange((2, 3, 4), numpy, dtype)
@@ -65,9 +75,10 @@ class TestBasic(unittest.TestCase):
             with cuda.Device(dev3):
                 c = testing.shaped_arange((2, 3, 4), cupy, '?')
             with cuda.Device(dev4):
-                with self.assertRaisesRegex(
+                with pytest.raises(
                         ValueError,
-                        '^Array device must be same as the current device'):
+                        match='^Array device must be same as the '
+                        'current device'):
                     cupy.copyto(a, b, where=c)
 
     @testing.multi_gpu(2)
@@ -108,7 +119,7 @@ class TestBasic(unittest.TestCase):
         {'src': [float(3.2), int(0), int(4), int(-4), True, False, 1 + 1j],
          'dst_shape': [(), (0,), (1,), (1, 1), (2, 2)]}))
 @testing.gpu
-class TestCopytoFromScalar(unittest.TestCase):
+class TestCopytoFromScalar:
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(accept_error=TypeError)
@@ -124,4 +135,18 @@ class TestCopytoFromScalar(unittest.TestCase):
         mask = (testing.shaped_arange(
             self.dst_shape, xp, dtype) % 2).astype(xp.bool_)
         xp.copyto(dst, self.src, where=mask)
+        return dst
+
+
+class TestCopytoScalarWhere:
+    @pytest.mark.parametrize('shape', [(3, 2), (0,)])
+    @pytest.mark.parametrize('where', [
+        float(3.2), int(0), int(4), int(-4), True, False, 1 + 1j
+    ])
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose()
+    def test_copyto_scalarwhere(self, xp, dtype, where, shape):
+        dst = xp.zeros(shape, dtype=dtype)
+        src = xp.ones(shape, dtype=dtype)
+        xp.copyto(dst, src, where=where)
         return dst

--- a/tests/cupy_tests/math_tests/test_arithmetic.py
+++ b/tests/cupy_tests/math_tests/test_arithmetic.py
@@ -332,7 +332,16 @@ class TestUfunc:
     @testing.for_all_dtypes_combination(
         names=['in0_type', 'in1_type', 'out_type'])
     @testing.numpy_cupy_allclose(accept_error=TypeError)
-    def test_casting(self, xp, in0_type, in1_type, out_type, casting):
+    def test_casting_out(self, xp, in0_type, in1_type, out_type, casting):
+        a = testing.shaped_arange((2, 3), xp, in0_type)
+        b = testing.shaped_arange((2, 3), xp, in1_type)
+        c = xp.zeros((2, 3), out_type)
+        return xp.add(a, b, out=c, casting=casting)
+
+    @testing.for_all_dtypes_combination(
+        names=['in0_type', 'in1_type', 'out_type'])
+    @testing.numpy_cupy_allclose()
+    def test_casting_out_unsafe(self, xp, in0_type, in1_type, out_type):
         a = testing.shaped_arange((2, 3), xp, in0_type)
         b = testing.shaped_arange((2, 3), xp, in1_type)
         c = xp.zeros((2, 3), out_type)
@@ -340,16 +349,29 @@ class TestUfunc:
             warnings.simplefilter('ignore', numpy.ComplexWarning)
             return xp.add(a, b, out=c, casting='unsafe')
 
+    @pytest.mark.parametrize('casting', [
+        'no',
+        'equiv',
+        'safe',
+        'same_kind',
+    ])
     @testing.for_all_dtypes_combination(
-        names=['in0_type', 'in1_type', 'out_type'])
-    @testing.numpy_cupy_allclose()
-    def test_casting_unsafe(self, xp, in0_type, in1_type, out_type):
+        names=['in0_type', 'in1_type', 'dtype'])
+    @testing.numpy_cupy_allclose(accept_error=TypeError)
+    def test_casting_dtype(self, xp, in0_type, in1_type, dtype, casting):
         a = testing.shaped_arange((2, 3), xp, in0_type)
         b = testing.shaped_arange((2, 3), xp, in1_type)
-        c = xp.zeros((2, 3), out_type)
+        return xp.add(a, b, dtype=dtype, casting=casting)
+
+    @testing.for_all_dtypes_combination(
+        names=['in0_type', 'in1_type', 'dtype'])
+    @testing.numpy_cupy_allclose()
+    def test_casting_dtype_unsafe(self, xp, in0_type, in1_type, dtype):
+        a = testing.shaped_arange((2, 3), xp, in0_type)
+        b = testing.shaped_arange((2, 3), xp, in1_type)
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', numpy.ComplexWarning)
-            return xp.add(a, b, out=c, casting='unsafe')
+            return xp.add(a, b, dtype=dtype, casting='unsafe')
 
 
 class TestArithmeticModf:

--- a/tests/cupy_tests/math_tests/test_arithmetic.py
+++ b/tests/cupy_tests/math_tests/test_arithmetic.py
@@ -324,8 +324,8 @@ class TestArithmeticBinary2(ArithmeticBinaryBase):
 class TestUfunc:
 
     @pytest.mark.parametrize('casting', [
-        'no',
-        'equiv',
+        pytest.param('no', marks=pytest.mark.xfail(strict=False)),
+        pytest.param('equiv', marks=pytest.mark.xfail(strict=False)),
         'safe',
         'same_kind',
     ])
@@ -349,6 +349,7 @@ class TestUfunc:
             warnings.simplefilter('ignore', numpy.ComplexWarning)
             return xp.add(a, b, out=c, casting='unsafe')
 
+    @pytest.mark.xfail(strict=False)
     @pytest.mark.parametrize('casting', [
         'no',
         'equiv',

--- a/tests/cupy_tests/math_tests/test_arithmetic.py
+++ b/tests/cupy_tests/math_tests/test_arithmetic.py
@@ -345,9 +345,12 @@ class TestUfunc:
         a = testing.shaped_arange((2, 3), xp, in0_type)
         b = testing.shaped_arange((2, 3), xp, in1_type)
         c = xp.zeros((2, 3), out_type)
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore', numpy.ComplexWarning)
-            return xp.add(a, b, out=c, casting='unsafe')
+        with warnings.catch_warnings(record=True) as ws:
+            warnings.simplefilter('always')
+            ret = xp.add(a, b, out=c, casting='unsafe')
+        ws = [w.category for w in ws]
+        assert all([w == numpy.ComplexWarning for w in ws]), str(ws)
+        return ret, xp.array(len(ws))
 
     @pytest.mark.xfail(strict=False)
     @pytest.mark.parametrize('casting', [
@@ -364,15 +367,19 @@ class TestUfunc:
         b = testing.shaped_arange((2, 3), xp, in1_type)
         return xp.add(a, b, dtype=dtype, casting=casting)
 
+    @pytest.mark.xfail(strict=False)
     @testing.for_all_dtypes_combination(
         names=['in0_type', 'in1_type', 'dtype'])
     @testing.numpy_cupy_allclose()
     def test_casting_dtype_unsafe(self, xp, in0_type, in1_type, dtype):
         a = testing.shaped_arange((2, 3), xp, in0_type)
         b = testing.shaped_arange((2, 3), xp, in1_type)
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore', numpy.ComplexWarning)
-            return xp.add(a, b, dtype=dtype, casting='unsafe')
+        with warnings.catch_warnings(record=True) as ws:
+            warnings.simplefilter('always')
+            ret = xp.add(a, b, dtype=dtype, casting='unsafe')
+        ws = [w.category for w in ws]
+        assert all([w == numpy.ComplexWarning for w in ws]), str(ws)
+        return ret, xp.array(len(ws))
 
 
 class TestArithmeticModf:


### PR DESCRIPTION
This PR fixes #5527 and simplifies `elementwise_copy` (e.g. reverts #5410 except for the test).

See also #5539.