### PR TITLE
Workaround for CSR/CSC argmin/argmax on HIP

### DIFF
--- a/cupyx/scipy/sparse/data.py
+++ b/cupyx/scipy/sparse/data.py
@@ -201,6 +201,10 @@ class _minmax_mixin(object):
             raise ValueError("Can't apply the operation along a zero-sized "
                              "dimension.")
 
+        if self.dtype.kind == 'c':
+            raise NotImplementedError(
+                'Not supported for complex numbers when `axis` specified')
+
         mat = self.tocsc() if axis == 0 else self.tocsr()
         mat.sum_duplicates()
 


### PR DESCRIPTION
Rel #5843 and #5920.

CSR/CSC matrices' `argmin`/`argmax` methods have the same problem with #5920, as they have a templated kernel. This PR does the same care for that.

- [x] Implementation
- [ ] Writing a test