### PR TITLE
Avoid 64bit division for reduce register consumption

### DIFF
--- a/cupy/_core/_carray.pxd
+++ b/cupy/_core/_carray.pxd
@@ -45,6 +45,7 @@ cdef class Indexer:
     cdef:
         readonly Py_ssize_t size
         readonly shape_t shape
+        readonly bint _index_32_bits
 
     cdef void init(self, const shape_t& shape)
 

--- a/cupy/_core/_carray.pyx
+++ b/cupy/_core/_carray.pyx
@@ -43,6 +43,7 @@ cdef class Indexer:
     cdef void init(self, const shape_t& shape):
         self.shape = shape
         self.size = internal.prod(shape)
+        self._index_32_bits = self.size <= (1 << 31)
 
     @property
     def ndim(self):

--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -47,11 +47,13 @@ cdef function.Function _get_simple_elementwise_kernel(
         tuple params, tuple arginfos, str operation, str name,
         _TypeMap type_map, str preamble, str loop_prep='', str after_loop='',
         tuple options=()):
+    # No loop unrolling due to avoid 64-bit division
     module_code = string.Template('''
     ${typedef_preamble}
     ${preamble}
     extern "C" __global__ void ${name}(${params}) {
       ${loop_prep};
+      #pragma unroll 1
       CUPY_FOR(i, _ind.size()) {
         _ind.set(i);
         ${operation};
@@ -192,7 +194,7 @@ cdef class _ArgInfo:
     cdef _ArgInfo from_indexer(_carray.Indexer arg):
         cdef _ArgInfo ret = _ArgInfo.__new__(_ArgInfo)
         ret._init(
-            ARG_KIND_INDEXER, _carray.Indexer, None, arg.ndim, True, True)
+            ARG_KIND_INDEXER, _carray.Indexer, None, arg.ndim, True, arg._index_32_bits)
         return ret
 
     @staticmethod
@@ -261,7 +263,7 @@ cdef class _ArgInfo:
         if self.arg_kind == ARG_KIND_SCALAR:
             return _get_typename(self.dtype)
         if self.arg_kind == ARG_KIND_INDEXER:
-            return 'CIndexer<%d>' % self.ndim
+            return 'CIndexer<%d, %d>' % (self.ndim, self.index_32_bits)
         if self.arg_kind == ARG_KIND_TEXTURE:
             return 'cudaTextureObject_t'
         assert False

--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -194,7 +194,8 @@ cdef class _ArgInfo:
     cdef _ArgInfo from_indexer(_carray.Indexer arg):
         cdef _ArgInfo ret = _ArgInfo.__new__(_ArgInfo)
         ret._init(
-            ARG_KIND_INDEXER, _carray.Indexer, None, arg.ndim, True, arg._index_32_bits)
+            ARG_KIND_INDEXER, _carray.Indexer, None, arg.ndim, True,
+            arg._index_32_bits)
         return ret
 
     @staticmethod

--- a/cupy/_core/include/cupy/carray.cuh
+++ b/cupy/_core/include/cupy/carray.cuh
@@ -441,7 +441,7 @@ public:
   }
 };
 
-template <int _ndim>
+template <int _ndim, bool _use_32bit_indexing=false>
 class CIndexer {
 public:
   static const int ndim = _ndim;
@@ -515,7 +515,7 @@ public:
     // ndim == 0 case uses partial template specialization
     if (ndim == 1) {
       index_[0] = i;
-    } else if (size_ > 1LL << 31) {
+    } else if (!_use_32bit_indexing && size_ > 1LL << 31) {
       // 64-bit division is very slow on GPU
       this->_set(static_cast<unsigned long long int>(i));
     } else {
@@ -545,8 +545,8 @@ private:
   static unsigned long long int __device__ _log2(unsigned long long int x) { return __popcll(x-1); }
 };
 
-template <>
-class CIndexer<0> {
+template <bool _use_32bit_indexing>
+class CIndexer<0, _use_32bit_indexing> {
 private:
   ptrdiff_t size_;
 


### PR DESCRIPTION
Current CuPy elementwise generate 64bit division code.
1. For loop unrolling. 
2. For large indexing. (generate but not used. CUDA kernel register consumption increases.) 


For 1

benchmark code
```
import cupy
size = 1024
a = cupy.ones((size, size))
for i in range(10):
    a * a
```
| | #register |  time[usec]
| - | - | - |
| before | 21 | 18 |
| after | 18 | 18 |


For 2

benchmark code
```
import cupy
size = 1024
b = cupy.broadcast_to(cupy.ones((size, 1)), (size, size))
for i in range(10):
    b * b
```

| | #register |  time[usec]
| - | - | - |
| before | 28 | 25 |
| after | 24 | 25 |


