### PR TITLE
[v12] Filter DeprecationWarning for distutils.dep_util used in Cython

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ filterwarnings =
     error::numpy.ComplexWarning
     # distutils (Python 3.10)
     ignore:The distutils(.+) is deprecated:DeprecationWarning
+    ignore:dep_util is Deprecated:DeprecationWarning
     # pkg_resources
     ignore::DeprecationWarning:pkg_resources
     ignore:pkg_resources is deprecated


### PR DESCRIPTION
Backport of https://github.com/cupy/cupy/commit/822361561c (#7666).

