### PR TITLE
Support NumPy 1.24: `casting` and `dtype` keyword arguments for `stack`, `vstack`, `hstack`

### DIFF
--- a/cupy/_manipulation/join.py
+++ b/cupy/_manipulation/join.py
@@ -76,7 +76,7 @@ def dstack(tup):
     return concatenate([cupy.atleast_3d(m) for m in tup], 2)
 
 
-def hstack(tup):
+def hstack(tup, *, dtype=None, casting='same_kind'):
     """Stacks arrays horizontally.
 
     If an input array has one dimension, then the array is treated as a
@@ -85,6 +85,11 @@ def hstack(tup):
 
     Args:
         tup (sequence of arrays): Arrays to be stacked.
+        dtype (str or dtype): If provided, the destination array will have this
+            dtype.
+        casting ({‘no’, ‘equiv’, ‘safe’, ‘same_kind’, ‘unsafe’}, optional):
+            Controls what kind of data casting may occur. Defaults to
+            ``'same_kind'``.
 
     Returns:
         cupy.ndarray: Stacked array.
@@ -96,10 +101,10 @@ def hstack(tup):
     axis = 1
     if arrs[0].ndim == 1:
         axis = 0
-    return concatenate(arrs, axis)
+    return concatenate(arrs, axis, dtype=dtype, casting=casting)
 
 
-def vstack(tup):
+def vstack(tup, *, dtype=None, casting='same_kind'):
     """Stacks arrays vertically.
 
     If an input array has one dimension, then the array is treated as a
@@ -109,6 +114,11 @@ def vstack(tup):
     Args:
         tup (sequence of arrays): Arrays to be stacked. Each array is converted
             by :func:`cupy.atleast_2d` before stacking.
+        dtype (str or dtype): If provided, the destination array will have this
+            dtype.
+        casting ({‘no’, ‘equiv’, ‘safe’, ‘same_kind’, ‘unsafe’}, optional):
+            Controls what kind of data casting may occur. Defaults to
+            ``'same_kind'``.
 
     Returns:
         cupy.ndarray: Stacked array.
@@ -116,20 +126,27 @@ def vstack(tup):
     .. seealso:: :func:`numpy.dstack`
 
     """
-    return concatenate([cupy.atleast_2d(m) for m in tup], 0)
+    return concatenate([cupy.atleast_2d(m) for m in tup], 0,
+                       dtype=dtype, casting=casting)
 
 
-def stack(tup, axis=0, out=None):
+def stack(tup, axis=0, out=None, *, dtype=None, casting='same_kind'):
     """Stacks arrays along a new axis.
 
     Args:
         tup (sequence of arrays): Arrays to be stacked.
         axis (int): Axis along which the arrays are stacked.
         out (cupy.ndarray): Output array.
+        dtype (str or dtype): If provided, the destination array will have this
+            dtype. Cannot be provided together with ``out``.
+        casting ({‘no’, ‘equiv’, ‘safe’, ‘same_kind’, ‘unsafe’}, optional):
+            Controls what kind of data casting may occur. Defaults to
+            ``'same_kind'``.
 
     Returns:
         cupy.ndarray: Stacked array.
 
     .. seealso:: :func:`numpy.stack`
     """
-    return concatenate([cupy.expand_dims(x, axis) for x in tup], axis, out)
+    return concatenate([cupy.expand_dims(x, axis) for x in tup], axis, out,
+                       dtype=dtype, casting=casting)

--- a/cupy/testing/_array.py
+++ b/cupy/testing/_array.py
@@ -88,8 +88,7 @@ def assert_array_equal(x, y, err_msg='', verbose=True, strict=False,
              are appended to the error message.
          strict(bool): If ``True``, raise an AssertionError when either
              the shape or the data type of the array_like objects does not
-             match. The special handling for scalars mentioned in the Notes
-             section is disabled.
+             match.
 
     .. seealso:: :func:`numpy.testing.assert_array_equal`
     """
@@ -120,8 +119,7 @@ def assert_array_list_equal(xlist, ylist, err_msg='', verbose=True,
              are appended to the error message.
          strict(bool): If ``True``, raise an AssertionError when either
              the shape or the data type of the array_like objects does not
-             match. The special handling for scalars mentioned in the Notes
-             section is disabled.
+             match.
 
     Each element of ``x`` and ``y`` must be either :class:`numpy.ndarray`
     or :class:`cupy.ndarray`. ``x`` and ``y`` must have same length.

--- a/cupy/testing/_array.py
+++ b/cupy/testing/_array.py
@@ -74,8 +74,8 @@ def assert_array_max_ulp(a, b, maxulp=1, dtype=None):
         cupy.asnumpy(a), cupy.asnumpy(b), maxulp=maxulp, dtype=dtype)
 
 
-def assert_array_equal(x, y, err_msg='', verbose=True, strict=False,
-                       strides_check=False):
+def assert_array_equal(x, y, err_msg='', verbose=True, strides_check=False,
+                       **kwargs):
     """Raises an AssertionError if two array_like objects are not equal.
 
     Args:
@@ -88,13 +88,13 @@ def assert_array_equal(x, y, err_msg='', verbose=True, strict=False,
              are appended to the error message.
          strict(bool): If ``True``, raise an AssertionError when either
              the shape or the data type of the array_like objects does not
-             match.
+             match. Requires NumPy version 1.24 or above.
 
     .. seealso:: :func:`numpy.testing.assert_array_equal`
     """
     numpy.testing.assert_array_equal(
         cupy.asnumpy(x), cupy.asnumpy(y), err_msg=err_msg,
-        verbose=verbose, strict=strict)
+        verbose=verbose, **kwargs)
 
     if strides_check:
         if x.strides != y.strides:
@@ -107,8 +107,7 @@ def assert_array_equal(x, y, err_msg='', verbose=True, strict=False,
             raise AssertionError('\n'.join(msg))
 
 
-def assert_array_list_equal(xlist, ylist, err_msg='', verbose=True,
-                            strict=False):
+def assert_array_list_equal(xlist, ylist, err_msg='', verbose=True):
     """Compares lists of arrays pairwise with ``assert_array_equal``.
 
     Args:
@@ -117,9 +116,6 @@ def assert_array_list_equal(xlist, ylist, err_msg='', verbose=True,
          err_msg(str): The error message to be printed in case of failure.
          verbose(bool): If ``True``, the conflicting values
              are appended to the error message.
-         strict(bool): If ``True``, raise an AssertionError when either
-             the shape or the data type of the array_like objects does not
-             match.
 
     Each element of ``x`` and ``y`` must be either :class:`numpy.ndarray`
     or :class:`cupy.ndarray`. ``x`` and ``y`` must have same length.
@@ -145,7 +141,7 @@ def assert_array_list_equal(xlist, ylist, err_msg='', verbose=True,
     for x, y in zip(xlist, ylist):
         numpy.testing.assert_array_equal(
             cupy.asnumpy(x), cupy.asnumpy(y), err_msg=err_msg,
-            verbose=verbose, strict=strict)
+            verbose=verbose)
 
 
 def assert_array_less(x, y, err_msg='', verbose=True):

--- a/cupy/testing/_array.py
+++ b/cupy/testing/_array.py
@@ -74,7 +74,8 @@ def assert_array_max_ulp(a, b, maxulp=1, dtype=None):
         cupy.asnumpy(a), cupy.asnumpy(b), maxulp=maxulp, dtype=dtype)
 
 
-def assert_array_equal(x, y, err_msg='', verbose=True, strides_check=False):
+def assert_array_equal(x, y, err_msg='', verbose=True, strict=False,
+                       strides_check=False):
     """Raises an AssertionError if two array_like objects are not equal.
 
     Args:
@@ -85,12 +86,16 @@ def assert_array_equal(x, y, err_msg='', verbose=True, strides_check=False):
          err_msg(str): The error message to be printed in case of failure.
          verbose(bool): If ``True``, the conflicting values
              are appended to the error message.
+         strict(bool): If ``True``, raise an AssertionError when either
+             the shape or the data type of the array_like objects does not
+             match. The special handling for scalars mentioned in the Notes
+             section is disabled.
 
     .. seealso:: :func:`numpy.testing.assert_array_equal`
     """
     numpy.testing.assert_array_equal(
         cupy.asnumpy(x), cupy.asnumpy(y), err_msg=err_msg,
-        verbose=verbose)
+        verbose=verbose, strict=strict)
 
     if strides_check:
         if x.strides != y.strides:
@@ -103,7 +108,8 @@ def assert_array_equal(x, y, err_msg='', verbose=True, strides_check=False):
             raise AssertionError('\n'.join(msg))
 
 
-def assert_array_list_equal(xlist, ylist, err_msg='', verbose=True):
+def assert_array_list_equal(xlist, ylist, err_msg='', verbose=True,
+                            strict=False):
     """Compares lists of arrays pairwise with ``assert_array_equal``.
 
     Args:
@@ -112,6 +118,10 @@ def assert_array_list_equal(xlist, ylist, err_msg='', verbose=True):
          err_msg(str): The error message to be printed in case of failure.
          verbose(bool): If ``True``, the conflicting values
              are appended to the error message.
+         strict(bool): If ``True``, raise an AssertionError when either
+             the shape or the data type of the array_like objects does not
+             match. The special handling for scalars mentioned in the Notes
+             section is disabled.
 
     Each element of ``x`` and ``y`` must be either :class:`numpy.ndarray`
     or :class:`cupy.ndarray`. ``x`` and ``y`` must have same length.
@@ -137,7 +147,7 @@ def assert_array_list_equal(xlist, ylist, err_msg='', verbose=True):
     for x, y in zip(xlist, ylist):
         numpy.testing.assert_array_equal(
             cupy.asnumpy(x), cupy.asnumpy(y), err_msg=err_msg,
-            verbose=verbose)
+            verbose=verbose, strict=strict)
 
 
 def assert_array_less(x, y, err_msg='', verbose=True):


### PR DESCRIPTION
Regarding to #7250 supporting NumPy 1.24, add keyword arguments `casting` and `dtype` to `stack`, `vstack` and `hstack`.

The under-the-hood function `concatenate` has been supporting these two kwargs since version 1.20 and therefore should not break code in versions before 1.24.