### PR TITLE
Docs: CentOS installation from source

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -365,7 +365,7 @@ On CentOS 6 / 7::
   $ sudo yum install centos-release-scl
   $ sudo yum install devtoolset-7-gcc-c++
   $ source /opt/rh/devtoolset-7/enable
-  $ export NVCC="nvcc --compiler-bidir gcc-7"
+  $ export NVCC="nvcc --compiler-bindir gcc"
 
 
 Using CuPy on AMD GPU (experimental)


### PR DESCRIPTION
A quick fix on a typo in the nvcc compiler flag and the `gcc` executable, as there is no `gcc-7` or similar in CentOS, unlike Ubuntu which all get symlinked. After installing the `devtoolset-7-gcc-c++` and activating those binaries, calling `gcc` will use the `gcc` at version 7 for compilation.