### PR TITLE
Make sparse argmin/max return a scalar array containing the index

### DIFF
--- a/cupyx/scipy/sparse/_data.py
+++ b/cupyx/scipy/sparse/_data.py
@@ -123,16 +123,10 @@ class _data_matrix(_base.spmatrix):
 def _find_missing_index(ind, n):
     positions = cupy.arange(ind.size)
     diff = ind != positions
-    non_zero = cupy.argwhere(diff).ravel()
-
-    if non_zero.size != 0:
-        return non_zero[0]
-
-    k = ind.size + 1
-    if k < n:
-        return cupy.asarray(k)
-    else:
-        return cupy.asarray(-1)
+    return cupy.where(
+        diff.any(),
+        diff.argmax(),
+        cupy.asarray(ind.size if ind.size < n else -1))
 
 
 class _minmax_mixin(object):

--- a/cupyx/scipy/sparse/_data.py
+++ b/cupyx/scipy/sparse/_data.py
@@ -139,7 +139,7 @@ def _non_zero_cmp(mat, am, zero, m):
         zero_ind = _find_missing_index(ind, size)
         return cupy.where(
             m == zero,
-            cupy.where(cupy.greater(zero_ind, am), am, zero_ind),
+            cupy.minimum(zero_ind, am)
             zero_ind)
 
 

--- a/cupyx/scipy/sparse/_data.py
+++ b/cupyx/scipy/sparse/_data.py
@@ -1,6 +1,5 @@
-from operator import mul
-from functools import reduce
 import cupy
+import numpy as np
 from cupy._core import internal
 from cupy import _util
 from cupyx.scipy.sparse import _base
@@ -132,7 +131,7 @@ def _find_missing_index(ind, n):
 
 
 def _non_zero_cmp(mat, am, zero, m):
-    size = reduce(mul, mat.shape, 1)
+    size = np.prod(mat.shape)
     if size == mat.nnz:
         return am
     else:

--- a/cupyx/scipy/sparse/_data.py
+++ b/cupyx/scipy/sparse/_data.py
@@ -225,7 +225,7 @@ class _minmax_mixin(object):
             if self.nnz == 0:
                 return 0
             else:
-                zero = self.dtype.type(0)
+                zero = cupy.asarray(self.dtype.type(0))
                 mat = self.tocoo()
 
                 mat.sum_duplicates()
@@ -243,7 +243,7 @@ class _minmax_mixin(object):
                         ind = mat.row * mat.shape[1] + mat.col
                         zero_ind = _find_missing_index(ind, size)
                         if m == zero:
-                            return min(zero_ind, am)
+                            return cupy.min(zero_ind, am)
                         else:
                             return zero_ind
 

--- a/cupyx/scipy/sparse/_data.py
+++ b/cupyx/scipy/sparse/_data.py
@@ -139,7 +139,7 @@ def _non_zero_cmp(mat, am, zero, m):
         zero_ind = _find_missing_index(ind, size)
         return cupy.where(
             m == zero,
-            cupy.minimum(zero_ind, am)
+            cupy.minimum(zero_ind, am),
             zero_ind)
 
 

--- a/cupyx/scipy/sparse/_data.py
+++ b/cupyx/scipy/sparse/_data.py
@@ -121,11 +121,14 @@ class _data_matrix(_base.spmatrix):
 
 
 def _find_missing_index(ind, n):
-    for k, a in enumerate(ind):
-        if k != a:
-            return cupy.asarray(k)
+    positions = cupy.arange(ind.size)
+    diff = ind != positions
+    non_zero = cupy.argwhere(diff).ravel()
 
-    k += 1
+    if non_zero.size != 0:
+        return non_zero[0]
+
+    k = ind.size + 1
     if k < n:
         return cupy.asarray(k)
     else:

--- a/cupyx/scipy/sparse/_data.py
+++ b/cupyx/scipy/sparse/_data.py
@@ -1,4 +1,5 @@
-import math
+from operator import mul
+from functools import reduce
 import cupy
 from cupy._core import internal
 from cupy import _util
@@ -131,7 +132,7 @@ def _find_missing_index(ind, n):
 
 
 def _non_zero_cmp(mat, am, zero, m):
-    size = math.prod(mat.shape)
+    size = reduce(mul, mat.shape, 1)
     if size == mat.nnz:
         return am
     else:

--- a/cupyx/scipy/sparse/_data.py
+++ b/cupyx/scipy/sparse/_data.py
@@ -233,7 +233,9 @@ class _minmax_mixin(object):
                 am = op(mat.data)
                 m = mat.data[am]
 
-                if compare(m, zero):
+                zero_cmp = cupy.where(compare(m, zero), True, False)
+
+                if zero_cmp:
                     return mat.row[am] * mat.shape[1] + mat.col[am]
                 else:
                     size = math.prod(mat.shape)
@@ -243,7 +245,9 @@ class _minmax_mixin(object):
                         ind = mat.row * mat.shape[1] + mat.col
                         zero_ind = _find_missing_index(ind, size)
                         if m == zero:
-                            return cupy.min(zero_ind, am)
+                            min_idx = cupy.where(
+                                cupy.greater(zero_ind, am), am, zero_ind)
+                            return min_idx
                         else:
                             return zero_ind
 

--- a/cupyx/scipy/sparse/_data.py
+++ b/cupyx/scipy/sparse/_data.py
@@ -123,13 +123,13 @@ class _data_matrix(_base.spmatrix):
 def _find_missing_index(ind, n):
     for k, a in enumerate(ind):
         if k != a:
-            return k
+            return cupy.asarray(k)
 
     k += 1
     if k < n:
-        return k
+        return cupy.asarray(k)
     else:
-        return -1
+        return cupy.asarray(-1)
 
 
 class _minmax_mixin(object):
@@ -238,7 +238,7 @@ class _minmax_mixin(object):
                 if compare(m, zero):
                     return mat.row[am] * mat.shape[1] + mat.col[am]
                 else:
-                    size = cupy.prod(mat.shape)
+                    size = cupy.prod(cupy.asarray(mat.shape))
                     if size == mat.nnz:
                         return am
                     else:

--- a/cupyx/scipy/sparse/_data.py
+++ b/cupyx/scipy/sparse/_data.py
@@ -1,3 +1,4 @@
+import math
 import cupy
 from cupy._core import internal
 from cupy import _util
@@ -235,7 +236,7 @@ class _minmax_mixin(object):
                 if compare(m, zero):
                     return mat.row[am] * mat.shape[1] + mat.col[am]
                 else:
-                    size = cupy.prod(cupy.asarray(mat.shape))
+                    size = math.prod(mat.shape)
                     if size == mat.nnz:
                         return am
                     else:

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
@@ -1266,7 +1266,7 @@ class TestCscMatrixScipyCompressedMinMax:
     @testing.numpy_cupy_array_equal(sp_name='sp')
     def test_argmax(self, xp, sp):
         data = self._make_data_max(xp, sp, dense=self.dense)
-        return data.argmax(axis=self.axis)
+        return xp.array(data.argmax(axis=self.axis))
 
 
 @testing.parameterize(*testing.product({

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
@@ -1261,11 +1261,19 @@ class TestCscMatrixScipyCompressedMinMax:
     @testing.numpy_cupy_array_equal(sp_name='sp')
     def test_argmin(self, xp, sp):
         data = self._make_data_min(xp, sp, dense=self.dense)
+        # Due to a SciPy bug, the argmin output is different from the expected
+        # one
+        if self.axis is None and self.dense:
+            pytest.skip()
         return xp.array(data.argmin(axis=self.axis))
 
     @testing.numpy_cupy_array_equal(sp_name='sp')
     def test_argmax(self, xp, sp):
         data = self._make_data_max(xp, sp, dense=self.dense)
+        # Due to a SciPy bug, the argmin output is different from the expected
+        # one
+        if self.axis is None and self.dense:
+            pytest.skip()
         return xp.array(data.argmax(axis=self.axis))
 
 

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
@@ -1258,7 +1258,7 @@ class TestCscMatrixScipyCompressedMinMax:
         else:
             return data.max(axis=self.axis)
 
-    @testing.numpy_cupy_array_equal(sp_name='sp')
+    @testing.numpy_cupy_array_equal(sp_name='sp', type_check=False)
     def test_argmin(self, xp, sp):
         data = self._make_data_min(xp, sp, dense=self.dense)
         # Due to a SciPy bug, the argmin output is different from the expected
@@ -1267,7 +1267,7 @@ class TestCscMatrixScipyCompressedMinMax:
             pytest.skip()
         return xp.array(data.argmin(axis=self.axis))
 
-    @testing.numpy_cupy_array_equal(sp_name='sp')
+    @testing.numpy_cupy_array_equal(sp_name='sp', type_check=False)
     def test_argmax(self, xp, sp):
         data = self._make_data_max(xp, sp, dense=self.dense)
         # Due to a SciPy bug, the argmin output is different from the expected

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
@@ -1261,7 +1261,7 @@ class TestCscMatrixScipyCompressedMinMax:
     @testing.numpy_cupy_array_equal(sp_name='sp')
     def test_argmin(self, xp, sp):
         data = self._make_data_min(xp, sp, dense=self.dense)
-        return data.argmin(axis=self.axis)
+        return xp.array(data.argmin(axis=self.axis))
 
     @testing.numpy_cupy_array_equal(sp_name='sp')
     def test_argmax(self, xp, sp):

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
@@ -1260,17 +1260,11 @@ class TestCscMatrixScipyCompressedMinMax:
 
     @testing.numpy_cupy_array_equal(sp_name='sp')
     def test_argmin(self, xp, sp):
-        # TODO(takagi) Fix axis=None
-        if self.axis is None:
-            pytest.skip()
         data = self._make_data_min(xp, sp, dense=self.dense)
         return data.argmin(axis=self.axis)
 
     @testing.numpy_cupy_array_equal(sp_name='sp')
     def test_argmax(self, xp, sp):
-        # TODO(takagi) Fix axis=None
-        if self.axis is None:
-            pytest.skip()
         data = self._make_data_max(xp, sp, dense=self.dense)
         return data.argmax(axis=self.axis)
 

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -1454,11 +1454,19 @@ class TestCsrMatrixScipyCompressedMinMax:
     @testing.numpy_cupy_array_equal(sp_name='sp')
     def test_argmin(self, xp, sp):
         data = self._make_data_min(xp, sp, dense=self.dense)
+        # Due to a SciPy bug, the argmin output is different from the expected
+        # one
+        if self.axis is None and self.dense:
+            pytest.skip()
         return xp.array(data.argmin(axis=self.axis))
 
     @testing.numpy_cupy_array_equal(sp_name='sp')
     def test_argmax(self, xp, sp):
         data = self._make_data_max(xp, sp, dense=self.dense)
+        # Due to a SciPy bug, the argmin output is different from the expected
+        # one
+        if self.axis is None and self.dense:
+            pytest.skip()
         return xp.array(data.argmax(axis=self.axis))
 
 

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -1453,17 +1453,11 @@ class TestCsrMatrixScipyCompressedMinMax:
 
     @testing.numpy_cupy_array_equal(sp_name='sp')
     def test_argmin(self, xp, sp):
-        # TODO(takagi) Fix axis=None
-        if self.axis is None:
-            pytest.skip()
         data = self._make_data_min(xp, sp, dense=self.dense)
         return data.argmin(axis=self.axis)
 
     @testing.numpy_cupy_array_equal(sp_name='sp')
     def test_argmax(self, xp, sp):
-        # TODO(takagi) Fix axis=None
-        if self.axis is None:
-            pytest.skip()
         data = self._make_data_max(xp, sp, dense=self.dense)
         return data.argmax(axis=self.axis)
 

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -1451,7 +1451,7 @@ class TestCsrMatrixScipyCompressedMinMax:
         else:
             return data.max(axis=self.axis)
 
-    @testing.numpy_cupy_array_equal(sp_name='sp')
+    @testing.numpy_cupy_array_equal(sp_name='sp', type_check=False)
     def test_argmin(self, xp, sp):
         data = self._make_data_min(xp, sp, dense=self.dense)
         # Due to a SciPy bug, the argmin output is different from the expected
@@ -1460,7 +1460,7 @@ class TestCsrMatrixScipyCompressedMinMax:
             pytest.skip()
         return xp.array(data.argmin(axis=self.axis))
 
-    @testing.numpy_cupy_array_equal(sp_name='sp')
+    @testing.numpy_cupy_array_equal(sp_name='sp', type_check=False)
     def test_argmax(self, xp, sp):
         data = self._make_data_max(xp, sp, dense=self.dense)
         # Due to a SciPy bug, the argmin output is different from the expected

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -1454,12 +1454,12 @@ class TestCsrMatrixScipyCompressedMinMax:
     @testing.numpy_cupy_array_equal(sp_name='sp')
     def test_argmin(self, xp, sp):
         data = self._make_data_min(xp, sp, dense=self.dense)
-        return data.argmin(axis=self.axis)
+        return xp.array(data.argmin(axis=self.axis))
 
     @testing.numpy_cupy_array_equal(sp_name='sp')
     def test_argmax(self, xp, sp):
         data = self._make_data_max(xp, sp, dense=self.dense)
-        return data.argmax(axis=self.axis)
+        return xp.array(data.argmax(axis=self.axis))
 
 
 @testing.parameterize(*testing.product({


### PR DESCRIPTION
Fixes #3640

The aforementioned issue only happened when `argmax/min` was called without an `axis` defined. Now `argmin/max` returns a scalar array with the index.