### PR TITLE
add flag to cupyx.profiler.benchmark to deepcopy positional arguments before calling function under test

### DIFF
--- a/cupyx/profiler/_time.py
+++ b/cupyx/profiler/_time.py
@@ -82,7 +82,8 @@ class _PerfCaseResult:
 
 def benchmark(
         func, args=(), kwargs={}, n_repeat=10000, *,
-        name=None, n_warmup=10, max_duration=_math.inf, devices=None, copy_args=False):
+        name=None, n_warmup=10, max_duration=_math.inf, devices=None,
+        copy_args=False):
     """ Timing utility for measuring time spent by both CPU and GPU.
 
     This function is a very convenient helper for setting up a timing test. The
@@ -122,8 +123,9 @@ def benchmark(
         devices (tuple): a tuple of device IDs (int) that will be timed during
             the timing test. If not given, the current device is used.
         copy_args (bool): a flag indicating the positional arguments should be
-            copied before calling the function under test. Useful if the function
-            under test modifies data in place, and this modification effects runtime.
+            copied before calling the function under test. Useful if the
+            function under test modifies data in place, and this modification
+            effects runtime.
 
     Returns:
         :class:`~cupyx.profiler._time._PerfCaseResult`:
@@ -155,11 +157,13 @@ def benchmark(
         raise ValueError('`devices` should be of tuple type')
 
     return _repeat(
-        func, args, kwargs, n_repeat, name, n_warmup, max_duration, devices, copy_args)
+        func, args, kwargs, n_repeat, name, n_warmup, max_duration, devices,
+        copy_args)
 
 
 def _repeat(
-        func, args, kwargs, n_repeat, name, n_warmup, max_duration, devices, copy_args):
+        func, args, kwargs, n_repeat, name, n_warmup, max_duration, devices,
+        copy_args):
 
     events_1 = []
     events_2 = []


### PR DESCRIPTION
This PR adds a `copy_args` flag to `cupyx.profiler.benchmark` to deep copy all positional arguments before calling the function under test.

Currently `cupyx.profiler.benchmark` will call the function under test repeatedly with the same positional arguments. I ran into an issue where I wanted to benchmark a function I wrote that modifies data in place for one of it's arguments. This function does not behave the same when passed data that has already been modified, so in order to get an accurate benchmark, the the positional arguments need to be copied before each call. This seems like a feature that could be helpful for others too.

