### PR TITLE
Fix sparse test to follow SciPy 1.9

### DIFF
--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_coo.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_coo.py
@@ -859,9 +859,7 @@ class TestCooMatrixScipyComparison:
             with pytest.raises(ValueError):
                 x * m
 
-    @pytest.mark.xfail(
-        numpy.lib.NumpyVersion(scipy.__version__) >= '1.8.0rc1',
-        reason='See scipy/15210')
+    @testing.with_requires('scipy>=1.9.0,<1.8.0')  # See scipy/15210
     def test_rmul_unsupported(self):
         for xp, sp in ((numpy, scipy.sparse), (cupy, sparse)):
             m = _make(xp, sp, self.dtype)

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
@@ -896,12 +896,8 @@ class TestCscMatrixScipyComparison:
             with pytest.raises(ValueError):
                 x * m
 
+    @testing.with_requires('scipy>=1.9.0,<1.8.0')  # See scipy/15210
     def test_rmul_unsupported(self):
-        if (
-            numpy.lib.NumpyVersion(scipy.__version__) >= '1.8.0rc1' and
-            self.make_method not in ['_make_empty', '_make_shape']
-        ):
-            pytest.xfail('See scipy/15210')
         for xp, sp in ((numpy, scipy.sparse), (cupy, sparse)):
             m = self.make(xp, sp, self.dtype)
             # TODO(unno): When a sparse matrix has no element, scipy.sparse

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -923,12 +923,8 @@ class TestCsrMatrixScipyComparison:
             with pytest.raises(ValueError):
                 x * m
 
+    @testing.with_requires('scipy>=1.9.0,<1.8.0')  # See scipy/15210
     def test_rmul_unsupported(self):
-        if (
-            numpy.lib.NumpyVersion(scipy.__version__) >= '1.8.0rc1' and
-            self.make_method not in ['_make_empty', '_make_shape']
-        ):
-            pytest.xfail('See scipy/15210')
         for xp, sp in ((numpy, scipy.sparse), (cupy, sparse)):
             m = self.make(xp, sp, self.dtype)
             if m.nnz == 0:


### PR DESCRIPTION
https://github.com/scipy/scipy/issues/15210 is fixed in scipy==1.9.0.