### PR TITLE
Add wrapper for `cutensorPermutation`

### DIFF
--- a/cupy_backends/cuda/libs/cutensor.pxd
+++ b/cupy_backends/cuda/libs/cutensor.pxd
@@ -170,6 +170,17 @@ cpdef elementwiseBinary(
     int opAC,
     int typeScalar)
 
+cpdef permutation(
+    Handle handle,
+    intptr_t alpha,
+    intptr_t A,
+    TensorDescriptor descA,
+    intptr_t modeA,
+    intptr_t B,
+    TensorDescriptor descB,
+    intptr_t modeB,
+    int typeScalar)
+
 cpdef initContractionDescriptor(
     Handle handle,
     ContractionDescriptor desc,

--- a/cupy_backends/cuda/libs/cutensor.pyx
+++ b/cupy_backends/cuda/libs/cutensor.pyx
@@ -65,6 +65,13 @@ cdef extern from '../../cupy_cutensor.h' nogil:
         Operator otAC,
         DataType typeScalar, driver.Stream stream)
 
+    int cutensorPermutation(
+        cutensorHandle_t* handle,
+        void* alpha,
+        void* A, cutensorTensorDescriptor_t* descA, int32_t* modeA,
+        void* B, cutensorTensorDescriptor_t* descB, int32_t* modeB,
+        DataType typeScalar, driver.Stream stream)
+
     int cutensorInitContractionDescriptor(
         cutensorHandle_t* handle,
         cutensorContractionDescriptor_t* desc,
@@ -502,6 +509,31 @@ cpdef elementwiseBinary(
         <cutensorTensorDescriptor_t*> descD._ptr,
         <int32_t*> modeD,
         <Operator> opAC,
+        <DataType> typeScalar,
+        <driver.Stream> stream)
+    check_status(status)
+
+
+cpdef permutation(
+        Handle handle,
+        intptr_t alpha,
+        intptr_t A,
+        TensorDescriptor descA,
+        intptr_t modeA,
+        intptr_t B,
+        TensorDescriptor descB,
+        intptr_t modeB,
+        int typeScalar):
+    cdef intptr_t stream = stream_module.get_current_stream_ptr()
+    status = cutensorPermutation(
+        <cutensorHandle_t*> handle._ptr,
+        <void*> alpha,
+        <void*> A,
+        <cutensorTensorDescriptor_t*> descA._ptr,
+        <int32_t*> modeA,
+        <void*> B,
+        <cutensorTensorDescriptor_t*> descB._ptr,
+        <int32_t*> modeB,
         <DataType> typeScalar,
         <driver.Stream> stream)
     check_status(status)

--- a/cupy_backends/stub/cupy_cutensor.h
+++ b/cupy_backends/stub/cupy_cutensor.h
@@ -42,6 +42,10 @@ extern "C" {
 	return CUTENSOR_STATUS_SUCCESS;
     }
 
+    cutensorStatus_t cutensorPermutation(...) {
+    return CUTENSOR_STATUS_SUCCESS;
+    }
+
     cutensorStatus_t cutensorInitContractionDescriptor(...) {
 	return CUTENSOR_STATUS_SUCCESS;
     }


### PR DESCRIPTION
Starting cuTENSOR 1.6.0 the performance of `cutensorPermutation` is improved significantly. It'd be nice to make use of it:
1. Expose the API to Python (this PR)
2. Make cuTENSOR an optional backend for permutation-related functions such as `reshape`, where actual data movement may be required (future work)

It'd be nice to backport this PR to the v11 branch 🙂