### PR TITLE
Drop support for Python 3.7, NumPy 1.20, and SciPy 1.6 on document and setup.py

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -14,7 +14,7 @@ Requirements
     * This requirement is optional if you install CuPy from ``conda-forge``. However, you still need to have a compatible
       driver installed for your GPU. See :ref:`install_cupy_from_conda_forge` for details.
 
-* `Python <https://python.org/>`_: v3.7.0+ / v3.8.0+ / v3.9.0+ / v3.10.0+ / v3.11.0+
+* `Python <https://python.org/>`_: v3.8 / v3.9 / v3.10 / v3.11
 
 .. note::
 
@@ -25,9 +25,9 @@ Python Dependencies
 
 NumPy/SciPy-compatible API in CuPy v12 is based on NumPy 1.24 and SciPy 1.9, and has been tested against the following versions:
 
-* `NumPy <https://numpy.org/>`_: v1.20 / v1.21 / v1.22 / v1.23 / v1.24
+* `NumPy <https://numpy.org/>`_: v1.21 / v1.22 / v1.23 / v1.24
 
-* `SciPy <https://scipy.org/>`_ (*optional*): v1.6 / v1.7 / v1.8 / v1.9
+* `SciPy <https://scipy.org/>`_ (*optional*): v1.7 / v1.8 / v1.9
 
     * Required only when coping sparse matrices from GPU to CPU (see :doc:`../reference/scipy_sparse`.)
 

--- a/setup.py
+++ b/setup.py
@@ -23,12 +23,12 @@ setup_requires = [
     'fastrlock>=0.5',
 ]
 install_requires = [
-    'numpy>=1.20,<1.27',  # see #4773
+    'numpy>=1.21,<1.27',  # see #4773
     'fastrlock>=0.5',
 ]
 extras_require = {
     'all': [
-        'scipy>=1.6,<1.12',  # see #4773
+        'scipy>=1.7,<1.12',  # see #4773
         'Cython>=0.29.22,<3',
         'optuna>=2.0',
     ],
@@ -105,7 +105,6 @@ Intended Audience :: Developers
 License :: OSI Approved :: MIT License
 Programming Language :: Python
 Programming Language :: Python :: 3
-Programming Language :: Python :: 3.7
 Programming Language :: Python :: 3.8
 Programming Language :: Python :: 3.9
 Programming Language :: Python :: 3.10
@@ -138,7 +137,7 @@ setup(
     packages=find_packages(exclude=['install', 'tests']),
     package_data=package_data,
     zip_safe=False,
-    python_requires='>=3.7',
+    python_requires='>=3.8',
     setup_requires=setup_requires,
     install_requires=install_requires,
     tests_require=tests_require,


### PR DESCRIPTION
#7405 has some CI issues, so we update the documentation and setup.py first for the next release.