### PR TITLE
CI: remove explicit Cython installation

### DIFF
--- a/.github/workflows/pretest-rocm-test.sh
+++ b/.github/workflows/pretest-rocm-test.sh
@@ -8,7 +8,6 @@ DEBIAN_FRONTEND=noninteractive apt-get -y install python3.9-dev python3-pip
 hipconfig
 
 python3.9 -m pip install -U pip wheel
-python3.9 -m pip install cython
 
 export ROCM_HOME="/opt/rocm"
 export HCC_AMDGPU_TARGET="gfx900"

--- a/.github/workflows/pretest.yml
+++ b/.github/workflows/pretest.yml
@@ -71,7 +71,6 @@ jobs:
     - name: Build
       run: |
         pip install -U pip wheel
-        pip install cython
         READTHEDOCS=True pip install -v -e .
         ccache --max-size 0.5Gi --cleanup --show-stats
 


### PR DESCRIPTION
CI failing as Cython 3.0.0 is out. Fix the version to Cython 0.29.* for now.
