### PR TITLE
MAINT: centralize np.roots calls

### DIFF
--- a/cupyx/scipy/signal/_filter_design.py
+++ b/cupyx/scipy/signal/_filter_design.py
@@ -8,6 +8,7 @@ from cupy.polynomial.polynomial import (
 import cupyx.scipy.fft as sp_fft
 from cupyx import jit
 from cupyx.scipy._lib._util import float_factorial
+from cupyx.scipy.signal._polyutils import roots
 
 EPSILON = 2e-16
 
@@ -30,15 +31,6 @@ def _try_convert_to_int(x):
         return operator.index(value), True
     except TypeError:
         return value, False
-
-
-def roots(arr):
-    """np.roots replacement. XXX: calls into NumPy, then converts back.
-    """
-    import numpy as np
-
-    arr = cupy.asarray(arr).get()
-    return cupy.asarray(np.roots(arr))
 
 
 def findfreqs(num, den, N, kind='ba'):

--- a/cupyx/scipy/signal/_polyutils.py
+++ b/cupyx/scipy/signal/_polyutils.py
@@ -5,7 +5,6 @@ Routines for manipulating partial fraction expansions.
 import cupy
 
 
-# FIXME: remove the clone from _filter_design.py (gh-7641)
 def roots(arr):
     """np.roots replacement. XXX: calls into NumPy, then converts back.
     """


### PR DESCRIPTION
Trivial code health tweak: remove a duplicate wrapper for `np.roots`, so that all calls go through the _polyutils version. Will also be easier to remove if/when CuPy grows a general unsymmetric eigenvalue solver.