### PR TITLE
[special] add `cupyx.scipy.special.softmax`

### DIFF
--- a/cupyx/scipy/special/__init__.py
+++ b/cupyx/scipy/special/__init__.py
@@ -80,6 +80,7 @@ from cupyx.scipy.special._sph_harm import sph_harm  # NOQA
 
 # Other special functions
 from cupyx.scipy.special._expn import expn  # NOQA
+from cupyx.scipy.special._softmax import softmax  # NOQA
 from cupyx.scipy.special._logsoftmax import log_softmax  # NOQA
 from cupyx.scipy.special._zeta import zeta  # NOQA
 

--- a/cupyx/scipy/special/_softmax.py
+++ b/cupyx/scipy/special/_softmax.py
@@ -1,0 +1,28 @@
+import cupy
+
+
+def softmax(x, axis=None):
+    """Softmax function.
+
+    The softmax function transforms each element of a
+    collection by computing the exponential of each element
+    divided by the sum of the exponentials of all the elements.
+
+    Parameters
+    ----------
+    x : array-like
+        The input array
+    axis : int or tuple of ints, optional
+        Axis to compute values along. Default is None
+
+    Returns
+    -------
+    s : cupy.ndarray
+        Returns an array with same shape as input. The result
+        will sum to 1 along the provided axis
+
+    """
+
+    x_max = cupy.amax(x, axis=axis, keepdims=True)
+    exp_x_shifted = cupy.exp(x - x_max)
+    return exp_x_shifted / cupy.sum(exp_x_shifted, axis=axis, keepdims=True)

--- a/docs/source/reference/scipy_special.rst
+++ b/docs/source/reference/scipy_special.rst
@@ -129,6 +129,7 @@ Other special functions
    :toctree: generated/
 
    expn
+   softmax
    log_softmax
    zeta
 

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_softmax.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_softmax.py
@@ -1,0 +1,84 @@
+import pytest
+
+import cupy
+from cupy import testing
+import cupyx
+import cupyx.scipy.special  # NOQA
+
+import scipy.special  # NOQA
+
+
+atol = {
+    'default': 1e-6,
+    cupy.float16: 1e-3,
+}
+rtol = {
+    'default': 1e-6,
+    cupy.float16: 1e-3,
+}
+
+
+@testing.with_requires('scipy')
+class TestSoftmax:
+
+    @testing.for_all_dtypes(no_bool=True)
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_1dim(self, xp, scp, dtype):
+        x = xp.arange(400)
+        return scp.special.softmax(x)
+
+    @testing.for_all_dtypes(no_float16=True, no_bool=True)
+    @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=rtol)
+    def test_2dim(self, xp, scp, dtype):
+        if xp.dtype(dtype).kind == 'u':
+            # Unsigned integers make underflows in numpy (eventually seen as
+            # overflows in `np.exp(tmp)`)
+            pytest.skip()
+        x = testing.shaped_random((5, 4), xp, dtype=dtype, scale=8)
+        return scp.special.softmax(x)
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=rtol)
+    def test_2dim_float16(self, xp, scp):
+        x = testing.shaped_random((5, 4), xp, dtype=xp.float16, scale=8)
+        return scp.special.softmax(x)
+
+    @testing.for_all_dtypes(no_float16=True, no_bool=True)
+    @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=rtol)
+    def test_multi_dim(self, xp, scp, dtype):
+        if xp.dtype(dtype).kind == 'u':
+            # Unsigned integers make underflows in numpy (eventually seen as
+            # overflows in `np.exp(tmp)`)
+            pytest.skip()
+        x = testing.shaped_random((5, 6, 7, 4), xp, dtype=dtype, scale=8)
+        return scp.special.softmax(x)
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', atol=1e-4, rtol=1e-4)
+    def test_multi_dim_float16(self, xp, scp):
+        x = testing.shaped_random((5, 6, 7, 4), xp, dtype=xp.float16, scale=8)
+        return scp.special.softmax(x)
+
+    @testing.for_all_dtypes(no_float16=True, no_bool=True)
+    @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=atol)
+    def test_2dim_with_axis(self, xp, scp, dtype):
+        if xp.dtype(dtype).kind == 'u':
+            # Unsigned integers make underflows in numpy (eventually seen as
+            # overflows in `np.exp(tmp)`)
+            pytest.skip()
+        x = testing.shaped_random((5, 4), xp, dtype=dtype, scale=8)
+        return scp.special.softmax(x, axis=1)
+
+    @testing.for_all_dtypes(no_bool=True)
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_empty(self, xp, scp, dtype):
+        x = testing.shaped_random((), xp, dtype=dtype)
+        return scp.special.softmax(x)
+
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_zeros_ones(self, xp, scp):
+        x = xp.array([0.0, 1.0, -1.0, -0.0])
+        return scp.special.softmax(x)
+
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_nans_infs(self, xp, scp):
+        x = xp.array([cupy.inf, cupy.nan, -cupy.nan, -cupy.inf])
+        return scp.special.softmax(x)


### PR DESCRIPTION
Adds `cupyx.scipy.special.softmax`.

#### Benchmarks
size | dtype | SciPy | CuPy
-----|-------|-------|-----
1000 | int8 | 0.106 ms | 0.104 ms
1000 | int32 | 0.062 ms | 0.104 ms
1000 | float32 | 0.046 ms | 0.106 ms
1000 | float64 | 0.058 ms | 0.105 ms
100000 | int8 | 5.711 ms | 0.111 ms
100000 | int32 | 1.761 ms | 0.139 ms
100000 | float32 | 0.378 ms | 0.115 ms
100000 | float64 | 1.620 ms | 0.138 ms
1000000 | int8 | 56.208 ms | 0.225 ms
1000000 | int32 | 17.004 ms | 0.774 ms
1000000 | float32 | 2.805 ms | 0.270 ms
1000000 | float64 | 17.225 ms | 0.925 ms

<details>
<summary>Script (Click Please)</summary>

<p>

```python
import cupy
import cupyx
import cupyx.scipy.stats

import scipy

from cupy import testing
from cupyx.profiler import benchmark

import scipy.stats


n_warmup = 1
n_repeat = 10
dtype_set = ('int8', 'int32', 'float32', 'float64')
n_set = (1000, 100000, 1000000)


def get_time(pref):
    cpu_time = pref.cpu_times.mean()
    gpu_time = pref.gpu_times.mean()
    return max(cpu_time, gpu_time) * 1000  # ms


def time(a):
    cp_a = cupy.array(a)
    ref = scipy.special.softmax(a)
    ret = cupyx.scipy.special.softmax(cp_a)
    times = []
    perf = benchmark(scipy.special.softmax, (a,),
                     n_warmup=n_warmup, n_repeat=n_repeat)
    times.append(get_time(perf))
    perf = benchmark(cupyx.scipy.special.softmax, (cp_a,),
                     n_warmup=n_warmup, n_repeat=n_repeat)
    times.append(get_time(perf))
    return times


print('size | dtype | SciPy | CuPy')
print('-----|-------|-------|-----')
for n in n_set:
    for dtype in dtype_set:
        a = scipy.random.randint(0, 2, size=n).astype(dtype)
        times = time(a)
        print('{} | {} | {:.3f} ms | {:.3f} ms'.format(n, dtype, times[0], times[1]))
```

</p>
</details>