### PR TITLE
Increase timeout for CUDA 11.4 tests

### DIFF
--- a/.pfnci/config.pbtxt
+++ b/.pfnci/config.pbtxt
@@ -48,7 +48,7 @@ configs {
       gpu: 2
     }
     time_limit: {
-      seconds: 14400
+      seconds: 21600
     }
     environment_variables { key: "GPU" value: "2" }
     command: ".pfnci/linux/main-flexci.sh cuda114"


### PR DESCRIPTION
It seems that SASS fix (#5097) increased the compilation time.

Previously, running all unit tests without cache took:

* `CUPY_TEST_FULL_COMBINATION=1` 3h53m (https://ci.preferred.jp/cupy.linux.cuda114/75345/)
* `CUPY_TEST_FULL_COMBINATION=0` 2h8m (https://ci.preferred.jp/cupy.linux.cuda114/75362/)

Now it takes more than 4h (`CUPY_TEST_FULL_COMBINATION=1`):
https://ci.preferred.jp/cupy.linux.cuda114/75868/