### PR TITLE
Support NumPy 1.24: Adding `strict` option to `testing.assert_array_equal`

### DIFF
--- a/cupy/testing/_array.py
+++ b/cupy/testing/_array.py
@@ -88,8 +88,7 @@ def assert_array_equal(x, y, err_msg='', verbose=True, strict=False,
              are appended to the error message.
          strict(bool): If ``True``, raise an AssertionError when either
              the shape or the data type of the array_like objects does not
-             match. The special handling for scalars mentioned in the Notes
-             section is disabled.
+             match.
 
     .. seealso:: :func:`numpy.testing.assert_array_equal`
     """
@@ -120,8 +119,7 @@ def assert_array_list_equal(xlist, ylist, err_msg='', verbose=True,
              are appended to the error message.
          strict(bool): If ``True``, raise an AssertionError when either
              the shape or the data type of the array_like objects does not
-             match. The special handling for scalars mentioned in the Notes
-             section is disabled.
+             match.
 
     Each element of ``x`` and ``y`` must be either :class:`numpy.ndarray`
     or :class:`cupy.ndarray`. ``x`` and ``y`` must have same length.

--- a/cupy/testing/_array.py
+++ b/cupy/testing/_array.py
@@ -74,8 +74,8 @@ def assert_array_max_ulp(a, b, maxulp=1, dtype=None):
         cupy.asnumpy(a), cupy.asnumpy(b), maxulp=maxulp, dtype=dtype)
 
 
-def assert_array_equal(x, y, err_msg='', verbose=True, strict=False,
-                       strides_check=False):
+def assert_array_equal(x, y, err_msg='', verbose=True, strides_check=False,
+                       **kwargs):
     """Raises an AssertionError if two array_like objects are not equal.
 
     Args:
@@ -88,13 +88,13 @@ def assert_array_equal(x, y, err_msg='', verbose=True, strict=False,
              are appended to the error message.
          strict(bool): If ``True``, raise an AssertionError when either
              the shape or the data type of the array_like objects does not
-             match.
+             match. Requires NumPy version 1.24 or above.
 
     .. seealso:: :func:`numpy.testing.assert_array_equal`
     """
     numpy.testing.assert_array_equal(
         cupy.asnumpy(x), cupy.asnumpy(y), err_msg=err_msg,
-        verbose=verbose, strict=strict)
+        verbose=verbose, **kwargs)
 
     if strides_check:
         if x.strides != y.strides:
@@ -107,8 +107,7 @@ def assert_array_equal(x, y, err_msg='', verbose=True, strict=False,
             raise AssertionError('\n'.join(msg))
 
 
-def assert_array_list_equal(xlist, ylist, err_msg='', verbose=True,
-                            strict=False):
+def assert_array_list_equal(xlist, ylist, err_msg='', verbose=True):
     """Compares lists of arrays pairwise with ``assert_array_equal``.
 
     Args:
@@ -117,9 +116,6 @@ def assert_array_list_equal(xlist, ylist, err_msg='', verbose=True,
          err_msg(str): The error message to be printed in case of failure.
          verbose(bool): If ``True``, the conflicting values
              are appended to the error message.
-         strict(bool): If ``True``, raise an AssertionError when either
-             the shape or the data type of the array_like objects does not
-             match.
 
     Each element of ``x`` and ``y`` must be either :class:`numpy.ndarray`
     or :class:`cupy.ndarray`. ``x`` and ``y`` must have same length.
@@ -145,7 +141,7 @@ def assert_array_list_equal(xlist, ylist, err_msg='', verbose=True,
     for x, y in zip(xlist, ylist):
         numpy.testing.assert_array_equal(
             cupy.asnumpy(x), cupy.asnumpy(y), err_msg=err_msg,
-            verbose=verbose, strict=strict)
+            verbose=verbose)
 
 
 def assert_array_less(x, y, err_msg='', verbose=True):

--- a/cupy/testing/_array.py
+++ b/cupy/testing/_array.py
@@ -74,7 +74,8 @@ def assert_array_max_ulp(a, b, maxulp=1, dtype=None):
         cupy.asnumpy(a), cupy.asnumpy(b), maxulp=maxulp, dtype=dtype)
 
 
-def assert_array_equal(x, y, err_msg='', verbose=True, strides_check=False):
+def assert_array_equal(x, y, err_msg='', verbose=True, strict=False,
+                       strides_check=False):
     """Raises an AssertionError if two array_like objects are not equal.
 
     Args:
@@ -85,12 +86,16 @@ def assert_array_equal(x, y, err_msg='', verbose=True, strides_check=False):
          err_msg(str): The error message to be printed in case of failure.
          verbose(bool): If ``True``, the conflicting values
              are appended to the error message.
+         strict(bool): If ``True``, raise an AssertionError when either
+             the shape or the data type of the array_like objects does not
+             match. The special handling for scalars mentioned in the Notes
+             section is disabled.
 
     .. seealso:: :func:`numpy.testing.assert_array_equal`
     """
     numpy.testing.assert_array_equal(
         cupy.asnumpy(x), cupy.asnumpy(y), err_msg=err_msg,
-        verbose=verbose)
+        verbose=verbose, strict=strict)
 
     if strides_check:
         if x.strides != y.strides:
@@ -103,7 +108,8 @@ def assert_array_equal(x, y, err_msg='', verbose=True, strides_check=False):
             raise AssertionError('\n'.join(msg))
 
 
-def assert_array_list_equal(xlist, ylist, err_msg='', verbose=True):
+def assert_array_list_equal(xlist, ylist, err_msg='', verbose=True,
+                            strict=False):
     """Compares lists of arrays pairwise with ``assert_array_equal``.
 
     Args:
@@ -112,6 +118,10 @@ def assert_array_list_equal(xlist, ylist, err_msg='', verbose=True):
          err_msg(str): The error message to be printed in case of failure.
          verbose(bool): If ``True``, the conflicting values
              are appended to the error message.
+         strict(bool): If ``True``, raise an AssertionError when either
+             the shape or the data type of the array_like objects does not
+             match. The special handling for scalars mentioned in the Notes
+             section is disabled.
 
     Each element of ``x`` and ``y`` must be either :class:`numpy.ndarray`
     or :class:`cupy.ndarray`. ``x`` and ``y`` must have same length.
@@ -137,7 +147,7 @@ def assert_array_list_equal(xlist, ylist, err_msg='', verbose=True):
     for x, y in zip(xlist, ylist):
         numpy.testing.assert_array_equal(
             cupy.asnumpy(x), cupy.asnumpy(y), err_msg=err_msg,
-            verbose=verbose)
+            verbose=verbose, strict=strict)
 
 
 def assert_array_less(x, y, err_msg='', verbose=True):


### PR DESCRIPTION
Added `strict` option to the two related functions `assert_array_equal()` and `assert_array_list_equal()` conforming to the respective new feature in NumPy 1.24, discussed in #7250.

_[This is my very first PR in a big project. Let me know if I violated anything :) ]_