### PR TITLE
Fix pre-commit configuration error

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,7 @@ repos:
     hooks:
     -   id: ci-generate
         name: "check CI files are up-to-date (.pfnci/generate.py)"
-        files: .pfnci/*
+        files: .pfnci/
         entry: .pfnci/generate.py --dry-run
         pass_filenames: false
         language: python


### PR DESCRIPTION
> Warning: The 'files' field in hook 'ci-generate' is a regex, not a glob -- matching '/*' probably isn't what you want here