### PR TITLE
Add the `nearest` method for percentile/quantile estimation

### DIFF
--- a/cupy/_statistics/order.py
+++ b/cupy/_statistics/order.py
@@ -309,7 +309,7 @@ def percentile(a, q, axis=None, out=None,
             function completes is undefined.
         method (str): Interpolation method when a quantile lies between
             two data points. ``linear`` interpolation is used by default.
-            Supported interpolations are``lower``, ``higher``, ``midpoint``,
+            Supported interpolations are ``lower``, ``higher``, ``midpoint``,
             ``nearest`` and ``linear``.
         keepdims (bool): If ``True``, the axis is remained as an axis of
             size one.
@@ -356,7 +356,7 @@ def quantile(a, q, axis=None, out=None,
             function completes is undefined.
         method (str): Interpolation method when a quantile lies between
             two data points. ``linear`` interpolation is used by default.
-            Supported interpolations are``lower``, ``higher``, ``midpoint``,
+            Supported interpolations are ``lower``, ``higher``, ``midpoint``,
             ``nearest`` and ``linear``.
         keepdims (bool): If ``True``, the axis is remained as an axis of
             size one.

--- a/cupy/_statistics/order.py
+++ b/cupy/_statistics/order.py
@@ -233,9 +233,7 @@ def _quantile_unchecked(a, q, axis=None, out=None,
     elif method == 'midpoint':
         indices = 0.5 * (cupy.floor(indices) + cupy.ceil(indices))
     elif method == 'nearest':
-        # TODO(hvy): Implement nearest using around
-        raise ValueError('\'nearest\' method is not yet supported. '
-                         'Please use any other method.')
+        indices = cupy.around(indices).astype(cupy.int32)
     elif method == 'linear':
         pass
     else:

--- a/tests/cupy_tests/statistics_tests/test_order.py
+++ b/tests/cupy_tests/statistics_tests/test_order.py
@@ -22,7 +22,7 @@ _all_methods = (
     'lower',
     'higher',
     'midpoint',
-    # 'nearest',                    # TODO(hvy): Not implemented
+    'nearest',
 )
 
 


### PR DESCRIPTION
I'd been going through the issue #6229 and thought I'd finish off the to-do, since the docs say we already support the `nearest` interpolation method.

https://docs.cupy.dev/en/stable/reference/generated/cupy.percentile.html