### PR TITLE
[backport] Change a parameter name in `percentile` and `quantile` to support NumPy 1.22

### DIFF
--- a/tests/cupy_tests/statistics_tests/test_order.py
+++ b/tests/cupy_tests/statistics_tests/test_order.py
@@ -381,7 +381,7 @@ class TestOrder:
 @testing.gpu
 class TestPercentileMonotonic:
 
-    @testing.with_requires('numpy>=1.20', 'numpy<1.22')
+    @testing.with_requires('numpy>=1.20,<1.22')
     @testing.for_float_dtypes(no_float16=True)
     @testing.numpy_cupy_allclose()
     def test_percentile_monotonic(self, dtype, xp):

--- a/tests/cupy_tests/statistics_tests/test_order.py
+++ b/tests/cupy_tests/statistics_tests/test_order.py
@@ -1,4 +1,3 @@
-import unittest
 import warnings
 
 import numpy
@@ -19,7 +18,7 @@ _all_interpolations = (
 
 
 def for_all_interpolations(name='interpolation'):
-    return testing.for_orders(_all_interpolations, name=name)
+    return pytest.mark.parametrize(name, _all_interpolations)
 
 
 @testing.with_requires('numpy<1.22')
@@ -380,9 +379,9 @@ class TestOrder:
     'magic_value': (-29, -53, -207, -16373, -99999,)
 }))
 @testing.gpu
-class TestPercentileMonotonic(unittest.TestCase):
+class TestPercentileMonotonic:
 
-    @testing.with_requires('numpy>=1.20')
+    @testing.with_requires('numpy>=1.20', 'numpy<1.22')
     @testing.for_float_dtypes(no_float16=True)
     @testing.numpy_cupy_allclose()
     def test_percentile_monotonic(self, dtype, xp):

--- a/tests/cupy_tests/statistics_tests/test_order.py
+++ b/tests/cupy_tests/statistics_tests/test_order.py
@@ -72,6 +72,7 @@ class TestQuantile:
                 xp.quantile(a, q, axis=-1, interpolation='deadbeef')
 
 
+@testing.with_requires('numpy<1.22')
 @for_all_interpolations()
 class TestQuantileInterpolations:
 


### PR DESCRIPTION
Partial backport of #6228, containing test refactoring and DeprecationWarning skip only.