### PR TITLE
add NdBSpline based interpolation methods to RGI

### DIFF
--- a/cupyx/scipy/interpolate/_ndbspline.py
+++ b/cupyx/scipy/interpolate/_ndbspline.py
@@ -398,12 +398,12 @@ def colloc_nd(xvals, t, len_t, k):
     # Precompute the shape and strides of the coefficients array.
     # This would have been the NdBSpline coefficients; in the present context
     # this is a helper to compute the indices into the collocation matrix.
-    c_shape = tuple(len(t[d]) - k1_shape[d] for d in range(ndim))
+    c_shape = len_t - cupy.asarray(k1_shape, dtype=len_t.dtype)
 
     # The computation is equivalent to
     # >>> x = cupy.empty(c_shape)
     # >>> cstrides = [s // 8 for s in x.strides]
-    cs = cupy.asarray(c_shape[1:] + (1,))
+    cs = cupy.r_[c_shape[1:], 1]
     cstrides = cupy.cumprod(cs[::-1], dtype=cupy.int64)[::-1].copy()
 
     # tabulate flat indices for iterating over the (k+1)**ndim subarray of

--- a/cupyx/scipy/interpolate/_ndbspline.py
+++ b/cupyx/scipy/interpolate/_ndbspline.py
@@ -136,10 +136,12 @@ __global__ void compute_nd_bsplines(
         const int* nu, bool extrapolate, bool check_all_validity,
         long long* intervals, double* splines, bool* invalid) {
 
-    int start = getCurThreadIdx() / ndim;
-    int dim_idx = getCurThreadIdx() % ndim;
+    int total = n_xi * ndim;
 
-    for(int idx = start; idx < n_xi; idx += getThreadNum()) {
+    for(int midx = getCurThreadIdx(); midx < total; midx += getThreadNum()) {
+        int idx = midx / ndim;
+        int dim_idx = midx % ndim;
+
         double xd = xi[ndim * idx + dim_idx];
         const double* dim_t = t + max_t * dim_idx;
         const long long dim_k = k[dim_idx];
@@ -210,10 +212,12 @@ __global__ void store_nd_bsplines(
         long long* volume, int ndim, int n_xi, const long long* max_k,
         long long* out_idx, double* out) {
 
-    int start = getCurThreadIdx() / volume[0];
-    int iflat = getCurThreadIdx() % volume[0];
+    int total = n_xi * volume[0];
 
-    for(int idx = start; idx < n_xi; idx += getThreadNum()) {
+    for(int midx = getCurThreadIdx(); midx < total; midx += getThreadNum()) {
+        int idx = midx / volume[0];
+        int iflat = midx % volume[0];
+
         const double* idx_splines = b + ndim * (2 * max_k[0] + 2) * idx;
         const long long* idx_b = indices_k1d + ndim * iflat;
 

--- a/cupyx/scipy/interpolate/_rgi.py
+++ b/cupyx/scipy/interpolate/_rgi.py
@@ -5,7 +5,7 @@ import cupy as cp
 from cupyx.scipy.interpolate._bspline2 import make_interp_spline
 from cupyx.scipy.interpolate._cubic import PchipInterpolator
 from cupyx.scipy.interpolate._interpolate import _ndim_coords_from_arrays
-
+from cupyx.scipy.interpolate._ndbspline import make_ndbspl
 
 def _check_points(points):
     descending_dimensions = []
@@ -43,10 +43,10 @@ def _check_dimensionality(points, values):
 
 class RegularGridInterpolator:
     """
-    Interpolation on a regular or rectilinear grid in arbitrary dimensions.
+    Interpolator on a regular or rectilinear grid in arbitrary dimensions.
 
     The data must be defined on a rectilinear grid; that is, a rectangular
-    grid with even or uneven spacing. Linear and nearest-neighbor
+    grid with even or uneven spacing. Linear, nearest-neighbor, spline
     interpolations are supported. After setting up the interpolator object,
     the interpolation method may be chosen at each evaluation.
 
@@ -58,7 +58,7 @@ class RegularGridInterpolator:
         strictly ascending or descending.
 
     values : ndarray, shape (m1, ..., mn, ...)
-        The data on the regular grid in n dimensions. Complex data can be
+        The data on the regular grid in n dimensions. Complex data is accepted
         acceptable.
 
     method : str, optional
@@ -86,6 +86,11 @@ class RegularGridInterpolator:
 
     In other words, this class assumes that the data is defined on a
     *rectilinear* grid.
+
+    The 'slinear'(k=1), 'cubic'(k=3), and 'quintic'(k=5) methods are
+    tensor-product spline interpolators, where `k` is the spline degree,
+    If any dimension has fewer points than `k` + 1, an error will be raised.
+
 
     If the input data is such that dimensions have incommensurate
     units and differ by many orders of magnitude, the interpolant may have
@@ -165,6 +170,8 @@ class RegularGridInterpolator:
 
     See Also
     --------
+    scipy.interpolate.RegularGridInterpolator
+
     interpn : a convenience function which wraps `RegularGridInterpolator`
 
     scipy.ndimage.map_coordinates : interpolation on grids with equal spacing
@@ -184,7 +191,11 @@ class RegularGridInterpolator:
     # this class is based on code originally programmed by Johannes Buchner,
     # see https://github.com/JohannesBuchner/regulargrid
 
-    _SPLINE_DEGREE_MAP = {"slinear": 1, "cubic": 3, "quintic": 5, 'pchip': 3}
+    _SPLINE_DEGREE_MAP = {"slinear": 1, "cubic": 3, "quintic": 5, 'pchip': 3,
+                          "slinear_legacy": 1, "cubic_legacy": 3, "quintic_legacy": 5,}
+    _SPLINE_METHODS_recursive = {"slinear_legacy", "cubic_legacy",
+                                "quintic_legacy", "pchip"}
+    _SPLINE_METHODS_ndbspl = {"slinear", "cubic", "quintic"}
     _SPLINE_METHODS = list(_SPLINE_DEGREE_MAP.keys())
     _ALL_METHODS = ["linear", "nearest"] + _SPLINE_METHODS
 
@@ -203,6 +214,14 @@ class RegularGridInterpolator:
         self.fill_value = self._check_fill_value(self.values, fill_value)
         if self._descending_dimensions:
             self.values = cp.flip(values, axis=self._descending_dimensions)
+        if self.method in self._SPLINE_METHODS_ndbspl:
+            self._spline = self._construct_spline(method)
+
+    def _construct_spline(self, method, solver=None):
+        spl = make_ndbspl(
+                self.grid, self.values, self._SPLINE_DEGREE_MAP[method],
+              )
+        return spl
 
     def _check_dimensionality(self, grid, values):
         _check_dimensionality(grid, values)
@@ -235,7 +254,7 @@ class RegularGridInterpolator:
                                  "of a type compatible with values")
         return fill_value
 
-    def __call__(self, xi, method=None):
+    def __call__(self, xi, method=None, *, nu=None):
         """
         Interpolation at coordinates.
 
@@ -245,9 +264,14 @@ class RegularGridInterpolator:
             The coordinates to evaluate the interpolator at.
 
         method : str, optional
-            The method of interpolation to perform. Supported are "linear" and
-            "nearest".  Default is the method chosen when the interpolator was
-            created.
+            The method of interpolation to perform. Supported are "linear",
+            "nearest", "slinear", "cubic", "quintic" and "pchip". Default is
+            the method chosen when the interpolator was created.
+
+        nu : sequence of ints, length ndim, optional
+            If not None, the orders of the derivatives to evaluate.
+            Each entry must be non-negative.
+            Only allowed for methods "slinear", "cubic" and "quintic".
 
         Returns
         -------
@@ -285,10 +309,18 @@ class RegularGridInterpolator:
         >>> interp([[1.5, 1.3], [0.3, 4.5]], method='linear')
         array([ 4.7, 24.3])
         """
-        is_method_changed = self.method != method
         method = self.method if method is None else method
+        is_method_changed = self.method != method
         if method not in self._ALL_METHODS:
             raise ValueError("Method '%s' is not defined" % method)
+        if is_method_changed and method in self._SPLINE_METHODS_ndbspl:
+            self._spline = self._construct_spline(method)
+
+        if nu is not None and method not in self._SPLINE_METHODS_ndbspl:
+            raise ValueError(
+                f"Can only compute derivatives for methods "
+                f"{self._SPLINE_METHODS_ndbspl}, got {method =}."
+            )
 
         xi, xi_shape, ndim, nans, out_of_bounds = self._prepare_xi(xi)
 
@@ -301,7 +333,10 @@ class RegularGridInterpolator:
         elif method in self._SPLINE_METHODS:
             if is_method_changed:
                 self._validate_grid_dimensions(self.grid, method)
-            result = self._evaluate_spline(xi, method)
+            if method in self._SPLINE_METHODS_recursive:
+                result = self._evaluate_spline(xi, method)
+            else:
+                result = self._spline(xi, nu=nu)
 
         if not self.bounds_error and self.fill_value is not None:
             result[out_of_bounds] = self.fill_value

--- a/cupyx/scipy/interpolate/_rgi.py
+++ b/cupyx/scipy/interpolate/_rgi.py
@@ -632,7 +632,8 @@ def interpn(points, values, xi, method="linear", bounds_error=True,
                                  "in dimension %d" % i)
 
     # perform interpolation
-    if method in ["linear", "nearest", "slinear", "cubic", "quintic", "pchip"]:
+    if method in ["linear", "nearest", "slinear", "cubic", "quintic", "pchip",
+                  "slinear_legacy", "cubic_legacy", "quintic_legacy"]:
         interp = RegularGridInterpolator(points, values, method=method,
                                          bounds_error=bounds_error,
                                          fill_value=fill_value)

--- a/cupyx/scipy/interpolate/_rgi.py
+++ b/cupyx/scipy/interpolate/_rgi.py
@@ -7,6 +7,7 @@ from cupyx.scipy.interpolate._cubic import PchipInterpolator
 from cupyx.scipy.interpolate._interpolate import _ndim_coords_from_arrays
 from cupyx.scipy.interpolate._ndbspline import make_ndbspl
 
+
 def _check_points(points):
     descending_dimensions = []
     grid = []
@@ -58,8 +59,7 @@ class RegularGridInterpolator:
         strictly ascending or descending.
 
     values : ndarray, shape (m1, ..., mn, ...)
-        The data on the regular grid in n dimensions. Complex data is accepted
-        acceptable.
+        The data on the regular grid in n dimensions.
 
     method : str, optional
         The method of interpolation to perform. Supported are "linear",
@@ -91,10 +91,17 @@ class RegularGridInterpolator:
     tensor-product spline interpolators, where `k` is the spline degree,
     If any dimension has fewer points than `k` + 1, an error will be raised.
 
-
     If the input data is such that dimensions have incommensurate
     units and differ by many orders of magnitude, the interpolant may have
     numerical artifacts. Consider rescaling the data before interpolating.
+
+    ** Choosing a spline method **
+
+    Spline methods, "slinear", "cubic" and "quintic" involve solving a large
+    sparse linear system at instantiation time. Alternatively, you may instead
+    use the legacy methods, "slinear_legacy", "cubic_legacy" and
+    "quintic_legacy". These methods allow faster construction but evaluations
+    will be much slower.
 
     Examples
     --------
@@ -192,9 +199,9 @@ class RegularGridInterpolator:
     # see https://github.com/JohannesBuchner/regulargrid
 
     _SPLINE_DEGREE_MAP = {"slinear": 1, "cubic": 3, "quintic": 5, 'pchip': 3,
-                          "slinear_legacy": 1, "cubic_legacy": 3, "quintic_legacy": 5,}
+                          "slinear_legacy": 1, "cubic_legacy": 3, "quintic_legacy": 5, }
     _SPLINE_METHODS_recursive = {"slinear_legacy", "cubic_legacy",
-                                "quintic_legacy", "pchip"}
+                                 "quintic_legacy", "pchip"}
     _SPLINE_METHODS_ndbspl = {"slinear", "cubic", "quintic"}
     _SPLINE_METHODS = list(_SPLINE_DEGREE_MAP.keys())
     _ALL_METHODS = ["linear", "nearest"] + _SPLINE_METHODS
@@ -219,8 +226,8 @@ class RegularGridInterpolator:
 
     def _construct_spline(self, method, solver=None):
         spl = make_ndbspl(
-                self.grid, self.values, self._SPLINE_DEGREE_MAP[method],
-              )
+            self.grid, self.values, self._SPLINE_DEGREE_MAP[method],
+        )
         return spl
 
     def _check_dimensionality(self, grid, values):
@@ -592,8 +599,9 @@ def interpn(points, values, xi, method="linear", bounds_error=True,
                                           resampling)
     """
     # sanity check 'method' kwarg
-    if method not in ["linear", "nearest", "slinear", "cubic",
-                      "quintic", "pchip"]:
+    if method not in ["linear", "nearest", "slinear", "cubic", "quintic",
+                      "pchip",
+                      "slinear_legacy", "cubic_legacy", "quintic_legacy"]:
         raise ValueError(
             "interpn only understands the methods 'linear', 'nearest', "
             "'slinear', 'cubic', 'quintic' and 'pchip'. "

--- a/cupyx/scipy/interpolate/_rgi.py
+++ b/cupyx/scipy/interpolate/_rgi.py
@@ -199,7 +199,8 @@ class RegularGridInterpolator:
     # see https://github.com/JohannesBuchner/regulargrid
 
     _SPLINE_DEGREE_MAP = {"slinear": 1, "cubic": 3, "quintic": 5, 'pchip': 3,
-                          "slinear_legacy": 1, "cubic_legacy": 3, "quintic_legacy": 5, }
+                          "slinear_legacy": 1, "cubic_legacy": 3,
+                          "quintic_legacy": 5, }
     _SPLINE_METHODS_recursive = {"slinear_legacy", "cubic_legacy",
                                  "quintic_legacy", "pchip"}
     _SPLINE_METHODS_ndbspl = {"slinear", "cubic", "quintic"}

--- a/tests/cupyx_tests/scipy_tests/interpolate_tests/test_ndbspline.py
+++ b/tests/cupyx_tests/scipy_tests/interpolate_tests/test_ndbspline.py
@@ -1,5 +1,6 @@
 import numpy
 import cupy
+from cupy.cuda import runtime
 from cupy import testing
 
 import cupyx.scipy.interpolate  # NOQA
@@ -413,6 +414,7 @@ class TestNdBSpline:
         return dm.indices.astype(xp.int64)
 
 
+@pytest.mark.skipif(runtime.is_hip, reason='csrlsvqr not available')
 @testing.with_requires('scipy>=1.13')
 class TestMakeND:
 

--- a/tests/cupyx_tests/scipy_tests/interpolate_tests/test_ndbspline.py
+++ b/tests/cupyx_tests/scipy_tests/interpolate_tests/test_ndbspline.py
@@ -1,4 +1,5 @@
-
+import numpy
+import cupy
 from cupy import testing
 
 import cupyx.scipy.interpolate  # NOQA
@@ -391,3 +392,134 @@ class TestNdBSpline:
             scp.interpolate.NdBSpline.design_matrix([[1, 2]], t3, [k]*3)
 
         return dm.todense(), dm1.todense()
+
+    @testing.with_requires('scipy>=1.13')
+    @pytest.mark.parametrize('k', [(3, 1), (1, 3), (1, 1), (3, 3)])
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_design_matrix_2(self, xp, scp, k):
+        xvals = [(a, b)
+                 for a, b in
+                 itertools.product(xp.arange(6), xp.arange(7) + 1.5)
+                 ]
+        xvals = xp.asarray(xvals)
+
+        t = (xp.array([0., 0., 0., 0., 2., 3., 5., 5., 5., 5.]),
+             xp.array([1.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 7.5])
+             # xp.array([1.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 7.5, 8.5])  # equal lengths
+             )
+
+        dm = scp.interpolate.NdBSpline.design_matrix(xvals, t, k)
+#        return dm.todense()
+        return dm.indices.astype(xp.int64)
+
+
+@testing.with_requires('scipy>=1.13')
+class TestMakeND:
+
+    def _make(self, xp):
+        if xp == cupy:
+            return cupyx.scipy.interpolate._ndbspline.make_ndbspl
+        else:
+            import functools
+            import scipy.sparse.linalg as ssl
+            return functools.partial(scipy.interpolate._ndbspline.make_ndbspl,
+                                     solver=ssl.spsolve)
+
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_2D_separable_simple(self, xp, scp):
+        x = xp.arange(6)
+        y = xp.arange(6) + 0.5
+        values = x[:, None]**3 * (y**3 + 2*y)[None, :]
+        xi = [(a, b) for a, b in itertools.product(x, y)]
+
+        make_ndbspl = self._make(xp)
+        bspl = make_ndbspl((x, y), values, k=1)
+        return bspl(xi), bspl.c
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', atol=1e-11)
+    def test_2D_separable_trailing_dims(self, xp, scp):
+        # test `c` with trailing dimensions, i.e. c.ndim > ndim
+        x = xp.arange(6)
+        y = xp.arange(6)
+        xi = [(a, b) for a, b in itertools.product(x, y)]
+
+        # make values4.shape = (6, 6, 4)
+        values = x[:, None]**3 * (y**3 + 2*y)[None, :]
+        values4 = xp.dstack((values, values, values, values))
+
+        make_ndbspl = self._make(xp)
+        bspl = make_ndbspl((x, y), values4, k=3)
+        return bspl(xi), bspl.c
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', atol=1e-13)
+    def test_2D_separable_trailing_dims_2(self, xp, scp):
+        x = xp.arange(6)
+        y = xp.arange(6)
+        xi = [(a, b) for a, b in itertools.product(x, y)]
+
+        # make values4.shape = (6, 6, 4)
+        values = x[:, None]**3 * (y**3 + 2*y)[None, :]
+        values4 = xp.dstack((values, values, values, values))
+
+        # now two trailing dimensions
+        values22 = values4.reshape((6, 6, 2, 2))
+
+        make_ndbspl = self._make(xp)
+        bspl = make_ndbspl((x, y), values22, k=3)
+        return bspl(xi)
+
+    @pytest.mark.parametrize('k', [(3, 3), (1, 1), (3, 1), (1, 3), (3, 5)])
+    @testing.numpy_cupy_allclose(scipy_name='scp', atol=1e-12)
+    def test_2D_mixed(self, k, xp, scp):
+        # make a 2D separable spline w/ len(tx) != len(ty)
+        x = xp.arange(6)
+        y = xp.arange(7) + 1.5
+        xi = [(a, b) for a, b in itertools.product(x, y)]
+        values = (x**3)[:, None] * (y**2 + 2*y)[None, :]
+        make_ndbspl = self._make(xp)
+        bspl = make_ndbspl((x, y), values, k=k)
+        return bspl(xi)
+
+    def _get_sample_2d_data(self, xp):
+        # from test_rgi.py::TestIntepN
+        x = xp.array([.5, 2., 3., 4., 5.5, 6.])
+        y = xp.array([.5, 2., 3., 4., 5.5, 6.])
+        z = xp.array(
+            [
+                [1, 2, 1, 2, 1, 1],
+                [1, 2, 1, 2, 1, 1],
+                [1, 2, 3, 2, 1, 1],
+                [1, 2, 2, 2, 1, 1],
+                [1, 2, 1, 2, 1, 1],
+                [1, 2, 2, 2, 1, 1],
+            ]
+        )
+        return x, y, z
+
+    @pytest.mark.parametrize('k', [1, 3, 5])
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_2D_vs_RGI_k(self, xp, scp, k):
+        x, y, z = self._get_sample_2d_data(xp)
+        make_ndbspl = self._make(xp)
+        bspl = make_ndbspl((x, y), z, k=1)
+        xi = xp.array([[1, 2.3, 5.3, 0.5, 3.3, 1.2, 3],
+                       [1, 3.3, 1.2, 4.0, 5.0, 1.0, 3]]).T
+        return bspl(xi)
+
+    @pytest.mark.parametrize(
+        'k, meth', [(1, 'linear'), (3, 'cubic_legacy'), (5, 'quintic_legacy')]
+    )
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_3D_random_vs_RGI(self, k, meth, xp, scp):
+        rndm = numpy.random.default_rng(123456)
+        x = xp.cumsum(xp.asarray(rndm.uniform(size=6)))
+        y = xp.cumsum(xp.asarray(rndm.uniform(size=7)))
+        z = xp.cumsum(xp.asarray(rndm.uniform(size=8)))
+        values = xp.asarray(rndm.uniform(size=(6, 7, 8)))
+
+        make_ndbspl = self._make(xp)
+        bspl = make_ndbspl((x, y, z), values, k=k)
+
+        xi = rndm.uniform(low=0.7, high=2.1, size=(11, 3))
+        xi = xp.asarray(xi)
+        return bspl(xi)

--- a/tests/cupyx_tests/scipy_tests/interpolate_tests/test_ndbspline.py
+++ b/tests/cupyx_tests/scipy_tests/interpolate_tests/test_ndbspline.py
@@ -406,12 +406,10 @@ class TestNdBSpline:
 
         t = (xp.array([0., 0., 0., 0., 2., 3., 5., 5., 5., 5.]),
              xp.array([1.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 7.5])
-             # xp.array([1.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 7.5, 8.5])  # equal lengths
              )
 
         dm = scp.interpolate.NdBSpline.design_matrix(xvals, t, k)
-#        return dm.todense()
-        return dm.indices.astype(xp.int64)
+        return dm.todense()
 
 
 @pytest.mark.skipif(runtime.is_hip, reason='csrlsvqr not available')

--- a/tests/cupyx_tests/scipy_tests/interpolate_tests/test_rgi.py
+++ b/tests/cupyx_tests/scipy_tests/interpolate_tests/test_rgi.py
@@ -479,6 +479,26 @@ class TestRegularGridInterpolator:
         v2 = cp.expand_dims(vs, axis=0)
         assert_allclose(v, v2, atol=1e-14, err_msg=method)
 
+    def test_derivatives(self):
+        points, values = self._get_sample_4d()
+        sample = cp.array([[0.1 , 0.1 , 1.  , 0.9 ],
+                           [0.2 , 0.1 , 0.45, 0.8 ],
+                           [0.5 , 0.5 , 0.5 , 0.5 ]])
+        interp = RegularGridInterpolator(points, values, method="slinear")
+
+        with assert_raises(ValueError):
+            # wrong number of derivatives (need 4)
+            interp(sample, nu=1)
+
+        assert_allclose(interp(sample, nu=(1, 0, 0, 0)),
+                        [1, 1, 1], atol=1e-15)
+        assert_allclose(interp(sample, nu=(0, 1, 0, 0)),
+                        [10, 10, 10], atol=1e-15)
+
+        # 2nd derivatives of a linear function are zero
+        assert_allclose(interp(sample, nu=(0, 1, 1, 0)),
+                        [0, 0, 0], atol=1e-12)
+
 
 class MyValue:
     """

--- a/tests/cupyx_tests/scipy_tests/interpolate_tests/test_rgi.py
+++ b/tests/cupyx_tests/scipy_tests/interpolate_tests/test_rgi.py
@@ -10,7 +10,8 @@ from cupyx.scipy.interpolate import RegularGridInterpolator, interpn
 
 methods = ['linear', 'nearest']
 if not runtime.is_hip:
-    methods += ["slinear", "cubic", "quintic", 'pchip']
+    methods += ["slinear", "cubic", "quintic", 'pchip',
+                "slinear_legacy", "cubic_legacy", "quintic_legacy"]
 
 parametrize_rgi_interp_methods = pytest.mark.parametrize("method", methods)
 

--- a/tests/cupyx_tests/scipy_tests/interpolate_tests/test_rgi.py
+++ b/tests/cupyx_tests/scipy_tests/interpolate_tests/test_rgi.py
@@ -386,6 +386,9 @@ class TestRegularGridInterpolator:
 
     @parametrize_rgi_interp_methods
     def test_nonscalar_values(self, method):
+        if method in ("cubic_legacy", "quintic_legacy"):
+            pytest.skip("way too slow for a test")
+
         # Verify that non-scalar valued values also works
         points = [(0.0, 0.5, 1.0, 1.5, 2.0, 2.5)] * 2 + [
             (0.0, 5.0, 10.0, 15.0, 20, 25.0)
@@ -413,6 +416,9 @@ class TestRegularGridInterpolator:
     @parametrize_rgi_interp_methods
     @pytest.mark.parametrize("flip_points", [False, True])
     def test_nonscalar_values_2(self, method, flip_points):
+        if method in ("cubic_legacy", "quintic_legacy"):
+            pytest.skip("way too slow for a test")
+
         # Verify that non-scalar valued values also work : use different
         # lengths of axes to simplify tracing the internals
         points = [(0.0, 0.5, 1.0, 1.5, 2.0, 2.5),
@@ -627,6 +633,9 @@ class TestInterpN:
     @parametrize_rgi_interp_methods
     def test_nonscalar_values(self, method):
         # Verify that non-scalar valued values also works
+        if method in ("cubic_legacy", "quintic_legacy"):
+            pytest.skip("way too slow for a test")
+
         points = [(0.0, 0.5, 1.0, 1.5, 2.0, 2.5)] * 2 + [
             (0.0, 5.0, 10.0, 15.0, 20, 25.0)
         ] * 2
@@ -649,6 +658,9 @@ class TestInterpN:
     def test_nonscalar_values_2(self, method):
         # Verify that non-scalar valued values also work : use different
         # lengths of axes to simplify tracing the internals
+        if method in ("cubic_legacy", "quintic_legacy"):
+            pytest.skip("way too slow for a test")
+
         points = [(0.0, 0.5, 1.0, 1.5, 2.0, 2.5),
                   (0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0),
                   (0.0, 5.0, 10.0, 15.0, 20, 25.0, 35.0, 36.0),

--- a/tests/cupyx_tests/scipy_tests/interpolate_tests/test_rgi.py
+++ b/tests/cupyx_tests/scipy_tests/interpolate_tests/test_rgi.py
@@ -488,9 +488,9 @@ class TestRegularGridInterpolator:
 
     def test_derivatives(self):
         points, values = self._get_sample_4d()
-        sample = cp.array([[0.1 , 0.1 , 1.  , 0.9 ],
-                           [0.2 , 0.1 , 0.45, 0.8 ],
-                           [0.5 , 0.5 , 0.5 , 0.5 ]])
+        sample = cp.array([[0.1, 0.1, 1., 0.9],
+                           [0.2, 0.1, 0.45, 0.8],
+                           [0.5, 0.5, 0.5, 0.5]])
         interp = RegularGridInterpolator(points, values, method="slinear")
 
         with assert_raises(ValueError):


### PR DESCRIPTION
Add a constructor for N-dimensional b-splines from data, which is new in SciPy 1.13.0. 

The user API matches that of SciPy 1.13.0:
- the constructor is exposed via the RegularGridInterpolator only
- there is a slight backwards compat change: RGI(..., method="cubic") now goes through the NdBSpline. Previous behavior is available via `RGI(..., method="cubic_legacy")`
- the new way is parametrically slower for construction of an interpolator (previously: essentially zero work; currently: construct and solve a large sparse linear system)
- the new way is parametrically faster for evaluations: previously the evaluation went through a python loop over the data points, and for each data point a loop over the dimensions; the new way delegates to NdBSpline, which has a GPU kernel for evaluations.
- new methods can compute the derivatives.

cross-ref https://github.com/cupy/cupy/issues/7186