### PR TITLE
Fix cuSPARSE error message

### DIFF
--- a/cupy_backends/hip/cupy_hipsparse.h
+++ b/cupy_backends/hip/cupy_hipsparse.h
@@ -59,6 +59,17 @@ cusparseStatus_t cusparseGetVersion(cusparseHandle_t handle,
   return hipsparseGetVersion(handle, version);
 }
 
+// Error handling
+const char* cusparseGetErrorName(...) {
+    // Unavailable in hipSparse; this should not be called
+    return "CUPY_HIPSPARSE_BINDING_UNEXPECTED_ERROR";
+}
+
+const char* cusparseGetErrorString(...) {
+    // Unavailable in hipSparse; this should not be called
+    return "unexpected error in CuPy hipSparse binding";
+}
+
 // cuSPARSE Helper Function
 cusparseStatus_t cusparseCreate(cusparseHandle_t* handle) {
   return hipsparseCreate(handle);

--- a/cupy_backends/stub/cupy_cusparse.h
+++ b/cupy_backends/stub/cupy_cusparse.h
@@ -34,6 +34,15 @@ cusparseStatus_t cusparseGetVersion(...) {
   return CUSPARSE_STATUS_SUCCESS;
 }
 
+// Error handling
+const char* cusparseGetErrorName(...) {
+    return NULL;
+}
+
+const char* cusparseGetErrorString(...) {
+    return NULL;
+}
+
 // cuSPARSE Helper Function
 cusparseStatus_t cusparseCreate(...) {
   return CUSPARSE_STATUS_SUCCESS;

--- a/tests/cupy_tests/cuda_tests/test_cusparse.py
+++ b/tests/cupy_tests/cuda_tests/test_cusparse.py
@@ -1,12 +1,26 @@
 import pickle
 import unittest
 
+import cupy
 from cupy.cuda import cusparse
 
 
-class TestExceptionPicklable(unittest.TestCase):
+class TestException(unittest.TestCase):
 
-    def test(self):
+    def test_error_message(self):
+        e = cusparse.CuSparseError(1)
+        if cupy.cuda.runtime.is_hip:
+            assert str(e) == (
+                'HIPSPARSE_STATUS_NOT_INITIALIZED: '
+                'HIPSPARSE_STATUS_NOT_INITIALIZED'
+            )
+        else:
+            assert str(e) == (
+                'CUSPARSE_STATUS_NOT_INITIALIZED: '
+                'initialization error'
+            )
+
+    def test_pickle(self):
         e1 = cusparse.CuSparseError(1)
         e2 = pickle.loads(pickle.dumps(e1))
         assert e1.args == e2.args


### PR DESCRIPTION
The error code `CUSPARSE_STATUS_INSUFFICIENT_RESOURCES` (11) was missing in the mapping.
This fixes `CuSparseError` to generate an error message using `cusparseGetError` and `cusparseGetErrorString` available since CUDA 10.2.

Closes #7677.
