### PR TITLE
ENH: signal: add `lanczos` and `kaiser_bessel_derived` windows

### DIFF
--- a/cupyx/scipy/signal/windows/__init__.py
+++ b/cupyx/scipy/signal/windows/__init__.py
@@ -14,6 +14,7 @@ from cupyx.scipy.signal.windows._windows import barthann  # NOQA
 from cupyx.scipy.signal.windows._windows import general_hamming  # NOQA
 from cupyx.scipy.signal.windows._windows import hamming  # NOQA
 from cupyx.scipy.signal.windows._windows import kaiser  # NOQA
+from cupyx.scipy.signal.windows._windows import kaiser_bessel_derived  # NOQA
 from cupyx.scipy.signal.windows._windows import gaussian  # NOQA
 from cupyx.scipy.signal.windows._windows import general_gaussian  # NOQA
 from cupyx.scipy.signal.windows._windows import chebwin  # NOQA

--- a/cupyx/scipy/signal/windows/__init__.py
+++ b/cupyx/scipy/signal/windows/__init__.py
@@ -20,4 +20,5 @@ from cupyx.scipy.signal.windows._windows import chebwin  # NOQA
 from cupyx.scipy.signal.windows._windows import cosine  # NOQA
 from cupyx.scipy.signal.windows._windows import exponential  # NOQA
 from cupyx.scipy.signal.windows._windows import taylor  # NOQA
+from cupyx.scipy.signal.windows._windows import lanczos  # NOQA
 from cupyx.scipy.signal.windows._windows import get_window  # NOQA

--- a/cupyx/scipy/signal/windows/_windows.py
+++ b/cupyx/scipy/signal/windows/_windows.py
@@ -1450,6 +1450,7 @@ def kaiser_bessel_derived(M, beta, sym=True):
     See Also
     --------
     kaiser
+    scipy.signal.windows.kaiser_bessel_derived
 
     Notes
     -----
@@ -1462,32 +1463,7 @@ def kaiser_bessel_derived(M, beta, sym=True):
     ----------
     .. [1] Bosi, Marina, and Richard E. Goldberg. Introduction to Digital
            Audio Coding and Standards. Dordrecht: Kluwer, 2003.
-    .. [2] Wikipedia, "Kaiser window",
-           https://en.wikipedia.org/wiki/Kaiser_window
 
-    Examples
-    --------
-    Plot the Kaiser-Bessel derived window based on the wikipedia
-    reference [2]_:
-
-    >>> import numpy as np
-    >>> from scipy import signal
-    >>> import matplotlib.pyplot as plt
-    >>> fig, ax = plt.subplots()
-    >>> N = 50
-    >>> for alpha in [0.64, 2.55, 7.64, 31.83]:
-    ...     ax.plot(signal.windows.kaiser_bessel_derived(2*N, np.pi*alpha),
-    ...             label=f"{alpha=}")
-    >>> ax.grid(True)
-    >>> ax.set_title("Kaiser-Bessel derived window")
-    >>> ax.set_ylabel("Amplitude")
-    >>> ax.set_xlabel("Sample")
-    >>> ax.set_xticks([0, N, 2*N-1])
-    >>> ax.set_xticklabels(["0", "N", "2N+1"])  # doctest: +SKIP
-    >>> ax.set_yticks([0.0, 0.2, 0.4, 0.6, 0.707, 0.8, 1.0])
-    >>> fig.legend(loc="center")
-    >>> fig.tight_layout()
-    >>> fig.show()
     """
     if not sym:
         raise ValueError(

--- a/cupyx/scipy/signal/windows/_windows.py
+++ b/cupyx/scipy/signal/windows/_windows.py
@@ -2036,6 +2036,64 @@ def taylor(M, nbar=4, sll=30, norm=True, sym=True):
     return _truncate(w, needs_trunc)
 
 
+def lanczos(M, sym=True):
+    r"""Return a Lanczos window also known as a sinc window.
+
+    Parameters
+    ----------
+    M : int
+        Number of points in the output window. If zero, an empty array
+        is returned. An exception is thrown when it is negative.
+    sym : bool, optional
+        When True (default), generates a symmetric window, for use in filter
+        design.
+        When False, generates a periodic window, for use in spectral analysis.
+
+    Returns
+    -------
+    w : ndarray
+        The window, with the maximum value normalized to 1 (though the value 1
+        does not appear if `M` is even and `sym` is True).
+
+    Notes
+    -----
+    The Lanczos window is defined as
+
+    .. math::  w(n) = sinc \left( \frac{2n}{M - 1} - 1 \right)
+
+    where
+
+    .. math::  sinc(x) = \frac{\sin(\pi x)}{\pi x}
+
+    The Lanczos window has reduced Gibbs oscillations and is widely used for
+    filtering climate timeseries with good properties in the physical and
+    spectral domains.
+
+    See Also
+    --------
+    scipy.signal.windows.lanczos
+
+    """
+    if _len_guards(M):
+        return cupy.ones(M)
+    M, needs_trunc = _extend(M, sym)
+
+    # To make sure that the window is symmetric, we concatenate the right hand
+    # half of the window and the flipped one which is the left hand half of
+    # the window.
+    def _calc_right_side_lanczos(n, m):
+        return cupy.sinc(2. * cupy.arange(n, m) / (m - 1) - 1.0)
+
+    if M % 2 == 0:
+        wh = _calc_right_side_lanczos(M/2, M)
+        w = cupy.r_[cupy.flip(wh), wh]
+    else:
+        wh = _calc_right_side_lanczos((M+1)/2, M)
+        w = cupy.r_[cupy.flip(wh), 1.0, wh]
+
+    return _truncate(w, needs_trunc)
+
+
 def _fftautocorr(x):
     """Compute the autocorrelation of a real array and crop the result."""
     N = x.shape[-1]
@@ -2071,6 +2129,7 @@ _win_equiv_raw = {
     ('general hamming', 'general_hamming'): (general_hamming, True),
     ("hamming", "hamm", "ham"): (hamming, False),
     ("hanning", "hann", "han"): (hann, False),
+    ('lanczos', 'sinc'): (lanczos, False),
     ("kaiser", "ksr"): (kaiser, True),
     ("nuttall", "nutl", "nut"): (nuttall, False),
     ("parzen", "parz", "par"): (parzen, False),

--- a/docs/source/reference/scipy_signal_windows.rst
+++ b/docs/source/reference/scipy_signal_windows.rst
@@ -32,4 +32,5 @@ The suite of window functions for filtering and spectral estimation.
    parzen
    taylor
    triang
+   lanczos
    tukey

--- a/docs/source/reference/scipy_signal_windows.rst
+++ b/docs/source/reference/scipy_signal_windows.rst
@@ -28,6 +28,7 @@ The suite of window functions for filtering and spectral estimation.
    hamming
    hann
    kaiser
+   kaiser_bessel_derived
    nuttall
    parzen
    taylor

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_windows.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_windows.py
@@ -276,6 +276,7 @@ class TestKaiser:
                 scp.signal.windows.kaiser(6, 2.7, False),)
 
 
+@testing.with_requires('scipy >= 1.10')
 class TestKaiserBesselDerived:
     @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-13, atol=1e-13)
     def test_basic(self, xp, scp):
@@ -416,6 +417,7 @@ class TestDPSS:
         assert_raises(ValueError, windows.dpss, -1, 1, 3)  # negative M
 
 
+@testing.with_requires("scipy >= 1.10")
 class TestLanczos:
     @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-13, atol=1e-13)
     def test_basic(self, xp, scp):
@@ -508,6 +510,7 @@ class TestGetWindow:
             scp.signal.get_window(('general_hamming', 0.7), 5),
             scp.signal.get_window(('general_hamming', 0.7), 5, fftbins=False),)
 
+    @testing.with_requires("scipy >= 1.10")
     @testing.numpy_cupy_allclose(scipy_name='scp', atol=1e-15)
     def test_lanczos(self, xp, scp):
         return (scp.signal.get_window('lanczos', 6),
@@ -573,6 +576,13 @@ def test_needs_params(windows):
                    'dss', 'dpss', 'general cosine', 'general_cosine',
                    'chebwin', 'cheb', 'general hamming', 'general_hamming',
                    ]:
+        assert_raises(ValueError, windows.get_window, winstr, 7)
+
+
+@testing.with_requires("scipy >= 1.10")
+@pytest.mark.parametrize('windows', [cu_windows, cpu_windows])
+def test_needs_params_2(windows):
+    for winstr in ['kaiser_bessel_derived']:
         assert_raises(ValueError, windows.get_window, winstr, 7)
 
 

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_windows.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_windows.py
@@ -276,7 +276,6 @@ class TestKaiser:
                 scp.signal.windows.kaiser(6, 2.7, False),)
 
 
-@pytest.mark.skip('This has not been implemented yet in CuPy')
 class TestKaiserBesselDerived:
     @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-13, atol=1e-13)
     def test_basic(self, xp, scp):
@@ -303,6 +302,7 @@ class TestKaiserBesselDerived:
                "symmetric shapes")
         with assert_raises(ValueError, match=msg):
             scp.signal.windows.kaiser_bessel_derived(M + 1, beta=4., sym=False)
+        return 42
 
 
 class TestNuttall:

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_windows.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_windows.py
@@ -416,7 +416,6 @@ class TestDPSS:
         assert_raises(ValueError, windows.dpss, -1, 1, 3)  # negative M
 
 
-@pytest.mark.skip('This has not been implemented yet in CuPy')
 class TestLanczos:
     @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-13, atol=1e-13)
     def test_basic(self, xp, scp):
@@ -509,7 +508,7 @@ class TestGetWindow:
             scp.signal.get_window(('general_hamming', 0.7), 5),
             scp.signal.get_window(('general_hamming', 0.7), 5, fftbins=False),)
 
-    @pytest.mark.skip('This has not been implemented yet in CuPy')
+    @testing.numpy_cupy_allclose(scipy_name='scp', atol=1e-15)
     def test_lanczos(self, xp, scp):
         return (scp.signal.get_window('lanczos', 6),
                 scp.signal.get_window('lanczos', 6, fftbins=False),


### PR DESCRIPTION
cross-ref https://github.com/cupy/cupy/issues/7404

Both windows are trivial enough so that just copy pasting scipy implementations seems enough.