### PR TITLE
avoid DeprecationWarning from SciPy 1.8 (`cupyx.scipy.sparse`)

### DIFF
--- a/cupyx/scipy/sparse/_index.py
+++ b/cupyx/scipy/sparse/_index.py
@@ -14,7 +14,7 @@ from cupy.cuda import runtime
 import numpy
 
 try:
-    import scipy
+    import scipy.sparse
     scipy_available = True
 except ImportError:
     scipy_available = False
@@ -564,7 +564,7 @@ class IndexMixin(object):
 
 def _try_is_scipy_spmatrix(index):
     if scipy_available:
-        return isinstance(index, scipy.sparse.base.spmatrix)
+        return isinstance(index, scipy.sparse.spmatrix)
     return False
 
 


### PR DESCRIPTION
This small change is to avoid a new `DeprecationWarning` I noticed when using SciPy 1.8.0rc2

```
DeprecationWarning: Please use `spmatrix` from the `scipy.sparse` namespace, the `scipy.sparse.base` namespace is deprecated.
  from scipy.sparse.base import spmatrix
```

