### PR TITLE
Preload cuTENSORMg

### DIFF
--- a/cupy/_environment.py
+++ b/cupy/_environment.py
@@ -416,12 +416,20 @@ def _get_cutensor_from_wheel(version: str, cuda: str) -> List[str]:
         return []
 
     if sys.platform == 'linux':
-        shared_lib = cutensor_dist.locate_file(
-            f'cutensor/lib/libcutensor.so.{version.split(".")[0]}'
-        )
+        shared_libs = [
+            cutensor_dist.locate_file(
+                f'cutensor/lib/libcutensor.so.{version.split(".")[0]}'
+            ),
+            cutensor_dist.locate_file(
+                f'cutensor/lib/libcutensorMg.so.{version.split(".")[0]}'
+            ),
+        ]
     else:
-        shared_lib = cutensor_dist.locate_file('cutensor\\bin\\cutensor.dll')
-    return [str(shared_lib)]
+        shared_libs = [
+            cutensor_dist.locate_file('cutensor\\bin\\cutensor.dll'),
+            cutensor_dist.locate_file('cutensor\\bin\\cutensorMg.dll'),
+        ]
+    return [str(lib) for lib in shared_libs]
 
 
 def _preload_warning(lib, exc):

--- a/cupyx/tools/install_library.py
+++ b/cupyx/tools/install_library.py
@@ -95,11 +95,14 @@ def __make_cutensor_record(
         'assets': {
             'Linux': {
                 'url': _make_cutensor_url('linux', filename_linux),
-                'filenames': ['libcutensor.so.{}'.format(public_version)],
+                'filenames': [
+                    'libcutensor.so.{}'.format(public_version),
+                    'libcutensorMg.so.{}'.format(public_version),
+                ],
             },
             'Windows': {
                 'url': _make_cutensor_url('windows', filename_windows),
-                'filenames': ['cutensor.dll'],
+                'filenames': ['cutensor.dll', 'cutensorMg.dll'],
             },
         }
     }


### PR DESCRIPTION
Support for cuTENSORMg has been added in #8212 but the library was not loaded. As a result `cupy_backends.cuda.libs.cutensor` import was failing as the library could not be found.

No backport required as cuTENSORMg support is new in v14.
