### PR TITLE
Avoid warning when uploading packages

### DIFF
--- a/install/cupy_builder/_context.py
+++ b/install/cupy_builder/_context.py
@@ -62,7 +62,7 @@ def parse_args(argv: List[str]) -> Tuple[Any, List[str]]:
         help='alternate package name')
     parser.add_argument(
         '--cupy-long-description', type=str, default=None,
-        help='path to the long description file')
+        help='path to the long description file (reST)')
     parser.add_argument(
         '--cupy-wheel-lib', type=str, action='append', default=[],
         help='shared library to copy into the wheel '

--- a/setup.py
+++ b/setup.py
@@ -125,6 +125,7 @@ setup(
     version=__version__,  # NOQA
     description='CuPy: NumPy & SciPy for GPU',
     long_description=long_description,
+    long_description_content_type='text/x-rst',
     author='Seiya Tokui',
     author_email='tokui@preferred.jp',
     maintainer='CuPy Developers',


### PR DESCRIPTION
(Not required for release.)

PyPI upload emits warning if `long_description_content_type` is not specified.
https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#description
