### PR TITLE
DOC: cupyx/scipy: add missing names

### DIFF
--- a/cupyx/scipy/signal/__init__.py
+++ b/cupyx/scipy/signal/__init__.py
@@ -67,6 +67,7 @@ from cupyx.scipy.signal._iir_filter_conversions import lp2bs_zpk  # NOQA
 
 from cupyx.scipy.signal._iir_filter_conversions import zpk2tf  # NOQA
 from cupyx.scipy.signal._iir_filter_conversions import zpk2sos  # NOQA
+from cupyx.scipy.signal._iir_filter_conversions import zpk2ss   # NOQA
 from cupyx.scipy.signal._iir_filter_conversions import tf2zpk  # NOQA
 from cupyx.scipy.signal._iir_filter_conversions import tf2sos  # NOQA
 from cupyx.scipy.signal._iir_filter_conversions import tf2ss  # NOQA

--- a/docs/source/reference/scipy_signal.rst
+++ b/docs/source/reference/scipy_signal.rst
@@ -95,6 +95,7 @@ Filter design
    residuez
    invres
    invresz
+   BadCoefficients
 
 
 Matlab-style IIR filter design
@@ -123,6 +124,20 @@ Low-level filter design functions
    :toctree: generated/
 
    abcd_normalize
+   band_stop_obj
+   buttap
+   cheb1ap
+   cheb2ap
+   ellipap
+   lp2bp
+   lp2bp_zpk
+   lp2bs
+   lp2bs_zpk
+   lp2hp
+   lp2hp_zpk
+   lp2lp
+   lp2lp_zpk
+   normalize
 
 
 LTI representations
@@ -133,12 +148,15 @@ LTI representations
 
    zpk2tf
    zpk2sos
+   zpk2ss
    tf2zpk
    tf2sos
    tf2ss
    ss2tf
+   ss2zpk
    sos2tf
    sos2zpk
+   cont2discrete
 
 
 Continuous-time linear systems


### PR DESCRIPTION
Add several names which were missing from the refguide listing at https://docs.cupy.dev/en/latest/reference/scipy_signal.html plus one name which was missing in `__init__.py` namespace export.

On the branch and scipy main, the set difference of the documented API names between scipy.signal and  cupyx.scipy.signal is

```
ShortTimeFFT
bessel
besselap
bspline
cascade
cmplx_sort
coherence
cubic
daub
decimate
find_peaks_cwt
impulse2
istft
lsim2
max_len_seq
place_poles
quadratic
remez
resample
resample_poly
spectrogram
step2
stft
sweep_poly
upfirdn
vectorstrength
```

which looks reasonable given the current set of PRs in flight and scipy deprecations (cmplx_sort, step2 etc).
A quick-and-dirty script to generate the listing above is under the fold.


<details>


```
cupy_listing = "/home/br/repos/cupy/docs/source/reference/scipy_signal.rst"
with open(cupy_listing, "r") as cp_f:
    cp_txt = cp_f.read()

cp_names = [line.strip() for line in cp_txt.split("\n") if line.startswith("   ") and ":" not in line]
# print(cp_names)

scipy_listing = "/home/br/repos/scipy/scipy/scipy/signal/__init__.py"
with open(scipy_listing, "r") as sp_f:
    sp_txt = sp_f.read()

sp_names = [line.strip() for line in sp_txt.split("\n") if line.startswith("   ") and "--" in line and ":" not in line]
sp_names = [line.split('--')[0].strip() for line in sp_names]
#print("=================\n", sp_names)

print(">>>>>>>>>>>>>>>>>>>>>>><<<<<<<<<<<<<<<<<<<<<<<")

for missing in sorted((set(sp_names) - set(cp_names))):
    print(missing)
```