### PR TITLE
[WIP] Add `scipy.stats.tmin` to cupyx 

### DIFF
--- a/cupy/_core/_routines_statistics.pxd
+++ b/cupy/_core/_routines_statistics.pxd
@@ -25,6 +25,8 @@ cpdef _ndarray_base _nanmean(_ndarray_base a, axis, dtype, out, keepdims)
 cpdef _ndarray_base _nanvar(_ndarray_base a, axis, dtype, out, ddof, keepdims)
 cpdef _ndarray_base _nanstd(_ndarray_base a, axis, dtype, out, ddof, keepdims)
 
-cpdef _ndarray_base _tmin(_ndarray_base a, limit , inclusive, propagate_nan,infinity,axis)
+
 cpdef _ndarray_base _nanargmin(_ndarray_base a, axis, out, dtype, keepdims)
 cpdef _ndarray_base _nanargmax(_ndarray_base a, axis, out, dtype, keepdims)
+cpdef _ndarray_base _tmin(
+    _ndarray_base a, limit, inclusive, propagate_nan, infinity, axis)

--- a/cupy/_core/_routines_statistics.pxd
+++ b/cupy/_core/_routines_statistics.pxd
@@ -25,6 +25,6 @@ cpdef _ndarray_base _nanmean(_ndarray_base a, axis, dtype, out, keepdims)
 cpdef _ndarray_base _nanvar(_ndarray_base a, axis, dtype, out, ddof, keepdims)
 cpdef _ndarray_base _nanstd(_ndarray_base a, axis, dtype, out, ddof, keepdims)
 
-cpdef _ndarray_base _tmin(_ndarray_base a, limit , inclusive, propagate_nan,axis)
+cpdef _ndarray_base _tmin(_ndarray_base a, limit , inclusive, propagate_nan,infinity,axis)
 cpdef _ndarray_base _nanargmin(_ndarray_base a, axis, out, dtype, keepdims)
 cpdef _ndarray_base _nanargmax(_ndarray_base a, axis, out, dtype, keepdims)

--- a/cupy/_core/_routines_statistics.pxd
+++ b/cupy/_core/_routines_statistics.pxd
@@ -25,6 +25,6 @@ cpdef _ndarray_base _nanmean(_ndarray_base a, axis, dtype, out, keepdims)
 cpdef _ndarray_base _nanvar(_ndarray_base a, axis, dtype, out, ddof, keepdims)
 cpdef _ndarray_base _nanstd(_ndarray_base a, axis, dtype, out, ddof, keepdims)
 
-
+cpdef _ndarray_base _tmin(_ndarray_base a, limit , inclusive, propagate_nan,axis)
 cpdef _ndarray_base _nanargmin(_ndarray_base a, axis, out, dtype, keepdims)
 cpdef _ndarray_base _nanargmax(_ndarray_base a, axis, out, dtype, keepdims)

--- a/cupy/_core/_routines_statistics.pyx
+++ b/cupy/_core/_routines_statistics.pyx
@@ -608,12 +608,6 @@ __device__ double my_norm(const complex<double>& x) { return norm(x); }
 
 cdef _tmin_preamble = '''
 template <typename S>
-__device__ S my_tmin_omit(S a, S  b){
-if (b<0) return a;
-return min(a,b);
-}
-
-template <typename S>
 __device__ S my_tmin_propagate(S a, S b){
 if (a!=a) return a;
 if (b!=b) return b;

--- a/cupyx/scipy/stats/__init__.py
+++ b/cupyx/scipy/stats/__init__.py
@@ -2,7 +2,7 @@
 
 from cupyx.scipy.stats._distributions import entropy  # NOQA
 from cupyx.scipy.stats._stats import trim_mean  # NOQA
-
+from cupyx.scipy.stats._stats import tmin  # NOQA
 
 # Other statistical functionality
 

--- a/cupyx/scipy/stats/_stats.py
+++ b/cupyx/scipy/stats/_stats.py
@@ -9,6 +9,157 @@ References
 """
 import cupy as cp
 
+from cupy._core import _routines_statistics as _statistics
+
+# tmin_kernel =  cp.ReductionKernel(
+#         'S x1 , S limit, bool inclusive, bool propagate_nan',
+#         'S y',
+#         'x1',
+#         'tmin_helper(a,b,limit,inclusive,propagate_nan)',
+#         'y=a',
+#         'CUDART_INF',
+#         name='tmin',
+#         reduce_dims=True,
+#         preamble="""    template <typename S>
+#                         __device__ S tmin_helper(S a , S b ,S limit, bool inclusive , bool propagate_nan ){
+#                             if (propagate_nan){
+#                                 return ((b!=b || a!=a  ) ? nan("")  :
+#                                 (inclusive ? (b>=limit ? min(a,b) : a) : (b>limit ? min(a,b) : a)));
+#                             }
+#                             else{
+#                                 return inclusive ? (b>=limit ? min(a,b) : a) : (b>limit ? min(a,b) : a);
+#                             }
+#                         }
+
+
+#                         """
+
+
+#     )
+
+tmin_kernel =  cp.ReductionKernel(
+        'S x1 ,T limit, bool inclusive, bool propagate_nan',
+        'S y',
+        'x1',
+        'tmin_helper(a,b,limit,inclusive,propagate_nan)',
+        'y=a',
+        'CUDART_INF',
+        name='tmin',
+        reduce_dims=True,
+        preamble="""   
+                        template <typename S,typename T>
+                        __device__ S tmin_helper(S a , S b ,T limit , bool inclusive , bool propagate_nan ){
+                            
+                            if (propagate_nan){
+                                return ((b!=b || a!=a  ) ? nan("")  :
+                                (inclusive ? (a>=(S) limit ? min(a,b) : b) : (a>(S) limit ? min(a,b) : b)));
+                            }
+                            else{
+                                printf("a=%d,b=%d  ",a,b);
+                                return inclusive ? (a>=(S) limit ? min(a,b) : b) : (a>(S) limit ? min(a,b) : b);
+                            }
+                        }
+
+
+                        """
+
+
+    )
+
+# tmin_kernel =  cp.ReductionKernel(
+#         'S x1 , T limit, bool inclusive, bool propagate_nan',
+#         'S y',
+#         'x1',
+#         'tmin_helper(a,b,limit,inclusive,propagate_nan)',
+#         'y=a',
+#         'CUDART_INF',
+#         name='tmin',
+#         reduce_dims=True,
+#         preamble="""    template <typename S>
+#                         __device__ S tmin_helper(S a , S b ,T limit, bool inclusive , bool propagate_nan ){
+#                             if (propagate_nan){
+                                
+#                                 if ((b!=b) || (a!=a)) {
+#                                     return nan("");
+#                                 }
+#                                 else{
+#                                     if (inclusive) {
+#                                         return (b>=limit ? min(a,b) : a);
+#                                     } 
+#                                     else{ 
+#                                         return (b>limit ? min(a,b) : a);
+#                                     }
+#                                 }
+#                             }
+#                             else{
+                                 
+#                                  if (inclusive) {
+#                                         printf("%d   ",a);
+#                                         return (b>=limit ? min(a,b) : a);
+#                                     } 
+#                                     else{ 
+#                                         return (b>limit ? min(a,b) : a);
+#                                     }
+#                             }
+#                         }
+
+
+#                         """
+
+
+#     )
+
+# tmin_kernel=cp.ReductionKernel(
+#             'T x1 ,T limit,bool inclusive,bool propagate_nan',
+#             'T y , T within_limits',
+#             'x1',
+#             '(tmin_helper(a,b,limit,inclusive,propagate_nan),10)',
+#             '(y=a) , within_limits=0',
+#             '(CUDART_INF,0)',
+#             name='tmin',
+#             reduce_dims=True,
+#             preamble="""
+#                     bool within_limits=false;
+#                     __device__ T tmin_helper(T a , T b ,T limit, bool inclusive , bool propagate_nan ){
+
+#                         if (propagate_nan){
+#                             return  ((isnan(b) || isnan(a)  ) ? nan("")  :
+#                             (inclusive ? (b>=limit ? min(a,b) : a) : (b>limit ? min(a,b) : a)));
+#                         }
+#                         else{
+#                             return inclusive ? (b>=limit ? min(a,b) : a) : (b>limit ? min(a,b) : a);
+#                         }
+#                     }
+
+
+#                     """
+
+# )
+# params = ['input','limit',]
+# arginfos = [('input', cp.ndarray),
+#                 ('limit', 'float64')]
+# tmin_kernel= _core.create_reduction_func(
+#     'cupy_tmin',
+
+#     ('e->e', 'f->f', 'd->d', 'F->F', 'D->D'),
+#     ('T in0 ,T limit,bool inclusive,bool propagate_nan',
+#      'in0', 'tmin_helper(a, b,in1,in2,in3)',
+#      'out0 = a'), 'CUDART_INF' ,
+#      preamble="""
+#             __device__ T tmin_helper(T a , T b ,T limit, bool inclusive , bool propagate_nan ){
+#                 if (propagate_nan){
+#                     return ((isnan(a) || isnan(b) ) ? nan("")  :
+#                     (inclusive ? (b>=limit ? min(a,b) : a) : (b>limit ? min(a,b) : a)));
+#                 }
+#                 else{
+#                     return inclusive ? (b>=limit ? min(a,b) : a) : (b>limit ? min(a,b) : a);
+#                 }
+#             }
+
+
+#             """
+
+#         )
 
 def trim_mean(a, proportiontocut, axis=0):
     """Return mean of array after trimming distribution from both tails.
@@ -75,3 +226,42 @@ def trim_mean(a, proportiontocut, axis=0):
     sl = [slice(None)] * atmp.ndim
     sl[axis] = slice(lowercut, uppercut)
     return cp.mean(atmp[tuple(sl)], axis=axis)
+
+
+def tmin(a, lowerlimit=None, axis=0, inclusive=True, nan_policy='propagate'):
+    
+    if a.size == 0:
+        raise ValueError("No array values within given limits")
+    if axis is None:
+        a = a.ravel()
+        axis = 0
+    if a.ndim == 0:
+        a = cp.atleast_1d(a)
+   
+    policies = ['propagate', 'raise', 'omit']
+
+    if nan_policy not in policies:
+        raise ValueError("nan_policy must be one of {%s}" %
+                         ', '.join("'%s'" % s for s in policies))
+
+
+    contains_nan = cp.isnan(cp.sum(a))
+    
+    
+    if contains_nan :
+            if nan_policy != 'propagate':
+                if nan_policy == 'raise':
+                    raise ValueError("The input contains nan values")
+                return _statistics._tmin(a,cp.atleast_1d( -cp.inf if lowerlimit is None else lowerlimit), inclusive, False, axis=axis)
+            return _statistics._tmin(a, cp.atleast_1d(-cp.inf if lowerlimit is None else lowerlimit), inclusive, True, axis=axis)
+    else:
+        if lowerlimit is None:
+            return cp.amin(a, axis=axis)
+        max_element= cp.max(a)
+        if max_element>lowerlimit or (max_element==lowerlimit and inclusive):
+            return _statistics._tmin(a, cp.atleast_1d(lowerlimit), inclusive, False, axis=axis)
+        raise ValueError("No array values within given limits")
+            
+            # if cp.all(solution==cp.iinfo(solution.dtype).max):
+            #     raise ValueError("No array values within given limits")
+            

--- a/cupyx/scipy/stats/_stats.py
+++ b/cupyx/scipy/stats/_stats.py
@@ -8,158 +8,8 @@ References
    York. 2000.
 """
 import cupy as cp
-
 from cupy._core import _routines_statistics as _statistics
 
-# tmin_kernel =  cp.ReductionKernel(
-#         'S x1 , S limit, bool inclusive, bool propagate_nan',
-#         'S y',
-#         'x1',
-#         'tmin_helper(a,b,limit,inclusive,propagate_nan)',
-#         'y=a',
-#         'CUDART_INF',
-#         name='tmin',
-#         reduce_dims=True,
-#         preamble="""    template <typename S>
-#                         __device__ S tmin_helper(S a , S b ,S limit, bool inclusive , bool propagate_nan ){
-#                             if (propagate_nan){
-#                                 return ((b!=b || a!=a  ) ? nan("")  :
-#                                 (inclusive ? (b>=limit ? min(a,b) : a) : (b>limit ? min(a,b) : a)));
-#                             }
-#                             else{
-#                                 return inclusive ? (b>=limit ? min(a,b) : a) : (b>limit ? min(a,b) : a);
-#                             }
-#                         }
-
-
-#                         """
-
-
-#     )
-
-tmin_kernel =  cp.ReductionKernel(
-        'S x1 ,T limit, bool inclusive, bool propagate_nan',
-        'S y',
-        'x1',
-        'tmin_helper(a,b,limit,inclusive,propagate_nan)',
-        'y=a',
-        'CUDART_INF',
-        name='tmin',
-        reduce_dims=True,
-        preamble="""   
-                        template <typename S,typename T>
-                        __device__ S tmin_helper(S a , S b ,T limit , bool inclusive , bool propagate_nan ){
-                            
-                            if (propagate_nan){
-                                return ((b!=b || a!=a  ) ? nan("")  :
-                                (inclusive ? (a>=(S) limit ? min(a,b) : b) : (a>(S) limit ? min(a,b) : b)));
-                            }
-                            else{
-                                printf("a=%d,b=%d  ",a,b);
-                                return inclusive ? (a>=(S) limit ? min(a,b) : b) : (a>(S) limit ? min(a,b) : b);
-                            }
-                        }
-
-
-                        """
-
-
-    )
-
-# tmin_kernel =  cp.ReductionKernel(
-#         'S x1 , T limit, bool inclusive, bool propagate_nan',
-#         'S y',
-#         'x1',
-#         'tmin_helper(a,b,limit,inclusive,propagate_nan)',
-#         'y=a',
-#         'CUDART_INF',
-#         name='tmin',
-#         reduce_dims=True,
-#         preamble="""    template <typename S>
-#                         __device__ S tmin_helper(S a , S b ,T limit, bool inclusive , bool propagate_nan ){
-#                             if (propagate_nan){
-                                
-#                                 if ((b!=b) || (a!=a)) {
-#                                     return nan("");
-#                                 }
-#                                 else{
-#                                     if (inclusive) {
-#                                         return (b>=limit ? min(a,b) : a);
-#                                     } 
-#                                     else{ 
-#                                         return (b>limit ? min(a,b) : a);
-#                                     }
-#                                 }
-#                             }
-#                             else{
-                                 
-#                                  if (inclusive) {
-#                                         printf("%d   ",a);
-#                                         return (b>=limit ? min(a,b) : a);
-#                                     } 
-#                                     else{ 
-#                                         return (b>limit ? min(a,b) : a);
-#                                     }
-#                             }
-#                         }
-
-
-#                         """
-
-
-#     )
-
-# tmin_kernel=cp.ReductionKernel(
-#             'T x1 ,T limit,bool inclusive,bool propagate_nan',
-#             'T y , T within_limits',
-#             'x1',
-#             '(tmin_helper(a,b,limit,inclusive,propagate_nan),10)',
-#             '(y=a) , within_limits=0',
-#             '(CUDART_INF,0)',
-#             name='tmin',
-#             reduce_dims=True,
-#             preamble="""
-#                     bool within_limits=false;
-#                     __device__ T tmin_helper(T a , T b ,T limit, bool inclusive , bool propagate_nan ){
-
-#                         if (propagate_nan){
-#                             return  ((isnan(b) || isnan(a)  ) ? nan("")  :
-#                             (inclusive ? (b>=limit ? min(a,b) : a) : (b>limit ? min(a,b) : a)));
-#                         }
-#                         else{
-#                             return inclusive ? (b>=limit ? min(a,b) : a) : (b>limit ? min(a,b) : a);
-#                         }
-#                     }
-
-
-#                     """
-
-# )
-# params = ['input','limit',]
-# arginfos = [('input', cp.ndarray),
-#                 ('limit', 'float64')]
-# tmin_kernel= _core.create_reduction_func(
-#     'cupy_tmin',
-
-#     ('e->e', 'f->f', 'd->d', 'F->F', 'D->D'),
-#     ('T in0 ,T limit,bool inclusive,bool propagate_nan',
-#      'in0', 'tmin_helper(a, b,in1,in2,in3)',
-#      'out0 = a'), 'CUDART_INF' ,
-#      preamble="""
-#             __device__ T tmin_helper(T a , T b ,T limit, bool inclusive , bool propagate_nan ){
-#                 if (propagate_nan){
-#                     return ((isnan(a) || isnan(b) ) ? nan("")  :
-#                     (inclusive ? (b>=limit ? min(a,b) : a) : (b>limit ? min(a,b) : a)));
-#                 }
-#                 else{
-#                     return inclusive ? (b>=limit ? min(a,b) : a) : (b>limit ? min(a,b) : a);
-#                 }
-#             }
-
-
-#             """
-
-#         )
 
 def trim_mean(a, proportiontocut, axis=0):
     """Return mean of array after trimming distribution from both tails.
@@ -229,14 +79,61 @@ def trim_mean(a, proportiontocut, axis=0):
 
 
 def tmin(a, lowerlimit=None, axis=0, inclusive=True, nan_policy='propagate'):
-    
+    """Compute the trimmed minimum.
+
+    This function finds the miminum value of an array `a` along the
+    specified axis, but only considering values greater than a specified
+    lower limit.
+
+    Parameters
+    ----------
+    a : cupy.ndarray
+        Array of values.
+    lowerlimit : None or float, optional
+        Values in the input array less than the given limit will be ignored.
+        When lowerlimit is None, then all values are used. The default value
+        is None.
+    axis : int or None, optional
+        Axis along which to operate. Default is 0. If None, compute over the
+        whole array `a`.
+    inclusive : {True, False}, optional
+        This flag determines whether values exactly equal to the lower limit
+        are included.  The default value is True.
+    nan_policy : {'propagate', 'raise', 'omit'}, optional
+        Defines how to handle when input contains nan.
+        The following options are available (default is 'propagate'):
+
+          * 'propagate': returns nan
+          * 'raise': throws an error
+          * 'omit': performs the calculations ignoring nan values
+
+    Returns
+    -------
+    tmin : float, int or ndarray
+        Trimmed minimum.
+
+    Examples
+    --------
+    >>> import cupy as cp
+    >>> from cupyx.scipy import stats
+    >>> x = cp.arange(20)
+    >>> stats.tmin(x)
+    0
+
+    >>> stats.tmin(x, 13)
+    13
+
+    >>> stats.tmin(x, 13, inclusive=False)
+    14
+
+    """
     if a.size == 0:
         raise ValueError("No array values within given limits")
     if axis is None:
         a = a.ravel()
         axis = 0
     if a.ndim == 0:
-        a = cp.atleast_1d(a)
+        a = cp.atleast_1d(a).astype(a.dtype)
    
     policies = ['propagate', 'raise', 'omit']
 
@@ -244,24 +141,23 @@ def tmin(a, lowerlimit=None, axis=0, inclusive=True, nan_policy='propagate'):
         raise ValueError("nan_policy must be one of {%s}" %
                          ', '.join("'%s'" % s for s in policies))
 
+    lowerlimit=cp.atleast_1d( -cp.inf if lowerlimit is None else lowerlimit)
+    lowerlimit = lowerlimit.astype(cp.float16) if a.dtype==cp.float16 else lowerlimit
 
+    inf=cp.iinfo(a.dtype).max if cp.dtype(a.dtype).kind in 'iu' else cp.inf
     contains_nan = cp.isnan(cp.sum(a))
-    
     
     if contains_nan :
             if nan_policy != 'propagate':
                 if nan_policy == 'raise':
                     raise ValueError("The input contains nan values")
-                return _statistics._tmin(a,cp.atleast_1d( -cp.inf if lowerlimit is None else lowerlimit), inclusive, False, axis=axis)
-            return _statistics._tmin(a, cp.atleast_1d(-cp.inf if lowerlimit is None else lowerlimit), inclusive, True, axis=axis)
+                return _statistics._tmin(a.astype(cp.float64),lowerlimit,inclusive, False, inf,axis=axis).astype(a.dtype, copy=False)
+            return _statistics._tmin(a.astype(cp.float64), lowerlimit, inclusive, True, inf,axis=axis).astype(a.dtype, copy=False)
     else:
-        if lowerlimit is None:
+       
+        if lowerlimit==-cp.inf:
             return cp.amin(a, axis=axis)
-        max_element= cp.max(a)
-        if max_element>lowerlimit or (max_element==lowerlimit and inclusive):
-            return _statistics._tmin(a, cp.atleast_1d(lowerlimit), inclusive, False, axis=axis)
+        max_element= cp.max(a,keepdims=True)
+        if max_element>lowerlimit or (cp.allclose(max_element,lowerlimit) and inclusive):
+            return _statistics._tmin(a.astype(cp.float64), lowerlimit, inclusive, False,inf, axis=axis).astype(a.dtype, copy=False)
         raise ValueError("No array values within given limits")
-            
-            # if cp.all(solution==cp.iinfo(solution.dtype).max):
-            #     raise ValueError("No array values within given limits")
-            

--- a/cupyx/scipy/stats/_stats.py
+++ b/cupyx/scipy/stats/_stats.py
@@ -134,30 +134,38 @@ def tmin(a, lowerlimit=None, axis=0, inclusive=True, nan_policy='propagate'):
         axis = 0
     if a.ndim == 0:
         a = cp.atleast_1d(a).astype(a.dtype)
-   
+
     policies = ['propagate', 'raise', 'omit']
 
     if nan_policy not in policies:
         raise ValueError("nan_policy must be one of {%s}" %
                          ', '.join("'%s'" % s for s in policies))
 
-    lowerlimit=cp.atleast_1d( -cp.inf if lowerlimit is None else lowerlimit)
-    lowerlimit = lowerlimit.astype(cp.float16) if a.dtype==cp.float16 else lowerlimit
+    lowerlimit = cp.atleast_1d(-cp.inf if lowerlimit is None else lowerlimit)
+    lowerlimit = lowerlimit.astype(
+        cp.float16) if a.dtype == cp.float16 else lowerlimit
 
-    inf=cp.iinfo(a.dtype).max if cp.dtype(a.dtype).kind in 'iu' else cp.inf
+    inf = cp.iinfo(a.dtype).max if cp.dtype(a.dtype).kind in 'iu' else cp.inf
     contains_nan = cp.isnan(cp.sum(a))
-    
-    if contains_nan :
-            if nan_policy != 'propagate':
-                if nan_policy == 'raise':
-                    raise ValueError("The input contains nan values")
-                return _statistics._tmin(a.astype(cp.float64),lowerlimit,inclusive, False, inf,axis=axis).astype(a.dtype, copy=False)
-            return _statistics._tmin(a.astype(cp.float64), lowerlimit, inclusive, True, inf,axis=axis).astype(a.dtype, copy=False)
+
+    if contains_nan:
+        if nan_policy != 'propagate':
+            if nan_policy == 'raise':
+                raise ValueError("The input contains nan values")
+            return _statistics._tmin(a.astype(cp.float64), lowerlimit,
+                                     inclusive, False, inf, axis=axis)\
+                .astype(a.dtype, copy=False)
+        return _statistics._tmin(a.astype(cp.float64), lowerlimit,
+                                 inclusive, True, inf, axis=axis)\
+            .astype(a.dtype, copy=False)
     else:
-       
-        if lowerlimit==-cp.inf:
+
+        if lowerlimit == -cp.inf:
             return cp.amin(a, axis=axis)
-        max_element= cp.max(a,keepdims=True)
-        if max_element>lowerlimit or (cp.allclose(max_element,lowerlimit) and inclusive):
-            return _statistics._tmin(a.astype(cp.float64), lowerlimit, inclusive, False,inf, axis=axis).astype(a.dtype, copy=False)
+        max_element = cp.max(a, keepdims=True)
+        if max_element > lowerlimit or (cp.allclose(max_element, lowerlimit)
+                                        and inclusive):
+            return _statistics._tmin(a.astype(cp.float64), lowerlimit,
+                                     inclusive, False, inf, axis=axis)\
+                .astype(a.dtype, copy=False)
         raise ValueError("No array values within given limits")

--- a/docs/source/reference/scipy_stats.rst
+++ b/docs/source/reference/scipy_stats.rst
@@ -14,6 +14,7 @@ Summary statistics
 
    trim_mean
    entropy
+   tmin
 
 
 Other statistical functionality

--- a/tests/cupyx_tests/scipy_tests/stats_tests/test_stats.py
+++ b/tests/cupyx_tests/scipy_tests/stats_tests/test_stats.py
@@ -242,3 +242,72 @@ class TestZscore:
             x = xp.array([1, 2, 3, xp.nan], dtype=dtype)
             with pytest.raises(ValueError):
                 scp.stats.zscore(x, nan_policy='raise')
+
+
+
+@testing.with_requires('scipy')
+class TestTmin:
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=rtol)
+    def test_tmin_1dim(self, xp, scp, dtype):
+        x = testing.shaped_random((10,), xp, dtype=dtype)
+        print(x)
+        return scp.stats.tmin(x,3.2)
+
+   
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=rtol)
+    def test_tmin_2dim(self, xp, scp, dtype):
+        x = testing.shaped_random((5, 3), xp, dtype=dtype)
+        return scp.stats.tmin(x,3)
+
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=rtol)
+    def test_tmin_multi_dim(self, xp, scp, dtype):
+        x = testing.shaped_random((3, 4, 5, 7), xp, dtype=dtype)
+        return scp.stats.tmin(x,12)
+
+    @testing.for_all_dtypes(no_bool=True)
+    @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=atol)
+    def test_tmin_with_axis(self, xp, scp, dtype):
+        x = testing.shaped_random((5, 6), xp, dtype=dtype)
+        return scp.stats.tmin(x,2, axis=1)
+    
+    @testing.for_all_dtypes(no_bool=True)
+    @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=atol)
+    def test_tmin_with_axis_none(self, xp, scp, dtype):
+        x = testing.shaped_random((5, 6), xp, dtype=dtype)
+        return scp.stats.tmin(x,3,axis=None)
+
+    @testing.for_all_dtypes(no_bool=True)
+    @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=atol)
+    def test_tmin_with_lowerlimit_none(self, xp, scp, dtype):
+        x = testing.shaped_random((5, 6), xp, dtype=dtype)
+        return scp.stats.tmin(x,lowerlimit=None)
+
+    @testing.for_all_dtypes(no_bool=True)
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_tmin_empty(self, xp, scp, dtype):
+        x = xp.array([], dtype=dtype)
+        with pytest.raises(ValueError):
+            return scp.stats.tmin(x,2)
+    
+    @testing.for_all_dtypes(no_bool=True)
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_tmin_without_inclusive(self, xp, scp, dtype):
+        x = xp.array([[5,4.8,3,2],[10,8,7,22]], dtype=dtype)
+        return scp.stats.tmin(x,5,inclusive=False)
+
+    def test_tmin_nan_policy_raise(self, dtype):
+        for xp, scp in [(numpy, scipy), (cupy, cupyx.scipy)]:
+            x = xp.array([1, 2, 3, xp.nan], dtype=dtype)
+            with pytest.raises(ValueError):
+                scp.stats.tmin(x, nan_policy='raise')
+
+    def test_tmin_nan_policy_raise(self, dtype):
+        for xp, scp in [(numpy, scipy), (cupy, cupyx.scipy)]:
+            x = xp.array([1, 2, 3, 1.2], dtype=dtype)
+            with pytest.raises(ValueError):
+                scp.stats.tmin(x, nan_policy='raise')

--- a/tests/cupyx_tests/scipy_tests/stats_tests/test_stats.py
+++ b/tests/cupyx_tests/scipy_tests/stats_tests/test_stats.py
@@ -246,83 +246,75 @@ class TestZscore:
 
 @testing.with_requires('scipy')
 class TestTmin:
-    
-    @testing.for_all_dtypes(no_complex=True, no_bool=True)
-    @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=rtol)
-    @pytest.mark.parametrize('limit', [3.2, 17, True, 100]) 
-    def test_tmin_1dim(self, xp, scp, dtype,limit):
-        x = testing.shaped_random((10,), xp, dtype=dtype)
-        x=xp.where(x<limit,limit,x).astype(dtype)
-        return scp.stats.tmin(x, limit)
-    
-    @testing.for_all_dtypes( no_complex=True, no_bool=True)
-    @pytest.mark.parametrize('limit', [3.2, 17, True, 100]) 
-    def test_tmin_1dim_ValueError(self, dtype,limit):
-        for xp, scp in [(numpy, scipy), (cupy, cupyx.scipy)]:
-            x = testing.shaped_random((10,), xp, dtype=dtype)
-            x=xp.where(x>=limit,limit-0.01,x).astype(dtype)
-            with pytest.raises(ValueError):
-                return scp.stats.tmin(x,limit)
 
     @testing.for_all_dtypes(no_complex=True, no_bool=True)
     @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=rtol)
-    @pytest.mark.parametrize('limit', [3.2, 17, True, 100]) 
-    def test_tmin_2dim(self, xp, scp, dtype,limit):
-        
-        x = testing.shaped_random((5, 3), xp, dtype=dtype)
-        x=xp.where(x<limit,limit,x).astype(dtype)
+    @pytest.mark.parametrize('limit', [3.2, 17, True, 100])
+    def test_tmin_1dim(self, xp, scp, dtype, limit):
+        x = testing.shaped_random((10,), xp, dtype=dtype)
+        x = xp.where(x < limit, limit, x).astype(dtype)
         return scp.stats.tmin(x, limit)
-       
-            
+
     @testing.for_all_dtypes(no_complex=True, no_bool=True)
-    @pytest.mark.parametrize('limit', [3.2, 17, True, 100])  
-    def test_tmin_2dim_ValueError(self, dtype,limit):
-        
+    @pytest.mark.parametrize('limit', [3.2, 17, True, 100])
+    def test_tmin_1dim_ValueError(self, dtype, limit):
         for xp, scp in [(numpy, scipy), (cupy, cupyx.scipy)]:
-            x = testing.shaped_random((5, 3), xp, dtype=dtype)
-            x=xp.where(x>=limit,limit-0.1,x).astype(dtype)
+            x = testing.shaped_random((10,), xp, dtype=dtype)
+            x = xp.where(x >= limit, limit-0.01, x).astype(dtype)
             with pytest.raises(ValueError):
                 return scp.stats.tmin(x, limit)
 
+    @testing.for_all_dtypes(no_complex=True, no_bool=True)
+    @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=rtol)
+    @pytest.mark.parametrize('limit', [3.2, 17, True, 100])
+    def test_tmin_2dim(self, xp, scp, dtype, limit):
+
+        x = testing.shaped_random((5, 3), xp, dtype=dtype)
+        x = xp.where(x < limit, limit, x).astype(dtype)
+        return scp.stats.tmin(x, limit)
+
+    @testing.for_all_dtypes(no_complex=True, no_bool=True)
+    @pytest.mark.parametrize('limit', [3.2, 17, True, 100])
+    def test_tmin_2dim_ValueError(self, dtype, limit):
+
+        for xp, scp in [(numpy, scipy), (cupy, cupyx.scipy)]:
+            x = testing.shaped_random((5, 3), xp, dtype=dtype)
+            x = xp.where(x >= limit, limit-0.1, x).astype(dtype)
+            with pytest.raises(ValueError):
+                return scp.stats.tmin(x, limit)
 
     @testing.for_all_dtypes(no_complex=True, no_bool=True)
     @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=rtol)
-    @pytest.mark.parametrize('limit', [3.2, 17, True, 100])    
-    def test_tmin_multi_dim(self, xp, scp, dtype,limit):
-        x = testing.shaped_random((3, 4,5, 2), xp, dtype=dtype)
-        x=xp.where(x<limit,limit,x).astype(dtype)
+    @pytest.mark.parametrize('limit', [3.2, 17, True, 100])
+    def test_tmin_multi_dim(self, xp, scp, dtype, limit):
+        x = testing.shaped_random((3, 4, 5, 2), xp, dtype=dtype)
+        x = xp.where(x < limit, limit, x).astype(dtype)
         return scp.stats.tmin(x, limit)
-            
-       
-    
-    @testing.for_all_dtypes(no_complex=True, no_bool=True) 
-    @pytest.mark.parametrize('limit', [3.2, 17, True, 100])       
-    def test_tmin_multi_dim_ValueError_exclusive(self, dtype,limit):
-        for xp, scp in [(numpy, scipy), (cupy, cupyx.scipy)]:
-            x = testing.shaped_random((3, 4,5, 2), xp, dtype=dtype)
-            x=xp.where(x>=limit,limit,x).astype(dtype)
-            with pytest.raises(ValueError):
-                return scp.stats.tmin(x, 124,inclusive=False)
 
+    @testing.for_all_dtypes(no_complex=True, no_bool=True)
+    @pytest.mark.parametrize('limit', [3.2, 17, True, 100])
+    def test_tmin_multi_dim_ValueError_exclusive(self, dtype, limit):
+        for xp, scp in [(numpy, scipy), (cupy, cupyx.scipy)]:
+            x = testing.shaped_random((3, 4, 5, 2), xp, dtype=dtype)
+            x = xp.where(x >= limit, limit, x).astype(dtype)
+            with pytest.raises(ValueError):
+                return scp.stats.tmin(x, 124, inclusive=False)
 
     @testing.for_all_dtypes(no_bool=True, no_complex=True)
     @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=atol)
     @pytest.mark.parametrize('axis', [0, 1, 2, 3, -1, None])
-    def test_tmin_with_axis(self, xp, scp, dtype,axis):
+    def test_tmin_with_axis(self, xp, scp, dtype, axis):
         if xp.dtype(dtype).kind == 'u':
-                pytest.skip()
-        x = testing.shaped_random((5, 6,12,2), xp, dtype=dtype)
-        x=xp.where(x<54,54,x).astype(dtype)
-        return scp.stats.tmin(x, 54,axis=axis)
-    
- 
+            pytest.skip()
+        x = testing.shaped_random((5, 6, 12, 2), xp, dtype=dtype)
+        x = xp.where(x < 54, 54, x).astype(dtype)
+        return scp.stats.tmin(x, 54, axis=axis)
 
     @testing.for_all_dtypes(no_complex=True, no_bool=True)
     @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=atol)
     def test_tmin_with_lowerlimit_none(self, xp, scp, dtype):
         x = testing.shaped_random((5, 6), xp, dtype=dtype)
         return scp.stats.tmin(x)
-       
 
     @testing.for_all_dtypes()
     def test_tmin_empty(self, dtype):
@@ -332,112 +324,106 @@ class TestTmin:
                 return scp.stats.tmin(x, 2)
 
     @testing.for_all_dtypes(no_complex=True, no_bool=True)
-    @pytest.mark.parametrize('limit', [22,25.5])
-    def test_tmin_without_inclusive(self, dtype,limit):
+    @pytest.mark.parametrize('limit', [22, 25.5])
+    def test_tmin_without_inclusive(self, dtype, limit):
         for xp, scp in [(numpy, scipy), (cupy, cupyx.scipy)]:
             x = xp.array([[5, 4.8, 3, 2], [10, 8, 7, 22]], dtype=dtype)
             with pytest.raises(ValueError):
-                    return scp.stats.tmin(x,limit, inclusive=False)
-        
-            
+                return scp.stats.tmin(x, limit, inclusive=False)
+
     @testing.for_float_dtypes()
     def test_tmin_nan_policy_raise(self, dtype):
         for xp, scp in [(numpy, scipy), (cupy, cupyx.scipy)]:
             x = xp.array([1, 2, 3, xp.nan], dtype=dtype)
             with pytest.raises(ValueError):
                 scp.stats.tmin(x, nan_policy='raise')
-                
 
     @testing.for_all_dtypes(no_complex=True, no_bool=True)
     def test_tmin_nan_policy_raise_2(self, dtype):
         for xp, scp in [(numpy, scipy), (cupy, cupyx.scipy)]:
             x = xp.array([1, 2, 3, 1.2], dtype=dtype)
             with pytest.raises(ValueError):
-                return scp.stats.tmin(x, 3.2,nan_policy='raise')
+                return scp.stats.tmin(x, 3.2, nan_policy='raise')
 
     @testing.for_all_dtypes(no_complex=True, no_bool=True)
     @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=atol)
-    def test_tmin_nan_policy_raise_3(self,xp, scp, dtype):
-            x = xp.array([1, 2, 3, 1.2], dtype=dtype)
-            return scp.stats.tmin(x, 2,nan_policy='raise')
-    
+    def test_tmin_nan_policy_raise_3(self, xp, scp, dtype):
+        x = xp.array([1, 2, 3, 1.2], dtype=dtype)
+        return scp.stats.tmin(x, 2, nan_policy='raise')
+
     @testing.for_float_dtypes()
     @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=atol)
-    def test_tmin_nan_policy_omit_1(self,xp,scp,dtype):
-            x = xp.array([1.4, 2.1, 3, xp.nan], dtype=dtype)
-            return scp.stats.tmin(x, 1.4,nan_policy='omit')
+    def test_tmin_nan_policy_omit_1(self, xp, scp, dtype):
+        x = xp.array([1.4, 2.1, 3, xp.nan], dtype=dtype)
+        return scp.stats.tmin(x, 1.4, nan_policy='omit')
 
     @testing.for_all_dtypes(no_complex=True, no_bool=True)
     def test_tmin_nan_policy_omit_2(self, dtype):
         for xp, scp in [(numpy, scipy), (cupy, cupyx.scipy)]:
             x = xp.array([1, 2, 3, 1.2], dtype=dtype)
             with pytest.raises(ValueError):
-                return scp.stats.tmin(x, 3.2,nan_policy='omit')
-    
+                return scp.stats.tmin(x, 3.2, nan_policy='omit')
+
     @testing.for_all_dtypes(no_complex=True, no_bool=True)
     @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=rtol)
     @pytest.mark.parametrize('limit', [102.778, 17, True, 100])
-    def test_tmin_nan_policy_omit_3(self, xp, scp, dtype,limit):
-            x = testing.shaped_random((5, 3), xp, dtype=dtype)
-            x=xp.where(x<limit,limit,x).astype(dtype)
-            return scp.stats.tmin(x, dtype(limit),nan_policy='omit')
-    
-    @testing.for_all_dtypes(no_complex=True, no_bool=True)
-    @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=rtol)
-    def test_tmin_nan_inf_1(self,xp,scp, dtype):
-                x = xp.array([-xp.inf, xp.nan, xp.inf])
-                x = xp.tile(x, (3, 3))
-                return scp.stats.tmin(x,xp.inf)
+    def test_tmin_nan_policy_omit_3(self, xp, scp, dtype, limit):
+        x = testing.shaped_random((5, 3), xp, dtype=dtype)
+        x = xp.where(x < limit, limit, x).astype(dtype)
+        return scp.stats.tmin(x, dtype(limit), nan_policy='omit')
 
     @testing.for_all_dtypes(no_complex=True, no_bool=True)
     @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=rtol)
-    @pytest.mark.parametrize('limit', [3.2, 17, True, 100,None])
-    def test_tmin_nan_inf_2(self, xp, scp, dtype,limit):
-
-            x = xp.array([-xp.inf, xp.nan, xp.inf])
-            x = xp.tile(x, (3, 3))
-            return scp.stats.tmin(x,limit)
+    def test_tmin_nan_inf_1(self, xp, scp, dtype):
+        x = xp.array([-xp.inf, xp.nan, xp.inf])
+        x = xp.tile(x, (3, 3))
+        return scp.stats.tmin(x, xp.inf)
 
     @testing.for_all_dtypes(no_complex=True, no_bool=True)
     @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=rtol)
-    @pytest.mark.parametrize('limit', [3.2, 17, True, 100,None])
-    def test_tmin_nan_inf_omit(self,xp,scp, dtype,limit):
-                x = xp.array([-xp.inf, xp.nan, xp.inf])
-                x = xp.tile(x, (3, 3))
-                return scp.stats.tmin(x,limit,nan_policy='omit')
-        
+    @pytest.mark.parametrize('limit', [3.2, 17, True, 100, None])
+    def test_tmin_nan_inf_2(self, xp, scp, dtype, limit):
+
+        x = xp.array([-xp.inf, xp.nan, xp.inf])
+        x = xp.tile(x, (3, 3))
+        return scp.stats.tmin(x, limit)
+
     @testing.for_all_dtypes(no_complex=True, no_bool=True)
-    @pytest.mark.parametrize('limit', [3.2, 17, True, 100,None])
-    def test_tmin_nan_inf_raise(self, dtype,limit):
+    @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=rtol)
+    @pytest.mark.parametrize('limit', [3.2, 17, True, 100, None])
+    def test_tmin_nan_inf_omit(self, xp, scp, dtype, limit):
+        x = xp.array([-xp.inf, xp.nan, xp.inf])
+        x = xp.tile(x, (3, 3))
+        return scp.stats.tmin(x, limit, nan_policy='omit')
+
+    @testing.for_all_dtypes(no_complex=True, no_bool=True)
+    @pytest.mark.parametrize('limit', [3.2, 17, True, 100, None])
+    def test_tmin_nan_inf_raise(self, dtype, limit):
         for xp, scp in [(numpy, scipy), (cupy, cupyx.scipy)]:
             x = xp.array([-xp.inf, xp.nan, xp.inf])
             x = xp.tile(x, (3, 3))
             with pytest.raises(ValueError):
-                return scp.stats.tmin(x,limit,nan_policy='raise')
+                return scp.stats.tmin(x, limit, nan_policy='raise')
 
     @testing.for_dtypes('b')
-    @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=rtol)     
-    @pytest.mark.parametrize('limit', [0, 1, True, False,None])
-    def test_tmin_bool(self,xp,scp,dtype,limit):
-        x=xp.array([True,False,True]).astype(dtype)
-        return scp.stats.tmin(x,limit)
+    @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=rtol)
+    @pytest.mark.parametrize('limit', [0, 1, True, False, None])
+    def test_tmin_bool(self, xp, scp, dtype, limit):
+        x = xp.array([True, False, True]).astype(dtype)
+        return scp.stats.tmin(x, limit)
 
     @testing.for_dtypes('b')
-    @pytest.mark.parametrize('limit', [2,100,172.20])
-    def test_tmin_bool_2(self,dtype,limit):
+    @pytest.mark.parametrize('limit', [2, 100, 172.20])
+    def test_tmin_bool_2(self, dtype, limit):
         for xp, scp in [(numpy, scipy), (cupy, cupyx.scipy)]:
-            x=xp.array([True,False,True]).astype(dtype)
+            x = xp.array([True, False, True]).astype(dtype)
             with pytest.raises(ValueError):
-                return scp.stats.tmin(x,limit)
-            
+                return scp.stats.tmin(x, limit)
 
     @testing.for_dtypes('b')
     @pytest.mark.parametrize('limit', [1, True])
-    def test_tmin_bool_exclusive(self,dtype,limit):
+    def test_tmin_bool_exclusive(self, dtype, limit):
         for xp, scp in [(numpy, scipy), (cupy, cupyx.scipy)]:
-            x=xp.array([True,False,True]).astype(dtype)
+            x = xp.array([True, False, True]).astype(dtype)
             with pytest.raises(ValueError):
-                return scp.stats.tmin(x,limit,inclusive=False)
-
-    
-   
+                return scp.stats.tmin(x, limit, inclusive=False)

--- a/tests/cupyx_tests/scipy_tests/stats_tests/test_stats.py
+++ b/tests/cupyx_tests/scipy_tests/stats_tests/test_stats.py
@@ -244,70 +244,200 @@ class TestZscore:
                 scp.stats.zscore(x, nan_policy='raise')
 
 
-
 @testing.with_requires('scipy')
 class TestTmin:
-
-    @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=rtol)
-    def test_tmin_1dim(self, xp, scp, dtype):
-        x = testing.shaped_random((10,), xp, dtype=dtype)
-        print(x)
-        return scp.stats.tmin(x,3.2)
-
-   
-    @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=rtol)
-    def test_tmin_2dim(self, xp, scp, dtype):
-        x = testing.shaped_random((5, 3), xp, dtype=dtype)
-        return scp.stats.tmin(x,3)
-
-
-    @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=rtol)
-    def test_tmin_multi_dim(self, xp, scp, dtype):
-        x = testing.shaped_random((3, 4, 5, 7), xp, dtype=dtype)
-        return scp.stats.tmin(x,12)
-
-    @testing.for_all_dtypes(no_bool=True)
-    @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=atol)
-    def test_tmin_with_axis(self, xp, scp, dtype):
-        x = testing.shaped_random((5, 6), xp, dtype=dtype)
-        return scp.stats.tmin(x,2, axis=1)
     
-    @testing.for_all_dtypes(no_bool=True)
-    @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=atol)
-    def test_tmin_with_axis_none(self, xp, scp, dtype):
-        x = testing.shaped_random((5, 6), xp, dtype=dtype)
-        return scp.stats.tmin(x,3,axis=None)
+    @testing.for_all_dtypes(no_complex=True, no_bool=True)
+    @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=rtol)
+    @pytest.mark.parametrize('limit', [3.2, 17, True, 100]) 
+    def test_tmin_1dim(self, xp, scp, dtype,limit):
+        x = testing.shaped_random((10,), xp, dtype=dtype)
+        x=xp.where(x<limit,limit,x).astype(dtype)
+        return scp.stats.tmin(x, limit)
+    
+    @testing.for_all_dtypes( no_complex=True, no_bool=True)
+    @pytest.mark.parametrize('limit', [3.2, 17, True, 100]) 
+    def test_tmin_1dim_ValueError(self, dtype,limit):
+        for xp, scp in [(numpy, scipy), (cupy, cupyx.scipy)]:
+            x = testing.shaped_random((10,), xp, dtype=dtype)
+            x=xp.where(x>=limit,limit-0.01,x).astype(dtype)
+            with pytest.raises(ValueError):
+                return scp.stats.tmin(x,limit)
 
-    @testing.for_all_dtypes(no_bool=True)
+    @testing.for_all_dtypes(no_complex=True, no_bool=True)
+    @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=rtol)
+    @pytest.mark.parametrize('limit', [3.2, 17, True, 100]) 
+    def test_tmin_2dim(self, xp, scp, dtype,limit):
+        
+        x = testing.shaped_random((5, 3), xp, dtype=dtype)
+        x=xp.where(x<limit,limit,x).astype(dtype)
+        return scp.stats.tmin(x, limit)
+       
+            
+    @testing.for_all_dtypes(no_complex=True, no_bool=True)
+    @pytest.mark.parametrize('limit', [3.2, 17, True, 100])  
+    def test_tmin_2dim_ValueError(self, dtype,limit):
+        
+        for xp, scp in [(numpy, scipy), (cupy, cupyx.scipy)]:
+            x = testing.shaped_random((5, 3), xp, dtype=dtype)
+            x=xp.where(x>=limit,limit-0.1,x).astype(dtype)
+            with pytest.raises(ValueError):
+                return scp.stats.tmin(x, limit)
+
+
+    @testing.for_all_dtypes(no_complex=True, no_bool=True)
+    @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=rtol)
+    @pytest.mark.parametrize('limit', [3.2, 17, True, 100])    
+    def test_tmin_multi_dim(self, xp, scp, dtype,limit):
+        x = testing.shaped_random((3, 4,5, 2), xp, dtype=dtype)
+        x=xp.where(x<limit,limit,x).astype(dtype)
+        return scp.stats.tmin(x, limit)
+            
+       
+    
+    @testing.for_all_dtypes(no_complex=True, no_bool=True) 
+    @pytest.mark.parametrize('limit', [3.2, 17, True, 100])       
+    def test_tmin_multi_dim_ValueError_exclusive(self, dtype,limit):
+        for xp, scp in [(numpy, scipy), (cupy, cupyx.scipy)]:
+            x = testing.shaped_random((3, 4,5, 2), xp, dtype=dtype)
+            x=xp.where(x>=limit,limit,x).astype(dtype)
+            with pytest.raises(ValueError):
+                return scp.stats.tmin(x, 124,inclusive=False)
+
+
+    @testing.for_all_dtypes(no_bool=True, no_complex=True)
+    @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=atol)
+    @pytest.mark.parametrize('axis', [0, 1, 2, 3, -1, None])
+    def test_tmin_with_axis(self, xp, scp, dtype,axis):
+        if xp.dtype(dtype).kind == 'u':
+                pytest.skip()
+        x = testing.shaped_random((5, 6,12,2), xp, dtype=dtype)
+        x=xp.where(x<54,54,x).astype(dtype)
+        return scp.stats.tmin(x, 54,axis=axis)
+    
+ 
+
+    @testing.for_all_dtypes(no_complex=True, no_bool=True)
     @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=atol)
     def test_tmin_with_lowerlimit_none(self, xp, scp, dtype):
         x = testing.shaped_random((5, 6), xp, dtype=dtype)
-        return scp.stats.tmin(x,lowerlimit=None)
+        return scp.stats.tmin(x)
+       
 
-    @testing.for_all_dtypes(no_bool=True)
-    @testing.numpy_cupy_allclose(scipy_name='scp')
-    def test_tmin_empty(self, xp, scp, dtype):
-        x = xp.array([], dtype=dtype)
-        with pytest.raises(ValueError):
-            return scp.stats.tmin(x,2)
-    
-    @testing.for_all_dtypes(no_bool=True)
-    @testing.numpy_cupy_allclose(scipy_name='scp')
-    def test_tmin_without_inclusive(self, xp, scp, dtype):
-        x = xp.array([[5,4.8,3,2],[10,8,7,22]], dtype=dtype)
-        return scp.stats.tmin(x,5,inclusive=False)
+    @testing.for_all_dtypes()
+    def test_tmin_empty(self, dtype):
+        for xp, scp in [(numpy, scipy), (cupy, cupyx.scipy)]:
+            x = xp.array([], dtype=dtype)
+            with pytest.raises(ValueError):
+                return scp.stats.tmin(x, 2)
 
+    @testing.for_all_dtypes(no_complex=True, no_bool=True)
+    @pytest.mark.parametrize('limit', [22,25.5])
+    def test_tmin_without_inclusive(self, dtype,limit):
+        for xp, scp in [(numpy, scipy), (cupy, cupyx.scipy)]:
+            x = xp.array([[5, 4.8, 3, 2], [10, 8, 7, 22]], dtype=dtype)
+            with pytest.raises(ValueError):
+                    return scp.stats.tmin(x,limit, inclusive=False)
+        
+            
+    @testing.for_float_dtypes()
     def test_tmin_nan_policy_raise(self, dtype):
         for xp, scp in [(numpy, scipy), (cupy, cupyx.scipy)]:
             x = xp.array([1, 2, 3, xp.nan], dtype=dtype)
             with pytest.raises(ValueError):
                 scp.stats.tmin(x, nan_policy='raise')
+                
 
-    def test_tmin_nan_policy_raise(self, dtype):
+    @testing.for_all_dtypes(no_complex=True, no_bool=True)
+    def test_tmin_nan_policy_raise_2(self, dtype):
         for xp, scp in [(numpy, scipy), (cupy, cupyx.scipy)]:
             x = xp.array([1, 2, 3, 1.2], dtype=dtype)
             with pytest.raises(ValueError):
-                scp.stats.tmin(x, nan_policy='raise')
+                return scp.stats.tmin(x, 3.2,nan_policy='raise')
+
+    @testing.for_all_dtypes(no_complex=True, no_bool=True)
+    @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=atol)
+    def test_tmin_nan_policy_raise_3(self,xp, scp, dtype):
+            x = xp.array([1, 2, 3, 1.2], dtype=dtype)
+            return scp.stats.tmin(x, 2,nan_policy='raise')
+    
+    @testing.for_float_dtypes()
+    @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=atol)
+    def test_tmin_nan_policy_omit_1(self,xp,scp,dtype):
+            x = xp.array([1.4, 2.1, 3, xp.nan], dtype=dtype)
+            return scp.stats.tmin(x, 1.4,nan_policy='omit')
+
+    @testing.for_all_dtypes(no_complex=True, no_bool=True)
+    def test_tmin_nan_policy_omit_2(self, dtype):
+        for xp, scp in [(numpy, scipy), (cupy, cupyx.scipy)]:
+            x = xp.array([1, 2, 3, 1.2], dtype=dtype)
+            with pytest.raises(ValueError):
+                return scp.stats.tmin(x, 3.2,nan_policy='omit')
+    
+    @testing.for_all_dtypes(no_complex=True, no_bool=True)
+    @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=rtol)
+    @pytest.mark.parametrize('limit', [102.778, 17, True, 100])
+    def test_tmin_nan_policy_omit_3(self, xp, scp, dtype,limit):
+            x = testing.shaped_random((5, 3), xp, dtype=dtype)
+            x=xp.where(x<limit,limit,x).astype(dtype)
+            return scp.stats.tmin(x, dtype(limit),nan_policy='omit')
+    
+    @testing.for_all_dtypes(no_complex=True, no_bool=True)
+    @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=rtol)
+    def test_tmin_nan_inf_1(self,xp,scp, dtype):
+                x = xp.array([-xp.inf, xp.nan, xp.inf])
+                x = xp.tile(x, (3, 3))
+                return scp.stats.tmin(x,xp.inf)
+
+    @testing.for_all_dtypes(no_complex=True, no_bool=True)
+    @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=rtol)
+    @pytest.mark.parametrize('limit', [3.2, 17, True, 100,None])
+    def test_tmin_nan_inf_2(self, xp, scp, dtype,limit):
+
+            x = xp.array([-xp.inf, xp.nan, xp.inf])
+            x = xp.tile(x, (3, 3))
+            return scp.stats.tmin(x,limit)
+
+    @testing.for_all_dtypes(no_complex=True, no_bool=True)
+    @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=rtol)
+    @pytest.mark.parametrize('limit', [3.2, 17, True, 100,None])
+    def test_tmin_nan_inf_omit(self,xp,scp, dtype,limit):
+                x = xp.array([-xp.inf, xp.nan, xp.inf])
+                x = xp.tile(x, (3, 3))
+                return scp.stats.tmin(x,limit,nan_policy='omit')
+        
+    @testing.for_all_dtypes(no_complex=True, no_bool=True)
+    @pytest.mark.parametrize('limit', [3.2, 17, True, 100,None])
+    def test_tmin_nan_inf_raise(self, dtype,limit):
+        for xp, scp in [(numpy, scipy), (cupy, cupyx.scipy)]:
+            x = xp.array([-xp.inf, xp.nan, xp.inf])
+            x = xp.tile(x, (3, 3))
+            with pytest.raises(ValueError):
+                return scp.stats.tmin(x,limit,nan_policy='raise')
+
+    @testing.for_dtypes('b')
+    @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=rtol)     
+    @pytest.mark.parametrize('limit', [0, 1, True, False,None])
+    def test_tmin_bool(self,xp,scp,dtype,limit):
+        x=xp.array([True,False,True]).astype(dtype)
+        return scp.stats.tmin(x,limit)
+
+    @testing.for_dtypes('b')
+    @pytest.mark.parametrize('limit', [2,100,172.20])
+    def test_tmin_bool_2(self,dtype,limit):
+        for xp, scp in [(numpy, scipy), (cupy, cupyx.scipy)]:
+            x=xp.array([True,False,True]).astype(dtype)
+            with pytest.raises(ValueError):
+                return scp.stats.tmin(x,limit)
+            
+
+    @testing.for_dtypes('b')
+    @pytest.mark.parametrize('limit', [1, True])
+    def test_tmin_bool_exclusive(self,dtype,limit):
+        for xp, scp in [(numpy, scipy), (cupy, cupyx.scipy)]:
+            x=xp.array([True,False,True]).astype(dtype)
+            with pytest.raises(ValueError):
+                return scp.stats.tmin(x,limit,inclusive=False)
+
+    
+   


### PR DESCRIPTION
This PR aims to add ` scipy.stats.tmin ` to cupy . 
Support for complex dtypes is still pending . 
Related Issue : #6324
Was hoping for some feedback on the implementation!

Here are the benchmarks for non-complex dtypes : -

size | dtype | SciPy | CuPy
-----|-------|-------|-----
1000 | float16 | 0.218 ms | 0.408 ms
1000 | float32 | 0.181 ms | 0.221 ms
1000 | float64 | 0.191 ms | 0.202 ms
1000 | int8 | 0.224 ms | 0.407 ms
1000 | int32 | 0.184 ms | 0.418 ms
1000 | int64 | 0.181 ms | 0.421 ms
1000 | uint8 | 0.184 ms | 0.429 ms
1000 | uint32 | 0.188 ms | 0.409 ms
1000 | uint64 | 0.181 ms | 0.572 ms
1000 | bool | 0.124 ms | 0.454 ms
100000 | float16 | 3.693 ms | 0.571 ms
100000 | float32 | 1.115 ms | 0.594 ms
100000 | float64 | 2.776 ms | 0.512 ms
100000 | int8 | 1.993 ms | 0.705 ms
100000 | int32 | 3.731 ms | 0.566 ms
100000 | int64 | 2.195 ms | 0.703 ms
100000 | uint8 | 2.172 ms | 0.565 ms
100000 | uint32 | 1.813 ms | 0.574 ms
100000 | uint64 | 1.287 ms | 0.544 ms
100000 | bool | 0.233 ms | 0.452 ms
1000000 | float16 | 46.155 ms | 2.047 ms
1000000 | float32 | 18.979 ms | 3.064 ms
1000000 | float64 | 22.321 ms | 3.067 ms
1000000 | int8 | 18.933 ms | 1.974 ms
1000000 | int32 | 10.438 ms | 1.976 ms
1000000 | int64 | 20.925 ms | 2.020 ms
1000000 | uint8 | 14.508 ms | 2.037 ms
1000000 | uint32 | 30.618 ms | 2.134 ms
1000000 | uint64 | 21.754 ms | 2.086 ms
1000000 | bool | 1.494 ms | 0.728 ms

<details>
<summary>Script</summary>

```
import cupy
import scipy
import numpy 
from random import randint,choice
from cupyx.profiler import benchmark
import cupyx.scipy.stats as csp


n_warmup = 1
n_repeat = 10
dtype_set_float = ('float16','float32', 'float64')
dtype_set_other = ('int8','int32', 'int64','uint8','uint32','uint64')
n_set = (1000, 100000, 1000000)


def get_time(pref):
    cpu_time = pref.cpu_times.mean()
    gpu_time = pref.gpu_times.mean()
    return max(cpu_time, gpu_time) * 1000  # ms


def time(a,b):
    cp_a = cupy.array(a)
    
    times = []
    perf = benchmark(scipy.stats.tmin, (a,b),
                     n_warmup=n_warmup, n_repeat=n_repeat)
    times.append(get_time(perf))
 
    perf = benchmark(csp.tmin, (cp_a,b),
                     n_warmup=n_warmup, n_repeat=n_repeat)
    times.append(get_time(perf))
    return times


print('size | dtype | SciPy | CuPy')
print('-----|-------|-------|-----')



for n in n_set:
    
    i=0
    j=0

    while i<len(dtype_set_float):
        a = numpy.random.random(size=n).astype(dtype_set_float[i])*50

        if choice([True, False]):
            a=numpy.insert(a,randint(0, len(a)-1),numpy.nan)

        b=randint(1,100)

        try:

            times = time(a,b)
            print('{} | {} | {:.3f} ms | {:.3f} ms'.format(n, dtype_set_float[i], times[0], times[1]))
            i+=1

        except:

            pass
    
    while j<len(dtype_set_other):

        max_val=numpy.iinfo(dtype_set_other[j]).max - 1

        if dtype_set_other[j]=='uint64':
            max_val=numpy.iinfo('int64').max - 1

        a=numpy.asarray(numpy.random.randint(max_val, size=n),dtype=dtype_set_other[j])
        
        b=randint(1,max_val//2)

        try:
            if choice([True, False]):
                a=numpy.insert(a,randint(0, len(a)-1),numpy.nan)

            times = time(a,b)
            print('{} | {} | {:.3f} ms | {:.3f} ms'.format(n, dtype_set_other[j], times[0], times[1]))
            j+=1
        except:
            pass
   
    x=numpy.random.choice(a=[False, True], size=(1,n), p=[0.5, 0.5]) 

    try:
            times = time(x,False)
            print('{} | {} | {:.3f} ms | {:.3f} ms'.format(n, 'bool', times[0], times[1]))
            i+=1
    except:
            pass 

```

</details>