### PR TITLE
Improve symlink handling and preflight

### DIFF
--- a/cupy/_core/include/cupy/_cccl/.gitattributes
+++ b/cupy/_core/include/cupy/_cccl/.gitattributes
@@ -1,0 +1,1 @@
+libcudacxx symlink=dir

--- a/cupy/_core/include/cupy/_cccl/cub/.gitattributes
+++ b/cupy/_core/include/cupy/_cccl/cub/.gitattributes
@@ -1,0 +1,1 @@
+cub symlink=dir

--- a/cupy/_core/include/cupy/_cccl/thrust/.gitattributes
+++ b/cupy/_core/include/cupy/_cccl/thrust/.gitattributes
@@ -1,0 +1,1 @@
+thrust symlink=dir

--- a/install/cupy_builder/_preflight.py
+++ b/install/cupy_builder/_preflight.py
@@ -5,6 +5,10 @@ from cupy_builder import Context
 
 
 def preflight_check(ctx: Context) -> bool:
+    if sys.platform not in ('linux', 'win32'):
+        print('Error: macOS is no longer supported', file=sys.stderr)
+        return False
+
     source_root = ctx.source_root
     is_git = os.path.isdir(os.path.join(source_root, '.git'))
     for submodule in ('third_party/cccl',

--- a/install/cupy_builder/_preflight.py
+++ b/install/cupy_builder/_preflight.py
@@ -13,8 +13,15 @@ def preflight_check(ctx: Context) -> bool:
     is_git = os.path.isdir(os.path.join(source_root, '.git'))
     for submodule in ('third_party/cccl',
                       'cupy/_core/include/cupy/jitify'):
-        if 0 < len(os.listdir(os.path.join(source_root, submodule))):
-            continue
+        dirpath = os.path.join(source_root, submodule)
+        if os.path.isdir(dirpath):
+            if 0 < len(os.listdir(dirpath)):
+                continue
+        else:
+            if not is_git:
+                # sdist does not contain third_party directory
+                continue
+
         if is_git:
             msg = f'''
 ===========================================================================

--- a/install/cupy_builder/cupy_setup_build.py
+++ b/install/cupy_builder/cupy_setup_build.py
@@ -392,8 +392,6 @@ def make_extensions(ctx: Context, compiler, use_cython):
                 rpath.append(
                     '{}{}/cupy/.data/lib'.format(_rpath_base(), '/..' * depth))
 
-            if not PLATFORM_WIN32 and not PLATFORM_LINUX:
-                assert False, "macOS is no longer supported"
             if (PLATFORM_LINUX and len(rpath) != 0):
                 ldflag = '-Wl,'
                 if PLATFORM_LINUX:


### PR DESCRIPTION
This PR:

* Adds `.gitattributes` to allow checking out directory symlinks pointing to submodules.
* Fix sdist to pass preflight check. sdist does not contain `third_party`.

This is a blocker for a release.
