### PR TITLE
Adding uniform() to random generator, since numpy has this functionality

### DIFF
--- a/cupy/random/_generator_api.pyx
+++ b/cupy/random/_generator_api.pyx
@@ -227,7 +227,7 @@ class Generator:
         # cython cant call astype with the default values for
         # omitted args.
         return (<object>y).astype(dtype, copy=False)
-    
+
     def integers(
             self, low, high=None, size=None,
             dtype=numpy.int64, endpoint=False):

--- a/cupy/random/_generator_api.pyx
+++ b/cupy/random/_generator_api.pyx
@@ -159,6 +159,75 @@ class Generator:
         # omitted args.
         return (<object>y).astype(dtype, copy=False)
 
+    def uniform(self, low=0.0, high=1.0, size=None, dtype=numpy.float64):
+        """
+        Draw samples from a uniform distribution.
+        Samples are uniformly distributed over the half-open interval
+        ``[low, high)`` (includes low, but excludes high).  In other words,
+        any value within the given interval is equally likely to be drawn
+        by `uniform`.
+
+        Parameters
+        ----------
+        low : float or array_like of floats, optional
+            Lower boundary of the output interval.  All values generated will
+            be greater than or equal to low.  The default value is 0.
+        high : float or array_like of floats
+            Upper boundary of the output interval.  All values generated will
+            be less than high.  The high limit may be included in the returned
+            array of floats due to floating-point rounding in the equation
+            ``low + (high-low) * random()``.  high - low must be
+            non-negative.  The default value is 1.0.
+        size : int or tuple of ints, optional
+            Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
+            ``m * n * k`` samples are drawn.  If size is ``None`` (default),
+            a single value is returned if ``low`` and ``high`` are both
+            scalars.  Otherwise, ``cupy.broadcast(low, high).size`` samples are
+            drawn.
+
+        Returns
+        -------
+        out : ndarray or scalar
+            Drawn samples from the parameterized uniform distribution.
+        See Also
+        --------
+        - :meth:`numpy.random.Generator.uniform`
+        - :meth:`integers`: Discrete uniform distribution, yielding integers.
+        - :meth:`random`: Floats uniformly distributed over ``[0, 1)``.
+        """
+
+        cdef _ndarray_base y
+
+        if not isinstance(low, _ndarray_base):
+            if type(low) in (float, int):
+                low = cupy.asarray(low, numpy.float64)
+            else:
+                raise TypeError('low is required to be a cupy.ndarray'
+                                ' or a scalar')
+        if not isinstance(high, _ndarray_base):
+            if type(high) in (float, int):
+                high = cupy.asarray(high, numpy.float64)
+            else:
+                raise TypeError('high is required to be a cupy.ndarray'
+                                ' or a scalar')
+
+        if size is not None and not isinstance(size, tuple):
+            size = (size, )
+        elif size is None:
+            size = cupy.broadcast(low, high).shape
+
+        y = _core.ndarray(size, numpy.float64)
+        low = cupy.broadcast_to(low, y.shape)
+        high = cupy.broadcast_to(high, y.shape)
+
+        _launch_dist(self.bit_generator, random_uniform, y, ())
+        y = low + (high - low) * y
+
+        # we cast the array to a python object because
+        # cython cant call astype with the default values for
+        # omitted args.
+        return (<object>y).astype(dtype, copy=False)
+    
     def integers(
             self, low, high=None, size=None,
             dtype=numpy.int64, endpoint=False):

--- a/cupy/random/_generator_api.pyx
+++ b/cupy/random/_generator_api.pyx
@@ -198,24 +198,12 @@ class Generator:
 
         cdef _ndarray_base y
 
-        if not isinstance(low, _ndarray_base):
-            if type(low) in (float, int):
-                low = cupy.asarray(low, numpy.float64)
-            else:
-                raise TypeError('low is required to be a cupy.ndarray'
-                                ' or a scalar')
-        if not isinstance(high, _ndarray_base):
-            if type(high) in (float, int):
-                high = cupy.asarray(high, numpy.float64)
-            else:
-                raise TypeError('high is required to be a cupy.ndarray'
-                                ' or a scalar')
+        low = cupy.asarray(low)        
+        high = cupy.asarray(high)
 
-        if size is not None and not isinstance(size, tuple):
-            size = (size, )
-        elif size is None:
+        if size is None:
             size = cupy.broadcast(low, high).shape
-
+            
         y = _core.ndarray(size, numpy.float64)
         low = cupy.broadcast_to(low, y.shape)
         high = cupy.broadcast_to(high, y.shape)

--- a/cupy/random/_generator_api.pyx
+++ b/cupy/random/_generator_api.pyx
@@ -198,12 +198,12 @@ class Generator:
 
         cdef _ndarray_base y
 
-        low = cupy.asarray(low)        
+        low = cupy.asarray(low)
         high = cupy.asarray(high)
 
         if size is None:
             size = cupy.broadcast(low, high).shape
-            
+
         y = _core.ndarray(size, numpy.float64)
         low = cupy.broadcast_to(low, y.shape)
         high = cupy.broadcast_to(high, y.shape)

--- a/tests/cupy_tests/random_tests/common_distributions.py
+++ b/tests/cupy_tests/random_tests/common_distributions.py
@@ -127,6 +127,23 @@ D- (cupy > numpy): %f''' % (p_value, d_plus, d_minus)
             raise AssertionError(message)
 
 
+uniform_params = [
+    {'low': 1, 'high': 10.0, 'size': (3, 5)},
+    {'low': cupy.array([1, 2]), 'high': 3, 'size': None},
+    {'low': 20, 'high': 20.1, 'size': 1000}
+]
+
+
+class Uniform:
+    target_method = 'uniform'
+
+    def test_uniform(self):
+        print("testing uniform")
+        result = self.generate(self.low, self.high, self.size)
+        assert cupy.all(result >= cupy.asarray(self.low).min())
+        assert cupy.all(result < cupy.asarray(self.high).max())
+
+
 beta_params = [
     {'a': 1.0, 'b': 3.0},
     {'a': 3.0, 'b': 3.0},

--- a/tests/cupy_tests/random_tests/common_distributions.py
+++ b/tests/cupy_tests/random_tests/common_distributions.py
@@ -129,7 +129,7 @@ D- (cupy > numpy): %f''' % (p_value, d_plus, d_minus)
 
 uniform_params = [
     {'low': 1, 'high': 10.0, 'size': (3, 5)},
-    {'low': cupy.array([1, 2]), 'high': 3, 'size': None},
+    {'low': [1, 2], 'high': 3, 'size': None},
     {'low': 20, 'high': 20.1, 'size': 1000}
 ]
 
@@ -138,10 +138,22 @@ class Uniform:
     target_method = 'uniform'
 
     def test_uniform(self):
-        print("testing uniform")
-        result = self.generate(self.low, self.high, self.size)
-        assert cupy.all(result >= cupy.asarray(self.low).min())
-        assert cupy.all(result < cupy.asarray(self.high).max())
+        low = self.low
+        if isinstance(low, list):
+            low = cupy.array(low)
+        high = self.high
+        if isinstance(high, list):
+            high = cupy.array(high)
+            
+        result = self.generate(low, high, self.size)
+        assert cupy.all(result >= cupy.asarray(low).min())
+        assert cupy.all(result < cupy.asarray(high).max())
+
+    @_condition.repeat_with_success_at_least(10, 3)
+    def test_uniform_ks(self):
+        if (isinstance(self.low, list) or isinstance(self.high, list)):
+            self.skipTest('Stastical checks only for scalar args')
+        self.check_ks(0.05)(low=self.low, high=self.low, size=2000)
 
 
 beta_params = [

--- a/tests/cupy_tests/random_tests/common_distributions.py
+++ b/tests/cupy_tests/random_tests/common_distributions.py
@@ -144,7 +144,7 @@ class Uniform:
         high = self.high
         if isinstance(high, list):
             high = cupy.array(high)
-            
+
         result = self.generate(low, high, self.size)
         assert cupy.all(result >= cupy.asarray(low).min())
         assert cupy.all(result < cupy.asarray(high).max())

--- a/tests/cupy_tests/random_tests/test_generator_api.py
+++ b/tests/cupy_tests/random_tests/test_generator_api.py
@@ -58,6 +58,17 @@ class InvalidOutsMixin:
         self.invalid_shape()
 
 
+@testing.parameterize(*common_distributions.uniform_params)
+@testing.with_requires('numpy>=1.17.0')
+@testing.gpu
+@testing.fix_random()
+class TestUniform(
+    common_distributions.Uniform,
+    GeneratorTestCase
+):
+    pass
+
+
 @testing.parameterize(*common_distributions.exponential_params)
 @testing.with_requires('numpy>=1.17.0')
 @testing.gpu


### PR DESCRIPTION
Implementing this method: https://numpy.org/doc/stable/reference/random/generated/numpy.random.Generator.uniform.html