### PR TITLE
Static link to CUDA Runtime in CUB module

### DIFF
--- a/install/cupy_builder/_command.py
+++ b/install/cupy_builder/_command.py
@@ -202,7 +202,7 @@ class custom_build_ext(setuptools.command.build_ext.build_ext):
         # Remove device code from list of sources, and instead add compiled
         # object files to link.
         ext.sources = sources_cpp
-        ext.extra_objects += extra_objects
+        ext.extra_objects = extra_objects + ext.extra_objects
 
         # Let setuptools do the rest of the build process, i.e., compile
         # "*.cpp" files and link object files generated from "*.cu".

--- a/install/cupy_builder/_features.py
+++ b/install/cupy_builder/_features.py
@@ -1,3 +1,4 @@
+import sys
 from typing import Any, Dict, List
 
 import cupy_builder.install_build as build
@@ -25,6 +26,9 @@ class Feature:
 
         # Shared libraries to be linked.
         self.libraries: List[str] = []
+
+        # Static libraries to be linked.
+        self.static_libraries: List[str] = []
 
         # Version of the feature.
         self._version: Any = self._UNDETERMINED
@@ -64,6 +68,7 @@ def _from_dict(d: Dict[str, Any], ctx: Context) -> Feature:
     f.name = d['name']
     f.required = d.get('required', False)
     f.libraries = d['libraries']
+    f.static_libraries = d.get('static_libraries', [])
 
     # Note: the followings are renamed
     f.modules = d['file']
@@ -262,8 +267,12 @@ def get_features(ctx: Context) -> Dict[str, Feature]:
             'cub/util_namespace.cuh',  # dummy
         ],
         'libraries': [
+            # Dependencies for cudart_static
+            'pthread', 'rt', 'dl',
+        ] if sys.platform == 'linux' else [],
+        'static_libraries': [
             # Dependency from CUB header files
-            'cudart',
+            'cudart_static',
         ],
         'check_method': build.check_cub_version,
         'version_method': build.get_cub_version,
@@ -440,6 +449,7 @@ class CUDA_cuda(Feature):
     minimum_cuda_version = 10020
 
     def __init__(self, ctx: Context):
+        super().__init__(ctx)
         self.name = 'cuda'
         self.required = True
         self.modules = _cuda_files

--- a/install/cupy_builder/cupy_setup_build.py
+++ b/install/cupy_builder/cupy_setup_build.py
@@ -260,7 +260,7 @@ def _find_static_library(name: str) -> str:
         libdir = 'lib64'
     elif PLATFORM_WIN32:
         filename = f'{name}.lib'
-        libdir = 'lib'
+        libdir = 'lib\\x64'
     else:
         raise Exception('not supported on this platform')
 

--- a/install/cupy_builder/cupy_setup_build.py
+++ b/install/cupy_builder/cupy_setup_build.py
@@ -254,6 +254,25 @@ def _rpath_base():
         raise Exception('not supported on this platform')
 
 
+def _find_static_library(name: str) -> str:
+    if PLATFORM_LINUX:
+        filename = f'lib{name}.a'
+        libdir = 'lib64'
+    elif PLATFORM_WIN32:
+        filename = f'{name}.lib'
+        libdir = 'lib'
+    else:
+        raise Exception('not supported on this platform')
+
+    cuda_path = build.get_cuda_path()
+    if cuda_path is None:
+        raise Exception(f'Could not find {filename}: CUDA path unavailable')
+    path = os.path.join(cuda_path, libdir, filename)
+    if not os.path.exists(path):
+        raise Exception(f'Could not find {filename}: {path} does not exist')
+    return path
+
+
 def make_extensions(ctx: Context, compiler, use_cython):
     """Produce a list of Extension instances which passed to cythonize()."""
 
@@ -312,7 +331,10 @@ def make_extensions(ctx: Context, compiler, use_cython):
 
         s = copy.deepcopy(settings)
         if not no_cuda:
-            s['libraries'] = module['libraries']
+            s['libraries'] = module.libraries
+            s['extra_objects'] = [
+                _find_static_library(name) for name in module.static_libraries
+            ]
 
         compile_args = s.setdefault('extra_compile_args', [])
         link_args = s.setdefault('extra_link_args', [])


### PR DESCRIPTION
This is a part of #7620.

As discussed in https://github.com/cupy/cupy/pull/7843#issuecomment-1705200327 and #7727, statically link libcudart to CUB to avoid dependency to CTK.
