### PR TITLE
Revert "Tentatively disable pytest-xdist" (#5826)

### DIFF
--- a/.pfnci/linux/tests/actions/unittest.sh
+++ b/.pfnci/linux/tests/actions/unittest.sh
@@ -10,6 +10,7 @@ pytest_opts=(
     --maxfail 500
     --showlocals
     --durations 10
+    --numprocesses 2
 )
 
 if [[ "${MARKER}" != "" ]]; then


### PR DESCRIPTION
Reverts #5826 as cache issue has been resolved.