### PR TITLE
[v9] Fix broken build on CUDA 9.2

### DIFF
--- a/cupy_backends/cuda/api/runtime.pyx
+++ b/cupy_backends/cuda/api/runtime.pyx
@@ -75,7 +75,7 @@ cdef extern from '../../cupy_backend_runtime.h' nogil:
             int device
             void* devicePointer
             void* hostPointer
-    ELIF (0 < HIP_VERSION) or (CUDA_VERSION < 10000):
+    ELIF (0 < HIP_VERSION) or (0 < CUDA_VERSION < 10000):
         ctypedef struct _PointerAttributes 'cudaPointerAttributes':
             int memoryType
             int device
@@ -813,7 +813,7 @@ cpdef PointerAttributes pointerGetAttributes(intptr_t ptr):
             <intptr_t>attrs.devicePointer,
             <intptr_t>attrs.hostPointer,
             attrs.type)
-    ELIF (0 < HIP_VERSION) or (CUDA_VERSION < 10000):
+    ELIF (0 < HIP_VERSION) or (0 < CUDA_VERSION < 10000):
         return PointerAttributes(
             attrs.device,
             <intptr_t>attrs.devicePointer,

--- a/cupy_backends/cuda/api/runtime.pyx
+++ b/cupy_backends/cuda/api/runtime.pyx
@@ -69,13 +69,13 @@ cdef extern from *:
 cdef extern from '../../cupy_backend_runtime.h' nogil:
 
     # Types
-    IF CUDA_VERSION > 0:
+    IF 10000 <= CUDA_VERSION:
         ctypedef struct _PointerAttributes 'cudaPointerAttributes':
             int type
             int device
             void* devicePointer
             void* hostPointer
-    ELIF HIP_VERSION > 0:
+    ELIF (0 < HIP_VERSION) or (CUDA_VERSION < 10000):
         ctypedef struct _PointerAttributes 'cudaPointerAttributes':
             int memoryType
             int device
@@ -807,13 +807,13 @@ cpdef PointerAttributes pointerGetAttributes(intptr_t ptr):
     cdef _PointerAttributes attrs
     status = cudaPointerGetAttributes(&attrs, <void*>ptr)
     check_status(status)
-    IF CUDA_VERSION > 0:
+    IF 10000 <= CUDA_VERSION:
         return PointerAttributes(
             attrs.device,
             <intptr_t>attrs.devicePointer,
             <intptr_t>attrs.hostPointer,
             attrs.type)
-    ELIF HIP_VERSION > 0:
+    ELIF (0 < HIP_VERSION) or (CUDA_VERSION < 10000):
         return PointerAttributes(
             attrs.device,
             <intptr_t>attrs.devicePointer,

--- a/cupy_backends/cuda/api/runtime.pyx
+++ b/cupy_backends/cuda/api/runtime.pyx
@@ -75,7 +75,7 @@ cdef extern from '../../cupy_backend_runtime.h' nogil:
             int device
             void* devicePointer
             void* hostPointer
-    ELIF (0 < HIP_VERSION) or (0 < CUDA_VERSION < 10000):
+    ELIF (0 < HIP_VERSION) or (0 < CUDA_VERSION < 10000):  # NOQA
         ctypedef struct _PointerAttributes 'cudaPointerAttributes':
             int memoryType
             int device
@@ -813,7 +813,7 @@ cpdef PointerAttributes pointerGetAttributes(intptr_t ptr):
             <intptr_t>attrs.devicePointer,
             <intptr_t>attrs.hostPointer,
             attrs.type)
-    ELIF (0 < HIP_VERSION) or (0 < CUDA_VERSION < 10000):
+    ELIF (0 < HIP_VERSION) or (0 < CUDA_VERSION < 10000):  # NOQA
         return PointerAttributes(
             attrs.device,
             <intptr_t>attrs.devicePointer,


### PR DESCRIPTION
`type` member has been added in CUDA 10.0. Have to use `memoryType` for CUDA 9.2 (or earlier or HIP).

Follow-up: #5571