### PR TITLE
CI: allow running tests selectively

### DIFF
--- a/.pfnci/config.pbtxt
+++ b/.pfnci/config.pbtxt
@@ -60,6 +60,7 @@ configs {
       seconds: 21600
     }
     environment_variables { key: "GPU" value: "2" }
+    environment_variables { key: "TAGS" value: "all,mini" }
     command: ".pfnci/linux/main-flexci.sh cuda102"
   }
 }
@@ -78,6 +79,7 @@ configs {
       seconds: 21600
     }
     environment_variables { key: "GPU" value: "2" }
+    environment_variables { key: "TAGS" value: "all" }
     command: ".pfnci/linux/main-flexci.sh cuda110"
   }
 }
@@ -96,6 +98,7 @@ configs {
       seconds: 21600
     }
     environment_variables { key: "GPU" value: "2" }
+    environment_variables { key: "TAGS" value: "all" }
     command: ".pfnci/linux/main-flexci.sh cuda111"
   }
 }
@@ -114,6 +117,7 @@ configs {
       seconds: 21600
     }
     environment_variables { key: "GPU" value: "2" }
+    environment_variables { key: "TAGS" value: "all" }
     command: ".pfnci/linux/main-flexci.sh cuda112"
   }
 }
@@ -132,6 +136,7 @@ configs {
       seconds: 21600
     }
     environment_variables { key: "GPU" value: "2" }
+    environment_variables { key: "TAGS" value: "all" }
     command: ".pfnci/linux/main-flexci.sh cuda113"
   }
 }
@@ -150,6 +155,7 @@ configs {
       seconds: 21600
     }
     environment_variables { key: "GPU" value: "2" }
+    environment_variables { key: "TAGS" value: "all" }
     command: ".pfnci/linux/main-flexci.sh cuda114"
   }
 }
@@ -168,6 +174,7 @@ configs {
       seconds: 21600
     }
     environment_variables { key: "GPU" value: "2" }
+    environment_variables { key: "TAGS" value: "all,mini" }
     command: ".pfnci/linux/main-flexci.sh cuda115"
   }
 }
@@ -186,6 +193,7 @@ configs {
       seconds: 21600
     }
     environment_variables { key: "GPU" value: "2" }
+    environment_variables { key: "TAGS" value: "all,cuda-python" }
     command: ".pfnci/linux/main-flexci.sh cuda11x-cuda-python"
   }
 }
@@ -204,6 +212,7 @@ configs {
       seconds: 3600
     }
     environment_variables { key: "GPU" value: "1" }
+    environment_variables { key: "TAGS" value: "all,rapids" }
     command: ".pfnci/linux/main-flexci.sh cuda-rapids"
   }
 }
@@ -222,6 +231,7 @@ configs {
       seconds: 3600
     }
     environment_variables { key: "GPU" value: "2" }
+    environment_variables { key: "TAGS" value: "all,doctest" }
     command: ".pfnci/linux/main-flexci.sh cuda-doctest"
   }
 }
@@ -240,6 +250,7 @@ configs {
       seconds: 3600
     }
     environment_variables { key: "GPU" value: "2" }
+    environment_variables { key: "TAGS" value: "all,mini,example" }
     command: ".pfnci/linux/main-flexci.sh cuda-example"
   }
 }
@@ -258,6 +269,7 @@ configs {
       seconds: 21600
     }
     environment_variables { key: "GPU" value: "2" }
+    environment_variables { key: "TAGS" value: "head" }
     command: ".pfnci/linux/main-flexci.sh cuda-head"
   }
 }
@@ -276,6 +288,7 @@ configs {
       seconds: 7200
     }
     environment_variables { key: "GPU" value: "1" }
+    environment_variables { key: "TAGS" value: "all,array-api" }
     command: ".pfnci/linux/main-flexci.sh array-api"
   }
 }

--- a/.pfnci/config.pbtxt
+++ b/.pfnci/config.pbtxt
@@ -60,7 +60,7 @@ configs {
       seconds: 21600
     }
     environment_variables { key: "GPU" value: "2" }
-    environment_variables { key: "TAGS" value: "all,mini" }
+    environment_variables { key: "TAGS" value: "mini" }
     command: ".pfnci/linux/main-flexci.sh cuda102"
   }
 }
@@ -79,7 +79,6 @@ configs {
       seconds: 21600
     }
     environment_variables { key: "GPU" value: "2" }
-    environment_variables { key: "TAGS" value: "all" }
     command: ".pfnci/linux/main-flexci.sh cuda110"
   }
 }
@@ -98,7 +97,6 @@ configs {
       seconds: 21600
     }
     environment_variables { key: "GPU" value: "2" }
-    environment_variables { key: "TAGS" value: "all" }
     command: ".pfnci/linux/main-flexci.sh cuda111"
   }
 }
@@ -117,7 +115,6 @@ configs {
       seconds: 21600
     }
     environment_variables { key: "GPU" value: "2" }
-    environment_variables { key: "TAGS" value: "all" }
     command: ".pfnci/linux/main-flexci.sh cuda112"
   }
 }
@@ -136,7 +133,6 @@ configs {
       seconds: 21600
     }
     environment_variables { key: "GPU" value: "2" }
-    environment_variables { key: "TAGS" value: "all" }
     command: ".pfnci/linux/main-flexci.sh cuda113"
   }
 }
@@ -155,7 +151,6 @@ configs {
       seconds: 21600
     }
     environment_variables { key: "GPU" value: "2" }
-    environment_variables { key: "TAGS" value: "all" }
     command: ".pfnci/linux/main-flexci.sh cuda114"
   }
 }
@@ -174,7 +169,7 @@ configs {
       seconds: 21600
     }
     environment_variables { key: "GPU" value: "2" }
-    environment_variables { key: "TAGS" value: "all,mini" }
+    environment_variables { key: "TAGS" value: "mini" }
     command: ".pfnci/linux/main-flexci.sh cuda115"
   }
 }
@@ -193,7 +188,7 @@ configs {
       seconds: 21600
     }
     environment_variables { key: "GPU" value: "2" }
-    environment_variables { key: "TAGS" value: "all,cuda-python" }
+    environment_variables { key: "TAGS" value: "cuda-python" }
     command: ".pfnci/linux/main-flexci.sh cuda11x-cuda-python"
   }
 }
@@ -212,7 +207,7 @@ configs {
       seconds: 3600
     }
     environment_variables { key: "GPU" value: "1" }
-    environment_variables { key: "TAGS" value: "all,rapids" }
+    environment_variables { key: "TAGS" value: "rapids" }
     command: ".pfnci/linux/main-flexci.sh cuda-rapids"
   }
 }
@@ -231,7 +226,7 @@ configs {
       seconds: 3600
     }
     environment_variables { key: "GPU" value: "2" }
-    environment_variables { key: "TAGS" value: "all,doctest" }
+    environment_variables { key: "TAGS" value: "doctest" }
     command: ".pfnci/linux/main-flexci.sh cuda-doctest"
   }
 }
@@ -250,7 +245,7 @@ configs {
       seconds: 3600
     }
     environment_variables { key: "GPU" value: "2" }
-    environment_variables { key: "TAGS" value: "all,mini,example" }
+    environment_variables { key: "TAGS" value: "mini,example" }
     command: ".pfnci/linux/main-flexci.sh cuda-example"
   }
 }
@@ -288,7 +283,7 @@ configs {
       seconds: 7200
     }
     environment_variables { key: "GPU" value: "1" }
-    environment_variables { key: "TAGS" value: "all,array-api" }
+    environment_variables { key: "TAGS" value: "array-api" }
     command: ".pfnci/linux/main-flexci.sh array-api"
   }
 }

--- a/.pfnci/flexci_test_tag.py
+++ b/.pfnci/flexci_test_tag.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+
+import os
+import re
+import sys
+
+import github
+
+
+GITHUB_REPOSITORY = 'cupy/cupy'
+
+
+def _log(msg):
+    sys.stderr.write(msg)
+    sys.stderr.write('\n')
+    sys.stderr.flush()
+
+
+def get_requested_tags(github_token, description):
+    # Returns a set of test tags requested in the pull-request comment.
+    # The comment format is the test phrase followed by comma-searated tags.
+    # e.g., "/test mini,doctest"
+    match = re.search(r'/pull/(\d+)#issuecomment-(\d+)', description)
+    if match is None:
+        raise RuntimeError(
+            'Cannot detect information from FLEXCI_DESCRIPTION:'
+            f' {description}')
+    pull_request = int(match.group(1))
+    comment_id = int(match.group(2))
+    _log(f'Pull-Request: #{pull_request} (comment {comment_id})')
+
+    repo = github.Github(github_token).get_repo(GITHUB_REPOSITORY)
+    comment = repo.get_issue(pull_request).get_comment(comment_id)
+    for line in comment.body.splitlines():
+        match = re.fullmatch(r'/test\s+([\w,\-]+)', line)
+        if match is not None:
+            return set(match.group(1).split(','))
+    _log('No test tags specified, assumes "all"')
+    return set(('all',))
+
+
+def main(argv):
+    # Prints "yes" if the current test is requested to run.
+    # Prints "no" otherwise.
+
+    # Comma-separated list of tags of the current test.
+    tags = set(argv[1].split(','))
+
+    github_token = os.environ.get('GITHUB_TOKEN', None)
+    description = os.environ.get('FLEXCI_DESCRIPTION', '')
+    req_tags = get_requested_tags(github_token, description)
+
+    _log(f'Test tags: {tags}')
+    _log(f'Requested tags: {req_tags}')
+    for req_tag in req_tags:
+        if req_tag in tags:
+            print('yes')
+            return
+    print('no')
+
+
+if __name__ == '__main__':
+    main(sys.argv)

--- a/.pfnci/flexci_test_tag.py
+++ b/.pfnci/flexci_test_tag.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Note: keep this script runnable Python 3.6 until FlexCI Python update
 

--- a/.pfnci/flexci_test_tag.py
+++ b/.pfnci/flexci_test_tag.py
@@ -35,8 +35,8 @@ def get_requested_tags(github_token, description):
         match = re.fullmatch(r'/test\s+([\w,\-]+)', line)
         if match is not None:
             return set(match.group(1).split(','))
-    _log('No test tags specified, assumes "all"')
-    return set(('all',))
+    _log('No test tags specified in comment')
+    return None
 
 
 def main(argv):
@@ -52,6 +52,12 @@ def main(argv):
 
     _log(f'Test tags: {tags}')
     _log(f'Requested tags: {req_tags}')
+
+    if req_tags is None:
+        # No tags requested; run all tests.
+        print('yes')
+        return
+
     for req_tag in req_tags:
         if req_tag in tags:
             print('yes')

--- a/.pfnci/flexci_test_tag.py
+++ b/.pfnci/flexci_test_tag.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+# Note: keep this script runnable Python 3.6 until FlexCI Python update
+
 import os
 import re
 import sys
@@ -23,14 +25,15 @@ def get_requested_tags(github_token, description):
     match = re.search(r'/pull/(\d+)#issuecomment-(\d+)', description)
     if match is None:
         raise RuntimeError(
-            'Cannot detect information from FLEXCI_DESCRIPTION:'
-            f' {description}')
-    pull_request = int(match.group(1))
+            'Cannot detect information from FLEXCI_DESCRIPTION: {}'.format(
+                description))
+    pr_id = int(match.group(1))
     comment_id = int(match.group(2))
-    _log(f'Pull-Request: #{pull_request} (comment {comment_id})')
+    _log('Triggered by pull-request: #{} (comment {})'.format(
+        pr_id, comment_id))
 
     repo = github.Github(github_token).get_repo(GITHUB_REPOSITORY)
-    comment = repo.get_issue(pull_request).get_comment(comment_id)
+    comment = repo.get_issue(pr_id).get_comment(comment_id)
     for line in comment.body.splitlines():
         match = re.fullmatch(r'/test\s+([\w,\-]+)', line)
         if match is not None:
@@ -50,8 +53,8 @@ def main(argv):
     description = os.environ.get('FLEXCI_DESCRIPTION', '')
     req_tags = get_requested_tags(github_token, description)
 
-    _log(f'Test tags: {tags}')
-    _log(f'Requested tags: {req_tags}')
+    _log('Test tags: {}'.format(tags))
+    _log('Requested tags: {}'.format(req_tags))
 
     if req_tags is None:
         # No tags requested; run all tests.

--- a/.pfnci/linux/main-flexci.sh
+++ b/.pfnci/linux/main-flexci.sh
@@ -17,7 +17,7 @@ if [[ "${FLEXCI_BRANCH:-}" == refs/pull/* ]]; then
     echo "Testing Pull-Request: #${pull_req}"
 
     pip install pygithub
-    TO_EXECUTE=$(./.pfnci/flexci_test_tag.py "${TAGS}")
+    TO_EXECUTE=$(./.pfnci/flexci_test_tag.py "${TAGS:-}")
     if [[ "${TO_EXECUTE}" == "no" ]]; then
         exit 0
     fi

--- a/.pfnci/linux/main-flexci.sh
+++ b/.pfnci/linux/main-flexci.sh
@@ -15,6 +15,12 @@ if [[ "${FLEXCI_BRANCH:-}" == refs/pull/* ]]; then
     # Extract pull-request ID
     pull_req="$(echo "${FLEXCI_BRANCH}" | cut -d/ -f3)"
     echo "Testing Pull-Request: #${pull_req}"
+
+    pip install pygithub
+    TO_EXECUTE=$(./.pfnci/flexci_test_tag.py "${TAGS}")
+    if [[ "${TO_EXECUTE}" == "no" ]]; then
+        exit 0
+    fi
 fi
 
 # TODO(kmaehashi): Hack for CUDA 11.5 until FlexCI base image update

--- a/.pfnci/linux/main-flexci.sh
+++ b/.pfnci/linux/main-flexci.sh
@@ -16,7 +16,7 @@ if [[ "${FLEXCI_BRANCH:-}" == refs/pull/* ]]; then
     pull_req="$(echo "${FLEXCI_BRANCH}" | cut -d/ -f3)"
     echo "Testing Pull-Request: #${pull_req}"
 
-    pip install pygithub
+    pip3 install -q pygithub
     TO_EXECUTE=$(./.pfnci/flexci_test_tag.py "${TAGS:-}")
     if [[ "${TO_EXECUTE}" == "no" ]]; then
         exit 0


### PR DESCRIPTION
This PR adds a feature to run FlexCI tests selectively, based on the tags assigned to each FlexCI project.

For example:

* `/test mini` to run tests tagged with `mini`
* `/test example,rapids` to run tests tagged with `example` or `rapids`

`/test` runs all tests regardless of tags.

We may also need to discuss review criteria (e.g., what kind of PRs can be merged without "all" tests).