### PR TITLE
Add `tril_indices` and `tril_indices_from` API.

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -397,6 +397,8 @@ from cupy._indexing.generate import c_  # NOQA
 from cupy._indexing.generate import indices  # NOQA
 from cupy._indexing.generate import ix_  # NOQA
 from cupy._indexing.generate import mask_indices  # NOQA
+from cupy._indexing.generate import tril_indices  # NOQA
+from cupy._indexing.generate import tril_indices_from  # NOQA
 from cupy._indexing.generate import r_  # NOQA
 from cupy._indexing.generate import ravel_multi_index  # NOQA
 from cupy._indexing.generate import unravel_index  # NOQA

--- a/cupy/_indexing/generate.py
+++ b/cupy/_indexing/generate.py
@@ -469,13 +469,11 @@ def mask_indices(n, mask_func, k=0):
 # TODO(okuta): Implement diag_indices_from
 
 
-# TODO(okuta): Implement mask_indices
-
-
 def tril_indices(n, k=0, m=None):
     """Returns the indices of the lower triangular matrix.
-    Here, the first row contains row coordinates of all indices and
-    the second row contains column coordinates.
+    Here, the first group of elements contains row coordinates
+    of all indices and the second group of elements
+    contains column coordinates.
 
     Parameters
     ----------
@@ -488,7 +486,7 @@ def tril_indices(n, k=0, m=None):
         below it and `k > 0` is above.
     m : int, optional
         The column dimension of the arrays for which the
-        returned arrays will be valid. By default, `m = 0`.
+        returned arrays will be valid. By default, `m = n`.
 
     Returns
     -------

--- a/cupy/_indexing/generate.py
+++ b/cupy/_indexing/generate.py
@@ -494,7 +494,7 @@ def tril_indices(n, k=0, m=None):
     .. seealso:: :func:`numpy.tril_indices`
     """
 
-    tri_ =  cupy.tri(n, m, k=k, dtype=bool)
+    tri_ = cupy.tri(n, m, k=k, dtype=bool)
 
     return tuple(cupy.broadcast_to(inds, tri_.shape)[tri_]
                  for inds in cupy.indices(tri_.shape, dtype=int))

--- a/cupy/_indexing/generate.py
+++ b/cupy/_indexing/generate.py
@@ -477,21 +477,30 @@ def tril_indices(n, k=0, m=None):
     Here, the first row contains row coordinates of all indices and
     the second row contains column coordinates.
 
-    Args:
-    n (int): The row dimension of the arrays for which the returned
-             indices will be valid.
-    k (int, optional): Diagonal above which to zero elements. `k = 0`
-                       (the default) is the main diagonal, `k < 0` is
-                       below it and `k > 0` is above.
-    m (int, optional): The column dimension of the arrays for which the
-                       returned arrays will be valid. By default, `m = 0`.
+    Parameters
+    ----------
+    n : int
+        The row dimension of the arrays for which the returned
+        indices will be valid.
+    k : int, optional
+        Diagonal above which to zero elements. `k = 0`
+        (the default) is the main diagonal, `k < 0` is
+        below it and `k > 0` is above.
+    m : int, optional
+        The column dimension of the arrays for which the
+        returned arrays will be valid. By default, `m = 0`.
 
-    Returns:
-        tuple of ndarrays: The indices for the triangle. The returned tuple
-                           contains two arrays, each with the indices along
-                           one dimension of the array.
+    Returns
+    -------
+    y : tuple of ndarrays
+        The indices for the triangle. The returned tuple
+        contains two arrays, each with the indices along
+        one dimension of the array.
 
-    .. seealso:: :func:`numpy.tril_indices`
+    See Also
+    --------
+    numpy.tril_indices
+
     """
 
     tri_ = cupy.tri(n, m, k=k, dtype=bool)
@@ -503,12 +512,18 @@ def tril_indices(n, k=0, m=None):
 def tril_indices_from(arr, k=0):
     """Returns the indices for the lower-triangle of arr.
 
-    Args:
-    arr (cupy.ndarray): The indices are valid for square arrays
-                        whose dimensions are the same as arr.
-    k (int, optional): Diagonal offset.
+    Parameters
+    ----------
+    arr : cupy.ndarray
+          The indices are valid for square arrays
+          whose dimensions are the same as arr.
+    k : int, optional
+        Diagonal offset.
 
-    .. seealso:: :func:`numpy.tril_indices_from`
+    See Also
+    --------
+    numpy.tril_indices_from
+
     """
 
     if arr.ndim != 2:

--- a/cupy/_indexing/generate.py
+++ b/cupy/_indexing/generate.py
@@ -472,10 +472,48 @@ def mask_indices(n, mask_func, k=0):
 # TODO(okuta): Implement mask_indices
 
 
-# TODO(okuta): Implement tril_indices
+def tril_indices(n, k=0, m=None):
+    """Returns the indices of the lower triangular matrix.
+    Here, the first row contains row coordinates of all indices and
+    the second row contains column coordinates.
+
+    Args:
+    n (int): The row dimension of the arrays for which the returned
+             indices will be valid.
+    k (int, optional): Diagonal above which to zero elements. `k = 0`
+                       (the default) is the main diagonal, `k < 0` is
+                       below it and `k > 0` is above.
+    m (int, optional): The column dimension of the arrays for which the
+                       returned arrays will be valid. By default, `m = 0`.
+
+    Returns:
+        tuple of ndarrays: The indices for the triangle. The returned tuple
+                           contains two arrays, each with the indices along
+                           one dimension of the array.
+
+    .. seealso:: :func:`numpy.tril_indices`
+    """
+
+    tri_ =  cupy.tri(n, m, k=k, dtype=bool)
+
+    return tuple(cupy.broadcast_to(inds, tri_.shape)[tri_]
+                 for inds in cupy.indices(tri_.shape, dtype=int))
 
 
-# TODO(okuta): Implement tril_indices_from
+def tril_indices_from(arr, k=0):
+    """Returns the indices for the lower-triangle of arr.
+
+    Args:
+    arr (cupy.ndarray): The indices are valid for square arrays
+                        whose dimensions are the same as arr.
+    k (int, optional): Diagonal offset.
+
+    .. seealso:: :func:`numpy.tril_indices_from`
+    """
+
+    if arr.ndim != 2:
+        raise ValueError("input array must be 2-d")
+    return tril_indices(arr.shape[-2], k=k, m=arr.shape[-1])
 
 
 # TODO(okuta): Implement triu_indices

--- a/docs/source/reference/indexing.rst
+++ b/docs/source/reference/indexing.rst
@@ -17,6 +17,8 @@ Generating index arrays
    where
    indices
    mask_indices
+   tril_indices
+   tril_indices_from
    ix_
    ravel_multi_index
    unravel_index

--- a/tests/cupy_tests/indexing_tests/test_generate.py
+++ b/tests/cupy_tests/indexing_tests/test_generate.py
@@ -315,18 +315,27 @@ class TestTrilIndices:
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_tril_indices_1(self, xp, dtype):
-        arr = testing.shaped_random((10, 10), xp=xp, dtype=dtype)
-        return xp.tril_indices(n=10, k=0)
+        return xp.tril_indices(n=29, k=0)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_tril_indices_2(self, xp, dtype):
-        arr = testing.shaped_random((10, 20), xp=xp, dtype=dtype)
-        return xp.tril_indices(n=5, k=4, m=4)
+        return xp.tril_indices(n=11, k=4, m=4)
 
     @testing.numpy_cupy_array_equal()
     def test_tril_indices_3(self, xp):
         return xp.tril_indices(n=4, k=4, m=3)
+
+    @testing.for_all_dtypes()
+    def test_tril_indices(self, dtype):
+        for xp in (numpy, cupy):
+            arr = testing.shaped_random((10, 10), xp=xp, dtype=dtype)
+            if xp is numpy:
+                error = ValueError
+            else:
+                error = TypeError
+            with pytest.raises(error):
+                xp.tril_indices(arr, k=0)
 
 
 @testing.gpu

--- a/tests/cupy_tests/indexing_tests/test_generate.py
+++ b/tests/cupy_tests/indexing_tests/test_generate.py
@@ -309,7 +309,6 @@ class TestMaskIndices:
         return xp.mask_indices(0, xp.triu)
 
 
-@testing.gpu
 class TestTrilIndices:
 
     @testing.for_all_dtypes()
@@ -338,7 +337,6 @@ class TestTrilIndices:
                 xp.tril_indices(arr, k=0)
 
 
-@testing.gpu
 class TestTrilIndicesForm:
 
     @testing.for_all_dtypes()

--- a/tests/cupy_tests/indexing_tests/test_generate.py
+++ b/tests/cupy_tests/indexing_tests/test_generate.py
@@ -307,3 +307,51 @@ class TestMaskIndices:
     @testing.numpy_cupy_array_equal()
     def test_empty(self, xp):
         return xp.mask_indices(0, xp.triu)
+
+
+@testing.gpu
+class TestTrilIndices:
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_tril_indices_1(self, xp, dtype):
+        arr = testing.shaped_random((10, 10), xp=xp, dtype=dtype)
+        return xp.tril_indices(n=10, k=0)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_tril_indices_2(self, xp, dtype):
+        arr = testing.shaped_random((10, 20), xp=xp, dtype=dtype)
+        return xp.tril_indices(n=5, k=4, m=4)
+
+    @testing.numpy_cupy_array_equal()
+    def test_tril_indices_3(self, xp):
+        return xp.tril_indices(n=4, k=4, m=3)
+
+
+@testing.gpu
+class TestTrilIndicesForm:
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_tril_indices_from_1(self, xp, dtype):
+        arr = testing.shaped_random((10, 10), xp=xp, dtype=dtype)
+        return xp.tril_indices_from(arr, k=4)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_tril_indices_from_2(self, xp, dtype):
+        arr = testing.shaped_random((10, 20), xp=xp, dtype=dtype)
+        return xp.tril_indices_from(arr, k=13)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_tril_indices_from_3(self, xp, dtype):
+        arr = testing.shaped_random((4, 6), xp=xp, dtype=dtype)
+        return xp.tril_indices_from(arr)
+
+    @testing.for_all_dtypes()
+    def test_tril_indices_from_4(self, dtype):
+        for xp in (numpy, cupy):
+            with pytest.raises(AttributeError):
+                xp.tril_indices_from(4, k=1)


### PR DESCRIPTION
Hi, Team!
The PR **aims** to add `cupy.tril_indices` and `cupy.tril_indices_from` API. It follows #6078.

Looking forward to your viewpoints :)
Thanks!

cc: @kmaehashi @takagi @leofang @asi1024  @toslunar 