### PR TITLE
Fix `cupy.copyto` to take NumPy array scalars

### DIFF
--- a/cupy/_manipulation/basic.py
+++ b/cupy/_manipulation/basic.py
@@ -37,7 +37,7 @@ def copyto(dst, src, casting='same_kind', where=None):
         src_dtype = numpy.dtype(type(src))
         can_cast = numpy.can_cast(src, dst.dtype, casting)
     elif isinstance(src, numpy.ndarray):
-        if src.shape != ():
+        if src.size != 1:
             raise ValueError(
                 'non-scalar numpy.ndarray cannot be used for copyto')
         src_dtype = src.dtype

--- a/cupy/_manipulation/basic.py
+++ b/cupy/_manipulation/basic.py
@@ -27,6 +27,7 @@ def copyto(dst, src, casting='same_kind', where=None):
     .. seealso:: :func:`numpy.copyto`
 
     """
+    src_is_numpy_scalar = False
 
     src_type = type(src)
     src_is_python_scalar = src_type in (
@@ -35,6 +36,14 @@ def copyto(dst, src, casting='same_kind', where=None):
     if src_is_python_scalar:
         src_dtype = numpy.dtype(type(src))
         can_cast = numpy.can_cast(src, dst.dtype, casting)
+    elif isinstance(src, numpy.ndarray):
+        if src.shape != ():
+            raise ValueError(
+                'non-scalar numpy.ndarray cannot be used for copyto')
+        src_dtype = src.dtype
+        can_cast = numpy.can_cast(src, dst.dtype, casting)
+        src = src.item()
+        src_is_numpy_scalar = True
     else:
         src_dtype = src.dtype
         can_cast = numpy.can_cast(src_dtype, dst.dtype, casting)
@@ -54,7 +63,7 @@ def copyto(dst, src, casting='same_kind', where=None):
             fusion._call_ufunc(search._where_ufunc, where, src, dst, dst)
         return
 
-    if not src_is_python_scalar:
+    if not src_is_python_scalar and not src_is_numpy_scalar:
         # Check broadcast condition
         # - for fast-paths and
         # - for a better error message (than ufunc's).
@@ -79,8 +88,8 @@ def copyto(dst, src, casting='same_kind', where=None):
     if dst.size == 0:
         return
 
-    if src_is_python_scalar:
-        dst.fill(src)
+    if src_is_python_scalar or src_is_numpy_scalar:
+        _core.elementwise_copy(src, dst)
         return
 
     if _can_memcpy(dst, src):

--- a/tests/cupy_tests/manipulation_tests/test_basic.py
+++ b/tests/cupy_tests/manipulation_tests/test_basic.py
@@ -234,6 +234,16 @@ class TestCopytoFromNumPyScalar:
             xp.copyto(dst, src, casting=casting, where=mask)
         return dst
 
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose(accept_error=TypeError)
+    def test_copyto_size_one(self, xp, dtype, casting):
+        dst = xp.zeros((2, 3, 4), dtype=dtype)
+        src = numpy.array([1], dtype=dtype)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', numpy.ComplexWarning)
+            xp.copyto(dst, src, casting)
+        return dst
+
 
 @pytest.mark.parametrize('shape', [(3, 2), (0,)])
 @pytest.mark.parametrize('where', [

--- a/tests/cupy_tests/manipulation_tests/test_basic.py
+++ b/tests/cupy_tests/manipulation_tests/test_basic.py
@@ -1,4 +1,5 @@
 import itertools
+import warnings
 
 import numpy
 import pytest
@@ -204,6 +205,33 @@ class TestCopytoFromScalar:
         mask = (testing.shaped_arange(
             self.dst_shape, xp, dtype) % 2).astype(xp.bool_)
         xp.copyto(dst, self.src, where=mask)
+        return dst
+
+
+@pytest.mark.parametrize(
+    'casting', ['no', 'equiv', 'safe', 'same_kind', 'unsafe'])
+class TestCopytoFromNumPyScalar:
+
+    @testing.for_all_dtypes_combination(('dtype1', 'dtype2'))
+    @testing.numpy_cupy_allclose(accept_error=TypeError)
+    def test_copyto(self, xp, dtype1, dtype2, casting):
+        dst = xp.zeros((2, 3, 4), dtype=dtype1)
+        src = numpy.array(1, dtype=dtype2)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', numpy.ComplexWarning)
+            xp.copyto(dst, src, casting)
+        return dst
+
+    @testing.for_all_dtypes_combination(('dtype1', 'dtype2'))
+    @testing.numpy_cupy_allclose(accept_error=TypeError)
+    def test_copyto_where(self, xp, dtype1, dtype2, casting):
+        shape = (2, 3, 4)
+        dst = xp.ones(shape, dtype=dtype1)
+        src = numpy.array(1, dtype=dtype2)
+        mask = (testing.shaped_arange(shape, xp, dtype1) % 2).astype(xp.bool_)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', numpy.ComplexWarning)
+            xp.copyto(dst, src, casting=casting, where=mask)
         return dst
 
 


### PR DESCRIPTION
Rel #6577.

This PR fixes `cupy.copyto` to be able to take NumPy array scalars as its `src` data. I want to change this in advance to fixing #6577 in order to implement `cupy.full` using `cupy.copyto` as `numpy.full` does.