### PR TITLE
Show error when importing `cupy.array_api` with Python 3.7

### DIFF
--- a/cupy/array_api/__init__.py
+++ b/cupy/array_api/__init__.py
@@ -118,6 +118,13 @@ Still TODO in this module are:
 
 """
 
+# CuPy-specific: still need to support Python 3.7.
+import sys
+
+if sys.version_info < (3, 8):
+    raise RuntimeError('cupy.array_api requires Python 3.8+')
+
+
 import warnings
 
 warnings.warn(


### PR DESCRIPTION
This is to avoid this on Py37:

```
>>> import cupy.array_api
__main__:1: UserWarning: The numpy.array_api submodule is still experimental. See NEP 47.
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/maehashi/Development/cupy/cupy/array_api/__init__.py", line 133, in <module>
    from ._creation_functions import (
  File "/home/maehashi/Development/cupy/cupy/array_api/_creation_functions.py", line 43
    /,
    ^
SyntaxError: invalid syntax
```