### PR TITLE
CI: allow discarding docker image cache manually

### DIFF
--- a/.pfnci/linux/main-flexci-prep.sh
+++ b/.pfnci/linux/main-flexci-prep.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Build and push Docker images for CUDA test targets.
+# Build and push Docker images for all test targets.
 
 set -ue
 
@@ -8,6 +8,6 @@ env
 
 gcloud auth configure-docker
 
-for DF in "$(dirname ${0})"/tests/cuda*.Dockerfile; do
+for DF in "$(dirname ${0})"/tests/*.Dockerfile; do
     echo "$(basename "${DF}")" | cut -d . -f 1
-done | xargs -i -n 1 -P 4 bash -c 'echo "flexci-prep: $2 start"; "$1" "$2" build push rmi > /dev/null 2>&1 && echo "flexci-prep: $2 succeeded" || echo "flexci-prep: $2 failed"' -- "$(dirname ${0})/run.sh" "{}"
+done | xargs -i -n 1 -P 4 bash -c 'echo "flexci-prep: $2 start"; DOCKER_IMAGE_CACHE=0 "$1" "$2" build push rmi > /dev/null 2>&1 && echo "flexci-prep: $2 succeeded" || echo "flexci-prep: $2 failed"' -- "$(dirname ${0})/run.sh" "{}"

--- a/.pfnci/linux/run.sh
+++ b/.pfnci/linux/run.sh
@@ -52,7 +52,7 @@ main() {
   cache_archive="linux-${TARGET}-${base_branch}.tar.gz"
   cache_gcs_dir="${CACHE_GCS_DIR:-gs://tmp-asia-pfn-public-ci/cupy-ci/cache}"
 
-  if [[ "${DOCKER_IMAGE_CACHE}" = "0" ]]; then
+  if [[ "${DOCKER_IMAGE_CACHE:-1}" = "0" ]]; then
     docker_cache_from=""
   fi
 

--- a/.pfnci/linux/run.sh
+++ b/.pfnci/linux/run.sh
@@ -25,6 +25,8 @@ Environment variables:
 - CACHE_DIR: Path to the local directory to store cache files.
 - CACHE_GCS_DIR: Path to the GCS directory to store a cache archive.
 - DOCKER_IMAGE: Base name of the Docker image (without a tag).
+- DOCKER_IMAGE_CACHE: Set to 0 to disable using cache when building a docker
+                      image.
 "
 
 set -eu
@@ -46,8 +48,13 @@ main() {
   repo_root="$(cd "$(dirname "${BASH_SOURCE}")/../.."; pwd)"
   base_branch="$(cat "${repo_root}/.pfnci/BRANCH")"
   docker_image="${DOCKER_IMAGE:-asia.gcr.io/pfn-public-ci/cupy-ci}:${TARGET}-${base_branch}"
+  docker_cache_from="${docker_image}"
   cache_archive="linux-${TARGET}-${base_branch}.tar.gz"
   cache_gcs_dir="${CACHE_GCS_DIR:-gs://tmp-asia-pfn-public-ci/cupy-ci/cache}"
+
+  if [[ "${DOCKER_IMAGE_CACHE}" = "0" ]]; then
+    docker_cache_from=""
+  fi
 
   echo "
     =====================================================================
@@ -60,6 +67,7 @@ main() {
     Repository Root     : ${repo_root}
     Base Branch         : ${base_branch}
     Docker Image        : ${docker_image}
+    Docker Image Cache  : ${docker_cache_from}
     Remote Cache        : ${cache_gcs_dir}/${cache_archive}
     Local Cache         : ${CACHE_DIR:-(not set)}
     =====================================================================
@@ -71,7 +79,7 @@ main() {
       tests_dir="${repo_root}/.pfnci/linux/tests"
       DOCKER_BUILDKIT=1 docker build \
           -t "${docker_image}" \
-          --cache-from "${docker_image}" \
+          --cache-from "${docker_cache_from}" \
           --build-arg BUILDKIT_INLINE_CACHE=1 \
           -f "${tests_dir}/${TARGET}.Dockerfile" \
           "${tests_dir}"


### PR DESCRIPTION
This fix allows regenerating CI docker images manually.
The script can be triggered via FlexCI Web UI <https://ci.preferred.jp/cupy.prep-linux/>.

Currently we pin dependent library versions using wildcard:
https://github.com/cupy/cupy/blob/master/.pfnci/linux/tests/cuda-head.Dockerfile#L26

However as CI docker images are cached without expiry, tests won't be able to newer versions of these libraries (e.g., newer RC releases of NumPy/SciPy).