### PR TITLE
Fix error message comparison

### DIFF
--- a/tests/cupy_tests/core_tests/test_ndarray.py
+++ b/tests/cupy_tests/core_tests/test_ndarray.py
@@ -252,7 +252,7 @@ class TestNdarrayShape(unittest.TestCase):
             arr = xp.ndarray((2, 3), order='F')
             with pytest.raises(AttributeError) as e:
                 arr.shape = (3, 2)
-            assert 'Incompatible shape' in str(e.value)
+            assert 'incompatible shape' in str(e.value).lower()
 
 
 @pytest.mark.skipif(cupy.cuda.runtime.is_hip,


### PR DESCRIPTION
Follows-up #5749

```
NumPy 1.18
AttributeError: incompatible shape for a non-contiguous array

NumPy 1.19
AttributeError: Incompatible shape for in-place modification. Use `.reshape()` to make a copy with the desired shape.
```