### PR TITLE
Fix mempool test skip condition

### DIFF
--- a/tests/cupy_tests/cuda_tests/test_runtime.py
+++ b/tests/cupy_tests/cuda_tests/test_runtime.py
@@ -19,17 +19,12 @@ class TestExceptionPicklable:
 
 class TestMemPool:
 
-    @pytest.mark.skipif(runtime.is_hip,
-                        reason='HIP does not support async allocator')
-    @pytest.mark.skipif(driver._is_cuda_python()
-                        and runtime.runtimeGetVersion() < 11020,
-                        reason='cudaMemPool_t is supported since CUDA 11.2')
-    @pytest.mark.skipif(not driver._is_cuda_python()
-                        and driver.get_build_version() < 11020,
-                        reason='cudaMemPool_t is supported since CUDA 11.2')
-    @pytest.mark.skipif(runtime.deviceGetAttribute(
-        runtime.cudaDevAttrMemoryPoolsSupported, 0) == 0,
-        reason='cudaMemPool_t is not supported on device 0')
+    @pytest.mark.skipif(
+        runtime.is_hip or
+        runtime.runtimeGetVersion() < 11020 or
+        runtime.deviceGetAttribute(
+            runtime.cudaDevAttrMemoryPoolsSupported, 0) == 0,
+        reason='CUDA 11.2+ and device supporting cudaMemPool_t is required')
     def test_mallocFromPoolAsync(self):
         # also test create/destroy a pool
         props = runtime.MemPoolProps(

--- a/tests/cupy_tests/cuda_tests/test_runtime.py
+++ b/tests/cupy_tests/cuda_tests/test_runtime.py
@@ -3,7 +3,6 @@ import pickle
 import pytest
 
 import cupy
-from cupy.cuda import driver
 from cupy.cuda import nvrtc
 from cupy.cuda import runtime
 


### PR DESCRIPTION
This is causing test collection error on JetPack.

## CUDA 10.2 on x86_64

```pycon
>>> from cupy.cuda import runtime
>>> runtime.deviceGetAttribute(runtime.cudaDevAttrMemoryPoolsSupported, 0)
1
```

## CUDA 10.2 on JetPack 4.6.2

```pycon
>>> from cupy.cuda import runtime
>>> runtime.deviceGetAttribute(runtime.cudaDevAttrMemoryPoolsSupported, 0)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "cupy_backends/cuda/api/runtime.pyx", line 181, in cupy_backends.cuda.api.runtime.deviceGetAttribute
    cpdef int deviceGetAttribute(int attrib, int device) except? -1:
  File "cupy_backends/cuda/api/runtime.pyx", line 184, in cupy_backends.cuda.api.runtime.deviceGetAttribute
    check_status(status)
  File "cupy_backends/cuda/api/runtime.pyx", line 143, in cupy_backends.cuda.api.runtime.check_status
    raise CUDARuntimeError(status)
cupy_backends.cuda.api.runtime.CUDARuntimeError: cudaErrorInvalidValue: invalid argument
```