### PR TITLE
Fix for cuDNN directory structure in Windows

### DIFF
--- a/cupyx/tools/install_library.py
+++ b/cupyx/tools/install_library.py
@@ -273,7 +273,8 @@ The current platform ({}) is not supported.'''.format(target_platform))
 
         print('Installing...')
         if library == 'cudnn':
-            for item in ['include', 'lib', 'LICENSE']:
+            libdir = 'bin' if sys.platform == 'win32' else 'lib'
+            for item in ['include', libdir, 'LICENSE']:
                 shutil.move(
                     os.path.join(outdir, dir_name, item),
                     os.path.join(destination, item))


### PR DESCRIPTION
Bug added in #6337.

In cuDNN Windows archive,
* `lib` directory only contains static libraries
* `bin` directory contains dynamic libraries (DLL) which are what we need