### PR TITLE
Tentatively fix fastrlock version to 0.6

### DIFF
--- a/.pfnci/windows/test.ps1
+++ b/.pfnci/windows/test.ps1
@@ -69,6 +69,8 @@ function Main {
     RunOrDie python -V
     RunOrDie python -m pip install -U pip setuptools
     RunOrDie python -m pip install Cython 'scipy<1.7' optuna
+    # TODO(kmaehashi): tentatively pin to 0.6 until Windows wheels released
+    RunOrDie python -m pip install 'fastrlock==0.6'
     RunOrDie python -m pip freeze
 
     echo "Building..."


### PR DESCRIPTION
fastrlock 0.7 is out, but Windows wheels are not available.
This is causing failure in Windows CI.