### PR TITLE
Add complex support for the digamma function

### DIFF
--- a/cupy/_core/include/cupy/special/binom.h
+++ b/cupy/_core/include/cupy/special/binom.h
@@ -1,0 +1,85 @@
+/* Translated from Cython into C++ by SciPy developers in 2024.
+ *
+ * Original authors: Pauli Virtanen, Eric Moore
+ */
+
+// Binomial coefficient
+
+#pragma once
+
+#include "config.h"
+
+#include "cephes/beta.h"
+#include "cephes/gamma.h"
+
+namespace special {
+
+SPECFUN_HOST_DEVICE inline double binom(double n, double k) {
+    double kx, nx, num, den, dk, sgn;
+
+    if (n < 0) {
+        nx = std::floor(n);
+        if (n == nx) {
+            // Undefined
+            return std::numeric_limits<double>::quiet_NaN();
+        }
+    }
+
+    kx = std::floor(k);
+    if (k == kx && (std::abs(n) > 1E-8 || n == 0)) {
+        /* Integer case: use multiplication formula for less rounding
+         * error for cases where the result is an integer.
+         *
+         * This cannot be used for small nonzero n due to loss of
+         * precision. */
+        nx = std::floor(n);
+        if (nx == n && kx > nx / 2 && nx > 0) {
+            // Reduce kx by symmetry
+            kx = nx - kx;
+        }
+
+        if (kx >= 0 && kx < 20) {
+            num = 1.0;
+            den = 1.0;
+            for (int i = 1; i < 1 + static_cast<int>(kx); i++) {
+                num *= i + n - kx;
+                den *= i;
+                if (std::abs(num) > 1E50) {
+                    num /= den;
+                    den = 1.0;
+                }
+            }
+            return num / den;
+        }
+    }
+
+    // general case
+    if (n >= 1E10 * k and k > 0) {
+        // avoid under/overflows intermediate results
+        return std::exp(-cephes::lbeta(1 + n - k, 1 + k) - std::log(n + 1));
+    }
+    if (k > 1E8 * std::abs(n)) {
+        // avoid loss of precision
+        num = cephes::Gamma(1 + n) / std::abs(k) + cephes::Gamma(1 + n) * n / (2 * k * k); // + ...
+        num /= M_PI * std::pow(std::abs(k), n);
+        if (k > 0) {
+            kx = std::floor(k);
+            if (static_cast<int>(kx) == kx) {
+                dk = k - kx;
+                sgn = (static_cast<int>(kx) % 2 == 0) ? 1 : -1;
+            } else {
+                dk = k;
+                sgn = 1;
+            }
+            return num * std::sin((dk - n) * M_PI) * sgn;
+        }
+        kx = std::floor(k);
+        if (static_cast<int>(kx) == kx) {
+            return 0;
+        }
+        return num * std::sin(k * M_PI);
+    }
+    return 1 / (n + 1) / cephes::beta(1 + n - k, 1 + k);
+}
+
+} // namespace special

--- a/cupy/_core/include/cupy/special/cephes/beta.h
+++ b/cupy/_core/include/cupy/special/cephes/beta.h
@@ -1,0 +1,255 @@
+/* Translated into C++ by SciPy developers in 2024.
+ * Original header with Copyright information appears below.
+ */
+
+/*                                                     beta.c
+ *
+ *     Beta function
+ *
+ *
+ *
+ * SYNOPSIS:
+ *
+ * double a, b, y, beta();
+ *
+ * y = beta( a, b );
+ *
+ *
+ *
+ * DESCRIPTION:
+ *
+ *                   -     -
+ *                  | (a) | (b)
+ * beta( a, b )  =  -----------.
+ *                     -
+ *                    | (a+b)
+ *
+ * For large arguments the logarithm of the function is
+ * evaluated using lgam(), then exponentiated.
+ *
+ *
+ *
+ * ACCURACY:
+ *
+ *                      Relative error:
+ * arithmetic   domain     # trials      peak         rms
+ *    IEEE       0,30       30000       8.1e-14     1.1e-14
+ *
+ * ERROR MESSAGES:
+ *
+ *   message         condition          value returned
+ * beta overflow    log(beta) > MAXLOG       0.0
+ *                  a or b <0 integer        0.0
+ *
+ */
+
+/*
+ * Cephes Math Library Release 2.0:  April, 1987
+ * Copyright 1984, 1987 by Stephen L. Moshier
+ * Direct inquiries to 30 Frost Street, Cambridge, MA 02140
+ */
+#pragma once
+
+#include "../config.h"
+#include "const.h"
+#include "gamma.h"
+
+namespace special {
+namespace cephes {
+
+    SPECFUN_HOST_DEVICE double beta(double, double);
+    SPECFUN_HOST_DEVICE double lbeta(double, double);
+
+    namespace detail {
+        constexpr double beta_ASYMP_FACTOR = 1e6;
+
+        /*
+         * Asymptotic expansion for  ln(|B(a, b)|) for a > ASYMP_FACTOR*max(|b|, 1).
+         */
+        SPECFUN_HOST_DEVICE inline double lbeta_asymp(double a, double b, int *sgn) {
+            double r = lgam_sgn(b, sgn);
+            r -= b * std::log(a);
+
+            r += b * (1 - b) / (2 * a);
+            r += b * (1 - b) * (1 - 2 * b) / (12 * a * a);
+            r += -b * b * (1 - b) * (1 - b) / (12 * a * a * a);
+
+            return r;
+        }
+
+        /*
+         * Special case for a negative integer argument
+         */
+
+        SPECFUN_HOST_DEVICE inline double beta_negint(int a, double b) {
+            int sgn;
+            if (b == static_cast<int>(b) && 1 - a - b > 0) {
+                sgn = (static_cast<int>(b) % 2 == 0) ? 1 : -1;
+                return sgn * special::cephes::beta(1 - a - b, b);
+            } else {
+                set_error("lbeta", SF_ERROR_OVERFLOW, NULL);
+                return std::numeric_limits<double>::infinity();
+            }
+        }
+
+        SPECFUN_HOST_DEVICE inline double lbeta_negint(int a, double b) {
+            double r;
+            if (b == static_cast<int>(b) && 1 - a - b > 0) {
+                r = special::cephes::lbeta(1 - a - b, b);
+                return r;
+            } else {
+                set_error("lbeta", SF_ERROR_OVERFLOW, NULL);
+                return std::numeric_limits<double>::infinity();
+            }
+        }
+    } // namespace detail
+
+    SPECFUN_HOST_DEVICE inline double beta(double a, double b) {
+        double y;
+        int sign = 1;
+
+        if (a <= 0.0) {
+            if (a == std::floor(a)) {
+                if (a == static_cast<int>(a)) {
+                    return detail::beta_negint(static_cast<int>(a), b);
+                } else {
+                    goto overflow;
+                }
+            }
+        }
+
+        if (b <= 0.0) {
+            if (b == std::floor(b)) {
+                if (b == static_cast<int>(b)) {
+                    return detail::beta_negint(static_cast<int>(b), a);
+                } else {
+                    goto overflow;
+                }
+            }
+        }
+
+        if (std::abs(a) < std::abs(b)) {
+            y = a;
+            a = b;
+            b = y;
+        }
+
+        if (std::abs(a) > detail::beta_ASYMP_FACTOR * std::abs(b) && a > detail::beta_ASYMP_FACTOR) {
+            /* Avoid loss of precision in lgam(a + b) - lgam(a) */
+            y = detail::lbeta_asymp(a, b, &sign);
+            return sign * std::exp(y);
+        }
+
+        y = a + b;
+        if (std::abs(y) > detail::MAXGAM || std::abs(a) > detail::MAXGAM || std::abs(b) > detail::MAXGAM) {
+            int sgngam;
+            y = detail::lgam_sgn(y, &sgngam);
+            sign *= sgngam; /* keep track of the sign */
+            y = detail::lgam_sgn(b, &sgngam) - y;
+            sign *= sgngam;
+            y = detail::lgam_sgn(a, &sgngam) + y;
+            sign *= sgngam;
+            if (y > detail::MAXLOG) {
+                goto overflow;
+            }
+            return (sign * std::exp(y));
+        }
+
+        y = Gamma(y);
+        a = Gamma(a);
+        b = Gamma(b);
+        if (y == 0.0)
+            goto overflow;
+
+        if (std::abs(std::abs(a) - std::abs(y)) > std::abs(std::abs(b) - std::abs(y))) {
+            y = b / y;
+            y *= a;
+        } else {
+            y = a / y;
+            y *= b;
+        }
+
+        return (y);
+
+    overflow:
+        set_error("beta", SF_ERROR_OVERFLOW, NULL);
+        return (sign * std::numeric_limits<double>::infinity());
+    }
+
+    /* Natural log of |beta|. */
+
+    SPECFUN_HOST_DEVICE inline double lbeta(double a, double b) {
+        double y;
+        int sign;
+
+        sign = 1;
+
+        if (a <= 0.0) {
+            if (a == std::floor(a)) {
+                if (a == static_cast<int>(a)) {
+                    return detail::lbeta_negint(static_cast<int>(a), b);
+                } else {
+                    goto over;
+                }
+            }
+        }
+
+        if (b <= 0.0) {
+            if (b == std::floor(b)) {
+                if (b == static_cast<int>(b)) {
+                    return detail::lbeta_negint(static_cast<int>(b), a);
+                } else {
+                    goto over;
+                }
+            }
+        }
+
+        if (std::abs(a) < std::abs(b)) {
+            y = a;
+            a = b;
+            b = y;
+        }
+
+        if (std::abs(a) > detail::beta_ASYMP_FACTOR * std::abs(b) && a > detail::beta_ASYMP_FACTOR) {
+            /* Avoid loss of precision in lgam(a + b) - lgam(a) */
+            y = detail::lbeta_asymp(a, b, &sign);
+            return y;
+        }
+
+        y = a + b;
+        if (std::abs(y) > detail::MAXGAM || std::abs(a) > detail::MAXGAM || std::abs(b) > detail::MAXGAM) {
+            int sgngam;
+            y = detail::lgam_sgn(y, &sgngam);
+            sign *= sgngam; /* keep track of the sign */
+            y = detail::lgam_sgn(b, &sgngam) - y;
+            sign *= sgngam;
+            y = detail::lgam_sgn(a, &sgngam) + y;
+            sign *= sgngam;
+            return (y);
+        }
+
+        y = Gamma(y);
+        a = Gamma(a);
+        b = Gamma(b);
+        if (y == 0.0) {
+        over:
+            set_error("lbeta", SF_ERROR_OVERFLOW, NULL);
+            return (sign * std::numeric_limits<double>::infinity());
+        }
+
+        if (std::abs(std::abs(a) - std::abs(y)) > std::abs(std::abs(b) - std::abs(y))) {
+            y = b / y;
+            y *= a;
+        } else {
+            y = a / y;
+            y *= b;
+        }
+
+        if (y < 0) {
+            y = -y;
+        }
+
+        return (std::log(y));
+    }
+} // namespace cephes
+} // namespace special

--- a/cupy/_core/include/cupy/special/cephes/const.h
+++ b/cupy/_core/include/cupy/special/cephes/const.h
@@ -1,0 +1,77 @@
+/* Translated into C++ by SciPy developers in 2024.
+ * Original header with Copyright information appears below.
+ *
+ * Since we support only IEEE-754 floating point numbers, conditional logic
+ * supporting other arithmetic types has been removed.
+ */
+
+/*
+ *
+ *
+ *                                                   const.c
+ *
+ *     Globally declared constants
+ *
+ *
+ *
+ * SYNOPSIS:
+ *
+ * extern double nameofconstant;
+ *
+ *
+ *
+ *
+ * DESCRIPTION:
+ *
+ * This file contains a number of mathematical constants and
+ * also some needed size parameters of the computer arithmetic.
+ * The values are supplied as arrays of hexadecimal integers
+ * for IEEE arithmetic, and in a normal decimal scientific notation for
+ * other machines.  The particular notation used is determined
+ * by a symbol (IBMPC, or UNK) defined in the include file
+ * mconf.h.
+ *
+ * The default size parameters are as follows.
+ *
+ * For UNK mode:
+ * MACHEP =  1.38777878078144567553E-17       2**-56
+ * MAXLOG =  8.8029691931113054295988E1       log(2**127)
+ * MINLOG = -8.872283911167299960540E1        log(2**-128)
+ *
+ * For IEEE arithmetic (IBMPC):
+ * MACHEP =  1.11022302462515654042E-16       2**-53
+ * MAXLOG =  7.09782712893383996843E2         log(2**1024)
+ * MINLOG = -7.08396418532264106224E2         log(2**-1022)
+ *
+ * The global symbols for mathematical constants are
+ * SQ2OPI =  7.9788456080286535587989E-1      sqrt( 2/pi )
+ * LOGSQ2 =  3.46573590279972654709E-1        log(2)/2
+ * THPIO4 =  2.35619449019234492885           3*pi/4
+ *
+ * These lists are subject to change.
+ */
+/*                                                     const.c */
+
+/*
+ * Cephes Math Library Release 2.3:  March, 1995
+ * Copyright 1984, 1995 by Stephen L. Moshier
+ */
+#pragma once
+
+namespace special {
+namespace cephes {
+    namespace detail {
+        constexpr double MACHEP = 1.11022302462515654042E-16;  // 2**-53
+        constexpr double MAXLOG = 7.09782712893383996732E2;    // log(DBL_MAX)
+        constexpr double MINLOG = -7.451332191019412076235E2;  // log 2**-1022
+        constexpr double SQ2OPI = 7.9788456080286535587989E-1; // sqrt( 2/pi )
+        constexpr double LOGSQ2 = 3.46573590279972654709E-1;   // log(2)/2
+        constexpr double THPIO4 = 2.35619449019234492885;      // 3*pi/4
+        // Following two added by SciPy developers.
+        // Euler's constant
+        constexpr double SCIPY_EULER = 0.577215664901532860606512090082402431;
+        // e as long double
+        constexpr long double SCIPY_El = 2.718281828459045235360287471352662498L;
+    } // namespace detail
+} // namespace cephes
+} // namespace special

--- a/cupy/_core/include/cupy/special/cephes/expn.h
+++ b/cupy/_core/include/cupy/special/cephes/expn.h
@@ -1,0 +1,288 @@
+/* Translated into C++ by SciPy developers in 2024.
+ * Original header with Copyright information appears below.
+ */
+
+/*                                                     expn.c
+ *
+ *             Exponential integral En
+ *
+ *
+ *
+ * SYNOPSIS:
+ *
+ * int n;
+ * double x, y, expn();
+ *
+ * y = expn( n, x );
+ *
+ *
+ *
+ * DESCRIPTION:
+ *
+ * Evaluates the exponential integral
+ *
+ *                 inf.
+ *                   -
+ *                  | |   -xt
+ *                  |    e
+ *      E (x)  =    |    ----  dt.
+ *       n          |      n
+ *                | |     t
+ *                 -
+ *                  1
+ *
+ *
+ * Both n and x must be nonnegative.
+ *
+ * The routine employs either a power series, a continued
+ * fraction, or an asymptotic formula depending on the
+ * relative values of n and x.
+ *
+ * ACCURACY:
+ *
+ *                      Relative error:
+ * arithmetic   domain     # trials      peak         rms
+ *    IEEE      0, 30       10000       1.7e-15     3.6e-16
+ *
+ */
+
+/*                                                     expn.c  */
+
+/* Cephes Math Library Release 1.1:  March, 1985
+ * Copyright 1985 by Stephen L. Moshier
+ * Direct inquiries to 30 Frost Street, Cambridge, MA 02140 */
+
+/* Sources
+ * [1] NIST, "The Digital Library of Mathematical Functions", dlmf.nist.gov
+ */
+
+/* Scipy changes:
+ * - 09-10-2016: improved asymptotic expansion for large n
+ */
+
+#include "../config.h"
+#include "error.h"
+#include "gamma.h"
+#include "polevl.h"
+
+namespace special {
+namespace cephes {
+
+    namespace detail {
+
+        constexpr int expn_nA = 13 constexpr double expn_A0[] = {1.00000000000000000};
+        constexpr double expn_A1[] = {1.00000000000000000};
+        constexpr double expn_A2[] = {-2.00000000000000000, 1.00000000000000000};
+        constexpr double expn_A3[] = {6.00000000000000000, -8.00000000000000000, 1.00000000000000000};
+        constexpr double expn_A4[] = {-24.0000000000000000, 58.0000000000000000, -22.0000000000000000,
+                                      1.00000000000000000};
+        constexpr double expn_A5[] = {120.000000000000000, -444.000000000000000, 328.000000000000000,
+                                      -52.0000000000000000, 1.00000000000000000};
+        constexpr double expn_A6[] = {-720.000000000000000, 3708.00000000000000,  -4400.00000000000000,
+                                      1452.00000000000000,  -114.000000000000000, 1.00000000000000000};
+        constexpr double expn_A7[] = {5040.00000000000000,  -33984.0000000000000, 58140.0000000000000,
+                                      -32120.0000000000000, 5610.00000000000000,  -240.000000000000000,
+                                      1.00000000000000000};
+        constexpr double expn_A8[] = {-40320.0000000000000, 341136.000000000000,  -785304.000000000000,
+                                      644020.000000000000,  -195800.000000000000, 19950.0000000000000,
+                                      -494.000000000000000, 1.00000000000000000};
+        constexpr double expn_A9[] = {362880.000000000000,  -3733920.00000000000, 11026296.0000000000,
+                                      -12440064.0000000000, 5765500.00000000000,  -1062500.00000000000,
+                                      67260.0000000000000,  -1004.00000000000000, 1.00000000000000000};
+        constexpr double expn_A10[] = {-3628800.00000000000, 44339040.0000000000,  -162186912.000000000,
+                                       238904904.000000000,  -155357384.000000000, 44765000.0000000000,
+                                       -5326160.00000000000, 218848.000000000000,  -2026.00000000000000,
+                                       1.00000000000000000};
+        constexpr double expn_A11[] = {39916800.0000000000,  -568356480.000000000, 2507481216.00000000,
+                                       -4642163952.00000000, 4002695088.00000000,  -1648384304.00000000,
+                                       314369720.000000000,  -25243904.0000000000, 695038.000000000000,
+                                       -4072.00000000000000, 1.00000000000000000};
+        constexpr double expn_A12[] = {-479001600.000000000, 7827719040.00000000,  -40788301824.0000000,
+                                       92199790224.0000000,  -101180433024.000000, 56041398784.0000000,
+                                       -15548960784.0000000, 2051482776.00000000,  -114876376.000000000,
+                                       2170626.00000000000,  -8166.00000000000000, 1.00000000000000000};
+        constexpr double *expn_expn_A[] = {expn_A0, expn_A1, expn_A2, expn_A3,  expn_A4,  expn_A5, expn_A6,
+                                           expn_A7, expn_A8, expn_A9, expn_A10, expn_A11, expn_A12};
+        constexpr int expn_Adegs[] = {0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
+
+        /* Asymptotic expansion for large n, DLMF 8.20(ii) */
+        SPECFUN_HOST_DEVICE double expn_large_n(int n, double x) {
+            int k;
+            double p = n;
+            double lambda = x / p;
+            double multiplier = 1 / p / (lambda + 1) / (lambda + 1);
+            double fac = 1;
+            double res = 1; /* A[0] = 1 */
+            double expfac, term;
+
+            expfac = std::exp(-lambda * p) / (lambda + 1) / p;
+            if (expfac == 0) {
+                set_error("expn", SF_ERROR_UNDERFLOW, NULL);
+                return 0;
+            }
+
+            /* Do the k = 1 term outside the loop since A[1] = 1 */
+            fac *= multiplier;
+            res += fac;
+
+            for (k = 2; k < nA; k++) {
+                fac *= multiplier;
+                term = fac * polevl(lambda, expn_A[k], expn_Adegs[k]);
+                res += term;
+                if (std::abs(term) < MACHEP * fabs(res)) {
+                    break;
+                }
+            }
+
+            return expfac * res;
+        }
+
+        SPECFUN_HOST_DEVICE double expn(int n, double x) {
+            double ans, r, t, yk, xk;
+            double pk, pkm1, pkm2, qk, qkm1, qkm2;
+            double psi, z;
+            int i, k;
+            constexpr double big = 1.44115188075855872E+17;
+
+            if (std::isnan(x)) {
+                return std::numeric_limits<double>::quiet_NaN();
+            } else if (n < 0 || x < 0) {
+                set_error("expn", SF_ERROR_DOMAIN, NULL);
+                return std::numeric_limits<double>::quiet_NaN();
+            }
+
+            if (x > detail::MAXLOG) {
+                return (0.0);
+            }
+
+            if (x == 0.0) {
+                if (n < 2) {
+                    set_error("expn", SF_ERROR_SINGULAR, NULL);
+                    return std::numeric_limits<double>::infinity();
+                } else {
+                    return (1.0 / (n - 1.0));
+                }
+            }
+
+            if (n == 0) {
+                return (std::exp(-x) / x);
+            }
+
+            /* Asymptotic expansion for large n, DLMF 8.20(ii) */
+            if (n > 50) {
+                ans = detail::expn_large_n(n, x);
+                goto done;
+            }
+
+            if (x > 1.0) {
+                goto cfrac;
+            }
+
+            /* Power series expansion, DLMF 8.19.8 */
+            psi = -detail::SCIPY_EULER - std::log(x);
+            for (i = 1; i < n; i++) {
+                psi = psi + 1.0 / i;
+            }
+
+            class SeriesGenerator {
+              public:
+                SeriesGenerator(double z, int n) : z(z), pk(1.0 - n), xk(0.0), yk(1.0) {
+                    if (n == 1) {
+                        current_term = 0.0;
+                    } else {
+                        current_term = 1.0 / pk;
+                    }
+                }
+
+                double operator()() {
+                    xk += 1.0;
+                    yk *= z / xk;
+                    pk += 1.0;
+                    if (pk != 0.0) {
+                        current_term = yk / pk;
+                    } else {
+                        current_term = 0.0;
+                    }
+                    return current_term;
+                }
+
+              private:
+                double z, pk, xk, yk;
+                double current_term;
+            };
+
+            z = -x;
+            xk = 0.0;
+            yk = 1.0;
+            pk = 1.0 - n;
+            if (n == 1) {
+                ans = 0.0;
+            } else {
+                ans = 1.0 / pk;
+            }
+            do {
+                xk += 1.0;
+                yk *= z / xk;
+                pk += 1.0;
+                if (pk != 0.0) {
+                    ans += yk / pk;
+                }
+                if (ans != 0.0)
+                    t = std::abs(yk / ans);
+                else
+                    t = 1.0;
+            } while (t > detail::MACHEP);
+            k = xk;
+            t = n;
+            r = n - 1;
+            ans = (std::pow(z, r) * psi / Gamma(t)) - ans;
+            goto done;
+
+            /* Continued fraction, DLMF 8.19.17 */
+        cfrac:
+            k = 1;
+            pkm2 = 1.0;
+            qkm2 = x;
+            pkm1 = 1.0;
+            qkm1 = x + n;
+            ans = pkm1 / qkm1;
+
+            do {
+                k += 1;
+                if (k & 1) {
+                    yk = 1.0;
+                    xk = n + (k - 1) / 2;
+                } else {
+                    yk = x;
+                    xk = k / 2;
+                }
+                pk = pkm1 * yk + pkm2 * xk;
+                qk = qkm1 * yk + qkm2 * xk;
+                if (qk != 0) {
+                    r = pk / qk;
+                    t = std::abs((ans - r) / r);
+                    ans = r;
+                } else {
+                    t = 1.0;
+                }
+                pkm2 = pkm1;
+                pkm1 = pk;
+                qkm2 = qkm1;
+                qkm1 = qk;
+                if (fabs(pk) > big) {
+                    pkm2 /= big;
+                    pkm1 /= big;
+                    qkm2 /= big;
+                    qkm1 /= big;
+                }
+            } while (t > MACHEP);
+
+            ans *= std::exp(-x);
+
+        done:
+            return (ans);
+        }
+
+    } // namespace detail
+} // namespace cephes
+} // namespace special

--- a/cupy/_core/include/cupy/special/cephes/gamma.h
+++ b/cupy/_core/include/cupy/special/cephes/gamma.h
@@ -1,0 +1,343 @@
+/* Translated into C++ by SciPy developers in 2024.
+ * Original header with Copyright information appears below.
+ */
+
+/*
+ *     Gamma function
+ *
+ *
+ *
+ * SYNOPSIS:
+ *
+ * double x, y, Gamma();
+ *
+ * y = Gamma( x );
+ *
+ *
+ *
+ * DESCRIPTION:
+ *
+ * Returns Gamma function of the argument.  The result is
+ * correctly signed.
+ *
+ * Arguments |x| <= 34 are reduced by recurrence and the function
+ * approximated by a rational function of degree 6/7 in the
+ * interval (2,3).  Large arguments are handled by Stirling's
+ * formula. Large negative arguments are made positive using
+ * a reflection formula.
+ *
+ *
+ * ACCURACY:
+ *
+ *                      Relative error:
+ * arithmetic   domain     # trials      peak         rms
+ *    IEEE    -170,-33      20000       2.3e-15     3.3e-16
+ *    IEEE     -33,  33     20000       9.4e-16     2.2e-16
+ *    IEEE      33, 171.6   20000       2.3e-15     3.2e-16
+ *
+ * Error for arguments outside the test range will be larger
+ * owing to error amplification by the exponential function.
+ *
+ */
+
+/*                                                     lgam()
+ *
+ *     Natural logarithm of Gamma function
+ *
+ *
+ *
+ * SYNOPSIS:
+ *
+ * double x, y, lgam();
+ *
+ * y = lgam( x );
+ *
+ *
+ *
+ * DESCRIPTION:
+ *
+ * Returns the base e (2.718...) logarithm of the absolute
+ * value of the Gamma function of the argument.
+ *
+ * For arguments greater than 13, the logarithm of the Gamma
+ * function is approximated by the logarithmic version of
+ * Stirling's formula using a polynomial approximation of
+ * degree 4. Arguments between -33 and +33 are reduced by
+ * recurrence to the interval [2,3] of a rational approximation.
+ * The cosecant reflection formula is employed for arguments
+ * less than -33.
+ *
+ * Arguments greater than MAXLGM return INFINITY and an error
+ * message.  MAXLGM = 2.556348e305 for IEEE arithmetic.
+ *
+ *
+ *
+ * ACCURACY:
+ *
+ *
+ * arithmetic      domain        # trials     peak         rms
+ *    IEEE    0, 3                 28000     5.4e-16     1.1e-16
+ *    IEEE    2.718, 2.556e305     40000     3.5e-16     8.3e-17
+ * The error criterion was relative when the function magnitude
+ * was greater than one but absolute when it was less than one.
+ *
+ * The following test used the relative error criterion, though
+ * at certain points the relative error could be much higher than
+ * indicated.
+ *    IEEE    -200, -4             10000     4.8e-16     1.3e-16
+ *
+ */
+
+/*
+ * Cephes Math Library Release 2.2:  July, 1992
+ * Copyright 1984, 1987, 1989, 1992 by Stephen L. Moshier
+ * Direct inquiries to 30 Frost Street, Cambridge, MA 02140
+ */
+#pragma once
+
+#include "../config.h"
+#include "../error.h"
+#include "polevl.h"
+
+namespace special {
+namespace cephes {
+    namespace detail {
+        constexpr double gamma_P[] = {1.60119522476751861407E-4, 1.19135147006586384913E-3, 1.04213797561761569935E-2,
+                                      4.76367800457137231464E-2, 2.07448227648435975150E-1, 4.94214826801497100753E-1,
+                                      9.99999999999999996796E-1};
+
+        constexpr double gamma_Q[] = {-2.31581873324120129819E-5, 5.39605580493303397842E-4, -4.45641913851797240494E-3,
+                                      1.18139785222060435552E-2,  3.58236398605498653373E-2, -2.34591795718243348568E-1,
+                                      7.14304917030273074085E-2,  1.00000000000000000320E0};
+
+        constexpr double MAXGAM = 171.624376956302725;
+        constexpr double LOGPI = 1.14472988584940017414;
+
+        /* Stirling's formula for the Gamma function */
+        constexpr double gamma_STIR[5] = {
+            7.87311395793093628397E-4, -2.29549961613378126380E-4, -2.68132617805781232825E-3,
+            3.47222221605458667310E-3, 8.33333333333482257126E-2,
+        };
+
+        constexpr double MAXSTIR = 143.01608;
+        constexpr double SQTPI = 2.50662827463100050242E0;
+
+        /* Gamma function computed by Stirling's formula.
+         * The polynomial STIR is valid for 33 <= x <= 172.
+         */
+        SPECFUN_HOST_DEVICE inline double stirf(double x) {
+            double y, w, v;
+
+            if (x >= MAXGAM) {
+                return (std::numeric_limits<double>::infinity());
+            }
+            w = 1.0 / x;
+            w = 1.0 + w * special::cephes::polevl(w, gamma_STIR, 4);
+            y = std::exp(x);
+            if (x > MAXSTIR) { /* Avoid overflow in pow() */
+                v = std::pow(x, 0.5 * x - 0.25);
+                y = v * (v / y);
+            } else {
+                y = std::pow(x, x - 0.5) / y;
+            }
+            y = SQTPI * y * w;
+            return (y);
+        }
+    } // namespace detail
+
+    SPECFUN_HOST_DEVICE inline double Gamma(double x) {
+        double p, q, z;
+        int i;
+        int sgngam = 1;
+
+        if (!std::isfinite(x)) {
+            return x;
+        }
+        q = std::abs(x);
+
+        if (q > 33.0) {
+            if (x < 0.0) {
+                p = floor(q);
+                if (p == q) {
+                gamnan:
+                    set_error("Gamma", SF_ERROR_OVERFLOW, NULL);
+                    return (std::numeric_limits<double>::infinity());
+                }
+                i = p;
+                if ((i & 1) == 0) {
+                    sgngam = -1;
+                }
+                z = q - p;
+                if (z > 0.5) {
+                    p += 1.0;
+                    z = q - p;
+                }
+                z = q * std::sin(M_PI * z);
+                if (z == 0.0) {
+                    return (sgngam * std::numeric_limits<double>::infinity());
+                }
+                z = std::abs(z);
+                z = M_PI / (z * detail::stirf(q));
+            } else {
+                z = detail::stirf(x);
+            }
+            return (sgngam * z);
+        }
+
+        z = 1.0;
+        while (x >= 3.0) {
+            x -= 1.0;
+            z *= x;
+        }
+
+        while (x < 0.0) {
+            if (x > -1.E-9) {
+                goto small;
+            }
+            z /= x;
+            x += 1.0;
+        }
+
+        while (x < 2.0) {
+            if (x < 1.e-9) {
+                goto small;
+            }
+            z /= x;
+            x += 1.0;
+        }
+
+        if (x == 2.0) {
+            return (z);
+        }
+
+        x -= 2.0;
+        p = polevl(x, detail::gamma_P, 6);
+        q = polevl(x, detail::gamma_Q, 7);
+        return (z * p / q);
+
+    small:
+        if (x == 0.0) {
+            goto gamnan;
+        } else
+            return (z / ((1.0 + 0.5772156649015329 * x) * x));
+    }
+
+    namespace detail {
+        /* A[]: Stirling's formula expansion of log Gamma
+         * B[], C[]: log Gamma function between 2 and 3
+         */
+        constexpr double gamma_A[] = {8.11614167470508450300E-4, -5.95061904284301438324E-4, 7.93650340457716943945E-4,
+                                      -2.77777777730099687205E-3, 8.33333333333331927722E-2};
+
+        constexpr double gamma_B[] = {-1.37825152569120859100E3, -3.88016315134637840924E4, -3.31612992738871184744E5,
+                                      -1.16237097492762307383E6, -1.72173700820839662146E6, -8.53555664245765465627E5};
+
+        constexpr double gamma_C[] = {
+            /* 1.00000000000000000000E0, */
+            -3.51815701436523470549E2, -1.70642106651881159223E4, -2.20528590553854454839E5,
+            -1.13933444367982507207E6, -2.53252307177582951285E6, -2.01889141433532773231E6};
+
+        /* log( sqrt( 2*pi ) ) */
+        constexpr double LS2PI = 0.91893853320467274178;
+
+        constexpr double MAXLGM = 2.556348e305;
+
+        SPECFUN_HOST_DEVICE double lgam_sgn(double x, int *sign) {
+            double p, q, u, w, z;
+            int i;
+
+            *sign = 1;
+
+            if (!std::isfinite(x)) {
+                return x;
+            }
+
+            if (x < -34.0) {
+                q = -x;
+                w = lgam_sgn(q, sign);
+                p = floor(q);
+                if (p == q) {
+                lgsing:
+                    set_error("lgam", SF_ERROR_SINGULAR, NULL);
+                    return (std::numeric_limits<double>::infinity());
+                }
+                i = p;
+                if ((i & 1) == 0) {
+                    *sign = -1;
+                } else {
+                    *sign = 1;
+                }
+                z = q - p;
+                if (z > 0.5) {
+                    p += 1.0;
+                    z = p - q;
+                }
+                z = q * std::sin(M_PI * z);
+                if (z == 0.0) {
+                    goto lgsing;
+                }
+                /*     z = log(M_PI) - log( z ) - w; */
+                z = LOGPI - std::log(z) - w;
+                return (z);
+            }
+
+            if (x < 13.0) {
+                z = 1.0;
+                p = 0.0;
+                u = x;
+                while (u >= 3.0) {
+                    p -= 1.0;
+                    u = x + p;
+                    z *= u;
+                }
+                while (u < 2.0) {
+                    if (u == 0.0) {
+                        goto lgsing;
+                    }
+                    z /= u;
+                    p += 1.0;
+                    u = x + p;
+                }
+                if (z < 0.0) {
+                    *sign = -1;
+                    z = -z;
+                } else {
+                    *sign = 1;
+                }
+                if (u == 2.0) {
+                    return (std::log(z));
+                }
+                p -= 2.0;
+                x = x + p;
+                p = x * polevl(x, gamma_B, 5) / p1evl(x, gamma_C, 6);
+                return (std::log(z) + p);
+            }
+
+            if (x > MAXLGM) {
+                return (*sign * std::numeric_limits<double>::infinity());
+            }
+
+            q = (x - 0.5) * std::log(x) - x + LS2PI;
+            if (x > 1.0e8) {
+                return (q);
+            }
+
+            p = 1.0 / (x * x);
+            if (x >= 1000.0) {
+                q += ((7.9365079365079365079365e-4 * p - 2.7777777777777777777778e-3) * p + 0.0833333333333333333333) /
+                     x;
+            } else {
+                q += polevl(p, gamma_A, 4) / x;
+            }
+            return (q);
+        }
+    } // namespace detail
+
+    /* Logarithm of Gamma function */
+    SPECFUN_HOST_DEVICE double lgam(double x) {
+        int sign;
+        return detail::lgam_sgn(x, &sign);
+    }
+
+} // namespace cephes
+} // namespace special

--- a/cupy/_core/include/cupy/special/cephes/mconf.h
+++ b/cupy/_core/include/cupy/special/cephes/mconf.h
@@ -1,0 +1,7 @@
+#include "../config.h"
+#include "../error.h"
+#include "const.h"
+
+namespace special {
+namespace cephes {
+    namespace detail

--- a/cupy/_core/include/cupy/special/cephes/polevl.h
+++ b/cupy/_core/include/cupy/special/cephes/polevl.h
@@ -1,0 +1,165 @@
+/* Translated into C++ by SciPy developers in 2024.
+ * Original header with Copyright information appears below.
+ */
+
+/*                                                     polevl.c
+ *                                                     p1evl.c
+ *
+ *     Evaluate polynomial
+ *
+ *
+ *
+ * SYNOPSIS:
+ *
+ * int N;
+ * double x, y, coef[N+1], polevl[];
+ *
+ * y = polevl( x, coef, N );
+ *
+ *
+ *
+ * DESCRIPTION:
+ *
+ * Evaluates polynomial of degree N:
+ *
+ *                     2          N
+ * y  =  C  + C x + C x  +...+ C x
+ *        0    1     2          N
+ *
+ * Coefficients are stored in reverse order:
+ *
+ * coef[0] = C  , ..., coef[N] = C  .
+ *            N                   0
+ *
+ * The function p1evl() assumes that c_N = 1.0 so that coefficent
+ * is omitted from the array.  Its calling arguments are
+ * otherwise the same as polevl().
+ *
+ *
+ * SPEED:
+ *
+ * In the interest of speed, there are no checks for out
+ * of bounds arithmetic.  This routine is used by most of
+ * the functions in the library.  Depending on available
+ * equipment features, the user may wish to rewrite the
+ * program in microcode or assembly language.
+ *
+ */
+
+/*
+ * Cephes Math Library Release 2.1:  December, 1988
+ * Copyright 1984, 1987, 1988 by Stephen L. Moshier
+ * Direct inquiries to 30 Frost Street, Cambridge, MA 02140
+ */
+
+/* Sources:
+ * [1] Holin et. al., "Polynomial and Rational Function Evaluation",
+ *     https://www.boost.org/doc/libs/1_61_0/libs/math/doc/html/math_toolkit/roots/rational.html
+ */
+
+/* Scipy changes:
+ * - 06-23-2016: add code for evaluating rational functions
+ */
+#pragma once
+
+#include "../config.h"
+
+namespace special {
+namespace cephes {
+    SPECFUN_HOST_DEVICE inline double polevl(double x, const double coef[], int N) {
+        double ans;
+        int i;
+        const double *p;
+
+        p = coef;
+        ans = *p++;
+        i = N;
+
+        do {
+            ans = ans * x + *p++;
+        } while (--i);
+
+        return (ans);
+    }
+
+    /*                                                     p1evl() */
+    /*                                          N
+     * Evaluate polynomial when coefficient of x  is 1.0.
+     * That is, C_{N} is assumed to be 1, and that coefficient
+     * is not included in the input array coef.
+     * coef must have length N and contain the polynomial coefficients
+     * stored as
+     *     coef[0] = C_{N-1}
+     *     coef[1] = C_{N-2}
+     *          ...
+     *     coef[N-2] = C_1
+     *     coef[N-1] = C_0
+     * Otherwise same as polevl.
+     */
+
+    SPECFUN_HOST_DEVICE inline double p1evl(double x, const double coef[], int N) {
+        double ans;
+        const double *p;
+        int i;
+
+        p = coef;
+        ans = x + *p++;
+        i = N - 1;
+
+        do
+            ans = ans * x + *p++;
+        while (--i);
+
+        return (ans);
+    }
+
+    /* Evaluate a rational function. See [1]. */
+
+    SPECFUN_HOST_DEVICE inline double ratevl(double x, const double num[], int M, const double denom[], int N) {
+        int i, dir;
+        double y, num_ans, denom_ans;
+        double absx = std::abs(x);
+        const double *p;
+
+        if (absx > 1) {
+            /* Evaluate as a polynomial in 1/x. */
+            dir = -1;
+            p = num + M;
+            y = 1 / x;
+        } else {
+            dir = 1;
+            p = num;
+            y = x;
+        }
+
+        /* Evaluate the numerator */
+        num_ans = *p;
+        p += dir;
+        for (i = 1; i <= M; i++) {
+            num_ans = num_ans * y + *p;
+            p += dir;
+        }
+
+        /* Evaluate the denominator */
+        if (absx > 1) {
+            p = denom + N;
+        } else {
+            p = denom;
+        }
+
+        denom_ans = *p;
+        p += dir;
+        for (i = 1; i <= N; i++) {
+            denom_ans = denom_ans * y + *p;
+            p += dir;
+        }
+
+        if (absx > 1) {
+            i = N - M;
+            return std::pow(x, i) * num_ans / denom_ans;
+        } else {
+            return num_ans / denom_ans;
+        }
+    }
+} // namespace cephes
+} // namespace special

--- a/cupy/_core/include/cupy/special/cephes/psi.h
+++ b/cupy/_core/include/cupy/special/cephes/psi.h
@@ -1,0 +1,194 @@
+/* Translated into C++ by SciPy developers in 2024.
+ * Original header with Copyright information appears below.
+ */
+
+/*                                                     psi.c
+ *
+ *     Psi (digamma) function
+ *
+ *
+ * SYNOPSIS:
+ *
+ * double x, y, psi();
+ *
+ * y = psi( x );
+ *
+ *
+ * DESCRIPTION:
+ *
+ *              d      -
+ *   psi(x)  =  -- ln | (x)
+ *              dx
+ *
+ * is the logarithmic derivative of the gamma function.
+ * For integer x,
+ *                   n-1
+ *                    -
+ * psi(n) = -EUL  +   >  1/k.
+ *                    -
+ *                   k=1
+ *
+ * This formula is used for 0 < n <= 10.  If x is negative, it
+ * is transformed to a positive argument by the reflection
+ * formula  psi(1-x) = psi(x) + pi cot(pi x).
+ * For general positive x, the argument is made greater than 10
+ * using the recurrence  psi(x+1) = psi(x) + 1/x.
+ * Then the following asymptotic expansion is applied:
+ *
+ *                           inf.   B
+ *                            -      2k
+ * psi(x) = log(x) - 1/2x -   >   -------
+ *                            -        2k
+ *                           k=1   2k x
+ *
+ * where the B2k are Bernoulli numbers.
+ *
+ * ACCURACY:
+ *    Relative error (except absolute when |psi| < 1):
+ * arithmetic   domain     # trials      peak         rms
+ *    IEEE      0,30        30000       1.3e-15     1.4e-16
+ *    IEEE      -30,0       40000       1.5e-15     2.2e-16
+ *
+ * ERROR MESSAGES:
+ *     message         condition      value returned
+ * psi singularity    x integer <=0      INFINITY
+ */
+
+/*
+ * Cephes Math Library Release 2.8:  June, 2000
+ * Copyright 1984, 1987, 1992, 2000 by Stephen L. Moshier
+ */
+
+/*
+ * Code for the rational approximation on [1, 2] is:
+ *
+ * (C) Copyright John Maddock 2006.
+ * Use, modification and distribution are subject to the
+ * Boost Software License, Version 1.0. (See accompanying file
+ * LICENSE_1_0.txt or copy at https://www.boost.org/LICENSE_1_0.txt)
+ */
+#pragma once
+
+#include "../config.h"
+#include "../error.h"
+#include "const.h"
+#include "polevl.h"
+
+namespace special {
+namespace cephes {
+    namespace detail {
+        constexpr double psi_A[] = {8.33333333333333333333E-2,  -2.10927960927960927961E-2, 7.57575757575757575758E-3,
+                                    -4.16666666666666666667E-3, 3.96825396825396825397E-3,  -8.33333333333333333333E-3,
+                                    8.33333333333333333333E-2};
+
+        constexpr float psi_Y = 0.99558162689208984f;
+
+        constexpr double psi_root1 = 1569415565.0 / 1073741824.0;
+        constexpr double psi_root2 = (381566830.0 / 1073741824.0) / 1073741824.0;
+        constexpr double psi_root3 = 0.9016312093258695918615325266959189453125e-19;
+
+        constexpr double psi_P[] = {-0.0020713321167745952, -0.045251321448739056, -0.28919126444774784,
+                                    -0.65031853770896507,   -0.32555031186804491,  0.25479851061131551};
+        constexpr double psi_Q[] = {-0.55789841321675513e-6,
+                                    0.0021284987017821144,
+                                    0.054151797245674225,
+                                    0.43593529692665969,
+                                    1.4606242909763515,
+                                    2.0767117023730469,
+                                    1.0};
+
+        SPECFUN_HOST_DEVICE double digamma_imp_1_2(double x) {
+            /*
+             * Rational approximation on [1, 2] taken from Boost.
+             *
+             * Now for the approximation, we use the form:
+             *
+             * digamma(x) = (x - root) * (Y + R(x-1))
+             *
+             * Where root is the location of the positive root of digamma,
+             * Y is a constant, and R is optimised for low absolute error
+             * compared to Y.
+             *
+             * Maximum Deviation Found:               1.466e-18
+             * At double precision, max error found:  2.452e-17
+             */
+            double r, g;
+
+            g = x - psi_root1;
+            g -= psi_root2;
+            g -= psi_root3;
+            r = special::cephes::polevl(x - 1.0, psi_P, 5) / special::cephes::polevl(x - 1.0, psi_Q, 6);
+
+            return g * psi_Y + g * r;
+        }
+
+        SPECFUN_HOST_DEVICE double psi_asy(double x) {
+            double y, z;
+
+            if (x < 1.0e17) {
+                z = 1.0 / (x * x);
+                y = z * special::cephes::polevl(z, psi_A, 6);
+            } else {
+                y = 0.0;
+            }
+
+            return std::log(x) - (0.5 / x) - y;
+        }
+    } // namespace detail
+
+    SPECFUN_HOST_DEVICE double psi(double x) {
+        double y = 0.0;
+        double q, r;
+        int i, n;
+
+        if (std::isnan(x)) {
+            return x;
+        } else if (x == std::numeric_limits<double>::infinity()) {
+            return x;
+        } else if (x == -std::numeric_limits<double>::infinity()) {
+            return std::numeric_limits<double>::quiet_NaN();
+        } else if (x == 0) {
+            set_error("psi", SF_ERROR_SINGULAR, NULL);
+            return std::copysign(std::numeric_limits<double>::infinity(), -x);
+        } else if (x < 0.0) {
+            /* argument reduction before evaluating tan(pi * x) */
+            r = std::modf(x, &q);
+            if (r == 0.0) {
+                set_error("psi", SF_ERROR_SINGULAR, NULL);
+                return std::numeric_limits<double>::quiet_NaN();
+            }
+            y = -M_PI / std::tan(M_PI * r);
+            x = 1.0 - x;
+        }
+
+        /* check for positive integer up to 10 */
+        if ((x <= 10.0) && (x == std::floor(x))) {
+            n = static_cast<int>(x);
+            for (i = 1; i < n; i++) {
+                y += 1.0 / i;
+            }
+            y -= detail::SCIPY_EULER;
+            return y;
+        }
+
+        /* use the recurrence relation to move x into [1, 2] */
+        if (x < 1.0) {
+            y -= 1.0 / x;
+            x += 1.0;
+        } else if (x < 10.0) {
+            while (x > 2.0) {
+                x -= 1.0;
+                y += 1.0 / x;
+            }
+        }
+        if ((1.0 <= x) && (x <= 2.0)) {
+            y += detail::digamma_imp_1_2(x);
+            return y;
+        }
+
+        /* x is large, use the asymptotic series */
+        y += detail::psi_asy(x);
+        return y;
+    }
+} // namespace cephes
+} // namespace special

--- a/cupy/_core/include/cupy/special/cephes/trig.h
+++ b/cupy/_core/include/cupy/special/cephes/trig.h
@@ -1,0 +1,56 @@
+/* Translated into C++ by SciPy developers in 2024.
+ *
+ * Original author: Josh Wilson, 2020.
+ */
+
+/*
+ * Implement sin(pi * x) and cos(pi * x) for real x. Since the periods
+ * of these functions are integral (and thus representable in double
+ * precision), it's possible to compute them with greater accuracy
+ * than sin(x) and cos(x).
+ */
+#pragma once
+
+#include "../config.h"
+
+namespace special {
+namespace cephes {
+
+    /* Compute sin(pi * x). */
+    SPECFUN_HOST_DEVICE double sinpi(double x) {
+        double s = 1.0;
+
+        if (x < 0.0) {
+            x = -x;
+            s = -1.0;
+        }
+
+        double r = fmod(x, 2.0);
+        if (r < 0.5) {
+            return s * sin(M_PI * r);
+        } else if (r > 1.5) {
+            return s * sin(M_PI * (r - 2.0));
+        } else {
+            return -s * sin(M_PI * (r - 1.0));
+        }
+    }
+
+    /* Compute cos(pi * x) */
+    SPECFUN_HOST_DEVICE double cospi(double x) {
+        if (x < 0.0) {
+            x = -x;
+        }
+
+        double r = fmod(x, 2.0);
+        if (r == 0.5) {
+            // We don't want to return -0.0
+            return 0.0;
+        }
+        if (r < 1.0) {
+            return -sin(M_PI * (r - 0.5));
+        } else {
+            return sin(M_PI * (r - 1.5));
+        }
+    }
+} // namespace cephes
+} // namespace special

--- a/cupy/_core/include/cupy/special/cephes/zeta.h
+++ b/cupy/_core/include/cupy/special/cephes/zeta.h
@@ -1,0 +1,172 @@
+/* Translated into C++ by SciPy developers in 2024.
+ * Original header with Copyright information appears below.
+ */
+
+/*                                                     zeta.c
+ *
+ *     Riemann zeta function of two arguments
+ *
+ *
+ *
+ * SYNOPSIS:
+ *
+ * double x, q, y, zeta();
+ *
+ * y = zeta( x, q );
+ *
+ *
+ *
+ * DESCRIPTION:
+ *
+ *
+ *
+ *                 inf.
+ *                  -        -x
+ *   zeta(x,q)  =   >   (k+q)
+ *                  -
+ *                 k=0
+ *
+ * where x > 1 and q is not a negative integer or zero.
+ * The Euler-Maclaurin summation formula is used to obtain
+ * the expansion
+ *
+ *                n
+ *                -       -x
+ * zeta(x,q)  =   >  (k+q)
+ *                -
+ *               k=1
+ *
+ *           1-x                 inf.  B   x(x+1)...(x+2j)
+ *      (n+q)           1         -     2j
+ *  +  ---------  -  -------  +   >    --------------------
+ *        x-1              x      -                   x+2j+1
+ *                   2(n+q)      j=1       (2j)! (n+q)
+ *
+ * where the B2j are Bernoulli numbers.  Note that (see zetac.c)
+ * zeta(x,1) = zetac(x) + 1.
+ *
+ *
+ *
+ * ACCURACY:
+ *
+ *
+ *
+ * REFERENCE:
+ *
+ * Gradshteyn, I. S., and I. M. Ryzhik, Tables of Integrals,
+ * Series, and Products, p. 1073; Academic Press, 1980.
+ *
+ */
+
+/*
+ * Cephes Math Library Release 2.0:  April, 1987
+ * Copyright 1984, 1987 by Stephen L. Moshier
+ * Direct inquiries to 30 Frost Street, Cambridge, MA 02140
+ */
+#pragma once
+
+#include "../config.h"
+#include "../error.h"
+#include "const.h"
+
+namespace special {
+namespace cephes {
+
+    namespace detail {
+        /* Expansion coefficients
+         * for Euler-Maclaurin summation formula
+         * (2k)! / B2k
+         * where B2k are Bernoulli numbers
+         */
+        constexpr double zeta_A[] = {
+            12.0,
+            -720.0,
+            30240.0,
+            -1209600.0,
+            47900160.0,
+            -1.8924375803183791606e9, /*1.307674368e12/691 */
+            7.47242496e10,
+            -2.950130727918164224e12,  /*1.067062284288e16/3617 */
+            1.1646782814350067249e14,  /*5.109094217170944e18/43867 */
+            -4.5979787224074726105e15, /*8.028576626982912e20/174611 */
+            1.8152105401943546773e17,  /*1.5511210043330985984e23/854513 */
+            -7.1661652561756670113e18  /*1.6938241367317436694528e27/236364091 */
+        };
+
+        /* 30 Nov 86 -- error in third coefficient fixed */
+    } // namespace detail
+
+    SPECFUN_HOST_DEVICE double zeta(double x, double q) {
+        int i;
+        double a, b, k, s, t, w;
+
+        if (x == 1.0)
+            goto retinf;
+
+        if (x < 1.0) {
+        domerr:
+            set_error("zeta", SF_ERROR_DOMAIN, NULL);
+            return (std::numeric_limits<double>::quiet_NaN());
+        }
+
+        if (q <= 0.0) {
+            if (q == floor(q)) {
+                set_error("zeta", SF_ERROR_SINGULAR, NULL);
+            retinf:
+                return (std::numeric_limits<double>::infinity());
+            }
+            if (x != std::floor(x))
+                goto domerr; /* because q^-x not defined */
+        }
+
+        /* Asymptotic expansion
+         * https://dlmf.nist.gov/25.11#E43
+         */
+        if (q > 1e8) {
+            return (1 / (x - 1) + 1 / (2 * q)) * std::pow(q, 1 - x);
+        }
+
+        /* Euler-Maclaurin summation formula */
+
+        /* Permit negative q but continue sum until n+q > +9 .
+         * This case should be handled by a reflection formula.
+         * If q<0 and x is an integer, there is a relation to
+         * the polyGamma function.
+         */
+        s = std::pow(q, -x);
+        a = q;
+        i = 0;
+        b = 0.0;
+        while ((i < 9) || (a <= 9.0)) {
+            i += 1;
+            a += 1.0;
+            b = std::pow(a, -x);
+            s += b;
+            if (std::abs(b / s) < detail::MACHEP)
+                goto done;
+        }
+
+        w = a;
+        s += b * w / (x - 1.0);
+        s -= 0.5 * b;
+        a = 1.0;
+        k = 0.0;
+        for (i = 0; i < 12; i++) {
+            a *= x + k;
+            b /= w;
+            t = a * b / detail::zeta_A[i];
+            s = s + t;
+            t = std::abs(t / s);
+            if (t < detail::MACHEP)
+                goto done;
+            k += 1.0;
+            a *= x + k;
+            b /= w;
+            k += 1.0;
+        }
+    done:
+        return (s);
+    }
+
+} // namespace cephes
+} // namespace special

--- a/cupy/_core/include/cupy/special/config.h
+++ b/cupy/_core/include/cupy/special/config.h
@@ -82,13 +82,30 @@ SPECFUN_HOST_DEVICE inline double pow(double x, double y) { return cuda::std::po
 
 SPECFUN_HOST_DEVICE inline double sin(double x) { return cuda::std::sin(x); }
 
+SPECFUN_HOST_DEVICE inline double tan(double x) { return cuda::std::tan(x); }
+
+SPECFUN_HOST_DEVICE inline double sinh(double x) { return cuda::std::sinh(x); }
+
+SPECFUN_HOST_DEVICE inline double cosh(double x) { return cuda::std::cosh(x); }
+
+SPECFUN_HOST_DEVICE inline bool signbit(double x) { return cuda::std::signbit(x); }
+
 // Fallback to global namespace for functions unsupported on NVRTC
 #ifndef _LIBCUDACXX_COMPILER_NVRTC
+SPECFUN_HOST_DEVICE inline double ceil(double x) { return cuda::std::ceil(x); }
 SPECFUN_HOST_DEVICE inline double floor(double x) { return cuda::std::floor(x); }
+SPECFUN_HOST_DEVICE inline double trunc(double x) { return cuda::std::trunc(x); }
 SPECFUN_HOST_DEVICE inline double fma(double x, double y, double z) { return cuda::std::fma(x, y, z); }
+SPECFUN_HOST_DEVICE inline double copysign(double x, double y) { return cuda::std::copysign(x, y); }
+SPECFUN_HOST_DEVICE inline double modf(double value, double *iptr) { return cuda::std::modf(value, iptr); }
+
 #else
+SPECFUN_HOST_DEVICE inline double ceil(double x) { return ::ceil(x); }
 SPECFUN_HOST_DEVICE inline double floor(double x) { return ::floor(x); }
+SPECFUN_HOST_DEVICE inline double trunc(double x) { return ::trunc(x); }
 SPECFUN_HOST_DEVICE inline double fma(double x, double y, double z) { return ::fma(x, y, z); }
+SPECFUN_HOST_DEVICE inline double copysign(double x, double y) { return ::copysign(x, y); }
+SPECFUN_HOST_DEVICE inline double modf(double value, double *iptr) { return ::modf(value, iptr); }
 #endif
 
 template <typename T>
@@ -121,6 +138,11 @@ SPECFUN_HOST_DEVICE T norm(const complex<T> &z) {
 template <typename T>
 SPECFUN_HOST_DEVICE complex<T> sqrt(const complex<T> &z) {
     return thrust::sqrt(z);
+}
+
+template <typename T>
+SPECFUN_HOST_DEVICE complex<T> conj(const complex<T> &z) {
+    return thrust::conj(z);
 }
 
 } // namespace std

--- a/cupy/_core/include/cupy/special/digamma.h
+++ b/cupy/_core/include/cupy/special/digamma.h
@@ -93,6 +93,14 @@ namespace detail {
         std::complex<double> term;
         std::complex<double> res;
 
+        if (!(std::isfinite(z.real()) && std::isfinite(z.imag()))) {
+            /* Check for infinity (or nan) and return early.
+             * Result of division by complex infinity is implementation dependent.
+             * and has been observed to vary between C++ stdlib and CUDA stdlib.
+             */
+            return std::log(z);
+        }
+
         res = std::log(z) - 0.5 / z;
 
         for (int k = 1; k < 17; k++) {

--- a/cupy/_core/include/cupy/special/digamma.h
+++ b/cupy/_core/include/cupy/special/digamma.h
@@ -1,0 +1,190 @@
+/* Translated from Cython into C++ by SciPy developers in 2024.
+ * Original header comment appears below.
+ */
+
+/* An implementation of the digamma function for complex arguments.
+ *
+ * Author: Josh Wilson
+ *
+ * Distributed under the same license as Scipy.
+ *
+ * Sources:
+ * [1] "The Digital Library of Mathematical Functions", dlmf.nist.gov
+ *
+ * [2] mpmath (version 0.19), http://mpmath.org
+ */
+
+#pragma once
+
+#include "cephes/psi.h"
+#include "cephes/zeta.h"
+#include "config.h"
+#include "error.h"
+#include "trig.h"
+
+namespace special {
+namespace detail {
+    // All of the following were computed with mpmath
+    // Location of the positive root
+    constexpr double digamma_posroot = 1.4616321449683623;
+    // Value of the positive root
+    constexpr double digamma_posrootval = -9.2412655217294275e-17;
+    // Location of the negative root
+    constexpr double digamma_negroot = -0.504083008264455409;
+    // Value of the negative root
+    constexpr double digamma_negrootval = 7.2897639029768949e-17;
+
+    template <typename T>
+    SPECFUN_HOST_DEVICE T digamma_zeta_series(T z, double root, double rootval) {
+        T res = rootval;
+        T coeff = -1.0;
+
+        z = z - root;
+        T term;
+        for (int n = 1; n < 100; n++) {
+            coeff *= -z;
+            term = coeff * cephes::zeta(n + 1, root);
+            res += term;
+            if (std::abs(term) < std::numeric_limits<double>::epsilon() * std::abs(res)) {
+                break;
+            }
+        }
+        return res;
+    }
+
+    SPECFUN_HOST_DEVICE inline std::complex<double> digamma_forward_recurrence(std::complex<double> z,
+                                                                               std::complex<double> psiz, int n) {
+        /* Compute digamma(z + n) using digamma(z) using the recurrence
+         * relation
+         *
+         * digamma(z + 1) = digamma(z) + 1/z.
+         *
+         * See https://dlmf.nist.gov/5.5#E2 */
+        std::complex<double> res = psiz;
+
+        for (int k = 0; k < n; k++) {
+            res += 1.0 / (z + static_cast<double>(k));
+        }
+        return res;
+    }
+
+    SPECFUN_HOST_DEVICE inline std::complex<double> digamma_backward_recurrence(std::complex<double> z,
+                                                                                std::complex<double> psiz, int n) {
+        /* Compute digamma(z - n) using digamma(z) and a recurrence relation. */
+        std::complex<double> res = psiz;
+
+        for (int k = 1; k < n + 1; k++) {
+            res -= 1.0 / (z - static_cast<double>(k));
+        }
+        return res;
+    }
+
+    SPECFUN_HOST_DEVICE inline std::complex<double> digamma_asymptotic_series(std::complex<double> z) {
+        /* Evaluate digamma using an asymptotic series. See
+         *
+         * https://dlmf.nist.gov/5.11#E2 */
+        double bernoulli2k[] = {
+            0.166666666666666667,  -0.0333333333333333333, 0.0238095238095238095, -0.0333333333333333333,
+            0.0757575757575757576, -0.253113553113553114,  1.16666666666666667,   -7.09215686274509804,
+            54.9711779448621554,   -529.124242424242424,   6192.12318840579710,   -86580.2531135531136,
+            1425517.16666666667,   -27298231.0678160920,   601580873.900642368,   -15116315767.0921569};
+        std::complex<double> rzz = 1.0 / z / z;
+        std::complex<double> zfac = 1.0;
+        std::complex<double> term;
+        std::complex<double> res;
+
+        res = std::log(z) - 0.5 / z;
+
+        for (int k = 1; k < 17; k++) {
+            zfac *= rzz;
+            term = -bernoulli2k[k - 1] * zfac / (2 * static_cast<double>(k));
+            res += term;
+            if (std::abs(term) < std::numeric_limits<double>::epsilon() * std::abs(res)) {
+                break;
+            }
+        }
+        return res;
+    }
+
+} // namespace detail
+
+SPECFUN_HOST_DEVICE inline double digamma(double z) {
+    /* Wrap Cephes' psi to take advantage of the series expansion around
+     * the smallest negative zero.
+     */
+    if (std::abs(z - detail::digamma_negroot) < 0.3) {
+        return detail::digamma_zeta_series(z, detail::digamma_negroot, detail::digamma_negrootval);
+    }
+    return cephes::psi(z);
+}
+
+SPECFUN_HOST_DEVICE inline std::complex<double> digamma(std::complex<double> z) {
+    /*
+     * Compute the digamma function for complex arguments. The strategy
+     * is:
+     *
+     * - Around the two zeros closest to the origin (posroot and negroot)
+     * use a Taylor series with precomputed zero order coefficient.
+     * - If close to the origin, use a recurrence relation to step away
+     * from the origin.
+     * - If close to the negative real axis, use the reflection formula
+     * to move to the right halfplane.
+     * - If |z| is large (> 16), use the asymptotic series.
+     * - If |z| is small, use a recurrence relation to make |z| large
+     * enough to use the asymptotic series.
+     */
+    double absz = std::abs(z);
+    std::complex<double> res = 0;
+    /* Use the asymptotic series for z away from the negative real axis
+     * with abs(z) > smallabsz. */
+    int smallabsz = 16;
+    /* Use the reflection principle for z with z.real < 0 that are within
+     * smallimag of the negative real axis.
+     * int smallimag = 6  # unused below except in a comment */
+
+    if (z.real() <= 0.0 && std::ceil(z.real()) == z) {
+        // Poles
+        set_error("digamma", SF_ERROR_SINGULAR, NULL);
+        return {std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN()};
+    }
+    if (std::abs(z - detail::digamma_negroot) < 0.3) {
+        // First negative root.
+        return detail::digamma_zeta_series(z, detail::digamma_negroot, detail::digamma_negrootval);
+    }
+
+    if (z.real() < 0 and std::abs(z.imag()) < smallabsz) {
+        /* Reflection formula for digamma. See
+         *
+         *https://dlmf.nist.gov/5.5#E4
+         */
+        res = -M_PI * cospi(z) / sinpi(z);
+        z = 1.0 - z;
+        absz = std::abs(z);
+    }
+
+    if (absz < 0.5) {
+        /* Use one step of the recurrence relation to step away from
+         * the pole. */
+        res = -1.0 / z;
+        z += 1.0;
+        absz = std::abs(z);
+    }
+
+    if (std::abs(z - detail::digamma_posroot) < 0.5) {
+        res += detail::digamma_zeta_series(z, detail::digamma_posroot, detail::digamma_posrootval);
+    } else if (absz > smallabsz) {
+        res += detail::digamma_asymptotic_series(z);
+    } else if (z.real() >= 0.0) {
+        double n = std::trunc(smallabsz - absz) + 1;
+        std::complex<double> init = detail::digamma_asymptotic_series(z + n);
+        res += detail::digamma_backward_recurrence(z + n, init, n);
+    } else {
+        // z.real() < 0, absz < smallabsz, and z.imag() > smallimag
+        double n = std::trunc(smallabsz - absz) - 1;
+        std::complex<double> init = detail::digamma_asymptotic_series(z - n);
+        res += detail::digamma_forward_recurrence(z - n, init, n);
+    }
+    return res;
+}
+
+} // namespace special

--- a/cupy/_core/include/cupy/special/evalpoly.h
+++ b/cupy/_core/include/cupy/special/evalpoly.h
@@ -1,3 +1,8 @@
+/* Translated from Cython into C++ by SciPy developers in 2024.
+ *
+ * Original author: Josh Wilson, 2016.
+ */
+
 /* Evaluate polynomials.
  *
  * All of the coefficients are stored in reverse order, i.e. if the

--- a/cupy/_core/include/cupy/special/lambertw.h
+++ b/cupy/_core/include/cupy/special/lambertw.h
@@ -1,3 +1,7 @@
+/* Translated from Cython into C++ by SciPy developers in 2023.
+ * Original header with Copyright information appears below.
+ */
+
 /* Implementation of the Lambert W function [1]. Based on MPMath
  *  Implementation [2], and documentation [3].
  *
@@ -5,7 +9,7 @@
  * Author email: mellerf@netvision.net.il
  *
  * Distributed under the same license as SciPy
- * Translated into C++ by SciPy developers, 2023.
+ *
  *
  * References:
  * [1] On the Lambert W function, Adv. Comp. Math. 5 (1996) 329-359,
@@ -135,7 +139,7 @@ SPECFUN_HOST_DEVICE inline std::complex<double> lambertw(std::complex<double> z,
     }
 
     set_error("lambertw", SF_ERROR_SLOW, "iteration failed to converge: %g + %gj", z.real(), z.imag());
-    return std::complex<double>(std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN());
+    return {std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN()};
 }
 
 } // namespace special

--- a/cupy/_core/include/cupy/special/loggamma.h
+++ b/cupy/_core/include/cupy/special/loggamma.h
@@ -1,0 +1,158 @@
+/* Translated from Cython into C++ by SciPy developers in 2024.
+ * Original header comment appears below.
+ */
+
+/* An implementation of the principal branch of the logarithm of
+ * Gamma. Also contains implementations of Gamma and 1/Gamma which are
+ * easily computed from log-Gamma.
+ *
+ * Author: Josh Wilson
+ *
+ * Distributed under the same license as Scipy.
+ *
+ * References
+ * ----------
+ * [1] Hare, "Computing the Principal Branch of log-Gamma",
+ *     Journal of Algorithms, 1997.
+ *
+ * [2] Julia,
+ *     https://github.com/JuliaLang/julia/blob/master/base/special/gamma.jl
+ */
+
+#pragma once
+
+#include "cephes/gamma.h"
+#include "config.h"
+#include "error.h"
+#include "evalpoly.h"
+#include "trig.h"
+#include "zlog1.h"
+
+namespace special {
+
+namespace detail {
+    constexpr double loggamma_SMALLX = 7;
+    constexpr double loggamma_SMALLY = 7;
+    constexpr double loggamma_HLOG2PI = 0.918938533204672742;      // log(2*pi)/2
+    constexpr double loggamma_LOGPI = 1.1447298858494001741434262; // log(pi)
+    constexpr double loggamma_TAYLOR_RADIUS = 0.2;
+
+    SPECFUN_HOST_DEVICE std::complex<double> loggamma_stirling(std::complex<double> z) {
+        /* Stirling series for log-Gamma
+         *
+         * The coefficients are B[2*n]/(2*n*(2*n - 1)) where B[2*n] is the
+         * (2*n)th Bernoulli number. See (1.1) in [1].
+         */
+        double coeffs[] = {-2.955065359477124183E-2,  6.4102564102564102564E-3, -1.9175269175269175269E-3,
+                           8.4175084175084175084E-4,  -5.952380952380952381E-4, 7.9365079365079365079E-4,
+                           -2.7777777777777777778E-3, 8.3333333333333333333E-2};
+        std::complex<double> rz = 1.0 / z;
+        std::complex<double> rzz = rz / z;
+
+        return (z - 0.5) * std::log(z) - z + loggamma_HLOG2PI + rz * cevalpoly(coeffs, 7, rzz);
+    }
+
+    SPECFUN_HOST_DEVICE std::complex<double> loggamma_recurrence(std::complex<double> z) {
+        /* Backward recurrence relation.
+         *
+         * See Proposition 2.2 in [1] and the Julia implementation [2].
+         *
+         */
+        int signflips = 0;
+        int sb = 0;
+        std::complex<double> shiftprod = z;
+
+        z += 1.0;
+        int nsb;
+        while (z.real() <= loggamma_SMALLX) {
+            shiftprod *= z;
+            nsb = std::signbit(shiftprod.imag());
+            signflips += nsb != 0 && sb == 0 ? 1 : 0;
+            sb = nsb;
+            z += 1.0;
+        }
+        return loggamma_stirling(z) - std::log(shiftprod) - signflips * 2 * M_PI * std::complex<double>(0, 1);
+    }
+
+    SPECFUN_HOST_DEVICE std::complex<double> loggamma_taylor(std::complex<double> z) {
+        /* Taylor series for log-Gamma around z = 1.
+         *
+         * It is
+         *
+         * loggamma(z + 1) = -gamma*z + zeta(2)*z**2/2 - zeta(3)*z**3/3 ...
+         *
+         * where gamma is the Euler-Mascheroni constant.
+         */
+
+        double coeffs[] = {
+            -4.3478266053040259361E-2, 4.5454556293204669442E-2, -4.7619070330142227991E-2, 5.000004769810169364E-2,
+            -5.2631679379616660734E-2, 5.5555767627403611102E-2, -5.8823978658684582339E-2, 6.2500955141213040742E-2,
+            -6.6668705882420468033E-2, 7.1432946295361336059E-2, -7.6932516411352191473E-2, 8.3353840546109004025E-2,
+            -9.0954017145829042233E-2, 1.0009945751278180853E-1, -1.1133426586956469049E-1, 1.2550966952474304242E-1,
+            -1.4404989676884611812E-1, 1.6955717699740818995E-1, -2.0738555102867398527E-1, 2.7058080842778454788E-1,
+            -4.0068563438653142847E-1, 8.2246703342411321824E-1, -5.7721566490153286061E-1};
+
+        z -= 1.0;
+        return z * cevalpoly(coeffs, 22, z);
+    }
+} // namespace detail
+
+SPECFUN_HOST_DEVICE inline double loggamma(double x) {
+    if (x < 0.0) {
+        return std::numeric_limits<double>::quiet_NaN();
+    }
+    return cephes::lgam(x);
+}
+
+SPECFUN_HOST_DEVICE inline std::complex<double> loggamma(std::complex<double> z) {
+    // Compute the principal branch of log-Gamma
+
+    if (std::isnan(z.real()) || std::isnan(z.imag())) {
+        return {std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN()};
+    }
+    if (z.real() <= 0 and z == std::floor(z.real())) {
+        set_error("loggamma", SF_ERROR_SINGULAR, NULL);
+        return {std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN()};
+    }
+    if (z.real() > detail::loggamma_SMALLX || std::abs(z.imag()) > detail::loggamma_SMALLY) {
+        return detail::loggamma_stirling(z);
+    }
+    if (std::abs(z - 1.0) < detail::loggamma_TAYLOR_RADIUS) {
+        return detail::loggamma_taylor(z);
+    }
+    if (std::abs(z - 2.0) < detail::loggamma_TAYLOR_RADIUS) {
+        // Recurrence relation and the Taylor series around 1.
+        return detail::zlog1(z - 1.0) + detail::loggamma_taylor(z - 1.0);
+    }
+    if (z.real() < 0.1) {
+        // Reflection formula; see Proposition 3.1 in [1]
+        double tmp = std::copysign(2 * M_PI, z.imag()) * std::floor(0.5 * z.real() + 0.25);
+        return std::complex<double>(detail::loggamma_LOGPI, tmp) - std::log(sinpi(z)) - loggamma(1.0 - z);
+    }
+    if (std::signbit(z.imag()) == 0) {
+        // z.imag() >= 0 but is not -0.0
+        return detail::loggamma_recurrence(z);
+    }
+    return std::conj(detail::loggamma_recurrence(std::conj(z)));
+}
+
+SPECFUN_HOST_DEVICE inline std::complex<double> gamma(std::complex<double> z) {
+    // Compute Gamma(z) using loggamma.
+    if (z.real() <= 0 && z == std::floor(z.real())) {
+        // Poles
+        set_error("gamma", SF_ERROR_SINGULAR, NULL);
+        return {std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN()};
+    }
+    return std::exp(loggamma(z));
+}
+
+SPECFUN_HOST_DEVICE inline std::complex<double> rgamma(std::complex<double> z) {
+    // Compute 1/Gamma(z) using loggamma.
+    if (z.real() <= 0 && z == std::floor(z.real())) {
+        // Zeros at 0, -1, -2, ...
+        return 0.0;
+    }
+    return std::exp(-loggamma(z));
+}
+
+} // namespace special

--- a/cupy/_core/include/cupy/special/trig.h
+++ b/cupy/_core/include/cupy/special/trig.h
@@ -1,0 +1,99 @@
+/* Translated from Cython into C++ by SciPy developers in 2023.
+ *
+ * Original author: Josh Wilson, 2016.
+ */
+
+/* Implement sin(pi*z) and cos(pi*z) for complex z. Since the periods
+ * of these functions are integral (and thus better representable in
+ * floating point), it's possible to compute them with greater accuracy
+ * than sin(z), cos(z).
+ */
+
+#pragma once
+
+#include "cephes/trig.h"
+#include "config.h"
+#include "evalpoly.h"
+
+namespace special {
+
+SPECFUN_HOST_DEVICE inline std::complex<double> sinpi(std::complex<double> z) {
+    double x = z.real();
+    double piy = M_PI * z.imag();
+    double abspiy = std::abs(piy);
+    double sinpix = cephes::sinpi(x);
+    double cospix = cephes::cospi(x);
+
+    if (abspiy < 700) {
+        return {sinpix * std::cosh(piy), cospix * std::sinh(piy)};
+    }
+
+    /* Have to be careful--sinh/cosh could overflow while cos/sin are small.
+     * At this large of values
+     *
+     * cosh(y) ~ exp(y)/2
+     * sinh(y) ~ sgn(y)*exp(y)/2
+     *
+     * so we can compute exp(y/2), scale by the right factor of sin/cos
+     * and then multiply by exp(y/2) to avoid overflow. */
+    double exphpiy = std::exp(abspiy / 2);
+    double coshfac;
+    double sinhfac;
+    if (exphpiy == std::numeric_limits<double>::infinity()) {
+        if (sinpix == 0.0) {
+            // Preserve the sign of zero.
+            coshfac = std::copysign(0.0, sinpix);
+        } else {
+            coshfac = std::copysign(std::numeric_limits<double>::infinity(), sinpix);
+        }
+        if (cospix == 0.0) {
+            // Preserve the sign of zero.
+            sinhfac = std::copysign(0.0, cospix);
+        } else {
+            sinhfac = std::copysign(std::numeric_limits<double>::infinity(), cospix);
+        }
+        return {coshfac, sinhfac};
+    }
+
+    coshfac = 0.5 * sinpix * exphpiy;
+    sinhfac = 0.5 * cospix * exphpiy;
+    return {coshfac * exphpiy, sinhfac * exphpiy};
+}
+
+SPECFUN_HOST_DEVICE inline std::complex<double> cospi(std::complex<double> z) {
+    double x = z.real();
+    double piy = M_PI * z.imag();
+    double abspiy = std::abs(piy);
+    double sinpix = cephes::sinpi(x);
+    double cospix = cephes::cospi(x);
+
+    if (abspiy < 700) {
+        return {cospix * std::cosh(piy), -sinpix * std::sinh(piy)};
+    }
+
+    // See csinpi(z) for an idea of what's going on here.
+    double exphpiy = std::exp(abspiy / 2);
+    double coshfac;
+    double sinhfac;
+    if (exphpiy == std::numeric_limits<double>::infinity()) {
+        if (sinpix == 0.0) {
+            // Preserve the sign of zero.
+            coshfac = std::copysign(0.0, cospix);
+        } else {
+            coshfac = std::copysign(std::numeric_limits<double>::infinity(), cospix);
+        }
+        if (cospix == 0.0) {
+            // Preserve the sign of zero.
+            sinhfac = std::copysign(0.0, sinpix);
+        } else {
+            sinhfac = std::copysign(std::numeric_limits<double>::infinity(), sinpix);
+        }
+        return {coshfac, sinhfac};
+    }
+
+    coshfac = 0.5 * cospix * exphpiy;
+    sinhfac = 0.5 * sinpix * exphpiy;
+    return {coshfac * exphpiy, sinhfac * exphpiy};
+}
+
+} // namespace special

--- a/cupy/_core/include/cupy/special/zlog1.h
+++ b/cupy/_core/include/cupy/special/zlog1.h
@@ -1,0 +1,35 @@
+/* Translated from Cython into C++ by SciPy developers in 2023.
+ *
+ * Original author: Josh Wilson, 2016.
+ */
+
+#pragma once
+
+#include "config.h"
+
+namespace special {
+namespace detail {
+
+    SPECFUN_HOST_DEVICE inline std::complex<double> zlog1(std::complex<double> z) {
+        /* Compute log, paying special attention to accuracy around 1. We
+         * implement this ourselves because some systems (most notably the
+         * Travis CI machines) are weak in this regime. */
+        std::complex<double> coeff = -1.0;
+        std::complex<double> res = 0.0;
+
+        if (std::abs(z - 1.0) > 0.1) {
+            return std::log(z);
+        }
+
+        z -= 1.0;
+        for (int n = 1; n < 17; n++) {
+            coeff *= -z;
+            res += coeff / static_cast<double>(n);
+            if (std::abs(res / coeff) < std::numeric_limits<double>::epsilon()) {
+                break;
+            }
+        }
+        return res;
+    }
+} // namespace detail
+} // namespace special

--- a/cupyx/scipy/special/_digamma.py
+++ b/cupyx/scipy/special/_digamma.py
@@ -1,17 +1,13 @@
-# This source code contains SciPy's code.
-# https://github.com/scipy/scipy/blob/master/scipy/special/cephes/psi.c
-#
-#
-# Cephes Math Library Release 2.8:  June, 2000
-# Copyright 1984, 1987, 1992, 2000 by Stephen L. Moshier
-#
-#
-# Code for the rational approximation on [1, 2] is:
-#
-# (C) Copyright John Maddock 2006.
-# Use, modification and distribution are subject to the
-# Boost Software License, Version 1.0. (See accompanying file
-# LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+"""Digamma function
+
+See cupy/_core/include/cupy/special/digamma.h for copyright information.
+
+polevl below from Cephes Math Library Release 2.1: December, 1988
+Copyright 1984, 1987, 1988 by Stephen L. Moshier
+
+polevl_definition is kept because it is used elsewhere in CuPy,
+although it is now no longer used in digamma.
+"""
 
 from cupy import _core
 
@@ -34,150 +30,13 @@ template<int N> static __device__ double polevl(double x, double coef[])
 '''
 
 
-psi_definition = '''
-__constant__ double A[] = {
-    8.33333333333333333333E-2,
-    -2.10927960927960927961E-2,
-    7.57575757575757575758E-3,
-    -4.16666666666666666667E-3,
-    3.96825396825396825397E-3,
-    -8.33333333333333333333E-3,
-    8.33333333333333333333E-2
-};
-
-__constant__ double PI = 3.141592653589793;
-__constant__ double EULER = 0.5772156649015329;
-
-__constant__ float Y = 0.99558162689208984f;
-
-__constant__ double root1 = 1569415565.0 / 1073741824.0;
-__constant__ double root2 = (381566830.0 / 1073741824.0) / 1073741824.0;
-__constant__ double root3 = 0.9016312093258695918615325266959189453125e-19;
-
-__constant__ double P[] = {
-    -0.0020713321167745952,
-    -0.045251321448739056,
-    -0.28919126444774784,
-    -0.65031853770896507,
-    -0.32555031186804491,
-    0.25479851061131551
-};
-__constant__ double Q[] = {
-    -0.55789841321675513e-6,
-    0.0021284987017821144,
-    0.054151797245674225,
-    0.43593529692665969,
-    1.4606242909763515,
-    2.0767117023730469,
-    1.0
-};
-
-static __device__ double digamma_imp_1_2(double x)
-{
-    /*
-     * Rational approximation on [1, 2] taken from Boost.
-     *
-     * Now for the approximation, we use the form:
-     *
-     * digamma(x) = (x - root) * (Y + R(x-1))
-     *
-     * Where root is the location of the positive root of digamma,
-     * Y is a constant, and R is optimised for low absolute error
-     * compared to Y.
-     *
-     * Maximum Deviation Found:               1.466e-18
-     * At double precision, max error found:  2.452e-17
-     */
-    double r, g;
-    g = x - root1 - root2 - root3;
-    r = polevl<5>(x - 1.0, P) / polevl<6>(x - 1.0, Q);
-
-    return g * Y + g * r;
-}
-
-
-static __device__ double psi_asy(double x)
-{
-    double y, z;
-
-    if (x < 1.0e17) {
-        z = 1.0 / (x * x);
-        y = z * polevl<6>(z, A);
-    }
-    else {
-        y = 0.0;
-    }
-
-    return log(x) - (0.5 / x) - y;
-}
-
-
-double __device__ psi(double x)
-{
-    double y = 0.0;
-    double q, r;
-    int i, n;
-
-    if (isnan(x)) {
-        return x;
-    }
-    else if (isinf(x)){
-        if(x > 0){
-            return x;
-        }else{
-            return nan("");
-        }
-    }
-    else if (x == 0) {
-        return -1.0/0.0;
-    }
-    else if (x < 0.0) {
-        /* argument reduction before evaluating tan(pi * x) */
-        r = modf(x, &q);
-        if (r == 0.0) {
-            return nan("");
-        }
-        y = -PI / tan(PI * r);
-        x = 1.0 - x;
-    }
-
-    /* check for positive integer up to 10 */
-    if ((x <= 10.0) && (x == floor(x))) {
-        n = (int)x;
-        for (i = 1; i < n; i++) {
-            y += 1.0 / i;
-        }
-        y -= EULER;
-        return y;
-    }
-
-    /* use the recurrence relation to move x into [1, 2] */
-    if (x < 1.0) {
-        y -= 1.0 / x;
-        x += 1.0;
-    }
-    else if (x < 10.0) {
-        while (x > 2.0) {
-            x -= 1.0;
-            y += 1.0 / x;
-        }
-    }
-    if ((1.0 <= x) && (x <= 2.0)) {
-        y += digamma_imp_1_2(x);
-        return y;
-    }
-
-    /* x is large, use the asymptotic series */
-    y += psi_asy(x);
-    return y;
-}
-'''
+digamma_preamble = "#include <cupy/special/digamma.h>"
 
 
 digamma = _core.create_ufunc(
-    'cupyx_scipy_special_digamma', ('f->f', 'd->d'),
-    'out0 = psi(in0)',
-    preamble=polevl_definition+psi_definition,
+    'cupyx_scipy_special_digamma', ('f->f', 'd->d', 'F->F', 'D->D'),
+    'out0 = special::digamma(in0)',
+    preamble=digamma_preamble,
     doc="""The digamma function.
 
     Args:

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_digamma.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_digamma.py
@@ -9,7 +9,7 @@ import numpy
 class TestDigamma(unittest.TestCase):
 
     @testing.with_requires('scipy>=1.1.0')
-    @testing.for_all_dtypes(no_complex=False)
+    @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(atol=1e-13, rtol=1e-15, scipy_name='scp')
     def test_arange(self, xp, scp, dtype):
         import scipy.special  # NOQA
@@ -18,7 +18,7 @@ class TestDigamma(unittest.TestCase):
         return scp.special.digamma(a)
 
     @testing.with_requires('scipy>=1.1.0')
-    @testing.for_all_dtypes(no_complex=False)
+    @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(atol=1e-13, rtol=1e-10, scipy_name='scp')
     def test_linspace_positive(self, xp, scp, dtype):
         import scipy.special  # NOQA
@@ -28,7 +28,7 @@ class TestDigamma(unittest.TestCase):
         return scp.special.digamma(a)
 
     @testing.with_requires('scipy>=1.1.0')
-    @testing.for_all_dtypes(no_complex=False)
+    @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(atol=1e-13, rtol=1e-10, scipy_name='scp')
     def test_linspace_negative(self, xp, scp, dtype):
         import scipy.special  # NOQA
@@ -37,7 +37,7 @@ class TestDigamma(unittest.TestCase):
         a = xp.asarray(a)
         return scp.special.digamma(a)
 
-    @testing.for_all_dtypes(no_complex=False)
+    @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(atol=1e-13, rtol=1e-10, scipy_name='scp')
     def test_scalar(self, xp, scp, dtype):
         import scipy.special  # NOQA
@@ -45,7 +45,7 @@ class TestDigamma(unittest.TestCase):
         return scp.special.digamma(dtype(1.5))
 
     @testing.with_requires('scipy>=1.1.0')
-    @testing.for_all_dtypes(no_complex=False)
+    @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(atol=1e-13, rtol=1e-10, scipy_name='scp')
     def test_inf_and_nan(self, xp, scp, dtype):
         import scipy.special  # NOQA

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_digamma.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_digamma.py
@@ -57,3 +57,12 @@ class TestDigamma(unittest.TestCase):
     def test_psi(self):
         """Verify that psi exists and is the same as digamma"""
         assert cupyx.scipy.special.psi is cupyx.scipy.special.digamma
+
+    @testing.for_dtypes('fd')
+    @testing.numpy_cupy_allclose(atol=1e-20, rtol=1e-15, scipy_name='scp')
+    def test_complex(self, xp, scp, dtype):
+        x = xp.linspace(-20, 20, 12, dtype=dtype)
+        y = xp.linspace(-20, 20, 12, dtype=dtype)
+        x, y = xp.meshgrid(x, y)
+        z = (x + y*1j).ravel()
+        return scp.special.digamma(z)

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_digamma.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_digamma.py
@@ -9,8 +9,8 @@ import numpy
 class TestDigamma(unittest.TestCase):
 
     @testing.with_requires('scipy>=1.1.0')
-    @testing.for_all_dtypes(no_complex=True)
-    @testing.numpy_cupy_allclose(atol=1e-20, rtol=1e-15, scipy_name='scp')
+    @testing.for_all_dtypes(no_complex=False)
+    @testing.numpy_cupy_allclose(atol=1e-13, rtol=1e-15, scipy_name='scp')
     def test_arange(self, xp, scp, dtype):
         import scipy.special  # NOQA
 
@@ -18,8 +18,8 @@ class TestDigamma(unittest.TestCase):
         return scp.special.digamma(a)
 
     @testing.with_requires('scipy>=1.1.0')
-    @testing.for_all_dtypes(no_complex=True)
-    @testing.numpy_cupy_allclose(atol=1e-20, rtol=1e-15, scipy_name='scp')
+    @testing.for_all_dtypes(no_complex=False)
+    @testing.numpy_cupy_allclose(atol=1e-13, rtol=1e-10, scipy_name='scp')
     def test_linspace_positive(self, xp, scp, dtype):
         import scipy.special  # NOQA
 
@@ -28,8 +28,8 @@ class TestDigamma(unittest.TestCase):
         return scp.special.digamma(a)
 
     @testing.with_requires('scipy>=1.1.0')
-    @testing.for_all_dtypes(no_complex=True)
-    @testing.numpy_cupy_allclose(atol=1e-20, rtol=1e-15, scipy_name='scp')
+    @testing.for_all_dtypes(no_complex=False)
+    @testing.numpy_cupy_allclose(atol=1e-13, rtol=1e-10, scipy_name='scp')
     def test_linspace_negative(self, xp, scp, dtype):
         import scipy.special  # NOQA
 
@@ -37,16 +37,16 @@ class TestDigamma(unittest.TestCase):
         a = xp.asarray(a)
         return scp.special.digamma(a)
 
-    @testing.for_all_dtypes(no_complex=True)
-    @testing.numpy_cupy_allclose(atol=1e-20, rtol=1e-15, scipy_name='scp')
+    @testing.for_all_dtypes(no_complex=False)
+    @testing.numpy_cupy_allclose(atol=1e-13, rtol=1e-10, scipy_name='scp')
     def test_scalar(self, xp, scp, dtype):
         import scipy.special  # NOQA
 
         return scp.special.digamma(dtype(1.5))
 
     @testing.with_requires('scipy>=1.1.0')
-    @testing.for_all_dtypes(no_complex=True)
-    @testing.numpy_cupy_allclose(atol=1e-20, rtol=1e-15, scipy_name='scp')
+    @testing.for_all_dtypes(no_complex=False)
+    @testing.numpy_cupy_allclose(atol=1e-13, rtol=1e-10, scipy_name='scp')
     def test_inf_and_nan(self, xp, scp, dtype):
         import scipy.special  # NOQA
 
@@ -59,7 +59,7 @@ class TestDigamma(unittest.TestCase):
         assert cupyx.scipy.special.psi is cupyx.scipy.special.digamma
 
     @testing.for_dtypes('fd')
-    @testing.numpy_cupy_allclose(atol=1e-20, rtol=1e-15, scipy_name='scp')
+    @testing.numpy_cupy_allclose(atol=1e-13, rtol=1e-10, scipy_name='scp')
     def test_complex(self, xp, scp, dtype):
         x = xp.linspace(-20, 20, 12, dtype=dtype)
         y = xp.linspace(-20, 20, 12, dtype=dtype)

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_digamma.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_digamma.py
@@ -10,7 +10,7 @@ class TestDigamma(unittest.TestCase):
 
     @testing.with_requires('scipy>=1.1.0')
     @testing.for_all_dtypes(no_complex=True)
-    @testing.numpy_cupy_allclose(atol=1e-5, scipy_name='scp')
+    @testing.numpy_cupy_allclose(atol=1e-20, rtol=1e-15, scipy_name='scp')
     def test_arange(self, xp, scp, dtype):
         import scipy.special  # NOQA
 
@@ -19,7 +19,7 @@ class TestDigamma(unittest.TestCase):
 
     @testing.with_requires('scipy>=1.1.0')
     @testing.for_all_dtypes(no_complex=True)
-    @testing.numpy_cupy_allclose(atol=1e-5, scipy_name='scp')
+    @testing.numpy_cupy_allclose(atol=1e-20, rtol=1e-15, scipy_name='scp')
     def test_linspace_positive(self, xp, scp, dtype):
         import scipy.special  # NOQA
 
@@ -29,7 +29,7 @@ class TestDigamma(unittest.TestCase):
 
     @testing.with_requires('scipy>=1.1.0')
     @testing.for_all_dtypes(no_complex=True)
-    @testing.numpy_cupy_allclose(atol=1e-2, rtol=1e-3, scipy_name='scp')
+    @testing.numpy_cupy_allclose(atol=1e-20, rtol=1e-15, scipy_name='scp')
     def test_linspace_negative(self, xp, scp, dtype):
         import scipy.special  # NOQA
 
@@ -38,7 +38,7 @@ class TestDigamma(unittest.TestCase):
         return scp.special.digamma(a)
 
     @testing.for_all_dtypes(no_complex=True)
-    @testing.numpy_cupy_allclose(atol=1e-2, rtol=1e-3, scipy_name='scp')
+    @testing.numpy_cupy_allclose(atol=1e-20, rtol=1e-15, scipy_name='scp')
     def test_scalar(self, xp, scp, dtype):
         import scipy.special  # NOQA
 
@@ -46,7 +46,7 @@ class TestDigamma(unittest.TestCase):
 
     @testing.with_requires('scipy>=1.1.0')
     @testing.for_all_dtypes(no_complex=True)
-    @testing.numpy_cupy_allclose(atol=1e-2, rtol=1e-3, scipy_name='scp')
+    @testing.numpy_cupy_allclose(atol=1e-20, rtol=1e-15, scipy_name='scp')
     def test_inf_and_nan(self, xp, scp, dtype):
         import scipy.special  # NOQA
 


### PR DESCRIPTION
This PR adds support for complex values to the `digamma` function. This is made possible by the recent translation of SciPy's complex valued `digamma` implementation to CUDA compatible C++, https://github.com/scipy/scipy/pull/19834. This PR also makes an improvement to the real valued `digamma` implementation which was made in SciPy but had not been ported to CuPy (https://github.com/scipy/scipy/pull/8129).

I've copied over the entirety of the SciPy special C++ library as it exists now, despite it not all being used for `digamma`, but if you'd like, I can go through and try to add only the minimum number of headers that are actually needed. I just thought it would be easier to maintain if SciPy and CuPy vendor the same version of this set of files.

`polevl_definition` in `_digamma.py` is no longer used for the `digamma` function but I've left it in place because it is imported in other files.