### PR TITLE
Fix CUDA Python CI failure

### DIFF
--- a/.pfnci/generate.py
+++ b/.pfnci/generate.py
@@ -173,7 +173,7 @@ class LinuxGenerator:
             'ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"',
             f'RUN pyenv install {py_spec} && \\',
             f'    pyenv global {py_spec} && \\',
-            '    pip install -U setuptools pip',
+            '    pip install -U setuptools pip wheel',
             '',
         ]
 

--- a/.pfnci/linux/tests/benchmark.Dockerfile
+++ b/.pfnci/linux/tests/benchmark.Dockerfile
@@ -26,7 +26,7 @@ ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
 RUN pyenv install 3.11.0 && \
     pyenv global 3.11.0 && \
-    pip install -U setuptools pip
+    pip install -U setuptools pip wheel
 
 RUN pip install -U 'numpy==1.24.*' 'scipy==1.9.*' 'optuna==3.*' 'cython==0.29.*'
 RUN pip uninstall -y mpi4py cuda-python && \

--- a/.pfnci/linux/tests/benchmark.head.Dockerfile
+++ b/.pfnci/linux/tests/benchmark.head.Dockerfile
@@ -26,7 +26,7 @@ ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
 RUN pyenv install 3.11.0 && \
     pyenv global 3.11.0 && \
-    pip install -U setuptools pip
+    pip install -U setuptools pip wheel
 
 RUN pip install -U 'numpy==1.24.*' 'scipy==1.9.*' 'optuna==3.*' 'cython==0.29.*'
 RUN pip uninstall -y mpi4py cuda-python && \

--- a/.pfnci/linux/tests/cuda-example.Dockerfile
+++ b/.pfnci/linux/tests/cuda-example.Dockerfile
@@ -26,7 +26,7 @@ ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
 RUN pyenv install 3.8.11 && \
     pyenv global 3.8.11 && \
-    pip install -U setuptools pip
+    pip install -U setuptools pip wheel
 
 RUN pip install -U 'numpy==1.20.*' 'scipy==1.7.*' 'optuna==3.*' 'cython==0.29.*'
 RUN pip uninstall -y mpi4py cuda-python && \

--- a/.pfnci/linux/tests/cuda-head.Dockerfile
+++ b/.pfnci/linux/tests/cuda-head.Dockerfile
@@ -26,7 +26,7 @@ ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
 RUN pyenv install 3.11.0 && \
     pyenv global 3.11.0 && \
-    pip install -U setuptools pip
+    pip install -U setuptools pip wheel
 
 RUN pip install -U 'numpy>=0a0' 'scipy>=0a0' 'optuna>=0a0' 'cython==0.29.*'
 RUN pip uninstall -y mpi4py cuda-python && \

--- a/.pfnci/linux/tests/cuda-slow.Dockerfile
+++ b/.pfnci/linux/tests/cuda-slow.Dockerfile
@@ -26,7 +26,7 @@ ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
 RUN pyenv install 3.11.0 && \
     pyenv global 3.11.0 && \
-    pip install -U setuptools pip
+    pip install -U setuptools pip wheel
 
 RUN pip install -U 'numpy==1.23.*' 'scipy==1.9.*' 'optuna==3.*' 'cython==0.29.*'
 RUN pip uninstall -y mpi4py cuda-python && \

--- a/.pfnci/linux/tests/cuda102.Dockerfile
+++ b/.pfnci/linux/tests/cuda102.Dockerfile
@@ -29,7 +29,7 @@ ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
 RUN pyenv install 3.8.11 && \
     pyenv global 3.8.11 && \
-    pip install -U setuptools pip
+    pip install -U setuptools pip wheel
 
 RUN pip install -U 'numpy==1.20.*' 'scipy==1.6.*' 'optuna==3.*' 'cython==0.29.*'
 RUN pip uninstall -y mpi4py cuda-python && \

--- a/.pfnci/linux/tests/cuda102.multi.Dockerfile
+++ b/.pfnci/linux/tests/cuda102.multi.Dockerfile
@@ -29,7 +29,7 @@ ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
 RUN pyenv install 3.8.11 && \
     pyenv global 3.8.11 && \
-    pip install -U setuptools pip
+    pip install -U setuptools pip wheel
 
 RUN pip install -U 'numpy==1.20.*' 'scipy==1.6.*' 'optuna==3.*' 'mpi4py==3.*' 'cython==0.29.*'
 RUN pip uninstall -y cuda-python && \

--- a/.pfnci/linux/tests/cuda110.Dockerfile
+++ b/.pfnci/linux/tests/cuda110.Dockerfile
@@ -26,7 +26,7 @@ ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
 RUN pyenv install 3.9.6 && \
     pyenv global 3.9.6 && \
-    pip install -U setuptools pip
+    pip install -U setuptools pip wheel
 
 RUN pip install -U 'numpy==1.20.*' 'scipy==1.7.*' 'optuna==3.*' 'cython==0.29.*'
 RUN pip uninstall -y mpi4py cuda-python && \

--- a/.pfnci/linux/tests/cuda110.multi.Dockerfile
+++ b/.pfnci/linux/tests/cuda110.multi.Dockerfile
@@ -26,7 +26,7 @@ ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
 RUN pyenv install 3.9.6 && \
     pyenv global 3.9.6 && \
-    pip install -U setuptools pip
+    pip install -U setuptools pip wheel
 
 RUN pip install -U 'numpy==1.20.*' 'scipy==1.7.*' 'optuna==3.*' 'mpi4py==3.*' 'cython==0.29.*'
 RUN pip uninstall -y cuda-python && \

--- a/.pfnci/linux/tests/cuda111.Dockerfile
+++ b/.pfnci/linux/tests/cuda111.Dockerfile
@@ -25,7 +25,7 @@ ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
 RUN pyenv install 3.8.11 && \
     pyenv global 3.8.11 && \
-    pip install -U setuptools pip
+    pip install -U setuptools pip wheel
 
 RUN pip install -U 'numpy==1.20.*' 'cython==0.29.*'
 RUN pip uninstall -y scipy optuna mpi4py cuda-python && \

--- a/.pfnci/linux/tests/cuda111.multi.Dockerfile
+++ b/.pfnci/linux/tests/cuda111.multi.Dockerfile
@@ -25,7 +25,7 @@ ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
 RUN pyenv install 3.8.11 && \
     pyenv global 3.8.11 && \
-    pip install -U setuptools pip
+    pip install -U setuptools pip wheel
 
 RUN pip install -U 'numpy==1.20.*' 'cython==0.29.*'
 RUN pip uninstall -y scipy optuna mpi4py cuda-python && \

--- a/.pfnci/linux/tests/cuda112.Dockerfile
+++ b/.pfnci/linux/tests/cuda112.Dockerfile
@@ -25,7 +25,7 @@ ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
 RUN pyenv install 3.8.11 && \
     pyenv global 3.8.11 && \
-    pip install -U setuptools pip
+    pip install -U setuptools pip wheel
 
 RUN pip install -U 'numpy==1.21.*' 'scipy==1.7.*' 'optuna==3.*' 'cython==0.29.*'
 RUN pip uninstall -y mpi4py cuda-python && \

--- a/.pfnci/linux/tests/cuda112.multi.Dockerfile
+++ b/.pfnci/linux/tests/cuda112.multi.Dockerfile
@@ -25,7 +25,7 @@ ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
 RUN pyenv install 3.8.11 && \
     pyenv global 3.8.11 && \
-    pip install -U setuptools pip
+    pip install -U setuptools pip wheel
 
 RUN pip install -U 'numpy==1.21.*' 'scipy==1.7.*' 'optuna==3.*' 'cython==0.29.*'
 RUN pip uninstall -y mpi4py cuda-python && \

--- a/.pfnci/linux/tests/cuda113.Dockerfile
+++ b/.pfnci/linux/tests/cuda113.Dockerfile
@@ -26,7 +26,7 @@ ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
 RUN pyenv install 3.8.11 && \
     pyenv global 3.8.11 && \
-    pip install -U setuptools pip
+    pip install -U setuptools pip wheel
 
 RUN pip install -U 'numpy==1.20.*' 'scipy==1.6.*' 'optuna==3.*' 'cython==0.29.*'
 RUN pip uninstall -y mpi4py cuda-python && \

--- a/.pfnci/linux/tests/cuda113.multi.Dockerfile
+++ b/.pfnci/linux/tests/cuda113.multi.Dockerfile
@@ -26,7 +26,7 @@ ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
 RUN pyenv install 3.8.11 && \
     pyenv global 3.8.11 && \
-    pip install -U setuptools pip
+    pip install -U setuptools pip wheel
 
 RUN pip install -U 'numpy==1.20.*' 'scipy==1.6.*' 'optuna==3.*' 'mpi4py==3.*' 'cython==0.29.*'
 RUN pip uninstall -y cuda-python && \

--- a/.pfnci/linux/tests/cuda114.Dockerfile
+++ b/.pfnci/linux/tests/cuda114.Dockerfile
@@ -26,7 +26,7 @@ ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
 RUN pyenv install 3.10.0 && \
     pyenv global 3.10.0 && \
-    pip install -U setuptools pip
+    pip install -U setuptools pip wheel
 
 RUN pip install -U 'numpy==1.22.*' 'scipy==1.7.*' 'optuna==3.*' 'cython==0.29.*'
 RUN pip uninstall -y mpi4py cuda-python && \

--- a/.pfnci/linux/tests/cuda114.multi.Dockerfile
+++ b/.pfnci/linux/tests/cuda114.multi.Dockerfile
@@ -26,7 +26,7 @@ ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
 RUN pyenv install 3.10.0 && \
     pyenv global 3.10.0 && \
-    pip install -U setuptools pip
+    pip install -U setuptools pip wheel
 
 RUN pip install -U 'numpy==1.22.*' 'scipy==1.7.*' 'optuna==3.*' 'mpi4py==3.*' 'cython==0.29.*'
 RUN pip uninstall -y cuda-python && \

--- a/.pfnci/linux/tests/cuda115.Dockerfile
+++ b/.pfnci/linux/tests/cuda115.Dockerfile
@@ -26,7 +26,7 @@ ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
 RUN pyenv install 3.10.0 && \
     pyenv global 3.10.0 && \
-    pip install -U setuptools pip
+    pip install -U setuptools pip wheel
 
 RUN pip install -U 'numpy==1.23.*' 'scipy==1.8.*' 'optuna==3.*' 'cython==0.29.*'
 RUN pip uninstall -y mpi4py cuda-python && \

--- a/.pfnci/linux/tests/cuda115.multi.Dockerfile
+++ b/.pfnci/linux/tests/cuda115.multi.Dockerfile
@@ -26,7 +26,7 @@ ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
 RUN pyenv install 3.10.0 && \
     pyenv global 3.10.0 && \
-    pip install -U setuptools pip
+    pip install -U setuptools pip wheel
 
 RUN pip install -U 'numpy==1.23.*' 'scipy==1.8.*' 'optuna==3.*' 'mpi4py==3.*' 'cython==0.29.*'
 RUN pip uninstall -y cuda-python && \

--- a/.pfnci/linux/tests/cuda116.Dockerfile
+++ b/.pfnci/linux/tests/cuda116.Dockerfile
@@ -26,7 +26,7 @@ ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
 RUN pyenv install 3.11.0 && \
     pyenv global 3.11.0 && \
-    pip install -U setuptools pip
+    pip install -U setuptools pip wheel
 
 RUN pip install -U 'numpy==1.23.*' 'scipy==1.9.*' 'optuna==3.*' 'cython==0.29.*'
 RUN pip uninstall -y mpi4py cuda-python && \

--- a/.pfnci/linux/tests/cuda116.multi.Dockerfile
+++ b/.pfnci/linux/tests/cuda116.multi.Dockerfile
@@ -26,7 +26,7 @@ ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
 RUN pyenv install 3.11.0 && \
     pyenv global 3.11.0 && \
-    pip install -U setuptools pip
+    pip install -U setuptools pip wheel
 
 RUN pip install -U 'numpy==1.23.*' 'scipy==1.9.*' 'optuna==3.*' 'mpi4py==3.*' 'cython==0.29.*'
 RUN pip uninstall -y cuda-python && \

--- a/.pfnci/linux/tests/cuda117.Dockerfile
+++ b/.pfnci/linux/tests/cuda117.Dockerfile
@@ -26,7 +26,7 @@ ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
 RUN pyenv install 3.11.0 && \
     pyenv global 3.11.0 && \
-    pip install -U setuptools pip
+    pip install -U setuptools pip wheel
 
 RUN pip install -U 'numpy==1.23.*' 'scipy==1.9.*' 'optuna==3.*' 'cython==0.29.*'
 RUN pip uninstall -y mpi4py cuda-python && \

--- a/.pfnci/linux/tests/cuda117.multi.Dockerfile
+++ b/.pfnci/linux/tests/cuda117.multi.Dockerfile
@@ -26,7 +26,7 @@ ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
 RUN pyenv install 3.11.0 && \
     pyenv global 3.11.0 && \
-    pip install -U setuptools pip
+    pip install -U setuptools pip wheel
 
 RUN pip install -U 'numpy==1.23.*' 'scipy==1.9.*' 'optuna==3.*' 'mpi4py==3.*' 'cython==0.29.*'
 RUN pip uninstall -y cuda-python && \

--- a/.pfnci/linux/tests/cuda118.Dockerfile
+++ b/.pfnci/linux/tests/cuda118.Dockerfile
@@ -26,7 +26,7 @@ ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
 RUN pyenv install 3.11.0 && \
     pyenv global 3.11.0 && \
-    pip install -U setuptools pip
+    pip install -U setuptools pip wheel
 
 RUN pip install -U 'numpy==1.24.*' 'scipy==1.9.*' 'optuna==3.*' 'cython==0.29.*'
 RUN pip uninstall -y mpi4py cuda-python && \

--- a/.pfnci/linux/tests/cuda118.multi.Dockerfile
+++ b/.pfnci/linux/tests/cuda118.multi.Dockerfile
@@ -26,7 +26,7 @@ ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
 RUN pyenv install 3.11.0 && \
     pyenv global 3.11.0 && \
-    pip install -U setuptools pip
+    pip install -U setuptools pip wheel
 
 RUN pip install -U 'numpy==1.24.*' 'scipy==1.9.*' 'optuna==3.*' 'mpi4py==3.*' 'cython==0.29.*'
 RUN pip uninstall -y cuda-python && \

--- a/.pfnci/linux/tests/cuda11x-cuda-python.Dockerfile
+++ b/.pfnci/linux/tests/cuda11x-cuda-python.Dockerfile
@@ -26,7 +26,7 @@ ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
 RUN pyenv install 3.10.0 && \
     pyenv global 3.10.0 && \
-    pip install -U setuptools pip
+    pip install -U setuptools pip wheel
 
 RUN pip install -U 'numpy==1.21.*' 'scipy==1.7.*' 'optuna==3.*' 'cython==0.29.*' 'cuda-python==11.*'
 RUN pip uninstall -y mpi4py && \

--- a/.pfnci/linux/tests/cuda120.Dockerfile
+++ b/.pfnci/linux/tests/cuda120.Dockerfile
@@ -26,7 +26,7 @@ ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
 RUN pyenv install 3.11.0 && \
     pyenv global 3.11.0 && \
-    pip install -U setuptools pip
+    pip install -U setuptools pip wheel
 
 RUN pip install -U 'numpy==1.23.*' 'scipy==1.9.*' 'optuna==3.*' 'cython==0.29.*'
 RUN pip uninstall -y mpi4py cuda-python && \

--- a/.pfnci/linux/tests/cuda120.multi.Dockerfile
+++ b/.pfnci/linux/tests/cuda120.multi.Dockerfile
@@ -26,7 +26,7 @@ ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
 RUN pyenv install 3.11.0 && \
     pyenv global 3.11.0 && \
-    pip install -U setuptools pip
+    pip install -U setuptools pip wheel
 
 RUN pip install -U 'numpy==1.23.*' 'scipy==1.9.*' 'optuna==3.*' 'mpi4py==3.*' 'cython==0.29.*'
 RUN pip uninstall -y cuda-python && \

--- a/.pfnci/linux/tests/cuda121.Dockerfile
+++ b/.pfnci/linux/tests/cuda121.Dockerfile
@@ -26,7 +26,7 @@ ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
 RUN pyenv install 3.11.0 && \
     pyenv global 3.11.0 && \
-    pip install -U setuptools pip
+    pip install -U setuptools pip wheel
 
 RUN pip install -U 'numpy==1.23.*' 'scipy==1.9.*' 'optuna==3.*' 'cython==0.29.*'
 RUN pip uninstall -y mpi4py cuda-python && \

--- a/.pfnci/linux/tests/cuda121.multi.Dockerfile
+++ b/.pfnci/linux/tests/cuda121.multi.Dockerfile
@@ -26,7 +26,7 @@ ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
 RUN pyenv install 3.11.0 && \
     pyenv global 3.11.0 && \
-    pip install -U setuptools pip
+    pip install -U setuptools pip wheel
 
 RUN pip install -U 'numpy==1.23.*' 'scipy==1.9.*' 'optuna==3.*' 'mpi4py==3.*' 'cython==0.29.*'
 RUN pip uninstall -y cuda-python && \

--- a/.pfnci/linux/tests/rocm-4-3.Dockerfile
+++ b/.pfnci/linux/tests/rocm-4-3.Dockerfile
@@ -32,7 +32,7 @@ ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
 RUN pyenv install 3.8.11 && \
     pyenv global 3.8.11 && \
-    pip install -U setuptools pip
+    pip install -U setuptools pip wheel
 
 RUN pip install -U 'numpy==1.20.*' 'scipy==1.6.*' 'optuna==3.*' 'cython==0.29.*'
 RUN pip uninstall -y mpi4py cuda-python && \

--- a/.pfnci/linux/tests/rocm-5-0.Dockerfile
+++ b/.pfnci/linux/tests/rocm-5-0.Dockerfile
@@ -32,7 +32,7 @@ ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
 RUN pyenv install 3.10.0 && \
     pyenv global 3.10.0 && \
-    pip install -U setuptools pip
+    pip install -U setuptools pip wheel
 
 RUN pip install -U 'numpy==1.23.*' 'scipy==1.9.*' 'optuna==3.*' 'cython==0.29.*'
 RUN pip uninstall -y mpi4py cuda-python && \

--- a/.pfnci/linux/tests/rocm-5-3.Dockerfile
+++ b/.pfnci/linux/tests/rocm-5-3.Dockerfile
@@ -32,7 +32,7 @@ ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
 RUN pyenv install 3.11.0 && \
     pyenv global 3.11.0 && \
-    pip install -U setuptools pip
+    pip install -U setuptools pip wheel
 
 RUN pip install -U 'numpy==1.24.*' 'scipy==1.9.*' 'optuna==3.*' 'cython==0.29.*'
 RUN pip uninstall -y mpi4py cuda-python && \


### PR DESCRIPTION
Fixes the CI failure of CUDA Python. THe CUDA Python installed in the environment cannot be found during CuPy build because the build is done in isolated environment if `wheel` package is missing.

https://pip.pypa.io/en/stable/news/#v23-1

> When the wheel package is not installed, pip now uses the default build backend instead of setup.py install and setup.py develop for project without pyproject.toml.