### PR TITLE
Prohibit conversion from Variable to Python scalar in fusion

### DIFF
--- a/cupy/_core/_fusion_interface.py
+++ b/cupy/_core/_fusion_interface.py
@@ -188,6 +188,18 @@ class _VariableProxy:
     def shape(self):
         raise NotImplementedError('`shape` is not supported, currently.')
 
+    def __bool__(self):
+        raise TypeError('Cannot convert to Python scalar in cupy.fuse')
+
+    def __int__(self):
+        raise TypeError('Cannot convert to Python scalar in cupy.fuse')
+
+    def __float__(self):
+        raise TypeError('Cannot convert to Python scalar in cupy.fuse')
+
+    def __complex__(self):
+        raise TypeError('Cannot convert to Python scalar in cupy.fuse')
+
 
 class _ScalarProxy(_VariableProxy):
     """An abstracted scalar object passed to the target function.

--- a/tests/cupy_tests/core_tests/fusion_tests/test_misc.py
+++ b/tests/cupy_tests/core_tests/fusion_tests/test_misc.py
@@ -2,6 +2,8 @@ import threading
 import unittest
 from unittest import mock
 
+import pytest
+
 import cupy
 from cupy import testing
 from cupy_tests.core_tests.fusion_tests import fusion_utils
@@ -420,3 +422,17 @@ class TestFusionMultiDevice(unittest.TestCase):
             out2 = f(x2, y2)
 
         return out1, out2
+
+
+class TestFusionInvalid():
+
+    def test_branch(self):
+        @cupy.fuse()
+        def f(x):
+            if x > 0:
+                return x
+            return -x
+
+        x = testing.shaped_random((3, 3), cupy, cupy.int64, seed=0)
+        with pytest.raises(TypeError, match="Python scalar"):
+            f(x)


### PR DESCRIPTION
Reported at https://github.com/cupy/cupy/issues/7878.

This PR fixes to raise TypeError when trying to cast `_VariableProxy` to Python scalar.