### PR TITLE
Optimize spmatrix._set_many

### DIFF
--- a/cupyx/scipy/sparse/_compressed.py
+++ b/cupyx/scipy/sparse/_compressed.py
@@ -543,7 +543,7 @@ class _compressed_sparse_matrix(sparse_data._data_matrix,
         if mask.all():
             # only affects existing non-zero cells
             return
-        
+
         # only insertions remain
         warnings.warn('Changing the sparsity structure of a '
                       '{}_matrix is expensive.'.format(self.format),

--- a/cupyx/scipy/sparse/_compressed.py
+++ b/cupyx/scipy/sparse/_compressed.py
@@ -537,25 +537,23 @@ class _compressed_sparse_matrix(sparse_data._data_matrix,
         offsets = new_sp._get_arrayXarray(
             i, j, not_found_val=-1).astype(cupy.int32).ravel()
 
-        if -1 not in offsets:
-            # only affects existing non-zero cells
-            self.data[offsets] = x
-            return
+        mask = offsets > -1
+        self.data[offsets[mask]] = x[mask]
 
-        else:
-            warnings.warn('Changing the sparsity structure of a '
-                          '{}_matrix is expensive.'.format(self.format),
-                          _base.SparseEfficiencyWarning)
-            # replace where possible
-            mask = offsets > -1
-            self.data[offsets[mask]] = x[mask]
-            # only insertions remain
-            mask = ~mask
-            i = i[mask]
-            i[i < 0] += M
-            j = j[mask]
-            j[j < 0] += N
-            self._insert_many(i, j, x[mask])
+        if mask.all():
+            # only affects existing non-zero cells
+            return
+        
+        # only insertions remain
+        warnings.warn('Changing the sparsity structure of a '
+                      '{}_matrix is expensive.'.format(self.format),
+                      _base.SparseEfficiencyWarning)
+        mask = ~mask
+        i = i[mask]
+        i[i < 0] += M
+        j = j[mask]
+        j[j < 0] += N
+        self._insert_many(i, j, x[mask])
 
     def _zero_many(self, i, j):
         """Sets value at each (i, j) to zero, preserving sparsity structure.


### PR DESCRIPTION
This PR implements the change proposed in https://github.com/cupy/cupy/issues/7876.

## Performance tests

Run with CuPy 11.0.0 on Google Colab because I don't have a local GPU.


### Update only, no insert

```python
def test_update_only(size, nnz):

  import numpy as np
  import cupy
  import cupyx

  rows = cupy.random.randint(0, size, nnz)
  cols = cupy.random.randint(0, size, nnz)
  old_vals = cupy.random.random(nnz)
  new_vals = cupy.random.random(nnz)
  
  mat_cupy_old = cupyx.scipy.sparse.csr_matrix((old_vals, (rows, cols)))
  mat_cupy_new = cupyx.scipy.sparse.csr_matrix((old_vals, (rows, cols)))

  def run_old():
    vals = cupy.roll(new_vals, -1)
    mat_cupy_old._set_many(rows, cols, vals)
    return mat_cupy_old.get()

  def run_new():
    vals = cupy.roll(new_vals, -1)
    _set_many(mat_cupy_new, rows, cols, vals)
    return mat_cupy_new.get()

  print(f"{size = }, {nnz = }")

  print("Old _set_many:")
  %timeit mat_scipy_old = run_old()

  print("New _set_many:")
  %timeit mat_scipy_new = run_new()

  mat_scipy_old = run_old()
  mat_scipy_new = run_new()

  assert np.array_equal(mat_scipy_old.indices, mat_scipy_new.indices)
  assert np.array_equal(mat_scipy_old.indptr, mat_scipy_new.indptr)
  assert np.allclose(mat_scipy_old.data, mat_scipy_new.data)
  return mat_scipy_old, mat_scipy_new
```

Results:

```
size = 1000, nnz = 100
Old _set_many:
8.06 ms ± 707 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
New _set_many:
1.84 ms ± 143 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

size = 10000, nnz = 1000
Old _set_many:
74.9 ms ± 13.5 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
New _set_many:
2.05 ms ± 206 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

size = 100000, nnz = 1000
Old _set_many:
73.4 ms ± 11 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
New _set_many:
2.1 ms ± 45.1 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

size = 100000, nnz = 10000
Old _set_many:
647 ms ± 20 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
New _set_many:
2.17 ms ± 40.8 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

### Insert only, no update

I expect very little performance difference here because this line https://github.com/cupy/cupy/blob/5c32e40af32f6f9627e09d47ecfeb7e9281ccab2/cupyx/scipy/sparse/_compressed.py#L540 will always immediately find a -1 in the offsets when performing all inserts.

```python
def test_insert_only(size, nnz):

  import numpy as np
  import cupy
  import cupyx

  rows = cupy.random.randint(0, size, nnz)
  cols = cupy.random.randint(0, size, nnz)
  old_vals = cupy.random.random(nnz)
  new_vals = cupy.random.random(nnz)

  mat_cupy_old = cupyx.scipy.sparse.csr_matrix((old_vals, (rows, cols)))
  mat_cupy_new = cupyx.scipy.sparse.csr_matrix((old_vals, (rows, cols)))

  def run_old():
    mat = cupyx.scipy.sparse.csr_matrix((size, size), dtype=old_vals.dtype)
    mat._set_many(rows, cols, new_vals)
    return mat.get()

  def run_new():
    mat = cupyx.scipy.sparse.csr_matrix((size, size), dtype=old_vals.dtype)
    _set_many(mat, rows, cols, new_vals)
    return mat.get()

  print(f"{size = }, {nnz = }")

  print("Old _set_many:")
  %timeit mat_scipy_old = run_old()

  print("New _set_many:")
  %timeit mat_scipy_new = run_new()

  mat_scipy_old = run_old()
  mat_scipy_new = run_new()

  assert np.array_equal(mat_scipy_old.indices, mat_scipy_new.indices)
  assert np.array_equal(mat_scipy_old.indptr, mat_scipy_new.indptr)
  assert np.allclose(mat_scipy_old.data, mat_scipy_new.data)
  return mat_scipy_old, mat_scipy_new
```

Results. Old and new are the same within the noise/reproducibility of the test.

```
size = 1000, nnz = 100
Old _set_many:
5.47 ms ± 696 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
New _set_many:
4.36 ms ± 76.7 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

output
size = 10000, nnz = 1000
Old _set_many:
5.08 ms ± 191 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
New _set_many:
5.87 ms ± 875 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)


size = 100000, nnz = 1000
Old _set_many:
5.71 ms ± 735 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
New _set_many:
5.07 ms ± 107 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

output
size = 10000, nnz = 10000
Old _set_many:
5.48 ms ± 125 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
New _set_many:
5.43 ms ± 98 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```