### PR TITLE
Fix failing tests in ROCm

### DIFF
--- a/tests/cupyx_tests/scipy_tests/special_tests/test_beta.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_beta.py
@@ -65,7 +65,7 @@ class TestBeta:
     def test_beta_specific_vals(self):
         # specific values borrowed from SciPy test suite
         special = cupyx.scipy.special
-        assert special.beta(1, 1) == 1.0
+        testing.assert_allclose(special.beta(1, 1), 1.0)
         testing.assert_allclose(special.beta(-100.3, 1e-200),
                                 special.gamma(1e-200))
         testing.assert_allclose(special.beta(0.0342, 171),
@@ -74,7 +74,7 @@ class TestBeta:
     def test_betaln_specific_vals(self):
         # specific values borrowed from SciPy test suite
         special = cupyx.scipy.special
-        assert special.betaln(1, 1) == 0.0
+        testing.assert_allclose(special.betaln(1, 1), 0.0, atol=1e-10)
         testing.assert_allclose(special.betaln(-100.3, 1e-200),
                                 special.gammaln(1e-200))
         testing.assert_allclose(special.betaln(0.0342, 170),

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_gammainc.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_gammainc.py
@@ -11,6 +11,10 @@ INVALID_POINTS = [(1, -1), (0, 0), (-1, 1), (cp.nan, 1), (1, cp.nan)]
 
 
 class TestGammainc(object):
+    @pytest.mark.skipif(
+        cp.cuda.runtime.is_hip and
+        cp.cuda.runtime.runtimeGetVersion() < 5_00_00000,
+        reason='ROCm/HIP fails in ROCm 4.x')
     @pytest.mark.parametrize("a, x", INVALID_POINTS)
     def test_domain(self, a, x):
         assert cp.isnan(sc.gammainc(a, x))
@@ -34,6 +38,10 @@ class TestGammainc(object):
         else:
             assert result == desired
 
+    @pytest.mark.skipif(
+        cp.cuda.runtime.is_hip and
+        cp.cuda.runtime.runtimeGetVersion() < 5_00_00000,
+        reason='ROCm/HIP fails in ROCm 4.x')
     def test_infinite_limits(self):
         # Test that large arguments converge to the hard-coded limits
         # at infinity.
@@ -49,6 +57,10 @@ class TestGammainc(object):
         a = cp.arange(1, 10)
         assert_array_equal(sc.gammainc(a, 0), 0)
 
+    @pytest.mark.skipif(
+        cp.cuda.runtime.is_hip and
+        cp.cuda.runtime.runtimeGetVersion() < 5_00_00000,
+        reason='ROCm/HIP fails in ROCm 4.x')
     def test_limit_check(self):
         result = sc.gammainc(1e-10, 1)
         limit = sc.gammainc(0, 1)
@@ -120,6 +132,10 @@ class TestGammaincc(object):
         else:
             assert result == desired
 
+    @pytest.mark.skipif(
+        cp.cuda.runtime.is_hip and
+        cp.cuda.runtime.runtimeGetVersion() < 5_00_00000,
+        reason='ROCm/HIP fails in ROCm 4.x')
     def test_infinite_limits(self):
         # Test that large arguments converge to the hard-coded limits
         # at infinity.
@@ -140,6 +156,10 @@ class TestGammaincc(object):
         a = cp.arange(1, 10)
         assert_array_equal(sc.gammaincc(a, 0), 1)
 
+    @pytest.mark.skipif(
+        cp.cuda.runtime.is_hip and
+        cp.cuda.runtime.runtimeGetVersion() < 5_00_00000,
+        reason='ROCm/HIP fails in ROCm 4.x')
     def test_roundtrip(self):
         a = cp.logspace(-5, 10, 100)
         x = cp.logspace(-5, 10, 100)

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_gammainc.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_gammainc.py
@@ -84,6 +84,10 @@ class TestGammainc(object):
     #     dataset = cp.vstack((a, x, self.gammainc_line(x))).T
     #     FuncData(sc.gammainc, dataset, (0, 1), 2, rtol=1e-11).check()
 
+    @pytest.mark.skipif(
+        cp.cuda.runtime.is_hip and
+        cp.cuda.runtime.runtimeGetVersion() < 5_00_00000,
+        reason='ROCm/HIP fails in ROCm 4.x')
     def test_roundtrip(self):
         a = cp.logspace(-5, 10, 100)
         x = cp.logspace(-5, 10, 100)

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_ufunc_dispatch.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_ufunc_dispatch.py
@@ -18,6 +18,7 @@ try:
         for f in dir(cupyx.scipy.special)
         if isinstance(getattr(cupyx.scipy.special, f), cupy.ufunc)
     }
+
 except ImportError:
     scipy_ufuncs = set()
     cupyx_scipy_ufuncs = set()
@@ -27,8 +28,17 @@ except ImportError:
 @testing.with_requires("scipy")
 @pytest.mark.parametrize("ufunc", sorted(cupyx_scipy_ufuncs & scipy_ufuncs))
 class TestUfunc:
+    def _should_skip(self, f):
+        if f.startswith("gammainc"):
+            if (
+                cupy.cuda.runtime.is_hip
+                and cupy.cuda.runtime.runtimeGetVersion() < 5_00_00000
+            ):
+                pytest.skip('ROCm/HIP fails in ROCm 4.x')
+
     @testing.numpy_cupy_allclose(atol=1e-4)
     def test_dispatch(self, xp, ufunc):
+        self._should_skip(ufunc)
         ufunc = getattr(scipy.special, ufunc)
         # some ufunc (like sph_harm) do not work with float inputs
         # therefore we retrieve the types from the ufunc itself


### PR DESCRIPTION
```
13:53:34 FAILED cupyx_tests/scipy_tests/special_tests/test_beta.py::TestBeta::test_beta_specific_vals
13:53:34 FAILED cupyx_tests/scipy_tests/special_tests/test_beta.py::TestBeta::test_betaln_specific_vals
```

Tolerance needs to be adjusted.

```
13:53:34 FAILED cupyx_tests/scipy_tests/special_tests/test_gammainc.py::TestGammainc::test_roundtrip
```
This issue seems to be resolved in ROCm 5.0.