### PR TITLE
Skip tests for bug cases (FFT on CUDA 10.2 + Pascal)

### DIFF
--- a/tests/cupyx_tests/scipy_tests/fft_tests/test_fft.py
+++ b/tests/cupyx_tests/scipy_tests/fft_tests/test_fft.py
@@ -1657,8 +1657,12 @@ class TestHfft2:
     def test_hfft2(self, xp, dtype):
         x = testing.shaped_random(self.shape, xp, dtype)
         x_orig = x.copy()
-        out = _fft_module(xp).hfft2(x, s=self.s, axes=self.axes,
-                                    norm=self.norm)
+        with pytest.warns(None) as record:
+            out = _fft_module(xp).hfft2(x, s=self.s, axes=self.axes,
+                                        norm=self.norm)
+        if len(record) == 1 and 'issue of cuFFT' in record[0].message:
+            # CUDA 10.2 bug
+            pytest.skip(record[0].message)
         testing.assert_array_equal(x, x_orig)
         return _correct_np_dtype(xp, dtype, out)
 
@@ -1669,8 +1673,13 @@ class TestHfft2:
         x = testing.shaped_random(self.shape, xp, dtype)
         x_orig = x.copy()
         backend = 'scipy' if xp is np else cp_fft
-        with scipy_fft.set_backend(backend):
-            out = scipy_fft.hfft2(x, s=self.s, axes=self.axes, norm=self.norm)
+        with pytest.warns(None) as record:
+            with scipy_fft.set_backend(backend):
+                out = scipy_fft.hfft2(
+                    x, s=self.s, axes=self.axes, norm=self.norm)
+        if len(record) == 1 and 'issue of cuFFT' in record[0].message:
+            # CUDA 10.2 bug
+            pytest.skip(record[0].message)
         testing.assert_array_equal(x, x_orig)
         return _correct_np_dtype(xp, dtype, out)
 
@@ -1729,8 +1738,13 @@ class TestHfftn:
     def test_hfftn(self, xp, dtype):
         x = testing.shaped_random(self.shape, xp, dtype)
         x_orig = x.copy()
-        out = _fft_module(xp).hfftn(x, s=self.s, axes=self.axes,
-                                    norm=self.norm)
+
+        with pytest.warns(None) as record:
+            out = _fft_module(xp).hfftn(x, s=self.s, axes=self.axes,
+                                        norm=self.norm)
+        if len(record) == 1 and 'issue of cuFFT' in record[0].message:
+            # CUDA 10.2 bug
+            pytest.skip(record[0].message)
         testing.assert_array_equal(x, x_orig)
         return _correct_np_dtype(xp, dtype, out)
 
@@ -1741,8 +1755,13 @@ class TestHfftn:
         x = testing.shaped_random(self.shape, xp, dtype)
         x_orig = x.copy()
         backend = 'scipy' if xp is np else cp_fft
-        with scipy_fft.set_backend(backend):
-            out = scipy_fft.hfftn(x, s=self.s, axes=self.axes, norm=self.norm)
+        with pytest.warns(None) as record:
+            with scipy_fft.set_backend(backend):
+                out = scipy_fft.hfftn(
+                    x, s=self.s, axes=self.axes, norm=self.norm)
+        if len(record) == 1 and 'issue of cuFFT' in record[0].message:
+            # CUDA 10.2 bug
+            pytest.skip(record[0].message)
         testing.assert_array_equal(x, x_orig)
         return _correct_np_dtype(xp, dtype, out)
 


### PR DESCRIPTION
Automatically skip tests when hitting this condition:
https://github.com/cupy/cupy/blob/6071fc769486ce0209c6760215c3ecba64ba9e84/cupyx/scipy/fft/_fft.py#L508-L509

Jenkins uses P100, so it fails when testing with CUDA 10.2.