### PR TITLE
Fix: always switch to the submodule dir before checking git tag/commit

### DIFF
--- a/install/cupy_builder/install_build.py
+++ b/install/cupy_builder/install_build.py
@@ -528,7 +528,9 @@ def check_cub_version(compiler, settings):
         # could be in a git submodule?
         try:
             # CuPy's bundle
-            cupy_cub_include = _cub_path
+            cupy_cub_include = os.path.join(
+                cupy_builder.get_context().source_root,
+                "third_party/cccl")
             a = subprocess.run(' '.join(['git', 'describe', '--tags']),
                                stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                                shell=True, cwd=cupy_cub_include)
@@ -578,7 +580,9 @@ def check_jitify_version(compiler, settings):
     global _jitify_version
 
     try:
-        cupy_jitify_include = _jitify_path
+        cupy_jitify_include = os.path.join(
+            cupy_builder.get_context().source_root,
+            "third_party/jitify")
         # Unfortunately Jitify does not have any identifiable name (branch,
         # tag, etc), so we must use the commit here
         a = subprocess.run(' '.join(['git', 'rev-parse', '--short', 'HEAD']),


### PR DESCRIPTION
Close #8185.