### PR TITLE
Add `cupyx.profiler` to python module API list

### DIFF
--- a/docs/source/_comparison_generator.py
+++ b/docs/source/_comparison_generator.py
@@ -259,6 +259,22 @@ def generate():
         'Sparse Matrices',
         'scipy.sparse', 'cupyx.scipy.sparse', 'SciPy', exclude=['test'])
     buf += _section(
+        'Sparse Matrices: COOrdinate Format',
+        'scipy.sparse', 'cupyx.scipy.sparse', 'SciPy', klass='coo_matrix', 
+        exclude=['test'])
+    buf += _section(
+        'Sparse Matrices: Compressed Sparse Column',
+        'scipy.sparse', 'cupyx.scipy.sparse', 'SciPy', klass='csc_matrix', 
+        exclude=['test'])
+    buf += _section(
+        'Sparse Matrices: Compressed Sparse Row',
+        'scipy.sparse', 'cupyx.scipy.sparse', 'SciPy', klass='csr_matrix', 
+        exclude=['test'])
+    buf += _section(
+        'Sparse Matrices: DIAgonal Storage',
+        'scipy.sparse', 'cupyx.scipy.sparse', 'SciPy', klass='dia_matrix', 
+        exclude=['test'])
+    buf += _section(
         'Sparse Linear Algebra',
         'scipy.sparse.linalg', 'cupyx.scipy.sparse.linalg', 'SciPy',
         exclude=['test'])

--- a/docs/source/_comparison_generator.py
+++ b/docs/source/_comparison_generator.py
@@ -259,22 +259,6 @@ def generate():
         'Sparse Matrices',
         'scipy.sparse', 'cupyx.scipy.sparse', 'SciPy', exclude=['test'])
     buf += _section(
-        'Sparse Matrices: COOrdinate Format',
-        'scipy.sparse', 'cupyx.scipy.sparse', 'SciPy', klass='coo_matrix', 
-        exclude=['test'])
-    buf += _section(
-        'Sparse Matrices: Compressed Sparse Column',
-        'scipy.sparse', 'cupyx.scipy.sparse', 'SciPy', klass='csc_matrix', 
-        exclude=['test'])
-    buf += _section(
-        'Sparse Matrices: Compressed Sparse Row',
-        'scipy.sparse', 'cupyx.scipy.sparse', 'SciPy', klass='csr_matrix', 
-        exclude=['test'])
-    buf += _section(
-        'Sparse Matrices: DIAgonal Storage',
-        'scipy.sparse', 'cupyx.scipy.sparse', 'SciPy', klass='dia_matrix', 
-        exclude=['test'])
-    buf += _section(
         'Sparse Linear Algebra',
         'scipy.sparse.linalg', 'cupyx.scipy.sparse.linalg', 'SciPy',
         exclude=['test'])

--- a/docs/source/reference/ext.rst
+++ b/docs/source/reference/ext.rst
@@ -32,16 +32,6 @@ through the courtesy of Nvidia cuSignal team.
    cupyx.signal.cfar_alpha
    cupyx.signal.ca_cfar
    cupyx.signal.freq_shift
-   
-Profiling utilities
--------------------
-
-.. autosummary::
-   :toctree: generated/
-
-   cupyx.profiler.benchmark
-   cupyx.profiler.time_range
-   cupyx.profiler.profile
 
 DLPack utilities
 ----------------
@@ -55,6 +45,16 @@ For further detail see :ref:`dlpack`.
 
    cupy.from_dlpack
 
+Profiling utilities
+-------------------
+
+.. module:: cupyx.profiler
+.. autosummary::
+   :toctree: generated/
+
+   cupyx.profiler.benchmark
+   cupyx.profiler.time_range
+   cupyx.profiler.profile
 
 .. _kernel_param_opt:
 

--- a/docs/source/reference/ext.rst
+++ b/docs/source/reference/ext.rst
@@ -32,8 +32,16 @@ through the courtesy of Nvidia cuSignal team.
    cupyx.signal.cfar_alpha
    cupyx.signal.ca_cfar
    cupyx.signal.freq_shift
+   
+Profiling utilities
+-------------------
 
+.. autosummary::
+   :toctree: generated/
 
+   cupyx.profiler.benchmark
+   cupyx.profiler.time_range
+   cupyx.profiler.profile
 
 DLPack utilities
 ----------------
@@ -50,17 +58,6 @@ For further detail see :ref:`dlpack`.
 
 .. _kernel_param_opt:
 
-Profiling utilities
--------------------
-
-.. module:: cupyx.profiler
-.. autosummary::
-   :toctree: generated/
-
-   cupyx.profiler.benchmark
-   cupyx.profiler.time_range
-   cupyx.profiler.profile
-
 Automatic Kernel Parameters Optimizations (:mod:`cupyx.optimizing`)
 -------------------------------------------------------------------
 
@@ -69,4 +66,3 @@ Automatic Kernel Parameters Optimizations (:mod:`cupyx.optimizing`)
    :toctree: generated/
 
    cupyx.optimizing.optimize
-

--- a/docs/source/reference/ext.rst
+++ b/docs/source/reference/ext.rst
@@ -32,16 +32,8 @@ through the courtesy of Nvidia cuSignal team.
    cupyx.signal.cfar_alpha
    cupyx.signal.ca_cfar
    cupyx.signal.freq_shift
-   
-Profiling utilities
--------------------
 
-.. autosummary::
-   :toctree: generated/
 
-   cupyx.profiler.benchmark
-   cupyx.profiler.time_range
-   cupyx.profiler.profile
 
 DLPack utilities
 ----------------
@@ -58,6 +50,17 @@ For further detail see :ref:`dlpack`.
 
 .. _kernel_param_opt:
 
+Profiling utilities
+-------------------
+
+.. module:: cupyx.profiler
+.. autosummary::
+   :toctree: generated/
+
+   cupyx.profiler.benchmark
+   cupyx.profiler.time_range
+   cupyx.profiler.profile
+
 Automatic Kernel Parameters Optimizations (:mod:`cupyx.optimizing`)
 -------------------------------------------------------------------
 
@@ -66,3 +69,4 @@ Automatic Kernel Parameters Optimizations (:mod:`cupyx.optimizing`)
    :toctree: generated/
 
    cupyx.optimizing.optimize
+


### PR DESCRIPTION
I've add `cupyx.profiler` to python module API list via adding `.. module:: cupyx.profiler` in the file `est.rst`, regarding to issue #6018 

Initially just adding the line of code threw an exception that no module named `cupyx.profiler`, but after trying different implementation I found that when moving the hole code piece to the bottom of the file above `.. _kernel_param_opt:` will work.

I've tested using `sphinx-build -b html . _build` to build the html page, and opened with `xdg-open _build/py-modindex.html`. The hyperlink of profiler work as expected, and the code below for `cupyx.optimizing` will not be affected. The only thing that changed on the page for [cupy-specific fuctions](https://docs.cupy.dev/en/stable/reference/ext.html#cupy-specific-functions), is the order of each section.