### PR TITLE
Ignore typing errors in `_compiler.py`

### DIFF
--- a/install/cupy_builder/_compiler.py
+++ b/install/cupy_builder/_compiler.py
@@ -130,8 +130,9 @@ class DeviceCompilerBase:
         incdirs = ext.include_dirs[:]  # type: ignore
         macros = ext.define_macros[:]  # type: ignore
         for undef in ext.undef_macros:  # type: ignore
-            macros.append((undef,))
-        return distutils.ccompiler.gen_preprocess_options(macros, incdirs)
+            macros.append((undef,))  # type: ignore
+        return distutils.ccompiler.gen_preprocess_options(
+            macros, incdirs)  # type: ignore
 
     def spawn(self, commands: List[str]) -> None:
         print('Command:', commands)


### PR DESCRIPTION
mypy was updated to 0.950 in the pretests (Seen in v10)
This caused the following errors to appear

```
cupy_builder/_compiler.py:133: error: Argument 1 to "append" of "list" has incompatible type "Tuple[str]"; expected "Tuple[str, Optional[str]]"  [arg-type]
cupy_builder/_compiler.py:134: error: Argument 1 to "gen_preprocess_options" has incompatible type "List[Tuple[str, Optional[str]]]"; expected "List[Union[Tuple[str], Tuple[str, Optional[str]]]]"  [arg-type]
```