### PR TITLE
Clean up plan cache in a FFT slow test

### DIFF
--- a/tests/cupy_tests/fft_tests/test_fft.py
+++ b/tests/cupy_tests/fft_tests/test_fft.py
@@ -366,6 +366,8 @@ class TestFftAllocate:
         # Free huge memory for slow test
         del b
         cupy.get_default_memory_pool().free_all_blocks()
+        # Clean up FFT plan cache
+        cupy.fft.config.clear_plan_cache()
 
 
 @pytest.mark.usefixtures('skip_forward_backward')


### PR DESCRIPTION
Partially fix #5329.

Currently, `TestFftAllocate.test_fft_allocate` places a FFT plan to the plan cache in its `cupy.fft.fft` call. However, the cached plan (3GB+) is still being grabbed after returning from the test, which eventually causes OOM in another test that requires large memory. This PR fixes the test to clear the plan cache before it returns.
