### PR TITLE
Add dtype argument to cupy.load

### DIFF
--- a/cupy/_io/npz.py
+++ b/cupy/_io/npz.py
@@ -28,7 +28,7 @@ class NpzFile(object):
         self.npz_file.close()
 
 
-def load(file, mmap_mode=None, allow_pickle=None):
+def load(file, mmap_mode=None, allow_pickle=None, dtype=None):
     """Loads arrays or pickled objects from ``.npy``, ``.npz`` or pickled file.
 
     This function just calls ``numpy.load`` and then sends the arrays to the
@@ -50,6 +50,7 @@ def load(file, mmap_mode=None, allow_pickle=None):
             This option is available only for NumPy 1.10 or later.
             In NumPy 1.9, this option cannot be specified (loading pickled
             objects is always allowed).
+        dtype: Data type specifier.
 
     Returns:
         CuPy array or NpzFile object depending on the type of the file. NpzFile
@@ -68,7 +69,7 @@ def load(file, mmap_mode=None, allow_pickle=None):
         obj = numpy.load(file, mmap_mode)
 
     if isinstance(obj, numpy.ndarray):
-        return cupy.array(obj)
+        return cupy.array(obj, dtype=dtype)
     elif isinstance(obj, numpy.lib.npyio.NpzFile):
         return NpzFile(obj)
     else:

--- a/tests/cupy_tests/io_tests/test_npz.py
+++ b/tests/cupy_tests/io_tests/test_npz.py
@@ -4,6 +4,7 @@ import unittest
 
 import cupy
 from cupy import testing
+import numpy
 
 
 class TestNpz(unittest.TestCase):
@@ -21,6 +22,21 @@ class TestNpz(unittest.TestCase):
         sio.close()
 
         testing.assert_array_equal(a, b)
+
+    @testing.for_all_dtypes()
+    def test_load_dtype(self, dtype):
+        a = testing.shaped_arange((2, 3, 4))
+        b = numpy.array(a.get(), dtype=dtype)
+        sio = io.BytesIO()
+        cupy.save(sio, a)
+        s = sio.getvalue()
+        sio.close()
+
+        sio = io.BytesIO(s)
+        c = cupy.load(sio, dtype=dtype)
+        sio.close()
+
+        testing.assert_array_equal(b, c)
 
     def test_save_pickle(self):
         data = object()


### PR DESCRIPTION
Adds the ability to specify dtype as an argument to cupy.load. Resolves issue #7841 