### PR TITLE
Fix jitify warmup kernel - Cont'd

### DIFF
--- a/cupy/cuda/jitify.pyx
+++ b/cupy/cuda/jitify.pyx
@@ -145,9 +145,6 @@ cdef str warmup_kernel = r"""cupy_jitify_exercise
 // not supported before CC 7.0
 #include <cuda/barrier>
 #endif
-#include <cooperative_groups.h>
-#include <cooperative_groups/memcpy_async.h>
-
 
 extern "C" __global__ void jitify_exercise() { }
 """


### PR DESCRIPTION
Close #8249. Follow-up of #8200.

Starting CUDA 12.3 there are some internal NVRTC compiler changes that led to issues with the CG & cudart headers (e.g. nvbugs 4130337). From the user perspective, it manifests as compile-time errors. Since the CG headers are not redistributable, vendoring them is not a viable option, and the warm-up kernel should only include headers that are guaranteed default-accessible in all package formats (it means CCCL headers + other CuPy headers, after this PR), so I simply remove the CG headers. 

It could be possible to include `cuda_device_runtime_api.h` before the CG headers to fix the compile-time error, however it raises a compiler warning 
```
/usr/local/cuda-12.0.0/include/crt/host_defines.h(54): warning #1105-D: #warning directive: "crt/host_defines.h is an internal header file and must not be used directly.  Please use cuda_runtime_api.h or cuda_runtime.h instead."
```
and caching a cudart header is not favored.