### PR TITLE
Support pre-release NumPy version in tests

### DIFF
--- a/tests/cupyx_tests/fallback_mode_tests/test_fallback.py
+++ b/tests/cupyx_tests/fallback_mode_tests/test_fallback.py
@@ -127,7 +127,8 @@ def enable_slice_copy(func):
 
 
 def get_numpy_version():
-    return tuple(map(int, numpy.__version__.split('.')))
+    v = numpy.lib.NumpyVersion(numpy.__version__)
+    return (v.major, v.minor, v.bugfix)
 
 
 @ignore_fallback_warnings


### PR DESCRIPTION
Test with pre-release failed:
https://ci.preferred.jp/cupy.linux.cuda-head/87777/