### PR TITLE
Update aarch64 install insturctions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,14 +40,11 @@ Choose the right package for your platform.
 
 | Platform              | Architecture      | Command                                                       |
 | --------------------- | ----------------- | ------------------------------------------------------------- |
-| CUDA 10.2             | x86_64            | `pip install cupy-cuda102`                                    |
-|                       | aarch64           | `pip install cupy-cuda102 -f https://pip.cupy.dev/aarch64`    |
+| CUDA 10.2             | x86_64 / aarch64  | `pip install cupy-cuda102`                                    |
 | CUDA 11.0             | x86_64            | `pip install cupy-cuda110`                                    |
 | CUDA 11.1             | x86_64            | `pip install cupy-cuda111`                                    |
-| CUDA 11.2 ~ 11.8      | x86_64            | `pip install cupy-cuda11x`                                    |
-|                       | aarch64           | `pip install cupy-cuda11x -f https://pip.cupy.dev/aarch64`    |
-| CUDA 12.x             | x86_64            | `pip install cupy-cuda12x`                                    |
-|                       | aarch64           | `pip install cupy-cuda12x -f https://pip.cupy.dev/aarch64`    |
+| CUDA 11.2 ~ 11.8      | x86_64 / aarch64  | `pip install cupy-cuda11x`                                    |
+| CUDA 12.x             | x86_64 / aarch64  | `pip install cupy-cuda12x`                                    |
 | ROCm 4.3 (*)          | x86_64            | `pip install cupy-rocm-4-3`                                   |
 | ROCm 5.0 (*)          | x86_64            | `pip install cupy-rocm-5-0`                                   |
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -81,22 +81,16 @@ Package names are different depending on your CUDA Toolkit version.
 
    * - CUDA
      - Command
-   * - **v10.2** (x86_64)
+   * - **v10.2** (x86_64 / aarch64)
      - ``pip install cupy-cuda102``
-   * - **v10.2** (aarch64 - `JetPack 4 <https://developer.nvidia.com/embedded/jetpack>`_)
-     - ``pip install cupy-cuda102 -f https://pip.cupy.dev/aarch64``
    * - **v11.0** (x86_64)
      - ``pip install cupy-cuda110``
    * - **v11.1** (x86_64)
      - ``pip install cupy-cuda111``
-   * - **v11.2 ~ 11.8** (x86_64)
+   * - **v11.2 ~ 11.8** (x86_64 / aarch64)
      - ``pip install cupy-cuda11x``
-   * - **v11.2 ~ 11.8** (aarch64 - `JetPack 5 <https://developer.nvidia.com/embedded/jetpack>`_ / Arm SBSA)
-     - ``pip install cupy-cuda11x -f https://pip.cupy.dev/aarch64``
-   * - **v12.x** (x86_64)
+   * - **v12.x** (x86_64 / aarch64)
      - ``pip install cupy-cuda12x``
-   * - **v12.x** (aarch64 - `JetPack 5 <https://developer.nvidia.com/embedded/jetpack>`_ / Arm SBSA)
-     - ``pip install cupy-cuda12x -f https://pip.cupy.dev/aarch64``
 
 .. note::
 


### PR DESCRIPTION
Starting in CuPy v12, aarch64 wheels are now on PyPI.