### PR TITLE
Accelerate `bincount`, `histogram2d`, `histogramdd` with CUB

### DIFF
--- a/cupy/_statistics/histogram.py
+++ b/cupy/_statistics/histogram.py
@@ -555,7 +555,8 @@ def bincount(x, weights=None, minlength=None):
         for accelerator in _accelerator.get_routine_accelerators():
             # CUB uses int for bin counts
             # TODO(leofang): support >= 2^31 elements in x?
-            if (accelerator == _accelerator.ACCELERATOR_CUB
+            if (not runtime.is_hip
+                    and accelerator == _accelerator.ACCELERATOR_CUB
                     and x.size <= 0x7fffffff and size <= 0x7fffffff):
                 b = cub.device_histogram(x, b, size+1)
                 break

--- a/cupy/_statistics/histogram.py
+++ b/cupy/_statistics/histogram.py
@@ -545,7 +545,7 @@ def bincount(x, weights=None, minlength=None):
         if minlength < 0:
             raise ValueError('minlength must be non-negative')
 
-    size = int(cupy.max(x)) + 1
+    size = int(cupy.max(x)) + 1  # synchronize!
     if minlength is not None:
         size = max(size, minlength)
 

--- a/cupy/cuda/cub.pyx
+++ b/cupy/cuda/cub.pyx
@@ -368,11 +368,11 @@ def device_histogram(ndarray x, ndarray y, bins):
         bins = _internal_ascontiguousarray(bins)
         bins_ptr = <void*><intptr_t>bins.data.ptr
         n_bins = bins.size
-        assert y.size == n_bins - 1
         is_even = False
     else:
         n_bins = bins
         is_even = True
+    assert y.size == n_bins - 1
 
     x_ptr = <void*>x.data.ptr
     y_ptr = <void*>y.data.ptr
@@ -382,7 +382,7 @@ def device_histogram(ndarray x, ndarray y, bins):
 
     if is_even:
         ws_size = cub_device_histogram_even_get_workspace_size(
-            x_ptr, y_ptr, n_bins, 0, n_bins, n_samples, s, dtype_id)
+            x_ptr, y_ptr, n_bins, 0, n_bins-1, n_samples, s, dtype_id)
     else:
         ws_size = cub_device_histogram_range_get_workspace_size(
             x_ptr, y_ptr, n_bins, bins_ptr, n_samples, s, dtype_id)
@@ -392,7 +392,7 @@ def device_histogram(ndarray x, ndarray y, bins):
     with nogil:
         if is_even:
             cub_device_histogram_even(
-                ws_ptr, ws_size, x_ptr, y_ptr, n_bins, 0, n_bins,
+                ws_ptr, ws_size, x_ptr, y_ptr, n_bins, 0, n_bins-1,
                 n_samples, s, dtype_id)
         else:
             cub_device_histogram_range(

--- a/cupy/cuda/cub.pyx
+++ b/cupy/cuda/cub.pyx
@@ -374,6 +374,8 @@ def device_histogram(ndarray x, ndarray y, bins):
         is_even = True
         if runtime._is_hip_environment:
             raise RuntimeError("not supported yet")
+        if x.dtype.kind not in 'bui':
+            raise ValueError("only integer input is supported")
     assert y.size == n_bins - 1
 
     x_ptr = <void*>x.data.ptr

--- a/cupy/cuda/cub.pyx
+++ b/cupy/cuda/cub.pyx
@@ -3,6 +3,7 @@
 """Wrapper of CUB functions for CuPy API."""
 
 from cpython cimport sequence
+from libc.stdint cimport intptr_t
 
 from cupy_backends.cuda.api cimport runtime
 from cupy._core.core cimport _internal_ascontiguousarray
@@ -58,6 +59,8 @@ cdef extern from 'cupy_cub.h' nogil:
     void cub_device_scan(void*, size_t&, void*, void*, int, Stream_t, int, int)
     void cub_device_histogram_range(void*, size_t&, void*, void*, int, void*,
                                     size_t, Stream_t, int)
+    void cub_device_histogram_even(void*, size_t&, void*, void*, int, int, int,
+                                   size_t, Stream_t, int)
     size_t cub_device_reduce_get_workspace_size(void*, void*, int, Stream_t,
                                                 int, int)
     size_t cub_device_segmented_reduce_get_workspace_size(
@@ -68,6 +71,8 @@ cdef extern from 'cupy_cub.h' nogil:
         void*, void*, int, Stream_t, int, int)
     size_t cub_device_histogram_range_get_workspace_size(
         void*, void*, int, void*, size_t, Stream_t, int)
+    size_t cub_device_histogram_even_get_workspace_size(
+        void*, void*, int, int, int, size_t, Stream_t, int)
 
     # Build-time version
     int CUPY_CUB_VERSION_CODE
@@ -345,7 +350,7 @@ def device_scan(ndarray x, op):
     return x
 
 
-def device_histogram(ndarray x, ndarray bins, ndarray y):
+def device_histogram(ndarray x, ndarray y, bins):
     cdef memory.MemoryPointer ws
     cdef size_t ws_size, n_samples
     cdef int dtype_id, n_bins
@@ -354,28 +359,45 @@ def device_histogram(ndarray x, ndarray bins, ndarray y):
     cdef void* y_ptr
     cdef void* ws_ptr
     cdef Stream_t s
+    cdef bint is_even
 
     # TODO(leofang): perhaps not needed?
     # y is guaranteed contiguous
     x = _internal_ascontiguousarray(x)
-    bins = _internal_ascontiguousarray(bins)
+    if isinstance(bins, ndarray):
+        bins = _internal_ascontiguousarray(bins)
+        bins_ptr = <void*><intptr_t>bins.data.ptr
+        n_bins = bins.size
+        assert y.size == n_bins - 1
+        is_even = False
+    else:
+        n_bins = bins
+        is_even = True
 
     x_ptr = <void*>x.data.ptr
     y_ptr = <void*>y.data.ptr
-    n_bins = bins.size
-    bins_ptr = <void*>bins.data.ptr
     n_samples = x.size
     s = <Stream_t>stream.get_current_stream_ptr()
     dtype_id = common._get_dtype_id(x.dtype)
-    assert y.size == n_bins - 1
-    ws_size = cub_device_histogram_range_get_workspace_size(
-        x_ptr, y_ptr, n_bins, bins_ptr, n_samples, s, dtype_id)
 
+    if is_even:
+        ws_size = cub_device_histogram_even_get_workspace_size(
+            x_ptr, y_ptr, n_bins, 0, n_bins, n_samples, s, dtype_id)
+    else:
+        ws_size = cub_device_histogram_range_get_workspace_size(
+            x_ptr, y_ptr, n_bins, bins_ptr, n_samples, s, dtype_id)
     ws = memory.alloc(ws_size)
     ws_ptr = <void*>ws.ptr
+
     with nogil:
-        cub_device_histogram_range(ws_ptr, ws_size, x_ptr, y_ptr, n_bins,
-                                   bins_ptr, n_samples, s, dtype_id)
+        if is_even:
+            cub_device_histogram_even(
+                ws_ptr, ws_size, x_ptr, y_ptr, n_bins, 0, n_bins,
+                n_samples, s, dtype_id)
+        else:
+            cub_device_histogram_range(
+                ws_ptr, ws_size, x_ptr, y_ptr, n_bins,
+                bins_ptr, n_samples, s, dtype_id)
     return y
 
 

--- a/cupy/cuda/cub.pyx
+++ b/cupy/cuda/cub.pyx
@@ -372,6 +372,8 @@ def device_histogram(ndarray x, ndarray y, bins):
     else:
         n_bins = bins
         is_even = True
+        if runtime._is_hip_environment:
+            raise RuntimeError("not supported yet")
     assert y.size == n_bins - 1
 
     x_ptr = <void*>x.data.ptr

--- a/cupy/cuda/cupy_cub.cu
+++ b/cupy/cuda/cupy_cub.cu
@@ -895,9 +895,10 @@ size_t cub_device_histogram_range_get_workspace_size(void* x, void* y, int n_bin
 void cub_device_histogram_even(void* workspace, size_t& workspace_size, void* x, void* y,
     int n_bins, int lower, int upper, size_t n_samples, cudaStream_t stream, int dtype_id)
 {
-    // TODO(leofang): n_samples is of type size_t, but if it's < 2^31 we cast it to int later
+    #ifndef CUPY_USE_HIP
     return dtype_dispatcher(dtype_id, _cub_histogram_even(),
                             workspace, workspace_size, x, y, n_bins, lower, upper, n_samples, stream);
+    #endif
 }
 
 size_t cub_device_histogram_even_get_workspace_size(void* x, void* y, int n_bins,

--- a/cupy/cuda/cupy_cub.h
+++ b/cupy/cuda/cupy_cub.h
@@ -30,11 +30,13 @@ void cub_device_segmented_reduce(void*, size_t&, void*, void*, int, int, cudaStr
 void cub_device_spmv(void*, size_t&, void*, void*, void*, void*, void*, int, int, int, cudaStream_t, int);
 void cub_device_scan(void*, size_t&, void*, void*, int, cudaStream_t, int, int);
 void cub_device_histogram_range(void*, size_t&, void*, void*, int, void*, size_t, cudaStream_t, int);
+void cub_device_histogram_even(void*, size_t&, void*, void*, int, int, int, size_t, cudaStream_t, int);
 size_t cub_device_reduce_get_workspace_size(void*, void*, int, cudaStream_t, int, int);
 size_t cub_device_segmented_reduce_get_workspace_size(void*, void*, int, int, cudaStream_t, int, int);
 size_t cub_device_spmv_get_workspace_size(void*, void*, void*, void*, void*, int, int, int, cudaStream_t, int);
 size_t cub_device_scan_get_workspace_size(void*, void*, int, cudaStream_t, int, int);
 size_t cub_device_histogram_range_get_workspace_size(void*, void*, int, void*, size_t, cudaStream_t, int);
+size_t cub_device_histogram_even_get_workspace_size(void*, void*, int, int, int, size_t, cudaStream_t, int);
 
 // This is for CUB's HistogramRange; hipCUB does not need this (see comment in cupy_cub.cu)
 #ifdef __CUDA_ARCH__
@@ -63,6 +65,9 @@ void cub_device_scan(...) {
 void cub_device_histogram_range(...) {
 }
 
+void cub_device_histogram_even(...) {
+}
+
 size_t cub_device_reduce_get_workspace_size(...) {
     return 0;
 }
@@ -80,6 +85,10 @@ size_t cub_device_scan_get_workspace_size(...) {
 }
 
 size_t cub_device_histogram_range_get_workspace_size(...) {
+    return 0;
+}
+
+size_t cub_device_histogram_even_get_workspace_size(...) {
     return 0;
 }
 


### PR DESCRIPTION
This PR accelerates all histogram related operations. The key insight is `bincount` is internally used to support multi-dimensional histograms (`histogram2d` and `histogramdd`), so if no weighting is required they can all be accelerated using CUB. 

Under the hood, we use CUB's `HistogramEven` instead of `HistogramRange`, as the former does not require constructing an extra `bins` array.

* `cupy.bincount()`:

(Here we also compare the timing of `cupy.histogram()` to show the benefit of not constructing a `bins` array, as for 1D integer inputs the result of the two APIs are identical.)

GPU elapsed time (us) | without CUB | with CUB | speedup | histogram (with CUB)
-----|-----|-----|-----|-----
size=100 | 96.36800214648247  | 118.18240210413933  | 0.8154175277429666  | 198.46399873495102
size=1000 | 97.90400192141533  | 120.51840275526047  | 0.8123572805742478  | 199.99359846115112
size=10000 | 97.59360253810883  | 129.33760136365888  | 0.7545648095305605  | 215.53920060396194
size=100000 | 193.79840195178988  | 130.36480098962784  | 1.4865853396056576  | 216.89600199460983
size=1000000 | 1473.8304138183594  | 152.9728040099144  | 9.634591085372524  | 252.87359803915024
size=10000000 | 16550.16632080078  | 510.9504044055939  | 32.39094475334481  | 672.3680019378662
size=100000000 | 160673.51531982422  | 4273.424053192139  | 37.59830836347851  | 4860.195207595825
size=1000000000 | 1623228.3813476562  | 42328.556823730476  | 38.34830438720823  | 46743.06869506836

* `cupy.histogram2d()`:

 GPU elapsed time (us) | without CUB | with CUB | speedup
-----|-----|-----|-----
shape=(100, 2) | 934.396803379059  | 913.814401626587  | 1.0225236127990929
shape=(1000, 2) | 937.7823948860167  | 976.0864019393922  | 0.9607575651322783
shape=(10000, 2) | 991.2000000476837  | 1032.803201675415  | 0.9597181713222398
shape=(100000, 2) | 1177.3823976516726  | 1157.2927951812744  | 1.0173591355221834
shape=(1000000, 2) | 5112.409543991089  | 3885.055994987488  | 1.3159165660899448
shape=(10000000, 2) | 46488.457107543945  | 31364.92462158204  | 1.482179781026972
shape=(100000000, 2) | 459340.2465820312  | 308182.36083984375  | 1.4904819514337526

* `cupy.histogramdd()`:

(Using a 3D histogram as an example)

 GPU elapsed time (us) | without CUB | with CUB | speedup
-----|-----|-----|-----
shape=(100, 3) | 1193.2639956474304  | 1229.7056078910828  | 0.9703655801764222
shape=(1000, 3) | 1294.3391919136045  | 1331.2928080558777  | 0.9722423076886915
shape=(10000, 3) | 1292.953610420227  | 1332.8224062919617  | 0.9700869405529778
shape=(100000, 3) | 1613.651192188263  | 1601.974391937256  | 1.0072890055607482
shape=(1000000, 3) | 6862.847948074342  | 5752.640056610107  | 1.1929910233456278
shape=(10000000, 3) | 61017.379379272454  | 48613.85307312012  | 1.2551438637767753
shape=(100000000, 3) | 612207.4829101562  | 488465.4846191406  | 1.2533280286681832

* Benchmark script:
<details><summary>Click to unfold</summary>
<p>

```python
import cupy as cp
from cupyx.profiler import benchmark

rand_max = 30
n_warmup = 3
n_repeat = 10

print(' GPU elapsed time (us) | without CUB | with CUB | speedup | histogram (with CUB)')
print('-----|-----|-----|-----|-----')
for size in range(2, 10):
    size = 10**size
    a = cp.random.randint(rand_max, size=size)
    print(f"size={size} | ", end='')

    cp._core.set_routine_accelerators([])
    cp._core.set_reduction_accelerators([])
    result = benchmark(cp.bincount, (a,), n_warmup=n_warmup, n_repeat=n_repeat)
    result_old = cp.average(result.gpu_times[0])
    print(10**6 * result_old, ' | ', end='')

    cp._core.set_routine_accelerators(['cub'])
    cp._core.set_reduction_accelerators(['cub'])
    result = benchmark(cp.bincount, (a,), n_warmup=n_warmup, n_repeat=n_repeat)
    result_new = cp.average(result.gpu_times[0])
    print(10**6 * result_new, ' | ', end='')

    print(result_old/result_new, ' | ', end='')

    result = benchmark(cp.histogram, (a,), {'bins': rand_max}, n_warmup=n_warmup, n_repeat=n_repeat)
    print(10**6 * cp.average(result.gpu_times[0]))

    out1 = cp.bincount(a)
    out2, _ = cp.histogram(a, bins=rand_max)
    assert (out1 == out2).all(), f"out1={out1}, out2={out2}"

print(' GPU elapsed time (us) | without CUB | with CUB | speedup')
print('-----|-----|-----|-----')
for size in range(2, 9):
    size = 10**size
    x = cp.random.randint(rand_max, size=size)
    y = cp.random.randint(rand_max, size=size)
    print(f"shape={(size, 2)} | ", end='')

    cp._core.set_routine_accelerators([])
    cp._core.set_reduction_accelerators([])
    result = benchmark(cp.histogram2d, (x, y), n_warmup=n_warmup, n_repeat=n_repeat)
    result_old = cp.average(result.gpu_times[0])
    print(10**6 * result_old, ' | ', end='')

    cp._core.set_routine_accelerators(['cub'])
    cp._core.set_reduction_accelerators(['cub'])
    result = benchmark(cp.histogram2d, (x, y), n_warmup=n_warmup, n_repeat=n_repeat)
    result_new = cp.average(result.gpu_times[0])
    print(10**6 * result_new, ' | ', end='')

    print(result_old/result_new)

print(' GPU elapsed time (us) | without CUB | with CUB | speedup')
print('-----|-----|-----|-----')
for size in range(2, 10):
    size = 10**size
    x = cp.random.randint(rand_max, size=3*size).reshape(size, 3)
    print(f"shape={(size, 3)} | ", end='')

    cp._core.set_routine_accelerators([])
    cp._core.set_reduction_accelerators([])
    result = benchmark(cp.histogramdd, (x,), n_warmup=n_warmup, n_repeat=n_repeat)
    result_old = cp.average(result.gpu_times[0])
    print(10**6 * result_old, ' | ', end='')

    cp._core.set_routine_accelerators(['cub'])
    cp._core.set_reduction_accelerators(['cub'])
    result = benchmark(cp.histogramdd, (x,), n_warmup=n_warmup, n_repeat=n_repeat)
    result_new = cp.average(result.gpu_times[0])
    print(10**6 * result_new, ' | ', end='')

    print(result_old/result_new)
```

</p>
</details>