### PR TITLE
Implement “excluded” option in vectorize.py

### DIFF
--- a/cupy/_functional/vectorize.py
+++ b/cupy/_functional/vectorize.py
@@ -45,14 +45,15 @@ class vectorize(object):
         if otypes is not None:
             self.otypes = ''.join([numpy.dtype(t).char for t in otypes])
 
-        if excluded is not None:
-            raise NotImplementedError(
-                'cupy.vectorize does not support `excluded` option currently.')
-
         if signature is not None:
             raise NotImplementedError(
                 'cupy.vectorize does not support `signature`'
                 ' option currently.')
+        args = pyfunc.__code__.co_varnames[:pyfunc.__code__.co_argcount]
+        if excluded is not None:
+            self.excluded = \
+                [args.index(arg) for arg in args if arg in excluded]
+            # args are passed in positionally later, so this is best format
 
     @staticmethod
     def _get_body(return_type, call):
@@ -101,5 +102,23 @@ class vectorize(object):
                 options=('-DCUPY_JIT_MODE', '--std=c++14'),
             )
             self._kernel_cache[itypes] = kern
+
+        if self.excluded is not None and len(args) > len(self.excluded):
+            def copy_shape(obj, copy):
+                if isinstance(obj, cupy.ndarray):
+                    new_obj = cupy.empty_like(obj)
+                    new_obj[:] = copy
+                    return new_obj
+                elif isinstance(obj, (list, tuple)):
+                    return type(obj)(copy_shape(item, copy) for item in obj)
+
+            reference_shape = 0
+            arg_list = list(args)
+            while reference_shape in self.excluded:
+                reference_shape += 1
+            for Index in self.excluded:
+                arg_list[Index] = (
+                    copy_shape(arg_list[reference_shape], arg_list[Index]))
+            args = tuple(arg_list)
 
         return kern(*args)

--- a/tests/cupy_tests/functional_tests/test_vectorize.py
+++ b/tests/cupy_tests/functional_tests/test_vectorize.py
@@ -666,3 +666,59 @@ class TestVectorize(unittest.TestCase):
         a = cupy.array([0.4, -0.2, 1.8, -1.2], dtype=cupy.float32)
         with pytest.raises(TypeError):
             return f(a)
+
+
+class TestVectorizeExclude(unittest.TestCase):
+    def _run(self, func, xp, dtypes, excluded=None):
+        f = xp.vectorize(func, excluded=excluded)
+        args = [
+            testing.shaped_random((20, 30), xp, dtype, seed=seed)
+            for seed, dtype in enumerate(dtypes)
+        ]
+        if excluded is not None:
+            param = func.__code__.co_varnames[:func.__code__.co_argcount]
+            excluded = [i for i, arg in enumerate(param) if arg in excluded]
+            for index in excluded:
+                test = testing.shaped_random((1, 1), xp, dtypes[index])[0][0]
+                args[index] = test
+                # Ugly implementation, but testing doesn't
+                # have a method to return a singular value not a matrix
+
+        return f(*args)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose(rtol=1e-6)
+    def test_vectorize_reciprocal(self, xp, dtype):
+        def addition(x, y, z):
+            return x + y + z
+
+        return self._run(addition, xp, [dtype, dtype, dtype], excluded=['y'])
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose(rtol=1e-6)
+    def test_all_excluded(self, xp, dtype):
+        def addition(x, y, z):
+            return x + y + z
+
+        return self._run(addition, xp,
+                         [dtype, dtype, dtype], excluded=['x', 'y', 'z'])
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose(rtol=1e-6)
+    def test_none_excluded(self, xp, dtype):
+        def addition(x, y, z):
+            return x + y + z
+
+        return self._run(addition, xp, [dtype, dtype, dtype], excluded=[])
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose(rtol=1e-6)
+    def test_excluded_vectorize_broadcast(self, xp, dtype):
+        def my_func(x1, x2, x3):
+            return x1 + x2 + x3
+
+        f = xp.vectorize(my_func, excluded='x1')
+        x1 = testing.shaped_random((1, 1), xp, dtype)[0][0]
+        x2 = testing.shaped_random((30,), xp, dtype, seed=2)
+        x3 = testing.shaped_random((20, 30), xp, dtype, seed=3)
+        return f(x1, x2, x3)

--- a/tests/cupy_tests/functional_tests/test_vectorize.py
+++ b/tests/cupy_tests/functional_tests/test_vectorize.py
@@ -562,7 +562,6 @@ class TestVectorizeConstants(unittest.TestCase):
 
     @testing.numpy_cupy_array_equal()
     def test_vectorize_const_value(self, xp):
-
         def my_func(x1, x2):
             return x1 - x2 + const
 
@@ -574,7 +573,6 @@ class TestVectorizeConstants(unittest.TestCase):
 
     @testing.numpy_cupy_array_equal()
     def test_vectorize_const_attr(self, xp):
-
         def my_func(x1, x2):
             return x1 - x2 + const.x
 
@@ -717,8 +715,32 @@ class TestVectorizeExclude(unittest.TestCase):
         def my_func(x1, x2, x3):
             return x1 + x2 + x3
 
-        f = xp.vectorize(my_func, excluded='x1')
+        f = xp.vectorize(my_func, excluded=['x1'])
         x1 = testing.shaped_random((1, 1), xp, dtype)[0][0]
         x2 = testing.shaped_random((30,), xp, dtype, seed=2)
         x3 = testing.shaped_random((20, 30), xp, dtype, seed=3)
+        return f(x1, x2, x3)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose(rtol=1e-5)
+    def test_excluded_shape(self, xp, dtype):
+        def my_func(x1, x2, x3):
+            return x1 + x2 + x2 * x1
+
+        f = xp.vectorize(my_func, excluded=['x2'])
+        x1 = testing.shaped_random((20, 30, 40), xp, dtype, seed=12)
+        x2 = testing.shaped_random((30, 40), xp, dtype, seed=2)
+        x3 = testing.shaped_random((20, 30, 40), xp, dtype, seed=5)
+        return f(x1, x2, x3)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose(rtol=1e-5)
+    def test_excluded_shape_flat(self, xp, dtype):
+        def my_func(x1: xp, x2, x3):
+            return x1 + x2 + x2 * x1
+
+        f = xp.vectorize(my_func, excluded=['x2'])
+        x1 = testing.shaped_random((20, 30, 40), xp, dtype, seed=12)
+        x2 = testing.shaped_random((40,), xp, dtype, seed=2)
+        x3 = testing.shaped_random((20, 30, 40), xp, dtype, seed=5)
         return f(x1, x2, x3)


### PR DESCRIPTION
Why:
Fixes #8166 
TLDR: Implements a option numpy recently introduced in vectorize.py


How: Take the arguments for the vectorized function and copy the “excluded” parameters into a data structure that is the same shape as the non-”excluded” parameters. Pass these modified args into the function generated by ElementwiseKernel like normal. 
