### PR TITLE
Add support for sparse matrices in `cupyx.distributed`

### DIFF
--- a/tests/cupyx_tests/distributed_tests/comm_runner.py
+++ b/tests/cupyx_tests/distributed_tests/comm_runner.py
@@ -333,10 +333,10 @@ def _make_sparse_empty(dtype):
 
 
 def sparse_send_and_recv(dtype, use_mpi=False):
-    def run_send_and_recv(rank, dtype, force_store=True):
+    def run_send_and_recv(rank, dtype, use_mpi=False):
         dev = cuda.Device(rank)
         dev.use()
-        comm = NCCLBackend(N_WORKERS, rank, force_store=force_store)
+        comm = NCCLBackend(N_WORKERS, rank, use_mpi=use_mpi)
         in_array = _make_sparse(dtype)
         out_array = _make_sparse_empty(dtype)
         warnings.filterwarnings(

--- a/tests/cupyx_tests/distributed_tests/comm_runner.py
+++ b/tests/cupyx_tests/distributed_tests/comm_runner.py
@@ -1,5 +1,6 @@
 import sys
 import time
+import warnings
 
 import cupy
 from cupy import cuda
@@ -9,6 +10,8 @@ from cupy import testing
 from cupyx.distributed import init_process_group
 from cupyx.distributed._nccl_comm import NCCLBackend
 from cupyx.distributed._store import ExceptionAwareProcess
+from cupyx.scipy import sparse
+
 
 nccl_available = nccl.available
 
@@ -313,6 +316,43 @@ def init(use_mpi=False):
         run_init(MPI.COMM_WORLD.Get_rank(), dtype, False)
     else:
         _launch_workers(run_init)
+
+
+def _make_sparse(dtype):
+    data = cupy.array([0, 1, 2, 3], dtype)
+    indices = cupy.array([0, 1, 3, 2], 'i')
+    indptr = cupy.array([0, 2, 3, 4], 'i')
+    return sparse.csr_matrix((data, indices, indptr), shape=(3, 4))
+
+
+def _make_sparse_empty(dtype):
+    data = cupy.array([0], dtype)
+    indices = cupy.array([0], 'i')
+    indptr = cupy.array([0], 'i')
+    return sparse.csr_matrix((data, indices, indptr), shape=(0, 0))
+
+
+def sparse_send_and_recv(dtype, use_mpi=False):
+    def run_send_and_recv(rank, dtype, force_store=True):
+        dev = cuda.Device(rank)
+        dev.use()
+        comm = NCCLBackend(N_WORKERS, rank, force_store=force_store)
+        in_array = _make_sparse(dtype)
+        out_array = _make_sparse_empty(dtype)
+        warnings.filterwarnings(
+            'ignore', '.*transferring sparse.*', UserWarning)
+        if rank == 0:
+            comm.send(in_array, 1)
+        else:
+            comm.recv(out_array, 0)
+            testing.assert_allclose(out_array.todense(), in_array.todense())
+
+    if use_mpi:
+        from mpi4py import MPI
+        # This process was run with mpiexec
+        run_send_and_recv(MPI.COMM_WORLD.Get_rank(), dtype, False)
+    else:
+        _launch_workers(run_send_and_recv, (dtype,))
 
 
 if __name__ == '__main__':

--- a/tests/cupyx_tests/distributed_tests/test_comm.py
+++ b/tests/cupyx_tests/distributed_tests/test_comm.py
@@ -107,6 +107,24 @@ class TestNCCLBackendWithMPI(TestNCCLBackend):
 
 
 @pytest.mark.skipif(not nccl_available, reason='nccl is not installed')
+@testing.multi_gpu(2)
+class TestNCCLBackendSparse:
+    def _run_test(self, test, dtype):
+        _run_test(test, dtype)
+
+    @testing.for_dtypes('fdFD')
+    def test_send_and_recv(self, dtype):
+        self._run_test('sparse_send_and_recv', dtype)
+
+
+@pytest.mark.skipif(not _mpi_available, reason='mpi is not installed')
+@testing.multi_gpu(2)
+class TestNCCLBackendSparseWithMPI(TestNCCLBackendSparse):
+    def _run_test(self, test, dtype):
+        _run_test_with_mpi(test, dtype)
+
+
+@pytest.mark.skipif(not nccl_available, reason='nccl is not installed')
 class TestInitDistributed(unittest.TestCase):
 
     @testing.multi_gpu(2)


### PR DESCRIPTION
There are several difficult things going on here that need to be discussed.

A proper way to send the shape/sizes of the internal matrix arrays, right now is done in nccl and this ends up syncing the device. Doing through the backing TCP store would be also pretty slow and will require modifying the store too for cases when a process is accessing elements that are not yet set.

cc @leofang do you have some thoughts on this?

Thanks!