### PR TITLE
Tentatively pin to CUDA Driver 495

### DIFF
--- a/.pfnci/linux/main-flexci.sh
+++ b/.pfnci/linux/main-flexci.sh
@@ -22,7 +22,7 @@ if [[ "${TARGET}" == cuda115* ]]; then
     if [[ $(dpkg -s cuda-drivers | grep Version: | cut -d ' ' -f 2) == 470.* ]]; then
         add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/ /"
         apt-get purge -qqy "cuda-drivers*" "*nvidia*-470"
-        apt-get install -qqy "cuda-drivers"
+        apt-get install -qqy "cuda-drivers-495"
         modprobe -r nvidia_drm nvidia_uvm nvidia_modeset nvidia
         nvidia-smi
     fi


### PR DESCRIPTION
It seems CUDA Driver 510 cannot be reloaded without reboot?

```
[  238.136623] NVRM: loading NVIDIA UNIX x86_64 Kernel Module  510.39.01  Fri Dec 31 11:03:22 UTC 2021
[  238.521491] NVRM: GPU 0000:00:04.0: RmInitAdapter failed! (0x63:0x55:2344)
[  238.522786] NVRM: GPU 0000:00:04.0: rm_init_adapter failed, device minor number 0
```