### PR TITLE
Fix `_depends.json` not included in wheel

### DIFF
--- a/install/cupy_builder/_command.py
+++ b/install/cupy_builder/_command.py
@@ -189,6 +189,7 @@ class custom_build_ext(setuptools.command.build_ext.build_ext):
 
             depends_json = os.path.join(
                 self.build_lib, 'cupy', '.data', '_depends.json')
+            os.makedirs(os.path.dirname(depends_json), exist_ok=True)
             with open(depends_json, 'w') as f:
                 json.dump({'depends': depends}, f)
 

--- a/install/cupy_builder/_command.py
+++ b/install/cupy_builder/_command.py
@@ -186,7 +186,10 @@ class custom_build_ext(setuptools.command.build_ext.build_ext):
             depends = sorted(set(sum([
                 dumpbin_dependents(dumpbin, f) for f in self.get_outputs()
             ], [])))
-            with open('cupy/.data/_depends.json', 'w') as f:
+
+            depends_json = os.path.join(
+                self.build_lib, 'cupy', '.data', '_depends.json')
+            with open(depends_json, 'w') as f:
                 json.dump({'depends': depends}, f)
 
     def build_extension(self, ext: setuptools.Extension) -> None:


### PR DESCRIPTION
The feature added in #7279 was not working in shipped wheels as the `_depends.json` file is not included in the wheel.

c.f. https://github.com/pypa/setuptools/issues/1064