### PR TITLE
Utilize CUDA Enhanced Compatibility

### DIFF
--- a/cupy_backends/cuda/_softlink.pxd
+++ b/cupy_backends/cuda/_softlink.pxd
@@ -1,0 +1,5 @@
+cdef class SoftLink:
+    cdef:
+        object _cdll
+        str _prefix
+        void* get_func(self, str name)

--- a/cupy_backends/cuda/_softlink.pyx
+++ b/cupy_backends/cuda/_softlink.pyx
@@ -1,0 +1,53 @@
+import ctypes
+import warnings
+
+from libc.stdint cimport intptr_t
+cimport cython
+
+
+cdef class SoftLink:
+    def __init__(self, object libname, str prefix):
+        self._cdll = None
+        if libname is not None:
+            try:
+                self._cdll = ctypes.CDLL(libname)
+            except Exception as e:
+                warnings.warn(
+                    f'Warning: CuPy failed to load "{libname}": '
+                    f'({type(e).__name__}: {e})')
+        self._prefix = prefix
+
+    cdef void* get_func(self, str name):
+        """
+        Returns a function pointer for the API.
+        """
+        if self._cdll is None:
+            return <void*>_fail_unsupported
+        cdef str funcname = f'{self._prefix}{name}'
+        cdef object func = getattr(self._cdll, funcname, None)
+        if func is None:
+            return <void*>_fail_not_found
+        cdef intptr_t ptr = ctypes.addressof(func)
+        return cython.operator.dereference(<void**>ptr)
+
+
+cdef int _fail_unsupported() nogil except -1:
+    with gil:
+        raise AssertionError('''
+*** The requested function is not supported in the current version of
+*** the toolkit installed in your environment.
+***
+*** This is likely a bug in CuPy. Please report this issue to:
+***   https://github.com/cupy/cupy/issues
+''')
+    return -1
+
+cdef int _fail_not_found() nogil except -1:
+    with gil:
+        raise AssertionError('''
+*** The requested function could not be found in the library.
+***
+*** This is likely a bug in CuPy. Please report this issue to:
+***   https://github.com/cupy/cupy/issues
+''')
+    return -1

--- a/cupy_backends/cuda/cupy_nvrtc.h
+++ b/cupy_backends/cuda/cupy_nvrtc.h
@@ -17,16 +17,6 @@ nvrtcResult nvrtcGetCUBIN(...) {
 }
 #endif
 
-#if CUDA_VERSION < 11020
-// functions added in CUDA 11.2
-nvrtcResult nvrtcGetNumSupportedArchs(...) {
-    return NVRTC_ERROR_INTERNAL_ERROR;
-}
-
-nvrtcResult nvrtcGetSupportedArchs(...) {
-    return NVRTC_ERROR_INTERNAL_ERROR;
-}
-#endif
 }
 
 #endif // #ifndef INCLUDE_GUARD_CUDA_CUPY_NVRTC_H

--- a/cupy_backends/hip/cupy_hiprtc.h
+++ b/cupy_backends/hip/cupy_hiprtc.h
@@ -58,14 +58,6 @@ nvrtcResult nvrtcGetNVVM(...) {
     return HIPRTC_ERROR_COMPILATION;
 }
 
-nvrtcResult nvrtcGetNumSupportedArchs(...) {
-    return HIPRTC_ERROR_INTERNAL_ERROR;
-}
-
-nvrtcResult nvrtcGetSupportedArchs(...) {
-    return HIPRTC_ERROR_INTERNAL_ERROR;
-}
-
 nvrtcResult nvrtcGetProgramLogSize(nvrtcProgram prog, std::size_t* logSizeRet) {
     return hiprtcGetProgramLogSize(prog, logSizeRet);
 }

--- a/cupy_backends/stub/cupy_nvrtc.h
+++ b/cupy_backends/stub/cupy_nvrtc.h
@@ -56,14 +56,6 @@ nvrtcResult nvrtcGetNVVM(...) {
     return NVRTC_SUCCESS;
 }
 
-nvrtcResult nvrtcGetNumSupportedArchs(...) {
-    return NVRTC_SUCCESS;
-}
-
-nvrtcResult nvrtcGetSupportedArchs(...) {
-    return NVRTC_SUCCESS;
-}
-
 nvrtcResult nvrtcGetProgramLogSize(...) {
     return NVRTC_SUCCESS;
 }

--- a/install/cupy_builder/_modules.py
+++ b/install/cupy_builder/_modules.py
@@ -24,6 +24,7 @@ _cuda_files = [
     'cupy_backends.cuda.libs.nvrtc',
     'cupy_backends.cuda.libs.profiler',
     'cupy_backends.cuda.stream',
+    'cupy_backends.cuda._softlink',
     'cupy._core._accelerator',
     'cupy._core._carray',
     'cupy._core._cub_reduction',


### PR DESCRIPTION
Currently, we are maintaining binary packages for 8 minor versions of CUDA (10.2 & 11.0 ~ 11.6).
However, now that CUDA minor releases are cut every 3~4 months, it is becoming unsustainable to build and distribute wheels for each minor release, both in terms of PyPI's limit and our release load.

This PR aims to make CuPy binary package utilize CUDA Enhanced Compatibility (it seems now a part of [Minor Version Compatibility](https://docs.nvidia.com/deploy/cuda-compatibility/index.html#minor-version-compatibility)). This way we can reduce the number of packages to one for each CUDA **major** version.

* `cupy-cuda102` # for CUDA 10.2
* `cupy-cuda110` # for CUDA 11.0
* `cupy-cuda111` # for CUDA 11.1
* `cupy-cuda11x` # for CUDA 11.2 ~ 11.x
* `cupy-cuda12x` # for CUDA 12.x (in future)

Note: CUDA Enhanced Compatibility is a new feature in CUDA 11.1, but NVRTC support has been added in CUDA 11.2. So we still need a separate package for CUDA 11.1 or earlier.

## What's done in this PR

This PR fixes each CUDA library binding to "lazy" load symbols for APIs added in CUDA minor releases. By implementing a symbol resolution in Python, instead of letting a dynamic loader do it, CuPy binaries can be compatible across all CUDA 11.2 ~ 11.x releases. This is a similar approach to what's done in CUDA Python except for the following differences:

* CUDA Python resolves all symbols in Python. This PR instead only resolves the new APIs added within CUDA minor releases to reduce the development cost.
* CUDA Python directly uses `dlfcn`/`win32api`. This PR instead uses `ctypes` to let Python handle the platform differences.

Note that this PR only fixes NVRTC. Once we agree with this idea, I'll fix the remaining ones in a separate PR. Feature availability check must also be fixed to use `cudaRuntimeGetVersion` instead of `CUPY_CUDA_VERSION` constant.