### PR TITLE
Disable CentOS 8 test

### DIFF
--- a/.pfnci/coverage.rst
+++ b/.pfnci/coverage.rst
@@ -223,6 +223,8 @@ CuPy CI Test Coverage
      - 
      - ✅
      - ✅
+     - ✅
+     - ✅
      - 
      - 
      - 
@@ -238,9 +240,7 @@ CuPy CI Test Coverage
      - 
      - 
      - 
-     - 
-     - 
-     - 2
+     - 4
    * - 
      - centos:8
      - 
@@ -249,8 +249,6 @@ CuPy CI Test Coverage
      - 
      - 
      - 
-     - ✅
-     - ✅
      - 
      - 
      - 
@@ -266,7 +264,9 @@ CuPy CI Test Coverage
      - 
      - 
      - 
-     - 2
+     - 
+     - 
+     - 0 🚨
    * - 
      - ws:2016
      - 

--- a/.pfnci/linux/tests/cuda112.Dockerfile
+++ b/.pfnci/linux/tests/cuda112.Dockerfile
@@ -1,6 +1,11 @@
 # AUTO GENERATED: DO NOT EDIT!
-ARG BASE_IMAGE="nvidia/cuda:11.2.1-devel-centos8"
+ARG BASE_IMAGE="nvidia/cuda:11.2.1-devel-centos7"
 FROM ${BASE_IMAGE}
+
+RUN yum -y install centos-release-scl && \
+    yum -y install devtoolset-7-gcc-c++
+ENV PATH "/opt/rh/devtoolset-7/root/usr/bin:${PATH}"
+ENV LD_LIBRARY_PATH "/opt/rh/devtoolset-7/root/usr/lib64:/opt/rh/devtoolset-7/root/usr/lib:${LD_LIBRARY_PATH}"
 
 RUN yum -y install \
        zlib-devel bzip2 bzip2-devel readline-devel sqlite \

--- a/.pfnci/linux/tests/cuda112.multi.Dockerfile
+++ b/.pfnci/linux/tests/cuda112.multi.Dockerfile
@@ -1,6 +1,11 @@
 # AUTO GENERATED: DO NOT EDIT!
-ARG BASE_IMAGE="nvidia/cuda:11.2.1-devel-centos8"
+ARG BASE_IMAGE="nvidia/cuda:11.2.1-devel-centos7"
 FROM ${BASE_IMAGE}
+
+RUN yum -y install centos-release-scl && \
+    yum -y install devtoolset-7-gcc-c++
+ENV PATH "/opt/rh/devtoolset-7/root/usr/bin:${PATH}"
+ENV LD_LIBRARY_PATH "/opt/rh/devtoolset-7/root/usr/lib64:/opt/rh/devtoolset-7/root/usr/lib:${LD_LIBRARY_PATH}"
 
 RUN yum -y install \
        zlib-devel bzip2 bzip2-devel readline-devel sqlite \

--- a/.pfnci/matrix.yaml
+++ b/.pfnci/matrix.yaml
@@ -92,7 +92,7 @@
   tags: ["full"]
   target: "cuda112"
   system: "linux"
-  os: "centos:8"
+  os: "centos:7"
   cuda: "11.2"
   rocm: null
   nccl: "2.8"


### PR DESCRIPTION
CentOS 8 reached EOL, and `yum` in CentOS-based CUDA images stopped working.
Tentatively disable CentOS 8 in our CI.

I tried to use UBI 8 images but UBI does not offer `readonly-devel` and `tk-devel` RPMs so they did not work.