### PR TITLE
Add `dtype` and `casting` arguments to `cupy.concatenate()`

### DIFF
--- a/cupy/_core/_routines_manipulation.pxd
+++ b/cupy/_core/_routines_manipulation.pxd
@@ -33,5 +33,6 @@ cpdef ndarray _reshape(ndarray self, const shape_t &shape_spec)
 cpdef ndarray _T(ndarray self)
 cpdef ndarray _transpose(ndarray self, const vector.vector[Py_ssize_t] &axes)
 cpdef ndarray _concatenate(
-    list arrays, Py_ssize_t axis, tuple shape, ndarray out)
-cpdef ndarray concatenate_method(tup, int axis, ndarray out=*)
+    list arrays, Py_ssize_t axis, tuple shape, ndarray out, str casting)
+cpdef ndarray concatenate_method(
+    tup, int axis, ndarray out=*, dtype=*, casting=*)

--- a/cupy/_core/_routines_manipulation.pyx
+++ b/cupy/_core/_routines_manipulation.pyx
@@ -11,6 +11,7 @@ cimport cpython  # NOQA
 cimport cython  # NOQA
 from libcpp cimport vector
 
+from cupy._core._dtype cimport get_dtype
 from cupy._core cimport _routines_indexing as _indexing
 from cupy._core cimport core
 from cupy._core.core cimport ndarray
@@ -528,50 +529,80 @@ cpdef ndarray _repeat(ndarray a, repeats, axis=None):
     return ret
 
 
-cpdef ndarray concatenate_method(tup, int axis, ndarray out=None):
-    cdef int ndim, a_ndim
+cpdef ndarray concatenate_method(tup, int axis, ndarray out=None, dtype=None,
+                                 casting='same_kind'):
+    cdef int ndim0
     cdef int i
-    cdef ndarray a
-    cdef bint have_same_types
+    cdef ndarray a, a0
     cdef shape_t shape
 
-    ndim = -1
-    dtype = None
-    have_same_types = True
+    if dtype is not None:
+        dtype = get_dtype(dtype)
+
     arrays = list(tup)
+
+    # Check if the input is not an empty sequence
+    if len(arrays) == 0:
+        raise ValueError('Cannot concatenate from empty tuple')
+
+    # Check types of the input arrays
     for o in arrays:
         if not isinstance(o, ndarray):
             raise TypeError('Only cupy arrays can be concatenated')
-        a = o
-        a_ndim = a._shape.size()
-        if a_ndim == 0:
-            raise TypeError('zero-dimensional arrays cannot be concatenated')
-        if ndim == -1:
-            ndim = a_ndim
-            shape = a._shape
-            axis = internal._normalize_axis_index(axis, ndim)
-            dtype = a.dtype
-            continue
 
-        have_same_types = have_same_types and (a.dtype == dtype)
-        if a_ndim != ndim:
+    # Check ndim > 0 for the input arrays
+    for o in arrays:
+        a = o
+        if a._shape.size() == 0:
+            raise TypeError('zero-dimensional arrays cannot be concatenated')
+
+    # Check ndim consistency of the input arrays
+    a0 = arrays[0]
+    ndim0 = a0._shape.size()
+    for o in arrays[1:]:
+        a = o
+        if a._shape.size() != ndim0:
             raise ValueError(
                 'All arrays to concatenate must have the same ndim')
-        for i in range(ndim):
-            if i != axis and shape[i] != a._shape[i]:
+
+    # Check shape consistency of the input arrays, and compute the output shape
+    shape0 = a0._shape
+    axis = internal._normalize_axis_index(axis, ndim0)
+    for o in arrays[1:]:
+        a = o
+        for i in range(ndim0):
+            if i != axis and shape0[i] != a._shape[i]:
                 raise ValueError(
                     'All arrays must have same shape except the axis to '
                     'concatenate')
-        shape[axis] += a._shape[axis]
+        shape0[axis] += a._shape[axis]
 
-    if ndim == -1:
-        raise ValueError('Cannot concatenate from empty tuple')
-
-    shape_t = tuple(shape)
+    # Compute the output dtype
     if out is None:
-        if not have_same_types:
-            dtype = functools.reduce(numpy.promote_types,
-                                     set([a.dtype for a in arrays]))
+        if dtype is None:
+            dtype = a0.dtype
+            have_same_types = True
+            for o in arrays[1:]:
+                have_same_types = have_same_types and (o.dtype == dtype)
+            if not have_same_types:
+                dtype = functools.reduce(
+                    numpy.promote_types, set([a.dtype for a in arrays]))
+    else:
+        if dtype is not None:
+            raise TypeError('concatenate() only takes `out` or `dtype` as an '
+                            'argument, but both were provided.')
+        dtype = out.dtype
+
+    # Check casting rule
+    for o in arrays:
+        if not _can_cast(o.dtype, dtype, casting):
+            msg = (f"Cannot cast array data from dtype('{o.dtype}') to "
+                   f"dtype('{dtype}') according to the rule '{casting}'")
+            raise TypeError(msg)
+
+    # Prpare the output array
+    shape_t = tuple(shape0)
+    if out is None:
         out = ndarray(shape_t, dtype=dtype)
     else:
         if len(out.shape) != len(shape_t):
@@ -579,11 +610,11 @@ cpdef ndarray concatenate_method(tup, int axis, ndarray out=None):
         if out.shape != shape_t:
             raise ValueError('Output array is the wrong shape')
 
-    return _concatenate(arrays, axis, shape_t, out)
+    return _concatenate(arrays, axis, shape_t, out, casting)
 
 
 cpdef ndarray _concatenate(
-        list arrays, Py_ssize_t axis, tuple shape, ndarray out):
+        list arrays, Py_ssize_t axis, tuple shape, ndarray out, str casting):
     cdef ndarray a
     cdef Py_ssize_t i, aw, itemsize, axis_size
     cdef bint all_same_type, same_shape_and_contiguous
@@ -617,7 +648,7 @@ cpdef ndarray _concatenate(
         aw = a._shape[axis]
         slice_list[axis] = slice(i, i + aw)
         elementwise_copy(
-            a, _indexing._simple_getitem(out, slice_list), casting='same_kind')
+            a, _indexing._simple_getitem(out, slice_list), casting=casting)
         i += aw
     return out
 
@@ -648,6 +679,15 @@ cpdef Py_ssize_t size(ndarray a, axis=None) except? -1:
 
 
 # private
+
+
+cdef _numpy_can_cast = numpy.can_cast
+
+
+cdef bint _can_cast(d1, d2, casting):
+    if casting == 'same_kind' and d1.kind == d2.kind:  # most cases
+        return True
+    return _numpy_can_cast(d1, d2, casting=casting)
 
 
 cdef bint _has_element(const shape_t &source, Py_ssize_t n):

--- a/cupy/_manipulation/join.py
+++ b/cupy/_manipulation/join.py
@@ -32,7 +32,7 @@ def column_stack(tup):
     return concatenate(lst, axis=1)
 
 
-def concatenate(tup, axis=0, out=None):
+def concatenate(tup, axis=0, out=None, *, dtype=None, casting='same_kind'):
     """Joins arrays along an axis.
 
     Args:
@@ -42,6 +42,11 @@ def concatenate(tup, axis=0, out=None):
             If axis is None, arrays are flattened before use.
             Default is 0.
         out (cupy.ndarray): Output array.
+        dtype (str or dtype): If provided, the destination array will have this
+            dtype. Cannot be provided together with ``out``.
+        casting ({‘no’, ‘equiv’, ‘safe’, ‘same_kind’, ‘unsafe’}, optional):
+            Controls what kind of data casting may occur. Defaults to
+            ``'same_kind'``.
 
     Returns:
         cupy.ndarray: Joined array.
@@ -52,7 +57,7 @@ def concatenate(tup, axis=0, out=None):
     if axis is None:
         tup = [m.ravel() for m in tup]
         axis = 0
-    return _core.concatenate_method(tup, axis, out)
+    return _core.concatenate_method(tup, axis, out, dtype, casting)
 
 
 def dstack(tup):

--- a/tests/cupy_tests/manipulation_tests/test_join.py
+++ b/tests/cupy_tests/manipulation_tests/test_join.py
@@ -118,7 +118,7 @@ class TestJoin:
         return xp.concatenate((a, b, c, d, e) * 2, axis=-1)
 
     @testing.numpy_cupy_array_equal()
-    def test_concatenate_many_multi_dptye(self, xp):
+    def test_concatenate_many_multi_dtype(self, xp):
         a = testing.shaped_arange((2, 1), xp, 'i')
         b = testing.shaped_arange((2, 1), xp, 'f')
         return xp.concatenate((a, b) * 1024, axis=1)
@@ -207,6 +207,39 @@ class TestJoin:
         b = testing.shaped_arange((3, 4), xp, dtype1)
         out = xp.zeros((6, 4), dtype=dtype2)
         return xp.concatenate((a, b), out=out)
+
+    @testing.with_requires('numpy>=1.20.0')
+    @testing.for_all_dtypes_combination(names=['dtype1', 'dtype2'])
+    @testing.numpy_cupy_array_equal(accept_error=TypeError)
+    def test_concatenate_dtype(self, xp, dtype1, dtype2):
+        a = testing.shaped_arange((3, 4), xp, dtype1)
+        b = testing.shaped_arange((3, 4), xp, dtype1)
+        return xp.concatenate((a, b), dtype=dtype2)
+
+    @testing.with_requires('numpy>=1.20.0')
+    def test_concatenate_dtype_invalid_out(self):
+        for xp in (numpy, cupy):
+            a = testing.shaped_arange((3, 4), xp, xp.float64)
+            b = testing.shaped_arange((3, 4), xp, xp.float64)
+            out = xp.zeros((6, 4), dtype=xp.int64)
+            with pytest.raises(TypeError):
+                xp.concatenate((a, b), out=out, dtype=xp.int64)
+
+    @testing.with_requires('numpy>=1.20.0')
+    @pytest.mark.parametrize('casting', [
+        'no',
+        'equiv',
+        'safe',
+        'same_kind',
+        'unsafe',
+    ])
+    @testing.for_all_dtypes_combination(names=['dtype1', 'dtype2'])
+    @testing.numpy_cupy_array_equal(accept_error=TypeError)
+    def test_concatenate_casting(self, xp, dtype1, dtype2, casting):
+        a = testing.shaped_arange((3, 4), xp, dtype1)
+        b = testing.shaped_arange((3, 4), xp, dtype1)
+        # may raise TypeError
+        return xp.concatenate((a, b), dtype=dtype2)
 
     @testing.numpy_cupy_array_equal()
     def test_dstack(self, xp):


### PR DESCRIPTION
Close #5700. Blocked by #5764.