### PR TITLE
Add `pyproject.toml`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ _readthedocs_build
 /docs/source/reference/**/generated
 /tags
 *.egg-info/
+*.dist-info/
 dist/
 htmlcov/
 .idea/

--- a/.pfnci/linux/tests/actions/build.sh
+++ b/.pfnci/linux/tests/actions/build.sh
@@ -2,4 +2,8 @@
 
 set -uex
 
-time CUPY_NUM_NVCC_THREADS=8 CUPY_NUM_BUILD_JOBS=8 python3 -m pip install --user -v ".[test]"
+# Use the "--no-build-isolation" option to test building with dependencies
+# installed in the current environment. Otherwise builds always run in an
+# isolated environment with the latest version of the build-system
+# requirements specified in pyproject.toml and `setup_requires`.
+time CUPY_NUM_NVCC_THREADS=8 CUPY_NUM_BUILD_JOBS=8 python3 -m pip install --no-build-isolation --user -v ".[test]"

--- a/docs/source/contribution.rst
+++ b/docs/source/contribution.rst
@@ -178,7 +178,7 @@ You can use ``autopep8`` and ``flake8`` commands to check your code.
 In order to avoid confusion from using different tool versions, we pin the versions of those tools.
 Install them with the following command (from within the top directory of CuPy repository)::
 
-  $ pip install -e '.[stylecheck]'
+  $ pip install --no-build-isolation -e '.[stylecheck]'
 
 And check your code with::
 
@@ -254,11 +254,11 @@ How to Run Tests
 
 In order to run unit tests at the repository root, you first have to build Cython files in place by running the following command::
 
-  $ pip install -e .
+  $ pip install --no-build-isolation -e .
 
 .. note::
 
-  When you modify ``*.pxd`` files, before running ``pip install -e .``, you must clean ``*.cpp`` and ``*.so`` files once with the following command, because Cython does not automatically rebuild those files nicely::
+  When you modify ``*.pxd`` files, before running ``pip install``, you must clean ``*.cpp`` and ``*.so`` files once with the following command, because Cython does not automatically rebuild those files nicely::
 
     $ git clean -fdx
 
@@ -384,7 +384,7 @@ Open ``index.html`` with the browser and see if it is rendered as expected.
 .. note::
 
    Docstrings (documentation comments in the source code) are collected from the installed CuPy module.
-   If you modified docstrings, make sure to install the module (e.g., using `pip install -e .`) before building the documentation.
+   If you modified docstrings, make sure to install the module (e.g., using ``pip install --no-build-isolation -e .``) before building the documentation.
 
 
 Tips for Developers
@@ -397,9 +397,12 @@ Install as Editable
 
 During the development we recommend using ``pip`` with ``-e`` option to install as editable mode::
 
-  $ pip install -e .
+  $ pip install --no-build-isolation -e .
 
-Please note that even with ``-e``, you will have to rerun ``pip install -e .`` to regenerate C++ sources using Cython if you modified Cython source files (e.g., ``*.pyx`` files).
+The ``--no-build-isolation`` option enables incremental compilation.
+More specifically, the build runs inside the ``build/temp.*`` directory instead of the isolated temporary directory created for each invocation, reusing object files generated in the previous build.
+
+Please note that even with ``-e``, you will have to rerun ``pip install --no-build-isolation -e .`` to regenerate C++ sources using Cython if you modified Cython source files (e.g., ``*.pyx`` files).
 
 Use ccache
 ~~~~~~~~~~

--- a/install/cupy_builder/_command.py
+++ b/install/cupy_builder/_command.py
@@ -111,7 +111,6 @@ class custom_build_ext(setuptools.command.build_ext.build_ext):
         compile_time_env: Dict[str, Any] = {}
 
         # Enable CUDA Python.
-        # TODO: add `cuda` to `setup_requires` only when this flag is set
         use_cuda_python = ctx.use_cuda_python
         compile_time_env['CUPY_USE_CUDA_PYTHON'] = use_cuda_python
         if use_cuda_python:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "Cython>=0.29.22,<3", "fastrlock>=0.5"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -17,11 +17,7 @@ if not cupy_builder.preflight_check(ctx):
     sys.exit(1)
 
 
-# TODO(kmaehashi): migrate to pyproject.toml (see #4727, #4619)
-setup_requires = [
-    'Cython>=0.29.22,<3',
-    'fastrlock>=0.5',
-]
+setup_requires = []
 install_requires = [
     'numpy>=1.20,<1.27',  # see #4773
     'fastrlock>=0.5',
@@ -50,6 +46,10 @@ extras_require = {
     ],
 }
 tests_require = extras_require['test']
+
+if ctx.use_cuda_python:
+    setup_requires += ['cuda-python']
+    install_requires += ['cuda-python']
 
 
 # List of files that needs to be in the distribution (sdist/wheel).
@@ -80,7 +80,7 @@ package_data = {
 package_data['cupy'] += cupy_setup_build.prepare_wheel_libs(ctx)
 
 
-if len(sys.argv) < 2 or sys.argv[1] == 'egg_info':
+if len(sys.argv) < 2 or sys.argv[1] in ('egg_info', 'dist_info'):
     # Extensions are unnecessary for egg_info generation as all sources files
     # can be enumerated via MANIFEST.in.
     ext_modules = []

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,11 @@ if not cupy_builder.preflight_check(ctx):
     sys.exit(1)
 
 
-setup_requires = []
+setup_requires = [
+    # Keep the list in sync with `pyproject.toml`.
+    "Cython>=0.29.22,<3",
+    "fastrlock>=0.5",
+]
 install_requires = [
     'numpy>=1.20,<1.27',  # see #4773
     'fastrlock>=0.5',


### PR DESCRIPTION
Closes #6986 and #7870.

**After merging this PR, contributors will need to use `pip install --no-build-isolation -e .` for incremental compilation during development.**

Let's merge this one after the release this week.