### PR TITLE
Minor updates for cuQuantum/cuTensorNet support

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -368,7 +368,7 @@ intersphinx_mapping = {
     'numpy': ('https://numpy.org/doc/stable/', None),
     'scipy': ('https://docs.scipy.org/doc/scipy/', None),
     'numba': ('https://numba.readthedocs.io/en/stable', None),
-    'cuquantum': ('https://docs.nvidia.com/cuda/cuquantum/', None),
+    'cuquantum': ('https://docs.nvidia.com/cuda/cuquantum/latest', None),
     # blocked by data-apis/array-api#428
     #'array-api': ('https://data-apis.org/array-api/2021.12/', None),
 }


### PR DESCRIPTION
1. Update link to cuQuantum docs (the old link will soon be invalidated!)
2. Restore `cupy.einsum()`'s async behavior when dispatching to cuTensorNet
3. ~~Support computing trace `ii->` with cuTensorNet~~
   - I still see issues with general singleton expressions, so I disable it for now
4. Support multi-threading (each thread will use its own handle)
5. Fix leaking the handle at shutdown

Recall that currently the CI does not test this integration, so manual testing is still required:
```
pip install cuquantum-python-cu11  # or -cu12 for CUDA 12
CUPY_ACCELERATORS=cub,cutensornet pytest tests/cupy_tests/linalg_tests/test_einsum.py
````

Please kindly backport this PR, thanks! 😅