### PR TITLE
Change a parameter name in `percentile` and `quantile` to support NumPy 1.22

### DIFF
--- a/cupy/_statistics/order.py
+++ b/cupy/_statistics/order.py
@@ -283,7 +283,7 @@ def _quantile_is_valid(q):
     return True
 
 
-def percentile(a, q, axis=None, out=None, method='linear', keepdims=False, *,
+def percentile(a, q, axis=None, out=None, *, method='linear', keepdims=False,
                interpolation=None):
     """Computes the q-th percentile of the data along the specified axis.
 
@@ -319,7 +319,7 @@ def percentile(a, q, axis=None, out=None, method='linear', keepdims=False, *,
         a, q, axis=axis, out=out, method=method, keepdims=keepdims)
 
 
-def quantile(a, q, axis=None, out=None, method='linear', keepdims=False, *,
+def quantile(a, q, axis=None, out=None, *, method='linear', keepdims=False,
              interpolation=None):
     """Computes the q-th quantile of the data along the specified axis.
 
@@ -363,7 +363,7 @@ def _check_interpolation_as_method(method, interpolation, fname):
         "Users of the modes 'nearest', 'lower', 'higher', or "
         "'midpoint' are encouraged to review the method they. "
         "(Deprecated NumPy 1.22)",
-        DeprecationWarning, stacklevel=4)
+        DeprecationWarning, stacklevel=3)
     if method != "linear":
         # sanity check, we assume this basically never happens
         raise TypeError(

--- a/cupy/_statistics/order.py
+++ b/cupy/_statistics/order.py
@@ -174,7 +174,7 @@ def ptp(a, axis=None, out=None, keepdims=False):
     return a.ptp(axis=axis, out=out, keepdims=keepdims)
 
 
-def _quantile_unchecked(a, q, axis=None, out=None, interpolation='linear',
+def _quantile_unchecked(a, q, axis=None, out=None, method='linear',
                         keepdims=False):
     if q.ndim == 0:
         q = q[None]
@@ -213,22 +213,28 @@ def _quantile_unchecked(a, q, axis=None, out=None, interpolation='linear',
     Nx = ap.shape[axis]
     indices = q * (Nx - 1.)
 
-    if interpolation == 'lower':
+    if method in ['inverted_cdf', 'averaged_inverted_cdf',
+                  'closest_observation', 'interpolated_inverted_cdf',
+                  'hazen', 'weibull', 'median_unbiased', 'normal_unbiased']:
+        # TODO(takagi) Implement new methods introduced in NumPy 1.22
+        raise ValueError(f'\'{method}\' method is not yet supported. '
+                         'Please use any other method.')
+    elif method == 'lower':
         indices = cupy.floor(indices).astype(cupy.int32)
-    elif interpolation == 'higher':
+    elif method == 'higher':
         indices = cupy.ceil(indices).astype(cupy.int32)
-    elif interpolation == 'midpoint':
+    elif method == 'midpoint':
         indices = 0.5 * (cupy.floor(indices) + cupy.ceil(indices))
-    elif interpolation == 'nearest':
+    elif method == 'nearest':
         # TODO(hvy): Implement nearest using around
-        raise ValueError('\'nearest\' interpolation is not yet supported. '
-                         'Please use any other interpolation method.')
-    elif interpolation == 'linear':
+        raise ValueError('\'nearest\' method is not yet supported. '
+                         'Please use any other method.')
+    elif method == 'linear':
         pass
     else:
         raise ValueError('Unexpected interpolation method.\n'
                          'Actual: \'{0}\' not in (\'linear\', \'lower\', '
-                         '\'higher\', \'midpoint\')'.format(interpolation))
+                         '\'higher\', \'midpoint\')'.format(method))
 
     if indices.dtype == cupy.int32:
         ret = cupy.rollaxis(ap, axis)
@@ -277,8 +283,8 @@ def _quantile_is_valid(q):
     return True
 
 
-def percentile(a, q, axis=None, out=None, interpolation='linear',
-               keepdims=False):
+def percentile(a, q, axis=None, out=None, method='linear', keepdims=False, *,
+               interpolation=None):
     """Computes the q-th percentile of the data along the specified axis.
 
     Args:
@@ -288,29 +294,33 @@ def percentile(a, q, axis=None, out=None, interpolation='linear',
         axis (int or tuple of ints): Along which axis or axes to compute the
             percentiles. The flattened array is used by default.
         out (cupy.ndarray): Output array.
-        interpolation (str): Interpolation method when a quantile lies between
+        method (str): Interpolation method when a quantile lies between
             two data points. ``linear`` interpolation is used by default.
             Supported interpolations are``lower``, ``higher``, ``midpoint``,
             ``nearest`` and ``linear``.
         keepdims (bool): If ``True``, the axis is remained as an axis of
             size one.
+        interpolation (str): Deprecated name for the method keyword argument.
 
     Returns:
         cupy.ndarray: The percentiles of ``a``, along the axis if specified.
 
     .. seealso:: :func:`numpy.percentile`
     """
+    if interpolation is not None:
+        method = _check_interpolation_as_method(
+            method, interpolation, 'percentile')
     if not isinstance(q, cupy.ndarray):
         q = cupy.asarray(q, dtype='d')
     q = cupy.true_divide(q, 100)
     if not _quantile_is_valid(q):  # synchronize
         raise ValueError('Percentiles must be in the range [0, 100]')
-    return _quantile_unchecked(a, q, axis=axis, out=out,
-                               interpolation=interpolation, keepdims=keepdims)
+    return _quantile_unchecked(
+        a, q, axis=axis, out=out, method=method, keepdims=keepdims)
 
 
-def quantile(a, q, axis=None, out=None, interpolation='linear',
-             keepdims=False):
+def quantile(a, q, axis=None, out=None, method='linear', keepdims=False, *,
+             interpolation=None):
     """Computes the q-th quantile of the data along the specified axis.
 
     Args:
@@ -320,21 +330,43 @@ def quantile(a, q, axis=None, out=None, interpolation='linear',
         axis (int or tuple of ints): Along which axis or axes to compute the
             quantiles. The flattened array is used by default.
         out (cupy.ndarray): Output array.
-        interpolation (str): Interpolation method when a quantile lies between
+        method (str): Interpolation method when a quantile lies between
             two data points. ``linear`` interpolation is used by default.
             Supported interpolations are``lower``, ``higher``, ``midpoint``,
             ``nearest`` and ``linear``.
         keepdims (bool): If ``True``, the axis is remained as an axis of
             size one.
+        interpolation (str): Deprecated name for the method keyword argument.
 
     Returns:
         cupy.ndarray: The quantiles of ``a``, along the axis if specified.
 
     .. seealso:: :func:`numpy.quantile`
     """
+    if interpolation is not None:
+        method = _check_interpolation_as_method(
+            method, interpolation, 'quantile')
     if not isinstance(q, cupy.ndarray):
         q = cupy.asarray(q, dtype='d')
     if not _quantile_is_valid(q):  # synchronize
         raise ValueError('Quantiles must be in the range [0, 1]')
-    return _quantile_unchecked(a, q, axis=axis, out=out,
-                               interpolation=interpolation, keepdims=keepdims)
+    return _quantile_unchecked(
+        a, q, axis=axis, out=out, method=method, keepdims=keepdims)
+
+
+# Borrowd from NumPy
+def _check_interpolation_as_method(method, interpolation, fname):
+    # Deprecated NumPy 1.22, 2021-11-08
+    warnings.warn(
+        f"the `interpolation=` argument to {fname} was renamed to "
+        "`method=`, which has additional options.\n"
+        "Users of the modes 'nearest', 'lower', 'higher', or "
+        "'midpoint' are encouraged to review the method they. "
+        "(Deprecated NumPy 1.22)",
+        DeprecationWarning, stacklevel=4)
+    if method != "linear":
+        # sanity check, we assume this basically never happens
+        raise TypeError(
+            "You shall not pass both `method` and `interpolation`!\n"
+            "(`interpolation` is Deprecated in favor of `method`)")
+    return interpolation

--- a/tests/cupy_tests/statistics_tests/test_order.py
+++ b/tests/cupy_tests/statistics_tests/test_order.py
@@ -23,7 +23,7 @@ _all_methods = (
     'higher',
     'midpoint',
     # 'nearest',                    # TODO(hvy): Not implemented
-    )
+)
 
 
 def for_all_methods(name='method'):

--- a/tests/cupy_tests/statistics_tests/test_order.py
+++ b/tests/cupy_tests/statistics_tests/test_order.py
@@ -80,6 +80,7 @@ class TestQuantile:
                 xp.quantile(a, q, axis=-1, method='deadbeef')
 
 
+@testing.with_requires('numpy>=1.22.0rc1')
 @for_all_methods()
 class TestQuantileMethods:
 

--- a/tests/cupy_tests/statistics_tests/test_order.py
+++ b/tests/cupy_tests/statistics_tests/test_order.py
@@ -1,4 +1,3 @@
-import unittest
 import warnings
 
 import numpy
@@ -10,113 +9,122 @@ from cupy import cuda
 from cupy import testing
 
 
-_all_interpolations = (
+_all_methods = (
+    # 'inverted_cdf',               # TODO(takagi) Not implemented
+    # 'averaged_inverted_cdf',      # TODO(takagi) Not implemented
+    # 'closest_observation',        # TODO(takagi) Not implemented
+    # 'interpolated_inverted_cdf',  # TODO(takagi) Not implemented
+    # 'hazen',                      # TODO(takagi) Not implemented
+    # 'weibull',                    # TODO(takagi) Not implemented
+    'linear',
+    # 'median_unbiased',            # TODO(takagi) Not implemented
+    # 'normal_unbiased',            # TODO(takagi) Not implemented
     'lower',
     'higher',
     'midpoint',
-    # 'nearest', # TODO(hvy): Not implemented
-    'linear')
+    # 'nearest',                    # TODO(hvy): Not implemented
+    )
 
 
-def for_all_interpolations(name='interpolation'):
-    return testing.for_orders(_all_interpolations, name=name)
+def for_all_methods(name='method'):
+    return pytest.mark.parametrize(name, _all_methods)
 
 
-@testing.gpu
-class TestOrder(unittest.TestCase):
+@testing.with_requires('numpy>=1.22.0rc1')
+class TestOrder:
 
-    @for_all_interpolations()
+    @for_all_methods()
     @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
     @testing.numpy_cupy_allclose()
-    def test_percentile_defaults(self, xp, dtype, interpolation):
+    def test_percentile_defaults(self, xp, dtype, method):
         a = testing.shaped_random((2, 3, 8), xp, dtype)
         q = testing.shaped_random((3,), xp, dtype=dtype, scale=100)
-        return xp.percentile(a, q, interpolation=interpolation)
+        return xp.percentile(a, q, method=method)
 
-    @for_all_interpolations()
+    @for_all_methods()
     @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
     @testing.numpy_cupy_allclose()
-    def test_percentile_q_list(self, xp, dtype, interpolation):
+    def test_percentile_q_list(self, xp, dtype, method):
         a = testing.shaped_arange((1001,), xp, dtype)
         q = [99, 99.9]
-        return xp.percentile(a, q, interpolation=interpolation)
+        return xp.percentile(a, q, method=method)
 
-    @for_all_interpolations()
+    @for_all_methods()
     @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
     @testing.numpy_cupy_allclose(rtol=1e-6)
-    def test_percentile_no_axis(self, xp, dtype, interpolation):
+    def test_percentile_no_axis(self, xp, dtype, method):
         a = testing.shaped_random((10, 2, 4, 8), xp, dtype)
         q = testing.shaped_random((5,), xp, dtype=dtype, scale=100)
-        return xp.percentile(a, q, axis=None, interpolation=interpolation)
+        return xp.percentile(a, q, axis=None, method=method)
 
-    @for_all_interpolations()
+    @for_all_methods()
     @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
     @testing.numpy_cupy_allclose(rtol=1e-6)
-    def test_percentile_neg_axis(self, xp, dtype, interpolation):
+    def test_percentile_neg_axis(self, xp, dtype, method):
         a = testing.shaped_random((4, 3, 10, 2, 8), xp, dtype)
         q = testing.shaped_random((5,), xp, dtype=dtype, scale=100)
-        return xp.percentile(a, q, axis=-1, interpolation=interpolation)
+        return xp.percentile(a, q, axis=-1, method=method)
 
-    @for_all_interpolations()
+    @for_all_methods()
     @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
     @testing.numpy_cupy_allclose(rtol=1e-6)
-    def test_percentile_tuple_axis(self, xp, dtype, interpolation):
+    def test_percentile_tuple_axis(self, xp, dtype, method):
         a = testing.shaped_random((1, 6, 3, 2), xp, dtype)
         q = testing.shaped_random((5,), xp, dtype=dtype, scale=100)
-        return xp.percentile(a, q, axis=(0, 1, 2), interpolation=interpolation)
+        return xp.percentile(a, q, axis=(0, 1, 2), method=method)
 
-    @for_all_interpolations()
+    @for_all_methods()
     @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
     @testing.numpy_cupy_allclose()
-    def test_percentile_scalar_q(self, xp, dtype, interpolation):
+    def test_percentile_scalar_q(self, xp, dtype, method):
         a = testing.shaped_random((2, 3, 8), xp, dtype)
         q = 13.37
-        return xp.percentile(a, q, interpolation=interpolation)
+        return xp.percentile(a, q, method=method)
 
-    @for_all_interpolations()
+    @for_all_methods()
     @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
     @testing.numpy_cupy_allclose(rtol=1e-5)
-    def test_percentile_keepdims(self, xp, dtype, interpolation):
+    def test_percentile_keepdims(self, xp, dtype, method):
         a = testing.shaped_random((7, 2, 9, 2), xp, dtype)
         q = testing.shaped_random((5,), xp, dtype=dtype, scale=100)
         return xp.percentile(
-            a, q, axis=None, keepdims=True, interpolation=interpolation)
+            a, q, axis=None, keepdims=True, method=method)
 
-    @for_all_interpolations()
+    @for_all_methods()
     @testing.for_float_dtypes(no_float16=True)  # NumPy raises error on int8
     @testing.numpy_cupy_allclose(rtol=1e-6)
-    def test_percentile_out(self, xp, dtype, interpolation):
+    def test_percentile_out(self, xp, dtype, method):
         a = testing.shaped_random((10, 2, 3, 2), xp, dtype)
         q = testing.shaped_random((5,), xp, dtype=dtype, scale=100)
         out = testing.shaped_random((5, 10, 2, 3), xp, dtype)
         return xp.percentile(
-            a, q, axis=-1, interpolation=interpolation, out=out)
+            a, q, axis=-1, method=method, out=out)
 
-    @for_all_interpolations()
+    @for_all_methods()
     @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
-    def test_percentile_bad_q(self, dtype, interpolation):
+    def test_percentile_bad_q(self, dtype, method):
         for xp in (numpy, cupy):
             a = testing.shaped_random((4, 2, 3, 2), xp, dtype)
             q = testing.shaped_random((1, 2, 3), xp, dtype=dtype, scale=100)
             with pytest.raises(ValueError):
-                xp.percentile(a, q, axis=-1, interpolation=interpolation)
+                xp.percentile(a, q, axis=-1, method=method)
 
-    @for_all_interpolations()
+    @for_all_methods()
     @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
-    def test_percentile_out_of_range_q(self, dtype, interpolation):
+    def test_percentile_out_of_range_q(self, dtype, method):
         for xp in (numpy, cupy):
             a = testing.shaped_random((4, 2, 3, 2), xp, dtype)
             for q in [[-0.1], [100.1]]:
                 with pytest.raises(ValueError):
-                    xp.percentile(a, q, axis=-1, interpolation=interpolation)
+                    xp.percentile(a, q, axis=-1, method=method)
 
     @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
-    def test_percentile_unexpected_interpolation(self, dtype):
+    def test_percentile_unexpected_method(self, dtype):
         for xp in (numpy, cupy):
             a = testing.shaped_random((4, 2, 3, 2), xp, dtype)
             q = testing.shaped_random((5,), xp, dtype=dtype, scale=100)
             with pytest.raises(ValueError):
-                xp.percentile(a, q, axis=-1, interpolation='deadbeef')
+                xp.percentile(a, q, axis=-1, method='deadbeef')
 
     # See gh-4453
     @testing.for_float_dtypes()
@@ -142,105 +150,105 @@ class TestOrder(unittest.TestCase):
         cuda.set_allocator(controlled_allocator)
         try:
             percentiles = cupy.percentile(a, q, axis=None,
-                                          interpolation='linear')
+                                          method='linear')
         finally:
             cuda.set_allocator(original_allocator)
 
         assert not cupy.any(cupy.isnan(percentiles))
 
     @testing.for_all_dtypes()
-    @for_all_interpolations()
+    @for_all_methods()
     @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
     @testing.numpy_cupy_allclose()
-    def test_quantile_defaults(self, xp, dtype, interpolation):
+    def test_quantile_defaults(self, xp, dtype, method):
         a = testing.shaped_random((2, 3, 8), xp, dtype)
         q = testing.shaped_random((3,), xp, scale=1)
-        return xp.quantile(a, q, interpolation=interpolation)
+        return xp.quantile(a, q, method=method)
 
-    @for_all_interpolations()
+    @for_all_methods()
     @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
     @testing.numpy_cupy_allclose()
-    def test_quantile_q_list(self, xp, dtype, interpolation):
+    def test_quantile_q_list(self, xp, dtype, method):
         a = testing.shaped_arange((1001,), xp, dtype)
         q = [.99, .999]
-        return xp.quantile(a, q, interpolation=interpolation)
+        return xp.quantile(a, q, method=method)
 
-    @for_all_interpolations()
+    @for_all_methods()
     @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
     @testing.numpy_cupy_allclose(rtol=1e-5)
-    def test_quantile_no_axis(self, xp, dtype, interpolation):
+    def test_quantile_no_axis(self, xp, dtype, method):
         a = testing.shaped_random((10, 2, 4, 8), xp, dtype)
         q = testing.shaped_random((5,), xp, scale=1)
-        return xp.quantile(a, q, axis=None, interpolation=interpolation)
+        return xp.quantile(a, q, axis=None, method=method)
 
-    @for_all_interpolations()
+    @for_all_methods()
     @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
     @testing.numpy_cupy_allclose(rtol=1e-6)
-    def test_quantile_neg_axis(self, xp, dtype, interpolation):
+    def test_quantile_neg_axis(self, xp, dtype, method):
         a = testing.shaped_random((4, 3, 10, 2, 8), xp, dtype)
         q = testing.shaped_random((5,), xp, scale=1)
-        return xp.quantile(a, q, axis=-1, interpolation=interpolation)
+        return xp.quantile(a, q, axis=-1, method=method)
 
-    @for_all_interpolations()
+    @for_all_methods()
     @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
     @testing.numpy_cupy_allclose(rtol=1e-6)
-    def test_quantile_tuple_axis(self, xp, dtype, interpolation):
+    def test_quantile_tuple_axis(self, xp, dtype, method):
         a = testing.shaped_random((1, 6, 3, 2), xp, dtype)
         q = testing.shaped_random((5,), xp, scale=1)
-        return xp.quantile(a, q, axis=(0, 1, 2), interpolation=interpolation)
+        return xp.quantile(a, q, axis=(0, 1, 2), method=method)
 
-    @for_all_interpolations()
+    @for_all_methods()
     @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
     @testing.numpy_cupy_allclose()
-    def test_quantile_scalar_q(self, xp, dtype, interpolation):
+    def test_quantile_scalar_q(self, xp, dtype, method):
         a = testing.shaped_random((2, 3, 8), xp, dtype)
         q = .1337
-        return xp.quantile(a, q, interpolation=interpolation)
+        return xp.quantile(a, q, method=method)
 
-    @for_all_interpolations()
+    @for_all_methods()
     @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
     @testing.numpy_cupy_allclose(rtol=1e-5)
-    def test_quantile_keepdims(self, xp, dtype, interpolation):
+    def test_quantile_keepdims(self, xp, dtype, method):
         a = testing.shaped_random((7, 2, 9, 2), xp, dtype)
         q = testing.shaped_random((5,), xp, scale=1)
         return xp.quantile(
-            a, q, axis=None, keepdims=True, interpolation=interpolation)
+            a, q, axis=None, keepdims=True, method=method)
 
-    @for_all_interpolations()
+    @for_all_methods()
     @testing.for_float_dtypes(no_float16=True)  # NumPy raises error on int8
     @testing.numpy_cupy_allclose(rtol=1e-6)
-    def test_quantile_out(self, xp, dtype, interpolation):
+    def test_quantile_out(self, xp, dtype, method):
         a = testing.shaped_random((10, 2, 3, 2), xp, dtype)
         q = testing.shaped_random((5,), xp, dtype=dtype, scale=1)
         out = testing.shaped_random((5, 10, 2, 3), xp, dtype)
         return xp.quantile(
-            a, q, axis=-1, interpolation=interpolation, out=out)
+            a, q, axis=-1, method=method, out=out)
 
-    @for_all_interpolations()
+    @for_all_methods()
     @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
-    def test_quantile_bad_q(self, dtype, interpolation):
+    def test_quantile_bad_q(self, dtype, method):
         for xp in (numpy, cupy):
             a = testing.shaped_random((4, 2, 3, 2), xp, dtype)
             q = testing.shaped_random((1, 2, 3), xp, dtype=dtype, scale=1)
             with pytest.raises(ValueError):
-                xp.quantile(a, q, axis=-1, interpolation=interpolation)
+                xp.quantile(a, q, axis=-1, method=method)
 
-    @for_all_interpolations()
+    @for_all_methods()
     @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
-    def test_quantile_out_of_range_q(self, dtype, interpolation):
+    def test_quantile_out_of_range_q(self, dtype, method):
         for xp in (numpy, cupy):
             a = testing.shaped_random((4, 2, 3, 2), xp, dtype)
             for q in [[-0.1], [1.1]]:
                 with pytest.raises(ValueError):
-                    xp.quantile(a, q, axis=-1, interpolation=interpolation)
+                    xp.quantile(a, q, axis=-1, method=method)
 
     @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
-    def test_quantile_unexpected_interpolation(self, dtype):
+    def test_quantile_unexpected_method(self, dtype):
         for xp in (numpy, cupy):
             a = testing.shaped_random((4, 2, 3, 2), xp, dtype)
             q = testing.shaped_random((5,), xp, dtype=dtype, scale=1)
             with pytest.raises(ValueError):
-                xp.quantile(a, q, axis=-1, interpolation='deadbeef')
+                xp.quantile(a, q, axis=-1, method='deadbeef')
 
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose()
@@ -391,10 +399,9 @@ class TestOrder(unittest.TestCase):
 @testing.parameterize(*testing.product({
     'magic_value': (-29, -53, -207, -16373, -99999,)
 }))
-@testing.gpu
-class TestPercentileMonotonic(unittest.TestCase):
+class TestPercentileMonotonic:
 
-    @testing.with_requires('numpy>=1.20')
+    @testing.with_requires('numpy>=1.22.0rc1')
     @testing.for_float_dtypes(no_float16=True)
     @testing.numpy_cupy_allclose()
     def test_percentile_monotonic(self, dtype, xp):
@@ -403,7 +410,7 @@ class TestPercentileMonotonic(unittest.TestCase):
         a[0] = self.magic_value
         a[1] = self.magic_value
         q = xp.linspace(0, 100, 21)
-        percentiles = xp.percentile(a, q, interpolation='linear')
+        percentiles = xp.percentile(a, q, method='linear')
 
         # Assert that percentile output increases monotonically
         assert xp.all(xp.diff(percentiles) >= 0)


### PR DESCRIPTION
Partially fix #6198.

`percentile` and `quantile`'s `interpolation` parameter is renamed to `method` in NumPy 1.22, and some new interpolation methods are introduced as well. In this PR, I cover the change in the parameter name only to support NumPy 1.22, and will open another issue to implement the newly introduced methods.