### PR TITLE
Use exposed name in user guide

### DIFF
--- a/docs/source/user_guide/difference.rst
+++ b/docs/source/user_guide/difference.rst
@@ -95,7 +95,7 @@ If you want to use scalar values, cast the returned arrays explicitly.
 
   >>> type(np.sum(np.arange(3))) == np.int64
   True
-  >>> type(cupy.sum(cupy.arange(3))) == cupy._core.core.ndarray
+  >>> type(cupy.sum(cupy.arange(3))) == cupy.ndarray
   True
 
 


### PR DESCRIPTION
Rel #6716. This PR removes an unnecessarily used internal name in the user guide, which caused a `cuda-example` CI failure in #6716.