### PR TITLE
Revert FP16 headers from CUDA 12.2.0 to CUDA 12.1.1

### DIFF
--- a/cupy/_core/include/cupy/_cuda/README.md
+++ b/cupy/_core/include/cupy/_cuda/README.md
@@ -6,4 +6,4 @@ For CUDA 11.2+, we enable CUDA Enhanced Compatibility by hosting the fp16 header
 CUDA Toolkit release.
 
 * ``cuda-11`` contains headers from CTK 11.8.0.
-* ``cuda-12`` contains headers from CTK 12.2.0.
+* ``cuda-12`` contains headers from CTK 12.1.1.

--- a/cupy/_core/include/cupy/_cuda/cuda-12/cuda_fp16.h
+++ b/cupy/_core/include/cupy/_cuda/cuda-12/cuda_fp16.h
@@ -1,5 +1,5 @@
 /*
-* Copyright 1993-2023 NVIDIA Corporation.  All rights reserved.
+* Copyright 1993-2021 NVIDIA Corporation.  All rights reserved.
 *
 * NOTICE TO LICENSEE:
 *
@@ -49,16 +49,9 @@
 
 /**
 * \defgroup CUDA_MATH_INTRINSIC_HALF Half Precision Intrinsics
-* This section describes half precision intrinsic functions.
+* This section describes half precision intrinsic functions that are
+* only supported in device code.
 * To use these functions, include the header file \p cuda_fp16.h in your program.
-* All of the functions defined here are available in device code.
-* Some of the functions are also available to host compilers, please
-* refer to respective functions' documentation for details.
-*
-* NOTE: Aggressive floating-point optimizations performed by host or device
-* compilers may affect numeric behavior of the functions implemented in this
-* header.
-*
 * The following macros are available to help users selectively enable/disable
 * various definitions present in the header file:
 * - \p CUDA_NO_HALF - If defined, this macro will prevent the definition of
@@ -72,12 +65,6 @@
 * defined, these macros will prevent the inadvertent use of usual arithmetic
 * and comparison operators. This enforces the storage-only type semantics and
 * prevents C++ style computations on \p half and \p half2 types.
-*/
-
-/**
-* \defgroup CUDA_MATH_INTRINSIC_HALF_CONSTANTS Half Arithmetic Constants
-* \ingroup CUDA_MATH_INTRINSIC_HALF
-* To use these constants, include the header file \p cuda_fp16.h in your program.
 */
 
 /**
@@ -125,16 +112,11 @@
 #ifndef __CUDA_FP16_H__
 #define __CUDA_FP16_H__
 
-/* bring in float2, double4, etc vector types */
-#include "vector_types.h"
-/* bring in operations on vector types like: make_float2 */
-#include "vector_functions.h"
-
 #define ___CUDA_FP16_STRINGIFY_INNERMOST(x) #x
 #define __CUDA_FP16_STRINGIFY(x) ___CUDA_FP16_STRINGIFY_INNERMOST(x)
 
 #if defined(__cplusplus)
-#if defined(__CUDACC__) || defined(_NVHPC_CUDA)
+#if defined(__CUDACC__)
 #define __CUDA_FP16_DECL__ static __device__ __inline__
 #define __CUDA_HOSTDEVICE_FP16_DECL__ static __host__ __device__ __inline__
 #else
@@ -144,7 +126,37 @@
 #define __CUDA_FP16_TYPES_EXIST__
 
 /* Forward-declaration of structures defined in "cuda_fp16.hpp" */
+
+/**
+ * \brief half datatype 
+ * 
+ * \details This structure implements the datatype for storing 
+ * half-precision floating-point numbers. The structure implements 
+ * assignment operators and type conversions. 
+ * 16 bits are being used in total: 1 sign bit, 5 bits for the exponent, 
+ * and the significand is being stored in 10 bits. 
+ * The total precision is 11 bits. There are 15361 representable 
+ * numbers within the interval [0.0, 1.0], endpoints included. 
+ * On average we have log10(2**11) ~ 3.311 decimal digits. 
+ * 
+ * \internal
+ * \req IEEE 754-2008 compliant implementation of half-precision 
+ * floating-point numbers. 
+ * \endinternal
+ */
 struct __half;
+
+/**
+ * \brief half2 datatype
+ * 
+ * \details This structure implements the datatype for storing two 
+ * half-precision floating-point numbers. 
+ * The structure implements assignment operators and type conversions. 
+ * 
+ * \internal
+ * \req Vectorified version of half. 
+ * \endinternal
+ */
 struct __half2;
 
 /**
@@ -327,39 +339,6 @@ __CUDA_HOSTDEVICE_FP16_DECL__ float __low2float(const __half2 a);
 __CUDA_HOSTDEVICE_FP16_DECL__ float __high2float(const __half2 a);
 /**
 * \ingroup CUDA_MATH__HALF_MISC
-* \brief Convert a half to a signed char in round-towards-zero mode.
-*
-* \details Convert the half-precision floating-point value \p h to a signed char
-* integer in round-towards-zero mode. NaN inputs are converted to 0.
-* \param[in] h - half. Is only being read.
-*
-* \returns signed char
-* - \p h converted to a signed char.
-* \internal
-* \exception-guarantee no-throw guarantee
-* \behavior reentrant, thread safe
-* \endinternal
-*/
-__CUDA_HOSTDEVICE_FP16_DECL__ signed char __half2char_rz(const __half h);
-/**
-* \ingroup CUDA_MATH__HALF_MISC
-* \brief Convert a half to an unsigned char in round-towards-zero
-* mode.
-*
-* \details Convert the half-precision floating-point value \p h to an unsigned
-* char in round-towards-zero mode. NaN inputs are converted to 0.
-* \param[in] h - half. Is only being read.
-*
-* \returns unsigned char
-* - \p h converted to an unsigned char.
-* \internal
-* \exception-guarantee no-throw guarantee
-* \behavior reentrant, thread safe
-* \endinternal
-*/
-__CUDA_HOSTDEVICE_FP16_DECL__ unsigned char __half2uchar_rz(const __half h);
-/**
-* \ingroup CUDA_MATH__HALF_MISC
 * \brief Convert a half to a signed short integer in round-towards-zero mode.
 *
 * \details Convert the half-precision floating-point value \p h to a signed short
@@ -456,30 +435,14 @@ __CUDA_HOSTDEVICE_FP16_DECL__ long long int __half2ll_rz(const __half h);
 * \endinternal
 */
 __CUDA_HOSTDEVICE_FP16_DECL__ unsigned long long int __half2ull_rz(const __half h);
-/**
-* \ingroup CUDA_MATH__HALF_MISC
-* \brief Vector function, combines two \p __half numbers into one \p __half2 number.
-* 
-* \details Combines two input \p __half number \p x and \p y into one \p __half2 number.
-* Input \p x is stored in low 16 bits of the return value, input \p y is stored
-* in high 16 bits of the return value.
-* \param[in] x - half. Is only being read. 
-* \param[in] y - half. Is only being read. 
-* 
-* \returns __half2
-* - The \p __half2 vector with one half equal to \p x and the other to \p y. 
-* \internal
-* \exception-guarantee no-throw guarantee
-* \behavior reentrant, thread safe
-* \endinternal
-*/
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 make_half2(const __half x, const __half y);
+
+#if defined(__CUDACC__)
 /**
 * \ingroup CUDA_MATH__HALF_MISC
 * \brief Converts both components of float2 number to half precision in
 * round-to-nearest-even mode and returns \p half2 with converted values.
 * 
-* \details Converts both components of float2 to half precision in round-to-nearest-even
+* \details Converts both components of float2 to half precision in round-to-nearest
 * mode and combines the results into one \p half2 number. Low 16 bits of the
 * return value correspond to \p a.x and high 16 bits of the return value
 * correspond to \p a.y.
@@ -510,7 +473,6 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half2 __float22half2_rn(const float2 a);
 * \endinternal
 */
 __CUDA_HOSTDEVICE_FP16_DECL__ float2 __half22float2(const __half2 a);
-#if defined(__CUDACC__) || defined(_NVHPC_CUDA)
 /**
 * \ingroup CUDA_MATH__HALF_MISC
 * \brief Convert a half to a signed integer in round-to-nearest-even mode.
@@ -559,7 +521,7 @@ __CUDA_FP16_DECL__ int __half2int_rd(const __half h);
 * \endinternal
 */
 __CUDA_FP16_DECL__ int __half2int_ru(const __half h);
-#endif /* defined(__CUDACC__) || defined(_NVHPC_CUDA) */
+
 /**
 * \ingroup CUDA_MATH__HALF_MISC
 * \brief Convert a signed integer to a half in round-to-nearest-even mode.
@@ -591,7 +553,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half __int2half_rn(const int i);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __int2half_rz(const int i);
+__CUDA_FP16_DECL__ __half __int2half_rz(const int i);
 /**
 * \ingroup CUDA_MATH__HALF_MISC
 * \brief Convert a signed integer to a half in round-down mode.
@@ -607,7 +569,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half __int2half_rz(const int i);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __int2half_rd(const int i);
+__CUDA_FP16_DECL__ __half __int2half_rd(const int i);
 /**
 * \ingroup CUDA_MATH__HALF_MISC
 * \brief Convert a signed integer to a half in round-up mode.
@@ -623,8 +585,8 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half __int2half_rd(const int i);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __int2half_ru(const int i);
-#if defined(__CUDACC__) || defined(_NVHPC_CUDA)
+__CUDA_FP16_DECL__ __half __int2half_ru(const int i);
+
 /**
 * \ingroup CUDA_MATH__HALF_MISC
 * \brief Convert a half to a signed short integer in round-to-nearest-even
@@ -674,7 +636,7 @@ __CUDA_FP16_DECL__ short int __half2short_rd(const __half h);
 * \endinternal
 */
 __CUDA_FP16_DECL__ short int __half2short_ru(const __half h);
-#endif /* defined(__CUDACC__) || defined(_NVHPC_CUDA) */
+
 /**
 * \ingroup CUDA_MATH__HALF_MISC
 * \brief Convert a signed short integer to a half in round-to-nearest-even
@@ -707,7 +669,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half __short2half_rn(const short int i);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __short2half_rz(const short int i);
+__CUDA_FP16_DECL__ __half __short2half_rz(const short int i);
 /**
 * \ingroup CUDA_MATH__HALF_MISC
 * \brief Convert a signed short integer to a half in round-down mode.
@@ -723,7 +685,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half __short2half_rz(const short int i);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __short2half_rd(const short int i);
+__CUDA_FP16_DECL__ __half __short2half_rd(const short int i);
 /**
 * \ingroup CUDA_MATH__HALF_MISC
 * \brief Convert a signed short integer to a half in round-up mode.
@@ -739,8 +701,8 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half __short2half_rd(const short int i);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __short2half_ru(const short int i);
-#if defined(__CUDACC__) || defined(_NVHPC_CUDA)
+__CUDA_FP16_DECL__ __half __short2half_ru(const short int i);
+
 /**
 * \ingroup CUDA_MATH__HALF_MISC
 * \brief Convert a half to an unsigned integer in round-to-nearest-even mode.
@@ -789,7 +751,7 @@ __CUDA_FP16_DECL__ unsigned int __half2uint_rd(const __half h);
 * \endinternal
 */
 __CUDA_FP16_DECL__ unsigned int __half2uint_ru(const __half h);
-#endif /* defined(__CUDACC__) || defined(_NVHPC_CUDA) */
+
 /**
 * \ingroup CUDA_MATH__HALF_MISC
 * \brief Convert an unsigned integer to a half in round-to-nearest-even mode.
@@ -821,7 +783,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half __uint2half_rn(const unsigned int i);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __uint2half_rz(const unsigned int i);
+__CUDA_FP16_DECL__ __half __uint2half_rz(const unsigned int i);
 /**
 * \ingroup CUDA_MATH__HALF_MISC
 * \brief Convert an unsigned integer to a half in round-down mode.
@@ -837,7 +799,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half __uint2half_rz(const unsigned int i);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __uint2half_rd(const unsigned int i);
+__CUDA_FP16_DECL__ __half __uint2half_rd(const unsigned int i);
 /**
 * \ingroup CUDA_MATH__HALF_MISC
 * \brief Convert an unsigned integer to a half in round-up mode.
@@ -853,8 +815,8 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half __uint2half_rd(const unsigned int i);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __uint2half_ru(const unsigned int i);
-#if defined(__CUDACC__) || defined(_NVHPC_CUDA)
+__CUDA_FP16_DECL__ __half __uint2half_ru(const unsigned int i);
+
 /**
 * \ingroup CUDA_MATH__HALF_MISC
 * \brief Convert a half to an unsigned short integer in round-to-nearest-even
@@ -896,7 +858,7 @@ __CUDA_FP16_DECL__ unsigned short int __half2ushort_rd(const __half h);
 * - \p h converted to an unsigned short integer. 
 */
 __CUDA_FP16_DECL__ unsigned short int __half2ushort_ru(const __half h);
-#endif /* defined(__CUDACC__) || defined(_NVHPC_CUDA) */
+
 /**
 * \ingroup CUDA_MATH__HALF_MISC
 * \brief Convert an unsigned short integer to a half in round-to-nearest-even
@@ -930,7 +892,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half __ushort2half_rn(const unsigned short int i
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __ushort2half_rz(const unsigned short int i);
+__CUDA_FP16_DECL__ __half __ushort2half_rz(const unsigned short int i);
 /**
 * \ingroup CUDA_MATH__HALF_MISC
 * \brief Convert an unsigned short integer to a half in round-down mode.
@@ -946,7 +908,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half __ushort2half_rz(const unsigned short int i
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __ushort2half_rd(const unsigned short int i);
+__CUDA_FP16_DECL__ __half __ushort2half_rd(const unsigned short int i);
 /**
 * \ingroup CUDA_MATH__HALF_MISC
 * \brief Convert an unsigned short integer to a half in round-up mode.
@@ -962,8 +924,8 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half __ushort2half_rd(const unsigned short int i
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __ushort2half_ru(const unsigned short int i);
-#if defined(__CUDACC__) || defined(_NVHPC_CUDA)
+__CUDA_FP16_DECL__ __half __ushort2half_ru(const unsigned short int i);
+
 /**
 * \ingroup CUDA_MATH__HALF_MISC
 * \brief Convert a half to an unsigned 64-bit integer in round-to-nearest-even
@@ -1013,7 +975,7 @@ __CUDA_FP16_DECL__ unsigned long long int __half2ull_rd(const __half h);
 * \endinternal
 */
 __CUDA_FP16_DECL__ unsigned long long int __half2ull_ru(const __half h);
-#endif /* defined(__CUDACC__) || defined(_NVHPC_CUDA) */
+
 /**
 * \ingroup CUDA_MATH__HALF_MISC
 * \brief Convert an unsigned 64-bit integer to a half in round-to-nearest-even
@@ -1047,7 +1009,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half __ull2half_rn(const unsigned long long int 
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __ull2half_rz(const unsigned long long int i);
+__CUDA_FP16_DECL__ __half __ull2half_rz(const unsigned long long int i);
 /**
 * \ingroup CUDA_MATH__HALF_MISC
 * \brief Convert an unsigned 64-bit integer to a half in round-down mode.
@@ -1063,7 +1025,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half __ull2half_rz(const unsigned long long int 
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __ull2half_rd(const unsigned long long int i);
+__CUDA_FP16_DECL__ __half __ull2half_rd(const unsigned long long int i);
 /**
 * \ingroup CUDA_MATH__HALF_MISC
 * \brief Convert an unsigned 64-bit integer to a half in round-up mode.
@@ -1079,8 +1041,8 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half __ull2half_rd(const unsigned long long int 
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __ull2half_ru(const unsigned long long int i);
-#if defined(__CUDACC__) || defined(_NVHPC_CUDA)
+__CUDA_FP16_DECL__ __half __ull2half_ru(const unsigned long long int i);
+
 /**
 * \ingroup CUDA_MATH__HALF_MISC
 * \brief Convert a half to a signed 64-bit integer in round-to-nearest-even
@@ -1130,7 +1092,7 @@ __CUDA_FP16_DECL__ long long int __half2ll_rd(const __half h);
 * \endinternal
 */
 __CUDA_FP16_DECL__ long long int __half2ll_ru(const __half h);
-#endif /* defined(__CUDACC__) || defined(_NVHPC_CUDA) */
+
 /**
 * \ingroup CUDA_MATH__HALF_MISC
 * \brief Convert a signed 64-bit integer to a half in round-to-nearest-even
@@ -1159,7 +1121,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half __ll2half_rn(const long long int i);
 * \returns half
 * - \p i converted to half. 
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __ll2half_rz(const long long int i);
+__CUDA_FP16_DECL__ __half __ll2half_rz(const long long int i);
 /**
 * \ingroup CUDA_MATH__HALF_MISC
 * \brief Convert a signed 64-bit integer to a half in round-down mode.
@@ -1175,7 +1137,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half __ll2half_rz(const long long int i);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __ll2half_rd(const long long int i);
+__CUDA_FP16_DECL__ __half __ll2half_rd(const long long int i);
 /**
 * \ingroup CUDA_MATH__HALF_MISC
 * \brief Convert a signed 64-bit integer to a half in round-up mode.
@@ -1191,8 +1153,8 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half __ll2half_rd(const long long int i);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __ll2half_ru(const long long int i);
-#if defined(__CUDACC__) || defined(_NVHPC_CUDA)
+__CUDA_FP16_DECL__ __half __ll2half_ru(const long long int i);
+
 /**
 * \ingroup CUDA_MATH__HALF_FUNCTIONS
 * \brief Truncate input argument to the integral part.
@@ -1323,7 +1285,7 @@ __CUDA_FP16_DECL__ __half2 h2floor(const __half2 h);
 * \endinternal
 */
 __CUDA_FP16_DECL__ __half2 h2rint(const __half2 h);
-#endif /* defined(__CUDACC__) || defined(_NVHPC_CUDA) */
+
 /**
 * \ingroup CUDA_MATH__HALF_MISC
 * \brief Returns \p half2 with both halves equal to the input value.
@@ -1339,7 +1301,7 @@ __CUDA_FP16_DECL__ __half2 h2rint(const __half2 h);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __half2half2(const __half a);
+__CUDA_FP16_DECL__ __half2 __half2half2(const __half a);
 /**
 * \ingroup CUDA_MATH__HALF_MISC
 * \brief Swaps both halves of the \p half2 input.
@@ -1355,7 +1317,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half2 __half2half2(const __half a);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __lowhigh2highlow(const __half2 a);
+__CUDA_FP16_DECL__ __half2 __lowhigh2highlow(const __half2 a);
 /**
 * \ingroup CUDA_MATH__HALF_MISC
 * \brief Extracts low 16 bits from each of the two \p half2 inputs and combines
@@ -1375,7 +1337,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half2 __lowhigh2highlow(const __half2 a);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __lows2half2(const __half2 a, const __half2 b);
+__CUDA_FP16_DECL__ __half2 __lows2half2(const __half2 a, const __half2 b);
 /**
 * \ingroup CUDA_MATH__HALF_MISC
 * \brief Extracts high 16 bits from each of the two \p half2 inputs and
@@ -1395,7 +1357,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half2 __lows2half2(const __half2 a, const __half
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __highs2half2(const __half2 a, const __half2 b);
+__CUDA_FP16_DECL__ __half2 __highs2half2(const __half2 a, const __half2 b);
 /**
 * \ingroup CUDA_MATH__HALF_MISC
 * \brief Returns high 16 bits of \p half2 input.
@@ -1410,7 +1372,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half2 __highs2half2(const __half2 a, const __hal
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __high2half(const __half2 a);
+__CUDA_FP16_DECL__ __half __high2half(const __half2 a);
 /**
 * \ingroup CUDA_MATH__HALF_MISC
 * \brief Returns low 16 bits of \p half2 input.
@@ -1425,7 +1387,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half __high2half(const __half2 a);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __low2half(const __half2 a);
+__CUDA_FP16_DECL__ __half __low2half(const __half2 a);
 /**
 * \ingroup CUDA_MATH__HALF_COMPARISON
 * \brief Checks if the input \p half number is infinite.
@@ -1442,7 +1404,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half __low2half(const __half2 a);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ int __hisinf(const __half a);
+__CUDA_FP16_DECL__ int __hisinf(const __half a);
 /**
 * \ingroup CUDA_MATH__HALF_MISC
 * \brief Combines two \p half numbers into one \p half2 number.
@@ -1460,7 +1422,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ int __hisinf(const __half a);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __halves2half2(const __half a, const __half b);
+__CUDA_FP16_DECL__ __half2 __halves2half2(const __half a, const __half b);
 /**
 * \ingroup CUDA_MATH__HALF_MISC
 * \brief Extracts low 16 bits from \p half2 input.
@@ -1476,7 +1438,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half2 __halves2half2(const __half a, const __hal
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __low2half2(const __half2 a);
+__CUDA_FP16_DECL__ __half2 __low2half2(const __half2 a);
 /**
 * \ingroup CUDA_MATH__HALF_MISC
 * \brief Extracts high 16 bits from \p half2 input.
@@ -1492,7 +1454,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half2 __low2half2(const __half2 a);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __high2half2(const __half2 a);
+__CUDA_FP16_DECL__ __half2 __high2half2(const __half2 a);
 
 /**
 * \ingroup CUDA_MATH__HALF_MISC
@@ -1509,7 +1471,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half2 __high2half2(const __half2 a);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ short int __half_as_short(const __half h);
+__CUDA_FP16_DECL__ short int __half_as_short(const __half h);
 /**
 * \ingroup CUDA_MATH__HALF_MISC
 * \brief Reinterprets bits in a \p half as an unsigned short integer.
@@ -1525,7 +1487,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ short int __half_as_short(const __half h);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ unsigned short int __half_as_ushort(const __half h);
+__CUDA_FP16_DECL__ unsigned short int __half_as_ushort(const __half h);
 /**
 * \ingroup CUDA_MATH__HALF_MISC
 * \brief Reinterprets bits in a signed short integer as a \p half.
@@ -1541,7 +1503,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ unsigned short int __half_as_ushort(const __half h
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __short_as_half(const short int i);
+__CUDA_FP16_DECL__ __half __short_as_half(const short int i);
 /**
 * \ingroup CUDA_MATH__HALF_MISC
 * \brief Reinterprets bits in an unsigned short integer as a \p half.
@@ -1557,7 +1519,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half __short_as_half(const short int i);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __ushort_as_half(const unsigned short int i);
+__CUDA_FP16_DECL__ __half __ushort_as_half(const unsigned short int i);
 /**
 * \ingroup CUDA_MATH__HALF_COMPARISON
 * \brief Calculates \p half maximum of two input values.
@@ -1576,7 +1538,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half __ushort_as_half(const unsigned short int i
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __hmax(const __half a, const __half b);
+__CUDA_FP16_DECL__ __half __hmax(const __half a, const __half b);
 /**
 * \ingroup CUDA_MATH__HALF_COMPARISON
 * \brief Calculates \p half minimum of two input values.
@@ -1595,7 +1557,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half __hmax(const __half a, const __half b);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __hmin(const __half a, const __half b);
+__CUDA_FP16_DECL__ __half __hmin(const __half a, const __half b);
 /**
 * \ingroup CUDA_MATH__HALF2_COMPARISON
 * \brief Calculates \p half2 vector maximum of two inputs.
@@ -1616,7 +1578,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half __hmin(const __half a, const __half b);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hmax2(const __half2 a, const __half2 b);
+__CUDA_FP16_DECL__ __half2 __hmax2(const __half2 a, const __half2 b);
 /**
 * \ingroup CUDA_MATH__HALF2_COMPARISON
 * \brief Calculates \p half2 vector minimum of two inputs.
@@ -1637,9 +1599,8 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hmax2(const __half2 a, const __half2 b);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hmin2(const __half2 a, const __half2 b);
+__CUDA_FP16_DECL__ __half2 __hmin2(const __half2 a, const __half2 b);
 
-#if defined(__CUDACC__) || defined(_NVHPC_CUDA)
 #if !defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 300)
 #if !defined warpSize && !defined __local_warpSize
 #define warpSize    32
@@ -2012,8 +1973,8 @@ __CUDA_FP16_DECL__ void __stwt(__half2 *const ptr, const __half2 value);
 */
 __CUDA_FP16_DECL__ void __stwt(__half *const ptr, const __half value);
 #endif /*defined(__cplusplus) && ( !defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 320) )*/
-#endif /* defined(__CUDACC__) || defined(_NVHPC_CUDA) */
 
+#if !defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 530)
 /**
 * \ingroup CUDA_MATH__HALF2_COMPARISON
 * \brief Performs half2 vector if-equal comparison.
@@ -2031,7 +1992,7 @@ __CUDA_FP16_DECL__ void __stwt(__half *const ptr, const __half value);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __heq2(const __half2 a, const __half2 b);
+__CUDA_FP16_DECL__ __half2 __heq2(const __half2 a, const __half2 b);
 /**
 * \ingroup CUDA_MATH__HALF2_COMPARISON
 * \brief Performs \p half2 vector not-equal comparison.
@@ -2049,7 +2010,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half2 __heq2(const __half2 a, const __half2 b);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hne2(const __half2 a, const __half2 b);
+__CUDA_FP16_DECL__ __half2 __hne2(const __half2 a, const __half2 b);
 /**
 * \ingroup CUDA_MATH__HALF2_COMPARISON
 * \brief Performs \p half2 vector less-equal comparison.
@@ -2067,7 +2028,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hne2(const __half2 a, const __half2 b);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hle2(const __half2 a, const __half2 b);
+__CUDA_FP16_DECL__ __half2 __hle2(const __half2 a, const __half2 b);
 /**
 * \ingroup CUDA_MATH__HALF2_COMPARISON
 * \brief Performs \p half2 vector greater-equal comparison.
@@ -2085,7 +2046,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hle2(const __half2 a, const __half2 b);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hge2(const __half2 a, const __half2 b);
+__CUDA_FP16_DECL__ __half2 __hge2(const __half2 a, const __half2 b);
 /**
 * \ingroup CUDA_MATH__HALF2_COMPARISON
 * \brief Performs \p half2 vector less-than comparison.
@@ -2103,7 +2064,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hge2(const __half2 a, const __half2 b);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hlt2(const __half2 a, const __half2 b);
+__CUDA_FP16_DECL__ __half2 __hlt2(const __half2 a, const __half2 b);
 /**
 * \ingroup CUDA_MATH__HALF2_COMPARISON
 * \brief Performs \p half2 vector greater-than comparison.
@@ -2121,7 +2082,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hlt2(const __half2 a, const __half2 b);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hgt2(const __half2 a, const __half2 b);
+__CUDA_FP16_DECL__ __half2 __hgt2(const __half2 a, const __half2 b);
 /**
 * \ingroup CUDA_MATH__HALF2_COMPARISON
 * \brief Performs \p half2 vector unordered if-equal comparison.
@@ -2139,7 +2100,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hgt2(const __half2 a, const __half2 b);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hequ2(const __half2 a, const __half2 b);
+__CUDA_FP16_DECL__ __half2 __hequ2(const __half2 a, const __half2 b);
 /**
 * \ingroup CUDA_MATH__HALF2_COMPARISON
 * \brief Performs \p half2 vector unordered not-equal comparison.
@@ -2157,7 +2118,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hequ2(const __half2 a, const __half2 b);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hneu2(const __half2 a, const __half2 b);
+__CUDA_FP16_DECL__ __half2 __hneu2(const __half2 a, const __half2 b);
 /**
 * \ingroup CUDA_MATH__HALF2_COMPARISON
 * \brief Performs \p half2 vector unordered less-equal comparison.
@@ -2175,7 +2136,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hneu2(const __half2 a, const __half2 b);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hleu2(const __half2 a, const __half2 b);
+__CUDA_FP16_DECL__ __half2 __hleu2(const __half2 a, const __half2 b);
 /**
 * \ingroup CUDA_MATH__HALF2_COMPARISON
 * \brief Performs \p half2 vector unordered greater-equal comparison.
@@ -2193,7 +2154,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hleu2(const __half2 a, const __half2 b);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hgeu2(const __half2 a, const __half2 b);
+__CUDA_FP16_DECL__ __half2 __hgeu2(const __half2 a, const __half2 b);
 /**
 * \ingroup CUDA_MATH__HALF2_COMPARISON
 * \brief Performs \p half2 vector unordered less-than comparison.
@@ -2211,7 +2172,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hgeu2(const __half2 a, const __half2 b);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hltu2(const __half2 a, const __half2 b);
+__CUDA_FP16_DECL__ __half2 __hltu2(const __half2 a, const __half2 b);
 /**
 * \ingroup CUDA_MATH__HALF2_COMPARISON
 * \brief Performs \p half2 vector unordered greater-than comparison.
@@ -2229,7 +2190,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hltu2(const __half2 a, const __half2 b);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hgtu2(const __half2 a, const __half2 b);
+__CUDA_FP16_DECL__ __half2 __hgtu2(const __half2 a, const __half2 b);
 /**
 * \ingroup CUDA_MATH__HALF2_COMPARISON
 * \brief Performs half2 vector if-equal comparison.
@@ -2247,7 +2208,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hgtu2(const __half2 a, const __half2 b);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ unsigned __heq2_mask(const __half2 a, const __half2 b);
+__CUDA_FP16_DECL__ unsigned __heq2_mask(const __half2 a, const __half2 b);
 /**
 * \ingroup CUDA_MATH__HALF2_COMPARISON
 * \brief Performs \p half2 vector not-equal comparison.
@@ -2265,7 +2226,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ unsigned __heq2_mask(const __half2 a, const __half
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ unsigned __hne2_mask(const __half2 a, const __half2 b);
+__CUDA_FP16_DECL__ unsigned __hne2_mask(const __half2 a, const __half2 b);
 /**
 * \ingroup CUDA_MATH__HALF2_COMPARISON
 * \brief Performs \p half2 vector less-equal comparison.
@@ -2283,7 +2244,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ unsigned __hne2_mask(const __half2 a, const __half
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ unsigned __hle2_mask(const __half2 a, const __half2 b);
+__CUDA_FP16_DECL__ unsigned __hle2_mask(const __half2 a, const __half2 b);
 /**
 * \ingroup CUDA_MATH__HALF2_COMPARISON
 * \brief Performs \p half2 vector greater-equal comparison.
@@ -2301,7 +2262,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ unsigned __hle2_mask(const __half2 a, const __half
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ unsigned __hge2_mask(const __half2 a, const __half2 b);
+__CUDA_FP16_DECL__ unsigned __hge2_mask(const __half2 a, const __half2 b);
 /**
 * \ingroup CUDA_MATH__HALF2_COMPARISON
 * \brief Performs \p half2 vector less-than comparison.
@@ -2319,7 +2280,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ unsigned __hge2_mask(const __half2 a, const __half
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ unsigned __hlt2_mask(const __half2 a, const __half2 b);
+__CUDA_FP16_DECL__ unsigned __hlt2_mask(const __half2 a, const __half2 b);
 /**
 * \ingroup CUDA_MATH__HALF2_COMPARISON
 * \brief Performs \p half2 vector greater-than comparison.
@@ -2337,7 +2298,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ unsigned __hlt2_mask(const __half2 a, const __half
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ unsigned __hgt2_mask(const __half2 a, const __half2 b);
+__CUDA_FP16_DECL__ unsigned __hgt2_mask(const __half2 a, const __half2 b);
 /**
 * \ingroup CUDA_MATH__HALF2_COMPARISON
 * \brief Performs \p half2 vector unordered if-equal comparison.
@@ -2355,7 +2316,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ unsigned __hgt2_mask(const __half2 a, const __half
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ unsigned __hequ2_mask(const __half2 a, const __half2 b);
+__CUDA_FP16_DECL__ unsigned __hequ2_mask(const __half2 a, const __half2 b);
 /**
 * \ingroup CUDA_MATH__HALF2_COMPARISON
 * \brief Performs \p half2 vector unordered not-equal comparison.
@@ -2373,7 +2334,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ unsigned __hequ2_mask(const __half2 a, const __hal
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ unsigned __hneu2_mask(const __half2 a, const __half2 b);
+__CUDA_FP16_DECL__ unsigned __hneu2_mask(const __half2 a, const __half2 b);
 /**
 * \ingroup CUDA_MATH__HALF2_COMPARISON
 * \brief Performs \p half2 vector unordered less-equal comparison.
@@ -2391,7 +2352,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ unsigned __hneu2_mask(const __half2 a, const __hal
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ unsigned __hleu2_mask(const __half2 a, const __half2 b);
+__CUDA_FP16_DECL__ unsigned __hleu2_mask(const __half2 a, const __half2 b);
 /**
 * \ingroup CUDA_MATH__HALF2_COMPARISON
 * \brief Performs \p half2 vector unordered greater-equal comparison.
@@ -2409,7 +2370,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ unsigned __hleu2_mask(const __half2 a, const __hal
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ unsigned __hgeu2_mask(const __half2 a, const __half2 b);
+__CUDA_FP16_DECL__ unsigned __hgeu2_mask(const __half2 a, const __half2 b);
 /**
 * \ingroup CUDA_MATH__HALF2_COMPARISON
 * \brief Performs \p half2 vector unordered less-than comparison.
@@ -2427,7 +2388,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ unsigned __hgeu2_mask(const __half2 a, const __hal
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ unsigned __hltu2_mask(const __half2 a, const __half2 b);
+__CUDA_FP16_DECL__ unsigned __hltu2_mask(const __half2 a, const __half2 b);
 /**
 * \ingroup CUDA_MATH__HALF2_COMPARISON
 * \brief Performs \p half2 vector unordered greater-than comparison.
@@ -2445,7 +2406,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ unsigned __hltu2_mask(const __half2 a, const __hal
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ unsigned __hgtu2_mask(const __half2 a, const __half2 b);
+__CUDA_FP16_DECL__ unsigned __hgtu2_mask(const __half2 a, const __half2 b);
 /**
 * \ingroup CUDA_MATH__HALF2_COMPARISON
 * \brief Determine whether \p half2 argument is a NaN.
@@ -2461,12 +2422,12 @@ __CUDA_HOSTDEVICE_FP16_DECL__ unsigned __hgtu2_mask(const __half2 a, const __hal
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hisnan2(const __half2 a);
+__CUDA_FP16_DECL__ __half2 __hisnan2(const __half2 a);
 /**
 * \ingroup CUDA_MATH__HALF2_ARITHMETIC
 * \brief Performs \p half2 vector addition in round-to-nearest-even mode.
 *
-* \details Performs \p half2 vector add of inputs \p a and \p b, in round-to-nearest-even
+* \details Performs \p half2 vector add of inputs \p a and \p b, in round-to-nearest
 * mode.
 * \internal
 * \req DEEPLEARN-SRM_REQ-95
@@ -2481,7 +2442,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hisnan2(const __half2 a);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hadd2(const __half2 a, const __half2 b);
+__CUDA_FP16_DECL__ __half2 __hadd2(const __half2 a, const __half2 b);
 /**
 * \ingroup CUDA_MATH__HALF2_ARITHMETIC
 * \brief Performs \p half2 vector subtraction in round-to-nearest-even mode.
@@ -2501,7 +2462,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hadd2(const __half2 a, const __half2 b);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hsub2(const __half2 a, const __half2 b);
+__CUDA_FP16_DECL__ __half2 __hsub2(const __half2 a, const __half2 b);
 /**
 * \ingroup CUDA_MATH__HALF2_ARITHMETIC
 * \brief Performs \p half2 vector multiplication in round-to-nearest-even mode.
@@ -2521,12 +2482,12 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hsub2(const __half2 a, const __half2 b);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hmul2(const __half2 a, const __half2 b);
+__CUDA_FP16_DECL__ __half2 __hmul2(const __half2 a, const __half2 b);
 /**
 * \ingroup CUDA_MATH__HALF2_ARITHMETIC
 * \brief Performs \p half2 vector addition in round-to-nearest-even mode.
 *
-* \details Performs \p half2 vector add of inputs \p a and \p b, in round-to-nearest-even
+* \details Performs \p half2 vector add of inputs \p a and \p b, in round-to-nearest
 * mode. Prevents floating-point contractions of mul+add into fma.
 * \internal
 * \req DEEPLEARN-SRM_REQ-95
@@ -2541,7 +2502,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hmul2(const __half2 a, const __half2 b);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hadd2_rn(const __half2 a, const __half2 b);
+__CUDA_FP16_DECL__ __half2 __hadd2_rn(const __half2 a, const __half2 b);
 /**
 * \ingroup CUDA_MATH__HALF2_ARITHMETIC
 * \brief Performs \p half2 vector subtraction in round-to-nearest-even mode.
@@ -2562,7 +2523,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hadd2_rn(const __half2 a, const __half2 
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hsub2_rn(const __half2 a, const __half2 b);
+__CUDA_FP16_DECL__ __half2 __hsub2_rn(const __half2 a, const __half2 b);
 /**
 * \ingroup CUDA_MATH__HALF2_ARITHMETIC
 * \brief Performs \p half2 vector multiplication in round-to-nearest-even mode.
@@ -2583,12 +2544,12 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hsub2_rn(const __half2 a, const __half2 
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hmul2_rn(const __half2 a, const __half2 b);
+__CUDA_FP16_DECL__ __half2 __hmul2_rn(const __half2 a, const __half2 b);
 /**
 * \ingroup CUDA_MATH__HALF2_ARITHMETIC
 * \brief Performs \p half2 vector division in round-to-nearest-even mode.
 *
-* \details Divides \p half2 input vector \p a by input vector \p b in round-to-nearest-even
+* \details Divides \p half2 input vector \p a by input vector \p b in round-to-nearest
 * mode.
 * \internal
 * \req DEEPLEARN-SRM_REQ-103
@@ -2603,7 +2564,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hmul2_rn(const __half2 a, const __half2 
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __h2div(const __half2 a, const __half2 b);
+__CUDA_FP16_DECL__ __half2 __h2div(const __half2 a, const __half2 b);
 /**
 * \ingroup CUDA_MATH__HALF2_ARITHMETIC
 * \brief Calculates the absolute value of both halves of the input \p half2 number and
@@ -2620,13 +2581,13 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half2 __h2div(const __half2 a, const __half2 b);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __habs2(const __half2 a);
+__CUDA_FP16_DECL__ __half2 __habs2(const __half2 a);
 /**
 * \ingroup CUDA_MATH__HALF2_ARITHMETIC
 * \brief Performs \p half2 vector addition in round-to-nearest-even mode, with
 * saturation to [0.0, 1.0].
 *
-* \details Performs \p half2 vector add of inputs \p a and \p b, in round-to-nearest-even
+* \details Performs \p half2 vector add of inputs \p a and \p b, in round-to-nearest
 * mode, and clamps the results to range [0.0, 1.0]. NaN results are flushed to
 * +0.0.
 * \param[in] a - half2. Is only being read. 
@@ -2639,7 +2600,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half2 __habs2(const __half2 a);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hadd2_sat(const __half2 a, const __half2 b);
+__CUDA_FP16_DECL__ __half2 __hadd2_sat(const __half2 a, const __half2 b);
 /**
 * \ingroup CUDA_MATH__HALF2_ARITHMETIC
 * \brief Performs \p half2 vector subtraction in round-to-nearest-even mode,
@@ -2658,7 +2619,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hadd2_sat(const __half2 a, const __half2
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hsub2_sat(const __half2 a, const __half2 b);
+__CUDA_FP16_DECL__ __half2 __hsub2_sat(const __half2 a, const __half2 b);
 /**
 * \ingroup CUDA_MATH__HALF2_ARITHMETIC
 * \brief Performs \p half2 vector multiplication in round-to-nearest-even mode,
@@ -2678,9 +2639,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hsub2_sat(const __half2 a, const __half2
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hmul2_sat(const __half2 a, const __half2 b);
-
-#if defined(__CUDACC__) && (!defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 530)) || defined(_NVHPC_CUDA)
+__CUDA_FP16_DECL__ __half2 __hmul2_sat(const __half2 a, const __half2 b);
 /**
 * \ingroup CUDA_MATH__HALF2_ARITHMETIC
 * \brief Performs \p half2 vector fused multiply-add in round-to-nearest-even
@@ -2726,7 +2685,6 @@ __CUDA_FP16_DECL__ __half2 __hfma2(const __half2 a, const __half2 b, const __hal
 * \endinternal
 */
 __CUDA_FP16_DECL__ __half2 __hfma2_sat(const __half2 a, const __half2 b, const __half2 c);
-#endif /* defined(__CUDACC__) && (!defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 530)) || defined(_NVHPC_CUDA) */
 /**
 * \ingroup CUDA_MATH__HALF2_ARITHMETIC
 * \brief Negates both halves of the input \p half2 number and returns the
@@ -2745,7 +2703,7 @@ __CUDA_FP16_DECL__ __half2 __hfma2_sat(const __half2 a, const __half2 b, const _
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hneg2(const __half2 a);
+__CUDA_FP16_DECL__ __half2 __hneg2(const __half2 a);
 /**
 * \ingroup CUDA_MATH__HALF_ARITHMETIC
 * \brief Calculates the absolute value of input \p half number and returns the result.
@@ -2760,7 +2718,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hneg2(const __half2 a);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __habs(const __half a);
+__CUDA_FP16_DECL__ __half __habs(const __half a);
 /**
 * \ingroup CUDA_MATH__HALF_ARITHMETIC
 * \brief Performs \p half addition in round-to-nearest-even mode.
@@ -2780,12 +2738,12 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half __habs(const __half a);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __hadd(const __half a, const __half b);
+__CUDA_FP16_DECL__ __half __hadd(const __half a, const __half b);
 /**
 * \ingroup CUDA_MATH__HALF_ARITHMETIC
 * \brief Performs \p half subtraction in round-to-nearest-even mode.
 *
-* \details Subtracts \p half input \p b from input \p a in round-to-nearest-even
+* \details Subtracts \p half input \p b from input \p a in round-to-nearest
 * mode.
 * \internal
 * \req DEEPLEARN-SRM_REQ-97
@@ -2800,12 +2758,12 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half __hadd(const __half a, const __half b);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __hsub(const __half a, const __half b);
+__CUDA_FP16_DECL__ __half __hsub(const __half a, const __half b);
 /**
 * \ingroup CUDA_MATH__HALF_ARITHMETIC
 * \brief Performs \p half multiplication in round-to-nearest-even mode.
 *
-* \details Performs \p half multiplication of inputs \p a and \p b, in round-to-nearest-even
+* \details Performs \p half multiplication of inputs \p a and \p b, in round-to-nearest
 * mode.
 * \internal
 * \req DEEPLEARN-SRM_REQ-99
@@ -2816,7 +2774,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half __hsub(const __half a, const __half b);
 * \returns half
 * - The result of multiplying \p a and \p b. 
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __hmul(const __half a, const __half b);
+__CUDA_FP16_DECL__ __half __hmul(const __half a, const __half b);
 /**
 * \ingroup CUDA_MATH__HALF_ARITHMETIC
 * \brief Performs \p half addition in round-to-nearest-even mode.
@@ -2836,12 +2794,12 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half __hmul(const __half a, const __half b);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __hadd_rn(const __half a, const __half b);
+__CUDA_FP16_DECL__ __half __hadd_rn(const __half a, const __half b);
 /**
 * \ingroup CUDA_MATH__HALF_ARITHMETIC
 * \brief Performs \p half subtraction in round-to-nearest-even mode.
 *
-* \details Subtracts \p half input \p b from input \p a in round-to-nearest-even
+* \details Subtracts \p half input \p b from input \p a in round-to-nearest
 * mode. Prevents floating-point contractions of mul+sub into fma.
 * \internal
 * \req DEEPLEARN-SRM_REQ-97
@@ -2856,12 +2814,12 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half __hadd_rn(const __half a, const __half b);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __hsub_rn(const __half a, const __half b);
+__CUDA_FP16_DECL__ __half __hsub_rn(const __half a, const __half b);
 /**
 * \ingroup CUDA_MATH__HALF_ARITHMETIC
 * \brief Performs \p half multiplication in round-to-nearest-even mode.
 *
-* \details Performs \p half multiplication of inputs \p a and \p b, in round-to-nearest-even
+* \details Performs \p half multiplication of inputs \p a and \p b, in round-to-nearest
 * mode. Prevents floating-point contractions of mul+add or sub into fma.
 * \internal
 * \req DEEPLEARN-SRM_REQ-99
@@ -2872,12 +2830,12 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half __hsub_rn(const __half a, const __half b);
 * \returns half
 * - The result of multiplying \p a and \p b.
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __hmul_rn(const __half a, const __half b);
+__CUDA_FP16_DECL__ __half __hmul_rn(const __half a, const __half b);
 /**
 * \ingroup CUDA_MATH__HALF_ARITHMETIC
 * \brief Performs \p half division in round-to-nearest-even mode.
 * 
-* \details Divides \p half input \p a by input \p b in round-to-nearest-even
+* \details Divides \p half input \p a by input \p b in round-to-nearest
 * mode.
 * \internal
 * \req DEEPLEARN-SRM_REQ-98
@@ -2892,7 +2850,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half __hmul_rn(const __half a, const __half b);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__  __half __hdiv(const __half a, const __half b);
+__CUDA_FP16_DECL__  __half __hdiv(const __half a, const __half b);
 /**
 * \ingroup CUDA_MATH__HALF_ARITHMETIC
 * \brief Performs \p half addition in round-to-nearest-even mode, with
@@ -2910,13 +2868,13 @@ __CUDA_HOSTDEVICE_FP16_DECL__  __half __hdiv(const __half a, const __half b);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __hadd_sat(const __half a, const __half b);
+__CUDA_FP16_DECL__ __half __hadd_sat(const __half a, const __half b);
 /**
 * \ingroup CUDA_MATH__HALF_ARITHMETIC
 * \brief Performs \p half subtraction in round-to-nearest-even mode, with
 * saturation to [0.0, 1.0].
 *
-* \details Subtracts \p half input \p b from input \p a in round-to-nearest-even
+* \details Subtracts \p half input \p b from input \p a in round-to-nearest
 * mode,
 * and clamps the result to range [0.0, 1.0]. NaN results are flushed to +0.0.
 * \param[in] a - half. Is only being read. 
@@ -2929,13 +2887,13 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half __hadd_sat(const __half a, const __half b);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __hsub_sat(const __half a, const __half b);
+__CUDA_FP16_DECL__ __half __hsub_sat(const __half a, const __half b);
 /**
 * \ingroup CUDA_MATH__HALF_ARITHMETIC
 * \brief Performs \p half multiplication in round-to-nearest-even mode, with
 * saturation to [0.0, 1.0].
 *
-* \details Performs \p half multiplication of inputs \p a and \p b, in round-to-nearest-even
+* \details Performs \p half multiplication of inputs \p a and \p b, in round-to-nearest
 * mode, and clamps the result to range [0.0, 1.0]. NaN results are flushed to
 * +0.0.
 * \param[in] a - half. Is only being read. 
@@ -2948,9 +2906,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half __hsub_sat(const __half a, const __half b);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __hmul_sat(const __half a, const __half b);
-
-#if defined(__CUDACC__) && (!defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 530)) || defined(_NVHPC_CUDA)
+__CUDA_FP16_DECL__ __half __hmul_sat(const __half a, const __half b);
 /**
 * \ingroup CUDA_MATH__HALF_ARITHMETIC
 * \brief Performs \p half fused multiply-add in round-to-nearest-even mode.
@@ -2996,8 +2952,6 @@ __CUDA_FP16_DECL__ __half __hfma(const __half a, const __half b, const __half c)
 * \endinternal
 */
 __CUDA_FP16_DECL__ __half __hfma_sat(const __half a, const __half b, const __half c);
-#endif /* defined(__CUDACC__) && (!defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 530)) || defined(_NVHPC_CUDA) */
-
 /**
 * \ingroup CUDA_MATH__HALF_ARITHMETIC
 * \brief Negates input \p half number and returns the result.
@@ -3015,7 +2969,7 @@ __CUDA_FP16_DECL__ __half __hfma_sat(const __half a, const __half b, const __hal
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __hneg(const __half a);
+__CUDA_FP16_DECL__ __half __hneg(const __half a);
 /**
 * \ingroup CUDA_MATH__HALF2_COMPARISON
 * \brief Performs \p half2 vector if-equal comparison and returns boolean true
@@ -3037,7 +2991,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half __hneg(const __half a);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ bool __hbeq2(const __half2 a, const __half2 b);
+__CUDA_FP16_DECL__ bool __hbeq2(const __half2 a, const __half2 b);
 /**
 * \ingroup CUDA_MATH__HALF2_COMPARISON
 * \brief Performs \p half2 vector not-equal comparison and returns boolean
@@ -3059,7 +3013,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ bool __hbeq2(const __half2 a, const __half2 b);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ bool __hbne2(const __half2 a, const __half2 b);
+__CUDA_FP16_DECL__ bool __hbne2(const __half2 a, const __half2 b);
 /**
 * \ingroup CUDA_MATH__HALF2_COMPARISON
 * \brief Performs \p half2 vector less-equal comparison and returns boolean
@@ -3081,7 +3035,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ bool __hbne2(const __half2 a, const __half2 b);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ bool __hble2(const __half2 a, const __half2 b);
+__CUDA_FP16_DECL__ bool __hble2(const __half2 a, const __half2 b);
 /**
 * \ingroup CUDA_MATH__HALF2_COMPARISON
 * \brief Performs \p half2 vector greater-equal comparison and returns boolean
@@ -3103,7 +3057,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ bool __hble2(const __half2 a, const __half2 b);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ bool __hbge2(const __half2 a, const __half2 b);
+__CUDA_FP16_DECL__ bool __hbge2(const __half2 a, const __half2 b);
 /**
 * \ingroup CUDA_MATH__HALF2_COMPARISON
 * \brief Performs \p half2 vector less-than comparison and returns boolean
@@ -3125,7 +3079,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ bool __hbge2(const __half2 a, const __half2 b);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ bool __hblt2(const __half2 a, const __half2 b);
+__CUDA_FP16_DECL__ bool __hblt2(const __half2 a, const __half2 b);
 /**
 * \ingroup CUDA_MATH__HALF2_COMPARISON
 * \brief Performs \p half2 vector greater-than comparison and returns boolean
@@ -3147,7 +3101,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ bool __hblt2(const __half2 a, const __half2 b);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ bool __hbgt2(const __half2 a, const __half2 b);
+__CUDA_FP16_DECL__ bool __hbgt2(const __half2 a, const __half2 b);
 /**
 * \ingroup CUDA_MATH__HALF2_COMPARISON
 * \brief Performs \p half2 vector unordered if-equal comparison and returns
@@ -3169,7 +3123,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ bool __hbgt2(const __half2 a, const __half2 b);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ bool __hbequ2(const __half2 a, const __half2 b);
+__CUDA_FP16_DECL__ bool __hbequ2(const __half2 a, const __half2 b);
 /**
 * \ingroup CUDA_MATH__HALF2_COMPARISON
 * \brief Performs \p half2 vector unordered not-equal comparison and returns
@@ -3191,7 +3145,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ bool __hbequ2(const __half2 a, const __half2 b);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ bool __hbneu2(const __half2 a, const __half2 b);
+__CUDA_FP16_DECL__ bool __hbneu2(const __half2 a, const __half2 b);
 /**
 * \ingroup CUDA_MATH__HALF2_COMPARISON
 * \brief Performs \p half2 vector unordered less-equal comparison and returns
@@ -3213,7 +3167,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ bool __hbneu2(const __half2 a, const __half2 b);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ bool __hbleu2(const __half2 a, const __half2 b);
+__CUDA_FP16_DECL__ bool __hbleu2(const __half2 a, const __half2 b);
 /**
 * \ingroup CUDA_MATH__HALF2_COMPARISON
 * \brief Performs \p half2 vector unordered greater-equal comparison and
@@ -3236,7 +3190,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ bool __hbleu2(const __half2 a, const __half2 b);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ bool __hbgeu2(const __half2 a, const __half2 b);
+__CUDA_FP16_DECL__ bool __hbgeu2(const __half2 a, const __half2 b);
 /**
 * \ingroup CUDA_MATH__HALF2_COMPARISON
 * \brief Performs \p half2 vector unordered less-than comparison and returns
@@ -3258,7 +3212,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ bool __hbgeu2(const __half2 a, const __half2 b);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ bool __hbltu2(const __half2 a, const __half2 b);
+__CUDA_FP16_DECL__ bool __hbltu2(const __half2 a, const __half2 b);
 /**
 * \ingroup CUDA_MATH__HALF2_COMPARISON
 * \brief Performs \p half2 vector unordered greater-than comparison and
@@ -3281,7 +3235,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ bool __hbltu2(const __half2 a, const __half2 b);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ bool __hbgtu2(const __half2 a, const __half2 b);
+__CUDA_FP16_DECL__ bool __hbgtu2(const __half2 a, const __half2 b);
 /**
 * \ingroup CUDA_MATH__HALF_COMPARISON
 * \brief Performs \p half if-equal comparison.
@@ -3298,7 +3252,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ bool __hbgtu2(const __half2 a, const __half2 b);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ bool __heq(const __half a, const __half b);
+__CUDA_FP16_DECL__ bool __heq(const __half a, const __half b);
 /**
 * \ingroup CUDA_MATH__HALF_COMPARISON
 * \brief Performs \p half not-equal comparison.
@@ -3315,7 +3269,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ bool __heq(const __half a, const __half b);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ bool __hne(const __half a, const __half b);
+__CUDA_FP16_DECL__ bool __hne(const __half a, const __half b);
 /**
 * \ingroup CUDA_MATH__HALF_COMPARISON
 * \brief Performs \p half less-equal comparison.
@@ -3332,7 +3286,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ bool __hne(const __half a, const __half b);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ bool __hle(const __half a, const __half b);
+__CUDA_FP16_DECL__ bool __hle(const __half a, const __half b);
 /**
 * \ingroup CUDA_MATH__HALF_COMPARISON
 * \brief Performs \p half greater-equal comparison.
@@ -3349,7 +3303,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ bool __hle(const __half a, const __half b);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ bool __hge(const __half a, const __half b);
+__CUDA_FP16_DECL__ bool __hge(const __half a, const __half b);
 /**
 * \ingroup CUDA_MATH__HALF_COMPARISON
 * \brief Performs \p half less-than comparison.
@@ -3366,7 +3320,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ bool __hge(const __half a, const __half b);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ bool __hlt(const __half a, const __half b);
+__CUDA_FP16_DECL__ bool __hlt(const __half a, const __half b);
 /**
 * \ingroup CUDA_MATH__HALF_COMPARISON
 * \brief Performs \p half greater-than comparison.
@@ -3383,7 +3337,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ bool __hlt(const __half a, const __half b);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ bool __hgt(const __half a, const __half b);
+__CUDA_FP16_DECL__ bool __hgt(const __half a, const __half b);
 /**
 * \ingroup CUDA_MATH__HALF_COMPARISON
 * \brief Performs \p half unordered if-equal comparison.
@@ -3401,7 +3355,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ bool __hgt(const __half a, const __half b);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ bool __hequ(const __half a, const __half b);
+__CUDA_FP16_DECL__ bool __hequ(const __half a, const __half b);
 /**
 * \ingroup CUDA_MATH__HALF_COMPARISON
 * \brief Performs \p half unordered not-equal comparison.
@@ -3419,7 +3373,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ bool __hequ(const __half a, const __half b);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ bool __hneu(const __half a, const __half b);
+__CUDA_FP16_DECL__ bool __hneu(const __half a, const __half b);
 /**
 * \ingroup CUDA_MATH__HALF_COMPARISON
 * \brief Performs \p half unordered less-equal comparison.
@@ -3437,7 +3391,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ bool __hneu(const __half a, const __half b);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ bool __hleu(const __half a, const __half b);
+__CUDA_FP16_DECL__ bool __hleu(const __half a, const __half b);
 /**
 * \ingroup CUDA_MATH__HALF_COMPARISON
 * \brief Performs \p half unordered greater-equal comparison.
@@ -3455,7 +3409,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ bool __hleu(const __half a, const __half b);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ bool __hgeu(const __half a, const __half b);
+__CUDA_FP16_DECL__ bool __hgeu(const __half a, const __half b);
 /**
 * \ingroup CUDA_MATH__HALF_COMPARISON
 * \brief Performs \p half unordered less-than comparison.
@@ -3473,7 +3427,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ bool __hgeu(const __half a, const __half b);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ bool __hltu(const __half a, const __half b);
+__CUDA_FP16_DECL__ bool __hltu(const __half a, const __half b);
 /**
 * \ingroup CUDA_MATH__HALF_COMPARISON
 * \brief Performs \p half unordered greater-than comparison.
@@ -3491,7 +3445,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ bool __hltu(const __half a, const __half b);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ bool __hgtu(const __half a, const __half b);
+__CUDA_FP16_DECL__ bool __hgtu(const __half a, const __half b);
 /**
 * \ingroup CUDA_MATH__HALF_COMPARISON
 * \brief Determine whether \p half argument is a NaN.
@@ -3506,7 +3460,8 @@ __CUDA_HOSTDEVICE_FP16_DECL__ bool __hgtu(const __half a, const __half b);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ bool __hisnan(const __half a);
+__CUDA_FP16_DECL__ bool __hisnan(const __half a);
+#if !defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 800)
 /**
 * \ingroup CUDA_MATH__HALF_COMPARISON
 * \brief Calculates \p half maximum of two input values, NaNs pass through.
@@ -3524,7 +3479,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ bool __hisnan(const __half a);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __hmax_nan(const __half a, const __half b);
+__CUDA_FP16_DECL__ __half __hmax_nan(const __half a, const __half b);
 /**
 * \ingroup CUDA_MATH__HALF_COMPARISON
 * \brief Calculates \p half minimum of two input values, NaNs pass through.
@@ -3542,8 +3497,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half __hmax_nan(const __half a, const __half b);
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __hmin_nan(const __half a, const __half b);
-#if defined(__CUDACC__) && (!defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 530)) || defined(_NVHPC_CUDA)
+__CUDA_FP16_DECL__ __half __hmin_nan(const __half a, const __half b);
 /**
 * \ingroup CUDA_MATH__HALF_ARITHMETIC
 * \brief Performs \p half fused multiply-add in round-to-nearest-even mode with relu saturation.
@@ -3566,7 +3520,6 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half __hmin_nan(const __half a, const __half b);
 * \endinternal
 */
 __CUDA_FP16_DECL__ __half __hfma_relu(const __half a, const __half b, const __half c);
-#endif /* defined(__CUDACC__) && (!defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 530)) || defined(_NVHPC_CUDA) */
 /**
 * \ingroup CUDA_MATH__HALF2_COMPARISON
 * \brief Calculates \p half2 vector maximum of two inputs, NaNs pass through.
@@ -3586,7 +3539,7 @@ __CUDA_FP16_DECL__ __half __hfma_relu(const __half a, const __half b, const __ha
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hmax2_nan(const __half2 a, const __half2 b);
+__CUDA_FP16_DECL__ __half2 __hmax2_nan(const __half2 a, const __half2 b);
 /**
 * \ingroup CUDA_MATH__HALF2_COMPARISON
 * \brief Calculates \p half2 vector minimum of two inputs, NaNs pass through.
@@ -3606,8 +3559,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hmax2_nan(const __half2 a, const __half2
 * \behavior reentrant, thread safe
 * \endinternal
 */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hmin2_nan(const __half2 a, const __half2 b);
-#if defined(__CUDACC__) && (!defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 530)) || defined(_NVHPC_CUDA)
+__CUDA_FP16_DECL__ __half2 __hmin2_nan(const __half2 a, const __half2 b);
 /**
 * \ingroup CUDA_MATH__HALF2_ARITHMETIC
 * \brief Performs \p half2 vector fused multiply-add in round-to-nearest-even
@@ -3630,7 +3582,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hmin2_nan(const __half2 a, const __half2
 * \endinternal
 */
 __CUDA_FP16_DECL__ __half2 __hfma2_relu(const __half2 a, const __half2 b, const __half2 c);
-
+#endif /* !defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 800) */
 /**
 * \ingroup CUDA_MATH__HALF2_ARITHMETIC
 * \brief Performs fast complex multiply-accumulate
@@ -3650,8 +3602,6 @@ __CUDA_FP16_DECL__ __half2 __hfma2_relu(const __half2 a, const __half2 b, const 
 * \endinternal
 */
 __CUDA_FP16_DECL__ __half2 __hcmadd(const __half2 a, const __half2 b, const __half2 c);
-#endif /* defined(__CUDACC__) && (!defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 530)) || defined(_NVHPC_CUDA) */
-#if defined(__CUDACC__) || defined(_NVHPC_CUDA)
 /**
 * \ingroup CUDA_MATH__HALF_FUNCTIONS
 * \brief Calculates \p half square root in round-to-nearest-even mode.
@@ -3672,7 +3622,7 @@ __CUDA_FP16_DECL__ __half hsqrt(const __half a);
 * \brief Calculates \p half reciprocal square root in round-to-nearest-even
 * mode.
 *
-* \details Calculates \p half reciprocal square root of input \p a in round-to-nearest-even
+* \details Calculates \p half reciprocal square root of input \p a in round-to-nearest
 * mode.
 * \param[in] a - half. Is only being read. 
 *
@@ -3699,7 +3649,6 @@ __CUDA_FP16_DECL__ __half hrsqrt(const __half a);
 * \endinternal
 */
 __CUDA_FP16_DECL__ __half hrcp(const __half a);
-#if defined(__CUDACC__) && (!defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 530)) || defined(_NVHPC_CUDA)
 /**
 * \ingroup CUDA_MATH__HALF_FUNCTIONS
 * \brief Calculates \p half natural logarithm in round-to-nearest-even mode.
@@ -3750,7 +3699,7 @@ __CUDA_FP16_DECL__ __half hlog2(const __half a);
 __CUDA_FP16_DECL__ __half hlog10(const __half a);
 /**
 * \ingroup CUDA_MATH__HALF_FUNCTIONS
-* \brief Calculates \p half natural exponential function in round-to-nearest-even
+* \brief Calculates \p half natural exponential function in round-to-nearest
 * mode.
 *
 * \details Calculates \p half natural exponential function of input \p a in
@@ -3765,10 +3714,9 @@ __CUDA_FP16_DECL__ __half hlog10(const __half a);
 * \endinternal
 */
 __CUDA_FP16_DECL__ __half hexp(const __half a);
-#endif /* defined(__CUDACC__) && (!defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 530)) || defined(_NVHPC_CUDA) */
 /**
 * \ingroup CUDA_MATH__HALF_FUNCTIONS
-* \brief Calculates \p half binary exponential function in round-to-nearest-even
+* \brief Calculates \p half binary exponential function in round-to-nearest
 * mode.
 *
 * \details Calculates \p half binary exponential function of input \p a in
@@ -3783,10 +3731,9 @@ __CUDA_FP16_DECL__ __half hexp(const __half a);
 * \endinternal
 */
 __CUDA_FP16_DECL__ __half hexp2(const __half a);
-#if defined(__CUDACC__) && (!defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 530)) || defined(_NVHPC_CUDA)
 /**
 * \ingroup CUDA_MATH__HALF_FUNCTIONS
-* \brief Calculates \p half decimal exponential function in round-to-nearest-even
+* \brief Calculates \p half decimal exponential function in round-to-nearest
 * mode.
 *
 * \details Calculates \p half decimal exponential function of input \p a in
@@ -3831,12 +3778,11 @@ __CUDA_FP16_DECL__ __half hcos(const __half a);
 * \endinternal
 */
 __CUDA_FP16_DECL__ __half hsin(const __half a);
-#endif /* defined(__CUDACC__) && (!defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 530)) || defined(_NVHPC_CUDA) */
 /**
 * \ingroup CUDA_MATH__HALF2_FUNCTIONS
 * \brief Calculates \p half2 vector square root in round-to-nearest-even mode.
 *
-* \details Calculates \p half2 square root of input vector \p a in round-to-nearest-even
+* \details Calculates \p half2 square root of input vector \p a in round-to-nearest
 * mode.
 * \param[in] a - half2. Is only being read. 
 *
@@ -3850,7 +3796,7 @@ __CUDA_FP16_DECL__ __half hsin(const __half a);
 __CUDA_FP16_DECL__ __half2 h2sqrt(const __half2 a);
 /**
 * \ingroup CUDA_MATH__HALF2_FUNCTIONS
-* \brief Calculates \p half2 vector reciprocal square root in round-to-nearest-even
+* \brief Calculates \p half2 vector reciprocal square root in round-to-nearest
 * mode.
 *
 * \details Calculates \p half2 reciprocal square root of input vector \p a in
@@ -3881,7 +3827,6 @@ __CUDA_FP16_DECL__ __half2 h2rsqrt(const __half2 a);
 * \endinternal
 */
 __CUDA_FP16_DECL__ __half2 h2rcp(const __half2 a);
-#if defined(__CUDACC__) && (!defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 530)) || defined(_NVHPC_CUDA)
 /**
 * \ingroup CUDA_MATH__HALF2_FUNCTIONS
 * \brief Calculates \p half2 vector natural logarithm in round-to-nearest-even
@@ -3904,7 +3849,7 @@ __CUDA_FP16_DECL__ __half2 h2log(const __half2 a);
 * \brief Calculates \p half2 vector binary logarithm in round-to-nearest-even
 * mode.
 *
-* \details Calculates \p half2 binary logarithm of input vector \p a in round-to-nearest-even
+* \details Calculates \p half2 binary logarithm of input vector \p a in round-to-nearest
 * mode.
 * \param[in] a - half2. Is only being read. 
 *
@@ -3935,7 +3880,7 @@ __CUDA_FP16_DECL__ __half2 h2log2(const __half2 a);
 __CUDA_FP16_DECL__ __half2 h2log10(const __half2 a);
 /**
 * \ingroup CUDA_MATH__HALF2_FUNCTIONS
-* \brief Calculates \p half2 vector exponential function in round-to-nearest-even
+* \brief Calculates \p half2 vector exponential function in round-to-nearest
 * mode.
 *
 * \details Calculates \p half2 exponential function of input vector \p a in
@@ -3950,7 +3895,6 @@ __CUDA_FP16_DECL__ __half2 h2log10(const __half2 a);
 * \endinternal
 */
 __CUDA_FP16_DECL__ __half2 h2exp(const __half2 a);
-#endif /* defined(__CUDACC__) && (!defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 530)) || defined(_NVHPC_CUDA) */
 /**
 * \ingroup CUDA_MATH__HALF2_FUNCTIONS
 * \brief Calculates \p half2 vector binary exponential function in
@@ -3968,7 +3912,6 @@ __CUDA_FP16_DECL__ __half2 h2exp(const __half2 a);
 * \endinternal
 */
 __CUDA_FP16_DECL__ __half2 h2exp2(const __half2 a);
-#if defined(__CUDACC__) && (!defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 530)) || defined(_NVHPC_CUDA)
 /**
 * \ingroup CUDA_MATH__HALF2_FUNCTIONS
 * \brief Calculates \p half2 vector decimal exponential function in
@@ -4017,7 +3960,10 @@ __CUDA_FP16_DECL__ __half2 h2cos(const __half2 a);
 * \endinternal
 */
 __CUDA_FP16_DECL__ __half2 h2sin(const __half2 a);
-#endif /* defined(__CUDACC__) && (!defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 530)) || defined(_NVHPC_CUDA) */
+
+#endif /*if !defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 530)*/
+
+#if !defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 600)
 
 /**
 * \ingroup CUDA_MATH__HALF2_ARITHMETIC
@@ -4026,8 +3972,7 @@ __CUDA_FP16_DECL__ __half2 h2sin(const __half2 a);
 * two __half elements; the entire __half2 is not guaranteed to be atomic as a single 32-bit access.
 * 
 * \details The location of \p address must be in global or shared memory. This operation has undefined
-* behavior otherwise. This operation is natively supported by devices of compute capability 6.x and higher,
-* older devices use emulation path.
+* behavior otherwise. This operation is only supported by devices of compute capability 6.x and higher.
 * 
 * \param[in] address - half2*. An address in global or shared memory.
 * \param[in] val - half2. The value to be added.
@@ -4039,7 +3984,10 @@ __CUDA_FP16_DECL__ __half2 h2sin(const __half2 a);
 */
 __CUDA_FP16_DECL__ __half2 atomicAdd(__half2 *const address, const __half2 val);
 
-#if (defined(__CUDACC__) && (!defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 700))) || defined(_NVHPC_CUDA)
+#endif /*if !defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 600)*/
+
+#if !defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 700)
+
 /**
 * \ingroup CUDA_MATH__HALF_ARITHMETIC
 * \brief Adds \p val to the value stored at \p address in global or shared memory, and writes this value
@@ -4057,9 +4005,10 @@ __CUDA_FP16_DECL__ __half2 atomicAdd(__half2 *const address, const __half2 val);
 * \note_ref_guide_atomic
 */
 __CUDA_FP16_DECL__ __half atomicAdd(__half *const address, const __half val);
-#endif /* (defined(__CUDACC__) && (!defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 700))) || defined(_NVHPC_CUDA) */
 
-#endif /*defined(__CUDACC__) || defined(_NVHPC_CUDA)*/
+#endif /*if !defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 700)*/
+
+#endif /* defined(__CUDACC__) */
 
 #undef __CUDA_FP16_DECL__
 #undef __CUDA_HOSTDEVICE_FP16_DECL__

--- a/cupy/_core/include/cupy/_cuda/cuda-12/cuda_fp16.hpp
+++ b/cupy/_core/include/cupy/_cuda/cuda-12/cuda_fp16.hpp
@@ -1,5 +1,5 @@
 /*
-* Copyright 1993-2023 NVIDIA Corporation.  All rights reserved.
+* Copyright 1993-2022 NVIDIA Corporation.  All rights reserved.
 *
 * NOTICE TO LICENSEE:
 *
@@ -93,6 +93,7 @@
 #if defined(__CUDACC__) || defined(_NVHPC_CUDA)
 #define __CUDA_FP16_DECL__ static __device__ __inline__
 #define __CUDA_HOSTDEVICE_FP16_DECL__ static __host__ __device__ __inline__
+#define __VECTOR_FUNCTIONS_DECL__ static __inline__ __host__ __device__
 #define __CUDA_HOSTDEVICE__ __host__ __device__
 #else /* !defined(__CUDACC__) */
 #if defined(__GNUC__)
@@ -153,43 +154,17 @@
    return val; \
 } /* while(0) */
 
-// define __CUDA_FP16_CONSTEXPR__ in order to
-// use constexpr where possible, with supporting C++ dialects
-// undef after use
-#if (defined __CPP_VERSION_AT_LEAST_11_FP16)
-#define __CUDA_FP16_CONSTEXPR__   constexpr
-#else
-#define __CUDA_FP16_CONSTEXPR__
-#endif
-
 /**
- * \ingroup CUDA_MATH_INTRINSIC_HALF
- * \brief __half_raw data type
- * \details Type allows static initialization of \p half until it becomes
- * a builtin type.
- * 
- * - Note: this initialization is as a bit-field representation of \p half,
- * and not a conversion from \p short to \p half.
- * Such representation will be deprecated in a future version of CUDA.
- * 
- * - Note: this is visible to non-nvcc compilers, including C-only compilations
- */
+* Types which allow static initialization of "half" and "half2" until
+* these become an actual builtin. Note this initialization is as a
+* bitfield representation of "half", and not a conversion from short->half.
+* Such a representation will be deprecated in a future version of CUDA. 
+* (Note these are visible to non-nvcc compilers, including C-only compilation)
+*/
 typedef struct __CUDA_ALIGN__(2) {
     unsigned short x;
 } __half_raw;
 
-/**
- * \ingroup CUDA_MATH_INTRINSIC_HALF
- * \brief __half2_raw data type
- * \details Type allows static initialization of \p half2 until it becomes
- * a builtin type.
- * 
- * - Note: this initialization is as a bit-field representation of \p half2,
- * and not a conversion from \p short2 to \p half2.
- * Such representation will be deprecated in a future version of CUDA.
- * 
- * - Note: this is visible to non-nvcc compilers, including C-only compilations
- */
 typedef struct __CUDA_ALIGN__(4) {
     unsigned short x;
     unsigned short y;
@@ -214,72 +189,11 @@ typedef struct __CUDA_ALIGN__(4) {
 #pragma warning( disable:4522 )
 #endif /* defined(__GNUC__) */
 
-// forward-declaration of bfloat type to be used in converting constructor
-struct __nv_bfloat16;
-
-/**
- * \ingroup CUDA_MATH_INTRINSIC_HALF_CONSTANTS
- * \brief Defines floating-point positive infinity value for the \p half data type
- */
-#define CUDART_INF_FP16            __ushort_as_half((unsigned short)0x7C00U)
-/**
- * \ingroup CUDA_MATH_INTRINSIC_HALF_CONSTANTS
- * \brief Defines canonical NaN value for the \p half data type
- */
-#define CUDART_NAN_FP16            __ushort_as_half((unsigned short)0x7FFFU)
-/**
- * \ingroup CUDA_MATH_INTRINSIC_HALF_CONSTANTS
- * \brief Defines a minimum representable (denormalized) value for the \p half data type
- */
-#define CUDART_MIN_DENORM_FP16     __ushort_as_half((unsigned short)0x0001U)
-/**
- * \ingroup CUDA_MATH_INTRINSIC_HALF_CONSTANTS
- * \brief Defines a maximum representable value for the \p half data type
- */
-#define CUDART_MAX_NORMAL_FP16     __ushort_as_half((unsigned short)0x7BFFU)
-/**
- * \ingroup CUDA_MATH_INTRINSIC_HALF_CONSTANTS
- * \brief Defines a negative zero value for the \p half data type
- */
-#define CUDART_NEG_ZERO_FP16       __ushort_as_half((unsigned short)0x8000U)
-/**
- * \ingroup CUDA_MATH_INTRINSIC_HALF_CONSTANTS
- * \brief Defines a positive zero value for the \p half data type
- */
-#define CUDART_ZERO_FP16           __ushort_as_half((unsigned short)0x0000U)
-/**
- * \ingroup CUDA_MATH_INTRINSIC_HALF_CONSTANTS
- * \brief Defines a value of 1.0 for the \p half data type
- */
-#define CUDART_ONE_FP16            __ushort_as_half((unsigned short)0x3C00U)
-
-/**
- * \ingroup CUDA_MATH_INTRINSIC_HALF
- * \brief __half data type
- * \details This structure implements the datatype for storing 
- * half-precision floating-point numbers. The structure implements 
- * assignment, arithmetic and comparison operators, and type conversions. 
- * 16 bits are being used in total: 1 sign bit, 5 bits for the exponent, 
- * and the significand is being stored in 10 bits. 
- * The total precision is 11 bits. There are 15361 representable 
- * numbers within the interval [0.0, 1.0], endpoints included. 
- * On average we have log10(2**11) ~ 3.311 decimal digits. 
- * 
- * The objective here is to provide IEEE754-compliant implementation
- * of \p binary16 type and arithmetic with limitations due to
- * device HW not supporting floating-point exceptions.
- */
 struct __CUDA_ALIGN__(2) __half {
 protected:
-    /**
-     * Protected storage variable contains the bits of floating-point data.
-     */
     unsigned short __x;
 
 public:
-    /**
-     * Constructor by default.
-     */
 #if defined(__CPP_VERSION_AT_LEAST_11_FP16)
     __half() = default;
 #else
@@ -287,379 +201,82 @@ public:
 #endif /* defined(__CPP_VERSION_AT_LEAST_11_FP16) */
 
     /* Convert to/from __half_raw */
-    /**
-     * Constructor from \p __half_raw.
-     */
-    __CUDA_HOSTDEVICE__ __CUDA_FP16_CONSTEXPR__ __half(const __half_raw &hr) : __x(hr.x) { }
-    /**
-     * Assignment operator from \p __half_raw.
-     */
+    __CUDA_HOSTDEVICE__ __half(const __half_raw &hr) : __x(hr.x) { }
     __CUDA_HOSTDEVICE__ __half &operator=(const __half_raw &hr) { __x = hr.x; return *this; }
-    /**
-     * Assignment operator from \p __half_raw to \p volatile \p __half.
-     */
     __CUDA_HOSTDEVICE__ volatile __half &operator=(const __half_raw &hr) volatile { __x = hr.x; return *this; }
-    /**
-     * Assignment operator from \p volatile \p __half_raw to \p volatile \p __half.
-     */
     __CUDA_HOSTDEVICE__ volatile __half &operator=(const volatile __half_raw &hr) volatile { __x = hr.x; return *this; }
-    /**
-     * Type cast to \p __half_raw operator.
-     */
     __CUDA_HOSTDEVICE__ operator __half_raw() const { __half_raw ret; ret.x = __x; return ret; }
-    /**
-     * Type cast to \p __half_raw operator with \p volatile input.
-     */
     __CUDA_HOSTDEVICE__ operator __half_raw() const volatile { __half_raw ret; ret.x = __x; return ret; }
 
 #if !defined(__CUDA_NO_HALF_CONVERSIONS__)
-#if defined(__CPP_VERSION_AT_LEAST_11_FP16)
-    /**
-     * Construct \p __half from \p __nv_bfloat16 input using default round-to-nearest-even rounding mode.
-     * Need to include the header file \p cuda_bf16.h
-     */
-    explicit __CUDA_HOSTDEVICE__ __half(const __nv_bfloat16 f); //forward declaration only, implemented in cuda_bf16.hpp
-#endif /* #if defined(__CPP_VERSION_AT_LEAST_11_FP16) */
 
     /* Construct from float/double */
-    /**
-     * Construct \p __half from \p float input using default round-to-nearest-even rounding mode.
-     */
     __CUDA_HOSTDEVICE__ __half(const float f) { __x = __float2half(f).__x;  }
-    /**
-     * Construct \p __half from \p double input using default round-to-nearest-even rounding mode.
-     */
     __CUDA_HOSTDEVICE__ __half(const double f) { __x = __double2half(f).__x;  }
 
-    /**
-     * Type cast to \p float operator.
-     */
     __CUDA_HOSTDEVICE__ operator float() const { return __half2float(*this); }
-    /**
-     * Type cast to \p __half assignment operator from \p float input using default round-to-nearest-even rounding mode.
-     */
     __CUDA_HOSTDEVICE__ __half &operator=(const float f) { __x = __float2half(f).__x; return *this; }
 
     /* We omit "cast to double" operator, so as to not be ambiguous about up-cast */
-    /**
-     * Type cast to \p __half assignment operator from \p double input using default round-to-nearest-even rounding mode.
-     */
     __CUDA_HOSTDEVICE__ __half &operator=(const double f) { __x = __double2half(f).__x; return *this; }
 
-/*
- * Implicit type conversions to/from integer types were only available to nvcc compilation.
- * Introducing them for all compilers is a potentially breaking change that may affect
- * overloads resolution and will require users to update their code.
- * Define __CUDA_FP16_DISABLE_IMPLICIT_INTEGER_CONVERTS_FOR_HOST_COMPILERS__ to opt-out.
- */
-#if !(defined __CUDA_FP16_DISABLE_IMPLICIT_INTEGER_CONVERTS_FOR_HOST_COMPILERS__) || (defined __CUDACC__)
+/* Member functions only available to nvcc compilation so far */
+#if defined(__CUDACC__)
     /* Allow automatic construction from types supported natively in hardware */
     /* Note we do avoid constructor init-list because of special host/device compilation rules */
-
-    /**
-     * Construct \p __half from \p short integer input using default round-to-nearest-even rounding mode.
-     */
     __CUDA_HOSTDEVICE__ __half(const short val) { __x = __short2half_rn(val).__x;  }
-    /**
-     * Construct \p __half from \p unsigned \p short integer input using default round-to-nearest-even rounding mode.
-     */
     __CUDA_HOSTDEVICE__ __half(const unsigned short val) { __x = __ushort2half_rn(val).__x;  }
-    /**
-     * Construct \p __half from \p int input using default round-to-nearest-even rounding mode.
-     */
     __CUDA_HOSTDEVICE__ __half(const int val) { __x = __int2half_rn(val).__x;  }
-    /**
-     * Construct \p __half from \p unsigned \p int input using default round-to-nearest-even rounding mode.
-     */
     __CUDA_HOSTDEVICE__ __half(const unsigned int val) { __x = __uint2half_rn(val).__x;  }
-
-
-    /**
-     * Construct \p __half from \p long input using default round-to-nearest-even rounding mode.
-     */
-    __CUDA_HOSTDEVICE__ __half(const long val) {
-
-        /* Suppress VS warning: warning C4127: conditional expression is constant */
-#if defined(_MSC_VER) && !defined(__CUDA_ARCH__)
-#pragma warning (disable: 4127)
-#endif /* _MSC_VER && !defined(__CUDA_ARCH__) */
-        if (sizeof(long) == sizeof(long long))
-#if defined(_MSC_VER) && !defined(__CUDA_ARCH__)
-#pragma warning (default: 4127)
-#endif /* _MSC_VER && !defined(__CUDA_ARCH__) */
-
-        {
-            __x = __ll2half_rn(static_cast<long long>(val)).__x;
-        } else {
-            __x = __int2half_rn(static_cast<int>(val)).__x;
-        }
-    }
-
-    /**
-     * Construct \p __half from \p unsigned \p long input using default round-to-nearest-even rounding mode.
-     */
-    __CUDA_HOSTDEVICE__ __half(const unsigned long val) {
-
-        /* Suppress VS warning: warning C4127: conditional expression is constant */
-#if defined(_MSC_VER) && !defined(__CUDA_ARCH__)
-#pragma warning (disable: 4127)
-#endif /* _MSC_VER && !defined(__CUDA_ARCH__) */
-        if (sizeof(unsigned long) == sizeof(unsigned long long))
-#if defined(_MSC_VER) && !defined(__CUDA_ARCH__)
-#pragma warning (default: 4127)
-#endif /* _MSC_VER && !defined(__CUDA_ARCH__) */
-
-        {
-            __x = __ull2half_rn(static_cast<unsigned long long>(val)).__x;
-        } else {
-            __x = __uint2half_rn(static_cast<unsigned int>(val)).__x;
-        }
-    }
-
-    /**
-     * Construct \p __half from \p long \p long input using default round-to-nearest-even rounding mode.
-     */
     __CUDA_HOSTDEVICE__ __half(const long long val) { __x = __ll2half_rn(val).__x;  }
-    /**
-     * Construct \p __half from \p unsigned \p long \p long input using default round-to-nearest-even rounding mode.
-     */
     __CUDA_HOSTDEVICE__ __half(const unsigned long long val) { __x = __ull2half_rn(val).__x; }
 
     /* Allow automatic casts to supported builtin types, matching all that are permitted with float */
-
-    /**
-     * Conversion operator to \p signed \p char data type.
-     * Using round-toward-zero rounding mode.
-     * 
-     * See __half2char_rz(__half) for further details
-     */
-    __CUDA_HOSTDEVICE__ operator signed char() const { return __half2char_rz(*this); }
-    /**
-     * Conversion operator to \p unsigned \p char data type.
-     * Using round-toward-zero rounding mode.
-     * 
-     * See __half2uchar_rz(__half) for further details
-     */
-    __CUDA_HOSTDEVICE__ operator unsigned char() const { return __half2uchar_rz(*this); }
-    /**
-     * Conversion operator to an implementation defined \p char data type.
-     * Using round-toward-zero rounding mode.
-     * 
-     * Detects signedness of the \p char type and proceeds accordingly, see
-     * further details in signed and unsigned char operators.
-     */
-    __CUDA_HOSTDEVICE__ operator char() const {
-        char value;
-        /* Suppress VS warning: warning C4127: conditional expression is constant */
-#if defined(_MSC_VER) && !defined(__CUDA_ARCH__)
-#pragma warning (disable: 4127)
-#endif /* _MSC_VER && !defined(__CUDA_ARCH__) */
-        if (((char)-1) < (char)0)
-#if defined(_MSC_VER) && !defined(__CUDA_ARCH__)
-#pragma warning (default: 4127)
-#endif /* _MSC_VER && !defined(__CUDA_ARCH__) */
-        {
-            value = static_cast<char>(__half2char_rz(*this));
-        }
-        else
-        {
-            value = static_cast<char>(__half2uchar_rz(*this));
-        }
-        return value;
-    }
-    /**
-     * Conversion operator to \p short data type.
-     * Using round-toward-zero rounding mode.
-     * 
-     * See __half2short_rz(__half) for further details
-     */
     __CUDA_HOSTDEVICE__ operator short() const { return __half2short_rz(*this); }
-    /**
-     * Conversion operator to \p unsigned \p short data type.
-     * Using round-toward-zero rounding mode.
-     * 
-     * See __half2ushort_rz(__half) for further details
-     */
-    __CUDA_HOSTDEVICE__ operator unsigned short() const { return __half2ushort_rz(*this); }
-    /**
-     * Conversion operator to \p int data type.
-     * Using round-toward-zero rounding mode.
-     * 
-     * See __half2int_rz(__half) for further details
-     */
-    __CUDA_HOSTDEVICE__ operator int() const { return __half2int_rz(*this); }
-    /**
-     * Conversion operator to \p unsigned \p int data type.
-     * Using round-toward-zero rounding mode.
-     * 
-     * See __half2uint_rz(__half) for further details
-     */
-    __CUDA_HOSTDEVICE__ operator unsigned int() const { return __half2uint_rz(*this); }
-
-
-    /**
-     * Conversion operator to \p long data type.
-     * Using round-toward-zero rounding mode.
-     */
-    __CUDA_HOSTDEVICE__ operator long() const {
-        long retval;
-        /* Suppress VS warning: warning C4127: conditional expression is constant */
-#if defined(_MSC_VER) && !defined(__CUDA_ARCH__)
-#pragma warning (disable: 4127)
-#endif /* _MSC_VER && !defined(__CUDA_ARCH__) */
-        if (sizeof(long) == sizeof(long long))
-#if defined(_MSC_VER) && !defined(__CUDA_ARCH__)
-#pragma warning (default: 4127)
-#endif /* _MSC_VER && !defined(__CUDA_ARCH__) */
-        {
-            retval = static_cast<long>(__half2ll_rz(*this));
-        }
-        else
-        {
-            retval = static_cast<long>(__half2int_rz(*this));
-        }
-        return retval;
-    }
-
-    /**
-     * Conversion operator to \p unsigned \p long data type.
-     * Using round-toward-zero rounding mode.
-     */
-    __CUDA_HOSTDEVICE__ operator unsigned long() const {
-        unsigned long retval;
-        /* Suppress VS warning: warning C4127: conditional expression is constant */
-#if defined(_MSC_VER) && !defined(__CUDA_ARCH__)
-#pragma warning (disable: 4127)
-#endif /* _MSC_VER && !defined(__CUDA_ARCH__) */
-        if (sizeof(unsigned long) == sizeof(unsigned long long))
-#if defined(_MSC_VER) && !defined(__CUDA_ARCH__)
-#pragma warning (default: 4127)
-#endif /* _MSC_VER && !defined(__CUDA_ARCH__) */
-        {
-            retval = static_cast<unsigned long>(__half2ull_rz(*this));
-        }
-        else
-        {
-            retval = static_cast<unsigned long>(__half2uint_rz(*this));
-        }
-        return retval;
-    }
-
-    /**
-     * Conversion operator to \p long \p long data type.
-     * Using round-toward-zero rounding mode.
-     * 
-     * See __half2ll_rz(__half) for further details
-     */
-    __CUDA_HOSTDEVICE__ operator long long() const { return __half2ll_rz(*this); }
-    /**
-     * Conversion operator to \p unsigned \p long \p long data type.
-     * Using round-toward-zero rounding mode.
-     * 
-     * See __half2ull_rz(__half) for further details
-     */
-    __CUDA_HOSTDEVICE__ operator unsigned long long() const { return __half2ull_rz(*this); }
-
-    /**
-     * Type cast from \p short assignment operator, using default round-to-nearest-even rounding mode.
-     */
     __CUDA_HOSTDEVICE__ __half &operator=(const short val) { __x = __short2half_rn(val).__x; return *this; }
-    /**
-     * Type cast from \p unsigned \p short assignment operator, using default round-to-nearest-even rounding mode.
-     */
+
+    __CUDA_HOSTDEVICE__ operator unsigned short() const { return __half2ushort_rz(*this); }
     __CUDA_HOSTDEVICE__ __half &operator=(const unsigned short val) { __x = __ushort2half_rn(val).__x; return *this; }
-    /**
-     * Type cast from \p int assignment operator, using default round-to-nearest-even rounding mode.
-     */
+
+    __CUDA_HOSTDEVICE__ operator int() const { return __half2int_rz(*this); }
     __CUDA_HOSTDEVICE__ __half &operator=(const int val) { __x = __int2half_rn(val).__x; return *this; }
-    /**
-     * Type cast from \p unsigned \p int assignment operator, using default round-to-nearest-even rounding mode.
-     */
+
+    __CUDA_HOSTDEVICE__ operator unsigned int() const { return __half2uint_rz(*this); }
     __CUDA_HOSTDEVICE__ __half &operator=(const unsigned int val) { __x = __uint2half_rn(val).__x; return *this; }
-    /**
-     * Type cast from \p long \p long assignment operator, using default round-to-nearest-even rounding mode.
-     */
+
+    __CUDA_HOSTDEVICE__ operator long long() const { return __half2ll_rz(*this); }
     __CUDA_HOSTDEVICE__ __half &operator=(const long long val) { __x = __ll2half_rn(val).__x; return *this; }
-    /**
-     * Type cast from \p unsigned \p long \p long assignment operator, using default round-to-nearest-even rounding mode.
-     */
+
+    __CUDA_HOSTDEVICE__ operator unsigned long long() const { return __half2ull_rz(*this); }
     __CUDA_HOSTDEVICE__ __half &operator=(const unsigned long long val) { __x = __ull2half_rn(val).__x; return *this; }
 
-    /**
-     * Conversion operator to \p bool data type.
-     * +0 and -0 inputs convert to \p false.
-     * Non-zero inputs convert to \p true.
-     */
-    __CUDA_HOSTDEVICE__ __CUDA_FP16_CONSTEXPR__ operator bool() const { return (__x & 0x7FFFU) != 0U; }
-#endif /* !(defined __CUDA_FP16_DISABLE_IMPLICIT_INTEGER_CONVERTS_FOR_HOST_COMPILERS__) || (defined __CUDACC__) */
+    /* Boolean conversion - note both 0 and -0 must return false */
+    __CUDA_HOSTDEVICE__ operator bool() const { return (__x & 0x7FFFU) != 0U; }
+#endif /* defined(__CUDACC__) */
 #endif /* !defined(__CUDA_NO_HALF_CONVERSIONS__) */
 };
 
+/* Global-space operator functions are only available to nvcc compilation */
+#if defined(__CUDACC__)
+
+/* Arithmetic FP16 operations only supported on arch >= 5.3 */
+#if !defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 530) || defined(_NVHPC_CUDA)
 #if !defined(__CUDA_NO_HALF_OPERATORS__)
 /* Some basic arithmetic operations expected of a builtin */
+__device__ __forceinline__ __half operator+(const __half &lh, const __half &rh) { return __hadd(lh, rh); }
+__device__ __forceinline__ __half operator-(const __half &lh, const __half &rh) { return __hsub(lh, rh); }
+__device__ __forceinline__ __half operator*(const __half &lh, const __half &rh) { return __hmul(lh, rh); }
+__device__ __forceinline__ __half operator/(const __half &lh, const __half &rh) { return __hdiv(lh, rh); }
 
-/**
- * \ingroup CUDA_MATH__HALF_ARITHMETIC
- * Performs \p half addition operation.
- * See also __hadd(__half, __half)
- */
-__CUDA_HOSTDEVICE__ __forceinline__ __half operator+(const __half &lh, const __half &rh) { return __hadd(lh, rh); }
-/**
- * \ingroup CUDA_MATH__HALF_ARITHMETIC
- * Performs \p half subtraction operation.
- * See also __hsub(__half, __half)
- */
-__CUDA_HOSTDEVICE__ __forceinline__ __half operator-(const __half &lh, const __half &rh) { return __hsub(lh, rh); }
-/**
- * \ingroup CUDA_MATH__HALF_ARITHMETIC
- * Performs \p half multiplication operation.
- * See also __hmul(__half, __half)
- */
-__CUDA_HOSTDEVICE__ __forceinline__ __half operator*(const __half &lh, const __half &rh) { return __hmul(lh, rh); }
-/**
- * \ingroup CUDA_MATH__HALF_ARITHMETIC
- * Performs \p half division operation.
- * See also __hdiv(__half, __half)
- */
-__CUDA_HOSTDEVICE__ __forceinline__ __half operator/(const __half &lh, const __half &rh) { return __hdiv(lh, rh); }
-
-/**
- * \ingroup CUDA_MATH__HALF_ARITHMETIC
- * Performs \p half compound assignment with addition operation.
- */
-__CUDA_HOSTDEVICE__ __forceinline__ __half &operator+=(__half &lh, const __half &rh) { lh = __hadd(lh, rh); return lh; }
-/**
- * \ingroup CUDA_MATH__HALF_ARITHMETIC
- * Performs \p half compound assignment with subtraction operation.
- */
-__CUDA_HOSTDEVICE__ __forceinline__ __half &operator-=(__half &lh, const __half &rh) { lh = __hsub(lh, rh); return lh; }
-/**
- * \ingroup CUDA_MATH__HALF_ARITHMETIC
- * Performs \p half compound assignment with multiplication operation.
- */
-__CUDA_HOSTDEVICE__ __forceinline__ __half &operator*=(__half &lh, const __half &rh) { lh = __hmul(lh, rh); return lh; }
-/**
- * \ingroup CUDA_MATH__HALF_ARITHMETIC
- * Performs \p half compound assignment with division operation.
- */
-__CUDA_HOSTDEVICE__ __forceinline__ __half &operator/=(__half &lh, const __half &rh) { lh = __hdiv(lh, rh); return lh; }
+__device__ __forceinline__ __half &operator+=(__half &lh, const __half &rh) { lh = __hadd(lh, rh); return lh; }
+__device__ __forceinline__ __half &operator-=(__half &lh, const __half &rh) { lh = __hsub(lh, rh); return lh; }
+__device__ __forceinline__ __half &operator*=(__half &lh, const __half &rh) { lh = __hmul(lh, rh); return lh; }
+__device__ __forceinline__ __half &operator/=(__half &lh, const __half &rh) { lh = __hdiv(lh, rh); return lh; }
 
 /* Note for increment and decrement we use the raw value 0x3C00U equating to half(1.0F), to avoid the extra conversion */
-/**
- * \ingroup CUDA_MATH__HALF_ARITHMETIC
- * Performs \p half prefix increment operation.
- */
-__CUDA_HOSTDEVICE__ __forceinline__ __half &operator++(__half &h)      { __half_raw one; one.x = 0x3C00U; h += one; return h; }
-/**
- * \ingroup CUDA_MATH__HALF_ARITHMETIC
- * Performs \p half prefix decrement operation.
- */
-__CUDA_HOSTDEVICE__ __forceinline__ __half &operator--(__half &h)      { __half_raw one; one.x = 0x3C00U; h -= one; return h; }
-/**
- * \ingroup CUDA_MATH__HALF_ARITHMETIC
- * Performs \p half postfix increment operation.
- */
-__CUDA_HOSTDEVICE__ __forceinline__ __half  operator++(__half &h, const int ignored)
+__device__ __forceinline__ __half &operator++(__half &h)      { __half_raw one; one.x = 0x3C00U; h += one; return h; }
+__device__ __forceinline__ __half &operator--(__half &h)      { __half_raw one; one.x = 0x3C00U; h -= one; return h; }
+__device__ __forceinline__ __half  operator++(__half &h, const int ignored)
 {
     // ignored on purpose. Parameter only needed to distinguish the function declaration from other types of operators.
     static_cast<void>(ignored);
@@ -670,11 +287,7 @@ __CUDA_HOSTDEVICE__ __forceinline__ __half  operator++(__half &h, const int igno
     h += one;
     return ret;
 }
-/**
- * \ingroup CUDA_MATH__HALF_ARITHMETIC
- * Performs \p half postfix decrement operation.
- */
-__CUDA_HOSTDEVICE__ __forceinline__ __half  operator--(__half &h, const int ignored)
+__device__ __forceinline__ __half  operator--(__half &h, const int ignored)
 {
     // ignored on purpose. Parameter only needed to distinguish the function declaration from other types of operators.
     static_cast<void>(ignored);
@@ -687,184 +300,63 @@ __CUDA_HOSTDEVICE__ __forceinline__ __half  operator--(__half &h, const int igno
 }
 
 /* Unary plus and inverse operators */
-/**
- * \ingroup CUDA_MATH__HALF_ARITHMETIC
- * Implements \p half unary plus operator, returns input value.
- */
-__CUDA_HOSTDEVICE__ __forceinline__ __half operator+(const __half &h) { return h; }
-/**
- * \ingroup CUDA_MATH__HALF_ARITHMETIC
- * Implements \p half unary minus operator.
- * See also __hneg(__half)
- */
-__CUDA_HOSTDEVICE__ __forceinline__ __half operator-(const __half &h) { return __hneg(h); }
+__device__ __forceinline__ __half operator+(const __half &h) { return h; }
+__device__ __forceinline__ __half operator-(const __half &h) { return __hneg(h); }
 
 /* Some basic comparison operations to make it look like a builtin */
-/**
- * \ingroup CUDA_MATH__HALF_COMPARISON
- * Performs \p half ordered compare equal operation.
- * See also __heq(__half, __half)
- */
-__CUDA_HOSTDEVICE__ __forceinline__ bool operator==(const __half &lh, const __half &rh) { return __heq(lh, rh); }
-/**
- * \ingroup CUDA_MATH__HALF_COMPARISON
- * Performs \p half unordered compare not-equal operation.
- * See also __hneu(__half, __half)
- */
-__CUDA_HOSTDEVICE__ __forceinline__ bool operator!=(const __half &lh, const __half &rh) { return __hneu(lh, rh); }
-/**
- * \ingroup CUDA_MATH__HALF_COMPARISON
- * Performs \p half ordered greater-than compare operation.
- * See also __hgt(__half, __half)
- */
-__CUDA_HOSTDEVICE__ __forceinline__ bool operator> (const __half &lh, const __half &rh) { return __hgt(lh, rh); }
-/**
- * \ingroup CUDA_MATH__HALF_COMPARISON
- * Performs \p half ordered less-than compare operation.
- * See also __hlt(__half, __half)
- */
-__CUDA_HOSTDEVICE__ __forceinline__ bool operator< (const __half &lh, const __half &rh) { return __hlt(lh, rh); }
-/**
- * \ingroup CUDA_MATH__HALF_COMPARISON
- * Performs \p half ordered greater-or-equal compare operation.
- * See also __hge(__half, __half)
- */
-__CUDA_HOSTDEVICE__ __forceinline__ bool operator>=(const __half &lh, const __half &rh) { return __hge(lh, rh); }
-/**
- * \ingroup CUDA_MATH__HALF_COMPARISON
- * Performs \p half ordered less-or-equal compare operation.
- * See also __hle(__half, __half)
- */
-__CUDA_HOSTDEVICE__ __forceinline__ bool operator<=(const __half &lh, const __half &rh) { return __hle(lh, rh); }
+__device__ __forceinline__ bool operator==(const __half &lh, const __half &rh) { return __heq(lh, rh); }
+__device__ __forceinline__ bool operator!=(const __half &lh, const __half &rh) { return __hneu(lh, rh); }
+__device__ __forceinline__ bool operator> (const __half &lh, const __half &rh) { return __hgt(lh, rh); }
+__device__ __forceinline__ bool operator< (const __half &lh, const __half &rh) { return __hlt(lh, rh); }
+__device__ __forceinline__ bool operator>=(const __half &lh, const __half &rh) { return __hge(lh, rh); }
+__device__ __forceinline__ bool operator<=(const __half &lh, const __half &rh) { return __hle(lh, rh); }
 #endif /* !defined(__CUDA_NO_HALF_OPERATORS__) */
+#endif /* !defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 530) || defined(_NVHPC_CUDA) */
+#endif /* defined(__CUDACC__) */
 
-/**
- * \ingroup CUDA_MATH_INTRINSIC_HALF
- * \brief __half2 data type
- * \details This structure implements the datatype for storing two 
- * half-precision floating-point numbers. 
- * The structure implements assignment, arithmetic and comparison
- * operators, and type conversions. 
- * 
- * - NOTE: __half2 is visible to non-nvcc host compilers
- */
+/* __half2 is visible to non-nvcc host compilers */
 struct __CUDA_ALIGN__(4) __half2 {
-    /**
-     * Storage field holding lower \p __half part.
-     */
     __half x;
-    /**
-     * Storage field holding upper \p __half part.
-     */
     __half y;
 
     // All construct/copy/assign/move
 public:
-    /**
-     * Constructor by default.
-     */
 #if defined(__CPP_VERSION_AT_LEAST_11_FP16)
     __half2() = default;
-    /**
-     * Move constructor, available for \p C++11 and later dialects
-     */
     __CUDA_HOSTDEVICE__ __half2(const __half2 &&src) { __HALF2_TO_UI(*this) = std::move(__HALF2_TO_CUI(src)); }
-    /**
-     * Move assignment operator, available for \p C++11 and later dialects
-     */
     __CUDA_HOSTDEVICE__ __half2 &operator=(const __half2 &&src) { __HALF2_TO_UI(*this) = std::move(__HALF2_TO_CUI(src)); return *this; }
 #else
     __CUDA_HOSTDEVICE__ __half2() { }
 #endif /* defined(__CPP_VERSION_AT_LEAST_11_FP16) */
-
-    /**
-     * Constructor from two \p __half variables
-     */
-    __CUDA_HOSTDEVICE__ __CUDA_FP16_CONSTEXPR__ __half2(const __half &a, const __half &b) : x(a), y(b) { }
-    /**
-     * Copy constructor
-     */
+    __CUDA_HOSTDEVICE__ __half2(const __half &a, const __half &b) : x(a), y(b) { }
     __CUDA_HOSTDEVICE__ __half2(const __half2 &src) { __HALF2_TO_UI(*this) = __HALF2_TO_CUI(src); }
-    /**
-     * Copy assignment operator
-     */
     __CUDA_HOSTDEVICE__ __half2 &operator=(const __half2 &src) { __HALF2_TO_UI(*this) = __HALF2_TO_CUI(src); return *this; }
 
     /* Convert to/from __half2_raw */
-    /**
-     * Constructor from \p __half2_raw
-     */
     __CUDA_HOSTDEVICE__ __half2(const __half2_raw &h2r ) { __HALF2_TO_UI(*this) = __HALF2_TO_CUI(h2r); }
-    /**
-     * Assignment operator from \p __half2_raw
-     */
     __CUDA_HOSTDEVICE__ __half2 &operator=(const __half2_raw &h2r) { __HALF2_TO_UI(*this) = __HALF2_TO_CUI(h2r); return *this; }
-    /**
-     * Conversion operator to \p __half2_raw
-     */
     __CUDA_HOSTDEVICE__ operator __half2_raw() const { __half2_raw ret; ret.x = 0U; ret.y = 0U; __HALF2_TO_UI(ret) = __HALF2_TO_CUI(*this); return ret; }
 };
 
-#if !defined(__CUDA_NO_HALF2_OPERATORS__)
-/**
- * \ingroup CUDA_MATH__HALF2_ARITHMETIC
- * Performs packed \p half addition operation.
- * See also __hadd2(__half2, __half2)
- */
-__CUDA_HOSTDEVICE__ __forceinline__ __half2 operator+(const __half2 &lh, const __half2 &rh) { return __hadd2(lh, rh); }
-/**
- * \ingroup CUDA_MATH__HALF2_ARITHMETIC
- * Performs packed \p half subtraction operation.
- * See also __hsub2(__half2, __half2)
- */
-__CUDA_HOSTDEVICE__ __forceinline__ __half2 operator-(const __half2 &lh, const __half2 &rh) { return __hsub2(lh, rh); }
-/**
- * \ingroup CUDA_MATH__HALF2_ARITHMETIC
- * Performs packed \p half multiplication operation.
- * See also __hmul2(__half2, __half2)
- */
-__CUDA_HOSTDEVICE__ __forceinline__ __half2 operator*(const __half2 &lh, const __half2 &rh) { return __hmul2(lh, rh); }
-/**
- * \ingroup CUDA_MATH__HALF2_ARITHMETIC
- * Performs packed \p half division operation.
- * See also __h2div(__half2, __half2)
- */
-__CUDA_HOSTDEVICE__ __forceinline__ __half2 operator/(const __half2 &lh, const __half2 &rh) { return __h2div(lh, rh); }
-/**
- * \ingroup CUDA_MATH__HALF2_ARITHMETIC
- * Performs packed \p half compound assignment with addition operation.
- */
-__CUDA_HOSTDEVICE__ __forceinline__ __half2& operator+=(__half2 &lh, const __half2 &rh) { lh = __hadd2(lh, rh); return lh; }
-/**
- * \ingroup CUDA_MATH__HALF2_ARITHMETIC
- * Performs packed \p half compound assignment with subtraction operation.
- */
-__CUDA_HOSTDEVICE__ __forceinline__ __half2& operator-=(__half2 &lh, const __half2 &rh) { lh = __hsub2(lh, rh); return lh; }
-/**
- * \ingroup CUDA_MATH__HALF2_ARITHMETIC
- * Performs packed \p half compound assignment with multiplication operation.
- */
-__CUDA_HOSTDEVICE__ __forceinline__ __half2& operator*=(__half2 &lh, const __half2 &rh) { lh = __hmul2(lh, rh); return lh; }
-/**
- * \ingroup CUDA_MATH__HALF2_ARITHMETIC
- * Performs packed \p half compound assignment with division operation.
- */
-__CUDA_HOSTDEVICE__ __forceinline__ __half2& operator/=(__half2 &lh, const __half2 &rh) { lh = __h2div(lh, rh); return lh; }
-/**
- * \ingroup CUDA_MATH__HALF2_ARITHMETIC
- * Performs packed \p half prefix increment operation.
- */
-__CUDA_HOSTDEVICE__ __forceinline__ __half2 &operator++(__half2 &h)      { __half2_raw one; one.x = 0x3C00U; one.y = 0x3C00U; h = __hadd2(h, one); return h; }
-/**
- * \ingroup CUDA_MATH__HALF2_ARITHMETIC
- * Performs packed \p half prefix decrement operation.
- */
-__CUDA_HOSTDEVICE__ __forceinline__ __half2 &operator--(__half2 &h)      { __half2_raw one; one.x = 0x3C00U; one.y = 0x3C00U; h = __hsub2(h, one); return h; }
-/**
- * \ingroup CUDA_MATH__HALF2_ARITHMETIC
- * Performs packed \p half postfix increment operation.
- */
-__CUDA_HOSTDEVICE__ __forceinline__ __half2  operator++(__half2 &h, const int ignored)
+/* Global-space operator functions are only available to nvcc compilation */
+#if defined(__CUDACC__)
+
+/* Arithmetic FP16x2 operations only supported on arch >= 5.3 */
+#if (!defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 530) || defined(_NVHPC_CUDA)) && !defined(__CUDA_NO_HALF2_OPERATORS__)
+
+__device__ __forceinline__ __half2 operator+(const __half2 &lh, const __half2 &rh) { return __hadd2(lh, rh); }
+__device__ __forceinline__ __half2 operator-(const __half2 &lh, const __half2 &rh) { return __hsub2(lh, rh); }
+__device__ __forceinline__ __half2 operator*(const __half2 &lh, const __half2 &rh) { return __hmul2(lh, rh); }
+__device__ __forceinline__ __half2 operator/(const __half2 &lh, const __half2 &rh) { return __h2div(lh, rh); }
+
+__device__ __forceinline__ __half2& operator+=(__half2 &lh, const __half2 &rh) { lh = __hadd2(lh, rh); return lh; }
+__device__ __forceinline__ __half2& operator-=(__half2 &lh, const __half2 &rh) { lh = __hsub2(lh, rh); return lh; }
+__device__ __forceinline__ __half2& operator*=(__half2 &lh, const __half2 &rh) { lh = __hmul2(lh, rh); return lh; }
+__device__ __forceinline__ __half2& operator/=(__half2 &lh, const __half2 &rh) { lh = __h2div(lh, rh); return lh; }
+
+__device__ __forceinline__ __half2 &operator++(__half2 &h)      { __half2_raw one; one.x = 0x3C00U; one.y = 0x3C00U; h = __hadd2(h, one); return h; }
+__device__ __forceinline__ __half2 &operator--(__half2 &h)      { __half2_raw one; one.x = 0x3C00U; one.y = 0x3C00U; h = __hsub2(h, one); return h; }
+__device__ __forceinline__ __half2  operator++(__half2 &h, const int ignored)
 {
     // ignored on purpose. Parameter only needed to distinguish the function declaration from other types of operators.
     static_cast<void>(ignored);
@@ -876,11 +368,7 @@ __CUDA_HOSTDEVICE__ __forceinline__ __half2  operator++(__half2 &h, const int ig
     h = __hadd2(h, one);
     return ret;
 }
-/**
- * \ingroup CUDA_MATH__HALF2_ARITHMETIC
- * Performs packed \p half postfix decrement operation.
- */
-__CUDA_HOSTDEVICE__ __forceinline__ __half2  operator--(__half2 &h, const int ignored)
+__device__ __forceinline__ __half2  operator--(__half2 &h, const int ignored)
 {
     // ignored on purpose. Parameter only needed to distinguish the function declaration from other types of operators.
     static_cast<void>(ignored);
@@ -892,55 +380,19 @@ __CUDA_HOSTDEVICE__ __forceinline__ __half2  operator--(__half2 &h, const int ig
     h = __hsub2(h, one);
     return ret;
 }
-/**
- * \ingroup CUDA_MATH__HALF2_ARITHMETIC
- * Implements packed \p half unary plus operator, returns input value.
- */
-__CUDA_HOSTDEVICE__ __forceinline__ __half2 operator+(const __half2 &h) { return h; }
-/**
- * \ingroup CUDA_MATH__HALF2_ARITHMETIC
- * Implements packed \p half unary minus operator.
- * See also __hneg2(__half2)
- */
-__CUDA_HOSTDEVICE__ __forceinline__ __half2 operator-(const __half2 &h) { return __hneg2(h); }
-/**
- * \ingroup CUDA_MATH__HALF2_COMPARISON
- * Performs packed \p half ordered compare equal operation.
- * See also __hbeq2(__half2, __half2)
- */
-__CUDA_HOSTDEVICE__ __forceinline__ bool operator==(const __half2 &lh, const __half2 &rh) { return __hbeq2(lh, rh); }
-/**
- * \ingroup CUDA_MATH__HALF2_COMPARISON
- * Performs packed \p half unordered compare not-equal operation.
- * See also __hbneu2(__half2, __half2)
- */
-__CUDA_HOSTDEVICE__ __forceinline__ bool operator!=(const __half2 &lh, const __half2 &rh) { return __hbneu2(lh, rh); }
-/**
- * \ingroup CUDA_MATH__HALF2_COMPARISON
- * Performs packed \p half ordered greater-than compare operation.
- * See also __hbgt2(__half2, __half2)
- */
-__CUDA_HOSTDEVICE__ __forceinline__ bool operator>(const __half2 &lh, const __half2 &rh) { return __hbgt2(lh, rh); }
-/**
- * \ingroup CUDA_MATH__HALF2_COMPARISON
- * Performs packed \p half ordered less-than compare operation.
- * See also __hblt2(__half2, __half2)
- */
-__CUDA_HOSTDEVICE__ __forceinline__ bool operator<(const __half2 &lh, const __half2 &rh) { return __hblt2(lh, rh); }
-/**
- * \ingroup CUDA_MATH__HALF2_COMPARISON
- * Performs packed \p half ordered greater-or-equal compare operation.
- * See also __hbge2(__half2, __half2)
- */
-__CUDA_HOSTDEVICE__ __forceinline__ bool operator>=(const __half2 &lh, const __half2 &rh) { return __hbge2(lh, rh); }
-/**
- * \ingroup CUDA_MATH__HALF2_COMPARISON
- * Performs packed \p half ordered less-or-equal compare operation.
- * See also __hble2(__half2, __half2)
- */
-__CUDA_HOSTDEVICE__ __forceinline__ bool operator<=(const __half2 &lh, const __half2 &rh) { return __hble2(lh, rh); }
 
-#endif /* !defined(__CUDA_NO_HALF2_OPERATORS__) */
+__device__ __forceinline__ __half2 operator+(const __half2 &h) { return h; }
+__device__ __forceinline__ __half2 operator-(const __half2 &h) { return __hneg2(h); }
+
+__device__ __forceinline__ bool operator==(const __half2 &lh, const __half2 &rh) { return __hbeq2(lh, rh); }
+__device__ __forceinline__ bool operator!=(const __half2 &lh, const __half2 &rh) { return __hbneu2(lh, rh); }
+__device__ __forceinline__ bool operator>(const __half2 &lh, const __half2 &rh) { return __hbgt2(lh, rh); }
+__device__ __forceinline__ bool operator<(const __half2 &lh, const __half2 &rh) { return __hblt2(lh, rh); }
+__device__ __forceinline__ bool operator>=(const __half2 &lh, const __half2 &rh) { return __hbge2(lh, rh); }
+__device__ __forceinline__ bool operator<=(const __half2 &lh, const __half2 &rh) { return __hble2(lh, rh); }
+
+#endif /* (!defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 530) || defined(_NVHPC_CUDA)) && !defined(__CUDA_NO_HALF2_OPERATORS__) */
+#endif /* defined(__CUDACC__) */
 
 /* Restore warning for multiple assignment operators */
 #if defined(_MSC_VER) && _MSC_VER >= 1500
@@ -1137,6 +589,7 @@ IF_DEVICE_OR_CUDACC(
     return result;
 )
 }
+
 __CUDA_HOSTDEVICE_FP16_DECL__ __half __float2half(const float a)
 {
     __half val;
@@ -1253,7 +706,7 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half2 __floats2half2_rn(const float a, const flo
 {
     __half2 val;
 NV_IF_ELSE_TARGET(NV_IS_DEVICE,
-    val = __internal_device_float2_to_half2_rn(a,b);
+   val = __internal_device_float2_to_half2_rn(a,b);
 ,
     val = __half2(__float2half_rn(a), __float2half_rn(b));
 )
@@ -1330,68 +783,6 @@ NV_IF_ELSE_TARGET(NV_IS_DEVICE,
 )
     return val;
 }
-
-__CUDA_HOSTDEVICE_FP16_DECL__ signed char __half2char_rz(const __half h)
-{
-    signed char i;
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_90,
-    unsigned int tmp;
-    asm("cvt.rzi.s8.f16 %0, %1;" : "=r"(tmp) : "h"(__HALF_TO_CUS(h)));
-    const unsigned char u = static_cast<unsigned char>(tmp);
-    i = static_cast<signed char>(u);
-,
-    const float f = __half2float(h);
-    const signed char max_val = (signed char)0x7fU;
-    const signed char min_val = (signed char)0x80U;
-    const unsigned short bits = static_cast<unsigned short>(static_cast<__half_raw>(h).x << 1U);
-    // saturation fixup
-    if (bits > (unsigned short)0xF800U) {
-        // NaN
-        i = 0;
-    } else if (f > static_cast<float>(max_val)) {
-        // saturate maximum
-        i = max_val;
-    } else if (f < static_cast<float>(min_val)) {
-        // saturate minimum
-        i = min_val;
-    } else {
-        // normal value, conversion is well-defined
-        i = static_cast<signed char>(f);
-    }
-)
-    return i;
-}
-
-__CUDA_HOSTDEVICE_FP16_DECL__ unsigned char __half2uchar_rz(const __half h)
-{
-    unsigned char i;
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_90,
-    unsigned int tmp;
-    asm("cvt.rzi.u8.f16 %0, %1;" : "=r"(tmp) : "h"(__HALF_TO_CUS(h)));
-    i = static_cast<unsigned char>(tmp);
-,
-    const float f = __half2float(h);
-    const unsigned char max_val = 0xffU;
-    const unsigned char min_val = 0U;
-    const unsigned short bits = static_cast<unsigned short>(static_cast<__half_raw>(h).x << 1U);
-    // saturation fixup
-    if (bits > (unsigned short)0xF800U) {
-        // NaN
-        i = 0U;
-    } else if (f > static_cast<float>(max_val)) {
-        // saturate maximum
-        i = max_val;
-    } else if (f < static_cast<float>(min_val)) {
-        // saturate minimum
-        i = min_val;
-    } else {
-        // normal value, conversion is well-defined
-        i = static_cast<unsigned char>(f);
-    }
-)
-    return i;
-}
-
 __CUDA_HOSTDEVICE_FP16_DECL__ short int __half2short_rz(const __half h)
 {
     short int i;
@@ -1554,11 +945,16 @@ NV_IF_ELSE_TARGET(NV_IS_DEVICE,
 )
     return i;
 }
+
+/* Intrinsic functions only available to nvcc compilers */
+#if defined(__CUDACC__)
+
 /* CUDA vector-types compatible vector creation function (note returns __half2, not half2) */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 make_half2(const __half x, const __half y)
+__VECTOR_FUNCTIONS_DECL__ __half2 make_half2(const __half x, const __half y)
 {
     __half2 t; t.x = x; t.y = y; return t;
 }
+#undef __VECTOR_FUNCTIONS_DECL__
 
 
 /* Definitions of intrinsics */
@@ -1585,7 +981,6 @@ NV_IF_ELSE_TARGET(NV_IS_DEVICE,
 )
     return make_float2(lo_float, hi_float);
 }
-#if defined(__CUDACC__) || defined(_NVHPC_CUDA)
 __CUDA_FP16_DECL__ int __half2int_rn(const __half h)
 {
     int i;
@@ -1604,7 +999,6 @@ __CUDA_FP16_DECL__ int __half2int_ru(const __half h)
     asm("cvt.rpi.s32.f16 %0, %1;" : "=r"(i) : "h"(__HALF_TO_CUS(h)));
     return i;
 }
-#endif /* defined(__CUDACC__) || defined(_NVHPC_CUDA) */
 __CUDA_HOSTDEVICE_FP16_DECL__ __half __int2half_rn(const int i)
 {
     __half h;
@@ -1620,40 +1014,25 @@ NV_IF_ELSE_TARGET(NV_IS_DEVICE,
 )
     return h;
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __int2half_rz(const int i)
+__CUDA_FP16_DECL__ __half __int2half_rz(const int i)
 {
     __half h;
-NV_IF_ELSE_TARGET(NV_IS_DEVICE,
     asm("cvt.rz.f16.s32 %0, %1;" : "=h"(__HALF_TO_US(h)) : "r"(i));
-,
-    const float  f = static_cast<float>(i);
-                 h = __float2half_rz(f);
-)
     return h;
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __int2half_rd(const int i)
+__CUDA_FP16_DECL__ __half __int2half_rd(const int i)
 {
     __half h;
-NV_IF_ELSE_TARGET(NV_IS_DEVICE,
     asm("cvt.rm.f16.s32 %0, %1;" : "=h"(__HALF_TO_US(h)) : "r"(i));
-,
-    const float  f = static_cast<float>(i);
-                 h = __float2half_rd(f);
-)
     return h;
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __int2half_ru(const int i)
+__CUDA_FP16_DECL__ __half __int2half_ru(const int i)
 {
     __half h;
-NV_IF_ELSE_TARGET(NV_IS_DEVICE,
     asm("cvt.rp.f16.s32 %0, %1;" : "=h"(__HALF_TO_US(h)) : "r"(i));
-,
-    const float  f = static_cast<float>(i);
-                 h = __float2half_ru(f);
-)
     return h;
 }
-#if defined(__CUDACC__) || defined(_NVHPC_CUDA)
+
 __CUDA_FP16_DECL__ short int __half2short_rn(const __half h)
 {
     short int i;
@@ -1672,7 +1051,6 @@ __CUDA_FP16_DECL__ short int __half2short_ru(const __half h)
     asm("cvt.rpi.s16.f16 %0, %1;" : "=h"(i) : "h"(__HALF_TO_CUS(h)));
     return i;
 }
-#endif /* defined(__CUDACC__) || defined(_NVHPC_CUDA) */
 __CUDA_HOSTDEVICE_FP16_DECL__ __half __short2half_rn(const short int i)
 {
     __half h;
@@ -1684,40 +1062,25 @@ NV_IF_ELSE_TARGET(NV_IS_DEVICE,
 )
     return h;
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __short2half_rz(const short int i)
+__CUDA_FP16_DECL__ __half __short2half_rz(const short int i)
 {
     __half h;
-NV_IF_ELSE_TARGET(NV_IS_DEVICE,
     asm("cvt.rz.f16.s16 %0, %1;" : "=h"(__HALF_TO_US(h)) : "h"(i));
-,
-    const float  f = static_cast<float>(i);
-                 h = __float2half_rz(f);
-)
     return h;
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __short2half_rd(const short int i)
+__CUDA_FP16_DECL__ __half __short2half_rd(const short int i)
 {
     __half h;
-NV_IF_ELSE_TARGET(NV_IS_DEVICE,
     asm("cvt.rm.f16.s16 %0, %1;" : "=h"(__HALF_TO_US(h)) : "h"(i));
-,
-    const float  f = static_cast<float>(i);
-                 h = __float2half_rd(f);
-)
     return h;
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __short2half_ru(const short int i)
+__CUDA_FP16_DECL__ __half __short2half_ru(const short int i)
 {
     __half h;
-NV_IF_ELSE_TARGET(NV_IS_DEVICE,
     asm("cvt.rp.f16.s16 %0, %1;" : "=h"(__HALF_TO_US(h)) : "h"(i));
-,
-    const float  f = static_cast<float>(i);
-                 h = __float2half_ru(f);
-)
     return h;
 }
-#if defined(__CUDACC__) || defined(_NVHPC_CUDA)
+
 __CUDA_FP16_DECL__ unsigned int __half2uint_rn(const __half h)
 {
     unsigned int i;
@@ -1736,7 +1099,6 @@ __CUDA_FP16_DECL__ unsigned int __half2uint_ru(const __half h)
     asm("cvt.rpi.u32.f16 %0, %1;" : "=r"(i) : "h"(__HALF_TO_CUS(h)));
     return i;
 }
-#endif /* defined(__CUDACC__) || defined(_NVHPC_CUDA) */
 __CUDA_HOSTDEVICE_FP16_DECL__ __half __uint2half_rn(const unsigned int i)
 {
     __half h;
@@ -1752,40 +1114,25 @@ NV_IF_ELSE_TARGET(NV_IS_DEVICE,
 )
     return h;
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __uint2half_rz(const unsigned int i)
+__CUDA_FP16_DECL__ __half __uint2half_rz(const unsigned int i)
 {
     __half h;
-NV_IF_ELSE_TARGET(NV_IS_DEVICE,
     asm("cvt.rz.f16.u32 %0, %1;" : "=h"(__HALF_TO_US(h)) : "r"(i));
-,
-    const float  f = static_cast<float>(i);
-                 h = __float2half_rz(f);
-)
     return h;
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __uint2half_rd(const unsigned int i)
+__CUDA_FP16_DECL__ __half __uint2half_rd(const unsigned int i)
 {
     __half h;
-NV_IF_ELSE_TARGET(NV_IS_DEVICE,
     asm("cvt.rm.f16.u32 %0, %1;" : "=h"(__HALF_TO_US(h)) : "r"(i));
-,
-    const float  f = static_cast<float>(i);
-                 h = __float2half_rd(f);
-)
     return h;
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __uint2half_ru(const unsigned int i)
+__CUDA_FP16_DECL__ __half __uint2half_ru(const unsigned int i)
 {
     __half h;
-NV_IF_ELSE_TARGET(NV_IS_DEVICE,
     asm("cvt.rp.f16.u32 %0, %1;" : "=h"(__HALF_TO_US(h)) : "r"(i));
-,
-    const float  f = static_cast<float>(i);
-                 h = __float2half_ru(f);
-)
     return h;
 }
-#if defined(__CUDACC__) || defined(_NVHPC_CUDA)
+
 __CUDA_FP16_DECL__ unsigned short int __half2ushort_rn(const __half h)
 {
     unsigned short int i;
@@ -1804,7 +1151,6 @@ __CUDA_FP16_DECL__ unsigned short int __half2ushort_ru(const __half h)
     asm("cvt.rpi.u16.f16 %0, %1;" : "=h"(i) : "h"(__HALF_TO_CUS(h)));
     return i;
 }
-#endif /* defined(__CUDACC__) || defined(_NVHPC_CUDA) */
 __CUDA_HOSTDEVICE_FP16_DECL__ __half __ushort2half_rn(const unsigned short int i)
 {
     __half h;
@@ -1816,40 +1162,25 @@ NV_IF_ELSE_TARGET(NV_IS_DEVICE,
 )
     return h;
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __ushort2half_rz(const unsigned short int i)
+__CUDA_FP16_DECL__ __half __ushort2half_rz(const unsigned short int i)
 {
     __half h;
-NV_IF_ELSE_TARGET(NV_IS_DEVICE,
     asm("cvt.rz.f16.u16 %0, %1;" : "=h"(__HALF_TO_US(h)) : "h"(i));
-,
-    const float  f = static_cast<float>(i);
-                 h = __float2half_rz(f);
-)
     return h;
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __ushort2half_rd(const unsigned short int i)
+__CUDA_FP16_DECL__ __half __ushort2half_rd(const unsigned short int i)
 {
     __half h;
-NV_IF_ELSE_TARGET(NV_IS_DEVICE,
     asm("cvt.rm.f16.u16 %0, %1;" : "=h"(__HALF_TO_US(h)) : "h"(i));
-,
-    const float  f = static_cast<float>(i);
-                 h = __float2half_rd(f);
-)
     return h;
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __ushort2half_ru(const unsigned short int i)
+__CUDA_FP16_DECL__ __half __ushort2half_ru(const unsigned short int i)
 {
     __half h;
-NV_IF_ELSE_TARGET(NV_IS_DEVICE,
     asm("cvt.rp.f16.u16 %0, %1;" : "=h"(__HALF_TO_US(h)) : "h"(i));
-,
-    const float  f = static_cast<float>(i);
-                 h = __float2half_ru(f);
-)
     return h;
 }
-#if defined(__CUDACC__) || defined(_NVHPC_CUDA)
+
 __CUDA_FP16_DECL__ unsigned long long int __half2ull_rn(const __half h)
 {
     unsigned long long int i;
@@ -1868,7 +1199,6 @@ __CUDA_FP16_DECL__ unsigned long long int __half2ull_ru(const __half h)
     asm("cvt.rpi.u64.f16 %0, %1;" : "=l"(i) : "h"(__HALF_TO_CUS(h)));
     return i;
 }
-#endif /* defined(__CUDACC__) || defined(_NVHPC_CUDA) */
 __CUDA_HOSTDEVICE_FP16_DECL__ __half __ull2half_rn(const unsigned long long int i)
 {
     __half h;
@@ -1884,40 +1214,25 @@ NV_IF_ELSE_TARGET(NV_IS_DEVICE,
 )
     return h;
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __ull2half_rz(const unsigned long long int i)
+__CUDA_FP16_DECL__ __half __ull2half_rz(const unsigned long long int i)
 {
     __half h;
-NV_IF_ELSE_TARGET(NV_IS_DEVICE,
     asm("cvt.rz.f16.u64 %0, %1;" : "=h"(__HALF_TO_US(h)) : "l"(i));
-,
-    const float  f = static_cast<float>(i);
-                 h = __float2half_rz(f);
-)
     return h;
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __ull2half_rd(const unsigned long long int i)
+__CUDA_FP16_DECL__ __half __ull2half_rd(const unsigned long long int i)
 {
     __half h;
-NV_IF_ELSE_TARGET(NV_IS_DEVICE,
     asm("cvt.rm.f16.u64 %0, %1;" : "=h"(__HALF_TO_US(h)) : "l"(i));
-,
-    const float  f = static_cast<float>(i);
-                 h = __float2half_rd(f);
-)
     return h;
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __ull2half_ru(const unsigned long long int i)
+__CUDA_FP16_DECL__ __half __ull2half_ru(const unsigned long long int i)
 {
     __half h;
-NV_IF_ELSE_TARGET(NV_IS_DEVICE,
     asm("cvt.rp.f16.u64 %0, %1;" : "=h"(__HALF_TO_US(h)) : "l"(i));
-,
-    const float  f = static_cast<float>(i);
-                 h = __float2half_ru(f);
-)
     return h;
 }
-#if defined(__CUDACC__) || defined(_NVHPC_CUDA)
+
 __CUDA_FP16_DECL__ long long int __half2ll_rn(const __half h)
 {
     long long int i;
@@ -1936,7 +1251,6 @@ __CUDA_FP16_DECL__ long long int __half2ll_ru(const __half h)
     asm("cvt.rpi.s64.f16 %0, %1;" : "=l"(i) : "h"(__HALF_TO_CUS(h)));
     return i;
 }
-#endif /* defined(__CUDACC__) || defined(_NVHPC_CUDA) */
 __CUDA_HOSTDEVICE_FP16_DECL__ __half __ll2half_rn(const long long int i)
 {
     __half h;
@@ -1952,40 +1266,25 @@ NV_IF_ELSE_TARGET(NV_IS_DEVICE,
 )
     return h;
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __ll2half_rz(const long long int i)
+__CUDA_FP16_DECL__ __half __ll2half_rz(const long long int i)
 {
     __half h;
-NV_IF_ELSE_TARGET(NV_IS_DEVICE,
     asm("cvt.rz.f16.s64 %0, %1;" : "=h"(__HALF_TO_US(h)) : "l"(i));
-,
-    const float  f = static_cast<float>(i);
-                 h = __float2half_rz(f);
-)
     return h;
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __ll2half_rd(const long long int i)
+__CUDA_FP16_DECL__ __half __ll2half_rd(const long long int i)
 {
     __half h;
-NV_IF_ELSE_TARGET(NV_IS_DEVICE,
     asm("cvt.rm.f16.s64 %0, %1;" : "=h"(__HALF_TO_US(h)) : "l"(i));
-,
-    const float  f = static_cast<float>(i);
-                 h = __float2half_rd(f);
-)
     return h;
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __ll2half_ru(const long long int i)
+__CUDA_FP16_DECL__ __half __ll2half_ru(const long long int i)
 {
     __half h;
-NV_IF_ELSE_TARGET(NV_IS_DEVICE,
     asm("cvt.rp.f16.s64 %0, %1;" : "=h"(__HALF_TO_US(h)) : "l"(i));
-,
-    const float  f = static_cast<float>(i);
-                 h = __float2half_ru(f);
-)
     return h;
 }
-#if defined(__CUDACC__) || defined(_NVHPC_CUDA)
+
 __CUDA_FP16_DECL__ __half htrunc(const __half h)
 {
     __half r;
@@ -2051,184 +1350,119 @@ __CUDA_FP16_DECL__ __half2 h2rint(const __half2 h)
         "  mov.b32 %0, {low,high};}\n" : "=r"(__HALF2_TO_UI(val)) : "r"(__HALF2_TO_CUI(h)));
     return val;
 }
-#endif /* defined(__CUDACC__) || defined(_NVHPC_CUDA) */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __lows2half2(const __half2 a, const __half2 b)
+__CUDA_FP16_DECL__ __half2 __lows2half2(const __half2 a, const __half2 b)
 {
     __half2 val;
-NV_IF_ELSE_TARGET(NV_IS_DEVICE,
     asm("{.reg .f16 alow,ahigh,blow,bhigh;\n"
         "  mov.b32 {alow,ahigh}, %1;\n"
         "  mov.b32 {blow,bhigh}, %2;\n"
         "  mov.b32 %0, {alow,blow};}\n" : "=r"(__HALF2_TO_UI(val)) : "r"(__HALF2_TO_CUI(a)), "r"(__HALF2_TO_CUI(b)));
-,
-    val.x = a.x;
-    val.y = b.x;
-)
     return val;
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __highs2half2(const __half2 a, const __half2 b)
+__CUDA_FP16_DECL__ __half2 __highs2half2(const __half2 a, const __half2 b)
 {
     __half2 val;
-NV_IF_ELSE_TARGET(NV_IS_DEVICE,
     asm("{.reg .f16 alow,ahigh,blow,bhigh;\n"
         "  mov.b32 {alow,ahigh}, %1;\n"
         "  mov.b32 {blow,bhigh}, %2;\n"
         "  mov.b32 %0, {ahigh,bhigh};}\n" : "=r"(__HALF2_TO_UI(val)) : "r"(__HALF2_TO_CUI(a)), "r"(__HALF2_TO_CUI(b)));
-,
-    val.x = a.y;
-    val.y = b.y;
-)
     return val;
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __low2half(const __half2 a)
+__CUDA_FP16_DECL__ __half __low2half(const __half2 a)
 {
     __half ret;
-NV_IF_ELSE_TARGET(NV_IS_DEVICE,
     asm("{.reg .f16 low,high;\n"
         " mov.b32 {low,high}, %1;\n"
         " mov.b16 %0, low;}" : "=h"(__HALF_TO_US(ret)) : "r"(__HALF2_TO_CUI(a)));
-,
-    ret = a.x;
-)
     return ret;
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ int __hisinf(const __half a)
+__CUDA_FP16_DECL__ int __hisinf(const __half a)
 {
     int retval;
-    const __half_raw araw = __half_raw(a);
-    if (araw.x == 0xFC00U) {
+    if (__HALF_TO_CUS(a) == 0xFC00U) {
         retval = -1;
-    } else if (araw.x == 0x7C00U) {
+    } else if (__HALF_TO_CUS(a) == 0x7C00U) {
         retval = 1;
     } else {
         retval = 0;
     }
     return retval;
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __low2half2(const __half2 a)
+__CUDA_FP16_DECL__ __half2 __low2half2(const __half2 a)
 {
     __half2 val;
-NV_IF_ELSE_TARGET(NV_IS_DEVICE,
     asm("{.reg .f16 low,high;\n"
         "  mov.b32 {low,high}, %1;\n"
         "  mov.b32 %0, {low,low};}\n" : "=r"(__HALF2_TO_UI(val)) : "r"(__HALF2_TO_CUI(a)));
-,
-    val.x = a.x;
-    val.y = a.x;
-)
     return val;
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __high2half2(const __half2 a)
+__CUDA_FP16_DECL__ __half2 __high2half2(const __half2 a)
 {
     __half2 val;
-NV_IF_ELSE_TARGET(NV_IS_DEVICE,
     asm("{.reg .f16 low,high;\n"
         "  mov.b32 {low,high}, %1;\n"
         "  mov.b32 %0, {high,high};}\n" : "=r"(__HALF2_TO_UI(val)) : "r"(__HALF2_TO_CUI(a)));
-,
-    val.x = a.y;
-    val.y = a.y;
-)
     return val;
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __high2half(const __half2 a)
+__CUDA_FP16_DECL__ __half __high2half(const __half2 a)
 {
     __half ret;
-NV_IF_ELSE_TARGET(NV_IS_DEVICE,
     asm("{.reg .f16 low,high;\n"
         " mov.b32 {low,high}, %1;\n"
         " mov.b16 %0, high;}" : "=h"(__HALF_TO_US(ret)) : "r"(__HALF2_TO_CUI(a)));
-,
-    ret = a.y;
-)
     return ret;
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __halves2half2(const __half a, const __half b)
+__CUDA_FP16_DECL__ __half2 __halves2half2(const __half a, const __half b)
 {
     __half2 val;
-NV_IF_ELSE_TARGET(NV_IS_DEVICE,
     asm("{  mov.b32 %0, {%1,%2};}\n"
         : "=r"(__HALF2_TO_UI(val)) : "h"(__HALF_TO_CUS(a)), "h"(__HALF_TO_CUS(b)));
-,
-    val.x = a;
-    val.y = b;
-)
     return val;
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __half2half2(const __half a)
+__CUDA_FP16_DECL__ __half2 __half2half2(const __half a)
 {
     __half2 val;
-NV_IF_ELSE_TARGET(NV_IS_DEVICE,
     asm("{  mov.b32 %0, {%1,%1};}\n"
         : "=r"(__HALF2_TO_UI(val)) : "h"(__HALF_TO_CUS(a)));
-,
-    val.x = a;
-    val.y = a;
-)
     return val;
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __lowhigh2highlow(const __half2 a)
+__CUDA_FP16_DECL__ __half2 __lowhigh2highlow(const __half2 a)
 {
     __half2 val;
-NV_IF_ELSE_TARGET(NV_IS_DEVICE,
     asm("{.reg .f16 low,high;\n"
         "  mov.b32 {low,high}, %1;\n"
         "  mov.b32 %0, {high,low};}\n" : "=r"(__HALF2_TO_UI(val)) : "r"(__HALF2_TO_CUI(a)));
-,
-    val.x = a.y;
-    val.y = a.x;
-)
     return val;
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ short int __half_as_short(const __half h)
+__CUDA_FP16_DECL__ short int __half_as_short(const __half h)
 {
-NV_IF_ELSE_TARGET(NV_IS_DEVICE,
     return static_cast<short int>(__HALF_TO_CUS(h));
-,
-    return static_cast<short int>(__half_raw(h).x);
-)
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ unsigned short int __half_as_ushort(const __half h)
+__CUDA_FP16_DECL__ unsigned short int __half_as_ushort(const __half h)
 {
-NV_IF_ELSE_TARGET(NV_IS_DEVICE,
     return __HALF_TO_CUS(h);
-,
-    return __half_raw(h).x;
-)
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __short_as_half(const short int i)
+__CUDA_FP16_DECL__ __half __short_as_half(const short int i)
 {
-NV_IF_ELSE_TARGET(NV_IS_DEVICE,
     __half h;
     __HALF_TO_US(h) = static_cast<unsigned short int>(i);
     return h;
-,
-    __half_raw hr;
-    hr.x = static_cast<unsigned short int>(i);
-    return __half(hr);
-)
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __ushort_as_half(const unsigned short int i)
+__CUDA_FP16_DECL__ __half __ushort_as_half(const unsigned short int i)
 {
-NV_IF_ELSE_TARGET(NV_IS_DEVICE,
     __half h;
     __HALF_TO_US(h) = i;
     return h;
-,
-    __half_raw hr;
-    hr.x = i;
-    return __half(hr);)
 }
 
 /******************************************************************************
 *                             __half arithmetic                             *
 ******************************************************************************/
-#if defined(__CUDACC__) || defined(_NVHPC_CUDA)
-__CUDA_FP16_DECL__ __half __internal_device_hmax(const __half a, const __half b)
+__CUDA_FP16_DECL__ __half __hmax(const __half a, const __half b)
 {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_80,
+#if !defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 800)
     __BINARY_OP_HALF_MACRO(max)
-,
+#else
     const float fa = __half2float(a);
     const float fb = __half2float(b);
     float fr;
@@ -2236,13 +1470,13 @@ NV_IF_ELSE_TARGET(NV_PROVIDES_SM_80,
         :"=f"(fr) : "f"(fa), "f"(fb));
     const __half hr = __float2half(fr);
     return hr;
-)
+#endif
 }
-__CUDA_FP16_DECL__ __half __internal_device_hmin(const __half a, const __half b)
+__CUDA_FP16_DECL__ __half __hmin(const __half a, const __half b)
 {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_80,
+#if !defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 800)
     __BINARY_OP_HALF_MACRO(min)
-,
+#else
     const float fa = __half2float(a);
     const float fb = __half2float(b);
     float fr;
@@ -2250,89 +1484,46 @@ NV_IF_ELSE_TARGET(NV_PROVIDES_SM_80,
         :"=f"(fr) : "f"(fa), "f"(fb));
     const __half hr = __float2half(fr);
     return hr;
-)
+#endif
 }
-#endif /* defined(__CUDACC__) || defined(_NVHPC_CUDA) */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __hmax(const __half a, const __half b)
-{
-NV_IF_ELSE_TARGET(NV_IS_DEVICE,
-    return __internal_device_hmax(a, b);
-,
-    __half maxval;
-
-    maxval = (__hge(a, b) || __hisnan(b)) ? a : b;
-
-    if (__hisnan(maxval))
-    {
-        // if both inputs are NaN, return canonical NaN
-        maxval = CUDART_NAN_FP16;
-    }
-    else if (__heq(a, b))
-    {
-        // hmax(+0.0, -0.0) = +0.0
-        // unsigned compare 0x8000U > 0x0000U
-        __half_raw ra = __half_raw(a);
-        __half_raw rb = __half_raw(b);
-        maxval = (ra.x > rb.x) ? b : a;
-    }
-    return maxval;
-)
-}
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __hmin(const __half a, const __half b)
-{
-NV_IF_ELSE_TARGET(NV_IS_DEVICE,
-    return __internal_device_hmin(a, b);
-,
-    __half minval;
-
-    minval = (__hle(a, b) || __hisnan(b)) ? a : b;
-
-    if (__hisnan(minval))
-    {
-        // if both inputs are NaN, return canonical NaN
-        minval = CUDART_NAN_FP16;
-    }
-    else if (__heq(a, b))
-    {
-        // hmin(+0.0, -0.0) = -0.0
-        // unsigned compare 0x8000U > 0x0000U
-        __half_raw ra = __half_raw(a);
-        __half_raw rb = __half_raw(b);
-        minval = (ra.x > rb.x) ? a : b;
-    }
-
-    return minval;
-)
-}
-
 
 /******************************************************************************
 *                            __half2 arithmetic                             *
 ******************************************************************************/
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hmax2(const __half2 a, const __half2 b)
+__CUDA_FP16_DECL__ __half2 __hmax2(const __half2 a, const __half2 b)
 {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_80,
+#if !defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 800)
     __BINARY_OP_HALF2_MACRO(max)
-,
-    __half2 val;
-    val.x = __hmax(a.x, b.x);
-    val.y = __hmax(a.y, b.y);
-    return val;
-)
+#else
+    const float2 fa = __half22float2(a);
+    const float2 fb = __half22float2(b);
+    float2 fr;
+    asm("{max.f32 %0,%1,%2;\n}"
+        :"=f"(fr.x) : "f"(fa.x), "f"(fb.x));
+    asm("{max.f32 %0,%1,%2;\n}"
+        :"=f"(fr.y) : "f"(fa.y), "f"(fb.y));
+    const __half2 hr = __float22half2_rn(fr);
+    return hr;
+#endif
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hmin2(const __half2 a, const __half2 b)
+__CUDA_FP16_DECL__ __half2 __hmin2(const __half2 a, const __half2 b)
 {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_80,
+#if !defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 800)
     __BINARY_OP_HALF2_MACRO(min)
-,
-    __half2 val;
-    val.x = __hmin(a.x, b.x);
-    val.y = __hmin(a.y, b.y);
-    return val;
-)
+#else
+    const float2 fa = __half22float2(a);
+    const float2 fb = __half22float2(b);
+    float2 fr;
+    asm("{min.f32 %0,%1,%2;\n}"
+        :"=f"(fr.x) : "f"(fa.x), "f"(fb.x));
+    asm("{min.f32 %0,%1,%2;\n}"
+        :"=f"(fr.y) : "f"(fa.y), "f"(fb.y));
+    const __half2 hr = __float22half2_rn(fr);
+    return hr;
+#endif
 }
 
-#if defined(__CUDACC__) || defined(_NVHPC_CUDA)
+
 #if !defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 300) || defined(_NVHPC_CUDA)
 /******************************************************************************
 *                           __half, __half2 warp shuffle                     *
@@ -2587,8 +1778,7 @@ __CUDA_FP16_DECL__ void __stwt(__half *const ptr, const __half value)
 }
 #undef __LDG_PTR
 #endif /* defined(__cplusplus) && (!defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 320) || defined(_NVHPC_CUDA)) */
-#endif /* defined(__CUDACC__) || defined(_NVHPC_CUDA) */
-
+#if !defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 530) || defined(_NVHPC_CUDA)
 /******************************************************************************
 *                             __half2 comparison                             *
 ******************************************************************************/
@@ -2598,137 +1788,53 @@ __CUDA_FP16_DECL__ void __stwt(__half *const ptr, const __half value)
         :"=r"(__HALF2_TO_UI(val)) : "r"(__HALF2_TO_CUI(a)),"r"(__HALF2_TO_CUI(b))); \
    return val; \
 } /* while(0) */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __heq2(const __half2 a, const __half2 b)
+__CUDA_FP16_DECL__ __half2 __heq2(const __half2 a, const __half2 b)
 {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53,
     __COMPARISON_OP_HALF2_MACRO(set.eq)
-,
-    __half2_raw val;
-    val.x = __heq(a.x, b.x) ? (unsigned short)0x3C00U : (unsigned short)0U;
-    val.y = __heq(a.y, b.y) ? (unsigned short)0x3C00U : (unsigned short)0U;
-    return __half2(val);
-)
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hne2(const __half2 a, const __half2 b)
+__CUDA_FP16_DECL__ __half2 __hne2(const __half2 a, const __half2 b)
 {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53,
     __COMPARISON_OP_HALF2_MACRO(set.ne)
-,
-    __half2_raw val;
-    val.x = __hne(a.x, b.x) ? (unsigned short)0x3C00U : (unsigned short)0U;
-    val.y = __hne(a.y, b.y) ? (unsigned short)0x3C00U : (unsigned short)0U;
-    return __half2(val);
-)
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hle2(const __half2 a, const __half2 b)
+__CUDA_FP16_DECL__ __half2 __hle2(const __half2 a, const __half2 b)
 {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53,
     __COMPARISON_OP_HALF2_MACRO(set.le)
-,
-    __half2_raw val;
-    val.x = __hle(a.x, b.x) ? (unsigned short)0x3C00U : (unsigned short)0U;
-    val.y = __hle(a.y, b.y) ? (unsigned short)0x3C00U : (unsigned short)0U;
-    return __half2(val);
-)
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hge2(const __half2 a, const __half2 b)
+__CUDA_FP16_DECL__ __half2 __hge2(const __half2 a, const __half2 b)
 {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53,
     __COMPARISON_OP_HALF2_MACRO(set.ge)
-,
-    __half2_raw val;
-    val.x = __hge(a.x, b.x) ? (unsigned short)0x3C00U : (unsigned short)0U;
-    val.y = __hge(a.y, b.y) ? (unsigned short)0x3C00U : (unsigned short)0U;
-    return __half2(val);
-)
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hlt2(const __half2 a, const __half2 b)
+__CUDA_FP16_DECL__ __half2 __hlt2(const __half2 a, const __half2 b)
 {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53,
     __COMPARISON_OP_HALF2_MACRO(set.lt)
-,
-    __half2_raw val;
-    val.x = __hlt(a.x, b.x) ? (unsigned short)0x3C00U : (unsigned short)0U;
-    val.y = __hlt(a.y, b.y) ? (unsigned short)0x3C00U : (unsigned short)0U;
-    return __half2(val);
-)
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hgt2(const __half2 a, const __half2 b)
+__CUDA_FP16_DECL__ __half2 __hgt2(const __half2 a, const __half2 b)
 {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53,
     __COMPARISON_OP_HALF2_MACRO(set.gt)
-,
-    __half2_raw val;
-    val.x = __hgt(a.x, b.x) ? (unsigned short)0x3C00U : (unsigned short)0U;
-    val.y = __hgt(a.y, b.y) ? (unsigned short)0x3C00U : (unsigned short)0U;
-    return __half2(val);
-)
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hequ2(const __half2 a, const __half2 b)
+__CUDA_FP16_DECL__ __half2 __hequ2(const __half2 a, const __half2 b)
 {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53,
     __COMPARISON_OP_HALF2_MACRO(set.equ)
-,
-    __half2_raw val;
-    val.x = __hequ(a.x, b.x) ? (unsigned short)0x3C00U : (unsigned short)0U;
-    val.y = __hequ(a.y, b.y) ? (unsigned short)0x3C00U : (unsigned short)0U;
-    return __half2(val);
-)
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hneu2(const __half2 a, const __half2 b)
+__CUDA_FP16_DECL__ __half2 __hneu2(const __half2 a, const __half2 b)
 {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53,
     __COMPARISON_OP_HALF2_MACRO(set.neu)
-,
-    __half2_raw val;
-    val.x = __hneu(a.x, b.x) ? (unsigned short)0x3C00U : (unsigned short)0U;
-    val.y = __hneu(a.y, b.y) ? (unsigned short)0x3C00U : (unsigned short)0U;
-    return __half2(val);
-)
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hleu2(const __half2 a, const __half2 b)
+__CUDA_FP16_DECL__ __half2 __hleu2(const __half2 a, const __half2 b)
 {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53,
     __COMPARISON_OP_HALF2_MACRO(set.leu)
-,
-    __half2_raw val;
-    val.x = __hleu(a.x, b.x) ? (unsigned short)0x3C00U : (unsigned short)0U;
-    val.y = __hleu(a.y, b.y) ? (unsigned short)0x3C00U : (unsigned short)0U;
-    return __half2(val);
-)
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hgeu2(const __half2 a, const __half2 b)
+__CUDA_FP16_DECL__ __half2 __hgeu2(const __half2 a, const __half2 b)
 {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53,
     __COMPARISON_OP_HALF2_MACRO(set.geu)
-,
-    __half2_raw val;
-    val.x = __hgeu(a.x, b.x) ? (unsigned short)0x3C00U : (unsigned short)0U;
-    val.y = __hgeu(a.y, b.y) ? (unsigned short)0x3C00U : (unsigned short)0U;
-    return __half2(val);
-)
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hltu2(const __half2 a, const __half2 b)
+__CUDA_FP16_DECL__ __half2 __hltu2(const __half2 a, const __half2 b)
 {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53,
     __COMPARISON_OP_HALF2_MACRO(set.ltu)
-,
-    __half2_raw val;
-    val.x = __hltu(a.x, b.x) ? (unsigned short)0x3C00U : (unsigned short)0U;
-    val.y = __hltu(a.y, b.y) ? (unsigned short)0x3C00U : (unsigned short)0U;
-    return __half2(val);
-)
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hgtu2(const __half2 a, const __half2 b)
+__CUDA_FP16_DECL__ __half2 __hgtu2(const __half2 a, const __half2 b)
 {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53,
     __COMPARISON_OP_HALF2_MACRO(set.gtu)
-,
-    __half2_raw val;
-    val.x = __hgtu(a.x, b.x) ? (unsigned short)0x3C00U : (unsigned short)0U;
-    val.y = __hgtu(a.y, b.y) ? (unsigned short)0x3C00U : (unsigned short)0U;
-    return __half2(val);
-)
 }
 #undef __COMPARISON_OP_HALF2_MACRO
 /******************************************************************************
@@ -2740,224 +1846,116 @@ NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53,
         :"=r"(__HALF2_TO_UI(val)) : "r"(__HALF2_TO_CUI(a)),"r"(__HALF2_TO_CUI(b))); \
    return val; \
 } /* while(0) */
-__CUDA_HOSTDEVICE_FP16_DECL__ unsigned __heq2_mask(const __half2 a, const __half2 b)
+__CUDA_FP16_DECL__ unsigned __heq2_mask(const __half2 a, const __half2 b)
 {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53,
     __COMPARISON_OP_HALF2_MACRO_MASK(set.eq)
-,
-    const unsigned short px = __heq(a.x, b.x) ? (unsigned short)0xFFFFU : (unsigned short)0U;
-    const unsigned short py = __heq(a.y, b.y) ? (unsigned short)0xFFFFU : (unsigned short)0U;
-    unsigned ur = (unsigned)py;
-             ur <<= (unsigned)16U;
-             ur |= (unsigned)px;
-    return ur;
-)
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ unsigned __hne2_mask(const __half2 a, const __half2 b)
+__CUDA_FP16_DECL__ unsigned __hne2_mask(const __half2 a, const __half2 b)
 {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53,
     __COMPARISON_OP_HALF2_MACRO_MASK(set.ne)
-,
-    const unsigned short px = __hne(a.x, b.x) ? (unsigned short)0xFFFFU : (unsigned short)0U;
-    const unsigned short py = __hne(a.y, b.y) ? (unsigned short)0xFFFFU : (unsigned short)0U;
-    unsigned ur = (unsigned)py;
-             ur <<= (unsigned)16U;
-             ur |= (unsigned)px;
-    return ur;
-)
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ unsigned __hle2_mask(const __half2 a, const __half2 b)
+__CUDA_FP16_DECL__ unsigned __hle2_mask(const __half2 a, const __half2 b)
 {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53,
     __COMPARISON_OP_HALF2_MACRO_MASK(set.le)
-,
-    const unsigned short px = __hle(a.x, b.x) ? (unsigned short)0xFFFFU : (unsigned short)0U;
-    const unsigned short py = __hle(a.y, b.y) ? (unsigned short)0xFFFFU : (unsigned short)0U;
-    unsigned ur = (unsigned)py;
-             ur <<= (unsigned)16U;
-             ur |= (unsigned)px;
-    return ur;
-)
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ unsigned __hge2_mask(const __half2 a, const __half2 b)
+__CUDA_FP16_DECL__ unsigned __hge2_mask(const __half2 a, const __half2 b)
 {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53,
     __COMPARISON_OP_HALF2_MACRO_MASK(set.ge)
-,
-    const unsigned short px = __hge(a.x, b.x) ? (unsigned short)0xFFFFU : (unsigned short)0U;
-    const unsigned short py = __hge(a.y, b.y) ? (unsigned short)0xFFFFU : (unsigned short)0U;
-    unsigned ur = (unsigned)py;
-             ur <<= (unsigned)16U;
-             ur |= (unsigned)px;
-    return ur;
-)
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ unsigned __hlt2_mask(const __half2 a, const __half2 b)
+__CUDA_FP16_DECL__ unsigned __hlt2_mask(const __half2 a, const __half2 b)
 {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53,
     __COMPARISON_OP_HALF2_MACRO_MASK(set.lt)
-,
-    const unsigned short px = __hlt(a.x, b.x) ? (unsigned short)0xFFFFU : (unsigned short)0U;
-    const unsigned short py = __hlt(a.y, b.y) ? (unsigned short)0xFFFFU : (unsigned short)0U;
-    unsigned ur = (unsigned)py;
-             ur <<= (unsigned)16U;
-             ur |= (unsigned)px;
-    return ur;
-)
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ unsigned __hgt2_mask(const __half2 a, const __half2 b)
+__CUDA_FP16_DECL__ unsigned __hgt2_mask(const __half2 a, const __half2 b)
 {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53,
     __COMPARISON_OP_HALF2_MACRO_MASK(set.gt)
-,
-    const unsigned short px = __hgt(a.x, b.x) ? (unsigned short)0xFFFFU : (unsigned short)0U;
-    const unsigned short py = __hgt(a.y, b.y) ? (unsigned short)0xFFFFU : (unsigned short)0U;
-    unsigned ur = (unsigned)py;
-             ur <<= (unsigned)16U;
-             ur |= (unsigned)px;
-    return ur;
-)
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ unsigned __hequ2_mask(const __half2 a, const __half2 b)
+__CUDA_FP16_DECL__ unsigned __hequ2_mask(const __half2 a, const __half2 b)
 {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53,
     __COMPARISON_OP_HALF2_MACRO_MASK(set.equ)
-,
-    const unsigned short px = __hequ(a.x, b.x) ? (unsigned short)0xFFFFU : (unsigned short)0U;
-    const unsigned short py = __hequ(a.y, b.y) ? (unsigned short)0xFFFFU : (unsigned short)0U;
-    unsigned ur = (unsigned)py;
-             ur <<= (unsigned)16U;
-             ur |= (unsigned)px;
-    return ur;
-)
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ unsigned __hneu2_mask(const __half2 a, const __half2 b)
+__CUDA_FP16_DECL__ unsigned __hneu2_mask(const __half2 a, const __half2 b)
 {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53,
     __COMPARISON_OP_HALF2_MACRO_MASK(set.neu)
-,
-    const unsigned short px = __hneu(a.x, b.x) ? (unsigned short)0xFFFFU : (unsigned short)0U;
-    const unsigned short py = __hneu(a.y, b.y) ? (unsigned short)0xFFFFU : (unsigned short)0U;
-    unsigned ur = (unsigned)py;
-             ur <<= (unsigned)16U;
-             ur |= (unsigned)px;
-    return ur;
-)
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ unsigned __hleu2_mask(const __half2 a, const __half2 b)
+__CUDA_FP16_DECL__ unsigned __hleu2_mask(const __half2 a, const __half2 b)
 {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53,
     __COMPARISON_OP_HALF2_MACRO_MASK(set.leu)
-,
-    const unsigned short px = __hleu(a.x, b.x) ? (unsigned short)0xFFFFU : (unsigned short)0U;
-    const unsigned short py = __hleu(a.y, b.y) ? (unsigned short)0xFFFFU : (unsigned short)0U;
-    unsigned ur = (unsigned)py;
-             ur <<= (unsigned)16U;
-             ur |= (unsigned)px;
-    return ur;
-)
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ unsigned __hgeu2_mask(const __half2 a, const __half2 b)
+__CUDA_FP16_DECL__ unsigned __hgeu2_mask(const __half2 a, const __half2 b)
 {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53,
     __COMPARISON_OP_HALF2_MACRO_MASK(set.geu)
-,
-    const unsigned short px = __hgeu(a.x, b.x) ? (unsigned short)0xFFFFU : (unsigned short)0U;
-    const unsigned short py = __hgeu(a.y, b.y) ? (unsigned short)0xFFFFU : (unsigned short)0U;
-    unsigned ur = (unsigned)py;
-             ur <<= (unsigned)16U;
-             ur |= (unsigned)px;
-    return ur;
-)
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ unsigned __hltu2_mask(const __half2 a, const __half2 b)
+__CUDA_FP16_DECL__ unsigned __hltu2_mask(const __half2 a, const __half2 b)
 {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53,
     __COMPARISON_OP_HALF2_MACRO_MASK(set.ltu)
-,
-    const unsigned short px = __hltu(a.x, b.x) ? (unsigned short)0xFFFFU : (unsigned short)0U;
-    const unsigned short py = __hltu(a.y, b.y) ? (unsigned short)0xFFFFU : (unsigned short)0U;
-    unsigned ur = (unsigned)py;
-             ur <<= (unsigned)16U;
-             ur |= (unsigned)px;
-    return ur;
-)
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ unsigned __hgtu2_mask(const __half2 a, const __half2 b)
+__CUDA_FP16_DECL__ unsigned __hgtu2_mask(const __half2 a, const __half2 b)
 {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53,
     __COMPARISON_OP_HALF2_MACRO_MASK(set.gtu)
-,
-    const unsigned short px = __hgtu(a.x, b.x) ? (unsigned short)0xFFFFU : (unsigned short)0U;
-    const unsigned short py = __hgtu(a.y, b.y) ? (unsigned short)0xFFFFU : (unsigned short)0U;
-    unsigned ur = (unsigned)py;
-             ur <<= (unsigned)16U;
-             ur |= (unsigned)px;
-    return ur;
-)
 }
 #undef __COMPARISON_OP_HALF2_MACRO_MASK
-
-__CUDA_HOSTDEVICE_FP16_DECL__ bool __hbeq2(const __half2 a, const __half2 b)
+#define __BOOL_COMPARISON_OP_HALF2_MACRO(name) /* do */ {\
+   __half2 val; \
+   bool retval; \
+   asm( "{ " __CUDA_FP16_STRINGIFY(name) ".f16x2.f16x2 %0,%1,%2;\n}" \
+        :"=r"(__HALF2_TO_UI(val)) : "r"(__HALF2_TO_CUI(a)),"r"(__HALF2_TO_CUI(b))); \
+   if (__HALF2_TO_CUI(val) == 0x3C003C00U) {\
+      retval = true; \
+   } else { \
+      retval = false; \
+   }\
+   return retval;\
+} /* while(0) */
+__CUDA_FP16_DECL__ bool __hbeq2(const __half2 a, const __half2 b)
 {
-    const unsigned mask = __heq2_mask(a, b);
-    return (mask == 0xFFFFFFFFU);
+    __BOOL_COMPARISON_OP_HALF2_MACRO(set.eq)
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ bool __hbne2(const __half2 a, const __half2 b)
+__CUDA_FP16_DECL__ bool __hbne2(const __half2 a, const __half2 b)
 {
-    const unsigned mask = __hne2_mask(a, b);
-    return (mask == 0xFFFFFFFFU);
+    __BOOL_COMPARISON_OP_HALF2_MACRO(set.ne)
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ bool __hble2(const __half2 a, const __half2 b)
+__CUDA_FP16_DECL__ bool __hble2(const __half2 a, const __half2 b)
 {
-    const unsigned mask = __hle2_mask(a, b);
-    return (mask == 0xFFFFFFFFU);
+    __BOOL_COMPARISON_OP_HALF2_MACRO(set.le)
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ bool __hbge2(const __half2 a, const __half2 b)
+__CUDA_FP16_DECL__ bool __hbge2(const __half2 a, const __half2 b)
 {
-    const unsigned mask = __hge2_mask(a, b);
-    return (mask == 0xFFFFFFFFU);
+    __BOOL_COMPARISON_OP_HALF2_MACRO(set.ge)
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ bool __hblt2(const __half2 a, const __half2 b)
+__CUDA_FP16_DECL__ bool __hblt2(const __half2 a, const __half2 b)
 {
-    const unsigned mask = __hlt2_mask(a, b);
-    return (mask == 0xFFFFFFFFU);
+    __BOOL_COMPARISON_OP_HALF2_MACRO(set.lt)
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ bool __hbgt2(const __half2 a, const __half2 b)
+__CUDA_FP16_DECL__ bool __hbgt2(const __half2 a, const __half2 b)
 {
-    const unsigned mask = __hgt2_mask(a, b);
-    return (mask == 0xFFFFFFFFU);
+    __BOOL_COMPARISON_OP_HALF2_MACRO(set.gt)
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ bool __hbequ2(const __half2 a, const __half2 b)
+__CUDA_FP16_DECL__ bool __hbequ2(const __half2 a, const __half2 b)
 {
-    const unsigned mask = __hequ2_mask(a, b);
-    return (mask == 0xFFFFFFFFU);
+    __BOOL_COMPARISON_OP_HALF2_MACRO(set.equ)
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ bool __hbneu2(const __half2 a, const __half2 b)
+__CUDA_FP16_DECL__ bool __hbneu2(const __half2 a, const __half2 b)
 {
-    const unsigned mask = __hneu2_mask(a, b);
-    return (mask == 0xFFFFFFFFU);
+    __BOOL_COMPARISON_OP_HALF2_MACRO(set.neu)
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ bool __hbleu2(const __half2 a, const __half2 b)
+__CUDA_FP16_DECL__ bool __hbleu2(const __half2 a, const __half2 b)
 {
-    const unsigned mask = __hleu2_mask(a, b);
-    return (mask == 0xFFFFFFFFU);
+    __BOOL_COMPARISON_OP_HALF2_MACRO(set.leu)
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ bool __hbgeu2(const __half2 a, const __half2 b)
+__CUDA_FP16_DECL__ bool __hbgeu2(const __half2 a, const __half2 b)
 {
-    const unsigned mask = __hgeu2_mask(a, b);
-    return (mask == 0xFFFFFFFFU);
+    __BOOL_COMPARISON_OP_HALF2_MACRO(set.geu)
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ bool __hbltu2(const __half2 a, const __half2 b)
+__CUDA_FP16_DECL__ bool __hbltu2(const __half2 a, const __half2 b)
 {
-    const unsigned mask = __hltu2_mask(a, b);
-    return (mask == 0xFFFFFFFFU);
+    __BOOL_COMPARISON_OP_HALF2_MACRO(set.ltu)
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ bool __hbgtu2(const __half2 a, const __half2 b)
+__CUDA_FP16_DECL__ bool __hbgtu2(const __half2 a, const __half2 b)
 {
-    const unsigned mask = __hgtu2_mask(a, b);
-    return (mask == 0xFFFFFFFFU);
+    __BOOL_COMPARISON_OP_HALF2_MACRO(set.gtu)
 }
+#undef __BOOL_COMPARISON_OP_HALF2_MACRO
 /******************************************************************************
 *                             __half comparison                              *
 ******************************************************************************/
@@ -2969,230 +1967,94 @@ __CUDA_HOSTDEVICE_FP16_DECL__ bool __hbgtu2(const __half2 a, const __half2 b)
         : "=h"(val) : "h"(__HALF_TO_CUS(a)), "h"(__HALF_TO_CUS(b))); \
    return (val != 0U) ? true : false; \
 } /* while(0) */
-__CUDA_HOSTDEVICE_FP16_DECL__ bool __heq(const __half a, const __half b)
+__CUDA_FP16_DECL__ bool __heq(const __half a, const __half b)
 {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53,
     __COMPARISON_OP_HALF_MACRO(eq)
-,
-    const float fa = __half2float(a);
-    const float fb = __half2float(b);
-    return (fa == fb);
-)
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ bool __hne(const __half a, const __half b)
+__CUDA_FP16_DECL__ bool __hne(const __half a, const __half b)
 {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53,
     __COMPARISON_OP_HALF_MACRO(ne)
-,
-    const float fa = __half2float(a);
-    const float fb = __half2float(b);
-    return (fa != fb) && (!__hisnan(a)) && (!__hisnan(b));
-)
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ bool __hle(const __half a, const __half b)
+__CUDA_FP16_DECL__ bool __hle(const __half a, const __half b)
 {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53,
     __COMPARISON_OP_HALF_MACRO(le)
-,
-    const float fa = __half2float(a);
-    const float fb = __half2float(b);
-    return (fa <= fb);
-)
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ bool __hge(const __half a, const __half b)
+__CUDA_FP16_DECL__ bool __hge(const __half a, const __half b)
 {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53,
     __COMPARISON_OP_HALF_MACRO(ge)
-,
-    const float fa = __half2float(a);
-    const float fb = __half2float(b);
-    return (fa >= fb);
-)
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ bool __hlt(const __half a, const __half b)
+__CUDA_FP16_DECL__ bool __hlt(const __half a, const __half b)
 {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53,
     __COMPARISON_OP_HALF_MACRO(lt)
-,
-    const float fa = __half2float(a);
-    const float fb = __half2float(b);
-    return (fa < fb);
-)
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ bool __hgt(const __half a, const __half b)
+__CUDA_FP16_DECL__ bool __hgt(const __half a, const __half b)
 {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53,
     __COMPARISON_OP_HALF_MACRO(gt)
-,
-    const float fa = __half2float(a);
-    const float fb = __half2float(b);
-    return (fa > fb);
-)
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ bool __hequ(const __half a, const __half b)
+__CUDA_FP16_DECL__ bool __hequ(const __half a, const __half b)
 {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53,
     __COMPARISON_OP_HALF_MACRO(equ)
-,
-    const float fa = __half2float(a);
-    const float fb = __half2float(b);
-    return (fa == fb) || (__hisnan(a)) || (__hisnan(b));
-)
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ bool __hneu(const __half a, const __half b)
+__CUDA_FP16_DECL__ bool __hneu(const __half a, const __half b)
 {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53,
     __COMPARISON_OP_HALF_MACRO(neu)
-,
-    const float fa = __half2float(a);
-    const float fb = __half2float(b);
-    return (fa != fb);
-)
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ bool __hleu(const __half a, const __half b)
+__CUDA_FP16_DECL__ bool __hleu(const __half a, const __half b)
 {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53,
     __COMPARISON_OP_HALF_MACRO(leu)
-,
-    const float fa = __half2float(a);
-    const float fb = __half2float(b);
-    return (fa <= fb) || (__hisnan(a)) || (__hisnan(b));
-)
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ bool __hgeu(const __half a, const __half b)
+__CUDA_FP16_DECL__ bool __hgeu(const __half a, const __half b)
 {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53,
     __COMPARISON_OP_HALF_MACRO(geu)
-,
-    const float fa = __half2float(a);
-    const float fb = __half2float(b);
-    return (fa >= fb) || (__hisnan(a)) || (__hisnan(b));
-)
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ bool __hltu(const __half a, const __half b)
+__CUDA_FP16_DECL__ bool __hltu(const __half a, const __half b)
 {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53,
     __COMPARISON_OP_HALF_MACRO(ltu)
-,
-    const float fa = __half2float(a);
-    const float fb = __half2float(b);
-    return (fa < fb) || (__hisnan(a)) || (__hisnan(b));
-)
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ bool __hgtu(const __half a, const __half b)
+__CUDA_FP16_DECL__ bool __hgtu(const __half a, const __half b)
 {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53,
     __COMPARISON_OP_HALF_MACRO(gtu)
-,
-    const float fa = __half2float(a);
-    const float fb = __half2float(b);
-    return (fa > fb) || (__hisnan(a)) || (__hisnan(b));
-)
 }
 #undef __COMPARISON_OP_HALF_MACRO
 /******************************************************************************
 *                            __half2 arithmetic                             *
 ******************************************************************************/
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hadd2(const __half2 a, const __half2 b)
+__CUDA_FP16_DECL__ __half2 __hadd2(const __half2 a, const __half2 b)
 {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53,
     __BINARY_OP_HALF2_MACRO(add)
-,
-    __half2 val;
-    val.x = __hadd(a.x, b.x);
-    val.y = __hadd(a.y, b.y);
-    return val;
-)
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hsub2(const __half2 a, const __half2 b)
+__CUDA_FP16_DECL__ __half2 __hsub2(const __half2 a, const __half2 b)
 {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53,
     __BINARY_OP_HALF2_MACRO(sub)
-,
-    __half2 val;
-    val.x = __hsub(a.x, b.x);
-    val.y = __hsub(a.y, b.y);
-    return val;
-)
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hmul2(const __half2 a, const __half2 b)
+__CUDA_FP16_DECL__ __half2 __hmul2(const __half2 a, const __half2 b)
 {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53,
     __BINARY_OP_HALF2_MACRO(mul)
-,
-    __half2 val;
-    val.x = __hmul(a.x, b.x);
-    val.y = __hmul(a.y, b.y);
-    return val;
-)
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hadd2_sat(const __half2 a, const __half2 b)
+__CUDA_FP16_DECL__ __half2 __hadd2_sat(const __half2 a, const __half2 b)
 {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53,
     __BINARY_OP_HALF2_MACRO(add.sat)
-,
-    __half2 val;
-    val.x = __hadd_sat(a.x, b.x);
-    val.y = __hadd_sat(a.y, b.y);
-    return val;
-)
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hsub2_sat(const __half2 a, const __half2 b)
+__CUDA_FP16_DECL__ __half2 __hsub2_sat(const __half2 a, const __half2 b)
 {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53,
     __BINARY_OP_HALF2_MACRO(sub.sat)
-,
-    __half2 val;
-    val.x = __hsub_sat(a.x, b.x);
-    val.y = __hsub_sat(a.y, b.y);
-    return val;
-)
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hmul2_sat(const __half2 a, const __half2 b)
+__CUDA_FP16_DECL__ __half2 __hmul2_sat(const __half2 a, const __half2 b)
 {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53,
     __BINARY_OP_HALF2_MACRO(mul.sat)
-,
-    __half2 val;
-    val.x = __hmul_sat(a.x, b.x);
-    val.y = __hmul_sat(a.y, b.y);
-    return val;
-)
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hadd2_rn(const __half2 a, const __half2 b)
+__CUDA_FP16_DECL__ __half2 __hadd2_rn(const __half2 a, const __half2 b)
 {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53,
     __BINARY_OP_HALF2_MACRO(add.rn)
-,
-    __half2 val;
-    val.x = __hadd_rn(a.x, b.x);
-    val.y = __hadd_rn(a.y, b.y);
-    return val;
-)
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hsub2_rn(const __half2 a, const __half2 b)
+__CUDA_FP16_DECL__ __half2 __hsub2_rn(const __half2 a, const __half2 b)
 {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53,
     __BINARY_OP_HALF2_MACRO(sub.rn)
-,
-    __half2 val;
-    val.x = __hsub_rn(a.x, b.x);
-    val.y = __hsub_rn(a.y, b.y);
-    return val;
-)
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hmul2_rn(const __half2 a, const __half2 b)
+__CUDA_FP16_DECL__ __half2 __hmul2_rn(const __half2 a, const __half2 b)
 {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53,
     __BINARY_OP_HALF2_MACRO(mul.rn)
-,
-    __half2 val;
-    val.x = __hmul_rn(a.x, b.x);
-    val.y = __hmul_rn(a.y, b.y);
-    return val;
-)
 }
-#if defined(__CUDACC__) && (!defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 530)) || defined(_NVHPC_CUDA)
 __CUDA_FP16_DECL__ __half2 __hfma2(const __half2 a, const __half2 b, const __half2 c)
 {
     __TERNARY_OP_HALF2_MACRO(fma.rn)
@@ -3201,8 +2063,7 @@ __CUDA_FP16_DECL__ __half2 __hfma2_sat(const __half2 a, const __half2 b, const _
 {
     __TERNARY_OP_HALF2_MACRO(fma.rn.sat)
 }
-#endif /* defined(__CUDACC__) && (!defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 530)) || defined(_NVHPC_CUDA) */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __h2div(const __half2 a, const __half2 b) {
+__CUDA_FP16_DECL__ __half2 __h2div(const __half2 a, const __half2 b) {
     __half ha = __low2half(a);
     __half hb = __low2half(b);
 
@@ -3215,96 +2076,45 @@ __CUDA_HOSTDEVICE_FP16_DECL__ __half2 __h2div(const __half2 a, const __half2 b) 
 
     return __halves2half2(v1, v2);
 }
-
 /******************************************************************************
 *                             __half arithmetic                             *
 ******************************************************************************/
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __hadd(const __half a, const __half b)
+__CUDA_FP16_DECL__ __half __hadd(const __half a, const __half b)
 {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53,
     __BINARY_OP_HALF_MACRO(add)
-,
-    const float fa = __half2float(a);
-    const float fb = __half2float(b);
-    return __float2half(fa + fb);
-)
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __hsub(const __half a, const __half b)
+__CUDA_FP16_DECL__ __half __hsub(const __half a, const __half b)
 {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53,
     __BINARY_OP_HALF_MACRO(sub)
-,
-    const float fa = __half2float(a);
-    const float fb = __half2float(b);
-    return __float2half(fa - fb);
-)
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __hmul(const __half a, const __half b)
+__CUDA_FP16_DECL__ __half __hmul(const __half a, const __half b)
 {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53,
     __BINARY_OP_HALF_MACRO(mul)
-,
-    const float fa = __half2float(a);
-    const float fb = __half2float(b);
-    return __float2half(fa * fb);
-)
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __hadd_sat(const __half a, const __half b)
+__CUDA_FP16_DECL__ __half __hadd_sat(const __half a, const __half b)
 {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53,
     __BINARY_OP_HALF_MACRO(add.sat)
-,
-    return __hmin(__hmax(__hadd(a, b), CUDART_ZERO_FP16), CUDART_ONE_FP16);
-)
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __hsub_sat(const __half a, const __half b)
+__CUDA_FP16_DECL__ __half __hsub_sat(const __half a, const __half b)
 {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53,
     __BINARY_OP_HALF_MACRO(sub.sat)
-,
-    return __hmin(__hmax(__hsub(a, b), CUDART_ZERO_FP16), CUDART_ONE_FP16);
-)
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __hmul_sat(const __half a, const __half b)
+__CUDA_FP16_DECL__ __half __hmul_sat(const __half a, const __half b)
 {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53,
     __BINARY_OP_HALF_MACRO(mul.sat)
-,
-    return __hmin(__hmax(__hmul(a, b), CUDART_ZERO_FP16), CUDART_ONE_FP16);
-)
 }
-
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __hadd_rn(const __half a, const __half b)
+__CUDA_FP16_DECL__ __half __hadd_rn(const __half a, const __half b)
 {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53,
     __BINARY_OP_HALF_MACRO(add.rn)
-,
-    const float fa = __half2float(a);
-    const float fb = __half2float(b);
-    return __float2half(fa + fb);
-)
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __hsub_rn(const __half a, const __half b)
+__CUDA_FP16_DECL__ __half __hsub_rn(const __half a, const __half b)
 {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53,
     __BINARY_OP_HALF_MACRO(sub.rn)
-,
-    const float fa = __half2float(a);
-    const float fb = __half2float(b);
-    return __float2half(fa - fb);
-)
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __hmul_rn(const __half a, const __half b)
+__CUDA_FP16_DECL__ __half __hmul_rn(const __half a, const __half b)
 {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53,
     __BINARY_OP_HALF_MACRO(mul.rn)
-,
-    const float fa = __half2float(a);
-    const float fb = __half2float(b);
-    return __float2half(fa * fb);
-)
 }
-#if defined(__CUDACC__) && (!defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 530)) || defined(_NVHPC_CUDA)
 __CUDA_FP16_DECL__ __half __hfma(const __half a, const __half b, const __half c)
 {
     __TERNARY_OP_HALF_MACRO(fma.rn)
@@ -3313,10 +2123,7 @@ __CUDA_FP16_DECL__ __half __hfma_sat(const __half a, const __half b, const __hal
 {
     __TERNARY_OP_HALF_MACRO(fma.rn.sat)
 }
-#endif /* defined(__CUDACC__) && (!defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 530)) || defined(_NVHPC_CUDA) */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __hdiv(const __half a, const __half b)
-{
-NV_IF_ELSE_TARGET(NV_IS_DEVICE,
+__CUDA_FP16_DECL__ __half __hdiv(const __half a, const __half b) {
     __half v;
     __half abs;
     __half den;
@@ -3338,17 +2145,23 @@ NV_IF_ELSE_TARGET(NV_IS_DEVICE,
         v = __float2half(fv);
     }
     return v;
-,
-    const float fa = __half2float(a);
-    const float fb = __half2float(b);
-    return __float2half(fa / fb);
-)
 }
 
 /******************************************************************************
 *                             __half2 functions                  *
 ******************************************************************************/
-#if defined(_NVHPC_CUDA) || defined(__CUDACC__)
+#define __SPEC_CASE2(i,r, spc, ulp) \
+   "{.reg.b32 spc, ulp, p;\n"\
+   "  mov.b32 spc," __CUDA_FP16_STRINGIFY(spc) ";\n"\
+   "  mov.b32 ulp," __CUDA_FP16_STRINGIFY(ulp) ";\n"\
+   "  set.eq.f16x2.f16x2 p," __CUDA_FP16_STRINGIFY(i) ", spc;\n"\
+   "  fma.rn.f16x2 " __CUDA_FP16_STRINGIFY(r) ",p,ulp," __CUDA_FP16_STRINGIFY(r) ";\n}\n"
+#define __SPEC_CASE(i,r, spc, ulp) \
+   "{.reg.b16 spc, ulp, p;\n"\
+   "  mov.b16 spc," __CUDA_FP16_STRINGIFY(spc) ";\n"\
+   "  mov.b16 ulp," __CUDA_FP16_STRINGIFY(ulp) ";\n"\
+   "  set.eq.f16.f16 p," __CUDA_FP16_STRINGIFY(i) ", spc;\n"\
+   "  fma.rn.f16 " __CUDA_FP16_STRINGIFY(r) ",p,ulp," __CUDA_FP16_STRINGIFY(r) ";\n}\n"
 #define __APPROX_FCAST(fun) /* do */ {\
    __half val;\
    asm("{.reg.b32         f;        \n"\
@@ -3376,19 +2189,6 @@ NV_IF_ELSE_TARGET(NV_IS_DEVICE,
                 "}":"=r"(__HALF2_TO_UI(val)) : "r"(__HALF2_TO_CUI(a)));       \
    return val;\
 } /* while(0) */
-#if !defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 530) || defined(_NVHPC_CUDA)
-#define __SPEC_CASE2(i,r, spc, ulp) \
-   "{.reg.b32 spc, ulp, p;\n"\
-   "  mov.b32 spc," __CUDA_FP16_STRINGIFY(spc) ";\n"\
-   "  mov.b32 ulp," __CUDA_FP16_STRINGIFY(ulp) ";\n"\
-   "  set.eq.f16x2.f16x2 p," __CUDA_FP16_STRINGIFY(i) ", spc;\n"\
-   "  fma.rn.f16x2 " __CUDA_FP16_STRINGIFY(r) ",p,ulp," __CUDA_FP16_STRINGIFY(r) ";\n}\n"
-#define __SPEC_CASE(i,r, spc, ulp) \
-   "{.reg.b16 spc, ulp, p;\n"\
-   "  mov.b16 spc," __CUDA_FP16_STRINGIFY(spc) ";\n"\
-   "  mov.b16 ulp," __CUDA_FP16_STRINGIFY(ulp) ";\n"\
-   "  set.eq.f16.f16 p," __CUDA_FP16_STRINGIFY(i) ", spc;\n"\
-   "  fma.rn.f16 " __CUDA_FP16_STRINGIFY(r) ",p,ulp," __CUDA_FP16_STRINGIFY(r) ";\n}\n"
 static __device__ __forceinline__ float __float_simpl_sinf(float a);
 static __device__ __forceinline__ float __float_simpl_cosf(float a);
 __CUDA_FP16_DECL__ __half hsin(const __half a) {
@@ -3564,7 +2364,6 @@ __CUDA_FP16_DECL__ __half2 h2exp(const __half2 a) {
         "}":"=r"(__HALF2_TO_UI(val)) : "r"(__HALF2_TO_CUI(a)));
     return val;
 }
-#endif /* !defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 530) || defined(_NVHPC_CUDA) */
 __CUDA_FP16_DECL__ __half hexp2(const __half a) {
     __half val;
     asm("{.reg.b32         f, ULP;         \n"
@@ -3597,7 +2396,6 @@ __CUDA_FP16_DECL__ __half2 h2exp2(const __half2 a) {
         "}":"=r"(__HALF2_TO_UI(val)) : "r"(__HALF2_TO_CUI(a)));
     return val;
 }
-#if !defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 530) || defined(_NVHPC_CUDA)
 __CUDA_FP16_DECL__ __half hexp10(const __half a) {
     __half val;
     asm("{.reg.b16         h,r;            \n"
@@ -3762,7 +2560,6 @@ __CUDA_FP16_DECL__ __half2 h2log10(const __half2 a) {
 }
 #undef __SPEC_CASE2
 #undef __SPEC_CASE
-#endif /* !defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 530) || defined(_NVHPC_CUDA) */
 __CUDA_FP16_DECL__ __half2 h2rcp(const __half2 a) {
     __APPROX_FCAST2(rcp)
 }
@@ -3783,88 +2580,49 @@ __CUDA_FP16_DECL__ __half hsqrt(const __half a) {
 }
 #undef __APPROX_FCAST
 #undef __APPROX_FCAST2
-#endif /* defined(_NVHPC_CUDA) || defined(__CUDACC__) */
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hisnan2(const __half2 a)
+__CUDA_FP16_DECL__ __half2 __hisnan2(const __half2 a)
 {
     __half2 r;
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53,
     asm("{set.nan.f16x2.f16x2 %0,%1,%2;\n}"
         :"=r"(__HALF2_TO_UI(r)) : "r"(__HALF2_TO_CUI(a)), "r"(__HALF2_TO_CUI(a)));
-,
-    __half2_raw val;
-    val.x = __hisnan(a.x) ? (unsigned short)0x3C00U : (unsigned short)0U;
-    val.y = __hisnan(a.y) ? (unsigned short)0x3C00U : (unsigned short)0U;
-    r = __half2(val);
-)
     return r;
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ bool __hisnan(const __half a)
+__CUDA_FP16_DECL__ bool __hisnan(const __half a)
 {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53,
     __half r;
     asm("{set.nan.f16.f16 %0,%1,%2;\n}"
         :"=h"(__HALF_TO_US(r)) : "h"(__HALF_TO_CUS(a)), "h"(__HALF_TO_CUS(a)));
     return __HALF_TO_CUS(r) != 0U;
-,
-    const __half_raw hr = static_cast<__half_raw>(a);
-    return ((hr.x & (unsigned short)0x7FFFU) > (unsigned short)0x7C00U);
-)
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hneg2(const __half2 a)
+__CUDA_FP16_DECL__ __half2 __hneg2(const __half2 a)
 {
     __half2 r;
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53,
     asm("{neg.f16x2 %0,%1;\n}"
         :"=r"(__HALF2_TO_UI(r)) : "r"(__HALF2_TO_CUI(a)));
-,
-    r.x = __hneg(a.x);
-    r.y = __hneg(a.y);
-)
     return r;
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __hneg(const __half a)
+__CUDA_FP16_DECL__ __half __hneg(const __half a)
 {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53,
     __half r;
     asm("{neg.f16 %0,%1;\n}"
         :"=h"(__HALF_TO_US(r)) : "h"(__HALF_TO_CUS(a)));
     return r;
-,
-    const float fa = __half2float(a);
-    return __float2half(-fa);
-)
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __habs2(const __half2 a)
+__CUDA_FP16_DECL__ __half2 __habs2(const __half2 a)
 {
     __half2 r;
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53,
     asm("{abs.f16x2 %0,%1;\n}"
         :"=r"(__HALF2_TO_UI(r)) : "r"(__HALF2_TO_CUI(a)));
-,
-    r.x = __habs(a.x);
-    r.y = __habs(a.y);
-)
     return r;
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __habs(const __half a)
+__CUDA_FP16_DECL__ __half __habs(const __half a)
 {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53,
     __half r;
     asm("{abs.f16 %0,%1;\n}"
         :"=h"(__HALF_TO_US(r)) : "h"(__HALF_TO_CUS(a)));
     return r;
-,
-    __half_raw abs_a_raw = static_cast<__half_raw>(a);
-    abs_a_raw.x &= (unsigned short)0x7FFFU;
-    if (abs_a_raw.x > (unsigned short)0x7C00U)
-    {
-        // return canonical NaN
-        abs_a_raw.x = (unsigned short)0x7FFFU;
-    }
-    return static_cast<__half>(abs_a_raw);
-)
 }
-#if defined(__CUDACC__) && (!defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 530)) || defined(_NVHPC_CUDA)
+
 __CUDA_FP16_DECL__ __half2 __hcmadd(const __half2 a, const __half2 b, const __half2 c)
 {
     // fast version of complex multiply-accumulate
@@ -3877,103 +2635,37 @@ __CUDA_FP16_DECL__ __half2 __hcmadd(const __half2 a, const __half2 b, const __ha
     img_tmp  = __hfma(a.y,         b.x, img_tmp);
     return make_half2(real_tmp, img_tmp);
 }
-#endif /* defined(__CUDACC__) && (!defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 530)) || defined(_NVHPC_CUDA) */
 
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __hmax_nan(const __half a, const __half b)
+#endif /* !defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 530) || defined(_NVHPC_CUDA) */
+
+#if defined(_NVHPC_CUDA) || !defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 800)
+__CUDA_FP16_DECL__ __half __hmax_nan(const __half a, const __half b)
 {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_80,
     __BINARY_OP_HALF_MACRO(max.NaN)
-,
-    __half maxval;
-    if (__hisnan(a) || __hisnan(b))
-    {
-        maxval = CUDART_NAN_FP16;
-    }
-    else
-    {
-        maxval = __hmax(a, b);
-    }
-    return maxval;
-)
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ __half __hmin_nan(const __half a, const __half b)
+__CUDA_FP16_DECL__ __half __hmin_nan(const __half a, const __half b)
 {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_80,
     __BINARY_OP_HALF_MACRO(min.NaN)
-,
-    __half minval;
-    if (__hisnan(a) || __hisnan(b))
-    {
-        minval = CUDART_NAN_FP16;
-    }
-    else
-    {
-        minval = __hmin(a, b);
-    }
-    return minval;
-)
 }
-
-#if defined(__CUDACC__) && (!defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 530)) || defined(_NVHPC_CUDA)
 __CUDA_FP16_DECL__ __half __hfma_relu(const __half a, const __half b, const __half c)
 {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_80,
     __TERNARY_OP_HALF_MACRO(fma.rn.relu)
-,
-    return __hmax_nan(__hfma(a, b, c), CUDART_ZERO_FP16);
-)
 }
-#endif /* defined(__CUDACC__) && (!defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 530)) || defined(_NVHPC_CUDA) */
 
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hmax2_nan(const __half2 a, const __half2 b)
+__CUDA_FP16_DECL__ __half2 __hmax2_nan(const __half2 a, const __half2 b)
 {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_80,
     __BINARY_OP_HALF2_MACRO(max.NaN)
-,
-    __half2 result = __hmax2(a, b);
-    if (__hisnan(a.x) || __hisnan(b.x))
-    {
-        result.x = CUDART_NAN_FP16;
-    }
-    if (__hisnan(a.y) || __hisnan(b.y))
-    {
-        result.y = CUDART_NAN_FP16;
-    }
-    return result;
-)
 }
-__CUDA_HOSTDEVICE_FP16_DECL__ __half2 __hmin2_nan(const __half2 a, const __half2 b)
+__CUDA_FP16_DECL__ __half2 __hmin2_nan(const __half2 a, const __half2 b)
 {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_80,
     __BINARY_OP_HALF2_MACRO(min.NaN)
-,
-    __half2 result = __hmin2(a, b);
-    if (__hisnan(a.x) || __hisnan(b.x))
-    {
-        result.x = CUDART_NAN_FP16;
-    }
-    if (__hisnan(a.y) || __hisnan(b.y))
-    {
-        result.y = CUDART_NAN_FP16;
-    }
-    return result;
-)
 }
-#if defined(__CUDACC__) && (!defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 530)) || defined(_NVHPC_CUDA)
 __CUDA_FP16_DECL__ __half2 __hfma2_relu(const __half2 a, const __half2 b, const __half2 c)
 {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_80,
     __TERNARY_OP_HALF2_MACRO(fma.rn.relu)
-,
-    __half2_raw hzero;
-    hzero.x = (unsigned short)0U;
-    hzero.y = (unsigned short)0U;
-    return __hmax2_nan(__hfma2(a, b, c), __half2(hzero));
-)
 }
-#endif /* defined(__CUDACC__) && (!defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 530)) || defined(_NVHPC_CUDA) */
+#endif /*defined(_NVHPC_CUDA) || !defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 800)*/
 
-#if defined(__CUDACC__) || defined(_NVHPC_CUDA)
 /* Define __PTR for atomicAdd prototypes below, undef after done */
 #if (defined(_MSC_VER) && defined(_WIN64)) || defined(__LP64__) || defined(__CUDACC_RTC__)
 #define __PTR   "l"
@@ -3981,39 +2673,35 @@ NV_IF_ELSE_TARGET(NV_PROVIDES_SM_80,
 #define __PTR   "r"
 #endif /*(defined(_MSC_VER) && defined(_WIN64)) || defined(__LP64__) || defined(__CUDACC_RTC__)*/
 
+#if defined(_NVHPC_CUDA) || !defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 600)
+
 __CUDA_FP16_DECL__  __half2 atomicAdd(__half2 *const address, const __half2 val) {
-NV_IF_ELSE_TARGET(NV_PROVIDES_SM_60,
     __half2 r;
     asm volatile ("{ atom.add.noftz.f16x2 %0,[%1],%2; }\n"
                   : "=r"(__HALF2_TO_UI(r)) : __PTR(address), "r"(__HALF2_TO_CUI(val))
                   : "memory");
-    return r;
-,
-    unsigned int* address_as_uint = (unsigned int*)address;
-    unsigned int old = *address_as_uint;
-    unsigned int assumed;
-    do {
-        assumed = old;
-        __half2 new_val = __hadd2(val, *(__half2*)&assumed);
-        old = atomicCAS(address_as_uint, assumed, *(unsigned int*)&new_val);
-    } while (assumed != old);
-    return *(__half2*)&old;
-)
+   return r;
 }
 
-#if (defined(__CUDACC__) && (!defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 700))) || defined(_NVHPC_CUDA)
+#endif /*defined(_NVHPC_CUDA) || !defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 600)*/
+
+#if defined(_NVHPC_CUDA) || !defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 700)
+
 __CUDA_FP16_DECL__  __half atomicAdd(__half *const address, const __half val) {
     __half r;
     asm volatile ("{ atom.add.noftz.f16 %0,[%1],%2; }\n"
                   : "=h"(__HALF_TO_US(r))
                   : __PTR(address), "h"(__HALF_TO_CUS(val))
                   : "memory");
-    return r;
+   return r;
 }
-#endif /* (defined(__CUDACC__) && (!defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 700))) || defined(_NVHPC_CUDA) */
+
+#endif /*defined(_NVHPC_CUDA) || !defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 700)*/
 
 #undef __PTR
-#endif /* defined(__CUDACC__) || defined(_NVHPC_CUDA) */
+
+#undef __CUDA_FP16_DECL__
+#endif /* defined(__CUDACC__) */
 #endif /* defined(__cplusplus) */
 
 #undef __TERNARY_OP_HALF2_MACRO
@@ -4028,63 +2716,18 @@ __CUDA_FP16_DECL__  __half atomicAdd(__half *const address, const __half val) {
 #undef __HALF_TO_CUS
 #undef __HALF2_TO_UI
 #undef __HALF2_TO_CUI
-#undef __CUDA_FP16_CONSTEXPR__
 
 /* Define first-class types "half" and "half2", unless user specifies otherwise via "#define CUDA_NO_HALF" */
 /* C cannot ever have these types defined here, because __half and __half2 are C++ classes */
 #if defined(__cplusplus) && !defined(CUDA_NO_HALF)
-/**
- * \ingroup CUDA_MATH_INTRINSIC_HALF
- * \brief This datatype is meant to be the first-class or fundamental
- * implementation of the half-precision numbers format.
- * 
- * \details Should be implemented in the compiler in the future.
- * Current implementation is a simple typedef to a respective
- * user-level type with underscores.
- */
 typedef __half half;
-
-/**
- * \ingroup CUDA_MATH_INTRINSIC_HALF
- * \brief This datatype is meant to be the first-class or fundamental
- * implementation of type for pairs of half-precision numbers.
- * 
- * \details Should be implemented in the compiler in the future.
- * Current implementation is a simple typedef to a respective
- * user-level type with underscores.
- */
 typedef __half2 half2;
 // for consistency with __nv_bfloat16
-
-/**
- * \ingroup CUDA_MATH_INTRINSIC_HALF
- * \brief This datatype is an \p __nv_ prefixed alias
- */
 typedef __half      __nv_half;
-/**
- * \ingroup CUDA_MATH_INTRINSIC_HALF
- * \brief This datatype is an \p __nv_ prefixed alias
- */
 typedef __half2     __nv_half2;
-/**
- * \ingroup CUDA_MATH_INTRINSIC_HALF
- * \brief This datatype is an \p __nv_ prefixed alias
- */
 typedef __half_raw  __nv_half_raw;
-/**
- * \ingroup CUDA_MATH_INTRINSIC_HALF
- * \brief This datatype is an \p __nv_ prefixed alias
- */
 typedef __half2_raw __nv_half2_raw;
-/**
- * \ingroup CUDA_MATH_INTRINSIC_HALF
- * \brief This datatype is an \p nv_ prefixed alias
- */
 typedef __half        nv_half;
-/**
- * \ingroup CUDA_MATH_INTRINSIC_HALF
- * \brief This datatype is an \p nv_ prefixed alias
- */
 typedef __half2       nv_half2;
 #endif /* defined(__cplusplus) && !defined(CUDA_NO_HALF) */
 


### PR DESCRIPTION
Follows-up #7748. FP16 headers from CUDA 12.2.0 added dependency to `vector_types.h`, `vector_functions.h`, `cuda_runtime_api.h`, etc., causing compilation errors in environment without these headers.

CUDA 12.1.1:
```
% grep '#include' /usr/local/cuda-12.1.1/include/cuda_fp16.h
/usr/local/cuda-12.1.1/include/cuda_fp16.h:#include "cuda_fp16.hpp"
```

CUDA 12.2.0:
```
% grep '#include' /usr/local/cuda-12.2.0/include/cuda_fp16.h
/usr/local/cuda-12.2.0/include/cuda_fp16.h:#include "vector_types.h"
/usr/local/cuda-12.2.0/include/cuda_fp16.h:#include "vector_functions.h"
/usr/local/cuda-12.2.0/include/cuda_fp16.h:#include "cuda_fp16.hpp"

% grep '#include' /usr/local/cuda-12.2.0/include/vector_types.h
#include "crt/host_defines.h"

% grep '#include' /usr/local/cuda-12.2.0/include/vector_functions.h
#include "cuda_runtime_api.h"
#include "vector_functions.hpp"
```
