### PR TITLE
DOC: cupyx.interpolate: document limitations on ROCm

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -463,6 +463,7 @@ The following features are not yet supported:
 * cuDNN (hipDNN)
 * Hermitian/symmetric eigenvalue solver (``cupy.linalg.eigh``)
 * Polynomial roots (uses Hermitian/symmetric eigenvalue solver)
+* Splines in ``cupyx.scipy.interpolate`` (``make_interp_spline``, spline modes of ``RegularGridInterpolator``/``interpn``), as they depend on sparse matrices.
 
 The following features may not work in edge cases (e.g., some combinations of dtype):
 


### PR DESCRIPTION
Splines use banded linear algebra, which we emulate with sparse solvers, and those are not available on ROCm, so document the limitation.