### PR TITLE
Handles infinities of the same sign in `logaddexp` and `logaddexp2`

### DIFF
--- a/cupy/_math/explog.py
+++ b/cupy/_math/explog.py
@@ -70,7 +70,14 @@ log1p = ufunc.create_math_ufunc(
 logaddexp = _core.create_ufunc(
     'cupy_logaddexp',
     ('ee->e', 'ff->f', 'dd->d'),
-    'out0 = fmax(in0, in1) + log1p(exp(-fabs(in0 - in1)))',
+    '''
+    if (in0 == in1) {
+        /* Handles infinities of the same sign */
+        out0 = in0 + log(2.0);
+    } else {
+        out0 = fmax(in0, in1) + log1p(exp(-fabs(in0 - in1)));
+    }
+    ''',
     doc='''Computes ``log(exp(x1) + exp(x2))`` elementwise.
 
     .. seealso:: :data:`numpy.logaddexp`
@@ -81,7 +88,14 @@ logaddexp = _core.create_ufunc(
 logaddexp2 = _core.create_ufunc(
     'cupy_logaddexp2',
     ('ee->e', 'ff->f', 'dd->d'),
-    'out0 = fmax(in0, in1) + log2(1 + exp2(-fabs(in0 - in1)))',
+    '''
+    if (in0 == in1) {
+        /* Handles infinities of the same sign */
+        out0 = in0 + 1.0;
+    } else {
+        out0 = fmax(in0, in1) + log2(1 + exp2(-fabs(in0 - in1)));
+    }
+    ''',
     doc='''Computes ``log2(exp2(x1) + exp2(x2))`` elementwise.
 
     .. seealso:: :data:`numpy.logaddexp2`

--- a/tests/cupy_tests/math_tests/test_explog.py
+++ b/tests/cupy_tests/math_tests/test_explog.py
@@ -1,12 +1,10 @@
-import unittest
-
 import numpy
+import pytest
 
 from cupy import testing
 
 
-@testing.gpu
-class TestExplog(unittest.TestCase):
+class TestExplog:
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(atol=1e-5)
@@ -54,5 +52,19 @@ class TestExplog(unittest.TestCase):
     def test_logaddexp(self):
         self.check_binary('logaddexp', no_complex=True)
 
+    @pytest.mark.parametrize('val', [numpy.inf, -numpy.inf])
+    @testing.for_float_dtypes()
+    @testing.numpy_cupy_allclose()
+    def test_logaddexp_infinities(self, xp, dtype, val):
+        a = xp.full((2, 3), val, dtype=dtype)
+        return xp.logaddexp(a, a)
+
     def test_logaddexp2(self):
         self.check_binary('logaddexp2', no_complex=True)
+
+    @pytest.mark.parametrize('val', [numpy.inf, -numpy.inf])
+    @testing.for_float_dtypes()
+    @testing.numpy_cupy_allclose()
+    def test_logaddexp2_infinities(self, xp, dtype, val):
+        a = xp.full((2, 3), val, dtype=dtype)
+        return xp.logaddexp2(a, a)


### PR DESCRIPTION
Fix #5716.