### PR TITLE
Fix return type of division of csr_matrix and dense array for SciPy 1.11

### DIFF
--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -1226,19 +1226,22 @@ class TestCsrMatrixScipyComparison:
         y = m / xp.array(self._make_scalar(dtype))
         return y.toarray()
 
+    @testing.with_requires('scipy>=1.11')
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_divide_dense_row(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
         x = xp.arange(4, dtype=self.dtype)
         return m / x
 
+    @testing.with_requires('scipy>=1.11')
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_divide_dense_col(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
         x = xp.arange(3, dtype=self.dtype).reshape(3, 1)
         return m / x
 
-    @testing.numpy_cupy_allclose(sp_name='sp')
+    @testing.with_requires('scipy>=1.11')
+    @testing.numpy_cupy_allclose(sp_name='sp', rtol=2e-7)
     def test_divide_dense_matrix(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
         x = xp.arange(12, dtype=self.dtype).reshape(3, 4)


### PR DESCRIPTION
Part of https://github.com/cupy/cupy/issues/7664.

`csr_matrix.__truediv__(dense_array)` returns `coo_matrix` in SciPy 1.11.
https://docs.scipy.org/doc/scipy/release/1.11.0-notes.html#scipy-sparse-improvements