### PR TITLE
Support using cuTENSOR in elementwise ufuncs

### DIFF
--- a/cupy/_core/__init__.py
+++ b/cupy/_core/__init__.py
@@ -4,8 +4,10 @@ from cupy._core import internal  # NOQA
 
 
 # internal APIs for testing and developement
+from cupy._core._accelerator import set_elementwise_accelerators  # NOQA
 from cupy._core._accelerator import set_reduction_accelerators  # NOQA
 from cupy._core._accelerator import set_routine_accelerators  # NOQA
+from cupy._core._accelerator import get_elementwise_accelerators  # NOQA
 from cupy._core._accelerator import get_reduction_accelerators  # NOQA
 from cupy._core._accelerator import get_routine_accelerators  # NOQA
 

--- a/cupy/_core/_accelerator.pxd
+++ b/cupy/_core/_accelerator.pxd
@@ -1,3 +1,5 @@
+cdef list _elementwise_accelerators
+
 cdef list _reduction_accelerators
 
 cdef list _routine_accelerators

--- a/cupy/_core/_accelerator.pyx
+++ b/cupy/_core/_accelerator.pyx
@@ -1,5 +1,6 @@
 import os
 
+cdef list _elementwise_accelerators = []
 cdef list _reduction_accelerators = []
 cdef list _routine_accelerators = []
 
@@ -14,6 +15,11 @@ cdef int _get_accelerator(accelerator) except -1:
     raise ValueError('Unknown accelerator: {}'.format(accelerator))
 
 
+def set_elementwise_accelerators(accelerators):
+    global _elementwise_accelerators
+    _elementwise_accelerators = [_get_accelerator(b) for b in accelerators]
+
+
 def set_reduction_accelerators(accelerators):
     global _reduction_accelerators
     _reduction_accelerators = [_get_accelerator(b) for b in accelerators]
@@ -22,6 +28,10 @@ def set_reduction_accelerators(accelerators):
 def set_routine_accelerators(accelerators):
     global _routine_accelerators
     _routine_accelerators = [_get_accelerator(b) for b in accelerators]
+
+
+def get_elementwise_accelerators():
+    return _elementwise_accelerators
 
 
 def get_reduction_accelerators():
@@ -35,6 +45,7 @@ def get_routine_accelerators():
 cdef _set_default_accelerators():
     cdef str b, accelerator_names = os.getenv('CUPY_ACCELERATORS', '')
     cdef list accelerators = [b for b in accelerator_names.split(',') if b]
+    set_elementwise_accelerators(accelerators)
     set_reduction_accelerators(accelerators)
     set_routine_accelerators(accelerators)
 

--- a/cupy/_core/_kernel.pxd
+++ b/cupy/_core/_kernel.pxd
@@ -146,7 +146,7 @@ cdef class _Ops:
 
 
 cpdef create_ufunc(name, ops, routine=*, preamble=*, doc=*,
-                   default_casting=*, loop_prep=*, out_ops=*)
+                   default_casting=*, loop_prep=*, out_ops=*, cutensor_op=*)
 
 cdef tuple _get_arginfos(list args)
 

--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -1034,6 +1034,8 @@ cdef class ufunc:
         readonly object _loop_prep
         readonly object _default_casting
         readonly object _cutensor_op
+        readonly int _cutensor_alpha
+        readonly int _cutensor_gamma
         readonly tuple _params
         readonly tuple _params_with_where
         readonly dict _routine_cache
@@ -1060,7 +1062,9 @@ cdef class ufunc:
         else:
             self._default_casting = default_casting
         if cutensor_op is not None and cuda_cutensor is not None:
-            self._cutensor_op = getattr(cuda_cutensor, cutensor_op)
+            self._cutensor_op, self._cutensor_alpha, self._cutensor_gamma = (
+                getattr(cuda_cutensor, cutensor_op[0]),
+                cutensor_op[1], cutensor_op[2])
         _in_params = tuple(
             ParameterInfo('T in%d' % i, True)
             for i in range(nin))
@@ -1182,8 +1186,8 @@ cdef class ufunc:
                     in _accelerator._elementwise_accelerators):
                 if self.nin == 2 and self.nout == 1:
                     ret = cupy.cutensor._try_elementwise_binary_routine(
-                        in_args[0], in_args[1], dtype, None,
-                        self._cutensor_op, 1, 1)
+                        in_args[0], in_args[1], dtype, None, self._cutensor_op,
+                        self._cutensor_alpha, self._cutensor_gamma)
                     if ret is not None:
                         return ret
 

--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -1184,7 +1184,9 @@ cdef class ufunc:
         if (self._cutensor_op is not None
                 and _accelerator.ACCELERATOR_CUTENSOR in
                 _accelerator._elementwise_accelerators):
-            if self.nin == 2 and self.nout == 1:
+            if (self.nin == 2 and self.nout == 1 and
+                    isinstance(in_args[0], ndarray) and
+                    isinstance(in_args[1], ndarray)):
                 ret = cupy.cutensor._try_elementwise_binary_routine(
                     in_args[0], in_args[1], dtype, None, self._cutensor_op,
                     self._cutensor_alpha, self._cutensor_gamma)

--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -1181,15 +1181,15 @@ cdef class ufunc:
         # _broadcast updates shape
         internal._broadcast_core(broad_values, shape)
 
-        if (self._cutensor_op is not None and
-            _accelerator.ACCELERATOR_CUTENSOR
-                    in _accelerator._elementwise_accelerators):
-                if self.nin == 2 and self.nout == 1:
-                    ret = cupy.cutensor._try_elementwise_binary_routine(
-                        in_args[0], in_args[1], dtype, None, self._cutensor_op,
-                        self._cutensor_alpha, self._cutensor_gamma)
-                    if ret is not None:
-                        return ret
+        if (self._cutensor_op is not None
+                and _accelerator.ACCELERATOR_CUTENSOR in
+                _accelerator._elementwise_accelerators):
+            if self.nin == 2 and self.nout == 1:
+                ret = cupy.cutensor._try_elementwise_binary_routine(
+                    in_args[0], in_args[1], dtype, None, self._cutensor_op,
+                    self._cutensor_alpha, self._cutensor_gamma)
+                if ret is not None:
+                    return ret
 
         op = self._ops.guess_routine(
             self.name, self._routine_cache, in_args, dtype, self._out_ops)

--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -16,6 +16,7 @@ from cupy.cuda cimport device
 from cupy.cuda cimport function
 from cupy.cuda cimport memory
 from cupy.cuda cimport texture
+from cupy._core cimport _accelerator
 from cupy._core cimport _carray
 from cupy._core cimport _scalar
 from cupy._core._dtype cimport get_dtype
@@ -1187,11 +1188,14 @@ cdef class ufunc:
         if _contains_zero(shape):
             return ret
         if (cuda_cutensor is not None and self._cutensor_op is not None and
-            self.nin == 2 and self.nout == 1):
-            ret = cupy.cutensor._try_elementwise_binary_routine(
-                in_args[0], in_args[1], dtype, out_args[0], self._cutensor_op, 1, 1)
-            if ret is not None:
-                return ret
+            _accelerator.ACCELERATOR_CUTENSOR
+                    in _accelerator._elementwise_accelerators):
+                if self.nin == 2 and self.nout == 1:
+                    ret = cupy.cutensor._try_elementwise_binary_routine(
+                        in_args[0], in_args[1], dtype, out_args[0],
+                        self._cutensor_op, 1, 1)
+                    if ret is not None:
+                        return ret
         inout_args = []
         for i, t in enumerate(op.in_types):
             x = broad_values[i]

--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -1188,8 +1188,12 @@ cdef class ufunc:
                     isinstance(in_args[0], ndarray) and
                     isinstance(in_args[1], ndarray)):
                 ret = cupy.cutensor._try_elementwise_binary_routine(
-                    in_args[0], in_args[1], dtype, None, self._cutensor_op,
-                    self._cutensor_alpha, self._cutensor_gamma)
+                    in_args[0], in_args[1], dtype,
+                    out_args[0] if len(out_args) == 1 else None,
+                    self._cutensor_op,
+                    self._cutensor_alpha,
+                    self._cutensor_gamma,
+                )
                 if ret is not None:
                     return ret
 

--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -1181,7 +1181,7 @@ cdef class ufunc:
         # _broadcast updates shape
         internal._broadcast_core(broad_values, shape)
 
-        if (cuda_cutensor is not None and self._cutensor_op is not None and
+        if (self._cutensor_op is not None and
             _accelerator.ACCELERATOR_CUTENSOR
                     in _accelerator._elementwise_accelerators):
                 if self.nin == 2 and self.nout == 1:

--- a/cupy/_core/_routines_math.pyx
+++ b/cupy/_core/_routines_math.pyx
@@ -851,7 +851,7 @@ _nanprod_complex_dtype = create_reduction_func(
     ''',
      'a * b', 'out0 = type_out0_raw(a)', None), 1)
 
-cdef create_arithmetic(name, op, boolop, doc):
+cdef create_arithmetic(name, op, boolop, doc, cutensor_op=None):
     # boolop is either
     #  - str (the operator for bool-bool inputs) or
     #  - callable (a function to raise an error for bool-bool inputs).
@@ -865,7 +865,8 @@ cdef create_arithmetic(name, op, boolop, doc):
          'LL->L', 'qq->q', 'QQ->Q', 'ee->e', 'ff->f', 'dd->d', 'FF->F',
          'DD->D'),
         'out0 = in0 %s in1' % op,
-        doc=doc)
+        doc=doc,
+        cutensor_op=cutensor_op)
 
 
 _add = create_arithmetic(
@@ -874,7 +875,8 @@ _add = create_arithmetic(
 
     .. seealso:: :data:`numpy.add`
 
-    ''')
+    ''',
+    cutensor_op='OP_ADD')
 
 
 _conjugate = create_ufunc(

--- a/cupy/_core/_routines_math.pyx
+++ b/cupy/_core/_routines_math.pyx
@@ -876,7 +876,7 @@ _add = create_arithmetic(
     .. seealso:: :data:`numpy.add`
 
     ''',
-    cutensor_op='OP_ADD')
+    cutensor_op=('OP_ADD', 1, 1))
 
 
 _conjugate = create_ufunc(
@@ -949,7 +949,8 @@ _multiply = create_arithmetic(
 
     .. seealso:: :data:`numpy.multiply`
 
-    ''')
+    ''',
+    cutensor_op=('OP_MUL', 1, 1))
 
 
 # `integral_power` should return somewhat appropriate values for negative
@@ -1009,7 +1010,8 @@ _subtract = create_arithmetic(
 
     .. seealso:: :data:`numpy.subtract`
 
-    ''')
+    ''',
+    cutensor_op=('OP_ADD', 1, -1))
 
 
 _true_divide = create_ufunc(

--- a/cupy/_math/misc.py
+++ b/cupy/_math/misc.py
@@ -253,7 +253,8 @@ maximum = _core.create_ufunc(
 
     .. seealso:: :data:`numpy.maximum`
 
-    ''')
+    ''',
+    cutensor_op=('OP_MAX', 1, 1))
 
 
 _float_minimum = ('out0 = (isnan(in0) | isnan(in1)) ? out0_type(NAN) : '
@@ -275,7 +276,8 @@ minimum = _core.create_ufunc(
 
     .. seealso:: :data:`numpy.minimum`
 
-    ''')
+    ''',
+    cutensor_op=('OP_MIN', 1, 1))
 
 
 fmax = _core.create_ufunc(

--- a/cupy/cutensor.pyx
+++ b/cupy/cutensor.pyx
@@ -835,6 +835,18 @@ def _try_elementwise_binary_routine(
         return None
 
     if out is None:
+        if c._c_contiguous:
+            pass
+        elif a._c_contiguous:
+            a, c = c, a
+            alpha, gamma = gamma, alpha
+        elif c._f_contiguous:
+            pass
+        elif a._f_contiguous:
+            a, c = c, a
+            alpha, gamma = gamma, alpha
+        else:
+            return None
         out = core._create_ndarray_from_shape_strides(
             c._shape, c._strides, dtype)
     elif out.dtype != dtype:

--- a/cupy/cutensor.pyx
+++ b/cupy/cutensor.pyx
@@ -811,10 +811,7 @@ def _try_reduction_routine(
 
 def _all_strides_positive(ndarray a):
     # cuTENSOR requires each stride > 0.
-    for s in a._strides:
-        if s <= 0:
-            return False
-    return True
+    return all(s > 0 for s in a._strides)
 
 
 def _try_elementwise_binary_routine(

--- a/cupy/cutensor.pyx
+++ b/cupy/cutensor.pyx
@@ -838,6 +838,10 @@ def _try_elementwise_binary_routine(
 
     compute_dtype = a.dtype
 
+    if (op == cutensor.OP_MAX or op == cutensor.OP_MIN) and \
+           compute_dtype.kind == 'c':
+        return None
+
     if out is None:
         if c._c_contiguous:
             pass

--- a/cupy/cutensor.pyx
+++ b/cupy/cutensor.pyx
@@ -385,7 +385,7 @@ def elementwise_binary(
         _create_scalar(alpha, compute_dtype),
         A, desc_A, _auto_create_mode(A, mode_A),
         _create_scalar(gamma, compute_dtype),
-        C, desc_C, _auto_create_mode(A, mode_C),
+        C, desc_C, _auto_create_mode(C, mode_C),
         out, op_AC, _dtype.to_cuda_dtype(compute_dtype, is_half_allowed=True))
 
 
@@ -394,6 +394,7 @@ cdef inline ndarray _elementwise_binary_impl(
         _Scalar alpha, ndarray A, TensorDescriptor desc_A, Mode mode_A,
         _Scalar gamma, ndarray C, TensorDescriptor desc_C, Mode mode_C,
         ndarray out, int op_AC, int compute_type):
+    # stride and mode of `out` and `C` must be the same.
     cutensor.elementwiseBinary(
         handle,
         alpha.ptr, A.data.ptr, desc_A, mode_A.data,

--- a/cupy/cutensor.pyx
+++ b/cupy/cutensor.pyx
@@ -835,7 +835,8 @@ def _try_elementwise_binary_routine(
         return None
 
     if out is None:
-        out = core._create_ndarray_from_shape_strides(c._shape, c._strides, dtype)
+        out = core._create_ndarray_from_shape_strides(
+            c._shape, c._strides, dtype)
     elif out.dtype != dtype:
         return None
     elif not internal.vector_equal(c._shape, out._shape):

--- a/cupy/cutensor.pyx
+++ b/cupy/cutensor.pyx
@@ -838,8 +838,8 @@ def _try_elementwise_binary_routine(
 
     compute_dtype = a.dtype
 
-    if (op == cutensor.OP_MAX or op == cutensor.OP_MIN) and \
-           compute_dtype.kind == 'c':
+    if compute_dtype.kind == 'c' and (
+            op == cutensor.OP_MAX or op == cutensor.OP_MIN):
         return None
 
     if out is None:

--- a/cupy/cutensor.pyx
+++ b/cupy/cutensor.pyx
@@ -831,8 +831,12 @@ def _try_elementwise_binary_routine(
         return None
     if not internal.vector_equal(a._shape, c._shape):
         return None
+    if a.size == 0:
+        return None
     if not (_all_strides_positive(a) and _all_strides_positive(c)):
         return None
+
+    compute_dtype = a.dtype
 
     if out is None:
         if c._c_contiguous:
@@ -848,8 +852,8 @@ def _try_elementwise_binary_routine(
         else:
             return None
         out = core._create_ndarray_from_shape_strides(
-            c._shape, c._strides, dtype)
-    elif out.dtype != dtype:
+            c._shape, c._strides, compute_dtype)
+    elif out.dtype != compute_dtype:
         return None
     elif not internal.vector_equal(c._shape, out._shape):
         return None
@@ -862,14 +866,14 @@ def _try_elementwise_binary_routine(
 
     return _elementwise_binary_impl(
         handle,
-        _create_scalar(alpha, dtype),
+        _create_scalar(alpha, compute_dtype),
         a,
         create_tensor_descriptor(a, handle=handle),
         _create_mode_with_cache(a._shape.size()),
-        _create_scalar(gamma, dtype),
+        _create_scalar(gamma, compute_dtype),
         c,
         create_tensor_descriptor(c, handle=handle),
         _create_mode_with_cache(c._shape.size()),
         out,
         op,
-        _dtype.to_cuda_dtype(dtype, is_half_allowed=True))
+        _dtype.to_cuda_dtype(compute_dtype, is_half_allowed=True))


### PR DESCRIPTION
Closes #5776.

This PR also fixes the issue in `cupy.cutensor.elementwise_binary` that the wrong mode is used for `C` (the second argument).