### PR TITLE
CI: Use `ccache` in Pre-review Test

### DIFF
--- a/.github/workflows/pretest.yml
+++ b/.github/workflows/pretest.yml
@@ -20,11 +20,23 @@ jobs:
         # cupyx.array_api uses Python 3.8 syntaxes
         python-version: '3.8'
 
+    - name: Setup ccache
+      run: |
+        sudo apt-get update -y
+        sudo apt-get install -y ccache
+        echo "PATH=/usr/lib/ccache:${PATH}" >> "${GITHUB_ENV}"
+
+    - name: Load ccache
+      uses: actions/cache@v2
+      with:
+        path: ~/.ccache
+        key: ccache
+
     - name: Build
       run: |
         pip install -U pip wheel
         pip install cython
-        READTHEDOCS=True pip install -U -e .[stylecheck]
+        READTHEDOCS=True pip install -v -e .[stylecheck]
 
     - name: Coding Style (flake8)
       run: |

--- a/.github/workflows/pretest.yml
+++ b/.github/workflows/pretest.yml
@@ -25,6 +25,7 @@ jobs:
         sudo apt-get update -y
         sudo apt-get install -y ccache
         echo "PATH=/usr/lib/ccache:${PATH}" >> "${GITHUB_ENV}"
+        which gcc g++
 
     - name: Load ccache
       uses: actions/cache@v2


### PR DESCRIPTION
This reduces the build time from 3~4 minutes to ~1 minute.

First run: https://github.com/cupy/cupy/runs/4130095842 (3m9s)
Second run: https://github.com/cupy/cupy/runs/4130153202 (46s)