### PR TITLE
Define float16::operator-() only for ROCm 5.0+

### DIFF
--- a/cupy/_core/include/cupy/carray.cuh
+++ b/cupy/_core/include/cupy/carray.cuh
@@ -126,9 +126,13 @@ public:
     return (__half_raw(data_).x & 0x8000u) != 0;
   }
 
+#ifdef __HIPCC__ && HIP_VERSION >= 50000000
+
   __device__ float16 operator-() {
     return float16(-data_);
   }
+
+#endif
 
   template<typename T>
   inline __device__ float16& operator+=(const T& rhs) {


### PR DESCRIPTION
Fix #6615. Following up #6524.