### PR TITLE
Subclass cupy.ndarray subclassing - Part 3 - New from template (ufunc)

### DIFF
--- a/cupy/_core/_kernel.pxd
+++ b/cupy/_core/_kernel.pxd
@@ -155,8 +155,8 @@ cdef str _get_kernel_params(tuple params, tuple arginfos)
 cdef list _broadcast(list args, tuple params, bint use_size, shape_t& shape)
 
 cdef list _get_out_args_from_optionals(
-    list out_args, tuple out_types, const shape_t& out_shape, casting
-)
+    subtype, list out_args, tuple out_types, const shape_t& out_shape, casting,
+    obj)
 
 cdef list _get_out_args_with_params(
     list out_args, tuple out_types,

--- a/cupy/_core/_reduction.pyx
+++ b/cupy/_core/_reduction.pyx
@@ -253,7 +253,7 @@ cdef tuple _get_shape_and_strides(list in_args, list out_args):
 cdef _optimizer_copy_arg(a):
     if isinstance(a, _ndarray_base):
         x = _create_ndarray_from_shape_strides(
-            a._shape, a._strides, a.dtype)
+            cupy.ndarray, a._shape, a._strides, a.dtype, None)
         assert a.data.device_id == x.data.device_id
         elementwise_copy(a, x)
         return x
@@ -607,7 +607,7 @@ cdef class _SimpleReductionKernel(_AbstractReductionKernel):
     cdef list _get_out_args(
             self, list out_args, tuple out_types, const shape_t& out_shape):
         return _get_out_args_from_optionals(
-            out_args, out_types, out_shape, 'unsafe')
+            cupy.ndarray, out_args, out_types, out_shape, 'unsafe', None)
 
     cdef function.Function _get_function(
             self,

--- a/cupy/_core/core.pxd
+++ b/cupy/_core/core.pxd
@@ -111,4 +111,4 @@ cpdef _ndarray_base _convert_object_with_cuda_array_interface(a)
 cdef _ndarray_base _ndarray_init(subtype, const shape_t& shape, dtype, obj)
 
 cdef _ndarray_base _create_ndarray_from_shape_strides(
-    const shape_t& shape, const strides_t& strides, dtype)
+    subtype, const shape_t& shape, const strides_t& strides, dtype, obj)

--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -2761,7 +2761,7 @@ cdef _ndarray_base _ndarray_init(subtype, const shape_t& shape, dtype, obj):
 
 
 cdef _ndarray_base _create_ndarray_from_shape_strides(
-        const shape_t& shape, const strides_t& strides, dtype):
+        subtype, const shape_t& shape, const strides_t& strides, dtype, obj):
     cdef int ndim = shape.size()
     cdef int64_t begin = 0, end = dtype.itemsize
     cdef memory.MemoryPointer ptr
@@ -2771,4 +2771,5 @@ cdef _ndarray_base _create_ndarray_from_shape_strides(
         elif strides[i] < 0:
             begin += strides[i] * (shape[i] - 1)
     ptr = memory.alloc(end - begin) + begin
-    return ndarray(shape, dtype, memptr=ptr, strides=strides)
+    return ndarray.__new__(
+        subtype, shape, dtype, _obj=obj, memptr=ptr, strides=strides)

--- a/cupy/cutensor.pyx
+++ b/cupy/cutensor.pyx
@@ -874,8 +874,23 @@ def _try_elementwise_binary_routine(
             alpha, gamma = gamma, alpha
         else:
             return None
+
+        # Determine a template object from which we initialize the output when
+        # inputs have subclass instances
+        def issubclass1(cls, classinfo):
+            return issubclass(cls, classinfo) and cls is not classinfo
+        subtype = _cupy.ndarray
+        template = None
+        a_type, c_type = type(a), type(c)
+        if issubclass1(a_type, _cupy.ndarray):
+            subtype = a_type
+            template = a
+        elif issubclass1(c_type, _cupy.ndarray):
+            subtype = c_type
+            template = c
+
         out = core._create_ndarray_from_shape_strides(
-            c._shape, c._strides, compute_dtype)
+            subtype, c._shape, c._strides, compute_dtype, template)
     elif out.dtype != compute_dtype:
         return None
     elif not internal.vector_equal(c._shape, out._shape):


### PR DESCRIPTION
Merge #6720 first.

This PR is a part of supporting `cupy.ndarray` subclassing, and support instantiating subclass via ufunc, including two paths: the original one and cutensor one.