### PR TITLE
Support for break and continue keywords

### DIFF
--- a/cupyx/jit/_compile.py
+++ b/cupyx/jit/_compile.py
@@ -664,9 +664,9 @@ def _transpile_stmt(
     if isinstance(stmt, ast.Pass):
         return [';']
     if isinstance(stmt, ast.Break):
-        raise NotImplementedError('Not implemented.')
+        return ['break;']
     if isinstance(stmt, ast.Continue):
-        raise NotImplementedError('Not implemented.')
+        return ['continue;']
     assert False
 
 

--- a/tests/cupyx_tests/jit_tests/test_raw.py
+++ b/tests/cupyx_tests/jit_tests/test_raw.py
@@ -287,7 +287,7 @@ class TestRaw:
             f((1,), (32,), (x, mask))
             y[:mask] += 1
             assert bool((x == y).all())
-            
+
     def test_loop_continue(self):
         @jit.rawkernel()
         def f(x, y, z):
@@ -323,7 +323,7 @@ class TestRaw:
         assert bool((x == 40).all())
         assert bool((y == 39).all())
         assert bool((z == 38).all())
-        
+
     def test_loop_break(self):
         @jit.rawkernel()
         def f(x, y, z):

--- a/tests/cupyx_tests/jit_tests/test_raw.py
+++ b/tests/cupyx_tests/jit_tests/test_raw.py
@@ -317,13 +317,10 @@ class TestRaw:
         x = cupy.zeros(32, dtype=int)
         y = cupy.zeros(32, dtype=int)
         z = cupy.zeros(32, dtype=int)
-        expected_x = cupy.zeros(32, dtype=int)+40
-        expected_y = cupy.zeros(32, dtype=int)+39
-        expected_z = cupy.zeros(32, dtype=int)+38
         f[1, 32](x, y, z)
-        assert bool((x == expected_x).all())
-        assert bool((y == expected_y).all())
-        assert bool((z == expected_z).all())
+        assert bool((x == 40).all())
+        assert bool((y == 39).all())
+        assert bool((z == 38).all())
         
     def test_loop_break():
         @jit.rawkernel()

--- a/tests/cupyx_tests/jit_tests/test_raw.py
+++ b/tests/cupyx_tests/jit_tests/test_raw.py
@@ -288,9 +288,9 @@ class TestRaw:
             y[:mask] += 1
             assert bool((x == y).all())
             
-    def test_break_and_continue():
+    def test_loop_continue():
         @jit.rawkernel()
-        def f(w, x, y, z):
+        def f(x, y, z):
             tid = jit.grid(1)
             ntid = jit.gridsize(1)
 
@@ -298,41 +298,66 @@ class TestRaw:
                 #adds 0-9, except for 5. Sum is 40
                 if(i == 5):
                     continue
-                w[tid] += i
-                
+                x[tid] += i
+
             i2 = 0
             while (i2 < 9):
                 #adds 1-9 in a while loop, except for 6, should equal 39
                 i2 += 1
                 if(i2 == 6):
                     continue
-                x[tid] += i2
-                
+                y[tid] += i2
+
+            for i in range(11):
+                #adds 0-10, but skips if the sum is greater than 3*i, skips 8 and 9, but not 10 (28 < 3*10), sum is 38
+                if(z[tid] > 3*i):
+                    continue
+                z[tid] += i
+
+        x = cupy.zeros(32, dtype=int)
+        y = cupy.zeros(32, dtype=int)
+        z = cupy.zeros(32, dtype=int)
+        expected_x = cupy.zeros(32, dtype=int)+40
+        expected_y = cupy.zeros(32, dtype=int)+39
+        expected_z = cupy.zeros(32, dtype=int)+38
+        f[1, 32](x, y, z)
+        assert bool((x == expected_x).all())
+        assert bool((y == expected_y).all())
+        assert bool((z == expected_z).all())
+        
+    def test_loop_break():
+        @jit.rawkernel()
+        def f(x, y, z):
+            tid = jit.grid(1)
+            ntid = jit.gridsize(1)
+
             for i in range(10):
                 #adds 0-4, break at 5. Sum is 10
                 if(i == 5):
                     break
-                y[tid] += i
-                
+                x[tid] += i
+
             i2 = 0
             while (i2 < 9):
                 #adds 1-5 in a while loop, breaks at 6, should equal 15
                 i2 += 1
                 if(i2 == 6):
                     break
-                z[tid] += i2
-                
-            
-        w = cupy.zeros(32, dtype=int)
+                y[tid] += i2
+            for i in range(11):
+                #adds 0-10, but stops once the sum is greater than 3*i, breaks at 8 (28 > 3*8), sum is 28
+                if(z[tid] > 3*i):
+                    break
+                z[tid] += i
+
         x = cupy.zeros(32, dtype=int)
         y = cupy.zeros(32, dtype=int)
         z = cupy.zeros(32, dtype=int)
-        expected_w = cupy.zeros(32, dtype=int)+40
-        expected_x = cupy.zeros(32, dtype=int)+39
-        expected_y = cupy.zeros(32, dtype=int)+10
-        expected_z = cupy.zeros(32, dtype=int)+15
-        f[1, 32](w, x, y, z)
-        assert bool((w == expected_w).all())
+        expected_x = cupy.zeros(32, dtype=int)+10
+        expected_y = cupy.zeros(32, dtype=int)+15
+        expected_z = cupy.zeros(32, dtype=int)+28
+        f[1, 32](x, y, z)
+        print(z)
         assert bool((x == expected_x).all())
         assert bool((y == expected_y).all())
         assert bool((z == expected_z).all())

--- a/tests/cupyx_tests/jit_tests/test_raw.py
+++ b/tests/cupyx_tests/jit_tests/test_raw.py
@@ -288,7 +288,7 @@ class TestRaw:
             y[:mask] += 1
             assert bool((x == y).all())
             
-    def test_loop_continue():
+    def test_loop_continue(self):
         @jit.rawkernel()
         def f(x, y, z):
             tid = jit.grid(1)
@@ -322,7 +322,7 @@ class TestRaw:
         assert bool((y == 39).all())
         assert bool((z == 38).all())
         
-    def test_loop_break():
+    def test_loop_break(self):
         @jit.rawkernel()
         def f(x, y, z):
             tid = jit.grid(1)

--- a/tests/cupyx_tests/jit_tests/test_raw.py
+++ b/tests/cupyx_tests/jit_tests/test_raw.py
@@ -292,25 +292,27 @@ class TestRaw:
         @jit.rawkernel()
         def f(x, y, z):
             tid = jit.grid(1)
-            ntid = jit.gridsize(1)
 
             for i in range(10):
-                #adds 0-9, except for 5. Sum is 40
-                if(i == 5):
+                # adds 0-9, except for 5.
+                # Sum is 40
+                if i == 5:
                     continue
                 x[tid] += i
 
             i2 = 0
-            while (i2 < 9):
-                #adds 1-9 in a while loop, except for 6, should equal 39
+            while i2 < 9:
+                # adds 1-9 in a while loop, except for 6,
+                # should equal 39
                 i2 += 1
-                if(i2 == 6):
+                if i2 == 6:
                     continue
                 y[tid] += i2
 
             for i in range(11):
-                #adds 0-10, but skips if the sum is greater than 3*i, skips 8 and 9, but not 10 (28 < 3*10), sum is 38
-                if(z[tid] > 3*i):
+                # adds 0-10, but skips if the sum is greater than 3*i,
+                # skips 8 and 9, but not 10 (28 < 3*10), sum is 38
+                if z[tid] > 3*i:
                     continue
                 z[tid] += i
 
@@ -326,24 +328,26 @@ class TestRaw:
         @jit.rawkernel()
         def f(x, y, z):
             tid = jit.grid(1)
-            ntid = jit.gridsize(1)
 
             for i in range(10):
-                #adds 0-4, break at 5. Sum is 10
-                if(i == 5):
+                # adds 0-4,
+                # break at 5. Sum is 10
+                if i == 5:
                     break
                 x[tid] += i
 
             i2 = 0
-            while (i2 < 9):
-                #adds 1-5 in a while loop, breaks at 6, should equal 15
+            while i2 < 9:
+                # adds 1-5 in a while loop,
+                # breaks at 6, should equal 15
                 i2 += 1
-                if(i2 == 6):
+                if i2 == 6:
                     break
                 y[tid] += i2
             for i in range(11):
-                #adds 0-10, but stops once the sum is greater than 3*i, breaks at 8 (28 > 3*8), sum is 28
-                if(z[tid] > 3*i):
+                # adds 0-10, but stops once the sum is greater than 3*i,
+                # breaks at 8 (28 > 3*8), sum is 28
+                if z[tid] > 3*i:
                     break
                 z[tid] += i
 

--- a/tests/cupyx_tests/jit_tests/test_raw.py
+++ b/tests/cupyx_tests/jit_tests/test_raw.py
@@ -353,14 +353,10 @@ class TestRaw:
         x = cupy.zeros(32, dtype=int)
         y = cupy.zeros(32, dtype=int)
         z = cupy.zeros(32, dtype=int)
-        expected_x = cupy.zeros(32, dtype=int)+10
-        expected_y = cupy.zeros(32, dtype=int)+15
-        expected_z = cupy.zeros(32, dtype=int)+28
         f[1, 32](x, y, z)
-        print(z)
-        assert bool((x == expected_x).all())
-        assert bool((y == expected_y).all())
-        assert bool((z == expected_z).all())
+        assert bool((x == 10).all())
+        assert bool((y == 15).all())
+        assert bool((z == 28).all())
 
     def test_shared_memory_static(self):
         @jit.rawkernel()


### PR DESCRIPTION
Allows functions with "break" and "continue" keywords to be compiled by @jit.rawkernel

Added a test to cupy/tests/cupyx_tests/jit_tests/test_raw.py for both keywords, in both for and while loops.