### PR TITLE
Support passing int as shape to `broadcast_to`

### DIFF
--- a/cupy/_core/_routines_manipulation.pyx
+++ b/cupy/_core/_routines_manipulation.pyx
@@ -476,6 +476,7 @@ cpdef _ndarray_base broadcast_to(_ndarray_base array, shape):
         :meth:`numpy.broadcast_to`
 
     """
+    shape = tuple(shape) if numpy.iterable(shape) else (shape,)
     cdef int i, j, ndim = array._shape.size(), length = len(shape)
     cdef Py_ssize_t sh, a_sh
     if ndim > length:

--- a/tests/cupy_tests/manipulation_tests/test_dims.py
+++ b/tests/cupy_tests/manipulation_tests/test_dims.py
@@ -55,6 +55,13 @@ class TestDims(unittest.TestCase):
         b = xp.broadcast_to(a, (2, 3, 3, 4))
         return b
 
+    @testing.numpy_cupy_array_equal()
+    def test_broadcast_to_int(self, xp):
+        # Broadcast 0-dim array to 1-dim.
+        a = xp.array(10, dtype=xp.float32)
+        b = xp.broadcast_to(a, 10)
+        return b
+
     @testing.for_all_dtypes()
     def test_broadcast_to_fail(self, dtype):
         for xp in (numpy, cupy):


### PR DESCRIPTION
Reported internally. `broadcast_to` should accept int as shape.

https://numpy.org/doc/stable/reference/generated/numpy.broadcast_to.html

> shape : tuple or int
> The shape of the desired array. A single integer i is interpreted as (i,).