### PR TITLE
Fix random module performance regression

### DIFF
--- a/cupy/random/_bit_generator.pyx
+++ b/cupy/random/_bit_generator.pyx
@@ -76,7 +76,7 @@ class _cuRANDGenerator(BitGenerator):
         # Raw kernel has problems with integers with the 64th bit set
         self._seed = self._seed_seq.generate_state(1, numpy.uint32)[0]
         if size < 0:
-           size = 8 * 256 * cupy.cuda.runtime.cudaDevAttrMultiProcessorCount
+            size = 8 * 256 * cupy.cuda.runtime.cudaDevAttrMultiProcessorCount
         self._size = size
         cdef uint64_t b_size = self._type_size() * size
         self._state = cupy.zeros(b_size, dtype=numpy.int8)

--- a/cupy/random/_bit_generator.pyx
+++ b/cupy/random/_bit_generator.pyx
@@ -71,10 +71,12 @@ class BitGenerator:
 
 class _cuRANDGenerator(BitGenerator):
     # Size is the number of threads that will be initialized
-    def __init__(self, seed=None, *, size=1000*256):
+    def __init__(self, seed=None, *, size=-1):
         super().__init__(seed)
         # Raw kernel has problems with integers with the 64th bit set
         self._seed = self._seed_seq.generate_state(1, numpy.uint32)[0]
+        if size < 0:
+           size = 8 * 256 * cupy.cuda.runtime.cudaDevAttrMultiProcessorCount
         self._size = size
         cdef uint64_t b_size = self._type_size() * size
         self._state = cupy.zeros(b_size, dtype=numpy.int8)

--- a/cupy/random/_generator_api.pyx
+++ b/cupy/random/_generator_api.pyx
@@ -13,8 +13,6 @@ from cupy_backends.cuda.api import runtime
 _UINT32_MAX = 0xffffffff
 _UINT64_MAX = 0xffffffffffffffff
 
-
-
 cdef extern from 'cupy_distributions.cuh' nogil:
     cppclass rk_binomial_state:
         pass

--- a/cupy/random/cupy_distributions.cu
+++ b/cupy/random/cupy_distributions.cu
@@ -29,7 +29,7 @@ struct curand_pseudo_state {
     }
 
     __device__ uint32_t rk_int() {
-        return curand(_state_ptr);
+        return curand(&_state);
     }
 
     __device__ double rk_double() {

--- a/cupy/random/cupy_distributions.cuh
+++ b/cupy/random/cupy_distributions.cuh
@@ -61,6 +61,7 @@ typedef struct {} hiprandStatePhilox4_32_10_t;
 #if !defined(CUPY_NO_CUDA)
 void init_curand_generator(int generator, intptr_t state_ptr, uint64_t seed, ssize_t size, intptr_t stream);
 void random_uniform(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream);
+void random_uniform_float(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream);
 void raw(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream);
 void interval_32(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream, int32_t mx, int32_t mask);
 void interval_64(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream, int64_t mx, int64_t mask);
@@ -82,6 +83,7 @@ typedef struct {} curandStateMRG32k3a;
 typedef struct {} curandStatePhilox4_32_10_t;
 void init_curand_generator(int generator, intptr_t state_ptr, uint64_t seed, ssize_t size, intptr_t stream) {}
 void random_uniform(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream) {}
+void random_uniform_float(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream) {}
 void raw(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream) {}
 void interval_32(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream, int32_t mx, int32_t mask) {}
 void interval_64(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream, int64_t mx, int64_t mask) {}

--- a/cupy/random/cupy_distributions.cuh
+++ b/cupy/random/cupy_distributions.cuh
@@ -60,21 +60,21 @@ typedef struct {} hiprandStatePhilox4_32_10_t;
 
 #if !defined(CUPY_NO_CUDA)
 void init_curand_generator(int generator, intptr_t state_ptr, uint64_t seed, ssize_t size, intptr_t stream);
-void random_uniform(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream);
-void random_uniform_float(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream);
-void raw(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream);
-void interval_32(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream, int32_t mx, int32_t mask);
-void interval_64(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream, int64_t mx, int64_t mask);
-void beta(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream, intptr_t a, intptr_t b);
-void exponential(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream);
-void geometric(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream, intptr_t p);
-void hypergeometric(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream, intptr_t ngood, intptr_t nbad, intptr_t nsample);
-void logseries(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream, intptr_t p);
-void poisson(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream, intptr_t lam);
-void standard_normal(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream);
-void standard_normal_float(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream);
-void standard_gamma(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream, intptr_t shape);
-void binomial(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream, intptr_t n, intptr_t p, intptr_t binomial_state);
+void random_uniform(int generator, intptr_t state, ssize_t state_size, intptr_t out, ssize_t size, intptr_t stream);
+void random_uniform_float(int generator, intptr_t state, ssize_t state_size, intptr_t out, ssize_t size, intptr_t stream);
+void raw(int generator, intptr_t state, ssize_t state_size, intptr_t out, ssize_t size, intptr_t stream);
+void interval_32(int generator, intptr_t state, ssize_t state_size, intptr_t out, ssize_t size, intptr_t stream, int32_t mx, int32_t mask);
+void interval_64(int generator, intptr_t state, ssize_t state_size, intptr_t out, ssize_t size, intptr_t stream, int64_t mx, int64_t mask);
+void beta(int generator, intptr_t state, ssize_t state_size, intptr_t out, ssize_t size, intptr_t stream, intptr_t a, intptr_t b);
+void exponential(int generator, intptr_t state, ssize_t state_size, intptr_t out, ssize_t size, intptr_t stream);
+void geometric(int generator, intptr_t state, ssize_t state_size, intptr_t out, ssize_t size, intptr_t stream, intptr_t p);
+void hypergeometric(int generator, intptr_t state, ssize_t state_size, intptr_t out, ssize_t size, intptr_t stream, intptr_t ngood, intptr_t nbad, intptr_t nsample);
+void logseries(int generator, intptr_t state, ssize_t state_size, intptr_t out, ssize_t size, intptr_t stream, intptr_t p);
+void poisson(int generator, intptr_t state, ssize_t state_size, intptr_t out, ssize_t size, intptr_t stream, intptr_t lam);
+void standard_normal(int generator, intptr_t state, ssize_t state_size, intptr_t out, ssize_t size, intptr_t stream);
+void standard_normal_float(int generator, intptr_t state, ssize_t state_size, intptr_t out, ssize_t size, intptr_t stream);
+void standard_gamma(int generator, intptr_t state, ssize_t state_size, intptr_t out, ssize_t size, intptr_t stream, intptr_t shape);
+void binomial(int generator, intptr_t state, ssize_t state_size, intptr_t out, ssize_t size, intptr_t stream, intptr_t n, intptr_t p, intptr_t binomial_state);
 
 #else
 // --no -cuda will not compile the .cu file, so the definition needs to be done here explicitly
@@ -82,21 +82,21 @@ typedef struct {} curandState;
 typedef struct {} curandStateMRG32k3a;
 typedef struct {} curandStatePhilox4_32_10_t;
 void init_curand_generator(int generator, intptr_t state_ptr, uint64_t seed, ssize_t size, intptr_t stream) {}
-void random_uniform(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream) {}
-void random_uniform_float(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream) {}
-void raw(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream) {}
-void interval_32(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream, int32_t mx, int32_t mask) {}
-void interval_64(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream, int64_t mx, int64_t mask) {}
-void beta(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream, intptr_t a, intptr_t b) {}
-void exponential(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream) {}
-void geometric(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream, intptr_t p) {}
-void hypergeometric(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream, intptr_t ngood, intptr_t nbad, intptr_t nsample) {}
-void logseries(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream, intptr_t p) {}
-void poisson(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream, intptr_t lam) {}
-void standard_normal(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream) {}
-void standard_normal_float(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream) {}
-void standard_gamma(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream, intptr_t shape) {}
-void binomial(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream, intptr_t n, intptr_t p, intptr_t binomial_state) {}
+void random_uniform(int generator, intptr_t state, ssize_t state_size, intptr_t out, ssize_t size, intptr_t stream) {}
+void random_uniform_float(int generator, intptr_t state, ssize_t state_size, intptr_t out, ssize_t size, intptr_t stream) {}
+void raw(int generator, intptr_t state, ssize_t state_size, intptr_t out, ssize_t size, intptr_t stream) {}
+void interval_32(int generator, intptr_t state, ssize_t state_size, intptr_t out, ssize_t size, intptr_t stream, int32_t mx, int32_t mask) {}
+void interval_64(int generator, intptr_t state, ssize_t state_size, intptr_t out, ssize_t size, intptr_t stream, int64_t mx, int64_t mask) {}
+void beta(int generator, intptr_t state, ssize_t state_size, intptr_t out, ssize_t size, intptr_t stream, intptr_t a, intptr_t b) {}
+void exponential(int generator, intptr_t state, ssize_t state_size, intptr_t out, ssize_t size, intptr_t stream) {}
+void geometric(int generator, intptr_t state, ssize_t state_size, intptr_t out, ssize_t size, intptr_t stream, intptr_t p) {}
+void hypergeometric(int generator, intptr_t state, ssize_t state_size, intptr_t out, ssize_t size, intptr_t stream, intptr_t ngood, intptr_t nbad, intptr_t nsample) {}
+void logseries(int generator, intptr_t state, ssize_t state_size, intptr_t out, ssize_t size, intptr_t stream, intptr_t p) {}
+void poisson(int generator, intptr_t state, ssize_t state_size, intptr_t out, ssize_t size, intptr_t stream, intptr_t lam) {}
+void standard_normal(int generator, intptr_t state, ssize_t state_size, intptr_t out, ssize_t size, intptr_t stream) {}
+void standard_normal_float(int generator, intptr_t state, ssize_t state_size, intptr_t out, ssize_t size, intptr_t stream) {}
+void standard_gamma(int generator, intptr_t state, ssize_t state_size, intptr_t out, ssize_t size, intptr_t stream, intptr_t shape) {}
+void binomial(int generator, intptr_t state, ssize_t state_size, intptr_t out, ssize_t size, intptr_t stream, intptr_t n, intptr_t p, intptr_t binomial_state) {}
 
 #endif
 


### PR DESCRIPTION
Simplified the code, added missing support for fp32 and changed the splitting by state to be inside the kernel so its much clearer and faster now.

Performance using a simplified script from #7515

Main/Master
```
********
TIMING STANDARD NORMAL
********
********************************************************
Timing `standard_normal` with array size 100000, shape: (100000,)...


Benchmarking cp.random.standard_normal ...
<lambda>            :    CPU:    27.143 us   +/-  1.011 (min:    26.302 / max:    38.236) us     GPU-0:    30.346 us   +/-  1.230 (min:    28.672 / max:    41.984) us

Benchmarking [cp.random.XORWOW()].standard_normal ...
<lambda>            :    CPU:    30.759 us   +/-  6.240 (min:    23.974 / max:    38.324) us     GPU-0:    33.915 us   +/-  6.275 (min:    25.600 / max:    41.984) us
********************************************************
Timing `standard_normal` with array size 1000000, shape: (1000000,)...


Benchmarking cp.random.standard_normal ...
<lambda>            :    CPU:    61.516 us   +/-  0.405 (min:    60.602 / max:    65.008) us     GPU-0:    64.753 us   +/-  0.614 (min:    63.488 / max:    68.608) us

Benchmarking [cp.random.XORWOW()].standard_normal ...
<lambda>            :    CPU:   180.614 us   +/-  1.326 (min:   177.837 / max:   184.092) us     GPU-0:   184.340 us   +/-  1.543 (min:   181.248 / max:   193.536) us
********************************************************
Timing `standard_normal` with array size 10000000, shape: (10000000,)...


Benchmarking cp.random.standard_normal ...
<lambda>            :    CPU:   404.132 us   +/-  0.473 (min:   403.105 / max:   406.323) us     GPU-0:   407.695 us   +/-  0.710 (min:   406.528 / max:   410.624) us

Benchmarking [cp.random.XORWOW()].standard_normal ...
<lambda>            :    CPU:  1193.174 us   +/- 171.686 (min:  1123.574 / max:  1699.047) us     GPU-0:  1196.918 us   +/- 171.638 (min:  1127.424 / max:  1702.912) us
********
TIMING UNIFORM
********
********************************************************
Timing `random` with array size 100000, shape: (100000,)...


Benchmarking cp.random.random ...
<lambda>            :    CPU:    34.927 us   +/-  0.868 (min:    34.125 / max:    45.038) us     GPU-0:    38.267 us   +/-  1.075 (min:    36.864 / max:    50.176) us

Benchmarking [cp.random.XORWOW()].random ...
<lambda>            :    CPU:    51.995 us   +/-  1.060 (min:    50.746 / max:    62.435) us     GPU-0:    55.818 us   +/-  1.220 (min:    54.272 / max:    66.560) us
********************************************************
Timing `random` with array size 1000000, shape: (1000000,)...


Benchmarking cp.random.random ...
<lambda>            :    CPU:    46.244 us   +/-  1.110 (min:    45.146 / max:    57.454) us     GPU-0:    49.649 us   +/-  1.295 (min:    48.128 / max:    62.464) us

Benchmarking [cp.random.XORWOW()].random ...
<lambda>            :    CPU:   162.092 us   +/-  6.725 (min:   159.210 / max:   255.178) us     GPU-0:   166.420 us   +/-  6.968 (min:   163.840 / max:   262.144) us
********************************************************
Timing `random` with array size 10000000, shape: (10000000,)...


Benchmarking cp.random.random ...
<lambda>            :    CPU:   155.917 us   +/-  0.746 (min:   154.506 / max:   161.210) us     GPU-0:   159.401 us   +/-  0.968 (min:   156.672 / max:   164.864) us

Benchmarking [cp.random.XORWOW()].random ...
<lambda>            :    CPU:  1265.306 us   +/-  6.491 (min:  1254.442 / max:  1301.529) us     GPU-0:  1270.077 us   +/-  6.552 (min:  1258.496 / max:  1306.624) us
```


This PR

```
********
TIMING STANDARD NORMAL
********
********************************************************
Timing `standard_normal` with array size 100000, shape: (100000,)...


Benchmarking cp.random.standard_normal ...
<lambda>            :    CPU:    26.453 us   +/-  0.950 (min:    25.765 / max:    36.244) us     GPU-0:    29.655 us   +/-  1.144 (min:    28.672 / max:    39.936) us

Benchmarking [cp.random.XORWOW()].standard_normal ...
<lambda>            :    CPU:    26.588 us   +/-  0.470 (min:    25.709 / max:    28.604) us     GPU-0:    29.829 us   +/-  0.962 (min:    28.672 / max:    39.936) us
********************************************************
Timing `standard_normal` with array size 1000000, shape: (1000000,)...


Benchmarking cp.random.standard_normal ...
<lambda>            :    CPU:    60.723 us   +/-  0.369 (min:    59.944 / max:    63.176) us     GPU-0:    63.954 us   +/-  0.646 (min:    62.464 / max:    67.584) us

Benchmarking [cp.random.XORWOW()].standard_normal ...
<lambda>            :    CPU:    32.553 us   +/-  0.988 (min:    30.977 / max:    35.313) us     GPU-0:    35.773 us   +/-  1.117 (min:    33.792 / max:    39.936) us
********************************************************
Timing `standard_normal` with array size 10000000, shape: (10000000,)...


Benchmarking cp.random.standard_normal ...
<lambda>            :    CPU:   405.243 us   +/- 117.471 (min:   311.472 / max:  2024.242) us     GPU-0:   409.006 us   +/- 120.920 (min:   314.368 / max:  2077.696) us

Benchmarking [cp.random.XORWOW()].standard_normal ...
<lambda>            :    CPU:   100.466 us   +/-  0.665 (min:    99.075 / max:   102.271) us     GPU-0:   103.982 us   +/-  0.837 (min:   102.400 / max:   105.472) us
********
TIMING UNIFORM
********
********************************************************
Timing `random` with array size 100000, shape: (100000,)...


Benchmarking cp.random.random ...
<lambda>            :    CPU:    37.344 us   +/-  0.875 (min:    36.594 / max:    47.588) us     GPU-0:    40.504 us   +/-  1.028 (min:    39.936 / max:    51.200) us

Benchmarking [cp.random.XORWOW()].random ...
<lambda>            :    CPU:    23.074 us   +/-  0.959 (min:    22.067 / max:    32.974) us     GPU-0:    26.435 us   +/-  1.113 (min:    24.576 / max:    35.840) us
********************************************************
Timing `random` with array size 1000000, shape: (1000000,)...


Benchmarking cp.random.random ...
<lambda>            :    CPU:    52.414 us   +/-  1.022 (min:    51.414 / max:    62.767) us     GPU-0:    56.008 us   +/-  1.159 (min:    54.272 / max:    66.560) us

Benchmarking [cp.random.XORWOW()].random ...
<lambda>            :    CPU:    26.527 us   +/-  0.800 (min:    25.643 / max:    36.892) us     GPU-0:    29.875 us   +/-  0.918 (min:    28.672 / max:    39.936) us
********************************************************
Timing `random` with array size 10000000, shape: (10000000,)...


Benchmarking cp.random.random ...
<lambda>            :    CPU:   192.572 us   +/-  0.554 (min:   191.610 / max:   196.988) us     GPU-0:   196.239 us   +/-  0.760 (min:   194.560 / max:   200.704) us

Benchmarking [cp.random.XORWOW()].random ...
<lambda>            :    CPU:    65.483 us   +/-  0.642 (min:    63.784 / max:    69.437) us     GPU-0:    69.064 us   +/-  0.798 (min:    67.584 / max:    73.728) us
```

The difference is quite significant :)

Script used for measuring
```python
import numpy as np
import cupy as cp
from cupyx.profiler import benchmark

def benchmark_function(f, args, n_repeat=200):
    # cp.cuda.Stream.null.synchronize()
    print(benchmark(f, args, n_warmup=10, n_repeat=n_repeat))

arrtype = cp.float32   # array type

ARR_SIZES = [
    (100000,),      # N = 1e5
    (1000000,),     # N = 1e6
    (10000000,),    # N = 1e7
]

# Time standard normal
print("********\nTIMING STANDARD NORMAL\n********")
default_rng = cp.random.default_rng()
xor_rng = cp.random.Generator(cp.random.XORWOW())
for arrsize in ARR_SIZES:
    print("********************************************************")
    print(f"Timing `standard_normal` with array size {np.prod(arrsize)}, shape: {arrsize}...\n")

    # Directly use `cp.random.standard_normal`
    print("\nBenchmarking cp.random.standard_normal ...")
    f1 = lambda n: cp.random.standard_normal(size=n, dtype=arrtype)
    benchmark_function(f1, (arrsize,))

    # Construct a Generator explicitly
    print("\nBenchmarking [cp.random.XORWOW()].standard_normal ...")
    f3 = lambda n: xor_rng.standard_normal(size=n, dtype=arrtype)
    benchmark_function(f3, (arrsize,))

# Time uniform
print("********\nTIMING UNIFORM\n********")
default_rng = cp.random.default_rng()
xor_rng = cp.random.Generator(cp.random.XORWOW())
for arrsize in ARR_SIZES:
    print("********************************************************")
    print(f"Timing `random` with array size {np.prod(arrsize)}, shape: {arrsize}...\n")

    # Directly use `cp.random.random`
    print("\nBenchmarking cp.random.random ...")
    f1 = lambda n: cp.random.random(size=n, dtype=arrtype)
    benchmark_function(f1, (arrsize,))

    print("\nBenchmarking [cp.random.XORWOW()].random ...")
    f3 = lambda n: xor_rng.random(size=n, dtype=arrtype)
    f3(arrsize)
    benchmark_function(f3, (arrsize,))
```