### PR TITLE
Fallback to PTX rather than CUBIN in runtime compilation

### DIFF
--- a/tests/cupy_tests/core_tests/test_include.py
+++ b/tests/cupy_tests/core_tests/test_include.py
@@ -38,22 +38,11 @@ __device__ void kernel() {
 class TestIncludesCompileCUDA:
     def _get_cuda_archs(self):
         cuda_ver = cupy.cuda.runtime.runtimeGetVersion()
-        to_exclude = set((int(a) for a in cupy.cuda.compiler._tegra_archs))
-        if cuda_ver < 11000:
-            # CUDA 10.2 (Tegra excluded)
-            archs = (30, 35, 50, 52, 60, 61, 70, 75)
-        elif cuda_ver < 11010:
-            # CUDA 11.0
-            archs = (35, 37, 50, 52, 53, 60, 61, 62, 70, 72, 75, 80)
-        elif cuda_ver < 11020:
-            # CUDA 11.1
-            archs = (35, 37, 50, 52, 53, 60, 61, 62, 70, 72, 75, 80, 86)
-        else:
-            # CUDA 11.2+
-            archs = cupy.cuda.nvrtc.getSupportedArchs()
-            if cuda_ver == 11020 or cuda_ver >= 12000:
-                to_exclude.add(69)
-        archs = tuple(set(archs) - to_exclude)
+        archs = set(cupy.cuda.compiler._get_supported_archs())
+        to_exclude = set(cupy.cuda.compiler._tegra_archs)
+        if cuda_ver == 11020 or cuda_ver >= 12000:
+            to_exclude.add(69)
+        archs = tuple(archs - to_exclude)
 
         return archs
 
@@ -74,13 +63,13 @@ class TestIncludesCompileCUDA:
         options = self._get_options()
         for arch in self._get_cuda_archs():
             with mock.patch(
-                    'cupy.cuda.compiler._get_arch_for_options_for_nvrtc',
-                    lambda _: (f'-arch=compute_{arch}', 'ptx')):
+                    'cupy.cuda.compiler._get_arch_option',
+                    lambda *_, **__: (f'-arch=compute_{arch}', 'ptx')):
                 cupy.cuda.compiler.compile_using_nvrtc(
                     _code_nvrtc, options=options)
             if cuda_ver >= 11010:
                 with mock.patch(
-                        'cupy.cuda.compiler._get_arch_for_options_for_nvrtc',
-                        lambda _: (f'-arch=sm_{arch}', 'cubin')):
+                        'cupy.cuda.compiler._get_arch_option',
+                        lambda *_, **__: (f'-arch=sm_{arch}', 'cubin')):
                     cupy.cuda.compiler.compile_using_nvrtc(
                         _code_nvrtc, options=options)


### PR DESCRIPTION
Closes #7455.

I've tested the fix with CUDA 11.7 (max supported CC = 87) against H100 (CC = 90):

Before this PR:
```
>>> import cupy
>>> cupy.arange(10)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/maehashi/Development/cupy/cupy/_creation/ranges.py", line 60, in arange
    _arange_ufunc(typ(start), typ(step), ret, dtype=dtype)
  File "cupy/_core/_kernel.pyx", line 1376, in cupy._core._kernel.ufunc.__call__
    kern = self._get_ufunc_kernel(dev_id, op, arginfos, has_where)
  File "cupy/_core/_kernel.pyx", line 1403, in cupy._core._kernel.ufunc._get_ufunc_kernel
    kern = _get_ufunc_kernel(
  File "cupy/_core/_kernel.pyx", line 1085, in cupy._core._kernel._get_ufunc_kernel
    return _get_simple_elementwise_kernel(
  File "cupy/_core/_kernel.pyx", line 95, in cupy._core._kernel._get_simple_elementwise_kernel
    return _get_simple_elementwise_kernel_from_code(name, code, options)
  File "cupy/_core/_kernel.pyx", line 83, in cupy._core._kernel._get_simple_elementwise_kernel_from_code
    module = compile_with_cache(code, options)
  File "cupy/_core/core.pyx", line 2257, in cupy._core.core.compile_with_cache
    return cuda.compiler._compile_module_with_cache(
  File "/home/maehashi/Development/cupy/cupy/cuda/compiler.py", line 496, in _compile_module_with_cache
    return _compile_with_cache_cuda(
  File "/home/maehashi/Development/cupy/cupy/cuda/compiler.py", line 618, in _compile_with_cache_cuda
    mod.load(cubin)
  File "cupy/cuda/function.pyx", line 264, in cupy.cuda.function.Module.load
    cpdef load(self, bytes cubin):
  File "cupy/cuda/function.pyx", line 266, in cupy.cuda.function.Module.load
    self.ptr = driver.moduleLoadData(cubin)
  File "cupy_backends/cuda/api/driver.pyx", line 210, in cupy_backends.cuda.api.driver.moduleLoadData
    check_status(status)
  File "cupy_backends/cuda/api/driver.pyx", line 60, in cupy_backends.cuda.api.driver.check_status
    raise CUDADriverError(status)
cupy_backends.cuda.api.driver.CUDADriverError: CUDA_ERROR_INVALID_SOURCE: device kernel image is invalid
```

After this PR:

```
>>> import cupy
>>> cupy.arange(10)
/home/maehashi/Development/cupy/cupy/cuda/compiler.py:176: UserWarning: The compute capability of the current device (90) is not supported by this version of CUDA; falling back to compute capability 87
  warnings.warn(
array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
```