### PR TITLE
Fix `csrmatrix.__pow__` to raise ValueError for non-int other

### DIFF
--- a/cupyx/scipy/sparse/_base.py
+++ b/cupyx/scipy/sparse/_base.py
@@ -1,3 +1,5 @@
+import numbers
+
 import numpy
 
 import cupy
@@ -182,6 +184,8 @@ class spmatrix(object):
         m, n = self.shape
         if m != n:
             raise TypeError('matrix is not square')
+        if not isinstance(other, numbers.Integral):
+            raise ValueError("exponent must be an integer")
 
         if _util.isintlike(other):
             other = int(other)

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -1306,10 +1306,11 @@ class TestCsrMatrixPowScipyComparison:
             with pytest.raises(ValueError):
                 m ** 1.5
 
+    @testing.with_requires('scipy>1.11')
     def test_pow_list(self):
         for xp, sp in ((numpy, scipy.sparse), (cupy, sparse)):
             m = _make_square(xp, sp, self.dtype)
-            with pytest.raises(TypeError):
+            with pytest.raises(ValueError):
                 m ** []
 
 


### PR DESCRIPTION
Part of https://github.com/cupy/cupy/issues/8046.