### PR TITLE
ENH: Remove `NINF`, `PINF`, `Inf`,... usages

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -62,6 +62,14 @@ from numpy import nan  # NOQA
 from numpy import newaxis  # == None  # NOQA
 from numpy import pi  # NOQA
 
+# APIs to be removed in NumPy 2.0.
+# Remove these when bumping the baseline API to NumPy 2.0.
+# https://github.com/cupy/cupy/pull/7800
+PINF = Inf = Infinity = infty = inf  # NOQA
+NINF = -inf  # NOQA
+NAN = NaN = nan  # NOQA
+PZERO = 0.0  # NOQA
+NZERO = -0.0  # NOQA
 
 # =============================================================================
 # Data types (borrowed from NumPy)

--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -57,19 +57,10 @@ from cupy._core import ufunc  # NOQA
 # =============================================================================
 from numpy import e  # NOQA
 from numpy import euler_gamma  # NOQA
-from numpy import Inf  # NOQA
 from numpy import inf  # NOQA
-from numpy import Infinity  # NOQA
-from numpy import infty  # NOQA
-from numpy import NAN  # NOQA
-from numpy import NaN  # NOQA
 from numpy import nan  # NOQA
 from numpy import newaxis  # == None  # NOQA
-from numpy import NINF  # NOQA
-from numpy import NZERO  # NOQA
 from numpy import pi  # NOQA
-from numpy import PINF  # NOQA
-from numpy import PZERO  # NOQA
 
 
 # =============================================================================

--- a/cupy/linalg/_norms.py
+++ b/cupy/linalg/_norms.py
@@ -77,9 +77,9 @@ def norm(x, ord=None, axis=None, keepdims=False):
         axis = (axis,)
 
     if len(axis) == 1:
-        if ord == numpy.Inf:
+        if ord == numpy.inf:
             return abs(x).max(axis=axis, keepdims=keepdims)
-        elif ord == -numpy.Inf:
+        elif ord == -numpy.inf:
             return abs(x).min(axis=axis, keepdims=keepdims)
         elif ord == 0:
             # Zero norm
@@ -126,7 +126,7 @@ def norm(x, ord=None, axis=None, keepdims=False):
             if col_axis > row_axis:
                 col_axis -= 1
             ret = abs(x).sum(axis=row_axis).max(axis=col_axis)
-        elif ord == numpy.Inf:
+        elif ord == numpy.inf:
             if row_axis > col_axis:
                 row_axis -= 1
             ret = abs(x).sum(axis=col_axis).max(axis=row_axis)
@@ -134,7 +134,7 @@ def norm(x, ord=None, axis=None, keepdims=False):
             if col_axis > row_axis:
                 col_axis -= 1
             ret = abs(x).sum(axis=row_axis).min(axis=col_axis)
-        elif ord == -numpy.Inf:
+        elif ord == -numpy.inf:
             if row_axis > col_axis:
                 row_axis -= 1
             ret = abs(x).sum(axis=col_axis).min(axis=row_axis)

--- a/cupyx/scipy/sparse/linalg/_norm.py
+++ b/cupyx/scipy/sparse/linalg/_norm.py
@@ -72,11 +72,11 @@ def norm(x, ord=None, axis=None):
             # return _multi_svd_norm(x, row_axis, col_axis, amin)
         elif ord == 1:
             return abs(x).sum(axis=row_axis).max()
-        elif ord == numpy.Inf:
+        elif ord == numpy.inf:
             return abs(x).sum(axis=col_axis).max()
         elif ord == -1:
             return abs(x).sum(axis=row_axis).min()
-        elif ord == -numpy.Inf:
+        elif ord == -numpy.inf:
             return abs(x).sum(axis=col_axis).min()
         elif ord in (None, 'f', 'fro'):
             # The axis order does not matter for this norm.
@@ -88,9 +88,9 @@ def norm(x, ord=None, axis=None):
         if not (-nd <= a < nd):
             raise ValueError('Invalid axis %r for an array with shape %r' %
                              (axis, x.shape))
-        if ord == numpy.Inf:
+        if ord == numpy.inf:
             return abs(x).max(axis=a).A.ravel()
-        elif ord == -numpy.Inf:
+        elif ord == -numpy.inf:
             return abs(x).min(axis=a).A.ravel()
         elif ord == 0:
             # Zero norm

--- a/cupyx/scipy/sparse/linalg/_solve.py
+++ b/cupyx/scipy/sparse/linalg/_solve.py
@@ -353,7 +353,7 @@ def lsmr(A, b, x0=None, damp=0.0, atol=1e-6, btol=1e-6, conlim=1e8,
         if (normA * normr) != 0:
             test2 = normar / (normA * normr)
         else:
-            test2 = numpy.infty
+            test2 = numpy.inf
         test3 = 1 / condA
         t1 = test1 / (1 + normA*normx/normb)
         rtol = btol + atol*normA*normx/normb

--- a/examples/gmm/gmm.py
+++ b/examples/gmm/gmm.py
@@ -49,7 +49,7 @@ def e_step(X, inv_cov, means, weights):
 
 def train_gmm(X, max_iter, tol, means, covariances):
     xp = cupy.get_array_module(X)
-    lower_bound = -np.infty
+    lower_bound = -np.inf
     converged = False
     weights = xp.array([0.5, 0.5], dtype=np.float32)
     inv_cov = 1 / xp.sqrt(covariances)

--- a/tests/cupy_tests/linalg_tests/test_norms.py
+++ b/tests/cupy_tests/linalg_tests/test_norms.py
@@ -25,22 +25,22 @@ class TestTrace(unittest.TestCase):
 
 @testing.parameterize(*testing.product({
     'shape': [(1,), (2,)],
-    'ord': [-numpy.Inf, -2, -1, 0, 1, 2, 3, numpy.Inf],
+    'ord': [-numpy.inf, -2, -1, 0, 1, 2, 3, numpy.inf],
     'axis': [0, None],
     'keepdims': [True, False],
 }) + testing.product({
     'shape': [(1, 2), (2, 2)],
-    'ord': [-numpy.Inf, -2, -1, 1, 2, numpy.Inf, 'fro', 'nuc'],
+    'ord': [-numpy.inf, -2, -1, 1, 2, numpy.inf, 'fro', 'nuc'],
     'axis': [(0, 1), None],
     'keepdims': [True, False],
 }) + testing.product({
     'shape': [(2, 2, 2)],
-    'ord': [-numpy.Inf, -2, -1, 0, 1, 2, 3, numpy.Inf],
+    'ord': [-numpy.inf, -2, -1, 0, 1, 2, 3, numpy.inf],
     'axis': [0, 1, 2],
     'keepdims': [True, False],
 }) + testing.product({
     'shape': [(2, 2, 2)],
-    'ord': [-numpy.Inf, -1, 1, numpy.Inf, 'fro'],
+    'ord': [-numpy.inf, -1, 1, numpy.inf, 'fro'],
     'axis': [(0, 1), (0, 2), (1, 2)],
     'keepdims': [True, False],
 })

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
@@ -68,7 +68,7 @@ class TestLsqr(unittest.TestCase):
 
 
 @testing.parameterize(*testing.product({
-    'ord': [None, -numpy.Inf, -2, -1, 0, 1, 2, 3, numpy.Inf, 'fro'],
+    'ord': [None, -numpy.inf, -2, -1, 0, 1, 2, 3, numpy.inf, 'fro'],
     'dtype': [
         numpy.float32,
         numpy.float64,
@@ -84,7 +84,7 @@ class TestMatrixNorm:
                                  accept_error=(ValueError,
                                                NotImplementedError))
     def test_matrix_norm(self, xp, sp):
-        if runtime.is_hip and self.ord in (1, -1, numpy.Inf, -numpy.Inf):
+        if runtime.is_hip and self.ord in (1, -1, numpy.inf, -numpy.inf):
             pytest.xfail('csc spmv is buggy')
         if self.ord == 2:
             pytest.xfail('ord=2 is not implemented in cupy')
@@ -95,7 +95,7 @@ class TestMatrixNorm:
 
 
 @testing.parameterize(*testing.product({
-    'ord': [None, -numpy.Inf, -2, -1, 0, 1, 2, numpy.Inf, 'fro'],
+    'ord': [None, -numpy.inf, -2, -1, 0, 1, 2, numpy.inf, 'fro'],
     'dtype': [
         numpy.float32,
         numpy.float64,


### PR DESCRIPTION
Hi!
Due to NumPy's main namespace being changed in https://github.com/numpy/numpy/pull/24357, here I update warning imports. Here I delete aliases that were decided to be removed. 