### PR TITLE
Support Python 3.12, add Windows CI

### DIFF
--- a/.pfnci/config.pbtxt
+++ b/.pfnci/config.pbtxt
@@ -730,7 +730,7 @@ configs {
       include_dot_git: true
     }
     environment_variables { key: "GPU" value: "2" }
-    command: ".pfnci\\windows\\run.bat 12.1 3.10 test"
+    command: ".pfnci\\windows\\run.bat 12.1 3.11 test"
   }
 }
 
@@ -751,6 +751,6 @@ configs {
       include_dot_git: true
     }
     environment_variables { key: "GPU" value: "2" }
-    command: ".pfnci\\windows\\run.bat 12.2 3.10 test"
+    command: ".pfnci\\windows\\run.bat 12.2 3.12 test"
   }
 }

--- a/.pfnci/windows/_flexci.ps1
+++ b/.pfnci/windows/_flexci.ps1
@@ -13,6 +13,8 @@ function ActivatePython($version) {
         $pydir = "Python310"
     } elseif ($version -eq "3.11") {
         $pydir = "Python311"
+    } elseif ($version -eq "3.12") {
+        $pydir = "Python312"
     } else {
         throw "Unsupported Python version: $version"
     }

--- a/.pfnci/windows/test.ps1
+++ b/.pfnci/windows/test.ps1
@@ -85,7 +85,7 @@ function Main {
 
     echo "Building..."
     $build_retval = 0
-    RunOrDie python -m pip install -U "numpy<1.24" "scipy<1.10.0"
+    RunOrDie python -m pip install -U "numpy" "scipy"
     python -m pip install ".[all,test]" -vvv > cupy_build_log.txt
     if (-not $?) {
         $build_retval = $LastExitCode

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -14,7 +14,7 @@ Requirements
     * This requirement is optional if you install CuPy from ``conda-forge``. However, you still need to have a compatible
       driver installed for your GPU. See :ref:`install_cupy_from_conda_forge` for details.
 
-* `Python <https://python.org/>`_: v3.9 / v3.10 / v3.11
+* `Python <https://python.org/>`_: v3.9 / v3.10 / v3.11 / v3.12
 
 .. note::
 

--- a/setup.py
+++ b/setup.py
@@ -113,6 +113,7 @@ Programming Language :: Python :: 3
 Programming Language :: Python :: 3.9
 Programming Language :: Python :: 3.10
 Programming Language :: Python :: 3.11
+Programming Language :: Python :: 3.12
 Programming Language :: Python :: 3 :: Only
 Programming Language :: Cython
 Topic :: Software Development

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
@@ -507,7 +507,7 @@ class TestValueIndices:
     def test_value_indices(self, dtype, ignore_value, num_values,
                            adaptive_index_dtype):
         if sys.platform == 'win32' and dtype in (cupy.intc, cupy.uintc):
-            pytest.skip()
+            pytest.skip()  # https://github.com/scipy/scipy/issues/19423
         image = self._make_image(self.shape, cupy, dtype, scale=num_values)
         self._compare_scipy_cupy(image, ignore_value, adaptive_index_dtype)
 
@@ -515,7 +515,7 @@ class TestValueIndices:
     @testing.for_int_dtypes(no_bool=True)
     def test_value_indices_noncontiguous_labels(self, dtype, ignore_value, ):
         if sys.platform == 'win32' and dtype in (cupy.intc, cupy.uintc):
-            pytest.skip()
+            pytest.skip()  # https://github.com/scipy/scipy/issues/19423
         image = self._make_image(self.shape, cupy, dtype, scale=8)
 
         # Make introduce gaps in the labels present in the image

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
@@ -1,3 +1,4 @@
+import sys
 import warnings
 
 import numpy
@@ -505,12 +506,16 @@ class TestValueIndices:
     @testing.for_int_dtypes(no_bool=True)
     def test_value_indices(self, dtype, ignore_value, num_values,
                            adaptive_index_dtype):
+        if sys.platform == 'win32' and dtype in (cupy.intc, cupy.uintc):
+            pytest.skip()
         image = self._make_image(self.shape, cupy, dtype, scale=num_values)
         self._compare_scipy_cupy(image, ignore_value, adaptive_index_dtype)
 
     @pytest.mark.parametrize('ignore_value', [None, 0, 5])
     @testing.for_int_dtypes(no_bool=True)
     def test_value_indices_noncontiguous_labels(self, dtype, ignore_value, ):
+        if sys.platform == 'win32' and dtype in (cupy.intc, cupy.uintc):
+            pytest.skip()
         image = self._make_image(self.shape, cupy, dtype, scale=8)
 
         # Make introduce gaps in the labels present in the image


### PR DESCRIPTION
Part of #7899

- Update Python versions used in Windows CI
- Add classifier
- Update docs

I'm now installing Python 3.12 to Windows CI image... ⏳ -> Done