### PR TITLE
Add `CUPY_INCLUDE_PATH` and `CUPY_LIBRARY_PATH` env vars

### DIFF
--- a/install/cupy_builder/_context.py
+++ b/install/cupy_builder/_context.py
@@ -10,6 +10,13 @@ def _get_env_bool(name: str, default: bool, env: Mapping[str, str]) -> bool:
     return env[name] != '0' if name in env else default
 
 
+def _get_env_path(name: str, env: Mapping[str, str]) -> List[str]:
+    paths = env.get(name, None)
+    if paths is None:
+        return []
+    return [x for x in paths.split(os.pathsep) if len(x) != 0]
+
+
 class Context:
     def __init__(
             self, source_root: str, *,
@@ -21,6 +28,8 @@ class Context:
             'CUPY_USE_CUDA_PYTHON', False, _env)
         self.use_hip = _get_env_bool(
             'CUPY_INSTALL_USE_HIP', False, _env)
+        self.include_dirs = _get_env_path('CUPY_INCLUDE_PATH', _env)
+        self.library_dirs = _get_env_path('CUPY_LIBRARY_PATH', _env)
 
         cmdopts, _argv[:] = parse_args(_argv)
         self.package_name: str = cmdopts.cupy_package_name

--- a/install/cupy_builder/cupy_setup_build.py
+++ b/install/cupy_builder/cupy_setup_build.py
@@ -261,7 +261,7 @@ def make_extensions(ctx: Context, compiler, use_cython):
 
     no_cuda = ctx.use_stub
     use_hip = not no_cuda and ctx.use_hip
-    settings = build.get_compiler_setting(use_hip)
+    settings = build.get_compiler_setting(ctx, use_hip)
 
     include_dirs = settings['include_dirs']
 

--- a/install/cupy_builder/install_build.py
+++ b/install/cupy_builder/install_build.py
@@ -8,7 +8,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
-from typing import List, Optional, Set
+from typing import List, Set
 
 import cupy_builder
 import cupy_builder.install_utils as utils
@@ -126,7 +126,7 @@ def get_hipcc_path() -> List[str]:
         return None
 
 
-def get_compiler_setting(ctx: Optional[Context], use_hip):
+def get_compiler_setting(ctx: Context, use_hip):
     cuda_path = None
     rocm_path = None
 
@@ -134,12 +134,9 @@ def get_compiler_setting(ctx: Optional[Context], use_hip):
         rocm_path = get_rocm_path()
     else:
         cuda_path = get_cuda_path()
-    if ctx is not None:
-        include_dirs = ctx.include_dirs.copy()
-        library_dirs = ctx.library_dirs.copy()
-    else:
-        include_dirs = []
-        library_dirs = []
+
+    include_dirs = ctx.include_dirs.copy()
+    library_dirs = ctx.library_dirs.copy()
     define_macros = []
     extra_compile_args = []
 

--- a/install/cupy_builder/install_build.py
+++ b/install/cupy_builder/install_build.py
@@ -13,6 +13,7 @@ from typing import List, Set
 import cupy_builder
 import cupy_builder.install_utils as utils
 from cupy_builder import _environment
+from cupy_builder._context import Context
 
 
 PLATFORM_LINUX = sys.platform.startswith('linux')
@@ -125,7 +126,7 @@ def get_hipcc_path() -> List[str]:
         return None
 
 
-def get_compiler_setting(use_hip):
+def get_compiler_setting(ctx: Context, use_hip):
     cuda_path = None
     rocm_path = None
 
@@ -134,8 +135,8 @@ def get_compiler_setting(use_hip):
     else:
         cuda_path = get_cuda_path()
 
-    include_dirs = []
-    library_dirs = []
+    include_dirs = ctx.include_dirs.copy()
+    library_dirs = ctx.library_dirs.copy()
     define_macros = []
     extra_compile_args = []
 

--- a/install/cupy_builder/install_build.py
+++ b/install/cupy_builder/install_build.py
@@ -8,7 +8,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
-from typing import List, Set
+from typing import List, Optional, Set
 
 import cupy_builder
 import cupy_builder.install_utils as utils
@@ -126,7 +126,7 @@ def get_hipcc_path() -> List[str]:
         return None
 
 
-def get_compiler_setting(ctx: Context, use_hip):
+def get_compiler_setting(ctx: Optional[Context], use_hip):
     cuda_path = None
     rocm_path = None
 
@@ -134,9 +134,12 @@ def get_compiler_setting(ctx: Context, use_hip):
         rocm_path = get_rocm_path()
     else:
         cuda_path = get_cuda_path()
-
-    include_dirs = ctx.include_dirs.copy()
-    library_dirs = ctx.library_dirs.copy()
+    if ctx is not None:
+        include_dirs = ctx.include_dirs.copy()
+        library_dirs = ctx.library_dirs.copy()
+    else:
+        include_dirs = []
+        library_dirs = []
     define_macros = []
     extra_compile_args = []
 

--- a/tests/install_tests/test_build.py
+++ b/tests/install_tests/test_build.py
@@ -5,6 +5,7 @@ import unittest
 
 import pytest
 
+from cupy_builder._context import Context
 from cupy_builder import install_build as build
 
 
@@ -14,9 +15,10 @@ test_hip = bool(int(os.environ.get('CUPY_INSTALL_USE_HIP', '0')))
 class TestCheckVersion(unittest.TestCase):
 
     def setUp(self):
+        ctx = Context('.', _env={}, _argv=[])
         self.compiler = ccompiler.new_compiler()
         sysconfig.customize_compiler(self.compiler)
-        self.settings = build.get_compiler_setting(False)
+        self.settings = build.get_compiler_setting(ctx, False)
 
     @pytest.mark.gpu
     @pytest.mark.skipif(not test_hip, reason='For ROCm/HIP environment')

--- a/tests/install_tests/test_build.py
+++ b/tests/install_tests/test_build.py
@@ -16,7 +16,7 @@ class TestCheckVersion(unittest.TestCase):
     def setUp(self):
         self.compiler = ccompiler.new_compiler()
         sysconfig.customize_compiler(self.compiler)
-        self.settings = build.get_compiler_setting(None, False)
+        self.settings = build.get_compiler_setting(False)
 
     @pytest.mark.gpu
     @pytest.mark.skipif(not test_hip, reason='For ROCm/HIP environment')

--- a/tests/install_tests/test_build.py
+++ b/tests/install_tests/test_build.py
@@ -16,7 +16,7 @@ class TestCheckVersion(unittest.TestCase):
     def setUp(self):
         self.compiler = ccompiler.new_compiler()
         sysconfig.customize_compiler(self.compiler)
-        self.settings = build.get_compiler_setting(False)
+        self.settings = build.get_compiler_setting(None, False)
 
     @pytest.mark.gpu
     @pytest.mark.skipif(not test_hip, reason='For ROCm/HIP environment')

--- a/tests/install_tests/test_cupy_builder/test_features.py
+++ b/tests/install_tests/test_cupy_builder/test_features.py
@@ -10,10 +10,11 @@ import pytest
 
 
 def get_compiler_settings():
+    ctx = Context('.', _env={}, _argv=[])
     sysconfig.get_config_vars()
     compiler = ccompiler.new_compiler()
     sysconfig.customize_compiler(compiler)
-    settings = build.get_compiler_setting(False)
+    settings = build.get_compiler_setting(ctx, False)
     return compiler, settings
 
 

--- a/tests/install_tests/test_cupy_builder/test_features.py
+++ b/tests/install_tests/test_cupy_builder/test_features.py
@@ -13,7 +13,7 @@ def get_compiler_settings():
     sysconfig.get_config_vars()
     compiler = ccompiler.new_compiler()
     sysconfig.customize_compiler(compiler)
-    settings = build.get_compiler_setting(False)
+    settings = build.get_compiler_setting(None, False)
     return compiler, settings
 
 

--- a/tests/install_tests/test_cupy_builder/test_features.py
+++ b/tests/install_tests/test_cupy_builder/test_features.py
@@ -13,7 +13,7 @@ def get_compiler_settings():
     sysconfig.get_config_vars()
     compiler = ccompiler.new_compiler()
     sysconfig.customize_compiler(compiler)
-    settings = build.get_compiler_setting(None, False)
+    settings = build.get_compiler_setting(False)
     return compiler, settings
 
 


### PR DESCRIPTION
This closes #5751.
(I'm going to use this one in v11 to support building NVTX1 on CUDA 12.0 / Windows)