### PR TITLE
Support `keepdims` parameter for `average`

### DIFF
--- a/cupy/_statistics/meanvar.py
+++ b/cupy/_statistics/meanvar.py
@@ -124,7 +124,7 @@ def average(a, axis=None, weights=None, returned=False, *, keepdims=False):
             wgt = cupy.broadcast_to(wgt, (a.ndim - 1) * (1,) + wgt.shape)
             wgt = wgt.swapaxes(-1, axis)
 
-        scl = wgt.sum(axis=axis, dtype=result_dtype)
+        scl = wgt.sum(axis=axis, dtype=result_dtype, keepdims=keepdims)
         if cupy.any(scl == 0.0):  # synchronize!
             raise ZeroDivisionError(
                 'Weights sum to zero, can\'t be normalized')

--- a/cupy/_statistics/meanvar.py
+++ b/cupy/_statistics/meanvar.py
@@ -67,7 +67,7 @@ def nanmedian(a, axis=None, out=None, overwrite_input=False, keepdims=False):
                       keepdims=keepdims)
 
 
-def average(a, axis=None, weights=None, returned=False):
+def average(a, axis=None, weights=None, returned=False, *, keepdims=False):
     """Returns the weighted average along an axis.
 
     Args:
@@ -79,6 +79,8 @@ def average(a, axis=None, weights=None, returned=False):
             in ``a`` have a weight equal to one.
         returned (bool): If ``True``, a tuple of the average and the sum
             of weights is returned, otherwise only the average is returned.
+        keepdims (bool): If ``True``, the axis is remained as an axis of size
+            one.
 
     Returns:
         cupy.ndarray or tuple of cupy.ndarray: The average of the input array
@@ -94,7 +96,7 @@ def average(a, axis=None, weights=None, returned=False):
     a = cupy.asarray(a)
 
     if weights is None:
-        avg = a.mean(axis)
+        avg = a.mean(axis=axis, keepdims=keepdims)
         scl = avg.dtype.type(a.size / avg.size)
     else:
         wgt = cupy.asarray(weights)
@@ -127,7 +129,8 @@ def average(a, axis=None, weights=None, returned=False):
             raise ZeroDivisionError(
                 'Weights sum to zero, can\'t be normalized')
 
-        avg = cupy.multiply(a, wgt, dtype=result_dtype).sum(axis) / scl
+        avg = cupy.multiply(a, wgt, dtype=result_dtype).sum(
+            axis, keepdims=keepdims) / scl
 
     if returned:
         if scl.shape != avg.shape:

--- a/tests/cupy_tests/statistics_tests/test_meanvar.py
+++ b/tests/cupy_tests/statistics_tests/test_meanvar.py
@@ -185,6 +185,22 @@ class TestAverage:
         self.check_returned(a, axis=None, weights=w)
         self.check_returned(a, axis=1, weights=w)
 
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose(rtol={'default': 5e-7})
+    @testing.with_requires('numpy>=1.23')
+    def test_average_keepdims_axis1(self, xp, dtype):
+        a = testing.shaped_random((2, 3), xp, dtype)
+        w = testing.shaped_random((2, 3), xp, dtype)
+        return xp.average(a, axis=1, weights=w, keepdims=True)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose(rtol={'default': 1e-7, numpy.float16: 1e-3})
+    @testing.with_requires('numpy>=1.23')
+    def test_average_keepdims_noaxis(self, xp, dtype):
+        a = testing.shaped_random((2, 3), xp, dtype)
+        w = testing.shaped_random((2, 3), xp, dtype)
+        return xp.average(a, weights=w, keepdims=True)
+
 
 @testing.gpu
 class TestMeanVar:

--- a/tests/cupy_tests/statistics_tests/test_meanvar.py
+++ b/tests/cupy_tests/statistics_tests/test_meanvar.py
@@ -174,7 +174,7 @@ class TestAverage:
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(rtol={'default': 5e-7})
     @pytest.mark.parametrize('returned', [True, False])
-    @testing.with_requires('numpy>=1.23')
+    @testing.with_requires('numpy>=1.23.1')
     def test_average_keepdims_axis1(self, xp, dtype, returned):
         a = testing.shaped_random((2, 3), xp, dtype)
         w = testing.shaped_random((2, 3), xp, dtype)
@@ -184,7 +184,7 @@ class TestAverage:
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(rtol={'default': 1e-7, numpy.float16: 1e-3})
     @pytest.mark.parametrize('returned', [True, False])
-    @testing.with_requires('numpy>=1.23')
+    @testing.with_requires('numpy>=1.23.1')
     def test_average_keepdims_noaxis(self, xp, dtype, returned):
         a = testing.shaped_random((2, 3), xp, dtype)
         w = testing.shaped_random((2, 3), xp, dtype)

--- a/tests/cupy_tests/statistics_tests/test_meanvar.py
+++ b/tests/cupy_tests/statistics_tests/test_meanvar.py
@@ -161,45 +161,34 @@ class TestAverage:
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
-    def test_average_axis_weights(self, xp, dtype):
-        a = testing.shaped_arange((2, 3, 4), xp, dtype)
-        w = testing.shaped_arange((2, 3, 4), xp, dtype)
-        return xp.average(a, axis=2, weights=w)
-
-    def check_returned(self, a, axis, weights):
-        average_cpu, sum_weights_cpu = numpy.average(
-            a, axis, weights, returned=True)
-        result = cupy.average(
-            cupy.asarray(a), axis, weights, returned=True)
-        assert isinstance(result, tuple)
-        assert len(result) == 2
-        average_gpu, sum_weights_gpu = result
-        testing.assert_allclose(average_cpu, average_gpu)
-        testing.assert_allclose(sum_weights_cpu, sum_weights_gpu)
-
-    @testing.for_all_dtypes()
-    def test_returned(self, dtype):
+    @pytest.mark.parametrize(
+        'axis,weights', [(1, False), (None, True), (1, True)])
+    def test_returned(self, xp, dtype, axis, weights):
         a = testing.shaped_arange((2, 3), numpy, dtype)
-        w = testing.shaped_arange((2, 3), numpy, dtype)
-        self.check_returned(a, axis=1, weights=None)
-        self.check_returned(a, axis=None, weights=w)
-        self.check_returned(a, axis=1, weights=w)
+        if weights:
+            w = testing.shaped_arange((2, 3), numpy, dtype)
+        else:
+            w = None
+        return xp.average(a, axis=axis, weights=w, returned=True)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(rtol={'default': 5e-7})
+    @pytest.mark.parametrize('returned', [True, False])
     @testing.with_requires('numpy>=1.23')
-    def test_average_keepdims_axis1(self, xp, dtype):
+    def test_average_keepdims_axis1(self, xp, dtype, returned):
         a = testing.shaped_random((2, 3), xp, dtype)
         w = testing.shaped_random((2, 3), xp, dtype)
-        return xp.average(a, axis=1, weights=w, keepdims=True)
+        return xp.average(
+            a, axis=1, weights=w, returned=returned, keepdims=True)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(rtol={'default': 1e-7, numpy.float16: 1e-3})
+    @pytest.mark.parametrize('returned', [True, False])
     @testing.with_requires('numpy>=1.23')
-    def test_average_keepdims_noaxis(self, xp, dtype):
+    def test_average_keepdims_noaxis(self, xp, dtype, returned):
         a = testing.shaped_random((2, 3), xp, dtype)
         w = testing.shaped_random((2, 3), xp, dtype)
-        return xp.average(a, weights=w, keepdims=True)
+        return xp.average(a, weights=w, returned=returned, keepdims=True)
 
 
 @testing.gpu


### PR DESCRIPTION
Part of https://github.com/cupy/cupy/issues/6821, following a change of NumPy 1.23.

https://numpy.org/devdocs/release/1.23.0-notes.html#keepdims-parameter-for-average