### PR TITLE
Fix cuTensorNet shim layer

### DIFF
--- a/cupy/linalg/_einsum_cutn.py
+++ b/cupy/linalg/_einsum_cutn.py
@@ -88,8 +88,10 @@ def _try_use_cutensornet(*args, **kwargs):
 
     # prepare cutn inputs
     device = cupy.cuda.runtime.getDevice()
-    handle = cutn_handle_cache.get(
-        device, cutensornet.create())
+    handle = cutn_handle_cache.get(device)
+    if handle is None:
+        handle = cutensornet.create()
+        cutn_handle_cache[device] = handle
     cutn_options = {'device_id': device, 'handle': handle,
                     'memory_limit': 4**31}  # TODO(leofang): fix?
 

--- a/cupy/linalg/_einsum_cutn.py
+++ b/cupy/linalg/_einsum_cutn.py
@@ -92,8 +92,7 @@ def _try_use_cutensornet(*args, **kwargs):
     if handle is None:
         handle = cutensornet.create()
         cutn_handle_cache[device] = handle
-    cutn_options = {'device_id': device, 'handle': handle,
-                    'memory_limit': 4**31}  # TODO(leofang): fix?
+    cutn_options = {'device_id': device, 'handle': handle}
 
     # TODO(leofang): support all valid combinations:
     # - path from user, contract with cutn (done)


### PR DESCRIPTION
Fix two bugs:
1. The cuTensorNet handle was not reused
2. The `memory_limit` was too large (4**31 bytes = 4294967296 GB)
   - In cuQuantum Python, the semantics of `memory_limit` is different from that of `{numpy,cupy}.einsum()`. In the latter it is the size of the largest intermediate tensor, but in the former it is used
     - as a constraint for max device memory to guide the contraction path optimizer
     - additionally, as a hard limit to determine if the actual workspace size is too large
   - Since there's no perfect way to map the two `memory_limit`s, I just disable it entirely and let cuQuantum Python's default kick in.