### PR TITLE
[WIP] Revert "Avoid using numpy.find_common_type" partially

### DIFF
--- a/cupy/_indexing/generate.py
+++ b/cupy/_indexing/generate.py
@@ -39,7 +39,6 @@ class AxisConcatenator(object):
         trans1d = self.trans1d
         ndmin = self.ndmin
         objs = []
-        arrays = []
         scalars = []
         if isinstance(key, str):
             raise NotImplementedError
@@ -63,11 +62,10 @@ class AxisConcatenator(object):
                     ndim = from_data.array(k, copy=False).ndim
                     if trans1d != -1 and ndim < ndmin:
                         newobj = self._output_obj(newobj, ndim, ndmin, trans1d)
-                arrays.append(newobj)
 
             objs.append(newobj)
 
-        final_dtype = numpy.result_type(*arrays, *[objs[k] for k in scalars])
+        final_dtype = numpy.result_type(*key)
         if final_dtype is not None:
             for k in scalars:
                 objs[k] = objs[k].astype(final_dtype)


### PR DESCRIPTION
This reverts commit 9cc8dc29e108bca975e4b1d57108ea703d4731e3 partially in https://github.com/cupy/cupy/pull/7651.