### PR TITLE
Add `triu_indices` and `triu_indices_from` API.

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -397,6 +397,8 @@ from cupy._indexing.generate import c_  # NOQA
 from cupy._indexing.generate import indices  # NOQA
 from cupy._indexing.generate import ix_  # NOQA
 from cupy._indexing.generate import mask_indices  # NOQA
+from cupy._indexing.generate import triu_indices  # NOQA
+from cupy._indexing.generate import triu_indices_from  # NOQA
 from cupy._indexing.generate import r_  # NOQA
 from cupy._indexing.generate import ravel_multi_index  # NOQA
 from cupy._indexing.generate import unravel_index  # NOQA

--- a/cupy/_indexing/generate.py
+++ b/cupy/_indexing/generate.py
@@ -478,7 +478,66 @@ def mask_indices(n, mask_func, k=0):
 # TODO(okuta): Implement tril_indices_from
 
 
-# TODO(okuta): Implement triu_indices
+def triu_indices(n, k=0, m=None):
+    """Returns the indices of the upper triangular matrix.
+    Here, the first group of elements contains row coordinates
+    of all indices and the second group of elements
+    contains column coordinates.
+
+    Parameters
+    ----------
+    n : int
+        The size of the arrays for which the returned indices will
+        be valid.
+    k : int, optional
+        Refers to the diagonal offset. By default, `k = 0` i.e.
+        the main dialogal. The positive value of `k`
+        denotes the diagonals above the main diagonal, while the negative
+        value includes the diagonals below the main diagonal.
+    m : int, optional
+        The column dimension of the arrays for which the
+        returned arrays will be valid. By default, `m = n`.
+
+    Returns
+    -------
+    y : tuple of ndarrays
+        The indices for the triangle. The returned tuple
+        contains two arrays, each with the indices along
+        one dimension of the array.
+
+    See Also
+    --------
+    numpy.triu_indices
+
+    """
+
+    tri_ = ~cupy.tri(n, m, k=k - 1, dtype=bool)
+
+    return tuple(cupy.broadcast_to(inds, tri_.shape)[tri_]
+                 for inds in cupy.indices(tri_.shape, dtype=int))
 
 
-# TODO(okuta): Implement triu_indices_from
+def triu_indices_from(arr, k=0):
+    """Returns indices for the upper-triangle of arr.
+
+    Parameters
+    ----------
+    arr : cupy.ndarray
+          The indices are valid for square arrays.
+    k : int, optional
+        Diagonal offset (see 'triu_indices` for details).
+
+    Returns
+    -------
+    triu_indices_from : tuple of ndarrays
+        Indices for the upper-triangle of `arr`.
+
+    See Also
+    --------
+    numpy.triu_indices_from
+
+    """
+
+    if arr.ndim != 2:
+        raise ValueError("input array must be 2-d")
+    return triu_indices(arr.shape[-2], k=k, m=arr.shape[-1])

--- a/docs/source/reference/indexing.rst
+++ b/docs/source/reference/indexing.rst
@@ -17,6 +17,8 @@ Generating index arrays
    where
    indices
    mask_indices
+   triu_indices
+   triu_indices_from
    ix_
    ravel_multi_index
    unravel_index

--- a/tests/cupy_tests/indexing_tests/test_generate.py
+++ b/tests/cupy_tests/indexing_tests/test_generate.py
@@ -363,7 +363,7 @@ class TestTrilIndicesForm:
             with pytest.raises(AttributeError):
                 xp.tril_indices_from(4, k=1)
 
-                
+
 class TestTriuIndices:
 
     @testing.numpy_cupy_array_equal()

--- a/tests/cupy_tests/indexing_tests/test_generate.py
+++ b/tests/cupy_tests/indexing_tests/test_generate.py
@@ -307,3 +307,56 @@ class TestMaskIndices:
     @testing.numpy_cupy_array_equal()
     def test_empty(self, xp):
         return xp.mask_indices(0, xp.triu)
+
+
+class TestTriuIndices:
+
+    @testing.numpy_cupy_array_equal()
+    def test_triu_indices_1(self, xp):
+        return xp.triu_indices(n=10, k=0)
+
+    @testing.numpy_cupy_array_equal()
+    def test_triu_indices_2(self, xp):
+        return xp.triu_indices(n=23, k=3, m=4)
+
+    @testing.numpy_cupy_array_equal()
+    def test_triu_indices_3(self, xp):
+        return xp.triu_indices(n=4, k=4, m=4)
+
+    @testing.for_all_dtypes()
+    def test_triu_indices_4(self, dtype):
+        for xp in (numpy, cupy):
+            arr = testing.shaped_random((10, 10), xp=xp, dtype=dtype)
+            if xp is numpy:
+                error = ValueError
+            else:
+                error = TypeError
+            with pytest.raises(error):
+                xp.triu_indices(arr, k=0)
+
+
+class TestTriuIndicesFrom:
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_triu_indices_from_1(self, xp, dtype):
+        arr = testing.shaped_random((20, 20), xp=xp, dtype=dtype)
+        return xp.triu_indices_from(arr, k=11)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_triu_indices_from_2(self, xp, dtype):
+        arr = testing.shaped_random((20, 5), xp=xp, dtype=dtype)
+        return xp.triu_indices_from(arr, k=32)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_triu_indices_from_3(self, xp, dtype):
+        arr = testing.shaped_random((4, 6), xp=xp, dtype=dtype)
+        return xp.triu_indices_from(arr)
+
+    @testing.for_all_dtypes()
+    def test_tril_indices_from_4(self, dtype):
+        for xp in (numpy, cupy):
+            with pytest.raises(AttributeError):
+                xp.triu_indices_from(4, k=1)


### PR DESCRIPTION
Hi,
The PR **aims** to add `cupy.triu_indices` and `cupy_indices_from` API's. It follows #6078.
Looking forward to your viewpoints.
Thanks!
