### PR TITLE
Add optional argument `device_id=-1` to `get_current_stream`

### DIFF
--- a/cupy/cuda/stream.pxd
+++ b/cupy/cuda/stream.pxd
@@ -2,4 +2,4 @@ from libc.stdint cimport intptr_t
 
 
 cdef intptr_t get_current_stream_ptr()
-cpdef get_current_stream()
+cpdef get_current_stream(int device_id=*)

--- a/cupy/cuda/stream.pyx
+++ b/cupy/cuda/stream.pyx
@@ -84,14 +84,14 @@ cdef intptr_t get_current_stream_ptr():
     return <intptr_t>tls.get_current_stream_ptr()
 
 
-cpdef get_current_stream():
+cpdef get_current_stream(int device_id=-1):
     """Gets current CUDA stream.
 
     Returns:
         cupy.cuda.Stream: The current CUDA stream.
     """
     tls = _ThreadLocal.get()
-    return tls.get_current_stream()
+    return tls.get_current_stream(device_id)
 
 
 class Event(object):

--- a/cupy/cuda/stream.pyx
+++ b/cupy/cuda/stream.pyx
@@ -85,8 +85,11 @@ cdef intptr_t get_current_stream_ptr():
 
 
 cpdef get_current_stream(int device_id=-1):
-    """Gets current CUDA stream.
+    """Gets the current CUDA stream for the specified CUDA device.
 
+    Args:
+        device_id (int, optional): Index of the device to check for the current
+            stream. The currently active device is selected by default.
     Returns:
         cupy.cuda.Stream: The current CUDA stream.
     """

--- a/tests/cupy_tests/cuda_tests/test_stream.py
+++ b/tests/cupy_tests/cuda_tests/test_stream.py
@@ -162,6 +162,7 @@ class TestStream(unittest.TestCase):
                 with cuda.Device(1):
                     assert stream0 != cuda.get_current_stream()
                     assert cuda.Stream.null == cuda.get_current_stream()
+                    assert stream0 == cuda.get_current_stream(0)
                 assert stream0 == cuda.get_current_stream()
 
     @testing.multi_gpu(2)


### PR DESCRIPTION
`cupy.cuda.stream._ThreadLocal.get_current_stream` has an optional parameter `device_id`. However its wrapper `cupy.cuda.stream.get_current_stream` currently does not have that parameter, and it can only check the active device.

This change gives the optional parameter `device_id` to `cupy.cuda.stream.get_current_stream` too. It is then directly passed to `_ThreadLocal.get_current_stream`.

This is going to be used in #7881, which involves changing streams on multiple devices.