### PR TITLE
CI: tentatively fix hypothesis version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ extras_require = {
     'test': [
         # 4.2 <= pytest < 6.2 is slow collecting tests and times out on CI.
         'pytest>=6.2',
-        'hypothesis>=6.37.2',
+        'hypothesis>=6.37.2,<6.55.0',
     ],
 }
 tests_require = extras_require['test']


### PR DESCRIPTION
hypothesis 65.5.0 started to infer array api spec version from `__array_api_version__` attribute. https://github.com/HypothesisWorks/hypothesis/releases/tag/hypothesis-python-6.55.0
This broke the CI so until we decide the proper value for that attribute pin the hypothesis version to the previous one.

https://data-apis.org/array-api/latest/future_API_evolution.html#versioning

`numpy.array_api` doesn't seem to have the attribute either.
