### PR TITLE
Support `deg` in `cupy.angle`

### DIFF
--- a/cupy/_core/__init__.py
+++ b/cupy/_core/__init__.py
@@ -48,7 +48,7 @@ from cupy._core._routines_manipulation import rollaxis  # NOQA
 from cupy._core._routines_manipulation import size  # NOQA'
 from cupy._core._routines_math import absolute  # NOQA
 from cupy._core._routines_math import add  # NOQA
-from cupy._core._routines_math import angle  # NOQA
+from cupy._core._routines_math import angle, angle_deg  # NOQA
 from cupy._core._routines_math import conjugate  # NOQA
 from cupy._core._routines_math import divide  # NOQA
 from cupy._core._routines_math import floor_divide  # NOQA

--- a/cupy/_core/_routines_math.pyx
+++ b/cupy/_core/_routines_math.pyx
@@ -915,7 +915,7 @@ _angle = create_ufunc(
 
 
 _angle_deg = create_ufunc(
-    'cupy_angle',
+    'cupy_angle_deg',
     ('?->d', 'e->e', 'f->f', 'd->d',
      ('F->f', 'out0 = arg(in0) * (180.0 / M_PI)'),
      ('D->d', 'out0 = arg(in0) * (180.0 / M_PI)')),

--- a/cupy/_core/_routines_math.pyx
+++ b/cupy/_core/_routines_math.pyx
@@ -914,6 +914,19 @@ _angle = create_ufunc(
     ''')
 
 
+_angle_deg = create_ufunc(
+    'cupy_angle',
+    ('?->d', 'e->e', 'f->f', 'd->d',
+     ('F->f', 'out0 = arg(in0) * (180.0 / M_PI)'),
+     ('D->d', 'out0 = arg(in0) * (180.0 / M_PI)')),
+    'out0 = in0 >= 0 ? 0 : 180.0',
+    doc='''Returns the angle of the complex argument.
+
+    .. seealso:: :func:`numpy.angle`
+
+    ''')
+
+
 def _positive_boolean_error():
     raise TypeError(
         'The cupy boolean positive, the `+` operator, is not supported.')
@@ -1110,6 +1123,7 @@ _clip = create_ufunc(
 add = _add
 conjugate = _conjugate
 angle = _angle
+angle_deg = _angle_deg
 positive = _positive
 negative = _negative
 multiply = _multiply

--- a/cupy/_math/arithmetic.py
+++ b/cupy/_math/arithmetic.py
@@ -30,9 +30,6 @@ negative = _core.negative
 conjugate = _core.conjugate
 
 
-angle = _core.angle
-
-
 # cupy.real is not a ufunc because it returns a view.
 # The ufunc implementation is used by fusion.
 _real_ufunc = _core.create_ufunc(
@@ -63,6 +60,17 @@ _imag_ufunc = _core.create_ufunc(
     .. seealso:: :func:`numpy.imag`
 
     ''')
+
+
+def angle(z, deg=False):
+    '''Returns the angle of the complex argument.
+
+    .. seealso:: :func:`numpy.angle`
+
+    '''
+    if deg:
+        return _core.angle_deg(z)
+    return _core.angle(z)
 
 
 def real(val):

--- a/tests/cupy_tests/math_tests/test_arithmetic.py
+++ b/tests/cupy_tests/math_tests/test_arithmetic.py
@@ -16,6 +16,9 @@ int_types = signed_int_types + unsigned_int_types
 all_types = [numpy.bool_] + float_types + int_types + complex_types
 negative_types = (
     [numpy.bool_] + float_types + signed_int_types + complex_types)
+negative_types_wo_fp16 = (
+    [numpy.bool_] + [numpy.float32, numpy.float64]
+    + [numpy.int16, numpy.int32, numpy.int64] + complex_types)
 negative_no_complex_types = [numpy.bool_] + float_types + signed_int_types
 no_complex_types = [numpy.bool_] + float_types + int_types
 
@@ -55,11 +58,18 @@ class TestArithmeticRaisesWithNumpyInput:
         'arg1': ([testing.shaped_arange((2, 3), numpy, dtype=d)
                   for d in all_types
                   ] + [0, 0.0j, 0j, 2, 2.0, 2j, True, False]),
-        'name': ['conj', 'conjugate', 'angle', 'real', 'imag'],
+        'name': ['conj', 'conjugate', 'real', 'imag'],
+    }) + testing.product({
+        'arg1': ([testing.shaped_arange((2, 3), numpy, dtype=d)
+                  for d in all_types
+                  ] + [0, 0.0j, 0j, 2, 2.0, 2j, True, False]),
+        'deg': [True, False],
+        'name': ['angle'],
     }) + testing.product({
         'arg1': ([numpy.array([-3, -2, -1, 1, 2, 3], dtype=d)
-                  for d in negative_types
+                  for d in negative_types_wo_fp16
                   ] + [0, 0.0j, 0j, 2, 2.0, 2j, -2, -2.0, -2j, True, False]),
+        'deg': [True, False],
         'name': ['angle'],
     }) + testing.product({
         'arg1': ([testing.shaped_arange((2, 3), numpy, dtype=d) + 1
@@ -75,7 +85,11 @@ class TestArithmeticUnary:
         arg1 = self.arg1
         if isinstance(arg1, numpy.ndarray):
             arg1 = xp.asarray(arg1)
-        y = getattr(xp, self.name)(arg1)
+
+        if self.name in ('angle'):
+            y = getattr(xp, self.name)(arg1, self.deg)
+        else:
+            y = getattr(xp, self.name)(arg1)
 
         if self.name in ('real', 'imag'):
             # Some NumPy functions return Python scalars for Python scalar

--- a/tests/cupy_tests/math_tests/test_arithmetic.py
+++ b/tests/cupy_tests/math_tests/test_arithmetic.py
@@ -86,7 +86,7 @@ class TestArithmeticUnary:
         if isinstance(arg1, numpy.ndarray):
             arg1 = xp.asarray(arg1)
 
-        if self.name in ('angle'):
+        if self.name in {'angle'}:
             y = getattr(xp, self.name)(arg1, self.deg)
         else:
             y = getattr(xp, self.name)(arg1)


### PR DESCRIPTION
There are numerical issues so for negative numbers I try to avoid using fp16 type and anything promoting to fp16.
This is just to reuse the test machinery and avoid creating new tests only for this.

numyp does the full calc in fp16 resulting in 179.9 due to numerical issues. CuPy just returns 180