### PR TITLE
Remove incorrect `cupyx.distributed.NCCLBackend.all_gather` comment

### DIFF
--- a/cupyx/distributed/_nccl_comm.py
+++ b/cupyx/distributed/_nccl_comm.py
@@ -210,9 +210,6 @@ class NCCLBackend(_Backend):
             in_array (cupy.ndarray): array to be sent.
             out_array (cupy.ndarray): array where the result with be stored.
             count (int): Number of elements to send to each rank.
-            op (str): reduction operation, can be one of
-                ('sum', 'prod', 'min' 'max'), arrays of complex type only
-                support `'sum'`. Defaults to `'sum'`.
             stream (cupy.cuda.Stream, optional): if supported, stream to
                 perform the communication.
         """


### PR DESCRIPTION
`op` is not a supported parameter for `all_gather(in_array, out_array, count, stream=None)`

original code: https://github.com/cupy/cupy/blob/main/cupyx/distributed/_nccl_comm.py#L206