### PR TITLE
Check if the slice does not have inhomogeneous shape before converting it to array

### DIFF
--- a/cupy/_core/_routines_indexing.pyx
+++ b/cupy/_core/_routines_indexing.pyx
@@ -266,6 +266,9 @@ cpdef list _prepare_slice_list(slices):
                 # keep scalar int
                 continue
 
+        if cupy.min_scalar_type(s).char == 'O':
+            raise IndexError(
+                'arrays used as indices must be of integer (or boolean) type')
         try:
             s = core.array(s, dtype=None, copy=False)
         except ValueError:

--- a/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
@@ -167,16 +167,15 @@ class TestArrayAdvancedIndexingGetitemParametrized2:
     {'shape': (2, 3, 4), 'indexes': [[1], slice(1, 2)]},
     {'shape': (2, 3, 4), 'indexes': [[[1]], slice(1, 2)]},
 )
-@testing.with_requires('numpy>=1.23')
-class TestArrayAdvancedIndexingGetitemParametrizedIndexError:
+@testing.with_requires('numpy>=1.24')
+class TestArrayAdvancedIndexingGetitemParametrizedValueError:
 
     @testing.for_all_dtypes()
     def test_adv_getitem(self, dtype):
         for xp in (numpy, cupy):
             a = testing.shaped_arange(self.shape, xp, dtype)
-            with pytest.raises(IndexError):
-                with testing.assert_warns(numpy.VisibleDeprecationWarning):
-                    a[self.indexes]
+            with pytest.raises(ValueError):
+                a[self.indexes]
 
 
 @testing.parameterize(

--- a/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
@@ -362,16 +362,14 @@ class TestArrayInvalidIndexAdvGetitem2:
 @testing.parameterize(
     {'shape': (2, 3, 4), 'indexes': [1, [1, [1]]]},
 )
-@testing.gpu
-@testing.with_requires('numpy>=1.16')
+@testing.with_requires('numpy>=1.24')
 class TestArrayInvalidValueAdvGetitem:
 
     def test_invalid_adv_getitem(self):
         for xp in (numpy, cupy):
             a = testing.shaped_arange(self.shape, xp)
-            with pytest.raises(IndexError):
-                with testing.assert_warns(FutureWarning):
-                    a[self.indexes]
+            with pytest.raises(ValueError):
+                a[self.indexes]
 
 
 @testing.parameterize(
@@ -577,17 +575,15 @@ class TestArrayAdvancedIndexingSetitemScalarValueIndexError:
     {'shape': (2, 3, 4), 'indexes': [[1], slice(1, 2)], 'value': 1},
     {'shape': (2, 3, 4), 'indexes': [[[1]], slice(1, 2)], 'value': 1},
 )
-@testing.with_requires('numpy>=1.23,<1.24')
-class TestArrayAdvancedIndexingSetitemScalarValueIndexError2:
+@testing.with_requires('numpy>=1.24')
+class TestArrayAdvancedIndexingSetitemScalarValueValueError2:
 
     @testing.for_all_dtypes()
     def test_adv_setitem(self, dtype):
         for xp in (numpy, cupy):
             a = xp.zeros(self.shape, dtype=dtype)
-            with pytest.raises(IndexError):
-                # This is deprecated and fails in NumPy 1.24.
-                with testing.assert_warns(numpy.VisibleDeprecationWarning):
-                    a[self.indexes] = self.value
+            with pytest.raises(ValueError):
+                a[self.indexes] = self.value
 
 
 @testing.parameterize(


### PR DESCRIPTION
Part of NumPy 1.24 support #7243.

NumPy 1.24:

```pycon
>>> import numpy as np
>>> np.arange(10)[[1,2,[3]]]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: setting an array element with a sequence. The requested array has an inhomogeneous shape after 1 dimensions. The detected shape was (3,) + inhomogeneous part.
```

NumPy 1.23:

```pycon
>>> import numpy as np
>>> np.arange(10)[[1,2,[3]]]
<stdin>:1: VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray.
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
IndexError: only integers, slices (`:`), ellipsis (`...`), numpy.newaxis (`None`) and integer or boolean arrays are valid indices
```
