### PR TITLE
JIT: Support `__device__` function

### DIFF
--- a/cupyx/jit/__init__.py
+++ b/cupyx/jit/__init__.py
@@ -29,3 +29,4 @@ from cupyx.jit._builtin_funcs import shfl_down_sync  # NOQA
 from cupyx.jit._builtin_funcs import shfl_xor_sync  # NOQA
 
 _getsource_func = None  # NOQA
+_n_functions_upperlimit = 100

--- a/cupyx/jit/_builtin_funcs.py
+++ b/cupyx/jit/_builtin_funcs.py
@@ -390,7 +390,7 @@ class LaneID(BuiltinFunc):
         return preamble
 
     def call_const(self, env):
-        env.preambles.add(self._get_preamble())
+        env.generated.add_code(self._get_preamble())
         return Data('LaneId()', _cuda_types.uint32)
 
 

--- a/cupyx/jit/_compile.py
+++ b/cupyx/jit/_compile.py
@@ -116,9 +116,11 @@ class Generated:
         # (function, in_types) => Optional(function_name, return_type)
         self.device_function = {}
 
-    def add_code(self, code):
+    def add_code(self, code: str) -> None:
         if code not in self.codes:
-            return self.codes.append(code)
+            self.codes.append(code)
+            if len(self.codes) > jit._n_functions_upperlimit:
+                raise ValueError("Number of functions exceeds upper limit.")
 
 
 def transpile(func, attributes, mode, in_types, ret_type):

--- a/cupyx/jit/_interface.py
+++ b/cupyx/jit/_interface.py
@@ -157,7 +157,8 @@ def rawkernel(*, mode='cuda', device=False):
     cupy._util.experimental('cupyx.jit.rawkernel')
 
     def wrapper(func):
-        return functools.update_wrapper(_JitRawKernel(func, mode, device), func)
+        return functools.update_wrapper(
+            _JitRawKernel(func, mode, device), func)
     return wrapper
 
 

--- a/cupyx/jit/_interface.py
+++ b/cupyx/jit/_interface.py
@@ -47,9 +47,10 @@ class _JitRawKernel:
     by users.
     """
 
-    def __init__(self, func, mode):
+    def __init__(self, func, mode, device):
         self._func = func
         self._mode = mode
+        self._device = device
         self._cache = {}
         self._cached_codes = {}
 
@@ -150,13 +151,13 @@ class _JitRawKernel:
         return next(iter(codes.values()))
 
 
-def rawkernel(mode='cuda'):
+def rawkernel(*, mode='cuda', device=False):
     """A decorator compiles a Python function into CUDA kernel.
     """
     cupy._util.experimental('cupyx.jit.rawkernel')
 
     def wrapper(func):
-        return functools.update_wrapper(_JitRawKernel(func, mode), func)
+        return functools.update_wrapper(_JitRawKernel(func, mode, device), func)
     return wrapper
 
 

--- a/tests/cupyx_tests/jit_tests/test_device_function.py
+++ b/tests/cupyx_tests/jit_tests/test_device_function.py
@@ -25,3 +25,60 @@ class TestDeviceFunction(unittest.TestCase):
         z = testing.shaped_random((30,), dtype=numpy.int32, seed=2)
         f((1,), (30,), (x, y, z))
         assert (z == (x + y + 1) * 2).all()
+
+    def test_device_function_duplicated_names(self):
+        @jit.rawkernel()
+        def f(x, y, z):
+            tid = jit.threadIdx.x
+            z[tid] = g(10)(x[tid], y[tid])
+            z[tid] += g(20)(x[tid], y[tid])
+            z[tid] += g(30)(x[tid], y[tid])
+
+        def g(const):
+            def f(x, y):
+                return x + y + const
+            return f
+
+        x = testing.shaped_random((30,), dtype=numpy.int32, seed=0)
+        y = testing.shaped_random((30,), dtype=numpy.int32, seed=1)
+        z = testing.shaped_random((30,), dtype=numpy.int32, seed=2)
+        f((1,), (30,), (x, y, z))
+        assert (z == (x + y) * 3 + 60).all()
+
+    def test_device_function_recursive(self):
+        @jit.rawkernel()
+        def f(x, y, z):
+            tid = jit.threadIdx.x
+            z[tid] = g(x[tid], y[tid])
+
+        def g(x, y):
+            return x + y + g(x, y)
+
+        x = testing.shaped_random((30,), dtype=numpy.int32, seed=0)
+        y = testing.shaped_random((30,), dtype=numpy.int32, seed=1)
+        z = testing.shaped_random((30,), dtype=numpy.int32, seed=2)
+        with pytest.raises(ValueError):
+            f((1,), (30,), (x, y, z))
+
+    def test_device_function_template_recursion(self):
+        @jit.rawkernel()
+        def f(x, y):
+            tid = jit.threadIdx.x
+            y[tid] = x[tid]
+            jit.syncthreads()
+            g(1)(y)
+
+        def g(step):
+            def f(x):
+                if step < 256:
+                    tid = jit.threadIdx.x
+                    if tid % (step * 2) == 0:
+                        x[tid] += x[tid + step]
+                        jit.syncthreads()
+                        g(step * 2)(x)
+            return f
+
+        x = testing.shaped_random((256,), dtype=numpy.int32, seed=0)
+        y = testing.shaped_random((256,), dtype=numpy.int32, seed=1)
+        f((1,), (256,), (x, y))
+        assert y[0] == x.sum()

--- a/tests/cupyx_tests/jit_tests/test_device_function.py
+++ b/tests/cupyx_tests/jit_tests/test_device_function.py
@@ -1,0 +1,27 @@
+import unittest
+import numpy
+
+import pytest
+
+from cupyx import jit
+from cupy import testing
+
+
+class TestDeviceFunction(unittest.TestCase):
+
+    def test_device_function(self):
+        @jit.rawkernel()
+        def f(x, y, z):
+            tid = jit.threadIdx.x
+            z[tid] = g(x[tid], y[tid]) + x[tid] + y[tid]
+
+        def g(x, y):
+            x += 1
+            y += 1
+            return x + y
+        
+        x = testing.shaped_random((30,), dtype=numpy.int32, seed=0)
+        y = testing.shaped_random((30,), dtype=numpy.int32, seed=1)
+        z = testing.shaped_random((30,), dtype=numpy.int32, seed=2)
+        f((1,), (30,), (x, y, z))
+        assert (z == (x + y + 1) * 2).all()

--- a/tests/cupyx_tests/jit_tests/test_device_function.py
+++ b/tests/cupyx_tests/jit_tests/test_device_function.py
@@ -15,6 +15,7 @@ class TestDeviceFunction(unittest.TestCase):
             tid = jit.threadIdx.x
             z[tid] = g(x[tid], y[tid]) + x[tid] + y[tid]
 
+        @jit.rawkernel(device=True)
         def g(x, y):
             x += 1
             y += 1
@@ -35,6 +36,7 @@ class TestDeviceFunction(unittest.TestCase):
             z[tid] += g(30)(x[tid], y[tid])
 
         def g(const):
+            @jit.rawkernel(device=True)
             def f(x, y):
                 return x + y + const
             return f
@@ -51,6 +53,7 @@ class TestDeviceFunction(unittest.TestCase):
             tid = jit.threadIdx.x
             z[tid] = g(x[tid], y[tid])
 
+        @jit.rawkernel(device=True)
         def g(x, y):
             return x + y + g(x, y)
 
@@ -69,6 +72,7 @@ class TestDeviceFunction(unittest.TestCase):
             g(1)(y)
 
         def g(step):
+            @jit.rawkernel(device=True)
             def f(x):
                 if step < 256:
                     tid = jit.threadIdx.x

--- a/tests/cupyx_tests/jit_tests/test_device_function.py
+++ b/tests/cupyx_tests/jit_tests/test_device_function.py
@@ -19,7 +19,7 @@ class TestDeviceFunction(unittest.TestCase):
             x += 1
             y += 1
             return x + y
-        
+
         x = testing.shaped_random((30,), dtype=numpy.int32, seed=0)
         y = testing.shaped_random((30,), dtype=numpy.int32, seed=1)
         z = testing.shaped_random((30,), dtype=numpy.int32, seed=2)


### PR DESCRIPTION
Close https://github.com/cupy/cupy/issues/5421.

Usage:
```py
import numpy
import cupy
from cupy import testing
from cupyx import jit

@jit.rawkernel(device=True)
def getitem(x, tid):
    return x[tid]

@jit.rawkernel()
def elementwise_copy(x, y):
    tid = jit.threadIdx.x + jit.blockDim.x * jit.blockIdx.x
    y[tid] = getitem(x, tid)

x = testing.shaped_random((30,), dtype=numpy.int32, seed=0)
y = testing.shaped_random((30,), dtype=numpy.int32, seed=1)

elementwise_copy((5,), (6,), (x, y))
assert bool((x == y).all())

print(elementwise_copy.cached_code)
```

Output:
```cpp
__device__ int getitem_1(CArray<int, 1, true, true> x, unsigned int tid) {
  return x[tid];
}
extern "C" __global__ void elementwise_copy(CArray<int, 1, true, true> x, CArray<int, 1, true, true> y) {
  unsigned int tid;
  tid = (threadIdx.x + (blockDim.x * blockIdx.x));
  y[tid] = getitem_1(x, tid);
}
```

TODO:
- [x] Raise `Valuerror` for recursive function.
- [x] Write tests