### PR TITLE
Ignore warnings from Optuna 3.0 pre-releases

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,9 @@ filterwarnings =
     ignore::PendingDeprecationWarning:numpy\.matrixlib\.defmatrix
     # pyreadline (dependency from optuna -> cliff -> cmd2) uses deprecated ABCs
     ignore:Using or importing the ABCs from:DeprecationWarning:pyreadline
+    # Ignore warnings from Optuna 3.0 internal code
+    # TODO(kmaehashi): Remove after the issue is fixed in Optuna.
+    ignore:(.+?) has been deprecated in v3.0.0:FutureWarning:optuna
 xfail_strict=true
 
 [metadata]


### PR DESCRIPTION
Part of #6455

It seems that Optuna 3.0.0a1/a2 has an issue that emits FutureWarning when using `Trial.suggest_int`.
Let's ignore them until the issue is fixed in Optuna side.

https://github.com/optuna/optuna/releases/tag/v3.0.0-a1

> v3.0.0-a1 contains several changes for this project and you will temporarily see UserWarning when you call Trial.suggest_int and Trial.suggest_float. We apologize for the inconvenience and the warning will be removed from the next release.