### PR TITLE
Utilize CUDA Enhanced Compatibility in all wrappers

### DIFF
--- a/cupy_backends/cuda/cupy_cusparse.h
+++ b/cupy_backends/cuda/cupy_cusparse.h
@@ -604,26 +604,6 @@ cusparseStatus_t cusparseSpGEMM_copy(...) {
 typedef enum {} cusparseSparseToDenseAlg_t;
 typedef enum {} cusparseDenseToSparseAlg_t;
 
-cusparseStatus_t cusparseSparseToDense_bufferSize(...) {
-  return CUSPARSE_STATUS_SUCCESS;
-}
-
-cusparseStatus_t cusparseSparseToDense(...) {
-  return CUSPARSE_STATUS_SUCCESS;
-}
-
-cusparseStatus_t cusparseDenseToSparse_bufferSize(...) {
-  return CUSPARSE_STATUS_SUCCESS;
-}
-
-cusparseStatus_t cusparseDenseToSparse_analysis(...) {
-  return CUSPARSE_STATUS_SUCCESS;
-}
-
-cusparseStatus_t cusparseDenseToSparse_convert(...) {
-  return CUSPARSE_STATUS_SUCCESS;
-}
-
 #endif // CUSPARSE_VERSION < 11300
 
 

--- a/cupy_backends/cuda/cupy_cusparse.h
+++ b/cupy_backends/cuda/cupy_cusparse.h
@@ -599,14 +599,10 @@ cusparseStatus_t cusparseSpGEMM_copy(...) {
 #endif // #if CUSPARSE_VERSION < 11100
 
 #if CUSPARSE_VERSION < 11300
-// Types, macro and functions added in cuSparse 11.3 (CUDA 11.2)
+// Types and macros added in cuSparse 11.3 (CUDA 11.2)
 
 typedef enum {} cusparseSparseToDenseAlg_t;
 typedef enum {} cusparseDenseToSparseAlg_t;
-
-cusparseStatus_t cusparseCreateCsc(...) {
-  return CUSPARSE_STATUS_SUCCESS;
-}
 
 cusparseStatus_t cusparseSparseToDense_bufferSize(...) {
   return CUSPARSE_STATUS_SUCCESS;

--- a/cupy_backends/cuda/libs/cusparse.pyx
+++ b/cupy_backends/cuda/libs/cusparse.pyx
@@ -1367,12 +1367,13 @@ cdef extern from '../../cupy_sparse.h' nogil:
 
 # APIs added after CUDA 11.2+.
 cdef void* _cusparseCreateCsc = NULL
-cdef Status cusparseCreateCsc(SpMatDescr* spMatDescr, int64_t rows,
-                         int64_t cols, int64_t nnz, void* cscColOffsets,
-                         void* cscRowInd, void* cscValues,
-                         IndexType cscColOffsetsType,
-                         IndexType cscRowIndType, IndexBase idxBase,
-                         DataType valueType):
+cdef Status cusparseCreateCsc(
+        SpMatDescr* spMatDescr, int64_t rows,
+        int64_t cols, int64_t nnz, void* cscColOffsets,
+        void* cscRowInd, void* cscValues,
+        IndexType cscColOffsetsType,
+        IndexType cscRowIndType, IndexBase idxBase,
+        DataType valueType):
     return (<Status(*)(...) nogil>_cusparseCreateCsc)(
         spMatDescr, rows,
         cols, nnz, cscColOffsets,
@@ -1426,11 +1427,11 @@ cdef load_functions(libname, prefix):
     global _cusparseCreateCsc
     _cusparseCreateCsc = lib.get_func('CreateCsc')
     global _cusparseSparseToDense_bufferSize
-    _cusparseSparseToDense_bufferSize = lib.get_func('SparseToDense_bufferSize')
+    _cusparseSparseToDense_bufferSize = lib.get_func('SparseToDense_bufferSize')  # NOQA
     global _cusparseSparseToDense
     _cusparseSparseToDense = lib.get_func('SparseToDense')
     global _cusparseDenseToSparse_bufferSize
-    _cusparseDenseToSparse_bufferSize = lib.get_func('DenseToSparse_bufferSize')
+    _cusparseDenseToSparse_bufferSize = lib.get_func('DenseToSparse_bufferSize')  # NOQA
     global _cusparseDenseToSparse_analysis
     _cusparseDenseToSparse_analysis = lib.get_func('DenseToSparse_analysis')
     global _cusparseDenseToSparse_convert

--- a/cupy_backends/cuda/libs/cusparse.pyx
+++ b/cupy_backends/cuda/libs/cusparse.pyx
@@ -1349,23 +1349,6 @@ cdef extern from '../../cupy_sparse.h' nogil:
         SpMatDescr matA, SpMatDescr matB, const void* beta, SpMatDescr matC,
         DataType computeType, SpGEMMAlg alg, SpGEMMDescr spgemmDescr)
 
-    Status cusparseSparseToDense_bufferSize(
-        Handle handle, SpMatDescr matA, DnMatDescr matB,
-        cusparseSparseToDenseAlg_t alg, size_t* bufferSize)
-    Status cusparseSparseToDense(
-        Handle handle, SpMatDescr matA, DnMatDescr matB,
-        cusparseSparseToDenseAlg_t alg, void* buffer)
-
-    Status cusparseDenseToSparse_bufferSize(
-        Handle handle, DnMatDescr matA, SpMatDescr matB,
-        cusparseDenseToSparseAlg_t alg, size_t* bufferSize)
-    Status cusparseDenseToSparse_analysis(
-        Handle handle, DnMatDescr matA, SpMatDescr matB,
-        cusparseDenseToSparseAlg_t alg, void* buffer)
-    Status cusparseDenseToSparse_convert(
-        Handle handle, DnMatDescr matA, SpMatDescr matB,
-        cusparseDenseToSparseAlg_t alg, void* buffer)
-
     # CSR2CSC
     Status cusparseCsr2cscEx2_bufferSize(
         Handle handle, int m, int n, int nnz, const void* csrVal,
@@ -1381,7 +1364,6 @@ cdef extern from '../../cupy_sparse.h' nogil:
 
     # Build-time version
     int CUSPARSE_VERSION
-
 
 # APIs added after CUDA 11.2+.
 cdef void* _cusparseCreateCsc = NULL
@@ -1399,11 +1381,60 @@ cdef Status cusparseCreateCsc(SpMatDescr* spMatDescr, int64_t rows,
         cscRowIndType, idxBase,
         valueType)
 
+cdef void* _cusparseSparseToDense_bufferSize = NULL
+cdef Status cusparseSparseToDense_bufferSize(
+        Handle handle, SpMatDescr matA, DnMatDescr matB,
+        cusparseSparseToDenseAlg_t alg, size_t* bufferSize):
+    return (<Status(*)(...) nogil>_cusparseSparseToDense_bufferSize)(
+        handle, matA, matB,
+        alg, bufferSize)
+
+cdef void* _cusparseSparseToDense = NULL
+cdef Status cusparseSparseToDense(
+        Handle handle, SpMatDescr matA, DnMatDescr matB,
+        cusparseSparseToDenseAlg_t alg, void* buffer):
+    return (<Status(*)(...) nogil>_cusparseSparseToDense)(
+        handle, matA, matB,
+        alg, buffer)
+
+cdef void* _cusparseDenseToSparse_bufferSize = NULL
+cdef Status cusparseDenseToSparse_bufferSize(
+        Handle handle, DnMatDescr matA, SpMatDescr matB,
+        cusparseDenseToSparseAlg_t alg, size_t* bufferSize):
+    return (<Status(*)(...) nogil>_cusparseDenseToSparse_bufferSize)(
+        handle, matA, matB,
+        alg, bufferSize)
+
+cdef void* _cusparseDenseToSparse_analysis = NULL
+cdef Status cusparseDenseToSparse_analysis(
+        Handle handle, DnMatDescr matA, SpMatDescr matB,
+        cusparseDenseToSparseAlg_t alg, void* buffer):
+    return (<Status(*)(...) nogil>_cusparseDenseToSparse_analysis)(
+        handle, matA, matB,
+        alg, buffer)
+
+cdef void* _cusparseDenseToSparse_convert = NULL
+cdef Status cusparseDenseToSparse_convert(
+        Handle handle, DnMatDescr matA, SpMatDescr matB,
+        cusparseDenseToSparseAlg_t alg, void* buffer):
+    return (<Status(*)(...) nogil>_cusparseDenseToSparse_convert)(
+        handle, matA, matB,
+        alg, buffer)
 
 cdef load_functions(libname, prefix):
     lib = SoftLink(libname, prefix)
     global _cusparseCreateCsc
     _cusparseCreateCsc = lib.get_func('CreateCsc')
+    global _cusparseSparseToDense_bufferSize
+    _cusparseSparseToDense_bufferSize = lib.get_func('SparseToDense_bufferSize')
+    global _cusparseSparseToDense
+    _cusparseSparseToDense = lib.get_func('SparseToDense')
+    global _cusparseDenseToSparse_bufferSize
+    _cusparseDenseToSparse_bufferSize = lib.get_func('DenseToSparse_bufferSize')
+    global _cusparseDenseToSparse_analysis
+    _cusparseDenseToSparse_analysis = lib.get_func('DenseToSparse_analysis')
+    global _cusparseDenseToSparse_convert
+    _cusparseDenseToSparse_convert = lib.get_func('DenseToSparse_convert')
 
 IF 11020 <= CUPY_CUDA_VERSION < 12000:
     if _sys.platform == 'linux':

--- a/cupy_backends/cuda/libs/nvrtc.pyx
+++ b/cupy_backends/cuda/libs/nvrtc.pyx
@@ -40,8 +40,6 @@ ELSE:
         int nvrtcGetPTX(Program prog, char *ptx)
         int nvrtcGetCUBINSize(Program prog, size_t *cubinSizeRet)
         int nvrtcGetCUBIN(Program prog, char *cubin)
-        int nvrtcGetNVVMSize(Program, size_t*)
-        int nvrtcGetNVVM(Program, char*)
         int nvrtcGetProgramLogSize(Program prog, size_t* logSizeRet)
         int nvrtcGetProgramLog(Program prog, char* log)
         int nvrtcAddNameExpression(Program, const char*)
@@ -56,12 +54,24 @@ ELSE:
     cdef int nvrtcGetSupportedArchs(int* supportedArchs) nogil:
         return (<int(*)(...) nogil>_nvrtcGetSupportedArchs)(supportedArchs)
 
+    cdef void* _nvrtcGetNVVMSize = NULL
+    cdef int nvrtcGetNVVMSize(Program prog, size_t* nvvmSizeRet) nogil:
+        return (<int(*)(...) nogil>_nvrtcGetNVVMSize)(prog, nvvmSizeRet)
+
+    cdef void* _nvrtcGetNVVM = NULL
+    cdef int nvrtcGetNVVM(Program prog, char* nvvm) nogil:
+        return (<int(*)(...) nogil>_nvrtcGetNVVM)(prog, nvvm)
+
     cdef load_functions(libname):
-        global _nvrtcGetNumSupportedArchs
-        global _nvrtcGetSupportedArchs
         _nvrtc = SoftLink(libname, 'nvrtc')
+        global _nvrtcGetNumSupportedArchs
         _nvrtcGetNumSupportedArchs = _nvrtc.get_func('GetNumSupportedArchs')
+        global _nvrtcGetSupportedArchs
         _nvrtcGetSupportedArchs = _nvrtc.get_func('GetSupportedArchs')
+        global _nvrtcGetNVVMSize
+        _nvrtcGetNVVMSize = _nvrtc.get_func('GetNVVMSize')
+        global _nvrtcGetNVVM
+        _nvrtcGetNVVM = _nvrtc.get_func('GetNVVM')
 
     IF 11020 <= CUPY_CUDA_VERSION < 12000:
         if _sys.platform == 'linux':

--- a/cupy_backends/hip/cupy_hiprtc.h
+++ b/cupy_backends/hip/cupy_hiprtc.h
@@ -50,14 +50,6 @@ nvrtcResult nvrtcGetCUBIN(...) {
     return HIPRTC_ERROR_COMPILATION;
 }
 
-nvrtcResult nvrtcGetNVVMSize(...) {
-    return HIPRTC_ERROR_COMPILATION;
-}
-
-nvrtcResult nvrtcGetNVVM(...) {
-    return HIPRTC_ERROR_COMPILATION;
-}
-
 nvrtcResult nvrtcGetProgramLogSize(nvrtcProgram prog, std::size_t* logSizeRet) {
     return hiprtcGetProgramLogSize(prog, logSizeRet);
 }

--- a/cupy_backends/stub/cupy_cusparse.h
+++ b/cupy_backends/stub/cupy_cusparse.h
@@ -1137,26 +1137,6 @@ cusparseStatus_t cusparseConstrainedGeMM(...) {
   return CUSPARSE_STATUS_SUCCESS;
 }
 
-cusparseStatus_t cusparseSparseToDense_bufferSize(...) {
-  return CUSPARSE_STATUS_SUCCESS;
-}
-
-cusparseStatus_t cusparseSparseToDense(...) {
-  return CUSPARSE_STATUS_SUCCESS;
-}
-
-cusparseStatus_t cusparseDenseToSparse_bufferSize(...) {
-  return CUSPARSE_STATUS_SUCCESS;
-}
-
-cusparseStatus_t cusparseDenseToSparse_analysis(...) {
-  return CUSPARSE_STATUS_SUCCESS;
-}
-
-cusparseStatus_t cusparseDenseToSparse_convert(...) {
-  return CUSPARSE_STATUS_SUCCESS;
-}
-
 typedef enum {} cusparseCsr2CscAlg_t;
 
 cusparseStatus_t cusparseCsr2cscEx2_bufferSize(...) {

--- a/cupy_backends/stub/cupy_cusparse.h
+++ b/cupy_backends/stub/cupy_cusparse.h
@@ -1009,10 +1009,6 @@ cusparseStatus_t cusparseCreateCsr(...) {
   return CUSPARSE_STATUS_SUCCESS;
 }
 
-cusparseStatus_t cusparseCreateCsc(...) {
-  return CUSPARSE_STATUS_SUCCESS;
-}
-
 cusparseStatus_t cusparseDestroySpMat(...) {
   return CUSPARSE_STATUS_SUCCESS;
 }

--- a/cupy_backends/stub/cupy_nvrtc.h
+++ b/cupy_backends/stub/cupy_nvrtc.h
@@ -48,14 +48,6 @@ nvrtcResult nvrtcGetCUBIN(...) {
     return NVRTC_SUCCESS;
 }
 
-nvrtcResult nvrtcGetNVVMSize(...) {
-    return NVRTC_SUCCESS;
-}
-
-nvrtcResult nvrtcGetNVVM(...) {
-    return NVRTC_SUCCESS;
-}
-
 nvrtcResult nvrtcGetProgramLogSize(...) {
     return NVRTC_SUCCESS;
 }


### PR DESCRIPTION
This PR completes the support of CUDA Enhanced Compatibility in CuPy.

Using the mechanism introduced in #6730, this PR lazy loads all symbols added in CUDA 11.2 or later.
This should allow CuPy built with any of CUDA 11.2+ to run on any of CUDA 11.2+.