### PR TITLE
[backport] scipy.special.{btdtr,btdtri} are deprecated since SciPy

### DIFF
--- a/tests/cupyx_tests/scipy_tests/special_tests/test_statistics.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_statistics.py
@@ -214,7 +214,10 @@ class TestThreeArgumentDistributions(_TestDistributionsBase):
         This method uses first two arguments with mostly non-negative values.
         In some cases, the last argument is constrained to range [0, 1]
         """
-        if function in ['btdtr', 'btdtri'] and testing.installed('scipy>=1.12.0rc1'):
+        if (
+            function in ['btdtr', 'btdtri'] and
+            testing.installed('scipy>=1.12.0rc1')
+        ):
             pytest.skip('btdtr and btdtri are deprecated since SciPy 1.12')
 
         import scipy.special  # NOQA

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_statistics.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_statistics.py
@@ -214,6 +214,8 @@ class TestThreeArgumentDistributions(_TestDistributionsBase):
         This method uses first two arguments with mostly non-negative values.
         In some cases, the last argument is constrained to range [0, 1]
         """
+        if function in ['btdtr', 'btdtri'] and testing.installed('scipy>1.11'):
+            pytest.skip('btdtr and btdtri are deprecated since SciPy 1.12')
 
         import scipy.special  # NOQA
 

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_statistics.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_statistics.py
@@ -214,7 +214,7 @@ class TestThreeArgumentDistributions(_TestDistributionsBase):
         This method uses first two arguments with mostly non-negative values.
         In some cases, the last argument is constrained to range [0, 1]
         """
-        if function in ['btdtr', 'btdtri'] and testing.installed('scipy>1.11'):
+        if function in ['btdtr', 'btdtri'] and testing.installed('scipy>=1.12.0rc1'):
             pytest.skip('btdtr and btdtri are deprecated since SciPy 1.12')
 
         import scipy.special  # NOQA


### PR DESCRIPTION
backport of #8066