### PR TITLE
[DO NOT MERGE] Allow Jitify to only cache CuPy-owned headers

### DIFF
--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -2188,22 +2188,7 @@ cdef inline str _translate_cucomplex_to_thrust(str source):
     return ''.join(lines)
 
 
-cpdef function.Module compile_with_cache(
-        str source, tuple options=(), arch=None, cachd_dir=None,
-        prepend_cupy_headers=True, backend='nvrtc', translate_cucomplex=False,
-        enable_cooperative_groups=False, name_expressions=None,
-        log_stream=None, bint jitify=False):
-    if translate_cucomplex:
-        source = _translate_cucomplex_to_thrust(source)
-        cupy_header_list.append('cupy/cuComplex_bridge.h')
-        prepend_cupy_headers = True
-
-    if prepend_cupy_headers:
-        source = _cupy_header + source
-    if jitify:
-        source = '#include <cupy/cuda_workaround.h>\n' + source
-    extra_source = _get_header_source()
-
+cpdef tuple assemble_cupy_compiler_options(tuple options):
     for op in options:
         if '-std=c++' in op:
             if op.endswith('03'):
@@ -2264,6 +2249,27 @@ cpdef function.Module compile_with_cache(
 
     if _cuda_path is not None:
         options += ('-I' + os.path.join(_cuda_path, 'include'),)
+
+    return options
+
+
+cpdef function.Module compile_with_cache(
+        str source, tuple options=(), arch=None, cachd_dir=None,
+        prepend_cupy_headers=True, backend='nvrtc', translate_cucomplex=False,
+        enable_cooperative_groups=False, name_expressions=None,
+        log_stream=None, bint jitify=False):
+    if translate_cucomplex:
+        source = _translate_cucomplex_to_thrust(source)
+        cupy_header_list.append('cupy/cuComplex_bridge.h')
+        prepend_cupy_headers = True
+
+    if prepend_cupy_headers:
+        source = _cupy_header + source
+    if jitify:
+        source = '#include <cupy/cuda_workaround.h>\n' + source
+    extra_source = _get_header_source()
+
+    options = assemble_cupy_compiler_options(options)
 
     return cuda.compiler._compile_module_with_cache(
         source, options, arch, cachd_dir, extra_source, backend,

--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -234,6 +234,7 @@ def _jitify_prep(source, options, cu_path):
     global _jitify_header_source_map_populated
     if not _jitify_header_source_map_populated:
         from cupy._core import core
+        jitify._init_module()
         jitify._add_sources(core._get_header_source_map())
         _jitify_header_source_map_populated = True
 


### PR DESCRIPTION
@kmaehashi raised the concern offline that the Jitify cache (introduced in #7851) could also cache user-supplied headers, potentially causing hard-to-debug problems, unless users read the docs and set `CUPY_DISABLE_JITIFY_CACHE=1` to force initializing a fresh cache.

This PR raises an alternative solution as per offline discussion, by caching only the headers that are owned by CuPy (including the CCCL bundle), thereby alleviating the cognition overhead on the user side.

A new issue with this PR is that if any of the CuPy headers is updated (say in a minor CuPy release) but the cache is not, we could still run into issues. The potential solution is to put the burden on us (maintainers) to remember to bump the internal `build_num` in `jitify.pyx` to invalidate the cache (which was already working back in #7851). Still, I'd like to raise for awareness and for stimulating discussion for other alternatives.