### PR TITLE
Support CUDA 12.1

### DIFF
--- a/.pfnci/config.pbtxt
+++ b/.pfnci/config.pbtxt
@@ -415,6 +415,42 @@ configs {
   }
 }
 
+# CUDA 12.1 | Linux
+configs {
+  key: "cupy.linux.cuda121"
+  value {
+    requirement {
+      cpu: 8
+      memory: 50
+      disk: 10
+      gpu: 1
+    }
+    time_limit: {
+      seconds: 21600
+    }
+    environment_variables { key: "GPU" value: "1" }
+    command: ".pfnci/linux/main-flexci.sh cuda121"
+  }
+}
+
+# CUDA 12.1 (Multi-GPU) | Linux
+configs {
+  key: "cupy.linux.cuda121.multi"
+  value {
+    requirement {
+      cpu: 8
+      memory: 50
+      disk: 10
+      gpu: 2
+    }
+    time_limit: {
+      seconds: 21600
+    }
+    environment_variables { key: "GPU" value: "2" }
+    command: ".pfnci/linux/main-flexci.sh cuda121.multi"
+  }
+}
+
 # CUDA 11.x + CUDA Python
 configs {
   key: "cupy.linux.cuda11x-cuda-python"
@@ -826,5 +862,26 @@ configs {
     }
     environment_variables { key: "GPU" value: "2" }
     command: ".pfnci\\windows\\run.bat 12.0 3.10 test"
+  }
+}
+
+configs {
+  key: "cupy.win.cuda121"
+  value {
+    requirement {
+      cpu: 8
+      memory: 24
+      disk: 10
+      gpu: 2
+      image: "windows"
+    }
+    time_limit {
+      seconds: 36000
+    }
+    checkout_strategy {
+      include_dot_git: true
+    }
+    environment_variables { key: "GPU" value: "2" }
+    command: ".pfnci\\windows\\run.bat 12.1 3.10 test"
   }
 }

--- a/.pfnci/config.tags.json
+++ b/.pfnci/config.tags.json
@@ -126,6 +126,19 @@
         "multi",
         "cuda120"
     ],
+    "cupy.linux.cuda121": [
+        "@push",
+        "full",
+        "mini",
+        "cuda121"
+    ],
+    "cupy.linux.cuda121.multi": [
+        "@push",
+        "full",
+        "mini",
+        "multi",
+        "cuda121"
+    ],
     "cupy.linux.cuda-slow": [
         "slow"
     ],

--- a/.pfnci/coverage.rst
+++ b/.pfnci/coverage.rst
@@ -41,9 +41,13 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
    * - 
      - System
      - 
+     - linux
+     - linux
      - linux
      - linux
      - linux
@@ -100,16 +104,20 @@ CuPy CI Test Coverage
      - `cuda118.multi <t19_>`_ `🐳 <d19_>`_ `📜 <s19_>`_
      - `cuda120 <t20_>`_ `🐳 <d20_>`_ `📜 <s20_>`_
      - `cuda120.multi <t21_>`_ `🐳 <d21_>`_ `📜 <s21_>`_
-     - `rocm-4-3 <t22_>`_ `🐳 <d22_>`_ `📜 <s22_>`_
-     - `rocm-5-0 <t23_>`_ `🐳 <d23_>`_ `📜 <s23_>`_
-     - `rocm-5-3 <t24_>`_ `🐳 <d24_>`_ `📜 <s24_>`_
-     - `cuda-slow <t25_>`_ `🐳 <d25_>`_ `📜 <s25_>`_
-     - `cuda-example <t26_>`_ `🐳 <d26_>`_ `📜 <s26_>`_
-     - `cuda-head <t27_>`_ `🐳 <d27_>`_ `📜 <s27_>`_
-     - `cuda11x-cuda-python <t28_>`_ `🐳 <d28_>`_ `📜 <s28_>`_
-     - `benchmark.head <t29_>`_ `🐳 <d29_>`_ `📜 <s29_>`_
-     - `benchmark <t30_>`_ `🐳 <d30_>`_ `📜 <s30_>`_
+     - `cuda121 <t22_>`_ `🐳 <d22_>`_ `📜 <s22_>`_
+     - `cuda121.multi <t23_>`_ `🐳 <d23_>`_ `📜 <s23_>`_
+     - `rocm-4-3 <t24_>`_ `🐳 <d24_>`_ `📜 <s24_>`_
+     - `rocm-5-0 <t25_>`_ `🐳 <d25_>`_ `📜 <s25_>`_
+     - `rocm-5-3 <t26_>`_ `🐳 <d26_>`_ `📜 <s26_>`_
+     - `cuda-slow <t27_>`_ `🐳 <d27_>`_ `📜 <s27_>`_
+     - `cuda-example <t28_>`_ `🐳 <d28_>`_ `📜 <s28_>`_
+     - `cuda-head <t29_>`_ `🐳 <d29_>`_ `📜 <s29_>`_
+     - `cuda11x-cuda-python <t30_>`_ `🐳 <d30_>`_ `📜 <s30_>`_
+     - `benchmark.head <t31_>`_ `🐳 <d31_>`_ `📜 <s31_>`_
+     - `benchmark <t32_>`_ `🐳 <d32_>`_ `📜 <s32_>`_
    * - 
+     - 
+     - 
      - 
      - 
      - 
@@ -145,7 +153,9 @@ CuPy CI Test Coverage
      - 
    * - system
      - linux
-     - 31
+     - 33
+     - ✅
+     - ✅
      - ✅
      - ✅
      - ✅
@@ -211,6 +221,8 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
    * - os
      - ubuntu:18.04
      - 4
@@ -245,9 +257,11 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
    * - 
      - ubuntu:20.04
-     - 23
+     - 25
      - 
      - 
      - ✅
@@ -258,6 +272,8 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - ✅
+     - ✅
      - ✅
      - ✅
      - ✅
@@ -313,9 +329,13 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
    * - 
      - centos:8
      - 🚨
+     - 
+     - 
      - 
      - 
      - 
@@ -381,9 +401,13 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
    * - cuda
      - null
      - 3
+     - 
+     - 
      - 
      - 
      - 
@@ -449,6 +473,8 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
    * - 
      - 11.0
      - 2
@@ -456,6 +482,8 @@ CuPy CI Test Coverage
      - 
      - ✅
      - ✅
+     - 
+     - 
      - 
      - 
      - 
@@ -517,6 +545,8 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
    * - 
      - 11.2
      - 2
@@ -528,6 +558,8 @@ CuPy CI Test Coverage
      - 
      - ✅
      - ✅
+     - 
+     - 
      - 
      - 
      - 
@@ -585,6 +617,8 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
    * - 
      - 11.4
      - 2
@@ -600,6 +634,8 @@ CuPy CI Test Coverage
      - 
      - ✅
      - ✅
+     - 
+     - 
      - 
      - 
      - 
@@ -653,6 +689,8 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
    * - 
      - 11.6
      - 3
@@ -672,6 +710,8 @@ CuPy CI Test Coverage
      - 
      - ✅
      - ✅
+     - 
+     - 
      - 
      - 
      - 
@@ -721,6 +761,8 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
    * - 
      - 11.8
      - 7
@@ -744,6 +786,8 @@ CuPy CI Test Coverage
      - 
      - ✅
      - ✅
+     - 
+     - 
      - 
      - 
      - 
@@ -789,9 +833,49 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
+   * - 
+     - 12.1
+     - 2
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - ✅
+     - ✅
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
    * - rocm
      - null
-     - 28
+     - 30
+     - ✅
+     - ✅
      - ✅
      - ✅
      - ✅
@@ -848,6 +932,8 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
      - ✅
      - 
      - 
@@ -860,6 +946,8 @@ CuPy CI Test Coverage
    * - 
      - 5.0
      - 1
+     - 
+     - 
      - 
      - 
      - 
@@ -918,6 +1006,8 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
      - ✅
      - 
      - 
@@ -928,6 +1018,8 @@ CuPy CI Test Coverage
    * - nccl
      - null
      - 3
+     - 
+     - 
      - 
      - 
      - 
@@ -993,6 +1085,8 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
    * - 
      - 2.9
      - 2
@@ -1006,6 +1100,8 @@ CuPy CI Test Coverage
      - 
      - ✅
      - ✅
+     - 
+     - 
      - 
      - 
      - 
@@ -1061,6 +1157,8 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
    * - 
      - 2.11
      - 3
@@ -1078,6 +1176,8 @@ CuPy CI Test Coverage
      - 
      - ✅
      - ✅
+     - 
+     - 
      - 
      - 
      - 
@@ -1129,6 +1229,8 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
    * - 
      - 2.13
      - 2
@@ -1163,9 +1265,13 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
    * - 
      - 2.14
      - 🚨
+     - 
+     - 
      - 
      - 
      - 
@@ -1231,6 +1337,8 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
    * - 
      - 2.16
      - 9
@@ -1259,17 +1367,57 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
      - ✅
      - ✅
      - ✅
      - 
      - ✅
      - ✅
+   * - 
+     - 2.17
+     - 2
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - ✅
+     - ✅
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
    * - cutensor
      - null
      - 5
      - ✅
      - ✅
+     - 
+     - 
      - 
      - 
      - 
@@ -1333,6 +1481,8 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
    * - 
      - 1.5
      - 11
@@ -1354,6 +1504,8 @@ CuPy CI Test Coverage
      - ✅
      - ✅
      - ✅
+     - 
+     - 
      - 
      - 
      - 
@@ -1395,12 +1547,50 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
      - ✅
      - ✅
      - ✅
      - 
      - ✅
      - ✅
+   * - 
+     - 1.7
+     - 2
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - ✅
+     - ✅
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
    * - cusparselt
      - null
      - 11
@@ -1426,6 +1616,8 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
      - ✅
      - ✅
      - ✅
@@ -1437,7 +1629,7 @@ CuPy CI Test Coverage
      - 
    * - 
      - 0.2.0
-     - 20
+     - 22
      - 
      - 
      - 
@@ -1448,6 +1640,8 @@ CuPy CI Test Coverage
      - ✅
      - 
      - 
+     - ✅
+     - ✅
      - ✅
      - ✅
      - ✅
@@ -1472,6 +1666,8 @@ CuPy CI Test Coverage
    * - cudnn
      - null
      - 3
+     - 
+     - 
      - 
      - 
      - 
@@ -1537,6 +1733,8 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
    * - 
      - 8.0
      - 2
@@ -1546,6 +1744,8 @@ CuPy CI Test Coverage
      - 
      - ✅
      - ✅
+     - 
+     - 
      - 
      - 
      - 
@@ -1605,6 +1805,8 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
    * - 
      - 8.2
      - 4
@@ -1618,6 +1820,8 @@ CuPy CI Test Coverage
      - 
      - ✅
      - ✅
+     - 
+     - 
      - 
      - 
      - 
@@ -1673,6 +1877,8 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
    * - 
      - 8.4
      - 2
@@ -1690,6 +1896,8 @@ CuPy CI Test Coverage
      - 
      - ✅
      - ✅
+     - 
+     - 
      - 
      - 
      - 
@@ -1738,12 +1946,16 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
      - ✅
      - 
      - 
    * - 
      - 8.6
      - 3
+     - 
+     - 
      - 
      - 
      - 
@@ -1809,9 +2021,11 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
    * - 
      - 8.8
-     - 6
+     - 8
      - 
      - 
      - 
@@ -1830,6 +2044,8 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - ✅
+     - ✅
      - ✅
      - ✅
      - ✅
@@ -1846,6 +2062,8 @@ CuPy CI Test Coverage
    * - python
      - 3.7
      - 🚨
+     - 
+     - 
      - 
      - 
      - 
@@ -1902,6 +2120,8 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
      - ✅
      - 
      - 
@@ -1918,6 +2138,8 @@ CuPy CI Test Coverage
      - 
      - ✅
      - ✅
+     - 
+     - 
      - 
      - 
      - 
@@ -1971,6 +2193,8 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
      - ✅
      - 
      - 
@@ -1981,7 +2205,7 @@ CuPy CI Test Coverage
      - 
    * - 
      - 3.11
-     - 13
+     - 15
      - 
      - 
      - 
@@ -1996,6 +2220,8 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - ✅
+     - ✅
      - ✅
      - ✅
      - ✅
@@ -2016,6 +2242,8 @@ CuPy CI Test Coverage
    * - 
      - pre
      - 🚨
+     - 
+     - 
      - 
      - 
      - 
@@ -2072,6 +2300,8 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
      - ✅
      - 
      - 
@@ -2092,6 +2322,8 @@ CuPy CI Test Coverage
      - 
      - ✅
      - ✅
+     - 
+     - 
      - 
      - 
      - 
@@ -2149,9 +2381,11 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
    * - 
      - 1.23
-     - 10
+     - 12
      - 
      - 
      - 
@@ -2172,6 +2406,8 @@ CuPy CI Test Coverage
      - ✅
      - 
      - 
+     - ✅
+     - ✅
      - ✅
      - ✅
      - 
@@ -2210,6 +2446,8 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
      - ✅
      - 
      - 
@@ -2220,6 +2458,8 @@ CuPy CI Test Coverage
    * - 
      - pre
      - 1
+     - 
+     - 
      - 
      - 
      - 
@@ -2285,6 +2525,8 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
    * - 
      - 1.6
      - 5
@@ -2298,6 +2540,8 @@ CuPy CI Test Coverage
      - 
      - ✅
      - ✅
+     - 
+     - 
      - 
      - 
      - 
@@ -2334,6 +2578,8 @@ CuPy CI Test Coverage
      - 
      - ✅
      - ✅
+     - 
+     - 
      - 
      - 
      - 
@@ -2387,9 +2633,11 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
    * - 
      - 1.9
-     - 13
+     - 15
      - 
      - 
      - 
@@ -2404,6 +2652,8 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - ✅
+     - ✅
      - ✅
      - ✅
      - ✅
@@ -2424,6 +2674,8 @@ CuPy CI Test Coverage
    * - 
      - pre
      - 1
+     - 
+     - 
      - 
      - 
      - 
@@ -2489,15 +2741,19 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
    * - 
      - 3
-     - 28
+     - 30
      - ✅
      - ✅
      - ✅
      - ✅
      - 
      - 
+     - ✅
+     - ✅
      - ✅
      - ✅
      - ✅
@@ -2553,13 +2809,15 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
      - ✅
      - 
      - 
      - 
    * - mpi4py
      - null
-     - 22
+     - 23
      - ✅
      - 
      - ✅
@@ -2568,6 +2826,8 @@ CuPy CI Test Coverage
      - ✅
      - ✅
      - ✅
+     - ✅
+     - 
      - ✅
      - 
      - ✅
@@ -2593,7 +2853,7 @@ CuPy CI Test Coverage
      - ✅
    * - 
      - 3
-     - 9
+     - 10
      - 
      - ✅
      - 
@@ -2602,6 +2862,8 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - ✅
      - 
      - ✅
      - 
@@ -2627,7 +2889,9 @@ CuPy CI Test Coverage
      - 
    * - cython
      - 0.29
-     - 31
+     - 33
+     - ✅
+     - ✅
      - ✅
      - ✅
      - ✅
@@ -2693,9 +2957,13 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
    * - cuda-python
      - null
-     - 30
+     - 32
+     - ✅
+     - ✅
      - ✅
      - ✅
      - ✅
@@ -2758,6 +3026,8 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
      - ✅
      - 
      - 
@@ -2766,6 +3036,8 @@ CuPy CI Test Coverage
      - 5
      - ✅
      - ✅
+     - 
+     - 
      - 
      - 
      - 
@@ -2824,6 +3096,8 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
      - ✅
      - 
      - 
@@ -2832,6 +3106,8 @@ CuPy CI Test Coverage
    * - 
      - cub
      - 🚨
+     - 
+     - 
      - 
      - 
      - 
@@ -2897,6 +3173,8 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
    * - 
      - cub,cutensor
      - 5
@@ -2927,13 +3205,15 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
      - ✅
      - 
      - 
      - 
    * - 
      - cutensor,cub
-     - 18
+     - 20
      - 
      - 
      - 
@@ -2944,6 +3224,8 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - ✅
+     - ✅
      - ✅
      - ✅
      - ✅
@@ -2967,7 +3249,9 @@ CuPy CI Test Coverage
      - ✅
    * - test
      - unit
-     - 16
+     - 17
+     - ✅
+     - 
      - ✅
      - 
      - ✅
@@ -3001,7 +3285,9 @@ CuPy CI Test Coverage
      - 
    * - 
      - unit-multi
-     - 11
+     - 12
+     - 
+     - ✅
      - 
      - ✅
      - 
@@ -3036,6 +3322,8 @@ CuPy CI Test Coverage
    * - 
      - unit-slow
      - 1
+     - 
+     - 
      - 
      - 
      - 
@@ -3096,6 +3384,8 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
      - ✅
      - 
      - 
@@ -3104,6 +3394,8 @@ CuPy CI Test Coverage
    * - 
      - benchmark
      - 2
+     - 
+     - 
      - 
      - 
      - 
@@ -3202,30 +3494,36 @@ CuPy CI Test Coverage
 .. _t21: https://ci.preferred.jp/cupy.linux.cuda120.multi/
 .. _d21: linux/tests/cuda120.multi.Dockerfile
 .. _s21: linux/tests/cuda120.multi.sh
-.. _t22: https://jenkins.preferred.jp/job/chainer/job/cupy_main/TEST=rocm-4-3,label=mnj-mi50/
-.. _d22: linux/tests/rocm-4-3.Dockerfile
-.. _s22: linux/tests/rocm-4-3.sh
-.. _t23: https://jenkins.preferred.jp/job/chainer/job/cupy_main/TEST=rocm-5-0,label=mnj-mi50/
-.. _d23: linux/tests/rocm-5-0.Dockerfile
-.. _s23: linux/tests/rocm-5-0.sh
-.. _t24: https://jenkins.preferred.jp/job/chainer/job/cupy_main/TEST=rocm-5-3,label=mnj-mi50/
-.. _d24: linux/tests/rocm-5-3.Dockerfile
-.. _s24: linux/tests/rocm-5-3.sh
-.. _t25: https://ci.preferred.jp/cupy.linux.cuda-slow/
-.. _d25: linux/tests/cuda-slow.Dockerfile
-.. _s25: linux/tests/cuda-slow.sh
-.. _t26: https://ci.preferred.jp/cupy.linux.cuda-example/
-.. _d26: linux/tests/cuda-example.Dockerfile
-.. _s26: linux/tests/cuda-example.sh
-.. _t27: https://ci.preferred.jp/cupy.linux.cuda-head/
-.. _d27: linux/tests/cuda-head.Dockerfile
-.. _s27: linux/tests/cuda-head.sh
-.. _t28: https://ci.preferred.jp/cupy.linux.cuda11x-cuda-python/
-.. _d28: linux/tests/cuda11x-cuda-python.Dockerfile
-.. _s28: linux/tests/cuda11x-cuda-python.sh
-.. _t29: https://ci.preferred.jp/cupy.linux.benchmark.head/
-.. _d29: linux/tests/benchmark.head.Dockerfile
-.. _s29: linux/tests/benchmark.head.sh
-.. _t30: https://ci.preferred.jp/cupy.linux.benchmark.pr/
-.. _d30: linux/tests/benchmark.Dockerfile
-.. _s30: linux/tests/benchmark.sh
+.. _t22: https://ci.preferred.jp/cupy.linux.cuda121/
+.. _d22: linux/tests/cuda121.Dockerfile
+.. _s22: linux/tests/cuda121.sh
+.. _t23: https://ci.preferred.jp/cupy.linux.cuda121.multi/
+.. _d23: linux/tests/cuda121.multi.Dockerfile
+.. _s23: linux/tests/cuda121.multi.sh
+.. _t24: https://jenkins.preferred.jp/job/chainer/job/cupy_main/TEST=rocm-4-3,label=mnj-mi50/
+.. _d24: linux/tests/rocm-4-3.Dockerfile
+.. _s24: linux/tests/rocm-4-3.sh
+.. _t25: https://jenkins.preferred.jp/job/chainer/job/cupy_main/TEST=rocm-5-0,label=mnj-mi50/
+.. _d25: linux/tests/rocm-5-0.Dockerfile
+.. _s25: linux/tests/rocm-5-0.sh
+.. _t26: https://jenkins.preferred.jp/job/chainer/job/cupy_main/TEST=rocm-5-3,label=mnj-mi50/
+.. _d26: linux/tests/rocm-5-3.Dockerfile
+.. _s26: linux/tests/rocm-5-3.sh
+.. _t27: https://ci.preferred.jp/cupy.linux.cuda-slow/
+.. _d27: linux/tests/cuda-slow.Dockerfile
+.. _s27: linux/tests/cuda-slow.sh
+.. _t28: https://ci.preferred.jp/cupy.linux.cuda-example/
+.. _d28: linux/tests/cuda-example.Dockerfile
+.. _s28: linux/tests/cuda-example.sh
+.. _t29: https://ci.preferred.jp/cupy.linux.cuda-head/
+.. _d29: linux/tests/cuda-head.Dockerfile
+.. _s29: linux/tests/cuda-head.sh
+.. _t30: https://ci.preferred.jp/cupy.linux.cuda11x-cuda-python/
+.. _d30: linux/tests/cuda11x-cuda-python.Dockerfile
+.. _s30: linux/tests/cuda11x-cuda-python.sh
+.. _t31: https://ci.preferred.jp/cupy.linux.benchmark.head/
+.. _d31: linux/tests/benchmark.head.Dockerfile
+.. _s31: linux/tests/benchmark.head.sh
+.. _t32: https://ci.preferred.jp/cupy.linux.benchmark.pr/
+.. _d32: linux/tests/benchmark.Dockerfile
+.. _s32: linux/tests/benchmark.sh

--- a/.pfnci/generate.py
+++ b/.pfnci/generate.py
@@ -607,10 +607,14 @@ def main(argv: List[str]) -> int:
     for filename, content in output.items():
         filepath = f'{out_basedir}/{filename}'
         if options.dry_run:
-            with open(filepath) as f:
-                if f.read() != content:
-                    log(f'{filepath} needs to be regenerated')
-                    retval = 1
+            if os.path.exists(filepath):
+                with open(filepath) as f:
+                    if f.read() != content:
+                        log(f'{filepath} needs to be regenerated')
+                        retval = 1
+            else:
+                log(f'{filepath} needs to be generated')
+                retval = 1
         else:
             log(f'Writing {filepath}', options.verbose)
             with open(filepath, 'w') as f:

--- a/.pfnci/linux/tests/cuda121.Dockerfile
+++ b/.pfnci/linux/tests/cuda121.Dockerfile
@@ -1,0 +1,33 @@
+# AUTO GENERATED: DO NOT EDIT!
+ARG BASE_IMAGE="nvidia/cuda:12.1.0-devel-ubuntu20.04"
+FROM ${BASE_IMAGE}
+
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get -qqy update && \
+    apt-get -qqy install \
+       make build-essential libssl-dev zlib1g-dev \
+       libbz2-dev libreadline-dev libsqlite3-dev wget \
+       curl llvm libncursesw5-dev xz-utils tk-dev \
+       libxml2-dev libxmlsec1-dev libffi-dev \
+       liblzma-dev \
+\
+       && \
+    apt-get -qqy install ccache git curl && \
+    apt-get -qqy --allow-change-held-packages \
+            --allow-downgrades install 'libnccl2=2.17.*+cuda12.1' 'libnccl-dev=2.17.*+cuda12.1' 'libcutensor1=1.7.*' 'libcutensor-dev=1.7.*' 'libcusparselt0=0.2.0.*' 'libcusparselt-dev=0.2.0.*' 'libcudnn8=8.8.*+cuda12.0' 'libcudnn8-dev=8.8.*+cuda12.0'
+
+ENV PATH "/usr/lib/ccache:${PATH}"
+
+COPY setup/update-alternatives-cutensor.sh /
+RUN /update-alternatives-cutensor.sh
+
+RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
+ENV PYENV_ROOT "/opt/pyenv"
+ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
+RUN pyenv install 3.11.0 && \
+    pyenv global 3.11.0 && \
+    pip install -U setuptools pip
+
+RUN pip install -U 'numpy==1.23.*' 'scipy==1.9.*' 'optuna==3.*' 'cython==0.29.*'
+RUN pip uninstall -y mpi4py cuda-python && \
+    pip check

--- a/.pfnci/linux/tests/cuda121.multi.Dockerfile
+++ b/.pfnci/linux/tests/cuda121.multi.Dockerfile
@@ -1,0 +1,33 @@
+# AUTO GENERATED: DO NOT EDIT!
+ARG BASE_IMAGE="nvidia/cuda:12.1.0-devel-ubuntu20.04"
+FROM ${BASE_IMAGE}
+
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get -qqy update && \
+    apt-get -qqy install \
+       make build-essential libssl-dev zlib1g-dev \
+       libbz2-dev libreadline-dev libsqlite3-dev wget \
+       curl llvm libncursesw5-dev xz-utils tk-dev \
+       libxml2-dev libxmlsec1-dev libffi-dev \
+       liblzma-dev \
+       libopenmpi-dev \
+       && \
+    apt-get -qqy install ccache git curl && \
+    apt-get -qqy --allow-change-held-packages \
+            --allow-downgrades install 'libnccl2=2.17.*+cuda12.1' 'libnccl-dev=2.17.*+cuda12.1' 'libcutensor1=1.7.*' 'libcutensor-dev=1.7.*' 'libcusparselt0=0.2.0.*' 'libcusparselt-dev=0.2.0.*' 'libcudnn8=8.8.*+cuda12.0' 'libcudnn8-dev=8.8.*+cuda12.0'
+
+ENV PATH "/usr/lib/ccache:${PATH}"
+
+COPY setup/update-alternatives-cutensor.sh /
+RUN /update-alternatives-cutensor.sh
+
+RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
+ENV PYENV_ROOT "/opt/pyenv"
+ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
+RUN pyenv install 3.11.0 && \
+    pyenv global 3.11.0 && \
+    pip install -U setuptools pip
+
+RUN pip install -U 'numpy==1.23.*' 'scipy==1.9.*' 'optuna==3.*' 'mpi4py==3.*' 'cython==0.29.*'
+RUN pip uninstall -y cuda-python && \
+    pip check

--- a/.pfnci/linux/tests/cuda121.multi.sh
+++ b/.pfnci/linux/tests/cuda121.multi.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# AUTO GENERATED: DO NOT EDIT!
+
+set -uex
+
+ACTIONS="$(dirname $0)/actions"
+. "$ACTIONS/_environment.sh"
+
+export NVCC="ccache nvcc"
+
+export CUPY_ACCELERATORS="cutensor,cub"
+
+"$ACTIONS/build.sh"
+export OMPI_ALLOW_RUN_AS_ROOT=1
+export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
+"$ACTIONS/unittest.sh" "not slow and multi_gpu"
+"$ACTIONS/cleanup.sh"

--- a/.pfnci/linux/tests/cuda121.sh
+++ b/.pfnci/linux/tests/cuda121.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# AUTO GENERATED: DO NOT EDIT!
+
+set -uex
+
+ACTIONS="$(dirname $0)/actions"
+. "$ACTIONS/_environment.sh"
+
+export NVCC="ccache nvcc"
+
+export CUPY_ACCELERATORS="cutensor,cub"
+
+"$ACTIONS/build.sh"
+"$ACTIONS/unittest.sh" "not slow and not multi_gpu"
+"$ACTIONS/cleanup.sh"

--- a/.pfnci/matrix.yaml
+++ b/.pfnci/matrix.yaml
@@ -304,7 +304,6 @@
   test: "unit-multi"
 
 # CUDA 12.0 | Linux
-# The latest CUDA version matrix is intended to cover the highest supported combination.
 - project: "cupy.linux.cuda120"
   target: "cuda120"
   tags: ["@push", "full", "mini", "cuda120"]
@@ -333,6 +332,38 @@
   target: "cuda120.multi"
   mpi4py: "3"
   test: "unit-multi"
+
+# CUDA 12.1 | Linux
+# The latest CUDA version matrix is intended to cover the highest supported combination.
+- project: "cupy.linux.cuda121"
+  target: "cuda121"
+  tags: ["@push", "full", "mini", "cuda121"]
+  system: "linux"
+  os: "ubuntu:20.04"
+  cuda: "12.1"
+  rocm: null
+  nccl: "2.17"
+  cutensor: "1.7"
+  cusparselt: "0.2.0"
+  cudnn: "8.8"
+  python: "3.11"
+  numpy: "1.23"
+  scipy: "1.9"
+  optuna: "3"
+  mpi4py: null
+  cython: "0.29"
+  cuda-python: null
+  env:CUPY_ACCELERATORS: "cutensor,cub"
+  test: "unit"
+
+# CUDA 12.1 (Multi-GPU) | Linux
+- project: "cupy.linux.cuda121.multi"
+  _inherits: "cupy.linux.cuda121"
+  tags: ["@push", "full", "mini", "multi", "cuda121"]
+  target: "cuda121.multi"
+  mpi4py: "3"
+  test: "unit-multi"
+
 
 ###############################################################################
 # CUDA (Windows)

--- a/.pfnci/schema.yaml
+++ b/.pfnci/schema.yaml
@@ -55,6 +55,8 @@ cuda:
     full_version: "11.8.0"
   "12.0":
     full_version: "12.0.0"
+  "12.1":
+    full_version: "12.1.0"
 rocm:
   null:
     full_version: null
@@ -146,6 +148,12 @@ nccl:
       "11.0":
       "11.8":
       "12.0":
+  "2.17":
+    spec: "2.17.*"
+    cuda:
+      "11.0":
+      "12.0":
+      "12.1":
 cutensor:
   # https://docs.nvidia.com/cuda/cutensor/
   # https://developer.nvidia.com/cutensor/downloads
@@ -188,6 +196,14 @@ cutensor:
       "11.7":
       "11.8":
       "12.0":  # v1.6.2+
+  "1.7":
+    spec: "1.7.*"
+    cuda:
+      # "10.2":  -- cuTENSOR distributed through binary package does not support CUDA 10.2
+      "11.0":
+      "11.8":
+      "12.0":
+      "12.1":
 cusparselt:
   # https://docs.nvidia.com/cuda/cusparselt/
   # https://developer.nvidia.com/cusparselt/downloads
@@ -204,6 +220,7 @@ cusparselt:
       "11.7":
       "11.8":
       "12.0":  # TODO(kmaehashi): Tentatively use v0.2.0 for CUDA 12
+      "12.1":  # TODO(kmaehashi): Tentatively use v0.2.0 for CUDA 12
 cudnn:
   # https://docs.nvidia.com/deeplearning/cudnn/support-matrix/index.html
   # https://docs.nvidia.com/deeplearning/cudnn/archives/
@@ -373,6 +390,8 @@ cudnn:
       "11.8":
         alias: "11.8"
       "12.0":
+        alias: "12.0"
+      "12.1":
         alias: "12.0"
 
 

--- a/.pfnci/windows/_flexci.ps1
+++ b/.pfnci/windows/_flexci.ps1
@@ -44,8 +44,10 @@ function ActivateCUDA($version) {
         $Env:CUDA_PATH = $Env:CUDA_PATH_V11_8
     } elseif ($version -eq "12.0") {
         $Env:CUDA_PATH = $Env:CUDA_PATH_V12_0
+    } elseif ($version -eq "12.1") {
+        $Env:CUDA_PATH = $Env:CUDA_PATH_V12_1
     } elseif ($version -eq "12.x") {
-        $Env:CUDA_PATH = $Env:CUDA_PATH_V12_0
+        $Env:CUDA_PATH = $Env:CUDA_PATH_V12_1
     } else {
         throw "Unsupported CUDA version: $version"
     }

--- a/cupy/_core/include/cupy/_cuda/cuda-12/cuda_fp16.h
+++ b/cupy/_core/include/cupy/_cuda/cuda-12/cuda_fp16.h
@@ -52,6 +52,19 @@
 * This section describes half precision intrinsic functions that are
 * only supported in device code.
 * To use these functions, include the header file \p cuda_fp16.h in your program.
+* The following macros are available to help users selectively enable/disable
+* various definitions present in the header file:
+* - \p CUDA_NO_HALF - If defined, this macro will prevent the definition of
+* additional type aliases in the global namespace, helping to avoid potential
+* conflicts with symbols defined in the user program.
+* - \p __CUDA_NO_HALF_CONVERSIONS__ - If defined, this macro will prevent the
+* use of the C++ type conversions (converting constructors and conversion
+* operators) that are common for built-in floating-point types, but may be
+* undesirable for \p half which is essentially a user-defined type.
+* - \p __CUDA_NO_HALF_OPERATORS__ and \p __CUDA_NO_HALF2_OPERATORS__ - If
+* defined, these macros will prevent the inadvertent use of usual arithmetic
+* and comparison operators. This enforces the storage-only type semantics and
+* prevents C++ style computations on \p half and \p half2 types.
 */
 
 /**


### PR DESCRIPTION
Depends on ~#7472~ (merged)

Ref #7441, #7378, #7471

CI for CUDA 12.1:
* https://ci.preferred.jp/cupy.linux.cuda121/126591/
* https://ci.preferred.jp/cupy.linux.cuda121.multi/126592/
* https://ci.preferred.jp/cupy.win.cuda121/126632/