### PR TITLE
Add CC 3.2 to Tegra arch list

### DIFF
--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -120,7 +120,7 @@ def _get_nvrtc_version():
 
 
 # Known archs for Tegra/Jetson/Xavier/etc
-_tegra_archs = ('53', '62', '72')
+_tegra_archs = ('32', '53', '62', '72')
 
 
 @_util.memoize()


### PR DESCRIPTION
I believe CC 3.2 (Jetson TK1) is unlikely used but fixing it for sure as we still support CUDA 10.2.