### PR TITLE
Increase test timeout

### DIFF
--- a/.pfnci/linux/tests/_build_and_test.sh
+++ b/.pfnci/linux/tests/_build_and_test.sh
@@ -6,7 +6,7 @@ MARKER="${1:-}"
 
 pytest_opts=(
     -rfEX
-    --timeout 300
+    --timeout 500
     --maxfail 500
     --showlocals
 )


### PR DESCRIPTION
The following test takes 5.5 min (in my environment) and times out, when `CUPY_TEST_FULL_COMBINATION=1` is set.

```
FAILED cupy_tests/math_tests/test_arithmetic.py::TestUfunc::test_casting_out_unsafe 
```

https://ci.preferred.jp/cupy.linux.cuda114/76501/