### PR TITLE
CI: Migrate to GAR from GCR

### DIFF
--- a/.pfnci/linux/main-flexci-prep.sh
+++ b/.pfnci/linux/main-flexci-prep.sh
@@ -6,7 +6,7 @@ set -ue
 
 env
 
-gcloud auth configure-docker
+gcloud auth configure-docker asia-northeast1-docker.pkg.dev
 
 for DF in $(find "$(dirname ${0})/tests" -name "*.Dockerfile" -type f); do
     echo "$(basename "${DF}" .Dockerfile)"

--- a/.pfnci/linux/main-flexci.sh
+++ b/.pfnci/linux/main-flexci.sh
@@ -20,7 +20,7 @@ fi
 # TODO(kmaehashi): Hack for CUDA 11.6+ until FlexCI base image update
 .pfnci/linux/update-cuda-driver.sh
 
-gcloud auth configure-docker
+gcloud auth configure-docker asia-northeast1-docker.pkg.dev
 
 echo "Starting: "${TARGET}""
 echo "****************************************************************************************************"

--- a/.pfnci/linux/run.sh
+++ b/.pfnci/linux/run.sh
@@ -49,7 +49,7 @@ main() {
 
   repo_root="$(cd "$(dirname "${BASH_SOURCE}")/../.."; pwd)"
   base_branch="$(cat "${repo_root}/.pfnci/BRANCH")"
-  docker_image="${DOCKER_IMAGE:-asia.gcr.io/pfn-public-ci/cupy-ci}:${TARGET}-${base_branch}"
+  docker_image="${DOCKER_IMAGE:-asia-northeast1-docker.pkg.dev/pfn-artifactregistry/tmp-public-ci-dlfw/cupy-ci}:${TARGET}-${base_branch}"
   docker_cache_from="${docker_image}"
   cache_archive="linux-${TARGET}-${base_branch}.tar.gz"
   cache_gcs_dir="${CACHE_GCS_DIR:-gs://tmp-asia-pfn-public-ci/cupy-ci/cache}"


### PR DESCRIPTION
Closes #6561.

GCS bucket has also been changed to region-only (no code changes needed).