### PR TITLE
Fix compilation warning caused by ifdef

### DIFF
--- a/cupy/_core/include/cupy/carray.cuh
+++ b/cupy/_core/include/cupy/carray.cuh
@@ -126,7 +126,7 @@ public:
     return (__half_raw(data_).x & 0x8000u) != 0;
   }
 
-#ifdef __HIPCC__ && HIP_VERSION >= 50000000
+#if defined(__HIPCC__) && HIP_VERSION >= 50000000
 
   __device__ float16 operator-() {
     return float16(-data_);


### PR DESCRIPTION
`cupy.cuda.compiler.CompileException: .../cupy/_core/include/cupy/carray.cuh(129): warning #14-D: extra text after expected end of preprocessing directive`