### PR TITLE
Fix backport trigger

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -11,7 +11,10 @@ jobs:
     if: |
         github.repository_owner == 'cupy' &&
         github.event.pull_request.merged == true &&
-        contains(github.event.pull_request.labels.*.name, 'to-be-backported')
+        (
+            (github.event.action == 'closed'  && contains(github.event.pull_request.labels.*.name, 'to-be-backported')) ||
+            (github.event.action == 'labeled' && github.event.label.name == 'to-be-backported')
+        )
     runs-on: ubuntu-18.04
     env:
       CUPY_CI: GitHub


### PR DESCRIPTION
Backport should be triggered only when the label added is `to-be-backported`.

This avoids backport to retrigger when labels other than `to-be-backported` is added to a already-closed PR with `to-be-backported` label, e.g., https://github.com/cupy/cupy/pull/5735#issuecomment-916625858