### PR TITLE
[v12] Require numpy<1.25 for `round_` tests

### DIFF
--- a/tests/cupy_tests/math_tests/test_rounding.py
+++ b/tests/cupy_tests/math_tests/test_rounding.py
@@ -68,7 +68,7 @@ class TestRounding(unittest.TestCase):
         self.check_unary('around')
         self.check_unary_complex('around')
 
-    @testing.requires('numpy<1.25')
+    @testing.with_requires('numpy<1.25')
     def test_round_(self):
         self.check_unary('round_')
         self.check_unary_complex('round_')

--- a/tests/cupy_tests/math_tests/test_rounding.py
+++ b/tests/cupy_tests/math_tests/test_rounding.py
@@ -68,6 +68,7 @@ class TestRounding(unittest.TestCase):
         self.check_unary('around')
         self.check_unary_complex('around')
 
+    @testing.requires('numpy<1.25')
     def test_round_(self):
         self.check_unary('round_')
         self.check_unary_complex('round_')

--- a/tests/cupyx_tests/scipy_tests/fft_tests/test_fftlog.py
+++ b/tests/cupyx_tests/scipy_tests/fft_tests/test_fftlog.py
@@ -31,7 +31,7 @@ class TestFftlog:
 
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose(rtol=rtol, atol=atol, scipy_name='scp')
-    @testing.with_requires('scipy>=1.7.0')
+    @testing.with_requires('numpy<1.25', 'scipy>=1.7.0')
     def test_fht(self, xp, scp, dtype):
 
         # test function, analytical Hankel transform is of the same form


### PR DESCRIPTION
Following #7623.