### PR TITLE
`scipy.linalg.{tri/tril/triu}` are deprecated in SciPy 1.11.0

### DIFF
--- a/cupyx/scipy/linalg/_special_matrices.py
+++ b/cupyx/scipy/linalg/_special_matrices.py
@@ -1,4 +1,6 @@
 import math
+import warnings
+
 import cupy
 from cupy import _core
 from cupyx.scipy.linalg import _uarray
@@ -23,6 +25,8 @@ def tri(N, M=None, k=0, dtype=None):
 
     .. seealso:: :func:`scipy.linalg.tri`
     """
+    warnings.warn("'tri'/'tril/'triu' are deprecated", DeprecationWarning)
+
     if M is None:
         M = N
     elif isinstance(M, str):
@@ -50,6 +54,8 @@ def tril(m, k=0):
 
     .. seealso:: :func:`scipy.linalg.tril`
     """
+    warnings.warn("'tri'/'tril/'triu' are deprecated", DeprecationWarning)
+
     # this is ~2x faster than cupy.tril for a 500x500 float64 matrix
     t = tri(m.shape[0], m.shape[1], k=k, dtype=m.dtype.char)
     t *= m
@@ -73,6 +79,8 @@ def triu(m, k=0):
 
     .. seealso:: :func:`scipy.linalg.triu`
     """
+    warnings.warn("'tri'/'tril/'triu' are deprecated", DeprecationWarning)
+
     # this is ~25% faster than cupy.tril for a 500x500 float64 matrix
     t = tri(m.shape[0], m.shape[1], k - 1, m.dtype.char)
     cupy.subtract(1, t, out=t)

--- a/tests/cupyx_tests/scipy_tests/linalg_tests/test_special_matrices.py
+++ b/tests/cupyx_tests/scipy_tests/linalg_tests/test_special_matrices.py
@@ -32,12 +32,11 @@ class TestSpecialMatricesBase(unittest.TestCase):
                  ((10,), (9,)), ((25,), (24,))],
     }) + testing.product({
         # 1 argument: int
-        'function': ['tri', 'hadamard', 'helmert', 'hilbert', 'dft'],
+        'function': ['hadamard', 'helmert', 'hilbert', 'dft'],
         'args': [(1,), (2,), (4,), (10,), (25,)],
     }) + testing.product({
         # 2 arguments: int, dtype
-        # NOTE: for tri this is an undocumented, legacy, call
-        'function': ['tri', 'hadamard'],
+        'function': ['hadamard'],
         'args': [(4, 'int32'), (8, 'float64'), (6, 'float64')],
     }) + testing.product({
         # 2 arguments: int, bool
@@ -47,17 +46,6 @@ class TestSpecialMatricesBase(unittest.TestCase):
         # 2 arguments: int, str
         'function': ['dft'],
         'args': [(4, 'sqrtn'), (5, 'n')],
-    }) + testing.product({
-        # 2-4 arguments: int, int, optional int, optional dtype
-        'function': ['tri'],
-        'args': [(4, 5), (5, 5), (5, 4),
-                 (4, 5, -1), (4, 5, 1), (4, 5, 0), (5, 4, -1), (5, 5, 1),
-                 (4, 5, -1, int), (5, 4, 0, float)],
-    }) + testing.product({
-        # 1-2 arguments: 2D array, optional int
-        'function': ['tril', 'triu'],
-        'args': [((5, 5),), ((4, 5),), ((5, 4),), ((4, 4),),
-                 ((5, 5), -1), ((4, 5), 1), ((5, 4), -1), ((4, 4), 1)],
     }) + testing.product({
         # 2 arguments: both 2D arrays
         'function': ['kron'],


### PR DESCRIPTION
Part of https://github.com/cupy/cupy/issues/7664.

https://scipy.github.io/devdocs/release/1.11.0-notes.html#deprecated-features