### PR TITLE
Make scipy.special ufuncs work with CuPy inputs

### DIFF
--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -1560,7 +1560,9 @@ cdef class ndarray:
         if method == '__call__':
             name = ufunc.__name__
             try:
-                cp_ufunc = getattr(cupy, name, None) or getattr(cupyx.scipy.special, name)
+                cp_ufunc = getattr(cupy, name, None) or getattr(
+                    cupyx.scipy.special, name
+                )
             except AttributeError:
                 return NotImplemented
             for x in inout:

--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -1545,6 +1545,7 @@ cdef class ndarray:
         numpy array.
         """
         import cupy  # top-level ufuncs
+        import cupyx.scipy.special  # special ufuncs
         inout = inputs
         if 'out' in kwargs:
             # need to unfold tuple argument in kwargs
@@ -1559,7 +1560,7 @@ cdef class ndarray:
         if method == '__call__':
             name = ufunc.__name__
             try:
-                cp_ufunc = getattr(cupy, name)
+                cp_ufunc = getattr(cupy, name, None) or getattr(cupyx.scipy.special, name)
             except AttributeError:
                 return NotImplemented
             for x in inout:

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_ufunc_dispatch.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_ufunc_dispatch.py
@@ -1,21 +1,27 @@
 import numpy
 import cupy
-import scipy.special
 import cupyx.scipy.special
 
 from cupy import testing
 import pytest
 
-scipy_ufuncs = {
-    f
-    for f in scipy.special.__all__
-    if isinstance(getattr(scipy.special, f), numpy.ufunc)
-}
-cupyx_scipy_ufuncs = {
-    f
-    for f in dir(cupyx.scipy.special)
-    if isinstance(getattr(cupyx.scipy.special, f), cupy.ufunc)
-}
+try:
+    import scipy.special
+
+    scipy_ufuncs = {
+        f
+        for f in scipy.special.__all__
+        if isinstance(getattr(scipy.special, f), numpy.ufunc)
+    }
+    cupyx_scipy_ufuncs = {
+        f
+        for f in dir(cupyx.scipy.special)
+        if isinstance(getattr(cupyx.scipy.special, f), cupy.ufunc)
+    }
+except ImportError:
+    scipy_ufuncs = set()
+    cupyx_scipy_ufuncs = set()
+
 
 @testing.gpu
 @testing.with_requires("scipy")

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_ufunc_dispatch.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_ufunc_dispatch.py
@@ -17,10 +17,9 @@ cupyx_scipy_ufuncs = {
     if isinstance(getattr(cupyx.scipy.special, f), cupy.ufunc)
 }
 
-
 @testing.gpu
 @testing.with_requires("scipy")
-@pytest.mark.parametrize("ufunc", cupyx_scipy_ufuncs & scipy_ufuncs)
+@pytest.mark.parametrize("ufunc", sorted(cupyx_scipy_ufuncs & scipy_ufuncs))
 class TestUfunc:
     @testing.numpy_cupy_allclose(atol=1e-5)
     def test_dispatch(self, xp, ufunc):

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_ufunc_dispatch.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_ufunc_dispatch.py
@@ -35,6 +35,6 @@ class TestUfunc:
         types = ufunc.types[0]
         args = [
             cupy.testing.shaped_random((5,), xp, dtype=types[i])
-            for i in range(ufunc.nargs - 1)
+            for i in range(ufunc.nin)
         ]
         return ufunc(*args)

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_ufunc_dispatch.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_ufunc_dispatch.py
@@ -37,6 +37,4 @@ class TestUfunc:
             cupy.testing.shaped_random((5,), xp, dtype=types[i])
             for i in range(ufunc.nargs - 1)
         ]
-        res = ufunc(*args)
-        assert type(res) == xp.ndarray
-        return res
+        return ufunc(*args)


### PR DESCRIPTION
This PR makes it possible to pass CuPy arrays to `scipy.special` ufuncs. The actual implementation is dispatched to `cupyx.scipy.special` using `__array_ufunc__`.

Fixes https://github.com/cupy/cupy/issues/6158.