### PR TITLE
Ensure D2H copies are stream ordered and by default blocking

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -808,7 +808,7 @@ def asnumpy(a, stream=None, order='C', out=None, *, blocking=True):
         out (numpy.ndarray): The output array to be written to. It must have
             compatible shape and dtype with those of ``a``'s.
         blocking (bool): If set to ``False``, the copy runs asynchronously
-            on the given (if given) or default stream, and users are
+            on the given (if given) or current stream, and users are
             responsible for ensuring the stream order. Default is ``True``,
             so the copy is synchronous (with respect to the host).
 

--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -792,29 +792,35 @@ from cupy._core import fromDlpack  # NOQA
 from cupy._core import from_dlpack  # NOQA
 
 
-def asnumpy(a, stream=None, order='C', out=None):
+def asnumpy(a, stream=None, order='C', out=None, *, blocking=True):
     """Returns an array on the host memory from an arbitrary source array.
 
     Args:
         a: Arbitrary object that can be converted to :class:`numpy.ndarray`.
-        stream (cupy.cuda.Stream): CUDA stream object. If it is specified, then
-            the device-to-host copy runs asynchronously. Otherwise, the copy is
-            synchronous. Note that if ``a`` is not a :class:`cupy.ndarray`
+        stream (cupy.cuda.Stream): CUDA stream object. If given, the
+            stream is used to perform the copy. Otherwise, the current
+            stream is used. Note that if ``a`` is not a :class:`cupy.ndarray`
             object, then this argument has no effect.
         order ({'C', 'F', 'A'}): The desired memory layout of the host
-            array. When ``order`` is 'A', it uses 'F' if ``a`` is
-            fortran-contiguous and 'C' otherwise.
+            array. When ``order`` is 'A', it uses 'F' if the array is
+            fortran-contiguous and 'C' otherwise. The ``order`` will be
+            ignored if ``out`` is specified.
         out (numpy.ndarray): The output array to be written to. It must have
             compatible shape and dtype with those of ``a``'s.
+        blocking (bool): If set to ``False``, the copy runs asynchronously
+            on the given (if given) or default stream, and users are
+            responsible for ensuring the stream order. Default is ``True``,
+            so the copy is synchronous (with respect to the host).
 
     Returns:
         numpy.ndarray: Converted array on the host memory.
 
     """
     if isinstance(a, ndarray):
-        return a.get(stream=stream, order=order, out=out)
+        return a.get(stream=stream, order=order, out=out, blocking=blocking)
     elif hasattr(a, "__cuda_array_interface__"):
-        return array(a).get(stream=stream, order=order, out=out)
+        return array(a).get(
+            stream=stream, order=order, out=out, blocking=blocking)
     else:
         temp = _numpy.asarray(a, order=order)
         if out is not None:

--- a/cupy/_core/core.pxd
+++ b/cupy/_core/core.pxd
@@ -71,7 +71,7 @@ cdef class _ndarray_base:
     cpdef _ndarray_base any(self, axis=*, out=*, keepdims=*)
     cpdef _ndarray_base conj(self)
     cpdef _ndarray_base conjugate(self)
-    cpdef get(self, stream=*, order=*, out=*)
+    cpdef get(self, stream=*, order=*, out=*, blocking=*)
     cpdef set(self, arr, stream=*)
     cpdef _ndarray_base reduced_view(self, dtype=*)
     cpdef _update_c_contiguity(self)

--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -1778,7 +1778,7 @@ cdef class _ndarray_base:
             out (numpy.ndarray): Output array. In order to enable asynchronous
                 copy, the underlying memory should be a pinned memory.
             blocking (bool): If set to ``False``, the copy runs asynchronously
-                on the given (if given) or default stream, and users are
+                on the given (if given) or current stream, and users are
                 responsible for ensuring the stream order. Default is ``True``,
                 so the copy is synchronous (with respect to the host).
 

--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -1579,11 +1579,7 @@ cdef class _ndarray_base:
                 order = 'F' if self._f_contiguous else 'C'
                 tmp = value.ravel(order)
                 ptr = tmp.ctypes.data
-                stream_ptr = stream_module.get_current_stream_ptr()
-                if stream_ptr == 0:
-                    self.data.copy_from_host(ptr, self.nbytes)
-                else:
-                    self.data.copy_from_host_async(ptr, self.nbytes)
+                self.data.copy_from_host_async(ptr, self.nbytes)
             else:
                 raise ValueError(
                     'copying a numpy.ndarray to a cupy.ndarray by empty slice '
@@ -1768,19 +1764,23 @@ cdef class _ndarray_base:
         """CUDA device on which this array resides."""
         return self.data.device
 
-    cpdef get(self, stream=None, order='C', out=None):
+    cpdef get(self, stream=None, order='C', out=None, blocking=True):
         """Returns a copy of the array on host memory.
 
         Args:
-            stream (cupy.cuda.Stream): CUDA stream object. If it is given, the
-                copy runs asynchronously. Otherwise, the copy is synchronous.
-                The default uses CUDA stream object of the current context.
+            stream (cupy.cuda.Stream): CUDA stream object. If given, the
+                stream is used to perform the copy. Otherwise, the current
+                stream is used.
             order ({'C', 'F', 'A'}): The desired memory layout of the host
                 array. When ``order`` is 'A', it uses 'F' if the array is
                 fortran-contiguous and 'C' otherwise. The ``order`` will be
                 ignored if ``out`` is specified.
             out (numpy.ndarray): Output array. In order to enable asynchronous
                 copy, the underlying memory should be a pinned memory.
+            blocking (bool): If set to ``False``, the copy runs asynchronously
+                on the given (if given) or default stream, and users are
+                responsible for ensuring the stream order. Default is ``True``,
+                so the copy is synchronous (with respect to the host).
 
         Returns:
             numpy.ndarray: Copy of the array on host memory.
@@ -1843,19 +1843,17 @@ cdef class _ndarray_base:
                 a_gpu = self
             a_cpu = numpy.empty(self._shape, dtype=self.dtype, order=order)
 
+        if stream is None:
+            stream = stream_module.get_current_stream()
+
         syncdetect._declare_synchronize()
         ptr = a_cpu.ctypes.data
         prev_device = runtime.getDevice()
         try:
             runtime.setDevice(self.device.id)
-            if stream is not None:
-                a_gpu.data.copy_to_host_async(ptr, a_gpu.nbytes, stream)
-            else:
-                stream_ptr = stream_module.get_current_stream_ptr()
-                if stream_ptr == 0:
-                    a_gpu.data.copy_to_host(ptr, a_gpu.nbytes)
-                else:
-                    a_gpu.data.copy_to_host_async(ptr, a_gpu.nbytes)
+            a_gpu.data.copy_to_host_async(ptr, a_gpu.nbytes, stream)
+            if blocking:
+                stream.synchronize()
         finally:
             runtime.setDevice(prev_device)
         return a_cpu
@@ -1865,10 +1863,9 @@ cdef class _ndarray_base:
 
         Args:
             arr (numpy.ndarray): The source array on the host memory.
-            stream (cupy.cuda.Stream): CUDA stream object. If it is given, the
-                copy runs asynchronously. Otherwise, the copy is synchronous.
-                The default uses CUDA stream object of the current context.
-
+            stream (cupy.cuda.Stream): CUDA stream object. If given, the
+                stream is used to perform the copy. Otherwise, the current
+                stream is used.
         """
         if not isinstance(arr, numpy.ndarray):
             raise TypeError('Only numpy.ndarray can be set to cupy.ndarray')
@@ -1886,18 +1883,14 @@ cdef class _ndarray_base:
         else:
             raise RuntimeError('Cannot set to non-contiguous array')
 
+        if stream is None:
+            stream = stream_module.get_current_stream()
+
         ptr = arr.ctypes.data
         prev_device = runtime.getDevice()
         try:
             runtime.setDevice(self.device.id)
-            if stream is not None:
-                self.data.copy_from_host_async(ptr, self.nbytes, stream)
-            else:
-                stream_ptr = stream_module.get_current_stream_ptr()
-                if stream_ptr == 0:
-                    self.data.copy_from_host(ptr, self.nbytes)
-                else:
-                    self.data.copy_from_host_async(ptr, self.nbytes)
+            self.data.copy_from_host_async(ptr, self.nbytes, stream)
         finally:
             runtime.setDevice(prev_device)
 

--- a/docs/source/upgrade.rst
+++ b/docs/source/upgrade.rst
@@ -28,7 +28,7 @@ the lowest C++ standard. CCCL expects to move to C++17 in the near future.
 Change in :func:`cupy.asnumpy`/:meth:`cupy.ndarray.get` Behavior
 ----------------------------------------------------------------
 
-When transferring a CuPy array from GPU to CPU (as a NumPy array), previously the transfer could be nonblocking and not properly ordered,
+When transferring a CuPy array from GPU to CPU (as a NumPy array), previously the transfer could be nonblocking and not properly ordered when a non-default stream is in use,
 leading to potential data race if the resulting array is modified on host immediately after the copy starts. In CuPy v13, the default
 behavior is changed to be always blocking, with a new optional argument ``blocking`` added to allow the previous nonblocking behavior
 if set to ``False``, in which case users are responsible for ensuring proper stream order.

--- a/docs/source/upgrade.rst
+++ b/docs/source/upgrade.rst
@@ -25,6 +25,14 @@ by CCCL (currently CUDA 11 & 12), but this change leads to the following consequ
 As a result of this movement, CuPy now follows the same compiler requirement as CCCL (and, in turn, CUDA Toolkit) and requires C++11 as
 the lowest C++ standard. CCCL expects to move to C++17 in the near future.
 
+Change in :func:`cupy.asnumpy`/:meth:`cupy.ndarray.get` Behavior
+----------------------------------------------------------------
+
+When transferring a CuPy array from GPU to CPU (as a NumPy array), previously the transfer could be nonblocking and not properly ordered,
+leading to potential data race if the resulting array is modified on host immediately after the copy starts. In CuPy v13, the default
+behavior is changed to be always blocking, with a new optional argument ``blocking`` added to allow the previous nonblocking behavior
+if set to ``False``, in which case users are responsible for ensuring proper stream order.
+
 
 CuPy v12
 ========

--- a/tests/cupy_tests/core_tests/test_ndarray_get.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_get.py
@@ -12,9 +12,9 @@ class TestArrayGet(unittest.TestCase):
     def setUp(self):
         self.stream = cuda.Stream.null
 
-    def check_get(self, f, stream, order='C'):
+    def check_get(self, f, stream, order='C', blocking=True):
         a_gpu = f(cupy)
-        a_cpu = a_gpu.get(stream, order=order)
+        a_cpu = a_gpu.get(stream, order=order, blocking=blocking)
         if stream:
             stream.synchronize()
         b_cpu = f(numpy)
@@ -44,6 +44,15 @@ class TestArrayGet(unittest.TestCase):
         def contiguous_array(xp):
             return testing.shaped_arange((3,), xp, dtype, order)
         self.check_get(contiguous_array, self.stream, order)
+
+    @testing.for_orders('CFA')
+    @testing.for_all_dtypes()
+    def test_contiguous_array_stream_nonblocking(self, dtype, order):
+        # Note: This is just a smoking gun test, the real test is done for
+        # testing cupy.asnumpy(), which under the hood calls .get().
+        def contiguous_array(xp):
+            return testing.shaped_arange((3,), xp, dtype, order)
+        self.check_get(contiguous_array, self.stream, order, False)
 
     @testing.for_orders('CFA')
     @testing.for_all_dtypes()

--- a/tests/cupy_tests/test_numpy_interop.py
+++ b/tests/cupy_tests/test_numpy_interop.py
@@ -1,3 +1,4 @@
+import contextlib
 import unittest
 
 import numpy
@@ -148,3 +149,32 @@ class TestAsnumpy:
         testing.assert_array_equal(x, y)
         assert isinstance(y.base, cupy.cuda.PinnedMemoryPointer)
         assert y.base.ptr == y.ctypes.data
+
+    @pytest.mark.parametrize('blocking', (True, False))
+    def test_asnumpy_blocking(self, blocking):
+        prefactor = 4
+        a = cupy.random.random(prefactor*128*1024*1024, dtype=cupy.float64)
+        cupy.cuda.Device().synchronize()
+
+        # Idea: perform D2H copy on a nonblocking stream, during which we try
+        # to "corrupt" the host data via NumPy operation. If the copy is
+        # properly ordered, corruption would not be possible. Here we craft a
+        # problem size and use pinned memory to ensure the failure can be
+        # always triggered. (The CUDART API reference ("API synchronization
+        # behavior") states that copying between device and pageable memory
+        # "might be" synchronous, whereas between device and page-locked
+        # memory "should be" fully asynchronous.)
+        s = cupy.cuda.Stream(non_blocking=True)
+        with s:
+            c = cupyx.empty_pinned(a.shape, dtype=a.dtype)
+            cupy.asnumpy(a, out=c, blocking=blocking)
+            c[c.size//2:] = -1.  # potential data race
+        s.synchronize()
+
+        a[c.size//2:] = -1.
+        if not blocking:
+            ctx = pytest.raises(AssertionError)
+        else:
+            ctx = contextlib.nullcontext()
+        with ctx:
+            assert cupy.allclose(a, c)


### PR DESCRIPTION
Close #7820. 

As discussed in the linked issue, this PR adds a new, optional argument `blocking` to control the copy behavior, and make it default to `True` to avoid data race. A test that can easily expose the data race is added.

Note that during the discussion, it was proposed to name the new argument as `async`. However, `async` is a reserved Python keyword (for coroutines), so I changed it to `blocking`, but I am happy to make changes if requested.