### PR TITLE
Adding 'bitorder' support to `cupy.unpackbits` 

### DIFF
--- a/cupy/_binary/packing.py
+++ b/cupy/_binary/packing.py
@@ -62,7 +62,7 @@ def unpackbits(myarray, bitorder='big'):
     Args:
         myarray (cupy.ndarray): Input array.
 
-        bitorder : {'big', 'little'}, optional. Defaults to 'big'
+        bitorder (str, optional): bit order to use when unpacking the array, allowed values are `'little'` and `'big'`. Defaults to `'big'`.
 
     Returns:
         cupy.ndarray: The unpacked array.

--- a/cupy/_binary/packing.py
+++ b/cupy/_binary/packing.py
@@ -62,7 +62,9 @@ def unpackbits(myarray, bitorder='big'):
     Args:
         myarray (cupy.ndarray): Input array.
 
-        bitorder (str, optional): bit order to use when unpacking the array, allowed values are `'little'` and `'big'`. Defaults to `'big'`.
+        bitorder (str, optional): bit order to use when unpacking the array,
+
+        allowed values are `'little'` and `'big'`. Defaults to `'big'`.
 
     Returns:
         cupy.ndarray: The unpacked array.

--- a/cupy/_binary/packing.py
+++ b/cupy/_binary/packing.py
@@ -62,7 +62,7 @@ def unpackbits(myarray, bitorder='big'):
     Args:
         myarray (cupy.ndarray): Input array.
 
-        bitorder{'big', 'little'}, optional. Defaults to 'big'
+        bitorder : {'big', 'little'}, optional. Defaults to 'big'
 
     Returns:
         cupy.ndarray: The unpacked array.
@@ -73,7 +73,7 @@ def unpackbits(myarray, bitorder='big'):
         raise TypeError('Expected an input array of unsigned byte data type')
 
     if bitorder not in ['big', 'little']:
-        raise ValueError(f"bitorder must be either 'big' or 'little' not '{bitorder}'")
+        raise ValueError("bitorder must be either 'big' or 'little'")
 
     unpacked = cupy.ndarray((myarray.size * 8), dtype=cupy.uint8)
     return _unpackbits_kernel[bitorder](myarray, unpacked)

--- a/cupy/_binary/packing.py
+++ b/cupy/_binary/packing.py
@@ -42,16 +42,16 @@ def packbits(myarray):
     return _packbits_kernel(myarray, myarray.size, packed)
 
 
-_unpackbits_kernel = { 'big': _core.ElementwiseKernel(
+_unpackbits_kernel = {'big': _core.ElementwiseKernel(
                             'raw uint8 myarray', 'T unpacked',
                             'unpacked = (myarray[i / 8] >> (7 - i % 8)) & 1;',
                             'cupy_unpackbits_kernel'
-                        ),
-                        'little': _core.ElementwiseKernel(
+                            ),
+                      'little': _core.ElementwiseKernel(
                             'raw uint8 myarray', 'T unpacked',
                             'unpacked = (myarray[i / 8] >> (i % 8)) & 1;',
                             'cupy_unpackbits_kernel'
-                        ) }
+                            )}
 
 
 def unpackbits(myarray, bitorder='big'):

--- a/cupy/_binary/packing.py
+++ b/cupy/_binary/packing.py
@@ -42,20 +42,27 @@ def packbits(myarray):
     return _packbits_kernel(myarray, myarray.size, packed)
 
 
-_unpackbits_kernel = _core.ElementwiseKernel(
-    'raw uint8 myarray', 'T unpacked',
-    'unpacked = (myarray[i / 8] >> (7 - i % 8)) & 1;',
-    'cupy_unpackbits_kernel'
-)
+_unpackbits_kernel = { 'big': _core.ElementwiseKernel(
+                            'raw uint8 myarray', 'T unpacked',
+                            'unpacked = (myarray[i / 8] >> (7 - i % 8)) & 1;',
+                            'cupy_unpackbits_kernel'
+                        ),
+                        'little': _core.ElementwiseKernel(
+                            'raw uint8 myarray', 'T unpacked',
+                            'unpacked = (myarray[i / 8] >> (i % 8)) & 1;',
+                            'cupy_unpackbits_kernel'
+                        ) }
 
 
-def unpackbits(myarray):
+def unpackbits(myarray, bitorder='big'):
     """Unpacks elements of a uint8 array into a binary-valued output array.
 
     This function currently does not support ``axis`` option.
 
     Args:
         myarray (cupy.ndarray): Input array.
+
+        bitorder{'big', 'little'}, optional. Defaults to 'big'
 
     Returns:
         cupy.ndarray: The unpacked array.
@@ -65,5 +72,8 @@ def unpackbits(myarray):
     if myarray.dtype != cupy.uint8:
         raise TypeError('Expected an input array of unsigned byte data type')
 
+    if bitorder not in ['big', 'little']:
+        raise ValueError(f"bitorder must be either 'big' or 'little' not '{bitorder}'")
+
     unpacked = cupy.ndarray((myarray.size * 8), dtype=cupy.uint8)
-    return _unpackbits_kernel(myarray, unpacked)
+    return _unpackbits_kernel[bitorder](myarray, unpacked)

--- a/cupy/_binary/packing.py
+++ b/cupy/_binary/packing.py
@@ -43,15 +43,15 @@ def packbits(myarray):
 
 
 _unpackbits_kernel = {'big': _core.ElementwiseKernel(
-                            'raw uint8 myarray', 'T unpacked',
-                            'unpacked = (myarray[i / 8] >> (7 - i % 8)) & 1;',
-                            'cupy_unpackbits_kernel'
-                            ),
-                      'little': _core.ElementwiseKernel(
-                            'raw uint8 myarray', 'T unpacked',
-                            'unpacked = (myarray[i / 8] >> (i % 8)) & 1;',
-                            'cupy_unpackbits_kernel'
-                            )}
+    'raw uint8 myarray', 'T unpacked',
+    'unpacked = (myarray[i / 8] >> (7 - i % 8)) & 1;',
+    'cupy_unpackbits_kernel'
+),
+    'little': _core.ElementwiseKernel(
+    'raw uint8 myarray', 'T unpacked',
+    'unpacked = (myarray[i / 8] >> (i % 8)) & 1;',
+    'cupy_unpackbits_kernel'
+)}
 
 
 def unpackbits(myarray, bitorder='big'):

--- a/tests/cupy_tests/binary_tests/test_packing.py
+++ b/tests/cupy_tests/binary_tests/test_packing.py
@@ -54,3 +54,4 @@ class TestPacking(unittest.TestCase):
         a = cupy.array([10, 20, 30], dtype=cupy.uint8)
         pytest.raises(ValueError, cupy.unpackbits, a,  bitorder='r')
         pytest.raises(ValueError, cupy.unpackbits, a,  bitorder=10)
+        

--- a/tests/cupy_tests/binary_tests/test_packing.py
+++ b/tests/cupy_tests/binary_tests/test_packing.py
@@ -52,5 +52,5 @@ class TestPacking(unittest.TestCase):
             self.check_unpackbits([255], bitorder=bo)
             self.check_unpackbits([100, 200, 123, 213], bitorder=bo)
         a = cupy.array([10, 20, 30], dtype=cupy.uint8)
-        pytest.raises(ValueError, cupy.unpackbits, a,  bitorder='r')
-        pytest.raises(ValueError, cupy.unpackbits, a,  bitorder=10)
+        pytest.raises(ValueError, cupy.unpackbits, a, bitorder='r')
+        pytest.raises(ValueError, cupy.unpackbits, a, bitorder=10)

--- a/tests/cupy_tests/binary_tests/test_packing.py
+++ b/tests/cupy_tests/binary_tests/test_packing.py
@@ -54,4 +54,3 @@ class TestPacking(unittest.TestCase):
         a = cupy.array([10, 20, 30], dtype=cupy.uint8)
         pytest.raises(ValueError, cupy.unpackbits, a,  bitorder='r')
         pytest.raises(ValueError, cupy.unpackbits, a,  bitorder=10)
-        

--- a/tests/cupy_tests/binary_tests/test_packing.py
+++ b/tests/cupy_tests/binary_tests/test_packing.py
@@ -41,8 +41,8 @@ class TestPacking(unittest.TestCase):
         self.check_unpackbits([255])
         self.check_unpackbits([100, 200, 123, 213])
         a = cupy.array([10, 20, 30])
-        pytest.raises(TypeError, cupy.unpackbits, cupy.array([10, 20, 30],dtype=int))
-        pytest.raises(TypeError, cupy.unpackbits, cupy.array([10, 20, 30],dtype=float))
+        pytest.raises(TypeError, cupy.unpackbits, a)
+        pytest.raises(TypeError, cupy.unpackbits, a.astype(float))
 
     def test_pack_unpack_order(self):
         for bo in ['big', 'little']:
@@ -54,6 +54,3 @@ class TestPacking(unittest.TestCase):
         a = cupy.array([10, 20, 30], dtype=cupy.uint8)
         pytest.raises(ValueError, cupy.unpackbits, a,  bitorder='r')
         pytest.raises(ValueError, cupy.unpackbits, a,  bitorder=10)
-
-        # assert_raises(ValueError, np.unpackbits, a, bitorder='r')
-        # assert_raises(TypeError, np.unpackbits, a, bitorder=10)

--- a/tests/cupy_tests/binary_tests/test_packing.py
+++ b/tests/cupy_tests/binary_tests/test_packing.py
@@ -40,6 +40,8 @@ class TestPacking(unittest.TestCase):
         self.check_unpackbits([1])
         self.check_unpackbits([255])
         self.check_unpackbits([100, 200, 123, 213])
+
+    def test_unpack_invalid_array(self):
         a = cupy.array([10, 20, 30])
         pytest.raises(TypeError, cupy.unpackbits, a)
         pytest.raises(TypeError, cupy.unpackbits, a.astype(float))
@@ -51,6 +53,8 @@ class TestPacking(unittest.TestCase):
             self.check_unpackbits([1], bitorder=bo)
             self.check_unpackbits([255], bitorder=bo)
             self.check_unpackbits([100, 200, 123, 213], bitorder=bo)
+
+    def test_unpack_invalid_order(self):
         a = cupy.array([10, 20, 30], dtype=cupy.uint8)
         pytest.raises(ValueError, cupy.unpackbits, a, bitorder='r')
         pytest.raises(ValueError, cupy.unpackbits, a, bitorder=10)


### PR DESCRIPTION
This PR is about this issue: https://github.com/cupy/cupy/issues/5762