### PR TITLE
[v12] Skip fusion `round_` tests

### DIFF
--- a/tests/cupy_tests/core_tests/fusion_tests/test_routines.py
+++ b/tests/cupy_tests/core_tests/fusion_tests/test_routines.py
@@ -153,8 +153,7 @@ class TestFusionDegRad(FusionUnaryUfuncTestBase):
 
 
 @testing.parameterize(*testing.product({
-    'func': ['around', 'round', 'round_', 'rint', 'floor', 'ceil', 'trunc',
-             'fix']
+    'func': ['around', 'round', 'rint', 'floor', 'ceil', 'trunc', 'fix']
 }))
 class TestFusionRounding(FusionUnaryUfuncTestBase):
 


### PR DESCRIPTION
Backport of #7623.
Related to https://github.com/cupy/cupy/pull/7642.