### PR TITLE
Update for deprecations in NumPy 1.24

### DIFF
--- a/.pfnci/windows/test.ps1
+++ b/.pfnci/windows/test.ps1
@@ -73,6 +73,7 @@ function Main {
 
     echo "Building..."
     $build_retval = 0
+    RunOrDie python -m pip install -U "numpy<1.24"
     python -m pip install ".[all,test]" -vvv > cupy_build_log.txt
     if (-not $?) {
         $build_retval = $LastExitCode

--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -1,6 +1,5 @@
 import functools as _functools
 import sys as _sys
-import warnings as _warnings
 
 import numpy as _numpy
 
@@ -100,7 +99,6 @@ from numpy import unsignedinteger  # NOQA
 # Booleans
 # -----------------------------------------------------------------------------
 from numpy import bool_  # NOQA
-from numpy import bool8  # NOQA
 
 # -----------------------------------------------------------------------------
 # Integers
@@ -111,7 +109,6 @@ from numpy import intc  # NOQA
 from numpy import int_  # NOQA
 from numpy import longlong  # NOQA
 from numpy import intp  # NOQA
-from numpy import int0  # NOQA
 from numpy import int8  # NOQA
 from numpy import int16  # NOQA
 from numpy import int32  # NOQA
@@ -126,7 +123,6 @@ from numpy import uintc  # NOQA
 from numpy import uint  # NOQA
 from numpy import ulonglong  # NOQA
 from numpy import uintp  # NOQA
-from numpy import uint0  # NOQA
 from numpy import uint8  # NOQA
 from numpy import uint16  # NOQA
 from numpy import uint32  # NOQA
@@ -912,29 +908,13 @@ def show_config(*, _full=False):
 
 
 _deprecated_apis = [
-    'MachAr',  # NumPy 1.22
+    'int0',
+    'uint0',
+    'bool8',
 ]
-
-_deprecated_scalar_aliases = {  # NumPy 1.20
-    'int': (int, 'cupy.int_'),
-    'bool': (bool, 'cupy.bool_'),
-    'float': (float, 'cupy.float_'),
-    'complex': (complex, 'cupy.complex_'),
-}
 
 
 def __getattr__(name):
-    value = _deprecated_scalar_aliases.get(name)
-    if value is not None:
-        attr, eq_attr = value
-        _warnings.warn(
-            f'`cupy.{name}` is a deprecated alias for the Python scalar type '
-            f'`{name}`. Please use the builtin `{name}` or its corresponding '
-            f'NumPy scalar type `{eq_attr}` instead.',
-            DeprecationWarning, stacklevel=2
-        )
-        return attr
-
     if name in _deprecated_apis:
         return getattr(_numpy, name)
 

--- a/cupy/_sorting/sort.py
+++ b/cupy/_sorting/sort.py
@@ -1,3 +1,5 @@
+import warnings
+
 import cupy
 import numpy
 
@@ -130,7 +132,9 @@ def msort(a):
     .. seealso:: :func:`numpy.msort`
 
     """
-
+    warnings.warn(
+        'msort is deprecated, use cupy.sort(a, axis=0) instead',
+        DeprecationWarning)
     return sort(a, axis=0)
 
 

--- a/tests/cupy_tests/binary_tests/test_elementwise.py
+++ b/tests/cupy_tests/binary_tests/test_elementwise.py
@@ -9,14 +9,14 @@ class TestElementwise(unittest.TestCase):
     @testing.for_int_dtypes()
     @testing.numpy_cupy_array_equal()
     def check_unary_int(self, name, xp, dtype):
-        a = xp.array([-3, -2, -1, 0, 1, 2, 3], dtype=dtype)
+        a = xp.array([-3, -2, -1, 0, 1, 2, 3]).astype(dtype)
         return getattr(xp, name)(a)
 
     @testing.for_int_dtypes()
     @testing.numpy_cupy_array_equal()
     def check_binary_int(self, name, xp, dtype):
-        a = xp.array([-3, -2, -1, 0, 1, 2, 3], dtype=dtype)
-        b = xp.array([0, 1, 2, 3, 4, 5, 6], dtype=dtype)
+        a = xp.array([-3, -2, -1, 0, 1, 2, 3]).astype(dtype)
+        b = xp.array([0, 1, 2, 3, 4, 5, 6]).astype(dtype)
         return getattr(xp, name)(a, b)
 
     def test_bitwise_and(self):

--- a/tests/cupy_tests/core_tests/test_core.py
+++ b/tests/cupy_tests/core_tests/test_core.py
@@ -71,13 +71,13 @@ class TestMinScalarType:
 
     @testing.for_all_dtypes()
     def test_numpy_scalar(self, dtype):
-        sc = dtype(-1)
+        sc = dtype(1)
         for v in (sc, [sc, sc]):
             assert cupy.min_scalar_type(v) is numpy.min_scalar_type(v)
 
     @testing.for_all_dtypes()
     def test_cupy_scalar(self, dtype):
-        sc = cupy.array(-1, dtype=dtype)
+        sc = cupy.array(-1).astype(dtype)
         for v in (sc, [sc, sc]):
             assert cupy.min_scalar_type(v) is sc.dtype
 

--- a/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
@@ -578,7 +578,7 @@ class TestArrayAdvancedIndexingSetitemScalarValueIndexError:
     {'shape': (2, 3, 4), 'indexes': [[1], slice(1, 2)], 'value': 1},
     {'shape': (2, 3, 4), 'indexes': [[[1]], slice(1, 2)], 'value': 1},
 )
-@testing.with_requires('numpy>=1.23')
+@testing.with_requires('numpy>=1.23,<1.24')
 class TestArrayAdvancedIndexingSetitemScalarValueIndexError2:
 
     @testing.for_all_dtypes()
@@ -586,6 +586,7 @@ class TestArrayAdvancedIndexingSetitemScalarValueIndexError2:
         for xp in (numpy, cupy):
             a = xp.zeros(self.shape, dtype=dtype)
             with pytest.raises(IndexError):
+                # This is deprecated and fails in NumPy 1.24.
                 with testing.assert_warns(numpy.VisibleDeprecationWarning):
                     a[self.indexes] = self.value
 

--- a/tests/cupy_tests/math_tests/test_arithmetic.py
+++ b/tests/cupy_tests/math_tests/test_arithmetic.py
@@ -288,14 +288,23 @@ class TestArithmeticBinary(ArithmeticBinaryBase):
         self.check_binary()
 
 
-@testing.gpu
 @testing.parameterize(*(
     testing.product({
+        'arg1': [numpy.array([3, 2, 1, 1, 2, 3], dtype=d)
+                 for d in unsigned_int_types
+                 ] + [0, 0.0, 2, 2.0, -2, -2.0, True, False],
+        'arg2': [numpy.array([3, 2, 1, 1, 2, 3], dtype=d)
+                 for d in unsigned_int_types
+                 ] + [0, 0.0, 2, 2.0, -2, -2.0, True, False],
+        'name': ['true_divide'],
+        'dtype': [numpy.float64],
+        'use_dtype': [True, False],
+    }) + testing.product({
         'arg1': [numpy.array([-3, -2, -1, 1, 2, 3], dtype=d)
-                 for d in int_types
+                 for d in signed_int_types
                  ] + [0, 0.0, 2, 2.0, -2, -2.0, True, False],
         'arg2': [numpy.array([-3, -2, -1, 1, 2, 3], dtype=d)
-                 for d in int_types
+                 for d in signed_int_types
                  ] + [0, 0.0, 2, 2.0, -2, -2.0, True, False],
         'name': ['true_divide'],
         'dtype': [numpy.float64],

--- a/tests/cupy_tests/sorting_tests/test_sort.py
+++ b/tests/cupy_tests/sorting_tests/test_sort.py
@@ -398,7 +398,7 @@ class TestArgsort(unittest.TestCase):
         return self.argsort(a)
 
 
-@testing.gpu
+@pytest.mark.filterwarnings('ignore:.*msort.*:DeprecationWarning')
 class TestMsort(unittest.TestCase):
 
     # Test base cases


### PR DESCRIPTION
Refs #7243

https://numpy.org/devdocs/release/1.24.0-notes.html

Deprecated in NumPy 1.24:
* Deprecate msort
* np.str0 and similar are now deprecated

Expired deprecations in NumPy 1.24:
* The deprecation for the aliases np.object, np.bool, np.float, np.complex, np.str, and np.int is expired (introduces NumPy 1.20). Some of these will now give a FutureWarning in addition to raising an error since they will be mapped to the NumPy scalars in the future.