### PR TITLE
CI: Support cuTENSOR 1.6.2 which defaults to CUDA 12

### DIFF
--- a/.pfnci/generate.py
+++ b/.pfnci/generate.py
@@ -144,6 +144,14 @@ class LinuxGenerator:
         else:
             raise AssertionError
 
+        # Update alternatives for cuTENSOR for the current CUDA version.
+        if matrix.cutensor is not None:
+            lines += [
+                'COPY setup/update-alternatives-cutensor.sh /',
+                'RUN /update-alternatives-cutensor.sh',
+                '',
+            ]
+
         # Set environment variables for ROCm.
         if matrix.rocm is not None:
             lines += [

--- a/.pfnci/linux/tests/benchmark.Dockerfile
+++ b/.pfnci/linux/tests/benchmark.Dockerfile
@@ -18,6 +18,9 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
 
 ENV PATH "/usr/lib/ccache:${PATH}"
 
+COPY setup/update-alternatives-cutensor.sh /
+RUN /update-alternatives-cutensor.sh
+
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"

--- a/.pfnci/linux/tests/benchmark.head.Dockerfile
+++ b/.pfnci/linux/tests/benchmark.head.Dockerfile
@@ -18,6 +18,9 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
 
 ENV PATH "/usr/lib/ccache:${PATH}"
 
+COPY setup/update-alternatives-cutensor.sh /
+RUN /update-alternatives-cutensor.sh
+
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"

--- a/.pfnci/linux/tests/cuda-example.Dockerfile
+++ b/.pfnci/linux/tests/cuda-example.Dockerfile
@@ -18,6 +18,9 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
 
 ENV PATH "/usr/lib/ccache:${PATH}"
 
+COPY setup/update-alternatives-cutensor.sh /
+RUN /update-alternatives-cutensor.sh
+
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"

--- a/.pfnci/linux/tests/cuda-head.Dockerfile
+++ b/.pfnci/linux/tests/cuda-head.Dockerfile
@@ -18,6 +18,9 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
 
 ENV PATH "/usr/lib/ccache:${PATH}"
 
+COPY setup/update-alternatives-cutensor.sh /
+RUN /update-alternatives-cutensor.sh
+
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"

--- a/.pfnci/linux/tests/cuda-slow.Dockerfile
+++ b/.pfnci/linux/tests/cuda-slow.Dockerfile
@@ -18,6 +18,9 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
 
 ENV PATH "/usr/lib/ccache:${PATH}"
 
+COPY setup/update-alternatives-cutensor.sh /
+RUN /update-alternatives-cutensor.sh
+
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"

--- a/.pfnci/linux/tests/cuda110.Dockerfile
+++ b/.pfnci/linux/tests/cuda110.Dockerfile
@@ -18,6 +18,9 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
 
 ENV PATH "/usr/lib/ccache:${PATH}"
 
+COPY setup/update-alternatives-cutensor.sh /
+RUN /update-alternatives-cutensor.sh
+
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"

--- a/.pfnci/linux/tests/cuda110.multi.Dockerfile
+++ b/.pfnci/linux/tests/cuda110.multi.Dockerfile
@@ -18,6 +18,9 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
 
 ENV PATH "/usr/lib/ccache:${PATH}"
 
+COPY setup/update-alternatives-cutensor.sh /
+RUN /update-alternatives-cutensor.sh
+
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"

--- a/.pfnci/linux/tests/cuda111.Dockerfile
+++ b/.pfnci/linux/tests/cuda111.Dockerfile
@@ -17,6 +17,9 @@ RUN yum -y install \
 
 ENV PATH "/usr/lib64/ccache:${PATH}"
 
+COPY setup/update-alternatives-cutensor.sh /
+RUN /update-alternatives-cutensor.sh
+
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"

--- a/.pfnci/linux/tests/cuda111.multi.Dockerfile
+++ b/.pfnci/linux/tests/cuda111.multi.Dockerfile
@@ -17,6 +17,9 @@ RUN yum -y install \
 
 ENV PATH "/usr/lib64/ccache:${PATH}"
 
+COPY setup/update-alternatives-cutensor.sh /
+RUN /update-alternatives-cutensor.sh
+
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"

--- a/.pfnci/linux/tests/cuda112.Dockerfile
+++ b/.pfnci/linux/tests/cuda112.Dockerfile
@@ -17,6 +17,9 @@ RUN yum -y install \
 
 ENV PATH "/usr/lib64/ccache:${PATH}"
 
+COPY setup/update-alternatives-cutensor.sh /
+RUN /update-alternatives-cutensor.sh
+
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"

--- a/.pfnci/linux/tests/cuda112.multi.Dockerfile
+++ b/.pfnci/linux/tests/cuda112.multi.Dockerfile
@@ -17,6 +17,9 @@ RUN yum -y install \
 
 ENV PATH "/usr/lib64/ccache:${PATH}"
 
+COPY setup/update-alternatives-cutensor.sh /
+RUN /update-alternatives-cutensor.sh
+
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"

--- a/.pfnci/linux/tests/cuda113.Dockerfile
+++ b/.pfnci/linux/tests/cuda113.Dockerfile
@@ -18,6 +18,9 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
 
 ENV PATH "/usr/lib/ccache:${PATH}"
 
+COPY setup/update-alternatives-cutensor.sh /
+RUN /update-alternatives-cutensor.sh
+
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"

--- a/.pfnci/linux/tests/cuda113.multi.Dockerfile
+++ b/.pfnci/linux/tests/cuda113.multi.Dockerfile
@@ -18,6 +18,9 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
 
 ENV PATH "/usr/lib/ccache:${PATH}"
 
+COPY setup/update-alternatives-cutensor.sh /
+RUN /update-alternatives-cutensor.sh
+
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"

--- a/.pfnci/linux/tests/cuda114.Dockerfile
+++ b/.pfnci/linux/tests/cuda114.Dockerfile
@@ -18,6 +18,9 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
 
 ENV PATH "/usr/lib/ccache:${PATH}"
 
+COPY setup/update-alternatives-cutensor.sh /
+RUN /update-alternatives-cutensor.sh
+
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"

--- a/.pfnci/linux/tests/cuda114.multi.Dockerfile
+++ b/.pfnci/linux/tests/cuda114.multi.Dockerfile
@@ -18,6 +18,9 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
 
 ENV PATH "/usr/lib/ccache:${PATH}"
 
+COPY setup/update-alternatives-cutensor.sh /
+RUN /update-alternatives-cutensor.sh
+
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"

--- a/.pfnci/linux/tests/cuda115.Dockerfile
+++ b/.pfnci/linux/tests/cuda115.Dockerfile
@@ -18,6 +18,9 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
 
 ENV PATH "/usr/lib/ccache:${PATH}"
 
+COPY setup/update-alternatives-cutensor.sh /
+RUN /update-alternatives-cutensor.sh
+
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"

--- a/.pfnci/linux/tests/cuda115.multi.Dockerfile
+++ b/.pfnci/linux/tests/cuda115.multi.Dockerfile
@@ -18,6 +18,9 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
 
 ENV PATH "/usr/lib/ccache:${PATH}"
 
+COPY setup/update-alternatives-cutensor.sh /
+RUN /update-alternatives-cutensor.sh
+
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"

--- a/.pfnci/linux/tests/cuda116.Dockerfile
+++ b/.pfnci/linux/tests/cuda116.Dockerfile
@@ -18,6 +18,9 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
 
 ENV PATH "/usr/lib/ccache:${PATH}"
 
+COPY setup/update-alternatives-cutensor.sh /
+RUN /update-alternatives-cutensor.sh
+
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"

--- a/.pfnci/linux/tests/cuda116.multi.Dockerfile
+++ b/.pfnci/linux/tests/cuda116.multi.Dockerfile
@@ -18,6 +18,9 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
 
 ENV PATH "/usr/lib/ccache:${PATH}"
 
+COPY setup/update-alternatives-cutensor.sh /
+RUN /update-alternatives-cutensor.sh
+
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"

--- a/.pfnci/linux/tests/cuda117.Dockerfile
+++ b/.pfnci/linux/tests/cuda117.Dockerfile
@@ -18,6 +18,9 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
 
 ENV PATH "/usr/lib/ccache:${PATH}"
 
+COPY setup/update-alternatives-cutensor.sh /
+RUN /update-alternatives-cutensor.sh
+
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"

--- a/.pfnci/linux/tests/cuda117.multi.Dockerfile
+++ b/.pfnci/linux/tests/cuda117.multi.Dockerfile
@@ -18,6 +18,9 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
 
 ENV PATH "/usr/lib/ccache:${PATH}"
 
+COPY setup/update-alternatives-cutensor.sh /
+RUN /update-alternatives-cutensor.sh
+
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"

--- a/.pfnci/linux/tests/cuda118.Dockerfile
+++ b/.pfnci/linux/tests/cuda118.Dockerfile
@@ -18,6 +18,9 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
 
 ENV PATH "/usr/lib/ccache:${PATH}"
 
+COPY setup/update-alternatives-cutensor.sh /
+RUN /update-alternatives-cutensor.sh
+
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"

--- a/.pfnci/linux/tests/cuda118.multi.Dockerfile
+++ b/.pfnci/linux/tests/cuda118.multi.Dockerfile
@@ -18,6 +18,9 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
 
 ENV PATH "/usr/lib/ccache:${PATH}"
 
+COPY setup/update-alternatives-cutensor.sh /
+RUN /update-alternatives-cutensor.sh
+
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"

--- a/.pfnci/linux/tests/cuda11x-cuda-python.Dockerfile
+++ b/.pfnci/linux/tests/cuda11x-cuda-python.Dockerfile
@@ -18,6 +18,9 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
 
 ENV PATH "/usr/lib/ccache:${PATH}"
 
+COPY setup/update-alternatives-cutensor.sh /
+RUN /update-alternatives-cutensor.sh
+
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"

--- a/.pfnci/linux/tests/setup/update-alternatives-cutensor.sh
+++ b/.pfnci/linux/tests/setup/update-alternatives-cutensor.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Updates alternatives configuration for cuTENSOR package
+
+set -ue
+
+case "${CUDA_VERSION:-}" in
+    10.2.* )  CUTENSOR_CUDA_PREFIX="10.2" ;;
+    11.0.* )  CUTENSOR_CUDA_PREFIX="11.0" ;;
+    11.*   )  CUTENSOR_CUDA_PREFIX="11"   ;;
+    12.*   )  CUTENSOR_CUDA_PREFIX="12"   ;;
+    *      )  echo "Unknown CUDA_VERSION: ${CUDA_VERSION:-(not set)}" && exit 1 ;;
+esac
+echo "CUDA version prefix for cuTENSOR derived from CUDA_VERSION (${CUDA_VERSION}): ${CUTENSOR_CUDA_PREFIX}"
+
+# TODO(kmaehashi): this assumes x86_64 env
+if which apt &> /dev/null; then
+    # APT
+    SYSTEM_LIBDIR="/usr/lib/x86_64-linux-gnu"
+else
+    # RPM
+    SYSTEM_LIBDIR="/usr/lib64"
+fi
+
+CUTENSOR_LIBNAME="$(basename ${SYSTEM_LIBDIR}/libcutensor.so.?.*)"
+CUTENSORMG_LIBNAME="$(basename ${SYSTEM_LIBDIR}/libcutensorMg.so.?.*)"
+
+echo "Changing alternatives configuration:"
+set -x
+update-alternatives --set "${CUTENSOR_LIBNAME}" "${SYSTEM_LIBDIR}/libcutensor/${CUTENSOR_CUDA_PREFIX}/${CUTENSOR_LIBNAME}"
+update-alternatives --set "${CUTENSORMG_LIBNAME}" "${SYSTEM_LIBDIR}/libcutensor/${CUTENSOR_CUDA_PREFIX}/${CUTENSORMG_LIBNAME}"
+set +x
+
+echo "Done setting up alternatives for cuTENSOR!"


### PR DESCRIPTION
cuTENSOR's deb/rpm packages now setup libraries for CUDA 12 by default.
So it is needed to switch to the appropriate binary depending on the current CUDA version.

This was discovered during review of #7235 (https://ci.preferred.jp/cupy.linux.cuda-example/118609/).

```
00:25:57.151677 STDOUT 1621]	+ python3 cutensor/contraction.py	1.7s
00:25:58.826849 STDOUT 1621]	Traceback (most recent call last):	
00:25:58.826859 STDOUT 1621]	  File "cutensor/contraction.py", line 6, in <module>	
00:25:58.826866 STDOUT 1621]	    from cupyx import cutensor	
00:25:58.826990 STDOUT 1621]	  File "cupyx/cutensor.pyx", line 1, in init cupyx.cutensor	
00:25:58.827087 STDOUT 1621]	ImportError: libcublasLt.so.12: cannot open shared object file: No such file or directory	
```