### PR TITLE
Enhancement: NotImplementedError clarity

### DIFF
--- a/cupy/random/_generator.py
+++ b/cupy/random/_generator.py
@@ -1042,7 +1042,7 @@ class RandomState(object):
                 raise ValueError('probabilities do not sum to 1')
 
         if size is None:
-            raise NotImplementedError
+            raise ValuError('size cannot be None')
         shape = size
         size = numpy.prod(shape)
 


### PR DESCRIPTION
Changed ***raise NotImplementedError*** to ***raise ValueError('size cannot be none')*** in ***def choice(self, a, size=None, replace=True, p=None)*** on line ***1045***.
[https://github.com/cupy/cupy/issues/5832]