### PR TITLE
Fix `linalg.eigh` and `linalg.eigvalsh` on empty inputs

### DIFF
--- a/cupy/linalg/_eigenvalue.py
+++ b/cupy/linalg/_eigenvalue.py
@@ -129,12 +129,8 @@ def eigh(a, UPLO='L'):
 
     .. seealso:: :func:`numpy.linalg.eigh`
     """
-    if a.ndim < 2:
-        raise ValueError('Array must be at least two-dimensional')
-
-    m, n = a.shape[-2:]
-    if m != n:
-        raise ValueError('Last 2 dimensions of the array must be square')
+    _util._assert_stacked_2d(a)
+    _util._assert_stacked_square(a)
 
     if a.ndim > 2 or runtime.is_hip:
         w, v = cupy.cusolver.syevj(a, UPLO, True)

--- a/cupy/linalg/_eigenvalue.py
+++ b/cupy/linalg/_eigenvalue.py
@@ -132,6 +132,13 @@ def eigh(a, UPLO='L'):
     _util._assert_stacked_2d(a)
     _util._assert_stacked_square(a)
 
+    if a.size == 0:
+        _, v_dtype = _util.linalg_common_type(a)
+        w_dtype = v_dtype.char.lower()
+        w = cupy.empty(a.shape[:-1], w_dtype)
+        v = cupy.empty(a.shape, v_dtype)
+        return w, v
+
     if a.ndim > 2 or runtime.is_hip:
         w, v = cupy.cusolver.syevj(a, UPLO, True)
         return w, v
@@ -170,6 +177,11 @@ def eigvalsh(a, UPLO='L'):
     """
     _util._assert_stacked_2d(a)
     _util._assert_stacked_square(a)
+
+    if a.size == 0:
+        _, v_dtype = _util.linalg_common_type(a)
+        w_dtype = v_dtype.char.lower()
+        return cupy.empty(a.shape[:-1], w_dtype)
 
     if a.ndim > 2 or runtime.is_hip:
         return cupy.cusolver.syevj(a, UPLO, False)

--- a/tests/cupy_tests/linalg_tests/test_eigenvalue.py
+++ b/tests/cupy_tests/linalg_tests/test_eigenvalue.py
@@ -145,6 +145,32 @@ class TestEigenvalue:
 
 @pytest.mark.parametrize('UPLO', ['U', 'L'])
 @pytest.mark.parametrize('shape', [
+    (0, 0),
+    (2, 0, 0),
+    (0, 3, 3),
+])
+@pytest.mark.skipif(
+    runtime.is_hip and driver.get_build_version() < 402,
+    reason='eigensolver not added until ROCm 4.2.0')
+class TestEigenvalueEmpty:
+
+    @testing.for_dtypes('ifdFD')
+    @testing.numpy_cupy_allclose()
+    def test_eigh(self, xp, dtype, shape, UPLO):
+        a = xp.empty(shape, dtype)
+        assert a.size == 0
+        return xp.linalg.eigh(a, UPLO=UPLO)
+
+    @testing.for_dtypes('ifdFD')
+    @testing.numpy_cupy_allclose()
+    def test_eigvalsh(self, xp, dtype, shape, UPLO):
+        a = xp.empty(shape, dtype)
+        assert a.size == 0
+        return xp.linalg.eigvalsh(a, UPLO=UPLO)
+
+
+@pytest.mark.parametrize('UPLO', ['U', 'L'])
+@pytest.mark.parametrize('shape', [
     (),
     (3,),
     (2, 3),


### PR DESCRIPTION
#6160