### PR TITLE
Support batched QR solver

### DIFF
--- a/cupy/cusolver.pyx
+++ b/cupy/cusolver.pyx
@@ -11,7 +11,9 @@ from cupy_backends.cuda.api cimport runtime
 from cupy_backends.cuda.libs cimport cusolver
 # due to a Cython bug (cython/cython#4000) we cannot just cimport the module
 from cupy_backends.cuda.libs.cusolver cimport (  # noqa
-    sgesvd_bufferSize, dgesvd_bufferSize, cgesvd_bufferSize, zgesvd_bufferSize)
+    sgesvd_bufferSize, dgesvd_bufferSize, cgesvd_bufferSize, zgesvd_bufferSize,
+    sgeqrf_bufferSize, dgeqrf_bufferSize, cgeqrf_bufferSize, zgeqrf_bufferSize,
+    sorgqr_bufferSize, dorgqr_bufferSize, cungqr_bufferSize, zungqr_bufferSize)
 
 from cupy.cuda cimport memory
 from cupy._core.core cimport _internal_ascontiguousarray
@@ -46,9 +48,23 @@ cdef extern from '../cupy_backends/cupy_lapack.h' nogil:
         intptr_t s_ptr, intptr_t u_ptr, intptr_t vt_ptr,
         intptr_t w_ptr, int buffersize, intptr_t info_ptr,
         int batch_size)
+    int geqrf_loop[T](
+        intptr_t handle, int m, int n, intptr_t a_ptr, int lda,
+        intptr_t tau_ptr, intptr_t w_ptr,
+        int buffersize, intptr_t info_ptr,
+        int batch_size)
+    int orgqr_loop[T](
+        intptr_t handle, int m, int n, int k, intptr_t a_ptr, int lda,
+        intptr_t tau_ptr, intptr_t w_ptr,
+        int buffersize, intptr_t info_ptr,
+        int batch_size)
 
 ctypedef int(*gesvd_ptr)(intptr_t, char, char, int, int, intptr_t,
                          intptr_t, intptr_t, intptr_t,
+                         intptr_t, int, intptr_t, int) nogil
+ctypedef int(*geqrf_ptr)(intptr_t, int, int, intptr_t, int, intptr_t,
+                         intptr_t, int, intptr_t, int) nogil
+ctypedef int(*orgqr_ptr)(intptr_t, int, int, int, intptr_t, int, intptr_t,
                          intptr_t, int, intptr_t, int) nogil
 
 
@@ -843,3 +859,128 @@ def csrlsvqr(A, b, tol=0, reorder=1):
                        'tolerance {} (singularity: {})'.
                        format(tol, singularity))
     return x
+
+
+cpdef _qr_batched(a, mode):
+    cdef intptr_t x_ptr, tau_ptr, w_ptr, info_ptr
+    cdef int m, n, k, batch_size, buffersize
+
+    # support float32, float64, complex64, and complex128
+    dtype, out_dtype = _util.linalg_common_type(a)
+    if mode == 'raw':
+        # compatibility with numpy.linalg.qr
+        out_dtype = _numpy.promote_types(out_dtype, 'd')
+
+    batch_size, m, n = a.shape
+    mn = min(m, n)
+    if batch_size == 0 or mn == 0:
+        if mode == 'reduced':
+            return (_cupy.empty((batch_size, m, 0), out_dtype),
+                    _cupy.empty((batch_size, 0, n), out_dtype))
+        elif mode == 'complete':
+            q = _cupy.eye(m)
+            q = _cupy.stack([q for i in range(batch_size)])
+            return (q, _cupy.empty((batch_size, m, n), out_dtype))
+        elif mode == 'r':
+            return _cupy.empty((batch_size, 0, n), out_dtype)
+        elif mode == 'raw':
+            return (_cupy.empty((batch_size, n, m), out_dtype),
+                    _cupy.empty((batch_size, 0,), out_dtype))
+        else:
+            raise ValueError
+
+    x = a.swapaxes(-2, -1).astype(dtype, order='C', copy=True)
+    x_ptr = x.data.ptr
+
+    cdef intptr_t handle = _device.get_cusolver_handle()
+    dev_info = _ndarray_init((batch_size,), _numpy.int32)
+    info_ptr = dev_info.data.ptr
+
+    cdef geqrf_ptr geqrf
+    if dtype == 'f':
+        geqrf_bufferSize = sgeqrf_bufferSize
+        geqrf = geqrf_loop[float]
+    elif dtype == 'd':
+        geqrf_bufferSize = dgeqrf_bufferSize
+        geqrf = geqrf_loop[double]
+    elif dtype == 'F':
+        geqrf_bufferSize = cgeqrf_bufferSize
+        geqrf = geqrf_loop[cuComplex]
+    elif dtype == 'D':
+        geqrf_bufferSize = zgeqrf_bufferSize
+        geqrf = geqrf_loop[cuDoubleComplex]
+    else:
+        msg = ('dtype must be float32, float64, complex64 or complex128'
+               ' (actual: {})'.format(a.dtype))
+        raise ValueError(msg)
+
+    # this wrapper also sets the stream for us
+    buffersize = geqrf_bufferSize(handle, m, n, x.data.ptr, n)
+    # we are on the same stream, so the workspace can be reused in the loop
+    workspace = memory.alloc(buffersize * a.dtype.itemsize)
+    w_ptr = workspace.ptr
+    tau = _cupy.empty((batch_size, mn), dtype=dtype)
+    tau_ptr = tau.data.ptr
+
+    # compute working space of geqrf and solve R
+    # the loop starts here, with gil released to reduce overhead
+    with nogil:
+        status = geqrf(handle, m, n, x_ptr, m, tau_ptr,
+                       w_ptr, buffersize, info_ptr, batch_size)
+    if status != 0:
+        raise _cusolver.CUSOLVERError(status)
+
+    _cupy.linalg._util._check_cusolver_dev_info_if_synchronization_allowed(
+        'geqrf', dev_info)
+
+    if mode == 'r':
+        r = x[..., :mn].swapaxes(-2, -1)
+        return _util._triu(r).astype(out_dtype, copy=False)
+
+    if mode == 'raw':
+        return (x.astype(out_dtype, copy=False),
+                tau.astype(out_dtype, copy=False))
+
+    if mode == 'complete' and m > n:
+        mc = m
+        q = _cupy.empty((batch_size, m, m), dtype)
+    else:  # mode == 'reduced'
+        mc = mn
+        q = _cupy.empty((batch_size, n, m), dtype)
+    q[..., :n] = x
+
+    # compute working space of orgqr and solve Q
+    cdef orgqr_ptr orgqr
+    if dtype == 'f':
+        orgqr_bufferSize = sorgqr_bufferSize
+        orgqr = orgqr_loop[float]
+    elif dtype == 'd':
+        orgqr_bufferSize = dorgqr_bufferSize
+        orgqr = orgqr_loop[double]
+    elif dtype == 'F':
+        orgqr_bufferSize = cungqr_bufferSize
+        orgqr = orgqr_loop[cuComplex]
+    elif dtype == 'D':
+        orgqr_bufferSize = zungqr_bufferSize
+        orgqr = orgqr_loop[cuDoubleComplex]
+
+    # this wrapper also sets the stream for us
+    buffersize = orgqr_bufferSize(
+        handle, m, mc, mn, q.data.ptr, m, tau_ptr)
+    workspace = memory.alloc(buffersize * a.dtype.itemsize)
+    w_ptr = workspace.ptr
+    x_ptr = q.data.ptr
+
+    with nogil:
+        status = orgqr(
+            handle, m, mc, mn, x_ptr, m, tau_ptr, w_ptr,
+            buffersize, info_ptr, batch_size)
+    if status != 0:
+        raise _cusolver.CUSOLVERError(status)
+    _cupy.linalg._util._check_cusolver_dev_info_if_synchronization_allowed(
+        'orgqr', dev_info)
+
+    q = q[..., :mc].swapaxes(-2, -1)
+    r = x[..., :mc].swapaxes(-2, -1)
+    return (q.astype(out_dtype, copy=False),
+            _util._triu(r).astype(out_dtype, copy=False))

--- a/cupy/cusolver.pyx
+++ b/cupy/cusolver.pyx
@@ -878,7 +878,12 @@ cpdef _geqrf_orgqr_batched(a, mode):
     mn = min(m, n)
 
     x = a.swapaxes(-2, -1).astype(dtype, order='C', copy=True)
-    x_ptr = x.data.ptr
+    if runtime._is_hip_environment:
+        # rocsolver_<t>geqrf_batched has a different signature...
+        ap = _linalg._mat_ptrs(x)
+    else:
+        ap = a
+    x_ptr = ap.data.ptr
 
     cdef intptr_t handle = _device.get_cusolver_handle()
     dev_info = _ndarray_init((batch_size,), _numpy.int32)

--- a/cupy/cusolver.pyx
+++ b/cupy/cusolver.pyx
@@ -882,7 +882,7 @@ cpdef _geqrf_orgqr_batched(a, mode):
         # rocsolver_<t>geqrf_batched has a different signature...
         ap = _linalg._mat_ptrs(x)
     else:
-        ap = a
+        ap = x
     x_ptr = ap.data.ptr
 
     cdef intptr_t handle = _device.get_cusolver_handle()

--- a/cupy/cusolver.pyx
+++ b/cupy/cusolver.pyx
@@ -866,7 +866,7 @@ cpdef _qr_batched(a, mode):
     cdef int m, n, k, batch_size, buffersize
 
     # support float32, float64, complex64, and complex128
-    dtype, out_dtype = _util.linalg_common_type(a)
+    dtype, out_dtype = _cupy.linalg._util.linalg_common_type(a)
     if mode == 'raw':
         # compatibility with numpy.linalg.qr
         out_dtype = _numpy.promote_types(out_dtype, 'd')
@@ -935,7 +935,7 @@ cpdef _qr_batched(a, mode):
 
     if mode == 'r':
         r = x[..., :mn].swapaxes(-2, -1)
-        return _util._triu(r).astype(out_dtype, copy=False)
+        return _cupy.linalg._util._triu(r).astype(out_dtype, copy=False)
 
     if mode == 'raw':
         return (x.astype(out_dtype, copy=False),
@@ -983,4 +983,4 @@ cpdef _qr_batched(a, mode):
     q = q[..., :mc].swapaxes(-2, -1)
     r = x[..., :mc].swapaxes(-2, -1)
     return (q.astype(out_dtype, copy=False),
-            _util._triu(r).astype(out_dtype, copy=False))
+            _cupy.linalg._util._triu(r).astype(out_dtype, copy=False))

--- a/cupy/linalg/_decomposition.py
+++ b/cupy/linalg/_decomposition.py
@@ -263,9 +263,9 @@ def qr(a, mode='reduced'):
         a (cupy.ndarray): The input matrix.
         mode (str): The mode of decomposition. Currently 'reduced',
             'complete', 'r', and 'raw' modes are supported. The default mode
-            is 'reduced', in which matrix ``A = (M, N)`` is decomposed into
-            ``Q``, ``R`` with dimensions ``(M, K)``, ``(K, N)``, where
-            ``K = min(M, N)``.
+            is 'reduced', in which matrix ``A = (..., M, N)`` is decomposed
+            into ``Q``, ``R`` with dimensions ``(..., M, K)``, ``(..., K, N)``,
+            where ``K = min(M, N)``.
 
     Returns:
         cupy.ndarray, or tuple of ndarray:
@@ -291,6 +291,7 @@ def qr(a, mode='reduced'):
             msg = 'Unrecognized mode \'{}\''.format(mode)
         raise ValueError(msg)
     if a.ndim > 2:
+        cupy._util.experimental('cupy.linalg.qr')
         return _qr_batched(a, mode)
 
     # support float32, float64, complex64, and complex128

--- a/cupy/linalg/_decomposition.py
+++ b/cupy/linalg/_decomposition.py
@@ -239,16 +239,15 @@ def qr(a, mode='reduced'):
 
     .. seealso:: :func:`numpy.linalg.qr`
     """
-    # TODO(Saito): Current implementation only accepts two-dimensional arrays
     _util._assert_cupy_array(a)
-    _util._assert_rank2(a)
-
     if mode not in ('reduced', 'complete', 'r', 'raw'):
         if mode in ('f', 'full', 'e', 'economic'):
             msg = 'The deprecated mode \'{}\' is not supported'.format(mode)
             raise ValueError(msg)
         else:
             raise ValueError('Unrecognized mode \'{}\''.format(mode))
+    if a.ndim > 2:
+        return _gr_batched(a, mode)
 
     # support float32, float64, complex64, and complex128
     dtype, out_dtype = _util.linalg_common_type(a)

--- a/cupy/linalg/_decomposition.py
+++ b/cupy/linalg/_decomposition.py
@@ -7,7 +7,7 @@ from cupy_backends.cuda.libs import cusolver
 from cupy._core import internal
 from cupy.cuda import device
 from cupy.cusolver import check_availability
-from cupy.cusolver import _gesvdj_batched, _gesvd_batched
+from cupy.cusolver import _gesvdj_batched, _gesvd_batched, _qr_batched
 from cupy.linalg import _util
 
 
@@ -247,7 +247,7 @@ def qr(a, mode='reduced'):
         else:
             raise ValueError('Unrecognized mode \'{}\''.format(mode))
     if a.ndim > 2:
-        return _gr_batched(a, mode)
+        return _qr_batched(a, mode)
 
     # support float32, float64, complex64, and complex128
     dtype, out_dtype = _util.linalg_common_type(a)

--- a/cupy/linalg/_util.py
+++ b/cupy/linalg/_util.py
@@ -139,6 +139,7 @@ def _tril(x, k=0):
     return x
 
 
+# support a batch of matrices
 _triu_kernel = _core.ElementwiseKernel(
     'int64 k', 'S x',
     'x = (_ind.get()[_ind.ndim - 1] - _ind.get()[_ind.ndim - 2] >= k) ? x : 0',

--- a/cupy/linalg/_util.py
+++ b/cupy/linalg/_util.py
@@ -141,7 +141,7 @@ def _tril(x, k=0):
 
 _triu_kernel = _core.ElementwiseKernel(
     'int64 k', 'S x',
-    'x = (_ind.get()[1] - _ind.get()[0] >= k) ? x : 0',
+    'x = (_ind.get()[_ind.ndim - 1] - _ind.get()[_ind.ndim - 2] >= k) ? x : 0',
     'triu_kernel',
     reduce_dims=False
 )

--- a/cupy_backends/cupy_lapack.h
+++ b/cupy_backends/cupy_lapack.h
@@ -138,7 +138,7 @@ int orgqr_loop(
         intptr_t handle, int m, int n, int k, intptr_t a_ptr, int lda,
         intptr_t tau_ptr, intptr_t w_ptr,
         int buffersize, intptr_t info_ptr,
-        int batch_size, int reduced, int origin_n) {
+        int batch_size, int origin_n) {
     /*
      * Assumptions:
      * 1. the stream is set prior to calling this function
@@ -146,7 +146,6 @@ int orgqr_loop(
      */
 
     cusolverStatus_t status;
-    int qm = (!reduced && (m > origin_n)) ? m : origin_n;
     T* A = reinterpret_cast<T*>(a_ptr);
     const T* Tau = reinterpret_cast<const T*>(tau_ptr);
     T* Work = reinterpret_cast<T*>(w_ptr);
@@ -160,8 +159,8 @@ int orgqr_loop(
         status = func(reinterpret_cast<cusolverDnHandle_t>(handle),
                       m, n, k, A, lda, Tau, Work, buffersize, devInfo);
         if (status != 0) break;
-        A += m * qm;
-        Tau += k;  // k = min(m, n)
+        A += m * origin_n;
+        Tau += k;
         devInfo += 1;
     }
 

--- a/cupy_backends/cupy_lapack.h
+++ b/cupy_backends/cupy_lapack.h
@@ -138,7 +138,7 @@ int orgqr_loop(
         intptr_t handle, int m, int n, int k, intptr_t a_ptr, int lda,
         intptr_t tau_ptr, intptr_t w_ptr,
         int buffersize, intptr_t info_ptr,
-        int batch_size) {
+        int batch_size, int reduced, int origin_n) {
     /*
      * Assumptions:
      * 1. the stream is set prior to calling this function
@@ -146,7 +146,7 @@ int orgqr_loop(
      */
 
     cusolverStatus_t status;
-    int mn = (m<n?m:n);
+    int qm = (!reduced && (m > origin_n)) ? m : origin_n;
     T* A = reinterpret_cast<T*>(a_ptr);
     const T* Tau = reinterpret_cast<const T*>(tau_ptr);
     T* Work = reinterpret_cast<T*>(w_ptr);
@@ -160,8 +160,8 @@ int orgqr_loop(
         status = func(reinterpret_cast<cusolverDnHandle_t>(handle),
                       m, n, k, A, lda, Tau, Work, buffersize, devInfo);
         if (status != 0) break;
-        A += m * n;
-        Tau += k;
+        A += m * qm;
+        Tau += k;  // k = min(m, n)
         devInfo += 1;
     }
 

--- a/cupy_backends/stub/cupy_cusolver.h
+++ b/cupy_backends/stub/cupy_cusolver.h
@@ -193,19 +193,53 @@ cusolverStatus_t cusolverDnZgeqrf_bufferSize(...) {
     return CUSOLVER_STATUS_SUCCESS;
 }
 
-cusolverStatus_t cusolverDnSgeqrf(...) {
+// The function signatures are explicitly spelled out because we need to
+// fetch the function pointers.
+cusolverStatus_t cusolverDnSgeqrf(cusolverDnHandle_t handle,
+                                  int m,
+                                  int n,
+                                  float *A,
+                                  int lda,
+                                  float *TAU,
+                                  float *Workspace,
+                                  int Lwork,
+                                  int *devInfo) {
     return CUSOLVER_STATUS_SUCCESS;
 }
 
-cusolverStatus_t cusolverDnDgeqrf(...) {
+cusolverStatus_t cusolverDnDgeqrf(cusolverDnHandle_t handle,
+                                  int m,
+                                  int n,
+                                  double *A,
+                                  int lda,
+                                  double *TAU,
+                                  double *Workspace,
+                                  int Lwork,
+                                  int *devInfo) {
     return CUSOLVER_STATUS_SUCCESS;
 }
 
-cusolverStatus_t cusolverDnCgeqrf(...) {
+cusolverStatus_t cusolverDnCgeqrf(cusolverDnHandle_t handle,
+                                  int m,
+                                  int n,
+                                  cuComplex *A,
+                                  int lda,
+                                  cuComplex *TAU,
+                                  cuComplex *Workspace,
+                                  int Lwork,
+                                  int *devInfo) {
     return CUSOLVER_STATUS_SUCCESS;
 }
 
-cusolverStatus_t cusolverDnZgeqrf(...) {
+cusolverStatus_t cusolverDnZgeqrf(cusolverDnHandle_t handle,
+                                  int m,
+                                  int n,
+                                  cuDoubleComplex *A,
+                                  int lda,
+                                  cuDoubleComplex *TAU,
+                                  cuDoubleComplex *Workspace,
+                                  int Lwork,
+                                  int *devInfo) {
     return CUSOLVER_STATUS_SUCCESS;
 }
 
@@ -225,19 +259,57 @@ cusolverStatus_t cusolverDnZungqr_bufferSize(...) {
     return CUSOLVER_STATUS_SUCCESS;
 }
 
-cusolverStatus_t cusolverDnSorgqr(...) {
+// The function signatures are explicitly spelled out because we need to
+// fetch the function pointers.
+cusolverStatus_t cusolverDnSorgqr(cusolverDnHandle_t handle,
+                                  int m,
+                                  int n,
+                                  int k,
+                                  float *A,
+                                  int lda,
+                                  const float *tau,
+                                  float *work,
+                                  int lwork,
+                                  int *devInfo) {
     return CUSOLVER_STATUS_SUCCESS;
 }
 
-cusolverStatus_t cusolverDnDorgqr(...) {
+cusolverStatus_t cusolverDnDorgqr(cusolverDnHandle_t handle,
+                                  int m,
+                                  int n,
+                                  int k,
+                                  double *A,
+                                  int lda,
+                                  const double *tau,
+                                  double *work,
+                                  int lwork,
+                                  int *devInfo) {
     return CUSOLVER_STATUS_SUCCESS;
 }
 
-cusolverStatus_t cusolverDnCungqr(...) {
+cusolverStatus_t cusolverDnCungqr(cusolverDnHandle_t handle,
+                                  int m,
+                                  int n,
+                                  int k,
+                                  cuComplex *A,
+                                  int lda,
+                                  const cuComplex *tau,
+                                  cuComplex *work,
+                                  int lwork,
+                                  int *devInfo) {
     return CUSOLVER_STATUS_SUCCESS;
 }
 
-cusolverStatus_t cusolverDnZungqr(...) {
+cusolverStatus_t cusolverDnZungqr(cusolverDnHandle_t handle,
+                                  int m,
+                                  int n,
+                                  int k,
+                                  cuDoubleComplex *A,
+                                  int lda,
+                                  const cuDoubleComplex *tau,
+                                  cuDoubleComplex *work,
+                                  int lwork,
+                                  int *devInfo) {
     return CUSOLVER_STATUS_SUCCESS;
 }
 

--- a/tests/cupy_tests/linalg_tests/test_decomposition.py
+++ b/tests/cupy_tests/linalg_tests/test_decomposition.py
@@ -7,6 +7,8 @@ import cupy
 from cupy._core.internal import prod
 from cupy import cusolver
 from cupy import testing
+from cupy.cuda import driver
+from cupy.cuda import runtime
 from cupy.testing import _condition
 import cupyx
 
@@ -102,6 +104,10 @@ class TestQRDecomposition(unittest.TestCase):
 
     @testing.for_dtypes('fdFD')
     def check_mode(self, array, mode, dtype, batched=False):
+        if runtime.is_hip and driver.get_build_version() < 307:
+            if dtype in (numpy.complex64, numpy.complex128):
+                pytest.skip('ungqr unsupported')
+
         a_cpu = numpy.asarray(array, dtype=dtype)
         a_gpu = cupy.asarray(array, dtype=dtype)
         result_gpu = cupy.linalg.qr(a_gpu, mode=mode)


### PR DESCRIPTION
Close #4986.

To prepare for the upcoming NumPy 1.22 (https://github.com/numpy/numpy/pull/19151) and the Array API standard.

**UPDATE**: I made some educated guesses about zero-size input. But before NumPy 1.22 is out so that we can actually test all corner cases the validity remains to be seen. As a result, I require those tests to be run on NumPy 1.22+, and added an experimental warning if batching is in use.

TODO:
- [x] HIP
- [x] tests
- [x] docstring
- [x] benchmark