### PR TITLE
Fix cudart errors raised by texture APIs swallowed by Cython 

### DIFF
--- a/cupy/cuda/texture.pyx
+++ b/cupy/cuda/texture.pyx
@@ -57,8 +57,9 @@ cdef class ChannelFormatDescriptor:
         desc.f = <ChannelFormatKind>f
 
     def __dealloc__(self):
-        PyMem_Free(<ChannelFormatDesc*>self.ptr)
-        self.ptr = 0
+        if self.ptr != 0:
+            PyMem_Free(<ChannelFormatDesc*>self.ptr)
+            self.ptr = 0
 
     def get_channel_format(self):
         '''Returns a dict containing the input.'''
@@ -143,8 +144,9 @@ cdef class ResourceDescriptor:
         self.arr = arr
 
     def __dealloc__(self):
-        PyMem_Free(<ResourceDesc*>self.ptr)
-        self.ptr = 0
+        if self.ptr != 0:
+            PyMem_Free(<ResourceDesc*>self.ptr)
+            self.ptr = 0
 
     def get_resource_desc(self):
         '''Returns a dict containing the input.'''
@@ -230,8 +232,9 @@ cdef class TextureDescriptor:
         # TODO(leofang): support mipmap?
 
     def __dealloc__(self):
-        PyMem_Free(<TextureDesc*>self.ptr)
-        self.ptr = 0
+        if self.ptr != 0:
+            PyMem_Free(<TextureDesc*>self.ptr)
+            self.ptr = 0
 
     def get_texture_desc(self):
         '''Returns a dict containing the input.'''
@@ -305,8 +308,9 @@ cdef class CUDAarray:
         self.ndim = 3 if depth > 0 else 2 if height > 0 else 1
 
     def __dealloc__(self):
-        runtime.freeArray(self.ptr)
-        self.ptr = 0
+        if self.ptr != 0:
+            runtime.freeArray(self.ptr)
+            self.ptr = 0
 
     cdef int _get_memory_kind(self, src, dst):
         cdef int kind
@@ -530,8 +534,9 @@ cdef class TextureObject:
         self.TexDesc = TexDesc
 
     def __dealloc__(self):
-        runtime.destroyTextureObject(self.ptr)
-        self.ptr = 0
+        if self.ptr != 0:
+            runtime.destroyTextureObject(self.ptr)
+            self.ptr = 0
 
 
 cdef class SurfaceObject:
@@ -552,5 +557,6 @@ cdef class SurfaceObject:
         self.ResDesc = ResDesc
 
     def __dealloc__(self):
-        runtime.destroySurfaceObject(self.ptr)
-        self.ptr = 0
+        if self.ptr != 0:
+            runtime.destroySurfaceObject(self.ptr)
+            self.ptr = 0

--- a/cupy_backends/cuda/api/runtime.pxd
+++ b/cupy_backends/cuda/api/runtime.pxd
@@ -294,16 +294,18 @@ cdef _ensure_context()
 # Texture
 ##############################################################################
 
-cpdef uintmax_t createTextureObject(intptr_t ResDesc, intptr_t TexDesc)
+cpdef uintmax_t createTextureObject(
+    intptr_t ResDesc, intptr_t TexDesc) except? 0
 cpdef destroyTextureObject(uintmax_t texObject)
-cdef ChannelFormatDesc getChannelDesc(intptr_t array)
-cdef ResourceDesc getTextureObjectResourceDesc(uintmax_t texobj)
-cdef TextureDesc getTextureObjectTextureDesc(uintmax_t texobj)
-cdef Extent make_Extent(size_t w, size_t h, size_t d)
-cdef Pos make_Pos(size_t x, size_t y, size_t z)
-cdef PitchedPtr make_PitchedPtr(intptr_t d, size_t p, size_t xsz, size_t ysz)
+cdef ChannelFormatDesc getChannelDesc(intptr_t array) except*
+cdef ResourceDesc getTextureObjectResourceDesc(uintmax_t texobj) except*
+cdef TextureDesc getTextureObjectTextureDesc(uintmax_t texobj) except*
+cdef Extent make_Extent(size_t w, size_t h, size_t d) except*
+cdef Pos make_Pos(size_t x, size_t y, size_t z) except*
+cdef PitchedPtr make_PitchedPtr(
+    intptr_t d, size_t p, size_t xsz, size_t ysz) except*
 
-cpdef uintmax_t createSurfaceObject(intptr_t ResDesc)
+cpdef uintmax_t createSurfaceObject(intptr_t ResDesc) except? 0
 cpdef destroySurfaceObject(uintmax_t surfObject)
 # TODO(leofang): add cudaGetSurfaceObjectResourceDesc
 

--- a/cupy_backends/cuda/api/runtime.pyx
+++ b/cupy_backends/cuda/api/runtime.pyx
@@ -999,7 +999,8 @@ cdef _ensure_context():
 # Texture
 ##############################################################################
 
-cpdef uintmax_t createTextureObject(intptr_t ResDescPtr, intptr_t TexDescPtr):
+cpdef uintmax_t createTextureObject(
+        intptr_t ResDescPtr, intptr_t TexDescPtr) except? 0:
     cdef uintmax_t texobj = 0
     with nogil:
         status = cudaCreateTextureObject(<TextureObject*>(&texobj),
@@ -1014,7 +1015,7 @@ cpdef destroyTextureObject(uintmax_t texObject):
         status = cudaDestroyTextureObject(<TextureObject>texObject)
     check_status(status)
 
-cpdef uintmax_t createSurfaceObject(intptr_t ResDescPtr):
+cpdef uintmax_t createSurfaceObject(intptr_t ResDescPtr) except? 0:
     cdef uintmax_t surfobj = 0
     with nogil:
         status = cudaCreateSurfaceObject(<SurfaceObject*>(&surfobj),
@@ -1027,34 +1028,35 @@ cpdef destroySurfaceObject(uintmax_t surfObject):
         status = cudaDestroySurfaceObject(<SurfaceObject>surfObject)
     check_status(status)
 
-cdef ChannelFormatDesc getChannelDesc(intptr_t array):
+cdef ChannelFormatDesc getChannelDesc(intptr_t array) except*:
     cdef ChannelFormatDesc desc
     with nogil:
         status = cudaGetChannelDesc(&desc, <Array>array)
     check_status(status)
     return desc
 
-cdef ResourceDesc getTextureObjectResourceDesc(uintmax_t obj):
+cdef ResourceDesc getTextureObjectResourceDesc(uintmax_t obj) except*:
     cdef ResourceDesc desc
     with nogil:
         status = cudaGetTextureObjectResourceDesc(&desc, <TextureObject>obj)
     check_status(status)
     return desc
 
-cdef TextureDesc getTextureObjectTextureDesc(uintmax_t obj):
+cdef TextureDesc getTextureObjectTextureDesc(uintmax_t obj) except*:
     cdef TextureDesc desc
     with nogil:
         status = cudaGetTextureObjectTextureDesc(&desc, <TextureObject>obj)
     check_status(status)
     return desc
 
-cdef Extent make_Extent(size_t w, size_t h, size_t d):
+cdef Extent make_Extent(size_t w, size_t h, size_t d) except*:
     return make_cudaExtent(w, h, d)
 
-cdef Pos make_Pos(size_t x, size_t y, size_t z):
+cdef Pos make_Pos(size_t x, size_t y, size_t z) except*:
     return make_cudaPos(x, y, z)
 
-cdef PitchedPtr make_PitchedPtr(intptr_t d, size_t p, size_t xsz, size_t ysz):
+cdef PitchedPtr make_PitchedPtr(
+        intptr_t d, size_t p, size_t xsz, size_t ysz) except*:
     return make_cudaPitchedPtr(<void*>d, p, xsz, ysz)
 
 


### PR DESCRIPTION
Close #7533.

I belive commit ec99a210875f3af3c383d78a8fbd810500cac4ab is the real fix; commit 6db0ea9373402bbcfe30d7d36b4fe2a119ec44da is just nice-to-have (if any error happens, `ptr` remains 0 and `free(0)` should be a no-op).

Unfortunately, none of the reproducers offered by @kalvdans in #7533 would trigger the error, so I did not add any test. But I believe the change should work. 