### PR TITLE
[v12] Skip `TestSpmatrix` on SciPy 1.11 or later

### DIFF
--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_base.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_base.py
@@ -37,7 +37,7 @@ class DummySparseGPU(sparse.spmatrix):
         return self._nnz
 
 
-@testing.with_requires('scipy')
+@testing.with_requires('scipy<1.11')
 class TestSpmatrix(unittest.TestCase):
 
     def dummy_class(self, sp):


### PR DESCRIPTION
Manual backport of #7905 by @asi1024
