### PR TITLE
Port periodogram, welch and csd from CuSignal to cupyx.signal

### DIFF
--- a/cupyx/scipy/signal/__init__.py
+++ b/cupyx/scipy/signal/__init__.py
@@ -135,6 +135,7 @@ from cupyx.scipy.signal._ltisys import cont2discrete  # NOQA
 from cupyx.scipy.signal._spectral import lombscargle  # NOQA
 from cupyx.scipy.signal._spectral import periodogram  # NOQA
 from cupyx.scipy.signal._spectral import welch  # NOQA
+from cupyx.scipy.signal._spectral import csd  # NOQA
 
 from cupyx.scipy.signal._peak_finding import argrelextrema  # NOQA
 from cupyx.scipy.signal._peak_finding import argrelmin  # NOQA

--- a/cupyx/scipy/signal/__init__.py
+++ b/cupyx/scipy/signal/__init__.py
@@ -134,6 +134,7 @@ from cupyx.scipy.signal._ltisys import cont2discrete  # NOQA
 
 from cupyx.scipy.signal._spectral import lombscargle  # NOQA
 from cupyx.scipy.signal._spectral import periodogram  # NOQA
+from cupyx.scipy.signal._spectral import welch  # NOQA
 
 from cupyx.scipy.signal._peak_finding import argrelextrema  # NOQA
 from cupyx.scipy.signal._peak_finding import argrelmin  # NOQA

--- a/cupyx/scipy/signal/__init__.py
+++ b/cupyx/scipy/signal/__init__.py
@@ -133,6 +133,7 @@ from cupyx.scipy.signal._ltisys import ZerosPolesGain  # NOQA
 from cupyx.scipy.signal._ltisys import cont2discrete  # NOQA
 
 from cupyx.scipy.signal._spectral import lombscargle  # NOQA
+from cupyx.scipy.signal._spectral import periodogram  # NOQA
 
 from cupyx.scipy.signal._peak_finding import argrelextrema  # NOQA
 from cupyx.scipy.signal._peak_finding import argrelmin  # NOQA

--- a/cupyx/scipy/signal/_arraytools.py
+++ b/cupyx/scipy/signal/_arraytools.py
@@ -238,3 +238,35 @@ def zero_ext(x, n, axis=-1):
     zeros = cupy.zeros(zeros_shape, dtype=x.dtype)
     ext = cupy.concatenate((zeros, x, zeros), axis=axis)
     return ext
+
+
+def _as_strided(x, shape=None, strides=None):
+    """
+    Create a view into the array with the given shape and strides.
+    .. warning:: This function has to be used with extreme care, see notes.
+
+    Parameters
+    ----------
+    x : ndarray
+        Array to create a new.
+    shape : sequence of int, optional
+        The shape of the new array. Defaults to ``x.shape``.
+    strides : sequence of int, optional
+        The strides of the new array. Defaults to ``x.strides``.
+
+    Returns
+    -------
+    view : ndarray
+
+    Notes
+    -----
+    ``as_strided`` creates a view into the array given the exact strides
+    and shape. This means it manipulates the internal data structure of
+    ndarray and, if done incorrectly, the array elements can point to
+    invalid memory and can corrupt results or crash your program.
+    """
+    shape = x.shape if shape is None else tuple(shape)
+    strides = x.strides if strides is None else tuple(strides)
+
+    return cupy.ndarray(
+        shape=shape, dtype=x.dtype, memptr=x.data, strides=strides)

--- a/cupyx/scipy/signal/_spectral.py
+++ b/cupyx/scipy/signal/_spectral.py
@@ -99,3 +99,358 @@ def lombscargle(x, y, freqs, precenter=False, normalize=False):
     _lombscargle(x, y_in, freqs, pgram, y_dot)
 
     return pgram
+
+
+def periodogram(
+    x,
+    fs=1.0,
+    window="boxcar",
+    nfft=None,
+    detrend="constant",
+    return_onesided=True,
+    scaling="density",
+    axis=-1,
+):
+    """
+    Estimate power spectral density using a periodogram.
+
+    Parameters
+    ----------
+    x : array_like
+        Time series of measurement values
+    fs : float, optional
+        Sampling frequency of the `x` time series. Defaults to 1.0.
+    window : str or tuple or array_like, optional
+        Desired window to use. If `window` is a string or tuple, it is
+        passed to `get_window` to generate the window values, which are
+        DFT-even by default. See `get_window` for a list of windows and
+        required parameters. If `window` is array_like it will be used
+        directly as the window and its length must be nperseg. Defaults
+        to 'boxcar'.
+    nfft : int, optional
+        Length of the FFT used. If `None` the length of `x` will be
+        used.
+    detrend : str or function or `False`, optional
+        Specifies how to detrend each segment. If `detrend` is a
+        string, it is passed as the `type` argument to the `detrend`
+        function. If it is a function, it takes a segment and returns a
+        detrended segment. If `detrend` is `False`, no detrending is
+        done. Defaults to 'constant'.
+    return_onesided : bool, optional
+        If `True`, return a one-sided spectrum for real data. If
+        `False` return a two-sided spectrum. Defaults to `True`, but for
+        complex data, a two-sided spectrum is always returned.
+    scaling : { 'density', 'spectrum' }, optional
+        Selects between computing the power spectral density ('density')
+        where `Pxx` has units of V**2/Hz and computing the power
+        spectrum ('spectrum') where `Pxx` has units of V**2, if `x`
+        is measured in V and `fs` is measured in Hz. Defaults to
+        'density'
+    axis : int, optional
+        Axis along which the periodogram is computed; the default is
+        over the last axis (i.e. ``axis=-1``).
+
+    Returns
+    -------
+    f : ndarray
+        Array of sample frequencies.
+    Pxx : ndarray
+        Power spectral density or power spectrum of `x`.
+
+    See Also
+    --------
+    welch: Estimate power spectral density using Welch's method
+    lombscargle: Lomb-Scargle periodogram for unevenly sampled data
+    """
+    x = cupy.asarray(x)
+
+    if x.size == 0:
+        return cupy.empty(x.shape), cupy.empty(x.shape)
+
+    if window is None:
+        window = "boxcar"
+
+    if nfft is None:
+        nperseg = x.shape[axis]
+    elif nfft == x.shape[axis]:
+        nperseg = nfft
+    elif nfft > x.shape[axis]:
+        nperseg = x.shape[axis]
+    elif nfft < x.shape[axis]:
+        # cp.s_ not implemented
+        s = [cupy.s_[:]] * len(x.shape)
+        s[axis] = cupy.s_[:nfft]
+        x = cupy.asarray(x[tuple(s)])
+        nperseg = nfft
+        nfft = None
+
+    return welch(
+        x,
+        fs=fs,
+        window=window,
+        nperseg=nperseg,
+        noverlap=0,
+        nfft=nfft,
+        detrend=detrend,
+        return_onesided=return_onesided,
+        scaling=scaling,
+        axis=axis,
+    )
+
+
+def welch(
+    x,
+    fs=1.0,
+    window="hann",
+    nperseg=None,
+    noverlap=None,
+    nfft=None,
+    detrend="constant",
+    return_onesided=True,
+    scaling="density",
+    axis=-1,
+    average="mean",
+):
+    r"""
+    Estimate power spectral density using Welch's method.
+
+    Welch's method [1]_ computes an estimate of the power spectral
+    density by dividing the data into overlapping segments, computing a
+    modified periodogram for each segment and averaging the
+    periodograms.
+
+    Parameters
+    ----------
+    x : array_like
+        Time series of measurement values
+    fs : float, optional
+        Sampling frequency of the `x` time series. Defaults to 1.0.
+    window : str or tuple or array_like, optional
+        Desired window to use. If `window` is a string or tuple, it is
+        passed to `get_window` to generate the window values, which are
+        DFT-even by default. See `get_window` for a list of windows and
+        required parameters. If `window` is array_like it will be used
+        directly as the window and its length must be nperseg. Defaults
+        to a Hann window.
+    nperseg : int, optional
+        Length of each segment. Defaults to None, but if window is str or
+        tuple, is set to 256, and if window is array_like, is set to the
+        length of the window.
+    noverlap : int, optional
+        Number of points to overlap between segments. If `None`,
+        ``noverlap = nperseg // 2``. Defaults to `None`.
+    nfft : int, optional
+        Length of the FFT used, if a zero padded FFT is desired. If
+        `None`, the FFT length is `nperseg`. Defaults to `None`.
+    detrend : str or function or `False`, optional
+        Specifies how to detrend each segment. If `detrend` is a
+        string, it is passed as the `type` argument to the `detrend`
+        function. If it is a function, it takes a segment and returns a
+        detrended segment. If `detrend` is `False`, no detrending is
+        done. Defaults to 'constant'.
+    return_onesided : bool, optional
+        If `True`, return a one-sided spectrum for real data. If
+        `False` return a two-sided spectrum. Defaults to `True`, but for
+        complex data, a two-sided spectrum is always returned.
+    scaling : { 'density', 'spectrum' }, optional
+        Selects between computing the power spectral density ('density')
+        where `Pxx` has units of V**2/Hz and computing the power
+        spectrum ('spectrum') where `Pxx` has units of V**2, if `x`
+        is measured in V and `fs` is measured in Hz. Defaults to
+        'density'
+    axis : int, optional
+        Axis along which the periodogram is computed; the default is
+        over the last axis (i.e. ``axis=-1``).
+    average : { 'mean', 'median' }, optional
+        Method to use when averaging periodograms. Defaults to 'mean'.
+
+
+    Returns
+    -------
+    f : ndarray
+        Array of sample frequencies.
+    Pxx : ndarray
+        Power spectral density or power spectrum of x.
+
+    See Also
+    --------
+    periodogram: Simple, optionally modified periodogram
+    lombscargle: Lomb-Scargle periodogram for unevenly sampled data
+
+    Notes
+    -----
+    An appropriate amount of overlap will depend on the choice of window
+    and on your requirements. For the default Hann window an overlap of
+    50% is a reasonable trade off between accurately estimating the
+    signal power, while not over counting any of the data. Narrower
+    windows may require a larger overlap.
+
+    If `noverlap` is 0, this method is equivalent to Bartlett's method
+    [2]_.
+
+    References
+    ----------
+    .. [1] P. Welch, "The use of the fast Fourier transform for the
+           estimation of power spectra: A method based on time averaging
+           over short, modified periodograms", IEEE Trans. Audio
+           Electroacoust. vol. 15, pp. 70-73, 1967.
+    .. [2] M.S. Bartlett, "Periodogram Analysis and Continuous Spectra",
+           Biometrika, vol. 37, pp. 1-16, 1950.
+    """
+
+    freqs, Pxx = csd(
+        x,
+        x,
+        fs=fs,
+        window=window,
+        nperseg=nperseg,
+        noverlap=noverlap,
+        nfft=nfft,
+        detrend=detrend,
+        return_onesided=return_onesided,
+        scaling=scaling,
+        axis=axis,
+        average=average,
+    )
+
+    return freqs, Pxx.real
+
+
+def csd(
+    x,
+    y,
+    fs=1.0,
+    window="hann",
+    nperseg=None,
+    noverlap=None,
+    nfft=None,
+    detrend="constant",
+    return_onesided=True,
+    scaling="density",
+    axis=-1,
+    average="mean",
+):
+    r"""
+    Estimate the cross power spectral density, Pxy, using Welch's
+    method.
+
+    Parameters
+    ----------
+    x : array_like
+        Time series of measurement values
+    y : array_like
+        Time series of measurement values
+    fs : float, optional
+        Sampling frequency of the `x` and `y` time series. Defaults
+        to 1.0.
+    window : str or tuple or array_like, optional
+        Desired window to use. If `window` is a string or tuple, it is
+        passed to `get_window` to generate the window values, which are
+        DFT-even by default. See `get_window` for a list of windows and
+        required parameters. If `window` is array_like it will be used
+        directly as the window and its length must be nperseg. Defaults
+        to a Hann window.
+    nperseg : int, optional
+        Length of each segment. Defaults to None, but if window is str or
+        tuple, is set to 256, and if window is array_like, is set to the
+        length of the window.
+    noverlap: int, optional
+        Number of points to overlap between segments. If `None`,
+        ``noverlap = nperseg // 2``. Defaults to `None`.
+    nfft : int, optional
+        Length of the FFT used, if a zero padded FFT is desired. If
+        `None`, the FFT length is `nperseg`. Defaults to `None`.
+    detrend : str or function or `False`, optional
+        Specifies how to detrend each segment. If `detrend` is a
+        string, it is passed as the `type` argument to the `detrend`
+        function. If it is a function, it takes a segment and returns a
+        detrended segment. If `detrend` is `False`, no detrending is
+        done. Defaults to 'constant'.
+    return_onesided : bool, optional
+        If `True`, return a one-sided spectrum for real data. If
+        `False` return a two-sided spectrum. Defaults to `True`, but for
+        complex data, a two-sided spectrum is always returned.
+    scaling : { 'density', 'spectrum' }, optional
+        Selects between computing the cross spectral density ('density')
+        where `Pxy` has units of V**2/Hz and computing the cross spectrum
+        ('spectrum') where `Pxy` has units of V**2, if `x` and `y` are
+        measured in V and `fs` is measured in Hz. Defaults to 'density'
+    axis : int, optional
+        Axis along which the CSD is computed for both inputs; the
+        default is over the last axis (i.e. ``axis=-1``).
+    average : { 'mean', 'median' }, optional
+        Method to use when averaging periodograms. Defaults to 'mean'.
+
+
+    Returns
+    -------
+    f : ndarray
+        Array of sample frequencies.
+    Pxy : ndarray
+        Cross spectral density or cross power spectrum of x,y.
+
+    See Also
+    --------
+    periodogram: Simple, optionally modified periodogram
+    lombscargle: Lomb-Scargle periodogram for unevenly sampled data
+    welch: Power spectral density by Welch's method. [Equivalent to
+           csd(x,x)]
+    coherence: Magnitude squared coherence by Welch's method.
+
+    Notes
+    -----
+    By convention, Pxy is computed with the conjugate FFT of X
+    multiplied by the FFT of Y.
+
+    If the input series differ in length, the shorter series will be
+    zero-padded to match.
+
+    An appropriate amount of overlap will depend on the choice of window
+    and on your requirements. For the default Hann window an overlap of
+    50% is a reasonable trade off between accurately estimating the
+    signal power, while not over counting any of the data. Narrower
+    windows may require a larger overlap.
+
+
+    References
+    ----------
+    .. [1] P. Welch, "The use of the fast Fourier transform for the
+           estimation of power spectra: A method based on time averaging
+           over short, modified periodograms", IEEE Trans. Audio
+           Electroacoust. vol. 15, pp. 70-73, 1967.
+    .. [2] Rabiner, Lawrence R., and B. Gold. "Theory and Application of
+           Digital Signal Processing" Prentice-Hall, pp. 414-419, 1975
+
+    """
+    x = cupy.asarray(x)
+    y = cupy.asarray(y)
+    freqs, _, Pxy = _spectral_helper(  # NOQA
+        x,
+        y,
+        fs,
+        window,
+        nperseg,
+        noverlap,
+        nfft,
+        detrend,
+        return_onesided,
+        scaling,
+        axis,
+        mode="psd",
+    )  # NOQA
+
+    # Average over windows.
+    if len(Pxy.shape) >= 2 and Pxy.size > 0:
+        if Pxy.shape[-1] > 1:
+            if average == "median":
+                Pxy = cupy.median(Pxy, axis=-1) / _median_bias(Pxy.shape[-1])  # NOQA
+            elif average == "mean":
+                Pxy = Pxy.mean(axis=-1)
+            else:
+                raise ValueError(
+                    'average must be "median" or "mean", got %s' % (average,)
+                )
+        else:
+            Pxy = cupy.reshape(Pxy, Pxy.shape[:-1])
+
+    return freqs, Pxy

--- a/cupyx/scipy/signal/_spectral.py
+++ b/cupyx/scipy/signal/_spectral.py
@@ -20,7 +20,8 @@ limitations under the License.
 
 
 import cupy
-from cupyx.scipy.signal._spectral_impl import _lombscargle
+from cupyx.scipy.signal._spectral_impl import (
+    _lombscargle, _spectral_helper, _median_bias)
 
 
 def lombscargle(x, y, freqs, precenter=False, normalize=False):
@@ -444,7 +445,7 @@ def csd(
     """
     x = cupy.asarray(x)
     y = cupy.asarray(y)
-    freqs, _, Pxy = _spectral_helper(  # NOQA
+    freqs, _, Pxy = _spectral_helper(
         x,
         y,
         fs,
@@ -457,13 +458,13 @@ def csd(
         scaling,
         axis,
         mode="psd",
-    )  # NOQA
+    )
 
     # Average over windows.
     if len(Pxy.shape) >= 2 and Pxy.size > 0:
         if Pxy.shape[-1] > 1:
             if average == "median":
-                Pxy = cupy.median(Pxy, axis=-1) / _median_bias(Pxy.shape[-1])  # NOQA
+                Pxy = cupy.median(Pxy, axis=-1) / _median_bias(Pxy.shape[-1])
             elif average == "mean":
                 Pxy = Pxy.mean(axis=-1)
             else:

--- a/cupyx/scipy/signal/_spectral.py
+++ b/cupyx/scipy/signal/_spectral.py
@@ -432,16 +432,6 @@ def csd(
     signal power, while not over counting any of the data. Narrower
     windows may require a larger overlap.
 
-
-    References
-    ----------
-    .. [1] P. Welch, "The use of the fast Fourier transform for the
-           estimation of power spectra: A method based on time averaging
-           over short, modified periodograms", IEEE Trans. Audio
-           Electroacoust. vol. 15, pp. 70-73, 1967.
-    .. [2] Rabiner, Lawrence R., and B. Gold. "Theory and Application of
-           Digital Signal Processing" Prentice-Hall, pp. 414-419, 1975
-
     """
     x = cupy.asarray(x)
     y = cupy.asarray(y)

--- a/cupyx/scipy/signal/_spectral.py
+++ b/cupyx/scipy/signal/_spectral.py
@@ -1,3 +1,23 @@
+"""
+Spectral analysis functions and utilities.
+
+Some of the functions defined here were ported directly from CuSignal under
+terms of the Apache license, under the following notice
+
+Copyright (c) 2019-2020, NVIDIA CORPORATION.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
 
 import cupy
 from cupyx.scipy.signal._spectral_impl import _lombscargle

--- a/cupyx/scipy/signal/_spectral_impl.py
+++ b/cupyx/scipy/signal/_spectral_impl.py
@@ -25,9 +25,13 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 """
 
+import warnings
+
 import cupy
 
 from cupy_backends.cuda.api import runtime
+from cupyx.scipy.signal._arraytools import (
+    odd_ext, even_ext, zero_ext, const_ext)
 
 
 def _get_raw_typename(dtype):
@@ -210,3 +214,327 @@ def _lombscargle(x, y, freqs, pgram, y_dot):
 
     args = (x.shape[0], freqs.shape[0], x, y, freqs, pgram, y_dot)
     lombscargle_kernel((num_blocks,), (block_sz,), args)
+
+
+def _spectral_helper(
+    x,
+    y,
+    fs=1.0,
+    window="hann",
+    nperseg=None,
+    noverlap=None,
+    nfft=None,
+    detrend="constant",
+    return_onesided=True,
+    scaling="density",
+    axis=-1,
+    mode="psd",
+    boundary=None,
+    padded=False,
+):
+    """
+    Calculate various forms of windowed FFTs for PSD, CSD, etc.
+
+    This is a helper function that implements the commonality between
+    the stft, psd, csd, and spectrogram functions. It is not designed to
+    be called externally. The windows are not averaged over; the result
+    from each window is returned.
+
+    Parameters
+    ---------
+    x : array_like
+        Array or sequence containing the data to be analyzed.
+    y : array_like
+        Array or sequence containing the data to be analyzed. If this is
+        the same object in memory as `x` (i.e. ``_spectral_helper(x,
+        x, ...)``), the extra computations are spared.
+    fs : float, optional
+        Sampling frequency of the time series. Defaults to 1.0.
+    window : str or tuple or array_like, optional
+        Desired window to use. If `window` is a string or tuple, it is
+        passed to `get_window` to generate the window values, which are
+        DFT-even by default. See `get_window` for a list of windows and
+        required parameters. If `window` is array_like it will be used
+        directly as the window and its length must be nperseg. Defaults
+        to a Hann window.
+    nperseg : int, optional
+        Length of each segment. Defaults to None, but if window is str or
+        tuple, is set to 256, and if window is array_like, is set to the
+        length of the window.
+    noverlap : int, optional
+        Number of points to overlap between segments. If `None`,
+        ``noverlap = nperseg // 2``. Defaults to `None`.
+    nfft : int, optional
+        Length of the FFT used, if a zero padded FFT is desired. If
+        `None`, the FFT length is `nperseg`. Defaults to `None`.
+    detrend : str or function or `False`, optional
+        Specifies how to detrend each segment. If `detrend` is a
+        string, it is passed as the `type` argument to the `detrend`
+        function. If it is a function, it takes a segment and returns a
+        detrended segment. If `detrend` is `False`, no detrending is
+        done. Defaults to 'constant'.
+    return_onesided : bool, optional
+        If `True`, return a one-sided spectrum for real data. If
+        `False` return a two-sided spectrum. Defaults to `True`, but for
+        complex data, a two-sided spectrum is always returned.
+    scaling : { 'density', 'spectrum' }, optional
+        Selects between computing the cross spectral density ('density')
+        where `Pxy` has units of V**2/Hz and computing the cross
+        spectrum ('spectrum') where `Pxy` has units of V**2, if `x`
+        and `y` are measured in V and `fs` is measured in Hz.
+        Defaults to 'density'
+    axis : int, optional
+        Axis along which the FFTs are computed; the default is over the
+        last axis (i.e. ``axis=-1``).
+    mode: str {'psd', 'stft'}, optional
+        Defines what kind of return values are expected. Defaults to
+        'psd'.
+    boundary : str or None, optional
+        Specifies whether the input signal is extended at both ends, and
+        how to generate the new values, in order to center the first
+        windowed segment on the first input point. This has the benefit
+        of enabling reconstruction of the first input point when the
+        employed window function starts at zero. Valid options are
+        ``['even', 'odd', 'constant', 'zeros', None]``. Defaults to
+        `None`.
+    padded : bool, optional
+        Specifies whether the input signal is zero-padded at the end to
+        make the signal fit exactly into an integer number of window
+        segments, so that all of the signal is included in the output.
+        Defaults to `False`. Padding occurs after boundary extension, if
+        `boundary` is not `None`, and `padded` is `True`.
+    Returns
+    -------
+    freqs : ndarray
+        Array of sample frequencies.
+    t : ndarray
+        Array of times corresponding to each data segment
+    result : ndarray
+        Array of output data, contents dependent on *mode* kwarg.
+
+    Notes
+    -----
+    Adapted from matplotlib.mlab
+
+    """
+    if mode not in ["psd", "stft"]:
+        raise ValueError(
+            f"Unknown value for mode {mode}, must be one of: "
+            "{'psd', 'stft'}"
+        )
+
+    boundary_funcs = {
+        "even": even_ext,
+        "odd": odd_ext,
+        "constant": const_ext,
+        "zeros": zero_ext,
+        None: None,
+    }
+
+    if boundary not in boundary_funcs:
+        raise ValueError(
+            "Unknown boundary option '{0}', must be one of: {1}".format(
+                boundary, list(boundary_funcs.keys())
+            )
+        )
+
+    # If x and y are the same object we can save ourselves some computation.
+    same_data = y is x
+
+    if not same_data and mode != "psd":
+        raise ValueError("x and y must be equal if mode is 'stft'")
+
+    axis = int(axis)
+
+    # Ensure we have cp.arrays, get outdtype
+    x = cupy.asarray(x)
+    if not same_data:
+        y = cupy.asarray(y)
+        outdtype = cupy.result_type(x, y, cupy.complex64)
+    else:
+        outdtype = cupy.result_type(x, cupy.complex64)
+
+    if not same_data:
+        # Check if we can broadcast the outer axes together
+        xouter = list(x.shape)
+        youter = list(y.shape)
+        xouter.pop(axis)
+        youter.pop(axis)
+        try:
+            outershape = cupy.broadcast(
+                cupy.empty(xouter), cupy.empty(youter)).shape
+        except ValueError:
+            raise ValueError("x and y cannot be broadcast together.")
+
+    if same_data:
+        if x.size == 0:
+            return (
+                cupy.empty(x.shape), cupy.empty(x.shape), cupy.empty(x.shape))
+    else:
+        if x.size == 0 or y.size == 0:
+            outshape = outershape + (cupy.min([x.shape[axis], y.shape[axis]]),)
+            emptyout = cupy.rollaxis(cupy.empty(outshape), -1, axis)
+            return emptyout, emptyout, emptyout
+
+    if x.ndim > 1:
+        if axis != -1:
+            x = cupy.rollaxis(x, axis, len(x.shape))
+            if not same_data and y.ndim > 1:
+                y = cupy.rollaxis(y, axis, len(y.shape))
+
+    # Check if x and y are the same length, zero-pad if necessary
+    if not same_data:
+        if x.shape[-1] != y.shape[-1]:
+            if x.shape[-1] < y.shape[-1]:
+                pad_shape = list(x.shape)
+                pad_shape[-1] = y.shape[-1] - x.shape[-1]
+                x = cupy.concatenate((x, cupy.zeros(pad_shape)), -1)
+            else:
+                pad_shape = list(y.shape)
+                pad_shape[-1] = x.shape[-1] - y.shape[-1]
+                y = cupy.concatenate((y, cupy.zeros(pad_shape)), -1)
+
+    if nperseg is not None:  # if specified by user
+        nperseg = int(nperseg)
+        if nperseg < 1:
+            raise ValueError("nperseg must be a positive integer")
+
+    # parse window; if array like, then set nperseg = win.shape
+    win, nperseg = _triage_segments(window, nperseg, input_length=x.shape[-1])  # NOQA
+
+    if nfft is None:
+        nfft = nperseg
+    elif nfft < nperseg:
+        raise ValueError("nfft must be greater than or equal to nperseg.")
+    else:
+        nfft = int(nfft)
+
+    if noverlap is None:
+        noverlap = nperseg // 2
+    else:
+        noverlap = int(noverlap)
+    if noverlap >= nperseg:
+        raise ValueError("noverlap must be less than nperseg.")
+    nstep = nperseg - noverlap
+
+    # Padding occurs after boundary extension, so that the extended signal ends
+    # in zeros, instead of introducing an impulse at the end.
+    # I.e. if x = [..., 3, 2]
+    # extend then pad -> [..., 3, 2, 2, 3, 0, 0, 0]
+    # pad then extend -> [..., 3, 2, 0, 0, 0, 2, 3]
+
+    if boundary is not None:
+        ext_func = boundary_funcs[boundary]
+        x = ext_func(x, nperseg // 2, axis=-1)
+        if not same_data:
+            y = ext_func(y, nperseg // 2, axis=-1)
+
+    if padded:
+        # Pad to integer number of windowed segments
+        # I.e make x.shape[-1] = nperseg + (nseg-1)*nstep, with integer nseg
+        nadd = (-(x.shape[-1] - nperseg) % nstep) % nperseg
+        zeros_shape = list(x.shape[:-1]) + [nadd]
+        x = cupy.concatenate((x, cupy.zeros(zeros_shape)), axis=-1)
+        if not same_data:
+            zeros_shape = list(y.shape[:-1]) + [nadd]
+            y = cupy.concatenate((y, cupy.zeros(zeros_shape)), axis=-1)
+
+    # Handle detrending and window functions
+    if not detrend:
+
+        def detrend_func(d):
+            return d
+
+    elif not hasattr(detrend, "__call__"):
+
+        def detrend_func(d):
+            return filtering.detrend(d, type=detrend, axis=-1)  # NOQA
+
+    elif axis != -1:
+        # Wrap this function so that it receives a shape that it could
+        # reasonably expect to receive.
+        def detrend_func(d):
+            d = cupy.rollaxis(d, -1, axis)
+            d = detrend(d)
+            return cupy.rollaxis(d, axis, len(d.shape))
+
+    else:
+        detrend_func = detrend
+
+    if cupy.result_type(win, cupy.complex64) != outdtype:
+        win = win.astype(outdtype)
+
+    if scaling == "density":
+        scale = 1.0 / (fs * (win * win).sum())
+    elif scaling == "spectrum":
+        scale = 1.0 / win.sum() ** 2
+    else:
+        raise ValueError("Unknown scaling: %r" % scaling)
+
+    if mode == "stft":
+        scale = cupy.sqrt(scale)
+
+    if return_onesided:
+        if cupy.iscomplexobj(x):
+            sides = "twosided"
+            warnings.warn(
+                "Input data is complex, switching to "
+                "return_onesided=False"
+            )
+        else:
+            sides = "onesided"
+            if not same_data:
+                if cupy.iscomplexobj(y):
+                    sides = "twosided"
+                    warnings.warn(
+                        "Input data is complex, switching to "
+                        "return_onesided=False"
+                    )
+    else:
+        sides = "twosided"
+
+    if sides == "twosided":
+        freqs = cupy.fft.fftfreq(nfft, 1 / fs)
+    elif sides == "onesided":
+        freqs = cupy.fft.rfftfreq(nfft, 1 / fs)
+
+    # Perform the windowed FFTs
+    result = _fft_helper(x, win, detrend_func, nperseg, noverlap, nfft, sides)  # NOQA
+
+    if not same_data:
+        # All the same operations on the y data
+        result_y = _fft_helper(y, win, detrend_func,  # NOQA
+                               nperseg, noverlap, nfft, sides)
+        result = cupy.conj(result) * result_y
+    elif mode == "psd":
+        result = cupy.conj(result) * result
+
+    result *= scale
+    if sides == "onesided" and mode == "psd":
+        if nfft % 2:
+            result[..., 1:] *= 2
+        else:
+            # Last point is unpaired Nyquist freq point, don't double
+            result[..., 1:-1] *= 2
+
+    time = cupy.arange(
+        nperseg / 2, x.shape[-1] - nperseg / 2 + 1, nperseg - noverlap
+    ) / float(fs)
+    if boundary is not None:
+        time -= (nperseg / 2) / fs
+
+    result = result.astype(outdtype)
+
+    # All imaginary parts are zero anyways
+    if same_data and mode != "stft":
+        result = result.real
+
+    # Output is going to have new last axis for time/window index, so a
+    # negative axis index shifts down one
+    if axis < 0:
+        axis -= 1
+
+    # Roll frequency axis back to axis where the data came from
+    result = cupy.rollaxis(result, -1, axis)
+
+    return freqs, time, result

--- a/cupyx/scipy/signal/_spectral_impl.py
+++ b/cupyx/scipy/signal/_spectral_impl.py
@@ -375,7 +375,7 @@ def _spectral_helper(
                 cupy.empty(x.shape), cupy.empty(x.shape), cupy.empty(x.shape))
     else:
         if x.size == 0 or y.size == 0:
-            outshape = outershape + (cupy.min([x.shape[axis], y.shape[axis]]),)
+            outshape = outershape + (min([x.shape[axis], y.shape[axis]]),)
             emptyout = cupy.rollaxis(cupy.empty(outshape), -1, axis)
             return emptyout, emptyout, emptyout
 

--- a/docs/source/reference/scipy_signal.rst
+++ b/docs/source/reference/scipy_signal.rst
@@ -214,4 +214,7 @@ Spectral analysis
 .. autosummary::
    :toctree: generated/
 
+   periodogram
+   welch
+   csd
    lombscargle

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_spectral.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_spectral.py
@@ -320,3 +320,296 @@ class TestPeriodogram:
         win = scp.signal.get_window('hann', 10)
         with pytest.raises(ValueError):
             scp.signal.periodogram(x, window=win)
+
+
+@testing.with_requires('scipy')
+class TestWelch:
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_real_onesided_even(self, xp, scp):
+        x = xp.zeros(16)
+        x[0] = 1
+        x[8] = 1
+        f, p = scp.signal.welch(x, nperseg=8)
+        return f, p
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_real_onesided_odd(self, xp, scp):
+        x = xp.zeros(16)
+        x[0] = 1
+        x[8] = 1
+        f, p = scp.signal.welch(x, nperseg=9)
+        return f, p
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_real_twosided(self, xp, scp):
+        x = xp.zeros(16)
+        x[0] = 1
+        x[8] = 1
+        f, p = scp.signal.welch(x, nperseg=8, return_onesided=False)
+        return f, p
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_real_spectrum(self, xp, scp):
+        x = xp.zeros(16)
+        x[0] = 1
+        x[8] = 1
+        f, p = scp.signal.welch(x, nperseg=8, scaling='spectrum')
+        return f, p
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_integer_onesided_even(self, xp, scp):
+        x = xp.zeros(16, dtype=int)
+        x[0] = 1
+        x[8] = 1
+        f, p = scp.signal.welch(x, nperseg=8)
+        return f, p
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_integer_onesided_odd(self, xp, scp):
+        x = xp.zeros(16, dtype=int)
+        x[0] = 1
+        x[8] = 1
+        f, p = scp.signal.welch(x, nperseg=9)
+        return f, p
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_integer_twosided(self, xp, scp):
+        x = xp.zeros(16, dtype=int)
+        x[0] = 1
+        x[8] = 1
+        f, p = scp.signal.welch(x, nperseg=8, return_onesided=False)
+        return f, p
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_complex(self, xp, scp):
+        x = xp.zeros(16, xp.complex128)
+        x[0] = 1.0 + 2.0j
+        x[8] = 1.0 + 2.0j
+        f, p = scp.signal.welch(x, nperseg=8, return_onesided=False)
+        return f, p
+
+    @pytest.mark.parametrize('mod', [(cupy, cupyx.scipy), (np, scipy)])
+    def test_unk_scaling(self, mod):
+        xp, scp = mod
+        with pytest.raises(ValueError):
+            x = xp.zeros(4, xp.complex128)
+            scp.signal.welch(x, scaling='foo', nperseg=4)
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_detrend_linear(self, xp, scp):
+        x = xp.arange(10, dtype=xp.float64) + 0.04
+        f, p = scp.signal.welch(x, nperseg=10, detrend='linear')
+        return f, p
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_no_detrending(self, xp, scp):
+        x = xp.arange(10, dtype=xp.float64) + 0.04
+        f1, p1 = scp.signal.welch(x, nperseg=10, detrend=False)
+        f2, p2 = scp.signal.welch(x, nperseg=10, detrend=lambda x: x)
+        return f1, p1, f2, p2
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_detrend_external(self, xp, scp):
+        x = xp.arange(10, dtype=xp.float64) + 0.04
+        f, p = scp.signal.welch(
+            x, nperseg=10,
+            detrend=lambda seg: scp.signal.detrend(seg, type='l'))
+        return f, p
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_detrend_external_nd_m1(self, xp, scp):
+        x = xp.arange(40, dtype=xp.float64) + 0.04
+        x = x.reshape((2, 2, 10))
+        f, p = scp.signal.welch(
+            x, nperseg=10,
+            detrend=lambda seg: scp.signal.detrend(seg, type='l'))
+        return f, p
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_detrend_external_nd_0(self, xp, scp):
+        x = xp.arange(20, dtype=xp.float64) + 0.04
+        x = x.reshape((2, 1, 10))
+        x = xp.moveaxis(x, 2, 0)
+        f, p = scp.signal.welch(
+            x, nperseg=10, axis=0,
+            detrend=lambda seg: scp.signal.detrend(seg, axis=0, type='l'))
+        return f, p
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_nd_axis_m1(self, xp, scp):
+        x = xp.arange(20, dtype=xp.float64) + 0.04
+        x = x.reshape((2, 1, 10))
+        f, p = scp.signal.welch(x, nperseg=10)
+        f0, p0 = scp.signal.welch(x[0, 0, :], nperseg=10)
+        return f, p, f0, p0
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_nd_axis_0(self, xp, scp):
+        x = xp.arange(20, dtype=xp.float64) + 0.04
+        x = x.reshape((10, 2, 1))
+        f, p = scp.signal.welch(x, nperseg=10, axis=0)
+        f0, p0 = scp.signal.welch(x[:, 0, 0], nperseg=10)
+        return f, p, f0, p0
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_window_external(self, xp, scp):
+        x = xp.zeros(16)
+        x[0] = 1
+        x[8] = 1
+        f, p = scp.signal.welch(x, 10, 'hann', nperseg=8)
+        win = scp.signal.get_window('hann', 8)
+        fe, pe = scp.signal.welch(x, 10, win, nperseg=None)
+
+        with pytest.raises(ValueError):
+            scp.signal.welch(x, 10, win, nperseg=4)
+
+        with pytest.raises(ValueError):
+            win_err = scp.signal.get_window('hann', 32)
+            scp.signal.welch(x, 10, win_err, nperseg=None)
+
+        return f, p, fe, pe
+
+    @pytest.mark.parametrize('shape', [(0,), (3, 0), (0, 5, 2)])
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_empty_input(self, shape, xp, scp):
+        f, p = scp.signal.welch(xp.empty(shape))
+        return f, p
+
+    @pytest.mark.parametrize('shape', [(3, 0), (0, 5, 2)])
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_empty_input_other_axis(self, shape, xp, scp):
+        f, p = scp.signal.welch(xp.empty(shape), axis=1)
+        return f, p
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_short_data(self, xp, scp):
+        x = np.zeros(8)
+        x[0] = 1
+
+        # default nperseg
+        f, p = scp.signal.welch(x, window='hann')
+        # user-specified nperseg
+        f1, p1 = scp.signal.welch(x, window='hann', nperseg=256)
+        # valid nperseg, doesn't give warning
+        f2, p2 = scp.signal.welch(x, nperseg=8)
+        return f, p, f1, p1, f2, p2
+
+    @pytest.mark.parametrize('mod', [(cupy, cupyx.scipy), (np, scipy)])
+    def test_window_long_or_nd(self, mod):
+        xp, scp = mod
+
+        with pytest.raises(ValueError):
+            scp.signal.welch(xp.zeros(4), 1, xp.array([1, 1, 1, 1, 1]))
+
+        with pytest.raises(ValueError):
+            scp.signal.welch(xp.zeros(4), 1, xp.arange(6).reshape((2, 3)))
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_nondefault_noverlap(self, xp, scp):
+        x = xp.zeros(64)
+        x[::8] = 1
+        f, p = scp.signal.welch(x, nperseg=16, noverlap=4)
+        return f, p
+
+    @pytest.mark.parametrize('mod', [(cupy, cupyx.scipy), (np, scipy)])
+    def test_bad_noverlap(self, mod):
+        xp, scp = mod
+        with pytest.raises(ValueError):
+            scp.signal.welch(xp.zeros(4), 1, 'hann', 2, 7)
+
+    @pytest.mark.parametrize('mod', [(cupy, cupyx.scipy), (np, scipy)])
+    def test_nfft_too_short(self, mod):
+        xp, scp = mod
+        with pytest.raises(ValueError):
+            scp.signal.welch(xp.ones(12), nfft=3, nperseg=4)
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_real_onesided_even_32(self, xp, scp):
+        x = xp.zeros(16, 'f')
+        x[0] = 1
+        x[8] = 1
+        f, p = scp.signal.welch(x, nperseg=8)
+        return f, p
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_real_onesided_odd_32(self, xp, scp):
+        x = xp.zeros(16, 'f')
+        x[0] = 1
+        x[8] = 1
+        f, p = scp.signal.welch(x, nperseg=9)
+        return f, p
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_real_twosided_32(self, xp, scp):
+        x = xp.zeros(16, 'f')
+        x[0] = 1
+        x[8] = 1
+        f, p = scp.signal.welch(x, nperseg=8, return_onesided=False)
+        return f, p
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_complex_32(self, xp, scp):
+        x = xp.zeros(16, 'F')
+        x[0] = 1.0 + 2.0j
+        x[8] = 1.0 + 2.0j
+        f, p = scp.signal.welch(x, nperseg=8, return_onesided=False)
+        return f, p
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_padded_freqs(self, xp, scp):
+        x = xp.zeros(12)
+
+        nfft = 24
+        fodd1, _ = scp.signal.welch(x, nperseg=5, nfft=nfft)
+        feven1, _ = scp.signal.welch(x, nperseg=6, nfft=nfft)
+
+        nfft = 25
+        fodd2, _ = scp.signal.welch(x, nperseg=5, nfft=nfft)
+        feven2, _ = scp.signal.welch(x, nperseg=6, nfft=nfft)
+
+        return fodd1, feven1, fodd2, feven2
+
+    @pytest.mark.parametrize(
+        'window', ['hann', 'bartlett', ('tukey', 0.1), 'flattop'])
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_window_correction(self, window, xp, scp):
+        A = 20
+        fs = 1e4
+        nperseg = int(fs // 10)
+        fsig = 300
+
+        tt = xp.arange(fs) / fs
+        x = A * xp.sin(2 * np.pi * fsig * tt)
+
+        _, p_spec = scp.signal.welch(
+            x, fs=fs, nperseg=nperseg, window=window, scaling='spectrum')
+        freq, p_dens = scp.signal.welch(
+            x, fs=fs, nperseg=nperseg, window=window, scaling='density')
+
+        return p_spec, freq, p_dens
+
+    @pytest.mark.parametrize('axis', [0, 1, 2])
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_axis_rolling(self, axis, xp, scp):
+        x_flat = testing.shaped_random((1024,), xp)
+        _, p_flat = scp.signal.welch(x_flat)
+
+        newshape = [1,] * 3
+        newshape[axis] = -1
+        x = x_flat.reshape(newshape)
+
+        _, p_plus = scp.signal.welch(x, axis=axis)  # Positive axis index
+        # Negative axis index
+        _, p_minus = scp.signal.welch(x, axis=axis - x.ndim)
+        return p_flat, p_plus, p_minus
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_average(self, xp, scp):
+        x = xp.zeros(16)
+        x[0] = 1
+        x[8] = 1
+        f, p = scp.signal.welch(x, nperseg=8, average='median')
+
+        with pytest.raises(ValueError):
+            scp.signal.welch(x, nperseg=8, average='unrecognised-average')
+        return f, p

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_spectral.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_spectral.py
@@ -894,6 +894,9 @@ class TestCSD:
         feven2, _ = scp.signal.csd(x, y, nperseg=6, nfft=nfft)
         return fodd1, feven1, fodd2, feven2
 
+    @pytest.mark.skipif(
+        cupy.cuda.runtime.runtimeGetVersion() < 12000,
+        reason="It fails on CUDA 11.x")
     @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
     def test_copied_data(self, xp, scp):
         x = testing.shaped_random((64,), xp, xp.float64)

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_spectral.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_spectral.py
@@ -3,6 +3,7 @@ import pytest
 
 import numpy as np
 
+import cupy
 from cupy.cuda import driver
 from cupy.cuda import runtime
 from cupy import testing
@@ -146,3 +147,176 @@ class TestLombscargle:
 
         # check if normalization works as expected
         return pgram, pgram2
+
+
+@pytest.mark.xfail(
+    runtime.is_hip and driver.get_build_version() < 5_00_00000,
+    reason='name_expressions with ROCm 4.3 may not work')
+@testing.with_requires('scipy')
+class TestPeriodogram:
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_real_onesided_even(self, xp, scp):
+        x = xp.zeros(16)
+        x[0] = 1
+        f, p = scp.signal.periodogram(x)
+        return f, p
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_real_onesided_odd(self, xp, scp):
+        x = xp.zeros(15)
+        x[0] = 1
+        f, p = scp.signal.periodogram(x)
+        return f, p
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_real_twosided(self, xp, scp):
+        x = xp.zeros(16)
+        x[0] = 1
+        f, p = scp.signal.periodogram(x, return_onesided=False)
+        return f, p
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_real_spectrum(self, xp, scp):
+        x = np.zeros(16)
+        x[0] = 1
+        f, p = scp.signal.periodogram(x, scaling='spectrum')
+        g, q = scp.signal.periodogram(x, scaling='density')
+        return f, p, g, q
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_integer_even(self, xp, scp):
+        x = xp.zeros(16, dtype=int)
+        x[0] = 1
+        f, p = scp.signal.periodogram(x)
+        return f, p
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_integer_odd(self, xp, scp):
+        x = xp.zeros(15, dtype=int)
+        x[0] = 1
+        f, p = scp.signal.periodogram(x)
+        return f, p
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_integer_twosided(self, xp, scp):
+        x = np.zeros(16, dtype=int)
+        x[0] = 1
+        f, p = scp.signal.periodogram(x, return_onesided=False)
+        return f, p
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_complex(self, xp, scp):
+        x = xp.zeros(16, xp.complex128)
+        x[0] = 1.0 + 2.0j
+        f, p = scp.signal.periodogram(x, return_onesided=False)
+        return f, p
+
+    @pytest.mark.parametrize('mod', [(cupy, cupyx.scipy), (np, scipy)])
+    def test_unk_scaling(self, mod):
+        xp, scp = mod
+        with pytest.raises(ValueError):
+            x = xp.zeros(4, xp.complex128)
+            scp.signal.periodogram(x, scaling='foo')
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_nd_axis_m1(self, xp, scp):
+        x = xp.zeros(20, dtype=np.float64)
+        x = x.reshape((2, 1, 10))
+        x[:, :, 0] = 1.0
+        f, p = scp.signal.periodogram(x)
+        f0, p0 = scp.signal.periodogram(x[0, 0, :])
+        return f, p, f0, p0
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_nd_axis_0(self, xp, scp):
+        x = xp.zeros(20, dtype=np.float64)
+        x = x.reshape((10, 2, 1))
+        x[0, :, :] = 1.0
+        f, p = scp.signal.periodogram(x, axis=0)
+        f0, p0 = scp.signal.periodogram(x[:, 0, 0])
+        return f, p, f0, p0
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_window_external(self, xp, scp):
+        x = xp.zeros(16)
+        x[0] = 1
+        f, p = scp.signal.periodogram(x, 10, 'hann')
+        win = scp.signal.get_window('hann', 16)
+        fe, pe = scp.signal.periodogram(x, 10, win)
+
+        win_err = scp.signal.get_window('hann', 32)
+        with pytest.raises(ValueError):
+            scp.signal.periodogram(x, 10, win_err)
+
+        return f, p, fe, pe
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_padded_fft(self, xp, scp):
+        x = xp.zeros(16)
+        x[0] = 1
+        f, p = scp.signal.periodogram(x)
+        fp, pp = scp.signal.periodogram(x, nfft=32)
+        return f, p, fp, pp
+
+    @pytest.mark.parametrize('shape', [(0,), (3, 0), (0, 5, 2)])
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_empty_input(self, shape, xp, scp):
+        f, p = scp.signal.periodogram(xp.empty(shape))
+        return f, p
+
+    @pytest.mark.parametrize('shape', [(3, 0), (0, 5, 2)])
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_empty_input_other_axis(self, shape, xp, scp):
+        f, p = scp.signal.periodogram(xp.empty(shape), axis=1)
+        return f, p
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_short_nfft(self, xp, scp):
+        x = xp.zeros(18)
+        x[0] = 1
+        f, p = scp.signal.periodogram(x, nfft=16)
+        return f, p
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_nfft_is_xshape(self, xp, scp):
+        x = xp.zeros(16)
+        x[0] = 1
+        f, p = scp.signal.periodogram(x, nfft=16)
+        return f, p
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_real_onesided_even_32(self, xp, scp):
+        x = xp.zeros(16, 'f')
+        x[0] = 1
+        f, p = scp.signal.periodogram(x)
+        return f, p
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_real_onesided_odd_32(self, xp, scp):
+        x = xp.zeros(15, 'f')
+        x[0] = 1
+        f, p = scp.signal.periodogram(x)
+        return f, p
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_real_twosided_32(self, xp, scp):
+        x = xp.zeros(16, 'f')
+        x[0] = 1
+        f, p = scp.signal.periodogram(x, return_onesided=False)
+        return f, p
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_complex_32(self, xp, scp):
+        x = xp.zeros(16, 'F')
+        x[0] = 1.0 + 2.0j
+        f, p = scp.signal.periodogram(x, return_onesided=False)
+        return f, p
+
+    @pytest.mark.parametrize('mod', [(cupy, cupyx.scipy), (np, scipy)])
+    def test_shorter_window_error(self, mod):
+        xp, scp = mod
+        x = xp.zeros(16)
+        x[0] = 1
+        win = scp.signal.get_window('hann', 10)
+        with pytest.raises(ValueError):
+            scp.signal.periodogram(x, window=win)

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_spectral.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_spectral.py
@@ -613,3 +613,299 @@ class TestWelch:
         with pytest.raises(ValueError):
             scp.signal.welch(x, nperseg=8, average='unrecognised-average')
         return f, p
+
+
+@testing.with_requires('scipy')
+class TestCSD:
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_pad_shorter_x(self, xp, scp):
+        x = xp.zeros(8)
+        y = xp.zeros(12)
+        f1, c1 = scp.signal.csd(x, y, nperseg=12)
+        return f1, c1
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_pad_shorter_y(self, xp, scp):
+        x = xp.zeros(12)
+        y = xp.zeros(8)
+        f1, c1 = scp.signal.csd(x, y, nperseg=12)
+        return f1, c1
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_real_onesided_even(self, xp, scp):
+        x = xp.zeros(16)
+        x[0] = 1
+        x[8] = 1
+        f, p = scp.signal.csd(x, x, nperseg=8)
+        return f, p
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_real_onesided_odd(self, xp, scp):
+        x = xp.zeros(16)
+        x[0] = 1
+        x[8] = 1
+        f, p = scp.signal.csd(x, x, nperseg=9)
+        return f, p
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_real_twosided(self, xp, scp):
+        x = xp.zeros(16)
+        x[0] = 1
+        x[8] = 1
+        f, p = scp.signal.csd(x, x, nperseg=8, return_onesided=False)
+        return f, p
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_real_spectrum(self, xp, scp):
+        x = xp.zeros(16)
+        x[0] = 1
+        x[8] = 1
+        f, p = scp.signal.csd(x, x, nperseg=8, scaling='spectrum')
+        return f, p
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_integer_onesided_even(self, xp, scp):
+        x = xp.zeros(16, dtype=int)
+        x[0] = 1
+        x[8] = 1
+        f, p = scp.signal.csd(x, x, nperseg=8)
+        return f, p
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_integer_onesided_odd(self, xp, scp):
+        x = xp.zeros(16, dtype=int)
+        x[0] = 1
+        x[8] = 1
+        f, p = scp.signal.csd(x, x, nperseg=9)
+        return f, p
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_integer_twosided(self, xp, scp):
+        x = xp.zeros(16, dtype=int)
+        x[0] = 1
+        x[8] = 1
+        f, p = scp.signal.csd(x, x, nperseg=8, return_onesided=False)
+        return f, p
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_complex(self, xp, scp):
+        x = xp.zeros(16, xp.complex128)
+        x[0] = 1.0 + 2.0j
+        x[8] = 1.0 + 2.0j
+        f, p = scp.signal.csd(x, x, nperseg=8, return_onesided=False)
+        return f, p
+
+    @pytest.mark.parametrize('mod', [(cupy, cupyx.scipy), (np, scipy)])
+    def test_unk_scaling(self, mod):
+        xp, scp = mod
+        with pytest.raises(ValueError):
+            scp.signal.csd(
+                xp.zeros(4, np.complex128), xp.ones(4, np.complex128),
+                scaling='foo', nperseg=4)
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_detrend_linear(self, xp, scp):
+        x = xp.arange(10, dtype=xp.float64) + 0.04
+        f, p = scp.signal.csd(x, x, nperseg=10, detrend='linear')
+        return f, p
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_no_detrending(self, xp, scp):
+        x = xp.arange(10, dtype=xp.float64) + 0.04
+        f1, p1 = scp.signal.csd(x, x, nperseg=10, detrend=False)
+        f2, p2 = scp.signal.csd(x, x, nperseg=10, detrend=lambda x: x)
+        return f1, p1, f2, p2
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_detrend_external(self, xp, scp):
+        x = xp.arange(10, dtype=xp.float64) + 0.04
+        f, p = scp.signal.csd(
+            x, x, nperseg=10,
+            detrend=lambda seg: scp.signal.detrend(seg, type='l'))
+        return f, p
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_detrend_external_nd_m1(self, xp, scp):
+        x = xp.arange(40, dtype=xp.float64) + 0.04
+        x = x.reshape((2, 2, 10))
+        f, p = scp.signal.csd(
+            x, x, nperseg=10,
+            detrend=lambda seg: scp.signal.detrend(seg, type='l'))
+        return f, p
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_detrend_external_nd_0(self, xp, scp):
+        x = xp.arange(20, dtype=xp.float64) + 0.04
+        x = x.reshape((2, 1, 10))
+        x = xp.moveaxis(x, 2, 0)
+        f, p = scp.signal.csd(
+            x, x, nperseg=10, axis=0,
+            detrend=lambda seg: scp.signal.detrend(seg, axis=0, type='l'))
+        return f, p
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_nd_axis_m1(self, xp, scp):
+        x = xp.arange(20, dtype=xp.float64) + 0.04
+        x = x.reshape((2, 1, 10))
+        f, p = scp.signal.csd(x, x, nperseg=10)
+        f0, p0 = scp.signal.csd(x[0, 0, :], x[0, 0, :], nperseg=10)
+        return f, p, f0, p0
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_nd_axis_0(self, xp, scp):
+        x = xp.arange(20, dtype=xp.float64) + 0.04
+        x = x.reshape((10, 2, 1))
+        f, p = scp.signal.csd(x, x, nperseg=10, axis=0)
+        f0, p0 = scp.signal.csd(x[:, 0, 0], x[:, 0, 0], nperseg=10)
+        return f, p, f0, p0
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_window_external(self, xp, scp):
+        x = xp.zeros(16)
+        x[0] = 1
+        x[8] = 1
+        f, p = scp.signal.csd(x, x, 10, 'hann', 8)
+        win = scp.signal.get_window('hann', 8)
+        fe, pe = scp.signal.csd(x, x, 10, win, nperseg=None)
+        win_err = scp.signal.get_window('hann', 32)
+
+        with pytest.raises(ValueError):
+            scp.signal.csd(x, x, 10, win_err, nperseg=None)
+        return f, p, fe, pe
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_empty_input(self, xp, scp):
+        result = []
+
+        for shape in [(0,), (3, 0), (0, 5, 2)]:
+            f, p = scp.signal.csd(xp.empty(shape), xp.empty(shape))
+            result += [f, p]
+
+        f, p = scp.signal.csd(xp.ones(10), xp.empty((5, 0)))
+        result += [f, p]
+
+        f, p = scp.signal.csd(xp.empty((5, 0)), xp.ones(10))
+        result += [f, p]
+        return result
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_empty_input_other_axis(self, xp, scp):
+        result = []
+        for shape in [(3, 0), (0, 5, 2)]:
+            f, p = scp.signal.csd(xp.empty(shape), xp.empty(shape), axis=1)
+            result += [f, p]
+
+        f, p = scp.signal.csd(xp.empty((10, 10, 3)),
+                              xp.zeros((10, 0, 1)), axis=1)
+        result += [f, p]
+
+        f, p = scp.signal.csd(xp.empty((10, 0, 1)),
+                              xp.zeros((10, 10, 3)), axis=1)
+        result += [f, p]
+        return result
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_short_data(self, xp, scp):
+        x = xp.zeros(8)
+        x[0] = 1
+
+        # default nperseg
+        f, p = scp.signal.csd(x, x, window='hann')
+        # user-specified nperseg
+        f1, p1 = scp.signal.csd(x, x, window='hann', nperseg=256)
+        # valid nperseg, doesn't give warning
+        f2, p2 = scp.signal.csd(x, x, nperseg=8)
+        return f, p, f1, p1, f2, p2
+
+    @pytest.mark.parametrize('mod', [(cupy, cupyx.scipy), (np, scipy)])
+    def test_window_long_or_nd(self, mod):
+        xp, scp = mod
+        with pytest.raises(ValueError):
+            scp.signal.csd(xp.zeros(4), xp.zeros(
+                4), 1, xp.array([1, 1, 1, 1, 1]))
+
+        with pytest.raises(ValueError):
+            scp.signal.csd(xp.zeros(4), xp.ones(4), 1,
+                           xp.arange(6).reshape((2, 3)))
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_nondefault_noverlap(self, xp, scp):
+        x = xp.zeros(64)
+        x[::8] = 1
+        f, p = scp.signal.csd(x, x, nperseg=16, noverlap=4)
+        return f, p
+
+    @pytest.mark.parametrize('mod', [(cupy, cupyx.scipy), (np, scipy)])
+    def test_bad_noverlap(self, mod):
+        xp, scp = mod
+        with pytest.raises(ValueError):
+            scp.signal.csd(xp.zeros(4), xp.ones(4), 1, 'hann', 2, 7)
+
+    @pytest.mark.parametrize('mod', [(cupy, cupyx.scipy), (np, scipy)])
+    def test_nfft_too_short(self, mod):
+        xp, scp = mod
+        with pytest.raises(ValueError):
+            scp.signal.csd(xp.ones(12), xp.zeros(12), nfft=3,
+                           nperseg=4)
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_real_onesided_even_32(self, xp, scp):
+        x = xp.zeros(16, 'f')
+        x[0] = 1
+        x[8] = 1
+        f, p = scp.signal.csd(x, x, nperseg=8)
+        return f, p
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_real_onesided_odd_32(self, xp, scp):
+        x = xp.zeros(16, 'f')
+        x[0] = 1
+        x[8] = 1
+        f, p = scp.signal.csd(x, x, nperseg=9)
+        return f, p
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_real_twosided_32(self, xp, scp):
+        x = xp.zeros(16, 'f')
+        x[0] = 1
+        x[8] = 1
+        f, p = scp.signal.csd(x, x, nperseg=8, return_onesided=False)
+        return f, p
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_complex_32(self, xp, scp):
+        x = xp.zeros(16, 'F')
+        x[0] = 1.0 + 2.0j
+        x[8] = 1.0 + 2.0j
+        f, p = scp.signal.csd(x, x, nperseg=8, return_onesided=False)
+        return f, p
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_padded_freqs(self, xp, scp):
+        x = xp.zeros(12)
+        y = xp.ones(12)
+
+        nfft = 24
+        fodd1, _ = scp.signal.csd(x, y, nperseg=5, nfft=nfft)
+        feven1, _ = scp.signal.csd(x, y, nperseg=6, nfft=nfft)
+
+        nfft = 25
+        fodd2, _ = scp.signal.csd(x, y, nperseg=5, nfft=nfft)
+        feven2, _ = scp.signal.csd(x, y, nperseg=6, nfft=nfft)
+        return fodd1, feven1, fodd2, feven2
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_copied_data(self, xp, scp):
+        x = testing.shaped_random((64,), xp, xp.float64)
+        y = x.copy()
+
+        _, p_same1 = scp.signal.csd(x, x, nperseg=8, average='mean',
+                                    return_onesided=False)
+        _, p_copied1 = scp.signal.csd(x, y, nperseg=8, average='mean',
+                                      return_onesided=False)
+
+        _, p_same2 = scp.signal.csd(x, x, nperseg=8, average='median',
+                                    return_onesided=False)
+        _, p_copied2 = scp.signal.csd(x, y, nperseg=8, average='median',
+                                      return_onesided=False)
+        return p_same1, p_copied1, p_same2, p_copied2


### PR DESCRIPTION
See https://github.com/cupy/cupy/issues/7403
Depends on https://github.com/cupy/cupy/pull/7563 to ensure that the files do not get merge conflicts
Depends on https://github.com/cupy/cupy/pull/7536 to implement `csd`
Depends on https://github.com/cupy/cupy/pull/7568 to implement `spectral_analysis`, it depends on `get_window`

This port implies Python-only functions and therefore can be copied 1:1 from the original CuSignal implementation.