### PR TITLE
Fix `NVRTCError` not calling `initialize()`

### DIFF
--- a/cupy_backends/cuda/libs/nvrtc.pyx
+++ b/cupy_backends/cuda/libs/nvrtc.pyx
@@ -37,6 +37,7 @@ ELSE:
 class NVRTCError(RuntimeError):
 
     def __init__(self, status):
+        initialize()
         self.status = status
         cdef bytes msg = nvrtcGetErrorString(<nvrtcResult>status)
         super(NVRTCError, self).__init__(


### PR DESCRIPTION
In most cases this bug does not affect users unless users are manually instantiating `NVRTCError` before calling NVRTC routines.
