### PR TITLE
Fix distributed test failure

### DIFF
--- a/cupyx/distributed/_store.py
+++ b/cupyx/distributed/_store.py
@@ -79,8 +79,8 @@ class TCPStore:
                     continue
 
                 t = threading.Thread(
-                    target=self._process_request, args=(c_socket,))
-                t.setDaemon(True)
+                    target=self._process_request,
+                    args=(c_socket,), daemon=True)
                 t.start()
 
     def run(self, host=_DEFAULT_HOST, port=_DEFAULT_PORT):


### PR DESCRIPTION
``setDaemon`` is deprecated and now emits a warning in Python 3.10.

https://ci.preferred.jp/cupy.linux.cuda114/85040/