### PR TITLE
Find wheels from pip.cupy.dev in Dockerfile

### DIFF
--- a/docker/python3/Dockerfile
+++ b/docker/python3/Dockerfile
@@ -9,4 +9,4 @@ RUN apt-get update -y && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
 RUN pip3 install --no-cache-dir -U install setuptools pip
-RUN pip3 install --no-cache-dir -f https://github.com/cupy/cupy/releases/v12.0.0a2 "cupy-cuda11x[all]==12.0.0a2"
+RUN pip3 install --no-cache-dir -f https://pip.cupy.dev/pre/ "cupy-cuda11x[all]==12.0.0a2"

--- a/docker/rocm/Dockerfile
+++ b/docker/rocm/Dockerfile
@@ -16,6 +16,6 @@ RUN apt-get update -y && \
 RUN curl https://bootstrap.pypa.io/get-pip.py | sudo python3.7
 
 RUN pip3 install --no-cache-dir -U install setuptools pip
-RUN pip3 install --no-cache-dir -f https://github.com/cupy/cupy/releases/v12.0.0a2 "cupy-rocm-5-0[all]==12.0.0a2"
+RUN pip3 install --no-cache-dir -f https://pip.cupy.dev/pre/ "cupy-rocm-5-0[all]==12.0.0a2"
 
 USER rocm-user


### PR DESCRIPTION
Assets section of GitHub Releases are now lazy-loaded and so pip cannot find links from there.