### PR TITLE
Add `cupy.lib.stride_tricks.sliding_window_view`

### DIFF
--- a/cupy/lib/stride_tricks.py
+++ b/cupy/lib/stride_tricks.py
@@ -116,7 +116,7 @@ def sliding_window_view(x, window_shape, axis=None, *,
 
     # writeable is not supported:
     if writeable:
-            raise NotImplementedError("Writeable views are not supported.")
+        raise NotImplementedError("Writeable views are not supported.")
 
     # first convert input to array, possibly keeping subclass
     x = _cupy.array(x, copy=False, subok=subok)

--- a/cupy/lib/stride_tricks.py
+++ b/cupy/lib/stride_tricks.py
@@ -1,5 +1,6 @@
 import cupy as _cupy
 import numpy as np
+from numpy.core.numeric import normalize_axis_tuple
 
 def as_strided(x, shape=None, strides=None):
     """
@@ -126,7 +127,7 @@ def sliding_window_view(x, window_shape, axis=None, *,
                              f'got {len(window_shape)} window_shape elements '
                              f'and `x.ndim` is {x.ndim}.')
     else:
-        axis = np.normalize_axis_tuple(axis, x.ndim)
+        axis = normalize_axis_tuple(axis, x.ndim)
         if len(window_shape) != len(axis):
             raise ValueError(f'Must provide matching length window_shape and '
                              f'axis; got {len(window_shape)} window_shape '

--- a/cupy/lib/stride_tricks.py
+++ b/cupy/lib/stride_tricks.py
@@ -69,7 +69,7 @@ def sliding_window_view(x, window_shape, axis=None, *,
     subok : bool, optional
         If True, sub-classes will be passed-through, otherwise the returned
         array will be forced to be a base-class array (default).
-    writeable : bool, optional
+    writeable : bool, optional -- not supported
         When true, allow writing to the returned view. The default is false,
         as this should be used with caution: the returned view contains the
         same memory location multiple times, so writing to one location will
@@ -109,9 +109,14 @@ def sliding_window_view(x, window_shape, axis=None, *,
            [3, 4, 5]])
 
     """
+
     window_shape = (tuple(window_shape)
                     if np.iterable(window_shape)
                     else (window_shape,))
+
+    # writeable is not supported:
+    if writeable:
+            raise NotImplementedError("Writeable views are not supported.")
 
     # first convert input to array, possibly keeping subclass
     x = _cupy.array(x, copy=False, subok=subok)
@@ -129,7 +134,7 @@ def sliding_window_view(x, window_shape, axis=None, *,
                              f'got {len(window_shape)} window_shape elements '
                              f'and `x.ndim` is {x.ndim}.')
     else:
-        axis = np.core.numeric.normalize_axis_tuple(axis, x.ndim)
+        axis = _cupy._core.internal._normalize_axis_indices(axis, x.ndim)
         if len(window_shape) != len(axis):
             raise ValueError(f'Must provide matching length window_shape and '
                              f'axis; got {len(window_shape)} window_shape '

--- a/cupy/lib/stride_tricks.py
+++ b/cupy/lib/stride_tricks.py
@@ -116,9 +116,9 @@ def sliding_window_view(x, window_shape, axis=None, *,
     # first convert input to array, possibly keeping subclass
     x = _cupy.array(x, copy=False, subok=subok)
 
-    window_shape_array = _cupy.array(window_shape)
-    if _cupy.any(window_shape_array < 0):
-        raise ValueError('`window_shape` cannot contain negative values')
+    for dim in window_shape_array:
+        if dim < 0:
+            raise ValueError('`window_shape` cannot contain negative values')
 
     if axis is None:
         axis = tuple(range(x.ndim))

--- a/cupy/lib/stride_tricks.py
+++ b/cupy/lib/stride_tricks.py
@@ -48,7 +48,7 @@ def sliding_window_view(x, window_shape, axis=None, *,
     positions.
 
 
-	Parameters
+    Parameters
     ----------
     x : array_like
         Array to create the sliding window view from.

--- a/cupy/lib/stride_tricks.py
+++ b/cupy/lib/stride_tricks.py
@@ -1,6 +1,5 @@
 import cupy as _cupy
 import numpy as np
-from ..core.internal import _normalize_axis_indices as normalize_axis_tuple
 
 def as_strided(x, shape=None, strides=None):
     """
@@ -112,14 +111,6 @@ def sliding_window_view(x, window_shape, axis=None, *,
                     if np.iterable(window_shape)
                     else (window_shape,))
 
-    # -- because normalize_axis_tuple does not handle lists:
-    # -- with Xarray it causes error : 
-    # -- TypeError: 'list' object cannot be interpreted as an integer
-    axis = (
-        axis[0]
-        if np.iterable(axis) and len(axis) == 1
-        else axis)
-
     # first convert input to array, possibly keeping subclass
     x = _cupy.array(x, copy=False, subok=subok)
 
@@ -135,7 +126,7 @@ def sliding_window_view(x, window_shape, axis=None, *,
                              f'got {len(window_shape)} window_shape elements '
                              f'and `x.ndim` is {x.ndim}.')
     else:
-        axis = normalize_axis_tuple(axis, x.ndim)
+        axis = np.normalize_axis_tuple(axis, x.ndim)
         if len(window_shape) != len(axis):
             raise ValueError(f'Must provide matching length window_shape and '
                              f'axis; got {len(window_shape)} window_shape '

--- a/cupy/lib/stride_tricks.py
+++ b/cupy/lib/stride_tricks.py
@@ -116,6 +116,7 @@ def sliding_window_view(x, window_shape, axis=None, *,
     # first convert input to array, possibly keeping subclass
     x = _cupy.array(x, copy=False, subok=subok)
 
+    window_shape_array = _cupy.array(window_shape)
     for dim in window_shape_array:
         if dim < 0:
             raise ValueError('`window_shape` cannot contain negative values')

--- a/cupy/lib/stride_tricks.py
+++ b/cupy/lib/stride_tricks.py
@@ -152,10 +152,3 @@ def sliding_window_view(x, window_shape, axis=None, *,
         x_shape_trimmed[ax] -= dim - 1
     out_shape = tuple(x_shape_trimmed) + window_shape
     return as_strided(x, strides=out_strides, shape=out_shape)
-
-
-
-
-
-
-

--- a/cupy/lib/stride_tricks.py
+++ b/cupy/lib/stride_tricks.py
@@ -1,6 +1,7 @@
 import cupy as _cupy
 import numpy as np
 
+
 def as_strided(x, shape=None, strides=None):
     """
     Create a view into the array with the given shape and strides.
@@ -37,6 +38,7 @@ def as_strided(x, shape=None, strides=None):
 
     return _cupy.ndarray(shape=shape, dtype=x.dtype,
                          memptr=x.data, strides=strides)
+
 
 def sliding_window_view(x, window_shape, axis=None, *,
                         subok=False, writeable=False):

--- a/cupy/lib/stride_tricks.py
+++ b/cupy/lib/stride_tricks.py
@@ -41,7 +41,73 @@ def as_strided(x, shape=None, strides=None):
 
 def sliding_window_view(x, window_shape, axis=None, *,
                         subok=False, writeable=False):
+    """
+    Create a sliding window view into the array with the given window shape.
 
+    Also known as rolling or moving window, the window slides across all
+    dimensions of the array and extracts subsets of the array at all window
+    positions.
+
+
+	Parameters
+    ----------
+    x : array_like
+        Array to create the sliding window view from.
+    window_shape : int or tuple of int
+        Size of window over each axis that takes part in the sliding window.
+        If `axis` is not present, must have same length as the number of input
+        array dimensions. Single integers `i` are treated as if they were the
+        tuple `(i,)`.
+    axis : int or tuple of int, optional
+        Axis or axes along which the sliding window is applied.
+        By default, the sliding window is applied to all axes and
+        `window_shape[i]` will refer to axis `i` of `x`.
+        If `axis` is given as a `tuple of int`, `window_shape[i]` will refer to
+        the axis `axis[i]` of `x`.
+        Single integers `i` are treated as if they were the tuple `(i,)`.
+    subok : bool, optional
+        If True, sub-classes will be passed-through, otherwise the returned
+        array will be forced to be a base-class array (default).
+    writeable : bool, optional
+        When true, allow writing to the returned view. The default is false,
+        as this should be used with caution: the returned view contains the
+        same memory location multiple times, so writing to one location will
+        cause others to change.
+
+    Returns
+    -------
+    view : ndarray
+        Sliding window view of the array. The sliding window dimensions are
+        inserted at the end, and the original dimensions are trimmed as
+        required by the size of the sliding window.
+        That is, ``view.shape = x_shape_trimmed + window_shape``, where
+        ``x_shape_trimmed`` is ``x.shape`` with every entry reduced by one less
+        than the corresponding window size.
+
+
+    See also
+    --------
+    numpy.lib.stride_tricks.as_strided
+
+	Notes
+	--------
+	This function is adapted from numpy.lib.stride_tricks.as_strided.
+
+	Examples
+    --------
+    >>> x = _cupy.arange(6)
+    >>> x.shape
+    (6,)
+    >>> v = sliding_window_view(x, 3)
+    >>> v.shape
+    (4, 3)
+    >>> v
+    array([[0, 1, 2],
+           [1, 2, 3],
+           [2, 3, 4],
+           [3, 4, 5]])
+
+    """
     window_shape = (tuple(window_shape)
                     if np.iterable(window_shape)
                     else (window_shape,))
@@ -49,7 +115,6 @@ def sliding_window_view(x, window_shape, axis=None, *,
     # -- because normalize_axis_tuple does not handle lists:
     # -- with Xarray it causes error : 
     # -- TypeError: 'list' object cannot be interpreted as an integer
-    print ('axis :', axis)
     axis = (
         axis[0]
         if np.iterable(axis) and len(axis) == 1
@@ -64,15 +129,12 @@ def sliding_window_view(x, window_shape, axis=None, *,
 
     if axis is None:
         axis = tuple(range(x.ndim))
-        #print ('axis after None:', axis)
         if len(window_shape) != len(axis):
             raise ValueError(f'Since axis is `None`, must provide '
                              f'window_shape for all dimensions of `x`; '
                              f'got {len(window_shape)} window_shape elements '
                              f'and `x.ndim` is {x.ndim}.')
     else:
-        #print ('axis:', axis)
-        #print ('x.ndim:',x.ndim)
         axis = normalize_axis_tuple(axis, x.ndim)
         if len(window_shape) != len(axis):
             raise ValueError(f'Must provide matching length window_shape and '

--- a/cupy/lib/stride_tricks.py
+++ b/cupy/lib/stride_tricks.py
@@ -1,6 +1,5 @@
 import cupy as _cupy
 import numpy as np
-from numpy.core.numeric import normalize_axis_tuple
 
 def as_strided(x, shape=None, strides=None):
     """
@@ -127,7 +126,7 @@ def sliding_window_view(x, window_shape, axis=None, *,
                              f'got {len(window_shape)} window_shape elements '
                              f'and `x.ndim` is {x.ndim}.')
     else:
-        axis = normalize_axis_tuple(axis, x.ndim)
+        axis = np.core.numeric.normalize_axis_tuple(axis, x.ndim)
         if len(window_shape) != len(axis):
             raise ValueError(f'Must provide matching length window_shape and '
                              f'axis; got {len(window_shape)} window_shape '

--- a/cupy/lib/stride_tricks.py
+++ b/cupy/lib/stride_tricks.py
@@ -88,11 +88,11 @@ def sliding_window_view(x, window_shape, axis=None, *,
     --------
     numpy.lib.stride_tricks.as_strided
 
-	Notes
-	--------
-	This function is adapted from numpy.lib.stride_tricks.as_strided.
+    Notes
+    --------
+    This function is adapted from numpy.lib.stride_tricks.as_strided.
 
-	Examples
+    Examples
     --------
     >>> x = _cupy.arange(6)
     >>> x.shape

--- a/tests/cupy_tests/lib_tests/test_strided_tricks.py
+++ b/tests/cupy_tests/lib_tests/test_strided_tricks.py
@@ -84,6 +84,26 @@ class TestSlidingWindowView(unittest.TestCase):
         with pytest.raises(ValueError, match='Since axis is `None`'):
             stride_tricks.sliding_window_view(x, window_shape, axis)
 
+    def test_otherarrays (self):
+        x = numpy.arange(5)
+        arr_view = stride_tricks.sliding_window_view(x, 2)
+        expected=[[0,1],
+                  [1,2],
+                  [2,3],
+                  [3,4]]
+        testing.assert_array_equal(arr_view, expected)
+
+    def test_writeable_views_not_supported(self):
+        x = cupy.arange(24).reshape((2, 3, 4))
+        window_shape = (2, 2)
+        axis = None
+        writeable = True
+
+        with self.assertRaises(NotImplementedError):
+            stride_tricks.sliding_window_view(x, window_shape, axis, writeable=writeable)
+
+
+
 def rolling_window(a, window, axis=-1):
     """
     Make an ndarray with a rolling window along axis.

--- a/tests/cupy_tests/lib_tests/test_strided_tricks.py
+++ b/tests/cupy_tests/lib_tests/test_strided_tricks.py
@@ -12,14 +12,12 @@ import pytest
 class TestAsStrided(unittest.TestCase):
     def test_as_strided(self):
         a = cupy.array([1, 2, 3, 4])
-        a_view = stride_tricks.as_strided(
-            a, shape=(2,), strides=(2 * a.itemsize,))
+        a_view = stride_tricks.as_strided(a, shape=(2,), strides=(2 * a.itemsize,))
         expected = cupy.array([1, 3])
         testing.assert_array_equal(a_view, expected)
 
         a = cupy.array([1, 2, 3, 4])
-        a_view = stride_tricks.as_strided(
-            a, shape=(3, 4), strides=(0, 1 * a.itemsize))
+        a_view = stride_tricks.as_strided(a, shape=(3, 4), strides=(0, 1 * a.itemsize))
         expected = cupy.array([[1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4]])
         testing.assert_array_equal(a_view, expected)
 
@@ -35,8 +33,7 @@ class TestSlidingWindowView(unittest.TestCase):
     def test_1d(self, xp):
         arr = testing.shaped_arange((3, 4), xp)
         window_size = 2
-        arr_view = xp.lib.stride_tricks.sliding_window_view(
-            arr, window_size, 0)
+        arr_view = xp.lib.stride_tricks.sliding_window_view(arr, window_size, 0)
         return arr_view
 
     @testing.numpy_cupy_array_equal()
@@ -44,7 +41,8 @@ class TestSlidingWindowView(unittest.TestCase):
         arr = testing.shaped_arange((3, 4), xp)
         window_shape = (2, 2)
         arr_view = xp.lib.stride_tricks.sliding_window_view(
-            arr, window_shape=window_shape)
+            arr, window_shape=window_shape
+        )
         return arr_view
 
     @testing.numpy_cupy_array_equal()
@@ -52,8 +50,7 @@ class TestSlidingWindowView(unittest.TestCase):
         arr = testing.shaped_arange((3, 4), xp)
         window_shape = 3
         axis = 0
-        arr_view = xp.lib.stride_tricks.sliding_window_view(
-            arr, window_shape, axis)
+        arr_view = xp.lib.stride_tricks.sliding_window_view(arr, window_shape, axis)
         return arr_view
 
     @testing.numpy_cupy_array_equal()
@@ -61,8 +58,7 @@ class TestSlidingWindowView(unittest.TestCase):
         arr = testing.shaped_arange((3, 4), xp)
         window_shape = (2, 3)
         axis = (0, 1)
-        arr_view = xp.lib.stride_tricks.sliding_window_view(
-            arr, window_shape, axis)
+        arr_view = xp.lib.stride_tricks.sliding_window_view(arr, window_shape, axis)
         return arr_view
 
     def test_0d(self):
@@ -72,7 +68,7 @@ class TestSlidingWindowView(unittest.TestCase):
         window_size = 1
 
         # Test if the correct ValueError is raised!
-        with pytest.raises(ValueError, match='axis 0 is out of bounds'):
+        with pytest.raises(ValueError, match="axis 0 is out of bounds"):
             cupy.lib.stride_tricks.sliding_window_view(arr, window_size, 0)
 
     def test_window_shape_axis_length_mismatch(self):
@@ -81,16 +77,13 @@ class TestSlidingWindowView(unittest.TestCase):
         axis = None
 
         # Test if ValueError is raised when len(window_shape) != len(axis)
-        with pytest.raises(ValueError, match='Since axis is `None`'):
+        with pytest.raises(ValueError, match="Since axis is `None`"):
             stride_tricks.sliding_window_view(x, window_shape, axis)
 
-    def test_otherarrays (self):
+    def test_otherarrays(self):
         x = numpy.arange(5)
         arr_view = stride_tricks.sliding_window_view(x, 2)
-        expected=[[0,1],
-                  [1,2],
-                  [2,3],
-                  [3,4]]
+        expected = [[0, 1], [1, 2], [2, 3], [3, 4]]
         testing.assert_array_equal(arr_view, expected)
 
     def test_writeable_views_not_supported(self):
@@ -100,8 +93,9 @@ class TestSlidingWindowView(unittest.TestCase):
         writeable = True
 
         with self.assertRaises(NotImplementedError):
-            stride_tricks.sliding_window_view(x, window_shape, axis, writeable=writeable)
-
+            stride_tricks.sliding_window_view(
+                x, window_shape, axis, writeable=writeable
+            )
 
 
 def rolling_window(a, window, axis=-1):
@@ -114,8 +108,7 @@ def rolling_window(a, window, axis=-1):
     shape = a.shape[:-1] + (a.shape[-1] - window + 1, window)
     strides = a.strides + (a.strides[-1],)
     if isinstance(a, numpy.ndarray):
-        rolling = numpy.lib.stride_tricks.as_strided(
-            a, shape=shape, strides=strides)
+        rolling = numpy.lib.stride_tricks.as_strided(a, shape=shape, strides=strides)
     elif isinstance(a, cupy.ndarray):
         rolling = stride_tricks.as_strided(a, shape=shape, strides=strides)
     return rolling.swapaxes(-2, axis)

--- a/tests/cupy_tests/lib_tests/test_strided_tricks.py
+++ b/tests/cupy_tests/lib_tests/test_strided_tricks.py
@@ -34,6 +34,7 @@ class TestSlidingWindowView(unittest.TestCase):
         arr = testing.shaped_arange((3, 4), xp)
         window_size = 2
         arr_view = xp.lib.stride_tricks.sliding_window_view(arr, window_size, 0)
+        assert arr_view.strides == (16, 4, 16)
         return arr_view
 
     @testing.numpy_cupy_array_equal()
@@ -43,14 +44,17 @@ class TestSlidingWindowView(unittest.TestCase):
         arr_view = xp.lib.stride_tricks.sliding_window_view(
             arr, window_shape=window_shape
         )
+        assert arr_view.strides == (16, 4, 16, 4)
         return arr_view
 
     @testing.numpy_cupy_array_equal()
     def test_2d_with_axis(self, xp):
         arr = testing.shaped_arange((3, 4), xp)
         window_shape = 3
-        axis = 0
-        arr_view = xp.lib.stride_tricks.sliding_window_view(arr, window_shape, axis)
+        axis = 1
+        arr_view = xp.lib.stride_tricks.sliding_window_view(
+            arr, window_shape, axis)
+        assert arr_view.strides == (16, 4, 4)
         return arr_view
 
     @testing.numpy_cupy_array_equal()
@@ -59,32 +63,36 @@ class TestSlidingWindowView(unittest.TestCase):
         window_shape = (2, 3)
         axis = (0, 1)
         arr_view = xp.lib.stride_tricks.sliding_window_view(arr, window_shape, axis)
+        assert arr_view.strides == (16, 4, 16, 4)
         return arr_view
 
     def test_0d(self):
-        # Create a 0-D array (scalar) for testing
-        arr = cupy.array(42)
-        # Sliding window with window size 1
-        window_size = 1
+        for xp in (numpy, cupy):
+            # Create a 0-D array (scalar) for testing
+            arr = xp.array(42)
+            # Sliding window with window size 1
+            window_size = 1
 
-        # Test if the correct ValueError is raised!
-        with pytest.raises(ValueError, match="axis 0 is out of bounds"):
-            cupy.lib.stride_tricks.sliding_window_view(arr, window_size, 0)
+            # Test if the correct ValueError is raised!
+            with pytest.raises(ValueError, match="axis 0 is out of bounds"):
+                xp.lib.stride_tricks.sliding_window_view(arr, window_size, 0)
 
     def test_window_shape_axis_length_mismatch(self):
-        x = cupy.arange(24).reshape((2, 3, 4))
-        window_shape = (2, 2)
-        axis = None
+        for xp in (numpy, cupy):
+            x = xp.arange(24).reshape((2, 3, 4))
+            window_shape = (2, 2)
+            axis = None
 
-        # Test if ValueError is raised when len(window_shape) != len(axis)
-        with pytest.raises(ValueError, match="Since axis is `None`"):
-            stride_tricks.sliding_window_view(x, window_shape, axis)
+            # Test if ValueError is raised when len(window_shape) != len(axis)
+            with pytest.raises(ValueError, match="Since axis is `None`"):
+                xp.lib.stride_tricks.sliding_window_view(x, window_shape, axis)
 
-    def test_otherarrays(self):
-        x = numpy.arange(5)
-        arr_view = stride_tricks.sliding_window_view(x, 2)
-        expected = [[0, 1], [1, 2], [2, 3], [3, 4]]
-        testing.assert_array_equal(arr_view, expected)
+    @testing.numpy_cupy_array_equal()
+    def test_arraylike_input(self, xp):
+        x = [0, 1, 2, 3, 4]
+        arr_view = xp.lib.stride_tricks.sliding_window_view(x, 2)
+        assert arr_view.strides == (8, 8)
+        return arr_view
 
     def test_writeable_views_not_supported(self):
         x = cupy.arange(24).reshape((2, 3, 4))

--- a/tests/cupy_tests/lib_tests/test_strided_tricks.py
+++ b/tests/cupy_tests/lib_tests/test_strided_tricks.py
@@ -31,32 +31,36 @@ class TestAsStrided(unittest.TestCase):
 class TestSlidingWindowView(unittest.TestCase):
     @testing.numpy_cupy_array_equal()
     def test_1d(self, xp):
-        arr = testing.shaped_arange((3,4), xp)
+        arr = testing.shaped_arange((3, 4), xp)
         window_size = 2
-        arr_view = xp.lib.stride_tricks.sliding_window_view(arr, window_size, 0)
+        arr_view = xp.lib.stride_tricks.sliding_window_view(
+            arr, window_size, 0)
         return arr_view
 
     @testing.numpy_cupy_array_equal()
     def test_2d(self, xp):
-        arr = testing.shaped_arange((3,4), xp)
-        window_shape = (2,2)
-        arr_view = xp.lib.stride_tricks.sliding_window_view(arr, window_shape=window_shape)
+        arr = testing.shaped_arange((3, 4), xp)
+        window_shape = (2, 2)
+        arr_view = xp.lib.stride_tricks.sliding_window_view(
+            arr, window_shape=window_shape)
         return arr_view
 
     @testing.numpy_cupy_array_equal()
     def test_2d_with_axis(self, xp):
-        arr = testing.shaped_arange((3,4), xp)
+        arr = testing.shaped_arange((3, 4), xp)
         window_shape = 3
         axis = 0
-        arr_view = xp.lib.stride_tricks.sliding_window_view(arr, window_shape,axis)
+        arr_view = xp.lib.stride_tricks.sliding_window_view(
+            arr, window_shape, axis)
         return arr_view
 
     @testing.numpy_cupy_array_equal()
     def test_2d_multi_axis(self, xp):
-        arr = testing.shaped_arange((3,4), xp)
-        window_shape = (2,3)
-        axis = (0,1)
-        arr_view = xp.lib.stride_tricks.sliding_window_view(arr, window_shape,axis)
+        arr = testing.shaped_arange((3, 4), xp)
+        window_shape = (2, 3)
+        axis = (0, 1)
+        arr_view = xp.lib.stride_tricks.sliding_window_view(
+            arr, window_shape, axis)
         return arr_view
 
 

--- a/tests/cupy_tests/lib_tests/test_strided_tricks.py
+++ b/tests/cupy_tests/lib_tests/test_strided_tricks.py
@@ -12,12 +12,14 @@ import pytest
 class TestAsStrided(unittest.TestCase):
     def test_as_strided(self):
         a = cupy.array([1, 2, 3, 4])
-        a_view = stride_tricks.as_strided(a, shape=(2,), strides=(2 * a.itemsize,))
+        a_view = stride_tricks.as_strided(
+            a, shape=(2,), strides=(2 * a.itemsize,))
         expected = cupy.array([1, 3])
         testing.assert_array_equal(a_view, expected)
 
         a = cupy.array([1, 2, 3, 4])
-        a_view = stride_tricks.as_strided(a, shape=(3, 4), strides=(0, 1 * a.itemsize))
+        a_view = stride_tricks.as_strided(
+            a, shape=(3, 4), strides=(0, 1 * a.itemsize))
         expected = cupy.array([[1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4]])
         testing.assert_array_equal(a_view, expected)
 
@@ -33,7 +35,8 @@ class TestSlidingWindowView(unittest.TestCase):
     def test_1d(self, xp):
         arr = testing.shaped_arange((3, 4), xp)
         window_size = 2
-        arr_view = xp.lib.stride_tricks.sliding_window_view(arr, window_size, 0)
+        arr_view = xp.lib.stride_tricks.sliding_window_view(
+            arr, window_size, 0)
         assert arr_view.strides == (16, 4, 16)
         return arr_view
 
@@ -62,7 +65,8 @@ class TestSlidingWindowView(unittest.TestCase):
         arr = testing.shaped_arange((3, 4), xp)
         window_shape = (2, 3)
         axis = (0, 1)
-        arr_view = xp.lib.stride_tricks.sliding_window_view(arr, window_shape, axis)
+        arr_view = xp.lib.stride_tricks.sliding_window_view(
+            arr, window_shape, axis)
         assert arr_view.strides == (16, 4, 16, 4)
         return arr_view
 
@@ -116,7 +120,8 @@ def rolling_window(a, window, axis=-1):
     shape = a.shape[:-1] + (a.shape[-1] - window + 1, window)
     strides = a.strides + (a.strides[-1],)
     if isinstance(a, numpy.ndarray):
-        rolling = numpy.lib.stride_tricks.as_strided(a, shape=shape, strides=strides)
+        rolling = numpy.lib.stride_tricks.as_strided(
+            a, shape=shape, strides=strides)
     elif isinstance(a, cupy.ndarray):
         rolling = stride_tricks.as_strided(a, shape=shape, strides=strides)
     return rolling.swapaxes(-2, axis)

--- a/tests/cupy_tests/lib_tests/test_strided_tricks.py
+++ b/tests/cupy_tests/lib_tests/test_strided_tricks.py
@@ -29,35 +29,35 @@ class TestAsStrided(unittest.TestCase):
         return a_rolling
 
 
-class TestSlidingWindowView:
+class TestSlidingWindowView(unittest.TestCase):
     @testing.numpy_cupy_array_equal()
-    def test_1d(self):
-        arr = testing.shaped_arange((9,))
-        window_size = 3
-        arr_view = sliding_window_view(arr, 2)
+    def test_1d(self, xp):
+        arr = testing.shaped_arange((9,), xp)
+        window_size = 2
+        arr_view = stride_tricks.sliding_window_view(arr, 2, 0)
         return arr_view
 
     @testing.numpy_cupy_array_equal()
-    def test_2d(self):
-        arr = testing.shaped_arange((3,4))
+    def test_2d(self, xp):
+        arr = testing.shaped_arange((3,4), xp)
         window_shape = (2,2)
-        arr_view = sliding_window_view_cp(arr, window_shape=window_shape)
+        arr_view = stride_tricks.sliding_window_view(arr, window_shape=window_shape)
         return arr_view
 
     @testing.numpy_cupy_array_equal()
-    def test_2d_with_axis(self):
-        arr = testing.shaped_arange((3,4))
+    def test_2d_with_axis(self, xp):
+        arr = testing.shaped_arange((3,4), xp)
         window_shape = 3
         axis = 0
-        arr_view = sliding_window_view_cp(arr, window_shape,axis)
+        arr_view = stride_tricks.sliding_window_view(arr, window_shape,axis)
         return arr_view
 
     @testing.numpy_cupy_array_equal()
-    def test_2d_multi_axis(self):
-        arr = testing.shaped_arange((3,4))
+    def test_2d_multi_axis(self, xp):
+        arr = testing.shaped_arange((3,4), xp)
         window_shape = (2,3)
         axis = (0,1)
-        arr_view = sliding_window_view_cp(arr, window_shape,axis)
+        arr_view = stride_tricks.sliding_window_view(arr, window_shape,axis)
         return arr_view
 
 

--- a/tests/cupy_tests/lib_tests/test_strided_tricks.py
+++ b/tests/cupy_tests/lib_tests/test_strided_tricks.py
@@ -29,6 +29,65 @@ class TestAsStrided(unittest.TestCase):
         return a_rolling
 
 
+class TestSlidingWindowView:
+    def test_1d(self):
+        arr = np.arange(5)
+        arr_view = sliding_window_view(arr, 2)
+        expected = np.array([[0, 1],
+                             [1, 2],
+                             [2, 3],
+                             [3, 4]])
+        assert_array_equal(arr_view, expected)
+
+    def test_2d(self):
+        i, j = np.ogrid[:3, :4]
+        arr = 10*i + j
+        shape = (2, 2)
+        arr_view = sliding_window_view(arr, shape)
+        expected = np.array([[[[0, 1], [10, 11]],
+                              [[1, 2], [11, 12]],
+                              [[2, 3], [12, 13]]],
+                             [[[10, 11], [20, 21]],
+                              [[11, 12], [21, 22]],
+                              [[12, 13], [22, 23]]]])
+        assert_array_equal(arr_view, expected)
+
+    def test_2d_with_axis(self):
+        i, j = np.ogrid[:3, :4]
+        arr = 10*i + j
+        arr_view = sliding_window_view(arr, 3, 0)
+        expected = np.array([[[0, 10, 20],
+                              [1, 11, 21],
+                              [2, 12, 22],
+                              [3, 13, 23]]])
+        assert_array_equal(arr_view, expected)
+
+    def test_2d_repeated_axis(self):
+        i, j = np.ogrid[:3, :4]
+        arr = 10*i + j
+        arr_view = sliding_window_view(arr, (2, 3), (1, 1))
+        expected = np.array([[[[0, 1, 2],
+                               [1, 2, 3]]],
+                             [[[10, 11, 12],
+                               [11, 12, 13]]],
+                             [[[20, 21, 22],
+                               [21, 22, 23]]]])
+        assert_array_equal(arr_view, expected)
+
+    def test_2d_without_axis(self):
+        i, j = np.ogrid[:4, :4]
+        arr = 10*i + j
+        shape = (2, 3)
+        arr_view = sliding_window_view(arr, shape)
+        expected = np.array([[[[0, 1, 2], [10, 11, 12]],
+                              [[1, 2, 3], [11, 12, 13]]],
+                             [[[10, 11, 12], [20, 21, 22]],
+                              [[11, 12, 13], [21, 22, 23]]],
+                             [[[20, 21, 22], [30, 31, 32]],
+                              [[21, 22, 23], [31, 32, 33]]]])
+        assert_array_equal(arr_view, expected)
+
+
 def rolling_window(a, window, axis=-1):
     """
     Make an ndarray with a rolling window along axis.

--- a/tests/cupy_tests/lib_tests/test_strided_tricks.py
+++ b/tests/cupy_tests/lib_tests/test_strided_tricks.py
@@ -25,23 +25,22 @@ class TestAsStrided(unittest.TestCase):
     def test_rolling_window(self, xp):
         a = testing.shaped_arange((3, 4), xp)
         a_rolling = rolling_window(a, 2, 0)
-
         return a_rolling
 
 
 class TestSlidingWindowView(unittest.TestCase):
     @testing.numpy_cupy_array_equal()
     def test_1d(self, xp):
-        arr = testing.shaped_arange((9,), xp)
+        arr = testing.shaped_arange((3,4), xp)
         window_size = 2
-        arr_view = stride_tricks.sliding_window_view(arr, 2, 0)
+        arr_view = xp.lib.stride_tricks.sliding_window_view(arr, window_size, 0)
         return arr_view
 
     @testing.numpy_cupy_array_equal()
     def test_2d(self, xp):
         arr = testing.shaped_arange((3,4), xp)
         window_shape = (2,2)
-        arr_view = stride_tricks.sliding_window_view(arr, window_shape=window_shape)
+        arr_view = xp.lib.stride_tricks.sliding_window_view(arr, window_shape=window_shape)
         return arr_view
 
     @testing.numpy_cupy_array_equal()
@@ -49,7 +48,7 @@ class TestSlidingWindowView(unittest.TestCase):
         arr = testing.shaped_arange((3,4), xp)
         window_shape = 3
         axis = 0
-        arr_view = stride_tricks.sliding_window_view(arr, window_shape,axis)
+        arr_view = xp.lib.stride_tricks.sliding_window_view(arr, window_shape,axis)
         return arr_view
 
     @testing.numpy_cupy_array_equal()
@@ -57,7 +56,7 @@ class TestSlidingWindowView(unittest.TestCase):
         arr = testing.shaped_arange((3,4), xp)
         window_shape = (2,3)
         axis = (0,1)
-        arr_view = stride_tricks.sliding_window_view(arr, window_shape,axis)
+        arr_view = xp.lib.stride_tricks.sliding_window_view(arr, window_shape,axis)
         return arr_view
 
 

--- a/tests/cupy_tests/lib_tests/test_strided_tricks.py
+++ b/tests/cupy_tests/lib_tests/test_strided_tricks.py
@@ -93,7 +93,7 @@ class TestSlidingWindowView(unittest.TestCase):
 
     @testing.numpy_cupy_array_equal()
     def test_arraylike_input(self, xp):
-        x = [0, 1, 2, 3, 4]
+        x = [0., 1., 2., 3., 4.]
         arr_view = xp.lib.stride_tricks.sliding_window_view(x, 2)
         assert arr_view.strides == (8, 8)
         return arr_view

--- a/tests/cupy_tests/lib_tests/test_strided_tricks.py
+++ b/tests/cupy_tests/lib_tests/test_strided_tricks.py
@@ -30,62 +30,35 @@ class TestAsStrided(unittest.TestCase):
 
 
 class TestSlidingWindowView:
+    @testing.numpy_cupy_array_equal()
     def test_1d(self):
-        arr = np.arange(5)
+        arr = testing.shaped_arange((9,))
+        window_size = 3
         arr_view = sliding_window_view(arr, 2)
-        expected = np.array([[0, 1],
-                             [1, 2],
-                             [2, 3],
-                             [3, 4]])
-        assert_array_equal(arr_view, expected)
+        return arr_view
 
+    @testing.numpy_cupy_array_equal()
     def test_2d(self):
-        i, j = np.ogrid[:3, :4]
-        arr = 10*i + j
-        shape = (2, 2)
-        arr_view = sliding_window_view(arr, shape)
-        expected = np.array([[[[0, 1], [10, 11]],
-                              [[1, 2], [11, 12]],
-                              [[2, 3], [12, 13]]],
-                             [[[10, 11], [20, 21]],
-                              [[11, 12], [21, 22]],
-                              [[12, 13], [22, 23]]]])
-        assert_array_equal(arr_view, expected)
+        arr = testing.shaped_arange((3,4))
+        window_shape = (2,2)
+        arr_view = sliding_window_view_cp(arr, window_shape=window_shape)
+        return arr_view
 
+    @testing.numpy_cupy_array_equal()
     def test_2d_with_axis(self):
-        i, j = np.ogrid[:3, :4]
-        arr = 10*i + j
-        arr_view = sliding_window_view(arr, 3, 0)
-        expected = np.array([[[0, 10, 20],
-                              [1, 11, 21],
-                              [2, 12, 22],
-                              [3, 13, 23]]])
-        assert_array_equal(arr_view, expected)
+        arr = testing.shaped_arange((3,4))
+        window_shape = 3
+        axis = 0
+        arr_view = sliding_window_view_cp(arr, window_shape,axis)
+        return arr_view
 
-    def test_2d_repeated_axis(self):
-        i, j = np.ogrid[:3, :4]
-        arr = 10*i + j
-        arr_view = sliding_window_view(arr, (2, 3), (1, 1))
-        expected = np.array([[[[0, 1, 2],
-                               [1, 2, 3]]],
-                             [[[10, 11, 12],
-                               [11, 12, 13]]],
-                             [[[20, 21, 22],
-                               [21, 22, 23]]]])
-        assert_array_equal(arr_view, expected)
-
-    def test_2d_without_axis(self):
-        i, j = np.ogrid[:4, :4]
-        arr = 10*i + j
-        shape = (2, 3)
-        arr_view = sliding_window_view(arr, shape)
-        expected = np.array([[[[0, 1, 2], [10, 11, 12]],
-                              [[1, 2, 3], [11, 12, 13]]],
-                             [[[10, 11, 12], [20, 21, 22]],
-                              [[11, 12, 13], [21, 22, 23]]],
-                             [[[20, 21, 22], [30, 31, 32]],
-                              [[21, 22, 23], [31, 32, 33]]]])
-        assert_array_equal(arr_view, expected)
+    @testing.numpy_cupy_array_equal()
+    def test_2d_multi_axis(self):
+        arr = testing.shaped_arange((3,4))
+        window_shape = (2,3)
+        axis = (0,1)
+        arr_view = sliding_window_view_cp(arr, window_shape,axis)
+        return arr_view
 
 
 def rolling_window(a, window, axis=-1):

--- a/tests/cupy_tests/lib_tests/test_strided_tricks.py
+++ b/tests/cupy_tests/lib_tests/test_strided_tricks.py
@@ -6,6 +6,8 @@ import cupy
 from cupy import testing
 from cupy.lib import stride_tricks
 
+import pytest
+
 
 class TestAsStrided(unittest.TestCase):
     def test_as_strided(self):
@@ -63,6 +65,24 @@ class TestSlidingWindowView(unittest.TestCase):
             arr, window_shape, axis)
         return arr_view
 
+    def test_0d(self):
+        # Create a 0-D array (scalar) for testing
+        arr = cupy.array(42)
+        # Sliding window with window size 1
+        window_size = 1
+
+        # Test if the correct ValueError is raised!
+        with pytest.raises(ValueError, match='axis 0 is out of bounds'):
+            cupy.lib.stride_tricks.sliding_window_view(arr, window_size, 0)
+
+    def test_window_shape_axis_length_mismatch(self):
+        x = cupy.arange(24).reshape((2, 3, 4))
+        window_shape = (2, 2)
+        axis = None
+
+        # Test if ValueError is raised when len(window_shape) != len(axis)
+        with pytest.raises(ValueError, match='Since axis is `None`'):
+            stride_tricks.sliding_window_view(x, window_shape, axis)
 
 def rolling_window(a, window, axis=-1):
     """


### PR DESCRIPTION
## Summary

This pull request introduces the `sliding_window_view` function to CuPy, enhancing its alignment with the NumPy API. The addition of this feature allows users to create a sliding window view of n-dimensional arrays, providing powerful and flexible functionality for array manipulation. Please see #6078. 

## Key Changes

- Implements the `sliding_window_view` function in CuPy, similar to its counterpart in the NumPy API.
- Resolves: Issue #6956 and part of #6078.  Also relevant to [cupy-xarray/9](https://github.com/xarray-contrib/cupy-xarray/issues/9)

## Motivation

The integration of this function enables a more seamless transition for users who switch between or use both NumPy and CuPy in their projects. 

Importantly, this feature is critical for Xarray-Cupy integration (see [cupy-xarray/9](https://github.com/xarray-contrib/cupy-xarray/issues/9)) , allowing users to benefit from a more efficient and enhanced use case experience. 

Contributors: @negin513, @dcherian
Looking forward to your feedback!

Thank you for your time and consideration.
