### PR TITLE
Partially revert device context behavior (to v9 and before)

### DIFF
--- a/cupy/cuda/device.pxd
+++ b/cupy/cuda/device.pxd
@@ -17,6 +17,7 @@ cdef class Handle:
 cdef class Device:
     cdef:
         public int id
+        int previous_id
         list _device_stack
 
     cpdef use(self)

--- a/cupy/cuda/device.pxd
+++ b/cupy/cuda/device.pxd
@@ -18,7 +18,6 @@ cdef class Device:
     cdef:
         public int id
         int previous_id
-        list _device_stack
 
     cpdef use(self)
     cpdef synchronize(self)

--- a/tests/cupy_tests/cuda_tests/test_device.py
+++ b/tests/cupy_tests/cuda_tests/test_device.py
@@ -193,8 +193,8 @@ class TestDeviceSwitch(unittest.TestCase):
             dev1.use()
             with dev1:
                 assert 1 == cuda.Device().id
-            assert 0 == cuda.Device().id
-        assert 0 == cuda.Device().id
+            assert 1 == cuda.Device().id
+        assert 1 == cuda.Device().id
 
     def test_thread_safe(self):
         dev0 = cuda.Device(0)
@@ -227,7 +227,7 @@ class TestDeviceSwitch(unittest.TestCase):
         t1.start()
         t0_seq()
         t1.join()
-        assert t0_exit_device[0] == 0
+        assert t0_exit_device[0] == 1
         assert t1_exit_device[0] == 1
 
     def test_invalid(self):


### PR DESCRIPTION
Close #6965.

It's a "partial" revert because the non-reentrant property (https://github.com/cupy/cupy/issues/6965#issuecomment-1383574548) had not been emphasized before AFAIR.