### PR TITLE
CI: Do not run full combination test even for branch tests for ROCm

### DIFF
--- a/.pfnci/generate.py
+++ b/.pfnci/generate.py
@@ -228,6 +228,8 @@ class LinuxGenerator:
             ]
         elif matrix.rocm is not None:
             lines += [
+                '# TODO(kmaehashi): Tentatively sparsen parameterization to make test run complete.',  # NOQA
+                'export CUPY_TEST_FULL_COMBINATION="0"',
                 'export CUPY_INSTALL_USE_HIP=1',
                 '',
             ]

--- a/.pfnci/linux/tests/actions/_environment.sh
+++ b/.pfnci/linux/tests/actions/_environment.sh
@@ -9,6 +9,7 @@ export CUPY_DUMP_CUDA_SOURCE_ON_ERROR="1"
 
 if [[ "${PULL_REQUEST:-}" == "" ]]; then
     # When testing branches, test full matrix to generate caches for all combinations.
+    # Note: this may be overridden by individual test scripts.
     export CUPY_TEST_FULL_COMBINATION="1"
 else
     # When testing pull-requests, make test combinations sparse.

--- a/.pfnci/linux/tests/rocm-4-0.sh
+++ b/.pfnci/linux/tests/rocm-4-0.sh
@@ -7,6 +7,8 @@ set -uex
 ACTIONS="$(dirname $0)/actions"
 . "$ACTIONS/_environment.sh"
 
+# TODO(kmaehashi): Tentatively sparsen parameterization to make test run complete.
+export CUPY_TEST_FULL_COMBINATION="0"
 export CUPY_INSTALL_USE_HIP=1
 
 "$ACTIONS/build.sh"

--- a/.pfnci/linux/tests/rocm-4-2.sh
+++ b/.pfnci/linux/tests/rocm-4-2.sh
@@ -7,6 +7,8 @@ set -uex
 ACTIONS="$(dirname $0)/actions"
 . "$ACTIONS/_environment.sh"
 
+# TODO(kmaehashi): Tentatively sparsen parameterization to make test run complete.
+export CUPY_TEST_FULL_COMBINATION="0"
 export CUPY_INSTALL_USE_HIP=1
 
 "$ACTIONS/build.sh"

--- a/.pfnci/linux/tests/rocm-4-3.sh
+++ b/.pfnci/linux/tests/rocm-4-3.sh
@@ -7,6 +7,8 @@ set -uex
 ACTIONS="$(dirname $0)/actions"
 . "$ACTIONS/_environment.sh"
 
+# TODO(kmaehashi): Tentatively sparsen parameterization to make test run complete.
+export CUPY_TEST_FULL_COMBINATION="0"
 export CUPY_INSTALL_USE_HIP=1
 
 "$ACTIONS/build.sh"


### PR DESCRIPTION
Currently ROCm tests for branches in Jenkins is unstable.
This PR makes parameterization for branch tests sparse (i.e., reduce number of combinations to that of pull-request tests) to resolve this issue.

https://jenkins.preferred.jp/job/chainer/job/cupy_master/
https://jenkins.preferred.jp/job/chainer/job/cupy_stable/