### PR TITLE
[v12] Fix test of `product`, `cumproduct`, `alltrue` and `sometrue` for deprecation

### DIFF
--- a/cupy/_indexing/insert.py
+++ b/cupy/_indexing/insert.py
@@ -173,7 +173,7 @@ def fill_diagonal(a, val, wrap=False):
         if not wrap:
             end = a.shape[1] * a.shape[1]
     else:
-        if not numpy.alltrue(numpy.diff(a.shape) == 0):
+        if not numpy.all(numpy.diff(a.shape) == 0):
             raise ValueError('All dimensions of input must be of equal length')
         step = 1 + numpy.cumprod(a.shape[:-1]).sum()
 

--- a/tests/cupy_tests/logic_tests/test_truth.py
+++ b/tests/cupy_tests/logic_tests/test_truth.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy
 
 from cupy import testing
@@ -81,11 +83,15 @@ class TestAllAnyWithNaN:
 class TestAllAnyAlias:
     @testing.numpy_cupy_array_equal()
     def test_alltrue(self, xp):
-        return xp.alltrue(xp.array([1, 2, 3]))
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', DeprecationWarning)
+            return xp.alltrue(xp.array([1, 2, 3]))
 
     @testing.numpy_cupy_array_equal()
     def test_sometrue(self, xp):
-        return xp.sometrue(xp.array([0]))
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', DeprecationWarning)
+            return xp.sometrue(xp.array([0]))
 
 
 @testing.parameterize(

--- a/tests/cupy_tests/math_tests/test_sumprod.py
+++ b/tests/cupy_tests/math_tests/test_sumprod.py
@@ -1,4 +1,5 @@
 import math
+import warnings
 
 import numpy
 import pytest
@@ -204,7 +205,9 @@ class TestSumprod:
     @testing.numpy_cupy_allclose()
     def test_product_alias(self, xp):
         a = testing.shaped_arange((2, 3), xp, xp.float32)
-        return xp.product(a)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', DeprecationWarning)
+            return xp.product(a)
 
 
 # This class compares CUB results against NumPy's
@@ -773,7 +776,9 @@ class TestCumprod:
     @testing.numpy_cupy_allclose()
     def test_cumproduct_alias(self, xp):
         a = testing.shaped_arange((2, 3), xp, xp.float32)
-        return xp.cumproduct(a)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', DeprecationWarning)
+            return xp.cumproduct(a)
 
 
 @testing.parameterize(*testing.product({


### PR DESCRIPTION
Backport of #7645.