### PR TITLE
BUG: Fix new strides when array is both C and F-contiguous

### DIFF
--- a/cupy/_core/internal.pyx
+++ b/cupy/_core/internal.pyx
@@ -498,15 +498,15 @@ cpdef int _update_order_char(
         bint is_c_contiguous, bint is_f_contiguous, int order_char):
     # update order_char based on array contiguity
     if order_char == b'A':
-        if is_f_contiguous:
+        if is_f_contiguous and not is_c_contiguous:
             order_char = b'F'
         else:
             order_char = b'C'
     elif order_char == b'K':
-        if is_f_contiguous:
-            order_char = b'F'
-        elif is_c_contiguous:
+        if is_c_contiguous:
             order_char = b'C'
+        elif is_f_contiguous:
+            order_char = b'F'
     return order_char
 
 

--- a/tests/cupy_tests/creation_tests/test_from_data.py
+++ b/tests/cupy_tests/creation_tests/test_from_data.py
@@ -172,6 +172,20 @@ class TestFromData(unittest.TestCase):
 
     @testing.for_orders('CFAK')
     @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal(strides_check=True)
+    def test_array_both_c_and_f_contig_copy(self, xp, dtype, order):
+        a = testing.shaped_arange((1, 4, 1), xp, dtype, order="C")
+        return xp.array(a, order=order)
+
+    @testing.for_orders('CFAK')
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal(strides_check=True)
+    def test_array_both_c_and_f_contig_f_strides_copy(self, xp, dtype, order):
+        a = testing.shaped_arange((1, 4, 1), xp, dtype, order="F")
+        return xp.array(a, order=order)
+
+    @testing.for_orders('CFAK')
+    @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_array_copy_is_copied(self, xp, dtype, order):
         a = testing.shaped_arange((2, 3, 4), xp, dtype)


### PR DESCRIPTION
In this case, NumPy will prefer the C contiguous strides, not the F contiguous ones.

I will note that I do not think users should reuly on strides if they rely on contiguity, and the old strides could be considered just as valid as the new one.

Just as NumPy the strides of an F- and C-contiguous array created as an F-contiguous one will have strides mutate on copy after this. Currently, this happens for C contiguous ones.

Closes gh-5897