### PR TITLE
Fix dtype typings for basic creation functions (`cp.empty` etc.)

### DIFF
--- a/cupy/_creation/basic.py
+++ b/cupy/_creation/basic.py
@@ -4,7 +4,7 @@ import cupy
 from cupy._core.internal import _get_strides_for_order_K, _update_order_char
 
 
-def empty(shape, dtype=float, order='C'):
+def empty(shape, dtype=None, order='C'):
     """Returns an array without initializing the elements.
 
     Args:
@@ -88,7 +88,7 @@ def empty_like(a, dtype=None, order='K', subok=None, shape=None):
     return cupy.ndarray(shape, dtype, memptr, strides, order)
 
 
-def eye(N, M=None, k=0, dtype=float, order='C'):
+def eye(N, M=None, k=0, dtype=None, order='C'):
     """Returns a 2-D array with ones on the diagonals and zeros elsewhere.
 
     Args:
@@ -117,7 +117,7 @@ def eye(N, M=None, k=0, dtype=float, order='C'):
     return ret
 
 
-def identity(n, dtype=float):
+def identity(n, dtype=None):
     """Returns a 2-D identity array.
 
     It is equivalent to ``eye(n, n, dtype)``.
@@ -135,7 +135,7 @@ def identity(n, dtype=float):
     return eye(n, dtype=dtype)
 
 
-def ones(shape, dtype=float, order='C'):
+def ones(shape, dtype=None, order='C'):
     """Returns a new array of given shape and dtype, filled with ones.
 
     This function currently does not support ``order`` option.
@@ -193,7 +193,7 @@ def ones_like(a, dtype=None, order='K', subok=None, shape=None):
     return a
 
 
-def zeros(shape, dtype=float, order='C'):
+def zeros(shape, dtype=None, order='C'):
     """Returns a new array of given shape and dtype, filled with zeros.
 
     Args:


### PR DESCRIPTION
A few functions in `_creation/basic.py` assign `float` (i.e. the builtin python float) as the default value for `dtype`. This leads to type checking issues further down the line:

```python
cupy.empty(1, dtype=cupy.float32)
```

yields

```
Argument of type "float32" cannot be assigned to parameter "dtype" of type "type[float]" in function "empty"
  "float32" is incompatible with "type[float]"
  Type "float32" cannot be assigned to type "type[float]"
```

with basic typechecking enabled, as the valid arguments for `dtype` are narrowed down to values that share the type of `float`. The same goes for `cupy.ones`, `cupy.zeros` etc.

In case I didn't miss anything here, I would propose changing these occurrences of `dtype=float` to `dtype=None`, since the default argument does not make a difference: `dtype=None` will still lead to the creation of a double precision array.