### PR TITLE
Avoid triggering Project Updates for updates from assignees

### DIFF
--- a/.github/workflows/pr-updated.yml
+++ b/.github/workflows/pr-updated.yml
@@ -16,12 +16,12 @@ jobs:
             github.event_name == 'issue_comment' &&
             github.event.issue.state == 'open' &&
             github.event.issue.pull_request &&
-            !contains(github.event.issue.assignees, github.actor)
+            !contains(github.event.issue.assignees.*.login, github.actor)
         ) ||
         (
             github.event_name != 'issue_comment' &&
             github.event.pull_request.state == 'open' &&
-            !contains(github.event.pull_request.assignees, github.actor)
+            !contains(github.event.pull_request.assignees.*.login, github.actor)
         )
       )
     runs-on: ubuntu-22.04


### PR DESCRIPTION
`github.event.issue.assignees` is an object, whereas `github.actor` is a string (GitHub login ID). `contains` check had to be done in all login IDs in the object.