### PR TITLE
Fix squareness checks

### DIFF
--- a/cupy/cublas.py
+++ b/cupy/cublas.py
@@ -36,7 +36,7 @@ def batched_gesv(a, b):
             The matrix with dimension ``(..., M)`` or ``(..., M, K)``.
     """
     _util._assert_cupy_array(a, b)
-    _util._assert_nd_squareness(a)
+    _util._assert_stacked_square(a)
 
     if not ((a.ndim == b.ndim or a.ndim == b.ndim + 1) and
             a.shape[:-1] == b.shape[:a.ndim - 1]):

--- a/cupy/cublas.py
+++ b/cupy/cublas.py
@@ -36,6 +36,7 @@ def batched_gesv(a, b):
             The matrix with dimension ``(..., M)`` or ``(..., M, K)``.
     """
     _util._assert_cupy_array(a, b)
+    _util._assert_stacked_2d(a)
     _util._assert_stacked_square(a)
 
     if not ((a.ndim == b.ndim or a.ndim == b.ndim + 1) and

--- a/cupy/linalg/_decomposition.py
+++ b/cupy/linalg/_decomposition.py
@@ -173,7 +173,7 @@ def cholesky(a):
     .. seealso:: :func:`numpy.linalg.cholesky`
     """
     _util._assert_cupy_array(a)
-    _util._assert_nd_squareness(a)
+    _util._assert_stacked_square(a)
 
     if a.ndim > 2:
         return _potrf_batched(a)

--- a/cupy/linalg/_decomposition.py
+++ b/cupy/linalg/_decomposition.py
@@ -173,6 +173,7 @@ def cholesky(a):
     .. seealso:: :func:`numpy.linalg.cholesky`
     """
     _util._assert_cupy_array(a)
+    _util._assert_stacked_2d(a)
     _util._assert_stacked_square(a)
 
     if a.ndim > 2:

--- a/cupy/linalg/_eigenvalue.py
+++ b/cupy/linalg/_eigenvalue.py
@@ -144,7 +144,7 @@ def eigvalsh(a, UPLO='L'):
     if a.ndim < 2:
         raise ValueError('Array must be at least two-dimensional')
 
-    _util._assert_nd_squareness(a)
+    _util._assert_stacked_square(a)
 
     if a.ndim > 2 or runtime.is_hip:
         return cupy.cusolver.syevj(a, UPLO, False)

--- a/cupy/linalg/_eigenvalue.py
+++ b/cupy/linalg/_eigenvalue.py
@@ -141,9 +141,7 @@ def eigvalsh(a, UPLO='L'):
 
     .. seealso:: :func:`numpy.linalg.eigvalsh`
     """
-    if a.ndim < 2:
-        raise ValueError('Array must be at least two-dimensional')
-
+    _util._assert_stacked_2d(a)
     _util._assert_stacked_square(a)
 
     if a.ndim > 2 or runtime.is_hip:

--- a/cupy/linalg/_norms.py
+++ b/cupy/linalg/_norms.py
@@ -238,7 +238,7 @@ def slogdet(a):
         msg = ('%d-dimensional array given. '
                'Array must be at least two-dimensional' % a.ndim)
         raise linalg.LinAlgError(msg)
-    _util._assert_nd_squareness(a)
+    _util._assert_stacked_square(a)
 
     dtype, sign_dtype = _util.linalg_common_type(a)
     logdet_dtype = numpy.dtype(sign_dtype.char.lower())

--- a/cupy/linalg/_norms.py
+++ b/cupy/linalg/_norms.py
@@ -1,5 +1,4 @@
 import numpy
-from numpy import linalg
 
 import cupy
 from cupy import _core
@@ -234,10 +233,7 @@ def slogdet(a):
 
     .. seealso:: :func:`numpy.linalg.slogdet`
     """
-    if a.ndim < 2:
-        msg = ('%d-dimensional array given. '
-               'Array must be at least two-dimensional' % a.ndim)
-        raise linalg.LinAlgError(msg)
+    _util._assert_stacked_2d(a)
     _util._assert_stacked_square(a)
 
     dtype, sign_dtype = _util.linalg_common_type(a)

--- a/cupy/linalg/_product.py
+++ b/cupy/linalg/_product.py
@@ -363,7 +363,7 @@ def matrix_power(M, n):
     ..seealso:: :func:`numpy.linalg.matrix_power`
     """
     _util._assert_cupy_array(M)
-    _util._assert_nd_squareness(M)
+    _util._assert_stacked_square(M)
     if not isinstance(n, int):
         raise TypeError('exponent must be an integer')
 

--- a/cupy/linalg/_product.py
+++ b/cupy/linalg/_product.py
@@ -363,6 +363,7 @@ def matrix_power(M, n):
     ..seealso:: :func:`numpy.linalg.matrix_power`
     """
     _util._assert_cupy_array(M)
+    _util._assert_stacked_2d(M)
     _util._assert_stacked_square(M)
     if not isinstance(n, int):
         raise TypeError('exponent must be an integer')

--- a/cupy/linalg/_solve.py
+++ b/cupy/linalg/_solve.py
@@ -44,7 +44,7 @@ def solve(a, b):
         return batched_gesv(a, b)
 
     _util._assert_cupy_array(a, b)
-    _util._assert_nd_squareness(a)
+    _util._assert_stacked_square(a)
 
     if not ((a.ndim == b.ndim or a.ndim == b.ndim + 1) and
             a.shape[:-1] == b.shape[:a.ndim - 1]):
@@ -243,7 +243,7 @@ def lstsq(a, b, rcond='warn'):
         rcond = -1
 
     _util._assert_cupy_array(a, b)
-    _util._assert_rank2(a)
+    _util._assert_2d(a)
     if b.ndim > 2:
         raise linalg.LinAlgError('{}-dimensional array given. Array must be at'
                                  ' most two-dimensional'.format(b.ndim))
@@ -307,8 +307,8 @@ def inv(a):
         return _batched_inv(a)
 
     _util._assert_cupy_array(a)
-    _util._assert_rank2(a)
-    _util._assert_nd_squareness(a)
+    _util._assert_2d(a)
+    _util._assert_stacked_square(a)
 
     dtype, out_dtype = _util.linalg_common_type(a)
     order = 'F' if a._f_contiguous else 'C'
@@ -326,7 +326,7 @@ def _batched_inv(a):
 
     assert(a.ndim >= 3)
     _util._assert_cupy_array(a)
-    _util._assert_nd_squareness(a)
+    _util._assert_stacked_square(a)
     dtype, out_dtype = _util.linalg_common_type(a)
 
     if dtype == cupy.float32:

--- a/cupy/linalg/_solve.py
+++ b/cupy/linalg/_solve.py
@@ -43,7 +43,9 @@ def solve(a, b):
         # large, so it is not used in such cases.
         return batched_gesv(a, b)
 
+    # TODO(kataoka): Move the checks to the beginning
     _util._assert_cupy_array(a, b)
+    _util._assert_stacked_2d(a)
     _util._assert_stacked_square(a)
 
     if not ((a.ndim == b.ndim or a.ndim == b.ndim + 1) and
@@ -244,6 +246,7 @@ def lstsq(a, b, rcond='warn'):
 
     _util._assert_cupy_array(a, b)
     _util._assert_2d(a)
+    # TODO(kataoka): Fix 0-dim
     if b.ndim > 2:
         raise linalg.LinAlgError('{}-dimensional array given. Array must be at'
                                  ' most two-dimensional'.format(b.ndim))
@@ -306,6 +309,7 @@ def inv(a):
     if a.ndim >= 3:
         return _batched_inv(a)
 
+    # TODO(kataoka): Move the checks to the beginning
     _util._assert_cupy_array(a)
     _util._assert_2d(a)
     _util._assert_stacked_square(a)
@@ -324,7 +328,7 @@ def inv(a):
 
 def _batched_inv(a):
 
-    assert(a.ndim >= 3)
+    assert a.ndim >= 3
     _util._assert_cupy_array(a)
     _util._assert_stacked_square(a)
     dtype, out_dtype = _util.linalg_common_type(a)

--- a/cupy/linalg/_util.py
+++ b/cupy/linalg/_util.py
@@ -12,6 +12,8 @@ import cupyx
 _default_precision = os.getenv('CUPY_DEFAULT_PRECISION')
 
 
+# The helper functions raise LinAlgError if the conditions are not met.
+
 def _assert_cupy_array(*arrays):
     for a in arrays:
         if not isinstance(a, cupy._core.ndarray):
@@ -36,6 +38,18 @@ def _assert_stacked_2d(*arrays):
 
 
 def _assert_stacked_square(*arrays):
+    """Assert that stacked matrices are square matrices
+
+    Precondition: `arrays` are at least 2d. The caller should assert it
+    beforehand. For example,
+
+    >>> def det(a):
+    ...     _assert_stacked_2d(a)
+    ...     _assert_stacked_square(a)
+    ...     ...
+
+    """
+
     for a in arrays:
         m, n = a.shape[-2:]
         if m != n:

--- a/cupy/linalg/_util.py
+++ b/cupy/linalg/_util.py
@@ -19,7 +19,7 @@ def _assert_cupy_array(*arrays):
                 'cupy.linalg only supports cupy.ndarray')
 
 
-def _assert_rank2(*arrays):
+def _assert_2d(*arrays):
     for a in arrays:
         if a.ndim != 2:
             raise linalg.LinAlgError(
@@ -27,9 +27,18 @@ def _assert_rank2(*arrays):
                 'two-dimensional'.format(a.ndim))
 
 
-def _assert_nd_squareness(*arrays):
+def _assert_stacked_2d(*arrays):
     for a in arrays:
-        if max(a.shape[-2:]) != min(a.shape[-2:]):
+        if a.ndim != 2:
+            raise linalg.LinAlgError(
+                '{}-dimensional array given. Array must be '
+                'at least two-dimensional'.format(a.ndim))
+
+
+def _assert_stacked_square(*arrays):
+    for a in arrays:
+        m, n = a.shape[-2:]
+        if m != n:
             raise linalg.LinAlgError(
                 'Last 2 dimensions of the array must be square')
 

--- a/cupy/linalg/_util.py
+++ b/cupy/linalg/_util.py
@@ -29,7 +29,7 @@ def _assert_2d(*arrays):
 
 def _assert_stacked_2d(*arrays):
     for a in arrays:
-        if a.ndim != 2:
+        if a.ndim < 2:
             raise linalg.LinAlgError(
                 '{}-dimensional array given. Array must be '
                 'at least two-dimensional'.format(a.ndim))

--- a/cupyx/lapack.py
+++ b/cupyx/lapack.py
@@ -282,7 +282,7 @@ def posv(a, b):
     """
 
     _cupy.linalg._util._assert_cupy_array(a, b)
-    _cupy.linalg._util._assert_nd_squareness(a)
+    _cupy.linalg._util._assert_stacked_square(a)
 
     if a.ndim > 2:
         return _batched_posv(a, b)

--- a/cupyx/lapack.py
+++ b/cupyx/lapack.py
@@ -281,8 +281,10 @@ def posv(a, b):
         x (cupy.ndarray): The solution (shape matches b).
     """
 
-    _cupy.linalg._util._assert_cupy_array(a, b)
-    _cupy.linalg._util._assert_stacked_square(a)
+    _util = _cupy.linalg._util
+    _util._assert_cupy_array(a, b)
+    _util._assert_stacked_2d(a)
+    _util._assert_stacked_square(a)
 
     if a.ndim > 2:
         return _batched_posv(a, b)

--- a/cupyx/linalg/_solve.py
+++ b/cupyx/linalg/_solve.py
@@ -18,10 +18,10 @@ def invh(a):
     """
 
     _util._assert_cupy_array(a)
-    _util._assert_stacked_square(a)
-
-    # TODO: Remove this assert once cusolver supports nrhs > 1 for potrsBatched
+    # TODO: Use `_assert_stacked_2d` instead, once cusolver supports nrhs > 1
+    # for potrsBatched
     _util._assert_2d(a)
+    _util._assert_stacked_square(a)
 
     n = a.shape[-1]
     identity_matrix = cupy.eye(n, dtype=a.dtype)

--- a/cupyx/linalg/_solve.py
+++ b/cupyx/linalg/_solve.py
@@ -18,10 +18,10 @@ def invh(a):
     """
 
     _util._assert_cupy_array(a)
-    _util._assert_nd_squareness(a)
+    _util._assert_stacked_square(a)
 
     # TODO: Remove this assert once cusolver supports nrhs > 1 for potrsBatched
-    _util._assert_rank2(a)
+    _util._assert_2d(a)
 
     n = a.shape[-1]
     identity_matrix = cupy.eye(n, dtype=a.dtype)

--- a/cupyx/linalg/sparse/_solve.py
+++ b/cupyx/linalg/sparse/_solve.py
@@ -27,6 +27,7 @@ def lschol(A, b):
 
     if not sparse.isspmatrix_csr(A):
         A = sparse.csr_matrix(A)
+    # csr_matrix is 2d
     _util._assert_stacked_square(A)
     _util._assert_cupy_array(b)
     m = A.shape[0]

--- a/cupyx/linalg/sparse/_solve.py
+++ b/cupyx/linalg/sparse/_solve.py
@@ -27,7 +27,7 @@ def lschol(A, b):
 
     if not sparse.isspmatrix_csr(A):
         A = sparse.csr_matrix(A)
-    _util._assert_nd_squareness(A)
+    _util._assert_stacked_square(A)
     _util._assert_cupy_array(b)
     m = A.shape[0]
     if b.ndim != 1 or len(b) != m:

--- a/cupyx/scipy/linalg/decomp_lu.py
+++ b/cupyx/scipy/linalg/decomp_lu.py
@@ -88,7 +88,7 @@ def lu(a, permute_l=False, overwrite_a=False, check_finite=True):
 
 def _lu_factor(a, overwrite_a=False, check_finite=True):
     a = cupy.asarray(a)
-    _util._assert_rank2(a)
+    _util._assert_2d(a)
 
     dtype = a.dtype
 
@@ -286,8 +286,8 @@ def lu_solve(lu_and_piv, b, trans=0, overwrite_b=False, check_finite=True):
     (lu, ipiv) = lu_and_piv
 
     _util._assert_cupy_array(lu)
-    _util._assert_rank2(lu)
-    _util._assert_nd_squareness(lu)
+    _util._assert_2d(lu)
+    _util._assert_stacked_square(lu)
 
     m = lu.shape[0]
     if m != b.shape[0]:

--- a/cupyx/scipy/sparse/csgraph/_traversal.py
+++ b/cupyx/scipy/sparse/csgraph/_traversal.py
@@ -1,6 +1,4 @@
 import cupy
-
-from cupy.linalg import _util
 import cupyx.scipy.sparse
 try:
     from cupy_backends.cuda.libs import cugraph
@@ -40,10 +38,14 @@ def connected_components(csgraph, directed=True, connection='weak',
     if not directed:
         connection = 'weak'
 
+    if csgraph.ndim != 2:
+        raise ValueError('graph should have two dimensions')
+
     if not cupyx.scipy.sparse.isspmatrix_csr(csgraph):
         csgraph = cupyx.scipy.sparse.csr_matrix(csgraph)
-    _util._assert_stacked_square(csgraph)
-    m = csgraph.shape[0]
+    m, m1 = csgraph.shape
+    if m != m1:
+        raise ValueError('graph should be a square array')
     if csgraph.nnz == 0:
         return m, cupy.arange(m, dtype=csgraph.indices.dtype)
     labels = cupy.empty(m, dtype=csgraph.indices.dtype)

--- a/cupyx/scipy/sparse/csgraph/_traversal.py
+++ b/cupyx/scipy/sparse/csgraph/_traversal.py
@@ -42,7 +42,7 @@ def connected_components(csgraph, directed=True, connection='weak',
 
     if not cupyx.scipy.sparse.isspmatrix_csr(csgraph):
         csgraph = cupyx.scipy.sparse.csr_matrix(csgraph)
-    _util._assert_nd_squareness(csgraph)
+    _util._assert_stacked_square(csgraph)
     m = csgraph.shape[0]
     if csgraph.nnz == 0:
         return m, cupy.arange(m, dtype=csgraph.indices.dtype)

--- a/cupyx/scipy/sparse/linalg/_solve.py
+++ b/cupyx/scipy/sparse/linalg/_solve.py
@@ -47,6 +47,7 @@ def lsqr(A, b):
         raise RuntimeError('HIP does not support lsqr')
     if not sparse.isspmatrix_csr(A):
         A = sparse.csr_matrix(A)
+    # csr_matrix is 2d
     _util._assert_stacked_square(A)
     _util._assert_cupy_array(b)
     m = A.shape[0]

--- a/cupyx/scipy/sparse/linalg/_solve.py
+++ b/cupyx/scipy/sparse/linalg/_solve.py
@@ -47,7 +47,7 @@ def lsqr(A, b):
         raise RuntimeError('HIP does not support lsqr')
     if not sparse.isspmatrix_csr(A):
         A = sparse.csr_matrix(A)
-    _util._assert_nd_squareness(A)
+    _util._assert_stacked_square(A)
     _util._assert_cupy_array(b)
     m = A.shape[0]
     if b.ndim != 1 or len(b) != m:


### PR DESCRIPTION
Fix bugs caused by the fact that `_assert_nd_squareness` does not assert the inputs are at least 2d.

```
>>> for xp in (numpy, cupy):
...  try: xp.linalg.cholesky(xp.ones(()))
...  except Exception: traceback.print_exc(limit=0)
...
numpy.linalg.LinAlgError: 0-dimensional array given. Array must be at least two-dimensional
ValueError: max() arg is an empty sequence
>>> for xp in (numpy, cupy):
...  try: xp.linalg.eigh(xp.ones(()))
...  except Exception: traceback.print_exc(limit=0)
...
numpy.linalg.LinAlgError: 0-dimensional array given. Array must be at least two-dimensional
ValueError: Array must be at least two-dimensional
```

`scipy.sparse.csgraph`, on the other hand, should not raise `LinAlgError`.
```
>>> scipy.sparse.csgraph.connected_components(numpy.ones((3, 2)))
ValueError: graph should be a square array
```

This PR also fixes the names of the assertions (see numpy/numpy#14814).