### PR TITLE
compile cub/thrust with no unique symbol

### DIFF
--- a/install/cupy_builder/cupy_setup_build.py
+++ b/install/cupy_builder/cupy_setup_build.py
@@ -650,6 +650,7 @@ class _UnixCCompiler(unixccompiler.UnixCCompiler):
             postargs += [f'-t{num_threads}']
         else:
             postargs += ['--std=c++11']
+        postargs += ['-Xcompiler=-fno-gnu-unique']
         print('NVCC options:', postargs)
         try:
             self.spawn(compiler_so + base_opts + cc_args + [src, '-o', obj] +


### PR DESCRIPTION
In many cases we may want to combine cupy with other frameworks (like pytorch or TensorRT).

when using pytorch and cupy together, since both of them compiled with cub/thrust, there would be a conflict with the static variable.  this may result cuda runtime error (when calling both cupy.argsort and torch.argsort in the same process) or stuck (it's hard to reproduce the stuck behavior here since this happens in my unittest).

this PR fixes this issue and cupy can work well with other frameworks.

the related issue may be #2409.

for detail you can see that https://github.com/NVIDIA/thrust/issues/1401#issuecomment-806403746