### PR TITLE
Deprecate MachAr (support NumPy 1.22)

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -367,7 +367,6 @@ from numpy import format_parser  # NOQA
 
 from numpy import finfo  # NOQA
 from numpy import iinfo  # NOQA
-from numpy import MachAr  # NOQA
 
 from numpy import find_common_type  # NOQA
 from numpy import issctype  # NOQA
@@ -873,19 +872,21 @@ def show_config(*, _full=False):
     _sys.stdout.flush()
 
 
-if _sys.version_info >= (3, 7):
-    _deprecated_attrs = {
-        'int': (int, 'cupy.int_'),
-        'bool': (bool, 'cupy.bool_'),
-        'float': (float, 'cupy.float_'),
-        'complex': (complex, 'cupy.complex_'),
-    }
+_deprecated_apis = [
+    'MachAr',  # NumPy 1.22
+]
 
-    def __getattr__(name):
-        value = _deprecated_attrs.get(name)
-        if value is None:
-            raise AttributeError(
-                f"module 'cupy' has no attribute {name!r}")
+_deprecated_scalar_aliases = {  # NumPy 1.20
+    'int': (int, 'cupy.int_'),
+    'bool': (bool, 'cupy.bool_'),
+    'float': (float, 'cupy.float_'),
+    'complex': (complex, 'cupy.complex_'),
+}
+
+
+def __getattr__(name):
+    value = _deprecated_scalar_aliases.get(name)
+    if value is not None:
         attr, eq_attr = value
         _warnings.warn(
             f'`cupy.{name}` is a deprecated alias for the Python scalar type '
@@ -894,9 +895,8 @@ if _sys.version_info >= (3, 7):
             DeprecationWarning, stacklevel=2
         )
         return attr
-else:
-    # Does not emit warnings.
-    from builtins import int
-    from builtins import bool
-    from builtins import float
-    from builtins import complex
+
+    if name in _deprecated_apis:
+        return getattr(_numpy, name)
+
+    raise AttributeError(f"module 'cupy' has no attribute {name!r}")


### PR DESCRIPTION
Test with NumPy 1.22.0rc1 failed:
https://ci.preferred.jp/cupy.linux.cuda-head/87655/

This is because `np.MachAr` has been deprecated (https://github.com/numpy/numpy/pull/20201)