### PR TITLE
Fix branch name of cuda-python

### DIFF
--- a/.pfnci/linux/tests/cuda11x-cuda-python.sh
+++ b/.pfnci/linux/tests/cuda11x-cuda-python.sh
@@ -8,6 +8,6 @@ export CUPY_USE_CUDA_PYTHON="1"
 . "$(dirname $0)/_environment.sh"
 
 python3 -m pip install --user Cython
-python3 -m pip install --user https://github.com/NVIDIA/cuda-python/archive/refs/heads/master.tar.gz
+python3 -m pip install --user https://github.com/NVIDIA/cuda-python/archive/refs/heads/main.tar.gz
 
 bash "$(dirname $0)/_build_and_test.sh" "not slow"


### PR DESCRIPTION
Branch name seems changed from `master` to `main` 😅 