### PR TITLE
[v9] Fix scipy requirement

### DIFF
--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
@@ -1,4 +1,3 @@
-import sys
 import unittest
 
 import pytest

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
@@ -253,14 +253,12 @@ class TestOrderFilter(unittest.TestCase):
     'kernel_size': [3, 4, (3, 3, 5)],
 }))
 @testing.gpu
-@testing.with_requires('scipy>=1.7.0')
+@testing.with_requires('scipy<1.7.0')
 class TestMedFilt(unittest.TestCase):
     @testing.numpy_cupy_allclose(atol=1e-8, rtol=1e-8, scipy_name='scp',
                                  accept_error=ValueError)  # for even kernels
     @testing.for_all_dtypes()
     def test_medfilt(self, xp, scp, dtype):
-        if sys.platform == 'win32':
-            pytest.xfail('medfilt broken for Scipy 1.7.0 in windows')
         volume = testing.shaped_random(self.volume, xp, dtype)
         kernel_size = self.kernel_size
         if isinstance(kernel_size, tuple):
@@ -273,14 +271,12 @@ class TestMedFilt(unittest.TestCase):
     'kernel_size': [3, 4, (3, 5)],
 }))
 @testing.gpu
-@testing.with_requires('scipy>=1.7.0')
+@testing.with_requires('scipy<1.7.0')
 class TestMedFilt2d(unittest.TestCase):
     @testing.numpy_cupy_allclose(atol=1e-8, rtol=1e-8, scipy_name='scp',
                                  accept_error=ValueError)  # for even kernels
     @testing.for_all_dtypes()
     def test_medfilt2d(self, xp, scp, dtype):
-        if sys.platform == 'win32':
-            pytest.xfail('medfilt2d broken for Scipy 1.7.0 in windows')
         input = testing.shaped_random(self.input, xp, dtype)
         kernel_size = self.kernel_size
         return scp.signal.medfilt2d(input, kernel_size)


### PR DESCRIPTION
API baseline of CuPy v9's is SciPy 1.6 so we have to test against it.
This was my fault in backport: #5413.