### PR TITLE
JIT: Skip HIP `thrust::sort` test

### DIFF
--- a/tests/cupyx_tests/jit_tests/test_thrust.py
+++ b/tests/cupyx_tests/jit_tests/test_thrust.py
@@ -124,6 +124,9 @@ class TestThrust:
 
     @pytest.mark.parametrize('order', ['C', 'F'])
     def test_sort_iterator(self, order):
+        if runtime.is_hip:
+            pytest.skip('See https://github.com/cupy/cupy/pull/7162')
+
         @jit.rawkernel()
         def sort(x):
             i = jit.threadIdx.x
@@ -140,6 +143,9 @@ class TestThrust:
 
     @pytest.mark.parametrize('order', ['C', 'F'])
     def test_sort_by_key_iterator(self, order):
+        if runtime.is_hip:
+            pytest.skip('See https://github.com/cupy/cupy/pull/7162')
+
         @jit.rawkernel()
         def sort_by_key(x, y):
             i = jit.threadIdx.x


### PR DESCRIPTION
Rel. https://github.com/cupy/cupy/pull/7139#issuecomment-1298198379

```
22:48:26 cupyx_tests/jit_tests/test_thrust.py .......xxsstimeout: the monitored command dumped core
22:48:27 /src/.pfnci/linux/tests/actions/unittest.sh: line 26:  1401 Aborted                 timeout --signal INT --kill-after 60 18000 python3 -m pytest "${pytest_opts[@]}" "${PYTEST_FILES[@]}"
22:48:33 + test_retval=134
```