### PR TITLE
ENH: add LTI class hierarchy and lti/dlti related functions

### DIFF
--- a/cupyx/scipy/signal/__init__.py
+++ b/cupyx/scipy/signal/__init__.py
@@ -107,6 +107,8 @@ from cupyx.scipy.signal._peak_finding import peak_prominences  # NOQA
 from cupyx.scipy.signal._peak_finding import peak_widths  # NOQA
 
 from cupyx.scipy.signal._ltisys import lti  # NOQA
+from cupyx.scipy.signal._ltisys import freqresp  # NOQA
+
 from cupyx.scipy.signal._ltisys import dlti  # NOQA
 from cupyx.scipy.signal._ltisys import dlsim  # NOQA
 from cupyx.scipy.signal._ltisys import dstep  # NOQA

--- a/cupyx/scipy/signal/__init__.py
+++ b/cupyx/scipy/signal/__init__.py
@@ -108,6 +108,7 @@ from cupyx.scipy.signal._peak_finding import peak_widths  # NOQA
 
 from cupyx.scipy.signal._ltisys import lti  # NOQA
 from cupyx.scipy.signal._ltisys import lsim  # NOQA
+from cupyx.scipy.signal._ltisys import impulse  # NOQA
 from cupyx.scipy.signal._ltisys import freqresp  # NOQA
 from cupyx.scipy.signal._ltisys import bode  # NOQA
 

--- a/cupyx/scipy/signal/__init__.py
+++ b/cupyx/scipy/signal/__init__.py
@@ -105,3 +105,12 @@ from cupyx.scipy.signal._lti_conversion import abcd_normalize   # NOQA
 from cupyx.scipy.signal._peak_finding import find_peaks  # NOQA
 from cupyx.scipy.signal._peak_finding import peak_prominences  # NOQA
 from cupyx.scipy.signal._peak_finding import peak_widths  # NOQA
+
+from cupyx.scipy.signal._ltisys import dlsim
+from cupyx.scipy.signal._ltisys import dstep
+from cupyx.scipy.signal._ltisys import dimpulse
+from cupyx.scipy.signal._ltisys import dbode
+from cupyx.scipy.signal._ltisys import dfreqresp
+from cupyx.scipy.signal._ltisys import StateSpace
+from cupyx.scipy.signal._ltisys import TransferFunction
+from cupyx.scipy.signal._ltisys import ZeroPolesGain

--- a/cupyx/scipy/signal/__init__.py
+++ b/cupyx/scipy/signal/__init__.py
@@ -107,6 +107,7 @@ from cupyx.scipy.signal._peak_finding import peak_prominences  # NOQA
 from cupyx.scipy.signal._peak_finding import peak_widths  # NOQA
 
 from cupyx.scipy.signal._ltisys import lti  # NOQA
+from cupyx.scipy.signal._ltisys import lsim  # NOQA
 from cupyx.scipy.signal._ltisys import freqresp  # NOQA
 from cupyx.scipy.signal._ltisys import bode  # NOQA
 

--- a/cupyx/scipy/signal/__init__.py
+++ b/cupyx/scipy/signal/__init__.py
@@ -106,11 +106,13 @@ from cupyx.scipy.signal._peak_finding import find_peaks  # NOQA
 from cupyx.scipy.signal._peak_finding import peak_prominences  # NOQA
 from cupyx.scipy.signal._peak_finding import peak_widths  # NOQA
 
-from cupyx.scipy.signal._ltisys import dlsim
-from cupyx.scipy.signal._ltisys import dstep
-from cupyx.scipy.signal._ltisys import dimpulse
-from cupyx.scipy.signal._ltisys import dbode
-from cupyx.scipy.signal._ltisys import dfreqresp
-from cupyx.scipy.signal._ltisys import StateSpace
-from cupyx.scipy.signal._ltisys import TransferFunction
-from cupyx.scipy.signal._ltisys import ZeroPolesGain
+from cupyx.scipy.signal._ltisys import lti  # NOQA
+from cupyx.scipy.signal._ltisys import dlti  # NOQA
+from cupyx.scipy.signal._ltisys import dlsim  # NOQA
+from cupyx.scipy.signal._ltisys import dstep  # NOQA
+from cupyx.scipy.signal._ltisys import dimpulse  # NOQA
+from cupyx.scipy.signal._ltisys import dbode  # NOQA
+from cupyx.scipy.signal._ltisys import dfreqresp  # NOQA
+from cupyx.scipy.signal._ltisys import StateSpace  # NOQA
+from cupyx.scipy.signal._ltisys import TransferFunction  # NOQA
+from cupyx.scipy.signal._ltisys import ZerosPolesGain  # NOQA

--- a/cupyx/scipy/signal/__init__.py
+++ b/cupyx/scipy/signal/__init__.py
@@ -109,6 +109,7 @@ from cupyx.scipy.signal._peak_finding import peak_widths  # NOQA
 from cupyx.scipy.signal._ltisys import lti  # NOQA
 from cupyx.scipy.signal._ltisys import lsim  # NOQA
 from cupyx.scipy.signal._ltisys import impulse  # NOQA
+from cupyx.scipy.signal._ltisys import step  # NOQA
 from cupyx.scipy.signal._ltisys import freqresp  # NOQA
 from cupyx.scipy.signal._ltisys import bode  # NOQA
 

--- a/cupyx/scipy/signal/__init__.py
+++ b/cupyx/scipy/signal/__init__.py
@@ -63,6 +63,7 @@ from cupyx.scipy.signal._iir_filter_conversions import tf2zpk  # NOQA
 from cupyx.scipy.signal._iir_filter_conversions import tf2sos  # NOQA
 from cupyx.scipy.signal._iir_filter_conversions import tf2ss  # NOQA
 from cupyx.scipy.signal._iir_filter_conversions import ss2tf  # NOQA
+from cupyx.scipy.signal._iir_filter_conversions import ss2zpk  # NOQA
 from cupyx.scipy.signal._iir_filter_conversions import sos2tf  # NOQA
 from cupyx.scipy.signal._iir_filter_conversions import sos2zpk  # NOQA
 
@@ -122,3 +123,5 @@ from cupyx.scipy.signal._ltisys import dfreqresp  # NOQA
 from cupyx.scipy.signal._ltisys import StateSpace  # NOQA
 from cupyx.scipy.signal._ltisys import TransferFunction  # NOQA
 from cupyx.scipy.signal._ltisys import ZerosPolesGain  # NOQA
+
+from cupyx.scipy.signal._ltisys import cont2discrete  # NOQA

--- a/cupyx/scipy/signal/__init__.py
+++ b/cupyx/scipy/signal/__init__.py
@@ -108,6 +108,7 @@ from cupyx.scipy.signal._peak_finding import peak_widths  # NOQA
 
 from cupyx.scipy.signal._ltisys import lti  # NOQA
 from cupyx.scipy.signal._ltisys import freqresp  # NOQA
+from cupyx.scipy.signal._ltisys import bode  # NOQA
 
 from cupyx.scipy.signal._ltisys import dlti  # NOQA
 from cupyx.scipy.signal._ltisys import dlsim  # NOQA

--- a/cupyx/scipy/signal/_iir_filter_conversions.py
+++ b/cupyx/scipy/signal/_iir_filter_conversions.py
@@ -32,7 +32,7 @@ def _trim_zeros(filt, trim='fb'):
                 first = first + 1
 
     last = len(filt)
-    if 'f' in trim:
+    if 'b' in trim:
         for i in filt[::-1]:
             if i != 0.:
                 break

--- a/cupyx/scipy/signal/_ltisys.py
+++ b/cupyx/scipy/signal/_ltisys.py
@@ -1418,6 +1418,58 @@ class StateSpaceDiscrete(StateSpace, dlti):
 
 # ### lsim and related functions
 
+def bode(system, w=None, n=100):
+    """
+    Calculate Bode magnitude and phase data of a continuous-time system.
+
+    Parameters
+    ----------
+    system : an instance of the LTI class or a tuple describing the system.
+        The following gives the number of elements in the tuple and
+        the interpretation:
+
+            * 1 (instance of `lti`)
+            * 2 (num, den)
+            * 3 (zeros, poles, gain)
+            * 4 (A, B, C, D)
+
+    w : array_like, optional
+        Array of frequencies (in rad/s). Magnitude and phase data is calculated
+        for every value in this array. If not given a reasonable set will be
+        calculated.
+    n : int, optional
+        Number of frequency points to compute if `w` is not given. The `n`
+        frequencies are logarithmically spaced in an interval chosen to
+        include the influence of the poles and zeros of the system.
+
+    Returns
+    -------
+    w : 1D ndarray
+        Frequency array [rad/s]
+    mag : 1D ndarray
+        Magnitude array [dB]
+    phase : 1D ndarray
+        Phase array [deg]
+
+    See Also
+    --------
+    scipy.signal.bode
+
+    Notes
+    -----
+    If (num, den) is passed in for ``system``, coefficients for both the
+    numerator and denominator should be specified in descending exponent
+    order (e.g. ``s^2 + 3s + 5`` would be represented as ``[1, 3, 5]``).
+
+    """
+    w, y = freqresp(system, w=w, n=n)
+
+    mag = 20.0 * cupy.log10(abs(y))
+    phase = cupy.unwrap(cupy.arctan2(y.imag, y.real)) * 180.0 / cupy.pi
+
+    return w, mag, phase
+
+
 def freqresp(system, w=None, n=10000):
     r"""Calculate the frequency response of a continuous-time system.
 

--- a/cupyx/scipy/signal/_ltisys.py
+++ b/cupyx/scipy/signal/_ltisys.py
@@ -1680,6 +1680,65 @@ def impulse(system, X0=None, T=None, N=None):
     return T, h
 
 
+def step(system, X0=None, T=None, N=None):
+    """Step response of continuous-time system.
+
+    Parameters
+    ----------
+    system : an instance of the LTI class or a tuple of array_like
+        describing the system.
+        The following gives the number of elements in the tuple and
+        the interpretation:
+
+            * 1 (instance of `lti`)
+            * 2 (num, den)
+            * 3 (zeros, poles, gain)
+            * 4 (A, B, C, D)
+
+    X0 : array_like, optional
+        Initial state-vector (default is zero).
+    T : array_like, optional
+        Time points (computed if not given).
+    N : int, optional
+        Number of time points to compute if `T` is not given.
+
+    Returns
+    -------
+    T : 1D ndarray
+        Output time points.
+    yout : 1D ndarray
+        Step response of system.
+
+
+    Notes
+    -----
+    If (num, den) is passed in for ``system``, coefficients for both the
+    numerator and denominator should be specified in descending exponent
+    order (e.g. ``s^2 + 3s + 5`` would be represented as ``[1, 3, 5]``).
+
+    See Also
+    --------
+    scipy.signal.step
+
+    """
+    if isinstance(system, lti):
+        sys = system._as_ss()
+    elif isinstance(system, dlti):
+        raise AttributeError('step can only be used with continuous-time '
+                             'systems.')
+    else:
+        sys = lti(*system)._as_ss()
+    if N is None:
+        N = 100
+    if T is None:
+        T = _default_response_times(sys.A, N)
+    else:
+        T = cupy.asarray(T)
+    U = cupy.ones(T.shape, sys.A.dtype)
+    vals = lsim(sys, U, T, X0=X0, interp=False)
+    return vals[0], vals[1]
+
+
 def bode(system, w=None, n=100):
     """
     Calculate Bode magnitude and phase data of a continuous-time system.

--- a/cupyx/scipy/signal/_ltisys.py
+++ b/cupyx/scipy/signal/_ltisys.py
@@ -1,0 +1,1421 @@
+"""
+ltisys -- a collection of classes and functions for modeling linear
+time invariant systems.
+"""
+import warnings
+import copy
+
+#from scipy.linalg import qr as s_qr
+#from scipy import integrate, interpolate, linalg
+#from scipy.interpolate import interp1d
+#from ._filter_design import (tf2zpk, zpk2tf, normalize, freqs, freqz, freqs_zpk,
+#                            freqz_zpk)
+#from ._lti_conversion import (tf2ss, abcd_normalize, ss2tf, zpk2ss, ss2zpk,
+#                             cont2discrete)
+
+import cupy
+
+from cupyx.scipy import linalg
+
+from cupyx.scipy.signal._iir_filter_conversions import (
+        normalize, tf2zpk, tf2ss, _atleast_2d_or_none)
+
+
+class LinearTimeInvariant:
+    def __new__(cls, *system, **kwargs):
+        """Create a new object, don't allow direct instances."""
+        if cls is LinearTimeInvariant:
+            raise NotImplementedError('The LinearTimeInvariant class is not '
+                                      'meant to be used directly, use `lti` '
+                                      'or `dlti` instead.')
+        return super().__new__(cls)
+
+    def __init__(self):
+        """
+        Initialize the `lti` baseclass.
+
+        The heavy lifting is done by the subclasses.
+        """
+        super().__init__()
+
+        self.inputs = None
+        self.outputs = None
+        self._dt = None
+
+    @property
+    def dt(self):
+        """Return the sampling time of the system, `None` for `lti` systems."""
+        return self._dt
+
+    @property
+    def _dt_dict(self):
+        if self.dt is None:
+            return {}
+        else:
+            return {'dt': self.dt}
+
+    @property
+    def zeros(self):
+        """Zeros of the system."""
+        return self.to_zpk().zeros
+
+    @property
+    def poles(self):
+        """Poles of the system."""
+        return self.to_zpk().poles
+
+    def _as_ss(self):
+        """Convert to `StateSpace` system, without copying.
+
+        Returns
+        -------
+        sys: StateSpace
+            The `StateSpace` system. If the class is already an instance of
+            `StateSpace` then this instance is returned.
+        """
+        if isinstance(self, StateSpace):
+            return self
+        else:
+            return self.to_ss()
+
+    def _as_zpk(self):
+        """Convert to `ZerosPolesGain` system, without copying.
+
+        Returns
+        -------
+        sys: ZerosPolesGain
+            The `ZerosPolesGain` system. If the class is already an instance of
+            `ZerosPolesGain` then this instance is returned.
+        """
+        if isinstance(self, ZerosPolesGain):
+            return self
+        else:
+            return self.to_zpk()
+
+    def _as_tf(self):
+        """Convert to `TransferFunction` system, without copying.
+
+        Returns
+        -------
+        sys: ZerosPolesGain
+            The `TransferFunction` system. If the class is already an instance of
+            `TransferFunction` then this instance is returned.
+        """
+        if isinstance(self, TransferFunction):
+            return self
+        else:
+            return self.to_tf()
+
+
+class lti(LinearTimeInvariant):
+    r"""
+    Continuous-time linear time invariant system base class.
+
+    Parameters
+    ----------
+    *system : arguments
+        The `lti` class can be instantiated with either 2, 3 or 4 arguments.
+        The following gives the number of arguments and the corresponding
+        continuous-time subclass that is created:
+
+            * 2: `TransferFunction`:  (numerator, denominator)
+            * 3: `ZerosPolesGain`: (zeros, poles, gain)
+            * 4: `StateSpace`:  (A, B, C, D)
+
+        Each argument can be an array or a sequence.
+
+    See Also
+    --------
+    scipy.signal.lti
+    ZerosPolesGain, StateSpace, TransferFunction, dlti
+
+    Notes
+    -----
+    `lti` instances do not exist directly. Instead, `lti` creates an instance
+    of one of its subclasses: `StateSpace`, `TransferFunction` or
+    `ZerosPolesGain`.
+
+    If (numerator, denominator) is passed in for ``*system``, coefficients for
+    both the numerator and denominator should be specified in descending
+    exponent order (e.g., ``s^2 + 3s + 5`` would be represented as ``[1, 3,
+    5]``).
+
+    Changing the value of properties that are not directly part of the current
+    system representation (such as the `zeros` of a `StateSpace` system) is
+    very inefficient and may lead to numerical inaccuracies. It is better to
+    convert to the specific system representation first. For example, call
+    ``sys = sys.to_zpk()`` before accessing/changing the zeros, poles or gain.
+    """
+    def __new__(cls, *system):
+        """Create an instance of the appropriate subclass."""
+        if cls is lti:
+            N = len(system)
+            if N == 2:
+                return TransferFunctionContinuous.__new__(
+                    TransferFunctionContinuous, *system)
+            elif N == 3:
+                return ZerosPolesGainContinuous.__new__(
+                    ZerosPolesGainContinuous, *system)
+            elif N == 4:
+                return StateSpaceContinuous.__new__(StateSpaceContinuous,
+                                                    *system)
+            else:
+                raise ValueError("`system` needs to be an instance of `lti` "
+                                 "or have 2, 3 or 4 arguments.")
+        # __new__ was called from a subclass, let it call its own functions
+        return super().__new__(cls)
+
+    def __init__(self, *system):
+        """
+        Initialize the `lti` baseclass.
+
+        The heavy lifting is done by the subclasses.
+        """
+        super().__init__(*system)
+
+    def impulse(self, X0=None, T=None, N=None):
+        """
+        Return the impulse response of a continuous-time system.
+        See `impulse` for details.
+        """
+        return impulse(self, X0=X0, T=T, N=N)
+
+    def step(self, X0=None, T=None, N=None):
+        """
+        Return the step response of a continuous-time system.
+        See `step` for details.
+        """
+        return step(self, X0=X0, T=T, N=N)
+
+    def output(self, U, T, X0=None):
+        """
+        Return the response of a continuous-time system to input `U`.
+        See `lsim` for details.
+        """
+        return lsim(self, U, T, X0=X0)
+
+    def bode(self, w=None, n=100):
+        """
+        Calculate Bode magnitude and phase data of a continuous-time system.
+
+        Returns a 3-tuple containing arrays of frequencies [rad/s], magnitude
+        [dB] and phase [deg]. See `bode` for details.
+        """
+        return bode(self, w=w, n=n)
+
+    def freqresp(self, w=None, n=10000):
+        """
+        Calculate the frequency response of a continuous-time system.
+
+        Returns a 2-tuple containing arrays of frequencies [rad/s] and
+        complex magnitude.
+        See `freqresp` for details.
+        """
+        return freqresp(self, w=w, n=n)
+
+    def to_discrete(self, dt, method='zoh', alpha=None):
+        """Return a discretized version of the current system.
+
+        Parameters: See `cont2discrete` for details.
+
+        Returns
+        -------
+        sys: instance of `dlti`
+        """
+        raise NotImplementedError('to_discrete is not implemented for this '
+                                  'system class.')
+
+
+class dlti(LinearTimeInvariant):
+    r"""
+    Discrete-time linear time invariant system base class.
+
+    Parameters
+    ----------
+    *system: arguments
+        The `dlti` class can be instantiated with either 2, 3 or 4 arguments.
+        The following gives the number of arguments and the corresponding
+        discrete-time subclass that is created:
+
+            * 2: `TransferFunction`:  (numerator, denominator)
+            * 3: `ZerosPolesGain`: (zeros, poles, gain)
+            * 4: `StateSpace`:  (A, B, C, D)
+
+        Each argument can be an array or a sequence.
+    dt: float, optional
+        Sampling time [s] of the discrete-time systems. Defaults to ``True``
+        (unspecified sampling time). Must be specified as a keyword argument,
+        for example, ``dt=0.1``.
+
+    See Also
+    --------
+    scipy.signal.dlti
+    ZerosPolesGain, StateSpace, TransferFunction, lti
+
+    Notes
+    -----
+    `dlti` instances do not exist directly. Instead, `dlti` creates an instance
+    of one of its subclasses: `StateSpace`, `TransferFunction` or
+    `ZerosPolesGain`.
+
+    Changing the value of properties that are not directly part of the current
+    system representation (such as the `zeros` of a `StateSpace` system) is
+    very inefficient and may lead to numerical inaccuracies.  It is better to
+    convert to the specific system representation first. For example, call
+    ``sys = sys.to_zpk()`` before accessing/changing the zeros, poles or gain.
+
+    If (numerator, denominator) is passed in for ``*system``, coefficients for
+    both the numerator and denominator should be specified in descending
+    exponent order (e.g., ``z^2 + 3z + 5`` would be represented as ``[1, 3,
+    5]``).
+    """
+    def __new__(cls, *system, **kwargs):
+        """Create an instance of the appropriate subclass."""
+        if cls is dlti:
+            N = len(system)
+            if N == 2:
+                return TransferFunctionDiscrete.__new__(
+                    TransferFunctionDiscrete, *system, **kwargs)
+            elif N == 3:
+                return ZerosPolesGainDiscrete.__new__(ZerosPolesGainDiscrete,
+                                                      *system, **kwargs)
+            elif N == 4:
+                return StateSpaceDiscrete.__new__(StateSpaceDiscrete, *system,
+                                                  **kwargs)
+            else:
+                raise ValueError("`system` needs to be an instance of `dlti` "
+                                 "or have 2, 3 or 4 arguments.")
+        # __new__ was called from a subclass, let it call its own functions
+        return super().__new__(cls)
+
+    def __init__(self, *system, **kwargs):
+        """
+        Initialize the `lti` baseclass.
+
+        The heavy lifting is done by the subclasses.
+        """
+        dt = kwargs.pop('dt', True)
+        super().__init__(*system, **kwargs)
+
+        self.dt = dt
+
+    @property
+    def dt(self):
+        """Return the sampling time of the system."""
+        return self._dt
+
+    @dt.setter
+    def dt(self, dt):
+        self._dt = dt
+
+    def impulse(self, x0=None, t=None, n=None):
+        """
+        Return the impulse response of the discrete-time `dlti` system.
+        See `dimpulse` for details.
+        """
+        return dimpulse(self, x0=x0, t=t, n=n)
+
+    def step(self, x0=None, t=None, n=None):
+        """
+        Return the step response of the discrete-time `dlti` system.
+        See `dstep` for details.
+        """
+        return dstep(self, x0=x0, t=t, n=n)
+
+    def output(self, u, t, x0=None):
+        """
+        Return the response of the discrete-time system to input `u`.
+        See `dlsim` for details.
+        """
+        return dlsim(self, u, t, x0=x0)
+
+    def bode(self, w=None, n=100):
+        r"""
+        Calculate Bode magnitude and phase data of a discrete-time system.
+
+        Returns a 3-tuple containing arrays of frequencies [rad/s], magnitude
+        [dB] and phase [deg]. See `dbode` for details.
+        """
+        return dbode(self, w=w, n=n)
+
+    def freqresp(self, w=None, n=10000, whole=False):
+        """
+        Calculate the frequency response of a discrete-time system.
+
+        Returns a 2-tuple containing arrays of frequencies [rad/s] and
+        complex magnitude.
+        See `dfreqresp` for details.
+
+        """
+        return dfreqresp(self, w=w, n=n, whole=whole)
+
+
+
+class TransferFunction(LinearTimeInvariant):
+    r"""Linear Time Invariant system class in transfer function form.
+
+    Represents the system as the continuous-time transfer function
+    :math:`H(s)=\sum_{i=0}^N b[N-i] s^i / \sum_{j=0}^M a[M-j] s^j` or the
+    discrete-time transfer function
+    :math:`H(z)=\sum_{i=0}^N b[N-i] z^i / \sum_{j=0}^M a[M-j] z^j`, where
+    :math:`b` are elements of the numerator `num`, :math:`a` are elements of
+    the denominator `den`, and ``N == len(b) - 1``, ``M == len(a) - 1``.
+    `TransferFunction` systems inherit additional
+    functionality from the `lti`, respectively the `dlti` classes, depending on
+    which system representation is used.
+
+    Parameters
+    ----------
+    *system: arguments
+        The `TransferFunction` class can be instantiated with 1 or 2
+        arguments. The following gives the number of input arguments and their
+        interpretation:
+
+            * 1: `lti` or `dlti` system: (`StateSpace`, `TransferFunction` or
+              `ZerosPolesGain`)
+            * 2: array_like: (numerator, denominator)
+    dt: float, optional
+        Sampling time [s] of the discrete-time systems. Defaults to `None`
+        (continuous-time). Must be specified as a keyword argument, for
+        example, ``dt=0.1``.
+
+    See Also
+    --------
+    scipy.signal.TransferFunction
+    ZerosPolesGain, StateSpace, lti, dlti
+    tf2ss, tf2zpk, tf2sos
+
+    Notes
+    -----
+    Changing the value of properties that are not part of the
+    `TransferFunction` system representation (such as the `A`, `B`, `C`, `D`
+    state-space matrices) is very inefficient and may lead to numerical
+    inaccuracies.  It is better to convert to the specific system
+    representation first. For example, call ``sys = sys.to_ss()`` before
+    accessing/changing the A, B, C, D system matrices.
+
+    If (numerator, denominator) is passed in for ``*system``, coefficients
+    for both the numerator and denominator should be specified in descending
+    exponent order (e.g. ``s^2 + 3s + 5`` or ``z^2 + 3z + 5`` would be
+    represented as ``[1, 3, 5]``)
+    """
+    def __new__(cls, *system, **kwargs):
+        """Handle object conversion if input is an instance of lti."""
+        if len(system) == 1 and isinstance(system[0], LinearTimeInvariant):
+            return system[0].to_tf()
+
+        # Choose whether to inherit from `lti` or from `dlti`
+        if cls is TransferFunction:
+            if kwargs.get('dt') is None:
+                return TransferFunctionContinuous.__new__(
+                    TransferFunctionContinuous,
+                    *system,
+                    **kwargs)
+            else:
+                return TransferFunctionDiscrete.__new__(
+                    TransferFunctionDiscrete,
+                    *system,
+                    **kwargs)
+
+        # No special conversion needed
+        return super().__new__(cls)
+
+    def __init__(self, *system, **kwargs):
+        """Initialize the state space LTI system."""
+        # Conversion of lti instances is handled in __new__
+        if isinstance(system[0], LinearTimeInvariant):
+            return
+
+        # Remove system arguments, not needed by parents anymore
+        super().__init__(**kwargs)
+
+        self._num = None
+        self._den = None
+
+        self.num, self.den = normalize(*system)
+
+    def __repr__(self):
+        """Return representation of the system's transfer function"""
+        return '{}(\n{},\n{},\ndt: {}\n)'.format(
+            self.__class__.__name__,
+            repr(self.num),
+            repr(self.den),
+            repr(self.dt),
+            )
+
+    @property
+    def num(self):
+        """Numerator of the `TransferFunction` system."""
+        return self._num
+
+    @num.setter
+    def num(self, num):
+        self._num = cupy.atleast_1d(num)
+
+        # Update dimensions
+        if len(self.num.shape) > 1:
+            self.outputs, self.inputs = self.num.shape
+        else:
+            self.outputs = 1
+            self.inputs = 1
+
+    @property
+    def den(self):
+        """Denominator of the `TransferFunction` system."""
+        return self._den
+
+    @den.setter
+    def den(self, den):
+        self._den = cupy.atleast_1d(den)
+
+    def _copy(self, system):
+        """
+        Copy the parameters of another `TransferFunction` object
+
+        Parameters
+        ----------
+        system : `TransferFunction`
+            The `StateSpace` system that is to be copied
+
+        """
+        self.num = system.num
+        self.den = system.den
+
+    def to_tf(self):
+        """
+        Return a copy of the current `TransferFunction` system.
+
+        Returns
+        -------
+        sys : instance of `TransferFunction`
+            The current system (copy)
+
+        """
+        return copy.deepcopy(self)
+
+    def to_zpk(self):
+        """
+        Convert system representation to `ZerosPolesGain`.
+
+        Returns
+        -------
+        sys : instance of `ZerosPolesGain`
+            Zeros, poles, gain representation of the current system
+
+        """
+        return ZerosPolesGain(*tf2zpk(self.num, self.den),
+                              **self._dt_dict)
+
+    def to_ss(self):
+        """
+        Convert system representation to `StateSpace`.
+
+        Returns
+        -------
+        sys : instance of `StateSpace`
+            State space model of the current system
+
+        """
+        return StateSpace(*tf2ss(self.num, self.den),
+                          **self._dt_dict)
+
+    @staticmethod
+    def _z_to_zinv(num, den):
+        """Change a transfer function from the variable `z` to `z**-1`.
+
+        Parameters
+        ----------
+        num, den: 1d array_like
+            Sequences representing the coefficients of the numerator and
+            denominator polynomials, in order of descending degree of 'z'.
+            That is, ``5z**2 + 3z + 2`` is presented as ``[5, 3, 2]``.
+
+        Returns
+        -------
+        num, den: 1d array_like
+            Sequences representing the coefficients of the numerator and
+            denominator polynomials, in order of ascending degree of 'z**-1'.
+            That is, ``5 + 3 z**-1 + 2 z**-2`` is presented as ``[5, 3, 2]``.
+        """
+        diff = len(num) - len(den)
+        if diff > 0:
+            den = cupy.hstack((cupy.zeros(diff), den))
+        elif diff < 0:
+            num = cupy.hstack((cupy.zeros(-diff), num))
+        return num, den
+
+    @staticmethod
+    def _zinv_to_z(num, den):
+        """Change a transfer function from the variable `z` to `z**-1`.
+
+        Parameters
+        ----------
+        num, den: 1d array_like
+            Sequences representing the coefficients of the numerator and
+            denominator polynomials, in order of ascending degree of 'z**-1'.
+            That is, ``5 + 3 z**-1 + 2 z**-2`` is presented as ``[5, 3, 2]``.
+
+        Returns
+        -------
+        num, den: 1d array_like
+            Sequences representing the coefficients of the numerator and
+            denominator polynomials, in order of descending degree of 'z'.
+            That is, ``5z**2 + 3z + 2`` is presented as ``[5, 3, 2]``.
+        """
+        diff = len(num) - len(den)
+        if diff > 0:
+            den = cupy.hstack((den, cupy.zeros(diff)))
+        elif diff < 0:
+            num = cupy.hstack((num, cupy.zeros(-diff)))
+        return num, den
+
+
+class TransferFunctionContinuous(TransferFunction, lti):
+    r"""
+    Continuous-time Linear Time Invariant system in transfer function form.
+
+    Represents the system as the transfer function
+    :math:`H(s)=\sum_{i=0}^N b[N-i] s^i / \sum_{j=0}^M a[M-j] s^j`, where
+    :math:`b` are elements of the numerator `num`, :math:`a` are elements of
+    the denominator `den`, and ``N == len(b) - 1``, ``M == len(a) - 1``.
+    Continuous-time `TransferFunction` systems inherit additional
+    functionality from the `lti` class.
+
+    Parameters
+    ----------
+    *system: arguments
+        The `TransferFunction` class can be instantiated with 1 or 2
+        arguments. The following gives the number of input arguments and their
+        interpretation:
+
+            * 1: `lti` system: (`StateSpace`, `TransferFunction` or
+              `ZerosPolesGain`)
+            * 2: array_like: (numerator, denominator)
+
+    See Also
+    --------
+    scipy.signal.TransferFunction
+    ZerosPolesGain, StateSpace, lti
+    tf2ss, tf2zpk, tf2sos
+
+    Notes
+    -----
+    Changing the value of properties that are not part of the
+    `TransferFunction` system representation (such as the `A`, `B`, `C`, `D`
+    state-space matrices) is very inefficient and may lead to numerical
+    inaccuracies.  It is better to convert to the specific system
+    representation first. For example, call ``sys = sys.to_ss()`` before
+    accessing/changing the A, B, C, D system matrices.
+
+    If (numerator, denominator) is passed in for ``*system``, coefficients
+    for both the numerator and denominator should be specified in descending
+    exponent order (e.g. ``s^2 + 3s + 5`` would be represented as
+    ``[1, 3, 5]``)
+
+    """
+    def to_discrete(self, dt, method='zoh', alpha=None):
+        """
+        Returns the discretized `TransferFunction` system.
+
+        Parameters: See `cont2discrete` for details.
+
+        Returns
+        -------
+        sys: instance of `dlti` and `StateSpace`
+        """
+        return TransferFunction(*cont2discrete((self.num, self.den),
+                                               dt,
+                                               method=method,
+                                               alpha=alpha)[:-1],
+                                dt=dt)
+
+
+class TransferFunctionDiscrete(TransferFunction, dlti):
+    r"""
+    Discrete-time Linear Time Invariant system in transfer function form.
+
+    Represents the system as the transfer function
+    :math:`H(z)=\sum_{i=0}^N b[N-i] z^i / \sum_{j=0}^M a[M-j] z^j`, where
+    :math:`b` are elements of the numerator `num`, :math:`a` are elements of
+    the denominator `den`, and ``N == len(b) - 1``, ``M == len(a) - 1``.
+    Discrete-time `TransferFunction` systems inherit additional functionality
+    from the `dlti` class.
+
+    Parameters
+    ----------
+    *system: arguments
+        The `TransferFunction` class can be instantiated with 1 or 2
+        arguments. The following gives the number of input arguments and their
+        interpretation:
+
+            * 1: `dlti` system: (`StateSpace`, `TransferFunction` or
+              `ZerosPolesGain`)
+            * 2: array_like: (numerator, denominator)
+    dt: float, optional
+        Sampling time [s] of the discrete-time systems. Defaults to `True`
+        (unspecified sampling time). Must be specified as a keyword argument,
+        for example, ``dt=0.1``.
+
+    See Also
+    --------
+    scipy.signal.TransferFunctionDiscrete
+    ZerosPolesGain, StateSpace, dlti
+    tf2ss, tf2zpk, tf2sos
+
+    Notes
+    -----
+    Changing the value of properties that are not part of the
+    `TransferFunction` system representation (such as the `A`, `B`, `C`, `D`
+    state-space matrices) is very inefficient and may lead to numerical
+    inaccuracies.
+
+    If (numerator, denominator) is passed in for ``*system``, coefficients
+    for both the numerator and denominator should be specified in descending
+    exponent order (e.g., ``z^2 + 3z + 5`` would be represented as
+    ``[1, 3, 5]``).
+    """
+    pass
+
+
+class ZerosPolesGain(LinearTimeInvariant):
+    r"""
+    Linear Time Invariant system class in zeros, poles, gain form.
+
+    Represents the system as the continuous- or discrete-time transfer function
+    :math:`H(s)=k \prod_i (s - z[i]) / \prod_j (s - p[j])`, where :math:`k` is
+    the `gain`, :math:`z` are the `zeros` and :math:`p` are the `poles`.
+    `ZerosPolesGain` systems inherit additional functionality from the `lti`,
+    respectively the `dlti` classes, depending on which system representation
+    is used.
+
+    Parameters
+    ----------
+    *system : arguments
+        The `ZerosPolesGain` class can be instantiated with 1 or 3
+        arguments. The following gives the number of input arguments and their
+        interpretation:
+
+            * 1: `lti` or `dlti` system: (`StateSpace`, `TransferFunction` or
+              `ZerosPolesGain`)
+            * 3: array_like: (zeros, poles, gain)
+    dt: float, optional
+        Sampling time [s] of the discrete-time systems. Defaults to `None`
+        (continuous-time). Must be specified as a keyword argument, for
+        example, ``dt=0.1``.
+
+
+    See Also
+    --------
+    scipy.signal.ZerosPolesGain
+    TransferFunction, StateSpace, lti, dlti
+    zpk2ss, zpk2tf, zpk2sos
+
+    Notes
+    -----
+    Changing the value of properties that are not part of the
+    `ZerosPolesGain` system representation (such as the `A`, `B`, `C`, `D`
+    state-space matrices) is very inefficient and may lead to numerical
+    inaccuracies.  It is better to convert to the specific system
+    representation first. For example, call ``sys = sys.to_ss()`` before
+    accessing/changing the A, B, C, D system matrices.
+    """
+    def __new__(cls, *system, **kwargs):
+        """Handle object conversion if input is an instance of `lti`"""
+        if len(system) == 1 and isinstance(system[0], LinearTimeInvariant):
+            return system[0].to_zpk()
+
+        # Choose whether to inherit from `lti` or from `dlti`
+        if cls is ZerosPolesGain:
+            if kwargs.get('dt') is None:
+                return ZerosPolesGainContinuous.__new__(
+                    ZerosPolesGainContinuous,
+                    *system,
+                    **kwargs)
+            else:
+                return ZerosPolesGainDiscrete.__new__(
+                    ZerosPolesGainDiscrete,
+                    *system,
+                    **kwargs
+                    )
+
+        # No special conversion needed
+        return super().__new__(cls)
+
+    def __init__(self, *system, **kwargs):
+        """Initialize the zeros, poles, gain system."""
+        # Conversion of lti instances is handled in __new__
+        if isinstance(system[0], LinearTimeInvariant):
+            return
+
+        super().__init__(**kwargs)
+
+        self._zeros = None
+        self._poles = None
+        self._gain = None
+
+        self.zeros, self.poles, self.gain = system
+
+    def __repr__(self):
+        """Return representation of the `ZerosPolesGain` system."""
+        return '{}(\n{},\n{},\n{},\ndt: {}\n)'.format(
+            self.__class__.__name__,
+            repr(self.zeros),
+            repr(self.poles),
+            repr(self.gain),
+            repr(self.dt),
+            )
+
+    @property
+    def zeros(self):
+        """Zeros of the `ZerosPolesGain` system."""
+        return self._zeros
+
+    @zeros.setter
+    def zeros(self, zeros):
+        self._zeros = atleast_1d(zeros)
+
+        # Update dimensions
+        if len(self.zeros.shape) > 1:
+            self.outputs, self.inputs = self.zeros.shape
+        else:
+            self.outputs = 1
+            self.inputs = 1
+
+    @property
+    def poles(self):
+        """Poles of the `ZerosPolesGain` system."""
+        return self._poles
+
+    @poles.setter
+    def poles(self, poles):
+        self._poles = cupy.atleast_1d(poles)
+
+    @property
+    def gain(self):
+        """Gain of the `ZerosPolesGain` system."""
+        return self._gain
+
+    @gain.setter
+    def gain(self, gain):
+        self._gain = gain
+
+    def _copy(self, system):
+        """
+        Copy the parameters of another `ZerosPolesGain` system.
+
+        Parameters
+        ----------
+        system : instance of `ZerosPolesGain`
+            The zeros, poles gain system that is to be copied
+
+        """
+        self.poles = system.poles
+        self.zeros = system.zeros
+        self.gain = system.gain
+
+    def to_tf(self):
+        """
+        Convert system representation to `TransferFunction`.
+
+        Returns
+        -------
+        sys : instance of `TransferFunction`
+            Transfer function of the current system
+
+        """
+        return TransferFunction(*zpk2tf(self.zeros, self.poles, self.gain),
+                                **self._dt_dict)
+
+    def to_zpk(self):
+        """
+        Return a copy of the current 'ZerosPolesGain' system.
+
+        Returns
+        -------
+        sys : instance of `ZerosPolesGain`
+            The current system (copy)
+
+        """
+        return copy.deepcopy(self)
+
+    def to_ss(self):
+        """
+        Convert system representation to `StateSpace`.
+
+        Returns
+        -------
+        sys : instance of `StateSpace`
+            State space model of the current system
+
+        """
+        return StateSpace(*zpk2ss(self.zeros, self.poles, self.gain),
+                          **self._dt_dict)
+
+
+class ZerosPolesGainContinuous(ZerosPolesGain, lti):
+    r"""
+    Continuous-time Linear Time Invariant system in zeros, poles, gain form.
+
+    Represents the system as the continuous time transfer function
+    :math:`H(s)=k \prod_i (s - z[i]) / \prod_j (s - p[j])`, where :math:`k` is
+    the `gain`, :math:`z` are the `zeros` and :math:`p` are the `poles`.
+    Continuous-time `ZerosPolesGain` systems inherit additional functionality
+    from the `lti` class.
+
+    Parameters
+    ----------
+    *system : arguments
+        The `ZerosPolesGain` class can be instantiated with 1 or 3
+        arguments. The following gives the number of input arguments and their
+        interpretation:
+
+            * 1: `lti` system: (`StateSpace`, `TransferFunction` or
+              `ZerosPolesGain`)
+            * 3: array_like: (zeros, poles, gain)
+
+    See Also
+    --------
+    TransferFunction, StateSpace, lti
+    zpk2ss, zpk2tf, zpk2sos
+
+    Notes
+    -----
+    Changing the value of properties that are not part of the
+    `ZerosPolesGain` system representation (such as the `A`, `B`, `C`, `D`
+    state-space matrices) is very inefficient and may lead to numerical
+    inaccuracies.  It is better to convert to the specific system
+    representation first. For example, call ``sys = sys.to_ss()`` before
+    accessing/changing the A, B, C, D system matrices.
+
+    Examples
+    --------
+    Construct the transfer function
+    :math:`H(s)=\frac{5(s - 1)(s - 2)}{(s - 3)(s - 4)}`:
+
+    >>> from scipy import signal
+
+    >>> signal.ZerosPolesGain([1, 2], [3, 4], 5)
+    ZerosPolesGainContinuous(
+    array([1, 2]),
+    array([3, 4]),
+    5,
+    dt: None
+    )
+
+    """
+
+    def to_discrete(self, dt, method='zoh', alpha=None):
+        """
+        Returns the discretized `ZerosPolesGain` system.
+
+        Parameters: See `cont2discrete` for details.
+
+        Returns
+        -------
+        sys: instance of `dlti` and `ZerosPolesGain`
+        """
+        return ZerosPolesGain(
+            *cont2discrete((self.zeros, self.poles, self.gain),
+                           dt,
+                           method=method,
+                           alpha=alpha)[:-1],
+            dt=dt)
+
+
+class ZerosPolesGainDiscrete(ZerosPolesGain, dlti):
+    r"""
+    Discrete-time Linear Time Invariant system in zeros, poles, gain form.
+
+    Represents the system as the discrete-time transfer function
+    :math:`H(z)=k \prod_i (z - q[i]) / \prod_j (z - p[j])`, where :math:`k` is
+    the `gain`, :math:`q` are the `zeros` and :math:`p` are the `poles`.
+    Discrete-time `ZerosPolesGain` systems inherit additional functionality
+    from the `dlti` class.
+
+    Parameters
+    ----------
+    *system : arguments
+        The `ZerosPolesGain` class can be instantiated with 1 or 3
+        arguments. The following gives the number of input arguments and their
+        interpretation:
+
+            * 1: `dlti` system: (`StateSpace`, `TransferFunction` or
+              `ZerosPolesGain`)
+            * 3: array_like: (zeros, poles, gain)
+    dt: float, optional
+        Sampling time [s] of the discrete-time systems. Defaults to `True`
+        (unspecified sampling time). Must be specified as a keyword argument,
+        for example, ``dt=0.1``.
+
+    See Also
+    --------
+    scipy.signal.ZerosPolesGainDiscrete
+    TransferFunction, StateSpace, dlti
+    zpk2ss, zpk2tf, zpk2sos
+
+    Notes
+    -----
+    Changing the value of properties that are not part of the
+    `ZerosPolesGain` system representation (such as the `A`, `B`, `C`, `D`
+    state-space matrices) is very inefficient and may lead to numerical
+    inaccuracies.  It is better to convert to the specific system
+    representation first. For example, call ``sys = sys.to_ss()`` before
+    accessing/changing the A, B, C, D system matrices.
+    """
+    pass
+
+
+class StateSpace(LinearTimeInvariant):
+    r"""
+    Linear Time Invariant system in state-space form.
+
+    Represents the system as the continuous-time, first order differential
+    equation :math:`\dot{x} = A x + B u` or the discrete-time difference
+    equation :math:`x[k+1] = A x[k] + B u[k]`. `StateSpace` systems
+    inherit additional functionality from the `lti`, respectively the `dlti`
+    classes, depending on which system representation is used.
+
+    Parameters
+    ----------
+    *system: arguments
+        The `StateSpace` class can be instantiated with 1 or 4 arguments.
+        The following gives the number of input arguments and their
+        interpretation:
+
+            * 1: `lti` or `dlti` system: (`StateSpace`, `TransferFunction` or
+              `ZerosPolesGain`)
+            * 4: array_like: (A, B, C, D)
+    dt: float, optional
+        Sampling time [s] of the discrete-time systems. Defaults to `None`
+        (continuous-time). Must be specified as a keyword argument, for
+        example, ``dt=0.1``.
+
+    See Also
+    --------
+    scipy.signal.StateSpace
+    TransferFunction, ZerosPolesGain, lti, dlti
+    ss2zpk, ss2tf, zpk2sos
+
+    Notes
+    -----
+    Changing the value of properties that are not part of the
+    `StateSpace` system representation (such as `zeros` or `poles`) is very
+    inefficient and may lead to numerical inaccuracies.  It is better to
+    convert to the specific system representation first. For example, call
+    ``sys = sys.to_zpk()`` before accessing/changing the zeros, poles or gain.
+    """
+
+    # Override NumPy binary operations and ufuncs
+    __array_priority__ = 100.0
+    __array_ufunc__ = None
+
+    def __new__(cls, *system, **kwargs):
+        """Create new StateSpace object and settle inheritance."""
+        # Handle object conversion if input is an instance of `lti`
+        if len(system) == 1 and isinstance(system[0], LinearTimeInvariant):
+            return system[0].to_ss()
+
+        # Choose whether to inherit from `lti` or from `dlti`
+        if cls is StateSpace:
+            if kwargs.get('dt') is None:
+                return StateSpaceContinuous.__new__(StateSpaceContinuous,
+                                                    *system, **kwargs)
+            else:
+                return StateSpaceDiscrete.__new__(StateSpaceDiscrete,
+                                                  *system, **kwargs)
+
+        # No special conversion needed
+        return super().__new__(cls)
+
+    def __init__(self, *system, **kwargs):
+        """Initialize the state space lti/dlti system."""
+        # Conversion of lti instances is handled in __new__
+        if isinstance(system[0], LinearTimeInvariant):
+            return
+
+        # Remove system arguments, not needed by parents anymore
+        super().__init__(**kwargs)
+
+        self._A = None
+        self._B = None
+        self._C = None
+        self._D = None
+
+        self.A, self.B, self.C, self.D = abcd_normalize(*system)
+
+    def __repr__(self):
+        """Return representation of the `StateSpace` system."""
+        return '{}(\n{},\n{},\n{},\n{},\ndt: {}\n)'.format(
+            self.__class__.__name__,
+            repr(self.A),
+            repr(self.B),
+            repr(self.C),
+            repr(self.D),
+            repr(self.dt),
+            )
+
+    def _check_binop_other(self, other):
+        return isinstance(other, (StateSpace, np.ndarray, float, complex,
+                                  np.number, int))
+
+    def __mul__(self, other):
+        """
+        Post-multiply another system or a scalar
+
+        Handles multiplication of systems in the sense of a frequency domain
+        multiplication. That means, given two systems E1(s) and E2(s), their
+        multiplication, H(s) = E1(s) * E2(s), means that applying H(s) to U(s)
+        is equivalent to first applying E2(s), and then E1(s).
+
+        Notes
+        -----
+        For SISO systems the order of system application does not matter.
+        However, for MIMO systems, where the two systems are matrices, the
+        order above ensures standard Matrix multiplication rules apply.
+        """
+        if not self._check_binop_other(other):
+            return NotImplemented
+
+        if isinstance(other, StateSpace):
+            # Disallow mix of discrete and continuous systems.
+            if type(other) is not type(self):
+                return NotImplemented
+
+            if self.dt != other.dt:
+                raise TypeError('Cannot multiply systems with different `dt`.')
+
+            n1 = self.A.shape[0]
+            n2 = other.A.shape[0]
+
+            # Interconnection of systems
+            # x1' = A1 x1 + B1 u1
+            # y1  = C1 x1 + D1 u1
+            # x2' = A2 x2 + B2 y1
+            # y2  = C2 x2 + D2 y1
+            #
+            # Plugging in with u1 = y2 yields
+            # [x1']   [A1 B1*C2 ] [x1]   [B1*D2]
+            # [x2'] = [0  A2    ] [x2] + [B2   ] u2
+            #                    [x1]
+            #  y2   = [C1 D1*C2] [x2] + D1*D2 u2
+            a = cupy.vstack((cupy.hstack((self.A, self.B @ other.C)),
+                           cupy.hstack((cupy.zeros((n2, n1)), other.A))))
+            b = cupy.vstack((self.B @ other.D, other.B))
+            c = cupy.hstack((self.C, self.D @ other.C ))
+            d = self.D @ other.D
+        else:
+            # Assume that other is a scalar / matrix
+            # For post multiplication the input gets scaled
+            a = self.A
+            b = self.B @ other
+            c = self.C
+            d = self.D @ other
+
+        common_dtype = cupy.result_type(a.dtype, b.dtype, c.dtype, d.dtype)
+        return StateSpace(cupy.asarray(a, dtype=common_dtype),
+                          cupy.asarray(b, dtype=common_dtype),
+                          cupy.asarray(c, dtype=common_dtype),
+                          cupy.asarray(d, dtype=common_dtype),
+                          **self._dt_dict)
+
+    def __rmul__(self, other):
+        """Pre-multiply a scalar or matrix (but not StateSpace)"""
+        if not self._check_binop_other(other) or isinstance(other, StateSpace):
+            return NotImplemented
+
+        # For pre-multiplication only the output gets scaled
+        a = self.A
+        b = self.B
+        c = other @ self.C
+        d = other @ self.D
+
+        common_dtype = cupy.result_type(a.dtype, b.dtype, c.dtype, d.dtype)
+        return StateSpace(cupy.asarray(a, dtype=common_dtype),
+                          cupy.asarray(b, dtype=common_dtype),
+                          cupy.asarray(c, dtype=common_dtype),
+                          cupy.asarray(d, dtype=common_dtype),
+                          **self._dt_dict)
+
+    def __neg__(self):
+        """Negate the system (equivalent to pre-multiplying by -1)."""
+        return StateSpace(self.A, self.B, -self.C, -self.D, **self._dt_dict)
+
+    def __add__(self, other):
+        """
+        Adds two systems in the sense of frequency domain addition.
+        """
+        if not self._check_binop_other(other):
+            return NotImplemented
+
+        if isinstance(other, StateSpace):
+            # Disallow mix of discrete and continuous systems.
+            if type(other) is not type(self):
+                raise TypeError('Cannot add {} and {}'.format(type(self),
+                                                              type(other)))
+
+            if self.dt != other.dt:
+                raise TypeError('Cannot add systems with different `dt`.')
+            # Interconnection of systems
+            # x1' = A1 x1 + B1 u
+            # y1  = C1 x1 + D1 u
+            # x2' = A2 x2 + B2 u
+            # y2  = C2 x2 + D2 u
+            # y   = y1 + y2
+            #
+            # Plugging in yields
+            # [x1']   [A1 0 ] [x1]   [B1]
+            # [x2'] = [0  A2] [x2] + [B2] u
+            #                 [x1]
+            #  y    = [C1 C2] [x2] + [D1 + D2] u
+            a = linalg.block_diag(self.A, other.A)
+            b = cupy.vstack((self.B, other.B))
+            c = cupy.hstack((self.C, other.C))
+            d = self.D + other.D
+        else:
+            other = cupy.atleast_2d(other)
+            if self.D.shape == other.shape:
+                # A scalar/matrix is really just a static system (A=0, B=0, C=0)
+                a = self.A
+                b = self.B
+                c = self.C
+                d = self.D + other
+            else:
+                raise ValueError("Cannot add systems with incompatible "
+                                 "dimensions ({} and {})"
+                                 .format(self.D.shape, other.shape))
+
+        common_dtype = cipy.result_type(a.dtype, b.dtype, c.dtype, d.dtype)
+        return StateSpace(cupy.asarray(a, dtype=common_dtype),
+                          cupy.asarray(b, dtype=common_dtype),
+                          cupy.asarray(c, dtype=common_dtype),
+                          cupy.asarray(d, dtype=common_dtype),
+                          **self._dt_dict)
+
+    def __sub__(self, other):
+        if not self._check_binop_other(other):
+            return NotImplemented
+
+        return self.__add__(-other)
+
+    def __radd__(self, other):
+        if not self._check_binop_other(other):
+            return NotImplemented
+
+        return self.__add__(other)
+
+    def __rsub__(self, other):
+        if not self._check_binop_other(other):
+            return NotImplemented
+
+        return (-self).__add__(other)
+
+    def __truediv__(self, other):
+        """
+        Divide by a scalar
+        """
+        # Division by non-StateSpace scalars
+        if not self._check_binop_other(other) or isinstance(other, StateSpace):
+            return NotImplemented
+
+        if isinstance(other, cupy.ndarray) and other.ndim > 0:
+            # It's ambiguous what this means, so disallow it
+            raise ValueError("Cannot divide StateSpace by non-scalar numpy arrays")
+
+        return self.__mul__(1/other)
+
+    @property
+    def A(self):
+        """State matrix of the `StateSpace` system."""
+        return self._A
+
+    @A.setter
+    def A(self, A):
+        self._A = _atleast_2d_or_none(A)
+
+    @property
+    def B(self):
+        """Input matrix of the `StateSpace` system."""
+        return self._B
+
+    @B.setter
+    def B(self, B):
+        self._B = _atleast_2d_or_none(B)
+        self.inputs = self.B.shape[-1]
+
+    @property
+    def C(self):
+        """Output matrix of the `StateSpace` system."""
+        return self._C
+
+    @C.setter
+    def C(self, C):
+        self._C = _atleast_2d_or_none(C)
+        self.outputs = self.C.shape[0]
+
+    @property
+    def D(self):
+        """Feedthrough matrix of the `StateSpace` system."""
+        return self._D
+
+    @D.setter
+    def D(self, D):
+        self._D = _atleast_2d_or_none(D)
+
+    def _copy(self, system):
+        """
+        Copy the parameters of another `StateSpace` system.
+
+        Parameters
+        ----------
+        system : instance of `StateSpace`
+            The state-space system that is to be copied
+
+        """
+        self.A = system.A
+        self.B = system.B
+        self.C = system.C
+        self.D = system.D
+
+    def to_tf(self, **kwargs):
+        """
+        Convert system representation to `TransferFunction`.
+
+        Parameters
+        ----------
+        kwargs : dict, optional
+            Additional keywords passed to `ss2zpk`
+
+        Returns
+        -------
+        sys : instance of `TransferFunction`
+            Transfer function of the current system
+
+        """
+        return TransferFunction(*ss2tf(self._A, self._B, self._C, self._D,
+                                       **kwargs), **self._dt_dict)
+
+    def to_zpk(self, **kwargs):
+        """
+        Convert system representation to `ZerosPolesGain`.
+
+        Parameters
+        ----------
+        kwargs : dict, optional
+            Additional keywords passed to `ss2zpk`
+
+        Returns
+        -------
+        sys : instance of `ZerosPolesGain`
+            Zeros, poles, gain representation of the current system
+
+        """
+        return ZerosPolesGain(*ss2zpk(self._A, self._B, self._C, self._D,
+                                      **kwargs), **self._dt_dict)
+
+    def to_ss(self):
+        """
+        Return a copy of the current `StateSpace` system.
+
+        Returns
+        -------
+        sys : instance of `StateSpace`
+            The current system (copy)
+
+        """
+        return copy.deepcopy(self)
+
+
+class StateSpaceContinuous(StateSpace, lti):
+    r"""
+    Continuous-time Linear Time Invariant system in state-space form.
+
+    Represents the system as the continuous-time, first order differential
+    equation :math:`\dot{x} = A x + B u`.
+    Continuous-time `StateSpace` systems inherit additional functionality
+    from the `lti` class.
+
+    Parameters
+    ----------
+    *system: arguments
+        The `StateSpace` class can be instantiated with 1 or 3 arguments.
+        The following gives the number of input arguments and their
+        interpretation:
+
+            * 1: `lti` system: (`StateSpace`, `TransferFunction` or
+              `ZerosPolesGain`)
+            * 4: array_like: (A, B, C, D)
+
+    See Also
+    --------
+    scipy.signal.StateSpaceContinuous
+    TransferFunction, ZerosPolesGain, lti
+    ss2zpk, ss2tf, zpk2sos
+
+    Notes
+    -----
+    Changing the value of properties that are not part of the
+    `StateSpace` system representation (such as `zeros` or `poles`) is very
+    inefficient and may lead to numerical inaccuracies.  It is better to
+    convert to the specific system representation first. For example, call
+    ``sys = sys.to_zpk()`` before accessing/changing the zeros, poles or gain.
+    """
+
+    def to_discrete(self, dt, method='zoh', alpha=None):
+        """
+        Returns the discretized `StateSpace` system.
+
+        Parameters: See `cont2discrete` for details.
+
+        Returns
+        -------
+        sys: instance of `dlti` and `StateSpace`
+        """
+        return StateSpace(*cont2discrete((self.A, self.B, self.C, self.D),
+                                         dt,
+                                         method=method,
+                                         alpha=alpha)[:-1],
+                          dt=dt)
+
+
+class StateSpaceDiscrete(StateSpace, dlti):
+    r"""
+    Discrete-time Linear Time Invariant system in state-space form.
+
+    Represents the system as the discrete-time difference equation
+    :math:`x[k+1] = A x[k] + B u[k]`.
+    `StateSpace` systems inherit additional functionality from the `dlti`
+    class.
+
+    Parameters
+    ----------
+    *system: arguments
+        The `StateSpace` class can be instantiated with 1 or 3 arguments.
+        The following gives the number of input arguments and their
+        interpretation:
+
+            * 1: `dlti` system: (`StateSpace`, `TransferFunction` or
+              `ZerosPolesGain`)
+            * 4: array_like: (A, B, C, D)
+    dt: float, optional
+        Sampling time [s] of the discrete-time systems. Defaults to `True`
+        (unspecified sampling time). Must be specified as a keyword argument,
+        for example, ``dt=0.1``.
+
+    See Also
+    --------
+    scipy.signal.StateSpaceDiscrete
+    TransferFunction, ZerosPolesGain, dlti
+    ss2zpk, ss2tf, zpk2sos
+
+    Notes
+    -----
+    Changing the value of properties that are not part of the
+    `StateSpace` system representation (such as `zeros` or `poles`) is very
+    inefficient and may lead to numerical inaccuracies.  It is better to
+    convert to the specific system representation first. For example, call
+    ``sys = sys.to_zpk()`` before accessing/changing the zeros, poles or gain.
+    """
+    pass
+
+
+

--- a/cupyx/scipy/signal/_ltisys.py
+++ b/cupyx/scipy/signal/_ltisys.py
@@ -1418,6 +1418,164 @@ class StateSpaceDiscrete(StateSpace, dlti):
 
 # ### lsim and related functions
 
+def lsim(system, U, T, X0=None, interp=True):
+    """
+    Simulate output of a continuous-time linear system.
+
+    Parameters
+    ----------
+    system : an instance of the LTI class or a tuple describing the system.
+        The following gives the number of elements in the tuple and
+        the interpretation:
+
+        * 1: (instance of `lti`)
+        * 2: (num, den)
+        * 3: (zeros, poles, gain)
+        * 4: (A, B, C, D)
+
+    U : array_like
+        An input array describing the input at each time `T`
+        (interpolation is assumed between given times).  If there are
+        multiple inputs, then each column of the rank-2 array
+        represents an input.  If U = 0 or None, a zero input is used.
+    T : array_like
+        The time steps at which the input is defined and at which the
+        output is desired.  Must be nonnegative, increasing, and equally spaced
+    X0 : array_like, optional
+        The initial conditions on the state vector (zero by default).
+    interp : bool, optional
+        Whether to use linear (True, the default) or zero-order-hold (False)
+        interpolation for the input array.
+
+    Returns
+    -------
+    T : 1D ndarray
+        Time values for the output.
+    yout : 1D ndarray
+        System response.
+    xout : ndarray
+        Time evolution of the state vector.
+
+    Notes
+    -----
+    If (num, den) is passed in for ``system``, coefficients for both the
+    numerator and denominator should be specified in descending exponent
+    order (e.g. ``s^2 + 3s + 5`` would be represented as ``[1, 3, 5]``).
+
+    See Also
+    --------
+    scipy.signal.lsim
+
+    """
+    if isinstance(system, lti):
+        sys = system._as_ss()
+    elif isinstance(system, dlti):
+        raise AttributeError('lsim can only be used with continuous-time '
+                             'systems.')
+    else:
+        sys = lti(*system)._as_ss()
+    T = cupy.atleast_1d(T)
+    if len(T.shape) != 1:
+        raise ValueError("T must be a rank-1 array.")
+
+    A, B, C, D = map(cupy.asarray, (sys.A, sys.B, sys.C, sys.D))
+    n_states = A.shape[0]
+    n_inputs = B.shape[1]
+
+    n_steps = T.size
+    if X0 is None:
+        X0 = cupy.zeros(n_states, sys.A.dtype)
+    xout = cupy.empty((n_steps, n_states), sys.A.dtype)
+
+    if T[0] == 0:
+        xout[0] = X0
+    elif T[0] > 0:
+        # step forward to initial time, with zero input
+        xout[0] = X0 @ linalg.expm(A.T * T[0])
+    else:
+        raise ValueError("Initial time must be nonnegative")
+
+    no_input = (U is None or
+                (isinstance(U, (int, float)) and U == 0.) or
+                not cupy.any(U))
+
+    if n_steps == 1:
+        yout = cupy.squeeze(xout @ C.T)
+        if not no_input:
+            yout += cupy.squeeze(U @ D.T)
+        return T, cupy.squeeze(yout), cupy.squeeze(xout)
+
+    dt = T[1] - T[0]
+    if not cupy.allclose(cupy.diff(T), dt):
+        raise ValueError("Time steps are not equally spaced.")
+
+    if no_input:
+        # Zero input: just use matrix exponential
+        # take transpose because state is a row vector
+        expAT_dt = linalg.expm(A.T * dt)
+        for i in range(1, n_steps):
+            xout[i] = xout[i-1] @ expAT_dt
+        yout = cupy.squeeze(xout @ C.T)
+        return T, cupy.squeeze(yout), cupy.squeeze(xout)
+
+    # Nonzero input
+    U = cupy.atleast_1d(U)
+    if U.ndim == 1:
+        U = U[:, None]
+
+    if U.shape[0] != n_steps:
+        raise ValueError("U must have the same number of rows "
+                         "as elements in T.")
+
+    if U.shape[1] != n_inputs:
+        raise ValueError("System does not define that many inputs.")
+
+    if not interp:
+        # Zero-order hold
+        # Algorithm: to integrate from time 0 to time dt, we solve
+        #   xdot = A x + B u,  x(0) = x0
+        #   udot = 0,          u(0) = u0.
+        #
+        # Solution is
+        #   [ x(dt) ]       [ A*dt   B*dt ] [ x0 ]
+        #   [ u(dt) ] = exp [  0     0    ] [ u0 ]
+        M = cupy.vstack([cupy.hstack([A * dt, B * dt]),
+                         cupy.zeros((n_inputs, n_states + n_inputs))])
+        # transpose everything because the state and input are row vectors
+        expMT = linalg.expm(M.T)
+        Ad = expMT[:n_states, :n_states]
+        Bd = expMT[n_states:, :n_states]
+        for i in range(1, n_steps):
+            xout[i] = xout[i-1] @ Ad + U[i-1] @ Bd
+    else:
+        # Linear interpolation between steps
+        # Algorithm: to integrate from time 0 to time dt, with linear
+        # interpolation between inputs u(0) = u0 and u(dt) = u1, we solve
+        #   xdot = A x + B u,        x(0) = x0
+        #   udot = (u1 - u0) / dt,   u(0) = u0.
+        #
+        # Solution is
+        #   [ x(dt) ]       [ A*dt  B*dt  0 ] [  x0   ]
+        #   [ u(dt) ] = exp [  0     0    I ] [  u0   ]
+        #   [u1 - u0]       [  0     0    0 ] [u1 - u0]
+        Mlst = [cupy.hstack([A * dt, B * dt,
+                             cupy.zeros((n_states, n_inputs))]),
+                cupy.hstack([cupy.zeros((n_inputs, n_states + n_inputs)),
+                             cupy.identity(n_inputs)]),
+                cupy.zeros((n_inputs, n_states + 2 * n_inputs))]
+
+        M = cupy.vstack(Mlst)
+        expMT = linalg.expm(M.T)
+        Ad = expMT[:n_states, :n_states]
+        Bd1 = expMT[n_states+n_inputs:, :n_states]
+        Bd0 = expMT[n_states:n_states + n_inputs, :n_states] - Bd1
+        for i in range(1, n_steps):
+            xout[i] = ((xout[i-1] @ Ad) + (U[i-1] @ Bd0) + (U[i] @ Bd1))
+
+    yout = cupy.squeeze(xout @ C.T) + cupy.squeeze(U @ D.T)
+    return T, cupy.squeeze(yout), cupy.squeeze(xout)
+
+
 def bode(system, w=None, n=100):
     """
     Calculate Bode magnitude and phase data of a continuous-time system.

--- a/docs/source/reference/scipy_signal.rst
+++ b/docs/source/reference/scipy_signal.rst
@@ -148,6 +148,7 @@ Continuous-time linear systems
    ZerosPolesGain
    lsim
    impulse
+   step
    freqresp
    bode
 

--- a/docs/source/reference/scipy_signal.rst
+++ b/docs/source/reference/scipy_signal.rst
@@ -136,6 +136,23 @@ LTI representations
    sos2zpk
 
 
+Discrete-time linear systems
+----------------------------
+
+.. autosummary::
+   :toctree: generated/
+
+   dlti
+   StateSpace
+   TransferFunction
+   ZerosPolesGain
+   dlsim
+   dimpulse
+   dstep
+   dfreqresp
+   dbode
+
+
 Peak finding
 ------------
 

--- a/docs/source/reference/scipy_signal.rst
+++ b/docs/source/reference/scipy_signal.rst
@@ -136,18 +136,30 @@ LTI representations
    sos2zpk
 
 
-Discrete-time linear systems
+Continuous-time linear systems
 ----------------------------
 
 .. autosummary::
    :toctree: generated/
 
    lti
-   dlti
    StateSpace
    TransferFunction
    ZerosPolesGain
    freqresp
+   bode
+
+
+Discrete-time linear systems
+----------------------------
+
+.. autosummary::
+   :toctree: generated/
+
+   dlti
+   StateSpace
+   TransferFunction
+   ZerosPolesGain
    dlsim
    dimpulse
    dstep

--- a/docs/source/reference/scipy_signal.rst
+++ b/docs/source/reference/scipy_signal.rst
@@ -147,6 +147,7 @@ Continuous-time linear systems
    TransferFunction
    ZerosPolesGain
    lsim
+   impulse
    freqresp
    bode
 

--- a/docs/source/reference/scipy_signal.rst
+++ b/docs/source/reference/scipy_signal.rst
@@ -142,6 +142,7 @@ Discrete-time linear systems
 .. autosummary::
    :toctree: generated/
 
+   lti
    dlti
    StateSpace
    TransferFunction

--- a/docs/source/reference/scipy_signal.rst
+++ b/docs/source/reference/scipy_signal.rst
@@ -137,7 +137,7 @@ LTI representations
 
 
 Continuous-time linear systems
-----------------------------
+------------------------------
 
 .. autosummary::
    :toctree: generated/

--- a/docs/source/reference/scipy_signal.rst
+++ b/docs/source/reference/scipy_signal.rst
@@ -147,6 +147,7 @@ Discrete-time linear systems
    StateSpace
    TransferFunction
    ZerosPolesGain
+   freqresp
    dlsim
    dimpulse
    dstep

--- a/docs/source/reference/scipy_signal.rst
+++ b/docs/source/reference/scipy_signal.rst
@@ -146,6 +146,7 @@ Continuous-time linear systems
    StateSpace
    TransferFunction
    ZerosPolesGain
+   lsim
    freqresp
    bode
 

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_cont2discrete.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_cont2discrete.py
@@ -9,7 +9,7 @@ from cupy import testing
 @testing.with_requires("scipy")
 class TestC2D:
 
-    @testing.numpy_cupy_allclose(scipy_name='scp')
+    @testing.numpy_cupy_allclose(scipy_name='scp', contiguous_check=False)
     def test_zoh(self, xp, scp):
         ac = xp.eye(2)
         bc = xp.full((2, 1), 0.5)
@@ -33,7 +33,7 @@ class TestC2D:
         ad, bd, cd, dd, dt = c2d((ac, bc, cc, dc), dt_requested, method='foh')
         return ad, bd, cd, dd, dt
 
-    @testing.numpy_cupy_allclose(scipy_name='scp')
+    @testing.numpy_cupy_allclose(scipy_name='scp', contiguous_check=False)
     def test_impulse(self, xp, scp):
         ac = xp.eye(2)
         bc = xp.full((2, 1), 0.5)
@@ -223,7 +223,7 @@ class TestC2D:
 @testing.with_requires('scipy')
 class TestC2dLti:
 
-    @testing.numpy_cupy_allclose(scipy_name='scp')
+    @testing.numpy_cupy_allclose(scipy_name='scp', contiguous_check=False)
     def test_c2d_ss(self, xp, scp):
         # StateSpace
         A = xp.array([[-0.3, 0.1], [0.2, -0.7]])

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_cont2discrete.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_cont2discrete.py
@@ -1,0 +1,298 @@
+import math
+
+import cupyx.scipy.signal as signal  # noqa
+
+import pytest
+from cupy import testing
+
+
+@testing.with_requires("scipy")
+class TestC2D:
+
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_zoh(self, xp, scp):
+        ac = xp.eye(2)
+        bc = xp.full((2, 1), 0.5)
+        cc = xp.array([[0.75, 1.0], [1.0, 1.0], [1.0, 0.25]])
+        dc = xp.array([[0.0], [0.0], [-0.33]])
+        dt_requested = 0.5
+
+        c2d = scp.signal.cont2discrete
+        ad, bd, cd, dd, dt = c2d((ac, bc, cc, dc), dt_requested, method='zoh')
+        return ad, bd, cd, dd, dt
+
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_foh(self, xp, scp):
+        ac = xp.eye(2)
+        bc = xp.full((2, 1), 0.5)
+        cc = xp.array([[0.75, 1.0], [1.0, 1.0], [1.0, 0.25]])
+        dc = xp.array([[0.0], [0.0], [-0.33]])
+        dt_requested = 0.5
+
+        c2d = scp.signal.cont2discrete
+        ad, bd, cd, dd, dt = c2d((ac, bc, cc, dc), dt_requested, method='foh')
+        return ad, bd, cd, dd, dt
+
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_impulse(self, xp, scp):
+        ac = xp.eye(2)
+        bc = xp.full((2, 1), 0.5)
+        cc = xp.array([[0.75, 1.0], [1.0, 1.0], [1.0, 0.25]])
+        dc = xp.array([[0.0], [0.0], [0.0]])
+        dt_requested = 0.5
+
+        c2d = scp.signal.cont2discrete
+        ad, bd, cd, dd, dt = c2d((ac, bc, cc, dc), dt_requested,
+                                 method='impulse')
+        return ad, bd, cd, dd, dt
+
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_gbt(self, xp, scp):
+        ac = xp.eye(2)
+        bc = xp.full((2, 1), 0.5)
+        cc = xp.array([[0.75, 1.0], [1.0, 1.0], [1.0, 0.25]])
+        dc = xp.array([[0.0], [0.0], [-0.33]])
+
+        dt_requested = 0.5
+        alpha = 1.0 / 3.0
+
+        c2d = scp.signal.cont2discrete
+        ad, bd, cd, dd, dt = c2d((ac, bc, cc, dc), dt_requested,
+                                 method='gbt', alpha=alpha)
+        return ad, bd, cd, dd, dt
+
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_euler(self, xp, scp):
+        ac = xp.eye(2)
+        bc = xp.full((2, 1), 0.5)
+        cc = xp.array([[0.75, 1.0], [1.0, 1.0], [1.0, 0.25]])
+        dc = xp.array([[0.0], [0.0], [-0.33]])
+        dt_requested = 0.5
+
+        c2d = scp.signal.cont2discrete
+        ad, bd, cd, dd, dt = c2d((ac, bc, cc, dc), dt_requested,
+                                 method='euler')
+        return ad, bd, cd, dd, dt
+
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_backward_diff(self, xp, scp):
+        ac = xp.eye(2)
+        bc = xp.full((2, 1), 0.5)
+        cc = xp.array([[0.75, 1.0], [1.0, 1.0], [1.0, 0.25]])
+        dc = xp.array([[0.0], [0.0], [-0.33]])
+        dt_requested = 0.5
+
+        c2d = scp.signal.cont2discrete
+        ad, bd, cd, dd, dt = c2d((ac, bc, cc, dc), dt_requested,
+                                 method='backward_diff')
+        return ad, bd, cd, dd, dt
+
+    @pytest.mark.parametrize('dt_requested', [0.5, 1.0 / 3.0])
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_bilinear(self, xp, scp, dt_requested):
+        ac = xp.eye(2)
+        bc = xp.full((2, 1), 0.5)
+        cc = xp.array([[0.75, 1.0], [1.0, 1.0], [1.0, 0.25]])
+        dc = xp.array([[0.0], [0.0], [-0.33]])
+
+        c2d = scp.signal.cont2discrete
+        ad, bd, cd, dd, dt = c2d((ac, bc, cc, dc), dt_requested,
+                                 method='bilinear')
+        return ad, bd, cd, dd, dt
+
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_transferfunction(self, xp, scp):
+        numc = xp.array([0.25, 0.25, 0.5])
+        denc = xp.array([0.75, 0.75, 1.0])
+        dt_requested = 0.5
+
+        c2d = scp.signal.cont2discrete
+        num, den, dt = c2d((numc, denc), dt_requested, method='zoh')
+        return num, den, dt
+
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_zerospolesgain(self, xp, scp):
+        zeros_c = xp.array([0.5, -0.5])
+        poles_c = xp.array([1.j / math.sqrt(2), -1.j / math.sqrt(2)])
+        k_c = 1.0
+        dt_requested = 0.5
+
+        c2d = scp.signal.cont2discrete
+        zeros, poles, k, dt = c2d((zeros_c, poles_c, k_c), dt_requested,
+                                  method='zoh')
+        return zeros, poles, k, dt
+
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_gbt_with_sio_tf_and_zpk(self, xp, scp):
+        """Test method='gbt' with alpha=0.25 for tf and zpk cases."""
+        # State space coefficients for the continuous SIO system.
+        A = -1.0
+        B = 1.0
+        C = 1.0
+        D = 0.5
+
+        # The continuous transfer function coefficients.
+        cnum, cden = scp.signal.ss2tf(A, B, C, D)
+
+        # Continuous zpk representation
+        cz, cp, ck = scp.signal.ss2zpk(A, B, C, D)
+
+        h = 1.0
+        alpha = 0.25
+
+        # Compute the discrete tf using cont2discrete.
+        c2d = scp.signal.cont2discrete
+        c2dnum, c2dden, dt = c2d((cnum, cden), h, method='gbt', alpha=alpha)
+        return c2dnum, c2dden, dt
+
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_discrete_approx(self, xp, scp):
+        """
+        Test that the solution to the discrete approximation of a continuous
+        system actually approximates the solution to the continuous system.
+        This is an indirect test of the correctness of the implementation
+        of cont2discrete.
+        """
+
+        def u(t):
+            return xp.sin(2.5 * t)
+
+        a = xp.array([[-0.01]])
+        b = xp.array([[1.0]])
+        c = xp.array([[1.0]])
+        d = xp.array([[0.2]])
+        x0 = 1.0
+
+        t = xp.linspace(0, 10.0, 101)
+        dt = t[1] - t[0]
+        u1 = u(t)
+
+        # Use lsim to compute the solution to the continuous system.
+        t, yout, xout = scp.signal.lsim((a, b, c, d), T=t, U=u1, X0=x0)
+
+        # Convert the continuous system to a discrete approximation.
+        dsys = scp.signal.cont2discrete((a, b, c, d), dt, method='bilinear')
+
+        # Use dlsim with the pairwise averaged input to compute the output
+        # of the discrete system.
+        u2 = 0.5 * (u1[:-1] + u1[1:])
+        t2 = t[:-1]
+        td2, yd2, xd2 = scp.signal.dlsim(
+            dsys, u=u2.reshape(-1, 1), t=t2, x0=x0)
+
+        # ymid is the average of consecutive terms of the "exact" output
+        # computed by lsim2.  This is what the discrete approximation
+        # actually approximates.
+        ymid = 0.5 * (yout[:-1] + yout[1:])
+
+        return yd2, ymid
+
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_simo_tf(self, xp, scp):
+        # See gh-5753
+        tf = ([[1, 0], [1, 1]], [1, 1])
+        num, den, dt = scp.signal.cont2discrete(tf, 0.01)
+        return num, den, dt
+
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_multioutput(self, xp, scp):
+        ts = 0.01  # time step
+        tf = ([[1, -3], [1, 5]], [1, 1])
+        num, den, dt = scp.signal.cont2discrete(tf, ts)
+        return num, den, dt
+
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_multioutput_1(self, xp, scp):
+        ts = 0.01  # time step
+        tf = ([[1, -3], [1, 5]], [1, 1])
+
+        tf1 = (tf[0][0], tf[1])
+        num1, den1, dt1 = scp.signal.cont2discrete(tf1, ts)
+        return num1, den1, dt1
+
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_multioutput_2(self, xp, scp):
+        ts = 0.01  # time step
+        tf = ([[1, -3], [1, 5]], [1, 1])
+
+        tf2 = (tf[0][1], tf[1])
+        num2, den2, dt2 = scp.signal.cont2discrete(tf2, ts)
+        return num2, den2, dt2
+
+
+@testing.with_requires('scipy')
+class TestC2dLti:
+
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_c2d_ss(self, xp, scp):
+        # StateSpace
+        A = xp.array([[-0.3, 0.1], [0.2, -0.7]])
+        B = xp.array([[0], [1]])
+        C = xp.array([[1, 0]])
+        D = 0
+
+        sys_ssc = scp.signal.lti(A, B, C, D)
+        sys_ssd = sys_ssc.to_discrete(0.05)
+        return sys_ssd.A, sys_ssd.B, sys_ssd.C, sys_ssd.D
+
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_c2d_tf(self, xp, scp):
+
+        sys = scp.signal.lti([0.5, 0.3], [1.0, 0.4])
+        sys = sys.to_discrete(0.005)
+        return sys.num, sys.den
+
+
+# Some test cases for checking the invariances.
+# Array of triplets: (system, sample time, number of samples)
+# here 'system' is a tuple to be wrapped into tfss(*system)
+cases = [
+    (([1, 1], [1, 1.5, 1]), 0.25, 10),
+    (([1, 2], [1, 1.5, 3, 1]), 0.5, 10),
+    ((0.1, [1, 1, 2, 1]), 0.5, 10),
+]
+
+
+@testing.with_requires('scipy')
+class TestC2dInvariants:
+
+    # Check that systems discretized with the impulse-invariant
+    # method really hold the invariant
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    @pytest.mark.parametrize("sys,sample_time,samples_number", cases)
+    def test_impulse_invariant(self, xp, scp,
+                               sys, sample_time, samples_number):
+        time = xp.arange(samples_number) * sample_time
+        sys = scp.signal.tf2ss(*sys)
+
+        c2d = scp.signal.cont2discrete
+        _, yout_cont = scp.signal.impulse(sys, T=time)
+        _, yout_disc = scp.signal.dimpulse(
+            c2d(sys, sample_time, method='impulse'), n=len(time))
+        return yout_cont, yout_disc[0]
+
+    # Step invariant should hold for ZOH discretized systems
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    @pytest.mark.parametrize("sys,sample_time,samples_number", cases)
+    def test_step_invariant(self, xp, scp, sys, sample_time, samples_number):
+        time = xp.arange(samples_number) * sample_time
+        sys = scp.signal.tf2ss(*sys)
+
+        c2d = scp.signal.cont2discrete
+        _, yout_cont = scp.signal.step(sys, T=time)
+        _, yout_disc = scp.signal.dstep(
+            c2d(sys, sample_time, method='zoh'), n=len(time))
+        return yout_cont, yout_disc[0]
+
+    # Linear invariant should hold for FOH discretized systems
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    @pytest.mark.parametrize("sys,sample_time,samples_number", cases)
+    def test_linear_invariant(self, xp, scp, sys, sample_time, samples_number):
+        time = xp.arange(samples_number) * sample_time
+        sys = scp.signal.tf2ss(*sys)
+
+        c2d = scp.signal.cont2discrete
+        _, yout_cont, _ = scp.signal.lsim(sys, T=time, U=time)
+        _, yout_disc, _ = scp.signal.dlsim(
+            c2d(sys, sample_time, method='foh'), u=time)
+        return yout_cont, yout_disc

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_dltisys.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_dltisys.py
@@ -1,0 +1,612 @@
+# Author: Jeffrey Armstrong <jeff@approximatrix.com>
+# April 4, 2011
+
+#import numpy as np
+#from numpy.testing import (assert_equal,
+#                           assert_array_almost_equal, assert_array_equal,
+#                           assert_allclose, assert_, assert_almost_equal,
+#                           suppress_warnings)
+import pytest
+from pytest import raises as assert_raises
+
+import cupy
+from cupy import testing
+
+import cupyx.scipy.signal as signal
+
+#from cupyx.scipy.signal import (dlsim, dstep, dimpulse, tf2zpk, lti, dlti,
+#                                StateSpace, TransferFunction, ZerosPolesGain,
+#                                dfreqresp, dbode, BadCoefficients)
+
+
+@testing.with_requires('scipy')
+class TestDLTI:
+
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_dlsim(self, xp, scp):
+
+        a = xp.asarray([[0.9, 0.1], [-0.2, 0.9]])
+        b = xp.asarray([[0.4, 0.1, -0.1], [0.0, 0.05, 0.0]])
+        c = xp.asarray([[0.1, 0.3]])
+        d = xp.asarray([[0.0, -0.1, 0.0]])
+        dt = 0.5
+
+        # Create an input matrix with inputs down the columns (3 cols) and its
+        # respective time input vector
+        u = xp.hstack((xp.linspace(0, 4.0, num=5)[:, None],
+                       xp.full((5, 1), 0.01),
+                       xp.full((5, 1), -0.002)))
+        t_in = xp.linspace(0, 2.0, num=5)
+
+        tout, yout, xout = scp.signal.dlsim((a, b, c, d, dt), u, t_in)
+        return tout, yout, xout
+
+
+        # Define the known result
+        yout_truth = np.array([[-0.001,
+                                -0.00073,
+                                0.039446,
+                                0.0915387,
+                                0.13195948]]).T
+        xout_truth = np.asarray([[0, 0],
+                                 [0.0012, 0.0005],
+                                 [0.40233, 0.00071],
+                                 [1.163368, -0.079327],
+                                 [2.2402985, -0.3035679]])
+
+        tout, yout, xout = scp.signal.dlsim((a, b, c, d, dt), u, t_in)
+        return tout, yout, xout
+
+        assert_array_almost_equal(yout_truth, yout)
+        assert_array_almost_equal(xout_truth, xout)
+        assert_array_almost_equal(t_in, tout)
+
+        # Make sure input with single-dimension doesn't raise error
+        dlsim((1, 2, 3), 4)
+
+        # Interpolated control - inputs should have different time steps
+        # than the discrete model uses internally
+        u_sparse = u[[0, 4], :]
+        t_sparse = np.asarray([0.0, 2.0])
+
+        tout, yout, xout = dlsim((a, b, c, d, dt), u_sparse, t_sparse)
+
+        assert_array_almost_equal(yout_truth, yout)
+        assert_array_almost_equal(xout_truth, xout)
+        assert_equal(len(tout), yout.shape[0])
+
+        # Transfer functions (assume dt = 0.5)
+        num = np.asarray([1.0, -0.1])
+        den = np.asarray([0.3, 1.0, 0.2])
+        yout_truth = np.array([[0.0,
+                                0.0,
+                                3.33333333333333,
+                                -4.77777777777778,
+                                23.0370370370370]]).T
+
+        # Assume use of the first column of the control input built earlier
+        tout, yout = dlsim((num, den, 0.5), u[:, 0], t_in)
+
+        assert_array_almost_equal(yout, yout_truth)
+        assert_array_almost_equal(t_in, tout)
+
+        # Retest the same with a 1-D input vector
+        uflat = np.asarray(u[:, 0])
+        uflat = uflat.reshape((5,))
+        tout, yout = dlsim((num, den, 0.5), uflat, t_in)
+
+        assert_array_almost_equal(yout, yout_truth)
+        assert_array_almost_equal(t_in, tout)
+
+        # zeros-poles-gain representation
+        zd = np.array([0.5, -0.5])
+        pd = np.array([1.j / np.sqrt(2), -1.j / np.sqrt(2)])
+        k = 1.0
+        yout_truth = np.array([[0.0, 1.0, 2.0, 2.25, 2.5]]).T
+
+        tout, yout = dlsim((zd, pd, k, 0.5), u[:, 0], t_in)
+
+        assert_array_almost_equal(yout, yout_truth)
+        assert_array_almost_equal(t_in, tout)
+
+        # Raise an error for continuous-time systems
+        system = lti([1], [1, 1])
+        assert_raises(AttributeError, dlsim, system, u)
+
+    def test_dstep(self):
+
+        a = np.asarray([[0.9, 0.1], [-0.2, 0.9]])
+        b = np.asarray([[0.4, 0.1, -0.1], [0.0, 0.05, 0.0]])
+        c = np.asarray([[0.1, 0.3]])
+        d = np.asarray([[0.0, -0.1, 0.0]])
+        dt = 0.5
+
+        # Because b.shape[1] == 3, dstep should result in a tuple of three
+        # result vectors
+        yout_step_truth = (np.asarray([0.0, 0.04, 0.052, 0.0404, 0.00956,
+                                       -0.036324, -0.093318, -0.15782348,
+                                       -0.226628324, -0.2969374948]),
+                           np.asarray([-0.1, -0.075, -0.058, -0.04815,
+                                       -0.04453, -0.0461895, -0.0521812,
+                                       -0.061588875, -0.073549579,
+                                       -0.08727047595]),
+                           np.asarray([0.0, -0.01, -0.013, -0.0101, -0.00239,
+                                       0.009081, 0.0233295, 0.03945587,
+                                       0.056657081, 0.0742343737]))
+
+        tout, yout = dstep((a, b, c, d, dt), n=10)
+
+        assert_equal(len(yout), 3)
+
+        for i in range(0, len(yout)):
+            assert_equal(yout[i].shape[0], 10)
+            assert_array_almost_equal(yout[i].flatten(), yout_step_truth[i])
+
+        # Check that the other two inputs (tf, zpk) will work as well
+        tfin = ([1.0], [1.0, 1.0], 0.5)
+        yout_tfstep = np.asarray([0.0, 1.0, 0.0])
+        tout, yout = dstep(tfin, n=3)
+        assert_equal(len(yout), 1)
+        assert_array_almost_equal(yout[0].flatten(), yout_tfstep)
+
+        zpkin = tf2zpk(tfin[0], tfin[1]) + (0.5,)
+        tout, yout = dstep(zpkin, n=3)
+        assert_equal(len(yout), 1)
+        assert_array_almost_equal(yout[0].flatten(), yout_tfstep)
+
+        # Raise an error for continuous-time systems
+        system = lti([1], [1, 1])
+        assert_raises(AttributeError, dstep, system)
+
+    def test_dimpulse(self):
+
+        a = np.asarray([[0.9, 0.1], [-0.2, 0.9]])
+        b = np.asarray([[0.4, 0.1, -0.1], [0.0, 0.05, 0.0]])
+        c = np.asarray([[0.1, 0.3]])
+        d = np.asarray([[0.0, -0.1, 0.0]])
+        dt = 0.5
+
+        # Because b.shape[1] == 3, dimpulse should result in a tuple of three
+        # result vectors
+        yout_imp_truth = (np.asarray([0.0, 0.04, 0.012, -0.0116, -0.03084,
+                                      -0.045884, -0.056994, -0.06450548,
+                                      -0.068804844, -0.0703091708]),
+                          np.asarray([-0.1, 0.025, 0.017, 0.00985, 0.00362,
+                                      -0.0016595, -0.0059917, -0.009407675,
+                                      -0.011960704, -0.01372089695]),
+                          np.asarray([0.0, -0.01, -0.003, 0.0029, 0.00771,
+                                      0.011471, 0.0142485, 0.01612637,
+                                      0.017201211, 0.0175772927]))
+
+        tout, yout = dimpulse((a, b, c, d, dt), n=10)
+
+        assert_equal(len(yout), 3)
+
+        for i in range(0, len(yout)):
+            assert_equal(yout[i].shape[0], 10)
+            assert_array_almost_equal(yout[i].flatten(), yout_imp_truth[i])
+
+        # Check that the other two inputs (tf, zpk) will work as well
+        tfin = ([1.0], [1.0, 1.0], 0.5)
+        yout_tfimpulse = np.asarray([0.0, 1.0, -1.0])
+        tout, yout = dimpulse(tfin, n=3)
+        assert_equal(len(yout), 1)
+        assert_array_almost_equal(yout[0].flatten(), yout_tfimpulse)
+
+        zpkin = tf2zpk(tfin[0], tfin[1]) + (0.5,)
+        tout, yout = dimpulse(zpkin, n=3)
+        assert_equal(len(yout), 1)
+        assert_array_almost_equal(yout[0].flatten(), yout_tfimpulse)
+
+        # Raise an error for continuous-time systems
+        system = lti([1], [1, 1])
+        assert_raises(AttributeError, dimpulse, system)
+
+    def test_dlsim_trivial(self):
+        a = np.array([[0.0]])
+        b = np.array([[0.0]])
+        c = np.array([[0.0]])
+        d = np.array([[0.0]])
+        n = 5
+        u = np.zeros(n).reshape(-1, 1)
+        tout, yout, xout = dlsim((a, b, c, d, 1), u)
+        assert_array_equal(tout, np.arange(float(n)))
+        assert_array_equal(yout, np.zeros((n, 1)))
+        assert_array_equal(xout, np.zeros((n, 1)))
+
+    def test_dlsim_simple1d(self):
+        a = np.array([[0.5]])
+        b = np.array([[0.0]])
+        c = np.array([[1.0]])
+        d = np.array([[0.0]])
+        n = 5
+        u = np.zeros(n).reshape(-1, 1)
+        tout, yout, xout = dlsim((a, b, c, d, 1), u, x0=1)
+        assert_array_equal(tout, np.arange(float(n)))
+        expected = (0.5 ** np.arange(float(n))).reshape(-1, 1)
+        assert_array_equal(yout, expected)
+        assert_array_equal(xout, expected)
+
+    def test_dlsim_simple2d(self):
+        lambda1 = 0.5
+        lambda2 = 0.25
+        a = np.array([[lambda1, 0.0],
+                      [0.0, lambda2]])
+        b = np.array([[0.0],
+                      [0.0]])
+        c = np.array([[1.0, 0.0],
+                      [0.0, 1.0]])
+        d = np.array([[0.0],
+                      [0.0]])
+        n = 5
+        u = np.zeros(n).reshape(-1, 1)
+        tout, yout, xout = dlsim((a, b, c, d, 1), u, x0=1)
+        assert_array_equal(tout, np.arange(float(n)))
+        # The analytical solution:
+        expected = (np.array([lambda1, lambda2]) **
+                                np.arange(float(n)).reshape(-1, 1))
+        assert_array_equal(yout, expected)
+        assert_array_equal(xout, expected)
+
+    def test_more_step_and_impulse(self):
+        lambda1 = 0.5
+        lambda2 = 0.75
+        a = np.array([[lambda1, 0.0],
+                      [0.0, lambda2]])
+        b = np.array([[1.0, 0.0],
+                      [0.0, 1.0]])
+        c = np.array([[1.0, 1.0]])
+        d = np.array([[0.0, 0.0]])
+
+        n = 10
+
+        # Check a step response.
+        ts, ys = dstep((a, b, c, d, 1), n=n)
+
+        # Create the exact step response.
+        stp0 = (1.0 / (1 - lambda1)) * (1.0 - lambda1 ** np.arange(n))
+        stp1 = (1.0 / (1 - lambda2)) * (1.0 - lambda2 ** np.arange(n))
+
+        assert_allclose(ys[0][:, 0], stp0)
+        assert_allclose(ys[1][:, 0], stp1)
+
+        # Check an impulse response with an initial condition.
+        x0 = np.array([1.0, 1.0])
+        ti, yi = dimpulse((a, b, c, d, 1), n=n, x0=x0)
+
+        # Create the exact impulse response.
+        imp = (np.array([lambda1, lambda2]) **
+                            np.arange(-1, n + 1).reshape(-1, 1))
+        imp[0, :] = 0.0
+        # Analytical solution to impulse response
+        y0 = imp[:n, 0] + np.dot(imp[1:n + 1, :], x0)
+        y1 = imp[:n, 1] + np.dot(imp[1:n + 1, :], x0)
+
+        assert_allclose(yi[0][:, 0], y0)
+        assert_allclose(yi[1][:, 0], y1)
+
+        # Check that dt=0.1, n=3 gives 3 time values.
+        system = ([1.0], [1.0, -0.5], 0.1)
+        t, (y,) = dstep(system, n=3)
+        assert_allclose(t, [0, 0.1, 0.2])
+        assert_array_equal(y.T, [[0, 1.0, 1.5]])
+        t, (y,) = dimpulse(system, n=3)
+        assert_allclose(t, [0, 0.1, 0.2])
+        assert_array_equal(y.T, [[0, 1, 0.5]])
+
+
+class TestDlti:
+    def test_dlti_instantiation(self):
+        # Test that lti can be instantiated.
+
+        dt = 0.05
+        # TransferFunction
+        s = dlti([1], [-1], dt=dt)
+        assert_(isinstance(s, TransferFunction))
+        assert_(isinstance(s, dlti))
+        assert_(not isinstance(s, lti))
+        assert_equal(s.dt, dt)
+
+        # ZerosPolesGain
+        s = dlti(np.array([]), np.array([-1]), 1, dt=dt)
+        assert_(isinstance(s, ZerosPolesGain))
+        assert_(isinstance(s, dlti))
+        assert_(not isinstance(s, lti))
+        assert_equal(s.dt, dt)
+
+        # StateSpace
+        s = dlti([1], [-1], 1, 3, dt=dt)
+        assert_(isinstance(s, StateSpace))
+        assert_(isinstance(s, dlti))
+        assert_(not isinstance(s, lti))
+        assert_equal(s.dt, dt)
+
+        # Number of inputs
+        assert_raises(ValueError, dlti, 1)
+        assert_raises(ValueError, dlti, 1, 1, 1, 1, 1)
+
+
+class TestStateSpaceDisc:
+    def test_initialization(self):
+        # Check that all initializations work
+        dt = 0.05
+        StateSpace(1, 1, 1, 1, dt=dt)
+        StateSpace([1], [2], [3], [4], dt=dt)
+        StateSpace(np.array([[1, 2], [3, 4]]), np.array([[1], [2]]),
+                   np.array([[1, 0]]), np.array([[0]]), dt=dt)
+        StateSpace(1, 1, 1, 1, dt=True)
+
+    def test_conversion(self):
+        # Check the conversion functions
+        s = StateSpace(1, 2, 3, 4, dt=0.05)
+        assert_(isinstance(s.to_ss(), StateSpace))
+        assert_(isinstance(s.to_tf(), TransferFunction))
+        assert_(isinstance(s.to_zpk(), ZerosPolesGain))
+
+        # Make sure copies work
+        assert_(StateSpace(s) is not s)
+        assert_(s.to_ss() is not s)
+
+    def test_properties(self):
+        # Test setters/getters for cross class properties.
+        # This implicitly tests to_tf() and to_zpk()
+
+        # Getters
+        s = StateSpace(1, 1, 1, 1, dt=0.05)
+        assert_equal(s.poles, [1])
+        assert_equal(s.zeros, [0])
+
+
+class TestTransferFunction:
+    def test_initialization(self):
+        # Check that all initializations work
+        dt = 0.05
+        TransferFunction(1, 1, dt=dt)
+        TransferFunction([1], [2], dt=dt)
+        TransferFunction(np.array([1]), np.array([2]), dt=dt)
+        TransferFunction(1, 1, dt=True)
+
+    def test_conversion(self):
+        # Check the conversion functions
+        s = TransferFunction([1, 0], [1, -1], dt=0.05)
+        assert_(isinstance(s.to_ss(), StateSpace))
+        assert_(isinstance(s.to_tf(), TransferFunction))
+        assert_(isinstance(s.to_zpk(), ZerosPolesGain))
+
+        # Make sure copies work
+        assert_(TransferFunction(s) is not s)
+        assert_(s.to_tf() is not s)
+
+    def test_properties(self):
+        # Test setters/getters for cross class properties.
+        # This implicitly tests to_ss() and to_zpk()
+
+        # Getters
+        s = TransferFunction([1, 0], [1, -1], dt=0.05)
+        assert_equal(s.poles, [1])
+        assert_equal(s.zeros, [0])
+
+
+class TestZerosPolesGain:
+    def test_initialization(self):
+        # Check that all initializations work
+        dt = 0.05
+        ZerosPolesGain(1, 1, 1, dt=dt)
+        ZerosPolesGain([1], [2], 1, dt=dt)
+        ZerosPolesGain(np.array([1]), np.array([2]), 1, dt=dt)
+        ZerosPolesGain(1, 1, 1, dt=True)
+
+    def test_conversion(self):
+        # Check the conversion functions
+        s = ZerosPolesGain(1, 2, 3, dt=0.05)
+        assert_(isinstance(s.to_ss(), StateSpace))
+        assert_(isinstance(s.to_tf(), TransferFunction))
+        assert_(isinstance(s.to_zpk(), ZerosPolesGain))
+
+        # Make sure copies work
+        assert_(ZerosPolesGain(s) is not s)
+        assert_(s.to_zpk() is not s)
+
+
+class Test_dfreqresp:
+
+    def test_manual(self):
+        # Test dfreqresp() real part calculation (manual sanity check).
+        # 1st order low-pass filter: H(z) = 1 / (z - 0.2),
+        system = TransferFunction(1, [1, -0.2], dt=0.1)
+        w = [0.1, 1, 10]
+        w, H = dfreqresp(system, w=w)
+
+        # test real
+        expected_re = [1.2383, 0.4130, -0.7553]
+        assert_almost_equal(H.real, expected_re, decimal=4)
+
+        # test imag
+        expected_im = [-0.1555, -1.0214, 0.3955]
+        assert_almost_equal(H.imag, expected_im, decimal=4)
+
+    def test_auto(self):
+        # Test dfreqresp() real part calculation.
+        # 1st order low-pass filter: H(z) = 1 / (z - 0.2),
+        system = TransferFunction(1, [1, -0.2], dt=0.1)
+        w = [0.1, 1, 10, 100]
+        w, H = dfreqresp(system, w=w)
+        jw = np.exp(w * 1j)
+        y = np.polyval(system.num, jw) / np.polyval(system.den, jw)
+
+        # test real
+        expected_re = y.real
+        assert_almost_equal(H.real, expected_re)
+
+        # test imag
+        expected_im = y.imag
+        assert_almost_equal(H.imag, expected_im)
+
+    def test_freq_range(self):
+        # Test that freqresp() finds a reasonable frequency range.
+        # 1st order low-pass filter: H(z) = 1 / (z - 0.2),
+        # Expected range is from 0.01 to 10.
+        system = TransferFunction(1, [1, -0.2], dt=0.1)
+        n = 10
+        expected_w = np.linspace(0, np.pi, 10, endpoint=False)
+        w, H = dfreqresp(system, n=n)
+        assert_almost_equal(w, expected_w)
+
+    def test_pole_one(self):
+        # Test that freqresp() doesn't fail on a system with a pole at 0.
+        # integrator, pole at zero: H(s) = 1 / s
+        system = TransferFunction([1], [1, -1], dt=0.1)
+
+        with suppress_warnings() as sup:
+            sup.filter(RuntimeWarning, message="divide by zero")
+            sup.filter(RuntimeWarning, message="invalid value encountered")
+            w, H = dfreqresp(system, n=2)
+        assert_equal(w[0], 0.)  # a fail would give not-a-number
+
+    def test_error(self):
+        # Raise an error for continuous-time systems
+        system = lti([1], [1, 1])
+        assert_raises(AttributeError, dfreqresp, system)
+
+    def test_from_state_space(self):
+        # H(z) = 2 / z^3 - 0.5 * z^2
+
+        system_TF = dlti([2], [1, -0.5, 0, 0])
+
+        A = np.array([[0.5, 0, 0],
+                      [1, 0, 0],
+                      [0, 1, 0]])
+        B = np.array([[1, 0, 0]]).T
+        C = np.array([[0, 0, 2]])
+        D = 0
+
+        system_SS = dlti(A, B, C, D)
+        w = 10.0**np.arange(-3,0,.5)
+        with suppress_warnings() as sup:
+            sup.filter(BadCoefficients)
+            w1, H1 = dfreqresp(system_TF, w=w)
+            w2, H2 = dfreqresp(system_SS, w=w)
+
+        assert_almost_equal(H1, H2)
+
+    def test_from_zpk(self):
+        # 1st order low-pass filter: H(s) = 0.3 / (z - 0.2),
+        system_ZPK = dlti([],[0.2],0.3)
+        system_TF = dlti(0.3, [1, -0.2])
+        w = [0.1, 1, 10, 100]
+        w1, H1 = dfreqresp(system_ZPK, w=w)
+        w2, H2 = dfreqresp(system_TF, w=w)
+        assert_almost_equal(H1, H2)
+
+
+class Test_bode:
+
+    def test_manual(self):
+        # Test bode() magnitude calculation (manual sanity check).
+        # 1st order low-pass filter: H(s) = 0.3 / (z - 0.2),
+        dt = 0.1
+        system = TransferFunction(0.3, [1, -0.2], dt=dt)
+        w = [0.1, 0.5, 1, np.pi]
+        w2, mag, phase = dbode(system, w=w)
+
+        # Test mag
+        expected_mag = [-8.5329, -8.8396, -9.6162, -12.0412]
+        assert_almost_equal(mag, expected_mag, decimal=4)
+
+        # Test phase
+        expected_phase = [-7.1575, -35.2814, -67.9809, -180.0000]
+        assert_almost_equal(phase, expected_phase, decimal=4)
+
+        # Test frequency
+        assert_equal(np.array(w) / dt, w2)
+
+    def test_auto(self):
+        # Test bode() magnitude calculation.
+        # 1st order low-pass filter: H(s) = 0.3 / (z - 0.2),
+        system = TransferFunction(0.3, [1, -0.2], dt=0.1)
+        w = np.array([0.1, 0.5, 1, np.pi])
+        w2, mag, phase = dbode(system, w=w)
+        jw = np.exp(w * 1j)
+        y = np.polyval(system.num, jw) / np.polyval(system.den, jw)
+
+        # Test mag
+        expected_mag = 20.0 * np.log10(abs(y))
+        assert_almost_equal(mag, expected_mag)
+
+        # Test phase
+        expected_phase = np.rad2deg(np.angle(y))
+        assert_almost_equal(phase, expected_phase)
+
+    def test_range(self):
+        # Test that bode() finds a reasonable frequency range.
+        # 1st order low-pass filter: H(s) = 0.3 / (z - 0.2),
+        dt = 0.1
+        system = TransferFunction(0.3, [1, -0.2], dt=0.1)
+        n = 10
+        # Expected range is from 0.01 to 10.
+        expected_w = np.linspace(0, np.pi, n, endpoint=False) / dt
+        w, mag, phase = dbode(system, n=n)
+        assert_almost_equal(w, expected_w)
+
+    def test_pole_one(self):
+        # Test that freqresp() doesn't fail on a system with a pole at 0.
+        # integrator, pole at zero: H(s) = 1 / s
+        system = TransferFunction([1], [1, -1], dt=0.1)
+
+        with suppress_warnings() as sup:
+            sup.filter(RuntimeWarning, message="divide by zero")
+            sup.filter(RuntimeWarning, message="invalid value encountered")
+            w, mag, phase = dbode(system, n=2)
+        assert_equal(w[0], 0.)  # a fail would give not-a-number
+
+    def test_imaginary(self):
+        # bode() should not fail on a system with pure imaginary poles.
+        # The test passes if bode doesn't raise an exception.
+        system = TransferFunction([1], [1, 0, 100], dt=0.1)
+        dbode(system, n=2)
+
+    def test_error(self):
+        # Raise an error for continuous-time systems
+        system = lti([1], [1, 1])
+        assert_raises(AttributeError, dbode, system)
+
+
+class TestTransferFunctionZConversion:
+    """Test private conversions between 'z' and 'z**-1' polynomials."""
+
+    def test_full(self):
+        # Numerator and denominator same order
+        num = [2, 3, 4]
+        den = [5, 6, 7]
+        num2, den2 = TransferFunction._z_to_zinv(num, den)
+        assert_equal(num, num2)
+        assert_equal(den, den2)
+
+        num2, den2 = TransferFunction._zinv_to_z(num, den)
+        assert_equal(num, num2)
+        assert_equal(den, den2)
+
+    def test_numerator(self):
+        # Numerator lower order than denominator
+        num = [2, 3]
+        den = [5, 6, 7]
+        num2, den2 = TransferFunction._z_to_zinv(num, den)
+        assert_equal([0, 2, 3], num2)
+        assert_equal(den, den2)
+
+        num2, den2 = TransferFunction._zinv_to_z(num, den)
+        assert_equal([2, 3, 0], num2)
+        assert_equal(den, den2)
+
+    def test_denominator(self):
+        # Numerator higher order than denominator
+        num = [2, 3, 4]
+        den = [5, 6]
+        num2, den2 = TransferFunction._z_to_zinv(num, den)
+        assert_equal(num, num2)
+        assert_equal([0, 5, 6], den2)
+
+        num2, den2 = TransferFunction._zinv_to_z(num, den)
+        assert_equal(num, num2)
+        assert_equal([5, 6, 0], den2)
+

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_dltisys.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_dltisys.py
@@ -1,12 +1,5 @@
-# Author: Jeffrey Armstrong <jeff@approximatrix.com>
-# April 4, 2011
+from math import sqrt, pi
 
-#import numpy as np
-#from numpy.testing import (assert_equal,
-#                           assert_array_almost_equal, assert_array_equal,
-#                           assert_allclose, assert_, assert_almost_equal,
-#                           suppress_warnings)
-import pytest
 from pytest import raises as assert_raises
 
 import cupy
@@ -14,17 +7,12 @@ from cupy import testing
 
 import cupyx.scipy.signal as signal
 
-#from cupyx.scipy.signal import (dlsim, dstep, dimpulse, tf2zpk, lti, dlti,
-#                                StateSpace, TransferFunction, ZerosPolesGain,
-#                                dfreqresp, dbode, BadCoefficients)
-
 
 @testing.with_requires('scipy')
 class TestDLTI:
 
     @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_dlsim(self, xp, scp):
-
         a = xp.asarray([[0.9, 0.1], [-0.2, 0.9]])
         b = xp.asarray([[0.4, 0.1, -0.1], [0.0, 0.05, 0.0]])
         c = xp.asarray([[0.1, 0.3]])
@@ -41,258 +29,236 @@ class TestDLTI:
         tout, yout, xout = scp.signal.dlsim((a, b, c, d, dt), u, t_in)
         return tout, yout, xout
 
-
-        # Define the known result
-        yout_truth = np.array([[-0.001,
-                                -0.00073,
-                                0.039446,
-                                0.0915387,
-                                0.13195948]]).T
-        xout_truth = np.asarray([[0, 0],
-                                 [0.0012, 0.0005],
-                                 [0.40233, 0.00071],
-                                 [1.163368, -0.079327],
-                                 [2.2402985, -0.3035679]])
-
-        tout, yout, xout = scp.signal.dlsim((a, b, c, d, dt), u, t_in)
-        return tout, yout, xout
-
-        assert_array_almost_equal(yout_truth, yout)
-        assert_array_almost_equal(xout_truth, xout)
-        assert_array_almost_equal(t_in, tout)
-
+    def test_dlsim_2(self):
         # Make sure input with single-dimension doesn't raise error
-        dlsim((1, 2, 3), 4)
+        signal.dlsim((1, 2, 3), 4)
+
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_dlsim_3(self, xp, scp):
+        a = xp.asarray([[0.9, 0.1], [-0.2, 0.9]])
+        b = xp.asarray([[0.4, 0.1, -0.1], [0.0, 0.05, 0.0]])
+        c = xp.asarray([[0.1, 0.3]])
+        d = xp.asarray([[0.0, -0.1, 0.0]])
+        dt = 0.5
+
+        # Create an input matrix with inputs down the columns (3 cols) and its
+        # respective time input vector
+        u = xp.hstack((xp.linspace(0, 4.0, num=5)[:, None],
+                       xp.full((5, 1), 0.01),
+                       xp.full((5, 1), -0.002)))
 
         # Interpolated control - inputs should have different time steps
         # than the discrete model uses internally
         u_sparse = u[[0, 4], :]
-        t_sparse = np.asarray([0.0, 2.0])
+        t_sparse = xp.asarray([0.0, 2.0])
 
-        tout, yout, xout = dlsim((a, b, c, d, dt), u_sparse, t_sparse)
+        tout, yout, xout = scp.signal.dlsim(
+            (a, b, c, d, dt), u_sparse, t_sparse)
+        return tout, yout, xout
 
-        assert_array_almost_equal(yout_truth, yout)
-        assert_array_almost_equal(xout_truth, xout)
-        assert_equal(len(tout), yout.shape[0])
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_dlsim_4(self, xp, scp):
+
+        # Create an input matrix with inputs down the columns (3 cols) and its
+        # respective time input vector
+        u = xp.hstack((xp.linspace(0, 4.0, num=5)[:, None],
+                       xp.full((5, 1), 0.01),
+                       xp.full((5, 1), -0.002)))
+        t_in = xp.linspace(0, 2.0, num=5)
 
         # Transfer functions (assume dt = 0.5)
-        num = np.asarray([1.0, -0.1])
-        den = np.asarray([0.3, 1.0, 0.2])
-        yout_truth = np.array([[0.0,
-                                0.0,
-                                3.33333333333333,
-                                -4.77777777777778,
-                                23.0370370370370]]).T
+        num = xp.asarray([1.0, -0.1])
+        den = xp.asarray([0.3, 1.0, 0.2])
 
         # Assume use of the first column of the control input built earlier
-        tout, yout = dlsim((num, den, 0.5), u[:, 0], t_in)
+        tout, yout = scp.signal.dlsim((num, den, 0.5), u[:, 0], t_in)
+        return tout, yout
 
-        assert_array_almost_equal(yout, yout_truth)
-        assert_array_almost_equal(t_in, tout)
-
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_dlsim_5(self, xp, scp):
         # Retest the same with a 1-D input vector
-        uflat = np.asarray(u[:, 0])
+        u = xp.hstack((xp.linspace(0, 4.0, num=5)[:, None],
+                       xp.full((5, 1), 0.01),
+                       xp.full((5, 1), -0.002)))
+        t_in = xp.linspace(0, 2.0, num=5)
+
+        # Transfer functions (assume dt = 0.5)
+        num = xp.asarray([1.0, -0.1])
+        den = xp.asarray([0.3, 1.0, 0.2])
+
+        uflat = xp.asarray(u[:, 0])
         uflat = uflat.reshape((5,))
-        tout, yout = dlsim((num, den, 0.5), uflat, t_in)
+        tout, yout = scp.signal.dlsim((num, den, 0.5), uflat, t_in)
+        return tout, yout
 
-        assert_array_almost_equal(yout, yout_truth)
-        assert_array_almost_equal(t_in, tout)
-
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_dlsim_6(self, xp, scp):
         # zeros-poles-gain representation
-        zd = np.array([0.5, -0.5])
-        pd = np.array([1.j / np.sqrt(2), -1.j / np.sqrt(2)])
+        zd = xp.array([0.5, -0.5])
+        pd = xp.array([1.j / sqrt(2), -1.j / sqrt(2)])
         k = 1.0
-        yout_truth = np.array([[0.0, 1.0, 2.0, 2.25, 2.5]]).T
 
-        tout, yout = dlsim((zd, pd, k, 0.5), u[:, 0], t_in)
+        u = xp.hstack((xp.linspace(0, 4.0, num=5)[:, None],
+                       xp.full((5, 1), 0.01),
+                       xp.full((5, 1), -0.002)))
+        t_in = xp.linspace(0, 2.0, num=5)
 
-        assert_array_almost_equal(yout, yout_truth)
-        assert_array_almost_equal(t_in, tout)
+        tout, yout = scp.signal.dlsim((zd, pd, k, 0.5), u[:, 0], t_in)
+        return tout, yout
 
+    def test_dlsim_7(self):
         # Raise an error for continuous-time systems
-        system = lti([1], [1, 1])
-        assert_raises(AttributeError, dlsim, system, u)
+        system = signal.lti([1], [1, 1])
+        u = cupy.hstack((cupy.linspace(0, 4.0, num=5)[:, None],
+                         cupy.full((5, 1), 0.01),
+                         cupy.full((5, 1), -0.002)))
+        with assert_raises(AttributeError):
+            signal.dlsim(system, u)
 
-    def test_dstep(self):
-
-        a = np.asarray([[0.9, 0.1], [-0.2, 0.9]])
-        b = np.asarray([[0.4, 0.1, -0.1], [0.0, 0.05, 0.0]])
-        c = np.asarray([[0.1, 0.3]])
-        d = np.asarray([[0.0, -0.1, 0.0]])
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_dstep(self, xp, scp):
+        a = xp.asarray([[0.9, 0.1], [-0.2, 0.9]])
+        b = xp.asarray([[0.4, 0.1, -0.1], [0.0, 0.05, 0.0]])
+        c = xp.asarray([[0.1, 0.3]])
+        d = xp.asarray([[0.0, -0.1, 0.0]])
         dt = 0.5
 
-        # Because b.shape[1] == 3, dstep should result in a tuple of three
-        # result vectors
-        yout_step_truth = (np.asarray([0.0, 0.04, 0.052, 0.0404, 0.00956,
-                                       -0.036324, -0.093318, -0.15782348,
-                                       -0.226628324, -0.2969374948]),
-                           np.asarray([-0.1, -0.075, -0.058, -0.04815,
-                                       -0.04453, -0.0461895, -0.0521812,
-                                       -0.061588875, -0.073549579,
-                                       -0.08727047595]),
-                           np.asarray([0.0, -0.01, -0.013, -0.0101, -0.00239,
-                                       0.009081, 0.0233295, 0.03945587,
-                                       0.056657081, 0.0742343737]))
+        tout, yout = scp.signal.dstep((a, b, c, d, dt), n=10)
 
-        tout, yout = dstep((a, b, c, d, dt), n=10)
+        # NB: yout is a 3-tuple, unpack it
+        return tout, *yout
 
-        assert_equal(len(yout), 3)
-
-        for i in range(0, len(yout)):
-            assert_equal(yout[i].shape[0], 10)
-            assert_array_almost_equal(yout[i].flatten(), yout_step_truth[i])
-
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_dstep_2(self, xp, scp):
         # Check that the other two inputs (tf, zpk) will work as well
         tfin = ([1.0], [1.0, 1.0], 0.5)
-        yout_tfstep = np.asarray([0.0, 1.0, 0.0])
-        tout, yout = dstep(tfin, n=3)
-        assert_equal(len(yout), 1)
-        assert_array_almost_equal(yout[0].flatten(), yout_tfstep)
+        tout, yout = scp.signal.dstep(tfin, n=3)
+        return tout, *yout
 
-        zpkin = tf2zpk(tfin[0], tfin[1]) + (0.5,)
-        tout, yout = dstep(zpkin, n=3)
-        assert_equal(len(yout), 1)
-        assert_array_almost_equal(yout[0].flatten(), yout_tfstep)
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_dstep_3(self, xp, scp):
+        tfin = ([1.0], [1.0, 1.0], 0.5)
+        zpkin = scp.signal.tf2zpk(tfin[0], tfin[1]) + (0.5,)
+        tout, yout = scp.signal.dstep(zpkin, n=3)
+        return tout, *yout
 
+    def test_dstep_4(self):
         # Raise an error for continuous-time systems
-        system = lti([1], [1, 1])
-        assert_raises(AttributeError, dstep, system)
+        system = signal.lti([1], [1, 1])
+        with assert_raises(AttributeError):
+            signal.dstep(system)
 
-    def test_dimpulse(self):
-
-        a = np.asarray([[0.9, 0.1], [-0.2, 0.9]])
-        b = np.asarray([[0.4, 0.1, -0.1], [0.0, 0.05, 0.0]])
-        c = np.asarray([[0.1, 0.3]])
-        d = np.asarray([[0.0, -0.1, 0.0]])
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_dimpulse(self, xp, scp):
+        a = xp.asarray([[0.9, 0.1], [-0.2, 0.9]])
+        b = xp.asarray([[0.4, 0.1, -0.1], [0.0, 0.05, 0.0]])
+        c = xp.asarray([[0.1, 0.3]])
+        d = xp.asarray([[0.0, -0.1, 0.0]])
         dt = 0.5
 
-        # Because b.shape[1] == 3, dimpulse should result in a tuple of three
-        # result vectors
-        yout_imp_truth = (np.asarray([0.0, 0.04, 0.012, -0.0116, -0.03084,
-                                      -0.045884, -0.056994, -0.06450548,
-                                      -0.068804844, -0.0703091708]),
-                          np.asarray([-0.1, 0.025, 0.017, 0.00985, 0.00362,
-                                      -0.0016595, -0.0059917, -0.009407675,
-                                      -0.011960704, -0.01372089695]),
-                          np.asarray([0.0, -0.01, -0.003, 0.0029, 0.00771,
-                                      0.011471, 0.0142485, 0.01612637,
-                                      0.017201211, 0.0175772927]))
+        tout, yout = scp.signal.dimpulse((a, b, c, d, dt), n=10)
+        return tout, *yout
 
-        tout, yout = dimpulse((a, b, c, d, dt), n=10)
-
-        assert_equal(len(yout), 3)
-
-        for i in range(0, len(yout)):
-            assert_equal(yout[i].shape[0], 10)
-            assert_array_almost_equal(yout[i].flatten(), yout_imp_truth[i])
-
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_dimpulse_2(self, xp, scp):
         # Check that the other two inputs (tf, zpk) will work as well
         tfin = ([1.0], [1.0, 1.0], 0.5)
-        yout_tfimpulse = np.asarray([0.0, 1.0, -1.0])
-        tout, yout = dimpulse(tfin, n=3)
-        assert_equal(len(yout), 1)
-        assert_array_almost_equal(yout[0].flatten(), yout_tfimpulse)
+        tout, yout = scp.signal.dimpulse(tfin, n=3)
+        return tout, *yout
 
-        zpkin = tf2zpk(tfin[0], tfin[1]) + (0.5,)
-        tout, yout = dimpulse(zpkin, n=3)
-        assert_equal(len(yout), 1)
-        assert_array_almost_equal(yout[0].flatten(), yout_tfimpulse)
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_dimpulse_3(self, xp, scp):
+        tfin = ([1.0], [1.0, 1.0], 0.5)
+        zpkin = scp.signal.tf2zpk(tfin[0], tfin[1]) + (0.5,)
+        tout, yout = scp.signal.dimpulse(zpkin, n=3)
+        return tout, *yout
 
+    def test_dimpulse_4(self):
         # Raise an error for continuous-time systems
-        system = lti([1], [1, 1])
-        assert_raises(AttributeError, dimpulse, system)
+        system = signal.lti([1], [1, 1])
+        assert_raises(AttributeError, signal.dimpulse, system)
 
-    def test_dlsim_trivial(self):
-        a = np.array([[0.0]])
-        b = np.array([[0.0]])
-        c = np.array([[0.0]])
-        d = np.array([[0.0]])
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_dlsim_trivial(self, xp, scp):
+        a = xp.array([[0.0]])
+        b = xp.array([[0.0]])
+        c = xp.array([[0.0]])
+        d = xp.array([[0.0]])
         n = 5
-        u = np.zeros(n).reshape(-1, 1)
-        tout, yout, xout = dlsim((a, b, c, d, 1), u)
-        assert_array_equal(tout, np.arange(float(n)))
-        assert_array_equal(yout, np.zeros((n, 1)))
-        assert_array_equal(xout, np.zeros((n, 1)))
+        u = xp.zeros(n).reshape(-1, 1)
+        tout, yout, xout = scp.signal.dlsim((a, b, c, d, 1), u)
+        return tout, yout, xout
 
-    def test_dlsim_simple1d(self):
-        a = np.array([[0.5]])
-        b = np.array([[0.0]])
-        c = np.array([[1.0]])
-        d = np.array([[0.0]])
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_dlsim_simple1d(self, xp, scp):
+        a = xp.array([[0.5]])
+        b = xp.array([[0.0]])
+        c = xp.array([[1.0]])
+        d = xp.array([[0.0]])
         n = 5
-        u = np.zeros(n).reshape(-1, 1)
-        tout, yout, xout = dlsim((a, b, c, d, 1), u, x0=1)
-        assert_array_equal(tout, np.arange(float(n)))
-        expected = (0.5 ** np.arange(float(n))).reshape(-1, 1)
-        assert_array_equal(yout, expected)
-        assert_array_equal(xout, expected)
+        u = xp.zeros(n).reshape(-1, 1)
+        tout, yout, xout = scp.signal.dlsim((a, b, c, d, 1), u, x0=1)
+        return tout, yout, xout
 
-    def test_dlsim_simple2d(self):
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_dlsim_simple2d(self, xp, scp):
         lambda1 = 0.5
         lambda2 = 0.25
-        a = np.array([[lambda1, 0.0],
+        a = xp.array([[lambda1, 0.0],
                       [0.0, lambda2]])
-        b = np.array([[0.0],
+        b = xp.array([[0.0],
                       [0.0]])
-        c = np.array([[1.0, 0.0],
+        c = xp.array([[1.0, 0.0],
                       [0.0, 1.0]])
-        d = np.array([[0.0],
+        d = xp.array([[0.0],
                       [0.0]])
         n = 5
-        u = np.zeros(n).reshape(-1, 1)
-        tout, yout, xout = dlsim((a, b, c, d, 1), u, x0=1)
-        assert_array_equal(tout, np.arange(float(n)))
-        # The analytical solution:
-        expected = (np.array([lambda1, lambda2]) **
-                                np.arange(float(n)).reshape(-1, 1))
-        assert_array_equal(yout, expected)
-        assert_array_equal(xout, expected)
+        u = xp.zeros(n).reshape(-1, 1)
+        tout, yout, xout = scp.signal.dlsim((a, b, c, d, 1), u, x0=1)
+        return tout, yout, xout
 
-    def test_more_step_and_impulse(self):
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_more_step_and_impulse(self, xp, scp):
         lambda1 = 0.5
         lambda2 = 0.75
-        a = np.array([[lambda1, 0.0],
+        a = xp.array([[lambda1, 0.0],
                       [0.0, lambda2]])
-        b = np.array([[1.0, 0.0],
+        b = xp.array([[1.0, 0.0],
                       [0.0, 1.0]])
-        c = np.array([[1.0, 1.0]])
-        d = np.array([[0.0, 0.0]])
+        c = xp.array([[1.0, 1.0]])
+        d = xp.array([[0.0, 0.0]])
 
         n = 10
 
         # Check a step response.
-        ts, ys = dstep((a, b, c, d, 1), n=n)
+        ts, ys = scp.signal.dstep((a, b, c, d, 1), n=n)
+        return ts, *ys
 
-        # Create the exact step response.
-        stp0 = (1.0 / (1 - lambda1)) * (1.0 - lambda1 ** np.arange(n))
-        stp1 = (1.0 / (1 - lambda2)) * (1.0 - lambda2 ** np.arange(n))
-
-        assert_allclose(ys[0][:, 0], stp0)
-        assert_allclose(ys[1][:, 0], stp1)
-
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_more_step_and_impulse_2(self, xp, scp):
         # Check an impulse response with an initial condition.
-        x0 = np.array([1.0, 1.0])
-        ti, yi = dimpulse((a, b, c, d, 1), n=n, x0=x0)
+        lambda1 = 0.5
+        lambda2 = 0.75
+        a = xp.array([[lambda1, 0.0],
+                      [0.0, lambda2]])
+        b = xp.array([[1.0, 0.0],
+                      [0.0, 1.0]])
+        c = xp.array([[1.0, 1.0]])
+        d = xp.array([[0.0, 0.0]])
 
-        # Create the exact impulse response.
-        imp = (np.array([lambda1, lambda2]) **
-                            np.arange(-1, n + 1).reshape(-1, 1))
-        imp[0, :] = 0.0
-        # Analytical solution to impulse response
-        y0 = imp[:n, 0] + np.dot(imp[1:n + 1, :], x0)
-        y1 = imp[:n, 1] + np.dot(imp[1:n + 1, :], x0)
+        n = 10
 
-        assert_allclose(yi[0][:, 0], y0)
-        assert_allclose(yi[1][:, 0], y1)
+        x0 = xp.array([1.0, 1.0])
+        ti, yi = scp.signal.dimpulse((a, b, c, d, 1), n=n, x0=x0)
+        return ti, *yi
 
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_more_step_and_impulse_3(self, xp, scp):
         # Check that dt=0.1, n=3 gives 3 time values.
         system = ([1.0], [1.0, -0.5], 0.1)
-        t, (y,) = dstep(system, n=3)
-        assert_allclose(t, [0, 0.1, 0.2])
-        assert_array_equal(y.T, [[0, 1.0, 1.5]])
-        t, (y,) = dimpulse(system, n=3)
-        assert_allclose(t, [0, 0.1, 0.2])
-        assert_array_equal(y.T, [[0, 1, 0.5]])
+        t, (y,) = scp.signal.dstep(system, n=3)
+        t1, (y1,) = scp.signal.dimpulse(system, n=3)
+        return t, y, t1, y1
 
 
 class TestDlti:
@@ -301,312 +267,267 @@ class TestDlti:
 
         dt = 0.05
         # TransferFunction
-        s = dlti([1], [-1], dt=dt)
-        assert_(isinstance(s, TransferFunction))
-        assert_(isinstance(s, dlti))
-        assert_(not isinstance(s, lti))
-        assert_equal(s.dt, dt)
+        s = signal.dlti([1], [-1], dt=dt)
+        assert isinstance(s, signal.TransferFunction)
+        assert isinstance(s, signal.dlti)
+        assert not isinstance(s, signal.lti)
+        assert s.dt == dt
 
         # ZerosPolesGain
-        s = dlti(np.array([]), np.array([-1]), 1, dt=dt)
-        assert_(isinstance(s, ZerosPolesGain))
-        assert_(isinstance(s, dlti))
-        assert_(not isinstance(s, lti))
-        assert_equal(s.dt, dt)
+        s = signal.dlti(cupy.array([]), cupy.array([-1]), 1, dt=dt)
+        assert isinstance(s, signal.ZerosPolesGain)
+        assert isinstance(s, signal.dlti)
+        assert not isinstance(s, signal.lti)
+        assert s.dt == dt
 
         # StateSpace
-        s = dlti([1], [-1], 1, 3, dt=dt)
-        assert_(isinstance(s, StateSpace))
-        assert_(isinstance(s, dlti))
-        assert_(not isinstance(s, lti))
-        assert_equal(s.dt, dt)
+        s = signal.dlti([1], [-1], 1, 3, dt=dt)
+        assert isinstance(s, signal.StateSpace)
+        assert isinstance(s, signal.dlti)
+        assert not isinstance(s, signal.lti)
+        assert s.dt == dt
 
         # Number of inputs
-        assert_raises(ValueError, dlti, 1)
-        assert_raises(ValueError, dlti, 1, 1, 1, 1, 1)
+        assert_raises(ValueError, signal.dlti, 1)
+        assert_raises(ValueError, signal.dlti, 1, 1, 1, 1, 1)
 
 
 class TestStateSpaceDisc:
     def test_initialization(self):
         # Check that all initializations work
         dt = 0.05
-        StateSpace(1, 1, 1, 1, dt=dt)
-        StateSpace([1], [2], [3], [4], dt=dt)
-        StateSpace(np.array([[1, 2], [3, 4]]), np.array([[1], [2]]),
-                   np.array([[1, 0]]), np.array([[0]]), dt=dt)
-        StateSpace(1, 1, 1, 1, dt=True)
+        signal.StateSpace(1, 1, 1, 1, dt=dt)
+        signal.StateSpace([1], [2], [3], [4], dt=dt)
+        signal.StateSpace(cupy.array([[1, 2], [3, 4]]), cupy.array([[1], [2]]),
+                          cupy.array([[1, 0]]), cupy.array([[0]]), dt=dt)
+        signal.StateSpace(1, 1, 1, 1, dt=True)
 
     def test_conversion(self):
         # Check the conversion functions
-        s = StateSpace(1, 2, 3, 4, dt=0.05)
-        assert_(isinstance(s.to_ss(), StateSpace))
-        assert_(isinstance(s.to_tf(), TransferFunction))
-        assert_(isinstance(s.to_zpk(), ZerosPolesGain))
+        s = signal.StateSpace(1, 2, 3, 4, dt=0.05)
+        assert isinstance(s.to_ss(), signal.StateSpace)
+        assert isinstance(s.to_tf(), signal.TransferFunction)
+        assert isinstance(s.to_zpk(), signal.ZerosPolesGain)
 
         # Make sure copies work
-        assert_(StateSpace(s) is not s)
-        assert_(s.to_ss() is not s)
+        assert signal.StateSpace(s) is not s
+        assert s.to_ss() is not s
 
     def test_properties(self):
         # Test setters/getters for cross class properties.
         # This implicitly tests to_tf() and to_zpk()
 
         # Getters
-        s = StateSpace(1, 1, 1, 1, dt=0.05)
-        assert_equal(s.poles, [1])
-        assert_equal(s.zeros, [0])
+        s = signal.StateSpace(1, 1, 1, 1, dt=0.05)
+        assert s.poles == cupy.array([1])
+        assert s.zeros == cupy.array([0])
 
 
 class TestTransferFunction:
     def test_initialization(self):
         # Check that all initializations work
         dt = 0.05
-        TransferFunction(1, 1, dt=dt)
-        TransferFunction([1], [2], dt=dt)
-        TransferFunction(np.array([1]), np.array([2]), dt=dt)
-        TransferFunction(1, 1, dt=True)
+        signal.TransferFunction(1, 1, dt=dt)
+        signal.TransferFunction([1], [2], dt=dt)
+        signal.TransferFunction(cupy.array([1]), cupy.array([2]), dt=dt)
+        signal.TransferFunction(1, 1, dt=True)
 
     def test_conversion(self):
         # Check the conversion functions
-        s = TransferFunction([1, 0], [1, -1], dt=0.05)
-        assert_(isinstance(s.to_ss(), StateSpace))
-        assert_(isinstance(s.to_tf(), TransferFunction))
-        assert_(isinstance(s.to_zpk(), ZerosPolesGain))
+        s = signal.TransferFunction([1, 0], [1, -1], dt=0.05)
+        assert isinstance(s.to_ss(), signal.StateSpace)
+        assert isinstance(s.to_tf(), signal.TransferFunction)
+        assert isinstance(s.to_zpk(), signal.ZerosPolesGain)
 
         # Make sure copies work
-        assert_(TransferFunction(s) is not s)
-        assert_(s.to_tf() is not s)
+        assert signal.TransferFunction(s) is not s
+        assert s.to_tf() is not s
 
     def test_properties(self):
         # Test setters/getters for cross class properties.
         # This implicitly tests to_ss() and to_zpk()
 
         # Getters
-        s = TransferFunction([1, 0], [1, -1], dt=0.05)
-        assert_equal(s.poles, [1])
-        assert_equal(s.zeros, [0])
+        s = signal.TransferFunction([1, 0], [1, -1], dt=0.05)
+        assert s.poles == cupy.array([1])
+        assert s.zeros == cupy.array([0])
 
 
 class TestZerosPolesGain:
     def test_initialization(self):
         # Check that all initializations work
         dt = 0.05
-        ZerosPolesGain(1, 1, 1, dt=dt)
-        ZerosPolesGain([1], [2], 1, dt=dt)
-        ZerosPolesGain(np.array([1]), np.array([2]), 1, dt=dt)
-        ZerosPolesGain(1, 1, 1, dt=True)
+        signal.ZerosPolesGain(1, 1, 1, dt=dt)
+        signal.ZerosPolesGain([1], [2], 1, dt=dt)
+        signal.ZerosPolesGain(cupy.array([1]), cupy.array([2]), 1, dt=dt)
+        signal.ZerosPolesGain(1, 1, 1, dt=True)
 
     def test_conversion(self):
         # Check the conversion functions
-        s = ZerosPolesGain(1, 2, 3, dt=0.05)
-        assert_(isinstance(s.to_ss(), StateSpace))
-        assert_(isinstance(s.to_tf(), TransferFunction))
-        assert_(isinstance(s.to_zpk(), ZerosPolesGain))
+        s = signal.ZerosPolesGain(1, 2, 3, dt=0.05)
+        assert isinstance(s.to_ss(), signal.StateSpace)
+        assert isinstance(s.to_tf(), signal.TransferFunction)
+        assert isinstance(s.to_zpk(), signal.ZerosPolesGain)
 
         # Make sure copies work
-        assert_(ZerosPolesGain(s) is not s)
-        assert_(s.to_zpk() is not s)
+        assert signal.ZerosPolesGain(s) is not s
+        assert s.to_zpk() is not s
 
 
+@testing.with_requires('scipy')
 class Test_dfreqresp:
 
-    def test_manual(self):
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_manual(self, xp, scp):
         # Test dfreqresp() real part calculation (manual sanity check).
         # 1st order low-pass filter: H(z) = 1 / (z - 0.2),
-        system = TransferFunction(1, [1, -0.2], dt=0.1)
+        system = scp.signal.TransferFunction(1, [1, -0.2], dt=0.1)
         w = [0.1, 1, 10]
-        w, H = dfreqresp(system, w=w)
+        w, H = scp.signal.dfreqresp(system, w=w)
+        return w, H
 
-        # test real
-        expected_re = [1.2383, 0.4130, -0.7553]
-        assert_almost_equal(H.real, expected_re, decimal=4)
-
-        # test imag
-        expected_im = [-0.1555, -1.0214, 0.3955]
-        assert_almost_equal(H.imag, expected_im, decimal=4)
-
-    def test_auto(self):
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_auto(self, xp, scp):
         # Test dfreqresp() real part calculation.
         # 1st order low-pass filter: H(z) = 1 / (z - 0.2),
-        system = TransferFunction(1, [1, -0.2], dt=0.1)
+        system = scp.signal.TransferFunction(1, [1, -0.2], dt=0.1)
         w = [0.1, 1, 10, 100]
-        w, H = dfreqresp(system, w=w)
-        jw = np.exp(w * 1j)
-        y = np.polyval(system.num, jw) / np.polyval(system.den, jw)
+        w, H = scp.signal.dfreqresp(system, w=w)
+        return w, H
 
-        # test real
-        expected_re = y.real
-        assert_almost_equal(H.real, expected_re)
-
-        # test imag
-        expected_im = y.imag
-        assert_almost_equal(H.imag, expected_im)
-
-    def test_freq_range(self):
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_freq_range(self, xp, scp):
         # Test that freqresp() finds a reasonable frequency range.
         # 1st order low-pass filter: H(z) = 1 / (z - 0.2),
         # Expected range is from 0.01 to 10.
-        system = TransferFunction(1, [1, -0.2], dt=0.1)
+        system = scp.signal.TransferFunction(1, [1, -0.2], dt=0.1)
         n = 10
-        expected_w = np.linspace(0, np.pi, 10, endpoint=False)
-        w, H = dfreqresp(system, n=n)
-        assert_almost_equal(w, expected_w)
+        w, H = scp.signal.dfreqresp(system, n=n)
+        return w, H
 
-    def test_pole_one(self):
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_pole_one(self, xp, scp):
         # Test that freqresp() doesn't fail on a system with a pole at 0.
         # integrator, pole at zero: H(s) = 1 / s
-        system = TransferFunction([1], [1, -1], dt=0.1)
-
-        with suppress_warnings() as sup:
-            sup.filter(RuntimeWarning, message="divide by zero")
-            sup.filter(RuntimeWarning, message="invalid value encountered")
-            w, H = dfreqresp(system, n=2)
-        assert_equal(w[0], 0.)  # a fail would give not-a-number
+        system = scp.signal.TransferFunction([1], [1, -1], dt=0.1)
+        w, H = scp.signal.dfreqresp(system, n=2)
+        return w, H
 
     def test_error(self):
         # Raise an error for continuous-time systems
-        system = lti([1], [1, 1])
-        assert_raises(AttributeError, dfreqresp, system)
+        system = signal.lti([1], [1, 1])
+        assert_raises(AttributeError, signal.dfreqresp, system)
 
-    def test_from_state_space(self):
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_from_state_space(self, xp, scp):
         # H(z) = 2 / z^3 - 0.5 * z^2
+        system_TF = scp.signal.dlti([2], [1, -0.5, 0, 0])
 
-        system_TF = dlti([2], [1, -0.5, 0, 0])
-
-        A = np.array([[0.5, 0, 0],
+        A = xp.array([[0.5, 0, 0],
                       [1, 0, 0],
                       [0, 1, 0]])
-        B = np.array([[1, 0, 0]]).T
-        C = np.array([[0, 0, 2]])
+        B = xp.array([[1, 0, 0]]).T
+        C = xp.array([[0, 0, 2]])
         D = 0
 
-        system_SS = dlti(A, B, C, D)
-        w = 10.0**np.arange(-3,0,.5)
-        with suppress_warnings() as sup:
-            sup.filter(BadCoefficients)
-            w1, H1 = dfreqresp(system_TF, w=w)
-            w2, H2 = dfreqresp(system_SS, w=w)
+        system_SS = scp.signal.dlti(A, B, C, D)
+        w = 10.0**xp.arange(-3, 0, .5)
+        w1, H1 = scp.signal.dfreqresp(system_TF, w=w)
+        w2, H2 = scp.signal.dfreqresp(system_SS, w=w)
+        return w1, H1, w2, H2
 
-        assert_almost_equal(H1, H2)
-
-    def test_from_zpk(self):
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_from_zpk(self, xp, scp):
         # 1st order low-pass filter: H(s) = 0.3 / (z - 0.2),
-        system_ZPK = dlti([],[0.2],0.3)
-        system_TF = dlti(0.3, [1, -0.2])
+        system_ZPK = scp.signal.dlti([], [0.2], 0.3)
+        system_TF = scp.signal.dlti(0.3, [1, -0.2])
         w = [0.1, 1, 10, 100]
-        w1, H1 = dfreqresp(system_ZPK, w=w)
-        w2, H2 = dfreqresp(system_TF, w=w)
-        assert_almost_equal(H1, H2)
+        w1, H1 = scp.signal.dfreqresp(system_ZPK, w=w)
+        w2, H2 = scp.signal.dfreqresp(system_TF, w=w)
+        return w1, H1, w2, H2
 
 
+@testing.with_requires('scipy')
 class Test_bode:
 
-    def test_manual(self):
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_manual(self, xp, scp):
         # Test bode() magnitude calculation (manual sanity check).
         # 1st order low-pass filter: H(s) = 0.3 / (z - 0.2),
         dt = 0.1
-        system = TransferFunction(0.3, [1, -0.2], dt=dt)
-        w = [0.1, 0.5, 1, np.pi]
-        w2, mag, phase = dbode(system, w=w)
+        system = scp.signal.TransferFunction(0.3, [1, -0.2], dt=dt)
+        w = [0.1, 0.5, 1, pi]
+        w2, mag, phase = scp.signal.dbode(system, w=w)
+        return w2, mag, phase
 
-        # Test mag
-        expected_mag = [-8.5329, -8.8396, -9.6162, -12.0412]
-        assert_almost_equal(mag, expected_mag, decimal=4)
-
-        # Test phase
-        expected_phase = [-7.1575, -35.2814, -67.9809, -180.0000]
-        assert_almost_equal(phase, expected_phase, decimal=4)
-
-        # Test frequency
-        assert_equal(np.array(w) / dt, w2)
-
-    def test_auto(self):
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_auto(self, xp, scp):
         # Test bode() magnitude calculation.
         # 1st order low-pass filter: H(s) = 0.3 / (z - 0.2),
-        system = TransferFunction(0.3, [1, -0.2], dt=0.1)
-        w = np.array([0.1, 0.5, 1, np.pi])
-        w2, mag, phase = dbode(system, w=w)
-        jw = np.exp(w * 1j)
-        y = np.polyval(system.num, jw) / np.polyval(system.den, jw)
+        system = scp.signal.TransferFunction(0.3, [1, -0.2], dt=0.1)
+        w = xp.array([0.1, 0.5, 1, pi])
+        w2, mag, phase = scp.signal.dbode(system, w=w)
+        return w2, mag, phase
 
-        # Test mag
-        expected_mag = 20.0 * np.log10(abs(y))
-        assert_almost_equal(mag, expected_mag)
-
-        # Test phase
-        expected_phase = np.rad2deg(np.angle(y))
-        assert_almost_equal(phase, expected_phase)
-
-    def test_range(self):
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_range(self, xp, scp):
         # Test that bode() finds a reasonable frequency range.
         # 1st order low-pass filter: H(s) = 0.3 / (z - 0.2),
-        dt = 0.1
-        system = TransferFunction(0.3, [1, -0.2], dt=0.1)
+        system = scp.signal.TransferFunction(0.3, [1, -0.2], dt=0.1)
         n = 10
-        # Expected range is from 0.01 to 10.
-        expected_w = np.linspace(0, np.pi, n, endpoint=False) / dt
-        w, mag, phase = dbode(system, n=n)
-        assert_almost_equal(w, expected_w)
+        w, mag, phase = scp.signal.dbode(system, n=n)
+        return w, mag, phase
 
-    def test_pole_one(self):
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_pole_one(self, xp, scp):
         # Test that freqresp() doesn't fail on a system with a pole at 0.
         # integrator, pole at zero: H(s) = 1 / s
-        system = TransferFunction([1], [1, -1], dt=0.1)
-
-        with suppress_warnings() as sup:
-            sup.filter(RuntimeWarning, message="divide by zero")
-            sup.filter(RuntimeWarning, message="invalid value encountered")
-            w, mag, phase = dbode(system, n=2)
-        assert_equal(w[0], 0.)  # a fail would give not-a-number
+        system = scp.signal.TransferFunction([1], [1, -1], dt=0.1)
+        w, mag, phase = scp.signal.dbode(system, n=2)
+        m = mag[xp.isfinite(mag)]   # nan-vs-inf mismatch
+        return w, m, phase
 
     def test_imaginary(self):
         # bode() should not fail on a system with pure imaginary poles.
         # The test passes if bode doesn't raise an exception.
-        system = TransferFunction([1], [1, 0, 100], dt=0.1)
-        dbode(system, n=2)
+        system = signal.TransferFunction([1], [1, 0, 100], dt=0.1)
+        signal.dbode(system, n=2)
 
     def test_error(self):
         # Raise an error for continuous-time systems
-        system = lti([1], [1, 1])
-        assert_raises(AttributeError, dbode, system)
+        system = signal.lti([1], [1, 1])
+        assert_raises(AttributeError, signal.dbode, system)
 
 
+@testing.with_requires('scipy')
 class TestTransferFunctionZConversion:
     """Test private conversions between 'z' and 'z**-1' polynomials."""
 
-    def test_full(self):
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_full(self, xp, scp):
         # Numerator and denominator same order
         num = [2, 3, 4]
         den = [5, 6, 7]
-        num2, den2 = TransferFunction._z_to_zinv(num, den)
-        assert_equal(num, num2)
-        assert_equal(den, den2)
+        num2, den2 = scp.signal.TransferFunction._z_to_zinv(num, den)
+        num3, den3 = scp.signal.TransferFunction._zinv_to_z(num, den)
 
-        num2, den2 = TransferFunction._zinv_to_z(num, den)
-        assert_equal(num, num2)
-        assert_equal(den, den2)
+        # convert to 1D arrays to help the comparator
+        return xp.atleast_1d(num2, den2, num3, den3)
 
-    def test_numerator(self):
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_numerator(self, xp, scp):
         # Numerator lower order than denominator
         num = [2, 3]
         den = [5, 6, 7]
-        num2, den2 = TransferFunction._z_to_zinv(num, den)
-        assert_equal([0, 2, 3], num2)
-        assert_equal(den, den2)
+        num2, den2 = scp.signal.TransferFunction._z_to_zinv(num, den)
+        num3, den3 = scp.signal.TransferFunction._zinv_to_z(num, den)
+        return xp.atleast_1d(num2, den2, num3, den3)
 
-        num2, den2 = TransferFunction._zinv_to_z(num, den)
-        assert_equal([2, 3, 0], num2)
-        assert_equal(den, den2)
-
-    def test_denominator(self):
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_denominator(self, xp, scp):
         # Numerator higher order than denominator
         num = [2, 3, 4]
         den = [5, 6]
-        num2, den2 = TransferFunction._z_to_zinv(num, den)
-        assert_equal(num, num2)
-        assert_equal([0, 5, 6], den2)
-
-        num2, den2 = TransferFunction._zinv_to_z(num, den)
-        assert_equal(num, num2)
-        assert_equal([5, 6, 0], den2)
-
+        num2, den2 = scp.signal.TransferFunction._z_to_zinv(num, den)
+        num3, den3 = scp.signal.TransferFunction._zinv_to_z(num, den)
+        return xp.atleast_1d(num2, den2, num3, den3)

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_ltisys.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_ltisys.py
@@ -4,7 +4,6 @@ import cupyx.scipy.signal as signal
 
 from cupy import testing
 from pytest import raises as assert_raises
-import pytest
 
 
 def assert_equal(actual, desired):
@@ -227,7 +226,6 @@ class Test_bode:
         w, mag, phase = system.bode(w=xp.logspace(-3, 40, 100))
         return w, mag, phase
 
-    @pytest.mark.xfail(reason="subject to fp errors in findfreqs")
     @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_from_state_space(self, xp, scp):
         # Ensure that bode works with a system that was created from the
@@ -288,7 +286,6 @@ class Test_freqresp:
         w, H = scp.signal.freqresp(system, n=2)
         return w, H
 
-    @pytest.mark.xfail(reason="subject to fp errors in findfreqs")
     @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_from_state_space(self, xp, scp):
         # Ensure that freqresp works with a system that was created from the

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_ltisys.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_ltisys.py
@@ -422,3 +422,63 @@ class TestLsim:
         with assert_raises(ValueError,
                            match="Time steps are not equally spaced."):
             signal.lsim(system, u, t, X0=cupy.array([1.0]))
+
+
+@testing.with_requires("scipy")
+class TestImpulse:
+
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_first_order(self, xp, scp):
+        # First order system: x'(t) + x(t) = u(t)
+        # Exact impulse response is x(t) = exp(-t).
+        system = ([1.0], [1.0, 1.0])
+        tout, y = scp.signal.impulse(system)
+        return tout, y
+
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_first_order_fixed_time(self, xp, scp):
+        # Specify the desired time values for the output.
+
+        # First order system: x'(t) + x(t) = u(t)
+        # Exact impulse response is x(t) = exp(-t).
+        system = ([1.0], [1.0, 1.0])
+        n = 21
+        t = xp.linspace(0, 2.0, n)
+        tout, y = scp.signal.impulse(system, T=t)
+        return tout, y
+
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_first_order_initial(self, xp, scp):
+        # Specify an initial condition as a scalar.
+
+        # First order system: x'(t) + x(t) = u(t), x(0)=3.0
+        # Exact impulse response is x(t) = 4*exp(-t).
+        system = ([1.0], [1.0, 1.0])
+        tout, y = scp.signal.impulse(system, X0=3.0)
+        return tout, y
+
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_first_order_initial_list(self, xp, scp):
+        # Specify an initial condition as a list.
+
+        # First order system: x'(t) + x(t) = u(t), x(0)=3.0
+        # Exact impulse response is x(t) = 4*exp(-t).
+        system = ([1.0], [1.0, 1.0])
+        tout, y = scp.signal.impulse(system, X0=xp.asarray([3.0]))
+        return tout, y
+
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_integrator(self, xp, scp):
+        # Simple integrator: x'(t) = u(t)
+        system = ([1.0], [1.0, 0.0])
+        tout, y = scp.signal.impulse(system)
+        return tout, y
+
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_second_order(self, xp, scp):
+        # Second order system with a repeated root:
+        #     x''(t) + 2*x(t) + x(t) = u(t)
+        # The exact impulse response is t*exp(-t).
+        system = ([1.0], [1.0, 2.0, 1.0])
+        tout, y = scp.signal.impulse(system)
+        return tout, y

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_ltisys.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_ltisys.py
@@ -143,3 +143,4 @@ class Test_abcd_normalize:
 
     def test_missing_CD_fails(self):
         assert_raises(ValueError, abcd_normalize, A=self.A, B=self.B)
+

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_ltisys.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_ltisys.py
@@ -482,3 +482,64 @@ class TestImpulse:
         system = ([1.0], [1.0, 2.0, 1.0])
         tout, y = scp.signal.impulse(system)
         return tout, y
+
+
+@testing.with_requires("scipy")
+class TestStep:
+
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_first_order(self, xp, scp):
+        # First order system: x'(t) + x(t) = u(t)
+        # Exact step response is x(t) = 1 - exp(-t).
+        system = ([1.0], [1.0, 1.0])
+        tout, y = scp.signal.step(system)
+        return tout, y
+
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_first_order_fixed_time(self, xp, scp):
+        # Specify the desired time values for the output.
+
+        # First order system: x'(t) + x(t) = u(t)
+        # Exact step response is x(t) = 1 - exp(-t).
+        system = ([1.0], [1.0, 1.0])
+        n = 21
+        t = xp.linspace(0, 2.0, n)
+        tout, y = scp.signal.step(system, T=t)
+        return tout, y
+
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_first_order_initial(self, xp, scp):
+        # Specify an initial condition as a scalar.
+
+        # First order system: x'(t) + x(t) = u(t), x(0)=3.0
+        # Exact step response is x(t) = 1 + 2*exp(-t).
+        system = ([1.0], [1.0, 1.0])
+        tout, y = scp.signal.step(system, X0=3.0)
+        return tout, y
+
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_first_order_initial_list(self, xp, scp):
+        # Specify an initial condition as a list.
+
+        # First order system: x'(t) + x(t) = u(t), x(0)=3.0
+        # Exact step response is x(t) = 1 + 2*exp(-t).
+        system = ([1.0], [1.0, 1.0])
+        tout, y = scp.signal.step(system, X0=xp.array([3.0]))
+        return tout, y
+
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_integrator(self, xp, scp):
+        # Simple integrator: x'(t) = u(t)
+        # Exact step response is x(t) = t.
+        system = ([1.0], [1.0, 0.0])
+        tout, y = scp.signal.step(system)
+        return tout, y
+
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_second_order(self, xp, scp):
+        # Second order system with a repeated root:
+        #     x''(t) + 2*x(t) + x(t) = u(t)
+        # The exact step response is 1 - (1 + t)*exp(-t).
+        system = ([1.0], [1.0, 2.0, 1.0])
+        tout, y = scp.signal.step(system)
+        return tout, y

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_ltisys.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_ltisys.py
@@ -143,4 +143,3 @@ class Test_abcd_normalize:
 
     def test_missing_CD_fails(self):
         assert_raises(ValueError, abcd_normalize, A=self.A, B=self.B)
-


### PR DESCRIPTION
cross-ref https://github.com/cupy/cupy/issues/7403

- [x] StateSpace
- [x] TransferFunction
- [x] ZerosPolesGain
.
- [x] dlti
- [x] dlsim
- [x] dimpulse
- [x] dstep
- [x] dbode
- [x] dfreqresp
.
- [x] lti
- [x] lsim
- [x] impulse
- [x] step 
- [x] freqresp
- [x] bode
.
- [x] cont2discrete

Also add the matrix exponential, `cupyx.scipy.linalg.expm` (needed for lsim, cont2discrete).