### PR TITLE
filter design "prototypes"

### DIFF
--- a/cupyx/scipy/signal/__init__.py
+++ b/cupyx/scipy/signal/__init__.py
@@ -41,3 +41,4 @@ from cupyx.scipy.signal._iir_filter_conversions import lp2bs_zpk  # NOQA
 from cupyx.scipy.signal._iir_filter_conversions import buttap  # NOQA
 from cupyx.scipy.signal._iir_filter_conversions import cheb1ap  # NOQA
 from cupyx.scipy.signal._iir_filter_conversions import cheb2ap  # NOQA
+from cupyx.scipy.signal._iir_filter_conversions import ellipap  # NOQA

--- a/cupyx/scipy/signal/__init__.py
+++ b/cupyx/scipy/signal/__init__.py
@@ -37,3 +37,7 @@ from cupyx.scipy.signal._iir_filter_conversions import lp2lp_zpk  # NOQA
 from cupyx.scipy.signal._iir_filter_conversions import lp2hp_zpk  # NOQA
 from cupyx.scipy.signal._iir_filter_conversions import lp2bp_zpk  # NOQA
 from cupyx.scipy.signal._iir_filter_conversions import lp2bs_zpk  # NOQA
+
+from cupyx.scipy.signal._iir_filter_conversions import buttap  # NOQA
+from cupyx.scipy.signal._iir_filter_conversions import cheb1ap  # NOQA
+from cupyx.scipy.signal._iir_filter_conversions import cheb2ap  # NOQA

--- a/cupyx/scipy/signal/_iir_filter_conversions.py
+++ b/cupyx/scipy/signal/_iir_filter_conversions.py
@@ -1054,12 +1054,9 @@ def _arc_jac_sc1(w, m):
 
     m - modulus
 
-    From [1], sc(z, m) = -i * sn(i * z, 1 - m)
-
-    References
-    ----------
-    .. [1] https://functions.wolfram.com/EllipticFunctions/JacobiSC/introductions/JacobiPQs/ShowAll.html,
-       "Representations through other Jacobi functions"
+    Using that sc(z, m) = -i * sn(i * z, 1 - m)
+    cf scipy/signal/_filter_design.py analog for an explanation
+    and a reference.
 
     """
 

--- a/cupyx/scipy/signal/_iir_filter_conversions.py
+++ b/cupyx/scipy/signal/_iir_filter_conversions.py
@@ -7,6 +7,7 @@ from math import pi
 
 import cupy
 from cupyx.scipy.special import binom as comb
+import cupyx.scipy.special as special
 
 
 class BadCoefficients(UserWarning):
@@ -935,3 +936,39 @@ def cheb2ap(N, rs):
 
     k = (cupy.prod(-p, axis=0) / cupy.prod(-z, axis=0)).real
     return z, p, k
+
+
+# ### Elliptic filter prototype ###
+
+
+def _ellipdeg(n, m1):
+    """Solve degree equation using nomes
+
+    Given n, m1, solve
+       n * K(m) / K'(m) = K1(m1) / K1'(m1)
+    for m
+
+    See [1], Eq. (49)
+
+    References
+    ----------
+    .. [1] Orfanidis, "Lecture Notes on Elliptic Filter Design",
+           https://www.ece.rutgers.edu/~orfanidi/ece521/notes.pdf
+    """
+    # number of terms in solving degree equation
+    _ELLIPDEG_MMAX = 7
+
+    K1 = special.ellipk(m1)
+    K1p = special.ellipkm1(m1)
+
+    q1 = cupy.exp(-pi * K1p / K1)
+    q = q1 ** (1/n)
+
+    mnum = cupy.arange(_ELLIPDEG_MMAX + 1)
+    mden = cupy.arange(1, _ELLIPDEG_MMAX + 2)
+
+    num = (q ** (mnum * (mnum+1))).sum()
+    den = 1 + 2 * (q ** (mden**2)).sum()
+
+    return 16 * q * (num / den) ** 4
+

--- a/cupyx/scipy/signal/_iir_filter_conversions.py
+++ b/cupyx/scipy/signal/_iir_filter_conversions.py
@@ -891,7 +891,7 @@ def cheb1ap(N, rp):
 
     k = cupy.prod(-p, axis=0).real
     if N % 2 == 0:
-        k = k / sqrt(1 + eps * eps)
+        k = k / cupy.sqrt(1 + eps * eps)
 
     return z, p, k
 

--- a/cupyx/scipy/signal/_iir_filter_conversions.py
+++ b/cupyx/scipy/signal/_iir_filter_conversions.py
@@ -3,6 +3,7 @@
 Split off _filter_design.py
 """
 import warnings
+import math
 from math import pi
 
 import cupy
@@ -940,7 +941,7 @@ def cheb2ap(N, rs):
 
 # ### Elliptic filter prototype ###
 
-_POW10_LOG10 = cupy.log(10)
+_POW10_LOG10 = math.log(10)
 
 
 def _pow10m1(x):

--- a/cupyx/scipy/special/__init__.py
+++ b/cupyx/scipy/special/__init__.py
@@ -111,3 +111,7 @@ from cupyx.scipy.special._xlogy import xlogy  # NOQA
 from cupyx.scipy.special._xlogy import xlog1py  # NOQA
 from cupyx.scipy.special._logsumexp import logsumexp  # NOQA
 from cupy._math.special import sinc  # NOQA
+
+# Elliptic functions
+from cupyx.scipy.special._ellip import ellipk  # NOQA
+from cupyx.scipy.special._ellip import ellipkm1  # NOQA

--- a/cupyx/scipy/special/__init__.py
+++ b/cupyx/scipy/special/__init__.py
@@ -115,5 +115,4 @@ from cupy._math.special import sinc  # NOQA
 # Elliptic functions
 from cupyx.scipy.special._ellip import ellipk  # NOQA
 from cupyx.scipy.special._ellip import ellipkm1  # NOQA
-from cupyx.scipy.special._ellip import ellipj  #NOQA
-
+from cupyx.scipy.special._ellip import ellipj  # NOQA

--- a/cupyx/scipy/special/__init__.py
+++ b/cupyx/scipy/special/__init__.py
@@ -115,3 +115,5 @@ from cupy._math.special import sinc  # NOQA
 # Elliptic functions
 from cupyx.scipy.special._ellip import ellipk  # NOQA
 from cupyx.scipy.special._ellip import ellipkm1  # NOQA
+from cupyx.scipy.special._ellip import ellipj  #NOQA
+

--- a/cupyx/scipy/special/_ellip.py
+++ b/cupyx/scipy/special/_ellip.py
@@ -1,0 +1,114 @@
+# This source code contains SciPy's code.
+# https://github.com/scipy/scipy/blob/master/scipy/special/cephes/ellipk.c
+# https://github.com/scipy/scipy/blob/master/scipy/special/cephes/ellipk.pxd
+#
+#
+# Cephes Math Library Release 2.8:  June, 2000
+# Copyright 1984, 1987, 1992, 2000 by Stephen L. Moshier
+
+from cupy import _core
+from cupyx.scipy.special._digamma import polevl_definition
+
+ellpk_definition = """
+#include <cupy/math_constants.h>
+
+__constant__ double P[] = {
+    1.37982864606273237150E-4,
+    2.28025724005875567385E-3,
+    7.97404013220415179367E-3,
+    9.85821379021226008714E-3,
+    6.87489687449949877925E-3,
+    6.18901033637687613229E-3,
+    8.79078273952743772254E-3,
+    1.49380448916805252718E-2,
+    3.08851465246711995998E-2,
+    9.65735902811690126535E-2,
+    1.38629436111989062502E0
+};
+
+__constant__ double Q[] = {
+    2.94078955048598507511E-5,
+    9.14184723865917226571E-4,
+    5.94058303753167793257E-3,
+    1.54850516649762399335E-2,
+    2.39089602715924892727E-2,
+    3.01204715227604046988E-2,
+    3.73774314173823228969E-2,
+    4.88280347570998239232E-2,
+    7.03124996963957469739E-2,
+    1.24999999999870820058E-1,
+    4.99999999999999999821E-1
+};
+
+__constant__ double C1 = 1.3862943611198906188E0;	/* log(4) */
+
+
+static __device__ double ellpk(double x)
+{
+    double MACHEP = 1.11022302462515654042E-16;	/* 2**-53 */
+
+
+    if (x < 0.0) {
+        return (CUDART_NAN);
+    }
+
+    if (x > 1.0) {
+        if (isinf(x)) {
+            return 0.0;
+        }
+        return ellpk(1/x)/sqrt(x);
+    }
+
+    if (x > MACHEP) {
+        return (polevl<10>(x, P) - log(x) * polevl<10>(x, Q));
+    }
+    else {
+        if (x == 0.0) {
+            return (CUDART_INF);
+        }
+        else {
+            return (C1 - 0.5 * log(x));
+        }
+    }
+}
+
+
+static __device__ double ellpkm1(double x)
+{
+    return ellpk(1 - x);
+}
+
+"""
+
+ellipkm1 = _core.create_ufunc(
+    'cupyx_scipy_special_ellipkm1', ('d->d',),
+    'out0 = ellpk(in0)',
+    preamble=polevl_definition+ellpk_definition,
+    doc="""ellpkm1.
+
+    Args:
+        x (cupy.ndarray): The input of digamma function.
+
+    Returns:
+        cupy.ndarray: Computed value of digamma function.
+
+    .. seealso:: :data:`scipy.special.digamma`
+
+    """)
+
+
+ellipk = _core.create_ufunc(
+    'cupyx_scipy_special_ellipkm1', ('d->d',),
+    'out0 = ellpkm1(in0)',
+    preamble=polevl_definition+ellpk_definition,
+    doc="""ellpk.
+
+    Args:
+        x (cupy.ndarray): The input of digamma function.
+
+    Returns:
+        cupy.ndarray: Computed value of digamma function.
+
+    .. seealso:: :data:`scipy.special.digamma`
+
+    """)

--- a/cupyx/scipy/special/_ellip.py
+++ b/cupyx/scipy/special/_ellip.py
@@ -119,7 +119,8 @@ ellipj_preamble = """
 
 __constant__ double M_PI_2 = 1.57079632679489661923;
 
-static __device__ double ellipj(double u, double m, double* sn, double* cn, double *dn, double *ph)
+static __device__ double ellipj(double u, double m, double* sn,
+                                double* cn, double *dn, double *ph)
 {
 
     double MACHEP = 1.11022302462515654042E-16;	/* 2**-53 */

--- a/cupyx/scipy/special/_ellip.py
+++ b/cupyx/scipy/special/_ellip.py
@@ -81,7 +81,8 @@ static __device__ double ellpkm1(double x)
 """
 
 ellipkm1 = _core.create_ufunc(
-    'cupyx_scipy_special_ellipkm1', ('d->d',),
+    'cupyx_scipy_special_ellipk',
+    ('f->f', 'd->d'),
     'out0 = ellpk(in0)',
     preamble=polevl_definition+ellpk_definition,
     doc="""ellpkm1.
@@ -98,7 +99,8 @@ ellipkm1 = _core.create_ufunc(
 
 
 ellipk = _core.create_ufunc(
-    'cupyx_scipy_special_ellipkm1', ('d->d',),
+    'cupyx_scipy_special_ellipkm1',
+    ("f->f", "d->d"),
     'out0 = ellpkm1(in0)',
     preamble=polevl_definition+ellpk_definition,
     doc="""ellpk.
@@ -211,7 +213,7 @@ static __device__ double ellipj(double u, double m, double* sn,
 
 ellipj = _core.create_ufunc(
     'cupyx_scipy_special_ellipj',
-    ('dd->dddd',),
+    ('ff->ffff', 'dd->dddd'),
     '''
         double sn, cn, dn, ph; ellipj(in0, in1, &sn, &cn, &dn, &ph);
         out0 = sn; out1 = cn; out2 = dn; out3 = ph;

--- a/cupyx/scipy/special/_ellip.py
+++ b/cupyx/scipy/special/_ellip.py
@@ -114,7 +114,7 @@ ellipk = _core.create_ufunc(
     """)
 
 
-ellipj_preamble="""
+ellipj_preamble = """
 #include <cupy/math_constants.h>
 
 __constant__ double M_PI_2 = 1.57079632679489661923;

--- a/docs/source/reference/scipy_special.rst
+++ b/docs/source/reference/scipy_special.rst
@@ -104,6 +104,13 @@ Gamma and related functions
    poch
 
 
+Elliptic integrals
+------------------
+
+   ellipk
+   ellipkm1
+
+
 Error function and Fresnel integrals
 ------------------------------------
 

--- a/docs/source/reference/scipy_special.rst
+++ b/docs/source/reference/scipy_special.rst
@@ -109,6 +109,7 @@ Elliptic integrals
 
    ellipk
    ellipkm1
+   ellipj
 
 
 Error function and Fresnel integrals

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_iir_filter_conversion.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_iir_filter_conversion.py
@@ -252,5 +252,3 @@ class TestLowLevelAP:
     @testing.numpy_cupy_allclose(scipy_name="scp")
     def test_cheb2ap(self, xp, scp):
         return scp.signal.cheb2ap(3, 1)
-
-

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_iir_filter_conversion.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_iir_filter_conversion.py
@@ -253,6 +253,6 @@ class TestLowLevelAP:
     def test_cheb2ap(self, xp, scp):
         return scp.signal.cheb2ap(3, 1)
 
-    @testing.numpy_cupy_allclose(scipy_name="scp", atol=1e-5, rtol=1e-5)
+    @testing.numpy_cupy_allclose(scipy_name="scp", atol=3e-5, rtol=3e-5)
     def test_ellipap(self, xp, scp):
         return scp.signal.ellipap(7, 1, 10)

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_iir_filter_conversion.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_iir_filter_conversion.py
@@ -253,6 +253,6 @@ class TestLowLevelAP:
     def test_cheb2ap(self, xp, scp):
         return scp.signal.cheb2ap(3, 1)
 
-    @testing.numpy_cupy_allclose(scipy_name="scp")
+    @testing.numpy_cupy_allclose(scipy_name="scp", atol=1e-5, rtol=1e-5)
     def test_ellipap(self, xp, scp):
         return scp.signal.ellipap(7, 1, 10)

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_iir_filter_conversion.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_iir_filter_conversion.py
@@ -253,6 +253,6 @@ class TestLowLevelAP:
     def test_cheb2ap(self, xp, scp):
         return scp.signal.cheb2ap(3, 1)
 
-    @testing.numpy_cupy_allclose(scipy_name="scp", atol=3e-5, rtol=3e-5)
+    @testing.numpy_cupy_allclose(scipy_name="scp", atol=2e-4, rtol=2e-4)
     def test_ellipap(self, xp, scp):
         return scp.signal.ellipap(7, 1, 10)

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_iir_filter_conversion.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_iir_filter_conversion.py
@@ -237,3 +237,20 @@ class TestLp2bs_zpk:
         z_bs_s = z_bs[xp.argsort(z_bs.imag)]
         p_bs_s = p_bs[xp.argsort(p_bs.imag)]
         return z_bs_s, p_bs_s, k_bs
+
+
+@testing.with_requires("scipy")
+class TestLowLevelAP:
+    @testing.numpy_cupy_allclose(scipy_name="scp")
+    def test_buttap(self, xp, scp):
+        return scp.signal.buttap(3)
+
+    @testing.numpy_cupy_allclose(scipy_name="scp")
+    def test_cheb1ap(self, xp, scp):
+        return scp.signal.cheb1ap(3, 1)
+
+    @testing.numpy_cupy_allclose(scipy_name="scp")
+    def test_cheb2ap(self, xp, scp):
+        return scp.signal.cheb2ap(3, 1)
+
+

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_iir_filter_conversion.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_iir_filter_conversion.py
@@ -252,3 +252,7 @@ class TestLowLevelAP:
     @testing.numpy_cupy_allclose(scipy_name="scp")
     def test_cheb2ap(self, xp, scp):
         return scp.signal.cheb2ap(3, 1)
+
+    @testing.numpy_cupy_allclose(scipy_name="scp")
+    def test_ellipap(self, xp, scp):
+        return scp.signal.ellipap(7, 1, 10)

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_ellipk.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_ellipk.py
@@ -29,4 +29,3 @@ class TestEllipj:
     def test_basic(self, xp, scp):
         el = scp.special.ellipj(0.2, 0)
         return el
-

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_ellipk.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_ellipk.py
@@ -1,0 +1,23 @@
+import numpy
+import pytest
+
+import cupy
+from cupy import testing
+
+try:
+    import cupyx.scipy.special
+except ImportError:
+    pass
+
+
+@testing.with_requires('scipy')
+class TestEllipk:
+    @testing.numpy_cupy_allclose(scipy_name="scp", rtol=1e-15)
+    def test_basic_ellipk(self, xp, scp):
+        x = xp.linspace(1e-14, 1, 101)
+        return scp.special.ellipk(x)
+
+    @testing.numpy_cupy_allclose(scipy_name="scp", rtol=1e-15)
+    def test_basic_ellipkm1(self, xp, scp):
+        x = xp.linspace(1e-14, 1, 101)
+        return scp.special.ellipkm1(1./x)

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_ellipk.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_ellipk.py
@@ -1,11 +1,7 @@
-import numpy
-import pytest
-
-import cupy
 from cupy import testing
 
 try:
-    import cupyx.scipy.special
+    import cupyx.scipy.special    # NOQA
 except ImportError:
     pass
 

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_ellipk.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_ellipk.py
@@ -21,3 +21,12 @@ class TestEllipk:
     def test_basic_ellipkm1(self, xp, scp):
         x = xp.linspace(1e-14, 1, 101)
         return scp.special.ellipkm1(1./x)
+
+
+@testing.with_requires('scipy')
+class TestEllipj:
+    @testing.numpy_cupy_allclose(scipy_name="scp", rtol=1e-13)
+    def test_basic(self, xp, scp):
+        el = scp.special.ellipj(0.2, 0)
+        return el
+


### PR DESCRIPTION
- [x] `buttap`
- [x] `cheb1ap`
- [x] `cheb2ap`
- [x] `ellipap` --- requires elliptic integrals, so add them to `cupyx.scipy.special`
- [ ] `besselap` -- will do in a follow-up PR


cupyx/scipy/special
- [x] `ellipk`
- [x] `ellipkm1`
- [x] `ellipj` 

