### PR TITLE
Let argpartition use the kth argument properly

### DIFF
--- a/cupy/_core/_routines_sorting.pyx
+++ b/cupy/_core/_routines_sorting.pyx
@@ -237,6 +237,10 @@ cdef _ndarray_base _ndarray_argpartition(self, kth, axis):
         data = _manipulation.rollaxis(self, axis, ndim).copy()
 
     length = data._shape[_axis]
+
+    if length == 0:
+        return cupy.empty((0,), dtype=cupy.int64)
+
     if isinstance(kth, int):
         kth = kth,
     max_k = 0

--- a/cupy/_core/_routines_sorting.pyx
+++ b/cupy/_core/_routines_sorting.pyx
@@ -290,7 +290,8 @@ cdef _ndarray_base _ndarray_argpartition(self, kth, axis):
             s *= 2
 
     # Rearrange indices w.r.t the original axis
-    indices = indices % length
+    axis_indices = cupy.unravel_index(indices, shape)
+    indices = axis_indices[-1]
     indices = indices.reshape(shape)
 
     if _axis != ndim - 1:

--- a/cupy/_core/_routines_sorting.pyx
+++ b/cupy/_core/_routines_sorting.pyx
@@ -219,7 +219,7 @@ cdef _ndarray_base _ndarray_argpartition(self, kth, axis):
 
     """
     cdef int _axis, ndim
-    cdef Py_ssize_t k, length
+    cdef Py_ssize_t k, max_k, length, s, sz, t
     cdef _ndarray_base data
     if axis is None:
         data = self.ravel()
@@ -231,21 +231,63 @@ cdef _ndarray_base _ndarray_argpartition(self, kth, axis):
     ndim = data._shape.size()
     _axis = internal._normalize_axis_index(_axis, ndim)
 
+    if axis == ndim - 1:
+        data = self
+    else:
+        data = _manipulation.rollaxis(self, axis, ndim).copy()
+
     length = data._shape[_axis]
     if isinstance(kth, int):
         kth = kth,
+    max_k = 0
     for k in kth:
         if k < 0:
             k += length
         if not (0 <= k < length):
             raise ValueError('kth(={}) out of bounds {}'.format(k, length))
+        if max_k < k:
+            max_k = k
 
-    # TODO(takgi) For its implementation reason, cupy.ndarray.argsort
-    # currently performs full argsort with Thrust's efficient radix sort
-    # algorithm.
+    # For simplicity, max_k is round up to the power of 2. If max_k is
+    # already the power of 2, it is round up to the next power of 2 because
+    # we need to collect the first max(kth)+1 elements.
+    max_k = max(32, 1 << max_k.bit_length())
 
-    # kth is ignored.
-    return data.argsort(_axis)
+    # The parameter t is the length of the list that stores elements to be
+    # selected for each thread. We divide the array into sz subarrays.
+    # These parameters are determined from the measurement on TITAN X.
+    t = 4
+    sz = 512
+    while sz > 0 and length // sz < max_k + 32 * t:
+        sz //= 2
+    sz *= self.size // length
+
+    # If the array size is small or k is large, we simply sort the array.
+    if length < 32 or sz < 1 or max_k >= 1024:
+        # kth is ignored.
+        return data.argsort(axis=-1)
+
+    shape = data.shape
+    data = data.ravel()
+    indices = cupy.arange(0, data.shape[0], dtype=cupy.int64)
+
+    # For each subarray, we collect first k elements to the head.
+    kern, merge_kern = _argpartition_kernel(self.dtype)
+    block_size = 32
+    grid_size = sz
+    kern(grid=(grid_size,), block=(block_size,), args=(
+        data, indices, max_k, self.size, t, sz))
+
+    # Merge heads of subarrays.
+    s = 1
+    while s < sz // (self.size // length):
+        block_size = 32
+        grid_size = sz // s // 2
+        merge_kern(grid=(grid_size,), block=(block_size,), args=(
+            data, indices, max_k, self.size, sz, s))
+        s *= 2
+
+    return indices
 
 
 @_util.memoize(for_each_device=True)
@@ -356,6 +398,125 @@ def _partition_kernel(dtype):
         ptrdiff_t m = (i / 32 * 2 + 1) * s * n / sz;
         int id = i % 32;
         merge< ${dtype} >(a, k, id, z, m, k);
+    }
+    }
+    ''').substitute(name=name, merge_kernel=merge_kernel, dtype=dtype)
+    module = compile_with_cache(source)
+    return module.get_function(name), module.get_function(merge_kernel)
+
+
+@_util.memoize(for_each_device=True)
+def _argpartition_kernel(dtype):
+    name = 'argpartition_kernel'
+    merge_kernel = 'argpartition_merge_kernel'
+    dtype = _get_typename(dtype)
+    source = string.Template('''
+    template<typename T>
+    __device__ void bitonic_sort_step(
+            CArray<T, 1, true> a, CArray<long long, 1, true> b,
+            ptrdiff_t x, ptrdiff_t y, int i, ptrdiff_t s, ptrdiff_t w) {
+        for (ptrdiff_t j = i; j < (y - x) / 2; j += 32) {
+            ptrdiff_t n = j + (j & -w);
+            T v = a[b[n + x]], u = a[b[n + w + x]];
+            if (n & s ? v < u : v > u) {
+                long long temp = b[n + x];
+                b[n + x] = b[n + w + x];
+                b[n + w + x] = temp;
+            }
+        }
+    }
+
+    // Sort a[x:y].
+    template<typename T>
+    __device__ void bitonic_sort(
+            CArray<T, 1, true> a, CArray<long long, 1, true> b,
+            ptrdiff_t x, ptrdiff_t y, int i) {
+        for (ptrdiff_t s = 2; s <= y - x; s *= 2) {
+            for (ptrdiff_t w = s / 2; w >= 1; w /= 2) {
+                bitonic_sort_step< T >(a, b, x, y, i, s, w);
+            }
+        }
+    }
+
+    // Merge first k elements and the next 32 times t elements.
+    template<typename T>
+    __device__ void merge(
+            CArray<T, 1, true> a, CArray<long long, 1, true> b,
+            int k, int i, ptrdiff_t x, ptrdiff_t z, int u) {
+        for (int s = i; s < u; s += 32) {
+            if (a[b[x + k - s - 1]] > a[b[z + s]]) {
+                long long tmp = b[x + k - s - 1];
+                b[x + k - s - 1] = b[z + s];
+                b[z + s] = tmp;
+            }
+        }
+
+        // After merge step, the first k elements are already bitonic.
+        // Therefore, we do not need to fully sort.
+        for (int w = k / 2; w >= 1; w /= 2) {
+            bitonic_sort_step< T >(a, b, x, k + x, i, k, w);
+        }
+    }
+
+    extern "C" {
+    // In this function, 32 threads handle one subarray. This number equals to
+    // the warp size. The first k elements are always sorted and the next 32
+    // times t elements stored values that have possibilities to be selected.
+    __global__ void ${name}(
+            CArray<${dtype}, 1, true> a, CArray<long long, 1, true> b,
+            int k, ptrdiff_t n, int t, ptrdiff_t sz) {
+
+        // This thread handles a[z:m].
+        ptrdiff_t i = static_cast<ptrdiff_t>(blockIdx.x) * blockDim.x
+            + threadIdx.x;
+        ptrdiff_t z = i / 32 * n / sz;
+        ptrdiff_t m = (i / 32 + 1) * n / sz;
+        int id = i % 32;
+        int x = 0;
+
+        bitonic_sort< ${dtype} >(a, b, z, k + z, id);
+        ptrdiff_t j;
+        for (j = k + id + z; j < m - (m - z) % 32; j += 32) {
+            if (a[b[j]] < a[b[k - 1 + z]]) {
+                long long tmp = b[k + 32 * x + id + z];
+                b[k + 32 * x + id + z] = b[j];
+                b[j] = tmp;
+                ++x;
+            }
+
+            // If at least one thread in the warp has found t values that
+            // can be selected, we update the first k elements.
+    #if __CUDACC_VER_MAJOR__ >= 9
+            if (__any_sync(0xffffffff, x >= t)) {
+    #else
+            if (__any(x >= t)) {
+    #endif
+                bitonic_sort< ${dtype} >(a, b, k + z, 32 * t + k + z, id);
+                merge< ${dtype} >(a, b, k, id, z, k + z, min(k, 32 * t));
+                x = 0;
+            }
+        }
+        if (j < m && a[b[j]] < a[b[k - 1 + z]]) {
+            long long tmp = b[k + 32 * x + id + z];
+            b[k + 32 * x + id + z] = b[j];
+            b[j] = tmp;
+        }
+
+        // Finally, we merge the first k elements and the remainders to be
+        // stored.
+        bitonic_sort< ${dtype} >(a, b, k + z, 32 * t + k + z, id);
+        merge< ${dtype} >(a, b, k, id, z, k + z, min(k, 32 * t));
+    }
+
+    __global__ void ${merge_kernel}(
+            CArray<${dtype}, 1, true> a,  CArray<long long, 1, true> b,
+            int k, ptrdiff_t n, int sz, int s) {
+        ptrdiff_t i = static_cast<ptrdiff_t>(blockIdx.x) * blockDim.x
+            + threadIdx.x;
+        ptrdiff_t z = i / 32 * 2 * s * n / sz;
+        ptrdiff_t m = (i / 32 * 2 + 1) * s * n / sz;
+        int id = i % 32;
+        merge< ${dtype} >(a, b, k, id, z, m, k);
     }
     }
     ''').substitute(name=name, merge_kernel=merge_kernel, dtype=dtype)

--- a/tests/cupy_tests/sorting_tests/test_sort.py
+++ b/tests/cupy_tests/sorting_tests/test_sort.py
@@ -651,7 +651,7 @@ class TestArgpartition(unittest.TestCase):
         return idx[:, :, kth:kth + 1]
 
     @testing.for_all_dtypes(no_bool=True)
-    @testing.numpy_cupy_array_equal(accept_error=True)
+    @testing.numpy_cupy_array_equal()
     def test_argpartition_multi_dim_kernel(self, xp, dtype):
         a = testing.shaped_random((3, 3, 256), xp, dtype, 100)
         kth = 2

--- a/tests/cupy_tests/sorting_tests/test_sort.py
+++ b/tests/cupy_tests/sorting_tests/test_sort.py
@@ -654,15 +654,15 @@ class TestArgpartition(unittest.TestCase):
     @testing.numpy_cupy_array_equal()
     def test_argpartition_multi_dim_kernel(self, xp, dtype):
         a = testing.shaped_random((3, 3, 256), xp, dtype, 100)
-        kth = 2
+        kth = 20
         idx = self.argpartition(a, kth, axis=-1)
 
         rows = [[[0]], [[1]], [[2]]]
         cols = [[[0], [1], [2]]]
 
-        assert (a[rows, cols, idx[:, :, :kth]] <
+        assert (a[rows, cols, idx[:, :, :kth]] <=
                 a[rows, cols, idx[:, :, kth:kth + 1]]).all()
-        assert (a[rows, cols, idx[:, :, kth:kth + 1]] <
+        assert (a[rows, cols, idx[:, :, kth:kth + 1]] <=
                 a[rows, cols, idx[:, :, kth + 1:]]).all()
         return idx[:, :, kth:kth + 1]
 

--- a/tests/cupy_tests/sorting_tests/test_sort.py
+++ b/tests/cupy_tests/sorting_tests/test_sort.py
@@ -650,6 +650,22 @@ class TestArgpartition(unittest.TestCase):
                 a[rows, cols, idx[:, :, kth + 1:]]).all()
         return idx[:, :, kth:kth + 1]
 
+    @testing.for_all_dtypes(no_bool=True)
+    @testing.numpy_cupy_array_equal(accept_error=True)
+    def test_argpartition_multi_dim_kernel(self, xp, dtype):
+        a = testing.shaped_random((3, 3, 256), xp, dtype, 100)
+        kth = 2
+        idx = self.argpartition(a, kth, axis=-1)
+
+        rows = [[[0]], [[1]], [[2]]]
+        cols = [[[0], [1], [2]]]
+
+        assert (a[rows, cols, idx[:, :, :kth]] <
+                a[rows, cols, idx[:, :, kth:kth + 1]]).all()
+        assert (a[rows, cols, idx[:, :, kth:kth + 1]] <
+                a[rows, cols, idx[:, :, kth + 1:]]).all()
+        return idx[:, :, kth:kth + 1]
+
     # Test non-contiguous array
 
     @testing.numpy_cupy_equal()

--- a/tests/cupy_tests/sorting_tests/test_sort.py
+++ b/tests/cupy_tests/sorting_tests/test_sort.py
@@ -653,7 +653,12 @@ class TestArgpartition(unittest.TestCase):
     @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_array_equal()
     def test_argpartition_multi_dim_kernel(self, xp, dtype):
-        a = testing.shaped_random((3, 3, 256), xp, dtype, 100)
+        # Use a larger scale for shaped_random to avoid duplicated numbers,
+        # which may make different indices at kth between NumPy and CuPy. Skip
+        # if int8 and uint8 not to overflow.
+        if dtype in (xp.int8, xp.uint8):
+            pytest.skip()
+        a = testing.shaped_random((3, 3, 256), xp, dtype, 10000)
         kth = 20
         idx = self.argpartition(a, kth, axis=-1)
 


### PR DESCRIPTION
Fixes #3287
Fixes #6812 

`argpartition` now uses an indirect-sort version of the `partition` kernel