### PR TITLE
Fix: Allow generating cubins for the max known CC

### DIFF
--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -150,6 +150,7 @@ def _get_arch():
         return min(arch, nvrtc_max_compute_capability)
 
 
+@_util.memoize(for_each_device=True)
 def _get_arch_for_options_for_nvrtc(arch=None):
     # NVRTC in CUDA 11.3+ generates PTX that cannot be run an earlier driver
     # version than the one included in the used CUDA version, as
@@ -165,7 +166,7 @@ def _get_arch_for_options_for_nvrtc(arch=None):
         version = _cuda_hip_version
     if (
         not _use_ptx and version >= 11010
-        and arch < _get_max_compute_capability()
+        and arch <= _get_max_compute_capability()
     ):
         return f'-arch=sm_{arch}', 'cubin'
     return f'-arch=compute_{arch}', 'ptx'


### PR DESCRIPTION
On CUDA 11.4 + driver 470.57 + A6000, I am seeing the following error in `test_raw.py`: 
```
$ pytest tests/cupy_tests/core_tests/test_raw.py 

...

cupy/cuda/compiler.py:582: in _compile_with_cache_cuda
    mod.load(cubin)
cupy/cuda/function.pyx:264: in cupy.cuda.function.Module.load
    cpdef load(self, bytes cubin):
cupy/cuda/function.pyx:266: in cupy.cuda.function.Module.load
    self.ptr = driver.moduleLoadData(cubin)
cupy_backends/cuda/api/driver.pyx:192: in cupy_backends.cuda.api.driver.moduleLoadData
    check_status(status)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

>   raise CUDADriverError(status)
E   cupy_backends.cuda.api.driver.CUDADriverError: CUDA_ERROR_INVALID_PTX: a PTX JIT compilation failed

cupy_backends/cuda/api/driver.pyx:60: CUDADriverError
=========================================================== short test summary info ===========================================================
FAILED tests/cupy_tests/core_tests/test_raw.py::TestRaw_param_0_{backend='nvrtc', in_memory=False}::test_dynamical_parallelism_compile_failure
FAILED tests/cupy_tests/core_tests/test_raw.py::TestRaw_param_1_{backend='nvrtc', in_memory=True}::test_dynamical_parallelism_compile_failure
FAILED tests/cupy_tests/core_tests/test_raw.py::TestRaw_param_2_{backend='nvrtc', clean_up=True, in_memory=True}::test_dynamical_parallelism_compile_failure
FAILED tests/cupy_tests/core_tests/test_raw.py::TestRaw_param_3_{backend='nvrtc', in_memory=False, jitify=True}::test_dynamical_parallelism_compile_failure
FAILED tests/cupy_tests/core_tests/test_raw.py::TestRaw_param_4_{backend='nvrtc', in_memory=True, jitify=True}::test_dynamical_parallelism_compile_failure
FAILED tests/cupy_tests/core_tests/test_raw.py::TestRaw_param_5_{backend='nvrtc', clean_up=True, in_memory=True, jitify=True}::test_dynamical_parallelism_compile_failure
============================================ 6 failed, 215 passed, 10 skipped in 61.16s (0:01:01) =============================================
```

This PR fixes the test by ~~relaxing the version requirement~~ removing the invalid arch check.