### PR TITLE
Fix cusparseSpSM compatibility

### DIFF
--- a/cupy_backends/cuda/cupy_cusparse.h
+++ b/cupy_backends/cuda/cupy_cusparse.h
@@ -645,21 +645,6 @@ cusparseStatus_t cusparseSpSM_solve(...) {
 
 #endif // #if CUSPARSE_VERSION < 11600
 
-// See cusparse.pyx
-cusparseStatus_t _cusparseSpSM_solve(cusparseHandle_t     handle,
-                                     cusparseOperation_t  opA,
-                                     cusparseOperation_t  opB,
-                                     const void*          alpha,
-                                     cusparseSpMatDescr_t matA,
-                                     cusparseDnMatDescr_t matB,
-                                     cusparseDnMatDescr_t matC,
-                                     cudaDataType         computeType,
-                                     cusparseSpSMAlg_t    alg,
-                                     cusparseSpSMDescr_t  spsmDescr,
-                                     void*                externalBuffer) {
-    return cusparseSpSM_solve(handle, opA, opB, alpha, matA, matB, matC, computeType, alg, spsmDescr);
-}
-
 #if CUSPARSE_VERSION >= 12000
 // Types and functions deleted in cuSPARSE 12.0 (CUDA 12.0)
 

--- a/cupy_backends/cuda/cupy_cusparse.h
+++ b/cupy_backends/cuda/cupy_cusparse.h
@@ -611,10 +611,6 @@ typedef enum {} cusparseDenseToSparseAlg_t;
 
 typedef enum {} cusparseSpMatAttribute_t;
 
-cusparseStatus_t cusparseSpMatSetAttribute(...) {
-  return CUSPARSE_STATUS_SUCCESS;
-}
-
 #endif // CUSPARSE_VERSION < 11500
 
 #if CUSPARSE_VERSION < 11600
@@ -622,26 +618,6 @@ cusparseStatus_t cusparseSpMatSetAttribute(...) {
 
 typedef void* cusparseSpSMDescr_t;
 typedef enum {} cusparseSpSMAlg_t;
-
-cusparseStatus_t cusparseSpSM_createDescr(...) {
-  return CUSPARSE_STATUS_SUCCESS;
-}
-
-cusparseStatus_t cusparseSpSM_destroyDescr(...) {
-  return CUSPARSE_STATUS_SUCCESS;
-}
-
-cusparseStatus_t cusparseSpSM_bufferSize(...) {
-  return CUSPARSE_STATUS_SUCCESS;
-}
-
-cusparseStatus_t cusparseSpSM_analysis(...) {
-  return CUSPARSE_STATUS_SUCCESS;
-}
-
-cusparseStatus_t cusparseSpSM_solve(...) {
-  return CUSPARSE_STATUS_SUCCESS;
-}
 
 #endif // #if CUSPARSE_VERSION < 11600
 

--- a/cupy_backends/hip/cupy_hipsparse.h
+++ b/cupy_backends/hip/cupy_hipsparse.h
@@ -3578,17 +3578,17 @@ cusparseStatus_t cusparseSpSM_analysis(cusparseHandle_t     handle,
 }
 
 // See cusparse.pyx for a comment
-cusparseStatus_t _cusparseSpSM_solve(cusparseHandle_t     handle,
-                                     cusparseOperation_t  opA,
-                                     cusparseOperation_t  opB,
-                                     const void*          alpha,
-                                     cusparseSpMatDescr_t matA,
-                                     cusparseDnMatDescr_t matB,
-                                     cusparseDnMatDescr_t matC,
-                                     cudaDataType         computeType,
-                                     cusparseSpSMAlg_t    alg,
-                                     cusparseSpSMDescr_t  spsmDescr,
-                                     void*                externalBuffer) {
+cusparseStatus_t cusparseSpSM_solve(cusparseHandle_t     handle,
+                                    cusparseOperation_t  opA,
+                                    cusparseOperation_t  opB,
+                                    const void*          alpha,
+                                    cusparseSpMatDescr_t matA,
+                                    cusparseDnMatDescr_t matB,
+                                    cusparseDnMatDescr_t matC,
+                                    cudaDataType         computeType,
+                                    cusparseSpSMAlg_t    alg,
+                                    cusparseSpSMDescr_t  spsmDescr,
+                                    void*                externalBuffer) {
 #if HIP_VERSION >= 50000000
   hipDataType computeType1 = convert_hipDatatype(computeType);
   return hipsparseSpSM_solve(handle, opA, opB, alpha, matA, matB, matC, computeType1, alg, spsmDescr, externalBuffer);

--- a/cupy_backends/stub/cupy_cusparse.h
+++ b/cupy_backends/stub/cupy_cusparse.h
@@ -1145,7 +1145,7 @@ cusparseStatus_t cusparseSpSM_analysis(...) {
 }
 
 // See cusparse.pyx for a comment
-cusparseStatus_t _cusparseSpSM_solve(...) {
+cusparseStatus_t cusparseSpSM_solve(...) {
   return CUSPARSE_STATUS_SUCCESS;
 }
 


### PR DESCRIPTION
CUDA 11.x basically have minor version compatibility. However, they have some APIs that are introduced in the middle of 11.x minor versions, which APIs do not exist in CUDA toolkit before they're introduced. In such a case we have to dlopen the APIs at runtime instead of (dynamic-)link them at build-time against the latest 11.x minor version. Otherwise, the process complains when the depending (cython-origin) shared object is loaded.