### PR TITLE
Fix handling of scalars in cupy.r_

### DIFF
--- a/cupy/_indexing/generate.py
+++ b/cupy/_indexing/generate.py
@@ -56,7 +56,7 @@ class AxisConcatenator(object):
                 raise NotImplementedError
             elif type(k) in numpy.ScalarType:
                 newobj = from_data.array(k, ndmin=ndmin)
-                scalars.append(i)
+                scalars.append(k)
             else:
                 newobj = from_data.array(k, copy=False, ndmin=ndmin)
                 if ndmin > 1:
@@ -69,7 +69,7 @@ class AxisConcatenator(object):
 
         final_dtype = numpy.result_type(*arrays, *scalars)
         if final_dtype is not None:
-            for k in scalars:
+            for k in range(len(scalars)):
                 objs[k] = objs[k].astype(final_dtype)
 
         return join.concatenate(tuple(objs), axis=self.axis)

--- a/cupy/_indexing/generate.py
+++ b/cupy/_indexing/generate.py
@@ -56,7 +56,7 @@ class AxisConcatenator(object):
                 raise NotImplementedError
             elif type(k) in numpy.ScalarType:
                 newobj = from_data.array(k, ndmin=ndmin)
-                scalars.append(k)
+                scalars.append(i)
             else:
                 newobj = from_data.array(k, copy=False, ndmin=ndmin)
                 if ndmin > 1:
@@ -67,9 +67,9 @@ class AxisConcatenator(object):
 
             objs.append(newobj)
 
-        final_dtype = numpy.result_type(*arrays, *scalars)
+        final_dtype = numpy.result_type(*arrays, *[objs[k] for k in scalars])
         if final_dtype is not None:
-            for k in range(len(scalars)):
+            for k in scalars:
                 objs[k] = objs[k].astype(final_dtype)
 
         return join.concatenate(tuple(objs), axis=self.axis)

--- a/cupyx/scipy/signal/_splines.py
+++ b/cupyx/scipy/signal/_splines.py
@@ -337,7 +337,12 @@ def symiirorder2(input, r, omega, precision=-1.0):
 
     # Apply the system cs / (1 - a2 * z^-1 - a3 * z^-2)
     zi = cupy.r_[y0, y1]
-    y_fwd, _ = lfilter(cs, cupy.r_[1, -a2, -a3], input[2:], zi=zi)
+    zi = zi.astype(input.dtype)
+
+    coef = cupy.r_[1, -a2, -a3]
+    coef = coef.astype(input.dtype)
+
+    y_fwd, _ = lfilter(cs, coef, input[2:], zi=zi)
     y_fwd = cupy.r_[zi, y_fwd]
 
     # Then compute the symmetric backward starting conditions
@@ -386,5 +391,5 @@ def symiirorder2(input, r, omega, precision=-1.0):
 
     # Apply the system cs / (1 - a2 * z^1 - a3 * z^2)
     zi = cupy.r_[y0, y1]
-    out, _ = lfilter(cs, cupy.r_[1, -a2, -a3], y_fwd[:-2][::-1], zi=zi)
+    out, _ = lfilter(cs, coef, y_fwd[:-2][::-1], zi=zi)
     return cupy.r_[out[::-1], zi[::-1]]

--- a/cupyx/scipy/signal/_splines.py
+++ b/cupyx/scipy/signal/_splines.py
@@ -189,15 +189,21 @@ def symiirorder1(input, c0, z1, precision=-1.0):
         raise ValueError(
             'Sum to find symmetric boundary conditions did not converge.')
 
+    a = cupy.r_[1, -z1]
+    a = a.astype(input.dtype)
+
     # Apply first the system 1 / (1 - z1 * z^-1)
     y1, _ = lfilter(
-        cupy.ones(1, dtype=input.dtype), cupy.r_[1, -z1], input[1:], zi=zi)
+        cupy.ones(1, dtype=input.dtype), a, input[1:], zi=zi)
     y1 = cupy.r_[zi, y1]
 
     # Compute backward symmetric condition and apply the system
     # c0 / (1 - z1 * z)
     zi = -c0 / (z1 - 1.0) * y1[-1]
-    out, _ = lfilter(c0, cupy.r_[1, -z1], y1[:-1][::-1], zi=zi)
+    a = cupy.r_[1, -z1]
+    a = a.astype(input.dtype)
+
+    out, _ = lfilter(c0, a, y1[:-1][::-1], zi=zi)
     return cupy.r_[out[::-1], zi]
 
 

--- a/tests/cupy_tests/indexing_tests/test_generate.py
+++ b/tests/cupy_tests/indexing_tests/test_generate.py
@@ -109,6 +109,11 @@ class TestR_(unittest.TestCase):
         with self.assertRaises(ValueError):
             cupy.r_[a, b]
 
+    @testing.numpy_cupy_array_equal(
+        type_check=(numpy.lib.NumpyVersion(numpy.__version__) >= "1.25.0"))
+    def test_r_scalars(self, xp):
+        return xp.r_[0, 0.5, -1, 0.3]
+
 
 class TestC_(unittest.TestCase):
 

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
@@ -555,6 +555,7 @@ class TestLFilter:
         b = testing.shaped_random((fir_order,), xp, scale=0.3)
         a = testing.shaped_random((iir_order,), xp, scale=0.3)
         a = xp.r_[1, a]
+        a = a.astype(x.dtype)
 
         zi = testing.shaped_random((fir_order + iir_order - 1,), xp)
         zi = scp.signal.lfiltic(b, a, zi[-iir_order:], zi[:fir_order - 1])
@@ -570,6 +571,7 @@ class TestLFilter:
         b = testing.shaped_random((fir_order,), xp, scale=0.3)
         a = testing.shaped_random((iir_order,), xp, scale=0.3)
         a = xp.r_[1, a]
+        a = a.astype(x.dtype)
 
         zi = scp.signal.lfilter_zi(b, a)
         out, _ = scp.signal.lfilter(b, a, x, zi=zi)


### PR DESCRIPTION
After https://github.com/cupy/cupy/pull/7651, `cupy_r` stopped working with floating point scalars, which were being interpreted as integer ones. This was due to the use of the positions of the values (integer values) as opposed to the values themselves.

For example:
![imagen](https://github.com/cupy/cupy/assets/1878982/336313c0-4f5b-41d8-b5be-0fb08d9d1192)


See https://github.com/cupy/cupy/pull/7721#issuecomment-1688923731