### PR TITLE
Bump documentation build requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
-sphinx==4.1.2
-pydata_sphinx_theme==0.6.3
-sphinx-copybutton==0.4.0
+sphinx==5.0.2
+pydata_sphinx_theme==0.9.0
+sphinx-copybutton==0.5.0
 
 Cython==0.29.*
 numpy==1.22.*

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -32,8 +32,8 @@ if rtd_version == 'latest':
 else:
     tag = 'v{}'.format(__version__)
 extlinks = {
-    'blob': ('https://github.com/cupy/cupy/blob/{}/%s'.format(tag), ''),
-    'tree': ('https://github.com/cupy/cupy/tree/{}/%s'.format(tag), ''),
+    'blob': ('https://github.com/cupy/cupy/blob/{}/%s'.format(tag), '%s'),
+    'tree': ('https://github.com/cupy/cupy/tree/{}/%s'.format(tag), '%s'),
 }
 
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -103,7 +103,7 @@ release = __version__
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:


### PR DESCRIPTION
pydata-sphinx-theme v0.9.0 provides the dark mode support!
https://github.com/pydata/pydata-sphinx-theme/releases/tag/v0.9.0

----

Let's merge this after the branch cut to avoid unexpected doc build failures.