### PR TITLE
Fix Flags not to allow setters

### DIFF
--- a/cupy/_core/flags.pyx
+++ b/cupy/_core/flags.pyx
@@ -4,9 +4,21 @@
 class Flags(object):
 
     def __init__(self, c_contiguous, f_contiguous, owndata):
-        self.c_contiguous = c_contiguous
-        self.f_contiguous = f_contiguous
-        self.owndata = owndata
+        self._c_contiguous = c_contiguous
+        self._f_contiguous = f_contiguous
+        self._owndata = owndata
+
+    @property
+    def c_contiguous(self):
+        return self._c_contiguous
+
+    @property
+    def f_contiguous(self):
+        return self._f_contiguous
+
+    @property
+    def owndata(self):
+        return self._owndata
 
     @property
     def fnc(self):

--- a/tests/cupy_tests/core_tests/test_flags.py
+++ b/tests/cupy_tests/core_tests/test_flags.py
@@ -1,5 +1,9 @@
 import unittest
 
+import numpy
+import pytest
+
+import cupy
 from cupy._core import flags
 from cupy import testing
 
@@ -65,3 +69,21 @@ class TestContiguityFlags(unittest.TestCase):
     def test_c_contiguous(self, xp):
         self.init_flags(xp)
         return self.flags.c_contiguous
+
+    def test_c_contiguous_setter(self):
+        for xp in (numpy, cupy):
+            self.init_flags(xp)
+            with pytest.raises(AttributeError):
+                self.flags.c_contiguous = True
+
+    def test_f_contiguous_setter(self):
+        for xp in (numpy, cupy):
+            self.init_flags(xp)
+            with pytest.raises(AttributeError):
+                self.flags.f_contiguous = True
+
+    def test_owndata_setter(self):
+        for xp in (numpy, cupy):
+            self.init_flags(xp)
+            with pytest.raises(AttributeError):
+                self.flags.owndata = True


### PR DESCRIPTION
```py
>>> import numpy
>>> x = numpy.array([1, 2, 3])
>>> x.flags.c_contiguous = True
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: attribute 'c_contiguous' of 'numpy.core.multiarray.flagsobj' objects is not writable
```