### PR TITLE
Update docs for `cupy-cuda11x` wheel

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,18 +43,13 @@ Choose the right package for your platform.
 | CUDA 10.2     | `pip install cupy-cuda102`    |
 | CUDA 11.0     | `pip install cupy-cuda110`    |
 | CUDA 11.1     | `pip install cupy-cuda111`    |
-| CUDA 11.2     | `pip install cupy-cuda112`    |
-| CUDA 11.3     | `pip install cupy-cuda113`    |
-| CUDA 11.4     | `pip install cupy-cuda114`    |
-| CUDA 11.5     | `pip install cupy-cuda115`    |
-| CUDA 11.6     | `pip install cupy-cuda116`    |
-| CUDA 11.7     | `pip install cupy-cuda117`    |
+| CUDA 11.2+    | `pip install cupy-cuda11x`    |
 | ROCm 4.3 (*)  | `pip install cupy-rocm-4-3`   |
 | ROCm 5.0 (*)  | `pip install cupy-rocm-5-0`   |
 
 (\*) ROCm support is an experimental feature. Refer to the [docs](https://docs.cupy.dev/en/latest/install.html#using-cupy-on-amd-gpu-experimental) for details.
 
-Use `--pre -f https://pip.cupy.dev/pre` option to install pre-releases (e.g., `pip install cupy-cuda117 --pre -f https://pip.cupy.dev/pre`).
+Use `--pre -f https://pip.cupy.dev/pre` option to install pre-releases (e.g., `pip install cupy-cuda11x --pre -f https://pip.cupy.dev/pre`).
 See the [Installation Guide](https://docs.cupy.dev/en/stable/install.html) if you are using Conda/Anaconda or building from source.
 
 ## Run on Docker

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -87,18 +87,8 @@ Package names are different depending on your CUDA Toolkit version.
      - ``$ pip install cupy-cuda110``
    * - v11.1
      - ``$ pip install cupy-cuda111``
-   * - v11.2
-     - ``$ pip install cupy-cuda112``
-   * - v11.3
-     - ``$ pip install cupy-cuda113``
-   * - v11.4
-     - ``$ pip install cupy-cuda114``
-   * - v11.5
-     - ``$ pip install cupy-cuda115``
-   * - v11.6
-     - ``$ pip install cupy-cuda116``
-   * - v11.7
-     - ``$ pip install cupy-cuda117``
+   * - v11.2 or later
+     - ``$ pip install cupy-cuda11x``
 
 .. note::
 


### PR DESCRIPTION
Blocked by https://github.com/cupy/cupy-release-tools/pull/269

I want to do some additional manual confirmation once the above PR has merged, so marking it as draft until then.