### PR TITLE
Fix `cupy.median` for NaN inputs

### DIFF
--- a/cupy/_core/_routines_statistics.pyx
+++ b/cupy/_core/_routines_statistics.pyx
@@ -375,6 +375,10 @@ cdef _nanargmax_func = create_reduction_func(
     None, _min_max_preamble, sort_reduce_axis=False)
 
 
+cdef _exists_nan = ReductionKernel(
+    'T x', 'bool y', 'isnan(x)', 'a || b', 'y = a', 'false', '_exists_nan')
+
+
 cpdef ndarray _median(
         ndarray a, axis, out, overwrite_input, keepdims):
 
@@ -438,6 +442,9 @@ cpdef ndarray _median(
 
     out = _mean(
         part[indexer], axis=axis, dtype=None, out=out, keepdims=keepdims)
+    if part.dtype.kind in 'fc':
+        isnan = _exists_nan(part, axis=axis, keepdims=keepdims)
+        out = cupy.where(isnan, numpy.nan, out)
     if out_shape is not None:
         out = out.reshape(out_shape)
     return out

--- a/tests/cupy_tests/statistics_tests/test_meanvar.py
+++ b/tests/cupy_tests/statistics_tests/test_meanvar.py
@@ -64,6 +64,17 @@ class TestMedian:
             with pytest.raises(numpy.AxisError):
                 return xp.median(a, (0, a.ndim,), keepdims=False)
 
+    @testing.for_dtypes('efdFD')
+    @testing.numpy_cupy_allclose()
+    def test_median_nan(self, xp, dtype):
+        a = xp.array(
+            [[xp.nan, 1, 2, 3],
+             [4, 5, 6, 7],
+             [8, 9, 10, xp.nan]],
+            dtype=dtype,
+        )
+        return xp.median(a, axis=1)
+
 
 @testing.parameterize(
     *testing.product({


### PR DESCRIPTION
Fixes https://github.com/cupy/cupy/issues/6755.