### PR TITLE
Prefix Cython `compile_time_env` with `CUPY_`

### DIFF
--- a/cupy/_util.pyx
+++ b/cupy/_util.pyx
@@ -12,7 +12,7 @@ import cupy
 from cupy.cuda cimport device
 
 
-DEF CYTHON_BUILD_VER = cython_version
+DEF CYTHON_BUILD_VER = CUPY_CYTHON_VERSION
 cython_build_ver = CYTHON_BUILD_VER
 
 

--- a/cupy/cuda/cufft.pxd
+++ b/cupy/cuda/cufft.pxd
@@ -9,7 +9,7 @@ cdef extern from *:
     ctypedef double Double 'cufftDoubleReal'
     ctypedef int Result 'cufftResult_t'
 
-    IF HIP_VERSION > 0:
+    IF CUPY_HIP_VERSION > 0:
         ctypedef int Handle 'cufftHandle'
     ELSE:
         ctypedef struct hipHandle 'hipfftHandle_t':

--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -108,7 +108,7 @@ cdef class Memory(BaseMemory):
 
 
 cdef inline void check_async_alloc_supported(int device_id) except*:
-    if CUDA_VERSION < 11020:
+    if CUPY_CUDA_VERSION < 11020:
         raise RuntimeError("memory_async is supported since CUDA 11.2")
     if runtime._is_hip_environment:
         raise RuntimeError('HIP does not support memory_async')

--- a/cupy/fft/_callback.pyx
+++ b/cupy/fft/_callback.pyx
@@ -170,8 +170,8 @@ cdef inline void _cythonize(str tempdir, str mod_name) except*:
     shutil.copyfile(os.path.join(_source_dir, 'cufft.pyx'),
                     os.path.join(tempdir, mod_name + '.pyx'))
     p = subprocess.run(['cython', '-3', '--cplus',
-                        '-E', 'HIP_VERSION=0',
-                        '-E', 'CUDA_VERSION=' + _build_ver,
+                        '-E', 'CUPY_HIP_VERSION=0',
+                        '-E', 'CUPY_CUDA_VERSION=' + _build_ver,
                         '-E', 'CUPY_CUFFT_STATIC=True',
                         os.path.join(tempdir, mod_name + '.pyx'),
                         '-o', os.path.join(tempdir, mod_name + '.cpp')],

--- a/cupy_backends/cuda/api/_driver_extern.pxi
+++ b/cupy_backends/cuda/api/_driver_extern.pxi
@@ -74,4 +74,4 @@ cdef extern from '../../cupy_backend.h' nogil:
         block2shmem, size_t dynamicSMemSize, int blockSizeLimit)
 
     # Build-time version
-    int CUDA_VERSION
+    enum: CUDA_VERSION

--- a/cupy_backends/cuda/api/_runtime_enum.pxd
+++ b/cupy_backends/cuda/api/_runtime_enum.pxd
@@ -84,7 +84,7 @@ cpdef enum:
 # so that we can directly assign their C counterparts here. Now because
 # of backward compatibility and no flexible Cython macro (IF/ELSE), we
 # have to duplicate the enum. (CUDA and HIP use different values!)
-IF HIP_VERSION > 0:
+IF CUPY_HIP_VERSION > 0:
     # separate in groups of 10 for easier counting...
     cpdef enum:
         cudaDevAttrMaxThreadsPerBlock = 0
@@ -200,7 +200,7 @@ IF HIP_VERSION > 0:
         # cudaDevAttrMaxSharedMemoryPerBlockOptin
         # cudaDevAttrCanFlushRemoteWrites
         # cudaDevAttrHostRegisterSupported
-    IF HIP_VERSION >= 310:
+    IF CUPY_HIP_VERSION >= 310:
         cpdef enum:
             # hipDeviceAttributeAsicRevision  # does not exist in CUDA
             cudaDevAttrManagedMemory = 47

--- a/cupy_backends/cuda/api/_runtime_typedef.pxi
+++ b/cupy_backends/cuda/api/_runtime_typedef.pxi
@@ -107,13 +107,13 @@ cdef extern from *:
     ctypedef void* MemPool 'cudaMemPool_t'
     ctypedef int MemPoolAttr 'cudaMemPoolAttr'
 
-    IF CUDA_VERSION > 0:
+    IF CUPY_CUDA_VERSION > 0:
         ctypedef struct _PointerAttributes 'cudaPointerAttributes':
             int type
             int device
             void* devicePointer
             void* hostPointer
-    ELIF HIP_VERSION > 0:
+    ELIF CUPY_HIP_VERSION > 0:
         ctypedef struct _PointerAttributes 'cudaPointerAttributes':
             int memoryType
             int device
@@ -123,7 +123,7 @@ cdef extern from *:
         ctypedef struct _PointerAttributes 'cudaPointerAttributes':
             pass  # for RTD
 
-    IF CUDA_VERSION >= 11000:
+    IF CUPY_CUDA_VERSION >= 11000:
         # We can't use IF in the middle of structs declaration
         # to add or ignore fields in compile time so we have to
         # replicate the struct definition
@@ -208,7 +208,7 @@ cdef extern from *:
             int          maxBlocksPerMultiProcessor  # CUDA 11.0 field
             int          accessPolicyMaxWindowSize  # CUDA 11.0 field
             size_t       reservedSharedMemPerBlock  # CUDA 11.0 field
-    ELIF CUDA_VERSION >= 10000:
+    ELIF CUPY_CUDA_VERSION >= 10000:
         ctypedef struct DeviceProp 'cudaDeviceProp':
             char         name[256]
             cudaUUID     uuid
@@ -286,7 +286,7 @@ cdef extern from *:
             size_t       sharedMemPerBlockOptin
             int          pageableMemoryAccessUsesHostPageTables
             int          directManagedMemAccessFromHost
-    ELIF CUDA_VERSION == 9020:
+    ELIF CUPY_CUDA_VERSION == 9020:
         ctypedef struct DeviceProp 'cudaDeviceProp':
             char         name[256]
             size_t       totalGlobalMem
@@ -361,7 +361,7 @@ cdef extern from *:
             size_t       sharedMemPerBlockOptin
             int          pageableMemoryAccessUsesHostPageTables
             int          directManagedMemAccessFromHost
-    ELIF HIP_VERSION > 0:
+    ELIF CUPY_HIP_VERSION > 0:
         ctypedef struct deviceArch 'hipDeviceArch_t':
             unsigned hasGlobalInt32Atomics
             unsigned hasGlobalFloatAtomicExch
@@ -386,7 +386,7 @@ cdef extern from *:
             unsigned has3dGrid
             unsigned hasDynamicParallelism
 
-        IF HIP_VERSION >= 310:
+        IF CUPY_HIP_VERSION >= 310:
             ctypedef struct DeviceProp 'cudaDeviceProp':
                 char name[256]
                 size_t totalGlobalMem

--- a/cupy_backends/cuda/api/driver.pyx
+++ b/cupy_backends/cuda/api/driver.pyx
@@ -28,7 +28,7 @@ ELSE:
 cdef extern from '../../cupy_backend.h' nogil:
     # Build-time version
     # Note: CUDA_VERSION is defined either in CUDA Python or _driver_extern.pxi
-    int HIP_VERSION
+    enum: HIP_VERSION
 
 # Provide access to constants from Python.
 from cupy_backends.cuda.api._driver_enum import *
@@ -75,9 +75,9 @@ cdef inline void check_attribute_status(int status, int* pi) except *:
 
 cpdef get_build_version():
     # The versions are mutually exclusive
-    if CUDA_VERSION > 0:
+    if CUPY_CUDA_VERSION > 0:
         return CUDA_VERSION
-    elif HIP_VERSION > 0:
+    elif CUPY_HIP_VERSION > 0:
         return HIP_VERSION
     else:
         return 0
@@ -276,7 +276,7 @@ cpdef int funcGetAttribute(int attribute, intptr_t f) except? -2:
 
 
 cpdef funcSetAttribute(intptr_t f, int attribute, int value):
-    if CUDA_VERSION < 9000:
+    if CUPY_CUDA_VERSION < 9000:
         raise RuntimeError("Your CUDA does not support cuFuncSetAttribute.")
     with nogil:
         status = cuFuncSetAttribute(

--- a/cupy_backends/cuda/api/runtime.pyx
+++ b/cupy_backends/cuda/api/runtime.pyx
@@ -173,7 +173,7 @@ cpdef getDeviceProperties(int device):
     cdef dict properties = {'name': b'UNAVAILABLE'}  # for RTD
 
     # Common properties to CUDA 9.0, 9.2, 10.x, 11.x, and HIP
-    IF CUDA_VERSION > 0 or HIP_VERSION > 0:
+    IF CUPY_CUDA_VERSION > 0 or CUPY_HIP_VERSION > 0:
         properties = {
             'name': props.name,
             'totalGlobalMem': props.totalGlobalMem,
@@ -211,7 +211,7 @@ cpdef getDeviceProperties(int device):
             'cooperativeLaunch': props.cooperativeLaunch,
             'cooperativeMultiDeviceLaunch': props.cooperativeMultiDeviceLaunch,
         }
-    IF CUDA_VERSION >= 9020:
+    IF CUPY_CUDA_VERSION >= 9020:
         properties['deviceOverlap'] = props.deviceOverlap
         properties['maxTexture1DMipmap'] = props.maxTexture1DMipmap
         properties['maxTexture1DLinear'] = props.maxTexture1DLinear
@@ -259,11 +259,11 @@ cpdef getDeviceProperties(int device):
             props.pageableMemoryAccessUsesHostPageTables)
         properties['directManagedMemAccessFromHost'] = (
             props.directManagedMemAccessFromHost)
-    IF CUDA_VERSION >= 10000:
+    IF CUPY_CUDA_VERSION >= 10000:
         properties['uuid'] = props.uuid.bytes
         properties['luid'] = props.luid
         properties['luidDeviceNodeMask'] = props.luidDeviceNodeMask
-    IF CUDA_VERSION >= 11000:
+    IF CUPY_CUDA_VERSION >= 11000:
         properties['persistingL2CacheMaxSize'] = props.persistingL2CacheMaxSize
         properties['maxBlocksPerMultiProcessor'] = (
             props.maxBlocksPerMultiProcessor)
@@ -271,7 +271,7 @@ cpdef getDeviceProperties(int device):
             props.accessPolicyMaxWindowSize)
         properties['reservedSharedMemPerBlock'] = (
             props.reservedSharedMemPerBlock)
-    IF HIP_VERSION > 0:  # HIP-only props
+    IF CUPY_HIP_VERSION > 0:  # HIP-only props
         properties['clockInstructionRate'] = props.clockInstructionRate
         properties['maxSharedMemoryPerMultiProcessor'] = (
             props.maxSharedMemoryPerMultiProcessor)
@@ -308,7 +308,7 @@ cpdef getDeviceProperties(int device):
         arch['has3dGrid'] = props.arch.has3dGrid
         arch['hasDynamicParallelism'] = props.arch.hasDynamicParallelism
         properties['arch'] = arch
-    IF HIP_VERSION >= 310:
+    IF CUPY_HIP_VERSION >= 310:
         properties['gcnArchName'] = props.gcnArchName
         properties['asicRevision'] = props.asicRevision
         properties['managedMemory'] = props.managedMemory
@@ -475,7 +475,7 @@ cpdef intptr_t mallocArray(intptr_t descPtr, size_t width, size_t height,
 
 cpdef intptr_t mallocAsync(size_t size, intptr_t stream) except? 0:
     cdef void* ptr
-    if CUDA_VERSION < 11020:
+    if CUPY_CUDA_VERSION < 11020:
         raise RuntimeError('mallocAsync is supported since CUDA 11.2')
     with nogil:
         status = cudaMallocAsync(&ptr, size, <driver.Stream>stream)
@@ -515,7 +515,7 @@ cpdef freeArray(intptr_t ptr):
     check_status(status)
 
 cpdef freeAsync(intptr_t ptr, intptr_t stream):
-    if CUDA_VERSION < 11020:
+    if CUPY_CUDA_VERSION < 11020:
         raise RuntimeError('freeAsync is supported since CUDA 11.2')
     with nogil:
         status = cudaFreeAsync(<void*>ptr, <driver.Stream>stream)
@@ -645,13 +645,13 @@ cpdef PointerAttributes pointerGetAttributes(intptr_t ptr):
     cdef _PointerAttributes attrs
     status = cudaPointerGetAttributes(&attrs, <void*>ptr)
     check_status(status)
-    IF CUDA_VERSION > 0:
+    IF CUPY_CUDA_VERSION > 0:
         return PointerAttributes(
             attrs.device,
             <intptr_t>attrs.devicePointer,
             <intptr_t>attrs.hostPointer,
             attrs.type)
-    ELIF HIP_VERSION > 0:
+    ELIF CUPY_HIP_VERSION > 0:
         return PointerAttributes(
             attrs.device,
             <intptr_t>attrs.devicePointer,
@@ -662,7 +662,7 @@ cpdef PointerAttributes pointerGetAttributes(intptr_t ptr):
 
 cpdef intptr_t deviceGetDefaultMemPool(int device) except? 0:
     '''Get the default mempool on the current device.'''
-    if CUDA_VERSION < 11020:
+    if CUPY_CUDA_VERSION < 11020:
         raise RuntimeError('deviceGetDefaultMemPool is supported since '
                            'CUDA 11.2')
     cdef MemPool pool
@@ -673,7 +673,7 @@ cpdef intptr_t deviceGetDefaultMemPool(int device) except? 0:
 
 cpdef intptr_t deviceGetMemPool(int device) except? 0:
     '''Get the current mempool on the current device.'''
-    if CUDA_VERSION < 11020:
+    if CUPY_CUDA_VERSION < 11020:
         raise RuntimeError('deviceGetMemPool is supported since '
                            'CUDA 11.2')
     cdef MemPool pool
@@ -684,7 +684,7 @@ cpdef intptr_t deviceGetMemPool(int device) except? 0:
 
 cpdef deviceSetMemPool(int device, intptr_t pool):
     '''Set the current mempool on the current device to pool.'''
-    if CUDA_VERSION < 11020:
+    if CUPY_CUDA_VERSION < 11020:
         raise RuntimeError('deviceSetMemPool is supported since '
                            'CUDA 11.2')
     with nogil:
@@ -692,14 +692,14 @@ cpdef deviceSetMemPool(int device, intptr_t pool):
     check_status(status)
 
 cpdef memPoolTrimTo(intptr_t pool, size_t size):
-    if CUDA_VERSION < 11020:
+    if CUPY_CUDA_VERSION < 11020:
         raise RuntimeError('memPoolTrimTo is supported since CUDA 11.2')
     with nogil:
         status = cudaMemPoolTrimTo(<MemPool>pool, size)
     check_status(status)
 
 cpdef memPoolGetAttribute(intptr_t pool, int attr):
-    if CUDA_VERSION < 11020:
+    if CUPY_CUDA_VERSION < 11020:
         raise RuntimeError('memPoolGetAttribute is supported since CUDA 11.2')
     cdef int val1
     cdef uint64_t val2
@@ -714,7 +714,7 @@ cpdef memPoolGetAttribute(intptr_t pool, int attr):
     return val1 if attr <= 0x3 else val2
 
 cpdef memPoolSetAttribute(intptr_t pool, int attr, object value):
-    if CUDA_VERSION < 11020:
+    if CUPY_CUDA_VERSION < 11020:
         raise RuntimeError('memPoolSetAttribute is supported since CUDA 11.2')
     cdef int val1
     cdef uint64_t val2
@@ -769,7 +769,7 @@ cdef _streamCallbackFunc(driver.Stream hStream, int status,
 
 
 # Use Cython macro to suppress compiler warning
-IF CUDA_VERSION >= 10000:
+IF CUPY_CUDA_VERSION >= 10000:
     cdef _HostFnFunc(void* func_arg) with gil:
         obj = <object>func_arg
         func, arg = obj
@@ -794,7 +794,7 @@ cpdef streamAddCallback(intptr_t stream, callback, intptr_t arg,
 cpdef launchHostFunc(intptr_t stream, callback, intptr_t arg):
     if _is_hip_environment:
         raise RuntimeError('This feature is not supported on HIP')
-    if CUDA_VERSION < 10000:
+    if CUPY_CUDA_VERSION < 10000:
         raise RuntimeError('This feature is only supported on CUDA 10.0+')
 
     func_arg = (callback, arg)

--- a/cupy_backends/cuda/libs/nvrtc.pyx
+++ b/cupy_backends/cuda/libs/nvrtc.pyx
@@ -78,7 +78,7 @@ cpdef tuple getVersion():
 cpdef tuple getSupportedArchs():
     cdef int status, num_archs
     cdef vector.vector[int] archs
-    if CUDA_VERSION < 11020 or runtime._is_hip_environment:
+    if CUPY_CUDA_VERSION < 11020 or runtime._is_hip_environment:
         raise RuntimeError("getSupportedArchs is supported since CUDA 11.2")
 
     with nogil:
@@ -171,7 +171,7 @@ cpdef bytes getCUBIN(intptr_t prog):
     cdef size_t cubinSizeRet = 0
     cdef vector.vector[char] cubin
     cdef char* cubin_ptr = NULL
-    if CUDA_VERSION < 11010 or runtime._is_hip_environment:
+    if CUPY_CUDA_VERSION < 11010 or runtime._is_hip_environment:
         raise RuntimeError("getCUBIN is supported since CUDA 11.1")
     with nogil:
         status = nvrtcGetCUBINSize(<Program>prog, &cubinSizeRet)

--- a/install/cupy_builder/cupy_setup_build.py
+++ b/install/cupy_builder/cupy_setup_build.py
@@ -945,16 +945,16 @@ def cythonize(extensions, arg_options):
         print('Using CUDA Python')
 
     compile_time_env['CUPY_CUFFT_STATIC'] = False
-    compile_time_env['cython_version'] = str(cython_version)
+    compile_time_env['CUPY_CYTHON_VERSION'] = str(cython_version)
     if arg_options['no_cuda']:  # on RTD
-        compile_time_env['CUDA_VERSION'] = 0
-        compile_time_env['HIP_VERSION'] = 0
+        compile_time_env['CUPY_CUDA_VERSION'] = 0
+        compile_time_env['CUPY_HIP_VERSION'] = 0
     elif use_hip:  # on ROCm/HIP
-        compile_time_env['CUDA_VERSION'] = 0
-        compile_time_env['HIP_VERSION'] = build.get_hip_version()
+        compile_time_env['CUPY_CUDA_VERSION'] = 0
+        compile_time_env['CUPY_HIP_VERSION'] = build.get_hip_version()
     else:  # on CUDA
-        compile_time_env['CUDA_VERSION'] = build.get_cuda_version()
-        compile_time_env['HIP_VERSION'] = 0
+        compile_time_env['CUPY_CUDA_VERSION'] = build.get_cuda_version()
+        compile_time_env['CUPY_HIP_VERSION'] = 0
 
     return Cython.Build.cythonize(
         extensions, verbose=True, language_level=3,


### PR DESCRIPTION
Preparing for #5723. See #5696.

This PR makes all of Cython's `compile_time_env` entries prefixed with `CUPY_` to keep off conflicts as CUDA Python's `CUDA_VERSION`.