### PR TITLE
Make `cupy.var` stable

### DIFF
--- a/cupy/_core/_routines_statistics.pyx
+++ b/cupy/_core/_routines_statistics.pyx
@@ -559,7 +559,12 @@ cdef ndarray _var(
     # on why NaN is the result.
     div = max(items - ddof, 0)
     alpha = 1. / div if div != 0 else nan
-
+    # when using very large arrays, the mean calculation with low precision
+    # can lead to incorrect results when calculating the std. 
+    # Just by accomulating the (x_mean - x) we can notice the error.
+    # see #6425
+    if items > 10 ** 7:
+        dtype_mean = 'float64'
     arrmean = a.mean(axis=axis, dtype=dtype_mean, out=None, keepdims=True)
 
     if out is None:

--- a/cupy/_core/_routines_statistics.pyx
+++ b/cupy/_core/_routines_statistics.pyx
@@ -560,7 +560,7 @@ cdef ndarray _var(
     div = max(items - ddof, 0)
     alpha = 1. / div if div != 0 else nan
     # when using very large arrays, the mean calculation with low precision
-    # can lead to incorrect results when calculating the std. 
+    # can lead to incorrect results when calculating the std.
     # Just by accomulating the (x_mean - x) we can notice the error.
     # see #6425
     if items > 10 ** 7:

--- a/tests/cupy_tests/statistics_tests/test_meanvar.py
+++ b/tests/cupy_tests/statistics_tests/test_meanvar.py
@@ -238,6 +238,12 @@ class TestMeanVar:
         a = testing.shaped_arange((2, 3), xp, dtype)
         return a.var(ddof=1)
 
+    @testing.slow
+    @testing.numpy_cupy_allclose()
+    def test_var_large(self, xp, dtype):
+        a = xp.ones(3 * 10 ** 8, dtype=xp.float32)
+        return a.var()
+
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
     def test_external_var_all_ddof(self, xp, dtype):


### PR DESCRIPTION
Fixes #6425 

For some reason, the calculated mean of a large array inside `var` routine may have some marginal error that is accumulated when calculating the variance leading to an incorrect result.