### PR TITLE
cupyx/signal: skip tests against older SciPy versions, adjust test tolerances

### DIFF
--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_filter_design.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_filter_design.py
@@ -441,7 +441,7 @@ class TestFreqz_zpk:
             assert_array_almost_equal(h, [1])
 
 
-@testing.with_requires("scipy")
+@testing.with_requires("scipy>=1.8")
 class TestSOSFreqz:
 
     @testing.numpy_cupy_allclose(scipy_name='scp')

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_iir_filter_design.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_iir_filter_design.py
@@ -6,6 +6,11 @@ import cupy
 from cupy import testing
 from cupyx.scipy import signal
 
+try:
+    import scipy.signal  # NOQA
+except ImportError:
+    pass
+
 
 nimpl = pytest.mark.xfail(reason="not implemented")
 prec_loss = pytest.mark.xfail(reason="zpk2tf loses precision")
@@ -37,7 +42,7 @@ class TestIIRFilter:
     @pytest.mark.parametrize("ftype", ['butter',
                                        pytest.param('bessel', marks=nimpl),
                                        'cheby1', 'cheby2', 'ellip'])
-    @testing.numpy_cupy_allclose(scipy_name='scp', atol=1e-5, rtol=1e-6)
+    @testing.numpy_cupy_allclose(scipy_name='scp', atol=1e-5, rtol=1e-5)
     def test_symmetry_2(self, N, ftype, xp, scp):
         b, a = scp.signal.iirfilter(N, 1.1, 1, 20, 'low', analog=True,
                                     ftype=ftype, output='ba')
@@ -70,6 +75,7 @@ class TestIIRFilter:
         assert_raises(ValueError, signal.iirfilter, 1, [1, 2], btype='band')
         assert_raises(ValueError, signal.iirfilter, 1, [10, 20], btype='stop')
 
+    @testing.with_requires("scipy>=1.8")
     @testing.numpy_cupy_allclose(scipy_name="scp")
     def test_analog_sos(self, xp, scp):
         # first order Butterworth filter with Wn = 1 has tf 1/(s+1)
@@ -161,6 +167,7 @@ class TestButter:
                               'sos',
                               pytest.param('ba', marks=prec_loss)])
     @testing.numpy_cupy_allclose(scipy_name="scp")
+    @testing.with_requires("scipy>=1.8")
     def test_ba_output(self, xp, scp, outp):
         outp = scp.signal.butter(
             4, [100, 300], 'bandpass', analog=True, output=outp)

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_iir_filter_design.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_iir_filter_design.py
@@ -4,6 +4,7 @@ from pytest import raises as assert_raises
 import cupy
 
 from cupy import testing
+from cupy.cuda import runtime
 from cupyx.scipy import signal
 
 try:
@@ -433,6 +434,7 @@ class TestEllip:
             N, 1, 40, wn, 'high', analog=False, output='zpk')
         return z, p, k
 
+    @testing.with_requires("scipy>=1.7")
     @testing.numpy_cupy_allclose(scipy_name='scp', atol=1e-14, rtol=1e-14)
     def test_basic_2(self, xp, scp):
         b3, a3 = scp.signal.ellip(5, 3, 26, 1, analog=True)

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_iir_filter_design.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_iir_filter_design.py
@@ -4,7 +4,6 @@ from pytest import raises as assert_raises
 import cupy
 
 from cupy import testing
-from cupy.cuda import runtime
 from cupyx.scipy import signal
 
 try:
@@ -17,13 +16,12 @@ nimpl = pytest.mark.xfail(reason="not implemented")
 prec_loss = pytest.mark.xfail(reason="zpk2tf loses precision")
 
 
-@testing.with_requires("scipy")
+@testing.with_requires("scipy>=1.8")
 class TestIIRFilter:
 
     # NB: test_symmetry with higher order ellip filters need low tolerance
     # on older CUDA versions.
 
-    @testing.with_requires("scipy>=1.8")
     @pytest.mark.parametrize("N", list(range(1, 25)))
     @pytest.mark.parametrize("ftype", ['butter',
                                        pytest.param('bessel', marks=nimpl),
@@ -38,7 +36,6 @@ class TestIIRFilter:
                                        ftype=ftype, output='zpk')
         return z, p, k
 
-    @testing.with_requires("scipy>=1.8")
     @pytest.mark.parametrize("N", list(range(1, 25)))
     @pytest.mark.parametrize("ftype", ['butter',
                                        pytest.param('bessel', marks=nimpl),
@@ -76,7 +73,6 @@ class TestIIRFilter:
         assert_raises(ValueError, signal.iirfilter, 1, [1, 2], btype='band')
         assert_raises(ValueError, signal.iirfilter, 1, [10, 20], btype='stop')
 
-    @testing.with_requires("scipy>=1.8")
     @testing.numpy_cupy_allclose(scipy_name="scp")
     def test_analog_sos(self, xp, scp):
         # first order Butterworth filter with Wn = 1 has tf 1/(s+1)
@@ -394,7 +390,7 @@ class TestCheby2:
         # assert_allclose(a, a2, rtol=1e-14)
 
 
-@testing.with_requires("scipy")
+@testing.with_requires("scipy>=1.8")
 class TestEllip:
 
     @testing.numpy_cupy_allclose(scipy_name='scp')
@@ -416,7 +412,6 @@ class TestEllip:
         z, p, k = scp.signal.ellip(1, 1, 55, 0.3, output='zpk')
         return z, p, k
 
-    @testing.with_requires("scipy>=1.8")
     @pytest.mark.parametrize('N', list(range(25)))
     @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_basic(self, xp, scp, N):
@@ -425,7 +420,6 @@ class TestEllip:
             N, 1, 40, wn, 'low', analog=True, output='zpk')
         return z, p, k
 
-    @testing.with_requires("scipy>=1.8")
     @pytest.mark.parametrize('N', list(range(20)))
     @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_basic_1(self, xp, scp, N):
@@ -434,19 +428,16 @@ class TestEllip:
             N, 1, 40, wn, 'high', analog=False, output='zpk')
         return z, p, k
 
-    @testing.with_requires("scipy>=1.7")
     @testing.numpy_cupy_allclose(scipy_name='scp', atol=1e-14, rtol=1e-14)
     def test_basic_2(self, xp, scp):
         b3, a3 = scp.signal.ellip(5, 3, 26, 1, analog=True)
         return b3, a3
 
-    @testing.with_requires("scipy>=1.8")
     @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_basic_3(self, xp, scp):
         b, a = scp.signal.ellip(3, 1, 60, [0.4, 0.7], 'stop')
         return b, a
 
-    @testing.with_requires("scipy>=1.8")
     @pytest.mark.parametrize("arg",
                              # high even order
                              [(24, 1, 80, 0.3, 'high'),
@@ -459,7 +450,6 @@ class TestEllip:
         z, p, k = scp.signal.ellip(*arg, output='zpk')
         return z, p, k
 
-    @testing.with_requires("scipy>=1.8")
     @pytest.mark.parametrize("arg",
                              [(7, 1, 40, [0.07, 0.2], 'pass'),
                               (5, 1, 75, [90.5, 110.5], 'pass', True),
@@ -469,7 +459,6 @@ class TestEllip:
         z, p, k = scp.signal.ellip(7, 1, 40, [0.07, 0.2], 'pass', output='zpk')
         return z, p, k
 
-    @testing.with_requires("scipy>=1.8")
     @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_bandstop(self, xp, scp):
         z, p, k = scp.signal.ellip(8, 1, 65, [0.2, 0.4], 'stop', output='zpk')

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_iir_filter_design.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_iir_filter_design.py
@@ -17,8 +17,7 @@ class TestIIRFilter:
     # NB: test_symmetry with higher order ellip filters need low tolerance
     # on older CUDA versions.
 
-    @pytest.mark.skipif(cupy.cuda.runtime.runtimeGetVersion() < 11060,
-                        reason='tolerance fails on older CUDA')
+    @testing.with_requires("scipy>=1.8")
     @pytest.mark.parametrize("N", list(range(1, 25)))
     @pytest.mark.parametrize("ftype", ['butter',
                                        pytest.param('bessel', marks=nimpl),
@@ -33,8 +32,7 @@ class TestIIRFilter:
                                        ftype=ftype, output='zpk')
         return z, p, k
 
-    @pytest.mark.skipif(cupy.cuda.runtime.runtimeGetVersion() < 11060,
-                        reason='tolerance fails on older CUDA')
+    @testing.with_requires("scipy>=1.8")
     @pytest.mark.parametrize("N", list(range(1, 25)))
     @pytest.mark.parametrize("ftype", ['butter',
                                        pytest.param('bessel', marks=nimpl),
@@ -410,8 +408,7 @@ class TestEllip:
         z, p, k = scp.signal.ellip(1, 1, 55, 0.3, output='zpk')
         return z, p, k
 
-    @pytest.mark.skipif(cupy.cuda.runtime.runtimeGetVersion() < 11060,
-                        reason='tolerance fails on older CUDA')
+    @testing.with_requires("scipy>=1.8")
     @pytest.mark.parametrize('N', list(range(25)))
     @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_basic(self, xp, scp, N):
@@ -420,8 +417,7 @@ class TestEllip:
             N, 1, 40, wn, 'low', analog=True, output='zpk')
         return z, p, k
 
-    @pytest.mark.skipif(cupy.cuda.runtime.runtimeGetVersion() < 11060,
-                        reason='tolerance fails on older CUDA')
+    @testing.with_requires("scipy>=1.8")
     @pytest.mark.parametrize('N', list(range(20)))
     @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_basic_1(self, xp, scp, N):
@@ -435,15 +431,13 @@ class TestEllip:
         b3, a3 = scp.signal.ellip(5, 3, 26, 1, analog=True)
         return b3, a3
 
-    @pytest.mark.skipif(cupy.cuda.runtime.runtimeGetVersion() < 11060,
-                        reason='tolerance fails on older CUDA')
+    @testing.with_requires("scipy>=1.8")
     @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_basic_3(self, xp, scp):
         b, a = scp.signal.ellip(3, 1, 60, [0.4, 0.7], 'stop')
         return b, a
 
-    @pytest.mark.skipif(cupy.cuda.runtime.runtimeGetVersion() < 11060,
-                        reason='tolerance fails on older CUDA')
+    @testing.with_requires("scipy>=1.8")
     @pytest.mark.parametrize("arg",
                              # high even order
                              [(24, 1, 80, 0.3, 'high'),
@@ -456,8 +450,7 @@ class TestEllip:
         z, p, k = scp.signal.ellip(*arg, output='zpk')
         return z, p, k
 
-    @pytest.mark.skipif(cupy.cuda.runtime.runtimeGetVersion() < 11060,
-                        reason='tolerance fails on older CUDA')
+    @testing.with_requires("scipy>=1.8")
     @pytest.mark.parametrize("arg",
                              [(7, 1, 40, [0.07, 0.2], 'pass'),
                               (5, 1, 75, [90.5, 110.5], 'pass', True),
@@ -467,8 +460,7 @@ class TestEllip:
         z, p, k = scp.signal.ellip(7, 1, 40, [0.07, 0.2], 'pass', output='zpk')
         return z, p, k
 
-    @pytest.mark.skipif(cupy.cuda.runtime.runtimeGetVersion() < 11060,
-                        reason='tolerance fails on older CUDA')
+    @testing.with_requires("scipy>=1.8")
     @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_bandstop(self, xp, scp):
         z, p, k = scp.signal.ellip(8, 1, 65, [0.2, 0.4], 'stop', output='zpk')

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_iir_filter_design.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_iir_filter_design.py
@@ -17,11 +17,13 @@ class TestIIRFilter:
     # NB: test_symmetry with higher order ellip filters need low tolerance
     # on older CUDA versions.
 
-    @pytest.mark.parametrize("N", list(range(1, 20)))
+    @pytest.mark.skipif(cupy.cuda.runtime.runtimeGetVersion() < 11060,
+                        reason='tolerance fails on older CUDA')
+    @pytest.mark.parametrize("N", list(range(1, 25)))
     @pytest.mark.parametrize("ftype", ['butter',
                                        pytest.param('bessel', marks=nimpl),
                                        'cheby1', 'cheby2', 'ellip'])
-    @testing.numpy_cupy_allclose(scipy_name='scp', atol=1e-2)
+    @testing.numpy_cupy_allclose(scipy_name='scp', atol=1e-5, rtol=1e-6)
     def test_symmetry(self, N, ftype, xp, scp):
         # All built-in IIR filters are real, so should have perfectly
         # symmetrical poles and zeros. Then ba representation (using
@@ -31,11 +33,13 @@ class TestIIRFilter:
                                        ftype=ftype, output='zpk')
         return z, p, k
 
-    @pytest.mark.parametrize("N", list(range(1, 20)))
+    @pytest.mark.skipif(cupy.cuda.runtime.runtimeGetVersion() < 11060,
+                        reason='tolerance fails on older CUDA')
+    @pytest.mark.parametrize("N", list(range(1, 25)))
     @pytest.mark.parametrize("ftype", ['butter',
                                        pytest.param('bessel', marks=nimpl),
                                        'cheby1', 'cheby2', 'ellip'])
-    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-6, atol=1e-2)
+    @testing.numpy_cupy_allclose(scipy_name='scp', atol=1e-5, rtol=1e-6)
     def test_symmetry_2(self, N, ftype, xp, scp):
         b, a = scp.signal.iirfilter(N, 1.1, 1, 20, 'low', analog=True,
                                     ftype=ftype, output='ba')
@@ -406,54 +410,66 @@ class TestEllip:
         z, p, k = scp.signal.ellip(1, 1, 55, 0.3, output='zpk')
         return z, p, k
 
+    @pytest.mark.skipif(cupy.cuda.runtime.runtimeGetVersion() < 11060,
+                        reason='tolerance fails on older CUDA')
     @pytest.mark.parametrize('N', list(range(25)))
-    @testing.numpy_cupy_allclose(scipy_name='scp', atol=1e-4, rtol=1e-4)
+    @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_basic(self, xp, scp, N):
         wn = 0.01
         z, p, k = scp.signal.ellip(
             N, 1, 40, wn, 'low', analog=True, output='zpk')
         return z, p, k
 
+    @pytest.mark.skipif(cupy.cuda.runtime.runtimeGetVersion() < 11060,
+                        reason='tolerance fails on older CUDA')
     @pytest.mark.parametrize('N', list(range(20)))
-    @testing.numpy_cupy_allclose(scipy_name='scp', atol=1e-3, rtol=1e-3)
+    @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_basic_1(self, xp, scp, N):
         wn = 0.01
         z, p, k = scp.signal.ellip(
             N, 1, 40, wn, 'high', analog=False, output='zpk')
         return z, p, k
 
-    @testing.numpy_cupy_allclose(scipy_name='scp', atol=1e-4, rtol=1e-4)
+    @testing.numpy_cupy_allclose(scipy_name='scp', atol=1e-14, rtol=1e-14)
     def test_basic_2(self, xp, scp):
         b3, a3 = scp.signal.ellip(5, 3, 26, 1, analog=True)
         return b3, a3
 
-    @testing.numpy_cupy_allclose(scipy_name='scp', atol=1e-4, rtol=1e-4)
+    @pytest.mark.skipif(cupy.cuda.runtime.runtimeGetVersion() < 11060,
+                        reason='tolerance fails on older CUDA')
+    @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_basic_3(self, xp, scp):
         b, a = scp.signal.ellip(3, 1, 60, [0.4, 0.7], 'stop')
         return b, a
 
+    @pytest.mark.skipif(cupy.cuda.runtime.runtimeGetVersion() < 11060,
+                        reason='tolerance fails on older CUDA')
     @pytest.mark.parametrize("arg",
                              # high even order
                              [(24, 1, 80, 0.3, 'high'),
                               # high odd order
                               (23, 1, 70, 0.5, 'high'),
                               ])
-    @testing.numpy_cupy_allclose(scipy_name='scp', atol=1e-4, rtol=1e-4)
+    @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_highpass(self, xp, scp, arg):
         # high even order
         z, p, k = scp.signal.ellip(*arg, output='zpk')
         return z, p, k
 
+    @pytest.mark.skipif(cupy.cuda.runtime.runtimeGetVersion() < 11060,
+                        reason='tolerance fails on older CUDA')
     @pytest.mark.parametrize("arg",
                              [(7, 1, 40, [0.07, 0.2], 'pass'),
                               (5, 1, 75, [90.5, 110.5], 'pass', True),
                               ])
-    @testing.numpy_cupy_allclose(scipy_name='scp', atol=5e-5, rtol=5e-5)
+    @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_bandpass(self, xp, scp, arg):
         z, p, k = scp.signal.ellip(7, 1, 40, [0.07, 0.2], 'pass', output='zpk')
         return z, p, k
 
-    @testing.numpy_cupy_allclose(scipy_name='scp', atol=3e-5, rtol=3e-5)
+    @pytest.mark.skipif(cupy.cuda.runtime.runtimeGetVersion() < 11060,
+                        reason='tolerance fails on older CUDA')
+    @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_bandstop(self, xp, scp):
         z, p, k = scp.signal.ellip(8, 1, 65, [0.2, 0.4], 'stop', output='zpk')
         z = z[xp.argsort(xp.angle(z))]


### PR DESCRIPTION
Older CUDA versions seem to have precision issues, had to make test tolerances *very* loose. So instead tighten tolerances, conditionally skip tests on older CUDA versions.

As suggested in https://github.com/cupy/cupy/pull/7591#issuecomment-1586561815