### PR TITLE
Support `equal_nan` parameter for `unique`

### DIFF
--- a/cupy/_manipulation/add_remove.py
+++ b/cupy/_manipulation/add_remove.py
@@ -124,11 +124,8 @@ def trim_zeros(filt, trim='fb'):
 
 
 @_core.fusion.fuse()
-def _unique_update_mask_equal_nan(mask, x0, x1):
-    x0_isnan = cupy.isnan(x0)
-    x1_isnan = cupy.isnan(x1)
-    mask1 = cupy.logical_not(
-        cupy.logical_and(x0_isnan, x1_isnan))  # NAND across isnan
+def _unique_update_mask_equal_nan(mask, x0):
+    mask1 = cupy.logical_not(cupy.isnan(x0))
     mask[:] = cupy.logical_and(mask, mask1)
 
 
@@ -193,7 +190,7 @@ def unique(ar, return_index=False, return_inverse=False,
     mask[:1] = True
     mask[1:] = aux[1:] != aux[:-1]
     if equal_nan:
-        _unique_update_mask_equal_nan(mask[1:], aux[1:], aux[:-1])
+        _unique_update_mask_equal_nan(mask[1:], aux[:-1])
 
     ret = aux[mask]
     if not return_index and not return_inverse and not return_counts:

--- a/tests/cupy_tests/manipulation_tests/test_add_remove.py
+++ b/tests/cupy_tests/manipulation_tests/test_add_remove.py
@@ -154,7 +154,10 @@ class TestUnique:
     def test_unique_equal_nan(self, xp, dtype, equal_nan):
         if xp.dtype(dtype).kind == 'c':
             # Nan and Nan+Nan*1j are collapsed when equal_nan=True
-            a = xp.array([xp.nan + 1j, 2, xp.nan, 2, xp.nan, 1], dtype=dtype)
+            a = xp.array([
+                complex(xp.nan, 3), 2, complex(7, xp.nan), xp.nan,
+                complex(xp.nan, xp.nan), 2, xp.nan, 1
+            ], dtype=dtype)
         else:
             a = xp.array([2, xp.nan, 2, xp.nan, 1], dtype=dtype)
         return xp.unique(a, equal_nan=equal_nan)

--- a/tests/cupy_tests/manipulation_tests/test_add_remove.py
+++ b/tests/cupy_tests/manipulation_tests/test_add_remove.py
@@ -148,9 +148,9 @@ class TestUnique:
             a, return_index=True, return_inverse=True, return_counts=True)
 
     @pytest.mark.parametrize('equal_nan', [True, False])
-    @pytest.mark.parametrize('dtype', 'fdFD')
+    @pytest.mark.parametrize('dtype', 'efdFD')
     @testing.numpy_cupy_array_equal()
-    @testing.with_requires('numpy>=1.23')
+    @testing.with_requires('numpy>=1.23.1')
     def test_unique_equal_nan(self, xp, dtype, equal_nan):
         if xp.dtype(dtype).kind == 'c':
             # Nan and Nan+Nan*1j are collapsed when equal_nan=True
@@ -160,21 +160,6 @@ class TestUnique:
             ], dtype=dtype)
         else:
             a = xp.array([2, xp.nan, 2, xp.nan, 1], dtype=dtype)
-        return xp.unique(a, equal_nan=equal_nan)
-
-    @pytest.mark.parametrize(
-        'equal_nan',
-        [
-            pytest.param(True, marks=pytest.mark.xfail(
-                reason='numpy.unique bug')),
-            False,
-        ]
-    )
-    @testing.numpy_cupy_array_equal()
-    @testing.with_requires('numpy>=1.23')
-    def test_unique_equal_nan_float16(self, xp, equal_nan):
-        dtype = xp.float16
-        a = xp.array([2, xp.nan, 2, xp.nan, 1], dtype=dtype)
         return xp.unique(a, equal_nan=equal_nan)
 
 

--- a/tests/cupy_tests/manipulation_tests/test_add_remove.py
+++ b/tests/cupy_tests/manipulation_tests/test_add_remove.py
@@ -101,8 +101,7 @@ class TestResize(unittest.TestCase):
         return xp.resize(xp.array([]), (10, 10))
 
 
-@testing.gpu
-class TestUnique(unittest.TestCase):
+class TestUnique:
 
     @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
     @testing.numpy_cupy_array_equal()
@@ -147,6 +146,33 @@ class TestUnique(unittest.TestCase):
         a = xp.empty((3, 0, 2), dtype)
         return xp.unique(
             a, return_index=True, return_inverse=True, return_counts=True)
+
+    @pytest.mark.parametrize('equal_nan', [True, False])
+    @pytest.mark.parametrize('dtype', 'fdFD')
+    @testing.numpy_cupy_array_equal()
+    @testing.with_requires('numpy>=1.23')
+    def test_unique_equal_nan(self, xp, dtype, equal_nan):
+        if xp.dtype(dtype).kind == 'c':
+            # Nan and Nan+Nan*1j are collapsed when equal_nan=True
+            a = xp.array([xp.nan + 1j, 2, xp.nan, 2, xp.nan, 1], dtype=dtype)
+        else:
+            a = xp.array([2, xp.nan, 2, xp.nan, 1], dtype=dtype)
+        return xp.unique(a, equal_nan=equal_nan)
+
+    @pytest.mark.parametrize(
+        'equal_nan',
+        [
+            pytest.param(True, marks=pytest.mark.xfail(
+                reason='numpy.unique bug')),
+            False,
+        ]
+    )
+    @testing.numpy_cupy_array_equal()
+    @testing.with_requires('numpy>=1.23')
+    def test_unique_equal_nan_float16(self, xp, equal_nan):
+        dtype = xp.float16
+        a = xp.array([2, xp.nan, 2, xp.nan, 1], dtype=dtype)
+        return xp.unique(a, equal_nan=equal_nan)
 
 
 @testing.parameterize(*testing.product({


### PR DESCRIPTION
Part of https://github.com/cupy/cupy/issues/6821, following a change of NumPy 1.23.

https://numpy.org/devdocs/release/1.23.0-notes.html#new-parameter-equal-nan-added-to-np-unique

Note that `numpy.unique` seems to have a bug that it returns wrong results when it takes float16 ndarrays with one or more `nan`.