### PR TITLE
Declare the same environment variables as Linux in Windows CI

### DIFF
--- a/.pfnci/windows/test.ps1
+++ b/.pfnci/windows/test.ps1
@@ -86,6 +86,9 @@ function Main {
         throw "Build failed with status $build_retval"
     }
 
+    $Env:CUPY_TEST_GPU_LIMIT = $Env:GPU
+    $Env:CUPY_DUMP_CUDA_SOURCE_ON_ERROR = "1"
+
     # Unit test
     if ($test -eq "build") {
         return


### PR DESCRIPTION
GPU limit was not set on Windows and test failed in #5496.