### PR TITLE
Remove legacy `cp.linalg.solve()` implementation

### DIFF
--- a/cupy/linalg/_solve.py
+++ b/cupy/linalg/_solve.py
@@ -5,8 +5,6 @@ from numpy import linalg
 
 import cupy
 from cupy._core import internal
-from cupy_backends.cuda.libs import cublas
-from cupy_backends.cuda.libs import cusolver
 from cupy.cuda import device
 from cupy.linalg import _decomposition
 from cupy.linalg import _util
@@ -73,78 +71,6 @@ def solve(a, b):
         cupyx.lapack.gesv(a[index], bi)
         x[index] = bi
     return x
-
-
-def _solve(a, b, cublas_handle, cusolver_handle):
-    a = cupy.asfortranarray(a)
-    b = cupy.asfortranarray(b)
-    dtype = a.dtype
-    m, k = (b.size, 1) if b.ndim == 1 else b.shape
-    dev_info = cupy.empty(1, dtype=numpy.int32)
-
-    if dtype == 'f':
-        geqrf = cusolver.sgeqrf
-        geqrf_bufferSize = cusolver.sgeqrf_bufferSize
-        ormqr = cusolver.sormqr
-        ormqr_bufferSize = cusolver.sormqr_bufferSize
-        trans = cublas.CUBLAS_OP_T
-        trsm = cublas.strsm
-    elif dtype == 'd':
-        geqrf = cusolver.dgeqrf
-        geqrf_bufferSize = cusolver.dgeqrf_bufferSize
-        ormqr = cusolver.dormqr
-        ormqr_bufferSize = cusolver.dormqr_bufferSize
-        trans = cublas.CUBLAS_OP_T
-        trsm = cublas.dtrsm
-    elif dtype == 'F':
-        geqrf = cusolver.cgeqrf
-        geqrf_bufferSize = cusolver.cgeqrf_bufferSize
-        ormqr = cusolver.cormqr
-        ormqr_bufferSize = cusolver.cunmqr_bufferSize
-        trans = cublas.CUBLAS_OP_C
-        trsm = cublas.ctrsm
-    elif dtype == 'D':
-        geqrf = cusolver.zgeqrf
-        geqrf_bufferSize = cusolver.zgeqrf_bufferSize
-        ormqr = cusolver.zormqr
-        ormqr_bufferSize = cusolver.zunmqr_bufferSize
-        trans = cublas.CUBLAS_OP_C
-        trsm = cublas.ztrsm
-    else:
-        raise NotImplementedError(dtype)
-
-    # 1. QR decomposition (A = Q * R)
-    buffersize = geqrf_bufferSize(cusolver_handle, m, m, a.data.ptr, m)
-    workspace = cupy.empty(buffersize, dtype=dtype)
-    tau = cupy.empty(m, dtype=dtype)
-    geqrf(
-        cusolver_handle, m, m, a.data.ptr, m, tau.data.ptr, workspace.data.ptr,
-        buffersize, dev_info.data.ptr)
-    cupy.linalg._util._check_cusolver_dev_info_if_synchronization_allowed(
-        geqrf, dev_info)
-    # Explicitly free the space allocated by geqrf
-    del workspace
-    # 2. ormqr (Q^T * B)
-    buffersize = ormqr_bufferSize(
-        cusolver_handle, cublas.CUBLAS_SIDE_LEFT, trans, m, k, m, a.data.ptr,
-        m, tau.data.ptr, b.data.ptr, m)
-    workspace = cupy.empty(buffersize, dtype=dtype)
-    ormqr(
-        cusolver_handle, cublas.CUBLAS_SIDE_LEFT, trans, m, k, m, a.data.ptr,
-        m, tau.data.ptr, b.data.ptr, m, workspace.data.ptr, buffersize,
-        dev_info.data.ptr)
-    cupy.linalg._util._check_cusolver_dev_info_if_synchronization_allowed(
-        ormqr, dev_info)
-
-    # Explicitly free the space allocated by ormqr
-    del workspace
-    # 3. trsm (X = R^{-1} * (Q^T * B))
-    one = numpy.array(1, dtype=dtype)
-    trsm(
-        cublas_handle, cublas.CUBLAS_SIDE_LEFT, cublas.CUBLAS_FILL_MODE_UPPER,
-        cublas.CUBLAS_OP_N, cublas.CUBLAS_DIAG_NON_UNIT,
-        m, k, one.ctypes.data, a.data.ptr, m, b.data.ptr, m)
-    return b
 
 
 def tensorsolve(a, b, axes=None):


### PR DESCRIPTION
Follow-up of #3942. Looks like the QR-based helper function `_solve()` is no longer used anywhere in the codebase.