### PR TITLE
[v9] CI: Increase timeout for CUDA 11.4 / 11.5 tests

### DIFF
--- a/.pfnci/config.pbtxt
+++ b/.pfnci/config.pbtxt
@@ -48,7 +48,7 @@ configs {
       gpu: 2
     }
     time_limit: {
-      seconds: 21600
+      seconds: 25200
     }
     environment_variables { key: "GPU" value: "2" }
     command: ".pfnci/linux/main-flexci.sh cuda114"
@@ -66,7 +66,7 @@ configs {
       gpu: 2
     }
     time_limit: {
-      seconds: 21600
+      seconds: 25200
     }
     environment_variables { key: "GPU" value: "2" }
     command: ".pfnci/linux/main-flexci.sh cuda115"


### PR DESCRIPTION
Fix https://ci.preferred.jp/cupy.linux.cuda115/84064/