### PR TITLE
Remove xfail for invh

### DIFF
--- a/tests/cupyx_tests/linalg_tests/test_solve.py
+++ b/tests/cupyx_tests/linalg_tests/test_solve.py
@@ -49,9 +49,9 @@ class TestInvh(unittest.TestCase):
 }))
 class TestErrorInvh(unittest.TestCase):
 
-    @pytest.mark.xfail(
+    @pytest.mark.skipif(
         cupy.cuda.runtime.runtimeGetVersion() == 12000,
-        reason='See #7309. Possibly cuSOLVER bug in CUDA 12?')
+        reason='This fails with CUDA 12.0.0 but pass in CUDA 12.0.1. (#7309)')
     def test_invh(self):
         a = self._create_symmetric_matrix(self.size, self.dtype)
         with cupyx.errstate(linalg='raise'):


### PR DESCRIPTION
Closes #7309.

Skip tests as we are using CUDA 12.0.1 on Linux (note that `nvidia/cuda:12.0.0-*` Docker images actually contains libraries from CUDA 12.0.1) and CUDA 12.0.0 on Windows.