### PR TITLE
Improve `_PerfCaseResult.to_str` format

### DIFF
--- a/cupyx/profiler/_time.py
+++ b/cupyx/profiler/_time.py
@@ -50,9 +50,9 @@ class _PerfCaseResult:
         assert t.size > 0
         t_us = t * 1e6
 
-        s = '    {}:{:9.03f} us'.format(device_name, t_us.mean())
+        s = '    {}: {:9.03f} us'.format(device_name, t_us.mean())
         if t.size > 1:
-            s += '   +/-{:6.03f} (min:{:9.03f} / max:{:9.03f}) us'.format(
+            s += '   +/- {:6.03f} (min: {:9.03f} / max: {:9.03f}) us'.format(
                 t_us.std(), t_us.min(), t_us.max())
         return s
 

--- a/tests/cupyx_tests/profiler_tests/test_benchmark.py
+++ b/tests/cupyx_tests/profiler_tests/test_benchmark.py
@@ -90,10 +90,10 @@ class TestPerfCaseResult(unittest.TestCase):
         perf = _time._PerfCaseResult('test_name_xxx', times, (0,))
         expected = (
             'test_name_xxx       :'
-            '    CPU:    5.620 us   +/- 0.943 '
-            '(min:    4.200 / max:    7.100) us '
-            '    GPU-0:    6.600 us   +/- 2.344 '
-            '(min:    3.800 / max:    9.600) us'
+            '    CPU:     5.620 us   +/-  0.943 '
+            '(min:     4.200 / max:     7.100) us '
+            '    GPU-0:     6.600 us   +/-  2.344 '
+            '(min:     3.800 / max:     9.600) us'
         )
         assert str(perf) == expected
 
@@ -105,8 +105,8 @@ class TestPerfCaseResult(unittest.TestCase):
         perf = _time._PerfCaseResult('test_name_xxx', times, (0,))
         expected = (
             'test_name_xxx       :'
-            '    CPU:    5.620 us   +/- 0.943 '
-            '(min:    4.200 / max:    7.100) us'
+            '    CPU:     5.620 us   +/-  0.943 '
+            '(min:     4.200 / max:     7.100) us'
         )
         assert perf.to_str() == expected
         # Checks if the result does not change.
@@ -115,18 +115,18 @@ class TestPerfCaseResult(unittest.TestCase):
     def test_single_show_gpu(self):
         times = numpy.array([[5.4], [6.4]]) * 1e-6
         perf = _time._PerfCaseResult('test_name_xxx', times, (0,))
-        assert str(perf) == ('test_name_xxx       :    CPU:    5.400 us '
-                             '    GPU-0:    6.400 us')
+        assert str(perf) == ('test_name_xxx       :    CPU:     5.400 us '
+                             '    GPU-0:     6.400 us')
 
     def test_single_no_show_gpu(self):
         times = numpy.array([[5.4], [6.4]]) * 1e-6
         perf = _time._PerfCaseResult('test_name_xxx', times, (0,))
-        assert perf.to_str() == 'test_name_xxx       :    CPU:    5.400 us'
+        assert perf.to_str() == 'test_name_xxx       :    CPU:     5.400 us'
 
     def test_show_multigpu(self):
         times = numpy.array([[5.4], [6.4], [7.0], [8.1]]) * 1e-6
         perf = _time._PerfCaseResult('test_name_xxx', times, (0, 1, 2))
-        assert str(perf) == ('test_name_xxx       :    CPU:    5.400 us '
-                             '    GPU-0:    6.400 us '
-                             '    GPU-1:    7.000 us '
-                             '    GPU-2:    8.100 us')
+        assert str(perf) == ('test_name_xxx       :    CPU:     5.400 us '
+                             '    GPU-0:     6.400 us '
+                             '    GPU-1:     7.000 us '
+                             '    GPU-2:     8.100 us')

--- a/tests/cupyx_tests/test_time.py
+++ b/tests/cupyx_tests/test_time.py
@@ -89,10 +89,10 @@ class TestPerfCaseResult(unittest.TestCase):
         perf = cupyx.time._PerfCaseResult('test_name_xxx', times, (0,))
         expected = (
             'test_name_xxx       :'
-            '    CPU:    5.620 us   +/- 0.943 '
-            '(min:    4.200 / max:    7.100) us '
-            '    GPU-0:    6.600 us   +/- 2.344 '
-            '(min:    3.800 / max:    9.600) us'
+            '    CPU:     5.620 us   +/-  0.943 '
+            '(min:     4.200 / max:     7.100) us '
+            '    GPU-0:     6.600 us   +/-  2.344 '
+            '(min:     3.800 / max:     9.600) us'
         )
         assert str(perf) == expected
 
@@ -104,8 +104,8 @@ class TestPerfCaseResult(unittest.TestCase):
         perf = cupyx.time._PerfCaseResult('test_name_xxx', times, (0,))
         expected = (
             'test_name_xxx       :'
-            '    CPU:    5.620 us   +/- 0.943 '
-            '(min:    4.200 / max:    7.100) us'
+            '    CPU:     5.620 us   +/-  0.943 '
+            '(min:     4.200 / max:     7.100) us'
         )
         assert perf.to_str() == expected
         # Checks if the result does not change.
@@ -114,18 +114,18 @@ class TestPerfCaseResult(unittest.TestCase):
     def test_single_show_gpu(self):
         times = numpy.array([[5.4], [6.4]]) * 1e-6
         perf = cupyx.time._PerfCaseResult('test_name_xxx', times, (0,))
-        assert str(perf) == ('test_name_xxx       :    CPU:    5.400 us '
-                             '    GPU-0:    6.400 us')
+        assert str(perf) == ('test_name_xxx       :    CPU:     5.400 us '
+                             '    GPU-0:     6.400 us')
 
     def test_single_no_show_gpu(self):
         times = numpy.array([[5.4], [6.4]]) * 1e-6
         perf = cupyx.time._PerfCaseResult('test_name_xxx', times, (0,))
-        assert perf.to_str() == 'test_name_xxx       :    CPU:    5.400 us'
+        assert perf.to_str() == 'test_name_xxx       :    CPU:     5.400 us'
 
     def test_show_multigpu(self):
         times = numpy.array([[5.4], [6.4], [7.0], [8.1]]) * 1e-6
         perf = cupyx.time._PerfCaseResult('test_name_xxx', times, (0, 1, 2))
-        assert str(perf) == ('test_name_xxx       :    CPU:    5.400 us '
-                             '    GPU-0:    6.400 us '
-                             '    GPU-1:    7.000 us '
-                             '    GPU-2:    8.100 us')
+        assert str(perf) == ('test_name_xxx       :    CPU:     5.400 us '
+                             '    GPU-0:     6.400 us '
+                             '    GPU-1:     7.000 us '
+                             '    GPU-2:     8.100 us')


### PR DESCRIPTION
Adds always spaces after `:` and `+/-` to improve parseability. In some cases spaces are not added so it is difficult to create generic scripts.

Before
```
rotate              :    CPU: 6083.005 us   +/-88.593 (min: 5992.784 / max: 6270.549) us     GPU-0:16082.317 us   +/-414.647 (min:15755.200 / max:17056.192) us
multiply            :    CPU:   20.559 us   +/- 0.455 (min:   20.134 / max:   22.139) us     GPU-0:   24.645 us   +/- 0.750 (min:   23.744 / max:   26.624) us
```

After
```
rotate              :    CPU:  6010.878 us   +/- 16.831 (min:  5975.687 / max:  6044.528) us     GPU-0: 15774.685 us   +/- 38.317 (min: 15732.384 / max: 15928.736) us
multiply            :    CPU:    21.008 us   +/-  0.636 (min:    20.439 / max:    23.427) us     GPU-0:    25.150 us   +/-  0.877 (min:    24.224 / max:    27.872) us
```

 Fixes #7150 