### PR TITLE
Add Dirichlet distribution to Generator

### DIFF
--- a/cupy/random/_generator_api.pyx
+++ b/cupy/random/_generator_api.pyx
@@ -319,6 +319,51 @@ class Generator:
         y *= 2
         return y
 
+    def dirichlet(self, alpha, size=None):
+        """Dirichlet distribution.
+
+        Returns an array of samples drawn from the dirichlet distribution. Its
+        probability density function is defined as
+
+        .. math::
+            f(x) = \\frac{\\Gamma(\\sum_{i=1}^K\\alpha_i)} \
+                {\\prod_{i=1}^{K}\\Gamma(\\alpha_i)} \
+                \\prod_{i=1}^Kx_i^{\\alpha_i-1}.
+
+        Args:
+            alpha (array): Parameters of the dirichlet distribution
+                :math:`\\alpha`.
+            size (int or tuple of ints): The shape of the array. If ``None``,
+                array of ``alpha.shape`` is generated
+
+        Returns:
+            cupy.ndarray: Samples drawn from the dirichlet distribution.
+
+        .. seealso::
+            :meth:`numpy.random.Generator.dirichlet`
+        """
+
+        if not isinstance(alpha, ndarray):
+            if type(alpha) in (float, int):
+                alpha = cupy.asarray(alpha, numpy.float64)
+            else:
+                raise TypeError('alpha is required to be a cupy.ndarray'
+                                ' or a scalar')
+        else:
+            alpha = alpha.astype('d', copy=False)
+
+        if size is not None:
+            if not isinstance(size, tuple):
+                size = (size,)
+            size += alpha.shape
+
+        elif size is None:
+            size = alpha.shape
+
+        y = self.standard_gamma(alpha, size)
+        y /= y.sum(axis=-1, keepdims=True)
+        return y
+
     def exponential(self, scale=1.0, size=None):
         """Exponential distribution.
 

--- a/tests/cupy_tests/random_tests/common_distributions.py
+++ b/tests/cupy_tests/random_tests/common_distributions.py
@@ -415,3 +415,28 @@ class Chisquare:
             self.skipTest('Statistical checks only for scalar `df`')
         self.check_ks(0.05)(
             df=self.df, size=2000)
+
+
+dirichlet_params = [
+    {'alpha': 5},
+    {'alpha': 1},
+    {'alpha': [2, 5, 8]}
+]
+
+
+class Dirichlet:
+    target_method = 'dirichlet'
+
+    def test_dirichlet(self):
+        alpha = self.alpha
+        if not isinstance(self.alpha, float):
+            alpha = cupy.array(self.alpha)
+        self.generate(alpha=alpha, size=(3, 2))
+
+    def test_dirichlet_int_shape(self):
+        alpha = self.alpha
+        if not isinstance(self.alpha, int):
+            alpha = cupy.array(self.alpha)
+        self.generate(alpha=alpha, size=5)
+
+    # TODO(kataoka): add distribution test

--- a/tests/cupy_tests/random_tests/test_generator.py
+++ b/tests/cupy_tests/random_tests/test_generator.py
@@ -195,23 +195,13 @@ class TestChisquare(
     pass
 
 
-@testing.gpu
-@testing.parameterize(
-    {'alpha': cupy.array([1.0, 1.0, 1.0])},
-    {'alpha': cupy.array([1.0, 3.0, 5.0])},
-)
+@testing.parameterize(*common_distributions.dirichlet_params)
 @testing.fix_random()
-class TestDirichlet(RandomGeneratorTestCase):
-
-    target_method = 'dirichlet'
-
-    def test_dirichlet(self):
-        self.generate(alpha=self.alpha, size=(3, 2, 3))
-
-    def test_dirichlet_int_shape(self):
-        self.generate(alpha=self.alpha, size=5)
-
-    # TODO(kataoka): add distribution test
+class TestDirichlet(
+    common_distributions.Dirichlet,
+    RandomGeneratorTestCase
+):
+    pass
 
 
 @testing.parameterize(*common_distributions.exponential_params)

--- a/tests/cupy_tests/random_tests/test_generator_api.py
+++ b/tests/cupy_tests/random_tests/test_generator_api.py
@@ -338,3 +338,12 @@ class TestChisquare(
     GeneratorTestCase
 ):
     pass
+
+
+@testing.parameterize(*common_distributions.dirichlet_params)
+@testing.fix_random()
+class TestDrichlet(
+    common_distributions.Dirichlet,
+    GeneratorTestCase
+):
+    pass


### PR DESCRIPTION
This PR adds Dirichlet distribution to Generator.

Following is the performance comparison on GTX1050.
(The comparison was done only for flattened shape as numpy does not support multi-dimension alpha as input)

size | numpy | cupy 
---|---|---
10000 | 0.001 | 0.001
12000 | 0.002 | 0.001
15000 | 0.002 | 0.001
25000 | 0.002 | 0.001
10000000 | 0.562 | 0.305
12000000 | 0.665 | 0.367
15000000 | 0.830 | 0.459
20000000 | 1.106 | 0.623
24000000 | 1.327 | 0.736
25000000 | 1.381 | 0.764
30000000 | 1.785 | 0.962
36000000 | 2.018 | 1.110
45000000 | 2.639 | 1.439
50000000 | 2.798 | 1.579
75000000 | 6.607 | 2.456

<details>
<summary>script</summary>

```python
import numpy as np
import cupy as cp
import cupyx

n_repeat = 2
n_warmup = 1
crng = cp.random.default_rng()
nrng = np.random.default_rng()

def get_time(perf):
    cpu_time = perf.cpu_times.mean()
    gpu_time = perf.gpu_times.mean()
    return max(cpu_time, gpu_time)

def run(p, q):
    times = []

    perf = cupyx.time.repeat(nrng.dirichlet, (p,),
                            n_repeat=n_repeat, n_warmup=n_warmup)
    times.append(get_time(perf))
    perf = cupyx.time.repeat(crng.dirichlet, (q,),
                            n_repeat=n_repeat, n_warmup=n_warmup)
    times.append(get_time(perf))
    return times


print('size | numpy | cupy ')
print('---|---|---')
nrows = [10000, 12000, 15000, 25000]
ncols = [1, 1000, 2000, 3000]
for m in ncols:
    for n in nrows:
        p = np.random.random( n*m )
        q = cp.asarray(p)
        times = run(p, q)
        print('{} | {:.3f} | {:.3f}'.format(n * m, times[0], times[1]))
```