### PR TITLE
Support NumPy 1.24: `dtype` and `casting` keyword arguments for `hstack`, `vstack`, `stack`

### DIFF
--- a/cupy/_manipulation/join.py
+++ b/cupy/_manipulation/join.py
@@ -76,7 +76,7 @@ def dstack(tup):
     return concatenate([cupy.atleast_3d(m) for m in tup], 2)
 
 
-def hstack(tup):
+def hstack(tup, *, dtype=None, casting='same_kind'):
     """Stacks arrays horizontally.
 
     If an input array has one dimension, then the array is treated as a
@@ -85,6 +85,11 @@ def hstack(tup):
 
     Args:
         tup (sequence of arrays): Arrays to be stacked.
+        dtype (str or dtype): If provided, the destination array will have this
+            dtype.
+        casting ({‘no’, ‘equiv’, ‘safe’, ‘same_kind’, ‘unsafe’}, optional):
+            Controls what kind of data casting may occur. Defaults to
+            ``'same_kind'``.
 
     Returns:
         cupy.ndarray: Stacked array.
@@ -96,10 +101,10 @@ def hstack(tup):
     axis = 1
     if arrs[0].ndim == 1:
         axis = 0
-    return concatenate(arrs, axis)
+    return concatenate(arrs, axis, dtype=dtype, casting=casting)
 
 
-def vstack(tup):
+def vstack(tup, *, dtype=None, casting='same_kind'):
     """Stacks arrays vertically.
 
     If an input array has one dimension, then the array is treated as a
@@ -109,6 +114,11 @@ def vstack(tup):
     Args:
         tup (sequence of arrays): Arrays to be stacked. Each array is converted
             by :func:`cupy.atleast_2d` before stacking.
+        dtype (str or dtype): If provided, the destination array will have this
+            dtype.
+        casting ({‘no’, ‘equiv’, ‘safe’, ‘same_kind’, ‘unsafe’}, optional):
+            Controls what kind of data casting may occur. Defaults to
+            ``'same_kind'``.
 
     Returns:
         cupy.ndarray: Stacked array.
@@ -116,20 +126,27 @@ def vstack(tup):
     .. seealso:: :func:`numpy.dstack`
 
     """
-    return concatenate([cupy.atleast_2d(m) for m in tup], 0)
+    return concatenate([cupy.atleast_2d(m) for m in tup], 0,
+                       dtype=dtype, casting=casting)
 
 
-def stack(tup, axis=0, out=None):
+def stack(tup, axis=0, out=None, *, dtype=None, casting='same_kind'):
     """Stacks arrays along a new axis.
 
     Args:
         tup (sequence of arrays): Arrays to be stacked.
         axis (int): Axis along which the arrays are stacked.
         out (cupy.ndarray): Output array.
+        dtype (str or dtype): If provided, the destination array will have this
+            dtype. Cannot be provided together with ``out``.
+        casting ({‘no’, ‘equiv’, ‘safe’, ‘same_kind’, ‘unsafe’}, optional):
+            Controls what kind of data casting may occur. Defaults to
+            ``'same_kind'``.
 
     Returns:
         cupy.ndarray: Stacked array.
 
     .. seealso:: :func:`numpy.stack`
     """
-    return concatenate([cupy.expand_dims(x, axis) for x in tup], axis, out)
+    return concatenate([cupy.expand_dims(x, axis) for x in tup], axis, out,
+                       dtype=dtype, casting=casting)

--- a/tests/cupy_tests/manipulation_tests/test_join.py
+++ b/tests/cupy_tests/manipulation_tests/test_join.py
@@ -289,6 +289,32 @@ class TestJoin:
         c = testing.shaped_arange((2, 3), xp)
         return xp.hstack((a, b, c))
 
+    @testing.with_requires('numpy>=1.24.0')
+    @testing.for_all_dtypes_combination(names=['dtype1', 'dtype2'])
+    @testing.numpy_cupy_array_equal(accept_error=TypeError)
+    def test_hstack_dtype(self, xp, dtype1, dtype2):
+        a = testing.shaped_arange((3, 4), xp, dtype1)
+        b = testing.shaped_arange((3, 4), xp, dtype1)
+        return xp.hstack((a, b), dtype=dtype2)
+
+    @testing.with_requires('numpy>=1.24.0')
+    @pytest.mark.filterwarnings('error::numpy.ComplexWarning')
+    @pytest.mark.parametrize('casting', [
+        'no',
+        'equiv',
+        'safe',
+        'same_kind',
+        'unsafe',
+    ])
+    @testing.for_all_dtypes_combination(names=['dtype1', 'dtype2'])
+    @testing.numpy_cupy_array_equal(
+        accept_error=(TypeError, numpy.ComplexWarning))
+    def test_hstack_casting(self, xp, dtype1, dtype2, casting):
+        a = testing.shaped_arange((3, 4), xp, dtype1)
+        b = testing.shaped_arange((3, 4), xp, dtype1)
+        # may raise TypeError or ComplexWarning
+        return xp.hstack((a, b), dtype=dtype2, casting=casting)
+
     @testing.numpy_cupy_array_equal()
     def test_vstack_vectors(self, xp):
         a = xp.arange(3)
@@ -305,6 +331,32 @@ class TestJoin:
         b = cupy.empty((3, 1))
         with pytest.raises(ValueError):
             cupy.vstack((a, b))
+
+    @testing.with_requires('numpy>=1.24.0')
+    @testing.for_all_dtypes_combination(names=['dtype1', 'dtype2'])
+    @testing.numpy_cupy_array_equal(accept_error=TypeError)
+    def test_vstack_dtype(self, xp, dtype1, dtype2):
+        a = testing.shaped_arange((3, 4), xp, dtype1)
+        b = testing.shaped_arange((3, 4), xp, dtype1)
+        return xp.vstack((a, b), dtype=dtype2)
+
+    @testing.with_requires('numpy>=1.24.0')
+    @pytest.mark.filterwarnings('error::numpy.ComplexWarning')
+    @pytest.mark.parametrize('casting', [
+        'no',
+        'equiv',
+        'safe',
+        'same_kind',
+        'unsafe',
+    ])
+    @testing.for_all_dtypes_combination(names=['dtype1', 'dtype2'])
+    @testing.numpy_cupy_array_equal(
+        accept_error=(TypeError, numpy.ComplexWarning))
+    def test_vstack_casting(self, xp, dtype1, dtype2, casting):
+        a = testing.shaped_arange((3, 4), xp, dtype1)
+        b = testing.shaped_arange((3, 4), xp, dtype1)
+        # may raise TypeError or ComplexWarning
+        return xp.vstack((a, b), dtype=dtype2, casting=casting)
 
     @testing.numpy_cupy_array_equal()
     def test_stack(self, xp):
@@ -423,6 +475,32 @@ class TestJoin:
             out = xp.zeros((3, 3, 4), dtype=xp.int64)
             with pytest.raises(TypeError):
                 xp.stack((a, b, c), axis=1, out=out)
+
+    @testing.with_requires('numpy>=1.24.0')
+    @testing.for_all_dtypes_combination(names=['dtype1', 'dtype2'])
+    @testing.numpy_cupy_array_equal(accept_error=TypeError)
+    def test_stack_dtype(self, xp, dtype1, dtype2):
+        a = testing.shaped_arange((3, 4), xp, dtype1)
+        b = testing.shaped_arange((3, 4), xp, dtype1)
+        return xp.stack((a, b), dtype=dtype2)
+
+    @testing.with_requires('numpy>=1.24.0')
+    @pytest.mark.filterwarnings('error::numpy.ComplexWarning')
+    @pytest.mark.parametrize('casting', [
+        'no',
+        'equiv',
+        'safe',
+        'same_kind',
+        'unsafe',
+    ])
+    @testing.for_all_dtypes_combination(names=['dtype1', 'dtype2'])
+    @testing.numpy_cupy_array_equal(
+        accept_error=(TypeError, numpy.ComplexWarning))
+    def test_stack_casting(self, xp, dtype1, dtype2, casting):
+        a = testing.shaped_arange((3, 4), xp, dtype1)
+        b = testing.shaped_arange((3, 4), xp, dtype1)
+        # may raise TypeError or ComplexWarning
+        return xp.stack((a, b), dtype=dtype2, casting=casting)
 
     @testing.for_all_dtypes(name='dtype1')
     @testing.for_all_dtypes(name='dtype2')


### PR DESCRIPTION
Following the items listed in #7250, adding `dtype` and `casting` keyword arguments for `hstack`, `vstack`, `stack`.

The addition of these kwargs should not make CuPy incompatible with NumPy versions before 1.24, as the under-the-hood `concatenate` supports these two kwargs since NumPy 1.20.