### PR TITLE
Change implementation of fftshift and ifftshift

### DIFF
--- a/cupy/fft/_fft.py
+++ b/cupy/fft/_fft.py
@@ -1079,9 +1079,7 @@ def fftshift(x, axes=None):
         axes = list(range(x.ndim))
     elif isinstance(axes, np.compat.integer_types):
         axes = (axes,)
-    for axis in axes:
-        x = cupy.roll(x, x.shape[axis] // 2, axis)
-    return x
+    return cupy.roll(x, [x.shape[axis] // 2 for axis in axes], axes)
 
 
 def ifftshift(x, axes=None):
@@ -1102,6 +1100,4 @@ def ifftshift(x, axes=None):
         axes = list(range(x.ndim))
     elif isinstance(axes, np.compat.integer_types):
         axes = (axes,)
-    for axis in axes:
-        x = cupy.roll(x, -(x.shape[axis] // 2), axis)
-    return x
+    return cupy.roll(x, [-x.shape[axis] // 2 for axis in axes], axes)

--- a/cupy/fft/_fft.py
+++ b/cupy/fft/_fft.py
@@ -1100,4 +1100,4 @@ def ifftshift(x, axes=None):
         axes = list(range(x.ndim))
     elif isinstance(axes, np.compat.integer_types):
         axes = (axes,)
-    return cupy.roll(x, [-x.shape[axis] // 2 for axis in axes], axes)
+    return cupy.roll(x, [-(x.shape[axis] // 2) for axis in axes], axes)


### PR DESCRIPTION
This changes the fftshifts to generate the amount of shift for each shifted axis and then execute the shift with a single call to cupy roll. For 1D shifts (i.e., where there is a single axis being shifted, regardless of the dimension of the array) there is no effective change, but for shifts along multiple axes, this decreases the amount of working memory required. Specifically, for an array of size N, and shifting along k axes, this requires only O(N) memory instead of O(kN) memory as before.

For FFTs that take most of the GPU's memory, this can mean the difference between completing the computation and an out of memory error or having to chunk the computation.