### PR TITLE
Wait before published items shown on PyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -92,6 +92,7 @@ jobs:
         python-version: '3.10'
     - name: Check
       run: |
+        sleep 60s  # wait for PyPI to be updated
         pip install distlib
         CHECK_WHEEL="${{ inputs.branch != 'main' && '--pypi-wheel' || '' }}"
         ./check_release_assets.py --version "${{ inputs.release }}" --pypi-sdist ${CHECK_WHEEL}


### PR DESCRIPTION
It seems that it takes a while before our published items are shown on PyPI.
https://github.com/cupy/cupy/actions/runs/8748240002/attempts/1