### PR TITLE
Fix `testing.multi_gpu` to add pytest marker

### DIFF
--- a/cupy/testing/_attr.py
+++ b/cupy/testing/_attr.py
@@ -42,6 +42,7 @@ def multi_gpu(gpu_num):
     # at this point we know pytest is available for sure
 
     assert 1 < gpu_num
+
     def _wrapper(f):
         return pytest.mark.skipif(
             0 <= _gpu_limit < gpu_num,


### PR DESCRIPTION
Closes #5912.

Now tests can be run selectively using `pytest -m pytest -m "multi_gpu"` or `pytest -m pytest -m "not multi_gpu"`.