### PR TITLE
ENH: cupyx/interpolate: port interp1d from scipy

### DIFF
--- a/cupyx/scipy/interpolate/__init__.py
+++ b/cupyx/scipy/interpolate/__init__.py
@@ -3,6 +3,7 @@ from cupyx.scipy.interpolate._polyint import BarycentricInterpolator  # NOQA
 from cupyx.scipy.interpolate._polyint import KroghInterpolator  # NOQA
 from cupyx.scipy.interpolate._polyint import barycentric_interpolate  # NOQA
 from cupyx.scipy.interpolate._polyint import krogh_interpolate  # NOQA
+from cupyx.scipy.interpolate._polyint import interp1d  # NOQA
 from cupyx.scipy.interpolate._interpolate import PPoly, BPoly, NdPPoly  # NOQA
 from cupyx.scipy.interpolate._cubic import (  # NOQA
     CubicHermiteSpline, PchipInterpolator, pchip_interpolate,  # NOQA

--- a/cupyx/scipy/interpolate/_polyint.py
+++ b/cupyx/scipy/interpolate/_polyint.py
@@ -78,6 +78,7 @@ class _Interpolator1D:
         """
         Reshape input array to 1-D
         """
+        x = cupy.asarray(x)
         x = _asarray_validated(x, check_finite=False, as_inexact=True)
         x_shape = x.shape
         return x.ravel(), x_shape
@@ -525,3 +526,418 @@ def krogh_interpolate(xi, yi, x, der=0, axis=0):
         return P.derivative(x, der=der)
     else:
         return P.derivatives(x, der=cupy.amax(der)+1)[der]
+
+
+def _check_broadcast_up_to(arr_from, shape_to, name):
+    """Helper to check that arr_from broadcasts up to shape_to"""
+    shape_from = arr_from.shape
+    if len(shape_to) >= len(shape_from):
+        for t, f in zip(shape_to[::-1], shape_from[::-1]):
+            if f != 1 and f != t:
+                break
+        else:  # all checks pass, do the upcasting that we need later
+            if arr_from.size != 1 and arr_from.shape != shape_to:
+                arr_from = cupy.ones(shape_to, arr_from.dtype) * arr_from
+            return arr_from.ravel()
+    # at least one check failed
+    raise ValueError(f'{name} argument must be able to broadcast up '
+                     f'to shape {shape_to} but had shape {shape_from}')
+
+
+def _do_extrapolate(fill_value):
+    """Helper to check if fill_value == "extrapolate" without warnings"""
+    return (isinstance(fill_value, str) and
+            fill_value == 'extrapolate')
+
+
+class interp1d(_Interpolator1D):
+    """
+    Interpolate a 1-D function.
+
+    `x` and `y` are arrays of values used to approximate some function f:
+    ``y = f(x)``. This class returns a function whose call method uses
+    interpolation to find the value of new points.
+
+    Parameters
+    ----------
+    x : (npoints, ) array_like
+        A 1-D array of real values.
+    y : (..., npoints, ...) array_like
+        A N-D array of real values. The length of `y` along the interpolation
+        axis must be equal to the length of `x`. Use the ``axis`` parameter
+        to select correct axis. Unlike other interpolators, the default
+        interpolation axis is the last axis of `y`.
+    kind : str or int, optional
+        Specifies the kind of interpolation as a string or as an integer
+        specifying the order of the spline interpolator to use.
+        The string has to be one of 'linear', 'nearest', 'nearest-up', 'zero',
+        'slinear', 'quadratic', 'cubic', 'previous', or 'next'. 'zero',
+        'slinear', 'quadratic' and 'cubic' refer to a spline interpolation of
+        zeroth, first, second or third order; 'previous' and 'next' simply
+        return the previous or next value of the point; 'nearest-up' and
+        'nearest' differ when interpolating half-integers (e.g. 0.5, 1.5)
+        in that 'nearest-up' rounds up and 'nearest' rounds down. Default
+        is 'linear'.
+    axis : int, optional
+        Axis in the ``y`` array corresponding to the x-coordinate values.
+        Unlike other interpolators, defaults to ``axis=-1``.
+    copy : bool, optional
+        If ``True``, the class makes internal copies of x and y. If ``False``,
+        references to ``x`` and ``y`` are used if possible. The default is to
+        copy.
+    bounds_error : bool, optional
+        If True, a ValueError is raised any time interpolation is attempted on
+        a value outside of the range of x (where extrapolation is
+        necessary). If False, out of bounds values are assigned `fill_value`.
+        By default, an error is raised unless ``fill_value="extrapolate"``.
+    fill_value : array-like or (array-like, array_like) or "extrapolate", optional
+        - if a ndarray (or float), this value will be used to fill in for
+          requested points outside of the data range. If not provided, then
+          the default is NaN. The array-like must broadcast properly to the
+          dimensions of the non-interpolation axes.
+        - If a two-element tuple, then the first element is used as a
+          fill value for ``x_new < x[0]`` and the second element is used for
+          ``x_new > x[-1]``. Anything that is not a 2-element tuple (e.g.,
+          list or ndarray, regardless of shape) is taken to be a single
+          array-like argument meant to be used for both bounds as
+          ``below, above = fill_value, fill_value``. Using a two-element tuple
+          or ndarray requires ``bounds_error=False``.
+        - If "extrapolate", then points outside the data range will be
+          extrapolated.
+
+    assume_sorted : bool, optional
+        If False, values of `x` can be in any order and they are sorted first.
+        If True, `x` has to be an array of monotonically increasing values.
+
+    See Also
+    --------
+    scipy.interpolate.interp1d
+
+    Notes
+    -----
+    Calling `interp1d` with NaNs present in input values results in
+    undefined behaviour.
+
+    Input values `x` and `y` must be convertible to `float` values like
+    `int` or `float`.
+
+    If the values in `x` are not unique, the resulting behavior is
+    undefined and specific to the choice of `kind`, i.e., changing
+    `kind` will change the behavior for duplicates.
+    """  # NOQA
+
+    def __init__(self, x, y, kind='linear', axis=-1,
+                 copy=True, bounds_error=None, fill_value=cupy.nan,
+                 assume_sorted=False):
+        """ Initialize a 1-D linear interpolation class."""
+        _Interpolator1D.__init__(self, x, y, axis=axis)
+
+        self.bounds_error = bounds_error  # used by fill_value setter
+
+        # `copy` keyword semantics changed in NumPy 2.0, once that is
+        # the minimum version this can use `copy=None`.
+        # XXX: https://github.com/scipy/scipy/blob/main/scipy/_lib/_util.py#L59
+        self.copy = copy
+        # if not copy:
+        #    self.copy = copy_if_needed
+
+        if kind in ['zero', 'slinear', 'quadratic', 'cubic']:
+            order = {'zero': 0, 'slinear': 1,
+                     'quadratic': 2, 'cubic': 3}[kind]
+            kind = 'spline'
+        elif isinstance(kind, int):
+            order = kind
+            kind = 'spline'
+        elif kind not in ('linear', 'nearest', 'nearest-up', 'previous',
+                          'next'):
+            raise NotImplementedError("%s is unsupported: Use fitpack "
+                                      "routines for other types." % kind)
+        x = cupy.array(x, copy=self.copy)
+        y = cupy.array(y, copy=self.copy)
+
+        if not assume_sorted:
+            ind = cupy.argsort(x, kind="stable")  # scipy uses kind="mergesort"
+            x = x[ind]
+            y = cupy.take(y, ind, axis=axis)
+
+        if x.ndim != 1:
+            raise ValueError("the x array must have exactly one dimension.")
+        if y.ndim == 0:
+            raise ValueError("the y array must have at least one dimension.")
+
+        # Force-cast y to a floating-point type, if it's not yet one
+        if not issubclass(y.dtype.type, cupy.inexact):
+            y = y.astype(cupy.float64)
+
+        # Backward compatibility
+        self.axis = axis % y.ndim
+
+        # Interpolation goes internally along the first axis
+        self.y = y
+        self._y = self._reshape_yi(self.y)
+        self.x = x
+        del y, x  # clean up namespace to prevent misuse; use attributes
+        self._kind = kind
+
+        # Adjust to interpolation kind; store reference to *unbound*
+        # interpolation methods, in order to avoid circular references to self
+        # stored in the bound instance methods, and therefore delayed garbage
+        # collection.  See: https://docs.python.org/reference/datamodel.html
+        if kind in ('linear', 'nearest', 'nearest-up', 'previous', 'next'):
+            # Make a "view" of the y array that is rotated to the interpolation
+            # axis.
+            minval = 1
+            if kind == 'nearest':
+                # Do division before addition to prevent possible integer
+                # overflow
+                self._side = 'left'
+                self.x_bds = self.x / 2.0
+                self.x_bds = self.x_bds[1:] + self.x_bds[:-1]
+
+                self._call = self.__class__._call_nearest
+            elif kind == 'nearest-up':
+                # Do division before addition to prevent possible integer
+                # overflow
+                self._side = 'right'
+                self.x_bds = self.x / 2.0
+                self.x_bds = self.x_bds[1:] + self.x_bds[:-1]
+
+                self._call = self.__class__._call_nearest
+            elif kind == 'previous':
+                # Side for cupy.searchsorted and index for clipping
+                self._side = 'left'
+                self._ind = 0
+                # Move x by one floating point value to the left
+                self._x_shift = cupy.nextafter(self.x, -cupy.inf)
+                self._call = self.__class__._call_previousnext
+                if _do_extrapolate(fill_value):
+                    self._check_and_update_bounds_error_for_extrapolation()
+                    # assume y is sorted by x ascending order here.
+                    fill_value = (cupy.nan, cupy.take(self.y, -1, axis))
+            elif kind == 'next':
+                self._side = 'right'
+                self._ind = 1
+                # Move x by one floating point value to the right
+                self._x_shift = cupy.nextafter(self.x, cupy.inf)
+                self._call = self.__class__._call_previousnext
+                if _do_extrapolate(fill_value):
+                    self._check_and_update_bounds_error_for_extrapolation()
+                    # assume y is sorted by x ascending order here.
+                    fill_value = (cupy.take(self.y, 0, axis), cupy.nan)
+            else:
+                # Check if we can delegate to numpy.interp (2x-10x faster).
+                np_dtypes = (cupy.dtype(cupy.float64), cupy.dtype(int))
+                cond = self.x.dtype in np_dtypes and self.y.dtype in np_dtypes
+                cond = cond and self.y.ndim == 1
+                cond = cond and not _do_extrapolate(fill_value)
+
+                if cond:
+                    self._call = self.__class__._call_linear_np
+                else:
+                    self._call = self.__class__._call_linear
+        else:
+            minval = order + 1
+
+            rewrite_nan = False
+            xx, yy = self.x, self._y
+            if order > 1:
+                # Quadratic or cubic spline. If input contains even a single
+                # nan, then the output is all nans. We cannot just feed data
+                # with nans to make_interp_spline because it calls LAPACK.
+                # So, we make up a bogus x and y with no nans and use it
+                # to get the correct shape of the output, which we then fill
+                # with nans.
+                # For slinear or zero order spline, we just pass nans through.
+                mask = cupy.isnan(self.x)
+                if mask.any():
+                    sx = self.x[~mask]
+                    if sx.size == 0:
+                        raise ValueError("`x` array is all-nan")
+                    xx = cupy.linspace(cupy.nanmin(self.x),
+                                       cupy.nanmax(self.x),
+                                       len(self.x))
+                    rewrite_nan = True
+                if cupy.isnan(self._y).any():
+                    yy = cupy.ones_like(self._y)
+                    rewrite_nan = True
+
+            from cupyx.scipy.interpolate import make_interp_spline
+            self._spline = make_interp_spline(xx, yy, k=order,
+                                              check_finite=False)
+            if rewrite_nan:
+                self._call = self.__class__._call_nan_spline
+            else:
+                self._call = self.__class__._call_spline
+
+        if len(self.x) < minval:
+            raise ValueError("x and y arrays must have at "
+                             "least %d entries" % minval)
+
+        self.fill_value = fill_value  # calls the setter, can modify bounds_err
+
+    @property
+    def fill_value(self):
+        """The fill value."""
+        # backwards compat: mimic a public attribute
+        return self._fill_value_orig
+
+    @fill_value.setter
+    def fill_value(self, fill_value):
+        # extrapolation only works for nearest neighbor and linear methods
+        if _do_extrapolate(fill_value):
+            self._check_and_update_bounds_error_for_extrapolation()
+            self._extrapolate = True
+        else:
+            broadcast_shape = (self.y.shape[:self.axis] +
+                               self.y.shape[self.axis + 1:])
+            if len(broadcast_shape) == 0:
+                broadcast_shape = (1,)
+            # it's either a pair (_below_range, _above_range) or a single value
+            # for both above and below range
+            if isinstance(fill_value, tuple) and len(fill_value) == 2:
+                below_above = [cupy.asarray(fill_value[0]),
+                               cupy.asarray(fill_value[1])]
+                names = ('fill_value (below)', 'fill_value (above)')
+                for ii in range(2):
+                    below_above[ii] = _check_broadcast_up_to(
+                        below_above[ii], broadcast_shape, names[ii])
+            else:
+                fill_value = cupy.asarray(fill_value)
+                below_above = [_check_broadcast_up_to(
+                    fill_value, broadcast_shape, 'fill_value')] * 2
+            self._fill_value_below, self._fill_value_above = below_above
+            self._extrapolate = False
+            if self.bounds_error is None:
+                self.bounds_error = True
+        # backwards compat: fill_value was a public attr; make it writeable
+        self._fill_value_orig = fill_value
+
+    def _check_and_update_bounds_error_for_extrapolation(self):
+        if self.bounds_error:
+            raise ValueError("Cannot extrapolate and raise "
+                             "at the same time.")
+        self.bounds_error = False
+
+    def _call_linear_np(self, x_new):
+        # Note that out-of-bounds values are taken care of in self._evaluate
+        return cupy.interp(x_new, self.x, self.y)
+
+    def _call_linear(self, x_new):
+        # 2. Find where in the original data, the values to interpolate
+        #    would be inserted.
+        #    Note: If x_new[n] == x[m], then m is returned by searchsorted.
+        x_new_indices = cupy.searchsorted(self.x, x_new)
+
+        # 3. Clip x_new_indices so that they are within the range of
+        #    self.x indices and at least 1. Removes mis-interpolation
+        #    of x_new[n] = x[0]
+        x_new_indices = x_new_indices.clip(1, len(self.x)-1).astype(int)
+
+        # 4. Calculate the slope of regions that each x_new value falls in.
+        lo = x_new_indices - 1
+        hi = x_new_indices
+
+        x_lo = self.x[lo]
+        x_hi = self.x[hi]
+        y_lo = self._y[lo]
+        y_hi = self._y[hi]
+
+        # Note that the following two expressions rely on the specifics of the
+        # broadcasting semantics.
+        slope = (y_hi - y_lo) / (x_hi - x_lo)[:, None]
+
+        # 5. Calculate the actual value for each entry in x_new.
+        y_new = slope*(x_new - x_lo)[:, None] + y_lo
+
+        return y_new
+
+    def _call_nearest(self, x_new):
+        """ Find nearest neighbor interpolated y_new = f(x_new)."""
+
+        # 2. Find where in the averaged data the values to interpolate
+        #    would be inserted.
+        #    Note: use side='left' (right) to searchsorted() to define the
+        #    halfway point to be nearest to the left (right) neighbor
+        x_new_indices = cupy.searchsorted(self.x_bds, x_new, side=self._side)
+
+        # 3. Clip x_new_indices so that they are within the range of x indices.
+        x_new_indices = x_new_indices.clip(0, len(self.x)-1).astype(cupy.intp)
+
+        # 4. Calculate the actual value for each entry in x_new.
+        y_new = self._y[x_new_indices]
+
+        return y_new
+
+    def _call_previousnext(self, x_new):
+        """Use previous/next neighbor of x_new, y_new = f(x_new)."""
+
+        # 1. Get index of left/right value
+        x_new_indices = cupy.searchsorted(
+            self._x_shift, x_new, side=self._side)
+
+        # 2. Clip x_new_indices so that they are within the range of x indices.
+        xn = len(self.x) - self._ind
+        x_new_indices = x_new_indices.clip(1 - self._ind,
+                                           xn).astype(cupy.intp)
+
+        # 3. Calculate the actual value for each entry in x_new.
+        y_new = self._y[x_new_indices+self._ind-1]
+
+        return y_new
+
+    def _call_spline(self, x_new):
+        return self._spline(x_new)
+
+    def _call_nan_spline(self, x_new):
+        out = self._spline(x_new)
+        out[...] = cupy.nan
+        return out
+
+    def _evaluate(self, x_new):
+        # 1. Handle values in x_new that are outside of x. Throw error,
+        #    or return a list of mask array indicating the outofbounds values.
+        #    The behavior is set by the bounds_error variable.
+        x_new = cupy.asarray(x_new)
+        y_new = self._call(self, x_new)
+        if not self._extrapolate:
+            below_bounds, above_bounds = self._check_bounds(x_new)
+            if len(y_new) > 0:
+                # Note fill_value must be broadcast up to the proper size
+                # and flattened to work here
+                y_new[below_bounds] = self._fill_value_below
+                y_new[above_bounds] = self._fill_value_above
+        return y_new
+
+    def _check_bounds(self, x_new):
+        """Check the inputs for being in the bounds of the interpolated data.
+
+        Parameters
+        ----------
+        x_new : array
+
+        Returns
+        -------
+        out_of_bounds : bool array
+            The mask on x_new of values that are out of the bounds.
+        """
+
+        # If self.bounds_error is True, we raise an error if any x_new values
+        # fall outside the range of x. Otherwise, we return an array indicating
+        # which values are outside the boundary region.
+        below_bounds = x_new < self.x[0]
+        above_bounds = x_new > self.x[-1]
+
+        if self.bounds_error and below_bounds.any():
+            below_bounds_value = x_new[cupy.argmax(below_bounds)]
+            raise ValueError(f"A value ({below_bounds_value}) in x_new is "
+                             f"below the interpolation range's minimum value "
+                             f"({self.x[0]}).")
+        if self.bounds_error and above_bounds.any():
+            above_bounds_value = x_new[cupy.argmax(above_bounds)]
+            raise ValueError(f"A value ({above_bounds_value}) in x_new is "
+                             f"above the interpolation range's maximum value "
+                             f"({self.x[-1]}).")
+
+        # !! Should we emit a warning if some values are out of bounds?
+        # !! matlab does not.
+        return below_bounds, above_bounds

--- a/docs/source/reference/scipy_interpolate.rst
+++ b/docs/source/reference/scipy_interpolate.rst
@@ -22,6 +22,7 @@ Univariate interpolation
    PPoly
    BPoly
    CubicSpline
+   interp1d
 
 1-D Splines
 -----------

--- a/tests/cupyx_tests/scipy_tests/interpolate_tests/test_polyint.py
+++ b/tests/cupyx_tests/scipy_tests/interpolate_tests/test_polyint.py
@@ -852,6 +852,7 @@ class TestInterp1D:
         yp = scp.interpolate.interp1d(x, y, kind='linear')(x)
         return yp
 
+    @testing.with_requires("scipy>=1.10")
     @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_linear_dtypes_2(self, xp, scp):
         # regression test for gh-14531, where 1D linear interpolation has been
@@ -885,6 +886,7 @@ class TestInterp1D:
         f = scp.interpolate.interp1d(x10, y10, kind='cubic')
         return f(x10), f(xp.asarray([2.4, 5.6, 6.0]))
 
+    @testing.with_requires("scipy>=1.10")
     @pytest.mark.parametrize('kind',
                              ['nearest', 'nearest-up', 'previous', 'next']
                              )
@@ -901,6 +903,7 @@ class TestInterp1D:
         xe = xp.asarray([-1., 0, 9, 11])
         return f(1.2), f(1.5), f(xval), fe(xe)
 
+    @testing.with_requires("scipy>=1.10")
     @pytest.mark.parametrize('kind', ['previous', 'next'])
     @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_previous_2(self, xp, scp, kind):
@@ -923,6 +926,7 @@ class TestInterp1D:
                 interpolator2D(xval),
                 interpolator2DAxis0(xval2))
 
+    @testing.with_requires("scipy>=1.10")
     @pytest.mark.parametrize('kind', ['previous', 'next'])
     @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_previous_3(self, xp, scp, kind):

--- a/tests/cupyx_tests/scipy_tests/interpolate_tests/test_polyint.py
+++ b/tests/cupyx_tests/scipy_tests/interpolate_tests/test_polyint.py
@@ -4,10 +4,12 @@ import warnings
 
 import numpy
 import pytest
+from pytest import raises as assert_raises
 
 import cupy
 from cupy.cuda import runtime
 from cupy import testing
+from cupy.testing import assert_array_almost_equal
 import cupyx.scipy.interpolate  # NOQA
 from cupyx.scipy.interpolate import CubicHermiteSpline
 
@@ -743,3 +745,575 @@ class TestCubicSpline:
         S = scp.interpolate.CubicSpline(x, y)
         q = xp.linspace(0, 1, 201)
         return S(q)
+
+
+class TestInterp1D:
+
+    def setup_method(self):
+        self.x5 = numpy.arange(5.)
+        self.x10 = numpy.arange(10.)
+        self.y10 = numpy.arange(10.)
+        self.x25 = self.x10.reshape((2, 5))
+        self.x2 = numpy.arange(2.)
+        self.y2 = numpy.arange(2.)
+        self.x1 = numpy.array([0.])
+        self.y1 = numpy.array([0.])
+
+        self.y210 = numpy.arange(20.).reshape((2, 10))
+        self.y102 = numpy.arange(20.).reshape((10, 2))
+        self.y225 = numpy.arange(20.).reshape((2, 2, 5))
+        self.y25 = numpy.arange(10.).reshape((2, 5))
+        self.y235 = numpy.arange(30.).reshape((2, 3, 5))
+        self.y325 = numpy.arange(30.).reshape((3, 2, 5))
+
+        # Edge updated test matrix 1
+        # array([[ 30,   1,   2,   3,   4,   5,   6,   7,   8, -30],
+        #        [ 30,  11,  12,  13,  14,  15,  16,  17,  18, -30]])
+        self.y210_edge_updated = numpy.arange(20.).reshape((2, 10))
+        self.y210_edge_updated[:, 0] = 30
+        self.y210_edge_updated[:, -1] = -30
+
+        # Edge updated test matrix 2
+        # array([[ 30,  30],
+        #       [  2,   3],
+        #       [  4,   5],
+        #       [  6,   7],
+        #       [  8,   9],
+        #       [ 10,  11],
+        #       [ 12,  13],
+        #       [ 14,  15],
+        #       [ 16,  17],
+        #       [-30, -30]])
+        self.y102_edge_updated = numpy.arange(20.).reshape((10, 2))
+        self.y102_edge_updated[0, :] = 30
+        self.y102_edge_updated[-1, :] = -30
+
+        self.fill_value = -100.0
+
+    def test_init(self):
+        # Check that the attributes are initialized appropriately by the
+        # constructor.
+        x10, y10, y210, y102 = map(cupy.asarray,
+                                   (self.x10, self.y10, self.y210, self.y102)
+                                   )
+        interp1d = cupyx.scipy.interpolate.interp1d
+
+        assert interp1d(x10, y10).copy
+        assert not interp1d(x10, y10, copy=False).copy
+        assert interp1d(x10, y10).bounds_error
+        assert not interp1d(x10, y10, bounds_error=False).bounds_error
+        assert cupy.isnan(interp1d(x10, y10).fill_value)
+        assert interp1d(x10, y10, fill_value=3.0).fill_value == 3.0
+        assert interp1d(x10, y10, fill_value=(
+            1.0, 2.0)).fill_value == (1.0, 2.0)
+        assert interp1d(x10, y10).axis == 0
+        assert interp1d(x10, y210).axis == 1
+        assert interp1d(x10, y102, axis=0).axis == 0
+        assert (interp1d(x10, y10).x == x10).all()
+        assert (interp1d(x10, y10).y == y10).all()
+        assert (interp1d(x10, y210).y == y210).all()
+
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_assume_sorted(self, xp, scp):
+        x10 = xp.asarray(self.x10)
+        y10 = xp.asarray(self.y10)
+        # Check for unsorted arrays
+        interp10_unsorted = scp.interpolate.interp1d(x10[::-1], y10[::-1])
+        return interp10_unsorted(x10)
+
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_assume_sorted_2D(self, xp, scp):
+        # Check that if y is a 2-D array, things are still consistent
+        x10 = xp.asarray(self.x10)
+        y210 = xp.asarray(self.y210)
+        interp10_y_2d_unsorted = scp.interpolate.interp1d(
+            x10[::-1], y210[:, ::-1]
+        )
+        return interp10_y_2d_unsorted(x10)
+
+    @pytest.mark.parametrize('kind', ['linear', 'slinear'])
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_linear(self, xp, scp, kind):
+        # Check the actual implementation of linear interpolation.
+        x10 = xp.asarray(self.x10)
+        y10 = xp.asarray(self.y10)
+
+        interp10 = scp.interpolate.interp1d(x10, y10, kind=kind)
+        extrapolator = scp.interpolate.interp1d(x10, y10, kind=kind,
+                                                fill_value='extrapolate')
+        xval = xp.asarray([-1., 0, 9, 11])
+        return interp10(x10), extrapolator(xval)
+
+    @pytest.mark.parametrize('dtyp', ['float16', 'float32', 'float64'])
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_linear_dtypes(self, xp, scp, dtyp):
+        x = xp.arange(8, dtype=dtyp)
+        y = x.copy()
+        yp = scp.interpolate.interp1d(x, y, kind='linear')(x)
+        return yp
+
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_linear_dtypes_2(self, xp, scp):
+        # regression test for gh-14531, where 1D linear interpolation has been
+        # has been extended to delegate to numpy.interp for integer dtypes
+        x = xp.asarray([0, 1, 2])
+        y = xp.asarray([xp.nan, 0, 1])
+        yp = scp.interpolate.interp1d(x, y)(x)
+        return yp
+
+    @pytest.mark.parametrize('kind', ['slinear', 'zero', 'quadratic', 'cubic'])
+    @pytest.mark.parametrize('dt_r', ['float16', 'float32', 'float64'])
+    @pytest.mark.parametrize('dt_n', ['float16', 'float32', 'float64'])
+    @pytest.mark.parametrize('dt_rc', ['float16', 'float32', 'float64',
+                                       'complex64', 'complex128'])
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=2e-7, atol=1e-15)
+    def test_slinear_dtypes(self, xp, scp, dt_n, dt_r, dt_rc, kind):
+        # regression test for gh-7273: 1D slinear interpolation fails with
+        # float32 inputs
+        x = xp.arange(0, 10, dtype=dt_r)
+        y = xp.exp(-x / 3.0).astype(dt_rc)
+        xnew = x.astype(dt_n)
+        return scp.interpolate.interp1d(
+            x, y, kind=kind, bounds_error=False
+        )(xnew)
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', atol=1e-15)
+    def test_cubic(self, xp, scp):
+        # Check the actual implementation of spline interpolation.
+        x10 = xp.asarray(self.x10)
+        y10 = xp.asarray(self.y10)
+        f = scp.interpolate.interp1d(x10, y10, kind='cubic')
+        return f(x10), f(xp.asarray([2.4, 5.6, 6.0]))
+
+    @pytest.mark.parametrize('kind',
+                             ['nearest', 'nearest-up', 'previous', 'next']
+                             )
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_nearest(self, xp, scp, kind):
+        # Check the actual implementation of nearest-neighbour interpolation.
+        # Nearest asserts that half-integer case (1.5) rounds down to 1
+        x10 = xp.asarray(self.x10)
+        y10 = xp.asarray(self.y10)
+        f = scp.interpolate.interp1d(x10, y10, kind=kind)
+        fe = scp.interpolate.interp1d(x10, y10, kind=kind,
+                                      fill_value='extrapolate')
+        xval = xp.asarray([2.4, 5.6, 6.0])
+        xe = xp.asarray([-1., 0, 9, 11])
+        return f(1.2), f(1.5), f(xval), fe(xe)
+
+    @pytest.mark.parametrize('kind', ['previous', 'next'])
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_previous_2(self, xp, scp, kind):
+        x10 = xp.asarray(self.x10)
+        y10 = xp.asarray(self.y10)
+        y210 = xp.asarray(self.y210)
+        y102 = xp.asarray(self.y102)
+
+        interpolator1D = scp.interpolate.interp1d(x10, y10, kind=kind,
+                                                  fill_value='extrapolate')
+        interpolator2D = scp.interpolate.interp1d(x10, y210, kind=kind,
+                                                  fill_value='extrapolate')
+        interpolator2DAxis0 = scp.interpolate.interp1d(
+            x10, y102, kind=kind, axis=0, fill_value='extrapolate'
+        )
+
+        xval = xp.asarray([-1, -2, 5, 8, 12, 25])
+        xval2 = xp.asarray([-2, 5, 12])
+        return (interpolator1D(xval),
+                interpolator2D(xval),
+                interpolator2DAxis0(xval2))
+
+    @pytest.mark.parametrize('kind', ['previous', 'next'])
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_previous_3(self, xp, scp, kind):
+        # Tests for gh-16813
+        x = xp.asarray([0, 1, 2])
+        y = xp.asarray([0, 1, -1])
+        xv = xp.asarray([-2, -1, 0, 1, 2, 3, 5])
+
+        interpolator1D = scp.interpolate.interp1d(x, y, kind=kind,
+                                                  fill_value='extrapolate',
+                                                  assume_sorted=True)
+
+        x1 = xp.asarray([2, 0, 1])   # x is not ascending
+        y1 = xp.asarray([-1, 0, 1])
+        interpolator1D_ns = scp.interpolate.interp1d(x1, y1, kind=kind,
+                                                     fill_value='extrapolate',
+                                                     assume_sorted=True)
+
+        x10 = xp.asarray(self.x10)
+        y210 = xp.asarray(self.y210_edge_updated)
+        interpolator2D = scp.interpolate.interp1d(x10, y210,
+                                                  kind=kind,
+                                                  fill_value='extrapolate')
+        xv1 = xp.asarray([-1, -2, 5, 8, 12, 25])
+
+        y102 = xp.asarray(self.y102_edge_updated)
+        interpolator2DAxis0 = scp.interpolate.interp1d(
+            x10, y102, kind=kind, axis=0, fill_value='extrapolate')
+
+        xv2 = xp.asarray([-2, 5, 11])
+        return (interpolator1D(xv),
+                interpolator1D_ns(xv),
+                interpolator2D(xv1),
+                interpolator2DAxis0(xv2))
+
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_zero(self, xp, scp):
+        # Check the actual implementation of zero-order spline interpolation.
+        x10 = xp.asarray(self.x10)
+        y10 = xp.asarray(self.y10)
+        xv = xp.asarray([2.4, 5.6, 6.0])
+
+        f = scp.interpolate.interp1d(x10, y10, kind='zero')
+        return f(1.2), f(1.5), f(xv), f(x10)
+
+    def bounds_check_helper(self, interpolant, test_array, fail_value):
+        # Asserts that a ValueError is raised and that the error message
+        # contains the value causing this exception.
+        assert_raises(ValueError, interpolant, test_array)
+        try:
+            interpolant(test_array)
+        except ValueError as err:
+            assert (f"{fail_value}" in str(err))
+
+    @pytest.mark.parametrize('kind', ['linear', 'cubic', 'nearest', 'previous',
+                                      'next', 'slinear', 'zero', 'quadratic'])
+    @testing.numpy_cupy_allclose(scipy_name='scp', atol=1e-15)
+    def test_bounds(self, kind, xp, scp):
+        x10 = xp.asarray(self.x10)
+        y10 = xp.asarray(self.y10)
+        fill_value = self.fill_value
+
+        # Test that our handling of out-of-bounds input is correct.
+        extrap10 = scp.interpolate.interp1d(x10, y10, fill_value=fill_value,
+                                            bounds_error=False, kind=kind)
+
+        xval1 = xp.asarray([[[11.2], [-3.4], [12.6], [19.3]]])
+        xval2 = xp.asarray([-1.0, 0.0, 5.0, 9.0, 11.0])
+        return extrap10(11.2), extrap10(-3.4), extrap10(xval1), extrap10(xval2)
+
+    @pytest.mark.parametrize('kind', ['linear', 'cubic', 'nearest', 'previous',
+                                      'next', 'slinear', 'zero', 'quadratic'])
+    @testing.numpy_cupy_allclose(scipy_name='scp', atol=2e-15)
+    def test_bounds_nan_fill(self, kind, xp, scp):
+        x = xp.arange(10).astype(int)
+        y = xp.arange(10).astype(int)
+        c = scp.interpolate.interp1d(x, y, kind=kind,
+                                     fill_value=cupy.nan, bounds_error=False)
+        yi = c(x - 1)
+        return yi
+
+    def _check_fill_value(self, kind):
+        interp1d = cupyx.scipy.interpolate.interp1d
+        x10 = cupy.asarray(self.x10)
+        y10 = cupy.asarray(self.y10)
+
+        x5 = cupy.asarray(self.x5)
+        y235, y325, y225, y25 = map(cupy.asarray,
+                                    (self.y235, self.y325, self.y225, self.y25)
+                                    )
+
+        interp = interp1d(x10, y10, kind=kind,
+                          fill_value=(-100, 100), bounds_error=False)
+        assert_array_almost_equal(interp(10), 100)
+        assert_array_almost_equal(interp(-10), -100)
+        assert_array_almost_equal(interp([-10, 10]), [-100, 100])
+
+        # Proper broadcasting:
+        #    interp along axis of length 5
+        # other dim=(2, 3), (3, 2), (2, 2), or (2,)
+
+        # one singleton fill_value (works for all)
+        for y in (y235, y325, y225, y25):
+            interp = interp1d(x5, y, kind=kind, axis=-1,
+                              fill_value=100, bounds_error=False)
+            assert_array_almost_equal(interp(10), 100)
+            assert_array_almost_equal(interp(-10), 100)
+            assert_array_almost_equal(interp([-10, 10]), 100)
+
+            # singleton lower, singleton upper
+            interp = interp1d(x5, y, kind=kind, axis=-1,
+                              fill_value=(-100, 100), bounds_error=False)
+            assert_array_almost_equal(interp(10), 100)
+            assert_array_almost_equal(interp(-10), -100)
+            if y.ndim == 3:
+                result = [[[-100, 100]] * y.shape[1]] * y.shape[0]
+            else:
+                result = [[-100, 100]] * y.shape[0]
+            assert_array_almost_equal(interp([-10, 10]), result)
+
+        # one broadcastable (3,) fill_value
+        fill_value = [100, 200, 300]
+        for y in (y325, y225):
+            assert_raises(ValueError, interp1d, self.x5, y, kind=kind,
+                          axis=-1, fill_value=fill_value, bounds_error=False)
+        interp = interp1d(self.x5, self.y235, kind=kind, axis=-1,
+                          fill_value=fill_value, bounds_error=False)
+        assert_array_almost_equal(interp(10), [[100, 200, 300]] * 2)
+        assert_array_almost_equal(interp(-10), [[100, 200, 300]] * 2)
+        assert_array_almost_equal(interp([-10, 10]), [[[100, 100],
+                                                       [200, 200],
+                                                       [300, 300]]] * 2)
+
+        # one broadcastable (2,) fill_value
+        fill_value = [100, 200]
+        assert_raises(ValueError, interp1d, self.x5, self.y235, kind=kind,
+                      axis=-1, fill_value=fill_value, bounds_error=False)
+        for y in (y225, y325, y25):
+            interp = interp1d(x5, y, kind=kind, axis=-1,
+                              fill_value=fill_value, bounds_error=False)
+            result = [100, 200]
+            if y.ndim == 3:
+                result = [result] * y.shape[0]
+            assert_array_almost_equal(interp(10), result)
+            assert_array_almost_equal(interp(-10), result)
+            result = [[100, 100], [200, 200]]
+            if y.ndim == 3:
+                result = [result] * y.shape[0]
+            assert_array_almost_equal(interp([-10, 10]), result)
+
+        # broadcastable (3,) lower, singleton upper
+        fill_value = (cupy.array([-100, -200, -300]), 100)
+        for y in (y325, y225):
+            assert_raises(ValueError, interp1d, self.x5, y, kind=kind,
+                          axis=-1, fill_value=fill_value, bounds_error=False)
+        interp = interp1d(x5, y235, kind=kind, axis=-1,
+                          fill_value=fill_value, bounds_error=False)
+        assert_array_almost_equal(interp(10), 100)
+        assert_array_almost_equal(interp(-10), [[-100, -200, -300]] * 2)
+        assert_array_almost_equal(interp([-10, 10]), [[[-100, 100],
+                                                       [-200, 100],
+                                                       [-300, 100]]] * 2)
+
+        # broadcastable (2,) lower, singleton upper
+        fill_value = (cupy.array([-100, -200]), 100)
+        assert_raises(ValueError, interp1d, self.x5, self.y235, kind=kind,
+                      axis=-1, fill_value=fill_value, bounds_error=False)
+        for y in (y225, y325, y25):
+            interp = interp1d(x5, y, kind=kind, axis=-1,
+                              fill_value=fill_value, bounds_error=False)
+            assert_array_almost_equal(interp(10), 100)
+            result = [-100, -200]
+            if y.ndim == 3:
+                result = [result] * y.shape[0]
+            assert_array_almost_equal(interp(-10), result)
+            result = [[-100, 100], [-200, 100]]
+            if y.ndim == 3:
+                result = [result] * y.shape[0]
+            assert_array_almost_equal(interp([-10, 10]), result)
+
+        # broadcastable (3,) lower, broadcastable (3,) upper
+        fill_value = ([-100, -200, -300], [100, 200, 300])
+        for y in (y325, y225):
+            assert_raises(ValueError, interp1d, self.x5, y, kind=kind,
+                          axis=-1, fill_value=fill_value, bounds_error=False)
+        for ii in range(2):  # check ndarray as well as list here
+            if ii == 1:
+                fill_value = tuple(cupy.array(f) for f in fill_value)
+            interp = interp1d(x5, y235, kind=kind, axis=-1,
+                              fill_value=fill_value, bounds_error=False)
+            assert_array_almost_equal(interp(10), [[100, 200, 300]] * 2)
+            assert_array_almost_equal(interp(-10), [[-100, -200, -300]] * 2)
+            assert_array_almost_equal(interp([-10, 10]), [[[-100, 100],
+                                                           [-200, 200],
+                                                           [-300, 300]]] * 2)
+        # broadcastable (2,) lower, broadcastable (2,) upper
+        fill_value = ([-100, -200], [100, 200])
+        assert_raises(ValueError, interp1d, x5, y235, kind=kind,
+                      axis=-1, fill_value=fill_value, bounds_error=False)
+        for y in (y325, y225, y25):
+            interp = interp1d(x5, y, kind=kind, axis=-1,
+                              fill_value=fill_value, bounds_error=False)
+            result = [100, 200]
+            if y.ndim == 3:
+                result = [result] * y.shape[0]
+            assert_array_almost_equal(interp(10), result)
+            result = [-100, -200]
+            if y.ndim == 3:
+                result = [result] * y.shape[0]
+            assert_array_almost_equal(interp(-10), result)
+            result = [[-100, 100], [-200, 200]]
+            if y.ndim == 3:
+                result = [result] * y.shape[0]
+            assert_array_almost_equal(interp([-10, 10]), result)
+
+        # one broadcastable (2, 2) array-like
+        fill_value = [[100, 200], [1000, 2000]]
+        for y in (y235, y325, y25):
+            assert_raises(ValueError, interp1d, x5, y, kind=kind,
+                          axis=-1, fill_value=fill_value, bounds_error=False)
+        for ii in range(2):
+            if ii == 1:
+                fill_value = cupy.array(fill_value)
+            interp = interp1d(x5, y225, kind=kind, axis=-1,
+                              fill_value=fill_value, bounds_error=False)
+            assert_array_almost_equal(interp(10), [[100, 200], [1000, 2000]])
+            assert_array_almost_equal(interp(-10), [[100, 200], [1000, 2000]])
+            assert_array_almost_equal(interp([-10, 10]), [[[100, 100],
+                                                           [200, 200]],
+                                                          [[1000, 1000],
+                                                           [2000, 2000]]])
+
+        # broadcastable (2, 2) lower, broadcastable (2, 2) upper
+        fill_value = ([[-100, -200], [-1000, -2000]],
+                      [[100, 200], [1000, 2000]])
+        for y in (y235, y325, y25):
+            assert_raises(ValueError, interp1d, x5, y, kind=kind,
+                          axis=-1, fill_value=fill_value, bounds_error=False)
+        for ii in range(2):
+            if ii == 1:
+                fill_value = (cupy.array(
+                    fill_value[0]), cupy.array(fill_value[1]))
+            interp = interp1d(x5, y225, kind=kind, axis=-1,
+                              fill_value=fill_value, bounds_error=False)
+            assert_array_almost_equal(interp(10), [[100, 200], [1000, 2000]])
+            assert_array_almost_equal(interp(-10), [[-100, -200],
+                                                    [-1000, -2000]])
+            assert_array_almost_equal(interp([-10, 10]), [[[-100, 100],
+                                                           [-200, 200]],
+                                                          [[-1000, 1000],
+                                                           [-2000, 2000]]])
+
+    @pytest.mark.parametrize('kind', ['linear', 'nearest', 'cubic', 'slinear',
+                                      'quadratic', 'zero', 'previous', 'next']
+                             )
+    def test_fill_value(self, kind):
+        # test that two-element fill value works
+        self._check_fill_value(kind)
+
+    def test_fill_value_writeable(self):
+        # backwards compat: fill_value is a public writeable attribute
+        x10, y10 = map(cupy.asarray, (self.x10, self.y10))
+        interp = cupyx.scipy.interpolate.interp1d(x10, y10, fill_value=123.0)
+        assert interp.fill_value == 123.0
+        interp.fill_value = 321.0
+        assert interp.fill_value == 321.0
+
+    def _nd_check_interp(self, kind='linear'):
+        # Check the behavior when the inputs and outputs are multidimensional.
+        x10, y10, y210, y102 = map(
+            cupy.asarray, (self.x10, self.y10, self.y210, self.y102))
+        interp1d = cupyx.scipy.interpolate.interp1d
+
+        # Multidimensional input.
+        interp10 = interp1d(x10, y10, kind=kind)
+        assert_array_almost_equal(interp10(cupy.array([[3., 5.], [2., 7.]])),
+                                  cupy.array([[3., 5.], [2., 7.]]))
+
+        # Scalar input -> 0-dim scalar array output
+        assert isinstance(interp10(1.2), cupy.ndarray)
+        assert interp10(1.2).shape == ()
+
+        # Multidimensional outputs.
+        interp210 = interp1d(x10, y210, kind=kind)
+        assert_array_almost_equal(interp210(1.), cupy.array([1., 11.]))
+        assert_array_almost_equal(interp210(cupy.array([1., 2.])),
+                                  cupy.array([[1., 2.], [11., 12.]]))
+
+        interp102 = interp1d(x10, y102, axis=0, kind=kind)
+        assert_array_almost_equal(interp102(1.), cupy.array([2.0, 3.0]))
+        assert_array_almost_equal(interp102(cupy.array([1., 3.])),
+                                  cupy.array([[2., 3.], [6., 7.]]))
+
+        # Both at the same time!
+        x_new = cupy.array([[3., 5.], [2., 7.]])
+        assert_array_almost_equal(interp210(x_new),
+                                  cupy.array([[[3., 5.], [2., 7.]],
+                                              [[13., 15.], [12., 17.]]]))
+        assert_array_almost_equal(interp102(x_new),
+                                  cupy.array([[[6., 7.], [10., 11.]],
+                                              [[4., 5.], [14., 15.]]]))
+
+    def _nd_check_shape(self, kind='linear'):
+        # Check large N-D output shape
+        a = [4, 5, 6, 7]
+        y = cupy.arange(cupy.prod(cupy.asarray(a))).reshape(*a)
+        for n, s in enumerate(a):
+            x = cupy.arange(s)
+            z = cupyx.scipy.interpolate.interp1d(x, y, axis=n, kind=kind)
+            assert_array_almost_equal(z(x), y, err_msg=kind)
+
+            x2 = cupy.arange(2*3*1).reshape((2, 3, 1)) / 12.
+            b = list(a)
+            b[n:n+1] = [2, 3, 1]
+            assert_array_almost_equal(z(x2).shape, b, err_msg=kind)
+
+    @pytest.mark.parametrize('kind', ['linear', 'cubic', 'slinear',
+                                      'quadratic',
+                                      'nearest', 'zero', 'previous', 'next'])
+    def test_nd(self, kind):
+        self._nd_check_interp(kind)
+        self._nd_check_shape(kind)
+
+    @pytest.mark.parametrize('kind', ['linear', 'cubic', 'slinear',
+                                      'quadratic',
+                                      'nearest', 'zero', 'previous', 'next'])
+    @pytest.mark.parametrize('dtyp', ['complex64', 'complex128'])
+    def test_complex(self, kind, dtyp):
+        x = cupy.array([1, 2.5, 3, 3.1, 4, 6.4, 7.9, 8.0, 9.5, 10])
+        y = x * x ** (1 + 2j)
+        y = y.astype(dtyp)
+
+        # simple test
+        c = cupyx.scipy.interpolate.interp1d(x, y, kind=kind)
+        assert_array_almost_equal(y[:-1], c(x)[:-1])
+
+        # check against interpolating real+imag separately
+        xi = cupy.linspace(1, 10, 31)
+        cr = cupyx.scipy.interpolate.interp1d(x, y.real, kind=kind)
+        ci = cupyx.scipy.interpolate.interp1d(x, y.imag, kind=kind)
+        assert_array_almost_equal(c(xi).real, cr(xi))
+        assert_array_almost_equal(c(xi).imag, ci(xi))
+
+    @pytest.mark.parametrize('kind', ['nearest', 'previous', 'next'])
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_overflow_nearest(self, xp, scp, kind):
+        # Test that the x range doesn't overflow when given integers as input
+        x = xp.array([0, 50, 127], dtype=xp.int8)
+        ii = scp.interpolate.interp1d(x, x, kind=kind)
+        return ii(x)
+
+    @pytest.mark.parametrize('kind', ['zero', 'slinear'])
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_local_nans(self, xp, scp, kind):
+        # check that for local interpolation kinds (slinear, zero) a single nan
+        # only affects its local neighborhood
+        x = xp.arange(10).astype(float)
+        y = x.copy()
+        y[6] = xp.nan
+        ir = scp.interpolate.interp1d(x, y, kind=kind)
+        return ir([4.9, 7.0])
+
+    @pytest.mark.parametrize('kind', ['quadratic', 'cubic'])
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_spline_nans(self, xp, scp, kind):
+        # Backwards compat: a single nan makes the whole spline interpolation
+        # return nans in an array of the correct shape. And it doesn't raise,
+        # just quiet nans because of backcompat.
+        x = xp.arange(8).astype(float)
+        y = x.copy()
+        yn = y.copy()
+        yn[3] = xp.nan
+
+        irn = scp.interpolate.interp1d(x, yn, kind=kind)
+        vals = tuple(irn(xv) for xv in (6, [1, 6], [[1, 6], [3, 5]]))
+        return vals
+
+    def test_all_nans(self):
+        # regression test for gh-11637: interp1d core dumps with all-nan `x`
+        x = cupy.ones(10) * cupy.nan
+        y = cupy.arange(10)
+        with assert_raises(ValueError):
+            cupyx.scipy.interpolate.interp1d(x, y, kind='cubic')
+
+    @pytest.mark.parametrize(
+        "kind", ("linear", "nearest", "nearest-up", "previous", "next")
+    )
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_single_value(self, xp, scp, kind):
+        # https://github.com/scipy/scipy/issues/4043
+        f = scp.interpolate.interp1d(xp.asarray([1.5]), xp.asarray([6]),
+                                     kind=kind, bounds_error=False,
+                                     fill_value=(2, 10))
+        return f(xp.asarray([1, 1.5, 2]))

--- a/tests/cupyx_tests/scipy_tests/interpolate_tests/test_polyint.py
+++ b/tests/cupyx_tests/scipy_tests/interpolate_tests/test_polyint.py
@@ -1307,6 +1307,7 @@ class TestInterp1D:
         with assert_raises(ValueError):
             cupyx.scipy.interpolate.interp1d(x, y, kind='cubic')
 
+    @testing.with_requires("scipy>=1.10")
     @pytest.mark.parametrize(
         "kind", ("linear", "nearest", "nearest-up", "previous", "next")
     )


### PR DESCRIPTION
Port `interp1d` routine from `scipy.interpolate`.
The routine itself is not very interesting: for `nearest`-like modes it delegates to `cupy.searchsorted`; for `cubic`-like modes it delegates to `make_interp_spline`. And it adds heaps and heaps of overhead on top.
It's public in SciPy though, and is used under the hood by `griddata`. So it's easier to port it and be done with it.

cross-ref https://github.com/cupy/cupy/issues/7186