### PR TITLE
[WIP] Use pylibcugraph for connected_components

### DIFF
--- a/tests/cupyx_tests/scipy_tests/sparse_tests/csgraph_tests/test_traversal.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/csgraph_tests/test_traversal.py
@@ -9,10 +9,10 @@ except ImportError:
     scipy_available = False
 import cupyx.scipy.sparse.csgraph  # NOQA
 try:
-    from cupy_backends.cuda.libs import cugraph  # NOQA
-    cugraph_available = True
+    import pylibcugraph
+    pylibcugraph_available = True
 except ImportError:
-    cugraph_available = False
+    pylibcugraph_available = False
 from cupy import testing
 
 
@@ -24,8 +24,8 @@ from cupy import testing
     'connection': ['weak', 'strong'],
     'return_labels': [True, False],
 }))
-@unittest.skipUnless(scipy_available and cugraph_available,
-                     'requires scipy and cugraph')
+@unittest.skipUnless(scipy_available and pylibcugraph_available,
+                     'requires scipy and pylibcugraph')
 class TestConnectedComponents(unittest.TestCase):
 
     def _make_matrix(self, dtype, xp):


### PR DESCRIPTION
Close https://github.com/cupy/cupy/issues/4219

This PR changes the backend of `connected_components` from `libcugraph` to `pylibcugraph`. If this change does not cause any problems, I will remove the cython wrapper for libcugraph.

@rlratzel, @kmaehashi, @leofang  - Thanks for all your comments on https://github.com/cupy/cupy/issues/4219.