### PR TITLE
Improve FlexCI test scripts

### DIFF
--- a/.pfnci/linux/main-flexci-prep.sh
+++ b/.pfnci/linux/main-flexci-prep.sh
@@ -6,6 +6,8 @@ set -ue
 
 env
 
+gcloud auth configure-docker
+
 for DF in "$(dirname ${0})"/tests/cuda*.Dockerfile; do
     echo "$(basename "${DF}")" | cut -d . -f 1
 done | xargs -i -n 1 -P 4 bash -c 'echo "flexci-prep: $2 start"; "$1" "$2" build push rmi > /dev/null 2>&1 && echo "flexci-prep: $2 succeeded" || echo "flexci-prep: $2 failed"' -- "$(dirname ${0})/run.sh" "{}"

--- a/.pfnci/linux/main-flexci.sh
+++ b/.pfnci/linux/main-flexci.sh
@@ -34,18 +34,20 @@ if [[ "${TARGET}" == "cuda115" ]]; then
     fi
 fi
 
+gcloud auth configure-docker
+
 echo "Starting: "${TARGET}""
 echo "****************************************************************************************************"
 CACHE_DIR=/tmp/cupy_cache PULL_REQUEST="${pull_req}" "$(dirname ${0})/run.sh" "${TARGET}" cache_get build test 2>&1 | tee "${LOG_FILE}"
 test_retval=${PIPESTATUS[0]}
 echo "****************************************************************************************************"
-echo "Exit with status ${test_retval}"
+echo "Build & Test: Exit with status ${test_retval}"
 
 if [[ "${pull_req}" == "" ]]; then
     # Upload cache when testing a branch, even when test failed.
     echo "Uploading cache and Docker image..."
     CACHE_DIR=/tmp/cupy_cache PULL_REQUEST="${pull_req}" "$(dirname ${0})/run.sh" "${TARGET}" cache_put push | tee --append "${LOG_FILE}"
-    echo "Upload exit with status ${PIPESTATUS[0]}"
+    echo "Upload: Exit with status ${PIPESTATUS[0]}"
 
     # Notify.
     if [[ ${test_retval} != 0 ]]; then


### PR DESCRIPTION
* Retry gsutil download as cache download may fail during other test uploading cache.
* Do `gcloud auth` outside of `run.sh` script to avoid configuring twice. (this is harmless but verbose)
* Improve message (show size of cache file, make docker push quiet).