### PR TITLE
Tentatively pin to `setuptools<60` in Windows CI

### DIFF
--- a/.pfnci/windows/test.ps1
+++ b/.pfnci/windows/test.ps1
@@ -67,7 +67,7 @@ function Main {
     # Build
     echo "Setting up test environment"
     RunOrDie python -V
-    RunOrDie python -m pip install -U pip setuptools
+    RunOrDie python -m pip install -U pip 'setuptools<60'
     RunOrDie python -m pip install Cython 'scipy<1.7' optuna
     RunOrDie python -m pip freeze
 


### PR DESCRIPTION
`setuptools==60.*` and `numpy.distutils` from `numpy==1.21.*` conflicts on Windows, as setuptools now uses vendored distutils by default.

https://setuptools.pypa.io/en/latest/history.html#v60-0-0