### PR TITLE
`cupyx.scipy.sparse.linalg.spsolve` : allow two-dimensional right-hand sides in `A @ X = B`

### DIFF
--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
@@ -885,6 +885,22 @@ class TestCsrlsvqr:
                                      atol=test_tol)
 
 
+@testing.with_requires('scipy')
+class TestSpSolve:
+    @pytest.mark.parametrize('dtyp',
+                             ['float32', 'float64', 'complex64', 'complex128'])
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_spsolve(self, xp, sp, dtyp):
+        n = 5
+        nb = 3
+
+        a = xp.diag(xp.arange(n) + 1)
+        sa = sp.csr_matrix(a.astype(dtyp))
+        b = xp.ones((n, nb), dtype=dtyp)
+        result = sp.linalg.spsolve(sa, b)
+        return result
+
+
 def _eigen_vec_transform(block_vec, xp):
     """Helper to swap sign of each eigen vector based on the first
     non-zero element. ie, to standardize the first non-zero element

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
@@ -887,12 +887,8 @@ class TestCsrlsvqr:
 
 @testing.with_requires('scipy')
 class TestSpSolve:
-    @pytest.mark.parametrize('dtyp',
-                             ['float32', 'float64', 'complex64', 'complex128'])
-    @testing.numpy_cupy_allclose(sp_name='sp', atol=5e-7)
-    def test_spsolve(self, xp, sp, dtyp):
-        n = 5
-        nb = 3
+    def _check_spsolve(self, xp, sp, dtyp):
+        n, nb = 5, 3
 
         a = xp.diag(xp.arange(n) + 1)
         sa = sp.csr_matrix(a.astype(dtyp))
@@ -902,6 +898,16 @@ class TestSpSolve:
         b = b[::2, :]
         result = sp.linalg.spsolve(sa, b)
         return result
+
+    @pytest.mark.parametrize('dtyp', ['float32', 'complex64'])
+    @testing.numpy_cupy_allclose(sp_name='sp', atol=5e-7)
+    def test_spsolve_single(self, xp, sp, dtyp):
+        return self._check_spsolve(xp, sp, dtyp)
+
+    @pytest.mark.parametrize('dtyp', ['float64', 'complex128'])
+    @testing.numpy_cupy_allclose(sp_name='sp', atol=1e-14)
+    def test_spsolve_double(self, xp, sp, dtyp):
+        return self._check_spsolve(xp, sp, dtyp)
 
 
 def _eigen_vec_transform(block_vec, xp):

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
@@ -885,6 +885,7 @@ class TestCsrlsvqr:
                                      atol=test_tol)
 
 
+@pytest.mark.skipif(runtime.is_hip, reason='csrlsvqr not available')
 @testing.with_requires('scipy')
 class TestSpSolve:
     def _check_spsolve(self, xp, sp, dtyp):

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
@@ -889,14 +889,17 @@ class TestCsrlsvqr:
 class TestSpSolve:
     @pytest.mark.parametrize('dtyp',
                              ['float32', 'float64', 'complex64', 'complex128'])
-    @testing.numpy_cupy_allclose(sp_name='sp')
+    @testing.numpy_cupy_allclose(sp_name='sp', atol=5e-7)
     def test_spsolve(self, xp, sp, dtyp):
         n = 5
         nb = 3
 
         a = xp.diag(xp.arange(n) + 1)
         sa = sp.csr_matrix(a.astype(dtyp))
-        b = xp.ones((n, nb), dtype=dtyp)
+
+        # prepare b to be non-contiguous
+        b = xp.arange((2*n*nb), dtype=dtyp).reshape((2*n, nb))
+        b = b[::2, :]
         result = sp.linalg.spsolve(sa, b)
         return result
 


### PR DESCRIPTION
Make `cupyx.scipy.sparse.spsolve` loop over the columns of `b` --- this matches the behavior of the scipy equivalent, which accepts 2D `B` arrays/matrices in `A @ X = B`: https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.linalg.spsolve.html

This is  a pure python loop since the underlying cusolver routine IIUC only accepts vectors. 

Several things to note:
1. This does not handle the case where A is real and b is complex. This still needs an upcast or looping on the user side 
2. This patch removes `b.ravel()` --- I tried testing with non-contiguous `b` arrays, so am *pretty sure* that it's OK, but please advise about how far one has to bend backwards to assert contiguity of inputs to cusolver routines.
3. Fortran ordering: this PR explicitly casts the result to be Fortran contiguous to match what `scipy.sparse.linalg.spsolve`  returns. Please advise.
4. Testing tolerance is pretty weak currently. Not sure how to best choose the dtype-dependent tolerance of `@assert_numpy_cupy_allclose` for a test which is additionally parametrized by dtypes.
