### PR TITLE
Add timeout to Windows CI

### DIFF
--- a/.pfnci/windows/_error_handler.ps1
+++ b/.pfnci/windows/_error_handler.ps1
@@ -13,3 +13,40 @@ function RunOrDie {
         throw "Command failed (exit code = $LastExitCode): $args"
     }
 }
+
+function RunWithTimeout {
+    param(
+        [Parameter(Mandatory=$true)]
+        [int]$timeout,
+        [Parameter(Mandatory=$true)]
+        [string]$command,
+        [Parameter(Mandatory=$true, ValueFromRemainingArguments=$true)]
+        [string[]]$params
+    )
+    $process = Start-Process -NoNewWindow -PassThru -FilePath $command -ArgumentList $params
+
+    for ($i = 0; $i -lt $timeout; $i++) {
+        if ($process.HasExited) {
+            break
+        }
+        Start-Sleep -Seconds 1
+    }
+    if (!$process.HasExited) {
+        Write-Warning "Command timed out: $command $params"
+        $process | Stop-Process -Force
+
+        # Wait until the process exit to retrieve the exit code.
+        for ($i = 0; $i -lt 100; $i++) {
+            if ($process.HasExited) {
+                break
+            }
+            Start-Sleep -Seconds 0.3
+        }
+        if (!$process.HasExited) {
+            Write-Warning "Failed to stop the process: $command $params"
+            return 999  # ExitCode unavailable, return a dummy value
+        }
+    }
+
+    return $process.ExitCode
+}

--- a/.pfnci/windows/_error_handler.ps1
+++ b/.pfnci/windows/_error_handler.ps1
@@ -19,11 +19,13 @@ function RunWithTimeout {
         [Parameter(Mandatory=$true)]
         [int]$timeout,
         [Parameter(Mandatory=$true)]
+        [string]$output,
+        [Parameter(Mandatory=$true)]
         [string]$command,
         [Parameter(Mandatory=$true, ValueFromRemainingArguments=$true)]
         [string[]]$params
     )
-    $process = Start-Process -NoNewWindow -PassThru -FilePath $command -ArgumentList $params
+    $process = Start-Process -NoNewWindow -PassThru -RedirectStandardOutput $output -FilePath $command -ArgumentList $params
 
     for ($i = 0; $i -lt $timeout; $i++) {
         if ($process.HasExited) {

--- a/.pfnci/windows/test.ps1
+++ b/.pfnci/windows/test.ps1
@@ -46,8 +46,10 @@ function PublishTestResults {
     echo "Uploading test results..."
     $artifact_id = $Env:CI_JOB_ID
     RunOrDie gsutil -m -q cp cupy_build_log.txt cupy_test_log.txt "gs://chainer-artifacts-pfn-public-ci/cupy-ci/$artifact_id/"
-    echo "Build Log: https://storage.googleapis.com/chainer-artifacts-pfn-public-ci/cupy-ci/$artifact_id/cupy_build_log.txt"
-    echo "Test Log: https://storage.googleapis.com/chainer-artifacts-pfn-public-ci/cupy-ci/$artifact_id/cupy_test_log.txt"
+    echo "Build Log:"
+    echo "https://storage.googleapis.com/chainer-artifacts-pfn-public-ci/cupy-ci/$artifact_id/cupy_build_log.txt"
+    echo "Test Log:"
+    echo "https://storage.googleapis.com/chainer-artifacts-pfn-public-ci/cupy-ci/$artifact_id/cupy_test_log.txt"
 }
 
 function Main {
@@ -138,8 +140,10 @@ function Main {
         UploadCache "${cache_archive}"
     }
 
+    echo "====================================================================="
     echo "Last 10 lines from the test output:"
     Get-Content cupy_test_log.txt -Tail 10
+    echo "====================================================================="
 
     PublishTestResults
     if ($test_retval -ne 0) {

--- a/.pfnci/windows/test.ps1
+++ b/.pfnci/windows/test.ps1
@@ -128,12 +128,8 @@ function Main {
     echo "CuPy Configuration:"
     RunOrDie python -c "import cupy; print(cupy); cupy.show_config()"
     echo "Running test..."
-    $test_retval = 0
-    python -c "import cupy; cupy.show_config()" > ../cupy_test_log.txt
-    python -m pytest -rfEX @pytest_opts . >> ../cupy_test_log.txt
-    if (-not $?) {
-        $test_retval = $LastExitCode
-    }
+    RunOrDie python -c "import cupy; cupy.show_config()" > ../cupy_test_log.txt
+    $test_retval = RunWithTimeout -timeout 300 python -m pytest -rfEX @pytest_opts . >> ../cupy_test_log.txt
     popd
 
     if (-Not $is_pull_request) {

--- a/.pfnci/windows/test.ps1
+++ b/.pfnci/windows/test.ps1
@@ -128,8 +128,8 @@ function Main {
     echo "CuPy Configuration:"
     RunOrDie python -c "import cupy; print(cupy); cupy.show_config()"
     echo "Running test..."
-    RunOrDie python -c "import cupy; cupy.show_config()" > ../cupy_test_log.txt
-    $test_retval = RunWithTimeout -timeout 300 -- python -m pytest -rfEX @pytest_opts . >> ../cupy_test_log.txt
+    RunOrDie python -c "import cupy; cupy.show_config()"
+    $test_retval = RunWithTimeout -timeout 300 -output ../cupy_test_log.txt -- python -m pytest -rfEX @pytest_opts .
     popd
 
     if (-Not $is_pull_request) {

--- a/.pfnci/windows/test.ps1
+++ b/.pfnci/windows/test.ps1
@@ -129,7 +129,7 @@ function Main {
     RunOrDie python -c "import cupy; print(cupy); cupy.show_config()"
     echo "Running test..."
     RunOrDie python -c "import cupy; cupy.show_config()"
-    $test_retval = RunWithTimeout -timeout 300 -output ../cupy_test_log.txt -- python -m pytest -rfEX @pytest_opts .
+    $test_retval = RunWithTimeout -timeout 18000 -output ../cupy_test_log.txt -- python -m pytest -rfEX @pytest_opts .
     popd
 
     if (-Not $is_pull_request) {

--- a/.pfnci/windows/test.ps1
+++ b/.pfnci/windows/test.ps1
@@ -101,7 +101,7 @@ function Main {
     if ($test -eq "build") {
         return
     } elseif ($test -eq "test") {
-        $pytest_opts = "-m", "not slow"
+        $pytest_opts = "-m", '"not slow"'
     } elseif ($test -eq "slow") {
         $pytest_opts = "-m", "slow"
     } else {

--- a/.pfnci/windows/test.ps1
+++ b/.pfnci/windows/test.ps1
@@ -129,7 +129,7 @@ function Main {
     RunOrDie python -c "import cupy; print(cupy); cupy.show_config()"
     echo "Running test..."
     RunOrDie python -c "import cupy; cupy.show_config()" > ../cupy_test_log.txt
-    $test_retval = RunWithTimeout -timeout 300 python -m pytest -rfEX @pytest_opts . >> ../cupy_test_log.txt
+    $test_retval = RunWithTimeout -timeout 300 -- python -m pytest -rfEX @pytest_opts . >> ../cupy_test_log.txt
     popd
 
     if (-Not $is_pull_request) {


### PR DESCRIPTION
Currently Windows CIs for branch tests take more than the hard limit (10 hours) set in `.pfnci/config.pbtxt`.
This is preventing the kernel cache to grow and taking 8 hours for each pull request tests.

This PR intends to add soft timeout to Windows CI to grow kernel cache incrementally.