### PR TITLE
Update branch name from `master` to `main`

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -4,7 +4,7 @@ on:
   pull_request_target:
     types: [closed, labeled]
     branches:
-       - master
+       - main
 
 jobs:
   backport:

--- a/.github/workflows/flexci.yml
+++ b/.github/workflows/flexci.yml
@@ -2,7 +2,7 @@ name: "FlexCI"
 
 on:
   push:
-    branches: ["master", "v[0-9]+", "hotfix-*"]
+    branches: ["main", "v[0-9]+", "hotfix-*"]
   issue_comment:
     types: [created]
 

--- a/.pfnci/BRANCH
+++ b/.pfnci/BRANCH
@@ -1,1 +1,1 @@
-master
+main

--- a/.pfnci/coverage.rst
+++ b/.pfnci/coverage.rst
@@ -3168,13 +3168,13 @@ CuPy CI Test Coverage
 .. _t21: https://ci.preferred.jp/cupy.linux.cuda120.multi/
 .. _d21: linux/tests/cuda120.multi.Dockerfile
 .. _s21: linux/tests/cuda120.multi.sh
-.. _t22: https://jenkins.preferred.jp/job/chainer/job/cupy_master/TEST=rocm-4-3,label=mnj-mi50/
+.. _t22: https://jenkins.preferred.jp/job/chainer/job/cupy_main/TEST=rocm-4-3,label=mnj-mi50/
 .. _d22: linux/tests/rocm-4-3.Dockerfile
 .. _s22: linux/tests/rocm-4-3.sh
-.. _t23: https://jenkins.preferred.jp/job/chainer/job/cupy_master/TEST=rocm-5-0,label=mnj-mi50/
+.. _t23: https://jenkins.preferred.jp/job/chainer/job/cupy_main/TEST=rocm-5-0,label=mnj-mi50/
 .. _d23: linux/tests/rocm-5-0.Dockerfile
 .. _s23: linux/tests/rocm-5-0.sh
-.. _t24: https://jenkins.preferred.jp/job/chainer/job/cupy_master/TEST=rocm-5-3,label=mnj-mi50/
+.. _t24: https://jenkins.preferred.jp/job/chainer/job/cupy_main/TEST=rocm-5-3,label=mnj-mi50/
 .. _d24: linux/tests/rocm-5-3.Dockerfile
 .. _s24: linux/tests/rocm-5-3.sh
 .. _t25: https://ci.preferred.jp/cupy.linux.cuda-slow/

--- a/.pfnci/linux/tests/actions/benchmark.sh
+++ b/.pfnci/linux/tests/actions/benchmark.sh
@@ -12,7 +12,7 @@ python3 prof.py benchmarks/bench_ufunc_cupy.py -c
 mkdir target
 mv *.csv target/
 
-# Run benchmarks for master branch
+# Run benchmarks for main branch
 # Since GCP instance may change and use diff gen processsors/GPUs
 # we just recompile and run to avoid false errors
 python3 -m pip uninstall -y cupy
@@ -23,10 +23,10 @@ if [[ "${PULL_REQUEST:-}" == "" ]]; then
     # For branches we compare against the latest release
     # TODO(ecastill) find a programatical way of doing this
     # sorting tags, or just checking the dates may mix the
-    # stable & master branches
+    # stable & main branches
     git checkout tags/v11.0.0a2 -b v11.0.0a2
 else
-    git checkout master
+    git checkout main
 fi
 git submodule update --init
 python3 -m pip install --user -v .

--- a/.pfnci/matrix.yaml
+++ b/.pfnci/matrix.yaml
@@ -347,7 +347,7 @@
 # ROCm 4.3 | Linux
 # The lowest ROCm version matrix is intended to cover the lowest supported combination.
 - project: "cupy.linux.rocm-4-3"
-  _url: "https://jenkins.preferred.jp/job/chainer/job/cupy_master/TEST=rocm-4-3,label=mnj-mi50/"
+  _url: "https://jenkins.preferred.jp/job/chainer/job/cupy_main/TEST=rocm-4-3,label=mnj-mi50/"
   tags: null  # Jenkins
   target: "rocm-4-3"
   system: "linux"
@@ -370,7 +370,7 @@
 
 # ROCm 5.0 | Linux
 - project: "cupy.linux.rocm-5-0"
-  _url: "https://jenkins.preferred.jp/job/chainer/job/cupy_master/TEST=rocm-5-0,label=mnj-mi50/"
+  _url: "https://jenkins.preferred.jp/job/chainer/job/cupy_main/TEST=rocm-5-0,label=mnj-mi50/"
   tags: null  # Jenkins
   target: "rocm-5-0"
   system: "linux"
@@ -394,7 +394,7 @@
 # ROCm 5.3 | Linux
 # The latest ROCm version matrix is intended to cover the highest supported combination.
 - project: "cupy.linux.rocm-5-3"
-  _url: "https://jenkins.preferred.jp/job/chainer/job/cupy_master/TEST=rocm-5-3,label=mnj-mi50/"
+  _url: "https://jenkins.preferred.jp/job/chainer/job/cupy_main/TEST=rocm-5-3,label=mnj-mi50/"
   tags: null  # Jenkins
   target: "rocm-5-3"
   system: "linux"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,8 +8,8 @@ repos:
     # Git
     -   id: check-added-large-files
     -   id: no-commit-to-branch
-        name: "ensure no direct commit to master/vXX branch"
-        args: [--branch, "master", --pattern, "v\\d+"]
+        name: "ensure no direct commit to main/vXX branch"
+        args: [--branch, "main", --pattern, "v\\d+"]
     -   id: check-case-conflict
     # Contents
     -   id: mixed-line-ending

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<div align="center"><img src="https://raw.githubusercontent.com/cupy/cupy/master/docs/image/cupy_logo_1000px.png" width="400"/></div>
+<div align="center"><img src="https://raw.githubusercontent.com/cupy/cupy/main/docs/image/cupy_logo_1000px.png" width="400"/></div>
 
 # CuPy : NumPy & SciPy for GPU
 
@@ -12,7 +12,7 @@
 [**Website**](https://cupy.dev/)
 | [**Install**](https://docs.cupy.dev/en/stable/install.html)
 | [**Tutorial**](https://docs.cupy.dev/en/stable/user_guide/basic.html)
-| [**Examples**](https://github.com/cupy/cupy/tree/master/examples)
+| [**Examples**](https://github.com/cupy/cupy/tree/main/examples)
 | [**Documentation**](https://docs.cupy.dev/en/stable/)
 | [**API Reference**](https://docs.cupy.dev/en/stable/reference/)
 | [**Forum**](https://groups.google.com/forum/#!forum/cupy)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -28,7 +28,7 @@ on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
 rtd_version = os.environ.get('READTHEDOCS_VERSION')
 if rtd_version == 'latest':
-    tag = 'master'
+    tag = 'main'
 else:
     tag = 'v{}'.format(__version__)
 extlinks = {

--- a/docs/source/contribution.rst
+++ b/docs/source/contribution.rst
@@ -81,24 +81,24 @@ The GitHub milestone is basically used for collecting the issues and PRs resolve
 Git Branches
 ~~~~~~~~~~~~
 
-The ``master`` branch is used to develop pre-release versions.
-It means that **alpha, beta, and RC updates are developed at the** ``master`` **branch**.
+The ``main`` branch is used to develop pre-release versions.
+It means that **alpha, beta, and RC updates are developed at the** ``main`` **branch**.
 This branch contains the most up-to-date source tree that includes features newly added after the latest major version.
 
 The stable version is developed at the individual branch named as ``vN`` where "N" reflects the version number (we call it a *versioned branch*).
 For example, v1.0.0, v1.0.1, and v1.0.2 will be developed at the ``v1`` branch.
 
 **Notes for contributors:**
-When you send a pull request, you basically have to send it to the ``master`` branch.
+When you send a pull request, you basically have to send it to the ``main`` branch.
 If the change can also be applied to the stable version, a core team member will apply the same change to the stable version so that the change is also included in the next revision update.
 
-If the change is only applicable to the stable version and not to the ``master`` branch, please send it to the versioned branch.
+If the change is only applicable to the stable version and not to the ``main`` branch, please send it to the versioned branch.
 We basically only accept changes to the latest versioned branch (where the stable version is developed) unless the fix is critical.
 
-If you want to make a new feature of the ``master`` branch available in the current stable version, please send a *backport PR* to the stable version (the latest ``vN`` branch).
+If you want to make a new feature of the ``main`` branch available in the current stable version, please send a *backport PR* to the stable version (the latest ``vN`` branch).
 See the next section for details.
 
-*Note: a change that can be applied to both branches should be sent to the* ``master`` *branch.*
+*Note: a change that can be applied to both branches should be sent to the* ``main`` *branch.*
 *Each release of the stable version is also merged to the development version so that the change is also reflected to the next major version.*
 
 Feature Backport PRs
@@ -134,7 +134,7 @@ First of all, before starting to write any code, do not forget to confirm the fo
 
 - Read through the :ref:`coding-guide` and :ref:`testing-guide`.
 - Check the appropriate branch that you should send the PR following :ref:`contrib-git-branches`.
-  If you do not have any idea about selecting a branch, please choose the ``master`` branch.
+  If you do not have any idea about selecting a branch, please choose the ``main`` branch.
 
 In particular, **check the branch before writing any code.**
 The current source tree of the chosen branch is the starting point of your change.
@@ -149,7 +149,7 @@ Note that this automatic PR test only includes CPU tests.
 
 .. note::
 
-   We are also running continuous integration with GPU tests for the ``master`` branch and the versioned branch of the latest major version.
+   We are also running continuous integration with GPU tests for the ``main`` branch and the versioned branch of the latest major version.
    Since this service is currently running on our internal server, we do not use it for automatic PR tests to keep the server secure.
 
 If you are planning to add a new feature or modify existing APIs, **it is recommended to open an issue and discuss the design first.**
@@ -389,7 +389,7 @@ When adding a new feature to the framework, you also need to document it in the 
    If you are unsure about how to fix the documentation, you can submit a pull request without doing so.
    Reviewers will help you fix the documentation appropriately.
 
-The documentation source is stored under `docs directory <https://github.com/cupy/cupy/tree/master/docs>`_ and written in `reStructuredText <http://www.sphinx-doc.org/en/master/usage/restructuredtext/index.html>`_ format.
+The documentation source is stored under `docs directory <https://github.com/cupy/cupy/tree/main/docs>`_ and written in `reStructuredText <http://www.sphinx-doc.org/en/master/usage/restructuredtext/index.html>`_ format.
 
 To build the documentation, you need to install `Sphinx <http://www.sphinx-doc.org/>`_::
 

--- a/docs/source/user_guide/kernel.rst
+++ b/docs/source/user_guide/kernel.rst
@@ -381,7 +381,7 @@ It may be important to note that this dedicated memory bank is not shared with t
 
 For now, CuPy offers no helper routines to create user defined composite types. 
 Such composite types can however be built recursively using NumPy dtype `offsets` and `itemsize` capabilities,
-see `cupy/examples/custum_struct <https://github.com/cupy/cupy/tree/master/examples/custom_struct>`_ for examples of advanced usage.
+see `cupy/examples/custum_struct <https://github.com/cupy/cupy/tree/main/examples/custom_struct>`_ for examples of advanced usage.
 
 .. warning::
     You cannot directly pass static arrays as kernel arguments with the ``type arg[N]`` syntax where N is a compile time constant. The signature of ``__global__ void kernel(float arg[5])`` is seen as ``__global__ void kernel(float* arg)`` by the compiler. If you want to pass five floats to the kernel by value you need to define a custom structure ``struct float5 { float val[5]; };`` and modify the kernel signature to ``__global__ void kernel(float5 arg)``.


### PR DESCRIPTION
Closes #7294.
Note: backport to v12 must exclude changes to BRANCH file.