### PR TITLE
Make streams hashable

### DIFF
--- a/cupy/cuda/stream.pyx
+++ b/cupy/cuda/stream.pyx
@@ -225,6 +225,9 @@ class _BaseStream:
         return '<{} {} (device {})>'.format(
             type(self).__name__, self.ptr, self.device_id)
 
+    def __hash__(self):
+        return self.ptr
+
     def use(self):
         """Makes this stream current.
 

--- a/tests/cupy_tests/cuda_tests/test_stream.py
+++ b/tests/cupy_tests/cuda_tests/test_stream.py
@@ -61,6 +61,12 @@ class TestStream(unittest.TestCase):
         assert null1 == null2
         assert null2 != null3
 
+    def test_hash(self):
+        hash(self.stream)
+        hash(cuda.Stream(True))
+        hash(cuda.Stream(False))
+        mapping = {cuda.Stream(): 1, cuda.Stream(): 2}
+
     def check_del(self, null, ptds):
         stream = cuda.Stream(null=null, ptds=ptds).use()
         assert stream is cuda.get_current_stream()

--- a/tests/cupy_tests/cuda_tests/test_stream.py
+++ b/tests/cupy_tests/cuda_tests/test_stream.py
@@ -65,7 +65,7 @@ class TestStream(unittest.TestCase):
         hash(self.stream)
         hash(cuda.Stream(True))
         hash(cuda.Stream(False))
-        mapping = {cuda.Stream(): 1, cuda.Stream(): 2}
+        mapping = {cuda.Stream(): 1, cuda.Stream(): 2}  # noqa
 
     def check_del(self, null, ptds):
         stream = cuda.Stream(null=null, ptds=ptds).use()


### PR DESCRIPTION
Close #6243. Because `stream_ptr` is an int, `hash(stream_ptr)` is equal to `stream_ptr` and there is no point to do the former. This actually allows a very simple implementation as `__eq__` does not need to be modified at all.