### PR TITLE
BUG: Fix the .T attribute in the `array_api` namespace

### DIFF
--- a/cupy/array_api/_array_object.py
+++ b/cupy/array_api/_array_object.py
@@ -1097,4 +1097,4 @@ class Array:
         # https://data-apis.org/array-api/latest/API_specification/array_object.html#t
         if self.ndim != 2:
             raise ValueError("x.T requires x to have 2 dimensions. Use x.mT to transpose stacks of matrices and permute_dims() to permute dimensions.")
-        return self._array.T
+        return self.__class__._new(self._array.T)

--- a/tests/cupy_tests/array_api_tests/test_array_object.py
+++ b/tests/cupy_tests/array_api_tests/test_array_object.py
@@ -17,6 +17,7 @@ from cupy.array_api._dtypes import (
     int64,
     uint64,
 )
+from cupy.array_api._array_object import Array
 
 
 def test_validate_index():
@@ -290,3 +291,17 @@ def test_python_scalar_construtors():
 
     assert_raises(TypeError, lambda: operator.index(b))
     assert_raises(TypeError, lambda: operator.index(f))
+
+
+def test_array_properties():
+    a = ones((1, 2, 3))
+    b = ones((2, 3))
+    assert_raises(ValueError, lambda: a.T)
+
+    assert isinstance(b.T, Array)
+    assert b.T.shape == (3, 2)
+
+    assert isinstance(a.mT, Array)
+    assert a.mT.shape == (1, 3, 2)
+    assert isinstance(b.mT, Array)
+    assert b.mT.shape == (3, 2)


### PR DESCRIPTION
Stay in sync with NumPy here: https://github.com/numpy/numpy/commit/eb865fa4683bca9a9d7c840f8addd30e39b62f5b

Ports https://github.com/numpy/numpy/pull/20499 to `cupy.array_api`

CC @asmeurer