### PR TITLE
Generate CUBIN for all supported GPUs at build time

### DIFF
--- a/install/cupy_builder/_compiler.py
+++ b/install/cupy_builder/_compiler.py
@@ -63,26 +63,32 @@ def _nvcc_gencode_options(cuda_version: int) -> List[str]:
         #
         #   https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#options-for-steering-gpu-code-generation
 
+        aarch64 = (platform.machine() == 'aarch64')
         if cuda_version >= 11040:
             # To utilize CUDA Minor Version Compatibility (`cupy-cuda11x`),
-            # PTX cannot be used:
+            # CUBIN must be generated for all supported compute capabilities
+            # instead of PTX:
             # https://docs.nvidia.com/deploy/cuda-compatibility/index.html#application-considerations
-            # Jetson TX1/TX2 are excluded as they don't support JetPack 5 (CUDA 11.4).
             arch_list = [('compute_35', 'sm_35'),
                          ('compute_37', 'sm_37'),
                          ('compute_50', 'sm_50'),
                          ('compute_52', 'sm_52'),
-                         # ('compute_53', 'sm_53'),  # Jetson (TX1 / Nano)
                          ('compute_60', 'sm_60'),
                          ('compute_61', 'sm_61'),
-                         # ('compute_62', 'sm_62'),  # Jetson (TX2)
                          ('compute_70', 'sm_70'),
-                         ('compute_72', 'sm_72'),  # Jetson (Xavier)
                          ('compute_75', 'sm_75'),
                          ('compute_80', 'sm_80'),
                          ('compute_86', 'sm_86'),
-                         ('compute_87', 'sm_87'),  # Jetson (Orin)
                          'compute_86']
+            if aarch64:
+                # Jetson TX1/TX2 are excluded as they don't support JetPack 5
+                # (CUDA 11.4).
+                arch_list += [
+                    # ('compute_53', 'sm_53'),  # Jetson (TX1 / Nano)
+                    # ('compute_62', 'sm_62'),  # Jetson (TX2)
+                    ('compute_72', 'sm_72'),  # Jetson (Xavier)
+                    ('compute_87', 'sm_87'),  # Jetson (Orin)
+                ]
         elif cuda_version >= 11010:
             arch_list = ['compute_35',
                          'compute_50',

--- a/install/cupy_builder/_compiler.py
+++ b/install/cupy_builder/_compiler.py
@@ -64,16 +64,25 @@ def _nvcc_gencode_options(cuda_version: int) -> List[str]:
         #   https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#options-for-steering-gpu-code-generation
 
         if cuda_version >= 11040:
-            arch_list = ['compute_35',
-                         'compute_50',
+            # To utilize CUDA Minor Version Compatibility (`cupy-cuda11x`),
+            # PTX cannot be used:
+            # https://docs.nvidia.com/deploy/cuda-compatibility/index.html#application-considerations
+            # Jetson TX1/TX2 are excluded as they don't support JetPack 5 (CUDA 11.4).
+            arch_list = [('compute_35', 'sm_35'),
+                         ('compute_37', 'sm_37'),
+                         ('compute_50', 'sm_50'),
+                         ('compute_52', 'sm_52'),
+                         # ('compute_53', 'sm_53'),  # Jetson (TX1 / Nano)
                          ('compute_60', 'sm_60'),
                          ('compute_61', 'sm_61'),
+                         # ('compute_62', 'sm_62'),  # Jetson (TX2)
                          ('compute_70', 'sm_70'),
+                         ('compute_72', 'sm_72'),  # Jetson (Xavier)
                          ('compute_75', 'sm_75'),
                          ('compute_80', 'sm_80'),
                          ('compute_86', 'sm_86'),
-                         ('compute_87', 'sm_87'),
-                         'compute_87']
+                         ('compute_87', 'sm_87'),  # Jetson (Orin)
+                         'compute_86']
         elif cuda_version >= 11010:
             arch_list = ['compute_35',
                          'compute_50',


### PR DESCRIPTION
- [x] Confirm issue fixed on Xavier (wheel build: https://github.com/kmaehashi/cupy-aarch64-wheel/actions/runs/2695092750)
- [x] Confirm issue fixed on GeForce GTX TITAN X (wheel build: https://ci.preferred.jp/r/job/106527)

----

I noticed `cupy-cuda11x` (v11rc1) failing on Jetson Xavier Dev Kit (CC 7.2 with CUDA 11.4, aarch64, Linux):

```
cupy_backends.cuda.api.runtime.CUDARuntimeError: cudaErrorUnsupportedPtxVersion: the provided PTX was compiled with an unsupported toolchain.
```

Also confirmed the same issue on NVIDIA GeForce GTX TITAN X (CC 5.2 with CUDA 11.4, x86_64, Windows).

This is because `cupy-cuda11x` wheel contains PTX generated with the latest driver (CUDA 11.7), which cannot be executed on earlier drivers.

https://docs.nvidia.com/deploy/cuda-compatibility/index.html#application-considerations

`compute_86` (PTX) is left for compatibility with future GPUs. Note that `compute_87` is not used as it is a CC for Tegra and [Binary Compatibility is not guaranteed between Desktop and Tegra](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#binary-compatibility).

Related: #6730 

----

This increases the wheel size a bit, but I think this is acceptable.

```
77M     before/cupy-11.0.0rc1-cp39-cp39-linux_x86_64.whl
84M     after/cupy-11.0.0rc1-cp39-cp39-linux_x86_64.whl
```