### PR TITLE
Rest of version check fix for new ROCm version definition

### DIFF
--- a/cupy/fft/_fft.py
+++ b/cupy/fft/_fft.py
@@ -87,8 +87,11 @@ def _exec_fft(a, direction, value_type, norm, axis, overwrite_x,
 
     if a.base is not None or not a.flags.c_contiguous:
         a = a.copy()
-    elif (value_type == 'C2R' and not overwrite_x and
-            10010 <= cupy.cuda.runtime.runtimeGetVersion()):
+    elif (
+        not cupy.cuda.runtime.is_hip and
+        value_type == 'C2R' and not overwrite_x and
+        10010 <= cupy.cuda.runtime.runtimeGetVersion()
+    ):
         # The input array may be modified in CUDA 10.1 and above.
         # See #3763 for the discussion.
         a = a.copy()

--- a/tests/cupy_tests/core_tests/fusion_tests/fusion_utils.py
+++ b/tests/cupy_tests/core_tests/fusion_tests/fusion_utils.py
@@ -138,6 +138,7 @@ def check_fusion(
 
 def can_use_grid_synchronization():
     return (
+        not cupy.cuda.runtime.is_hip and
         cupy.cuda.runtime.runtimeGetVersion() >= 9000 and
         int(cupy.cuda.device.get_compute_capability()) >= 70
     )

--- a/tests/cupy_tests/core_tests/test_raw.py
+++ b/tests/cupy_tests/core_tests/test_raw.py
@@ -1093,6 +1093,7 @@ void test_grid_sync(const float* x1, const float* x2, float* y, int n) {
 @unittest.skipUnless(
     60 <= int(cupy.cuda.device.get_compute_capability()),
     'Requires compute capability 6.0 or later')
+@unittest.skipIf(cupy.cuda.runtime.is_hip, 'Skip on HIP')
 class TestRawGridSync(unittest.TestCase):
 
     def test_grid_sync_rawkernel(self):

--- a/tests/cupy_tests/cuda_tests/test_compiler.py
+++ b/tests/cupy_tests/cuda_tests/test_compiler.py
@@ -11,7 +11,7 @@ def cuda_version():
     return cupy.cuda.runtime.runtimeGetVersion()
 
 
-@testing.gpu
+@unittest.skipIf(cupy.cuda.runtime.is_hip, 'CUDA specific tests')
 class TestNvrtcArch(unittest.TestCase):
     def setUp(self):
         cupy.clear_memo()  # _get_arch result is cached

--- a/tests/cupyx_tests/jit_tests/test_raw.py
+++ b/tests/cupyx_tests/jit_tests/test_raw.py
@@ -442,8 +442,11 @@ class TestRaw(unittest.TestCase):
     @testing.for_dtypes('iILQ' if runtime.is_hip else 'iHILQ')
     def test_atomic_cas(self, dtype):
         if dtype == cupy.uint16:
-            if (runtime.runtimeGetVersion() < 10010 or
-                    int(device.get_compute_capability()) < 70):
+            if (
+                runtime.is_hip or
+                runtime.runtimeGetVersion() < 10010 or
+                int(device.get_compute_capability()) < 70
+            ):
                 self.skipTest('not supported')
 
         @jit.rawkernel()

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
@@ -599,7 +599,7 @@ class TestCscMatrixScipyComparison(unittest.TestCase):
             HIP_version = driver.get_build_version()
             if HIP_version < 400:
                 pytest.skip('no working implementation')
-            elif HIP_version <= 402:
+            elif HIP_version < 40400000:
                 # I got HIPSPARSE_STATUS_INTERNAL_ERROR...
                 pytest.xfail('spmv is buggy (trans=True)')
 
@@ -612,7 +612,7 @@ class TestCscMatrixScipyComparison(unittest.TestCase):
             HIP_version = driver.get_build_version()
             if HIP_version < 400:
                 pytest.skip('no working implementation')
-            elif HIP_version <= 402:
+            elif HIP_version < 40400000:
                 # I got HIPSPARSE_STATUS_INTERNAL_ERROR...
                 pytest.xfail('spmv is buggy (trans=True)')
 
@@ -801,7 +801,7 @@ class TestCscMatrixScipyComparison(unittest.TestCase):
             HIP_version = driver.get_build_version()
             if HIP_version < 400:
                 pytest.skip('no working implementation')
-            elif HIP_version <= 402:
+            elif HIP_version < 40400000:
                 # I got HIPSPARSE_STATUS_INTERNAL_ERROR...
                 pytest.xfail('spmv is buggy (trans=True)')
 
@@ -1120,7 +1120,7 @@ class TestCscMatrixSum(unittest.TestCase):
             HIP_version = driver.get_build_version()
             if HIP_version < 400:
                 pytest.skip('no working implementation')
-            elif HIP_version <= 402:
+            elif HIP_version < 40400000:
                 # I got HIPSPARSE_STATUS_INTERNAL_ERROR...
                 pytest.xfail('spmv is buggy (trans=True)')
 
@@ -1317,7 +1317,7 @@ class TestCscMatrixData(unittest.TestCase):
             HIP_version = driver.get_build_version()
             if HIP_version < 400:
                 pytest.skip('no working implementation')
-            elif HIP_version <= 402:
+            elif HIP_version < 40400000:
                 # I got HIPSPARSE_STATUS_INTERNAL_ERROR...
                 pytest.xfail('spmv is buggy (trans=True)')
 
@@ -1335,7 +1335,7 @@ class TestCscMatrixData(unittest.TestCase):
             HIP_version = driver.get_build_version()
             if HIP_version < 400:
                 pytest.skip('no working implementation')
-            elif HIP_version <= 402:
+            elif HIP_version < 40400000:
                 # I got HIPSPARSE_STATUS_INTERNAL_ERROR...
                 pytest.xfail('spmv is buggy (trans=True)')
 
@@ -1348,7 +1348,7 @@ class TestCscMatrixData(unittest.TestCase):
             HIP_version = driver.get_build_version()
             if HIP_version < 400:
                 pytest.skip('no working implementation')
-            elif HIP_version <= 402:
+            elif HIP_version < 40400000:
                 # I got HIPSPARSE_STATUS_INTERNAL_ERROR...
                 pytest.xfail('spmv is buggy (trans=True)')
 

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -1293,7 +1293,7 @@ class TestCsrMatrixSum(unittest.TestCase):
             HIP_version = driver.get_build_version()
             if HIP_version < 400:
                 pytest.skip('no working implementation')
-            elif HIP_version <= 402:
+            elif HIP_version < 40400000:
                 # I got HIPSPARSE_STATUS_INTERNAL_ERROR...
                 pytest.xfail('spmv is buggy (trans=True)')
 
@@ -1515,7 +1515,7 @@ class TestCsrMatrixData(unittest.TestCase):
             HIP_version = driver.get_build_version()
             if HIP_version < 400:
                 pytest.skip('no working implementation')
-            elif HIP_version <= 402:
+            elif HIP_version < 40400000:
                 # I got HIPSPARSE_STATUS_INTERNAL_ERROR...
                 pytest.xfail('spmv is buggy (trans=True)')
 
@@ -1538,7 +1538,7 @@ class TestCsrMatrixData(unittest.TestCase):
             HIP_version = driver.get_build_version()
             if HIP_version < 400:
                 pytest.skip('no working implementation')
-            elif HIP_version <= 402:
+            elif HIP_version < 40400000:
                 # I got HIPSPARSE_STATUS_INTERNAL_ERROR...
                 pytest.xfail('spmv is buggy (trans=True)')
 

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_dia.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_dia.py
@@ -325,7 +325,7 @@ class TestDiaMatrixSum(unittest.TestCase):
     def setUp(self):
         if runtime.is_hip and self.axis in (0, -2):
             HIP_version = driver.get_build_version()
-            if HIP_version <= 402:
+            if HIP_version < 40400000:
                 # internally a temporary CSC matrix is generated and thus
                 # casues problems (see test_csc.py)
                 pytest.xfail('spmv is buggy (trans=True)')


### PR DESCRIPTION
Succeeding #5657. Rel #5592, especially https://github.com/cupy/cupy/issues/5592#issuecomment-900813721.

This PR fixes version checks for the new ROCM version definition. I looked up all the lines to fix by:
```
$ find . -name '*.py' -or -name '*.pyx' | xargs grep 'runtimeGetVersion\|driverGetVersion\|get_build_version' -n`
```
