### PR TITLE
Import SciPy in tests

### DIFF
--- a/tests/cupyx_tests/scipy_tests/special_tests/test_exprel.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_exprel.py
@@ -5,6 +5,12 @@ import cupy
 from cupy import testing
 from cupy.testing import numpy_cupy_allclose
 
+try:
+    import scipy.special  # NOQA
+except ImportError:
+    pass
+
+
 atol = {
     'default': 1e-6,
     cupy.float16: 1e-2,


### PR DESCRIPTION
Hi Team, apologies for the delay in PR, came down with a fever. 

This PR follows the https://github.com/cupy/cupy/pull/7474#issuecomment-1512348466 comment and imports SciPy in `cupyx.scipy.special.exprel` tests.