### PR TITLE
Add `sphinx-copybutton`

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,6 @@
 sphinx==4.1.2
 pydata_sphinx_theme==0.6.3
+sphinx-copybutton==0.4.0
 
 Cython==0.29.*
 numpy==1.21.*

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -159,6 +159,7 @@ napoleon_include_special_with_doc = True
 #     ipython and qtconsole + continuation (e.g., 'In [29]: ', '  ...: '),
 #     jupyter-console + continuation (e.g., 'In [29]: ', '     ...: ')
 # ]
+# regex taken from https://sphinx-copybutton.readthedocs.io/en/latest/#using-regexp-prompt-identifiers
 copybutton_prompt_text = r">>> |\.\.\. |\$ |In \[\d*\]: | {2,5}\.\.\.: | {5,8}: "
 copybutton_prompt_is_regexp = True
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -150,6 +150,21 @@ todo_include_todos = False
 napoleon_use_ivar = True
 napoleon_include_special_with_doc = True
 
+# -- Copybutton settings --------------------------------------------------
+
+# Only copy lines starting with the input prompts,
+# valid prompt styles: [
+#     Python Repl + continuation (e.g., '>>> ', '... '),
+#     Bash (e.g., '$ '),
+#     ipython and qtconsole + continuation (e.g., 'In [29]: ', '  ...: '),
+#     jupyter-console + continuation (e.g., 'In [29]: ', '     ...: ')
+# ]
+copybutton_prompt_text = r">>> |\.\.\. |\$ |In \[\d*\]: | {2,5}\.\.\.: | {5,8}: "
+copybutton_prompt_is_regexp = True
+
+# Continue copying lines as long as they end with this character
+copybutton_line_continuation_character = "\\"
+
 # -- Options for HTML output ----------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -61,7 +61,8 @@ extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.intersphinx',
               'sphinx.ext.mathjax',
               'sphinx.ext.napoleon',
-              'sphinx.ext.linkcode']
+              'sphinx.ext.linkcode',
+              'sphinx_copybutton']
 
 try:
     import sphinxcontrib.spelling  # noqa


### PR DESCRIPTION
Closes #5949 

* Added the dependency to `docs/requirements.txt`
* Added the extension in `docs/source/conf.py`
* Added configurations for Copybutton to:
  * Ignore lines without input prompts if input prompts are present
  * Copy multiline commands when lines end with `\`


Please find the screenshot attached below. On the right is the built HTML documentation with the `sphinx-copybutton` extension enabled.

<img width="2047" alt="Screenshot 2021-11-01 at 10 58 13 AM" src="https://user-images.githubusercontent.com/27927281/139636660-e110b49a-6446-41dc-9ce5-c25a1d7fda7a.png">
