### PR TITLE
Add maintainers in `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -118,6 +118,7 @@ setup(
     long_description=long_description,
     author='Seiya Tokui',
     author_email='tokui@preferred.jp',
+    maintainer='CuPy Developers',
     url='https://cupy.dev/',
     license='MIT License',
     project_urls={


### PR DESCRIPTION
Adding `maintainer` meta data to credit all contributors working on CuPy :smile:

This will be displayed under `Meta` section on PyPI. NumPy's example: https://pypi.org/project/numpy/