### PR TITLE
Fix edge case compatibility in `cupy.eye()`

### DIFF
--- a/cupy/_creation/basic.py
+++ b/cupy/_creation/basic.py
@@ -111,9 +111,7 @@ def eye(N, M=None, k=0, dtype=float, order='C'):
     if M is None:
         M = N
     ret = zeros((N, M), dtype=dtype, order=order)
-    if k >= M:
-        return ret
-    if k <= -N:
+    if k <= -N or k >= M:
         return ret
     ret.diagonal(k)[:] = 1
     return ret

--- a/cupy/_creation/basic.py
+++ b/cupy/_creation/basic.py
@@ -110,7 +110,11 @@ def eye(N, M=None, k=0, dtype=float, order='C'):
     """
     if M is None:
         M = N
-    ret = zeros((N, M), dtype, order=order)
+    ret = zeros((N, M), dtype=dtype, order=order)
+    if k >= M:
+        return ret
+    if k <= -N:
+        return ret
     ret.diagonal(k)[:] = 1
     return ret
 

--- a/tests/cupy_tests/creation_tests/test_basic.py
+++ b/tests/cupy_tests/creation_tests/test_basic.py
@@ -169,7 +169,7 @@ class TestBasic:
         b = cupy.empty((1, 0, 2), dtype='d', order=order)
         assert b.strides == a.strides
 
-    @pytest.mark.parametrize('offset', [1, -1, 1<<63, -(1<<63)])
+    @pytest.mark.parametrize('offset', [1, -1, 1 << 63, -(1 << 63)])
     @testing.for_CF_orders()
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()

--- a/tests/cupy_tests/creation_tests/test_basic.py
+++ b/tests/cupy_tests/creation_tests/test_basic.py
@@ -1,5 +1,3 @@
-import unittest
-
 import numpy
 import pytest
 
@@ -7,8 +5,7 @@ import cupy
 from cupy import testing
 
 
-@testing.gpu
-class TestBasic(unittest.TestCase):
+class TestBasic:
     @testing.for_CF_orders()
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
@@ -172,11 +169,12 @@ class TestBasic(unittest.TestCase):
         b = cupy.empty((1, 0, 2), dtype='d', order=order)
         assert b.strides == a.strides
 
+    @pytest.mark.parametrize('offset', [1, -1, 1<<63, -(1<<63)])
     @testing.for_CF_orders()
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
-    def test_eye(self, xp, dtype, order):
-        return xp.eye(5, 4, 1, dtype, order=order)
+    def test_eye(self, xp, dtype, order, offset):
+        return xp.eye(5, 4, offset, dtype, order=order)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
@@ -280,8 +278,7 @@ class TestBasic(unittest.TestCase):
         'shape': [4, (4, ), (4, 2), (4, 2, 3), (5, 4, 2, 3)],
     })
 )
-@testing.gpu
-class TestBasicReshape(unittest.TestCase):
+class TestBasicReshape:
 
     @testing.with_requires('numpy>=1.17.0')
     @testing.for_orders('CFAK')


### PR DESCRIPTION
Fix #5704