### PR TITLE
Disable Mergify's auto-merge

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,14 +1,4 @@
 pull_request_rules:
-  - name: Auto merge
-    conditions:
-      - "#changes-requested-reviews-by=0"
-      - label=st:test-and-merge
-      - status-success=Jenkins
-      - status-success=pretest  # github workflows
-    actions:
-      merge:
-        method: merge
-        strict: false  # strict mode and manually-triggered CIs do not get along
   - name: Notify conflict
     conditions:
       - conflict


### PR DESCRIPTION
We started using GitHub's native auto-merge, so let's turn off the Mergify.
Native auto-merge works well even with GitHub Actions (due to security restrictions Mergify can't do auto-merge if GitHub workflow files are updated in base branch after submitting the PR).