### PR TITLE
Improve publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ on:
         default: "v13.0.0rc9"
 
 jobs:
-  prepare:
+  check:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
@@ -33,6 +33,16 @@ jobs:
       run: |
         pip install distlib
         ./check_release_assets.py --version "${{ inputs.release }}" --github
+
+  upload:
+    needs: check
+    environment:
+      name: pypi-release
+      url: https://pypi.org/org/cupy/
+    permissions:
+      id-token: write
+    runs-on: ubuntu-latest
+    steps:
     - name: Download (sdist)
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -46,26 +56,6 @@ jobs:
       run: |
         cd dist
         find . -ls | tee "${GITHUB_STEP_SUMMARY}"
-    - name: Upload Artifacts to Publish
-      uses: actions/upload-artifact@v3
-      with:
-        name: dist
-        path: dist
-        retention-days: 1
-
-  upload:
-    needs: prepare
-    environment:
-      name: pypi-release
-      url: https://pypi.org/org/cupy/
-    permissions:
-      id-token: write
-    runs-on: ubuntu-latest
-    steps:
-    - name: Download Artifacts to Publish
-      uses: actions/download-artifact@v3
-      with:
-        name: dist
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,12 +47,12 @@ jobs:
     - name: Download (sdist)
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: gh -R cupy/cupy release download "${{ inputs.release }}" --dir dist --pattern "cupy-*.tar.gz"
+      run: gh release download "${{ inputs.release }}" --dir dist --pattern "cupy-*.tar.gz"
     - name: Download (wheels)
       if: ${{ inputs.branch != 'main' }}
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: gh -R cupy/cupy release download "${{ inputs.release }}" --dir dist --pattern "cupy_*.whl"
+      run: gh release download "${{ inputs.release }}" --dir dist --pattern "cupy_*.whl"
     - name: Enumerate Files
       run: |
         cd dist

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,7 +56,7 @@ jobs:
       run: |
         cd dist
         echo '```' >> "${GITHUB_STEP_SUMMARY}"
-        find . -ls | tee "${GITHUB_STEP_SUMMARY}"
+        find . -type f -ls | tee "${GITHUB_STEP_SUMMARY}"
         echo '```' >> "${GITHUB_STEP_SUMMARY}"
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,6 +33,7 @@ jobs:
       run: |
         pip install distlib
         ./check_release_assets.py --version "${{ inputs.release }}" --github
+        echo "::notice::Release: $(gh -R cupy/cupy release view '${{ inputs.release }}' --json 'url' --jq '.url')"
 
   upload:
     needs: check

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,7 +55,9 @@ jobs:
     - name: Enumerate Files
       run: |
         cd dist
+        echo '```' >> "${GITHUB_STEP_SUMMARY}"
         find . -ls | tee "${GITHUB_STEP_SUMMARY}"
+        echo '```' >> "${GITHUB_STEP_SUMMARY}"
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:


### PR DESCRIPTION
Another minor fixes to https://github.com/cupy/cupy/pull/7779. Let me self-merge.

Uploading checked assets via `actions/upload-artifacts` was slower than expected (20+ minutes). Let's upload directly from GitHub Releases.