### PR TITLE
Fix command in issue template for Windows

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -38,7 +38,7 @@ body:
     attributes:
       label: Environment
       description: |
-        Please copy and paste the output of `python -c 'import cupy; cupy.show_config()'`:
+        Please copy and paste the output of `python -c "import cupy; cupy.show_config()"`:
       value: |
         ```
         # Paste the output here


### PR DESCRIPTION
Fixes the command line so that Windows users can copy-and-paste and run.
