### PR TITLE
Subclass rename

### DIFF
--- a/cupy/_core/__init__.py
+++ b/cupy/_core/__init__.py
@@ -69,7 +69,7 @@ from cupy._core.core import ascontiguousarray  # NOQA
 from cupy._core.core import asfortranarray  # NOQA
 from cupy._core.core import divmod  # NOQA
 from cupy._core.core import elementwise_copy  # NOQA
-from cupy._core.core import _ndarray as ndarray  # NOQA
+from cupy._core.core import ndarray  # NOQA
 from cupy._core.dlpack import fromDlpack  # NOQA
 from cupy._core.dlpack import from_dlpack  # NOQA
 from cupy._core.internal import complete_slice  # NOQA

--- a/cupy/_core/_cub_reduction.pxd
+++ b/cupy/_core/_cub_reduction.pxd
@@ -1,6 +1,6 @@
 from cupy._core._carray cimport shape_t
 from cupy._core._kernel cimport _TypeMap
-from cupy._core.core cimport ndarray
+from cupy._core.core cimport _ndarray_base
 
 
 cdef bint _try_to_call_cub_reduction(
@@ -9,4 +9,4 @@ cdef bint _try_to_call_cub_reduction(
     map_expr, reduce_expr, post_map_expr,
     reduce_type, _TypeMap type_map,
     tuple reduce_axis, tuple out_axis, const shape_t& out_shape,
-    ndarray ret) except *
+    _ndarray_base ret) except *

--- a/cupy/_core/_cub_reduction.pyx
+++ b/cupy/_core/_cub_reduction.pyx
@@ -4,7 +4,7 @@ from cupy._core cimport _optimize_config
 from cupy._core cimport _reduction
 from cupy._core cimport _scalar
 from cupy._core.core cimport compile_with_cache
-from cupy._core.core cimport ndarray
+from cupy._core.core cimport _ndarray_base
 from cupy._core.core cimport _internal_ascontiguousarray
 from cupy._core cimport internal
 from cupy.cuda cimport cub
@@ -288,7 +288,7 @@ cpdef inline tuple _can_use_cub_block_reduction(
     parameters, otherwise returns None.
     '''
     cdef tuple axis_permutes_cub
-    cdef ndarray in_arr, out_arr
+    cdef _ndarray_base in_arr, out_arr
     cdef Py_ssize_t contiguous_size = 1
     cdef str order
 
@@ -431,7 +431,7 @@ cdef inline void _cub_two_pass_launch(
     cdef list inout_args
     cdef tuple cub_params
     cdef size_t gridx, blockx
-    cdef ndarray in_arr
+    cdef _ndarray_base in_arr
 
     # fair share
     contiguous_size = min(segment_size, block_size * items_per_thread)
@@ -607,7 +607,7 @@ cdef bint _try_to_call_cub_reduction(
         map_expr, reduce_expr, post_map_expr,
         reduce_type, _kernel._TypeMap type_map,
         tuple reduce_axis, tuple out_axis, const shape_t& out_shape,
-        ndarray ret) except *:
+        _ndarray_base ret) except *:
     """Try to use cub.
 
     Updates `ret` and returns a boolean value whether cub is used.

--- a/cupy/_core/_fusion_kernel.pyx
+++ b/cupy/_core/_fusion_kernel.pyx
@@ -7,7 +7,7 @@ import numpy
 from cupy._core cimport _carray
 from cupy._core.core cimport _ndarray_init
 from cupy._core.core cimport compile_with_cache
-from cupy._core.core cimport ndarray
+from cupy._core.core cimport _ndarray_base
 from cupy._core cimport internal
 from cupy._core cimport _routines_manipulation as _manipulation
 from cupy_backends.cuda.api cimport driver
@@ -234,7 +234,7 @@ cdef class FusedKernel:
         """Calculate the numnber of contiguous blocks in non-reduction axes
         of input arrays, and set them to ``self._contiguous_size``.
         """
-        cdef ndarray in_array, out_array
+        cdef _ndarray_base in_array, out_array
         cdef Py_ssize_t block_size, block_stride, contiguous_size
 
         cdef list block_strides = []
@@ -270,7 +270,7 @@ cdef class FusedKernel:
         """
         cdef list params = self._params
         cdef list ndims = []
-        cdef ndarray array
+        cdef _ndarray_base array
         cdef int i
 
         for i in range(len(params)):
@@ -294,7 +294,7 @@ cdef class FusedKernel:
 
         for i in range(len(self._params)):
             array = ndarray_list[i]
-            if isinstance(array, ndarray):
+            if isinstance(array, _ndarray_base):
                 indexer = _carray.Indexer.__new__(_carray.Indexer)
                 indexer.init(array._shape)
                 indexers.append(indexer)

--- a/cupy/_core/_fusion_trace.pyx
+++ b/cupy/_core/_fusion_trace.pyx
@@ -106,7 +106,7 @@ def _guess_routine(func, args, dtype):
             obj = x.dtype.type(0)
         else:
             assert isinstance(x, _TraceArray)
-            obj = core._ndarray((0,), x.dtype)
+            obj = core.ndarray((0,), x.dtype)
         dummy_args.append(obj)
 
     op = func._ops.guess_routine(

--- a/cupy/_core/_kernel.pxd
+++ b/cupy/_core/_kernel.pxd
@@ -3,7 +3,7 @@ from libcpp cimport vector
 from cupy._core cimport _carray
 from cupy._core cimport _scalar
 from cupy._core._carray cimport shape_t
-from cupy._core.core cimport ndarray
+from cupy._core.core cimport _ndarray_base
 from cupy.cuda cimport memory
 from cupy.cuda cimport texture
 
@@ -50,7 +50,7 @@ cdef class _ArgInfo:
     cdef _ArgInfo from_arg(object arg)
 
     @staticmethod
-    cdef _ArgInfo from_ndarray(ndarray arg)
+    cdef _ArgInfo from_ndarray(_ndarray_base arg)
 
     @staticmethod
     cdef _ArgInfo from_scalar(_scalar.CScalar arg)
@@ -162,7 +162,7 @@ cdef list _get_out_args_with_params(
     list out_args, tuple out_types,
     const shape_t& out_shape, tuple out_params, bint is_size_specified)
 
-cdef _check_peer_access(ndarray arr, int device_id)
+cdef _check_peer_access(_ndarray_base arr, int device_id)
 
 cdef list _preprocess_args(int dev_id, args, bint use_c_scalar)
 

--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -25,7 +25,7 @@ from cupy._core._scalar import get_typename as _get_typename
 from cupy._core.core cimport _convert_object_with_cuda_array_interface
 from cupy._core.core cimport _ndarray_init
 from cupy._core.core cimport compile_with_cache
-from cupy._core.core cimport ndarray
+from cupy._core.core cimport _ndarray_base
 from cupy._core cimport internal
 from cupy_backends.cuda.api cimport runtime
 
@@ -84,7 +84,7 @@ cdef inline int _get_kind_score(int kind):
 
 
 @cython.profile(False)
-cdef inline _check_peer_access(ndarray arr, int device_id):
+cdef inline _check_peer_access(_ndarray_base arr, int device_id):
     if arr.data.device_id == device_id:
         return
 
@@ -104,17 +104,17 @@ cdef inline _check_peer_access(ndarray arr, int device_id):
 
 
 cdef inline _preprocess_arg(int dev_id, arg, bint use_c_scalar):
-    if isinstance(arg, ndarray):
+    if isinstance(arg, _ndarray_base):
         s = arg
-        _check_peer_access(<ndarray>s, dev_id)
+        _check_peer_access(<_ndarray_base>s, dev_id)
     elif isinstance(arg, texture.TextureObject):
         s = arg
     elif hasattr(arg, '__cuda_array_interface__'):
         s = _convert_object_with_cuda_array_interface(arg)
-        _check_peer_access(<ndarray>s, dev_id)
+        _check_peer_access(<_ndarray_base>s, dev_id)
     elif hasattr(arg, '__cupy_get_ndarray__'):
         s = arg.__cupy_get_ndarray__()
-        _check_peer_access(<ndarray>s, dev_id)
+        _check_peer_access(<_ndarray_base>s, dev_id)
     else:  # scalars or invalid args
         if use_c_scalar:
             s = _scalar.scalar_to_c_scalar(arg)
@@ -182,7 +182,7 @@ cdef class _ArgInfo:
     @staticmethod
     cdef _ArgInfo from_arg(object arg):
         typ = type(arg)
-        if issubclass(typ, ndarray):
+        if issubclass(typ, _ndarray_base):
             return _ArgInfo.from_ndarray(arg)
         if typ is _scalar.CScalar:
             return _ArgInfo.from_scalar(arg)
@@ -195,7 +195,7 @@ cdef class _ArgInfo:
         assert False, typ
 
     @staticmethod
-    cdef _ArgInfo from_ndarray(ndarray arg):
+    cdef _ArgInfo from_ndarray(_ndarray_base arg):
         cdef _ArgInfo ret = _ArgInfo.__new__(_ArgInfo)
         ret._init(
             ARG_KIND_NDARRAY,
@@ -326,14 +326,14 @@ cdef str _get_kernel_params(tuple params, tuple arginfos):
 
 cdef shape_t _reduce_dims(list args, tuple params, const shape_t& shape):
     """ Remove contiguous stride to optimize CUDA kernel."""
-    cdef ndarray arr
+    cdef _ndarray_base arr
 
     if shape.size() <= 1 or len(args) == 0:
         return shape
 
     if len(args) == 1:  # fast path for reduction
         a = args[0]
-        if (<ParameterInfo>params[0]).raw or not isinstance(a, ndarray):
+        if (<ParameterInfo>params[0]).raw or not isinstance(a, _ndarray_base):
             return shape
         arr = a
         arr = arr.reduced_view()
@@ -352,7 +352,7 @@ cdef shape_t _reduced_view_core(list args, tuple params, const shape_t& shape):
     cdef vector.vector[int] array_indexes, axes
     cdef vector.vector[int] strides_indexes
     cdef ParameterInfo p
-    cdef ndarray arr
+    cdef _ndarray_base arr
 
     ndim = shape.size()
     array_indexes.reserve(len(args))
@@ -362,7 +362,7 @@ cdef shape_t _reduced_view_core(list args, tuple params, const shape_t& shape):
         if p.raw:
             continue
         a = args[i]
-        if isinstance(a, ndarray):
+        if isinstance(a, _ndarray_base):
             array_indexes.push_back(i)
             arr = a
             if not arr._c_contiguous:
@@ -580,7 +580,7 @@ cdef list _broadcast(list args, tuple params, bint use_size, shape_t& shape):
     value = []
     for i, a in enumerate(args):
         p = params[i]
-        if not p.raw and isinstance(a, ndarray):
+        if not p.raw and isinstance(a, _ndarray_base):
             # Non-raw array
             any_nonraw_array = True
             value.append(a)
@@ -626,7 +626,7 @@ cdef void _complex_warning(dtype_from, dtype_to):
 cdef list _get_out_args_from_optionals(
     list out_args, tuple out_types, const shape_t& out_shape, casting
 ):
-    cdef ndarray arr
+    cdef _ndarray_base arr
 
     while len(out_args) < len(out_types):
         out_args.append(None)
@@ -636,7 +636,7 @@ cdef list _get_out_args_from_optionals(
             out_args[i] = _ndarray_init(out_shape, out_types[i])
             continue
 
-        if not isinstance(a, ndarray):
+        if not isinstance(a, _ndarray_base):
             raise TypeError(
                 'Output arguments type must be cupy.ndarray')
         arr = a
@@ -657,10 +657,10 @@ cdef list _get_out_args_from_optionals(
 
 cdef _copy_in_args_if_needed(list in_args, list out_args):
     # `in_args` is an input and output argument
-    cdef ndarray inp, out
+    cdef _ndarray_base inp, out
     for i in range(len(in_args)):
         a = in_args[i]
-        if isinstance(a, ndarray):
+        if isinstance(a, _ndarray_base):
             inp = a
             for out in out_args:
                 if inp is not out and may_share_bounds(inp, out):
@@ -672,7 +672,7 @@ cdef list _get_out_args_with_params(
         list out_args, tuple out_types, const shape_t& out_shape,
         tuple out_params, bint is_size_specified):
     cdef ParameterInfo p
-    cdef ndarray arr
+    cdef _ndarray_base arr
     cdef shape_t shape
     cdef Py_ssize_t x
     if not out_args:
@@ -683,7 +683,7 @@ cdef list _get_out_args_with_params(
 
     for i, p in enumerate(out_params):
         a = out_args[i]
-        if not isinstance(a, ndarray):
+        if not isinstance(a, _ndarray_base):
             raise TypeError(
                 'Output arguments type must be cupy.ndarray')
         arr = a
@@ -855,7 +855,7 @@ cdef class ElementwiseKernel:
 
         in_ndarray_types = []
         for a in in_args:
-            if isinstance(a, ndarray):
+            if isinstance(a, _ndarray_base):
                 t = a.dtype.type
             elif isinstance(a, texture.TextureObject):
                 t = 'cudaTextureObject_t'
@@ -1035,7 +1035,7 @@ cdef inline bint _check_should_use_min_scalar(list in_args) except? -1:
     max_scalar_kind = -1
     for i in in_args:
         kind = _get_kind_score(ord(i.dtype.kind))
-        if isinstance(i, ndarray):
+        if isinstance(i, _ndarray_base):
             all_scalars = False
             max_array_kind = max(max_array_kind, kind)
         else:
@@ -1224,7 +1224,7 @@ cdef class ufunc:
         if has_where:
             where_args = _preprocess_args(dev_id, (where,), False)
             x = where_args[0]
-            if isinstance(x, ndarray):
+            if isinstance(x, _ndarray_base):
                 # NumPy seems using casting=safe here
                 if x.dtype != bool:
                     raise TypeError(
@@ -1250,8 +1250,8 @@ cdef class ufunc:
                 and _accelerator.ACCELERATOR_CUTENSOR in
                 _accelerator._elementwise_accelerators):
             if (self.nin == 2 and self.nout == 1 and
-                    isinstance(in_args[0], ndarray) and
-                    isinstance(in_args[1], ndarray)):
+                    isinstance(in_args[0], _ndarray_base) and
+                    isinstance(in_args[1], _ndarray_base)):
                 ret = cupy.cutensor._try_elementwise_binary_routine(
                     in_args[0], in_args[1], dtype,
                     out_args[0] if len(out_args) == 1 else None,
@@ -1278,7 +1278,7 @@ cdef class ufunc:
         for i, t in enumerate(op.in_types):
             x = broad_values[i]
             inout_args.append(
-                x if isinstance(x, ndarray) else
+                x if isinstance(x, _ndarray_base) else
                 _scalar.CScalar.from_numpy_scalar_with_dtype(x, t))
         if has_where:
             x = broad_values[self.nin]
@@ -1408,7 +1408,7 @@ cdef class _Ops:
             use_raw_value = _check_should_use_min_scalar(in_args)
             if use_raw_value:
                 in_types = tuple([
-                    a.dtype.type if isinstance(a, ndarray)
+                    a.dtype.type if isinstance(a, _ndarray_base)
                     else _min_scalar_type(a)
                     for a in in_args])
             else:

--- a/cupy/_core/_memory_range.pxd
+++ b/cupy/_core/_memory_range.pxd
@@ -1,7 +1,7 @@
-from cupy._core.core cimport ndarray
+from cupy._core.core cimport _ndarray_base
 
 from libcpp.pair cimport pair
 
 
-cpdef pair[Py_ssize_t, Py_ssize_t] get_bound(ndarray array)
-cpdef bint may_share_bounds(ndarray a, ndarray b)
+cpdef pair[Py_ssize_t, Py_ssize_t] get_bound(_ndarray_base array)
+cpdef bint may_share_bounds(_ndarray_base a, _ndarray_base b)

--- a/cupy/_core/_memory_range.pyx
+++ b/cupy/_core/_memory_range.pyx
@@ -1,4 +1,4 @@
-from cupy._core.core cimport ndarray
+from cupy._core.core cimport _ndarray_base
 from cupy.cuda cimport memory
 
 from libc.stdint cimport intptr_t
@@ -6,7 +6,7 @@ from libcpp.pair cimport pair
 from libcpp.vector cimport vector
 
 
-cpdef pair[Py_ssize_t, Py_ssize_t] get_bound(ndarray array):
+cpdef pair[Py_ssize_t, Py_ssize_t] get_bound(_ndarray_base array):
     cdef Py_ssize_t left = array.data.ptr
     cdef Py_ssize_t right = left
     cdef Py_ssize_t tmp
@@ -26,7 +26,7 @@ cpdef pair[Py_ssize_t, Py_ssize_t] get_bound(ndarray array):
     return ret
 
 
-cpdef bint may_share_bounds(ndarray a, ndarray b):
+cpdef bint may_share_bounds(_ndarray_base a, _ndarray_base b):
     cdef memory.MemoryPointer a_data = a.data
     cdef memory.MemoryPointer b_data = b.data
     cdef pair[Py_ssize_t, Py_ssize_t] a_range, b_range

--- a/cupy/_core/_reduction.pxd
+++ b/cupy/_core/_reduction.pxd
@@ -1,6 +1,6 @@
 from cupy._core._carray cimport shape_t
 from cupy._core cimport _kernel
-from cupy._core.core cimport ndarray
+from cupy._core.core cimport _ndarray_base
 from cupy.cuda cimport function
 
 
@@ -23,7 +23,7 @@ cdef class _AbstractReductionKernel:
         readonly tuple _params
         readonly str __name__
 
-    cpdef ndarray _call(
+    cpdef _ndarray_base _call(
         self,
         list in_args, list out_args,
         const shape_t& a_shape, axis, dtype,

--- a/cupy/_core/_reduction.pyx
+++ b/cupy/_core/_reduction.pyx
@@ -24,7 +24,7 @@ from cupy._core._scalar import get_typename as _get_typename
 from cupy._core.core cimport _convert_object_with_cuda_array_interface
 from cupy._core.core cimport _create_ndarray_from_shape_strides
 from cupy._core.core cimport compile_with_cache
-from cupy._core.core cimport ndarray
+from cupy._core.core cimport _ndarray_base
 from cupy._core cimport internal
 from cupy.cuda cimport device
 from cupy.cuda cimport function
@@ -37,6 +37,7 @@ import warnings
 
 import numpy
 
+import cupy
 from cupy._core._kernel import _get_param_info
 from cupy._core._kernel import _decide_params_type
 from cupy._core._ufuncs import elementwise_copy
@@ -172,7 +173,7 @@ cdef shape_t _set_permuted_args(
             if p.raw:
                 raise NotImplementedError('Illegal conditions')
         for i, a in enumerate(args):
-            if isinstance(a, ndarray):
+            if isinstance(a, _ndarray_base):
                 args[i] = _manipulation._transpose(a, axis_permutes)
         out_shape.reserve(len(axis_permutes))
         for i in axis_permutes:
@@ -193,7 +194,7 @@ cdef Py_ssize_t _get_contiguous_size(
     out_ndim = len(out_shape)
     contiguous_size = 1
     for i, a in enumerate(args):
-        if not isinstance(a, ndarray):
+        if not isinstance(a, _ndarray_base):
             continue
         p = params[i]
         if p.raw:
@@ -240,7 +241,7 @@ cdef tuple _sort_axis(tuple axis, tuple strides):
 cdef tuple _get_shape_and_strides(list in_args, list out_args):
     cdef list shape_and_strides = []
     for x in in_args + out_args:
-        if isinstance(x, ndarray):
+        if isinstance(x, _ndarray_base):
             shape_and_strides.append(x.shape)
             shape_and_strides.append(x.strides)
         else:
@@ -250,7 +251,7 @@ cdef tuple _get_shape_and_strides(list in_args, list out_args):
 
 
 cdef _optimizer_copy_arg(a):
-    if isinstance(a, ndarray):
+    if isinstance(a, _ndarray_base):
         x = _create_ndarray_from_shape_strides(
             a._shape, a._strides, a.dtype)
         assert a.data.device_id == x.data.device_id
@@ -284,7 +285,7 @@ cdef class _AbstractReductionKernel:
         # This is for profiling mechanisms to auto infer a name
         self.__name__ = name
 
-    cpdef ndarray _call(
+    cpdef _ndarray_base _call(
             self,
             list in_args, list out_args,
             const shape_t& a_shape, axis, dtype,
@@ -297,7 +298,7 @@ cdef class _AbstractReductionKernel:
         cdef Py_ssize_t contiguous_size = -1
         cdef Py_ssize_t block_size, block_stride, out_block_num = 0
         cdef shape_t in_shape, out_shape
-        cdef ndarray ret
+        cdef _ndarray_base ret
         cdef bint cub_success
 
         if dtype is not None:
@@ -332,7 +333,7 @@ cdef class _AbstractReductionKernel:
             raise ValueError(('zero-size array to reduction operation'
                               ' %s which has no identity') % self.name)
 
-        in_args = [x if isinstance(x, ndarray) else
+        in_args = [x if isinstance(x, _ndarray_base) else
                    _scalar.CScalar.from_numpy_scalar_with_dtype(x, t)
                    for x, t in zip(in_args, in_types)]
 
@@ -537,12 +538,12 @@ cdef class _SimpleReductionKernel(_AbstractReductionKernel):
         self._routine_cache = {}
         self._sort_reduce_axis = sort_reduce_axis
 
-    def __call__(self, object a, axis=None, dtype=None, ndarray out=None,
+    def __call__(self, object a, axis=None, dtype=None, _ndarray_base out=None,
                  bint keepdims=False):
 
-        cdef ndarray arr
+        cdef _ndarray_base arr
 
-        if isinstance(a, ndarray):
+        if isinstance(a, _ndarray_base):
             arr = a
         elif hasattr(a, '__cuda_array_interface__'):
             arr = _convert_object_with_cuda_array_interface(a)
@@ -551,7 +552,7 @@ cdef class _SimpleReductionKernel(_AbstractReductionKernel):
         else:
             raise TypeError(
                 'Argument \'a\' has incorrect type (expected %s, got %s)' %
-                (ndarray, type(a)))
+                (cupy.ndarray, type(a)))
         in_args = [arr]
 
         dev_id = device.get_device_id()
@@ -757,10 +758,10 @@ cdef class ReductionKernel(_AbstractReductionKernel):
             self, list in_args, list out_args, dtype):
 
         in_ndarray_types = tuple(
-            [a.dtype.type if isinstance(a, ndarray) else None
+            [a.dtype.type if isinstance(a, _ndarray_base) else None
              for a in in_args])
         out_ndarray_types = tuple(
-            [a.dtype.type if isinstance(a, ndarray) else None
+            [a.dtype.type if isinstance(a, _ndarray_base) else None
              for a in out_args])
         in_types, out_types, type_map = _decide_params_type(
             self.in_params, self.out_params,

--- a/cupy/_core/_routines_indexing.pxd
+++ b/cupy/_core/_routines_indexing.pxd
@@ -1,15 +1,15 @@
-from cupy._core.core cimport ndarray
+from cupy._core.core cimport _ndarray_base
 
 
-cpdef ndarray _ndarray_argwhere(ndarray self)
-cdef ndarray _ndarray_getitem(ndarray self, slices)
-cdef _ndarray_setitem(ndarray self, slices, value)
-cdef tuple _ndarray_nonzero(ndarray self)
-cdef _ndarray_scatter_add(ndarray self, slices, value)
-cdef _ndarray_scatter_max(ndarray self, slices, value)
-cdef _ndarray_scatter_min(ndarray self, slices, value)
-cdef ndarray _ndarray_take(ndarray self, indices, axis, out)
-cdef ndarray _ndarray_put(ndarray self, indices, values, mode)
-cdef ndarray _ndarray_choose(ndarray self, choices, out, mode)
-cdef ndarray _ndarray_compress(ndarray self, condition, axis, out)
-cdef ndarray _ndarray_diagonal(ndarray self, offset, axis1, axis2)
+cpdef _ndarray_base _ndarray_argwhere(_ndarray_base self)
+cdef _ndarray_base _ndarray_getitem(_ndarray_base self, slices)
+cdef _ndarray_setitem(_ndarray_base self, slices, value)
+cdef tuple _ndarray_nonzero(_ndarray_base self)
+cdef _ndarray_scatter_add(_ndarray_base self, slices, value)
+cdef _ndarray_scatter_max(_ndarray_base self, slices, value)
+cdef _ndarray_scatter_min(_ndarray_base self, slices, value)
+cdef _ndarray_base _ndarray_take(_ndarray_base self, indices, axis, out)
+cdef _ndarray_base _ndarray_put(_ndarray_base self, indices, values, mode)
+cdef _ndarray_base _ndarray_choose(_ndarray_base self, choices, out, mode)
+cdef _ndarray_base _ndarray_compress(_ndarray_base self, condition, axis, out)
+cdef _ndarray_base _ndarray_diagonal(_ndarray_base self, offset, axis1, axis2)

--- a/cupy/_core/_routines_indexing.pyx
+++ b/cupy/_core/_routines_indexing.pyx
@@ -18,17 +18,17 @@ from cupy._core._carray cimport strides_t
 from cupy._core cimport core
 from cupy._core cimport _routines_math as _math
 from cupy._core cimport _routines_manipulation as _manipulation
-from cupy._core.core cimport ndarray
+from cupy._core.core cimport _ndarray_base
 from cupy._core cimport internal
 
 
-# ndarray members
+# _ndarray_base members
 
 
-cdef ndarray _ndarray_getitem(ndarray self, slices):
+cdef _ndarray_base _ndarray_getitem(_ndarray_base self, slices):
     cdef Py_ssize_t axis
     cdef list slice_list
-    cdef ndarray a, mask
+    cdef _ndarray_base a, mask
 
     slice_list = _prepare_slice_list(slices)
     a, adv = _view_getitem(self, slice_list)
@@ -46,15 +46,15 @@ cdef ndarray _ndarray_getitem(ndarray self, slices):
     return _getitem_multiple(a, axis, slice_list)
 
 
-cdef _ndarray_setitem(ndarray self, slices, value):
-    if isinstance(value, ndarray):
+cdef _ndarray_setitem(_ndarray_base self, slices, value):
+    if isinstance(value, _ndarray_base):
         value = _squeeze_leading_unit_dims(value)
     _scatter_op(self, slices, value, 'update')
 
 
-cdef tuple _ndarray_nonzero(ndarray self):
+cdef tuple _ndarray_nonzero(_ndarray_base self):
     cdef int ndim
-    cdef ndarray dst = _ndarray_argwhere(self)
+    cdef _ndarray_base dst = _ndarray_argwhere(self)
     ndim = self.ndim
     if ndim >= 1:
         return tuple([dst[:, i] for i in range(ndim)])
@@ -65,12 +65,12 @@ cdef tuple _ndarray_nonzero(ndarray self):
         return cupy.zeros(dst.shape[0], numpy.int64),
 
 
-# TODO(kataoka): Rename the function because `ndarray` does not have
+# TODO(kataoka): Rename the function because `_ndarray_base` does not have
 # `argwhere` method
-cpdef ndarray _ndarray_argwhere(ndarray self):
+cpdef _ndarray_base _ndarray_argwhere(_ndarray_base self):
     cdef Py_ssize_t count_nonzero
     cdef int ndim
-    cdef ndarray nonzero
+    cdef _ndarray_base nonzero
     numpy_int64 = numpy.int64
     if self.size == 0:
         count_nonzero = 0
@@ -102,7 +102,7 @@ cpdef ndarray _ndarray_argwhere(ndarray self):
         count_nonzero = int(scan_index[-1])  # synchronize!
 
     ndim = self._shape.size()
-    dst = core._ndarray((count_nonzero, ndim), dtype=numpy_int64)
+    dst = core.ndarray((count_nonzero, ndim), dtype=numpy_int64)
     if dst.size == 0:
         return dst
 
@@ -120,19 +120,19 @@ cpdef ndarray _ndarray_argwhere(ndarray self):
     return dst
 
 
-cdef _ndarray_scatter_add(ndarray self, slices, value):
+cdef _ndarray_scatter_add(_ndarray_base self, slices, value):
     _scatter_op(self, slices, value, 'add')
 
 
-cdef _ndarray_scatter_max(ndarray self, slices, value):
+cdef _ndarray_scatter_max(_ndarray_base self, slices, value):
     _scatter_op(self, slices, value, 'max')
 
 
-cdef _ndarray_scatter_min(ndarray self, slices, value):
+cdef _ndarray_scatter_min(_ndarray_base self, slices, value):
     _scatter_op(self, slices, value, 'min')
 
 
-cdef ndarray _ndarray_take(ndarray self, indices, axis, out):
+cdef _ndarray_base _ndarray_take(_ndarray_base self, indices, axis, out):
     cdef Py_ssize_t ndim = self._shape.size()
     if axis is None:
         return _take(self, indices, 0, ndim, out)
@@ -145,16 +145,16 @@ cdef ndarray _ndarray_take(ndarray self, indices, axis, out):
         return _take(self, indices, axis, axis + 1, out)
 
 
-cdef ndarray _ndarray_put(ndarray self, indices, values, mode):
+cdef _ndarray_base _ndarray_put(_ndarray_base self, indices, values, mode):
     if mode not in ('raise', 'wrap', 'clip'):
         raise ValueError('clipmode not understood')
 
     n = self.size
-    if not isinstance(indices, ndarray):
+    if not isinstance(indices, _ndarray_base):
         indices = core.array(indices)
     indices = indices.ravel()
 
-    if not isinstance(values, ndarray):
+    if not isinstance(values, _ndarray_base):
         values = core.array(values, dtype=self.dtype)
     if values.size == 0:
         return
@@ -170,7 +170,7 @@ cdef ndarray _ndarray_put(ndarray self, indices, values, mode):
         _put_clip_kernel(indices, values, values.size, n, self)
 
 
-cdef ndarray _ndarray_choose(ndarray self, choices, out, mode):
+cdef _ndarray_base _ndarray_choose(_ndarray_base self, choices, out, mode):
     a = self
     n = choices.shape[0]
 
@@ -184,7 +184,7 @@ cdef ndarray _ndarray_choose(ndarray self, choices, out, mode):
     ba, bcs = _manipulation.broadcast(a, choices).values
 
     if out is None:
-        out = core._ndarray(ba.shape[1:], choices.dtype)
+        out = core.ndarray(ba.shape[1:], choices.dtype)
 
     n_channel = numpy.prod(bcs[0].shape)
     if mode == 'raise':
@@ -202,13 +202,13 @@ cdef ndarray _ndarray_choose(ndarray self, choices, out, mode):
     return out
 
 
-cdef ndarray _ndarray_compress(ndarray self, condition, axis, out):
+cdef _ndarray_base _ndarray_compress(_ndarray_base self, condition, axis, out):
     a = self
 
     if numpy.isscalar(condition):
         raise ValueError('condition must be a 1-d array')
 
-    if not isinstance(condition, ndarray):
+    if not isinstance(condition, _ndarray_base):
         condition = core.array(condition, dtype=int)
         if condition.ndim != 1:
             raise ValueError('condition must be a 1-d array')
@@ -220,14 +220,14 @@ cdef ndarray _ndarray_compress(ndarray self, condition, axis, out):
     return _ndarray_take(a, res[0], axis, out)
 
 
-cdef ndarray _ndarray_diagonal(ndarray self, offset, axis1, axis2):
+cdef _ndarray_base _ndarray_diagonal(_ndarray_base self, offset, axis1, axis2):
     return _diagonal(self, offset, axis1, axis2)
 
 
 # private/internal
 
 
-cdef ndarray _squeeze_leading_unit_dims(ndarray src):
+cdef _ndarray_base _squeeze_leading_unit_dims(_ndarray_base src):
     # remove leading 1s from the shape greedily.
     # TODO(kataoka): compute requested ndim and do not remove too much for
     # printing correct shape in error message.
@@ -278,7 +278,7 @@ cpdef list _prepare_slice_list(slices):
     # - Other array-like (including ()-shaped array) in indices forces to
     #   return a new array.
     for i, s in enumerate(slice_list):
-        if s is None or s is Ellipsis or isinstance(s, (slice, ndarray)):
+        if s is None or s is Ellipsis or isinstance(s, (slice, _ndarray_base)):
             continue
 
         fix_empty_dtype = False
@@ -309,7 +309,7 @@ cpdef list _prepare_slice_list(slices):
     return slice_list
 
 
-cdef tuple _view_getitem(ndarray a, list slice_list):
+cdef tuple _view_getitem(_ndarray_base a, list slice_list):
     # Process scalar/slice/ellipsis indices
     # Returns a 2-tuple
     # - [0] (ndarray): view of a
@@ -322,7 +322,7 @@ cdef tuple _view_getitem(ndarray a, list slice_list):
     #         cupy.ndarray
     cdef shape_t shape
     cdef strides_t strides
-    cdef ndarray v
+    cdef _ndarray_base v
     cdef Py_ssize_t ndim_a, axis_a, ndim_v, axis_v, ndim_ellipsis
     cdef Py_ssize_t i, k, offset, start
     cdef Py_ssize_t s_start, s_stop, s_step, dim, ind
@@ -343,7 +343,7 @@ cdef tuple _view_getitem(ndarray a, list slice_list):
                 raise IndexError(
                     "an index can only have a single ellipsis ('...')")
             has_ellipsis = True
-        elif isinstance(s, ndarray):
+        elif isinstance(s, _ndarray_base):
             kind = ord(s.dtype.kind)
             if kind == b'b':
                 k = s.ndim
@@ -382,7 +382,7 @@ cdef tuple _view_getitem(ndarray a, list slice_list):
             strides.push_back(0)
             axis_v += 1
             array_like_flags.push_back(False)
-        elif isinstance(s, ndarray):
+        elif isinstance(s, _ndarray_base):
             k = array_ndims[i]
             index_list.append((s, axis_v, k))
             i += 1
@@ -715,7 +715,7 @@ _getitem_mask_kernel = ElementwiseKernel(
     'cupy_getitem_mask')
 
 
-cdef _check_mask_shape(ndarray a, ndarray mask, Py_ssize_t axis):
+cdef _check_mask_shape(_ndarray_base a, _ndarray_base mask, Py_ssize_t axis):
     cdef Py_ssize_t i, a_sh, m_sh
     for i, m_sh in enumerate(mask._shape):
         a_sh = a._shape[axis + i]
@@ -727,8 +727,9 @@ cdef _check_mask_shape(ndarray a, ndarray mask, Py_ssize_t axis):
             )
 
 
-cpdef _prepare_mask_indexing_single(ndarray a, ndarray mask, Py_ssize_t axis):
-    cdef ndarray mask_scanned, mask_br, mask_br_scanned
+cpdef _prepare_mask_indexing_single(
+        _ndarray_base a, _ndarray_base mask, Py_ssize_t axis):
+    cdef _ndarray_base mask_scanned, mask_br, mask_br_scanned
     cdef int n_true
     cdef tuple lshape, rshape, out_shape, a_shape
     cdef Py_ssize_t a_ndim, mask_ndim
@@ -782,19 +783,21 @@ cpdef _prepare_mask_indexing_single(ndarray a, ndarray mask, Py_ssize_t axis):
     return mask, mask_scanned, masked_shape
 
 
-cpdef ndarray _getitem_mask_single(ndarray a, ndarray mask, int axis):
-    cdef ndarray mask_scanned
+cpdef _ndarray_base _getitem_mask_single(
+        _ndarray_base a, _ndarray_base mask, int axis):
+    cdef _ndarray_base mask_scanned
     cdef tuple masked_shape
 
     mask, mask_scanned, masked_shape = _prepare_mask_indexing_single(
         a, mask, axis)
-    out = core._ndarray(masked_shape, dtype=a.dtype)
+    out = core.ndarray(masked_shape, dtype=a.dtype)
     if out.size == 0:
         return out
     return _getitem_mask_kernel(a, mask, mask_scanned, out)
 
 
-cdef ndarray _take(ndarray a, indices, int start, int stop, ndarray out=None):
+cdef _ndarray_base _take(
+        _ndarray_base a, indices, int start, int stop, _ndarray_base out=None):
     # Take along (flattened) axes from start to stop.
     # When start + 1 == stop this function behaves similarly to np.take
     cdef tuple out_shape, ind_shape, indices_shape
@@ -807,7 +810,7 @@ cdef ndarray _take(ndarray a, indices, int start, int stop, ndarray out=None):
         indices_shape = ()
         cdim = 1
     else:
-        if not isinstance(indices, ndarray):
+        if not isinstance(indices, _ndarray_base):
             indices = core.array(indices, dtype=int)
         indices_shape = indices.shape
         cdim = indices.size
@@ -832,7 +835,7 @@ cdef ndarray _take(ndarray a, indices, int start, int stop, ndarray out=None):
             index_range *= a._shape[i]
 
     if out is None:
-        out = core._ndarray(out_shape, dtype=a.dtype)
+        out = core.ndarray(out_shape, dtype=a.dtype)
     else:
         if out.dtype != a.dtype:
             raise TypeError('Output dtype mismatch')
@@ -841,7 +844,7 @@ cdef ndarray _take(ndarray a, indices, int start, int stop, ndarray out=None):
     if a.size == 0 and out.size != 0:
         raise IndexError('cannot do a non-empty take from an empty axes.')
 
-    if isinstance(indices, ndarray):
+    if isinstance(indices, _ndarray_base):
         return _take_kernel(
             a.reduced_view(), indices, ldim, cdim, rdim, index_range, out)
     else:
@@ -850,8 +853,8 @@ cdef ndarray _take(ndarray a, indices, int start, int stop, ndarray out=None):
 
 
 cdef _scatter_op_single(
-        ndarray a, ndarray indices, value, Py_ssize_t start, Py_ssize_t stop,
-        op=''):
+        _ndarray_base a, _ndarray_base indices, value, Py_ssize_t start,
+        Py_ssize_t stop, op=''):
     # When op == 'update', this function behaves similarly to
     # a code below using NumPy under the condition that a = a._reshape(shape)
     # does not invoke copy.
@@ -864,11 +867,11 @@ cdef _scatter_op_single(
     # a[slices] = value
     cdef Py_ssize_t ndim, adim, cdim, rdim
     cdef tuple a_shape, indices_shape, lshape, rshape, v_shape
-    cdef ndarray v
+    cdef _ndarray_base v
 
     ndim = a._shape.size()
 
-    if not isinstance(value, ndarray):
+    if not isinstance(value, _ndarray_base):
         v = core.array(value, dtype=a.dtype)
     else:
         v = value.astype(a.dtype, copy=False)
@@ -929,8 +932,9 @@ cdef _scatter_op_single(
         raise ValueError('provided op is not supported')
 
 
-cdef _scatter_op_mask_single(ndarray a, ndarray mask, v, Py_ssize_t axis, op):
-    cdef ndarray mask_scanned, src
+cdef _scatter_op_mask_single(
+        _ndarray_base a, _ndarray_base mask, v, Py_ssize_t axis, op):
+    cdef _ndarray_base mask_scanned, src
     cdef tuple masked_shape
 
     mask, mask_scanned, masked_shape = _prepare_mask_indexing_single(
@@ -938,7 +942,7 @@ cdef _scatter_op_mask_single(ndarray a, ndarray mask, v, Py_ssize_t axis, op):
     if internal.prod(masked_shape) == 0:
         return
 
-    if not isinstance(v, ndarray):
+    if not isinstance(v, _ndarray_base):
         src = core.array(v, dtype=a.dtype)
     else:
         src = v
@@ -959,9 +963,9 @@ cdef _scatter_op_mask_single(ndarray a, ndarray mask, v, Py_ssize_t axis, op):
         raise ValueError('provided op is not supported')
 
 
-cdef _scatter_op(ndarray a, slices, value, op):
+cdef _scatter_op(_ndarray_base a, slices, value, op):
     cdef Py_ssize_t i, start, stop, axis
-    cdef ndarray v, x, y, reduced_idx, mask
+    cdef _ndarray_base v, x, y, reduced_idx, mask
     cdef list slice_list
 
     slice_list = _prepare_slice_list(slices)
@@ -984,7 +988,7 @@ cdef _scatter_op(ndarray a, slices, value, op):
     y = a
 
     if op == 'update':
-        if not isinstance(value, ndarray):
+        if not isinstance(value, _ndarray_base):
             y.fill(value)
             return
         x = value
@@ -1009,8 +1013,8 @@ cdef _scatter_op(ndarray a, slices, value, op):
     raise ValueError('this op is not supported')
 
 
-cdef ndarray _diagonal(
-        ndarray a, Py_ssize_t offset=0, Py_ssize_t axis1=0,
+cdef _ndarray_base _diagonal(
+        _ndarray_base a, Py_ssize_t offset=0, Py_ssize_t axis1=0,
         Py_ssize_t axis2=1):
     cdef Py_ssize_t ndim = a.ndim
     if not (-ndim <= axis1 < ndim and -ndim <= axis2 < ndim):
@@ -1037,7 +1041,7 @@ cdef ndarray _diagonal(
     diag_size = max(0, min(a.shape[-2], a.shape[-1] - offset))
     ret_shape = a.shape[:-2] + (diag_size,)
     if diag_size == 0:
-        return core._ndarray(ret_shape, dtype=a.dtype)
+        return core.ndarray(ret_shape, dtype=a.dtype)
 
     a = a[..., :diag_size, offset:offset + diag_size]
 
@@ -1059,12 +1063,12 @@ _prepare_array_indexing = ElementwiseKernel(
 
 
 cdef tuple _prepare_multiple_array_indexing(
-    ndarray a, Py_ssize_t start, list slices
+    _ndarray_base a, Py_ssize_t start, list slices
 ):
     # slices consist of ndarray
     cdef list indices = [], shapes = []  # int ndarrays
     cdef Py_ssize_t i, stop, stride
-    cdef ndarray reduced_idx, s
+    cdef _ndarray_base reduced_idx, s
 
     for s in slices:
         if s.dtype.kind == 'b':
@@ -1080,7 +1084,7 @@ cdef tuple _prepare_multiple_array_indexing(
     # br = _manipulation.broadcast(*indices)
     # indices = list(br.values)
 
-    reduced_idx = core._ndarray(
+    reduced_idx = core.ndarray(
         internal._broadcast_shapes(shapes), dtype=numpy.int64)
     reduced_idx.fill(0)
     stride = 1
@@ -1096,7 +1100,8 @@ cdef tuple _prepare_multiple_array_indexing(
     return reduced_idx, start, stop
 
 
-cdef ndarray _getitem_multiple(ndarray a, Py_ssize_t start, list slices):
+cdef _ndarray_base _getitem_multiple(
+        _ndarray_base a, Py_ssize_t start, list slices):
     reduced_idx, start, stop = _prepare_multiple_array_indexing(
         a, start, slices)
     return _take(a, reduced_idx, start, stop)

--- a/cupy/_core/_routines_linalg.pxd
+++ b/cupy/_core/_routines_linalg.pxd
@@ -1,18 +1,19 @@
 from cupy._core._carray cimport shape_t
-from cupy._core.core cimport ndarray
+from cupy._core.core cimport _ndarray_base
 
 
 cpdef compute_type_to_str(compute_type)
 
 cpdef get_compute_type(dtype)
 
-cpdef ndarray dot(ndarray a, ndarray b, ndarray out=*)
+cpdef _ndarray_base dot(_ndarray_base a, _ndarray_base b, _ndarray_base out=*)
 
-cpdef ndarray tensordot_core(
-    ndarray a, ndarray b, ndarray out, Py_ssize_t n, Py_ssize_t m,
-    Py_ssize_t k, const shape_t& ret_shape)
+cpdef _ndarray_base tensordot_core(
+    _ndarray_base a, _ndarray_base b, _ndarray_base out, Py_ssize_t n,
+    Py_ssize_t m, Py_ssize_t k, const shape_t& ret_shape)
 
-cpdef ndarray matmul(ndarray a, ndarray b, ndarray out=*)
+cpdef _ndarray_base matmul(
+    _ndarray_base a, _ndarray_base b, _ndarray_base out=*)
 
 
 cpdef enum:

--- a/cupy/_core/_routines_linalg.pyx
+++ b/cupy/_core/_routines_linalg.pyx
@@ -21,7 +21,7 @@ from cupy._core._scalar cimport get_typename
 from cupy._core.core cimport _internal_ascontiguousarray
 from cupy._core.core cimport _ndarray_init
 from cupy._core.core cimport ascontiguousarray
-from cupy._core.core cimport ndarray
+from cupy._core.core cimport _ndarray_base
 from cupy._core cimport _memory_range
 from cupy._core cimport _routines_manipulation as _manipulation
 from cupy._core cimport _routines_math as _math
@@ -306,9 +306,9 @@ __global__ void _tensordot_core_int_kernel(
     return ker
 
 
-cdef ndarray _integral_tensordot_core(
-        ndarray a, ndarray b, ndarray out, Py_ssize_t m, Py_ssize_t n,
-        Py_ssize_t k, str dtype, const shape_t& ret_shape):
+cdef _ndarray_base _integral_tensordot_core(
+        _ndarray_base a, _ndarray_base b, _ndarray_base out, Py_ssize_t m,
+        Py_ssize_t n, Py_ssize_t k, str dtype, const shape_t& ret_shape):
 
     # TODO(leofang): autotune the tuning parameters here? See the discussion
     # in this thread: https://groups.google.com/a/icl.utk.edu/g/magma-user/c/igc66uduTfI  # NOQA
@@ -353,7 +353,8 @@ cpdef get_compute_type(dtype):
 
 
 @cython.profile(False)
-cpdef inline tuple _mat_to_cublas_contiguous(ndarray a, Py_ssize_t trans):
+cpdef inline tuple _mat_to_cublas_contiguous(
+        _ndarray_base a, Py_ssize_t trans):
     assert a.ndim == 2
     if a._f_contiguous:
         # builtin max function is not used for Cython 0.23
@@ -366,7 +367,8 @@ cpdef inline tuple _mat_to_cublas_contiguous(ndarray a, Py_ssize_t trans):
     return a, 1 - trans, a._strides[0] // a.itemsize
 
 
-cpdef ndarray dot(ndarray a, ndarray b, ndarray out=None):
+cpdef _ndarray_base dot(
+        _ndarray_base a, _ndarray_base b, _ndarray_base out=None):
     cdef Py_ssize_t a_ndim, b_ndim, a_axis, b_axis, n, m, k
     cdef bint input_a_is_vec, input_b_is_vec
     cdef shape_t ret_shape, shape
@@ -431,15 +433,15 @@ cpdef ndarray dot(ndarray a, ndarray b, ndarray out=None):
     return tensordot_core(a, b, out, n, m, k, ret_shape)
 
 
-cpdef ndarray tensordot_core(
-        ndarray a, ndarray b, ndarray out, Py_ssize_t n, Py_ssize_t m,
-        Py_ssize_t k, const shape_t& ret_shape):
+cpdef _ndarray_base tensordot_core(
+        _ndarray_base a, _ndarray_base b, _ndarray_base out, Py_ssize_t n,
+        Py_ssize_t m, Py_ssize_t k, const shape_t& ret_shape):
     # out, if specified, must be C-contiguous and have correct shape.
     cdef shape_t shape
     cdef Py_ssize_t inca, incb, transa, transb, lda, ldb
     cdef Py_ssize_t mode
     cdef intptr_t handle
-    cdef ndarray copy_to_out = None
+    cdef _ndarray_base copy_to_out = None
     cdef str dtype = a.dtype.char
     cdef int compute_capability = int(device.get_compute_capability())
     if dtype != b.dtype.char:
@@ -591,10 +593,10 @@ cpdef ndarray tensordot_core(
     return out
 
 
-cpdef ndarray tensordot_core_v11(
+cpdef _ndarray_base tensordot_core_v11(
         Py_ssize_t transa, Py_ssize_t transb, Py_ssize_t m, Py_ssize_t n,
-        Py_ssize_t k, ndarray a, Py_ssize_t lda, ndarray b, Py_ssize_t ldb,
-        ndarray c, Py_ssize_t ldc):
+        Py_ssize_t k, _ndarray_base a, Py_ssize_t lda, _ndarray_base b,
+        Py_ssize_t ldb, _ndarray_base c, Py_ssize_t ldc):
     cdef float one_f, zero_f
     cdef double one_d, zero_d
     cdef cuComplex one_F, zero_F
@@ -664,7 +666,8 @@ cpdef ndarray tensordot_core_v11(
         algo)
 
 
-cdef Py_ssize_t _get_stride_for_strided_batched_gemm(ndarray a) except? 0:
+cdef Py_ssize_t _get_stride_for_strided_batched_gemm(
+        _ndarray_base a) except? 0:
     cdef int ndim = a._shape.size()
     assert ndim > 2
     assert a._c_contiguous
@@ -677,7 +680,7 @@ cdef _mat_ptrs_kernel = ElementwiseKernel(
     reduce_dims=False)
 
 
-cpdef ndarray _mat_ptrs(ndarray a):
+cpdef _ndarray_base _mat_ptrs(_ndarray_base a):
     """Creates an array of pointers to matrices
     Args:
         a: A batch of matrices on GPU.
@@ -690,20 +693,21 @@ cpdef ndarray _mat_ptrs(ndarray a):
     cdef int ndim = a._shape.size()
     assert ndim > 2
     cdef Py_ssize_t sh_, st_
-    cdef ndarray idx
+    cdef _ndarray_base idx
     idx = _mat_ptrs_kernel(
         a.data.ptr, a._strides[0],
-        core._ndarray((a._shape[0],), dtype=numpy.uintp))
+        core.ndarray((a._shape[0],), dtype=numpy.uintp))
 
     for i in range(1, ndim - 2):
         idx = _mat_ptrs_kernel(
             idx[:, None], a._strides[i],
-            core._ndarray((idx.size, a._shape[i]), dtype=numpy.uintp))
+            core.ndarray((idx.size, a._shape[i]), dtype=numpy.uintp))
         idx = idx.ravel()
     return idx
 
 
-cpdef ndarray matmul(ndarray a, ndarray b, ndarray out=None):
+cpdef _ndarray_base matmul(
+        _ndarray_base a, _ndarray_base b, _ndarray_base out=None):
     """Matrix product of two arrays.
 
     Returns the matrix product of two arrays and is the implementation of
@@ -730,7 +734,7 @@ cpdef ndarray matmul(ndarray a, ndarray b, ndarray out=None):
     cdef Py_ssize_t i, n, m, ka, kb, a_sh, b_sh, c_sh, ldc
     cdef Py_ssize_t batchCount, a_part_outshape, b_part_outshape
     cdef int orig_a_ndim, orig_b_ndim, a_ndim, b_ndim, ndim
-    cdef ndarray ap, bp, cp, c_view
+    cdef _ndarray_base ap, bp, cp, c_view
     cdef bint use_broadcast
 
     orig_a_ndim = a._shape.size()
@@ -853,12 +857,12 @@ cpdef ndarray matmul(ndarray a, ndarray b, ndarray out=None):
     ):
         c = out
     else:
-        c = core._ndarray(out_shape, dtype=dtype)
+        c = core.ndarray(out_shape, dtype=dtype)
         if out is None:
             if dtype == ret_dtype:
                 out = c
             else:
-                out = core._ndarray(out_shape, dtype=ret_dtype)
+                out = core.ndarray(out_shape, dtype=ret_dtype)
 
     if orig_a_ndim == 1 or orig_b_ndim == 1:
         c_view = c.view()

--- a/cupy/_core/_routines_logic.pxd
+++ b/cupy/_core/_routines_logic.pxd
@@ -1,11 +1,11 @@
-from cupy._core.core cimport ndarray
+from cupy._core.core cimport _ndarray_base
 
 
-cdef ndarray _ndarray_all(ndarray self, axis, out, keepdims)
-cdef ndarray _ndarray_any(ndarray self, axis, out, keepdims)
-cdef ndarray _ndarray_greater(ndarray self, other)
-cdef ndarray _ndarray_greater_equal(ndarray self, other)
-cdef ndarray _ndarray_less(ndarray self, other)
-cdef ndarray _ndarray_less_equal(ndarray self, other)
-cdef ndarray _ndarray_equal(ndarray self, other)
-cdef ndarray _ndarray_not_equal(ndarray self, other)
+cdef _ndarray_base _ndarray_all(_ndarray_base self, axis, out, keepdims)
+cdef _ndarray_base _ndarray_any(_ndarray_base self, axis, out, keepdims)
+cdef _ndarray_base _ndarray_greater(_ndarray_base self, other)
+cdef _ndarray_base _ndarray_greater_equal(_ndarray_base self, other)
+cdef _ndarray_base _ndarray_less(_ndarray_base self, other)
+cdef _ndarray_base _ndarray_less_equal(_ndarray_base self, other)
+cdef _ndarray_base _ndarray_equal(_ndarray_base self, other)
+cdef _ndarray_base _ndarray_not_equal(_ndarray_base self, other)

--- a/cupy/_core/_routines_logic.pyx
+++ b/cupy/_core/_routines_logic.pyx
@@ -1,38 +1,38 @@
 from cupy._core._kernel import create_ufunc
 from cupy._core._reduction import create_reduction_func
 
-from cupy._core.core cimport ndarray
+from cupy._core.core cimport _ndarray_base
 
 
-cdef ndarray _ndarray_all(ndarray self, axis, out, keepdims):
+cdef _ndarray_base _ndarray_all(_ndarray_base self, axis, out, keepdims):
     return _all(self, axis=axis, out=out, keepdims=keepdims)
 
 
-cdef ndarray _ndarray_any(ndarray self, axis, out, keepdims):
+cdef _ndarray_base _ndarray_any(_ndarray_base self, axis, out, keepdims):
     return _any(self, axis=axis, out=out, keepdims=keepdims)
 
 
-cdef ndarray _ndarray_greater(ndarray self, other):
+cdef _ndarray_base _ndarray_greater(_ndarray_base self, other):
     return _greater(self, other)
 
 
-cdef ndarray _ndarray_greater_equal(ndarray self, other):
+cdef _ndarray_base _ndarray_greater_equal(_ndarray_base self, other):
     return _greater_equal(self, other)
 
 
-cdef ndarray _ndarray_less(ndarray self, other):
+cdef _ndarray_base _ndarray_less(_ndarray_base self, other):
     return _less(self, other)
 
 
-cdef ndarray _ndarray_less_equal(ndarray self, other):
+cdef _ndarray_base _ndarray_less_equal(_ndarray_base self, other):
     return _less_equal(self, other)
 
 
-cdef ndarray _ndarray_equal(ndarray self, other):
+cdef _ndarray_base _ndarray_equal(_ndarray_base self, other):
     return _equal(self, other)
 
 
-cdef ndarray _ndarray_not_equal(ndarray self, other):
+cdef _ndarray_base _ndarray_not_equal(_ndarray_base self, other):
     return _not_equal(self, other)
 
 

--- a/cupy/_core/_routines_manipulation.pxd
+++ b/cupy/_core/_routines_manipulation.pxd
@@ -2,7 +2,7 @@ from libcpp cimport vector
 
 from cupy._core._carray cimport shape_t
 from cupy._core._carray cimport strides_t
-from cupy._core.core cimport ndarray
+from cupy._core.core cimport _ndarray_base
 
 
 cdef class broadcast:
@@ -13,26 +13,28 @@ cdef class broadcast:
         readonly Py_ssize_t nd
 
 
-cdef _ndarray_shape_setter(ndarray self, newshape)
-cdef ndarray _ndarray_reshape(ndarray self, tuple shape, order)
-cdef ndarray _ndarray_transpose(ndarray self, tuple axes)
-cdef ndarray _ndarray_swapaxes(
-    ndarray self, Py_ssize_t axis1, Py_ssize_t axis2)
-cdef ndarray _ndarray_flatten(ndarray self, order)
-cdef ndarray _ndarray_ravel(ndarray self, order)
-cdef ndarray _ndarray_squeeze(ndarray self, axis)
-cdef ndarray _ndarray_repeat(ndarray self, repeats, axis)
+cdef _ndarray_shape_setter(_ndarray_base self, newshape)
+cdef _ndarray_base _ndarray_reshape(_ndarray_base self, tuple shape, order)
+cdef _ndarray_base _ndarray_transpose(_ndarray_base self, tuple axes)
+cdef _ndarray_base _ndarray_swapaxes(
+    _ndarray_base self, Py_ssize_t axis1, Py_ssize_t axis2)
+cdef _ndarray_base _ndarray_flatten(_ndarray_base self, order)
+cdef _ndarray_base _ndarray_ravel(_ndarray_base self, order)
+cdef _ndarray_base _ndarray_squeeze(_ndarray_base self, axis)
+cdef _ndarray_base _ndarray_repeat(_ndarray_base self, repeats, axis)
 
-cpdef ndarray _expand_dims(ndarray a, tuple axis)
-cpdef ndarray moveaxis(ndarray a, source, destination)
-cpdef ndarray _move_single_axis(ndarray a, Py_ssize_t source,
-                                Py_ssize_t destination)
-cpdef ndarray rollaxis(ndarray a, Py_ssize_t axis, Py_ssize_t start=*)
-cpdef ndarray broadcast_to(ndarray array, shape)
-cpdef ndarray _reshape(ndarray self, const shape_t &shape_spec)
-cpdef ndarray _T(ndarray self)
-cpdef ndarray _transpose(ndarray self, const vector.vector[Py_ssize_t] &axes)
-cpdef ndarray _concatenate(
-    list arrays, Py_ssize_t axis, tuple shape, ndarray out, str casting)
-cpdef ndarray concatenate_method(
-    tup, int axis, ndarray out=*, dtype=*, casting=*)
+cpdef _ndarray_base _expand_dims(_ndarray_base a, tuple axis)
+cpdef _ndarray_base moveaxis(_ndarray_base a, source, destination)
+cpdef _ndarray_base _move_single_axis(
+    _ndarray_base a, Py_ssize_t source, Py_ssize_t destination)
+cpdef _ndarray_base rollaxis(
+    _ndarray_base a, Py_ssize_t axis, Py_ssize_t start=*)
+cpdef _ndarray_base broadcast_to(_ndarray_base array, shape)
+cpdef _ndarray_base _reshape(_ndarray_base self, const shape_t &shape_spec)
+cpdef _ndarray_base _T(_ndarray_base self)
+cpdef _ndarray_base _transpose(
+    _ndarray_base self, const vector.vector[Py_ssize_t] &axes)
+cpdef _ndarray_base _concatenate(
+    list arrays, Py_ssize_t axis, tuple shape, _ndarray_base out, str casting)
+cpdef _ndarray_base concatenate_method(
+    tup, int axis, _ndarray_base out=*, dtype=*, casting=*)

--- a/cupy/_core/_routines_manipulation.pyx
+++ b/cupy/_core/_routines_manipulation.pyx
@@ -15,7 +15,7 @@ from libcpp cimport vector
 from cupy._core._dtype cimport get_dtype
 from cupy._core cimport _routines_indexing as _indexing
 from cupy._core cimport core
-from cupy._core.core cimport ndarray
+from cupy._core.core cimport _ndarray_base
 from cupy._core cimport internal
 from cupy._core._kernel cimport _check_peer_access
 
@@ -52,10 +52,10 @@ cdef class broadcast:
         self.size = internal.prod(shape)
 
 
-# ndarray members
+# _ndarray_base members
 
 
-cdef _ndarray_shape_setter(ndarray self, newshape):
+cdef _ndarray_shape_setter(_ndarray_base self, newshape):
     cdef shape_t shape, strides
     if not cpython.PySequence_Check(newshape):
         newshape = (newshape,)
@@ -68,7 +68,7 @@ cdef _ndarray_shape_setter(ndarray self, newshape):
     self._set_shape_and_strides(shape, strides, False, True)
 
 
-cdef ndarray _ndarray_reshape(ndarray self, tuple shape, order):
+cdef _ndarray_base _ndarray_reshape(_ndarray_base self, tuple shape, order):
     cdef int order_char = internal._normalize_order(order, False)
 
     if len(shape) == 1 and cpython.PySequence_Check(shape[0]):
@@ -91,7 +91,7 @@ cdef ndarray _ndarray_reshape(ndarray self, tuple shape, order):
         return _T(_reshape(_T(self), shape[::-1]))
 
 
-cdef ndarray _ndarray_transpose(ndarray self, tuple axes):
+cdef _ndarray_base _ndarray_transpose(_ndarray_base self, tuple axes):
     if len(axes) == 0:
         return _T(self)
     if len(axes) == 1:
@@ -103,8 +103,8 @@ cdef ndarray _ndarray_transpose(ndarray self, tuple axes):
     return _transpose(self, axes)
 
 
-cdef ndarray _ndarray_swapaxes(
-        ndarray self, Py_ssize_t axis1, Py_ssize_t axis2):
+cdef _ndarray_base _ndarray_swapaxes(
+        _ndarray_base self, Py_ssize_t axis1, Py_ssize_t axis2):
     cdef Py_ssize_t ndim = self.ndim
     cdef vector.vector[Py_ssize_t] axes
     if axis1 < -ndim or axis1 >= ndim or axis2 < -ndim or axis2 >= ndim:
@@ -117,7 +117,7 @@ cdef ndarray _ndarray_swapaxes(
     return _transpose(self, axes)
 
 
-cdef ndarray _ndarray_flatten(ndarray self, order):
+cdef _ndarray_base _ndarray_flatten(_ndarray_base self, order):
     cdef int order_char
     cdef vector.vector[Py_ssize_t] axes
 
@@ -136,7 +136,7 @@ cdef ndarray _ndarray_flatten(ndarray self, order):
         return _ndarray_flatten_order_c(_transpose(self, axes))
 
 
-cdef ndarray _ndarray_flatten_order_c(ndarray self):
+cdef _ndarray_base _ndarray_flatten_order_c(_ndarray_base self):
     newarray = self.copy(order='C')
     newarray._shape.assign(<Py_ssize_t>1, self.size)
     newarray._strides.assign(<Py_ssize_t>1,
@@ -176,7 +176,7 @@ cdef vector.vector[Py_ssize_t] _npyiter_k_order_axes(strides_t& strides):
     return axes
 
 
-cdef ndarray _ndarray_ravel(ndarray self, order):
+cdef _ndarray_base _ndarray_ravel(_ndarray_base self, order):
     cdef int order_char
     cdef shape_t shape
     cdef vector.vector[Py_ssize_t] axes
@@ -197,7 +197,7 @@ cdef ndarray _ndarray_ravel(ndarray self, order):
         return _reshape(_transpose(self, axes), shape)
 
 
-cdef ndarray _ndarray_squeeze(ndarray self, axis):
+cdef _ndarray_base _ndarray_squeeze(_ndarray_base self, axis):
     cdef vector.vector[char] axis_flags
     cdef shape_t newshape
     cdef strides_t newstrides
@@ -253,14 +253,14 @@ cdef ndarray _ndarray_squeeze(ndarray self, axis):
     return v
 
 
-cdef ndarray _ndarray_repeat(ndarray self, repeats, axis):
+cdef _ndarray_base _ndarray_repeat(_ndarray_base self, repeats, axis):
     return _repeat(self, repeats, axis)
 
 
 # exposed
 
 
-cpdef ndarray _expand_dims(ndarray a, tuple axis):
+cpdef _ndarray_base _expand_dims(_ndarray_base a, tuple axis):
     cdef vector.vector[Py_ssize_t] normalized_axis
     cdef out_ndim = a.ndim + len(axis)
     cdef shape_t a_shape = a.shape, out_shape
@@ -278,7 +278,7 @@ cpdef ndarray _expand_dims(ndarray a, tuple axis):
     return _reshape(a, out_shape)
 
 
-cpdef ndarray moveaxis(ndarray a, source, destination):
+cpdef _ndarray_base moveaxis(_ndarray_base a, source, destination):
     cdef shape_t src, dest
     cdef Py_ssize_t ndim = a.ndim
     _normalize_axis_tuple(source, ndim, src)
@@ -301,8 +301,8 @@ cpdef ndarray moveaxis(ndarray a, source, destination):
     return _transpose(a, order)
 
 
-cpdef ndarray _move_single_axis(ndarray a, Py_ssize_t source,
-                                Py_ssize_t destination):
+cpdef _ndarray_base _move_single_axis(
+        _ndarray_base a, Py_ssize_t source, Py_ssize_t destination):
     """Like moveaxis, but supporting only integer source and destination."""
     cdef Py_ssize_t ndim = a.ndim
     source = internal._normalize_axis_index(source, ndim)
@@ -321,7 +321,8 @@ cpdef ndarray _move_single_axis(ndarray a, Py_ssize_t source,
     return _transpose(a, order)
 
 
-cpdef ndarray rollaxis(ndarray a, Py_ssize_t axis, Py_ssize_t start=0):
+cpdef _ndarray_base rollaxis(
+        _ndarray_base a, Py_ssize_t axis, Py_ssize_t start=0):
     cdef Py_ssize_t i, ndim = a.ndim
     cdef vector.vector[Py_ssize_t] axes
     if axis < 0:
@@ -344,10 +345,10 @@ cpdef ndarray rollaxis(ndarray a, Py_ssize_t axis, Py_ssize_t start=0):
     return _transpose(a, axes)
 
 
-cpdef ndarray _reshape(ndarray self, const shape_t &shape_spec):
+cpdef _ndarray_base _reshape(_ndarray_base self, const shape_t &shape_spec):
     cdef shape_t shape
     cdef strides_t strides
-    cdef ndarray newarray
+    cdef _ndarray_base newarray
     shape = internal.infer_unknown_dimension(shape_spec, self.size)
     if internal.vector_equal(shape, self._shape):
         return self.view()
@@ -363,7 +364,7 @@ cpdef ndarray _reshape(ndarray self, const shape_t &shape_spec):
     return newarray
 
 
-cpdef ndarray _T(ndarray self):
+cpdef _ndarray_base _T(_ndarray_base self):
     ret = self.view()
     ret._shape.assign(self._shape.rbegin(), self._shape.rend())
     ret._strides.assign(self._strides.rbegin(), self._strides.rend())
@@ -372,7 +373,8 @@ cpdef ndarray _T(ndarray self):
     return ret
 
 
-cpdef ndarray _transpose(ndarray self, const vector.vector[Py_ssize_t] &axes):
+cpdef _ndarray_base _transpose(
+        _ndarray_base self, const vector.vector[Py_ssize_t] &axes):
     cdef vector.vector[Py_ssize_t] a_axes
     cdef vector.vector[char] axis_flags
     cdef Py_ssize_t i, ndim, axis, axes_size
@@ -414,7 +416,7 @@ cpdef ndarray _transpose(ndarray self, const vector.vector[Py_ssize_t] &axes):
     return ret
 
 
-cpdef array_split(ndarray ary, indices_or_sections, Py_ssize_t axis):
+cpdef array_split(_ndarray_base ary, indices_or_sections, Py_ssize_t axis):
     cdef Py_ssize_t i, ndim, size, each_size, index, prev, offset, stride
     cdef Py_ssize_t num_large
     cdef shape_t shape
@@ -466,7 +468,7 @@ cpdef array_split(ndarray ary, indices_or_sections, Py_ssize_t axis):
     return ret
 
 
-cpdef ndarray broadcast_to(ndarray array, shape):
+cpdef _ndarray_base broadcast_to(_ndarray_base array, shape):
     """Broadcast an array to a given shape.
 
     .. seealso::
@@ -500,7 +502,7 @@ cpdef ndarray broadcast_to(ndarray array, shape):
     return view
 
 
-cpdef ndarray _repeat(ndarray a, repeats, axis=None):
+cpdef _ndarray_base _repeat(_ndarray_base a, repeats, axis=None):
     """Repeat arrays along an axis.
 
     Args:
@@ -514,9 +516,9 @@ cpdef ndarray _repeat(ndarray a, repeats, axis=None):
     .. seealso:: :func:`numpy.repeat`
 
     """
-    cdef ndarray ret
+    cdef _ndarray_base ret
 
-    if isinstance(repeats, ndarray):
+    if isinstance(repeats, _ndarray_base):
         raise ValueError(
             'cupy.ndaray cannot be specified as `repeats` argument.')
 
@@ -547,7 +549,7 @@ cpdef ndarray _repeat(ndarray a, repeats, axis=None):
     if axis is None:
         if broadcast:
             a = _reshape(a, (-1, 1))
-            ret = core._ndarray((a.size, repeats[0]), dtype=a.dtype)
+            ret = core.ndarray((a.size, repeats[0]), dtype=a.dtype)
             if ret.size:
                 elementwise_copy(a, ret)
             return ret.ravel()
@@ -566,7 +568,7 @@ cpdef ndarray _repeat(ndarray a, repeats, axis=None):
 
     ret_shape = list(a.shape)
     ret_shape[axis] = sum(repeats)
-    ret = core._ndarray(ret_shape, dtype=a.dtype)
+    ret = core.ndarray(ret_shape, dtype=a.dtype)
     a_index = [slice(None)] * len(ret_shape)
     ret_index = list(a_index)
     offset = 0
@@ -581,11 +583,12 @@ cpdef ndarray _repeat(ndarray a, repeats, axis=None):
     return ret
 
 
-cpdef ndarray concatenate_method(tup, int axis, ndarray out=None, dtype=None,
-                                 casting='same_kind'):
+cpdef _ndarray_base concatenate_method(
+        tup, int axis, _ndarray_base out=None, dtype=None,
+        casting='same_kind'):
     cdef int ndim0
     cdef int i
-    cdef ndarray a, a0
+    cdef _ndarray_base a, a0
     cdef shape_t shape
 
     if dtype is not None:
@@ -599,7 +602,7 @@ cpdef ndarray concatenate_method(tup, int axis, ndarray out=None, dtype=None,
 
     # Check types of the input arrays
     for o in arrays:
-        if not isinstance(o, ndarray):
+        if not isinstance(o, _ndarray_base):
             raise TypeError('Only cupy arrays can be concatenated')
 
     # Check ndim > 0 for the input arrays
@@ -655,7 +658,7 @@ cpdef ndarray concatenate_method(tup, int axis, ndarray out=None, dtype=None,
     # Prpare the output array
     shape_t = tuple(shape0)
     if out is None:
-        out = core._ndarray(shape_t, dtype=dtype)
+        out = core.ndarray(shape_t, dtype=dtype)
     else:
         if len(out.shape) != len(shape_t):
             raise ValueError('Output array has wrong dimensionality')
@@ -665,9 +668,10 @@ cpdef ndarray concatenate_method(tup, int axis, ndarray out=None, dtype=None,
     return _concatenate(arrays, axis, shape_t, out, casting)
 
 
-cpdef ndarray _concatenate(
-        list arrays, Py_ssize_t axis, tuple shape, ndarray out, str casting):
-    cdef ndarray a, b
+cpdef _ndarray_base _concatenate(
+        list arrays, Py_ssize_t axis, tuple shape, _ndarray_base out,
+        str casting):
+    cdef _ndarray_base a, b
     cdef Py_ssize_t i, aw, itemsize, axis_size
     cdef bint all_same_type, same_shape_and_contiguous
     # If arrays are large, Issuing each copy method is efficient.
@@ -705,7 +709,7 @@ cpdef ndarray _concatenate(
     return out
 
 
-cpdef Py_ssize_t size(ndarray a, axis=None) except? -1:
+cpdef Py_ssize_t size(_ndarray_base a, axis=None) except? -1:
     """Returns the number of elements along a given axis.
 
     Args:
@@ -750,7 +754,7 @@ cdef bint _has_element(const shape_t &source, Py_ssize_t n):
 
 
 cdef _get_strides_for_nocopy_reshape(
-        ndarray a, const shape_t &newshape, strides_t &newstrides):
+        _ndarray_base a, const shape_t &newshape, strides_t &newstrides):
     cdef Py_ssize_t size, itemsize, ndim, dim, last_stride
     size = a.size
     newstrides.clear()
@@ -805,10 +809,10 @@ cdef _normalize_axis_tuple(axis, Py_ssize_t ndim, shape_t &ret):
         ret.push_back(ax)
 
 
-cdef ndarray _concatenate_single_kernel(
+cdef _ndarray_base _concatenate_single_kernel(
         list arrays, Py_ssize_t axis, tuple shape, dtype,
-        bint same_shape_and_contiguous, ndarray out):
-    cdef ndarray a, x
+        bint same_shape_and_contiguous, _ndarray_base out):
+    cdef _ndarray_base a, x
     cdef Py_ssize_t base, cum, ndim
     cdef int i, j
     cdef Py_ssize_t[:] ptrs

--- a/cupy/_core/_routines_math.pxd
+++ b/cupy/_core/_routines_math.pxd
@@ -1,26 +1,27 @@
-from cupy._core.core cimport ndarray
+from cupy._core.core cimport _ndarray_base
 
 
-cdef ndarray _ndarray_conj(ndarray self)
-cdef ndarray _ndarray_real_getter(ndarray self)
-cdef ndarray _ndarray_real_setter(ndarray self, value)
-cdef ndarray _ndarray_imag_getter(ndarray self)
-cdef ndarray _ndarray_imag_setter(ndarray self, value)
-cdef ndarray _ndarray_prod(ndarray self, axis, dtype, out, keepdims)
-cdef ndarray _ndarray_sum(ndarray self, axis, dtype, out, keepdims)
-cdef ndarray _ndarray_cumsum(ndarray self, axis, dtype, out)
-cdef ndarray _ndarray_cumprod(ndarray self, axis, dtype, out)
-cdef ndarray _ndarray_clip(ndarray self, a_min, a_max, out)
+cdef _ndarray_base _ndarray_conj(_ndarray_base self)
+cdef _ndarray_base _ndarray_real_getter(_ndarray_base self)
+cdef _ndarray_base _ndarray_real_setter(_ndarray_base self, value)
+cdef _ndarray_base _ndarray_imag_getter(_ndarray_base self)
+cdef _ndarray_base _ndarray_imag_setter(_ndarray_base self, value)
+cdef _ndarray_base _ndarray_prod(
+    _ndarray_base self, axis, dtype, out, keepdims)
+cdef _ndarray_base _ndarray_sum(_ndarray_base self, axis, dtype, out, keepdims)
+cdef _ndarray_base _ndarray_cumsum(_ndarray_base self, axis, dtype, out)
+cdef _ndarray_base _ndarray_cumprod(_ndarray_base self, axis, dtype, out)
+cdef _ndarray_base _ndarray_clip(_ndarray_base self, a_min, a_max, out)
 
-cpdef ndarray _nansum(ndarray a, axis, dtype, out, keepdims)
-cpdef ndarray _nanprod(ndarray a, axis, dtype, out, keepdims)
+cpdef _ndarray_base _nansum(_ndarray_base a, axis, dtype, out, keepdims)
+cpdef _ndarray_base _nanprod(_ndarray_base a, axis, dtype, out, keepdims)
 
 cpdef enum scan_op:
     SCAN_SUM = 0
     SCAN_PROD = 1
 
-cdef ndarray scan(ndarray a, op, dtype=*, ndarray out=*, incomplete=*,
-                  chunk_size=*)
+cdef _ndarray_base scan(_ndarray_base a, op, dtype=*, _ndarray_base out=*,
+                        incomplete=*, chunk_size=*)
 cdef object _sum_auto_dtype
 cdef object _add
 cdef object _conj

--- a/cupy/_core/_routines_math.pyx
+++ b/cupy/_core/_routines_math.pyx
@@ -17,7 +17,7 @@ from cupy._core._dtype cimport get_dtype
 from cupy._core cimport _kernel
 from cupy._core.core cimport _ndarray_init
 from cupy._core.core cimport compile_with_cache
-from cupy._core.core cimport ndarray
+from cupy._core.core cimport _ndarray_base
 from cupy.cuda cimport memory
 
 from cupy.cuda import cub
@@ -30,31 +30,32 @@ except ImportError:
     cutensor = None
 
 
-# ndarray members
+# _ndarray_base members
 
 
-cdef ndarray _ndarray_conj(ndarray self):
+cdef _ndarray_base _ndarray_conj(_ndarray_base self):
     if self.dtype.kind == 'c':
         return _conjugate(self)
     else:
         return self
 
 
-cdef ndarray _ndarray_real_getter(ndarray self):
+cdef _ndarray_base _ndarray_real_getter(_ndarray_base self):
     if self.dtype.kind == 'c':
-        view = core._ndarray(
+        view = core.ndarray(
             shape=self._shape, dtype=get_dtype(self.dtype.char.lower()),
             memptr=self.data, strides=self._strides)
-        (<ndarray>view).base = self.base if self.base is not None else self
+        (<_ndarray_base>view).base = (
+            self.base if self.base is not None else self)
         return view
     return self
 
 
-cdef ndarray _ndarray_real_setter(ndarray self, value):
+cdef _ndarray_base _ndarray_real_setter(_ndarray_base self, value):
     elementwise_copy(value, _ndarray_real_getter(self))
 
 
-cdef ndarray _ndarray_imag_getter(ndarray self):
+cdef _ndarray_base _ndarray_imag_getter(_ndarray_base self):
     cdef memory.MemoryPointer memptr
     if self.dtype.kind == 'c':
         dtype = get_dtype(self.dtype.char.lower())
@@ -65,24 +66,26 @@ cdef ndarray _ndarray_imag_getter(ndarray self):
         # aligning with NumPy behavior.
         if memptr.ptr != 0:
             memptr = memptr + self.dtype.itemsize // 2
-        view = core._ndarray(
+        view = core.ndarray(
             shape=self._shape, dtype=dtype, memptr=memptr,
             strides=self._strides)
-        (<ndarray>view).base = self.base if self.base is not None else self
+        (<_ndarray_base>view).base = (
+            self.base if self.base is not None else self)
         return view
-    new_array = core._ndarray(self.shape, dtype=self.dtype)
+    new_array = core.ndarray(self.shape, dtype=self.dtype)
     new_array.fill(0)
     return new_array
 
 
-cdef ndarray _ndarray_imag_setter(ndarray self, value):
+cdef _ndarray_base _ndarray_imag_setter(_ndarray_base self, value):
     if self.dtype.kind == 'c':
         elementwise_copy(value, _ndarray_imag_getter(self))
     else:
         raise TypeError('cupy.ndarray does not have imaginary part to set')
 
 
-cdef ndarray _ndarray_prod(ndarray self, axis, dtype, out, keepdims):
+cdef _ndarray_base _ndarray_prod(
+        _ndarray_base self, axis, dtype, out, keepdims):
     for accelerator in _accelerator._routine_accelerators:
         result = None
         if accelerator == _accelerator.ACCELERATOR_CUB:
@@ -101,7 +104,8 @@ cdef ndarray _ndarray_prod(ndarray self, axis, dtype, out, keepdims):
         return _prod_keep_dtype(self, axis, dtype, out, keepdims)
 
 
-cdef ndarray _ndarray_sum(ndarray self, axis, dtype, out, keepdims):
+cdef _ndarray_base _ndarray_sum(
+        _ndarray_base self, axis, dtype, out, keepdims):
     for accelerator in _accelerator._routine_accelerators:
         result = None
         if accelerator == _accelerator.ACCELERATOR_CUB:
@@ -121,15 +125,15 @@ cdef ndarray _ndarray_sum(ndarray self, axis, dtype, out, keepdims):
         return _sum_keep_dtype(self, axis, dtype, out, keepdims)
 
 
-cdef ndarray _ndarray_cumsum(ndarray self, axis, dtype, out):
+cdef _ndarray_base _ndarray_cumsum(_ndarray_base self, axis, dtype, out):
     return cupy.cumsum(self, axis, dtype, out)
 
 
-cdef ndarray _ndarray_cumprod(ndarray self, axis, dtype, out):
+cdef _ndarray_base _ndarray_cumprod(_ndarray_base self, axis, dtype, out):
     return cupy.cumprod(self, axis, dtype, out)
 
 
-cdef ndarray _ndarray_clip(ndarray self, a_min, a_max, out):
+cdef _ndarray_base _ndarray_clip(_ndarray_base self, a_min, a_max, out):
     if a_min is None and a_max is None:
         raise ValueError('array_clip: must set either max or min')
     kind = self.dtype.kind
@@ -427,8 +431,9 @@ def _cupy_scan_btree(op, chunk_size, warp_size=32):
                                   'cupy_scan_btree', loop_prep=loop_prep)
 
 
-cdef ndarray scan(ndarray a, op, dtype=None, ndarray out=None,
-                  incomplete=False, chunk_size=512):
+cdef _ndarray_base scan(
+        _ndarray_base a, op, dtype=None, _ndarray_base out=None,
+        incomplete=False, chunk_size=512):
     """Return the prefix sum(scan) of the elements.
 
     Args:
@@ -639,7 +644,8 @@ def _add_scan_batch_blocked_sum_kernel(dtype, op, block_size, c_cont):
     return module.get_function(name)
 
 
-cdef ndarray _batch_scan_op(ndarray a, scan_op op, ndarray out):
+cdef _ndarray_base _batch_scan_op(
+        _ndarray_base a, scan_op op, _ndarray_base out):
     batch_size = a.shape[1]
     # TODO(ecastill) replace this with "_reduction._block_size" once it is
     # properly exposed
@@ -673,7 +679,7 @@ cdef ndarray _batch_scan_op(ndarray a, scan_op op, ndarray out):
     return out
 
 
-cdef _proc_as_batch(ndarray x, int axis, scan_op op):
+cdef _proc_as_batch(_ndarray_base x, int axis, scan_op op):
     if x.shape[axis] == 0:
         return cupy.empty_like(x)
     t = cupy.rollaxis(x, axis, x.ndim)
@@ -683,7 +689,8 @@ cdef _proc_as_batch(ndarray x, int axis, scan_op op):
     return cupy.rollaxis(r.reshape(s), x.ndim-1, axis)
 
 
-cpdef scan_core(ndarray a, axis, scan_op op, dtype=None, ndarray out=None):
+cpdef scan_core(
+        _ndarray_base a, axis, scan_op op, dtype=None, _ndarray_base out=None):
     if out is None:
         if dtype is None:
             kind = a.dtype.kind
@@ -739,7 +746,7 @@ def _scan_for_test(a, out=None):
     return scan(a, scan_op.SCAN_SUM, dtype=None, out=out)
 
 
-cpdef ndarray _nansum(ndarray a, axis, dtype, out, keepdims):
+cpdef _ndarray_base _nansum(_ndarray_base a, axis, dtype, out, keepdims):
     if cupy.iscomplexobj(a):
         return _nansum_complex_dtype(a, axis, dtype, out, keepdims)
     elif dtype is None:
@@ -748,7 +755,7 @@ cpdef ndarray _nansum(ndarray a, axis, dtype, out, keepdims):
         return _nansum_keep_dtype(a, axis, dtype, out, keepdims)
 
 
-cpdef ndarray _nanprod(ndarray a, axis, dtype, out, keepdims):
+cpdef _ndarray_base _nanprod(_ndarray_base a, axis, dtype, out, keepdims):
     if cupy.iscomplexobj(a):
         return _nanprod_complex_dtype(a, axis, dtype, out, keepdims)
     elif dtype is None:

--- a/cupy/_core/_routines_sorting.pxd
+++ b/cupy/_core/_routines_sorting.pxd
@@ -1,7 +1,7 @@
-from cupy._core.core cimport ndarray
+from cupy._core.core cimport _ndarray_base
 
 
-cdef _ndarray_sort(ndarray self, int axis)
-cdef ndarray _ndarray_argsort(ndarray self, axis)
-cdef _ndarray_partition(ndarray self, kth, int axis)
-cdef ndarray _ndarray_argpartition(self, kth, axis)
+cdef _ndarray_sort(_ndarray_base self, int axis)
+cdef _ndarray_base _ndarray_argsort(_ndarray_base self, axis)
+cdef _ndarray_partition(_ndarray_base self, kth, int axis)
+cdef _ndarray_base _ndarray_argpartition(self, kth, axis)

--- a/cupy/_core/_routines_sorting.pyx
+++ b/cupy/_core/_routines_sorting.pyx
@@ -11,13 +11,13 @@ from cupy.cuda import thrust
 
 from cupy._core cimport _routines_manipulation as _manipulation
 from cupy._core.core cimport compile_with_cache
-from cupy._core.core cimport ndarray
+from cupy._core.core cimport _ndarray_base
 from cupy._core cimport internal
 
 
-cdef _ndarray_sort(ndarray self, int axis):
+cdef _ndarray_sort(_ndarray_base self, int axis):
     cdef int ndim = self._shape.size()
-    cdef ndarray data
+    cdef _ndarray_base data
 
     if not cupy.cuda.thrust.available:
         raise RuntimeError('Thrust is needed to use cupy.sort. Please '
@@ -44,7 +44,7 @@ cdef _ndarray_sort(ndarray self, int axis):
         thrust.sort(self.dtype, data.data.ptr, 0, self.shape)
     else:
         max_size = max(min(1 << 22, data.size) // data.shape[-1], 1)
-        keys_array = core._ndarray(
+        keys_array = core.ndarray(
             (max_size * data.shape[-1],), dtype=numpy.intp)
         stop = data.size // data.shape[-1]
         for offset in range(0, stop, max_size):
@@ -63,9 +63,9 @@ cdef _ndarray_sort(ndarray self, int axis):
         elementwise_copy(data, self)
 
 
-cdef ndarray _ndarray_argsort(ndarray self, axis):
+cdef _ndarray_base _ndarray_argsort(_ndarray_base self, axis):
     cdef int _axis, ndim
-    cdef ndarray data
+    cdef _ndarray_base data
 
     if not cupy.cuda.thrust.available:
         raise RuntimeError('Thrust is needed to use cupy.argsort. Please '
@@ -90,13 +90,13 @@ cdef ndarray _ndarray_argsort(ndarray self, axis):
         data = _manipulation.rollaxis(data, _axis, ndim).copy()
     shape = data.shape
 
-    idx_array = core._ndarray(shape, dtype=numpy.intp)
+    idx_array = core.ndarray(shape, dtype=numpy.intp)
 
     if ndim == 1:
         thrust.argsort(self.dtype, idx_array.data.ptr, data.data.ptr, 0,
                        shape)
     else:
-        keys_array = core._ndarray(shape, dtype=numpy.intp)
+        keys_array = core.ndarray(shape, dtype=numpy.intp)
         thrust.argsort(self.dtype, idx_array.data.ptr, data.data.ptr,
                        keys_array.data.ptr, shape)
 
@@ -106,7 +106,7 @@ cdef ndarray _ndarray_argsort(ndarray self, axis):
         return _manipulation.rollaxis(idx_array, -1, _axis)
 
 
-cdef _ndarray_partition(ndarray self, kth, int axis):
+cdef _ndarray_partition(_ndarray_base self, kth, int axis):
     """Partitions an array.
 
     Args:
@@ -125,7 +125,7 @@ cdef _ndarray_partition(ndarray self, kth, int axis):
 
     cdef int ndim = self._shape.size()
     cdef Py_ssize_t k, max_k, length, s, sz, t
-    cdef ndarray data
+    cdef _ndarray_base data
 
     if ndim == 0:
         raise numpy.AxisError('Sorting arrays with the rank of zero is not '
@@ -199,7 +199,7 @@ cdef _ndarray_partition(ndarray self, kth, int axis):
         elementwise_copy(data, self)
 
 
-cdef ndarray _ndarray_argpartition(self, kth, axis):
+cdef _ndarray_base _ndarray_argpartition(self, kth, axis):
     """Returns the indices that would partially sort an array.
 
     Args:
@@ -220,7 +220,7 @@ cdef ndarray _ndarray_argpartition(self, kth, axis):
     """
     cdef int _axis, ndim
     cdef Py_ssize_t k, length
-    cdef ndarray data
+    cdef _ndarray_base data
     if axis is None:
         data = self.ravel()
         _axis = -1

--- a/cupy/_core/_routines_statistics.pxd
+++ b/cupy/_core/_routines_statistics.pxd
@@ -1,24 +1,30 @@
-from cupy._core.core cimport ndarray
+from cupy._core.core cimport _ndarray_base
 
 
 # TODO(niboshi): Move {nan,}arg{min,max} to sorting
 
 
-cdef ndarray _ndarray_max(ndarray self, axis, out, dtype, keepdims)
-cdef ndarray _ndarray_min(ndarray self, axis, out, dtype, keepdims)
-cdef ndarray _ndarray_ptp(ndarray self, axis, out, keepdims)
-cdef ndarray _ndarray_argmax(ndarray self, axis, out, dtype, keepdims)
-cdef ndarray _ndarray_argmin(ndarray self, axis, out, dtype, keepdims)
-cdef ndarray _ndarray_mean(ndarray self, axis, dtype, out, keepdims)
-cdef ndarray _ndarray_var(ndarray self, axis, dtype, out, ddof, keepdims)
-cdef ndarray _ndarray_std(ndarray self, axis, dtype, out, ddof, keepdims)
+cdef _ndarray_base _ndarray_max(_ndarray_base self, axis, out, dtype, keepdims)
+cdef _ndarray_base _ndarray_min(_ndarray_base self, axis, out, dtype, keepdims)
+cdef _ndarray_base _ndarray_ptp(_ndarray_base self, axis, out, keepdims)
+cdef _ndarray_base _ndarray_argmax(
+    _ndarray_base self, axis, out, dtype, keepdims)
+cdef _ndarray_base _ndarray_argmin(
+    _ndarray_base self, axis, out, dtype, keepdims)
+cdef _ndarray_base _ndarray_mean(
+    _ndarray_base self, axis, dtype, out, keepdims)
+cdef _ndarray_base _ndarray_var(
+    _ndarray_base self, axis, dtype, out, ddof, keepdims)
+cdef _ndarray_base _ndarray_std(
+    _ndarray_base self, axis, dtype, out, ddof, keepdims)
 
-cpdef ndarray _median(ndarray a, axis, out, overwrite_input, keepdims)
+cpdef _ndarray_base _median(
+    _ndarray_base a, axis, out, overwrite_input, keepdims)
 
-cpdef ndarray _nanmean(ndarray a, axis, dtype, out, keepdims)
-cpdef ndarray _nanvar(ndarray a, axis, dtype, out, ddof, keepdims)
-cpdef ndarray _nanstd(ndarray a, axis, dtype, out, ddof, keepdims)
+cpdef _ndarray_base _nanmean(_ndarray_base a, axis, dtype, out, keepdims)
+cpdef _ndarray_base _nanvar(_ndarray_base a, axis, dtype, out, ddof, keepdims)
+cpdef _ndarray_base _nanstd(_ndarray_base a, axis, dtype, out, ddof, keepdims)
 
 
-cpdef ndarray _nanargmin(ndarray a, axis, out, dtype, keepdims)
-cpdef ndarray _nanargmax(ndarray a, axis, out, dtype, keepdims)
+cpdef _ndarray_base _nanargmin(_ndarray_base a, axis, out, dtype, keepdims)
+cpdef _ndarray_base _nanargmax(_ndarray_base a, axis, out, dtype, keepdims)

--- a/cupy/_core/_routines_statistics.pyx
+++ b/cupy/_core/_routines_statistics.pyx
@@ -12,7 +12,7 @@ from cupy._core._ufuncs import elementwise_copy
 
 from cupy._core cimport _accelerator
 from cupy._core cimport _routines_math as _math
-from cupy._core.core cimport ndarray
+from cupy._core.core cimport _ndarray_base
 
 from cupy.cuda import cub
 
@@ -24,7 +24,8 @@ except ImportError:
     cutensor = None
 
 
-cdef ndarray _ndarray_max(ndarray self, axis, out, dtype, keepdims):
+cdef _ndarray_base _ndarray_max(
+        _ndarray_base self, axis, out, dtype, keepdims):
     for accelerator in _accelerator._routine_accelerators:
         result = None
         if accelerator == _accelerator.ACCELERATOR_CUB:
@@ -43,7 +44,8 @@ cdef ndarray _ndarray_max(ndarray self, axis, out, dtype, keepdims):
     return _amax(self, axis=axis, out=out, dtype=dtype, keepdims=keepdims)
 
 
-cdef ndarray _ndarray_min(ndarray self, axis, out, dtype, keepdims):
+cdef _ndarray_base _ndarray_min(
+        _ndarray_base self, axis, out, dtype, keepdims):
     for accelerator in _accelerator._routine_accelerators:
         result = None
         if accelerator == _accelerator.ACCELERATOR_CUB:
@@ -62,7 +64,7 @@ cdef ndarray _ndarray_min(ndarray self, axis, out, dtype, keepdims):
     return _amin(self, axis=axis, out=out, dtype=dtype, keepdims=keepdims)
 
 
-cdef ndarray _ndarray_ptp(ndarray self, axis, out, keepdims):
+cdef _ndarray_base _ndarray_ptp(_ndarray_base self, axis, out, keepdims):
     for accelerator in _accelerator._routine_accelerators:
         if accelerator == _accelerator.ACCELERATOR_CUB:
             # result will be None if the reduction is not compatible with CUB
@@ -90,7 +92,8 @@ cdef ndarray _ndarray_ptp(ndarray self, axis, out, keepdims):
 
 
 # TODO(leofang): this signature is incompatible with NumPy!
-cdef ndarray _ndarray_argmax(ndarray self, axis, out, dtype, keepdims):
+cdef _ndarray_base _ndarray_argmax(
+        _ndarray_base self, axis, out, dtype, keepdims):
     for accelerator in _accelerator._routine_accelerators:
         if accelerator == _accelerator.ACCELERATOR_CUB:
             # result will be None if the reduction is not compatible with CUB
@@ -107,7 +110,8 @@ cdef ndarray _ndarray_argmax(ndarray self, axis, out, dtype, keepdims):
 
 
 # TODO(leofang): this signature is incompatible with NumPy!
-cdef ndarray _ndarray_argmin(ndarray self, axis, out, dtype, keepdims):
+cdef _ndarray_base _ndarray_argmin(
+        _ndarray_base self, axis, out, dtype, keepdims):
     for accelerator in _accelerator._routine_accelerators:
         if accelerator == _accelerator.ACCELERATOR_CUB:
             # result will be None if the reduction is not compatible with CUB
@@ -118,7 +122,8 @@ cdef ndarray _ndarray_argmin(ndarray self, axis, out, dtype, keepdims):
     return _argmin(self, axis=axis, out=out, dtype=dtype, keepdims=keepdims)
 
 
-cdef ndarray _ndarray_mean(ndarray self, axis, dtype, out, keepdims):
+cdef _ndarray_base _ndarray_mean(
+        _ndarray_base self, axis, dtype, out, keepdims):
     cdef Py_ssize_t n
 
     dtype_sum = dtype_out = dtype
@@ -163,12 +168,14 @@ cdef ndarray _ndarray_mean(ndarray self, axis, dtype, out, keepdims):
     return result
 
 
-cdef ndarray _ndarray_var(ndarray self, axis, dtype, out, ddof, keepdims):
+cdef _ndarray_base _ndarray_var(
+        _ndarray_base self, axis, dtype, out, ddof, keepdims):
     return _var(
         self, axis=axis, dtype=dtype, out=out, ddof=ddof, keepdims=keepdims)
 
 
-cdef ndarray _ndarray_std(ndarray self, axis, dtype, out, ddof, keepdims):
+cdef _ndarray_base _ndarray_std(
+        _ndarray_base self, axis, dtype, out, ddof, keepdims):
     return _std(
         self, axis=axis, dtype=dtype, out=out, ddof=ddof, keepdims=keepdims)
 
@@ -337,12 +344,12 @@ cdef _argmax = create_reduction_func(
     None, _min_max_preamble, sort_reduce_axis=False)
 
 
-cpdef ndarray _nanargmax(ndarray a, axis, out, dtype, keepdims):
+cpdef _ndarray_base _nanargmax(_ndarray_base a, axis, out, dtype, keepdims):
     return _nanargmax_func(
         a, axis=axis, out=out, dtype=dtype, keepdims=keepdims)
 
 
-cpdef ndarray _nanargmin(ndarray a, axis, out, dtype, keepdims):
+cpdef _ndarray_base _nanargmin(_ndarray_base a, axis, out, dtype, keepdims):
     return _nanargmin_func(
         a, axis=axis, out=out, dtype=dtype, keepdims=keepdims)
 
@@ -375,8 +382,8 @@ cdef _nanargmax_func = create_reduction_func(
     None, _min_max_preamble, sort_reduce_axis=False)
 
 
-cpdef ndarray _median(
-        ndarray a, axis, out, overwrite_input, keepdims):
+cpdef _ndarray_base _median(
+        _ndarray_base a, axis, out, overwrite_input, keepdims):
 
     keep_ndim = a.ndim
 
@@ -443,8 +450,8 @@ cpdef ndarray _median(
     return out
 
 
-cpdef ndarray _nanmedian(
-        ndarray a, axis, out, overwrite_input, keepdims):
+cpdef _ndarray_base _nanmedian(
+        _ndarray_base a, axis, out, overwrite_input, keepdims):
 
     if axis is None:
         axis = tuple(range(a.ndim))
@@ -521,15 +528,16 @@ cdef _pickup_median_kernel = ElementwiseKernel(
 )
 
 
-cdef ndarray _mean(
-        ndarray a, axis=None, dtype=None, out=None, keepdims=False):
+cdef _ndarray_base _mean(
+        _ndarray_base a, axis=None, dtype=None, out=None, keepdims=False):
     if a.size == 0:
         # Return nan; see also https://github.com/numpy/numpy/issues/13582
         return _mean_core_empty(a, axis, dtype, out, keepdims)
     return _mean_core(a, axis, dtype, out, keepdims)
 
-cdef ndarray _var(
-        ndarray a, axis=None, dtype=None, out=None, ddof=0, keepdims=False):
+cdef _ndarray_base _var(
+        _ndarray_base a, axis=None, dtype=None, out=None, ddof=0,
+        keepdims=False):
 
     if axis is None:
         axis = tuple(range(a.ndim))
@@ -574,8 +582,9 @@ cdef ndarray _var(
     return out.astype(dtype_out, copy=False)
 
 
-cdef ndarray _std(
-        ndarray a, axis=None, dtype=None, out=None, ddof=0, keepdims=False):
+cdef _ndarray_base _std(
+        _ndarray_base a, axis=None, dtype=None, out=None, ddof=0,
+        keepdims=False):
     ret = _var(
         a, axis=axis, dtype=dtype, out=None, ddof=ddof, keepdims=keepdims)
     return _math._sqrt(ret, dtype=dtype, out=out)
@@ -669,16 +678,16 @@ _count_non_nan = create_reduction_func(
     ('isnan(in0) ? 0 : 1', 'a + b', 'out0 = a', None), 0)
 
 
-cpdef ndarray _nanmean(ndarray a, axis, dtype, out, keepdims):
+cpdef _ndarray_base _nanmean(_ndarray_base a, axis, dtype, out, keepdims):
     return _nanmean_func(a, axis=axis, dtype=dtype, out=out, keepdims=keepdims)
 
 
-cpdef ndarray _nanstd(ndarray a, axis, dtype, out, ddof, keepdims):
+cpdef _ndarray_base _nanstd(_ndarray_base a, axis, dtype, out, ddof, keepdims):
     var = _nanvar(a, axis, dtype, None, ddof, keepdims)
     return _math._sqrt(var, dtype=dtype, out=out)
 
 
-cpdef ndarray _nanvar(ndarray a, axis, dtype, out, ddof, keepdims):
+cpdef _ndarray_base _nanvar(_ndarray_base a, axis, dtype, out, ddof, keepdims):
     assert a.dtype.kind != 'c', 'Variance for complex numbers is not ' \
                                 'implemented. Current implemention does not ' \
                                 'convert the dtype'

--- a/cupy/_core/core.pxd
+++ b/cupy/_core/core.pxd
@@ -7,7 +7,7 @@ from cupy._core._carray cimport shape_t
 from cupy._core._carray cimport strides_t
 
 
-cdef class ndarray:
+cdef class _ndarray_base:
     cdef:
         object __weakref__
         readonly Py_ssize_t size
@@ -21,7 +21,7 @@ cdef class ndarray:
         readonly memory.MemoryPointer data
         # TODO(niboshi): Return arbitrary owner object as `base` if the
         # underlying memory is UnownedMemory.
-        readonly ndarray base
+        readonly _ndarray_base base
 
     cdef _init_fast(self, const shape_t& shape, dtype, bint c_order)
     cpdef item(self)
@@ -30,53 +30,49 @@ cdef class ndarray:
     cpdef tofile(self, fid, sep=*, format=*)
     cpdef dump(self, file)
     cpdef bytes dumps(self)
-    cpdef ndarray astype(self, dtype, order=*, casting=*, subok=*, copy=*)
-    cpdef ndarray copy(self, order=*)
-    cpdef ndarray view(self, dtype=*)
+    cpdef _ndarray_base astype(
+        self, dtype, order=*, casting=*, subok=*, copy=*)
+    cpdef _ndarray_base copy(self, order=*)
+    cpdef _ndarray_base view(self, dtype=*)
     cpdef fill(self, value)
-    cpdef ndarray swapaxes(self, Py_ssize_t axis1, Py_ssize_t axis2)
-    cpdef ndarray flatten(self, order=*)
-    cpdef ndarray ravel(self, order=*)
-    cpdef ndarray squeeze(self, axis=*)
-    cpdef ndarray take(self, indices, axis=*, out=*)
+    cpdef _ndarray_base swapaxes(self, Py_ssize_t axis1, Py_ssize_t axis2)
+    cpdef _ndarray_base flatten(self, order=*)
+    cpdef _ndarray_base ravel(self, order=*)
+    cpdef _ndarray_base squeeze(self, axis=*)
+    cpdef _ndarray_base take(self, indices, axis=*, out=*)
     cpdef put(self, indices, values, mode=*)
     cpdef repeat(self, repeats, axis=*)
     cpdef choose(self, choices, out=*, mode=*)
     cpdef sort(self, int axis=*)
-    cpdef ndarray argsort(self, axis=*)
+    cpdef _ndarray_base argsort(self, axis=*)
     cpdef partition(self, kth, int axis=*)
-    cpdef ndarray argpartition(self, kth, axis=*)
+    cpdef _ndarray_base argpartition(self, kth, axis=*)
     cpdef tuple nonzero(self)
-    cpdef ndarray compress(self, condition, axis=*, out=*)
-    cpdef ndarray diagonal(self, offset=*, axis1=*, axis2=*)
-    cpdef ndarray max(self, axis=*, out=*, keepdims=*)
-    cpdef ndarray argmax(self, axis=*, out=*, dtype=*,
-                         keepdims=*)
-    cpdef ndarray min(self, axis=*, out=*, keepdims=*)
-    cpdef ndarray argmin(self, axis=*, out=*, dtype=*,
-                         keepdims=*)
-    cpdef ndarray ptp(self, axis=*, out=*, keepdims=*)
-    cpdef ndarray clip(self, min=*, max=*, out=*)
-    cpdef ndarray round(self, decimals=*, out=*)
+    cpdef _ndarray_base compress(self, condition, axis=*, out=*)
+    cpdef _ndarray_base diagonal(self, offset=*, axis1=*, axis2=*)
+    cpdef _ndarray_base max(self, axis=*, out=*, keepdims=*)
+    cpdef _ndarray_base argmax(self, axis=*, out=*, dtype=*, keepdims=*)
+    cpdef _ndarray_base min(self, axis=*, out=*, keepdims=*)
+    cpdef _ndarray_base argmin(self, axis=*, out=*, dtype=*, keepdims=*)
+    cpdef _ndarray_base ptp(self, axis=*, out=*, keepdims=*)
+    cpdef _ndarray_base clip(self, min=*, max=*, out=*)
+    cpdef _ndarray_base round(self, decimals=*, out=*)
 
-    cpdef ndarray trace(self, offset=*, axis1=*, axis2=*, dtype=*,
-                        out=*)
-    cpdef ndarray sum(self, axis=*, dtype=*, out=*, keepdims=*)
-    cpdef ndarray cumsum(self, axis=*, dtype=*, out=*)
-    cpdef ndarray mean(self, axis=*, dtype=*, out=*, keepdims=*)
-    cpdef ndarray var(self, axis=*, dtype=*, out=*, ddof=*,
-                      keepdims=*)
-    cpdef ndarray std(self, axis=*, dtype=*, out=*, ddof=*,
-                      keepdims=*)
-    cpdef ndarray prod(self, axis=*, dtype=*, out=*, keepdims=*)
-    cpdef ndarray cumprod(self, axis=*, dtype=*, out=*)
-    cpdef ndarray all(self, axis=*, out=*, keepdims=*)
-    cpdef ndarray any(self, axis=*, out=*, keepdims=*)
-    cpdef ndarray conj(self)
-    cpdef ndarray conjugate(self)
+    cpdef _ndarray_base trace(self, offset=*, axis1=*, axis2=*, dtype=*, out=*)
+    cpdef _ndarray_base sum(self, axis=*, dtype=*, out=*, keepdims=*)
+    cpdef _ndarray_base cumsum(self, axis=*, dtype=*, out=*)
+    cpdef _ndarray_base mean(self, axis=*, dtype=*, out=*, keepdims=*)
+    cpdef _ndarray_base var(self, axis=*, dtype=*, out=*, ddof=*, keepdims=*)
+    cpdef _ndarray_base std(self, axis=*, dtype=*, out=*, ddof=*, keepdims=*)
+    cpdef _ndarray_base prod(self, axis=*, dtype=*, out=*, keepdims=*)
+    cpdef _ndarray_base cumprod(self, axis=*, dtype=*, out=*)
+    cpdef _ndarray_base all(self, axis=*, out=*, keepdims=*)
+    cpdef _ndarray_base any(self, axis=*, out=*, keepdims=*)
+    cpdef _ndarray_base conj(self)
+    cpdef _ndarray_base conjugate(self)
     cpdef get(self, stream=*, order=*, out=*)
     cpdef set(self, arr, stream=*)
-    cpdef ndarray reduced_view(self, dtype=*)
+    cpdef _ndarray_base reduced_view(self, dtype=*)
     cpdef _update_c_contiguity(self)
     cpdef _update_f_contiguity(self)
     cpdef _update_contiguity(self)
@@ -84,20 +80,20 @@ cdef class ndarray:
                                  const strides_t& strides,
                                  bint update_c_contiguity,
                                  bint update_f_contiguity)
-    cdef ndarray _view(self, const shape_t& shape,
-                       const strides_t& strides,
-                       bint update_c_contiguity,
-                       bint update_f_contiguity)
+    cdef _ndarray_base _view(self, const shape_t& shape,
+                             const strides_t& strides,
+                             bint update_c_contiguity,
+                             bint update_f_contiguity)
     cpdef _set_contiguous_strides(
         self, Py_ssize_t itemsize, bint is_c_contiguous)
     cdef CPointer get_pointer(self)
     cpdef object toDlpack(self)
 
 
-cpdef ndarray _internal_ascontiguousarray(ndarray a)
-cpdef ndarray _internal_asfortranarray(ndarray a)
-cpdef ndarray ascontiguousarray(ndarray a, dtype=*)
-cpdef ndarray asfortranarray(ndarray a, dtype=*)
+cpdef _ndarray_base _internal_ascontiguousarray(_ndarray_base a)
+cpdef _ndarray_base _internal_asfortranarray(_ndarray_base a)
+cpdef _ndarray_base ascontiguousarray(_ndarray_base a, dtype=*)
+cpdef _ndarray_base asfortranarray(_ndarray_base a, dtype=*)
 
 cpdef Module compile_with_cache(str source, tuple options=*, arch=*,
                                 cachd_dir=*, prepend_cupy_headers=*,
@@ -108,11 +104,11 @@ cpdef Module compile_with_cache(str source, tuple options=*, arch=*,
 
 
 # TODO(niboshi): Move to _routines_creation.pyx
-cpdef ndarray array(obj, dtype=*, bint copy=*, order=*, bint subok=*,
-                    Py_ssize_t ndmin=*)
-cpdef ndarray _convert_object_with_cuda_array_interface(a)
+cpdef _ndarray_base array(
+    obj, dtype=*, bint copy=*, order=*, bint subok=*, Py_ssize_t ndmin=*)
+cpdef _ndarray_base _convert_object_with_cuda_array_interface(a)
 
-cdef ndarray _ndarray_init(const shape_t& shape, dtype)
+cdef _ndarray_base _ndarray_init(const shape_t& shape, dtype)
 
-cdef ndarray _create_ndarray_from_shape_strides(
+cdef _ndarray_base _create_ndarray_from_shape_strides(
     const shape_t& shape, const strides_t& strides, dtype)

--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -92,30 +92,30 @@ cdef tuple _HANDLED_TYPES
 cdef object _null_context = contextlib.nullcontext()
 
 
-class _ndarray(ndarray):
+class ndarray(_ndarray_base):
     __module__ = 'cupy'
-    __doc__ = ndarray.__doc__
+    __doc__ = _ndarray_base.__doc__
 
     def __new__(cls, *args, _obj=None, _no_init=False, **kwargs):
         x = super().__new__(cls, *args, **kwargs)
         if _no_init:
             return x
         x._init(*args, **kwargs)
-        if cls is not _ndarray:
+        if cls is not ndarray:
             x.__array_finalize__(_obj)
         return x
 
     def __init__(self, *args, **kwargs):
-        # Prevent from calling the super class `ndarray.__init__()` as
+        # Prevent from calling the super class `_ndarray_base.__init__()` as
         # it is used to check accidental direct instantiation of underlaying
-        # `ndarray` extention.
+        # `_ndarray_base` extention.
         pass
 
     def __array_finalize__(self, obj):
         pass
 
 
-cdef class ndarray:
+cdef class _ndarray_base:
 
     """Multi-dimensional array on a CUDA device.
 
@@ -149,9 +149,9 @@ cdef class ndarray:
     """
 
     def __init__(self, *args, **kwargs):
-        # Raise an error if underlaying `ndarray` extension type is directly
-        # instantiated. We must instantiate `_ndarray` class instead for our
-        # ndarray subclassing mechanism.
+        # Raise an error if underlaying `_ndarray_base` extension type is
+        # directly instantiated. We must instantiate `ndarray` class instead
+        # for our ndarray subclassing mechanism.
         raise RuntimeError('Must not be directly instantiated')
 
     def _init(self, shape, dtype=float, memptr=None, strides=None,
@@ -489,7 +489,7 @@ cdef class ndarray:
         """Dumps a pickle of the array to a string."""
         return pickle.dumps(self, -1)
 
-    cpdef ndarray astype(
+    cpdef _ndarray_base astype(
             self, dtype, order='K', casting=None, subok=None, copy=True):
         """Casts the array to given data type.
 
@@ -548,7 +548,7 @@ cdef class ndarray:
             # TODO(niboshi): Confirm update_x_contiguity flags
             newarray._set_shape_and_strides(self._shape, strides, True, True)
         else:
-            newarray = _ndarray(self.shape, dtype=dtype, order=chr(order_char))
+            newarray = ndarray(self.shape, dtype=dtype, order=chr(order_char))
 
         if self.size == 0:
             # skip copy
@@ -563,7 +563,7 @@ cdef class ndarray:
 
     # TODO(okuta): Implement byteswap
 
-    cpdef ndarray copy(self, order='C'):
+    cpdef _ndarray_base copy(self, order='C'):
         """Returns a copy of the array.
 
         This method makes a copy of a given array in the current device.
@@ -583,7 +583,7 @@ cdef class ndarray:
            :meth:`numpy.ndarray.copy`
 
         """
-        cdef ndarray x
+        cdef _ndarray_base x
         if self.size == 0:
             return self.astype(self.dtype, order=order)
 
@@ -618,7 +618,7 @@ cdef class ndarray:
             newarray.data.copy_from_device_async(x.data, x.nbytes)
         return newarray
 
-    cpdef ndarray view(self, dtype=None):
+    cpdef _ndarray_base view(self, dtype=None):
         """Returns a view of the array.
 
         Args:
@@ -752,7 +752,7 @@ cdef class ndarray:
         """
         return _manipulation._ndarray_transpose(self, axes)
 
-    cpdef ndarray swapaxes(self, Py_ssize_t axis1, Py_ssize_t axis2):
+    cpdef _ndarray_base swapaxes(self, Py_ssize_t axis1, Py_ssize_t axis2):
         """Returns a view of the array with two axes swapped.
 
         .. seealso::
@@ -762,7 +762,7 @@ cdef class ndarray:
         """
         return _manipulation._ndarray_swapaxes(self, axis1, axis2)
 
-    cpdef ndarray flatten(self, order='C'):
+    cpdef _ndarray_base flatten(self, order='C'):
         """Returns a copy of the array flatten into one dimension.
 
         Args:
@@ -783,7 +783,7 @@ cdef class ndarray:
         """
         return _manipulation._ndarray_flatten(self, order)
 
-    cpdef ndarray ravel(self, order='C'):
+    cpdef _ndarray_base ravel(self, order='C'):
         """Returns an array flattened into one dimension.
 
         .. seealso::
@@ -794,7 +794,7 @@ cdef class ndarray:
         return _internal_ascontiguousarray(
             _manipulation._ndarray_ravel(self, order))
 
-    cpdef ndarray squeeze(self, axis=None):
+    cpdef _ndarray_base squeeze(self, axis=None):
         """Returns a view with size-one axes removed.
 
         .. seealso::
@@ -807,7 +807,7 @@ cdef class ndarray:
     # -------------------------------------------------------------------------
     # Item selection and manipulation
     # -------------------------------------------------------------------------
-    cpdef ndarray take(self, indices, axis=None, out=None):
+    cpdef _ndarray_base take(self, indices, axis=None, out=None):
         """Returns an array of elements at given indices along the axis.
 
         .. seealso::
@@ -860,7 +860,7 @@ cdef class ndarray:
         # TODO(takagi): Support kind argument.
         _sorting._ndarray_sort(self, axis)
 
-    cpdef ndarray argsort(self, axis=-1):
+    cpdef _ndarray_base argsort(self, axis=-1):
         """Returns the indices that would sort an array with stable sorting
 
         Args:
@@ -897,7 +897,7 @@ cdef class ndarray:
         """
         _sorting._ndarray_partition(self, kth, axis)
 
-    cpdef ndarray argpartition(self, kth, axis=-1):
+    cpdef _ndarray_base argpartition(self, kth, axis=-1):
         """Returns the indices that would partially sort an array.
 
         Args:
@@ -937,7 +937,7 @@ cdef class ndarray:
         """
         return _indexing._ndarray_nonzero(self)
 
-    cpdef ndarray compress(self, condition, axis=None, out=None):
+    cpdef _ndarray_base compress(self, condition, axis=None, out=None):
         """Returns selected slices of this array along given axis.
 
         .. warning::
@@ -951,7 +951,7 @@ cdef class ndarray:
         """
         return _indexing._ndarray_compress(self, condition, axis, out)
 
-    cpdef ndarray diagonal(self, offset=0, axis1=0, axis2=1):
+    cpdef _ndarray_base diagonal(self, offset=0, axis1=0, axis2=1):
         """Returns a view of the specified diagonals.
 
         .. seealso::
@@ -964,7 +964,7 @@ cdef class ndarray:
     # -------------------------------------------------------------------------
     # Calculation
     # -------------------------------------------------------------------------
-    cpdef ndarray max(self, axis=None, out=None, keepdims=False):
+    cpdef _ndarray_base max(self, axis=None, out=None, keepdims=False):
         """Returns the maximum along a given axis.
 
         .. seealso::
@@ -974,8 +974,8 @@ cdef class ndarray:
         """
         return _statistics._ndarray_max(self, axis, out, None, keepdims)
 
-    cpdef ndarray argmax(self, axis=None, out=None, dtype=None,
-                         keepdims=False):
+    cpdef _ndarray_base argmax(
+            self, axis=None, out=None, dtype=None, keepdims=False):
         """Returns the indices of the maximum along a given axis.
 
         .. note::
@@ -993,7 +993,7 @@ cdef class ndarray:
         """
         return _statistics._ndarray_argmax(self, axis, out, dtype, keepdims)
 
-    cpdef ndarray min(self, axis=None, out=None, keepdims=False):
+    cpdef _ndarray_base min(self, axis=None, out=None, keepdims=False):
         """Returns the minimum along a given axis.
 
         .. seealso::
@@ -1003,8 +1003,8 @@ cdef class ndarray:
         """
         return _statistics._ndarray_min(self, axis, out, None, keepdims)
 
-    cpdef ndarray argmin(self, axis=None, out=None, dtype=None,
-                         keepdims=False):
+    cpdef _ndarray_base argmin(
+            self, axis=None, out=None, dtype=None, keepdims=False):
         """Returns the indices of the minimum along a given axis.
 
         .. note::
@@ -1022,7 +1022,7 @@ cdef class ndarray:
         """
         return _statistics._ndarray_argmin(self, axis, out, dtype, keepdims)
 
-    cpdef ndarray ptp(self, axis=None, out=None, keepdims=False):
+    cpdef _ndarray_base ptp(self, axis=None, out=None, keepdims=False):
         """Returns (maximum - minimum) along a given axis.
 
         .. seealso::
@@ -1032,7 +1032,7 @@ cdef class ndarray:
         """
         return _statistics._ndarray_ptp(self, axis, out, keepdims)
 
-    cpdef ndarray clip(self, min=None, max=None, out=None):
+    cpdef _ndarray_base clip(self, min=None, max=None, out=None):
         """Returns an array with values limited to [min, max].
 
         .. seealso::
@@ -1042,7 +1042,7 @@ cdef class ndarray:
         """
         return _math._ndarray_clip(self, min, max, out)
 
-    cpdef ndarray round(self, decimals=0, out=None):
+    cpdef _ndarray_base round(self, decimals=0, out=None):
         """Returns an array with values rounded to the given number of decimals.
 
         .. seealso::
@@ -1052,8 +1052,8 @@ cdef class ndarray:
         """
         return _round_ufunc(self, decimals, out=out)
 
-    cpdef ndarray trace(self, offset=0, axis1=0, axis2=1, dtype=None,
-                        out=None):
+    cpdef _ndarray_base trace(
+            self, offset=0, axis1=0, axis2=1, dtype=None, out=None):
         """Returns the sum along diagonals of the array.
 
         .. seealso::
@@ -1064,7 +1064,8 @@ cdef class ndarray:
         d = self.diagonal(offset, axis1, axis2)
         return d.sum(-1, dtype, out, False)
 
-    cpdef ndarray sum(self, axis=None, dtype=None, out=None, keepdims=False):
+    cpdef _ndarray_base sum(
+            self, axis=None, dtype=None, out=None, keepdims=False):
         """Returns the sum along a given axis.
 
         .. seealso::
@@ -1074,7 +1075,7 @@ cdef class ndarray:
         """
         return _math._ndarray_sum(self, axis, dtype, out, keepdims)
 
-    cpdef ndarray cumsum(self, axis=None, dtype=None, out=None):
+    cpdef _ndarray_base cumsum(self, axis=None, dtype=None, out=None):
         """Returns the cumulative sum of an array along a given axis.
 
         .. seealso::
@@ -1084,7 +1085,8 @@ cdef class ndarray:
         """
         return _math._ndarray_cumsum(self, axis, dtype, out)
 
-    cpdef ndarray mean(self, axis=None, dtype=None, out=None, keepdims=False):
+    cpdef _ndarray_base mean(
+            self, axis=None, dtype=None, out=None, keepdims=False):
         """Returns the mean along a given axis.
 
         .. seealso::
@@ -1094,8 +1096,8 @@ cdef class ndarray:
         """
         return _statistics._ndarray_mean(self, axis, dtype, out, keepdims)
 
-    cpdef ndarray var(self, axis=None, dtype=None, out=None, ddof=0,
-                      keepdims=False):
+    cpdef _ndarray_base var(
+            self, axis=None, dtype=None, out=None, ddof=0, keepdims=False):
         """Returns the variance along a given axis.
 
         .. seealso::
@@ -1106,8 +1108,8 @@ cdef class ndarray:
         return _statistics._ndarray_var(
             self, axis, dtype, out, ddof, keepdims)
 
-    cpdef ndarray std(self, axis=None, dtype=None, out=None, ddof=0,
-                      keepdims=False):
+    cpdef _ndarray_base std(
+            self, axis=None, dtype=None, out=None, ddof=0, keepdims=False):
         """Returns the standard deviation along a given axis.
 
         .. seealso::
@@ -1117,7 +1119,8 @@ cdef class ndarray:
         """
         return _statistics._ndarray_std(self, axis, dtype, out, ddof, keepdims)
 
-    cpdef ndarray prod(self, axis=None, dtype=None, out=None, keepdims=None):
+    cpdef _ndarray_base prod(
+            self, axis=None, dtype=None, out=None, keepdims=None):
         """Returns the product along a given axis.
 
         .. seealso::
@@ -1127,7 +1130,7 @@ cdef class ndarray:
         """
         return _math._ndarray_prod(self, axis, dtype, out, keepdims)
 
-    cpdef ndarray cumprod(self, axis=None, dtype=None, out=None):
+    cpdef _ndarray_base cumprod(self, axis=None, dtype=None, out=None):
         """Returns the cumulative product of an array along a given axis.
 
         .. seealso::
@@ -1137,11 +1140,11 @@ cdef class ndarray:
         """
         return _math._ndarray_cumprod(self, axis, dtype, out)
 
-    cpdef ndarray all(self, axis=None, out=None, keepdims=False):
+    cpdef _ndarray_base all(self, axis=None, out=None, keepdims=False):
         # TODO(niboshi): Write docstring
         return _logic._ndarray_all(self, axis, out, keepdims)
 
-    cpdef ndarray any(self, axis=None, out=None, keepdims=False):
+    cpdef _ndarray_base any(self, axis=None, out=None, keepdims=False):
         # TODO(niboshi): Write docstring
         return _logic._ndarray_any(self, axis, out, keepdims)
 
@@ -1393,10 +1396,10 @@ cdef class ndarray:
     def __ixor__(self, other):
         return _binary._bitwise_xor(self, other, self)
 
-    cpdef ndarray conj(self):
+    cpdef _ndarray_base conj(self):
         return _math._ndarray_conj(self)
 
-    cpdef ndarray conjugate(self):
+    cpdef _ndarray_base conjugate(self):
         return _math._ndarray_conj(self)
 
     @property
@@ -1437,7 +1440,7 @@ cdef class ndarray:
 
     # Basic customization:
 
-    # cupy.ndarray does not define __new__
+    # _ndarray_base does not define __new__
 
     def __array__(self, dtype=None):
         # TODO(imanishi): Support an environment variable or a global
@@ -1707,7 +1710,7 @@ cdef class ndarray:
     # -------------------------------------------------------------------------
     # Methods outside of the ndarray main documentation
     # -------------------------------------------------------------------------
-    def dot(self, ndarray b, ndarray out=None):
+    def dot(self, _ndarray_base b, _ndarray_base out=None):
         """Returns the dot product with given array.
 
         .. seealso::
@@ -1858,7 +1861,7 @@ cdef class ndarray:
         finally:
             runtime.setDevice(prev_device)
 
-    cpdef ndarray reduced_view(self, dtype=None):
+    cpdef _ndarray_base reduced_view(self, dtype=None):
         """Returns a view of the array with minimum number of dimensions.
 
         Args:
@@ -1873,7 +1876,7 @@ cdef class ndarray:
         cdef shape_t shape
         cdef strides_t strides
         cdef Py_ssize_t ndim
-        cdef ndarray view
+        cdef _ndarray_base view
         if dtype is not None:
             warnings.warn(
                 'calling reduced_view with dtype is deprecated',
@@ -1946,13 +1949,13 @@ cdef class ndarray:
         if update_f_contiguity:
             self._update_f_contiguity()
 
-    cdef ndarray _view(self, const shape_t& shape,
-                       const strides_t& strides,
-                       bint update_c_contiguity,
-                       bint update_f_contiguity):
-        cdef ndarray v
+    cdef _ndarray_base _view(self, const shape_t& shape,
+                             const strides_t& strides,
+                             bint update_c_contiguity,
+                             bint update_f_contiguity):
+        cdef _ndarray_base v
         # Use `_no_init=True`  to skip recomputation of contiguity.
-        v = _ndarray.__new__(_ndarray, _no_init=True)
+        v = ndarray.__new__(ndarray, _no_init=True)
         v.data = self.data
         v.base = self.base if self.base is not None else self
         v.dtype = self.dtype
@@ -2018,7 +2021,7 @@ cdef class ndarray:
         return dlpack.toDlpack(self)
 
 
-cdef inline _carray.CArray _CArray_from_ndarray(ndarray arr):
+cdef inline _carray.CArray _CArray_from_ndarray(_ndarray_base arr):
     # Creates CArray from ndarray.
     # Note that this function cannot be defined in _carray.pxd because that
     # would cause cyclic cimport dependencies.
@@ -2027,7 +2030,7 @@ cdef inline _carray.CArray _CArray_from_ndarray(ndarray arr):
     return carr
 
 
-_HANDLED_TYPES = (_ndarray, numpy.ndarray)
+_HANDLED_TYPES = (ndarray, numpy.ndarray)
 
 
 # =============================================================================
@@ -2324,8 +2327,8 @@ _round_ufunc = create_ufunc(
 # Array creation routines
 # -----------------------------------------------------------------------------
 
-cpdef ndarray array(obj, dtype=None, bint copy=True, order='K',
-                    bint subok=False, Py_ssize_t ndmin=0):
+cpdef _ndarray_base array(obj, dtype=None, bint copy=True, order='K',
+                          bint subok=False, Py_ssize_t ndmin=0):
     # TODO(beam2d): Support subok options
     if subok:
         raise NotImplementedError
@@ -2351,10 +2354,10 @@ cpdef ndarray array(obj, dtype=None, bint copy=True, order='K',
     return _array_default(obj, dtype, order, ndmin)
 
 
-cdef ndarray _array_from_cupy_ndarray(
+cdef _ndarray_base _array_from_cupy_ndarray(
         obj, dtype, bint copy, order, Py_ssize_t ndmin):
     cdef Py_ssize_t ndim
-    cdef ndarray a, src
+    cdef _ndarray_base a, src
 
     src = obj
 
@@ -2376,14 +2379,14 @@ cdef ndarray _array_from_cupy_ndarray(
     return a
 
 
-cdef ndarray _array_from_cuda_array_interface(
+cdef _ndarray_base _array_from_cuda_array_interface(
         obj, dtype, bint copy, order, bint subok, Py_ssize_t ndmin):
     return array(
         _convert_object_with_cuda_array_interface(obj),
         dtype, copy, order, subok, ndmin)
 
 
-cdef ndarray _array_from_nested_sequence(
+cdef _ndarray_base _array_from_nested_sequence(
         obj, dtype, order, Py_ssize_t ndmin, concat_shape, concat_type,
         concat_dtype):
     cdef Py_ssize_t ndim
@@ -2405,20 +2408,20 @@ cdef ndarray _array_from_nested_sequence(
     if concat_type is numpy.ndarray:
         return _array_from_nested_numpy_sequence(
             obj, concat_dtype, dtype, concat_shape, order, ndmin)
-    elif concat_type is _ndarray:  # TODO(takagi) Consider subclases
+    elif concat_type is ndarray:  # TODO(takagi) Consider subclases
         return _array_from_nested_cupy_sequence(
             obj, dtype, concat_shape, order)
     else:
         assert False
 
 
-cdef ndarray _array_from_nested_numpy_sequence(
+cdef _ndarray_base _array_from_nested_numpy_sequence(
         arrays, src_dtype, dst_dtype, const shape_t& shape, order,
         Py_ssize_t ndmin):
     a_dtype = get_dtype(dst_dtype)  # convert to numpy.dtype
     if a_dtype.char not in '?bhilqBHILQefdFD':
         raise ValueError('Unsupported dtype %s' % a_dtype)
-    cdef ndarray a  # allocate it after pinned memory is secured
+    cdef _ndarray_base a  # allocate it after pinned memory is secured
     cdef size_t itemcount = internal.prod(shape)
     cdef size_t nbytes = itemcount * a_dtype.itemsize
 
@@ -2441,7 +2444,7 @@ cdef ndarray _array_from_nested_numpy_sequence(
             get_dtype(src_dtype),
             a_dtype,
             src_cpu)
-        a = _ndarray(shape, dtype=a_dtype, order=order)
+        a = ndarray(shape, dtype=a_dtype, order=order)
         a.data.copy_from_host_async(mem.ptr, nbytes)
         pinned_memory._add_to_watch_list(stream.record(), mem)
     else:
@@ -2449,13 +2452,13 @@ cdef ndarray _array_from_nested_numpy_sequence(
         # Note: a_cpu.ndim is always >= 1
         a_cpu = numpy.array(arrays, dtype=a_dtype, copy=False, order=order,
                             ndmin=ndmin)
-        a = _ndarray(shape, dtype=a_dtype, order=order)
+        a = ndarray(shape, dtype=a_dtype, order=order)
         a.data.copy_from_host(a_cpu.ctypes.data, nbytes)
 
     return a
 
 
-cdef ndarray _array_from_nested_cupy_sequence(obj, dtype, shape, order):
+cdef _ndarray_base _array_from_nested_cupy_sequence(obj, dtype, shape, order):
     lst = _flatten_list(obj)
 
     # convert each scalar (0-dim) ndarray to 1-dim
@@ -2467,7 +2470,7 @@ cdef ndarray _array_from_nested_cupy_sequence(obj, dtype, shape, order):
     return a
 
 
-cdef ndarray _array_default(obj, dtype, order, Py_ssize_t ndmin):
+cdef _ndarray_base _array_default(obj, dtype, order, Py_ssize_t ndmin):
     if order is not None and len(order) >= 1 and order[0] in 'KAka':
         if isinstance(obj, numpy.ndarray) and obj.flags.f_contiguous:
             order = 'F'
@@ -2480,7 +2483,7 @@ cdef ndarray _array_default(obj, dtype, order, Py_ssize_t ndmin):
     a_cpu = a_cpu.astype(a_cpu.dtype.newbyteorder('<'), copy=False)
     a_dtype = a_cpu.dtype
     cdef shape_t a_shape = a_cpu.shape
-    cdef ndarray a = _ndarray(a_shape, dtype=a_dtype, order=order)
+    cdef _ndarray_base a = ndarray(a_shape, dtype=a_dtype, order=order)
     if a_cpu.ndim == 0:
         a.fill(a_cpu)
         return a
@@ -2592,7 +2595,7 @@ cdef inline _alloc_async_transfer_buffer(Py_ssize_t nbytes):
     return None
 
 
-cpdef ndarray _internal_ascontiguousarray(ndarray a):
+cpdef _ndarray_base _internal_ascontiguousarray(_ndarray_base a):
     if a._c_contiguous:
         return a
     newarray = _ndarray_init(a._shape, a.dtype)
@@ -2600,15 +2603,15 @@ cpdef ndarray _internal_ascontiguousarray(ndarray a):
     return newarray
 
 
-cpdef ndarray _internal_asfortranarray(ndarray a):
-    cdef ndarray newarray
+cpdef _ndarray_base _internal_asfortranarray(_ndarray_base a):
+    cdef _ndarray_base newarray
     cdef int m, n
     cdef intptr_t handle
 
     if a._f_contiguous:
         return a
 
-    newarray = _ndarray(a.shape, a.dtype, order='F')
+    newarray = ndarray(a.shape, a.dtype, order='F')
     if (a._c_contiguous and a._shape.size() == 2 and
             (a.dtype == numpy.float32 or a.dtype == numpy.float64)):
         m, n = a.shape
@@ -2634,7 +2637,7 @@ cpdef ndarray _internal_asfortranarray(ndarray a):
     return newarray
 
 
-cpdef ndarray ascontiguousarray(ndarray a, dtype=None):
+cpdef _ndarray_base ascontiguousarray(_ndarray_base a, dtype=None):
     cdef bint same_dtype = False
     zero_dim = a._shape.size() == 0
     if dtype is None:
@@ -2650,13 +2653,13 @@ cpdef ndarray ascontiguousarray(ndarray a, dtype=None):
         return a
 
     shape = (1,) if zero_dim else a.shape
-    newarray = _ndarray(shape, dtype)
+    newarray = ndarray(shape, dtype)
     elementwise_copy(a, newarray)
     return newarray
 
 
-cpdef ndarray asfortranarray(ndarray a, dtype=None):
-    cdef ndarray newarray
+cpdef _ndarray_base asfortranarray(_ndarray_base a, dtype=None):
+    cdef _ndarray_base newarray
     cdef int m, n
     cdef bint same_dtype = False
     zero_dim = a._shape.size() == 0
@@ -2676,12 +2679,12 @@ cpdef ndarray asfortranarray(ndarray a, dtype=None):
     if same_dtype and not zero_dim:
         return _internal_asfortranarray(a)
 
-    newarray = _ndarray((1,) if zero_dim else a.shape, dtype, order='F')
+    newarray = ndarray((1,) if zero_dim else a.shape, dtype, order='F')
     elementwise_copy(a, newarray)
     return newarray
 
 
-cpdef ndarray _convert_object_with_cuda_array_interface(a):
+cpdef _ndarray_base _convert_object_with_cuda_array_interface(a):
     if runtime._is_hip_environment:
         raise RuntimeError(
             'HIP/ROCm does not support cuda array interface')
@@ -2719,16 +2722,16 @@ cpdef ndarray _convert_object_with_cuda_array_interface(a):
     if stream_ptr is not None:
         if _util.CUDA_ARRAY_INTERFACE_SYNC:
             runtime.streamSynchronize(stream_ptr)
-    return _ndarray(shape, dtype, memptr, strides)
+    return ndarray(shape, dtype, memptr, strides)
 
 
-cdef ndarray _ndarray_init(const shape_t& shape, dtype):
-    cdef ndarray ret = _ndarray.__new__(_ndarray, _no_init=True)
+cdef _ndarray_base _ndarray_init(const shape_t& shape, dtype):
+    cdef _ndarray_base ret = ndarray.__new__(ndarray, _no_init=True)
     ret._init_fast(shape, dtype, True)
     return ret
 
 
-cdef ndarray _create_ndarray_from_shape_strides(
+cdef _ndarray_base _create_ndarray_from_shape_strides(
         const shape_t& shape, const strides_t& strides, dtype):
     cdef int ndim = shape.size()
     cdef int64_t begin = 0, end = dtype.itemsize
@@ -2739,4 +2742,4 @@ cdef ndarray _create_ndarray_from_shape_strides(
         elif strides[i] < 0:
             begin += strides[i] * (shape[i] - 1)
     ptr = memory.alloc(end - begin) + begin
-    return _ndarray(shape, dtype, memptr=ptr, strides=strides)
+    return ndarray(shape, dtype, memptr=ptr, strides=strides)

--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -93,6 +93,9 @@ cdef object _null_context = contextlib.nullcontext()
 
 
 class _ndarray(ndarray):
+    __module__ = 'cupy'
+    __doc__ = ndarray.__doc__
+
     def __new__(cls, *args, _obj=None, _no_init=False, **kwargs):
         x = super().__new__(cls, *args, **kwargs)
         if _no_init:

--- a/cupy/_core/dlpack.pxd
+++ b/cupy/_core/dlpack.pxd
@@ -1,4 +1,4 @@
-from cupy._core.core cimport ndarray
+from cupy._core.core cimport _ndarray_base
 
 
 cdef extern from './include/cupy/dlpack/dlpack.h' nogil:
@@ -7,6 +7,6 @@ cdef extern from './include/cupy/dlpack/dlpack.h' nogil:
     int device_ROCM 'kDLROCM'
 
 
-cpdef object toDlpack(ndarray array) except +
-cpdef ndarray fromDlpack(object dltensor) except +
+cpdef object toDlpack(_ndarray_base array) except +
+cpdef _ndarray_base fromDlpack(object dltensor) except +
 cpdef from_dlpack(array)

--- a/cupy/_core/dlpack.pyx
+++ b/cupy/_core/dlpack.pyx
@@ -10,7 +10,7 @@ from libcpp.vector cimport vector
 
 from cupy_backends.cuda.api cimport runtime
 from cupy_backends.cuda cimport stream as stream_module
-from cupy._core.core cimport ndarray
+from cupy._core.core cimport _ndarray_base
 from cupy.cuda cimport device
 from cupy.cuda cimport memory
 
@@ -83,14 +83,14 @@ cdef void deleter(DLManagedTensor* tensor) with gil:
     if tensor.manager_ctx is NULL:
         return
     stdlib.free(tensor.dl_tensor.shape)
-    cpython.Py_DECREF(<ndarray>tensor.manager_ctx)
+    cpython.Py_DECREF(<_ndarray_base>tensor.manager_ctx)
     tensor.manager_ctx = NULL
     stdlib.free(tensor)
 
 
 # The name of this function is following the framework integration guide of
 # TensorComprehensions.
-cpdef object toDlpack(ndarray array) except +:
+cpdef object toDlpack(_ndarray_base array) except +:
     cdef DLManagedTensor* dlm_tensor = \
         <DLManagedTensor*>stdlib.malloc(sizeof(DLManagedTensor))
 
@@ -207,7 +207,7 @@ cdef class DLPackMemory(memory.BaseMemory):
 
 # The name of this function is following the framework integration guide of
 # TensorComprehensions.
-cpdef ndarray fromDlpack(object dltensor) except +:
+cpdef _ndarray_base fromDlpack(object dltensor) except +:
     """Zero-copy conversion from a DLPack tensor to a :class:`~cupy.ndarray`.
 
     DLPack is a open in memory tensor structure proposed in this repository:
@@ -257,7 +257,7 @@ cpdef ndarray fromDlpack(object dltensor) except +:
     return _dlpack_to_cupy_array(dltensor)
 
 
-cdef inline ndarray _dlpack_to_cupy_array(dltensor) except +:
+cdef inline _ndarray_base _dlpack_to_cupy_array(dltensor) except +:
     cdef DLPackMemory mem = DLPackMemory(dltensor)
     cdef DLDataType dtype = mem.dlm_tensor.dl_tensor.dtype
     cdef int bits = dtype.bits
@@ -318,7 +318,7 @@ cdef inline ndarray _dlpack_to_cupy_array(dltensor) except +:
     if mem.dlm_tensor.dl_tensor.strides is NULL:
         # Make sure this capsule will never be used again.
         cpython.PyCapsule_SetName(mem.dltensor, 'used_dltensor')
-        return core._ndarray(shape_vec, cp_dtype, mem_ptr, strides=None)
+        return core.ndarray(shape_vec, cp_dtype, mem_ptr, strides=None)
     cdef int64_t* strides = mem.dlm_tensor.dl_tensor.strides
     cdef vector[Py_ssize_t] strides_vec
     for i in range(ndim):
@@ -326,7 +326,7 @@ cdef inline ndarray _dlpack_to_cupy_array(dltensor) except +:
 
     # Make sure this capsule will never be used again.
     cpython.PyCapsule_SetName(mem.dltensor, 'used_dltensor')
-    return core._ndarray(shape_vec, cp_dtype, mem_ptr, strides=strides_vec)
+    return core.ndarray(shape_vec, cp_dtype, mem_ptr, strides=strides_vec)
 
 
 # TODO(leofang): this function is exposed to the cupy namespace, so it returns

--- a/cupy/_core/internal.pyx
+++ b/cupy/_core/internal.pyx
@@ -10,7 +10,7 @@ import warnings
 
 import numpy
 
-from cupy._core.core cimport ndarray
+from cupy._core.core cimport _ndarray_base
 
 
 cdef extern from 'halffloat.h':
@@ -335,14 +335,14 @@ cdef _broadcast_core(list arrays, shape_t& shape):
     cdef Py_ssize_t i, j, s, a_ndim, a_sh, nd
     cdef strides_t strides
     cdef vector.vector[int] index
-    cdef ndarray a
+    cdef _ndarray_base a
     cdef list ret
 
     shape.clear()
     index.reserve(len(arrays))
     nd = 0
     for i, x in enumerate(arrays):
-        if not isinstance(x, ndarray):
+        if not isinstance(x, _ndarray_base):
             continue
         a = x
         index.push_back(i)
@@ -368,7 +368,7 @@ cdef _broadcast_core(list arrays, shape_t& shape):
             raise ValueError(
                 'operands could not be broadcast together with shapes {}'
                 .format(
-                    ' '.join([str(x.shape) if isinstance(x, ndarray)
+                    ' '.join([str(x.shape) if isinstance(x, _ndarray_base)
                               else '()' for x in arrays])))
         shape.push_back(s)
 

--- a/cupy/cuda/cub.pxd
+++ b/cupy/cuda/cub.pxd
@@ -1,4 +1,4 @@
-from cupy._core.core cimport ndarray
+from cupy._core.core cimport _ndarray_base
 
 
 cpdef enum cupy_cub_op:
@@ -13,8 +13,8 @@ cpdef enum cupy_cub_op:
 
 
 # TODO(leofang): cimport these in other modules?
-cpdef cub_reduction(ndarray arr, op,
-                    axis=*, dtype=*, ndarray out=*, keepdims=*)
-cpdef cub_scan(ndarray arr, op)
+cpdef cub_reduction(_ndarray_base arr, op,
+                    axis=*, dtype=*, _ndarray_base out=*, keepdims=*)
+cpdef cub_scan(_ndarray_base arr, op)
 
 cpdef bint _cub_device_segmented_reduce_axis_compatible(tuple, Py_ssize_t, str)

--- a/cupy/cuda/cub.pyx
+++ b/cupy/cuda/cub.pyx
@@ -101,7 +101,7 @@ cpdef _get_cuda_build_version():
         return 0
 
 
-cdef tuple _get_output_shape(ndarray arr, tuple out_axis, bint keepdims):
+cdef tuple _get_output_shape(_ndarray_base arr, tuple out_axis, bint keepdims):
     cdef tuple out_shape
 
     if not keepdims:
@@ -133,9 +133,9 @@ cpdef Py_ssize_t _preprocess_array(tuple arr_shape, tuple reduce_axis,
     return contiguous_size
 
 
-def device_reduce(ndarray x, op, tuple out_axis, out=None,
+def device_reduce(_ndarray_base x, op, tuple out_axis, out=None,
                   bint keepdims=False):
-    cdef ndarray y
+    cdef _ndarray_base y
     cdef memory.MemoryPointer ws
     cdef int dtype_id, ndim_out, kv_bytes, x_size, op_code
     cdef size_t ws_size
@@ -198,10 +198,10 @@ def device_reduce(ndarray x, op, tuple out_axis, out=None,
     return y
 
 
-def device_segmented_reduce(ndarray x, op, tuple reduce_axis,
+def device_segmented_reduce(_ndarray_base x, op, tuple reduce_axis,
                             tuple out_axis, out=None, bint keepdims=False,
                             Py_ssize_t contiguous_size=0):
-    cdef ndarray y, offset
+    cdef _ndarray_base y, offset
     cdef str order
     cdef memory.MemoryPointer ws
     cdef void* x_ptr
@@ -262,9 +262,9 @@ def device_segmented_reduce(ndarray x, op, tuple reduce_axis,
     return y
 
 
-def device_csrmv(int n_rows, int n_cols, int nnz, ndarray values,
-                 ndarray indptr, ndarray indices, ndarray x):
-    cdef ndarray y
+def device_csrmv(int n_rows, int n_cols, int nnz, _ndarray_base values,
+                 _ndarray_base indptr, _ndarray_base indices, _ndarray_base x):
+    cdef _ndarray_base y
     cdef memory.MemoryPointer ws
     cdef void* values_ptr
     cdef void* row_offsets_ptr
@@ -318,7 +318,7 @@ def device_csrmv(int n_rows, int n_cols, int nnz, ndarray values,
     return y
 
 
-def device_scan(ndarray x, op):
+def device_scan(_ndarray_base x, op):
     cdef memory.MemoryPointer ws
     cdef int dtype_id, x_size, op_code
     cdef size_t ws_size
@@ -351,7 +351,7 @@ def device_scan(ndarray x, op):
     return x
 
 
-def device_histogram(ndarray x, ndarray y, bins):
+def device_histogram(_ndarray_base x, _ndarray_base y, bins):
     cdef memory.MemoryPointer ws
     cdef size_t ws_size, n_samples
     cdef int dtype_id, n_bins
@@ -365,7 +365,7 @@ def device_histogram(ndarray x, ndarray y, bins):
     # TODO(leofang): perhaps not needed?
     # y is guaranteed contiguous
     x = _internal_ascontiguousarray(x)
-    if isinstance(bins, ndarray):
+    if isinstance(bins, _ndarray_base):
         bins = _internal_ascontiguousarray(bins)
         bins_ptr = <void*><intptr_t>bins.data.ptr
         n_bins = bins.size
@@ -418,7 +418,7 @@ cpdef bint _cub_device_segmented_reduce_axis_compatible(
 
 
 cdef bint can_use_device_reduce(
-        ndarray x, int op, tuple out_axis, dtype=None) except*:
+        _ndarray_base x, int op, tuple out_axis, dtype=None) except*:
     return (
         out_axis is ()
         and _cub_reduce_dtype_compatible(x.dtype, op, dtype)
@@ -426,7 +426,7 @@ cdef bint can_use_device_reduce(
 
 
 cdef (bint, Py_ssize_t) can_use_device_segmented_reduce(  # noqa: E211
-        ndarray x, int op, tuple reduce_axis, tuple out_axis,
+        _ndarray_base x, int op, tuple reduce_axis, tuple out_axis,
         dtype=None, str order='C') except*:
     if not _cub_reduce_dtype_compatible(x.dtype, op, dtype):
         return (False, 0)
@@ -483,8 +483,8 @@ cdef _cub_reduce_dtype_compatible(x_dtype, int op, dtype=None):
 
 
 cpdef cub_reduction(
-        ndarray arr, op,
-        axis=None, dtype=None, ndarray out=None, keepdims=False):
+        _ndarray_base arr, op,
+        axis=None, dtype=None, _ndarray_base out=None, keepdims=False):
     """Perform a reduction using CUB.
 
     If the specified reduction is not possible, None is returned.
@@ -545,7 +545,7 @@ cpdef cub_reduction(
     return None
 
 
-cpdef cub_scan(ndarray arr, op):
+cpdef cub_scan(_ndarray_base arr, op):
     """Perform an (in-place) prefix scan using CUB.
 
     If the specified scan is not possible, None is returned.

--- a/cupy/cuda/function.pyx
+++ b/cupy/cuda/function.pyx
@@ -13,7 +13,7 @@ from libc.stdint cimport uintmax_t
 from libcpp cimport vector
 
 from cupy._core cimport _carray
-from cupy._core cimport core
+from cupy._core.core cimport _ndarray_base
 from cupy_backends.cuda.api cimport driver
 from cupy_backends.cuda.api cimport runtime
 from cupy.cuda cimport stream as stream_module
@@ -108,8 +108,8 @@ cdef inline CPointer _pointer(x):
 
     if x is None:
         return CPointer()
-    if isinstance(x, core.ndarray):
-        return (<core.ndarray>x).get_pointer()
+    if isinstance(x, _ndarray_base):
+        return (<_ndarray_base>x).get_pointer()
     if isinstance(x, _carray.Indexer):
         return (<_carray.Indexer>x).get_pointer()
     if isinstance(x, MemoryPointer):

--- a/cupy/cuda/texture.pxd
+++ b/cupy/cuda/texture.pxd
@@ -1,6 +1,6 @@
 from libc.stdint cimport intptr_t, uintmax_t
 
-from cupy._core.core cimport ndarray
+from cupy._core.core cimport _ndarray_base
 
 
 cdef class ChannelFormatDescriptor:
@@ -13,7 +13,7 @@ cdef class ResourceDescriptor:
         readonly intptr_t ptr
         readonly ChannelFormatDescriptor chDesc
         readonly CUDAarray cuArr
-        readonly ndarray arr
+        readonly _ndarray_base arr
 
 
 cdef class TextureDescriptor:

--- a/cupy/cusolver.pyx
+++ b/cupy/cusolver.pyx
@@ -16,7 +16,7 @@ from cupy_backends.cuda.libs.cusolver cimport (  # noqa
 
 from cupy.cuda cimport memory
 from cupy._core.core cimport _internal_ascontiguousarray
-from cupy._core.core cimport _ndarray_init, ndarray
+from cupy._core.core cimport _ndarray_init, _ndarray_base
 
 import cupy as _cupy
 from cupy_backends.cuda.api import runtime as _runtime
@@ -288,7 +288,7 @@ cpdef _gesvd_batched(a, a_dtype, full_matrices, compute_uv, overwrite_a):
 
     # TODO(leofang): try overlapping using a small stream pool?
 
-    cdef ndarray x, s, u, vt, dev_info
+    cdef _ndarray_base x, s, u, vt, dev_info
     cdef int n, m, k, batch_size, i, buffersize, d_size, status
     cdef intptr_t a_ptr, s_ptr, u_ptr, vt_ptr, rwork_ptr, w_ptr, info_ptr
     cdef str s_dtype

--- a/cupy/cutensor.pyx
+++ b/cupy/cutensor.pyx
@@ -9,7 +9,7 @@ cimport cython
 from libcpp cimport vector
 from libc.stdint cimport intptr_t, uint32_t, uint64_t
 from cupy._core._carray cimport shape_t
-from cupy._core.core cimport ndarray
+from cupy._core.core cimport _ndarray_base
 from cupy._core cimport internal
 from cupy_backends.cuda.libs.cutensor cimport Handle
 from cupy_backends.cuda.libs.cutensor cimport TensorDescriptor
@@ -181,7 +181,7 @@ def create_mode(*mode):
     return Mode(integer_mode)
 
 
-cdef inline Mode _auto_create_mode(ndarray array, mode):
+cdef inline Mode _auto_create_mode(_ndarray_base array, mode):
     if not isinstance(mode, Mode):
         mode = create_mode(*mode)
     if array.ndim != mode.ndim:
@@ -224,7 +224,7 @@ cdef inline Mode _create_mode_with_cache(axis_or_ndim):
 
 
 cpdef TensorDescriptor create_tensor_descriptor(
-        ndarray a, int uop=cutensor.OP_IDENTITY, Handle handle=None):
+        _ndarray_base a, int uop=cutensor.OP_IDENTITY, Handle handle=None):
     """Create a tensor descriptor
 
     Args:
@@ -257,10 +257,10 @@ cpdef TensorDescriptor create_tensor_descriptor(
 
 
 def elementwise_trinary(
-        alpha, ndarray A, TensorDescriptor desc_A, mode_A,
-        beta, ndarray B, TensorDescriptor desc_B, mode_B,
-        gamma, ndarray C, TensorDescriptor desc_C, mode_C,
-        ndarray out=None,
+        alpha, _ndarray_base A, TensorDescriptor desc_A, mode_A,
+        beta, _ndarray_base B, TensorDescriptor desc_B, mode_B,
+        gamma, _ndarray_base C, TensorDescriptor desc_C, mode_C,
+        _ndarray_base out=None,
         op_AB=cutensor.OP_ADD, op_ABC=cutensor.OP_ADD, compute_dtype=None):
     """Element-wise tensor operation for three input tensors
 
@@ -331,12 +331,12 @@ def elementwise_trinary(
         _dtype.to_cuda_dtype(compute_dtype, is_half_allowed=True))
 
 
-cdef inline ndarray _elementwise_trinary_impl(
+cdef inline _ndarray_base _elementwise_trinary_impl(
         Handle handle,
-        _Scalar alpha, ndarray A, TensorDescriptor desc_A, Mode mode_A,
-        _Scalar beta, ndarray B, TensorDescriptor desc_B, Mode mode_B,
-        _Scalar gamma, ndarray C, TensorDescriptor desc_C, Mode mode_C,
-        ndarray out, int op_AB, int op_ABC, int compute_type):
+        _Scalar alpha, _ndarray_base A, TensorDescriptor desc_A, Mode mode_A,
+        _Scalar beta, _ndarray_base B, TensorDescriptor desc_B, Mode mode_B,
+        _Scalar gamma, _ndarray_base C, TensorDescriptor desc_C, Mode mode_C,
+        _ndarray_base out, int op_AB, int op_ABC, int compute_type):
     cutensor.elementwiseTrinary(
         handle,
         alpha.ptr, A.data.ptr, desc_A, mode_A.data,
@@ -348,9 +348,9 @@ cdef inline ndarray _elementwise_trinary_impl(
 
 
 def elementwise_binary(
-        alpha, ndarray A, TensorDescriptor desc_A, mode_A,
-        gamma, ndarray C, TensorDescriptor desc_C, mode_C,
-        ndarray out=None,
+        alpha, _ndarray_base A, TensorDescriptor desc_A, mode_A,
+        gamma, _ndarray_base C, TensorDescriptor desc_C, mode_C,
+        _ndarray_base out=None,
         op_AC=cutensor.OP_ADD, compute_dtype=None):
     """Element-wise tensor operation for two input tensors
 
@@ -391,11 +391,11 @@ def elementwise_binary(
         out, op_AC, _dtype.to_cuda_dtype(compute_dtype, is_half_allowed=True))
 
 
-cdef inline ndarray _elementwise_binary_impl(
+cdef inline _ndarray_base _elementwise_binary_impl(
         Handle handle,
-        _Scalar alpha, ndarray A, TensorDescriptor desc_A, Mode mode_A,
-        _Scalar gamma, ndarray C, TensorDescriptor desc_C, Mode mode_C,
-        ndarray out, int op_AC, int compute_type):
+        _Scalar alpha, _ndarray_base A, TensorDescriptor desc_A, Mode mode_A,
+        _Scalar gamma, _ndarray_base C, TensorDescriptor desc_C, Mode mode_C,
+        _ndarray_base out, int op_AC, int compute_type):
     # stride and mode of `out` and `C` must be the same.
     cutensor.elementwiseBinary(
         handle,
@@ -408,9 +408,9 @@ cdef inline ndarray _elementwise_binary_impl(
 
 cdef inline ContractionDescriptor _create_contraction_descriptor(
         Handle handle,
-        ndarray A, TensorDescriptor desc_A, Mode mode_A,
-        ndarray B, TensorDescriptor desc_B, Mode mode_B,
-        ndarray C, TensorDescriptor desc_C, Mode mode_C,
+        _ndarray_base A, TensorDescriptor desc_A, Mode mode_A,
+        _ndarray_base B, TensorDescriptor desc_B, Mode mode_B,
+        _ndarray_base C, TensorDescriptor desc_C, Mode mode_C,
         int cutensor_compute_type):
     """Create a contraction descriptor"""
     cdef uint32_t alignment_req_A = cutensor.getAlignmentRequirement(
@@ -522,9 +522,9 @@ cdef _get_scalar_dtype(out_dtype):
 
 
 def contraction(
-        alpha, ndarray A, TensorDescriptor desc_A, mode_A,
-        ndarray B, TensorDescriptor desc_B, mode_B,
-        beta, ndarray C, TensorDescriptor desc_C, mode_C,
+        alpha, _ndarray_base A, TensorDescriptor desc_A, mode_A,
+        _ndarray_base B, TensorDescriptor desc_B, mode_B,
+        beta, _ndarray_base C, TensorDescriptor desc_C, mode_C,
         compute_dtype=None,
         int algo=cutensor.ALGO_DEFAULT,
         int ws_pref=cutensor.WORKSPACE_RECOMMENDED):
@@ -583,17 +583,17 @@ def contraction(
         compute_type, algo, ws_pref)
 
 
-cdef inline ndarray _contraction_impl(
+cdef inline _ndarray_base _contraction_impl(
         Handle handle,
-        _Scalar alpha, ndarray A, TensorDescriptor desc_A, Mode mode_A,
-        ndarray B, TensorDescriptor desc_B, Mode mode_B,
-        _Scalar beta, ndarray C, TensorDescriptor desc_C, Mode mode_C,
+        _Scalar alpha, _ndarray_base A, TensorDescriptor desc_A, Mode mode_A,
+        _ndarray_base B, TensorDescriptor desc_B, Mode mode_B,
+        _Scalar beta, _ndarray_base C, TensorDescriptor desc_C, Mode mode_C,
         int cutensor_compute_type, int algo, int ws_pref):
     cdef ContractionDescriptor desc
     cdef ContractionFind find
     cdef ContractionPlan plan
     cdef uint64_t ws_size
-    cdef ndarray out, ws
+    cdef _ndarray_base out, ws
 
     out = C
 
@@ -637,8 +637,8 @@ def contraction_max_algos():
 
 
 def reduction(
-        alpha, ndarray A, TensorDescriptor desc_A, mode_A,
-        beta, ndarray C, TensorDescriptor desc_C, mode_C,
+        alpha, _ndarray_base A, TensorDescriptor desc_A, mode_A,
+        beta, _ndarray_base C, TensorDescriptor desc_C, mode_C,
         int reduce_op=cutensor.OP_ADD, compute_dtype=None):
     """Tensor reduction
 
@@ -690,13 +690,13 @@ def reduction(
     )
 
 
-cdef inline ndarray _reduction_impl(
+cdef inline _ndarray_base _reduction_impl(
         Handle handle,
-        _Scalar alpha, ndarray A, TensorDescriptor desc_A, Mode mode_A,
-        _Scalar beta, ndarray C, TensorDescriptor desc_C, Mode mode_C,
+        _Scalar alpha, _ndarray_base A, TensorDescriptor desc_A, Mode mode_A,
+        _Scalar beta, _ndarray_base C, TensorDescriptor desc_C, Mode mode_C,
         int reduce_op, int cutensor_compute_type):
     cdef uint64_t ws_size
-    cdef ndarray ws, out
+    cdef _ndarray_base ws, out
 
     out = C
     ws_size = cutensor.reductionGetWorkspace(
@@ -733,9 +733,10 @@ _cutensor_dtypes = [
 
 
 def _try_reduction_routine(
-        ndarray x, axis, dtype, ndarray out, keepdims, reduce_op, alpha, beta):
+        _ndarray_base x, axis, dtype, _ndarray_base out, keepdims, reduce_op,
+        alpha, beta):
     cdef Handle handle
-    cdef ndarray in_arg, out_arg
+    cdef _ndarray_base in_arg, out_arg
     cdef shape_t out_shape
     cdef tuple reduce_axis, out_axis
     cdef TensorDescriptor desc_in, desc_out
@@ -825,7 +826,8 @@ cdef inline bint _all_positive(const vector.vector[Py_ssize_t]& args):
 
 
 def _try_elementwise_binary_routine(
-        ndarray a, ndarray c, dtype, ndarray out, op, alpha, gamma):
+        _ndarray_base a, _ndarray_base c, dtype, _ndarray_base out, op, alpha,
+        gamma):
     cdef Handle handle
     cdef TensorDescriptor desc_a, desc_c, desc_out
 

--- a/cupy/fft/_callback.pyx
+++ b/cupy/fft/_callback.pyx
@@ -1,7 +1,7 @@
 from libc.stdint cimport intptr_t
 
 from cupy_backends.cuda.api.runtime cimport _is_hip_environment
-from cupy._core.core cimport ndarray
+from cupy._core.core cimport _ndarray_base
 from cupy.cuda.device cimport get_compute_capability
 
 import hashlib
@@ -132,7 +132,7 @@ cdef inline void _set_nvcc_path() except*:
 
 cdef inline void _sanity_checks(
         str cb_load, str cb_store,
-        ndarray cb_load_aux_arr, ndarray cb_store_aux_arr) except*:
+        _ndarray_base cb_load_aux_arr, _ndarray_base cb_store_aux_arr) except*:
     if _is_hip_environment:
         raise RuntimeError('hipFFT does not support callbacks')
     if not sys.platform.startswith('linux'):
@@ -327,15 +327,15 @@ cdef class _CallbackManager:
     cdef:
         readonly str cb_load
         readonly str cb_store
-        readonly ndarray cb_load_aux_arr
-        readonly ndarray cb_store_aux_arr
+        readonly _ndarray_base cb_load_aux_arr
+        readonly _ndarray_base cb_store_aux_arr
         object mod
 
     def __init__(self,
                  str cb_load='',
                  str cb_store='',
-                 ndarray cb_load_aux_arr=None,
-                 ndarray cb_store_aux_arr=None):
+                 _ndarray_base cb_load_aux_arr=None,
+                 _ndarray_base cb_store_aux_arr=None):
         if not _is_init:
             _set_vars()
         _sanity_checks(cb_load, cb_store,
@@ -434,8 +434,8 @@ cdef class _CallbackManager:
             follow.
 
         '''
-        cdef ndarray cb_load_aux_arr = self.cb_load_aux_arr
-        cdef ndarray cb_store_aux_arr = self.cb_store_aux_arr
+        cdef _ndarray_base cb_load_aux_arr = self.cb_load_aux_arr
+        cdef _ndarray_base cb_store_aux_arr = self.cb_store_aux_arr
         cdef intptr_t cb_load_ptr=0, cb_store_ptr=0
 
         fft_type = plan.fft_type
@@ -472,8 +472,8 @@ cdef class _CallbackManager:
                 plan.handle, cb_store_type, False, cb_store_ptr)
 
     cdef set_caller_infos(self,
-                          ndarray cb_load_aux_arr=None,
-                          ndarray cb_store_aux_arr=None):
+                          _ndarray_base cb_load_aux_arr=None,
+                          _ndarray_base cb_store_aux_arr=None):
         '''Set the auxilliary arrays to be used by the load/store callbacks.
         Corresponding to the ``callerInfo`` field in cuFFT's callback API.
 
@@ -572,8 +572,8 @@ cdef class set_cufft_callbacks:
                  str cb_load='',
                  str cb_store='',
                  *,
-                 ndarray cb_load_aux_arr=None,
-                 ndarray cb_store_aux_arr=None):
+                 _ndarray_base cb_load_aux_arr=None,
+                 _ndarray_base cb_store_aux_arr=None):
         # For every distinct pair of load & store callbacks, we compile an
         # external Python module and cache it.
         cdef tuple key = (cb_load, cb_store)

--- a/cupy/lib/_polynomial.pyx
+++ b/cupy/lib/_polynomial.pyx
@@ -2,7 +2,7 @@ import numbers
 
 import numpy
 
-from cupy._core.core cimport ndarray
+from cupy._core.core cimport _ndarray_base
 
 import cupy
 from cupy.lib import _routines_poly
@@ -31,7 +31,7 @@ cdef class poly1d:
     __hash__ = None
 
     cdef:
-        readonly ndarray _coeffs
+        readonly _ndarray_base _coeffs
         readonly str _variable
         readonly bint _trimmed
 

--- a/cupy/random/_bit_generator.pyx
+++ b/cupy/random/_bit_generator.pyx
@@ -7,7 +7,6 @@ from libc.stdint cimport intptr_t, uint64_t, uint32_t
 
 import cupy
 from cupy.cuda cimport stream
-from cupy._core.core cimport ndarray
 from cupy.random._generator_api import init_curand, random_raw
 from cupy_backends.cuda.api import runtime
 

--- a/cupy/random/_generator_api.pyx
+++ b/cupy/random/_generator_api.pyx
@@ -6,7 +6,7 @@ from libc.stdint cimport intptr_t, uint64_t, uint32_t, int32_t, int64_t
 import cupy
 from cupy import _core
 from cupy.cuda cimport stream
-from cupy._core.core cimport ndarray
+from cupy._core.core cimport _ndarray_base
 from cupy._core cimport internal
 from cupy_backends.cuda.api import runtime
 
@@ -69,7 +69,7 @@ cdef extern from 'cupy_distributions.cuh' nogil:
         intptr_t stream, intptr_t arg1, intptr_t arg2, intptr_t arg3)
 
 
-cdef ndarray _array_data(ndarray x):
+cdef _ndarray_base _array_data(_ndarray_base x):
     return cupy.array((x.data.ptr, x.ndim) + x.shape + x.strides)
 
 
@@ -144,7 +144,7 @@ class Generator:
         .. seealso::
             - :meth:`numpy.random.Generator.random`
         """
-        cdef ndarray y
+        cdef _ndarray_base y
 
         if out is not None:
             self._check_output_array(dtype, size, out)
@@ -188,7 +188,7 @@ class Generator:
         .. seealso::
             - :meth:`numpy.random.Generator.integers`
         """
-        cdef ndarray y
+        cdef _ndarray_base y
         if high is None:
             lo = 0
             hi1 = int(low)
@@ -250,16 +250,16 @@ class Generator:
         .. seealso::
             :meth:`numpy.random.Generator.beta`
         """
-        cdef ndarray y
+        cdef _ndarray_base y
         cdef a_arr, b_arr
 
-        if not isinstance(a, ndarray):
+        if not isinstance(a, _ndarray_base):
             if type(a) in (float, int):
                 a = cupy.asarray(a, numpy.float64)
             else:
                 raise TypeError('a is required to be a cupy.ndarray'
                                 ' or a scalar')
-        if not isinstance(b, ndarray):
+        if not isinstance(b, _ndarray_base):
             if type(b) in (float, int):
                 b = cupy.asarray(b, numpy.float64)
             else:
@@ -307,9 +307,9 @@ class Generator:
             :meth:`numpy.random.Generator.chisquare`
         """
 
-        cdef ndarray y
+        cdef _ndarray_base y
 
-        if not isinstance(df, ndarray):
+        if not isinstance(df, _ndarray_base):
             if type(df) in (float, int):
                 df = cupy.asarray(df, numpy.float64)
             else:
@@ -354,7 +354,7 @@ class Generator:
             :meth:`numpy.random.Generator.dirichlet`
         """
 
-        if not isinstance(alpha, ndarray):
+        if not isinstance(alpha, _ndarray_base):
             if type(alpha) in (float, int):
                 alpha = cupy.asarray(alpha, numpy.float64)
             else:
@@ -425,7 +425,7 @@ class Generator:
         .. seealso::
             :meth:`numpy.random.Generator.f`
         """
-        if not isinstance(dfnum, ndarray):
+        if not isinstance(dfnum, _ndarray_base):
             if type(dfnum) in (float, int):
                 dfnum = cupy.asarray(dfnum, numpy.float64)
             else:
@@ -434,7 +434,7 @@ class Generator:
         else:
             dfnum = dfnum.astype('d', copy=False)
 
-        if not isinstance(dfden, ndarray):
+        if not isinstance(dfden, _ndarray_base):
             if type(dfden) in (float, int):
                 dfden = cupy.asarray(dfden, numpy.float64)
             else:
@@ -472,10 +472,10 @@ class Generator:
         .. seealso::
             :meth:`numpy.random.Generator.geometric`
         """
-        cdef ndarray y
-        cdef ndarray p_arr
+        cdef _ndarray_base y
+        cdef _ndarray_base p_arr
 
-        if not isinstance(p, ndarray):
+        if not isinstance(p, _ndarray_base):
             if type(p) in (float, int):
                 p_a = _core.ndarray((), numpy.float64)
                 p_a.fill(p)
@@ -523,12 +523,12 @@ class Generator:
         .. seealso::
             :meth:`numpy.random.Generator.hypergeometric`
         """
-        cdef ndarray y
-        cdef ndarray ngood_arr
-        cdef ndarray nbad_arr
-        cdef ndarray nsample_arr
+        cdef _ndarray_base y
+        cdef _ndarray_base ngood_arr
+        cdef _ndarray_base nbad_arr
+        cdef _ndarray_base nsample_arr
 
-        if not isinstance(ngood, ndarray):
+        if not isinstance(ngood, _ndarray_base):
             if type(ngood) in (float, int):
                 ngood_a = _core.ndarray((), numpy.int64)
                 ngood_a.fill(ngood)
@@ -539,7 +539,7 @@ class Generator:
         else:
             ngood = ngood.astype(numpy.int64, copy=False)
 
-        if not isinstance(nbad, ndarray):
+        if not isinstance(nbad, _ndarray_base):
             if type(nbad) in (float, int):
                 nbad_a = _core.ndarray((), numpy.int64)
                 nbad_a.fill(nbad)
@@ -550,7 +550,7 @@ class Generator:
         else:
             nbad = nbad.astype(numpy.int64, copy=False)
 
-        if not isinstance(nsample, ndarray):
+        if not isinstance(nsample, _ndarray_base):
             if type(nsample) in (float, int):
                 nsample_a = _core.ndarray((), numpy.int64)
                 nsample_a.fill(nsample)
@@ -603,10 +603,10 @@ class Generator:
         .. seealso::
             :meth:`numpy.random.Generator.logseries`
         """
-        cdef ndarray y
-        cdef ndarray p_arr
+        cdef _ndarray_base y
+        cdef _ndarray_base p_arr
 
-        if not isinstance(p, ndarray):
+        if not isinstance(p, _ndarray_base):
             if type(p) in (float, int):
                 p = cupy.asarray(p, numpy.float64)
             else:
@@ -655,7 +655,7 @@ class Generator:
         .. seealso::
             :meth:`numpy.random.Generator.standard_exponential`
         """
-        cdef ndarray y
+        cdef _ndarray_base y
 
         if method == 'zig':
             raise NotImplementedError('Ziggurat method is not supported')
@@ -695,10 +695,10 @@ class Generator:
         .. seealso::
             :meth:`numpy.random.Generator.poisson`
         """
-        cdef ndarray y
-        cdef ndarray lam_arr
+        cdef _ndarray_base y
+        cdef _ndarray_base lam_arr
 
-        if not isinstance(lam, ndarray):
+        if not isinstance(lam, _ndarray_base):
             if type(lam) in (float, int):
                 lam_a = _core.ndarray((), numpy.float64)
                 lam_a.fill(lam)
@@ -746,7 +746,7 @@ class Generator:
             :meth:`numpy.random.Generator.power`
         """
 
-        if not isinstance(a, ndarray):
+        if not isinstance(a, _ndarray_base):
             if type(a) in (float, int):
                 a = cupy.asarray(a, numpy.float64)
             else:
@@ -786,7 +786,7 @@ class Generator:
         .. seealso::
             - :meth:`numpy.random.Generator.standard_normal`
         """
-        cdef ndarray y
+        cdef _ndarray_base y
 
         if out is not None:
             self._check_output_array(dtype, size, out)
@@ -855,10 +855,10 @@ class Generator:
         .. seealso::
             - :meth:`numpy.random.Generator.standard_gamma`
         """
-        cdef ndarray y
-        cdef ndarray shape_arr
+        cdef _ndarray_base y
+        cdef _ndarray_base shape_arr
 
-        if not isinstance(shape, ndarray):
+        if not isinstance(shape, _ndarray_base):
             if type(shape) in (float, int):
                 shape_a = _core.ndarray((), numpy.float64)
                 shape_a.fill(shape)
@@ -930,19 +930,19 @@ class Generator:
         .. seealso::
            :meth:`numpy.random.Generator.binomial`
         """
-        cdef ndarray y
-        cdef ndarray n_arr
-        cdef ndarray p_arr
+        cdef _ndarray_base y
+        cdef _ndarray_base n_arr
+        cdef _ndarray_base p_arr
         cdef intptr_t binomial_state_ptr
 
-        if isinstance(n, ndarray):
+        if isinstance(n, _ndarray_base):
             n = n.astype(numpy.int64, copy=False)
         elif type(n) in (float, int):
             n = cupy.asarray(n, numpy.int64)
         else:
             raise TypeError('n is required to be a cupy.ndarray or a scalar')
 
-        if isinstance(p, ndarray):
+        if isinstance(p, _ndarray_base):
             p = p.astype(numpy.float64, copy=False)
         elif type(p) is float:
             p = cupy.asarray(p, numpy.float64)
@@ -995,7 +995,7 @@ cdef void _launch_dist(bit_generator, func, out, args) except*:
     cdef state = <intptr_t>state_ptr
     cdef y_ptr = <intptr_t>out.data.ptr
     cdef ssize_t size = out.size
-    cdef ndarray chunk
+    cdef _ndarray_base chunk
     cdef int generator = bit_generator.generator
     # out is always contiguous, when out parameter is specified the checks
     # ensure it

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -448,14 +448,27 @@ def linkcode_resolve(domain, info):
         # obj is not a module, class, function, ..etc.
         return None
 
-    # `inspect.getsourcefile` returns None for C-extension objects
-    if filename is None:
+    def get_pyx_file(obj):
         filename = inspect.getfile(obj)
         for ext in importlib.machinery.EXTENSION_SUFFIXES:
             if filename.endswith(ext):
                 filename = filename[:-len(ext)] + '.pyx'
-                break
+                return filename
         else:
+            return None
+
+    # `cupy.ndarray` (aka. `cupy._core.core.ndarray`) has `__module__`
+    # attribute overwritten and `inspect.getsourcefile` doesn't work on it,
+    # so use `cupy._core.core`'s source location instead
+    if obj is cupy.ndarray:
+        filename = get_pyx_file(cupy._core.core)
+        if filename is None:
+            return None
+        linenum = None
+    # `inspect.getsourcefile` returns None for C-extension objects
+    elif filename is None:
+        filename = get_pyx_file(obj)
+        if filename is None:
             return None
         linenum = None
     else:
@@ -490,6 +503,17 @@ def fix_jit_callable_signature(
     if 'cupyx.jit' in name and callable(obj) and signature is None:
         return (f'{inspect.signature(obj)}', None)
 
+def fix_ndarray_signature(
+        app, what, name, obj, options, signature, return_annotation):
+    # Replace `cupy.ndarray` constructor arguments
+    if obj is cupy.ndarray:
+        return ("(self, shape, dtype=float, memptr=None, strides=None, order='C')", return_annotation)
+    # Replace `-> _ndarray_base` return annoation on document to `-> ndarray`
+    if return_annotation == '_ndarray_base':
+        return (signature, 'ndarray')
+    return (signature, return_annotation)
+
 def setup(app):
     app.connect("autodoc-process-docstring", remove_array_api_module_docstring)
     app.connect("autodoc-process-signature", fix_jit_callable_signature)
+    app.connect("autodoc-process-signature", fix_ndarray_signature)

--- a/tests/cupy_tests/core_tests/test_core.py
+++ b/tests/cupy_tests/core_tests/test_core.py
@@ -57,7 +57,7 @@ class TestOrder(unittest.TestCase):
     @testing.for_orders(_orders.keys())
     def test_ndarray(self, order):
         order_expect = _orders[order]
-        a = core._ndarray((2, 3), order=order)
+        a = core.ndarray((2, 3), order=order)
         expect_c = order_expect == 'C'
         expect_f = order_expect == 'F'
         assert a.flags.c_contiguous == expect_c


### PR DESCRIPTION
Follows up #6716. This PR renames `cupy._core.core._ndarray` to `cupy._core.core.ndarray` and `cupy._core.core.ndarray` to `cupy._core.core._ndarray_base`, as well as fixes the broken `cupy.ndarray` document.