### PR TITLE
Require newer SciPy in a test

### DIFF
--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_splines.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_splines.py
@@ -13,7 +13,7 @@ except ImportError:
     pass
 
 
-@testing.with_requires('scipy')
+@testing.with_requires('scipy>=1.9')
 class TestSymIIROrder:
     @pytest.mark.parametrize('size', [11, 20, 32, 51, 64, 120])
     @pytest.mark.parametrize(


### PR DESCRIPTION
Following up #7511 and #7518.

We can see some signal filter fixes on SciPy 1.9.0 release.
https://docs.scipy.org/doc/scipy/release.1.9.0.html

This fixes https://ci.preferred.jp/cupy.linux.cuda115/128715/