### PR TITLE
Fix cythonize warnings

### DIFF
--- a/cupy_backends/cuda/_softlink.pyx
+++ b/cupy_backends/cuda/_softlink.pyx
@@ -40,7 +40,6 @@ cdef int _fail_unsupported() nogil except -1:
 *** This is likely a bug in CuPy. Please report this issue to:
 ***   https://github.com/cupy/cupy/issues
 ''')
-    return -1
 
 cdef int _fail_not_found() nogil except -1:
     with gil:
@@ -50,4 +49,3 @@ cdef int _fail_not_found() nogil except -1:
 *** This is likely a bug in CuPy. Please report this issue to:
 ***   https://github.com/cupy/cupy/issues
 ''')
-    return -1


### PR DESCRIPTION
Fixes:
```
warning: cupy_backends/cuda/_softlink.pyx:43:4: Unreachable code
warning: cupy_backends/cuda/_softlink.pyx:53:4: Unreachable code
```