### PR TITLE
Import cupyx.lapack inside cupy.linalg.solve

### DIFF
--- a/cupy/linalg/_solve.py
+++ b/cupy/linalg/_solve.py
@@ -35,6 +35,7 @@ def solve(a, b):
 
     .. seealso:: :func:`numpy.linalg.solve`
     """
+    from cupyx import lapack
     from cupy.cublas import batched_gesv, get_batched_gesv_limit
 
     if a.ndim > 2 and a.shape[-1] <= get_batched_gesv_limit():
@@ -64,7 +65,7 @@ def solve(a, b):
         # prevent 'a' and 'b' to be overwritten
         a = a.astype(dtype, copy=True, order='F')
         b = b.astype(dtype, copy=True, order='F')
-        cupyx.lapack.gesv(a, b)
+        lapack.gesv(a, b)
         return b.astype(out_dtype, copy=False)
 
     # prevent 'a' to be overwritten
@@ -75,7 +76,7 @@ def solve(a, b):
         index = numpy.unravel_index(i, shape)
         # prevent 'b' to be overwritten
         bi = b[index].astype(dtype, copy=True, order='F')
-        cupyx.lapack.gesv(a[index], bi)
+        lapack.gesv(a[index], bi)
         x[index] = bi
     return x
 


### PR DESCRIPTION
After https://github.com/cupy/cupy/pull/7921/ `cupy.linalg.solve` stopped working due to `cupyx.lapack` not being located. This PR adds an explicit import inside `solve` in order to solve this issue.

This is an example traceback that demonstrates this issue:

```python
Traceback (most recent call last):
  File "/home/andfoy/Documentos/Quansight/cupy/../iir_plot.py", line 49, in <module>
    zi = signal.lfilter_zi(b, a)
  File "/home/andfoy/Documentos/Quansight/cupy/cupyx/scipy/signal/_signaltools.py", line 929, in lfilter_zi
    y_zi = cupy.linalg.solve(C1 - C2, y2 - y1)
  File "/home/andfoy/Documentos/Quansight/cupy/cupy/linalg/_solve.py", line 67, in solve
    cupyx.lapack.gesv(a, b)
AttributeError: module 'cupyx' has no attribute 'lapack'
```