### PR TITLE
Support comparison to `None` and `Ellipsis`

### DIFF
--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -1112,6 +1112,12 @@ cdef class ndarray:
                 return _logic._ndarray_greater(self, other)
             if op == 5:
                 return _logic._ndarray_greater_equal(self, other)
+        elif other is None or other is Ellipsis:
+            if op == 2:
+                return cupy.zeros(self._shape, dtype=cupy.bool_)
+            if op == 3:
+                return cupy.ones(self._shape, dtype=cupy.bool_)
+            return NotImplemented
         elif not _should_use_rop(self, other):
             if isinstance(other, numpy.ndarray) and other.ndim == 0:
                 other = other.item()  # Workaround for numpy<1.13

--- a/tests/cupy_tests/core_tests/test_ndarray_elementwise_op.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_elementwise_op.py
@@ -1,14 +1,13 @@
 import operator
-import unittest
 
 import numpy
+import pytest
 
 import cupy
 from cupy import testing
 
 
-@testing.gpu
-class TestArrayElementwiseOp(unittest.TestCase):
+class TestArrayElementwiseOp:
 
     @testing.for_all_dtypes_combination(names=['x_type', 'y_type'])
     @testing.numpy_cupy_allclose(rtol=1e-6, accept_error=TypeError)
@@ -128,8 +127,30 @@ class TestArrayElementwiseOp(unittest.TestCase):
     def test_eq_scalar(self):
         self.check_array_scalar_op(operator.eq)
 
+    @pytest.mark.parametrize('swap', [False, True])
+    @pytest.mark.parametrize('value', [None, Ellipsis])
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_eq_builtin_constant(self, xp, dtype, value, swap):
+        a = xp.array([[1, 2, 3], [4, 5, 6]], dtype=dtype)
+        if swap:
+            return value == a
+        else:
+            return a == value
+
     def test_ne_scalar(self):
         self.check_array_scalar_op(operator.ne)
+
+    @pytest.mark.parametrize('swap', [False, True])
+    @pytest.mark.parametrize('value', [None, Ellipsis])
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_ne_builtin_constant(self, xp, dtype, value, swap):
+        a = xp.array([[1, 2, 3], [4, 5, 6]], dtype=dtype)
+        if swap:
+            return value != a
+        else:
+            return a != value
 
     @testing.for_all_dtypes_combination(names=['x_type', 'y_type'])
     @testing.numpy_cupy_allclose(accept_error=TypeError)
@@ -481,8 +502,7 @@ class TestArrayElementwiseOp(unittest.TestCase):
         self.check_array_boolarray_op(operator.iadd)
 
 
-@testing.gpu
-class TestArrayIntElementwiseOp(unittest.TestCase):
+class TestArrayIntElementwiseOp:
 
     @testing.for_all_dtypes_combination(names=['x_type', 'y_type'])
     @testing.numpy_cupy_allclose(accept_error=TypeError)


### PR DESCRIPTION
Fix #5715.

This PR implements comparisons to Python's built-in constants, `None` and `Ellipsis`. It returns a ndarray filled with `True` or `False` with the same shape as the ndarray as if the operation is performed elementwise.
