### PR TITLE
cupyx.scipy.signal: add CZT and ZoomFFT

### DIFF
--- a/cupyx/scipy/signal/__init__.py
+++ b/cupyx/scipy/signal/__init__.py
@@ -42,3 +42,5 @@ from cupyx.scipy.signal._iir_filter_conversions import buttap  # NOQA
 from cupyx.scipy.signal._iir_filter_conversions import cheb1ap  # NOQA
 from cupyx.scipy.signal._iir_filter_conversions import cheb2ap  # NOQA
 from cupyx.scipy.signal._iir_filter_conversions import ellipap  # NOQA
+
+from cupyx.scipy.signal._czt import *   # NOQA

--- a/cupyx/scipy/signal/_czt.py
+++ b/cupyx/scipy/signal/_czt.py
@@ -1,0 +1,449 @@
+# This program is public domain
+# Authors: Paul Kienzle, Nadav Horesh
+#
+# Adapted from scipy 1.10.1.
+#
+"""
+Chirp z-transform.
+
+We provide two interfaces to the chirp z-transform: an object interface
+which precalculates part of the transform and can be applied efficiently
+to many different data sets, and a functional interface which is applied
+only to the given data set.
+
+Transforms
+----------
+
+CZT : callable (x, axis=-1) -> array
+   Define a chirp z-transform that can be applied to different signals.
+ZoomFFT : callable (x, axis=-1) -> array
+   Define a Fourier transform on a range of frequencies.
+
+Functions
+---------
+
+czt : array
+   Compute the chirp z-transform for a signal.
+zoom_fft : array
+   Compute the Fourier transform on a range of frequencies.
+"""
+
+import cmath
+import numbers
+import cupy
+from numpy import pi
+from cupyx.scipy.fft import fft, ifft, next_fast_len
+
+__all__ = ['czt', 'zoom_fft', 'CZT', 'ZoomFFT', 'czt_points']
+
+
+def _validate_sizes(n, m):
+    if n < 1 or not isinstance(n, numbers.Integral):
+        raise ValueError('Invalid number of CZT data '
+                         f'points ({n}) specified. '
+                         'n must be positive and integer type.')
+
+    if m is None:
+        m = n
+    elif m < 1 or not isinstance(m, numbers.Integral):
+        raise ValueError('Invalid number of CZT output '
+                         f'points ({m}) specified. '
+                         'm must be positive and integer type.')
+
+    return m
+
+
+def czt_points(m, w=None, a=1+0j):
+    """
+    Return the points at which the chirp z-transform is computed.
+
+    Parameters
+    ----------
+    m : int
+        The number of points desired.
+    w : complex, optional
+        The ratio between points in each step.
+        Defaults to equally spaced points around the entire unit circle.
+    a : complex, optional
+        The starting point in the complex plane.  Default is 1+0j.
+
+    Returns
+    -------
+    out : ndarray
+        The points in the Z plane at which `CZT` samples the z-transform,
+        when called with arguments `m`, `w`, and `a`, as complex numbers.
+
+    See Also
+    --------
+    CZT : Class that creates a callable chirp z-transform function.
+    czt : Convenience function for quickly calculating CZT.
+    scipy.signal.czt_points
+
+    """
+    m = _validate_sizes(1, m)
+
+    k = cupy.arange(m)
+
+    a = 1.0 * a  # at least float
+
+    if w is None:
+        # Nothing specified, default to FFT
+        return a * cupy.exp(2j * pi * k / m)
+    else:
+        # w specified
+        w = 1.0 * w  # at least float
+        return a * w**-k
+
+
+class CZT:
+    """
+    Create a callable chirp z-transform function.
+
+    Transform to compute the frequency response around a spiral.
+    Objects of this class are callables which can compute the
+    chirp z-transform on their inputs.  This object precalculates the constant
+    chirps used in the given transform.
+
+    Parameters
+    ----------
+    n : int
+        The size of the signal.
+    m : int, optional
+        The number of output points desired.  Default is `n`.
+    w : complex, optional
+        The ratio between points in each step.  This must be precise or the
+        accumulated error will degrade the tail of the output sequence.
+        Defaults to equally spaced points around the entire unit circle.
+    a : complex, optional
+        The starting point in the complex plane.  Default is 1+0j.
+
+    Returns
+    -------
+    f : CZT
+        Callable object ``f(x, axis=-1)`` for computing the chirp z-transform
+        on `x`.
+
+    See Also
+    --------
+    czt : Convenience function for quickly calculating CZT.
+    ZoomFFT : Class that creates a callable partial FFT function.
+    scipy.signal.CZT
+
+    Notes
+    -----
+    The defaults are chosen such that ``f(x)`` is equivalent to
+    ``fft.fft(x)`` and, if ``m > len(x)``, that ``f(x, m)`` is equivalent to
+    ``fft.fft(x, m)``.
+
+    If `w` does not lie on the unit circle, then the transform will be
+    around a spiral with exponentially-increasing radius.  Regardless,
+    angle will increase linearly.
+
+    For transforms that do lie on the unit circle, accuracy is better when
+    using `ZoomFFT`, since any numerical error in `w` is
+    accumulated for long data lengths, drifting away from the unit circle.
+
+    The chirp z-transform can be faster than an equivalent FFT with
+    zero padding.  Try it with your own array sizes to see.
+
+    However, the chirp z-transform is considerably less precise than the
+    equivalent zero-padded FFT.
+
+    As this CZT is implemented using the Bluestein algorithm, it can compute
+    large prime-length Fourier transforms in O(N log N) time, rather than the
+    O(N**2) time required by the direct DFT calculation.  (`scipy.fft` also
+    uses Bluestein's algorithm'.)
+
+    (The name "chirp z-transform" comes from the use of a chirp in the
+    Bluestein algorithm.  It does not decompose signals into chirps, like
+    other transforms with "chirp" in the name.)
+
+    References
+    ----------
+    .. [1] Leo I. Bluestein, "A linear filtering approach to the computation
+           of the discrete Fourier transform," Northeast Electronics Research
+           and Engineering Meeting Record 10, 218-219 (1968).
+    .. [2] Rabiner, Schafer, and Rader, "The chirp z-transform algorithm and
+           its application," Bell Syst. Tech. J. 48, 1249-1292 (1969).
+
+    """
+
+    def __init__(self, n, m=None, w=None, a=1+0j):
+        m = _validate_sizes(n, m)
+
+        k = cupy.arange(max(m, n), dtype=cupy.min_scalar_type(-max(m, n)**2))
+
+        if w is None:
+            # Nothing specified, default to FFT-like
+            w = cmath.exp(-2j*pi/m)
+            wk2 = cupy.exp(-(1j * pi * ((k**2) % (2*m))) / m)
+        else:
+            # w specified
+            wk2 = w**(k**2/2.)
+
+        a = 1.0 * a  # at least float
+
+        self.w, self.a = w, a
+        self.m, self.n = m, n
+
+        nfft = next_fast_len(n + m - 1)
+        self._Awk2 = a**-k[:n] * wk2[:n]
+        self._nfft = nfft
+        self._Fwk2 = fft(1/cupy.hstack((wk2[n-1:0:-1], wk2[:m])), nfft)
+        self._wk2 = wk2[:m]
+        self._yidx = slice(n-1, n+m-1)
+
+    def __call__(self, x, *, axis=-1):
+        """
+        Calculate the chirp z-transform of a signal.
+
+        Parameters
+        ----------
+        x : array
+            The signal to transform.
+        axis : int, optional
+            Axis over which to compute the FFT. If not given, the last axis is
+            used.
+
+        Returns
+        -------
+        out : ndarray
+            An array of the same dimensions as `x`, but with the length of the
+            transformed axis set to `m`.
+        """
+        x = cupy.asarray(x)
+        if x.shape[axis] != self.n:
+            raise ValueError(f"CZT defined for length {self.n}, not "
+                             f"{x.shape[axis]}")
+        # Calculate transpose coordinates, to allow operation on any given axis
+        trnsp = cupy.arange(x.ndim)
+        trnsp[[axis, -1]] = [-1, axis]
+        x = x.transpose(*trnsp)
+        y = ifft(self._Fwk2 * fft(x*self._Awk2, self._nfft))
+        y = y[..., self._yidx] * self._wk2
+        return y.transpose(*trnsp)
+
+    def points(self):
+        """
+        Return the points at which the chirp z-transform is computed.
+        """
+        return czt_points(self.m, self.w, self.a)
+
+
+class ZoomFFT(CZT):
+    """
+    Create a callable zoom FFT transform function.
+
+    This is a specialization of the chirp z-transform (`CZT`) for a set of
+    equally-spaced frequencies around the unit circle, used to calculate a
+    section of the FFT more efficiently than calculating the entire FFT and
+    truncating.
+
+    Parameters
+    ----------
+    n : int
+        The size of the signal.
+    fn : array_like
+        A length-2 sequence [`f1`, `f2`] giving the frequency range, or a
+        scalar, for which the range [0, `fn`] is assumed.
+    m : int, optional
+        The number of points to evaluate.  Default is `n`.
+    fs : float, optional
+        The sampling frequency.  If ``fs=10`` represented 10 kHz, for example,
+        then `f1` and `f2` would also be given in kHz.
+        The default sampling frequency is 2, so `f1` and `f2` should be
+        in the range [0, 1] to keep the transform below the Nyquist
+        frequency.
+    endpoint : bool, optional
+        If True, `f2` is the last sample. Otherwise, it is not included.
+        Default is False.
+
+    Returns
+    -------
+    f : ZoomFFT
+        Callable object ``f(x, axis=-1)`` for computing the zoom FFT on `x`.
+
+    See Also
+    --------
+    zoom_fft : Convenience function for calculating a zoom FFT.
+    scipy.signal.ZoomFFT
+
+    Notes
+    -----
+    The defaults are chosen such that ``f(x, 2)`` is equivalent to
+    ``fft.fft(x)`` and, if ``m > len(x)``, that ``f(x, 2, m)`` is equivalent to
+    ``fft.fft(x, m)``.
+
+    Sampling frequency is 1/dt, the time step between samples in the
+    signal `x`.  The unit circle corresponds to frequencies from 0 up
+    to the sampling frequency.  The default sampling frequency of 2
+    means that `f1`, `f2` values up to the Nyquist frequency are in the
+    range [0, 1). For `f1`, `f2` values expressed in radians, a sampling
+    frequency of 2*pi should be used.
+
+    Remember that a zoom FFT can only interpolate the points of the existing
+    FFT.  It cannot help to resolve two separate nearby frequencies.
+    Frequency resolution can only be increased by increasing acquisition
+    time.
+
+    These functions are implemented using Bluestein's algorithm (as is
+    `scipy.fft`). [2]_
+
+    References
+    ----------
+    .. [1] Steve Alan Shilling, "A study of the chirp z-transform and its
+           applications", pg 29 (1970)
+           https://krex.k-state.edu/dspace/bitstream/handle/2097/7844/LD2668R41972S43.pdf
+    .. [2] Leo I. Bluestein, "A linear filtering approach to the computation
+           of the discrete Fourier transform," Northeast Electronics Research
+           and Engineering Meeting Record 10, 218-219 (1968).
+    """
+
+    def __init__(self, n, fn, m=None, *, fs=2, endpoint=False):
+        m = _validate_sizes(n, m)
+
+        k = cupy.arange(max(m, n), dtype=cupy.min_scalar_type(-max(m, n)**2))
+
+        if cupy.size(fn) == 2:
+            f1, f2 = fn
+        elif cupy.size(fn) == 1:
+            f1, f2 = 0.0, fn
+        else:
+            raise ValueError('fn must be a scalar or 2-length sequence')
+
+        self.f1, self.f2, self.fs = f1, f2, fs
+
+        if endpoint:
+            scale = ((f2 - f1) * m) / (fs * (m - 1))
+        else:
+            scale = (f2 - f1) / fs
+        a = cmath.exp(2j * pi * f1/fs)
+        wk2 = cupy.exp(-(1j * pi * scale * k**2) / m)
+
+        self.w = cmath.exp(-2j*pi/m * scale)
+        self.a = a
+        self.m, self.n = m, n
+
+        ak = cupy.exp(-2j * pi * f1/fs * k[:n])
+        self._Awk2 = ak * wk2[:n]
+
+        nfft = next_fast_len(n + m - 1)
+        self._nfft = nfft
+        self._Fwk2 = fft(1/cupy.hstack((wk2[n-1:0:-1], wk2[:m])), nfft)
+        self._wk2 = wk2[:m]
+        self._yidx = slice(n-1, n+m-1)
+
+
+def czt(x, m=None, w=None, a=1+0j, *, axis=-1):
+    """
+    Compute the frequency response around a spiral in the Z plane.
+
+    Parameters
+    ----------
+    x : array
+        The signal to transform.
+    m : int, optional
+        The number of output points desired.  Default is the length of the
+        input data.
+    w : complex, optional
+        The ratio between points in each step.  This must be precise or the
+        accumulated error will degrade the tail of the output sequence.
+        Defaults to equally spaced points around the entire unit circle.
+    a : complex, optional
+        The starting point in the complex plane.  Default is 1+0j.
+    axis : int, optional
+        Axis over which to compute the FFT. If not given, the last axis is
+        used.
+
+    Returns
+    -------
+    out : ndarray
+        An array of the same dimensions as `x`, but with the length of the
+        transformed axis set to `m`.
+
+    See Also
+    --------
+    CZT : Class that creates a callable chirp z-transform function.
+    zoom_fft : Convenience function for partial FFT calculations.
+    scipy.signal.czt
+
+    Notes
+    -----
+    The defaults are chosen such that ``signal.czt(x)`` is equivalent to
+    ``fft.fft(x)`` and, if ``m > len(x)``, that ``signal.czt(x, m)`` is
+    equivalent to ``fft.fft(x, m)``.
+
+    If the transform needs to be repeated, use `CZT` to construct a
+    specialized transform function which can be reused without
+    recomputing constants.
+
+    An example application is in system identification, repeatedly evaluating
+    small slices of the z-transform of a system, around where a pole is
+    expected to exist, to refine the estimate of the pole's true location. [1]_
+
+    References
+    ----------
+    .. [1] Steve Alan Shilling, "A study of the chirp z-transform and its
+           applications", pg 20 (1970)
+           https://krex.k-state.edu/dspace/bitstream/handle/2097/7844/LD2668R41972S43.pdf
+
+    """
+    x = cupy.asarray(x)
+    transform = CZT(x.shape[axis], m=m, w=w, a=a)
+    return transform(x, axis=axis)
+
+
+def zoom_fft(x, fn, m=None, *, fs=2, endpoint=False, axis=-1):
+    """
+    Compute the DFT of `x` only for frequencies in range `fn`.
+
+    Parameters
+    ----------
+    x : array
+        The signal to transform.
+    fn : array_like
+        A length-2 sequence [`f1`, `f2`] giving the frequency range, or a
+        scalar, for which the range [0, `fn`] is assumed.
+    m : int, optional
+        The number of points to evaluate.  The default is the length of `x`.
+    fs : float, optional
+        The sampling frequency.  If ``fs=10`` represented 10 kHz, for example,
+        then `f1` and `f2` would also be given in kHz.
+        The default sampling frequency is 2, so `f1` and `f2` should be
+        in the range [0, 1] to keep the transform below the Nyquist
+        frequency.
+    endpoint : bool, optional
+        If True, `f2` is the last sample. Otherwise, it is not included.
+        Default is False.
+    axis : int, optional
+        Axis over which to compute the FFT. If not given, the last axis is
+        used.
+
+    Returns
+    -------
+    out : ndarray
+        The transformed signal.  The Fourier transform will be calculated
+        at the points f1, f1+df, f1+2df, ..., f2, where df=(f2-f1)/m.
+
+    See Also
+    --------
+    ZoomFFT : Class that creates a callable partial FFT function.
+    scipy.signal.zoom_fft
+
+    Notes
+    -----
+    The defaults are chosen such that ``signal.zoom_fft(x, 2)`` is equivalent
+    to ``fft.fft(x)`` and, if ``m > len(x)``, that ``signal.zoom_fft(x, 2, m)``
+    is equivalent to ``fft.fft(x, m)``.
+
+    To graph the magnitude of the resulting transform, use::
+
+        plot(linspace(f1, f2, m, endpoint=False), abs(zoom_fft(x, [f1, f2], m)))
+
+    If the transform needs to be repeated, use `ZoomFFT` to construct
+    a specialized transform function which can be reused without
+    recomputing constants.
+    """
+    x = cupy.asarray(x)
+    transform = ZoomFFT(x.shape[axis], fn, m=m, fs=fs, endpoint=endpoint)
+    return transform(x, axis=axis)

--- a/cupyx/scipy/signal/_czt.py
+++ b/cupyx/scipy/signal/_czt.py
@@ -149,13 +149,13 @@ class CZT:
     However, the chirp z-transform is considerably less precise than the
     equivalent zero-padded FFT.
 
-    As this CZT is implemented using the Bluestein algorithm, it can compute
-    large prime-length Fourier transforms in O(N log N) time, rather than the
-    O(N**2) time required by the direct DFT calculation.  (`scipy.fft` also
-    uses Bluestein's algorithm'.)
+    As this CZT is implemented using the Bluestein algorithm [1]_, it can
+    compute large prime-length Fourier transforms in O(N log N) time, rather
+    than the O(N**2) time required by the direct DFT calculation.
+    (`scipy.fft` also uses Bluestein's algorithm'.)
 
     (The name "chirp z-transform" comes from the use of a chirp in the
-    Bluestein algorithm.  It does not decompose signals into chirps, like
+    Bluestein algorithm [2]_.  It does not decompose signals into chirps, like
     other transforms with "chirp" in the name.)
 
     References
@@ -237,7 +237,7 @@ class ZoomFFT(CZT):
     This is a specialization of the chirp z-transform (`CZT`) for a set of
     equally-spaced frequencies around the unit circle, used to calculate a
     section of the FFT more efficiently than calculating the entire FFT and
-    truncating.
+    truncating. [1]_
 
     Parameters
     ----------

--- a/cupyx/scipy/signal/_czt.py
+++ b/cupyx/scipy/signal/_czt.py
@@ -216,8 +216,8 @@ class CZT:
             raise ValueError(f"CZT defined for length {self.n}, not "
                              f"{x.shape[axis]}")
         # Calculate transpose coordinates, to allow operation on any given axis
-        trnsp = cupy.arange(x.ndim)
-        trnsp[[axis, -1]] = [-1, axis]
+        trnsp = list(range(x.ndim))
+        trnsp[axis], trnsp[-1] = trnsp[-1], trnsp[axis]
         x = x.transpose(*trnsp)
         y = ifft(self._Fwk2 * fft(x*self._Awk2, self._nfft))
         y = y[..., self._yidx] * self._wk2
@@ -304,6 +304,7 @@ class ZoomFFT(CZT):
 
         k = cupy.arange(max(m, n), dtype=cupy.min_scalar_type(-max(m, n)**2))
 
+        fn = cupy.asarray(fn)
         if cupy.size(fn) == 2:
             f1, f2 = fn
         elif cupy.size(fn) == 1:
@@ -438,7 +439,8 @@ def zoom_fft(x, fn, m=None, *, fs=2, endpoint=False, axis=-1):
 
     To graph the magnitude of the resulting transform, use::
 
-        plot(linspace(f1, f2, m, endpoint=False), abs(zoom_fft(x, [f1, f2], m)))
+        plot(linspace(f1, f2, m, endpoint=False),
+             abs(zoom_fft(x, [f1, f2], m)))
 
     If the transform needs to be repeated, use `ZoomFFT` to construct
     a specialized transform function which can be reused without

--- a/docs/source/reference/scipy_signal.rst
+++ b/docs/source/reference/scipy_signal.rst
@@ -50,3 +50,17 @@ Filter design
    bilinear
    bilinear_zpk
    savgol_coeffs
+
+
+Chirp Z-transform and Zoom FFT
+------------------------------
+
+.. autosummary::
+   :toctree: generated/
+
+   czt
+   zoom_fft
+   CZT
+   ZoomFFT
+   czt_points
+

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_czt.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_czt.py
@@ -1,0 +1,219 @@
+# This program is public domain
+# Authors: Paul Kienzle, Nadav Horesh
+'''
+A unit test module for czt.py
+'''
+import pytest
+from numpy.testing import assert_allclose
+from scipy.fft import fft
+from scipy.signal import (czt, zoom_fft, czt_points, CZT, ZoomFFT)
+import numpy as np
+
+
+def check_czt(x):
+    # Check that czt is the equivalent of normal fft
+    y = fft(x)
+    y1 = czt(x)
+    assert_allclose(y1, y, rtol=1e-13)
+
+    # Check that interpolated czt is the equivalent of normal fft
+    y = fft(x, 100*len(x))
+    y1 = czt(x, 100*len(x))
+    assert_allclose(y1, y, rtol=1e-12)
+
+
+def check_zoom_fft(x):
+    # Check that zoom_fft is the equivalent of normal fft
+    y = fft(x)
+    y1 = zoom_fft(x, [0, 2-2./len(y)], endpoint=True)
+    assert_allclose(y1, y, rtol=1e-11, atol=1e-14)
+    y1 = zoom_fft(x, [0, 2])
+    assert_allclose(y1, y, rtol=1e-11, atol=1e-14)
+
+    # Test fn scalar
+    y1 = zoom_fft(x, 2-2./len(y), endpoint=True)
+    assert_allclose(y1, y, rtol=1e-11, atol=1e-14)
+    y1 = zoom_fft(x, 2)
+    assert_allclose(y1, y, rtol=1e-11, atol=1e-14)
+
+    # Check that zoom_fft with oversampling is equivalent to zero padding
+    over = 10
+    yover = fft(x, over*len(x))
+    y2 = zoom_fft(x, [0, 2-2./len(yover)], m=len(yover), endpoint=True)
+    assert_allclose(y2, yover, rtol=1e-12, atol=1e-10)
+    y2 = zoom_fft(x, [0, 2], m=len(yover))
+    assert_allclose(y2, yover, rtol=1e-12, atol=1e-10)
+
+    # Check that zoom_fft works on a subrange
+    w = np.linspace(0, 2-2./len(x), len(x))
+    f1, f2 = w[3], w[6]
+    y3 = zoom_fft(x, [f1, f2], m=3*over+1, endpoint=True)
+    idx3 = slice(3*over, 6*over+1)
+    assert_allclose(y3, yover[idx3], rtol=1e-13)
+
+
+def test_1D():
+    # Test of 1D version of the transforms
+
+    np.random.seed(0)  # Deterministic randomness
+
+    # Random signals
+    lengths = np.random.randint(8, 200, 20)
+    np.append(lengths, 1)
+    for length in lengths:
+        x = np.random.random(length)
+        check_zoom_fft(x)
+        check_czt(x)
+
+    # Gauss
+    t = np.linspace(-2, 2, 128)
+    x = np.exp(-t**2/0.01)
+    check_zoom_fft(x)
+
+    # Linear
+    x = [1, 2, 3, 4, 5, 6, 7]
+    check_zoom_fft(x)
+
+    # Check near powers of two
+    check_zoom_fft(range(126-31))
+    check_zoom_fft(range(127-31))
+    check_zoom_fft(range(128-31))
+    check_zoom_fft(range(129-31))
+    check_zoom_fft(range(130-31))
+
+    # Check transform on n-D array input
+    x = np.reshape(np.arange(3*2*28), (3, 2, 28))
+    y1 = zoom_fft(x, [0, 2-2./28])
+    y2 = zoom_fft(x[2, 0, :], [0, 2-2./28])
+    assert_allclose(y1[2, 0], y2, rtol=1e-13, atol=1e-12)
+
+    y1 = zoom_fft(x, [0, 2], endpoint=False)
+    y2 = zoom_fft(x[2, 0, :], [0, 2], endpoint=False)
+    assert_allclose(y1[2, 0], y2, rtol=1e-13, atol=1e-12)
+
+    # Random (not a test condition)
+    x = np.random.rand(101)
+    check_zoom_fft(x)
+
+    # Spikes
+    t = np.linspace(0, 1, 128)
+    x = np.sin(2*np.pi*t*5)+np.sin(2*np.pi*t*13)
+    check_zoom_fft(x)
+
+    # Sines
+    x = np.zeros(100, dtype=complex)
+    x[[1, 5, 21]] = 1
+    check_zoom_fft(x)
+
+    # Sines plus complex component
+    x += 1j*np.linspace(0, 0.5, x.shape[0])
+    check_zoom_fft(x)
+
+
+def test_large_prime_lengths():
+    np.random.seed(0)  # Deterministic randomness
+    for N in (101, 1009, 10007):
+        x = np.random.rand(N)
+        y = fft(x)
+        y1 = czt(x)
+        assert_allclose(y, y1, rtol=1e-12)
+
+
+@pytest.mark.slow
+def test_czt_vs_fft():
+    np.random.seed(123)
+    random_lengths = np.random.exponential(100000, size=10).astype('int')
+    for n in random_lengths:
+        a = np.random.randn(n)
+        assert_allclose(czt(a), fft(a), rtol=1e-11)
+
+
+def test_empty_input():
+    with pytest.raises(ValueError, match='Invalid number of CZT'):
+        czt([])
+    with pytest.raises(ValueError, match='Invalid number of CZT'):
+        zoom_fft([], 0.5)
+
+
+def test_0_rank_input():
+    with pytest.raises(IndexError, match='tuple index out of range'):
+        czt(5)
+    with pytest.raises(IndexError, match='tuple index out of range'):
+        zoom_fft(5, 0.5)
+
+
+@pytest.mark.parametrize('impulse', ([0, 0, 1], [0, 0, 1, 0, 0],
+                                     np.concatenate((np.array([0, 0, 1]),
+                                                     np.zeros(100)))))
+@pytest.mark.parametrize('m', (1, 3, 5, 8, 101, 1021))
+@pytest.mark.parametrize('a', (1, 2, 0.5, 1.1))
+# Step that tests away from the unit circle, but not so far it explodes from
+# numerical error
+@pytest.mark.parametrize('w', (None, 0.98534 + 0.17055j))
+def test_czt_math(impulse, m, w, a):
+    # z-transform of an impulse is 1 everywhere
+    assert_allclose(czt(impulse[2:], m=m, w=w, a=a),
+                    np.ones(m), rtol=1e-10)
+
+    # z-transform of a delayed impulse is z**-1
+    assert_allclose(czt(impulse[1:], m=m, w=w, a=a),
+                    czt_points(m=m, w=w, a=a)**-1, rtol=1e-10)
+
+    # z-transform of a 2-delayed impulse is z**-2
+    assert_allclose(czt(impulse, m=m, w=w, a=a),
+                    czt_points(m=m, w=w, a=a)**-2, rtol=1e-10)
+
+
+def test_int_args():
+    # Integer argument `a` was producing all 0s
+    assert_allclose(abs(czt([0, 1], m=10, a=2)), 0.5*np.ones(10), rtol=1e-15)
+    assert_allclose(czt_points(11, w=2), 1/(2**np.arange(11)), rtol=1e-30)
+
+
+def test_czt_points():
+    for N in (1, 2, 3, 8, 11, 100, 101, 10007):
+        assert_allclose(czt_points(N), np.exp(2j*np.pi*np.arange(N)/N),
+                        rtol=1e-30)
+
+    assert_allclose(czt_points(7, w=1), np.ones(7), rtol=1e-30)
+    assert_allclose(czt_points(11, w=2.), 1/(2**np.arange(11)), rtol=1e-30)
+
+    func = CZT(12, m=11, w=2., a=1)
+    assert_allclose(func.points(), 1/(2**np.arange(11)), rtol=1e-30)
+
+
+@pytest.mark.parametrize('cls, args', [(CZT, (100,)), (ZoomFFT, (100, 0.2))])
+def test_CZT_size_mismatch(cls, args):
+    # Data size doesn't match function's expected size
+    myfunc = cls(*args)
+    with pytest.raises(ValueError, match='CZT defined for'):
+        myfunc(np.arange(5))
+
+
+def test_invalid_range():
+    with pytest.raises(ValueError, match='2-length sequence'):
+        ZoomFFT(100, [1, 2, 3])
+
+
+@pytest.mark.parametrize('m', [0, -11, 5.5, 4.0])
+def test_czt_points_errors(m):
+    # Invalid number of points
+    with pytest.raises(ValueError, match='Invalid number of CZT'):
+        czt_points(m)
+
+
+@pytest.mark.parametrize('size', [0, -5, 3.5, 4.0])
+def test_nonsense_size(size):
+    # Numpy and Scipy fft() give ValueError for 0 output size, so we do, too
+    with pytest.raises(ValueError, match='Invalid number of CZT'):
+        CZT(size, 3)
+    with pytest.raises(ValueError, match='Invalid number of CZT'):
+        ZoomFFT(size, 0.2, 3)
+    with pytest.raises(ValueError, match='Invalid number of CZT'):
+        CZT(3, size)
+    with pytest.raises(ValueError, match='Invalid number of CZT'):
+        ZoomFFT(3, 0.2, size)
+    with pytest.raises(ValueError, match='Invalid number of CZT'):
+        czt([1, 2, 3], size)
+    with pytest.raises(ValueError, match='Invalid number of CZT'):
+        zoom_fft([1, 2, 3], 0.2, size)

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_czt.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_czt.py
@@ -3,148 +3,236 @@
 '''
 A unit test module for czt.py
 '''
+from math import pi
+
 import pytest
-from numpy.testing import assert_allclose
-from scipy.fft import fft
-from scipy.signal import (czt, zoom_fft, czt_points, CZT, ZoomFFT)
+import cupy
 import numpy as np
 
+from cupy import testing
+from cupy.testing import assert_allclose
 
-def check_czt(x):
+import cupyx.scipy.fft as fft
+import cupyx.scipy.signal as signal
+
+
+def check_czt(x, xp, scp):
     # Check that czt is the equivalent of normal fft
-    y = fft(x)
-    y1 = czt(x)
-    assert_allclose(y1, y, rtol=1e-13)
+    y1 = scp.signal.czt(x)
 
     # Check that interpolated czt is the equivalent of normal fft
-    y = fft(x, 100*len(x))
-    y1 = czt(x, 100*len(x))
-    assert_allclose(y1, y, rtol=1e-12)
+    y1_ = scp.signal.czt(x, 100*len(x))
+    return y1, y1_
 
 
-def check_zoom_fft(x):
+def check_zoom_fft(x, xp, scp):
     # Check that zoom_fft is the equivalent of normal fft
-    y = fft(x)
-    y1 = zoom_fft(x, [0, 2-2./len(y)], endpoint=True)
-    assert_allclose(y1, y, rtol=1e-11, atol=1e-14)
-    y1 = zoom_fft(x, [0, 2])
-    assert_allclose(y1, y, rtol=1e-11, atol=1e-14)
+    y = scp.fft.fft(x)
+    y1 = scp.signal.zoom_fft(x, [0, 2-2./len(y)], endpoint=True)
+    y2 = scp.signal.zoom_fft(x, [0, 2])
+    return y1, y2
 
+
+def check_zoom_fft_2(x, xp, scp):
     # Test fn scalar
-    y1 = zoom_fft(x, 2-2./len(y), endpoint=True)
-    assert_allclose(y1, y, rtol=1e-11, atol=1e-14)
-    y1 = zoom_fft(x, 2)
-    assert_allclose(y1, y, rtol=1e-11, atol=1e-14)
+    y = scp.fft.fft(x)
+    y1 = scp.signal.zoom_fft(x, 2-2./len(y), endpoint=True)
+    y2 = scp.signal.zoom_fft(x, 2)
+    return y1, y2
 
+
+def check_zoom_fft_3(x, xp, scp):
     # Check that zoom_fft with oversampling is equivalent to zero padding
     over = 10
-    yover = fft(x, over*len(x))
-    y2 = zoom_fft(x, [0, 2-2./len(yover)], m=len(yover), endpoint=True)
-    assert_allclose(y2, yover, rtol=1e-12, atol=1e-10)
-    y2 = zoom_fft(x, [0, 2], m=len(yover))
-    assert_allclose(y2, yover, rtol=1e-12, atol=1e-10)
+    yover = scp.fft.fft(x, over*len(x))
+    y1 = scp.signal.zoom_fft(
+        x, [0, 2-2./len(yover)], m=len(yover), endpoint=True)
+    y2 = scp.signal.zoom_fft(x, [0, 2], m=len(yover))
 
     # Check that zoom_fft works on a subrange
-    w = np.linspace(0, 2-2./len(x), len(x))
+    w = xp.linspace(0, 2-2./len(x), len(x))
     f1, f2 = w[3], w[6]
-    y3 = zoom_fft(x, [f1, f2], m=3*over+1, endpoint=True)
-    idx3 = slice(3*over, 6*over+1)
-    assert_allclose(y3, yover[idx3], rtol=1e-13)
+    y3 = scp.signal.zoom_fft(x, [f1, f2], m=3*over+1, endpoint=True)
+
+    return y1, y2, y3
 
 
-def test_1D():
-    # Test of 1D version of the transforms
-
-    np.random.seed(0)  # Deterministic randomness
-
-    # Random signals
-    lengths = np.random.randint(8, 200, 20)
-    np.append(lengths, 1)
-    for length in lengths:
-        x = np.random.random(length)
-        check_zoom_fft(x)
-        check_czt(x)
-
-    # Gauss
-    t = np.linspace(-2, 2, 128)
-    x = np.exp(-t**2/0.01)
-    check_zoom_fft(x)
-
-    # Linear
-    x = [1, 2, 3, 4, 5, 6, 7]
-    check_zoom_fft(x)
-
-    # Check near powers of two
-    check_zoom_fft(range(126-31))
-    check_zoom_fft(range(127-31))
-    check_zoom_fft(range(128-31))
-    check_zoom_fft(range(129-31))
-    check_zoom_fft(range(130-31))
-
-    # Check transform on n-D array input
-    x = np.reshape(np.arange(3*2*28), (3, 2, 28))
-    y1 = zoom_fft(x, [0, 2-2./28])
-    y2 = zoom_fft(x[2, 0, :], [0, 2-2./28])
-    assert_allclose(y1[2, 0], y2, rtol=1e-13, atol=1e-12)
-
-    y1 = zoom_fft(x, [0, 2], endpoint=False)
-    y2 = zoom_fft(x[2, 0, :], [0, 2], endpoint=False)
-    assert_allclose(y1[2, 0], y2, rtol=1e-13, atol=1e-12)
-
-    # Random (not a test condition)
-    x = np.random.rand(101)
-    check_zoom_fft(x)
-
-    # Spikes
-    t = np.linspace(0, 1, 128)
-    x = np.sin(2*np.pi*t*5)+np.sin(2*np.pi*t*13)
-    check_zoom_fft(x)
-
-    # Sines
-    x = np.zeros(100, dtype=complex)
-    x[[1, 5, 21]] = 1
-    check_zoom_fft(x)
-
-    # Sines plus complex component
-    x += 1j*np.linspace(0, 0.5, x.shape[0])
-    check_zoom_fft(x)
+pw2_ranges = [range(126-31), range(127-31), range(128-31), range(129-31),
+              range(130-31), ]
+zf_checks = [check_zoom_fft, check_zoom_fft_2, check_zoom_fft_3, check_czt]
 
 
-def test_large_prime_lengths():
-    np.random.seed(0)  # Deterministic randomness
-    for N in (101, 1009, 10007):
-        x = np.random.rand(N)
-        y = fft(x)
-        y1 = czt(x)
-        assert_allclose(y, y1, rtol=1e-12)
+def _gen_random_signal():
+    lengths = testing.shaped_random((8, 200, 20))
+    for x in lengths:
+        yield x
 
 
+@testing.with_requires("scipy")
+class Test1D:
+
+    @pytest.mark.parametrize('func', zf_checks)
+    @pytest.mark.parametrize('x', pw2_ranges)
+    @testing.numpy_cupy_allclose(scipy_name="scp")
+    def test_near_pow2(self, xp, scp, x, func):
+        x = xp.asarray(x)
+        return func(x, xp, scp)
+
+    @pytest.mark.parametrize('func', zf_checks)
+    @testing.numpy_cupy_allclose(scipy_name="scp", atol=1e-14)
+    def test_gauss(self, xp, scp, func):
+        t = xp.linspace(-2, 2, 128)
+        x = xp.exp(-t**2/0.01)
+        return func(x, xp, scp)
+
+    @pytest.mark.parametrize('func', zf_checks)
+    @testing.numpy_cupy_allclose(scipy_name="scp")
+    def test_linear(self, xp, scp, func):
+        x = xp.asarray([1, 2, 3, 4, 5, 6, 7])
+        return func(x, xp, scp)
+
+    @pytest.mark.parametrize('func', zf_checks)
+    @testing.numpy_cupy_allclose(scipy_name="scp", atol=1e-13)
+    def test_spikes(self, xp, scp, func):
+        t = xp.linspace(0, 1, 128)
+        x = xp.sin(2*pi*t*5) + xp.sin(2*pi*t*13)
+        return func(x, xp, scp)
+
+    @pytest.mark.parametrize('func', zf_checks)
+    @testing.numpy_cupy_allclose(scipy_name="scp")
+    def test_sines(self, xp, scp, func):
+        x = xp.zeros(100, dtype=complex)
+        x[[1, 5, 21]] = 1
+        return func(x, xp, scp)
+
+    @pytest.mark.parametrize('func', zf_checks)
+    @testing.numpy_cupy_allclose(scipy_name="scp")
+    def test_sines_plus(self, xp, scp, func):
+        x = xp.zeros(100, dtype=complex)
+        x[[1, 5, 21]] = 1
+        x += 1j*xp.linspace(0, 0.5, x.shape[0])
+        return func(x, xp, scp)
+
+    @pytest.mark.parametrize('func', zf_checks)
+    @testing.numpy_cupy_allclose(scipy_name="scp")
+    def test_random(self, xp, scp, func):
+        x = testing.shaped_random((101,), xp, dtype=float)
+        # check_zoom_fft(x)
+        return func(x, xp, scp)
+
+    @testing.numpy_cupy_allclose(scipy_name="scp")
+    def test_nd(self, xp, scp):
+        # Check transform on n-D array input
+        x = xp.arange(3*2*28).reshape(3, 2, 28)
+        y1 = scp.signal.zoom_fft(x, [0, 2-2./28])
+        y2 = scp.signal.zoom_fft(x[2, 0, :], [0, 2-2./28])
+        return y1, y2
+
+    @testing.numpy_cupy_allclose(scipy_name="scp")
+    def test_nd_2(self, xp, scp):
+        # Check transform on n-D array input
+        x = xp.arange(3*2*28).reshape(3, 2, 28)
+        y1 = scp.signal.zoom_fft(x, [0, 2], endpoint=False)
+        y2 = scp.signal.zoom_fft(x[2, 0, :], [0, 2], endpoint=False)
+        return y1, y2
+
+    @pytest.mark.parametrize('func', zf_checks)
+    @pytest.mark.parametrize("x", list(_gen_random_signal()))
+    @testing.numpy_cupy_allclose(scipy_name="scp")
+    def test_random_signals(self, xp, scp, x, func):
+        assert x.shape == (200, 20)
+        if xp == np:
+            x = x.get()
+        return func(x, xp, scp)
+
+    @pytest.mark.parametrize("N", [101, 1009, 10007])
+    @testing.numpy_cupy_allclose(scipy_name="scp")
+    def test_large_prime_lengths(self, xp, scp, N):
+        x = testing.shaped_random((N,))
+        if xp == np:
+            x = x.get()
+        return scp.signal.czt(x)
+
+
+@testing.with_requires("scipy")
+class TestErrors:
+
+    @pytest.mark.parametrize('size', [0, -5, 3.5, 4.0])
+    def test_nonsense_size(self, size):
+        # Numpy and Scipy fft() give ValueError for 0 output size
+        with pytest.raises(ValueError, match='Invalid number of CZT'):
+            signal.CZT(size, 3)
+        with pytest.raises(ValueError, match='Invalid number of CZT'):
+            signal.ZoomFFT(size, 0.2, 3)
+        with pytest.raises(ValueError, match='Invalid number of CZT'):
+            signal.CZT(3, size)
+        with pytest.raises(ValueError, match='Invalid number of CZT'):
+            signal.ZoomFFT(3, 0.2, size)
+        with pytest.raises(ValueError, match='Invalid number of CZT'):
+            signal.czt([1, 2, 3], size)
+        with pytest.raises(ValueError, match='Invalid number of CZT'):
+            signal.zoom_fft([1, 2, 3], 0.2, size)
+
+    def test_invalid_range(self):
+        with pytest.raises(ValueError, match='2-length sequence'):
+            signal.ZoomFFT(100, [1, 2, 3])
+
+    @pytest.mark.parametrize('m', [0, -11, 5.5, 4.0])
+    def test_czt_points_errors(self, m):
+        # Invalid number of points
+        with pytest.raises(ValueError, match='Invalid number of CZT'):
+            signal.czt_points(m)
+
+    def test_empty_input(self):
+        with pytest.raises(ValueError, match='Invalid number of CZT'):
+            signal.czt([])
+        with pytest.raises(ValueError, match='Invalid number of CZT'):
+            signal.zoom_fft([], 0.5)
+
+    def test_0_rank_input(self):
+        with pytest.raises(IndexError, match='tuple index out of range'):
+            signal.czt(5)
+        with pytest.raises(IndexError, match='tuple index out of range'):
+            signal.zoom_fft(5, 0.5)
+
+
+@testing.with_requires("scipy")
+class TestCZTPoints:
+
+    @pytest.mark.parametrize("N", [1, 2, 3, 8, 11, 100, 101, 10007])
+    @testing.numpy_cupy_allclose(scipy_name="scp", rtol=1e-15)
+    def test_points(self, xp, scp, N):
+        return scp.signal.czt_points(N)
+
+    @testing.numpy_cupy_allclose(scipy_name="scp", rtol=1e-15)
+    def test_points_w(self, xp, scp):
+        return scp.signal.czt_points(7, w=1), scp.signal.czt_points(11, w=2)
+
+    @testing.numpy_cupy_allclose(scipy_name="scp", rtol=1e-15)
+    def test_points_meth(self, xp, scp):
+        func = scp.signal.CZT(12, m=11, w=2., a=1)
+        return func.points()
+
+    @testing.numpy_cupy_allclose(scipy_name="scp")
+    def test_int_args(self, xp, scp):
+        # Integer argument `a` was producing all 0s
+        return (scp.signal.czt([0, 1], m=10, a=2),
+                scp.signal.czt_points(11, w=2))
+
+
+@testing.with_requires("scipy")
 @pytest.mark.slow
 def test_czt_vs_fft():
-    np.random.seed(123)
-    random_lengths = np.random.exponential(100000, size=10).astype('int')
+    cupy.random.seed(123)
+    random_lengths = cupy.random.exponential(100000, size=10).astype('int')
     for n in random_lengths:
-        a = np.random.randn(n)
-        assert_allclose(czt(a), fft(a), rtol=1e-11)
-
-
-def test_empty_input():
-    with pytest.raises(ValueError, match='Invalid number of CZT'):
-        czt([])
-    with pytest.raises(ValueError, match='Invalid number of CZT'):
-        zoom_fft([], 0.5)
-
-
-def test_0_rank_input():
-    with pytest.raises(IndexError, match='tuple index out of range'):
-        czt(5)
-    with pytest.raises(IndexError, match='tuple index out of range'):
-        zoom_fft(5, 0.5)
+        a = cupy.random.randn(int(n))
+        assert_allclose(signal.czt(a), fft.fft(a), rtol=1e-11)
 
 
 @pytest.mark.parametrize('impulse', ([0, 0, 1], [0, 0, 1, 0, 0],
-                                     np.concatenate((np.array([0, 0, 1]),
-                                                     np.zeros(100)))))
+                                     cupy.concatenate((cupy.array([0, 0, 1]),
+                                                       cupy.zeros(100)))))
 @pytest.mark.parametrize('m', (1, 3, 5, 8, 101, 1021))
 @pytest.mark.parametrize('a', (1, 2, 0.5, 1.1))
 # Step that tests away from the unit circle, but not so far it explodes from
@@ -152,68 +240,13 @@ def test_0_rank_input():
 @pytest.mark.parametrize('w', (None, 0.98534 + 0.17055j))
 def test_czt_math(impulse, m, w, a):
     # z-transform of an impulse is 1 everywhere
-    assert_allclose(czt(impulse[2:], m=m, w=w, a=a),
-                    np.ones(m), rtol=1e-10)
+    assert_allclose(signal.czt(impulse[2:], m=m, w=w, a=a),
+                    cupy.ones(m), rtol=1e-10)
 
     # z-transform of a delayed impulse is z**-1
-    assert_allclose(czt(impulse[1:], m=m, w=w, a=a),
-                    czt_points(m=m, w=w, a=a)**-1, rtol=1e-10)
+    assert_allclose(signal.czt(impulse[1:], m=m, w=w, a=a),
+                    signal.czt_points(m=m, w=w, a=a)**-1, rtol=1e-10)
 
     # z-transform of a 2-delayed impulse is z**-2
-    assert_allclose(czt(impulse, m=m, w=w, a=a),
-                    czt_points(m=m, w=w, a=a)**-2, rtol=1e-10)
-
-
-def test_int_args():
-    # Integer argument `a` was producing all 0s
-    assert_allclose(abs(czt([0, 1], m=10, a=2)), 0.5*np.ones(10), rtol=1e-15)
-    assert_allclose(czt_points(11, w=2), 1/(2**np.arange(11)), rtol=1e-30)
-
-
-def test_czt_points():
-    for N in (1, 2, 3, 8, 11, 100, 101, 10007):
-        assert_allclose(czt_points(N), np.exp(2j*np.pi*np.arange(N)/N),
-                        rtol=1e-30)
-
-    assert_allclose(czt_points(7, w=1), np.ones(7), rtol=1e-30)
-    assert_allclose(czt_points(11, w=2.), 1/(2**np.arange(11)), rtol=1e-30)
-
-    func = CZT(12, m=11, w=2., a=1)
-    assert_allclose(func.points(), 1/(2**np.arange(11)), rtol=1e-30)
-
-
-@pytest.mark.parametrize('cls, args', [(CZT, (100,)), (ZoomFFT, (100, 0.2))])
-def test_CZT_size_mismatch(cls, args):
-    # Data size doesn't match function's expected size
-    myfunc = cls(*args)
-    with pytest.raises(ValueError, match='CZT defined for'):
-        myfunc(np.arange(5))
-
-
-def test_invalid_range():
-    with pytest.raises(ValueError, match='2-length sequence'):
-        ZoomFFT(100, [1, 2, 3])
-
-
-@pytest.mark.parametrize('m', [0, -11, 5.5, 4.0])
-def test_czt_points_errors(m):
-    # Invalid number of points
-    with pytest.raises(ValueError, match='Invalid number of CZT'):
-        czt_points(m)
-
-
-@pytest.mark.parametrize('size', [0, -5, 3.5, 4.0])
-def test_nonsense_size(size):
-    # Numpy and Scipy fft() give ValueError for 0 output size, so we do, too
-    with pytest.raises(ValueError, match='Invalid number of CZT'):
-        CZT(size, 3)
-    with pytest.raises(ValueError, match='Invalid number of CZT'):
-        ZoomFFT(size, 0.2, 3)
-    with pytest.raises(ValueError, match='Invalid number of CZT'):
-        CZT(3, size)
-    with pytest.raises(ValueError, match='Invalid number of CZT'):
-        ZoomFFT(3, 0.2, size)
-    with pytest.raises(ValueError, match='Invalid number of CZT'):
-        czt([1, 2, 3], size)
-    with pytest.raises(ValueError, match='Invalid number of CZT'):
-        zoom_fft([1, 2, 3], 0.2, size)
+    assert_allclose(signal.czt(impulse, m=m, w=w, a=a),
+                    signal.czt_points(m=m, w=w, a=a)**-2, rtol=1e-10)

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_czt.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_czt.py
@@ -68,7 +68,7 @@ def _gen_random_signal():
         yield x
 
 
-@testing.with_requires("scipy")
+@testing.with_requires("scipy >= 1.8.0")
 class Test1D:
 
     @pytest.mark.parametrize('func', zf_checks)
@@ -154,7 +154,7 @@ class Test1D:
         return scp.signal.czt(x)
 
 
-@testing.with_requires("scipy")
+@testing.with_requires("scipy >= 1.8.0")
 class TestErrors:
 
     @pytest.mark.parametrize('size', [0, -5, 3.5, 4.0])
@@ -196,7 +196,7 @@ class TestErrors:
             signal.zoom_fft(5, 0.5)
 
 
-@testing.with_requires("scipy")
+@testing.with_requires("scipy >= 1.8.0")
 class TestCZTPoints:
 
     @pytest.mark.parametrize("N", [1, 2, 3, 8, 11, 100, 101, 10007])
@@ -220,7 +220,7 @@ class TestCZTPoints:
                 scp.signal.czt_points(11, w=2))
 
 
-@testing.with_requires("scipy")
+@testing.with_requires("scipy >= 1.8.0")
 @pytest.mark.slow
 def test_czt_vs_fft():
     cupy.random.seed(123)


### PR DESCRIPTION
Adapt code and its tests from scipy.

Heavy lifting is all done in `cupyx.fft`, so the rest is kept in pure python.

cross-ref gh-7403


- [x] czt
- [x] zoom_fft
- [x] CZT
- [x] ZoomFFT
- [x] czt_points