### PR TITLE
Bump NumPy version used in docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,5 +3,5 @@ pydata_sphinx_theme==0.6.3
 sphinx-copybutton==0.4.0
 
 Cython==0.29.*
-numpy==1.22.*
+numpy==1.23.*
 scipy==1.8.*


### PR DESCRIPTION
Render comparison table with NumPy 1.23 which is the baseline API version for v11.

#6764
Follows up #6820