### PR TITLE
Bump supported NumPy & SciPy versions

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,5 +4,5 @@ pydata_sphinx_theme==0.11.0
 sphinx-copybutton==0.5.1
 
 # These requirements must match with the Baseline API version documented in the Installation Guide.
-numpy==1.24.*
-scipy==1.10.*
+numpy==1.26.*
+scipy==1.11.*

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -23,7 +23,7 @@ Requirements
 Python Dependencies
 ~~~~~~~~~~~~~~~~~~~
 
-NumPy/SciPy-compatible API in CuPy v12 is based on NumPy 1.24 and SciPy 1.10, and has been tested against the following versions:
+NumPy/SciPy-compatible API in CuPy v12 is based on NumPy 1.26 and SciPy 1.11, and has been tested against the following versions:
 
 * `NumPy <https://numpy.org/>`_: v1.22 / v1.23 / v1.24 / v1.25 / v1.26
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -25,9 +25,9 @@ Python Dependencies
 
 NumPy/SciPy-compatible API in CuPy v12 is based on NumPy 1.24 and SciPy 1.10, and has been tested against the following versions:
 
-* `NumPy <https://numpy.org/>`_: v1.22 / v1.23 / v1.24
+* `NumPy <https://numpy.org/>`_: v1.22 / v1.23 / v1.24 / v1.25 / v1.26
 
-* `SciPy <https://scipy.org/>`_ (*optional*): v1.7 / v1.8 / v1.9 / v1.10
+* `SciPy <https://scipy.org/>`_ (*optional*): v1.7 / v1.8 / v1.9 / v1.10 / v1.11
 
     * Required only when coping sparse matrices from GPU to CPU (see :doc:`../reference/scipy_sparse`.)
 

--- a/setup.py
+++ b/setup.py
@@ -23,12 +23,12 @@ setup_requires = [
     'fastrlock>=0.5',
 ]
 install_requires = [
-    'numpy>=1.22,<1.27',  # see #4773
+    'numpy>=1.22,<1.29',  # see #4773
     'fastrlock>=0.5',
 ]
 extras_require = {
     'all': [
-        'scipy>=1.7,<1.13',  # see #4773
+        'scipy>=1.7,<1.14',  # see #4773
         'Cython>=0.29.22,<3',
         'optuna>=2.0',
     ],


### PR DESCRIPTION
Part of #7616 and #7664
