### PR TITLE
Remove proxy functions for softlink

### DIFF
--- a/cupy_backends/cuda/_softlink.pxd
+++ b/cupy_backends/cuda/_softlink.pxd
@@ -1,4 +1,4 @@
-ctypedef int (*func_ptr)(...) nogil
+ctypedef int (*func_ptr)(...) nogil  # NOQA
 
 cdef class SoftLink:
     cdef:

--- a/cupy_backends/cuda/_softlink.pxd
+++ b/cupy_backends/cuda/_softlink.pxd
@@ -1,5 +1,7 @@
+ctypedef int (*func_ptr)(...) nogil
+
 cdef class SoftLink:
     cdef:
         object _cdll
         str _prefix
-        void* get_func(self, str name)
+        func_ptr get(self, str name)

--- a/cupy_backends/cuda/_softlink.pyx
+++ b/cupy_backends/cuda/_softlink.pyx
@@ -17,18 +17,18 @@ cdef class SoftLink:
                     f'({type(e).__name__}: {e})')
         self._prefix = prefix
 
-    cdef void* get_func(self, str name):
+    cdef func_ptr get(self, str name):
         """
         Returns a function pointer for the API.
         """
         if self._cdll is None:
-            return <void*>_fail_unsupported
+            return <func_ptr>_fail_unsupported
         cdef str funcname = f'{self._prefix}{name}'
         cdef object func = getattr(self._cdll, funcname, None)
         if func is None:
-            return <void*>_fail_not_found
+            return <func_ptr>_fail_not_found
         cdef intptr_t ptr = ctypes.addressof(func)
-        return cython.operator.dereference(<void**>ptr)
+        return cython.operator.dereference(<func_ptr*>ptr)
 
 
 cdef int _fail_unsupported() nogil except -1:

--- a/cupy_backends/cuda/libs/cusparse.pyx
+++ b/cupy_backends/cuda/libs/cusparse.pyx
@@ -1365,93 +1365,27 @@ cdef extern from '../../cupy_sparse.h' nogil:
     # Build-time version
     int CUSPARSE_VERSION
 
-# APIs added after CUDA 11.2+.
-cdef void* _cusparseCreateCsc = NULL
-cdef Status cusparseCreateCsc(
-        SpMatDescr* spMatDescr, int64_t rows,
-        int64_t cols, int64_t nnz, void* cscColOffsets,
-        void* cscRowInd, void* cscValues,
-        IndexType cscColOffsetsType,
-        IndexType cscRowIndType, IndexBase idxBase,
-        DataType valueType):
-    return (<Status(*)(...) nogil>_cusparseCreateCsc)(
-        spMatDescr, rows,
-        cols, nnz, cscColOffsets,
-        cscRowInd, cscValues,
-        cscColOffsetsType,
-        cscRowIndType, idxBase,
-        valueType)
-
-cdef void* _cusparseSparseToDense_bufferSize = NULL
-cdef Status cusparseSparseToDense_bufferSize(
-        Handle handle, SpMatDescr matA, DnMatDescr matB,
-        cusparseSparseToDenseAlg_t alg, size_t* bufferSize):
-    return (<Status(*)(...) nogil>_cusparseSparseToDense_bufferSize)(
-        handle, matA, matB,
-        alg, bufferSize)
-
-cdef void* _cusparseSparseToDense = NULL
-cdef Status cusparseSparseToDense(
-        Handle handle, SpMatDescr matA, DnMatDescr matB,
-        cusparseSparseToDenseAlg_t alg, void* buffer):
-    return (<Status(*)(...) nogil>_cusparseSparseToDense)(
-        handle, matA, matB,
-        alg, buffer)
-
-cdef void* _cusparseDenseToSparse_bufferSize = NULL
-cdef Status cusparseDenseToSparse_bufferSize(
-        Handle handle, DnMatDescr matA, SpMatDescr matB,
-        cusparseDenseToSparseAlg_t alg, size_t* bufferSize):
-    return (<Status(*)(...) nogil>_cusparseDenseToSparse_bufferSize)(
-        handle, matA, matB,
-        alg, bufferSize)
-
-cdef void* _cusparseDenseToSparse_analysis = NULL
-cdef Status cusparseDenseToSparse_analysis(
-        Handle handle, DnMatDescr matA, SpMatDescr matB,
-        cusparseDenseToSparseAlg_t alg, void* buffer):
-    return (<Status(*)(...) nogil>_cusparseDenseToSparse_analysis)(
-        handle, matA, matB,
-        alg, buffer)
-
-cdef void* _cusparseDenseToSparse_convert = NULL
-cdef Status cusparseDenseToSparse_convert(
-        Handle handle, DnMatDescr matA, SpMatDescr matB,
-        cusparseDenseToSparseAlg_t alg, void* buffer):
-    return (<Status(*)(...) nogil>_cusparseDenseToSparse_convert)(
-        handle, matA, matB,
-        alg, buffer)
-
-cdef load_functions(libname, prefix):
-    lib = SoftLink(libname, prefix)
-
-    # cuSPARSE 11.3.1+ (CUDA 11.2.0+)
-    global _cusparseCreateCsc
-    _cusparseCreateCsc = lib.get_func('CreateCsc')
-
-    # cuSPARSE 11.3+ (CUDA 11.1.1+)
-    # Note: CUDA 11.1.0 contains cuSPARSE 11.2.0.275
-    global _cusparseSparseToDense_bufferSize
-    _cusparseSparseToDense_bufferSize = lib.get_func('SparseToDense_bufferSize')  # NOQA
-    global _cusparseSparseToDense
-    _cusparseSparseToDense = lib.get_func('SparseToDense')
-    global _cusparseDenseToSparse_bufferSize
-    _cusparseDenseToSparse_bufferSize = lib.get_func('DenseToSparse_bufferSize')  # NOQA
-    global _cusparseDenseToSparse_analysis
-    _cusparseDenseToSparse_analysis = lib.get_func('DenseToSparse_analysis')
-    global _cusparseDenseToSparse_convert
-    _cusparseDenseToSparse_convert = lib.get_func('DenseToSparse_convert')
-
+ctypedef Status (*f_type)(...) nogil
 IF 11010 <= CUPY_CUDA_VERSION < 12000:
     if _sys.platform == 'linux':
         _libname = 'libcusparse.so.11'
     else:
         _libname = 'cusparse64_11.dll'
-    load_functions(_libname, 'cusparse')
 ELIF 0 < CUPY_HIP_VERSION:
-    load_functions(__file__, 'cusparse')
+    _libname = __file__
 ELSE:
-    load_functions(None, 'cusparse')
+    _libname = None
+
+cdef SoftLink _lib = SoftLink(_libname, 'cusparse')
+# cuSPARSE 11.3.1+ (CUDA 11.2.0+)
+cdef f_type cusparseCreateCsc = <f_type>_lib.get('CreateCsc')
+# cuSPARSE 11.3+ (CUDA 11.1.1+)
+# Note: CUDA 11.1.0 contains cuSPARSE 11.2.0.275
+cdef f_type cusparseSparseToDense_bufferSize = <f_type>_lib.get('SparseToDense_bufferSize')  # NOQA
+cdef f_type cusparseSparseToDense = <f_type>_lib.get('SparseToDense')
+cdef f_type cusparseDenseToSparse_bufferSize = <f_type>_lib.get('DenseToSparse_bufferSize')  # NOQA
+cdef f_type cusparseDenseToSparse_analysis = <f_type>_lib.get('DenseToSparse_analysis')  # NOQA
+cdef f_type cusparseDenseToSparse_convert = <f_type>_lib.get('DenseToSparse_convert')  # NOQA
 
 
 cdef dict STATUS = {

--- a/cupy_backends/cuda/libs/cusparse.pyx
+++ b/cupy_backends/cuda/libs/cusparse.pyx
@@ -1365,7 +1365,7 @@ cdef extern from '../../cupy_sparse.h' nogil:
     # Build-time version
     int CUSPARSE_VERSION
 
-ctypedef Status (*f_type)(...) nogil
+ctypedef Status (*f_type)(...) nogil  # NOQA
 IF 11010 <= CUPY_CUDA_VERSION < 12000:
     if _sys.platform == 'linux':
         _libname = 'libcusparse.so.11'

--- a/cupy_backends/cuda/libs/nvrtc.pyx
+++ b/cupy_backends/cuda/libs/nvrtc.pyx
@@ -45,7 +45,7 @@ ELSE:
         int nvrtcAddNameExpression(Program, const char*)
         int nvrtcGetLoweredName(Program, const char*, const char**)
 
-    ctypedef int (*f_type)(...) nogil
+    ctypedef int (*f_type)(...) nogil  # NOQA
     IF 11020 <= CUPY_CUDA_VERSION < 12000:
         if _sys.platform == 'linux':
             _libname = 'libnvrtc.so.11.2'

--- a/cupy_backends/cuda/libs/nvrtc.pyx
+++ b/cupy_backends/cuda/libs/nvrtc.pyx
@@ -45,42 +45,21 @@ ELSE:
         int nvrtcAddNameExpression(Program, const char*)
         int nvrtcGetLoweredName(Program, const char*, const char**)
 
-    # APIs added after CUDA 11.2+.
-    cdef void* _nvrtcGetNumSupportedArchs = NULL
-    cdef int nvrtcGetNumSupportedArchs(int* numArchs) nogil:
-        return (<int(*)(...) nogil>_nvrtcGetNumSupportedArchs)(numArchs)
-
-    cdef void* _nvrtcGetSupportedArchs = NULL
-    cdef int nvrtcGetSupportedArchs(int* supportedArchs) nogil:
-        return (<int(*)(...) nogil>_nvrtcGetSupportedArchs)(supportedArchs)
-
-    cdef void* _nvrtcGetNVVMSize = NULL
-    cdef int nvrtcGetNVVMSize(Program prog, size_t* nvvmSizeRet) nogil:
-        return (<int(*)(...) nogil>_nvrtcGetNVVMSize)(prog, nvvmSizeRet)
-
-    cdef void* _nvrtcGetNVVM = NULL
-    cdef int nvrtcGetNVVM(Program prog, char* nvvm) nogil:
-        return (<int(*)(...) nogil>_nvrtcGetNVVM)(prog, nvvm)
-
-    cdef load_functions(libname):
-        _nvrtc = SoftLink(libname, 'nvrtc')
-        global _nvrtcGetNumSupportedArchs
-        _nvrtcGetNumSupportedArchs = _nvrtc.get_func('GetNumSupportedArchs')
-        global _nvrtcGetSupportedArchs
-        _nvrtcGetSupportedArchs = _nvrtc.get_func('GetSupportedArchs')
-        global _nvrtcGetNVVMSize
-        _nvrtcGetNVVMSize = _nvrtc.get_func('GetNVVMSize')
-        global _nvrtcGetNVVM
-        _nvrtcGetNVVM = _nvrtc.get_func('GetNVVM')
-
+    ctypedef int (*f_type)(...) nogil
     IF 11020 <= CUPY_CUDA_VERSION < 12000:
         if _sys.platform == 'linux':
             _libname = 'libnvrtc.so.11.2'
         else:
             _libname = 'nvrtc64_112_0.dll'
-        load_functions(_libname)
     ELSE:
-        load_functions(None)
+        _libname = None
+
+    cdef SoftLink _lib = SoftLink(_libname, 'nvrtc')
+    # APIs added after CUDA 11.2+.
+    cdef f_type nvrtcGetNumSupportedArchs = <f_type>_lib.get('GetNumSupportedArchs')  # NOQA
+    cdef f_type nvrtcGetSupportedArchs = <f_type>_lib.get('GetSupportedArchs')  # NOQA
+    cdef f_type nvrtcGetNVVMSize = <f_type>_lib.get('GetNVVMSize')
+    cdef f_type nvrtcGetNVVM = <f_type>_lib.get('GetNVVM')
 
 
 ###############################################################################


### PR DESCRIPTION
This reduces the code needed to support new CUDA APIs.

Follows-up #6730 and #6799.
