### PR TITLE
Tentatively pin SciPy to v1.12 in CI

### DIFF
--- a/.pfnci/windows/test.ps1
+++ b/.pfnci/windows/test.ps1
@@ -85,7 +85,7 @@ function Main {
 
     echo "Building..."
     $build_retval = 0
-    RunOrDie python -m pip install -U "numpy" "scipy"
+    RunOrDie python -m pip install -U "numpy" "scipy==1.12.*"
     python -m pip install ".[all,test]" -v > cupy_build_log.txt
     if (-not $?) {
         $build_retval = $LastExitCode


### PR DESCRIPTION
Ref #8272

Test failures are observed after SciPy v1.13.0. Pin Windows tests to use SciPy v1.12 until further investigation. https://ci.preferred.jp/cupy.win.cuda122/159080/