### PR TITLE
Remove use of `distutils.utils`

### DIFF
--- a/install/cupy_builder/install_build.py
+++ b/install/cupy_builder/install_build.py
@@ -1,9 +1,9 @@
 # mypy: ignore-errors
 
 import contextlib
-import distutils.util
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -85,7 +85,7 @@ def get_cuda_path():
 def get_nvcc_path() -> List[str]:
     nvcc = os.environ.get('NVCC', None)
     if nvcc:
-        return distutils.util.split_quoted(nvcc)
+        return shlex.split(nvcc)
 
     cuda_path = get_cuda_path()
     if cuda_path is None:
@@ -106,7 +106,7 @@ def get_nvcc_path() -> List[str]:
 def get_hipcc_path() -> List[str]:
     hipcc = os.environ.get('HIPCC', None)
     if hipcc:
-        return distutils.util.split_quoted(hipcc)
+        return shlex.split(hipcc)
 
     rocm_path = get_rocm_path()
     if rocm_path is None:


### PR DESCRIPTION
Part of https://github.com/cupy/cupy/issues/4983#issuecomment-1020816566

`distutils.utils.split_quoted` and `shlex.split` is interchangable except for the difference of the control character handling. I think there's no problem in our case.
https://stackoverflow.com/questions/54999301/what-is-the-difference-between-distutils-util-split-quoted-and-shlex-split