### PR TITLE
[stats] add `cupyx.scipy.stats.boxcox_llf`

### DIFF
--- a/cupyx/scipy/stats/__init__.py
+++ b/cupyx/scipy/stats/__init__.py
@@ -1,2 +1,9 @@
+# Summary statistics
+
 from cupyx.scipy.stats._distributions import entropy  # NOQA
 from cupyx.scipy.stats._stats import trim_mean  # NOQA
+
+
+# Other statistical functionality
+
+from cupyx.scipy.stats._morestats import boxcox_llf  # NOQA

--- a/cupyx/scipy/stats/_morestats.py
+++ b/cupyx/scipy/stats/_morestats.py
@@ -1,0 +1,57 @@
+import cupy
+
+
+@cupy.fuse(kernel_name='find_sum')
+def find_sum(a):
+    return cupy.sum(a, axis=0)
+
+
+@cupy.fuse(kernel_name='find_log')
+def find_log(a):
+    return cupy.log(a)
+
+
+def boxcox_llf(lmb, data):
+    """The boxcox log-likelihood function.
+
+    Parameters
+    ----------
+    lmb : scalar
+        Parameter for Box-Cox transformation
+    data : array-like
+        Data to calculate Box-Cox log-likelihood for. If
+        `data` is multi-dimensional, the log-likelihood
+        is calculated along the first axis
+
+    Returns
+    -------
+    llf : float or cupy.ndarray
+        Box-Cox log-likelihood of `data` given `lmb`. A float
+        for 1-D `data`, an array otherwise
+
+    See Also
+    --------
+    scipy.stats.boxcox_llf
+
+    """
+
+    if data.ndim == 1 and data.dtype == cupy.float16:
+        data = data.astype(cupy.float64)
+    if data.ndim == 1 and data.dtype == cupy.float32:
+        data = data.astype(cupy.float64)
+    if data.ndim == 1 and data.dtype == cupy.complex64:
+        data = data.astype(cupy.complex128)
+
+    N = data.shape[0]
+    if N == 0:
+        return cupy.nan
+
+    logdata = find_log(data)
+
+    # Compute the variance of the transformed data
+    if lmb == 0:
+        variance = cupy.var(logdata, axis=0)
+    else:
+        variance = cupy.var(data**lmb / lmb, axis=0)
+
+    return (lmb - 1) * find_sum(logdata) - N/2 * find_log(variance)

--- a/cupyx/scipy/stats/_morestats.py
+++ b/cupyx/scipy/stats/_morestats.py
@@ -1,16 +1,6 @@
 import cupy
 
 
-@cupy.fuse(kernel_name='find_sum')
-def find_sum(a):
-    return cupy.sum(a, axis=0)
-
-
-@cupy.fuse(kernel_name='find_log')
-def find_log(a):
-    return cupy.log(a)
-
-
 def boxcox_llf(lmb, data):
     """The boxcox log-likelihood function.
 
@@ -46,7 +36,7 @@ def boxcox_llf(lmb, data):
     if N == 0:
         return cupy.nan
 
-    logdata = find_log(data)
+    logdata = cupy.log(data)
 
     # Compute the variance of the transformed data
     if lmb == 0:
@@ -54,4 +44,4 @@ def boxcox_llf(lmb, data):
     else:
         variance = cupy.var(data**lmb / lmb, axis=0)
 
-    return (lmb - 1) * find_sum(logdata) - N/2 * find_log(variance)
+    return (lmb - 1) * cupy.sum(logdata, axis=0) - N/2 * cupy.log(variance)

--- a/docs/source/reference/scipy_stats.rst
+++ b/docs/source/reference/scipy_stats.rst
@@ -14,3 +14,13 @@ Summary statistics
 
    trim_mean
    entropy
+
+
+Other statistical functionality
+-------------------------------
+
+.. autosummary::
+   :toctree: generated/
+
+   boxcox_llf
+

--- a/tests/cupyx_tests/scipy_tests/stats_tests/test_morestats.py
+++ b/tests/cupyx_tests/scipy_tests/stats_tests/test_morestats.py
@@ -22,85 +22,88 @@ rtol = {
 }
 
 
-atol_low = {
-    'default': 1e-6,
-    cupy.float16: 5e-3,
-    cupy.float32: 1e-5,
-    cupy.float64: 5e-3
-}
-rtol_low = {
-    'default': 1e-6,
-    cupy.float16: 5e-3,
-    cupy.float32: 1e-5,
-    cupy.float64: 5e-3
-}
-
-
 @testing.with_requires('scipy')
 class TestBoxcox_llf:
 
-    @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose(
-        scipy_name='scp',
-        atol=atol_low,
-        rtol=rtol_low
-    )
+    @testing.for_all_dtypes(no_float16=True, no_bool=True)
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-6)
     def test_array_1dim(self, xp, scp, dtype):
         data = testing.shaped_random((2,), xp, dtype=dtype, scale=9)
         lmb = 4.0
         return scp.stats.boxcox_llf(lmb, data)
 
-    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=5e-3)
+    def test_array_1dim_float16(self, xp, scp):
+        data = xp.array([2, 3], dtype=xp.float16)
+        lmb = 4.0
+        return scp.stats.boxcox_llf(lmb, data)
+
+    @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=rtol)
     def test_array_2dim(self, xp, scp, dtype):
-        data = testing.shaped_random((4, 5), xp, dtype=dtype)
+        data = xp.array([[1], [2]], dtype=dtype)
         lmb = 6.0
         return scp.stats.boxcox_llf(lmb, data)
 
-    @testing.for_all_dtypes()
+    @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=rtol)
     def test_array_3dim(self, xp, scp, dtype):
-        data = testing.shaped_random((2, 5, 3), xp, dtype=dtype)
+        data = xp.array([
+            [
+                [1, 2, 3], [4, 5, 6]
+            ],
+            [
+                [7, 8, 9], [10, 11, 12]
+            ],
+        ], dtype=dtype)
         lmb = 1.0
         return scp.stats.boxcox_llf(lmb, data)
 
-    @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose(
-        scipy_name='scp', atol=atol, rtol=rtol)
+    @testing.for_all_dtypes(no_bool=True)
+    @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=rtol)
     def test_array_multi_dim(self, xp, scp, dtype):
-        data = testing.shaped_random((2, 5, 8, 9), xp, dtype=dtype)
+        data = xp.array([
+            [
+                [[1, 2], [3, 4]],
+                [[5, 6], [7, 8]]
+            ],
+            [
+                [[9, 10], [11, 12]],
+                [[13, 14], [15, 16]]
+            ]
+        ], dtype=dtype)
         lmb = 9.0
         return scp.stats.boxcox_llf(lmb, data)
 
-    @testing.for_all_dtypes()
+    @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=rtol)
     def test_array_zero_lmb(self, xp, scp, dtype):
-        data = testing.shaped_random((4, 5), xp, dtype=dtype)
+        data = xp.array([[1, 2, 3], [6, 8, 9]], dtype=dtype)
         lmb = 0.0
         return scp.stats.boxcox_llf(lmb, data)
 
-    @testing.for_all_dtypes()
+    @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_array_empty(self, xp, scp, dtype):
         data = xp.array([], dtype=dtype)
         lmb = 1
         return scp.stats.boxcox_llf(lmb, data)
 
-    @testing.for_all_dtypes()
+    @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=rtol)
     def test_array_lmb_neg(self, xp, scp, dtype):
         data = xp.array([198.0, 233.0, 233.0, 392.0])
         lmb = -45
         return scp.stats.boxcox_llf(lmb, data)
 
-    @testing.for_all_dtypes()
+    @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=rtol)
     def test_array_lmb_neg2(self, xp, scp, dtype):
-        data = testing.shaped_random((4, 5), xp, dtype=dtype)
+        data = xp.array([[1, 2, 3], [4, 5, 6]], dtype=dtype)
         lmb = -3.0
         return scp.stats.boxcox_llf(lmb, data)
 
-    @testing.for_all_dtypes()
+    @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=rtol)
     def test_array_empty_neg_lmb(self, xp, scp, dtype):
         data = xp.array([], dtype=dtype)

--- a/tests/cupyx_tests/scipy_tests/stats_tests/test_morestats.py
+++ b/tests/cupyx_tests/scipy_tests/stats_tests/test_morestats.py
@@ -1,9 +1,7 @@
 import warnings
 
 import cupy
-
 from cupy import testing
-
 import cupyx
 import cupyx.scipy.stats  # NOQA
 
@@ -12,14 +10,14 @@ import scipy.stats  # NOQA
 
 atol = {
     'default': 1e-6,
-    cupy.float16: 5e-2,
-    cupy.float32: 1e-5,
+    cupy.float16: 1e-3,
+    cupy.float32: 1e-6,
     cupy.float64: 1e-14
 }
 rtol = {
     'default': 1e-6,
-    cupy.float16: 5e-2,
-    cupy.float32: 1e-5,
+    cupy.float16: 1e-3,
+    cupy.float32: 1e-6,
     cupy.float64: 1e-14
 }
 
@@ -28,9 +26,14 @@ rtol = {
 class TestBoxcox_llf:
 
     @testing.for_all_dtypes(no_float16=True, no_bool=True)
-    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-3, atol=1e-3)
+    @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_array_1dim(self, xp, scp, dtype):
-        data = testing.shaped_arange((10,), xp, dtype=dtype)
+        if dtype in (xp.int8, xp.uint8):
+            # Test with smaller shape because of tolerance
+            shape = 5,
+        else:
+            shape = 10,
+        data = testing.shaped_arange(shape, xp, dtype=dtype)
         lmb = 4.0
         return scp.stats.boxcox_llf(lmb, data)
 

--- a/tests/cupyx_tests/scipy_tests/stats_tests/test_morestats.py
+++ b/tests/cupyx_tests/scipy_tests/stats_tests/test_morestats.py
@@ -43,7 +43,7 @@ class TestBoxcox_llf:
     @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=rtol)
     def test_array_2dim(self, xp, scp, dtype):
-        data = testing.shaped_arange((3, 3), xp, dtype=dtype)
+        data = testing.shaped_arange((3, 8), xp, dtype=dtype)
         lmb = 6.0
         with warnings.catch_warnings():
             warnings.simplefilter('ignore')
@@ -52,7 +52,7 @@ class TestBoxcox_llf:
     @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=rtol)
     def test_array_3dim(self, xp, scp, dtype):
-        data = testing.shaped_arange((6, 3, 4), xp, dtype=dtype)
+        data = testing.shaped_arange((10, 3, 4), xp, dtype=dtype)
         lmb = 1.0
         return scp.stats.boxcox_llf(lmb, data)
 
@@ -68,7 +68,7 @@ class TestBoxcox_llf:
     @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=rtol)
     def test_array_zero_lmb(self, xp, scp, dtype):
-        data = testing.shaped_arange((9, 10), xp, dtype=dtype)
+        data = testing.shaped_arange((9, 14), xp, dtype=dtype)
         lmb = 0.0
         return scp.stats.boxcox_llf(lmb, data)
 

--- a/tests/cupyx_tests/scipy_tests/stats_tests/test_morestats.py
+++ b/tests/cupyx_tests/scipy_tests/stats_tests/test_morestats.py
@@ -11,11 +11,13 @@ import scipy.stats  # NOQA
 atol = {
     'default': 1e-6,
     cupy.float16: 5e-2,
+    cupy.float32: 1e-5,
     cupy.float64: 1e-14
 }
 rtol = {
     'default': 1e-6,
     cupy.float16: 5e-2,
+    cupy.float32: 1e-5,
     cupy.float64: 1e-14
 }
 
@@ -44,7 +46,7 @@ class TestBoxcox_llf:
         rtol=rtol_low
     )
     def test_array_1dim(self, xp, scp, dtype):
-        data = testing.shaped_arange((2,), xp, dtype=dtype)
+        data = testing.shaped_random((2,), xp, dtype=dtype, scale=9)
         lmb = 4.0
         return scp.stats.boxcox_llf(lmb, data)
 
@@ -64,10 +66,7 @@ class TestBoxcox_llf:
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(
-        scipy_name='scp',
-        atol=atol_low,
-        rtol=rtol_low
-    )
+        scipy_name='scp', atol=atol, rtol=rtol)
     def test_array_multi_dim(self, xp, scp, dtype):
         data = testing.shaped_random((2, 5, 8, 9), xp, dtype=dtype)
         lmb = 9.0

--- a/tests/cupyx_tests/scipy_tests/stats_tests/test_morestats.py
+++ b/tests/cupyx_tests/scipy_tests/stats_tests/test_morestats.py
@@ -1,3 +1,5 @@
+import warnings
+
 import cupy
 
 from cupy import testing
@@ -73,7 +75,9 @@ class TestBoxcox_llf:
             ]
         ], dtype=dtype)
         lmb = 9.0
-        return scp.stats.boxcox_llf(lmb, data)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            return scp.stats.boxcox_llf(lmb, data)
 
     @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=rtol)

--- a/tests/cupyx_tests/scipy_tests/stats_tests/test_morestats.py
+++ b/tests/cupyx_tests/scipy_tests/stats_tests/test_morestats.py
@@ -28,52 +28,38 @@ rtol = {
 class TestBoxcox_llf:
 
     @testing.for_all_dtypes(no_float16=True, no_bool=True)
-    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-6)
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-3, atol=1e-3)
     def test_array_1dim(self, xp, scp, dtype):
-        data = testing.shaped_random((2,), xp, dtype=dtype, scale=9)
+        data = testing.shaped_arange((10,), xp, dtype=dtype)
         lmb = 4.0
         return scp.stats.boxcox_llf(lmb, data)
 
     @testing.numpy_cupy_allclose(scipy_name='scp', rtol=5e-3)
     def test_array_1dim_float16(self, xp, scp):
-        data = xp.array([2, 3], dtype=xp.float16)
+        data = testing.shaped_arange((5,), xp, dtype=xp.float16)
         lmb = 4.0
         return scp.stats.boxcox_llf(lmb, data)
 
     @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=rtol)
     def test_array_2dim(self, xp, scp, dtype):
-        data = xp.array([[1], [2]], dtype=dtype)
+        data = testing.shaped_arange((3, 3), xp, dtype=dtype)
         lmb = 6.0
-        return scp.stats.boxcox_llf(lmb, data)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            return scp.stats.boxcox_llf(lmb, data)
 
     @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=rtol)
     def test_array_3dim(self, xp, scp, dtype):
-        data = xp.array([
-            [
-                [1, 2, 3], [4, 5, 6]
-            ],
-            [
-                [7, 8, 9], [10, 11, 12]
-            ],
-        ], dtype=dtype)
+        data = testing.shaped_arange((6, 3, 4), xp, dtype=dtype)
         lmb = 1.0
         return scp.stats.boxcox_llf(lmb, data)
 
     @testing.for_all_dtypes(no_bool=True)
-    @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=rtol)
+    @testing.numpy_cupy_allclose(scipy_name='scp', atol=1e-6, rtol=1e-6)
     def test_array_multi_dim(self, xp, scp, dtype):
-        data = xp.array([
-            [
-                [[1, 2], [3, 4]],
-                [[5, 6], [7, 8]]
-            ],
-            [
-                [[9, 10], [11, 12]],
-                [[13, 14], [15, 16]]
-            ]
-        ], dtype=dtype)
+        data = testing.shaped_arange((3, 2, 4, 3), xp, dtype=dtype)
         lmb = 9.0
         with warnings.catch_warnings():
             warnings.simplefilter('ignore')
@@ -82,14 +68,14 @@ class TestBoxcox_llf:
     @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=rtol)
     def test_array_zero_lmb(self, xp, scp, dtype):
-        data = xp.array([[1, 2, 3], [6, 8, 9]], dtype=dtype)
+        data = testing.shaped_arange((9, 10), xp, dtype=dtype)
         lmb = 0.0
         return scp.stats.boxcox_llf(lmb, data)
 
     @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_array_empty(self, xp, scp, dtype):
-        data = xp.array([], dtype=dtype)
+        data = testing.shaped_arange((0,), xp, dtype=dtype)
         lmb = 1
         return scp.stats.boxcox_llf(lmb, data)
 
@@ -103,13 +89,13 @@ class TestBoxcox_llf:
     @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=rtol)
     def test_array_lmb_neg2(self, xp, scp, dtype):
-        data = xp.array([[1, 2, 3], [4, 5, 6]], dtype=dtype)
+        data = testing.shaped_arange((3, 5), xp, dtype=dtype)
         lmb = -3.0
         return scp.stats.boxcox_llf(lmb, data)
 
     @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=rtol)
     def test_array_empty_neg_lmb(self, xp, scp, dtype):
-        data = xp.array([], dtype=dtype)
+        data = testing.shaped_arange((0,), xp, dtype=dtype)
         lmb = -1.0
         return scp.stats.boxcox_llf(lmb, data)

--- a/tests/cupyx_tests/scipy_tests/stats_tests/test_morestats.py
+++ b/tests/cupyx_tests/scipy_tests/stats_tests/test_morestats.py
@@ -1,0 +1,109 @@
+import cupy
+
+from cupy import testing
+
+import cupyx
+import cupyx.scipy.stats  # NOQA
+
+import scipy.stats  # NOQA
+
+
+atol = {
+    'default': 1e-6,
+    cupy.float16: 5e-2,
+    cupy.float64: 1e-14
+}
+rtol = {
+    'default': 1e-6,
+    cupy.float16: 5e-2,
+    cupy.float64: 1e-14
+}
+
+
+atol_low = {
+    'default': 1e-6,
+    cupy.float16: 5e-3,
+    cupy.float32: 1e-5,
+    cupy.float64: 5e-3
+}
+rtol_low = {
+    'default': 1e-6,
+    cupy.float16: 5e-3,
+    cupy.float32: 1e-5,
+    cupy.float64: 5e-3
+}
+
+
+@testing.with_requires('scipy')
+class TestBoxcox_llf:
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose(
+        scipy_name='scp',
+        atol=atol_low,
+        rtol=rtol_low
+    )
+    def test_array_1dim(self, xp, scp, dtype):
+        data = testing.shaped_arange((2,), xp, dtype=dtype)
+        lmb = 4.0
+        return scp.stats.boxcox_llf(lmb, data)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=rtol)
+    def test_array_2dim(self, xp, scp, dtype):
+        data = testing.shaped_random((4, 5), xp, dtype=dtype)
+        lmb = 6.0
+        return scp.stats.boxcox_llf(lmb, data)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=rtol)
+    def test_array_3dim(self, xp, scp, dtype):
+        data = testing.shaped_random((2, 5, 3), xp, dtype=dtype)
+        lmb = 1.0
+        return scp.stats.boxcox_llf(lmb, data)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose(
+        scipy_name='scp',
+        atol=atol_low,
+        rtol=rtol_low
+    )
+    def test_array_multi_dim(self, xp, scp, dtype):
+        data = testing.shaped_random((2, 5, 8, 9), xp, dtype=dtype)
+        lmb = 9.0
+        return scp.stats.boxcox_llf(lmb, data)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=rtol)
+    def test_array_zero_lmb(self, xp, scp, dtype):
+        data = testing.shaped_random((4, 5), xp, dtype=dtype)
+        lmb = 0.0
+        return scp.stats.boxcox_llf(lmb, data)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_array_empty(self, xp, scp, dtype):
+        data = xp.array([], dtype=dtype)
+        lmb = 1
+        return scp.stats.boxcox_llf(lmb, data)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=rtol)
+    def test_array_lmb_neg(self, xp, scp, dtype):
+        data = xp.array([198.0, 233.0, 233.0, 392.0])
+        lmb = -45
+        return scp.stats.boxcox_llf(lmb, data)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=rtol)
+    def test_array_lmb_neg2(self, xp, scp, dtype):
+        data = testing.shaped_random((4, 5), xp, dtype=dtype)
+        lmb = -3.0
+        return scp.stats.boxcox_llf(lmb, data)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=rtol)
+    def test_array_empty_neg_lmb(self, xp, scp, dtype):
+        data = xp.array([], dtype=dtype)
+        lmb = -1.0
+        return scp.stats.boxcox_llf(lmb, data)


### PR DESCRIPTION
Hi, the PR adds `cupyx.scipy.stats.boxcox_llf`!

#### Benchmarks (using cupy fusion for `log` and `sum`) :
size | dtype | SciPy | CuPy
-----|-------|-------|-----
1000 | int8 | 0.101 ms | 0.356 ms
1000 | int32 | 0.079 ms | 0.353 ms
1000 | uint32 | 0.080 ms | 0.414 ms
1000 | float32 | 0.076 ms | 0.389 ms
1000 | float64 | 0.084 ms | 0.457 ms
100000 | int8 | 4.178 ms | 0.458 ms
100000 | int32 | 2.964 ms | 0.522 ms
100000 | uint32 | 2.845 ms | 0.521 ms
100000 | float32 | 1.425 ms | 0.550 ms
100000 | float64 | 2.693 ms | 0.521 ms
1000000 | int8 | 41.181 ms | 3.824 ms
1000000 | int32 | 27.627 ms | 4.676 ms
1000000 | uint32 | 27.741 ms | 4.795 ms
1000000 | float32 | 13.221 ms | 4.771 ms
1000000 | float64 | 27.190 ms | 4.804 ms

#### Updated Benchmarks (without using cupy fusion):
size | dtype | SciPy | CuPy
-----|-------|-------|-----
1000 | int8 | 0.100 ms | 0.310 ms
1000 | int32 | 0.079 ms | 0.298 ms
1000 | uint32 | 0.079 ms | 0.370 ms
1000 | float32 | 0.072 ms | 0.413 ms
1000 | float64 | 0.077 ms | 0.331 ms
100000 | int8 | 4.397 ms | 0.453 ms
100000 | int32 | 2.930 ms | 0.514 ms
100000 | uint32 | 2.889 ms | 0.513 ms
100000 | float32 | 1.391 ms | 0.537 ms
100000 | float64 | 2.745 ms | 0.511 ms
1000000 | int8 | 44.292 ms | 3.863 ms
1000000 | int32 | 29.930 ms | 6.129 ms
1000000 | uint32 | 28.011 ms | 3.745 ms
1000000 | float32 | 14.635 ms | 4.381 ms
1000000 | float64 | 29.569 ms | 4.234 ms

<details>
<summary>Script (Click Please)</summary>

<p>

```python
import cupy
import cupyx
import cupyx.scipy.stats

import scipy

from cupy import testing
from cupyx.profiler import benchmark

import scipy.stats


n_warmup = 1
n_repeat = 10
dtype_set = ('int8', 'int32', 'uint32', 'float32', 'float64')
n_set = (1000, 100000, 1000000)


def get_time(pref):
    cpu_time = pref.cpu_times.mean()
    gpu_time = pref.gpu_times.mean()
    return max(cpu_time, gpu_time) * 1000  # ms


def time(a, b):
    cp_a = a # cupy.array(a)
    cp_b = cupy.array(b)
    ref = scipy.stats.boxcox_llf(a, b)
    ret = cupyx.scipy.stats.boxcox_llf(cp_a, cp_b)
    times = []
    perf = benchmark(scipy.stats.boxcox_llf, (a, b),
                     n_warmup=n_warmup, n_repeat=n_repeat)
    times.append(get_time(perf))
    perf = benchmark(cupyx.scipy.stats.boxcox_llf, (cp_a, cp_b),
                     n_warmup=n_warmup, n_repeat=n_repeat)
    times.append(get_time(perf))
    return times


print('size | dtype | SciPy | CuPy')
print('-----|-------|-------|-----')
for n in n_set:
    for dtype in dtype_set:
        a = 4.0
        b = scipy.random.randint(0, 10, size=n).astype(dtype)
        times = time(a, b)
        print('{} | {} | {:.3f} ms | {:.3f} ms'.format(n, dtype, times[0], times[1]))
```

</p>
</details>

Thanks! :)