### PR TITLE
Fix lfilter_zi and sosfilt_zi when any IIR coefficient is zero

### DIFF
--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
@@ -603,6 +603,24 @@ class TestLFilter:
         out, _ = scp.signal.lfilter(b, a, x, zi=zi)
         return out
 
+    @pytest.mark.parametrize(
+        'zeros', [(2,), (1,), (0,), (1, 2), (0, 1), (0, 2), (0, 1, 2)])
+    @testing.numpy_cupy_array_almost_equal(scipy_name='scp', decimal=5)
+    def test_lfilter_zi_with_zeros(self, zeros, xp, scp):
+        fir_order = 3
+        iir_order = 3
+
+        x = xp.ones(20)
+        b = testing.shaped_random((fir_order,), xp, scale=0.3)
+        a = testing.shaped_random((iir_order,), xp, scale=0.3)
+        a[list(zeros)] = 0
+        a = xp.r_[1, a]
+        a = a.astype(x.dtype)
+
+        zi = scp.signal.lfilter_zi(b, a)
+        out, _ = scp.signal.lfilter(b, a, x, zi=zi)
+        return out
+
 
 @testing.with_requires('scipy')
 class TestDeconvolve:
@@ -778,6 +796,19 @@ class TestSosFilt:
         x = xp.ones(20)
         sos = testing.shaped_random((sections, 6), xp, xp.float64, scale=0.2)
         sos[:, 3] = 1
+
+        zi = scp.signal.sosfilt_zi(sos)
+        out, _ = scp.signal.sosfilt(sos, x, zi=zi)
+        return out
+
+    @pytest.mark.parametrize(
+        'zeros', [(4,), (5,), (4, 5)])
+    @testing.numpy_cupy_array_almost_equal(scipy_name='scp', decimal=5)
+    def test_sosfilt_zi_with_zeros(self, zeros, xp, scp):
+        x = xp.ones(20)
+        sos = testing.shaped_random((1, 6), xp, xp.float64, scale=0.2)
+        sos[:, 3] = 1
+        sos[0, list(zeros)] = 0
 
         zi = scp.signal.sosfilt_zi(sos)
         out, _ = scp.signal.sosfilt(sos, x, zi=zi)


### PR DESCRIPTION
Fixes #8028 

This PR fixes a major issue when initial state conditions were computed for filters whose IIR coefficients contained any zero value. Such cases caused the solver to handle a singular matrix, which in turn, produced NaNs and Inf values as output. Now, a least square solution is produced whenever an IIR coefficient is zero.

This PR also fixes the order of the initial state produced by the `lfilter_zi` and `sosfilt_zi` functions, which were reversed prior to this fix. We didn't detected this error previously, since most of the time, the initial conditions are symmetrical, thus are invariant with respect to the order. However, when zero coefficients are defined, then the state will contain zeros in the same positions as the missing coefficients, therefore order does matter.

Regression tests were added in order to test for IIR coefficients that are zero.