### PR TITLE
Docs: Update linkcode implementation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -436,12 +436,7 @@ def linkcode_resolve(domain, info):
         return None
 
     # If it's wrapped (e.g., by `contextlib.contextmanager`), unwrap it
-    for _ in range(10):
-        if not hasattr(obj, '__wrapped__'):
-            break
-        obj = obj.__wrapped__
-    else:
-        raise RuntimeError(f'nested too deep: {info}')
+    obj = inspect.unwrap(obj)
 
     # Get the source file name and line number at which obj is defined.
     try:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -445,7 +445,7 @@ def linkcode_resolve(domain, info):
         # obj is not a module, class, function, ..etc.
         return None
 
-    # inspect can return None for cython objects
+    # `inspect.getsourcefile` returns None for C-extension objects
     if filename is None:
         filename = inspect.getfile(obj)
         for ext in importlib.machinery.EXTENSION_SUFFIXES:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -463,8 +463,8 @@ def linkcode_resolve(domain, info):
     filename = os.path.realpath(filename)
     relpath = _get_source_relative_path(filename)
 
-    return 'https://github.com/cupy/cupy/blob/{}/{}'.format(
-        tag, relpath if linenum is None else f'{relpath}#L{linenum}')
+    fragment = '' if linenum is None else f'#L{linenum}'
+    return f'https://github.com/cupy/cupy/blob/{tag}/{relpath}{fragment}'
 
 
 # Python Array API methods have type hints, which do not render

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -434,6 +434,14 @@ def linkcode_resolve(domain, info):
     if not mod.__name__.split('.')[0] in _top_modules:
         return None
 
+    # If it's wrapped (e.g., by `contextlib.contextmanager`), unwrap it
+    for _ in range(10):
+        if not hasattr(obj, '__wrapped__'):
+            break
+        obj = obj.__wrapped__
+    else:
+        raise RuntimeError(f'nested too deep: {info}')
+
     # Get the source file name and line number at which obj is defined.
     try:
         filename = inspect.getsourcefile(obj)


### PR DESCRIPTION
Unwrap functions wrapped by `contextmanager` to fix `[source]` deadlink, e.g.:

* https://docs.cupy.dev/en/v10.0.0rc1/reference/generated/cupy.cuda.using_allocator.html?highlight=[source]
* https://docs.cupy.dev/en/v10.0.0rc1/reference/generated/cupyx.optimizing.optimize.html?highlight=[source]

Add `[source]` link to objects defined in C-extensions, e.g.:

* https://docs.cupy.dev/en/v10.0.0rc1/reference/generated/cupy.cuda.Device.html