### PR TITLE
Add function to diagnose Windows DLL load issue

### DIFF
--- a/install/cupy_builder/_command.py
+++ b/install/cupy_builder/_command.py
@@ -74,7 +74,11 @@ def _get_timestamp(path: str) -> float:
 
 def dumpbin_dependents(dumpbin: str, path: str) -> List[str]:
     args = [dumpbin, '/nologo', '/dependents', path]
-    p = subprocess.run(args, stdout=subprocess.PIPE)
+    try:
+        p = subprocess.run(args, stdout=subprocess.PIPE)
+    except FileNotFoundError:
+        print(f'*** DUMPBIN not found: {args}')
+        return []
     if p.returncode != 0:
         print(f'*** DUMPBIN failed ({p.returncode}): {args}')
         return []

--- a/install/cupy_builder/cupy_setup_build.py
+++ b/install/cupy_builder/cupy_setup_build.py
@@ -399,8 +399,9 @@ def prepare_wheel_libs(ctx: Context):
     """
     data_dir = os.path.abspath(os.path.join('cupy', '.data'))
     if os.path.exists(data_dir):
-        print('Removing directory: {}'.format(data_dir))
+        print('Clearing directory: {}'.format(data_dir))
         shutil.rmtree(data_dir)
+    os.mkdir(data_dir)
 
     # Generate list files to copy
     # tuple of (src_path, dst_path)
@@ -432,7 +433,10 @@ def prepare_wheel_libs(ctx: Context):
             os.makedirs(dirpath)
         shutil.copy2(srcpath, dstpath)
 
-    return [os.path.relpath(x[1], 'cupy') for x in files_to_copy]
+    package_files = [x[1] for x in files_to_copy] + [
+        'cupy/.data/_depends.json',
+    ]
+    return [os.path.relpath(f, 'cupy') for f in package_files]
 
 
 def get_ext_modules(use_cython: bool, ctx: Context):


### PR DESCRIPTION
This PR improves the import error message to output Windows DLL dependency in a format similar to `ldd` on Linux.

Unlike Linux, on Windows it is difficult for users to diagnose DLL dependency issues because the error message only says `The specified module could not be found`. This PR improves the error message as follows:

```pycon
>>> import cupy
...

Traceback (most recent call last):
  File "C:\Users\maehashi\dev\cupy\cupy\__init__.py", line 17, in <module>
    from cupy import _core  # NOQA
  File "C:\Users\maehashi\dev\cupy\cupy\_core\__init__.py", line 3, in <module>
    from cupy._core import core  # NOQA
  File "cupy\_core\core.pyx", line 1, in init cupy._core.core
    # distutils: language = c++
  File "C:\Users\maehashi\dev\cupy\cupy\cuda\__init__.py", line 8, in <module>
    from cupy.cuda import compiler  # NOQA
  File "C:\Users\maehashi\dev\cupy\cupy\cuda\compiler.py", line 13, in <module>
    from cupy.cuda import device
  File "cupy\cuda\device.pyx", line 1, in init cupy.cuda.device
    # distutils: language = c++
ImportError: DLL load failed while importing runtime: The specified module could not be found.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\maehashi\dev\cupy\cupy\__init__.py", line 19, in <module>
    raise ImportError(f'''
ImportError:
================================================================
Failed to import CuPy.

If you installed CuPy via wheels (cupy-cudaXXX or cupy-rocm-X-X), make sure that the package matches with the version of CUDA or ROCm installed.

On Linux, you may need to set LD_LIBRARY_PATH environment variable depending on how you installed CUDA/ROCm.
On Windows, try setting CUDA_PATH environment variable.

Check the Installation Guide for details:
  https://docs.cupy.dev/en/latest/install.html

CUDA Path: None
DLL dependencies:
  KERNEL32.dll -> C:\Windows\System32\KERNEL32.DLL
  MSVCP140.dll -> C:\Windows\SYSTEM32\MSVCP140.dll
  VCRUNTIME140.dll -> C:\Program Files\Python39\VCRUNTIME140.dll
  VCRUNTIME140_1.dll -> C:\Program Files\Python39\VCRUNTIME140_1.dll
  api-ms-win-crt-convert-l1-1-0.dll -> C:\Windows\System32\ucrtbase.dll
  api-ms-win-crt-filesystem-l1-1-0.dll -> C:\Windows\System32\ucrtbase.dll
  api-ms-win-crt-heap-l1-1-0.dll -> C:\Windows\System32\ucrtbase.dll
  api-ms-win-crt-runtime-l1-1-0.dll -> C:\Windows\System32\ucrtbase.dll
  api-ms-win-crt-stdio-l1-1-0.dll -> C:\Windows\System32\ucrtbase.dll
  cublas64_12.dll -> not found
  cudart64_12.dll -> not found
  cufft64_11.dll -> not found
  curand64_10.dll -> not found
  cusolver64_11.dll -> not found
  cusparse64_12.dll -> not found
  nvcuda.dll -> C:\Windows\SYSTEM32\nvcuda.dll
  nvrtc64_120_0.dll -> not found
  python39.dll -> C:\Program Files\Python39\python39.dll

Original error:
  ImportError: DLL load failed while importing runtime: The specified module could not be found.
================================================================
```

In addition, this function can also be used for debugging DLL issues in a complicated setup even after successfully loading CuPy:

```pycon
>>> import torch, cupy
>>> print(cupy._environment._diagnose_win32_dll_load())


CUDA Path: C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.0
DLL dependencies:
  KERNEL32.dll -> C:\Windows\System32\KERNEL32.DLL
  MSVCP140.dll -> C:\Windows\SYSTEM32\msvcp140.dll
  VCRUNTIME140.dll -> C:\Program Files\Python39\VCRUNTIME140.dll
  VCRUNTIME140_1.dll -> C:\Program Files\Python39\VCRUNTIME140_1.dll
  api-ms-win-crt-convert-l1-1-0.dll -> C:\Windows\System32\ucrtbase.dll
  api-ms-win-crt-filesystem-l1-1-0.dll -> C:\Windows\System32\ucrtbase.dll
  api-ms-win-crt-heap-l1-1-0.dll -> C:\Windows\System32\ucrtbase.dll
  api-ms-win-crt-runtime-l1-1-0.dll -> C:\Windows\System32\ucrtbase.dll
  api-ms-win-crt-stdio-l1-1-0.dll -> C:\Windows\System32\ucrtbase.dll
  cublas64_12.dll -> C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.0\bin\cublas64_12.dll
  cudart64_12.dll -> C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.0\bin\cudart64_12.dll
  cufft64_11.dll -> C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.0\bin\cufft64_11.dll
  curand64_10.dll -> C:\Users\maehashi\.venv-py39\lib\site-packages\torch\lib\curand64_10.dll
  cusolver64_11.dll -> C:\Users\maehashi\.venv-py39\lib\site-packages\torch\lib\cusolver64_11.dll
  cusparse64_12.dll -> C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.0\bin\cusparse64_12.dll
  nvcuda.dll -> C:\Windows\SYSTEM32\nvcuda.dll
  nvrtc64_120_0.dll -> C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.0\bin\nvrtc64_120_0.dll
  python39.dll -> C:\Program Files\Python39\python39.dll
```

The above example shows that some DLLs are loaded from PyTorch distribution.

### How it works

* During build, after all extension modules are generated, the setup script runs `dumpbin /dependents *.pyd` for all extensions in CuPy to list up all dependent DLLs. The result is stored as `cupy/.data/_depends.json` which will be distributed in wheels.
* At runtime, if CuPy import failed, the diagnosis code automatically tries to open each dependent DLL, and if it succeeds, retrieves a full path for the DLL.

Note that `dumpbin` is only available where Visual Studio Build Tools is installed. That's why dependency needs to be listed during the build, not at runtime.