### PR TITLE
Fix project automation to skip when pull-request is already closed

### DIFF
--- a/.github/workflows/pr-project.yml
+++ b/.github/workflows/pr-project.yml
@@ -8,8 +8,12 @@ on:
 jobs:
   needs-attention:
     # Brings the pull-request to attention by any activities triggered by users other than assignees.
+    # c.f. https://docs.github.com/en/issues/planning-and-tracking-with-projects/automating-your-project/automating-projects-using-actions
     # c.f. https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
-    if: github.repository_owner == 'cupy'
+    if: |
+      github.repository_owner == 'cupy' &&
+      github.event.workflow_run.conclusion == 'success'
+
     runs-on: ubuntu-22.04
     steps:
       # Get the GitHub app installation token.
@@ -42,10 +46,13 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
+            const workflow_run_id = ${{ github.event.workflow_run.id }};
+            core.notice(`Triggered by: https://github.com/cupy/cupy/actions/runs/${workflow_run_id}`);
+
             var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
                owner: context.repo.owner,
                repo: context.repo.repo,
-               run_id: ${{ github.event.workflow_run.id }},
+               run_id: workflow_run_id,
             });
             var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
               return artifact.name == "PULL_REQUEST_NUMBER"
@@ -66,6 +73,7 @@ jobs:
           GH_TOKEN: ${{ steps.token.outputs.result }}
         run: |
           PULL_REQUEST="$(cat 'PULL_REQUEST_NUMBER')"
+          echo "::notice::Pull-Request: #${PULL_REQUEST}"
 
           # https://github.com/orgs/cupy/projects/4
           gh api graphql -F "pull_request=${PULL_REQUEST}" -f query='
@@ -85,6 +93,7 @@ jobs:
                 }
                 repository(name: "cupy") {
                   pullRequest(number: $pull_request) {
+                    state
                     projectItems(first: 100, includeArchived: false) {
                       nodes {
                         project {
@@ -98,15 +107,22 @@ jobs:
               }
             }
           ' --jq '
-            .data.organization.projectV2.id as $project_id |
+            .data.organization.projectV2 as $project |
+            .data.organization.repository as $repo |
             {
-              "project_id": $project_id,
-              "field_id":   .data.organization.projectV2.field.id,
-              "option_id":  .data.organization.projectV2.field.options[] | select(.name == "Needs Attention") | .id,
-              "item_id":    .data.organization.repository.pullRequest.projectItems.nodes[] | select(.project.id == $project_id) | .id,
+              "project_id": $project.id,
+              "field_id":   $project.field.id,
+              "option_id":  $project.field.options[] | select(.name == "Needs Attention") | .id,
+              "item_id":    (($repo.pullRequest.projectItems.nodes[] | select(.project.id == $project.id) | .id) // -1),
+              "state":      $repo.pullRequest.state
             }
           ' > params.json
           jq . params.json
+          if [[ $(jq .item_id params.json) == -1 && $(jq .state params.json) != OPEN ]]; then
+            echo "The pull-request is already closed."
+            exit
+          fi
+
           gh api graphql $(jq -r '[to_entries[] | "-F " + .key + "=\"" + .value + "\""] | join(" ")' params.json) -f query='
             mutation ($project_id: ID!, $field_id: ID!, $item_id: ID!) {
               updateProjectV2ItemFieldValue(

--- a/.github/workflows/pr-updated.yml
+++ b/.github/workflows/pr-updated.yml
@@ -7,6 +7,10 @@ on:
   pull_request_review:
   pull_request_review_comment:
 
+concurrency:
+  group: "pull-request-update-${{ (github.event.pull_request || github.event.issue).number }}"
+  cancel-in-progress: true
+
 jobs:
   mark-needs-attention:
     if: |


### PR DESCRIPTION
This fixes the problem that:
* The workflow is triggered even if it is an issue, e.g., https://github.com/cupy/cupy/actions/runs/5330383404/jobs/9657009231
* The workflow fails if pull-request is closed, e.g. https://github.com/cupy/cupy/actions/runs/5332268592
* Limit triggering workflows for many times