### PR TITLE
Adds `scipy.special.jn`

### DIFF
--- a/cupyx/scipy/special/__init__.py
+++ b/cupyx/scipy/special/__init__.py
@@ -5,6 +5,7 @@ from cupyx.scipy.special._bessel import i1  # NOQA
 from cupyx.scipy.special._bessel import i1e  # NOQA
 from cupyx.scipy.special._bessel import j0  # NOQA
 from cupyx.scipy.special._bessel import j1  # NOQA
+from cupyx.scipy.special._bessel import jn  # NOQA
 from cupyx.scipy.special._bessel import y0  # NOQA
 from cupyx.scipy.special._bessel import y1  # NOQA
 from cupyx.scipy.special._bessel import yn  # NOQA

--- a/cupyx/scipy/special/_bessel.py
+++ b/cupyx/scipy/special/_bessel.py
@@ -20,13 +20,14 @@ j1 = _core.create_ufunc(
 
     ''')
 
+
 jn = _core.create_ufunc(
     'cupyx_scipy_special_jn',
     (('ff->f', 'out0 = jnf((int)in0, in1)'),
      'dd->d'),
     'out0 = jn((int)in0, in1)',
     doc='''Bessel function of the first kind of order n.
-    
+
     Args:
         n (cupy.ndarray): order (integer)
         x (cupy.ndarray): argument (float)

--- a/cupyx/scipy/special/_bessel.py
+++ b/cupyx/scipy/special/_bessel.py
@@ -20,6 +20,22 @@ j1 = _core.create_ufunc(
 
     ''')
 
+jn = _core.create_ufunc(
+    'cupyx_scipy_special_jn', ('f->f', 'd->d'),
+    'out0 = jn(in0)',
+    doc='''Bessel function of the first kind of order n.
+    
+    Args:
+        n (cupy.ndarray): order (integer)
+        x (cupy.ndarray): argument (float)
+
+    Returns:
+        cupy.ndarray: The result.
+
+    .. seealso:: :meth:`scipy.special.jn`
+
+    ''')
+
 
 y0 = _core.create_ufunc(
     'cupyx_scipy_special_y0', ('f->f', 'd->d'),

--- a/cupyx/scipy/special/_bessel.py
+++ b/cupyx/scipy/special/_bessel.py
@@ -21,8 +21,10 @@ j1 = _core.create_ufunc(
     ''')
 
 jn = _core.create_ufunc(
-    'cupyx_scipy_special_jn', ('f->f', 'd->d'),
-    'out0 = jn(in0)',
+    'cupyx_scipy_special_jn',
+    (('ff->f', 'out0 = jnf((int)in0, in1)'),
+     'dd->d'),
+    'out0 = jn((int)in0, in1)',
     doc='''Bessel function of the first kind of order n.
     
     Args:

--- a/docs/source/reference/scipy_special.rst
+++ b/docs/source/reference/scipy_special.rst
@@ -13,6 +13,7 @@ Bessel functions
 
    j0
    j1
+   jn
    y0
    y1
    yn

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_bessel.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_bessel.py
@@ -51,6 +51,14 @@ class TestSpecial:
         a = xp.linspace(-10, 10, 100, dtype=dtype)
         return scp.special.yn(n[:, xp.newaxis], a[xp.newaxis, :])
 
+    @testing.for_dtypes('iId', name='order_dtype')
+    @testing.for_dtypes('efd')
+    @testing.numpy_cupy_allclose(atol=1e-12, scipy_name='scp')
+    def test_jn(self, xp, scp, dtype, order_dtype):
+        n = xp.arange(0, 10, dtype=order_dtype)
+        a = xp.linspace(-10, 10, 100, dtype=dtype)
+        return scp.special.jn(n[:, xp.newaxis], a[xp.newaxis, :])
+
 
 @testing.gpu
 @testing.with_requires('scipy')


### PR DESCRIPTION
Closes #6982 

This implementation does not support complex numbers

BTW, there's simliar function, called `yn`, that also implemented in cuda math library both for float and double, has the same signature, but it has [only float64 implementation](https://github.com/cupy/cupy/blob/master/cupyx/scipy/special/_bessel.py#L46) -> has no performance gain from using float32.
Benchmark results (GPU time only)
| function | float32 | float64 |
| :----        | :-----    | :-----    |
| jn            | 65.302 us   +/-20.038 | 384.330 us   +/-13.284 | 
| yn           | 364.019 us   +/-18.958 | 369.111 us   +/-13.074 |
 
Rewriting `yn` the same way as I made with `jn` makes great perf gain with floats. https://github.com/1MrEnot/cupy/commit/f89952f143a5416a2dc378c01c191b5d72ccfcfe
 All tests passed without any changes.
Benchmark results (GPU time only)
| function | float32 | float64 |
| :----        | :-----    | :-----    |
| jn            | 61.408 us   +/-13.355 | 383.780 us   +/-11.177 | 
| yn           | 58.458 us   +/-11.620 | 370.120 us   +/-11.019 |

If it's ok, I can make a separate PR or add this commit to current one. 