### PR TITLE
CI: Add timeout to show_config

### DIFF
--- a/.pfnci/linux/tests/actions/unittest.sh
+++ b/.pfnci/linux/tests/actions/unittest.sh
@@ -21,7 +21,7 @@ fi
 python3 -m pip install --user pytest-timeout pytest-xdist
 
 pushd tests
-python3 -c 'import cupy; cupy.show_config(_full=True)'
+timeout --signal INT --kill-after 10 60 python3 -c 'import cupy; cupy.show_config(_full=True)'
 test_retval=0
 timeout --signal INT --kill-after 60 18000 python3 -m pytest "${pytest_opts[@]}" "${PYTEST_FILES[@]}" || test_retval=$?
 popd


### PR DESCRIPTION
For some reason sometimes ROCm hangs here. To make it detectable set a timeout.