### PR TITLE
ENH: cupyx/scipy/interpolate: add `griddata`

### DIFF
--- a/cupyx/scipy/interpolate/__init__.py
+++ b/cupyx/scipy/interpolate/__init__.py
@@ -14,6 +14,7 @@ from cupyx.scipy.interpolate._interpnd import LinearNDInterpolator  # NOQA
 from cupyx.scipy.interpolate._interpnd import (  # NOQA
     CloughTocher2DInterpolator)  # NOQA
 from cupyx.scipy.interpolate._ndgriddata import NearestNDInterpolator  # NOQA
+from cupyx.scipy.interpolate._ndgriddata import griddata  # NOQA
 
 # 1-D Splines
 from cupyx.scipy.interpolate._bspline import BSpline, splantider, splder  # NOQA

--- a/cupyx/scipy/interpolate/_ndgriddata.py
+++ b/cupyx/scipy/interpolate/_ndgriddata.py
@@ -4,7 +4,8 @@ Convenience interface to N-D interpolation
 
 import cupy
 from cupyx.scipy.interpolate._interpnd import (
-    NDInterpolatorBase, _ndim_coords_from_arrays)
+    NDInterpolatorBase, _ndim_coords_from_arrays,
+    LinearNDInterpolator, CloughTocher2DInterpolator)
 from cupyx.scipy.spatial import KDTree
 
 
@@ -155,3 +156,110 @@ class NearestNDInterpolator(NDInterpolatorBase):
         interp_values = interp_values.reshape(new_shape)
 
         return interp_values
+
+
+# ------------------------------------------------------------------------------
+# Convenience interface function
+# ------------------------------------------------------------------------------
+
+
+def griddata(points, values, xi, method='linear', fill_value=cupy.nan,
+             rescale=False):
+    """
+    Interpolate unstructured D-D data.
+
+    Parameters
+    ----------
+    points : 2-D ndarray of floats with shape (n, D), or length-D tuple of
+             1-D ndarrays with shape (n,).
+        Data point coordinates.
+    values : ndarray of float or complex, shape (n,)
+        Data values.
+    xi : 2-D ndarray of floats with shape (m, D), or length D tuple of
+        ndarrays broadcastable to the same shape.
+        Points at which to interpolate data.
+    method : {'linear', 'nearest', 'cubic'}, optional
+        Method of interpolation. One of
+
+        ``nearest``
+          return the value at the data point closest to
+          the point of interpolation. See `NearestNDInterpolator` for
+          more details.
+
+        ``linear``
+          tessellate the input point set to N-D
+          simplices, and interpolate linearly on each simplex. See
+          `LinearNDInterpolator` for more details.
+
+        ``cubic`` (1-D)
+          return the value determined from a cubic
+          spline.
+
+        ``cubic`` (2-D)
+          return the value determined from a
+          piecewise cubic, continuously differentiable (C1), and
+          approximately curvature-minimizing polynomial surface. See
+          `CloughTocher2DInterpolator` for more details.
+    fill_value : float, optional
+        Value used to fill in for requested points outside of the
+        convex hull of the input points. If not provided, then the
+        default is ``nan``. This option has no effect for the
+        'nearest' method.
+    rescale : bool, optional
+        Rescale points to unit cube before performing interpolation.
+        This is useful if some of the input dimensions have
+        incommensurable units and differ by many orders of magnitude.
+
+    Returns
+    -------
+    ndarray
+        Array of interpolated values.
+
+    See Also
+    --------
+    scipy.interpolate.griddata
+
+    Notes
+    -----
+
+    .. note:: For data on a regular grid use `interpn` instead.
+
+    """
+
+    points = _ndim_coords_from_arrays(points)
+
+    if points.ndim < 2:
+        ndim = points.ndim
+    else:
+        ndim = points.shape[-1]
+
+    if ndim == 1 and method in ('nearest', 'linear', 'cubic'):
+        from cupyx.scipy.interpolate._polyint import interp1d
+        points = points.ravel()
+        if isinstance(xi, tuple):
+            if len(xi) != 1:
+                raise ValueError("invalid number of dimensions in xi")
+            xi, = xi
+        # Sort points/values together, necessary as input for interp1d
+        idx = cupy.argsort(points)
+        points = points[idx]
+        values = values[idx]
+        if method == 'nearest':
+            fill_value = 'extrapolate'
+        ip = interp1d(points, values, kind=method, axis=0, bounds_error=False,
+                      fill_value=fill_value)
+        return ip(xi)
+    elif method == 'nearest':
+        ip = NearestNDInterpolator(points, values, rescale=rescale)
+        return ip(xi)
+    elif method == 'linear':
+        ip = LinearNDInterpolator(points, values, fill_value=fill_value,
+                                  rescale=rescale)
+        return ip(xi)
+    elif method == 'cubic' and ndim == 2:
+        ip = CloughTocher2DInterpolator(points, values, fill_value=fill_value,
+                                        rescale=rescale)
+        return ip(xi)
+    else:
+        raise ValueError("Unknown interpolation method %r for "
+                         "%d dimensional data" % (method, ndim))

--- a/docs/source/reference/scipy_interpolate.rst
+++ b/docs/source/reference/scipy_interpolate.rst
@@ -58,6 +58,7 @@ Unstructured data:
    LinearNDInterpolator
    NearestNDInterpolator
    CloughTocher2DInterpolator
+   griddata
    RBFInterpolator
 
 

--- a/tests/cupyx_tests/scipy_tests/interpolate_tests/test_ndgriddata.py
+++ b/tests/cupyx_tests/scipy_tests/interpolate_tests/test_ndgriddata.py
@@ -70,3 +70,154 @@ class TestNearestNDInterpolator:
         NI = scp.interpolate.NearestNDInterpolator((nd[0], nd[1]), nd[2])
         with pytest.raises(TypeError):
             NI([0.5, 0.5], query_options="not a dictionary")
+
+
+@testing.with_requires("scipy")
+class TestGriddata:
+
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_fill_value(self, xp, scp):
+        x = [(0, 0), (0, 1), (1, 0)]
+        y = [1, 2, 3]
+
+        yi = scp.interpolate.griddata(x, y, [(1, 1), (1, 2), (0, 0)],
+                                      fill_value=-1)
+        yi_ = scp.interpolate.griddata(x, y, [(1, 1), (1, 2), (0, 0)])
+        return yi, yi_
+
+    @pytest.mark.parametrize('method', ('nearest', 'linear', 'cubic'))
+    @pytest.mark.parametrize('rescale', (True, False))
+    @testing.numpy_cupy_allclose(scipy_name='scp', atol=5e-16)
+    def test_alternative_call(self, xp, scp, method, rescale):
+        x = xp.array([(0, 0), (-0.5, -0.5), (-0.5, 0.5), (0.5, 0.5),
+                     (0.25, 0.3)], dtype=xp.float64)
+        y = (xp.arange(x.shape[0], dtype=xp.float64)[:, None]
+             + xp.array([0, 1])[None, :])
+
+        yi = scp.interpolate.griddata((x[:, 0], x[:, 1]), y,
+                                      (x[:, 0], x[:, 1]),
+                                      method=method, rescale=rescale)
+        return yi
+
+    @pytest.mark.parametrize('method', ('nearest', 'linear', 'cubic'))
+    @pytest.mark.parametrize('rescale', (True, False))
+    @testing.numpy_cupy_allclose(scipy_name='scp', atol=5e-16)
+    def test_multivalue_2d(self, xp, scp, method, rescale):
+        x = xp.array([(0, 0), (-0.5, -0.5), (-0.5, 0.5), (0.5, 0.5),
+                      (0.25, 0.3)], dtype=xp.float64)
+        y = (xp.arange(x.shape[0], dtype=xp.float64)[:, None]
+             + xp.array([0, 1])[None, :])
+
+        yi = scp.interpolate.griddata(x, y, x, method=method, rescale=rescale)
+        return yi
+
+    @pytest.mark.parametrize('method', ('nearest', 'linear', 'cubic'))
+    @pytest.mark.parametrize('rescale', (True, False))
+    @testing.numpy_cupy_allclose(scipy_name='scp', atol=5e-16)
+    def test_multipoint_2d(self, xp, scp, method, rescale):
+        x = xp.array([(0, 0), (-0.5, -0.5), (-0.5, 0.5), (0.5, 0.5),
+                      (0.25, 0.3)], dtype=xp.float64)
+        y = xp.arange(x.shape[0], dtype=xp.float64)
+        xi = x[:, None, :] + xp.array([0, 0, 0])[None, :, None]
+        yi = scp.interpolate.griddata(x, y, xi, method=method, rescale=rescale)
+        return yi
+
+    @pytest.mark.parametrize('method', ('nearest', 'linear', 'cubic'))
+    @pytest.mark.parametrize('rescale', (True, False))
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_complex_2d(self, xp, scp, method, rescale):
+        x = xp.array([(0, 0), (-0.5, -0.5), (-0.5, 0.5), (0.5, 0.5),
+                      (0.25, 0.3)], dtype=xp.float64)
+        y = xp.arange(x.shape[0], dtype=xp.float64)
+        y = y - 2j*y[::-1]
+
+        xi = x[:, None, :] + xp.array([0, 0, 0])[None, :, None]
+
+        yi = scp.interpolate.griddata(x, y, xi, method=method, rescale=rescale)
+        return yi
+
+    @pytest.mark.parametrize('method', ('nearest', 'linear', 'cubic'))
+    @testing.numpy_cupy_allclose(scipy_name='scp', atol=2e-15)
+    def test_1d(self, xp, scp, method):
+        x = xp.array([1, 2.5, 3, 4.5, 5, 6])
+        y = xp.array([1, 2, 0, 3.9, 2, 1])
+
+        return (scp.interpolate.griddata(x, y, x, method=method),
+                scp.interpolate.griddata(x.reshape(6, 1), y, x, method=method),
+                scp.interpolate.griddata((x,), y, (x,), method=method)
+                )
+
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_1d_borders(self, xp, scp):
+        # Test for nearest neighbor case with xi outside
+        # the range of the values.
+        x = xp.array([1, 2.5, 3, 4.5, 5, 6])
+        y = xp.array([1, 2, 0, 3.9, 2, 1])
+        xi = xp.array([0.9, 6.5])
+
+        method = 'nearest'
+        return (scp.interpolate.griddata(x, y, xi, method=method),
+                scp.interpolate.griddata(
+                    x.reshape(6, 1), y, xi, method=method),
+                scp.interpolate.griddata((x, ), y, (xi, ), method=method)
+                )
+
+    @pytest.mark.parametrize('method', ('nearest', 'linear', 'cubic'))
+    @testing.numpy_cupy_allclose(scipy_name='scp', atol=2e-15)
+    def test_1d_unsorted(self, xp, scp, method):
+        x = xp.array([2.5, 1, 4.5, 5, 6, 3])
+        y = xp.array([1, 2, 0, 3.9, 2, 1])
+
+        return (scp.interpolate.griddata(x, y, x, method=method),
+                scp.interpolate.griddata(x.reshape(6, 1), y, x, method=method),
+                scp.interpolate.griddata((x,), y, (x,), method=method)
+                )
+
+    @pytest.mark.parametrize('method', ('nearest', 'linear', 'cubic'))
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5)
+    def test_square_rescale_manual(self, xp, scp, method):
+        points = xp.array([(0, 0), (0, 100), (10, 100), (10, 0), (1, 5)],
+                          dtype=xp.float64)
+        points_rescaled = xp.array([(0, 0), (0, 1), (1, 1), (1, 0),
+                                   (0.1, 0.05)], dtype=xp.float64)
+        values = xp.array([1., 2., -3., 5., 9.], dtype=xp.float64)
+
+        xx, yy = xp.broadcast_arrays(xp.linspace(0, 10, 14)[:, None],
+                                     xp.linspace(0, 100, 14)[None, :])
+        xx = xx.ravel()
+        yy = yy.ravel()
+        xi = xp.array([xx, yy]).T.copy()
+
+        zi = scp.interpolate.griddata(points_rescaled, values,
+                                      xi/xp.array([10, 100.]), method=method)
+        zi_rescaled = scp.interpolate.griddata(points, values, xi,
+                                               method=method, rescale=True)
+        return zi, zi_rescaled
+
+    @pytest.mark.parametrize('method', ('nearest', 'linear', 'cubic'))
+    @testing.numpy_cupy_allclose(scipy_name='scp', atol=2e-15)
+    def test_xi_1d(self, xp, scp, method):
+        # Check that 1-D xi is interpreted as a coordinate
+        x = xp.array([(0, 0), (-0.5, -0.5), (-0.5, 0.5), (0.5, 0.5),
+                      (0.25, 0.3)], dtype=xp.float64)
+        y = xp.arange(x.shape[0], dtype=xp.float64)
+        y = y - 2j*y[::-1]
+        xi = xp.array([0.5, 0.5])
+        return (scp.interpolate.griddata(x, y, xi, method=method),
+                scp.interpolate.griddata(x, y, xi[None, :], method=method))
+
+    @pytest.mark.parametrize('method', ('nearest', 'linear', 'cubic'))
+    def test_xi_1d_raises(self, method):
+        x = cupy.array([(0, 0), (-0.5, -0.5), (-0.5, 0.5), (0.5, 0.5),
+                        (0.25, 0.3)], dtype=cupy.float64)
+        y = cupy.arange(x.shape[0], dtype=cupy.float64)
+        y = y - 2j*y[::-1]
+
+        xi1 = cupy.array([0.5])
+        xi3 = cupy.array([0.5, 0.5, 0.5])
+
+        with pytest.raises(ValueError):
+            cupyx.scipy.interpolate.griddata(x, y, xi1, method=method)
+
+        with pytest.raises(ValueError):
+            cupyx.scipy.interpolate.griddata(x, y, xi3, method=method)


### PR DESCRIPTION
Port `griddata` function from `scipy.interpolate`. This is a pure python convenience wrapper of`LinearNDInterpolator`, `NearestNDInterpolator` and `CloughTocher2DInterpolator`, so no need to benchmark performance.

This PR is on top of https://github.com/cupy/cupy/pull/8220 for the NearestNDInterpolator and https://github.com/cupy/cupy/pull/8289 for `interp1d`. Will need a rebase or two when these two PRs land.