### PR TITLE
Fix `copyto` with non-contiguous multidevice

### DIFF
--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -549,11 +549,9 @@ cdef class ndarray:
             return self.astype(self.dtype, order=order)
 
         # It need to make a contiguous copy for copying from another device
-        runtime.setDevice(self.data.device_id)
-        try:
+        with self.device:
             x = self.astype(self.dtype, order=order, copy=False)
-        finally:
-            runtime.setDevice(dev_id)
+
         newarray = _ndarray_init(x._shape, x.dtype)
         if not x._c_contiguous and not x._f_contiguous:
             raise NotImplementedError(


### PR DESCRIPTION
This fixes an error when dealing with multiple devices and a non-contiguous copy.

https://github.com/cupy/cupy/blob/550133201e379168ca21217ef9eee5e9fd3087be/cupy/_core/core.pyx#L552-L557

Here, if the array is non-contiguous `astype` creates a new array and in  `elementwise_copy` it uses the `with device` context manager.
Before doing this we have changed the device manually  using `runtime.setDevice` so when that context manager exits, a wrong device is set as the current one.

Easy reproducer to see the issue

```python
import cupy


class manual:

    def __init__(self, dev):
        self._dev = dev

    def __enter__(self):
        self._prev = cupy.cuda.runtime.getDevice()
        cupy.cuda.runtime.setDevice(self._dev)  # Manual change

    def __exit__(self, *args):
        cupy.cuda.runtime.setDevice(self._prev)  # Manual change


def works():
    with cupy.cuda.Device(0):
        with cupy.cuda.Device(1):
            with cupy.cuda.Device(0):
                with cupy.cuda.Device(0):
                    pass
                print('works: current_device', cupy.cuda.runtime.getDevice())


def fails():
    with cupy.cuda.Device(0):
        with cupy.cuda.Device(1):
            with manual(0):
                with cupy.cuda.Device(0):
                    pass
                print('fails: current_device', cupy.cuda.runtime.getDevice())


works()
fails()
```

output

```
works: current_device 0
fails: current_device 1
```

Originally reported by @kmaehashi 