### PR TITLE
Revert cupy.cuda.Device behavior to v9

### DIFF
--- a/tests/cupy_tests/cuda_tests/test_device.py
+++ b/tests/cupy_tests/cuda_tests/test_device.py
@@ -193,8 +193,8 @@ class TestDeviceSwitch(unittest.TestCase):
             dev1.use()
             with dev1:
                 assert 1 == cuda.Device().id
-            assert 0 == cuda.Device().id
-        assert 0 == cuda.Device().id
+            assert 1 == cuda.Device().id
+        assert 1 == cuda.Device().id
 
     def test_thread_safe(self):
         dev0 = cuda.Device(0)


### PR DESCRIPTION
This reverts #5853 as discussed in #6965.

Closes #6965 and #7315.

I've tested interoperability with PyTorch and looks working as expected:

```py
# Note: requires 3 GPUs

import cupy
import torch


dev1 = cupy.cuda.Device(1)

with dev1:
    t1 = torch.arange(10, device='cuda')
    assert 'cuda:1' == str(t1.device)
    assert ((t1 - torch.from_dlpack(cupy.arange(10))).sum() == 0).item() is True
    with torch.cuda.device(2):
        t2 = torch.arange(10).cuda()
        assert 'cuda:2' == str(t2.device)
        assert cupy.cuda.Device().id == 2
        with dev1:
            assert 1 == torch.cuda.current_device()
    assert cupy.cuda.Device().id == 1
assert 0 == torch.cuda.current_device()
```
cc/ @leofang 