### PR TITLE
Fix invalid `vectorstength` tests

### DIFF
--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_spectral.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_spectral.py
@@ -1295,23 +1295,19 @@ class TestVectorstrength:
         strength, phase = scp.signal.vectorstrength(events, period)
         return strength, phase
 
-    @testing.with_requires('scipy>=1.12.0rc1')
     @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-7, atol=1e-7)
     def test_opposite_1dperiod(self, xp, scp):
         events = xp.array([0, .25, .5, .75])
         period = 1.
+        strength, _ = scp.signal.vectorstrength(events, period)
+        return strength
 
-        strength, phase = scp.signal.vectorstrength(events, period)
-        return strength, phase
-
-    @testing.with_requires('scipy>=1.12.0rc1')
     @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-7, atol=1e-7)
     def test_opposite_2dperiod(self, xp, scp):
         events = xp.array([0, .25, .5, .75])
         period = [1.] * 10
-
-        strength, phase = scp.signal.vectorstrength(events, period)
-        return strength, phase
+        strength, _ = scp.signal.vectorstrength(events, period)
+        return strength
 
     @pytest.mark.parametrize('mod', [(cupy, cupyx.scipy), (np, scipy)])
     def test_2d_events_ValueError(self, mod):


### PR DESCRIPTION
In these test cases, CuPy should not guarantee compatibility of `phase` because it is computed with `angle(0 + 0j)`.

```py
>>> x = numpy.array([0, 0.25, 0.5, 0.75])
>>> scipy.signal.vectorstrength(x, 1.)
(6.206335383118183e-17, 2.677945044588987)
>>> x = numpy.array([0 + 1e-11, 0.25, 0.5, 0.75])
>>> scipy.signal.vectorstrength(x, 1.)
(1.570801821958273e-11, 1.5707998607321798)
>>> x = numpy.array([0, 0.25 + 1e-11, 0.5, 0.75])
>>> scipy.signal.vectorstrength(x, 1.)
(1.5708018219509164e-11, 3.1415908866211515)
>>> x = numpy.array([0, 0.25, 0.5, 0.75 + 1e-11])
>>> scipy.signal.vectorstrength(x, 1.)
(1.5707823930479852e-11, 1.7669904971232676e-06)
```