### PR TITLE
Add local memory array in addition to shared memory array

### DIFF
--- a/cupyx/jit/_builtin_funcs.py
+++ b/cupyx/jit/_builtin_funcs.py
@@ -219,6 +219,28 @@ class SharedMemory(BuiltinFunc):
         env.locals[name] = var
         return Data(name, _cuda_types.Ptr(ctype))
 
+class LocalMemory(BuiltinFunc):
+
+    def __call__(self, dtype, size, alignment=None):
+        """Allocates local memory and returns it as a 1-D array.
+
+        Args:
+            dtype (dtype):
+                The dtype of the returned array.
+            size (int or None):
+                If ``int`` type, the size of static local memory.
+                If ``None``, declares the local memory with extern specifier.
+            alignment (int or None): Enforce the alignment via __align__(N).
+        """
+        super().__call__()
+
+    def call_const(self, env, dtype, size, alignment=None):
+        name = env.get_fresh_variable_name(prefix='_lmem')
+        ctype = _cuda_typerules.to_ctype(dtype)
+        var = Data(name, _cuda_types.LocalMem(ctype, size, alignment))
+        env.decls[name] = var
+        env.locals[name] = var
+        return Data(name, _cuda_types.Ptr(ctype))
 
 class AtomicOp(BuiltinFunc):
 
@@ -456,6 +478,7 @@ range_ = RangeFunc()
 syncthreads = SyncThreads()
 syncwarp = SyncWarp()
 shared_memory = SharedMemory()
+local_memory = LocalMemory()
 grid = GridFunc('grid')
 gridsize = GridFunc('gridsize')
 laneid = LaneID()

--- a/cupyx/jit/_cuda_types.py
+++ b/cupyx/jit/_cuda_types.py
@@ -243,6 +243,33 @@ class SharedMem(ArrayBase):
             code = f'{code} __shared__ {self.child_type} {x}[{self._size}]'
         return code
 
+class LocalMem(ArrayBase):
+
+    def __init__(
+            self,
+            child_type: TypeBase,
+            size: Optional[int],
+            alignment: Optional[int] = None,
+    ) -> None:
+        if not (isinstance(size, int) or size is None):
+            raise 'size of local_memory must be integer or `None`'
+        if not (isinstance(alignment, int) or alignment is None):
+            raise 'alignment must be integer or `None`'
+        self._size = size
+        self._alignment = alignment
+        super().__init__(child_type, 1)
+
+    def declvar(self, x: str, init: Optional['Data']) -> str:
+        assert init is None
+        if self._alignment is not None:
+            code = f'__align__({self._alignment})'
+        else:
+            code = ''
+        if self._size is None:
+            code = f'extern {code} {self.child_type} {x}[]'
+        else:
+            code = f'{code} {self.child_type} {x}[{self._size}]'
+        return code
 
 class Ptr(PointerBase):
 


### PR DESCRIPTION
This pull request roughly attempts to copy the functionality of creating a local memory array that exists in numba (the function "numba.cuda.local.array(size, dtype)"). This function copies the code from the existing SharedMemory() function in cupy, but in the codegen piece it removes the "\_\_shared\_\_" line to instead have it be a local array. This function can be called using "cupyx.jit.local_memory(dtype, size)"

Here is a piece of code built for the current build of cupy, which demonstrates a locally-specified copy of the local_memory function. By changing the definition of the array "la" in the rawkernel to use either local_memory or shared_memory, it demonstrates the difference by writing to a cell, which another thread attempts to read from.

```
import cupy as cp
from cupyx import jit
from cupyx.jit._cuda_types import ArrayBase, TypeBase
from typing import Optional
from cupyx.jit._internal_types import BuiltinFunc, Data
from cupy_backends.cuda.api import runtime
from cupy.cuda import device
from cupyx.jit import _cuda_types
from cupyx.jit import _compile
import numpy

def to_ctype(t) -> _cuda_types.TypeBase:
    if isinstance(t, _cuda_types.TypeBase):
        return t
    return _cuda_types.Scalar(numpy.dtype(t))

class LocalMem(ArrayBase):

    def __init__(
            self,
            child_type: TypeBase,
            size: Optional[int],
            alignment: Optional[int] = None,
    ) -> None:
        if not (isinstance(size, int) or size is None):
            raise 'size of local_memory must be integer or `None`'
        if not (isinstance(alignment, int) or alignment is None):
            raise 'alignment must be integer or `None`'
        self._size = size
        self._alignment = alignment
        super().__init__(child_type, 1)

    def declvar(self, x: str, init: Optional['Data']) -> str:
        assert init is None
        if self._alignment is not None:
            code = f'__align__({self._alignment})'
        else:
            code = ''
        if self._size is None:
            code = f'extern {code} {self.child_type} {x}[]'
        else:
            code = f'{code} {self.child_type} {x}[{self._size}]'
        return code
    
class LocalMemory(BuiltinFunc):

    def __call__(self, dtype, size, alignment=None):
        """Allocates local memory and returns it as a 1-D array.

        Args:
            dtype (dtype):
                The dtype of the returned array.
            size (int or None):
                If ``int`` type, the size of static local memory.
                If ``None``, declares the local memory with extern specifier.
            alignment (int or None): Enforce the alignment via __align__(N).
        """
        super().__call__()

    def call_const(self, env, dtype, size, alignment=None):
        name = env.get_fresh_variable_name(prefix='_lmem')
        ctype = to_ctype(dtype)
        var = Data(name, LocalMem(ctype, size, alignment))
        env.decls[name] = var
        env.locals[name] = var
        return Data(name, _cuda_types.Ptr(ctype))
    
local_memory = LocalMemory()

cp.cuda.Device(2)

@jit.rawkernel(device=True)
def square(a):
    b = local_memory(int, 2) #also demonstrates local_memory array working in a device function
    b[0] = a
    b[1] = a
    return b[0]*b[1]

@jit.rawkernel()
def elementwise_square_ish(x, y, size):
    tid = jit.grid(1)
    ntid = jit.gridsize(1)
    
    #la = jit.shared_memory(int, 10) #computes x^2+1, because threads can interfere. Might have race conditions.
    la = local_memory(int, 10) #computes x^2, because threads do not interfere.
    la[tid] = 1
    
    for i in range(tid, size, ntid):
        x[i] += la[(i+5)%10] #equals 0 with local mem, if shared mem another thread set this to 1, barring race conditions
        x[i] += square(i)

c = cp.zeros(10, dtype=int)
elementwise_square_ish[1, 10](c, c, 10)
print(c)
```