### PR TITLE
Add Log Series distribution to Generator

### DIFF
--- a/cupy/random/_generator_api.pyx
+++ b/cupy/random/_generator_api.pyx
@@ -444,7 +444,7 @@ class Generator:
                 distribution. Must be in the range (0, 1).
             size (int or tuple of ints, optional): The shape of the output
                 array. If ``None`` (default), a single value is returned if
-                 ``p`` is scalar. Otherwise, ``p.size`` samples are drawn.
+                ``p`` is scalar. Otherwise, ``p.size`` samples are drawn.
 
         Returns:
             cupy.ndarray: Samples drawn from the log series distribution.

--- a/cupy/random/_generator_api.pyx
+++ b/cupy/random/_generator_api.pyx
@@ -431,13 +431,33 @@ class Generator:
         return y
 
     def logseries(self, p, size=None):
-        """logseries distribution"""
+        """Log series distribution.
+
+        Returns an array of samples drawn from the log series distribution.
+            Its probability mass function is defined as
+
+        .. math::
+           f(x) = \\frac{-p^x}{x\\ln(1-p)}.
+
+        Args:
+            p (float or cupy.ndarray of floats): Parameter of the log series
+                distribution. Must be in the range (0, 1).
+            size (int or tuple of ints, optional): The shape of the output
+                array. If `None`(default), a single value is returned if ``p``
+                is scalar. Otherwise, ``p.size`` samples are drawn.
+
+        Returns:
+            cupy.ndarray: Samples drawn from the log series distribution.
+
+        .. seealso::
+            :meth:`numpy.random.Generator.logseries`
+    """
         cdef ndarray y
         cdef ndarray p_arr
 
         if not isinstance(p, ndarray):
             if type(p) in (float, int):
-                p = cupy.asarray
+                p = cupy.asarray(p, numpy.float64)
             else:
                 raise TypeError('p is required to be a cupy.ndarray'
                                 ' or a scalar')

--- a/cupy/random/_generator_api.pyx
+++ b/cupy/random/_generator_api.pyx
@@ -451,7 +451,7 @@ class Generator:
 
         .. seealso::
             :meth:`numpy.random.Generator.logseries`
-    """
+        """
         cdef ndarray y
         cdef ndarray p_arr
 

--- a/cupy/random/_generator_api.pyx
+++ b/cupy/random/_generator_api.pyx
@@ -434,7 +434,7 @@ class Generator:
         """Log series distribution.
 
         Returns an array of samples drawn from the log series distribution.
-            Its probability mass function is defined as
+        Its probability mass function is defined as
 
         .. math::
            f(x) = \\frac{-p^x}{x\\ln(1-p)}.
@@ -443,8 +443,8 @@ class Generator:
             p (float or cupy.ndarray of floats): Parameter of the log series
                 distribution. Must be in the range (0, 1).
             size (int or tuple of ints, optional): The shape of the output
-                array. If `None`(default), a single value is returned if ``p``
-                is scalar. Otherwise, ``p.size`` samples are drawn.
+                array. If ``None`` (default), a single value is returned if
+                 ``p`` is scalar. Otherwise, ``p.size`` samples are drawn.
 
         Returns:
             cupy.ndarray: Samples drawn from the log series distribution.

--- a/cupy/random/cupy_distributions.cu
+++ b/cupy/random/cupy_distributions.cu
@@ -616,7 +616,7 @@ void hypergeometric(int generator, intptr_t state, intptr_t out, ssize_t size, i
 }
 
 void logseries(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream, intptr_t p) {
-    kernel_launcher<geometric_functor, int64_t> launcher(size, reinterpret_cast<cudaStream_t>(stream));
+    kernel_launcher<logseries_functor, int64_t> launcher(size, reinterpret_cast<cudaStream_t>(stream));
     generator_dispatcher(generator, launcher, state, out, size, reinterpret_cast<int64_t*>(p));
 }
 

--- a/cupy/random/cupy_distributions.cu
+++ b/cupy/random/cupy_distributions.cu
@@ -317,6 +317,36 @@ __device__ int64_t rk_hypergeometric(rk_state *state, double good, double bad, d
     }
 }
 
+__device__ int64_t rk_logseries(rk_state *state, double p)
+{
+    double q, r, U, V;
+    int64_t result;
+
+    r = log(1.0 - p);
+
+    while (1) {
+        V = state->rk_double();
+        if (V >= p) {
+            return 1;
+        }
+        U = state->rk_double();
+        q = 1.0 - exp(r*U);
+        if (V <= q*q) {
+            result = floor(1 + log(V)/log(q));
+            if (result < 1) {
+                continue;
+            }
+            else {
+                return result;
+            }
+        }
+        if (V >= q) {
+            return 1;
+        }
+        return 2;
+    }
+}
+
 __device__ int64_t rk_poisson_mult(rk_state *state, double lam) {
     int64_t X;
     double prod, U, enlam;
@@ -467,6 +497,13 @@ struct hypergeometric_functor {
     }
 };
 
+struct logseries_functor {
+    template<typename... Args>
+    __device__ int64_t operator () (Args&&... args) {
+        return rk_logseries(args...);
+    }
+};
+
 struct standard_normal_functor {
     template<typename... Args>
     __device__ double operator () (Args&&... args) {
@@ -576,6 +613,11 @@ void geometric(int generator, intptr_t state, intptr_t out, ssize_t size, intptr
 void hypergeometric(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream, intptr_t ngood, intptr_t nbad, intptr_t nsample) {
     kernel_launcher<hypergeometric_functor, int64_t> launcher(size, reinterpret_cast<cudaStream_t>(stream));
     generator_dispatcher(generator, launcher, state, out, size, reinterpret_cast<int64_t*>(ngood), reinterpret_cast<int64_t*>(nbad), reinterpret_cast<int64_t*>(nsample));
+}
+
+void logseries(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream, intptr_t p) {
+    kernel_launcher<geometric_functor, int64_t> launcher(size, reinterpret_cast<cudaStream_t>(stream));
+    generator_dispatcher(generator, launcher, state, out, size, reinterpret_cast<int64_t*>(p));
 }
 
 void poisson(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream, intptr_t lam) {

--- a/cupy/random/cupy_distributions.cuh
+++ b/cupy/random/cupy_distributions.cuh
@@ -32,6 +32,7 @@ void beta(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t st
 void exponential(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream);
 void geometric(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream, intptr_t p);
 void hypergeometric(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream, intptr_t ngood, intptr_t nbad, intptr_t nsample);
+void logseries(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream, intptr_t p);
 void poisson(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream, intptr_t lam);
 void standard_normal(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream);
 void standard_normal_float(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream);
@@ -53,6 +54,7 @@ void beta(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t st
 void exponential(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream) {}
 void geometric(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream, intptr_t p) {}
 void hypergeometric(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream, intptr_t ngood, intptr_t nbad, intptr_t nsample) {}
+void logseries(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream, intptr_t p) {}
 void poisson(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream, intptr_t lam) {}
 void standard_normal(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream) {}
 void standard_normal_float(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream){}

--- a/tests/cupy_tests/random_tests/common_distributions.py
+++ b/tests/cupy_tests/random_tests/common_distributions.py
@@ -338,3 +338,28 @@ class Hypergeometric:
                 or isinstance(self.nsample, list)):
             self.skipTest('Stastical checks only for scalar args')
         self.check_ks(0.05)(self.ngood, self.nbad, self.nsample, size=2000)
+
+
+logseries_params = [
+    {'p': 0.5},
+    {'p': 0.1},
+    {'p': 0.9},
+    {'p': [0.8, 0.7]},
+]
+
+
+class Logseries:
+
+    target_method = 'logseries'
+
+    def test_logseries(self):
+        p = self.p
+        if not isinstance(self.p, float):
+            p = cupy.array(self.p)
+        self.generate(p=p, size=(3, 2))
+
+    @_condition.repeat_with_success_at_least(10, 3)
+    def test_geometric_ks(self):
+        if not isinstance(self.p, float):
+            self.skipTest('Statistical checks only for scalar `p`')
+        self.check_ks(0.05)(p=self.p, size=2000)

--- a/tests/cupy_tests/random_tests/test_generator.py
+++ b/tests/cupy_tests/random_tests/test_generator.py
@@ -383,21 +383,13 @@ class TestLogNormal(RandomGeneratorTestCase):
             *self.args, size=self.size, dtype=dtype)
 
 
-@testing.parameterize(
-    {'p': 0.5},
-    {'p': 0.1},
-    {'p': 0.9},
-)
-@testing.gpu
+@testing.parameterize(*common_distributions.logseries_params)
 @testing.fix_random()
-class TestLogseries(RandomGeneratorTestCase):
-
-    target_method = 'logseries'
-
-    def test_logseries(self):
-        self.generate(p=self.p, size=(3, 2))
-
-    # TODO(kataoka): add distribution test
+class TestLogseries(
+    common_distributions.Logseries,
+    RandomGeneratorTestCase
+):
+    pass
 
 
 @testing.gpu

--- a/tests/cupy_tests/random_tests/test_generator_api.py
+++ b/tests/cupy_tests/random_tests/test_generator_api.py
@@ -311,3 +311,12 @@ class TestRandomStateThreadSafe(unittest.TestCase):
         actual = cupy.random.default_rng(seed).standard_exponential()
         expected = cupy.random.default_rng(seed).standard_exponential()
         assert actual == expected
+
+
+@testing.parameterize(*common_distributions.logseries_params)
+@testing.fix_random()
+class TestLogseries(
+    common_distributions.Logseries,
+    GeneratorTestCase
+):
+    pass


### PR DESCRIPTION
This PR adds log series distribution to Generator.

Following is the performance comparison on GTX1050.
size(nrows * ncols) | numpy (sec) | cupyx (sec)
---|---|---
10000 * 1 | 0.000 | 0.000
12000 * 1 | 0.000 | 0.000
15000 * 1 | 0.001 | 0.000
20000 * 1 | 0.001 | 0.000
10000 * 1000 | 0.381 | 0.044
12000 * 1000 | 0.468 | 0.056
15000 * 1000 | 0.622 | 0.058
20000 * 1000 | 0.795 | 0.095
10000 * 2000 | 0.788 | 0.081
12000 * 2000 | 0.949 | 0.093
15000 * 2000 | 1.194 | 0.123
20000 * 2000 | 1.643 | 0.155
10000 * 3000 | 1.231 | 0.116
12000 * 3000 | 1.507 | 0.140
15000 * 3000 | 2.034 | 0.174
20000 * 3000 | 3.184 | 0.231

<details>
<summary>script</summary>

```python

import numpy as np
import cupy as cp
import cupyx

n_repeat = 2
n_warmup = 1
crng = cp.random.default_rng()
nrng = np.random.default_rng()

def get_time(perf):
    cpu_time = perf.cpu_times.mean()
    gpu_time = perf.gpu_times.mean()
    return max(cpu_time, gpu_time)

def run(p, q):
    times = []

    perf = cupyx.time.repeat(nrng.logseries, (p,),
                            n_repeat=n_repeat, n_warmup=n_warmup)
    times.append(get_time(perf))
    perf = cupyx.time.repeat(crng.logseries, (q,),
                            n_repeat=n_repeat, n_warmup=n_warmup)
    times.append(get_time(perf))
    return times


print('size(nrows * ncols) | numpy (sec) | cupyx (sec)')
print('---|---|---')
nrows = [10000, 12000, 15000, 20000]
ncols = [1, 1000, 2000, 3000]
for m in ncols:
    for n in nrows:
        p = np.random.random((n, m))
        q = cp.asarray(p)
        times = run(p, q)
        print('{} * {} | {:.3f} | {:.3f}'.format(n, m, times[0], times[1]))
```