### PR TITLE
Update DLPack to v0.8 to support bool arrays

### DIFF
--- a/cupy/_core/dlpack.pyx
+++ b/cupy/_core/dlpack.pyx
@@ -315,7 +315,7 @@ cdef inline _ndarray_base _dlpack_to_cupy_array(dltensor) except +:
         if bits == 8:
             cp_dtype = cupy.bool_
         else:
-            raise TypeError('sizeof(bool) != 8 is not supported')
+            raise TypeError(f'{bits}-bit bool is not supported')
     elif dtype.code == kDLBfloat:
         raise NotImplementedError('CuPy does not support bfloat16 yet')
     else:

--- a/cupy/_core/dlpack.pyx
+++ b/cupy/_core/dlpack.pyx
@@ -3,6 +3,7 @@ cimport cpython  # NOQA
 from libc cimport stdlib
 from libc.stdint cimport uint8_t
 from libc.stdint cimport uint16_t
+from libc.stdint cimport int32_t
 from libc.stdint cimport int64_t
 from libc.stdint cimport uint64_t
 from libc.stdint cimport intptr_t
@@ -27,17 +28,21 @@ cdef extern from './include/cupy/dlpack/dlpack.h' nogil:
         kDLCPU
         kDLCUDA
         kDLCUDAHost
-        kDLCUDAManaged
-        kDLROCM
-        kDLROCMHost
         kDLOpenCL
         kDLVulkan
         kDLMetal
         kDLVPI
+        kDLROCM
+        kDLROCMHost
+        kDLExtDev
+        kDLCUDAManaged
+        kDLOneAPI
+        kDLWebGPU
+        kDLHexagon
 
     ctypedef struct DLDevice:
         DLDeviceType device_type
-        int device_id
+        int32_t device_id
 
     cdef enum DLDataTypeCode:
         kDLInt
@@ -45,6 +50,7 @@ cdef extern from './include/cupy/dlpack/dlpack.h' nogil:
         kDLFloat
         kDLBfloat
         kDLComplex
+        kDLBool
 
     ctypedef struct DLDataType:
         uint8_t code
@@ -54,7 +60,7 @@ cdef extern from './include/cupy/dlpack/dlpack.h' nogil:
     ctypedef struct DLTensor:
         void* data
         DLDevice device
-        int ndim
+        int32_t ndim
         DLDataType dtype
         int64_t* shape
         int64_t* strides
@@ -135,6 +141,8 @@ cpdef object toDlpack(_ndarray_base array) except +:
         dtype.code = <uint8_t>kDLFloat
     elif array.dtype.kind == 'c':
         dtype.code = <uint8_t>kDLComplex
+    elif array.dtype.kind == 'b':
+        dtype.code = <uint8_t>kDLBool
     else:
         raise ValueError('Unknown dtype')
     dtype.lanes = <uint16_t>1
@@ -303,6 +311,11 @@ cdef inline _ndarray_base _dlpack_to_cupy_array(dltensor) except +:
             cp_dtype = cupy.complex128
         else:
             raise TypeError('complex{} is not supported.'.format(bits))
+    elif dtype.code == kDLBool:
+        if bits == 8:
+            cp_dtype = cupy.bool_
+        else:
+            raise TypeError('sizeof(bool) != 8 is not supported')
     elif dtype.code == kDLBfloat:
         raise NotImplementedError('CuPy does not support bfloat16 yet')
     else:

--- a/cupy/_core/include/cupy/dlpack/README.md
+++ b/cupy/_core/include/cupy/dlpack/README.md
@@ -1,4 +1,4 @@
 ## DLPack header
 
 The header `dlpack.h` is downloaded from https://github.com/dmlc/dlpack/blob/main/include/dlpack/dlpack.h.
-The commit is [`2775088`](https://github.com/dmlc/dlpack/commit/277508879878e0a5b5b43599b1bea11f66eb3c6c).
+The commit is [`365b823`](https://github.com/dmlc/dlpack/commit/365b823cedb281cd0240ca601aba9b78771f91a3).

--- a/cupy/_core/include/cupy/dlpack/dlpack.h
+++ b/cupy/_core/include/cupy/dlpack/dlpack.h
@@ -6,6 +6,9 @@
 #ifndef DLPACK_DLPACK_H_
 #define DLPACK_DLPACK_H_
 
+/**
+ * \brief Compatibility with C++
+ */
 #ifdef __cplusplus
 #define DLPACK_EXTERN_C extern "C"
 #else
@@ -13,7 +16,10 @@
 #endif
 
 /*! \brief The current version of dlpack */
-#define DLPACK_VERSION 60
+#define DLPACK_VERSION 80
+
+/*! \brief The current ABI version of dlpack */
+#define DLPACK_ABI_VERSION 1
 
 /*! \brief DLPACK_DLL prefix for windows */
 #ifdef _WIN32
@@ -35,7 +41,11 @@ extern "C" {
 /*!
  * \brief The device type in DLDevice.
  */
+#ifdef __cplusplus
+typedef enum : int32_t {
+#else
 typedef enum {
+#endif
   /*! \brief CPU device */
   kDLCPU = 1,
   /*! \brief CUDA GPU device */
@@ -68,6 +78,17 @@ typedef enum {
    * \brief CUDA managed/unified memory allocated by cudaMallocManaged
    */
   kDLCUDAManaged = 13,
+  /*!
+   * \brief Unified shared memory allocated on a oneAPI non-partititioned
+   * device. Call to oneAPI runtime is required to determine the device
+   * type, the USM allocation type and the sycl context it is bound to.
+   *
+   */
+  kDLOneAPI = 14,
+  /*! \brief GPU support for next generation WebGPU standard. */
+  kDLWebGPU = 15,
+  /*! \brief Qualcomm Hexagon DSP */
+  kDLHexagon = 16,
 } DLDeviceType;
 
 /*!
@@ -80,7 +101,7 @@ typedef struct {
    * \brief The device index.
    * For vanilla CPU memory, pinned memory, or managed memory, this is set to 0.
    */
-  int device_id;
+  int32_t device_id;
 } DLDevice;
 
 /*!
@@ -105,16 +126,21 @@ typedef enum {
    * (C/C++/Python layout: compact struct per complex number)
    */
   kDLComplex = 5U,
+  /*! \brief boolean */
+  kDLBool = 6U,
 } DLDataTypeCode;
 
 /*!
- * \brief The data type the tensor can hold.
+ * \brief The data type the tensor can hold. The data type is assumed to follow the
+ * native endian-ness. An explicit error message should be raised when attempting to
+ * export an array with non-native endianness
  *
  *  Examples
- *   - float: type_code = 2, bits = 32, lanes=1
- *   - float4(vectorized 4 float): type_code = 2, bits = 32, lanes=4
- *   - int8: type_code = 0, bits = 8, lanes=1
+ *   - float: type_code = 2, bits = 32, lanes = 1
+ *   - float4(vectorized 4 float): type_code = 2, bits = 32, lanes = 4
+ *   - int8: type_code = 0, bits = 8, lanes = 1
  *   - std::complex<float>: type_code = 5, bits = 64, lanes = 1
+ *   - bool: type_code = 6, bits = 8, lanes = 1 (as per common array library convention, the underlying storage size of bool is 8 bits)
  */
 typedef struct {
   /*!
@@ -136,9 +162,16 @@ typedef struct {
  */
 typedef struct {
   /*!
-   * \brief The opaque data pointer points to the allocated data. This will be
-   * CUDA device pointer or cl_mem handle in OpenCL. This pointer is always
-   * aligned to 256 bytes as in CUDA.
+   * \brief The data pointer points to the allocated data. This will be CUDA
+   * device pointer or cl_mem handle in OpenCL. It may be opaque on some device
+   * types. This pointer is always aligned to 256 bytes as in CUDA. The
+   * `byte_offset` field should be used to point to the beginning of the data.
+   *
+   * Note that as of Nov 2021, multiply libraries (CuPy, PyTorch, TensorFlow,
+   * TVM, perhaps others) do not adhere to this 256 byte aligment requirement
+   * on CPU/CUDA/ROCm, and always use `byte_offset=0`.  This must be fixed
+   * (after which this note will be updated); at the moment it is recommended
+   * to not rely on the data pointer being correctly aligned.
    *
    * For given DLTensor, the size of memory required to store the contents of
    * data is calculated as follows:
@@ -158,7 +191,7 @@ typedef struct {
   /*! \brief The device of the tensor */
   DLDevice device;
   /*! \brief Number of dimensions */
-  int ndim;
+  int32_t ndim;
   /*! \brief The data type of the pointer*/
   DLDataType dtype;
   /*! \brief The shape of the tensor */

--- a/tests/cupy_tests/core_tests/test_dlpack.py
+++ b/tests/cupy_tests/core_tests/test_dlpack.py
@@ -19,6 +19,8 @@ def _gen_array(dtype):
             2, 3).astype(dtype)
     elif cupy.issubdtype(dtype, cupy.complexfloating):
         array = cupy.random.random((2, 3)).astype(dtype)
+    elif dtype == cupy.bool_:
+        array = cupy.random.randint(0, 2, size=(2, 3)).astype(cupy.bool_)
     else:
         assert False, f'unrecognized dtype: {dtype}'
     return array
@@ -27,7 +29,7 @@ def _gen_array(dtype):
 class TestDLPackConversion(unittest.TestCase):
 
     @pytest.mark.filterwarnings('ignore::DeprecationWarning')
-    @testing.for_all_dtypes(no_bool=True)
+    @testing.for_all_dtypes(no_bool=False)
     def test_conversion(self, dtype):
         orig_array = _gen_array(dtype)
         tensor = orig_array.toDlpack()
@@ -64,7 +66,7 @@ class TestNewDLPackConversion(unittest.TestCase):
         else:
             return cuda.Stream()
 
-    @testing.for_all_dtypes(no_bool=True)
+    @testing.for_all_dtypes(no_bool=False)
     def test_conversion(self, dtype):
         orig_array = _gen_array(dtype)
         out_array = cupy.from_dlpack(orig_array)


### PR DESCRIPTION
Would fix #7144. Part of #7306.

This PR updates CuPy's DLPack support to the latest version (before the proposed ABI break).