### PR TITLE
Fix: remove unnecessary include that causes deployment issue

### DIFF
--- a/cupyx/scipy/interpolate/_interpolate.py
+++ b/cupyx/scipy/interpolate/_interpolate.py
@@ -4,7 +4,6 @@ import math
 import cupy
 from cupy._core import internal  # NOQA
 from cupy._core._scalar import get_typename  # NOQA
-from cupy_backends.cuda.api import runtime
 from cupyx.scipy import special as spec
 from cupyx.scipy.interpolate._bspline import BSpline, _get_dtype
 
@@ -122,15 +121,7 @@ INTERVAL_MODULE = cupy.RawModule(
     name_expressions=[
         'find_breakpoint_position_1d', 'find_breakpoint_position_nd'])
 
-if runtime.is_hip:
-    BASE_HEADERS = """#include <hip/hip_runtime.h>
-"""
-else:
-    BASE_HEADERS = """#include <cuda_runtime.h>
-#include <device_launch_parameters.h>
-"""
-
-PPOLY_KERNEL = BASE_HEADERS + r"""
+PPOLY_KERNEL = r"""
 #include <cupy/complex.cuh>
 #include <cupy/math_constants.h>
 
@@ -404,7 +395,7 @@ PPOLY_MODULE = cupy.RawModule(
         [f'fix_continuity<{type_name}>' for type_name in TYPES] +
         [f'integrate<{type_name}>' for type_name in TYPES]))
 
-BPOLY_KERNEL = BASE_HEADERS + r"""
+BPOLY_KERNEL = r"""
 #include <cupy/complex.cuh>
 #include <cupy/math_constants.h>
 

--- a/cupyx/scipy/signal/_iir_utils.py
+++ b/cupyx/scipy/signal/_iir_utils.py
@@ -35,17 +35,7 @@ TYPE_NAMES = [_get_typename(t) for t in TYPES]
 TYPE_PAIR_NAMES = [(_get_typename(x), _get_typename(y)) for x, y in TYPE_PAIRS]
 
 
-if runtime.is_hip:
-    IIR_KERNEL_BASE = r"""
-    #include <hip/hip_runtime.h>
-"""
-else:
-    IIR_KERNEL_BASE = r"""
-#include <cuda_runtime.h>
-#include <device_launch_parameters.h>
-"""
-
-IIR_KERNEL = IIR_KERNEL_BASE + r"""
+IIR_KERNEL = r"""
 #include <cupy/math_constants.h>
 #include <cupy/carray.cuh>
 #include <cupy/complex.cuh>
@@ -200,7 +190,7 @@ __global__ void second_pass_iir(
 }
 """
 
-IIR_SOS_KERNEL = IIR_KERNEL_BASE + r"""
+IIR_SOS_KERNEL = r"""
 #include <cupy/math_constants.h>
 #include <cupy/carray.cuh>
 #include <cupy/complex.cuh>

--- a/cupyx/scipy/signal/_max_len_seq.py
+++ b/cupyx/scipy/signal/_max_len_seq.py
@@ -1,6 +1,5 @@
-
 import cupy
-from cupy_backends.cuda.api import runtime
+
 
 _mls_taps = {2: [1], 3: [2], 4: [3], 5: [3], 6: [5], 7: [6], 8: [7, 6, 1],
              9: [5], 10: [7], 11: [9], 12: [11, 10, 4], 13: [12, 11, 8],
@@ -10,17 +9,8 @@ _mls_taps = {2: [1], 3: [2], 4: [3], 5: [3], 6: [5], 7: [6], 8: [7, 6, 1],
              27: [26, 25, 22], 28: [25], 29: [27], 30: [29, 28, 7],
              31: [28], 32: [31, 30, 10]}
 
-if runtime.is_hip:
-    MAX_LEN_SEQ_BASE = r"""
-    #include <hip/hip_runtime.h>
-"""
-else:
-    MAX_LEN_SEQ_BASE = r"""
-#include <cuda_runtime.h>
-#include <device_launch_parameters.h>
-"""
 
-MAX_LEN_SEQ_KERNEL = MAX_LEN_SEQ_BASE + r"""
+MAX_LEN_SEQ_KERNEL = r"""
 #include <cupy/math_constants.h>
 #include <cupy/carray.cuh>
 #include <cupy/complex.cuh>

--- a/cupyx/scipy/signal/_peak_finding.py
+++ b/cupyx/scipy/signal/_peak_finding.py
@@ -66,17 +66,7 @@ _modedict = {
     cupy.not_equal: 5,
 }
 
-if runtime.is_hip:
-    PEAKS_KERNEL_BASE = r"""
-    #include <hip/hip_runtime.h>
-"""
-else:
-    PEAKS_KERNEL_BASE = r"""
-#include <cuda_runtime.h>
-#include <device_launch_parameters.h>
-"""
-
-PEAKS_KERNEL = PEAKS_KERNEL_BASE + r"""
+PEAKS_KERNEL = r"""
 #include <cupy/math_constants.h>
 #include <cupy/carray.cuh>
 #include <cupy/complex.cuh>

--- a/cupyx/scipy/signal/_spectral_impl.py
+++ b/cupyx/scipy/signal/_spectral_impl.py
@@ -29,7 +29,6 @@ import warnings
 
 import cupy
 
-from cupy_backends.cuda.api import runtime
 import cupyx.scipy.signal._signaltools as filtering
 from cupyx.scipy.signal._arraytools import (
     odd_ext, even_ext, zero_ext, const_ext, _as_strided)
@@ -48,17 +47,7 @@ def _get_module_func_raw(module, func_name, *template_args):
     return kernel
 
 
-if runtime.is_hip:
-    KERNEL_BASE = r"""
-    #include <hip/hip_runtime.h>
-"""
-else:
-    KERNEL_BASE = r"""
-#include <cuda_runtime.h>
-#include <device_launch_parameters.h>
-"""
-
-LOMBSCARGLE_KERNEL = KERNEL_BASE + r"""
+LOMBSCARGLE_KERNEL = r"""
 
 ///////////////////////////////////////////////////////////////////////////////
 //                            LOMBSCARGLE                                    //

--- a/cupyx/scipy/signal/_splines.py
+++ b/cupyx/scipy/signal/_splines.py
@@ -1,7 +1,6 @@
 
 import cupy
 from cupy._core._scalar import get_typename
-from cupy_backends.cuda.api import runtime
 from cupy._core.internal import _normalize_axis_index
 
 from cupyx.scipy.signal._signaltools import lfilter
@@ -10,16 +9,7 @@ from cupyx.scipy.signal._arraytools import (
 from cupyx.scipy.signal._iir_utils import collapse_2d, apply_iir_sos
 
 
-if runtime.is_hip:
-    SYMIIR2_KERNEL = r"""#include <hip/hip_runtime.h>
-"""
-else:
-    SYMIIR2_KERNEL = r"""
-#include <cuda_runtime.h>
-#include <device_launch_parameters.h>
-"""
-
-SYMIIR2_KERNEL = SYMIIR2_KERNEL + r"""
+SYMIIR2_KERNEL = r"""
 #include <cupy/math_constants.h>
 #include <cupy/carray.cuh>
 

--- a/cupyx/scipy/signal/_waveforms.py
+++ b/cupyx/scipy/signal/_waveforms.py
@@ -661,17 +661,7 @@ def _sweep_poly_phase(t, poly):
     return phase
 
 
-if runtime.is_hip:
-    KERNEL_BASE = r"""
-    #include <hip/hip_runtime.h>
-"""
-else:
-    KERNEL_BASE = r"""
-#include <cuda_runtime.h>
-#include <device_launch_parameters.h>
-"""
-
-UNIT_KERNEL = KERNEL_BASE + r'''
+UNIT_KERNEL = r'''
 #include <cupy/math_constants.h>
 #include <cupy/carray.cuh>
 #include <cupy/complex.cuh>

--- a/cupyx/scipy/spatial/_kdtree_utils.py
+++ b/cupyx/scipy/spatial/_kdtree_utils.py
@@ -29,17 +29,7 @@ TYPES = FLOAT_TYPES + INT_TYPES + UNSIGNED_TYPES + COMPLEX_TYPES  # type: ignore
 TYPE_NAMES = [_get_typename(t) for t in TYPES]
 
 
-if runtime.is_hip:
-    KERNEL_BASE = r"""
-    #include <hip/hip_runtime.h>
-"""
-else:
-    KERNEL_BASE = r"""
-#include <cuda_runtime.h>
-#include <device_launch_parameters.h>
-"""
-
-KD_KERNEL = KERNEL_BASE + r'''
+KD_KERNEL = r'''
 #include <cupy/math_constants.h>
 #include <cupy/carray.cuh>
 #include <cupy/complex.cuh>
@@ -202,7 +192,7 @@ __global__ void tag_pairs(
 }
 '''
 
-KNN_KERNEL = KERNEL_BASE + r'''
+KNN_KERNEL = r'''
 #include <cupy/math_constants.h>
 #include <cupy/carray.cuh>
 #include <cupy/complex.cuh>


### PR DESCRIPTION
The `cuda_runtime.h` header is hard-wired in the compiler (for the device API bits; for host APIs we don't care), so there is really no point in including it. It also caused issues in deployment, because we can't bundle CUDA headers.

Close #8162.