### PR TITLE
Deprecate `product`, `cumproduct`, `alltrue` and `sometrue`

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -582,10 +582,10 @@ from cupy._math.rounding import round_  # NOQA
 from cupy._math.rounding import trunc  # NOQA
 
 from cupy._math.sumprod import prod  # NOQA
-from cupy._math.sumprod import prod as product  # NOQA
+from cupy._math.sumprod import product  # NOQA
 from cupy._math.sumprod import sum  # NOQA
 from cupy._math.sumprod import cumprod  # NOQA
-from cupy._math.sumprod import cumprod as cumproduct  # NOQA
+from cupy._math.sumprod import cumproduct  # NOQA
 from cupy._math.sumprod import cumsum  # NOQA
 from cupy._math.sumprod import ediff1d  # NOQA
 from cupy._math.sumprod import nancumprod  # NOQA

--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -529,9 +529,9 @@ from cupy._logic.comparison import less_equal  # NOQA
 from cupy._logic.comparison import not_equal  # NOQA
 
 from cupy._logic.truth import all  # NOQA
-from cupy._logic.truth import all as alltrue  # NOQA
+from cupy._logic.truth import alltrue  # NOQA
 from cupy._logic.truth import any  # NOQA
-from cupy._logic.truth import any as sometrue  # NOQA
+from cupy._logic.truth import sometrue  # NOQA
 
 # ------------------------------------------------------------------------------
 # Polynomial functions

--- a/cupy/_indexing/insert.py
+++ b/cupy/_indexing/insert.py
@@ -173,7 +173,7 @@ def fill_diagonal(a, val, wrap=False):
         if not wrap:
             end = a.shape[1] * a.shape[1]
     else:
-        if not numpy.alltrue(numpy.diff(a.shape) == 0):
+        if not numpy.all(numpy.diff(a.shape) == 0):
             raise ValueError('All dimensions of input must be of equal length')
         step = 1 + numpy.cumprod(a.shape[:-1]).sum()
 

--- a/cupy/_logic/truth.py
+++ b/cupy/_logic/truth.py
@@ -1,3 +1,5 @@
+import warnings
+
 import cupy
 from cupy._core import _routines_logic as _logic
 from cupy._core import _fusion_thread_local
@@ -314,3 +316,13 @@ def union1d(arr1, arr2):
 
     """
     return cupy.unique(cupy.concatenate((arr1, arr2), axis=None))
+
+
+def alltrue(a, axis=None, out=None, keepdims=False):
+    warnings.warn('Please use `all` instead.', DeprecationWarning)
+    return all(a, axis, out, keepdims)
+
+
+def sometrue(a, axis=None, out=None, keepdims=False):
+    warnings.warn('Please use `any` instead.', DeprecationWarning)
+    return any(a, axis, out, keepdims)

--- a/cupy/_math/sumprod.py
+++ b/cupy/_math/sumprod.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy
 
 import cupy
@@ -624,3 +626,13 @@ def trapz(y, x=None, dx=1.0, axis=-1):
     except ValueError:
         ret = cupy.add.reduce(product, axis)
     return ret
+
+
+def product(a, axis=None, dtype=None, out=None, keepdims=False):
+    warnings.warn('Please use `prod` instead.', DeprecationWarning)
+    return prod(a, axis, dtype, out, keepdims)
+
+
+def cumproduct(a, axis=None, dtype=None, out=None):
+    warnings.warn('Please use `cumprod` instead.', DeprecationWarning)
+    return cumprod(a, axis, dtype, out)

--- a/tests/cupy_tests/logic_tests/test_truth.py
+++ b/tests/cupy_tests/logic_tests/test_truth.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy
 
 from cupy import testing
@@ -81,11 +83,15 @@ class TestAllAnyWithNaN:
 class TestAllAnyAlias:
     @testing.numpy_cupy_array_equal()
     def test_alltrue(self, xp):
-        return xp.alltrue(xp.array([1, 2, 3]))
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', DeprecationWarning)
+            return xp.alltrue(xp.array([1, 2, 3]))
 
     @testing.numpy_cupy_array_equal()
     def test_sometrue(self, xp):
-        return xp.sometrue(xp.array([0]))
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', DeprecationWarning)
+            return xp.sometrue(xp.array([0]))
 
 
 @testing.parameterize(

--- a/tests/cupy_tests/math_tests/test_sumprod.py
+++ b/tests/cupy_tests/math_tests/test_sumprod.py
@@ -1,4 +1,5 @@
 import math
+import warnings
 
 import numpy
 import pytest
@@ -204,7 +205,9 @@ class TestSumprod:
     @testing.numpy_cupy_allclose()
     def test_product_alias(self, xp):
         a = testing.shaped_arange((2, 3), xp, xp.float32)
-        return xp.product(a)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', DeprecationWarning)
+            return xp.product(a)
 
 
 # This class compares CUB results against NumPy's
@@ -773,7 +776,9 @@ class TestCumprod:
     @testing.numpy_cupy_allclose()
     def test_cumproduct_alias(self, xp):
         a = testing.shaped_arange((2, 3), xp, xp.float32)
-        return xp.cumproduct(a)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', DeprecationWarning)
+            return xp.cumproduct(a)
 
 
 @testing.parameterize(*testing.product({


### PR DESCRIPTION
Part of #7616.
Deprecated in NumPy 1.25.