### PR TITLE
Add tests for `convolve2d`

### DIFF
--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
@@ -209,6 +209,38 @@ class TestConvolveCorrelate2D:
         return self._filter('correlate2d', dtype, xp, scp)
 
 
+@testing.with_requires('scipy')
+class TestConvolve2DEdgeCase:
+
+    @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
+    def test_convolve2d_1(self, xp, scp):
+        # see cupy/cupy#5989
+        from scipy import misc
+        ascent = misc.ascent()
+        if xp is cupy:
+            ascent = xp.asarray(ascent)
+        scharr = xp.array(
+            [[-3-3j, 0-10j, +3-3j],
+             [-10+0j, 0+0j, +10+0j],
+             [-3+3j, 0+10j, +3+3j]])  # Gx + j*Gy
+        return scp.signal.convolve2d(
+            ascent, scharr, boundary='symm', mode='same')
+
+    @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
+    def test_convolve2d_2(self, xp, scp):
+        # see cupy/cupy#6047
+        a = xp.array([[257]], dtype="uint64")
+        b = xp.array([[1]], dtype="uint8")
+        return scp.signal.convolve2d(a, b, mode="same")
+
+    @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
+    def test_convolve2d_3(self, xp, scp):
+        # see cupy/cupy#6047
+        a = xp.array([[257]], dtype="uint64")
+        b = xp.array([[1]], dtype="uint8")
+        return scp.signal.convolve2d(b, a, mode="same")
+
+
 @testing.gpu
 @testing.parameterize(*testing.product({
     'mode': ['valid', 'same', 'full']


### PR DESCRIPTION
Follow-up of #6046. Close #6057. 

Verified that the added tests would fail on CuPy v9.6 (as #6046 was not backported) but not on the `master` branch.