### PR TITLE
Fix cuDNN version not displayed in wheel installation

### DIFF
--- a/cupyx/_runtime.py
+++ b/cupyx/_runtime.py
@@ -164,19 +164,19 @@ class _RuntimeInfo:
 
         # cuDNN
         if cupy._environment._can_attempt_preload('cudnn'):
-            self.cudnn_build_version = (
-                '(not loaded; try `import cupy.cuda.cudnn` first)')
-            self.cudnn_version = self.cudnn_build_version
             if full:
                 cupy._environment._preload_library('cudnn')
+            else:
+                self.cudnn_build_version = (
+                    '(not loaded; try `import cupy.cuda.cudnn` first)')
+                self.cudnn_version = self.cudnn_build_version
         try:
             import cupy_backends.cuda.libs.cudnn as cudnn
             self.cudnn_build_version = cudnn.get_build_version()
             self.cudnn_version = _eval_or_error(
                 cudnn.getVersion, cudnn.CuDNNError)
         except ImportError:
-            self.cudnn_build_version = None
-            self.cudnn_version = None
+            pass
 
         # NCCL
         try:


### PR DESCRIPTION
When cuDNN preload can be attempted (i.e., installed via wheel AND `import cupy.cuda.cudnn` is not performed yet), `show_config` should behave as follows:

* If `full` mode is requested, preload cuDNN immedeately and show the version. Output would be either the actual version, or None (if cuDNN is unavailable).
* If `full` mode is not requested, try to get cuDNN version without preloading. Output would be either the actual version, or 'not loaded' message.

This was a bug added by me in #5677