### PR TITLE
Avoid cache download failure in CI when conflicting with cache upload

### DIFF
--- a/.pfnci/linux/run.sh
+++ b/.pfnci/linux/run.sh
@@ -98,7 +98,7 @@ main() {
         exit 1
       fi
       mkdir -p "${CACHE_DIR}"
-      gsutil -m -q cp "${cache_gcs_dir}/${cache_archive}" . &&
+      gsutil -m -o 'GSUtil:sliced_object_download_threshold=0' -q cp "${cache_gcs_dir}/${cache_archive}" . &&
         tar -x -f "${cache_archive}" -C "${CACHE_DIR}" &&
         rm -f "${cache_archive}" || echo "WARNING: Remote cache could not be retrieved."
       ;;


### PR DESCRIPTION
Currently, cache download fails when cache upload (done in branch test) happens during the download.
This PR disables the sliced download to avoid the failure.
This also improve the download speed.