### PR TITLE
Fusion `TypeError` in `cupy._core.fusion._call_ufunc()`

### DIFF
--- a/cupy/_core/fusion.pyx
+++ b/cupy/_core/fusion.pyx
@@ -524,7 +524,7 @@ class _FusionHistory(object):
             return _FusionVarScalar(var, -1, self._has_reduction())
         raise TypeError('Unsupported type {}'.format(type(arg)))
 
-    def call_ufunc(self, ufunc, args, kwargs):
+    def call_ufunc(self, ufunc, *args, **kwargs):
         nin = ufunc.nin
         nout = ufunc.nout
 
@@ -958,7 +958,7 @@ def fuse(*args, **kwargs):
 
 
 def _call_ufunc(fusion_op, *args, **kwargs):
-    return _thread_local.history.call_ufunc(fusion_op, args, kwargs)
+    return _thread_local.history.call_ufunc(fusion_op, *args, **kwargs)
 
 
 def _call_reduction(fusion_op, *args, **kwargs):

--- a/tests/cupy_tests/core_tests/fusion_tests/test_reduction.py
+++ b/tests/cupy_tests/core_tests/fusion_tests/test_reduction.py
@@ -232,3 +232,21 @@ class TestFusionReductionRoutines(unittest.TestCase):
     @fusion_utils.check_fusion()
     def test_nanprod(self, xp):
         return lambda x: xp.nanprod(x)
+
+
+@testing.gpu
+class TestFusionMisc(unittest.TestCase):
+
+    def generate_inputs(self, xp):
+        x = testing.shaped_random((3, 4), xp, 'int64', scale=10, seed=0)
+        return (x,), {}
+
+    @unittest.skipUnless(
+        fusion_utils.can_use_grid_synchronization(),
+        'Requires CUDA grid synchronization')
+    @fusion_utils.check_fusion()
+    def test_sum_div_clip(self, xp):
+        def impl(x):
+            x = x / xp.sum(x)
+            return xp.clip(x, 2, 7)
+        return impl

--- a/tests/cupy_tests/core_tests/fusion_tests/test_reduction.py
+++ b/tests/cupy_tests/core_tests/fusion_tests/test_reduction.py
@@ -96,7 +96,7 @@ class TestFusionReductionAndElementwise(unittest.TestCase):
 
     def generate_inputs(self, xp):
         x = testing.shaped_random((3, 4), xp, 'int64', scale=10, seed=0)
-        y = testing.shaped_random((3, 4), xp, 'int64', scale=10, seed=0)
+        y = testing.shaped_random((3, 4), xp, 'int64', scale=10, seed=1)
         return (x, y), {}
 
     @fusion_utils.check_fusion()
@@ -155,7 +155,7 @@ class TestFusionMultipleReductions(unittest.TestCase):
 
     def generate_inputs(self, xp):
         x = testing.shaped_random((3, 4), xp, 'int64', scale=10, seed=0)
-        y = testing.shaped_random((3, 4), xp, 'int64', scale=10, seed=0)
+        y = testing.shaped_random((3, 4), xp, 'int64', scale=10, seed=1)
         return (x, y), {}
 
     @unittest.skipUnless(


### PR DESCRIPTION
Fix #7098.