### PR TITLE
CI: Update limits to reduce cache size

### DIFF
--- a/.github/workflows/pretest.yml
+++ b/.github/workflows/pretest.yml
@@ -20,18 +20,18 @@ jobs:
         # cupyx.array_api uses Python 3.8 syntaxes
         python-version: '3.8'
 
-    - name: Setup ccache
-      run: |
-        sudo apt-get update -y
-        sudo apt-get install -y ccache
-        echo "PATH=/usr/lib/ccache:${PATH}" >> "${GITHUB_ENV}"
-        which gcc g++
-
     - name: Load ccache
       uses: actions/cache@v2
       with:
         path: ~/.ccache
         key: ccache
+
+    - name: Setup ccache
+      run: |
+        sudo apt-get update -y
+        sudo apt-get install -y ccache
+        echo "PATH=/usr/lib/ccache:${PATH}" >> "${GITHUB_ENV}"
+        ccache --max-size 0.5Gi --cleanup --show-stats
 
     - name: Build
       run: |

--- a/.pfnci/linux/tests/actions/cleanup.sh
+++ b/.pfnci/linux/tests/actions/cleanup.sh
@@ -2,4 +2,5 @@
 
 set -uex
 
-python3 .pfnci/trim_cupy_kernel_cache.py --max-size $((5*1024*1024*1024)) --rm
+python3 .pfnci/trim_cupy_kernel_cache.py --max-size $((3*1024*1024*1024)) --rm
+ccache --max-size 0.5Gi --cleanup --show-stats


### PR DESCRIPTION
Further limit cache size to reduce upload/download/creation/extraction time.

* Default limit of ccache is 5GB but it was too large to keep CuPy build cache.
* Also adjust CuPy kernel cache size limit.