### PR TITLE
[Documentation] Fixed spelling of environment

### DIFF
--- a/docs/source/install_rocm.rst
+++ b/docs/source/install_rocm.rst
@@ -1,4 +1,4 @@
-[Experimental] Installation Guide for ROCm environemt
+[Experimental] Installation Guide for ROCm environment
 =====================================================
 
 .. contents:: :local:


### PR DESCRIPTION
Quick fix of typo on 'environment' from CuPy's ROCm docs