### PR TITLE
Add `scipy.special.spherical_yn`

### DIFF
--- a/cupyx/scipy/special/__init__.py
+++ b/cupyx/scipy/special/__init__.py
@@ -12,6 +12,7 @@ from cupyx.scipy.special._bessel import k1e  # NOQA
 from cupyx.scipy.special._bessel import y0  # NOQA
 from cupyx.scipy.special._bessel import y1  # NOQA
 from cupyx.scipy.special._bessel import yn  # NOQA
+from cupyx.scipy.special._spherical_bessel import spherical_yn  # NOQA
 
 # Raw statistical functions
 from cupyx.scipy.special._stats_distributions import bdtr  # NOQA

--- a/cupyx/scipy/special/_spherical_bessel.py
+++ b/cupyx/scipy/special/_spherical_bessel.py
@@ -97,7 +97,8 @@ def spherical_yn(n, z, derivative=False):
         Argument of the Bessel function.
         Real-valued input.
     derivative : bool, optional
-        If True, the value of the derivative (rather than the function itself) is returned.
+        If True, the value of the derivative (rather than the function
+        itself) is returned.
 
     Returns
     -------

--- a/cupyx/scipy/special/_spherical_bessel.py
+++ b/cupyx/scipy/special/_spherical_bessel.py
@@ -1,0 +1,120 @@
+import cupy
+from cupy import _core
+
+spherical_bessel_preamble = """
+#include <cupy/math_constants.h>
+
+__device__ double spherical_yn_real(int n, double x) {
+    double s, s0, s1;
+
+    if (isnan(x))
+        return x;
+    if (x < 0) {
+        if (n % 2 == 0)
+            return -spherical_yn_real(n, -x);
+        else
+            return spherical_yn_real(n, -x);
+    }
+    if (isinf(x))
+        return 0;
+    if (x == 0)
+        return -CUDART_INF;
+
+    s0 = -cos(x) / x;
+    if (n == 0) {
+        return s0;
+    }
+    s1 = (s0 - sin(x)) / x;
+    for (int k = 2; k <= n; ++k) {
+        s = (2.0 * k - 1.0) * s1 / x - s0;
+        if (isinf(s)) {
+            return s;
+        }
+        s0 = s1;
+        s1 = s;
+    }
+
+    return s1;
+}
+
+__device__ double spherical_yn_d_real(int n, double x) {
+    double s, s0, s1;
+
+    if (isnan(x))
+        return x;
+    if (x < 0) {
+        if (n % 2 == 0)
+            return -spherical_yn_d_real(n, -x);
+        else
+            return spherical_yn_d_real(n, -x);
+    }
+    if (isinf(x))
+        return 0;
+    if (x == 0)
+        return CUDART_INF;
+
+    if (n == 1) {
+        return (sin(x) + cos(x) / x) / x;
+    }
+    s0 = -cos(x) / x;
+    s1 = (s0 - sin(x)) / x;
+    for (int k = 2; k <= n; ++k) {
+        s = (2.0 * k - 1.0) * s1 / x - s0;
+        if (isinf(s)) {
+            return s;
+        }
+        s0 = s1;
+        s1 = s;
+    }
+
+    return s0 - (n + 1.0) * s1 / x;
+}
+"""
+
+_spherical_yn_real = _core.create_ufunc(
+    "cupyx_scipy_spherical_yn_real",
+    ("if->d", "id->d"),
+    "out0 = out0_type(spherical_yn_real(in0, in1))",
+    preamble=spherical_bessel_preamble,
+)
+
+_spherical_dyn_real = _core.create_ufunc(
+    "cupyx_scipy_spherical_dyn_real",
+    ("if->d", "id->d"),
+    "out0 = out0_type(spherical_yn_d_real(in0, in1));",
+    preamble=spherical_bessel_preamble,
+)
+
+
+def spherical_yn(n, z, derivative=False):
+    """Spherical Bessel function of the second kind or its derivative.
+
+    Parameters
+    ----------
+    n : cupy.ndarray
+        Order of the Bessel function.
+    z : cupy.ndarray
+        Argument of the Bessel function.
+        Real-valued input.
+    derivative : bool, optional
+        If True, the value of the derivative (rather than the function itself) is returned.
+
+    Returns
+    -------
+    yn : cupy.ndarray
+
+    See Also
+    -------
+    :func:`scipy.special.spherical_yn`
+
+    """
+    if cupy.iscomplexobj(z):
+        if derivative:
+            raise NotImplementedError
+        else:
+            raise NotImplementedError
+    else:
+        if derivative:
+            return _spherical_dyn_real(n, z)
+        else:
+            return _spherical_yn_real(n, z)

--- a/docs/source/reference/scipy_special.rst
+++ b/docs/source/reference/scipy_special.rst
@@ -24,6 +24,7 @@ Bessel functions
    i0e
    i1
    i1e
+   spherical_yn
 
 
 Raw statistical functions

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_spherical_bessel.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_spherical_bessel.py
@@ -3,6 +3,11 @@ import numpy
 from cupy import testing
 import cupyx.scipy.special  # NOQA
 
+try:
+    import scipy.special  # NOQA
+except ImportError:
+    pass
+
 
 @testing.gpu
 @testing.with_requires('scipy')
@@ -12,8 +17,6 @@ class TestSphericalBessel:
     @testing.for_dtypes('fd')
     @testing.numpy_cupy_allclose(atol=1e-12, rtol=1e-12, scipy_name='scp')
     def test_spherical_yn_inf_and_nan(self, xp, scp, dtype, order_dtype):
-        import scipy.special  # NOQA
-
         n = xp.arange(0, 100, dtype=order_dtype)
         a = xp.array([numpy.nan, numpy.inf, -numpy.inf], dtype=dtype)
         return scp.special.spherical_yn(n[xp.newaxis, :], a[:, xp.newaxis])
@@ -22,8 +25,6 @@ class TestSphericalBessel:
     @testing.for_dtypes('fd')
     @testing.numpy_cupy_allclose(atol=1e-12, rtol=1e-12, scipy_name='scp')
     def test_spherical_yn_linspace(self, xp, scp, dtype, order_dtype):
-        import scipy.special  # NOQA
-
         n = xp.arange(0, 10, dtype=order_dtype)
         a = xp.linspace(-10, 10, 100, dtype=dtype)
         return scp.special.spherical_yn(n[xp.newaxis, :], a[:, xp.newaxis])

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_spherical_bessel.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_spherical_bessel.py
@@ -13,7 +13,7 @@ class TestSphericalBessel:
     @testing.for_dtypes('i', name='order_dtype')
     @testing.for_dtypes('fd')
     @testing.numpy_cupy_allclose(atol=1e-12, rtol=1e-12, scipy_name='scp')
-    def test_inf_and_nan(self, xp, scp, dtype, order_dtype):
+    def test_spherical_yn_inf_and_nan(self, xp, scp, dtype, order_dtype):
         import scipy.special
 
         n = xp.arange(0, 100, dtype=order_dtype)

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_spherical_bessel.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_spherical_bessel.py
@@ -1,0 +1,39 @@
+import unittest
+
+import cupy
+import numpy
+from cupy import testing
+import cupyx.scipy.special  # NOQA
+
+
+@testing.gpu
+@testing.with_requires('scipy')
+class TestSphericalBessel:
+
+    # @testing.for_dtypes(['f', 'd'])
+    # @testing.numpy_cupy_allclose(rtol=1e-5, scipy_name='scp')
+    # def check_unary(self, name, xp, scp, dtype):
+    #     import scipy.special  # NOQA
+
+    #     a = testing.shaped_arange((2, 3), xp, dtype)
+    #     return getattr(scp.special, name)(a)
+
+    @testing.for_dtypes('i', name='order_dtype')
+    @testing.for_dtypes('fd')
+    @testing.numpy_cupy_allclose(atol=1e-12, rtol=1e-12, scipy_name='scp')
+    def test_inf_and_nan(self, xp, scp, dtype, order_dtype):
+        import scipy.special
+
+        n = xp.arange(0, 100, dtype=order_dtype)
+        a = xp.array([numpy.nan, numpy.inf, -numpy.inf], dtype=dtype)
+        return scp.special.spherical_yn(n[xp.newaxis, :], a[:, xp.newaxis])
+
+    @testing.for_dtypes('i', name='order_dtype')
+    @testing.for_dtypes('fd')
+    @testing.numpy_cupy_allclose(atol=1e-12, rtol=1e-12, scipy_name='scp')
+    def test_spherical_yn_linspace(self, xp, scp, dtype, order_dtype):
+        import scipy.special  # NOQA
+
+        n = xp.arange(0, 10, dtype=order_dtype)
+        a = xp.linspace(-10, 10, 100, dtype=dtype)
+        return scp.special.spherical_yn(n[xp.newaxis, :], a[:, xp.newaxis])

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_spherical_bessel.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_spherical_bessel.py
@@ -14,7 +14,7 @@ class TestSphericalBessel:
     @testing.for_dtypes('fd')
     @testing.numpy_cupy_allclose(atol=1e-12, rtol=1e-12, scipy_name='scp')
     def test_spherical_yn_inf_and_nan(self, xp, scp, dtype, order_dtype):
-        import scipy.special
+        import scipy.special  # NOQA
 
         n = xp.arange(0, 100, dtype=order_dtype)
         a = xp.array([numpy.nan, numpy.inf, -numpy.inf], dtype=dtype)

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_spherical_bessel.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_spherical_bessel.py
@@ -1,7 +1,5 @@
-import unittest
-
-import cupy
 import numpy
+
 from cupy import testing
 import cupyx.scipy.special  # NOQA
 

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_spherical_bessel.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_spherical_bessel.py
@@ -9,7 +9,6 @@ except ImportError:
     pass
 
 
-@testing.gpu
 @testing.with_requires('scipy')
 class TestSphericalBessel:
 

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_spherical_bessel.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_spherical_bessel.py
@@ -10,14 +10,6 @@ import cupyx.scipy.special  # NOQA
 @testing.with_requires('scipy')
 class TestSphericalBessel:
 
-    # @testing.for_dtypes(['f', 'd'])
-    # @testing.numpy_cupy_allclose(rtol=1e-5, scipy_name='scp')
-    # def check_unary(self, name, xp, scp, dtype):
-    #     import scipy.special  # NOQA
-
-    #     a = testing.shaped_arange((2, 3), xp, dtype)
-    #     return getattr(scp.special, name)(a)
-
     @testing.for_dtypes('i', name='order_dtype')
     @testing.for_dtypes('fd')
     @testing.numpy_cupy_allclose(atol=1e-12, rtol=1e-12, scipy_name='scp')


### PR DESCRIPTION
This PR adds `scipy.special.spherical_yn`.

This implementation supports real numbers and uses almost the same algorithm as in scipy.
Calculation for complex number requires other unimplemented Bessel functions, and therefore not supported in this PR.

Linked Issue : #6324