### PR TITLE
add discrete cosine and sine transforms to cupyx.scipy.fft

### DIFF
--- a/cupyx/scipy/fft/__init__.py
+++ b/cupyx/scipy/fft/__init__.py
@@ -6,7 +6,7 @@ from cupyx.scipy.fft._fft import (
 )
 from cupyx.scipy.fft._fft import (
     __ua_domain__, __ua_convert__, __ua_function__)
-from cupyx.scipy.fft._fft import _scipy_150
+from cupyx.scipy.fft._fft import _scipy_150, _scipy_160
 from cupyx.scipy.fft._helper import next_fast_len  # NOQA
 from cupy.fft import fftshift, ifftshift, fftfreq, rfftfreq
 from cupyx.scipy.fftpack import get_fft_plan

--- a/cupyx/scipy/fft/__init__.py
+++ b/cupyx/scipy/fft/__init__.py
@@ -10,3 +10,6 @@ from cupyx.scipy.fft._fft import _scipy_150
 from cupyx.scipy.fft._helper import next_fast_len  # NOQA
 from cupy.fft import fftshift, ifftshift, fftfreq, rfftfreq
 from cupyx.scipy.fftpack import get_fft_plan
+from cupyx.scipy.fft._realtransforms import (
+    dct, dctn, dst, dstn, idct, idctn, idst, idstn
+)

--- a/cupyx/scipy/fft/_fft.py
+++ b/cupyx/scipy/fft/_fft.py
@@ -11,6 +11,7 @@ from cupy.fft._fft import (_fft, _default_fft_func, hfft as _hfft,
                            _swap_direction)
 
 _scipy_150 = False
+_scipy_160 = False
 try:
     import scipy
     import scipy.fft as _scipy_fft
@@ -23,6 +24,7 @@ except ImportError:
 else:
     from numpy.lib import NumpyVersion as Version
     _scipy_150 = Version(scipy.__version__) >= Version('1.5.0')
+    _scipy_160 = Version(scipy.__version__) >= Version('1.6.0')
     del Version
     del scipy
 

--- a/cupyx/scipy/fft/_realtransforms.py
+++ b/cupyx/scipy/fft/_realtransforms.py
@@ -437,7 +437,7 @@ def dst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False):
         truncated.  If ``n > x.shape[axis]``, `x` is zero-padded. The
         default results in ``n = x.shape[axis]``.
     axis : int, optional
-        Axis along which the idct is computed; the default is over the
+        Axis along which the dst is computed; the default is over the
         last axis (i.e., ``axis=-1``).
     norm : {"backward", "ortho", "forward"}, optional
         Normalization mode (see Notes). Default is "backward".

--- a/cupyx/scipy/fft/_realtransforms.py
+++ b/cupyx/scipy/fft/_realtransforms.py
@@ -24,7 +24,7 @@ described in [5]_.
 
 .. [3] http://fourier.eng.hmc.edu/e161/lectures/dct/node2.html
 
-.. [4] https://dsp.stackexchange.com/questions/2807/fast-cosine-transform-via-fft
+.. [4] https://dsp.stackexchange.com/questions/2807/fast-cosine-transform-via-fft  # noqa
 
 .. [5] X. Shao, S. G. Johnson. Type-II/III DCT/DST algorithms with reduced
     number of arithmetic operations, Signal Processing, Volume 88, Issue 6,

--- a/cupyx/scipy/fft/_realtransforms.py
+++ b/cupyx/scipy/fft/_realtransforms.py
@@ -39,7 +39,7 @@ import numpy
 
 import cupy
 from cupy import _core
-from cupy.fft import fft as cp_fft
+from cupy.fft._fft import _cook_shape
 from cupyx.scipy.fft import _fft
 
 
@@ -157,7 +157,7 @@ def _dct_or_dst_type2(
             f'invalid number of data points ({n}) specified'
         )
 
-    x = cp_fft._cook_shape(x, (n,), (axis,), 'R2R')
+    x = _cook_shape(x, (n,), (axis,), 'R2R')
     n = x.shape[axis]
 
     x = _reshuffle_dct2(x, x.shape[axis], axis, dst)
@@ -268,7 +268,7 @@ def _dct_or_dst_type3(
             f'invalid number of data points ({n}) specified'
         )
 
-    x = cp_fft._cook_shape(x, (n,), (axis,), 'R2R')
+    x = _cook_shape(x, (n,), (axis,), 'R2R')
     n = x.shape[axis]
 
     # determine normalization factor

--- a/cupyx/scipy/fft/_realtransforms.py
+++ b/cupyx/scipy/fft/_realtransforms.py
@@ -58,17 +58,22 @@ def _promote_dtype(x):
 def _get_dct_norm_factor(n, inorm, dct_type=2):
     """Normalization factors for DCT/DST I-IV.
 
-    Args:
-        n (int): Data size.
-        inorm ({'none', 'sqrt', 'full'}): When `inorm` is 'none', the scaling
-            factor is 1.0 (unnormalized). When `inorm` is 1, scaling by
-            ``1/sqrt(d)`` as needed for an orthogonal transform is used. When
-            `inorm` is 2, normalization by ``1/d`` is applied. The value of
-            ``d`` depends on both `n` and the `dct_type`.
-        dct_type ({1, 2, 3, 4}): Which type of DCT or DST is being normalized?
+    Parameters
+    ----------
+    n : int
+        Data size.
+    inorm : {'none', 'sqrt', 'full'}
+        When `inorm` is 'none', the scaling factor is 1.0 (unnormalized). When
+        `inorm` is 1, scaling by ``1/sqrt(d)`` as needed for an orthogonal
+        transform is used. When `inorm` is 2, normalization by ``1/d`` is
+        applied. The value of ``d`` depends on both `n` and the `dct_type`.
+    dct_type : {1, 2, 3, 4}
+        Which type of DCT or DST is being normalized?.
 
-    Returns:
-        fct (float): The normalization factor
+    Returns
+    -------
+    fct : float
+        The normalization factor.
     """
     if inorm == 'none':
         return 1
@@ -131,22 +136,31 @@ def _dct_or_dst_type2(
 ):
     """Forward DCT/DST-II (or inverse DCT/DST-III) along a single axis
 
-    Args:
-        x (cupy.ndarray): The data to transform.
-        n (int): The size of the transform. If None, ``x.shape[axis]`` is used.
-        axis (int): Axis along which the transform is applied.
-        forward (bool): Set true to indicate that this is a forward DCT-II as
-            opposed to an inverse DCT-III (The difference between the two is
-            only in the normalization factor).
-        norm ({None or 'ortho'}): The normalization convention to use.
-        dst (bool): If True, a discrete sine transform is computed rather than
-            the discrete cosine transform.
-        overwrite_x (bool): Indicates that it is okay to overwrite x. In
-            practice, the current implementation never performs the transform
-            in-place.
+    Parameters
+    ----------
+    x : cupy.ndarray
+        The data to transform.
+    n : int
+        The size of the transform. If None, ``x.shape[axis]`` is used.
+    axis : int
+        Axis along which the transform is applied.
+    forward : bool
+        Set true to indicate that this is a forward DCT-II as opposed to an
+        inverse DCT-III (The difference between the two is only in the
+        normalization factor).
+    norm : {None, 'ortho', 'forward', 'backward'}
+        The normalization convention to use.
+    dst : bool
+        If True, a discrete sine transform is computed rather than the discrete
+        cosine transform.
+    overwrite_x : bool
+        Indicates that it is okay to overwrite x. In practice, the current
+        implementation never performs the transform in-place.
 
-    Returns:
-        cupy.ndarray: The transformed array.
+    Returns
+    -------
+    y: cupy.ndarray
+        The transformed array.
     """
     if axis < -x.ndim or axis >= x.ndim:
         raise numpy.AxisError('axis out of range')
@@ -240,24 +254,34 @@ def _exp_factor_dct3(x, n, axis, dtype, norm_factor):
 def _dct_or_dst_type3(
     x, n=None, axis=-1, norm=None, forward=True, dst=False, overwrite_x=False
 ):
-    """Forward DCT/DST-III (or inverse DCT/DST-II).
+    """Forward DCT/DST-III (or inverse DCT/DST-II) along a single axis.
 
-    Args:
-        x (cupy.ndarray): The data to transform.
-        n (int): The size of the transform. If None, ``x.shape[axis]`` is used.
-        axis (int): Axis along which the transform is applied.
-        forward (bool): Set true to indicate that this is a forward DCT-II as
-            opposed to an inverse DCT-III (The difference between the two is
-            only in the normalization factor).
-        norm ({None or 'ortho'}): The normalization convention to use.
-        dst (bool): If True, a discrete sine transform is computed rather than
-            the discrete cosine transform.
-        overwrite_x (bool): Indicates that it is okay to overwrite x. In
-            practice, the current implementation never performs the transform
-            in-place.
+    Parameters
+    ----------
+    x : cupy.ndarray
+        The data to transform.
+    n : int
+        The size of the transform. If None, ``x.shape[axis]`` is used.
+    axis : int
+        Axis along which the transform is applied.
+    forward : bool
+        Set true to indicate that this is a forward DCT-II as opposed to an
+        inverse DCT-III (The difference between the two is only in the
+        normalization factor).
+    norm : {None, 'ortho', 'forward', 'backward'}
+        The normalization convention to use.
+    dst : bool
+        If True, a discrete sine transform is computed rather than the discrete
+        cosine transform.
+    overwrite_x : bool
+        Indicates that it is okay to overwrite x. In practice, the current
+        implementation never performs the transform in-place.
 
-    Returns:
-        cupy.ndarray: The transformed array.
+    Returns
+    -------
+    y: cupy.ndarray
+        The transformed array.
+
     """
     if axis < -x.ndim or axis >= x.ndim:
         raise numpy.AxisError('axis out of range')
@@ -320,47 +344,57 @@ def _dct_or_dst_type3(
 def dct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False):
     """Return the Discrete Cosine Transform of an array, x.
 
-    Args:
-        x (array_like): The input array.
-        type ({1, 2, 3, 4}, optional, optional): Type of the DCT (see Notes).
-            Default type is 2. Currently CuPy only supports types 2 and 3.
-        n (int, optional, optional): Length of the transform.  If
-            ``n < x.shape[axis]``, `x` is truncated. If ``n > x.shape[axis]``,
-            `x` is zero-padded. The default results in ``n = x.shape[axis]``.
-        axis (int, optional): Axis along which the dct is computed; the default
-            is over the last axis (i.e., ``axis=-1``).
-        norm ({None, 'ortho'}, optional): Normalization mode (see Notes).
-        overwrite_x (bool, optional, optional): If True, the contents of `x`
-            can be destroyed; the default is False.
+    Parameters
+    ----------
+    x : cupy.ndarray
+        The input array.
+    type : {1, 2, 3, 4}, optional
+        Type of the DCT (see Notes). Default type is 2. Currently CuPy only
+        supports types 2 and 3.
+    n : int, optional:
+        Length of the transform.  If ``n < x.shape[axis]``, `x` is
+        truncated. If ``n > x.shape[axis]``, `x` is zero-padded.
+        The default results in ``n = x.shape[axis]``.
+    axis : int, optional
+        Axis along which the dct is computed; the default is over the
+        last axis (i.e., ``axis=-1``).
+    norm : {"backward", "ortho", "forward"}, optional
+        Normalization mode (see Notes). Default is "backward".
+    overwrite_x : bool, optional
+        If True, the contents of `x` can be destroyed; the default is False.
 
-    Returns:
-        ndarray of real: The transformed input array.
+    Returns
+    -------
+    y : cupy.ndarray of real
+        The transformed input array.
 
     See Also
     --------
-    idct : Inverse DCT
+    :func:`scipy.fft.dct`
 
     Notes
     -----
-    For a single dimension array ``x``, ``dct(x, norm='ortho')`` is equal to
-    MATLAB ``dct(x)``.
+    For a single dimension array ``x``, ``dct(x, norm='ortho')`` is equal
+    to MATLAB ``dct(x)``.
 
-    For ``norm=None``, there is no scaling on `dct` and the `idct` is scaled by
-    ``1/N`` where ``N`` is the "logical" size of the DCT. For ``norm='ortho'``
-    both directions are scaled by the same factor ``1/sqrt(N)``.
+    For ``norm="ortho"`` both the `dct` and `idct` are scaled by the same
+    overall factor in both directions. By default, the transform is also
+    orthogonalized which for types 1, 2 and 3 means the transform definition is
+    modified to give orthogonality of the DCT matrix (see below).
 
-    CuPy currently only supports DCT types 2 and 3. 'The' DCT generally refers
-    to DCT type 2, and 'the' Inverse DCT generally refers to DCT type 3.
+    For ``norm="backward"``, there is no scaling on `dct` and the `idct` is
+    scaled by ``1/N`` where ``N`` is the "logical" size of the DCT. For
+    ``norm="forward"`` the ``1/N`` normalization is applied to the forward
+    `dct` instead and the `idct` is unnormalized.
 
-    See the `scipy.fft.dct` documentation for a full description of each type.
+    CuPy currently only supports DCT types 2 and 3. 'The' DCT generally
+    refers to DCT type 2, and 'the' Inverse DCT generally refers to DCT
+    type 3 [1]_. See the :func:`scipy.fft.dct` documentation for a full
+    description of each type.
 
     References
     ----------
-    .. [1] 'A Fast Cosine Transform in One and Two Dimensions', by J.
-           Makhoul, `IEEE Transactions on acoustics, speech and signal
-           processing` vol. 28(1), pp. 27-34, 1980.
-           https://doi.org/10.1109/TASSP.1980.1163351
-    .. [2] Wikipedia, "Discrete cosine transform",
+    .. [1] Wikipedia, "Discrete cosine transform",
            https://en.wikipedia.org/wiki/Discrete_cosine_transform
 
     """
@@ -392,46 +426,46 @@ def dct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False):
 def dst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False):
     """Return the Discrete Sine Transform of an array, x.
 
-    Args:
-        x (array_like): The input array.
-        type ({1, 2, 3, 4}, optional, optional): Type of the DST (see Notes).
-            Default type is 2. Currently CuPy only supports types 2 and 3.
-        n (int, optional, optional): Length of the transform.  If
-            ``n < x.shape[axis]``, `x` is truncated. If ``n > x.shape[axis]``,
-            `x` is zero-padded. The default results in ``n = x.shape[axis]``.
-        axis (int, optional): Axis along which the dct is computed; the default
-            is over the last axis (i.e., ``axis=-1``).
-        norm ({None, 'ortho'}, optional): Normalization mode (see Notes).
-        overwrite_x (bool, optional, optional): If True, the contents of `x`
-            can be destroyed; the default is False.
+    Parameters
+    ----------
+    x : cupy.ndarray
+        The input array.
+    type : {1, 2, 3, 4}, optional
+        Type of the DCT (see Notes). Default type is 2.
+    n : int, optional
+        Length of the transform.  If ``n < x.shape[axis]``, `x` is
+        truncated.  If ``n > x.shape[axis]``, `x` is zero-padded. The
+        default results in ``n = x.shape[axis]``.
+    axis : int, optional
+        Axis along which the idct is computed; the default is over the
+        last axis (i.e., ``axis=-1``).
+    norm : {"backward", "ortho", "forward"}, optional
+        Normalization mode (see Notes). Default is "backward".
+    overwrite_x : bool, optional
+        If True, the contents of `x` can be destroyed; the default is False.
 
-    Returns:
-      ndarray of reals: The transformed input array.
+    Returns
+    -------
+    idct : cupy.ndarray of real
+        The transformed input array.
 
     See Also
     --------
-    idst : Inverse DST
+    :func:`scipy.fft.dst`
 
     Notes
     -----
-    For a single dimension array ``x``.
 
-    For ``norm=None``, there is no scaling on the `dst` and the `idst` is
-    scaled by ``1/N`` where ``N`` is the "logical" size of the DST. For
-    ``norm='ortho'`` both directions are scaled by the same factor
-    ``1/sqrt(N)``.
+    For ``norm="ortho"`` both the `dst` and `idst` are scaled by the same
+    overall factor in both directions. By default, the transform is also
+    orthogonalized which for types 2 and 3 means the transform definition is
+    modified to give orthogonality of the DST matrix (see below).
 
-    There are, theoretically, 8 types of the DST for different combinations of
-    even/odd boundary conditions and boundary off sets [1]_, only types 2 and
-    3 are currently implemented in CuPy.
+    For ``norm="backward"``, there is no scaling on the `dst` and the `idst` is
+    scaled by ``1/N`` where ``N`` is the "logical" size of the DST.
 
-    See the `scipy.fft.dst` documentation for the full description of each
-    type.
-
-    References
-    ----------
-    .. [1] Wikipedia, "Discrete sine transform",
-           https://en.wikipedia.org/wiki/Discrete_sine_transform
+    See the :func:`scipy.fft.dst` documentation for a full description of each
+    type. CuPy currently only supports DST types 2 and 3.
     """
     if x.dtype.kind == 'c':
         # separable application on real and imaginary parts
@@ -461,42 +495,52 @@ def dst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False):
 def idct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False):
     """Return the Inverse Discrete Cosine Transform of an array, x.
 
-    Args:
-        x (array_like): The input array.
-        type ({1, 2, 3, 4}, optional, optional): Type of the DCT (see Notes).
-            Default type is 2. Currently CuPy only supports types 2 and 3.
-        n (int, optional, optional): Length of the transform.  If
-            ``n < x.shape[axis]``, `x` is truncated. If ``n > x.shape[axis]``,
-            `x` is zero-padded. The default results in ``n = x.shape[axis]``.
-        axis (int, optional): Axis along which the dct is computed; the default
-            is over the last axis (i.e., ``axis=-1``).
-        norm ({None, 'ortho'}, optional): Normalization mode (see Notes).
-        overwrite_x (bool, optional, optional): If True, the contents of `x`
-            can be destroyed; the default is False.
+    Parameters
+    ----------
+    x : cupy.ndarray
+        The input array.
+    type : {1, 2, 3, 4}, optional
+        Type of the DCT (see Notes). Default type is 2.
+    n : int, optional
+        Length of the transform.  If ``n < x.shape[axis]``, `x` is
+        truncated.  If ``n > x.shape[axis]``, `x` is zero-padded. The
+        default results in ``n = x.shape[axis]``.
+    axis : int, optional
+        Axis along which the idct is computed; the default is over the
+        last axis (i.e., ``axis=-1``).
+    norm : {"backward", "ortho", "forward"}, optional
+        Normalization mode (see Notes). Default is "backward".
+    overwrite_x : bool, optional
+        If True, the contents of `x` can be destroyed; the default is False.
 
-
-    Returns:
-        ndarray of real: The transformed input array.
+    Returns
+    -------
+    idct : cupy.ndarray of real
+        The transformed input array.
 
     See Also
     --------
-    dct : Forward DCT
+    :func:`scipy.fft.idct`
 
     Notes
     -----
     For a single dimension array `x`, ``idct(x, norm='ortho')`` is equal to
     MATLAB ``idct(x)``.
 
-    'The' IDCT is the IDCT-II, which is the same as the normalized DCT-III.
+    For ``norm="ortho"`` both the `dct` and `idct` are scaled by the same
+    overall factor in both directions. By default, the transform is also
+    orthogonalized which for types 1, 2 and 3 means the transform definition is
+    modified to give orthogonality of the IDCT matrix (see `dct` for the full
+    definitions).
 
-    The IDCT is equivalent to a normal DCT except for the normalization and
-    type. DCT type 1 and 4 are their own inverse and DCTs 2 and 3 are each
-    other's inverses.
+    'The' IDCT is the IDCT-II, which is the same as the normalized DCT-III
+    [1]_. See the :func:`scipy.fft.dct` documentation for a full description of
+    each type. CuPy currently only supports DCT types 2 and 3.
 
-    CuPy currently only supports DCT types 2 and 3.
-
-    See the `scipy.fft.dct` documentation for a full description of each type.
-
+    References
+    ----------
+    .. [1] Wikipedia, "Discrete sine transform",
+           https://en.wikipedia.org/wiki/Discrete_sine_transform
     """
     if x.dtype.kind == 'c':
         # separable application on real and imaginary parts
@@ -524,34 +568,37 @@ def idct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False):
 def idst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False):
     """Return the Inverse Discrete Sine Transform of an array, x.
 
-    Args:
-        x (array_like): The input array.
-        type ({1, 2, 3, 4}, optional, optional): Type of the DCT (see Notes).
-            Default type is 2. Currently CuPy only supports types 2 and 3.
-        n (int, optional, optional): Length of the transform.  If
-            ``n < x.shape[axis]``, `x` is truncated. If ``n > x.shape[axis]``,
-            `x` is zero-padded. The default results in ``n = x.shape[axis]``.
-        axis (int, optional): Axis along which the dct is computed; the default
-            is over the last axis (i.e., ``axis=-1``).
-        norm ({None, 'ortho'}, optional): Normalization mode (see Notes).
-        overwrite_x (bool, optional, optional): If True, the contents of `x`
-            can be destroyed; the default is False.
+    Parameters
+    ----------
+    x : cupy.ndarray
+        The input array.
+    type : {1, 2, 3, 4}, optional
+        Type of the DST (see Notes). Default type is 2.
+    n : int, optional
+        Length of the transform. If ``n < x.shape[axis]``, `x` is
+        truncated.  If ``n > x.shape[axis]``, `x` is zero-padded. The
+        default results in ``n = x.shape[axis]``.
+    axis : int, optional
+        Axis along which the idst is computed; the default is over the
+        last axis (i.e., ``axis=-1``).
+    norm : {"backward", "ortho", "forward"}, optional
+        Normalization mode (see Notes). Default is "backward".
+    overwrite_x : bool, optional
+        If True, the contents of `x` can be destroyed; the default is False.
 
-
-    Returns:
-        ndarray of real: The transformed input array.
+    Returns
+    -------
+    idst : cupy.ndarray of real
+        The transformed input array.
 
     See Also
     --------
-    dst : Forward DST
+    :func:`scipy.fft.idst`
 
     Notes
     -----
-    'The' IDST is the IDST-II, which is the same as the normalized DST-III.
-
-    CuPy currently only supports DST types 2 and 3.
-
-    See the `scipy.fft.dst` documentation for a full description of each type.
+    For full details of the DCT types and normalization modes, as well as
+    references, see :func:`scipy.fft.dct`.
     """
     if x.dtype.kind == 'c':
         # separable application on real and imaginary parts
@@ -641,34 +688,37 @@ def _init_nd_shape_and_axes(x, shape, axes):
 def dctn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False):
     """Compute a multidimensional Discrete Cosine Transform.
 
-    Args:
-        x (array_like): The input array.
-        type ({1, 2, 3, 4}, optional): Type of the DCT (see Notes).
-            Default type is 2. Only types 2 and 3 are currently supported by
-            CuPy.
-        s (int or array_like of ints or None, optional): The shape of the
-            result. If both `s` and `axes` (see below) are None, `s` is
-            ``x.shape``; if `s` is None but `axes` is not None, then `s` is
-            ``scipy.take(x.shape, axes, axis=0)``.
-           If ``s[i] > x.shape[i]``, the ith dimension is padded with zeros.
-           If ``s[i] < x.shape[i]``, the ith dimension is truncated to length
-           ``s[i]``.
-           If any element of `s` is -1, the size of the corresponding dimension
-           of `x` is used. (Default value = None)
-        axes (int or array_like of ints or None, optional): Axes over which the
-           DCT is computed. If not given, the last ``len(s)`` axes are used, or
-           all axes if `s` is also not specified. (Default value = None)
-        norm ({None, 'ortho'}, optional): Normalization mode (see Notes).
-           Default is None.
-        overwrite_x (bool, optional, optional): If True, the contents of `x`
-           can be destroyed; the default is False.
+    Parameters
+    ----------
+    x : cupy.ndarray
+        The input array.
+    type : {1, 2, 3, 4}, optional
+        Type of the DCT (see Notes). Default type is 2.
+    s : int or array_like of ints or None, optional
+        The shape of the result. If both `s` and `axes` (see below) are None,
+        `s` is ``x.shape``; if `s` is None but `axes` is not None, then `s` is
+        ``numpy.take(x.shape, axes, axis=0)``.
+        If ``s[i] > x.shape[i]``, the ith dimension is padded with zeros.
+        If ``s[i] < x.shape[i]``, the ith dimension is truncated to length
+        ``s[i]``.
+        If any element of `s` is -1, the size of the corresponding dimension of
+        `x` is used.
+    axes : int or array_like of ints or None, optional
+        Axes over which the DCT is computed. If not given, the last ``len(s)``
+        axes are used, or all axes if `s` is also not specified.
+    norm : {"backward", "ortho", "forward"}, optional
+        Normalization mode (see Notes). Default is "backward".
+    overwrite_x : bool, optional
+        If True, the contents of `x` can be destroyed; the default is False.
 
-    Returns:
-        ndarray of real: The transformed input array.
+    Returns
+    -------
+    y : cupy.ndarray of real
+        The transformed input array.
 
     See Also
     --------
-    idctn : Inverse multidimensional DCT
+    :func:`scipy.fft.dctn`
 
     Notes
     -----
@@ -698,39 +748,42 @@ def dctn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False):
 def idctn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False):
     """Compute a multidimensional Discrete Cosine Transform.
 
-    Args:
-        x (array_like): The input array.
-        type ({1, 2, 3, 4}, optional): Type of the DCT (see Notes).
-            Default type is 2. Only types 2 and 3 are currently supported by
-            CuPy.
-        s (int or array_like of ints or None, optional): The shape of the
-            result. If both `s` and `axes` (see below) are None, `s` is
-            ``x.shape``; if `s` is None but `axes` is not None, then `s` is
-            ``scipy.take(x.shape, axes, axis=0)``.
-           If ``s[i] > x.shape[i]``, the ith dimension is padded with zeros.
-           If ``s[i] < x.shape[i]``, the ith dimension is truncated to length
-           ``s[i]``.
-           If any element of `s` is -1, the size of the corresponding dimension
-           of `x` is used. (Default value = None)
-        axes (int or array_like of ints or None, optional): Axes over which the
-           DCT is computed. If not given, the last ``len(s)`` axes are used, or
-           all axes if `s` is also not specified. (Default value = None)
-        norm ({None, 'ortho'}, optional): Normalization mode (see Notes).
-           Default is None.
-        overwrite_x (bool, optional, optional): If True, the contents of `x`
-           can be destroyed; the default is False.
+    Parameters
+    ----------
+    x : cupy.ndarray
+        The input array.
+    type : {1, 2, 3, 4}, optional
+        Type of the DCT (see Notes). Default type is 2.
+    s : int or array_like of ints or None, optional
+        The shape of the result. If both `s` and `axes` (see below) are None,
+        `s` is ``x.shape``; if `s` is None but `axes` is not None, then `s` is
+        ``numpy.take(x.shape, axes, axis=0)``.
+        If ``s[i] > x.shape[i]``, the ith dimension is padded with zeros.
+        If ``s[i] < x.shape[i]``, the ith dimension is truncated to length
+        ``s[i]``.
+        If any element of `s` is -1, the size of the corresponding dimension of
+        `x` is used.
+    axes : int or array_like of ints or None, optional
+        Axes over which the DCT is computed. If not given, the last ``len(s)``
+        axes are used, or all axes if `s` is also not specified.
+    norm : {"backward", "ortho", "forward"}, optional
+        Normalization mode (see Notes). Default is "backward".
+    overwrite_x : bool, optional
+        If True, the contents of `x` can be destroyed; the default is False.
 
-    Returns:
-      ndarray of real: The transformed input array.
+    Returns
+    -------
+    y : cupy.ndarray of real
+        The transformed input array.
 
     See Also
     --------
-    dctn : multidimensional DCT
+    :func:`scipy.fft.idctn`
 
     Notes
     -----
     For full details of the IDCT types and normalization modes, as well as
-    references, see `idct`.
+    references, see :func:`scipy.fft.idct`.
     """
     if x.dtype.kind == 'c':
         # separable application on real and imaginary parts
@@ -755,39 +808,42 @@ def idctn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False):
 def dstn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False):
     """Compute a multidimensional Discrete Sine Transform.
 
-    Args:
-        x (array_like): The input array.
-        type ({1, 2, 3, 4}, optional): Type of the DST (see Notes).
-            Default type is 2. Only types 2 and 3 are currently supported by
-            CuPy.
-        s (int or array_like of ints or None, optional): The shape of the
-            result. If both `s` and `axes` (see below) are None, `s` is
-            ``x.shape``; if `s` is None but `axes` is not None, then `s` is
-            ``scipy.take(x.shape, axes, axis=0)``.
-           If ``s[i] > x.shape[i]``, the ith dimension is padded with zeros.
-           If ``s[i] < x.shape[i]``, the ith dimension is truncated to length
-           ``s[i]``.
-           If any element of `s` is -1, the size of the corresponding dimension
-           of `x` is used. (Default value = None)
-        axes (int or array_like of ints or None, optional): Axes over which the
-           DST is computed. If not given, the last ``len(s)`` axes are used, or
-           all axes if `s` is also not specified. (Default value = None)
-        norm ({None, 'ortho'}, optional): Normalization mode (see Notes).
-           Default is None.
-        overwrite_x (bool, optional, optional): If True, the contents of `x`
-           can be destroyed; the default is False.
+    Parameters
+    ----------
+    x : cupy.ndarray
+        The input array.
+    type : {1, 2, 3, 4}, optional
+        Type of the DST (see Notes). Default type is 2.
+    s : int or array_like of ints or None, optional
+        The shape of the result. If both `s` and `axes` (see below) are None,
+        `s` is ``x.shape``; if `s` is None but `axes` is not None, then `s` is
+        ``numpy.take(x.shape, axes, axis=0)``.
+        If ``s[i] > x.shape[i]``, the ith dimension is padded with zeros.
+        If ``s[i] < x.shape[i]``, the ith dimension is truncated to length
+        ``s[i]``.
+        If any element of `s` is -1, the size of the corresponding dimension of
+        `x` is used.
+    axes : int or array_like of ints or None, optional
+        Axes over which the DST is computed. If not given, the last ``len(s)``
+        axes are used, or all axes if `s` is also not specified.
+    norm : {"backward", "ortho", "forward"}, optional
+        Normalization mode (see Notes). Default is "backward".
+    overwrite_x : bool, optional
+        If True, the contents of `x` can be destroyed; the default is False.
 
-    Returns:
-        ndarray of real: The transformed input array.
+    Returns
+    -------
+    y : cupy.ndarray of real
+        The transformed input array.
 
     See Also
     --------
-    idstn : Inverse multidimensional DST
+    :func:`scipy.fft.dstn`
 
     Notes
     -----
-    For full details of the DST types and normalization modes, as well as
-    references, see `dst`.
+    For full details of the IDST types and normalization modes, as well as
+    references, see :func:`scipy.fft.dst`.
     """
     if x.dtype.kind == 'c':
         # separable application on real and imaginary parts
@@ -812,39 +868,42 @@ def dstn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False):
 def idstn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False):
     """Compute a multidimensional Discrete Sine Transform.
 
-    Args:
-        x (array_like): The input array.
-        type ({1, 2, 3, 4}, optional): Type of the DST (see Notes).
-            Default type is 2. Only types 2 and 3 are currently supported by
-            CuPy.
-        s (int or array_like of ints or None, optional): The shape of the
-            result. If both `s` and `axes` (see below) are None, `s` is
-            ``x.shape``; if `s` is None but `axes` is not None, then `s` is
-            ``scipy.take(x.shape, axes, axis=0)``.
-           If ``s[i] > x.shape[i]``, the ith dimension is padded with zeros.
-           If ``s[i] < x.shape[i]``, the ith dimension is truncated to length
-           ``s[i]``.
-           If any element of `s` is -1, the size of the corresponding dimension
-           of `x` is used. (Default value = None)
-        axes (int or array_like of ints or None, optional): Axes over which the
-           DST is computed. If not given, the last ``len(s)`` axes are used, or
-           all axes if `s` is also not specified. (Default value = None)
-        norm ({None, 'ortho'}, optional): Normalization mode (see Notes).
-           Default is None.
-        overwrite_x (bool, optional, optional): If True, the contents of `x`
-           can be destroyed; the default is False.
+    Parameters
+    ----------
+    x : cupy.ndarray
+        The input array.
+    type : {1, 2, 3, 4}, optional
+        Type of the DST (see Notes). Default type is 2.
+    s : int or array_like of ints or None, optional
+        The shape of the result. If both `s` and `axes` (see below) are None,
+        `s` is ``x.shape``; if `s` is None but `axes` is not None, then `s` is
+        ``numpy.take(x.shape, axes, axis=0)``.
+        If ``s[i] > x.shape[i]``, the ith dimension is padded with zeros.
+        If ``s[i] < x.shape[i]``, the ith dimension is truncated to length
+        ``s[i]``.
+        If any element of `s` is -1, the size of the corresponding dimension of
+        `x` is used.
+    axes : int or array_like of ints or None, optional
+        Axes over which the DST is computed. If not given, the last ``len(s)``
+        axes are used, or all axes if `s` is also not specified.
+    norm : {"backward", "ortho", "forward"}, optional
+        Normalization mode (see Notes). Default is "backward".
+    overwrite_x : bool, optional
+        If True, the contents of `x` can be destroyed; the default is False.
 
-    Returns:
-        ndarray of real: The transformed input array.
+    Returns
+    -------
+    y : cupy.ndarray of real
+        The transformed input array.
 
     See Also
     --------
-    dstn : multidimensional DST
+    :func:`scipy.fft.idstn`
 
     Notes
     -----
     For full details of the IDST types and normalization modes, as well as
-    references, see `idst`.
+    references, see :func:`scipy.fft.idst`.
     """
     if x.dtype.kind == 'c':
         # separable application on real and imaginary parts

--- a/cupyx/scipy/fft/_realtransforms.py
+++ b/cupyx/scipy/fft/_realtransforms.py
@@ -39,33 +39,8 @@ import numpy
 
 import cupy
 from cupy import _core
+from cupy.fft import fft as cp_fft
 from cupyx.scipy.fft import _fft
-
-try:
-    from cupy.fft.fft import _cook_shape
-except ImportError:
-    # local copy of private cupy.fft function
-    def _cook_shape(a, s, axes, value_type, order='C'):
-        if s is None or s == a.shape:
-            return a
-        if (value_type == 'C2R') and (s[-1] is not None):
-            s = list(s)
-            s[-1] = s[-1] // 2 + 1
-        for sz, axis in zip(s, axes):
-            if (sz is not None) and (sz != a.shape[axis]):
-                shape = list(a.shape)
-                if shape[axis] > sz:
-                    index = [slice(None)] * a.ndim
-                    index[axis] = slice(0, sz)
-                    a = a[tuple(index)]
-                else:
-                    index = [slice(None)] * a.ndim
-                    index[axis] = slice(0, shape[axis])
-                    shape[axis] = sz
-                    z = cupy.zeros(shape, a.dtype.char, order=order)
-                    z[tuple(index)] = a
-                    a = z
-        return a
 
 
 __all__ = ['dct', 'dctn', 'dst', 'dstn', 'idct', 'idctn', 'idst', 'idstn']
@@ -182,7 +157,7 @@ def _dct_or_dst_type2(
             f'invalid number of data points ({n}) specified'
         )
 
-    x = _cook_shape(x, (n,), (axis,), 'R2R')
+    x = cp_fft._cook_shape(x, (n,), (axis,), 'R2R')
     n = x.shape[axis]
 
     x = _reshuffle_dct2(x, x.shape[axis], axis, dst)
@@ -293,7 +268,7 @@ def _dct_or_dst_type3(
             f'invalid number of data points ({n}) specified'
         )
 
-    x = _cook_shape(x, (n,), (axis,), 'R2R')
+    x = cp_fft._cook_shape(x, (n,), (axis,), 'R2R')
     n = x.shape[axis]
 
     # determine normalization factor

--- a/cupyx/scipy/fft/_realtransforms.py
+++ b/cupyx/scipy/fft/_realtransforms.py
@@ -446,7 +446,7 @@ def dst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False):
 
     Returns
     -------
-    idct : cupy.ndarray of real
+    dst : cupy.ndarray of real
         The transformed input array.
 
     See Also
@@ -597,8 +597,8 @@ def idst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False):
 
     Notes
     -----
-    For full details of the DCT types and normalization modes, as well as
-    references, see :func:`scipy.fft.dct`.
+    For full details of the DST types and normalization modes, as well as
+    references, see :func:`scipy.fft.dst`.
     """
     if x.dtype.kind == 'c':
         # separable application on real and imaginary parts
@@ -764,7 +764,7 @@ def idctn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False):
         If any element of `s` is -1, the size of the corresponding dimension of
         `x` is used.
     axes : int or array_like of ints or None, optional
-        Axes over which the DCT is computed. If not given, the last ``len(s)``
+        Axes over which the IDCT is computed. If not given, the last ``len(s)``
         axes are used, or all axes if `s` is also not specified.
     norm : {"backward", "ortho", "forward"}, optional
         Normalization mode (see Notes). Default is "backward".
@@ -842,7 +842,7 @@ def dstn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False):
 
     Notes
     -----
-    For full details of the IDST types and normalization modes, as well as
+    For full details of the DST types and normalization modes, as well as
     references, see :func:`scipy.fft.dst`.
     """
     if x.dtype.kind == 'c':
@@ -884,7 +884,7 @@ def idstn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False):
         If any element of `s` is -1, the size of the corresponding dimension of
         `x` is used.
     axes : int or array_like of ints or None, optional
-        Axes over which the DST is computed. If not given, the last ``len(s)``
+        Axes over which the IDST is computed. If not given, the last ``len(s)``
         axes are used, or all axes if `s` is also not specified.
     norm : {"backward", "ortho", "forward"}, optional
         Normalization mode (see Notes). Default is "backward".

--- a/cupyx/scipy/fft/_realtransforms.py
+++ b/cupyx/scipy/fft/_realtransforms.py
@@ -431,7 +431,7 @@ def dst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False):
     x : cupy.ndarray
         The input array.
     type : {1, 2, 3, 4}, optional
-        Type of the DCT (see Notes). Default type is 2.
+        Type of the DST (see Notes). Default type is 2.
     n : int, optional
         Length of the transform.  If ``n < x.shape[axis]``, `x` is
         truncated.  If ``n > x.shape[axis]``, `x` is zero-padded. The

--- a/cupyx/scipy/fft/_realtransforms.py
+++ b/cupyx/scipy/fft/_realtransforms.py
@@ -358,8 +358,8 @@ def dct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False):
     ----------
     .. [1] 'A Fast Cosine Transform in One and Two Dimensions', by J.
            Makhoul, `IEEE Transactions on acoustics, speech and signal
-           processing` vol. 28(1), pp. 27-34,
-           :doi:`10.1109/TASSP.1980.1163351` (1980).
+           processing` vol. 28(1), pp. 27-34, 1980.
+           https://doi.org/10.1109/TASSP.1980.1163351
     .. [2] Wikipedia, "Discrete cosine transform",
            https://en.wikipedia.org/wiki/Discrete_cosine_transform
 

--- a/cupyx/scipy/fft/_realtransforms.py
+++ b/cupyx/scipy/fft/_realtransforms.py
@@ -38,8 +38,8 @@ import operator
 import numpy
 
 import cupy
-import cupyx.scipy.fft
 from cupy import _core
+from cupyx.scipy.fft import _fft
 
 try:
     from cupy.fft.fft import _cook_shape
@@ -193,7 +193,7 @@ def _dct_or_dst_type2(
         inorm = "none" if forward else "full"
     norm_factor = _get_dct_norm_factor(n, inorm=inorm, dct_type=2)
 
-    x = cupyx.scipy.fft.fft(x, n=n, axis=axis, overwrite_x=True)
+    x = _fft.fft(x, n=n, axis=axis, overwrite_x=True)
     tmp = _exp_factor_dct2(x, n, axis, norm_factor)
 
     x *= tmp  # broadcasting
@@ -326,13 +326,14 @@ def _dct_or_dst_type3(
     x[tuple(sl0)] *= sl0_scale
 
     # inverse fft
-    x = cupyx.scipy.fft.ifft(x, n=n, axis=axis, overwrite_x=True)
+    x = _fft.ifft(x, n=n, axis=axis, overwrite_x=True)
     x = cupy.real(x)
 
     # reorder entries
     return _reshuffle_dct3(x, n, axis, dst)
 
 
+@_fft._implements(_fft._scipy_fft.dct)
 def dct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False):
     """Return the Discrete Cosine Transform of an array, x.
 
@@ -404,6 +405,7 @@ def dct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False):
         raise ValueError("invalid DCT type")
 
 
+@_fft._implements(_fft._scipy_fft.dst)
 def dst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False):
     """Return the Discrete Sine Transform of an array, x.
 
@@ -472,6 +474,7 @@ def dst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False):
         raise ValueError("invalid DST type")
 
 
+@_fft._implements(_fft._scipy_fft.idct)
 def idct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False):
     """Return the Inverse Discrete Cosine Transform of an array, x.
 
@@ -534,6 +537,7 @@ def idct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False):
         raise ValueError("invalid DCT type")
 
 
+@_fft._implements(_fft._scipy_fft.idst)
 def idst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False):
     """Return the Inverse Discrete Sine Transform of an array, x.
 
@@ -650,6 +654,7 @@ def _init_nd_shape_and_axes(x, shape, axes):
     return shape, axes
 
 
+@_fft._implements(_fft._scipy_fft.dctn)
 def dctn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False):
     """Compute a multidimensional Discrete Cosine Transform.
 
@@ -706,6 +711,7 @@ def dctn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False):
     return x
 
 
+@_fft._implements(_fft._scipy_fft.idctn)
 def idctn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False):
     """Compute a multidimensional Discrete Cosine Transform.
 
@@ -762,6 +768,7 @@ def idctn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False):
     return x
 
 
+@_fft._implements(_fft._scipy_fft.dstn)
 def dstn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False):
     """Compute a multidimensional Discrete Sine Transform.
 
@@ -818,6 +825,7 @@ def dstn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False):
     return x
 
 
+@_fft._implements(_fft._scipy_fft.idstn)
 def idstn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False):
     """Compute a multidimensional Discrete Sine Transform.
 

--- a/cupyx/scipy/fft/_realtransforms.py
+++ b/cupyx/scipy/fft/_realtransforms.py
@@ -1,0 +1,874 @@
+"""Real-to-real transforms
+
+cuFFT does not implement real-to-real FFTs. This module implements forward
+and inverse DCT-II and DCT-III transforms using FFTs.
+
+A length N DCT can be computed using a length N FFT and some additional
+multiplications and reordering of entries.
+
+The approach taken here is based on the work in [1]_, [2]_ and is discussed in
+the freely-available online resources [3]_, [4]_.
+
+The implementation here follows that approach with only minor modification to
+match the normalization conventions in SciPy.
+
+The modifications to turn a type II or III DCT to a DST were implemented as
+described in [5]_.
+
+.. [1] J. Makhoul, "A fast cosine transform in one and two dimensions," in
+    IEEE Transactions on Acoustics, Speech, and Signal Processing, vol. 28,
+    no. 1, pp. 27-34, February 1980.
+
+.. [2] M.J. Narasimha and A.M. Peterson, “On the computation of the discrete
+    cosine  transform,” IEEE Trans. Commun., vol. 26, no. 6, pp. 934–936, 1978.
+
+.. [3] http://fourier.eng.hmc.edu/e161/lectures/dct/node2.html
+
+.. [4] https://dsp.stackexchange.com/questions/2807/fast-cosine-transform-via-fft
+
+.. [5] X. Shao, S. G. Johnson. Type-II/III DCT/DST algorithms with reduced
+    number of arithmetic operations, Signal Processing, Volume 88, Issue 6,
+    pp. 1553-1564, 2008.
+"""
+
+import math
+import numbers
+import operator
+
+import numpy
+
+import cupy
+import cupyx.scipy.fft
+from cupy import _core
+
+try:
+    from cupy.fft.fft import _cook_shape
+except ImportError:
+    # local copy of private cupy.fft function
+    def _cook_shape(a, s, axes, value_type, order="C"):
+        if s is None or s == a.shape:
+            return a
+        if (value_type == "C2R") and (s[-1] is not None):
+            s = list(s)
+            s[-1] = s[-1] // 2 + 1
+        for sz, axis in zip(s, axes):
+            if (sz is not None) and (sz != a.shape[axis]):
+                shape = list(a.shape)
+                if shape[axis] > sz:
+                    index = [slice(None)] * a.ndim
+                    index[axis] = slice(0, sz)
+                    a = a[tuple(index)]
+                else:
+                    index = [slice(None)] * a.ndim
+                    index[axis] = slice(0, shape[axis])
+                    shape[axis] = sz
+                    z = cupy.zeros(shape, a.dtype.char, order=order)
+                    z[tuple(index)] = a
+                    a = z
+        return a
+
+
+__all__ = ["dct", "dctn", "dst", "dstn", "idct", "idctn", "idst", "idstn"]
+
+
+def _promote_dtype(x):
+    if x.dtype.kind in "bui":
+        # use float64 instead of promote_types to match SciPy's behavior
+        float_dtype = cupy.float64
+    else:
+        float_dtype = cupy.promote_types(x.dtype, cupy.float32)
+    return x.astype(float_dtype, copy=False)
+
+
+def _get_dct_norm_factor(n, inorm, dct_type=2):
+    """Normalization factors for DCT/DST I-IV.
+
+    Args:
+        n (int): Data size.
+        inorm ({'none', 'sqrt', 'full'}): When `inorm` is 'none', the scaling
+            factor is 1.0 (unnormalized). When `inorm` is 1, scaling by
+            ``1/sqrt(d)`` as needed for an orthogonal transform is used. When
+            `inorm` is 2, normalization by ``1/d`` is applied. The value of
+            ``d`` depends on both `n` and the `dct_type`.
+        dct_type ({1, 2, 3, 4}): Which type of DCT or DST is being normalized?
+
+    Returns:
+        fct (float): The normalization factor
+    """
+    if inorm == "none":
+        return 1
+    delta = -1 if dct_type == 1 else 0
+    d = 2 * (n + delta)
+    if inorm == "full":
+        fct = 1 / d
+    elif inorm == "sqrt":
+        fct = 1 / math.sqrt(d)
+    else:
+        raise ValueError("expected inorm = 'none', 'sqrt' or 'full'")
+    return fct
+
+
+def _reshuffle_dct2(x, n, axis, dst=False):
+    """Reorder entries to allow computation of DCT/DST-II via FFT."""
+    sl_even = [slice(None)] * x.ndim
+    sl_even[axis] = slice(0, None, 2)
+    sl_even = tuple(sl_even)
+    sl_odd = [slice(None)] * x.ndim
+    if n % 2:
+        sl_odd[axis] = slice(-2, None, -2)
+        sl_odd = tuple(sl_odd)
+    else:
+        sl_odd[axis] = slice(None, None, -2)
+        sl_odd = tuple(sl_odd)
+    if dst:
+        x = cupy.concatenate((x[sl_even], -x[sl_odd]), axis=axis)
+    else:
+        x = cupy.concatenate((x[sl_even], x[sl_odd]), axis=axis)
+    return x
+
+
+_mult_factor_dct2 = _core.ElementwiseKernel(
+    in_params="R xr, int32 N, R norm_factor",
+    out_params="C y",
+    operation="""
+    C j(0., -1.);
+    y = (R)2.0 * norm_factor * exp(j * (R)(i * M_PI / (2 * N)));""",
+)
+
+
+def _exp_factor_dct2(x, n, axis, norm_factor, n_truncate=None):
+    """Twiddle & scaling factors for computation of DCT/DST-II via FFT."""
+    if n_truncate is None:
+        n_truncate = n
+    tmp = cupy.empty((n_truncate,), dtype=x.dtype)
+    _mult_factor_dct2(tmp.real, n, norm_factor, tmp)
+
+    if x.ndim == 1:
+        return tmp
+    tmp_shape = [1] * x.ndim
+    tmp_shape[axis] = n_truncate
+    tmp_shape = tuple(tmp_shape)
+    return tmp.reshape(tmp_shape)
+
+
+def _dct_or_dst_type2(
+    x, n=None, axis=-1, forward=True, norm=None, dst=False, overwrite_x=False
+):
+    """Forward DCT/DST-II (or inverse DCT/DST-III) along a single axis
+
+    Args:
+        x (cupy.ndarray): The data to transform.
+        n (int): The size of the transform. If None, ``x.shape[axis]`` is used.
+        axis (int): Axis along which the transform is applied.
+        forward (bool): Set true to indicate that this is a forward DCT-II as
+            opposed to an inverse DCT-III (The difference between the two is
+            only in the normalization factor).
+        norm ({None or 'ortho'}): The normalization convention to use.
+        dst (bool): If True, a discrete sine transform is computed rather than
+            the discrete cosine transform.
+        overwrite_x (bool): Indicates that it is okay to overwrite x. In
+            practice, the current implementation never performs the transform
+            in-place.
+
+    Returns:
+        cupy.ndarray: The transformed array.
+    """
+    if axis < -x.ndim or axis >= x.ndim:
+        raise numpy.AxisError("axis out of range")
+    if axis < 0:
+        axis += x.ndim
+    if n is not None and n < 1:
+        raise ValueError(
+            "invalid number of data points ({}) specified".format(n)
+        )
+
+    x = _cook_shape(x, (n,), (axis,), "R2R")
+    n = x.shape[axis]
+
+    x = _reshuffle_dct2(x, x.shape[axis], axis, dst)
+
+    if norm == "ortho":
+        inorm = "sqrt"
+    else:
+        inorm = "none" if forward else "full"
+    norm_factor = _get_dct_norm_factor(n, inorm=inorm, dct_type=2)
+
+    x = cupyx.scipy.fft.fft(x, n=n, axis=axis, overwrite_x=True)
+    tmp = _exp_factor_dct2(x, n, axis, norm_factor)
+
+    x *= tmp  # broadcasting
+    x = cupy.real(x)
+
+    if dst:
+        slrev = [slice(None)] * x.ndim
+        slrev[axis] = slice(None, None, -1)
+        x = x[tuple(slrev)]
+
+    if norm == "ortho":
+        sl0 = [slice(None)] * x.ndim
+        sl0[axis] = slice(1)
+        x[tuple(sl0)] *= math.sqrt(2) * 0.5
+    return x
+
+
+def _reshuffle_dct3(y, n, axis, dst):
+    """Reorder entries to allow computation of DCT/DST-II via FFT."""
+    x = cupy.empty_like(y)
+    n_half = (n + 1) // 2
+
+    # Store first half of y in the even entries of the output
+    sl_even = [slice(None)] * y.ndim
+    sl_even[axis] = slice(0, None, 2)
+    sl_even = tuple(sl_even)
+
+    sl_half = [slice(None)] * y.ndim
+    sl_half[axis] = slice(0, n_half)
+    x[sl_even] = y[tuple(sl_half)]
+
+    # Store the second half of y in the odd entries of the output
+    sl_odd = [slice(None)] * y.ndim
+    sl_odd[axis] = slice(1, None, 2)
+    sl_odd = tuple(sl_odd)
+
+    sl_half[axis] = slice(-1, n_half - 1, -1)
+    if dst:
+        x[sl_odd] = -y[tuple(sl_half)]
+    else:
+        x[sl_odd] = y[tuple(sl_half)]
+    return x
+
+
+_mult_factor_dct3 = _core.ElementwiseKernel(
+    in_params="R xr, int32 N, R norm_factor",
+    out_params="C y",
+    operation="""
+    C j(0., 1.);
+    y = (R)(2 * N * norm_factor) * exp(j * (R)(i * M_PI / (2 * N)));""",
+)
+
+
+def _exp_factor_dct3(x, n, axis, dtype, norm_factor):
+    """Twiddle & scaling factors for computation of DCT/DST-III via FFT."""
+    tmp = cupy.empty((n,), dtype=dtype)
+    _mult_factor_dct3(tmp.real, n, norm_factor, tmp)
+    if x.ndim == 1:
+        return tmp
+    # prepare shape for broadcasting along non-transformed axes
+    tmp_shape = [1] * x.ndim
+    tmp_shape[axis] = n
+    tmp_shape = tuple(tmp_shape)
+    return tmp.reshape(tmp_shape)
+
+
+def _dct_or_dst_type3(
+    x, n=None, axis=-1, norm=None, forward=True, dst=False, overwrite_x=False
+):
+    """Forward DCT/DST-III (or inverse DCT/DST-II).
+
+    Args:
+        x (cupy.ndarray): The data to transform.
+        n (int): The size of the transform. If None, ``x.shape[axis]`` is used.
+        axis (int): Axis along which the transform is applied.
+        forward (bool): Set true to indicate that this is a forward DCT-II as
+            opposed to an inverse DCT-III (The difference between the two is
+            only in the normalization factor).
+        norm ({None or 'ortho'}): The normalization convention to use.
+        dst (bool): If True, a discrete sine transform is computed rather than
+            the discrete cosine transform.
+        overwrite_x (bool): Indicates that it is okay to overwrite x. In
+            practice, the current implementation never performs the transform
+            in-place.
+
+    Returns:
+        cupy.ndarray: The transformed array.
+    """
+    if axis < -x.ndim or axis >= x.ndim:
+        raise numpy.AxisError("axis out of range")
+    if axis < 0:
+        axis += x.ndim
+    if n is not None and n < 1:
+        raise ValueError(
+            "invalid number of data points ({}) specified".format(n)
+        )
+
+    x = _cook_shape(x, (n,), (axis,), "R2R")
+    n = x.shape[axis]
+
+    # determine normalization factor
+    if norm == "ortho":
+        sl0_scale = 0.5 * math.sqrt(2)
+        inorm = "sqrt"
+    else:
+        sl0_scale = 0.5
+        inorm = "none" if forward else "full"
+    norm_factor = _get_dct_norm_factor(n, inorm=inorm, dct_type=3)
+    dtype = cupy.promote_types(x, cupy.complex64)
+
+    sl0 = [slice(None)] * x.ndim
+    sl0[axis] = slice(1)
+
+    if dst:
+        if norm == "ortho":
+            float_dtype = cupy.promote_types(x.dtype, cupy.float32)
+            if x.dtype != float_dtype:
+                x = x.astype(float_dtype)
+            elif not overwrite_x:
+                x = x.copy()
+            x[tuple(sl0)] *= math.sqrt(2)
+            sl0_scale = 0.5
+        slrev = [slice(None)] * x.ndim
+        slrev[axis] = slice(None, None, -1)
+        x = x[tuple(slrev)]
+
+    # scale by exponentials and normalization factor
+    tmp = _exp_factor_dct3(x, n, axis, dtype, norm_factor)
+    x = x * tmp  # broadcasting
+    x[tuple(sl0)] *= sl0_scale
+
+    # inverse fft
+    x = cupyx.scipy.fft.ifft(x, n=n, axis=axis, overwrite_x=True)
+    x = cupy.real(x)
+
+    # reorder entries
+    return _reshuffle_dct3(x, n, axis, dst)
+
+
+def dct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False):
+    """Return the Discrete Cosine Transform of an array, x.
+
+    Args:
+        x (array_like): The input array.
+        type ({1, 2, 3, 4}, optional, optional): Type of the DCT (see Notes).
+            Default type is 2. Currently CuPy only supports types 2 and 3.
+        n (int, optional, optional): Length of the transform.  If
+            ``n < x.shape[axis]``, `x` is truncated. If ``n > x.shape[axis]``,
+            `x` is zero-padded. The default results in ``n = x.shape[axis]``.
+        axis (int, optional): Axis along which the dct is computed; the default
+            is over the last axis (i.e., ``axis=-1``).
+        norm ({None, 'ortho'}, optional): Normalization mode (see Notes).
+        overwrite_x (bool, optional, optional): If True, the contents of `x`
+            can be destroyed; the default is False.
+
+    Returns:
+        ndarray of real: The transformed input array.
+
+    See Also
+    --------
+    idct : Inverse DCT
+
+    Notes
+    -----
+    For a single dimension array ``x``, ``dct(x, norm='ortho')`` is equal to
+    MATLAB ``dct(x)``.
+
+    For ``norm=None``, there is no scaling on `dct` and the `idct` is scaled by
+    ``1/N`` where ``N`` is the "logical" size of the DCT. For ``norm='ortho'``
+    both directions are scaled by the same factor ``1/sqrt(N)``.
+
+    CuPy currently only supports DCT types 2 and 3. 'The' DCT generally refers
+    to DCT type 2, and 'the' Inverse DCT generally refers to DCT type 3.
+
+    See the `scipy.fft.dct` documentation for a full description of each type.
+
+    References
+    ----------
+    .. [1] 'A Fast Cosine Transform in One and Two Dimensions', by J.
+           Makhoul, `IEEE Transactions on acoustics, speech and signal
+           processing` vol. 28(1), pp. 27-34,
+           :doi:`10.1109/TASSP.1980.1163351` (1980).
+    .. [2] Wikipedia, "Discrete cosine transform",
+           https://en.wikipedia.org/wiki/Discrete_cosine_transform
+
+    """
+    if x.dtype.kind == "c":
+        # separable application on real and imaginary parts
+        out = dct(x.real, type, n, axis, norm, overwrite_x)
+        out = out + 1j * dct(x.imag, type, n, axis, norm, overwrite_x)
+        return out
+
+    x = _promote_dtype(x)
+
+    if type == 2:
+        return _dct_or_dst_type2(
+            x, n=n, axis=axis, norm=norm, forward=True, dst=False
+        )
+    elif type == 3:
+        return _dct_or_dst_type3(
+            x, n=n, axis=axis, norm=norm, forward=True, dst=False
+        )
+    elif type in [1, 4]:
+        raise NotImplementedError(
+            "Only DCT-II and DCT-III have been implemented."
+        )
+    else:
+        raise ValueError("invalid DCT type")
+
+
+def dst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False):
+    """Return the Discrete Sine Transform of an array, x.
+
+    Args:
+        x (array_like): The input array.
+        type ({1, 2, 3, 4}, optional, optional): Type of the DST (see Notes).
+            Default type is 2. Currently CuPy only supports types 2 and 3.
+        n (int, optional, optional): Length of the transform.  If
+            ``n < x.shape[axis]``, `x` is truncated. If ``n > x.shape[axis]``,
+            `x` is zero-padded. The default results in ``n = x.shape[axis]``.
+        axis (int, optional): Axis along which the dct is computed; the default
+            is over the last axis (i.e., ``axis=-1``).
+        norm ({None, 'ortho'}, optional): Normalization mode (see Notes).
+        overwrite_x (bool, optional, optional): If True, the contents of `x`
+            can be destroyed; the default is False.
+
+    Returns:
+      ndarray of reals: The transformed input array.
+
+    See Also
+    --------
+    idst : Inverse DST
+
+    Notes
+    -----
+    For a single dimension array ``x``.
+
+    For ``norm=None``, there is no scaling on the `dst` and the `idst` is
+    scaled by ``1/N`` where ``N`` is the "logical" size of the DST. For
+    ``norm='ortho'`` both directions are scaled by the same factor
+    ``1/sqrt(N)``.
+
+    There are, theoretically, 8 types of the DST for different combinations of
+    even/odd boundary conditions and boundary off sets [1]_, only types 2 and
+    3 are currently implemented in CuPy.
+
+    See the `scipy.fft.dst` documentation for the full description of each
+    type.
+
+    References
+    ----------
+    .. [1] Wikipedia, "Discrete sine transform",
+           https://en.wikipedia.org/wiki/Discrete_sine_transform
+    """
+    if x.dtype.kind == "c":
+        # separable application on real and imaginary parts
+        out = dst(x.real, type, n, axis, norm, overwrite_x)
+        out = out + 1j * dst(x.imag, type, n, axis, norm, overwrite_x)
+        return out
+
+    x = _promote_dtype(x)
+
+    if type == 2:
+        return _dct_or_dst_type2(
+            x, n=n, axis=axis, norm=norm, forward=True, dst=True
+        )
+    elif type == 3:
+        return _dct_or_dst_type3(
+            x, n=n, axis=axis, norm=norm, forward=True, dst=True
+        )
+    elif type in [1, 4]:
+        raise NotImplementedError(
+            "Only DST-II and DST-III have been implemented."
+        )
+    else:
+        raise ValueError("invalid DST type")
+
+
+def idct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False):
+    """Return the Inverse Discrete Cosine Transform of an array, x.
+
+    Args:
+        x (array_like): The input array.
+        type ({1, 2, 3, 4}, optional, optional): Type of the DCT (see Notes).
+            Default type is 2. Currently CuPy only supports types 2 and 3.
+        n (int, optional, optional): Length of the transform.  If
+            ``n < x.shape[axis]``, `x` is truncated. If ``n > x.shape[axis]``,
+            `x` is zero-padded. The default results in ``n = x.shape[axis]``.
+        axis (int, optional): Axis along which the dct is computed; the default
+            is over the last axis (i.e., ``axis=-1``).
+        norm ({None, 'ortho'}, optional): Normalization mode (see Notes).
+        overwrite_x (bool, optional, optional): If True, the contents of `x`
+            can be destroyed; the default is False.
+
+
+    Returns:
+        ndarray of real: The transformed input array.
+
+    See Also
+    --------
+    dct : Forward DCT
+
+    Notes
+    -----
+    For a single dimension array `x`, ``idct(x, norm='ortho')`` is equal to
+    MATLAB ``idct(x)``.
+
+    'The' IDCT is the IDCT-II, which is the same as the normalized DCT-III.
+
+    The IDCT is equivalent to a normal DCT except for the normalization and
+    type. DCT type 1 and 4 are their own inverse and DCTs 2 and 3 are each
+    other's inverses.
+
+    CuPy currently only supports DCT types 2 and 3.
+
+    See the `scipy.fft.dct` documentation for a full description of each type.
+
+    """
+    if x.dtype.kind == "c":
+        # separable application on real and imaginary parts
+        out = idct(x.real, type, n, axis, norm, overwrite_x)
+        out = out + 1j * idct(x.imag, type, n, axis, norm, overwrite_x)
+        return out
+
+    x = _promote_dtype(x)
+
+    if type == 2:
+        # DCT-III is the inverse of DCT-II
+        return _dct_or_dst_type3(x, n=n, axis=axis, norm=norm, forward=False)
+    elif type == 3:
+        # DCT-II is the inverse of DCT-III
+        return _dct_or_dst_type2(x, n=n, axis=axis, norm=norm, forward=False)
+    elif type in [1, 4]:
+        raise NotImplementedError(
+            "Only DCT-II and DCT-III have been implemented."
+        )
+    else:
+        raise ValueError("invalid DCT type")
+
+
+def idst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False):
+    """Return the Inverse Discrete Sine Transform of an array, x.
+
+    Args:
+        x (array_like): The input array.
+        type ({1, 2, 3, 4}, optional, optional): Type of the DCT (see Notes).
+            Default type is 2. Currently CuPy only supports types 2 and 3.
+        n (int, optional, optional): Length of the transform.  If
+            ``n < x.shape[axis]``, `x` is truncated. If ``n > x.shape[axis]``,
+            `x` is zero-padded. The default results in ``n = x.shape[axis]``.
+        axis (int, optional): Axis along which the dct is computed; the default
+            is over the last axis (i.e., ``axis=-1``).
+        norm ({None, 'ortho'}, optional): Normalization mode (see Notes).
+        overwrite_x (bool, optional, optional): If True, the contents of `x`
+            can be destroyed; the default is False.
+
+
+    Returns:
+        ndarray of real: The transformed input array.
+
+    See Also
+    --------
+    dst : Forward DST
+
+    Notes
+    -----
+    'The' IDST is the IDST-II, which is the same as the normalized DST-III.
+
+    CuPy currently only supports DST types 2 and 3.
+
+    See the `scipy.fft.dst` documentation for a full description of each type.
+    """
+    if x.dtype.kind == "c":
+        # separable application on real and imaginary parts
+        out = idst(x.real, type, n, axis, norm, overwrite_x)
+        out = out + 1j * idst(x.imag, type, n, axis, norm, overwrite_x)
+        return out
+
+    x = _promote_dtype(x)
+
+    if type == 2:
+        # DCT-III is the inverse of DCT-II
+        return _dct_or_dst_type3(
+            x, n=n, axis=axis, norm=norm, forward=False, dst=True
+        )
+    elif type == 3:
+        # DCT-II is the inverse of DCT-III
+        return _dct_or_dst_type2(
+            x, n=n, axis=axis, norm=norm, forward=False, dst=True
+        )
+    elif type in [1, 4]:
+        raise NotImplementedError(
+            "Only DST-II and DST-III have been implemented."
+        )
+    else:
+        raise ValueError("invalid DST type")
+
+
+def _iterable_of_int(x, name=None):
+    """Convert ``x`` to an iterable sequence of int."""
+    if isinstance(x, numbers.Number):
+        x = (x,)
+
+    try:
+        x = [operator.index(a) for a in x]
+    except TypeError as e:
+        name = name or "value"
+        raise ValueError(
+            "{} must be a scalar or iterable of integers".format(name)
+        ) from e
+
+    return x
+
+
+def _init_nd_shape_and_axes(x, shape, axes):
+    """Handles shape and axes arguments for nd transforms."""
+    noshape = shape is None
+    noaxes = axes is None
+
+    if not noaxes:
+        axes = _iterable_of_int(axes, "axes")
+        axes = [a + x.ndim if a < 0 else a for a in axes]
+
+        if any(a >= x.ndim or a < 0 for a in axes):
+            raise ValueError("axes exceeds dimensionality of input")
+        if len(set(axes)) != len(axes):
+            raise ValueError("all axes must be unique")
+
+    if not noshape:
+        shape = _iterable_of_int(shape, "shape")
+        nshape = len(shape)
+        if axes and len(axes) != nshape:
+            raise ValueError(
+                "when given, axes and shape arguments"
+                " have to be of the same length"
+            )
+        if noaxes:
+            if nshape > x.ndim:
+                raise ValueError("shape requires more axes than are present")
+            axes = range(x.ndim - len(shape), x.ndim)
+
+        shape = [x.shape[a] if s == -1 else s for s, a in zip(shape, axes)]
+    elif noaxes:
+        shape = list(x.shape)
+        axes = range(x.ndim)
+    else:
+        shape = [x.shape[a] for a in axes]
+
+    if any(s < 1 for s in shape):
+        raise ValueError(
+            "invalid number of data points ({0}) specified".format(shape)
+        )
+
+    return shape, axes
+
+
+def dctn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False):
+    """Compute a multidimensional Discrete Cosine Transform.
+
+    Args:
+        x (array_like): The input array.
+        type ({1, 2, 3, 4}, optional): Type of the DCT (see Notes).
+            Default type is 2. Only types 2 and 3 are currently supported by
+            CuPy.
+        s (int or array_like of ints or None, optional): The shape of the
+            result. If both `s` and `axes` (see below) are None, `s` is
+            ``x.shape``; if `s` is None but `axes` is not None, then `s` is
+            ``scipy.take(x.shape, axes, axis=0)``.
+           If ``s[i] > x.shape[i]``, the ith dimension is padded with zeros.
+           If ``s[i] < x.shape[i]``, the ith dimension is truncated to length
+           ``s[i]``.
+           If any element of `s` is -1, the size of the corresponding dimension
+           of `x` is used. (Default value = None)
+        axes (int or array_like of ints or None, optional): Axes over which the
+           DCT is computed. If not given, the last ``len(s)`` axes are used, or
+           all axes if `s` is also not specified. (Default value = None)
+        norm ({None, 'ortho'}, optional): Normalization mode (see Notes).
+           Default is None.
+        overwrite_x (bool, optional, optional): If True, the contents of `x`
+           can be destroyed; the default is False.
+
+    Returns:
+        ndarray of real: The transformed input array.
+
+    See Also
+    --------
+    idctn : Inverse multidimensional DCT
+
+    Notes
+    -----
+    For full details of the DCT types and normalization modes, as well as
+    references, see `dct`.
+    """
+    if x.dtype.kind == "c":
+        # separable application on real and imaginary parts
+        out = dctn(x.real, type, s, axes, norm, overwrite_x)
+        out = out + 1j * dctn(x.imag, type, s, axes, norm, overwrite_x)
+        return out
+
+    shape, axes = _init_nd_shape_and_axes(x, s, axes)
+    x = _promote_dtype(x)
+
+    if len(axes) == 0:
+        return x
+
+    for n, axis in zip(shape, axes):
+        x = dct(
+            x, type=type, n=n, axis=axis, norm=norm, overwrite_x=overwrite_x
+        )
+    return x
+
+
+def idctn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False):
+    """Compute a multidimensional Discrete Cosine Transform.
+
+    Args:
+        x (array_like): The input array.
+        type ({1, 2, 3, 4}, optional): Type of the DCT (see Notes).
+            Default type is 2. Only types 2 and 3 are currently supported by
+            CuPy.
+        s (int or array_like of ints or None, optional): The shape of the
+            result. If both `s` and `axes` (see below) are None, `s` is
+            ``x.shape``; if `s` is None but `axes` is not None, then `s` is
+            ``scipy.take(x.shape, axes, axis=0)``.
+           If ``s[i] > x.shape[i]``, the ith dimension is padded with zeros.
+           If ``s[i] < x.shape[i]``, the ith dimension is truncated to length
+           ``s[i]``.
+           If any element of `s` is -1, the size of the corresponding dimension
+           of `x` is used. (Default value = None)
+        axes (int or array_like of ints or None, optional): Axes over which the
+           DCT is computed. If not given, the last ``len(s)`` axes are used, or
+           all axes if `s` is also not specified. (Default value = None)
+        norm ({None, 'ortho'}, optional): Normalization mode (see Notes).
+           Default is None.
+        overwrite_x (bool, optional, optional): If True, the contents of `x`
+           can be destroyed; the default is False.
+
+    Returns:
+      ndarray of real: The transformed input array.
+
+    See Also
+    --------
+    dctn : multidimensional DCT
+
+    Notes
+    -----
+    For full details of the IDCT types and normalization modes, as well as
+    references, see `idct`.
+    """
+    if x.dtype.kind == "c":
+        # separable application on real and imaginary parts
+        out = idctn(x.real, type, s, axes, norm, overwrite_x)
+        out = out + 1j * idctn(x.imag, type, s, axes, norm, overwrite_x)
+        return out
+
+    shape, axes = _init_nd_shape_and_axes(x, s, axes)
+    x = _promote_dtype(x)
+
+    if len(axes) == 0:
+        return x
+
+    for n, axis in zip(shape, axes):
+        x = idct(
+            x, type=type, n=n, axis=axis, norm=norm, overwrite_x=overwrite_x
+        )
+    return x
+
+
+def dstn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False):
+    """Compute a multidimensional Discrete Sine Transform.
+
+    Args:
+        x (array_like): The input array.
+        type ({1, 2, 3, 4}, optional): Type of the DST (see Notes).
+            Default type is 2. Only types 2 and 3 are currently supported by
+            CuPy.
+        s (int or array_like of ints or None, optional): The shape of the
+            result. If both `s` and `axes` (see below) are None, `s` is
+            ``x.shape``; if `s` is None but `axes` is not None, then `s` is
+            ``scipy.take(x.shape, axes, axis=0)``.
+           If ``s[i] > x.shape[i]``, the ith dimension is padded with zeros.
+           If ``s[i] < x.shape[i]``, the ith dimension is truncated to length
+           ``s[i]``.
+           If any element of `s` is -1, the size of the corresponding dimension
+           of `x` is used. (Default value = None)
+        axes (int or array_like of ints or None, optional): Axes over which the
+           DST is computed. If not given, the last ``len(s)`` axes are used, or
+           all axes if `s` is also not specified. (Default value = None)
+        norm ({None, 'ortho'}, optional): Normalization mode (see Notes).
+           Default is None.
+        overwrite_x (bool, optional, optional): If True, the contents of `x`
+           can be destroyed; the default is False.
+
+    Returns:
+        ndarray of real: The transformed input array.
+
+    See Also
+    --------
+    idstn : Inverse multidimensional DST
+
+    Notes
+    -----
+    For full details of the DST types and normalization modes, as well as
+    references, see `dst`.
+    """
+    if x.dtype.kind == "c":
+        # separable application on real and imaginary parts
+        out = dstn(x.real, type, s, axes, norm, overwrite_x)
+        out = out + 1j * dstn(x.imag, type, s, axes, norm, overwrite_x)
+        return out
+
+    shape, axes = _init_nd_shape_and_axes(x, s, axes)
+    x = _promote_dtype(x)
+
+    if len(axes) == 0:
+        return x
+
+    for n, axis in zip(shape, axes):
+        x = dst(
+            x, type=type, n=n, axis=axis, norm=norm, overwrite_x=overwrite_x
+        )
+    return x
+
+
+def idstn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False):
+    """Compute a multidimensional Discrete Sine Transform.
+
+    Args:
+        x (array_like): The input array.
+        type ({1, 2, 3, 4}, optional): Type of the DST (see Notes).
+            Default type is 2. Only types 2 and 3 are currently supported by
+            CuPy.
+        s (int or array_like of ints or None, optional): The shape of the
+            result. If both `s` and `axes` (see below) are None, `s` is
+            ``x.shape``; if `s` is None but `axes` is not None, then `s` is
+            ``scipy.take(x.shape, axes, axis=0)``.
+           If ``s[i] > x.shape[i]``, the ith dimension is padded with zeros.
+           If ``s[i] < x.shape[i]``, the ith dimension is truncated to length
+           ``s[i]``.
+           If any element of `s` is -1, the size of the corresponding dimension
+           of `x` is used. (Default value = None)
+        axes (int or array_like of ints or None, optional): Axes over which the
+           DST is computed. If not given, the last ``len(s)`` axes are used, or
+           all axes if `s` is also not specified. (Default value = None)
+        norm ({None, 'ortho'}, optional): Normalization mode (see Notes).
+           Default is None.
+        overwrite_x (bool, optional, optional): If True, the contents of `x`
+           can be destroyed; the default is False.
+
+    Returns:
+        ndarray of real: The transformed input array.
+
+    See Also
+    --------
+    dstn : multidimensional DST
+
+    Notes
+    -----
+    For full details of the IDST types and normalization modes, as well as
+    references, see `idst`.
+    """
+    if x.dtype.kind == "c":
+        # separable application on real and imaginary parts
+        out = idstn(x.real, type, s, axes, norm, overwrite_x)
+        out = out + 1j * idstn(x.imag, type, s, axes, norm, overwrite_x)
+        return out
+
+    shape, axes = _init_nd_shape_and_axes(x, s, axes)
+    x = _promote_dtype(x)
+
+    if len(axes) == 0:
+        return x
+
+    for n, axis in zip(shape, axes):
+        x = idst(
+            x, type=type, n=n, axis=axis, norm=norm, overwrite_x=overwrite_x
+        )
+    return x

--- a/docs/source/reference/scipy_fft.rst
+++ b/docs/source/reference/scipy_fft.rst
@@ -32,6 +32,20 @@ Fast Fourier Transforms (FFTs)
    hfftn
    ihfftn
 
+Discrete Cosine and Sine Transforms (DST and DCT)
+-------------------------------------------------
+
+.. autosummary::
+   :toctree: generated/
+
+   dct
+   idct
+   dctn
+   idctn
+   dst
+   idst
+   dstn
+   idstn
 
 Helper functions
 ----------------
@@ -48,7 +62,7 @@ Helper functions
 
 Code compatibility features
 ---------------------------
-1. As with other FFT modules in CuPy, FFT functions in this module can take advantage of an existing cuFFT plan (returned by :func:`~cupyx.scipy.fftpack.get_fft_plan`) to accelarate the computation. The plan can be either passed in explicitly via the keyword-only ``plan`` argument or used as a context manager.
+1. As with other FFT modules in CuPy, FFT functions in this module can take advantage of an existing cuFFT plan (returned by :func:`~cupyx.scipy.fftpack.get_fft_plan`) to accelerate the computation. The plan can be either passed in explicitly via the keyword-only ``plan`` argument or used as a context manager. One exception to this are the DCT and DST transforms, which do not currently support a plan argument.
 
 2. The boolean switch ``cupy.fft.config.enable_nd_planning`` also affects the FFT functions in this module, see :doc:`./fft`. This switch is neglected when planning manually using :func:`~cupyx.scipy.fftpack.get_fft_plan`.
 
@@ -57,3 +71,5 @@ Code compatibility features
 4. The ``cupyx.scipy.fft`` module can also be used as a backend for ``scipy.fft`` e.g. by installing with ``scipy.fft.set_backend(cupyx.scipy.fft)``. This can allow ``scipy.fft`` to work with both ``numpy`` and ``cupy`` arrays. For more information, see :ref:`scipy_fft_backend`.
 
 5. The boolean switch :data:`cupy.fft.config.use_multi_gpus` also affects the FFT functions in this module, see :doc:`./fft`. Moreover, this switch is *honored* when planning manually using :func:`~cupyx.scipy.fftpack.get_fft_plan`.
+
+6. Both type II and III DCT and DST transforms are implemented. Type I and IV transforms are currently unavailable.

--- a/tests/cupyx_tests/scipy_tests/fft_tests/test_realtransforms.py
+++ b/tests/cupyx_tests/scipy_tests/fft_tests/test_realtransforms.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pytest
-import scipy
 
 import cupyx.scipy.fft  # noqa
 from cupyx.scipy import fft as cp_fft

--- a/tests/cupyx_tests/scipy_tests/fft_tests/test_realtransforms.py
+++ b/tests/cupyx_tests/scipy_tests/fft_tests/test_realtransforms.py
@@ -33,6 +33,7 @@ else:
             'axis': [-1, 0],
             'norm': ['ortho'],
             'overwrite_x': [False],
+            'function': ['dct', 'dst', 'idct', 'idst'],
         }
     )
     # test all overwrite_x and norm combinations on a smaller subset of shapes
@@ -44,6 +45,7 @@ else:
             'axis': [-1, 0],
             'norm': all_dct_norms,
             'overwrite_x': [False, True],
+            'function': ['dct', 'dst', 'idct', 'idst'],
         }
     )
 
@@ -74,24 +76,22 @@ class TestDctDst():
             testing.assert_array_equal(x, x_orig)
         return out
 
-    @pytest.mark.parametrize('function', ['dct', 'dst', 'idct', 'idst'])
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(
         scipy_name='scp', rtol=1e-4, atol=1e-5, accept_error=ValueError,
         contiguous_check=False
     )
-    def test_dct(self, xp, scp, dtype, function):
-        fft_func = getattr(getattr(scp, 'fft'), function)
+    def test_dct(self, xp, scp, dtype):
+        fft_func = getattr(getattr(scp, 'fft'), self.function)
         return self._run_transform(fft_func, xp, dtype)
 
-    @pytest.mark.parametrize('function', ['dct', 'dst', 'idct', 'idst'])
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-5, accept_error=ValueError,
                                  contiguous_check=False)
-    def test_dct_backend(self, xp, dtype, function):
+    def test_dct_backend(self, xp, dtype):
         backend = 'scipy' if xp is np else cp_fft
         with scipy_fft.set_backend(backend):
-            fft_func = getattr(scipy_fft, function)
+            fft_func = getattr(scipy_fft, self.function)
             return self._run_transform(fft_func, xp, dtype)
 
 
@@ -105,8 +105,9 @@ class TestDctDst():
                 # Note: non-integer s or s == 0 will cause a ValueError
                 's': [None, (1, 5), (-1, -1), (0, 5), (1.5, 2.5)],
                 'axes': [None, (-2, -1), (-1, -2), (0,)],
-                'norm': [None, 'ortho'],
-                'overwrite_x': [True, False],
+                'norm': ['ortho'],
+                'overwrite_x': [False],
+                'function': ['dctn', 'dstn', 'idctn', 'idstn'],
             }
         )
         # 3D cases
@@ -118,8 +119,9 @@ class TestDctDst():
                 #       len(s) > ndim raises a ValueError
                 's': [None, (1, 5), (1, 4, 10), (2, 2, 2, 2)],
                 'axes': [None, (-2, -1), (-1, -2, -3)],
-                'norm': [None, 'ortho'],
-                'overwrite_x': [True, False],
+                'norm': ['ortho'],
+                'overwrite_x': [False],
+                'function': ['dctn', 'dstn', 'idctn', 'idstn'],
             }
         )
         # 4D cases
@@ -128,9 +130,10 @@ class TestDctDst():
                 'shape': [(2, 3, 4, 5)],
                 'type': [2, 3],
                 's': [None],
-                'axes': [None, (0, 1, 2, 3)],
-                'norm': [None, 'ortho'],
+                'axes': [None],
+                'norm': all_dct_norms,
                 'overwrite_x': [True, False],
+                'function': ['dctn', 'dstn', 'idctn', 'idstn'],
             }
         )
     )
@@ -157,22 +160,20 @@ class TestDctnDstn():
             testing.assert_array_equal(x, x_orig)
         return out
 
-    @pytest.mark.parametrize('function', ['dctn', 'dstn', 'idctn', 'idstn'])
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(
         scipy_name='scp', rtol=1e-4, atol=1e-5, accept_error=ValueError,
         contiguous_check=False
     )
-    def test_dctn(self, xp, scp, dtype, function):
-        fft_func = getattr(getattr(scp, 'fft'), function)
+    def test_dctn(self, xp, scp, dtype):
+        fft_func = getattr(getattr(scp, 'fft'), self.function)
         return self._run_transform(fft_func, xp, dtype)
 
-    @pytest.mark.parametrize('function', ['dctn', 'dstn', 'idctn', 'idstn'])
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-5, accept_error=ValueError,
                                  contiguous_check=False)
-    def test_dctn_backend(self, xp, dtype, function):
+    def test_dctn_backend(self, xp, dtype):
         backend = 'scipy' if xp is np else cp_fft
         with scipy_fft.set_backend(backend):
-            fft_func = getattr(scipy_fft, function)
+            fft_func = getattr(scipy_fft, self.function)
             return self._run_transform(fft_func, xp, dtype)

--- a/tests/cupyx_tests/scipy_tests/fft_tests/test_realtransforms.py
+++ b/tests/cupyx_tests/scipy_tests/fft_tests/test_realtransforms.py
@@ -1,0 +1,133 @@
+import pytest
+import scipy
+
+import cupyx.scipy.fft  # noqa
+from cupy import testing
+
+try:
+    # scipy.fft is available since scipy v1.4.0+
+    import scipy.fft  # noqa
+except ImportError:
+    pass
+
+# used to avoid SciPy bug in complex dtype cases with output_x=True
+# https://github.com/scipy/scipy/pull/11904
+scipy_cplx_bug = not cupyx.scipy.fft._scipy_150
+
+
+@testing.parameterize(
+    *testing.product(
+        {
+            "n": [None, 0, 5, 10, 15],
+            "type": [2, 3],
+            "shape": [(9,), (10,), (10, 9), (10, 10)],
+            "axis": [-1, 0],
+            "norm": [None, "ortho"],
+            "overwrite_x": [True, False],
+        }
+    )
+)
+@testing.gpu
+@testing.with_requires('scipy>=1.4')
+class TestDctDst():
+
+    def _run_transform(self, dct_func, xp, dtype):
+        x = testing.shaped_random(self.shape, xp, dtype)
+        if scipy_cplx_bug and x.dtype.kind == "c":
+            # skip cases where SciPy has a bug
+            return x
+        x_orig = x.copy()
+        out = dct_func(
+            x,
+            type=self.type,
+            n=self.n,
+            axis=self.axis,
+            norm=self.norm,
+            overwrite_x=self.overwrite_x,
+        )
+        if not self.overwrite_x:
+            testing.assert_array_equal(x, x_orig)
+        return out
+
+    @pytest.mark.parametrize('function', ['dct', 'dst', 'idct', 'idst'])
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose(
+        scipy_name="scp", rtol=1e-4, atol=1e-5, accept_error=ValueError,
+        contiguous_check=False
+    )
+    def test_dct(self, xp, scp, dtype, function):
+        fft_func = getattr(getattr(scp, 'fft'), function)
+        return self._run_transform(fft_func, xp, dtype)
+
+
+@testing.parameterize(
+    *(
+        # 2D cases
+        testing.product(
+            {
+                "shape": [(3, 4)],
+                "type": [2, 3],
+                # Note: non-integer s or s == 0 will cause a ValueError
+                "s": [None, (1, 5), (-1, -1), (0, 5), (1.5, 2.5)],
+                "axes": [None, (-2, -1), (-1, -2), (0,)],
+                "norm": [None, "ortho"],
+                "overwrite_x": [True, False],
+            }
+        )
+        # 3D cases
+        + testing.product(
+            {
+                "shape": [(2, 3, 4)],
+                "type": [2, 3],
+                # Note: len(s) < ndim is allowed
+                #       len(s) > ndim raises a ValueError
+                "s": [None, (1, 5), (1, 4, 10), (2, 2, 2, 2)],
+                "axes": [None, (-2, -1), (-1, -2, -3)],
+                "norm": [None, "ortho"],
+                "overwrite_x": [True, False],
+            }
+        )
+        # 4D cases
+        + testing.product(
+            {
+                "shape": [(2, 3, 4, 5)],
+                "type": [2, 3],
+                "s": [None],
+                "axes": [None, (0, 1, 2, 3)],
+                "norm": [None, "ortho"],
+                "overwrite_x": [True, False],
+            }
+        )
+    )
+)
+@testing.gpu
+@testing.with_requires('scipy>=1.4')
+class TestDctnDstn():
+
+    def _run_transform(self, dct_func, xp, dtype):
+        x = testing.shaped_random(self.shape, xp, dtype)
+        if scipy_cplx_bug and x.dtype.kind == "c":
+            # skip cases where SciPy has a bug
+            return x
+        x_orig = x.copy()
+        out = dct_func(
+            x,
+            type=self.type,
+            s=self.s,
+            axes=self.axes,
+            norm=self.norm,
+            overwrite_x=self.overwrite_x,
+        )
+        if not self.overwrite_x:
+            testing.assert_array_equal(x, x_orig)
+        return out
+
+    @pytest.mark.parametrize('function', ['dctn', 'dstn', 'idctn', 'idstn'])
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose(
+        scipy_name="scp", rtol=1e-4, atol=1e-5, accept_error=ValueError,
+        contiguous_check=False
+    )
+    def test_dctn(self, xp, scp, dtype, function):
+        fft_func = getattr(getattr(scp, 'fft'), function)
+        return self._run_transform(fft_func, xp, dtype)

--- a/tests/cupyx_tests/scipy_tests/fft_tests/test_realtransforms.py
+++ b/tests/cupyx_tests/scipy_tests/fft_tests/test_realtransforms.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pytest
 
-import cupyx.scipy.fft  # noqa
 from cupyx.scipy import fft as cp_fft
 from cupy import testing
 
@@ -10,13 +9,12 @@ try:
     import scipy.fft as scipy_fft  # noqa
 except ImportError:
     scipy_fft = None
-    pass
 
 # used to avoid SciPy bug in complex dtype cases with output_x=True
 # https://github.com/scipy/scipy/pull/11904
-scipy_cplx_bug = not cupyx.scipy.fft._scipy_150
+scipy_cplx_bug = not cp_fft._scipy_150
 
-if cupyx.scipy.fft._scipy_160:
+if cp_fft._scipy_160:
     # additional normalization options available for SciPy>=1.6
     all_dct_norms = [None, 'ortho', 'forward', 'backward']
 else:
@@ -47,11 +45,9 @@ else:
             'function': ['dct', 'dst', 'idct', 'idst'],
         }
     )
-
 )
-@testing.gpu
 @testing.with_requires('scipy>=1.4')
-class TestDctDst():
+class TestDctDst:
 
     def _run_transform(self, dct_func, xp, dtype):
         x = testing.shaped_random(self.shape, xp, dtype)
@@ -81,7 +77,7 @@ class TestDctDst():
         contiguous_check=False
     )
     def test_dct(self, xp, scp, dtype):
-        fft_func = getattr(getattr(scp, 'fft'), self.function)
+        fft_func = getattr(scp.fft, self.function)
         return self._run_transform(fft_func, xp, dtype)
 
     @testing.for_all_dtypes()
@@ -137,7 +133,6 @@ class TestDctDst():
         )
     )
 )
-@testing.gpu
 @testing.with_requires('scipy>=1.4')
 class TestDctnDstn():
 
@@ -165,7 +160,7 @@ class TestDctnDstn():
         contiguous_check=False
     )
     def test_dctn(self, xp, scp, dtype):
-        fft_func = getattr(getattr(scp, 'fft'), self.function)
+        fft_func = getattr(scp.fft, self.function)
         return self._run_transform(fft_func, xp, dtype)
 
     @testing.for_all_dtypes()


### PR DESCRIPTION
This PR implements type II and III DCT and DST transforms. Since the corresponding real-to-real transforms are not implemented in cuFFT, the implementations here rely on manipulating the output of standard FFTs of equivalent length (see the references at the top of `_realtransforms.py` in this PR). This is a bit less efficient than if cuFFT supplied these transforms directly, but will still be fast relative to a CPU-based implementation. 

cc @IvanYashchuk for awareness
