### PR TITLE
add logit, expit and log_expit to cupyx.scipy.special

### DIFF
--- a/cupyx/scipy/special/__init__.py
+++ b/cupyx/scipy/special/__init__.py
@@ -7,7 +7,11 @@ from cupyx.scipy.special._bessel import y0  # NOQA
 from cupyx.scipy.special._bessel import y1  # NOQA
 
 # Raw statistical functions
+
 from cupyx.scipy.special._statistics import ndtr  # NOQA
+from cupyx.scipy.special._statistics import logit  # NOQA
+from cupyx.scipy.special._statistics import expit  # NOQA
+from cupyx.scipy.special._statistics import log_expit  # NOQA
 
 # Information Theory functions
 from cupyx.scipy.special._convex_analysis import entr  # NOQA

--- a/cupyx/scipy/special/_statistics.py
+++ b/cupyx/scipy/special/_statistics.py
@@ -88,7 +88,7 @@ log_expit = _core.create_ufunc(
     Returns:
         cupy.ndarray: values of log(expit(x))
 
-    .. seealso:: :data:`scipy.special.expit`
+    .. seealso:: :data:`scipy.special.log_expit`
 
     .. note::
         The function is mathematically equivalent to ``log(expit(x))``, but

--- a/cupyx/scipy/special/_statistics.py
+++ b/cupyx/scipy/special/_statistics.py
@@ -1,6 +1,102 @@
 from cupy import _core
 
 
+logit_definition = """
+template <typename T>
+static __device__ T logit(T x) {
+    x /= 1 - x;
+    return log(x);
+}
+
+"""
+
+
+logit = _core.create_ufunc(
+    'cupy_logit',
+    ('e->f', 'f->f', 'd->d'),
+    'out0 = logit(in0)',
+    preamble=logit_definition,
+    doc='''Logit function.
+
+    Args:
+        x (cupy.ndarray): input data
+
+    Returns:
+        cupy.ndarray: values of logit(x)
+
+    .. seealso:: :data:`scipy.special.logit`
+
+    ''')
+
+
+expit_definition = """
+template <typename T>
+static __device__ T expit(T x) {
+    return 1 / (1 + exp(-x));
+}
+
+"""
+
+
+expit = _core.create_ufunc(
+    'cupy_expit',
+    ('e->f', 'f->f', 'd->d'),
+    'out0 = expit(in0)',
+    preamble=expit_definition,
+    doc='''Logistic sigmoid function (expit).
+
+    Args:
+        x (cupy.ndarray): input data (must be real)
+
+    Returns:
+        cupy.ndarray: values of expit(x)
+
+    .. seealso:: :data:`scipy.special.expit`
+
+    .. note::
+        expit is the inverse of logit.
+
+    ''')
+
+
+# log_expit implemented based on log1p as in SciPy's scipy/special/_logit.h
+
+log_expit_definition = """
+template <typename T>
+static __device__ T log_expit(T x)
+{
+    if (x < 0.0) {
+        return x - log1p(exp(x));
+    } else {
+        return -log1p(exp(-x));
+    }
+}
+
+"""
+
+
+log_expit = _core.create_ufunc(
+    'cupy_log_expit',
+    ('e->f', 'f->f', 'd->d'),
+    'out0 = log_expit(in0)',
+    preamble=log_expit_definition,
+    doc='''Logarithm of the logistic sigmoid function.
+
+    Args:
+        x (cupy.ndarray): input data (must be real)
+
+    Returns:
+        cupy.ndarray: values of log(expit(x))
+
+    .. seealso:: :data:`scipy.special.expit`
+
+    .. note::
+        The function is mathematically equivalent to ``log(expit(x))``, but
+        is formulated to avoid loss of precision for inputs with large
+        (positive or negative) magnitude.
+    ''')
+
+
 ndtr = _core.create_ufunc(
     'cupyx_scipy_special_ndtr', ('f->f', 'd->d'),
     'out0 = normcdf(in0)',

--- a/docs/source/reference/scipy_special.rst
+++ b/docs/source/reference/scipy_special.rst
@@ -28,6 +28,9 @@ Raw statistical functions
    :toctree: generated/
 
    ndtr
+   logit
+   expit
+   log_expit
 
 
 Information Theory functions

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_statistics.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_statistics.py
@@ -1,8 +1,10 @@
 import unittest
 
+import numpy
+
 import cupy
 from cupy import testing
-import cupyx.scipy.special  # NOQA
+import cupyx.scipy.special
 
 
 class _TestBase(object):
@@ -10,27 +12,65 @@ class _TestBase(object):
     def test_ndtr(self):
         self.check_unary('ndtr')
 
+    def test_expit(self):
+        self.check_unary_lower_precision('expit')
+
+    @testing.with_requires('scipy>=1.8.0rc0')
+    def test_log_expit(self):
+        self.check_unary_lower_precision('log_expit')
+
+
+atol = {'default': 1e-15, cupy.float64: 1e-15}
+rtol = {'default': 1e-5, cupy.float64: 1e-15}
+
+# not all functions pass at the stricter tolerances above
+atol_low = {'default': 5e-4, cupy.float64: 1e-12}
+rtol_low = {'default': 5e-4, cupy.float64: 1e-12}
+
 
 @testing.gpu
 @testing.with_requires('scipy')
 class TestSpecial(unittest.TestCase, _TestBase):
 
-    @testing.for_dtypes(['e', 'f', 'd'])
-    @testing.numpy_cupy_allclose(atol=1e-5, scipy_name='scp')
-    def check_unary(self, name, xp, scp, dtype):
+    def _check_unary(self, name, xp, scp, dtype):
         import scipy.special  # NOQA
 
-        a = testing.shaped_arange((2, 3), xp, dtype)
+        a = xp.linspace(-10, 10, 100, dtype=dtype)
         return getattr(scp.special, name)(a)
+
+    @testing.for_dtypes(['e', 'f', 'd'])
+    @testing.numpy_cupy_allclose(atol=atol, rtol=rtol, scipy_name='scp')
+    def check_unary(self, name, xp, scp, dtype):
+        return self._check_unary(name, xp, scp, dtype)
+
+    @testing.for_dtypes(['e', 'f', 'd'])
+    @testing.numpy_cupy_allclose(atol=atol_low, rtol=rtol_low,
+                                 scipy_name='scp')
+    def check_unary_lower_precision(self, name, xp, scp, dtype):
+        return self._check_unary(name, xp, scp, dtype)
+
+    @testing.for_dtypes(['e', 'f', 'd'])
+    @testing.numpy_cupy_allclose(atol=atol_low, rtol=rtol_low,
+                                 scipy_name='scp')
+    def test_logit(self, xp, scp, dtype):
+        import scipy.special  # NOQA
+
+        # outputs are only finite over range (0, 1)
+        a = xp.linspace(0.001, .999, 1000, dtype=dtype)
+        return scp.special.logit(a)
+
+    def test_logit_nonfinite(self):
+        assert float(cupyx.scipy.special.logit(0)) == -numpy.inf
+        assert float(cupyx.scipy.special.logit(1)) == numpy.inf
+        assert numpy.isnan(float(cupyx.scipy.special.logit(1.1)))
+        assert numpy.isnan(float(cupyx.scipy.special.logit(-0.1)))
 
 
 @testing.gpu
 @testing.with_requires('scipy')
 class TestFusionSpecial(unittest.TestCase, _TestBase):
 
-    @testing.for_dtypes(['e', 'f', 'd'])
-    @testing.numpy_cupy_allclose(atol=1e-5, scipy_name='scp')
-    def check_unary(self, name, xp, scp, dtype):
+    def _check_unary(self, name, xp, scp, dtype):
         import scipy.special  # NOQA
 
         a = testing.shaped_arange((2, 3), xp, dtype)
@@ -40,3 +80,14 @@ class TestFusionSpecial(unittest.TestCase, _TestBase):
             return getattr(scp.special, name)(x)
 
         return f(a)
+
+    @testing.for_dtypes(['e', 'f', 'd'])
+    @testing.numpy_cupy_allclose(atol=atol, rtol=rtol, scipy_name='scp')
+    def check_unary(self, name, xp, scp, dtype):
+        return self._check_unary(name, xp, scp, dtype)
+
+    @testing.for_dtypes(['e', 'f', 'd'])
+    @testing.numpy_cupy_allclose(atol=atol_low, rtol=rtol_low,
+                                 scipy_name='scp')
+    def check_unary_lower_precision(self, name, xp, scp, dtype):
+        return self._check_unary(name, xp, scp, dtype)


### PR DESCRIPTION
This PR adds three very simple statistical functions to `cupyx.scipy.special`. This PR is built on top of #5687 to avoid conflicts with the changes to `__init__.py` made there. Only the last commit here is new.

cc @IvanYashchuk 
