### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/auto-cc.yml
+++ b/.github/workflows/auto-cc.yml
@@ -6,8 +6,14 @@ on:
   pull_request_target:
     types: [labeled]
 
+permissions:
+  contents: read
+
 jobs:
   auto-notify:
+    permissions:
+      issues: write  # for peter-evans/create-or-update-comment to create or update comment
+      pull-requests: write  # for peter-evans/create-or-update-comment to create or update comment
     if: |
         github.repository_owner == 'cupy' &&
         contains('|hip|array-api|', github.event.label.name)

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -6,6 +6,9 @@ on:
     branches:
        - master
 
+permissions:
+  contents: read
+
 jobs:
   backport:
     if: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,6 +8,9 @@ on:
       - docker/**
       - .github/workflows/docker.yml
 
+permissions:
+  contents: read
+
 jobs:
   docker-build-push:
     if: |

--- a/.github/workflows/pretest.yml
+++ b/.github/workflows/pretest.yml
@@ -2,6 +2,9 @@ name: "Pre-review Tests"
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-18.04


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
