### PR TITLE
cupy-wheel: Use NVRTC to infer the toolkit version

### DIFF
--- a/install/universal_pkg/setup.py
+++ b/install/universal_pkg/setup.py
@@ -95,7 +95,7 @@ def _setup_win32_dll_directory() -> None:
         _log('CUDA_PATH is not set.'
              'cupy-wheel may not be able to discover NVRTC to probe version')
         return
-    os.add_dll_directory(os.path.join(cuda_path, 'bin'))
+    os.add_dll_directory(os.path.join(cuda_path, 'bin'))  # type: ignore[attr-defined] # NOQA
 
 
 def _get_cuda_version() -> Optional[int]:

--- a/install/universal_pkg/setup.py
+++ b/install/universal_pkg/setup.py
@@ -86,6 +86,18 @@ def _get_version_from_library(
     return version
 
 
+def _setup_win32_dll_directory() -> None:
+    if not hasattr(os, 'add_dll_directory'):
+        # Python 3.7 or earlier.
+        return
+    cuda_path = os.environ.get('CUDA_PATH', None)
+    if cuda_path is None:
+        _log('CUDA_PATH is not set.'
+             'cupy-wheel may not be able to discover NVRTC to probe version')
+        return
+    os.add_dll_directory(os.path.join(cuda_path, 'bin'))
+
+
 def _get_cuda_version() -> Optional[int]:
     """Returns the detected CUDA version or None."""
 
@@ -103,6 +115,7 @@ def _get_cuda_version() -> Optional[int]:
             'nvrtc64_110_0.dll',
             'nvrtc64_102_0.dll',
         ]
+        _setup_win32_dll_directory()
     else:
         _log(f'CUDA detection unsupported on platform: {sys.platform}')
         return None

--- a/install/universal_pkg/setup.py
+++ b/install/universal_pkg/setup.py
@@ -201,10 +201,21 @@ def _cuda_version_to_package(ver: int) -> str:
 
 
 def _rocm_version_to_package(ver: int) -> str:
-    if 400 <= ver < 410:
+    """
+    ROCm 4.0.x = 3212
+    ROCm 4.1.x = 3241
+    ROCm 4.2.0 = 3275
+    ROCm 4.3.0 = 40321300
+    ROCm 4.3.1 = 40321331
+    ROCm 4.5.0 = 40421401
+    ROCm 4.5.1 = 40421432
+    ROCm 5.0.0 = 50013601
+    ROCm 5.1.0 = 50120531
+    """
+    if ver == 3212:
         # ROCm 4.0
         suffix = '4-0'
-    elif 420 <= ver < 430:
+    elif ver == 3275:
         # ROCm 4.2
         suffix = '4-2'
     elif 4_03_00000 <= ver < 4_04_00000:

--- a/tests/install_tests/test_universal_pkg/test_setup.py
+++ b/tests/install_tests/test_universal_pkg/test_setup.py
@@ -34,7 +34,7 @@ def test_cuda_version_to_package():
 def test_rocm_version_to_package():
     with pytest.raises(setup.AutoDetectionFailed):
         assert setup._rocm_version_to_package(399)
-    assert setup._rocm_version_to_package(400) == 'cupy-rocm-4-0'
+    assert setup._rocm_version_to_package(3212) == 'cupy-rocm-4-0'
     assert setup._rocm_version_to_package(5_00_13601) == 'cupy-rocm-5-0'
     with pytest.raises(setup.AutoDetectionFailed):
         assert setup._rocm_version_to_package(9_00_00000)


### PR DESCRIPTION
Ref #6688

This PR fixes this issue described in the above PR.

> GPUs are required to install cupy-wheel

This PR also fixes the issue that ROCm 4.0/4.2 detection was not working.