### PR TITLE
Fix `skipTest` in `test_decomp_lu`

### DIFF
--- a/tests/cupyx_tests/scipy_tests/linalg_tests/test_decomp_lu.py
+++ b/tests/cupyx_tests/scipy_tests/linalg_tests/test_decomp_lu.py
@@ -20,8 +20,8 @@ class TestLUFactor(unittest.TestCase):
     @testing.for_dtypes('fdFD')
     def test_lu_factor(self, dtype):
         if self.shape[0] != self.shape[1]:
-            # skip non-square tests since scipy.lu_factor requires square
-            return unittest.SkipTest()
+            self.skipTest(
+                'skip non-square tests since scipy.lu_factor requires square')
         a_cpu = testing.shaped_random(self.shape, numpy, dtype=dtype)
         a_gpu = cupy.asarray(a_cpu)
         result_cpu = scipy.linalg.lu_factor(a_cpu)
@@ -65,7 +65,8 @@ class TestLUFactor(unittest.TestCase):
     @testing.for_dtypes('fdFD')
     def test_lu_factor_reconstruction_singular(self, dtype):
         if self.shape[0] != self.shape[1]:
-            return unittest.SkipTest()
+            self.skipTest(
+                'skip non-square tests since scipy.lu_factor requires square')
         A = testing.shaped_random(self.shape, cupy, dtype=dtype)
         A -= A.mean(axis=0, keepdims=True)
         A -= A.mean(axis=1, keepdims=True)


### PR DESCRIPTION
Fix Typo in https://github.com/cupy/cupy/pull/2286#issuecomment-508328266 (`raise unittest.SkipTest()` is OK).  #5463 found this.

However, the fix keeps the test result (= pass), because `for_dtypes` does not propagate skips.

Notes:
- `unittest.skipTest` and `return` are equivalent inside `for_dtypes`, except for the debug message.
- `for_dtypes` catches `_skip_classes` because `numpy_cupy_*` propagates skips.  (This explanation is different than #1757.)
- Other loop helpers (e.g. `for_orders`) short-circuit skips, which may be error-prone.

