### PR TITLE
Doc: downgrade pydata-sphinx-theme to v0.11.0

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,6 @@
 sphinx==5.3.0
-pydata_sphinx_theme==0.12.0
+# TODO(kmaehashi): Bump pydata-sphinx-theme when https://github.com/pydata/pydata-sphinx-theme/issues/1161 closed
+pydata_sphinx_theme==0.11.0
 sphinx-copybutton==0.5.1
 
 Cython==0.29.*


### PR DESCRIPTION
Closes #7374.

Let's stick with v0.11.0 until https://github.com/pydata/pydata-sphinx-theme/pull/1133 got merged.

discussion: https://github.com/pydata/pydata-sphinx-theme/issues/1161