### PR TITLE
JIT: fix function signatures in the docs

### DIFF
--- a/cupyx/jit/_builtin_funcs.py
+++ b/cupyx/jit/_builtin_funcs.py
@@ -58,6 +58,7 @@ class RangeFunc(BuiltinFunc):
 
 
 class LenFunc(BuiltinFunc):
+
     def call(self, env, *args, **kwds):
         if len(args) != 1:
             raise TypeError(f'len() expects only 1 argument, got {len(args)}')
@@ -73,6 +74,7 @@ class LenFunc(BuiltinFunc):
 
 
 class MinFunc(BuiltinFunc):
+
     def call(self, env, *args, **kwds):
         if len(args) < 2:
             raise TypeError(
@@ -84,6 +86,7 @@ class MinFunc(BuiltinFunc):
 
 
 class MaxFunc(BuiltinFunc):
+
     def call(self, env, *args, **kwds):
         if len(args) < 2:
             raise TypeError(
@@ -147,7 +150,7 @@ class SyncWarp(BuiltinFunc):
 class SharedMemory(BuiltinFunc):
 
     def __call__(self, dtype, size):
-        """Allocates shared memory and returns the 1-dim array.
+        """Allocates shared memory and returns a 1-D array.
 
         Args:
             dtype (dtype):

--- a/cupyx/jit/_internal_types.py
+++ b/cupyx/jit/_internal_types.py
@@ -56,6 +56,9 @@ class Range(Expr):
 
 
 class BuiltinFunc(Expr):
+    # subclasses must implement:
+    # - either call or call_const
+    # - `__call__` with a correct signature, which calls the parent's __call__
 
     def call(self, env, *args, **kwargs):
         for x in itertools.chain(args, kwargs.values()):

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -482,5 +482,11 @@ def remove_array_api_module_docstring(app, what, name, obj, options, lines):
     if what == "module" and 'array_api' in name:
         del lines[:]
 
+def fix_jit_callable_signature(
+        app, what, name, obj, options, signature, return_annotation):
+    if 'cupyx.jit' in name and callable(obj) and signature is None:
+        return (f'{inspect.signature(obj)}', None)
+
 def setup(app):
     app.connect("autodoc-process-docstring", remove_array_api_module_docstring)
+    app.connect("autodoc-process-signature", fix_jit_callable_signature)

--- a/docs/source/reference/kernel.rst
+++ b/docs/source/reference/kernel.rst
@@ -14,7 +14,7 @@ Custom kernels
 JIT kernel definition
 ---------------------
 
-Supported Python built-in functions include: :func:`range`, :func:`len`, :func:`max`, :func:`min`
+Supported Python built-in functions include: :obj:`range`, :func:`len`, :func:`max`, :func:`min`
 
 .. autosummary::
    :toctree: generated/

--- a/docs/source/reference/kernel.rst
+++ b/docs/source/reference/kernel.rst
@@ -14,6 +14,8 @@ Custom kernels
 JIT kernel definition
 ---------------------
 
+Supported Python built-in functions include: :func:`range`, :func:`len`, :func:`max`, :func:`min`
+
 .. autosummary::
    :toctree: generated/
 


### PR DESCRIPTION
Close #5390. 

Still not perfect but a lot better than before. It'd be nice to backport this.

before | after 
-------|------
<img width="400" alt="截圖 2022-04-12 上午3 02 39" src="https://user-images.githubusercontent.com/5534781/162900882-fe1f6757-0a5d-42d1-8a36-e5df7bb5dc36.png"> | <img width="400" alt="截圖 2022-04-12 上午3 02 49" src="https://user-images.githubusercontent.com/5534781/162900908-d7f15914-2568-49e8-a815-bbb980c44241.png">

before | after 
-------|------
<img width="400" alt="截圖 2022-04-12 上午3 03 36" src="https://user-images.githubusercontent.com/5534781/162901031-0f41ed74-b093-4934-8c68-2ff7c489f5b3.png"> | <img width="400" alt="截圖 2022-04-12 上午3 03 47" src="https://user-images.githubusercontent.com/5534781/162901058-c9d9c0c4-800e-42a6-babd-f8dbe88e89ad.png">
