### PR TITLE
CI: Use default schema/matrix path in `generate.py`

### DIFF
--- a/.pfnci/README.md
+++ b/.pfnci/README.md
@@ -2,18 +2,16 @@
 
 CuPy uses two infrastructures for GPU tests.
 
-* FlexCI (`pfn-public-ci`): GCP, Linux/Windows, CUDA only
-* Jenkins: on-premise, Linux only, CUDA/ROCm
-
-Currently most of test configurations are managed by [chainer-test](http://github.com/chainer/chainer-test), which contains a set of scripts for Jenkins, but we are gradually migrating to new tooling in this directory.
-We are also gradually migrating from Jenkins to FlexCI for better performance; eventually Jenkins will only be used for ROCm tests.
+* FlexCI (`pfn-public-ci`): GCP, Linux/Windows + CUDA tests
+* Jenkins: on-premise, Linux + ROCm tests
 
 This directory contains the test matrix definition, and a tool to generate test environment from the matrix.
 
-* `schema.yaml` defines all the possible values for each test axis, and constraints between them.
-* `matrix.yaml` defines the configuration of each matrix.
-* `generate.py` generates the test environment (Dockerfile/shell script for Linux, PowerShell script for Windows) for each matrix from the schema and the matrix.
-  This program also generates `coverage.md` to see the configuration coverage.
+* [`schema.yaml`](schema.yml) defines all the possible values for each test axis (e.g., `cuda`, `python`, `numpy`), and constraints between them.
+* [`matrix.yaml`](matrix.yml) defines the configuration of each test matrix (e.g., `cupy.linux.cuda115`.)
+* [`generate.py`](generate.py) generates the test assets (Dockerfile/shell script for Linux, PowerShell script for Windows) for each matrix from the schema and the matrix.
+  This program also generates [`coverage.md`](coverage.md) to see the configuration coverage.
+* [`config.pbtxt`](config.pbtxt) is a FlexCI configuration file that defines hardware configurations of each test matrix.
 
 ## Usage
 
@@ -21,13 +19,12 @@ To generate `linux/tests/*.Dockerfile`, `linux/tests/*.sh` and `coverage.md`:
 
 ```
 pip install PyYAML
-./generate.py -s schema.yaml -m matrix.yaml
+./generate.py
 ```
 
 ## Future work
 
 * Support generating Windows test environment.
-* Test notifications to Gitter.
 * Generate shuffle tests from `schema.yaml`.
 * Support using OS-provided Python binary packages instead of pyenv.
 * Support coverage reporting.


### PR DESCRIPTION
I noticed that we need to run `generate.py` frequently than I initially thought (e.g. when there is a conflict on backport) so let's give these options default values. Now `./generate.py` does everything.