### PR TITLE
Fixing index calculation for random constructor

### DIFF
--- a/cupyx/scipy/sparse/construct.py
+++ b/cupyx/scipy/sparse/construct.py
@@ -365,7 +365,7 @@ def random(m, n, density=0.01, format='coo', dtype=None,
         data_rvs = random_state.rand
 
     ind = random_state.choice(mn, size=k, replace=False)
-    j = cupy.floor(ind * (1. / m)).astype('i')
+    j = ind//m
     i = ind - j * m
     vals = data_rvs(k).astype(dtype)
     return coo.coo_matrix(


### PR DESCRIPTION
The previous algorithm had numerical issues with certain values, like m = 3150
Now it uses directly the integer division, without doing magic tricks 