### PR TITLE
Fix flake8-cython not working

### DIFF
--- a/.flake8.cython
+++ b/.flake8.cython
@@ -1,4 +1,4 @@
 [flake8]
 filename = *.pyx, *.pxd, *.pxi
 exclude = .git, .eggs, *.py
-ignore = W503,W504,E225,E226,E227,E402,E999
+ignore = W503,W504,E225,E226,E227,E275,E402,E999

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,8 @@ repos:
     -   id: flake8
         name: flake8 (cython)
         types: ["cython"]
-        args: [--config, ".flake8.cython"]
+        args: [--config, ".flake8.cython", "--force-check"]
+        additional_dependencies: [flake8-force]
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.3.0

--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -943,7 +943,7 @@ cdef class _ndarray_base:
 
         .. seealso:: :func:`numpy.searchsorted`
 
-        """
+        """  # NOQA
         return cupy.searchsorted(self, v, side, sorter)
 
     cpdef tuple nonzero(self):
@@ -1077,7 +1077,7 @@ cdef class _ndarray_base:
            :func:`cupy.around` for full documentation,
            :meth:`numpy.ndarray.round`
 
-        """
+        """  # NOQA
         return _round_ufunc(self, decimals, out=out)
 
     cpdef _ndarray_base trace(


### PR DESCRIPTION
This had to be in #7595 to enable flake8 lint against Cython.

I think these config can be removed after a certain period of time, once #7508 got merged.
