### PR TITLE
Fix `cupyx.optimize` to save file when no optimization ran

### DIFF
--- a/cupyx/optimizing/_optimize.py
+++ b/cupyx/optimizing/_optimize.py
@@ -101,7 +101,8 @@ The optimization results will never be stored.
 
     try:
         yield context
-        if path is not None and not readonly and context._is_dirty():
-            context.save(path)
+        if path is not None and not readonly:
+            if context._is_dirty() or not os.path.exists(path):
+                context.save(path)
     finally:
         _optimize_config.set_current_context(old_context)

--- a/tests/cupyx_tests/test_optimize.py
+++ b/tests/cupyx_tests/test_optimize.py
@@ -146,7 +146,7 @@ class TestOptimize(unittest.TestCase):
             # existing file, readonly=False
             with cupyx.optimizing.optimize(path=filepath, readonly=False):
                 cupy.sum(cupy.arange(8))
-            assert filesize < os.stat(filepath).st_size
+            assert filesize <= os.stat(filepath).st_size
 
 
 # TODO(leofang): check the optimizer is not applicable to the cutensor backend?

--- a/tests/cupyx_tests/test_optimize.py
+++ b/tests/cupyx_tests/test_optimize.py
@@ -38,6 +38,10 @@ class TestOptimize(unittest.TestCase):
         testing.assert_array_equal(y1, y2)
 
     def test_optimize_cache(self):
+        if (_accelerator.ACCELERATOR_CUB
+                in _accelerator.get_reduction_accelerators()):
+            pytest.skip('optimize cannot be mocked for CUB reduction')
+
         target = cupyx.optimizing._optimize._optimize
         target_full_name = '{}.{}'.format(target.__module__, target.__name__)
 
@@ -81,6 +85,10 @@ class TestOptimize(unittest.TestCase):
 
     @testing.multi_gpu(2)
     def test_optimize_cache_multi_gpus(self):
+        if (_accelerator.ACCELERATOR_CUB
+                in _accelerator.get_reduction_accelerators()):
+            pytest.skip('optimize cannot be mocked for CUB reduction')
+
         target = cupyx.optimizing._optimize._optimize
         target_full_name = '{}.{}'.format(target.__module__, target.__name__)
 


### PR DESCRIPTION
Previously `cupyx.optimize` context manager does not save a file when no optimization run within the scope.
I think it is better to save an empty result instead to make the behavior consistent.

This PR also fixes the issue that `cupyx.optimize` tests fail when CUB acceleartor is enabled.