### PR TITLE
CI: Trigger `push` event of FlexCI via GitHub Actions

### DIFF
--- a/.github/workflows/flexci.yml
+++ b/.github/workflows/flexci.yml
@@ -2,7 +2,7 @@ name: "FlexCI"
 
 on:
   push:
-    branches: ["master", "v*"]
+    branches: ["master", "v[0-9]+"]
   issue_comment:
     types: [created]
 

--- a/.github/workflows/flexci.yml
+++ b/.github/workflows/flexci.yml
@@ -1,6 +1,8 @@
 name: "FlexCI"
 
 on:
+  push:
+    branches: ["master", "v*"]
   issue_comment:
     types: [created]
 
@@ -8,8 +10,12 @@ jobs:
   dispatch:
     if: |
         github.repository_owner == 'cupy' &&
-        github.event.issue.pull_request &&
-        contains(github.event.comment.body, '/test ')
+        (
+            (github.event_name == 'issue_comment' &&
+             github.event.issue.pull_request &&
+             contains(github.event.comment.body, '/test ') ||
+            (github.event_name == 'push')
+        )
     runs-on: ubuntu-20.04
 
     steps:
@@ -19,14 +25,11 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.9'
+        python-version: '3.10'
 
     - name: Setup Environment
-      env:
-        GITHUB_EVENT_PAYLOAD: ${{ toJSON(github.event) }}
       run: |
         pip install pygithub
-        echo "${GITHUB_EVENT_PAYLOAD}" > payload.json
 
     - name: Dispatch
       env:
@@ -34,5 +37,6 @@ jobs:
         FLEXCI_WEBHOOK_SECRET: ${{ secrets.FLEXCI_WEBHOOK_SECRET }}
       run: |
         ./.github/workflows/flexci_dispatcher.py \
-            --webhook payload.json \
+            --event "${GITHUB_EVENT_NAME}" \
+            --webhook "${GITHUB_EVENT_PATH}" \
             --projects ./.pfnci/config.tags.json

--- a/.github/workflows/flexci.yml
+++ b/.github/workflows/flexci.yml
@@ -13,7 +13,7 @@ jobs:
         (
             (github.event_name == 'issue_comment' &&
              github.event.issue.pull_request &&
-             contains(github.event.comment.body, '/test ') ||
+             contains(github.event.comment.body, '/test ')) ||
             (github.event_name == 'push')
         )
     runs-on: ubuntu-20.04

--- a/.github/workflows/flexci_dispatcher.py
+++ b/.github/workflows/flexci_dispatcher.py
@@ -28,21 +28,21 @@ def _forward_to_flexci(
     """
     Submits the GitHub webhook payload to FlexCI.
     """
-    payload_bytes = json.dumps(payload).encode('utf-8')
+    payload_enc = json.dumps(payload).encode('utf-8')
     project_list = ','.join(projects)
     url = f'{base_url}/x/github_webhook?project={project_list}&rule=^{event_name}:&quiet=true'  # NOQA
     _log(f'Request URI: {url}')
     req = urllib.request.Request(
         url,
-        data=payload_bytes,
+        data=payload_enc,
         headers={
             'User-Agent': 'FlexCI-Dispatcher',
             'Content-Type': 'application/json',
             'X-GitHub-Event': 'issue_comment',
             'X-Hub-Signature': 'sha1={}'.format(
-                hmac.new(secret.encode(), payload_bytes, 'sha1').hexdigest()),
+                hmac.new(secret.encode(), payload_enc, 'sha1').hexdigest()),
             'X-Hub-Signature-256': 'sha256={}'.format(
-                hmac.new(secret.encode(), payload_bytes, 'sha256').hexdigest()),
+                hmac.new(secret.encode(), payload_enc, 'sha256').hexdigest()),
         },
     )
     with urllib.request.urlopen(req) as res:

--- a/.github/workflows/flexci_dispatcher.py
+++ b/.github/workflows/flexci_dispatcher.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# FlexCI Dispatcher: Trigger FlexCI based on comments.
+# FlexCI Dispatcher: Trigger FlexCI based on webhooks.
 #
 
 import argparse
@@ -10,7 +10,7 @@ import json
 import os
 import re
 import sys
-from typing import Any, Optional, Set
+from typing import Any, Dict, Optional, Set
 import urllib.request
 
 import github
@@ -23,25 +23,26 @@ def _log(msg: str) -> None:
 
 
 def _forward_to_flexci(
-        payload: bytes, secret: str, projects: Set[str],
-        base_url: str) -> bool:
+        event_name: str, payload: Dict[str, Any], secret: str,
+        projects: Set[str], base_url: str) -> bool:
     """
     Submits the GitHub webhook payload to FlexCI.
     """
+    payload_bytes = json.dumps(payload).encode('utf-8')
     project_list = ','.join(projects)
-    url = f'{base_url}/x/github_webhook?project={project_list}&rule=^issue_comment:test$&quiet=true'  # NOQA
+    url = f'{base_url}/x/github_webhook?project={project_list}&rule=^{event_name}:&quiet=true'  # NOQA
     _log(f'Request URI: {url}')
     req = urllib.request.Request(
         url,
-        data=payload,
+        data=payload_bytes,
         headers={
             'User-Agent': 'FlexCI-Dispatcher',
             'Content-Type': 'application/json',
             'X-GitHub-Event': 'issue_comment',
             'X-Hub-Signature': 'sha1={}'.format(
-                hmac.new(secret.encode(), payload, 'sha1').hexdigest()),
+                hmac.new(secret.encode(), payload_bytes, 'sha1').hexdigest()),
             'X-Hub-Signature-256': 'sha256={}'.format(
-                hmac.new(secret.encode(), payload, 'sha256').hexdigest()),
+                hmac.new(secret.encode(), payload_bytes, 'sha256').hexdigest()),
         },
     )
     with urllib.request.urlopen(req) as res:
@@ -57,11 +58,19 @@ def _forward_to_flexci(
 
 
 def _complement_commit_status(
-        repo: str, pull_req: int, token: str,
+        event_name: str, payload: Dict[str, Any], token: str,
         projects: Set[str], context_prefix: str) -> None:
-    gh_repo = github.Github(token).get_repo(repo)
-    gh_commit = gh_repo.get_commit(gh_repo.get_pull(pull_req).head.sha)
-    _log(f'Checking statuses: {repo}, PR #{pull_req}, commit {gh_commit.sha}')
+    gh_repo = github.Github(token).get_repo(payload['repository']['full_name'])
+    match event_name:
+        case 'push':
+            sha = payload['after']
+        case 'issue_comment':
+            sha = gh_repo.get_pull(payload['issue']['number']).head.sha
+        case _:
+            assert False
+
+    _log(f'Checking statuses for commit {sha}')
+    gh_commit = gh_repo.get_commit(sha)
     contexts = [s.context for s in gh_commit.get_statuses()]
     for prj in projects:
         context = f'{context_prefix}/{prj}'
@@ -87,8 +96,11 @@ def extract_requested_tags(comment: str) -> Optional[Set[str]]:
 def parse_args(argv: Any) -> Any:
     parser = argparse.ArgumentParser()
     parser.add_argument(
+        '--event', type=str, required=True, choices=['issue_comment', 'push'],
+        help='The name of the event')
+    parser.add_argument(
         '--webhook', type=str, required=True,
-        help='Path to the JSON file containing issue_comment webhook payload')
+        help='Path to the JSON file containing the webhook payload')
     parser.add_argument(
         '--projects', type=str, required=True,
         help='Path to the JSON file containing map from FlexCI project to '
@@ -107,35 +119,45 @@ def main(argv: Any) -> int:
     webhook_secret = str(os.environ['FLEXCI_WEBHOOK_SECRET'])
     github_token = str(os.environ['GITHUB_TOKEN'])
 
+    event_name = options.event
     with open(options.webhook, 'rb') as f:
-        payload = f.read()
-    with open(options.projects) as f:  # type: ignore
+        payload = json.load(f)
+    with open(options.projects) as f:
         project_tags = json.load(f)
 
-    payload_obj = json.loads(payload)
-    if payload_obj['action'] != 'created':
-        _log('Invalid action')
-        return 1
+    match event_name:
+        case 'push':
+            requested_tags = {'@push'}
+            _log('Requesting tests with @push tag')
+        case 'issue_comment':
+            action = payload['action']
+            if action != 'created':
+                _log(f'Invalid issue_comment action: {action}')
+                return 1
 
-    requested_tags = extract_requested_tags(payload_obj['comment']['body'])
-    if requested_tags is None:
-        _log('No test requested in comment.')
-        return 0
-    _log(f'Test tags requested: {requested_tags}')
+            requested_tags = extract_requested_tags(payload['comment']['body'])
+            if requested_tags is None:
+                _log('No test requested in comment.')
+                return 0
 
-    association = payload_obj['comment']['author_association']
-    if association not in ('OWNER', 'MEMBER'):
-        _log(f'Tests cannot be triggered by {association}')
-        return 1
+            association = payload['comment']['author_association']
+            if association not in ('OWNER', 'MEMBER'):
+                _log(f'Tests cannot be triggered by {association}')
+                return 1
+
+            _log(f'Requesting tests with tags: {requested_tags}')
+        case _:
+            _log(f'Invalid event name: {event_name}')
+            return 1
 
     projects_dispatch: Set[str] = set()
-    projects_skipped: Set[str] = set()
+    projects_skip: Set[str] = set()
     for project, tags in project_tags.items():
         _log(f'Project: {project} (tags: {tags})')
         if len(set(tags) & requested_tags) != 0:
             projects_dispatch.add(project)
         else:
-            projects_skipped.add(project)
+            projects_skip.add(project)
 
     if len(projects_dispatch) == 0:
         if requested_tags == {'skip'}:
@@ -146,17 +168,15 @@ def main(argv: Any) -> int:
     else:
         _log(f'Dispatching projects: {projects_dispatch}')
         success = _forward_to_flexci(
-            payload, webhook_secret, projects_dispatch, options.flexci_uri)
+            event_name, payload, webhook_secret, projects_dispatch,
+            options.flexci_uri)
         if not success:
             _log('Failed to dispatch')
             return 1
 
-    if len(projects_skipped) != 0:
+    if len(projects_skip) != 0:
         _complement_commit_status(
-            payload_obj['repository']['full_name'],
-            payload_obj['issue']['number'],
-            github_token,
-            projects_skipped,
+            event_name, payload, github_token, projects_skip,
             options.flexci_context)
 
     return 0

--- a/.pfnci/config.tags.json
+++ b/.pfnci/config.tags.json
@@ -1,53 +1,67 @@
 {
     "cupy.linux.cuda102": [
+        "@push",
         "full",
         "mini"
     ],
     "cupy.linux.cuda102.multi": [
+        "@push",
         "full",
         "mini",
         "multi"
     ],
     "cupy.linux.cuda110": [
+        "@push",
         "full"
     ],
     "cupy.linux.cuda110.multi": [
+        "@push",
         "full",
         "multi"
     ],
     "cupy.linux.cuda111": [
+        "@push",
         "full"
     ],
     "cupy.linux.cuda111.multi": [
+        "@push",
         "full",
         "multi"
     ],
     "cupy.linux.cuda112": [
+        "@push",
         "full"
     ],
     "cupy.linux.cuda112.multi": [
+        "@push",
         "full",
         "multi"
     ],
     "cupy.linux.cuda113": [
+        "@push",
         "full"
     ],
     "cupy.linux.cuda113.multi": [
+        "@push",
         "full",
         "multi"
     ],
     "cupy.linux.cuda114": [
+        "@push",
         "full"
     ],
     "cupy.linux.cuda114.multi": [
+        "@push",
         "full",
         "multi"
     ],
     "cupy.linux.cuda115": [
+        "@push",
         "full",
         "mini"
     ],
     "cupy.linux.cuda115.multi": [
+        "@push",
         "full",
         "mini",
         "multi"
@@ -58,6 +72,7 @@
         "slow"
     ],
     "cupy.linux.cuda-example": [
+        "@push",
         "full",
         "mini",
         "example"
@@ -66,10 +81,12 @@
         "head"
     ],
     "cupy.linux.cuda11x-cuda-python": [
+        "@push",
         "full",
         "cuda-python"
     ],
     "cupy.win.cuda102": [
+        "@push",
         "full",
         "mini",
         "windows"
@@ -96,6 +113,7 @@
         "windows"
     ],
     "cupy.linux.cuda-rapids": [
+        "@push",
         "full",
         "rapids"
     ],

--- a/.pfnci/matrix.yaml
+++ b/.pfnci/matrix.yaml
@@ -5,7 +5,7 @@
 # CUDA 10.2 | Linux
 # The lowest CUDA version matrix is intended to cover the lowest supported combination.
 - project: "cupy.linux.cuda102"
-  tags: ["full", "mini"]
+  tags: ["@push", "full", "mini"]
   target: "cuda102"
   system: "linux"
   os: "ubuntu:18.04"
@@ -27,13 +27,13 @@
 # CUDA 10.2 (Multi-GPU) | Linux
 - project: "cupy.linux.cuda102.multi"
   _inherits: "cupy.linux.cuda102"
-  tags: ["full", "mini", "multi"]
+  tags: ["@push", "full", "mini", "multi"]
   target: "cuda102.multi"
   test: "unit-multi"
 
 # CUDA 11.0 | Linux
 - project: "cupy.linux.cuda110"
-  tags: ["full"]
+  tags: ["@push", "full"]
   target: "cuda110"
   system: "linux"
   os: "ubuntu:20.04"
@@ -55,13 +55,13 @@
 # CUDA 11.0 (Multi-GPU) | Linux
 - project: "cupy.linux.cuda110.multi"
   _inherits: "cupy.linux.cuda110"
-  tags: ["full", "multi"]
+  tags: ["@push", "full", "multi"]
   target: "cuda110.multi"
   test: "unit-multi"
 
 # CUDA 11.1 | Linux
 - project: "cupy.linux.cuda111"
-  tags: ["full"]
+  tags: ["@push", "full"]
   target: "cuda111"
   system: "linux"
   os: "centos:7"
@@ -82,14 +82,14 @@
 
 # CUDA 11.1 (Multi-GPU) | Linux
 - project: "cupy.linux.cuda111.multi"
-  tags: ["full", "multi"]
+  tags: ["@push", "full", "multi"]
   _inherits: "cupy.linux.cuda111"
   target: "cuda111.multi"
   test: "unit-multi"
 
 # CUDA 11.2 | Linux
 - project: "cupy.linux.cuda112"
-  tags: ["full"]
+  tags: ["@push", "full"]
   target: "cuda112"
   system: "linux"
   os: "centos:7"
@@ -111,13 +111,13 @@
 # CUDA 11.2 (Multi-GPU) | Linux
 - project: "cupy.linux.cuda112.multi"
   _inherits: "cupy.linux.cuda112"
-  tags: ["full", "multi"]
+  tags: ["@push", "full", "multi"]
   target: "cuda112.multi"
   test: "unit-multi"
 
 # CUDA 11.3 | Linux
 - project: "cupy.linux.cuda113"
-  tags: ["full"]
+  tags: ["@push", "full"]
   target: "cuda113"
   system: "linux"
   os: "ubuntu:18.04"
@@ -139,13 +139,13 @@
 # CUDA 11.3 (Multi-GPU) | Linux
 - project: "cupy.linux.cuda113.multi"
   _inherits: "cupy.linux.cuda113"
-  tags: ["full", "multi"]
+  tags: ["@push", "full", "multi"]
   target: "cuda113.multi"
   test: "unit-multi"
 
 # CUDA 11.4 | Linux
 - project: "cupy.linux.cuda114"
-  tags: ["full"]
+  tags: ["@push", "full"]
   target: "cuda114"
   system: "linux"
   os: "ubuntu:20.04"
@@ -167,13 +167,13 @@
 # CUDA 11.4 (Multi-GPU) | Linux
 - project: "cupy.linux.cuda114.multi"
   _inherits: "cupy.linux.cuda114"
-  tags: ["full", "multi"]
+  tags: ["@push", "full", "multi"]
   target: "cuda114.multi"
   test: "unit-multi"
 
 # CUDA 11.5 | Linux
 - project: "cupy.linux.cuda115"
-  tags: ["full", "mini"]
+  tags: ["@push", "full", "mini"]
   target: "cuda115"
   system: "linux"
   os: "ubuntu:20.04"
@@ -195,7 +195,7 @@
 # CUDA 11.5 (Multi-GPU) | Linux
 - project: "cupy.linux.cuda115.multi"
   _inherits: "cupy.linux.cuda115"
-  tags: ["full", "mini", "multi"]
+  tags: ["@push", "full", "mini", "multi"]
   target: "cuda115.multi"
   test: "unit-multi"
 
@@ -344,7 +344,7 @@
 # - Accelerators are disabled as doctests expect it (#5891)
 - project: "cupy.linux.cuda-example"
   target: "cuda-example"
-  tags: ["full", "mini", "example"]
+  tags: ["@push", "full", "mini", "example"]
   system: "linux"
   os: "ubuntu:20.04"
   cuda: "11.4"
@@ -395,7 +395,7 @@
 # CUDA 11.x / CUDA Python | Linux
 - project: "cupy.linux.cuda11x-cuda-python"
   target: "cuda11x-cuda-python"
-  tags: ["full", "cuda-python"]
+  tags: ["@push", "full", "cuda-python"]
   system: "linux"
   os: "ubuntu:20.04"
   cuda: "11.5"
@@ -421,7 +421,7 @@
 - project: "cupy.win.cuda102"
   _extern: true
   target: "cuda102"
-  tags: ["full", "mini", "windows"]
+  tags: ["@push", "full", "mini", "windows"]
   system: "windows"
 
 - project: "cupy.win.cuda110"
@@ -469,7 +469,7 @@
 - project: "cupy.linux.cuda-rapids"
   _extern: true
   target: "cuda-rapids"
-  tags: ["full", "rapids"]
+  tags: ["@push", "full", "rapids"]
   system: "linux"
 
 - project: "cupy.linux.array-api"


### PR DESCRIPTION
We have been triggering FlexCI via `push` webhook to run tests against merged commit. However, it is becoming costly to maintain a webhook URL because we have to embed a comma-separated list of FlexCI projects to trigger in the URL, and the list is so long.
This PR lets GitHub Actions trigger FlexCI on push event in addition to `issue_comment` event (`/test`).

(note: after merging this PR we should remove webhook configuration)