### PR TITLE
`scipy.special.{btdtr,btdtri}` are deprecated since SciPy 1.12

### DIFF
--- a/cupyx/scipy/special/_stats_distributions.py
+++ b/cupyx/scipy/special/_stats_distributions.py
@@ -13,6 +13,7 @@ https://github.com/scipy/scipy/blob/main/scipy/special/cephes/pdtr.c
 Cephes Math Library, Release 2.3:  March, 1995
 Copyright 1984, 1995 by Stephen L. Moshier
 """
+import warnings
 
 from cupy import _core
 from cupyx.scipy.special._beta import incbet_preamble, incbi_preamble
@@ -353,7 +354,7 @@ bdtri = _core.create_ufunc(
 
 # Beta distribution functions
 
-btdtr = _core.create_ufunc(
+_btdtr = _core.create_ufunc(
     "cupyx_scipy_btdtr",
     ("fff->f", "ddd->d"),
     "out0 = out0_type(incbet(in0, in1, in2));",
@@ -383,7 +384,13 @@ btdtr = _core.create_ufunc(
 )
 
 
-btdtri = _core.create_ufunc(
+def btdtr(a, b, x, out=None):
+    warnings.warn(
+        "Use cupyx.scipy.special.betainc instead.", DeprecationWarning)
+    return _btdtr(a, b, x, out)
+
+
+_btdtri = _core.create_ufunc(
     "cupyx_scipy_btdtri",
     ("fff->f", "ddd->d"),
     "out0 = out0_type(incbi(in0, in1, in2));",
@@ -413,6 +420,12 @@ btdtri = _core.create_ufunc(
 
     """,
 )
+
+
+def btdtri(a, b, p, out=None):
+    warnings.warn(
+        "Use cupyx.scipy.special.betaincinv instead.", DeprecationWarning)
+    return _btdtri(a, b, p, out)
 
 
 # Chi square distribution functions

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_statistics.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_statistics.py
@@ -204,7 +204,7 @@ class TestTwoArgumentDistribution(_TestDistributionsBase):
 @testing.with_requires('scipy')
 class TestThreeArgumentDistributions(_TestDistributionsBase):
 
-    @pytest.mark.parametrize('function', ['btdtr', 'btdtri', 'fdtr', 'fdtrc',
+    @pytest.mark.parametrize('function', ['fdtr', 'fdtrc',
                                           'fdtri', 'gdtr', 'gdtrc'])
     @testing.for_float_dtypes()
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
@@ -221,7 +221,7 @@ class TestThreeArgumentDistributions(_TestDistributionsBase):
         # a and b should be positive
         a = xp.linspace(-1, 21, 30, dtype=dtype)[:, xp.newaxis, xp.newaxis]
         b = xp.linspace(-1, 21, 30, dtype=dtype)[xp.newaxis, :, xp.newaxis]
-        if function in ['fdtri', 'btdtr', 'btdtri']:
+        if function == 'fdtri':
             # x should be in [0, 1] so concentrate values around that
             x = xp.linspace(-0.1, 1.3, 20, dtype=dtype)
         else:
@@ -275,9 +275,7 @@ class TestThreeArgumentDistributions(_TestDistributionsBase):
 
     @pytest.mark.parametrize(
         'function, args, expected',
-        [('btdtr', (1, 1, 1), 1.0),
-         ('btdtri', (1, 1, 1), 1.0),
-         ('betainc', (1, 1, 0), 0.0),
+        [('betainc', (1, 1, 0), 0.0),
          # Computed using Wolfram Alpha: CDF[FRatioDistribution[1e-6, 5], 10]
          ('fdtr', (1e-6, 5, 10), 0.9999940790193488),
          ('fdtrc', (1, 1, 0), 1.0),


### PR DESCRIPTION
Part of https://github.com/cupy/cupy/issues/8046.
https://scipy.github.io/devdocs/reference/generated/scipy.special.btdtr.html