### PR TITLE
Change test pass condition for TestChoiceChi::test_goodness_of_fit

### DIFF
--- a/tests/cupy_tests/random_tests/test_generator.py
+++ b/tests/cupy_tests/random_tests/test_generator.py
@@ -826,7 +826,7 @@ class TestChoiceChi(RandomGeneratorTestCase):
 
     target_method = 'choice'
 
-    @_condition.repeat(3, 10)
+    @_condition.repeat_with_success_at_least(10, 9)
     def test_goodness_of_fit(self):
         trial = 100
         vals = self.generate_many(3, 1, True, [0.3, 0.3, 0.4], _count=trial)


### PR DESCRIPTION
TestChoiceChi::test_goodness_of_fit(https://github.com/cupy/cupy/blob/main/tests/cupy_tests/random_tests/test_generator.py#L830) is sensitive to data randomness and fails on ROCm with its current setup. The test generates random numbers using cupy random generator, which is seeded with random numbers from numpy.random(https://github.com/cupy/cupy/blob/main/cupy/testing/_random.py#L90). 
The numpy.random is hardcoded to a seed of 100(https://github.com/cupy/cupy/blob/main/cupy/testing/_random.py#L37). 
The test runs for 10 test cases following the seed, but one of them fails on ROCm, which is fine based on significance level used for the test(more details in https://github.com/cupy/cupy/issues/7544). This PR changes test passing condition to let it pass on ROCm as mentioned here - https://github.com/cupy/cupy/issues/7544#issuecomment-1566616536.