### PR TITLE
Do not use plain thrust namespace in complex clone

### DIFF
--- a/cupy/_core/include/cupy/complex/arithmetic.h
+++ b/cupy/_core/include/cupy/complex/arithmetic.h
@@ -20,7 +20,9 @@
 #include <cupy/complex/complex.h>
 #include <cupy/complex/math_private.h>
 
-namespace thrust {
+#include <thrust/detail/config.h>
+
+THRUST_NAMESPACE_BEGIN
 
 /* --- Binary Arithmetic Operators --- */
 
@@ -311,4 +313,5 @@ __host__ __device__ inline complex<T> polar(const T& m,
                                            const T& theta) {
   return complex<T>(m * cos(theta), m * sin(theta));
 }
-}
+
+THRUST_NAMESPACE_END

--- a/cupy/_core/include/cupy/complex/catrig.h
+++ b/cupy/_core/include/cupy/complex/catrig.h
@@ -51,7 +51,9 @@
 #include <cupy/complex/complex.h>
 #include <cupy/complex/math_private.h>
 
-namespace thrust {
+#include <thrust/detail/config.h>
+
+THRUST_NAMESPACE_BEGIN
 namespace detail {
 namespace complex {
 
@@ -727,4 +729,4 @@ __host__ __device__ inline complex<double> atanh(const complex<double>& z) {
 }
 #endif
 
-}  // namespace thrust
+THRUST_NAMESPACE_END

--- a/cupy/_core/include/cupy/complex/catrigf.h
+++ b/cupy/_core/include/cupy/complex/catrigf.h
@@ -52,7 +52,9 @@
 #include <cupy/complex/complex.h>
 #include <cupy/complex/math_private.h>
 
-namespace thrust {
+#include <thrust/detail/config.h>
+
+THRUST_NAMESPACE_BEGIN
 namespace detail {
 namespace complex {
 
@@ -441,4 +443,4 @@ __host__ __device__ inline complex<float> atanh(const complex<float>& z) {
 }
 #endif
 
-}  // namespace thrust
+THRUST_NAMESPACE_END

--- a/cupy/_core/include/cupy/complex/ccosh.h
+++ b/cupy/_core/include/cupy/complex/ccosh.h
@@ -50,7 +50,9 @@
 #include <cupy/complex/complex.h>
 #include <cupy/complex/math_private.h>
 
-namespace thrust {
+#include <thrust/detail/config.h>
+
+THRUST_NAMESPACE_BEGIN
 namespace detail {
 namespace complex {
 
@@ -202,4 +204,4 @@ __host__ __device__ inline thrust::complex<double> cosh(
   return detail::complex::ccosh(z);
 }
 
-}  // namespace thrust
+THRUST_NAMESPACE_END

--- a/cupy/_core/include/cupy/complex/ccoshf.h
+++ b/cupy/_core/include/cupy/complex/ccoshf.h
@@ -51,7 +51,9 @@
 #include <cupy/complex/complex.h>
 #include <cupy/complex/math_private.h>
 
-namespace thrust {
+#include <thrust/detail/config.h>
+
+THRUST_NAMESPACE_BEGIN
 namespace detail {
 namespace complex {
 
@@ -132,4 +134,4 @@ __host__ __device__ inline complex<float> cosh(const complex<float>& z) {
   return detail::complex::ccoshf(z);
 }
 
-}  // namespace thrust
+THRUST_NAMESPACE_END

--- a/cupy/_core/include/cupy/complex/cexp.h
+++ b/cupy/_core/include/cupy/complex/cexp.h
@@ -52,7 +52,9 @@
 #include <cupy/complex/complex.h>
 #include <cupy/complex/math_private.h>
 
-namespace thrust {
+#include <thrust/detail/config.h>
+
+THRUST_NAMESPACE_BEGIN
 namespace detail {
 namespace complex {
 
@@ -170,4 +172,4 @@ __host__ __device__ inline complex<double> exp(const complex<double>& z) {
   return detail::complex::cexp(z);
 }
 
-}  // namespace thrust
+THRUST_NAMESPACE_END

--- a/cupy/_core/include/cupy/complex/cexpf.h
+++ b/cupy/_core/include/cupy/complex/cexpf.h
@@ -52,7 +52,9 @@
 #include <cupy/complex/complex.h>
 #include <cupy/complex/math_private.h>
 
-namespace thrust {
+#include <thrust/detail/config.h>
+
+THRUST_NAMESPACE_BEGIN
 namespace detail {
 namespace complex {
 
@@ -150,4 +152,4 @@ __host__ __device__ inline complex<float> exp(const complex<float>& z) {
   return detail::complex::cexpf(z);
 }
 
-}  // namespace thrust
+THRUST_NAMESPACE_END

--- a/cupy/_core/include/cupy/complex/clog.h
+++ b/cupy/_core/include/cupy/complex/clog.h
@@ -48,7 +48,9 @@
 #include <cupy/complex/complex.h>
 #include <cupy/complex/math_private.h>
 
-namespace thrust {
+#include <thrust/detail/config.h>
+
+THRUST_NAMESPACE_BEGIN
 namespace detail {
 namespace complex {
 
@@ -200,4 +202,4 @@ __host__ __device__ inline complex<ValueType> log10(const complex<ValueType>& z)
   return thrust::log(z) / ValueType(2.30258509299404568402);
 }
 
-}  // namespace thrust
+THRUST_NAMESPACE_END

--- a/cupy/_core/include/cupy/complex/clogf.h
+++ b/cupy/_core/include/cupy/complex/clogf.h
@@ -48,7 +48,9 @@
 #include <cupy/complex/complex.h>
 #include <cupy/complex/math_private.h>
 
-namespace thrust {
+#include <thrust/detail/config.h>
+
+THRUST_NAMESPACE_BEGIN
 namespace detail {
 namespace complex {
 
@@ -189,4 +191,4 @@ __host__ __device__ inline complex<float> log(const complex<float>& z) {
   return detail::complex::clogf(z);
 }
 
-}  // namespace thrust
+THRUST_NAMESPACE_END

--- a/cupy/_core/include/cupy/complex/complex.h
+++ b/cupy/_core/include/cupy/complex/complex.h
@@ -20,7 +20,9 @@
 
 #pragma once
 
-namespace thrust {
+#include <thrust/detail/config.h>
+
+THRUST_NAMESPACE_BEGIN
 
 template <typename T, typename U, bool x>
 struct _select_greater_type_impl {
@@ -669,6 +671,6 @@ __host__ __device__ inline bool operator!=(const T& lhs, const complex<T>& rhs);
 template <typename T>
 __host__ __device__ inline bool operator!=(const complex<T>& lhs, const T& rhs);
 
-}  // end namespace thrust
+THRUST_NAMESPACE_END
 
 #include <cupy/complex/complex_inl.h>

--- a/cupy/_core/include/cupy/complex/complex_inl.h
+++ b/cupy/_core/include/cupy/complex/complex_inl.h
@@ -19,7 +19,9 @@
 
 #include <cupy/complex/complex.h>
 
-namespace thrust {
+#include <thrust/detail/config.h>
+
+THRUST_NAMESPACE_BEGIN
 
 /* --- Constructors --- */
 template <typename T>
@@ -142,7 +144,8 @@ template <typename T>
 __host__ __device__ inline bool operator!=(const complex<T>& lhs, const T& rhs) {
   return !(lhs == rhs);
 }
-}
+
+THRUST_NAMESPACE_END
 
 
 #include <cupy/complex/arithmetic.h>

--- a/cupy/_core/include/cupy/complex/cpow.h
+++ b/cupy/_core/include/cupy/complex/cpow.h
@@ -2,7 +2,9 @@
 
 #include <cupy/complex/complex.h>
 
-namespace thrust {
+#include <thrust/detail/config.h>
+
+THRUST_NAMESPACE_BEGIN
 
 template <typename T>
 __host__ __device__ inline complex<T> pow(const complex<T>& z,
@@ -41,4 +43,4 @@ __host__ __device__ inline complex<typename _select_greater_type<T, U>::type> po
   return pow(PromotedType(x), complex<PromotedType>(exponent));
 }
 
-}
+THRUST_NAMESPACE_END

--- a/cupy/_core/include/cupy/complex/cproj.h
+++ b/cupy/_core/include/cupy/complex/cproj.h
@@ -20,7 +20,10 @@
 #include <cupy/complex/complex.h>
 #include <cupy/complex/math_private.h>
 
-namespace thrust {
+#include <thrust/detail/config.h>
+
+THRUST_NAMESPACE_BEGIN
+
 namespace detail {
 namespace complex {
 
@@ -61,4 +64,5 @@ template <>
 __host__ __device__ inline thrust::complex<float> proj(const thrust::complex<float>& z) {
   return detail::complex::cprojf(z);
 }
-}
+
+THRUST_NAMESPACE_END

--- a/cupy/_core/include/cupy/complex/csinh.h
+++ b/cupy/_core/include/cupy/complex/csinh.h
@@ -50,7 +50,9 @@
 #include <cupy/complex/complex.h>
 #include <cupy/complex/math_private.h>
 
-namespace thrust {
+#include <thrust/detail/config.h>
+
+THRUST_NAMESPACE_BEGIN
 namespace detail {
 namespace complex {
 
@@ -189,4 +191,4 @@ __host__ __device__ inline complex<double> sinh(const complex<double>& z) {
   return detail::complex::csinh(z);
 }
 
-}  // namespace thrust
+THRUST_NAMESPACE_END

--- a/cupy/_core/include/cupy/complex/csinhf.h
+++ b/cupy/_core/include/cupy/complex/csinhf.h
@@ -50,7 +50,9 @@
 #include <cupy/complex/complex.h>
 #include <cupy/complex/math_private.h>
 
-namespace thrust {
+#include <thrust/detail/config.h>
+
+THRUST_NAMESPACE_BEGIN
 namespace detail {
 namespace complex {
 
@@ -130,4 +132,4 @@ __host__ __device__ inline complex<float> sinh(const complex<float>& z) {
   return detail::complex::csinhf(z);
 }
 
-}  // namespace thrust
+THRUST_NAMESPACE_END

--- a/cupy/_core/include/cupy/complex/csqrt.h
+++ b/cupy/_core/include/cupy/complex/csqrt.h
@@ -51,7 +51,9 @@
 #include <cupy/complex/complex.h>
 #include <cupy/complex/math_private.h>
 
-namespace thrust {
+#include <thrust/detail/config.h>
+
+THRUST_NAMESPACE_BEGIN
 namespace detail {
 namespace complex {
 
@@ -141,4 +143,4 @@ __host__ __device__ inline complex<double> sqrt(const complex<double>& z) {
   return detail::complex::csqrt(z);
 }
 
-}  // namespace thrust
+THRUST_NAMESPACE_END

--- a/cupy/_core/include/cupy/complex/csqrtf.h
+++ b/cupy/_core/include/cupy/complex/csqrtf.h
@@ -51,7 +51,9 @@
 #include <cupy/complex/complex.h>
 #include <cupy/complex/math_private.h>
 
-namespace thrust {
+#include <thrust/detail/config.h>
+
+THRUST_NAMESPACE_BEGIN
 namespace detail {
 namespace complex {
 
@@ -138,4 +140,4 @@ __host__ __device__ inline complex<float> sqrt(const complex<float>& z) {
   return detail::complex::csqrtf(z);
 }
 
-}  // namespace thrust
+THRUST_NAMESPACE_END

--- a/cupy/_core/include/cupy/complex/ctanh.h
+++ b/cupy/_core/include/cupy/complex/ctanh.h
@@ -90,7 +90,9 @@
 #include <cupy/complex/complex.h>
 #include <cupy/complex/math_private.h>
 
-namespace thrust {
+#include <thrust/detail/config.h>
+
+THRUST_NAMESPACE_BEGIN
 namespace detail {
 namespace complex {
 
@@ -188,4 +190,4 @@ __host__ __device__ inline complex<double> tanh(const complex<double>& z) {
   return detail::complex::ctanh(z);
 }
 
-}  // namespace thrust
+THRUST_NAMESPACE_END

--- a/cupy/_core/include/cupy/complex/ctanhf.h
+++ b/cupy/_core/include/cupy/complex/ctanhf.h
@@ -55,7 +55,9 @@
 #include <cupy/complex/complex.h>
 #include <cupy/complex/math_private.h>
 
-namespace thrust {
+#include <thrust/detail/config.h>
+
+THRUST_NAMESPACE_BEGIN
 namespace detail {
 namespace complex {
 
@@ -113,4 +115,4 @@ __host__ __device__ inline complex<float> tanh(const complex<float>& z) {
   return detail::complex::ctanhf(z);
 }
 
-}  // namespace thrust
+THRUST_NAMESPACE_END

--- a/cupy/_core/include/cupy/complex/math_private.h
+++ b/cupy/_core/include/cupy/complex/math_private.h
@@ -36,7 +36,9 @@
 #include <cfloat>
 #endif  // defined(_MSC_VER)
 
-namespace thrust {
+#include <thrust/detail/config.h>
+
+THRUST_NAMESPACE_BEGIN
 
 #if !defined(_MSC_VER)  // see #6823
 const float FLT_MIN = 1.17549435e-38F;
@@ -189,4 +191,4 @@ using ::isnan;
 using ::signbit;
 using ::isfinite;
 
-}  // namespace thrust
+THRUST_NAMESPACE_END

--- a/cupy/cuda/cupy_thrust.cu
+++ b/cupy/cuda/cupy_thrust.cu
@@ -80,10 +80,10 @@ THRUST_OPTIONAL_CPP11_CONSTEXPR
 #endif
 bool _tuple_less(const thrust::tuple<size_t, T>& lhs,
 		 const thrust::tuple<size_t, T>& rhs) {
-    const size_t& lhs_k = lhs.template get<0>();
-    const size_t& rhs_k = rhs.template get<0>();
-    const T& lhs_v = lhs.template get<1>();
-    const T& rhs_v = rhs.template get<1>();
+    const size_t& lhs_k = thrust::get<0>(lhs);
+    const size_t& rhs_k = thrust::get<0>(rhs);
+    const T& lhs_v = thrust::get<1>(lhs);
+    const T& rhs_v = thrust::get<1>(rhs);
     const thrust::less<T> _less;
 
     // tuple's comparison rule: compare the 1st member, then 2nd, then 3rd, ...,


### PR DESCRIPTION
Thrust has introduced a wrapped versioning namespace. This is colliding with the namespace introduced in `cupy/complex`

To avoid that issue pull in the thrust config and use the proper thrust namespace macro