### PR TITLE
Fix non-determinisitc behavior in `cupy.random.shuffle`

### DIFF
--- a/cupy/random/_generator.py
+++ b/cupy/random/_generator.py
@@ -1111,31 +1111,9 @@ class RandomState(object):
 
     def _permutation(self, num):
         """Returns a permuted range."""
-        sample = cupy.empty((num), dtype=numpy.int32)
+        sample = cupy.empty((num,), dtype=numpy.int32)
         curand.generate(self._generator, sample.data.ptr, num)
-        if 128 < num <= 32 * 1024 * 1024:
-            array = cupy.arange(num, dtype=numpy.int32)
-            # apply sort of cache blocking
-            block_size = 1 * 1024 * 1024
-            # The block size above is a value determined from the L2 cache size
-            # of GP100 (L2 cache size / size of int = 4MB / 4B = 1M). It may be
-            # better to change the value base on the L2 cache size of the GPU
-            # you use.
-            # When num > block_size, cupy kernel: _cupy_permutation is to be
-            # launched multiple times. However, it is observed that performance
-            # will be degraded if the launch count is too many. Therefore,
-            # the block size is adjusted so that launch count will not exceed
-            # twelve Note that this twelve is the value determined from
-            # measurement on GP100.
-            while num // block_size > 12:
-                block_size *= 2
-            for j_start in range(0, num, block_size):
-                j_end = j_start + block_size
-                _cupy_permutation(sample, j_start, j_end, array, size=num)
-        else:
-            # When num > 32M, argsort is used, because it is faster than
-            # custom kernel. See https://github.com/cupy/cupy/pull/603.
-            array = cupy.argsort(sample)
+        array = cupy.argsort(sample)
         return array
 
     _gumbel_kernel = _core.ElementwiseKernel(
@@ -1187,62 +1165,6 @@ class RandomState(object):
         x = self._interval(diff, size).astype(dtype, copy=False)
         cupy.add(x, lo, out=x)
         return x
-
-
-_cupy_permutation = _core.ElementwiseKernel(
-    'raw int32 sample, int32 j_start, int32 _j_end',
-    'raw int32 array',
-    '''
-        const int invalid = -1;
-        const int num = _ind.size();
-        int j = (sample[i] & 0x7fffffff) % num;
-        int j_end = _j_end;
-        if (j_end > num) j_end = num;
-        if (j == i || j < j_start || j >= j_end) continue;
-
-        // If a thread fails to do data swaping once, it changes j
-        // value using j_offset below and try data swaping again.
-        // This process is repeated until data swapping is succeeded.
-        // The j_offset is determined from the initial j
-        // (random number assigned to each thread) and the initial
-        // offset between j and i (ID of each thread).
-        // If a given number sequence in sample is really random,
-        // this j-update would not be necessary. This is work-around
-        // mainly to avoid potential eternal conflict when sample has
-        // rather synthetic number sequence.
-        int j_offset = ((2*j - i + num) % (num - 1)) + 1;
-
-        // A thread gives up to do data swapping if loop count exceed
-        // a threathod determined below. This is kind of safety
-        // mechanism to escape the eternal race condition, though I
-        // believe it never happens.
-        int loops = 256;
-
-        bool do_next = true;
-        while (do_next && loops > 0) {
-            // try to swap the contents of array[i] and array[j]
-            if (i != j) {
-                int val_j = atomicExch(&array[j], invalid);
-                if (val_j != invalid) {
-                    int val_i = atomicExch(&array[i], invalid);
-                    if (val_i != invalid) {
-                        array[i] = val_j;
-                        array[j] = val_i;
-                        do_next = false;
-                        // done
-                    }
-                    else {
-                        // restore array[j]
-                        array[j] = val_j;
-                    }
-                }
-            }
-            j = (j + j_offset) % num;
-            loops--;
-        }
-    ''',
-    'cupy_permutation',
-)
 
 
 def seed(seed=None):


### PR DESCRIPTION
Close https://github.com/cupy/cupy/issues/5831. (cc: @Nanthini10)

`_cupy_permutation` kernel has a non-deterministic behavior.

There is the issue of non-determinism behavior in the kernel algorithm itself, so it cannot be solved by simply modifying the kernel implementation.
This PR will be modified to always use `argsort` for any array size.