### PR TITLE
Fix `nan_to_num` to comply with NumPy API

### DIFF
--- a/cupy/_math/misc.py
+++ b/cupy/_math/misc.py
@@ -349,7 +349,7 @@ _nan_to_num = _core.create_ufunc(
       'out0 = nan_to_num(in0, in1, in2, in3)')),
     'out0 = in0',
     preamble=_nan_to_num_preamble,
-    doc=''' Elementwise nan_to_num function.
+    doc='''Elementwise nan_to_num function.
 
     .. seealso:: :func:`numpy.nan_to_num`
 
@@ -370,19 +370,20 @@ def _check_nan_inf(x, dtype, neg=None):
     return cupy.asanyarray(x, dtype)
 
 
-def nan_to_num(x, out=None, *, nan=0.0, posinf=None, neginf=None, **kwds):
-    """ Elementwise nan_to_num function.
+def nan_to_num(x, copy=True, nan=0.0, posinf=None, neginf=None):
+    """Replace NaN with zero and infinity with large finite numbers (default
+    behaviour) or with the numbers defined by the user using the `nan`,
+    `posinf` and/or `neginf` keywords.
 
     .. seealso:: :func:`numpy.nan_to_num`
 
     """
-
-    kwds.setdefault('out', out)
-    dtype = cupy.asanyarray(x).dtype
+    dtype = x.dtype
     nan = _check_nan_inf(nan, dtype)
     posinf = _check_nan_inf(posinf, dtype, False)
     neginf = _check_nan_inf(neginf, dtype, True)
-    return _nan_to_num(x, nan, posinf, neginf, **kwds)
+    out = None if copy else x
+    return _nan_to_num(x, nan, posinf, neginf, out=out)
 
 
 # TODO(okuta): Implement real_if_close

--- a/tests/cupy_tests/math_tests/test_misc.py
+++ b/tests/cupy_tests/math_tests/test_misc.py
@@ -218,6 +218,20 @@ class TestMisc(unittest.TestCase):
     def test_nan_to_num_inf_arg(self):
         self.check_unary_inf('nan_to_num', posinf=1.0, neginf=-1.0)
 
+    @testing.numpy_cupy_array_equal()
+    def test_nan_to_num_copy(self, xp):
+        x = xp.asarray([0, 1, xp.nan, 4], dtype=xp.float64)
+        y = xp.nan_to_num(x, copy=True)
+        assert x is not y
+        return y
+
+    @testing.numpy_cupy_array_equal()
+    def test_nan_to_num_inplace(self, xp):
+        x = xp.asarray([0, 1, xp.nan, 4], dtype=xp.float64)
+        y = xp.nan_to_num(x, copy=False)
+        assert x is y
+        return y
+
     @testing.for_all_dtypes(name='dtype_x', no_bool=True, no_complex=True)
     @testing.for_all_dtypes(name='dtype_y', no_bool=True)
     @testing.numpy_cupy_allclose(atol=1e-5)


### PR DESCRIPTION
Closes #5866, Follows-up #5295.

* Fix `cupy.nan_to_num` signature to comply with NumPy API.
* Fix docstring.
* Do not perform implicit H2D transfer.

This bug is v10 specific issue and not needed to backport.

This is no-compat as this drops support for `out` and `dtype` argument.