### PR TITLE
Update pip and setuptools in Windows CI

### DIFF
--- a/.pfnci/windows/test.ps1
+++ b/.pfnci/windows/test.ps1
@@ -67,6 +67,7 @@ function Main {
     # Build
     echo "Setting up test environment"
     RunOrDie python -V
+    RunOrDie python -m pip install -U pip setuptools
     RunOrDie python -m pip install Cython 'scipy<1.7' optuna
     RunOrDie python -m pip freeze
 


### PR DESCRIPTION
Default setuptools in Windows CI environment seems outdated (detected in CI of #5730: https://ci.preferred.jp/r/job/78702)