### PR TITLE
DOC: Use `cupy.__version__` instead of `pkg_resources`

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,16 +15,15 @@
 import importlib
 import inspect
 import os
-import pkg_resources
 import sys
 
+import cupy
 
 sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
 import _comparison_generator
 
 
-__version__ = pkg_resources.get_distribution('cupy').version
-
+__version__ = cupy.__version__
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
 rtd_version = os.environ.get('READTHEDOCS_VERSION')


### PR DESCRIPTION
This is to allow building docs against wheel packages (`cupy-cudaXXX`).

(Background: I sometimes want to generate comparison table to compare the difference between multiple CuPy versions. However CuPy wheels are not recognized by `pkg_resources.get_distribution('cupy')`. It is handy if I can do this using wheel packages.)