### PR TITLE
Fix cupyx.scipy.ndimage.zoom for outputs of size 1 when mode is 'opencv'

### DIFF
--- a/cupyx/scipy/ndimage/_interpolation.py
+++ b/cupyx/scipy/ndimage/_interpolation.py
@@ -721,7 +721,7 @@ def zoom(input, zoom, output=None, order=3, mode='constant', cval=0.0,
         zoom = []
         offset = []
         for in_size, out_size in zip(input.shape, output_shape):
-            if out_size > 1:
+            if out_size > 0:
                 zoom.append(float(in_size) / out_size)
                 offset.append((zoom[-1] - 1) / 2.0)
             else:

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
@@ -907,6 +907,18 @@ class TestZoomOpenCV:
             output_shape = numpy.rint(numpy.multiply(a.shape, self.zoom))
             return cv2.resize(a, tuple(output_shape.astype(int)))
 
+    @testing.for_float_dtypes(no_float16=True)
+    @testing.numpy_cupy_allclose(atol=1e-4)
+    def test_zoom_opencv_output_size1(self, xp, dtype):
+        a = testing.shaped_random((100, 100, 1), xp, dtype)
+        if xp == cupy:
+            return cupyx.scipy.ndimage.zoom(a, (self.zoom, self.zoom, 1),
+                                            order=1, mode='opencv')
+        else:
+            output_shape = numpy.rint(numpy.multiply(a.shape[:2], self.zoom))
+            return numpy.expand_dims(
+                cv2.resize(a, tuple(output_shape.astype(int))), axis=-1)
+
 
 @testing.parameterize(*testing.product({
     # these 3 modes have analytical spline boundary conditions


### PR DESCRIPTION
This PR fixes a bug in `cupyx.scipy.ndimage.zoom` that occurs when `mode='opencv'` and an image output size is 1 along any axis (it includes resizing grayscale images (N, M, 1) or batches of images (1, N, M, C)). The bug is caused by incorrectly setting zoom coefficients for output axes of size 1 and eventually [division by 0](https://github.com/cupy/cupy/blob/ec7bd5434f7f41a8c4d57367ef9afc05ccdaf121/cupyx/scipy/ndimage/_interpolation.py#L453) during the affine transform stage.