### PR TITLE
Fix to return correct CUDA version when in CUDA Python mode

### DIFF
--- a/cupy_backends/cuda/api/runtime.pyx
+++ b/cupy_backends/cuda/api/runtime.pyx
@@ -18,6 +18,7 @@ cimport cpython  # NOQA
 cimport cython  # NOQA
 
 from cupy_backends.cuda.api cimport driver  # NOQA
+from cupy_backends.cuda.libs cimport nvrtc  # NOQA
 
 
 ###############################################################################
@@ -154,8 +155,16 @@ cpdef int driverGetVersion() except? -1:
 
 cpdef int runtimeGetVersion() except? -1:
     cdef int version
-    status = cudaRuntimeGetVersion(&version)
-    check_status(status)
+    IF CUPY_USE_CUDA_PYTHON:
+        # Workarounds an issue that cuda-python returns its version instead of
+        # the real runtime version.
+        # https://github.com/NVIDIA/cuda-python/issues/16
+        cdef int major, minor
+        (major, minor) = nvrtc.getVersion()
+        version = major * 1000 + minor * 10
+    ELSE:
+        status = cudaRuntimeGetVersion(&version)
+        check_status(status)
     return version
 
 

--- a/tests/cupy_tests/cuda_tests/test_runtime.py
+++ b/tests/cupy_tests/cuda_tests/test_runtime.py
@@ -46,6 +46,8 @@ class TestMemPool:
         runtime.memPoolDestroy(pool)
 
 
+@pytest.mark.skipif(runtime.is_hip,
+                    reason='This assumption is correct only in CUDA')
 def test_assumed_runtime_version():
     # When CUDA Python is enabled, CuPy calculates the CUDA runtime version
     # from NVRTC version. This test ensures that the assumption is correct

--- a/tests/cupy_tests/cuda_tests/test_runtime.py
+++ b/tests/cupy_tests/cuda_tests/test_runtime.py
@@ -4,6 +4,7 @@ import pytest
 
 import cupy
 from cupy.cuda import driver
+from cupy.cuda import nvrtc
 from cupy.cuda import runtime
 
 
@@ -43,3 +44,12 @@ class TestMemPool:
         assert ptr > 0
         runtime.freeAsync(ptr, s.ptr)
         runtime.memPoolDestroy(pool)
+
+
+def test_assumed_runtime_version():
+    # When CUDA Python is enabled, CuPy calculates the CUDA runtime version
+    # from NVRTC version. This test ensures that the assumption is correct
+    # by running the same logic in non-CUDA Python environment.
+    # When this fails, `runtime.runtimeGetVersion()` logic needs to be fixed.
+    (major, minor) = nvrtc.getVersion()
+    assert runtime.runtimeGetVersion() == major * 1000 + minor * 10


### PR DESCRIPTION
This will allow using `runtime.runtimeGetVersion()` in all locations where branch based on the current CUDA version (to test feature availability) is needed.