### PR TITLE
Fix `github-token` used in workflow

### DIFF
--- a/.github/workflows/pr-project.yml
+++ b/.github/workflows/pr-project.yml
@@ -119,6 +119,6 @@ jobs:
         uses: actions/github-script@v6
         if: always() && steps.token.outcome == 'success'
         with:
-          github-token: ${{ steps.token.outputs.result }}
+          github-token: ${{ steps.token.outputs.token }}
           script: |
             await github.rest.apps.revokeInstallationAccessToken();


### PR DESCRIPTION
Fixes workflow error: https://github.com/cupy/cupy/actions/runs/5518147034/jobs/10062260194
