### PR TITLE
Reorganize build scripts, part 4: remove global `cupy_setup_options`

### DIFF
--- a/install/cupy_builder/_context.py
+++ b/install/cupy_builder/_context.py
@@ -17,3 +17,62 @@ class Context:
             'CUPY_USE_CUDA_PYTHON', False, _env)
         self.use_hip = _get_env_bool(
             'CUPY_INSTALL_USE_HIP', False, _env)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(add_help=False)
+
+    parser.add_argument(
+        '--cupy-package-name', type=str, default='cupy',
+        help='alternate package name')
+    parser.add_argument(
+        '--cupy-long-description', type=str, default=None,
+        help='path to the long description file')
+    parser.add_argument(
+        '--cupy-wheel-lib', type=str, action='append', default=[],
+        help='shared library to copy into the wheel '
+             '(can be specified for multiple times)')
+    parser.add_argument(
+        '--cupy-wheel-include', type=str, action='append', default=[],
+        help='An include file to copy into the wheel. '
+             'Delimited by a colon. '
+             'The former part is a full path of the source include file and '
+             'the latter is the relative path within cupy wheel. '
+             '(can be specified for multiple times)')
+    parser.add_argument(
+        '--cupy-wheel-metadata', type=str, default=None,
+        help='wheel metadata (cupy/.data/_wheel.json)')
+    parser.add_argument(
+        '--cupy-no-rpath', action='store_true', default=False,
+        help='disable adding default library directories to RPATH')
+    parser.add_argument(
+        '--cupy-profile', action='store_true', default=False,
+        help='enable profiling for Cython code')
+    parser.add_argument(
+        '--cupy-coverage', action='store_true', default=False,
+        help='enable coverage for Cython code')
+    parser.add_argument(
+        '--cupy-no-cuda', action='store_true', default=False,
+        help='build CuPy with stub header file')
+    # parser.add_argument(
+    #     '--cupy-use-hip', action='store_true', default=False,
+    #     help='build CuPy with HIP')
+
+    opts, sys.argv = parser.parse_known_args(sys.argv)
+
+    arg_options = {
+        'package_name': opts.cupy_package_name,
+        'long_description': opts.cupy_long_description,
+        'wheel_libs': opts.cupy_wheel_lib,  # list
+        'wheel_includes': opts.cupy_wheel_include,  # list
+        'wheel_metadata': opts.cupy_wheel_metadata,
+        'no_rpath': opts.cupy_no_rpath,
+        'profile': opts.cupy_profile,
+        'linetrace': opts.cupy_coverage,
+        'annotate': opts.cupy_coverage,
+        'no_cuda': opts.cupy_no_cuda,
+        'use_hip': use_hip  # opts.cupy_use_hip,
+    }
+    if check_readthedocs_environment():
+        arg_options['no_cuda'] = True
+    return arg_options

--- a/install/cupy_builder/cupy_setup_build.py
+++ b/install/cupy_builder/cupy_setup_build.py
@@ -1,4 +1,3 @@
-import argparse
 import copy
 from distutils import ccompiler
 from distutils import errors
@@ -66,10 +65,6 @@ def module_extension_sources(file, use_cython, no_cuda):
 
 def get_required_modules(MODULES):
     return [m['name'] for m in MODULES if m.get('required', False)]
-
-
-def check_readthedocs_environment():
-    return os.environ.get('READTHEDOCS', None) == 'True'
 
 
 def check_library(compiler, includes=(), libraries=(),

--- a/install/cupy_builder/cupy_setup_build.py
+++ b/install/cupy_builder/cupy_setup_build.py
@@ -410,66 +410,6 @@ def make_extensions(options, compiler, use_cython):
     return ret
 
 
-# TODO(oktua): use enviriment variable
-def parse_args():
-    parser = argparse.ArgumentParser(add_help=False)
-
-    parser.add_argument(
-        '--cupy-package-name', type=str, default='cupy',
-        help='alternate package name')
-    parser.add_argument(
-        '--cupy-long-description', type=str, default=None,
-        help='path to the long description file')
-    parser.add_argument(
-        '--cupy-wheel-lib', type=str, action='append', default=[],
-        help='shared library to copy into the wheel '
-             '(can be specified for multiple times)')
-    parser.add_argument(
-        '--cupy-wheel-include', type=str, action='append', default=[],
-        help='An include file to copy into the wheel. '
-             'Delimited by a colon. '
-             'The former part is a full path of the source include file and '
-             'the latter is the relative path within cupy wheel. '
-             '(can be specified for multiple times)')
-    parser.add_argument(
-        '--cupy-wheel-metadata', type=str, default=None,
-        help='wheel metadata (cupy/.data/_wheel.json)')
-    parser.add_argument(
-        '--cupy-no-rpath', action='store_true', default=False,
-        help='disable adding default library directories to RPATH')
-    parser.add_argument(
-        '--cupy-profile', action='store_true', default=False,
-        help='enable profiling for Cython code')
-    parser.add_argument(
-        '--cupy-coverage', action='store_true', default=False,
-        help='enable coverage for Cython code')
-    parser.add_argument(
-        '--cupy-no-cuda', action='store_true', default=False,
-        help='build CuPy with stub header file')
-    # parser.add_argument(
-    #     '--cupy-use-hip', action='store_true', default=False,
-    #     help='build CuPy with HIP')
-
-    opts, sys.argv = parser.parse_known_args(sys.argv)
-
-    arg_options = {
-        'package_name': opts.cupy_package_name,
-        'long_description': opts.cupy_long_description,
-        'wheel_libs': opts.cupy_wheel_lib,  # list
-        'wheel_includes': opts.cupy_wheel_include,  # list
-        'wheel_metadata': opts.cupy_wheel_metadata,
-        'no_rpath': opts.cupy_no_rpath,
-        'profile': opts.cupy_profile,
-        'linetrace': opts.cupy_coverage,
-        'annotate': opts.cupy_coverage,
-        'no_cuda': opts.cupy_no_cuda,
-        'use_hip': use_hip  # opts.cupy_use_hip,
-    }
-    if check_readthedocs_environment():
-        arg_options['no_cuda'] = True
-    return arg_options
-
-
 cupy_setup_options = parse_args()
 print('Options:', cupy_setup_options)
 

--- a/install/cupy_builder/cupy_setup_build.py
+++ b/install/cupy_builder/cupy_setup_build.py
@@ -409,18 +409,6 @@ cupy_setup_options = parse_args()
 print('Options:', cupy_setup_options)
 
 
-def get_package_name():
-    return cupy_setup_options['package_name']
-
-
-def get_long_description():
-    path = cupy_setup_options['long_description']
-    if path is None:
-        return None
-    with open(path) as f:
-        return f.read()
-
-
 def prepare_wheel_libs():
     """Prepare shared libraries and include files for wheels.
 

--- a/setup.py
+++ b/setup.py
@@ -82,14 +82,18 @@ package_data = {
 
 package_data['cupy'] += cupy_setup_build.prepare_wheel_libs()
 
-package_name = cupy_setup_build.get_package_name()
-long_description = cupy_setup_build.get_long_description()
 ext_modules = cupy_setup_build.get_ext_modules()
 build_ext = cupy_setup_build.custom_build_ext
 
 # Get __version__ variable
 with open(os.path.join(source_root, 'cupy', '_version.py')) as f:
     exec(f.read())
+
+long_description = None
+if ctx.long_description_path is not None:
+    with open(ctx.long_description_path) as f:
+        long_description = f.read()
+
 
 CLASSIFIERS = """\
 Development Status :: 5 - Production/Stable
@@ -112,7 +116,7 @@ Operating System :: Microsoft :: Windows
 
 
 setup(
-    name=package_name,
+    name=ctx.package_name,
     version=__version__,  # NOQA
     description='CuPy: NumPy & SciPy for GPU',
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -80,9 +80,9 @@ package_data = {
     ],
 }
 
-package_data['cupy'] += cupy_setup_build.prepare_wheel_libs()
+package_data['cupy'] += cupy_setup_build.prepare_wheel_libs(ctx)
 
-ext_modules = cupy_setup_build.get_ext_modules()
+ext_modules = cupy_setup_build.get_ext_modules(False, ctx)
 build_ext = cupy_setup_build.custom_build_ext
 
 # Get __version__ variable

--- a/tests/install_tests/__init__.py
+++ b/tests/install_tests/__init__.py
@@ -17,4 +17,4 @@ def _from_install_import(name):
 
 
 cupy_builder = _from_install_import('cupy_builder')
-cupy_builder.initialize(cupy_builder.Context(source_root))
+cupy_builder.initialize(cupy_builder.Context(source_root, _env={}, _argv=[]))

--- a/tests/install_tests/test_cupy_builder/test_context.py
+++ b/tests/install_tests/test_cupy_builder/test_context.py
@@ -1,4 +1,4 @@
-from cupy_builder._context import _get_env_bool, Context
+from cupy_builder._context import _get_env_bool, Context, parse_args
 
 
 class TestGetEnvBool:
@@ -15,7 +15,48 @@ class TestGetEnvBool:
 
 class TestContext:
     def test_default(self):
-        ctx = Context('.', _env={})
+        ctx = Context('.', _env={}, _argv=[])
+
+        assert ctx.source_root == '.'
+
         assert ctx.enable_thrust
         assert not ctx.use_cuda_python
         assert not ctx.use_hip
+
+        assert ctx.package_name == 'cupy'
+        assert ctx.long_description_path is None
+        assert ctx.wheel_libs == []
+        assert ctx.wheel_includes == []
+        assert ctx.wheel_metadata_path is None
+        assert not ctx.no_rpath
+        assert not ctx.profile
+        assert not ctx.linetrace
+        assert not ctx.annotate
+        assert not ctx.use_stub
+
+
+class TestParseArgs:
+    def test_args(self):
+        args = [
+            'python', 'setup.py', 'develop',
+            '--cupy-package-name', 'cupy-cudaXXX',
+            '--cupy-long-description', 'foo.rst',
+            '--cupy-wheel-lib', 'lib1',
+            '--cupy-wheel-lib', 'lib2',
+            '--cupy-wheel-metadata', '_wheel.json',
+            '--cupy-no-rpath',
+            '--cupy-profile',
+            '--cupy-coverage',
+            '--cupy-no-cuda',
+            '--extra-option',
+        ]
+        options, remaining = parse_args(args)
+        assert options.cupy_package_name == 'cupy-cudaXXX'
+        assert options.cupy_long_description == 'foo.rst'
+        assert options.cupy_wheel_lib == ['lib1', 'lib2']
+        assert options.cupy_wheel_metadata == '_wheel.json'
+        assert options.cupy_no_rpath
+        assert options.cupy_profile
+        assert options.cupy_coverage
+        assert options.cupy_no_cuda
+        assert remaining == ['python', 'setup.py', 'develop', '--extra-option']


### PR DESCRIPTION
context: #5722, #5730, #5743, #5745

Remove the global variable `cupy_setup_options`.
Recommends commit-by-commit review.