### PR TITLE
Fix for supporting ROCm 5.0

### DIFF
--- a/.pfnci/schema.yaml
+++ b/.pfnci/schema.yaml
@@ -64,7 +64,7 @@ rocm:
                'rocsparse', 'rocrand', 'rocthrust', 'rocsolver', 'rocfft',
                'rocprim', 'rccl']
   "5.0":
-    full_version: "5.0"  # TODO(kmaehashi): bump to 5.0.1
+    full_version: "5.0"  # TODO(kmaehashi): bump to 5.0.2
     packages: ['rocm-dev', 'hipblas', 'hipfft', 'hipsparse', 'hipcub',
                'rocsparse', 'rocrand', 'rocthrust', 'rocsolver', 'rocfft',
                'rocprim', 'rccl']

--- a/cupy/_core/include/cupy/carray.cuh
+++ b/cupy/_core/include/cupy/carray.cuh
@@ -127,7 +127,7 @@ public:
   }
 
   __device__ float16 operator-() {
-    return float16{-data_};
+    return float16(-data_);
   }
 
   template<typename T>

--- a/cupy/_core/include/cupy/carray.cuh
+++ b/cupy/_core/include/cupy/carray.cuh
@@ -38,6 +38,12 @@ namespace cupy {
 // we only include necessary standard headers.
 #include <cassert>
 #include <cstddef>
+
+// Confirmed to AMD, ROCm 5.0 doesn't recognize __forceinline__ and
+// __noinline__.
+#define __noinline__ __attribute__((noinline))
+#define __forceinline__ inline __attribute__((always_inline))
+
 #else
 #include <hip/hip_fp16.h>
 #endif  // #if HIP_VERSION >= 40400000
@@ -118,6 +124,10 @@ public:
 
   __device__ int signbit() const {
     return (__half_raw(data_).x & 0x8000u) != 0;
+  }
+
+  __device__ float16 operator-() {
+    return float16{-data_};
   }
 
   template<typename T>

--- a/cupyx/scipy/ndimage/_filters_generic.py
+++ b/cupyx/scipy/ndimage/_filters_generic.py
@@ -1,5 +1,4 @@
 import cupy
-from cupy_backends.cuda.api import driver
 from cupy_backends.cuda.api import runtime
 from cupy import _util
 from cupyx.scipy.ndimage import _filters_core
@@ -201,6 +200,7 @@ def _get_generic_filter1d(rk, length, n_lines, filter_size, origin, mode, cval,
     name = 'generic1d_{}_{}_{}'.format(length, filter_size, rk.name)
     code = '''#include "cupy/carray.cuh"
 #include "cupy/complex.cuh"
+{include_type_traits}  // let Jitify handle this
 
 namespace raw_kernel {{\n{rk_code}\n}}
 
@@ -261,8 +261,8 @@ void {name}(const byte* input, byte* output, const idx_t* x) {{
              # wouldn't compile if code only contains device functions, so this
              # is necessary.
              rk_code=rk.code.replace('__global__', '__device__'),
+             include_type_traits=(
+                 '' if runtime.is_hip else '#include <type_traits>\n'),
              CAST=_filters_core._CAST_FUNCTION)
-    if runtime.is_hip and driver.get_build_version() < 5_00_00000:
-        code = _filters_core.includes + code
     return cupy.RawKernel(code, name, ('--std=c++11',) + rk.options,
                           jitify=True)

--- a/examples/custom_struct/complex_struct.py
+++ b/examples/custom_struct/complex_struct.py
@@ -19,7 +19,7 @@ extern "C" __global__ void get_struct_layout(
                                 unsigned long long *itemsize,
                                 unsigned long long *sizes,
                                 unsigned long long *offsets) {{
-    const complex_struct* ptr = NULL;
+    const complex_struct* ptr = nullptr;
 
     itemsize[0] = sizeof(complex_struct);
 

--- a/examples/custom_struct/complex_struct.py
+++ b/examples/custom_struct/complex_struct.py
@@ -82,7 +82,8 @@ def main():
     sizes = cupy.ndarray(shape=(5,), dtype=numpy.uint64)
     offsets = cupy.ndarray(shape=(5,), dtype=numpy.uint64)
 
-    kernel = cupy.RawKernel(struct_layout_code, 'get_struct_layout')
+    kernel = cupy.RawKernel(
+        struct_layout_code, 'get_struct_layout', options=('--std=c++11',))
     kernel((1,), (1,), (itemsize, sizes, offsets))
 
     (itemsize, sizes, offsets) = map(cupy.asnumpy, (itemsize, sizes, offsets))

--- a/tests/cupy_tests/core_tests/test_function.py
+++ b/tests/cupy_tests/core_tests/test_function.py
@@ -133,7 +133,7 @@ extern "C" __global__ void get_struct_layout(
                                 unsigned long long *itemsize,
                                 unsigned long long *sizes,
                                 unsigned long long *offsets) {{
-    const custom_user_struct* ptr = NULL;
+    const custom_user_struct* ptr = nullptr;
 
     itemsize[0] = sizeof(custom_user_struct);
 

--- a/tests/cupy_tests/core_tests/test_function.py
+++ b/tests/cupy_tests/core_tests/test_function.py
@@ -14,7 +14,7 @@ def _compile_func(kernel_name, code):
     # workaround for hipRTC
     extra_source = core._get_header_source() if runtime.is_hip else None
     mod = compiler._compile_module_with_cache(
-        code, options=('-std=c++11',), extra_source=extra_source)
+        code, options=('--std=c++11',), extra_source=extra_source)
     return mod.get_function(kernel_name)
 
 

--- a/tests/cupy_tests/core_tests/test_function.py
+++ b/tests/cupy_tests/core_tests/test_function.py
@@ -13,7 +13,8 @@ from cupy import testing
 def _compile_func(kernel_name, code):
     # workaround for hipRTC
     extra_source = core._get_header_source() if runtime.is_hip else None
-    mod = compiler._compile_module_with_cache(code, extra_source=extra_source)
+    mod = compiler._compile_module_with_cache(
+        code, options=('-std=c++11',), extra_source=extra_source)
     return mod.get_function(kernel_name)
 
 

--- a/tests/cupy_tests/core_tests/test_raw.py
+++ b/tests/cupy_tests/core_tests/test_raw.py
@@ -808,8 +808,15 @@ class TestRaw(unittest.TestCase):
             self.skipTest('skip a potential hiprtc bug')
 
         # compile code
-        name_expressions = ['my_sqrt<int>', 'my_sqrt<float>',
-                            'my_sqrt<complex<double>>', 'my_func']
+        if cupy.cuda.runtime.is_hip:
+            # ROCm 5.0 returns HIP_HIPRTC_ERROR_NAME_EXPRESSION_NOT_VALID for
+            # my_sqrt<complex<double>>, so we use thrust::complex<double>
+            # instead.
+            name_expressions = ['my_sqrt<int>', 'my_sqrt<float>',
+                                'my_sqrt<thrust::complex<double>>', 'my_func']
+        else:
+            name_expressions = ['my_sqrt<int>', 'my_sqrt<float>',
+                                'my_sqrt<complex<double>>', 'my_func']
         mod = cupy.RawModule(code=test_cxx_template,
                              options=('--std=c++11',),
                              name_expressions=name_expressions,

--- a/tests/cupy_tests/cuda_tests/test_memory.py
+++ b/tests/cupy_tests/cuda_tests/test_memory.py
@@ -79,7 +79,15 @@ class TestUnownedMemory(unittest.TestCase):
         if self.specify_device_id:
             kwargs = {'device_id': device_id}
 
-        unowned_mem = memory.UnownedMemory(*args, **kwargs)
+        if cupy.cuda.runtime.is_hip and self.allocator is memory._malloc:
+            # In ROCm, it seems that `hipPointerGetAttributes()`, which is
+            # called in `UnownedMemory()`, requires an unmanaged device pointer
+            # that the current device must be the one on which the memory
+            # referred to by the pointer physically resides.
+            with device.Device(device_id):
+                unowned_mem = memory.UnownedMemory(*args, **kwargs)
+        else:
+            unowned_mem = memory.UnownedMemory(*args, **kwargs)
         assert unowned_mem.size == size
         assert unowned_mem.ptr == src_ptr
         assert unowned_mem.device_id == device_id

--- a/tests/cupy_tests/functional_tests/test_vectorize.py
+++ b/tests/cupy_tests/functional_tests/test_vectorize.py
@@ -79,7 +79,8 @@ class TestVectorizeOps(unittest.TestCase):
         return self.run_div(my_floor_div, xp, [dtype1, dtype2])
 
     @testing.for_all_dtypes_combination(names=('dtype1', 'dtype2'))
-    @testing.numpy_cupy_allclose(accept_error=TypeError)
+    @testing.numpy_cupy_allclose(
+        rtol=1e-6, atol=1e-6, accept_error=TypeError)
     def test_vectorize_mod(self, xp, dtype1, dtype2):
         def my_mod(x, y):
             return x % y

--- a/tests/cupy_tests/linalg_tests/test_product.py
+++ b/tests/cupy_tests/linalg_tests/test_product.py
@@ -476,7 +476,7 @@ class TestMatrixPower(unittest.TestCase):
 class TestMatrixPowerBatched:
 
     @testing.for_float_dtypes(no_float16=True)
-    @testing.numpy_cupy_allclose(rtol=1e-5)
+    @testing.numpy_cupy_allclose(rtol=5e-5)
     def test_matrix_power_batched(self, xp, dtype, shape, n):
         a = testing.shaped_arange(shape, xp, dtype)
         a += xp.identity(shape[-1], dtype)

--- a/tests/cupyx_tests/fallback_mode_tests/test_fallback.py
+++ b/tests/cupyx_tests/fallback_mode_tests/test_fallback.py
@@ -455,7 +455,7 @@ class TestArrayUnaryMethodsArray(unittest.TestCase):
 @testing.gpu
 class TestArrayArithmeticMethods(unittest.TestCase):
 
-    @numpy_fallback_array_equal()
+    @numpy_fallback_array_allclose(rtol=1e-6)
     def test_arithmetic_methods(self, xp):
         a = testing.shaped_random(self.shape, xp=xp, dtype=self.dtype)
         b = testing.shaped_random(self.shape, xp=xp, dtype=self.dtype, seed=5)

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
@@ -188,7 +188,7 @@ class TestAffineTransform:
         return self._affine_transform(xp, scp, a, matrix)
 
     @testing.for_complex_dtypes()
-    @testing.numpy_cupy_allclose(atol=1e-5, scipy_name='scp')
+    @testing.numpy_cupy_allclose(rtol=1e-6, atol=1e-5, scipy_name='scp')
     @testing.with_requires('scipy>=1.6.0')
     def test_affine_transform_complex_float(self, xp, scp, dtype):
         if self.output == numpy.float64:

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
@@ -607,7 +607,7 @@ class TestCscMatrixScipyComparison:
             HIP_version = driver.get_build_version()
             if HIP_version < 400:
                 pytest.skip('no working implementation')
-            elif HIP_version < 40400000:
+            elif HIP_version < 5_00_00000:
                 # I got HIPSPARSE_STATUS_INTERNAL_ERROR...
                 pytest.xfail('spmv is buggy (trans=True)')
 
@@ -620,7 +620,7 @@ class TestCscMatrixScipyComparison:
             HIP_version = driver.get_build_version()
             if HIP_version < 400:
                 pytest.skip('no working implementation')
-            elif HIP_version < 40400000:
+            elif HIP_version < 5_00_00000:
                 # I got HIPSPARSE_STATUS_INTERNAL_ERROR...
                 pytest.xfail('spmv is buggy (trans=True)')
 
@@ -809,7 +809,7 @@ class TestCscMatrixScipyComparison:
             HIP_version = driver.get_build_version()
             if HIP_version < 400:
                 pytest.skip('no working implementation')
-            elif HIP_version < 40400000:
+            elif HIP_version < 5_00_00000:
                 # I got HIPSPARSE_STATUS_INTERNAL_ERROR...
                 pytest.xfail('spmv is buggy (trans=True)')
 
@@ -1134,7 +1134,7 @@ class TestCscMatrixSum:
             HIP_version = driver.get_build_version()
             if HIP_version < 400:
                 pytest.skip('no working implementation')
-            elif HIP_version < 40400000:
+            elif HIP_version < 5_00_00000:
                 # I got HIPSPARSE_STATUS_INTERNAL_ERROR...
                 pytest.xfail('spmv is buggy (trans=True)')
 
@@ -1331,7 +1331,7 @@ class TestCscMatrixData:
             HIP_version = driver.get_build_version()
             if HIP_version < 400:
                 pytest.skip('no working implementation')
-            elif HIP_version < 40400000:
+            elif HIP_version < 5_00_00000:
                 # I got HIPSPARSE_STATUS_INTERNAL_ERROR...
                 pytest.xfail('spmv is buggy (trans=True)')
 
@@ -1349,7 +1349,7 @@ class TestCscMatrixData:
             HIP_version = driver.get_build_version()
             if HIP_version < 400:
                 pytest.skip('no working implementation')
-            elif HIP_version < 40400000:
+            elif HIP_version < 5_00_00000:
                 # I got HIPSPARSE_STATUS_INTERNAL_ERROR...
                 pytest.xfail('spmv is buggy (trans=True)')
 
@@ -1362,7 +1362,7 @@ class TestCscMatrixData:
             HIP_version = driver.get_build_version()
             if HIP_version < 400:
                 pytest.skip('no working implementation')
-            elif HIP_version < 40400000:
+            elif HIP_version < 5_00_00000:
                 # I got HIPSPARSE_STATUS_INTERNAL_ERROR...
                 pytest.xfail('spmv is buggy (trans=True)')
 

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -1307,7 +1307,7 @@ class TestCsrMatrixSum:
             HIP_version = driver.get_build_version()
             if HIP_version < 400:
                 pytest.skip('no working implementation')
-            elif HIP_version < 40400000:
+            elif HIP_version < 5_00_00000:
                 # I got HIPSPARSE_STATUS_INTERNAL_ERROR...
                 pytest.xfail('spmv is buggy (trans=True)')
 
@@ -1529,7 +1529,7 @@ class TestCsrMatrixData:
             HIP_version = driver.get_build_version()
             if HIP_version < 400:
                 pytest.skip('no working implementation')
-            elif HIP_version < 40400000:
+            elif HIP_version < 5_00_00000:
                 # I got HIPSPARSE_STATUS_INTERNAL_ERROR...
                 pytest.xfail('spmv is buggy (trans=True)')
 
@@ -1552,7 +1552,7 @@ class TestCsrMatrixData:
             HIP_version = driver.get_build_version()
             if HIP_version < 400:
                 pytest.skip('no working implementation')
-            elif HIP_version < 40400000:
+            elif HIP_version < 5_00_00000:
                 # I got HIPSPARSE_STATUS_INTERNAL_ERROR...
                 pytest.xfail('spmv is buggy (trans=True)')
 

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_dia.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_dia.py
@@ -325,7 +325,7 @@ class TestDiaMatrixSum(unittest.TestCase):
     def setUp(self):
         if runtime.is_hip and self.axis in (0, -2):
             HIP_version = driver.get_build_version()
-            if HIP_version < 40400000:
+            if HIP_version < 5_00_00000:
                 # internally a temporary CSC matrix is generated and thus
                 # casues problems (see test_csc.py)
                 pytest.xfail('spmv is buggy (trans=True)')

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
@@ -1156,8 +1156,9 @@ class TestLOBPCG:
                                                cupy: %s''' % (stdout_numpy,
                                                               stdout_cupy)
 
-    @testing.numpy_cupy_allclose(rtol=1e-5, atol=1e-3, sp_name='sp',
-                                 contiguous_check=False)
+    @testing.numpy_cupy_allclose(
+        rtol=1e-5, atol=5e-3 if runtime.is_hip else 1e-3, sp_name='sp',
+        contiguous_check=False)
     def test_random_initial_float32(self, xp, sp):
         """Check lobpcg in float32 for specific initial.
         """


### PR DESCRIPTION
Rel #6459. Merge #6517 first.

A number of fixes for making CuPy work healthy with ROCm 5.0.
