### PR TITLE
Warn if unexpectedlly failed to detect device count in `cupy.show_config()`

### DIFF
--- a/cupyx/_runtime.py
+++ b/cupyx/_runtime.py
@@ -2,6 +2,7 @@ import inspect
 import io
 import os
 import platform
+import warnings
 
 import numpy
 
@@ -275,7 +276,7 @@ class _RuntimeInfo:
             device_count = cupy.cuda.runtime.getDeviceCount()
         except cupy.cuda.runtime.CUDARuntimeError as e:
             if 'ErrorNoDevice' not in e.args[0]:
-                raise
+                warnings.warn(f'Failed to detect number of GPUs: {e}')
             # No GPU devices available.
         for device_id in range(device_count):
             with cupy.cuda.Device(device_id) as device:


### PR DESCRIPTION
Both CUDA/ROCm may fail to detect the number of GPUs with errors other than ErrorNoDevice in `cupy.show_config()`. See https://github.com/cupy/cupy/pull/6466#issuecomment-1041104492.