### PR TITLE
[backport] Fix `test_fht` not to feed `cupy.ndarray` to `scipy.fft.fhtoffset`

### DIFF
--- a/tests/cupyx_tests/scipy_tests/fft_tests/test_fftlog.py
+++ b/tests/cupyx_tests/scipy_tests/fft_tests/test_fftlog.py
@@ -31,7 +31,7 @@ class TestFftlog:
 
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose(rtol=rtol, atol=atol, scipy_name='scp')
-    @testing.with_requires('numpy<1.25', 'scipy>=1.7.0')
+    @testing.with_requires('scipy>=1.7.0')
     def test_fht(self, xp, scp, dtype):
 
         # test function, analytical Hankel transform is of the same form
@@ -48,7 +48,7 @@ class TestFftlog:
         mu = self.mu
         bias = self.bias
         if self.offset == 'optimal':
-            offset = fhtoffset(dln, mu, bias)
+            offset = fhtoffset(dln.item(), mu, bias)
         else:
             offset = self.offset
 


### PR DESCRIPTION
Backport of #7643 by @asi1024