### PR TITLE
Make `CUPY_DLPACK_EXPORT_VERSION` consistent

### DIFF
--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -267,7 +267,7 @@ cdef class ndarray:
             attrs = runtime.pointerGetAttributes(self.data.ptr)
             is_managed = (
                 attrs.type == runtime.memoryTypeManaged
-                and _util.CUPY_DLPACK_EXPORT_VERSION >= (0, 6))
+                and _util.DLPACK_EXPORT_VERSION >= (0, 6))
             if is_managed:
                 device_type = dlpack.managed_CUDA
             else:

--- a/cupy/_util.pyx
+++ b/cupy/_util.pyx
@@ -26,10 +26,10 @@ CUDA_ARRAY_INTERFACE_EXPORT_VERSION = int(
     os.environ.get('CUPY_CUDA_ARRAY_INTERFACE_EXPORT_VERSION', 3))
 
 
-CUPY_DLPACK_EXPORT_VERSION = tuple(
+DLPACK_EXPORT_VERSION = tuple(
     [
         int(x)
-        for x in os.environ.get("CUPY_DLPACK_EXPORT_VERSION", "0.6").split(".")
+        for x in os.environ.get('CUPY_DLPACK_EXPORT_VERSION', '0.6').split('.')
     ]
 )
 


### PR DESCRIPTION
My mistake, I didn't double check that the format was aligned to other env vars.