### PR TITLE
Fix returned CUDA statuses not being checked

### DIFF
--- a/cupy/_core/new_fusion.pyx
+++ b/cupy/_core/new_fusion.pyx
@@ -6,8 +6,8 @@ from cupy._core import core
 from cupy._core import _fusion_trace
 from cupy._core import _fusion_kernel
 from cupy._core import _fusion_thread_local
-from cupy._core._fusion_interface import _ScalarProxy  # NOQA  # no-cython-lint
-from cupy._core._fusion_interface import _ArrayProxy  # NOQA  # no-cython-lint
+from cupy._core._fusion_interface import _ScalarProxy  # no-cython-lint
+from cupy._core._fusion_interface import _ArrayProxy  # no-cython-lint
 from cupy._core._fusion_variable import _AbstractDim
 
 

--- a/cupy/_core/raw.pyx
+++ b/cupy/_core/raw.pyx
@@ -482,7 +482,7 @@ cdef class RawModule:
         # for lookup in case we specialize a template
         ker.name_expressions = self.name_expressions
         # register the kernel in the cache
-        func = ker.kernel  # noqa  # no-cython-lint
+        func = ker.kernel  # no-cython-lint
         return ker
 
     def get_global(self, name):

--- a/cupy/cuda/cufft.pyx
+++ b/cupy/cuda/cufft.pyx
@@ -1028,7 +1028,8 @@ cdef class XtPlanNd:
         cdef int result
 
         with nogil:
-            result = cufftSetStream(<Handle>plan, <Stream>s)  # no-cython-lint
+            result = cufftSetStream(<Handle>plan, <Stream>s)
+        check_result(result)
         XtExec(plan, a.data.ptr, out.data.ptr, direction)
 
     def _sanity_checks(self, int itype, int otype, int etype,

--- a/cupy_backends/cuda/libs/cublas.pyx
+++ b/cupy_backends/cuda/libs/cublas.pyx
@@ -1013,11 +1013,12 @@ cpdef zgemmBatched(
         size_t beta, size_t Carray, int ldc, int batchCount):
     _setStream(handle)
     with nogil:
-        status = cublasZgemmBatched(  # no-cython-lint
+        status = cublasZgemmBatched(
             <Handle>handle, <Operation>transa, <Operation>transb, m, n, k,
             <cuDoubleComplex*>alpha, <const cuDoubleComplex**>Aarray, lda,
             <const cuDoubleComplex**>Barray, ldb, <cuDoubleComplex*>beta,
             <cuDoubleComplex**>Carray, ldc, batchCount)
+    check_status(status)
 
 
 cpdef sgemmStridedBatched(

--- a/cupy_backends/cuda/libs/cudnn.pyx
+++ b/cupy_backends/cuda/libs/cudnn.pyx
@@ -1128,8 +1128,9 @@ cpdef setConvolutionMathType(size_t convDesc, size_t mathType):
 
 cpdef size_t getConvolutionMathType(size_t convDesc) except? 0:
     cdef MathType mathType
-    status = cudnnGetConvolutionMathType(  # no-cython-lint
+    status = cudnnGetConvolutionMathType(
         <ConvolutionDescriptor>convDesc, &mathType)
+    check_status(status)
     return <size_t>mathType
 
 
@@ -1141,8 +1142,9 @@ cpdef setConvolutionGroupCount(size_t convDesc, int groupCount):
 
 cpdef int getConvolutionGroupCount(size_t convDesc) except? -1:
     cdef int groupCount
-    status = cudnnGetConvolutionGroupCount(  # no-cython-lint
+    status = cudnnGetConvolutionGroupCount(
         <ConvolutionDescriptor>convDesc, &groupCount)
+    check_status(status)
     return groupCount
 
 


### PR DESCRIPTION
Found by cython-lint in #7508 review. Also removes some more `no-cython-lint`s.