### PR TITLE
Add mixed precision (FP16) support for ROCm

### DIFF
--- a/cupy/_core/_routines_linalg.pyx
+++ b/cupy/_core/_routines_linalg.pyx
@@ -646,7 +646,8 @@ cpdef _ndarray_base tensordot_core(
     if dtype == 'e':
         use_tensor_core = (not runtime._is_hip_environment and
                            _cuda_runtime_version >= 9000 and
-                           compute_capability >= 70) or (runtime._is_hip_environment)
+                           compute_capability >= 70
+                           ) or runtime._is_hip_environment
         if use_tensor_core:
             can_opt_in_tensorcore = not runtime._is_hip_environment
 

--- a/cupy_backends/cuda/api/_runtime_enum.pxd
+++ b/cupy_backends/cuda/api/_runtime_enum.pxd
@@ -1,4 +1,7 @@
 cpdef enum:
+    # need to revisit this when cython supports C++ enums (in 3.0)
+    # https://stackoverflow.com/a/67138945
+
     cudaMemoryTypeHost = 1
     cudaMemoryTypeDevice = 2
 

--- a/cupy_backends/cuda/libs/cublas.pxd
+++ b/cupy_backends/cuda/libs/cublas.pxd
@@ -29,6 +29,9 @@ cdef extern from *:
 ###############################################################################
 
 cpdef enum:
+    # need to revisit this when cython supports C++ enums (in 3.0)
+    # https://stackoverflow.com/a/67138945
+
     CUBLAS_OP_N = 0
     CUBLAS_OP_T = 1
     CUBLAS_OP_C = 2

--- a/cupy_backends/cuda/libs/cublas.pyx
+++ b/cupy_backends/cuda/libs/cublas.pyx
@@ -1430,7 +1430,10 @@ cpdef gemmEx(
         int ldc, int computeType, int algo):
     _setStream(handle)
     with nogil:
-        if not runtime._is_hip_environment and computeType >= CUBLAS_COMPUTE_16F:
+        if (
+            not runtime._is_hip_environment and
+            computeType >= CUBLAS_COMPUTE_16F
+        ):
             status = cublasGemmEx_v11(
                 <Handle>handle, <Operation>transa, <Operation>transb, m, n, k,
                 <const void*>alpha,

--- a/cupy_backends/cuda/libs/cublas.pyx
+++ b/cupy_backends/cuda/libs/cublas.pyx
@@ -1430,7 +1430,7 @@ cpdef gemmEx(
         int ldc, int computeType, int algo):
     _setStream(handle)
     with nogil:
-        if computeType >= CUBLAS_COMPUTE_16F:
+        if not runtime._is_hip_environment and computeType >= CUBLAS_COMPUTE_16F:
             status = cublasGemmEx_v11(
                 <Handle>handle, <Operation>transa, <Operation>transb, m, n, k,
                 <const void*>alpha,


### PR DESCRIPTION
This PR adds mixed precision support for matrix-matrix multiplies on ROCm, which is available in hipBLAS through `hipblasGemmEx`. On MI200 GPUs, this utilizes the MFMA (matrix fused-multiply add) instructions, which are intended as analogues of the NVIDIA tensor cores.

For `cupy.float16` arrays, we allow the use of the hipBLAS primitive, which was previously disabled, and fp16 values were casted to single precision, albeit issuing a warning. I am not entirely sure if the reason for this was the lack of hardware and/or API support in earlier versions of the AMD libraries, therefore a version check for hipBLAS might be required. It appears though that support has been stable since ROCm 4.2.0 (https://github.com/ROCmSoftwarePlatform/hipBLAS/blob/develop/CHANGELOG.md).

To verify that the code now uses `rocblas_gemm_ex` under the hood, enable rocBLAS runtime tracing with the unit test like this
``` 
ROCBLAS_LAYER=1 pytest tests/cupy_tests/math_tests/test_matmul.py -s -k TestMatmulOut
```