### PR TITLE
Prevent contiguous 1D arrays from switching to F-order

### DIFF
--- a/cupy/_core/internal.pyx
+++ b/cupy/_core/internal.pyx
@@ -498,15 +498,15 @@ cpdef int _update_order_char(
         bint is_c_contiguous, bint is_f_contiguous, int order_char):
     # update order_char based on array contiguity
     if order_char == b'A':
-        if is_f_contiguous:
+        if is_f_contiguous and not is_c_contiguous:
             order_char = b'F'
         else:
             order_char = b'C'
     elif order_char == b'K':
-        if is_f_contiguous:
-            order_char = b'F'
-        elif is_c_contiguous:
+        if is_c_contiguous:
             order_char = b'C'
+        elif is_f_contiguous:
+            order_char = b'F'
     return order_char
 
 

--- a/tests/cupy_tests/core_tests/test_ndarray.py
+++ b/tests/cupy_tests/core_tests/test_ndarray.py
@@ -23,7 +23,7 @@ def wrap_take(array, *args, **kwargs):
 
 
 @testing.gpu
-class TestNdarrayInit(unittest.TestCase):
+class TestNdarrayInit:
 
     def test_shape_none(self):
         with testing.assert_warns(DeprecationWarning):
@@ -79,6 +79,26 @@ class TestNdarrayInit(unittest.TestCase):
         a = cupy.ndarray(
             (2, 3), numpy.float32, buf.data, strides=(8, 4), order='C')
         assert a.strides == (8, 4)
+
+    @pytest.mark.parametrize('copy', [False, True])
+    @pytest.mark.parametrize('order', ['A', 'K', 'C'])
+    def test_array_1d(self, copy, order):
+        # Test that C-contiguous strides are preserved on copy for 1D arrays
+        a = cupy.ones((1, 1, 3), dtype=numpy.float32)
+        original_strides = a.strides
+
+        b = cupy.array(a, copy=copy, order=order)
+        assert b.strides == original_strides
+
+    @pytest.mark.parametrize('copy', [False, True])
+    @pytest.mark.parametrize('order', ['A', 'K', 'C'])
+    def test_astype_1d(self, copy, order):
+        # Test that C-contiguous strides are preserved on copy for 1D arrays
+        a = cupy.ones((1, 1, 3), dtype=numpy.float32)
+        original_strides = a.strides
+
+        c = a.astype(numpy.float32, copy=copy, order=order)
+        assert c.strides == original_strides
 
     @testing.with_requires('numpy>=1.19')
     def test_strides_is_given_but_order_is_invalid(self):


### PR DESCRIPTION
This MR fixes the behavior of array creation with `order='A'` or `order='K'` when the array is both C and F contiguous (as is the case for a 1D contiguous array). In this case, 'F' order was being selected over 'C' order while in NumPy the behavior is the other way around. This MR changes the behavior to match NumPy's.

Some new test cases were added. Prior to this MR 4 of these cases would fail as follows
```
FAILED tests/cupy_tests/core_tests/test_ndarray.py::TestNdarrayInit::test_array_1d[A-True] - assert (4, 4, 4) == (12, 12, 4)
FAILED tests/cupy_tests/core_tests/test_ndarray.py::TestNdarrayInit::test_array_1d[K-True] - assert (4, 4, 4) == (12, 12, 4)
FAILED tests/cupy_tests/core_tests/test_ndarray.py::TestNdarrayInit::test_astype_1d[A-True] - assert (4, 4, 4) == (12, 12, 4)
FAILED tests/cupy_tests/core_tests/test_ndarray.py::TestNdarrayInit::test_astype_1d[K-True] - assert (4, 4, 4) == (12, 12, 4)
```
