### PR TITLE
Add `cupy.testing.installed`

### DIFF
--- a/cupy/testing/__init__.py
+++ b/cupy/testing/__init__.py
@@ -19,6 +19,7 @@ from cupy.testing._helper import shaped_random  # NOQA
 from cupy.testing._helper import generate_matrix  # NOQA
 from cupy.testing._helper import shaped_reverse_arange  # NOQA
 from cupy.testing._helper import with_requires  # NOQA
+from cupy.testing._helper import installed  # NOQA
 from cupy.testing._loops import for_all_dtypes  # NOQA
 from cupy.testing._loops import for_all_dtypes_combination  # NOQA
 from cupy.testing._loops import for_CF_orders  # NOQA

--- a/cupy/testing/_helper.py
+++ b/cupy/testing/_helper.py
@@ -57,7 +57,7 @@ def installed(*specifiers):
     for spec in specifiers:
         try:
             pkg_resources.require(spec)
-        except pkg_resources.VersionConflict:
+        except pkg_resources.ResolutionError:
             return False
     return True
 

--- a/tests/cupy_tests/testing_tests/test_helper.py
+++ b/tests/cupy_tests/testing_tests/test_helper.py
@@ -7,6 +7,23 @@ import cupy
 from cupy import testing
 
 
+class TestPackageRequirements:
+    def test_installed(self):
+        assert testing.installed('cupy')
+        assert testing.installed('cupy>9', 'numpy>=1.12')
+        assert testing.installed('numpy>=1.10,<=2.0')
+        assert not testing.installed('numpy>=2.0')
+        assert not testing.installed('numpy>1.10,<1.9')
+
+    def test_numpy_satisfies(self):
+        assert testing.numpy_satisfies('>1.10')
+        assert not testing.numpy_satisfies('>=2.10')
+
+    @testing.with_requires('numpy>2.0')
+    def test_with_requires(self):
+        assert False, 'this should not happen'
+
+
 @testing.parameterize(*testing.product({
     'xp': [numpy, cupy],
     'shape': [(3, 2), (), (3, 0, 2)],


### PR DESCRIPTION
This can be used for markers other than `skipif`, e.g., `pytest.mark.xfail(installed('scipy==1.8.*'))`