### PR TITLE
Allow `__cuda_array_interface__` in HIP

### DIFF
--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -190,9 +190,6 @@ cdef class ndarray:
 
     @property
     def __cuda_array_interface__(self):
-        if runtime._is_hip_environment:
-            raise AttributeError(
-                'HIP/ROCm does not support cuda array interface')
         cdef dict desc = {
             'shape': self.shape,
             'typestr': self.dtype.str,
@@ -200,6 +197,8 @@ cdef class ndarray:
         }
         cdef int ver = _util.CUDA_ARRAY_INTERFACE_EXPORT_VERSION
         cdef intptr_t stream_ptr
+        if runtime._is_hip_environment:
+            ver = 2
 
         if ver == 3:
             stream_ptr = stream_module.get_current_stream_ptr()
@@ -2623,9 +2622,6 @@ cpdef ndarray asfortranarray(ndarray a, dtype=None):
 
 
 cpdef ndarray _convert_object_with_cuda_array_interface(a):
-    if runtime._is_hip_environment:
-        raise RuntimeError(
-            'HIP/ROCm does not support cuda array interface')
 
     cdef Py_ssize_t sh, st
     cdef dict desc = a.__cuda_array_interface__

--- a/tests/cupy_tests/core_tests/test_ndarray.py
+++ b/tests/cupy_tests/core_tests/test_ndarray.py
@@ -360,22 +360,6 @@ class TestNdarrayCudaInterfaceStream(unittest.TestCase):
                 assert iface['stream'] == stream.ptr
 
 
-@pytest.mark.skipif(not cupy.cuda.runtime.is_hip,
-                    reason='This is supported on CUDA')
-class TestNdarrayCudaInterfaceNoneCUDA(unittest.TestCase):
-
-    def setUp(self):
-        self.arr = cupy.zeros(shape=(2, 3), dtype=cupy.float64)
-
-    def test_cuda_array_interface_hasattr(self):
-        assert not hasattr(self.arr, '__cuda_array_interface__')
-
-    def test_cuda_array_interface_getattr(self):
-        with pytest.raises(AttributeError) as e:
-            getattr(self.arr, '__cuda_array_interface__')
-        assert 'HIP' in str(e.value)
-
-
 @testing.parameterize(
     *testing.product({
         'indices_shape': [(2,), (2, 3)],

--- a/tests/cupy_tests/lib_tests/test_polynomial.py
+++ b/tests/cupy_tests/lib_tests/test_polynomial.py
@@ -321,8 +321,6 @@ class TestPoly1dPolynomialArithmetic(Poly1dTestBase):
     'type_l': ['poly1d', 'ndarray', 'python_scalar', 'numpy_scalar'],
     'type_r': ['poly1d'],
 }))
-@pytest.mark.xfail(runtime.is_hip,
-                   reason='HIP/ROCm does not support cuda array interface')
 class TestPoly1dMathArithmetic(Poly1dTestBase):
 
     @testing.for_all_dtypes()


### PR DESCRIPTION
This should fix

```
cupy_tests/lib_tests/test_polynomial.py::TestPoly1dPolynomialArithmetic::test_poly1d_arithmetic[_param_8_{func=<lambda>, type_l='ndarray', type_r='poly1d'}]
cupy_tests/lib_tests/test_polynomial.py::TestPoly1dPolynomialArithmetic::test_poly1d_arithmetic[_param_20_{func=<lambda>, type_l='ndarray', type_r='poly1d'}]
cupy_tests/lib_tests/test_polynomial.py::TestPoly1dPolynomialArithmetic::test_poly1d_arithmetic[_param_32_{func=<lambda>, type_l='ndarray', type_r='poly1d'}]
```

tests in hip, we can actually use this but we have to resort to v2 to avoid issues with stream sync.

TODO: run tests with hip