### PR TITLE
Fix cache key for github actions

### DIFF
--- a/.github/workflows/pretest.yml
+++ b/.github/workflows/pretest.yml
@@ -24,7 +24,8 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/.ccache
-        key: ccache
+        key: ccache-${{ github.sha }}
+        restore-keys: ccache-${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.sha }}
 
     - name: Setup ccache
       run: |


### PR DESCRIPTION
I noticed that we should update `actions/cache` key for every commit, otherwise cahce will never be updated...

https://github.com/cupy/cupy/runs/4648731921?check_suite_focus=true
> Post Load ccache
> Post job cleanup.
> Cache hit occurred on the primary key ccache, not saving cache.

This PR changes to use the commit hash as a primary key, and falls back to the base branch's commit hash for pull-requests.