### PR TITLE
Fix `cupy.cumsum` on ROCm 5.0

### DIFF
--- a/cupy/_core/include/cupy/hip_workaround.cuh
+++ b/cupy/_core/include/cupy/hip_workaround.cuh
@@ -9,9 +9,11 @@
 #define __shfl_down_sync(mask, ...) __shfl_down(__VA_ARGS__)
 #define __shfl_xor_sync(mask, ...) __shfl_xor(__VA_ARGS__)
 
-// It is guaranteed to be safe on AMD's hardware, see
-// https://rocmdocs.amd.com/en/latest/Programming_Guides/HIP-GUIDE.html#warp-cross-lane-functions
-#define __syncwarp() {}
+// In ROCm, threads in a warp march in lock-step, so we don't need to
+// synchronize the threads. But it doesn't guarantee the memory order,
+// which still make us use memory fences.
+// https://rocmdocs.amd.com/en/latest/Programming_Guides/Kernel_language.html#warp-cross-lane-functions
+#define __syncwarp() { __threadfence_block(); }
 
 #endif  // __HIP_DEVICE_COMPILE__
 


### PR DESCRIPTION
Close #6517.

This PR fixes `cupy.cumsum` to use memory fences at the points where CUDA synchronizes threads in a warp. We don't need to synchronize threads in a warp in ROCm as they march in lock-step, but still have to ensure its memory order.

The following is a performance comparison based on the script in #4366 on ROCm 4.3. I think its overhead is reasonably ignorable:

size | dtype | NumPy | CuPy(w/fence) | CuPy(wo/fence)
--|--|--|--|--
1000000 | int32 | 5.057 ms | 0.119 ms | 0.122 ms
1000000 | int64 | 1.710 ms | 0.128 ms | 0.123 ms
1000000 | float32 | 2.536 ms | 0.137 ms | 0.126 ms
1000000 | float64 | 2.560 ms | 0.153 ms | 0.134 ms
10000000 | int32 | 50.272 ms | 0.650 ms | 0.639 ms
10000000 | int64 | 29.694 ms | 0.741 ms | 0.735 ms
10000000 | float32 | 31.232 ms | 0.623 ms | 0.588 ms
10000000 | float64 | 38.383 ms | 0.828 ms | 0.805 ms
100000000 | int32 | 506.477 ms | 5.978 ms | 5.863 ms
100000000 | int64 | 300.734 ms | 6.882 ms | 6.801 ms
100000000 | float32 | 312.368 ms | 5.649 ms | 5.401 ms
100000000 | float64 | 379.666 ms | 7.792 ms | 7.628 ms
