### PR TITLE
Fix reduction contiguous size calculation

### DIFF
--- a/cupy/_core/_reduction.pyx
+++ b/cupy/_core/_reduction.pyx
@@ -183,7 +183,7 @@ cdef shape_t _set_permuted_args(
 
 
 cdef Py_ssize_t _get_contiguous_size(
-        list args, tuple params, Py_ssize_t ndim,
+        list args, tuple params, list out_shape, Py_ssize_t ndim,
         Py_ssize_t out_ndim) except -1:
     '''
     get contiguous size in the *output* axis (not *reduce* axis!)
@@ -203,7 +203,7 @@ cdef Py_ssize_t _get_contiguous_size(
         for j in range(out_ndim):
             if a._strides[ndim-j-1] != tmp_contiguous_size * itemsize:
                 break
-            tmp_contiguous_size *= a._shape[ndim-j-1]
+            tmp_contiguous_size *= out_shape[out_ndim-j-1]
         contiguous_size = max(contiguous_size, tmp_contiguous_size)
     return contiguous_size
 
@@ -368,7 +368,8 @@ cdef class _AbstractReductionKernel:
         if optimize_context is None:
             # Calculate manually
             contiguous_size = _get_contiguous_size(
-                in_args, self.in_params, in_shape.size(), out_shape.size())
+                in_args, self.in_params, out_shape,
+                in_shape.size(), out_shape.size())
             block_size, block_stride, out_block_num = _get_block_specs(
                 internal.prod(in_shape),
                 internal.prod(out_shape),
@@ -407,7 +408,7 @@ cdef class _AbstractReductionKernel:
         out_args = [_optimizer_copy_arg(a) for a in out_args]
 
         contiguous_size = _get_contiguous_size(
-            in_args, self.in_params, len(in_shape), len(out_shape))
+            in_args, self.in_params, out_shape, len(in_shape), len(out_shape))
         block_size, block_stride, default_out_block_num = _get_block_specs(
             internal.prod(in_shape),
             internal.prod(out_shape),

--- a/cupy/_core/_reduction.pyx
+++ b/cupy/_core/_reduction.pyx
@@ -183,14 +183,14 @@ cdef shape_t _set_permuted_args(
 
 
 cdef Py_ssize_t _get_contiguous_size(
-        list args, tuple params, list out_shape, Py_ssize_t ndim,
-        Py_ssize_t out_ndim) except -1:
+        list args, tuple params, list out_shape, Py_ssize_t ndim) except -1:
     '''
     get contiguous size in the *output* axis (not *reduce* axis!)
     '''
     cdef int i, j
     cdef ParameterInfo p
     cdef Py_ssize_t contiguous_size, tmp_contiguous_size, itemsize
+    out_ndim = len(out_shape)
     contiguous_size = 1
     for i, a in enumerate(args):
         if not isinstance(a, ndarray):
@@ -368,8 +368,7 @@ cdef class _AbstractReductionKernel:
         if optimize_context is None:
             # Calculate manually
             contiguous_size = _get_contiguous_size(
-                in_args, self.in_params, out_shape,
-                in_shape.size(), out_shape.size())
+                in_args, self.in_params, out_shape, in_shape.size())
             block_size, block_stride, out_block_num = _get_block_specs(
                 internal.prod(in_shape),
                 internal.prod(out_shape),
@@ -408,7 +407,7 @@ cdef class _AbstractReductionKernel:
         out_args = [_optimizer_copy_arg(a) for a in out_args]
 
         contiguous_size = _get_contiguous_size(
-            in_args, self.in_params, out_shape, len(in_shape), len(out_shape))
+            in_args, self.in_params, out_shape, len(in_shape))
         block_size, block_stride, default_out_block_num = _get_block_specs(
             internal.prod(in_shape),
             internal.prod(out_shape),


### PR DESCRIPTION
The calculations done for the block size are not correct in some cases leading to inefficient block sizes when `keepdims=True` in regular reductions. Closes #6425

This PR uses the sizes of the output array to figure this instead of the input ones.
master
`sum` of `(400, 400, 400)` shaped array in all axis with `keepdims=True`
```
CPU:  111.235 us   +/-117.695 (min:   30.789 / max:  340.247) us     GPU-0:1540503.906 us   +/-112.247 (min:1540392.822 / max:1540723.633) us 
```
this pr
```
CPU:   26.479 us   +/- 7.041 (min:   21.125 / max:   44.058) us     GPU-0:50921.146 us   +/-13.583 (min:50900.673 / max:50951.263) us
```