### PR TITLE
Tune gridx max value

### DIFF
--- a/cupy/cuda/function.pyx
+++ b/cupy/cuda/function.pyx
@@ -231,8 +231,9 @@ cdef class Function:
                         size_t block_max_size=128, stream=None,
                         bint enable_cooperative_groups=False):
         # TODO(beam2d): Tune it
+        cdef size_t gridx_max = 4 * 1024 * 1024
         cdef size_t gridx = min(
-            0x7fffffffUL, (size + block_max_size - 1) // block_max_size)
+            gridx_max, (size + block_max_size - 1) // block_max_size)
         cdef size_t blockx = min(block_max_size, size)
         s = _get_stream(stream)
         _launch(


### PR DESCRIPTION
I optimize gridx value from 2^31-1 to 2^22.

benchmark code
``` python
import cupy
from cupyx.time import repeat

def f():
    cupy.arange(2 ** 33, dtype="b")
f()
cupy.cuda.function.grid_size = 2 ** 30
for i in range(100):
    print(cupy.cuda.function.grid_size)
    print(repeat(f, (), n_repeat=20))
    cupy.cuda.function.grid_size //= 2
    if cupy.cuda.function.grid_size <= 4:
        break
```

result
V100
| gridx  |  time |
| -- | -- |
| 1073741824  |      104675.256 us   +/- 9.549 (min : 104669.212 / max : 104713.341) us |
| 536870912  |    104671.804 us   +/- 2.411 (min : 104670.212 / max : 104681.313) us |
| 268435456  |  104728.125 us   +/-116.991 (min : 104669.823 / max : 105078.369) us |
| 134217728  |   104672.326 us   +/- 3.603 (min : 104669.411 / max : 104685.501) us |
| 67108864  |    104683.869 us   +/-47.655 (min : 104670.364 / max : 104890.915) us |
| 33554432  |    52346.548 us   +/- 1.916 (min : 52344.994 / max : 52352.737) us |
| 16777216  |    26185.416 us   +/- 2.809 (min : 26183.201 / max : 26193.472) us |
| 8388608  |       13106.067 us   +/- 1.829 (min : 13103.424 / max : 13111.424) us |
| 4194304  |     10565.525 us   +/-24.794 (min : 10548.960 / max : 10615.968) us |
| 2097152  |      18427.557 us   +/-85.596 (min : 18254.528 / max : 18577.185) us |
| 1048576  |      23043.906 us   +/-68.755 (min : 22904.032 / max : 23209.087) us |
| 524288  |   24838.496 us   +/-58.473 (min : 24732.927 / max : 24943.232) us |
| 262144  |    27064.747 us   +/-28.578 (min : 27004.225 / max : 27101.664) us |
| 131072  |   29110.002 us   +/- 9.510 (min : 29096.607 / max : 29124.161) us |
| 65536  |       30433.365 us   +/- 9.852 (min : 30418.240 / max : 30455.969) us |
| 32768  |       31000.357 us   +/-13.687 (min : 30963.264 / max : 31019.009) us |
| 16384  |       31479.030 us   +/-64.733 (min : 31413.025 / max : 31725.985) us |
| 8192  |     31979.518 us   +/-118.074 (min : 31701.471 / max : 32216.415) us |
| 4096  |     35831.046 us   +/-236.049 (min : 35477.535 / max : 36377.953) us |
| 2048  |     40414.914 us   +/-165.271 (min : 40156.673 / max : 40775.490) us |
| 1024  |     41213.078 us   +/-132.159 (min : 40947.327 / max : 41467.072) us |
| 512  |     44719.976 us   +/-228.161 (min : 44245.823 / max : 45098.335) us |
| 256  |     36737.194 us   +/-571.929 (min : 35782.848 / max : 37835.522) us |
| 128  |     17319.326 us   +/-30.452 (min : 17273.216 / max : 17383.007) us |
| 64  |   31803.418 us   +/- 7.982 (min : 31792.608 / max : 31820.320) us |
| 32  |   63650.120 us   +/-41.615 (min : 63583.168 / max : 63759.071) us |
| 16  |   127177.157 us   +/-59.914 (min : 127108.482 / max : 127363.869) us |
| 8  |   263145.093 us   +/-1053.346 (min : 260775.116 / max : 264250.702) us |

A100
| gridx  |  time |
| -- | -- |
| 1073741824             | 49737.248 us   +/-12.684 (min : 49731.487 / max : 49790.047) us |
| 536870912              | 49733.811 us   +/- 2.981 (min : 49731.457 / max : 49742.046) us |
| 268435456              | 49735.725 us   +/- 4.818 (min : 49731.262 / max : 49746.143) us |
| 134217728              | 49733.192 us   +/- 2.425 (min : 49731.583 / max : 49741.440) us |
| 67108864               | 49733.837 us   +/- 2.924 (min : 49731.327 / max : 49741.985) us |
| 33554432               | 24879.958 us   +/- 3.497 (min : 24875.744 / max : 24885.824) us |
| 16777216               | 12650.027 us   +/-96.023 (min : 12588.032 / max : 12958.624) us |
| 8388608                |  9524.669 us   +/-26.287 (min :  9506.144 / max :  9577.664) us |
| 4194304                |  8941.002 us   +/-227.974 (min :  8727.584 / max :  9328.160) us |
| 2097152                |  8613.982 us   +/-55.887 (min :  8502.048 / max :  8691.712) us |
| 1048576                |  9116.450 us   +/-97.995 (min :  9023.456 / max :  9326.144) us |
| 524288                 | 11448.856 us   +/-51.819 (min : 11356.192 / max : 11544.352) us |
| 262144                 | 11733.744 us   +/-128.667 (min : 11573.504 / max : 12031.456) us |
| 131072                 | 12171.574 us   +/-151.029 (min : 11960.064 / max : 12432.576) us |
| 65536                  | 12168.832 us   +/-65.393 (min : 12051.968 / max : 12299.328) us |
| 32768                  | 12554.645 us   +/-97.530 (min : 12288.096 / max : 12664.096) us |
| 16384                  | 12735.386 us   +/-39.173 (min : 12671.456 / max : 12819.040) us |
| 8192                   | 10955.742 us   +/-181.548 (min : 10635.872 / max : 11204.576) us |
| 4096                   |  8114.971 us   +/-35.791 (min :  8072.192 / max :  8178.624) us |
| 2048                   |  8696.030 us   +/- 6.780 (min :  8678.144 / max :  8708.128) us |
| 1024                   |  8414.707 us   +/-38.359 (min :  8358.272 / max :  8471.040) us |
| 512                    |  8294.819 us   +/-63.348 (min :  8227.776 / max :  8442.016) us |
| 256                    | 10640.813 us   +/-90.227 (min : 10545.536 / max : 10850.336) us |
| 128                    | 17301.389 us   +/- 2.257 (min : 17297.567 / max : 17306.944) us |
| 64                     | 33409.604 us   +/-145.031 (min : 33307.327 / max : 33647.297) us |
| 32                     | 66693.466 us   +/-221.878 (min : 66592.674 / max : 67258.301) us |
| 16                     | 133181.217 us   +/-52.143 (min : 133163.879 / max : 133407.776) us |
| 8                      | 266312.462 us   +/- 6.546 (min : 266305.695 / max : 266330.872) us |

