### PR TITLE
Temporarily skip Array API tests on ROCm

### DIFF
--- a/tests/cupy_tests/array_api_tests/__init__.py
+++ b/tests/cupy_tests/array_api_tests/__init__.py
@@ -10,7 +10,17 @@ import sys
 
 import pytest
 
+from cupy_backends.cuda.api import runtime
+
 
 if sys.version_info < (3, 8):
     pytest.skip('Python array API requires Python 3.8+',
+                allow_module_level=True)
+
+
+# hiprtc seems to have a bug and it causes errors in some tests later. We
+# temporarily skip the Python array API tests on ROCm until it is fixed.
+# See #5843
+if runtime.is_hip:
+    pytest.skip('Python array API tests are temporarily skipped on ROCm',
                 allow_module_level=True)


### PR DESCRIPTION
Rel #5843.

This PR temporarily makes Python Array API tests skipped on ROCm to avoid some test errors caused by a hiprtc bug.