### PR TITLE
Expose pairwise distance functions

### DIFF
--- a/cupyx/scipy/spatial/distance.py
+++ b/cupyx/scipy/spatial/distance.py
@@ -254,7 +254,7 @@ def hamming(u, v):
     in both `u` and `v` that are not in the exact same position:
 
     .. math::
-        d(u, v) = \\frac{1}{n} \sum_{k=0}^n u_i \\neq v_i
+        d(u, v) = \\frac{1}{n} \\sum_{k=0}^n u_i \\neq v_i
 
     where :math:`x \\neq y` is one if :math:`x` is different from :math:`y`
     and zero otherwise.
@@ -280,7 +280,7 @@ def euclidean(u, v):
     The Euclidean distance is defined as
 
     .. math::
-        d(u, v) = \\left(\sum_{i} (u_i - v_i)^2\\right)^{\sfrac{1}{2}}
+        d(u, v) = \\left(\\sum_{i} (u_i - v_i)^2\\right)^{\\sfrac{1}{2}}
 
     Args:
         u (array_like): Input array of size (N,)
@@ -331,7 +331,7 @@ def russellrao(u, v):
     in both `u` and `v` that are in the exact same position:
 
     .. math::
-        d(u, v) = \\frac{1}{n} \sum_{k=0}^n u_i = v_i
+        d(u, v) = \\frac{1}{n} \\sum_{k=0}^n u_i = v_i
 
     where :math:`x = y` is one if :math:`x` is different from :math:`y`
     and zero otherwise.

--- a/cupyx/scipy/spatial/distance.py
+++ b/cupyx/scipy/spatial/distance.py
@@ -406,7 +406,7 @@ def kl_divergence(u, v):
     The Kullback-Leibler divergence is defined as
 
     .. math::
-        KL(U \\| V) = \\sum_{i} U_i \log{\\left(\\frac{U_i}{V_i}\\right)}
+        KL(U \\| V) = \\sum_{i} U_i \\log{\\left(\\frac{U_i}{V_i}\\right)}
 
     Args:
         u (array_like): Input array of size (N,)

--- a/cupyx/scipy/spatial/distance.py
+++ b/cupyx/scipy/spatial/distance.py
@@ -124,6 +124,233 @@ def minkowski(u, v, p):
     return output_arr[0]
 
 
+def canberra(u, v):
+    """Compute the Canberra distance between two 1-D arrays.
+
+    The Canberra distance is defined as
+
+    .. math::
+        d(u, v) = \\sum_{i} \\frac{| u_i - v_i |}{|u_i| + |v_i|}
+
+    Args:
+        u (array_like): Input array of size (N,)
+        v (array_like): Input array of size (N,)
+
+    Returns:
+        canberra (double): The Canberra distance between vectors `u` and `v`.
+    """
+    u = cupy.asarray(u)
+    v = cupy.asarray(v)
+    output_arr = cupy.zeros((1,), dtype=u.dtype)
+    pairwise_distance(u, v, output_arr, "canberra")
+
+    return output_arr[0]
+
+
+def chebyshev(u, v):
+    """Compute the Chebyshev distance between two 1-D arrays.
+
+    The Chebyshev distance is defined as
+
+    .. math::
+        d(u, v) = \\max_{i} |u_i - v_i|
+
+    Args:
+        u (array_like): Input array of size (N,)
+        v (array_like): Input array of size (N,)
+
+    Returns:
+        chebyshev (double): The Chebyshev distance between vectors `u` and `v`.
+    """
+    u = cupy.asarray(u)
+    v = cupy.asarray(v)
+    output_arr = cupy.zeros((1,), dtype=u.dtype)
+    pairwise_distance(u, v, output_arr, "chebyshev")
+
+    return output_arr[0]
+
+
+def cityblock(u, v):
+    """Compute the City Block (Manhattan) distance between two 1-D arrays.
+
+    The City Block distance is defined as
+
+    .. math::
+        d(u, v) = \\sum_{i} |u_i - v_i|
+
+    Args:
+        u (array_like): Input array of size (N,)
+        v (array_like): Input array of size (N,)
+
+    Returns:
+        cityblock (double): The City Block distance between
+        vectors `u` and `v`.
+    """
+    u = cupy.asarray(u)
+    v = cupy.asarray(v)
+    output_arr = cupy.zeros((1,), dtype=u.dtype)
+    pairwise_distance(u, v, output_arr, "cityblock")
+
+    return output_arr[0]
+
+
+def correlation(u, v):
+    """Compute the correlation distance between two 1-D arrays.
+
+    The correlation distance is defined as
+
+    .. math::
+        d(u, v) = 1 - \\frac{(u - \\bar{u}) \\cdot (v - \\bar{v})}{
+        \\|(u - \\bar{u})\\|_2 \\|(v - \\bar{v})\\|_2}
+
+    where :math:`\\bar{u}` is the mean of the elements of :math:`u` and
+    :math:`x \\cdot y` is the dot product.
+
+    Args:
+        u (array_like): Input array of size (N,)
+        v (array_like): Input array of size (N,)
+
+    Returns:
+        correlation (double): The correlation distance between
+        vectors `u` and `v`.
+    """
+    u = cupy.asarray(u)
+    v = cupy.asarray(v)
+    output_arr = cupy.zeros((1,), dtype=u.dtype)
+    pairwise_distance(u, v, output_arr, "correlation")
+
+    return output_arr[0]
+
+
+def cosine(u, v):
+    """Compute the Cosine distance between two 1-D arrays.
+
+    The Cosine distance is defined as
+
+    .. math::
+        d(u, v) = 1 - \\frac{u \\cdot v}{\\|u\\|_2 \\|v\\|_2}
+
+    where :math:`x \\cdot y` is the dot product.
+
+    Args:
+        u (array_like): Input array of size (N,)
+        v (array_like): Input array of size (N,)
+
+    Returns:
+        cosine (double): The Cosine distance between vectors `u` and `v`.
+    """
+    u = cupy.asarray(u)
+    v = cupy.asarray(v)
+    output_arr = cupy.zeros((1,), dtype=u.dtype)
+    pairwise_distance(u, v, output_arr, "cosine")
+
+    return output_arr[0]
+
+
+def hamming(u, v):
+    """Compute the Hamming distance between two 1-D arrays.
+
+    The Hamming distance is defined as the proportion of elements
+    in both `u` and `v` that are not in the exact same position:
+
+    .. math::
+        d(u, v) = \\frac{1}{n} \sum_{k=0}^n u_i \\neq v_i
+
+    where :math:`x \\neq y` is one if :math:`x` is different from :math:`y`
+    and zero otherwise.
+
+    Args:
+        u (array_like): Input array of size (N,)
+        v (array_like): Input array of size (N,)
+
+    Returns:
+        hamming (double): The Hamming distance between vectors `u` and `v`.
+    """
+    u = cupy.asarray(u)
+    v = cupy.asarray(v)
+    output_arr = cupy.zeros((1,), dtype=u.dtype)
+    pairwise_distance(u, v, output_arr, "hamming")
+
+    return output_arr[0]
+
+
+def euclidean(u, v):
+    """Compute the Euclidean distance between two 1-D arrays.
+
+    The Euclidean distance is defined as
+
+    .. math::
+        d(u, v) = \\left(\sum_{i} (u_i - v_i)^2\\right)^{\sfrac{1}{2}}
+
+    Args:
+        u (array_like): Input array of size (N,)
+        v (array_like): Input array of size (N,)
+
+    Returns:
+        euclidean (double): The Euclidean distance between vectors `u` and `v`.
+    """
+    u = cupy.asarray(u)
+    v = cupy.asarray(v)
+    output_arr = cupy.zeros((1,), dtype=u.dtype)
+    pairwise_distance(u, v, output_arr, "euclidean")
+
+    return output_arr[0]
+
+
+def jensenshannon(u, v):
+    """Compute the Jensen-Shannon distance between two 1-D arrays.
+
+    The Jensen-Shannon distance is defined as
+
+    .. math::
+        d(u, v) = \\sqrt{\\frac{KL(u \\| m) + KL(v \\| m)}{2}}
+
+    where :math:`KL` is the Kullback-Leibler divergence and :math:`m` is the
+    pointwise mean of `u` and `v`.
+
+    Args:
+        u (array_like): Input array of size (N,)
+        v (array_like): Input array of size (N,)
+
+    Returns:
+        jensenshannon (double): The Jensen-Shannon distance between
+        vectors `u` and `v`.
+    """
+    u = cupy.asarray(u)
+    v = cupy.asarray(v)
+    output_arr = cupy.zeros((1,), dtype=u.dtype)
+    pairwise_distance(u, v, output_arr, "jensenshannon")
+
+    return output_arr[0]
+
+
+def russellrao(u, v):
+    """Compute the Russell-Rao distance between two 1-D arrays.
+
+    The Russell-Rao distance is defined as the proportion of elements
+    in both `u` and `v` that are in the exact same position:
+
+    .. math::
+        d(u, v) = \\frac{1}{n} \sum_{k=0}^n u_i = v_i
+
+    where :math:`x = y` is one if :math:`x` is different from :math:`y`
+    and zero otherwise.
+
+    Args:
+        u (array_like): Input array of size (N,)
+        v (array_like): Input array of size (N,)
+
+    Returns:
+        hamming (double): The Hamming distance between vectors `u` and `v`.
+    """
+    u = cupy.asarray(u)
+    v = cupy.asarray(v)
+    output_arr = cupy.zeros((1,), dtype=u.dtype)
+    pairwise_distance(u, v, output_arr, "russellrao")
+
+    return output_arr[0]
+
+
 def cdist(XA, XB, metric='euclidean', out=None, **kwargs):
     """Compute distance between each pair of the two collections of inputs.
 

--- a/cupyx/scipy/spatial/distance.py
+++ b/cupyx/scipy/spatial/distance.py
@@ -351,6 +351,79 @@ def russellrao(u, v):
     return output_arr[0]
 
 
+def sqeuclidean(u, v):
+    """Compute the squared Euclidean distance between two 1-D arrays.
+
+    The squared Euclidean distance is defined as
+
+    .. math::
+        d(u, v) = \\sum_{i} (u_i - v_i)^2
+
+    Args:
+        u (array_like): Input array of size (N,)
+        v (array_like): Input array of size (N,)
+
+    Returns:
+        sqeuclidean (double): The squared Euclidean distance between
+        vectors `u` and `v`.
+    """
+    u = cupy.asarray(u)
+    v = cupy.asarray(v)
+    output_arr = cupy.zeros((1,), dtype=u.dtype)
+    pairwise_distance(u, v, output_arr, "sqeuclidean")
+
+    return output_arr[0]
+
+
+def hellinger(u, v):
+    """Compute the Hellinger distance between two 1-D arrays.
+
+    The Hellinger distance is defined as
+
+    .. math::
+        d(u, v) = \\frac{1}{\\sqrt{2}} \\sqrt{
+            \\sum_{i} (\\sqrt{u_i} - \\sqrt{v_i})^2}
+
+    Args:
+        u (array_like): Input array of size (N,)
+        v (array_like): Input array of size (N,)
+
+    Returns:
+        hellinger (double): The Hellinger distance between
+        vectors `u` and `v`.
+    """
+    u = cupy.asarray(u)
+    v = cupy.asarray(v)
+    output_arr = cupy.zeros((1,), dtype=u.dtype)
+    pairwise_distance(u, v, output_arr, "hellinger")
+
+    return output_arr[0]
+
+
+def kl_divergence(u, v):
+    """Compute the Kullback-Leibler divergence between two 1-D arrays.
+
+    The Kullback-Leibler divergence is defined as
+
+    .. math::
+        KL(U \\| V) = \\sum_{i} U_i \log{\\left(\\frac{U_i}{V_i}\\right)}
+
+    Args:
+        u (array_like): Input array of size (N,)
+        v (array_like): Input array of size (N,)
+
+    Returns:
+        kl_divergence (double): The Kullback-Leibler divergence between
+        vectors `u` and `v`.
+    """
+    u = cupy.asarray(u)
+    v = cupy.asarray(v)
+    output_arr = cupy.zeros((1,), dtype=u.dtype)
+    pairwise_distance(u, v, output_arr, "kl_divergence")
+
+    return output_arr[0]
+
+
 def cdist(XA, XB, metric='euclidean', out=None, **kwargs):
     """Compute distance between each pair of the two collections of inputs.
 

--- a/docs/source/reference/scipy_spatial_distance.rst
+++ b/docs/source/reference/scipy_spatial_distance.rst
@@ -44,4 +44,7 @@ Distance functions between two numeric vectors `u` and `v`. Computing distances 
    euclidean
    jensenshannon
    russellrao
+   sqeuclidean
+   hellinger
+   kl_divergence
 

--- a/docs/source/reference/scipy_spatial_distance.rst
+++ b/docs/source/reference/scipy_spatial_distance.rst
@@ -23,6 +23,7 @@ Distance matrix computation from a collection of raw observation vectors stored 
    :toctree: generated/
 
    cdist
+   distance_matrix
 
 
 Distance functions
@@ -34,4 +35,13 @@ Distance functions between two numeric vectors `u` and `v`. Computing distances 
    :toctree: generated/
 
    minkowski
+   canberra
+   chebyshev
+   cityblock
+   correlation
+   cosine
+   hamming
+   euclidean
+   jensenshannon
+   russellrao
 

--- a/tests/cupyx_tests/scipy_tests/spatial_tests/test_distance.py
+++ b/tests/cupyx_tests/scipy_tests/spatial_tests/test_distance.py
@@ -122,3 +122,67 @@ class TestDistanceFunction(unittest.TestCase):
         a = self._make_matrix(xp, self.dtype, self.order)
         out = scp.spatial.distance.minkowski(a, a, p=self.p)
         return out
+
+    @testing.numpy_cupy_equal(scipy_name='scp')
+    def test_canberra_(self, xp, scp):
+
+        a = self._make_matrix(xp, self.dtype, self.order)
+        out = scp.spatial.distance.canberra(a, a, p=self.p)
+        return out
+
+    @testing.numpy_cupy_equal(scipy_name='scp')
+    def test_chebyshev_(self, xp, scp):
+
+        a = self._make_matrix(xp, self.dtype, self.order)
+        out = scp.spatial.distance.chebyshev(a, a, p=self.p)
+        return out
+
+    @testing.numpy_cupy_equal(scipy_name='scp')
+    def test_cityblock_(self, xp, scp):
+
+        a = self._make_matrix(xp, self.dtype, self.order)
+        out = scp.spatial.distance.cityblock(a, a, p=self.p)
+        return out
+
+    @testing.numpy_cupy_equal(scipy_name='scp')
+    def test_correlation_(self, xp, scp):
+
+        a = self._make_matrix(xp, self.dtype, self.order)
+        out = scp.spatial.distance.correlation(a, a, p=self.p)
+        return out
+
+    @testing.numpy_cupy_equal(scipy_name='scp')
+    def test_cosine_(self, xp, scp):
+
+        a = self._make_matrix(xp, self.dtype, self.order)
+        out = scp.spatial.distance.cosine(a, a, p=self.p)
+        return out
+
+    @testing.numpy_cupy_equal(scipy_name='scp')
+    def test_hamming_(self, xp, scp):
+
+        a = self._make_matrix(xp, self.dtype, self.order)
+        out = scp.spatial.distance.hamming(a, a, p=self.p)
+        return out
+
+    @testing.numpy_cupy_equal(scipy_name='scp')
+    def test_euclidean_(self, xp, scp):
+
+        a = self._make_matrix(xp, self.dtype, self.order)
+        out = scp.spatial.distance.euclidean(a, a, p=self.p)
+        return out
+
+    @testing.numpy_cupy_equal(scipy_name='scp')
+    def test_jensenshannon_(self, xp, scp):
+
+        a = self._make_matrix(xp, self.dtype, self.order)
+        out = scp.spatial.distance.jensenshannon(a, a, p=self.p)
+        return out
+
+    @testing.numpy_cupy_equal(scipy_name='scp')
+    def test_russellrao_(self, xp, scp):
+
+        a = self._make_matrix(xp, self.dtype, self.order)
+        out = scp.spatial.distance.russellrao(a, a, p=self.p)
+        return out
+

--- a/tests/cupyx_tests/scipy_tests/spatial_tests/test_distance.py
+++ b/tests/cupyx_tests/scipy_tests/spatial_tests/test_distance.py
@@ -112,7 +112,7 @@ class TestDistanceMatrix(unittest.TestCase):
 class TestDistanceFunction(unittest.TestCase):
 
     def _make_matrix(self, xp, dtype, order):
-        shape = (1, self.cols)
+        shape = (1, self.cols) if xp is cupy else (self.cols,)
         return testing.shaped_random(shape, xp, dtype=dtype,
                                      scale=1, order=order)
 
@@ -127,68 +127,70 @@ class TestDistanceFunction(unittest.TestCase):
     def test_canberra_(self, xp, scp):
 
         a = self._make_matrix(xp, self.dtype, self.order)
-        out = scp.spatial.distance.canberra(a, a, p=self.p)
+        out = scp.spatial.distance.canberra(a, a)
         return out
 
     @testing.numpy_cupy_equal(scipy_name='scp')
     def test_chebyshev_(self, xp, scp):
 
         a = self._make_matrix(xp, self.dtype, self.order)
-        out = scp.spatial.distance.chebyshev(a, a, p=self.p)
+        out = scp.spatial.distance.chebyshev(a, a)
         return out
 
     @testing.numpy_cupy_equal(scipy_name='scp')
     def test_cityblock_(self, xp, scp):
 
         a = self._make_matrix(xp, self.dtype, self.order)
-        out = scp.spatial.distance.cityblock(a, a, p=self.p)
+        out = scp.spatial.distance.cityblock(a, a)
         return out
 
-    @testing.numpy_cupy_equal(scipy_name='scp')
+    @testing.numpy_cupy_array_almost_equal(scipy_name='scp', type_check=False)
     def test_correlation_(self, xp, scp):
 
         a = self._make_matrix(xp, self.dtype, self.order)
-        out = scp.spatial.distance.correlation(a, a, p=self.p)
-        return out
+        out = scp.spatial.distance.correlation(a, a)
+        return xp.asarray(out)
 
-    @testing.numpy_cupy_equal(scipy_name='scp')
+    @testing.numpy_cupy_array_almost_equal(scipy_name='scp', type_check=False)
     def test_cosine_(self, xp, scp):
 
         a = self._make_matrix(xp, self.dtype, self.order)
-        out = scp.spatial.distance.cosine(a, a, p=self.p)
-        return out
+        out = scp.spatial.distance.cosine(a, a)
+        return xp.asarray(out)
 
     @testing.numpy_cupy_equal(scipy_name='scp')
     def test_hamming_(self, xp, scp):
 
         a = self._make_matrix(xp, self.dtype, self.order)
-        out = scp.spatial.distance.hamming(a, a, p=self.p)
+        out = scp.spatial.distance.hamming(a, a)
         return out
 
     @testing.numpy_cupy_equal(scipy_name='scp')
     def test_euclidean_(self, xp, scp):
 
         a = self._make_matrix(xp, self.dtype, self.order)
-        out = scp.spatial.distance.euclidean(a, a, p=self.p)
+        out = scp.spatial.distance.euclidean(a, a)
         return out
 
     @testing.numpy_cupy_equal(scipy_name='scp')
     def test_jensenshannon_(self, xp, scp):
 
         a = self._make_matrix(xp, self.dtype, self.order)
-        out = scp.spatial.distance.jensenshannon(a, a, p=self.p)
+        out = scp.spatial.distance.jensenshannon(a, a)
         return out
 
-    @testing.numpy_cupy_equal(scipy_name='scp')
+    @testing.numpy_cupy_array_almost_equal(scipy_name='scp', type_check=False)
     def test_russellrao_(self, xp, scp):
 
         a = self._make_matrix(xp, self.dtype, self.order)
-        out = scp.spatial.distance.russellrao(a, a, p=self.p)
-        return out
+        a[a < 0.5] = 0
+        a[a >= 0.5] = 1
+        out = scp.spatial.distance.russellrao(a, a)
+        return xp.asarray(out)
 
     @testing.numpy_cupy_equal(scipy_name='scp')
     def test_sqeuclidean_(self, xp, scp):
 
         a = self._make_matrix(xp, self.dtype, self.order)
-        out = scp.spatial.distance.sqeuclidean(a, a, p=self.p)
+        out = scp.spatial.distance.sqeuclidean(a, a)
         return out

--- a/tests/cupyx_tests/scipy_tests/spatial_tests/test_distance.py
+++ b/tests/cupyx_tests/scipy_tests/spatial_tests/test_distance.py
@@ -185,4 +185,3 @@ class TestDistanceFunction(unittest.TestCase):
         a = self._make_matrix(xp, self.dtype, self.order)
         out = scp.spatial.distance.russellrao(a, a, p=self.p)
         return out
-

--- a/tests/cupyx_tests/scipy_tests/spatial_tests/test_distance.py
+++ b/tests/cupyx_tests/scipy_tests/spatial_tests/test_distance.py
@@ -185,3 +185,10 @@ class TestDistanceFunction(unittest.TestCase):
         a = self._make_matrix(xp, self.dtype, self.order)
         out = scp.spatial.distance.russellrao(a, a, p=self.p)
         return out
+
+    @testing.numpy_cupy_equal(scipy_name='scp')
+    def test_sqeuclidean_(self, xp, scp):
+
+        a = self._make_matrix(xp, self.dtype, self.order)
+        out = scp.spatial.distance.sqeuclidean(a, a, p=self.p)
+        return out


### PR DESCRIPTION
This PR exposes all the pairwise distance functions offered by RAFT, increasing the compatibility between `cupyx.scipy.distance` and `scipy.spatial.distance`