### PR TITLE
Array API changes for supporting cupy arrays with scipy

### DIFF
--- a/cupy/_creation/from_data.py
+++ b/cupy/_creation/from_data.py
@@ -104,6 +104,7 @@ def ascontiguousarray(a, dtype=None):
     .. seealso:: :func:`numpy.ascontiguousarray`
 
     """
+    a = a._array if hasattr(a, '_array') else a
     return _core.ascontiguousarray(a, dtype)
 
 

--- a/cupy/_math/misc.py
+++ b/cupy/_math/misc.py
@@ -167,7 +167,10 @@ def clip(a, a_min=None, a_max=None, out=None):
                                   a, a_min, a_max, out=out)
 
     # TODO(okuta): check type
-    return a.clip(a_min, a_max, out=out)
+    a = a._array if hasattr(a, '_array') else a
+    out = out._array if hasattr(out, '_array') else out
+    import cupy.array_api as cpx
+    return cpx.asarray(a.clip(a_min, a_max, out=out))
 
 
 # sqrt_fixed is deprecated.

--- a/cupy/_misc/memory_ranges.py
+++ b/cupy/_misc/memory_ranges.py
@@ -31,7 +31,7 @@ def shares_memory(a, b, max_work=None):
     if a is b and a.size != 0:
         return True
     if max_work == 'MAY_SHARE_BOUNDS':
-        return _memory_range.may_share_bounds(a, b)
+        return _memory_range.may_share_bounds(a, b._array if hasattr(b, '_array') else b)
 
     if max_work in (None, 'MAY_SHARE_EXACT'):
         a_ptrs = _get_memory_ptrs(a).ravel()

--- a/cupy/_misc/memory_ranges.py
+++ b/cupy/_misc/memory_ranges.py
@@ -31,7 +31,7 @@ def shares_memory(a, b, max_work=None):
     if a is b and a.size != 0:
         return True
     if max_work == 'MAY_SHARE_BOUNDS':
-        return _memory_range.may_share_bounds(a, b._array if hasattr(b, '_array') else b)
+        return _memory_range.may_share_bounds(a._array if hasattr(a, '_array') else a, b._array if hasattr(b, '_array') else b)
 
     if max_work in (None, 'MAY_SHARE_EXACT'):
         a_ptrs = _get_memory_ptrs(a).ravel()

--- a/cupyx/scipy/ndimage/_filters_core.py
+++ b/cupyx/scipy/ndimage/_filters_core.py
@@ -138,6 +138,7 @@ def _call_kernel(kernel, input, weights, output, structure=None,
     if needs_temp:
         output, temp = _util._get_output(output.dtype, input), output
     args.append(output)
+    args = [arg._array if hasattr(arg, '_array') else arg for arg in args]
     kernel(*args)
     if needs_temp:
         temp[...] = output[...]

--- a/cupyx/scipy/ndimage/_util.py
+++ b/cupyx/scipy/ndimage/_util.py
@@ -25,7 +25,7 @@ def _get_weights_dtype(input, weights):
     elif weights.dtype.kind in 'iub':
         # convert integer dtype weights to double as in SciPy
         return cupy.float64
-    return cupy.promote_types(input.real.dtype, cupy.float32)
+    return cupy.promote_types(input._array.real.dtype if hasattr(input, '_array') else input.real.dtype, cupy.float32)
 
 
 def _get_output(output, input, shape=None, complex_output=False):
@@ -87,8 +87,9 @@ def _get_inttype(input):
     # The indices actually use byte positions and we can't just use
     # input.nbytes since that won't tell us the number of bytes between the
     # first and last elements when the array is non-contiguous
-    nbytes = sum((x-1)*abs(stride) for x, stride in
-                 zip(input.shape, input.strides)) + input.dtype.itemsize
+    nbytes = sum((x - 1) * abs(stride) for x, stride in
+                 zip(input.shape,
+                     input._array.strides if hasattr(input, '_array') else input.strides)) + input.dtype.itemsize
     return 'int' if nbytes < (1 << 31) else 'ptrdiff_t'
 
 

--- a/cupyx/scipy/ndimage/_util.py
+++ b/cupyx/scipy/ndimage/_util.py
@@ -30,22 +30,23 @@ def _get_weights_dtype(input, weights):
 
 def _get_output(output, input, shape=None, complex_output=False):
     shape = input.shape if shape is None else shape
+    import cupy.array_api as cpx
     if output is None:
         if complex_output:
             _dtype = cupy.promote_types(input.dtype, cupy.complex64)
         else:
             _dtype = input.dtype
-        output = cupy.zeros(shape, dtype=_dtype)
+        output = cpx.zeros(shape, dtype=_dtype)
     elif isinstance(output, (type, cupy.dtype)):
         if complex_output and cupy.dtype(output).kind != 'c':
             warnings.warn("promoting specified output dtype to complex")
             output = cupy.promote_types(output, cupy.complex64)
-        output = cupy.zeros(shape, dtype=output)
+        output = cpx.zeros(shape, dtype=output)
     elif isinstance(output, str):
         output = numpy.sctypeDict[output]
         if complex_output and cupy.dtype(output).kind != 'c':
             raise RuntimeError("output must have complex dtype")
-        output = cupy.zeros(shape, dtype=output)
+        output = cpx.zeros(shape, dtype=output)
     elif output.shape != shape:
         raise RuntimeError("output shape not correct")
     elif complex_output and output.dtype.kind != 'c':

--- a/cupyx/scipy/ndimage/interpolation.py
+++ b/cupyx/scipy/ndimage/interpolation.py
@@ -749,5 +749,6 @@ def zoom(input, zoom, output=None, order=3, mode='constant', cval=0.0,
             integer_output=integer_output, grid_mode=grid_mode,
             nprepad=nprepad)
         zoom = cupy.asarray(zoom, dtype=cupy.float64)
-        kern(filtered, zoom, output)
-    return output
+        import cupy.array_api as cpx
+        kern(filtered, zoom, output._array if hasattr(output, '_array') else output)
+    return cpx.asarray(output)

--- a/cupyx/scipy/sparse/_util.py
+++ b/cupyx/scipy/sparse/_util.py
@@ -3,6 +3,9 @@ from cupy._core import core
 
 
 def isdense(x):
+    # TODO: Use get_namespace here.
+    if hasattr(x, '__array_namespace__') and x.__array_namespace__():
+        return isinstance(x._array, core.ndarray)
     return isinstance(x, core.ndarray)
 
 

--- a/cupyx/scipy/sparse/coo.py
+++ b/cupyx/scipy/sparse/coo.py
@@ -95,9 +95,10 @@ class coo_matrix(sparse_data._data_matrix):
         elif _scipy_available and scipy.sparse.issparse(arg1):
             # Convert scipy.sparse to cupyx.scipy.sparse
             x = arg1.tocoo()
-            data = cupy.array(x.data)
-            row = cupy.array(x.row, dtype='i')
-            col = cupy.array(x.col, dtype='i')
+            import cupy.array_api as cpx
+            data = cpx.asarray(x.data)
+            row = cpx.asarray(x.row, dtype=cpx.int32)
+            col = cpx.asarray(x.col, dtype=cpx.int32)
             copy = False
             if shape is None:
                 shape = arg1.shape
@@ -114,7 +115,7 @@ class coo_matrix(sparse_data._data_matrix):
                     base.isdense(row) and row.ndim == 1 and
                     base.isdense(col) and col.ndim == 1):
                 raise ValueError('row, column, and data arrays must be 1-D')
-            if not (len(data) == len(row) == len(col)):
+            if not (data.shape[0] == row.shape[0] == col.shape[0]):
                 raise ValueError(
                     'row, column, and data array must all be the same length')
 
@@ -143,24 +144,34 @@ class coo_matrix(sparse_data._data_matrix):
                 'Only float32, float64, complex64 and complex128'
                 ' are supported')
 
-        data = data.astype(dtype, copy=copy)
-        row = row.astype('i', copy=copy)
-        col = col.astype('i', copy=copy)
+        #import cupy.array_api as cpx
+        # TODO: copy not supported yet
+        from cupy.array_api.array_compatibility import get_namespace
+        import ipdb; ipdb.set_trace()
+        cpx, array_api = get_namespace(data, row, col)
+        if array_api:
+            data = cpx.astype(cpx.asarray(data), dtype)
+            row = cpx.astype(cpx.asarray(row), dtype)
+            col = cpx.astype(cpx.asarray(col), dtype)
+        else:
+            data = data.astype(dtype)
+            row = row.astype(dtype)
+            col = col.astype(dtype)
 
         if shape is None:
-            if len(row) == 0 or len(col) == 0:
+            if row.shape[0] == 0 or col.shape[0] == 0:
                 raise ValueError(
                     'cannot infer dimensions from zero sized index arrays')
             shape = (int(row.max()) + 1, int(col.max()) + 1)
 
-        if len(data) > 0:
-            if row.max() >= shape[0]:
+        if data.shape[0] > 0:
+            if cpx.max(row) >= shape[0]:
                 raise ValueError('row index exceeds matrix dimensions')
-            if col.max() >= shape[1]:
+            if cpx.max(col) >= shape[1]:
                 raise ValueError('column index exceeds matrix dimensions')
-            if row.min() < 0:
+            if cpx.min(row) < 0:
                 raise ValueError('negative row index found')
-            if col.min() < 0:
+            if cpx.min(col) < 0:
                 raise ValueError('negative column index found')
 
         sparse_data._data_matrix.__init__(self, data)


### PR DESCRIPTION
TODO:

- [ ] Use `get_namespace` instead of directly importing `cupy.array_api`