### PR TITLE
Allow leading unit dimensions in copy source

### DIFF
--- a/cupy/_manipulation/basic.py
+++ b/cupy/_manipulation/basic.py
@@ -40,6 +40,16 @@ def copyto(dst, src, casting='same_kind', where=None):
     if not can_cast:
         raise TypeError('Cannot cast %s to %s in %s casting mode' %
                         (src_dtype, dst.dtype, casting))
+
+    if not src_is_python_scalar and src.ndim > dst.ndim:
+        # NumPy allows stripping leading unit dimensions.
+        try:
+            src = src.squeeze(tuple(range(src.ndim - dst.ndim)))
+        except ValueError:
+            # "cannot select an axis to squeeze out
+            # which has size not equal to one"
+            pass  # raise an error later
+
     if fusion._is_fusing():
         if where is None:
             _core.elementwise_copy(src, dst)

--- a/tests/cupy_tests/core_tests/test_ndarray_indexing.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_indexing.py
@@ -204,3 +204,33 @@ class TestArrayIndex(unittest.TestCase):
     def test_T_vector(self, xp):
         a = testing.shaped_arange((4,), xp)
         return a.T
+
+
+class TestSetItemCompatBroadcast:
+    @testing.numpy_cupy_array_equal()
+    def test_simple(self, xp):
+        dtype = int
+        a = xp.zeros(4, dtype)
+        a[:] = testing.shaped_arange((1, 4), xp, dtype)
+        return a
+
+    @testing.numpy_cupy_array_equal()
+    def test_other1(self, xp):
+        dtype = int
+        a = xp.zeros((2, 1, 3), dtype)
+        a[:] = testing.shaped_arange((1, 2, 1, 3), xp, dtype)
+        return a
+
+    @testing.numpy_cupy_array_equal()
+    def test_0d(self, xp):
+        dtype = int
+        a = xp.zeros((), dtype)
+        a[...] = testing.shaped_arange((1, 1), xp, dtype)
+        return a
+
+    @testing.numpy_cupy_array_equal()
+    def test_remain0d(self, xp):
+        dtype = int
+        a = xp.zeros((2, 3, 4), dtype)
+        a[0, 1, 2] = testing.shaped_arange((1, 1, 1), xp, dtype)
+        return a

--- a/tests/cupy_tests/manipulation_tests/test_basic.py
+++ b/tests/cupy_tests/manipulation_tests/test_basic.py
@@ -21,6 +21,14 @@ class TestBasic:
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
+    def test_copyto_different_contiguity(self, xp, dtype):
+        a = testing.shaped_arange((2, 3, 2), xp, dtype).T
+        b = xp.empty((2, 3, 2), dtype=dtype)
+        xp.copyto(b, a)
+        return b
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
     def test_copyto_dtype(self, xp, dtype):
         a = testing.shaped_arange((2, 3, 4), xp, dtype='?')
         b = xp.empty((2, 3, 4), dtype=dtype)
@@ -37,10 +45,43 @@ class TestBasic:
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
+    def test_copyto_squeeze(self, xp, dtype):
+        a = testing.shaped_arange((1, 1, 3, 4), xp, dtype)
+        b = xp.empty((3, 4), dtype=dtype)
+        xp.copyto(b, a)
+        return b
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_copyto_squeeze_different_contiguity(self, xp, dtype):
+        a = testing.shaped_arange((1, 1, 3, 4), xp, dtype)
+        b = xp.empty((4, 3), dtype=dtype).T
+        xp.copyto(b, a)
+        return b
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_copyto_squeeze_broadcast(self, xp, dtype):
+        a = testing.shaped_arange((1, 2, 1, 4), xp, dtype)
+        b = xp.empty((2, 3, 4), dtype=dtype)
+        xp.copyto(b, a)
+        return b
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
     def test_copyto_where(self, xp, dtype):
         a = testing.shaped_arange((2, 3, 4), xp, dtype)
         b = testing.shaped_reverse_arange((2, 3, 4), xp, dtype)
         c = testing.shaped_arange((2, 3, 4), xp, '?')
+        xp.copyto(a, b, where=c)
+        return a
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_copyto_where_squeeze_broadcast(self, xp, dtype):
+        a = testing.shaped_arange((2, 3, 4), xp, dtype)
+        b = testing.shaped_reverse_arange((1, 2, 1, 4), xp, dtype)
+        c = testing.shaped_arange((3, 4), xp, '?')
         xp.copyto(a, b, where=c)
         return a
 


### PR DESCRIPTION
Fix #5848.

[As a special case for backwards compatibility](https://github.com/numpy/numpy/blob/v1.21.4/numpy/core/src/multiarray/array_assign_array.c#L358), NumPy's broadcasting rule is more permissive in `copyto(dst, src, ...)` and `dst[indices] = src`.

