### PR TITLE
Fix Windows test scripts

### DIFF
--- a/.pfnci/windows/_flexci.ps1
+++ b/.pfnci/windows/_flexci.ps1
@@ -93,6 +93,10 @@ function ActivateNVTX1() {
     $Env:PATH = "$base\bin\x64;" + $Env:PATH
 }
 
+function InstallZLIB() {
+    Copy-Item -Path "C:\Development\ZLIB\zlibwapi.dll" -Destination "C:\Windows\System32"
+}
+
 function IsPullRequestTest() {
     return ${Env:FLEXCI_BRANCH} -ne $null -and ${Env:FLEXCI_BRANCH}.StartsWith("refs/pull/")
 }

--- a/.pfnci/windows/test.ps1
+++ b/.pfnci/windows/test.ps1
@@ -86,7 +86,7 @@ function Main {
     echo "Building..."
     $build_retval = 0
     RunOrDie python -m pip install -U "numpy" "scipy"
-    python -m pip install ".[all,test]" -vvv > cupy_build_log.txt
+    python -m pip install ".[all,test]" -v > cupy_build_log.txt
     if (-not $?) {
         $build_retval = $LastExitCode
     }

--- a/.pfnci/windows/test.ps1
+++ b/.pfnci/windows/test.ps1
@@ -128,9 +128,7 @@ function Main {
 
     # Install dependency for cuDNN 8.3+
     echo ">> Installing zlib"
-    RunOrDie curl.exe -LO http://www.winimage.com/zLibDll/zlib123dllx64.zip
-    RunOrDie 7z x "zlib123dllx64.zip"
-    Copy-Item -Path "dll_x64\zlibwapi.dll" -Destination "C:\Windows\System32"
+    InstallZLIB
 
     pushd tests
     echo "CuPy Configuration:"


### PR DESCRIPTION
- Reduce verbosity of pip install output
- Install ZLIB from local to fix the unstability issue

```
00:26:54.883675 STDERR 4280]      0     0    0     0    0     0      0      0 --:--:--  0:00:20 --:--:--     0curl: (7) Failed to connect to www.winimage.com port 80: Timed out    20s
00:27:15.664927 STDERR 4280]    Command failed (exit code = 7): curl.exe -LO    
```
