### PR TITLE
Support cusparseSpGEMM()

### DIFF
--- a/cupy/cusparse.py
+++ b/cupy/cusparse.py
@@ -108,6 +108,7 @@ _available_cusparse_version = {
     'csrilu02': (8000, None),
     'denseToSparse': (11300, None),
     'sparseToDense': (11300, None),
+    'spgemm': (11100, None),
 }
 
 
@@ -1785,3 +1786,94 @@ def sparseToDense(x, out=None):
                             desc_out.desc, algo, buff.data.ptr)
 
     return out
+
+
+def spgemm(a, b, alpha=1):
+    """Matrix-matrix product for CSR-matrix.
+
+    math::
+       C = alpha * A * B
+
+    Args:
+        a (cupyx.scipy.sparse.csr_matrix): Sparse matrix A.
+        b (cupyx.scipy.sparse.csr_matrix): Sparse matrix B.
+        alpha (scalar): Coefficient
+
+    Returns:
+        cupyx.scipy.sparse.csr_matrix
+
+    """
+    if not check_availability('spgemm'):
+        raise RuntimeError('spgemm is not available.')
+
+    assert a.ndim == b.ndim == 2
+    if not isinstance(a, cupyx.scipy.sparse.csr_matrix):
+        raise TypeError('unsupported type (actual: {})'.format(type(a)))
+    if not isinstance(b, cupyx.scipy.sparse.csr_matrix):
+        raise TypeError('unsupported type (actual: {})'.format(type(b)))
+    assert a.has_canonical_format
+    assert b.has_canonical_format
+    if a.shape[1] != b.shape[0]:
+        raise ValueError('mismatched shape')
+
+    m, k = a.shape
+    _, n = b.shape
+    a, b = _cast_common_type(a, b)
+    c_shape = (m, n)
+    c = cupyx.scipy.sparse.csr_matrix((c_shape), dtype=a.dtype)
+
+    handle = _device.get_cusparse_handle()
+    mat_a = SpMatDescriptor.create(a)
+    mat_b = SpMatDescriptor.create(b)
+    mat_c = SpMatDescriptor.create(c)
+    spgemm_descr = _cusparse.spGEMM_createDescr()
+    op_a = _cusparse.CUSPARSE_OPERATION_NON_TRANSPOSE
+    op_b = _cusparse.CUSPARSE_OPERATION_NON_TRANSPOSE
+    alpha = _numpy.array(alpha, dtype=c.dtype).ctypes
+    beta = _numpy.array(0, dtype=c.dtype).ctypes
+    cuda_dtype = _dtype.to_cuda_dtype(c.dtype)
+    algo = _cusparse.CUSPARSE_SPGEMM_DEFAULT
+    null_ptr = 0
+
+    # Analyze the matrices A and B to understand the memory requirement
+    buff1_size = _cusparse.spGEMM_workEstimation(
+        handle, op_a, op_b, alpha.data, mat_a.desc, mat_b.desc, beta.data,
+        mat_c.desc, cuda_dtype, algo, spgemm_descr, 0, null_ptr)
+    buff1 = _cupy.empty(buff1_size, _cupy.int8)
+    _cusparse.spGEMM_workEstimation(
+        handle, op_a, op_b, alpha.data, mat_a.desc, mat_b.desc, beta.data,
+        mat_c.desc, cuda_dtype, algo, spgemm_descr, buff1_size, buff1.data.ptr)
+
+    # Compute the intermediate product of A and B
+    buff2_size = _cusparse.spGEMM_compute(
+        handle, op_a, op_b, alpha.data, mat_a.desc, mat_b.desc, beta.data,
+        mat_c.desc, cuda_dtype, algo, spgemm_descr, 0, null_ptr)
+    buff2 = _cupy.empty(buff2_size, _cupy.int8)
+    _cusparse.spGEMM_compute(
+        handle, op_a, op_b, alpha.data, mat_a.desc, mat_b.desc, beta.data,
+        mat_c.desc, cuda_dtype, algo, spgemm_descr, buff2_size, buff2.data.ptr)
+
+    # Prepare the arrays for matrix C
+    c_num_rows = _numpy.array(0, dtype='int64')
+    c_num_cols = _numpy.array(0, dtype='int64')
+    c_nnz = _numpy.array(0, dtype='int64')
+    _cusparse.spMatGetSize(mat_c.desc, c_num_rows.ctypes.data,
+                           c_num_cols.ctypes.data, c_nnz.ctypes.data)
+    assert c_shape[0] == int(c_num_rows)
+    assert c_shape[1] == int(c_num_cols)
+    c_nnz = int(c_nnz)
+    c_indptr = c.indptr
+    c_indices = _cupy.empty(c_nnz, 'i')
+    c_data = _cupy.empty(c_nnz, c.dtype)
+    _cusparse.csrSetPointers(mat_c.desc, c_indptr.data.ptr, c_indices.data.ptr,
+                             c_data.data.ptr)
+
+    # Copy the final product to the matrix C
+    _cusparse.spGEMM_copy(
+        handle, op_a, op_b, alpha.data, mat_a.desc, mat_b.desc, beta.data,
+        mat_c.desc, cuda_dtype, algo, spgemm_descr)
+    c = cupyx.scipy.sparse.csr_matrix((c_data, c_indices, c_indptr),
+                                      shape=c_shape)
+
+    _cusparse.spGEMM_destroyDescr(spgemm_descr)
+    return c

--- a/cupy/cusparse.py
+++ b/cupy/cusparse.py
@@ -143,6 +143,7 @@ _available_hipsparse_version = {
     'csrilu02': (305, None),
     'denseToSparse': (402, None),
     'sparseToDense': (402, None),
+    'spgemm': (_numpy.inf, None),
 }
 
 

--- a/cupy_backends/cuda/cupy_cusparse.h
+++ b/cupy_backends/cuda/cupy_cusparse.h
@@ -573,6 +573,29 @@ cusparseStatus_t cusparseSpMatGetSize(...) {
   return CUSPARSE_STATUS_SUCCESS;
 }
 
+typedef void* cusparseSpGEMMDescr_t;
+typedef enum {} cusparseSpGEMMAlg_t;
+
+cusparseStatus_t cusparseSpGEMM_createDescr(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseSpGEMM_destroyDescr(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseSpGEMM_workEstimation(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseSpGEMM_compute(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseSpGEMM_copy(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
 #endif // #if CUSPARSE_VERSION < 11100
 
 #if CUSPARSE_VERSION < 11300

--- a/cupy_backends/cuda/libs/cusparse.pxd
+++ b/cupy_backends/cuda/libs/cusparse.pxd
@@ -42,20 +42,24 @@ cdef extern from *:
     ctypedef int Order 'cusparseOrder_t'
     ctypedef int SpMVAlg 'cusparseSpMVAlg_t'
     ctypedef int SpMMAlg 'cusparseSpMMAlg_t'
+    ctypedef int SpGEMMAlg 'cusparseSpGEMMAlg_t'
     ctypedef int DataType 'cudaDataType'
 
     ctypedef void* SpVecDescr 'cusparseSpVecDescr_t'
     ctypedef void* DnVecDescr 'cusparseDnVecDescr_t'
     ctypedef void* SpMatDescr 'cusparseSpMatDescr_t'
     ctypedef void* DnMatDescr 'cusparseDnMatDescr_t'
+    ctypedef void* SpGEMMDescr 'cusparseSpGEMMDescr_t'
 
     ctypedef void* cusparseSpVecDescr_t
     ctypedef void* cusparseDnVecDescr_t
     ctypedef void* cusparseSpMatDescr_t
     ctypedef void* cusparseDnMatDescr_t
+    ctypedef void* cusparseSpGEMMDescr_t
 
     ctypedef int cusparseSparseToDenseAlg_t
     ctypedef int cusparseDenseToSparseAlg_t
+    ctypedef int cusparseSpGEMMAlg_t
 
     # CSR2CSC
     ctypedef int Csr2CscAlg 'cusparseCsr2CscAlg_t'
@@ -123,6 +127,9 @@ cpdef enum:
     # CSR2CSC
     CUSPARSE_CSR2CSC_ALG1 = 1  # faster than ALG2 (in general), deterministc
     CUSPARSE_CSR2CSC_ALG2 = 2  # low memory requirement, non-deterministc
+
+    # ...
+    CUSPARSE_SPGEMM_DEFAULT = 0
 
     # cusparseSparseToDenseAlg_t
     CUSPARSE_SPARSETODENSE_ALG_DEFAULT = 0

--- a/cupy_backends/cuda/libs/cusparse.pyx
+++ b/cupy_backends/cuda/libs/cusparse.pyx
@@ -1336,6 +1336,23 @@ cdef extern from '../../cupy_sparse.h' nogil:
         DnMatDescr matA, DnMatDescr matB, void* beta, SpMatDescr matC,
         DataType computeType, void* externalBuffer)
 
+    Status cusparseSpGEMM_createDescr(SpGEMMDescr* spgemmDescr)
+    Status cusparseSpGEMM_destroyDescr(SpGEMMDescr spgemmDescr)
+    Status cusparseSpGEMM_workEstimation(
+        Handle handle, Operation opA, Operation opB, const void* alpha,
+        SpMatDescr matA, SpMatDescr matB, const void* beta, SpMatDescr matC,
+        DataType computeType, SpGEMMAlg alg, SpGEMMDescr spgemmDescr,
+        size_t* bufferSize1, void* externalBuffer1)
+    Status cusparseSpGEMM_compute(
+        Handle handle, Operation opA, Operation opB, const void* alpha,
+        SpMatDescr matA, SpMatDescr matB, const void* beta, SpMatDescr matC,
+        DataType computeType, SpGEMMAlg alg, SpGEMMDescr spgemmDescr,
+        size_t* bufferSize2, void* externalBuffer2)
+    Status cusparseSpGEMM_copy(
+        Handle handle, Operation opA, Operation opB, const void* alpha,
+        SpMatDescr matA, SpMatDescr matB, const void* beta, SpMatDescr matC,
+        DataType computeType, SpGEMMAlg alg, SpGEMMDescr spgemmDescr)
+
     Status cusparseSparseToDense_bufferSize(
         Handle handle, SpMatDescr matA, DnMatDescr matB,
         cusparseSparseToDenseAlg_t alg, size_t* bufferSize)
@@ -4854,6 +4871,54 @@ cpdef constrainedGeMM(intptr_t handle, Operation opA, Operation opB,
         <Handle>handle, opA, opB, <void*>alpha, <DnMatDescr>matA,
         <DnMatDescr>matB, <void*>beta, <SpMatDescr>matC, computeType,
         <void*>externalBuffer)
+    check_status(status)
+
+cpdef size_t spGEMM_createDescr():
+    cdef SpGEMMDescr descr
+    status = cusparseSpGEMM_createDescr(&descr)
+    check_status(status)
+    return <size_t>descr
+
+cpdef spGEMM_destroyDescr(size_t descr):
+    status = cusparseSpGEMM_destroyDescr(<SpGEMMDescr>descr)
+    check_status(status)
+
+cpdef size_t spGEMM_workEstimation(
+        intptr_t handle, Operation opA, Operation opB, intptr_t alpha,
+        size_t matA, size_t matB, intptr_t beta, size_t matC,
+        DataType computeType, int alg, size_t spgemmDescr,
+        size_t bufferSize, intptr_t externalBuffer1):
+    cdef size_t bufferSize1 = bufferSize
+    status = cusparseSpGEMM_workEstimation(
+        <Handle>handle, opA, opB, <const void*>alpha, <SpMatDescr>matA,
+        <SpMatDescr>matB, <const void*>beta, <SpMatDescr>matC, computeType,
+        <SpGEMMAlg>alg, <SpGEMMDescr>spgemmDescr, &bufferSize1,
+        <void*>externalBuffer1)
+    check_status(status)
+    return bufferSize1
+
+cpdef size_t spGEMM_compute(
+        intptr_t handle, Operation opA, Operation opB, intptr_t alpha,
+        size_t matA, size_t matB, intptr_t beta, size_t matC,
+        DataType computeType, int alg, size_t spgemmDescr,
+        size_t bufferSize, intptr_t externalBuffer2):
+    cdef size_t bufferSize2 = bufferSize
+    status = cusparseSpGEMM_compute(
+        <Handle>handle, opA, opB, <const void*>alpha, <SpMatDescr>matA,
+        <SpMatDescr>matB, <const void*>beta, <SpMatDescr>matC, computeType,
+        <SpGEMMAlg>alg, <SpGEMMDescr>spgemmDescr, &bufferSize2,
+        <void*>externalBuffer2)
+    check_status(status)
+    return bufferSize2
+
+cpdef spGEMM_copy(
+        intptr_t handle, Operation opA, Operation opB, intptr_t alpha,
+        size_t matA, size_t matB, intptr_t beta, size_t matC,
+        DataType computeType, int alg, size_t spgemmDescr):
+    status = cusparseSpGEMM_copy(
+        <Handle>handle, opA, opB, <const void*>alpha, <SpMatDescr>matA,
+        <SpMatDescr>matB, <const void*>beta, <SpMatDescr>matC, computeType,
+        <SpGEMMAlg>alg, <SpGEMMDescr>spgemmDescr)
     check_status(status)
 
 cpdef size_t sparseToDense_bufferSize(intptr_t handle, size_t matA,

--- a/cupy_backends/hip/cupy_hipsparse.h
+++ b/cupy_backends/hip/cupy_hipsparse.h
@@ -3618,6 +3618,28 @@ cusparseStatus_t cusparseCsr2cscEx2(...) {
   return HIPSPARSE_STATUS_NOT_SUPPORTED;
 }
 
+typedef void* cusparseSpGEMMDescr_t;
+typedef enum {} cusparseSpGEMMAlg_t;
+
+cusparseStatus_t cusparseSpGEMM_createDescr(...) {
+  return HIPSPARSE_STATUS_NOT_SUPPORTED;
+}
+
+cusparseStatus_t cusparseSpGEMM_destroyDescr(...) {
+  return HIPSPARSE_STATUS_NOT_SUPPORTED;
+}
+
+cusparseStatus_t cusparseSpGEMM_workEstimation(...) {
+  return HIPSPARSE_STATUS_NOT_SUPPORTED;
+}
+
+cusparseStatus_t cusparseSpGEMM_compute(...) {
+  return HIPSPARSE_STATUS_NOT_SUPPORTED;
+}
+
+cusparseStatus_t cusparseSpGEMM_copy(...) {
+  return HIPSPARSE_STATUS_NOT_SUPPORTED;
+}
 
 ///////////////////////////////////////////////////////////////////////////////
 // Definitions are for compatibility

--- a/cupy_backends/stub/cupy_cusparse.h
+++ b/cupy_backends/stub/cupy_cusparse.h
@@ -1171,6 +1171,28 @@ cusparseStatus_t cusparseCsr2cscEx2(...) {
   return CUSPARSE_STATUS_SUCCESS;
 }
 
+typedef void* cusparseSpGEMMDescr_t;
+typedef enum {} cusparseSpGEMMAlg_t;
+
+cusparseStatus_t cusparseSpGEMM_createDescr(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseSpGEMM_destroyDescr(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseSpGEMM_workEstimation(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseSpGEMM_compute(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
+
+cusparseStatus_t cusparseSpGEMM_copy(...) {
+  return CUSPARSE_STATUS_SUCCESS;
+}
 
 ///////////////////////////////////////////////////////////////////////////////
 // Definitions are for compatibility

--- a/cupyx/scipy/sparse/_csr.py
+++ b/cupyx/scipy/sparse/_csr.py
@@ -152,7 +152,9 @@ class csr_matrix(_compressed._compressed_sparse_matrix):
         elif isspmatrix_csr(other):
             self.sum_duplicates()
             other.sum_duplicates()
-            if cusparse.check_availability('csrgemm2'):
+            if cusparse.check_availability('spgemm'):
+                return cusparse.spgemm(self, other)
+            elif cusparse.check_availability('csrgemm2'):
                 return cusparse.csrgemm2(self, other)
             elif cusparse.check_availability('csrgemm'):
                 return cusparse.csrgemm(self, other)
@@ -164,6 +166,10 @@ class csr_matrix(_compressed._compressed_sparse_matrix):
             if cusparse.check_availability('csrgemm') and not runtime.is_hip:
                 # trans=True is still buggy as of ROCm 4.2.0
                 return cusparse.csrgemm(self, other.T, transb=True)
+            elif cusparse.check_availability('spgemm'):
+                b = other.tocsr()
+                b.sum_duplicates()
+                return cusparse.spgemm(self, b)
             elif cusparse.check_availability('csrgemm2'):
                 b = other.tocsr()
                 b.sum_duplicates()


### PR DESCRIPTION
This is related to https://github.com/cupy/cupy/issues/6463

Currently, CuPy uses [cusparse*csrgemm2()](https://docs.nvidia.com/cuda/cusparse/index.html#csrgemm2) for sparse matrix multiplication, but this function is deprecated and does not reflect recent performance improvements (that is, it's slow). In the future, it is recommended to use [cusparseSpGEMM()](https://docs.nvidia.com/cuda/cusparse/index.html#cusparse-generic-function-spgemm) instead of cusparse*csrgemm2, so this PR adds changes to allow cusparseSpGEMM() to be used with CuPy.

The results of comparing the performance using the reproducer of https://github.com/cupy/cupy/issues/6463 are as follows. `cusparse.csrgemm2` is the routine currently used in CuPy for the multiplication of sparse matrices. We have confirmed that `cusparse.spgemm` that is a routine added in this PR can reduce the computation time **from 41.8 ms to 1.6 ms!** I didn't expect such a bit difference in performance. The GPU used is V100.

```python
import cupy
from sklearn.datasets import fetch_20newsgroups
from sklearn.preprocessing import OneHotEncoder
from sklearn.feature_extraction.text import TfidfVectorizer
from cupyx.profiler import benchmark

news = fetch_20newsgroups(subset='train')

x = OneHotEncoder().fit_transform(news.target.reshape(-1, 1)).T
y = TfidfVectorizer().fit_transform(news.data)

x_sparse = cupy.sparse.csr_matrix(x)
y_sparse = cupy.sparse.csr_matrix(y)
    
x_dense = x_sparse.todense()
y_dense = y_sparse.todense()

def prod(x, y):
    x @ y
    
n_repeat = 10
print(benchmark(prod, (x_sparse, y_sparse), n_repeat=n_repeat, name='sparse prod'))
print(benchmark(prod, (x_dense, y_dense), n_repeat=n_repeat, name='dense prod'))
print(benchmark(cupy.cusparse.csrgemm2, (x_sparse, y_sparse), n_repeat=n_repeat, name='cusparse.csrgemm2'))
print(benchmark(cupy.cusparse.spgemm, (x_sparse, y_sparse), n_repeat=n_repeat, name='cusparse.spgemm'))
```

```
$ python repro.py
sparse prod         :    CPU:14310.440 us   +/-10.796 (min:14289.388 / max:14325.467) us     GPU-0:41838.900 us   +/-12.475 (min:41819.138 / max:41859.074) us
dense prod          :    CPU:   33.101 us   +/- 2.026 (min:   31.489 / max:   38.430) us     GPU-0:30594.150 us   +/-26.241 (min:30516.224 / max:30612.480) us
cusparse.csrgemm2   :    CPU:14318.144 us   +/-20.031 (min:14292.917 / max:14364.306) us     GPU-0:41879.655 us   +/-75.351 (min:41812.992 / max:42096.642) us
cusparse.spgemm     :    CPU: 1629.834 us   +/- 5.476 (min: 1619.690 / max: 1637.150) us     GPU-0: 1635.840 us   +/- 5.688 (min: 1626.112 / max: 1643.520) us
```


