### PR TITLE
Use CUDA's log1p for cupyx.scipy.special.log1p

### DIFF
--- a/cupyx/scipy/special/__init__.py
+++ b/cupyx/scipy/special/__init__.py
@@ -44,4 +44,4 @@ from cupyx.scipy.special._sph_harm import sph_harm  # NOQA
 from cupyx.scipy.special._zeta import zeta  # NOQA
 
 # Convenience functions
-from cupyx.scipy.special._gammainc import log1p  # NOQA
+from cupyx.scipy.special._basic import log1p  # NOQA

--- a/cupyx/scipy/special/_basic.py
+++ b/cupyx/scipy/special/_basic.py
@@ -1,0 +1,19 @@
+from cupy import _core
+
+
+log1p = _core.create_ufunc(
+    "cupyx_scipy_log1p",
+    ("f->f", "d->d"),
+    "out0 = out0_type(log1p(in0));",
+    doc="""Elementwise function for scipy.special.log1p
+
+    Calculates log(1 + x) for use when `x` is near zero.
+
+    Notes
+    -----
+    This implementation currently does not support complex-valued `x`.
+
+    .. seealso:: :meth:`scipy.special.log1p`
+
+    """,
+)

--- a/cupyx/scipy/special/_basic.py
+++ b/cupyx/scipy/special/_basic.py
@@ -1,10 +1,13 @@
 from cupy import _core
 
 
+# Note: cast complex<single> to complex<double> or tests fail tolerance
 log1p = _core.create_ufunc(
-    "cupyx_scipy_log1p",
-    ("f->f", "d->d"),
-    "out0 = out0_type(log1p(in0));",
+    'cupyx_scipy_log1p',
+    (('f->f', 'out0 = log1pf(in0)'),
+     ('F->F', 'out0 = out0_type(log1p((complex<double>)in0))'),
+     'd->d', 'D->D'),
+    'out0 = log1p(in0);',
     doc="""Elementwise function for scipy.special.log1p
 
     Calculates log(1 + x) for use when `x` is near zero.

--- a/cupyx/scipy/special/_gammainc.py
+++ b/cupyx/scipy/special/_gammainc.py
@@ -1094,24 +1094,6 @@ __device__ double igami(double a, double p)
 )
 
 
-log1p = _core.create_ufunc(
-    "cupyx_scipy_log1p",
-    ("f->f", "d->d"),
-    "out0 = out0_type(log1p(in0));",
-    doc="""Elementwise function for scipy.special.log1p
-
-    Calculates log(1 + x) for use when `x` is near zero.
-
-    Notes
-    -----
-    This implementation currently does not support complex-valued `x`.
-
-    .. seealso:: :meth:`scipy.special.log1p`
-
-    """,
-)
-
-
 gammaincc = _core.create_ufunc(
     "cupyx_scipy_gammaincc",
     ("ff->f", "dd->d"),

--- a/cupyx/scipy/special/_gammainc.py
+++ b/cupyx/scipy/special/_gammainc.py
@@ -111,39 +111,6 @@ _unity_c_partial = (
     + """
 // part of cephes/unity.c
 
-__constant__ double LP[] = {
-    4.5270000862445199635215E-5,
-    4.9854102823193375972212E-1,
-    6.5787325942061044846969E0,
-    2.9911919328553073277375E1,
-    6.0949667980987787057556E1,
-    5.7112963590585538103336E1,
-    2.0039553499201281259648E1,
-};
-
-__constant__ double LQ[] = {
-    /* 1.0000000000000000000000E0, */
-    1.5062909083469192043167E1,
-    8.3047565967967209469434E1,
-    2.2176239823732856465394E2,
-    3.0909872225312059774938E2,
-    2.1642788614495947685003E2,
-    6.0118660497603843919306E1,
-};
-
-__device__ double log1p(double x)
-{
-    double z;
-
-    z = 1.0 + x;
-    if ((z < NPY_SQRT1_2) || (z > NPY_SQRT2))
-        return (log(z));
-    z = x * x;
-    z = -0.5 * z + x * (z * polevl<6>(x, LP) / p1evl<6>(x, LQ));
-    return (x + z);
-}
-
-
 /* log(1 + x) - x */
 __device__ double log1pmx(double x)
 {
@@ -1131,7 +1098,6 @@ log1p = _core.create_ufunc(
     "cupyx_scipy_log1p",
     ("f->f", "d->d"),
     "out0 = out0_type(log1p(in0));",
-    preamble=_misc_preamble + _unity_c_partial,
     doc="""Elementwise function for scipy.special.log1p
 
     Calculates log(1 + x) for use when `x` is near zero.


### PR DESCRIPTION
This PR addresses the following post-merge review comment: https://github.com/cupy/cupy/pull/5687#pullrequestreview-852497622

Thanks, @asi1024!

I benchmarked calling log1p on a vector with 10,000,000 elements both before and after this PR and performance was very similar either way. 

One question: 
It is a little suprising to me that float32 ends up running 6-7 times faster than float64 even though I there is no float32-specific code path.  Do any of you have insight into why this is? Does CuPy somehow use `log1pf` instead of `log1p` when the input is single precision? (I think I did find that some functions like `log` have complex support via Thrust, but wasn't sure if this also extends to single vs. double precision)
