### PR TITLE
Fix `cupy.apply_along_axis` for tuple retval

### DIFF
--- a/cupy/lib/_shape_base.py
+++ b/cupy/lib/_shape_base.py
@@ -42,9 +42,7 @@ def apply_along_axis(func1d, axis, arr, *args, **kwargs):
             'Cannot apply_along_axis when any iteration dimensions are 0'
         )
     res = func1d(inarr_view[ind0], *args, **kwargs)
-    if cupy.isscalar(res):
-        # scalar outputs need to be transfered to a device ndarray
-        res = cupy.asarray(res)
+    res = cupy.asarray(res)
 
     # build a buffer for storing evaluations of func1d.
     # remove the requested axis, and add the new ones on the end.
@@ -55,7 +53,8 @@ def apply_along_axis(func1d, axis, arr, *args, **kwargs):
     # save the first result, then compute and save all remaining results
     buff[ind0] = res
     for ind in inds:
-        buff[ind] = func1d(inarr_view[ind], *args, **kwargs)
+        out = func1d(inarr_view[ind], *args, **kwargs)
+        buff[ind] = cupy.asarray(out)
 
     # restore the inserted axes back to where they belong
     for i in range(res.ndim):

--- a/tests/cupy_tests/lib_tests/test_shape_base.py
+++ b/tests/cupy_tests/lib_tests/test_shape_base.py
@@ -91,6 +91,14 @@ class TestApplyAlongAxis(unittest.TestCase):
                 xp.ones((10,))
             )
 
+    @testing.numpy_cupy_array_equal()
+    def test_tuple_outs(self, xp):
+        def func(x):
+            return x.sum(axis=-1), x.prod(axis=-1), x.max(axis=-1)
+
+        a = testing.shaped_arange((2, 2, 2), xp, cupy.int64)
+        return xp.apply_along_axis(func, 1, a)
+
 
 @testing.gpu
 @testing.with_requires('numpy>=1.16')


### PR DESCRIPTION
Fix #7061