### PR TITLE
Remove invalid pytest markers and turn on strict mode

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,13 @@ ignore_missing_imports = True
 disable_error_code = attr-defined
 
 [tool:pytest]
+addopts = --strict-markers
+markers =
+    slow
+    multi_gpu
+    # Legacy markers - do not use for new tests:
+    gpu
+    cudnn
 filterwarnings =
     error::FutureWarning
     # ignore FutureWarning from cupy._util.experimental

--- a/tests/cupy_tests/math_tests/test_misc.py
+++ b/tests/cupy_tests/math_tests/test_misc.py
@@ -1,5 +1,3 @@
-import sys
-
 import numpy
 import pytest
 
@@ -85,8 +83,6 @@ class TestMisc:
                      dtype=dtype)
         return getattr(xp, name)(a, b)
 
-    @pytest.mark.skipIf(
-        sys.platform == 'win32', reason='dtype problem on Windows')
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_array_equal()
     def test_clip1(self, xp, dtype):
@@ -118,8 +114,6 @@ class TestMisc:
             with pytest.raises(ValueError):
                 a.clip(None, None)
 
-    @pytest.mark.skipIf(
-        sys.platform == 'win32', reason='dtype problem on Windows')
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_array_equal()
     def test_external_clip1(self, xp, dtype):


### PR DESCRIPTION
I found `pytest.mark.skipIf` in test code but it is not working (it should be `pytest.mark.skipif`).
Removed the decorator as it seems unneeded, and also enable checkign unused markers.

https://docs.pytest.org/en/7.1.x/example/markers.html#registering-markers