### PR TITLE
Fix use of CUPY_CI environment variable

### DIFF
--- a/.pfnci/linux/tests/actions/_environment.sh
+++ b/.pfnci/linux/tests/actions/_environment.sh
@@ -4,6 +4,7 @@ export CCACHE_NOHASHDIR="true"
 export CUDA_CACHE_PATH="${CACHE_DIR}/.nv"
 export CUPY_CACHE_DIR="${CACHE_DIR}/.cupy/kernel_cache"
 
+export CUPY_CI="FlexCI"
 export CUPY_TEST_GPU_LIMIT="${GPU:--1}"
 export CUPY_DUMP_CUDA_SOURCE_ON_ERROR="1"
 

--- a/.pfnci/windows/test.ps1
+++ b/.pfnci/windows/test.ps1
@@ -59,6 +59,7 @@ function Main {
     ActivatePython $python
 
     # Setup build environment variables
+    $Env:CUPY_CI = "FlexCI"
     $Env:CUPY_NUM_BUILD_JOBS = "16"
     $Env:CUPY_NVCC_GENERATE_CODE = "current"
     echo "Environment:"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,5 @@
 import collections
 import os
-import subprocess
-import sys
 
 import pytest
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,24 +12,7 @@ import pytest
 pytest_plugins = ['pytester']
 
 
-def _is_pip_installed():
-    try:
-        import pip  # NOQA
-        return True
-    except ImportError:
-        return False
-
-
-def _is_in_ci():
-    ci_name = os.environ.get('CUPY_CI', '')
-    return ci_name != ''
-
-
 def pytest_configure(config):
-    # Print installed packages
-    if _is_in_ci() and _is_pip_installed():
-        print("***** Installed packages *****", flush=True)
-        subprocess.check_call([sys.executable, '-m', 'pip', 'freeze', '--all'])
     if config.pluginmanager.hasplugin("xdist"):
         config.pluginmanager.register(DeferPlugin())
 


### PR DESCRIPTION
* Declare CUPY_CI in FlexCI
* Remove `pip freeze` display (seems it's not working? if this is really needed I think it's better to do this outside of test suite)