### PR TITLE
Fix `signal.medfilt` complex error type for SciPy>=1.11

### DIFF
--- a/cupyx/scipy/signal/_signaltools.py
+++ b/cupyx/scipy/signal/_signaltools.py
@@ -575,9 +575,6 @@ def medfilt(volume, kernel_size=None):
     .. seealso:: :func:`cupyx.scipy.ndimage.median_filter`
     .. seealso:: :func:`scipy.signal.medfilt`
     """
-    if volume.dtype.kind == 'c':
-        # scipy doesn't support complex
-        raise ValueError("complex types not supported")
     if volume.dtype.char == 'e':
         # scipy doesn't support float16
         raise ValueError("float16 type not supported")
@@ -585,6 +582,11 @@ def medfilt(volume, kernel_size=None):
         # scipy doesn't support bool
         raise ValueError("bool type not supported")
     kernel_size = _get_kernel_size(kernel_size, volume.ndim)
+    if volume.dtype == 'F':
+        raise TypeError("complex types not supported")
+    if volume.dtype.kind == 'c':
+        # scipy doesn't support complex
+        raise ValueError("complex types not supported")
     if any(k > s for k, s in zip(kernel_size, volume.shape)):
         warnings.warn('kernel_size exceeds volume extent: '
                       'volume will be zero-padded')
@@ -618,9 +620,6 @@ def medfilt2d(input, kernel_size=3):
     .. seealso:: :func:`cupyx.scipy.signal.medfilt`
     .. seealso:: :func:`scipy.signal.medfilt2d`
     """
-    if input.dtype.kind == 'c':
-        # scipy doesn't support complex
-        raise ValueError("complex types not supported")
     if input.dtype.char == 'e':
         # scipy doesn't support float16
         raise ValueError("float16 type not supported")
@@ -630,6 +629,11 @@ def medfilt2d(input, kernel_size=3):
     if input.ndim != 2:
         raise ValueError('input must be 2d')
     kernel_size = _get_kernel_size(kernel_size, input.ndim)
+    if input.dtype == 'F':
+        raise TypeError("complex types not supported")
+    if input.dtype.kind == 'c':
+        # scipy doesn't support complex
+        raise ValueError("complex types not supported")
     order = kernel_size[0] * kernel_size[1] // 2
     return _filters.rank_filter(
         input, order, size=kernel_size, mode='constant')

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
@@ -355,11 +355,25 @@ class TestOrderFilter:
     'volume': [(10,), (5, 10), (10, 5), (5, 6, 10)],
     'kernel_size': [3, 4, (3, 3, 5)],
 }))
-@testing.with_requires('scipy>=1.7.0')
 class TestMedFilt:
-    @testing.for_all_dtypes()
+    @testing.with_requires('scipy>=1.7.0', 'scipy<1.11.0')
+    @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose(atol=1e-8, rtol=1e-8, scipy_name='scp',
                                  accept_error=ValueError)  # for even kernels
+    def test_medfilt_no_complex(self, xp, scp, dtype):
+        if sys.platform == 'win32':
+            pytest.xfail('medfilt broken for Scipy 1.7.0 in windows')
+        volume = testing.shaped_random(self.volume, xp, dtype)
+        kernel_size = self.kernel_size
+        if isinstance(kernel_size, tuple):
+            kernel_size = kernel_size[:volume.ndim]
+        return scp.signal.medfilt(volume, kernel_size)
+
+    @testing.with_requires('scipy>=1.11.0')
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose(
+        atol=1e-8, rtol=1e-8, scipy_name='scp',
+        accept_error=(ValueError, TypeError))  # for even kernels
     def test_medfilt(self, xp, scp, dtype):
         if sys.platform == 'win32':
             pytest.xfail('medfilt broken for Scipy 1.7.0 in windows')
@@ -374,11 +388,23 @@ class TestMedFilt:
     'input': [(5, 10), (10, 5)],
     'kernel_size': [3, 4, (3, 5)],
 }))
-@testing.with_requires('scipy>=1.7.0')
 class TestMedFilt2d:
-    @testing.for_all_dtypes()
+    @testing.with_requires('scipy>=1.7.0', 'scipy<1.11.0')
+    @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose(atol=1e-8, rtol=1e-8, scipy_name='scp',
                                  accept_error=ValueError)  # for even kernels
+    def test_medfilt2d_no_complex(self, xp, scp, dtype):
+        if sys.platform == 'win32':
+            pytest.xfail('medfilt2d broken for Scipy 1.7.0 in windows')
+        input = testing.shaped_random(self.input, xp, dtype)
+        kernel_size = self.kernel_size
+        return scp.signal.medfilt2d(input, kernel_size)
+
+    @testing.with_requires('scipy>=1.11.0')
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose(
+        atol=1e-8, rtol=1e-8, scipy_name='scp',
+        accept_error=(ValueError, TypeError))  # for even kernels
     def test_medfilt2d(self, xp, scp, dtype):
         if sys.platform == 'win32':
             pytest.xfail('medfilt2d broken for Scipy 1.7.0 in windows')


### PR DESCRIPTION
Part of https://github.com/cupy/cupy/issues/7664.