### PR TITLE
cupyx.scipy.special: add statistical distributions

### DIFF
--- a/cupyx/scipy/special/__init__.py
+++ b/cupyx/scipy/special/__init__.py
@@ -8,9 +8,27 @@ from cupyx.scipy.special._bessel import y1  # NOQA
 from cupyx.scipy.special._bessel import yn  # NOQA
 
 # Raw statistical functions
-
-from cupyx.scipy.special._statistics import ndtr  # NOQA
-from cupyx.scipy.special._statistics import ndtri  # NOQA
+from cupyx.scipy.special._stats_distributions import bdtr  # NOQA
+from cupyx.scipy.special._stats_distributions import bdtrc  # NOQA
+from cupyx.scipy.special._stats_distributions import bdtri  # NOQA
+from cupyx.scipy.special._stats_distributions import btdtr  # NOQA
+from cupyx.scipy.special._stats_distributions import btdtri  # NOQA
+from cupyx.scipy.special._stats_distributions import fdtr  # NOQA
+from cupyx.scipy.special._stats_distributions import fdtrc  # NOQA
+from cupyx.scipy.special._stats_distributions import fdtri  # NOQA
+from cupyx.scipy.special._stats_distributions import gdtr  # NOQA
+from cupyx.scipy.special._stats_distributions import gdtrc  # NOQA
+from cupyx.scipy.special._stats_distributions import nbdtr  # NOQA
+from cupyx.scipy.special._stats_distributions import nbdtrc  # NOQA
+from cupyx.scipy.special._stats_distributions import nbdtri  # NOQA
+from cupyx.scipy.special._stats_distributions import pdtr  # NOQA
+from cupyx.scipy.special._stats_distributions import pdtrc  # NOQA
+from cupyx.scipy.special._stats_distributions import pdtri  # NOQA
+from cupyx.scipy.special._stats_distributions import chdtr  # NOQA
+from cupyx.scipy.special._stats_distributions import chdtrc  # NOQA
+from cupyx.scipy.special._stats_distributions import chdtri  # NOQA
+from cupyx.scipy.special._stats_distributions import ndtr  # NOQA
+from cupyx.scipy.special._stats_distributions import ndtri  # NOQA
 from cupyx.scipy.special._statistics import logit  # NOQA
 from cupyx.scipy.special._statistics import expit  # NOQA
 from cupyx.scipy.special._statistics import log_expit  # NOQA
@@ -18,7 +36,6 @@ from cupyx.scipy.special._statistics import boxcox  # NOQA
 from cupyx.scipy.special._statistics import boxcox1p  # NOQA
 from cupyx.scipy.special._statistics import inv_boxcox  # NOQA
 from cupyx.scipy.special._statistics import inv_boxcox1p  # NOQA
-
 
 # Information Theory functions
 from cupyx.scipy.special._convex_analysis import entr  # NOQA

--- a/cupyx/scipy/special/_beta.py
+++ b/cupyx/scipy/special/_beta.py
@@ -380,11 +380,11 @@ __noinline__ __device__ double lbeta(double a, double b)
     }
 
     if (y < 0) {
-    y = -y;
+        y = -y;
     }
-
-    return (log(y));
+    return log(y);
 }
+
 """
 
 
@@ -780,22 +780,24 @@ __noinline__ __device__ static double pseries(double a, double b, double x)
 
 """
 
+incbet_preamble = (
+    beta_preamble +
+    gamma_definition +
+    polevl_definition +
+    p1evl_definition +
+    lgam_sgn_definition +
+    lbeta_symp_definition +
+    beta_definition +
+    lbeta_definition +
+    incbet_definition
+)
+
 
 betainc = _core.create_ufunc(
     "cupyx_scipy_betainc",
     ("fff->f", "ddd->d"),
     "out0 = out0_type(incbet(in0, in1, in2));",
-    preamble=(
-        beta_preamble +
-        gamma_definition +
-        polevl_definition +
-        p1evl_definition +
-        lgam_sgn_definition +
-        lbeta_symp_definition +
-        beta_definition +
-        lbeta_definition +
-        incbet_definition
-    ),
+    preamble=incbet_preamble,
     doc="""Incomplete beta function.
 
     Parameters
@@ -971,7 +973,6 @@ ihalve:
             dir -= 1;
         }
     }
-
     if (x0 >= 1.0) {
         x = 1.0 - MACHEP;
         goto done;
@@ -1058,24 +1059,14 @@ done:
 
 """
 
+incbi_preamble = incbet_preamble + incbi_definition
+
 
 betaincinv = _core.create_ufunc(
     "cupyx_scipy_betaincinv",
     ("fff->f", "ddd->d"),
     "out0 = out0_type(incbi(in0, in1, in2));",
-    preamble=(
-        beta_preamble +
-        gamma_definition +
-        polevl_definition +
-        p1evl_definition +
-        lgam_sgn_definition +
-        lbeta_symp_definition +
-        beta_definition +
-        lbeta_definition +
-        incbet_definition +
-        incbi_definition
-    ),
-
+    preamble=incbi_preamble,
     doc="""Inverse of the incomplete beta function.
 
     Parameters

--- a/cupyx/scipy/special/_gammainc.py
+++ b/cupyx/scipy/special/_gammainc.py
@@ -114,7 +114,12 @@ _unity_c_partial = (
 
 
 /* log(1 + x) - x */
+#ifdef __HIP_DEVICE_COMPILE__
+// For some reason ROCm 4.3 crashes with the noinline in this function
+__device__ double log1pmx(double x)
+#else
 __noinline__ __device__ double log1pmx(double x)
+#endif
 {
     if (fabs(x) < 0.5) {
         int n;

--- a/cupyx/scipy/special/_statistics.py
+++ b/cupyx/scipy/special/_statistics.py
@@ -97,28 +97,6 @@ log_expit = _core.create_ufunc(
     ''')
 
 
-ndtr = _core.create_ufunc(
-    'cupyx_scipy_special_ndtr',
-    (('f->f', 'out0 = normcdff(in0)'), 'd->d'),
-    'out0 = normcdf(in0)',
-    doc='''Cumulative distribution function of normal distribution.
-
-    .. seealso:: :data:`scipy.special.ndtr`
-
-    ''')
-
-
-ndtri = _core.create_ufunc(
-    'cupyx_scipy_special_ndtri',
-    (('f->f', 'out0 = normcdfinvf(in0)'), 'd->d'),
-    'out0 = normcdfinv(in0)',
-    doc='''Inverse of the cumulative distribution function of the standard
-           normal distribution.
-
-    .. seealso:: :data:`scipy.special.ndtri`
-''')
-
-
 boxcox_definition = """
 static __device__ double boxcox(double x, double lmbda) {
     // if lmbda << 1 and log(x) < 1.0, the lmbda*log(x) product can lose

--- a/cupyx/scipy/special/_stats_distributions.py
+++ b/cupyx/scipy/special/_stats_distributions.py
@@ -191,9 +191,9 @@ __device__ double bdtri_unsafe(double k, double n, double p)
 bdtr = _core.create_ufunc(
     "cupyx_scipy_bdtr",
     (
-        ('ddd->d', 'out0 = bdtr_unsafe(in0, in1, in2);'),
+        ('fff->f', 'out0 = out0_type(bdtr_unsafe(in0, in1, in2));'),
         'dld->d',
-        ('fff->f', 'out0 = out0_type(bdtr_unsafe(in0, in1, in2));')
+        ('ddd->d', 'out0 = bdtr_unsafe(in0, in1, in2);'),
     ),
     "out0 = bdtr(in0, (int)in1, in2);",
     preamble=incbet_preamble + bdtr_definition,
@@ -226,9 +226,9 @@ bdtr = _core.create_ufunc(
 bdtrc = _core.create_ufunc(
     "cupyx_scipy_bdtrc",
     (
-        ('ddd->d', 'out0 = bdtrc_unsafe(in0, in1, in2);'),
+        ('fff->f', 'out0 = out0_type(bdtrc_unsafe(in0, in1, in2));'),
         'dld->d',
-        ('fff->f', 'out0 = out0_type(bdtrc_unsafe(in0, in1, in2));')
+        ('ddd->d', 'out0 = bdtrc_unsafe(in0, in1, in2);'),
     ),
     "out0 = out0_type(bdtrc(in0, in1, in2));",
     preamble=incbet_preamble + bdtrc_definition,

--- a/cupyx/scipy/special/_stats_distributions.py
+++ b/cupyx/scipy/special/_stats_distributions.py
@@ -1,0 +1,1069 @@
+"""Statistical distribution functions (Beta, Binomial, Poisson, etc.)
+
+The source code here is an adaptation with minimal changes from the following
+files in SciPy's bundled Cephes library:
+
+https://github.com/scipy/scipy/blob/main/scipy/special/cephes/bdtr.c
+https://github.com/scipy/scipy/blob/main/scipy/special/cephes/chdtr.c
+https://github.com/scipy/scipy/blob/main/scipy/special/cephes/fdtr.c
+https://github.com/scipy/scipy/blob/main/scipy/special/cephes/gdtr.c
+https://github.com/scipy/scipy/blob/main/scipy/special/cephes/nbdtr.c
+https://github.com/scipy/scipy/blob/main/scipy/special/cephes/pdtr.c
+
+Cephes Math Library, Release 2.3:  March, 1995
+Copyright 1984, 1995 by Stephen L. Moshier
+"""
+
+from cupy import _core
+from cupyx.scipy.special._beta import incbet_preamble, incbi_preamble
+from cupyx.scipy.special._gammainc import _igam_preamble, _igami_preamble
+
+
+# Normal distribution functions
+
+ndtr = _core.create_ufunc(
+    'cupyx_scipy_special_ndtr',
+    (('f->f', 'out0 = normcdff(in0)'), 'd->d'),
+    'out0 = normcdf(in0)',
+    doc='''Cumulative distribution function of normal distribution.
+
+    .. seealso:: :data:`scipy.special.ndtr`
+
+    ''')
+
+
+ndtri = _core.create_ufunc(
+    'cupyx_scipy_special_ndtri',
+    (('f->f', 'out0 = normcdfinvf(in0)'), 'd->d'),
+    'out0 = normcdfinv(in0)',
+    doc='''Inverse of the cumulative distribution function of the standard
+           normal distribution.
+
+    .. seealso:: :data:`scipy.special.ndtri`
+''')
+
+
+# Binomial distribution functions
+
+bdtr_definition = """
+
+__device__ double bdtr(double k, int n, double p)
+{
+    double dk, dn;
+    double fk = floor(k);
+
+    if (isnan(p) || isnan(k)) {
+        return CUDART_NAN;
+    }
+
+    if (p < 0.0 || p > 1.0 || fk < 0 || n < fk) {
+        return CUDART_NAN;
+    }
+
+    if (fk == n) {
+        return 1.0;
+    }
+
+    dn = n - fk;
+    if (fk == 0) {
+        dk = pow(1.0 - p, dn);
+    } else {
+        dk = fk + 1.;
+        dk = incbet(dn, dk, 1.0 - p);
+    }
+    return dk;
+}
+
+
+__device__ double bdtr_unsafe(double k, double n, double p)
+{
+    if (isnan(n) || isinf(n)) {
+        return CUDART_NAN;
+    } else {
+        return bdtr(k, (int)n, p);
+    }
+}
+
+"""
+
+
+bdtrc_definition = """
+
+__device__ double bdtrc(double k, int n, double p)
+{
+    double dk, dn;
+    double fk = floor(k);
+
+    if (isnan(p) || isnan(k)) {
+        return CUDART_NAN;
+    }
+
+    if (p < 0.0 || p > 1.0 || n < fk) {
+        return CUDART_NAN;
+    }
+
+    if (fk < 0) {
+        return 1.0;
+    }
+
+    if (fk == n) {
+        return 0.0;
+    }
+
+    dn = n - fk;
+    if (k == 0) {
+        if (p < .01) {
+            dk = -expm1(dn * log1p(-p));
+        } else {
+            dk = 1.0 - pow(1.0 - p, dn);
+        }
+    } else {
+        dk = fk + 1;
+        dk = incbet(dk, dn, p);
+    }
+    return dk;
+}
+
+__device__ double bdtrc_unsafe(double k, double n, double p)
+{
+    if (isnan(n) || isinf(n)) {
+        return CUDART_NAN;
+    } else {
+        return bdtrc(k, (int)n, p);
+    }
+}
+
+"""
+
+
+bdtri_definition = """
+
+__device__ double bdtri(double k, int n, double y)
+{
+    double p, dn, dk;
+    double fk = floor(k);
+
+    if (isnan(k)) {
+        return CUDART_NAN;
+    }
+
+    if (y < 0.0 || y > 1.0 || fk < 0.0 || n <= fk) {
+        return CUDART_NAN;
+    }
+
+    dn = n - fk;
+
+    if (fk == n) {
+        return 1.0;
+    }
+
+    if (fk == 0) {
+        if (y > 0.8) {
+            p = -expm1(log1p(y - 1.0) / dn);
+        } else {
+            p = 1.0 - pow(y, 1.0 / dn);
+        }
+    } else {
+        dk = fk + 1;
+        p = incbet(dn, dk, 0.5);
+        if (p > 0.5) {
+            p = incbi(dk, dn, 1.0 - y);
+        } else {
+            p = 1.0 - incbi(dn, dk, y);
+        }
+    }
+    return p;
+}
+
+__device__ double bdtri_unsafe(double k, double n, double p)
+{
+    if (isnan(n) || isinf(n)) {
+        return CUDART_NAN;
+    } else {
+        return bdtri(k, (int)n, p);
+    }
+}
+
+"""
+
+
+# Note: bdtr ddd->d and fff-> are deprecated as of SciPy 1.7
+bdtr = _core.create_ufunc(
+    "cupyx_scipy_bdtr",
+    (
+        ('ddd->d', 'out0 = bdtr_unsafe(in0, in1, in2);'),
+        'dld->d',
+        ('fff->f', 'out0 = out0_type(bdtr_unsafe(in0, in1, in2));')
+    ),
+    "out0 = bdtr(in0, (int)in1, in2);",
+    preamble=incbet_preamble + bdtr_definition,
+    doc="""Binomial distribution cumulative distribution function.
+
+    Parameters
+    ----------
+    k : cupy.ndarray
+        Number of successes (float), rounded down to the nearest integer.
+    n : cupy.ndarray
+        Number of events (int).
+    p : cupy.ndarray
+        Probability of success in a single event (float).
+
+    Returns
+    -------
+    y : cupy.ndarray
+        Probability of floor(k) or fewer successes in n independent events with
+        success probabilities of p.
+
+    See Also
+    --------
+    :func:`scipy.special.bdtr`
+
+    """,
+)
+
+
+# Note: bdtrc ddd->d and fff->f are deprecated as of SciPy 1.7
+bdtrc = _core.create_ufunc(
+    "cupyx_scipy_bdtrc",
+    (
+        ('ddd->d', 'out0 = bdtrc_unsafe(in0, in1, in2);'),
+        'dld->d',
+        ('fff->f', 'out0 = out0_type(bdtrc_unsafe(in0, in1, in2));')
+    ),
+    "out0 = out0_type(bdtrc(in0, in1, in2));",
+    preamble=incbet_preamble + bdtrc_definition,
+    doc="""Binomial distribution survival function.
+
+    Returns the complemented binomial distribution function (the integral of
+    the density from x to infinity).
+
+    Parameters
+    ----------
+    k : cupy.ndarray
+        Number of successes (float), rounded down to the nearest integer.
+    n : cupy.ndarray
+        Number of events (int).
+    p : cupy.ndarray
+        Probability of success in a single event (float).
+
+    Returns
+    -------
+    y : cupy.ndarray
+        Probability of floor(k) + 1 or more successes in n independent events
+        with success probabilities of p.
+
+    See Also
+    --------
+    :func:`scipy.special.bdtrc`
+
+    """,
+)
+
+
+# Note: bdtri ddd->d and fff->f are deprecated as of SciPy 1.7
+bdtri = _core.create_ufunc(
+    "cupyx_scipy_bdtri",
+    (
+        ('fff->f', 'out0 = out0_type(bdtri_unsafe(in0, in1, in2));'),
+        'dld->d',
+        ('ddd->d', 'out0 = bdtri_unsafe(in0, in1, in2);'),
+    ),
+    "out0 = out0_type(bdtri(in0, in1, in2));",
+    preamble=incbi_preamble + bdtri_definition,
+    doc="""Inverse function to `bdtr` with respect to `p`.
+
+    Parameters
+    ----------
+    k : cupy.ndarray
+        Number of successes (float), rounded down to the nearest integer.
+    n : cupy.ndarray
+        Number of events (int).
+    y : cupy.ndarray
+        Cumulative probability (probability of k or fewer successes in n
+        events).
+
+    Returns
+    -------
+    p : cupy.ndarray
+        The event probability such that bdtr(floor(k), n, p) = y.
+
+    See Also
+    --------
+    :func:`scipy.special.bdtri`
+
+    """,
+)
+
+
+# Beta distribution functions
+
+btdtr = _core.create_ufunc(
+    "cupyx_scipy_btdtr",
+    ("fff->f", "ddd->d"),
+    "out0 = out0_type(incbet(in0, in1, in2));",
+    preamble=incbet_preamble,
+    doc="""Cumulative distribution function of the beta distribution.
+
+    Parameters
+    ----------
+    a : cupy.ndarray
+        Shape parameter (a > 0).
+    b : cupy.ndarray
+        Shape parameter (b > 0).
+    x : cupy.ndarray
+        Upper limit of integration, in [0, 1].
+
+    Returns
+    -------
+    I : cupy.ndarray
+        Cumulative distribution function of the beta distribution with
+        parameters a and b at x.
+
+    See Also
+    --------
+    :func:`scipy.special.btdtr`
+
+    """,
+)
+
+
+btdtri = _core.create_ufunc(
+    "cupyx_scipy_btdtri",
+    ("fff->f", "ddd->d"),
+    "out0 = out0_type(incbi(in0, in1, in2));",
+    preamble=incbi_preamble,
+    doc="""The p-th quantile of the beta distribution.
+
+    This function is the inverse of the beta cumulative distribution function,
+    `btdtr`, returning the value of `x` for which ``btdtr(a, b, x) = p``.
+
+    Parameters
+    ----------
+    a : cupy.ndarray
+        Shape parameter (a > 0).
+    b : cupy.ndarray
+        Shape parameter (b > 0).
+    p : cupy.ndarray
+        Cumulative probability, in [0, 1].
+
+    Returns
+    -------
+    x : cupy.ndarray
+        The quantile corresponding to p.
+
+    See Also
+    --------
+    :func:`scipy.special.btdtri`
+
+    """,
+)
+
+
+# Chi square distribution functions
+
+chdtrc_definition = """
+
+__device__ double chdtrc(double df, double x)
+{
+
+    if (x < 0.0) {
+        return 1.0;     /* modified by T. Oliphant */
+    }
+    return igamc(df / 2.0, x / 2.0);
+}
+"""
+
+
+chdtr_definition = """
+
+__device__ double chdtr(double df, double x)
+{
+    if (x < 0.0) {   /* || (df < 1.0) ) */
+        return CUDART_NAN;
+    }
+    return igam(df / 2.0, x / 2.0);
+}
+"""
+
+
+chdtri_definition = """
+__device__ double chdtri(double df, double y)
+{
+    double x;
+
+    if ((y < 0.0) || (y > 1.0)) {   /* || (df < 1.0) ) */
+        return CUDART_NAN;
+    }
+
+    x = igamci(0.5 * df, y);
+    return 2.0 * x;
+}
+"""
+
+
+chdtrc = _core.create_ufunc(
+    "cupyx_scipy_chdtrc",
+    ("ff->f", "dd->d"),
+    "out0 = out0_type(chdtrc(in0, in1));",
+    preamble=_igam_preamble + chdtrc_definition,
+    doc="""Chi square survival function.
+
+    Returns the complemented chi-squared distribution function (the integral of
+    the density from x to infinity).
+
+    Parameters
+    ----------
+    v : cupy.ndarray
+        Degrees of freedom.
+    x : cupy.ndarray
+        Upper bound of the integral (nonnegative float).
+
+    Returns
+    -------
+    y : cupy.ndarray
+        The complemented chi-squared distribution function with parameter df at
+        x.
+
+    See Also
+    --------
+    :func:`scipy.special.chdtrc`
+
+    """,
+)
+
+chdtri = _core.create_ufunc(
+    "cupyx_scipy_chdtri",
+    ("ff->f", "dd->d"),
+    "out0 = out0_type(chdtri(in0, in1));",
+    preamble=_igami_preamble + chdtri_definition,
+    doc="""Inverse to `chdtrc` with respect to `x`.
+
+    Parameters
+    ----------
+    v : cupy.ndarray
+        Degrees of freedom.
+    p : cupy.ndarray
+        Probability.
+    p : cupy.ndarray, optional
+        Optional output array for the function results.
+
+    Returns
+    -------
+    x : cupy.ndarray
+        Value so that the probability a Chi square random variable with `v`
+        degrees of freedom is greater than `x` equals `p`.
+
+    See Also
+    --------
+    :func:`scipy.special.chdtri`
+
+    """,
+)
+
+
+chdtr = _core.create_ufunc(
+    "cupyx_scipy_chdtr",
+    ("ff->f", "dd->d"),
+    "out0 = out0_type(chdtr(in0, in1));",
+    preamble=_igam_preamble + chdtr_definition,
+    doc="""Chi-square cumulative distribution function.
+
+    Parameters
+    ----------
+    v : cupy.ndarray
+        Degrees of freedom.
+    x : cupy.ndarray
+        Upper bound of the integral (nonnegative float).
+
+    Returns
+    -------
+    y : cupy.ndarray
+        The CDF of the chi-squared distribution with parameter df at x.
+
+    See Also
+    --------
+    :func:`scipy.special.chdtr`
+
+    """,
+)
+
+
+# F distribution functions
+
+fdtrc_definition = """
+
+__device__ double fdtrc(double a, double b, double x)
+{
+    double w;
+
+    if ((a <= 0.0) || (b <= 0.0) || (x < 0.0)) {
+        // sf_error("fdtrc", SF_ERROR_DOMAIN, NULL);
+        return CUDART_NAN;
+    }
+    w = b / (b + a * x);
+    return incbet(0.5 * b, 0.5 * a, w);
+}
+"""
+
+
+fdtr_definition = """
+
+__device__ double fdtr(double a, double b, double x)
+{
+    double w;
+
+    if ((a <= 0.0) || (b <= 0.0) || (x < 0.0)) {
+        // sf_error("fdtr", SF_ERROR_DOMAIN, NULL);
+        return CUDART_NAN;
+    }
+    w = a * x;
+    w = w / (b + w);
+    return incbet(0.5 * a, 0.5 * b, w);
+}
+"""
+
+
+fdtri_definition = """
+__device__ double fdtri(double a, double b, double y)
+{
+    double w, x;
+
+    if ((a <= 0.0) || (b <= 0.0) || (y <= 0.0) || (y > 1.0)) {
+        // sf_error("fdtri", SF_ERROR_DOMAIN, NULL);
+        return CUDART_NAN;
+    }
+    y = 1.0 - y;
+    /* Compute probability for x = 0.5.  */
+    w = incbet(0.5 * b, 0.5 * a, 0.5);
+    /* If that is greater than y, then the solution w < .5.
+     * Otherwise, solve at 1-y to remove cancellation in (b - b*w).  */
+    if (w > y || y < 0.001) {
+        w = incbi(0.5 * b, 0.5 * a, y);
+        x = (b - b * w) / (a * w);
+    }
+    else {
+        w = incbi(0.5 * a, 0.5 * b, 1.0 - y);
+        x = b * w / (a * (1.0 - w));
+    }
+    return x;
+}
+"""
+
+
+fdtrc = _core.create_ufunc(
+    "cupyx_scipy_fdtrc",
+    ("fff->f", "ddd->d"),
+    "out0 = out0_type(fdtrc(in0, in1, in2));",
+    preamble=incbi_preamble + fdtrc_definition,
+    doc="""F survival function.
+
+    Returns the complemented F-distribution function (the integral of the
+    density from x to infinity).
+
+    Parameters
+    ----------
+    dfn : cupy.ndarray
+        First parameter (positive float).
+    dfd : cupy.ndarray
+        Second parameter (positive float).
+    x : cupy.ndarray
+        Argument (nonnegative float).
+
+    Returns
+    -------
+    y : cupy.ndarray
+        The complemented F-distribution function with parameters dfn and dfd at
+        x.
+
+    .. seealso:: :meth:`scipy.special.fdtrc`
+
+    """,
+)
+
+fdtri = _core.create_ufunc(
+    "cupyx_scipy_fdtri",
+    ("fff->f", "ddd->d"),
+    "out0 = out0_type(fdtri(in0, in1, in2));",
+    preamble=incbi_preamble + fdtri_definition,
+    doc="""The p-th quantile of the F-distribution.
+
+    This function is the inverse of the F-distribution CDF, `fdtr`, returning
+    the `x` such that `fdtr(dfn, dfd, x)` = `p`.
+
+    Parameters
+    ----------
+    dfn : cupy.ndarray
+        First parameter (positive float).
+    dfd : cupy.ndarray
+        Second parameter (positive float).
+    p : cupy.ndarray
+        Cumulative probability, in [0, 1].
+
+    Returns
+    -------
+    y : cupy.ndarray
+        The quantile corresponding to p.
+
+    .. seealso:: :meth:`scipy.special.fdtri`
+
+    """,
+)
+
+
+fdtr = _core.create_ufunc(
+    "cupyx_scipy_fdtr",
+    ("fff->f", "ddd->d"),
+    "out0 = out0_type(fdtr(in0, in1, in2));",
+    preamble=incbi_preamble + fdtr_definition,
+    doc="""F cumulative distribution function.
+
+
+    Parameters
+    ----------
+    dfn : cupy.ndarray
+        First parameter (positive float).
+    dfd : cupy.ndarray
+        Second parameter (positive float).
+    x : cupy.ndarray
+        Argument (nonnegative float).
+
+    Returns
+    -------
+    y : cupy.ndarray
+        The CDF of the F-distribution with parameters dfn and dfd at x.
+
+    .. seealso:: :meth:`scipy.special.fdtr`
+
+    """,
+)
+
+
+# Gamma distribution functions
+
+gdtr_definition = """
+
+__device__ double gdtr(double a, double b, double x)
+{
+
+    if (x < 0.0) {
+        return CUDART_NAN;
+    }
+    return igam(b, a * x);
+}
+"""
+
+
+gdtrc_definition = """
+
+__device__ double gdtrc(double a, double b, double x)
+{
+    if (x < 0.0) {
+        return CUDART_NAN;
+    }
+    return (igamc(b, a * x));
+}
+
+"""
+
+
+gdtr = _core.create_ufunc(
+    "cupyx_scipy_gdtr",
+    ("fff->f", "ddd->d"),
+    "out0 = out0_type(gdtr(in0, in1, in2));",
+    preamble=_igam_preamble + gdtr_definition,
+    doc="""Gamma distribution cumulative distribution function.
+
+    Parameters
+    ----------
+    a : cupy.ndarray
+        The rate parameter of the gamma distribution, sometimes denoted
+        beta (float). It is also the reciprocal of the scale parameter theta.
+    b : cupy.ndarray
+        The shape parameter of the gamma distribution, sometimes denoted
+        alpha (float).
+    x : cupy.ndarray
+        The quantile (upper limit of integration; float).
+
+    Returns
+    -------
+    F : cupy.ndarray
+        The CDF of the gamma distribution with parameters `a` and `b` evaluated
+        at `x`.
+
+    See Also
+    --------
+    :func:`scipy.special.gdtr`
+
+    """,
+)
+
+
+gdtrc = _core.create_ufunc(
+    "cupyx_scipy_gdtrc",
+    ("fff->f", "ddd->d"),
+    "out0 = out0_type(gdtrc(in0, in1, in2));",
+    preamble=_igam_preamble + gdtrc_definition,
+    doc="""Gamma distribution survival function.
+
+    Parameters
+    ----------
+    a : cupy.ndarray
+        The rate parameter of the gamma distribution, sometimes denoted
+        beta (float). It is also the reciprocal of the scale parameter theta.
+    b : cupy.ndarray
+        The shape parameter of the gamma distribution, sometimes denoted
+        alpha (float).
+    x : cupy.ndarray
+        The quantile (lower limit of integration; float).
+
+    Returns
+    -------
+    I : cupy.ndarray
+        The survival function of the gamma distribution with parameters `a` and
+        `b` at `x`.
+
+    See Also
+    --------
+    :func:`scipy.special.gdtrc`
+
+    """,
+)
+
+
+# Negative Binomial distribution functions
+
+nbdtr_definition = """
+
+__device__ double nbdtr(int k, int n, double p)
+{
+    double dk, dn;
+
+    if (((p < 0.0) || (p > 1.0)) || (k < 0))
+    {
+        return CUDART_NAN;
+    }
+    dk = k + 1;
+    dn = n;
+    return (incbet(dn, dk, p));
+}
+
+__device__ double nbdtr_unsafe(double k, double n, double p)
+{
+    if (isnan(k) || isnan(n))
+    {
+        return CUDART_NAN;
+    }
+    return nbdtr((int)k, (int)n, p);
+}
+
+"""
+
+
+nbdtrc_definition = """
+
+__device__ double nbdtrc(int k, int n, double p)
+{
+    double dk, dn;
+
+    if (((p < 0.0) || (p > 1.0)) || k < 0)
+    {
+        return CUDART_NAN;
+    }
+
+    dk = k + 1;
+    dn = n;
+    return (incbet(dk, dn, 1.0 - p));
+}
+
+__device__ double nbdtrc_unsafe(double k, double n, double p)
+{
+    if (isnan(k) || isnan(n))
+    {
+        return CUDART_NAN;
+    }
+    return nbdtrc((int)k, (int)n, p);
+}
+
+"""
+
+
+nbdtri_definition = """
+
+__device__ double nbdtri(int k, int n, double y)
+{
+    double dk, dn, w;
+
+    if (((y < 0.0) || (y > 1.0)) || (k < 0)) {
+        return CUDART_NAN;
+    }
+    dk = k + 1;
+    dn = n;
+    w = incbi(dn, dk, y);
+    return (w);
+}
+
+__device__ double nbdtri_unsafe(double k, double n, double y)
+{
+    if (isnan(k) || isnan(n))
+    {
+        return CUDART_NAN;
+    }
+    return nbdtri((int)k, (int)n, y);
+}
+
+"""
+
+# Note: as in scipy we have a safe iid->d version and unsafe ddd->d one
+nbdtr = _core.create_ufunc(
+    "cupyx_scipy_nbdtr",
+    (
+        'lld->d',
+        ('fff->f', 'out0 = out0_type(nbdtr_unsafe(in0, in1, in2));'),
+        ('ddd->d', 'out0 = nbdtr_unsafe(in0, in1, in2);'),
+    ),
+    "out0 = nbdtr(in0, in1, in2);",
+    preamble=incbet_preamble + nbdtr_definition,
+    doc="""Negative binomial distribution cumulative distribution function.
+
+    Parameters
+    ----------
+    k : cupy.ndarray
+        The maximum number of allowed failures (nonnegative int).
+    n : cupy.ndarray
+        The target number of successes (positive int).
+    p : cupy.ndarray
+        Probability of success in a single event (float).
+
+    Returns
+    -------
+    F : cupy.ndarray
+        The probability of `k` or fewer failures before `n` successes in a
+        sequence of events with individual success probability `p`.
+
+    See Also
+    --------
+    :func:`scipy.special.nbdtr`
+
+    """,
+)
+
+
+nbdtrc = _core.create_ufunc(
+    "cupyx_scipy_nbdtrc",
+    (
+        'lld->d',
+        ('fff->f', 'out0 = out0_type(nbdtrc_unsafe(in0, in1, in2));'),
+        ('ddd->d', 'out0 = nbdtrc_unsafe(in0, in1, in2);'),
+    ),
+    "out0 = nbdtrc(in0, in1, in2);",
+    preamble=incbet_preamble + nbdtrc_definition,
+    doc="""Negative binomial distribution survival function.
+
+    Parameters
+    ----------
+    k : cupy.ndarray
+        The maximum number of allowed failures (nonnegative int).
+    n : cupy.ndarray
+        The target number of successes (positive int).
+    p : cupy.ndarray
+        Probability of success in a single event (float).
+
+    Returns
+    -------
+    F : cupy.ndarray
+        The probability of ``k + 1`` or more failures before `n` successes in a
+        sequence of events with individual success probability `p`.
+
+    See Also
+    --------
+    :func:`scipy.special.nbdtrc`
+
+    """,
+)
+
+nbdtri = _core.create_ufunc(
+    "cupyx_scipy_nbdtri",
+    (
+        'lld->d',
+        ('fff->f', 'out0 = out0_type(nbdtri_unsafe(in0, in1, in2));'),
+        ('ddd->d', 'out0 = nbdtri_unsafe(in0, in1, in2);'),
+    ),
+    "out0 = nbdtri(in0, in1, in2);",
+    preamble=incbi_preamble + nbdtri_definition,
+    doc="""Inverse function to `nbdtr` with respect to `p`.
+
+    Parameters
+    ----------
+    k : cupy.ndarray
+        The maximum number of allowed failures (nonnegative int).
+    n : cupy.ndarray
+        The target number of successes (positive int).
+    y : cupy.ndarray
+        The probability of `k` or fewer failures before `n` successes (float).
+
+    Returns
+    -------
+    p : cupy.ndarray
+        Probability of success in a single event (float) such that
+        ``nbdtr(k, n, p) = y``.
+
+    See Also
+    --------
+    :func:`scipy.special.nbdtri`
+
+    """,
+)
+
+
+# Poisson distribution functions
+
+pdtr_definition = """
+
+__device__ double pdtr(double k, double m)
+{
+    double v;
+
+    if ((k < 0) || (m < 0)) {
+        return CUDART_NAN;
+    }
+    if (m == 0.0) {
+        return 1.0;
+    }
+    v = floor(k) + 1;
+    return igamc(v, m);
+}
+
+"""
+
+
+pdtrc_definition = """
+
+__device__ double pdtrc(double k, double m)
+{
+    double v;
+
+    if ((k < 0.0) || (m < 0.0)) {
+        return CUDART_NAN;
+    }
+    if (m == 0.0) {
+        return 0.0;
+    }
+    v = floor(k) + 1;
+    return igam(v, m);
+}
+
+"""
+
+
+pdtri_definition = """
+
+__device__ double pdtri(int k, double y)
+{
+    double v;
+
+    if ((k < 0) || (y < 0.0) || (y >= 1.0)) {
+        return CUDART_NAN;
+    }
+    v = k + 1;
+    return igamci(v, y);
+}
+
+__device__ double pdtri_unsafe(double k, double y)
+{
+    if (isnan(k)) {
+        return CUDART_NAN;
+    } else {
+        return pdtri((int)k, y);
+    }
+}
+
+"""
+
+
+pdtr = _core.create_ufunc(
+    "cupyx_scipy_pdtr",
+    ('ff->f', 'dd->d'),
+    "out0 = out0_type(pdtr(in0, in1));",
+    preamble=_igam_preamble + pdtr_definition,
+    doc="""Poisson cumulative distribution function.
+
+    Parameters
+    ----------
+    k : cupy.ndarray
+        Nonnegative real argument.
+    m : cupy.ndarray
+        Nonnegative real shape parameter.
+
+    Returns
+    -------
+    y : cupy.ndarray
+        Values of the Poisson cumulative distribution function.
+
+    See Also
+    --------
+    :func:`scipy.special.pdtr`
+
+    """,
+)
+
+
+pdtrc = _core.create_ufunc(
+    "cupyx_scipy_pdtrc",
+    ('ff->f', 'dd->d'),
+    "out0 = out0_type(pdtrc(in0, in1));",
+    preamble=_igam_preamble + pdtrc_definition,
+    doc="""Binomial distribution survival function.
+
+    Returns the complemented binomial distribution function (the integral of
+    the density from x to infinity).
+
+    Parameters
+    ----------
+    k : cupy.ndarray
+        Nonnegative real argument.
+    m : cupy.ndarray
+        Nonnegative real shape parameter.
+
+    Returns
+    -------
+    y : cupy.ndarray
+        The sum of the terms from k+1 to infinity of the Poisson
+        distribution.
+
+    See Also
+    --------
+    :func:`scipy.special.pdtrc`
+
+    """,
+)
+
+
+pdtri = _core.create_ufunc(
+    "cupyx_scipy_pdtri",
+    # Note order of entries here is important to match SciPy behavior
+    ('ld->d',
+     ('ff->f', 'out0 = out0_type(pdtri_unsafe(in0, in1));'),
+     ('dd->d', 'out0 = pdtri_unsafe(in0, in1);')),
+    "out0 = pdtri((int)in0, in1);",
+    preamble=_igami_preamble + pdtri_definition,
+    doc="""Inverse function to `pdtr` with respect to `m`.
+
+    Parameters
+    ----------
+    k : cupy.ndarray
+        Nonnegative real argument.
+    y : cupy.ndarray
+        Cumulative probability.
+
+    Returns
+    -------
+    m : cupy.ndarray
+        The Poisson variable `m` such that the sum from 0 to `k` of the Poisson
+        density is equal to the given probability `y`.
+
+    See Also
+    --------
+    :func:`scipy.special.pdtri`
+
+    """,
+)

--- a/docs/source/reference/scipy_special.rst
+++ b/docs/source/reference/scipy_special.rst
@@ -28,6 +28,25 @@ Raw statistical functions
 .. autosummary::
    :toctree: generated/
 
+   bdtr
+   bdtrc
+   bdtri
+   btdtr
+   btdtri
+   fdtr
+   fdtrc
+   fdtri
+   gdtr
+   gdtrc
+   nbdtr
+   nbdtrc
+   nbdtri
+   pdtr
+   pdtrc
+   pdtri
+   chdtr
+   chdtrc
+   chdtri
    ndtr
    ndtri
    logit

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_statistics.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_statistics.py
@@ -143,19 +143,19 @@ class TestFusionSpecial(_TestBase):
 
 class _TestDistributionsBase:
 
-    def _test_scalar(self, function, args, expected, rtol=None):
+    def _test_scalar(self, function, args, expected, rtol=1e-12, atol=1e-12):
         special = cupyx.scipy.special
         function = getattr(special, function)
-        if rtol is None:
-            testing.assert_array_equal(function(*args), expected)
-        else:
-            testing.assert_allclose(function(*args), expected, rtol=rtol)
+        testing.assert_allclose(function(*args), expected, rtol=rtol,
+                                atol=atol)
 
 
 @testing.gpu
 @testing.with_requires('scipy')
 class TestTwoArgumentDistribution(_TestDistributionsBase):
 
+    @pytest.mark.skipif(cp.cuda.runtime.is_hip,
+                        reason="avoid failures observed on HIP")
     @pytest.mark.parametrize('function', ['chdtr', 'chdtrc', 'chdtri',
                                           'pdtr', 'pdtrc', 'pdtri'])
     @testing.for_float_dtypes()
@@ -187,18 +187,18 @@ class TestTwoArgumentDistribution(_TestDistributionsBase):
         return func(k, y)
 
     @pytest.mark.parametrize(
-        'function, args, expected, rtol',
-        [('chdtr', (1, 0), 0.0, None),
-         ('chdtr', (0.7, cupy.inf), 1.0, None),
-         ('chdtr', (0.6, 3), 0.957890536704110, 1e-12),
-         ('chdtrc', (1, 0), 1.0, None),
-         ('chdtrc', (0.6, 3), 1 - 0.957890536704110, 1e-12),
-         ('chdtri', (1, 1), 0.0, None),
-         ('chdtri', (0.6, 1 - 0.957890536704110), 3, 1e-12),
+        'function, args, expected',
+        [('chdtr', (1, 0), 0.0),
+         ('chdtr', (0.7, cupy.inf), 1.0),
+         ('chdtr', (0.6, 3), 0.957890536704110),
+         ('chdtrc', (1, 0), 1.0),
+         ('chdtrc', (0.6, 3), 1 - 0.957890536704110),
+         ('chdtri', (1, 1), 0.0),
+         ('chdtri', (0.6, 1 - 0.957890536704110), 3),
          ]
     )
-    def test_scalar(self, function, args, expected, rtol):
-        self._test_scalar(function, args, expected, rtol)
+    def test_scalar(self, function, args, expected):
+        self._test_scalar(function, args, expected)
 
 
 @testing.gpu
@@ -271,29 +271,29 @@ class TestThreeArgumentDistributions(_TestDistributionsBase):
         return func(k, n, p)
 
     @pytest.mark.parametrize(
-        'function, args, expected, rtol',
-        [('btdtr', (1, 1, 1), 1.0, None),
-         ('btdtri', (1, 1, 1), 1.0, None),
-         ('betainc', (1, 1, 0), 0.0, None),
+        'function, args, expected',
+        [('btdtr', (1, 1, 1), 1.0),
+         ('btdtri', (1, 1, 1), 1.0),
+         ('betainc', (1, 1, 0), 0.0),
          # Computed using Wolfram Alpha: CDF[FRatioDistribution[1e-6, 5], 10]
-         ('fdtr', (1e-6, 5, 10), 0.9999940790193488, 1e-12),
-         ('fdtrc', (1, 1, 0), 1.0, None),
+         ('fdtr', (1e-6, 5, 10), 0.9999940790193488),
+         ('fdtrc', (1, 1, 0), 1.0),
          # Computed using Wolfram Alpha:
          #   1 - CDF[FRatioDistribution[2, 1/10], 1e10]
-         ('fdtrc', (2, 0.1, 1e10), 0.2722378462129351, 1e-12),
+         ('fdtrc', (2, 0.1, 1e10), 0.2722378462129351),
          # From Wolfram Alpha:
          #   CDF[FRatioDistribution[1/10, 1], 3] = 0.8756751669632106...
-         ('fdtri', (0.1, 1, 0.8756751669632106), 3.0, 1e-12),
-         ('gdtr', (1, 1, 0), 0.0, None),
-         ('gdtr', (1, 1, cupy.inf), 1.0, None),
-         ('gdtrc', (1, 1, 0), 1.0, None),
-         ('bdtr', (1, 1, 0.5), 1.0, None),
-         ('bdtrc', (1, 3, 0.5), 0.5, None),
-         ('bdtri', (1, 3, 0.5), 0.5, None),
-         ('nbdtr', (1, 1, 1), 1.0, None),
-         ('nbdtrc', (1, 1, 1), 0.0, None),
-         ('nbdtri', (1, 1, 1), 1.0, None),
+         ('fdtri', (0.1, 1, 0.8756751669632106), 3.0),
+         ('gdtr', (1, 1, 0), 0.0),
+         ('gdtr', (1, 1, cupy.inf), 1.0),
+         ('gdtrc', (1, 1, 0), 1.0),
+         ('bdtr', (1, 1, 0.5), 1.0),
+         ('bdtrc', (1, 3, 0.5), 0.5),
+         ('bdtri', (1, 3, 0.5), 0.5),
+         ('nbdtr', (1, 1, 1), 1.0),
+         ('nbdtrc', (1, 1, 1), 0.0),
+         ('nbdtri', (1, 1, 1), 1.0),
          ]
     )
-    def test_scalar(self, function, args, expected, rtol):
-        self._test_scalar(function, args, expected, rtol)
+    def test_scalar(self, function, args, expected):
+        self._test_scalar(function, args, expected)

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_statistics.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_statistics.py
@@ -231,16 +231,18 @@ class TestThreeArgumentDistributions(_TestDistributionsBase):
         x = x[xp.newaxis, xp.newaxis, :]
         return func(a, b, x)
 
+    # omit test with scipy < 1.5 due to change in ufunc type signatures
     @pytest.mark.parametrize('function', ['bdtr', 'bdtrc', 'bdtri'])
     @testing.for_float_dtypes()
     @testing.for_signed_dtypes(name='int_dtype')
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
+    @testing.with_requires('scipy>=1.5.0')
     def test_binomdist_linspace(self, xp, scp, function, dtype, int_dtype):
         import scipy.special  # NOQA
 
         if xp.dtype(int_dtype) not in [xp.int32, xp.int64]:
             if xp.dtype(dtype) != xp.float64:
-                # Skip cases deprecated in SciPy 1.7+ via this Cython code:
+                # Skip cases deprecated in SciPy 1.5+ via this Cython code:
                 # https://github.com/scipy/scipy/blob/cdb9b034d46c7ba0cacf65a9b2848c5d49c286c4/scipy/special/_legacy.pxd#L39-L43  # NOQA
                 # It causes infinite recursion in numpy_cupy_allclose
                 return xp.zeros((1,))

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_statistics.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_statistics.py
@@ -240,15 +240,13 @@ class TestThreeArgumentDistributions(_TestDistributionsBase):
     def test_binomdist_linspace(self, xp, scp, function, dtype, int_dtype):
         import scipy.special  # NOQA
 
-        cast_to_long = [xp.float32]
-        if xp.dtype(int).itemsize == 8:
-            cast_to_long += [xp.float64]
-        if xp.dtype(int_dtype) not in cast_to_long:
-            if xp.dtype(dtype) != xp.float64:
-                # Skip cases deprecated in SciPy 1.5+ via this Cython code:
-                # https://github.com/scipy/scipy/blob/cdb9b034d46c7ba0cacf65a9b2848c5d49c286c4/scipy/special/_legacy.pxd#L39-L43  # NOQA
-                # It causes infinite recursion in numpy_cupy_allclose
-                return xp.zeros((1,))
+        if dtype != xp.float64:
+            # Skip cases deprecated in SciPy 1.5+ via this Cython code:
+            # https://github.com/scipy/scipy/blob/cdb9b034d46c7ba0cacf65a9b2848c5d49c286c4/scipy/special/_legacy.pxd#L39-L43  # NOQA
+            # All type casts except `dld->d` should raise a DeprecationWawrning
+            # However on the SciPy side, this shows up as a SystemError
+            #    SystemError: <class 'DeprecationWarning'> returned a result with an exception set  # NOQA
+            return xp.zeros((1,))
 
         func = getattr(scp.special, function)
         n = xp.linspace(0, 80, 80, dtype=int_dtype)[xp.newaxis, :, xp.newaxis]

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_statistics.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_statistics.py
@@ -240,7 +240,10 @@ class TestThreeArgumentDistributions(_TestDistributionsBase):
     def test_binomdist_linspace(self, xp, scp, function, dtype, int_dtype):
         import scipy.special  # NOQA
 
-        if xp.dtype(int_dtype) not in [xp.int32, xp.int64]:
+        cast_to_long = [xp.float32]
+        if xp.dtype(int).itemsize == 8:
+            cast_to_long += [xp.float64]
+        if xp.dtype(int_dtype) not in cast_to_long:
             if xp.dtype(dtype) != xp.float64:
                 # Skip cases deprecated in SciPy 1.5+ via this Cython code:
                 # https://github.com/scipy/scipy/blob/cdb9b034d46c7ba0cacf65a9b2848c5d49c286c4/scipy/special/_legacy.pxd#L39-L43  # NOQA
@@ -251,7 +254,7 @@ class TestThreeArgumentDistributions(_TestDistributionsBase):
         n = xp.linspace(0, 80, 80, dtype=int_dtype)[xp.newaxis, :, xp.newaxis]
 
         # broadcast to create k <= n
-        k = xp.linspace(0, 1, 10, dtype=int_dtype)
+        k = xp.linspace(0, 1, 10, dtype=dtype)
         k = k[:, xp.newaxis, xp.newaxis] * n
         p = xp.linspace(0, 1, 5, dtype=dtype)[xp.newaxis, xp.newaxis, :]
         return func(k, n, p)

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_statistics.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_statistics.py
@@ -1,5 +1,3 @@
-import unittest
-
 import numpy
 import pytest
 
@@ -112,7 +110,7 @@ class TestSpecial(_TestBase):
 
 @testing.gpu
 @testing.with_requires('scipy')
-class TestFusionSpecial(unittest.TestCase, _TestBase):
+class TestFusionSpecial(_TestBase):
 
     def _check_unary(self, a, name, scp):
         import scipy.special  # NOQA
@@ -141,3 +139,156 @@ class TestFusionSpecial(unittest.TestCase, _TestBase):
     def check_unary_linspace0_1(self, name, xp, scp, dtype):
         a = xp.linspace(0, 1, 1000, dtype)
         return self._check_unary(a, name, scp)
+
+
+class _TestDistributionsBase:
+
+    def _test_scalar(self, function, args, expected, rtol=None):
+        special = cupyx.scipy.special
+        function = getattr(special, function)
+        if rtol is None:
+            testing.assert_array_equal(function(*args), expected)
+        else:
+            testing.assert_allclose(function(*args), expected, rtol=rtol)
+
+
+@testing.gpu
+@testing.with_requires('scipy')
+class TestTwoArgumentDistribution(_TestDistributionsBase):
+
+    @pytest.mark.parametrize('function', ['chdtr', 'chdtrc', 'chdtri',
+                                          'pdtr', 'pdtrc', 'pdtri'])
+    @testing.for_float_dtypes()
+    @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
+    def test_linspace_broadcast(self, xp, scp, dtype, function):
+        import scipy.special  # NOQA
+
+        func = getattr(scp.special, function)
+        # chdtr* comparisons fail at < 1 degree of freedom
+        minval = 1 if function.startswith('chdtr') else -1
+        v = xp.arange(minval, 10, dtype=dtype)[:, xp.newaxis]
+        if function in ['chdtri', 'pdtri']:
+            # concentrate values around probability range ([0, 1])
+            x = xp.linspace(-.1, 1.3, 20, dtype=dtype)
+        else:
+            # concentrate mostly on valid, positive values
+            x = xp.linspace(-1, 10, 20, dtype=dtype)
+        return func(v, x[xp.newaxis, :])
+
+    @testing.for_float_dtypes()
+    @testing.for_int_dtypes(name='int_dtype', no_bool=True)
+    @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
+    def test_linspace_pdtri(self, xp, scp, int_dtype, dtype):
+        import scipy.special  # NOQA
+
+        func = getattr(scp.special, 'pdtri')
+        k = xp.arange(1, 10, dtype=int_dtype)[:, xp.newaxis]
+        y = xp.linspace(0, 1, 20, dtype=dtype)[xp.newaxis, :]
+        return func(k, y)
+
+    @pytest.mark.parametrize(
+        'function, args, expected, rtol',
+        [('chdtr', (1, 0), 0.0, None),
+         ('chdtr', (0.7, cupy.inf), 1.0, None),
+         ('chdtr', (0.6, 3), 0.957890536704110, 1e-12),
+         ('chdtrc', (1, 0), 1.0, None),
+         ('chdtrc', (0.6, 3), 1 - 0.957890536704110, 1e-12),
+         ('chdtri', (1, 1), 0.0, None),
+         ('chdtri', (0.6, 1 - 0.957890536704110), 3, 1e-12),
+         ]
+    )
+    def test_scalar(self, function, args, expected, rtol):
+        self._test_scalar(function, args, expected, rtol)
+
+
+@testing.gpu
+@testing.with_requires('scipy')
+class TestThreeArgumentDistributions(_TestDistributionsBase):
+
+    @pytest.mark.parametrize('function', ['btdtr', 'btdtri', 'fdtr', 'fdtrc',
+                                          'fdtri', 'gdtr', 'gdtrc'])
+    @testing.for_float_dtypes()
+    @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
+    def test_linspace_broadcasted(self, xp, scp, dtype, function):
+        """Linspace with three arguments.
+
+        This method uses first two arguments with mostly non-negative values.
+        In some cases, the last argument is constrained to range [0, 1]
+        """
+
+        import scipy.special  # NOQA
+
+        func = getattr(scp.special, function)
+        # a and b should be positive
+        a = xp.linspace(-1, 21, 30, dtype=dtype)[:, xp.newaxis, xp.newaxis]
+        b = xp.linspace(-1, 21, 30, dtype=dtype)[xp.newaxis, :, xp.newaxis]
+        if function in ['fdtri', 'btdtr', 'btdtri']:
+            # x should be in [0, 1] so concentrate values around that
+            x = xp.linspace(-0.1, 1.3, 20, dtype=dtype)
+        else:
+            # x should be non-negative, but test with at least 1 negative value
+            x = xp.linspace(-1, 10, 20, dtype=dtype)
+        x = x[xp.newaxis, xp.newaxis, :]
+        return func(a, b, x)
+
+    @pytest.mark.parametrize('function', ['bdtr', 'bdtrc', 'bdtri'])
+    @testing.for_float_dtypes()
+    @testing.for_signed_dtypes(name='int_dtype')
+    @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
+    def test_binomdist_linspace(self, xp, scp, function, dtype, int_dtype):
+        import scipy.special  # NOQA
+
+        if xp.dtype(int_dtype) not in [xp.int32, xp.int64]:
+            if xp.dtype(dtype) != xp.float64:
+                # Skip cases deprecated in SciPy 1.7+ via this Cython code:
+                # https://github.com/scipy/scipy/blob/cdb9b034d46c7ba0cacf65a9b2848c5d49c286c4/scipy/special/_legacy.pxd#L39-L43  # NOQA
+                # It causes infinite recursion in numpy_cupy_allclose
+                return xp.zeros((1,))
+
+        func = getattr(scp.special, function)
+        n = xp.linspace(0, 80, 80, dtype=int_dtype)[xp.newaxis, :, xp.newaxis]
+        # broadcast to create k <= n
+        k = xp.linspace(0, 1, 10, dtype=dtype)[:, xp.newaxis, xp.newaxis] * n
+        p = xp.linspace(0, 1, 5, dtype=dtype)[xp.newaxis, xp.newaxis, :]
+        return func(k, n, p)
+
+    @pytest.mark.parametrize('function', ['nbdtr', 'nbdtrc', 'nbdtri'])
+    @testing.for_float_dtypes()
+    @testing.for_signed_dtypes(name='int_dtype')
+    @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
+    def test_negbinomdist_linspace(self, xp, scp, function, dtype, int_dtype):
+        import scipy.special  # NOQA
+
+        func = getattr(scp.special, function)
+        n = xp.linspace(0, 20, 20, dtype=int_dtype)[xp.newaxis, :, xp.newaxis]
+        k = xp.linspace(0, 20, 20, dtype=int_dtype)[:, xp.newaxis, xp.newaxis]
+        p = xp.linspace(0, 1, 5, dtype=dtype)[xp.newaxis, xp.newaxis, :]
+        return func(k, n, p)
+
+    @pytest.mark.parametrize(
+        'function, args, expected, rtol',
+        [('btdtr', (1, 1, 1), 1.0, None),
+         ('btdtri', (1, 1, 1), 1.0, None),
+         ('betainc', (1, 1, 0), 0.0, None),
+         # Computed using Wolfram Alpha: CDF[FRatioDistribution[1e-6, 5], 10]
+         ('fdtr', (1e-6, 5, 10), 0.9999940790193488, 1e-12),
+         ('fdtrc', (1, 1, 0), 1.0, None),
+         # Computed using Wolfram Alpha:
+         #   1 - CDF[FRatioDistribution[2, 1/10], 1e10]
+         ('fdtrc', (2, 0.1, 1e10), 0.2722378462129351, 1e-12),
+         # From Wolfram Alpha:
+         #   CDF[FRatioDistribution[1/10, 1], 3] = 0.8756751669632106...
+         ('fdtri', (0.1, 1, 0.8756751669632106), 3.0, 1e-12),
+         ('gdtr', (1, 1, 0), 0.0, None),
+         ('gdtr', (1, 1, cupy.inf), 1.0, None),
+         ('gdtrc', (1, 1, 0), 1.0, None),
+         ('bdtr', (1, 1, 0.5), 1.0, None),
+         ('bdtrc', (1, 3, 0.5), 0.5, None),
+         ('bdtri', (1, 3, 0.5), 0.5, None),
+         ('nbdtr', (1, 1, 1), 1.0, None),
+         ('nbdtrc', (1, 1, 1), 0.0, None),
+         ('nbdtri', (1, 1, 1), 1.0, None),
+         ]
+    )
+    def test_scalar(self, function, args, expected, rtol):
+        self._test_scalar(function, args, expected, rtol)

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_statistics.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_statistics.py
@@ -247,8 +247,10 @@ class TestThreeArgumentDistributions(_TestDistributionsBase):
 
         func = getattr(scp.special, function)
         n = xp.linspace(0, 80, 80, dtype=int_dtype)[xp.newaxis, :, xp.newaxis]
+
         # broadcast to create k <= n
-        k = xp.linspace(0, 1, 10, dtype=dtype)[:, xp.newaxis, xp.newaxis] * n
+        k = xp.linspace(0, 1, 10, dtype=int_dtype)
+        k = k[:, xp.newaxis, xp.newaxis] * n
         p = xp.linspace(0, 1, 5, dtype=dtype)[xp.newaxis, xp.newaxis, :]
         return func(k, n, p)
 

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_statistics.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_statistics.py
@@ -237,6 +237,8 @@ class TestThreeArgumentDistributions(_TestDistributionsBase):
     @testing.for_signed_dtypes(name='int_dtype')
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
     @testing.with_requires('scipy>=1.5.0')
+    @pytest.mark.skipif(cupy.cuda.runtime.is_hip,
+                        reason="avoid failures observed on HIP")
     def test_binomdist_linspace(self, xp, scp, function, dtype, int_dtype):
         import scipy.special  # NOQA
 

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_ufunc_dispatch.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_ufunc_dispatch.py
@@ -32,7 +32,12 @@ class TestUfunc:
         ufunc = getattr(scipy.special, ufunc)
         # some ufunc (like sph_harm) do not work with float inputs
         # therefore we retrieve the types from the ufunc itself
-        types = ufunc.types[0]
+        if ufunc.__name__ in ['bdtr', 'bdtrc', 'bdtri']:
+            # Make sure non-deprecated types are used.
+            # (avoids DeprecationWarning from SciPy >=1.7)
+            types = 'dld->d'
+        else:
+            types = ufunc.types[0]
         args = [
             cupy.testing.shaped_random((5,), xp, dtype=types[i])
             for i in range(ufunc.nin)


### PR DESCRIPTION
This PR adds many functions related to statistical distributions. There are many new functions here, but each is quite small (often <10 lines of GPU kernel code) because they mostly call previously implemented gamma and beta functions. They also often share a common testing logic. It was mainly implementing the test cases that was time consuming.

I have grouped these together in their own `_stats_distributions.py` file and moved the existing normal distribution functions into that file as well. I tried to have common logic where possible in the test classes, but there are occasionally subtle differences in dtype behavior (e.g. differences on behavior/warnings around unsafe casting of double->int32). The `ufunc.types` match and are in the same order as those in SciPy to ensure the same type casting behavior.

attn: @IvanYashchuk 