### PR TITLE
Tentatively disable pytest-xdist

### DIFF
--- a/.pfnci/linux/tests/_build_and_test.sh
+++ b/.pfnci/linux/tests/_build_and_test.sh
@@ -9,7 +9,6 @@ pytest_opts=(
     --timeout 300
     --maxfail 500
     --showlocals
-    --numprocesses 2
 )
 
 if [[ "${MARKER}" != "" ]]; then


### PR DESCRIPTION
It seems that recently CI hangs for some reason.

https://ci.preferred.jp/cupy.linux.cuda114/
https://ci.preferred.jp/cupy.linux.cuda11x-cuda-python/

(Some timeout after running ``6h00m`` hard limit)

I haven't identified the root cause yet, but I'd like to disable recently-introduced pytest-xdist to isolate the issue.