### PR TITLE
add `cupyx.scipy.special.exprel`

### DIFF
--- a/cupyx/scipy/special/__init__.py
+++ b/cupyx/scipy/special/__init__.py
@@ -101,6 +101,7 @@ from cupyx.scipy.special._basic import tandg  # NOQA
 from cupyx.scipy.special._basic import cotdg  # NOQA
 from cupyx.scipy.special._basic import log1p  # NOQA
 from cupyx.scipy.special._basic import expm1  # NOQA
+from cupyx.scipy.special._basic import exprel  # NOQA
 from cupyx.scipy.special._basic import cosm1  # NOQA
 from cupy._math.rounding import round_ as round  # NOQA
 from cupyx.scipy.special._xlogy import xlogy  # NOQA

--- a/cupyx/scipy/special/_basic.py
+++ b/cupyx/scipy/special/_basic.py
@@ -93,7 +93,7 @@ expm1 = _core.create_ufunc(
 exprel = _core.create_ufunc(
     'cupyx_scipy_special_exprel',
     (('f->f'), 'd->d', 'F->F', 'D->D'),
-    'out0 = expm1(in0) / in0',
+    'out0 = abs(in0) >= 1e-16 ? expm1(in0) / in0 : 1',
     doc='''Computes ``(exp(x) - 1) / x``.
 
     .. seealso:: :meth:`scipy.special.exprel`

--- a/cupyx/scipy/special/_basic.py
+++ b/cupyx/scipy/special/_basic.py
@@ -90,6 +90,16 @@ expm1 = _core.create_ufunc(
 
     ''')
 
+exprel = _core.create_ufunc(
+    'cupyx_scipy_special_exprel',
+    (('f->f', 'out0 = exprelf(in0)'), 'd->d', 'F->F', 'D->D'),
+    'out0 = expm1(in0) / in0',
+    doc='''Computes ``(exp(x) - 1) / x``.
+
+    .. seealso:: :meth:`scipy.special.exprel`
+
+    ''')
+
 cosm1_implementation = """
 //Define from npy_math.h
 //https://github.com/numpy/numpy/blob/main/numpy/core/include/numpy/npy_math.h

--- a/cupyx/scipy/special/_basic.py
+++ b/cupyx/scipy/special/_basic.py
@@ -92,7 +92,7 @@ expm1 = _core.create_ufunc(
 
 exprel = _core.create_ufunc(
     'cupyx_scipy_special_exprel',
-    (('f->f', 'out0 = exprelf(in0)'), 'd->d', 'F->F', 'D->D'),
+    (('f->f'), 'd->d', 'F->F', 'D->D'),
     'out0 = expm1(in0) / in0',
     doc='''Computes ``(exp(x) - 1) / x``.
 

--- a/docs/source/reference/scipy_special.rst
+++ b/docs/source/reference/scipy_special.rst
@@ -135,6 +135,7 @@ Other special functions
    exp1
    expi
    expn
+   exprel
    softmax
    log_softmax
    zeta

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_exprel.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_exprel.py
@@ -1,0 +1,56 @@
+import cupyx.scipy.special  # NOQA
+
+import cupy
+
+from cupy import testing
+from cupy.testing import numpy_cupy_allclose
+
+atol = {
+    'default': 1e-6,
+    cupy.float16: 1e-2,
+}
+rtol = {
+    'default': 1e-6,
+    cupy.float16: 1e-2,
+}
+
+
+@testing.with_requires("scipy")
+class Testexprel:
+
+    @testing.for_dtypes("efdFD")
+    @numpy_cupy_allclose(scipy_name="scp")
+    def test_exprel(self, xp, scp, dtype):
+        return scp.special.exprel(-1)
+
+    @testing.for_dtypes("efdFD")
+    @numpy_cupy_allclose(scipy_name="scp", atol=atol, rtol=rtol)
+    def test_exprel_2(self, xp, scp, dtype):
+        return scp.special.exprel(1)
+
+    @testing.for_dtypes("efdFD")
+    @numpy_cupy_allclose(scipy_name="scp", atol=atol, rtol=rtol)
+    def test_exprel_large_values(self, xp, scp, dtype):
+        return scp.special.exprel(720)
+
+    @testing.for_dtypes("efdFD")
+    @numpy_cupy_allclose(scipy_name="scp", atol=atol, rtol=rtol)
+    def test_exprel_small_value(self, xp, scp, dtype):
+        return scp.special.exprel(1e-17)
+
+    @testing.for_dtypes("efdFD")
+    @numpy_cupy_allclose(scipy_name="scp", atol=atol, rtol=rtol)
+    def test_exprel_zero_values(self, xp, scp, dtype):
+        return scp.special.exprel(0.0)
+
+    @testing.for_dtypes("edf")
+    @numpy_cupy_allclose(scipy_name="scp", atol=atol, rtol=rtol)
+    def test_exprel_array_inputs(self, xp, scp, dtype):
+        n = testing.shaped_arange((5, 1, 2), xp, dtype) * 0.001
+        return scp.special.exprel(n)
+
+    @testing.for_dtypes("edf")
+    @numpy_cupy_allclose(scipy_name="scp", atol=atol, rtol=rtol)
+    def test_exprel_array_inputs_2(self, xp, scp, dtype):
+        n = testing.shaped_random((5, 3), xp, dtype) * 0.001
+        return scp.special.exprel(n)


### PR DESCRIPTION
Adds `cupyx.scipy.special.exprel`

Benchmarks:
size | dtype | SciPy | CuPy
-----|-------|-------|-----
1000 | float32 | 0.137 ms | 0.092 ms
1000 | float64 | 0.030 ms | 0.309 ms
100000 | float32 | 1.972 ms | 0.149 ms
100000 | float64 | 1.685 ms | 0.270 ms
1000000 | float32 | 26.247 ms | 0.414 ms
1000000 | float64 | 22.007 ms | 2.114 ms

<details>
<summary>Script</summary>

```
import cupy
import cupyx
import cupyx.scipy.stats

import scipy

from cupyx.profiler import benchmark

import scipy.stats


n_warmup = 1
n_repeat = 10
dtype_set = ('float32', 'float64')
n_set = (1000, 100000, 1000000)


def get_time(pref):
    cpu_time = pref.cpu_times.mean()
    gpu_time = pref.gpu_times.mean()
    return max(cpu_time, gpu_time) * 1000  # ms


def time(a):
    cp_a = cupy.array(a)
    times = []
    perf = benchmark(scipy.special.exprel, (a,),
                     n_warmup=n_warmup, n_repeat=n_repeat)
    times.append(get_time(perf))
    perf = benchmark(cupyx.scipy.special.exprel, (cp_a,),
                     n_warmup=n_warmup, n_repeat=n_repeat)
    times.append(get_time(perf))
    return times


print('size | dtype | SciPy | CuPy')
print('-----|-------|-------|-----')
for n in n_set:
    for dtype in dtype_set:
        a = scipy.random.random(size=n).astype(dtype) * 0.01
        times = time(a)
        print('{} | {} | {:.3f} ms | {:.3f} ms'.format(n, dtype, times[0], times[1]))
```
</details>