### PR TITLE
Various Jitify improvements

### DIFF
--- a/cupy/cuda/jitify.pyx
+++ b/cupy/cuda/jitify.pyx
@@ -11,9 +11,11 @@ import json
 import os
 import re
 import tempfile
+import warnings
 
 from cupy._environment import get_cuda_path
 from cupy.cuda import cub
+from cupy import _util
 
 
 ###############################################################################
@@ -185,6 +187,12 @@ cdef inline void _init_cupy_headers_from_scratch() except*:
     cupy_headers[b"type_traits"] = b"#include <cupy/cuda_workaround.h>\n"
     # Same for tuple
     cupy_headers[b"tuple"] = b"#include <cupy/cuda_workaround.h>\n"
+
+    # Ensure users know this is normal and not hanging...
+    warnings.warn(
+        "Jitify is performing a one-time only warm-up to populate the "
+        "persistent cache, this may take a few seconds and will be improved "
+        "in a future release...", _util.PerformanceWarning)
 
     # Compile a dummy kernel to further populate the cache (with bundled
     # headers)

--- a/install/cupy_builder/cupy_setup_build.py
+++ b/install/cupy_builder/cupy_setup_build.py
@@ -362,6 +362,8 @@ def make_extensions(ctx: Context, compiler, use_cython):
         if module['name'] == 'jitify':
             # this fixes RTD (no_cuda) builds...
             compile_args.append('--std=c++11')
+            # suppress printing Jitify logging to stdout
+            compile_args.append('-DJITIFY_PRINT_LOG=0')
             # Uncomment to diagnose Jitify issues.
             # compile_args.append('-DJITIFY_PRINT_ALL')
 


### PR DESCRIPTION
- Part of #8209: Add a Jitify warning as a stop-gap solution to avoid the hanging user experience.
- Suppress Jitify logs being printed to stdout to avoid surprises, e.g.
   - https://stackoverflow.com/questions/77961021/cupy-cooperative-groups-h-jitify-file-not-found
   - https://stackoverflow.com/questions/78060784/jitify-file-not-found
   - https://github.com/rapidsai/dask-cuda/issues/1317