### PR TITLE
[backport] CI: add link to ROCm projects in CI coverage matrix

### DIFF
--- a/.pfnci/coverage.md
+++ b/.pfnci/coverage.md
@@ -108,13 +108,13 @@
 [t11]:https://ci.preferred.jp/cupy.linux.cuda114.multi/
 [d11]:linux/tests/cuda114.multi.Dockerfile
 [s11]:linux/tests/cuda114.multi.sh
-[t12]:https://ci.preferred.jp/cupy.linux.rocm-4-0/
+[t12]:https://jenkins.preferred.jp/job/chainer/job/cupy_master/TEST=rocm-4-0,label=mnj-mi50/
 [d12]:linux/tests/rocm-4-0.Dockerfile
 [s12]:linux/tests/rocm-4-0.sh
-[t13]:https://ci.preferred.jp/cupy.linux.rocm-4-2/
+[t13]:https://jenkins.preferred.jp/job/chainer/job/cupy_master/TEST=rocm-4-2,label=mnj-mi50/
 [d13]:linux/tests/rocm-4-2.Dockerfile
 [s13]:linux/tests/rocm-4-2.sh
-[t14]:https://ci.preferred.jp/cupy.linux.rocm-4-3/
+[t14]:https://jenkins.preferred.jp/job/chainer/job/cupy_master/TEST=rocm-4-3,label=mnj-mi50/
 [d14]:linux/tests/rocm-4-3.Dockerfile
 [s14]:linux/tests/rocm-4-3.sh
 [t15]:https://ci.preferred.jp/cupy.linux.cuda-slow/

--- a/.pfnci/generate.py
+++ b/.pfnci/generate.py
@@ -346,8 +346,11 @@ class CoverageGenerator:
         # Add links to FlexCI projects.
         lines += ['']
         for i, m in enumerate(self.matrixes):
+            url = f'https://ci.preferred.jp/{m.project}/'
+            if hasattr(m, '_url'):
+                url = m._url
             lines += [
-                f'[t{i}]:https://ci.preferred.jp/{m.project}/',
+                f'[t{i}]:{url}',
                 f'[d{i}]:{m.system}/tests/{m.target}.Dockerfile',
                 f'[s{i}]:{m.system}/tests/{m.target}.sh',
             ]

--- a/.pfnci/linux/tests/cuda111.multi.Dockerfile
+++ b/.pfnci/linux/tests/cuda111.multi.Dockerfile
@@ -13,7 +13,7 @@ RUN yum -y install \
        xz-devel && \
     yum -y install epel-release && \
     yum -y install "@Development Tools" ccache git curl && \
-    yum -y install libnccl-devel-2.8.*-*+cuda11.1 libcutensor-devel-1.3.* libcudnn8-devel-8.0.*-*.cuda11.1
+    yum -y install libnccl-2.8.*-*+cuda11.1 libnccl-devel-2.8.*-*+cuda11.1 libcutensor1-1.3.* libcutensor-devel-1.3.* libcudnn8-8.0.*-*.cuda11.1 libcudnn8-devel-8.0.*-*.cuda11.1
 
 ENV PATH "/usr/lib64/ccache:${PATH}"
 

--- a/.pfnci/linux/tests/cuda112.multi.Dockerfile
+++ b/.pfnci/linux/tests/cuda112.multi.Dockerfile
@@ -8,7 +8,7 @@ RUN yum -y install \
        xz-devel && \
     yum -y install epel-release && \
     yum -y install "@Development Tools" ccache git curl && \
-    yum -y install libnccl-devel-2.8.*-*+cuda11.2 libcutensor-devel-1.3.* libcusparselt-devel-0.1.0.* libcudnn8-devel-8.1.*-*.cuda11.2
+    yum -y install libnccl-2.8.*-*+cuda11.2 libnccl-devel-2.8.*-*+cuda11.2 libcutensor1-1.3.* libcutensor-devel-1.3.* libcusparselt0-0.1.0.* libcusparselt-devel-0.1.0.* libcudnn8-8.1.*-*.cuda11.2 libcudnn8-devel-8.1.*-*.cuda11.2
 
 ENV PATH "/usr/lib64/ccache:${PATH}"
 

--- a/.pfnci/matrix.yaml
+++ b/.pfnci/matrix.yaml
@@ -186,6 +186,7 @@
 # ROCm 4.0 | Linux
 # The lowest ROCm version matrix is intended to cover the lowest supported combination.
 - project: "cupy.linux.rocm-4-0"
+  _url: "https://jenkins.preferred.jp/job/chainer/job/cupy_master/TEST=rocm-4-0,label=mnj-mi50/"
   target: "rocm-4-0"
   system: "linux"
   os: "ubuntu:20.04"
@@ -205,6 +206,7 @@
 
 # ROCm 4.2 | Linux
 - project: "cupy.linux.rocm-4-2"
+  _url: "https://jenkins.preferred.jp/job/chainer/job/cupy_master/TEST=rocm-4-2,label=mnj-mi50/"
   target: "rocm-4-2"
   system: "linux"
   os: "ubuntu:20.04"
@@ -225,6 +227,7 @@
 # ROCm 4.3 | Linux
 # The latest ROCm version matrix is intended to cover the highest supported combination.
 - project: "cupy.linux.rocm-4-3"
+  _url: "https://jenkins.preferred.jp/job/chainer/job/cupy_master/TEST=rocm-4-3,label=mnj-mi50/"
   target: "rocm-4-3"
   system: "linux"
   os: "ubuntu:20.04"


### PR DESCRIPTION
Backport of #6037 by @kmaehashi

Also fixes the issue that Dockerfiles are not regenerated.