### PR TITLE
Fix wrong argument in warnings.warn()

### DIFF
--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -1625,7 +1625,7 @@ cdef class _ndarray_base:
 
         """
         warnings.warn(
-            '`ndarray.scatter_max` is deprecated ',
+            '`ndarray.scatter_max` is deprecated '
             'Please use `cupy.maximum.at` instead.',
             DeprecationWarning)
         self._scatter_op(slices, value, 'max')
@@ -1638,7 +1638,7 @@ cdef class _ndarray_base:
 
         """
         warnings.warn(
-            '`ndarray.scatter_min` is deprecated ',
+            '`ndarray.scatter_min` is deprecated '
             'Please use `cupy.minimum.at` instead.',
             DeprecationWarning)
         self._scatter_op(slices, value, 'min')


### PR DESCRIPTION
The argument to `warnings.warn()`, added when `ndarray.scatter_max()` and `ndarray.scatter_min()` were deprecated, is not correct and `cupyx.scatter_max()` and `cupyx.scatter_min()` would result in the following error.
```
>>> import cupy as cp
>>> import cupyx
>>> a = cp.zeros(10)
>>> b = cp.arange(20)
>>> c = cp.arange(20)
>>> cupyx.scatter_max(a, b, c)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.8/dist-packages/cupyx/_scatter.py", line 91, in scatter_max
    a.scatter_max(slices, value)
  File "cupy/_core/core.pyx", line 1624, in cupy._core.core._ndarray_base.scatter_max
TypeError: 'type' object cannot be interpreted as an integer
```
This PR is to correct this problem.