### PR TITLE
Fix memory pool to try resolve fragmentation when limit is set

### DIFF
--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -1341,12 +1341,22 @@ cdef class SingleDeviceMemoryPool:
         return None
 
     cdef BaseMemory _try_malloc(self, size_t size):
+        cdef size_t limit
+        cdef bint limit_ok
         with LockAndNoGc(self._total_bytes_lock):
-            total_bytes_limit = self._total_bytes_limit
-            total = self._total_bytes + size
-            if total_bytes_limit != 0 and total_bytes_limit < total:
-                raise OutOfMemoryError(size, total - size, total_bytes_limit)
-            self._total_bytes = total
+            limit = self._total_bytes_limit
+            if limit != 0:
+                limit_ok = (self._total_bytes + size) <= limit
+                if not limit_ok:
+                    self.free_all_blocks()
+                    limit_ok = (self._total_bytes + size) <= limit
+                if not limit_ok:
+                    gc.collect()
+                    self.free_all_blocks()
+                    limit_ok = (self._total_bytes + size) <= limit
+                if not limit_ok:
+                    raise OutOfMemoryError(size, self._total_bytes, limit)
+            self._total_bytes += size
 
         mem = None
         oom_error = False
@@ -1373,9 +1383,8 @@ cdef class SingleDeviceMemoryPool:
             if mem is None:
                 with LockAndNoGc(self._total_bytes_lock):
                     self._total_bytes -= size
-                if oom_error:
-                    raise OutOfMemoryError(
-                        size, total - size, total_bytes_limit)
+                    if oom_error:
+                        raise OutOfMemoryError(size, self._total_bytes, limit)
 
         return mem
 

--- a/tests/cupy_tests/cuda_tests/test_memory.py
+++ b/tests/cupy_tests/cuda_tests/test_memory.py
@@ -419,6 +419,15 @@ class TestSingleDeviceMemoryPool(unittest.TestCase):
         p3 = self.pool.malloc(self.unit)
         del p1, p2, p3
 
+    def test_alloc_limit_fragmented(self):
+        # Test for #7678.
+        self.pool.set_limit(size=(self.unit * 6))
+
+        p1 = self.pool.malloc(self.unit * 5)
+        del p1
+        p2 = self.pool.malloc(self.unit * 6)
+        del p2
+
     def test_free(self):
         p1 = self.pool.malloc(self.unit * 4)
         ptr1 = p1.ptr


### PR DESCRIPTION
This fixes the problem that CuPy memory allocator does not call `free_all_blocks()` / `gc.collect()` when the limit is set, causing an OOM error immediately if the memory chunk is fragmented.

Closes #7678.
