### PR TITLE
Add CC 8.7 for Jetson Orin

### DIFF
--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -120,7 +120,7 @@ def _get_nvrtc_version():
 
 
 # Known archs for Tegra/Jetson/Xavier/etc
-_tegra_archs = ('32', '53', '62', '72')
+_tegra_archs = ('32', '53', '62', '72', '87')
 
 
 @_util.memoize()
@@ -137,7 +137,8 @@ def _get_max_compute_capability():
         nvrtc_max_compute_capability = '86'
     else:
         # CUDA 11.4+
-        nvrtc_max_compute_capability = '87'
+        # Note: 87 is for Jetson Orin
+        nvrtc_max_compute_capability = '86'
 
     return nvrtc_max_compute_capability
 


### PR DESCRIPTION
source: https://forums.developer.nvidia.com/t/what-is-the-compute-capability-for-the-orion-update-your-page/211447/3

> BTW the Orin GPU is CUDA compute capability 8.7. 