### PR TITLE
Port lombscargle from CuSignal to cupyx.scipy.signal

### DIFF
--- a/cupyx/scipy/signal/__init__.py
+++ b/cupyx/scipy/signal/__init__.py
@@ -129,3 +129,5 @@ from cupyx.scipy.signal._ltisys import TransferFunction  # NOQA
 from cupyx.scipy.signal._ltisys import ZerosPolesGain  # NOQA
 
 from cupyx.scipy.signal._ltisys import cont2discrete  # NOQA
+
+from cupyx.scipy.signal._spectral import lombscargle  # NOQA

--- a/cupyx/scipy/signal/_spectral.py
+++ b/cupyx/scipy/signal/_spectral.py
@@ -1,0 +1,101 @@
+
+import cupy
+from cupyx.scipy.signal._spectral_impl import _lombscargle
+
+
+def lombscargle(x, y, freqs, precenter=False, normalize=False):
+    """
+    lombscargle(x, y, freqs)
+
+    Computes the Lomb-Scargle periodogram.
+
+    The Lomb-Scargle periodogram was developed by Lomb [1]_ and further
+    extended by Scargle [2]_ to find, and test the significance of weak
+    periodic signals with uneven temporal sampling.
+
+    When *normalize* is False (default) the computed periodogram
+    is unnormalized, it takes the value ``(A**2) * N/4`` for a harmonic
+    signal with amplitude A for sufficiently large N.
+
+    When *normalize* is True the computed periodogram is normalized by
+    the residuals of the data around a constant reference model (at zero).
+
+    Input arrays should be one-dimensional and will be cast to float64.
+
+    Parameters
+    ----------
+    x : array_like
+        Sample times.
+    y : array_like
+        Measurement values.
+    freqs : array_like
+        Angular frequencies for output periodogram.
+    precenter : bool, optional
+        Pre-center amplitudes by subtracting the mean.
+    normalize : bool, optional
+        Compute normalized periodogram.
+
+    Returns
+    -------
+    pgram : array_like
+        Lomb-Scargle periodogram.
+
+    Raises
+    ------
+    ValueError
+        If the input arrays `x` and `y` do not have the same shape.
+
+    Notes
+    -----
+    This subroutine calculates the periodogram using a slightly
+    modified algorithm due to Townsend [3]_ which allows the
+    periodogram to be calculated using only a single pass through
+    the input arrays for each frequency.
+    The algorithm running time scales roughly as O(x * freqs) or O(N^2)
+    for a large number of samples and frequencies.
+
+    References
+    ----------
+    .. [1] N.R. Lomb "Least-squares frequency analysis of unequally spaced
+           data", Astrophysics and Space Science, vol 39, pp. 447-462, 1976
+    .. [2] J.D. Scargle "Studies in astronomical time series analysis. II -
+           Statistical aspects of spectral analysis of unevenly spaced data",
+           The Astrophysical Journal, vol 263, pp. 835-853, 1982
+    .. [3] R.H.D. Townsend, "Fast calculation of the Lomb-Scargle
+           periodogram using graphics processing units.", The Astrophysical
+           Journal Supplement Series, vol 191, pp. 247-253, 2010
+
+    See Also
+    --------
+    istft: Inverse Short Time Fourier Transform
+    check_COLA: Check whether the Constant OverLap Add (COLA) constraint is met
+    welch: Power spectral density by Welch's method
+    spectrogram: Spectrogram by Welch's method
+    csd: Cross spectral density by Welch's method
+    """
+
+    x = cupy.asarray(x, dtype=cupy.float64)
+    y = cupy.asarray(y, dtype=cupy.float64)
+    freqs = cupy.asarray(freqs, dtype=cupy.float64)
+    pgram = cupy.empty(freqs.shape[0], dtype=cupy.float64)
+
+    assert x.ndim == 1
+    assert y.ndim == 1
+    assert freqs.ndim == 1
+
+    # Check input sizes
+    if x.shape[0] != y.shape[0]:
+        raise ValueError("Input arrays do not have the same size.")
+
+    y_dot = cupy.zeros(1, dtype=cupy.float64)
+    if normalize:
+        cupy.dot(y, y, out=y_dot)
+
+    if precenter:
+        y_in = y - y.mean()
+    else:
+        y_in = y
+
+    _lombscargle(x, y_in, freqs, pgram, y_dot)
+
+    return pgram

--- a/cupyx/scipy/signal/_spectral_impl.py
+++ b/cupyx/scipy/signal/_spectral_impl.py
@@ -1,0 +1,205 @@
+"""
+Spectral analysis functions and utilities.
+
+Some of the functions defined here were ported directly from CuSignal under
+terms of the Apache license, under the following notice
+
+Copyright (c) 2019-2020, NVIDIA CORPORATION.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import cupy
+
+from cupy_backends.cuda.api import runtime
+
+
+def _get_raw_typename(dtype):
+    return cupy.dtype(dtype).name
+
+
+def _get_module_func_raw(module, func_name, *template_args):
+    args_dtypes = [_get_raw_typename(arg.dtype) for arg in template_args]
+    template = '_'.join(args_dtypes)
+    kernel_name = f'{func_name}_{template}' if template_args else func_name
+    kernel = module.get_function(kernel_name)
+    return kernel
+
+
+if runtime.is_hip:
+    KERNEL_BASE = r"""
+    #include <hip/hip_runtime.h>
+"""
+else:
+    KERNEL_BASE = r"""
+#include <cuda_runtime.h>
+#include <device_launch_parameters.h>
+"""
+
+LOMBSCARGLE_KERNEL = KERNEL_BASE + r"""
+
+///////////////////////////////////////////////////////////////////////////////
+//                            LOMBSCARGLE                                    //
+///////////////////////////////////////////////////////////////////////////////
+
+template<typename T>
+__device__ void _cupy_lombscargle_float( const int x_shape,
+                                         const int freqs_shape,
+                                         const T *__restrict__ x,
+                                         const T *__restrict__ y,
+                                         const T *__restrict__ freqs,
+                                         T *__restrict__ pgram,
+                                         const T *__restrict__ y_dot ) {
+
+    const int tx { static_cast<int>( blockIdx.x * blockDim.x + threadIdx.x ) };
+    const int stride { static_cast<int>( blockDim.x * gridDim.x ) };
+
+    T yD {};
+    if ( y_dot[0] == 0 ) {
+        yD = 1.0f;
+    } else {
+        yD = 2.0f / y_dot[0];
+    }
+
+    for ( int tid = tx; tid < freqs_shape; tid += stride ) {
+
+        T freq { freqs[tid] };
+
+        T xc {};
+        T xs {};
+        T cc {};
+        T ss {};
+        T cs {};
+        T c {};
+        T s {};
+
+        for ( int j = 0; j < x_shape; j++ ) {
+            sincosf( freq * x[j], &s, &c );
+            xc += y[j] * c;
+            xs += y[j] * s;
+            cc += c * c;
+            ss += s * s;
+            cs += c * s;
+        }
+
+        T c_tau {};
+        T s_tau {};
+        T tau { atan2f( 2.0f * cs, cc - ss ) / ( 2.0f * freq ) };
+        sincosf( freq * tau, &s_tau, &c_tau );
+        T c_tau2 { c_tau * c_tau };
+        T s_tau2 { s_tau * s_tau };
+        T cs_tau { 2.0f * c_tau * s_tau };
+
+        pgram[tid] = ( 0.5f * ( ( ( c_tau * xc + s_tau * xs ) *
+                                  ( c_tau * xc + s_tau * xs ) /
+                                  ( c_tau2 * cc + cs_tau * cs + s_tau2 * ss ) ) +
+                                ( ( c_tau * xs - s_tau * xc ) *
+                                  ( c_tau * xs - s_tau * xc ) /
+                                  ( c_tau2 * ss - cs_tau * cs + s_tau2 * cc ) ) ) ) *
+                     yD;
+    }
+}
+
+extern "C" __global__ void __launch_bounds__( 512 ) _cupy_lombscargle_float32(
+        const int x_shape, const int freqs_shape, const float *__restrict__ x,
+        const float *__restrict__ y, const float *__restrict__ freqs,
+        float *__restrict__ pgram, const float *__restrict__ y_dot ) {
+    _cupy_lombscargle_float<float>( x_shape, freqs_shape, x, y,
+                                    freqs, pgram, y_dot );
+}
+
+template<typename T>
+__device__ void _cupy_lombscargle_double( const int x_shape,
+                                          const int freqs_shape,
+                                          const T *__restrict__ x,
+                                          const T *__restrict__ y,
+                                          const T *__restrict__ freqs,
+                                          T *__restrict__ pgram,
+                                          const T *__restrict__ y_dot ) {
+
+    const int tx { static_cast<int>( blockIdx.x * blockDim.x + threadIdx.x ) };
+    const int stride { static_cast<int>( blockDim.x * gridDim.x ) };
+
+    T yD {};
+    if ( y_dot[0] == 0 ) {
+        yD = 1.0;
+    } else {
+        yD = 2.0 / y_dot[0];
+    }
+
+    for ( int tid = tx; tid < freqs_shape; tid += stride ) {
+
+        T freq { freqs[tid] };
+
+        T xc {};
+        T xs {};
+        T cc {};
+        T ss {};
+        T cs {};
+        T c {};
+        T s {};
+
+        for ( int j = 0; j < x_shape; j++ ) {
+
+            sincos( freq * x[j], &s, &c );
+            xc += y[j] * c;
+            xs += y[j] * s;
+            cc += c * c;
+            ss += s * s;
+            cs += c * s;
+        }
+
+        T c_tau {};
+        T s_tau {};
+        T tau { atan2( 2.0 * cs, cc - ss ) / ( 2.0 * freq ) };
+        sincos( freq * tau, &s_tau, &c_tau );
+        T c_tau2 { c_tau * c_tau };
+        T s_tau2 { s_tau * s_tau };
+        T cs_tau { 2.0 * c_tau * s_tau };
+
+        pgram[tid] = ( 0.5 * ( ( ( c_tau * xc + s_tau * xs ) *
+                                 ( c_tau * xc + s_tau * xs ) /
+                                 ( c_tau2 * cc + cs_tau * cs + s_tau2 * ss ) ) +
+                               ( ( c_tau * xs - s_tau * xc ) *
+                                 ( c_tau * xs - s_tau * xc ) /
+                                 ( c_tau2 * ss - cs_tau * cs + s_tau2 * cc ) ) ) ) *
+                     yD;
+    }
+}
+
+extern "C" __global__ void __launch_bounds__( 512 ) _cupy_lombscargle_float64(
+        const int x_shape, const int freqs_shape, const double *__restrict__ x,
+        const double *__restrict__ y, const double *__restrict__ freqs,
+        double *__restrict__ pgram, const double *__restrict__ y_dot ) {
+
+    _cupy_lombscargle_double<double>( x_shape, freqs_shape, x, y, freqs,
+                                      pgram, y_dot );
+}
+"""  # NOQA
+
+
+LOMBSCARGLE_MODULE = cupy.RawModule(
+    code=LOMBSCARGLE_KERNEL, options=('-std=c++11',),
+    name_expressions=['_cupy_lombscargle_float32',
+                      '_cupy_lombscargle_float64'])
+
+
+def _lombscargle(x, y, freqs, pgram, y_dot):
+    device_id = cupy.cuda.Device()
+
+    num_blocks = device_id.attributes["MultiProcessorCount"] * 20
+    block_sz = 512
+    lombscargle_kernel = _get_module_func_raw(
+        LOMBSCARGLE_KERNEL, '_cupy_lombscargle')
+
+    args = (x.shape[0], freqs.shape[0], x, y, freqs, pgram, y_dot)
+    lombscargle_kernel((num_blocks,)(block_sz,), args)

--- a/cupyx/scipy/signal/_spectral_impl.py
+++ b/cupyx/scipy/signal/_spectral_impl.py
@@ -199,7 +199,7 @@ def _lombscargle(x, y, freqs, pgram, y_dot):
     num_blocks = device_id.attributes["MultiProcessorCount"] * 20
     block_sz = 512
     lombscargle_kernel = _get_module_func_raw(
-        LOMBSCARGLE_KERNEL, '_cupy_lombscargle')
+        LOMBSCARGLE_MODULE, '_cupy_lombscargle', x)
 
     args = (x.shape[0], freqs.shape[0], x, y, freqs, pgram, y_dot)
-    lombscargle_kernel((num_blocks,)(block_sz,), args)
+    lombscargle_kernel((num_blocks,), (block_sz,), args)

--- a/cupyx/scipy/signal/_spectral_impl.py
+++ b/cupyx/scipy/signal/_spectral_impl.py
@@ -2,20 +2,27 @@
 Spectral analysis functions and utilities.
 
 Some of the functions defined here were ported directly from CuSignal under
-terms of the Apache license, under the following notice
+terms of the MIT license, under the following notice:
 
-Copyright (c) 2019-2020, NVIDIA CORPORATION.
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+Copyright (c) 2019-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
-    http://www.apache.org/licenses/LICENSE-2.0
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
 """
 
 import cupy

--- a/docs/source/reference/scipy_signal.rst
+++ b/docs/source/reference/scipy_signal.rst
@@ -191,3 +191,12 @@ Peak finding
    find_peaks
    peak_prominences
    peak_widths
+
+
+Spectral analysis
+-----------------
+
+.. autosummary::
+   :toctree: generated/
+
+   lombscargle

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_spectral.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_spectral.py
@@ -1,0 +1,148 @@
+
+import pytest
+
+import numpy as np
+
+from cupy.cuda import driver
+from cupy.cuda import runtime
+from cupy import testing
+import cupyx.scipy.signal  # NOQA
+
+try:
+    import scipy.signal  # NOQA
+except ImportError:
+    pass
+
+
+@pytest.mark.xfail(
+    runtime.is_hip and driver.get_build_version() < 5_00_00000,
+    reason='name_expressions with ROCm 4.3 may not work')
+@testing.with_requires('scipy')
+class TestLombscargle:
+    @pytest.mark.parametrize('dtype', ['float32', 'float64'])
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_frequency(self, dtype, xp, scp):
+        """Test if frequency locations of peak corresponds to frequency of
+        generated input signal.
+        """
+        dtype = xp.dtype(dtype)
+
+        # Input parameters
+        ampl = 2.
+        w = 1.
+        phi = 0.5 * xp.pi
+        nin = 100
+        nout = 1000
+        p = 0.7  # Fraction of points to select
+
+        # Randomly select a fraction of an array with timesteps
+        r = testing.shaped_random((nin,), xp, scale=1.0,
+                                  dtype=dtype, seed=2353425)
+        t = xp.linspace(0.01 * xp.pi, 10. * xp.pi, nin, dtype=dtype)[r >= p]
+
+        # Plot a sine wave for the selected times
+        x = ampl * np.sin(w*t + phi)
+
+        # Define the array of frequencies for which to compute the periodogram
+        f = np.linspace(0.01, 10., nout, dtype=dtype)
+
+        # Calculate Lomb-Scargle periodogram
+        P = scp.signal.lombscargle(t, x, f)
+        return P
+
+    @pytest.mark.parametrize('dtype', ['float32', 'float64'])
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_amplitude(self, dtype, xp, scp):
+        # Test if height of peak in normalized Lomb-Scargle periodogram
+        # corresponds to amplitude of the generated input signal.
+        dtype = xp.dtype(dtype)
+
+        # Input parameters
+        ampl = 2.
+        w = 1.
+        phi = 0.5 * xp.pi
+        nin = 100
+        nout = 1000
+        p = 0.7  # Fraction of points to select
+
+        # Randomly select a fraction of an array with timesteps
+        r = testing.shaped_random((nin,), xp, dtype=dtype, scale=1.0,
+                                  seed=2353425)
+        t = xp.linspace(0.01 * xp.pi, 10. * xp.pi, nin, dtype=dtype)[r >= p]
+
+        # Plot a sine wave for the selected times
+        x = ampl * xp.sin(w * t + phi)
+
+        # Define the array of frequencies for which to compute the periodogram
+        f = xp.linspace(0.01, 10., nout, dtype=dtype)
+
+        # Calculate Lomb-Scargle periodogram
+        pgram = scp.signal.lombscargle(t, x, f)
+
+        # Normalize
+        pgram = xp.sqrt(4 * pgram / t.shape[0])
+        return pgram
+
+    @pytest.mark.parametrize('dtype', ['float32', 'float64'])
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_precenter(self, dtype, xp, scp):
+        # Test if precenter gives the same result as manually precentering.
+        dtype = xp.dtype(dtype)
+
+        # Input parameters
+        ampl = 2.
+        w = 1.
+        phi = 0.5 * xp.pi
+        nin = 100
+        nout = 1000
+        p = 0.7  # Fraction of points to select
+        offset = 0.15  # Offset to be subtracted in pre-centering
+
+        # Randomly select a fraction of an array with timesteps
+        r = testing.shaped_random((nin,), xp, dtype=dtype, scale=1.0,
+                                  seed=2353425)
+        t = xp.linspace(0.01 * xp.pi, 10. * xp.pi, nin, dtype=dtype)[r >= p]
+
+        # Plot a sine wave for the selected times
+        x = ampl * xp.sin(w * t + phi) + offset
+
+        # Define the array of frequencies for which to compute the periodogram
+        f = xp.linspace(0.01, 10., nout, dtype=dtype)
+
+        # Calculate Lomb-Scargle periodogram
+        pgram = scp.signal.lombscargle(t, x, f, precenter=True)
+        pgram2 = scp.signal.lombscargle(t, x - x.mean(), f, precenter=False)
+
+        # check if centering worked
+        return pgram, pgram2
+
+    @pytest.mark.parametrize('dtype', ['float32', 'float64'])
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_normalize(self, dtype, xp, scp):
+        # Test normalize option of Lomb-Scarge.
+
+        # Input parameters
+        ampl = 2.
+        w = 1.
+        phi = 0.5 * xp.pi
+        nin = 100
+        nout = 1000
+        p = 0.7  # Fraction of points to select
+
+        # Randomly select a fraction of an array with timesteps
+        r = testing.shaped_random((nin,), xp, dtype=dtype, scale=1.0,
+                                  seed=2353425)
+        t = xp.linspace(0.01 * xp.pi, 10. * xp.pi, nin)[r >= p]
+
+        # Plot a sine wave for the selected times
+        x = ampl * xp.sin(w * t + phi)
+
+        # Define the array of frequencies for which to compute the periodogram
+        f = xp.linspace(0.01, 10., nout, dtype=dtype)
+
+        # Calculate Lomb-Scargle periodogram
+        pgram = scp.signal.lombscargle(t, x, f)
+        pgram2 = scp.signal.lombscargle(t, x, f, normalize=True)
+
+        # check if normalization works as expected
+        return pgram, pgram2


### PR DESCRIPTION
See https://github.com/cupy/cupy/issues/7403

This is the first spectral analysis function ported from CuSignal, the port was 1:1, there was no need to introduce additional changes, since the kernel already worked from CuPy