### PR TITLE
Update pylibcugraph weakly connected components call

### DIFF
--- a/.pfnci/linux/tests/cuda-rapids.Dockerfile
+++ b/.pfnci/linux/tests/cuda-rapids.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE="rapidsai/rapidsai-core-dev:23.06-cuda11.8-runtime-ubuntu22.04-py3.10"
+ARG BASE_IMAGE="rapidsai/rapidsai-core-dev:23.06-cuda11.8-devel-ubuntu22.04-py3.10"
 FROM ${BASE_IMAGE}
 
 RUN export DEBIAN_FRONTEND=noninteractive && \

--- a/.pfnci/linux/tests/cuda-rapids.Dockerfile
+++ b/.pfnci/linux/tests/cuda-rapids.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE="rapidsai/rapidsai-core-dev:22.10-cuda11.5-devel-ubuntu20.04-py3.9"
+ARG BASE_IMAGE="rapidsai/rapidsai-core-dev:23.06-cuda11.8-runtime-ubuntu22.04-py3.10"
 FROM ${BASE_IMAGE}
 
 RUN export DEBIAN_FRONTEND=noninteractive && \

--- a/cupyx/scipy/sparse/csgraph/_traversal.py
+++ b/cupyx/scipy/sparse/csgraph/_traversal.py
@@ -51,9 +51,9 @@ def connected_components(csgraph, directed=True, connection='weak',
         raise ValueError('graph should be a square array')
     if csgraph.nnz == 0:
         return m, cupy.arange(m, dtype=csgraph.indices.dtype)
-    labels = cupy.empty(m, dtype=csgraph.indices.dtype)
 
     if connection == 'strong':
+        labels = cupy.empty(m, dtype=csgraph.indices.dtype)
         pylibcugraph.strongly_connected_components(
             offsets=csgraph.indptr, indices=csgraph.indices, weights=None,
             num_verts=m, num_edges=csgraph.nnz, labels=labels)
@@ -61,9 +61,15 @@ def connected_components(csgraph, directed=True, connection='weak',
         csgraph += csgraph.T
         if not cupyx.scipy.sparse.isspmatrix_csr(csgraph):
             csgraph = cupyx.scipy.sparse.csr_matrix(csgraph)
-        pylibcugraph.weakly_connected_components(
-            offsets=csgraph.indptr, indices=csgraph.indices, weights=None,
-            num_verts=m, num_edges=csgraph.nnz, labels=labels)
+        _, labels = pylibcugraph.weakly_connected_components(
+            resource_handle=None,
+            graph=None,
+            indices=csgraph.indices,
+            offsets=csgraph.indptr,
+            weights=None,
+            labels=None,
+            do_expensive_check=False,
+            )
         # Note: In the case of weak connection, cuGraph creates labels with a
         # start number of 1, so decrement the label number.
         labels -= 1

--- a/cupyx/scipy/sparse/csgraph/_traversal.py
+++ b/cupyx/scipy/sparse/csgraph/_traversal.py
@@ -70,9 +70,6 @@ def connected_components(csgraph, directed=True, connection='weak',
             labels=None,
             do_expensive_check=False,
             )
-        # Note: In the case of weak connection, cuGraph creates labels with a
-        # start number of 1, so decrement the label number.
-        labels -= 1
 
     count = cupy.zeros((1,), dtype=csgraph.indices.dtype)
     root_labels = cupy.empty((m,), dtype=csgraph.indices.dtype)

--- a/cupyx/scipy/sparse/csgraph/_traversal.py
+++ b/cupyx/scipy/sparse/csgraph/_traversal.py
@@ -69,7 +69,7 @@ def connected_components(csgraph, directed=True, connection='weak',
             weights=None,
             labels=None,
             do_expensive_check=False,
-            )
+        )
 
     count = cupy.zeros((1,), dtype=csgraph.indices.dtype)
     root_labels = cupy.empty((m,), dtype=csgraph.indices.dtype)

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/csgraph_tests/test_traversal.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/csgraph_tests/test_traversal.py
@@ -44,16 +44,18 @@ class TestConnectedComponents(unittest.TestCase):
             n, labels = sp.csgraph.connected_components(
                 a, directed=self.directed, connection=self.connection,
                 return_labels=self.return_labels)
-            if xp == numpy and self.directed and self.connection == 'strong':
-                # Note: Label IDs are adjusted as SciPy returns un-ordered
-                # labels in strong connection case.
-                table = xp.zeros((n,), dtype=numpy.int32) - 1
-                j = 0
-                for i in range(labels.size):
-                    if table[labels[i]] < 0:
-                        table[labels[i]] = j
-                        j = j + 1
-                    labels[i] = table[labels[i]]
+            # Note: CuPy returns un-ordered results in both strong and
+            # weak connection case while SciPy returns un-ordered labels
+            # in strong connection case therefore. Since in most cases
+            # the labels returned by both cuPy and Scipy are un-ordered
+            # therefore, always adjust the labels.
+            table = xp.zeros((n,), dtype=numpy.int32) - 1
+            j = 0
+            for i in range(labels.size):
+                if table[labels[i]] < 0:
+                    table[labels[i]] = j
+                    j = j + 1
+                labels[i] = table[labels[i]]
             return n, labels
         else:
             return sp.csgraph.connected_components(


### PR DESCRIPTION
A breaking `pylibcugraph` [PR](https://github.com/rapidsai/cugraph/pull/2866/files) updated the function signature of weakly connected components thereby breaking the weak connection of CuPy `connected components`. Furthermore, both `pylibcugraph` strongly and weakly connected components no longer returns ordered labels and the starting value is now 0. 

This PR updates the `pylibcugraph.weakly_connected_components` call in cupy `connected_components` along with the tests to always adjust labels since in most cases, the labels returned by both CuPy and SciPy are un-ordered.

closes #7672 