### PR TITLE
Update `cupy.array_api`

### DIFF
--- a/cupy/array_api/__init__.py
+++ b/cupy/array_api/__init__.py
@@ -341,13 +341,14 @@ from ._manipulation_functions import (
     concat,
     expand_dims,
     flip,
+    permute_dims,
     reshape,
     roll,
     squeeze,
     stack,
 )
 
-__all__ += ["concat", "expand_dims", "flip", "reshape", "roll", "squeeze", "stack"]
+__all__ += ["concat", "expand_dims", "flip", "permute_dims", "reshape", "roll", "squeeze", "stack"]
 
 from ._searching_functions import argmax, argmin, nonzero, where
 

--- a/cupy/array_api/__init__.py
+++ b/cupy/array_api/__init__.py
@@ -143,6 +143,8 @@ from ._creation_functions import (
     meshgrid,
     ones,
     ones_like,
+    tril,
+    triu,
     zeros,
     zeros_like,
 )
@@ -160,6 +162,8 @@ __all__ += [
     "meshgrid",
     "ones",
     "ones_like",
+    "tril",
+    "triu",
     "zeros",
     "zeros_like",
 ]

--- a/cupy/array_api/__init__.py
+++ b/cupy/array_api/__init__.py
@@ -333,9 +333,9 @@ __all__ += [
 # from ._linear_algebra_functions import einsum
 # __all__ += ['einsum']
 
-from ._linear_algebra_functions import matmul, tensordot, transpose, vecdot
+from ._linear_algebra_functions import matmul, tensordot, matrix_transpose, vecdot
 
-__all__ += ["matmul", "tensordot", "transpose", "vecdot"]
+__all__ += ["matmul", "tensordot", "matrix_transpose", "vecdot"]
 
 from ._manipulation_functions import (
     concat,

--- a/cupy/array_api/_array_object.py
+++ b/cupy/array_api/_array_object.py
@@ -989,6 +989,11 @@ class Array:
         res = self._array.__rxor__(other._array)
         return self.__class__._new(res)
 
+    def to_device(self: Array, device: Device, /) -> Array:
+        if device == 'cpu':
+            return self
+        raise ValueError(f"Unsupported device {device!r}")
+
     @property
     def dtype(self) -> Dtype:
         """

--- a/cupy/array_api/_array_object.py
+++ b/cupy/array_api/_array_object.py
@@ -1007,6 +1007,12 @@ class Array:
     def device(self) -> Device:
         return self._array.device
 
+    # Note: mT is new in array API spec (see matrix_transpose)
+    @property
+    def mT(self) -> Array:
+        from ._linear_algebra_functions import matrix_transpose
+        return matrix_transpose(self)
+
     @property
     def ndim(self) -> int:
         """
@@ -1041,4 +1047,11 @@ class Array:
 
         See its docstring for more information.
         """
+        # Note: T only works on 2-dimensional arrays. See the corresponding
+        # note in the specification:
+        # https://data-apis.org/array-api/latest/API_specification/array_object.html#t
+        if self.ndim != 2:
+            raise ValueError("x.T requires x to have 2 dimensions. Use x.mT to transpose stacks of matrices.")
+            # TODO: Add note about permute_dims() to the error message once it is
+            # finalized in the spec.
         return self._array.T

--- a/cupy/array_api/_array_object.py
+++ b/cupy/array_api/_array_object.py
@@ -391,6 +391,8 @@ class Array:
         # Note: This is an error here.
         if self._array.ndim != 0:
             raise TypeError("bool is only allowed on arrays with 0 dimensions")
+        if self.dtype not in _boolean_dtypes:
+            raise ValueError("bool is only allowed on boolean arrays")
         res = self._array.__bool__()
         return res
 
@@ -426,6 +428,8 @@ class Array:
         # Note: This is an error here.
         if self._array.ndim != 0:
             raise TypeError("float is only allowed on arrays with 0 dimensions")
+        if self.dtype not in _floating_dtypes:
+            raise ValueError("float is only allowed on floating-point arrays")
         res = self._array.__float__()
         return res
 
@@ -485,7 +489,16 @@ class Array:
         # Note: This is an error here.
         if self._array.ndim != 0:
             raise TypeError("int is only allowed on arrays with 0 dimensions")
+        if self.dtype not in _integer_dtypes:
+            raise ValueError("int is only allowed on integer arrays")
         res = self._array.__int__()
+        return res
+
+    def __index__(self: Array, /) -> int:
+        """
+        Performs the operation __index__.
+        """
+        res = self._array.__index__()
         return res
 
     def __invert__(self: Array, /) -> Array:

--- a/cupy/array_api/_array_object.py
+++ b/cupy/array_api/_array_object.py
@@ -1051,7 +1051,5 @@ class Array:
         # note in the specification:
         # https://data-apis.org/array-api/latest/API_specification/array_object.html#t
         if self.ndim != 2:
-            raise ValueError("x.T requires x to have 2 dimensions. Use x.mT to transpose stacks of matrices.")
-            # TODO: Add note about permute_dims() to the error message once it is
-            # finalized in the spec.
+            raise ValueError("x.T requires x to have 2 dimensions. Use x.mT to transpose stacks of matrices and permute_dims() to permute dimensions.")
         return self._array.T

--- a/cupy/array_api/_creation_functions.py
+++ b/cupy/array_api/_creation_functions.py
@@ -23,7 +23,7 @@ def _check_valid_dtype(dtype):
     # Note: Only spelling dtypes as the dtype objects is supported.
 
     # We use this instead of "dtype in _all_dtypes" because the dtype objects
-    # define equality with the sorts of things we want to disallw.
+    # define equality with the sorts of things we want to disallow.
     for d in (None,) + _all_dtypes:
         if dtype is d:
             return
@@ -319,6 +319,34 @@ def ones_like(
         device = _Device()  # current device
     with device:
         return Array._new(np.ones_like(x._array, dtype=dtype))
+
+
+def tril(x: Array, /, *, k: int = 0) -> Array:
+    """
+    Array API compatible wrapper for :py:func:`np.tril <numpy.tril>`.
+
+    See its docstring for more information.
+    """
+    from ._array_object import Array
+
+    if x.ndim < 2:
+        # Note: Unlike np.tril, x must be at least 2-D
+        raise ValueError("x must be at least 2-dimensional for tril")
+    return Array._new(np.tril(x._array, k=k))
+
+
+def triu(x: Array, /, *, k: int = 0) -> Array:
+    """
+    Array API compatible wrapper for :py:func:`np.triu <numpy.triu>`.
+
+    See its docstring for more information.
+    """
+    from ._array_object import Array
+
+    if x.ndim < 2:
+        # Note: Unlike np.triu, x must be at least 2-D
+        raise ValueError("x must be at least 2-dimensional for triu")
+    return Array._new(np.triu(x._array, k=k))
 
 
 def zeros(

--- a/cupy/array_api/_linear_algebra_functions.py
+++ b/cupy/array_api/_linear_algebra_functions.py
@@ -52,13 +52,12 @@ def tensordot(
     return Array._new(np.tensordot(x1._array, x2._array, axes=axes))
 
 
-def transpose(x: Array, /, *, axes: Optional[Tuple[int, ...]] = None) -> Array:
-    """
-    Array API compatible wrapper for :py:func:`np.transpose <numpy.transpose>`.
-
-    See its docstring for more information.
-    """
-    return Array._new(np.transpose(x._array, axes=axes))
+# Note: this function is new in the array API spec. Unlike transpose, it only
+# transposes the last two axes.
+def matrix_transpose(x: Array, /) -> Array:
+    if x.ndim < 2:
+        raise ValueError("x must be at least 2-dimensional for matrix_transpose")
+    return Array._new(np.swapaxes(x._array, -1, -2))
 
 
 # Note: vecdot is not in NumPy

--- a/cupy/array_api/_manipulation_functions.py
+++ b/cupy/array_api/_manipulation_functions.py
@@ -41,6 +41,17 @@ def flip(x: Array, /, *, axis: Optional[Union[int, Tuple[int, ...]]] = None) -> 
     return Array._new(np.flip(x._array, axis=axis))
 
 
+# Note: The function name is different here (see also matrix_transpose).
+# Unlike transpose(), the axes argument is required.
+def permute_dims(x: Array, /, axes: Tuple[int, ...]) -> Array:
+    """
+    Array API compatible wrapper for :py:func:`np.transpose <numpy.transpose>`.
+
+    See its docstring for more information.
+    """
+    return Array._new(np.transpose(x._array, axes))
+
+
 def reshape(x: Array, /, shape: Tuple[int, ...]) -> Array:
     """
     Array API compatible wrapper for :py:func:`np.reshape <numpy.reshape>`.

--- a/cupy/array_api/_statistical_functions.py
+++ b/cupy/array_api/_statistical_functions.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+from ._dtypes import (
+    _floating_dtypes,
+    _numeric_dtypes,
+)
 from ._array_object import Array
 
 from typing import Optional, Tuple, Union
@@ -14,6 +18,8 @@ def max(
     axis: Optional[Union[int, Tuple[int, ...]]] = None,
     keepdims: bool = False,
 ) -> Array:
+    if x.dtype not in _numeric_dtypes:
+        raise TypeError("Only numeric dtypes are allowed in max")
     return Array._new(np.max(x._array, axis=axis, keepdims=keepdims))
 
 
@@ -24,6 +30,8 @@ def mean(
     axis: Optional[Union[int, Tuple[int, ...]]] = None,
     keepdims: bool = False,
 ) -> Array:
+    if x.dtype not in _floating_dtypes:
+        raise TypeError("Only floating-point dtypes are allowed in mean")
     return Array._new(np.mean(x._array, axis=axis, keepdims=keepdims))
 
 
@@ -34,6 +42,8 @@ def min(
     axis: Optional[Union[int, Tuple[int, ...]]] = None,
     keepdims: bool = False,
 ) -> Array:
+    if x.dtype not in _numeric_dtypes:
+        raise TypeError("Only numeric dtypes are allowed in min")
     return Array._new(np.min(x._array, axis=axis, keepdims=keepdims))
 
 
@@ -44,6 +54,8 @@ def prod(
     axis: Optional[Union[int, Tuple[int, ...]]] = None,
     keepdims: bool = False,
 ) -> Array:
+    if x.dtype not in _numeric_dtypes:
+        raise TypeError("Only numeric dtypes are allowed in prod")
     return Array._new(np.prod(x._array, axis=axis, keepdims=keepdims))
 
 
@@ -56,6 +68,8 @@ def std(
     keepdims: bool = False,
 ) -> Array:
     # Note: the keyword argument correction is different here
+    if x.dtype not in _floating_dtypes:
+        raise TypeError("Only floating-point dtypes are allowed in std")
     return Array._new(np.std(x._array, axis=axis, ddof=correction, keepdims=keepdims))
 
 
@@ -66,6 +80,8 @@ def sum(
     axis: Optional[Union[int, Tuple[int, ...]]] = None,
     keepdims: bool = False,
 ) -> Array:
+    if x.dtype not in _numeric_dtypes:
+        raise TypeError("Only numeric dtypes are allowed in sum")
     return Array._new(np.sum(x._array, axis=axis, keepdims=keepdims))
 
 
@@ -78,4 +94,6 @@ def var(
     keepdims: bool = False,
 ) -> Array:
     # Note: the keyword argument correction is different here
+    if x.dtype not in _floating_dtypes:
+        raise TypeError("Only floating-point dtypes are allowed in var")
     return Array._new(np.var(x._array, axis=axis, ddof=correction, keepdims=keepdims))

--- a/cupy/array_api/_statistical_functions.py
+++ b/cupy/array_api/_statistical_functions.py
@@ -5,8 +5,13 @@ from ._dtypes import (
     _numeric_dtypes,
 )
 from ._array_object import Array
+from ._creation_functions import asarray
+from ._dtypes import float32, float64
 
-from typing import Optional, Tuple, Union
+from typing import TYPE_CHECKING, Optional, Tuple, Union
+
+if TYPE_CHECKING:
+    from ._typing import Dtype
 
 import cupy as np
 
@@ -52,10 +57,15 @@ def prod(
     /,
     *,
     axis: Optional[Union[int, Tuple[int, ...]]] = None,
+    dtype: Optional[Dtype] = None,
     keepdims: bool = False,
 ) -> Array:
     if x.dtype not in _numeric_dtypes:
         raise TypeError("Only numeric dtypes are allowed in prod")
+    # Note: sum() and prod() always upcast float32 to float64 for dtype=None
+    # We need to do so here before computing the product to avoid overflow
+    if dtype is None and x.dtype == float32:
+        x = asarray(x, dtype=float64)
     return Array._new(np.prod(x._array, axis=axis, keepdims=keepdims))
 
 
@@ -78,10 +88,15 @@ def sum(
     /,
     *,
     axis: Optional[Union[int, Tuple[int, ...]]] = None,
+    dtype: Optional[Dtype] = None,
     keepdims: bool = False,
 ) -> Array:
     if x.dtype not in _numeric_dtypes:
         raise TypeError("Only numeric dtypes are allowed in sum")
+    # Note: sum() and prod() always upcast float32 to float64 for dtype=None
+    # We need to do so here before summing to avoid overflow
+    if dtype is None and x.dtype == float32:
+        x = asarray(x, dtype=float64)
     return Array._new(np.sum(x._array, axis=axis, keepdims=keepdims))
 
 

--- a/tests/cupy_tests/array_api_tests/test_array_object.py
+++ b/tests/cupy_tests/array_api_tests/test_array_object.py
@@ -1,3 +1,5 @@
+import operator
+
 from numpy.testing import assert_raises
 import cupy as cp
 
@@ -255,15 +257,31 @@ def test_operators():
 
 
 def test_python_scalar_construtors():
-    a = asarray(False)
-    b = asarray(0)
-    c = asarray(0.0)
+    b = asarray(False)
+    i = asarray(0)
+    f = asarray(0.0)
 
-    assert bool(a) == bool(b) == bool(c) == False
-    assert int(a) == int(b) == int(c) == 0
-    assert float(a) == float(b) == float(c) == 0.0
+    assert bool(b) == False
+    assert int(i) == 0
+    assert float(f) == 0.0
+    assert operator.index(i) == 0
 
     # bool/int/float should only be allowed on 0-D arrays.
     assert_raises(TypeError, lambda: bool(asarray([False])))
     assert_raises(TypeError, lambda: int(asarray([0])))
     assert_raises(TypeError, lambda: float(asarray([0.0])))
+    assert_raises(TypeError, lambda: operator.index(asarray([0])))
+
+    # bool/int/float should only be allowed on arrays of the corresponding
+    # dtype
+    assert_raises(ValueError, lambda: bool(i))
+    assert_raises(ValueError, lambda: bool(f))
+
+    assert_raises(ValueError, lambda: int(b))
+    assert_raises(ValueError, lambda: int(f))
+
+    assert_raises(ValueError, lambda: float(b))
+    assert_raises(ValueError, lambda: float(i))
+
+    assert_raises(TypeError, lambda: operator.index(b))
+    assert_raises(TypeError, lambda: operator.index(f))


### PR DESCRIPTION
Follow-up of #5698. This PR applies the patch from https://github.com/numpy/numpy/pull/19937, except for the following two commits:
- https://github.com/numpy/numpy/pull/19937/commits/95fef5c14d2896bf948219fdfd984035c0f3fd34
- https://github.com/numpy/numpy/pull/19937/commits/faf68596c69432f6af9b307f06c1b25dd4c81ee7

The reason is they do not seem applicable in CuPy, though I could be wrong.