### PR TITLE
[WIP] Fix matmul compatibility issues

### DIFF
--- a/cupy/_core/_routines_linalg.pyx
+++ b/cupy/_core/_routines_linalg.pyx
@@ -744,6 +744,10 @@ cpdef ndarray matmul(ndarray a, ndarray b, ndarray out=None):
         ret_dtype = numpy.promote_types(a.dtype, b.dtype)
         if out._c_contiguous and ret_dtype == out.dtype:
             return dot(a, b, out)
+        if not numpy.can_cast(out.dtype, ret_dtype, 'safe'):
+            ret_dtype = numpy.promote_types(ret_dtype, out.dtype)
+            a = a.astype(ret_dtype)
+            b = b.astype(ret_dtype)
         c = _ndarray_init(out._shape, dtype=ret_dtype)
         dot(a, b, c)
         elementwise_copy(c, out)


### PR DESCRIPTION
Close #6566.

This relatively simple patch can address this problem. However, I think this means that numpy.matmul takes that into account when `dtype` is specified to determine the computation type, but a quick look at the numpy source code did not show me where this is done. Does anyone know where this is done?