### PR TITLE
Add `cupy.intersect1d` API

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -493,6 +493,7 @@ from cupy._logic.type_test import isreal  # NOQA
 from cupy._logic.type_test import isrealobj  # NOQA
 
 from cupy._logic.truth import in1d  # NOQA
+from cupy._logic.truth import intersect1d  # NOQA
 from cupy._logic.truth import isin  # NOQA
 
 

--- a/cupy/_logic/truth.py
+++ b/cupy/_logic/truth.py
@@ -98,6 +98,79 @@ def in1d(ar1, ar2, assume_unique=False, invert=False):
     return v1 == v2 if invert else v1 != v2
 
 
+def intersect1d(ar1, ar2, assume_unique=False, return_indices=False):
+    """Find the intersection of two arrays.
+
+    Return the sorted, unique values that are in both of the input arrays.
+
+    Args:
+        ar1 (cupy.ndarray): Input array.
+        ar2 (cupy.ndarray): The values against which to test each value of
+            ``ar1``.
+        assume_unique (bool, optional): If ``True``, the input arrays are
+            both assumed to be unique, which can speed up the calculation.
+            If ``True`` but ``ar1`` or ``ar2`` are not unique, incorrect
+            results and out-of-bounds indices could result.
+            Default is ``False``.
+        return_indices (bool, optional): If ``True``, the indices which
+            correspond to the intersection of the two arrays are returned.
+            The first instance of a value is used if there are multiple.
+            Default is ``False``.
+
+    Returns:
+        intersect1d (cupy.ndarray):
+            Sorted 1D array of common and unique elements.
+
+        comm1 (cupy.ndarray):
+            The indices of the first occurrences of the common values
+            in ``ar1``. Only provided if ``return_indices`` is True.
+
+        comm2 (cupy.ndarray):
+            The indices of the first occurrences of the common values
+            in ``ar2``. Only provided if ``return_indices`` is True.
+
+    .. seealso:: :func:`numpy.intersect1d`
+
+    """
+
+    if not assume_unique:
+        if return_indices:
+            ar1, ind1 = cupy.unique(ar1, return_index=True)
+            ar2, ind2 = cupy.unique(ar2, return_index=True)
+        else:
+            ar1 = cupy.unique(ar1)
+            ar2 = cupy.unique(ar2)
+    else:
+        ar1 = ar1.ravel()
+        ar2 = ar2.ravel()
+
+    if return_indices:
+        ar2_sort_indices = cupy.argsort(ar2)
+        ar2 = ar2[ar2_sort_indices]
+    else:
+        ar2 = cupy.sort(ar2)
+
+    # Use brilliant searchsorted trick
+    # https://github.com/cupy/cupy/pull/4018#discussion_r495790724
+    v1 = cupy.searchsorted(ar2, ar1, 'left')
+    v2 = cupy.searchsorted(ar2, ar1, 'right')
+
+    mask = v1 != v2
+
+    int1d = ar1[mask]
+
+    if return_indices:
+        ar1_indices = cupy.flatnonzero(mask)
+        ar2_indices = ar2_sort_indices[v2[mask]-1]
+        if not assume_unique:
+            ar1_indices = ind1[ar1_indices]
+            ar2_indices = ind2[ar2_indices]
+
+        return int1d, ar1_indices, ar2_indices
+    else:
+        return int1d
+
+
 def isin(element, test_elements, assume_unique=False, invert=False):
     """Calculates element in ``test_elements``, broadcasting over ``element``
     only. Returns a boolean array of the same shape as ``element`` that is

--- a/docs/source/reference/set.rst
+++ b/docs/source/reference/set.rst
@@ -21,4 +21,5 @@ Boolean operations
    :toctree: generated/
 
    in1d
+   intersect1d
    isin

--- a/tests/cupy_tests/logic_tests/test_truth.py
+++ b/tests/cupy_tests/logic_tests/test_truth.py
@@ -92,6 +92,43 @@ class TestAllAnyAlias:
 
 @testing.parameterize(
     *testing.product(
+        {'f': ['intersect1d'],
+         'shape_x': [
+             (0, ),
+             (3, ),
+             (2, 3),
+             (2, 1, 3),
+             (2, 0, 1),
+             (2, 0, 1, 1)
+        ],
+            'shape_y': [
+             (0, ),
+             (3, ),
+             (2, 3),
+             (2, 1, 3),
+             (2, 0, 1),
+             (2, 0, 1, 1)
+        ],
+            'assume_unique': [False, True],
+            'return_indices': [False, True]}))
+@testing.gpu
+class TestIntersect1D:
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test(self, xp, dtype):
+        x = testing.shaped_arange(self.shape_x, xp, dtype)
+        y = testing.shaped_arange(self.shape_y, xp, dtype)
+
+        if dtype == numpy.bool_:
+            self.assume_unique = False
+
+        return getattr(xp, self.f)(x, y, self.assume_unique,
+                                   self.return_indices)
+
+
+@testing.parameterize(
+    *testing.product(
         {'f': ['in1d', 'isin'],
          'shape_x': [
              (0, ),


### PR DESCRIPTION
Hi,
This PR aims to add `cupy.intersect1d` API mention in #6078. 

I had used `cupy.flatnonzero`, `unique` which have warning of '_may synchronize the device_'.
It would be great if someone provides suggestions to improvise it.

Thank You!