### PR TITLE
Add sosfilt_zi to cupyx.scipy.signal

### DIFF
--- a/cupyx/scipy/signal/__init__.py
+++ b/cupyx/scipy/signal/__init__.py
@@ -16,6 +16,7 @@ from cupyx.scipy.signal._signaltools import lfilter_zi  # NOQA
 from cupyx.scipy.signal._signaltools import detrend  # NOQA
 from cupyx.scipy.signal._signaltools import filtfilt  # NOQA
 from cupyx.scipy.signal._signaltools import sosfilt  # NOQA
+from cupyx.scipy.signal._signaltools import sosfilt_zi  # NOQA
 
 from cupyx.scipy.signal._bsplines import sepfir2d  # NOQA
 

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
@@ -721,6 +721,17 @@ class TestSosFilt:
         out, _ = scp.signal.sosfilt(sos, x, zi=zi, axis=axis)
         return out
 
+    @pytest.mark.parametrize('sections', [1, 2, 3, 4, 5])
+    @testing.numpy_cupy_array_almost_equal(scipy_name='scp', decimal=5)
+    def test_sosfilt_zi(self, sections, xp, scp):
+        x = xp.ones(20)
+        sos = testing.shaped_random((sections, 6), xp, xp.float64, scale=0.2)
+        sos[:, 3] = 1
+
+        zi = scp.signal.sosfilt_zi(sos)
+        out, _ = scp.signal.sosfilt(sos, x, zi=zi)
+        return out
+
 
 @testing.with_requires('scipy')
 class TestDetrend:


### PR DESCRIPTION
See https://github.com/cupy/cupy/issues/7403
Depends on https://github.com/cupy/cupy/pull/7528

This PR is an extension of `lfilter_zi`, which uses the same principle applied to chained second order sections.