### PR TITLE
Bump CUDA minor versions used in CI

### DIFF
--- a/.pfnci/linux/tests/cuda112.Dockerfile
+++ b/.pfnci/linux/tests/cuda112.Dockerfile
@@ -1,5 +1,5 @@
 # AUTO GENERATED: DO NOT EDIT!
-ARG BASE_IMAGE="nvidia/cuda:11.2.1-devel-centos7"
+ARG BASE_IMAGE="nvidia/cuda:11.2.2-devel-centos7"
 FROM ${BASE_IMAGE}
 
 RUN yum -y install centos-release-scl && \

--- a/.pfnci/linux/tests/cuda112.multi.Dockerfile
+++ b/.pfnci/linux/tests/cuda112.multi.Dockerfile
@@ -1,5 +1,5 @@
 # AUTO GENERATED: DO NOT EDIT!
-ARG BASE_IMAGE="nvidia/cuda:11.2.1-devel-centos7"
+ARG BASE_IMAGE="nvidia/cuda:11.2.2-devel-centos7"
 FROM ${BASE_IMAGE}
 
 RUN yum -y install centos-release-scl && \

--- a/.pfnci/linux/tests/cuda114.Dockerfile
+++ b/.pfnci/linux/tests/cuda114.Dockerfile
@@ -1,5 +1,5 @@
 # AUTO GENERATED: DO NOT EDIT!
-ARG BASE_IMAGE="nvidia/cuda:11.4.0-devel-ubuntu20.04"
+ARG BASE_IMAGE="nvidia/cuda:11.4.3-devel-ubuntu20.04"
 FROM ${BASE_IMAGE}
 
 RUN export DEBIAN_FRONTEND=noninteractive && \

--- a/.pfnci/linux/tests/cuda114.multi.Dockerfile
+++ b/.pfnci/linux/tests/cuda114.multi.Dockerfile
@@ -1,5 +1,5 @@
 # AUTO GENERATED: DO NOT EDIT!
-ARG BASE_IMAGE="nvidia/cuda:11.4.0-devel-ubuntu20.04"
+ARG BASE_IMAGE="nvidia/cuda:11.4.3-devel-ubuntu20.04"
 FROM ${BASE_IMAGE}
 
 RUN export DEBIAN_FRONTEND=noninteractive && \

--- a/.pfnci/linux/tests/cuda115.Dockerfile
+++ b/.pfnci/linux/tests/cuda115.Dockerfile
@@ -1,5 +1,5 @@
 # AUTO GENERATED: DO NOT EDIT!
-ARG BASE_IMAGE="nvidia/cuda:11.5.0-devel-ubuntu20.04"
+ARG BASE_IMAGE="nvidia/cuda:11.5.2-devel-ubuntu20.04"
 FROM ${BASE_IMAGE}
 
 RUN export DEBIAN_FRONTEND=noninteractive && \

--- a/.pfnci/linux/tests/cuda115.multi.Dockerfile
+++ b/.pfnci/linux/tests/cuda115.multi.Dockerfile
@@ -1,5 +1,5 @@
 # AUTO GENERATED: DO NOT EDIT!
-ARG BASE_IMAGE="nvidia/cuda:11.5.0-devel-ubuntu20.04"
+ARG BASE_IMAGE="nvidia/cuda:11.5.2-devel-ubuntu20.04"
 FROM ${BASE_IMAGE}
 
 RUN export DEBIAN_FRONTEND=noninteractive && \

--- a/.pfnci/linux/tests/cuda116.Dockerfile
+++ b/.pfnci/linux/tests/cuda116.Dockerfile
@@ -1,5 +1,5 @@
 # AUTO GENERATED: DO NOT EDIT!
-ARG BASE_IMAGE="nvidia/cuda:11.6.0-devel-ubuntu20.04"
+ARG BASE_IMAGE="nvidia/cuda:11.6.2-devel-ubuntu20.04"
 FROM ${BASE_IMAGE}
 
 RUN export DEBIAN_FRONTEND=noninteractive && \

--- a/.pfnci/linux/tests/cuda116.multi.Dockerfile
+++ b/.pfnci/linux/tests/cuda116.multi.Dockerfile
@@ -1,5 +1,5 @@
 # AUTO GENERATED: DO NOT EDIT!
-ARG BASE_IMAGE="nvidia/cuda:11.6.0-devel-ubuntu20.04"
+ARG BASE_IMAGE="nvidia/cuda:11.6.2-devel-ubuntu20.04"
 FROM ${BASE_IMAGE}
 
 RUN export DEBIAN_FRONTEND=noninteractive && \

--- a/.pfnci/linux/tests/cuda117.Dockerfile
+++ b/.pfnci/linux/tests/cuda117.Dockerfile
@@ -1,5 +1,5 @@
 # AUTO GENERATED: DO NOT EDIT!
-ARG BASE_IMAGE="nvidia/cuda:11.7.0-devel-ubuntu20.04"
+ARG BASE_IMAGE="nvidia/cuda:11.7.1-devel-ubuntu20.04"
 FROM ${BASE_IMAGE}
 
 RUN export DEBIAN_FRONTEND=noninteractive && \

--- a/.pfnci/linux/tests/cuda117.multi.Dockerfile
+++ b/.pfnci/linux/tests/cuda117.multi.Dockerfile
@@ -1,5 +1,5 @@
 # AUTO GENERATED: DO NOT EDIT!
-ARG BASE_IMAGE="nvidia/cuda:11.7.0-devel-ubuntu20.04"
+ARG BASE_IMAGE="nvidia/cuda:11.7.1-devel-ubuntu20.04"
 FROM ${BASE_IMAGE}
 
 RUN export DEBIAN_FRONTEND=noninteractive && \

--- a/.pfnci/linux/tests/cuda11x-cuda-python.Dockerfile
+++ b/.pfnci/linux/tests/cuda11x-cuda-python.Dockerfile
@@ -1,5 +1,5 @@
 # AUTO GENERATED: DO NOT EDIT!
-ARG BASE_IMAGE="nvidia/cuda:11.6.0-devel-ubuntu20.04"
+ARG BASE_IMAGE="nvidia/cuda:11.6.2-devel-ubuntu20.04"
 FROM ${BASE_IMAGE}
 
 RUN export DEBIAN_FRONTEND=noninteractive && \

--- a/.pfnci/linux/tests/cuda120.Dockerfile
+++ b/.pfnci/linux/tests/cuda120.Dockerfile
@@ -1,5 +1,5 @@
 # AUTO GENERATED: DO NOT EDIT!
-ARG BASE_IMAGE="nvidia/cuda:12.0.0-devel-ubuntu20.04"
+ARG BASE_IMAGE="nvidia/cuda:12.0.1-devel-ubuntu20.04"
 FROM ${BASE_IMAGE}
 
 RUN export DEBIAN_FRONTEND=noninteractive && \

--- a/.pfnci/linux/tests/cuda120.multi.Dockerfile
+++ b/.pfnci/linux/tests/cuda120.multi.Dockerfile
@@ -1,5 +1,5 @@
 # AUTO GENERATED: DO NOT EDIT!
-ARG BASE_IMAGE="nvidia/cuda:12.0.0-devel-ubuntu20.04"
+ARG BASE_IMAGE="nvidia/cuda:12.0.1-devel-ubuntu20.04"
 FROM ${BASE_IMAGE}
 
 RUN export DEBIAN_FRONTEND=noninteractive && \

--- a/.pfnci/linux/tests/cuda121.Dockerfile
+++ b/.pfnci/linux/tests/cuda121.Dockerfile
@@ -1,5 +1,5 @@
 # AUTO GENERATED: DO NOT EDIT!
-ARG BASE_IMAGE="nvidia/cuda:12.1.0-devel-ubuntu20.04"
+ARG BASE_IMAGE="nvidia/cuda:12.1.1-devel-ubuntu20.04"
 FROM ${BASE_IMAGE}
 
 RUN export DEBIAN_FRONTEND=noninteractive && \

--- a/.pfnci/linux/tests/cuda121.multi.Dockerfile
+++ b/.pfnci/linux/tests/cuda121.multi.Dockerfile
@@ -1,5 +1,5 @@
 # AUTO GENERATED: DO NOT EDIT!
-ARG BASE_IMAGE="nvidia/cuda:12.1.0-devel-ubuntu20.04"
+ARG BASE_IMAGE="nvidia/cuda:12.1.1-devel-ubuntu20.04"
 FROM ${BASE_IMAGE}
 
 RUN export DEBIAN_FRONTEND=noninteractive && \

--- a/.pfnci/schema.yaml
+++ b/.pfnci/schema.yaml
@@ -34,23 +34,23 @@ cuda:
   null:
     full_version: null
   "11.2":
-    full_version: "11.2.1"
+    full_version: "11.2.2"
   "11.3":
     full_version: "11.3.1"
   "11.4":
-    full_version: "11.4.0"
+    full_version: "11.4.3"
   "11.5":
-    full_version: "11.5.0"
+    full_version: "11.5.2"
   "11.6":
-    full_version: "11.6.0"
+    full_version: "11.6.2"
   "11.7":
-    full_version: "11.7.0"
+    full_version: "11.7.1"
   "11.8":
     full_version: "11.8.0"
   "12.0":
-    full_version: "12.0.0"
+    full_version: "12.0.1"
   "12.1":
-    full_version: "12.1.0"
+    full_version: "12.1.1"
 rocm:
   null:
     full_version: null


### PR DESCRIPTION
Ref #7548

Outdated minor versions will be removed from Docker Hub:
https://gitlab.com/nvidia/container-images/cuda/-/blob/master/doc/container_tags.pdf
https://gitlab.com/nvidia/container-images/cuda/-/issues/209
