### PR TITLE
Deprecate `cupy.round_`

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -577,8 +577,8 @@ from cupy._math.rounding import ceil  # NOQA
 from cupy._math.rounding import fix  # NOQA
 from cupy._math.rounding import floor  # NOQA
 from cupy._math.rounding import rint  # NOQA
+from cupy._math.rounding import round  # NOQA
 from cupy._math.rounding import round_  # NOQA
-from cupy._math.rounding import round_ as round  # NOQA
 from cupy._math.rounding import trunc  # NOQA
 
 from cupy._math.sumprod import prod  # NOQA

--- a/cupy/_math/rounding.py
+++ b/cupy/_math/rounding.py
@@ -1,3 +1,5 @@
+import warnings
+
 from cupy import _core
 from cupy._core import fusion
 from cupy._math import ufunc
@@ -26,7 +28,12 @@ def around(a, decimals=0, out=None):
     return a.round(decimals, out=out)
 
 
+def round(a, decimals=0, out=None):
+    return around(a, decimals, out=out)
+
+
 def round_(a, decimals=0, out=None):
+    warnings.warn('Please use `round` instead.', DeprecationWarning)
     return around(a, decimals, out=out)
 
 

--- a/cupyx/scipy/special/__init__.py
+++ b/cupyx/scipy/special/__init__.py
@@ -106,7 +106,7 @@ from cupyx.scipy.special._basic import log1p  # NOQA
 from cupyx.scipy.special._basic import expm1  # NOQA
 from cupyx.scipy.special._basic import exprel  # NOQA
 from cupyx.scipy.special._basic import cosm1  # NOQA
-from cupy._math.rounding import round_ as round  # NOQA
+from cupy._math.rounding import round  # NOQA
 from cupyx.scipy.special._xlogy import xlogy  # NOQA
 from cupyx.scipy.special._xlogy import xlog1py  # NOQA
 from cupyx.scipy.special._logsumexp import logsumexp  # NOQA

--- a/tests/cupy_tests/core_tests/fusion_tests/test_routines.py
+++ b/tests/cupy_tests/core_tests/fusion_tests/test_routines.py
@@ -153,7 +153,7 @@ class TestFusionDegRad(FusionUnaryUfuncTestBase):
 
 
 @testing.parameterize(*testing.product({
-    'func': ['around', 'round', 'round_', 'rint', 'floor', 'ceil', 'trunc',
+    'func': ['around', 'round', 'rint', 'floor', 'ceil', 'trunc',
              'fix']
 }))
 class TestFusionRounding(FusionUnaryUfuncTestBase):

--- a/tests/cupy_tests/math_tests/test_rounding.py
+++ b/tests/cupy_tests/math_tests/test_rounding.py
@@ -1,4 +1,5 @@
 import unittest
+import warnings
 
 import numpy
 import pytest
@@ -68,9 +69,13 @@ class TestRounding(unittest.TestCase):
         self.check_unary('around')
         self.check_unary_complex('around')
 
-    def test_round_(self):
-        self.check_unary('round_')
-        self.check_unary_complex('round_')
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose(atol=1e-5)
+    def test_round_(self, xp, dtype):
+        a = testing.shaped_arange((2, 3), xp, dtype)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            return xp.round_(a)
 
     def test_round(self):
         self.check_unary('round')

--- a/tests/cupyx_tests/scipy_tests/fft_tests/test_fftlog.py
+++ b/tests/cupyx_tests/scipy_tests/fft_tests/test_fftlog.py
@@ -31,7 +31,7 @@ class TestFftlog:
 
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose(rtol=rtol, atol=atol, scipy_name='scp')
-    @testing.with_requires('scipy>=1.7.0')
+    @testing.with_requires('numpy>=1.25.0', 'scipy>=1.7.0')
     def test_fht(self, xp, scp, dtype):
 
         # test function, analytical Hankel transform is of the same form


### PR DESCRIPTION
`numpy.round_` will be deprecated in NumPy 1.25.