### PR TITLE
[backport] Fix overlapping `out` in `matmul` and `(tensor)dot`

### DIFF
--- a/cupy/_core/_routines_linalg.pyx
+++ b/cupy/_core/_routines_linalg.pyx
@@ -21,6 +21,7 @@ from cupy._core.core cimport _internal_ascontiguousarray
 from cupy._core.core cimport _ndarray_init
 from cupy._core.core cimport ascontiguousarray
 from cupy._core.core cimport ndarray
+from cupy._core cimport _memory_range
 from cupy._core cimport _routines_manipulation as _manipulation
 from cupy._core cimport _routines_math as _math
 from cupy.cuda cimport device
@@ -434,7 +435,7 @@ cpdef ndarray tensordot_core(
     cdef Py_ssize_t inca, incb, transa, transb, lda, ldb
     cdef Py_ssize_t mode
     cdef intptr_t handle
-    cdef bint use_sgemmEx = True
+    cdef ndarray copy_to_out = None
     cdef str dtype = a.dtype.char
     cdef int compute_capability = int(device.get_compute_capability())
     if dtype != b.dtype.char:
@@ -445,26 +446,21 @@ cpdef ndarray tensordot_core(
         out.fill(0)
         return out
 
-    if out is None:
-        out = _ndarray_init(ret_shape, dtype)
-    else:
-        if out.dtype != dtype:
-            out = _ndarray_init(ret_shape, dtype)
+    if out is not None:
+        assert out.flags.c_contiguous and out.dtype == dtype
     cdef int ace
     if m == 1 and n == 1:
+        if out is None:
+            out = _ndarray_init(ret_shape, dtype)
+        c = _manipulation._reshape(out, ())
         for ace in _accelerator._routine_accelerators:
-            ret = _ndarray_init(ret_shape, dtype)
             # fast path using CUB or cuTENSOR
             if ace in (_accelerator.ACCELERATOR_CUB,
                        _accelerator.ACCELERATOR_CUTENSOR):
-                ret = (a.ravel() * b.ravel()).sum(
-                    out=_manipulation._reshape(ret, ()))
-                elementwise_copy(ret, out)
+                (a.ravel() * b.ravel()).sum(out=c)
                 break
         else:
-            _tensordot_core_mul_sum(
-                a.ravel(), b.ravel(),
-                out=_manipulation._reshape(out, ()))
+            _tensordot_core_mul_sum(a.ravel(), b.ravel(), out=c)
         return out
 
     a = a.astype(dtype, order='K', casting=None, subok=None, copy=False)
@@ -480,10 +476,6 @@ cpdef ndarray tensordot_core(
         shape.push_back(k)
         shape.push_back(m)
         b = _manipulation._reshape(b, shape)
-    c = out
-    if c._shape.size() != 2 or c._shape[0] != n or c._shape[1] != m:
-        c = c.view()
-        c.shape = (n, m)
 
     # Be careful that cuBLAS uses the FORTRAN-order matrix representation.
     # Matrix-Matrix product A^T * B
@@ -492,13 +484,30 @@ cpdef ndarray tensordot_core(
     a, transa, lda = _mat_to_cublas_contiguous(a, 0)
     b, transb, ldb = _mat_to_cublas_contiguous(b, 1)
 
+    if out is None:
+        out = c = _ndarray_init(ret_shape, dtype)
+    elif (
+        _memory_range.may_share_bounds(out, a)
+        or _memory_range.may_share_bounds(out, b)
+    ):
+        copy_to_out = c = _ndarray_init(ret_shape, dtype)
+    else:
+        c = out
+
+    if c._shape.size() != 2 or c._shape[0] != n or c._shape[1] != m:
+        c = c.view()
+        c.shape = (n, m)
+
     if dtype not in 'efdFD':
         if transa:
             a = a.T
             a = _internal_ascontiguousarray(a)
         if transb:
             b = _internal_ascontiguousarray(b)
-        return _integral_tensordot_core(b, a, out, m, n, k, dtype, ret_shape)
+        _integral_tensordot_core(b, a, c, m, n, k, dtype, ret_shape)
+        if copy_to_out is not None:
+            out[...] = copy_to_out
+        return out
 
     global _cuda_runtime_version
     if _cuda_runtime_version < 0:
@@ -510,6 +519,8 @@ cpdef ndarray tensordot_core(
         compute_capability >= 50
     ):
         tensordot_core_v11(transb, transa, m, n, k, b, ldb, a, lda, c, m)
+        if copy_to_out is not None:
+            out[...] = copy_to_out
         return out
 
     handle = device.get_cublas_handle()
@@ -525,7 +536,7 @@ cpdef ndarray tensordot_core(
         a = a.astype(dtype, order='K', casting=None, subok=None, copy=True)
         b = b.astype(dtype, order='K', casting=None, subok=None, copy=True)
         c = _ndarray_init(ret_shape, dtype)
-        use_sgemmEx = False
+        copy_to_out = c
         warnings.warn('On ROCm/HIP, there is no specialized API to handle '
                       'half precision floating numbers, so the computation '
                       'will be done by casting to single precision')
@@ -571,8 +582,8 @@ cpdef ndarray tensordot_core(
             zero.ctypes.data, c.data.ptr, <int>m)
     else:
         raise ValueError('Invalid dtype: %s' % str(dtype))
-    if not use_sgemmEx:
-        out[...] = c
+    if copy_to_out is not None:
+        out[...] = copy_to_out
     return out
 
 
@@ -820,7 +831,19 @@ cpdef ndarray matmul(ndarray a, ndarray b, ndarray out=None):
     if a.size == 0 or b.size == 0:
         return cupy.zeros(out_shape, ret_dtype)
 
-    out = ndarray(out_shape, dtype=dtype)
+    if (
+        out is not None and out.dtype == dtype and out.flags.c_contiguous
+        and not _memory_range.may_share_bounds(out, a)
+        and not _memory_range.may_share_bounds(out, b)
+    ):
+        c = out
+    else:
+        c = ndarray(out_shape, dtype=dtype)
+        if out is None:
+            if dtype == ret_dtype:
+                out = c
+            else:
+                out = ndarray(out_shape, dtype=ret_dtype)
 
     if orig_a_ndim == 1 or orig_b_ndim == 1:
         out_view = out.view()

--- a/tests/cupy_tests/math_tests/test_matmul.py
+++ b/tests/cupy_tests/math_tests/test_matmul.py
@@ -75,6 +75,62 @@ class TestMatmul(unittest.TestCase):
         return xp.matmul(x1, x2)
 
 
+@testing.parameterize(
+    *testing.product({
+        'shape_pair': [
+            # dot test
+            ((2, 3), (3, 4), (2, 4)),
+            # ((0,), (0,), (0,)),  # TODO: fix GUFunc bug?
+            # matmul test
+            ((5, 3, 2), (5, 2, 4), (5, 3, 4)),
+            ((0, 3, 2), (0, 2, 4), (0, 3, 4)),
+        ],
+    }))
+@testing.gpu
+class TestMatmulOut(unittest.TestCase):
+
+    @testing.for_all_dtypes(name='dtype1')
+    @testing.for_all_dtypes(name='dtype2')
+    @testing.numpy_cupy_allclose(
+        rtol=1e-3, atol=1e-3,  # required for uint8
+        accept_error=TypeError)
+    def test_cupy_matmul_noncontiguous(self, xp, dtype1, dtype2):
+        x1 = testing.shaped_arange(self.shape_pair[0], xp, dtype1)
+        x2 = testing.shaped_arange(self.shape_pair[1], xp, dtype2)
+        out = xp.zeros(self.shape_pair[2], dtype1)[::-1]
+        ret = xp.matmul(x1, x2, out=out)
+        # TODO: Fix GUFunc bug
+        # assert ret is out
+        assert xp.allclose(ret, out)
+        return ret
+
+    @testing.for_all_dtypes(name='dtype1')
+    @testing.for_all_dtypes(name='dtype2')
+    @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-3)  # required for uint8
+    def test_cupy_matmul_out_cast(self, xp, dtype1, dtype2):
+        x1 = testing.shaped_arange(self.shape_pair[0], xp, dtype1)
+        x2 = testing.shaped_arange(self.shape_pair[1], xp, dtype2)
+        out = xp.zeros(self.shape_pair[2], bool)
+        ret = xp.matmul(x1, x2, out=out, casting='unsafe')
+        # TODO: Fix GUFunc bug
+        # assert ret is out
+        assert xp.allclose(ret, out)
+        return ret
+
+
+class TestMatmulOutOverlap:
+
+    @pytest.mark.parametrize('shape', [
+        (900, 900),
+        (2, 600, 600),
+    ])
+    @testing.for_dtypes([numpy.int32, numpy.float64])
+    @testing.numpy_cupy_allclose(rtol=1e-5, atol=1e-5)
+    def test_overlap_both(self, xp, dtype, shape):
+        a = xp.ones(shape, dtype)
+        return xp.matmul(a, a, out=a)
+
+
 class TestMatmulStrides:
 
     @testing.for_all_dtypes()


### PR DESCRIPTION
Backport of #6216 by @toslunar