### PR TITLE
Improve README and Installation Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,10 @@ Choose the right package for your platform.
 | CUDA 11.1             | x86_64            | `pip install cupy-cuda111`                                    |
 | CUDA 11.2 ~ 11.8      | x86_64 / aarch64  | `pip install cupy-cuda11x`                                    |
 | CUDA 12.x             | x86_64 / aarch64  | `pip install cupy-cuda12x`                                    |
-| ROCm 4.3 (*)          | x86_64            | `pip install cupy-rocm-4-3`                                   |
-| ROCm 5.0 (*)          | x86_64            | `pip install cupy-rocm-5-0`                                   |
+| ROCm 4.3 (*[experimental](https://docs.cupy.dev/en/latest/install.html#using-cupy-on-amd-gpu-experimental)*)          | x86_64            | `pip install cupy-rocm-4-3`                                   |
+| ROCm 5.0 (*[experimental](https://docs.cupy.dev/en/latest/install.html#using-cupy-on-amd-gpu-experimental)*)          | x86_64            | `pip install cupy-rocm-5-0`                                   |
 
-(\*) ROCm support is an experimental feature. Refer to the [docs](https://docs.cupy.dev/en/latest/install.html#using-cupy-on-amd-gpu-experimental) for details.
-
-Append `--pre -f https://pip.cupy.dev/pre` options to install pre-releases (e.g., `pip install cupy-cuda11x --pre -f https://pip.cupy.dev/pre`).
+> **Note** To install pre-releases, append `--pre -f https://pip.cupy.dev/pre` (e.g., `pip install cupy-cuda11x --pre -f https://pip.cupy.dev/pre`).
 
 ### Conda
 
@@ -62,6 +60,8 @@ Binary packages are also available for Linux and Windows on [Conda-Forge](https:
 | CUDA                  | x86_64 / aarch64 / ppc64le  | `conda install -c conda-forge cupy`                           |
 
 If you need to use a particular CUDA version (say 11.8), you can do `conda install -c conda-forge cupy cuda-version=11.8`.
+
+> **Note** If you encounter any problem with CuPy installed from `conda-forge`, please feel free to report to [cupy-feedstock](https://github.com/conda-forge/cupy-feedstock/issues), and we will help investigate if it is just a packaging issue in `conda-forge`'s recipe or a real issue in CuPy.
 
 ### Docker
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Binary packages are also available for Linux and Windows on [Conda-Forge](https:
 | --------------------- | --------------------------- | ------------------------------------------------------------- |
 | CUDA                  | x86_64 / aarch64 / ppc64le  | `conda install -c conda-forge cupy`                           |
 
-If you need to use a particular CUDA version (say 11.8), you can do `conda install -c conda-forge cupy cudatoolkit=11.8`.
+If you need to use a particular CUDA version (say 11.8), you can do `conda install -c conda-forge cupy cuda-version=11.8`.
 
 ### Docker
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ You can pass `ndarray` to existing CUDA C/C++ programs via [RawKernels](https://
 
 ### Pip
 
-Precompiled binary packages (wheels) are available for Linux and Windows on [PyPI](https://pypi.org/org/cupy/).
+Binary packages (wheels) are available for Linux and Windows on [PyPI](https://pypi.org/org/cupy/).
 Choose the right package for your platform.
 
 | Platform              | Architecture      | Command                                                       |

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 [![pypi](https://img.shields.io/pypi/v/cupy.svg)](https://pypi.python.org/pypi/cupy)
 [![Conda Version](https://img.shields.io/conda/vn/conda-forge/cupy.svg)](https://anaconda.org/conda-forge/cupy)
 [![GitHub license](https://img.shields.io/github/license/cupy/cupy.svg)](https://github.com/cupy/cupy)
-[![coveralls](https://img.shields.io/coveralls/cupy/cupy.svg)](https://coveralls.io/github/cupy/cupy)
 [![Gitter](https://badges.gitter.im/cupy/community.svg)](https://gitter.im/cupy/community)
 [![Twitter](https://img.shields.io/twitter/follow/CuPy_Team?label=%40CuPy_Team)](https://twitter.com/CuPy_Team)
 
@@ -35,7 +34,9 @@ You can pass `ndarray` to existing CUDA C/C++ programs via [RawKernels](https://
 
 ## Installation
 
-Wheels (precompiled binary packages) are available for Linux and Windows.
+### Pip
+
+Precompiled binary packages (wheels) are available for Linux and Windows on [PyPI](https://pypi.org/org/cupy/).
 Choose the right package for your platform.
 
 | Platform              | Architecture      | Command                                                       |
@@ -51,18 +52,28 @@ Choose the right package for your platform.
 (\*) ROCm support is an experimental feature. Refer to the [docs](https://docs.cupy.dev/en/latest/install.html#using-cupy-on-amd-gpu-experimental) for details.
 
 Append `--pre -f https://pip.cupy.dev/pre` options to install pre-releases (e.g., `pip install cupy-cuda11x --pre -f https://pip.cupy.dev/pre`).
-See the [Installation Guide](https://docs.cupy.dev/en/stable/install.html) if you are using Conda/Anaconda or building from source.
 
-## Run on Docker
+### Conda
 
-Use [NVIDIA Container Toolkit](https://github.com/NVIDIA/nvidia-docker) to run CuPy image with GPU.
+Binary packages are also available for Linux and Windows on [Conda-Forge](https://anaconda.org/conda-forge/cupy).
+
+| Platform              | Architecture                | Command                                                       |
+| --------------------- | --------------------------- | ------------------------------------------------------------- |
+| CUDA                  | x86_64 / aarch64 / ppc64le  | `conda install -c conda-forge cupy`                           |
+
+If you need to use a particular CUDA version (say 11.8), you can do `conda install -c conda-forge cupy cudatoolkit=11.8`.
+
+### Docker
+
+Use [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/overview.html) to run [CuPy container images](https://hub.docker.com/r/cupy/cupy).
 
 ```
 $ docker run --gpus all -it cupy/cupy
 ```
 
-## More information
+## Resources
 
+- [Installation Guide](https://docs.cupy.dev/en/stable/install.html) - instructions on building from source
 - [Release Notes](https://github.com/cupy/cupy/releases)
 - [Projects using CuPy](https://github.com/cupy/cupy/wiki/Projects-using-CuPy)
 - [Contribution Guide](https://docs.cupy.dev/en/stable/contribution.html)
@@ -73,7 +84,7 @@ MIT License (see `LICENSE` file).
 
 CuPy is designed based on NumPy's API and SciPy's API (see `docs/LICENSE_THIRD_PARTY` file).
 
-CuPy is being maintained and developed by [Preferred Networks Inc.](https://preferred.jp/en/) and [community contributors](https://github.com/cupy/cupy/graphs/contributors).
+CuPy is being developed and maintained by [Preferred Networks](https://www.preferred.jp/en/) and [community contributors](https://github.com/cupy/cupy/graphs/contributors).
 
 ## Reference
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -127,9 +127,9 @@ and ``conda`` will install a pre-built CuPy binary package for you, along with t
 (``cudatoolkit``). It is not necessary to install CUDA Toolkit in advance.
 
 Conda has a built-in mechanism to determine and install the latest version of ``cudatoolkit`` supported by your driver.
-However, if for any reason you need to force-install a particular CUDA version (say 11.0), you can do::
+However, if for any reason you need to force-install a particular CUDA version (say 11.8), you can do::
 
-    $ conda install -c conda-forge cupy cudatoolkit=11.0
+    $ conda install -c conda-forge cupy cuda-version=11.8
 
 .. note::
 


### PR DESCRIPTION
Recently we are getting more reports of installation failures, and it looks most issues are happening with CuPy wheels installed on conda env. This PR adds the instruction for Conda users to README to promote using packages from conda-forge.

This PR also removed Coveralls badge which is out-dated, and added several wording improvements.
