### PR TITLE
Fix JIT to support notebook environment

### DIFF
--- a/cupyx/jit/__init__.py
+++ b/cupyx/jit/__init__.py
@@ -28,5 +28,4 @@ from cupyx.jit._builtin_funcs import shfl_up_sync  # NOQA
 from cupyx.jit._builtin_funcs import shfl_down_sync  # NOQA
 from cupyx.jit._builtin_funcs import shfl_xor_sync  # NOQA
 
-_getsource_func = None  # NOQA
 _n_functions_upperlimit = 100

--- a/cupyx/jit/_compile.py
+++ b/cupyx/jit/_compile.py
@@ -11,6 +11,7 @@ import numpy
 
 from cupy._core._codeblock import CodeBlock
 from cupy._core import _kernel
+from cupyx import jit
 from cupyx.jit import _cuda_types
 from cupyx.jit import _cuda_typerules
 from cupyx.jit import _internal_types

--- a/cupyx/jit/_compile.py
+++ b/cupyx/jit/_compile.py
@@ -149,10 +149,12 @@ def _transpile_func_obj(func, attributes, mode, in_types, ret_type, generated):
             raise ValueError("Recursive function is not supported.")
         return result
 
+    # Do sanity check first.
+    tree, source = _parse_function_object(func)
+
     cvars = inspect.getclosurevars(func)
     consts = dict(**cvars.globals, **cvars.nonlocals, **cvars.builtins)
     attributes = ' '.join(attributes)
-    tree, source = _parse_function_object(func)
     name = tree.name
     if len(generated.device_function) > 0:
         name += '_' + str(len(generated.device_function))

--- a/cupyx/jit/_compile.py
+++ b/cupyx/jit/_compile.py
@@ -75,14 +75,10 @@ def _parse_function_object(func):
         # - "<ipython-input-XXXXXXXX>" (within IPython interpreter)
         filename = inspect.getsourcefile(func)
     except TypeError:
+        # Built-in function or method, or inside Doctest
         filename = None
 
-    if filename is None:
-        raise ValueError(
-            f'JIT needs access to Python source code for {func}'
-            ' but could not be located.\n'
-            '(hint: it is likely you passed a built-in function or method)')
-    elif filename == '<stdin>':
+    if filename == '<stdin>':
         raise RuntimeError(
             f'JIT needs access to the Python source code for {func}'
             ' but it cannot be retrieved within the Python interactive'
@@ -97,6 +93,13 @@ def _parse_function_object(func):
         assert isinstance(tree, ast.Module)
         assert len(tree.body) == 1
         return tree.body[0], source
+
+    if filename is None:
+        # filename is needed for lambdas.
+        raise ValueError(
+            f'JIT needs access to Python source code for {func}'
+            ' but could not be located.\n'
+            '(hint: it is likely you passed a built-in function or method)')
 
     # Extract the AST of the lambda from the AST of the whole source file
     # that defines that lambda.

--- a/cupyx/jit/_compile.py
+++ b/cupyx/jit/_compile.py
@@ -81,11 +81,11 @@ def _parse_function_object(func):
         raise ValueError(
             f'JIT needs access to Python source code for {func}'
             ' but could not be located.\n'
-            '(hint: it is likely you passed a built-in functions or methods)')
+            '(hint: it is likely you passed a built-in function or method)')
     elif filename == '<stdin>':
         raise RuntimeError(
             f'JIT needs access to the Python source code for {func}'
-            ' but it could not be retrieved within the Python interactive'
+            ' but it cannot be retrieved within the Python interactive'
             ' interpreter. Consider using IPython instead.')
 
     if func.__name__ != '<lambda>':

--- a/cupyx/jit/_compile.py
+++ b/cupyx/jit/_compile.py
@@ -113,6 +113,7 @@ def _parse_function_object(func):
              if isinstance(node, ast.Lambda)
              and start_line <= node.lineno < end_line]
     if len(nodes) > 1:
+        # TODO(kmaehashi): can be improved by heuristics (e.g. number of args)
         raise ValueError('Multiple callables are found near the'
                          f' definition of {func}, and JIT could not'
                          ' identify the source code for it.')
@@ -140,7 +141,8 @@ class Generated:
 
 
 def transpile(func, attributes, mode, in_types, ret_type):
-    """Transpile the target function
+    """Transpiles the target function.
+
     Args:
         func (function): Target function.
         attributes (list of str): Attributes of the generated CUDA function.

--- a/cupyx/jit/_compile.py
+++ b/cupyx/jit/_compile.py
@@ -1,7 +1,7 @@
 import ast
 import collections
 import inspect
-import math
+import linecache
 import numbers
 import re
 import sys
@@ -11,7 +11,6 @@ import numpy
 
 from cupy._core._codeblock import CodeBlock
 from cupy._core import _kernel
-from cupyx import jit
 from cupyx.jit import _cuda_types
 from cupyx.jit import _cuda_typerules
 from cupyx.jit import _internal_types
@@ -57,40 +56,56 @@ def transpile_function_wrapper(func):
 
 
 def _parse_function_object(func):
-    # Parses function object into ast.FunctionDef object.
+    """Returns the tuple of ``ast.FunctionDef`` object and the source string
+    for the given callable ``func``.
+
+    ``func`` can be a ``def`` function or a ``lambda`` expression.
+
+    The source is returned only for informational purposes (i.e., rendering
+    an exception message in case of an error).
+    """
     if not callable(func):
         raise ValueError('`func` must be a callable object.')
 
+    try:
+        # ``filename`` can be any of:
+        # - A "real" file path on the filesystem
+        # - "<stdin>" (within Python interpreter)
+        # - "<ipython-input-XXXXXXXX>" (within IPython interpreter)
+        filename = inspect.getsourcefile(func)
+    except TypeError:
+        raise ValueError(
+            f'JIT needs access to Python source code for {func}'
+            ' but could not be located.\n'
+            '(hint: it is likely you passed a built-in functions or methods)')
+
+    if filename == '<stdin>':
+        raise ValueError(
+            f'JIT needs access to the Python source code for {func}'
+            ' but it could not be retrieved within the Python interactive'
+            ' interpreter. Consider using IPython instead.')
+
     if func.__name__ != '<lambda>':
-        if jit._getsource_func is None:
-            lines = inspect.getsource(func).split('\n')
-            num_indent = len(lines[0]) - len(lines[0].lstrip())
-            source = '\n'.join([
-                line.replace(' ' * num_indent, '', 1) for line in lines])
-        else:
-            source = jit._getsource_func(func)
+        lines, _ = inspect.getsourcelines(func)
+        num_indent = len(lines[0]) - len(lines[0].lstrip())
+        source = ''.join([
+            line.replace(' ' * num_indent, '', 1) for line in lines])
         tree = ast.parse(source)
         assert isinstance(tree, ast.Module)
         assert len(tree.body) == 1
         return tree.body[0], source
 
-    if jit._getsource_func is not None:
-        full_source = jit._getsource_func(func)
-        start_line, end_line = 0, math.inf
-        source = full_source
-    else:
-        try:
-            filename = inspect.getsourcefile(func)
-        except TypeError:
-            filename = None
-        if filename is None:
-            raise ValueError(f'JIT needs access to Python source for {func}'
-                             'but could not be located')
-        with open(filename) as f:
-            full_source = f.read()
-        source, start_line = inspect.getsourcelines(func)
-        end_line = start_line + len(source)
-        source = ''.join(source)
+    # Extract the AST of the lambda from the AST of the whole source file
+    # that defines that lambda.
+    # This is needed because ``inspect.getsourcelines(lambda_expr)`` may
+    # return unparsable code snippet.
+
+    # Use ``linecache.getlines`` instead of directly opening a file to
+    # support notebook environments.
+    full_source = ''.join(linecache.getlines(filename))
+    source, start_line = inspect.getsourcelines(func)
+    end_line = start_line + len(source)
+    source = ''.join(source)
 
     tree = ast.parse(full_source)
 

--- a/cupyx/jit/_compile.py
+++ b/cupyx/jit/_compile.py
@@ -75,13 +75,15 @@ def _parse_function_object(func):
         # - "<ipython-input-XXXXXXXX>" (within IPython interpreter)
         filename = inspect.getsourcefile(func)
     except TypeError:
+        filename = None
+
+    if filename is None:
         raise ValueError(
             f'JIT needs access to Python source code for {func}'
             ' but could not be located.\n'
             '(hint: it is likely you passed a built-in functions or methods)')
-
-    if filename == '<stdin>':
-        raise ValueError(
+    elif filename == '<stdin>':
+        raise RuntimeError(
             f'JIT needs access to the Python source code for {func}'
             ' but it could not be retrieved within the Python interactive'
             ' interpreter. Consider using IPython instead.')

--- a/docs/source/user_guide/kernel.rst
+++ b/docs/source/user_guide/kernel.rst
@@ -576,7 +576,4 @@ The types of local variables are inferred at the first assignment in the functio
 Limitations
 ^^^^^^^^^^^
 
-CuPy's JIT compiler uses :py:func:`inspect.getsource` to get the source code of the target function, so the compiler does not work in the following situations:
-
-* In Python REPL
-* Lambda expressions as target functions
+JIT does not work inside Python's interactive interpreter (REPL) as the compiler needs to get the source code of the target function.


### PR DESCRIPTION
Closes #6320.

This fixes source retrival of JIT to support IPython and notebook environment such as Jupyter.

When JIT is used under Python interpreter, it now recommends using IPython:

```
>>> import cupy
>>> a = cupy.array([0.4, -0.2, 1.8, -1.2])
>>> relu = cupy.vectorize(lambda x: (x > 0.0) * x)
>>> print(relu(a))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/maehashi/Development/cupy/cupy/_functional/vectorize.py", line 87, in __call__
    result = func._emit_code_from_types(in_types, ret_type)
  File "/home/maehashi/Development/cupy/cupyx/jit/_interface.py", line 38, in _emit_code_from_types
    return _compile.transpile(
  File "/home/maehashi/Development/cupy/cupyx/jit/_compile.py", line 138, in transpile
    tree, source = _parse_function_object(func)
  File "/home/maehashi/Development/cupy/cupyx/jit/_compile.py", line 82, in _parse_function_object
    raise ValueError(
ValueError: JIT needs access to the Python source code for <function <lambda> at 0x7f5ce05ccaf0> but it could not be retrieved within the Python interactive interpreter. Consider using IPython instead.
```

IPython interpreter:

```
In [1]: import cupy

In [2]: a = cupy.array([0.4, -0.2, 1.8, -1.2])

In [3]: relu = cupy.vectorize(lambda x: (x > 0.0) * x)

In [4]: print(relu(a))
[ 0.4 -0.   1.8 -0. ]
```

Jupyter notebook:
![Screen Shot 2022-01-17 at 20 13 56](https://user-images.githubusercontent.com/939877/149759981-0f5be449-805c-4efe-9633-0cbde764738c.png)
