### PR TITLE
[v10] Fix cuSPARSELt 0.1.0 support in v10

### DIFF
--- a/cupy_backends/cuda/cupy_cusparselt.h
+++ b/cupy_backends/cuda/cupy_cusparselt.h
@@ -1,0 +1,31 @@
+#ifndef INCLUDE_GUARD_CUDA_CUPY_CUSPARSELT_H
+#define INCLUDE_GUARD_CUDA_CUPY_CUSPARSELT_H
+
+#include <library_types.h>
+#include <cusparseLt.h>
+
+#if CUSPARSELT_VERSION < 200
+// Added in cuSPARSELt 0.2.0
+
+typedef enum {} cusparseLtMatDescAttribute_t;
+typedef enum {} cusparseLtMatmulDescAttribute_t;
+
+cusparseStatus_t cusparseLtMatDescSetAttribute(...) {
+    return CUSPARSE_STATUS_NOT_SUPPORTED;
+}
+
+cusparseStatus_t cusparseLtMatDescGetAttribute(...) {
+    return CUSPARSE_STATUS_NOT_SUPPORTED;
+}
+
+cusparseStatus_t cusparseLtMatmulDescSetAttribute(...) {
+    return CUSPARSE_STATUS_NOT_SUPPORTED;
+}
+
+cusparseStatus_t cusparseLtMatmulDescGetAttribute(...) {
+    return CUSPARSE_STATUS_NOT_SUPPORTED;
+}
+
+#endif  // CUSPARSELT_VERSION < 200
+
+#endif  // INCLUDE_GUARD_CUDA_CUPY_CUSPARSELT_H

--- a/cupy_backends/cuda/libs/cusparselt.pyx
+++ b/cupy_backends/cuda/libs/cusparselt.pyx
@@ -292,6 +292,9 @@ cpdef matDescriptorDestroy(MatDescriptor matDescr):
 cpdef matDescSetAttribute(Handle handle, MatDescriptor matDescr,
                           matAttribute, size_t data, size_t dataSize):
     """Sets the attribute related to matrix descriptor."""
+    if CUSPARSELT_VERSION < 200:
+        raise RuntimeError(
+            'matDescSetAttribute is supported since cuSPARSELt 0.2.0')
     status = cusparseLtMatDescSetAttribute(
         <const cusparseLtHandle_t*> handle._ptr,
         <cusparseLtMatDescriptor_t*> matDescr._ptr,
@@ -302,6 +305,9 @@ cpdef matDescSetAttribute(Handle handle, MatDescriptor matDescr,
 cpdef matDescGetAttribute(Handle handle, MatDescriptor matDescr,
                           matAttribute, size_t data, size_t dataSize):
     """Gets the attribute related to matrix descriptor."""
+    if CUSPARSELT_VERSION < 200:
+        raise RuntimeError(
+            'matDescGetAttribute is supported since cuSPARSELt 0.2.0')
     status = cusparseLtMatDescGetAttribute(
         <const cusparseLtHandle_t*> handle._ptr,
         <const cusparseLtMatDescriptor_t*> matDescr._ptr,
@@ -333,6 +339,9 @@ cpdef matmulDescriptorInit(Handle handle,
 cpdef matmulDescSetAttribute(Handle handle, MatmulDescriptor matmulDescr,
                              matmulAttribute, size_t data, size_t dataSize):
     """Sets the attribute related to matmul descriptor."""
+    if CUSPARSELT_VERSION < 200:
+        raise RuntimeError(
+            'matmulDescSetAttribute is supported since cuSPARSELt 0.2.0')
     status = cusparseLtMatmulDescSetAttribute(
         <const cusparseLtHandle_t*> handle._ptr,
         <cusparseLtMatmulDescriptor_t*> matmulDescr._ptr,
@@ -343,6 +352,9 @@ cpdef matmulDescSetAttribute(Handle handle, MatmulDescriptor matmulDescr,
 cpdef matmulDescGetAttribute(Handle handle, MatmulDescriptor matmulDescr,
                              matmulAttribute, size_t data, size_t dataSize):
     """Gets the attribute related to matmul descriptor."""
+    if CUSPARSELT_VERSION < 200:
+        raise RuntimeError(
+            'matmulDescGetAttribute is supported since cuSPARSELt 0.2.0')
     status = cusparseLtMatmulDescGetAttribute(
         <const cusparseLtHandle_t*> handle._ptr,
         <const cusparseLtMatmulDescriptor_t*> matmulDescr._ptr,

--- a/cupy_backends/cupy_cusparselt.h
+++ b/cupy_backends/cupy_cusparselt.h
@@ -7,7 +7,7 @@
 
 #elif !defined(CUPY_NO_CUDA)
 
-#include <cusparseLt.h>
+#include "cuda/cupy_cusparselt.h"
 
 #else
 


### PR DESCRIPTION
Following up #6507.

This PR fixes cuSPARSELt 0.1.0 support in v10, which was corrupted in #6507.