### PR TITLE
Fix ROCm Dockerfile not working

### DIFF
--- a/docker/rocm/Dockerfile
+++ b/docker/rocm/Dockerfile
@@ -1,19 +1,18 @@
-FROM rocm/rocm-terminal:5.0.1
+FROM rocm/dev-ubuntu-20.04:5.0.1
 LABEL maintainer="CuPy Team"
 
-USER root
 RUN curl -qL https://repo.radeon.com/rocm/rocm.gpg.key | apt-key add -
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
-    hipblas hipsparse rocsparse rocrand rocthrust rocsolver rocfft hipcub rocprim rccl && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    hipblas hipsparse rocsparse rocrand rocthrust rocsolver rocfft hipfft hipcub rocprim rccl && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends python3.9 && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
-RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends python3.8 && \
-    update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 2 && \
-    update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 1
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 2 && \
+    update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 1
 
 RUN python3 -m pip install --no-cache-dir -U install setuptools pip
 RUN python3 -m pip install --no-cache-dir -f https://pip.cupy.dev/pre/ "cupy-rocm-5-0[all]==13.0.0b1"
 
-USER rocm-user
+ENV LD_LIBRARY_PATH=/opt/rocm/lib:$LD_LIBRARY_PATH
+RUN python3 -c "import cupy; cupy.show_config()"


### PR DESCRIPTION
This PR fixes the issue that ROCm Docker images not working due to missing `hipfft` and `LD_LIBRARY_PATH`. Also, now that Ubuntu 18.04 and Python 3.8 are deprecated in CuPy v13, we have to migrate to Ubuntu 20.04 and Python 3.9 instead.

To prevent the future error, I've added `RUN python3 -c "import cupy; cupy.show_config()"` line to verify that CuPy can be imported.
