### PR TITLE
Fix docs to hide `ndarray_base`

### DIFF
--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -93,31 +93,10 @@ cdef object _null_context = contextlib.nullcontext()
 
 
 class ndarray(_ndarray_base):
-    __module__ = 'cupy'
-    __doc__ = _ndarray_base.__doc__
+    """
+    __init__(self, shape, dtype=float, memptr=None, strides=None, order='C')
 
-    def __new__(cls, *args, _obj=None, _no_init=False, **kwargs):
-        x = super().__new__(cls, *args, **kwargs)
-        if _no_init:
-            return x
-        x._init(*args, **kwargs)
-        if cls is not ndarray:
-            x.__array_finalize__(_obj)
-        return x
-
-    def __init__(self, *args, **kwargs):
-        # Prevent from calling the super class `_ndarray_base.__init__()` as
-        # it is used to check accidental direct instantiation of underlaying
-        # `_ndarray_base` extention.
-        pass
-
-    def __array_finalize__(self, obj):
-        pass
-
-
-cdef class _ndarray_base:
-
-    """Multi-dimensional array on a CUDA device.
+    Multi-dimensional array on a CUDA device.
 
     This class implements a subset of methods of :class:`numpy.ndarray`.
     The difference is that this class allocates the array content on the
@@ -147,6 +126,29 @@ cdef class _ndarray_base:
             .. seealso:: :attr:`numpy.ndarray.size`
 
     """
+
+    __module__ = 'cupy'
+
+    def __new__(cls, *args, _obj=None, _no_init=False, **kwargs):
+        x = super().__new__(cls, *args, **kwargs)
+        if _no_init:
+            return x
+        x._init(*args, **kwargs)
+        if cls is not ndarray:
+            x.__array_finalize__(_obj)
+        return x
+
+    def __init__(self, *args, **kwargs):
+        # Prevent from calling the super class `_ndarray_base.__init__()` as
+        # it is used to check accidental direct instantiation of underlaying
+        # `_ndarray_base` extention.
+        pass
+
+    def __array_finalize__(self, obj):
+        pass
+
+
+cdef class _ndarray_base:
 
     def __init__(self, *args, **kwargs):
         # Raise an error if underlaying `_ndarray_base` extension type is

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -505,12 +505,12 @@ def fix_jit_callable_signature(
 
 def fix_ndarray_signature(
         app, what, name, obj, options, signature, return_annotation):
-    # Replace `cupy.ndarray` constructor arguments
-    if obj is cupy.ndarray:
-        return ("(self, shape, dtype=float, memptr=None, strides=None, order='C')", return_annotation)
-    # Replace `-> _ndarray_base` return annoation on document to `-> ndarray`
+    # Replace `_ndarray_base` with `ndarray` for signatures and return types
+    # on docs.
+    if signature is not None:
+        signature = signature.replace('_ndarray_base', 'ndarray')
     if return_annotation == '_ndarray_base':
-        return (signature, 'ndarray')
+        return_annotation = 'ndarray'
     return (signature, return_annotation)
 
 def setup(app):


### PR DESCRIPTION
Depends on ~#6746~ (merged)

* Declare `__init__` signature in docstring instead of modifying it in `conf.py`
* Replace `_ndarray_base` that appears in argument types of several functions