### PR TITLE
Add `cupy.einsum_path`

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -467,6 +467,7 @@ from numpy import set_string_function  # NOQA
 # Linear algebra
 # -----------------------------------------------------------------------------
 from cupy.linalg._einsum import einsum  # NOQA
+from cupy.linalg._einsum import einsum_path  # NOQA
 
 from cupy.linalg._product import cross  # NOQA
 from cupy.linalg._product import dot  # NOQA

--- a/cupy/linalg/_einsum.py
+++ b/cupy/linalg/_einsum.py
@@ -11,6 +11,7 @@ from cupy._core import _accelerator
 from cupy import _util
 from cupy.linalg._einsum_opt import _greedy_path
 from cupy.linalg._einsum_opt import _optimal_path
+from cupy.linalg._einsum_cutn import _get_einsum_operands
 from cupy.linalg._einsum_cutn import _try_use_cutensornet
 
 

--- a/docs/source/reference/linalg.rst
+++ b/docs/source/reference/linalg.rst
@@ -22,6 +22,7 @@ Matrix and vector products
    matmul
    tensordot
    einsum
+   einsum_path
    linalg.matrix_power
    kron
 

--- a/tests/cupy_tests/linalg_tests/test_einsum.py
+++ b/tests/cupy_tests/linalg_tests/test_einsum.py
@@ -348,6 +348,18 @@ class TestEinSumUnaryOperation:
             testing.assert_allclose(optimized_out, out)
         return out
 
+    @pytest.mark.parametrize('optimize', [False, True, 'optimal', 'greedy'])
+    def test_einsum_path_unary(self, optimize):
+        # dtype doesn't matter in path computation, so just pick one
+        a_np = testing.shaped_arange(self.shape_a, numpy, numpy.float32)
+        path_np, info_np = numpy.einsum_path(
+            self.subscripts, a_np, optimize=optimize)
+        a_cp = testing.shaped_arange(self.shape_a, cupy, cupy.float32)
+        path_cp, info_cp = cupy.einsum_path(
+            self.subscripts, a_cp, optimize=optimize)
+        assert path_np == path_cp
+        assert info_np == info_cp
+
     @testing.for_all_dtypes(no_bool=False)
     @testing.numpy_cupy_equal()
     def test_einsum_unary_views(self, xp, dtype):
@@ -442,6 +454,20 @@ class TestEinSumBinaryOperation:
         b = testing.shaped_arange(self.shape_b, xp, dtype_b)
         return xp.einsum(self.subscripts, a, b)
 
+    @pytest.mark.parametrize('optimize', [False, True, 'optimal', 'greedy'])
+    def test_einsum_path_binary(self, optimize):
+        # dtype doesn't matter in path computation, so just pick one
+        a_np = testing.shaped_arange(self.shape_a, numpy, numpy.float32)
+        b_np = testing.shaped_arange(self.shape_b, numpy, numpy.float32)
+        path_np, info_np = numpy.einsum_path(
+            self.subscripts, a_np, b_np, optimize=optimize)
+        a_cp = testing.shaped_arange(self.shape_a, cupy, cupy.float32)
+        b_cp = testing.shaped_arange(self.shape_b, cupy, cupy.float32)
+        path_cp, info_cp = cupy.einsum_path(
+            self.subscripts, a_cp, b_cp, optimize=optimize)
+        assert path_np == path_cp
+        assert info_np == info_cp
+
 
 class TestEinSumBinaryOperationWithScalar:
     @testing.for_all_dtypes()
@@ -507,6 +533,22 @@ class TestEinSumTernaryOperation:
                 testing.assert_allclose(optimized_out, out)
         return out
 
+    @pytest.mark.parametrize('optimize', [False, True, 'optimal', 'greedy'])
+    def test_einsum_path_ternary(self, optimize):
+        # dtype doesn't matter in path computation, so just pick one
+        a_np = testing.shaped_arange(self.shape_a, numpy, numpy.float32)
+        b_np = testing.shaped_arange(self.shape_b, numpy, numpy.float32)
+        c_np = testing.shaped_arange(self.shape_c, numpy, numpy.float32)
+        path_np, info_np = numpy.einsum_path(
+            self.subscripts, a_np, b_np, c_np, optimize=optimize)
+        a_cp = testing.shaped_arange(self.shape_a, cupy, cupy.float32)
+        b_cp = testing.shaped_arange(self.shape_b, cupy, cupy.float32)
+        c_cp = testing.shaped_arange(self.shape_c, cupy, cupy.float32)
+        path_cp, info_cp = cupy.einsum_path(
+            self.subscripts, a_cp, b_cp, c_cp, optimize=optimize)
+        assert path_np == path_cp
+        assert info_np == info_cp
+
 
 @testing.parameterize(*([
     # memory constraint
@@ -558,3 +600,19 @@ class TestEinSumLarge:
             else:
                 assert len(ws) == 0
         return out
+
+    def test_einsum_path(self, shapes):
+        arrays_np = [
+            testing.shaped_random(shape, numpy, float, scale=1)
+            for shape in shapes
+        ]
+        path_np, info_np = numpy.einsum_path(
+            self.subscript, *arrays_np, optimize=self.opt)
+        arrays_cp = [
+            testing.shaped_random(shape, cupy, float, scale=1)
+            for shape in shapes
+        ]
+        path_cp, info_cp = cupy.einsum_path(
+            self.subscript, *arrays_cp, optimize=self.opt)
+        assert path_np == path_cp
+        assert info_np == info_cp


### PR DESCRIPTION
Part of #6078. 

For the previous discussion about the `einsum_path` refactoring, please see #6261 and #6677.

This PR adds the missing `cupy.einsum_path` function for NumPy compatibility. In order to avoid the infinite `__array_function__` dispatching, I followed the advice from upstream (see https://github.com/numpy/numpy/issues/21379) and created dummy NumPy arrays (of zero size) to reuse `numpy.einsum_path()`. The path computation only cares about the array dimension and shape; actual data, memory layout, or dtype are irrelevant. 

cuTensorNet support will be added in a separate PR.

**Question for the team**: Should I also remove all related code copied from NumPy (specifically, `cupy/linalg/_einsum_opt.py`) as part of this PR, since they are redundant now? 