### PR TITLE
Lazy import cuSOLVER

### DIFF
--- a/.github/workflows/pretest.yml
+++ b/.github/workflows/pretest.yml
@@ -90,6 +90,14 @@ jobs:
         SPHINXOPTS="-W --keep-going -j 4" make html
         popd
 
+    - name: Import Test
+      run: |
+        python -c 'import cupy, cupyx'
+
+        # Test lazy-imported CUDA Toolkit library.
+        rm cupy_backends/cuda/libs/cusolver.*.so
+        python -c 'import cupy, cupyx'
+
   build-rocm:
     runs-on: ubuntu-22.04
 

--- a/cupy/cuda/__init__.py
+++ b/cupy/cuda/__init__.py
@@ -18,7 +18,6 @@ from cupy_backends.cuda.api import driver  # NOQA
 from cupy_backends.cuda.api import runtime  # NOQA
 from cupy_backends.cuda.libs import cublas  # NOQA
 from cupy_backends.cuda.libs import curand  # NOQA
-from cupy_backends.cuda.libs import cusolver  # NOQA
 from cupy_backends.cuda.libs import cusparse  # NOQA
 from cupy_backends.cuda.libs import nvrtc  # NOQA
 from cupy_backends.cuda.libs import profiler  # NOQA
@@ -53,6 +52,10 @@ except ImportError:
 
 
 def __getattr__(key):
+    if key == 'cusolver':
+        from cupy_backends.cuda.libs import cusolver
+        return cusolver
+
     # `nvtx_enabled` flags are kept for backward compatibility with Chainer.
     # Note: module-level getattr only runs on Python 3.7+.
     for mod in [nvtx]:

--- a/cupy/cuda/device.pyx
+++ b/cupy/cuda/device.pyx
@@ -6,7 +6,6 @@ from cupy._core import syncdetect
 from cupy_backends.cuda.api cimport runtime
 from cupy_backends.cuda.api import runtime as runtime_module
 from cupy_backends.cuda.libs import cublas
-from cupy_backends.cuda.libs import cusolver
 from cupy_backends.cuda.libs import cusparse
 from cupy import _util
 
@@ -264,6 +263,7 @@ cdef class Device:
         itself is different.
 
         """
+        from cupy.cuda import cusolver
         return self._get_handle(
             'cusolver_handles', cusolver.create, cusolver.destroy)
 
@@ -275,6 +275,7 @@ cdef class Device:
         itself is different.
 
         """
+        from cupy.cuda import cusolver
         return self._get_handle(
             'cusolver_sp_handles', cusolver.spCreate, cusolver.spDestroy)
 

--- a/cupy/cuda/device.pyx
+++ b/cupy/cuda/device.pyx
@@ -263,7 +263,7 @@ cdef class Device:
         itself is different.
 
         """
-        from cupy.cuda import cusolver
+        from cupy_backends.cuda.libs import cusolver
         return self._get_handle(
             'cusolver_handles', cusolver.create, cusolver.destroy)
 
@@ -275,7 +275,7 @@ cdef class Device:
         itself is different.
 
         """
-        from cupy.cuda import cusolver
+        from cupy_backends.cuda.libs import cusolver
         return self._get_handle(
             'cusolver_sp_handles', cusolver.spCreate, cusolver.spDestroy)
 

--- a/cupy/linalg/_decomposition.py
+++ b/cupy/linalg/_decomposition.py
@@ -33,7 +33,7 @@ def _lu_factor(a_t, dtype):
     .. seealso:: :func:`scipy.linalg.lu_factor`
 
     """
-    from cupy.cuda import cusolver
+    from cupy_backends.cuda.libs import cusolver
 
     orig_shape = a_t.shape
     n = orig_shape[-2]
@@ -117,7 +117,7 @@ def _potrf_batched(a):
     Returns:
         cupy.ndarray: The lower-triangular matrix.
     """
-    from cupy.cuda import cusolver
+    from cupy_backends.cuda.libs import cusolver
     from cupyx.cusolver import check_availability
     if not check_availability('potrfBatched'):
         raise RuntimeError('potrfBatched is not available')
@@ -175,7 +175,7 @@ def cholesky(a):
 
     .. seealso:: :func:`numpy.linalg.cholesky`
     """
-    from cupy.cuda import cusolver
+    from cupy_backends.cuda.libs import cusolver
 
     _util._assert_cupy_array(a)
     _util._assert_stacked_2d(a)
@@ -286,7 +286,7 @@ def qr(a, mode='reduced'):
 
     .. seealso:: :func:`numpy.linalg.qr`
     """
-    from cupy.cuda import cusolver
+    from cupy_backends.cuda.libs import cusolver
 
     _util._assert_cupy_array(a)
 
@@ -493,7 +493,7 @@ def svd(a, full_matrices=True, compute_uv=True):
 
     .. seealso:: :func:`numpy.linalg.svd`
     """
-    from cupy.cuda import cusolver
+    from cupy_backends.cuda.libs import cusolver
     _util._assert_cupy_array(a)
     if a.ndim > 2:
         return _svd_batched(a, full_matrices, compute_uv)

--- a/cupy/linalg/_decomposition.py
+++ b/cupy/linalg/_decomposition.py
@@ -3,12 +3,8 @@ import numpy
 import cupy
 from cupy_backends.cuda.api import runtime
 from cupy_backends.cuda.libs import cublas
-from cupy_backends.cuda.libs import cusolver
 from cupy._core import internal
 from cupy.cuda import device
-from cupyx.cusolver import check_availability
-from cupyx.cusolver import _gesvdj_batched, _gesvd_batched
-from cupyx.cusolver import _geqrf_orgqr_batched
 from cupy.linalg import _util
 
 
@@ -37,6 +33,8 @@ def _lu_factor(a_t, dtype):
     .. seealso:: :func:`scipy.linalg.lu_factor`
 
     """
+    from cupy.cuda import cusolver
+
     orig_shape = a_t.shape
     n = orig_shape[-2]
 
@@ -119,6 +117,8 @@ def _potrf_batched(a):
     Returns:
         cupy.ndarray: The lower-triangular matrix.
     """
+    from cupy.cuda import cusolver
+    from cupyx.cusolver import check_availability
     if not check_availability('potrfBatched'):
         raise RuntimeError('potrfBatched is not available')
 
@@ -175,6 +175,8 @@ def cholesky(a):
 
     .. seealso:: :func:`numpy.linalg.cholesky`
     """
+    from cupy.cuda import cusolver
+
     _util._assert_cupy_array(a)
     _util._assert_stacked_2d(a)
     _util._assert_stacked_square(a)
@@ -218,6 +220,8 @@ def cholesky(a):
 
 
 def _qr_batched(a, mode):
+    from cupyx.cusolver import _geqrf_orgqr_batched
+
     batch_shape = a.shape[:-2]
     batch_size = internal.prod(batch_shape)
     m, n = a.shape[-2:]
@@ -282,6 +286,8 @@ def qr(a, mode='reduced'):
 
     .. seealso:: :func:`numpy.linalg.qr`
     """
+    from cupy.cuda import cusolver
+
     _util._assert_cupy_array(a)
 
     if mode not in ('reduced', 'complete', 'r', 'raw'):
@@ -386,6 +392,8 @@ def qr(a, mode='reduced'):
 
 
 def _svd_batched(a, full_matrices, compute_uv):
+    from cupyx.cusolver import _gesvdj_batched, _gesvd_batched
+
     batch_shape = a.shape[:-2]
     batch_size = internal.prod(batch_shape)
     n, m = a.shape[-2:]
@@ -485,6 +493,7 @@ def svd(a, full_matrices=True, compute_uv=True):
 
     .. seealso:: :func:`numpy.linalg.svd`
     """
+    from cupy.cuda import cusolver
     _util._assert_cupy_array(a)
     if a.ndim > 2:
         return _svd_batched(a, full_matrices, compute_uv)

--- a/cupy/linalg/_eigenvalue.py
+++ b/cupy/linalg/_eigenvalue.py
@@ -2,18 +2,18 @@ import numpy
 
 import cupy
 from cupy_backends.cuda.libs import cublas
-from cupy_backends.cuda.libs import cusolver
 from cupy.cuda import device
 from cupy.cuda import runtime
 from cupy.linalg import _util
 from cupy._core import _dtype
-import cupyx.cusolver
 
 
 _cuda_runtime_version = -1
 
 
 def _syevd(a, UPLO, with_eigen_vector, overwrite_a=False):
+    from cupy_backends.cuda.libs import cusolver
+
     if UPLO not in ('L', 'U'):
         raise ValueError('UPLO argument must be \'L\' or \'U\'')
 
@@ -130,6 +130,7 @@ def eigh(a, UPLO='L'):
 
     .. seealso:: :func:`numpy.linalg.eigh`
     """
+    import cupyx.cusolver
     _util._assert_stacked_2d(a)
     _util._assert_stacked_square(a)
 
@@ -176,6 +177,7 @@ def eigvalsh(a, UPLO='L'):
 
     .. seealso:: :func:`numpy.linalg.eigvalsh`
     """
+    import cupyx.cusolver
     _util._assert_stacked_2d(a)
     _util._assert_stacked_square(a)
 

--- a/cupy/linalg/_eigenvalue.py
+++ b/cupy/linalg/_eigenvalue.py
@@ -68,17 +68,17 @@ def _syevd(a, UPLO, with_eigen_vector, overwrite_a=False):
             cusolver.xsyevd, dev_info)
     else:
         if dtype == 'f':
-            buffer_size = cupy.cuda.cusolver.ssyevd_bufferSize
-            syevd = cupy.cuda.cusolver.ssyevd
+            buffer_size = cusolver.ssyevd_bufferSize
+            syevd = cusolver.ssyevd
         elif dtype == 'd':
-            buffer_size = cupy.cuda.cusolver.dsyevd_bufferSize
-            syevd = cupy.cuda.cusolver.dsyevd
+            buffer_size = cusolver.dsyevd_bufferSize
+            syevd = cusolver.dsyevd
         elif dtype == 'F':
-            buffer_size = cupy.cuda.cusolver.cheevd_bufferSize
-            syevd = cupy.cuda.cusolver.cheevd
+            buffer_size = cusolver.cheevd_bufferSize
+            syevd = cusolver.cheevd
         elif dtype == 'D':
-            buffer_size = cupy.cuda.cusolver.zheevd_bufferSize
-            syevd = cupy.cuda.cusolver.zheevd
+            buffer_size = cusolver.zheevd_bufferSize
+            syevd = cusolver.zheevd
         else:
             raise RuntimeError('Only float32, float64, complex64, and '
                                'complex128 are supported')

--- a/cupyx/lapack.py
+++ b/cupyx/lapack.py
@@ -2,9 +2,7 @@ import numpy as _numpy
 
 import cupy as _cupy
 from cupy_backends.cuda.libs import cublas as _cublas
-from cupy_backends.cuda.libs import cusolver as _cusolver
 from cupy.cuda import device as _device
-import cupyx.cusolver
 
 
 def gesv(a, b):
@@ -22,6 +20,8 @@ def gesv(a, b):
 
     Note: ``a`` and ``b`` will be overwritten.
     """
+    from cupy_backends.cuda.libs import cusolver as _cusolver
+
     if a.ndim != 2:
         raise ValueError('a.ndim must be 2 (actual: {})'.format(a.ndim))
     if b.ndim not in (1, 2):
@@ -91,6 +91,8 @@ def gels(a, b):
         cupy.ndarray:
             The matrix with dimension ``(N)`` or ``(N, K)``.
     """
+    from cupy_backends.cuda.libs import cusolver as _cusolver
+
     if a.ndim != 2:
         raise ValueError('a.ndim must be 2 (actual: {})'.format(a.ndim))
     if b.ndim == 1:
@@ -209,6 +211,8 @@ def gels(a, b):
 
 
 def _batched_posv(a, b):
+    from cupy_backends.cuda.libs import cusolver as _cusolver
+    import cupyx.cusolver
 
     if not cupyx.cusolver.check_availability('potrsBatched'):
         raise RuntimeError('potrsBatched is not available')
@@ -281,6 +285,7 @@ def posv(a, b):
     Returns:
         x (cupy.ndarray): The solution (shape matches b).
     """
+    from cupy_backends.cuda.libs import cusolver as _cusolver
 
     _util = _cupy.linalg._util
     _util._assert_cupy_array(a, b)

--- a/cupyx/linalg/sparse/_solve.py
+++ b/cupyx/linalg/sparse/_solve.py
@@ -1,7 +1,6 @@
 import numpy
 
 import cupy
-from cupy.cuda import cusolver
 from cupy.cuda import device
 from cupy.linalg import _util
 from cupyx.scipy import sparse
@@ -24,6 +23,7 @@ def lschol(A, b):
         ret (cupy.ndarray): The solution vector ``x``.
 
     """
+    from cupy.cuda import cusolver
 
     if not sparse.isspmatrix_csr(A):
         A = sparse.csr_matrix(A)

--- a/cupyx/linalg/sparse/_solve.py
+++ b/cupyx/linalg/sparse/_solve.py
@@ -23,7 +23,7 @@ def lschol(A, b):
         ret (cupy.ndarray): The solution vector ``x``.
 
     """
-    from cupy.cuda import cusolver
+    from cupy_backends.cuda.libs import cusolver
 
     if not sparse.isspmatrix_csr(A):
         A = sparse.csr_matrix(A)

--- a/cupyx/scipy/linalg/_decomp_lu.py
+++ b/cupyx/scipy/linalg/_decomp_lu.py
@@ -89,7 +89,7 @@ def lu(a, permute_l=False, overwrite_a=False, check_finite=True):
 
 
 def _lu_factor(a, overwrite_a=False, check_finite=True):
-    from cupy.cuda import cusolver
+    from cupy_backends.cuda.libs import cusolver
 
     a = cupy.asarray(a)
     _util._assert_2d(a)
@@ -287,7 +287,7 @@ def lu_solve(lu_and_piv, b, trans=0, overwrite_b=False, check_finite=True):
 
     .. seealso:: :func:`scipy.linalg.lu_solve`
     """  # NOQA
-    from cupy.cuda import cusolver
+    from cupy_backends.cuda.libs import cusolver
 
     (lu, ipiv) = lu_and_piv
 

--- a/cupyx/scipy/linalg/_decomp_lu.py
+++ b/cupyx/scipy/linalg/_decomp_lu.py
@@ -4,7 +4,6 @@ import numpy
 
 import cupy
 from cupy.cuda import cublas
-from cupy.cuda import cusolver
 from cupy.cuda import device
 from cupy.cuda import runtime
 from cupy.linalg import _util
@@ -90,6 +89,8 @@ def lu(a, permute_l=False, overwrite_a=False, check_finite=True):
 
 
 def _lu_factor(a, overwrite_a=False, check_finite=True):
+    from cupy.cuda import cusolver
+
     a = cupy.asarray(a)
     _util._assert_2d(a)
 
@@ -286,6 +287,7 @@ def lu_solve(lu_and_piv, b, trans=0, overwrite_b=False, check_finite=True):
 
     .. seealso:: :func:`scipy.linalg.lu_solve`
     """  # NOQA
+    from cupy.cuda import cusolver
 
     (lu, ipiv) = lu_and_piv
 

--- a/cupyx/scipy/sparse/linalg/_solve.py
+++ b/cupyx/scipy/sparse/linalg/_solve.py
@@ -1,10 +1,8 @@
 import numpy
 
 import cupy
-import cupyx.cusolver
 from cupy import cublas
 from cupyx import cusparse
-from cupy.cuda import cusolver
 from cupy.cuda import device
 from cupy.cuda import runtime
 from cupy.linalg import _util
@@ -45,6 +43,8 @@ def lsqr(A, b):
 
     .. seealso:: :func:`scipy.sparse.linalg.lsqr`
     """
+    from cupy.cuda import cusolver
+
     if runtime.is_hip:
         raise RuntimeError('HIP does not support lsqr')
     if not sparse.isspmatrix_csr(A):
@@ -489,6 +489,8 @@ def spsolve(A, b):
         cupy.ndarray:
             Solution to the system ``A x = b``.
     """
+    import cupyx.cusolver
+
     if not cupyx.cusolver.check_availability('csrlsvqr'):
         raise NotImplementedError
     if not sparse.isspmatrix(A):

--- a/cupyx/scipy/sparse/linalg/_solve.py
+++ b/cupyx/scipy/sparse/linalg/_solve.py
@@ -43,7 +43,7 @@ def lsqr(A, b):
 
     .. seealso:: :func:`scipy.sparse.linalg.lsqr`
     """
-    from cupy.cuda import cusolver
+    from cupy_backends.cuda.libs import cusolver
 
     if runtime.is_hip:
         raise RuntimeError('HIP does not support lsqr')


### PR DESCRIPTION
This is a part of #7620.

I tried to softlink cuSOLVER as I did in NVRTC but found there is a native function calls to cuSOLVER in [`cupy_lapack.h`](https://github.com/kmaehashi/cupy/blob/401c3243a5d3bf88eaa1fe79572050609e788020/cupy_backends/cupy_lapack.h) where softlink doesn't work.
For cuSOLVER I'm thinking of using lazy-import instead of softlink.

Depends on ~#7840~ (merged).
