### PR TITLE
add `cupy.setxor1d` api

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -506,6 +506,7 @@ from cupy._logic.truth import in1d  # NOQA
 from cupy._logic.truth import intersect1d  # NOQA
 from cupy._logic.truth import isin  # NOQA
 from cupy._logic.truth import setdiff1d  # NOQA
+from cupy._logic.truth import setxor1d  # NOQA
 from cupy._logic.truth import union1d  # NOQA
 
 

--- a/cupy/_logic/truth.py
+++ b/cupy/_logic/truth.py
@@ -255,6 +255,44 @@ def setdiff1d(ar1, ar2, assume_unique=False):
     return ar1[in1d(ar1, ar2, assume_unique=True, invert=True)]
 
 
+def setxor1d(ar1, ar2, assume_unique=False):
+    """Find the set exclusive-or of two arrays.
+
+    Parameters
+    ----------
+    ar1, ar2 : cupy.ndarray
+        Input arrays. They are flattend if they are not already 1-D.
+    assume_unique : bool
+        By default, False, i.e. input arrays are not unique.
+        If True, input arrays are assumed to be unique. This can
+        speed up the calculation.
+
+    Returns
+    -------
+    setxor1d : cupy.ndarray
+        Return the sorted, unique values that are in only one
+        (not both) of the input arrays.
+
+    See Also
+    --------
+    numpy.setxor1d
+
+    """
+    if not assume_unique:
+        ar1 = cupy.unique(ar1)
+        ar2 = cupy.unique(ar2)
+
+    aux = cupy.concatenate((ar1, ar2), axis=None)
+    if aux.size == 0:
+        return aux
+
+    aux.sort()
+    flag = aux
+    flag = cupy.concatenate((cupy.asanyarray([True]), cupy.asanyarray(
+        aux[1:] != aux[:-1]), cupy.asanyarray([True])), axis=None)
+    return aux[flag[1:] & flag[:-1]]
+
+
 def union1d(arr1, arr2):
     """Find the union of two arrays.
 

--- a/cupy/_logic/truth.py
+++ b/cupy/_logic/truth.py
@@ -305,7 +305,8 @@ def setxor1d(ar1, ar2, assume_unique=False):
         'setxorkernel'
     )
 
-    return aux[setxorkernel(aux, aux.size, cupy.zeros(aux.size, dtype=cupy.bool8))]
+    return aux[setxorkernel(aux, aux.size,
+                            cupy.zeros(aux.size, dtype=cupy.bool8))]
 
 
 def union1d(arr1, arr2):

--- a/cupy/_logic/truth.py
+++ b/cupy/_logic/truth.py
@@ -4,7 +4,7 @@ from cupy._core import _fusion_thread_local
 from cupy import _util
 
 
-setxorkernel = cupy._core.ElementwiseKernel(
+_setxorkernel = cupy._core.ElementwiseKernel(
     'raw T X, int64 len',
     'bool z',
     'z = (i == 0 || X[i] != X[i-1]) && (i == len - 1 || X[i] != X[i+1])',

--- a/cupy/_logic/truth.py
+++ b/cupy/_logic/truth.py
@@ -4,6 +4,14 @@ from cupy._core import _fusion_thread_local
 from cupy import _util
 
 
+setxorkernel = cupy._core.ElementwiseKernel(
+    'raw T X, int64 len',
+    'bool z',
+    'z = (i == 0 || X[i] != X[i-1]) && (i == len - 1 || X[i] != X[i+1])',
+    'setxorkernel'
+)
+
+
 def all(a, axis=None, out=None, keepdims=False):
     """Tests whether all array elements along a given axis evaluate to True.
 
@@ -288,25 +296,8 @@ def setxor1d(ar1, ar2, assume_unique=False):
 
     aux.sort()
 
-    setxorkernel = cupy.ElementwiseKernel(
-        'raw T X, int32 len',
-        'bool z',
-        '''
-            if (i == 0) {
-                z = (X[0] != X[1]);
-            }
-            else if (i == len - 1) {
-                z = (X[i] != X[i-1]);
-            }
-            else {
-                z = X[i] != X[i-1] && X[i] != X[i+1];
-            }
-        ''',
-        'setxorkernel'
-    )
-
     return aux[setxorkernel(aux, aux.size,
-                            cupy.zeros(aux.size, dtype=cupy.bool8))]
+                            cupy.zeros(aux.size, dtype=cupy.bool_))]
 
 
 def union1d(arr1, arr2):

--- a/cupy/_logic/truth.py
+++ b/cupy/_logic/truth.py
@@ -296,8 +296,8 @@ def setxor1d(ar1, ar2, assume_unique=False):
 
     aux.sort()
 
-    return aux[setxorkernel(aux, aux.size,
-                            cupy.zeros(aux.size, dtype=cupy.bool_))]
+    return aux[_setxorkernel(aux, aux.size,
+                             cupy.zeros(aux.size, dtype=cupy.bool_))]
 
 
 def union1d(arr1, arr2):

--- a/docs/source/reference/set.rst
+++ b/docs/source/reference/set.rst
@@ -24,3 +24,4 @@ Boolean operations
    intersect1d
    isin
    setdiff1d
+   setxor1d

--- a/tests/cupy_tests/logic_tests/test_truth.py
+++ b/tests/cupy_tests/logic_tests/test_truth.py
@@ -183,6 +183,64 @@ class TestSetdiff1d:
         return xp.setdiff1d(x, y)
 
 
+class TestSetxor1d:
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_setxor1d_same_arrays(self, xp, dtype):
+        x = xp.array([1, 2, 3, 4, 5], dtype=dtype)
+        y = xp.array([1, 2, 3, 4, 5], dtype=dtype)
+        return xp.setxor1d(x, y, assume_unique=True)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_setxor1d_diff_size_arr_inputs(self, xp, dtype):
+        x = xp.array([3, 4, 9, 1, 5, 4], dtype=dtype)
+        y = xp.array([8, 7, 3, 9, 0], dtype=dtype)
+        return xp.setxor1d(x, y)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_setxor1d_diff_elements(self, xp, dtype):
+        x = xp.array([3, 4, 9, 1, 5, 4], dtype=dtype)
+        y = xp.array([8, 7, 3, 9, 0], dtype=dtype)
+        return xp.setxor1d(x, y, assume_unique=True)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_setxor1d_with_2d(self, xp, dtype):
+        x = testing.shaped_random((2, 3), xp, dtype=dtype)
+        y = testing.shaped_random((3, 5), xp, dtype=dtype)
+        return xp.setxor1d(x, y)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_setxor1d_with_duplicate_elements(self, xp, dtype):
+        x = xp.array([1, 2, 3, 2, 2, 6], dtype=dtype)
+        y = xp.array([3, 4, 2, 1, 1, 9], dtype=dtype)
+        return xp.setxor1d(x, y)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_setxor1d_empty_arr(self, xp, dtype):
+        x = xp.array([], dtype=dtype)
+        y = xp.array([], dtype=dtype)
+        return xp.setxor1d(x, y)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_setxor1d_more_dim(self, xp, dtype):
+        x = testing.shaped_arange((2, 3, 4, 8), xp, dtype=dtype)
+        y = testing.shaped_arange((5, 4, 2), xp, dtype=dtype)
+        return xp.setxor1d(x, y)
+
+    @testing.numpy_cupy_array_equal()
+    def test_setxor1d_bool_val(self, xp):
+        x = xp.array([True, False, True])
+        y = xp.array([False])
+        return xp.setxor1d(x, y)
+
+
 class TestIntersect1d:
 
     @testing.for_all_dtypes(no_bool=True)


### PR DESCRIPTION
Linked Issue: #6078 

Hey! I have implememeted numpy.setxor1d but seems like when you provide a multi-dim array with assume_unique as True, numpy raises an error, since their code concatenates array as - np.concatenate((ar1,ar2)) and not np.concatenate((ar1,ar2), axis=None).
However, when assume_unique is false, the array is flattened as it uses the numpy.unique function which returns a flattened array. Do we replicate the same behaviour in CuPy or allow multi-dim arrays even when assume_unique is set to true?

Attaching a screenshot below to explain the above:
<img width="670" alt="159218884-0c0ac806-b821-477b-b68a-bec7ef48077e" src="https://user-images.githubusercontent.com/64613009/159708757-839a520c-2e21-4b87-b34e-ec180c139e9b.png">

Open discussion in numpy - https://github.com/numpy/numpy/issues/14670
Currently, the code I have written does not throw errors for multi-dim arrays, regardless of where `assume_unique` is True or False. However, tests currently don't cover that, since I can't compare it to numpy results. Should I add some manual-comparison tests? Please let me know your opinion.