### PR TITLE
Skip tests if SciPy is unavailable

### DIFF
--- a/tests/cupyx_tests/scipy_tests/interpolate_tests/test_bspline2.py
+++ b/tests/cupyx_tests/scipy_tests/interpolate_tests/test_bspline2.py
@@ -13,6 +13,7 @@ except ImportError:
 
 
 @pytest.mark.skipif(runtime.is_hip, reason='csrlsvqr not available')
+@testing.with_requires("scipy")
 class TestInterp:
     #
     # Test basic ways of constructing interpolating splines.


### PR DESCRIPTION
Allow tests to run without SciPy.

https://ci.preferred.jp/cupy.linux.cuda111/118681/

> E           ModuleNotFoundError: No module named 'scipy'


ref #7195