### PR TITLE
Use naive comb() for Python 3.7

### DIFF
--- a/cupyx/scipy/interpolate/_rbfinterp.py
+++ b/cupyx/scipy/interpolate/_rbfinterp.py
@@ -394,6 +394,14 @@ _NAME_TO_MIN_DEGREE = {
 }
 
 
+try:
+    _comb = math.comb
+except AttributeError:
+    # Naive combination for Python 3.7
+    def _comb(n, k):
+        return math.factorial(n) // (math.factorial(n - k) * math.factorial(k))
+
+
 def _monomial_powers(ndim, degree):
     """Return the powers for each monomial in a polynomial.
 
@@ -411,7 +419,7 @@ def _monomial_powers(ndim, degree):
         monomial.
 
     """
-    nmonos = math.comb(degree + ndim, ndim)
+    nmonos = _comb(degree + ndim, ndim)
     out = cp.zeros((nmonos, ndim), dtype=int)
     count = 0
     for deg in range(degree + 1):


### PR DESCRIPTION
Follows up #7218. We fixed to use `math.comb()` instead of `scipy.special.comb()` there to remove scipy dependency, however, it requires Python 3.8 or higher.