### PR TITLE
[v12] Allow specifying Docker repository for CI images

### DIFF
--- a/.pfnci/generate.py
+++ b/.pfnci/generate.py
@@ -57,7 +57,8 @@ class LinuxGenerator:
         os_name, os_version = matrix.os.split(':')
         if matrix.cuda is not None:
             full_ver = self.schema['cuda'][matrix.cuda]['full_version']
-            base_image = f'nvidia/cuda:{full_ver}-devel-{os_name}{os_version}'
+            repo = self.schema['cuda'][matrix.cuda]['repository']
+            base_image = f'{repo}:{full_ver}-devel-{os_name}{os_version}'
         elif matrix.rocm is not None:
             full_ver = self.schema['rocm'][matrix.rocm]['full_version']
             base_image = f'rocm/dev-{os_name}-{os_version}:{full_ver}'

--- a/.pfnci/linux/tests/cuda102.Dockerfile
+++ b/.pfnci/linux/tests/cuda102.Dockerfile
@@ -1,5 +1,5 @@
 # AUTO GENERATED: DO NOT EDIT!
-ARG BASE_IMAGE="nvidia/cuda:10.2-devel-ubuntu18.04"
+ARG BASE_IMAGE="cupy/nvidia-cuda:10.2-devel-ubuntu18.04"
 FROM ${BASE_IMAGE}
 
 RUN export DEBIAN_FRONTEND=noninteractive && \

--- a/.pfnci/linux/tests/cuda102.multi.Dockerfile
+++ b/.pfnci/linux/tests/cuda102.multi.Dockerfile
@@ -1,5 +1,5 @@
 # AUTO GENERATED: DO NOT EDIT!
-ARG BASE_IMAGE="nvidia/cuda:10.2-devel-ubuntu18.04"
+ARG BASE_IMAGE="cupy/nvidia-cuda:10.2-devel-ubuntu18.04"
 FROM ${BASE_IMAGE}
 
 RUN export DEBIAN_FRONTEND=noninteractive && \

--- a/.pfnci/schema.yaml
+++ b/.pfnci/schema.yaml
@@ -28,35 +28,50 @@ os:
 # The platform to test with.
 # `cuda` and `rocm` are mutually exclusive; when one is set, the other must be null.
 # `full_version` is the version used in base Docker images.
+# `repository` is the Docker repository. (CUDA only)
+# `packages` is the list of DEB/RPM packages to be installed. (ROCm only)
 # When adding a new CUDA version, you may also need to add the version to the
 # list of supported CUDA versions in the optional libraries.
 cuda:
   null:
     full_version: null
+    repository: null
   "10.2":
     full_version: "10.2"
+    repository: "cupy/nvidia-cuda"
   "11.0":
     full_version: "11.0.3"
+    repository: "nvidia/cuda"
   "11.1":
     full_version: "11.1.1"
+    repository: "nvidia/cuda"
   "11.2":
     full_version: "11.2.2"
+    repository: "nvidia/cuda"
   "11.3":
     full_version: "11.3.1"
+    repository: "nvidia/cuda"
   "11.4":
     full_version: "11.4.3"
+    repository: "nvidia/cuda"
   "11.5":
     full_version: "11.5.2"
+    repository: "nvidia/cuda"
   "11.6":
     full_version: "11.6.2"
+    repository: "nvidia/cuda"
   "11.7":
     full_version: "11.7.1"
+    repository: "nvidia/cuda"
   "11.8":
     full_version: "11.8.0"
+    repository: "nvidia/cuda"
   "12.0":
     full_version: "12.0.1"
+    repository: "nvidia/cuda"
   "12.1":
     full_version: "12.1.1"
+    repository: "nvidia/cuda"
 rocm:
   null:
     full_version: null


### PR DESCRIPTION
This is a manual backport of #7689.

As CUDA 10.2 docker image has been removed (#7548), I've made a mirror repository at https://hub.docker.com/r/cupy/nvidia-cuda/tags. The repository is only for CuPy CI, and only minimal copies of images required for CI are mirrored.