### PR TITLE
Fix `_get_cuda_build_version` for ROCm

### DIFF
--- a/cupy/cuda/cub.pyx
+++ b/cupy/cuda/cub.pyx
@@ -86,7 +86,12 @@ def get_build_version():
 
 
 cpdef _get_cuda_build_version():
-    return CUPY_CUDA_VERSION
+    if CUPY_CUDA_VERSION > 0:
+        return CUPY_CUDA_VERSION
+    elif CUPY_HIP_VERSION > 0:
+        return CUPY_HIP_VERSION
+    else:
+        return 0
 
 
 cdef tuple _get_output_shape(ndarray arr, tuple out_axis, bint keepdims):

--- a/cupy_backends/cuda/libs/cusolver.pyx
+++ b/cupy_backends/cuda/libs/cusolver.pyx
@@ -9,7 +9,12 @@ from cupy_backends.cuda cimport stream as stream_module
 
 
 cpdef _get_cuda_build_version():
-    return CUPY_CUDA_VERSION
+    if CUPY_CUDA_VERSION > 0:
+        return CUPY_CUDA_VERSION
+    elif CUPY_HIP_VERSION > 0:
+        return CUPY_HIP_VERSION
+    else:
+        return 0
 
 
 ###############################################################################


### PR DESCRIPTION
Following up #5723.

