### PR TITLE
Add support for array input in beta distribution of Generator

### DIFF
--- a/cupy/random/_generator_api.pyx
+++ b/cupy/random/_generator_api.pyx
@@ -241,13 +241,13 @@ class Generator:
                 a = cupy.asarray(a, numpy.float64)
             else:
                 raise TypeError('a is required to be a cupy.ndarray'
-                                    ' or a scalar')
+                                ' or a scalar')
         if not isinstance(b, ndarray):
             if type(b) in (float, int):
                 b = cupy.asarray(b, numpy.float64)
             else:
                 raise TypeError('b is required to be a cupy.ndarray'
-                                    ' or a scalar')
+                                ' or a scalar')
 
         if size is not None and not isinstance(size, tuple):
             size = (size, )

--- a/cupy/random/_generator_api.pyx
+++ b/cupy/random/_generator_api.pyx
@@ -261,7 +261,7 @@ class Generator:
         a_arr = _array_data(a)
         b_arr = _array_data(b)
         a_ptr = a_arr.data.ptr
-        b_ptr = a_arr.data.ptr
+        b_ptr = b_arr.data.ptr
 
         _launch_dist(self.bit_generator, beta, y, (a_ptr, b_ptr))
         # we cast the array to a python object because

--- a/cupy/random/_generator_api.pyx
+++ b/cupy/random/_generator_api.pyx
@@ -30,7 +30,7 @@ cdef extern from 'cupy_distributions.cuh' nogil:
         ssize_t size, intptr_t stream, int64_t mx, int64_t mask)
     void beta(
         int generator, intptr_t state, intptr_t out,
-        ssize_t size, intptr_t stream, double a, double b)
+        ssize_t size, intptr_t stream, intptr_t a, intptr_t b)
     void exponential(
         int generator, intptr_t state, intptr_t out,
         ssize_t size, intptr_t stream)

--- a/cupy/random/cupy_distributions.cu
+++ b/cupy/random/cupy_distributions.cu
@@ -558,9 +558,9 @@ void interval_64(int generator, intptr_t state, intptr_t out, ssize_t size, intp
     generator_dispatcher(generator, launcher, state, out, size, static_cast<uint64_t>(mx), static_cast<uint64_t>(mask));
 }
 
-void beta(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream, double a, double b) {
+void beta(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream, intptr_t a, intptr_t b) {
     kernel_launcher<beta_functor, double> launcher(size, reinterpret_cast<cudaStream_t>(stream));
-    generator_dispatcher(generator, launcher, state, out, size, a, b);
+    generator_dispatcher(generator, launcher, state, out, size, reinterpret_cast<int64_t*>(a), reinterpret_cast<int64_t*>(b));
 }
 
 void exponential(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream) {

--- a/cupy/random/cupy_distributions.cuh
+++ b/cupy/random/cupy_distributions.cuh
@@ -28,7 +28,7 @@ void random_uniform(int generator, intptr_t state, intptr_t out, ssize_t size, i
 void raw(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream);
 void interval_32(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream, int32_t mx, int32_t mask);
 void interval_64(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream, int64_t mx, int64_t mask);
-void beta(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream, double a, double b);
+void beta(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream, intptr_t a, intptr_t b);
 void exponential(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream);
 void geometric(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream, intptr_t p);
 void hypergeometric(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream, intptr_t ngood, intptr_t nbad, intptr_t nsample);
@@ -49,7 +49,7 @@ void random_uniform(int generator, intptr_t state, intptr_t out, ssize_t size, i
 void raw(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream) {}
 void interval_32(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream, int32_t mx, int32_t mask) {}
 void interval_64(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream, int64_t mx, int64_t mask) {}
-void beta(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream, double a, double b) {}
+void beta(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream, intptr_t a, intptr_t b) {}
 void exponential(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream) {}
 void geometric(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream, intptr_t p) {}
 void hypergeometric(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream, intptr_t ngood, intptr_t nbad, intptr_t nsample) {}

--- a/tests/cupy_tests/random_tests/common_distributions.py
+++ b/tests/cupy_tests/random_tests/common_distributions.py
@@ -130,7 +130,10 @@ D- (cupy > numpy): %f''' % (p_value, d_plus, d_minus)
 beta_params = [
     {'a': 1.0, 'b': 3.0},
     {'a': 3.0, 'b': 3.0},
-    {'a': 3.0, 'b': 1.0}]
+    {'a': 3.0, 'b': 1.0},
+    {'a': [1.0, 3.0, 5.0, 6.0, 9.0], 'b':7.0},
+    {'a': 5.0, 'b': [1.0, 5.0, 8.0, 1.0, 3.0]},
+    {'a': [8.0, 6.0, 2.0, 4.0, 7.0], 'b':[3.0, 1.0, 2.0, 8.0, 1.0]}]
 
 
 class Beta:
@@ -138,13 +141,18 @@ class Beta:
     target_method = 'beta'
 
     def test_beta(self):
-        self.generate(a=self.a, b=self.b, size=(3, 2))
+        a = self.a
+        b = self.b
+        if (isinstance(self.a, list) or isinstance(self.b, list)):
+            a = cupy.array(self.a)
+            b = cupy.array(self.b)
+        self.generate(a, b, size=(3, 5))
 
-    @testing.for_dtypes('fd')
     @_condition.repeat_with_success_at_least(10, 3)
-    def test_beta_ks(self, dtype):
-        self.check_ks(0.05)(
-            a=self.a, b=self.b, size=2000, dtype=dtype)
+    def test_beta_ks(self):
+        if (isinstance(self.a, list) or isinstance(self.b, list)):
+            self.skipTest('Stastical checks only for scalar args')
+        self.check_ks(0.05)(a=self.a, b=self.b, size=2000)
 
 
 class StandardExponential:


### PR DESCRIPTION
This PR will add the support for array input in beta distribution of Generator.

Before:
```python
>>> import cupy as cp
>>> rng = cp.random.default_rng()
>>> a = cp.array([1, 2, 1])
>>> b = cp.array([2, 1, 2])
>>> rng.beta(a,b)
TypeError: only size-1 arrays can be converted to Python scalars

```
After this PR:
```python

>>> import cupy as cp
>>> rng = cp.random.default_rng()
>>> a = cp.array([1, 2, 1])
>>> b = cp.array([2, 1, 1])
>>> rng.beta(a, b)
array([0.49999993, 0.5       , 0.49999997])
```