### PR TITLE
Document the returned benchmark object

### DIFF
--- a/cupyx/profiler/_time.py
+++ b/cupyx/profiler/_time.py
@@ -112,7 +112,8 @@ def benchmark(
             the timing test. If not given, the current device is used.
 
     Returns:
-        :class:`_PerfCaseResult`: an object collecting all test results.
+        :class:`~cupyx.profiler._time._PerfCaseResult`:
+            an object collecting all test results.
 
     """
 

--- a/cupyx/time.py
+++ b/cupyx/time.py
@@ -51,7 +51,8 @@ def repeat(
             the timing test. If not given, the current device is used.
 
     Returns:
-        :class:`_PerfCaseResult`: an object collecting all test results.
+        :class:`~cupyx.profiler._time._PerfCaseResult`:
+            an object collecting all test results.
 
     .. warning::
         This API is moved to :func:`cupyx.profiler.benchmark` since CuPy v10.

--- a/docs/source/reference/perf_result.rst
+++ b/docs/source/reference/perf_result.rst
@@ -1,0 +1,7 @@
+:orphan:
+
+Benchmark Data
+--------------
+
+.. autoclass:: cupyx.profiler._time._PerfCaseResult
+   :members:


### PR DESCRIPTION
Make it a bit easier to understand what to do with `cupyx.profiler.benchmark()`.