### PR TITLE
Add a property to get access to the nccl handle.

### DIFF
--- a/cupy_backends/cuda/libs/nccl.pyx
+++ b/cupy_backends/cuda/libs/nccl.pyx
@@ -285,6 +285,10 @@ cdef class NcclCommunicator:
     def __dealloc__(self):
         self.destroy()
 
+    @property
+    def comm(self):
+        return <intptr_t>self._comm
+
     @staticmethod
     def initAll(devices):
         """ Initialize NCCL communicators for multiple devices in a single


### PR DESCRIPTION
Since there are no official nccl bindings from nvidia, there is no method of using NCCL from python or other libraries outside of cuPy. By allowing the cuPy nccl handle to be directly accessed, cuPy can interop with other NCCL enabled libraries by passing the nccl handle direclty.