### PR TITLE
Update `__repr__` to display some information

### DIFF
--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -1745,7 +1745,7 @@ cdef class _ndarray_base:
     # String representations:
 
     def __repr__(self):
-        return repr(self.get())
+        return f"{repr(self.get())} on {self.device}"
 
     def __str__(self):
         return str(self.get())


### PR DESCRIPTION
This is a quick update to the `__repr__` method to address issue #6926 and show device information from the repr. 

