### PR TITLE
Skip appending `--compiler-bindir` if `cl.exe` is already on `PATH`

### DIFF
--- a/install/cupy_builder/_command.py
+++ b/install/cupy_builder/_command.py
@@ -102,6 +102,8 @@ class custom_build_ext(setuptools.command.build_ext.build_ext):  # type: ignore[
             for src in ext.sources:
                 if not os.path.isfile(src):
                     raise RuntimeError(f'Fatal error: missing file: {src}')
+
+        print('Building extensions...')
         super().build_extensions()
 
     def build_extension(self, ext: setuptools.Extension) -> None:


### PR DESCRIPTION
This avoids appending a `--compiler-bindir` if `cl.exe` is already on PATH.

The issue was discovered in conda-forge build:
https://github.com/conda-forge/cupy-feedstock/pull/165#issuecomment-1050536590

conda-forge build env uses nvcc-feedstock that comes with the [wrapper batch file](https://github.com/conda-forge/nvcc-feedstock/blob/master/recipe/windows/nvcc_windows.bat) that prepends `-ccbin "%CXX%"`, and this batch file is used as NVCC command. As CuPy can't tell whether NVCC command is a wrapper or a real executable, this PR just skips appending `--compiler-bindir` and let NVCC find `cl.exe` if it's already on PATH.

cc/ @leofang