### PR TITLE
Fix issues with the initial state when a SOS filter has no IIR part

### DIFF
--- a/cupyx/scipy/signal/_signaltools.py
+++ b/cupyx/scipy/signal/_signaltools.py
@@ -1549,6 +1549,7 @@ def sosfilt_zi(sos):
         # Take the difference between the non-adjusted output values and
         # compute which initial output state would cause them to be constant.
         y_zi = cupy.linalg.solve(C1 - C2, y2 - y1)
+        y_zi = cupy.nan_to_num(y_zi, nan=0, posinf=cupy.inf, neginf=-cupy.inf)
         zi_s[0, 2:] = y_zi
         x_s, _ = sosfilt(sos_s, x_s, zi=zi_s)
 


### PR DESCRIPTION
Fixes https://github.com/cupy/cupy/issues/7990

The issue presented by the OP raised some NaN values, which were caused when `sosfilt_zi` tried to solve the equation `0x = 0`, which was due to a lack of IIR coefficients in the example `bessel` filter. This change is analogous to this call in `lfilter`:  https://github.com/cupy/cupy/blob/ff9b39bb107864f086b7a049562d4d48a9720834/cupyx/scipy/signal/_signaltools.py#L930