### PR TITLE
Raise better message when importing CPU array via DLPack

### DIFF
--- a/cupy/_core/dlpack.pyx
+++ b/cupy/_core/dlpack.pyx
@@ -387,9 +387,13 @@ cpdef from_dlpack(array):
             dltensor = array.__dlpack__(stream=stream)
         finally:
             cupy.cuda.runtime.setDevice(prev_device)
+    elif dev_type == <int>kDLCPU:
+        # TODO(kmaehashi): Call `np.from_dlpack` when DLPack support is in:
+        # https://github.com/numpy/numpy/pull/19083
+        raise ValueError('CPU arrays cannot be imported to CuPy.')
     else:
         # TODO(leofang): support kDLCUDAPinned etc
         dltensor = None
-        raise ValueError
+        raise ValueError(f'Unsupported array type: {dev_type}')
 
     return _dlpack_to_cupy_array(dltensor)


### PR DESCRIPTION
To ease diagnosing failure like this:

```py
cupy.from_dlpack(torch.arange(10))
```