### PR TITLE
Fix `ravel` for strides 0

### DIFF
--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -728,7 +728,8 @@ cdef class ndarray:
            :meth:`numpy.ndarray.ravel`
 
         """
-        return _manipulation._ndarray_ravel(self, order)
+        return _internal_ascontiguousarray(
+            _manipulation._ndarray_ravel(self, order))
 
     cpdef ndarray squeeze(self, axis=None):
         """Returns a view with size-one axes removed.

--- a/tests/cupy_tests/manipulation_tests/test_shape.py
+++ b/tests/cupy_tests/manipulation_tests/test_shape.py
@@ -186,10 +186,7 @@ class TestRavel(unittest.TestCase):
         b = xp.broadcast_to(a, (10,))
         assert not b.flags.c_contiguous and not b.flags.f_contiguous
         b = b.ravel(order)
-        if order == 'C':
-            assert b.flags.c_contiguous
-        else:
-            assert b.flags.f_contiguous
+        assert b.flags.c_contiguous
         return b
 
     @testing.numpy_cupy_array_equal()

--- a/tests/cupy_tests/manipulation_tests/test_shape.py
+++ b/tests/cupy_tests/manipulation_tests/test_shape.py
@@ -176,10 +176,7 @@ class TestRavel(unittest.TestCase):
         a = xp.arange(10)[::2]
         assert not a.flags.c_contiguous and not a.flags.f_contiguous
         b = a.ravel(order)
-        if order == 'C':
-            assert b.flags.c_contiguous
-        else:
-            assert b.flags.f_contiguous
+        assert b.flags.c_contiguous
         return b
 
     @testing.for_orders('CFA')

--- a/tests/cupy_tests/manipulation_tests/test_shape.py
+++ b/tests/cupy_tests/manipulation_tests/test_shape.py
@@ -170,6 +170,31 @@ class TestRavel(unittest.TestCase):
         a = xp.asfortranarray(a)
         return a.ravel(order)
 
+    @testing.for_orders('CFA')
+    @testing.numpy_cupy_array_equal()
+    def test_ravel_non_contiguous(self, xp, order):
+        a = xp.arange(10)[::2]
+        assert not a.flags.c_contiguous and not a.flags.f_contiguous
+        b = a.ravel(order)
+        if order == 'C':
+            assert b.flags.c_contiguous
+        else:
+            assert b.flags.f_contiguous
+        return b
+
+    @testing.for_orders('CFA')
+    @testing.numpy_cupy_array_equal()
+    def test_ravel_broadcasted(self, xp, order):
+        a = xp.array([1])
+        b = xp.broadcast_to(a, (10,))
+        assert not b.flags.c_contiguous and not b.flags.f_contiguous
+        b = b.ravel(order)
+        if order == 'C':
+            assert b.flags.c_contiguous
+        else:
+            assert b.flags.f_contiguous
+        return b
+
     @testing.numpy_cupy_array_equal()
     def test_external_ravel(self, xp):
         a = testing.shaped_arange((2, 3, 4), xp)


### PR DESCRIPTION
Always enforce the copy if the array is neither c- or f-contiguous.

Closes #5972 