### PR TITLE
Add `cupy.trapz`

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -580,6 +580,7 @@ from cupy._math.sumprod import nansum  # NOQA
 from cupy._math.sumprod import nanprod  # NOQA
 from cupy._math.sumprod import diff  # NOQA
 from cupy._math.sumprod import gradient  # NOQA
+from cupy._math.sumprod import trapz  # NOQA
 from cupy._math.window import bartlett  # NOQA
 from cupy._math.window import blackman  # NOQA
 from cupy._math.window import hamming  # NOQA

--- a/cupy/_math/sumprod.py
+++ b/cupy/_math/sumprod.py
@@ -514,3 +514,70 @@ def gradient(f, *varargs, axis=None, edge_order=1):
 
 
 # TODO(okuta): Implement trapz
+
+def trapz(y, x=None, dx=1.0, axis=-1):
+    """
+Line too long (110 > 79 characters) …
+    Lifted from `numpy <https://github.com/numpy/numpy/blob/v1.15.1/numpy/lib/function_base.py#L3804-L3891>`_.
+    Integrate along the given axis using the composite trapezoidal rule.
+    Integrate `y` (`x`) along given axis.
+    Parameters
+    ==========
+    y : array_like
+        Input array to integrate.
+    x : array_like, optional
+        The sample points corresponding to the `y` values. If `x` is None,
+        the sample points are assumed to be evenly spaced `dx` apart. The
+        default is None.
+    dx : scalar, optional
+        The spacing between sample points when `x` is None. The default is 1.
+    axis : int, optional
+        The axis along which to integrate.
+    Returns
+    =======
+    trapz : float
+        Definite integral as approximated by trapezoidal rule.
+    References
+    ==========
+    .. [1] Wikipedia page: http://en.wikipedia.org/wiki/Trapezoidal_rule
+    Examples
+    ========
+    >>> trapz([1,2,3])
+    4.0
+    >>> trapz([1,2,3], x=[4,6,8])
+    8.0
+    >>> trapz([1,2,3], dx=2)
+    8.0
+    >>> a = cupy.arange(6).reshape(2, 3)
+    >>> a
+    array([[0, 1, 2],
+           [3, 4, 5]])
+    >>> trapz(a, axis=0)
+    array([ 1.5,  2.5,  3.5])
+    >>> trapz(a, axis=1)
+    array([ 2.,  8.])
+    """
+    y = cupy.asanyarray(y)
+    if x is None:
+        d = dx
+    else:
+        x = cupy.asanyarray(x)
+        if x.ndim == 1:
+            d = diff(x)
+            # reshape to correct shape
+            shape = [1] * y.ndim
+            shape[axis] = d.shape[0]
+            d = d.reshape(shape)
+        else:
+            d = diff(x, axis=axis)
+    nd = y.ndim
+    slice1 = [slice(None)] * nd
+    slice2 = [slice(None)] * nd
+    slice1[axis] = slice(1, None)
+    slice2[axis] = slice(None, -1)
+    product = d * (y[tuple(slice1)] + y[tuple(slice2)]) / 2.0
+    try:
+        ret = product.sum(axis)
+    except ValueError:
+        ret = cupy.add.reduce(product, axis)
+    return ret

--- a/cupy/_math/sumprod.py
+++ b/cupy/_math/sumprod.py
@@ -514,7 +514,7 @@ def gradient(f, *varargs, axis=None, edge_order=1):
 
 
 def trapz(y, x=None, dx=1.0, axis=-1):
-    """Calculate the n-th discrete difference along the given axis.
+    """
     Integrate along the given axis using the composite trapezoidal rule.
     Integrate `y` (`x`) along given axis.
 
@@ -533,11 +533,14 @@ def trapz(y, x=None, dx=1.0, axis=-1):
 
     .. seealso:: :func:`numpy.trapz`
     """
-    y = cupy.asanyarray(y)
+    if not isinstance(y, cupy.ndarray):
+        raise TypeError('`y` should be of type cupy.ndarray')
+
     if x is None:
         d = dx
     else:
-        x = cupy.asanyarray(x)
+        if not isinstance(x, cupy.ndarray):
+            raise TypeError('`x` should be of type cupy.ndarray')
         if x.ndim == 1:
             d = diff(x)
             # reshape to correct shape

--- a/cupy/_math/sumprod.py
+++ b/cupy/_math/sumprod.py
@@ -513,49 +513,25 @@ def gradient(f, *varargs, axis=None, edge_order=1):
 # TODO(okuta): Implement cross
 
 
-# TODO(okuta): Implement trapz
-
 def trapz(y, x=None, dx=1.0, axis=-1):
-    """
-Line too long (110 > 79 characters) …
-    Lifted from `numpy <https://github.com/numpy/numpy/blob/v1.15.1/numpy/lib/function_base.py#L3804-L3891>`_.
+    """Calculate the n-th discrete difference along the given axis.
     Integrate along the given axis using the composite trapezoidal rule.
     Integrate `y` (`x`) along given axis.
-    Parameters
-    ==========
-    y : array_like
-        Input array to integrate.
-    x : array_like, optional
-        The sample points corresponding to the `y` values. If `x` is None,
-        the sample points are assumed to be evenly spaced `dx` apart. The
-        default is None.
-    dx : scalar, optional
-        The spacing between sample points when `x` is None. The default is 1.
-    axis : int, optional
-        The axis along which to integrate.
-    Returns
-    =======
-    trapz : float
-        Definite integral as approximated by trapezoidal rule.
-    References
-    ==========
-    .. [1] Wikipedia page: http://en.wikipedia.org/wiki/Trapezoidal_rule
-    Examples
-    ========
-    >>> trapz([1,2,3])
-    4.0
-    >>> trapz([1,2,3], x=[4,6,8])
-    8.0
-    >>> trapz([1,2,3], dx=2)
-    8.0
-    >>> a = cupy.arange(6).reshape(2, 3)
-    >>> a
-    array([[0, 1, 2],
-           [3, 4, 5]])
-    >>> trapz(a, axis=0)
-    array([ 1.5,  2.5,  3.5])
-    >>> trapz(a, axis=1)
-    array([ 2.,  8.])
+
+    Args:
+        y (cupy.ndarray): Input array to integrate.
+        x (cupy.ndarray): Sample points over which to integrate. If None equal
+            spacing `dx` is assumed.
+        dx (float): Spacing between sample points, used if `x` is None, default
+            is None.
+        axis (int): The axis along which the integral is taken, default is
+            the last axis.
+
+    Returns:
+        cupy.ndarray: Definite integral as approximated by the trapezoidal
+            rule.
+
+    .. seealso:: :func:`numpy.trapz`
     """
     y = cupy.asanyarray(y)
     if x is None:

--- a/docs/source/reference/math.rst
+++ b/docs/source/reference/math.rst
@@ -72,6 +72,7 @@ Sums, products, differences
    diff
    gradient
    cross
+   trapz
 
 
 Exponents and logarithms

--- a/tests/cupy_tests/math_tests/test_sumprod.py
+++ b/tests/cupy_tests/math_tests/test_sumprod.py
@@ -1037,3 +1037,58 @@ class TestGradientErrors:
             x = testing.shaped_random(shape, xp, dtype=numpy.bool_)
             with pytest.raises(TypeError):
                 xp.gradient(x)
+
+
+@testing.gpu
+class TestTrapz:
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose()
+    def test_trapz_1dim(self, xp, dtype):
+        a = testing.shaped_arange((5,), xp, dtype)
+        return xp.trapz(a)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose()
+    def test_trapz_1dim_with_x(self, xp, dtype):
+        a = testing.shaped_arange((5,), xp, dtype)
+        x = testing.shaped_arange((5,), xp, dtype)
+        return xp.trapz(a, x=x)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose()
+    def test_trapz_1dim_with_dx(self, xp, dtype):
+        a = testing.shaped_arange((5,), xp, dtype)
+        return xp.trapz(a, dx=0.1)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose()
+    def test_trapz_2dim_without_axis(self, xp, dtype):
+        a = testing.shaped_arange((4, 5), xp, dtype)
+        return xp.trapz(a)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose()
+    def test_trapz_2dim_with_axis(self, xp, dtype):
+        a = testing.shaped_arange((4, 5), xp, dtype)
+        return xp.trapz(a, axis=-2)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose()
+    def test_trapz_2dim_with_x_and_axis(self, xp, dtype):
+        a = testing.shaped_arange((4, 5), xp, dtype)
+        x = testing.shaped_arange((5,), xp, dtype)
+        return xp.diff(a, x=x, axis=1)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose()
+    def test_trapz_2dim_with_dx_and_axis(self, xp, dtype):
+        a = testing.shaped_arange((4, 5), xp, dtype)
+        return xp.diff(a, dx=0.1, axis=1)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose()
+    def test_trapz_1dim_with_x_and_dx(self, xp, dtype):
+        a = testing.shaped_arange((5,), xp, dtype)
+        x = testing.shaped_arange((5,), xp, dtype)
+        return xp.trapz(a, x=x, dx=0.1)

--- a/tests/cupy_tests/math_tests/test_sumprod.py
+++ b/tests/cupy_tests/math_tests/test_sumprod.py
@@ -1073,7 +1073,7 @@ class TestTrapz:
         return xp.trapz(a, axis=-2)
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(rtol={numpy.float16: 1e-3, 'default': 1e-7})
     def test_trapz_2dim_with_x_and_axis(self, xp, dtype):
         a = testing.shaped_arange((4, 5), xp, dtype)
         x = testing.shaped_arange((5,), xp, dtype)

--- a/tests/cupy_tests/math_tests/test_sumprod.py
+++ b/tests/cupy_tests/math_tests/test_sumprod.py
@@ -1039,7 +1039,6 @@ class TestGradientErrors:
                 xp.gradient(x)
 
 
-@testing.gpu
 class TestTrapz:
 
     @testing.for_all_dtypes()

--- a/tests/cupy_tests/math_tests/test_sumprod.py
+++ b/tests/cupy_tests/math_tests/test_sumprod.py
@@ -1078,13 +1078,13 @@ class TestTrapz:
     def test_trapz_2dim_with_x_and_axis(self, xp, dtype):
         a = testing.shaped_arange((4, 5), xp, dtype)
         x = testing.shaped_arange((5,), xp, dtype)
-        return xp.diff(a, x=x, axis=1)
+        return xp.trapz(a, x=x, axis=1)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_trapz_2dim_with_dx_and_axis(self, xp, dtype):
         a = testing.shaped_arange((4, 5), xp, dtype)
-        return xp.diff(a, dx=0.1, axis=1)
+        return xp.trapz(a, dx=0.1, axis=1)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()

--- a/tests/cupy_tests/math_tests/test_sumprod.py
+++ b/tests/cupy_tests/math_tests/test_sumprod.py
@@ -1080,13 +1080,13 @@ class TestTrapz:
         return xp.trapz(a, x=x, axis=1)
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(rtol={numpy.float16: 1e-3, 'default': 1e-7})
     def test_trapz_2dim_with_dx_and_axis(self, xp, dtype):
         a = testing.shaped_arange((4, 5), xp, dtype)
         return xp.trapz(a, dx=0.1, axis=1)
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose()
+    @testing.numpy_cupy_allclose(rtol={numpy.float16: 1e-3, 'default': 1e-7})
     def test_trapz_1dim_with_x_and_dx(self, xp, dtype):
         a = testing.shaped_arange((5,), xp, dtype)
         x = testing.shaped_arange((5,), xp, dtype)


### PR DESCRIPTION
Hi!

This PR adds a version of trapz as requested in https://github.com/cupy/cupy/issues/6078. This is my first contribution here, I hope it's the expected format/sufficiently tested and documented.

I've been using a version of this in [code for gravitational-wave astronomy](https://github.com/ColmTalbot/gwpopulation/blob/master/gwpopulation/cupy_utils.py#L49) for a while.