### PR TITLE
Check isinstance before comparison in ``__eq__``

### DIFF
--- a/cupy/cuda/stream.pyx
+++ b/cupy/cuda/stream.pyx
@@ -206,7 +206,9 @@ class _BaseStream:
         # This operator needed as the ptr may be shared between multiple Stream
         # instances (e.g, `Stream.null` singleton and `Stream(null=True)` or
         # `ExternalStream`s).
-        return self.ptr == other.ptr
+        if isinstance(other, _BaseStream):
+            return self.ptr == other.ptr
+        return False
 
     def __enter__(self):
         # N.B. for maintainers: do not use this context manager in CuPy


### PR DESCRIPTION
Follows-up: #6285

This fixes the following failure (https://github.com/cupy/cupy/issues/6243#issuecomment-994672793):

```py
>>> x = {cupy.cuda.Stream.null: 100, 0: 200}
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "cupy/cuda/stream.pyx", line 209, in cupy.cuda.stream._BaseStream.__eq__
    return self.ptr == other.ptr
AttributeError: 'int' object has no attribute 'ptr'
```