### PR TITLE
[backport] Support NCCL 2.11.4

### DIFF
--- a/.pfnci/linux/tests/cuda114.Dockerfile
+++ b/.pfnci/linux/tests/cuda114.Dockerfile
@@ -2,7 +2,7 @@ FROM nvidia/cuda:11.4.0-devel-ubuntu18.04
 
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get -qqy update && \
-    apt-get -qqy install libnccl-dev=2.10.*+cuda11.4 libcudnn8-dev=8.2.*+cuda11.4 libcutensor-dev=1.3.* libcusparselt-dev=0.1.* && \
+    apt-get -qqy --allow-change-held-packages install libnccl2=2.11.*+cuda11.4 libnccl-dev=2.11.*+cuda11.4 libcudnn8-dev=8.2.*+cuda11.4 libcutensor-dev=1.3.* libcusparselt-dev=0.1.* && \
     apt-get -qqy install ccache
 
 ENV PATH="/usr/lib/ccache:${PATH}"

--- a/cupyx/tools/install_library.py
+++ b/cupyx/tools/install_library.py
@@ -183,8 +183,8 @@ def _make_nccl_record(
 
 
 _nccl_records.append(_make_nccl_record(
-    '11.4', '2.10.3', '2.10',
-    'nccl_2.10.3-1+cuda11.4_x86_64.txz'))
+    '11.4', '2.11.4', '2.11',
+    'nccl_2.11.4-1+cuda11.4_x86_64.txz'))
 _nccl_records.append(_make_nccl_record(
     '11.3', '2.9.9', '2.9',
     'nccl_2.9.9-1+cuda11.3_x86_64.txz'))
@@ -195,11 +195,11 @@ _nccl_records.append(_make_nccl_record(
     '11.1', '2.8.4', '2.8',
     'nccl_2.8.4-1+cuda11.1_x86_64.txz'))
 _nccl_records.append(_make_nccl_record(
-    '11.0', '2.10.3', '2.10',
-    'nccl_2.10.3-1+cuda11.0_x86_64.txz'))
+    '11.0', '2.11.4', '2.11',
+    'nccl_2.11.4-1+cuda11.0_x86_64.txz'))
 _nccl_records.append(_make_nccl_record(
-    '10.2', '2.10.3', '2.10',
-    'nccl_2.10.3-1+cuda10.2_x86_64.txz'))
+    '10.2', '2.11.4', '2.11',
+    'nccl_2.11.4-1+cuda10.2_x86_64.txz'))
 _nccl_records.append(_make_nccl_record(
     '10.1', '2.8.3', '2.8',
     'nccl_2.8.3-1+cuda10.1_x86_64.txz'))

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -54,7 +54,7 @@ Part of the CUDA features in CuPy will be activated only when the corresponding 
 
     * The library to accelerate tensor operations. See :doc:`../reference/environment` for the details.
 
-* `NCCL <https://developer.nvidia.com/nccl>`_: v2.4 / v2.6 / v2.8 / v2.9 / v2.10
+* `NCCL <https://developer.nvidia.com/nccl>`_: v2.4 / v2.6 / v2.8 / v2.9 / v2.10 / v2.11
 
     * The library to perform collective multi-GPU / multi-node computations.
 


### PR DESCRIPTION
Backport of #5734 by @takagi

Docker image rebuild: https://ci.preferred.jp/cupy.prep-linux/78968/
Trigger FlexCI after the rebuild complete.