### PR TITLE
Fix nvrtc initialize not inlined for CUDA Python

### DIFF
--- a/cupy_backends/cuda/libs/nvrtc.pyx
+++ b/cupy_backends/cuda/libs/nvrtc.pyx
@@ -23,7 +23,7 @@ from cupy_backends.cuda.api cimport runtime
 
 IF CUPY_USE_CUDA_PYTHON:
     from cuda.cnvrtc cimport *
-    cdef void initialize():
+    cdef inline void initialize():
         pass
 ELSE:
     include "_cnvrtc.pxi"


### PR DESCRIPTION
Follows up #7621