### PR TITLE
Clarify sparse .transpose() return type in docstrings

### DIFF
--- a/cupyx/scipy/sparse/_csc.py
+++ b/cupyx/scipy/sparse/_csc.py
@@ -341,7 +341,7 @@ class csc_matrix(_compressed._compressed_sparse_matrix):
                 Otherwise, it shared data arrays as much as possible.
 
         Returns:
-            cupyx.scipy.sparse.csr_matrix: Transpose matrix in CSR format.
+            cupyx.scipy.sparse.csr_matrix: p : `self` with the dimensions reversed.
 
         """
         if axes is not None:

--- a/cupyx/scipy/sparse/_csc.py
+++ b/cupyx/scipy/sparse/_csc.py
@@ -341,7 +341,7 @@ class csc_matrix(_compressed._compressed_sparse_matrix):
                 Otherwise, it shared data arrays as much as possible.
 
         Returns:
-            cupyx.scipy.sparse.csr_matrix: p : `self` with the dimensions reversed.
+            cupyx.scipy.sparse.csr_matrix: `self` with the dimensions reversed.
 
         """
         if axes is not None:

--- a/cupyx/scipy/sparse/_csc.py
+++ b/cupyx/scipy/sparse/_csc.py
@@ -341,7 +341,7 @@ class csc_matrix(_compressed._compressed_sparse_matrix):
                 Otherwise, it shared data arrays as much as possible.
 
         Returns:
-            cupyx.scipy.sparse.spmatrix: Transpose matrix.
+            cupyx.scipy.sparse.csr_matrix: Transpose matrix in CSR format.
 
         """
         if axes is not None:

--- a/cupyx/scipy/sparse/_csr.py
+++ b/cupyx/scipy/sparse/_csr.py
@@ -521,7 +521,7 @@ class csr_matrix(_compressed._compressed_sparse_matrix):
                 Otherwise, it shared data arrays as much as possible.
 
         Returns:
-            cupyx.scipy.sparse.spmatrix: Transpose matrix.
+            cupyx.scipy.sparse.csc_matrix: Transpose matrix in CSC format.
 
         """
         if axes is not None:

--- a/cupyx/scipy/sparse/_csr.py
+++ b/cupyx/scipy/sparse/_csr.py
@@ -521,7 +521,7 @@ class csr_matrix(_compressed._compressed_sparse_matrix):
                 Otherwise, it shared data arrays as much as possible.
 
         Returns:
-            cupyx.scipy.sparse.csc_matrix: Transpose matrix in CSC format.
+            cupyx.scipy.sparse.csc_matrix: p : `self` with the dimensions reversed.
 
         """
         if axes is not None:

--- a/cupyx/scipy/sparse/_csr.py
+++ b/cupyx/scipy/sparse/_csr.py
@@ -521,7 +521,7 @@ class csr_matrix(_compressed._compressed_sparse_matrix):
                 Otherwise, it shared data arrays as much as possible.
 
         Returns:
-            cupyx.scipy.sparse.csc_matrix: p : `self` with the dimensions reversed.
+            cupyx.scipy.sparse.csc_matrix: `self` with the dimensions reversed.
 
         """
         if axes is not None:


### PR DESCRIPTION
Documentation for `cupyx.scipy.sparse.csc_matrix` and `cupyx.scipy.sparse.csr_matrix` currently does not specify that `.transpose(...)` changes the sparse representation.