### PR TITLE
Fix cuTENSOR contraction descriptor cache

### DIFF
--- a/cupyx/cutensor.pyx
+++ b/cupyx/cutensor.pyx
@@ -125,7 +125,7 @@ cdef class Mode:
     def __eq__(self, other):
         if not isinstance(other, Mode):
             return False
-        return (self._array == other._array).all()
+        return (self._array == (<Mode>other)._array).all()
 
     def __hash__(self):
         return hash(bytes(self._array))

--- a/cupyx/cutensor.pyx
+++ b/cupyx/cutensor.pyx
@@ -122,6 +122,14 @@ cdef class Mode:
     def __repr__(self):
         return 'mode(' + ', '.join([str(x) for x in self._array]) + ')'
 
+    def __eq__(self, other):
+        if not isinstance(other, Mode):
+            return False
+        return (self._array == other._array).all()
+
+    def __hash__(self):
+        return hash(bytes(self._array))
+
 
 cdef class _Scalar:
 
@@ -423,9 +431,9 @@ cdef inline ContractionDescriptor _create_contraction_descriptor(
     cdef ContractionDescriptor desc
 
     key = (handle.ptr, cutensor_compute_type,
-           desc_A.ptr, mode_A.data, alignment_req_A,
-           desc_B.ptr, mode_B.data, alignment_req_B,
-           desc_C.ptr, mode_C.data, alignment_req_C)
+           desc_A.ptr, mode_A, alignment_req_A,
+           desc_B.ptr, mode_B, alignment_req_B,
+           desc_C.ptr, mode_C, alignment_req_C)
     if key in _contraction_descriptors:
         desc = _contraction_descriptors[key]
         return desc

--- a/tests/cupyx_tests/test_cutensor.py
+++ b/tests/cupyx_tests/test_cutensor.py
@@ -187,12 +187,10 @@ class TestMode:
         m1 = cutensor.create_mode(10, 11, 12)
         m2 = cutensor.create_mode(10, 11, 12)
         assert m1 == m2
-        assert hash(m1) == hash(m2)
-        assert m1.data != m2.data
+        assert m1.data == m2.data  # cached
 
         m2 = cutensor.create_mode(12, 11, 10)
         assert m1 != m2
-        assert hash(m1) != hash(m2)
         assert m1.data != m2.data
 
 

--- a/tests/cupyx_tests/test_cutensor.py
+++ b/tests/cupyx_tests/test_cutensor.py
@@ -1,3 +1,5 @@
+import gc
+
 import numpy
 import pytest
 
@@ -181,6 +183,18 @@ class TestMode:
         assert m.ndim == 2
         assert repr(m) == 'mode(120, 121)'
 
+    def test_mode_compare(self):
+        m1 = cutensor.create_mode(10, 11, 12)
+        m2 = cutensor.create_mode(10, 11, 12)
+        assert m1 == m2
+        assert hash(m1) == hash(m2)
+        assert m1.data != m2.data
+
+        m2 = cutensor.create_mode(12, 11, 10)
+        assert m1 != m2
+        assert hash(m1) != hash(m2)
+        assert m1.data != m2.data
+
 
 @pytest.mark.skipif(not ct.available, reason='cuTensor is unavailable')
 class TestScalar:
@@ -273,7 +287,7 @@ class TestCuTensorDescriptor:
 @testing.parameterize(*testing.product({
     'dtype_combo': ['eee', 'fff', 'ddd', 'FFF', 'DDD', 'dDD', 'DdD'],
     'compute_type_hint': [None, 'down-convert', 'TF32'],
-    'shape': [(40, 30, 20)],
+    'shape': [(40, 20, 20)],  # let last two dim be the same for testing cache
     'alpha': [1.0],
     'beta': [0.0, 1.0],
 }))
@@ -335,6 +349,20 @@ class TestCuTensorContraction:
         mode_a = cutensor.create_mode('m', 'k')
         mode_b = cutensor.create_mode('k', 'n')
         mode_c = cutensor.create_mode('m', 'n')
+        cutensor.contraction(self.alpha,
+                             self.a, desc_a, mode_a,
+                             self.b, desc_b, mode_b,
+                             self.beta,
+                             self.c, desc_c, mode_c)
+        cupy.testing.assert_allclose(self.c, self.c_ref,
+                                     rtol=self.tol, atol=self.tol)
+
+        # test the contraction descriptor cache (issues #7318, #7812)
+        del mode_b
+        gc.collect()
+        mode_b = cutensor.create_mode('n', 'k')  # flipped
+        self.c_ref = self.alpha * cupy.matmul(self.a, self.b.T)
+        self.c_ref += self.beta * self.c
         cutensor.contraction(self.alpha,
                              self.a, desc_a, mode_a,
                              self.b, desc_b, mode_b,


### PR DESCRIPTION
Close #7318. Close #7812.

The mode labels encapsulated by the `Mode` object should be cached, not just the pointer to it as the same memory could be garbage collected and reused, leading to erroneous cache hits. 

The added tests would fail without the fix.