### PR TITLE
Work around a potential OOM error raised by CUB histogram 

### DIFF
--- a/cupy/cuda/cub.pyx
+++ b/cupy/cuda/cub.pyx
@@ -16,6 +16,7 @@ from cupy.cuda cimport stream
 
 import cupy
 import cupy._core as _core
+from cupy.cuda import memory as _memory
 import numpy
 
 
@@ -572,3 +573,15 @@ cpdef cub_scan(_ndarray_base arr, op):
         return device_scan(arr, op)
 
     return None
+
+
+cpdef cub_histogram(_ndarray_base x, _ndarray_base y, bins):
+    """Check if the required workspace size is too much, if not then proceed
+    to compute the histogram, otherwise return None. This is a workaround for
+    NVIDIA/cub#613.
+    """
+    try:
+        out = device_histogram(x, y, bins)
+    except _memory.OutOfMemoryError:
+        return None
+    return out

--- a/tests/cupy_tests/statistics_tests/test_histogram.py
+++ b/tests/cupy_tests/statistics_tests/test_histogram.py
@@ -330,7 +330,6 @@ class TestHistogram(unittest.TestCase):
 
 
 # This class compares CUB results against NumPy's
-@testing.gpu
 @unittest.skipUnless(cupy.cuda.cub.available, 'The CUB routine is not enabled')
 class TestCubHistogram(unittest.TestCase):
 
@@ -398,8 +397,17 @@ class TestCubHistogram(unittest.TestCase):
         # ...then perform the actual computation
         return xp.histogram(x, bins)[1]
 
+    @testing.slow
+    @testing.numpy_cupy_array_equal()
+    def test_no_oom(self, xp):
+        # ensure the workaround for NVIDIA/cub#613 kicks in
+        amax = 28854312
+        A = xp.linspace(0, amax, num=amax,
+                        endpoint=True, retstep=False, dtype=xp.int32)
+        out = xp.histogram(A, bins=amax, range=[0, amax])
+        return out
 
-@testing.gpu
+
 @testing.parameterize(*testing.product(
     {'bins': [
         # Test monotonically increasing with in-bounds values


### PR DESCRIPTION
Thanks @ogreen for reporting and providing the reproducer.

This PR adds a workaround to avoid CUB histogram from asking for unrealistic amount of workspace (NVIDIA/cub#613). For example, the reproducer (added as a standalone test) would ask for 91.6 GB of device memory on my system. The added workaround ensures that if such extreme cases happen, we fall back to CuPy's existing histogram implementation.

Note that the workaround is made as thin as possible, with the eventual removal in mind once it's fixed upstream. In `cub.pyx` we have never checked for unrealistic workspace requests (we always assume no OOM), and so I do not intend to make too much change, as it might need a separate PR to properly handle all CUB functions 😅