### PR TITLE
Support cupy.ndarray subclassing - Part 2 - View casting

### DIFF
--- a/cupy/_core/_fusion_kernel.pyx
+++ b/cupy/_core/_fusion_kernel.pyx
@@ -15,6 +15,7 @@ from cupy.cuda cimport function
 from cupy_backends.cuda.api cimport runtime
 from cupy._core cimport _reduction
 
+import cupy as _cupy
 from cupy._core import _dtype
 from cupy import _util
 from cupy._core import _codeblock
@@ -191,7 +192,8 @@ cdef class FusedKernel:
             elif isinstance(param, _TraceScalar):
                 array = None
             elif self._is_base[i]:
-                array = _ndarray_init(shape, self._dtypes[i])
+                array = _ndarray_init(
+                    _cupy.ndarray, shape, self._dtypes[i], None)
             else:
                 view_of = ndarray_list[<Py_ssize_t>self._view_of[i]]
                 if param.is_broadcast:

--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -384,7 +384,8 @@ cdef shape_t _reduced_view_core(list args, tuple params, const shape_t& shape):
             arr = args[i]
             newstrides[0] = arr.dtype.itemsize
             # TODO(niboshi): Confirm update_x_contiguity flags
-            args[i] = arr._view(type(arr), newshape, newstrides, False, True)
+            args[i] = arr._view(
+                type(arr), newshape, newstrides, False, True, arr)
         return newshape
 
     axes.reserve(ndim)
@@ -421,7 +422,7 @@ cdef shape_t _reduced_view_core(list args, tuple params, const shape_t& shape):
         for ax in axes:
             newstrides.push_back(arr._strides[ax])
         # TODO(niboshi): Confirm update_x_contiguity flags
-        args[i] = arr._view(type(arr), newshape, newstrides, False, True)
+        args[i] = arr._view(type(arr), newshape, newstrides, False, True, arr)
     return newshape
 
 

--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -384,7 +384,7 @@ cdef shape_t _reduced_view_core(list args, tuple params, const shape_t& shape):
             arr = args[i]
             newstrides[0] = arr.dtype.itemsize
             # TODO(niboshi): Confirm update_x_contiguity flags
-            args[i] = arr._view(newshape, newstrides, False, True)
+            args[i] = arr._view(type(arr), newshape, newstrides, False, True)
         return newshape
 
     axes.reserve(ndim)
@@ -421,7 +421,7 @@ cdef shape_t _reduced_view_core(list args, tuple params, const shape_t& shape):
         for ax in axes:
             newstrides.push_back(arr._strides[ax])
         # TODO(niboshi): Confirm update_x_contiguity flags
-        args[i] = arr._view(newshape, newstrides, False, True)
+        args[i] = arr._view(type(arr), newshape, newstrides, False, True)
     return newshape
 
 

--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -633,7 +633,8 @@ cdef list _get_out_args_from_optionals(
 
     for i, a in enumerate(out_args):
         if a is None:
-            out_args[i] = _ndarray_init(out_shape, out_types[i])
+            out_args[i] = _ndarray_init(
+                cupy.ndarray, out_shape, out_types[i], None)
             continue
 
         if not isinstance(a, _ndarray_base):
@@ -679,7 +680,8 @@ cdef list _get_out_args_with_params(
         for p in out_params:
             if p.raw and not is_size_specified:
                 raise ValueError('Output array size is Undecided')
-        return [_ndarray_init(out_shape, t) for t in out_types]
+        return [_ndarray_init(
+            cupy.ndarray, out_shape, t, None) for t in out_types]
 
     for i, p in enumerate(out_params):
         a = out_args[i]

--- a/cupy/_core/_routines_linalg.pyx
+++ b/cupy/_core/_routines_linalg.pyx
@@ -448,7 +448,7 @@ cpdef _ndarray_base tensordot_core(
         dtype = numpy.promote_types(dtype, b.dtype).char
     if not a.size or not b.size:
         if out is None:
-            out = _ndarray_init(ret_shape, dtype)
+            out = _ndarray_init(cupy.ndarray, ret_shape, dtype, None)
         out.fill(0)
         return out
 
@@ -457,7 +457,7 @@ cpdef _ndarray_base tensordot_core(
     cdef int ace
     if m == 1 and n == 1:
         if out is None:
-            out = _ndarray_init(ret_shape, dtype)
+            out = _ndarray_init(cupy.ndarray, ret_shape, dtype, None)
         c = _manipulation._reshape(out, ())
         for ace in _accelerator._routine_accelerators:
             # fast path using CUB or cuTENSOR
@@ -491,12 +491,12 @@ cpdef _ndarray_base tensordot_core(
     b, transb, ldb = _mat_to_cublas_contiguous(b, 1)
 
     if out is None:
-        out = c = _ndarray_init(ret_shape, dtype)
+        out = c = _ndarray_init(cupy.ndarray, ret_shape, dtype, None)
     elif (
         _memory_range.may_share_bounds(out, a)
         or _memory_range.may_share_bounds(out, b)
     ):
-        copy_to_out = c = _ndarray_init(ret_shape, dtype)
+        copy_to_out = c = _ndarray_init(cupy.ndarray, ret_shape, dtype, None)
     else:
         c = out
 
@@ -541,7 +541,7 @@ cpdef _ndarray_base tensordot_core(
         dtype = 'f'
         a = a.astype(dtype, order='K', casting=None, subok=None, copy=True)
         b = b.astype(dtype, order='K', casting=None, subok=None, copy=True)
-        c = _ndarray_init(ret_shape, dtype)
+        c = _ndarray_init(cupy.ndarray, ret_shape, dtype, None)
         copy_to_out = c
         warnings.warn('On ROCm/HIP, there is no specialized API to handle '
                       'half precision floating numbers, so the computation '
@@ -749,7 +749,7 @@ cpdef _ndarray_base matmul(
         ret_dtype = numpy.promote_types(a.dtype, b.dtype)
         if out._c_contiguous and ret_dtype == out.dtype:
             return dot(a, b, out)
-        c = _ndarray_init(out._shape, dtype=ret_dtype)
+        c = _ndarray_init(cupy.ndarray, out._shape, dtype=ret_dtype, obj=None)
         dot(a, b, c)
         elementwise_copy(c, out)
         return out

--- a/cupy/_core/_routines_manipulation.pyx
+++ b/cupy/_core/_routines_manipulation.pyx
@@ -365,7 +365,7 @@ cpdef _ndarray_base _reshape(_ndarray_base self, const shape_t &shape_spec):
 
 
 cpdef _ndarray_base _T(_ndarray_base self):
-    ret = self.view()
+    ret = self._view_impl()
     ret._shape.assign(self._shape.rbegin(), self._shape.rend())
     ret._strides.assign(self._strides.rbegin(), self._strides.rend())
     ret._c_contiguous = self._f_contiguous

--- a/cupy/_core/_routines_manipulation.pyx
+++ b/cupy/_core/_routines_manipulation.pyx
@@ -355,7 +355,7 @@ cpdef _ndarray_base _reshape(_ndarray_base self, const shape_t &shape_spec):
 
     _get_strides_for_nocopy_reshape(self, shape, strides)
     if strides.size() == shape.size():
-        return self._view(shape, strides, False, True)
+        return self._view(type(self), shape, strides, False, True)
     newarray = self.copy()
     _get_strides_for_nocopy_reshape(newarray, shape, strides)
 

--- a/cupy/_core/_routines_manipulation.pyx
+++ b/cupy/_core/_routines_manipulation.pyx
@@ -365,7 +365,7 @@ cpdef _ndarray_base _reshape(_ndarray_base self, const shape_t &shape_spec):
 
 
 cpdef _ndarray_base _T(_ndarray_base self):
-    ret = self._view_impl()
+    ret = self.view()
     ret._shape.assign(self._shape.rbegin(), self._shape.rend())
     ret._strides.assign(self._strides.rbegin(), self._strides.rend())
     ret._c_contiguous = self._f_contiguous

--- a/cupy/_core/_routines_manipulation.pyx
+++ b/cupy/_core/_routines_manipulation.pyx
@@ -355,7 +355,7 @@ cpdef _ndarray_base _reshape(_ndarray_base self, const shape_t &shape_spec):
 
     _get_strides_for_nocopy_reshape(self, shape, strides)
     if strides.size() == shape.size():
-        return self._view(type(self), shape, strides, False, True)
+        return self._view(type(self), shape, strides, False, True, self)
     newarray = self.copy()
     _get_strides_for_nocopy_reshape(newarray, shape, strides)
 

--- a/cupy/_core/_routines_math.pyx
+++ b/cupy/_core/_routines_math.pyx
@@ -452,7 +452,7 @@ cdef _ndarray_base scan(
         if dtype is None:
             dtype = a.dtype
         if not incomplete:
-            out = _ndarray_init(a._shape, dtype)
+            out = _ndarray_init(cupy.ndarray, a._shape, dtype, None)
     else:
         if a.size != out.size:
             raise ValueError('Provided out is the wrong size')

--- a/cupy/_core/core.pxd
+++ b/cupy/_core/core.pxd
@@ -108,7 +108,7 @@ cpdef _ndarray_base array(
     obj, dtype=*, bint copy=*, order=*, bint subok=*, Py_ssize_t ndmin=*)
 cpdef _ndarray_base _convert_object_with_cuda_array_interface(a)
 
-cdef _ndarray_base _ndarray_init(const shape_t& shape, dtype)
+cdef _ndarray_base _ndarray_init(subtype, const shape_t& shape, dtype, obj)
 
 cdef _ndarray_base _create_ndarray_from_shape_strides(
     const shape_t& shape, const strides_t& strides, dtype)

--- a/cupy/_core/core.pxd
+++ b/cupy/_core/core.pxd
@@ -33,7 +33,7 @@ cdef class _ndarray_base:
     cpdef _ndarray_base astype(
         self, dtype, order=*, casting=*, subok=*, copy=*)
     cpdef _ndarray_base copy(self, order=*)
-    cpdef _ndarray_base view(self, dtype=*, array_class=*)
+    cpdef _ndarray_base _view_impl(self, dtype=*, array_class=*)
     cpdef fill(self, value)
     cpdef _ndarray_base swapaxes(self, Py_ssize_t axis1, Py_ssize_t axis2)
     cpdef _ndarray_base flatten(self, order=*)

--- a/cupy/_core/core.pxd
+++ b/cupy/_core/core.pxd
@@ -83,7 +83,7 @@ cdef class _ndarray_base:
     cdef _ndarray_base _view(self, subtype, const shape_t& shape,
                              const strides_t& strides,
                              bint update_c_contiguity,
-                             bint update_f_contiguity)
+                             bint update_f_contiguity, obj)
     cpdef _set_contiguous_strides(
         self, Py_ssize_t itemsize, bint is_c_contiguous)
     cdef CPointer get_pointer(self)

--- a/cupy/_core/core.pxd
+++ b/cupy/_core/core.pxd
@@ -33,7 +33,7 @@ cdef class _ndarray_base:
     cpdef _ndarray_base astype(
         self, dtype, order=*, casting=*, subok=*, copy=*)
     cpdef _ndarray_base copy(self, order=*)
-    cpdef _ndarray_base view(self, dtype=*, typ=*)
+    cpdef _ndarray_base view(self, dtype=*, array_class=*)
     cpdef fill(self, value)
     cpdef _ndarray_base swapaxes(self, Py_ssize_t axis1, Py_ssize_t axis2)
     cpdef _ndarray_base flatten(self, order=*)

--- a/cupy/_core/core.pxd
+++ b/cupy/_core/core.pxd
@@ -33,7 +33,7 @@ cdef class _ndarray_base:
     cpdef _ndarray_base astype(
         self, dtype, order=*, casting=*, subok=*, copy=*)
     cpdef _ndarray_base copy(self, order=*)
-    cpdef _ndarray_base view(self, dtype=*)
+    cpdef _ndarray_base view(self, dtype=*, typ=*)
     cpdef fill(self, value)
     cpdef _ndarray_base swapaxes(self, Py_ssize_t axis1, Py_ssize_t axis2)
     cpdef _ndarray_base flatten(self, order=*)
@@ -80,7 +80,7 @@ cdef class _ndarray_base:
                                  const strides_t& strides,
                                  bint update_c_contiguity,
                                  bint update_f_contiguity)
-    cdef _ndarray_base _view(self, const shape_t& shape,
+    cdef _ndarray_base _view(self, subtype, const shape_t& shape,
                              const strides_t& strides,
                              bint update_c_contiguity,
                              bint update_f_contiguity)

--- a/cupy/_core/core.pxd
+++ b/cupy/_core/core.pxd
@@ -33,7 +33,7 @@ cdef class _ndarray_base:
     cpdef _ndarray_base astype(
         self, dtype, order=*, casting=*, subok=*, copy=*)
     cpdef _ndarray_base copy(self, order=*)
-    cpdef _ndarray_base _view_impl(self, dtype=*, array_class=*)
+    cpdef _ndarray_base view(self, dtype=*, array_class=*)
     cpdef fill(self, value)
     cpdef _ndarray_base swapaxes(self, Py_ssize_t axis1, Py_ssize_t axis2)
     cpdef _ndarray_base flatten(self, order=*)

--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -618,7 +618,7 @@ cdef class _ndarray_base:
             newarray.data.copy_from_device_async(x.data, x.nbytes)
         return newarray
 
-    cpdef _ndarray_base view(self, dtype=None, typ=None):
+    cpdef _ndarray_base view(self, dtype=None, array_class=None):
         """Returns a view of the array.
 
         Args:
@@ -635,7 +635,7 @@ cdef class _ndarray_base:
         """
         cdef Py_ssize_t ndim, axis, tmp_size
         cdef int self_is, v_is
-        subtype = typ if typ is not None else type(self)
+        subtype = array_class if array_class is not None else type(self)
         v = self._view(subtype, self._shape, self._strides, False, False)
         if dtype is None:
             return v

--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -620,7 +620,11 @@ cdef class _ndarray_base:
             newarray.data.copy_from_device_async(x.data, x.nbytes)
         return newarray
 
-    cpdef _ndarray_base view(self, dtype=None, array_class=None):
+    # It seems that Cython's 'cpdef'd methods take neither an argument named
+    # 'type' nor starargs ('*args' and '**kwargs'), so we have to provide
+    # 'def'd definition of view() to handle its arguments to follow NumPy's
+    # API.
+    def view(self, dtype=None, type=None):
         """Returns a view of the array.
 
         Args:
@@ -635,6 +639,9 @@ cdef class _ndarray_base:
         .. seealso:: :meth:`numpy.ndarray.view`
 
         """
+        return self._view_impl(dtype=dtype, array_class=type)
+
+    cpdef _ndarray_base _view_impl(self, dtype=None, array_class=None):
         cdef Py_ssize_t ndim, axis, tmp_size
         cdef int self_is, v_is
 

--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -635,6 +635,12 @@ cdef class _ndarray_base:
         """
         cdef Py_ssize_t ndim, axis, tmp_size
         cdef int self_is, v_is
+        if type(dtype) is type:
+            array_class = dtype
+            dtype = None
+        if array_class is not None:
+            if not issubclass(array_class, ndarray):
+                raise ValueError('Type must be a sub-type of ndarray type')
         subtype = array_class if array_class is not None else type(self)
         v = self._view(subtype, self._shape, self._strides, False, False)
         if dtype is None:

--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -635,14 +635,26 @@ cdef class _ndarray_base:
         """
         cdef Py_ssize_t ndim, axis, tmp_size
         cdef int self_is, v_is
-        if type(dtype) is type:
-            array_class = dtype
-            dtype = None
-        if array_class is not None:
-            if not issubclass(array_class, ndarray):
-                raise ValueError('Type must be a sub-type of ndarray type')
-        subtype = array_class if array_class is not None else type(self)
-        v = self._view(subtype, self._shape, self._strides, False, False)
+
+        if dtype is not None:
+            if type(dtype) is type and issubclass(dtype, ndarray):
+                if array_class is not None:
+                    raise ValueError('Cannot specify output type twice.')
+                array_class = dtype
+                dtype = None
+
+        if (
+            array_class is not None and (
+                type(array_class) is not type or
+                not issubclass(array_class, ndarray)
+            )
+        ):
+            raise ValueError('Type must be a sub-type of ndarray type')
+
+        if array_class is None:
+            array_class = type(self)
+
+        v = self._view(array_class, self._shape, self._strides, False, False)
         if dtype is None:
             return v
 

--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -147,6 +147,28 @@ class ndarray(_ndarray_base):
     def __array_finalize__(self, obj):
         pass
 
+    # We provide the Python-level wrapper of `view` method to follow NumPy's
+    # API signature, as it seems that Cython's `cpdef`d methods does not take
+    # an argument named `type`. Cython also does not take starargs
+    # (`*args` and `**kwargs`) for `cpdef`d methods so we can not interpret the
+    # arguments `dtype` and `type` from them.
+    def view(self, dtype=None, type=None):
+        """Returns a view of the array.
+
+        Args:
+            dtype: If this is different from the data type of the array, the
+                returned view reinterpret the memory sequence as an array of
+                this type.
+
+        Returns:
+            cupy.ndarray: A view of the array. A reference to the original
+            array is stored at the :attr:`~ndarray.base` attribute.
+
+        .. seealso:: :meth:`numpy.ndarray.view`
+
+        """
+        return super(ndarray, self).view(dtype=dtype, array_class=type)
+
 
 cdef class _ndarray_base:
 
@@ -620,28 +642,7 @@ cdef class _ndarray_base:
             newarray.data.copy_from_device_async(x.data, x.nbytes)
         return newarray
 
-    # It seems that Cython's 'cpdef'd methods take neither an argument named
-    # 'type' nor starargs ('*args' and '**kwargs'), so we have to provide
-    # 'def'd definition of view() to handle its arguments to follow NumPy's
-    # API.
-    def view(self, dtype=None, type=None):
-        """Returns a view of the array.
-
-        Args:
-            dtype: If this is different from the data type of the array, the
-                returned view reinterpret the memory sequence as an array of
-                this type.
-
-        Returns:
-            cupy.ndarray: A view of the array. A reference to the original
-            array is stored at the :attr:`~ndarray.base` attribute.
-
-        .. seealso:: :meth:`numpy.ndarray.view`
-
-        """
-        return self._view_impl(dtype=dtype, array_class=type)
-
-    cpdef _ndarray_base _view_impl(self, dtype=None, array_class=None):
+    cpdef _ndarray_base view(self, dtype=None, array_class=None):
         cdef Py_ssize_t ndim, axis, tmp_size
         cdef int self_is, v_is
 

--- a/cupy/_core/internal.pyx
+++ b/cupy/_core/internal.pyx
@@ -385,7 +385,7 @@ cdef _broadcast_core(list arrays, shape_t& shape):
                 strides[j + nd - a_ndim] = a._strides[j]
 
         # TODO(niboshi): Confirm update_x_contiguity flags
-        arrays[i] = a._view(shape, strides, True, True)
+        arrays[i] = a._view(type(a), shape, strides, True, True)
 
 
 @cython.boundscheck(False)

--- a/cupy/_core/internal.pyx
+++ b/cupy/_core/internal.pyx
@@ -385,7 +385,7 @@ cdef _broadcast_core(list arrays, shape_t& shape):
                 strides[j + nd - a_ndim] = a._strides[j]
 
         # TODO(niboshi): Confirm update_x_contiguity flags
-        arrays[i] = a._view(type(a), shape, strides, True, True)
+        arrays[i] = a._view(type(a), shape, strides, True, True, a)
 
 
 @cython.boundscheck(False)

--- a/cupy/cusolver.pyx
+++ b/cupy/cusolver.pyx
@@ -314,14 +314,15 @@ cpdef _gesvd_batched(a, a_dtype, full_matrices, compute_uv, overwrite_a):
     k = n  # = min(m, n) where m >= n is ensured above
     if compute_uv:
         if full_matrices:
-            u = _ndarray_init((batch_size, m, m), a_dtype)
+            u = _ndarray_init(_cupy.ndarray, (batch_size, m, m), a_dtype, None)
             vt = x[..., :n]
             job_u = b'A'
             job_vt = b'O'
             u_ptr, vt_ptr = u.data.ptr, 0
         else:
             u = x
-            vt = _ndarray_init((batch_size, k, n), a_dtype)
+            vt = _ndarray_init(
+                _cupy.ndarray, (batch_size, k, n), a_dtype, None)
             job_u = b'O'
             job_vt = b'S'
             u_ptr, vt_ptr = 0, vt.data.ptr
@@ -329,10 +330,10 @@ cpdef _gesvd_batched(a, a_dtype, full_matrices, compute_uv, overwrite_a):
         u_ptr, vt_ptr = 0, 0  # Use nullptr
         job_u = b'N'
         job_vt = b'N'
-    s = _ndarray_init((batch_size, k), s_dtype)
+    s = _ndarray_init(_cupy.ndarray, (batch_size, k), s_dtype, None)
     s_ptr = s.data.ptr
     cdef intptr_t handle = _device.get_cusolver_handle()
-    dev_info = _ndarray_init((batch_size,), _numpy.int32)
+    dev_info = _ndarray_init(_cupy.ndarray, (batch_size,), _numpy.int32, None)
     info_ptr = dev_info.data.ptr
 
     if a_dtype == 'f':
@@ -887,7 +888,7 @@ cpdef _geqrf_orgqr_batched(a, mode):
     x_ptr = ap.data.ptr
 
     cdef intptr_t handle = _device.get_cusolver_handle()
-    dev_info = _ndarray_init((batch_size,), _numpy.int32)
+    dev_info = _ndarray_init(_cupy.ndarray, (batch_size,), _numpy.int32, None)
     info_ptr = dev_info.data.ptr
 
     cdef geqrf_ptr geqrf

--- a/cupy/cutensor.pyx
+++ b/cupy/cutensor.pyx
@@ -308,7 +308,8 @@ def elementwise_trinary(
         raise ValueError('The inputs should be contiguous arrays.')
 
     if out is None:
-        out = core._ndarray_init(C._shape, dtype=C.dtype)
+        out = core._ndarray_init(
+            _cupy.ndarray, C._shape, dtype=C.dtype, obj=None)
     elif C.dtype != out.dtype:
         raise ValueError('dtype mismatch: {} != {}'.format(C.dtype, out.dtype))
     elif not internal.vector_equal(C._shape, out._shape):
@@ -371,7 +372,8 @@ def elementwise_binary(
         raise ValueError('The inputs should be contiguous arrays.')
 
     if out is None:
-        out = core._ndarray_init(C._shape, dtype=C.dtype)
+        out = core._ndarray_init(
+            _cupy.ndarray, C._shape, dtype=C.dtype, obj=None)
     elif C.dtype != out.dtype:
         raise ValueError('dtype mismatch: {} != {}'.format(C.dtype, out.dtype))
     elif not internal.vector_equal(C._shape, out._shape):
@@ -609,14 +611,16 @@ cdef inline _ndarray_base _contraction_impl(
     # Allocate workspace
     ws_size = cutensor.contractionGetWorkspace(handle, desc, find, ws_pref)
     try:
-        ws = core._ndarray_init(shape_t(1, ws_size), dtype=_numpy.int8)
+        ws = core._ndarray_init(
+            _cupy.ndarray, shape_t(1, ws_size), dtype=_numpy.int8, obj=None)
     except Exception:
         _warnings.warn('cuTENSOR: failed to allocate memory of workspace '
                        'with preference ({}) and size ({}).'
                        ''.format(ws_pref, ws_size))
         ws_size = cutensor.contractionGetWorkspace(
             handle, desc, find, cutensor.WORKSPACE_MIN)
-        ws = core._ndarray_init(shape_t(1, ws_size), dtype=_numpy.int8)
+        ws = core._ndarray_init(
+            _cupy.ndarray, shape_t(1, ws_size), dtype=_numpy.int8, obj=None)
 
     plan = _create_contraction_plan(handle, desc, find, ws_size)
 
@@ -706,12 +710,14 @@ cdef inline _ndarray_base _reduction_impl(
         out.data.ptr, desc_C, mode_C.data,
         reduce_op, cutensor_compute_type)
     try:
-        ws = core._ndarray_init(shape_t(1, ws_size), dtype=_numpy.int8)
+        ws = core._ndarray_init(
+            _cupy.ndarray, shape_t(1, ws_size), dtype=_numpy.int8, obj=None)
     except _cupy.cuda.memory.OutOfMemoryError:
         _warnings.warn('cuTENSOR: failed to allocate memory of workspace '
                        '(size: {}).'.format(ws_size))
         ws_size = 0
-        ws = core._ndarray_init(shape_t(1, ws_size), dtype=_numpy.int8)
+        ws = core._ndarray_init(
+            _cupy.ndarray, shape_t(1, ws_size), dtype=_numpy.int8, obj=None)
 
     cutensor.reduction(
         handle,
@@ -772,7 +778,8 @@ def _try_reduction_routine(
     out_shape = _reduction._get_out_shape(
         x._shape, reduce_axis, out_axis, keepdims)
     if out is None:
-        out = core._ndarray_init(out_shape, dtype=dtype)
+        out = core._ndarray_init(
+            _cupy.ndarray, out_shape, dtype=dtype, obj=None)
     elif not internal.vector_equal(out._shape, out_shape):
         # TODO(asi1024): Support broadcast
         return None

--- a/tests/cupy_tests/core_tests/test_ndarray_copy_and_view.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_copy_and_view.py
@@ -375,32 +375,32 @@ class TestSubclassArrayView:
 
     def test_view_casting(self):
         for xp, C in [(numpy, C_np), (cupy, C_cp)]:
-            a = xp.arange(5).view('f')
+            a = xp.arange(5, dtype='i').view('f')
             assert type(a) is xp.ndarray
             assert a.dtype == xp.float32
 
-            a = xp.arange(5).view(dtype='f')
+            a = xp.arange(5, dtype='i').view(dtype='f')
             assert type(a) is xp.ndarray
             assert a.dtype == xp.float32
 
             with pytest.raises(TypeError):
-                xp.arange(5).view('f', dtype='f')
+                xp.arange(5, dtype='i').view('f', dtype='f')
 
-            a = xp.arange(5).view(C)
+            a = xp.arange(5, dtype='i').view(C)
             assert type(a) is C
-            assert a.dtype == xp.int64
+            assert a.dtype == xp.int32
             assert a.info is None
 
-            a = xp.arange(5).view(type=C)
+            a = xp.arange(5, dtype='i').view(type=C)
             assert type(a) is C
-            assert a.dtype == xp.int64
+            assert a.dtype == xp.int32
             assert a.info is None
 
             # When an instance of ndarray's subclass is supplied to `dtype`,
             # view() interprets it as if it is supplied to `type`
-            a = xp.arange(5).view(dtype=C)
+            a = xp.arange(5, dtype='i').view(dtype=C)
             assert type(a) is C
-            assert a.dtype == xp.int64
+            assert a.dtype == xp.int32
             assert a.info is None
 
             with pytest.raises(TypeError):

--- a/tests/cupy_tests/core_tests/test_ndarray_copy_and_view.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_copy_and_view.py
@@ -371,6 +371,3 @@ class TestSubclassArrayView:
 
         with pytest.raises(ValueError):
             cupy.arange(5).view(array_class=numpy.ndarray)
-
-        with pytest.raises(ValueError):
-            cupy.arange(5).view(numpy.ndarray)

--- a/tests/cupy_tests/core_tests/test_ndarray_copy_and_view.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_copy_and_view.py
@@ -343,3 +343,24 @@ class TestNumPyArrayCopyView:
         b = xp.empty(a.shape, dtype=dtype, order=order)
         b[:] = a
         return b
+
+
+class C(cupy.ndarray):
+
+    def __new__(cls, *args, info=None, **kwargs):
+        obj = super().__new__(cls, *args, **kwargs)
+        obj.info = info
+        return obj
+
+    def __array_finalize__(self, obj):
+        if obj is None:
+            return
+        self.info = getattr(obj, 'info', None)
+
+
+class TestSubclassArrayView:
+
+    def test_view_casting(self):
+        a = cupy.arange(5).view(typ=C)
+        assert type(a) is C
+        assert a.info == None

--- a/tests/cupy_tests/core_tests/test_ndarray_copy_and_view.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_copy_and_view.py
@@ -361,6 +361,16 @@ class C(cupy.ndarray):
 class TestSubclassArrayView:
 
     def test_view_casting(self):
-        a = cupy.arange(5).view(typ=C)
+        a = cupy.arange(5).view(array_class=C)
         assert type(a) is C
-        assert a.info == None
+        assert a.info is None
+
+        a = cupy.arange(5).view(C)
+        assert type(a) is C
+        assert a.info is None
+
+        with pytest.raises(ValueError):
+            cupy.arange(5).view(array_class=numpy.ndarray)
+
+        with pytest.raises(ValueError):
+            cupy.arange(5).view(numpy.ndarray)


### PR DESCRIPTION
Merge #6746 first.

This PR is a part of supporting `cupy.ndarray` subclassing. Following #6716, I implement View casting.