### PR TITLE
Set `-arch` in the compiler options unconditionally

### DIFF
--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -280,6 +280,12 @@ def compile_using_nvrtc(source, options=(), arch=None, filename='kern.cu',
     def _compile(
             source, options, cu_path, name_expressions, log_stream, jitify):
 
+        if not runtime.is_hip:
+            arch_opt, method = _get_arch_for_options_for_nvrtc(arch)
+            options += (arch_opt,)
+        else:
+            method = 'ptx'
+
         if jitify:
             options, headers, include_names = _jitify_prep(
                 source, options, cu_path)
@@ -290,12 +296,6 @@ def compile_using_nvrtc(source, options=(), arch=None, filename='kern.cu',
                 # Starting with CUDA 12.0, even without using jitify, some
                 # tests cause an error if the following option is not included.
                 options += ('--device-as-default-execution-space',)
-
-        if not runtime.is_hip:
-            arch_opt, method = _get_arch_for_options_for_nvrtc(arch)
-            options += (arch_opt,)
-        else:
-            method = 'ptx'
 
         prog = _NVRTCProgram(source, cu_path, headers, include_names,
                              name_expressions=name_expressions, method=method)

--- a/tests/cupy_tests/core_tests/test_raw.py
+++ b/tests/cupy_tests/core_tests/test_raw.py
@@ -685,7 +685,9 @@ class TestRaw(unittest.TestCase):
         x = cupy.zeros((N,), dtype=cupy.float32)
         use_ptx = os.environ.get(
             'CUPY_COMPILE_WITH_PTX', False)
-        if self.backend == 'nvrtc' and (
+        if self.jitify:
+            error = cupy.cuda.compiler.JitifyException
+        elif self.backend == 'nvrtc' and (
                 use_ptx or
                 (cupy.cuda.driver._is_cuda_python()
                  and cupy.cuda.runtime.runtimeGetVersion() < 11010) or


### PR DESCRIPTION
Close #8155.

I verified locally that this is the right fix, see my analysis in https://github.com/cupy/cupy/issues/8155#issuecomment-1924812326. Also, I assume this patch must have been used by @mrakgr in his journey of #8156? 🙂