### PR TITLE
Add lazy load for `cupyx.lapack`

### DIFF
--- a/cupyx/__init__.py
+++ b/cupyx/__init__.py
@@ -22,3 +22,12 @@ from cupyx._pinned_array import zeros_pinned  # NOQA
 from cupyx._pinned_array import zeros_like_pinned  # NOQA
 
 from cupyx._gufunc import GeneralizedUFunc  # NOQA
+
+
+def __getattr__(key):
+    if key == 'lapack':
+        import cupyx.lapack
+        return cupyx.lapack
+
+    raise AttributeError(
+        "module '{}' has no attribute '{}'".format(__name__, key))


### PR DESCRIPTION
Fixes an regression in #7921 (https://github.com/cupy/cupy/pull/7921/files#diff-7713c972868d47b980b78c3d42e87accb70ae862be91b32506e7f7bb4d43b951L12)
Closes #7967.
