### PR TITLE
ENH: add cupyx.signal.{freqs, freqs_zpk, findfreqs}

### DIFF
--- a/cupyx/scipy/signal/__init__.py
+++ b/cupyx/scipy/signal/__init__.py
@@ -58,6 +58,9 @@ from cupyx.scipy.signal._iir_filter_design import ellip  # NOQA
 from cupyx.scipy.signal._fir_filter_design import firls  # NOQA
 from cupyx.scipy.signal._fir_filter_design import minimum_phase  # NOQA
 
+from cupyx.scipy.signal._filter_design import findfreqs  # NOQA
+from cupyx.scipy.signal._filter_design import freqs  # NOQA
+
 from cupyx.scipy.signal._filter_design import freqz  # NOQA
 from cupyx.scipy.signal._filter_design import freqz_zpk  # NOQA
 from cupyx.scipy.signal._filter_design import sosfreqz  # NOQA

--- a/cupyx/scipy/signal/__init__.py
+++ b/cupyx/scipy/signal/__init__.py
@@ -60,6 +60,7 @@ from cupyx.scipy.signal._fir_filter_design import minimum_phase  # NOQA
 
 from cupyx.scipy.signal._filter_design import findfreqs  # NOQA
 from cupyx.scipy.signal._filter_design import freqs  # NOQA
+from cupyx.scipy.signal._filter_design import freqs_zpk  # NOQA
 
 from cupyx.scipy.signal._filter_design import freqz  # NOQA
 from cupyx.scipy.signal._filter_design import freqz_zpk  # NOQA

--- a/cupyx/scipy/signal/_filter_design.py
+++ b/cupyx/scipy/signal/_filter_design.py
@@ -27,6 +27,219 @@ def _try_convert_to_int(x):
         return value, False
 
 
+def roots(arr):
+    """np.roots replacement. XXX: calls into NumPy, then converts back.
+    """
+    import numpy as np
+
+    arr = cupy.asarray(arr).get()
+    return cupy.asarray(np.roots(arr))
+
+
+def findfreqs(num, den, N, kind='ba'):
+    """
+    Find array of frequencies for computing the response of an analog filter.
+
+    Parameters
+    ----------
+    num, den : array_like, 1-D
+        The polynomial coefficients of the numerator and denominator of the
+        transfer function of the filter or LTI system, where the coefficients
+        are ordered from highest to lowest degree. Or, the roots  of the
+        transfer function numerator and denominator (i.e., zeroes and poles).
+    N : int
+        The length of the array to be computed.
+    kind : str {'ba', 'zp'}, optional
+        Specifies whether the numerator and denominator are specified by their
+        polynomial coefficients ('ba'), or their roots ('zp').
+
+    Returns
+    -------
+    w : (N,) ndarray
+        A 1-D array of frequencies, logarithmically spaced.
+
+    See Also
+    --------
+    scipy.signal.find_freqs
+
+    Examples
+    --------
+    Find a set of nine frequencies that span the "interesting part" of the
+    frequency response for the filter with the transfer function
+
+        H(s) = s / (s^2 + 8s + 25)
+
+    >>> from scipy import signal
+    >>> signal.findfreqs([1, 0], [1, 8, 25], N=9)
+    array([  1.00000000e-02,   3.16227766e-02,   1.00000000e-01,
+             3.16227766e-01,   1.00000000e+00,   3.16227766e+00,
+             1.00000000e+01,   3.16227766e+01,   1.00000000e+02])
+    """
+    if kind == 'ba':
+        ep = cupy.atleast_1d(roots(den)) + 0j
+        tz = cupy.atleast_1d(roots(num)) + 0j
+    elif kind == 'zp':
+        ep = cupy.atleast_1d(den) + 0j
+        tz = cupy.atleast_1d(num) + 0j
+    else:
+        raise ValueError("input must be one of {'ba', 'zp'}")
+
+    if len(ep) == 0:
+        ep = cupy.atleast_1d(-1000) + 0j
+
+    ez = cupy.r_[
+                 cupy.compress(ep.imag >= 0, ep, axis=-1),
+                 cupy.compress((abs(tz) < 1e5) & (tz.imag >= 0), tz, axis=-1)]
+
+    integ = cupy.abs(ez) < 1e-10
+    hfreq = cupy.around(cupy.log10(cupy.max(3 * cupy.abs(ez.real + integ) +
+                                            1.5 * ez.imag)) + 0.5)
+    lfreq = cupy.around(cupy.log10(0.1 * cupy.min(cupy.abs((ez + integ).real) +
+                                                  2 * ez.imag)) - 0.5)
+    w = cupy.logspace(lfreq, hfreq, N)
+    return w
+
+
+def freqs(b, a, worN=200, plot=None):
+    """
+    Compute frequency response of analog filter.
+
+    Given the M-order numerator `b` and N-order denominator `a` of an analog
+    filter, compute its frequency response::
+
+             b[0]*(jw)**M + b[1]*(jw)**(M-1) + ... + b[M]
+     H(w) = ----------------------------------------------
+             a[0]*(jw)**N + a[1]*(jw)**(N-1) + ... + a[N]
+
+    Parameters
+    ----------
+    b : array_like
+        Numerator of a linear filter.
+    a : array_like
+        Denominator of a linear filter.
+    worN : {None, int, array_like}, optional
+        If None, then compute at 200 frequencies around the interesting parts
+        of the response curve (determined by pole-zero locations). If a single
+        integer, then compute at that many frequencies. Otherwise, compute the
+        response at the angular frequencies (e.g., rad/s) given in `worN`.
+    plot : callable, optional
+        A callable that takes two arguments. If given, the return parameters
+        `w` and `h` are passed to plot. Useful for plotting the frequency
+        response inside `freqs`.
+
+    Returns
+    -------
+    w : ndarray
+        The angular frequencies at which `h` was computed.
+    h : ndarray
+        The frequency response.
+
+    See Also
+    --------
+    scipy.signal.freqs
+    freqz : Compute the frequency response of a digital filter.
+
+    """
+    if worN is None:
+        # For backwards compatibility
+        w = findfreqs(b, a, 200)
+
+    else:
+        N, _is_int = _try_convert_to_int(worN)
+        if _is_int:
+            w = findfreqs(b, a, N)
+        else:
+            w = cupy.atleast_1d(worN)
+
+    s = 1j * w
+    h = cupy.polyval(b, s) / cupy.polyval(a, s)
+
+    if plot is not None:
+        plot(w, h)
+
+    return w, h
+
+
+def freqs_zpk(z, p, k, worN=200):
+    """
+    Compute frequency response of analog filter.
+
+    Given the zeros `z`, poles `p`, and gain `k` of a filter, compute its
+    frequency response::
+
+                (jw-z[0]) * (jw-z[1]) * ... * (jw-z[-1])
+     H(w) = k * ----------------------------------------
+                (jw-p[0]) * (jw-p[1]) * ... * (jw-p[-1])
+
+    Parameters
+    ----------
+    z : array_like
+        Zeroes of a linear filter
+    p : array_like
+        Poles of a linear filter
+    k : scalar
+        Gain of a linear filter
+    worN : {None, int, array_like}, optional
+        If None, then compute at 200 frequencies around the interesting parts
+        of the response curve (determined by pole-zero locations). If a single
+        integer, then compute at that many frequencies. Otherwise, compute the
+        response at the angular frequencies (e.g., rad/s) given in `worN`.
+
+    Returns
+    -------
+    w : ndarray
+        The angular frequencies at which `h` was computed.
+    h : ndarray
+        The frequency response.
+
+    See Also
+    --------
+    freqs : Compute the frequency response of an analog filter in TF form
+    freqz : Compute the frequency response of a digital filter in TF form
+    freqz_zpk : Compute the frequency response of a digital filter in ZPK form
+
+    Notes
+    -----
+    .. versionadded:: 0.19.0
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from scipy.signal import freqs_zpk, iirfilter
+
+    >>> z, p, k = iirfilter(4, [1, 10], 1, 60, analog=True, ftype='cheby1',
+    ...                     output='zpk')
+
+    >>> w, h = freqs_zpk(z, p, k, worN=np.logspace(-1, 2, 1000))
+
+    >>> import matplotlib.pyplot as plt
+    >>> plt.semilogx(w, 20 * np.log10(abs(h)))
+    >>> plt.xlabel('Frequency')
+    >>> plt.ylabel('Amplitude response [dB]')
+    >>> plt.grid(True)
+    >>> plt.show()
+
+    """
+    k = np.asarray(k)
+    if k.size > 1:
+        raise ValueError('k must be a single scalar gain')
+
+    if worN is None:
+        # For backwards compatibility
+        w = findfreqs(z, p, 200, kind='zp')
+    elif _is_int_type(worN):
+        w = findfreqs(z, p, worN, kind='zp')
+    else:
+        w = worN
+
+    w = atleast_1d(w)
+    s = 1j * w
+    num = polyvalfromroots(s, z)
+    den = polyvalfromroots(s, p)
+    h = k * num/den
+    return w, h
+
+
 def freqz(b, a=1, worN=512, whole=False, plot=None, fs=2*pi,
           include_nyquist=False):
     """

--- a/docs/source/reference/scipy_signal.rst
+++ b/docs/source/reference/scipy_signal.rst
@@ -55,6 +55,8 @@ Filter design
 
    bilinear
    bilinear_zpk
+   findfreqs
+   freqs
    freqz
    freqz_zpk
    firls

--- a/docs/source/reference/scipy_signal.rst
+++ b/docs/source/reference/scipy_signal.rst
@@ -57,6 +57,7 @@ Filter design
    bilinear_zpk
    findfreqs
    freqs
+   freqs_zpk
    freqz
    freqz_zpk
    firls

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_filter_design.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_filter_design.py
@@ -24,10 +24,9 @@ class TestFindFreqs:
         return ff(xp.array([1, 0]), xp.array([1, 8, 25]), N=9)
 
     @testing.numpy_cupy_allclose(scipy_name="scp")
-    def test_docstring(self, xp, scp):
+    def test_ones(self, xp, scp):
         ff = scp.signal.findfreqs
         return ff(xp.array([1.0]), [1.0], N=8)
-
 
 
 @testing.with_requires("scipy")
@@ -62,6 +61,50 @@ class TestFreqs:
     @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_w_or_N_types(self, xp, scp, w):
         w, h = scp.signal.freqs(xp.asarray([1.0]), xp.asarray([1.0]), worN=w)
+        return w, h
+
+
+@testing.with_requires("scipy")
+class TestFreqs_zpk:
+
+    @testing.numpy_cupy_allclose(scipy_name="scp")
+    def test_basic(self, xp, scp):
+        w, h = scp.signal.freqs_zpk(xp.asarray(
+            [1.0]), xp.asarray([1.0]), xp.asarray([1.0]), worN=8)
+        return w, h
+
+    @testing.numpy_cupy_allclose(scipy_name="scp")
+    def test_output(self, xp, scp):
+        # 1st order low-pass filter: H(s) = 1 / (s + 1)
+        w = xp.asarray([0.1, 1, 10, 100])
+        z = xp.asarray([])
+        p = xp.asarray([-1])
+        k = 1
+        w, H = scp.signal.freqs_zpk(z, p, k, worN=w)
+        return w, H
+
+    @testing.numpy_cupy_allclose(scipy_name="scp")
+    def test_freq_range(self, xp, scp):
+        # Test that freqresp() finds a reasonable frequency range.
+        # 1st order low-pass filter: H(s) = 1 / (s + 1)
+        # Expected range is from 0.01 to 10.
+        z = xp.asarray([])
+        p = xp.asarray([-1])
+        k = 1
+        n = 10
+        w, H = scp.signal.freqs_zpk(z, p, k, worN=n)
+        return w, H
+
+    @testing.numpy_cupy_allclose(scipy_name="scp")
+    def test_vs_freqs(self, xp, scp):
+        z, p, k = scp.signal.cheby1(4, 5, 100, analog=True, output='zpk')
+        w2, h2 = scp.signal.freqs_zpk(z, p, k)
+        return w2, h2
+
+    @pytest.mark.parametrize('w', [8.0, 8.0 + 0j])
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_w_or_N_types(self, xp, scp, w):
+        w, h = scp.signal.freqs_zpk(xp.asarray([]), xp.asarray([]), 1, worN=w)
         return w, h
 
 

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_filter_design.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_filter_design.py
@@ -16,6 +16,56 @@ except ImportError:
 
 
 @testing.with_requires("scipy")
+class TestFindFreqs:
+
+    @testing.numpy_cupy_allclose(scipy_name="scp")
+    def test_docstring(self, xp, scp):
+        ff = scp.signal.findfreqs
+        return ff(xp.array([1, 0]), xp.array([1, 8, 25]), N=9)
+
+    @testing.numpy_cupy_allclose(scipy_name="scp")
+    def test_docstring(self, xp, scp):
+        ff = scp.signal.findfreqs
+        return ff(xp.array([1.0]), [1.0], N=8)
+
+
+
+@testing.with_requires("scipy")
+class TestFreqs:
+
+    @testing.numpy_cupy_allclose(scipy_name="scp")
+    def test_basic(self, xp, scp):
+        w, h = scp.signal.freqs(xp.asarray([1.0]), xp.asarray([1.0]), worN=8)
+        return w, h
+
+    @testing.numpy_cupy_allclose(scipy_name="scp")
+    def test_output(self, xp, scp):
+        # 1st order low-pass filter: H(s) = 1 / (s + 1)
+        w = xp.asarray([0.1, 1, 10, 100])
+        num = xp.asarray([1])
+        den = xp.asarray([1, 1])
+        w, H = scp.signal.freqs(num, den, worN=w)
+        return w, H
+
+    @testing.numpy_cupy_allclose(scipy_name="scp")
+    def test_freq_range(self, xp, scp):
+        # Test that freqresp() finds a reasonable frequency range.
+        # 1st order low-pass filter: H(s) = 1 / (s + 1)
+        # Expected range is from 0.01 to 10.
+        num = xp.asarray([1])
+        den = xp.asarray([1, 1])
+        n = 10
+        w, H = scp.signal.freqs(num, den, worN=n)
+        return w, H
+
+    @pytest.mark.parametrize('w', [8.0, 8.0 + 0j])
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_w_or_N_types(self, xp, scp, w):
+        w, h = scp.signal.freqs(xp.asarray([1.0]), xp.asarray([1.0]), worN=w)
+        return w, h
+
+
+@testing.with_requires("scipy")
 class TestFreqz:
 
     def test_ticket1441(self):


### PR DESCRIPTION
cross-ref https://github.com/cupy/cupy/issues/7403

As discussed on gitter, this PR delegates to `numpy.roots`  on CPU. The issue is that root-finding is typically done as the eigenvalue problem for the companion matrix, but `eigvals` is only available in MAGMA which is not a CuPy dependency.

<s>PR is on top of https://github.com/cupy/cupy/pull/7638 , will rebase</s> rebased.