### PR TITLE
Upload cache even when test failed in FlexCI

### DIFF
--- a/.pfnci/linux/main-flexci.sh
+++ b/.pfnci/linux/main-flexci.sh
@@ -24,7 +24,7 @@ test_retval=${PIPESTATUS[0]}
 echo "****************************************************************************************************"
 echo "Exit with status ${test_retval}"
 
-if [[ "${pull_req}" != "" ]]; then
+if [[ "${pull_req}" == "" ]]; then
     # Upload cache when testing a branch, even when test failed.
     echo "Uploading cache..."
     CACHE_DIR=/tmp/cupy_cache PULL_REQUEST="${pull_req}" "$(dirname ${0})/run.sh" "${TARGET}" cache_put | tee --append "${LOG_FILE}"


### PR DESCRIPTION
It seems branch test still times out even when xdist is disabled.
https://github.com/cupy/cupy/pull/5826
https://ci.preferred.jp/cupy.linux.cuda114/

This PR changes the test script to upload cache even when test failed by timeout. I think this improves the situation by gradually generating cache.