### PR TITLE
Add comparison table for `(cupyx.)scipy.sparse.*_matrix classes` class methods

### DIFF
--- a/docs/source/_comparison_generator.py
+++ b/docs/source/_comparison_generator.py
@@ -259,6 +259,22 @@ def generate():
         'Sparse Matrices',
         'scipy.sparse', 'cupyx.scipy.sparse', 'SciPy', exclude=['test'])
     buf += _section(
+        'Sparse Matrices: COOrdinate Format',
+        'scipy.sparse', 'cupyx.scipy.sparse', 'SciPy', klass='coo_matrix', 
+        exclude=['test'])
+    buf += _section(
+        'Sparse Matrices: Compressed Sparse Column',
+        'scipy.sparse', 'cupyx.scipy.sparse', 'SciPy', klass='csc_matrix', 
+        exclude=['test'])
+    buf += _section(
+        'Sparse Matrices: Compressed Sparse Row',
+        'scipy.sparse', 'cupyx.scipy.sparse', 'SciPy', klass='csr_matrix', 
+        exclude=['test'])
+    buf += _section(
+        'Sparse Matrices: DIAgonal Storage',
+        'scipy.sparse', 'cupyx.scipy.sparse', 'SciPy', klass='dia_matrix', 
+        exclude=['test'])
+    buf += _section(
         'Sparse Linear Algebra',
         'scipy.sparse.linalg', 'cupyx.scipy.sparse.linalg', 'SciPy',
         exclude=['test'])


### PR DESCRIPTION
Generate a comparison table that lists all APIs in `(cupyx.)scipy.sparse.*_matrix` classes as in #7762. 

Please check whether the naming for the comparison table is appropriate. Thank you.