### PR TITLE
Support fallback allgorithm for spgemm

### DIFF
--- a/cupy_backends/cuda/libs/cusparse.pxd
+++ b/cupy_backends/cuda/libs/cusparse.pxd
@@ -141,8 +141,13 @@ cpdef enum:
     # cusparseSpSMAlg_t
     CUSPARSE_SPSM_ALG_DEFAULT = 0
 
-    # ...
+    # cusparseSpGEMMAlg_t
     CUSPARSE_SPGEMM_DEFAULT = 0
+    CUSPARSE_SPGEMM_CSR_ALG_DETERMINITIC = 1
+    CUSPARSE_SPGEMM_CSR_ALG_NONDETERMINITIC = 2
+    CUSPARSE_SPGEMM_ALG1 = 3 # Default, fastest algorithm
+    CUSPARSE_SPGEMM_ALG2 = 4 # Balance between memory and time
+    CUSPARSE_SPGEMM_ALG3 = 5 # Low memory requirement, chunk computation
 
     # cusparseSparseToDenseAlg_t
     CUSPARSE_SPARSETODENSE_ALG_DEFAULT = 0

--- a/cupy_backends/cuda/libs/cusparse.pxd
+++ b/cupy_backends/cuda/libs/cusparse.pxd
@@ -145,9 +145,9 @@ cpdef enum:
     CUSPARSE_SPGEMM_DEFAULT = 0
     CUSPARSE_SPGEMM_CSR_ALG_DETERMINITIC = 1
     CUSPARSE_SPGEMM_CSR_ALG_NONDETERMINITIC = 2
-    CUSPARSE_SPGEMM_ALG1 = 3 # Default, fastest algorithm
-    CUSPARSE_SPGEMM_ALG2 = 4 # Balance between memory and time
-    CUSPARSE_SPGEMM_ALG3 = 5 # Low memory requirement, chunk computation
+    CUSPARSE_SPGEMM_ALG1 = 3  # Default, fastest algorithm
+    CUSPARSE_SPGEMM_ALG2 = 4  # Balance between memory and time
+    CUSPARSE_SPGEMM_ALG3 = 5  # Low memory requirement, chunk computation
 
     # cusparseSparseToDenseAlg_t
     CUSPARSE_SPARSETODENSE_ALG_DEFAULT = 0

--- a/cupyx/cusparse.py
+++ b/cupyx/cusparse.py
@@ -2049,14 +2049,28 @@ def spgemm(a, b, alpha=1):
     algo = _cusparse.CUSPARSE_SPGEMM_DEFAULT
     null_ptr = 0
 
-    # Analyze the matrices A and B to understand the memory requirement
-    buff1_size = _cusparse.spGEMM_workEstimation(
-        handle, op_a, op_b, alpha.data, mat_a.desc, mat_b.desc, beta.data,
-        mat_c.desc, cuda_dtype, algo, spgemm_descr, 0, null_ptr)
-    buff1 = _cupy.empty(buff1_size, _cupy.int8)
-    _cusparse.spGEMM_workEstimation(
-        handle, op_a, op_b, alpha.data, mat_a.desc, mat_b.desc, beta.data,
-        mat_c.desc, cuda_dtype, algo, spgemm_descr, buff1_size, buff1.data.ptr)
+    try: 
+        # Analyze the matrices A and B to understand the memory requirement
+        buff1_size = _cusparse.spGEMM_workEstimation(
+            handle, op_a, op_b, alpha.data, mat_a.desc, mat_b.desc, beta.data,
+            mat_c.desc, cuda_dtype, algo, spgemm_descr, 0, null_ptr)
+        buff1 = _cupy.empty(buff1_size, _cupy.int8)
+        _cusparse.spGEMM_workEstimation(
+            handle, op_a, op_b, alpha.data, mat_a.desc, mat_b.desc, beta.data,
+            mat_c.desc, cuda_dtype, algo, spgemm_descr, buff1_size, buff1.data.ptr)
+        
+    except _cusparse.CuSparseError as cse:
+        # If the memory required is too high, fall back to ALG2 if cuSPARSE >= 12.0
+        if getVersion() < 12000:
+            raise cse
+        algo = _cusparse.CUSPARSE_SPGEMM_ALG2
+        buff1_size = _cusparse.spGEMM_workEstimation(
+            handle, op_a, op_b, alpha.data, mat_a.desc, mat_b.desc, beta.data,
+            mat_c.desc, cuda_dtype, algo, spgemm_descr, 0, null_ptr)
+        buff1 = _cupy.empty(buff1_size, _cupy.int8)
+        _cusparse.spGEMM_workEstimation(
+            handle, op_a, op_b, alpha.data, mat_a.desc, mat_b.desc, beta.data,
+            mat_c.desc, cuda_dtype, algo, spgemm_descr, buff1_size, buff1.data.ptr)
 
     # Compute the intermediate product of A and B
     buff2_size = _cusparse.spGEMM_compute(

--- a/cupyx/cusparse.py
+++ b/cupyx/cusparse.py
@@ -2049,7 +2049,7 @@ def spgemm(a, b, alpha=1):
     algo = _cusparse.CUSPARSE_SPGEMM_DEFAULT
     null_ptr = 0
 
-    try: 
+    try:
         # Analyze the matrices A and B to understand the memory requirement
         buff1_size = _cusparse.spGEMM_workEstimation(
             handle, op_a, op_b, alpha.data, mat_a.desc, mat_b.desc, beta.data,
@@ -2057,10 +2057,12 @@ def spgemm(a, b, alpha=1):
         buff1 = _cupy.empty(buff1_size, _cupy.int8)
         _cusparse.spGEMM_workEstimation(
             handle, op_a, op_b, alpha.data, mat_a.desc, mat_b.desc, beta.data,
-            mat_c.desc, cuda_dtype, algo, spgemm_descr, buff1_size, buff1.data.ptr)
-        
+            mat_c.desc, cuda_dtype, algo, spgemm_descr, buff1_size,
+            buff1.data.ptr)
+
     except _cusparse.CuSparseError as cse:
-        # If the memory required is too high, fall back to ALG2 if cuSPARSE >= 12.0
+        # If the memory required is too high and cuSPARSE >= 12.0, fall back
+        # to ALG2
         if getVersion() < 12000:
             raise cse
         algo = _cusparse.CUSPARSE_SPGEMM_ALG2
@@ -2070,7 +2072,8 @@ def spgemm(a, b, alpha=1):
         buff1 = _cupy.empty(buff1_size, _cupy.int8)
         _cusparse.spGEMM_workEstimation(
             handle, op_a, op_b, alpha.data, mat_a.desc, mat_b.desc, beta.data,
-            mat_c.desc, cuda_dtype, algo, spgemm_descr, buff1_size, buff1.data.ptr)
+            mat_c.desc, cuda_dtype, algo, spgemm_descr, buff1_size,
+            buff1.data.ptr)
 
     # Compute the intermediate product of A and B
     buff2_size = _cusparse.spGEMM_compute(

--- a/tests/cupyx_tests/test_cusparse.py
+++ b/tests/cupyx_tests/test_cusparse.py
@@ -398,6 +398,7 @@ class TestSpgemm:
             # Lower memory algorithms for spgemm not available in CUDA < 12.0
             with pytest.raises(_cusparse.CuSparseError):
                 cusparse.spgemm(a, b)
+            return
 
         c = cusparse.spgemm(a, b, alpha=self.alpha)
         if (self.shape[0] == 100000):

--- a/tests/cupyx_tests/test_cusparse.py
+++ b/tests/cupyx_tests/test_cusparse.py
@@ -402,7 +402,7 @@ class TestSpgemm:
 
         c = cusparse.spgemm(a, b, alpha=self.alpha)
         if (self.shape[0] == 100000):
-            return # skip the comparison with scipy on large tests
+            return  # skip the comparison with scipy on large tests
         expect = self.alpha * self.a.dot(self.b)
         testing.assert_array_almost_equal(c.toarray(), expect.toarray())
 

--- a/tests/cupyx_tests/test_cusparse.py
+++ b/tests/cupyx_tests/test_cusparse.py
@@ -369,7 +369,7 @@ class TestCsrgemm2InvalidCases:
 
 @testing.parameterize(*testing.product({
     'dtype': [numpy.float32, numpy.float64, numpy.complex64, numpy.complex128],
-    'shape': [(2, 3, 4), (4, 3, 2)]
+    'shape': [(2, 3, 4), (4, 3, 2), (100000, 100000, 50)]
 }))
 @testing.with_requires('scipy>=1.2.0')
 class TestSpgemm:
@@ -393,7 +393,15 @@ class TestSpgemm:
     def test_spgemm_ab(self):
         a = sparse.csr_matrix(self.a)
         b = sparse.csr_matrix(self.b)
+
+        if (self.shape[0] == 100000) and cusparse.getVersion() < 12000:
+            # Lower memory algorithms for spgemm not available in CUDA < 12.0
+            with pytest.raises(_cusparse.CuSparseError):
+                cusparse.spgemm(a, b)
+
         c = cusparse.spgemm(a, b, alpha=self.alpha)
+        if (self.shape[0] == 100000):
+            return # skip the comparison with scipy on large tests
         expect = self.alpha * self.a.dot(self.b)
         testing.assert_array_almost_equal(c.toarray(), expect.toarray())
 


### PR DESCRIPTION
This PR closes #7699. It is adding support for SPGEMM ALG2 of cusparse that requires a much lower memory usage than the default, used only when the default algorithm would fail.