### PR TITLE
Fix docstring for fallback modules

### DIFF
--- a/cupyx/fallback_mode/fallback.py
+++ b/cupyx/fallback_mode/fallback.py
@@ -422,6 +422,7 @@ class vectorize(object):
             args = (args[0]._numpy_object,) + args[1:]
         notification._dispatch_notification(np.vectorize)
         self.__dict__['vec_obj'] = np.vectorize(*args, **kwargs)
+        self.__dict__['__doc__'] = self.__dict__['vec_obj'].__doc__
 
     def __getattr__(self, attr):
         return getattr(self.__dict__['vec_obj'], attr)

--- a/cupyx/fallback_mode/fallback.py
+++ b/cupyx/fallback_mode/fallback.py
@@ -163,6 +163,8 @@ class ndarray(object):
     gets initialized with a cupy ndarray.
     """
 
+    __doc__ = np.ndarray.__doc__
+
     def __new__(cls, *args, **kwargs):
         """
         If `_initial_array` and `_supports_cupy` are arguments,
@@ -360,6 +362,7 @@ def _create_magic_methods():
             if self._supports_cupy:
                 return _call_cupy(_method, args, kwargs)
             return _call_numpy(_method, args, kwargs)
+        method.__doc__ = getattr(np.ndarray, name).__doc__
         return method
 
     for method in (
@@ -406,6 +409,8 @@ _create_magic_methods()
 
 class vectorize(object):
 
+    __doc__ = np.vectorize.__doc__
+
     def __init__(self, *args, **kwargs):
         # NumPy will raise error if pyfunc is a cupy method
         self.__dict__['_is_numpy_pyfunc'] = False
@@ -423,10 +428,6 @@ class vectorize(object):
 
     def __setattr__(self, name, value):
         return setattr(self.vec_obj, name, value)
-
-    @property
-    def __doc__(self):
-        return self.vec_obj.__doc__
 
     def __call__(self, *args, **kwargs):
         if self._is_numpy_pyfunc:

--- a/tests/cupyx_tests/fallback_mode_tests/test_fallback.py
+++ b/tests/cupyx_tests/fallback_mode_tests/test_fallback.py
@@ -235,17 +235,18 @@ class TestFallbackMethodsArrayExternalOut(unittest.TestCase):
 
 
 @testing.parameterize(
-    {'object': fallback_mode.numpy.ndarray},
-    {'object': fallback_mode.numpy.ndarray.__add__},
-    {'object': fallback_mode.numpy.vectorize},
-    {'object': fallback_mode.numpy.linalg.eig},
+    {'object': ['ndarray']},
+    {'object': ['ndarray', '__add__']},
+    {'object': ['vectorize']},
+    {'object': ['linalg', 'eig']},
 )
 @testing.gpu
 class TestDocs(unittest.TestCase):
 
     @numpy_fallback_equal()
     def test_docs(self, xp):
-        return getattr(self.object, '__doc__')
+        obj = functools.reduce(getattr, self.object, xp)
+        return getattr(obj, '__doc__')
 
 
 @testing.gpu

--- a/tests/cupyx_tests/fallback_mode_tests/test_fallback.py
+++ b/tests/cupyx_tests/fallback_mode_tests/test_fallback.py
@@ -235,18 +235,17 @@ class TestFallbackMethodsArrayExternalOut(unittest.TestCase):
 
 
 @testing.parameterize(
-    {'object': ['ndarray']},
-    {'object': ['ndarray', '__add__']},
-    {'object': ['vectorize']},
-    {'object': ['linalg', 'eig']},
+    {'object': 'ndarray'},
+    {'object': 'ndarray.__add__'},
+    {'object': 'vectorize'},
+    {'object': 'linalg.eig'},
 )
 @testing.gpu
 class TestDocs(unittest.TestCase):
 
     @numpy_fallback_equal()
     def test_docs(self, xp):
-        obj = functools.reduce(getattr, self.object, xp)
-        return getattr(obj, '__doc__')
+        return operator.attrgetter(self.object)(xp).__doc__
 
 
 @testing.gpu

--- a/tests/cupyx_tests/fallback_mode_tests/test_fallback.py
+++ b/tests/cupyx_tests/fallback_mode_tests/test_fallback.py
@@ -1,8 +1,9 @@
-import pytest
-import unittest
 import functools
+import operator
+import unittest
 
 import numpy
+import pytest
 
 import cupy
 from cupy import testing


### PR DESCRIPTION
I was fixing a test code to support pytest-xdist but it seems the original TestDocs test is not working as expected.

context: https://github.com/cupy/cupy/pull/5659/files#r691093294