### PR TITLE
Reload GPG key for Docker images

### DIFF
--- a/docker/rocm/Dockerfile
+++ b/docker/rocm/Dockerfile
@@ -2,6 +2,7 @@ FROM rocm/rocm-terminal:4.0.1
 LABEL maintainer="CuPy Team"
 
 USER root
+RUN curl -qL https://repo.radeon.com/rocm/rocm.gpg.key | apt-key add -
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
     python3-dev \


### PR DESCRIPTION
GPG expired so `apt` stopped working in already-released Docker containers.