### PR TITLE
Copy source directory to support pip 21.3

### DIFF
--- a/.pfnci/linux/tests/actions/build.sh
+++ b/.pfnci/linux/tests/actions/build.sh
@@ -2,11 +2,11 @@
 
 set -uex
 
-src_dir=/src
-if ! touch "${src_dir}"; then
-    echo "Source directory (${src_dir}) is read-only; copying the source tree to /src-build"
-    cp -a /src /src-build
-    src_dir=/src-build
+src_dir=.
+if ! touch .; then
+    src_dir=$(mktemp -d)
+    echo "Source directory ($(pwd)) is read-only; copying the source tree to ${src_dir}"
+    cp -a . "${src_dir}"
 fi
 
 pushd "${src_dir}"


### PR DESCRIPTION
Previously pip copied the whole source tree before building it.
However pip 21.3, released today, stopped copying it.
As the source tree is read-only mounted in the Docker container we should manually copy it.

https://github.com/pypa/pip/issues/10128