### PR TITLE
Skip hfft related tests in HIP

### DIFF
--- a/tests/cupyx_tests/scipy_tests/fft_tests/test_fft.py
+++ b/tests/cupyx_tests/scipy_tests/fft_tests/test_fft.py
@@ -1677,8 +1677,8 @@ class TestHfft2:
         testing.assert_array_equal(x, x_orig)
         return _correct_np_dtype(xp, dtype, out)
 
-    @pytest.mark.skipif(cp.cuda.runtime.is_hip,  # see #6427
-                        reason="Flaky in HIP when running with other tests")
+    @pytest.mark.xfail(cp.cuda.runtime.is_hip, strict=False,  # see #6427
+                       reason="Flaky in HIP when running with other tests")
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
                                  contiguous_check=False)
@@ -1690,8 +1690,8 @@ class TestHfft2:
         testing.assert_array_equal(x, x_orig)
         return _correct_np_dtype(xp, dtype, out)
 
-    @pytest.mark.skipif(cp.cuda.runtime.is_hip,  # see #6427
-                        reason="Flaky in HIP when running with other tests")
+    @pytest.mark.xfail(cp.cuda.runtime.is_hip, strict=False,  # see #6427
+                       reason="Flaky in HIP when running with other tests")
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
                                  contiguous_check=False)
@@ -1757,8 +1757,8 @@ class TestHfftn:
         testing.assert_array_equal(x, x_orig)
         return _correct_np_dtype(xp, dtype, out)
 
-    @pytest.mark.skipif(cp.cuda.runtime.is_hip,  # see #6427
-                        reason="Flaky in HIP when running with other tests")
+    @pytest.mark.xfail(cp.cuda.runtime.is_hip, strict=False,  # see #6427
+                       reason="Flaky in HIP when running with other tests")
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
                                  contiguous_check=False)
@@ -1770,8 +1770,8 @@ class TestHfftn:
         testing.assert_array_equal(x, x_orig)
         return _correct_np_dtype(xp, dtype, out)
 
-    @pytest.mark.skipif(cp.cuda.runtime.is_hip,  # see #6427
-                        reason="Flaky in HIP when running with other tests")
+    @pytest.mark.xfail(cp.cuda.runtime.is_hip, strict=False,  # see #6427
+                       reason="Flaky in HIP when running with other tests")
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
                                  contiguous_check=False)

--- a/tests/cupyx_tests/scipy_tests/fft_tests/test_fft.py
+++ b/tests/cupyx_tests/scipy_tests/fft_tests/test_fft.py
@@ -1677,7 +1677,7 @@ class TestHfft2:
         testing.assert_array_equal(x, x_orig)
         return _correct_np_dtype(xp, dtype, out)
 
-    @pytest.mark.skipif(cp.cuda.runtime.is_hip,
+    @pytest.mark.skipif(cp.cuda.runtime.is_hip,  # see #6427
                         reason="Flaky in HIP when running with other tests")
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
@@ -1690,7 +1690,7 @@ class TestHfft2:
         testing.assert_array_equal(x, x_orig)
         return _correct_np_dtype(xp, dtype, out)
 
-    @pytest.mark.skipif(cp.cuda.runtime.is_hip,
+    @pytest.mark.skipif(cp.cuda.runtime.is_hip,  # see #6427
                         reason="Flaky in HIP when running with other tests")
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
@@ -1757,7 +1757,7 @@ class TestHfftn:
         testing.assert_array_equal(x, x_orig)
         return _correct_np_dtype(xp, dtype, out)
 
-    @pytest.mark.skipif(cp.cuda.runtime.is_hip,
+    @pytest.mark.skipif(cp.cuda.runtime.is_hip,  # see #6427
                         reason="Flaky in HIP when running with other tests")
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
@@ -1770,7 +1770,7 @@ class TestHfftn:
         testing.assert_array_equal(x, x_orig)
         return _correct_np_dtype(xp, dtype, out)
 
-    @pytest.mark.skipif(cp.cuda.runtime.is_hip,
+    @pytest.mark.skipif(cp.cuda.runtime.is_hip,  # see #6427
                         reason="Flaky in HIP when running with other tests")
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,

--- a/tests/cupyx_tests/scipy_tests/fft_tests/test_fft.py
+++ b/tests/cupyx_tests/scipy_tests/fft_tests/test_fft.py
@@ -1677,6 +1677,8 @@ class TestHfft2:
         testing.assert_array_equal(x, x_orig)
         return _correct_np_dtype(xp, dtype, out)
 
+    @pytest.mark.skipif(cp.cuda.runtime.is_hip,
+                        reason="Flaky in HIP when running with other tests")
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
                                  contiguous_check=False)
@@ -1688,6 +1690,8 @@ class TestHfft2:
         testing.assert_array_equal(x, x_orig)
         return _correct_np_dtype(xp, dtype, out)
 
+    @pytest.mark.skipif(cp.cuda.runtime.is_hip,
+                        reason="Flaky in HIP when running with other tests")
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
                                  contiguous_check=False)
@@ -1753,6 +1757,8 @@ class TestHfftn:
         testing.assert_array_equal(x, x_orig)
         return _correct_np_dtype(xp, dtype, out)
 
+    @pytest.mark.skipif(cp.cuda.runtime.is_hip,
+                        reason="Flaky in HIP when running with other tests")
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
                                  contiguous_check=False)
@@ -1764,6 +1770,8 @@ class TestHfftn:
         testing.assert_array_equal(x, x_orig)
         return _correct_np_dtype(xp, dtype, out)
 
+    @pytest.mark.skipif(cp.cuda.runtime.is_hip,
+                        reason="Flaky in HIP when running with other tests")
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
                                  contiguous_check=False)

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
@@ -14,6 +14,8 @@ except ImportError:
     pass
 
 
+@pytest.mark.skipif(runtime.is_hip,
+                    reason="Flaky in HIP when running with other tests")
 @testing.parameterize(*testing.product({
     'size1': [(10,), (5, 10), (10, 3), (3, 4, 10)],
     'size2': [3, 4, 5, 10],

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
@@ -14,8 +14,6 @@ except ImportError:
     pass
 
 
-@pytest.mark.skipif(runtime.is_hip,  # see #6427
-                    reason="Flaky in HIP when running with other tests")
 @testing.parameterize(*testing.product({
     'size1': [(10,), (5, 10), (10, 3), (3, 4, 10)],
     'size2': [3, 4, 5, 10],
@@ -63,9 +61,9 @@ class TestFFTConvolve:
 
     def _hip_skip_invalid_condition(self):
         invalid_condition = [
-            ('full', 4), ('full', 5), ('full', 10),
+            ('full', 3), ('full', 4), ('full', 5), ('full', 10),
             ('same', 3), ('same', 4), ('same', 5), ('same', 10),
-            ('valid', 10)]
+            ('valid', 3), ('valid', 10)]
         if (runtime.is_hip and self.size1 == (3, 4, 10)
                 and (self.mode, self.size2) in invalid_condition):
             pytest.xfail('ROCm/HIP may have a bug')

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
@@ -14,7 +14,7 @@ except ImportError:
     pass
 
 
-@pytest.mark.skipif(runtime.is_hip,
+@pytest.mark.skipif(runtime.is_hip,  # see #6427
                     reason="Flaky in HIP when running with other tests")
 @testing.parameterize(*testing.product({
     'size1': [(10,), (5, 10), (10, 3), (3, 4, 10)],


### PR DESCRIPTION
These tests are flaky, and fail if other tests are run in conjunction with them. Standalone runs never fail but
for example 
`pytest tests/cupy_tests/sorting_tests/test_search.py tests/cupyx_tests/scipy_tests/fft_tests/test_fft.py -k 'test_cub_argmin or test_ihfft'` causes the tests to fail. (Even with CUB disabled ...)

Currently I am not sure of where is the issue that causes this and if its solvable, but for the meantime I think it is better to just skip the tests to get a working CI.