### PR TITLE
Fix `cupy.clip` to match numpy

### DIFF
--- a/cupy/_core/_routines_math.pyx
+++ b/cupy/_core/_routines_math.pyx
@@ -1114,7 +1114,7 @@ _clip = create_ufunc(
     'cupy_clip',
     ('???->?', 'bbb->b', 'BBB->B', 'hhh->h', 'HHH->H', 'iii->i', 'III->I',
      'lll->l', 'LLL->L', 'qqq->q', 'QQQ->Q', 'eee->e', 'fff->f', 'ddd->d'),
-    'out0 = in0 < in1 ? in1 : (in0 > in2 ? in2 : in0)')
+    'out0 = in1 > in2 ? in2 : (in0 < in1 ? in1 : (in0 > in2 ? in2 : in0))')
 
 
 # Variables to expose to Python

--- a/cupy/_math/misc.py
+++ b/cupy/_math/misc.py
@@ -144,7 +144,7 @@ def _dot_convolve(a1, a2, mode):
     return output
 
 
-def clip(a, a_min=None, a_max=None, out=None):
+def clip(a, a_min, a_max, out=None):
     """Clips the values of an array to a given interval.
 
     This is equivalent to ``maximum(minimum(a, a_max), a_min)``, while this
@@ -163,6 +163,10 @@ def clip(a, a_min=None, a_max=None, out=None):
 
     .. seealso:: :func:`numpy.clip`
 
+    Notes
+    -----
+    When `a_min` is greater than `a_max`, `clip` returns an
+    array in which all values are equal to `a_max`.
     """
     if fusion._is_fusing():
         return fusion._call_ufunc(_math.clip,

--- a/tests/cupy_tests/math_tests/test_misc.py
+++ b/tests/cupy_tests/math_tests/test_misc.py
@@ -137,7 +137,7 @@ class TestMisc:
     def test_external_clip3(self, xp, dtype):
         a = testing.shaped_arange((2, 3, 4), xp, dtype)
         return xp.clip(a, 8, 1)
-    
+
     @testing.for_all_dtypes(no_bool=True, no_complex=True)
     def test_external_clip4(self, dtype):
         for xp in (numpy, cupy):

--- a/tests/cupy_tests/math_tests/test_misc.py
+++ b/tests/cupy_tests/math_tests/test_misc.py
@@ -136,7 +136,7 @@ class TestMisc:
     @testing.numpy_cupy_array_equal()
     def test_external_clip3(self, xp, dtype):
         a = testing.shaped_arange((2, 3, 4), xp, dtype)
-        return xp.clip(a, 8, 1)
+        return xp.clip(a, 8, 4)
 
     @testing.for_all_dtypes(no_bool=True, no_complex=True)
     def test_external_clip4(self, dtype):

--- a/tests/cupy_tests/math_tests/test_misc.py
+++ b/tests/cupy_tests/math_tests/test_misc.py
@@ -132,6 +132,19 @@ class TestMisc:
         a = testing.shaped_arange((2, 3, 4), xp, dtype)
         return xp.clip(a, 3, 13)
 
+    @testing.for_all_dtypes(no_bool=True, no_complex=True)
+    @testing.numpy_cupy_array_equal()
+    def test_external_clip3(self, xp, dtype):
+        a = testing.shaped_arange((2, 3, 4), xp, dtype)
+        return xp.clip(a, 8, 1)
+    
+    @testing.for_all_dtypes(no_bool=True, no_complex=True)
+    def test_external_clip4(self, dtype):
+        for xp in (numpy, cupy):
+            a = testing.shaped_arange((2, 3, 4), xp, dtype)
+            with pytest.raises(TypeError):
+                xp.clip(a, 3)
+
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_array_equal()
     def test_clip2(self, xp, dtype):


### PR DESCRIPTION
Fixes #6901 

Fixed the 'only `a_max` or `a_min` is given' issue by removing the default value of `None` for `a_min` and `a_max`.
Fixed the '`a_max` < `a_min`' issue by tweaking the cythonic implementation for the function.

Added test cases for the same.