### PR TITLE
Raise UserWarning in `cupy.cuda.compile_with_cache`

### DIFF
--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -456,11 +456,11 @@ _empty_file_preprocess_cache: dict = {}
 
 
 def compile_with_cache(*args, **kwargs):
-    # TODO(kmaehashi): change to visible warning in CuPy v11+.
+    # TODO(asi1024): Remove in CuPy v13+.
     warnings.warn(
         'cupy.cuda.compile_with_cache has been deprecated in CuPy v10, and'
         ' will be removed in the future. Use cupy.RawModule or cupy.RawKernel'
-        ' instead.', DeprecationWarning)
+        ' instead.', UserWarning)
     return _compile_module_with_cache(*args, **kwargs)
 
 

--- a/tests/cupy_tests/cuda_tests/test_compiler.py
+++ b/tests/cupy_tests/cuda_tests/test_compiler.py
@@ -134,5 +134,5 @@ class TestCompileWithCache:
         compiler._compile_module_with_cache('__device__ void func() {}')
 
     def test_deprecated_compile_with_cache(self):
-        with pytest.warns(DeprecationWarning):
+        with pytest.warns(UserWarning):
             compiler.compile_with_cache('__device__ void func() {}')


### PR DESCRIPTION
Part of #5297.