### PR TITLE
Fix fft test skip condition

### DIFF
--- a/tests/cupy_tests/fft_tests/test_fft.py
+++ b/tests/cupy_tests/fft_tests/test_fft.py
@@ -174,7 +174,7 @@ def _skip_multi_gpu_bug(shape, gpus):
     # avoid CUDA 11.0 (will be fixed by CUDA 11.2) bug triggered by
     # - batch = 1
     # - gpus = [1, 0]
-    if (11000 <= cupy.cuda.runtime.runtimeGetVersion() < 11200
+    if (11000 <= cupy.cuda.runtime.runtimeGetVersion() < 11020
             and len(shape) == 1
             and gpus == [1, 0]):
         pytest.skip('avoid CUDA 11 bug')


### PR DESCRIPTION
Follow-up #3775.
Fixes the issue that tests was unexpectedly skipped in CUDA 11.2+.

cc/ @leofang @pentschev