### PR TITLE
JIT: Support `.shape` and `.strides`

### DIFF
--- a/cupy/_core/include/cupy/carray.cuh
+++ b/cupy/_core/include/cupy/carray.cuh
@@ -326,6 +326,16 @@ public:
     return strides_;
   }
 
+#ifdef CUPY_JIT_MODE
+  __device__ typename cupy::as_tuple<_ndim>::type get_shape() const {
+    return cupy::as_tuple<_ndim>::call(shape_);
+  }
+
+  __device__ typename cupy::as_tuple<_ndim>::type get_strides() const {
+    return cupy::as_tuple<_ndim>::call(strides_);
+  }
+#endif  // CUPY_JIT_MODE
+
 #if __cplusplus >= 201103 || (defined(_MSC_VER) && _MSC_VER >= 1900)
   template <typename Int>
   __device__ T& operator[](const std::initializer_list<Int> idx_) {

--- a/cupy/_core/include/cupy/carray.cuh
+++ b/cupy/_core/include/cupy/carray.cuh
@@ -327,12 +327,12 @@ public:
   }
 
 #ifdef CUPY_JIT_MODE
-  __device__ typename cupy::as_tuple<_ndim>::type get_shape() const {
-    return cupy::as_tuple<_ndim>::call(shape_);
+  __device__ typename cupy::as_tuple<_ndim, ptrdiff_t>::type get_shape() const {
+    return cupy::as_tuple<_ndim, ptrdiff_t>::call(shape_);
   }
 
-  __device__ typename cupy::as_tuple<_ndim>::type get_strides() const {
-    return cupy::as_tuple<_ndim>::call(strides_);
+  __device__ typename cupy::as_tuple<_ndim, ptrdiff_t>::type get_strides() const {
+    return cupy::as_tuple<_ndim, ptrdiff_t>::call(strides_);
   }
 #endif  // CUPY_JIT_MODE
 

--- a/cupy/_core/include/cupy/tuple/tuple.h
+++ b/cupy/_core/include/cupy/tuple/tuple.h
@@ -961,25 +961,41 @@ inline bool operator>=(const detail::cons<T1, T2>& lhs, const detail::cons<S1, S
 
 namespace cupy {
 
-template <int ndim, typename... Args>
+/*
+ * param ndim: the size of the returned tuple
+ * param T: the type of the tuple elements
+ */
+template<int ndim, typename T>
 struct as_tuple {
-    using ChildClass = as_tuple<ndim - 1, ptrdiff_t, Args...>;
-    using type = typename ChildClass::type;
 
-    template <typename Ints>
+    template <int _ndim, typename... Args>
+    struct as_tuple_impl {
+        using ChildClass = as_tuple_impl<_ndim - 1, T, Args...>;
+        using type = typename ChildClass::type;
+
+        template <typename Ints>
+        __device__ static type call(Ints ints, Args... args) {
+            return ChildClass::call(ints, ints[_ndim - 1], args...);
+        }
+    };
+
+    template <typename... Args>
+    struct as_tuple_impl<0, Args...> {
+        using type = thrust::tuple<Args...>;
+
+        template <typename Ints>
+        __device__ static type call(Ints ints, Args... args) {
+            return thrust::make_tuple(args...);
+        }
+    };
+
+    using type = typename as_tuple_impl<ndim>::type;
+
+    template <typename Ints, typename... Args>
     __device__ static type call(Ints ints, Args... args) {
-        return ChildClass::call(ints, ints[ndim - 1], args...);
+        return as_tuple_impl<ndim>::call(ints, args...);
     }
-};
 
-template <typename... Args>
-struct as_tuple<0, Args...> {
-    using type = thrust::tuple<Args...>;
-
-    template <typename Ints>
-    __device__ static type call(Ints ints, Args... args) {
-        return thrust::make_tuple(args...);
-    }
 };
 
 }  // namespace cupy

--- a/cupy/_core/include/cupy/tuple/tuple.h
+++ b/cupy/_core/include/cupy/tuple/tuple.h
@@ -959,3 +959,27 @@ inline bool operator>=(const detail::cons<T1, T2>& lhs, const detail::cons<S1, S
 
 } // end thrust
 
+namespace cupy {
+
+template <int ndim, typename... Args>
+struct as_tuple {
+    using ChildClass = as_tuple<ndim - 1, ptrdiff_t, Args...>;
+    using type = typename ChildClass::type;
+
+    template <typename Ints>
+    __device__ static type call(Ints ints, Args... args) {
+        return ChildClass::call(ints, ints[ndim - 1], args...);
+    }
+};
+
+template <typename... Args>
+struct as_tuple<0, Args...> {
+    using type = thrust::tuple<Args...>;
+
+    template <typename Ints>
+    __device__ static type call(Ints ints, Args... args) {
+        return thrust::make_tuple(args...);
+    }
+};
+
+}  // namespace cupy

--- a/cupy/_core/include/cupy/tuple/tuple.h
+++ b/cupy/_core/include/cupy/tuple/tuple.h
@@ -959,6 +959,7 @@ inline bool operator>=(const detail::cons<T1, T2>& lhs, const detail::cons<S1, S
 
 } // end thrust
 
+#ifdef CUPY_JIT_MODE
 namespace cupy {
 
 /*
@@ -999,3 +1000,4 @@ struct as_tuple {
 };
 
 }  // namespace cupy
+#endif  // CUPY_JIT_MODE

--- a/cupy/_functional/vectorize.py
+++ b/cupy/_functional/vectorize.py
@@ -96,7 +96,8 @@ class vectorize(object):
             # defined regardless if CUPY_JIT_MODE is defined or not
             kern = _core.ElementwiseKernel(
                 in_params, out_params, body, 'cupy_vectorize',
-                preamble=result.code, options=('-DCUPY_JIT_MODE',))
+                preamble=result.code, options=('-DCUPY_JIT_MODE', '-std=c++11')
+                )
             self._kernel_cache[itypes] = kern
 
         return kern(*args)

--- a/cupy/_functional/vectorize.py
+++ b/cupy/_functional/vectorize.py
@@ -96,8 +96,9 @@ class vectorize(object):
             # defined regardless if CUPY_JIT_MODE is defined or not
             kern = _core.ElementwiseKernel(
                 in_params, out_params, body, 'cupy_vectorize',
-                preamble=result.code, options=('-DCUPY_JIT_MODE', '-std=c++11')
-                )
+                preamble=result.code,
+                options=('-DCUPY_JIT_MODE', '-std=c++11')
+            )
             self._kernel_cache[itypes] = kern
 
         return kern(*args)

--- a/cupyx/jit/_compile.py
+++ b/cupyx/jit/_compile.py
@@ -772,7 +772,8 @@ def _indexing(array, index, env):
     if isinstance(array.ctype, _cuda_types.Tuple):
         if is_constants(index):
             i = index.obj
-            return Data(f'thrust::get<{i}>({array.code})', array.types[i])
+            t = array.ctype.types[i]
+            return Data(f'thrust::get<{i}>({array.code})', t)
         raise TypeError('Tuple is not subscriptable with non-constants.')
 
     if isinstance(array.ctype, _cuda_types.ArrayBase):

--- a/cupyx/jit/_compile.py
+++ b/cupyx/jit/_compile.py
@@ -691,6 +691,12 @@ def _transpile_expr_internal(expr, env):
                 return Data(f'static_cast<long long>({value.code}.size())',
                             _cuda_types.Scalar('q'))
             if expr.attr in ('shape', 'strides'):
+                # this guard is needed to avoid NVRTC from throwing an
+                # obsecure error
+                if value.ctype.ndim > 10:
+                    raise NotImplementedError(
+                        'getting shape/strides for an array with ndim > 10 '
+                        'is not supported yet')
                 types = [_cuda_types.PtrDiff()]*value.ctype.ndim
                 return Data(f'{value.code}.get_{expr.attr}()',
                             _cuda_types.Tuple(types))

--- a/cupyx/jit/_compile.py
+++ b/cupyx/jit/_compile.py
@@ -686,6 +686,10 @@ def _transpile_expr_internal(expr, env):
             if 'size' == expr.attr:
                 return Data(f'static_cast<long long>({value.code}.size())',
                             _cuda_types.Scalar('q'))
+            if expr.attr in ('shape', 'strides'):
+                types = [_cuda_types.PtrDiff()]*value.ctype.ndim
+                return Data(f'{value.code}.get_{expr.attr}()',
+                            _cuda_types.Tuple(types))
         if isinstance(value.ctype, _interface._Dim3):
             if expr.attr in ('x', 'y', 'z'):
                 return Data(f'{value.code}.{expr.attr}', _cuda_types.uint32)

--- a/cupyx/jit/_cuda_types.py
+++ b/cupyx/jit/_cuda_types.py
@@ -46,11 +46,11 @@ class Scalar(TypeBase):
 
 
 class PtrDiff(Scalar):
-     def __init__(self):
-         super().__init__('q')
+    def __init__(self):
+        super().__init__('q')
 
-     def __str__(self):
-         return 'ptrdiff_t'
+    def __str__(self):
+        return 'ptrdiff_t'
 
 
 class ArrayBase(TypeBase):

--- a/cupyx/jit/_cuda_types.py
+++ b/cupyx/jit/_cuda_types.py
@@ -45,6 +45,14 @@ class Scalar(TypeBase):
         return hash(self.dtype)
 
 
+class PtrDiff(Scalar):
+     def __init__(self):
+         super().__init__('q')
+
+     def __str__(self):
+         return 'ptrdiff_t'
+
+
 class ArrayBase(TypeBase):
 
     def __init__(self, child_type: TypeBase, ndim: int):

--- a/tests/cupyx_tests/jit_tests/test_raw.py
+++ b/tests/cupyx_tests/jit_tests/test_raw.py
@@ -647,6 +647,26 @@ class TestRaw(unittest.TestCase):
         f((1,), (1,), (x,))
         assert x == N
 
+    @testing.for_CF_orders()
+    def test_shape_strides(self, order):
+        @jit.rawkernel()
+        def f(arr):
+            x = jit.grid(1)
+            if x == 0:
+                shapes = arr.shape
+                strides = arr.strides
+                arr[0, 0, 0] = shapes[0]
+                arr[0, 0, 1] = shapes[1]
+                arr[0, 0, 2] = shapes[2]
+                arr[0, 0, 3] = strides[0]
+                arr[0, 0, 4] = strides[1]
+                arr[0, 0, 5] = strides[2]
+
+        a = cupy.zeros((3, 4, 6), order=order)
+        f[1, 1](a)
+        assert (a[0, 0, 0:3] == cupy.asarray(a.shape)).all()
+        assert (a[0, 0, 3:6] == cupy.asarray(a.strides)).all()
+
     @testing.multi_gpu(2)
     def test_device_cache(self):
         @jit.rawkernel()


### PR DESCRIPTION
Based on the discussion between @eternalphane and @asi1024 in #5293.

It'd take some effort to support arrays of `ndim>10` (due to a Thrust limitation, see https://github.com/cupy/cupy/pull/5293#issuecomment-1101766792), but at least with this PR we unblock the most common use cases.