### PR TITLE
Update upgrade guide

### DIFF
--- a/docs/source/upgrade.rst
+++ b/docs/source/upgrade.rst
@@ -119,7 +119,7 @@ cuTENSOR can now be used when installing CuPy via wheels.
 ``cupy.cuda.{nccl,cudnn}`` Modules Needs Explicit Import
 --------------------------------------------------------
 
-Previously ``import cupy.cuda`` automatically made ``cupy.cuda.nccl`` and ``cupy.cuda.cudnn`` modules available.
+Previously ``cupy.cuda.nccl`` and ``cupy.cuda.cudnn`` modules were automatically imported.
 Since CuPy v9, these modules need to be explicitly imported (i.e., ``import cupy.cuda.nccl`` / ``import cupy.cuda.cudnn``.)
 
 Baseline API Changes

--- a/docs/source/upgrade.rst
+++ b/docs/source/upgrade.rst
@@ -7,16 +7,21 @@ This is a list of changes introduced in each release that users should be aware 
 CuPy v10
 ========
 
-Dropping CUDA 9.2 Support
-----------------------------
+Dropping CUDA 9.2 / 10.0 / 10.1 Support
+---------------------------------------
 
-CUDA 9.2 is no longer supported.
-Use CUDA 10.0 or later.
+CUDA 10.1 or earlier is no longer supported.
+Use CUDA 9.2 or later.
 
 Dropping NCCL v2.4 Support
 -----------------------------
 
 NCCL v2.4 is no longer supported.
+
+Dropping Python 3.6 Support
+---------------------------
+
+Python 3.6 is no longer supported.
 
 Changes in :class:`cupy.cuda.Stream` Behavior
 ---------------------------------------------
@@ -105,6 +110,17 @@ NCCL and cuDNN No Longer Included in Wheels
 
 NCCL and cuDNN shared libraires are no longer included in wheels (see `#4850 <https://github.com/cupy/cupy/issues/4850>`_ for discussions). 
 You can manually install them after installing wheel if you don't have a previous installation; see :doc:`install` for details.
+
+cuTENSOR Enabled in Wheels
+--------------------------
+
+cuTENSOR can now be used when installing CuPy via wheels.
+
+``cupy.cuda.{nccl,cudnn}`` Modules Needs Explicit Import
+--------------------------------------------------------
+
+Previously ``import cupy.cuda`` automatically made ``cupy.cuda.nccl`` and ``cupy.cuda.cudnn`` modules available.
+In CuPy v9, you need to import them explicitly to use these modules (i.e., ``import cupy.cuda.nccl`` / ``import cupy.cuda.cudnn``.)
 
 Baseline API Changes
 --------------------

--- a/docs/source/upgrade.rst
+++ b/docs/source/upgrade.rst
@@ -11,7 +11,7 @@ Dropping CUDA 9.2 / 10.0 / 10.1 Support
 ---------------------------------------
 
 CUDA 10.1 or earlier is no longer supported.
-Use CUDA 9.2 or later.
+Use CUDA 10.2 or later.
 
 Dropping NCCL v2.4 Support
 -----------------------------
@@ -120,7 +120,7 @@ cuTENSOR can now be used when installing CuPy via wheels.
 --------------------------------------------------------
 
 Previously ``import cupy.cuda`` automatically made ``cupy.cuda.nccl`` and ``cupy.cuda.cudnn`` modules available.
-In CuPy v9, you need to import them explicitly to use these modules (i.e., ``import cupy.cuda.nccl`` / ``import cupy.cuda.cudnn``.)
+Since CuPy v9, these modules need to be explicitly imported (i.e., ``import cupy.cuda.nccl`` / ``import cupy.cuda.cudnn``.)
 
 Baseline API Changes
 --------------------


### PR DESCRIPTION
Closes #5766
Refs #5818 (keeping this issue open as this PR is not covering all changes in v10)

Auto-backport to v9 should fail, I'll take care of it.