### PR TITLE
Fix build system for Thrust detection

### DIFF
--- a/install/cupy_builder/_features.py
+++ b/install/cupy_builder/_features.py
@@ -390,9 +390,7 @@ def get_features(ctx: Context) -> Dict[str, Feature]:
             ('cupy.cuda.thrust', ['cupy/cuda/cupy_thrust.cu']),
         ],
         'include': [
-            'thrust/device_ptr.h',
-            'thrust/sequence.h',
-            'thrust/sort.h',
+            'thrust/version.h',
         ],
         'libraries': list(_cudart_static_libs),
         'check_method': build.check_thrust_version,


### PR DESCRIPTION
Recent Thrust has changed such that it's no longer safe to use the host compiler to compile the headers. Making a new choice based on the discussion in https://github.com/NVIDIA/cccl/issues/1373. This also aligns the treatment with ROCm builds.