### PR TITLE
Fix array creation shape

### DIFF
--- a/tests/cupy_tests/core_tests/test_internal.py
+++ b/tests/cupy_tests/core_tests/test_internal.py
@@ -1,6 +1,7 @@
 import math
 import unittest
 
+import numpy
 import pytest
 
 from cupy._core import internal
@@ -48,6 +49,12 @@ class TestGetSize(unittest.TestCase):
 
     def test_int(self):
         assert internal.get_size(1) == (1,)
+
+    def test_numpy_int(self):
+        assert internal.get_size(numpy.int32(1)) == (1,)
+
+    def test_numpy_zero_dim_ndarray(self):
+        assert internal.get_size(numpy.array(1)) == (1,)
 
     def test_float(self):
         with pytest.raises(ValueError):

--- a/tests/cupy_tests/core_tests/test_internal.py
+++ b/tests/cupy_tests/core_tests/test_internal.py
@@ -32,7 +32,7 @@ class TestProdSequence(unittest.TestCase):
         assert internal.prod_sequence((2, 3)) == 6
 
 
-class TestGetSize(unittest.TestCase):
+class TestGetSize:
 
     def test_none(self):
         with testing.assert_warns(DeprecationWarning):
@@ -56,9 +56,21 @@ class TestGetSize(unittest.TestCase):
     def test_numpy_zero_dim_ndarray(self):
         assert internal.get_size(numpy.array(1)) == (1,)
 
+    def test_tuple_of_numpy_scalars(self):
+        assert internal.get_size((numpy.int32(1), numpy.array(1))) == (1, 1)
+
+    @pytest.mark.parametrize(
+        'value', [True, numpy.bool_(True), numpy.array(True, dtype='?')])
+    def test_bool(self, value):
+        with pytest.raises(TypeError):
+            internal.get_size(value)
+        with pytest.raises(TypeError):
+            internal.get_size((value, value))
+
     def test_float(self):
-        with pytest.raises(ValueError):
-            internal.get_size(1.0)
+        # `internal.get_size` is not responsible to interpret values as
+        # integers.
+        assert internal.get_size(1.0) == (1.0,)
 
 
 class TestVectorEqual(unittest.TestCase):

--- a/tests/cupy_tests/core_tests/test_ndarray.py
+++ b/tests/cupy_tests/core_tests/test_ndarray.py
@@ -32,6 +32,13 @@ class TestNdarrayInit(unittest.TestCase):
         a = cupy.ndarray(3)
         assert a.shape == (3,)
 
+    def test_shape_not_integer(self):
+        for xp in (numpy, cupy):
+            with pytest.raises(TypeError):
+                xp.ndarray(1.0)
+            with pytest.raises(TypeError):
+                xp.ndarray((1.0,))
+
     def test_shape_int_with_strides(self):
         dummy = cupy.ndarray(3)
         a = cupy.ndarray(3, strides=(0,), memptr=dummy.data)


### PR DESCRIPTION
Fix #5503.

This PR fixes array creation to be able to take values as NumPy ints and NumPy zero-dim arrays for `shape`.