### PR TITLE
Fix `arange()` to raise `TypeError` in boolean case

### DIFF
--- a/cupy/_creation/ranges.py
+++ b/cupy/_creation/ranges.py
@@ -46,7 +46,10 @@ def arange(start, stop=None, step=1, dtype=None):
 
     if numpy.dtype(dtype).type == numpy.bool_:
         if size > 2:
-            raise ValueError('no fill-function for data-type.')
+            raise TypeError(
+                'arange() is only supported for booleans '
+                'when the result has at most length 2.'
+            )
         if size == 2:
             return cupy.array([start, start - step], dtype=numpy.bool_)
         else:

--- a/tests/cupy_tests/creation_tests/test_ranges.py
+++ b/tests/cupy_tests/creation_tests/test_ranges.py
@@ -73,9 +73,10 @@ class TestRanges(unittest.TestCase):
     def test_arange8(self, xp, dtype):
         return xp.arange(10, 8, -1).astype(dtype)
 
+    @testing.with_requires('numpy>=1.24')
     def test_arange9(self):
         for xp in (numpy, cupy):
-            with pytest.raises(ValueError):
+            with pytest.raises(TypeError):
                 xp.arange(10, dtype=xp.bool_)
 
     @testing.numpy_cupy_array_equal()

--- a/tests/cupy_tests/indexing_tests/test_generate.py
+++ b/tests/cupy_tests/indexing_tests/test_generate.py
@@ -28,9 +28,10 @@ class TestIndices(unittest.TestCase):
     def test_indices_list2(self, xp, dtype):
         return xp.indices((1, 2, 3, 4), dtype)
 
+    @testing.with_requires('numpy>=1.24')
     def test_indices_list3(self):
         for xp in (numpy, cupy):
-            with pytest.raises(ValueError):
+            with pytest.raises(TypeError):
                 xp.indices((1, 2, 3, 4), dtype=xp.bool_)
 
 


### PR DESCRIPTION
Rel. https://github.com/cupy/cupy/pull/7338