### PR TITLE
Fix augassign target is evaluated twice in JIT

### DIFF
--- a/cupyx/jit/_builtin_funcs.py
+++ b/cupyx/jit/_builtin_funcs.py
@@ -212,8 +212,6 @@ class SharedMemory(BuiltinFunc):
     def call_const(self, env, dtype, size, alignment=None):
         name = env.get_fresh_variable_name(prefix='_smem')
         child_type = _cuda_types.Scalar(dtype)
-        while env[name] is not None:
-            name = env.get_fresh_variable_name(prefix='_smem')  # retry
         var = Data(name, _cuda_types.SharedMem(child_type, size, alignment))
         env.decls[name] = var
         env.locals[name] = var

--- a/cupyx/jit/_compile.py
+++ b/cupyx/jit/_compile.py
@@ -254,7 +254,11 @@ class Environment:
 
     def get_fresh_variable_name(self, prefix='', suffix=''):
         self.count += 1
-        return f'{prefix}{self.count}{suffix}'
+        name = f'{prefix}{self.count}{suffix}'
+        if self[name] is None:
+            return name
+        else:
+            return self.get_fresh_variable_name(prefix, suffix)
 
 
 def _transpile_function(
@@ -467,7 +471,7 @@ def _transpile_stmt(stmt, is_toplevel, env):
         if not isinstance(target, Data):
             raise TypeError(f'Cannot augassign to {target.code}')
         value = Data.init(value, env)
-        tmp = Data('tmp__', target.ctype)
+        tmp = Data(env.get_fresh_variable_name('_tmp_'), target.ctype)
         result = _eval_operand(stmt.op, (tmp, value), env)
         if not numpy.can_cast(
                 result.ctype.dtype, target.ctype.dtype, 'same_kind'):


### PR DESCRIPTION
Reproducer:
```py
import cupy
import cupyx

@cupyx.jit.rawkernel(device=True)
def g(x):
    x[0] += 1
    return 1

@cupyx.jit.rawkernel()
def f(x):
    x[g(x)] += 1

x = cupy.zeros((2,))

f[1, 1](x)

print(x)
print(f.cached_code)
```

master:
```cc
[2. 1.]

__device__ int g_1(CArray<double, 1, true, true> x) {
  x[0] = (x[0] + (double)(1));
  return 1;
}
extern "C" __global__ void f(CArray<double, 1, true, true> x) {
  x[g_1(x)] = (x[g_1(x)] + (double)(1));
}
```

This PR:
```cc
[1. 1.]

__device__ int g_1(CArray<double, 1, true, true> x) {
  { double &tmp__ = x[0]; tmp__ = (tmp__ + (double)(1)); }
  return 1;
}
extern "C" __global__ void f(CArray<double, 1, true, true> x) {
  { double &tmp__ = x[g_1(x)]; tmp__ = (tmp__ + (double)(1)); }
}
```