### PR TITLE
Fix race condition in Jitify

### DIFF
--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -20,7 +20,7 @@ from cupy import _util
 
 _cuda_hip_version = driver.get_build_version()
 if not runtime.is_hip and _cuda_hip_version > 0:
-    from cupy.cuda.jitify import jitify
+    from cupy.cuda import jitify
 
 
 _nvrtc_version = None
@@ -234,11 +234,7 @@ def _jitify_prep(source, options, cu_path):
     global _jitify_header_source_map_populated
     if not _jitify_header_source_map_populated:
         from cupy._core import core
-        _jitify_header_source_map = core._get_header_source_map()
-        _jitify_header_source_map_populated = True
-    else:
-        # this is already cached at the C++ level, so don't pass in anything
-        _jitify_header_source_map = None
+        jitify._add_sources(core._get_header_source_map())
 
     # jitify requires the 1st line to be the program name
     old_source = source
@@ -253,8 +249,7 @@ def _jitify_prep(source, options, cu_path):
     # (NVIDIA/jitify#79).
 
     try:
-        name, options, headers, include_names = jitify(
-            source, options, _jitify_header_source_map)
+        name, options, headers, include_names = jitify.jitify(source, options)
     except Exception as e:  # C++ could throw all kinds of errors
         cex = CompileException(str(e), old_source, cu_path, options, 'jitify')
         dump = _get_bool_env_variable(

--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -235,6 +235,7 @@ def _jitify_prep(source, options, cu_path):
     if not _jitify_header_source_map_populated:
         from cupy._core import core
         jitify._add_sources(core._get_header_source_map())
+        _jitify_header_source_map_populated = True
 
     # jitify requires the 1st line to be the program name
     old_source = source

--- a/cupy/cuda/jitify.pyx
+++ b/cupy/cuda/jitify.pyx
@@ -52,11 +52,16 @@ cdef inline void init_cupy_headers():
 init_cupy_headers()
 
 
+cpdef _add_sources(dict sources):
+    for hdr_name, hdr_source in sources.items():
+        cupy_headers[hdr_name] = hdr_source
+
+
 # Use Jitify's internal mechanism to search all included headers, and return
 # the modified options and the header mapping (as two lists). This roughly
 # follows the constructor of jitify::Program(). The found headers are cached
 # to accelerate Jitify's search loop.
-cpdef jitify(str code, tuple opt, dict cached_sources=None):
+cpdef jitify(str code, tuple opt):
 
     # input
     cdef cpp_str cuda_source
@@ -79,13 +84,6 @@ cpdef jitify(str code, tuple opt, dict cached_sources=None):
 
     cuda_source = code.encode()
     _options = [s.encode() for s in opt]
-
-    # Populate the cpp map
-    if cached_sources is not None:
-        for k, v in cached_sources.items():
-            hdr_name = k
-            hdr_source = v
-            _sources[hdr_name] = hdr_source
 
     with nogil:
         # Where the real magic happens: a compile-fail-search loop

--- a/cupy/cuda/jitify.pyx
+++ b/cupy/cuda/jitify.pyx
@@ -105,5 +105,6 @@ cpdef jitify(str code, tuple opt):
         v = itr.second
         hdr_codes.append(v)
         hdr_names.append(k)
+        cupy_headers[k] = v
 
     return _name.decode(), tuple(new_opt), hdr_codes, hdr_names

--- a/install/cupy_builder/cupy_setup_build.py
+++ b/install/cupy_builder/cupy_setup_build.py
@@ -336,6 +336,9 @@ def make_extensions(ctx: Context, compiler, use_cython):
         if module['name'] == 'jitify':
             # this fixes RTD (no_cuda) builds...
             compile_args.append('--std=c++11')
+            # Uncomment to diagnose Jitify issues.
+            # compile_args.append('-DJITIFY_PRINT_ALL')
+
             # if any change is made to the Jitify header, we force recompiling
             s['depends'] = ['./cupy/_core/include/cupy/jitify/jitify.hpp']
 


### PR DESCRIPTION
This fixes a race condition in jitify that `cupy_headers` (static variable) being modified under `with nogil:`. Reported in https://github.com/cupy/cupy/issues/6793#issuecomment-1308791091 and https://github.com/cupy/cupy/issues/6793#issuecomment-1360368533.

Reproducer

```
$ export CUPY_CACHE_IN_MEMORY=1
$ ./test.py 10
```

`test.py`:

```py
import sys
import threading
import cupy


def run():
    kern = cupy.RawKernel(code='''
#include <cupy/cuda_workaround.h>
#include <cupy/cub/cub/block/block_reduce.cuh>
#include <cupy/cub/cub/block/block_load.cuh>

extern "C" __global__ void mykernel() {}''', name='mykernel', jitify=True)
    kern.compile()

threads = []
for i in range(int(sys.argv[1])):
    threads.append(threading.Thread(target=run))

for t in threads:
    t.start()

for t in threads:
    t.join()
```