### PR TITLE
Fix `scp.signal.{medfilt,medfilt2d}` to raise ValueError for complex64 inputs

### DIFF
--- a/cupyx/scipy/signal/_signaltools.py
+++ b/cupyx/scipy/signal/_signaltools.py
@@ -582,8 +582,6 @@ def medfilt(volume, kernel_size=None):
         # scipy doesn't support bool
         raise ValueError("bool type not supported")
     kernel_size = _get_kernel_size(kernel_size, volume.ndim)
-    if volume.dtype == 'F':
-        raise TypeError("complex types not supported")
     if volume.dtype.kind == 'c':
         # scipy doesn't support complex
         raise ValueError("complex types not supported")
@@ -629,8 +627,6 @@ def medfilt2d(input, kernel_size=3):
     if input.ndim != 2:
         raise ValueError('input must be 2d')
     kernel_size = _get_kernel_size(kernel_size, input.ndim)
-    if input.dtype == 'F':
-        raise TypeError("complex types not supported")
     if input.dtype.kind == 'c':
         # scipy doesn't support complex
         raise ValueError("complex types not supported")

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_fir_filter_design.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_fir_filter_design.py
@@ -337,13 +337,15 @@ class TestFirls:
     @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_compare(self, xp, scp):
         # compare to OCTAVE output
-        taps = scp.signal.firls(9, [0, 0.5, 0.55, 1], [1, 1, 0, 0], [1, 2])
+        taps = scp.signal.firls(
+            9, [0, 0.5, 0.55, 1], [1, 1, 0, 0], weight=[1, 2])
         return taps
 
     @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_compare_2(self, xp, scp):
         # compare to MATLAB output
-        taps = scp.signal.firls(11, [0, 0.5, 0.5, 1], [1, 1, 0, 0], [1, 2])
+        taps = scp.signal.firls(
+            11, [0, 0.5, 0.5, 1], [1, 1, 0, 0], weight=[1, 2])
         return taps
 
     @testing.numpy_cupy_allclose(scipy_name='scp')

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
@@ -369,11 +369,11 @@ class TestMedFilt:
             kernel_size = kernel_size[:volume.ndim]
         return scp.signal.medfilt(volume, kernel_size)
 
-    @testing.with_requires('scipy>=1.11.0')
+    @testing.with_requires('scipy>1.11.0')
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(
         atol=1e-8, rtol=1e-8, scipy_name='scp',
-        accept_error=(ValueError, TypeError))  # for even kernels
+        accept_error=ValueError)  # for even kernels
     def test_medfilt(self, xp, scp, dtype):
         if sys.platform == 'win32':
             pytest.xfail('medfilt broken for Scipy 1.7.0 in windows')
@@ -404,7 +404,7 @@ class TestMedFilt2d:
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(
         atol=1e-8, rtol=1e-8, scipy_name='scp',
-        accept_error=(ValueError, TypeError))  # for even kernels
+        accept_error=ValueError)  # for even kernels
     def test_medfilt2d(self, xp, scp, dtype):
         if sys.platform == 'win32':
             pytest.xfail('medfilt2d broken for Scipy 1.7.0 in windows')


### PR DESCRIPTION
Part of https://github.com/cupy/cupy/issues/8046.