### PR TITLE
Fix `__repr__` of mode and scalar in cuTENSOR

### DIFF
--- a/cupy/cutensor.pyx
+++ b/cupy/cutensor.pyx
@@ -104,7 +104,7 @@ def check_availability(name):
     return True
 
 
-cdef class Mode(object):
+cdef class Mode:
 
     cdef:
         object _array
@@ -118,10 +118,10 @@ cdef class Mode(object):
         self.data = self._array.ctypes.data
 
     def __repr__(self):
-        return 'mode([' + ', '.join(self._array) + '])'
+        return 'mode(' + ', '.join([str(x) for x in self._array]) + ')'
 
 
-cdef class _Scalar(object):
+cdef class _Scalar:
 
     cdef:
         object _array
@@ -132,7 +132,9 @@ cdef class _Scalar(object):
         self.ptr = self._array.ctypes.data
 
     def __repr__(self):
-        return self._array.item()
+        return (
+            'scalar(' + str(self._array.item()) +
+            ', dtype=' + str(self._array.dtype) + ')')
 
 
 cdef Handle _get_handle():

--- a/tests/cupy_tests/test_cutensor.py
+++ b/tests/cupy_tests/test_cutensor.py
@@ -169,6 +169,28 @@ class TestCuTensor:
 
 
 @pytest.mark.skipif(not ct.available, reason='cuTensor is unavailable')
+class TestMode:
+
+    def test_create_mode_int(self):
+        m = cutensor.create_mode(10, 11, 12)
+        assert m.ndim == 3
+        assert repr(m) == 'mode(10, 11, 12)'
+
+    def test_create_mode_ascii(self):
+        m = cutensor.create_mode('x', 'y')
+        assert m.ndim == 2
+        assert repr(m) == 'mode(120, 121)'
+
+
+@pytest.mark.skipif(not ct.available, reason='cuTensor is unavailable')
+class TestScalar:
+
+    def test_create(self):
+        s = cutensor._Scalar(10, cupy.float32)
+        assert repr(s) == 'scalar(10.0, dtype=float32)'
+
+
+@pytest.mark.skipif(not ct.available, reason='cuTensor is unavailable')
 class TestCuTensorDescriptor:
 
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
This fixes the issue that `__repr__` is not working.
Also removed unnecessary `(object)`.