### PR TITLE
Use MPI for management in `cupyx.distributed`

### DIFF
--- a/cupyx/distributed/_init.py
+++ b/cupyx/distributed/_init.py
@@ -10,7 +10,8 @@ _backends = {'nccl': NCCLBackend}
 
 
 def init_process_group(
-        n_devices, rank, *, backend='nccl', host=None, port=None):
+        n_devices, rank, *, backend='nccl', host=None, port=None,
+        force_store=False):
     """Start `cupyx.distributed` and obtain a communicator.
 
     This call initializes the distributed environment, it needs to be
@@ -63,6 +64,9 @@ def init_process_group(
             defaults to `None`.
         port (int): port for the process rendezvous on initialization
             defaults to `None`.
+        force_store (bool): even if MPI is available, it will avoid it and use
+            the provided TCP server for exchanging CPU only information.
+            defaults to `False`.
     Returns:
         Backend: object used to perform communications, adheres to the
             :class:`~cupyx.distributed.Backend` specification:
@@ -81,4 +85,4 @@ def init_process_group(
         port = int(os.environ.get(
             'CUPYX_DISTRIBUTED_PORT', _store._DEFAULT_PORT))
 
-    return _backends[backend](n_devices, rank, host, port)
+    return _backends[backend](n_devices, rank, host, port, force_store)

--- a/cupyx/distributed/_nccl_comm.py
+++ b/cupyx/distributed/_nccl_comm.py
@@ -4,6 +4,13 @@ from cupyx.distributed import _store
 from cupyx.distributed._comm import _Backend
 
 
+try:
+    from mpi4py import MPI
+    _mpi_available = True
+except ImportError:
+    _mpi_available = False
+
+
 if nccl.available:
     # types are not compliant with windows on long/int32 issue
     # but nccl does not support windows so we don't care
@@ -44,25 +51,49 @@ class NCCLBackend(_Backend):
             initialization. Defaults to `"127.0.0.1"`.
         port (int, optional): port used for the process rendezvous on
             initialization. Defaults to `13333`.
+        force_store(bool, optional): Ignore MPI and use the included TCP
+            server for initialization & synchronization. Defaults to `False`.
     """
 
     def __init__(self, n_devices, rank,
-                 host=_store._DEFAULT_HOST, port=_store._DEFAULT_PORT):
+                 host=_store._DEFAULT_HOST, port=_store._DEFAULT_PORT,
+                 force_store=False):
         super().__init__(n_devices, rank, host, port)
+        self._use_mpi = _mpi_available and not force_store
+
+        if self._use_mpi:
+            self._init_with_mpi(n_devices, rank)
+        else:
+            self._init_with_tcp_store(n_devices, rank, host, port)
+
+    def _init_with_mpi(self, n_devices, rank):
+        # MPI is used only for management purposes
+        # so the rank may be different than the one specified
+        self._comm = MPI.COMM_WORLD
+        self._mpi_rank = self._comm.Get_rank()
+        self._comm.Barrier()
+        nccl_id = None
+        if self._mpi_rank == 0:
+            nccl_id = nccl.get_unique_id()
+        nccl_id = self._comm.bcast(nccl_id, root=0)
+        # Initialize devices
+        self._comm = nccl.NcclCommunicator(n_devices, nccl_id, rank)
+
+    def _init_with_tcp_store(self, n_devices, rank, host, port):
+        nccl_id = None
         if rank == 0:
             self._store.run(host, port)
             nccl_id = nccl.get_unique_id()
             # get_unique_id return negative values due to cython issues
             # with bytes && c strings. We shift them by 128 to
-            # avoid issues
-            nccl_id = bytes([b + 128 for b in nccl_id])
-            self._store_proxy['nccl_id'] = nccl_id
+            # make them positive and send them as bytes to the proxy store
+            shifted_nccl_id = bytes([b + 128 for b in nccl_id])
+            self._store_proxy['nccl_id'] = shifted_nccl_id
             self._store_proxy.barrier()
         else:
             self._store_proxy.barrier()
             nccl_id = self._store_proxy['nccl_id']
-        # Initialize devices
-        nccl_id = tuple([int(b) - 128 for b in nccl_id])
+            nccl_id = tuple([int(b) - 128 for b in nccl_id])
         self._comm = nccl.NcclCommunicator(n_devices, nccl_id, rank)
 
     def _check_contiguous(self, array):
@@ -354,4 +385,7 @@ class NCCLBackend(_Backend):
         """
         # implements a barrier CPU side
         # TODO allow multiple barriers to be executed
-        self._store_proxy.barrier()
+        if self._use_mpi:
+            self._comm.Barrier()
+        else:
+            self._store_proxy.barrier()

--- a/tests/cupyx_tests/distributed_tests/comm_runner.py
+++ b/tests/cupyx_tests/distributed_tests/comm_runner.py
@@ -16,13 +16,13 @@ nccl_available = nccl.available
 N_WORKERS = 2
 
 
-def _launch_workers(n_workers, func, args=()):
+def _launch_workers(func, args=(), n_workers=N_WORKERS):
     processes = []
     # TODO catch exceptions
     for rank in range(n_workers):
         p = ExceptionAwareProcess(
             target=func,
-            args=(rank, n_workers) + args)
+            args=(rank,) + args)
         p.start()
         processes.append(p)
 
@@ -30,14 +30,14 @@ def _launch_workers(n_workers, func, args=()):
         p.join()
 
 
-def broadcast(dtype):
+def broadcast(dtype, use_mpi=False):
     if dtype in 'hH':
         return  # nccl does not support int16
 
-    def run_broadcast(rank, n_workers, root, dtype):
+    def run_broadcast(rank, root, dtype, force_store=True):
         dev = cuda.Device(rank)
         dev.use()
-        comm = NCCLBackend(n_workers, rank)
+        comm = NCCLBackend(N_WORKERS, rank, force_store=force_store)
         expected = cupy.arange(2 * 3 * 4, dtype=dtype).reshape((2, 3, 4))
         if rank == root:
             in_array = expected
@@ -46,91 +46,118 @@ def broadcast(dtype):
         comm.broadcast(in_array, root)
         testing.assert_allclose(in_array, expected)
 
-    _launch_workers(N_WORKERS, run_broadcast, (0, dtype))
-    _launch_workers(N_WORKERS, run_broadcast, (1, dtype))
+    if use_mpi:
+        from mpi4py import MPI
+        # This process was run with mpiexec
+        run_broadcast(MPI.COMM_WORLD.Get_rank(), 0, dtype, False)
+        run_broadcast(MPI.COMM_WORLD.Get_rank(), 1, dtype, False)
+    else:
+        _launch_workers(run_broadcast, (0, dtype))
+        _launch_workers(run_broadcast, (1, dtype))
 
 
-def reduce(dtype):
+def reduce(dtype, use_mpi=False):
     if dtype in 'hH':
         return  # nccl does not support int16
 
-    def run_reduce(rank, n_workers, root, dtype):
+    def run_reduce(rank, root, dtype, force_store=True):
         dev = cuda.Device(rank)
         dev.use()
-        comm = NCCLBackend(n_workers, rank)
+        comm = NCCLBackend(N_WORKERS, rank, force_store=force_store)
         in_array = cupy.arange(2 * 3 * 4, dtype='f').reshape(2, 3, 4)
         out_array = cupy.zeros((2, 3, 4), dtype='f')
         comm.reduce(in_array, out_array, root)
         if rank == root:
             testing.assert_allclose(out_array, 2 * in_array)
 
-    _launch_workers(N_WORKERS, run_reduce, (0, dtype))
-    _launch_workers(N_WORKERS, run_reduce, (1, dtype))
+    if use_mpi:
+        from mpi4py import MPI
+        # This process was run with mpiexec
+        run_reduce(MPI.COMM_WORLD.Get_rank(), 0, dtype, False)
+        run_reduce(MPI.COMM_WORLD.Get_rank(), 1, dtype, False)
+    else:
+        _launch_workers(run_reduce, (0, dtype))
+        _launch_workers(run_reduce, (1, dtype))
 
 
-def all_reduce(dtype):
+def all_reduce(dtype, use_mpi=False):
     if dtype in 'hH':
         return  # nccl does not support int16
 
-    def run_all_reduce(rank, n_workers, dtype):
+    def run_all_reduce(rank, dtype, force_store=True):
         dev = cuda.Device(rank)
         dev.use()
-        comm = NCCLBackend(n_workers, rank)
+        comm = NCCLBackend(N_WORKERS, rank, force_store=force_store)
         in_array = cupy.arange(2 * 3 * 4, dtype='f').reshape(2, 3, 4)
         out_array = cupy.zeros((2, 3, 4), dtype='f')
 
         comm.all_reduce(in_array, out_array)
         testing.assert_allclose(out_array, 2 * in_array)
 
-    _launch_workers(N_WORKERS, run_all_reduce, (dtype,))
+    if use_mpi:
+        from mpi4py import MPI
+        # This process was run with mpiexec
+        run_all_reduce(MPI.COMM_WORLD.Get_rank(), dtype, False)
+    else:
+        _launch_workers(run_all_reduce, (dtype,))
 
 
-def reduce_scatter(dtype):
+def reduce_scatter(dtype, use_mpi=False):
     if dtype in 'hH':
         return  # nccl does not support int16
 
-    def run_reduce_scatter(rank, n_workers, dtype):
+    def run_reduce_scatter(rank, dtype, force_store=True):
         dev = cuda.Device(rank)
         dev.use()
-        comm = NCCLBackend(n_workers, rank)
+        comm = NCCLBackend(rank, force_store=force_store)
         in_array = 1 + cupy.arange(
-            n_workers * 10, dtype='f').reshape(n_workers, 10)
+            N_WORKERS * 10, dtype='f').reshape(N_WORKERS, 10)
         out_array = cupy.zeros((10,), dtype='f')
 
         comm.reduce_scatter(in_array, out_array, 10)
         testing.assert_allclose(out_array, 2 * in_array[rank])
 
-    _launch_workers(N_WORKERS, run_reduce_scatter, (dtype,))
+    if use_mpi:
+        from mpi4py import MPI
+        # This process was run with mpiexec
+        run_reduce_scatter(MPI.COMM_WORLD.Get_rank(), dtype, False)
+    else:
+        _launch_workers(run_reduce_scatter, (dtype,))
 
 
-def all_gather(dtype):
+def all_gather(dtype, use_mpi=False):
     if dtype in 'hH':
         return  # nccl does not support int16
 
-    def run_all_gather(rank, n_workers, dtype):
+    def run_all_gather(rank, dtype, force_store=True):
         dev = cuda.Device(rank)
         dev.use()
-        comm = NCCLBackend(n_workers, rank)
+        comm = NCCLBackend(rank, force_store=force_store)
         in_array = (rank + 1) * cupy.arange(
-            n_workers * 10, dtype='f').reshape(n_workers, 10)
-        out_array = cupy.zeros((n_workers, 10), dtype='f')
+            N_WORKERS * 10, dtype='f').reshape(N_WORKERS, 10)
+        out_array = cupy.zeros((N_WORKERS, 10), dtype='f')
         comm.all_gather(in_array, out_array, 10)
-        expected = 1 + cupy.arange(n_workers).reshape(n_workers, 1)
+        expected = 1 + cupy.arange(N_WORKERS).reshape(N_WORKERS, 1)
         expected = expected * cupy.broadcast_to(
-            cupy.arange(10, dtype='f'), (n_workers, 10))
+            cupy.arange(10, dtype='f'), (N_WORKERS, 10))
         testing.assert_allclose(out_array, expected)
 
-    _launch_workers(N_WORKERS, run_all_gather, (dtype,))
+    if use_mpi:
+        from mpi4py import MPI
+        # This process was run with mpiexec
+        run_all_gather(MPI.COMM_WORLD.Get_rank(), dtype, False)
+    else:
+        _launch_workers(run_all_gather, (dtype,))
 
 
-def send_and_recv(dtype):
+def send_and_recv(dtype, use_mpi=False):
     if dtype in 'hH':
         return  # nccl does not support int16
 
-    def run_send_and_recv(rank, n_workers, dtype):
+    def run_send_and_recv(rank, dtype, force_store=True):
         dev = cuda.Device(rank)
         dev.use()
-        comm = NCCLBackend(n_workers, rank)
+        comm = NCCLBackend(N_WORKERS, rank, force_store=force_store)
         in_array = cupy.arange(10, dtype='f')
         out_array = cupy.zeros((10,), dtype='f')
         if rank == 0:
@@ -139,91 +166,118 @@ def send_and_recv(dtype):
             comm.recv(out_array, 0)
             testing.assert_allclose(out_array, in_array)
 
-    _launch_workers(N_WORKERS, run_send_and_recv, (dtype,))
+    if use_mpi:
+        from mpi4py import MPI
+        # This process was run with mpiexec
+        run_send_and_recv(MPI.COMM_WORLD.Get_rank(), dtype, False)
+    else:
+        _launch_workers(run_send_and_recv, (dtype,))
 
 
-def send_recv(dtype):
+def send_recv(dtype, use_mpi=False):
     if dtype in 'hH':
         return  # nccl does not support int16
 
-    def run_send_recv(rank, n_workers, dtype):
+    def run_send_recv(rank, dtype, force_store=True):
         dev = cuda.Device(rank)
         dev.use()
-        comm = NCCLBackend(n_workers, rank)
+        comm = NCCLBackend(N_WORKERS, rank, force_store=force_store)
         in_array = cupy.arange(10, dtype='f')
-        for i in range(n_workers):
+        for i in range(N_WORKERS):
             out_array = cupy.zeros((10,), dtype='f')
             comm.send_recv(in_array, out_array, i)
             testing.assert_allclose(out_array, in_array)
 
-    _launch_workers(N_WORKERS, run_send_recv, (dtype,))
+    if use_mpi:
+        from mpi4py import MPI
+        # This process was run with mpiexec
+        run_send_recv(MPI.COMM_WORLD.Get_rank(), dtype, False)
+    else:
+        _launch_workers(run_send_recv, (dtype,))
 
 
-def scatter(dtype):
+def scatter(dtype, use_mpi=False):
     if dtype in 'hH':
         return  # nccl does not support int16
 
-    def run_scatter(rank, n_workers, root, dtype):
+    def run_scatter(rank, root, dtype, force_store=True):
         dev = cuda.Device(rank)
         dev.use()
-        comm = NCCLBackend(n_workers, rank)
+        comm = NCCLBackend(N_WORKERS, rank, force_store=force_store)
         in_array = 1 + cupy.arange(
-            n_workers * 10, dtype='f').reshape(n_workers, 10)
+            N_WORKERS * 10, dtype='f').reshape(N_WORKERS, 10)
         out_array = cupy.zeros((10,), dtype='f')
 
         comm.scatter(in_array, out_array, root)
         if rank > 0:
             testing.assert_allclose(out_array, in_array[rank])
 
-    _launch_workers(N_WORKERS, run_scatter, (0, dtype))
-    _launch_workers(N_WORKERS, run_scatter, (1, dtype))
+    if use_mpi:
+        from mpi4py import MPI
+        # This process was run with mpiexec
+        run_scatter(MPI.COMM_WORLD.Get_rank(), 0, dtype, False)
+        run_scatter(MPI.COMM_WORLD.Get_rank(), 1, dtype, False)
+    else:
+        _launch_workers(run_scatter, (0, dtype))
+        _launch_workers(run_scatter, (1, dtype))
 
 
-def gather(dtype):
+def gather(dtype, use_mpi=False):
     if dtype in 'hH':
         return  # nccl does not support int16
 
-    def run_gather(rank, n_workers, root, dtype):
+    def run_gather(rank, root, dtype, force_store=True):
         dev = cuda.Device(rank)
         dev.use()
-        comm = NCCLBackend(n_workers, rank)
+        comm = NCCLBackend(N_WORKERS, rank, force_store=force_store)
         in_array = (rank + 1) * cupy.arange(10, dtype='f')
-        out_array = cupy.zeros((n_workers, 10), dtype='f')
+        out_array = cupy.zeros((N_WORKERS, 10), dtype='f')
         comm.gather(in_array, out_array, root)
         if rank == root:
-            expected = 1 + cupy.arange(n_workers).reshape(n_workers, 1)
+            expected = 1 + cupy.arange(N_WORKERS).reshape(N_WORKERS, 1)
             expected = expected * cupy.broadcast_to(
-                cupy.arange(10, dtype='f'), (n_workers, 10))
+                cupy.arange(10, dtype='f'), (N_WORKERS, 10))
             testing.assert_allclose(out_array, expected)
 
-    _launch_workers(N_WORKERS, run_gather, (0, dtype))
-    _launch_workers(N_WORKERS, run_gather, (1, dtype))
+    if use_mpi:
+        from mpi4py import MPI
+        # This process was run with mpiexec
+        run_gather(MPI.COMM_WORLD.Get_rank(), 0, dtype, False)
+        run_gather(MPI.COMM_WORLD.Get_rank(), 1, dtype, False)
+    else:
+        _launch_workers(run_gather, (0, dtype))
+        _launch_workers(run_gather, (1, dtype))
 
 
-def all_to_all(dtype):
+def all_to_all(dtype, use_mpi=False):
     if dtype in 'hH':
         return  # nccl does not support int16
 
-    def run_all_to_all(rank, n_workers, dtype):
+    def run_all_to_all(rank, dtype, force_store=True):
         dev = cuda.Device(rank)
         dev.use()
-        comm = NCCLBackend(n_workers, rank)
+        comm = NCCLBackend(N_WORKERS, rank, force_store=force_store)
         in_array = cupy.arange(
-            n_workers * 10, dtype='f').reshape(n_workers, 10)
-        out_array = cupy.zeros((n_workers, 10), dtype='f')
+            N_WORKERS * 10, dtype='f').reshape(N_WORKERS, 10)
+        out_array = cupy.zeros((N_WORKERS, 10), dtype='f')
         comm.all_to_all(in_array, out_array)
         expected = (10 * rank) + cupy.broadcast_to(
-            cupy.arange(10, dtype='f'), (n_workers, 10))
+            cupy.arange(10, dtype='f'), (N_WORKERS, 10))
         testing.assert_allclose(out_array, expected)
 
-    _launch_workers(N_WORKERS, run_all_to_all, (dtype,))
+    if use_mpi:
+        from mpi4py import MPI
+        # This process was run with mpiexec
+        run_all_to_all(MPI.COMM_WORLD.Get_rank(), dtype, False)
+    else:
+        _launch_workers(run_all_to_all, (dtype,))
 
 
-def barrier():
-    def run_barrier(rank, n_workers):
+def barrier(use_mpi=False):
+    def run_barrier(rank, force_store=True):
         dev = cuda.Device(rank)
         dev.use()
-        comm = NCCLBackend(n_workers, rank)
+        comm = NCCLBackend(N_WORKERS, rank, force_store=force_store)
         comm.barrier()
         before = time.time()
         if rank == 0:
@@ -232,14 +286,19 @@ def barrier():
         after = time.time()
         assert int(after - before) == 2
 
-    _launch_workers(N_WORKERS, run_barrier)
+    if use_mpi:
+        from mpi4py import MPI
+        # This process was run with mpiexec
+        run_barrier(MPI.COMM_WORLD.Get_rank(), False)
+    else:
+        _launch_workers(run_barrier)
 
 
-def init():
-    def run_init(rank, n_workers):
+def init(use_mpi=False):
+    def run_init(rank, force_store=True):
         dev = cuda.Device(rank)
         dev.use()
-        comm = init_process_group(n_workers, rank)
+        comm = init_process_group(N_WORKERS, rank, force_store=force_store)
         # Do a simple call to verify we got a valid comm
         in_array = cupy.zeros(1)
         if rank == 0:
@@ -247,15 +306,22 @@ def init():
         comm.broadcast(in_array, 0)
         testing.assert_allclose(in_array, cupy.ones(1))
 
-    _launch_workers(N_WORKERS, run_init)
+    if use_mpi:
+        from mpi4py import MPI
+        # This process was run with mpiexec
+        run_init(MPI.COMM_WORLD.Get_rank(), dtype, False)
+        run_init(MPI.COMM_WORLD.Get_rank(), dtype, False)
+    else:
+        _launch_workers(run_init)
 
 
 if __name__ == '__main__':
     # Run the templatized test
     func = globals()[sys.argv[1]]
     # dtype is the char representation
-    dtype = sys.argv[2] if len(sys.argv) == 3 else None
+    use_mpi = True if sys.argv[2] == "mpi" else False
+    dtype = sys.argv[3] if len(sys.argv) == 4 else None
     if dtype is not None:
-        func(dtype)
+        func(dtype, use_mpi)
     else:
-        func()
+        func(use_mpi)


### PR DESCRIPTION
This is needed by #6228
We will use MPI to efficiently exchange the sizes of sparse matrices because doing it with NCCL causes device synchronization and the TCP store will kill performance when used heavily.