### PR TITLE
Add F distribution to Generator

### DIFF
--- a/cupy/random/_generator_api.pyx
+++ b/cupy/random/_generator_api.pyx
@@ -342,6 +342,58 @@ class Generator:
         """
         return self.standard_exponential(size) * scale
 
+    def f(self, dfnum, dfden, size=None):
+        """F distribution.
+
+        Returns an array of samples drawn from the f distribution. Its
+        probability density function is defined as
+
+        .. math::
+            f(x) = \\frac{1}{B(\\frac{d_1}{2},\\frac{d_2}{2})} \
+                \\left(\\frac{d_1}{d_2}\\right)^{\\frac{d_1}{2}} \
+                x^{\\frac{d_1}{2}-1} \
+                \\left(1+\\frac{d_1}{d_2}x\\right) \
+                ^{-\\frac{d_1+d_2}{2}}.
+
+        Args:
+            dfnum (float or array_like of floats): Degrees of freedom in
+                numerator, :math:`d_1`.
+            dfden (float or array_like of floats): Degrees of freedom in
+                denominator, :math:`d_2`.
+            size (int or tuple of ints): The shape of the array. If ``None``, a
+                zero-dimensional array is generated.
+
+        Returns:
+            cupy.ndarray: Samples drawn from the f distribution.
+
+        .. seealso::
+            :meth:`numpy.random.Generator.f`
+        """
+        if not isinstance(dfnum, ndarray):
+            if type(dfnum) in (float, int):
+                dfnum = cupy.asarray(dfnum, numpy.float64)
+            else:
+                raise TypeError('dfnum is required to be a cupy.ndarray'
+                                ' or a scalar')
+        else:
+            dfnum = dfnum.astype('d', copy=False)
+
+        if not isinstance(dfden, ndarray):
+            if type(dfden) in (float, int):
+                dfden = cupy.asarray(dfden, numpy.float64)
+            else:
+                raise TypeError('dfden is required to be a cupy.ndarray'
+                                ' or a scalar')
+        else:
+            dfden = dfden.astype('d', copy=False)
+
+        if size is None:
+            size = cupy.broadcast(dfnum, dfden).shape
+
+        y = (self.chisquare(dfnum, size) * dfden) / (
+            self.chisquare(dfden, size) * dfnum)
+        return y
+
     def geometric(self, p, size=None):
         """Geometric distribution.
 

--- a/tests/cupy_tests/random_tests/common_distributions.py
+++ b/tests/cupy_tests/random_tests/common_distributions.py
@@ -415,3 +415,30 @@ class Chisquare:
             self.skipTest('Statistical checks only for scalar `df`')
         self.check_ks(0.05)(
             df=self.df, size=2000)
+
+
+f_params = [
+    {'dfnum': 1.0, 'dfden': 3.0},
+    {'dfnum': 3.0, 'dfden': 3.0},
+    {'dfnum': 3.0, 'dfden': 1.0},
+    {'dfnum': [1.0, 3.0, 3.0], 'dfden': [3.0, 3.0, 1.0]},
+]
+
+
+class F:
+
+    target_method = 'f'
+
+    def test_f(self):
+        dfnum = self.dfnum
+        dfden = self.dfden
+        if isinstance(self.dfnum, list) or isinstance(self.dfden, list):
+            dfnum = cupy.array(self.dfnum)
+            dfden = cupy.array(self.dfden)
+        self.generate(dfnum, dfden)
+
+    @_condition.repeat_with_success_at_least(10, 3)
+    def test_f_ks(self):
+        if isinstance(self.dfnum, list) or isinstance(self.dfden, list):
+            self.skipTest('Stastical checks only for scalar args')
+        self.check_ks(0.05)(self.dfnum, self.dfden, size=2000)

--- a/tests/cupy_tests/random_tests/test_generator.py
+++ b/tests/cupy_tests/random_tests/test_generator.py
@@ -224,25 +224,13 @@ class TestExponential(
     pass
 
 
-@testing.parameterize(
-    {'dfnum': 1.0, 'dfden': 3.0},
-    {'dfnum': 3.0, 'dfden': 3.0},
-    {'dfnum': 3.0, 'dfden': 1.0},
-)
-@testing.gpu
+@testing.parameterize(*common_distributions.f_params)
 @testing.fix_random()
-class TestF(RandomGeneratorTestCase):
-
-    target_method = 'f'
-
-    def test_f(self):
-        self.generate(dfnum=self.dfnum, dfden=self.dfden, size=(3, 2))
-
-    @testing.for_dtypes('fd')
-    @_condition.repeat_with_success_at_least(10, 3)
-    def test_f_ks(self, dtype):
-        self.check_ks(0.05)(
-            self.dfnum, self.dfden, size=2000, dtype=dtype)
+class TestF(
+    common_distributions.F,
+    RandomGeneratorTestCase
+):
+    pass
 
 
 @testing.parameterize(*common_distributions.gamma_params)

--- a/tests/cupy_tests/random_tests/test_generator_api.py
+++ b/tests/cupy_tests/random_tests/test_generator_api.py
@@ -338,3 +338,12 @@ class TestChisquare(
     GeneratorTestCase
 ):
     pass
+
+
+@testing.parameterize(*common_distributions.f_params)
+@testing.fix_random()
+class TestF(
+    common_distributions.F,
+    GeneratorTestCase
+):
+    pass


### PR DESCRIPTION
This PR add F distribution to Generator.

Following is the performance comparison on GTX1050.

size(nrows * ncols) | numpy | cupy 
--- | --- | ---
10000 * 1 | 0.001 | 0.001
12000 * 1 | 0.001 | 0.001
15000 * 1 | 0.002 | 0.001
10000 * 1000 | 0.971 | 0.293
12000 * 1000 | 1.158 | 0.348
15000 * 1000 | 1.448 | 0.432
10000 * 2000 | 1.939 | 0.624
12000 * 2000 | 2.382 | 0.698
15000 * 2000 | 3.063 | 0.868
10000 * 3000 | 3.158 | 0.867
12000 * 3000 | 5.043 | 1.071
15000 * 3000 | 5.187 | 1.303

<details>
<summary>script</summary>

```python
import numpy as np
import cupy as cp
import cupyx

n_repeat = 2
n_warmup = 1
crng = cp.random.default_rng()
nrng = np.random.default_rng()

def get_time(perf):
    cpu_time = perf.cpu_times.mean()
    gpu_time = perf.gpu_times.mean()
    return max(cpu_time, gpu_time)

def run(dfn, dfd, dfn1, dfd1):
    times = []

    perf = cupyx.time.repeat(nrng.f,
                             (dfn, dfd),
                             n_repeat=n_repeat, n_warmup=n_warmup)
    times.append(get_time(perf))
    perf = cupyx.time.repeat(crng.f,
                             (dfn1, dfd1),
                             n_repeat=n_repeat, n_warmup=n_warmup)
    times.append(get_time(perf))
    return times


print('size(nrows * ncols) | numpy | cupy ')
print('---|---|---')
nrows = [10000, 12000, 15000]
ncols = [1, 1000, 2000, 3000]
for m in ncols:
    for n in nrows:
        dfnum = np.random.random((n,m))
        dfden = np.random.random((n,m))
        dfnum1 = cp.asarray(dfnum)
        dfden1 = cp.asarray(dfden)
        times = run(dfnum, dfden, dfnum1, dfden1)
        print('{} * {} | {:.3f} | {:.3f}'.format(n, m, times[0], times[1]))
```