### PR TITLE
Fix kernel cache not working in CUDA 12.0

### DIFF
--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -443,7 +443,10 @@ def _preprocess(source, options, arch, backend):
         raise ValueError('Invalid backend %s' % backend)
 
     assert isinstance(result, bytes)
-    return result
+
+    # Extract the part containing version information.
+    return '\n'.join(
+        x for x in result.decode().splitlines() if x.startswith('//'))
 
 
 _default_cache_dir = os.path.expanduser('~/.cupy/kernel_cache')

--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -501,7 +501,6 @@ def _compile_with_cache_cuda(
         enable_cooperative_groups=False, name_expressions=None,
         log_stream=None, cache_in_memory=False, jitify=False):
     # NVRTC does not use extra_source. extra_source is used for cache key.
-    global _empty_file_preprocess_cache
     if cache_dir is None:
         cache_dir = get_cache_dir()
     if arch is None:
@@ -530,13 +529,7 @@ def _compile_with_cache_cuda(
 
     env = ((arch, options, _get_nvrtc_version(), backend)
            + _get_arch_for_options_for_nvrtc(arch))
-    base = _empty_file_preprocess_cache.get(env, None)
-    if base is None:
-        # This is for checking NVRTC/NVCC compiler internal version
-        base = _preprocess('', options, arch, backend)
-        _empty_file_preprocess_cache[env] = base
-
-    key_src = '%s %s %s %s' % (env, base, source, extra_source)
+    key_src = '%s %s %s' % (env, source, extra_source)
     key_src = key_src.encode('utf-8')
     name = _hash_hexdigest(key_src) + '.cubin'
 

--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -501,6 +501,7 @@ def _compile_with_cache_cuda(
         enable_cooperative_groups=False, name_expressions=None,
         log_stream=None, cache_in_memory=False, jitify=False):
     # NVRTC does not use extra_source. extra_source is used for cache key.
+    global _empty_file_preprocess_cache
     if cache_dir is None:
         cache_dir = get_cache_dir()
     if arch is None:
@@ -529,7 +530,13 @@ def _compile_with_cache_cuda(
 
     env = ((arch, options, _get_nvrtc_version(), backend)
            + _get_arch_for_options_for_nvrtc(arch))
-    key_src = '%s %s %s' % (env, source, extra_source)
+    base = _empty_file_preprocess_cache.get(env, None)
+    if base is None:
+        # This is for checking NVRTC/NVCC compiler internal version
+        base = _preprocess('', options, arch, backend)
+        _empty_file_preprocess_cache[env] = base
+
+    key_src = '%s %s %s %s' % (env, base, source, extra_source)
     key_src = key_src.encode('utf-8')
     name = _hash_hexdigest(key_src) + '.cubin'
 


### PR DESCRIPTION
We noticed that kernel caching (`~/.cupy/kernel_cache`) is not working on CUDA 12.0. This is because PTX generated by CUDA 12.0 NVRTC includes identifiers randomly generated for every invocation.

CUDA 11.6 NVRTC:
```ptx
//
// Generated by NVIDIA NVVM Compiler
//
// Compiler Build ID: CL-30794723
// Cuda compilation tools, release 11.6, V11.6.55
// Based on NVVM 7.0.1
//

.version 7.6
.target sm_61
.address_size 64
```

CUDA 12.0 NVRTC:
```ptx
//
// Generated by NVIDIA NVVM Compiler
//
// Compiler Build ID: CL-31968024
// Cuda compilation tools, release 12.0, V12.0.76
// Based on NVVM 7.0.1
//
.version 8.0
.target sm_90
.address_size 64
.global .align 8 .u64 _ZN53_INTERNAL_00000000_15_default_program_26edde23_8009862nv6target6detail9all_hostsE = 1;
.global .align 8 .u64 _ZN53_INTERNAL_00000000_15_default_program_26edde23_8009862nv6target6detail9sm_35_bitE = 2;
.global .align 8 .u64 _ZN53_INTERNAL_00000000_15_default_program_26edde23_8009862nv6target6detail9sm_37_bitE = 4;
.global .align 8 .u64 _ZN53_INTERNAL_00000000_15_default_program_26edde23_8009862nv6target6detail9sm_50_bitE = 8;
.global .align 8 .u64 _ZN53_INTERNAL_00000000_15_default_program_26edde23_8009862nv6target6detail9sm_52_bitE = 16;
.global .align 8 .u64 _ZN53_INTERNAL_00000000_15_default_program_26edde23_8009862nv6target6detail9sm_53_bitE = 32;
.global .align 8 .u64 _ZN53_INTERNAL_00000000_15_default_program_26edde23_8009862nv6target6detail9sm_60_bitE = 64;
.global .align 8 .u64 _ZN53_INTERNAL_00000000_15_default_program_26edde23_8009862nv6target6detail9sm_61_bitE = 128;
.global .align 8 .u64 _ZN53_INTERNAL_00000000_15_default_program_26edde23_8009862nv6target6detail9sm_62_bitE = 256;
.global .align 8 .u64 _ZN53_INTERNAL_00000000_15_default_program_26edde23_8009862nv6target6detail9sm_70_bitE = 512;
.global .align 8 .u64 _ZN53_INTERNAL_00000000_15_default_program_26edde23_8009862nv6target6detail9sm_72_bitE = 1024;
.global .align 8 .u64 _ZN53_INTERNAL_00000000_15_default_program_26edde23_8009862nv6target6detail9sm_75_bitE = 2048;
.global .align 8 .u64 _ZN53_INTERNAL_00000000_15_default_program_26edde23_8009862nv6target6detail9sm_80_bitE = 4096;
.global .align 8 .u64 _ZN53_INTERNAL_00000000_15_default_program_26edde23_8009862nv6target6detail9sm_86_bitE = 8192;
.global .align 8 .u64 _ZN53_INTERNAL_00000000_15_default_program_26edde23_8009862nv6target6detail9sm_87_bitE = 16384;
.global .align 8 .u64 _ZN53_INTERNAL_00000000_15_default_program_26edde23_8009862nv6target6detail9sm_89_bitE = 32768;
.global .align 8 .u64 _ZN53_INTERNAL_00000000_15_default_program_26edde23_8009862nv6target6detail9sm_90_bitE = 65536;
.global .align 8 .u64 _ZN53_INTERNAL_00000000_15_default_program_26edde23_8009862nv6target6detail11all_devicesE = 131070;
.global .align 8 .b8 _ZN53_INTERNAL_00000000_15_default_program_26edde23_8009862nv6target7is_hostE[8] = {1, 0, 0, 0, 0, 0, 0, 0};
.global .align 8 .b8 _ZN53_INTERNAL_00000000_15_default_program_26edde23_8009862nv6target9is_deviceE[8] = {254, 255, 1, 0, 0, 0, 0, 0};
.global .align 8 .b8 _ZN53_INTERNAL_00000000_15_default_program_26edde23_8009862nv6target10any_targetE[8] = {255, 255, 1, 0, 0, 0, 0, 0};
.global .align 8 .b8 _ZN53_INTERNAL_00000000_15_default_program_26edde23_8009862nv6target9no_targetE[8];
.global .align 8 .u64 _ZN53_INTERNAL_00000000_15_default_program_26edde23_8009862nv6target5sm_35E = 35;
.global .align 8 .u64 _ZN53_INTERNAL_00000000_15_default_program_26edde23_8009862nv6target5sm_37E = 37;
.global .align 8 .u64 _ZN53_INTERNAL_00000000_15_default_program_26edde23_8009862nv6target5sm_50E = 50;
.global .align 8 .u64 _ZN53_INTERNAL_00000000_15_default_program_26edde23_8009862nv6target5sm_52E = 52;
.global .align 8 .u64 _ZN53_INTERNAL_00000000_15_default_program_26edde23_8009862nv6target5sm_53E = 53;
.global .align 8 .u64 _ZN53_INTERNAL_00000000_15_default_program_26edde23_8009862nv6target5sm_60E = 60;
.global .align 8 .u64 _ZN53_INTERNAL_00000000_15_default_program_26edde23_8009862nv6target5sm_61E = 61;
.global .align 8 .u64 _ZN53_INTERNAL_00000000_15_default_program_26edde23_8009862nv6target5sm_62E = 62;
.global .align 8 .u64 _ZN53_INTERNAL_00000000_15_default_program_26edde23_8009862nv6target5sm_70E = 70;
.global .align 8 .u64 _ZN53_INTERNAL_00000000_15_default_program_26edde23_8009862nv6target5sm_72E = 72;
.global .align 8 .u64 _ZN53_INTERNAL_00000000_15_default_program_26edde23_8009862nv6target5sm_75E = 75;
.global .align 8 .u64 _ZN53_INTERNAL_00000000_15_default_program_26edde23_8009862nv6target5sm_80E = 80;
.global .align 8 .u64 _ZN53_INTERNAL_00000000_15_default_program_26edde23_8009862nv6target5sm_86E = 86;
.global .align 8 .u64 _ZN53_INTERNAL_00000000_15_default_program_26edde23_8009862nv6target5sm_87E = 87;
.global .align 8 .u64 _ZN53_INTERNAL_00000000_15_default_program_26edde23_8009862nv6target5sm_89E = 89;
.global .align 8 .u64 _ZN53_INTERNAL_00000000_15_default_program_26edde23_8009862nv6target5sm_90E = 90;
```

CuPy has been compiling an empty source code into PTX (above) and using it as a part of cache keys to track the internal compiler version (0b6c0b263f15865434f6d29b2e42b75914103884).
I'm still wondering if it's okay to remove this from key (this means kernel cache will not be invalidated between bug-fix releases e.g. CUDA 11.5.0 and 11.5.1), but submitting a PR to raise a discussion.