### PR TITLE
Add `__cupy_get_ndarray__` dunder method to transform objects to arrays'

### DIFF
--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -19,7 +19,6 @@ from cupy.cuda cimport texture
 from cupy._core cimport _accelerator
 from cupy._core cimport _carray
 from cupy._core cimport _scalar
-from cupy._core.dlpack cimport from_dlpack
 from cupy._core._dtype cimport get_dtype
 from cupy._core._memory_range cimport may_share_bounds
 from cupy._core._scalar import get_typename as _get_typename
@@ -122,8 +121,8 @@ cdef list _preprocess_args(int dev_id, args, bint use_c_scalar):
         elif hasattr(arg, '__cuda_array_interface__'):
             s = _convert_object_with_cuda_array_interface(arg)
             _check_peer_access(<ndarray>s, dev_id)
-        elif hasattr(arg, '__dlpack__'):
-            s = from_dlpack(arg)
+        elif hasattr(arg, '__cupy_get_ndarray__'):
+            s = arg.__cupy_get_ndarray__()
             _check_peer_access(<ndarray>s, dev_id)
         else:  # scalars or invalid args
             if use_c_scalar:

--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -19,6 +19,7 @@ from cupy.cuda cimport texture
 from cupy._core cimport _accelerator
 from cupy._core cimport _carray
 from cupy._core cimport _scalar
+from cupy._core.dlpack cimport from_dlpack
 from cupy._core._dtype cimport get_dtype
 from cupy._core._memory_range cimport may_share_bounds
 from cupy._core._scalar import get_typename as _get_typename
@@ -120,6 +121,9 @@ cdef list _preprocess_args(int dev_id, args, bint use_c_scalar):
             s = arg
         elif hasattr(arg, '__cuda_array_interface__'):
             s = _convert_object_with_cuda_array_interface(arg)
+            _check_peer_access(<ndarray>s, dev_id)
+        elif hasattr(arg, '__dlpack__'):
+            s = from_dlpack(arg)
             _check_peer_access(<ndarray>s, dev_id)
         else:  # scalars or invalid args
             if use_c_scalar:

--- a/cupy/_core/_reduction.pyx
+++ b/cupy/_core/_reduction.pyx
@@ -25,6 +25,7 @@ from cupy._core.core cimport _convert_object_with_cuda_array_interface
 from cupy._core.core cimport _create_ndarray_from_shape_strides
 from cupy._core.core cimport compile_with_cache
 from cupy._core.core cimport ndarray
+from cupy._core.dlpack cimport from_dlpack
 from cupy._core cimport internal
 from cupy.cuda cimport device
 from cupy.cuda cimport function
@@ -546,6 +547,8 @@ cdef class _SimpleReductionKernel(_AbstractReductionKernel):
             arr = a
         elif hasattr(a, '__cuda_array_interface__'):
             arr = _convert_object_with_cuda_array_interface(a)
+        elif hasattr(a, '__dlpack__'):
+            arr = from_dlpack(a)
         else:
             raise TypeError(
                 'Argument \'a\' has incorrect type (expected %s, got %s)' %

--- a/cupy/_core/_reduction.pyx
+++ b/cupy/_core/_reduction.pyx
@@ -25,7 +25,6 @@ from cupy._core.core cimport _convert_object_with_cuda_array_interface
 from cupy._core.core cimport _create_ndarray_from_shape_strides
 from cupy._core.core cimport compile_with_cache
 from cupy._core.core cimport ndarray
-from cupy._core.dlpack cimport from_dlpack
 from cupy._core cimport internal
 from cupy.cuda cimport device
 from cupy.cuda cimport function
@@ -547,8 +546,8 @@ cdef class _SimpleReductionKernel(_AbstractReductionKernel):
             arr = a
         elif hasattr(a, '__cuda_array_interface__'):
             arr = _convert_object_with_cuda_array_interface(a)
-        elif hasattr(a, '__dlpack__'):
-            arr = from_dlpack(a)
+        elif hasattr(a, '__cupy_get_ndarray__'):
+            arr = a.__cupy_get_ndarray__()
         else:
             raise TypeError(
                 'Argument \'a\' has incorrect type (expected %s, got %s)' %

--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -1577,7 +1577,7 @@ cdef class ndarray:
                 # Except for numpy.ndarray, types should be supported by
                 # `_kernel._preprocess_args`.
                 check = (hasattr(x, '__cuda_array_interface__')
-                         or hasattr(x, '__dlpack__'))
+                         or hasattr(x, '__cupy_get_ndarray__'))
                 if runtime._is_hip_environment and isinstance(x, ndarray):
                     check = True
                 if (not check

--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -1576,7 +1576,8 @@ cdef class ndarray:
                 # implicit host-to-device conversion.
                 # Except for numpy.ndarray, types should be supported by
                 # `_kernel._preprocess_args`.
-                check = hasattr(x, '__cuda_array_interface__')
+                check = (hasattr(x, '__cuda_array_interface__')
+                         or hasattr(x, '__dlpack__'))
                 if runtime._is_hip_environment and isinstance(x, ndarray):
                     check = True
                 if (not check

--- a/cupy/lib/_polynomial.pyx
+++ b/cupy/lib/_polynomial.pyx
@@ -106,6 +106,12 @@ cdef class poly1d:
     def __cuda_array_interface__(self):
         return self.coeffs.__cuda_array_interface__
 
+    def __dlpack__(self, stream=None):
+        return self.coeffs.__dlpack__(stream)
+
+    def __dlpack_device__(self):
+        return self.coeffs.__dlpack_device__()
+
     def __array__(self, dtype=None):
         raise TypeError(
             'Implicit conversion to a NumPy array is not allowed. '

--- a/cupy/lib/_polynomial.pyx
+++ b/cupy/lib/_polynomial.pyx
@@ -102,15 +102,8 @@ cdef class poly1d:
             variable = 'x'
         self._variable = variable
 
-    @property
-    def __cuda_array_interface__(self):
-        return self.coeffs.__cuda_array_interface__
-
-    def __dlpack__(self, stream=None):
-        return self.coeffs.__dlpack__(stream)
-
-    def __dlpack_device__(self):
-        return self.coeffs.__dlpack_device__()
+    def __cupy_get_ndarray__(self):
+        return self.coeffs
 
     def __array__(self, dtype=None):
         raise TypeError(

--- a/tests/cupy_tests/lib_tests/test_polynomial.py
+++ b/tests/cupy_tests/lib_tests/test_polynomial.py
@@ -321,8 +321,6 @@ class TestPoly1dPolynomialArithmetic(Poly1dTestBase):
     'type_l': ['poly1d', 'ndarray', 'python_scalar', 'numpy_scalar'],
     'type_r': ['poly1d'],
 }))
-@pytest.mark.xfail(runtime.is_hip,
-                   reason='HIP/ROCm does not support cuda array interface')
 class TestPoly1dMathArithmetic(Poly1dTestBase):
 
     @testing.for_all_dtypes()


### PR DESCRIPTION
Alternative to #6413

in HIP `__cuda_array_interface__` is not well defined, so it causes some functionality that relies on it such as polynomial API to fail where it shouldn't because it is being used as a hack to transform a regular object into a cupy ndarray in a really convoluted way.
We add a method to transform objects into ndarrays explicitly, avoiding the obscurity of the previous approach.


This PR fixes

```
cupy_tests/lib_tests/test_polynomial.py::TestPoly1dPolynomialArithmetic::test_poly1d_arithmetic[_param_8_{func=<lambda>, type_l='ndarray', type_r='poly1d'}]
cupy_tests/lib_tests/test_polynomial.py::TestPoly1dPolynomialArithmetic::test_poly1d_arithmetic[_param_20_{func=<lambda>, type_l='ndarray', type_r='poly1d'}]
cupy_tests/lib_tests/test_polynomial.py::TestPoly1dPolynomialArithmetic::test_poly1d_arithmetic[_param_32_{func=<lambda>, type_l='ndarray', type_r='poly1d'}]
```