### PR TITLE
Fixup array/asarray call to prefer C order on plain NumPy arrays

### DIFF
--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -2524,7 +2524,7 @@ cdef _ndarray_base _array_from_nested_cupy_sequence(obj, dtype, shape, order):
 
 cdef _ndarray_base _array_default(obj, dtype, order, Py_ssize_t ndmin):
     if order is not None and len(order) >= 1 and order[0] in 'KAka':
-        if isinstance(obj, numpy.ndarray) and obj.flags.f_contiguous:
+        if isinstance(obj, numpy.ndarray) and obj.flags.fnc:
             order = 'F'
         else:
             order = 'C'

--- a/tests/cupy_tests/creation_tests/test_from_data.py
+++ b/tests/cupy_tests/creation_tests/test_from_data.py
@@ -45,6 +45,13 @@ class TestFromData(unittest.TestCase):
 
     @testing.for_orders('CFAK')
     @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal(strides_check=True)
+    def test_array_from_numpy_c_and_f(self, xp, dtype, order):
+        a = numpy.ones((1, 3, 1), dtype=dtype)
+        return xp.array(a, order=order)
+
+    @testing.for_orders('CFAK')
+    @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_array_from_numpy_broad_cast(self, xp, dtype, order):
         a = testing.shaped_arange((2, 1, 4), numpy, dtype)


### PR DESCRIPTION
This is a small followup to also prefer C order over F when converting from a NumPy array.

I had not realized that the original issue mentioned another similar path where it may be better to prefer C order strides (just for symmetry to NumPy, since I don't think the strides were ever wrong).