### PR TITLE
Deprecate `cupy.cuda.compile_with_cache`

### DIFF
--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -2080,7 +2080,7 @@ cpdef function.Module compile_with_cache(
     if _cuda_path is not None:
         options += ('-I' + os.path.join(_cuda_path, 'include'),)
 
-    return cuda.compile_with_cache(
+    return cuda.compiler._compile_module_with_cache(
         source, options, arch, cachd_dir, extra_source, backend,
         enable_cooperative_groups=enable_cooperative_groups,
         name_expressions=name_expressions, log_stream=log_stream,

--- a/cupy/cuda/__init__.py
+++ b/cupy/cuda/__init__.py
@@ -92,7 +92,6 @@ def is_available():
 
 
 # import class and function
-from cupy.cuda.compiler import compile_with_cache  # NOQA
 from cupy.cuda.device import Device  # NOQA
 from cupy.cuda.device import get_cublas_handle  # NOQA
 from cupy.cuda.device import get_device_id  # NOQA
@@ -124,6 +123,9 @@ from cupy.cuda.stream import get_current_stream  # NOQA
 from cupy.cuda.stream import get_elapsed_time  # NOQA
 from cupy.cuda.stream import Stream  # NOQA
 from cupy.cuda.stream import ExternalStream  # NOQA
+
+# Importing only for backward compatibility:
+from cupy.cuda.compiler import compile_with_cache  # NOQA
 
 
 @contextlib.contextmanager

--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -7,6 +7,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import warnings
 
 from cupy.cuda import device
 from cupy.cuda import function
@@ -429,7 +430,16 @@ def get_cache_dir():
 _empty_file_preprocess_cache = {}
 
 
-def compile_with_cache(
+def compile_with_cache(*args, **kwargs):
+    # TODO(kmaehashi): change to visible warning in CuPy v11+.
+    warnings.warn(
+        'cupy.cuda.compile_with_cache has been deprecated in CuPy v10, and'
+        ' will be removed in the future. Use cupy.RawModule or cupy.RawKernel'
+        ' instead.', DeprecationWarning)
+    _compile_module_with_cache(*args, **kwargs)
+
+
+def _compile_module_with_cache(
         source, options=(), arch=None, cache_dir=None, extra_source=None,
         backend='nvrtc', *, enable_cooperative_groups=False,
         name_expressions=None, log_stream=None, jitify=False):

--- a/tests/cupy_tests/core_tests/test_function.py
+++ b/tests/cupy_tests/core_tests/test_function.py
@@ -13,7 +13,7 @@ from cupy import testing
 def _compile_func(kernel_name, code):
     # workaround for hipRTC
     extra_source = core._get_header_source() if runtime.is_hip else None
-    mod = compiler.compile_with_cache(code, extra_source=extra_source)
+    mod = compiler._compile_module_with_cache(code, extra_source=extra_source)
     return mod.get_function(kernel_name)
 
 


### PR DESCRIPTION
As discussed in #5297, deprecating the legacy compile API.

I've renamed the existing `compile_with_cache` function under `cupy.cuda` to `_compile_module_with_cache` to distinguish it with `cupy._core.core.compile_with_cache`.