### PR TITLE
ENH: scipy.signal: add detrend

### DIFF
--- a/cupyx/scipy/signal/__init__.py
+++ b/cupyx/scipy/signal/__init__.py
@@ -13,6 +13,7 @@ from cupyx.scipy.signal._signaltools import medfilt2d  # NOQA
 from cupyx.scipy.signal._signaltools import lfilter  # NOQA
 from cupyx.scipy.signal._signaltools import lfiltic  # NOQA
 from cupyx.scipy.signal._signaltools import lfilter_zi  # NOQA
+from cupyx.scipy.signal._signaltools import detrend  # NOQA
 
 from cupyx.scipy.signal._bsplines import sepfir2d  # NOQA
 

--- a/docs/source/reference/scipy_signal.rst
+++ b/docs/source/reference/scipy_signal.rst
@@ -35,7 +35,7 @@ Filtering
    symiirorder2
    savgol_filter
    deconvolve
-
+   detrend
 
 Filter design
 -------------

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
@@ -564,6 +564,7 @@ class TestDeconvolve:
         return scp.signal.deconvolve(o, b)
 
 
+@testing.with_requires('scipy')
 class TestDetrend:
 
     def test_basic(self):

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
@@ -568,7 +568,6 @@ class TestDetrend:
 
     def test_basic(self):
         detrend = cupyx.scipy.signal.detrend
-
         detrended = detrend(cupy.array([1, 2, 3]))
         detrended_exact = cupy.array([0, 0, 0])
         testing.assert_array_almost_equal(detrended, detrended_exact)
@@ -583,12 +582,13 @@ class TestDetrend:
 
     @pytest.mark.parametrize('kind', ['linear', 'constant'])
     @pytest.mark.parametrize('axis', [0, 1, 2])
-    def test_axis(self, axis, kind):
-        detrend = cupyx.scipy.signal.detrend
-
-        data = cupy.arange(5*6*7).reshape(5, 6, 7)
+    @testing.numpy_cupy_allclose(scipy_name='scp', atol=4e-13)
+    def test_axis(self, axis, kind, xp, scp):
+        detrend = scp.signal.detrend
+        data = xp.arange(5*6*7).reshape(5, 6, 7)
         detrended = detrend(data, type=kind, axis=axis)
         assert detrended.shape == data.shape
+        return detrended
 
     def test_bp(self):
         data = [0, 1, 2] + [5, 0, -5, -10]


### PR DESCRIPTION
Add `cupux.scipy.signal.detrend`. This is fairly trivial subtraction of a linear LSQ fit from the input, real work is done in `lstsq`, so the rest can stay in pure python. 

Tests are mirroring those in scipy.signal, the corresponding scipy PR is https://github.com/scipy/scipy/pull/18383

cross-ref https://github.com/cupy/cupy/issues/7403