### PR TITLE
Support `subtract.at`, `bitwise_and.at`, `bitwise_or.at`, `bitwise_xor.at`

### DIFF
--- a/cupy/_core/_routines_binary.pyx
+++ b/cupy/_core/_routines_binary.pyx
@@ -2,14 +2,14 @@ from cupy._core._kernel import create_ufunc
 from cupy._core._reduction import create_reduction_func
 
 
-cdef _create_bit_op(name, op, no_bool, doc=''):
+cdef _create_bit_op(name, op, no_bool, doc='', scatter_op=None):
     types = () if no_bool else ('??->?',)
     return create_ufunc(
         'cupy_' + name,
         types + ('bb->b', 'BB->B', 'hh->h', 'HH->H', 'ii->i', 'II->I', 'll->l',
                  'LL->L', 'qq->q', 'QQ->Q'),
         'out0 = in0 %s in1' % op,
-        doc=doc)
+        doc=doc, scatter_op=scatter_op)
 
 
 cdef _bitwise_and = _create_bit_op(
@@ -20,7 +20,8 @@ cdef _bitwise_and = _create_bit_op(
 
     .. seealso:: :data:`numpy.bitwise_and`
 
-    ''')
+    ''',
+    scatter_op='and')
 
 
 cdef _bitwise_or = _create_bit_op(
@@ -31,7 +32,8 @@ cdef _bitwise_or = _create_bit_op(
 
     .. seealso:: :data:`numpy.bitwise_or`
 
-    ''')
+    ''',
+    scatter_op='or')
 
 
 cdef _bitwise_xor = _create_bit_op(
@@ -42,7 +44,8 @@ cdef _bitwise_xor = _create_bit_op(
 
     .. seealso:: :data:`numpy.bitwise_xor`
 
-    ''')
+    ''',
+    scatter_op='xor')
 
 
 cdef _invert = create_ufunc(

--- a/cupy/_core/_routines_indexing.pyx
+++ b/cupy/_core/_routines_indexing.pyx
@@ -626,11 +626,23 @@ cdef _scatter_update_kernel = _create_scatter_kernel(
 cdef _scatter_add_kernel = _create_scatter_kernel(
     'cupy_scatter_add', 'atomicAdd(&out0, in1)')
 
+cdef _scatter_sub_kernel = _create_scatter_kernel(
+    'cupy_scatter_sub', 'atomicSub(&out0, in1)')
+
 cdef _scatter_max_kernel = _create_scatter_kernel(
     'cupy_scatter_max', 'atomicMax(&out0, in1)')
 
 cdef _scatter_min_kernel = _create_scatter_kernel(
     'cupy_scatter_min', 'atomicMin(&out0, in1)')
+
+cdef _scatter_and_kernel = _create_scatter_kernel(
+    'cupy_scatter_and', 'atomicAnd(&out0, in1)')
+
+cdef _scatter_or_kernel = _create_scatter_kernel(
+    'cupy_scatter_or', 'atomicOr(&out0, in1)')
+
+cdef _scatter_xor_kernel = _create_scatter_kernel(
+    'cupy_scatter_xor', 'atomicXor(&out0, in1)')
 
 
 cdef _create_scatter_mask_kernel(name, code):
@@ -653,11 +665,23 @@ cdef _scatter_update_mask_kernel = _create_scatter_mask_kernel(
 cdef _scatter_add_mask_kernel = _create_scatter_mask_kernel(
     'cupy_scatter_add_mask', 'out0 = in0 + in1')
 
+cdef _scatter_sub_mask_kernel = _create_scatter_mask_kernel(
+    'cupy_scatter_add_mask', 'out0 = in0 - in1')
+
 cdef _scatter_max_mask_kernel = _create_scatter_mask_kernel(
     'cupy_scatter_max_mask', 'out0 = max(in0, in1)')
 
 cdef _scatter_min_mask_kernel = _create_scatter_mask_kernel(
     'cupy_scatter_min_mask', 'out0 = min(in0, in1)')
+
+cdef _scatter_and_mask_kernel = _create_scatter_mask_kernel(
+    'cupy_scatter_and_mask', 'out0 = (in0 & in1)')
+
+cdef _scatter_or_mask_kernel = _create_scatter_mask_kernel(
+    'cupy_scatter_or_mask', 'out0 = (in0 | in1)')
+
+cdef _scatter_xor_mask_kernel = _create_scatter_mask_kernel(
+    'cupy_scatter_xor_mask', 'out0 = (in0 ^ in1)')
 
 
 _getitem_mask_kernel = ElementwiseKernel(
@@ -856,9 +880,17 @@ cdef _scatter_op_single(
                            numpy.float64, numpy.uint32, numpy.uint64,
                            numpy.intc, numpy.uintc, numpy.ulonglong)):
             raise TypeError(
-                'scatter_add only supports int32, float16, float32, float64, '
+                'cupy.add.at only supports int32, float16, float32, float64, '
                 'uint32, uint64, as data type')
         _scatter_add_kernel(
+            v, indices, cdim, rdim, adim, a.reduced_view())
+    elif op == 'sub':
+        if not issubclass(v.dtype.type,
+                          (numpy.int32, numpy.uint32,
+                           numpy.intc, numpy.uintc)):
+            raise TypeError(
+                'cupy.subtract.at only supports int32, uint32, as data type')
+        _scatter_sub_kernel(
             v, indices, cdim, rdim, adim, a.reduced_view())
     elif op == 'max':
         if not issubclass(v.dtype.type,
@@ -866,7 +898,7 @@ cdef _scatter_op_single(
                            numpy.uint32, numpy.uint64,
                            numpy.intc, numpy.uintc, numpy.ulonglong)):
             raise TypeError(
-                'scatter_max only supports int32, float32, float64, '
+                'cupy.maximum.at only supports int32, float32, float64, '
                 'uint32, uint64 as data type')
         _scatter_max_kernel(
             v, indices, cdim, rdim, adim, a.reduced_view())
@@ -876,9 +908,42 @@ cdef _scatter_op_single(
                            numpy.uint32, numpy.uint64,
                            numpy.intc, numpy.uintc, numpy.ulonglong)):
             raise TypeError(
-                'scatter_min only supports int32, float32, float64, '
+                'cupy.minimum.at only supports int32, float32, float64, '
                 'uint32, uint64 as data type')
         _scatter_min_kernel(
+            v, indices, cdim, rdim, adim, a.reduced_view())
+    elif op == 'and':
+        if not issubclass(v.dtype.type,
+                          (numpy.int32, numpy.int64,
+                           numpy.uint32, numpy.uint64,
+                           numpy.intc, numpy.uintc,
+                           numpy.longlong, numpy.ulonglong)):
+            raise TypeError(
+                'cupy.bitwise_and.at only supports int32, int64, '
+                'uint32, uint64 as data type')
+        _scatter_and_kernel(
+            v, indices, cdim, rdim, adim, a.reduced_view())
+    elif op == 'or':
+        if not issubclass(v.dtype.type,
+                          (numpy.int32, numpy.int64,
+                           numpy.uint32, numpy.uint64,
+                           numpy.intc, numpy.uintc,
+                           numpy.longlong, numpy.ulonglong)):
+            raise TypeError(
+                'cupy.bitwise_or.at only supports int32, int64, '
+                'uint32, uint64 as data type')
+        _scatter_or_kernel(
+            v, indices, cdim, rdim, adim, a.reduced_view())
+    elif op == 'xor':
+        if not issubclass(v.dtype.type,
+                          (numpy.int32, numpy.int64,
+                           numpy.uint32, numpy.uint64,
+                           numpy.intc, numpy.uintc,
+                           numpy.longlong, numpy.ulonglong)):
+            raise TypeError(
+                'cupy.bitwise_xor.at only supports int32, int64, '
+                'uint32, uint64 as data type')
+        _scatter_xor_kernel(
             v, indices, cdim, rdim, adim, a.reduced_view())
     else:
         raise ValueError('provided op is not supported')
@@ -907,10 +972,18 @@ cdef _scatter_op_mask_single(
         _scatter_update_mask_kernel(src, mask, mask_scanned, a)
     elif op == 'add':
         _scatter_add_mask_kernel(src, mask, mask_scanned, a)
+    elif op == 'sub':
+        _scatter_sub_mask_kernel(src, mask, mask_scanned, a)
     elif op == 'max':
         _scatter_max_mask_kernel(src, mask, mask_scanned, a)
     elif op == 'min':
         _scatter_min_mask_kernel(src, mask, mask_scanned, a)
+    elif op == 'and':
+        _scatter_and_mask_kernel(src, mask, mask_scanned, a)
+    elif op == 'or':
+        _scatter_or_mask_kernel(src, mask, mask_scanned, a)
+    elif op == 'xor':
+        _scatter_xor_mask_kernel(src, mask, mask_scanned, a)
     else:
         raise ValueError('provided op is not supported')
 
@@ -956,11 +1029,23 @@ cdef _scatter_op(_ndarray_base a, slices, value, op):
     if op == 'add':
         _math._add(y, value, y)
         return
+    if op == 'sub':
+        _math._subtract(y, value, y)
+        return
     if op == 'max':
         cupy.maximum(y, value, y)
         return
     if op == 'min':
         cupy.minimum(y, value, y)
+        return
+    if op == 'and':
+        cupy.bitwise_and(y, value, y)
+        return
+    if op == 'or':
+        cupy.bitwise_or(y, value, y)
+        return
+    if op == 'xor':
+        cupy.bitwise_xor(y, value, y)
         return
     raise ValueError('this op is not supported')
 

--- a/cupy/_core/_routines_math.pyx
+++ b/cupy/_core/_routines_math.pyx
@@ -1035,7 +1035,7 @@ _subtract = create_arithmetic(
     .. seealso:: :data:`numpy.subtract`
 
     ''',
-    cutensor_op=('OP_ADD', 1, -1))
+    cutensor_op=('OP_ADD', 1, -1), scatter_op='sub')
 
 
 _true_divide = create_ufunc(

--- a/tests/cupy_tests/core_tests/test_ufunc_methods.py
+++ b/tests/cupy_tests/core_tests/test_ufunc_methods.py
@@ -35,6 +35,8 @@ class TestUfuncAtAtomicOps:
     @testing.for_dtypes('iIQefd')
     @testing.numpy_cupy_array_equal()
     def test_at_add_duplicate_indices(self, xp, dtype):
+        if cupy.cuda.runtime.is_hip and dtype == numpy.float16:
+            pytest.skip('atomicAdd does not support float16 in HIP')
         shape = (50,)
         x = testing.shaped_random(shape, xp=xp, dtype=dtype, seed=0)
         indices = testing.shaped_random(
@@ -109,6 +111,8 @@ class TestUfuncAtAtomicOps:
     @testing.for_dtypes('iIlLqQ')
     @testing.numpy_cupy_array_equal()
     def test_at_bitwise_and(self, xp, dtype):
+        if cupy.cuda.runtime.is_hip and numpy.dtype(dtype).char in 'lq':
+            pytest.skip('atomicOr does not support int64 in HIP')
         shape = (50,)
         x = testing.shaped_random(shape, xp=xp, dtype=dtype, seed=0)
         indices = testing.shaped_random(
@@ -121,6 +125,8 @@ class TestUfuncAtAtomicOps:
     @testing.for_dtypes('iIlLqQ')
     @testing.numpy_cupy_array_equal()
     def test_at_bitwise_or(self, xp, dtype):
+        if cupy.cuda.runtime.is_hip and numpy.dtype(dtype).char in 'lq':
+            pytest.skip('atomicOr does not support int64 in HIP')
         shape = (50,)
         x = testing.shaped_random(shape, xp=xp, dtype=dtype, seed=0)
         indices = testing.shaped_random(
@@ -133,6 +139,8 @@ class TestUfuncAtAtomicOps:
     @testing.for_dtypes('iIlLqQ')
     @testing.numpy_cupy_array_equal()
     def test_at_bitwise_xor(self, xp, dtype):
+        if cupy.cuda.runtime.is_hip and numpy.dtype(dtype).char in 'lq':
+            pytest.skip('atomicXor does not support int64 in HIP')
         shape = (50,)
         x = testing.shaped_random(shape, xp=xp, dtype=dtype, seed=0)
         indices = testing.shaped_random(

--- a/tests/cupy_tests/core_tests/test_ufunc_methods.py
+++ b/tests/cupy_tests/core_tests/test_ufunc_methods.py
@@ -32,6 +32,16 @@ class TestUfuncAtAtomicOps:
         xp.add.at(x, indices, 3)
         return x
 
+    @testing.for_dtypes('iIQefd')
+    @testing.numpy_cupy_array_equal()
+    def test_at_add_duplicate_indices(self, xp, dtype):
+        shape = (50,)
+        x = testing.shaped_random(shape, xp=xp, dtype=dtype, seed=0)
+        indices = testing.shaped_random(
+            shape, xp=xp, dtype=numpy.int32, scale=shape[0], seed=1)
+        xp.add.at(x, indices, 3)
+        return x
+
     @testing.for_dtypes('iIQfd')
     @testing.numpy_cupy_allclose()
     def test_at_min(self, xp, dtype):
@@ -44,12 +54,36 @@ class TestUfuncAtAtomicOps:
 
     @testing.for_dtypes('iIQfd')
     @testing.numpy_cupy_allclose()
+    def test_at_min_duplicate_indices(self, xp, dtype):
+        shape = (50,)
+        x = testing.shaped_random(shape, xp=xp, dtype=dtype, seed=0)
+        indices = testing.shaped_random(
+            shape, xp=xp, dtype=numpy.int32, scale=shape[0], seed=1)
+        values = testing.shaped_random(
+            indices.shape, xp=xp, dtype=dtype, seed=2)
+        xp.minimum.at(x, indices, values)
+        return x
+
+    @testing.for_dtypes('iIQfd')
+    @testing.numpy_cupy_allclose()
     def test_at_max(self, xp, dtype):
         shape = (50,)
         x = testing.shaped_random(shape, xp=xp, dtype=dtype, seed=0)
         mask = testing.shaped_random(shape, xp=xp, dtype=bool, seed=1)
         indices = xp.nonzero(mask)[0]
         xp.maximum.at(x, indices, 3)
+        return x
+
+    @testing.for_dtypes('iIQfd')
+    @testing.numpy_cupy_allclose()
+    def test_at_max_duplicate_indices(self, xp, dtype):
+        shape = (50,)
+        x = testing.shaped_random(shape, xp=xp, dtype=dtype, seed=0)
+        indices = testing.shaped_random(
+            shape, xp=xp, dtype=numpy.int32, scale=shape[0], seed=1)
+        values = testing.shaped_random(
+            indices.shape, xp=xp, dtype=dtype, seed=2)
+        xp.maximum.at(x, indices, values)
         return x
 
     @testing.for_dtypes('iIQefd')

--- a/tests/cupy_tests/core_tests/test_ufunc_methods.py
+++ b/tests/cupy_tests/core_tests/test_ufunc_methods.py
@@ -42,6 +42,26 @@ class TestUfuncAtAtomicOps:
         xp.add.at(x, indices, 3)
         return x
 
+    @testing.for_dtypes('iI')
+    @testing.numpy_cupy_array_equal()
+    def test_at_subtract(self, xp, dtype):
+        shape = (50,)
+        x = testing.shaped_random(shape, xp=xp, dtype=dtype, seed=0)
+        mask = testing.shaped_random(shape, xp=xp, dtype=bool, seed=1)
+        indices = xp.nonzero(mask)[0]
+        xp.subtract.at(x, indices, 3)
+        return x
+
+    @testing.for_dtypes('iI')
+    @testing.numpy_cupy_array_equal()
+    def test_at_subtract_duplicate_indices(self, xp, dtype):
+        shape = (50,)
+        x = testing.shaped_random(shape, xp=xp, dtype=dtype, seed=0)
+        indices = testing.shaped_random(
+            shape, xp=xp, dtype=numpy.int32, scale=shape[0], seed=1)
+        xp.subtract.at(x, indices, 3)
+        return x
+
     @testing.for_dtypes('iIQfd')
     @testing.numpy_cupy_allclose()
     def test_at_min(self, xp, dtype):
@@ -84,6 +104,42 @@ class TestUfuncAtAtomicOps:
         values = testing.shaped_random(
             indices.shape, xp=xp, dtype=dtype, seed=2)
         xp.maximum.at(x, indices, values)
+        return x
+
+    @testing.for_dtypes('iIlLqQ')
+    @testing.numpy_cupy_array_equal()
+    def test_at_bitwise_and(self, xp, dtype):
+        shape = (50,)
+        x = testing.shaped_random(shape, xp=xp, dtype=dtype, seed=0)
+        indices = testing.shaped_random(
+            shape, xp=xp, dtype=numpy.int32, scale=shape[0], seed=1)
+        values = testing.shaped_random(
+            indices.shape, xp=xp, dtype=dtype, seed=2)
+        xp.bitwise_and.at(x, indices, values)
+        return x
+
+    @testing.for_dtypes('iIlLqQ')
+    @testing.numpy_cupy_array_equal()
+    def test_at_bitwise_or(self, xp, dtype):
+        shape = (50,)
+        x = testing.shaped_random(shape, xp=xp, dtype=dtype, seed=0)
+        indices = testing.shaped_random(
+            shape, xp=xp, dtype=numpy.int32, scale=shape[0], seed=1)
+        values = testing.shaped_random(
+            indices.shape, xp=xp, dtype=dtype, seed=2)
+        xp.bitwise_or.at(x, indices, values)
+        return x
+
+    @testing.for_dtypes('iIlLqQ')
+    @testing.numpy_cupy_array_equal()
+    def test_at_bitwise_xor(self, xp, dtype):
+        shape = (50,)
+        x = testing.shaped_random(shape, xp=xp, dtype=dtype, seed=0)
+        indices = testing.shaped_random(
+            shape, xp=xp, dtype=numpy.int32, scale=shape[0], seed=1)
+        values = testing.shaped_random(
+            indices.shape, xp=xp, dtype=dtype, seed=2)
+        xp.bitwise_xor.at(x, indices, values)
         return x
 
     @testing.for_dtypes('iIQefd')


### PR DESCRIPTION
Part of https://github.com/cupy/cupy/issues/7082.

~Blocked by https://github.com/cupy/cupy/pull/7077.~