### PR TITLE
Exclude `kernel_version` from comparison table

### DIFF
--- a/docs/source/_comparison_generator.py
+++ b/docs/source/_comparison_generator.py
@@ -8,8 +8,9 @@ _footnotes = {}
 
 
 def _get_functions(obj, exclude=None):
+    children = obj.__all__ if hasattr(obj, '__all__') else dir(obj)
     return set([
-        n for n, target in [(n, getattr(obj, n)) for n in dir(obj)]
+        n for n, target in [(n, getattr(obj, n)) for n in children]
         if (
             # not in exclude list
             (exclude is None or n not in exclude)

--- a/docs/source/_comparison_generator.py
+++ b/docs/source/_comparison_generator.py
@@ -8,9 +8,8 @@ _footnotes = {}
 
 
 def _get_functions(obj, exclude=None):
-    children = obj.__all__ if hasattr(obj, '__all__') else dir(obj)
     return set([
-        n for n, target in [(n, getattr(obj, n)) for n in children]
+        n for n, target in [(n, getattr(obj, n)) for n in dir(obj)]
         if (
             # not in exclude list
             (exclude is None or n not in exclude)
@@ -127,6 +126,7 @@ def generate():
             'add_newdoc_ufunc',
             '_add_newdoc_ufunc',
             'fastCopyAndTranspose',
+            'kernel_version',
             'test',
             'Tester',
         ], footnotes={


### PR DESCRIPTION
~This hides several APIs that are unexpectedly exposed, by using `__all__`.~

~https://gist.github.com/kmaehashi/8e89e6cfd863a4bc0746b90c3467b795~

~Depends on #6071~

See discussion below.