### PR TITLE
added api for `cupy.float_power`

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -614,7 +614,7 @@ from cupy._math.arithmetic import add  # NOQA
 from cupy._math.arithmetic import divide  # NOQA
 from cupy._math.arithmetic import divmod  # NOQA
 from cupy._math.arithmetic import floor_divide  # NOQA
-from cupy._math.arithmetic import float_power
+from cupy._math.arithmetic import float_power  #NOQA
 from cupy._math.arithmetic import fmod  # NOQA
 from cupy._math.arithmetic import modf  # NOQA
 from cupy._math.arithmetic import multiply  # NOQA

--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -614,7 +614,7 @@ from cupy._math.arithmetic import add  # NOQA
 from cupy._math.arithmetic import divide  # NOQA
 from cupy._math.arithmetic import divmod  # NOQA
 from cupy._math.arithmetic import floor_divide  # NOQA
-from cupy._math.arithmetic import float_power  #NOQA
+from cupy._math.arithmetic import float_power  # NOQA
 from cupy._math.arithmetic import fmod  # NOQA
 from cupy._math.arithmetic import modf  # NOQA
 from cupy._math.arithmetic import multiply  # NOQA

--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -614,6 +614,7 @@ from cupy._math.arithmetic import add  # NOQA
 from cupy._math.arithmetic import divide  # NOQA
 from cupy._math.arithmetic import divmod  # NOQA
 from cupy._math.arithmetic import floor_divide  # NOQA
+from cupy._math.arithmetic import float_power
 from cupy._math.arithmetic import fmod  # NOQA
 from cupy._math.arithmetic import modf  # NOQA
 from cupy._math.arithmetic import multiply  # NOQA

--- a/cupy/_math/arithmetic.py
+++ b/cupy/_math/arithmetic.py
@@ -113,7 +113,7 @@ floor_divide = _core.floor_divide
 
 float_power = _core.create_ufunc(
     'cupy_float_power',
-    ('dd->d','FF->D',
+    ('dd->d', 'FF->D',
      ('DD->D', 'out0 = in1 == in1_type(0) ? in1_type(1): pow(in0, in1)')),
     'out0 = pow(in0, in1)',
     doc='''First array elements raised to powers from second array, element-wise.

--- a/cupy/_math/arithmetic.py
+++ b/cupy/_math/arithmetic.py
@@ -113,7 +113,7 @@ floor_divide = _core.floor_divide
 
 float_power = _core.create_ufunc(
     'cupy_float_power',
-    (('dd->d'),
+    ('dd->d','FF->D',
      ('DD->D', 'out0 = in1 == in1_type(0) ? in1_type(1): pow(in0, in1)')),
     'out0 = pow(in0, in1)',
     doc='''First array elements raised to powers from second array, element-wise.

--- a/cupy/_math/arithmetic.py
+++ b/cupy/_math/arithmetic.py
@@ -111,6 +111,17 @@ true_divide = _core.true_divide
 
 floor_divide = _core.floor_divide
 
+float_power = _core.create_ufunc(
+    'cupy_float_power',
+    (('dd->d'),
+     ('DD->D', 'out0 = in1 == in1_type(0) ? in1_type(1): pow(in0, in1)')),
+    'out0 = pow(in0, in1)',
+    doc='''First array elements raised to powers from second array, element-wise.
+
+    .. seealso:: :data:`numpy.float_power`
+
+    '''
+)
 
 fmod = _core.create_ufunc(
     'cupy_fmod',

--- a/docs/source/reference/math.rst
+++ b/docs/source/reference/math.rst
@@ -142,6 +142,7 @@ Arithmetic operations
    subtract
    true_divide
    floor_divide
+   float_power
    fmod
    mod
    modf

--- a/tests/cupy_tests/math_tests/test_arithmetic.py
+++ b/tests/cupy_tests/math_tests/test_arithmetic.py
@@ -228,7 +228,7 @@ class ArithmeticBinaryBase:
         # TODO(niboshi): Fix this. If rhs is a Python complex,
         #    numpy returns complex64
         #    cupy returns complex128
-        if xp is cupy and isinstance(arg2, complex):
+        if xp is cupy and isinstance(arg2, complex) and self.name != 'float_power':
             if dtype1 in (numpy.float16, numpy.float32):
                 y = y.astype(numpy.complex64)
 

--- a/tests/cupy_tests/math_tests/test_arithmetic.py
+++ b/tests/cupy_tests/math_tests/test_arithmetic.py
@@ -228,7 +228,8 @@ class ArithmeticBinaryBase:
         # TODO(niboshi): Fix this. If rhs is a Python complex,
         #    numpy returns complex64
         #    cupy returns complex128
-        if xp is cupy and isinstance(arg2, complex) and self.name != 'float_power':
+        if (xp is cupy and isinstance(arg2, complex)
+                and self.name != 'float_power'):
             if dtype1 in (numpy.float16, numpy.float32):
                 y = y.astype(numpy.complex64)
 

--- a/tests/cupy_tests/math_tests/test_arithmetic.py
+++ b/tests/cupy_tests/math_tests/test_arithmetic.py
@@ -29,7 +29,7 @@ no_complex_types = [numpy.bool_] + float_types + int_types
         'nargs': [2],
         'name': [
             'add', 'multiply', 'divide', 'power', 'subtract', 'true_divide',
-            'floor_divide', 'fmod', 'remainder'],
+            'floor_divide', 'float_power', 'fmod', 'remainder'],
     })
 ))
 class TestArithmeticRaisesWithNumpyInput:
@@ -191,7 +191,7 @@ class ArithmeticBinaryBase:
         dtype1 = np1.dtype
         dtype2 = np2.dtype
 
-        if self.name == 'power':
+        if self.name == 'power' or self.name == 'float_power':
             # TODO(niboshi): Fix this: power(0, 1j)
             #     numpy => 1+0j
             #     cupy => 0j
@@ -255,7 +255,7 @@ class ArithmeticBinaryBase:
         'arg2': [testing.shaped_reverse_arange((2, 3), numpy, dtype=d)
                  for d in all_types
                  ] + [0, 0.0, 0j, 2, 2.0, 2j, True, False],
-        'name': ['add', 'multiply', 'power', 'subtract'],
+        'name': ['add', 'multiply', 'power', 'subtract', 'float_power'],
     }) + testing.product({
         'arg1': [numpy.array([-3, -2, -1, 1, 2, 3], dtype=d)
                  for d in negative_types
@@ -290,7 +290,7 @@ class TestArithmeticBinary(ArithmeticBinaryBase):
                  for d in float_types] + [0.0, 2.0, -2.0],
         'arg2': [numpy.array([-3, -2, -1, 1, 2, 3], dtype=d)
                  for d in float_types] + [0.0, 2.0, -2.0],
-        'name': ['power', 'true_divide', 'subtract'],
+        'name': ['power', 'true_divide', 'subtract', 'float_power'],
         'dtype': [numpy.float64],
         'use_dtype': [True, False],
     }) + testing.product({


### PR DESCRIPTION
Hi,
This PR **aims** to resovle `cupy.float_power` as requested in #6078.

I am getting the data_type assertion error for complex datatype. 4 testcases are being failed.
expect data_type is `numpy.complex128` whereas output generated is `cupy.complex64`.

Looking for your guidance! Thank You.