### PR TITLE
Use warp size from `runtime.getDeviceProperties`

### DIFF
--- a/cupy/_core/__init__.py
+++ b/cupy/_core/__init__.py
@@ -18,6 +18,7 @@ from cupy._core._accelerator import get_routine_accelerators  # NOQA
 from cupy._core._kernel import create_ufunc  # NOQA
 from cupy._core._kernel import ElementwiseKernel  # NOQA
 from cupy._core._kernel import ufunc  # NOQA
+from cupy._core._kernel import _get_warpsize  # NOQA
 from cupy._core._reduction import create_reduction_func  # NOQA
 from cupy._core._reduction import ReductionKernel  # NOQA
 from cupy._core._routines_binary import bitwise_and  # NOQA

--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -45,6 +45,12 @@ cdef inline bint _contains_zero(const shape_t& v) except? -1:
     return False
 
 
+@_util.memoize(for_each_device=True)
+def _get_warpsize():
+    device_id = runtime.getDevice()
+    return runtime.getDeviceProperties(device_id)['warpSize']
+
+
 cdef function.Function _get_simple_elementwise_kernel(
         tuple params, tuple arginfos, str operation, str name,
         _TypeMap type_map, str preamble, str loop_prep='', str after_loop='',

--- a/cupy/_core/_routines_indexing.pyx
+++ b/cupy/_core/_routines_indexing.pyx
@@ -7,7 +7,7 @@ import numpy
 
 import cupy
 import cupy._core.core as core
-from cupy._core._kernel import ElementwiseKernel
+from cupy._core._kernel import ElementwiseKernel, _get_warpsize
 from cupy._core._ufuncs import elementwise_copy
 
 from libcpp cimport vector
@@ -108,7 +108,7 @@ cpdef _ndarray_base _ndarray_argwhere(_ndarray_base self):
 
     nonzero.shape = self.shape
     if incomplete_scan:
-        warp_size = 64 if runtime._is_hip_environment else 32
+        warp_size = _get_warpsize()
         size = scan_index.size * chunk_size
         _nonzero_kernel_incomplete_scan(chunk_size, warp_size)(
             nonzero, scan_index, dst,

--- a/cupy/_core/_routines_math.pyx
+++ b/cupy/_core/_routines_math.pyx
@@ -4,7 +4,7 @@ import numpy
 
 import cupy
 from cupy._core._reduction import create_reduction_func
-from cupy._core._kernel import create_ufunc
+from cupy._core._kernel import create_ufunc, _get_warpsize
 from cupy._core._scalar import get_typename
 from cupy._core._ufuncs import elementwise_copy
 import cupy._core.core as core
@@ -460,7 +460,7 @@ cdef _ndarray_base scan(
         dtype = out.dtype
     dtype = numpy.dtype(dtype)
 
-    warp_size = 64 if runtime._is_hip_environment else 32
+    warp_size = _get_warpsize()
     if runtime._is_hip_environment:
         if dtype.char in 'iIfdlq':
             # On HIP, __shfl* supports int, unsigned int, float, double,

--- a/cupyx/jit/_interface.py
+++ b/cupyx/jit/_interface.py
@@ -181,7 +181,7 @@ blockDim = _internal_types.Data('blockDim', _cuda_types.dim3)
 blockIdx = _internal_types.Data('blockIdx', _cuda_types.dim3)
 gridDim = _internal_types.Data('gridDim', _cuda_types.dim3)
 
-warpsize = _internal_types.Data('warpSize', _cuda_types.uint32)
+warpsize = _internal_types.Data('warpSize', _cuda_types.int32)
 warpsize.__doc__ = r"""Returns the number of threads in a warp.
 
 .. seealso:: :obj:`numba.cuda.warpsize`

--- a/cupyx/jit/_interface.py
+++ b/cupyx/jit/_interface.py
@@ -184,7 +184,5 @@ gridDim = _internal_types.Data('gridDim', _cuda_types.dim3)
 warpsize = _internal_types.Data('warpSize', _cuda_types.uint32)
 warpsize.__doc__ = r"""Returns the number of threads in a warp.
 
-In CUDA this is always 32, and in ROCm/HIP always 64.
-
 .. seealso:: :obj:`numba.cuda.warpsize`
 """

--- a/cupyx/jit/_interface.py
+++ b/cupyx/jit/_interface.py
@@ -3,7 +3,6 @@ import warnings
 
 import numpy
 
-from cupy_backends.cuda.api import runtime
 import cupy
 from cupy._core import core
 from cupyx.jit import _compile
@@ -182,8 +181,7 @@ blockDim = _internal_types.Data('blockDim', _cuda_types.dim3)
 blockIdx = _internal_types.Data('blockIdx', _cuda_types.dim3)
 gridDim = _internal_types.Data('gridDim', _cuda_types.dim3)
 
-warpsize = _internal_types.Data(
-    '64' if runtime.is_hip else '32', _cuda_types.uint32)
+warpsize = _internal_types.Data('warpSize', _cuda_types.uint32)
 warpsize.__doc__ = r"""Returns the number of threads in a warp.
 
 In CUDA this is always 32, and in ROCm/HIP always 64.

--- a/tests/cupyx_tests/jit_tests/test_raw.py
+++ b/tests/cupyx_tests/jit_tests/test_raw.py
@@ -580,7 +580,7 @@ class TestRaw:
     def test_shfl_down(self, dtype):
         N = 5
         # __shfl_down() on HIP does not seem to have the same behavior...
-        block = 64 if runtime.is_hip else 32
+        block = cupy._core._get_warpsize()
 
         @jit.rawkernel()
         def f(a):
@@ -627,7 +627,7 @@ class TestRaw:
             if x < arr.size:
                 arr[x] = jit.laneid()
 
-        N = 64 if runtime.is_hip else 32
+        N = cupy._core._get_warpsize()
         x = cupy.zeros((N*2,), dtype=cupy.uint32)
         f((1,), (N*2,), (x,))
         y = cupy.arange(N*2, dtype=cupy.uint32) % N
@@ -640,7 +640,7 @@ class TestRaw:
             if x == 0:
                 arr[0] = jit.warpsize
 
-        N = 64 if runtime.is_hip else 32
+        N = cupy._core._get_warpsize()
         x = cupy.zeros((1,), dtype=cupy.uint32)
         f((1,), (1,), (x,))
         assert x == N


### PR DESCRIPTION
Close #6523
cc: @ajflood @amathews-amd @kmaehashi @leofang @takagi