### PR TITLE
Fix `cupyx.ndimage.spline_filter1d` for HIP

### DIFF
--- a/cupyx/scipy/ndimage/_spline_prefilter_core.py
+++ b/cupyx/scipy/ndimage/_spline_prefilter_core.py
@@ -169,7 +169,9 @@ def _get_spline1d_code(mode, poles, n_boundary):
         for (i = 1; i < n; ++i) {{
             c[i * element_stride] += z * c[(i - 1) * element_stride];
         }}''')
-
+        code.append('''
+        __syncthreads();
+        ''')
         # initialize and apply the anti-causal filter
         code.append(_anticausal_init_code(mode))
         code.append('''

--- a/cupyx/scipy/ndimage/_spline_prefilter_core.py
+++ b/cupyx/scipy/ndimage/_spline_prefilter_core.py
@@ -170,7 +170,9 @@ def _get_spline1d_code(mode, poles, n_boundary):
             c[i * element_stride] += z * c[(i - 1) * element_stride];
         }}''')
         code.append('''
+        #ifdef __HIP_DEVICE_COMPILE__
         __syncthreads();
+        #endif
         ''')
         # initialize and apply the anti-causal filter
         code.append(_anticausal_init_code(mode))


### PR DESCRIPTION
Fixes an issue with some `cupyx.scipy.ndimage` routines that relied in `spline_filter` for input preprocessing in HIP environments.

This issue is similar to #4504, some of the values are not being updated in memory unless thread synchronization happens.

cc @grlee77 for future reference :)