### PR TITLE
Accept `kind` in `sort`/`argsort` and fix `cupy.array_api.{sort,argsort}` accordingly

### DIFF
--- a/cupy/_sorting/sort.py
+++ b/cupy/_sorting/sort.py
@@ -4,7 +4,7 @@ import numpy
 from cupy.cuda import thrust
 
 
-def sort(a, axis=-1):
+def sort(a, axis=-1, kind=None):
     """Returns a sorted copy of an array with a stable sorting algorithm.
 
     Args:
@@ -12,6 +12,8 @@ def sort(a, axis=-1):
         axis (int or None): Axis along which to sort. Default is -1, which
             means sort along the last axis. If None is supplied, the array is
             flattened before sorting.
+        kind: Default is `None`, which is equivalent to 'stable'. Unlike in
+            NumPy any other options are not accepted here.
 
     Returns:
         cupy.ndarray: Array of the same type and shape as ``a``.
@@ -24,6 +26,8 @@ def sort(a, axis=-1):
     .. seealso:: :func:`numpy.sort`
 
     """
+    if kind is not None and kind != 'stable':
+        raise ValueError("kind can only be None or 'stable'")
     if axis is None:
         ret = a.flatten()
         axis = -1
@@ -84,7 +88,7 @@ def lexsort(keys):
     return idx_array
 
 
-def argsort(a, axis=-1):
+def argsort(a, axis=-1, kind=None):
     """Returns the indices that would sort an array with a stable sorting.
 
     Args:
@@ -92,6 +96,8 @@ def argsort(a, axis=-1):
         axis (int or None): Axis along which to sort. Default is -1, which
             means sort along the last axis. If None is supplied, the array is
             flattened before sorting.
+        kind: Default is `None`, which is equivalent to 'stable'. Unlike in
+            NumPy any other options are not accepted here.
 
     Returns:
         cupy.ndarray: Array of indices that sort ``a``.
@@ -103,6 +109,8 @@ def argsort(a, axis=-1):
     .. seealso:: :func:`numpy.argsort`
 
     """
+    if kind is not None and kind != 'stable':
+        raise ValueError("kind can only be None or 'stable'")
     return a.argsort(axis=axis)
 
 

--- a/cupy/array_api/_sorting_functions.py
+++ b/cupy/array_api/_sorting_functions.py
@@ -15,8 +15,9 @@ def argsort(
 
     See its docstring for more information.
     """
-    # Note: this keyword argument is different, and the default is different.
-    kind = "stable" if stable else "quicksort"
+    # Note: Unlike in NumPy we only support kind={None, 'stable'}, but the standard
+    # does *not* require we need to support unstable sort.
+    kind = None
     if not descending:
         res = np.argsort(x._array, axis=axis, kind=kind)
     else:
@@ -42,8 +43,9 @@ def sort(
 
     See its docstring for more information.
     """
-    # Note: this keyword argument is different, and the default is different.
-    kind = "stable" if stable else "quicksort"
+    # Note: Unlike in NumPy we only support kind={None, 'stable'}, but the standard
+    # does *not* require we need to support unstable sort.
+    kind = None
     res = np.sort(x._array, axis=axis, kind=kind)
     if descending:
         res = np.flip(res, axis=axis)

--- a/tests/cupy_tests/array_api_tests/test_sorting_functions.py
+++ b/tests/cupy_tests/array_api_tests/test_sorting_functions.py
@@ -12,9 +12,6 @@ from cupy import array_api as xp
         ([[0, 1], [1, 1]], 1, [[1, 0], [0, 1]]),
     ],
 )
-@pytest.mark.skipif(
-    # https://github.com/cupy/cupy/issues/5701
-    True, reason="Sorting functions miss arguments kind and order")
 def test_stable_desc_argsort(obj, axis, expected):
     """
     Indices respect relative order of a descending stable-sort


### PR DESCRIPTION
This is for both NumPy compliance (#5701) and Array API compliance (#6779).

What this PR does is to simply add the kw-arg `kind`, allowing passing through of the argument.

However, given that currently there's only one sorting algorithm implemented in CuPy (from Thrust), we can't support `kind` being anything other than `None` or `"stable"`. So for Array API internally we always set `kind` to `None` regardless if users set `stable` to `True` or `False`. (Confirmed during a meeting that this was the intent of the standard.)

Close #5701. Close #6779.

cc: @asmeurer 