### PR TITLE
Implement `flatten(order)`

### DIFF
--- a/cupy/_core/_routines_manipulation.pxd
+++ b/cupy/_core/_routines_manipulation.pxd
@@ -18,7 +18,7 @@ cdef ndarray _ndarray_reshape(ndarray self, tuple shape, order)
 cdef ndarray _ndarray_transpose(ndarray self, tuple axes)
 cdef ndarray _ndarray_swapaxes(
     ndarray self, Py_ssize_t axis1, Py_ssize_t axis2)
-cdef ndarray _ndarray_flatten(ndarray self)
+cdef ndarray _ndarray_flatten(ndarray self, order)
 cdef ndarray _ndarray_ravel(ndarray self, order)
 cdef ndarray _ndarray_squeeze(ndarray self, axis)
 cdef ndarray _ndarray_repeat(ndarray self, repeats, axis)

--- a/cupy/_core/core.pxd
+++ b/cupy/_core/core.pxd
@@ -35,7 +35,7 @@ cdef class ndarray:
     cpdef ndarray view(self, dtype=*)
     cpdef fill(self, value)
     cpdef ndarray swapaxes(self, Py_ssize_t axis1, Py_ssize_t axis2)
-    cpdef ndarray flatten(self)
+    cpdef ndarray flatten(self, order=*)
     cpdef ndarray ravel(self, order=*)
     cpdef ndarray squeeze(self, axis=*)
     cpdef ndarray take(self, indices, axis=*, out=*)

--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -736,7 +736,15 @@ cdef class ndarray:
     cpdef ndarray flatten(self, order='C'):
         """Returns a copy of the array flatten into one dimension.
 
-        It currently supports C-order only.
+        Args:
+            order ({'C', 'F', 'A', 'K'}):
+                'C' means to flatten in row-major (C-style) order.
+                'F' means to flatten in column-major (Fortran-
+                style) order. 'A' means to flatten in column-major
+                order if `self` is Fortran *contiguous* in memory,
+                row-major order otherwise. 'K' means to flatten
+                `self` in the order the elements occur in memory.
+                The default is 'C'.
 
         Returns:
             cupy.ndarray: A copy of the array with one dimension.

--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -733,7 +733,7 @@ cdef class ndarray:
         """
         return _manipulation._ndarray_swapaxes(self, axis1, axis2)
 
-    cpdef ndarray flatten(self):
+    cpdef ndarray flatten(self, order='C'):
         """Returns a copy of the array flatten into one dimension.
 
         It currently supports C-order only.
@@ -744,8 +744,7 @@ cdef class ndarray:
         .. seealso:: :meth:`numpy.ndarray.flatten`
 
         """
-        # TODO(beam2d): Support ordering option
-        return _manipulation._ndarray_flatten(self)
+        return _manipulation._ndarray_flatten(self, order)
 
     cpdef ndarray ravel(self, order='C'):
         """Returns an array flattened into one dimension.

--- a/cupy/_manipulation/shape.py
+++ b/cupy/_manipulation/shape.py
@@ -60,22 +60,23 @@ def ravel(a, order='C'):
 
     It tries to return a view if possible, otherwise returns a copy.
 
-    This function currently does not support the ``order = 'K'`` option.
-
     Args:
         a (cupy.ndarray): Array to be flattened.
-        order ({'C', 'F', 'A'}):
-            Read the elements of ``a`` using this index order, and place the
-            elements into the reshaped array using this index order.
-            'C' means to read / write the elements using C-like index order,
-            with the last axis index changing fastest, back to the first axis
-            index changing slowest. 'F' means to read / write the elements
-            using Fortran-like index order, with the first index changing
-            fastest, and the last index changing slowest. Note that the 'C'
-            and 'F' options take no account of the memory layout of the
-            underlying array, and only refer to the order of indexing. 'A'
-            means to read / write the elements in Fortran-like index order if
-            a is Fortran contiguous in memory, C-like order otherwise.
+        order ({'C', 'F', 'A', 'K'}):
+            The elements of ``a`` are read using this index order. 'C' means
+            to index the elements in row-major, C-style order,
+            with the last axis index changing fastest, back to the first
+            axis index changing slowest.  'F' means to index the elements
+            in column-major, Fortran-style order, with the
+            first index changing fastest, and the last index changing
+            slowest. Note that the 'C' and 'F' options take no account of
+            the memory layout of the underlying array, and only refer to
+            the order of axis indexing.  'A' means to read the elements in
+            Fortran-like index order if ``a`` is Fortran *contiguous* in
+            memory, C-like order otherwise.  'K' means to read the
+            elements in the order they occur in memory, except for
+            reversing the data when strides are negative.  By default, 'C'
+            index order is used.
 
     Returns:
         cupy.ndarray: A flattened view of ``a`` if possible, otherwise a copy.

--- a/tests/cupy_tests/core_tests/test_ndarray_copy_and_view.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_copy_and_view.py
@@ -124,9 +124,29 @@ class TestArrayCopyAndView:
         return b
 
     @testing.numpy_cupy_array_equal()
-    def test_transposed_flatten(self, xp):
+    def test_flatten_transposed(self, xp):
         a = testing.shaped_arange((2, 3, 4), xp).transpose(2, 0, 1)
         return a.flatten()
+
+    @testing.for_orders('CFAK')
+    @testing.numpy_cupy_array_equal()
+    def test_flatten_order(self, xp, order):
+        a = testing.shaped_arange((2, 3, 4), xp)
+        return a.flatten(order)
+
+    @testing.for_orders('CFAK')
+    @testing.numpy_cupy_array_equal()
+    def test_flatten_order_copied(self, xp, order):
+        a = testing.shaped_arange((4,), xp)
+        b = a.flatten(order=order)
+        a[:] = 1
+        return b
+
+    @testing.for_orders('CFAK')
+    @testing.numpy_cupy_array_equal()
+    def test_flatten_order_transposed(self, xp, order):
+        a = testing.shaped_arange((2, 3, 4), xp).transpose(2, 0, 1)
+        return a.flatten(order=order)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()

--- a/tests/cupy_tests/manipulation_tests/test_shape.py
+++ b/tests/cupy_tests/manipulation_tests/test_shape.py
@@ -1,5 +1,3 @@
-import unittest
-
 import numpy
 import pytest
 
@@ -7,27 +5,21 @@ import cupy
 from cupy import testing
 
 
-@testing.parameterize(*testing.product({
-    'shape': [(2, 3), (), (4,)],
-}))
-@testing.gpu
-class TestShape(unittest.TestCase):
+@pytest.mark.parametrize('shape', [(2, 3), (), (4,)])
+class TestShape:
 
-    def test_shape(self):
-        shape = self.shape
+    def test_shape(self, shape):
         for xp in (numpy, cupy):
             a = testing.shaped_arange(shape, xp)
             assert cupy.shape(a) == shape
 
-    def test_shape_list(self):
-        shape = self.shape
+    def test_shape_list(self, shape):
         a = testing.shaped_arange(shape, numpy)
         a = a.tolist()
         assert cupy.shape(a) == shape
 
 
-@testing.gpu
-class TestReshape(unittest.TestCase):
+class TestReshape:
 
     def test_reshape_strides(self):
         def func(xp):
@@ -147,8 +139,7 @@ class TestReshape(unittest.TestCase):
                 self._test_ndim_limit(xp, 33, dtype, order)
 
 
-@testing.gpu
-class TestRavel(unittest.TestCase):
+class TestRavel:
 
     @testing.for_orders('CFAK')
     @testing.numpy_cupy_array_equal()
@@ -223,26 +214,27 @@ class TestRavel(unittest.TestCase):
         return xp.ravel(a)
 
 
-@testing.parameterize(*testing.product({
-    'order_init': ['C', 'F'],
-    'order_reshape': ['C', 'F', 'A', 'c', 'f', 'a'],
-    'shape_in_out': [((2, 3), (1, 6, 1)),  # (shape_init, shape_final)
-                     ((6,), (2, 3)),
-                     ((3, 3, 3), (9, 3))],
-}))
-@testing.gpu
-class TestReshapeOrder(unittest.TestCase):
+@pytest.mark.parametrize('order_init', ['C', 'F'])
+@pytest.mark.parametrize('order_reshape', ['C', 'F', 'A', 'c', 'f', 'a'])
+@pytest.mark.parametrize('shape_in_out', [
+    ((2, 3), (1, 6, 1)),  # (shape_init, shape_final)
+    ((6,), (2, 3)),
+    ((3, 3, 3), (9, 3)),
+])
+class TestReshapeOrder:
 
-    def test_reshape_contiguity(self):
-        shape_init, shape_final = self.shape_in_out
+    def test_reshape_contiguity(
+        self, order_init, order_reshape, shape_in_out
+    ):
+        shape_init, shape_final = shape_in_out
 
         a_cupy = testing.shaped_arange(shape_init, xp=cupy)
-        a_cupy = cupy.asarray(a_cupy, order=self.order_init)
-        b_cupy = a_cupy.reshape(shape_final, order=self.order_reshape)
+        a_cupy = cupy.asarray(a_cupy, order=order_init)
+        b_cupy = a_cupy.reshape(shape_final, order=order_reshape)
 
         a_numpy = testing.shaped_arange(shape_init, xp=numpy)
-        a_numpy = numpy.asarray(a_numpy, order=self.order_init)
-        b_numpy = a_numpy.reshape(shape_final, order=self.order_reshape)
+        a_numpy = numpy.asarray(a_numpy, order=order_init)
+        b_numpy = a_numpy.reshape(shape_final, order=order_reshape)
 
         assert b_cupy.flags.f_contiguous == b_numpy.flags.f_contiguous
         assert b_cupy.flags.c_contiguous == b_numpy.flags.c_contiguous


### PR DESCRIPTION
Fix `flatten` as `ravel` in #6585.

This PR also refactors the test of `ravel`.