### PR TITLE
Fix publish workflow permission and output for review

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,8 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -32,7 +34,9 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         pip install distlib
-        ./check_release_assets.py --version "${{ inputs.release }}" --github
+        echo '```' >> "${GITHUB_STEP_SUMMARY}"
+        ./check_release_assets.py --version "${{ inputs.release }}" --github | tee "${GITHUB_STEP_SUMMARY}"
+        echo '```' >> "${GITHUB_STEP_SUMMARY}"
         echo "::notice::Release: $(gh -R cupy/cupy release view '${{ inputs.release }}' --json 'url' --jq '.url')"
 
   upload:
@@ -41,6 +45,7 @@ jobs:
       name: pypi-release
       url: https://pypi.org/org/cupy/
     permissions:
+      contents: read
       id-token: write
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Minor fix to #7779. Fix broken permission. Let me self merge.
