### PR TITLE
Fix bessel test to pass ROCm CI

### DIFF
--- a/tests/cupyx_tests/scipy_tests/special_tests/test_bessel.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_bessel.py
@@ -14,7 +14,7 @@ class TestSpecial:
     def check_unary(self, name, xp, scp, dtype):
         import scipy.special  # NOQA
 
-        a = xp.linspace(-10, 10, 50, dtype=dtype).reshape((2, -1))
+        a = testing.shaped_arange((2, 3), xp, dtype)
         return getattr(scp.special, name)(a)
 
     def test_j0(self):
@@ -73,7 +73,7 @@ class TestFusionSpecial(unittest.TestCase):
     def check_unary(self, name, xp, scp, dtype):
         import scipy.special  # NOQA
 
-        a = xp.linspace(-10, 10, 50, dtype=dtype).reshape((2, -1))
+        a = testing.shaped_arange((2, 3), xp, dtype)
 
         @cupy.fuse()
         def f(x):


### PR DESCRIPTION
It seems that ROCm outputs NaN on a float16 input generated by `xp.linspace`. This PR reverts the test code.

https://github.com/cupy/cupy/pull/7036/files#r986430809