### PR TITLE
Fix docs build failure

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -406,7 +406,6 @@ def _find_source_root(source_abs_path):
     if _source_root is not None:
         return _source_root
 
-    assert os.path.isfile(source_abs_path)
     dirname = os.path.dirname(source_abs_path)
     while True:
         parent = os.path.dirname(dirname)


### PR DESCRIPTION
This fixes the master branch doc build (LaTeX) broken.

https://readthedocs.org/projects/cupy/builds/

This `assert` check was improper as the filenames for extension objects are not existing filenames after #6126 (which manually crafts the PYX filename by removing `~.so` and appending `.pyx` from the real extension object file).
Depending on the module discovery order of Sphinx, this assert triggers and build fails.