### PR TITLE
Disable spmm on Windows CUDA 10.2

### DIFF
--- a/cupy/cusparse.py
+++ b/cupy/cusparse.py
@@ -84,8 +84,12 @@ _available_cusparse_version = {
     'csrgeam2': (9020, None),
     'csrgemm': (8000, 11000),
     'csrgemm2': (8000, None),
+
+    # Generic APIs are not available on CUDA 10.2 on Windows.
     'spmv': ({'Linux': 10200, 'Windows': 11000}, None),
-    'spmm': (10301, None),  # accuracy bugs in cuSparse 10.3.0
+    # accuracy bugs in cuSparse 10.3.0
+    'spmm': ({'Linux': 10301, 'Windows': 11000}, None),
+
     'csr2dense': (8000, None),
     'csc2dense': (8000, None),
     'csrsort': (8000, None),


### PR DESCRIPTION
Test failure detected in https://github.com/cupy/cupy/pull/5770 (https://ci.preferred.jp/cupy.win.cuda102/79678/)

cuSPARSE Generic APIs are not available on Windows + CUDA 10.2.


> LIMITATION: The generic APIs are currently available for all platforms except Windows. Using these APIs in any other systems will result in compile-time or run-time failures. Their support will be extended in the next releases.

https://docs.nvidia.com/cuda/archive/10.2/cusparse/index.html#cusparse-generic-api-reference