### PR TITLE
Fix #4675 on resolving TODO in #4198

### DIFF
--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -1191,10 +1191,12 @@ cdef class ndarray:
             return numpy.multiply(x, y)
 
     def __matmul__(x, y):
-        if not isinstance(y, ndarray) and _should_use_rop(x, y):
+        if isinstance(y, ndarray):
+            return _linalg.matmul(x, y)
+        elif _should_use_rop(x, y):
             return NotImplemented
         else:
-            return cupy.linalg._product.matmul(x, y)
+            return numpy.matmul(x, y)
 
     def __div__(x, y):
         if isinstance(y, ndarray):


### PR DESCRIPTION
I should have written the TODO comment more precisely in [this commit](https://github.com/cupy/cupy/pull/4198/commits/a829c8d0adce0c6b22504631eeb9cba8078b1493).

Fix #4118 on `__matmul__`.
```
>>> import dask.array as da
>>> cupy.ones((3, 4)) @ da.ones_like(cupy.empty((4, 2)))
dask.array<reshape, shape=(3, 2), dtype=float64, chunksize=(3, 2), chunktype=cupy.ndarray>
```