### PR TITLE
Fix cuda python CI

### DIFF
--- a/cupy_backends/cuda/api/runtime.pxd
+++ b/cupy_backends/cuda/api/runtime.pxd
@@ -85,6 +85,10 @@ IF CUPY_USE_CUDA_PYTHON:
     ctypedef cudaGraphExec_t GraphExec
     ctypedef cudaGraphNode_t GraphNode
 
+    ctypedef cudaMemAllocationType MemAllocationType
+    ctypedef cudaMemAllocationHandleType MemAllocationHandleType
+    ctypedef cudaMemLocationType MemLocationType
+
 ELSE:
     include "_runtime_typedef.pxi"
     from cupy_backends.cuda.api._runtime_enum cimport *

--- a/tests/cupyx_tests/jit_tests/test_cooperative_groups.py
+++ b/tests/cupyx_tests/jit_tests/test_cooperative_groups.py
@@ -41,7 +41,7 @@ class TestCooperativeGroups:
     @pytest.mark.skipif(
         runtime.runtimeGetVersion() < 11060
         or (cupy.cuda.driver._is_cuda_python()
-            and cupy.cuda.nvrtc.get_version() < (11, 6)),
+            and cupy.cuda.nvrtc.getVersion() < (11, 6)),
         reason='not supported until CUDA 11.6')
     def test_thread_block_group_cu116_new_APIs(self):
         @jit.rawkernel()

--- a/tests/cupyx_tests/jit_tests/test_cooperative_groups.py
+++ b/tests/cupyx_tests/jit_tests/test_cooperative_groups.py
@@ -39,7 +39,9 @@ class TestCooperativeGroups:
         assert (x[11:] == -1).all()
 
     @pytest.mark.skipif(
-        runtime.runtimeGetVersion() < 11060,
+        runtime.runtimeGetVersion() < 11060
+        or (cupy.cuda.driver._is_cuda_python()
+            and cupy.cuda.nvrtc.get_version() < (11, 6)),
         reason='not supported until CUDA 11.6')
     def test_thread_block_group_cu116_new_APIs(self):
         @jit.rawkernel()
@@ -89,7 +91,9 @@ class TestCooperativeGroups:
         assert (x[5:] == 2**64-1).all()
 
     @pytest.mark.skipif(
-        runtime.runtimeGetVersion() < 11060,
+        runtime.runtimeGetVersion() < 11060
+        or (cupy.cuda.driver._is_cuda_python()
+            and cupy.cuda.nvrtc.get_version() < (11, 6)),
         reason='not supported until CUDA 11.6')
     @pytest.mark.skipif(runtime.deviceGetAttribute(
         runtime.cudaDevAttrCooperativeLaunch, 0) == 0,

--- a/tests/cupyx_tests/jit_tests/test_cooperative_groups.py
+++ b/tests/cupyx_tests/jit_tests/test_cooperative_groups.py
@@ -93,7 +93,7 @@ class TestCooperativeGroups:
     @pytest.mark.skipif(
         runtime.runtimeGetVersion() < 11060
         or (cupy.cuda.driver._is_cuda_python()
-            and cupy.cuda.nvrtc.get_version() < (11, 6)),
+            and cupy.cuda.nvrtc.getVersion() < (11, 6)),
         reason='not supported until CUDA 11.6')
     @pytest.mark.skipif(runtime.deviceGetAttribute(
         runtime.cudaDevAttrCooperativeLaunch, 0) == 0,


### PR DESCRIPTION
Should fix CIs

- Skip cooperative groups in CUDA-Python when toolkit < 1.6
- Declare missing types in async allocation APIs