### PR TITLE
CI: Fix ccache not working

### DIFF
--- a/.pfnci/linux/tests/actions/_environment.sh
+++ b/.pfnci/linux/tests/actions/_environment.sh
@@ -37,4 +37,5 @@ if ! touch .; then
     echo "Source directory ($(pwd)) is read-only; copying the source tree to ${_src_dir} and changing the current directory"
     cp -a . "${_src_dir}"
     pushd "${_src_dir}"
+    export CCACHE_BASEDIR="${_src_dir}"
 fi


### PR DESCRIPTION
This was a regression in #5881.

When src directory is copied, compiler command line always include a random path, preventing ccache to reuse the cache.

This PR sets the source root as a ccache basedir to let ccache omit the dir from hash calculation.

https://ccache.dev/manual/4.4.2.html#_configuration_options

> base_dir (CCACHE_BASEDIR)
> ...
> ccache will rewrite absolute paths into paths relative to the current working directory, but only absolute paths that begin with base_dir. Cache results can then be shared for compilations in different directories even if the project uses absolute paths in the compiler command line.