### PR TITLE
Allow to compile using PTX with an envvar

### DIFF
--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -160,10 +160,8 @@ def _get_arch_for_options_for_nvrtc(arch=None):
     # generate cubin (SASS) instead of PTX. See #5097 for details.
     if arch is None:
         arch = _get_arch()
-    use_ptx = _get_bool_env_variable(
-        'CUPY_COMPILE_WITH_PTX', False)
     if (
-        not use_ptx and _cuda_hip_version >= 11010
+        not _use_ptx and _cuda_hip_version >= 11010
         and arch < _get_max_compute_capability()
     ):
         return f'-arch=sm_{arch}', 'cubin'
@@ -217,6 +215,7 @@ def _get_bool_env_variable(name, default):
         return False
 
 
+_use_ptx = _get_bool_env_variable('CUPY_COMPILE_WITH_PTX', False)
 _jitify_header_source_map_populated = False
 
 

--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -160,7 +160,12 @@ def _get_arch_for_options_for_nvrtc(arch=None):
     # generate cubin (SASS) instead of PTX. See #5097 for details.
     if arch is None:
         arch = _get_arch()
-    if _cuda_hip_version >= 11010 and arch < _get_max_compute_capability():
+    use_ptx = _get_bool_env_variable(
+        'CUPY_COMPILE_WITH_PTX', False)
+    if (
+        not use_ptx and _cuda_hip_version >= 11010
+        and arch < _get_max_compute_capability()
+    ):
         return f'-arch=sm_{arch}', 'cubin'
     return f'-arch=compute_{arch}', 'ptx'
 

--- a/docs/source/reference/environment.rst
+++ b/docs/source/reference/environment.rst
@@ -118,7 +118,7 @@ Here are the environment variables that CuPy uses at runtime.
 
   By default, CuPy directly compiles kernels into SASS (CUBIN) to support `CUDA Enhanced Compatibility <https://docs.nvidia.com/deploy/cuda-compatibility/>`_
   If set to ``1``, CuPy instead compiles kernels into PTX and lets CUDA Driver assemble SASS from PTX.
-  This option is only effective for CUDA 11.1 or later; CuPy always compiles into PTX on earlier CUDA versions. Also, this option only applies when NVRTC is selected as the compilation backend.
+  This option is only effective for CUDA 11.1 or later; CuPy always compiles into PTX on earlier CUDA versions. Also, this option only applies when NVRTC is selected as the compilation backend. NVCC backend always compiles into SASS (CUBIN).
 
 CUDA Toolkit Environment Variables
   In addition to the environment variables listed above, as in any CUDA programs, all of the CUDA environment variables listed in the `CUDA Toolkit Documentation`_ will also be honored.

--- a/docs/source/reference/environment.rst
+++ b/docs/source/reference/environment.rst
@@ -116,8 +116,9 @@ Here are the environment variables that CuPy uses at runtime.
 
   Default: ``0``
 
-  If set to ``1``, CuPy will compile kernels using PTX instead of SSAS (CUBIN), PTX results in faster compilation time at the expenses of non-compatibility with drivers older than the toolkit.
-  If set to ``0`` (default), SASS (CUBIN) compilation mode is used for kernels.
+  By default, CuPy directly compiles kernels into SASS (CUBIN) to support `CUDA Enhanced Compatibility <https://docs.nvidia.com/deploy/cuda-compatibility/>`_
+  If set to ``1``, CuPy instead compiles kernels into PTX and lets CUDA Driver assemble SASS from PTX.
+  This option is only effective for CUDA 11.1 or later; CuPy always compiles into PTX on earlier CUDA versions. Also, this option only applies when NVRTC is selected as the compilation backend.
 
 CUDA Toolkit Environment Variables
   In addition to the environment variables listed above, as in any CUDA programs, all of the CUDA environment variables listed in the `CUDA Toolkit Documentation`_ will also be honored.

--- a/docs/source/reference/environment.rst
+++ b/docs/source/reference/environment.rst
@@ -112,6 +112,13 @@ Here are the environment variables that CuPy uses at runtime.
   If set to ``1``, CuPy will use the CUDA per-thread default stream, effectively causing each host thread to automatically execute in its own stream, unless the CUDA default (``null``) stream or a user-created stream is specified.
   If set to ``0`` (default), the CUDA default (``null``) stream is used, unless the per-thread default stream (``ptds``) or a user-created stream is specified.
 
+.. envvar:: CUPY_COMPILE_WITH_PTX
+
+  Default: ``0``
+
+  If set to ``1``, CuPy will compile kernels using PTX instead of SSAS (CUBIN), PTX results in faster compilation time at the expenses of non-compatibility with drivers older than the toolkit.
+  If set to ``0`` (default), SASS (CUBIN) compilation mode is used for kernels.
+
 CUDA Toolkit Environment Variables
   In addition to the environment variables listed above, as in any CUDA programs, all of the CUDA environment variables listed in the `CUDA Toolkit Documentation`_ will also be honored.
 

--- a/tests/cupy_tests/core_tests/test_raw.py
+++ b/tests/cupy_tests/core_tests/test_raw.py
@@ -634,8 +634,12 @@ class TestRaw(unittest.TestCase):
         N = 10
         inner_chunk = 2
         x = cupy.zeros((N,), dtype=cupy.float32)
-        if (self.backend == 'nvrtc' and not cupy.cuda.runtime.is_hip
-                and driver.get_build_version() < 11010):
+        use_ptx = os.environ.get(
+            'CUPY_COMPILE_WITH_PTX', False)
+        if (self.backend == 'nvrtc' and (
+                use_ptx or (
+                not cupy.cuda.runtime.is_hip
+                and driver.get_build_version() < 11010))):
             # raised when calling ls.complete()
             error = cupy.cuda.driver.CUDADriverError
         else:  # nvcc, hipcc, hiprtc


### PR DESCRIPTION
Seems like SASS (CUBIN) increases compilation times in a non-negligible amount (specially when running the test-suite).

Adds `CUPY_COMPILE_WITH_PTX` env var to explicitly request the older behavior.