### PR TITLE
[backport] Update for deprecations in NumPy 1.24

### DIFF
--- a/.pfnci/windows/test.ps1
+++ b/.pfnci/windows/test.ps1
@@ -73,6 +73,7 @@ function Main {
 
     echo "Building..."
     $build_retval = 0
+    RunOrDie python -m pip install -U "numpy<1.24"
     python -m pip install ".[all,test]" -vvv > cupy_build_log.txt
     if (-not $?) {
         $build_retval = $LastExitCode

--- a/tests/cupy_tests/binary_tests/test_elementwise.py
+++ b/tests/cupy_tests/binary_tests/test_elementwise.py
@@ -9,14 +9,14 @@ class TestElementwise(unittest.TestCase):
     @testing.for_int_dtypes()
     @testing.numpy_cupy_array_equal()
     def check_unary_int(self, name, xp, dtype):
-        a = xp.array([-3, -2, -1, 0, 1, 2, 3], dtype=dtype)
+        a = xp.array([-3, -2, -1, 0, 1, 2, 3]).astype(dtype)
         return getattr(xp, name)(a)
 
     @testing.for_int_dtypes()
     @testing.numpy_cupy_array_equal()
     def check_binary_int(self, name, xp, dtype):
-        a = xp.array([-3, -2, -1, 0, 1, 2, 3], dtype=dtype)
-        b = xp.array([0, 1, 2, 3, 4, 5, 6], dtype=dtype)
+        a = xp.array([-3, -2, -1, 0, 1, 2, 3]).astype(dtype)
+        b = xp.array([0, 1, 2, 3, 4, 5, 6]).astype(dtype)
         return getattr(xp, name)(a, b)
 
     def test_bitwise_and(self):

--- a/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
@@ -578,7 +578,7 @@ class TestArrayAdvancedIndexingSetitemScalarValueIndexError:
     {'shape': (2, 3, 4), 'indexes': [[1], slice(1, 2)], 'value': 1},
     {'shape': (2, 3, 4), 'indexes': [[[1]], slice(1, 2)], 'value': 1},
 )
-@testing.with_requires('numpy>=1.23')
+@testing.with_requires('numpy>=1.23,<1.24')
 class TestArrayAdvancedIndexingSetitemScalarValueIndexError2:
 
     @testing.for_all_dtypes()
@@ -586,6 +586,7 @@ class TestArrayAdvancedIndexingSetitemScalarValueIndexError2:
         for xp in (numpy, cupy):
             a = xp.zeros(self.shape, dtype=dtype)
             with pytest.raises(IndexError):
+                # This is deprecated and fails in NumPy 1.24.
                 with testing.assert_warns(numpy.VisibleDeprecationWarning):
                     a[self.indexes] = self.value
 

--- a/tests/cupy_tests/math_tests/test_arithmetic.py
+++ b/tests/cupy_tests/math_tests/test_arithmetic.py
@@ -288,14 +288,23 @@ class TestArithmeticBinary(ArithmeticBinaryBase):
         self.check_binary()
 
 
-@testing.gpu
 @testing.parameterize(*(
     testing.product({
+        'arg1': [numpy.array([3, 2, 1, 1, 2, 3], dtype=d)
+                 for d in unsigned_int_types
+                 ] + [0, 0.0, 2, 2.0, -2, -2.0, True, False],
+        'arg2': [numpy.array([3, 2, 1, 1, 2, 3], dtype=d)
+                 for d in unsigned_int_types
+                 ] + [0, 0.0, 2, 2.0, -2, -2.0, True, False],
+        'name': ['true_divide'],
+        'dtype': [numpy.float64],
+        'use_dtype': [True, False],
+    }) + testing.product({
         'arg1': [numpy.array([-3, -2, -1, 1, 2, 3], dtype=d)
-                 for d in int_types
+                 for d in signed_int_types
                  ] + [0, 0.0, 2, 2.0, -2, -2.0, True, False],
         'arg2': [numpy.array([-3, -2, -1, 1, 2, 3], dtype=d)
-                 for d in int_types
+                 for d in signed_int_types
                  ] + [0, 0.0, 2, 2.0, -2, -2.0, True, False],
         'name': ['true_divide'],
         'dtype': [numpy.float64],

--- a/tests/cupy_tests/sorting_tests/test_sort.py
+++ b/tests/cupy_tests/sorting_tests/test_sort.py
@@ -398,7 +398,7 @@ class TestArgsort(unittest.TestCase):
         return self.argsort(a)
 
 
-@testing.gpu
+@pytest.mark.filterwarnings('ignore:.*msort.*:DeprecationWarning')
 class TestMsort(unittest.TestCase):
 
     # Test base cases


### PR DESCRIPTION
Backport of #7245 by @kmaehashi

Only fixes in test code is backported as the v11 baseline API is NumPy 1.23.