### PR TITLE
Add explanation for JIT kernel.

### DIFF
--- a/docs/source/user_guide/kernel.rst
+++ b/docs/source/user_guide/kernel.rst
@@ -557,11 +557,7 @@ Here is a short example for how to write a :class:`cupyx.jit.rawkernel` to copy 
    >>> elementwise_copy[128, 1024](x, y, size)  #  Numba style
    >>> assert (x == y).all()
 
-The above two kinds of styles to launch the kernel are supported, see the documentation of :class:`cupyx.jit._interface._JitRawKernel` for details.
-
-The two first entries are the grid and block sizes. ``grid`` ( Rawkernel style ``(128,)`` or Numba style ``[128]``) is the size of the grid, i.e., the number of blocks. ``block`` (``(1024,)`` or ``[1024]``) is the dimensions of each thread block.
-This technique is used in CUDA Programming.
-For details, see `the CUDA Programming Model`_.
+Both styles to launch the kernel, as shown above, are supported. The first two entries are the grid and block sizes, respectively. ``grid`` ( RawKernel style ``(128,)`` or Numba style ``[128]``) is the sizes of the grid, i.e., the numbers of blocks in each dimension; ``block`` (``(1024,)`` or ``[1024]``) is the dimensions of each thread block, please refer to :class:`cupyx.jit._interface._JitRawKernel` for details. Launching a CUDA kernel on a GPU with pre-determined grid/block sizes requires basic understanding in the `CUDA Programming Model`_.
 
 .. _The CUDA Programming Model: https://developer.nvidia.com/blog/cuda-refresher-cuda-programming-model/
 

--- a/docs/source/user_guide/kernel.rst
+++ b/docs/source/user_guide/kernel.rst
@@ -559,6 +559,13 @@ Here is a short example for how to write a :class:`cupyx.jit.rawkernel` to copy 
 
 The above two kinds of styles to launch the kernel are supported, see the documentation of :class:`cupyx.jit._interface._JitRawKernel` for details.
 
+The two first entries mean grid and block. grid( Rawkernel style (128,) or Numba style [128] ) means the size of grid in blocks. block( (1024,) or [1024] ) means the dimensions of each thread block.
+This technique is used in CUDA Programming.
+
+For details, see `The CUDA Programming Model`_.
+
+.. _The CUDA Programming Model: https://developer.nvidia.com/blog/cuda-refresher-cuda-programming-model/
+
 The compilation will be deferred until the first function call. CuPy's JIT compiler infers the types of arguments at the call time, and will cache the compiled kernels for speeding up any subsequent calls.
 
 See :doc:`../reference/kernel` for a full list of API.

--- a/docs/source/user_guide/kernel.rst
+++ b/docs/source/user_guide/kernel.rst
@@ -559,10 +559,9 @@ Here is a short example for how to write a :class:`cupyx.jit.rawkernel` to copy 
 
 The above two kinds of styles to launch the kernel are supported, see the documentation of :class:`cupyx.jit._interface._JitRawKernel` for details.
 
-The two first entries are the grid and block sizes. grid( Rawkernel style (128,) or Numba style [128] ) is the size of the grid in blocks. block( (1024,) or [1024] ) is the dimensions of each thread block.
+The two first entries are the grid and block sizes. ``grid`` ( Rawkernel style ``(128,)`` or Numba style ``[128]``) is the size of the grid, i.e., the number of blocks. ``block`` (``(1024,)`` or ``[1024]``) is the dimensions of each thread block.
 This technique is used in CUDA Programming.
-
-For details, see `The CUDA Programming Model`_.
+For details, see `the CUDA Programming Model`_.
 
 .. _The CUDA Programming Model: https://developer.nvidia.com/blog/cuda-refresher-cuda-programming-model/
 

--- a/docs/source/user_guide/kernel.rst
+++ b/docs/source/user_guide/kernel.rst
@@ -559,7 +559,7 @@ Here is a short example for how to write a :class:`cupyx.jit.rawkernel` to copy 
 
 The above two kinds of styles to launch the kernel are supported, see the documentation of :class:`cupyx.jit._interface._JitRawKernel` for details.
 
-The two first entries mean grid and block. grid( Rawkernel style (128,) or Numba style [128] ) means the size of grid in blocks. block( (1024,) or [1024] ) means the dimensions of each thread block.
+The two first entries are the grid and block sizes. grid( Rawkernel style (128,) or Numba style [128] ) is the size of the grid in blocks. block( (1024,) or [1024] ) is the dimensions of each thread block.
 This technique is used in CUDA Programming.
 
 For details, see `The CUDA Programming Model`_.

--- a/docs/source/user_guide/kernel.rst
+++ b/docs/source/user_guide/kernel.rst
@@ -559,7 +559,7 @@ Here is a short example for how to write a :class:`cupyx.jit.rawkernel` to copy 
 
 Both styles to launch the kernel, as shown above, are supported. The first two entries are the grid and block sizes, respectively. ``grid`` ( RawKernel style ``(128,)`` or Numba style ``[128]``) is the sizes of the grid, i.e., the numbers of blocks in each dimension; ``block`` (``(1024,)`` or ``[1024]``) is the dimensions of each thread block, please refer to :class:`cupyx.jit._interface._JitRawKernel` for details. Launching a CUDA kernel on a GPU with pre-determined grid/block sizes requires basic understanding in the `CUDA Programming Model`_.
 
-.. _The CUDA Programming Model: https://developer.nvidia.com/blog/cuda-refresher-cuda-programming-model/
+.. _CUDA Programming Model: https://developer.nvidia.com/blog/cuda-refresher-cuda-programming-model/
 
 The compilation will be deferred until the first function call. CuPy's JIT compiler infers the types of arguments at the call time, and will cache the compiled kernels for speeding up any subsequent calls.
 


### PR DESCRIPTION
#7107 
I added explanation for the first two entries of elementwise_copy() functions, and added the link of CUDA programming model for details.