### PR TITLE
consistent kernel names

### DIFF
--- a/cupy/_binary/packing.py
+++ b/cupy/_binary/packing.py
@@ -9,7 +9,7 @@ _packbits_kernel = _core.ElementwiseKernel(
         int bit = k < myarray_size && myarray[k] != 0;
         packed |= bit << (7 - j);
     }''',
-    'packbits_kernel'
+    'cupy_packbits_kernel'
 )
 
 
@@ -45,7 +45,7 @@ def packbits(myarray):
 _unpackbits_kernel = _core.ElementwiseKernel(
     'raw uint8 myarray', 'T unpacked',
     'unpacked = (myarray[i / 8] >> (7 - i % 8)) & 1;',
-    'unpackbits_kernel'
+    'cupy_unpackbits_kernel'
 )
 
 

--- a/cupy/_core/_routines_indexing.pyx
+++ b/cupy/_core/_routines_indexing.pyx
@@ -478,7 +478,7 @@ def _nonzero_kernel_incomplete_scan(block_size, warp_size=32):
         }
     """).substitute(block_size=block_size, warp_size=warp_size)
     return cupy.ElementwiseKernel(in_params, out_params, loop_body,
-                                  'nonzero_kernel_incomplete_scan',
+                                  'cupy_nonzero_kernel_incomplete_scan',
                                   loop_prep=loop_prep)
 
 
@@ -491,7 +491,7 @@ _nonzero_kernel = ElementwiseKernel(
             dst[ind] = _ind.get()[j];
         }
     }''',
-    'nonzero_kernel',
+    'cupy_nonzero_kernel',
     reduce_dims=False)
 
 

--- a/cupy/_core/_routines_linalg.pyx
+++ b/cupy/_core/_routines_linalg.pyx
@@ -654,6 +654,7 @@ cdef Py_ssize_t _get_stride_for_strided_batched_gemm(ndarray a) except? 0:
 cdef _mat_ptrs_kernel = ElementwiseKernel(
     'T base, T stride', 'T out',
     'out = base + _ind.get()[_ind.ndim - 1] * stride', 'mat_ptrs',
+    'cupy_mat_ptrs',
     reduce_dims=False)
 
 

--- a/cupy/_core/_routines_linalg.pyx
+++ b/cupy/_core/_routines_linalg.pyx
@@ -653,8 +653,7 @@ cdef Py_ssize_t _get_stride_for_strided_batched_gemm(ndarray a) except? 0:
 
 cdef _mat_ptrs_kernel = ElementwiseKernel(
     'T base, T stride', 'T out',
-    'out = base + _ind.get()[_ind.ndim - 1] * stride', 'mat_ptrs',
-    'cupy_mat_ptrs',
+    'out = base + _ind.get()[_ind.ndim - 1] * stride', 'cupy_mat_ptrs',
     reduce_dims=False)
 
 

--- a/cupy/_core/_routines_math.pyx
+++ b/cupy/_core/_routines_math.pyx
@@ -520,7 +520,7 @@ def _inclusive_batch_scan_kernel(
     """
     op_char = {scan_op.SCAN_SUM: '+', scan_op.SCAN_PROD: '*'}
     identity = {scan_op.SCAN_SUM: 0, scan_op.SCAN_PROD: 1}
-    name = 'inclusive_batch_scan_kernel'
+    name = 'cupy_inclusive_batch_scan_kernel'
     dtype = get_typename(dtype)
     source = string.Template("""
     extern "C" __global__ void ${name}(
@@ -605,7 +605,7 @@ def _inclusive_batch_scan_kernel(
 
 @_util.memoize(for_each_device=True)
 def _add_scan_batch_blocked_sum_kernel(dtype, op, block_size, c_cont):
-    name = 'add_scan_blocked_sum_kernel'
+    name = 'cupy_add_scan_blocked_sum_kernel'
     dtype = get_typename(dtype)
     ops = {scan_op.SCAN_SUM: '+', scan_op.SCAN_PROD: '*'}
     source = string.Template("""

--- a/cupy/_core/_routines_statistics.pyx
+++ b/cupy/_core/_routines_statistics.pyx
@@ -620,7 +620,7 @@ cdef _mean_core = create_reduction_func(
      'out0 = a / _type_reduce(_in_ind.size() / _out_ind.size())', None))
 
 cdef _mean_core_empty = create_reduction_func(
-    'cupy_mean',
+    'cupy_mean_empty',
     ('?->d', 'B->d', 'h->d', 'H->d', 'i->d', 'I->d', 'l->d', 'L->d',
      'q->d', 'Q->d',
      ('e->e', (None, None, None, 'float')),

--- a/cupy/_core/_routines_statistics.pyx
+++ b/cupy/_core/_routines_statistics.pyx
@@ -588,25 +588,29 @@ __device__ double my_norm(const complex<double>& x) { return norm(x); }
 cdef _var_core_float16 = ReductionKernel(
     'S x, T mean, float32 alpha', 'float16 out',
     'my_norm(x - mean)',
-    'a + b', 'out = alpha * a', '0', '_var_core', preamble=_norm_preamble)
+    'a + b', 'out = alpha * a', '0', 'cupy_var_core_float16',
+    preamble=_norm_preamble)
 
 
 cdef _var_core_float32 = ReductionKernel(
     'S x, T mean, float32 alpha', 'float32 out',
     'my_norm(x - mean)',
-    'a + b', 'out = alpha * a', '0', '_var_core', preamble=_norm_preamble)
+    'a + b', 'out = alpha * a', '0', 'cupy_var_core_float32',
+    preamble=_norm_preamble)
 
 
 cdef _var_core_float64 = ReductionKernel(
     'S x, T mean, float64 alpha', 'float64 out',
     'my_norm(x - mean)',
-    'a + b', 'out = alpha * a', '0', '_var_core', preamble=_norm_preamble)
+    'a + b', 'out = alpha * a', '0', 'cupy_var_core_float64',
+    preamble=_norm_preamble)
 
 
 cdef _var_core_out = ReductionKernel(
     'S x, T mean, U alpha', 'U out',
     'my_norm(x - mean)',
-    'a + b', 'out = alpha * a', '0', '_var_core', preamble=_norm_preamble)
+    'a + b', 'out = alpha * a', '0', 'cupy_var_core_out',
+    preamble=_norm_preamble)
 
 
 # TODO(okuta) needs cast

--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -2094,7 +2094,7 @@ cpdef function.Module compile_with_cache(
 
 cdef str _id = 'out0 = in0'
 
-cdef fill_kernel = ElementwiseKernel('T x', 'T y', 'y = x', 'fill')
+cdef fill_kernel = ElementwiseKernel('T x', 'T y', 'y = x', 'cupy_fill')
 
 cdef str _divmod_float = '''
     out0_type a = _floor_divide(in0, in1);

--- a/cupy/_creation/matrix.py
+++ b/cupy/_creation/matrix.py
@@ -71,7 +71,7 @@ _tri_kernel = _core.ElementwiseKernel(
     int col = i % m;
     out = (col <= row + k);
     ''',
-    'tri',
+    'cupy_tri',
 )
 
 

--- a/cupy/_functional/piecewise.py
+++ b/cupy/_functional/piecewise.py
@@ -6,7 +6,7 @@ _piecewise_krnl = _core.ElementwiseKernel(
     'bool cond, T value',
     'T y',
     'if (cond) y = value',
-    'piecewise_kernel'
+    'cupy_piecewise_kernel'
 )
 
 

--- a/cupy/_functional/vectorize.py
+++ b/cupy/_functional/vectorize.py
@@ -94,8 +94,8 @@ class vectorize(object):
             # we unroll all headers for HIP and so thrust::tuple et al are all
             # defined regardless if CUPY_JIT_MODE is defined or not
             kern = _core.ElementwiseKernel(
-                in_params, out_params, body, preamble=result.code,
-                options=('-DCUPY_JIT_MODE',))
+                in_params, out_params, body, 'cupy_vectorize',
+                preamble=result.code, options=('-DCUPY_JIT_MODE',))
             self._kernel_cache[itypes] = kern
 
         return kern(*args)

--- a/cupy/_indexing/insert.py
+++ b/cupy/_indexing/insert.py
@@ -72,7 +72,7 @@ _putmask_kernel = _core.ElementwiseKernel(
     '''
     if (mask) out = (T) values[i % len_vals];
     ''',
-    'putmask_kernel'
+    'cupy_putmask_kernel'
 )
 
 

--- a/cupy/_manipulation/add_remove.py
+++ b/cupy/_manipulation/add_remove.py
@@ -46,7 +46,7 @@ def append(arr, values, axis=None):
 _resize_kernel = _core.ElementwiseKernel(
     'raw T x, int64 size', 'T y',
     'y = x[i % size]',
-    'resize',
+    'cupy_resize',
 )
 
 

--- a/cupy/_misc/memory_ranges.py
+++ b/cupy/_misc/memory_ranges.py
@@ -14,7 +14,7 @@ def may_share_memory(a, b, max_work=None):
 _get_memory_ptrs_kernel = _kernel.ElementwiseKernel(
     'T x', 'uint64 out',
     'out = (unsigned long long)(&x)',
-    'get_memory_ptrs'
+    'cupy_get_memory_ptrs'
 )
 
 

--- a/cupy/_sorting/search.py
+++ b/cupy/_sorting/search.py
@@ -258,7 +258,7 @@ _hip_preamble = r'''
 
 _searchsorted_kernel = _core.ElementwiseKernel(
     'S x, raw T bins, int64 n_bins, bool side_is_right, '
-    'bool assume_increassing',
+    'bool assume_increasing',
     'int64 y',
     '''
     #ifdef __HIP_DEVICE_COMPILE__
@@ -267,10 +267,10 @@ _searchsorted_kernel = _core.ElementwiseKernel(
 
     // Array is assumed to be monotonically
     // increasing unless a check is requested with the
-    // `assume_increassing = False` parameter.
+    // `assume_increasing = False` parameter.
     // `digitize` allows increasing and decreasing arrays.
     bool inc = true;
-    if (!assume_increassing && n_bins >= 2) {
+    if (!assume_increasing && n_bins >= 2) {
         // In the case all the bins are nan the array is considered
         // to be decreasing in numpy
         inc = (bins[0] <= bins[n_bins-1])
@@ -336,7 +336,7 @@ _searchsorted_kernel = _core.ElementwiseKernel(
         }
     }
     no_thread_divergence( y = right , false )
-    ''', preamble=_preamble+_hip_preamble)
+    ''', name='cupy_searchsorted_kernel', preamble=_preamble+_hip_preamble)
 
 
 def searchsorted(a, v, side='left', sorter=None):

--- a/cupy/_statistics/histogram.py
+++ b/cupy/_statistics/histogram.py
@@ -35,7 +35,8 @@ _histogram_kernel = _core.ElementwiseKernel(
         }
     }
     atomicAdd(&y[low], U(1));
-    ''')
+    ''',
+    'cupy_histogram_kernel')
 
 
 _weighted_histogram_kernel = _core.ElementwiseKernel(
@@ -57,7 +58,8 @@ _weighted_histogram_kernel = _core.ElementwiseKernel(
         }
     }
     atomicAdd(&y[low], (Y)weights[i]);
-    ''')
+    ''',
+    'cupy_weighted_histogram_kernel')
 
 
 def _ravel_and_check_weights(a, weights):
@@ -499,13 +501,13 @@ def histogram2d(x, y, bins=10, range=None, weights=None, density=None):
 _bincount_kernel = _core.ElementwiseKernel(
     'S x', 'raw U bin',
     'atomicAdd(&bin[x], U(1))',
-    'bincount_kernel')
+    'cupy_bincount_kernel')
 
 
 _bincount_with_weight_kernel = _core.ElementwiseKernel(
     'S x, T w', 'raw U bin',
     'atomicAdd(&bin[x], w)',
-    'bincount_with_weight_kernel')
+    'cupy_bincount_with_weight_kernel')
 
 
 def bincount(x, weights=None, minlength=None):

--- a/cupy/_statistics/order.py
+++ b/cupy/_statistics/order.py
@@ -257,7 +257,7 @@ def _quantile_unchecked(a, q, axis=None, out=None, interpolation='linear',
                 ret = a[offset_top] - diff * (1 - weight_above);
             }
             ''',
-            'percentile_weightnening'
+            'cupy_percentile_weightnening'
         )(indices, ap, ap.shape[-1] if ap.ndim > 1 else 0, ap.size, ret)
         ret = cupy.rollaxis(ret, -1)  # Roll q dimension back to first axis
 

--- a/cupy/linalg/_util.py
+++ b/cupy/linalg/_util.py
@@ -129,7 +129,7 @@ def _check_cublas_info_array_if_synchronization_allowed(routine, info_array):
 _tril_kernel = _core.ElementwiseKernel(
     'int64 k', 'S x',
     'x = (_ind.get()[1] - _ind.get()[0] <= k) ? x : 0',
-    'tril_kernel',
+    'cupy_tril_kernel',
     reduce_dims=False
 )
 
@@ -142,7 +142,7 @@ def _tril(x, k=0):
 _triu_kernel = _core.ElementwiseKernel(
     'int64 k', 'S x',
     'x = (_ind.get()[1] - _ind.get()[0] >= k) ? x : 0',
-    'triu_kernel',
+    'cupy_triu_kernel',
     reduce_dims=False
 )
 

--- a/cupy/random/_generator.py
+++ b/cupy/random/_generator.py
@@ -237,7 +237,7 @@ class RandomState(object):
     _laplace_kernel = _core.ElementwiseKernel(
         'T x, T loc, T scale', 'T y',
         'y = loc + scale * ((x <= 0.5) ? log(x + x): -log(x + x - 1.0))',
-        'laplace_kernel')
+        'cupy_laplace_kernel')
 
     def laplace(self, loc=0.0, scale=1.0, size=None, dtype=float):
         """Returns an array of samples drawn from the laplace distribution.
@@ -875,7 +875,7 @@ class RandomState(object):
             x = right - sqrt((1.0 - x) * rightprod);
         }
         """,
-        'triangular_kernel'
+        'cupy_triangular_kernel'
     )
 
     def triangular(self, left, mode, right, size=None, dtype=float):
@@ -951,7 +951,7 @@ class RandomState(object):
                 X = mean*mean/X;
             }
         """,
-        'wald_scale')
+        'cupy_wald_scale')
 
     def wald(self, mean, scale, size=None, dtype=float):
         """Returns an array of samples drawn from the Wald distribution.
@@ -1141,7 +1141,7 @@ class RandomState(object):
     _gumbel_kernel = _core.ElementwiseKernel(
         'T x, T loc, T scale', 'T y',
         'y = T(loc) - log(-log(x)) * T(scale)',
-        'gumbel_kernel')
+        'cupy_gumbel_kernel')
 
     def gumbel(self, loc=0.0, scale=1.0, size=None, dtype=float):
         """Returns an array of samples drawn from a Gumbel distribution.

--- a/cupy/random/_kernels.py
+++ b/cupy/random/_kernels.py
@@ -881,7 +881,7 @@ beta_kernel = _core.ElementwiseKernel(
     rk_seed(seed + i, &internal_state);
     y = rk_beta(&internal_state, a, b);
     ''',
-    'beta_kernel',
+    'cupy_beta_kernel',
     preamble=''.join(definitions),
     loop_prep='rk_state internal_state;'
 )
@@ -894,7 +894,7 @@ binomial_kernel = _core.ElementwiseKernel(
     rk_seed(seed + i, &internal_state);
     y = rk_binomial(&internal_state, n, p);
     ''',
-    'binomial_kernel',
+    'cupy_binomial_kernel',
     preamble=''.join(definitions),
     loop_prep='rk_state internal_state;'
 )
@@ -909,7 +909,7 @@ standard_t_kernel = _core.ElementwiseKernel(
     rk_seed(seed + i, &internal_state);
     y = rk_standard_t(&internal_state, df);
     ''',
-    'standard_t_kernel',
+    'cupy_standard_t_kernel',
     preamble=''.join(definitions),
     loop_prep='rk_state internal_state;'
 )
@@ -924,7 +924,7 @@ chisquare_kernel = _core.ElementwiseKernel(
     rk_seed(seed + i, &internal_state);
     y = rk_chisquare(&internal_state, df);
     ''',
-    'chisquare_kernel',
+    'cupy_chisquare_kernel',
     preamble=''.join(definitions),
     loop_prep='rk_state internal_state;'
 )
@@ -939,7 +939,7 @@ f_kernel = _core.ElementwiseKernel(
     rk_seed(seed + i, &internal_state);
     y = rk_f(&internal_state, dfnum, dfden);
     ''',
-    'f_kernel',
+    'cupy_f_kernel',
     preamble=''.join(definitions),
     loop_prep='rk_state internal_state;'
 )
@@ -952,7 +952,7 @@ geometric_kernel = _core.ElementwiseKernel(
     rk_seed(seed + i, &internal_state);
     y = rk_geometric(&internal_state, p);
     ''',
-    'geometric_kernel',
+    'cupy_geometric_kernel',
     preamble=''.join(definitions),
     loop_prep='rk_state internal_state;'
 )
@@ -966,7 +966,7 @@ hypergeometric_kernel = _core.ElementwiseKernel(
     rk_seed(seed + i, &internal_state);
     y = rk_hypergeometric(&internal_state, good, bad, sample);
     ''',
-    'hypergeometric_kernel',
+    'cupy_hypergeometric_kernel',
     preamble=''.join(definitions),
     loop_prep='rk_state internal_state;'
 )
@@ -979,7 +979,7 @@ logseries_kernel = _core.ElementwiseKernel(
     rk_seed(seed + i, &internal_state);
     y = rk_logseries(&internal_state, p);
     ''',
-    'logseries_kernel',
+    'cupy_logseries_kernel',
     preamble=''.join(definitions),
     loop_prep='rk_state internal_state;'
 )
@@ -996,7 +996,7 @@ noncentral_chisquare_kernel = _core.ElementwiseKernel(
     rk_seed(seed + i, &internal_state);
     y = rk_noncentral_chisquare(&internal_state, df, nonc);
     ''',
-    'noncentral_chisquare_kernel',
+    'cupy_noncentral_chisquare_kernel',
     preamble=''.join(definitions),
     loop_prep='rk_state internal_state;'
 )
@@ -1013,7 +1013,7 @@ noncentral_f_kernel = _core.ElementwiseKernel(
     rk_seed(seed + i, &internal_state);
     y = rk_noncentral_f(&internal_state, dfnum, dfden, nonc);
     ''',
-    'noncentral_f_kernel',
+    'cupy_noncentral_f_kernel',
     preamble=''.join(definitions),
     loop_prep='rk_state internal_state;'
 )
@@ -1028,7 +1028,7 @@ poisson_kernel = _core.ElementwiseKernel(
     rk_seed(seed + i, &internal_state);
     y = rk_poisson(&internal_state, lam);
     ''',
-    'poisson_kernel',
+    'cupy_poisson_kernel',
     preamble=''.join(definitions),
     loop_prep='rk_state internal_state;'
 )
@@ -1042,7 +1042,7 @@ standard_gamma_kernel = _core.ElementwiseKernel(
     rk_seed(seed + i, &internal_state);
     y = rk_standard_gamma(&internal_state, shape);
     ''',
-    'standard_gamma_kernel',
+    'cupy_standard_gamma_kernel',
     preamble=''.join(definitions),
     loop_prep='rk_state internal_state;'
 )
@@ -1055,7 +1055,7 @@ vonmises_kernel = _core.ElementwiseKernel(
     rk_seed(seed + i, &internal_state);
     y = rk_vonmises(&internal_state, mu, kappa);
     ''',
-    'vonmises_kernel',
+    'cupy_vonmises_kernel',
     preamble=''.join(definitions),
     loop_prep='rk_state internal_state;'
 )
@@ -1068,7 +1068,7 @@ zipf_kernel = _core.ElementwiseKernel(
     rk_seed(seed + i, &internal_state);
     y = rk_zipf(&internal_state, a);
     ''',
-    'zipf_kernel',
+    'cupy_zipf_kernel',
     preamble=''.join(definitions),
     loop_prep='rk_state internal_state;'
 )
@@ -1081,7 +1081,7 @@ open_uniform_kernel = _core.ElementwiseKernel(
     rk_seed(seed + i, &internal_state);
     open_uniform(&internal_state, &y);
     ''',
-    'open_uniform_kernel',
+    'cupy_open_uniform_kernel',
     preamble=''.join(definitions),
     loop_prep='rk_state internal_state;'
 )

--- a/cupyx/_texture.py
+++ b/cupyx/_texture.py
@@ -17,7 +17,7 @@ _affine_transform_2d_array_kernel = _core.ElementwiseKernel(
     float y = dot(pixel, make_float3(m[3],  m[4],  m[5])) + .5f;
     transformed_image = tex2D<T>(texObj, y, x);
     ''',
-    'affine_transformation_2d_array',
+    'cupyx_texture_affine_transformation_2d_array',
     preamble='''
     inline __host__ __device__ float dot(float3 a, float3 b)
     {
@@ -41,7 +41,7 @@ _affine_transform_3d_array_kernel = _core.ElementwiseKernel(
     float z = dot(voxel, make_float4(m[8],  m[9],  m[10], m[11])) + .5f;
     transformed_volume = tex3D<T>(texObj, z, y, x);
     ''',
-    'affine_transformation_3d_array',
+    'cupyx_texture_affine_transformation_3d_array',
     preamble='''
     inline __host__ __device__ float dot(float4 a, float4 b)
     {

--- a/cupyx/scipy/linalg/decomp_lu.py
+++ b/cupyx/scipy/linalg/decomp_lu.py
@@ -202,7 +202,7 @@ _kernel_cupy_split_lu = cupy.ElementwiseKernel(
         ptr_U[get_index(row, col, K, N, C_CONTIGUOUS)] = u_val;
     }
     ''',
-    'cupy_split_lu', preamble=_device_get_index
+    'cupyx_scipy_linalg_split_lu', preamble=_device_get_index
 )
 
 
@@ -246,7 +246,7 @@ _kernel_cupy_laswp = cupy.ElementwiseKernel(
         row1 += row_inc;
     }
     ''',
-    'cupy_laswp', preamble=_device_get_index
+    'cupyx_scipy_linalg_laswp', preamble=_device_get_index
 )
 
 

--- a/cupyx/scipy/linalg/special_matrices.py
+++ b/cupyx/scipy/linalg/special_matrices.py
@@ -194,7 +194,7 @@ def hadamard(n, dtype=int):
 _hadamard_kernel = _core.ElementwiseKernel(
     'T in', 'T out',
     'out = (__popc(_ind.get()[0] & _ind.get()[1]) & 1) ? -1 : 1;',
-    'hadamard', reduce_dims=False)
+    'cupyx_scipy_linalg_hadamard', reduce_dims=False)
 
 
 def leslie(f, s):

--- a/cupyx/scipy/ndimage/_filters_core.py
+++ b/cupyx/scipy/ndimage/_filters_core.py
@@ -278,7 +278,7 @@ def _generate_nd_kernel(name, pre, found, post, mode, w_shape, int_type,
                loops='\n'.join(loops), found=found, end_loops='}'*ndim)
 
     mode_str = mode.replace('-', '_')  # avoid potential hyphen in kernel name
-    name = 'cupy_ndimage_{}_{}d_{}_w{}'.format(
+    name = 'cupyx_scipy_ndimage_{}_{}d_{}_w{}'.format(
         name, ndim, mode_str, '_'.join(['{}'.format(x) for x in w_shape]))
     if all_weights_nonzero:
         name += '_all_nonzero'

--- a/cupyx/scipy/ndimage/_interp_kernels.py
+++ b/cupyx/scipy/ndimage/_interp_kernels.py
@@ -480,7 +480,7 @@ def _generate_interp_custom(coord_func, ndim, large_int, yshape, mode, cval,
     operation = '\n'.join(ops)
 
     mode_str = mode.replace('-', '_')  # avoid hyphen in kernel name
-    name = 'interpolate_{}_order{}_{}_{}d_y{}'.format(
+    name = 'cupyx_scipy_ndimage_interpolate_{}_order{}_{}_{}d_y{}'.format(
         name, order, mode_str, ndim, '_'.join([f'{j}' for j in yshape]),
     )
     if uint_t == 'size_t':

--- a/cupyx/scipy/ndimage/_spline_prefilter_core.py
+++ b/cupyx/scipy/ndimage/_spline_prefilter_core.py
@@ -209,7 +209,7 @@ __device__ T* row(
 _batch_spline1d_strided_template = """
 extern "C" __global__
 __launch_bounds__({block_size})
-void cupyx_spline_filter(T* __restrict__ y, const idx_t* __restrict__ info) {{
+void {kernel_name}(T* __restrict__ y, const idx_t* __restrict__ info) {{
     const idx_t n_signals = info[0], n_samples = info[1],
         * __restrict__ shape = info+2;
     idx_t y_elem_stride = 1;
@@ -248,8 +248,10 @@ def get_raw_spline1d_kernel(axis, ndim, mode, order, index_type='int',
     code += _get_spline1d_code(mode, poles, n_boundary)
 
     # generate code handling batch operation of the 1d filter
-    code += _batch_spline1d_strided_template.format(ndim=ndim, axis=axis,
-                                                    block_size=block_size)
+    mode_str = mode.replace('-', '_')  # cannot have '-' in kernel name
     kernel_name = (f'cupyx_scipy_ndimage_spline_filter_{ndim}d_ord{order}_'
-                   f'axis{axis}_{mode}')
+                   f'axis{axis}_{mode_str}')
+    code += _batch_spline1d_strided_template.format(ndim=ndim, axis=axis,
+                                                    block_size=block_size,
+                                                    kernel_name=kernel_name)
     return cupy.RawKernel(code, kernel_name)

--- a/cupyx/scipy/ndimage/_spline_prefilter_core.py
+++ b/cupyx/scipy/ndimage/_spline_prefilter_core.py
@@ -250,4 +250,6 @@ def get_raw_spline1d_kernel(axis, ndim, mode, order, index_type='int',
     # generate code handling batch operation of the 1d filter
     code += _batch_spline1d_strided_template.format(ndim=ndim, axis=axis,
                                                     block_size=block_size)
-    return cupy.RawKernel(code, 'cupyx_spline_filter')
+    kernel_name = (f'cupyx_scipy_ndimage_spline_filter_{ndim}d_ord{order}_'
+                   f'axis{axis}_{mode}')
+    return cupy.RawKernel(code, kernel_name)

--- a/cupyx/scipy/ndimage/measurements.py
+++ b/cupyx/scipy/ndimage/measurements.py
@@ -113,7 +113,7 @@ def _label(x, structure, y):
 def _kernel_init():
     return _core.ElementwiseKernel(
         'X x', 'Y y', 'if (x == 0) { y = -1; } else { y = i; }',
-        'cupyx_nd_label_init')
+        'cupyx_scipy_ndimage_label_init')
 
 
 def _kernel_connect():
@@ -156,7 +156,7 @@ def _kernel_connect():
             }
         }
         ''',
-        'cupyx_nd_label_connect')
+        'cupyx_scipy_ndimage_label_connect')
 
 
 def _kernel_count():
@@ -169,7 +169,7 @@ def _kernel_count():
         if (j != i) y[i] = j;
         else atomicAdd(&count[0], 1);
         ''',
-        'cupyx_nd_label_count')
+        'cupyx_scipy_ndimage_label_count')
 
 
 def _kernel_labels():
@@ -180,7 +180,7 @@ def _kernel_labels():
         int j = atomicAdd(&count[1], 1);
         labels[j] = i;
         ''',
-        'cupyx_nd_label_labels')
+        'cupyx_scipy_ndimage_label_labels')
 
 
 def _kernel_finalize():
@@ -203,7 +203,7 @@ def _kernel_finalize():
         }
         y[i] = j + 1;
         ''',
-        'cupyx_nd_label_finalize')
+        'cupyx_scipy_ndimage_label_finalize')
 
 
 _ndimage_variance_kernel = _core.ElementwiseKernel(
@@ -216,7 +216,8 @@ _ndimage_variance_kernel = _core.ElementwiseKernel(
         break;
       }
     }
-    """)
+    """,
+    'cupyx_scipy_ndimage_variance')
 
 
 _ndimage_sum_kernel = _core.ElementwiseKernel(
@@ -229,7 +230,8 @@ _ndimage_sum_kernel = _core.ElementwiseKernel(
         break;
       }
     }
-    """)
+    """,
+    'cupyx_scipy_ndimage_sum')
 
 
 def _ndimage_sum_kernel_2(input, labels, index, sum_val, batch_size=4):
@@ -253,7 +255,8 @@ _ndimage_mean_kernel = _core.ElementwiseKernel(
         break;
       }
     }
-    """)
+    """,
+    'cupyx_scipy_ndimage_mean')
 
 
 def _ndimage_mean_kernel_2(input, labels, index, batch_size=4,

--- a/cupyx/scipy/sparse/_index.py
+++ b/cupyx/scipy/sparse/_index.py
@@ -286,7 +286,7 @@ _unique_mask_kern = _core.ElementwiseKernel(
             mask[i+1] = false;
     }
     """,
-    'cupyx_scipy_sparse_unique_mask_kern'
+    'cupyx_scipy_sparse_unique_mask_kern',
     no_return=True
 )
 

--- a/cupyx/scipy/sparse/_index.py
+++ b/cupyx/scipy/sparse/_index.py
@@ -26,7 +26,7 @@ _bool_scalar_types = (bool, numpy.bool_)
 _compress_getitem_kern = _core.ElementwiseKernel(
     'T d, S ind, int32 minor', 'raw T answer',
     'if (ind == minor) atomicAdd(&answer[0], d);',
-    'compress_getitem')
+    'cupyx_scipy_sparse_compress_getitem')
 
 
 _compress_getitem_complex_kern = _core.ElementwiseKernel(
@@ -38,7 +38,7 @@ _compress_getitem_complex_kern = _core.ElementwiseKernel(
     atomicAdd(&answer_imag[0], imag);
     }
     ''',
-    'compress_getitem_complex')
+    'cupyx_scipy_sparse_compress_getitem_complex')
 
 
 def _get_csr_submatrix_major_axis(Ax, Aj, Ap, start, stop):
@@ -108,7 +108,7 @@ _csr_row_index_ker = _core.ElementwiseKernel(
 
     Bj = Aj[starting_input_offset + output_offset];
     Bx = Ax[starting_input_offset + output_offset];
-''', 'csr_row_index_ker')
+''', 'cupyx_scipy_sparse_csr_row_index_ker')
 
 
 def _csr_row_index(Ax, Aj, Ap, rows):
@@ -262,7 +262,7 @@ _insert_many_populate_arrays = _core.ElementwiseKernel(
 
             output_n++;
         }
-    ''', 'csr_copy_existing_indices_kern', no_return=True)
+    ''', 'cupyx_scipy_sparse_csr_copy_existing_indices_kern', no_return=True)
 
 
 # Create a filter mask based on the lowest value of order
@@ -285,7 +285,9 @@ _unique_mask_kern = _core.ElementwiseKernel(
         else
             mask[i+1] = false;
     }
-    """, no_return=True
+    """,
+    'cupyx_scipy_sparse_unique_mask_kern'
+    no_return=True
 )
 
 
@@ -332,7 +334,7 @@ _csr_sample_values_kern = _core.ElementwiseKernel(
         }
     }
     Bx[i] = val_found ? x : not_found_val;
-''', 'csr_sample_values_kern')
+''', 'cupyx_scipy_sparse_csr_sample_values_kern')
 
 
 class IndexMixin(object):

--- a/cupyx/scipy/sparse/compressed.py
+++ b/cupyx/scipy/sparse/compressed.py
@@ -172,7 +172,7 @@ class _compressed_sparse_matrix(sparse_data._data_matrix,
             }
         }
         diff = diff_out;
-        ''', 'has_sorted_indices')
+        ''', 'cupyx_scipy_sparse_has_sorted_indices')
 
     # TODO(leofang): rewrite a more load-balanced approach than this naive one?
     _has_canonical_format_kern = _core.ElementwiseKernel(
@@ -190,7 +190,7 @@ class _compressed_sparse_matrix(sparse_data._data_matrix,
             }
         }
         diff = diff_out;
-        ''', 'has_canonical_format')
+        ''', 'cupyx_scipy_sparse_has_canonical_format')
 
     def __init__(self, arg1, shape=None, dtype=None, copy=False):
         if shape is not None:

--- a/cupyx/scipy/sparse/coo.py
+++ b/cupyx/scipy/sparse/coo.py
@@ -58,7 +58,7 @@ class coo_matrix(sparse_data._data_matrix):
           diff_out = 0;
         }
         diff = diff_out;
-        ''', 'sum_duplicates_diff')
+        ''', 'cupyx_scipy_sparse_coo_sum_duplicates_diff')
 
     def __init__(self, arg1, shape=None, dtype=None, copy=False):
         if shape is not None and len(shape) != 2:
@@ -421,7 +421,7 @@ class coo_matrix(sparse_data._data_matrix):
                     row[index] = src_row;
                     col[index] = src_col;
                     ''',
-                    'sum_duplicates_assign'
+                    'cupyx_scipy_sparse_coo_sum_duplicates_assign'
                 )(src_data, src_row, src_col, index, data, row, col)
             elif self.data.dtype.kind == 'c':
                 cupy.ElementwiseKernel(
@@ -434,7 +434,7 @@ class coo_matrix(sparse_data._data_matrix):
                     row[index] = src_row;
                     col[index] = src_col;
                     ''',
-                    'sum_duplicates_assign_complex'
+                    'cupyx_scipy_sparse_coo_sum_duplicates_assign_complex'
                 )(src_data.real, src_data.imag, src_row, src_col, index,
                   data.real, data.imag, row, col)
 

--- a/cupyx/scipy/sparse/csr.py
+++ b/cupyx/scipy/sparse/csr.py
@@ -699,7 +699,7 @@ def cupy_multiply_by_dense():
         OUT_DATA = (O)(SP_DATA[i_sp] * DN_DATA[n_dn + (DN_N * m_dn)]);
         OUT_INDICES = n_out;
         ''',
-        'cupy_multiply_by_dense',
+        'cupyx_scipy_sparse_csr_multiply_by_dense',
         preamble=_GET_ROW_ID_
     )
 
@@ -788,7 +788,7 @@ def cupy_multiply_by_csr_step1():
             C_INDICES = n_c;
         }
         ''',
-        'cupy_multiply_by_csr_step1',
+        'cupyx_scipy_sparse_csr_multiply_by_csr_step1',
         preamble=_GET_ROW_ID_ + _FIND_INDEX_HOLDING_COL_IN_ROW_
     )
 
@@ -805,7 +805,7 @@ def cupy_multiply_by_csr_step2():
             D_INDICES[j] = C_INDICES;
         }
         ''',
-        'cupy_multiply_by_csr_step2'
+        'cupyx_scipy_sparse_csr_multiply_by_csr_step2'
     )
 
 
@@ -921,7 +921,7 @@ def binopt_csr(a, b, op_name):
 
 @cupy._util.memoize(for_each_device=True)
 def cupy_binopt_csr_step1(op_name, preamble=''):
-    name = 'cupy_binopt_csr' + op_name + 'step1'
+    name = 'cupyx_scipy_sparse_csr_binopt_' + op_name + 'step1'
     return cupy.ElementwiseKernel(
         '''
         int32 M, int32 N,
@@ -1073,7 +1073,7 @@ def cupy_binopt_csr_step1(op_name, preamble=''):
 
 @cupy._util.memoize(for_each_device=True)
 def cupy_binopt_csr_step2(op_name):
-    name = 'cupy_binopt_csr' + op_name + 'step2'
+    name = 'cupyx_scipy_sparse_csr_binopt' + op_name + 'step2'
     return cupy.ElementwiseKernel(
         '''
         raw I A_INFO, raw B A_VALID, raw I A_TMP_INDICES, raw O A_TMP_DATA,
@@ -1123,7 +1123,7 @@ def cupy_csr2dense():
             OUT[row + M * col] += DATA;
         }
         ''',
-        'cupy_csr2dense',
+        'cupyx_scipy_sparse_csr2dense',
         preamble=_GET_ROW_ID_
     )
 
@@ -1161,7 +1161,7 @@ def cupy_dense2csr_step1():
             INFO[i + 1] = 1;
         }
         ''',
-        'cupy_dense2csr_step1')
+        'cupyx_scipy_sparse_dense2csr_step1')
 
 
 @cupy._util.memoize(for_each_device=True)
@@ -1178,7 +1178,7 @@ def cupy_dense2csr_step2():
             DATA[idx] = A;
         }
         ''',
-        'cupy_dense2csr_step2')
+        'cupyx_scipy_sparse_dense2csr_step2')
 
 
 @cupy._util.memoize(for_each_device=True)
@@ -1201,6 +1201,6 @@ def _cupy_csr_diagonal():
             y = static_cast<T>(0);
         }
         ''',
-        '_cupy_csr_diagonal',
+        'cupyx_scipy_sparse_csr_diagonal',
         preamble=_FIND_INDEX_HOLDING_COL_IN_ROW_
     )

--- a/cupyx/scipy/sparse/dia.py
+++ b/cupyx/scipy/sparse/dia.py
@@ -165,8 +165,10 @@ class dia_matrix(data._data_matrix):
             mask = (row >= 0 && row < num_rows && offset_inds < num_cols
                     && data != T(0));
             ''',
-            'dia_tocsc')(offset_len, self.offsets[:, None], num_rows,
-                         num_cols, self.data)
+            'cupyx_scipy_sparse_dia_tocsc')(
+                offset_len, self.offsets[:, None], num_rows, num_cols,
+                self.data
+            )
         indptr = cupy.zeros(num_cols + 1, dtype='i')
         indptr[1: offset_len + 1] = cupy.cumsum(mask.sum(axis=0))
         indptr[offset_len + 1:] = indptr[offset_len]

--- a/cupyx/scipy/sparse/dia.py
+++ b/cupyx/scipy/sparse/dia.py
@@ -165,10 +165,8 @@ class dia_matrix(data._data_matrix):
             mask = (row >= 0 && row < num_rows && offset_inds < num_cols
                     && data != T(0));
             ''',
-            'cupyx_scipy_sparse_dia_tocsc')(
-                offset_len, self.offsets[:, None], num_rows, num_cols,
-                self.data
-            )
+            'cupyx_scipy_sparse_dia_tocsc')(offset_len, self.offsets[:, None],
+                                            num_rows, num_cols, self.data)
         indptr = cupy.zeros(num_cols + 1, dtype='i')
         indptr[1: offset_len + 1] = cupy.cumsum(mask.sum(axis=0))
         indptr[offset_len + 1:] = indptr[offset_len]

--- a/cupyx/scipy/special/_bessel.py
+++ b/cupyx/scipy/special/_bessel.py
@@ -2,7 +2,7 @@ from cupy import _core
 
 
 j0 = _core.create_ufunc(
-    'cupyx_scipy_j0', ('f->f', 'd->d'),
+    'cupyx_scipy_special_j0', ('f->f', 'd->d'),
     'out0 = j0(in0)',
     doc='''Bessel function of the first kind of order 0.
 
@@ -12,7 +12,7 @@ j0 = _core.create_ufunc(
 
 
 j1 = _core.create_ufunc(
-    'cupyx_scipy_j1', ('f->f', 'd->d'),
+    'cupyx_scipy_special_j1', ('f->f', 'd->d'),
     'out0 = j1(in0)',
     doc='''Bessel function of the first kind of order 1.
 
@@ -22,7 +22,7 @@ j1 = _core.create_ufunc(
 
 
 y0 = _core.create_ufunc(
-    'cupyx_scipy_y0', ('f->f', 'd->d'),
+    'cupyx_scipy_special_y0', ('f->f', 'd->d'),
     'out0 = y0(in0)',
     doc='''Bessel function of the second kind of order 0.
 
@@ -32,7 +32,7 @@ y0 = _core.create_ufunc(
 
 
 y1 = _core.create_ufunc(
-    'cupyx_scipy_y1', ('f->f', 'd->d'),
+    'cupyx_scipy_special_y1', ('f->f', 'd->d'),
     'out0 = y1(in0)',
     doc='''Bessel function of the second kind of order 1.
 
@@ -42,7 +42,7 @@ y1 = _core.create_ufunc(
 
 
 i0 = _core.create_ufunc(
-    'cupyx_scipy_i0', ('f->f', 'd->d'),
+    'cupyx_scipy_special_i0', ('f->f', 'd->d'),
     'out0 = cyl_bessel_i0(in0)',
     doc='''Modified Bessel function of order 0.
 
@@ -52,7 +52,7 @@ i0 = _core.create_ufunc(
 
 
 i1 = _core.create_ufunc(
-    'cupyx_scipy_i1', ('f->f', 'd->d'),
+    'cupyx_scipy_special_i1', ('f->f', 'd->d'),
     'out0 = cyl_bessel_i1(in0)',
     doc='''Modified Bessel function of order 1.
 

--- a/cupyx/scipy/special/_convex_analysis.py
+++ b/cupyx/scipy/special/_convex_analysis.py
@@ -66,7 +66,7 @@ double __device__ pseudo_huber(double delta, double r) {
 
 
 entr = _core.create_ufunc(
-    'cupyx_scipy_entr', ('f->f', 'd->d'),
+    'cupyx_scipy_special_entr', ('f->f', 'd->d'),
     'out0 = out0_type(entr(in0));',
     preamble=_float_preamble,
     doc='''Elementwise function for computing entropy.
@@ -77,7 +77,7 @@ entr = _core.create_ufunc(
 
 
 kl_div = _core.create_ufunc(
-    'cupyx_scipy_kl_div', ('ff->f', 'dd->d'),
+    'cupyx_scipy_special_kl_div', ('ff->f', 'dd->d'),
     'out0 = out0_type(kl_div(in0, in1));',
     preamble=_float_preamble,
     doc='''Elementwise function for computing Kullback-Leibler divergence.
@@ -88,7 +88,7 @@ kl_div = _core.create_ufunc(
 
 
 rel_entr = _core.create_ufunc(
-    'cupyx_scipy_rel_entr', ('ff->f', 'dd->d'),
+    'cupyx_scipy_special_rel_entr', ('ff->f', 'dd->d'),
     'out0 = out0_type(rel_entr(in0, in1));',
     preamble=_float_preamble,
     doc='''Elementwise function for computing relative entropy.
@@ -99,7 +99,7 @@ rel_entr = _core.create_ufunc(
 
 
 huber = _core.create_ufunc(
-    'cupyx_scipy_huber', ('ff->f', 'dd->d'),
+    'cupyx_scipy_special_huber', ('ff->f', 'dd->d'),
     'out0 = out0_type(huber(in0, in1));',
     preamble=_float_preamble,
     doc='''Elementwise function for computing the Huber loss.
@@ -110,7 +110,7 @@ huber = _core.create_ufunc(
 
 
 pseudo_huber = _core.create_ufunc(
-    'cupyx_scipy_pseudo_huber', ('ff->f', 'dd->d'),
+    'cupyx_scipy_special_pseudo_huber', ('ff->f', 'dd->d'),
     'out0 = out0_type(pseudo_huber(in0, in1));',
     preamble=_float_preamble,
     doc='''Elementwise function for computing the Pseudo-Huber loss.

--- a/cupyx/scipy/special/_digamma.py
+++ b/cupyx/scipy/special/_digamma.py
@@ -175,7 +175,7 @@ double __device__ psi(double x)
 
 
 digamma = _core.create_ufunc(
-    'cupyx_scipy_digamma', ('f->f', 'd->d'),
+    'cupyx_scipy_special_digamma', ('f->f', 'd->d'),
     'out0 = psi(in0)',
     preamble=polevl_definition+psi_definition,
     doc="""The digamma function.

--- a/cupyx/scipy/special/_erf.py
+++ b/cupyx/scipy/special/_erf.py
@@ -2,7 +2,7 @@ from cupy import _core
 
 
 erf = _core.create_ufunc(
-    'cupyx_scipy_erf', ('f->f', 'd->d'),
+    'cupyx_scipy_special_erf', ('f->f', 'd->d'),
     'out0 = erf(in0)',
     doc='''Error function.
 
@@ -12,7 +12,7 @@ erf = _core.create_ufunc(
 
 
 erfc = _core.create_ufunc(
-    'cupyx_scipy_erfc', ('f->f', 'd->d'),
+    'cupyx_scipy_special_erfc', ('f->f', 'd->d'),
     'out0 = erfc(in0)',
     doc='''Complementary error function.
 
@@ -22,7 +22,7 @@ erfc = _core.create_ufunc(
 
 
 erfcx = _core.create_ufunc(
-    'cupyx_scipy_erfcx', ('f->f', 'd->d'),
+    'cupyx_scipy_special_erfcx', ('f->f', 'd->d'),
     'out0 = erfcx(in0)',
     doc='''Scaled complementary error function.
 
@@ -32,7 +32,7 @@ erfcx = _core.create_ufunc(
 
 
 erfinv = _core.create_ufunc(
-    'cupyx_scipy_erfinv', ('f->f', 'd->d'),
+    'cupyx_scipy_special_erfinv', ('f->f', 'd->d'),
     'out0 = erfinv(in0);',
     doc='''Inverse function of error function.
 
@@ -46,7 +46,7 @@ erfinv = _core.create_ufunc(
 
 
 erfcinv = _core.create_ufunc(
-    'cupyx_scipy_erfcinv', ('f->f', 'd->d'),
+    'cupyx_scipy_special_erfcinv', ('f->f', 'd->d'),
     'out0 = erfcinv(in0);',
     doc='''Inverse function of complementary error function.
 

--- a/cupyx/scipy/special/_gammaln.py
+++ b/cupyx/scipy/special/_gammaln.py
@@ -2,7 +2,7 @@ from cupy import _core
 
 
 gammaln = _core.create_ufunc(
-    'cupyx_scipy_gammaln', ('f->f', 'd->d'),
+    'cupyx_scipy_special_gammaln', ('f->f', 'd->d'),
     '''
     if (isinf(in0) && in0 < 0) {
         out0 = -1.0 / 0.0;

--- a/cupyx/scipy/special/_statistics.py
+++ b/cupyx/scipy/special/_statistics.py
@@ -2,7 +2,7 @@ from cupy import _core
 
 
 ndtr = _core.create_ufunc(
-    'cupyx_scipy_ndtr', ('f->f', 'd->d'),
+    'cupyx_scipy_special_ndtr', ('f->f', 'd->d'),
     'out0 = normcdf(in0)',
     doc='''Cumulative distribution function of normal distribution.
 

--- a/cupyx/scipy/special/_zeta.py
+++ b/cupyx/scipy/special/_zeta.py
@@ -112,7 +112,7 @@ double __device__ zeta(double x, double q)
 
 
 zeta = _core.create_ufunc(
-    'cupyx_scipy_zeta', ('ff->f', 'dd->d'),
+    'cupyx_scipy_special_zeta', ('ff->f', 'dd->d'),
     'out0 = zeta(in0, in1)',
     preamble=zeta_definition,
     doc="""Hurwitz zeta function.


### PR DESCRIPTION
CuPy tends to follow the convention of naming kernels starting with a `cupy_` (or `cupyx_`) prefix. This PR is just to make this consistent across the library. There should be no change in behavior!

There were a few instances without any name specified, but mostly these are just adding or modify the prefix for an existing name.

For the `cupyx.scipy` modules, I used more descriptive `cupyx_scipy_ndimage_`, `cupyx_scipy_sparse_`, etc. as the prefixes