### PR TITLE
Use modern dlpack interface in torch interoperability document

### DIFF
--- a/docs/source/user_guide/interoperability.rst
+++ b/docs/source/user_guide/interoperability.rst
@@ -155,20 +155,16 @@ PyTorch also supports zero-copy data exchange through ``DLPack`` (see :ref:`dlpa
 	import cupy
 	import torch
 
-	from torch.utils.dlpack import to_dlpack
 	from torch.utils.dlpack import from_dlpack
 
 	# Create a PyTorch tensor.
 	tx1 = torch.randn(1, 2, 3, 4).cuda()
 
-	# Convert it into a DLPack tensor.
-	dx = to_dlpack(tx1)
-
 	# Convert it into a CuPy array.
-	cx = cupy.from_dlpack(dx)
+	cx = cupy.from_dlpack(tx1)
 
 	# Convert it back to a PyTorch tensor.
-	tx2 = from_dlpack(cx.toDlpack())
+	tx2 = from_dlpack(cx)
 
 `pytorch-pfn-extras <https://github.com/pfnet/pytorch-pfn-extras/>`_ library provides additional integration features with PyTorch, including memory pool sharing and stream sharing:
 

--- a/docs/source/user_guide/interoperability.rst
+++ b/docs/source/user_guide/interoperability.rst
@@ -155,7 +155,7 @@ PyTorch also supports zero-copy data exchange through ``DLPack`` (see :ref:`dlpa
 	import cupy
 	import torch
 
-	from torch.utils.dlpack import from_dlpack
+	from torch import from_dlpack
 
 	# Create a PyTorch tensor.
 	tx1 = torch.randn(1, 2, 3, 4).cuda()

--- a/docs/source/user_guide/interoperability.rst
+++ b/docs/source/user_guide/interoperability.rst
@@ -155,8 +155,6 @@ PyTorch also supports zero-copy data exchange through ``DLPack`` (see :ref:`dlpa
 	import cupy
 	import torch
 
-	from torch import from_dlpack
-
 	# Create a PyTorch tensor.
 	tx1 = torch.randn(1, 2, 3, 4).cuda()
 
@@ -164,7 +162,7 @@ PyTorch also supports zero-copy data exchange through ``DLPack`` (see :ref:`dlpa
 	cx = cupy.from_dlpack(tx1)
 
 	# Convert it back to a PyTorch tensor.
-	tx2 = from_dlpack(cx)
+	tx2 = torch.from_dlpack(cx)
 
 `pytorch-pfn-extras <https://github.com/pfnet/pytorch-pfn-extras/>`_ library provides additional integration features with PyTorch, including memory pool sharing and stream sharing:
 


### PR DESCRIPTION
Because old interface is removed in numpy and sometime breaks compatibility of numpy and cupy
```
>>> t = torch.rand(10, 10)
>>> numpy.from_dlpack(to_dlpack(t))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: type object 'PyCapsule' has no attribute '__dlpack__'
```