### PR TITLE
Fix cuDNN installer not working

### DIFF
--- a/cupyx/tools/install_library.py
+++ b/cupyx/tools/install_library.py
@@ -266,20 +266,20 @@ The current platform ({}) is not supported.'''.format(target_platform))
         print('Extracting...')
         outdir = os.path.join(tmpdir, 'extract')
         _unpack_archive(f.name, outdir)
+
+        subdir = os.listdir(outdir)
+        assert len(subdir) == 1
+        dir_name = subdir[0]
+
         print('Installing...')
         if library == 'cudnn':
-            shutil.move(os.path.join(outdir, 'cuda'), destination)
+            for item in ['include', 'lib', 'LICENSE']:
+                shutil.move(
+                    os.path.join(outdir, dir_name, item),
+                    os.path.join(destination, item))
         elif library == 'cutensor':
             if cuda.startswith('11.') and cuda != '11.0':
                 cuda = '11'
-            if target_platform == 'Linux':
-                ext = '.tar.xz'
-            elif target_platform == 'Windows':
-                ext = '.zip'
-            else:
-                assert False
-            assert url.endswith(ext)
-            dir_name = os.path.basename(url)[:-len(ext)]
             license = 'LICENSE'
             shutil.move(
                 os.path.join(outdir, dir_name, 'include'),
@@ -290,9 +290,7 @@ The current platform ({}) is not supported.'''.format(target_platform))
             shutil.move(
                 os.path.join(outdir, dir_name, license), destination)
         elif library == 'nccl':
-            subdir = os.listdir(outdir)  # ['nccl_2.8.4-1+cuda11.2_x86_64']
-            assert len(subdir) == 1
-            shutil.move(os.path.join(outdir, subdir[0]), destination)
+            shutil.move(os.path.join(outdir, dir_name), destination)
         else:
             assert False
         print('Cleaning up...')


### PR DESCRIPTION
Follows-up: #6314
Slow test failed: https://ci.preferred.jp/cupy.linux.cuda-slow/91281/#L4316

Directory structure in cuDNN archive has been changed and installer was not working.