### PR TITLE
Reorganize directory structure around CCCL

### DIFF
--- a/.github/workflows/pretest.yml
+++ b/.github/workflows/pretest.yml
@@ -84,8 +84,7 @@ jobs:
     - name: Docs Build
       run: |
         # Test to detect invalid escape sequences in docstrings (#1619)
-        # Skip checking any Python files from external dependencies
-        python -Werror::DeprecationWarning -m compileall -f -q cupy cupyx examples tests docs -x "include/cupy/cccl/"
+        python -Werror::DeprecationWarning -m compileall -f -q cupy cupyx examples tests docs
         pushd docs
         pip install -r requirements.txt
         SPHINXOPTS="-W --keep-going -j 4" make html

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,5 +2,5 @@
 	path = cupy/_core/include/cupy/jitify
 	url = https://github.com/NVIDIA/jitify.git
 [submodule "cupy/_core/include/cupy/cccl"]
-	path = cupy/_core/include/cupy/cccl
+	path = third_party/cccl
 	url = https://github.com/NVIDIA/cccl.git

--- a/.pfnci/windows/test.ps1
+++ b/.pfnci/windows/test.ps1
@@ -56,6 +56,10 @@ function Main {
     PrioritizeFlexCIDaemon
     EnableLongPaths
 
+    # Enable symbolic links and re-checkout
+    git config core.symlinks true
+    git reset --hard
+
     # Setup environment
     echo "Using CUDA $cuda and Python $python"
     ActivateCUDA $cuda

--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -2142,9 +2142,9 @@ cpdef str _get_header_dir_path():
 
 cpdef tuple _get_cccl_include_options():
     # the search paths are made such that they resemble the layout in CTK
-    return (f"-I{_get_header_dir_path()}/cupy/cccl/cub",
-            f"-I{_get_header_dir_path()}/cupy/cccl/thrust",
-            f"-I{_get_header_dir_path()}/cupy/cccl/libcudacxx/include")
+    return (f"-I{_get_header_dir_path()}/cupy/_cccl/cub",
+            f"-I{_get_header_dir_path()}/cupy/_cccl/thrust",
+            f"-I{_get_header_dir_path()}/cupy/_cccl/libcudacxx")
 
 
 cpdef str _get_header_source():

--- a/cupy/_core/include/cupy/README.md
+++ b/cupy/_core/include/cupy/README.md
@@ -4,12 +4,6 @@ All files and directories in this directory will be copied to the distribution (
 Note that items starting with `.` (e.g., `cub/.git`) are excluded.
 See `setup.py` for details.
 
-## CCCL
-
-The `cccl` folder is a git submodule for the CCCL project, the new home for Thrust, CUB, and
-libcu++. The CCCL headers are used at both build- and run- time.
-For further information on CUB, see the [CCCL repo](https://github.com/NVIDIA/cccl).
-
 ## Jitify
 The `Jitify` folder is a git submodule for the Jitify project.
 Including the Jitify header as a submodule for building the `cupy.cuda.jitify` module.

--- a/cupy/_core/include/cupy/_cccl/LICENSE
+++ b/cupy/_core/include/cupy/_cccl/LICENSE
@@ -1,0 +1,1 @@
+../../../../../third_party/cccl/LICENSE

--- a/cupy/_core/include/cupy/_cccl/cub/cub
+++ b/cupy/_core/include/cupy/_cccl/cub/cub
@@ -1,0 +1,1 @@
+../../../../../../third_party/cccl/cub/cub

--- a/cupy/_core/include/cupy/_cccl/libcudacxx
+++ b/cupy/_core/include/cupy/_cccl/libcudacxx
@@ -1,0 +1,1 @@
+../../../../../third_party/cccl/libcudacxx/include

--- a/cupy/_core/include/cupy/_cccl/thrust/thrust
+++ b/cupy/_core/include/cupy/_cccl/thrust/thrust
@@ -1,0 +1,1 @@
+../../../../../../third_party/cccl/thrust/thrust

--- a/cupy/_environment.py
+++ b/cupy/_environment.py
@@ -176,7 +176,7 @@ def _get_cub_path():
 
     if not runtime.is_hip:
         if os.path.isdir(
-                os.path.join(current_dir, '_core/include/cupy/cccl/cub')):
+                os.path.join(current_dir, '_core/include/cupy/_cccl/cub')):
             _cub_path = '<bundle>'
         else:
             _cub_path = None

--- a/install/cupy_builder/_preflight.py
+++ b/install/cupy_builder/_preflight.py
@@ -7,7 +7,7 @@ from cupy_builder import Context
 def preflight_check(ctx: Context) -> bool:
     source_root = ctx.source_root
     is_git = os.path.isdir(os.path.join(source_root, '.git'))
-    for submodule in ('cupy/_core/include/cupy/cccl',
+    for submodule in ('third_party/cccl',
                       'cupy/_core/include/cupy/jitify'):
         if 0 < len(os.listdir(os.path.join(source_root, submodule))):
             continue

--- a/install/cupy_builder/install_build.py
+++ b/install/cupy_builder/install_build.py
@@ -188,10 +188,9 @@ def get_compiler_setting(ctx: Context, use_hip):
         _libcudacxx_path = None
     else:
         # all bundled together under cccl
-        _cub_path = os.path.join(cupy_header, 'cupy/cccl/cub')
-        _thrust_path = os.path.join(cupy_header, 'cupy/cccl/thrust')
-        _libcudacxx_path = os.path.join(
-            cupy_header, 'cupy/cccl/libcudacxx/include')
+        _cub_path = os.path.join(cupy_header, 'cupy/_cccl/cub')
+        _thrust_path = os.path.join(cupy_header, 'cupy/_cccl/thrust')
+        _libcudacxx_path = os.path.join(cupy_header, 'cupy/_cccl/libcudacxx')
     include_dirs.insert(0, cupy_header)
     include_dirs.insert(0, _cub_path)
     if _thrust_path and _libcudacxx_path:

--- a/setup.py
+++ b/setup.py
@@ -71,16 +71,10 @@ cupy_package_data = [
     'cupyx/scipy/ndimage/cuda/LICENSE',
     'cupyx/scipy/ndimage/cuda/pba_kernels_2d.h',
     'cupyx/scipy/ndimage/cuda/pba_kernels_3d.h',
+] + [
+    x for x in glob.glob('cupy/_core/include/cupy/**', recursive=True)
+    if os.path.isfile(x)
 ]
-cupy_package_include = list(set(
-    [x for x in glob.iglob('cupy/_core/include/cupy/**', recursive=True)
-     if os.path.isfile(x)
-     ]) - set(
-    [x for x in glob.iglob(
-     'cupy/_core/include/cupy/cccl/libcudacxx/**/test/**', recursive=True)
-     if os.path.isfile(x)
-     ]))
-cupy_package_data += cupy_package_include
 
 package_data = {
     'cupy': [

--- a/third_party/README.md
+++ b/third_party/README.md
@@ -1,0 +1,7 @@
+# Third Party Libraries
+
+## CCCL
+
+The `cccl` folder is a git submodule for the CCCL project, the new home for Thrust, CUB, and
+libcu++. The CCCL headers are used at both build- and run- time.
+For further information on CUB, see the [CCCL repo](https://github.com/NVIDIA/cccl).


### PR DESCRIPTION
~(Do not merge, raising for discussion)~ Ready for review.

The current `main` branch generates a binary package with many files originated from the CCCL repository, which are essentially not required for CuPy's functionalities (C/C++ code, images, documentation, etc.)

This PR tries to mitigate the situation by placing `cccl` to `thrid_party/cccl` and taking only the necessary parts from there.

`python setup.py bdist_wheel` generates a wheel of:
* `main`: 53 MB, containing 4001 files
* This PR: 48 MB, containing 1949 files

Another idea could be to implement a filter in Python (like eb4922ebc0dc46c365149dff1729ebb4d2f82cc9), but I think it is harder to maintain.

If this is acceptable, we can also use the same strategy for Jitify and DLPack (which is not submodule currently due to directory structure) as well.

cc/ @leofang 
refs #7851