### PR TITLE
Make `show_config` runnable without GPU

### DIFF
--- a/cupyx/_runtime.py
+++ b/cupyx/_runtime.py
@@ -268,7 +268,14 @@ class _RuntimeInfo:
             ('cuSPARSELt Build Version', self.cusparselt_version),
         ]
 
-        for device_id in range(cupy.cuda.runtime.getDeviceCount()):
+        device_count = 0
+        try:
+            device_count = cupy.cuda.runtime.getDeviceCount()
+        except cupy.cuda.runtime.CUDARuntimeError as e:
+            if 'ErrorNoDevice' not in e.args[0]:
+                raise
+            # No GPU devices available.
+        for device_id in range(device_count):
             with cupy.cuda.Device(device_id) as device:
                 props = cupy.cuda.runtime.getDeviceProperties(device_id)
                 name = ('Device {} Name'.format(device_id),


### PR DESCRIPTION
This makes it possible to verify CuPy installation without GPU (although CUDA/ROCm is still required.)

The output would look like this:

```py
>>> cupy.show_config()
OS                        : Linux-4.15.0-153-generic-x86_64-with-glibc2.27
Python Version            : 3.9.5
CuPy Version              : 10.0.0b3
CuPy Platform             : NVIDIA CUDA
NumPy Version             : 1.21.2
SciPy Version             : 1.7.1
Cython Build Version      : 3.0.0a9
Cython Runtime Version    : 3.0.0a9
CUDA Root                 : /usr/local/cuda-11.4.1
nvcc PATH                 : ccache nvcc
CUDA Build Version        : 11040
CUDA Driver Version       : 11040
CUDA Runtime Version      : CUDARuntimeError('cudaErrorNoDevice: no CUDA-capable device is detected')
cuBLAS Version            : (available)
cuFFT Version             : 10501
cuRAND Version            : 10205
cuSOLVER Version          : (11, 2, 0)
cuSPARSE Version          : (available)
NVRTC Version             : (11, 4)
Thrust Version            : 101201
CUB Build Version         : 101201
Jitify Build Version      : 60e9e72
cuDNN Build Version       : None
cuDNN Version             : None
NCCL Build Version        : None
NCCL Runtime Version      : None
cuTENSOR Version          : None
cuSPARSELt Build Version  : None
```