### PR TITLE
Support passing `where` in `ufunc`

### DIFF
--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -1171,6 +1171,14 @@ cdef class ufunc:
                 specified by the ``out`` argument.
             out (cupy.ndarray): Output array. It outputs to new arrays
                 default.
+            where (cupy.ndarray):
+                This condition is broadcast over the input.
+                At locations where the condition is True, the out array will
+                be set to the ufunc result.
+                Elsewhere, the out array will retain its original value.
+                Note that if an uninitialized out array is created via the
+                default ``out=None``, locations within it where the condition
+                is False will remain uninitialized.
             dtype: Data type specifier.
 
         Returns:

--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -1186,7 +1186,7 @@ cdef class ufunc:
         cdef Py_ssize_t s
 
         out = kwargs.pop('out', None)
-        where = kwargs.pop('_where', None)
+        where = kwargs.pop('where', None)
         cdef bint has_where = where is not None
         dtype = kwargs.pop('dtype', None)
         # Note default behavior of casting is 'same_kind' on numpy>=1.10

--- a/cupy/_manipulation/basic.py
+++ b/cupy/_manipulation/basic.py
@@ -82,7 +82,7 @@ def copyto(dst, src, casting='same_kind', where=None):
             src = src.squeeze(tuple(range(squeeze_ndim)))
 
     if where is not None:
-        _core.elementwise_copy(src, dst, _where=where)
+        _core.elementwise_copy(src, dst, where=where)
         return
 
     if dst.size == 0:

--- a/tests/cupy_tests/core_tests/test_ndarray_ufunc.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_ufunc.py
@@ -177,6 +177,14 @@ class TestUfunc:
         return xp.sin(a, None)
 
     @testing.numpy_cupy_allclose()
+    def test_unary_out_where(self, xp):
+        dtype = xp.float64
+        a = testing.shaped_arange((20, 30), xp, dtype)
+        out = xp.zeros((20, 30), dtype)
+        where = testing.shaped_arange((20, 30), xp, xp.bool_)
+        return xp.sin(a, out=out, where=where)
+
+    @testing.numpy_cupy_allclose()
     def test_binary_out_tuple(self, xp):
         dtype = xp.float64
         a = testing.shaped_arange((2, 3), xp, dtype)
@@ -192,6 +200,15 @@ class TestUfunc:
         a = testing.shaped_arange((2, 3), xp, dtype)
         b = xp.ones((2, 3), dtype)
         return xp.add(a, b, None)
+
+    @testing.numpy_cupy_allclose()
+    def test_binary_where(self, xp):
+        dtype = xp.float32
+        a = testing.shaped_arange((20, 30), xp, dtype)
+        b = testing.shaped_arange((20, 30), xp, dtype)
+        out = xp.zeros((20, 30), dtype)
+        where = testing.shaped_arange((20, 30), xp, xp.bool_)
+        return xp.add(a, b, out=out, where=where)
 
     @testing.numpy_cupy_allclose()
     def test_divmod_out_tuple(self, xp):


### PR DESCRIPTION
Closes #7274.
Refs #6692, #6693

The feature itself was written by @toslunar in #5550, but the option was hidden as `_where` as the motivation of that pull-request was a bug-fix. I talked with him offline and agreed that there should be no issues exposing this option to public.