### PR TITLE
Reload GPG key for ROCm 4.2 test

### DIFF
--- a/.pfnci/linux/tests/rocm-4-2.Dockerfile
+++ b/.pfnci/linux/tests/rocm-4-2.Dockerfile
@@ -1,5 +1,6 @@
 FROM rocm/dev-ubuntu-20.04:4.2
 
+RUN curl -qL https://repo.radeon.com/rocm/rocm.gpg.key | apt-key add -
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get -qqy update && \
     apt-get -qqy install rocm-dev hipblas hipfft hipsparse rocsparse rocrand rocthrust rocsolver rocfft hipcub rocprim rccl && \


### PR DESCRIPTION
ROCm 4.2 test stopped working as GPG key in Docker image expired.