### PR TITLE
Pass by reference

### DIFF
--- a/cupyx/jit/__init__.py
+++ b/cupyx/jit/__init__.py
@@ -9,6 +9,7 @@ from cupyx.jit._interface import warpsize  # NOQA
 from cupyx.jit._builtin_funcs import range_ as range  # NOQA
 from cupyx.jit._builtin_funcs import syncthreads  # NOQA
 from cupyx.jit._builtin_funcs import syncwarp  # NOQA
+from cupyx.jit._builtin_funcs import ref  # NOQA
 from cupyx.jit._builtin_funcs import shared_memory  # NOQA
 from cupyx.jit._builtin_funcs import atomic_add  # NOQA
 from cupyx.jit._builtin_funcs import atomic_sub  # NOQA

--- a/cupyx/jit/_builtin_funcs.py
+++ b/cupyx/jit/_builtin_funcs.py
@@ -196,6 +196,20 @@ class SyncWarp(BuiltinFunc):
         return Data(code, _cuda_types.void)
 
 
+class Ref(BuiltinFunc):
+    def __call__(self, var):
+        """Returns a reference to the specified (scalar) variable
+
+        Args:
+            var (int or float):
+                The variable to return a reference to
+        """
+        super().__call__()
+
+    def call(self, env, var):
+        return Data(var.code, _cuda_types.ReferenceTo(var.ctype))
+
+
 class SharedMemory(BuiltinFunc):
 
     def __call__(self, dtype, size, alignment=None):
@@ -447,6 +461,7 @@ builtin_functions_dict: Mapping[Any, BuiltinFunc] = {
 range_ = RangeFunc()
 syncthreads = SyncThreads()
 syncwarp = SyncWarp()
+ref = Ref()
 shared_memory = SharedMemory()
 grid = GridFunc('grid')
 gridsize = GridFunc('gridsize')

--- a/cupyx/jit/_cuda_types.py
+++ b/cupyx/jit/_cuda_types.py
@@ -253,6 +253,18 @@ class Ptr(PointerBase):
         return f'{self.child_type}*'
 
 
+class ReferenceTo(Scalar):
+
+    def declvar(self, x: str, init: Optional['Data']) -> str:
+        ctype = get_typename(self.dtype)
+        if (x[0] == "&"):
+            x = x[1:]
+        if (init is None):
+            return f"{ctype} &{x}"
+        else:
+            return f'{ctype} &{x} = {init.code}'
+
+
 class Tuple(TypeBase):
 
     def __init__(self, types: Sequence[TypeBase]) -> None:

--- a/tests/cupyx_tests/jit_tests/test_raw.py
+++ b/tests/cupyx_tests/jit_tests/test_raw.py
@@ -359,6 +359,46 @@ class TestRaw:
         assert bool((y == 15).all())
         assert bool((z == 28).all())
 
+    def test_pass_by_reference(self):
+        @jit.rawkernel(device=True)
+        def func(a, b, c):
+            a += 1
+            b = 1  # this throws a flake error, but is valid c++
+            c -= 1
+
+        @jit.rawkernel()
+        def f(x, y, z):
+            tid = jit.grid(1)
+
+            a = 4
+            b = 4
+            c = 4
+
+            if (tid == 1):
+                func(jit.ref(a), jit.ref(b), c)
+            else:
+                # func is already defined,
+                # a, b will still be passed by reference
+                # c will still be passed by value
+                func(a, b, jit.ref(c))
+
+            # still test pass-by-reference with c
+            d = jit.ref(c)
+            e = 7
+            d += e
+
+            x[tid] = a
+            y[tid] = b
+            z[tid] = c
+
+        x = cupy.zeros(2, dtype=int)
+        y = cupy.zeros(2, dtype=int)
+        z = cupy.zeros(2, dtype=int)
+        f[1, 2](x, y, z)
+        assert bool((x == 5).all())
+        assert bool((y == 1).all())
+        assert bool((z == 11).all())  # 4+7
+
     def test_shared_memory_static(self):
         @jit.rawkernel()
         def f(x, y):

--- a/tests/cupyx_tests/jit_tests/test_raw.py
+++ b/tests/cupyx_tests/jit_tests/test_raw.py
@@ -363,7 +363,7 @@ class TestRaw:
         @jit.rawkernel(device=True)
         def func(a, b, c):
             a += 1
-            b = 1  # this throws a flake error, but is valid c++
+            b = 1  # noqa: F841
             c -= 1
 
         @jit.rawkernel()


### PR DESCRIPTION
This pull request aims to add pass-by-reference capabilities for ordinary scalar variables, which by default are passed by value in c++.

The code:
```py
@jit.rawkernel(device=True)
def test2(a):
    a += 1.

@jit.rawkernel()
def test(arr):
    a = 1.2
    b = jit.ref(a)
    c = 2.2
    b = c
    test2(b)
    arr[0] = a
    
c = cp.zeros(1, dtype=np.float64)
test[1,1](c)
```
sets c[0] to 3.2, and emits the following c++ code
```
__device__ void test2_1(double &a) {
  { double &_tmp_1 = a; _tmp_1 = (_tmp_1 + 1.0); }
}
extern "C" __global__ void test(CArray<double, 1, true, true> arr) {
  double a = 1.2;
  double &b = a;
  double c = 2.2;
  b = c;
  test2_1(b);
  arr[0] = a;
}
```

A test for this is included in tests/cupyx_tests/jit_tests/test_raw.py. 

Minor issue that may need to be corrected: the first instance of a device_function being called defines whether variables are passed by reference or value, and subsequent attempts to call the device_function with different choices still use the first definition, e.g.:

```py
func(jit.ref(a))
func(a)
```
would pass a by reference to the function func both times.