### PR TITLE
Skip `async_malloc` tests on unsupported device

### DIFF
--- a/tests/cupy_tests/cuda_tests/test_memory.py
+++ b/tests/cupy_tests/cuda_tests/test_memory.py
@@ -1004,6 +1004,9 @@ class TestExceptionPicklable(unittest.TestCase):
 class TestMallocAsync(unittest.TestCase):
 
     def setUp(self):
+        if cupy.cuda.runtime.deviceGetAttribute(
+            cupy.cuda.runtime.cudaDevAttrMemoryPoolsSupported, 0) == 0:
+            pytest.skip('malloc_async is not supported on device 0')
         self.old_pool = cupy.get_default_memory_pool()
         memory.set_allocator(memory.malloc_async)
 
@@ -1074,6 +1077,9 @@ class TestMallocAsync(unittest.TestCase):
 class TestMemoryAsyncPool(unittest.TestCase):
 
     def setUp(self):
+        if cupy.cuda.runtime.deviceGetAttribute(
+            cupy.cuda.runtime.cudaDevAttrMemoryPoolsSupported, 0) == 0:
+            pytest.skip('malloc_async is not supported on device 0')
         self.pool = memory.MemoryAsyncPool()
         self.unit = memory._allocation_unit_size
         self.stream = stream_module.Stream()

--- a/tests/cupy_tests/cuda_tests/test_memory.py
+++ b/tests/cupy_tests/cuda_tests/test_memory.py
@@ -10,6 +10,7 @@ import pytest
 import cupy.cuda
 from cupy.cuda import device
 from cupy.cuda import memory
+from cupy.cuda import runtime
 from cupy.cuda import stream as stream_module
 from cupy import testing
 
@@ -59,13 +60,18 @@ class TestUnownedMemory(unittest.TestCase):
             if self.allocator is memory.malloc_async:
                 raise unittest.SkipTest('HIP does not support async mempool')
         else:
-            if cupy.cuda.driver._is_cuda_python():
-                version = cupy.cuda.runtime.runtimeGetVersion()
-            else:
-                version = cupy.cuda.driver.get_build_version()
-            if version < 11020:
-                raise unittest.SkipTest('malloc_async is supported since '
-                                        'CUDA 11.2')
+            if self.allocator is memory.malloc_async:
+                if cupy.cuda.driver._is_cuda_python():
+                    version = cupy.cuda.runtime.runtimeGetVersion()
+                else:
+                    version = cupy.cuda.driver.get_build_version()
+                if version < 11020:
+                    raise unittest.SkipTest('malloc_async is supported since '
+                                            'CUDA 11.2')
+                elif runtime.deviceGetAttribute(
+                        runtime.cudaDevAttrMemoryPoolsSupported, 0) == 0:
+                    raise unittest.SkipTest(
+                        'malloc_async is not supported on device 0')
 
         size = 24
         shape = (2, 3)

--- a/tests/cupy_tests/cuda_tests/test_memory.py
+++ b/tests/cupy_tests/cuda_tests/test_memory.py
@@ -1005,7 +1005,7 @@ class TestMallocAsync(unittest.TestCase):
 
     def setUp(self):
         if cupy.cuda.runtime.deviceGetAttribute(
-            cupy.cuda.runtime.cudaDevAttrMemoryPoolsSupported, 0) == 0:
+                cupy.cuda.runtime.cudaDevAttrMemoryPoolsSupported, 0) == 0:
             pytest.skip('malloc_async is not supported on device 0')
         self.old_pool = cupy.get_default_memory_pool()
         memory.set_allocator(memory.malloc_async)
@@ -1078,7 +1078,7 @@ class TestMemoryAsyncPool(unittest.TestCase):
 
     def setUp(self):
         if cupy.cuda.runtime.deviceGetAttribute(
-            cupy.cuda.runtime.cudaDevAttrMemoryPoolsSupported, 0) == 0:
+                cupy.cuda.runtime.cudaDevAttrMemoryPoolsSupported, 0) == 0:
             pytest.skip('malloc_async is not supported on device 0')
         self.pool = memory.MemoryAsyncPool()
         self.unit = memory._allocation_unit_size


### PR DESCRIPTION
It seems Windows + TCC does not support async malloc.

https://github.com/cupy/cupy/pull/5889#issuecomment-1063588178

Testing with CUDA 11.6 on Windows:
https://ci.preferred.jp/cupy.win.cuda116/96658/