### PR TITLE
Raise `TypeError` instead of `ValueError` in `cupy.from_dlpack` when CPU tensor is passed

### DIFF
--- a/cupy/_core/dlpack.pyx
+++ b/cupy/_core/dlpack.pyx
@@ -389,9 +389,9 @@ cpdef from_dlpack(array):
         finally:
             cupy.cuda.runtime.setDevice(prev_device)
     elif dev_type == <int>kDLCPU:
-        # TODO(kmaehashi): Call `np.from_dlpack` when DLPack support is in:
-        # https://github.com/numpy/numpy/pull/19083
-        raise ValueError('CPU arrays cannot be imported to CuPy.')
+        raise ValueError(
+            'CPU arrays cannot be directly imported to CuPy. '
+            'Use `cupy.array(numpy.from_dlpack(input))` instead.')
     else:
         # TODO(leofang): support kDLCUDAPinned etc
         dltensor = None

--- a/cupy/_core/dlpack.pyx
+++ b/cupy/_core/dlpack.pyx
@@ -351,8 +351,12 @@ cpdef from_dlpack(array):
         are responsible to ensure data safety.
 
     .. seealso::
-        `Data interchange mechanisms`_
+        :func:`numpy.from_dlpack`,
+        `Python Specification for DLPack`_
+        `Data interchange mechanisms`_,
 
+    .. _Python Specification for DLPack:
+        https://dmlc.github.io/dlpack/latest/python_spec.html
     .. _Data interchange mechanisms:
         https://data-apis.org/array-api/latest/design_topics/data_interchange.html
     """

--- a/cupy/_core/dlpack.pyx
+++ b/cupy/_core/dlpack.pyx
@@ -389,12 +389,12 @@ cpdef from_dlpack(array):
         finally:
             cupy.cuda.runtime.setDevice(prev_device)
     elif dev_type == <int>kDLCPU:
-        raise ValueError(
+        raise TypeError(
             'CPU arrays cannot be directly imported to CuPy. '
             'Use `cupy.array(numpy.from_dlpack(input))` instead.')
     else:
         # TODO(leofang): support kDLCUDAPinned etc
         dltensor = None
-        raise ValueError(f'Unsupported array type: {dev_type}')
+        raise TypeError(f'Unsupported array type: {dev_type}')
 
     return _dlpack_to_cupy_array(dltensor)

--- a/cupy/_core/dlpack.pyx
+++ b/cupy/_core/dlpack.pyx
@@ -329,10 +329,6 @@ cdef inline _ndarray_base _dlpack_to_cupy_array(dltensor) except +:
     return core.ndarray(shape_vec, cp_dtype, mem_ptr, strides=strides_vec)
 
 
-# TODO(leofang): this function is exposed to the cupy namespace, so it returns
-# a cupy.ndarray which is not compliant with the Python array API. When we have
-# a compliant object living in, say, cupy.array_api, we will expose another
-# function cupy.array_api.from_dlpack().
 cpdef from_dlpack(array):
     """Zero-copy conversion between array objects compliant with the DLPack
     data exchange protocol.

--- a/cupy/_core/dlpack.pyx
+++ b/cupy/_core/dlpack.pyx
@@ -352,8 +352,8 @@ cpdef from_dlpack(array):
 
     .. seealso::
         :func:`numpy.from_dlpack`,
-        `Python Specification for DLPack`_
-        `Data interchange mechanisms`_,
+        `Python Specification for DLPack`_,
+        `Data interchange mechanisms`_
 
     .. _Python Specification for DLPack:
         https://dmlc.github.io/dlpack/latest/python_spec.html


### PR DESCRIPTION
https://data-apis.org/array-api/latest/design_topics/data_interchange.html

> If an array that is accessed via the interchange protocol lives on a device that the requesting library does not support, it is recommended to raise a TypeError.

ref. #7131