### PR TITLE
Fix overflow indexing ndarray generated with as_strided

### DIFF
--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -222,7 +222,8 @@ cdef class _ndarray_base:
         else:
             self.data = memptr
             bound = cupy._core._memory_range.get_bound(self)
-            self._index_32_bits = bound[1] - bound[0] <= (1 << 31)
+            max_diff = max(bound[1] - bound[0], self.size * itemsize)
+            self._index_32_bits = max_diff <= (1 << 31)
 
     cdef _init_fast(self, const shape_t& shape, dtype, bint c_order):
         """ For internal ndarray creation. """

--- a/tests/cupy_tests/indexing_tests/test_indexing.py
+++ b/tests/cupy_tests/indexing_tests/test_indexing.py
@@ -381,3 +381,10 @@ class TestSelect(unittest.TestCase):
         choicelist = [a, b]
         with pytest.raises(TypeError):
             cupy.select(condlist, choicelist, [dtype(2)])
+
+    @testing.numpy_cupy_array_equal()
+    def test_indexing_overflows(self, xp):
+        a = xp.arange(2, dtype=xp.int32)
+        a = xp.lib.stride_tricks.as_strided(
+            a, shape=(2, 2 ** 32), strides=(4, 0))
+        return a[xp.array([1]), xp.array([1])]


### PR DESCRIPTION
Close https://github.com/cupy/cupy/issues/8130.
Fix the condition for generating a kernel using 32-bit indexing.