### PR TITLE
Use `get_include` instead of `array_equiv` for fallback test

### DIFF
--- a/tests/cupyx_tests/fallback_mode_tests/test_notifications.py
+++ b/tests/cupyx_tests/fallback_mode_tests/test_notifications.py
@@ -48,15 +48,15 @@ class TestNotifications(NotificationTestBase):
 
 
 @testing.parameterize(
-    {'func_name': 'array_equiv', 'shape': (3, 4)},
+    {'func_name': 'get_include'},
 )
 @testing.gpu
 class TestNotificationModes(NotificationTestBase):
 
     @property
     def func(self):
-        if self.func_name == 'array_equiv':
-            return fallback_mode.numpy.array_equiv
+        if self.func_name == 'get_include':
+            return fallback_mode.numpy.get_include
         assert False
 
     def test_notification_ignore(self):
@@ -65,9 +65,7 @@ class TestNotificationModes(NotificationTestBase):
         saved_stdout = io.StringIO()
 
         with contextlib.redirect_stdout(saved_stdout):
-            a = testing.shaped_random(self.shape, fallback_mode.numpy)
-            b = testing.shaped_random(self.shape, fallback_mode.numpy)
-            self.func(a, b)
+            self.func()
 
         _ufunc_config.seterr(**old)
         output = saved_stdout.getvalue().strip()
@@ -79,9 +77,7 @@ class TestNotificationModes(NotificationTestBase):
         saved_stdout = io.StringIO()
 
         with contextlib.redirect_stdout(saved_stdout):
-            a = testing.shaped_random(self.shape, fallback_mode.numpy)
-            b = testing.shaped_random(self.shape, fallback_mode.numpy)
-            self.func(a, b)
+            self.func()
 
         _ufunc_config.seterr(**old)
         nf = self.func._numpy_object
@@ -95,18 +91,14 @@ class TestNotificationModes(NotificationTestBase):
         _ufunc_config.seterr(fallback_mode='warn')
 
         with pytest.warns(fallback_mode.notification.FallbackWarning):
-            a = testing.shaped_random(self.shape, fallback_mode.numpy)
-            b = testing.shaped_random(self.shape, fallback_mode.numpy)
-            self.func(a, b)
+            self.func()
 
     def test_notification_raise(self):
 
         old = _ufunc_config.seterr(fallback_mode='raise')
 
         with pytest.raises(AttributeError):
-            a = testing.shaped_random(self.shape, fallback_mode.numpy)
-            b = testing.shaped_random(self.shape, fallback_mode.numpy)
-            self.func(a, b)
+            self.func()
 
         _ufunc_config.seterr(**old)
 


### PR DESCRIPTION
`array_equiv` is going to be added in #6254.
Use `get_include`, which is unlikely to be added in CuPy, for fallback test.