### PR TITLE
Improve the comparison table

### DIFF
--- a/docs/source/_comparison_generator.py
+++ b/docs/source/_comparison_generator.py
@@ -162,7 +162,6 @@ def generate():
         'scipy.stats', 'cupyx.scipy.stats', 'SciPy',
         blacklist=['test'])
 
-
     # numpy.array_api is not ready yet...
     #    buf += [
     #        'NumPy / CuPy Array APIs',


### PR DESCRIPTION
This PR contains several improvements to the comparison table. Closes #5110.

### Remove NumPy internal APIs

Blacklists APIs like `numpy.add_docstring` from the comparison table, as these functions are solely for internal use and are unlikely to be implemented in CuPy.

### Cover all modules

Fixes the issue that following modules were not on the comparison table:

* `cupyx.scipy.signal`
* `cupyx.scipy.stats`
* `cupyx.scipy.sparse.csgraph`

The module order has been changed to align with the latest SciPy docs.

### Improve the method to generate a list of APIs in NumPy/SciPy

Previously, classes and objects starting with the large cases were not on the table. Such APIs (e.g. `poly1d`, `coo_matrix`,  dtypes, `BitGenerator`, `numpy.c_`) must be included for completeness. Here is the comparison of the output before/after the commit c2cef67:
https://gist.github.com/kmaehashi/976b79d0c431f8d924242743c1f6cb4d