### PR TITLE
Added dtype, fweights, aweights to cupy.cov

### DIFF
--- a/cupy/_statistics/correlation.py
+++ b/cupy/_statistics/correlation.py
@@ -78,7 +78,8 @@ def correlate(a, v, mode='valid'):
     return out
 
 
-def cov(a, y=None, rowvar=True, bias=False, ddof=None, fweights=None, aweights=None, *, dtype=None):
+def cov(a, y=None, rowvar=True, bias=False, ddof=None,
+        fweights=None, aweights=None, *, dtype=None):
     """Returns the covariance matrix of an array.
 
     This function currently does not support ``fweights`` and ``aweights``
@@ -100,9 +101,9 @@ def cov(a, y=None, rowvar=True, bias=False, ddof=None, fweights=None, aweights=N
         fweights (cupy.ndarray, int): 1-D array of integer frequency weights.
             the number of times each observation vector should be repeated.
         aweights (cupy.ndarray): 1-D array of observation vector weights.
-            These relative weights are typically large for observations 
-            considered "important" and smaller for observations considered 
-            less "important". If ``ddof=0`` the array of weights can be used 
+            These relative weights are typically large for observations
+            considered "important" and smaller for observations considered
+            less "important". If ``ddof=0`` the array of weights can be used
             to assign probabilities to observation vectors.
         dtype: Data type specifier. By default, the return data-type will have
             at least `numpy.float64` precision.
@@ -125,8 +126,10 @@ def cov(a, y=None, rowvar=True, bias=False, ddof=None, fweights=None, aweights=N
         else:
             if y.ndim > 2:
                 raise ValueError('y must be <= 2-d')
-            dtype = functools.reduce(numpy.promote_types,
-                                    (a.dtype, y.dtype, numpy.float64))
+            dtype = functools.reduce(
+                numpy.promote_types,
+                (a.dtype, y.dtype, numpy.float64)
+            )
 
     X = cupy.array(a, ndmin=2, dtype=dtype)
     if not rowvar and X.shape[0] != 1:
@@ -158,7 +161,7 @@ def cov(a, y=None, rowvar=True, bias=False, ddof=None, fweights=None, aweights=N
             raise ValueError(
                 "fweights cannot be negative")
         w = fweights
-    
+
     if aweights is not None:
         aweights = cupy.asarray(aweights, dtype=float)
         if aweights.ndim > 1:

--- a/cupy/_statistics/correlation.py
+++ b/cupy/_statistics/correlation.py
@@ -109,8 +109,8 @@ def cov(a, y=None, rowvar=True, bias=False, ddof=None,
             considered "important" and smaller for observations considered
             less "important". If ``ddof=0`` the array of weights can be used
             to assign probabilities to observation vectors.
-            It is required that fweights >= 0. However, the function will not
-            error when fweights < 0 for performance reasons.
+            It is required that aweights >= 0. However, the function will not
+            error when aweights < 0 for performance reasons.
         dtype: Data type specifier. By default, the return data-type will have
             at least `numpy.float64` precision.
 

--- a/cupy/_statistics/correlation.py
+++ b/cupy/_statistics/correlation.py
@@ -153,10 +153,10 @@ def cov(a, y=None, rowvar=True, bias=False, ddof=None,
 
     w = None
     if fweights is not None:
-        if not type(fweights) == cupy.ndarray: 
+        if not type(fweights) == cupy.ndarray:
             raise TypeError(
                 "fweights must be a cupy.ndarray")
-        if not fweights.dtype.char in 'bBhHiIlLqQ':
+        if fweights.dtype.char not in 'bBhHiIlLqQ':
             raise TypeError(
                 "fweights must be integer")
         fweights = fweights.astype(dtype=float)
@@ -169,7 +169,7 @@ def cov(a, y=None, rowvar=True, bias=False, ddof=None,
         w = fweights
 
     if aweights is not None:
-        if not type(aweights) == cupy.ndarray: 
+        if not type(aweights) == cupy.ndarray:
             raise TypeError(
                 "aweights must be a cupy.ndarray")
         aweights = aweights.astype(dtype=float)

--- a/cupy/_statistics/correlation.py
+++ b/cupy/_statistics/correlation.py
@@ -7,7 +7,7 @@ import cupy
 from cupy import _core
 
 
-def corrcoef(a, y=None, rowvar=True, bias=None, ddof=None):
+def corrcoef(a, y=None, rowvar=True, bias=None, ddof=None, *, dtype=None):
     """Returns the Pearson product-moment correlation coefficients of an array.
 
     Args:
@@ -31,7 +31,7 @@ def corrcoef(a, y=None, rowvar=True, bias=None, ddof=None):
         warnings.warn('bias and ddof have no effect and are deprecated',
                       DeprecationWarning)
 
-    out = cov(a, y, rowvar)
+    out = cov(a, y, rowvar, dtype=dtype)
     try:
         d = cupy.diag(out)
     except ValueError:
@@ -78,7 +78,7 @@ def correlate(a, v, mode='valid'):
     return out
 
 
-def cov(a, y=None, rowvar=True, bias=False, ddof=None):
+def cov(a, y=None, rowvar=True, bias=False, ddof=None, fweights=None, aweights=None, *, dtype=None):
     """Returns the covariance matrix of an array.
 
     This function currently does not support ``fweights`` and ``aweights``
@@ -97,6 +97,16 @@ def cov(a, y=None, rowvar=True, bias=False, ddof=None):
             overridden. Note that ``ddof=1`` will return the unbiased estimate
             and ``ddof=0`` will return the simple average.
 
+        fweights (cupy.ndarray, int): 1-D array of integer frequency weights.
+            the number of times each observation vector should be repeated.
+        aweights (cupy.ndarray): 1-D array of observation vector weights.
+            These relative weights are typically large for observations 
+            considered "important" and smaller for observations considered 
+            less "important". If ``ddof=0`` the array of weights can be used 
+            to assign probabilities to observation vectors.
+        dtype: Data type specifier. By default, the return data-type will have
+            at least `numpy.float64` precision.
+
     Returns:
         cupy.ndarray: The covariance matrix of the input array.
 
@@ -109,13 +119,14 @@ def cov(a, y=None, rowvar=True, bias=False, ddof=None):
     if a.ndim > 2:
         raise ValueError('Input must be <= 2-d')
 
-    if y is None:
-        dtype = numpy.promote_types(a.dtype, numpy.float64)
-    else:
-        if y.ndim > 2:
-            raise ValueError('y must be <= 2-d')
-        dtype = functools.reduce(numpy.promote_types,
-                                 (a.dtype, y.dtype, numpy.float64))
+    if dtype is None:
+        if y is None:
+            dtype = numpy.promote_types(a.dtype, numpy.float64)
+        else:
+            if y.ndim > 2:
+                raise ValueError('y must be <= 2-d')
+            dtype = functools.reduce(numpy.promote_types,
+                                    (a.dtype, y.dtype, numpy.float64))
 
     X = cupy.array(a, ndmin=2, dtype=dtype)
     if not rowvar and X.shape[0] != 1:
@@ -131,13 +142,62 @@ def cov(a, y=None, rowvar=True, bias=False, ddof=None):
     if ddof is None:
         ddof = 0 if bias else 1
 
-    fact = X.shape[1] - ddof
+    w = None
+    if fweights is not None:
+        fweights = cupy.asarray(fweights, dtype=float)
+        if not cupy.all(fweights == cupy.around(fweights)):
+            raise TypeError(
+                "fweights must be integer")
+        if fweights.ndim > 1:
+            raise RuntimeError(
+                "cannot handle multidimensional fweights")
+        if fweights.shape[0] != X.shape[1]:
+            raise RuntimeError(
+                "incompatible numbers of samples and fweights")
+        if any(fweights < 0):
+            raise ValueError(
+                "fweights cannot be negative")
+        w = fweights
+    
+    if aweights is not None:
+        aweights = cupy.asarray(aweights, dtype=float)
+        if aweights.ndim > 1:
+            raise RuntimeError(
+                "cannot handle multidimensional aweights")
+        if aweights.shape[0] != X.shape[1]:
+            raise RuntimeError(
+                "incompatible numbers of samples and aweights")
+        if any(aweights < 0):
+            raise ValueError(
+                "aweights cannot be negative")
+        if w is None:
+            w = aweights
+        else:
+            w *= aweights
+
+    avg, w_sum = cupy.average(X, axis=1, weights=w, returned=True)
+    w_sum = w_sum[0]
+
+    # Determine the normalization
+    if w is None:
+        fact = X.shape[1] - ddof
+    elif ddof == 0:
+        fact = w_sum
+    elif aweights is None:
+        fact = w_sum - ddof
+    else:
+        fact = w_sum - ddof*sum(w*aweights)/w_sum
+
     if fact <= 0:
         warnings.warn('Degrees of freedom <= 0 for slice',
                       RuntimeWarning, stacklevel=2)
         fact = 0.0
 
     X -= X.mean(axis=1)[:, None]
-    out = X.dot(X.T.conj()) * (1 / cupy.float64(fact))
+    if w is None:
+        X_T = X.T
+    else:
+        X_T = (X*w).T
+    out = X.dot(X_T.conj()) * (1 / cupy.float64(fact))
 
     return out.squeeze()

--- a/tests/cupy_tests/statistics_tests/test_correlation.py
+++ b/tests/cupy_tests/statistics_tests/test_correlation.py
@@ -81,7 +81,7 @@ class TestCov(unittest.TestCase):
             a, y = self.generate_input(a_shape, y_shape, xp, dtype)
             with pytest.raises(ValueError):
                 xp.cov(a, y, rowvar, bias, ddof,
-                      fweights, aweights, dtype=dtype)
+                       fweights, aweights, dtype=dtype)
 
     def test_cov(self):
         self.check((2, 3))

--- a/tests/cupy_tests/statistics_tests/test_correlation.py
+++ b/tests/cupy_tests/statistics_tests/test_correlation.py
@@ -60,7 +60,8 @@ class TestCov(unittest.TestCase):
               ddof=None, xp=None, dtype=None,
               fweights=None, aweights=None):
         a, y = self.generate_input(a_shape, y_shape, xp, dtype)
-        return xp.cov(a, y, rowvar, bias, ddof, fweights, aweights, dtype=dtype)
+        return xp.cov(a, y, rowvar, bias, ddof,
+                    fweights, aweights, dtype=dtype)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
@@ -69,7 +70,8 @@ class TestCov(unittest.TestCase):
                     fweights=None, aweights=None):
         with testing.assert_warns(RuntimeWarning):
             a, y = self.generate_input(a_shape, y_shape, xp, dtype)
-            return xp.cov(a, y, rowvar, bias, ddof, fweights, aweights, dtype=dtype)
+            return xp.cov(a, y, rowvar, bias, ddof,
+                        fweights, aweights, dtype=dtype)
 
     @testing.for_all_dtypes()
     def check_raises(self, a_shape, y_shape=None,
@@ -78,7 +80,8 @@ class TestCov(unittest.TestCase):
         for xp in (numpy, cupy):
             a, y = self.generate_input(a_shape, y_shape, xp, dtype)
             with pytest.raises(ValueError):
-                xp.cov(a, y, rowvar, bias, ddof, fweights, aweights, dtype=dtype)
+                xp.cov(a, y, rowvar, bias, ddof,
+                    fweights, aweights, dtype=dtype)
 
     def test_cov(self):
         self.check((2, 3))

--- a/tests/cupy_tests/statistics_tests/test_correlation.py
+++ b/tests/cupy_tests/statistics_tests/test_correlation.py
@@ -35,13 +35,14 @@ class TestCorrcoef(unittest.TestCase):
         a = testing.shaped_arange((2, 3), xp, dtype)
         y = testing.shaped_arange((2, 3), xp, dtype)
         return xp.corrcoef(a, y=y, rowvar=False)
-    
+
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_corrcoef_dtype(self, xp, dtype):
         a = testing.shaped_arange((2, 3), xp, dtype)
         y = testing.shaped_arange((2, 3), xp, dtype)
         return xp.corrcoef(a, y=y, dtype=dtype)
+
 
 @testing.gpu
 class TestCov(unittest.TestCase):
@@ -56,21 +57,24 @@ class TestCov(unittest.TestCase):
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def check(self, a_shape, y_shape=None, rowvar=True, bias=False,
-              ddof=None, xp=None, dtype=None, fweights=None, aweights=None):
+              ddof=None, xp=None, dtype=None,
+              fweights=None, aweights=None):
         a, y = self.generate_input(a_shape, y_shape, xp, dtype)
         return xp.cov(a, y, rowvar, bias, ddof, fweights, aweights, dtype=dtype)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def check_warns(self, a_shape, y_shape=None, rowvar=True, bias=False,
-                    ddof=None, xp=None, dtype=None, fweights=None, aweights=None):
+                    ddof=None, xp=None, dtype=None,
+                    fweights=None, aweights=None):
         with testing.assert_warns(RuntimeWarning):
             a, y = self.generate_input(a_shape, y_shape, xp, dtype)
             return xp.cov(a, y, rowvar, bias, ddof, fweights, aweights, dtype=dtype)
 
     @testing.for_all_dtypes()
-    def check_raises(self, a_shape, y_shape=None, rowvar=True, bias=False,
-                     ddof=None, dtype=None, fweights=None, aweights=None):
+    def check_raises(self, a_shape, y_shape=None,
+                     rowvar=True, bias=False, ddof=None,
+                     dtype=None, fweights=None, aweights=None):
         for xp in (numpy, cupy):
             a, y = self.generate_input(a_shape, y_shape, xp, dtype)
             with pytest.raises(ValueError):

--- a/tests/cupy_tests/statistics_tests/test_correlation.py
+++ b/tests/cupy_tests/statistics_tests/test_correlation.py
@@ -35,7 +35,13 @@ class TestCorrcoef(unittest.TestCase):
         a = testing.shaped_arange((2, 3), xp, dtype)
         y = testing.shaped_arange((2, 3), xp, dtype)
         return xp.corrcoef(a, y=y, rowvar=False)
-
+    
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose()
+    def test_corrcoef_dtype(self, xp, dtype):
+        a = testing.shaped_arange((2, 3), xp, dtype)
+        y = testing.shaped_arange((2, 3), xp, dtype)
+        return xp.corrcoef(a, y=y, dtype=dtype)
 
 @testing.gpu
 class TestCov(unittest.TestCase):
@@ -50,25 +56,25 @@ class TestCov(unittest.TestCase):
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def check(self, a_shape, y_shape=None, rowvar=True, bias=False,
-              ddof=None, xp=None, dtype=None):
+              ddof=None, xp=None, dtype=None, fweights=None, aweights=None):
         a, y = self.generate_input(a_shape, y_shape, xp, dtype)
-        return xp.cov(a, y, rowvar, bias, ddof)
+        return xp.cov(a, y, rowvar, bias, ddof, fweights, aweights, dtype=dtype)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def check_warns(self, a_shape, y_shape=None, rowvar=True, bias=False,
-                    ddof=None, xp=None, dtype=None):
+                    ddof=None, xp=None, dtype=None, fweights=None, aweights=None):
         with testing.assert_warns(RuntimeWarning):
             a, y = self.generate_input(a_shape, y_shape, xp, dtype)
-            return xp.cov(a, y, rowvar, bias, ddof)
+            return xp.cov(a, y, rowvar, bias, ddof, fweights, aweights, dtype=dtype)
 
     @testing.for_all_dtypes()
     def check_raises(self, a_shape, y_shape=None, rowvar=True, bias=False,
-                     ddof=None, dtype=None):
+                     ddof=None, dtype=None, fweights=None, aweights=None):
         for xp in (numpy, cupy):
             a, y = self.generate_input(a_shape, y_shape, xp, dtype)
             with pytest.raises(ValueError):
-                xp.cov(a, y, rowvar, bias, ddof)
+                xp.cov(a, y, rowvar, bias, ddof, fweights, aweights, dtype=dtype)
 
     def test_cov(self):
         self.check((2, 3))
@@ -77,6 +83,7 @@ class TestCov(unittest.TestCase):
         self.check((2, 3), (2, 3), rowvar=False)
         self.check((2, 3), bias=True)
         self.check((2, 3), ddof=2)
+        self.check((2, 3))
 
     def test_cov_warns(self):
         self.check_warns((2, 3), ddof=3)

--- a/tests/cupy_tests/statistics_tests/test_correlation.py
+++ b/tests/cupy_tests/statistics_tests/test_correlation.py
@@ -61,7 +61,7 @@ class TestCov(unittest.TestCase):
               fweights=None, aweights=None):
         a, y = self.generate_input(a_shape, y_shape, xp, dtype)
         return xp.cov(a, y, rowvar, bias, ddof,
-                    fweights, aweights, dtype=dtype)
+                      fweights, aweights, dtype=dtype)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
@@ -71,7 +71,7 @@ class TestCov(unittest.TestCase):
         with testing.assert_warns(RuntimeWarning):
             a, y = self.generate_input(a_shape, y_shape, xp, dtype)
             return xp.cov(a, y, rowvar, bias, ddof,
-                        fweights, aweights, dtype=dtype)
+                          fweights, aweights, dtype=dtype)
 
     @testing.for_all_dtypes()
     def check_raises(self, a_shape, y_shape=None,
@@ -81,7 +81,7 @@ class TestCov(unittest.TestCase):
             a, y = self.generate_input(a_shape, y_shape, xp, dtype)
             with pytest.raises(ValueError):
                 xp.cov(a, y, rowvar, bias, ddof,
-                    fweights, aweights, dtype=dtype)
+                      fweights, aweights, dtype=dtype)
 
     def test_cov(self):
         self.check((2, 3))
@@ -91,6 +91,11 @@ class TestCov(unittest.TestCase):
         self.check((2, 3), bias=True)
         self.check((2, 3), ddof=2)
         self.check((2, 3))
+        self.check((1, 3), fweights=cupy.array([1, 4, 1]))
+        self.check((1, 3), aweights=cupy.array([1.0, 4.0, 1.0]))
+        self.check((1, 3), bias=True, aweights=cupy.array([1.0, 4.0, 1.0]))
+        self.check((1, 3), fweights=cupy.array([1, 4, 1]),
+                   aweights=cupy.array([1.0, 4.0, 1.0]))
 
     def test_cov_warns(self):
         self.check_warns((2, 3), ddof=3)


### PR DESCRIPTION
**Note**
I have not been able to get the unit tests running on my computer, so adding unit tests and performing them still needs to be done. Apologies for this.

The arguments dtype, fweights and aweights have been added to the cupy.cov method. Furthermore, the dtype argument has been added to the corrcoef method. The ordering of arguments follows the numpy implementation