### PR TITLE
[backport] Fix ifdef for ROCm >= 4.2

### DIFF
--- a/cupy/_core/include/cupy/carray.cuh
+++ b/cupy/_core/include/cupy/carray.cuh
@@ -126,7 +126,7 @@ public:
     return (__half_raw(data_).x & 0x8000u) != 0;
   }
 
-#if defined(__HIPCC__) && HIP_VERSION >= 50000000
+#ifdef __HIPCC__
 
   __device__ float16 operator-() {
     return float16(-data_);


### PR DESCRIPTION
Backport of #6750