### PR TITLE
add cupy.put_along_axis API

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -227,6 +227,7 @@ from cupy._creation.matrix import vander  # NOQA
 from cupy._functional.piecewise import piecewise  # NOQA
 from cupy._functional.vectorize import vectorize  # NOQA
 from cupy.lib._shape_base import apply_along_axis  # NOQA
+from cupy.lib._shape_base import put_along_axis    # NOQA
 
 # -----------------------------------------------------------------------------
 # Array manipulation routines

--- a/cupy/lib/_shape_base.py
+++ b/cupy/lib/_shape_base.py
@@ -61,3 +61,70 @@ def apply_along_axis(func1d, axis, arr, *args, **kwargs):
         buff = cupy.moveaxis(buff, -1, axis)
 
     return buff
+
+
+def _make_along_axis_idx(arr_shape, indices, axis):
+    # compute dimensions to iterate over
+
+    if not cupy.issubdtype(indices.dtype, cupy.integer):
+        raise IndexError('`indices` must be an integer array')
+    if len(arr_shape) != indices.ndim:
+        raise ValueError(
+            "`indices` and `arr` must have the same number of dimensions")
+
+    shape_ones = (1, ) * indices.ndim
+    dest_dims = list(range(axis)) + [None] + \
+        list(range(axis + 1, indices.ndim))
+
+    # build a fancy index, consisting of orthogonal aranges, with the
+    # requested index inserted at the right location
+    fancy_index = []
+    for dim, n in zip(dest_dims, arr_shape):
+        if dim is None:
+            fancy_index.append(indices)
+        else:
+            ind_shape = shape_ones[:dim] + (-1,) + shape_ones[dim+1:]
+            fancy_index.append(cupy.arange(n).reshape(ind_shape))
+
+    return tuple(fancy_index)
+
+
+def put_along_axis(arr, indices, values, axis):
+    """
+    Put values into the destination array by matching 1d index and data slices.
+
+    This iterates over matching 1d slices oriented along the specified axis in
+    the index and data arrays, and uses the former to place values into the
+    latter. These slices can be different lengths.
+
+    Functions returning an index along an axis, like `argsort` and
+    `argpartition`, produce suitable indices for this function.
+
+    Args:
+        arr : cupy.ndarray (Ni..., M, Nk...)
+            Destination array.
+        indices : cupy.ndarray (Ni..., J, Nk...)
+            Indices to change along each 1d slice of `arr`. This must match the
+            dimension of arr, but dimensions in Ni and Nj may be 1 to broadcast
+            against `arr`.
+        values : array_like (Ni..., J, Nk...)
+            values to insert at those indices. Its shape and dimension are
+            broadcast to match that of `indices`.
+        axis : int
+            The axis to take 1d slices along. If axis is None, the destination
+            array is treated as if a flattened 1d view had been created of it.
+
+    .. seealso:: :func:`numpy.put_along_axis`
+    """
+
+    # normalize inputs
+    if axis is None:
+        arr = arr.flat
+        axis = 0
+        arr_shape = (len(arr),)  # flatiter has no .shape
+    else:
+        axis = internal._normalize_axis_index(axis, arr.ndim)
+        arr_shape = arr.shape
+
+    # use the fancy index
+    arr[_make_along_axis_idx(arr_shape, indices, axis)] = values

--- a/docs/source/reference/indexing.rst
+++ b/docs/source/reference/indexing.rst
@@ -52,6 +52,7 @@ Inserting data into arrays
 
    place
    put
+   put_along_axis
    putmask
    fill_diagonal
 


### PR DESCRIPTION
hello everyone~

I tried adding the cupy version of  `numpy.put_along_axis` API as mentioned in  #6078 . I'd be really grateful if someone could review this PR and help me improve it so that it can be merged~   