### PR TITLE
Fix small typos in docstrings

### DIFF
--- a/cupyx/jit/thrust.py
+++ b/cupyx/jit/thrust.py
@@ -500,7 +500,7 @@ def reduce_by_key(
 
 @_wrap_thrust_func(['thrust/remove.h'])
 def remove(env, exec_policy, first, last, value):
-    """Removes from the range all elements that are rqual to value.
+    """Removes from the range all elements that are equal to value.
     """
     _assert_exec_policy_type(exec_policy)
     _assert_pointer_type(first)
@@ -512,7 +512,7 @@ def remove(env, exec_policy, first, last, value):
 
 @_wrap_thrust_func(['thrust/remove.h'])
 def remove_copy(env, exec_policy, first, last, result, value):
-    """Removes from the range all elements that are rqual to value.
+    """Removes from the range all elements that are equal to value.
     """
     _assert_exec_policy_type(exec_policy)
     _assert_pointer_type(first)


### PR DESCRIPTION
This commit just fixes a couple of spelling typos.

Background: I'm doing a research study on function comments that may be incorrect. You can find more info and a short and optional anonymous survey [here](https://forms.office.com/e/yHv4PRXM2i).
 
Thanks for reviewing!