### PR TITLE
Skip `TestLOBPCG::test_maxit_None` in CUDA 12.1.1 & cuSOVLER 11.4.5

### DIFF
--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
@@ -1217,6 +1217,9 @@ class TestLOBPCG:
     @pytest.mark.xfail(
         runtime.is_hip and driver.get_build_version() >= 5_00_00000,
         reason='ROCm 5.0+ may have a bug')
+    @pytest.mark.xfail(
+        cupy.cuda.cusolver._getVersion() == (11, 4, 5),
+        reason='CUDA 12.1.1 + cuSOLVER 11.4.5 may have a bug')
     def test_maxit_None(self):
         """Check lobpcg if maxit=None runs 20 iterations (the default)
         by checking the size of the iteration history output, which should


### PR DESCRIPTION
Locally confirmed that the test passes with CUDA 12.1.0, and fails with CUDA 12.1.1.