### PR TITLE
Add debug feature to preloading and softlink

### DIFF
--- a/cupy/_environment.py
+++ b/cupy/_environment.py
@@ -60,12 +60,13 @@ _preload_libs = {
     'cutensor': None,
 }
 
-_preload_logs = []
+_debug = os.environ.get('CUPY_DEBUG_LIBRARY_LOAD', '0') == '1'
 
 
-def _log(msg):
-    # TODO(kmaehashi): replace with the standard logging
-    _preload_logs.append(msg)
+def _log(msg: str) -> None:
+    if _debug:
+        sys.stderr.write(f'[CUPY_DEBUG_LIBRARY_LOAD] {msg}\n')
+        sys.stderr.flush()
 
 
 def get_cuda_path():
@@ -370,10 +371,6 @@ def _preload_library(lib):
                 # Fallback to the standard shared library lookup which only
                 # uses the major version (e.g., `libcudnn.so.X`).
                 _log(f'Library {lib} could not be preloaded: {e}')
-
-
-def _get_preload_logs():
-    return '\n'.join(_preload_logs)
 
 
 def _preload_warning(lib, exc):

--- a/cupy/_environment.py
+++ b/cupy/_environment.py
@@ -290,7 +290,7 @@ def _can_attempt_preload(lib: str) -> bool:
         # Conda-Forge. See here for the configuration files used in
         # Conda-Forge distributions.
         # https://github.com/conda-forge/cupy-feedstock/blob/master/recipe/preload_config/
-        _log(f'Cannot preload {lib} as this is not a wheel installation')
+        _log(f'Not preloading {lib} as this is not a pip wheel installation')
         return False
 
     if lib not in _preload_libs:

--- a/cupy_backends/cuda/_softlink.pxd
+++ b/cupy_backends/cuda/_softlink.pxd
@@ -4,5 +4,6 @@ cdef class SoftLink:
     cdef:
         object error
         str prefix
+        str _libname
         object _cdll
         func_ptr get(self, str name)

--- a/cupy_backends/cuda/_softlink.pyx
+++ b/cupy_backends/cuda/_softlink.pyx
@@ -5,10 +5,16 @@ from libc.stdint cimport intptr_t
 cimport cython
 
 
+def _log(msg: str) -> None:
+    import cupy
+    cupy._environment._log(msg)
+
+
 cdef class SoftLink:
     def __init__(self, object libname, str prefix, *, bint mandatory=False):
         self.error = None
         self.prefix = prefix
+        self._libname = libname
         self._cdll = None
         if libname is None:
             # Stub build or CUDA/HIP only library.
@@ -17,6 +23,7 @@ cdef class SoftLink:
         else:
             try:
                 self._cdll = ctypes.CDLL(libname)
+                _log(f'Library "{libname}" loaded')
             except Exception as e:
                 self.error = e
                 msg = (
@@ -29,13 +36,16 @@ cdef class SoftLink:
         """
         Returns a function pointer for the API.
         """
-        if self._cdll is None:
-            return <func_ptr>_fail_unsupported
         cdef str funcname = f'{self.prefix}{name}'
+        if self._cdll is None:
+            _log(f'[NOTICE] {self._libname} ({funcname}): library not loaded')
+            return <func_ptr>_fail_unsupported
         cdef object func = getattr(self._cdll, funcname, None)
         if func is None:
+            _log(f'[NOTICE] {self._libname} ({funcname}): function not found')
             return <func_ptr>_fail_not_found
         cdef intptr_t ptr = ctypes.addressof(func)
+        _log(f'{self._libname} ({funcname}): function loaded')
         return cython.operator.dereference(<func_ptr*>ptr)
 
 


### PR DESCRIPTION
This PR adds the new environment variable `CUPY_DEBUG_LIBRARY_LOAD` which allows users to diagnose issues related to library load. This was originally proposed in #7929.
