### PR TITLE
Update cuTENSOR installer for CUDA 12.x

### DIFF
--- a/cupyx/tools/install_library.py
+++ b/cupyx/tools/install_library.py
@@ -247,6 +247,8 @@ The current platform ({}) is not supported.'''.format(target_platform))
         elif library == 'cutensor':
             if cuda.startswith('11.') and cuda != '11.0':
                 cuda = '11'
+            elif cuda.startswith('12.'):
+                cuda = '12'
             license = 'LICENSE'
             shutil.move(
                 os.path.join(outdir, dir_name, 'include'),


### PR DESCRIPTION
Follow up #7284.

Found in https://github.com/cupy/cupy-release-tools/pull/322 (https://ci.preferred.jp/cupy-release-tools/120571/)