### PR TITLE
Make sure that uniform sampling respects broadcasting

### DIFF
--- a/cupy/random/_generator.py
+++ b/cupy/random/_generator.py
@@ -921,7 +921,7 @@ class RandomState(object):
             high = cupy.asarray(high, dtype)
 
         if size is None:
-           size = cupy.broadcast(low, high).shape
+            size = cupy.broadcast(low, high).shape
 
         dtype = numpy.dtype(dtype)
         rand = self.random_sample(size=size, dtype=dtype)

--- a/cupy/random/_generator.py
+++ b/cupy/random/_generator.py
@@ -915,12 +915,16 @@ class RandomState(object):
             - :meth:`numpy.random.RandomState.uniform`
 
         """
-        dtype = numpy.dtype(dtype)
-        rand = self.random_sample(size=size, dtype=dtype)
         if not numpy.isscalar(low):
             low = cupy.asarray(low, dtype)
         if not numpy.isscalar(high):
             high = cupy.asarray(high, dtype)
+
+        if size is None:
+           size = cupy.broadcast(low, high).shape
+
+        dtype = numpy.dtype(dtype)
+        rand = self.random_sample(size=size, dtype=dtype)
         return RandomState._scale_kernel(low, high, rand)
 
     def vonmises(self, mu, kappa, size=None, dtype=float):

--- a/tests/cupy_tests/random_tests/test_generator.py
+++ b/tests/cupy_tests/random_tests/test_generator.py
@@ -1017,6 +1017,9 @@ class TestUniform(RandomGeneratorTestCase):
     def test_uniform_2(self):
         self.generate(-4.2, 2.4, size=(3, 2))
 
+    def test_uniform_broadcast(self):
+        self.generate([[2, 3]], [4])
+
     @testing.for_dtypes('fd')
     @_condition.repeat_with_success_at_least(10, 3)
     def test_uniform_ks_1(self, dtype):


### PR DESCRIPTION
Fixes #1644

When any of `low` or `high` are multidimensional and `size` is `None`, then the final shape is computed before sampling the values