### PR TITLE
Add a workaround for ROCm 4.3.0 for testing

### DIFF
--- a/.pfnci/linux/tests/rocm-4-3.Dockerfile
+++ b/.pfnci/linux/tests/rocm-4-3.Dockerfile
@@ -11,6 +11,11 @@ ENV LD_LIBRARY_PATH="${ROCM_HOME}/lib"
 ENV CPATH="${ROCM_HOME}/include"
 ENV LDFLAGS="-L${ROCM_HOME}/lib"
 
+# In ROCm 4.3, hiprtc has a problem that it can not find a header file related
+# to LLVM/clang. As a workaround, we temporarily give LLVM_PATH here. See
+# #5592.
+ENV LLVM_PATH="${ROCM_HOME}/llvm"
+
 # Python 3.8
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get -qqy install python3 python3-dev python3-pip python3-setuptools && \


### PR DESCRIPTION
See https://github.com/cupy/cupy/issues/5592#issuecomment-901136342.

This PR adds a workaround for ROCm 4.3 CI.