### PR TITLE
Performance improvement of `cupy.in1d`

### DIFF
--- a/cupy/_logic/truth.py
+++ b/cupy/_logic/truth.py
@@ -1,6 +1,7 @@
 import cupy
 from cupy._core import _routines_logic as _logic
 from cupy._core import _fusion_thread_local
+from cupy._sorting import search as _search
 from cupy import _util
 
 
@@ -115,9 +116,7 @@ def in1d(ar1, ar2, assume_unique=False, invert=False):
     # Use brilliant searchsorted trick
     # https://github.com/cupy/cupy/pull/4018#discussion_r495790724
     ar2 = cupy.sort(ar2)
-    v1 = cupy.searchsorted(ar2, ar1, 'left')
-    v2 = cupy.searchsorted(ar2, ar1, 'right')
-    return v1 == v2 if invert else v1 != v2
+    return _search._exists_kernel(ar1, ar2, ar2.size, invert)
 
 
 def intersect1d(arr1, arr2, assume_unique=False, return_indices=False):


### PR DESCRIPTION
Rel. #4018

master:
```
in1d                :    CPU: 8473.098 us   +/-52.090 (min: 8446.542 / max: 8763.044) us     GPU-0:120539.443 us   +/-47.472 (min:120487.938 / max:120788.994) us
```

This PR:
```
in1d                :    CPU: 8428.611 us   +/-44.928 (min: 8408.114 / max: 8835.957) us     GPU-0:64765.102 us   +/-43.197 (min:64736.259 / max:65145.859) us
```

Benchmark:
```py
import cupy
from cupy import testing
from cupyx.profiler import benchmark


shape = (64, 1024, 1024)
x1 = testing.shaped_random(shape, xp=cupy, dtype='l', seed=0, scale=100000000)
x2 = testing.shaped_random(shape, xp=cupy, dtype='l', seed=1, scale=100000000)
perf = benchmark(cupy.in1d, (x1, x2), n_repeat=100)

print(perf)
print(cupy.in1d(x1, x2).sum())
```

cc: @mrkwjc