### PR TITLE
Remove unused test decorators

### DIFF
--- a/cupy/testing/__init__.py
+++ b/cupy/testing/__init__.py
@@ -5,7 +5,6 @@ from cupy.testing._array import assert_array_equal  # NOQA
 from cupy.testing._array import assert_array_less  # NOQA
 from cupy.testing._array import assert_array_list_equal  # NOQA
 from cupy.testing._array import assert_array_max_ulp  # NOQA
-from cupy.testing._attr import gpu  # NOQA
 from cupy.testing._attr import multi_gpu  # NOQA
 from cupy.testing._attr import slow  # NOQA
 from cupy.testing._helper import assert_warns  # NOQA

--- a/cupy/testing/_attr.py
+++ b/cupy/testing/_attr.py
@@ -9,12 +9,6 @@ if is_available():
 
     _gpu_limit = int(os.getenv('CUPY_TEST_GPU_LIMIT', '-1'))
 
-    def gpu(*args, **kwargs):
-        return pytest.mark.gpu(*args, **kwargs)
-
-    def cudnn(*args, **kwargs):
-        return pytest.mark.cudnn(*args, **kwargs)
-
     def slow(*args, **kwargs):
         return pytest.mark.slow(*args, **kwargs)
 
@@ -23,8 +17,6 @@ else:
         check_available('pytest attributes')
         assert False  # Not reachable
 
-    gpu = _dummy_callable
-    cudnn = _dummy_callable
     slow = _dummy_callable
 
 

--- a/cupy/testing/_loops.py
+++ b/cupy/testing/_loops.py
@@ -485,8 +485,7 @@ def numpy_cupy_allclose(rtol=1e-7, atol=0, err_msg='', verbose=True,
 
     >>> import unittest
     >>> from cupy import testing
-    >>> @testing.gpu
-    ... class TestFoo(unittest.TestCase):
+    >>> class TestFoo(unittest.TestCase):
     ...
     ...     @testing.numpy_cupy_allclose()
     ...     def test_foo(self, xp):
@@ -908,8 +907,7 @@ def for_all_dtypes(name='dtype', no_float16=False, no_bool=False,
 
     >>> import unittest
     >>> from cupy import testing
-    >>> @testing.gpu
-    ... class TestNpz(unittest.TestCase):
+    >>> class TestNpz(unittest.TestCase):
     ...
     ...     @testing.for_all_dtypes()
     ...     def test_pickle(self, dtype):
@@ -925,8 +923,7 @@ def for_all_dtypes(name='dtype', no_float16=False, no_bool=False,
 
     >>> import unittest
     >>> from cupy import testing
-    >>> @testing.gpu
-    ... class TestMean(unittest.TestCase):
+    >>> class TestMean(unittest.TestCase):
     ...
     ...     @testing.for_all_dtypes()
     ...     @testing.numpy_cupy_allclose()

--- a/docs/source/contribution.rst
+++ b/docs/source/contribution.rst
@@ -322,55 +322,33 @@ In addition to the :ref:`coding-guide` mentioned above, the following rules are 
    We are incrementally applying the above style.
    Some existing tests may be using the old style (``self.assertRaises``, etc.), but all newly written tests should follow the above style.
 
-Even if your patch includes GPU-related code, your tests should not fail without GPU capability.
-Test functions that require CUDA must be tagged by the ``cupy.testing.attr.gpu``::
+In order to write tests for multiple GPUs, use ``cupy.testing.multi_gpu()`` decorators instead::
 
   import unittest
-  from cupy.testing import attr
+  from cupy import testing
 
   class TestMyFunc(unittest.TestCase):
       ...
 
-      @attr.gpu
-      def test_my_gpu_func(self):
-          ...
-
-The functions tagged by the ``gpu`` decorator are skipped if ``CUPY_TEST_GPU_LIMIT=0`` environment variable is set.
-We also have the ``cupy.testing.attr.cudnn`` decorator to let ``pytest`` know that the test depends on cuDNN.
-The test functions decorated by ``cudnn`` are skipped if ``-m='not cudnn'`` is given.
-
-The test functions decorated by ``gpu`` must not depend on multiple GPUs.
-In order to write tests for multiple GPUs, use ``cupy.testing.attr.multi_gpu()`` decorators instead::
-
-  import unittest
-  from cupy.testing import attr
-
-  class TestMyFunc(unittest.TestCase):
-      ...
-
-      @attr.multi_gpu(2)  # specify the number of required GPUs here
+      @testing.multi_gpu(2)  # specify the number of required GPUs here
       def test_my_two_gpu_func(self):
           ...
 
-If your test requires too much time, add ``cupy.testing.attr.slow`` decorator.
+If your test requires too much time, add ``cupy.testing.slow`` decorator.
 The test functions decorated by ``slow`` are skipped if ``-m='not slow'`` is given::
 
   import unittest
-  from cupy.testing import attr
+  from cupy import testing
 
   class TestMyFunc(unittest.TestCase):
       ...
 
-      @attr.slow
+      @testing.slow
       def test_my_slow_func(self):
           ...
 
-.. note::
-   If you want to specify more than two attributes, use ``and`` operator like ``-m='not cudnn and not slow'``.
-   See detail in `the document of pytest <https://docs.pytest.org/en/latest/example/markers.html>`_.
-
-Once you send a pull request, `Travis-CI <https://travis-ci.org/cupy/cupy/>`_ automatically checks if your code meets our coding guidelines described above.
-Since Travis-CI does not support CUDA, we cannot run unit tests automatically.
+Once you send a pull request, GitHub Actions automatically checks if your code meets our coding guidelines described above.
+Since GitHub Actions does not support CUDA, we cannot run unit tests automatically.
 The reviewing process starts after the automatic check passes.
 Note that reviewers will test your code without the option to check CUDA-related code.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,9 +19,6 @@ addopts = --strict-markers
 markers =
     slow
     multi_gpu
-    # Legacy markers - do not use for new tests:
-    gpu
-    cudnn
 filterwarnings =
     error::FutureWarning
     # ignore FutureWarning from cupy._util.experimental

--- a/tests/cupy_tests/binary_tests/test_elementwise.py
+++ b/tests/cupy_tests/binary_tests/test_elementwise.py
@@ -3,7 +3,6 @@ import unittest
 from cupy import testing
 
 
-@testing.gpu
 class TestElementwise(unittest.TestCase):
 
     @testing.for_int_dtypes()

--- a/tests/cupy_tests/binary_tests/test_packing.py
+++ b/tests/cupy_tests/binary_tests/test_packing.py
@@ -5,7 +5,6 @@ import cupy
 from cupy import testing
 
 
-@testing.gpu
 class TestPacking(unittest.TestCase):
 
     @testing.for_int_dtypes()

--- a/tests/cupy_tests/core_tests/fusion_tests/test_array.py
+++ b/tests/cupy_tests/core_tests/fusion_tests/test_array.py
@@ -28,7 +28,6 @@ class FusionArrayTestBase(unittest.TestCase):
         return (x, y), {}
 
 
-@testing.gpu
 @testing.parameterize(*testing._parameterized.product_dict(
     [
         {'name': 'neg', 'func': lambda x, y: -x},
@@ -61,7 +60,6 @@ class TestFusionArrayOperator(FusionArrayTestBase):
         return self.func
 
 
-@testing.gpu
 @testing.parameterize(*testing._parameterized.product_dict(
     [
         {'name': 'lshift', 'func': lambda x, y: x << y},
@@ -101,7 +99,6 @@ class TestFusionArrayBitwiseOperator(FusionArrayTestBase):
         return func
 
 
-@testing.gpu
 @testing.parameterize(
     {'left_value': 'array', 'right_value': 'array'},
     {'left_value': 'array', 'right_value': 'scalar'},
@@ -119,7 +116,6 @@ class TestFusionArrayFloorDivide(FusionArrayTestBase):
 
 
 # TODO(imanishi): Fix TypeError in use of dtypes_combination test.
-@testing.gpu
 @testing.parameterize(*testing._parameterized.product_dict(
     [
         {'left_value': 'array', 'right_value': 'array'},
@@ -231,7 +227,6 @@ class TestFusionArrayInplaceOperator(FusionArrayTestBase):
         return func
 
 
-@testing.gpu
 class TestFusionArraySetItem(unittest.TestCase):
 
     def generate_inputs(self, xp):
@@ -258,7 +253,6 @@ class TestFusionArraySetItem(unittest.TestCase):
         return func
 
 
-@testing.gpu
 class TestFusionArrayMethods(unittest.TestCase):
 
     def generate_inputs(self, xp, dtype):
@@ -301,7 +295,6 @@ class TestFusionArrayMethods(unittest.TestCase):
         return lambda x: x.any()
 
 
-@testing.gpu
 class TestFusionArrayAsType(unittest.TestCase):
 
     def generate_inputs(self, xp, dtype1, dtype2):

--- a/tests/cupy_tests/core_tests/fusion_tests/test_example.py
+++ b/tests/cupy_tests/core_tests/fusion_tests/test_example.py
@@ -6,7 +6,6 @@ from cupy import testing
 from cupy_tests.core_tests.fusion_tests import fusion_utils
 
 
-@testing.gpu
 @testing.slow
 @pytest.mark.skipif(
     cupy.cuda.runtime.is_hip, reason='HIP does not support this')

--- a/tests/cupy_tests/core_tests/fusion_tests/test_indexing.py
+++ b/tests/cupy_tests/core_tests/fusion_tests/test_indexing.py
@@ -32,7 +32,6 @@ from cupy_tests.core_tests.fusion_tests import fusion_utils
     {'shape': (2, 3, 4), 'indices': (1, Ellipsis)},
     {'shape': (2, 3, 4, 5), 'indices': (1, Ellipsis, 3)},
 )
-@testing.gpu
 class TestIndexing(unittest.TestCase):
 
     def generate_inputs(self, xp, dtype):
@@ -52,7 +51,6 @@ class TestIndexing(unittest.TestCase):
     {'shape': (2, 3, 4), 'indices': 3},
 )
 @testing.with_requires('numpy>=1.12.0')
-@testing.gpu
 class TestArrayInvalidIndex(unittest.TestCase):
 
     def generate_inputs(self, xp, dtype):
@@ -65,7 +63,6 @@ class TestArrayInvalidIndex(unittest.TestCase):
         return lambda x: x[self.indices]
 
 
-@testing.gpu
 class TestIndexingCombination(unittest.TestCase):
 
     def generate_inputs(self, xp, dtype1, dtype2):

--- a/tests/cupy_tests/core_tests/fusion_tests/test_kernel_cache.py
+++ b/tests/cupy_tests/core_tests/fusion_tests/test_kernel_cache.py
@@ -40,7 +40,6 @@ def mock_fusion_history():
     return wrapper
 
 
-@testing.gpu
 class TestFusionCache(unittest.TestCase):
 
     @mock_fusion_history()

--- a/tests/cupy_tests/core_tests/fusion_tests/test_misc.py
+++ b/tests/cupy_tests/core_tests/fusion_tests/test_misc.py
@@ -21,7 +21,6 @@ class FusionTestBase(unittest.TestCase):
         return (x, y), {}
 
 
-@testing.gpu
 class TestFusionInplaceUpdate(FusionTestBase):
 
     @testing.for_all_dtypes(no_bool=True)
@@ -47,7 +46,6 @@ class TestFusionInplaceUpdate(FusionTestBase):
         return func
 
 
-@testing.gpu
 class TestFusionTuple(FusionTestBase):
 
     @testing.for_all_dtypes(no_complex=True)
@@ -135,7 +133,6 @@ class TestReturnNone(FusionTestBase):
         return impl
 
 
-@testing.gpu
 class TestFusionNoneParams(unittest.TestCase):
 
     @testing.for_all_dtypes()
@@ -180,7 +177,6 @@ class TestSpecialValues(FusionTestBase):
         return func
 
 
-@testing.gpu
 class TestFusionDecorator(unittest.TestCase):
     def test_without_paren(self):
         @cupy.fuse
@@ -201,7 +197,6 @@ class TestFusionDecorator(unittest.TestCase):
         assert func_w_paren.__doc__ == 'Fuse with parentheses'
 
 
-@testing.gpu
 class TestFusionKernelName(unittest.TestCase):
 
     def check(self, xp, func, expected_name, is_elementwise):
@@ -331,7 +326,6 @@ class TestFusionCompile(unittest.TestCase):
         return f(x, y)
 
 
-@testing.gpu
 class TestFusionGetArrayModule(FusionTestBase):
 
     @testing.for_all_dtypes()
@@ -405,7 +399,6 @@ class TestFusionThread(unittest.TestCase):
         return xp.concatenate(out)
 
 
-@testing.gpu
 class TestFusionMultiDevice(unittest.TestCase):
 
     @testing.multi_gpu(2)

--- a/tests/cupy_tests/core_tests/fusion_tests/test_optimization.py
+++ b/tests/cupy_tests/core_tests/fusion_tests/test_optimization.py
@@ -54,7 +54,6 @@ def check_number_of_ops(
     return wrapper
 
 
-@testing.gpu
 class TestOptimizations(unittest.TestCase):
 
     def generate_inputs(self, xp):

--- a/tests/cupy_tests/core_tests/fusion_tests/test_reduction.py
+++ b/tests/cupy_tests/core_tests/fusion_tests/test_reduction.py
@@ -7,7 +7,6 @@ from cupy import testing
 from cupy_tests.core_tests.fusion_tests import fusion_utils
 
 
-@testing.gpu
 @testing.parameterize(*testing.product({
     'shape': [(1,), (3, 4), (2, 1, 4), (2, 0, 3)],
     'axis': [-4, -3, -2, -1, 0, 1, 2, 3, 4],
@@ -27,7 +26,6 @@ class TestFusionReductionAxis(unittest.TestCase):
         return lambda x: cupy.sum(x, axis=self.axis)
 
 
-@testing.gpu
 @testing.parameterize(*testing.product({
     'shape': [(1,), (3, 4), (2, 1, 4), (2, 0, 3), (2, 3, 2, 2, 3)],
     'axis': [
@@ -51,7 +49,6 @@ class TestFusionReductionMultiAxis(unittest.TestCase):
         return lambda x: cupy.sum(x, axis=self.axis)
 
 
-@testing.gpu
 @testing.parameterize(*testing.product({
     'shape': [
         (120, 128, 144),
@@ -74,7 +71,6 @@ class TestFusionReductionLarge(unittest.TestCase):
 
 
 # TODO(asi1024): Support for bool and complex dtypes.
-@testing.gpu
 class TestFusionReductionSpecifyDtype(unittest.TestCase):
 
     def generate_inputs(self, xp, dtype1, dtype2):
@@ -88,7 +84,6 @@ class TestFusionReductionSpecifyDtype(unittest.TestCase):
         return lambda x: x.sum(axis=0, dtype=dtype2)
 
 
-@testing.gpu
 @testing.parameterize(*testing.product({
     'axis': [None, 0, 1],
 }))
@@ -146,7 +141,6 @@ class TestFusionReductionAndElementwise(unittest.TestCase):
         return impl
 
 
-@testing.gpu
 @testing.parameterize(*testing.product({
     'axis1': [None, 0, 1],
     'axis2': [None, 0, 1],
@@ -173,7 +167,6 @@ class TestFusionMultipleReductions(unittest.TestCase):
         return lambda x, y: x.sum(self.axis1) + y.sum(self.axis2)
 
 
-@testing.gpu
 class TestFusionMultistageReductions(unittest.TestCase):
 
     def generate_inputs(self, xp):
@@ -195,7 +188,6 @@ class TestFusionMultistageReductions(unittest.TestCase):
         return lambda x: (xp.sqrt(x).prod(axis=0) + x).sum(axis=1) * 2
 
 
-@testing.gpu
 class TestFusionMultistageReductionsMultiAxis(unittest.TestCase):
 
     def generate_inputs(self, xp):
@@ -210,7 +202,6 @@ class TestFusionMultistageReductionsMultiAxis(unittest.TestCase):
         return lambda x: x.prod(axis=(-1, 1)).sum(axis=(0, 1))
 
 
-@testing.gpu
 class TestFusionReductionRoutines(unittest.TestCase):
 
     def generate_inputs(self, xp):
@@ -234,7 +225,6 @@ class TestFusionReductionRoutines(unittest.TestCase):
         return lambda x: xp.nanprod(x)
 
 
-@testing.gpu
 class TestFusionMisc(unittest.TestCase):
 
     def generate_inputs(self, xp):

--- a/tests/cupy_tests/core_tests/fusion_tests/test_routines.py
+++ b/tests/cupy_tests/core_tests/fusion_tests/test_routines.py
@@ -22,7 +22,6 @@ class FusionBinaryUfuncTestBase(unittest.TestCase):
         return (x, y), {}
 
 
-@testing.gpu
 @testing.parameterize(*testing.product({
     'func': [
         'bitwise_and', 'bitwise_or', 'bitwise_xor', 'left_shift', 'right_shift'
@@ -50,7 +49,6 @@ class TestFusionBitwiseUnary(FusionUnaryUfuncTestBase):
         return lambda x: xp.invert(x)
 
 
-@testing.gpu
 @testing.parameterize(*testing.product({
     'func': [
         'greater', 'greater_equal', 'less', 'less_equal', 'equal', 'not_equal',
@@ -67,7 +65,6 @@ class TestFusionComparisonBinary(FusionBinaryUfuncTestBase):
         return lambda x, y: getattr(xp, self.func)(x, y)
 
 
-@testing.gpu
 class TestFusionComparisonUnary(FusionUnaryUfuncTestBase):
 
     @testing.for_all_dtypes(no_complex=True)
@@ -76,7 +73,6 @@ class TestFusionComparisonUnary(FusionUnaryUfuncTestBase):
         return lambda x: xp.logical_not(x)
 
 
-@testing.gpu
 class TestFusionArrayContents(FusionUnaryUfuncTestBase):
 
     def generate_inputs(self, xp, has_nan, dtype):
@@ -109,7 +105,6 @@ class TestFusionArrayContents(FusionUnaryUfuncTestBase):
         return lambda x: xp.isnan(x)
 
 
-@testing.gpu
 @testing.parameterize(*testing.product({
     'func': [
         'sin', 'cos', 'tan', 'arcsin', 'arccos', 'arctan',
@@ -134,7 +129,6 @@ class TestFusionTrigonometricUnary(unittest.TestCase):
         return impl
 
 
-@testing.gpu
 @testing.parameterize(*testing.product({
     'func': ['arctan2', 'hypot']
 }))
@@ -147,7 +141,6 @@ class TestFusionTrigonometricBinary(FusionBinaryUfuncTestBase):
         return lambda x, y: getattr(xp, self.func)(x, y)
 
 
-@testing.gpu
 @testing.parameterize(*testing.product({
     'func': ['deg2rad', 'rad2deg', 'degrees', 'radians']
 }))
@@ -159,7 +152,6 @@ class TestFusionDegRad(FusionUnaryUfuncTestBase):
         return lambda x: getattr(xp, self.func)(x)
 
 
-@testing.gpu
 @testing.parameterize(*testing.product({
     'func': ['around', 'round', 'round_', 'rint', 'floor', 'ceil', 'trunc',
              'fix']
@@ -172,7 +164,6 @@ class TestFusionRounding(FusionUnaryUfuncTestBase):
         return lambda x: getattr(xp, self.func)(x)
 
 
-@testing.gpu
 @testing.parameterize(*testing.product({
     'func': ['exp', 'expm1', 'exp2', 'log', 'log10', 'log2', 'log1p']
 }))
@@ -188,7 +179,6 @@ class TestFusionExpLogUnary(unittest.TestCase):
         return lambda x: getattr(xp, self.func)(x)
 
 
-@testing.gpu
 @testing.parameterize(*testing.product({
     'func': ['logaddexp', 'logaddexp2']
 }))
@@ -201,7 +191,6 @@ class TestFusionExpLogBinary(FusionBinaryUfuncTestBase):
         return lambda x, y: getattr(xp, self.func)(x, y)
 
 
-@testing.gpu
 class TestFusionLdexp(FusionBinaryUfuncTestBase):
 
     @testing.for_float_dtypes(name='dtype1')
@@ -211,7 +200,6 @@ class TestFusionLdexp(FusionBinaryUfuncTestBase):
         return lambda x, y: xp.ldexp(x, y)
 
 
-@testing.gpu
 @testing.parameterize(*testing.product({
     'func': ['signbit', 'frexp']
 }))
@@ -223,7 +211,6 @@ class TestFusionFloatingUnary(FusionUnaryUfuncTestBase):
         return lambda x: getattr(xp, self.func)(x)
 
 
-@testing.gpu
 @testing.parameterize(*testing.product({
     'func': ['copysign', 'nextafter']
 }))
@@ -236,7 +223,6 @@ class TestFusionFloatingBinary(FusionBinaryUfuncTestBase):
         return lambda x, y: getattr(xp, self.func)(x, y)
 
 
-@testing.gpu
 @testing.parameterize(*testing.product({
     'func': ['reciprocal', 'negative', 'angle', 'conj', 'real', 'imag']
 }))
@@ -253,7 +239,6 @@ class TestArithmeticUnary(FusionUnaryUfuncTestBase):
         return lambda x: getattr(xp, self.func)(x)
 
 
-@testing.gpu
 class TestModf(FusionUnaryUfuncTestBase):
 
     def generate_inputs(self, xp, dtype):
@@ -266,7 +251,6 @@ class TestModf(FusionUnaryUfuncTestBase):
         return lambda x: xp.modf(x)
 
 
-@testing.gpu
 @testing.parameterize(*testing.product({
     'func': ['add', 'subtract', 'multiply', 'power']
 }))
@@ -285,7 +269,6 @@ class TestArithmeticBinary(FusionBinaryUfuncTestBase):
         return lambda x, y: getattr(xp, self.func)(x, y)
 
 
-@testing.gpu
 @testing.parameterize(*testing.product({
     'func': ['divide', 'true_divide', 'floor_divide', 'fmod', 'remainder']
 }))
@@ -304,7 +287,6 @@ class TestDivide(unittest.TestCase):
         return lambda x, y: getattr(xp, self.func)(x, y)
 
 
-@testing.gpu
 class TestDivmod(unittest.TestCase):
 
     def generate_inputs(self, xp, dtype1, dtype2):
@@ -321,7 +303,6 @@ class TestDivmod(unittest.TestCase):
         return lambda x, y: xp.divmod(x, y)
 
 
-@testing.gpu
 class TestFusionMisc(FusionUnaryUfuncTestBase):
 
     @testing.with_requires('numpy>=1.11.2')
@@ -362,7 +343,6 @@ class TestFusionMisc(FusionUnaryUfuncTestBase):
         return lambda x: xp.clip(x, dtype(2), dtype(4))
 
 
-@testing.gpu
 @testing.parameterize(*testing.product({
     'func': ['i0', 'sinc']
 }))
@@ -411,7 +391,6 @@ class TestFusionManipulation(unittest.TestCase):
         return lambda cond, x, y: xp.where(x, y, where=cond)
 
 
-@testing.gpu
 @testing.parameterize(*testing.product({
     'func': ['sum', 'prod', 'amax', 'amin', 'max', 'min']
 }))
@@ -423,7 +402,6 @@ class TestFusionNumericalReduction(FusionUnaryUfuncTestBase):
         return lambda x: getattr(xp, self.func)(x)
 
 
-@testing.gpu
 @testing.parameterize(*testing.product({
     'func': ['all', 'any']
 }))

--- a/tests/cupy_tests/core_tests/fusion_tests/test_ufunc.py
+++ b/tests/cupy_tests/core_tests/fusion_tests/test_ufunc.py
@@ -14,7 +14,6 @@ def _permutate_shapes(shapes_list):
     return list(permutated_shapes_set)
 
 
-@testing.gpu
 @testing.parameterize(*testing.product({
     'shapes': _permutate_shapes([
         # Same shapes
@@ -71,7 +70,6 @@ class TestFusionBroadcast(unittest.TestCase):
     #     return impl
 
 
-@testing.gpu
 @testing.parameterize(*testing.product({
     'shapes': _permutate_shapes([
         ((2,), (3,)),
@@ -100,7 +98,6 @@ class TestFusionBroadcastInvalid(unittest.TestCase):
         return impl
 
 
-@testing.gpu
 class TestFusionParseInput(unittest.TestCase):
 
     def generate_inputs(self, xp):
@@ -169,7 +166,6 @@ class TestFusionParseInput(unittest.TestCase):
         return lambda x: xp.divmod(x, x)
 
 
-@testing.gpu
 class TestFusionOutDtype(unittest.TestCase):
 
     def generate_inputs(self, xp, dtype1, dtype2):
@@ -189,7 +185,6 @@ class TestFusionOutDtype(unittest.TestCase):
         return impl
 
 
-@testing.gpu
 class TestFusionScalar(unittest.TestCase):
 
     def generate_inputs(self, xp, dtype1, dtype2):

--- a/tests/cupy_tests/core_tests/test_array_function.py
+++ b/tests/cupy_tests/core_tests/test_array_function.py
@@ -6,7 +6,6 @@ import cupy
 from cupy import testing
 
 
-@testing.gpu
 class TestArrayFunction(unittest.TestCase):
 
     @testing.with_requires('numpy>=1.17.0')

--- a/tests/cupy_tests/core_tests/test_core.py
+++ b/tests/cupy_tests/core_tests/test_core.py
@@ -97,7 +97,6 @@ class TestMinScalarType:
 @testing.parameterize(*testing.product({
     'cxx': (None, '--std=c++11'),
 }))
-@testing.gpu
 class TestCuPyHeaders(unittest.TestCase):
 
     def setUp(self):

--- a/tests/cupy_tests/core_tests/test_cub_reduction.py
+++ b/tests/cupy_tests/core_tests/test_cub_reduction.py
@@ -45,7 +45,6 @@ class CubReductionTestBase(unittest.TestCase):
     'shape': [(2,), (2, 3), (2, 3, 4), (2, 3, 4, 5)],
     'order': ('C', 'F'),
 }))
-@testing.gpu
 class TestSimpleCubReductionKernelContiguity(CubReductionTestBase):
 
     @testing.for_contiguous_axes()
@@ -72,7 +71,6 @@ class TestSimpleCubReductionKernelContiguity(CubReductionTestBase):
                                self.order, False)
 
 
-@testing.gpu
 class TestSimpleCubReductionKernelMisc(CubReductionTestBase):
 
     def test_can_use_cub_nonsense_input1(self):

--- a/tests/cupy_tests/core_tests/test_elementwise.py
+++ b/tests/cupy_tests/core_tests/test_elementwise.py
@@ -9,7 +9,6 @@ from cupy import cuda
 from cupy import testing
 
 
-@testing.gpu
 class TestElementwise(unittest.TestCase):
 
     def check_copy(self, dtype, src_id, dst_id):
@@ -70,7 +69,6 @@ class TestElementwise(unittest.TestCase):
         assert b.strides == b_cpu.strides
 
 
-@testing.gpu
 class TestElementwiseInvalidShape(unittest.TestCase):
 
     def test_invalid_shape(self):
@@ -81,7 +79,6 @@ class TestElementwiseInvalidShape(unittest.TestCase):
             f(x, y)
 
 
-@testing.gpu
 class TestElementwiseInvalidArgument(unittest.TestCase):
 
     def test_invalid_kernel_name(self):
@@ -89,7 +86,6 @@ class TestElementwiseInvalidArgument(unittest.TestCase):
             cupy.ElementwiseKernel('T x', '', '', '1')
 
 
-@testing.gpu
 class TestElementwiseType(unittest.TestCase):
 
     @testing.for_int_dtypes(no_bool=True)

--- a/tests/cupy_tests/core_tests/test_function.py
+++ b/tests/cupy_tests/core_tests/test_function.py
@@ -18,7 +18,6 @@ def _compile_func(kernel_name, code):
     return mod.get_function(kernel_name)
 
 
-@testing.gpu
 class TestFunction(unittest.TestCase):
 
     def test_python_scalar(self):

--- a/tests/cupy_tests/core_tests/test_iter.py
+++ b/tests/cupy_tests/core_tests/test_iter.py
@@ -7,7 +7,6 @@ import cupy
 from cupy import testing
 
 
-@testing.gpu
 @testing.parameterize(*testing.product(
     {'shape': [(3,), (2, 3, 4), (0,), (0, 2), (3, 0)]},
 ))
@@ -26,7 +25,6 @@ class TestIter(unittest.TestCase):
         return len(x)
 
 
-@testing.gpu
 class TestIterInvalid(unittest.TestCase):
 
     @testing.for_all_dtypes()

--- a/tests/cupy_tests/core_tests/test_ndarray.py
+++ b/tests/cupy_tests/core_tests/test_ndarray.py
@@ -22,7 +22,6 @@ def wrap_take(array, *args, **kwargs):
     return array.take(*args, **kwargs)
 
 
-@testing.gpu
 class TestNdarrayInit(unittest.TestCase):
 
     def test_shape_none(self):
@@ -112,7 +111,6 @@ class TestNdarrayInit(unittest.TestCase):
             numpy.uint16,  # itemsize=2
         ],
     }))
-@testing.gpu
 class TestNdarrayInitStrides(unittest.TestCase):
 
     # Check the strides given shape, itemsize and order.
@@ -126,7 +124,6 @@ class TestNdarrayInitStrides(unittest.TestCase):
             arr.flags.f_contiguous)
 
 
-@testing.gpu
 class TestNdarrayInitRaise(unittest.TestCase):
 
     def test_unsupported_type(self):
@@ -146,7 +143,6 @@ class TestNdarrayInitRaise(unittest.TestCase):
         'shape': [(), (0,), (1,), (0, 0, 2), (2, 3)],
     })
 )
-@testing.gpu
 class TestNdarrayDeepCopy(unittest.TestCase):
 
     def _check_deepcopy(self, arr, arr2):
@@ -238,7 +234,6 @@ class TestNdarrayCopy:
                     b, numpy.array([0, 0], dtype=numpy.uint64))
 
 
-@testing.gpu
 class TestNdarrayShape(unittest.TestCase):
 
     @testing.numpy_cupy_array_equal()
@@ -395,7 +390,6 @@ class TestNdarrayCudaInterfaceNoneCUDA(unittest.TestCase):
         'axis': [None, 0, 1, 2, -1, -2],
     })
 )
-@testing.gpu
 class TestNdarrayTake(unittest.TestCase):
 
     shape = (3, 4, 5)
@@ -418,7 +412,6 @@ class TestNdarrayTake(unittest.TestCase):
         'axis': [None, 0, 1, -1, -2],
     })
 )
-@testing.gpu
 class TestNdarrayTakeWithInt(unittest.TestCase):
 
     shape = (3, 4, 5)
@@ -436,7 +429,6 @@ class TestNdarrayTakeWithInt(unittest.TestCase):
         'axis': [None, 0, 1, -1, -2],
     })
 )
-@testing.gpu
 class TestNdarrayTakeWithIntWithOutParam(unittest.TestCase):
 
     shape = (3, 4, 5)
@@ -458,7 +450,6 @@ class TestNdarrayTakeWithIntWithOutParam(unittest.TestCase):
         'axis': [None, 0, -1],
     })
 )
-@testing.gpu
 class TestScalaNdarrayTakeWithIntWithOutParam(unittest.TestCase):
 
     shape = ()
@@ -478,7 +469,6 @@ class TestScalaNdarrayTakeWithIntWithOutParam(unittest.TestCase):
     {'shape': (3, 4, 5), 'indices': (2,), 'axis': 3},
     {'shape': (), 'indices': (0,), 'axis': 2}
 )
-@testing.gpu
 class TestNdarrayTakeErrorAxisOverRun(unittest.TestCase):
 
     def test_axis_overrun1(self):
@@ -497,7 +487,6 @@ class TestNdarrayTakeErrorAxisOverRun(unittest.TestCase):
     {'shape': (3, 4, 5), 'indices': (2, 3), 'out_shape': (2, 4)},
     {'shape': (), 'indices': (), 'out_shape': (1,)}
 )
-@testing.gpu
 class TestNdarrayTakeErrorShapeMismatch(unittest.TestCase):
 
     def test_shape_mismatch(self):
@@ -513,7 +502,6 @@ class TestNdarrayTakeErrorShapeMismatch(unittest.TestCase):
     {'shape': (3, 4, 5), 'indices': (2, 3), 'out_shape': (2, 3)},
     {'shape': (), 'indices': (), 'out_shape': ()}
 )
-@testing.gpu
 class TestNdarrayTakeErrorTypeMismatch(unittest.TestCase):
 
     def test_output_type_mismatch(self):
@@ -530,7 +518,6 @@ class TestNdarrayTakeErrorTypeMismatch(unittest.TestCase):
     {'shape': (0,), 'indices': (0, 1), 'axis': None},
     {'shape': (3, 0), 'indices': (2,), 'axis': 0},
 )
-@testing.gpu
 class TestZeroSizedNdarrayTake(unittest.TestCase):
 
     @testing.numpy_cupy_array_equal()
@@ -544,7 +531,6 @@ class TestZeroSizedNdarrayTake(unittest.TestCase):
     {'shape': (0,), 'indices': (1,)},
     {'shape': (0,), 'indices': (1, 1)},
 )
-@testing.gpu
 class TestZeroSizedNdarrayTakeIndexError(unittest.TestCase):
 
     def test_output_type_mismatch(self):
@@ -555,7 +541,6 @@ class TestZeroSizedNdarrayTakeIndexError(unittest.TestCase):
                 wrap_take(a, i)
 
 
-@testing.gpu
 class TestSize(unittest.TestCase):
 
     @testing.numpy_cupy_equal()
@@ -597,7 +582,6 @@ class TestSize(unittest.TestCase):
                 xp.size(x, 0)
 
 
-@testing.gpu
 class TestPythonInterface(unittest.TestCase):
 
     @testing.for_all_dtypes()
@@ -634,7 +618,6 @@ class TestPythonInterface(unittest.TestCase):
         return format(x, '.2f')
 
 
-@testing.gpu
 class TestNdarrayImplicitConversion(unittest.TestCase):
 
     def test_array(self):

--- a/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
@@ -33,7 +33,6 @@ def perm(iterable):
         )
     })
 )
-@testing.gpu
 class TestArrayAdvancedIndexingGetitemPerm:
 
     @testing.for_all_dtypes()
@@ -129,7 +128,6 @@ class TestArrayAdvancedIndexingGetitemPerm:
      'indexes': (slice(None), [1, 0], Ellipsis, numpy.ones((5, 2), int))},
     _ids=False,  # Do not generate ids from randomly generated params
 )
-@testing.gpu
 class TestArrayAdvancedIndexingGetitemParametrized:
 
     @testing.for_all_dtypes()
@@ -184,7 +182,6 @@ class TestArrayAdvancedIndexingGetitemParametrizedValueError:
     {'shape': (2, 3, 4), 'transpose': (1, 0, 2),
      'indexes': (None, [1, 2], [0, -1])},
 )
-@testing.gpu
 class TestArrayAdvancedIndexingGetitemParametrizedTransp:
 
     @testing.for_all_dtypes()
@@ -196,7 +193,6 @@ class TestArrayAdvancedIndexingGetitemParametrizedTransp:
         return a[self.indexes]
 
 
-@testing.gpu
 class TestArrayAdvancedIndexingGetitemCupyIndices:
 
     shape = (2, 3, 4)
@@ -272,7 +268,6 @@ class TestArrayAdvancedIndexingGetitemCupyIndices:
         slice(None),
         numpy.array([1], dtype=numpy.int8))},
 )
-@testing.gpu
 class TestArrayAdvancedIndexingOverflow:
 
     def test_getitem(self):
@@ -331,7 +326,6 @@ class TestArrayAdvancedIndexingOverflow:
     {'shape': (2, 3, 4),
      'indexes': (numpy.empty(0, bool), numpy.empty((0, 2), bool))},
 )
-@testing.gpu
 class TestArrayInvalidIndexAdvGetitem:
 
     def test_invalid_adv_getitem(self):
@@ -349,7 +343,6 @@ class TestArrayInvalidIndexAdvGetitem:
      'indexes': numpy.random.choice([False, True], (1, 3))},
     _ids=False,  # Do not generate ids from randomly generated params
 )
-@testing.gpu
 class TestArrayInvalidIndexAdvGetitem2:
 
     def test_invalid_adv_getitem(self):
@@ -559,7 +552,6 @@ class TestArrayAdvancedIndexingSetitemScalarValue2:
     {'shape': (0,), 'indexes': numpy.array([True]), 'value': 1},
     {'shape': (0,), 'indexes': numpy.array([False, True, True]), 'value': 1},
 )
-@testing.gpu
 class TestArrayAdvancedIndexingSetitemScalarValueIndexError:
 
     def test_adv_setitem(self):
@@ -632,7 +624,6 @@ class TestArrayAdvancedIndexingSetitemScalarValueValueError2:
      'value': numpy.arange(3 * 4).reshape(3, 4)},
     _ids=False,  # Do not generate ids from randomly generated params
 )
-@testing.gpu
 class TestArrayAdvancedIndexingVectorValue:
 
     @testing.for_all_dtypes()
@@ -643,7 +634,6 @@ class TestArrayAdvancedIndexingVectorValue:
         return a
 
 
-@testing.gpu
 class TestArrayAdvancedIndexingSetitemCupyIndices:
 
     shape = (2, 3)
@@ -685,7 +675,6 @@ class TestArrayAdvancedIndexingSetitemCupyIndices:
         testing.assert_array_almost_equal(original_index, index)
 
 
-@testing.gpu
 class TestArrayAdvancedIndexingSetitemDifferentDtypes:
 
     @testing.for_all_dtypes_combination(names=['src_dtype', 'dst_dtype'],
@@ -709,7 +698,6 @@ class TestArrayAdvancedIndexingSetitemDifferentDtypes:
         return a
 
 
-@testing.gpu
 class TestArrayAdvancedIndexingSetitemTranspose:
 
     @testing.numpy_cupy_array_equal()

--- a/tests/cupy_tests/core_tests/test_ndarray_complex_ops.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_complex_ops.py
@@ -7,7 +7,6 @@ import cupy
 from cupy import testing
 
 
-@testing.gpu
 class TestConj(unittest.TestCase):
 
     @testing.for_all_dtypes()
@@ -39,7 +38,6 @@ class TestConj(unittest.TestCase):
         return y
 
 
-@testing.gpu
 class TestAngle(unittest.TestCase):
 
     @testing.for_all_dtypes()
@@ -49,7 +47,6 @@ class TestAngle(unittest.TestCase):
         return xp.angle(x)
 
 
-@testing.gpu
 class TestRealImag(unittest.TestCase):
 
     @testing.for_all_dtypes()
@@ -157,7 +154,6 @@ class TestRealImag(unittest.TestCase):
         assert cupy.all(x == expected)
 
 
-@testing.gpu
 class TestScalarConversion(unittest.TestCase):
 
     @testing.for_all_dtypes()

--- a/tests/cupy_tests/core_tests/test_ndarray_contiguity.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_contiguity.py
@@ -3,7 +3,6 @@ import unittest
 from cupy import testing
 
 
-@testing.gpu
 class TestArrayContiguity(unittest.TestCase):
 
     def test_is_contiguous(self):

--- a/tests/cupy_tests/core_tests/test_ndarray_copy_and_view.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_copy_and_view.py
@@ -379,7 +379,6 @@ class TestArrayDiagonal:
     {'src_order': 'C'},
     {'src_order': 'F'},
 )
-@testing.gpu
 class TestNumPyArrayCopyView:
     @pytest.mark.skipif(
         not _util.ENABLE_SLICE_COPY, reason='Special copy disabled')

--- a/tests/cupy_tests/core_tests/test_ndarray_cuda_array_interface.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_cuda_array_interface.py
@@ -36,7 +36,6 @@ class DummyObjectWithCudaArrayInterface(object):
     'stream': ('null', 'new'),
     'ver': (2, 3),
 }))
-@testing.gpu
 @pytest.mark.skipif(cupy.cuda.runtime.is_hip,
                     reason='HIP does not support this')
 class TestArrayUfunc(unittest.TestCase):
@@ -73,7 +72,6 @@ class TestArrayUfunc(unittest.TestCase):
     'stream': ('null', 'new'),
     'ver': (2, 3),
 }))
-@testing.gpu
 @pytest.mark.skipif(cupy.cuda.runtime.is_hip,
                     reason='HIP does not support this')
 class TestElementwiseKernel(unittest.TestCase):
@@ -111,7 +109,6 @@ class TestElementwiseKernel(unittest.TestCase):
     'stream': ('null', 'new'),
     'ver': (2, 3),
 }))
-@testing.gpu
 @pytest.mark.skipif(cupy.cuda.runtime.is_hip,
                     reason='HIP does not support this')
 class TestSimpleReductionFunction(unittest.TestCase):
@@ -151,7 +148,6 @@ class TestSimpleReductionFunction(unittest.TestCase):
     'stream': ('null', 'new'),
     'ver': (2, 3),
 }))
-@testing.gpu
 @pytest.mark.skipif(cupy.cuda.runtime.is_hip,
                     reason='HIP does not support this')
 class TestReductionKernel(unittest.TestCase):
@@ -196,7 +192,6 @@ class TestReductionKernel(unittest.TestCase):
     {'shape': (10, 10), 'slices': (slice(2, None), slice(2, None))},
     {'shape': (10, 10), 'slices': (slice(2, None), slice(4, None))},
 )
-@testing.gpu
 @pytest.mark.skipif(cupy.cuda.runtime.is_hip,
                     reason='HIP does not support this')
 class TestSlicingMemoryPointer(unittest.TestCase):
@@ -242,7 +237,6 @@ test_cases_with_stream = [
 
 
 @testing.parameterize(*test_cases_with_stream)
-@testing.gpu
 @pytest.mark.skipif(cupy.cuda.runtime.is_hip,
                     reason='HIP does not support this')
 class TestCUDAArrayInterfaceCompliance(unittest.TestCase):
@@ -290,7 +284,6 @@ class TestCUDAArrayInterfaceCompliance(unittest.TestCase):
 @testing.parameterize(*testing.product({
     'stream': ('null', 'new', 'ptds'),
 }))
-@testing.gpu
 @pytest.mark.skipif(cupy.cuda.runtime.is_hip,
                     reason='HIP does not support this')
 class TestCUDAArrayInterfaceStream(unittest.TestCase):

--- a/tests/cupy_tests/core_tests/test_ndarray_get.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_get.py
@@ -7,7 +7,6 @@ import numpy
 from numpy import testing as np_testing
 
 
-@testing.gpu
 class TestArrayGet(unittest.TestCase):
 
     def setUp(self):
@@ -66,7 +65,6 @@ class TestArrayGet(unittest.TestCase):
         np_testing.assert_array_equal(dst, expected)
 
 
-@testing.gpu
 class TestArrayGetWithOut(unittest.TestCase):
 
     def setUp(self):

--- a/tests/cupy_tests/core_tests/test_ndarray_indexing.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_indexing.py
@@ -75,7 +75,6 @@ from cupy import testing
     {'shape': (2, 0), 'transpose': None,
      'indexes': (1, slice(None, None, None))},
 )
-@testing.gpu
 class TestArrayIndexingParameterized(unittest.TestCase):
 
     _getitem_hip_skip_condition = [
@@ -119,7 +118,6 @@ class TestArrayIndexingParameterized(unittest.TestCase):
     {'shape': (2, 3, 4), 'transpose': None,
      'indexes': (Ellipsis, Ellipsis, 1)},
 )
-@testing.gpu
 class TestArrayIndexIndexError(unittest.TestCase):
 
     @testing.for_all_dtypes()
@@ -141,7 +139,6 @@ class TestArrayIndexIndexError(unittest.TestCase):
     {'error_class': TypeError,
      'indexes': (slice(None, None, (0, 0)), )},
 )
-@testing.gpu
 class TestArrayIndexOtherError(unittest.TestCase):
 
     @testing.for_all_dtypes()
@@ -152,7 +149,6 @@ class TestArrayIndexOtherError(unittest.TestCase):
                 a[self.indexes]
 
 
-@testing.gpu
 class TestArrayIndex(unittest.TestCase):
 
     @testing.for_all_dtypes()

--- a/tests/cupy_tests/core_tests/test_ndarray_owndata.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_owndata.py
@@ -4,7 +4,6 @@ from cupy import _core
 from cupy import testing
 
 
-@testing.gpu
 class TestArrayOwndata(unittest.TestCase):
 
     def setUp(self):

--- a/tests/cupy_tests/core_tests/test_ndarray_owndata.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_owndata.py
@@ -1,7 +1,6 @@
 import unittest
 
 from cupy import _core
-from cupy import testing
 
 
 class TestArrayOwndata(unittest.TestCase):

--- a/tests/cupy_tests/core_tests/test_ndarray_reduction.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_reduction.py
@@ -12,7 +12,6 @@ from cupy import testing
 @testing.parameterize(*testing.product({
     'order': ('C', 'F'),
 }))
-@testing.gpu
 class TestArrayReduction(unittest.TestCase):
 
     @testing.for_all_dtypes()

--- a/tests/cupy_tests/core_tests/test_ndarray_scatter.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_scatter.py
@@ -109,7 +109,6 @@ from cupy import testing
     {'shape': (2, 3, 4), 'slices': ([[1]], slice(1, 2)), 'value': 1},
     _ids=False,  # Do not generate ids from randomly generated params
 )
-@testing.gpu
 class TestScatterParametrized:
 
     @testing.for_dtypes([numpy.float32, numpy.int32, numpy.uint32,
@@ -140,7 +139,6 @@ class TestScatterParametrized:
         return a
 
 
-@testing.gpu
 class TestScatterAdd:
 
     @testing.for_dtypes([numpy.float32, numpy.int32, numpy.uint32,

--- a/tests/cupy_tests/core_tests/test_ndarray_ufunc.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_ufunc.py
@@ -18,7 +18,6 @@ class C(cupy.ndarray):
         self.info = getattr(obj, 'info', None)
 
 
-@testing.gpu
 class TestArrayUfunc:
 
     @testing.for_all_dtypes()

--- a/tests/cupy_tests/core_tests/test_reduction.py
+++ b/tests/cupy_tests/core_tests/test_reduction.py
@@ -48,7 +48,6 @@ class SimpleReductionFunctionTestBase(AbstractReductionTestBase):
             'my_sum', ('b->b',), ('in0', 'a + b', 'out0 = a', None), 0)
 
 
-@testing.gpu
 class TestSimpleReductionFunction(
         unittest.TestCase, SimpleReductionFunctionTestBase):
     def test_shape1(self):
@@ -83,7 +82,6 @@ class TestSimpleReductionFunction(
         self.check_int8_sum((size, 1), axis=0)
 
 
-@testing.gpu
 @testing.parameterize(*_noncontiguous_params)
 class TestSimpleReductionFunctionNonContiguous(
         SimpleReductionFunctionTestBase, unittest.TestCase):
@@ -95,7 +93,6 @@ class TestSimpleReductionFunctionNonContiguous(
 @testing.parameterize(*testing.product({
     'backend': ([], ['cub']),
 }))
-@testing.gpu
 class TestSimpleReductionFunctionComplexWarning(unittest.TestCase):
 
     def setUp(self):
@@ -144,7 +141,6 @@ class ReductionKernelTestBase(AbstractReductionTestBase):
             'T x', 'T out', 'x', 'a + b', 'out = a', '0', 'my_sum')
 
 
-@testing.gpu
 class TestReductionKernel(ReductionKernelTestBase, unittest.TestCase):
 
     def test_shape1(self):
@@ -172,7 +168,6 @@ class TestReductionKernel(ReductionKernelTestBase, unittest.TestCase):
         self.check_int8_sum((512 + 1, 256 * 256 + 1), axis=1)
 
 
-@testing.gpu
 @testing.parameterize(*_noncontiguous_params)
 class TestReductionKernelNonContiguous(
         ReductionKernelTestBase, unittest.TestCase):
@@ -181,7 +176,6 @@ class TestReductionKernelNonContiguous(
         self.check_int8_sum(self.shape, trans=self.trans, axis=self.axis)
 
 
-@testing.gpu
 class TestReductionKernelInvalidArgument(unittest.TestCase):
 
     def test_invalid_kernel_name(self):
@@ -190,7 +184,6 @@ class TestReductionKernelInvalidArgument(unittest.TestCase):
                 'T x', 'T y', 'x', 'a + b', 'y = a', '0', name='1')
 
 
-@testing.gpu
 class TestReductionKernelCachedCode:
 
     @pytest.fixture(autouse=True)
@@ -229,7 +222,6 @@ class TestReductionKernelCachedCode:
         assert len(kernel._cached_codes) == 2
 
 
-@testing.gpu
 class TestLargeMultiDimReduction(
         ReductionKernelTestBase, unittest.TestCase):
 

--- a/tests/cupy_tests/core_tests/test_scan.py
+++ b/tests/cupy_tests/core_tests/test_scan.py
@@ -8,7 +8,6 @@ from cupy._core._routines_math import _scan_for_test as scan
 from cupy import testing
 
 
-@testing.gpu
 class TestScan(unittest.TestCase):
 
     @testing.for_all_dtypes()

--- a/tests/cupy_tests/core_tests/test_userkernel.py
+++ b/tests/cupy_tests/core_tests/test_userkernel.py
@@ -264,7 +264,6 @@ class TestUserkernelManualBlockSize(unittest.TestCase):
 @testing.parameterize(*testing.product({
     'dimensions': ((64, 0, 0), (64, 32, 0), (64, 32, 19)),
 }))
-@testing.gpu
 @pytest.mark.skipif(runtime.is_hip,
                     reason='texture support on HIP is not yet implemented')
 class TestElementwiseKernelTexture(unittest.TestCase):

--- a/tests/cupy_tests/creation_tests/test_matrix.py
+++ b/tests/cupy_tests/creation_tests/test_matrix.py
@@ -7,7 +7,6 @@ import cupy
 from cupy import testing
 
 
-@testing.gpu
 class TestMatrix(unittest.TestCase):
 
     @testing.numpy_cupy_array_equal()
@@ -108,7 +107,6 @@ class TestMatrix(unittest.TestCase):
     {'shape': (3, 3)},
     {'shape': (4, 3)},
 )
-@testing.gpu
 class TestTri(unittest.TestCase):
 
     @testing.for_all_dtypes()
@@ -133,7 +131,6 @@ class TestTri(unittest.TestCase):
     {'shape': (4, 3)},
     {'shape': (2, 3, 4)},
 )
-@testing.gpu
 class TestTriLowerAndUpper(unittest.TestCase):
 
     @testing.for_all_dtypes(no_complex=True)
@@ -187,7 +184,6 @@ class TestTriLowerAndUpper(unittest.TestCase):
         'increasing': [False, True]
     })
 )
-@testing.gpu
 class TestVander(unittest.TestCase):
 
     @testing.for_all_dtypes(no_bool=True)

--- a/tests/cupy_tests/creation_tests/test_ranges.py
+++ b/tests/cupy_tests/creation_tests/test_ranges.py
@@ -30,7 +30,6 @@ def skip_int_equality_before_numpy_1_20(names=('dtype',)):
     return decorator
 
 
-@testing.gpu
 class TestRanges(unittest.TestCase):
 
     @testing.for_all_dtypes(no_bool=True)
@@ -302,7 +301,6 @@ class TestRanges(unittest.TestCase):
         'copy': [False, True],
     })
 )
-@testing.gpu
 class TestMeshgrid(unittest.TestCase):
 
     @testing.for_all_dtypes()
@@ -336,7 +334,6 @@ class TestMeshgrid(unittest.TestCase):
                            copy=self.copy)
 
 
-@testing.gpu
 class TestMgrid(unittest.TestCase):
 
     @testing.numpy_cupy_array_equal()
@@ -370,7 +367,6 @@ class TestMgrid(unittest.TestCase):
         return xp.mgrid[x:y:10j, x:y:10j]
 
 
-@testing.gpu
 class TestOgrid(unittest.TestCase):
 
     @testing.numpy_cupy_array_equal()

--- a/tests/cupy_tests/cuda_tests/memory_hooks_tests/test_debug_print.py
+++ b/tests/cupy_tests/cuda_tests/memory_hooks_tests/test_debug_print.py
@@ -5,7 +5,6 @@ import unittest
 import cupy.cuda
 from cupy.cuda import memory
 from cupy.cuda import memory_hooks
-from cupy import testing
 
 
 class TestDebugPrintHook(unittest.TestCase):

--- a/tests/cupy_tests/cuda_tests/memory_hooks_tests/test_debug_print.py
+++ b/tests/cupy_tests/cuda_tests/memory_hooks_tests/test_debug_print.py
@@ -8,7 +8,6 @@ from cupy.cuda import memory_hooks
 from cupy import testing
 
 
-@testing.gpu
 class TestDebugPrintHook(unittest.TestCase):
 
     def setUp(self):

--- a/tests/cupy_tests/cuda_tests/memory_hooks_tests/test_line_profile.py
+++ b/tests/cupy_tests/cuda_tests/memory_hooks_tests/test_line_profile.py
@@ -4,7 +4,6 @@ import re
 
 from cupy.cuda import memory
 from cupy.cuda import memory_hooks
-from cupy import testing
 
 
 class TestLineProfileHook(unittest.TestCase):

--- a/tests/cupy_tests/cuda_tests/memory_hooks_tests/test_line_profile.py
+++ b/tests/cupy_tests/cuda_tests/memory_hooks_tests/test_line_profile.py
@@ -7,7 +7,6 @@ from cupy.cuda import memory_hooks
 from cupy import testing
 
 
-@testing.gpu
 class TestLineProfileHook(unittest.TestCase):
 
     def setUp(self):

--- a/tests/cupy_tests/cuda_tests/test_compiler.py
+++ b/tests/cupy_tests/cuda_tests/test_compiler.py
@@ -81,7 +81,6 @@ class TestNvrtcArch(unittest.TestCase):
             compiler.CompileException, self._compile, '83')
 
 
-@testing.gpu
 class TestNvrtcStderr(unittest.TestCase):
 
     @unittest.skipIf(cupy.cuda.runtime.is_hip,

--- a/tests/cupy_tests/cuda_tests/test_compiler.py
+++ b/tests/cupy_tests/cuda_tests/test_compiler.py
@@ -6,7 +6,6 @@ import pytest
 
 import cupy
 from cupy.cuda import compiler
-from cupy import testing
 
 
 def cuda_version():

--- a/tests/cupy_tests/cuda_tests/test_device.py
+++ b/tests/cupy_tests/cuda_tests/test_device.py
@@ -77,7 +77,6 @@ class TestDeviceComparison(unittest.TestCase):
         self.check_comparison_other_type(cuda.Device(1), object())
 
 
-@testing.gpu
 class TestDeviceAttributes(unittest.TestCase):
 
     def test_device_attributes(self):
@@ -94,7 +93,6 @@ class TestDeviceAttributes(unittest.TestCase):
             cuda.device.Device(cuda.runtime.getDeviceCount()).attributes
 
 
-@testing.gpu
 class TestDevicePCIBusId(unittest.TestCase):
     def test_device_get_pci_bus_id(self):
         d = cuda.Device()
@@ -120,7 +118,6 @@ class TestDevicePCIBusId(unittest.TestCase):
             assert excinfo == 'cudaErrorInvalidDevice: invalid device ordinal'
 
 
-@testing.gpu
 class TestDeviceHandles(unittest.TestCase):
     def _check_handle(self, func):
         handles = [func(), None, None]

--- a/tests/cupy_tests/cuda_tests/test_memory.py
+++ b/tests/cupy_tests/cuda_tests/test_memory.py
@@ -44,7 +44,6 @@ class TestUnownedMemoryClass(unittest.TestCase):
     'allocator': [memory._malloc, memory.malloc_managed, memory.malloc_async],
     'specify_device_id': [True, False],
 }))
-@testing.gpu
 class TestUnownedMemory(unittest.TestCase):
 
     def check(self, device_id):
@@ -115,7 +114,6 @@ class TestUnownedMemory(unittest.TestCase):
         self.check(1)
 
 
-@testing.gpu
 class TestMemoryPointer(unittest.TestCase):
 
     def test_int(self):
@@ -211,7 +209,6 @@ class TestMemoryPointer(unittest.TestCase):
 @testing.parameterize(*testing.product({
     'use_streams': [True, False],
 }))
-@testing.gpu
 class TestMemoryPointerAsync(unittest.TestCase):
 
     def setUp(self):
@@ -287,7 +284,6 @@ class TestMemoryPointerAsync(unittest.TestCase):
 # -----------------------------------------------------------------------------
 # Memory pool
 
-@testing.gpu
 class TestSingleDeviceMemoryPool(unittest.TestCase):
 
     def setUp(self):
@@ -675,7 +671,6 @@ class TestParseMempoolLimitEnvVar(unittest.TestCase):
 @testing.parameterize(*testing.product({
     'allocator': [memory._malloc, memory.malloc_managed],
 }))
-@testing.gpu
 class TestMemoryPool(unittest.TestCase):
 
     def setUp(self):
@@ -762,7 +757,6 @@ class TestMemoryPool(unittest.TestCase):
 @testing.parameterize(*testing.product({
     'mempool': ('MemoryPool',),
 }))
-@testing.gpu
 class TestAllocator(unittest.TestCase):
 
     def setUp(self):
@@ -911,7 +905,6 @@ class TestAllocator(unittest.TestCase):
         assert main_ptr != sub_ptr
 
 
-@testing.gpu
 class TestAllocatorDisabled(unittest.TestCase):
 
     def setUp(self):
@@ -950,7 +943,6 @@ class PythonAllocator(object):
         cupy.cuda.runtime.free(size)
 
 
-@testing.gpu
 class TestPythonFunctionAllocator(unittest.TestCase):
     def setUp(self):
         self.old_pool = cupy.get_default_memory_pool()
@@ -968,7 +960,6 @@ class TestPythonFunctionAllocator(unittest.TestCase):
         assert self.alloc.malloc_called and self.alloc.free_called
 
 
-@testing.gpu
 class TestMemInfo(unittest.TestCase):
 
     def test_mem_info(self):
@@ -980,7 +971,6 @@ class TestMemInfo(unittest.TestCase):
         assert all(m > 0 for m in mem_info)
 
 
-@testing.gpu
 class TestLockAndNoGc(unittest.TestCase):
 
     def test(self):
@@ -1006,7 +996,6 @@ class TestExceptionPicklable(unittest.TestCase):
         assert str(e1) == str(e2)
 
 
-@testing.gpu
 @pytest.mark.skipif(cupy.cuda.runtime.is_hip,
                     reason='HIP does not support async allocator')
 @pytest.mark.skipif(cupy.cuda.driver._is_cuda_python()
@@ -1085,7 +1074,6 @@ used_bytes_watermark = 0
 free_bytes_watermark = 0
 
 
-@testing.gpu
 @pytest.mark.skipif(cupy.cuda.runtime.is_hip,
                     reason='HIP does not support async allocator')
 @pytest.mark.skipif(cupy.cuda.driver._is_cuda_python()

--- a/tests/cupy_tests/cuda_tests/test_memory_hook.py
+++ b/tests/cupy_tests/cuda_tests/test_memory_hook.py
@@ -36,7 +36,6 @@ class SimpleMemoryHook(memory_hook.MemoryHook):
         self.free_postprocess_history.append(kwargs)
 
 
-@testing.gpu
 class TestMemoryHook(unittest.TestCase):
 
     def setUp(self):

--- a/tests/cupy_tests/cuda_tests/test_memory_hook.py
+++ b/tests/cupy_tests/cuda_tests/test_memory_hook.py
@@ -3,7 +3,6 @@ import unittest
 import cupy.cuda
 from cupy.cuda import memory
 from cupy.cuda import memory_hook
-from cupy import testing
 
 
 class SimpleMemoryHook(memory_hook.MemoryHook):

--- a/tests/cupy_tests/cuda_tests/test_nccl.py
+++ b/tests/cupy_tests/cuda_tests/test_nccl.py
@@ -18,21 +18,18 @@ else:
 @unittest.skipUnless(nccl_available, 'nccl is not installed')
 class TestNCCL(unittest.TestCase):
 
-    @testing.gpu
     def test_single_proc_ring(self):
         id = nccl.get_unique_id()
         comm = nccl.NcclCommunicator(1, id, 0)
         assert 0 == comm.rank_id()
         comm.destroy()
 
-    @testing.gpu
     @unittest.skipUnless(nccl_version >= 2400, 'Using old NCCL')
     def test_abort(self):
         id = nccl.get_unique_id()
         comm = nccl.NcclCommunicator(1, id, 0)
         comm.abort()
 
-    @testing.gpu
     @unittest.skipUnless(nccl_version >= 2400, 'Using old NCCL')
     def test_check_async_error(self):
         id = nccl.get_unique_id()
@@ -40,7 +37,6 @@ class TestNCCL(unittest.TestCase):
         comm.check_async_error()
         comm.destroy()
 
-    @testing.gpu
     def test_init_all(self):
         comms = nccl.NcclCommunicator.initAll(1)
         for i, comm in enumerate(comms):
@@ -48,7 +44,6 @@ class TestNCCL(unittest.TestCase):
         for i, comm in enumerate(comms):
             comms[i].destroy()
 
-    @testing.gpu
     def test_single_proc_single_dev(self):
         comms = nccl.NcclCommunicator.initAll(1)
         nccl.groupStart()
@@ -62,7 +57,6 @@ class TestNCCL(unittest.TestCase):
         nccl.groupEnd()
         assert cupy.allclose(sendbuf, recvbuf)
 
-    @testing.gpu
     def test_comm_size(self):
         id = nccl.get_unique_id()
         comm = nccl.NcclCommunicator(1, id, 0)

--- a/tests/cupy_tests/cuda_tests/test_nvtx.py
+++ b/tests/cupy_tests/cuda_tests/test_nvtx.py
@@ -1,26 +1,21 @@
 import unittest
 
 from cupy import cuda
-from cupy.testing import _attr
 
 
 @unittest.skipUnless(cuda.nvtx.available, 'nvtx is not installed')
 class TestNVTX(unittest.TestCase):
 
-    @_attr.gpu
     def test_Mark(self):
         cuda.nvtx.Mark('test:Mark', 0)
 
-    @_attr.gpu
     def test_MarkC(self):
         cuda.nvtx.MarkC('test:MarkC', 0xFF000000)
 
-    @_attr.gpu
     def test_RangePush(self):
         cuda.nvtx.RangePush('test:RangePush', 1)
         cuda.nvtx.RangePop()
 
-    @_attr.gpu
     def test_RangePushC(self):
         cuda.nvtx.RangePushC('test:RangePushC', 0xFF000000)
         cuda.nvtx.RangePop()

--- a/tests/cupy_tests/cuda_tests/test_pinned_memory.py
+++ b/tests/cupy_tests/cuda_tests/test_pinned_memory.py
@@ -25,7 +25,6 @@ def mock_alloc(size):
 # -----------------------------------------------------------------------------
 # Memory pointer
 
-@testing.gpu
 class TestMemoryPointer(unittest.TestCase):
 
     def test_int(self):
@@ -66,7 +65,6 @@ class TestMemoryPointer(unittest.TestCase):
 # Memory pool
 
 
-@testing.gpu
 class TestSingleDeviceMemoryPool(unittest.TestCase):
 
     def setUp(self):

--- a/tests/cupy_tests/cuda_tests/test_pinned_memory.py
+++ b/tests/cupy_tests/cuda_tests/test_pinned_memory.py
@@ -1,7 +1,6 @@
 import unittest
 
 from cupy.cuda import pinned_memory
-from cupy import testing
 
 
 class MockMemory(pinned_memory.PinnedMemory):

--- a/tests/cupy_tests/cuda_tests/test_stream.py
+++ b/tests/cupy_tests/cuda_tests/test_stream.py
@@ -14,7 +14,6 @@ from cupy import testing
     *testing.product({
         'stream_name': ['null', 'ptds'],
     }))
-@testing.gpu
 class TestStream(unittest.TestCase):
 
     def setUp(self):
@@ -244,7 +243,6 @@ class TestStream(unittest.TestCase):
             assert err is False
 
 
-@testing.gpu
 class TestExternalStream(unittest.TestCase):
 
     def setUp(self):

--- a/tests/cupy_tests/fft_tests/test_callback.py
+++ b/tests/cupy_tests/fft_tests/test_callback.py
@@ -104,7 +104,6 @@ def _set_store_cb(code, element, data_type, callback_type, aux_type=None):
     'norm': [None, 'ortho'],
 }))
 @testing.with_requires('cython>=0.29.0')
-@testing.gpu
 @pytest.mark.skipif(not sys.platform.startswith('linux'),
                     reason='callbacks are only supported on Linux')
 @pytest.mark.skipif(cupy.cuda.runtime.is_hip,
@@ -423,7 +422,6 @@ class Test1dCallbacks:
     {'shape': (2, 3, 4), 's': (2, 3), 'axes': (0, 1, 2), 'norm': 'ortho'},
 )
 @testing.with_requires('cython>=0.29.0')
-@testing.gpu
 @pytest.mark.skipif(not sys.platform.startswith('linux'),
                     reason='callbacks are only supported on Linux')
 @pytest.mark.skipif(cupy.cuda.runtime.is_hip,

--- a/tests/cupy_tests/fft_tests/test_fft.py
+++ b/tests/cupy_tests/fft_tests/test_fft.py
@@ -99,7 +99,6 @@ def multi_gpu_config(gpu_configs=None):
     'shape': [(0,), (10, 0), (10,), (10, 10)],
     'norm': [None, 'backward', 'ortho', 'forward', ''],
 }))
-@testing.gpu
 class TestFft:
 
     @testing.for_all_dtypes()
@@ -136,7 +135,6 @@ class TestFft:
     'data_order': ['F', 'C'],
     'axis': [0, 1, -1],
 }))
-@testing.gpu
 class TestFftOrder:
 
     @testing.for_all_dtypes()
@@ -279,7 +277,6 @@ class TestMultiGpuFftOrder:
         return out
 
 
-@testing.gpu
 class TestDefaultPlanType:
 
     @nd_planning_states()
@@ -349,7 +346,6 @@ class TestDefaultPlanType:
 
 @pytest.mark.skipif(10010 <= cupy.cuda.runtime.runtimeGetVersion() <= 11010,
                     reason='avoid a cuFFT bug (cupy/cupy#3777)')
-@testing.gpu
 @testing.slow
 class TestFftAllocate:
 
@@ -400,7 +396,6 @@ class TestFftAllocate:
         testing.product({'norm': [None, 'backward', 'ortho', 'forward', '']})
     )
 ))
-@testing.gpu
 class TestFft2:
 
     @nd_planning_states()
@@ -477,7 +472,6 @@ class TestFft2:
         testing.product({'norm': [None, 'backward', 'ortho', 'forward', '']})
     )
 ))
-@testing.gpu
 class TestFftn:
 
     @nd_planning_states()
@@ -547,7 +541,6 @@ class TestFftn:
         testing.product({'norm': [None, 'backward', 'ortho', 'forward']})
     )
 ))
-@testing.gpu
 class TestPlanCtxManagerFftn:
 
     @pytest.fixture(autouse=True)
@@ -639,7 +632,6 @@ class TestPlanCtxManagerFftn:
     'shape': [(10,), ],
     'norm': [None, 'backward', 'ortho', 'forward'],
 }))
-@testing.gpu
 class TestPlanCtxManagerFft:
 
     @testing.for_complex_dtypes()
@@ -806,7 +798,6 @@ class TestMultiGpuPlanCtxManagerFft:
         testing.product({'norm': [None, 'backward', 'ortho', 'forward', '']})
     )
 ))
-@testing.gpu
 class TestFftnContiguity:
 
     @nd_planning_states([True])
@@ -853,7 +844,6 @@ class TestFftnContiguity:
     'shape': [(10,), (10, 10)],
     'norm': [None, 'backward', 'ortho', 'forward', ''],
 }))
-@testing.gpu
 class TestRfft:
 
     @testing.for_all_dtypes(no_complex=True)
@@ -887,7 +877,6 @@ class TestRfft:
     'shape': [(10,)],
     'norm': [None, 'backward', 'ortho', 'forward'],
 }))
-@testing.gpu
 class TestPlanCtxManagerRfft:
 
     @testing.for_all_dtypes(no_complex=True)
@@ -974,7 +963,6 @@ class TestPlanCtxManagerRfft:
         testing.product({'norm': [None, 'backward', 'ortho', 'forward', '']})
     )
 ))
-@testing.gpu
 class TestRfft2:
 
     @nd_planning_states()
@@ -1020,7 +1008,6 @@ class TestRfft2:
     {'shape': (3, 4), 's': None, 'axes': (), 'norm': None},
     {'shape': (2, 3, 4), 's': None, 'axes': (), 'norm': None},
 )
-@testing.gpu
 class TestRfft2EmptyAxes:
 
     @testing.for_all_dtypes(no_complex=True)
@@ -1061,7 +1048,6 @@ class TestRfft2EmptyAxes:
         testing.product({'norm': [None, 'backward', 'ortho', 'forward', '']})
     )
 ))
-@testing.gpu
 class TestRfftn:
 
     @nd_planning_states()
@@ -1126,7 +1112,6 @@ class TestRfftn:
         testing.product({'norm': [None, 'backward', 'ortho', 'forward', '']})
     )
 ))
-@testing.gpu
 class TestPlanCtxManagerRfftn:
 
     @pytest.fixture(autouse=True)
@@ -1204,7 +1189,6 @@ class TestPlanCtxManagerRfftn:
         testing.product({'norm': [None, 'backward', 'ortho', 'forward', '']})
     )
 ))
-@testing.gpu
 class TestRfftnContiguity:
 
     @nd_planning_states([True])
@@ -1251,7 +1235,6 @@ class TestRfftnContiguity:
     {'shape': (3, 4), 's': None, 'axes': (), 'norm': None},
     {'shape': (2, 3, 4), 's': None, 'axes': (), 'norm': None},
 )
-@testing.gpu
 class TestRfftnEmptyAxes:
 
     @testing.for_all_dtypes(no_complex=True)
@@ -1275,7 +1258,6 @@ class TestRfftnEmptyAxes:
     'shape': [(10,), (10, 10)],
     'norm': [None, 'backward', 'ortho', 'forward', ''],
 }))
-@testing.gpu
 class TestHfft:
 
     @testing.for_all_dtypes()
@@ -1308,7 +1290,6 @@ class TestHfft:
     {'n': 10, 'd': 0.5},
     {'n': 100, 'd': 2},
 )
-@testing.gpu
 class TestFftfreq:
 
     @testing.for_all_dtypes()
@@ -1335,7 +1316,6 @@ class TestFftfreq:
     {'shape': (10, 10), 'axes': 0},
     {'shape': (10, 10), 'axes': (0, 1)},
 )
-@testing.gpu
 class TestFftshift:
 
     @testing.for_all_dtypes()

--- a/tests/cupy_tests/indexing_tests/test_generate.py
+++ b/tests/cupy_tests/indexing_tests/test_generate.py
@@ -10,7 +10,6 @@ from cupy._indexing import generate
 from cupy import testing
 
 
-@testing.gpu
 class TestIndices(unittest.TestCase):
 
     @testing.for_all_dtypes()
@@ -35,7 +34,6 @@ class TestIndices(unittest.TestCase):
                 xp.indices((1, 2, 3, 4), dtype=xp.bool_)
 
 
-@testing.gpu
 class TestIX_(unittest.TestCase):
 
     @testing.numpy_cupy_array_equal()
@@ -58,7 +56,6 @@ class TestIX_(unittest.TestCase):
         return xp.ix_(xp.array([True, False] * 2))
 
 
-@testing.gpu
 class TestR_(unittest.TestCase):
 
     @testing.for_all_dtypes()
@@ -112,7 +109,6 @@ class TestR_(unittest.TestCase):
             cupy.r_[a, b]
 
 
-@testing.gpu
 class TestC_(unittest.TestCase):
 
     @testing.for_all_dtypes()
@@ -138,7 +134,6 @@ class TestC_(unittest.TestCase):
             cupy.c_[a, b]
 
 
-@testing.gpu
 class TestAxisConcatenator(unittest.TestCase):
 
     def test_AxisConcatenator_init1(self):
@@ -150,7 +145,6 @@ class TestAxisConcatenator(unittest.TestCase):
         assert len(a) == 0
 
 
-@testing.gpu
 class TestUnravelIndex(unittest.TestCase):
 
     @testing.for_orders(['C', 'F', None])
@@ -186,7 +180,6 @@ class TestUnravelIndex(unittest.TestCase):
                 xp.unravel_index(a, (6, 4), order=order)
 
 
-@testing.gpu
 class TestRavelMultiIndex(unittest.TestCase):
 
     @testing.for_orders(['C', 'F', None])

--- a/tests/cupy_tests/indexing_tests/test_indexing.py
+++ b/tests/cupy_tests/indexing_tests/test_indexing.py
@@ -7,7 +7,6 @@ import cupy
 from cupy import testing
 
 
-@testing.gpu
 class TestIndexing(unittest.TestCase):
 
     @testing.numpy_cupy_array_equal()
@@ -203,7 +202,6 @@ class TestIndexing(unittest.TestCase):
         return xp.extract(b, a)
 
 
-@testing.gpu
 class TestChoose(unittest.TestCase):
 
     @testing.for_all_dtypes()
@@ -264,7 +262,6 @@ class TestChoose(unittest.TestCase):
                 return a.choose(c)
 
 
-@testing.gpu
 class TestSelect(unittest.TestCase):
 
     @testing.for_all_dtypes(no_bool=True, no_complex=True)

--- a/tests/cupy_tests/indexing_tests/test_insert.py
+++ b/tests/cupy_tests/indexing_tests/test_insert.py
@@ -11,7 +11,6 @@ from cupy import testing
     'shape': [(7,), (2, 3), (4, 3, 2)],
     'n_vals': [0, 1, 3, 15],
 }))
-@testing.gpu
 class TestPlace(unittest.TestCase):
 
     # NumPy 1.9 don't wraps values.
@@ -32,7 +31,6 @@ class TestPlace(unittest.TestCase):
 @testing.parameterize(*testing.product({
     'shape': [(7,), (2, 3), (4, 3, 2)],
 }))
-@testing.gpu
 class TestPlaceRaises(unittest.TestCase):
 
     # NumPy 1.9 performs illegal memory access.
@@ -64,7 +62,6 @@ class TestPlaceRaises(unittest.TestCase):
     'mode': ['raise', 'wrap', 'clip'],
     'n_vals': [0, 1, 3, 4, 5],
 }))
-@testing.gpu
 class TestPut(unittest.TestCase):
 
     @testing.for_all_dtypes()
@@ -84,7 +81,6 @@ class TestPut(unittest.TestCase):
 @testing.parameterize(*testing.product({
     'shape': [(7,), (2, 3), (4, 3, 2)],
 }))
-@testing.gpu
 class TestPutScalars(unittest.TestCase):
 
     @testing.numpy_cupy_array_equal()
@@ -110,7 +106,6 @@ class TestPutScalars(unittest.TestCase):
 @testing.parameterize(*testing.product({
     'shape': [(7,), (2, 3)],
 }))
-@testing.gpu
 class TestPutRaises(unittest.TestCase):
 
     @testing.for_all_dtypes()
@@ -145,7 +140,6 @@ class TestPutRaises(unittest.TestCase):
 @testing.parameterize(
     *testing.product(
         {'shape': [(0,), (1,), (2, 3), (2, 3, 4)]}))
-@testing.gpu
 class TestPutmaskSameShape(unittest.TestCase):
 
     @testing.for_all_dtypes()
@@ -163,7 +157,6 @@ class TestPutmaskSameShape(unittest.TestCase):
     *testing.product(
         {'shape': [(0,), (1,), (2, 3), (2, 3, 4)],
          'values_shape': [(2,), (3, 1), (5,)]}))
-@testing.gpu
 class TestPutmaskDifferentShapes(unittest.TestCase):
 
     @testing.for_all_dtypes()
@@ -178,7 +171,6 @@ class TestPutmaskDifferentShapes(unittest.TestCase):
         return a
 
 
-@testing.gpu
 class TestPutmask(unittest.TestCase):
 
     @testing.numpy_cupy_array_equal()
@@ -232,7 +224,6 @@ class TestPutmaskDifferentDtypes(unittest.TestCase):
     'val': [1, 0, (2,), (2, 2)],
     'wrap': [True, False],
 }))
-@testing.gpu
 class TestFillDiagonal(unittest.TestCase):
 
     def _compute_val(self, xp):
@@ -273,7 +264,6 @@ class TestFillDiagonal(unittest.TestCase):
     'n': [2, 4, -3, 0],
     'ndim': [2, 3, 1, 0, -2],
 }))
-@testing.gpu
 class TestDiagIndices(unittest.TestCase):
 
     @testing.numpy_cupy_array_equal()
@@ -285,7 +275,6 @@ class TestDiagIndices(unittest.TestCase):
     'n': [-3, 0],
     'ndim': [1, 0, -2],
 }))
-@testing.gpu
 class TestDiagIndicesInvalidValues(unittest.TestCase):
 
     @testing.numpy_cupy_array_equal()
@@ -296,7 +285,6 @@ class TestDiagIndicesInvalidValues(unittest.TestCase):
 @testing.parameterize(*testing.product({
     'shape': [(3, 3), (0, 0), (2, 2, 2)],
 }))
-@testing.gpu
 class TestDiagIndicesFrom(unittest.TestCase):
 
     @testing.numpy_cupy_array_equal()
@@ -308,7 +296,6 @@ class TestDiagIndicesFrom(unittest.TestCase):
 @testing.parameterize(*testing.product({
     'shape': [(3, 5), (3, 3, 4), (5,), (0,), (-1,)],
 }))
-@testing.gpu
 class TestDiagIndicesFromRaises(unittest.TestCase):
 
     def test_non_equal_dims(self):

--- a/tests/cupy_tests/indexing_tests/test_iterate.py
+++ b/tests/cupy_tests/indexing_tests/test_iterate.py
@@ -8,7 +8,6 @@ import cupy
 from cupy import testing
 
 
-@testing.gpu
 class TestFlatiter(unittest.TestCase):
 
     def test_base(self):
@@ -62,7 +61,6 @@ class TestFlatiter(unittest.TestCase):
     {'shape': (), 'index': slice(None)},
     {'shape': (10,), 'index': slice(None)},
 )
-@testing.gpu
 class TestFlatiterSubscript(unittest.TestCase):
 
     @testing.for_CF_orders()
@@ -124,7 +122,6 @@ class TestFlatiterSubscript(unittest.TestCase):
     {'shape': (2, 3, 4), 'index': cupy.array([0])},
     {'shape': (2, 3, 4), 'index': [0]},
 )
-@testing.gpu
 class TestFlatiterSubscriptIndexError(unittest.TestCase):
 
     @testing.for_all_dtypes()

--- a/tests/cupy_tests/io_tests/test_formatting.py
+++ b/tests/cupy_tests/io_tests/test_formatting.py
@@ -6,7 +6,6 @@ import cupy
 from cupy import testing
 
 
-@testing.gpu
 class TestFormatting(unittest.TestCase):
 
     def test_array_repr(self):

--- a/tests/cupy_tests/io_tests/test_npz.py
+++ b/tests/cupy_tests/io_tests/test_npz.py
@@ -6,7 +6,6 @@ import cupy
 from cupy import testing
 
 
-@testing.gpu
 class TestNpz(unittest.TestCase):
 
     @testing.for_all_dtypes()

--- a/tests/cupy_tests/io_tests/test_text.py
+++ b/tests/cupy_tests/io_tests/test_text.py
@@ -9,7 +9,6 @@ from cupy import testing
 import cupy
 
 
-@testing.gpu
 class TestText(unittest.TestCase):
 
     def test_savetxt(self):

--- a/tests/cupy_tests/io_tests/test_text.py
+++ b/tests/cupy_tests/io_tests/test_text.py
@@ -5,7 +5,6 @@ import unittest
 
 import numpy
 
-from cupy import testing
 import cupy
 
 

--- a/tests/cupy_tests/lib_tests/test_polynomial.py
+++ b/tests/cupy_tests/lib_tests/test_polynomial.py
@@ -12,7 +12,6 @@ from cupy import testing
     {'variable': None},
     {'variable': 'y'},
 )
-@testing.gpu
 class TestPoly1dInit:
 
     @testing.for_all_dtypes(no_bool=True)
@@ -107,7 +106,6 @@ class TestPoly1dInit:
         return out.coeffs
 
 
-@testing.gpu
 class TestPoly1d:
 
     @testing.for_all_dtypes()
@@ -244,7 +242,6 @@ class TestPoly1d:
         return b(a)
 
 
-@testing.gpu
 class TestPoly:
 
     @testing.for_all_dtypes(no_bool=True)
@@ -301,7 +298,6 @@ class TestPoly:
         return xp.poly(a)
 
 
-@testing.gpu
 @testing.parameterize(*testing.product({
     'shape': [(), (0,), (5,)],
     'exp': [0, 4, 5, numpy.int32(5), numpy.int64(5)],
@@ -316,7 +312,6 @@ class TestPoly1dPow:
         return xp.poly1d(a) ** self.exp
 
 
-@testing.gpu
 @testing.parameterize(*testing.product({
     'shape': [(5,), (5, 2)],
     'exp': [-10, 3.5, [1, 2, 3]],
@@ -331,7 +326,6 @@ class TestPoly1dPowInvalidValue:
                 xp.poly1d(a) ** self.exp
 
 
-@testing.gpu
 @testing.parameterize(*testing.product({
     'exp': [3.0, numpy.float64(5)],
 }))
@@ -363,7 +357,6 @@ class Poly1dTestBase:
         assert False
 
 
-@testing.gpu
 @testing.parameterize(*testing.product({
     'func': [
         lambda x, y: x + y,
@@ -386,7 +379,6 @@ class TestPoly1dPolynomialArithmetic(Poly1dTestBase):
         return self.func(a1, a2)
 
 
-@testing.gpu
 @testing.parameterize(*testing.product({
     'fname': ['add', 'subtract', 'multiply', 'divide', 'power'],
     'type_l': ['poly1d', 'ndarray', 'python_scalar', 'numpy_scalar'],
@@ -403,7 +395,6 @@ class TestPoly1dMathArithmetic(Poly1dTestBase):
         return func(a1, a2)
 
 
-@testing.gpu
 @testing.parameterize(*testing.product({
     'fname': ['polyadd', 'polysub', 'polymul'],
     'type_l': ['poly1d', 'ndarray', 'python_scalar', 'numpy_scalar'],
@@ -421,7 +412,6 @@ class TestPoly1dRoutines(Poly1dTestBase):
         return func(a1, a2)
 
 
-@testing.gpu
 class TestPoly1dEquality:
 
     def make_poly1d1(self, xp, dtype):
@@ -463,7 +453,6 @@ class TestPoly1dEquality:
         return a != b
 
 
-@testing.gpu
 @testing.parameterize(*testing.product({
     'fname': ['polyadd', 'polysub', 'polymul'],
     'shape1': [(), (0,), (3,), (5,)],
@@ -481,7 +470,6 @@ class TestPolyArithmeticShapeCombination:
         return func(a, b)
 
 
-@testing.gpu
 @testing.parameterize(*testing.product({
     'fname': ['polyadd', 'polysub', 'polymul'],
 }))
@@ -522,7 +510,6 @@ class TestPolyArithmeticDiffTypes:
             pass
 
 
-@testing.gpu
 @testing.parameterize(*testing.product({
     'shape1': [(3,)],
     'shape2': [(3,), (3, 2)],
@@ -565,7 +552,6 @@ class TestPolyfitParametersCombinations:
             assert cp_rcond == np_rcond
 
 
-@testing.gpu
 @testing.parameterize(*testing.product({
     'shape': [(3,), (3, 2)],
     'deg': [0, 1],
@@ -591,7 +577,6 @@ class TestPolyfitCovMode:
         testing.assert_allclose(cp_cov, np_cov, rtol=1e-3)
 
 
-@testing.gpu
 class TestPolyfit:
 
     @testing.for_all_dtypes(no_float16=True)
@@ -603,7 +588,6 @@ class TestPolyfit:
                 xp.polyfit(x, y, 6)
 
 
-@testing.gpu
 @testing.parameterize(*testing.product({
     'shape': [(), (0,), (5, 3, 3)],
 }))
@@ -634,7 +618,6 @@ class TestPolyfitInvalidShapes:
                 xp.polyfit(x, x, 5, w=w)
 
 
-@testing.gpu
 class TestPolyfitInvalid:
 
     @testing.for_all_dtypes(no_float16=True)
@@ -684,7 +667,6 @@ class TestPolyfitInvalid:
                 xp.polyfit(x, x, 4)
 
 
-@testing.gpu
 class TestPolyfitDiffTypes:
 
     @testing.for_all_dtypes_combination(
@@ -705,7 +687,6 @@ class TestPolyfitDiffTypes:
         return xp.polyfit(x, y, 5, w=w)
 
 
-@testing.gpu
 @testing.parameterize(*testing.product({
     'type_l': ['poly1d', 'ndarray'],
     'type_r': ['poly1d', 'ndarray', 'numpy_scalar', 'python_scalar'],
@@ -720,7 +701,6 @@ class TestPolyval(Poly1dTestBase):
         return xp.polyval(a1, a2)
 
 
-@testing.gpu
 @testing.parameterize(*testing.product({
     'type_l': ['numpy_scalar', 'python_scalar'],
     'type_r': ['poly1d', 'ndarray', 'python_scalar', 'numpy_scalar'],
@@ -736,7 +716,6 @@ class TestPolyvalInvalidTypes(Poly1dTestBase):
                 xp.polyval(a1, a2)
 
 
-@testing.gpu
 @testing.parameterize(*testing.product({
     'shape1': [(0,), (3,), (5,)],
     'shape2': [(), (0,), (3,), (5,)]
@@ -751,7 +730,6 @@ class TestPolyvalShapeCombination:
         return xp.polyval(a, b)
 
 
-@testing.gpu
 @testing.parameterize(*testing.product({
     'shape': [(), (0,), (3,), (5,)]
 }))
@@ -766,7 +744,6 @@ class TestPolyvalInvalidShapeCombination:
                 xp.polyval(a, b)
 
 
-@testing.gpu
 class TestPolyvalDtypesCombination:
 
     @testing.for_all_dtypes_combination(names=['dtype1', 'dtype2'], full=True)
@@ -784,7 +761,6 @@ class TestPolyvalDtypesCombination:
         return xp.polyval(a, b)
 
 
-@testing.gpu
 class TestPolyvalMultiDimensional:
 
     @testing.for_all_dtypes()
@@ -801,7 +777,6 @@ class TestPolyvalMultiDimensional:
         return cupy.polyval(a, b)
 
 
-@testing.gpu
 @testing.parameterize(*testing.product({
     'fname': ['polyadd', 'polysub', 'polymul', 'polyval'],
 }))
@@ -817,7 +792,6 @@ class TestPolyRoutinesNdim:
                 func(a, b)
 
 
-@testing.gpu
 @testing.parameterize(*testing.product({
     'input': [[2, -1, -2], [-4, 10, 4]],
 }))
@@ -840,7 +814,6 @@ class TestRootsReal:
         return xp.sort(out)
 
 
-@testing.gpu
 @testing.parameterize(*testing.product({
     'input': [[3j, 1.5j, -3j], [3 + 2j, 5], [3j, 0], [0, 3j]],
 }))
@@ -865,7 +838,6 @@ class TestRootsComplex:
         return xp.sort(out)
 
 
-@testing.gpu
 @testing.parameterize(*testing.product({
     'input': [[5, 10], [5, 0], [0, 5], [0, 0], [5]],
 }))
@@ -884,7 +856,6 @@ class TestRootsSpecialCases:
         return xp.roots(xp.poly1d(a))
 
 
-@testing.gpu
 class TestRoots:
 
     @testing.for_all_dtypes(no_bool=True)

--- a/tests/cupy_tests/lib_tests/test_shape_base.py
+++ b/tests/cupy_tests/lib_tests/test_shape_base.py
@@ -8,7 +8,6 @@ from cupy import testing
 
 
 @testing.parameterize(*(testing.product({'axis': [0, 1, -1]})))
-@testing.gpu
 class TestApplyAlongAxis(unittest.TestCase):
 
     @testing.numpy_cupy_array_equal()
@@ -100,7 +99,6 @@ class TestApplyAlongAxis(unittest.TestCase):
         return xp.apply_along_axis(func, 1, a)
 
 
-@testing.gpu
 @testing.with_requires('numpy>=1.16')
 def test_apply_along_axis_invalid_axis():
     for xp in [numpy, cupy]:

--- a/tests/cupy_tests/lib_tests/test_strided_tricks.py
+++ b/tests/cupy_tests/lib_tests/test_strided_tricks.py
@@ -7,7 +7,6 @@ from cupy import testing
 from cupy.lib import stride_tricks
 
 
-@testing.gpu
 class TestAsStrided(unittest.TestCase):
     def test_as_strided(self):
         a = cupy.array([1, 2, 3, 4])

--- a/tests/cupy_tests/linalg_tests/test_decomposition.py
+++ b/tests/cupy_tests/linalg_tests/test_decomposition.py
@@ -92,7 +92,6 @@ class TestCholeskyDecomposition:
         return xp.linalg.cholesky(a)
 
 
-@testing.gpu
 class TestCholeskyInvalid(unittest.TestCase):
 
     def check_L(self, array):
@@ -183,7 +182,6 @@ class TestQRDecomposition(unittest.TestCase):
     'full_matrices': [True, False],
 }))
 @testing.fix_random()
-@testing.gpu
 class TestSVD(unittest.TestCase):
 
     def setUp(self):

--- a/tests/cupy_tests/linalg_tests/test_norms.py
+++ b/tests/cupy_tests/linalg_tests/test_norms.py
@@ -8,7 +8,6 @@ from cupy import testing
 import cupyx
 
 
-@testing.gpu
 class TestTrace(unittest.TestCase):
 
     @testing.for_all_dtypes()
@@ -46,7 +45,6 @@ class TestTrace(unittest.TestCase):
     'keepdims': [True, False],
 })
 )
-@testing.gpu
 class TestNorm(unittest.TestCase):
 
     @testing.for_all_dtypes(no_float16=True)
@@ -73,7 +71,6 @@ class TestNorm(unittest.TestCase):
     ],
     'tol': [None, 1]
 }))
-@testing.gpu
 class TestMatrixRank(unittest.TestCase):
 
     @testing.for_all_dtypes(no_float16=True, no_complex=True)
@@ -90,7 +87,6 @@ class TestMatrixRank(unittest.TestCase):
         return y
 
 
-@testing.gpu
 class TestDet(unittest.TestCase):
 
     @testing.for_float_dtypes(no_float16=True)
@@ -164,7 +160,6 @@ class TestDet(unittest.TestCase):
         return xp.linalg.det(a)
 
 
-@testing.gpu
 class TestSlogdet(unittest.TestCase):
 
     @testing.for_dtypes('fdFD')

--- a/tests/cupy_tests/linalg_tests/test_product.py
+++ b/tests/cupy_tests/linalg_tests/test_product.py
@@ -31,7 +31,6 @@ from cupy import testing
     'trans_a': [True, False],
     'trans_b': [True, False],
 }))
-@testing.gpu
 class TestDot(unittest.TestCase):
 
     @testing.for_all_dtypes_combination(['dtype_a', 'dtype_b'])
@@ -89,7 +88,6 @@ class TestDot(unittest.TestCase):
         ((2, 4, 5, 2), (2, 4, 5, 2), 0, 0, -1),
     ],
 }))
-@testing.gpu
 class TestCrossProduct(unittest.TestCase):
 
     @testing.for_all_dtypes_combination(['dtype_a', 'dtype_b'])
@@ -113,7 +111,6 @@ class TestCrossProduct(unittest.TestCase):
     'trans_a': [True, False],
     'trans_b': [True, False],
 }))
-@testing.gpu
 class TestDotFor0Dim(unittest.TestCase):
 
     @testing.for_all_dtypes_combination(['dtype_a', 'dtype_b'])
@@ -131,7 +128,6 @@ class TestDotFor0Dim(unittest.TestCase):
         return xp.dot(a, b)
 
 
-@testing.gpu
 class TestProduct(unittest.TestCase):
 
     @testing.for_all_dtypes()
@@ -392,7 +388,6 @@ class TestProduct(unittest.TestCase):
         ((0, 0, 0), ([0, 2, 1], [1, 2, 0])),
     ],
 }))
-@testing.gpu
 class TestProductZeroLength(unittest.TestCase):
 
     @testing.for_all_dtypes()

--- a/tests/cupy_tests/linalg_tests/test_solve.py
+++ b/tests/cupy_tests/linalg_tests/test_solve.py
@@ -14,7 +14,6 @@ from cupy.cublas import get_batched_gesv_limit, set_batched_gesv_limit
     'batched_gesv_limit': [None, 0],
     'order': ['C', 'F'],
 }))
-@testing.gpu
 @testing.fix_random()
 class TestSolve(unittest.TestCase):
 
@@ -83,7 +82,6 @@ class TestSolve(unittest.TestCase):
     'axes': [None, (0, 2)],
 }))
 @testing.fix_random()
-@testing.gpu
 class TestTensorSolve(unittest.TestCase):
 
     @testing.for_dtypes('ifdFD')
@@ -99,7 +97,6 @@ class TestTensorSolve(unittest.TestCase):
 @testing.parameterize(*testing.product({
     'order': ['C', 'F'],
 }))
-@testing.gpu
 class TestInv(unittest.TestCase):
 
     @testing.for_dtypes('ifdFD')
@@ -140,7 +137,6 @@ class TestInv(unittest.TestCase):
         self.check_shape((0, 2, 3))
 
 
-@testing.gpu
 class TestInvInvalid(unittest.TestCase):
 
     @testing.for_dtypes('ifdFD')
@@ -161,7 +157,6 @@ class TestInvInvalid(unittest.TestCase):
                     xp.linalg.inv(a)
 
 
-@testing.gpu
 class TestPinv(unittest.TestCase):
 
     @testing.for_dtypes('ifdFD')
@@ -208,7 +203,6 @@ class TestPinv(unittest.TestCase):
         self.check_x((2, 0, 3), rcond=1e-15)
 
 
-@testing.gpu
 class TestLstsq:
 
     @testing.for_dtypes('ifdFD')
@@ -296,7 +290,6 @@ class TestLstsq:
             return xp.linalg.lstsq(a, b)
 
 
-@testing.gpu
 class TestTensorInv(unittest.TestCase):
 
     @testing.for_dtypes('ifdFD')

--- a/tests/cupy_tests/logic_tests/test_comparison.py
+++ b/tests/cupy_tests/logic_tests/test_comparison.py
@@ -7,7 +7,6 @@ import cupy
 from cupy import testing
 
 
-@testing.gpu
 class TestComparison(unittest.TestCase):
 
     @testing.for_all_dtypes(no_complex=True)
@@ -36,7 +35,6 @@ class TestComparison(unittest.TestCase):
         self.check_binary('equal')
 
 
-@testing.gpu
 class TestComparisonOperator(unittest.TestCase):
 
     operators = [

--- a/tests/cupy_tests/logic_tests/test_content.py
+++ b/tests/cupy_tests/logic_tests/test_content.py
@@ -5,7 +5,6 @@ import numpy
 from cupy import testing
 
 
-@testing.gpu
 class TestContent(unittest.TestCase):
 
     @testing.for_dtypes('efFdD')
@@ -33,7 +32,6 @@ class TestContent(unittest.TestCase):
         self.check_unary_nan('isnan')
 
 
-@testing.gpu
 class TestUfuncLike(unittest.TestCase):
 
     @testing.numpy_cupy_array_equal()

--- a/tests/cupy_tests/logic_tests/test_ops.py
+++ b/tests/cupy_tests/logic_tests/test_ops.py
@@ -3,7 +3,6 @@ import unittest
 from cupy import testing
 
 
-@testing.gpu
 class TestOps(unittest.TestCase):
 
     @testing.for_all_dtypes(no_complex=True)

--- a/tests/cupy_tests/logic_tests/test_truth.py
+++ b/tests/cupy_tests/logic_tests/test_truth.py
@@ -31,7 +31,6 @@ def _calc_out_shape(shape, axis, keepdims):
                numpy.ones((0, 3, 4))],
          'axis': [None, (0, 1, 2), 0, 1, 2, (0, 1)],
          'keepdims': [False, True]}))
-@testing.gpu
 class TestAllAny:
 
     @testing.for_all_dtypes()
@@ -59,7 +58,6 @@ class TestAllAny:
                numpy.array([[[numpy.nan, 0, 1]]])],
          'axis': [None, (0, 1, 2), 0, 1, 2, (0, 1)],
          'keepdims': [False, True]}))
-@testing.gpu
 class TestAllAnyWithNaN:
 
     @testing.for_dtypes(
@@ -111,7 +109,6 @@ class TestAllAnyAlias:
         ],
             'assume_unique': [False, True],
             'invert': [False, True]}))
-@testing.gpu
 class TestIn1DIsIn:
 
     @testing.for_all_dtypes()

--- a/tests/cupy_tests/manipulation_tests/test_add_remove.py
+++ b/tests/cupy_tests/manipulation_tests/test_add_remove.py
@@ -7,7 +7,6 @@ import cupy
 from cupy import testing
 
 
-@testing.gpu
 class TestDelete(unittest.TestCase):
 
     @testing.numpy_cupy_array_equal()
@@ -54,7 +53,6 @@ class TestDelete(unittest.TestCase):
         return xp.delete(arr, indices)
 
 
-@testing.gpu
 class TestAppend(unittest.TestCase):
 
     @testing.for_all_dtypes_combination(
@@ -112,7 +110,6 @@ class TestAppend(unittest.TestCase):
         return xp.append(xp.array([]), xp.arange(10))
 
 
-@testing.gpu
 class TestResize(unittest.TestCase):
 
     @testing.numpy_cupy_array_equal()
@@ -213,7 +210,6 @@ class TestUnique:
 @testing.parameterize(*testing.product({
     'trim': ['fb', 'f', 'b']
 }))
-@testing.gpu
 class TestTrim_zeros(unittest.TestCase):
 
     @testing.for_all_dtypes()

--- a/tests/cupy_tests/manipulation_tests/test_basic.py
+++ b/tests/cupy_tests/manipulation_tests/test_basic.py
@@ -9,7 +9,6 @@ from cupy import cuda
 from cupy import testing
 
 
-@testing.gpu
 class TestBasic:
 
     @testing.for_all_dtypes()
@@ -188,7 +187,6 @@ class TestBasic:
     *testing.product(
         {'src': [float(3.2), int(0), int(4), int(-4), True, False, 1 + 1j],
          'dst_shape': [(), (0,), (1,), (1, 1), (2, 2)]}))
-@testing.gpu
 class TestCopytoFromScalar:
 
     @testing.for_all_dtypes()

--- a/tests/cupy_tests/manipulation_tests/test_dims.py
+++ b/tests/cupy_tests/manipulation_tests/test_dims.py
@@ -8,7 +8,6 @@ from cupy.cuda import runtime
 from cupy import testing
 
 
-@testing.gpu
 class TestDims(unittest.TestCase):
 
     def check_atleast(self, func, xp):
@@ -290,7 +289,6 @@ class TestDims(unittest.TestCase):
     {'shapes': [(0, 1, 1, 3), (2, 1, 0, 0, 3)]},
     {'shapes': [(0, 1, 1, 0, 3), (5, 2, 0, 1, 0, 0, 3), (2, 1, 0, 0, 0, 3)]},
 )
-@testing.gpu
 class TestBroadcast(unittest.TestCase):
 
     def _broadcast(self, xp, dtype, shapes):
@@ -329,7 +327,6 @@ class TestBroadcast(unittest.TestCase):
     {'shapes': [(3, 2), (3, 4,)]},
     {'shapes': [(0,), (2,)]},
 )
-@testing.gpu
 class TestInvalidBroadcast(unittest.TestCase):
 
     @testing.for_all_dtypes()

--- a/tests/cupy_tests/manipulation_tests/test_kind.py
+++ b/tests/cupy_tests/manipulation_tests/test_kind.py
@@ -7,7 +7,6 @@ import cupy
 from cupy import testing
 
 
-@testing.gpu
 class TestKind(unittest.TestCase):
 
     @testing.for_orders('CFAK')

--- a/tests/cupy_tests/manipulation_tests/test_rearrange.py
+++ b/tests/cupy_tests/manipulation_tests/test_rearrange.py
@@ -7,7 +7,6 @@ import cupy
 from cupy import testing
 
 
-@testing.gpu
 @testing.parameterize(
     {'shape': (10,), 'shift': 2, 'axis': None},
     {'shape': (5, 2), 'shift': 1, 'axis': None},
@@ -84,7 +83,6 @@ class TestRollValueError(unittest.TestCase):
                 xp.roll(x, shift, axis=self.axis)
 
 
-@testing.gpu
 class TestFliplr(unittest.TestCase):
 
     @testing.for_all_dtypes()
@@ -107,7 +105,6 @@ class TestFliplr(unittest.TestCase):
                 xp.fliplr(x)
 
 
-@testing.gpu
 class TestFlipud(unittest.TestCase):
 
     @testing.for_all_dtypes()
@@ -130,7 +127,6 @@ class TestFlipud(unittest.TestCase):
                 xp.flipud(x)
 
 
-@testing.gpu
 class TestFlip(unittest.TestCase):
 
     @testing.for_all_dtypes()
@@ -215,7 +211,6 @@ class TestFlip(unittest.TestCase):
                 xp.flip(x, -3)
 
 
-@testing.gpu
 class TestRot90(unittest.TestCase):
 
     @testing.for_all_dtypes()

--- a/tests/cupy_tests/manipulation_tests/test_split.py
+++ b/tests/cupy_tests/manipulation_tests/test_split.py
@@ -3,7 +3,6 @@ import unittest
 from cupy import testing
 
 
-@testing.gpu
 class TestSplit(unittest.TestCase):
 
     @testing.numpy_cupy_array_equal()

--- a/tests/cupy_tests/manipulation_tests/test_tiling.py
+++ b/tests/cupy_tests/manipulation_tests/test_tiling.py
@@ -16,7 +16,6 @@ from cupy import testing
     {'repeats': [1, 2, 3], 'axis': 1},
     {'repeats': [1, 2, 3], 'axis': -2},
 )
-@testing.gpu
 class TestRepeat(unittest.TestCase):
 
     @testing.numpy_cupy_array_equal()
@@ -44,7 +43,6 @@ class TestRepeatRepeatsNdarray(unittest.TestCase):
     {'repeats': [2], 'axis': None},
     {'repeats': [2], 'axis': 1},
 )
-@testing.gpu
 class TestRepeatListBroadcast(unittest.TestCase):
 
     """Test for `repeats` argument using single element list.
@@ -65,7 +63,6 @@ class TestRepeatListBroadcast(unittest.TestCase):
     {'repeats': [1, 2, 3, 4], 'axis': None},
     {'repeats': [1, 2, 3, 4], 'axis': 0},
 )
-@testing.gpu
 class TestRepeat1D(unittest.TestCase):
 
     @testing.numpy_cupy_array_equal()
@@ -78,7 +75,6 @@ class TestRepeat1D(unittest.TestCase):
     {'repeats': [2], 'axis': None},
     {'repeats': [2], 'axis': 0},
 )
-@testing.gpu
 class TestRepeat1DListBroadcast(unittest.TestCase):
 
     """See comment in TestRepeatListBroadcast class."""
@@ -97,7 +93,6 @@ class TestRepeat1DListBroadcast(unittest.TestCase):
     {'repeats': 2, 'axis': -4},
     {'repeats': 2, 'axis': 3},
 )
-@testing.gpu
 class TestRepeatFailure(unittest.TestCase):
 
     def test_repeat_failure(self):
@@ -115,7 +110,6 @@ class TestRepeatFailure(unittest.TestCase):
     {'reps': (2, 3)},
     {'reps': (2, 3, 4, 5)},
 )
-@testing.gpu
 class TestTile(unittest.TestCase):
 
     @testing.numpy_cupy_array_equal()
@@ -128,7 +122,6 @@ class TestTile(unittest.TestCase):
     {'reps': -1},
     {'reps': (-1, -2)},
 )
-@testing.gpu
 class TestTileFailure(unittest.TestCase):
 
     def test_tile_failure(self):

--- a/tests/cupy_tests/manipulation_tests/test_transpose.py
+++ b/tests/cupy_tests/manipulation_tests/test_transpose.py
@@ -7,7 +7,6 @@ import cupy
 from cupy import testing
 
 
-@testing.gpu
 class TestTranspose(unittest.TestCase):
 
     @testing.numpy_cupy_array_equal()

--- a/tests/cupy_tests/math_tests/test_arithmetic.py
+++ b/tests/cupy_tests/math_tests/test_arithmetic.py
@@ -23,7 +23,6 @@ negative_no_complex_types = [numpy.bool_] + float_types + signed_int_types
 no_complex_types = [numpy.bool_] + float_types + int_types
 
 
-@testing.gpu
 @testing.parameterize(*(
     testing.product({
         'nargs': [1],
@@ -52,7 +51,6 @@ class TestArithmeticRaisesWithNumpyInput:
                 func(*arys)
 
 
-@testing.gpu
 @testing.parameterize(*(
     testing.product({
         'arg1': ([testing.shaped_arange((2, 3), numpy, dtype=d)
@@ -112,7 +110,6 @@ class TestArithmeticUnary:
 @testing.parameterize(*testing.product({
     'shape': [(3, 2), (), (3, 0, 2)],
 }))
-@testing.gpu
 class TestComplex:
 
     @testing.for_all_dtypes(no_complex=True)
@@ -260,7 +257,6 @@ class ArithmeticBinaryBase:
         return y
 
 
-@testing.gpu
 @testing.parameterize(*(
     testing.product({
         # TODO(unno): boolean subtract causes DeprecationWarning in numpy>=1.13
@@ -526,7 +522,6 @@ class TestArithmeticModf:
     'xp': [numpy, cupy],
     'shape': [(3, 2), (), (3, 0, 2)]
 }))
-@testing.gpu
 class TestBoolSubtract:
 
     def test_bool_subtract(self):

--- a/tests/cupy_tests/math_tests/test_floating.py
+++ b/tests/cupy_tests/math_tests/test_floating.py
@@ -6,7 +6,6 @@ import cupy
 from cupy import testing
 
 
-@testing.gpu
 class TestFloating(unittest.TestCase):
 
     @testing.for_all_dtypes(no_complex=True)

--- a/tests/cupy_tests/math_tests/test_hyperbolic.py
+++ b/tests/cupy_tests/math_tests/test_hyperbolic.py
@@ -3,7 +3,6 @@ import unittest
 from cupy import testing
 
 
-@testing.gpu
 class TestHyperbolic(unittest.TestCase):
 
     @testing.for_all_dtypes()

--- a/tests/cupy_tests/math_tests/test_matmul.py
+++ b/tests/cupy_tests/math_tests/test_matmul.py
@@ -55,7 +55,6 @@ from cupy import testing
             ((1, 3, 3), (10, 1, 3, 1)),
         ],
     }))
-@testing.gpu
 class TestMatmul(unittest.TestCase):
 
     @testing.for_all_dtypes(name='dtype1')
@@ -86,7 +85,6 @@ class TestMatmul(unittest.TestCase):
             ((0, 3, 2), (0, 2, 4), (0, 3, 4)),
         ],
     }))
-@testing.gpu
 class TestMatmulOut(unittest.TestCase):
 
     @testing.for_all_dtypes(name='dtype1')
@@ -157,7 +155,6 @@ class TestMatmulStrides:
             ((6, 5, 3, 2), (2,)),
         ],
     }))
-@testing.gpu
 class TestMatmulLarge(unittest.TestCase):
 
     # Avoid overflow
@@ -256,7 +253,6 @@ class _TestMatmulComputeTypes(unittest.TestCase):
             ((96, 32), (32, 64)),
         ],
     }))
-@testing.gpu
 class TestMatmulFp16ComputeTypes(_TestMatmulComputeTypes):
     dtype = numpy.float16
 
@@ -291,7 +287,6 @@ class TestMatmulFp16ComputeTypes(_TestMatmulComputeTypes):
             (numpy.complex64, numpy.complex64),
         ],
     }))
-@testing.gpu
 class TestMatmulFp32ComputeTypes(_TestMatmulComputeTypes):
     dtype = numpy.float32
 
@@ -326,7 +321,6 @@ class TestMatmulFp32ComputeTypes(_TestMatmulComputeTypes):
             (numpy.complex128, numpy.complex128),
         ],
     }))
-@testing.gpu
 class TestMatmulFp64ComputeTypes(_TestMatmulComputeTypes):
     dtype = numpy.float64
 
@@ -354,7 +348,6 @@ class TestMatmulFp64ComputeTypes(_TestMatmulComputeTypes):
             ((0, 1, 1), (2, 1, 1)),
         ],
     }))
-@testing.gpu
 class TestMatmulInvalidShape(unittest.TestCase):
 
     def test_invalid_shape(self):
@@ -379,7 +372,6 @@ class TestMatmulInvalidShape(unittest.TestCase):
              [(0, 1), (0, 1), (1, 2)]),
         ],
     }))
-@testing.gpu
 class TestMatmulAxes(unittest.TestCase):
 
     @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-3)  # required for uint8
@@ -397,7 +389,6 @@ class TestMatmulAxes(unittest.TestCase):
         return out
 
 
-@testing.gpu
 class TestMatmulDispatch(unittest.TestCase):
 
     def test_matmul_dispatch(self):

--- a/tests/cupy_tests/math_tests/test_rational.py
+++ b/tests/cupy_tests/math_tests/test_rational.py
@@ -6,7 +6,6 @@ import cupy
 from cupy import testing
 
 
-@testing.gpu
 class TestRational(unittest.TestCase):
 
     @testing.for_dtypes(['?', 'e', 'f', 'd', 'F', 'D'])

--- a/tests/cupy_tests/math_tests/test_rounding.py
+++ b/tests/cupy_tests/math_tests/test_rounding.py
@@ -7,7 +7,6 @@ import cupy
 from cupy import testing
 
 
-@testing.gpu
 class TestRounding(unittest.TestCase):
 
     @testing.for_all_dtypes(no_complex=True)

--- a/tests/cupy_tests/math_tests/test_special.py
+++ b/tests/cupy_tests/math_tests/test_special.py
@@ -4,7 +4,6 @@ import cupy
 from cupy import testing
 
 
-@testing.gpu
 class TestSpecial(unittest.TestCase):
 
     @testing.for_dtypes(['e', 'f', 'd'])

--- a/tests/cupy_tests/math_tests/test_sumprod.py
+++ b/tests/cupy_tests/math_tests/test_sumprod.py
@@ -10,7 +10,6 @@ from cupy._core import _cub_reduction
 from cupy import testing
 
 
-@testing.gpu
 class TestSumprod:
 
     @pytest.fixture(autouse=True)
@@ -214,7 +213,6 @@ class TestSumprod:
     'order': ('C', 'F'),
     'backend': ('device', 'block'),
 }))
-@testing.gpu
 @pytest.mark.skipif(
     not cupy.cuda.cub.available, reason='The CUB routine is not enabled')
 class TestCubReduction:
@@ -392,7 +390,6 @@ class TestCubReduction:
     'shape': [(10,), (10, 20), (10, 20, 30), (10, 20, 30, 40)],
     'order': ('C', 'F'),
 }))
-@testing.gpu
 @pytest.mark.skipif(
     not cupy.cuda.cutensor.available,
     reason='The cuTENSOR routine is not enabled')
@@ -448,7 +445,6 @@ class TestCuTensorReduction:
         'func': ['nansum', 'nanprod']
     })
 )
-@testing.gpu
 class TestNansumNanprodLong:
 
     def _do_transposed_axis_test(self):
@@ -489,7 +485,6 @@ class TestNansumNanprodLong:
         'shape': [(2, 3, 4), (20, 30, 40)],
     })
 )
-@testing.gpu
 class TestNansumNanprodExtra:
 
     def test_nansum_axis_float16(self):
@@ -529,7 +524,6 @@ class TestNansumNanprodExtra:
         'axis': [(1, 3), (0, 2, 3)],
     })
 )
-@testing.gpu
 class TestNansumNanprodAxes:
     @testing.for_all_dtypes(no_bool=True, no_float16=True)
     @testing.numpy_cupy_allclose(rtol=1e-6)
@@ -540,7 +534,6 @@ class TestNansumNanprodAxes:
         return xp.nansum(a, axis=self.axis)
 
 
-@testing.gpu
 class TestNansumNanprodHuge:
     def _test(self, xp, nan_slice):
         a = testing.shaped_random((2048, 1, 1024), xp, 'f')
@@ -565,7 +558,6 @@ axes = [0, 1, 2]
 
 
 @testing.parameterize(*testing.product({'axis': axes}))
-@testing.gpu
 class TestCumsum:
 
     def _cumsum(self, xp, a, *args, **kwargs):
@@ -680,7 +672,6 @@ class TestCumsum:
             return cupy.cumsum(a_numpy)
 
 
-@testing.gpu
 class TestCumprod:
 
     def _cumprod(self, xp, a, *args, **kwargs):
@@ -790,7 +781,6 @@ class TestCumprod:
     'axis': [None, 0, 1, 2],
     'func': ('nancumsum', 'nancumprod'),
 }))
-@testing.gpu
 class TestNanCumSumProd:
 
     zero_density = 0.25
@@ -839,7 +829,6 @@ class TestNanCumSumProd:
         return xp.ascontiguousarray(out)
 
 
-@testing.gpu
 class TestDiff:
 
     @testing.for_all_dtypes()
@@ -926,7 +915,6 @@ class TestDiff:
         'edge_order': [1, 2],
     }),
 ))
-@testing.gpu
 class TestGradient:
 
     def _gradient(self, xp, dtype, shape, spacing, axis, edge_order):
@@ -975,7 +963,6 @@ class TestGradient:
                               self.axis, self.edge_order)
 
 
-@testing.gpu
 class TestGradientErrors:
 
     def test_gradient_invalid_spacings1(self):

--- a/tests/cupy_tests/math_tests/test_trigonometric.py
+++ b/tests/cupy_tests/math_tests/test_trigonometric.py
@@ -3,7 +3,6 @@ import unittest
 from cupy import testing
 
 
-@testing.gpu
 class TestTrigonometric(unittest.TestCase):
 
     @testing.for_all_dtypes(no_complex=True)
@@ -57,7 +56,6 @@ class TestTrigonometric(unittest.TestCase):
 
 
 @testing.with_requires('numpy>=1.21.0')
-@testing.gpu
 class TestUnwrap(unittest.TestCase):
 
     @testing.for_all_dtypes(no_complex=True)

--- a/tests/cupy_tests/misc_tests/test_byte_bounds.py
+++ b/tests/cupy_tests/misc_tests/test_byte_bounds.py
@@ -2,7 +2,6 @@ import cupy
 from cupy import testing
 
 
-@testing.gpu
 class TestByteBounds:
 
     @testing.for_all_dtypes()

--- a/tests/cupy_tests/misc_tests/test_memory_ranges.py
+++ b/tests/cupy_tests/misc_tests/test_memory_ranges.py
@@ -5,7 +5,6 @@ import cupy
 from cupy import testing
 
 
-@testing.gpu
 class TestMayShareMemory(unittest.TestCase):
 
     @testing.numpy_cupy_equal()
@@ -101,7 +100,6 @@ class TestMayShareMemory(unittest.TestCase):
                     'Failed in case of {} and {}'.format(sl1, sl2)
 
 
-@testing.gpu
 class TestSharesMemory(unittest.TestCase):
 
     def test_different_arrays(self):

--- a/tests/cupy_tests/padding_tests/test_pad.py
+++ b/tests/cupy_tests/padding_tests/test_pad.py
@@ -17,7 +17,6 @@ from cupy import testing
                  'minimum', 'reflect', 'symmetric', 'wrap'],
     })
 )
-@testing.gpu
 class TestPadDefault(unittest.TestCase):
 
     @testing.for_all_dtypes(no_bool=True)
@@ -48,7 +47,6 @@ class TestPadDefault(unittest.TestCase):
         'pad_width': [1, [1, 2], [[1, 2], [3, 4]]],
     })
 )
-@testing.gpu
 class TestPadDefaultMean(unittest.TestCase):
 
     @testing.for_all_dtypes(no_bool=True)
@@ -121,7 +119,6 @@ class TestPadDefaultMean(unittest.TestCase):
      'pad_width': [[1, 2], [3, 4]], 'mode': 'maximum',
      'stat_length': None},
 )
-@testing.gpu
 # Old numpy does not work with multi-dimensional constant_values
 class TestPad(unittest.TestCase):
 
@@ -163,7 +160,6 @@ class TestPad(unittest.TestCase):
      'pad_width': [[1, 2], [3, 4]], 'mode': 'mean',
      'stat_length': None},
 )
-@testing.gpu
 # Old numpy does not work with multi-dimensional constant_values
 class TestPadMean(unittest.TestCase):
 
@@ -189,7 +185,6 @@ class TestPadMean(unittest.TestCase):
             return f()
 
 
-@testing.gpu
 class TestPadNumpybug(unittest.TestCase):
 
     @testing.for_all_dtypes(no_bool=True, no_complex=True)
@@ -203,7 +198,6 @@ class TestPadNumpybug(unittest.TestCase):
         return a
 
 
-@testing.gpu
 class TestPadEmpty(unittest.TestCase):
 
     @testing.with_requires('numpy>=1.17')
@@ -217,7 +211,6 @@ class TestPadEmpty(unittest.TestCase):
         return a[pad_width:-pad_width, pad_width:-pad_width]
 
 
-@testing.gpu
 class TestPadCustomFunction(unittest.TestCase):
 
     @testing.for_all_dtypes(no_bool=True)
@@ -248,7 +241,6 @@ class TestPadCustomFunction(unittest.TestCase):
     {'array': [0, 1, 2, 3], 'pad_width': 1, 'mode': 'reflect'},
     {'array': [0, 1, 2, 3], 'pad_width': [1, 2], 'mode': 'reflect'},
 )
-@testing.gpu
 class TestPadSpecial(unittest.TestCase):
 
     @testing.numpy_cupy_array_equal()
@@ -289,7 +281,6 @@ class TestPadSpecial(unittest.TestCase):
     {'array': [0, 1, 2, 3], 'pad_width': [1], 'mode': 'reflect',
      'kwargs': {'notallowedkeyword': 3}},
 )
-@testing.gpu
 @testing.with_requires('numpy>=1.17')
 class TestPadValueError(unittest.TestCase):
 
@@ -310,7 +301,6 @@ class TestPadValueError(unittest.TestCase):
     {'array': [0, 1, 2, 3], 'pad_width': [], 'mode': 'reflect',
      'kwargs': {}},
 )
-@testing.gpu
 class TestPadTypeError(unittest.TestCase):
 
     def test_pad_failure(self):

--- a/tests/cupy_tests/polynomial_tests/test_polynomial.py
+++ b/tests/cupy_tests/polynomial_tests/test_polynomial.py
@@ -7,7 +7,6 @@ import cupy
 from cupy import testing
 
 
-@testing.gpu
 class TestPolynomial(unittest.TestCase):
 
     @testing.for_all_dtypes(no_float16=True)

--- a/tests/cupy_tests/polynomial_tests/test_polyutils.py
+++ b/tests/cupy_tests/polynomial_tests/test_polyutils.py
@@ -10,7 +10,6 @@ from cupy import testing
 @testing.parameterize(*testing.product({
     'trim': [True, False]
 }))
-@testing.gpu
 class TestAsSeries(unittest.TestCase):
 
     @testing.for_all_dtypes(no_bool=True)
@@ -57,7 +56,6 @@ class TestAsSeries(unittest.TestCase):
                 xp.polynomial.polyutils.as_series(a, trim=self.trim)
 
 
-@testing.gpu
 class TestTrimseq(unittest.TestCase):
 
     @testing.for_all_dtypes()
@@ -101,7 +99,6 @@ class TestTrimseq(unittest.TestCase):
                 xp.polynomial.polyutils.trimseq(a)
 
 
-@testing.gpu
 @testing.parameterize(*testing.product({
     'tol': [0, 1e-3]
 }))
@@ -145,7 +142,6 @@ class TestTrimcoef(unittest.TestCase):
         return xp.polynomial.polyutils.trimcoef(a, dtype(self.tol))
 
 
-@testing.gpu
 class TestTrimcoefInvalid(unittest.TestCase):
 
     @testing.for_all_dtypes(no_bool=True)

--- a/tests/cupy_tests/random_tests/common_distributions.py
+++ b/tests/cupy_tests/random_tests/common_distributions.py
@@ -5,7 +5,6 @@ import numpy
 
 import cupy
 from cupy import testing
-from cupy.testing import _attr
 from cupy.testing import _condition
 
 
@@ -191,7 +190,7 @@ class StandardExponential:
     def test_standard_exponential(self):
         self.generate(size=(3, 2))
 
-    @_attr.slow
+    @testing.slow
     @_condition.repeat(10)
     def test_standard_exponential_isfinite(self):
         x = self.generate(size=10**7)

--- a/tests/cupy_tests/random_tests/test_bit_generator.py
+++ b/tests/cupy_tests/random_tests/test_bit_generator.py
@@ -47,7 +47,6 @@ class BitGeneratorTestCase:
 
 @testing.with_requires('numpy>=1.17.0')
 @testing.fix_random()
-@testing.gpu
 @pytest.mark.skipif(cupy.cuda.runtime.is_hip,
                     reason='HIP does not support this')
 class TestBitGeneratorXORWOW(BitGeneratorTestCase, unittest.TestCase):
@@ -58,7 +57,6 @@ class TestBitGeneratorXORWOW(BitGeneratorTestCase, unittest.TestCase):
 
 @testing.with_requires('numpy>=1.17.0')
 @testing.fix_random()
-@testing.gpu
 @pytest.mark.skipif(cupy.cuda.runtime.is_hip,
                     reason='HIP does not support this')
 class TestBitGeneratorMRG32k3a(BitGeneratorTestCase, unittest.TestCase):
@@ -69,7 +67,6 @@ class TestBitGeneratorMRG32k3a(BitGeneratorTestCase, unittest.TestCase):
 
 @testing.with_requires('numpy>=1.17.0')
 @testing.fix_random()
-@testing.gpu
 @pytest.mark.skipif(cupy.cuda.runtime.is_hip,
                     reason='HIP does not support this')
 class TestBitGeneratorPhilox4x3210(BitGeneratorTestCase, unittest.TestCase):

--- a/tests/cupy_tests/random_tests/test_distributions.py
+++ b/tests/cupy_tests/random_tests/test_distributions.py
@@ -43,7 +43,6 @@ class RandomDistributionsTestCase:
     'dtype': _float_dtypes,  # to escape timeout
 })
 )
-@testing.gpu
 class TestDistributionsBeta(RandomDistributionsTestCase):
 
     @cupy.testing.for_dtypes_combination(
@@ -62,7 +61,6 @@ class TestDistributionsBeta(RandomDistributionsTestCase):
     'dtype': _int_dtypes,  # to escape timeout
 })
 )
-@testing.gpu
 class TestDistributionsBinomial(RandomDistributionsTestCase):
 
     @cupy.testing.for_signed_dtypes('n_dtype')
@@ -81,7 +79,6 @@ class TestDistributionsBinomial(RandomDistributionsTestCase):
     'df_shape': [(), (3, 2)],
 })
 )
-@testing.gpu
 class TestDistributionsChisquare:
 
     def check_distribution(self, dist_func, df_dtype, dtype):
@@ -101,7 +98,6 @@ class TestDistributionsChisquare:
     'alpha_shape': [(3,)],
 })
 )
-@testing.gpu
 class TestDistributionsDirichlet(RandomDistributionsTestCase):
 
     @cupy.testing.for_dtypes_combination(
@@ -117,7 +113,6 @@ class TestDistributionsDirichlet(RandomDistributionsTestCase):
     'scale_shape': [(), (3, 2)],
 })
 )
-@testing.gpu
 class TestDistributionsExponential(RandomDistributionsTestCase):
 
     @cupy.testing.for_float_dtypes('dtype', no_float16=True)
@@ -128,7 +123,6 @@ class TestDistributionsExponential(RandomDistributionsTestCase):
                                 {'scale': scale}, dtype)
 
 
-@testing.gpu
 class TestDistributionsExponentialError(RandomDistributionsTestCase):
 
     def test_negative_scale(self):
@@ -144,7 +138,6 @@ class TestDistributionsExponentialError(RandomDistributionsTestCase):
     'dtype': _float_dtypes,  # to escape timeout
 })
 )
-@testing.gpu
 class TestDistributionsF:
 
     def check_distribution(self, dist_func, dfnum_dtype, dfden_dtype, dtype):
@@ -168,7 +161,6 @@ class TestDistributionsF:
     'dtype': _float_dtypes,  # to escape timeout
 })
 )
-@testing.gpu
 class TestDistributionsGamma:
 
     def check_distribution(self, dist_func, shape_dtype, scale_dtype,
@@ -209,7 +201,6 @@ class TestDistributionsGamma:
     'dtype': _int_dtypes,  # to escape timeout
 })
 )
-@testing.gpu
 class TestDistributionsGeometric:
 
     def check_distribution(self, dist_func, p_dtype, dtype):
@@ -230,7 +221,6 @@ class TestDistributionsGeometric:
     'scale_shape': [(), (3, 2)],
 })
 )
-@testing.gpu
 class TestDistributionsGumbel(RandomDistributionsTestCase):
 
     @cupy.testing.for_float_dtypes('dtype', no_float16=True)
@@ -252,7 +242,6 @@ class TestDistributionsGumbel(RandomDistributionsTestCase):
     'dtype': [numpy.int32, numpy.int64],  # to escape timeout
 })
 )
-@testing.gpu
 class TestDistributionsHyperGeometric:
 
     def check_distribution(self, dist_func, ngood_dtype, nbad_dtype,
@@ -277,7 +266,6 @@ class TestDistributionsHyperGeometric:
     'scale_shape': [(), (3, 2)],
 })
 )
-@testing.gpu
 class TestDistributionsuLaplace(RandomDistributionsTestCase):
 
     @cupy.testing.for_float_dtypes('dtype', no_float16=True)
@@ -296,7 +284,6 @@ class TestDistributionsuLaplace(RandomDistributionsTestCase):
     'scale_shape': [(), (3, 2)],
 })
 )
-@testing.gpu
 class TestDistributionsLogistic(RandomDistributionsTestCase):
 
     @cupy.testing.for_float_dtypes('dtype', no_float16=True)
@@ -315,7 +302,6 @@ class TestDistributionsLogistic(RandomDistributionsTestCase):
     'sigma_shape': [(), (3, 2)],
 })
 )
-@testing.gpu
 class TestDistributionsLognormal(RandomDistributionsTestCase):
 
     @cupy.testing.for_float_dtypes('dtype', no_float16=True)
@@ -333,7 +319,6 @@ class TestDistributionsLognormal(RandomDistributionsTestCase):
     'p_shape': [()],
 })
 )
-@testing.gpu
 class TestDistributionsLogseries(RandomDistributionsTestCase):
 
     @cupy.testing.for_dtypes([numpy.int64, numpy.int32], 'dtype')
@@ -359,7 +344,6 @@ class TestDistributionsLogseries(RandomDistributionsTestCase):
     'd': [2, 4],
 })
 )
-@testing.gpu
 class TestDistributionsMultivariateNormal:
 
     def check_distribution(self, dist_func, mean_dtype, cov_dtype, dtype):
@@ -385,7 +369,6 @@ class TestDistributionsMultivariateNormal:
     'dtype': _int_dtypes,  # to escape timeout
 })
 )
-@testing.gpu
 class TestDistributionsNegativeBinomial(RandomDistributionsTestCase):
 
     @cupy.testing.for_float_dtypes('n_dtype')
@@ -412,7 +395,6 @@ class TestDistributionsNegativeBinomial(RandomDistributionsTestCase):
     'dtype': _int_dtypes,  # to escape timeout
 })
 )
-@testing.gpu
 class TestDistributionsNoncentralChisquare(RandomDistributionsTestCase):
 
     @cupy.testing.for_dtypes_combination(
@@ -446,7 +428,6 @@ class TestDistributionsNoncentralChisquare(RandomDistributionsTestCase):
     'dtype': _int_dtypes,  # to escape timeout
 })
 )
-@testing.gpu
 class TestDistributionsNoncentralF(RandomDistributionsTestCase):
 
     @cupy.testing.for_dtypes_combination(
@@ -490,7 +471,6 @@ class TestDistributionsNoncentralF(RandomDistributionsTestCase):
     'scale_shape': [(), (3, 2)],
 })
 )
-@testing.gpu
 class TestDistributionsNormal(RandomDistributionsTestCase):
 
     @cupy.testing.for_float_dtypes('dtype', no_float16=True)
@@ -508,7 +488,6 @@ class TestDistributionsNormal(RandomDistributionsTestCase):
     'a_shape': [(), (3, 2)],
 })
 )
-@testing.gpu
 class TestDistributionsPareto:
 
     def check_distribution(self, dist_func, a_dtype, dtype):
@@ -530,7 +509,6 @@ class TestDistributionsPareto:
     'lam_shape': [(), (3, 2)],
 })
 )
-@testing.gpu
 class TestDistributionsPoisson:
 
     def check_distribution(self, dist_func, lam_dtype, dtype=None):
@@ -561,7 +539,6 @@ class TestDistributionsPoisson:
                                 lam_dtype)
 
 
-@testing.gpu
 class TestDistributionsPoissonInvalid:
 
     @pytest.mark.skipif(
@@ -583,7 +560,6 @@ class TestDistributionsPoissonInvalid:
     'a_shape': [()],
 })
 )
-@testing.gpu
 class TestDistributionsPower(RandomDistributionsTestCase):
 
     @cupy.testing.for_float_dtypes('dtype', no_float16=True)
@@ -607,7 +583,6 @@ class TestDistributionsPower(RandomDistributionsTestCase):
     'scale_shape': [(), (3, 2)],
 })
 )
-@testing.gpu
 class TestDistributionsRayleigh(RandomDistributionsTestCase):
 
     @cupy.testing.for_float_dtypes('dtype', no_float16=True)
@@ -637,7 +612,6 @@ class TestDistributionsRayleigh(RandomDistributionsTestCase):
     'shape': [(4, 3, 2), (3, 2)],
 })
 )
-@testing.gpu
 class TestDistributionsStandardCauchy(RandomDistributionsTestCase):
 
     @cupy.testing.for_float_dtypes('dtype', no_float16=True)
@@ -649,7 +623,6 @@ class TestDistributionsStandardCauchy(RandomDistributionsTestCase):
     'shape': [(4, 3, 2), (3, 2), None],
 })
 )
-@testing.gpu
 class TestDistributionsStandardExponential(RandomDistributionsTestCase):
 
     @cupy.testing.for_float_dtypes('dtype', no_float16=True)
@@ -662,7 +635,6 @@ class TestDistributionsStandardExponential(RandomDistributionsTestCase):
     'shape_shape': [(), (3, 2)],
 })
 )
-@testing.gpu
 class TestDistributionsStandardGamma(RandomDistributionsTestCase):
 
     @cupy.testing.for_float_dtypes('dtype', no_float16=True)
@@ -686,7 +658,6 @@ class TestDistributionsStandardGamma(RandomDistributionsTestCase):
                                           dtype)
 
 
-@testing.gpu
 class TestDistributionsStandardGammaInvalid(RandomDistributionsTestCase):
 
     @pytest.mark.skipif(
@@ -707,7 +678,6 @@ class TestDistributionsStandardGammaInvalid(RandomDistributionsTestCase):
     'shape': [(4, 3, 2), (3, 2), None],
 })
 )
-@testing.gpu
 class TestDistributionsStandardNormal(RandomDistributionsTestCase):
 
     @cupy.testing.for_float_dtypes('dtype', no_float16=True)
@@ -720,7 +690,6 @@ class TestDistributionsStandardNormal(RandomDistributionsTestCase):
     'df_shape': [(), (3, 2)],
 })
 )
-@testing.gpu
 class TestDistributionsStandardT:
 
     def check_distribution(self, dist_func, df_dtype, dtype):
@@ -743,7 +712,6 @@ class TestDistributionsStandardT:
     'dtype': _regular_float_dtypes,  # to escape timeout
 })
 )
-@testing.gpu
 class TestDistributionsTriangular(RandomDistributionsTestCase):
 
     @cupy.testing.for_dtypes_combination(
@@ -787,7 +755,6 @@ class TestDistributionsTriangular(RandomDistributionsTestCase):
     'high_shape': [(), (3, 2)],
 })
 )
-@testing.gpu
 class TestDistributionsUniform(RandomDistributionsTestCase):
 
     @cupy.testing.for_float_dtypes('dtype', no_float16=True)
@@ -807,7 +774,6 @@ class TestDistributionsUniform(RandomDistributionsTestCase):
     'dtype': _float_dtypes,  # to escape timeout
 })
 )
-@testing.gpu
 class TestDistributionsVonmises:
 
     def check_distribution(self, dist_func, mu_dtype, kappa_dtype, dtype):
@@ -831,7 +797,6 @@ class TestDistributionsVonmises:
     'dtype': _regular_float_dtypes,  # to escape timeout
 })
 )
-@testing.gpu
 class TestDistributionsWald(RandomDistributionsTestCase):
 
     @cupy.testing.for_dtypes_combination(
@@ -848,7 +813,6 @@ class TestDistributionsWald(RandomDistributionsTestCase):
     'a_shape': [(), (3, 2)],
 })
 )
-@testing.gpu
 class TestDistributionsWeibull(RandomDistributionsTestCase):
 
     @cupy.testing.for_float_dtypes('dtype', no_float16=True)
@@ -879,7 +843,6 @@ class TestDistributionsWeibull(RandomDistributionsTestCase):
     'a_shape': [(), (3, 2)],
 })
 )
-@testing.gpu
 class TestDistributionsZipf(RandomDistributionsTestCase):
 
     @cupy.testing.for_dtypes([numpy.int32, numpy.int64], 'dtype')

--- a/tests/cupy_tests/random_tests/test_generator.py
+++ b/tests/cupy_tests/random_tests/test_generator.py
@@ -11,7 +11,6 @@ from cupy import cuda
 from cupy.cuda import runtime
 from cupy.random import _generator
 from cupy import testing
-from cupy.testing import _attr
 from cupy.testing import _condition
 from cupy.testing import _hypothesis
 
@@ -281,7 +280,7 @@ class TestLogistic(RandomGeneratorTestCase):
     def test_logistic_2(self):
         self.generate(0.0, 1.0, size=(3, 2))
 
-    @_attr.slow
+    @testing.slow
     @_condition.repeat(10)
     def test_standard_logistic_isfinite(self):
         x = self.generate(size=10**7)
@@ -615,7 +614,7 @@ class TestStandardCauchy(RandomGeneratorTestCase):
     def test_standard_cauchy(self):
         self.generate(size=(3, 2))
 
-    @_attr.slow
+    @testing.slow
     @_condition.repeat(10)
     def test_standard_cauchy_isfinite(self):
         x = self.generate(size=10**7)

--- a/tests/cupy_tests/random_tests/test_generator.py
+++ b/tests/cupy_tests/random_tests/test_generator.py
@@ -90,7 +90,6 @@ def _xp_random(xp, method_name):
 
 
 @testing.fix_random()
-@testing.gpu
 class TestRandomState(unittest.TestCase):
 
     def setUp(self):
@@ -159,7 +158,6 @@ class TestRandomState(unittest.TestCase):
 
 @testing.parameterize(*common_distributions.beta_params)
 @testing.with_requires('numpy>=1.17.0')
-@testing.gpu
 @testing.fix_random()
 class TestBeta(
     common_distributions.Beta,
@@ -173,7 +171,6 @@ class TestBeta(
     {'n': 5, 'p': 0.0},
     {'n': 5, 'p': 1.0},
 )
-@testing.gpu
 @testing.fix_random()
 class TestBinomial(RandomGeneratorTestCase):
     # TODO(niboshi):
@@ -205,7 +202,6 @@ class TestDirichlet(
 
 
 @testing.parameterize(*common_distributions.exponential_params)
-@testing.gpu
 @testing.fix_random()
 class TestExponential(
     common_distributions.Exponential,
@@ -224,7 +220,6 @@ class TestF(
 
 
 @testing.parameterize(*common_distributions.gamma_params)
-@testing.gpu
 @testing.fix_random()
 class TestGamma(
     common_distributions.Gamma,
@@ -251,7 +246,6 @@ class TestHypergeometric(
     pass
 
 
-@testing.gpu
 @testing.fix_random()
 class TestLaplace(RandomGeneratorTestCase):
 
@@ -276,7 +270,6 @@ class TestLaplace(RandomGeneratorTestCase):
             2.3, 4.5, size=2000, dtype=dtype)
 
 
-@testing.gpu
 @testing.fix_random()
 class TestLogistic(RandomGeneratorTestCase):
 
@@ -307,7 +300,6 @@ class TestLogistic(RandomGeneratorTestCase):
             2.3, 4.5, size=2000, dtype=dtype)
 
 
-@testing.gpu
 @testing.parameterize(*[
     {'args': (0.0, 1.0), 'size': None},
     {'args': (10.0, 20.0), 'size': None},
@@ -358,7 +350,6 @@ class TestLogseries(
     pass
 
 
-@testing.gpu
 @testing.parameterize(*[
     {'args': ([0., 0.], [[1., 0.], [0., 1.]]), 'size': None, 'tol': 1e-6},
     {'args': ([10., 10.], [[20., 10.], [10., 20.]]),
@@ -397,7 +388,6 @@ class TestMultivariateNormal(RandomGeneratorTestCase):
 @testing.parameterize(
     {'n': 5, 'p': 0.5},
 )
-@testing.gpu
 @testing.fix_random()
 class TestNegativeBinomial(RandomGeneratorTestCase):
     target_method = 'negative_binomial'
@@ -412,7 +402,6 @@ class TestNegativeBinomial(RandomGeneratorTestCase):
     {'df': 1.5, 'nonc': 2.0},
     {'df': 2.0, 'nonc': 0.0},
 )
-@testing.gpu
 @testing.fix_random()
 class TestNoncentralChisquare(RandomGeneratorTestCase):
 
@@ -432,7 +421,6 @@ class TestNoncentralChisquare(RandomGeneratorTestCase):
     {'dfnum': 2.0, 'dfden': 3.0, 'nonc': 4.0},
     {'dfnum': 2.5, 'dfden': 1.5, 'nonc': 0.0},
 )
-@testing.gpu
 @testing.fix_random()
 class TestNoncentralF(RandomGeneratorTestCase):
 
@@ -449,7 +437,6 @@ class TestNoncentralF(RandomGeneratorTestCase):
             self.dfnum, self.dfden, self.nonc, size=2000, dtype=dtype)
 
 
-@testing.gpu
 @testing.parameterize(*[
     {'args': (0.0, 1.0), 'size': None},
     {'args': (10.0, 20.0), 'size': None},
@@ -492,7 +479,6 @@ class TestNormal(RandomGeneratorTestCase):
     {'a': 3.0},
     {'a': 10.0},
 )
-@testing.gpu
 @testing.fix_random()
 class TestPareto(RandomGeneratorTestCase):
 
@@ -509,7 +495,6 @@ class TestPareto(RandomGeneratorTestCase):
 
 
 @testing.parameterize(*common_distributions.poisson_params)
-@testing.gpu
 @testing.fix_random()
 class TestPoisson(
     common_distributions.Poisson,
@@ -523,7 +508,6 @@ class TestPoisson(
     {'df': 3.0},
     {'df': 10.0},
 )
-@testing.gpu
 @testing.fix_random()
 class TestStandardT(RandomGeneratorTestCase):
 
@@ -539,7 +523,6 @@ class TestStandardT(RandomGeneratorTestCase):
             df=self.df, size=2000, dtype=dtype)
 
 
-@testing.gpu
 @testing.parameterize(*[
     {'size': None},
     {'size': 10},
@@ -582,7 +565,6 @@ class TestRandomSampleDistrib(unittest.TestCase):
 
 
 @testing.fix_random()
-@testing.gpu
 class TestRandAndRandN(unittest.TestCase):
 
     def setUp(self):
@@ -610,7 +592,6 @@ class TestPower(
     {'scale': 1.0},
     {'scale': 3.0},
 )
-@testing.gpu
 @testing.fix_random()
 class TestRayleigh(RandomGeneratorTestCase):
 
@@ -626,7 +607,6 @@ class TestRayleigh(RandomGeneratorTestCase):
             scale=self.scale, size=2000, dtype=dtype)
 
 
-@testing.gpu
 @testing.fix_random()
 class TestStandardCauchy(RandomGeneratorTestCase):
 
@@ -649,7 +629,6 @@ class TestStandardCauchy(RandomGeneratorTestCase):
 
 
 @testing.parameterize(*common_distributions.standard_gamma_params)
-@testing.gpu
 @testing.fix_random()
 class TestStandardGamma(
     common_distributions.StandardGamma,
@@ -659,7 +638,6 @@ class TestStandardGamma(
 
 
 @testing.fix_random()
-@testing.gpu
 class TestInterval(RandomGeneratorTestCase):
 
     target_method = '_interval'
@@ -746,7 +724,6 @@ class TestInterval(RandomGeneratorTestCase):
 
 
 @testing.fix_random()
-@testing.gpu
 class TestTomaxint(RandomGeneratorTestCase):
 
     target_method = 'tomaxint'
@@ -781,7 +758,6 @@ class TestTomaxint(RandomGeneratorTestCase):
     {'a': numpy.array([]), 'size': 0, 'p': None},
 )
 @testing.fix_random()
-@testing.gpu
 class TestChoice1(RandomGeneratorTestCase):
 
     target_method = 'choice'
@@ -817,7 +793,6 @@ class TestChoice1(RandomGeneratorTestCase):
     {'a': [0, 1, 2], 'size': 2, 'p': [0.3, 0.3, 0.4]},
 )
 @testing.fix_random()
-@testing.gpu
 class TestChoice2(RandomGeneratorTestCase):
 
     target_method = 'choice'
@@ -848,7 +823,6 @@ class TestChoice2(RandomGeneratorTestCase):
 
 
 @testing.fix_random()
-@testing.gpu
 class TestChoiceChi(RandomGeneratorTestCase):
 
     target_method = 'choice'
@@ -872,7 +846,6 @@ class TestChoiceChi(RandomGeneratorTestCase):
 
 
 @testing.fix_random()
-@testing.gpu
 class TestChoiceMultinomial(unittest.TestCase):
 
     @_condition.repeat(3, 10)
@@ -899,7 +872,6 @@ class TestChoiceMultinomial(unittest.TestCase):
     {'a': 3, 'size': 1, 'p': [0.1, 0.1, 0.7]},
 )
 @testing.fix_random()
-@testing.gpu
 class TestChoiceFailure(unittest.TestCase):
 
     def setUp(self):
@@ -917,7 +889,6 @@ class TestChoiceFailure(unittest.TestCase):
     {'a': numpy.array([0.0, 2.0, 4.0]), 'size': 2},
 )
 @testing.fix_random()
-@testing.gpu
 class TestChoiceReplaceFalse(RandomGeneratorTestCase):
 
     target_method = 'choice'
@@ -946,7 +917,6 @@ class TestChoiceReplaceFalse(RandomGeneratorTestCase):
         assert numpy.unique(val).size == val.size
 
 
-@testing.gpu
 @testing.fix_random()
 class TestGumbel(RandomGeneratorTestCase):
 
@@ -971,7 +941,6 @@ class TestGumbel(RandomGeneratorTestCase):
             2.3, 4.5, size=2000, dtype=dtype)
 
 
-@testing.gpu
 @testing.fix_random()
 class TestRandint(RandomGeneratorTestCase):
     # TODO(niboshi):
@@ -1008,7 +977,6 @@ class TestRandint(RandomGeneratorTestCase):
         self.generate([[[-1], [0]], [[-2], [1]], [[3], [4]]], [[10, 11, 12]])
 
 
-@testing.gpu
 @testing.fix_random()
 class TestUniform(RandomGeneratorTestCase):
 
@@ -1041,7 +1009,6 @@ class TestUniform(RandomGeneratorTestCase):
     {'mu': 3.0, 'kappa': 3.0},
     {'mu': 3.0, 'kappa': 1.0},
 )
-@testing.gpu
 @testing.fix_random()
 class TestVonmises(RandomGeneratorTestCase):
 
@@ -1062,7 +1029,6 @@ class TestVonmises(RandomGeneratorTestCase):
     {'mean': 3.0, 'scale': 3.0},
     {'mean': 3.0, 'scale': 1.0},
 )
-@testing.gpu
 @testing.fix_random()
 class TestWald(RandomGeneratorTestCase):
 
@@ -1084,7 +1050,6 @@ class TestWald(RandomGeneratorTestCase):
     {'a': 3.0},
     {'a': numpy.inf},
 )
-@testing.gpu
 @testing.fix_random()
 class TestWeibull(RandomGeneratorTestCase):
 
@@ -1106,7 +1071,6 @@ class TestWeibull(RandomGeneratorTestCase):
 @testing.parameterize(
     {'a': 2.0},
 )
-@testing.gpu
 @testing.fix_random()
 class TestZipf(RandomGeneratorTestCase):
 
@@ -1123,7 +1087,6 @@ class TestZipf(RandomGeneratorTestCase):
     {'a': [1, 2, 3], 'size': 5},
 )
 @testing.fix_random()
-@testing.gpu
 class TestChoiceReplaceFalseFailure(unittest.TestCase):
 
     def test_choice_invalid_value(self):
@@ -1141,7 +1104,6 @@ class TestResetStates(unittest.TestCase):
         assert {} == _generator._random_states
 
 
-@testing.gpu
 class TestGetRandomState(unittest.TestCase):
 
     def setUp(self):
@@ -1165,7 +1127,6 @@ class TestGetRandomState(unittest.TestCase):
         assert 'expected' == rs
 
 
-@testing.gpu
 class TestSetRandomState(unittest.TestCase):
 
     def setUp(self):
@@ -1186,7 +1147,6 @@ class TestSetRandomState(unittest.TestCase):
         assert _generator.get_random_state() is rs
 
 
-@testing.gpu
 @testing.fix_random()
 class TestStandardExponential(
     common_distributions.StandardExponential,
@@ -1198,7 +1158,6 @@ class TestStandardExponential(
 @testing.parameterize(
     {'left': -1.0, 'mode': 0.0, 'right': 2.0},
 )
-@testing.gpu
 @testing.fix_random()
 class TestTriangular(RandomGeneratorTestCase):
 
@@ -1209,7 +1168,6 @@ class TestTriangular(RandomGeneratorTestCase):
             left=self.left, mode=self.mode, right=self.right, size=(3, 2))
 
 
-@testing.gpu
 class TestRandomStateThreadSafe(unittest.TestCase):
 
     def setUp(self):
@@ -1269,7 +1227,6 @@ class TestRandomStateThreadSafe(unittest.TestCase):
         assert cupy.random.get_random_state() is rs
 
 
-@testing.gpu
 class TestGetRandomState2(unittest.TestCase):
 
     def setUp(self):

--- a/tests/cupy_tests/random_tests/test_generator_api.py
+++ b/tests/cupy_tests/random_tests/test_generator_api.py
@@ -60,7 +60,6 @@ class InvalidOutsMixin:
 
 @testing.parameterize(*common_distributions.uniform_params)
 @testing.with_requires('numpy>=1.17.0')
-@testing.gpu
 @testing.fix_random()
 class TestUniform(
     common_distributions.Uniform,
@@ -71,7 +70,6 @@ class TestUniform(
 
 @testing.parameterize(*common_distributions.exponential_params)
 @testing.with_requires('numpy>=1.17.0')
-@testing.gpu
 @testing.fix_random()
 class TestExponential(
     common_distributions.Exponential,
@@ -82,7 +80,6 @@ class TestExponential(
 
 @testing.parameterize(*common_distributions.poisson_params)
 @testing.with_requires('numpy>=1.17.0')
-@testing.gpu
 @testing.fix_random()
 class TestPoisson(
     common_distributions.Poisson,
@@ -103,7 +100,6 @@ class TestBinomial(
 
 @testing.parameterize(*common_distributions.beta_params)
 @testing.with_requires('numpy>=1.17.0')
-@testing.gpu
 @testing.fix_random()
 class TestBeta(
     common_distributions.Beta,
@@ -113,7 +109,6 @@ class TestBeta(
 
 
 @testing.with_requires('numpy>=1.17.0')
-@testing.gpu
 @testing.fix_random()
 class TestStandardExponential(
     InvalidOutsMixin,
@@ -124,7 +119,6 @@ class TestStandardExponential(
 
 
 @testing.parameterize(*common_distributions.gamma_params)
-@testing.gpu
 @testing.fix_random()
 class TestGamma(
     common_distributions.Gamma,
@@ -134,7 +128,6 @@ class TestGamma(
 
 
 @testing.parameterize(*common_distributions.standard_gamma_params)
-@testing.gpu
 @testing.fix_random()
 class TestStandardGamma(
     common_distributions.StandardGamma,
@@ -143,7 +136,6 @@ class TestStandardGamma(
     pass
 
 
-@testing.gpu
 @testing.fix_random()
 class TestStandardGammaInvalid(InvalidOutsMixin, GeneratorTestCase):
 
@@ -168,7 +160,6 @@ class TestStandardGammaInvalid(InvalidOutsMixin, GeneratorTestCase):
                 self.generate(size=(3, 2), shape=1.0, dtype=dtype)
 
 
-@testing.gpu
 @testing.fix_random()
 class TestStandardGammaEmpty(GeneratorTestCase):
 
@@ -190,7 +181,6 @@ class TestStandardGammaEmpty(GeneratorTestCase):
 
 
 @testing.with_requires('numpy>=1.17.0')
-@testing.gpu
 @testing.parameterize(*common_distributions.standard_normal_params)
 @testing.fix_random()
 class TestStandardNormal(
@@ -201,7 +191,6 @@ class TestStandardNormal(
 
 
 @testing.with_requires('numpy>=1.17.0')
-@testing.gpu
 @testing.fix_random()
 class TestStandardNormalInvalid(InvalidOutsMixin, GeneratorTestCase):
 
@@ -214,7 +203,6 @@ class TestStandardNormalInvalid(InvalidOutsMixin, GeneratorTestCase):
 
 
 @testing.with_requires('numpy>=1.17.0')
-@testing.gpu
 @testing.fix_random()
 class TestIntegers(GeneratorTestCase):
     target_method = 'integers'
@@ -265,7 +253,6 @@ class TestIntegers(GeneratorTestCase):
 
 
 @testing.with_requires('numpy>=1.17.0')
-@testing.gpu
 @testing.fix_random()
 class TestRandom(InvalidOutsMixin, GeneratorTestCase):
     # TODO(niboshi):
@@ -313,7 +300,6 @@ class TestPower(
 
 
 @testing.with_requires('numpy>=1.17.0')
-@testing.gpu
 @pytest.mark.skipif(cupy.cuda.runtime.is_hip
                     and (int(
                         str(cupy.cuda.runtime.runtimeGetVersion())[:3]) < 403),

--- a/tests/cupy_tests/random_tests/test_permutations.py
+++ b/tests/cupy_tests/random_tests/test_permutations.py
@@ -12,7 +12,6 @@ from cupy.testing import _condition
     {'seed': None},
     {'seed': 0},
 )
-@testing.gpu
 class TestPermutations(unittest.TestCase):
 
     def _xp_random(self, xp):
@@ -71,7 +70,6 @@ class TestPermutations(unittest.TestCase):
         testing.assert_allclose(pa, pb)
 
 
-@testing.gpu
 class TestShuffle(unittest.TestCase):
 
     # Test ranks
@@ -114,7 +112,6 @@ class TestShuffle(unittest.TestCase):
 @testing.parameterize(*(testing.product({
     'num': [0, 1, 100, 1000, 10000, 100000],
 })))
-@testing.gpu
 class TestPermutationSoundness(unittest.TestCase):
 
     def setUp(self):
@@ -133,7 +130,6 @@ class TestPermutationSoundness(unittest.TestCase):
     'gap': [1, 2, 3, 5, 7],
     'mask': [1, 2, 4, 8, 16, 32, 64, 128],
 })))
-@testing.gpu
 class TestPermutationRandomness(unittest.TestCase):
 
     num = 256

--- a/tests/cupy_tests/random_tests/test_random.py
+++ b/tests/cupy_tests/random_tests/test_random.py
@@ -4,7 +4,6 @@ from cupy import random
 from cupy import testing
 
 
-@testing.gpu
 class TestResetSeed(unittest.TestCase):
 
     @testing.for_float_dtypes(no_float16=True)

--- a/tests/cupy_tests/random_tests/test_sample.py
+++ b/tests/cupy_tests/random_tests/test_sample.py
@@ -13,7 +13,6 @@ from cupy.testing import _condition
 from cupy.testing import _hypothesis
 
 
-@testing.gpu
 class TestRandint(unittest.TestCase):
 
     def test_lo_hi_reversed(self):
@@ -44,7 +43,6 @@ class TestRandint(unittest.TestCase):
 
 
 @testing.fix_random()
-@testing.gpu
 class TestRandint2(unittest.TestCase):
 
     @_condition.repeat(3, 10)
@@ -109,7 +107,6 @@ class TestRandint2(unittest.TestCase):
         assert _hypothesis.chi_square_test(counts, expected)
 
 
-@testing.gpu
 class TestRandintDtype(unittest.TestCase):
 
     @testing.for_dtypes([
@@ -147,7 +144,6 @@ class TestRandintDtype(unittest.TestCase):
             random.randint(iinfo.max - 10, iinfo.max + 2, size, dtype)
 
 
-@testing.gpu
 class TestRandomIntegers(unittest.TestCase):
 
     def test_normal(self):
@@ -167,7 +163,6 @@ class TestRandomIntegers(unittest.TestCase):
 
 
 @testing.fix_random()
-@testing.gpu
 class TestRandomIntegers2(unittest.TestCase):
 
     @_condition.repeat(3, 10)
@@ -205,7 +200,6 @@ class TestRandomIntegers2(unittest.TestCase):
         assert _hypothesis.chi_square_test(counts, expected)
 
 
-@testing.gpu
 class TestChoice(unittest.TestCase):
 
     def setUp(self):
@@ -251,7 +245,6 @@ class TestChoice(unittest.TestCase):
         self.m.choice.assert_called_with(3, 1, True, [0.1, 0.1, 0.8])
 
 
-@testing.gpu
 class TestRandomSample(unittest.TestCase):
 
     def test_rand(self):
@@ -295,7 +288,6 @@ class TestRandomSample(unittest.TestCase):
     {'size': (1, 0)},
 )
 @testing.fix_random()
-@testing.gpu
 class TestMultinomial(unittest.TestCase):
 
     @_condition.repeat(3, 10)

--- a/tests/cupy_tests/sorting_tests/test_count.py
+++ b/tests/cupy_tests/sorting_tests/test_count.py
@@ -6,7 +6,6 @@ import cupy
 from cupy import testing
 
 
-@testing.gpu
 class TestCount(unittest.TestCase):
 
     @testing.for_all_dtypes()

--- a/tests/cupy_tests/sorting_tests/test_search.py
+++ b/tests/cupy_tests/sorting_tests/test_search.py
@@ -7,7 +7,6 @@ from cupy._core import _cub_reduction
 from cupy import testing
 
 
-@testing.gpu
 class TestSearch:
 
     @testing.for_all_dtypes(no_complex=True)
@@ -173,7 +172,6 @@ def _skip_cuda90(dtype):
     'order_and_axis': (('C', -1), ('C', None), ('F', 0), ('F', None)),
     'backend': ('device', 'block'),
 }))
-@testing.gpu
 @pytest.mark.skipif(
     not cupy.cuda.cub.available, reason='The CUB routine is not enabled')
 class TestCubReduction:
@@ -266,7 +264,6 @@ class TestCubReduction:
         return a.argmax(axis=self.axis)
 
 
-@testing.gpu
 @testing.parameterize(*testing.product({
     'func': ['argmin', 'argmax'],
     'is_module': [True, False],
@@ -296,7 +293,6 @@ class TestArgMinMaxDtype:
     {'cond_shape': (2, 3, 4), 'x_shape': (2, 3, 4), 'y_shape': (3, 4)},
     {'cond_shape': (3, 4),    'x_shape': (2, 3, 4), 'y_shape': (4,)},
 )
-@testing.gpu
 class TestWhereTwoArrays:
 
     @testing.for_all_dtypes_combination(
@@ -318,7 +314,6 @@ class TestWhereTwoArrays:
     {'cond_shape': (2, 3, 4)},
     {'cond_shape': (3, 4)},
 )
-@testing.gpu
 class TestWhereCond:
 
     @testing.for_all_dtypes()
@@ -329,7 +324,6 @@ class TestWhereCond:
         return xp.where(cond)
 
 
-@testing.gpu
 class TestWhereError:
 
     def test_one_argument(self):
@@ -348,7 +342,6 @@ class TestWhereError:
     {'array': numpy.empty((0, 2, 0))},
     _ids=False,  # Do not generate ids from randomly generated params
 )
-@testing.gpu
 class TestNonzero:
 
     @testing.for_all_dtypes()
@@ -362,7 +355,6 @@ class TestNonzero:
     {'array': numpy.array(0)},
     {'array': numpy.array(1)},
 )
-@testing.gpu
 @testing.with_requires('numpy>=1.17.0')
 class TestNonzeroZeroDimension:
 
@@ -384,7 +376,6 @@ class TestNonzeroZeroDimension:
     {'array': numpy.empty((0, 2, 0))},
     _ids=False,  # Do not generate ids from randomly generated params
 )
-@testing.gpu
 class TestFlatNonzero:
 
     @testing.for_all_dtypes()
@@ -402,7 +393,6 @@ class TestFlatNonzero:
     {'array': numpy.empty((0, 2, 0))},
     _ids=False,  # Do not generate ids from randomly generated params
 )
-@testing.gpu
 class TestArgwhere:
 
     @testing.for_all_dtypes()
@@ -416,7 +406,6 @@ class TestArgwhere:
     {'value': 0},
     {'value': 3},
 )
-@testing.gpu
 @testing.with_requires('numpy>=1.18')
 class TestArgwhereZeroDimension:
 
@@ -427,7 +416,6 @@ class TestArgwhereZeroDimension:
         return xp.argwhere(array)
 
 
-@testing.gpu
 class TestNanArgMin:
 
     @testing.for_all_dtypes(no_complex=True)
@@ -519,7 +507,6 @@ class TestNanArgMin:
         return xp.nanargmin(a, axis=1)
 
 
-@testing.gpu
 class TestNanArgMax:
 
     @testing.for_all_dtypes(no_complex=True)
@@ -611,7 +598,6 @@ class TestNanArgMax:
         return xp.nanargmax(a, axis=1)
 
 
-@testing.gpu
 @testing.parameterize(*testing.product(
     {'bins': [
         [],
@@ -648,7 +634,6 @@ class TestSearchSorted:
         return y,
 
 
-@testing.gpu
 @testing.parameterize(
     {'side': 'left'},
     {'side': 'right'})
@@ -711,7 +696,6 @@ class TestSearchSortedNanInf:
         return y,
 
 
-@testing.gpu
 class TestSearchSortedInvalid:
 
     # Cant test unordered bins due to numpy undefined
@@ -732,7 +716,6 @@ class TestSearchSortedInvalid:
                 bins.searchsorted(x)
 
 
-@testing.gpu
 class TestSearchSortedWithSorter:
 
     @testing.numpy_cupy_array_equal()

--- a/tests/cupy_tests/sorting_tests/test_sort.py
+++ b/tests/cupy_tests/sorting_tests/test_sort.py
@@ -7,7 +7,6 @@ import cupy
 from cupy import testing
 
 
-@testing.gpu
 class TestSort(unittest.TestCase):
 
     # Test ranks
@@ -201,7 +200,6 @@ class TestSort(unittest.TestCase):
         return xp.sort(a, axis=-1)
 
 
-@testing.gpu
 class TestLexsort(unittest.TestCase):
 
     # Test ranks
@@ -282,7 +280,6 @@ class TestLexsort(unittest.TestCase):
 @testing.parameterize(*testing.product({
     'external': [False, True],
 }))
-@testing.gpu
 class TestArgsort(unittest.TestCase):
 
     def argsort(self, a, axis=-1):
@@ -422,7 +419,6 @@ class TestMsort(unittest.TestCase):
         return xp.msort(a)
 
 
-@testing.gpu
 class TestSort_complex(unittest.TestCase):
 
     def test_sort_complex_zero_dim(self):
@@ -455,7 +451,6 @@ class TestSort_complex(unittest.TestCase):
     'external': [False, True],
     'length': [10, 20000],
 }))
-@testing.gpu
 class TestPartition(unittest.TestCase):
 
     def partition(self, a, kth, axis=-1):
@@ -605,7 +600,6 @@ class TestPartition(unittest.TestCase):
 @testing.parameterize(*testing.product({
     'external': [False, True],
 }))
-@testing.gpu
 class TestArgpartition(unittest.TestCase):
 
     def argpartition(self, a, kth, axis=-1):

--- a/tests/cupy_tests/statistics_tests/test_correlation.py
+++ b/tests/cupy_tests/statistics_tests/test_correlation.py
@@ -7,7 +7,6 @@ import cupy
 from cupy import testing
 
 
-@testing.gpu
 class TestCorrcoef(unittest.TestCase):
 
     @testing.for_all_dtypes()
@@ -45,7 +44,6 @@ class TestCorrcoef(unittest.TestCase):
         return xp.corrcoef(a, y=y, dtype=dtype)
 
 
-@testing.gpu
 class TestCov(unittest.TestCase):
 
     def generate_input(self, a_shape, y_shape, xp, dtype):
@@ -116,7 +114,6 @@ class TestCov(unittest.TestCase):
         self.check((0, 1))
 
 
-@testing.gpu
 @testing.parameterize(*testing.product({
     'mode': ['valid', 'same', 'full'],
     'shape1': [(5,), (6,), (20,), (21,)],
@@ -157,7 +154,6 @@ class TestCorrelate:
         return xp.correlate(a, b, mode=mode)
 
 
-@testing.gpu
 @testing.parameterize(*testing.product({
     'mode': ['valid', 'same', 'full']
 }))

--- a/tests/cupy_tests/statistics_tests/test_histogram.py
+++ b/tests/cupy_tests/statistics_tests/test_histogram.py
@@ -38,7 +38,6 @@ def for_all_dtypes_combination_bincount(names):
     return testing.for_dtypes_combination(_all_types, names=names)
 
 
-@testing.gpu
 class TestHistogram(unittest.TestCase):
 
     @testing.for_all_dtypes(no_bool=True, no_complex=True)
@@ -435,7 +434,6 @@ class TestDigitize:
         return y,
 
 
-@testing.gpu
 @testing.parameterize(
     {'right': True},
     {'right': False})
@@ -509,7 +507,6 @@ class TestDigitizeNanInf(unittest.TestCase):
         return y,
 
 
-@testing.gpu
 class TestDigitizeInvalid(unittest.TestCase):
 
     def test_digitize_complex(self):
@@ -537,7 +534,6 @@ class TestDigitizeInvalid(unittest.TestCase):
          'range': [None, ((20, 50), (10, 100), (0, 40))]}
     )
 )
-@testing.gpu
 class TestHistogramdd:
 
     @testing.for_all_dtypes(no_bool=True, no_complex=True)
@@ -559,7 +555,6 @@ class TestHistogramdd:
         return [y, ] + [e for e in bin_edges]
 
 
-@testing.gpu
 class TestHistogramddErrors(unittest.TestCase):
 
     def test_histogramdd_invalid_bins(self):
@@ -613,7 +608,6 @@ class TestHistogramddErrors(unittest.TestCase):
          'range': [None, ((20, 50), (10, 100))]}
     )
 )
-@testing.gpu
 class TestHistogram2d:
 
     @testing.for_all_dtypes(no_bool=True, no_complex=True)
@@ -637,7 +631,6 @@ class TestHistogram2d:
         return y, edges0, edges1
 
 
-@testing.gpu
 class TestHistogram2dErrors(unittest.TestCase):
 
     def test_histogram2d_disallow_arraylike_bins(self):

--- a/tests/cupy_tests/statistics_tests/test_meanvar.py
+++ b/tests/cupy_tests/statistics_tests/test_meanvar.py
@@ -10,7 +10,6 @@ ignore_runtime_warnings = pytest.mark.filterwarnings(
     "ignore", category=RuntimeWarning)
 
 
-@testing.gpu
 class TestMedian:
 
     @testing.for_all_dtypes()
@@ -83,7 +82,6 @@ class TestMedian:
         'keepdims': [True, False]
     })
 )
-@testing.gpu
 class TestMedianAxis:
 
     @testing.for_all_dtypes()
@@ -101,7 +99,6 @@ class TestMedianAxis:
         'overwrite_input': [True, False]
     })
 )
-@testing.gpu
 class TestNanMedian:
 
     zero_density = 0.25
@@ -135,7 +132,6 @@ class TestNanMedian:
         return xp.ascontiguousarray(out)
 
 
-@testing.gpu
 class TestAverage:
 
     _multiprocess_can_split_ = True
@@ -191,7 +187,6 @@ class TestAverage:
         return xp.average(a, weights=w, returned=returned, keepdims=True)
 
 
-@testing.gpu
 class TestMeanVar:
 
     @testing.for_all_dtypes()
@@ -340,7 +335,6 @@ class TestMeanVar:
         'keepdims': [True, False]
     })
 )
-@testing.gpu
 class TestNanMean:
 
     @testing.for_all_dtypes(no_float16=True)
@@ -362,7 +356,6 @@ class TestNanMean:
         return xp.nanmean(a, axis=self.axis, keepdims=self.keepdims)
 
 
-@testing.gpu
 class TestNanMeanAdditional:
 
     @ignore_runtime_warnings
@@ -510,7 +503,6 @@ class TestNanVarStdAdditional:
     ],
     'func': ['mean', 'std', 'var'],
 }))
-@testing.gpu
 class TestProductZeroLength:
 
     @testing.for_all_dtypes(no_complex=True)

--- a/tests/cupy_tests/test_cublas.py
+++ b/tests/cupy_tests/test_cublas.py
@@ -4,7 +4,6 @@ import pytest
 import cupy
 from cupy import cublas
 from cupy import testing
-from cupy.testing import _attr
 
 
 @testing.parameterize(*testing.product({
@@ -13,7 +12,6 @@ from cupy.testing import _attr
     'bs': [None, 1, 10],
     'nrhs': [None, 1, 10],
 }))
-@_attr.gpu
 class TestBatchedGesv:
     _tol = {'f': 5e-5, 'd': 1e-12}
 
@@ -70,7 +68,6 @@ class TestBatchedGesv:
     'n': [10, 100],
     'mode': [None, numpy, cupy],
 }))
-@_attr.gpu
 class TestLevel1Functions:
     _tol = {'f': 1e-5, 'd': 1e-12}
 
@@ -194,7 +191,6 @@ class TestLevel1Functions:
     'order': ['C', 'F'],
     'mode': [None, numpy, cupy],
 }))
-@_attr.gpu
 class TestGemv:
     _tol = {'f': 1e-5, 'd': 1e-12}
 
@@ -237,7 +233,6 @@ class TestGemv:
     'order': ['C', 'F'],
     'mode': [None, numpy, cupy],
 }))
-@_attr.gpu
 class TestSbmv:
     _tol = {'f': 1e-5, 'd': 1e-12}
 
@@ -287,7 +282,6 @@ class TestSbmv:
     'order': ['C', 'F'],
     'mode': [None, numpy, cupy],
 }))
-@_attr.gpu
 class TestGer:
     _tol = {'f': 1e-5, 'd': 1e-12}
 
@@ -339,7 +333,6 @@ class TestGer:
     'lower': [0, 1],
     'mode': [None, numpy, cupy]
 }))
-@_attr.gpu
 class TestSyrk:
     _tol = {'f': 1e-5, 'd': 1e-12}
 
@@ -422,7 +415,6 @@ class TestSyrk:
     'orderc': ['C', 'F'],
     'mode': [None, numpy, cupy],
 }))
-@_attr.gpu
 class TestGemmAndGeam:
     _tol = {'f': 1e-5, 'd': 1e-12}
 
@@ -531,7 +523,6 @@ class TestGemmAndGeam:
     'ordera': ['C', 'F'],
     'orderc': ['C', 'F'],
 }))
-@_attr.gpu
 class TestDgmm:
     _tol = {'f': 1e-5, 'd': 1e-12}
 

--- a/tests/cupy_tests/test_init.py
+++ b/tests/cupy_tests/test_init.py
@@ -11,7 +11,6 @@ import numpy
 import pytest
 
 import cupy
-from cupy import testing
 import cupyx
 
 

--- a/tests/cupy_tests/test_init.py
+++ b/tests/cupy_tests/test_init.py
@@ -63,7 +63,6 @@ else:
 
 class TestAvailable(unittest.TestCase):
 
-    @testing.gpu
     def test_available(self):
         available = _test_cupy_available(self)
         assert available

--- a/tests/cupy_tests/test_ndim.py
+++ b/tests/cupy_tests/test_ndim.py
@@ -5,7 +5,6 @@ import cupy
 from cupy import testing
 
 
-@testing.gpu
 class TestNdim(unittest.TestCase):
 
     @testing.numpy_cupy_equal()

--- a/tests/cupy_tests/test_numpy_interop.py
+++ b/tests/cupy_tests/test_numpy_interop.py
@@ -14,7 +14,6 @@ except ImportError:
     scipy_available = False
 
 
-@testing.gpu
 class TestGetArrayModule(unittest.TestCase):
 
     def test_get_array_module_1(self):
@@ -59,7 +58,6 @@ class MockArray(numpy.lib.mixins.NDArrayOperatorsMixin):
         return name, inputs, kwargs
 
 
-@testing.gpu
 class TestArrayUfunc:
 
     def test_add(self):
@@ -115,7 +113,6 @@ class MockArray2:
         return 'gt'
 
 
-@testing.gpu
 class TestArrayUfuncOptout:
 
     def test_add(self):
@@ -137,7 +134,6 @@ class TestArrayUfuncOptout:
         assert (y < x) == 'lt'
 
 
-@testing.gpu
 class TestAsnumpy:
 
     def test_asnumpy(self):

--- a/tests/cupy_tests/testing_tests/test_array.py
+++ b/tests/cupy_tests/testing_tests/test_array.py
@@ -16,7 +16,6 @@ from cupy import testing
         'array_module_y': [numpy, cupy]
     })
 )
-@testing.gpu
 class TestEqualityAssertion(unittest.TestCase):
 
     def setUp(self):
@@ -55,7 +54,6 @@ def _convert_array(xs, array_module):
         'array_module_y': ['all_numpy', 'all_cupy', 'random']
     })
 )
-@testing.gpu
 class TestListEqualityAssertion(unittest.TestCase):
 
     def setUp(self):
@@ -80,7 +78,6 @@ class TestListEqualityAssertion(unittest.TestCase):
         'array_module_y': [numpy, cupy]
     })
 )
-@testing.gpu
 class TestStridesEqualityAssertion(unittest.TestCase):
 
     def setUp(self):
@@ -103,7 +100,6 @@ class TestStridesEqualityAssertion(unittest.TestCase):
         'array_module_y': [numpy, cupy]
     })
 )
-@testing.gpu
 class TestLessAssertion(unittest.TestCase):
 
     def setUp(self):

--- a/tests/cupy_tests/testing_tests/test_helper.py
+++ b/tests/cupy_tests/testing_tests/test_helper.py
@@ -28,7 +28,6 @@ class TestPackageRequirements:
     'xp': [numpy, cupy],
     'shape': [(3, 2), (), (3, 0, 2)],
 }))
-@testing.gpu
 class TestShapedRandom(unittest.TestCase):
 
     @testing.for_all_dtypes()
@@ -58,7 +57,6 @@ class TestShapedRandom(unittest.TestCase):
 @testing.parameterize(*testing.product({
     'xp': [numpy, cupy],
 }))
-@testing.gpu
 class TestShapedRandomBool(unittest.TestCase):
 
     def test_bool(self):

--- a/tests/cupy_tests/testing_tests/test_loops.py
+++ b/tests/cupy_tests/testing_tests/test_loops.py
@@ -247,7 +247,6 @@ def cupy_error(_, xp):
         raise ValueError()
 
 
-@testing.gpu
 class NumPyCuPyDecoratorBase2(object):
 
     def test_accept_error_numpy(self):
@@ -293,7 +292,6 @@ class TestNumPyCuPyEqual(unittest.TestCase, NumPyCuPyDecoratorBase,
 @testing.parameterize(
     {'decorator': 'numpy_cupy_array_equal'}
 )
-@testing.gpu
 class TestNumPyCuPyListEqual(unittest.TestCase, NumPyCuPyDecoratorBase):
 
     def valid_func(self, xp):

--- a/tests/cupyx_tests/fallback_mode_tests/test_fallback.py
+++ b/tests/cupyx_tests/fallback_mode_tests/test_fallback.py
@@ -132,7 +132,6 @@ def get_numpy_version():
 
 
 @ignore_fallback_warnings
-@testing.gpu
 class TestFallbackMode(unittest.TestCase):
 
     def test_module_not_callable(self):
@@ -192,7 +191,6 @@ class TestFallbackMode(unittest.TestCase):
      'kwargs': {'dtype': numpy.float64}}
 )
 @ignore_fallback_warnings
-@testing.gpu
 class TestFallbackMethodsArrayExternal(unittest.TestCase):
 
     @numpy_fallback_array_equal()
@@ -217,7 +215,6 @@ class TestFallbackMethodsArrayExternal(unittest.TestCase):
      'kwargs': {'axis': 0}, 'numpy_version': None}
 )
 @ignore_fallback_warnings
-@testing.gpu
 class TestFallbackMethodsArrayExternalOut(unittest.TestCase):
 
     @numpy_fallback_array_equal()
@@ -242,7 +239,6 @@ class TestFallbackMethodsArrayExternalOut(unittest.TestCase):
     {'object': 'vectorize'},
     {'object': 'linalg.eig'},
 )
-@testing.gpu
 class TestDocs(unittest.TestCase):
 
     @numpy_fallback_equal()
@@ -250,7 +246,6 @@ class TestDocs(unittest.TestCase):
         return operator.attrgetter(self.object)(xp).__doc__
 
 
-@testing.gpu
 class TestFallbackArray(unittest.TestCase):
 
     def test_ndarray_creation_compatible(self):
@@ -362,7 +357,6 @@ class TestFallbackArray(unittest.TestCase):
     {'func': 'compress', 'shape': (3, 2), 'args': ([False, True],),
      'kwargs': {'axis': 0}}
 )
-@testing.gpu
 class TestFallbackArrayMethodsInternal(unittest.TestCase):
 
     @numpy_fallback_array_equal()
@@ -393,7 +387,6 @@ class TestFallbackArrayMethodsInternal(unittest.TestCase):
     {'func': '__ge__', 'shape': (1, 2)},
     {'func': '__le__', 'shape': (1,)}
 )
-@testing.gpu
 class TestArrayComparison(unittest.TestCase):
 
     @numpy_fallback_array_equal()
@@ -413,7 +406,6 @@ class TestArrayComparison(unittest.TestCase):
     {'func': '__len__', 'shape': (3, 3)},
     {'func': '__bool__', 'shape': (1,)},
 )
-@testing.gpu
 class TestArrayUnaryMethods(unittest.TestCase):
 
     @numpy_fallback_equal()
@@ -428,7 +420,6 @@ class TestArrayUnaryMethods(unittest.TestCase):
     {'func': '__neg__', 'shape': (3, 3), 'dtype': numpy.float32},
     {'func': '__invert__', 'shape': (2, 4), 'dtype': numpy.int32}
 )
-@testing.gpu
 class TestArrayUnaryMethodsArray(unittest.TestCase):
 
     @numpy_fallback_array_equal()
@@ -452,7 +443,6 @@ class TestArrayUnaryMethodsArray(unittest.TestCase):
     {'func': '__lshift__', 'shape': (2,), 'dtype': numpy.int32},
     {'func': '__irshift__', 'shape': (3, 2), 'dtype': numpy.int32},
 )
-@testing.gpu
 class TestArrayArithmeticMethods(unittest.TestCase):
 
     @numpy_fallback_array_allclose(rtol=1e-6)
@@ -462,7 +452,6 @@ class TestArrayArithmeticMethods(unittest.TestCase):
         return getattr(a, self.func)(b)
 
 
-@testing.gpu
 class TestArrayMatmul(unittest.TestCase):
 
     @testing.with_requires('numpy>=1.16')
@@ -474,7 +463,6 @@ class TestArrayMatmul(unittest.TestCase):
         return a.__matmul__(b)
 
 
-@testing.gpu
 class TestVectorizeWrapper(unittest.TestCase):
 
     @numpy_fallback_array_equal()
@@ -518,7 +506,6 @@ class TestVectorizeWrapper(unittest.TestCase):
 
 
 @ignore_fallback_warnings
-@testing.gpu
 class TestInplaceSpecialMethods(unittest.TestCase):
 
     @numpy_fallback_array_equal()
@@ -575,7 +562,6 @@ class TestInplaceSpecialMethods(unittest.TestCase):
 
 
 @ignore_fallback_warnings
-@testing.gpu
 class TestArrayVariants(unittest.TestCase):
 
     @numpy_fallback_array_equal()

--- a/tests/cupyx_tests/fallback_mode_tests/test_notifications.py
+++ b/tests/cupyx_tests/fallback_mode_tests/test_notifications.py
@@ -19,7 +19,6 @@ class NotificationTestBase:
         _ufunc_config.seterr(**old_config)
 
 
-@testing.gpu
 class TestNotifications(NotificationTestBase):
 
     def test_seterr_geterr(self):
@@ -50,7 +49,6 @@ class TestNotifications(NotificationTestBase):
 @testing.parameterize(
     {'func_name': 'get_include'},
 )
-@testing.gpu
 class TestNotificationModes(NotificationTestBase):
 
     @property
@@ -103,7 +101,6 @@ class TestNotificationModes(NotificationTestBase):
         _ufunc_config.seterr(**old)
 
 
-@testing.gpu
 class TestNotificationVectorize(NotificationTestBase):
 
     @test_utils.enable_slice_copy

--- a/tests/cupyx_tests/linalg_tests/test_solve.py
+++ b/tests/cupyx_tests/linalg_tests/test_solve.py
@@ -14,7 +14,6 @@ import cupyx
     'size': [5, 9, 17, 33],
     'dtype': [numpy.float32, numpy.float64, numpy.complex64, numpy.complex128],
 }))
-@testing.gpu
 @pytest.mark.xfail(runtime.is_hip,
                    reason='rocSOLVER does not implement potrs yet.')
 class TestInvh(unittest.TestCase):
@@ -69,7 +68,6 @@ class TestErrorInvh(unittest.TestCase):
     'shape': [(2, 3, 3)],
     'dtype': [numpy.float32, numpy.float64, numpy.complex64, numpy.complex128],
 }))
-@testing.gpu
 class TestXFailBatchedInvh(unittest.TestCase):
 
     def test_invh(self):

--- a/tests/cupyx_tests/scipy_tests/fft_tests/test_fft.py
+++ b/tests/cupyx_tests/scipy_tests/fft_tests/test_fft.py
@@ -57,7 +57,6 @@ def _skip_forward_backward(norm):
     'axis': [-1, 0],
     'norm': [None, 'backward', 'ortho', 'forward', '']
 }))
-@testing.gpu
 class TestFft:
 
     @pytest.fixture(autouse=True)
@@ -320,7 +319,6 @@ class TestFft:
         })
     )
 ))
-@testing.gpu
 class TestFft2:
 
     @pytest.fixture(autouse=True)
@@ -581,7 +579,6 @@ class TestFft2:
         })
     )
 ))
-@testing.gpu
 class TestFftn:
 
     @pytest.fixture(autouse=True)
@@ -827,7 +824,6 @@ class TestFftn:
     'axis': [-1, 0],
     'norm': [None, 'backward', 'ortho', 'forward', '']
 }))
-@testing.gpu
 class TestRfft:
 
     @pytest.fixture(autouse=True)
@@ -1033,7 +1029,6 @@ def _skip_hipFFT_PlanNd_bug(axes, shape):
         testing.product({'norm': [None, 'backward', 'ortho', 'forward', '']})
     )
 ))
-@testing.gpu
 class TestRfft2:
 
     @pytest.fixture(autouse=True)
@@ -1291,7 +1286,6 @@ class TestRfft2:
         testing.product({'norm': [None, 'backward', 'ortho', 'forward', '']})
     )
 ))
-@testing.gpu
 class TestRfftn:
 
     @pytest.fixture(autouse=True)
@@ -1535,7 +1529,6 @@ class TestRfftn:
     'axis': [0, -1],
     'norm': [None, 'backward', 'ortho', 'forward', ''],
 }))
-@testing.gpu
 class TestHfft:
 
     @pytest.fixture(autouse=True)
@@ -1642,7 +1635,6 @@ class TestHfft:
         testing.product({'norm': [None, 'backward', 'ortho', 'forward']})
     )
 ))
-@testing.gpu
 @testing.with_requires('scipy>=1.4.0')
 class TestHfft2:
 
@@ -1722,7 +1714,6 @@ class TestHfft2:
         testing.product({'norm': [None, 'backward', 'ortho', 'forward']})
     )
 ))
-@testing.gpu
 @testing.with_requires('scipy>=1.4.0')
 class TestHfftn:
 
@@ -1785,7 +1776,6 @@ class TestHfftn:
         return _correct_np_dtype(xp, dtype, out)
 
 
-@testing.gpu
 @pytest.mark.parametrize('func', [
     cp_fft.fft2, cp_fft.ifft2, cp_fft.rfft2, cp_fft.irfft2,
     cp_fft.fftn, cp_fft.ifftn, cp_fft.rfftn, cp_fft.irfftn])

--- a/tests/cupyx_tests/scipy_tests/fft_tests/test_fftlog.py
+++ b/tests/cupyx_tests/scipy_tests/fft_tests/test_fftlog.py
@@ -27,7 +27,6 @@ rtol = {cupy.float64: 1e-10, 'default': 1e-5}
     'bias': [0.0, 0.8, -0.5],
     'function': ['fht', 'ifht'],
 }))
-@testing.gpu
 class TestFftlog:
 
     @testing.for_all_dtypes(no_complex=True)
@@ -61,7 +60,6 @@ class TestFftlog:
 @testing.parameterize(*testing.product({
     'function': ['fht', 'ifht'],
 }))
-@testing.gpu
 class TestFftlogScipyBackend:
 
     @testing.for_all_dtypes()

--- a/tests/cupyx_tests/scipy_tests/fftpack_tests/test_fftpack.py
+++ b/tests/cupyx_tests/scipy_tests/fftpack_tests/test_fftpack.py
@@ -17,7 +17,6 @@ if cupyx.scipy._scipy_available:
     'shape': [(9,), (10,), (10, 9), (10, 10)],
     'axis': [-1, 0],
 }))
-@testing.gpu
 @testing.with_requires('scipy>=0.19.0')
 class TestFft(unittest.TestCase):
 
@@ -201,7 +200,6 @@ class TestFft(unittest.TestCase):
     {'shape': (2, 3, 4), 's': None, 'axes': (0, 1)},
     {'shape': (2, 3, 4, 5), 's': None, 'axes': None},
 )
-@testing.gpu
 @testing.with_requires('scipy>=0.19.0')
 class TestFft2(unittest.TestCase):
 
@@ -369,7 +367,6 @@ class TestFft2(unittest.TestCase):
     {'shape': (2, 3, 4), 's': None, 'axes': (0, 1)},
     {'shape': (2, 3, 4, 5), 's': None, 'axes': None},
 )
-@testing.gpu
 @testing.with_requires('scipy>=0.19.0')
 class TestFftn(unittest.TestCase):
 
@@ -542,7 +539,6 @@ class TestFftn(unittest.TestCase):
     'shape': [(9,), (10,), (10, 9), (10, 10)],
     'axis': [-1, 0],
 }))
-@testing.gpu
 @testing.with_requires('scipy>=0.19.0')
 class TestRfft(unittest.TestCase):
 

--- a/tests/cupyx_tests/scipy_tests/linalg_tests/test_decomp_lu.py
+++ b/tests/cupyx_tests/scipy_tests/linalg_tests/test_decomp_lu.py
@@ -16,7 +16,6 @@ requires_scipy_linalg_backend = unittest.skip(
 )
 
 
-@testing.gpu
 @testing.parameterize(*testing.product({
     'shape': [(1, 1), (2, 2), (3, 3), (5, 5), (1, 5), (5, 1), (2, 5), (5, 2)],
 }))
@@ -82,7 +81,6 @@ class TestLUFactor(unittest.TestCase):
             self.check_lu_factor_reconstruction(A)
 
 
-@testing.gpu
 @testing.parameterize(*testing.product({
     'shape': [(1, 1), (2, 2), (3, 3), (5, 5), (1, 5), (5, 1), (2, 5), (5, 2)],
     'permute_l': [False, True],
@@ -122,7 +120,6 @@ class TestLU(unittest.TestCase):
         cupy.testing.assert_allclose(PLU, A, atol=1e-5)
 
 
-@testing.gpu
 @testing.parameterize(*testing.product({
     'trans': [0, 1, 2],
     'shapes': [((4, 4), (4,)), ((5, 5), (5, 2))],

--- a/tests/cupyx_tests/scipy_tests/linalg_tests/test_solve_triangular.py
+++ b/tests/cupyx_tests/scipy_tests/linalg_tests/test_solve_triangular.py
@@ -21,7 +21,6 @@ except ImportError:
     'overwrite_b': [True, False],
     'check_finite': [True, False],
 }))
-@testing.gpu
 @testing.with_requires('scipy')
 class TestSolveTriangular(unittest.TestCase):
 

--- a/tests/cupyx_tests/scipy_tests/linalg_tests/test_special_matrices.py
+++ b/tests/cupyx_tests/scipy_tests/linalg_tests/test_special_matrices.py
@@ -69,7 +69,6 @@ class TestSpecialMatricesBase(unittest.TestCase):
                  ((1,), (4, 5), (3, 6), (7, 2), (8, 9))],
     })
 ))
-@testing.gpu
 @testing.with_requires('scipy')
 class TestSpecialMatrices(TestSpecialMatricesBase):
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp',
@@ -86,7 +85,6 @@ class TestSpecialMatrices(TestSpecialMatricesBase):
         'args': [((0,),), ((1,),), ((2,),), ((4,),), ((10,),), ((25,),)],
     })
 ))
-@testing.gpu
 @testing.with_requires('scipy>=1.3.0')
 class TestSpecialMatrices_1_3_0(TestSpecialMatricesBase):
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp',
@@ -112,7 +110,6 @@ class TestSpecialMatrices_1_3_0(TestSpecialMatricesBase):
                  ((4,), 6, 'full'), ((10,), 8, 'same'), ((25,), 25, 'valid')],
     })
 ))
-@testing.gpu
 @testing.with_requires('scipy>=1.5.0')
 class TestSpecialMatrices_1_5_0(TestSpecialMatricesBase):
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp',

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
@@ -190,7 +190,6 @@ COMMON_FLOAT_PARAMS['dtype'] = [numpy.float32, numpy.float64]
         })
     )
 ))
-@testing.gpu
 @testing.with_requires('scipy')
 class TestFilter(FilterTestCaseBase):
 
@@ -303,7 +302,6 @@ def dummy_deriv_func(input, axis, output, mode, cval, *args, **kwargs):
         })
     )
 ))
-@testing.gpu
 @testing.with_requires('scipy')
 class TestFilterFast(FilterTestCaseBase):
 
@@ -368,7 +366,6 @@ class TestFilterFast(FilterTestCaseBase):
         })
     )
 ))
-@testing.gpu
 @testing.with_requires('scipy')
 class TestFilterComplexFast(FilterTestCaseBase):
 
@@ -449,7 +446,6 @@ def lt_pyfunc(x):
         'dtype': [numpy.float64],
     })
 ))
-@testing.gpu
 @testing.with_requires('scipy')
 class TestGenericFilter(FilterTestCaseBase):
 
@@ -515,7 +511,6 @@ void shift(const double* in, ptrdiff_t in_length,
         })
     )
 ))
-@testing.gpu
 @testing.with_requires('scipy')
 class TestGeneric1DFilter(FilterTestCaseBase):
     _func_or_kernels = {
@@ -556,7 +551,6 @@ class TestGeneric1DFilter(FilterTestCaseBase):
         })
     )
 ))
-@testing.gpu
 # SciPy behavior fixed in 1.5.0: https://github.com/scipy/scipy/issues/11661
 @testing.with_requires('scipy>=1.5.0')
 class TestMirrorWithDim1(FilterTestCaseBase):
@@ -584,7 +578,6 @@ class TestMirrorWithDim1(FilterTestCaseBase):
         })
     )
 ))
-@testing.gpu
 @testing.with_requires('scipy')
 class TestShellSort(FilterTestCaseBase):
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
@@ -610,7 +603,6 @@ class TestShellSort(FilterTestCaseBase):
         })
     )
 ))
-@testing.gpu
 @testing.with_requires('scipy')
 class TestFortranOrder(FilterTestCaseBase):
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
@@ -637,7 +629,6 @@ class TestFortranOrder(FilterTestCaseBase):
         })
     )
 ))
-@testing.gpu
 @testing.with_requires('scipy')
 class TestWeightDtype(FilterTestCaseBase):
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
@@ -668,7 +659,6 @@ class TestWeightDtype(FilterTestCaseBase):
         })
     )
 ))
-@testing.gpu
 @testing.with_requires('scipy>=1.5.9')
 class TestWeightComplexDtype(FilterTestCaseBase):
 
@@ -716,7 +706,6 @@ class TestWeightComplexDtype(FilterTestCaseBase):
     'shape': [(3, 3), (3, 3, 3)],
     'dtype': [numpy.uint8, numpy.float64],
 }))
-@testing.gpu
 @testing.with_requires('scipy')
 class TestSpecialWeightCases(FilterTestCaseBase):
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp',
@@ -754,7 +743,6 @@ class TestSpecialWeightCases(FilterTestCaseBase):
     'shape': [(3, 3), (3, 3, 3)],
     'dtype': [numpy.uint8, numpy.float64],
 }))
-@testing.gpu
 @testing.with_requires('scipy')
 class TestSpecialCases1D(FilterTestCaseBase):
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp',
@@ -770,7 +758,6 @@ class TestSpecialCases1D(FilterTestCaseBase):
                'minimum_filter1d', 'maximum_filter1d'],
     'shape': [(4, 5), (3, 4, 5), (1, 3, 4, 5)],
 }))
-@testing.gpu
 @testing.with_requires('scipy')
 class TestInvalidAxis(FilterTestCaseBase):
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp',
@@ -804,7 +791,6 @@ class TestInvalidAxis(FilterTestCaseBase):
     'mode': ['unknown'],
     'shape': [(4, 5)],
 }))
-@testing.gpu
 @testing.with_requires('scipy')
 class TestInvalidMode(FilterTestCaseBase):
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp',
@@ -822,7 +808,6 @@ class TestInvalidMode(FilterTestCaseBase):
     'ksize': [3, 4],
     'shape': [(4, 5)], 'dtype': [numpy.float64],
 }))
-@testing.gpu
 # SciPy behavior fixed in 1.2.0: https://github.com/scipy/scipy/issues/822
 @testing.with_requires('scipy>=1.2.0')
 class TestInvalidOrigin(FilterTestCaseBase):

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_fourier.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_fourier.py
@@ -52,7 +52,6 @@ except ImportError:
         )
     )
 )
-@testing.gpu
 @testing.with_requires("scipy")
 class TestFourierShift:
 
@@ -140,7 +139,6 @@ class TestFourierShift:
         )
     )
 )
-@testing.gpu
 @testing.with_requires("scipy")
 class TestFourierGaussian:
 
@@ -228,7 +226,6 @@ class TestFourierGaussian:
         )
     )
 )
-@testing.gpu
 @testing.with_requires("scipy")
 class TestFourierUniform:
 
@@ -310,7 +307,6 @@ class TestFourierUniform:
         )
     )
 )
-@testing.gpu
 @testing.with_requires('scipy')
 class TestFourierEllipsoid():
     def _test_real_nd(self, xp, scp, x, real_axis):
@@ -381,7 +377,6 @@ class TestFourierEllipsoid():
         return xp.ascontiguousarray(a)
 
 
-@testing.gpu
 @testing.with_requires('scipy')
 class TestFourierEllipsoidInvalid():
 

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
@@ -40,7 +40,6 @@ def _conditional_scipy_version_skip(mode, order):
     'cval': [1.0],
     'prefilter': [True],
 }))
-@testing.gpu
 @testing.with_requires('scipy')
 class TestMapCoordinates:
 
@@ -122,7 +121,6 @@ class TestMapCoordinates:
     'order': [0, 1, 2, 3, 4, 5],
     'mode': ['constant', 'nearest', 'mirror'] + scipy16_modes,
 }))
-@testing.gpu
 @testing.with_requires('scipy')
 class TestMapCoordinatesHalfInteger:
 
@@ -151,7 +149,6 @@ class TestMapCoordinatesHalfInteger:
     'cval': [1.0],
     'prefilter': [False, True],
 }))
-@testing.gpu
 @testing.with_requires('scipy')
 class TestAffineTransform:
 
@@ -236,7 +233,6 @@ class TestAffineTransform:
         return out
 
 
-@testing.gpu
 @testing.with_requires('scipy')
 class TestAffineExceptions:
 
@@ -324,7 +320,6 @@ class TestAffineExceptions:
     'shape': [(100, 100), (10, 20), (10, 10, 10), (10, 20, 30)],
     'theta': [0, 90, 180, 270]
 }))
-@testing.gpu
 @testing.with_requires('scipy')
 class TestAffineTransformTextureMemory:
 
@@ -410,7 +405,6 @@ class TestAffineTransformTextureMemory:
                      mode=self.mode)
 
 
-@testing.gpu
 @testing.with_requires('opencv-python')
 class TestAffineTransformOpenCV:
 
@@ -451,7 +445,6 @@ class TestAffineTransformOpenCV:
         'prefilter': [True],
     })
 ))
-@testing.gpu
 @testing.with_requires('scipy')
 class TestRotate:
 
@@ -528,7 +521,6 @@ class TestRotate:
         return out
 
 
-@testing.gpu
 # Scipy older than 1.3.0 raises IndexError instead of ValueError
 @testing.with_requires('scipy>=1.3.0')
 class TestRotateExceptions:
@@ -550,7 +542,6 @@ class TestRotateExceptions:
     {'axes': (2, 0)},
     {'axes': (-2, 2)},
 )
-@testing.gpu
 @testing.with_requires('scipy')
 class TestRotateAxes:
 
@@ -564,7 +555,6 @@ class TestRotateAxes:
         return rotate(a, 1, self.axes, order=1)
 
 
-@testing.gpu
 @testing.with_requires('opencv-python')
 class TestRotateOpenCV:
 
@@ -599,7 +589,6 @@ class TestRotateOpenCV:
         'prefilter': [True],
     })
 ))
-@testing.gpu
 @testing.with_requires('scipy')
 class TestShift:
 
@@ -680,7 +669,6 @@ class TestShift:
     'mode': ['constant', 'nearest'],
     'cval': [cupy.nan, cupy.inf, -cupy.inf],
 }))
-@testing.gpu
 class TestInterpolationInvalidCval:
 
     def _prep_output(self, a):
@@ -758,7 +746,6 @@ class TestInterpolationInvalidCval:
                             mode=self.mode, cval=self.cval)
 
 
-@testing.gpu
 @testing.with_requires('opencv-python')
 class TestShiftOpenCV:
 
@@ -785,7 +772,6 @@ class TestShiftOpenCV:
     'cval': [1.0],
     'prefilter': [True],
 }))
-@testing.gpu
 @testing.with_requires('scipy')
 class TestZoom:
 
@@ -849,7 +835,6 @@ class TestZoom:
     'zoom': [(1, 1), (3, 5), (8, 2), (8, 8)],
     'mode': ['nearest', 'reflect', 'mirror', 'grid-wrap', 'grid-constant'],
 }))
-@testing.gpu
 class TestZoomOrder0IntegerGrid():
 
     def test_zoom_grid_by_int_order0(self):
@@ -873,7 +858,6 @@ class TestZoomOrder0IntegerGrid():
     'order': [0, 1, 2, 3, 4, 5],
     'grid_mode': [False, True],
 }))
-@testing.gpu
 class TestZoomOutputSize1():
 
     @testing.for_float_dtypes(no_float16=True)
@@ -890,7 +874,6 @@ class TestZoomOutputSize1():
     {'zoom': 3},
     {'zoom': 0.3},
 )
-@testing.gpu
 @testing.with_requires('opencv-python')
 class TestZoomOpenCV:
 
@@ -928,7 +911,6 @@ class TestZoomOpenCV:
     'output': [numpy.float64, numpy.float32],
     'axis': [0, 1, 2, -1],
 }))
-@testing.gpu
 @testing.with_requires('scipy')
 class TestSplineFilter1d:
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
@@ -979,7 +961,6 @@ class TestSplineFilter1dLargeArray:
     'dtype': [numpy.uint8, numpy.float64],
     'output': [numpy.float64, numpy.float32],
 }))
-@testing.gpu
 @testing.with_requires('scipy')
 class TestSplineFilter:
     @testing.numpy_cupy_allclose(atol=1e-4, rtol=1e-4, scipy_name='scp')
@@ -1019,7 +1000,6 @@ class TestSplineFilter:
     'dtype': [numpy.complex64, numpy.complex128],
     'output': [numpy.complex64, numpy.complex128],
 }))
-@testing.gpu
 @testing.with_requires('scipy')
 class TestSplineFilterComplex:
 

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
@@ -44,7 +44,6 @@ def _generate_binary_structure(rank, connectivity):
     'output': [None, numpy.int32, numpy.int64],
     'o_type': [None, 'ndarray']
 }))
-@testing.gpu
 @testing.with_requires('scipy')
 class TestLabel:
 
@@ -69,7 +68,6 @@ class TestLabel:
         return labels
 
 
-@testing.gpu
 @testing.with_requires('scipy')
 class TestLabelSpecialCases:
 
@@ -111,7 +109,6 @@ class TestLabelSpecialCases:
         return labels
 
 
-@testing.gpu
 @testing.parameterize(*testing.product({
     'op': stats_ops,
 }))
@@ -288,7 +285,6 @@ class TestStats:
         return result
 
 
-@testing.gpu
 @testing.parameterize(*testing.product({
     'op': ['maximum', 'median', 'minimum', 'maximum_position',
            'minimum_position', 'extrema'],
@@ -369,7 +365,6 @@ class TestMeasurementsSelect:
         return result
 
 
-@testing.gpu
 @testing.parameterize(*testing.product({
     'labels': [None, 4, 6],
     'index': [None, [0, 2], [3, 1, 0], [1]],
@@ -408,7 +403,6 @@ class TestHistogram():
         return xp.stack(result)
 
 
-@testing.gpu
 @testing.parameterize(*testing.product({
     'labels': [None, 4],
     'index': [None, [0, 2], [3, 1, 0], [1]],

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_morphology.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_morphology.py
@@ -22,7 +22,6 @@ except ImportError:
     {'rank': -1, 'connectivity': 0},
     {'rank': 3, 'connectivity': 0},
     {'rank': 3, 'connectivity': 500})
-@testing.gpu
 @testing.with_requires('scipy')
 class TestGenerateBinaryStructure:
 
@@ -32,7 +31,6 @@ class TestGenerateBinaryStructure:
                                                      self.connectivity)
 
 
-@testing.gpu
 @testing.with_requires('scipy')
 class TestIterateStructure:
 
@@ -72,7 +70,6 @@ class TestIterateStructure:
         'output': [None, numpy.float32, numpy.int8, 'array']}
     ))
 )
-@testing.gpu
 @testing.with_requires('scipy')
 class TestBinaryErosionAndDilation1d:
     def _filter(self, xp, scp, x):
@@ -126,7 +123,6 @@ class TestBinaryErosionAndDilation1d:
         'output': [None, numpy.float32, numpy.int8]}
     ))
 )
-@testing.gpu
 @testing.with_requires('scipy>=1.1.0')
 class TestBinaryOpeningAndClosing:
     def _filter(self, xp, scp, x):
@@ -177,7 +173,6 @@ class TestBinaryOpeningAndClosing:
         'output': [None, numpy.float32, numpy.int8]}
     ))
 )
-@testing.gpu
 @testing.with_requires('scipy')
 class TestBinaryFillHoles:
     def _filter(self, xp, scp, x):
@@ -226,7 +221,6 @@ class TestBinaryFillHoles:
         'output': [None, numpy.float32, numpy.int8]}
     ))
 )
-@testing.gpu
 @testing.with_requires('scipy')
 class TestBinaryHitOrMiss:
     def _filter(self, xp, scp, x):
@@ -299,7 +293,6 @@ class TestBinaryHitOrMiss:
         'output': [None, numpy.float32, numpy.int8]}
     ))
 )
-@testing.gpu
 @testing.with_requires('scipy')
 class TestBinaryPropagation:
     def _filter(self, xp, scp, x):
@@ -331,7 +324,6 @@ class TestBinaryPropagation:
         'output': [None, numpy.float32, 'array']}
     ))
 )
-@testing.gpu
 @testing.with_requires('scipy')
 class TestBinaryErosionAndDilation:
     def _filter(self, xp, scp, x):
@@ -368,7 +360,6 @@ class TestBinaryErosionAndDilation:
         'contiguity': ['C', 'F', 'none']}
     ))
 )
-@testing.gpu
 @testing.with_requires('scipy')
 class TestBinaryErosionAndDilationContiguity:
     def _filter(self, xp, scp, x):
@@ -427,7 +418,6 @@ class TestBinaryErosionAndDilationContiguity:
         'filter': ['grey_erosion', 'grey_dilation']
     })
 ))
-@testing.gpu
 @testing.with_requires('scipy')
 class TestGreyErosionAndDilation:
 
@@ -473,7 +463,6 @@ class TestGreyErosionAndDilation:
     'output': [None, numpy.float64],
     'filter': ['grey_closing', 'grey_opening']
 }))
-@testing.gpu
 @testing.with_requires('scipy')
 class TestGreyClosingAndOpening:
 
@@ -523,7 +512,6 @@ class TestGreyClosingAndOpening:
         'structure': [None, 'random']}
     ))
 )
-@testing.gpu
 @testing.with_requires('scipy')
 class TestMorphologicalGradientAndLaplace:
 
@@ -586,7 +574,6 @@ class TestMorphologicalGradientAndLaplace:
         'structure': [None, 'random']}
     ))
 )
-@testing.gpu
 @testing.with_requires('scipy')
 class TestWhiteTophatAndBlackTopHat:
 

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_bsplines.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_bsplines.py
@@ -16,7 +16,6 @@ except ImportError:
     'hrow': [1, 3],
     'hcol': [1, 3],
 }))
-@testing.gpu
 @testing.with_requires('scipy')
 class TestSepFIR2d(unittest.TestCase):
 

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
@@ -20,7 +20,6 @@ except ImportError:
     'size2': [3, 4, 5, 10],
     'mode': ['full', 'same', 'valid'],
 }))
-@testing.gpu
 @testing.with_requires('scipy')
 class TestConvolveCorrelate:
     def _filter(self, func, dtype, xp, scp):
@@ -49,7 +48,6 @@ class TestConvolveCorrelate:
     'size2': [3, 4, 5, 10],
     'mode': ['full', 'same', 'valid'],
 }))
-@testing.gpu
 @testing.with_requires('scipy')
 class TestFFTConvolve:
     def _filter(self, func, dtype, xp, scp, **kwargs):
@@ -151,7 +149,6 @@ class TestFFTConvolveFastShape:
     'size2': [3, 4, 5, 10, None],
     'mode': ['full', 'same', 'valid'],
 }))
-@testing.gpu
 @testing.with_requires('scipy')
 class TestOAConvolve:
     tols = {np.float32: 1e-3, np.complex64: 1e-3,
@@ -182,7 +179,6 @@ class TestOAConvolve:
     'boundary': ['wrap', 'symm'],
     'fillvalue': [0],
 })))
-@testing.gpu
 @testing.with_requires('scipy')
 class TestConvolveCorrelate2D:
     def _filter(self, func, dtype, xp, scp):
@@ -244,7 +240,6 @@ class TestConvolve2DEdgeCase:
         return scp.signal.convolve2d(b, a, mode="same")
 
 
-@testing.gpu
 @testing.parameterize(*testing.product({
     'mode': ['valid', 'same', 'full']
 }))
@@ -291,7 +286,6 @@ class TestChooseConvMethod:
     'mysize': [3, 4, (3, 4, 5)],
     'noise': [False, True],
 }))
-@testing.gpu
 @testing.with_requires('scipy')
 class TestWiener:
     tols = {np.float32: 1e-5, np.complex64: 1e-5,
@@ -320,7 +314,6 @@ class TestWiener:
     'domain': [3, 4, (3, 3, 5)],
     'rank': [0, 1, 2],
 }))
-@testing.gpu
 @testing.with_requires('scipy')
 class TestOrderFilter:
     @testing.for_all_dtypes(no_float16=True, no_bool=True, no_complex=True)
@@ -339,7 +332,6 @@ class TestOrderFilter:
     'volume': [(10,), (5, 10), (10, 5), (5, 6, 10)],
     'kernel_size': [3, 4, (3, 3, 5)],
 }))
-@testing.gpu
 @testing.with_requires('scipy>=1.7.0')
 class TestMedFilt:
     @testing.for_all_dtypes()
@@ -359,7 +351,6 @@ class TestMedFilt:
     'input': [(5, 10), (10, 5)],
     'kernel_size': [3, 4, (3, 5)],
 }))
-@testing.gpu
 @testing.with_requires('scipy>=1.7.0')
 class TestMedFilt2d:
     @testing.for_all_dtypes()

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
@@ -364,7 +364,6 @@ class TestMedFilt2d:
         return scp.signal.medfilt2d(input, kernel_size)
 
 
-@testing.gpu
 @testing.with_requires('scipy')
 class TestLFilter:
     @pytest.mark.parametrize('size', [11, 20, 32, 51, 64, 120, 128, 250])

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_coo.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_coo.py
@@ -1099,7 +1099,6 @@ class TestIsspmatrixCoo:
     'shape': [(8, 5), (5, 5), (5, 8)],
 }))
 @testing.with_requires('scipy>=1.5.0')
-@testing.gpu
 class TestCooMatrixDiagonal:
     density = 0.5
 

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -1770,7 +1770,6 @@ class TestCsrMatrixGetitem2:
     'dtype': [numpy.float32, numpy.float64, cupy.complex64, cupy.complex128],
 }))
 @testing.with_requires('scipy')
-@testing.gpu
 @pytest.mark.skipif(
     cupy.cuda.cub._get_cuda_build_version() >= 11000,
     reason='CUDA built-in CUB SpMV is buggy, see cupy/cupy#3822')
@@ -1814,7 +1813,6 @@ class TestCubSpmv:
     'opt': ['maximum', 'minimum'],
 }))
 @testing.with_requires('scipy')
-@testing.gpu
 class TestCsrMatrixMaximumMinimum:
 
     def _make_array(self, shape, dtype, xp):
@@ -1926,7 +1924,6 @@ class TestCsrMatrixMaximumMinimum:
     'opt': ['_eq_', '_ne_', '_lt_', '_gt_', '_le_', '_ge_'],
 }))
 @testing.with_requires('scipy>=1.2')
-@testing.gpu
 class TestCsrMatrixComparison:
     nz_rate = 0.3
 
@@ -2089,7 +2086,6 @@ class TestCsrMatrixComparison:
     'shape': [(8, 5), (5, 5), (5, 8)],
 }))
 @testing.with_requires('scipy>=1.5.0')
-@testing.gpu
 class TestCsrMatrixDiagonal:
     density = 0.5
 

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_index.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_index.py
@@ -38,7 +38,6 @@ def _check_shares_memory(xp, sp, x, y):
     'n_cols': [25, 150]
 }))
 @testing.with_requires('scipy>=1.4.0')
-@testing.gpu
 class TestSetitemIndexing:
 
     def _run(self, maj, min=None, data=5):
@@ -380,7 +379,6 @@ _int_array_index = [
     ),
 }))
 @testing.with_requires('scipy>=1.4.0')
-@testing.gpu
 class TestSliceIndexing(IndexingTestBase):
 
     @testing.for_dtypes('fdFD')
@@ -449,7 +447,6 @@ def _check_bounds(indices, n_rows, n_cols, **kwargs):
     )
 }) if _check_bounds(**params)])
 @testing.with_requires('scipy>=1.4.0')
-@testing.gpu
 class TestArrayIndexing(IndexingTestBase):
 
     @skip_HIP_0_size_matrix()
@@ -505,7 +502,6 @@ class TestArrayIndexing(IndexingTestBase):
     ],
 }))
 @testing.with_requires('scipy>=1.4.0')
-@testing.gpu
 class TestBoolMaskIndexing(IndexingTestBase):
 
     n_rows = 3
@@ -554,7 +550,6 @@ class TestBoolMaskIndexing(IndexingTestBase):
     ],
 }))
 @testing.with_requires('scipy>=1.4.0')
-@testing.gpu
 class TestIndexingIndexError(IndexingTestBase):
 
     def test_indexing_index_error(self):
@@ -575,7 +570,6 @@ class TestIndexingIndexError(IndexingTestBase):
     ],
 }))
 @testing.with_requires('scipy>=1.4.0')
-@testing.gpu
 class TestIndexingValueError(IndexingTestBase):
 
     def test_indexing_value_error(self):

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
@@ -78,7 +78,6 @@ class TestLsqr(unittest.TestCase):
     'axis': [None, (0, 1), (1, -2)],
 }))
 @testing.with_requires('scipy')
-@testing.gpu
 class TestMatrixNorm:
 
     @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-4, sp_name='sp',
@@ -106,7 +105,6 @@ class TestMatrixNorm:
 })
 )
 @testing.with_requires('scipy')
-@testing.gpu
 class TestVectorNorm:
 
     @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-4, sp_name='sp',
@@ -312,7 +310,6 @@ class TestSvds:
     'use_linear_operator': [False, True],
 }))
 @testing.with_requires('scipy')
-@testing.gpu
 class TestCg:
     n = 30
     density = 0.33
@@ -461,7 +458,6 @@ class TestCg:
     'use_linear_operator': [False, True],
 }))
 @testing.with_requires('scipy>=1.4')
-@testing.gpu
 class TestGmres:
     n = 30
     density = 0.2
@@ -643,7 +639,6 @@ def skip_HIP_spMM_error(outer=()):
     'M': [1, 6],
     'N': [1, 7],
 }))
-@testing.gpu
 @testing.with_requires('scipy>=1.4')
 class TestLinearOperator:
 
@@ -768,7 +763,6 @@ class TestLinearOperator:
     'order': ['C', 'F']
 }))
 @testing.with_requires('scipy>=1.4.0')
-@testing.gpu
 @pytest.mark.skipif(not cusparse.check_availability('csrsm2'),
                     reason='no working implementation')
 class TestSpsolveTriangular:
@@ -924,7 +918,6 @@ def _eigen_vec_transform(block_vec, xp):
 
 
 @testing.with_requires('scipy>=1.4')
-@testing.gpu
 @pytest.mark.skipif(runtime.is_hip and driver.get_build_version() < 402,
                     reason='syevj not available')
 # tests adapted from scipy's tests of lobpcg
@@ -1228,7 +1221,6 @@ class TestLOBPCG:
 
 
 @testing.with_requires('scipy>=1.4')
-@testing.gpu
 @testing.parameterize(*testing.product({
     'A_sparsity': [True, False],
     'B_sparsity': [True, False],
@@ -1309,7 +1301,6 @@ class TestLOBPCGForDiagInput:
 @testing.with_requires('scipy')
 @pytest.mark.skipif(not cusparse.check_availability('csrsm2'),
                     reason='no working implementation')
-@testing.gpu
 class TestSplu:
 
     n = 10

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_basic.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_basic.py
@@ -15,7 +15,6 @@ from cupy.testing import numpy_cupy_allclose
 rtol = {'default': 1e-5, cupy.float64: 1e-12, cupy.complex128: 1e-12}
 
 
-@testing.gpu
 @testing.with_requires("scipy")
 class TestLegendreFunctions:
 
@@ -45,7 +44,6 @@ class TestLegendreFunctions:
         return scp.special.lpmv(order, degree, vals)
 
 
-@testing.gpu
 @testing.with_requires("scipy")
 class TestBasic:
 

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_bessel.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_bessel.py
@@ -5,7 +5,6 @@ from cupy import testing
 import cupyx.scipy.special  # NOQA
 
 
-@testing.gpu
 @testing.with_requires('scipy')
 class TestSpecial:
 
@@ -64,7 +63,6 @@ class TestSpecial:
         return scp.special.yn(n[:, xp.newaxis], a[xp.newaxis, :])
 
 
-@testing.gpu
 @testing.with_requires('scipy')
 class TestFusionSpecial(unittest.TestCase):
 

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_beta.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_beta.py
@@ -16,7 +16,6 @@ def _get_logspace_max(dtype):
         return 5
 
 
-@testing.gpu
 @testing.with_requires('scipy')
 class TestBeta:
 
@@ -86,7 +85,6 @@ class TestBeta:
                                 3.1811881124242447, rtol=1e-14, atol=0)
 
 
-@testing.gpu
 @testing.with_requires('scipy')
 class TestBetaInc:
 

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_binom.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_binom.py
@@ -4,7 +4,6 @@ from cupy import testing
 import cupyx.scipy.special  # NOQA
 
 
-@testing.gpu
 @testing.with_requires('scipy')
 class TestBinom:
     @testing.for_all_dtypes(no_complex=True)

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_convex_analysis.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_convex_analysis.py
@@ -8,7 +8,6 @@ from cupy import testing
 import cupyx.scipy.special
 
 
-@testing.gpu
 @testing.with_requires('scipy')
 class TestSpecialConvex(unittest.TestCase):
 

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_digamma.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_digamma.py
@@ -5,7 +5,6 @@ import cupyx.scipy.special  # NOQA
 import numpy
 
 
-@testing.gpu
 @testing.with_requires('scipy')
 class TestDigamma(unittest.TestCase):
 

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_erf.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_erf.py
@@ -39,7 +39,6 @@ class _TestBase(object):
         self.check_unary_boundary('erfcinv', boundary=2)
 
 
-@testing.gpu
 @testing.with_requires('scipy')
 class TestSpecial(unittest.TestCase, _TestBase):
 
@@ -105,7 +104,6 @@ class TestSpecial(unittest.TestCase, _TestBase):
         assert numpy.isneginf(cupy.asnumpy(a))
 
 
-@testing.gpu
 @testing.with_requires('scipy')
 class TestFusionSpecial(unittest.TestCase, _TestBase):
 

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_gamma.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_gamma.py
@@ -6,7 +6,6 @@ from cupy import testing
 import cupyx.scipy.special  # NOQA
 
 
-@testing.gpu
 @testing.with_requires('scipy')
 class TestGamma:
 

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_gammaln.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_gammaln.py
@@ -7,7 +7,6 @@ from cupy import testing
 import cupyx.scipy.special  # NOQA
 
 
-@testing.gpu
 @testing.with_requires('scipy')
 class TestGammaln:
 
@@ -44,7 +43,6 @@ class TestGammaln:
         return scp.special.gammaln(a)
 
 
-@testing.gpu
 @testing.with_requires('scipy')
 class TestMultigammaln:
 

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_polygamma.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_polygamma.py
@@ -7,7 +7,6 @@ import numpy
 import warnings
 
 
-@testing.gpu
 @testing.with_requires('scipy')
 class TestPolygamma(unittest.TestCase):
 

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_sph_harm.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_sph_harm.py
@@ -15,7 +15,6 @@ def _get_harmonic_list(degree_max):
     return harmonic_list
 
 
-@testing.gpu
 @testing.with_requires("scipy")
 class TestBasic():
 

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_statistics.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_statistics.py
@@ -36,7 +36,6 @@ atol_low = {'default': 5e-4, cupy.float64: 1e-12}
 rtol_low = {'default': 5e-4, cupy.float64: 1e-12}
 
 
-@testing.gpu
 @testing.with_requires('scipy')
 class TestSpecial(_TestBase):
 
@@ -111,7 +110,6 @@ class TestSpecial(_TestBase):
         assert numpy.isnan(float(boxcox1p(-1.1, 5)))
 
 
-@testing.gpu
 @testing.with_requires('scipy')
 class TestFusionSpecial(_TestBase):
 
@@ -153,7 +151,6 @@ class _TestDistributionsBase:
                                 atol=atol)
 
 
-@testing.gpu
 @testing.with_requires('scipy')
 class TestTwoArgumentDistribution(_TestDistributionsBase):
 
@@ -204,7 +201,6 @@ class TestTwoArgumentDistribution(_TestDistributionsBase):
         self._test_scalar(function, args, expected)
 
 
-@testing.gpu
 @testing.with_requires('scipy')
 class TestThreeArgumentDistributions(_TestDistributionsBase):
 

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_ufunc_dispatch.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_ufunc_dispatch.py
@@ -24,7 +24,6 @@ except ImportError:
     cupyx_scipy_ufuncs = set()
 
 
-@testing.gpu
 @testing.with_requires("scipy")
 @pytest.mark.parametrize("ufunc", sorted(cupyx_scipy_ufuncs & scipy_ufuncs))
 class TestUfunc:

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_zeta.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_zeta.py
@@ -5,7 +5,6 @@ import cupyx.scipy.special  # NOQA
 import numpy
 
 
-@testing.gpu
 @testing.with_requires('scipy')
 class TestZeta(unittest.TestCase):
 

--- a/tests/cupyx_tests/scipy_tests/stats_tests/test_distributions.py
+++ b/tests/cupyx_tests/scipy_tests/stats_tests/test_distributions.py
@@ -16,7 +16,6 @@ except ImportError:
     pass
 
 
-@testing.gpu
 class TestEntropyBasic(unittest.TestCase):
     def test_entropy_positive(self):
         # See ticket SciPy's gh-497
@@ -93,7 +92,6 @@ class TestEntropyBasic(unittest.TestCase):
         'normalize': [False, True],
     })
 ))
-@testing.gpu
 @testing.with_requires('scipy>=1.4.0')
 class TestEntropy(unittest.TestCase):
 

--- a/tests/cupyx_tests/scipy_tests/test_get_array_module.py
+++ b/tests/cupyx_tests/scipy_tests/test_get_array_module.py
@@ -4,7 +4,6 @@ from cupy import testing
 import cupyx.scipy.special
 
 
-@testing.gpu
 @testing.with_requires('scipy')
 class TestSpecial(unittest.TestCase):
 

--- a/tests/cupyx_tests/test_cusolver.py
+++ b/tests/cupyx_tests/test_cusolver.py
@@ -4,7 +4,6 @@ import pytest
 import cupy
 from cupyx import cusolver
 from cupy import testing
-from cupy.testing import _attr
 from cupy._core import _routines_linalg as _linalg
 import cupyx
 
@@ -21,7 +20,6 @@ import cupyx
     'full_matrices': [True, False],
     'overwrite_a': [True, False],
 }))
-@_attr.gpu
 class TestGesvdj:
 
     @pytest.fixture(autouse=True)
@@ -81,7 +79,6 @@ class TestGesvdj:
     'dtype': [numpy.float32, numpy.float64, numpy.complex64, numpy.complex128],
     'shape': [(5, 4), (1, 4, 3), (4, 3, 2)],
 }))
-@_attr.gpu
 class TestGesvda:
 
     @pytest.fixture(autouse=True)
@@ -136,7 +133,6 @@ class TestGesvda:
     'order': ['C', 'F'],
     'UPLO': ['L', 'U'],
 }))
-@_attr.gpu
 class TestSyevj:
 
     @pytest.fixture(autouse=True)
@@ -191,7 +187,6 @@ class TestSyevj:
                      _linalg.COMPUTE_TYPE_TF32,
                      _linalg.COMPUTE_TYPE_FP32],
 }))
-@_attr.gpu
 class TestGesv:
     _tol = {'f': 1e-5, 'd': 1e-12}
 
@@ -249,7 +244,6 @@ class TestGesv:
                      _linalg.COMPUTE_TYPE_TF32,
                      _linalg.COMPUTE_TYPE_FP32],
 }))
-@_attr.gpu
 class TestGels:
     _tol = {'f': 1e-5, 'd': 1e-12}
 

--- a/tests/cupyx_tests/test_lapack.py
+++ b/tests/cupyx_tests/test_lapack.py
@@ -5,7 +5,6 @@ import pytest
 
 import cupy
 from cupy import testing
-from cupy.testing import _attr
 import cupyx
 from cupyx import cusolver, lapack
 
@@ -16,7 +15,6 @@ from cupyx import cusolver, lapack
     'nrhs': [None, 1, 4],
     'order': ['C', 'F'],
 }))
-@_attr.gpu
 class TestGesv(unittest.TestCase):
     _tol = {'f': 1e-5, 'd': 1e-12}
 
@@ -90,7 +88,6 @@ class TestGesv(unittest.TestCase):
     'shape': [(4, 4), (5, 4), (4, 5)],
     'nrhs': [None, 1, 4],
 }))
-@_attr.gpu
 class TestGels(unittest.TestCase):
     _tol = {'f': 1e-5, 'd': 1e-12}
 
@@ -111,7 +108,6 @@ class TestGels(unittest.TestCase):
     'shape': [(3, 4, 2, 2), (5, 3, 3), (7, 7)],
     'nrhs': [None, 1, 4]
 }))
-@_attr.gpu
 class TestPosv(unittest.TestCase):
 
     def setUp(self):
@@ -149,7 +145,6 @@ class TestPosv(unittest.TestCase):
     'shape': [(2, 3, 3)],
     'dtype': [numpy.float32, numpy.float64, numpy.complex64, numpy.complex128],
 }))
-@_attr.gpu
 class TestXFailBatchedPosv(unittest.TestCase):
 
     def test_posv(self):

--- a/tests/cupyx_tests/test_optimize.py
+++ b/tests/cupyx_tests/test_optimize.py
@@ -21,7 +21,6 @@ except ImportError:
     pass
 
 
-@testing.gpu
 @testing.with_requires('optuna')
 class TestOptimize(unittest.TestCase):
 
@@ -161,7 +160,6 @@ class TestOptimize(unittest.TestCase):
 @testing.parameterize(*testing.product({
     'backend': ([], ['cub'])
 }))
-@testing.gpu
 @testing.with_requires('optuna')
 class TestOptimizeBackends(unittest.TestCase):
     """This class tests if optuna is in effect for create_reduction_func()"""

--- a/tests/cupyx_tests/test_pinned_array.py
+++ b/tests/cupyx_tests/test_pinned_array.py
@@ -174,7 +174,6 @@ class TestBasic(unittest.TestCase):
         return b
 
     @testing.for_all_dtypes()
-    @testing.gpu
     def test_empty_like_K_strides(self, dtype):
         # test strides that are both non-contiguous and non-descending;
         # also test accepting cupy.ndarray
@@ -266,7 +265,6 @@ class TestBasicReshape(unittest.TestCase):
 
     @testing.for_CF_orders()
     @testing.for_all_dtypes()
-    @testing.gpu
     def test_empty_like_reshape_cupy_only(self, dtype, order):
         a = testing.shaped_arange((2, 3, 4), cupy, dtype)
         b = cupyx.empty_like_pinned(a, shape=self.shape)
@@ -291,7 +289,6 @@ class TestBasicReshape(unittest.TestCase):
 
     @testing.for_orders('CFAK')
     @testing.for_all_dtypes()
-    @testing.gpu
     def test_empty_like_reshape_contiguity_cupy_only(self, dtype, order):
         a = testing.shaped_arange((2, 3, 4), cupy, dtype)
         b = cupyx.empty_like_pinned(a, order=order, shape=self.shape)
@@ -323,7 +320,6 @@ class TestBasicReshape(unittest.TestCase):
 
     @testing.for_orders('CFAK')
     @testing.for_all_dtypes()
-    @testing.gpu
     def test_empty_like_reshape_contiguity2_cupy_only(self, dtype, order):
         a = testing.shaped_arange((2, 3, 4), cupy, dtype)
         a = cupy.asfortranarray(a)
@@ -366,7 +362,6 @@ class TestBasicReshape(unittest.TestCase):
 
     @testing.for_orders('CFAK')
     @testing.for_all_dtypes()
-    @testing.gpu
     def test_empty_like_reshape_contiguity3_cupy_only(self, dtype, order):
         a = testing.shaped_arange((2, 3, 4), cupy, dtype)
         # test strides that are both non-contiguous and non-descending
@@ -393,7 +388,6 @@ class TestBasicReshape(unittest.TestCase):
 
     @testing.with_requires('numpy>=1.17.0')
     @testing.for_all_dtypes()
-    @testing.gpu
     def test_empty_like_K_strides_reshape(self, dtype):
         # test strides that are both non-contiguous and non-descending
         a = testing.shaped_arange((2, 3, 4), numpy, dtype)
@@ -421,7 +415,6 @@ class TestBasicReshape(unittest.TestCase):
 
     @testing.for_CF_orders()
     @testing.for_all_dtypes()
-    @testing.gpu
     def test_zeros_like_reshape_cupy_only(self, dtype, order):
         a = testing.shaped_arange((2, 3, 4), cupy, dtype)
         b = cupyx.zeros_like_pinned(a, shape=self.shape)

--- a/tests/cupyx_tests/test_rsqrt.py
+++ b/tests/cupyx_tests/test_rsqrt.py
@@ -7,7 +7,6 @@ from cupy import testing
 import cupyx
 
 
-@testing.gpu
 class TestRsqrt(unittest.TestCase):
 
     @testing.for_all_dtypes(no_complex=True)

--- a/tests/install_tests/test_build.py
+++ b/tests/install_tests/test_build.py
@@ -20,7 +20,6 @@ class TestCheckVersion(unittest.TestCase):
         sysconfig.customize_compiler(self.compiler)
         self.settings = build.get_compiler_setting(ctx, False)
 
-    @pytest.mark.gpu
     @pytest.mark.skipif(not test_hip, reason='For ROCm/HIP environment')
     def test_check_hip_version(self):
         with self.assertRaises(RuntimeError):


### PR DESCRIPTION
This PR removes legacy unused test decorators: `testing.gpu` and `testing.cudnn`.