### PR TITLE
Add env var to disable RPATH

### DIFF
--- a/install/cupy_builder/_context.py
+++ b/install/cupy_builder/_context.py
@@ -45,6 +45,9 @@ class Context:
         self.annotate: bool = cmdopts.cupy_coverage
         self.use_stub: bool = cmdopts.cupy_no_cuda
 
+        if _get_env_bool('CUPY_INSTALL_NO_RPATH', False, _env):
+            self.no_rpath = True
+
         if os.environ.get('READTHEDOCS', None) == 'True':
             self.use_stub = True
 


### PR DESCRIPTION
Introduces the env var `CUPY_INSTALL_NO_RPATH=1` which disables RPATH embedding.
RPATH embedding is disabled in wheels through `python setup.py bdist_wheel --cupy-no-rpath` argument, but I'd like to add an option to disable RPATH through env var so that it can be used when `pip install -e`.

By disabling RPATH, locally-built CuPy binaries can utilize CUDA enhanced compatibility. This is very handy when testing the local build against various CUDA versions, e.g.:

```
LD_LIBRARY_PATH=/usr/local/cuda-11.3.0/lib64 python -c 'import cupy; cupy.show_config()'
LD_LIBRARY_PATH=/usr/local/cuda-11.4.0/lib64 python -c 'import cupy; cupy.show_config()'
```

This option is for developers, and thus I'm thinking of keeping this undocumented.
