### PR TITLE
Initial experimental & private `cupyx.distributed._array` implementation

### DIFF
--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -1188,8 +1188,8 @@ cdef class ufunc:
 
         """
         for arg in args:
-            if hasattr(arg, '__cupy_prepare_elementwise_kernel__'):
-                return arg.__cupy_prepare_elementwise_kernel__(
+            if hasattr(arg, '__cupy_override_elementwise_kernel__'):
+                return arg.__cupy_override_elementwise_kernel__(
                     self, *args, **kwargs)
 
         if _fusion_thread_local.is_fusing():

--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -857,8 +857,8 @@ cdef class ElementwiseKernel:
                 'but given {}.'.format(
                     self.name, self.nin, self.nargs, n_args))
         for arg in args:
-            if hasattr(arg, '__cupy_prepare_elementwise_kernel__'):
-                return arg.__cupy_prepare_elementwise_kernel__(
+            if hasattr(arg, '__cupy_override_elementwise_kernel__'):
+                return arg.__cupy_override_elementwise_kernel__(
                     self, *args, **kwargs)
         dev_id = device.get_device_id()
         arg_list = _preprocess_args(dev_id, args, True)

--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -856,6 +856,10 @@ cdef class ElementwiseKernel:
                 'It must be either {} or {} (with outputs), '
                 'but given {}.'.format(
                     self.name, self.nin, self.nargs, n_args))
+        for arg in args:
+            if hasattr(arg, '__cupy_prepare_elementwise_kernel__'):
+                return arg.__cupy_prepare_elementwise_kernel__(
+                    self, *args, **kwargs)
         dev_id = device.get_device_id()
         arg_list = _preprocess_args(dev_id, args, True)
 
@@ -1183,6 +1187,11 @@ cdef class ufunc:
             Output array or a tuple of output arrays.
 
         """
+        for arg in args:
+            if hasattr(arg, '__cupy_prepare_elementwise_kernel__'):
+                return arg.__cupy_prepare_elementwise_kernel__(
+                    self, *args, **kwargs)
+
         if _fusion_thread_local.is_fusing():
             return _fusion_thread_local.call_ufunc(self, *args, **kwargs)
 

--- a/cupy/cuda/memory.pxd
+++ b/cupy/cuda/memory.pxd
@@ -16,7 +16,6 @@ cdef class BaseMemory:
         public int device_id
 
 
-@cython.final
 cdef class MemoryPointer:
 
     cdef:

--- a/cupyx/distributed/_array.py
+++ b/cupyx/distributed/_array.py
@@ -1,0 +1,189 @@
+import cupy
+import numpy
+
+
+class _MultiDeviceDummyMemory(cupy.cuda.Memory):
+    pass
+
+
+class _MultiDeviceDummyPointer(cupy.cuda.MemoryPointer):
+    @property
+    def device(self):
+        # This override is needed to assign an invalid device id
+        return cupy.cuda.device.Device(-1)
+
+
+class _DistributedArray(cupy.ndarray):
+    # Explicitly disable indexing, view, broadcast
+    def __new__(cls, shape, dtype, chunks, axis, tile_size, devices):
+        # Create a dummy memptr for the array data, we will also
+        # override its device methods
+        # memptr is needed to avoid actual device allocation on array init
+        # we need to generate other devices
+        mem = _MultiDeviceDummyMemory(0)
+        memptr = _MultiDeviceDummyPointer(mem, 0)
+        obj = super().__new__(cls, shape, dtype, memptr=memptr)
+        obj._chunks = chunks
+        obj._tile_size = tile_size
+        obj._mem = mem
+        obj._axis = axis
+        return obj
+
+    def __array_finalize__(self, obj):
+        if obj is None:
+            return
+        self._chunks = getattr(obj, 'chunks', None)
+        self._tile_size = getattr(obj, 'tile_size', None)
+        self._axis = getattr(obj, 'axis', None)
+        self._mem = getattr(obj, 'mem', None)
+
+    def _get_chunk(self, i):
+        return self._chunks[i]
+
+    def _prepare_args(self, dist_args, regular_args, device):
+        # Dist arrays must have chunks of compatible shapes, otherwise
+        # hard error?
+        # In case that they are of different, but broadcastable shapes
+        # Data movement may be needed
+        # First: Support only same shape chunks
+        args = []
+        c_shape = None
+        for (i, arg) in dist_args:
+            chunk = arg._get_chunk(device)
+            args.append((i, chunk))
+            if c_shape is None:
+                c_shape = chunk.shape
+            # All the chunks must have the same shape or
+            # broadcastable one, if broadcastable, the array must have been
+            # split in the same axis?
+            if chunk.shape != c_shape:
+                raise RuntimeError(
+                    'Operating distributed arrays of different chunk sizes'
+                    ' together is not supported')
+
+        # Case of X.T and other data movement requiring cases not supported
+        # TODO(ecastill) add support for operands being non distributed arrays
+        # 1. Check if the regular arrays are on the specified device or
+        #    peer access is enabled
+        # 2. Check that their shape is compatible with the chunks
+        #    distributed arrays
+        # 3. Create views of this array and copy to the given device if needed
+        #    so that the chunks in the distributed operate with the right slice
+        if len(regular_args) > 0:
+            raise RuntimeError(
+                'Mix `cupy.ndarray` with distributed arrays is not currently'
+                'supported')
+
+        return args
+
+    def _get_execution_devices(self, dist_args):
+        devices = set()
+        for _, arg in dist_args:
+            # The key of chunks is the device id
+            for dev in arg._chunks:
+                devices.add(dev)
+        # TODO: Assert that all the args have chunks in the same devices
+        return devices
+
+    def _execute_kernel(self, kernel, args, kwargs):
+        distributed_arrays = []
+        regular_arrays = []
+        for i, arg in enumerate(args):
+            if isinstance(arg, _DistributedArray):
+                distributed_arrays.append((i, arg))
+            elif isinstance(arg, cupy.ndarray):
+                regular_arrays.append((i, arg))
+
+        # Do it for kwargs too
+        for k, arg in kwargs.items():
+            if isinstance(arg, _DistributedArray):
+                distributed_arrays.append((k, arg))
+            elif isinstance(arg, cupy.ndarray):
+                regular_arrays.append((k, arg))
+
+        args = list(args)
+        # TODO check that regular devices are in valid devices
+        devices = self._get_execution_devices(distributed_arrays)
+        dev_outs = {}
+        dtype = None
+        for dev in devices:
+            # For all the distributed arrays check the shape of the chunks
+            # if the shapes of the chunks are the same we can just execute
+            # the kernel otherwise we need to check broadcastability
+            # and if they are views with different overlapping chunks
+            # If we have regular arrays we need to check if peer access is
+            # enabled to avoid copy, otherwise Check broadcastabilitly
+            # to the WHOLE shape Split it or copy it if needed
+            array_args = self._prepare_args(
+                distributed_arrays, regular_arrays, dev)
+            for (i, arg) in array_args:
+                if isinstance(i, int):
+                    args[i] = arg
+                else:
+                    kwargs[i] = arg
+            with cupy.cuda.Device(dev):
+                out = kernel(*args, **kwargs)
+                dtype = out.dtype
+                dev_outs[dev] = out
+
+        for out in dev_outs.values():
+            if not isinstance(out, cupy.ndarray):
+                raise RuntimeError(
+                    'kernels returning other than single array not supported')
+
+        return _DistributedArray(
+            self.shape, dtype, dev_outs,
+            self._axis, self._tile_size, devices)
+
+    def __cupy_prepare_elementwise_kernel__(self, kernel, *args, **kwargs):
+        # This defines a protocol to be called from elementwise kernel
+        # to override some of the ops done there
+        outs = self._execute_kernel(kernel, args, kwargs)
+        return outs
+
+    def asnumpy(self):
+        # Coalesce it in a single array
+        return numpy.concatenate(self._chunks.values(), axis=self._axis)
+
+
+def _split_tiles(array, nr_splits):
+    # TODO(ecastill) support arbitrary tiles shape
+    axis = nr_splits.argmax()
+    ind = nr_splits[axis]
+    if isinstance(array, cupy.ndarray):
+        arrs = [cupy.ascontiguousarray(a)
+                for a in cupy.array_split(array, int(ind), int(axis))]
+    else:
+        arrs = numpy.array_split(array, ind, axis)
+    return axis, arrs
+
+
+def array(array, devices, tile_shape):
+    """ Create an array that is splitted accross multiple devices in the
+    same host.
+    """
+    if not isinstance(array, (numpy.ndarray, cupy.ndarray)):
+        raise TypeError('`array` needs to be a numpy or cupy array')
+    # 1. Check that array_size / tile_shape == len(devices)
+    array_shape = numpy.array(array.shape, dtype=numpy.int32)
+    tile_shape = numpy.array(tile_shape, dtype=numpy.int32)
+    nr_splits = numpy.ceil(array_shape / tile_shape)
+    if nr_splits[nr_splits > 1].size > 1:
+        raise RuntimeError(
+            'Currently only sharding across a single axis is allowed')
+
+    assert len(tile_shape) == len(array_shape)
+
+    nr_chunks = numpy.prod(nr_splits)
+
+    if nr_chunks != len(devices):
+        raise RuntimeError(
+            'Array chunks must match the amount of devices')
+
+    axis, arrs = _split_tiles(array, nr_splits)
+    cp_chunks = {}
+    for arr, dev in zip(arrs, devices):
+        with cupy.cuda.Device(dev):
+            cp_chunks[dev] = cupy.array(arr)
+    return _DistributedArray(
+        array_shape, array.dtype, cp_chunks, axis, tile_shape, devices)

--- a/cupyx/distributed/_array.py
+++ b/cupyx/distributed/_array.py
@@ -143,7 +143,8 @@ class _DistributedArray(cupy.ndarray):
 
     def asnumpy(self):
         # Coalesce it in a single array
-        return numpy.concatenate(self._chunks.values(), axis=self._axis)
+        chunks = [cupy.asnumpy(c) for c in self._chunks.values()]
+        return numpy.concatenate(chunks, axis=self._axis)
 
 
 def _split_tiles(array, nr_splits):

--- a/cupyx/distributed/_array.py
+++ b/cupyx/distributed/_array.py
@@ -126,7 +126,7 @@ class _DistributedArray(cupy.ndarray):
             self.shape, dtype, dev_outs,
             self._axis, self._tile_size, devices)
 
-    def __cupy_prepare_elementwise_kernel__(self, kernel, *args, **kwargs):
+    def __cupy_override_elementwise_kernel__(self, kernel, *args, **kwargs):
         # This defines a protocol to be called from elementwise kernel
         # to override some of the ops done there
         outs = self._execute_kernel(kernel, args, kwargs)

--- a/tests/cupyx_tests/distributed_tests/test_array.py
+++ b/tests/cupyx_tests/distributed_tests/test_array.py
@@ -31,7 +31,7 @@ class TestDistributedArray:
         # Ensure no memory allocation other than the chunks
         assert da.data.ptr == 0
         assert da.shape == (8, 8)
-        assert mem_pool.used_bytes() == array.nbytes
+        assert mem_pool.used_bytes() >= array.nbytes
         testing.assert_array_equal(da._chunks[0], array[:4, :])
         testing.assert_array_equal(da._chunks[1], array[4:, :])
 

--- a/tests/cupyx_tests/distributed_tests/test_array.py
+++ b/tests/cupyx_tests/distributed_tests/test_array.py
@@ -1,0 +1,96 @@
+import pytest
+
+import numpy
+import cupy
+
+import cupyx.distributed._array
+from cupy import testing
+
+
+@pytest.fixture
+def mem_pool():
+    try:
+        old_pool = cupy.get_default_memory_pool()
+        pool = cupy.cuda.memory.MemoryPool()
+        cupy.cuda.memory.set_allocator(pool.malloc)
+        yield pool
+    finally:
+        pool.set_limit(size=0)
+        pool.free_all_blocks()
+        cupy.cuda.memory.set_allocator(old_pool.malloc)
+
+
+@testing.multi_gpu(2)
+class TestDistributedArray:
+    def test_array_creation_from_numpy(self, mem_pool):
+        array = numpy.arange(64).reshape(8, 8)
+        assert mem_pool.used_bytes() == 0
+        da = cupyx.distributed._array.array(array, (0, 1), (4, 8))
+        assert da.device.id == -1
+        # Ensure no memory allocation other than the chunks
+        assert da.data.ptr == 0
+        assert da.shape == (8, 8)
+        assert mem_pool.used_bytes() == array.nbytes
+        testing.assert_array_equal(da._chunks[0], array[:4, :])
+        testing.assert_array_equal(da._chunks[1], array[4:, :])
+
+    def test_array_creation_from_cupy(self, mem_pool):
+        array = cupy.arange(64).reshape(8, 8)
+        assert mem_pool.used_bytes() == array.nbytes
+        da = cupyx.distributed._array.array(array, (0, 1), (4, 8))
+        assert da.device.id == -1
+        # Ensure no memory allocation other than chunks & original array
+        assert da.data.ptr == 0
+        assert da.shape == (8, 8)
+        assert mem_pool.used_bytes() == 2 * array.nbytes
+        testing.assert_array_equal(da._chunks[0], array[:4, :])
+        testing.assert_array_equal(da._chunks[1], array[4:, :])
+
+    def test_invalid_array_creation(self):
+        with pytest.raises(TypeError, match=r'numpy or cupy'):
+            cupyx.distributed._array.array([1, 2, 3], (0, 1), (2, 8))
+
+    def test_array_creation_invalid_splits(self):
+        array = cupy.arange(64).reshape(8, 8)
+        with pytest.raises(RuntimeError, match=r'single axis'):
+            cupyx.distributed._array.array(array, (0, 1), (4, 4))
+
+    def test_array_creation_more_chunks_than_devices(self):
+        array = cupy.arange(64).reshape(8, 8)
+        with pytest.raises(RuntimeError, match=r'amount of devices'):
+            cupyx.distributed._array.array(array, (0, 1), (2, 8))
+
+    @pytest.mark.parametrize('split_shape', [(8, 4), (4, 8)])
+    def test_ufuncs(self, split_shape):
+        # TODO parameterize split shape
+        np_a = numpy.arange(64).reshape(8, 8)
+        np_b = numpy.arange(64).reshape(8, 8) * 2
+        np_r = numpy.sin(np_a * np_b)
+        d_a = cupyx.distributed._array.array(np_a, (0, 1), split_shape)
+        d_b = cupyx.distributed._array.array(np_b, (0, 1), split_shape)
+        d_r = cupy.sin(d_a * d_b)
+        testing.assert_array_almost_equal(d_r.asnumpy(), np_r)
+
+    @pytest.mark.parametrize('split_shape', [(8, 4), (4, 8)])
+    def test_elementwise_kernel(self, split_shape):
+        custom_kernel = cupy.ElementwiseKernel(
+           'float32 x, float32 y',
+           'float32 z',
+           'z = (x - y) * (x - y)',
+           'custom')
+        # TODO parameterize split shape
+        np_a = numpy.arange(64).reshape(8, 8).astype(numpy.float32)
+        np_b = (numpy.arange(64).reshape(8, 8) * 2.0).astype(numpy.float32)
+        np_r = (np_a - np_b) * (np_a - np_b)
+        d_a = cupyx.distributed._array.array(np_a, (0, 1), split_shape)
+        d_b = cupyx.distributed._array.array(np_b, (0, 1), split_shape)
+        d_r = custom_kernel(d_a, d_b)
+        testing.assert_array_almost_equal(d_r.asnumpy(), np_r)
+
+    def test_incompatible_chunk_shapes(self):
+        np_a = numpy.arange(64).reshape(8, 8)
+        np_b = numpy.arange(64).reshape(8, 8) * 2
+        d_a = cupyx.distributed._array.array(np_a, (0, 1), (4, 8))
+        d_b = cupyx.distributed._array.array(np_b, (0, 1), (8, 4))
+        with pytest.raises(RuntimeError, match=r'chunk sizes'):
+            cupy.sin(d_a * d_b)

--- a/tests/cupyx_tests/distributed_tests/test_array.py
+++ b/tests/cupyx_tests/distributed_tests/test_array.py
@@ -24,19 +24,19 @@ def mem_pool():
 @testing.multi_gpu(2)
 class TestDistributedArray:
     def test_array_creation_from_numpy(self, mem_pool):
-        array = numpy.arange(64).reshape(8, 8)
+        array = numpy.arange(64, dtype='q').reshape(8, 8)
         assert mem_pool.used_bytes() == 0
         da = cupyx.distributed._array.array(array, (0, 1), (4, 8))
         assert da.device.id == -1
         # Ensure no memory allocation other than the chunks
         assert da.data.ptr == 0
         assert da.shape == (8, 8)
-        assert mem_pool.used_bytes() >= array.nbytes
+        assert mem_pool.used_bytes() == array.nbytes
         testing.assert_array_equal(da._chunks[0], array[:4, :])
         testing.assert_array_equal(da._chunks[1], array[4:, :])
 
     def test_array_creation_from_cupy(self, mem_pool):
-        array = cupy.arange(64).reshape(8, 8)
+        array = cupy.arange(64, dtype='q').reshape(8, 8)
         assert mem_pool.used_bytes() == array.nbytes
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', cupy._util.PerformanceWarning)


### PR DESCRIPTION
Adds a private experimental API `cupyx.distributed._array` that is wip and subject to change.

Currently it works with ufuncs and custom elementwise kernels but with lots of limitations.

This is only intra-node, won't support inter-node communication like dask does.