### PR TITLE
Fix#7981, Update _nccl_comm.py

### DIFF
--- a/cupyx/distributed/_nccl_comm.py
+++ b/cupyx/distributed/_nccl_comm.py
@@ -124,7 +124,7 @@ class NCCLBackend(_Backend):
     def _get_op(self, op, dtype):
         if op not in _nccl_ops:
             raise RuntimeError(f'Unknown op {op} for NCCL')
-        if dtype in 'FD' and op != nccl.NCCL_SUM:
+        if dtype in 'FD' and op != 'sum':
             raise ValueError(
                 'Only nccl.SUM is supported for complex arrays')
         return _nccl_ops[op]


### PR DESCRIPTION
Fix #7981 , `op` should be compared with `sum`, the key of dict `_nccl_ops`, instead of `nccl.NCCL_SUM`, the values of dict `_nccl_ops`.