### PR TITLE
Reduce memory usage in `cupy.sort`

### DIFF
--- a/tests/cupy_tests/sorting_tests/test_sort.py
+++ b/tests/cupy_tests/sorting_tests/test_sort.py
@@ -192,6 +192,14 @@ class TestSort(unittest.TestCase):
         out = xp.sort(a, axis=2)
         return out
 
+    # Large case
+
+    @testing.slow
+    @testing.numpy_cupy_array_equal()
+    def test_large(self, xp):
+        a = testing.shaped_random((17, 1023, 1023), xp)
+        return xp.sort(a, axis=-1)
+
 
 @testing.gpu
 class TestLexsort(unittest.TestCase):


### PR DESCRIPTION
Fix #6384.

- benchmark script

```py
import cupy
from cupyx.profiler import benchmark


a = cupy.ones((300,22,201,201), dtype=cupy.float32)

hook = cupy.cuda.memory_hooks.LineProfileHook()

with hook:
    cupy.sort(a)

hook.print_report()


perf = benchmark(cupy.sort, (a,), n_repeat=5, n_warmup=1)
print(perf)
```

- master
```
_root (6.96GB, 6.96GB)
  /home/imanishi/cupy1/run.py:10:<module> (6.96GB, 6.96GB)
    /home/imanishi/cupy1/cupy/_sorting/sort.py:31:sort (1017.18MB, 1017.18MB)
    /home/imanishi/cupy1/cupy/_sorting/sort.py:32:sort (5.96GB, 5.96GB)
sort                :    CPU:184308.036 us   +/-103.517 (min:184198.084 / max:184479.268) us     GPU-0:184334.335 us   +/-124.955 (min:184202.240 / max:184485.886) us
```

- this PR
```
_root (5.00GB, 1.09GB)
  /home/imanishi/cupy1/run.py:10:<module> (5.00GB, 1.09GB)
    /home/imanishi/cupy1/cupy/_sorting/sort.py:31:sort (1017.18MB, 1017.18MB)
    /home/imanishi/cupy1/cupy/_sorting/sort.py:32:sort (4.01GB, 96.03MB)
sort                :    CPU:156243.111 us   +/-603.928 (min:155888.005 / max:157442.373) us     GPU-0:156258.099 us   +/-623.392 (min:155891.708 / max:157496.323) us
```