### PR TITLE
Avoid int8 overflow warning in `TestRoundHalfway`

### DIFF
--- a/tests/cupy_tests/core_tests/test_ndarray_math.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_math.py
@@ -69,7 +69,7 @@ class TestRoundHalfway(unittest.TestCase):
         a -= a.size + 1
         scale = 10**abs(self.decimals)
         if self.decimals < 0:
-            a *= xp.array(scale, dtype=dtype)
+            a *= xp.array(scale).astype(dtype)
         a >>= 1
 
         return a.round(self.decimals)
@@ -83,7 +83,7 @@ class TestRoundHalfway(unittest.TestCase):
         a -= 1
         scale = 10**abs(self.decimals)
         if self.decimals < 0:
-            a *= xp.array(scale, dtype=dtype)
+            a *= xp.array(scale).astype(dtype)
         a >>= 1
 
         return a.round(self.decimals)


### PR DESCRIPTION
Part of https://github.com/cupy/cupy/issues/7243

```
E   AssertionError: Both cupy and numpy raise exceptions
E
E   cupy
E   Traceback (most recent call last):
E     File ".../cupy/testing/_loops.py", line 45, in _call_func
E       result = impl(*args, **kw)
E     File ".../tests/cupy_tests/core_tests/test_ndarray_math.py", line 72, in test_round_halfway_int
E       a *= xp.array(scale, dtype=dtype)
E     File ".../cupy/_creation/from_data.py", line 46, in array
E       return _core.array(obj, dtype, copy, order, subok, ndmin)
E     File "cupy/_core/core.pyx", line 2390, in cupy._core.core.array
E       cpdef _ndarray_base array(obj, dtype=None, bint copy=True, order='K',
E     File "cupy/_core/core.pyx", line 2414, in cupy._core.core.array
E       return _array_default(obj, dtype, order, ndmin)
E     File "cupy/_core/core.pyx", line 2539, in cupy._core.core._array_default
E       a_cpu = numpy.array(obj, dtype=dtype, copy=False, order=order,
E   DeprecationWarning: NumPy will stop allowing conversion of out-of-bound Python integers to integer arrays.  The conversion of 1000 to int8 will fail in the future.
E   For the old behavior, usually:
E       np.array(value).astype(dtype)`
E   will give the desired result (the cast overflows).
E
E
E   numpy
E   Traceback (most recent call last):
E     File ".../cupy/testing/_loops.py", line 45, in _call_func
E       result = impl(*args, **kw)
E     File ".../cupy1/tests/cupy_tests/core_tests/test_ndarray_math.py", line 72, in test_round_halfway_int
E       a *= xp.array(scale, dtype=dtype)
E   DeprecationWarning: NumPy will stop allowing conversion of out-of-bound Python integers to integer arrays.  The conversion of 1000 to int8 will fail in the future.
E   For the old behavior, usually:
E       np.array(value).astype(dtype)`
E   will give the desired result (the cast overflows).
```