### PR TITLE
Mark XFAIL for SciPy 1.8 release candidate

### DIFF
--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_coo.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_coo.py
@@ -861,7 +861,10 @@ class TestCooMatrixScipyComparison:
             with pytest.raises(ValueError):
                 x * m
 
-    @testing.with_requires('scipy!=1.8.0rc1')  # scipy/15210
+    @testing.xfail(
+        numpy.lib.NumpyVersion(scipy.__version__) >= '1.8.0rc1',
+        reason='See scipy/15210')
+    @testing.with_requires('scipy>=1.8.0rc1')
     def test_rmul_unsupported(self):
         for xp, sp in ((numpy, scipy.sparse), (cupy, sparse)):
             m = _make(xp, sp, self.dtype)
@@ -898,7 +901,6 @@ class TestCooMatrixScipyComparison:
                 x @ m
 
     # __pow__
-    @testing.with_requires('scipy!=1.8.0rc1')  # scipy/15224
     @testing.numpy_cupy_allclose(sp_name='sp', _check_sparse_format=False)
     def test_pow_0(self, xp, sp):
         m = _make_square(xp, sp, self.dtype)

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_coo.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_coo.py
@@ -864,7 +864,6 @@ class TestCooMatrixScipyComparison:
     @testing.xfail(
         numpy.lib.NumpyVersion(scipy.__version__) >= '1.8.0rc1',
         reason='See scipy/15210')
-    @testing.with_requires('scipy>=1.8.0rc1')
     def test_rmul_unsupported(self):
         for xp, sp in ((numpy, scipy.sparse), (cupy, sparse)):
             m = _make(xp, sp, self.dtype)

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_coo.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_coo.py
@@ -861,7 +861,7 @@ class TestCooMatrixScipyComparison:
             with pytest.raises(ValueError):
                 x * m
 
-    @testing.xfail(
+    @pytest.mark.xfail(
         numpy.lib.NumpyVersion(scipy.__version__) >= '1.8.0rc1',
         reason='See scipy/15210')
     def test_rmul_unsupported(self):

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
@@ -898,7 +898,10 @@ class TestCscMatrixScipyComparison:
             with pytest.raises(ValueError):
                 x * m
 
-    @testing.with_requires('scipy!=1.8.0rc1')  # scipy/15210
+    @testing.xfail(
+        numpy.lib.NumpyVersion(scipy.__version__) >= '1.8.0rc1',
+        reason='See scipy/15210')
+    @testing.with_requires('scipy>=1.8.0rc1')
     def test_rmul_unsupported(self):
         for xp, sp in ((numpy, scipy.sparse), (cupy, sparse)):
             m = self.make(xp, sp, self.dtype)

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
@@ -898,10 +898,12 @@ class TestCscMatrixScipyComparison:
             with pytest.raises(ValueError):
                 x * m
 
-    @pytest.mark.xfail(
-        numpy.lib.NumpyVersion(scipy.__version__) >= '1.8.0rc1',
-        reason='See scipy/15210')
     def test_rmul_unsupported(self):
+        if (
+            numpy.lib.NumpyVersion(scipy.__version__) >= '1.8.0rc1' and
+            self.make_method not in ['_make_empty', '_make_shape']
+        ):
+            pytest.xfail('See scipy/15210')
         for xp, sp in ((numpy, scipy.sparse), (cupy, sparse)):
             m = self.make(xp, sp, self.dtype)
             # TODO(unno): When a sparse matrix has no element, scipy.sparse

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
@@ -901,7 +901,6 @@ class TestCscMatrixScipyComparison:
     @testing.xfail(
         numpy.lib.NumpyVersion(scipy.__version__) >= '1.8.0rc1',
         reason='See scipy/15210')
-    @testing.with_requires('scipy>=1.8.0rc1')
     def test_rmul_unsupported(self):
         for xp, sp in ((numpy, scipy.sparse), (cupy, sparse)):
             m = self.make(xp, sp, self.dtype)

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
@@ -898,7 +898,7 @@ class TestCscMatrixScipyComparison:
             with pytest.raises(ValueError):
                 x * m
 
-    @testing.xfail(
+    @pytest.mark.xfail(
         numpy.lib.NumpyVersion(scipy.__version__) >= '1.8.0rc1',
         reason='See scipy/15210')
     def test_rmul_unsupported(self):

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -925,10 +925,12 @@ class TestCsrMatrixScipyComparison:
             with pytest.raises(ValueError):
                 x * m
 
-    @pytest.mark.xfail(
-        numpy.lib.NumpyVersion(scipy.__version__) >= '1.8.0rc1',
-        reason='See scipy/15210')
     def test_rmul_unsupported(self):
+        if (
+            numpy.lib.NumpyVersion(scipy.__version__) >= '1.8.0rc1' and
+            self.make_method not in ['_make_empty', '_make_shape']
+        ):
+            pytest.xfail('See scipy/15210')
         for xp, sp in ((numpy, scipy.sparse), (cupy, sparse)):
             m = self.make(xp, sp, self.dtype)
             if m.nnz == 0:

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -925,7 +925,7 @@ class TestCsrMatrixScipyComparison:
             with pytest.raises(ValueError):
                 x * m
 
-    @testing.xfail(
+    @pytest.mark.xfail(
         numpy.lib.NumpyVersion(scipy.__version__) >= '1.8.0rc1',
         reason='See scipy/15210')
     def test_rmul_unsupported(self):

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -928,7 +928,6 @@ class TestCsrMatrixScipyComparison:
     @testing.xfail(
         numpy.lib.NumpyVersion(scipy.__version__) >= '1.8.0rc1',
         reason='See scipy/15210')
-    @testing.with_requires('scipy>=1.8.0rc1')
     def test_rmul_unsupported(self):
         for xp, sp in ((numpy, scipy.sparse), (cupy, sparse)):
             m = self.make(xp, sp, self.dtype)

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -925,7 +925,10 @@ class TestCsrMatrixScipyComparison:
             with pytest.raises(ValueError):
                 x * m
 
-    @testing.with_requires('scipy!=1.8.0rc1')  # scipy/15210
+    @testing.xfail(
+        numpy.lib.NumpyVersion(scipy.__version__) >= '1.8.0rc1',
+        reason='See scipy/15210')
+    @testing.with_requires('scipy>=1.8.0rc1')
     def test_rmul_unsupported(self):
         for xp, sp in ((numpy, scipy.sparse), (cupy, sparse)):
             m = self.make(xp, sp, self.dtype)
@@ -1243,7 +1246,6 @@ class TestCsrMatrixScipyComparison:
 @testing.with_requires('scipy')
 class TestCsrMatrixPowScipyComparison:
 
-    @testing.with_requires('scipy!=1.8.0rc1')  # scipy/15224
     @testing.numpy_cupy_allclose(sp_name='sp', _check_sparse_format=False)
     def test_pow_0(self, xp, sp):
         m = _make_square(xp, sp, self.dtype)


### PR DESCRIPTION
Rel #6323.

Mark tests as XFAIL, which fail with, at least, SciPy 1.8 rc because of its bug.