### PR TITLE
Update tags for FlexCI projects

### DIFF
--- a/.pfnci/config.tags.json
+++ b/.pfnci/config.tags.json
@@ -2,82 +2,105 @@
     "cupy.linux.cuda102": [
         "@push",
         "full",
-        "mini"
+        "mini",
+        "cuda102"
     ],
     "cupy.linux.cuda102.multi": [
         "@push",
         "full",
         "mini",
-        "multi"
+        "multi",
+        "cuda102"
     ],
     "cupy.linux.cuda110": [
         "@push",
-        "full"
+        "full",
+        "cuda110"
     ],
     "cupy.linux.cuda110.multi": [
         "@push",
         "full",
-        "multi"
+        "multi",
+        "cuda110"
     ],
     "cupy.linux.cuda111": [
         "@push",
-        "full"
+        "full",
+        "cuda111"
     ],
     "cupy.linux.cuda111.multi": [
         "@push",
         "full",
-        "multi"
+        "multi",
+        "cuda111"
     ],
     "cupy.linux.cuda112": [
         "@push",
-        "full"
+        "full",
+        "cuda112"
     ],
     "cupy.linux.cuda112.multi": [
         "@push",
         "full",
-        "multi"
+        "multi",
+        "cuda112"
     ],
     "cupy.linux.cuda113": [
         "@push",
-        "full"
+        "full",
+        "cuda113"
     ],
     "cupy.linux.cuda113.multi": [
         "@push",
         "full",
-        "multi"
+        "multi",
+        "cuda113"
     ],
     "cupy.linux.cuda114": [
         "@push",
-        "full"
+        "full",
+        "cuda114"
     ],
     "cupy.linux.cuda114.multi": [
         "@push",
         "full",
-        "multi"
+        "multi",
+        "cuda114"
     ],
     "cupy.linux.cuda115": [
         "@push",
         "full",
-        "mini"
+        "cuda115"
     ],
     "cupy.linux.cuda115.multi": [
         "@push",
         "full",
-        "mini",
-        "multi"
+        "multi",
+        "cuda115"
     ],
-    "cupy.linux.cuda116": [],
-    "cupy.linux.cuda116.multi": [],
+    "cupy.linux.cuda116": [
+        "@push",
+        "full",
+        "cuda116"
+    ],
+    "cupy.linux.cuda116.multi": [
+        "@push",
+        "full",
+        "multi",
+        "cuda116"
+    ],
     "cupy.linux.cuda117": [
         "@push",
         "full",
-        "mini"
+        "mini",
+        "cuda117"
     ],
     "cupy.linux.cuda117.multi": [
         "@push",
         "full",
         "mini",
-        "multi"
+        "multi",
+        "cuda117"
     ],
     "cupy.linux.cuda-slow": [
         "slow"
@@ -101,31 +124,45 @@
         "@push",
         "full",
         "mini",
-        "windows"
+        "windows",
+        "cuda102"
     ],
     "cupy.win.cuda110": [
-        "windows"
+        "windows",
+        "cuda110"
     ],
     "cupy.win.cuda111": [
-        "windows"
+        "windows",
+        "cuda111"
     ],
     "cupy.win.cuda112": [
-        "windows"
+        "windows",
+        "cuda112"
     ],
     "cupy.win.cuda113": [
-        "windows"
+        "windows",
+        "cuda113"
     ],
     "cupy.win.cuda114": [
-        "windows"
+        "windows",
+        "cuda114"
     ],
     "cupy.win.cuda115": [
-        "windows"
+        "windows",
+        "cuda115"
     ],
     "cupy.win.cuda116": [
         "@push",
         "full",
+        "windows",
+        "cuda116"
+    ],
+    "cupy.win.cuda117": [
+        "@push",
+        "full",
         "mini",
-        "windows"
+        "windows",
+        "cuda117"
     ],
     "cupy.linux.cuda-rapids": [
         "@push",

--- a/.pfnci/matrix.yaml
+++ b/.pfnci/matrix.yaml
@@ -5,7 +5,7 @@
 # CUDA 10.2 | Linux
 # The lowest CUDA version matrix is intended to cover the lowest supported combination.
 - project: "cupy.linux.cuda102"
-  tags: ["@push", "full", "mini"]
+  tags: ["@push", "full", "mini", "cuda102"]
   target: "cuda102"
   system: "linux"
   os: "ubuntu:18.04"
@@ -27,13 +27,13 @@
 # CUDA 10.2 (Multi-GPU) | Linux
 - project: "cupy.linux.cuda102.multi"
   _inherits: "cupy.linux.cuda102"
-  tags: ["@push", "full", "mini", "multi"]
+  tags: ["@push", "full", "mini", "multi", "cuda102"]
   target: "cuda102.multi"
   test: "unit-multi"
 
 # CUDA 11.0 | Linux
 - project: "cupy.linux.cuda110"
-  tags: ["@push", "full"]
+  tags: ["@push", "full", "cuda110"]
   target: "cuda110"
   system: "linux"
   os: "ubuntu:20.04"
@@ -55,13 +55,13 @@
 # CUDA 11.0 (Multi-GPU) | Linux
 - project: "cupy.linux.cuda110.multi"
   _inherits: "cupy.linux.cuda110"
-  tags: ["@push", "full", "multi"]
+  tags: ["@push", "full", "multi", "cuda110"]
   target: "cuda110.multi"
   test: "unit-multi"
 
 # CUDA 11.1 | Linux
 - project: "cupy.linux.cuda111"
-  tags: ["@push", "full"]
+  tags: ["@push", "full", "cuda111"]
   target: "cuda111"
   system: "linux"
   os: "centos:7"
@@ -82,14 +82,14 @@
 
 # CUDA 11.1 (Multi-GPU) | Linux
 - project: "cupy.linux.cuda111.multi"
-  tags: ["@push", "full", "multi"]
+  tags: ["@push", "full", "multi", "cuda111"]
   _inherits: "cupy.linux.cuda111"
   target: "cuda111.multi"
   test: "unit-multi"
 
 # CUDA 11.2 | Linux
 - project: "cupy.linux.cuda112"
-  tags: ["@push", "full"]
+  tags: ["@push", "full", "cuda112"]
   target: "cuda112"
   system: "linux"
   os: "centos:7"
@@ -111,13 +111,13 @@
 # CUDA 11.2 (Multi-GPU) | Linux
 - project: "cupy.linux.cuda112.multi"
   _inherits: "cupy.linux.cuda112"
-  tags: ["@push", "full", "multi"]
+  tags: ["@push", "full", "multi", "cuda112"]
   target: "cuda112.multi"
   test: "unit-multi"
 
 # CUDA 11.3 | Linux
 - project: "cupy.linux.cuda113"
-  tags: ["@push", "full"]
+  tags: ["@push", "full", "cuda113"]
   target: "cuda113"
   system: "linux"
   os: "ubuntu:18.04"
@@ -139,13 +139,13 @@
 # CUDA 11.3 (Multi-GPU) | Linux
 - project: "cupy.linux.cuda113.multi"
   _inherits: "cupy.linux.cuda113"
-  tags: ["@push", "full", "multi"]
+  tags: ["@push", "full", "multi", "cuda113"]
   target: "cuda113.multi"
   test: "unit-multi"
 
 # CUDA 11.4 | Linux
 - project: "cupy.linux.cuda114"
-  tags: ["@push", "full"]
+  tags: ["@push", "full", "cuda114"]
   target: "cuda114"
   system: "linux"
   os: "ubuntu:20.04"
@@ -167,13 +167,13 @@
 # CUDA 11.4 (Multi-GPU) | Linux
 - project: "cupy.linux.cuda114.multi"
   _inherits: "cupy.linux.cuda114"
-  tags: ["@push", "full", "multi"]
+  tags: ["@push", "full", "multi", "cuda114"]
   target: "cuda114.multi"
   test: "unit-multi"
 
 # CUDA 11.5 | Linux
 - project: "cupy.linux.cuda115"
-  tags: ["@push", "full", "mini"]
+  tags: ["@push", "full", "cuda115"]
   target: "cuda115"
   system: "linux"
   os: "ubuntu:20.04"
@@ -195,14 +195,14 @@
 # CUDA 11.5 (Multi-GPU) | Linux
 - project: "cupy.linux.cuda115.multi"
   _inherits: "cupy.linux.cuda115"
-  tags: ["@push", "full", "mini", "multi"]
+  tags: ["@push", "full", "multi", "cuda115"]
   target: "cuda115.multi"
   test: "unit-multi"
 
 # CUDA 11.6 | Linux
 - project: "cupy.linux.cuda116"
   target: "cuda116"
-  tags: []  # TODO: to be filled when adding this matrix to CI
+  tags: ["@push", "full", "cuda116"]
   system: "linux"
   os: "ubuntu:20.04"
   cuda: "11.6"
@@ -223,7 +223,7 @@
 # CUDA 11.6 (Multi-GPU) | Linux
 - project: "cupy.linux.cuda116.multi"
   _inherits: "cupy.linux.cuda116"
-  tags: []  # TODO: to be filled when adding this matrix to CI
+  tags: ["@push", "full", "multi", "cuda116"]
   target: "cuda116.multi"
   test: "unit-multi"
 
@@ -231,7 +231,7 @@
 # The latest CUDA version matrix is intended to cover the highest supported combination.
 - project: "cupy.linux.cuda117"
   target: "cuda117"
-  tags: ["@push", "full", "mini"]
+  tags: ["@push", "full", "mini", "cuda117"]
   system: "linux"
   os: "ubuntu:20.04"
   cuda: "11.7"
@@ -252,7 +252,7 @@
 # CUDA 11.7 (Multi-GPU) | Linux
 - project: "cupy.linux.cuda117.multi"
   _inherits: "cupy.linux.cuda117"
-  tags: ["@push", "full", "mini", "multi"]
+  tags: ["@push", "full", "mini", "multi", "cuda117"]
   target: "cuda117.multi"
   test: "unit-multi"
 
@@ -427,49 +427,55 @@
 - project: "cupy.win.cuda102"
   _extern: true
   target: "cuda102"
-  tags: ["@push", "full", "mini", "windows"]
+  tags: ["@push", "full", "mini", "windows", "cuda102"]
   system: "windows"
 
 - project: "cupy.win.cuda110"
   _extern: true
   target: "cuda110"
-  tags: ["windows"]
+  tags: ["windows", "cuda110"]
   system: "windows"
 
 - project: "cupy.win.cuda111"
   _extern: true
   target: "cuda111"
-  tags: ["windows"]
+  tags: ["windows", "cuda111"]
   system: "windows"
 
 - project: "cupy.win.cuda112"
   _extern: true
   target: "cuda112"
-  tags: ["windows"]
+  tags: ["windows", "cuda112"]
   system: "windows"
 
 - project: "cupy.win.cuda113"
   _extern: true
   target: "cuda113"
-  tags: ["windows"]
+  tags: ["windows", "cuda113"]
   system: "windows"
 
 - project: "cupy.win.cuda114"
   _extern: true
   target: "cuda114"
-  tags: ["windows"]
+  tags: ["windows", "cuda114"]
   system: "windows"
 
 - project: "cupy.win.cuda115"
   _extern: true
   target: "cuda115"
-  tags: ["windows"]
+  tags: ["windows", "cuda115"]
   system: "windows"
 
 - project: "cupy.win.cuda116"
   _extern: true
   target: "cuda116"
-  tags: ["@push", "full", "mini", "windows"]
+  tags: ["@push", "full", "windows", "cuda116"]
+  system: "windows"
+
+- project: "cupy.win.cuda117"
+  _extern: true
+  target: "cuda117"
+  tags: ["@push", "full", "mini", "windows", "cuda117"]
   system: "windows"
 
 - project: "cupy.linux.cuda-rapids"


### PR DESCRIPTION
* Add `cuda102` etc. tags to trigger tests based on CUDA versions
* Use CUDA 11.7 (Linux) instead of CUDA 11.5 (Linux) for `mini` tag
* Fix CUDA 11.7 (Windows) missing