### PR TITLE
Remove conversions of array with ndim > 0 to a scalar

### DIFF
--- a/cupyx/scipy/interpolate/_interpolate.py
+++ b/cupyx/scipy/interpolate/_interpolate.py
@@ -809,9 +809,9 @@ def _ndim_coords_from_arrays(points, ndim=None):
 
     if isinstance(points, tuple) and len(points) == 1:
         # handle argument tuple
-        points = points[0]
+        points = cupy.asarray(points[0])
     if isinstance(points, tuple):
-        p = cupy.broadcast_arrays(*points)
+        p = cupy.broadcast_arrays(*[cupy.asarray(x) for x in points])
         p = [cupy.expand_dims(x, -1) for x in p]
         points = cupy.concatenate(p, axis=-1)
     else:

--- a/cupyx/scipy/signal/_splines.py
+++ b/cupyx/scipy/signal/_splines.py
@@ -248,6 +248,9 @@ def symiirorder1(input, c0, z1, precision=-1.0):
     output : ndarray
         The filtered signal.
     """
+    c0 = cupy.asarray([c0], input.dtype)
+    z1 = cupy.asarray([z1], input.dtype)
+
     if cupy.abs(z1) >= 1:
         raise ValueError('|z1| must be less than 1.0')
 

--- a/tests/cupy_tests/core_tests/test_ndarray_complex_ops.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_complex_ops.py
@@ -159,7 +159,7 @@ class TestScalarConversion(unittest.TestCase):
     @testing.for_all_dtypes()
     def test_scalar_conversion(self, dtype):
         scalar = 1 + 1j if numpy.dtype(dtype).kind == 'c' else 1
-        x_1d = cupy.array([scalar]).astype(dtype)
+        x_1d = cupy.array(scalar).astype(dtype)
         assert complex(x_1d) == scalar
 
         x_0d = x_1d.reshape(())

--- a/tests/cupy_tests/core_tests/test_ndarray_indexing.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_indexing.py
@@ -228,5 +228,5 @@ class TestSetItemCompatBroadcast:
     def test_remain0d(self, xp):
         dtype = int
         a = xp.zeros((2, 3, 4), dtype)
-        a[0, 1, 2] = testing.shaped_arange((1, 1, 1), xp, dtype)
+        a[0, 1, 2] = testing.shaped_arange((), xp, dtype)
         return a

--- a/tests/cupy_tests/io_tests/test_formatting.py
+++ b/tests/cupy_tests/io_tests/test_formatting.py
@@ -29,13 +29,13 @@ class TestFormatting(unittest.TestCase):
             x) == numpy.format_float_positional(x)
 
     def test_format_float_positional(self):
-        a = testing.shaped_arange((1,), cupy)
-        b = testing.shaped_arange((1,), numpy)
+        a = testing.shaped_arange((), cupy)
+        b = testing.shaped_arange((), numpy)
         assert cupy.format_float_positional(
             a) == numpy.format_float_positional(b)
 
     def test_format_float_scientific(self):
-        a = testing.shaped_arange((1,), cupy)
-        b = testing.shaped_arange((1,), numpy)
+        a = testing.shaped_arange((), cupy)
+        b = testing.shaped_arange((), numpy)
         assert cupy.format_float_scientific(
             a) == numpy.format_float_scientific(b)

--- a/tests/cupyx_tests/fallback_mode_tests/test_fallback.py
+++ b/tests/cupyx_tests/fallback_mode_tests/test_fallback.py
@@ -401,10 +401,10 @@ class TestArrayComparison(unittest.TestCase):
 @testing.parameterize(
     {'func': '__str__', 'shape': (5, 6)},
     {'func': '__repr__', 'shape': (3, 4)},
-    {'func': '__int__', 'shape': (1,)},
-    {'func': '__float__', 'shape': (1, 1)},
+    {'func': '__int__', 'shape': ()},
+    {'func': '__float__', 'shape': ()},
     {'func': '__len__', 'shape': (3, 3)},
-    {'func': '__bool__', 'shape': (1,)},
+    {'func': '__bool__', 'shape': ()},
 )
 class TestArrayUnaryMethods(unittest.TestCase):
 

--- a/tests/cupyx_tests/scipy_tests/interpolate_tests/test_ppoly.py
+++ b/tests/cupyx_tests/scipy_tests/interpolate_tests/test_ppoly.py
@@ -1483,7 +1483,7 @@ class TestNdPPoly:
 
         u = testing.shaped_random((200,), xp)
         v = testing.shaped_random((200,), xp)
-        a, b = xp.asarray([0.2]), xp.asarray([0.7])
+        a, b = 0.2, 0.7
 
         result = []
 

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_splines.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_splines.py
@@ -32,8 +32,7 @@ class TestSymIIROrder:
             pytest.skip()
 
         x = testing.shaped_random((size,), xp, dtype=dtype)
-        c0 = xp.asarray([2.0], dtype=dtype)
-        z1 = xp.asarray([0.5], dtype=dtype)
+        c0, z1 = 2.0, 0.5
         return scp.signal.symiirorder1(x, c0, z1, precision)
 
     @pytest.mark.parametrize('size', [11, 20, 32, 51, 64, 120])


### PR DESCRIPTION
Part of https://github.com/cupy/cupy/issues/7616.