### PR TITLE
Make the warning for cupy.array_api say "cupy" instead of "numpy"

### DIFF
--- a/cupy/array_api/__init__.py
+++ b/cupy/array_api/__init__.py
@@ -125,7 +125,7 @@ if sys.version_info < (3, 8):
 import warnings
 
 warnings.warn(
-    "The numpy.array_api submodule is still experimental. See NEP 47.", stacklevel=2
+    "The cupy.array_api submodule is still experimental. See NEP 47.", stacklevel=2
 )
 
 __all__ = []


### PR DESCRIPTION
There are a lot of other references to "numpy" in the module docstrings, which I did not change, but this one is confusing because it prints to the screen when `cupy.array_api` is imported. 