### PR TITLE
Eliminate unnecessary configuration pass in setup

### DIFF
--- a/install/cupy_builder/_command.py
+++ b/install/cupy_builder/_command.py
@@ -91,16 +91,14 @@ class custom_build_ext(setuptools.command.build_ext.build_ext):  # type: ignore[
         print('Cythonizing...')
         cythonize(self.extensions, cupy_builder.get_context())
 
-        # Rewrite source filenames of each extension from "*.pyx" to "*.cpp".
+        # Change an extension in each source filenames from "*.pyx" to "*.cpp".
         # c.f. `Cython.Distutils.old_build_ext`
         for ext in self.extensions:
             sources_pyx, sources_others = filter_files_by_extension(
                 ext.sources, '.pyx')
-            sources_cpp = []
-            for src in sources_pyx:
-                sources_cpp.append('{}.cpp'.format(os.path.splitext(src)[0]))
+            sources_cpp = ['{}.cpp'.format(os.path.splitext(src)[0])
+                           for src in sources_pyx]
             ext.sources = sources_cpp + sources_others
-
         super().build_extensions()
 
     def build_extension(self, ext: setuptools.Extension) -> None:

--- a/install/cupy_builder/_command.py
+++ b/install/cupy_builder/_command.py
@@ -99,6 +99,9 @@ class custom_build_ext(setuptools.command.build_ext.build_ext):  # type: ignore[
             sources_cpp = ['{}.cpp'.format(os.path.splitext(src)[0])
                            for src in sources_pyx]
             ext.sources = sources_cpp + sources_others
+            for src in ext.sources:
+                if not os.path.isfile(src):
+                    raise RuntimeError(f'Fatal error: missing file: {src}')
         super().build_extensions()
 
     def build_extension(self, ext: setuptools.Extension) -> None:

--- a/install/cupy_builder/_command.py
+++ b/install/cupy_builder/_command.py
@@ -8,9 +8,21 @@ import setuptools.command.build_ext
 import cupy_builder
 from cupy_builder._context import Context
 from cupy_builder.cupy_setup_build import cythonize
-from cupy_builder.cupy_setup_build import check_extensions
-from cupy_builder.cupy_setup_build import get_ext_modules
 from cupy_builder._compiler import DeviceCompilerUnix, DeviceCompilerWin32
+
+
+def filter_files_by_extension(
+        sources: List[str],
+        extension: str,
+) -> Tuple[List[str], List[str]]:
+    sources_selected = []
+    sources_others = []
+    for src in sources:
+        if os.path.splitext(src)[1] == extension:
+            sources_selected.append(src)
+        else:
+            sources_others.append(src)
+    return sources_selected, sources_others
 
 
 def compile_device_code(
@@ -24,13 +36,8 @@ def compile_device_code(
     - list of remaining (non-device) source files ("*.cpp")
     - list of compiled object files for device code ("*.o")
     """
-    sources_cu = []
-    sources_cpp = []
-    for src in ext.sources:  # type: ignore[attr-defined]
-        if os.path.splitext(src)[1] == '.cu':
-            sources_cu.append(src)
-        else:
-            sources_cpp.append(src)
+    sources_cu, sources_cpp = filter_files_by_extension(
+        ext.sources, '.cu')  # type: ignore[attr-defined]
     if len(sources_cu) == 0:
         # No device code used in this extension.
         return ext.sources, []  # type: ignore[attr-defined]
@@ -66,13 +73,6 @@ class custom_build_ext(setuptools.command.build_ext.build_ext):  # type: ignore[
 
     """Custom `build_ext` command to include CUDA C source files."""
 
-    def run(self) -> None:
-        ctx = cupy_builder.get_context()
-        ext_modules = get_ext_modules(True, ctx)  # get .pyx modules
-        cythonize(ext_modules, ctx)
-        check_extensions(self.extensions)
-        super().run()
-
     def build_extensions(self) -> None:
         num_jobs = int(os.environ.get('CUPY_NUM_BUILD_JOBS', '4'))
         if num_jobs > 1:
@@ -86,6 +86,21 @@ class custom_build_ext(setuptools.command.build_ext.build_ext):  # type: ignore[
                 # state as the init code is not locked and is not idempotent.
                 # https://github.com/pypa/setuptools/blob/v60.0.0/setuptools/_distutils/_msvccompiler.py#L322-L327
                 self.compiler.initialize()
+
+        # Compile "*.pyx" files into "*.cpp" files.
+        print('Cythonizing...')
+        cythonize(self.extensions, cupy_builder.get_context())
+
+        # Rewrite source filenames of each extension from "*.pyx" to "*.cpp".
+        # c.f. `Cython.Distutils.old_build_ext`
+        for ext in self.extensions:
+            sources_pyx, sources_others = filter_files_by_extension(
+                ext.sources, '.pyx')
+            sources_cpp = []
+            for src in sources_pyx:
+                sources_cpp.append('{}.cpp'.format(os.path.splitext(src)[0]))
+            ext.sources = sources_cpp + sources_others
+
         super().build_extensions()
 
     def build_extension(self, ext: setuptools.Extension) -> None:

--- a/install/cupy_builder/cupy_setup_build.py
+++ b/install/cupy_builder/cupy_setup_build.py
@@ -6,7 +6,6 @@ from distutils import sysconfig
 import os
 import shutil
 import sys
-from typing import List
 
 import pkg_resources
 import setuptools

--- a/install/cupy_builder/cupy_setup_build.py
+++ b/install/cupy_builder/cupy_setup_build.py
@@ -485,17 +485,6 @@ def cythonize(extensions, ctx: Context):
         compiler_directives=directives, **cythonize_options)
 
 
-def check_extensions(extensions: List[setuptools.Extension]) -> None:
-    for x in extensions:
-        for f in x.sources:
-            if not os.path.isfile(f):
-                raise RuntimeError('''\
-Missing file: {}
-Please install Cython.
-See https://docs.cupy.dev/en/stable/install.html for details.
-'''.format(f))
-
-
 def get_ext_modules(use_cython: bool, ctx: Context):
     # We need to call get_config_vars to initialize _config_vars in distutils
     # see #1849

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,14 @@ package_data = {
 
 package_data['cupy'] += cupy_setup_build.prepare_wheel_libs(ctx)
 
-ext_modules = cupy_setup_build.get_ext_modules(False, ctx)
+
+if sys.argv[1] == 'egg_info':
+    # Extensions are unnecessary for egg_info generation as all sources files
+    # can be enumerated via MANIFEST.in.
+    ext_modules = []
+else:
+    ext_modules = cupy_setup_build.get_ext_modules(True, ctx)
+
 
 # Get __version__ variable
 with open(os.path.join(source_root, 'cupy', '_version.py')) as f:

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ package_data = {
 package_data['cupy'] += cupy_setup_build.prepare_wheel_libs(ctx)
 
 
-if sys.argv[1] == 'egg_info':
+if len(sys.argv) < 2 or sys.argv[1] == 'egg_info':
     # Extensions are unnecessary for egg_info generation as all sources files
     # can be enumerated via MANIFEST.in.
     ext_modules = []

--- a/tests/install_tests/test_cupy_builder/test_command.py
+++ b/tests/install_tests/test_cupy_builder/test_command.py
@@ -1,0 +1,17 @@
+from cupy_builder._command import filter_files_by_extension
+
+
+def test_filter_files_by_extension():
+    sources_cpp = ['a.cpp', 'b.cpp']
+    sources_pyx = ['c.pyx']
+    sources = sources_cpp + sources_pyx
+    assert filter_files_by_extension(
+        sources, '.cpp') == (sources_cpp, sources_pyx)
+    assert filter_files_by_extension(
+        sources, '.pyx') == (sources_pyx, sources_cpp)
+    assert filter_files_by_extension(
+        sources, '.cu') == ([], sources)
+    assert filter_files_by_extension(
+        sources_cpp, '.cpp') == (sources_cpp, [])
+    assert filter_files_by_extension(
+        sources_cpp, '.pyx') == ([], sources_cpp)


### PR DESCRIPTION
This PR reduces the installation time by making the module configuration (`get_ext_modules`) happen only once during the setup process.

Currently, module configuration runs three times when doing `pip install -e .`.
`pip` launches `setup.py` two times:

* `setup.py egg_info` (configuration happens at [setup.py](https://github.com/cupy/cupy/blob/v11.0.0a1/setup.py#L85))
* `setup.py develop` (configuration happens at [setup.py](https://github.com/cupy/cupy/blob/v11.0.0a1/setup.py#L85) & [custom_build_ext](https://github.com/cupy/cupy/blob/v11.0.0a1/install/cupy_builder/cupy_setup_build.py#L796))

However, the first process is only for generating `egg-info` (to list setup requirements etc.), and does not need module configuration (https://github.com/cupy/cupy/issues/5722#issuecomment-1004566726). The second process can also be improved to run configuration only once. This PR fixes the both.

In my environment, `pip install -e .` overhead (i.e., installation time without any changes to the source tree) reduced from 22 sec to 12 sec.

Depends on ~#6382~ (merged)