### PR TITLE
Build CI docker images using BuildKit to utilize cache from registry

### DIFF
--- a/.pfnci/linux/main-flexci.sh
+++ b/.pfnci/linux/main-flexci.sh
@@ -19,7 +19,7 @@ fi
 
 echo "Starting: "${TARGET}""
 echo "****************************************************************************************************"
-CACHE_DIR=/tmp/cupy_cache PULL_REQUEST="${pull_req}" "$(dirname ${0})/run.sh" "${TARGET}" cache_get test 2>&1 | tee "${LOG_FILE}"
+CACHE_DIR=/tmp/cupy_cache PULL_REQUEST="${pull_req}" "$(dirname ${0})/run.sh" "${TARGET}" cache_get build test 2>&1 | tee "${LOG_FILE}"
 test_retval=${PIPESTATUS[0]}
 echo "****************************************************************************************************"
 echo "Exit with status ${test_retval}"

--- a/.pfnci/linux/run.sh
+++ b/.pfnci/linux/run.sh
@@ -75,7 +75,12 @@ main() {
   for stage in ${STAGES}; do case "${stage}" in
     build )
       tests_dir="${repo_root}/.pfnci/linux/tests"
-      docker build -t "${docker_image}" -f "${tests_dir}/${TARGET}.Dockerfile" "${tests_dir}"
+      DOCKER_BUILDKIT=1 docker build \
+          -t "${docker_image}" \
+          --cache-from "${docker_image}" \
+          --build-arg BUILDKIT_INLINE_CACHE=1 \
+          -f "${tests_dir}/${TARGET}.Dockerfile" \
+          "${tests_dir}"
       ;;
 
     rmi )


### PR DESCRIPTION
This PR changes FlexCI script to utilize BuildKit for docker build so that docker images are built during every pull-request test runs, while using cache from the GCR docker registry whenever possible.

This makes it possible to test a pull-request that changes FlexCI Dockerfiles without manually triggering `prep-linux` FlexCI project.

Regenerated: https://ci.preferred.jp/cupy.prep-linux/80685/