### PR TITLE
Fix build-cuda test `restore-keys` not working

### DIFF
--- a/.github/workflows/pretest.yml
+++ b/.github/workflows/pretest.yml
@@ -58,7 +58,7 @@ jobs:
       with:
         path: ~/.cache
         key: build-cuda-${{ github.sha }}
-        restore-keys:
+        restore-keys: |
           build-cuda-${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
           build-cuda-
 


### PR DESCRIPTION
`restore-keys` were not working since #7546... :bow:

