### PR TITLE
Add sosfilt to cupyx.scipy.signal 

### DIFF
--- a/cupyx/scipy/signal/__init__.py
+++ b/cupyx/scipy/signal/__init__.py
@@ -13,6 +13,7 @@ from cupyx.scipy.signal._signaltools import medfilt2d  # NOQA
 from cupyx.scipy.signal._signaltools import lfilter  # NOQA
 from cupyx.scipy.signal._signaltools import lfiltic  # NOQA
 from cupyx.scipy.signal._signaltools import lfilter_zi  # NOQA
+from cupyx.scipy.signal._signaltools import sosfilt  # NOQA
 
 from cupyx.scipy.signal._bsplines import sepfir2d  # NOQA
 

--- a/cupyx/scipy/signal/_iir_utils.py
+++ b/cupyx/scipy/signal/_iir_utils.py
@@ -232,7 +232,7 @@ __global__ void compute_correction_factors_sos(
     for(int i = 0; i < m; i++) {
         U acc = 0.0;
         for(int j = 0; j < k; j++) {
-            acc += ((U) b_c[j]) * this_cache[off_idx - j];
+            acc += -((U) b_c[j]) * this_cache[off_idx - j];
 
         }
         this_cache[0] = this_cache[1];

--- a/cupyx/scipy/signal/_iir_utils.py
+++ b/cupyx/scipy/signal/_iir_utils.py
@@ -35,12 +35,15 @@ TYPE_PAIR_NAMES = [(_get_typename(x), _get_typename(y)) for x, y in TYPE_PAIRS]
 
 
 if runtime.is_hip:
-    IIR_KERNEL = r"""#include <hip/hip_runtime.h>
+    IIR_KERNEL = r"""
+    #include <hip/hip_runtime.h>
+    #include <hip/hip_cooperative_groups.h>
 """
 else:
     IIR_KERNEL = r"""
 #include <cuda_runtime.h>
 #include <device_launch_parameters.h>
+#include <cooperative_groups.h>
 """
 
 IIR_KERNEL = IIR_KERNEL + r"""
@@ -201,10 +204,10 @@ template<typename U, typename T>
 __global__ void compute_correction_factors_sos(
         const int m, const T* f_const, U* all_out) {
 
-    extern __shared__ __align__(sizeof(T)) unsigned char bc_d[2];
+    extern __shared__ __align__(sizeof(T)) thrust::complex<double> bc_d[2];
     T* b_c = reinterpret_cast<T*>(bc_d);
 
-    extern __shared__ __align__(sizeof(U)) unsigned char off_d[4];
+    extern __shared__ __align__(sizeof(T)) thrust::complex<double> off_d[4];
     U* off_cache = reinterpret_cast<U*>(off_d);
 
     int idx = threadIdx.x;
@@ -238,12 +241,13 @@ __global__ void compute_correction_factors_sos(
     }
 }
 
+
 template<typename T>
 __global__ void first_pass_iir_sos(
         const int n_sections, const int m, const int n, const int n_blocks,
         const T* factors, T* out, T* carries) {
 
-    extern __shared__ __align__(sizeof(T)) unsigned char fc_d[2 * 8];
+    extern __shared__ __align__(sizeof(T)) thrust::complex<double> fc_d[2 * 1024];
     T* factor_cache = reinterpret_cast<T*>(fc_d);
 
     int orig_idx = blockDim.x * (blockIdx.x % n_blocks) + threadIdx.x;
@@ -259,19 +263,19 @@ __global__ void first_pass_iir_sos(
     int group_num = idx / m;
     int group_pos = idx % m;
     T* out_off = out + num_row * n;
-    T* carries_off = carries + num_row * n_blocks * n_sections * k;
+    T* carries_off = carries + num_row * n_blocks * k;
 
     T* group_start = out_off + m * group_num;
-    T* group_carries = carries_off + group_num * n_sections * k;
+    T* group_carries = carries_off + group_num * k;
 
     for(int s = 0; s < n_sections; s++) {
         const T* section_factors = factors + s * m * k;
-        T* section_carries = group_carries + s * k;
+        T* section_carries = group_carries;
 
-        factor_cache[idx] = section_factors[idx];
-        factor_cache[idx - 1] = section_factors[idx - 1];
-        factor_cache[m + idx] = section_factors[m + idx];
-        factor_cache[m + idx - 1] = section_factors[m + idx - 1];
+        factor_cache[group_pos] = section_factors[group_pos];
+        factor_cache[group_pos - 1] = section_factors[group_pos - 1];
+        factor_cache[m + group_pos] = section_factors[m + group_pos];
+        factor_cache[m + group_pos - 1] = section_factors[m + group_pos - 1];
         __syncthreads();
 
         int pos = group_pos;
@@ -296,20 +300,22 @@ __global__ void first_pass_iir_sos(
                 pos += level / 2;
             }
 
-            if(pos + m * group_num >= n) {
+            if(pos + m * group_num >= n && n_sections == 1) {
                 break;
             }
 
-            rel_pos = pos % level;
-            T carry = 0.0;
-            for(int i = 1; i <= min(k, level); i++) {
-                T k_value = group_start[low_bound - i];
-                const T* k_factors = factor_cache + m  * (i - 1);
-                T factor = k_factors[rel_pos];
-                carry += k_value * factor;
-            }
+            if(pos + m * group_num < n || n_sections > 1) {
+                rel_pos = pos % level;
+                T carry = 0.0;
+                for(int i = 1; i <= min(k, level); i++) {
+                    T k_value = group_start[low_bound - i];
+                    const T* k_factors = factor_cache + m  * (i - 1);
+                    T factor = k_factors[rel_pos];
+                    carry += k_value * factor;
+                }
 
-            group_start[pos] += carry;
+                group_start[pos] += carry;
+            }
             __syncthreads();
         }
 
@@ -321,7 +327,89 @@ __global__ void first_pass_iir_sos(
     }
 
 }
-"""
+
+template<typename T>
+__global__ void correct_carries_sos(
+    const int m, const int n_blocks, const int carries_stride,
+    const int offset, const T* factors, T* carries) {
+
+    extern __shared__ __align__(sizeof(T)) thrust::complex<double> fcd3[4];
+    T* factor_cache = reinterpret_cast<T*>(fcd3);
+
+    int idx = threadIdx.x;
+    const int k = 2;
+    int pos = idx + (m - k);
+    T* row_carries = carries + carries_stride * blockIdx.x;
+
+    factor_cache[2 * idx] = factors[pos];
+    factor_cache[2 * idx + 1] = factors[m + pos];
+    __syncthreads();
+
+    for(int i = offset; i < n_blocks; i++) {
+        T* this_carries = row_carries + k * (i + (1 - offset));
+        T* prev_carries = row_carries + k * (i - offset);
+
+        T carry = 0.0;
+        for(int j = 1; j <= k; j++) {
+            // const T* k_factors = factors + m * (j - 1);
+            // T factor = k_factors[pos];
+            T factor = factor_cache[2 * idx + (j - 1)];
+            T k_value = prev_carries[k - j];
+            carry += factor * k_value;
+        }
+
+        this_carries[idx] += carry;
+        __syncthreads();
+    }
+}
+
+template<typename T>
+__global__ void second_pass_iir_sos(
+        const int m, const int n, const int carries_stride,
+        const int n_blocks, const int offset, const T* factors,
+        T* carries, T* out) {
+
+    extern __shared__ __align__(sizeof(T)) thrust::complex<double> fcd2[2 * 1024];
+    T* factor_cache = reinterpret_cast<T*>(fcd2);
+
+    extern __shared__ __align__(sizeof(T)) thrust::complex<double> c_d[2];
+    T* carries_cache = reinterpret_cast<T*>(c_d);
+
+    int idx = blockDim.x * (blockIdx.x % n_blocks) + threadIdx.x;
+    idx += offset * m;
+
+    int row_num = blockIdx.x / n_blocks;
+    int n_group = idx / m;
+    int pos = idx % m;
+    const int k = 2;
+
+    T* out_off = out + row_num * n;
+    T* carries_off = carries + row_num * carries_stride;
+    const T* prev_carries = carries_off + (n_group - offset) * k;
+
+    if(pos < k) {
+        carries_cache[pos] = prev_carries[pos];
+    }
+
+    if(idx >= n) {
+        return;
+    }
+
+    factor_cache[pos] = factors[pos];
+    factor_cache[pos + m] = factors[pos + m];
+    __syncthreads();
+
+    T carry = 0.0;
+    for(int i = 1; i <= k; i++) {
+        const T* k_factors = factor_cache + m * (i - 1);
+        T factor = k_factors[pos];
+        T k_value = carries_cache[k - i];
+        carry += factor * k_value;
+    }
+
+    out_off[idx] += carry;
+}
+"""  # NOQA
 
 IIR_MODULE = cupy.RawModule(
     code=IIR_KERNEL, options=('-std=c++11',),
@@ -332,7 +420,9 @@ IIR_MODULE = cupy.RawModule(
                      [f'second_pass_iir<{x}>' for x in TYPE_NAMES] +
                      [f'compute_correction_factors_sos<{x}, {y}>'
                       for x, y in TYPE_PAIR_NAMES] +
-                     [f'first_pass_iir_sos<{x}>' for x in TYPE_NAMES])
+                     [f'first_pass_iir_sos<{x}>' for x in TYPE_NAMES] +
+                     [f'correct_carries_sos<{x}>' for x in TYPE_NAMES] +
+                     [f'second_pass_iir_sos<{x}>' for x in TYPE_NAMES])
 
 
 def _get_module_func(module, func_name, *template_args):
@@ -347,6 +437,15 @@ def collapse_2d(x, axis):
     x = cupy.moveaxis(x, axis, -1)
     x_shape = x.shape
     x = x.reshape(-1, x.shape[-1])
+    if not x.flags.c_contiguous:
+        x = x.copy()
+    return x, x_shape
+
+
+def collapse_2d_rest(x, axis):
+    x = cupy.moveaxis(x, axis + 1, -1)
+    x_shape = x.shape
+    x = x.reshape(x.shape[0], -1, x.shape[-1])
     if not x.flags.c_contiguous:
         x = x.copy()
     return x, x_shape
@@ -474,7 +573,7 @@ def apply_iir_sos(x, sos, axis=-1, zi=None, dtype=None, block_sz=1024):
     if x_ndim > 1:
         x, x_shape = collapse_2d(x, axis)
         if zi is not None:
-            zi, _ = collapse_2d(zi, axis)
+            zi, _ = collapse_2d_rest(zi, axis)
 
     out = cupy.array(x, dtype=dtype, copy=True)
 
@@ -483,10 +582,44 @@ def apply_iir_sos(x, sos, axis=-1, zi=None, dtype=None, block_sz=1024):
     total_blocks = num_rows * n_blocks
 
     correction = compute_correction_factors_sos(sos, block_sz, dtype)
-    print(correction)
     carries = cupy.empty(
-        (num_rows, n_blocks, n_sections, k), dtype=dtype)
+        (num_rows, n_blocks, k), dtype=dtype)
+    all_carries = carries
+    if zi is not None:
+        all_carries = cupy.empty(
+            (num_rows, n_blocks + 1, k), dtype=dtype)
+
     first_pass_kernel = _get_module_func(IIR_MODULE, 'first_pass_iir_sos', out)
-    first_pass_kernel((total_blocks,), (block_sz // 2,),
-                      (n_sections, block_sz, n, n_blocks,
-                       correction, out, carries))
+    second_pass_kernel = _get_module_func(
+        IIR_MODULE, 'second_pass_iir_sos', out)
+    carry_correction_kernel = _get_module_func(
+        IIR_MODULE, 'correct_carries_sos', out)
+
+    if n_blocks == 1 and zi is None:
+        first_pass_kernel((total_blocks,), (block_sz // 2,),
+                          (n_sections, block_sz, n, n_blocks,
+                           correction, out, carries))
+    else:
+        starting_group = int(zi is None)
+        blocks_to_merge = n_blocks - starting_group
+        carries_stride = (n_blocks + (1 - starting_group)) * k
+        for s in range(n_sections):
+            first_pass_kernel(
+                (total_blocks,), (block_sz // 2,),
+                (1, block_sz, n, n_blocks, correction[s], out, carries))
+
+            if zi is not None:
+                section_zi = zi[s]
+                all_carries[:, 0, :] = section_zi
+                all_carries[:, 1:, :] = carries
+
+            carry_correction_kernel(
+                (num_rows,), (k,),
+                (block_sz, n_blocks, carries_stride, starting_group,
+                    correction[s], all_carries))
+            second_pass_kernel(
+                (num_rows * blocks_to_merge,), (block_sz,),
+                (block_sz, n, carries_stride, blocks_to_merge,
+                    starting_group, correction[s], all_carries, out))
+
+    return out

--- a/cupyx/scipy/signal/_signaltools.py
+++ b/cupyx/scipy/signal/_signaltools.py
@@ -929,3 +929,47 @@ def _get_kernel_size(kernel_size, ndim):
     if any((k % 2) != 1 for k in kernel_size):
         raise ValueError("Each element of kernel_size should be odd")
     return kernel_size
+
+
+def sosfilt(sos, x, axis=-1, zi=None):
+    """
+    Filter data along one dimension using cascaded second-order sections.
+
+    Filter a data sequence, `x`, using a digital IIR filter defined by
+    `sos`.
+
+    Parameters
+    ----------
+    sos : array_like
+        Array of second-order filter coefficients, must have shape
+        ``(n_sections, 6)``. Each row corresponds to a second-order
+        section, with the first three columns providing the numerator
+        coefficients and the last three providing the denominator
+        coefficients.
+    x : array_like
+        An N-dimensional input array.
+    axis : int, optional
+        The axis of the input data array along which to apply the
+        linear filter. The filter is applied to each subarray along
+        this axis.  Default is -1.
+    zi : array_like, optional
+        Initial conditions for the cascaded filter delays.  It is a (at
+        least 2D) vector of shape ``(n_sections, ..., 2, ...)``, where
+        ``..., 2, ...`` denotes the shape of `x`, but with ``x.shape[axis]``
+        replaced by 2.  If `zi` is None or is not given then initial rest
+        (i.e. all zeros) is assumed.
+        Note that these initial conditions are *not* the same as the initial
+        conditions given by `lfiltic` or `lfilter_zi`.
+
+    Returns
+    -------
+    y : ndarray
+        The output of the digital filter.
+    zf : ndarray, optional
+        If `zi` is None, this is not returned, otherwise, `zf` holds the
+        final filter delay values.
+
+    See Also
+    --------
+    zpk2sos, sos2zpk, sosfilt_zi, sosfiltfilt, sosfreqz
+    """

--- a/cupyx/scipy/signal/_signaltools.py
+++ b/cupyx/scipy/signal/_signaltools.py
@@ -6,7 +6,8 @@ from cupy._core import internal
 from cupyx.scipy.ndimage import _util
 from cupyx.scipy.ndimage import _filters
 from cupyx.scipy.signal import _signaltools_core as _st_core
-from cupyx.scipy.signal._iir_utils import apply_iir, compute_correction_factors
+from cupyx.scipy.signal._iir_utils import (
+    apply_iir, apply_iir_sos, compute_correction_factors)
 from cupyx.scipy.signal._arraytools import axis_slice, axis_assign
 
 
@@ -973,3 +974,34 @@ def sosfilt(sos, x, axis=-1, zi=None):
     --------
     zpk2sos, sos2zpk, sosfilt_zi, sosfiltfilt, sosfreqz
     """
+    x_ndim = x.ndim
+    axis = internal._normalize_axis_index(axis, x_ndim)
+    n = x.shape[axis]
+    n_sections = sos.shape[0]
+    fir_dtype = cupy.result_type(x, sos)
+
+    prev_in = None
+    prev_out = None
+    pad_shape = list(x.shape)
+    pad_shape[axis] += 2
+
+    x_full = cupy.zeros(pad_shape, dtype=fir_dtype)
+    out = cupy.empty_like(x_full, dtype=fir_dtype)
+    if zi is not None:
+        zi = cupy.atleast_2d(zi)
+        prev_in = axis_slice(zi, 0, 2, axis=axis + 1)
+        prev_out = axis_slice(zi, 2, 4, axis=axis + 1)
+
+    x_full = axis_assign(x_full, x, 2, axis=axis)
+    origin = -1
+    for s in range(n_sections):
+        b = sos[s, :3]
+        if zi is not None:
+            x_full = axis_assign(x_full, prev_in[s], 0, 2, axis=axis)
+        out = _filters.convolve1d(
+            x_full, b, axis=axis, mode='constant', origin=origin, output=out)
+        x_full = out.copy()
+
+    out = axis_slice(out, out.shape[axis] - n, out.shape[axis], axis=axis)
+    out = apply_iir_sos(out, sos, axis, prev_out)
+    return out

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_iir_utils.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_iir_utils.py
@@ -280,3 +280,127 @@ class TestIIRUtilSos:
         else:
             out = scp.signal.sosfilt(sos, x, axis=axis)
         return out
+
+    @pytest.mark.parametrize('size', [11, 20, 32, 51, 64, 120, 128, 250])
+    @pytest.mark.parametrize('sections', [1, 2, 3, 4, 5])
+    @testing.for_all_dtypes_combination(
+        no_float16=True, no_bool=True, names=('dtype',))
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=5e-5)
+    def test_zi_zeros(self, size, sections, dtype, xp, scp):
+        if xp.dtype(dtype).kind in {'i', 'u'}:
+            pytest.skip()
+
+        x_scale = 0.5 if xp.dtype(dtype).kind not in {'i', 'u'} else 1
+        c_scale = 0.2 if xp.dtype(dtype).kind not in {'i', 'u'} else 1
+
+        x = testing.shaped_random((size,), xp, dtype, scale=x_scale)
+        sos = testing.shaped_random((sections, 6), xp, dtype, scale=c_scale)
+        sos[:, 3] = 1
+        if xp is cupy:
+            zi = xp.zeros((sections, 4), dtype=dtype)
+            out, _ = apply_iir_sos(x, sos, zi=zi, block_sz=32)
+        else:
+            zi = xp.zeros((sections, 2), dtype=dtype)
+            out, _ = scp.signal.sosfilt(sos, x, zi=zi)
+        return out
+
+    @pytest.mark.parametrize('size', [11, 20, 32, 51, 64, 120, 128, 250])
+    @pytest.mark.parametrize('sections', [1, 2, 3, 4, 5])
+    @pytest.mark.parametrize('axis', [0, 1, 2, 3])
+    @testing.for_all_dtypes_combination(
+        no_float16=True, no_bool=True, names=('dtype',))
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=5e-5)
+    def test_zi_zeros_nd(self, size, sections, axis, dtype, xp, scp):
+        if xp.dtype(dtype).kind in {'i', 'u'}:
+            pytest.skip()
+
+        x_scale = 0.5 if xp.dtype(dtype).kind not in {'i', 'u'} else 1
+        c_scale = 0.2 if xp.dtype(dtype).kind not in {'i', 'u'} else 1
+
+        x = testing.shaped_random((4, 5, 3, size,), xp, dtype, scale=x_scale)
+        sos = testing.shaped_random((sections, 6), xp, dtype, scale=c_scale)
+        sos[:, 3] = 1
+        zi_size = [sections] + list(x.shape)
+        if xp is cupy:
+            zi_size[axis + 1] = 4
+            zi = xp.zeros(zi_size, dtype=dtype)
+            out, _ = apply_iir_sos(x, sos, zi=zi, axis=axis, block_sz=32)
+        else:
+            zi_size[axis + 1] = 2
+            zi = xp.zeros(zi_size, dtype=dtype)
+            out, _ = scp.signal.sosfilt(sos, x, zi=zi, axis=axis)
+        return out
+
+    @pytest.mark.parametrize('size', [11, 20, 32, 51, 64, 120, 128, 250])
+    @pytest.mark.parametrize('sections', [1, 2, 3, 4, 5])
+    @testing.for_all_dtypes_combination(
+        no_float16=True, no_bool=True, no_complex=True, names=('dtype',))
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=5e-5)
+    def test_zi(self, size, sections, dtype, xp, scp):
+        if xp.dtype(dtype).kind in {'i', 'u'}:
+            pytest.skip()
+
+        x_scale = 0.5 if xp.dtype(dtype).kind not in {'i', 'u'} else 1
+        c_scale = 0.2 if xp.dtype(dtype).kind not in {'i', 'u'} else 1
+
+        x = testing.shaped_random((size,), xp, dtype, scale=x_scale)
+        sos = testing.shaped_random((sections, 6), xp, dtype, scale=c_scale)
+        sos[:, 3] = 1
+        zi = testing.shaped_random((sections, 4), xp, dtype, scale=x_scale)
+        if xp is not cupy:
+            sections_zi = []
+            for s in range(sections):
+                b = sos[s, :3]
+                a = sos[s, 3:]
+                section_zi = zi[s]
+                section_zi = scp.signal.lfiltic(
+                    b, a, section_zi[2:][::-1], section_zi[:2][::-1])
+                sections_zi.append(xp.expand_dims(section_zi, 0))
+            zi = xp.concatenate(sections_zi)
+            out, _ = scp.signal.sosfilt(sos, x, zi=zi)
+        else:
+            out, _ = apply_iir_sos(x, sos, zi=zi, block_sz=32)
+        return out
+
+    @pytest.mark.parametrize('size', [11, 20, 32, 51, 64, 120, 128, 250])
+    @pytest.mark.parametrize('sections', [1, 2, 3, 4, 5])
+    @pytest.mark.parametrize('axis', [0, 1, 2, 3])
+    @testing.for_all_dtypes_combination(
+        no_float16=True, no_bool=True, names=('dtype',))
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=5e-5, atol=5e-5)
+    def test_zi_nd(self, size, sections, axis, dtype, xp, scp):
+        if xp.dtype(dtype).kind in {'i', 'u'}:
+            pytest.skip()
+
+        x_scale = 0.5 if xp.dtype(dtype).kind not in {'i', 'u'} else 1
+        c_scale = 0.2 if xp.dtype(dtype).kind not in {'i', 'u'} else 1
+
+        x = testing.shaped_random((4, 5, 3, size,), xp, dtype, scale=x_scale)
+        sos = testing.shaped_random((sections, 6), xp, dtype, scale=c_scale)
+        sos[:, 3] = 1
+
+        zi_size = [sections] + list(x.shape)
+        zi_size[axis + 1] = 4
+        zi = testing.shaped_random(zi_size, xp, dtype, scale=x_scale)
+
+        if xp is not cupy:
+            sections_zi = []
+            for s in range(sections):
+                b = sos[s, :3]
+                a = sos[s, 3:]
+                section_zi = zi[s]
+                section_zi = xp.moveaxis(section_zi, axis, -1)
+                zi_m_shape = section_zi.shape
+                section_zi = section_zi.reshape(-1, 4).copy()
+                section_zi = xp.concatenate([
+                    scp.signal.lfiltic(
+                        b, a, z[2:][::-1], z[:2][::-1])
+                    for z in section_zi])
+                section_zi = section_zi.reshape(zi_m_shape[:-1] + (2,))
+                section_zi = xp.moveaxis(section_zi, -1, axis)
+                sections_zi.append(xp.expand_dims(section_zi, 0))
+            zi = xp.concatenate(sections_zi)
+            out, _ = scp.signal.sosfilt(sos, x, zi=zi, axis=axis)
+        else:
+            out, _ = apply_iir_sos(x, sos, zi=zi, axis=axis, block_sz=32)
+        return out

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_iir_utils.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_iir_utils.py
@@ -4,7 +4,7 @@ import cupy
 from cupy.cuda import driver
 from cupy.cuda import runtime
 from cupy import testing
-from cupyx.scipy.signal._iir_utils import apply_iir
+from cupyx.scipy.signal._iir_utils import apply_iir, apply_iir_sos
 
 
 @pytest.mark.xfail(
@@ -231,3 +231,52 @@ class TestIIRUtils:
                                         a, x, zi=zi, axis=axis)
         res = xp.nan_to_num(res, nan=xp.nan, posinf=xp.nan, neginf=xp.nan)
         return res
+
+
+@pytest.mark.xfail(
+    runtime.is_hip and driver.get_build_version() < 5_00_00000,
+    reason='name_expressions with ROCm 4.3 may not work')
+@testing.with_requires('scipy')
+class TestIIRUtilSos:
+    @pytest.mark.parametrize('size', [11, 20, 32, 33, 51, 64, 120, 128, 250])
+    @pytest.mark.parametrize('sections', [1, 2, 3, 4, 5])
+    @testing.for_all_dtypes_combination(
+        no_float16=True, no_bool=True, names=('dtype',))
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=5e-5)
+    def test_sections(self, size, sections, dtype, xp, scp):
+        if xp.dtype(dtype).kind in {'i', 'u'}:
+            pytest.skip()
+
+        x_scale = 0.5 if xp.dtype(dtype).kind not in {'i', 'u'} else 1
+        c_scale = 0.2 if xp.dtype(dtype).kind not in {'i', 'u'} else 1
+
+        x = testing.shaped_random((size,), xp, dtype, scale=x_scale)
+        sos = testing.shaped_random((sections, 6), xp, dtype, scale=c_scale)
+        sos[:, 3] = 1
+        if xp is cupy:
+            out = apply_iir_sos(x, sos, block_sz=32)
+        else:
+            out = scp.signal.sosfilt(sos, x)
+        return out
+
+    @pytest.mark.parametrize('size', [11, 20, 32, 33, 51, 64, 120, 128, 250])
+    @pytest.mark.parametrize('sections', [1, 2, 3, 4, 5])
+    @pytest.mark.parametrize('axis', [0, 1, 2, 3])
+    @testing.for_all_dtypes_combination(
+        no_float16=True, no_bool=True, names=('dtype',))
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=5e-5)
+    def test_sections_nd(self, size, sections, axis, dtype, xp, scp):
+        if xp.dtype(dtype).kind in {'i', 'u'}:
+            pytest.skip()
+
+        x_scale = 0.5 if xp.dtype(dtype).kind not in {'i', 'u'} else 1
+        c_scale = 0.2 if xp.dtype(dtype).kind not in {'i', 'u'} else 1
+
+        x = testing.shaped_random((4, 5, 3, size,), xp, dtype, scale=x_scale)
+        sos = testing.shaped_random((sections, 6), xp, dtype, scale=c_scale)
+        sos[:, 3] = 1
+        if xp is cupy:
+            out = apply_iir_sos(x, sos, axis=axis, block_sz=32)
+        else:
+            out = scp.signal.sosfilt(sos, x, axis=axis)
+        return out

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
@@ -603,3 +603,120 @@ class TestSosFilt:
         sos = testing.shaped_random((sections, 6), xp, dtype, scale=c_scale)
         sos[:, 3] = 1
         return scp.signal.sosfilt(sos, x, axis=axis)
+
+    @pytest.mark.parametrize('size', [11, 20, 32, 51, 64, 120, 128, 250])
+    @pytest.mark.parametrize('sections', [1, 2, 3, 4, 5])
+    @testing.for_all_dtypes_combination(
+        no_float16=True, no_bool=True, names=('dtype',))
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=5e-5)
+    def test_zi_zeros(self, size, sections, dtype, xp, scp):
+        if xp.dtype(dtype).kind in {'i', 'u'}:
+            pytest.skip()
+
+        x_scale = 0.5 if xp.dtype(dtype).kind not in {'i', 'u'} else 1
+        c_scale = 0.2 if xp.dtype(dtype).kind not in {'i', 'u'} else 1
+
+        x = testing.shaped_random((size,), xp, dtype, scale=x_scale)
+        sos = testing.shaped_random((sections, 6), xp, dtype, scale=c_scale)
+        sos[:, 3] = 1
+        if xp is cupy:
+            zi = xp.zeros((sections, 4), dtype=dtype)
+        else:
+            zi = xp.zeros((sections, 2), dtype=dtype)
+        out, _ = scp.signal.sosfilt(sos, x, zi=zi)
+        return out
+
+    @pytest.mark.parametrize('size', [11, 20, 32, 51, 64, 120, 128, 250])
+    @pytest.mark.parametrize('sections', [1, 2, 3, 4, 5])
+    @pytest.mark.parametrize('axis', [0, 1, 2, 3])
+    @testing.for_all_dtypes_combination(
+        no_float16=True, no_bool=True, names=('dtype',))
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=5e-5)
+    def test_zi_zeros_nd(self, size, sections, axis, dtype, xp, scp):
+        if xp.dtype(dtype).kind in {'i', 'u'}:
+            pytest.skip()
+
+        x_scale = 0.5 if xp.dtype(dtype).kind not in {'i', 'u'} else 1
+        c_scale = 0.2 if xp.dtype(dtype).kind not in {'i', 'u'} else 1
+
+        x = testing.shaped_random((4, 5, 3, size,), xp, dtype, scale=x_scale)
+        sos = testing.shaped_random((sections, 6), xp, dtype, scale=c_scale)
+        sos[:, 3] = 1
+        zi_size = [sections] + list(x.shape)
+        if xp is cupy:
+            zi_size[axis + 1] = 4
+        else:
+            zi_size[axis + 1] = 2
+        zi = xp.zeros(zi_size, dtype=dtype)
+        out, _ = scp.signal.sosfilt(sos, x, zi=zi, axis=axis)
+        return out
+
+    @pytest.mark.parametrize('size', [11, 20, 32, 51, 64, 120, 128, 250])
+    @pytest.mark.parametrize('sections', [1, 2, 3, 4, 5])
+    @testing.for_all_dtypes_combination(
+        no_float16=True, no_bool=True, no_complex=True, names=('dtype',))
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=5e-5)
+    def test_zi(self, size, sections, dtype, xp, scp):
+        if xp.dtype(dtype).kind in {'i', 'u'}:
+            pytest.skip()
+
+        x_scale = 0.5 if xp.dtype(dtype).kind not in {'i', 'u'} else 1
+        c_scale = 0.2 if xp.dtype(dtype).kind not in {'i', 'u'} else 1
+
+        x = testing.shaped_random((size,), xp, dtype, scale=x_scale)
+        sos = testing.shaped_random((sections, 6), xp, dtype, scale=c_scale)
+        sos[:, 3] = 1
+        zi = testing.shaped_random((sections, 4), xp, dtype, scale=x_scale)
+        if xp is not cupy:
+            sections_zi = []
+            for s in range(sections):
+                b = sos[s, :3]
+                a = sos[s, 3:]
+                section_zi = zi[s]
+                section_zi = scp.signal.lfiltic(
+                    b, a, section_zi[2:][::-1], section_zi[:2][::-1])
+                sections_zi.append(xp.expand_dims(section_zi, 0))
+            zi = xp.concatenate(sections_zi)
+        out, _ = scp.signal.sosfilt(sos, x, zi=zi)
+        return out
+
+    @pytest.mark.parametrize('size', [11, 20, 32, 51, 64, 120, 128, 250])
+    @pytest.mark.parametrize('sections', [1, 2, 3, 4, 5])
+    @pytest.mark.parametrize('axis', [0, 1, 2, 3])
+    @testing.for_all_dtypes_combination(
+        no_float16=True, no_bool=True, names=('dtype',))
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=5e-5, atol=5e-5)
+    def test_zi_nd(self, size, sections, axis, dtype, xp, scp):
+        if xp.dtype(dtype).kind in {'i', 'u'}:
+            pytest.skip()
+
+        x_scale = 0.5 if xp.dtype(dtype).kind not in {'i', 'u'} else 1
+        c_scale = 0.2 if xp.dtype(dtype).kind not in {'i', 'u'} else 1
+
+        x = testing.shaped_random((4, 5, 3, size,), xp, dtype, scale=x_scale)
+        sos = testing.shaped_random((sections, 6), xp, dtype, scale=c_scale)
+        sos[:, 3] = 1
+
+        zi_size = [sections] + list(x.shape)
+        zi_size[axis + 1] = 4
+        zi = testing.shaped_random(zi_size, xp, dtype, scale=x_scale)
+
+        if xp is not cupy:
+            sections_zi = []
+            for s in range(sections):
+                b = sos[s, :3]
+                a = sos[s, 3:]
+                section_zi = zi[s]
+                section_zi = xp.moveaxis(section_zi, axis, -1)
+                zi_m_shape = section_zi.shape
+                section_zi = section_zi.reshape(-1, 4).copy()
+                section_zi = xp.concatenate([
+                    scp.signal.lfiltic(
+                        b, a, z[2:][::-1], z[:2][::-1])
+                    for z in section_zi])
+                section_zi = section_zi.reshape(zi_m_shape[:-1] + (2,))
+                section_zi = xp.moveaxis(section_zi, -1, axis)
+                sections_zi.append(xp.expand_dims(section_zi, 0))
+            zi = xp.concatenate(sections_zi)
+        out, _ = scp.signal.sosfilt(sos, x, zi=zi, axis=axis)
+        return out


### PR DESCRIPTION
See https://github.com/cupy/cupy/issues/7403

This implementation will contemplate the performance against the following baselines:

1. N sequential calls to `lfilter`, where each one of them computes each second order section.
3. N calls to convolve1d  to compute the FIR part and a extension of the `apply_iir` kernel to chained second order sections (the kernel would compute the IIR part from the FIR output in a chained fashion).
4. A generalization of `apply_iir` where the function would compute both FIR and IIR sections sequentially one after another with custom kernels for both parts.

If the third option improves the performance, then it would be possible to think about improving `lfilter` this route.