### PR TITLE
Fix tests for eigh() for CUDA 11.6

### DIFF
--- a/tests/cupy_tests/linalg_tests/test_eigenvalue.py
+++ b/tests/cupy_tests/linalg_tests/test_eigenvalue.py
@@ -40,15 +40,15 @@ class TestEigenvalue:
         # the eigenvectors of eigh() with CUDA 11.6 are mathematically correct
         # but may not match NumPy.
         A = _get_hermitian(xp, a, self.UPLO)
-        if dtype == numpy.float16:
-            atol = 1e-3
+        if _dtype == numpy.float16:
+            tol = 1e-3
         else:
-            atol = 1e-5
-        testing.assert_allclose(A @ v, v @ xp.diag(w), atol=atol, rtol=1)
+            tol = 1e-5
+        testing.assert_allclose(A @ v, v @ xp.diag(w), atol=tol, rtol=tol)
         # Check if v @ vt is an identity matrix
         testing.assert_allclose(v @ v.swapaxes(-2, -1).conj(),
-                                xp.identity(A.shape[-1], _dtype), atol=atol,
-                                rtol=atol)
+                                xp.identity(A.shape[-1], _dtype), atol=tol,
+                                rtol=tol)
         if xp == numpy and dtype == numpy.float16:
             w = w.astype('e')
         return w

--- a/tests/cupy_tests/linalg_tests/test_eigenvalue.py
+++ b/tests/cupy_tests/linalg_tests/test_eigenvalue.py
@@ -45,6 +45,10 @@ class TestEigenvalue:
         else:
             atol = 1e-5
         testing.assert_allclose(A @ v, v @ xp.diag(w), atol=atol, rtol=1)
+        # Check if v @ vt is an identity matrix
+        testing.assert_allclose(v @ v.swapaxes(-2, -1).conj(),
+                                xp.identity(A.shape[-1], _dtype), atol=atol,
+                                rtol=atol)
         if xp == numpy and dtype == numpy.float16:
             w = w.astype('e')
         return w


### PR DESCRIPTION
This PR addresses a problem that caused `eigh()` tests to fail in CUDA 11.6.

The current test for `eigh()` assumes that the results matches Numpy, but due to changes added to CUDA 11.6, or more precisely CUDA 11.6's cuSOLVER, the results does not necessarily match Numpy in the test cases. However, the CUDA 11.6 results are also mathematically correct, so we propose to change the way to test `eigh()`.

This is related to https://github.com/cupy/cupy/issues/6309 and depends on https://github.com/cupy/cupy/pull/6346.