### PR TITLE
Fix empty `solve`

### DIFF
--- a/cupy/cublas.py
+++ b/cupy/cublas.py
@@ -39,13 +39,19 @@ def batched_gesv(a, b):
     _util._assert_stacked_2d(a)
     _util._assert_stacked_square(a)
 
-    if not ((a.ndim == b.ndim or a.ndim == b.ndim + 1) and
-            a.shape[:-1] == b.shape[:a.ndim - 1]):
+    # TODO(kataoka): Support broadcast
+    if not (
+        (a.ndim == b.ndim or a.ndim == b.ndim + 1)
+        and a.shape[:-1] == b.shape[:a.ndim - 1]
+    ):
         raise ValueError(
             'a must have (..., M, M) shape and b must have (..., M) '
             'or (..., M, K)')
 
     dtype, out_dtype = _util.linalg_common_type(a, b)
+    if b.size == 0:
+        return cupy.empty(b.shape, out_dtype)
+
     if dtype == 'f':
         t = 's'
     elif dtype == 'd':

--- a/cupy/linalg/_solve.py
+++ b/cupy/linalg/_solve.py
@@ -22,7 +22,7 @@ def solve(a, b):
 
     Args:
         a (cupy.ndarray): The matrix with dimension ``(..., M, M)``.
-        b (cupy.ndarray): The matrix with dimension ``(...,M)`` or
+        b (cupy.ndarray): The matrix with dimension ``(..., M)`` or
             ``(..., M, K)``.
 
     Returns:
@@ -48,13 +48,19 @@ def solve(a, b):
     _util._assert_stacked_2d(a)
     _util._assert_stacked_square(a)
 
-    if not ((a.ndim == b.ndim or a.ndim == b.ndim + 1) and
-            a.shape[:-1] == b.shape[:a.ndim - 1]):
+    # TODO(kataoka): Support broadcast
+    if not (
+        (a.ndim == b.ndim or a.ndim == b.ndim + 1)
+        and a.shape[:-1] == b.shape[:a.ndim - 1]
+    ):
         raise ValueError(
             'a must have (..., M, M) shape and b must have (..., M) '
             'or (..., M, K)')
 
     dtype, out_dtype = _util.linalg_common_type(a, b)
+    if b.size == 0:
+        return cupy.empty(b.shape, out_dtype)
+
     if a.ndim == 2:
         # prevent 'a' and 'b' to be overwritten
         a = a.astype(dtype, copy=True, order='F')

--- a/tests/cupy_tests/linalg_tests/test_solve.py
+++ b/tests/cupy_tests/linalg_tests/test_solve.py
@@ -74,6 +74,8 @@ class TestSolve(unittest.TestCase):
         self.check_shape((3, 3), (2, 2), ValueError)
         self.check_shape((3, 3, 4), (3,), numpy.linalg.LinAlgError)
         self.check_shape((2, 3, 3), (3,), ValueError)
+        self.check_shape((3, 3), (0,), ValueError)
+        self.check_shape((0, 3, 4), (3,), numpy.linalg.LinAlgError)
 
 
 @testing.parameterize(*testing.product({
@@ -134,6 +136,8 @@ class TestInv(unittest.TestCase):
         self.check_shape((4, 1))
         self.check_shape((4, 3, 2))
         self.check_shape((2, 4, 3))
+        self.check_shape((2, 0))
+        self.check_shape((0, 2, 3))
 
 
 @testing.gpu

--- a/tests/cupy_tests/linalg_tests/test_solve.py
+++ b/tests/cupy_tests/linalg_tests/test_solve.py
@@ -114,6 +114,9 @@ class TestInv(unittest.TestCase):
         self.check_x((2, 5, 5))
         self.check_x((3, 4, 4))
         self.check_x((4, 2, 3, 3))
+        self.check_x((0, 0))
+        self.check_x((3, 0, 0))
+        self.check_x((2, 0, 3, 4, 4))
 
     def test_invalid_shape(self):
         self.check_shape((2, 3))

--- a/tests/cupy_tests/linalg_tests/test_solve.py
+++ b/tests/cupy_tests/linalg_tests/test_solve.py
@@ -49,6 +49,10 @@ class TestSolve(unittest.TestCase):
         self.check_x((2, 5, 5), (2, 5, 2))
         self.check_x((2, 3, 2, 2), (2, 3, 2,))
         self.check_x((2, 3, 3, 3), (2, 3, 3, 2))
+        self.check_x((0, 0), (0,))
+        self.check_x((0, 0), (0, 2))
+        self.check_x((0, 2, 2), (0, 2,))
+        self.check_x((0, 2, 2), (0, 2, 3))
 
     def check_shape(self, a_shape, b_shape, error_type):
         for xp in (numpy, cupy):
@@ -56,6 +60,13 @@ class TestSolve(unittest.TestCase):
             b = xp.random.rand(*b_shape)
             with pytest.raises(error_type):
                 xp.linalg.solve(a, b)
+
+    @testing.numpy_cupy_allclose()
+    def test_solve_singular_empty(self, xp):
+        a = xp.zeros((3, 3))  # singular
+        b = xp.empty((3, 0))  # nrhs = 0
+        # LinAlgError("Singular matrix") is not raised
+        return xp.linalg.solve(a, b)
 
     def test_invalid_shape(self):
         self.check_shape((2, 3), (4,), numpy.linalg.LinAlgError)


### PR DESCRIPTION
#6160

This PR fixes `linalg.solve` and `linalg.inv` for empty inputs.  As a consequence, `linalg.tensorsolve` and `linalg.tensorinv` are fixed, too.