### PR TITLE
XFAIL known test failures in cuSPARSE module

### DIFF
--- a/cupyx/cusparse.py
+++ b/cupyx/cusparse.py
@@ -152,7 +152,7 @@ _available_hipsparse_version = {
 }
 
 
-def _get_version(x):
+def _get_avail_version_from_spec(x):
     if isinstance(x, dict):
         os_name = _platform.system()
         if os_name not in x:
@@ -175,13 +175,17 @@ def check_availability(name):
         msg = 'No available version information specified for {}'.format(name)
         raise ValueError(msg)
     version_added, version_removed = available_version[name]
-    version_added = _get_version(version_added)
-    version_removed = _get_version(version_removed)
+    version_added = _get_avail_version_from_spec(version_added)
+    version_removed = _get_avail_version_from_spec(version_removed)
     if version_added is not None and version < version_added:
         return False
     if version_removed is not None and version >= version_removed:
         return False
     return True
+
+
+def getVersion() -> int:
+    return _cusparse.getVersion(_device.get_cusparse_handle())
 
 
 def csrmv(a, x, y=None, alpha=1, beta=0, transa=False):

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_coo.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_coo.py
@@ -1,4 +1,5 @@
 import pickle
+import sys
 
 import numpy
 import pytest
@@ -12,6 +13,7 @@ import cupy
 from cupy import testing
 from cupy.cuda import driver
 from cupy.cuda import runtime
+import cupyx.cusparse
 from cupyx.scipy import sparse
 
 
@@ -469,6 +471,13 @@ class TestCooMatrixInit:
 }))
 @testing.with_requires('scipy')
 class TestCooMatrixScipyComparison:
+
+    @pytest.fixture(autouse=True)
+    def setUp(self):
+        if (sys.platform == 'win32' and
+                cupyx.cusparse.getVersion() == 11301 and
+                self.dtype == cupy.complex128):
+            pytest.xfail('Known to fail on CUDA 11.2 for Windows')
 
     @property
     def make(self):

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
@@ -1,4 +1,5 @@
 import pickle
+import sys
 
 import numpy
 import pytest
@@ -12,6 +13,7 @@ import cupy
 from cupy import testing
 from cupy.cuda import driver
 from cupy.cuda import runtime
+import cupyx.cusparse
 from cupyx.scipy import sparse
 
 
@@ -449,6 +451,10 @@ class TestCscMatrixScipyComparison:
 
     @pytest.fixture(autouse=True)
     def setUp(self):
+        if (sys.platform == 'win32' and
+                cupyx.cusparse.getVersion() == 11301 and
+                self.dtype == cupy.complex128):
+            pytest.xfail('Known to fail on CUDA 11.2 for Windows')
         if runtime.is_hip:
             if self.make_method in ('_make_empty', '_make_shape'):
                 # xcsr2coo, xcsrgemm2Nnz, csrmm2, nnz_compress, ... could raise

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -1,5 +1,6 @@
 import contextlib
 import pickle
+import sys
 import warnings
 
 import numpy
@@ -494,6 +495,10 @@ class TestCsrMatrixScipyComparison:
 
     @pytest.fixture(autouse=True)
     def setUp(self):
+        if (sys.platform == 'win32' and
+                cupyx.cusparse.getVersion() == 11301 and
+                self.dtype == cupy.complex128):
+            pytest.xfail('Known to fail on CUDA 11.2 for Windows')
         if runtime.is_hip:
             if self.make_method in ('_make_empty', '_make_shape'):
                 # xcsr2coo, xcsrgemm2Nnz, csrmm2, nnz_compress, ... could raise
@@ -1251,6 +1256,13 @@ class TestCsrMatrixScipyComparison:
 }))
 @testing.with_requires('scipy')
 class TestCsrMatrixPowScipyComparison:
+
+    @pytest.fixture(autouse=True)
+    def setUp(self):
+        if (sys.platform == 'win32' and
+                cupyx.cusparse.getVersion() == 11301 and
+                self.dtype == cupy.complex128):
+            pytest.xfail('Known to fail on CUDA 11.2 for Windows')
 
     @testing.numpy_cupy_allclose(sp_name='sp', _check_sparse_format=False)
     def test_pow_0(self, xp, sp):

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -845,6 +845,9 @@ class TestCsrMatrixScipyComparison:
 
     @testing.numpy_cupy_allclose(sp_name='sp', contiguous_check=False)
     def test_mul_dense_matrix(self, xp, sp):
+        if (cupyx.cusparse.getVersion() == 11702
+                and self.make_method == '_make_duplicate'):
+            pytest.xfail('Known to fail on CUDA 11.6.1/11.6.2')
         m = self.make(xp, sp, self.dtype)
         x = xp.arange(8).reshape(4, 2).astype(self.dtype)
         return m * x

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -15,6 +15,7 @@ from cupy_backends.cuda.api import runtime
 import cupy
 from cupy._core import _accelerator
 from cupy import testing
+import cupyx.cusparse
 from cupyx.scipy import sparse
 
 
@@ -662,6 +663,9 @@ class TestCsrMatrixScipyComparison:
 
     @testing.numpy_cupy_allclose(sp_name='sp', contiguous_check=False)
     def test_dot_dense_matrix(self, xp, sp):
+        if (cupyx.cusparse.getVersion() == 11702
+                and self.make_method == '_make_duplicate'):
+            pytest.xfail('Known to fail on CUDA 11.6.1/11.6.2')
         m = self.make(xp, sp, self.dtype)
         x = xp.arange(8).reshape(4, 2).astype(self.dtype)
         return m.dot(x)


### PR DESCRIPTION
This fixes the following test failure:

CUDA 11.2 on Windows:

https://ci.preferred.jp/cupy.win.cuda112/136285/

```
tests/cupyx_tests/test_cusparse.py::TestSpgemm::test_spgemm_ab[_param_6_{dtype=complex128, shape=(2, 3, 4)}] Windows fatal exception: access violation

Current thread 0x00000e50 (most recent call first):
  File "C:\Users\chainer\cupy\cupyx\cusparse.py", line 2081 in spgemm
  File "C:\Users\chainer\cupy\tests\cupyx_tests\test_cusparse.py", line 390 in test_spgemm_ab
  File "C:\Development\Python\Python39\lib\site-packages\_pytest\python.py", line 194 in pytest_pyfunc_call
  File "C:\Development\Python\Python39\lib\site-packages\pluggy\_callers.py", line 80 in _multicall
  File "C:\Development\Python\Python39\lib\site-packages\pluggy\_manager.py", line 112 in _hookexec
  File "C:\Development\Python\Python39\lib\site-packages\pluggy\_hooks.py", line 433 in __call__
  File "C:\Development\Python\Python39\lib\site-packages\_pytest\python.py", line 1788 in runtest
  File "C:\Development\Python\Python39\lib\site-packages\_pytest\runner.py", line 169 in pytest_runtest_call
  File "C:\Development\Python\Python39\lib\site-packages\pluggy\_callers.py", line 80 in _multicall
  File "C:\Development\Python\Python39\lib\site-packages\pluggy\_manager.py", line 112 in _hookexec
  File "C:\Development\Python\Python39\lib\site-packages\pluggy\_hooks.py", line 433 in __call__
  File "C:\Development\Python\Python39\lib\site-packages\_pytest\runner.py", line 262 in <lambda>
  File "C:\Development\Python\Python39\lib\site-packages\_pytest\runner.py", line 341 in from_call
  File "C:\Development\Python\Python39\lib\site-packages\_pytest\runner.py", line 261 in call_runtest_hook
  File "C:\Development\Python\Python39\lib\site-packages\_pytest\runner.py", line 222 in call_and_report
  File "C:\Development\Python\Python39\lib\site-packages\_pytest\runner.py", line 133 in runtestprotocol
  File "C:\Development\Python\Python39\lib\site-packages\_pytest\runner.py", line 114 in pytest_runtest_protocol
  File "C:\Development\Python\Python39\lib\site-packages\pluggy\_callers.py", line 80 in _multicall
  File "C:\Development\Python\Python39\lib\site-packages\pluggy\_manager.py", line 112 in _hookexec
  File "C:\Development\Python\Python39\lib\site-packages\pluggy\_hooks.py", line 433 in __call__
  File "C:\Development\Python\Python39\lib\site-packages\_pytest\main.py", line 349 in pytest_runtestloop
  File "C:\Development\Python\Python39\lib\site-packages\pluggy\_callers.py", line 80 in _multicall
  File "C:\Development\Python\Python39\lib\site-packages\pluggy\_manager.py", line 112 in _hookexec
  File "C:\Development\Python\Python39\lib\site-packages\pluggy\_hooks.py", line 433 in __call__
  File "C:\Development\Python\Python39\lib\site-packages\_pytest\main.py", line 324 in _main
  File "C:\Development\Python\Python39\lib\site-packages\_pytest\main.py", line 270 in wrap_session
  File "C:\Development\Python\Python39\lib\site-packages\_pytest\main.py", line 317 in pytest_cmdline_main
  File "C:\Development\Python\Python39\lib\site-packages\pluggy\_callers.py", line 80 in _multicall
  File "C:\Development\Python\Python39\lib\site-packages\pluggy\_manager.py", line 112 in _hookexec
  File "C:\Development\Python\Python39\lib\site-packages\pluggy\_hooks.py", line 433 in __call__
  File "C:\Development\Python\Python39\lib\site-packages\_pytest\config\__init__.py", line 166 in main
  File "C:\Development\Python\Python39\lib\site-packages\_pytest\config\__init__.py", line 189 in console_main
  File "C:\Development\Python\Python39\lib\site-packages\pytest\__main__.py", line 5 in <module>
  File "C:\Development\Python\Python39\lib\runpy.py", line 87 in _run_code
  File "C:\Development\Python\Python39\lib\runpy.py", line 197 in _run_module_as_main
```

CUDA 11.5:

https://ci.preferred.jp/cupy.linux.cuda115/136430/

```
01:53:49.779070 STDOUT 1313]	FAILED cupyx_tests/test_cusparse.py::TestSpmm::test_spmm[_param_8_{dims=(2, 3, 4), dtype=float32, format='coo', transa=False, transb=False}]	
01:53:49.779082 STDOUT 1313]	FAILED cupyx_tests/test_cusparse.py::TestSpmm::test_spmm[_param_9_{dims=(2, 3, 4), dtype=float32, format='coo', transa=False, transb=True}]	
01:53:49.779088 STDOUT 1313]	FAILED cupyx_tests/test_cusparse.py::TestSpmm::test_spmm[_param_20_{dims=(2, 3, 4), dtype=float64, format='coo', transa=False, transb=False}]	
01:53:49.779100 STDOUT 1313]	FAILED cupyx_tests/test_cusparse.py::TestSpmm::test_spmm[_param_21_{dims=(2, 3, 4), dtype=float64, format='coo', transa=False, transb=True}]	
01:53:49.779120 STDOUT 1313]	FAILED cupyx_tests/test_cusparse.py::TestSpmm::test_spmm[_param_33_{dims=(2, 3, 4), dtype=complex64, format='coo', transa=False, transb=True}]	
01:53:49.779126 STDOUT 1313]	FAILED cupyx_tests/test_cusparse.py::TestSpmm::test_spmm[_param_44_{dims=(2, 3, 4), dtype=complex128, format='coo', transa=False, transb=False}]	
01:53:49.779141 STDOUT 1313]	FAILED cupyx_tests/test_cusparse.py::TestSpmm::test_spmm[_param_45_{dims=(2, 3, 4), dtype=complex128, format='coo', transa=False, transb=True}]	
01:53:49.779159 STDOUT 1313]	FAILED cupyx_tests/test_cusparse.py::TestSpmm::test_spmm[_param_93_{dims=(3, 4, 2), dtype=complex128, format='coo', transa=False, transb=True}]	
01:53:49.779174 STDOUT 1313]	FAILED cupyx_tests/test_cusparse.py::TestSpmm::test_spmm_with_c[_param_8_{dims=(2, 3, 4), dtype=float32, format='coo', transa=False, transb=False}]	
01:53:49.779192 STDOUT 1313]	FAILED cupyx_tests/test_cusparse.py::TestSpmm::test_spmm_with_c[_param_9_{dims=(2, 3, 4), dtype=float32, format='coo', transa=False, transb=True}]	
01:53:49.779211 STDOUT 1313]	FAILED cupyx_tests/test_cusparse.py::TestSpmm::test_spmm_with_c[_param_20_{dims=(2, 3, 4), dtype=float64, format='coo', transa=False, transb=False}]	
01:53:49.779217 STDOUT 1313]	FAILED cupyx_tests/test_cusparse.py::TestSpmm::test_spmm_with_c[_param_21_{dims=(2, 3, 4), dtype=float64, format='coo', transa=False, transb=True}]	
01:53:49.779231 STDOUT 1313]	FAILED cupyx_tests/test_cusparse.py::TestSpmm::test_spmm_with_c[_param_33_{dims=(2, 3, 4), dtype=complex64, format='coo', transa=False, transb=True}]	
01:53:49.779244 STDOUT 1313]	FAILED cupyx_tests/test_cusparse.py::TestSpmm::test_spmm_with_c[_param_44_{dims=(2, 3, 4), dtype=complex128, format='coo', transa=False, transb=False}]	
01:53:49.779261 STDOUT 1313]	FAILED cupyx_tests/test_cusparse.py::TestSpmm::test_spmm_with_c[_param_45_{dims=(2, 3, 4), dtype=complex128, format='coo', transa=False, transb=True}]	
01:53:49.779277 STDOUT 1313]	FAILED cupyx_tests/test_cusparse.py::TestSpmm::test_spmm_with_c[_param_57_{dims=(3, 4, 2), dtype=float32, format='coo', transa=False, transb=True}]	
01:53:49.779288 STDOUT 1313]	FAILED cupyx_tests/test_cusparse.py::TestSpmm::test_spmm_with_c[_param_69_{dims=(3, 4, 2), dtype=float64, format='coo', transa=False, transb=True}]	
```

CUDA 11.6:

https://ci.preferred.jp/cupy.linux.cuda116/136437/

```
01:58:36.577938 STDOUT 1304]	FAILED cupyx_tests/test_cusparse.py::TestSpmm::test_spmm[_param_0_{dims=(2, 3, 4), dtype=float32, format='csr', transa=False, transb=False}]	
01:58:36.577945 STDOUT 1304]	FAILED cupyx_tests/test_cusparse.py::TestSpmm::test_spmm[_param_6_{dims=(2, 3, 4), dtype=float32, format='csc', transa=True, transb=False}]	
01:58:36.577961 STDOUT 1304]	FAILED cupyx_tests/test_cusparse.py::TestSpmm::test_spmm[_param_12_{dims=(2, 3, 4), dtype=float64, format='csr', transa=False, transb=False}]	
01:58:36.577966 STDOUT 1304]	FAILED cupyx_tests/test_cusparse.py::TestSpmm::test_spmm[_param_13_{dims=(2, 3, 4), dtype=float64, format='csr', transa=False, transb=True}]	
01:58:36.577983 STDOUT 1304]	FAILED cupyx_tests/test_cusparse.py::TestSpmm::test_spmm[_param_18_{dims=(2, 3, 4), dtype=float64, format='csc', transa=True, transb=False}]	
01:58:36.577995 STDOUT 1304]	FAILED cupyx_tests/test_cusparse.py::TestSpmm::test_spmm[_param_19_{dims=(2, 3, 4), dtype=float64, format='csc', transa=True, transb=True}]	
01:58:36.578004 STDOUT 1304]	FAILED cupyx_tests/test_cusparse.py::TestSpmm::test_spmm[_param_24_{dims=(2, 3, 4), dtype=complex64, format='csr', transa=False, transb=False}]	
01:58:36.578018 STDOUT 1304]	FAILED cupyx_tests/test_cusparse.py::TestSpmm::test_spmm[_param_25_{dims=(2, 3, 4), dtype=complex64, format='csr', transa=False, transb=True}]	
01:58:36.578032 STDOUT 1304]	FAILED cupyx_tests/test_cusparse.py::TestSpmm::test_spmm[_param_30_{dims=(2, 3, 4), dtype=complex64, format='csc', transa=True, transb=False}]	
01:58:36.578036 STDOUT 1304]	FAILED cupyx_tests/test_cusparse.py::TestSpmm::test_spmm[_param_31_{dims=(2, 3, 4), dtype=complex64, format='csc', transa=True, transb=True}]	
01:58:36.578046 STDOUT 1304]	FAILED cupyx_tests/test_cusparse.py::TestSpmm::test_spmm[_param_36_{dims=(2, 3, 4), dtype=complex128, format='csr', transa=False, transb=False}]	
01:58:36.578057 STDOUT 1304]	FAILED cupyx_tests/test_cusparse.py::TestSpmm::test_spmm[_param_37_{dims=(2, 3, 4), dtype=complex128, format='csr', transa=False, transb=True}]	
01:58:36.578064 STDOUT 1304]	FAILED cupyx_tests/test_cusparse.py::TestSpmm::test_spmm[_param_42_{dims=(2, 3, 4), dtype=complex128, format='csc', transa=True, transb=False}]	
01:58:36.578071 STDOUT 1304]	FAILED cupyx_tests/test_cusparse.py::TestSpmm::test_spmm[_param_43_{dims=(2, 3, 4), dtype=complex128, format='csc', transa=True, transb=True}]	
01:58:36.578096 STDOUT 1304]	FAILED cupyx_tests/test_cusparse.py::TestSpmm::test_spmm[_param_54_{dims=(3, 4, 2), dtype=float32, format='csc', transa=True, transb=False}]	
01:58:36.578103 STDOUT 1304]	FAILED cupyx_tests/test_cusparse.py::TestSpmm::test_spmm[_param_66_{dims=(3, 4, 2), dtype=float64, format='csc', transa=True, transb=False}]	
01:58:36.578118 STDOUT 1304]	FAILED cupyx_tests/test_cusparse.py::TestSpmm::test_spmm[_param_84_{dims=(3, 4, 2), dtype=complex128, format='csr', transa=False, transb=False}]	
01:58:36.578127 STDOUT 1304]	FAILED cupyx_tests/test_cusparse.py::TestSpmm::test_spmm[_param_90_{dims=(3, 4, 2), dtype=complex128, format='csc', transa=True, transb=False}]	
01:58:36.578131 STDOUT 1304]	FAILED cupyx_tests/test_cusparse.py::TestSpmm::test_spmm_with_c[_param_0_{dims=(2, 3, 4), dtype=float32, format='csr', transa=False, transb=False}]	
01:58:36.578136 STDOUT 1304]	FAILED cupyx_tests/test_cusparse.py::TestSpmm::test_spmm_with_c[_param_6_{dims=(2, 3, 4), dtype=float32, format='csc', transa=True, transb=False}]	
01:58:36.578144 STDOUT 1304]	FAILED cupyx_tests/test_cusparse.py::TestSpmm::test_spmm_with_c[_param_12_{dims=(2, 3, 4), dtype=float64, format='csr', transa=False, transb=False}]	
01:58:36.578148 STDOUT 1304]	FAILED cupyx_tests/test_cusparse.py::TestSpmm::test_spmm_with_c[_param_13_{dims=(2, 3, 4), dtype=float64, format='csr', transa=False, transb=True}]	
01:58:36.578156 STDOUT 1304]	FAILED cupyx_tests/test_cusparse.py::TestSpmm::test_spmm_with_c[_param_18_{dims=(2, 3, 4), dtype=float64, format='csc', transa=True, transb=False}]	
01:58:36.610392 STDOUT 1304]	FAILED cupyx_tests/test_cusparse.py::TestSpmm::test_spmm_with_c[_param_19_{dims=(2, 3, 4), dtype=float64, format='csc', transa=True, transb=True}]	
01:58:36.610409 STDOUT 1304]	FAILED cupyx_tests/test_cusparse.py::TestSpmm::test_spmm_with_c[_param_24_{dims=(2, 3, 4), dtype=complex64, format='csr', transa=False, transb=False}]	
01:58:36.610446 STDOUT 1304]	FAILED cupyx_tests/test_cusparse.py::TestSpmm::test_spmm_with_c[_param_25_{dims=(2, 3, 4), dtype=complex64, format='csr', transa=False, transb=True}]	
01:58:36.610474 STDOUT 1304]	FAILED cupyx_tests/test_cusparse.py::TestSpmm::test_spmm_with_c[_param_30_{dims=(2, 3, 4), dtype=complex64, format='csc', transa=True, transb=False}]	
01:58:36.610484 STDOUT 1304]	FAILED cupyx_tests/test_cusparse.py::TestSpmm::test_spmm_with_c[_param_31_{dims=(2, 3, 4), dtype=complex64, format='csc', transa=True, transb=True}]	
01:58:36.610495 STDOUT 1304]	FAILED cupyx_tests/test_cusparse.py::TestSpmm::test_spmm_with_c[_param_36_{dims=(2, 3, 4), dtype=complex128, format='csr', transa=False, transb=False}]	
01:58:36.610521 STDOUT 1304]	FAILED cupyx_tests/test_cusparse.py::TestSpmm::test_spmm_with_c[_param_37_{dims=(2, 3, 4), dtype=complex128, format='csr', transa=False, transb=True}]	
01:58:36.610527 STDOUT 1304]	FAILED cupyx_tests/test_cusparse.py::TestSpmm::test_spmm_with_c[_param_42_{dims=(2, 3, 4), dtype=complex128, format='csc', transa=True, transb=False}]	
01:58:36.610556 STDOUT 1304]	FAILED cupyx_tests/test_cusparse.py::TestSpmm::test_spmm_with_c[_param_43_{dims=(2, 3, 4), dtype=complex128, format='csc', transa=True, transb=True}]	
01:58:36.610570 STDOUT 1304]	FAILED cupyx_tests/test_cusparse.py::TestSpmm::test_spmm_with_c[_param_48_{dims=(3, 4, 2), dtype=float32, format='csr', transa=False, transb=False}]	
01:58:36.610577 STDOUT 1304]	FAILED cupyx_tests/test_cusparse.py::TestSpmm::test_spmm_with_c[_param_54_{dims=(3, 4, 2), dtype=float32, format='csc', transa=True, transb=False}]	
01:58:36.610587 STDOUT 1304]	FAILED cupyx_tests/test_cusparse.py::TestSpmm::test_spmm_with_c[_param_66_{dims=(3, 4, 2), dtype=float64, format='csc', transa=True, transb=False}]	
01:58:36.610608 STDOUT 1304]	FAILED cupyx_tests/scipy_tests/sparse_tests/test_csr.py::TestCsrMatrixScipyComparison::test_dot_dense_matrix[_param_3_{dtype=float32, make_method='_make_duplicate'}]	
01:58:36.610611 STDOUT 1304]	FAILED cupyx_tests/scipy_tests/sparse_tests/test_csr.py::TestCsrMatrixScipyComparison::test_dot_dense_matrix[_param_8_{dtype=float64, make_method='_make_duplicate'}]	
01:58:36.610619 STDOUT 1304]	FAILED cupyx_tests/scipy_tests/sparse_tests/test_csr.py::TestCsrMatrixScipyComparison::test_dot_dense_matrix[_param_13_{dtype=complex64, make_method='_make_duplicate'}]	
01:58:36.610627 STDOUT 1304]	FAILED cupyx_tests/scipy_tests/sparse_tests/test_csr.py::TestCsrMatrixScipyComparison::test_dot_dense_matrix[_param_18_{dtype=complex128, make_method='_make_duplicate'}]	
01:58:36.610633 STDOUT 1304]	FAILED cupyx_tests/scipy_tests/sparse_tests/test_csr.py::TestCsrMatrixScipyComparison::test_mul_dense_matrix[_param_3_{dtype=float32, make_method='_make_duplicate'}]	
01:58:36.610646 STDOUT 1304]	FAILED cupyx_tests/scipy_tests/sparse_tests/test_csr.py::TestCsrMatrixScipyComparison::test_mul_dense_matrix[_param_8_{dtype=float64, make_method='_make_duplicate'}]	
01:58:36.610660 STDOUT 1304]	FAILED cupyx_tests/scipy_tests/sparse_tests/test_csr.py::TestCsrMatrixScipyComparison::test_mul_dense_matrix[_param_13_{dtype=complex64, make_method='_make_duplicate'}]	
01:58:36.610672 STDOUT 1304]	FAILED cupyx_tests/scipy_tests/sparse_tests/test_csr.py::TestCsrMatrixScipyComparison::test_mul_dense_matrix[_param_18_{dtype=complex128, make_method='_make_duplicate'}]	
```