### PR TITLE
Add 2D Delaunay triangulation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,3 @@ htmlcov/
 .pytest_cache/
 cupy/.data/
 cupy/cuda/thrust.h
-.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ htmlcov/
 .pytest_cache/
 cupy/.data/
 cupy/cuda/thrust.h
+.vscode/

--- a/cupyx/scipy/spatial/__init__.py
+++ b/cupyx/scipy/spatial/__init__.py
@@ -1,1 +1,2 @@
 from cupyx.scipy.spatial.distance import distance_matrix   # NOQA
+from cupyx.scipy.spatial._delaunay import Delaunay  # NOQA

--- a/cupyx/scipy/spatial/_delaunay.py
+++ b/cupyx/scipy/spatial/_delaunay.py
@@ -1,0 +1,158 @@
+
+import cupy
+from cupyx.scipy.spatial.delaunay_2d._tri import GDel2D
+
+
+class Delaunay:
+    """
+    Delaunay(points, furthest_site=False, incremental=False)
+
+    Delaunay tessellation in 2 dimensions.
+
+    Parameters
+    ----------
+    points : ndarray of floats, shape (npoints, ndim)
+        Coordinates of points to triangulate
+    furthest_site : bool, optional
+        Whether to compute a furthest-site Delaunay triangulation. This option
+        will be ignored, since it is not supported by CuPy
+        Default: False
+    incremental : bool, optional
+        Allow adding new points incrementally. This takes up some additional
+        resources. This option will be ignored, since it is not supported by
+        CuPy. Default: False
+
+    Attributes
+    ----------
+    points : ndarray of double, shape (npoints, ndim)
+        Coordinates of input points.
+    simplices : ndarray of ints, shape (nsimplex, ndim+1)
+        Indices of the points forming the simplices in the triangulation.
+        For 2-D, the points are oriented counterclockwise.
+    neighbors : ndarray of ints, shape (nsimplex, ndim+1)
+        Indices of neighbor simplices for each simplex.
+        The kth neighbor is opposite to the kth vertex.
+        For simplices at the boundary, -1 denotes no neighbor.0
+    vertex_to_simplex : ndarray of int, shape (npoints,)
+        Lookup array, from a vertex, to some simplex which it is a part of.
+        If qhull option "Qc" was not specified, the list will contain -1
+        for points that are not vertices of the tessellation.
+    convex_hull : ndarray of int, shape (nfaces, ndim)
+        Vertices of facets forming the convex hull of the point set.
+        The array contains the indices of the points belonging to
+        the (N-1)-dimensional facets that form the convex hull
+        of the triangulation.
+
+        .. note::
+
+           Computing convex hulls via the Delaunay triangulation is
+           inefficient and subject to increased numerical instability.
+           Use `ConvexHull` instead.
+    coplanar : ndarray of int, shape (ncoplanar, 3)
+        Indices of coplanar points and the corresponding indices of
+        the nearest facet and the nearest vertex.  Coplanar
+        points are input points which were *not* included in the
+        triangulation due to numerical precision issues.
+
+        If option "Qc" is not specified, this list is not computed.
+
+        .. versionadded:: 0.12.0
+    vertex_neighbor_vertices : tuple of two ndarrays of int; (indptr, indices)
+        Neighboring vertices of vertices. The indices of neighboring
+        vertices of vertex `k` are ``indices[indptr[k]:indptr[k+1]]``.
+    furthest_site
+        True if this was a furthest site triangulation and False if not.
+
+    Notes
+    -----
+    This implementation makes use of GDel2D to perform the triangulation in 2D.
+    See [1]_ for more information.
+
+    References
+    ----------
+    .. [1] A GPU accelerated algorithm for 3D Delaunay triangulation (2014).
+    Thanh-Tung Cao, Ashwin Nanjappa, Mingcen Gao, Tiow-Seng Tan.
+    Proc. 18th ACM SIGGRAPH Symp. Interactive 3D Graphics and Games, 47-55.
+    """
+
+    def __init__(self, points, furthest_site=False, incremental=False):
+        if points.shape[-1] != 2:
+            raise ValueError('Delaunay only supports 2D inputs at the moment.')
+
+        if furthest_site:
+            raise ValueError(
+                'furthest_site argument is not supported by CuPy.')
+
+        if incremental:
+            raise ValueError(
+                'incremental argument is not supported by CuPy.')
+
+        self.points = cupy.array(points, cupy.float64, copy=True)
+        # self._points = cupy.unique(self._points, axis=0)
+        self._triangulator = GDel2D(self.points)
+        self.simplices, self.neighbors = self._triangulator.compute()
+
+    def _find_simplex_coordinates(self, xi, eps, find_coords=False):
+        """
+        Find the simplices containing the given points.
+
+        Parameters
+        ----------
+        xi : ndarray of double, shape (..., ndim)
+            Points to locate
+        eps: float
+            Tolerance allowed in the inside-triangle check.
+        find_coords: bool, optional
+            Whether to return the barycentric coordinates of `xi`
+            with respect to the found simplices.
+
+        Returns
+        -------
+        i : ndarray of int, same shape as `xi`
+            Indices of simplices containing each point.
+            Points outside the triangulation get the value -1.
+        c : ndarray of float64, same shape as `xi`, optional
+            Barycentric coordinates of `xi` with respect to the enclosing
+            simplices. Returned only when `find_coords` is True.
+        """
+        out = cupy.empty((xi.shape[0],), dtype=cupy.int32)
+        c = cupy.empty(0, dtype=cupy.float64)
+        if find_coords:
+            c = cupy.empty((xi.shape[0], xi.shape[-1] + 1), dtype=cupy.float64)
+
+        out, c = self._triangulator.find_point_in_triangulation(
+            xi, eps, find_coords)
+
+        if find_coords:
+            return out, c
+        return out
+
+    def find_simplex(self, xi, bruteforce=False, tol=None):
+        """
+        Find the simplices containing the given points.
+
+        Parameters
+        ----------
+        xi : ndarray of double, shape (..., ndim)
+            Points to locate
+        bruteforce : bool, optional
+            Whether to only perform a brute-force search. Not used by CuPy
+        tol : float, optional
+            Tolerance allowed in the inside-triangle check.
+            Default is ``100*eps``.
+
+        Returns
+        -------
+        i : ndarray of int, same shape as `xi`
+            Indices of simplices containing each point.
+            Points outside the triangulation get the value -1.
+        """
+        if tol is None:
+            eps = 100 * cupy.finfo(cupy.double).eps
+        else:
+            eps = float(tol)
+
+        if xi.shape[-1] != 2:
+            raise ValueError('Delaunay only supports 2D inputs at the moment.')
+
+        return self._find_simplex_coordinates(xi, eps)

--- a/cupyx/scipy/spatial/_triangulation_2d.py
+++ b/cupyx/scipy/spatial/_triangulation_2d.py
@@ -1,0 +1,122 @@
+
+import cupy
+from cupy._core._scalar import get_typename
+from cupy_backends.cuda.api import runtime
+
+# from cupy.cuda import thrust
+
+
+def _get_typename(dtype):
+    typename = get_typename(dtype)
+    if cupy.dtype(dtype).kind == 'c':
+        typename = 'thrust::' + typename
+    elif typename == 'float16':
+        if runtime.is_hip:
+            # 'half' in name_expressions weirdly raises
+            # HIPRTC_ERROR_NAME_EXPRESSION_NOT_VALID in getLoweredName() on
+            # ROCm
+            typename = '__half'
+        else:
+            typename = 'half'
+    return typename
+
+
+def _get_module_func(module, func_name, *template_args):
+    args_dtypes = [_get_typename(arg.dtype) for arg in template_args]
+    template = ', '.join(args_dtypes)
+    kernel_name = f'{func_name}<{template}>' if template_args else func_name
+    kernel = module.get_function(kernel_name)
+    return kernel
+
+
+PREAMBLE_MODULE = r'''
+
+template<typename T>
+__global__ void get_morton_number(
+        const int n_points, const T* points, const T* min_val, const T* range,
+        int* out) {
+
+    int idx = blockDim.x * blockIdx.x + threadIdx.x;
+    const T* point = points + 2 * idx;
+
+    const int Gap08 = 0x00FF00FF;   // Creates 16-bit gap between value bits
+    const int Gap04 = 0x0F0F0F0F;   // ... and so on ...
+    const int Gap02 = 0x33333333;   // ...
+    const int Gap01 = 0x55555555;   // ...
+
+    const int minInt = 0x0;
+    const int maxInt = 0x7FFF;
+
+    int mortonNum = 0;
+
+    // Iterate coordinates of point
+    for ( int vi = 0; vi < 2; ++vi )
+    {
+        // Read
+        int v = int( ( point[ vi ] - min_val[0] ) / range[0] * 32768.0 );
+
+        if ( v < minInt )
+            v = minInt;
+
+        if ( v > maxInt )
+            v = maxInt;
+
+        // Create 1-bit gaps between the 10 value bits
+        // Ex: 1010101010101010101
+        v = ( v | ( v <<  8 ) ) & Gap08;
+        v = ( v | ( v <<  4 ) ) & Gap04;
+        v = ( v | ( v <<  2 ) ) & Gap02;
+        v = ( v | ( v <<  1 ) ) & Gap01;
+
+        // Interleave bits of x-y coordinates
+        mortonNum |= ( v << vi );
+    }
+
+    out[idx] = mortonNum;
+}
+
+'''
+
+_preamble_module = cupy.RawModule(
+    code=PREAMBLE_MODULE, options=('-std=c++11',),
+    name_expressions=[f'get_morton_number<{x}>' for x in ['float', 'double']])
+
+
+def _delaunay_triangulation_2d(points):
+    n_points = points.shape[0] + 1
+    max_triangles = 2 * n_points
+
+    point_vec = cupy.empty((n_points, 2), dtype=points.dtype)
+    point_vec[:-1] = points
+
+    triangles = cupy.empty((max_triangles, 3), dtype=cupy.int32)
+    triangle_opp = cupy.empty_like(triangles)  # NOQA
+    triangle_info = cupy.empty(max_triangles, dtype=cupy.int8)  # NOQA
+    counters = cupy.empty(2, dtype=cupy.int32)  # NOQA
+
+    flip = cupy.empty((max_triangles, 2, 2), dtype=cupy.int32)  # NOQA
+    tri_msg = cupy.empty((max_triangles, 2), dtype=cupy.int32)  # NOQA
+    values = cupy.empty(n_points, dtype=cupy.int32)
+    act_tri = cupy.empty(max_triangles, dtype=cupy.int32)  # NOQA
+    extra1 = cupy.empty(max_triangles, dtype=cupy.int32)  # NOQA
+    extra2 = cupy.empty(max_triangles, dtype=cupy.int32)  # NOQA
+
+    min_val = points.min()
+    max_val = points.max()
+    range_val = max_val - min_val
+
+    # points_idx = cupy.arange(n_points, dtype=cupy.int32)
+    _get_morton_number = _get_module_func(
+        _preamble_module, 'get_morton_number', points)
+
+    breakpoint()
+
+    block_sz = 128
+    n_blocks = (points.shape[0] + block_sz - 1) // block_sz
+    _get_morton_number(
+        (block_sz,), (n_blocks,),
+        (n_points - 1, points, min_val, range_val, values))
+
+    values[-1] = 2 ** 31 - 1
+    points_idx = cupy.argsort(values)
+    point_vec = point_vec[points_idx]

--- a/cupyx/scipy/spatial/delaunay_2d/_kernels.py
+++ b/cupyx/scipy/spatial/delaunay_2d/_kernels.py
@@ -2272,7 +2272,7 @@ kerUpdateVertIdx
 Tri*        triVec,
 int         nTri,
 char*       triInfoArr,
-long long*  orgPointIdx
+int*        orgPointIdx
 )
 {
     for ( int idx = getCurThreadIdx(); idx < nTri; idx += getThreadNum() )

--- a/cupyx/scipy/spatial/delaunay_2d/_kernels.py
+++ b/cupyx/scipy/spatial/delaunay_2d/_kernels.py
@@ -1,0 +1,286 @@
+
+import cupy
+
+
+KERNEL_DIVISION = r"""
+
+#define INLINE_H_D __forceinline__ __device__
+
+struct Point2
+{
+    RealType _p[ 2 ];
+
+    INLINE_H_D bool lessThan( const Point2& pt ) const
+    {
+        if ( _p[0] < pt._p[0] ) return true;
+        if ( _p[0] > pt._p[0] ) return false;
+        if ( _p[1] < pt._p[1] ) return true;
+
+        return false;
+    }
+
+    INLINE_H_D bool operator < ( const Point2& pt ) const
+    {
+        return lessThan( pt );
+    }
+
+    INLINE_H_D bool equals( const Point2& pt ) const
+    {
+        return ( _p[0] == pt._p[0] && _p[1] == pt._p[1] );
+    }
+
+    INLINE_H_D bool operator == ( const Point2& pt ) const
+    {
+        return equals( pt );
+    }
+
+    INLINE_H_D bool operator != ( const Point2& pt ) const
+    {
+        return !equals( pt );
+    }
+};
+
+struct Tri
+{
+    int _v[3];
+
+    INLINE_H_D bool has( int v ) const
+    {
+        return ( _v[0] == v || _v[1] == v || _v[2] == v );
+    }
+
+    INLINE_H_D int getIndexOf( int v ) const
+    {
+        if ( _v[0] == v ) return 0;
+        if ( _v[1] == v ) return 1;
+        if ( _v[2] == v ) return 2;
+
+        return -1;
+    }
+
+    INLINE_H_D bool equals( const Tri& tri ) const
+    {
+        return ( _v[0] == tri._v[0] && _v[1] == tri._v[1] &&
+                 _v[2] == tri._v[2] );
+    }
+
+    INLINE_H_D bool operator == ( const Tri& pt ) const
+    {
+        return equals( pt );
+    }
+
+    INLINE_H_D bool operator != ( const Tri& pt ) const
+    {
+        return !equals( pt );
+    }
+};
+
+INLINE_H_D Tri makeTri( int v0, int v1, int v2 )
+{
+    const Tri newTri = { v0, v1, v2 };
+
+    return newTri;
+}
+
+INLINE_H_D bool isValidTriVi( int vi )
+{
+    return ( vi >= 0 && vi < DEG );
+}
+
+// ...76543210
+//        ^^^^ vi (2 bits)
+//        ||__ constraint
+//        |___ special
+// Rest is triIdx
+
+template< typename T >
+INLINE_H_D bool isBitSet( T c, int bit )
+{
+    return ( 1 == ( ( c >> bit ) & 1 ) );
+}
+
+template< typename T >
+INLINE_H_D void setBitState( T& c, int bit, bool state )
+{
+    const T val = ( 1 << bit );
+    c = state
+        ? ( c | val )
+        : ( c & ~val );
+}
+
+// Get the opp tri and vi
+// Retain some states: constraint
+// Clear some states:  special
+INLINE_H_D int getOppValTriVi( int val )
+{
+    return ( val & ~0x08 );
+}
+
+INLINE_H_D int getOppValTri( int val )
+{
+    return (val >> 4);
+}
+
+INLINE_H_D int getOppValVi( int val )
+{
+    return (val & 3);
+}
+
+INLINE_H_D bool isOppValConstraint( int val )
+{
+    return isBitSet( val, 2 );
+}
+
+INLINE_H_D void setOppValTri( int &val, int idx )
+{
+    val = (val & 0x0F) | (idx << 4);
+}
+
+// Set the opp tri and vi
+// Retain some states: constraint
+// Clear some states:  special
+INLINE_H_D void setOppValTriVi( int &val, int idx, int vi )
+{
+    val = (idx << 4) | (val & 0x04) | vi;
+}
+
+INLINE_H_D int getTriIdx( int input, int oldVi )
+{
+    int idxVi = ( input >> (oldVi * 4) ) & 0xf;
+
+    return ( idxVi >> 2 ) & 0x3;
+}
+
+INLINE_H_D int getTriVi( int input, int oldVi )
+{
+    int idxVi = ( input >> (oldVi * 4) ) & 0xf;
+
+    return idxVi & 0x3;
+}
+
+struct TriOpp
+{
+    int _t[3];
+
+    INLINE_H_D void setOpp( int vi, int triIdx, int oppTriVi )
+    {
+        _t[ vi ] = ( triIdx << 4 ) | oppTriVi;
+    }
+
+    INLINE_H_D void setOpp(
+            int vi, int triIdx, int oppTriVi, bool isConstraint )
+    {
+        _t[ vi ] = ( triIdx << 4 ) | ( isConstraint << 2 ) | oppTriVi;
+    }
+
+    INLINE_H_D void setOppTriVi( int vi, int triIdx, int oppTriVi )
+    {
+        setOppValTriVi( _t[ vi ], triIdx, oppTriVi );
+    }
+
+    INLINE_H_D void setOppConstraint( int vi, bool val )
+    {
+        setBitState( _t[ vi ], 2, val );
+    }
+
+    INLINE_H_D void setOppSpecial( int vi, bool state )
+    {
+        setBitState( _t[ vi ], 3, state );
+    }
+
+    INLINE_H_D bool isNeighbor( int triIdx ) const
+    {
+        return ( (_t[0] >> 4) == triIdx ||
+                 (_t[1] >> 4) == triIdx ||
+                 (_t[2] >> 4) == triIdx );
+    }
+
+    INLINE_H_D int getIdxOf( int triIdx ) const
+    {
+        if ( ( _t[0] >> 4 ) == triIdx ) return 0;
+        if ( ( _t[1] >> 4 ) == triIdx ) return 1;
+        if ( ( _t[2] >> 4 ) == triIdx ) return 2;
+        return -1;
+    }
+
+    INLINE_H_D bool isOppSpecial( int vi ) const
+    {
+        return isBitSet( _t[ vi ], 3 );
+    }
+
+    INLINE_H_D int getOppTriVi( int vi ) const
+    {
+        if ( -1 == _t[ vi ] )
+            return -1;
+
+        return getOppValTriVi( _t[ vi ] );
+    }
+
+    INLINE_H_D bool isOppConstraint( int vi ) const
+    {
+        return isOppValConstraint( _t[ vi ] );
+    }
+
+    INLINE_H_D int getOppTri( int vi ) const
+    {
+        return getOppValTri( _t[ vi ] );
+    }
+
+    INLINE_H_D void setOppTri( int vi, int idx )
+    {
+        return setOppValTri( _t[ vi ], idx );
+    }
+
+    INLINE_H_D int getOppVi( int vi ) const
+    {
+        return getOppValVi( _t[ vi ] );
+    }
+};
+
+__global__ void kerMakeFirstTri
+(
+Tri*	triArr,
+TriOpp*	oppArr,
+char*	triInfoArr,
+Tri     tri,
+int     infIdx
+)
+{
+    const Tri tris[] = {
+        { tri._v[0], tri._v[1], tri._v[2] },
+        { tri._v[2], tri._v[1], infIdx },
+        { tri._v[0], tri._v[2], infIdx },
+        { tri._v[1], tri._v[0], infIdx }
+    };
+
+    const int oppTri[][3] = {
+        { 1, 2, 3 },
+        { 3, 2, 0 },
+        { 1, 3, 0 },
+        { 2, 1, 0 }
+    };
+
+    const int oppVi[][4] = {
+        { 2, 2, 2 },
+        { 1, 0, 0 },
+        { 1, 0, 1 },
+        { 1, 0, 2 }
+    };
+
+    for ( int i = 0; i < 4; ++i )
+    {
+        triArr[ i ]     = tris[ i ];
+        triInfoArr[ i ] = 1;
+
+        TriOpp opp = { -1, -1, -1 };
+
+        for ( int j = 0; j < 3; ++j )
+            opp.setOpp( j, oppTri[i][j], oppVi[i][j] );
+
+        oppArr[ i ] = opp;
+    }
+}
+"""
+
+DELAUNAY_MODULE = cupy.RawModule(code=KERNEL_DIVISION, options=('-std=c++11',),
+                                 name_expressions=['kerMakeFirstTri'])

--- a/cupyx/scipy/spatial/delaunay_2d/_kernels.py
+++ b/cupyx/scipy/spatial/delaunay_2d/_kernels.py
@@ -5,6 +5,10 @@ import cupy
 KERNEL_DIVISION = r"""
 
 #define INLINE_H_D __forceinline__ __device__
+#define DIM     2
+#define DEG     ( DIM + 1 )
+
+using RealType = double;
 
 struct Point2
 {
@@ -242,10 +246,12 @@ __global__ void kerMakeFirstTri
 Tri*	triArr,
 TriOpp*	oppArr,
 char*	triInfoArr,
-Tri     tri,
+Tri*     initTri,
 int     infIdx
 )
 {
+    Tri tri = initTri[0];
+
     const Tri tris[] = {
         { tri._v[0], tri._v[1], tri._v[2] },
         { tri._v[2], tri._v[1], infIdx },
@@ -284,3 +290,9 @@ int     infIdx
 
 DELAUNAY_MODULE = cupy.RawModule(code=KERNEL_DIVISION, options=('-std=c++11',),
                                  name_expressions=['kerMakeFirstTri'])
+
+
+def make_first_tri(tri_arr, opp_arr, tri_info_arr, tri, inf_idx):
+    ker_make_first_tri = DELAUNAY_MODULE.get_function('kerMakeFirstTri')
+    ker_make_first_tri(
+        (1,), (1,), (tri_arr, opp_arr, tri_info_arr, tri, inf_idx))

--- a/cupyx/scipy/spatial/delaunay_2d/_kernels.py
+++ b/cupyx/scipy/spatial/delaunay_2d/_kernels.py
@@ -1772,11 +1772,17 @@ int2*       triMsgArr,
 int*        actTriArr,
 FlipItem*   flipArr,
 int         orgFlipNum,
-int         actTriNum
+int         actTriNum,
+int         useActTri
 )
 {
     int*        triConsArr = NULL;
     int*        vertTriArr = NULL;
+
+    if(!useActTri) {
+        actTriArr = NULL;
+    }
+
     // Iterate flips
     for ( int flipIdx = getCurThreadIdx(); flipIdx < nFlip;
           flipIdx += getThreadNum() )
@@ -2521,11 +2527,11 @@ def mark_rejected_flips(act_tri, tri_opp, tri_vote, tri_info,
 
 
 def flip(flip_to_tri, tri, tri_opp, tri_info, tri_msg, act_tri, flip_arr,
-         org_flip_num, act_tri_num):
+         org_flip_num, act_tri_num, mode):
     ker_flip = DELAUNAY_MODULE.get_function('kerFlip')
     ker_flip((N_BLOCKS,), (32,), (
         flip_to_tri, flip_to_tri.shape[0], tri, tri_opp, tri_info,
-        tri_msg, act_tri, flip_arr, org_flip_num, act_tri_num))
+        tri_msg, act_tri, flip_arr, org_flip_num, act_tri_num, mode))
 
 
 def update_opp(flip_vec, tri_opp, tri_msg, flip_to_tri,

--- a/cupyx/scipy/spatial/delaunay_2d/_schewchuk.py
+++ b/cupyx/scipy/spatial/delaunay_2d/_schewchuk.py
@@ -1,0 +1,152 @@
+
+import cupy
+
+SCHEWCHUK_DEF = r"""
+
+*****************************************************************************/
+/*                                                                           */
+/*  Routines for Arbitrary Precision Floating-point Arithmetic               */
+/*  and Fast Robust Geometric Predicates                                     */
+/*  (predicates.c)                                                           */
+/*                                                                           */
+/*  May 18, 1996                                                             */
+/*                                                                           */
+/*  Placed in the public domain by                                           */
+/*  Jonathan Richard Shewchuk                                                */
+/*  School of Computer Science                                               */
+/*  Carnegie Mellon University                                               */
+/*  5000 Forbes Avenue                                                       */
+/*  Pittsburgh, Pennsylvania  15213-3891                                     */
+/*  jrs@cs.cmu.edu                                                           */
+/*                                                                           */
+/*  This file contains C implementation of algorithms for exact addition     */
+/*    and multiplication of floating-point numbers, and predicates for       */
+/*    robustly performing the orientation and incircle tests used in         */
+/*    computational geometry.  The algorithms and underlying theory are      */
+/*    described in Jonathan Richard Shewchuk.  "Adaptive Precision Floating- */
+/*    Point Arithmetic and Fast Robust Geometric Predicates."  Technical     */
+/*    Report CMU-CS-96-140, School of Computer Science, Carnegie Mellon      */
+/*    University, Pittsburgh, Pennsylvania, May 1996.  (Submitted to         */
+/*    Discrete & Computational Geometry.)                                    */
+/*                                                                           */
+/*  This file, the paper listed above, and other information are available   */
+/*    from the Web page http://www.cs.cmu.edu/~quake/robust.html .           */
+/*                                                                           */
+/*****************************************************************************/
+
+#define Absolute(a) fabs(a)
+#define MUL(a,b)    __dmul_rn(a,b)
+using RealType = double;
+
+/*****************************************************************************/
+/*                                                                           */
+/*  exactinit()   Initialize the variables used for exact arithmetic.        */
+/*                                                                           */
+/*  `epsilon' is the largest power of two such that 1.0 + epsilon = 1.0 in   */
+/*  floating-point arithmetic.  `epsilon' bounds the relative roundoff       */
+/*  error.  It is used for floating-point error analysis.                    */
+/*                                                                           */
+/*  `splitter' is used to split floating-point numbers into two half-        */
+/*  length significands for exact multiplication.                            */
+/*                                                                           */
+/*  I imagine that a highly optimizing compiler might be too smart for its   */
+/*  own good, and somehow cause this routine to fail, if it pretends that    */
+/*  floating-point arithmetic is too much like real arithmetic.              */
+/*                                                                           */
+/*  Don't change this routine unless you fully understand it.                */
+/*                                                                           */
+/*****************************************************************************/
+
+
+enum DPredicateBounds
+{
+    Splitter,       /* = 2^ceiling(p / 2) + 1.  Used to split floats in half.*/
+    Epsilon,        /* = 2^(-p).  Used to estimate roundoff errors. */
+
+    /* A set of coefficients used to calculate maximum roundoff errors.      */
+    Resulterrbound,
+    CcwerrboundA,
+    CcwerrboundB,
+    CcwerrboundC,
+    O3derrboundA,
+    O3derrboundB,
+    O3derrboundC,
+    IccerrboundA,
+    IccerrboundB,
+    IccerrboundC,
+    IsperrboundA,
+    IsperrboundB,
+    IsperrboundC,
+    O3derrboundAlifted,
+    O2derrboundAlifted,
+    O1derrboundAlifted,
+
+    DPredicateBoundNum  // Number of bounds in this enum
+};
+
+__global__ void kerInitPredicate( RealType* predConsts )
+{
+    RealType half;
+    RealType epsilon, splitter;
+    RealType check, lastcheck;
+    int every_other;
+
+    every_other = 1;
+    half        = 0.5;
+    epsilon     = 1.0;
+    splitter    = 1.0;
+    check       = 1.0;
+
+    /* Repeatedly divide `epsilon' by two until it is too small to add to    */
+    /*   one without causing roundoff.  (Also check if the sum is equal to   */
+    /*   the previous sum, for machines that round up instead of using exact */
+    /*   rounding.  Not that this library will work on such machines anyway. */
+    do
+    {
+        lastcheck   = check;
+        epsilon     *= half;
+
+        if (every_other)
+        {
+            splitter *= 2.0;
+        }
+
+        every_other = !every_other;
+        check       = 1.0 + epsilon;
+    } while ((check != 1.0) && (check != lastcheck));
+
+    /* Error bounds for orientation and incircle tests. */
+    predConsts[ Epsilon ]           = epsilon;
+    predConsts[ Splitter ]          = splitter + 1.0;
+    predConsts[ Resulterrbound ]    = (3.0 + 8.0 * epsilon) * epsilon;
+    predConsts[ CcwerrboundA ]      = (3.0 + 16.0 * epsilon) * epsilon;
+    predConsts[ CcwerrboundB ]      = (2.0 + 12.0 * epsilon) * epsilon;
+    predConsts[ CcwerrboundC ]    = (9.0 + 64.0 * epsilon) * epsilon * epsilon;
+    predConsts[ O3derrboundA ]      = (7.0 + 56.0 * epsilon) * epsilon;
+    predConsts[ O3derrboundB ]      = (3.0 + 28.0 * epsilon) * epsilon;
+    predConsts[ O3derrboundC ]  = (26.0 + 288.0 * epsilon) * epsilon * epsilon;
+    predConsts[ IccerrboundA ]      = (10.0 + 96.0 * epsilon) * epsilon;
+    predConsts[ IccerrboundB ]      = (4.0 + 48.0 * epsilon) * epsilon;
+    predConsts[ IccerrboundC ]  = (44.0 + 576.0 * epsilon) * epsilon * epsilon;
+    predConsts[ IsperrboundA ]      = (16.0 + 224.0 * epsilon) * epsilon;
+    predConsts[ IsperrboundB ]      = (5.0 + 72.0 * epsilon) * epsilon;
+    predConsts[ IsperrboundC ] = (71.0 + 1408.0 * epsilon) * epsilon * epsilon;
+    predConsts[ O3derrboundAlifted ] = (11.0 + 112.0 * epsilon) * epsilon;
+        //(10.0 + 112.0 * epsilon) * epsilon;
+    predConsts[ O2derrboundAlifted ]= (6.0 + 48.0 * epsilon) * epsilon;
+    predConsts[ O1derrboundAlifted ]= (3.0 + 16.0 * epsilon) * epsilon;
+
+    return;
+}
+
+"""
+
+
+SCHEWCHUK_MODULE = cupy.RawModule(
+    code=SCHEWCHUK_DEF, options=('-std=c++11',),
+    name_expressions=['kerInitPredicate'])
+
+
+def init_predicate(pred_values):
+    ker_init_predicate = SCHEWCHUK_MODULE.get_function('kerInitPredicate')
+    ker_init_predicate((1,), (1,), (pred_values))

--- a/cupyx/scipy/spatial/delaunay_2d/_schewchuk.py
+++ b/cupyx/scipy/spatial/delaunay_2d/_schewchuk.py
@@ -1,6 +1,4 @@
 
-import cupy
-
 SCHEWCHUK_DEF = r"""
 
 /*****************************************************************************/
@@ -1140,13 +1138,3 @@ bool            lifted
 }
 
 """
-
-
-SCHEWCHUK_MODULE = cupy.RawModule(
-    code=SCHEWCHUK_DEF, options=('-std=c++11', '-w'),
-    name_expressions=['kerInitPredicate'])
-
-
-def init_predicate(pred_values):
-    ker_init_predicate = SCHEWCHUK_MODULE.get_function('kerInitPredicate')
-    ker_init_predicate((1,), (1,), (pred_values))

--- a/cupyx/scipy/spatial/delaunay_2d/_schewchuk.py
+++ b/cupyx/scipy/spatial/delaunay_2d/_schewchuk.py
@@ -3,7 +3,7 @@ import cupy
 
 SCHEWCHUK_DEF = r"""
 
-*****************************************************************************/
+/*****************************************************************************/
 /*                                                                           */
 /*  Routines for Arbitrary Precision Floating-point Arithmetic               */
 /*  and Fast Robust Geometric Predicates                                     */

--- a/cupyx/scipy/spatial/delaunay_2d/_tri.py
+++ b/cupyx/scipy/spatial/delaunay_2d/_tri.py
@@ -4,6 +4,7 @@ from cupy._core._scalar import get_typename
 from cupy_backends.cuda.api import runtime
 
 from cupyx.scipy.spatial.delaunay_2d._schewchuk import init_predicate
+from cupyx.scipy.spatial.delaunay_2d._kernels import make_first_tri
 
 
 def _get_typename(dtype):
@@ -158,7 +159,7 @@ def _delaunay_triangulation_2d(points):
     triangles = cupy.empty((max_triangles, 3), dtype=cupy.int32)
     triangle_opp = cupy.empty_like(triangles)  # NOQA
     triangle_info = cupy.empty(max_triangles, dtype=cupy.int8)  # NOQA
-    counters = cupy.empty(2, dtype=cupy.int32)  # NOQA
+    counters = cupy.zeros(2, dtype=cupy.int32)  # NOQA
 
     flip = cupy.empty((max_triangles, 2, 2), dtype=cupy.int32)  # NOQA
     tri_msg = cupy.empty((max_triangles, 2), dtype=cupy.int32)  # NOQA
@@ -218,3 +219,7 @@ def _delaunay_triangulation_2d(points):
 
     pred_consts = cupy.empty(18, cupy.float64)
     init_predicate(pred_consts)
+
+    first_tri = cupy.r_[v0, v1, v2].astype(cupy.int32)
+    make_first_tri(triangles, triangle_opp, triangle_info,
+                   first_tri, n_points - 1)

--- a/cupyx/scipy/spatial/delaunay_2d/_tri.py
+++ b/cupyx/scipy/spatial/delaunay_2d/_tri.py
@@ -3,6 +3,8 @@ import cupy
 from cupy._core._scalar import get_typename
 from cupy_backends.cuda.api import runtime
 
+from cupyx.scipy.spatial.delaunay_2d._schewchuk import init_predicate
+
 
 def _get_typename(dtype):
     typename = get_typename(dtype)
@@ -213,3 +215,6 @@ def _delaunay_triangulation_2d(points):
 
     # Compute the centroid of v0 v1 v2, to be used as the kernel point.
     point_vec[-1] = point_vec[[v0, v1, v2]].mean(0)
+
+    pred_consts = cupy.empty(18, cupy.float64)
+    init_predicate(pred_consts)

--- a/tests/cupyx_tests/scipy_tests/spatial_tests/test_delaunay.py
+++ b/tests/cupyx_tests/scipy_tests/spatial_tests/test_delaunay.py
@@ -1,0 +1,91 @@
+
+from cupy import testing
+
+import cupy  # NOQA
+import cupyx.scipy.spatial  # NOQA
+
+import pytest
+import numpy as np
+
+try:
+    import scipy.spatial  # NOQA
+except ImportError:
+    pass
+
+
+pathological_data_1 = np.array([
+    [-3.14, -3.14], [-3.14, -2.36], [-3.14, -1.57], [-3.14, -0.79],
+    [-3.14, 0.0], [-3.14, 0.79], [-3.14, 1.57], [-3.14, 2.36],
+    [-3.14, 3.14], [-2.36, -3.14], [-2.36, -2.36], [-2.36, -1.57],
+    [-2.36, -0.79], [-2.36, 0.0], [-2.36, 0.79], [-2.36, 1.57],
+    [-2.36, 2.36], [-2.36, 3.14], [-1.57, -0.79], [-1.57, 0.79],
+    [-1.57, -1.57], [-1.57, 0.0], [-1.57, 1.57], [-1.57, -3.14],
+    [-1.57, -2.36], [-1.57, 2.36], [-1.57, 3.14], [-0.79, -1.57],
+    [-0.79, 1.57], [-0.79, -3.14], [-0.79, -2.36], [-0.79, -0.79],
+    [-0.79, 0.0], [-0.79, 0.79], [-0.79, 2.36], [-0.79, 3.14],
+    [0.0, -3.14], [0.0, -2.36], [0.0, -1.57], [0.0, -0.79], [0.0, 0.0],
+    [0.0, 0.79], [0.0, 1.57], [0.0, 2.36], [0.0, 3.14], [0.79, -3.14],
+    [0.79, -2.36], [0.79, -0.79], [0.79, 0.0], [0.79, 0.79],
+    [0.79, 2.36], [0.79, 3.14], [0.79, -1.57], [0.79, 1.57],
+    [1.57, -3.14], [1.57, -2.36], [1.57, 2.36], [1.57, 3.14],
+    [1.57, -1.57], [1.57, 0.0], [1.57, 1.57], [1.57, -0.79],
+    [1.57, 0.79], [2.36, -3.14], [2.36, -2.36], [2.36, -1.57],
+    [2.36, -0.79], [2.36, 0.0], [2.36, 0.79], [2.36, 1.57],
+    [2.36, 2.36], [2.36, 3.14], [3.14, -3.14], [3.14, -2.36],
+    [3.14, -1.57], [3.14, -0.79], [3.14, 0.0], [3.14, 0.79],
+    [3.14, 1.57], [3.14, 2.36], [3.14, 3.14],
+])
+
+pathological_data_2 = np.array([
+    [-1, -1], [-1, 0], [-1, 1],
+    [0, -1], [0, 0], [0, 1],
+    [1, -1 - np.finfo(np.float64).eps], [1, 0], [1, 1],
+])
+
+
+class TestDelaunay:
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_2d_triangulation(self, xp, scp):
+        points = testing.shaped_random((100, 2), xp, xp.float64)
+        tri = scp.spatial.Delaunay(points)
+        return xp.sort(xp.sort(tri.simplices, axis=-1), axis=0)
+
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_2d_square(self, xp, scp):
+        # simple smoke test: 2d square
+        points = xp.array([(0, 0), (0, 1), (1, 1), (1, 0)], dtype=xp.float64)
+        tri = scp.spatial.Delaunay(points)
+        return xp.sort(xp.sort(tri.simplices, axis=-1), axis=0)
+
+    @pytest.mark.parametrize(
+        'dataset', [pathological_data_1, pathological_data_2])
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_pathological(self, dataset, xp, scp):
+        points = xp.asarray(dataset, dtype=xp.float64)
+        tri = scp.spatial.Delaunay(points)
+        return points[tri.simplices].max(), points[tri.simplices].min()
+
+    @pytest.mark.parametrize('mod', [(cupy, cupyx.scipy), (np, scipy)])
+    def test_duplicate_points(self, mod):
+        xp, scp = mod
+        x = xp.array([0, 1, 0, 1], dtype=xp.float64)
+        y = xp.array([0, 0, 1, 1], dtype=xp.float64)
+
+        x_p = xp.r_[x, x]
+        y_p = xp.r_[y, y]
+
+        scp.spatial.Delaunay(xp.c_[x, y])
+        scp.spatial.Delaunay(xp.c_[x_p, y_p])
+
+    @pytest.mark.parametrize(
+        'point', [(0.25, 0.5), (0.5, 0.25), (0.75, 0.5), (0.5, 0.75)])
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_find_simplex(self, point, xp, scp):
+        points = xp.array([(0, 0), (0, 1), (1, 1), (1, 0), (0.5, 0.5)],
+                          dtype=xp.float64)
+        tri = scp.spatial.Delaunay(points)
+
+        search_point = xp.asarray([point], dtype=xp.float64)
+        tri_index = tri.find_simplex(search_point)
+        triangle = tri.simplices[tri_index]
+        return xp.sort(triangle)


### PR DESCRIPTION
This PR intends to add a two dimensional Delaunay triangulation in the `cupyx.scipy.spatial` namespace. This is required as part of https://github.com/cupy/cupy/issues/7186, where some interpolants such as `CloughTocher2DInterpolator` require them.

This implementation is derived from https://doi.org/10.1145/2556700.2556710, where the implementation is reduced from 3D to 2D.