### PR TITLE
port `upfirdn` from cuSignal

### DIFF
--- a/cupyx/scipy/signal/__init__.py
+++ b/cupyx/scipy/signal/__init__.py
@@ -127,6 +127,8 @@ from cupyx.scipy.signal._wavelets import cwt  # NOQA
 
 from cupyx.scipy.signal._lti_conversion import abcd_normalize   # NOQA
 
+from cupyx.scipy.signal._upfirdn import upfirdn  # NOQA
+
 from cupyx.scipy.signal._peak_finding import find_peaks  # NOQA
 from cupyx.scipy.signal._peak_finding import peak_prominences  # NOQA
 from cupyx.scipy.signal._peak_finding import peak_widths  # NOQA

--- a/cupyx/scipy/signal/_upfirdn.py
+++ b/cupyx/scipy/signal/_upfirdn.py
@@ -283,7 +283,6 @@ def _output_len(len_h, in_len, up, down):
     return (((in_len - 1) * up + len_h) - 1) // down + 1
 
 
-
 # These three _get_* functions are vendored from
 # https://github.com/rapidsai/cusignal/blob/branch-23.08/python/cusignal/utils/helper_tools.py#L55
 def _get_max_gdx():

--- a/cupyx/scipy/signal/_upfirdn.py
+++ b/cupyx/scipy/signal/_upfirdn.py
@@ -246,7 +246,7 @@ extern "C" __global__ void __launch_bounds__( 64 )
     _cupy_upfirdn2D<thrust::complex<double>>(
         inp, inpH, h_trans_flip, up, down, axis, x_shape_a, h_per_phase, padded_len, out, outW, outH );
 }
-'''
+'''  # NOQA
 
 
 UPFIRDN_MODULE = cupy.RawModule(
@@ -368,10 +368,12 @@ class _UpFIRDn(object):
             # set up the kernel launch parameters
             threadsperblock = (8, 8)
             blocks = ceil(out.shape[0] / threadsperblock[0])
-            blockspergrid_x = blocks if blocks < _get_max_gdx() else _get_max_gdx()
+            blockspergrid_x = (
+                blocks if blocks < _get_max_gdx() else _get_max_gdx())
 
             blocks = ceil(out.shape[1] / threadsperblock[1])
-            blockspergrid_y = blocks if blocks < _get_max_gdy() else _get_max_gdy()
+            blockspergrid_y = (
+                blocks if blocks < _get_max_gdy() else _get_max_gdy())
 
             blockspergrid = (blockspergrid_x, blockspergrid_y)
 

--- a/cupyx/scipy/signal/_upfirdn.py
+++ b/cupyx/scipy/signal/_upfirdn.py
@@ -1,0 +1,461 @@
+from math import ceil
+import cupy
+
+UPFIRDN_KERNEL = r'''
+#include <cupy/complex.cuh>
+
+///////////////////////////////////////////////////////////////////////////////
+//                              UPFIRDN1D                                    //
+///////////////////////////////////////////////////////////////////////////////
+
+template<typename T>
+__device__ void _cupy_upfirdn1D( const T *__restrict__ inp,
+                                 const T *__restrict__ h_trans_flip,
+                                 const int up,
+                                 const int down,
+                                 const int axis,
+                                 const int x_shape_a,
+                                 const int h_per_phase,
+                                 const int padded_len,
+                                 T *__restrict__ out,
+                                 const int outW ) {
+
+    const int t { static_cast<int>( blockIdx.x * blockDim.x + threadIdx.x ) };
+    const int stride { static_cast<int>( blockDim.x * gridDim.x ) };
+
+    for ( size_t tid = t; tid < outW; tid += stride ) {
+
+#if ( __CUDACC_VER_MAJOR__ >= 11 ) && ( __CUDACC_VER_MINOR__ >= 2 )
+        __builtin_assume( padded_len > 0 );
+        __builtin_assume( up > 0 );
+        __builtin_assume( down > 0 );
+        __builtin_assume( tid > 0 );
+#endif
+
+        const int x_idx { static_cast<int>( ( tid * down ) / up ) % padded_len };
+        int       h_idx { static_cast<int>( ( tid * down ) % up * h_per_phase ) };
+        int       x_conv_idx { x_idx - h_per_phase + 1 };
+
+        if ( x_conv_idx < 0 ) {
+            h_idx -= x_conv_idx;
+            x_conv_idx = 0;
+        }
+
+        T temp {};
+
+        int stop = ( x_shape_a < ( x_idx + 1 ) ) ? x_shape_a : ( x_idx + 1 );
+
+        for ( int x_c = x_conv_idx; x_c < stop; x_c++ ) {
+            temp += inp[x_c] * h_trans_flip[h_idx];
+            h_idx += 1;
+        }
+        out[tid] = temp;
+    }
+}
+
+extern "C" __global__ void __launch_bounds__( 512 ) _cupy_upfirdn1D_float32( const float *__restrict__ inp,
+                                                                             const float *__restrict__ h_trans_flip,
+                                                                             const int up,
+                                                                             const int down,
+                                                                             const int axis,
+                                                                             const int x_shape_a,
+                                                                             const int h_per_phase,
+                                                                             const int padded_len,
+                                                                             float *__restrict__ out,
+                                                                             const int outW ) {
+    _cupy_upfirdn1D<float>( inp, h_trans_flip, up, down, axis, x_shape_a, h_per_phase, padded_len, out, outW );
+}
+
+extern "C" __global__ void __launch_bounds__( 512 ) _cupy_upfirdn1D_float64( const double *__restrict__ inp,
+                                                                             const double *__restrict__ h_trans_flip,
+                                                                             const int up,
+                                                                             const int down,
+                                                                             const int axis,
+                                                                             const int x_shape_a,
+                                                                             const int h_per_phase,
+                                                                             const int padded_len,
+                                                                             double *__restrict__ out,
+                                                                             const int outW ) {
+    _cupy_upfirdn1D<double>( inp, h_trans_flip, up, down, axis, x_shape_a, h_per_phase, padded_len, out, outW );
+}
+
+extern "C" __global__ void __launch_bounds__( 512 )
+    _cupy_upfirdn1D_complex64( const thrust::complex<float> *__restrict__ inp,
+                               const thrust::complex<float> *__restrict__ h_trans_flip,
+                               const int up,
+                               const int down,
+                               const int axis,
+                               const int x_shape_a,
+                               const int h_per_phase,
+                               const int padded_len,
+                               thrust::complex<float> *__restrict__ out,
+                               const int outW ) {
+    _cupy_upfirdn1D<thrust::complex<float>>(
+        inp, h_trans_flip, up, down, axis, x_shape_a, h_per_phase, padded_len, out, outW );
+}
+
+extern "C" __global__ void __launch_bounds__( 512 )
+    _cupy_upfirdn1D_complex128( const thrust::complex<double> *__restrict__ inp,
+                                const thrust::complex<double> *__restrict__ h_trans_flip,
+                                const int up,
+                                const int down,
+                                const int axis,
+                                const int x_shape_a,
+                                const int h_per_phase,
+                                const int padded_len,
+                                thrust::complex<double> *__restrict__ out,
+                                const int outW ) {
+    _cupy_upfirdn1D<thrust::complex<double>>(
+        inp, h_trans_flip, up, down, axis, x_shape_a, h_per_phase, padded_len, out, outW );
+}
+
+///////////////////////////////////////////////////////////////////////////////
+//                              UPFIRDN2D                                    //
+///////////////////////////////////////////////////////////////////////////////
+
+template<typename T>
+__device__ void _cupy_upfirdn2D( const T *__restrict__ inp,
+                                 const int inpH,
+                                 const T *__restrict__ h_trans_flip,
+                                 const int up,
+                                 const int down,
+                                 const int axis,
+                                 const int x_shape_a,
+                                 const int h_per_phase,
+                                 const int padded_len,
+                                 T *__restrict__ out,
+                                 const int outW,
+                                 const int outH ) {
+
+    const int ty { static_cast<int>( blockIdx.x * blockDim.x + threadIdx.x ) };
+    const int tx { static_cast<int>( blockIdx.y * blockDim.y + threadIdx.y ) };
+
+    const int stride_y { static_cast<int>( blockDim.x * gridDim.x ) };
+    const int stride_x { static_cast<int>( blockDim.y * gridDim.y ) };
+
+    for ( int x = tx; x < outH; x += stride_x ) {
+        for ( int y = ty; y < outW; y += stride_y ) {
+            int x_idx {};
+            int h_idx {};
+
+#if ( __CUDACC_VER_MAJOR__ >= 11 ) && ( __CUDACC_VER_MINOR__ >= 2 )
+            __builtin_assume( padded_len > 0 );
+            __builtin_assume( up > 0 );
+            __builtin_assume( down > 0 );
+#endif
+
+            if ( axis == 1 ) {
+#if ( __CUDACC_VER_MAJOR__ >= 11 ) && ( __CUDACC_VER_MINOR__ >= 2 )
+                __builtin_assume( x > 0 );
+#endif
+                x_idx = ( static_cast<int>( x * down ) / up ) % padded_len;
+                h_idx = ( x * down ) % up * h_per_phase;
+            } else {
+#if ( __CUDACC_VER_MAJOR__ >= 11 ) && ( __CUDACC_VER_MINOR__ >= 2 )
+                __builtin_assume( y > 0 );
+#endif
+                x_idx = ( static_cast<int>( y * down ) / up ) % padded_len;
+                h_idx = ( y * down ) % up * h_per_phase;
+            }
+
+            int x_conv_idx { x_idx - h_per_phase + 1 };
+            if ( x_conv_idx < 0 ) {
+                h_idx -= x_conv_idx;
+                x_conv_idx = 0;
+            }
+
+            T temp {};
+
+            int stop = ( x_shape_a < ( x_idx + 1 ) ) ? x_shape_a : ( x_idx + 1 );
+
+            for ( int x_c = x_conv_idx; x_c < stop; x_c++ ) {
+                if ( axis == 1 ) {
+                    temp += inp[y * inpH + x_c] * h_trans_flip[h_idx];
+                } else {
+                    temp += inp[x_c * inpH + x] * h_trans_flip[h_idx];
+                }
+                h_idx += 1;
+            }
+            out[y * outH + x] = temp;
+        }
+    }
+}
+
+extern "C" __global__ void __launch_bounds__( 64 ) _cupy_upfirdn2D_float32( const float *__restrict__ inp,
+                                                                            const int inpH,
+                                                                            const float *__restrict__ h_trans_flip,
+                                                                            const int up,
+                                                                            const int down,
+                                                                            const int axis,
+                                                                            const int x_shape_a,
+                                                                            const int h_per_phase,
+                                                                            const int padded_len,
+                                                                            float *__restrict__ out,
+                                                                            const int outW,
+                                                                            const int outH ) {
+    _cupy_upfirdn2D<float>(
+        inp, inpH, h_trans_flip, up, down, axis, x_shape_a, h_per_phase, padded_len, out, outW, outH );
+}
+
+extern "C" __global__ void __launch_bounds__( 64 ) _cupy_upfirdn2D_float64( const double *__restrict__ inp,
+                                                                            const int inpH,
+                                                                            const double *__restrict__ h_trans_flip,
+                                                                            const int up,
+                                                                            const int down,
+                                                                            const int axis,
+                                                                            const int x_shape_a,
+                                                                            const int h_per_phase,
+                                                                            const int padded_len,
+                                                                            double *__restrict__ out,
+                                                                            const int outW,
+                                                                            const int outH ) {
+    _cupy_upfirdn2D<double>(
+        inp, inpH, h_trans_flip, up, down, axis, x_shape_a, h_per_phase, padded_len, out, outW, outH );
+}
+
+extern "C" __global__ void __launch_bounds__( 64 )
+    _cupy_upfirdn2D_complex64( const thrust::complex<float> *__restrict__ inp,
+                               const int inpH,
+                               const thrust::complex<float> *__restrict__ h_trans_flip,
+                               const int up,
+                               const int down,
+                               const int axis,
+                               const int x_shape_a,
+                               const int h_per_phase,
+                               const int padded_len,
+                               thrust::complex<float> *__restrict__ out,
+                               const int outW,
+                               const int outH ) {
+    _cupy_upfirdn2D<thrust::complex<float>>(
+        inp, inpH, h_trans_flip, up, down, axis, x_shape_a, h_per_phase, padded_len, out, outW, outH );
+}
+
+extern "C" __global__ void __launch_bounds__( 64 )
+    _cupy_upfirdn2D_complex128( const thrust::complex<double> *__restrict__ inp,
+                                const int inpH,
+                                const thrust::complex<double> *__restrict__ h_trans_flip,
+                                const int up,
+                                const int down,
+                                const int axis,
+                                const int x_shape_a,
+                                const int h_per_phase,
+                                const int padded_len,
+                                thrust::complex<double> *__restrict__ out,
+                                const int outW,
+                                const int outH ) {
+    _cupy_upfirdn2D<thrust::complex<double>>(
+        inp, inpH, h_trans_flip, up, down, axis, x_shape_a, h_per_phase, padded_len, out, outW, outH );
+}
+'''
+
+
+UPFIRDN_MODULE = cupy.RawModule(
+    code=UPFIRDN_KERNEL, options=('-std=c++11',),
+    name_expressions=[
+        '_cupy_upfirdn1D_float32',
+        '_cupy_upfirdn1D_float64',
+        '_cupy_upfirdn1D_complex64',
+        '_cupy_upfirdn1D_complex128',
+        '_cupy_upfirdn2D_float32',
+        '_cupy_upfirdn2D_float64',
+        '_cupy_upfirdn2D_complex64',
+        '_cupy_upfirdn2D_complex128',
+    ])
+
+
+def _pad_h(h, up):
+    """Store coefficients in a transposed, flipped arrangement.
+    For example, suppose upRate is 3, and the
+    input number of coefficients is 10, represented as h[0], ..., h[9].
+    Then the internal buffer will look like this::
+       h[9], h[6], h[3], h[0],   // flipped phase 0 coefs
+       0,    h[7], h[4], h[1],   // flipped phase 1 coefs (zero-padded)
+       0,    h[8], h[5], h[2],   // flipped phase 2 coefs (zero-padded)
+    """
+    h_padlen = len(h) + (-len(h) % up)
+    h_full = cupy.zeros(h_padlen, h.dtype)
+    h_full[: len(h)] = h
+    h_full = h_full.reshape(-1, up).T[:, ::-1].ravel()
+    return h_full
+
+
+def _output_len(len_h, in_len, up, down):
+    return (((in_len - 1) * up + len_h) - 1) // down + 1
+
+
+
+# These three _get_* functions are vendored from
+# https://github.com/rapidsai/cusignal/blob/branch-23.08/python/cusignal/utils/helper_tools.py#L55
+def _get_max_gdx():
+    device_id = cupy.cuda.Device()
+    return device_id.attributes["MaxGridDimX"]
+
+
+def _get_max_gdy():
+    device_id = cupy.cuda.Device()
+    return device_id.attributes["MaxGridDimY"]
+
+
+def _get_tpb_bpg():
+    device_id = cupy.cuda.Device()
+    numSM = device_id.attributes["MultiProcessorCount"]
+    threadsperblock = 512
+    blockspergrid = numSM * 20
+
+    return threadsperblock, blockspergrid
+
+
+class _UpFIRDn(object):
+    def __init__(self, h, x_dtype, up, down):
+        """Helper for resampling"""
+        h = cupy.asarray(h)
+        if h.ndim != 1 or h.size == 0:
+            raise ValueError("h must be 1D with non-zero length")
+
+        self._output_type = cupy.result_type(h.dtype, x_dtype, cupy.float32)
+        h = cupy.asarray(h, self._output_type)
+        self._up = int(up)
+        self._down = int(down)
+        if self._up < 1 or self._down < 1:
+            raise ValueError("Both up and down must be >= 1")
+        # This both transposes, and "flips" each phase for filtering
+        self._h_trans_flip = _pad_h(h, self._up)
+        self._h_trans_flip = cupy.asarray(self._h_trans_flip)
+        self._h_trans_flip = cupy.ascontiguousarray(self._h_trans_flip)
+        self._h_len_orig = len(h)
+
+    def apply_filter(
+        self,
+        x,
+        axis,
+    ):
+        """Apply the prepared filter to the specified axis of a nD signal x"""
+
+        x = cupy.asarray(x, self._output_type)
+
+        output_len = _output_len(
+            self._h_len_orig, x.shape[axis], self._up, self._down)
+        output_shape = list(x.shape)
+        output_shape[axis] = output_len
+        out = cupy.empty(output_shape, dtype=self._output_type, order="C")
+        axis = axis % x.ndim
+
+        # Precompute variables on CPU
+        x_shape_a = x.shape[axis]
+        h_per_phase = len(self._h_trans_flip) // self._up
+        padded_len = x.shape[axis] + (len(self._h_trans_flip) // self._up) - 1
+
+        if out.ndim == 1:
+
+            threadsperblock, blockspergrid = _get_tpb_bpg()
+
+            kernel = UPFIRDN_MODULE.get_function(
+                f'_cupy_upfirdn1D_{out.dtype.name}')
+            kernel(((x.shape[0] + 128 - 1) // 128,), (128,),
+                   (x,
+                    self._h_trans_flip,
+                    self._up,
+                    self._down,
+                    axis,
+                    x_shape_a,
+                    h_per_phase,
+                    padded_len,
+                    out,
+                    out.shape[0]
+                    )
+                   )
+
+        elif out.ndim == 2:
+            # set up the kernel launch parameters
+            threadsperblock = (8, 8)
+            blocks = ceil(out.shape[0] / threadsperblock[0])
+            blockspergrid_x = blocks if blocks < _get_max_gdx() else _get_max_gdx()
+
+            blocks = ceil(out.shape[1] / threadsperblock[1])
+            blockspergrid_y = blocks if blocks < _get_max_gdy() else _get_max_gdy()
+
+            blockspergrid = (blockspergrid_x, blockspergrid_y)
+
+            # do computations
+            kernel = UPFIRDN_MODULE.get_function(
+                f'_cupy_upfirdn2D_{out.dtype.name}')
+            kernel(threadsperblock, blockspergrid,
+                   (x,
+                    x.shape[1],
+                    self._h_trans_flip,
+                    self._up,
+                    self._down,
+                    axis,
+                    x_shape_a,
+                    h_per_phase,
+                    padded_len,
+                    out,
+                    out.shape[0],
+                    out.shape[1]
+                    )
+                   )
+        else:
+            raise NotImplementedError("upfirdn() requires ndim <= 2")
+
+        return out
+
+
+def upfirdn(
+    h,
+    x,
+    up=1,
+    down=1,
+    axis=-1,
+    mode=None,
+    cval=0
+):
+    """
+    Upsample, FIR filter, and downsample.
+
+    Parameters
+    ----------
+    h : array_like
+        1-dimensional FIR (finite-impulse response) filter coefficients.
+    x : array_like
+        Input signal array.
+    up : int, optional
+        Upsampling rate. Default is 1.
+    down : int, optional
+        Downsampling rate. Default is 1.
+    axis : int, optional
+        The axis of the input data array along which to apply the
+        linear filter. The filter is applied to each subarray along
+        this axis. Default is -1.
+
+    Returns
+    -------
+    y : ndarray
+        The output signal array. Dimensions will be the same as `x` except
+        for along `axis`, which will change size according to the `h`,
+        `up`,  and `down` parameters.
+
+    Notes
+    -----
+    The algorithm is an implementation of the block diagram shown on page 129
+    of the Vaidyanathan text [1]_ (Figure 4.3-8d).
+
+    The direct approach of upsampling by factor of P with zero insertion,
+    FIR filtering of length ``N``, and downsampling by factor of Q is
+    O(N*Q) per output sample. The polyphase implementation used here is
+    O(N/P).
+
+    See Also
+    --------
+    scipy.signal.upfirdn
+
+    References
+    ----------
+    .. [1] P. P. Vaidyanathan, Multirate Systems and Filter Banks,
+       Prentice Hall, 1993.
+    """
+    if mode is not None or cval != 0:
+        raise NotImplementedError(f"{mode = } and {cval =} not implemented.")
+
+    ufd = _UpFIRDn(h, x.dtype, up, down)
+    # This is equivalent to (but faster than) using cp.apply_along_axis
+    return ufd.apply_filter(x, axis)

--- a/cupyx/scipy/signal/_upfirdn.py
+++ b/cupyx/scipy/signal/_upfirdn.py
@@ -1,3 +1,31 @@
+"""
+upfirdn implementation.
+
+Functions defined here were ported directly from cuSignal under
+terms of the MIT license, under the following notice:
+
+Copyright (c) 2019-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+"""
+
 from math import ceil
 import cupy
 

--- a/cupyx/scipy/signal/_upfirdn.py
+++ b/cupyx/scipy/signal/_upfirdn.py
@@ -427,6 +427,10 @@ def upfirdn(
         The axis of the input data array along which to apply the
         linear filter. The filter is applied to each subarray along
         this axis. Default is -1.
+    mode : str, optional
+        This parameter is not implemented.
+    cval : float, optional
+        This parameter is not implemented.
 
     Returns
     -------

--- a/docs/source/reference/scipy_signal.rst
+++ b/docs/source/reference/scipy_signal.rst
@@ -62,6 +62,7 @@ Filtering
    detrend
    hilbert
    hilbert2
+   upfirdn
 
 
 Filter design

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_upfirdn.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_upfirdn.py
@@ -264,7 +264,8 @@ class TestUpfirdn:
     @pytest.mark.parametrize('case', ['2D', '2D_noncontig'])
     @pytest.mark.parametrize('axis', [0, 1, -1])
     @testing.numpy_cupy_allclose(scipy_name='scp')
-    def test_vs_naive_delta_2D(self, axis, x_dtype, h, up, down, case, xp, scp):
+    def test_vs_naive_delta_2D(self, axis, x_dtype, h, up, down,
+                               case, xp, scp):
         x, h = make_case_2D(up, down, h, x_dtype, case)
         x = xp.asarray(x)
         h = xp.asarray(h)

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_upfirdn.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_upfirdn.py
@@ -57,63 +57,6 @@ def upfirdn_naive(x, h, up=1, down=1):
     return out
 
 
-'''
-class UpFIRDnCase:
-    """Test _UpFIRDn object"""
-
-    def __init__(self, up, down, h, x_dtype):
-        self.up = up
-        self.down = down
-        self.h = np.atleast_1d(h)
-        self.x_dtype = x_dtype
-        self.rng = np.random.RandomState(17)
-
-    def __call__(self):
-        # tiny signal
-        self.scrub(np.ones(1, self.x_dtype))
-        # ones
-        self.scrub(np.ones(10, self.x_dtype))  # ones
-        # randn
-        x = self.rng.randn(10).astype(self.x_dtype)
-        if self.x_dtype in (np.complex64, np.complex128):
-            x += 1j * self.rng.randn(10)
-        self.scrub(x)
-        # ramp
-        self.scrub(np.arange(10).astype(self.x_dtype))
-        # 3D, random
-        size = (2, 3, 5)
-        x = self.rng.randn(*size).astype(self.x_dtype)
-        if self.x_dtype in (np.complex64, np.complex128):
-            x += 1j * self.rng.randn(*size)
-        for axis in range(len(size)):
-            self.scrub(x, axis=axis)
-        x = x[:, ::2, 1::3].T
-        for axis in range(len(size)):
-            self.scrub(x, axis=axis)
-
-    def scrub(self, x, axis=-1):
-        yr = np.apply_along_axis(upfirdn_naive, axis, x,
-                                 self.h, self.up, self.down)
-        want_len = _output_len(len(self.h), x.shape[axis], self.up, self.down)
-        assert yr.shape[axis] == want_len
-        y = upfirdn(self.h, x, self.up, self.down, axis=axis)
-        assert y.shape[axis] == want_len
-        assert y.shape == yr.shape
-        dtypes = (self.h.dtype, x.dtype)
-        if all(d == np.complex64 for d in dtypes):
-            assert_equal(y.dtype, np.complex64)
-        elif np.complex64 in dtypes and np.float32 in dtypes:
-            assert_equal(y.dtype, np.complex64)
-        elif all(d == np.float32 for d in dtypes):
-            assert_equal(y.dtype, np.float32)
-        elif np.complex128 in dtypes or np.complex64 in dtypes:
-            assert_equal(y.dtype, np.complex128)
-        else:
-            assert_equal(y.dtype, np.float64)
-        assert_allclose(yr, y)
-'''
-
-
 def make_case(up, down, h, x_dtype, case):
     # replacement for the UpFIRDnCase class from the SciPy tests
     rng = np.random.RandomState(17)

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_upfirdn.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_upfirdn.py
@@ -1,0 +1,317 @@
+#
+# Code in this file is adapted from SciPy version 1.11. The code in SciPy
+# contains the following notice:
+#
+# Code adapted from "upfirdn" python library with permission:
+#
+# Copyright (c) 2009, Motorola, Inc
+#
+# All Rights Reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+# * Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+#
+# * Neither the name of Motorola nor the names of its contributors may be
+# used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+# IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from itertools import product
+
+import pytest
+
+import numpy as np
+
+from cupy import testing
+from cupyx.scipy.signal._upfirdn import _output_len
+
+
+def upfirdn_naive(x, h, up=1, down=1):
+    """Naive upfirdn processing in Python.
+
+    Note: arg order (x, h) differs to facilitate apply_along_axis use.
+    """
+    h = np.asarray(h)
+    out = np.zeros(len(x) * up, x.dtype)
+    out[::up] = x
+    out = np.convolve(h, out)[::down][:_output_len(len(h), len(x), up, down)]
+    return out
+
+
+'''
+class UpFIRDnCase:
+    """Test _UpFIRDn object"""
+
+    def __init__(self, up, down, h, x_dtype):
+        self.up = up
+        self.down = down
+        self.h = np.atleast_1d(h)
+        self.x_dtype = x_dtype
+        self.rng = np.random.RandomState(17)
+
+    def __call__(self):
+        # tiny signal
+        self.scrub(np.ones(1, self.x_dtype))
+        # ones
+        self.scrub(np.ones(10, self.x_dtype))  # ones
+        # randn
+        x = self.rng.randn(10).astype(self.x_dtype)
+        if self.x_dtype in (np.complex64, np.complex128):
+            x += 1j * self.rng.randn(10)
+        self.scrub(x)
+        # ramp
+        self.scrub(np.arange(10).astype(self.x_dtype))
+        # 3D, random
+        size = (2, 3, 5)
+        x = self.rng.randn(*size).astype(self.x_dtype)
+        if self.x_dtype in (np.complex64, np.complex128):
+            x += 1j * self.rng.randn(*size)
+        for axis in range(len(size)):
+            self.scrub(x, axis=axis)
+        x = x[:, ::2, 1::3].T
+        for axis in range(len(size)):
+            self.scrub(x, axis=axis)
+
+    def scrub(self, x, axis=-1):
+        yr = np.apply_along_axis(upfirdn_naive, axis, x,
+                                 self.h, self.up, self.down)
+        want_len = _output_len(len(self.h), x.shape[axis], self.up, self.down)
+        assert yr.shape[axis] == want_len
+        y = upfirdn(self.h, x, self.up, self.down, axis=axis)
+        assert y.shape[axis] == want_len
+        assert y.shape == yr.shape
+        dtypes = (self.h.dtype, x.dtype)
+        if all(d == np.complex64 for d in dtypes):
+            assert_equal(y.dtype, np.complex64)
+        elif np.complex64 in dtypes and np.float32 in dtypes:
+            assert_equal(y.dtype, np.complex64)
+        elif all(d == np.float32 for d in dtypes):
+            assert_equal(y.dtype, np.float32)
+        elif np.complex128 in dtypes or np.complex64 in dtypes:
+            assert_equal(y.dtype, np.complex128)
+        else:
+            assert_equal(y.dtype, np.float64)
+        assert_allclose(yr, y)
+'''
+
+
+def make_case(up, down, h, x_dtype, case):
+    # replacement for the UpFIRDnCase class from the SciPy tests
+    rng = np.random.RandomState(17)
+    h = np.atleast_1d(h)
+    x = {'tiny': np.ones(1, dtype=x_dtype),
+         'ones': np.ones(10, dtype=x_dtype),
+         'randn': rng.randn(10).astype(x_dtype),
+         'ramp': np.arange(10).astype(x_dtype),
+         # XXX: add 2D / 3D cases from UpFIRDnCase
+         }[case]
+
+    if 'case' == 'randn' and x_dtype in (np.complex64, np.complex128):
+        x += 1j * rng.randn(10)
+    return x, h
+
+
+def make_case_2D(up, down, h, x_dtype, case):
+    # replacement for the UpFIRDnCase class from the SciPy tests
+    rng = np.random.RandomState(17)
+    h = np.atleast_1d(h)
+
+    if case == '2D':
+        # 2D, random
+        size = (3, 5)
+        x = rng.randn(*size).astype(x_dtype)
+        if x_dtype in (np.complex64, np.complex128):
+            x += 1j * rng.randn(*size)
+        return x, h
+    elif case == '2D_noncontig':
+        # 2D, random, non-contiguous
+        size = (3, 7)
+        x = rng.randn(*size).astype(x_dtype)
+        if x_dtype in (np.complex64, np.complex128):
+            x += 1j * rng.randn(*size)
+        x = x[::2, 1::3].T
+        return x, h
+    else:
+        raise ValueError(f"unknown 2D_case, {case}.")
+
+
+_UPFIRDN_TYPES = (int, np.float32, np.complex64, float, complex)
+
+_upfirdn_modes = [
+    'constant', 'wrap', 'edge', 'smooth', 'symmetric', 'reflect',
+    'antisymmetric', 'antireflect', 'line',
+]
+
+
+@testing.with_requires('scipy')
+class TestUpfirdn:
+
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    @pytest.mark.parametrize('len_h', [1, 2, 3, 4, 5])
+    @pytest.mark.parametrize('len_x', [1, 2, 3, 4, 5])
+    def test_singleton(self, xp, scp, len_h, len_x):
+        # gh-9844: lengths producing expected outputs
+        h = xp.zeros(len_h)
+        h[len_h // 2] = 1.  # make h a delta
+        x = xp.ones(len_x)
+        y = scp.signal.upfirdn(h, x, 1, 1)
+        return y
+
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_shift_x(self, xp, scp):
+        # gh-9844: shifted x can change values?
+        y = scp.signal.upfirdn(xp.asarray([1, 1]), xp.asarray([1.]), 1, 1)
+        y1 = scp.signal.upfirdn(xp.asarray([1, 1]), xp.asarray([0., 1.]), 1, 1)
+        return y, y1
+
+    # A bunch of lengths/factors chosen because they exposed differences
+    # between the "old way" and new way of computing length, and then
+    # got `expected` from MATLAB
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    @pytest.mark.parametrize('len_h, len_x, up, down, expected', [
+        (2, 2, 5, 2, [1, 0, 0, 0]),
+        (2, 3, 6, 3, [1, 0, 1, 0, 1]),
+        (2, 4, 4, 3, [1, 0, 0, 0, 1]),
+        (3, 2, 6, 2, [1, 0, 0, 1, 0]),
+        (4, 11, 3, 5, [1, 0, 0, 1, 0, 0, 1]),
+    ])
+    def test_length_factors(self, xp, scp, len_h, len_x, up, down, expected):
+        # gh-9844: weird factors
+        h = xp.zeros(len_h)
+        h[0] = 1.
+        x = xp.ones(len_x)
+        y = scp.signal.upfirdn(h, x, up, down)
+        return y
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', atol=1e-15)
+    @pytest.mark.parametrize('down, want_len', [  # lengths from MATLAB
+        (2, 5015),
+        (11, 912),
+        (79, 127),
+    ])
+    @pytest.mark.parametrize('dtype', _UPFIRDN_TYPES)
+    def test_vs_convolve(self, xp, scp, dtype, down, want_len):
+        random_state = np.random.RandomState(17)
+        size = 10000
+
+        x = random_state.randn(size).astype(dtype)
+        if dtype in (np.complex64, np.complex128):
+            x += 1j * random_state.randn(size)
+
+        x = xp.asarray(x)
+
+        h = scp.signal.firwin(31, 1. / down, window='hamming')
+        y = scp.signal.upfirdn(h, x, up=1, down=down)
+        return y
+
+    @pytest.mark.xfail(reason="upfirdn `mode=...` not implemented")
+    @pytest.mark.parametrize(
+        'size, h_len, mode, dtype',
+        product(
+            [8],
+            [4, 5, 26],  # include cases with h_len > 2*size
+            _upfirdn_modes,
+            [np.float32, np.float64, np.complex64, np.complex128],
+        )
+    )
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_modes(self, xp, scp, size, h_len, mode, dtype):
+        random_state = np.random.RandomState(5)
+        x = random_state.randn(size).astype(dtype)
+        if dtype in (np.complex64, np.complex128):
+            x += 1j * random_state.randn(size)
+        x = xp.asarray(x)
+
+        h = xp.arange(1, 1 + h_len, dtype=x.real.dtype)
+
+        y = scp.signal.upfirdn(h, x, up=1, down=1, mode=mode)
+        return y
+
+    @pytest.mark.parametrize('x_dtype', _UPFIRDN_TYPES)
+    @pytest.mark.parametrize('h', (1., 1j))
+    @pytest.mark.parametrize('up, down', [(1, 1), (2, 2), (3, 2), (2, 3)])
+    @pytest.mark.parametrize('case', ['tiny', 'ones', 'randn', 'ramp'])
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_vs_naive_delta(self, x_dtype, h, up, down, case, xp, scp):
+        x, h = make_case(up, down, h, x_dtype, case)
+        x = xp.asarray(x)
+        h = xp.asarray(h)
+        y = scp.signal.upfirdn(h, x, up, down)
+        return y
+
+    @pytest.mark.parametrize('x_dtype', _UPFIRDN_TYPES)
+    @pytest.mark.parametrize('h', (1., 1j))
+    @pytest.mark.parametrize('up, down', [(1, 1), (2, 2), (3, 2), (2, 3)])
+    @pytest.mark.parametrize('case', ['2D', '2D_noncontig'])
+    @pytest.mark.parametrize('axis', [0, 1, -1])
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_vs_naive_delta_2D(self, axis, x_dtype, h, up, down, case, xp, scp):
+        x, h = make_case_2D(up, down, h, x_dtype, case)
+        x = xp.asarray(x)
+        h = xp.asarray(h)
+        y = scp.signal.upfirdn(h, x, up, down, axis=axis)
+        return y
+
+    @pytest.mark.parametrize('x_dtype', _UPFIRDN_TYPES)
+    @pytest.mark.parametrize('h_dtype', _UPFIRDN_TYPES)
+    @pytest.mark.parametrize('p_max, q_max',
+                             list(product((10, 100), (10, 100))))
+    @pytest.mark.parametrize('case', ['tiny', 'ones', 'randn', 'ramp'])
+    @testing.numpy_cupy_allclose(scipy_name='scp', atol=1e-7)
+    def test_vs_naive(self, xp, scp, case, x_dtype, h_dtype, p_max, q_max):
+        n_reps = 3
+        longest_h = 25
+        random_state = np.random.RandomState(17)
+        cases = []
+        for _ in range(n_reps):
+            # Randomize the up/down factors somewhat
+            p_add = q_max if p_max > q_max else 1
+            q_add = p_max if q_max > p_max else 1
+            p = random_state.randint(p_max) + p_add
+            q = random_state.randint(q_max) + q_add
+
+            # Generate random FIR coefficients
+            len_h = random_state.randint(longest_h) + 1
+            h = np.atleast_1d(random_state.randint(len_h))
+            h = h.astype(h_dtype)
+            if h_dtype == complex:
+                h += 1j * random_state.randint(len_h)
+            x, h = make_case(p, q, h, x_dtype, case)
+            x = xp.asarray(x)
+            h = xp.asarray(x)
+            y = scp.signal.upfirdn(h, x, p, q)
+            cases.append(y)
+        return cases
+
+
+def test_output_len_long_input():
+    # Regression test for scipy/gh-17375.  On Windows, a large enough input
+    # that should have been well within the capabilities of 64 bit integers
+    # would result in a 32 bit overflow because of a bug in Cython 0.29.32.
+    len_h = 1001
+    in_len = 10**8
+    up = 320
+    down = 441
+    out_len = _output_len(len_h, in_len, up, down)
+    # The expected value was computed "by hand" from the formula
+    #   (((in_len - 1) * up + len_h) - 1) // down + 1
+    assert out_len == 72562360


### PR DESCRIPTION
cross-ref gh-7403

<s>Depends on gh-7568 for windows.get_window and gh-7722 for `firwin`.
The commit history is messy, will rewrite when these two merge.</s> 

Notes:
 - This ports cuSignal code + SciPy tests.
 - cuSignal caches kernels explicitly, do not port this part; delegate to RawKernels.
 - Follow cuSignal, which does not support the full set of `scipy.signal.upfirdn` functionality: 
      - `mode` parameter is not supported
      - 1D and 2D signals only (scipy allows any nD).

A minor style point: cuSignal's C++ sources do not conform to the strict 80-symbol line length check. We can of course 
- reformat them (makes code provenance harder?)
- move them back to `.cu`  files (makes python side a trifle messier, with reading from local files etc)
- allow flake8 violations.