### PR TITLE
Avoid `fillvalue` overflow in `cupyx.scipy.signal` test

### DIFF
--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
@@ -188,6 +188,8 @@ class TestConvolveCorrelate2D:
         if self.mode == 'full' and self.boundary != 'fill':
             # See https://github.com/scipy/scipy/issues/12685
             pytest.skip('broken in scipy')
+        if np.dtype(dtype).kind == 'u' and self.fillvalue < 0:
+            pytest.skip('fillvalue overflow')
         in1 = testing.shaped_random(self.size1, xp, dtype)
         in2 = testing.shaped_random(self.size2, xp, dtype)
         return getattr(scp.signal, func)(in1, in2, self.mode, self.boundary,


### PR DESCRIPTION
Rel. https://github.com/cupy/cupy/pull/7338