### PR TITLE
Add missing base type to cdef declarations

### DIFF
--- a/cupy/random/_generator_api.pyx
+++ b/cupy/random/_generator_api.pyx
@@ -251,7 +251,7 @@ class Generator:
             :meth:`numpy.random.Generator.beta`
         """
         cdef _ndarray_base y
-        cdef a_arr, b_arr
+        cdef _ndarray_base a_arr, b_arr
 
         if not isinstance(a, _ndarray_base):
             if type(a) in (float, int):

--- a/cupyx/cudnn.pyx
+++ b/cupyx/cudnn.pyx
@@ -363,7 +363,7 @@ cdef Descriptor _create_rnn_data_descriptor():
 cdef Descriptor _make_unpacked_rnn_data_descriptor(_ndarray_base xs, lengths):
     cdef Descriptor descriptor = _create_rnn_data_descriptor()
     cdef int data_type = get_data_type(xs.dtype)
-    cdef max_length, batch, n_dim
+    cdef Py_ssize_t max_length, batch, n_dim
     max_length, batch, n_dim = xs.shape
     cudnn.setRNNDataDescriptor(
         descriptor.value, data_type,


### PR DESCRIPTION
I presume the base type was forgotten in these two cases?

(found whilst testing out a [cython linter](https://github.com/MarcoGorelli/cython-lint))