### PR TITLE
add xlogy and xlog1py to cupyx.scipy.special

### DIFF
--- a/cupyx/scipy/special/__init__.py
+++ b/cupyx/scipy/special/__init__.py
@@ -45,3 +45,5 @@ from cupyx.scipy.special._zeta import zeta  # NOQA
 
 # Convenience functions
 from cupyx.scipy.special._gammainc import log1p  # NOQA
+from cupyx.scipy.special._xlogy import xlogy  # NOQA
+from cupyx.scipy.special._xlogy import xlog1py  # NOQA

--- a/cupyx/scipy/special/_xlogy.py
+++ b/cupyx/scipy/special/_xlogy.py
@@ -1,0 +1,68 @@
+from cupy import _core
+
+
+# Note: complex-valued isnan, log and log1p are all defined in
+#       cupy/_core/include/cupy/complex.cuh
+xlogy_definition = """
+
+template <typename T>
+static __device__ T xlogy(T x, T y) {
+    if ((x == (T)0.0) && ~isnan(y)) {
+        return (T)0.0;
+    } else {
+        return x * log(y);
+    }
+}
+
+"""
+
+
+# Note: SciPy only defines dd->d and DD->D
+xlogy = _core.create_ufunc(
+    'cupy_xlogy',
+    ('ee->f', 'ff->f', 'dd->d', 'FF->F', 'DD->D'),
+    'out0 = out0_type(xlogy(in0, in1));',
+    preamble=xlogy_definition,
+    doc='''Compute ``x*log(y)`` so that the result is 0 if ``x = 0``.
+
+    Args:
+        x (cupy.ndarray): input data
+
+    Returns:
+        cupy.ndarray: values of ``x * log(y)``
+
+    .. seealso:: :data:`scipy.special.xlogy`
+
+    ''')
+
+
+xlog1py_definition = """
+
+template <typename T>
+static __device__ T xlog1py(T x, T y) {
+    if ((x == (T)0.0) && ~isnan(y)) {
+        return (T)0.0;
+    } else {
+        return x * log1p(y);
+    }
+}
+
+"""
+
+# Note: SciPy only defines dd->d and DD->D
+xlog1py = _core.create_ufunc(
+    'cupy_xlog1py',
+    ('ee->f', 'ff->f', 'dd->d', 'FF->F', 'DD->D'),
+    'out0 = out0_type(xlog1py(in0, in1));',
+    preamble=xlog1py_definition,
+    doc='''Compute ``x*log1p(y)`` so that the result is 0 if ``x = 0``.
+
+    Args:
+        x (cupy.ndarray): input data
+
+    Returns:
+        cupy.ndarray: values of ``x * log1p(y)``
+
+    .. seealso:: :data:`scipy.special.xlog1py`
+
+    ''')

--- a/cupyx/scipy/special/_xlogy.py
+++ b/cupyx/scipy/special/_xlogy.py
@@ -7,7 +7,7 @@ xlogy_definition = """
 
 template <typename T>
 static __device__ T xlogy(T x, T y) {
-    if ((x == (T)0.0) && ~isnan(y)) {
+    if ((x == (T)0.0) && !isnan(y)) {
         return (T)0.0;
     } else {
         return x * log(y);

--- a/docs/source/reference/scipy_special.rst
+++ b/docs/source/reference/scipy_special.rst
@@ -100,3 +100,5 @@ Convenience functions
    :toctree: generated/
 
    log1p
+   xlogy
+   xlog1py

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_basic.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_basic.py
@@ -84,7 +84,7 @@ class TestBasic:
             cupyx.scipy.special.log1p(0 + 0j)
 
     @pytest.mark.parametrize("function", ["xlogy", "xlog1py"])
-    @testing.for_float_dtypes()
+    @testing.for_dtypes('efdFD')
     @numpy_cupy_allclose(scipy_name="scp", rtol={'default': 1e-3,
                                                  cupy.float64: 1e-12})
     def test_xlogy(self, xp, scp, dtype, function):
@@ -97,7 +97,7 @@ class TestBasic:
         return getattr(scp.special, function)(x, y)
 
     @pytest.mark.parametrize("function", ["xlogy", "xlog1py"])
-    @testing.for_float_dtypes()
+    @testing.for_dtypes('efdFD')
     @numpy_cupy_allclose(scipy_name="scp", rtol={'default': 1e-3,
                                                  cupy.float64: 1e-12})
     def test_xlogy_zeros(self, xp, scp, dtype, function):

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_basic.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_basic.py
@@ -1,12 +1,11 @@
 import math
-import unittest
 
 import cupy
 import numpy
 import pytest
 import scipy.special  # NOQA
 
-import cupyx.scipy.special  # NOQA
+import cupyx.scipy.special
 from cupy import testing
 from cupy.testing import (
     assert_array_equal,
@@ -14,10 +13,12 @@ from cupy.testing import (
 )
 from cupy.testing import numpy_cupy_allclose
 
+rtol = {'default': 1e-5, cupy.float64: 1e-12}
+
 
 @testing.gpu
 @testing.with_requires("scipy")
-class TestLegendreFunctions():
+class TestLegendreFunctions:
 
     def test_lpmv_basic(self):
         # specific values tested in the SciPy test suite
@@ -47,7 +48,7 @@ class TestLegendreFunctions():
 
 @testing.gpu
 @testing.with_requires("scipy")
-class TestBasic(unittest.TestCase):
+class TestBasic:
     @testing.for_dtypes(["e", "f", "d"])
     @numpy_cupy_allclose(scipy_name="scp")
     def test_gammasgn(self, xp, scp, dtype):
@@ -55,14 +56,14 @@ class TestBasic(unittest.TestCase):
         return scp.special.gammasgn(vals)
 
     @testing.for_dtypes(["e", "f", "d"])
-    @numpy_cupy_allclose(scipy_name="scp", rtol=1e-6)
+    @numpy_cupy_allclose(scipy_name="scp", rtol=rtol)
     def test_log1p_(self, xp, scp, dtype):
         # only test with values > 0 to avoid NaNs
         vals = xp.logspace(-10, 10, 10000, dtype=dtype)
         return scp.special.log1p(vals)
 
     @testing.for_dtypes(["e", "f", "d"])
-    @numpy_cupy_allclose(scipy_name="scp", rtol=1e-6)
+    @numpy_cupy_allclose(scipy_name="scp", rtol=rtol)
     def test_log1p_path2(self, xp, scp, dtype):
         # test values for code path corresponding to range [1/sqrt(2), sqrt(2)]
         vals = xp.linspace(1 / math.sqrt(2), math.sqrt(2), 1000, dtype=dtype)
@@ -81,3 +82,36 @@ class TestBasic(unittest.TestCase):
         # complex-valued log1p not yet implemented
         with pytest.raises(TypeError):
             cupyx.scipy.special.log1p(0 + 0j)
+
+    @pytest.mark.parametrize("function", ["xlogy", "xlog1py"])
+    @testing.for_float_dtypes()
+    @numpy_cupy_allclose(scipy_name="scp", rtol={'default': 1e-3,
+                                                 cupy.float64: 1e-12})
+    def test_xlogy(self, xp, scp, dtype, function):
+        # only test with values > 0 to avoid NaNs
+        x = xp.linspace(-100, 100, 1000, dtype=dtype)
+        y = xp.linspace(0.001, 100, 1000, dtype=dtype)
+        if x.dtype.kind == 'c':
+            x -= 1j * x
+            y += 1j * y
+        return getattr(scp.special, function)(x, y)
+
+    @pytest.mark.parametrize("function", ["xlogy", "xlog1py"])
+    @testing.for_float_dtypes()
+    @numpy_cupy_allclose(scipy_name="scp", rtol={'default': 1e-3,
+                                                 cupy.float64: 1e-12})
+    def test_xlogy_zeros(self, xp, scp, dtype, function):
+        # only test with values > 0 to avoid NaNs
+        x = xp.zeros((1, 100), dtype=dtype)
+        y = xp.linspace(-10, 10, 100, dtype=dtype)
+        if y.dtype.kind == 'c':
+            y += 1j * y
+        return getattr(scp.special, function)(x, y)
+
+    @pytest.mark.parametrize("function", ["xlogy", "xlog1py"])
+    @testing.for_all_dtypes()
+    def test_xlogy_nonfinite(self, dtype, function):
+        func = getattr(cupyx.scipy.special, function)
+        y = cupy.ones((5,), dtype=dtype)
+        assert cupy.all(cupy.isnan(func(cupy.nan, y)))
+        assert cupy.all(cupy.isnan(func(y, cupy.nan)))


### PR DESCRIPTION
This PR adds a couple of simple convenience functions to `cupyx.scipy.special`. This PR is built on top of #5687 to avoid conflicts with the changes to `__init__.py` made there. Only the last commit here is new.

cc @IvanYashchuk 

There is one deviation from SciPy in that the templated implementation here also has a single precision code path, while SciPy itself always promotes to double (see [here](https://github.com/scipy/scipy/blob/main/scipy/special/_xlogy.pxd) where `number_t` is a fused type made up of `double` and `complex<double>`). When testing locally the float32 code path was 4-5 times faster on large arrays. 