### PR TITLE
[backport] Access `cudaMemoryType` in the pointer attributes and fix for HIP 

### DIFF
--- a/cupy_backends/cuda/api/runtime.pxd
+++ b/cupy_backends/cuda/api/runtime.pxd
@@ -7,9 +7,10 @@ from libc.stdint cimport intptr_t, uintmax_t
 
 cdef class PointerAttributes:
     cdef:
-        public int device
-        public intptr_t devicePointer
-        public intptr_t hostPointer
+        readonly int device
+        readonly intptr_t devicePointer
+        readonly intptr_t hostPointer
+        readonly int type
 
 cdef extern from *:
     ctypedef int Error 'cudaError_t'
@@ -577,6 +578,12 @@ cpdef enum:
     # cudaTextureReadMode
     cudaReadModeElementType = 0
     cudaReadModeNormalizedFloat = 1
+
+    # cudaMemoryType
+    memoryTypeUnregistered = 0
+    memoryTypeHost = 1
+    memoryTypeDevice = 2
+    memoryTypeManaged = 3
 
 
 # This was a legacy mistake: the prefix "cuda" should have been removed

--- a/cupy_backends/cuda/api/runtime.pyx
+++ b/cupy_backends/cuda/api/runtime.pyx
@@ -20,7 +20,8 @@ from cupy_backends.cuda.api cimport driver
 cdef class PointerAttributes:
 
     def __init__(self, int device, intptr_t devicePointer,
-                 intptr_t hostPointer):
+                 intptr_t hostPointer, int type=-1):
+        self.type = type
         self.device = device
         self.devicePointer = devicePointer
         self.hostPointer = hostPointer
@@ -68,10 +69,21 @@ cdef extern from *:
 cdef extern from '../../cupy_backend_runtime.h' nogil:
 
     # Types
-    ctypedef struct _PointerAttributes 'cudaPointerAttributes':
-        int device
-        void* devicePointer
-        void* hostPointer
+    IF CUDA_VERSION > 0:
+        ctypedef struct _PointerAttributes 'cudaPointerAttributes':
+            int type
+            int device
+            void* devicePointer
+            void* hostPointer
+    ELIF HIP_VERSION > 0:
+        ctypedef struct _PointerAttributes 'cudaPointerAttributes':
+            int memoryType
+            int device
+            void* devicePointer
+            void* hostPointer
+    ELSE:
+        ctypedef struct _PointerAttributes 'cudaPointerAttributes':
+            pass  # for RTD
 
     # Error handling
     const char* cudaGetErrorName(Error error)
@@ -795,10 +807,20 @@ cpdef PointerAttributes pointerGetAttributes(intptr_t ptr):
     cdef _PointerAttributes attrs
     status = cudaPointerGetAttributes(&attrs, <void*>ptr)
     check_status(status)
-    return PointerAttributes(
-        attrs.device,
-        <intptr_t>attrs.devicePointer,
-        <intptr_t>attrs.hostPointer)
+    IF CUDA_VERSION > 0:
+        return PointerAttributes(
+            attrs.device,
+            <intptr_t>attrs.devicePointer,
+            <intptr_t>attrs.hostPointer,
+            attrs.type)
+    ELIF HIP_VERSION > 0:
+        return PointerAttributes(
+            attrs.device,
+            <intptr_t>attrs.devicePointer,
+            <intptr_t>attrs.hostPointer,
+            attrs.memoryType)
+    ELSE:  # for RTD
+        return None
 
 
 cpdef intptr_t deviceGetDefaultMemPool(int device) except? 0:

--- a/cupy_backends/hip/cupy_hip_runtime.h
+++ b/cupy_backends/hip/cupy_hip_runtime.h
@@ -235,7 +235,22 @@ cudaError_t cudaMemPrefetchAsync(...) {
 
 cudaError_t cudaPointerGetAttributes(cudaPointerAttributes *attributes,
                                      const void* ptr) {
-    return hipPointerGetAttributes(attributes, ptr);
+    cudaError_t status = hipPointerGetAttributes(attributes, ptr);
+    if (status == cudaSuccess) {
+        switch (attributes->memoryType) {
+            case 0 /* hipMemoryTypeHost */:
+                attributes->memoryType = (hipMemoryType)1; /* cudaMemoryTypeHost */
+                return status;
+            case 1 /* hipMemoryTypeDevice */:
+                attributes->memoryType = (hipMemoryType)2; /* cudaMemoryTypeDevice */
+                return status;
+            default:
+                /* we don't care the rest of possibilities */
+                return status;
+        }
+    } else {
+        return status;
+    }
 }
 
 cudaError_t cudaGetDeviceProperties(cudaDeviceProp *prop, int device) {


### PR DESCRIPTION
Backport of #5544.