### PR TITLE
Support cupy.ndarray subclassing - Part 1 - Direct constructor call

### DIFF
--- a/cupy/_core/__init__.py
+++ b/cupy/_core/__init__.py
@@ -69,7 +69,7 @@ from cupy._core.core import ascontiguousarray  # NOQA
 from cupy._core.core import asfortranarray  # NOQA
 from cupy._core.core import divmod  # NOQA
 from cupy._core.core import elementwise_copy  # NOQA
-from cupy._core.core import ndarray  # NOQA
+from cupy._core.core import _ndarray as ndarray  # NOQA
 from cupy._core.dlpack import fromDlpack  # NOQA
 from cupy._core.dlpack import from_dlpack  # NOQA
 from cupy._core.internal import complete_slice  # NOQA

--- a/cupy/_core/_fusion_trace.pyx
+++ b/cupy/_core/_fusion_trace.pyx
@@ -106,7 +106,7 @@ def _guess_routine(func, args, dtype):
             obj = x.dtype.type(0)
         else:
             assert isinstance(x, _TraceArray)
-            obj = core.ndarray((0,), x.dtype)
+            obj = core._ndarray((0,), x.dtype)
         dummy_args.append(obj)
 
     op = func._ops.guess_routine(

--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -182,7 +182,7 @@ cdef class _ArgInfo:
     @staticmethod
     cdef _ArgInfo from_arg(object arg):
         typ = type(arg)
-        if typ is ndarray:
+        if issubclass(typ, ndarray):
             return _ArgInfo.from_ndarray(arg)
         if typ is _scalar.CScalar:
             return _ArgInfo.from_scalar(arg)

--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -199,7 +199,7 @@ cdef class _ArgInfo:
         cdef _ArgInfo ret = _ArgInfo.__new__(_ArgInfo)
         ret._init(
             ARG_KIND_NDARRAY,
-            ndarray,  # TODO(takagi) investigate in detail!
+            type(arg),
             arg.dtype.type,
             arg._shape.size(),
             arg._c_contiguous,
@@ -270,7 +270,7 @@ cdef class _ArgInfo:
         if self.ndim == ndim:
             return self
         return _ArgInfo(
-            ARG_KIND_NDARRAY, ndarray, self.dtype, ndim, False, False)
+            ARG_KIND_NDARRAY, self.dtype, self.dtype, ndim, False, False)
 
     cdef bint is_ndarray(self):
         return self.arg_kind == ARG_KIND_NDARRAY

--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -199,7 +199,7 @@ cdef class _ArgInfo:
         cdef _ArgInfo ret = _ArgInfo.__new__(_ArgInfo)
         ret._init(
             ARG_KIND_NDARRAY,
-            ndarray,
+            ndarray,  # TODO(takagi) investigate in detail!
             arg.dtype.type,
             arg._shape.size(),
             arg._c_contiguous,

--- a/cupy/_core/_routines_indexing.pyx
+++ b/cupy/_core/_routines_indexing.pyx
@@ -6,6 +6,7 @@ import string
 import numpy
 
 import cupy
+import cupy._core.core as core
 from cupy._core._kernel import ElementwiseKernel
 from cupy._core._ufuncs import elementwise_copy
 
@@ -101,7 +102,7 @@ cpdef ndarray _ndarray_argwhere(ndarray self):
         count_nonzero = int(scan_index[-1])  # synchronize!
 
     ndim = self._shape.size()
-    dst = ndarray((count_nonzero, ndim), dtype=numpy_int64)
+    dst = core._ndarray((count_nonzero, ndim), dtype=numpy_int64)
     if dst.size == 0:
         return dst
 
@@ -183,7 +184,7 @@ cdef ndarray _ndarray_choose(ndarray self, choices, out, mode):
     ba, bcs = _manipulation.broadcast(a, choices).values
 
     if out is None:
-        out = ndarray(ba.shape[1:], choices.dtype)
+        out = core._ndarray(ba.shape[1:], choices.dtype)
 
     n_channel = numpy.prod(bcs[0].shape)
     if mode == 'raise':
@@ -787,7 +788,7 @@ cpdef ndarray _getitem_mask_single(ndarray a, ndarray mask, int axis):
 
     mask, mask_scanned, masked_shape = _prepare_mask_indexing_single(
         a, mask, axis)
-    out = ndarray(masked_shape, dtype=a.dtype)
+    out = core._ndarray(masked_shape, dtype=a.dtype)
     if out.size == 0:
         return out
     return _getitem_mask_kernel(a, mask, mask_scanned, out)
@@ -831,7 +832,7 @@ cdef ndarray _take(ndarray a, indices, int start, int stop, ndarray out=None):
             index_range *= a._shape[i]
 
     if out is None:
-        out = ndarray(out_shape, dtype=a.dtype)
+        out = core._ndarray(out_shape, dtype=a.dtype)
     else:
         if out.dtype != a.dtype:
             raise TypeError('Output dtype mismatch')
@@ -1036,7 +1037,7 @@ cdef ndarray _diagonal(
     diag_size = max(0, min(a.shape[-2], a.shape[-1] - offset))
     ret_shape = a.shape[:-2] + (diag_size,)
     if diag_size == 0:
-        return ndarray(ret_shape, dtype=a.dtype)
+        return core._ndarray(ret_shape, dtype=a.dtype)
 
     a = a[..., :diag_size, offset:offset + diag_size]
 
@@ -1079,7 +1080,7 @@ cdef tuple _prepare_multiple_array_indexing(
     # br = _manipulation.broadcast(*indices)
     # indices = list(br.values)
 
-    reduced_idx = ndarray(
+    reduced_idx = core._ndarray(
         internal._broadcast_shapes(shapes), dtype=numpy.int64)
     reduced_idx.fill(0)
     stride = 1

--- a/cupy/_core/_routines_linalg.pyx
+++ b/cupy/_core/_routines_linalg.pyx
@@ -9,6 +9,7 @@ import cupy
 from cupy._core._kernel import ElementwiseKernel
 from cupy._core._reduction import ReductionKernel
 from cupy._core._ufuncs import elementwise_copy
+import cupy._core.core as core
 
 
 from libc.stdint cimport intptr_t
@@ -692,12 +693,12 @@ cpdef ndarray _mat_ptrs(ndarray a):
     cdef ndarray idx
     idx = _mat_ptrs_kernel(
         a.data.ptr, a._strides[0],
-        ndarray((a._shape[0],), dtype=numpy.uintp))
+        core._ndarray((a._shape[0],), dtype=numpy.uintp))
 
     for i in range(1, ndim - 2):
         idx = _mat_ptrs_kernel(
             idx[:, None], a._strides[i],
-            ndarray((idx.size, a._shape[i]), dtype=numpy.uintp))
+            core._ndarray((idx.size, a._shape[i]), dtype=numpy.uintp))
         idx = idx.ravel()
     return idx
 
@@ -852,12 +853,12 @@ cpdef ndarray matmul(ndarray a, ndarray b, ndarray out=None):
     ):
         c = out
     else:
-        c = ndarray(out_shape, dtype=dtype)
+        c = core._ndarray(out_shape, dtype=dtype)
         if out is None:
             if dtype == ret_dtype:
                 out = c
             else:
-                out = ndarray(out_shape, dtype=ret_dtype)
+                out = core._ndarray(out_shape, dtype=ret_dtype)
 
     if orig_a_ndim == 1 or orig_b_ndim == 1:
         c_view = c.view()

--- a/cupy/_core/_routines_manipulation.pyx
+++ b/cupy/_core/_routines_manipulation.pyx
@@ -6,6 +6,7 @@ import numpy
 
 from cupy._core._kernel import ElementwiseKernel
 from cupy._core._ufuncs import elementwise_copy
+import cupy._core.core as core
 
 cimport cpython  # NOQA
 cimport cython  # NOQA
@@ -546,7 +547,7 @@ cpdef ndarray _repeat(ndarray a, repeats, axis=None):
     if axis is None:
         if broadcast:
             a = _reshape(a, (-1, 1))
-            ret = ndarray((a.size, repeats[0]), dtype=a.dtype)
+            ret = core._ndarray((a.size, repeats[0]), dtype=a.dtype)
             if ret.size:
                 elementwise_copy(a, ret)
             return ret.ravel()
@@ -565,7 +566,7 @@ cpdef ndarray _repeat(ndarray a, repeats, axis=None):
 
     ret_shape = list(a.shape)
     ret_shape[axis] = sum(repeats)
-    ret = ndarray(ret_shape, dtype=a.dtype)
+    ret = core._ndarray(ret_shape, dtype=a.dtype)
     a_index = [slice(None)] * len(ret_shape)
     ret_index = list(a_index)
     offset = 0
@@ -654,7 +655,7 @@ cpdef ndarray concatenate_method(tup, int axis, ndarray out=None, dtype=None,
     # Prpare the output array
     shape_t = tuple(shape0)
     if out is None:
-        out = ndarray(shape_t, dtype=dtype)
+        out = core._ndarray(shape_t, dtype=dtype)
     else:
         if len(out.shape) != len(shape_t):
             raise ValueError('Output array has wrong dimensionality')

--- a/cupy/_core/_routines_math.pyx
+++ b/cupy/_core/_routines_math.pyx
@@ -7,6 +7,7 @@ from cupy._core._reduction import create_reduction_func
 from cupy._core._kernel import create_ufunc
 from cupy._core._scalar import get_typename
 from cupy._core._ufuncs import elementwise_copy
+import cupy._core.core as core
 from cupy._core cimport internal
 from cupy import _util
 
@@ -41,10 +42,10 @@ cdef ndarray _ndarray_conj(ndarray self):
 
 cdef ndarray _ndarray_real_getter(ndarray self):
     if self.dtype.kind == 'c':
-        view = ndarray(
+        view = core._ndarray(
             shape=self._shape, dtype=get_dtype(self.dtype.char.lower()),
             memptr=self.data, strides=self._strides)
-        view.base = self.base if self.base is not None else self
+        (<ndarray>view).base = self.base if self.base is not None else self
         return view
     return self
 
@@ -64,12 +65,12 @@ cdef ndarray _ndarray_imag_getter(ndarray self):
         # aligning with NumPy behavior.
         if memptr.ptr != 0:
             memptr = memptr + self.dtype.itemsize // 2
-        view = ndarray(
+        view = core._ndarray(
             shape=self._shape, dtype=dtype, memptr=memptr,
             strides=self._strides)
-        view.base = self.base if self.base is not None else self
+        (<ndarray>view).base = self.base if self.base is not None else self
         return view
-    new_array = ndarray(self.shape, dtype=self.dtype)
+    new_array = core._ndarray(self.shape, dtype=self.dtype)
     new_array.fill(0)
     return new_array
 

--- a/cupy/_core/_routines_sorting.pyx
+++ b/cupy/_core/_routines_sorting.pyx
@@ -5,6 +5,7 @@ import numpy
 import cupy
 from cupy._core._scalar import get_typename as _get_typename
 from cupy._core._ufuncs import elementwise_copy
+import cupy._core.core as core
 from cupy import _util
 from cupy.cuda import thrust
 
@@ -43,7 +44,8 @@ cdef _ndarray_sort(ndarray self, int axis):
         thrust.sort(self.dtype, data.data.ptr, 0, self.shape)
     else:
         max_size = max(min(1 << 22, data.size) // data.shape[-1], 1)
-        keys_array = ndarray((max_size * data.shape[-1],), dtype=numpy.intp)
+        keys_array = core._ndarray(
+            (max_size * data.shape[-1],), dtype=numpy.intp)
         stop = data.size // data.shape[-1]
         for offset in range(0, stop, max_size):
             width = min(max_size, stop - offset)
@@ -88,13 +90,13 @@ cdef ndarray _ndarray_argsort(ndarray self, axis):
         data = _manipulation.rollaxis(data, _axis, ndim).copy()
     shape = data.shape
 
-    idx_array = ndarray(shape, dtype=numpy.intp)
+    idx_array = core._ndarray(shape, dtype=numpy.intp)
 
     if ndim == 1:
         thrust.argsort(self.dtype, idx_array.data.ptr, data.data.ptr, 0,
                        shape)
     else:
-        keys_array = ndarray(shape, dtype=numpy.intp)
+        keys_array = core._ndarray(shape, dtype=numpy.intp)
         thrust.argsort(self.dtype, idx_array.data.ptr, data.data.ptr,
                        keys_array.data.ptr, shape)
 

--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -1663,7 +1663,10 @@ cdef class ndarray:
             # avoid NumPy func
             return NotImplemented
         for t in types:
-            if t not in _HANDLED_TYPES:
+            for handled_type in _HANDLED_TYPES:
+                if issubclass(t, handled_type):
+                    break
+            else:
                 return NotImplemented
         return cupy_func(*args, **kwargs)
 

--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -2399,7 +2399,7 @@ cdef ndarray _array_from_nested_sequence(
     if concat_type is numpy.ndarray:
         return _array_from_nested_numpy_sequence(
             obj, concat_dtype, dtype, concat_shape, order, ndmin)
-    elif concat_type is ndarray:
+    elif concat_type is _ndarray:  # TODO(takagi) Consider subclases
         return _array_from_nested_cupy_sequence(
             obj, dtype, concat_shape, order)
     else:

--- a/cupy/_core/dlpack.pyx
+++ b/cupy/_core/dlpack.pyx
@@ -17,6 +17,7 @@ from cupy.cuda cimport memory
 import warnings
 
 import cupy
+import cupy._core.core as core
 
 
 cdef extern from './include/cupy/dlpack/dlpack.h' nogil:
@@ -317,7 +318,7 @@ cdef inline ndarray _dlpack_to_cupy_array(dltensor) except +:
     if mem.dlm_tensor.dl_tensor.strides is NULL:
         # Make sure this capsule will never be used again.
         cpython.PyCapsule_SetName(mem.dltensor, 'used_dltensor')
-        return ndarray(shape_vec, cp_dtype, mem_ptr, strides=None)
+        return core._ndarray(shape_vec, cp_dtype, mem_ptr, strides=None)
     cdef int64_t* strides = mem.dlm_tensor.dl_tensor.strides
     cdef vector[Py_ssize_t] strides_vec
     for i in range(ndim):
@@ -325,7 +326,7 @@ cdef inline ndarray _dlpack_to_cupy_array(dltensor) except +:
 
     # Make sure this capsule will never be used again.
     cpython.PyCapsule_SetName(mem.dltensor, 'used_dltensor')
-    return ndarray(shape_vec, cp_dtype, mem_ptr, strides=strides_vec)
+    return core._ndarray(shape_vec, cp_dtype, mem_ptr, strides=strides_vec)
 
 
 # TODO(leofang): this function is exposed to the cupy namespace, so it returns

--- a/cupy/cuda/cub.pyx
+++ b/cupy/cuda/cub.pyx
@@ -14,6 +14,7 @@ from cupy.cuda cimport memory
 from cupy.cuda cimport stream
 
 import cupy
+import cupy._core as _core
 import numpy
 
 
@@ -160,11 +161,11 @@ def device_reduce(ndarray x, op, tuple out_axis, out=None,
     x = _internal_ascontiguousarray(x)
 
     if op in (CUPY_CUB_SUM, CUPY_CUB_PROD, CUPY_CUB_MIN, CUPY_CUB_MAX):
-        y = ndarray((), x.dtype)
+        y = _core.ndarray((), x.dtype)
     else:  # argmin and argmax
         # cub::KeyValuePair has 1 int + 1 arbitrary type
         kv_bytes = (4 + x.dtype.itemsize)
-        y = ndarray((kv_bytes,), numpy.int8)
+        y = _core.ndarray((kv_bytes,), numpy.int8)
     x_ptr = <void *>x.data.ptr
     y_ptr = <void *>y.data.ptr
     dtype_id = common._get_dtype_id(x.dtype)
@@ -223,7 +224,7 @@ def device_segmented_reduce(ndarray x, op, tuple reduce_axis,
     # prepare input
     out_shape = _get_output_shape(x, out_axis, keepdims)
     x_ptr = <void*>x.data.ptr
-    y = ndarray(out_shape, dtype=x.dtype, order=order)
+    y = _core.ndarray(out_shape, dtype=x.dtype, order=order)
     y_ptr = <void*>y.data.ptr
     if out is not None and out.shape != out_shape:
         raise ValueError(
@@ -292,7 +293,7 @@ def device_csrmv(int n_rows, int n_cols, int nnz, ndarray values,
     x_ptr = <void*>x.data.ptr
 
     # prepare output array
-    y = ndarray((n_rows,), dtype=dtype)
+    y = _core.ndarray((n_rows,), dtype=dtype)
     y_ptr = <void*>y.data.ptr
 
     s = <Stream_t>stream.get_current_stream_ptr()

--- a/cupy/random/_generator_api.pyx
+++ b/cupy/random/_generator_api.pyx
@@ -149,7 +149,7 @@ class Generator:
         if out is not None:
             self._check_output_array(dtype, size, out)
 
-        y = ndarray(size if size is not None else (), numpy.float64)
+        y = _core.ndarray(size if size is not None else (), numpy.float64)
         _launch_dist(self.bit_generator, random_uniform, y, ())
         if out is not None:
             _core.elementwise_copy(y, out)
@@ -220,7 +220,7 @@ class Generator:
             raise ValueError(
                 f'high - low must be within uint64 range (actual: {diff})')
 
-        y = ndarray(size if size is not None else (), pdtype)
+        y = _core.ndarray(size if size is not None else (), pdtype)
         if pdtype is numpy.uint32:
             _launch_dist(self.bit_generator, interval_32, y, (diff, mask))
         else:
@@ -271,7 +271,7 @@ class Generator:
         elif size is None:
             size = cupy.broadcast(a, b).shape
 
-        y = ndarray(size, numpy.float64)
+        y = _core.ndarray(size, numpy.float64)
 
         a = cupy.broadcast_to(a, y.shape)
         b = cupy.broadcast_to(b, y.shape)
@@ -323,7 +323,7 @@ class Generator:
         if size is None:
             size = df.shape
 
-        y = ndarray(size, numpy.float64)
+        y = _core.ndarray(size, numpy.float64)
 
         df = cupy.broadcast_to(df, y.shape)
         y = self.standard_gamma(df / 2)
@@ -477,7 +477,7 @@ class Generator:
 
         if not isinstance(p, ndarray):
             if type(p) in (float, int):
-                p_a = ndarray((), numpy.float64)
+                p_a = _core.ndarray((), numpy.float64)
                 p_a.fill(p)
                 p = p_a
             else:
@@ -490,7 +490,7 @@ class Generator:
             size = (size,)
         elif size is None:
             size = p.shape
-        y = ndarray(size if size is not None else (), numpy.int64)
+        y = _core.ndarray(size if size is not None else (), numpy.int64)
 
         p = cupy.broadcast_to(p, y.shape)
         p_arr = _array_data(p)
@@ -530,7 +530,7 @@ class Generator:
 
         if not isinstance(ngood, ndarray):
             if type(ngood) in (float, int):
-                ngood_a = ndarray((), numpy.int64)
+                ngood_a = _core.ndarray((), numpy.int64)
                 ngood_a.fill(ngood)
                 ngood = ngood_a
             else:
@@ -541,7 +541,7 @@ class Generator:
 
         if not isinstance(nbad, ndarray):
             if type(nbad) in (float, int):
-                nbad_a = ndarray((), numpy.int64)
+                nbad_a = _core.ndarray((), numpy.int64)
                 nbad_a.fill(nbad)
                 nbad = nbad_a
             else:
@@ -552,7 +552,7 @@ class Generator:
 
         if not isinstance(nsample, ndarray):
             if type(nsample) in (float, int):
-                nsample_a = ndarray((), numpy.int64)
+                nsample_a = _core.ndarray((), numpy.int64)
                 nsample_a.fill(nsample)
                 nsample = nsample_a
             else:
@@ -565,7 +565,7 @@ class Generator:
             size = (size,)
         if size is None:
             size = cupy.broadcast(ngood, nbad, nsample).shape
-        y = ndarray(size, numpy.int64)
+        y = _core.ndarray(size, numpy.int64)
 
         ngood = cupy.broadcast_to(ngood, y.shape)
         nbad = cupy.broadcast_to(nbad, y.shape)
@@ -620,7 +620,7 @@ class Generator:
         elif size is None:
             size = p.shape
 
-        y = ndarray(size, numpy.int64)
+        y = _core.ndarray(size, numpy.int64)
 
         p = cupy.broadcast_to(p, y.shape)
         p_arr = _array_data(p)
@@ -663,7 +663,7 @@ class Generator:
         if out is not None:
             self._check_output_array(dtype, size, out)
 
-        y = ndarray(size if size is not None else (), numpy.float64)
+        y = _core.ndarray(size if size is not None else (), numpy.float64)
         _launch_dist(self.bit_generator, exponential, y, ())
         if out is not None:
             _core.elementwise_copy(y, out)
@@ -700,7 +700,7 @@ class Generator:
 
         if not isinstance(lam, ndarray):
             if type(lam) in (float, int):
-                lam_a = ndarray((), numpy.float64)
+                lam_a = _core.ndarray((), numpy.float64)
                 lam_a.fill(lam)
                 lam = lam_a
             else:
@@ -716,7 +716,7 @@ class Generator:
         elif size is None:
             size = lam.shape
 
-        y = ndarray(size if size is not None else (), numpy.int64)
+        y = _core.ndarray(size if size is not None else (), numpy.int64)
 
         lam = cupy.broadcast_to(lam, y.shape)
         lam_arr = _array_data(lam)
@@ -792,7 +792,7 @@ class Generator:
             self._check_output_array(dtype, size, out)
             y = out
         else:
-            y = ndarray(size if size is not None else (), dtype)
+            y = _core.ndarray(size if size is not None else (), dtype)
 
         if y.dtype.char not in ('f', 'd'):
             raise TypeError(
@@ -860,7 +860,7 @@ class Generator:
 
         if not isinstance(shape, ndarray):
             if type(shape) in (float, int):
-                shape_a = ndarray((), numpy.float64)
+                shape_a = _core.ndarray((), numpy.float64)
                 shape_a.fill(shape)
                 shape = shape_a
             else:
@@ -885,7 +885,7 @@ class Generator:
                 y = out
 
         if y is None:
-            y = ndarray(size if size is not None else (), numpy.float64)
+            y = _core.ndarray(size if size is not None else (), numpy.float64)
 
         if numpy.dtype(dtype).char not in ('f', 'd'):
             raise TypeError(
@@ -952,7 +952,7 @@ class Generator:
         if size is None:
             size = cupy.broadcast(n, p).shape
 
-        y = ndarray(size if size is not None else (), numpy.int64)
+        y = _core.ndarray(size if size is not None else (), numpy.int64)
 
         n = cupy.broadcast_to(n, y.shape)
         p = cupy.broadcast_to(p, y.shape)

--- a/tests/cupy_tests/core_tests/test_core.py
+++ b/tests/cupy_tests/core_tests/test_core.py
@@ -57,7 +57,7 @@ class TestOrder(unittest.TestCase):
     @testing.for_orders(_orders.keys())
     def test_ndarray(self, order):
         order_expect = _orders[order]
-        a = core.ndarray((2, 3), order=order)
+        a = core._ndarray((2, 3), order=order)
         expect_c = order_expect == 'C'
         expect_f = order_expect == 'F'
         assert a.flags.c_contiguous == expect_c

--- a/tests/cupy_tests/core_tests/test_ndarray.py
+++ b/tests/cupy_tests/core_tests/test_ndarray.py
@@ -641,3 +641,25 @@ class TestNdarrayImplicitConversion(unittest.TestCase):
         a = testing.shaped_arange((3, 4, 5), cupy, numpy.int64)
         with pytest.raises(TypeError):
             numpy.asarray(a)
+
+
+class C(cupy.ndarray):
+
+    def __new__(cls, *args, info=None, **kwargs):
+        obj = super().__new__(cls, *args, **kwargs)
+        obj.info = info
+        return obj
+
+    def __array_finalize__(self, obj):
+        if obj is None:
+            return
+        self.info = getattr(obj, 'info', None)
+
+
+class TestNdarraySubclass:
+
+    def test_explicit_constructor_call(self):
+        a = C([0, 1, 2, 3], info='information')
+        assert type(a) is C
+        assert issubclass(type(a), cupy.ndarray)
+        assert a.info == 'information'


### PR DESCRIPTION
Merge #6718 first.

This PR is a part of supporting `cupy.narray` subclassing. I implement Direct constructor call here.
- Define `cupy._core.core._ndarray` that wraps cdef'ed `cupy._core.core.ndarray`
- Replace codes where directly instantiating ndarrays
- Fix parts where an object is compared to `cupy._core.core.ndarray`
- Add a test

