### PR TITLE
Fix verbose LOBPCG for SciPy 1.8

### DIFF
--- a/cupyx/scipy/sparse/linalg/_lobpcg.py
+++ b/cupyx/scipy/sparse/linalg/_lobpcg.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy
 import cupy
 import cupy.linalg as linalg
@@ -69,9 +71,10 @@ def _report_nonhermitian(M, name):
     tol = 10 * cupy.finfo(M.dtype).eps
     tol *= max(1, float(linalg.norm(M, 1)))
     if nmd > tol:
-        print('matrix %s of the type %s is not sufficiently Hermitian:'
-              % (name, M.dtype))
-        print('condition: %.e < %e' % (nmd, tol))
+        warnings.warn(
+            f'Matrix {name} of the type {M.dtype} is not Hermitian: '
+            f'condition: {nmd} < {tol} fails.',
+            UserWarning, stacklevel=4)
 
 
 def _as2d(ar):
@@ -373,6 +376,7 @@ def lobpcg(A, X,
     while iterationNumber < maxiter:
         iterationNumber += 1
         if verbosityLevel > 0:
+            print('-' * 50)
             print('iteration %d' % iterationNumber)
 
         if B is not None:
@@ -401,9 +405,9 @@ def lobpcg(A, X,
             break
 
         if verbosityLevel > 0:
-            print('current block size:', currentBlockSize)
-            print('eigenvalue:', _lambda)
-            print('residual norms:', residualNorms)
+            print(f'current block size: {currentBlockSize}')
+            print(f'eigenvalue(s):\n{_lambda}')
+            print(f'residual norm(s):\n{residualNorms}')
         if verbosityLevel > 10:
             print(eigBlockVector)
 
@@ -655,8 +659,8 @@ def lobpcg(A, X,
     # Computing the actual true residuals
 
     if verbosityLevel > 0:
-        print('final eigenvalue:', _lambda)
-        print('final residual norms:', residualNorms)
+        print(f'Final eigenvalue(s):\n{_lambda}')
+        print(f'Final residual norm(s):\n{residualNorms}')
 
     if retLambdaHistory:
         if retResidualNormsHistory:

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
@@ -1139,6 +1139,7 @@ class TestLOBPCG:
         output = saved_stdout.getvalue().strip()
         return output
 
+    @testing.with_requires('scipy>=1.8.0rc1')
     def test_verbosity(self):
         """Check that nonzero verbosity level code runs
            and is identical to scipy's output format.


### PR DESCRIPTION
Rel. #6233.

This PR fixes the verbose messages of LOBPCG to make them get along with SciPy 1.8.