### PR TITLE
MAINT: cupyx/interpolate: remove a duplicate function

### DIFF
--- a/cupyx/scipy/interpolate/_rgi.py
+++ b/cupyx/scipy/interpolate/_rgi.py
@@ -4,33 +4,7 @@ import itertools
 import cupy as cp
 from cupyx.scipy.interpolate._bspline2 import make_interp_spline
 from cupyx.scipy.interpolate._cubic import PchipInterpolator
-
-
-def _ndim_coords_from_arrays(points, ndim=None):
-    """
-    Convert a tuple of coordinate arrays to a (..., ndim)-shaped array.
-    """
-    if isinstance(points, tuple) and len(points) == 1:
-        # handle argument tuple
-        points = points[0]
-    if isinstance(points, tuple):
-        p = cp.broadcast_arrays(*points)
-        n = len(p)
-        for j in range(1, n):
-            if p[j].shape != p[0].shape:
-                raise ValueError(
-                    "coordinate arrays do not have the same shape")
-        points = cp.empty(p[0].shape + (len(points),), dtype=float)
-        for j, item in enumerate(p):
-            points[..., j] = item
-    else:
-        points = cp.asanyarray(points)
-        if points.ndim == 1:
-            if ndim is None:
-                points = points.reshape(-1, 1)
-            else:
-                points = points.reshape(-1, ndim)
-    return points
+from cupyx.scipy.interpolate._interpolate import _ndim_coords_from_arrays
 
 
 def _check_points(points):


### PR DESCRIPTION
Just a cleanup: a helper function was vendored from scipy twice in two source files.