### PR TITLE
CI: Add support for the latest FlexCI Windows image

### DIFF
--- a/.pfnci/windows/_flexci.ps1
+++ b/.pfnci/windows/_flexci.ps1
@@ -11,6 +11,8 @@ function ActivatePython($version) {
         $pydir = "Python39"
     } elseif ($version -eq "3.10") {
         $pydir = "Python310"
+    } elseif ($version -eq "3.11") {
+        $pydir = "Python311"
     } else {
         throw "Unsupported Python version: $version"
     }
@@ -18,19 +20,7 @@ function ActivatePython($version) {
 }
 
 function ActivateCUDA($version) {
-    if ($version -eq "8.0") {
-        $Env:CUDA_PATH = $Env:CUDA_PATH_V8_0
-    } elseif ($version -eq "9.0") {
-        $Env:CUDA_PATH = $Env:CUDA_PATH_V9_0
-    } elseif ($version -eq "9.1") {
-        $Env:CUDA_PATH = $Env:CUDA_PATH_V9_1
-    } elseif ($version -eq "9.2") {
-        $Env:CUDA_PATH = $Env:CUDA_PATH_V9_2
-    } elseif ($version -eq "10.0") {
-        $Env:CUDA_PATH = $Env:CUDA_PATH_V10_0
-    } elseif ($version -eq "10.1") {
-        $Env:CUDA_PATH = $Env:CUDA_PATH_V10_1
-    } elseif ($version -eq "10.2") {
+    if ($version -eq "10.2") {
         $Env:CUDA_PATH = $Env:CUDA_PATH_V10_2
     } elseif ($version -eq "11.0") {
         $Env:CUDA_PATH = $Env:CUDA_PATH_V11_0
@@ -56,6 +46,24 @@ function ActivateCUDA($version) {
         throw "Unsupported CUDA version: $version"
     }
     $Env:PATH = "$Env:CUDA_PATH\bin;$Env:ProgramFiles\NVIDIA Corporation\NvToolsExt\bin\x64;" + $Env:PATH
+}
+
+function ActivateCuDNN($cudnn_version, $cuda_version) {
+    if ($cudnn_version -eq "8.6") {
+        $cudnn = "v8.6.0"
+    } else {
+        throw "Unsupported cuDNN version: $cudnn_version"
+    }
+
+    if ($cuda_version -eq "10.2") {
+        $cuda = "10"
+    } elseif ($cuda_version.startswith("11.")) {
+        $cuda = "11"
+    } else {
+        throw "Unsupported CUDA version: $cuda_version"
+    }
+
+    $Env:PATH = "C:\Development\cuDNN\$cudnn\cuda$cuda\bin;" + $Env:PATH
 }
 
 function IsPullRequestTest() {

--- a/.pfnci/windows/_flexci.ps1
+++ b/.pfnci/windows/_flexci.ps1
@@ -64,8 +64,8 @@ function ActivateCuDNN($cudnn_version, $cuda_version) {
     }
 
     $base = "C:\Development\cuDNN\$cudnn\cuda$cuda"
-    $Env:CL = "-I$base\include;" + $Env:CL
-    $Env:LINK = "/LIBPATH:$base\lib\x64;" + $Env:LINK
+    $Env:CL = "-I$base\include " + $Env:CL
+    $Env:LINK = "/LIBPATH:$base\lib\x64 " + $Env:LINK
     $Env:PATH = "$base\bin;" + $Env:PATH
 }
 

--- a/.pfnci/windows/_flexci.ps1
+++ b/.pfnci/windows/_flexci.ps1
@@ -63,7 +63,10 @@ function ActivateCuDNN($cudnn_version, $cuda_version) {
         throw "Unsupported CUDA version: $cuda_version"
     }
 
-    $Env:PATH = "C:\Development\cuDNN\$cudnn\cuda$cuda\bin;" + $Env:PATH
+    $base = "C:\Development\cuDNN\$cudnn\cuda$cuda"
+    $Env:CL = "-I$base\include;" + $Env:CL
+    $Env:LINK = "/LIBPATH:$base\lib\x64;" + $Env:LINK
+    $Env:PATH = "$base\bin;" + $Env:PATH
 }
 
 function IsPullRequestTest() {

--- a/.pfnci/windows/test.ps1
+++ b/.pfnci/windows/test.ps1
@@ -56,6 +56,7 @@ function Main {
     # Setup environment
     echo "Using CUDA $cuda and Python $python"
     ActivateCUDA $cuda
+    ActivateCuDNN "8.6" $cuda
     ActivatePython $python
 
     # Setup build environment variables


### PR DESCRIPTION
The new CI image (which is already deployed) has cuDNN in a separate path.