### PR TITLE
[WIP] Use `cudaRuntimeGetVersion` instead of `CUDA_VERSION` for CUDA Python support

### DIFF
--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -108,10 +108,10 @@ cdef class Memory(BaseMemory):
 
 
 cdef inline void check_async_alloc_supported(int device_id) except*:
-    if CUDA_VERSION < 11020:
-        raise RuntimeError("memory_async is supported since CUDA 11.2")
     if runtime._is_hip_environment:
         raise RuntimeError('HIP does not support memory_async')
+    if runtime.runtimeGetVersion() < 11020:
+        raise RuntimeError("memory_async is supported since CUDA 11.2")
     cdef int dev_id
     cdef list support
     try:

--- a/cupy_backends/cuda/api/_runtime_enum.pxd
+++ b/cupy_backends/cuda/api/_runtime_enum.pxd
@@ -200,6 +200,7 @@ IF HIP_VERSION > 0:
         # cudaDevAttrMaxSharedMemoryPerBlockOptin
         # cudaDevAttrCanFlushRemoteWrites
         # cudaDevAttrHostRegisterSupported
+        cudaDevAttrMemoryPoolsSupported = -1  # not supported
     IF HIP_VERSION >= 310:
         cpdef enum:
             # hipDeviceAttributeAsicRevision  # does not exist in CUDA

--- a/cupy_backends/cuda/api/driver.pyx
+++ b/cupy_backends/cuda/api/driver.pyx
@@ -276,8 +276,6 @@ cpdef int funcGetAttribute(int attribute, intptr_t f) except? -2:
 
 
 cpdef funcSetAttribute(intptr_t f, int attribute, int value):
-    if CUDA_VERSION < 9000:
-        raise RuntimeError("Your CUDA does not support cuFuncSetAttribute.")
     with nogil:
         status = cuFuncSetAttribute(
             <Function> f,

--- a/cupy_backends/cuda/cupy_cuda_runtime.h
+++ b/cupy_backends/cuda/cupy_cuda_runtime.h
@@ -12,6 +12,46 @@ bool hip_environment = false;
 const int cudaErrorContextIsDestroyed = 709;
 #endif
 
+#if CUDA_VERSION < 11020
+
+typedef void* cudaMemPool_t;
+enum cudaMemPoolAttr {};
+
+cudaError_t cudaDeviceGetDefaultMemPool(...) {
+    return cudaSuccess;
+}
+
+cudaError_t cudaDeviceGetMemPool(...) {
+    return cudaSuccess;
+}
+
+cudaError_t cudaDeviceSetMemPool(...) {
+    return cudaSuccess;
+}
+
+cudaError_t cudaFreeAsync(...) {
+    return cudaSuccess;
+}
+
+cudaError_t cudaMallocAsync(...) {
+    return cudaSuccess;
+}
+
+cudaError_t cudaMemPoolTrimTo(...) {
+    return cudaSuccess;
+}
+
+cudaError_t cudaMemPoolGetAttribute(...) {
+    return cudaSuccess;
+}
+
+cudaError_t cudaMemPoolSetAttribute(...) {
+    return cudaSuccess;
+}
+
+#endif
+
+
 } // extern "C"
 
 #endif // #ifndef INCLUDE_GUARD_CUDA_CUPY_CUDA_RUNTIME_H

--- a/cupy_backends/cuda/libs/nvrtc.pyx
+++ b/cupy_backends/cuda/libs/nvrtc.pyx
@@ -78,7 +78,7 @@ cpdef tuple getVersion():
 cpdef tuple getSupportedArchs():
     cdef int status, num_archs
     cdef vector.vector[int] archs
-    if CUDA_VERSION < 11020 or runtime._is_hip_environment:
+    if runtime.runtimeGetVersion() < 11020 or runtime._is_hip_environment:
         raise RuntimeError("getSupportedArchs is supported since CUDA 11.2")
 
     with nogil:
@@ -171,7 +171,7 @@ cpdef bytes getCUBIN(intptr_t prog):
     cdef size_t cubinSizeRet = 0
     cdef vector.vector[char] cubin
     cdef char* cubin_ptr = NULL
-    if CUDA_VERSION < 11010 or runtime._is_hip_environment:
+    if runtime.runtimeGetVersion() < 11010 or runtime._is_hip_environment:
         raise RuntimeError("getCUBIN is supported since CUDA 11.1")
     with nogil:
         status = nvrtcGetCUBINSize(<Program>prog, &cubinSizeRet)

--- a/cupy_backends/hip/cupy_hip_common.h
+++ b/cupy_backends/hip/cupy_hip_common.h
@@ -53,6 +53,7 @@ enum {
         = hipDeviceAttributeComputeCapabilityMajor,
     cudaDevAttrComputeCapabilityMinor
         = hipDeviceAttributeComputeCapabilityMinor,
+    cudaDevAttrMemoryPoolsSupported = -1,  // not supported
 };
 
 typedef hipError_t cudaError_t;

--- a/cupy_backends/stub/cupy_cuda_common.h
+++ b/cupy_backends/stub/cupy_cuda_common.h
@@ -75,6 +75,7 @@ enum cudaMemcpyKind {};
 typedef void (*cudaStreamCallback_t)(
     cudaStream_t stream, cudaError_t status, void* userData);
 
+typedef void (*cudaHostFn_t)(void* userData);
 
 struct cudaPointerAttributes{
     int device;

--- a/cupy_backends/stub/cupy_cuda_runtime.h
+++ b/cupy_backends/stub/cupy_cuda_runtime.h
@@ -29,7 +29,8 @@ cudaError_t cudaDriverGetVersion(int* driverVersion) {
     return cudaSuccess;
 }
 
-cudaError_t cudaRuntimeGetVersion(...) {
+cudaError_t cudaRuntimeGetVersion(int* runtimeVersion) {
+    *runtimeVersion = 0; // make the stub work safely without driver
     return cudaSuccess;
 }
 


### PR DESCRIPTION
Close #5696.

(sorry, described later)