### PR TITLE
Fix signal tests to get align with newer SciPy

### DIFF
--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_iir_filter_design.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_iir_filter_design.py
@@ -35,7 +35,7 @@ class TestIIRFilter:
     @pytest.mark.parametrize("ftype", ['butter',
                                        pytest.param('bessel', marks=nimpl),
                                        'cheby1', 'cheby2', 'ellip'])
-    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-6, atol=1e-2)
+    @testing.numpy_cupy_allclose(scipy_name='scp>=1.7')
     def test_symmetry_2(self, N, ftype, xp, scp):
         b, a = scp.signal.iirfilter(N, 1.1, 1, 20, 'low', analog=True,
                                     ftype=ftype, output='ba')
@@ -68,7 +68,7 @@ class TestIIRFilter:
         assert_raises(ValueError, signal.iirfilter, 1, [1, 2], btype='band')
         assert_raises(ValueError, signal.iirfilter, 1, [10, 20], btype='stop')
 
-    @testing.numpy_cupy_allclose(scipy_name="scp")
+    @testing.numpy_cupy_allclose(scipy_name="scp>=1.8")
     def test_analog_sos(self, xp, scp):
         # first order Butterworth filter with Wn = 1 has tf 1/(s+1)
         sos2 = scp.signal.iirfilter(
@@ -158,7 +158,7 @@ class TestButter:
                              ['zpk',
                               'sos',
                               pytest.param('ba', marks=prec_loss)])
-    @testing.numpy_cupy_allclose(scipy_name="scp")
+    @testing.numpy_cupy_allclose(scipy_name="scp>=1.8")
     def test_ba_output(self, xp, scp, outp):
         outp = scp.signal.butter(
             4, [100, 300], 'bandpass', analog=True, output=outp)


### PR DESCRIPTION
Older scipy.signal may return different results from newer.
https://ci.preferred.jp/cupy.linux.cuda112/133635/ (scipy 1.7)
https://ci.preferred.jp/cupy.linux.cuda113/133625/ (scipy 1.6)
https://ci.preferred.jp/cupy.linux.cuda114/133628/ (scipy 1.7)