### PR TITLE
Revert "Tentatively pin intersphinx to SciPy 1.7.1 docs"

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -366,7 +366,7 @@ autosummary_generate = True
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3/', None),
     'numpy': ('https://numpy.org/doc/stable/', None),
-    'scipy': ('https://docs.scipy.org/doc/scipy-1.7.1/', None),
+    'scipy': ('https://docs.scipy.org/doc/scipy/', None),
 }
 
 doctest_global_setup = '''


### PR DESCRIPTION
Reverts cupy/cupy#6440. The issue seems resolved.