### PR TITLE
Find and fix typos with codespell

### DIFF
--- a/cupy/_core/__init__.py
+++ b/cupy/_core/__init__.py
@@ -5,7 +5,7 @@ from cupy._core import fusion  # NOQA
 from cupy._core import internal  # NOQA
 
 
-# internal APIs for testing and developement
+# internal APIs for testing and development
 from cupy._core._accelerator import set_elementwise_accelerators  # NOQA
 from cupy._core._accelerator import set_reduction_accelerators  # NOQA
 from cupy._core._accelerator import set_routine_accelerators  # NOQA

--- a/cupy/_core/_fusion_optimization.py
+++ b/cupy/_core/_fusion_optimization.py
@@ -42,11 +42,11 @@ def _normalize_ashapes(ops, variables, shape_constraints):
 def _fuse_two_ops(op1, op2):
     """Returns a fused Op if the two ops can be fused, and ``None`` otherwise.
     """
-    # TODO(asi1024): Supoort reduction postmap.
+    # TODO(asi1024): Support reduction postmap.
     if not isinstance(op1, _fusion_op._ElementwiseTraceOp):
         return None
 
-    # TODO(asi1024): Supoort reduction premap.
+    # TODO(asi1024): Support reduction premap.
     if not isinstance(op2, _fusion_op._ElementwiseTraceOp):
         return None
 

--- a/cupy/_core/_gufuncs.py
+++ b/cupy/_core/_gufuncs.py
@@ -23,7 +23,7 @@ _SIGNATURE = '^{0:}->{1:}$'.format(_INPUT_ARGUMENTS, _OUTPUT_ARGUMENTS)
 
 
 def _parse_gufunc_signature(signature):
-    # The code has been modifyed from dask to support optional dimensions
+    # The code has been modified from dask to support optional dimensions
     if not isinstance(signature, str):
         raise TypeError('Signature is not a string')
 
@@ -388,7 +388,7 @@ class _GUFunc:
     def _apply_func_to_inputs(self, func, dim, sizes, dims, args, outs):
         # Apply function
         # The resulting array is loop_output_dims+the specified dims
-        # Some functions have batching logic inside due to higly
+        # Some functions have batching logic inside due to highly
         # optimized CUDA libraries so we just call them
         if self._supports_batched or dim == len(dims):
             # Check if the function supports out, order and other args
@@ -465,7 +465,7 @@ class _GUFunc:
             if len(transposed_outs) == len(outs):
                 outs = transposed_outs
 
-        # we cant directly broadcast arrays together since their core dims
+        # we can't directly broadcast arrays together since their core dims
         # might differ. Only the loop dimensions are broadcastable
         shape = internal._broadcast_shapes(
             [a.shape[:-len(self._input_coredimss)] for a in args])
@@ -626,7 +626,7 @@ class _GUFunc:
         ret_dtype = None
         func = self._func
 
-        # this will cast the inputs appropiately
+        # this will cast the inputs appropriately
         args, ret_dtype, func = self._ops_register.determine_dtype(
             args, dtype, casting, signature)
 

--- a/cupy/_core/include/cupy/complex/catrig.h
+++ b/cupy/_core/include/cupy/complex/catrig.h
@@ -462,7 +462,7 @@ __host__ __device__ inline complex<double> clog_for_large_values(complex<double>
    * Divide x and y by E, and then add 1 to the logarithm.  This depends
    * on E being larger than sqrt(2).
    * Dividing by E causes an insignificant loss of accuracy; however
-   * this method is still poor since it is uneccessarily slow.
+   * this method is still poor since it is unnecessarily slow.
    */
   if (ax > DBL_MAX / 2)
     return (complex<double>(log(hypot(x / m_e, y / m_e)) + 1, atan2(y, x)));

--- a/cupy/_core/include/cupy/special/cephes/polevl.h
+++ b/cupy/_core/include/cupy/special/cephes/polevl.h
@@ -31,7 +31,7 @@
  * coef[0] = C  , ..., coef[N] = C  .
  *            N                   0
  *
- * The function p1evl() assumes that c_N = 1.0 so that coefficent
+ * The function p1evl() assumes that c_N = 1.0 so that coefficient
  * is omitted from the array.  Its calling arguments are
  * otherwise the same as polevl().
  *

--- a/cupy/_indexing/insert.py
+++ b/cupy/_indexing/insert.py
@@ -164,7 +164,7 @@ def fill_diagonal(a, val, wrap=False):
 
     .. seealso:: :func:`numpy.fill_diagonal`
     """
-    # The followings are imported from the original numpy
+    # The following are imported from the original numpy
     if a.ndim < 2:
         raise ValueError('array must be at least 2-d')
     end = None

--- a/cupy/_logic/truth.py
+++ b/cupy/_logic/truth.py
@@ -139,7 +139,7 @@ def intersect1d(arr1, arr2, assume_unique=False, return_indices=False):
         Input arrays. Arrays will be flattened if they are not in 1D.
     assume_unique : bool
         By default, False. If set True, the input arrays will be
-        assumend to be unique, which speeds up the calculation. If set True,
+        assumed to be unique, which speeds up the calculation. If set True,
         but the arrays are not unique, incorrect results and out-of-bounds
         indices could result.
     return_indices : bool
@@ -231,7 +231,7 @@ def setdiff1d(ar1, ar2, assume_unique=False):
     ar1 : cupy.ndarray
         Input array
     ar2 : cupy.ndarray
-        Input array for comparision
+        Input array for comparison
     assume_unique : bool
         By default, False, i.e. input arrays are not unique.
         If True, input arrays are assumed to be unique. This can
@@ -263,7 +263,7 @@ def setxor1d(ar1, ar2, assume_unique=False):
     Parameters
     ----------
     ar1, ar2 : cupy.ndarray
-        Input arrays. They are flattend if they are not already 1-D.
+        Input arrays. They are flattened if they are not already 1-D.
     assume_unique : bool
         By default, False, i.e. input arrays are not unique.
         If True, input arrays are assumed to be unique. This can
@@ -303,7 +303,7 @@ def union1d(arr1, arr2):
     Parameters
     ----------
     arr1, arr2 : cupy.ndarray
-        Input arrays. They are flattend if they are not already 1-D.
+        Input arrays. They are flattened if they are not already 1-D.
 
     Returns
     -------

--- a/cupy/_manipulation/add_remove.py
+++ b/cupy/_manipulation/add_remove.py
@@ -208,7 +208,7 @@ def unique(ar, return_index=False, return_inverse=False,
             If there are no optional outputs, it returns the
             :class:`cupy.ndarray` of the sorted unique values. Otherwise, it
             returns the tuple which contains the sorted unique values and
-            followings.
+            following.
 
             * The indices of the first occurrences of the unique values in the
               original array. Only provided if `return_index` is True.

--- a/cupy/_math/sumprod.py
+++ b/cupy/_math/sumprod.py
@@ -516,7 +516,7 @@ def ediff1d(arr, to_end=None, to_begin=None):
     Args:
         arr (cupy.ndarray): Input array.
         to_end (cupy.ndarray, optional): Numbers to append at the end
-            of the returend differences.
+            of the returned differences.
         to_begin (cupy.ndarray, optional): Numbers to prepend at the
             beginning of the returned differences.
 
@@ -563,7 +563,7 @@ def ediff1d(arr, to_end=None, to_begin=None):
         to_end = to_end.ravel()
         l_end = len(to_end)
 
-    # calulating using in place operation
+    # calculating using in place operation
     l_diff = max(len(arr) - 1, 0)
     result = cupy.empty(l_diff + l_begin + l_end, dtype=arr.dtype)
     # Cupy does not support subclassing a ndarray

--- a/cupy/cuda/cupy_cufft.h
+++ b/cupy/cuda/cupy_cufft.h
@@ -283,7 +283,7 @@ cufftResult_t cufftXtExecDescriptorZ2Z(...) {
 // common stubs for both no-cuda and hip environments
 
 extern "C" {
-// cufftXt relavant data structs
+// cufftXt relevant data structs
 typedef struct cudaXtDesc_t {
    int version;
    int nGPUs;

--- a/cupy/lib/_shape_base.py
+++ b/cupy/lib/_shape_base.py
@@ -76,8 +76,8 @@ def _make_along_axis_idx(arr_shape, indices, axis):
     dest_dims = list(range(axis)) + [None] + \
         list(range(axis + 1, indices.ndim))
 
-    # build a fancy index, consisting of orthogonal arranges, with the
-    # requested index inserted at the right location
+    # build a fancy index, consisting of orthogonal cupy.arange calls,
+    # with the requested index inserted at the right location
     fancy_index = []
     for dim, n in zip(dest_dims, arr_shape):
         if dim is None:

--- a/cupy/lib/_shape_base.py
+++ b/cupy/lib/_shape_base.py
@@ -76,7 +76,7 @@ def _make_along_axis_idx(arr_shape, indices, axis):
     dest_dims = list(range(axis)) + [None] + \
         list(range(axis + 1, indices.ndim))
 
-    # build a fancy index, consisting of orthogonal aranges, with the
+    # build a fancy index, consisting of orthogonal arranges, with the
     # requested index inserted at the right location
     fancy_index = []
     for dim, n in zip(dest_dims, arr_shape):

--- a/cupy/linalg/_einsum_opt.py
+++ b/cupy/linalg/_einsum_opt.py
@@ -283,7 +283,7 @@ def _update_other_results(results, best):
     Returns
     -------
     mod_results : list
-        The list of modifed results, updated with outcome of ``best`` contraction.  # NOQA
+        The list of modified results, updated with outcome of ``best`` contraction.  # NOQA
     """
 
     best_con = best[1]

--- a/cupy/testing/_condition.py
+++ b/cupy/testing/_condition.py
@@ -63,7 +63,7 @@ def repeat_with_success_at_least(times, min_success):
                 result = QuietTestRunner().run(suite)
                 if len(result.skipped) == 1:
                     # "Skipped" is a special case of "Successful".
-                    # When the test has been skipped, immedeately quit the
+                    # When the test has been skipped, immediately quit the
                     # test regardleess of `times` and `min_success` by raising
                     # SkipTest exception using the original reason.
                     instance.skipTest(result.skipped[0][1])

--- a/cupy/testing/_helper.py
+++ b/cupy/testing/_helper.py
@@ -209,7 +209,7 @@ def generate_matrix(
             matrices. It must be broadcastable to shape :math:`(B..., K)`.
 
     Returns:
-        numpy.ndarray or cupy.ndarray: A random matrix that has specifiec
+        numpy.ndarray or cupy.ndarray: A random matrix that has specific
         singular values.
     """
 

--- a/cupy/testing/_loops.py
+++ b/cupy/testing/_loops.py
@@ -306,7 +306,7 @@ def _make_decorator(check_func, name, type_check, contiguous_check,
 cupy: {}
 numpy: {}'''.format(cupy_r.dtype, numpy_r.dtype))
 
-            # Check continuities
+            # Check contiguities
             if contiguous_check:
                 for cupy_r, numpy_r in zip(cupy_result, numpy_result):
                     if isinstance(numpy_r, numpy.ndarray):

--- a/cupy/testing/_loops.py
+++ b/cupy/testing/_loops.py
@@ -306,7 +306,7 @@ def _make_decorator(check_func, name, type_check, contiguous_check,
 cupy: {}
 numpy: {}'''.format(cupy_r.dtype, numpy_r.dtype))
 
-            # Check contiguities
+            # Check continuities
             if contiguous_check:
                 for cupy_r, numpy_r in zip(cupy_result, numpy_result):
                     if isinstance(numpy_r, numpy.ndarray):
@@ -973,7 +973,7 @@ def for_signed_dtypes(name='dtype'):
 
 
 def for_unsigned_dtypes(name='dtype'):
-    """Decorator that checks the fixture with unsinged dtypes.
+    """Decorator that checks the fixture with unsigned dtypes.
 
     Args:
          name(str): Argument name to which specified dtypes are passed.

--- a/cupy_backends/cuda/api/_runtime_enum.pxd
+++ b/cupy_backends/cuda/api/_runtime_enum.pxd
@@ -140,7 +140,7 @@ IF CUPY_HIP_VERSION > 0:
         cudaDevAttrMaxTexture3DWidth
         cudaDevAttrMaxTexture3DHeight
         cudaDevAttrMaxTexture3DDepth
-        # The following attributes do not exist in CUDA and cause segfualts
+        # The following attributes do not exist in CUDA and cause segfaults
         # if we try to access them
         # hipDeviceAttributeHdpMemFlushCntl
         # hipDeviceAttributeHdpRegFlushCntl

--- a/cupy_backends/cuda/api/_runtime_typedef.pxi
+++ b/cupy_backends/cuda/api/_runtime_typedef.pxi
@@ -50,7 +50,7 @@ cdef extern from *:
     ctypedef void* GraphExec 'cudaGraphExec_t'
 
     # This is for the annoying nested struct cudaResourceDesc, which is not
-    # perfectly supprted in Cython
+    # perfectly supported in Cython
     ctypedef struct _array:
         Array array
 
@@ -119,7 +119,7 @@ cdef extern from *:
     ctypedef int MemLocationType 'cudaMemLocationType'
     IF CUPY_CUDA_VERSION > 0:
         # This is for the annoying nested struct, which is not
-        # perfectly supprted in Cython
+        # perfectly supported in Cython
         ctypedef struct _MemLocation 'cudaMemLocation':
             MemLocationType type
             int id

--- a/cupy_backends/cuda/cupy_cusparse.h
+++ b/cupy_backends/cuda/cupy_cusparse.h
@@ -25,7 +25,7 @@
 #endif  // #if !defined(CUSPARSE_VERSION)
 
 /*
- * Generic APIs are not suppoted in CUDA 10.1/10.2 on Windows.
+ * Generic APIs are not supported in CUDA 10.1/10.2 on Windows.
  * These APIs are available in headers in CUDA 10.1 and 10.1 Update 1,
  * but hidden in 10.1 Update 2 and 10.2 on Windows.
  */

--- a/cupy_backends/cuda/libs/cusolver.pxd
+++ b/cupy_backends/cuda/libs/cusolver.pxd
@@ -463,7 +463,7 @@ cpdef zgesvd(intptr_t handle, char jobu, char jobvt, int m, int n, size_t A,
              int lda, size_t S, size_t U, int ldu, size_t VT, int ldvt,
              size_t Work, int lwork, size_t rwork, size_t devInfo)
 
-# gesvdj ... Singular value decomposition using Jacobi mathod
+# gesvdj ... Singular value decomposition using Jacobi method
 cpdef intptr_t createGesvdjInfo() except? 0
 cpdef destroyGesvdjInfo(intptr_t info)
 

--- a/cupy_backends/cuda/libs/cutensor.pxd
+++ b/cupy_backends/cuda/libs/cutensor.pxd
@@ -97,7 +97,7 @@ cpdef enum:
     STATUS_IO_ERROR = 21
 
     # cutensorComputeType_t
-    # (*) compute types added in versoin 1.2
+    # (*) compute types added in version 1.2
     COMPUTE_16F = 1     # NOQA, half
     COMPUTE_16BF = 1024  # NOQA, bfloat
     COMPUTE_TF32 = 4096  # NOQA, tensor-float-32
@@ -108,7 +108,7 @@ cpdef enum:
     COMPUTE_8I = 256   # NOQA, int8
     COMPUTE_32U = 128   # NOQA, uint32
     COMPUTE_32I = 512   # NOQA, int32
-    # (*) compute types below will be deprecated in the furture release.
+    # (*) compute types below will be deprecated in the future release.
     R_MIN_16F = 1    # NOQA, real as a half
     C_MIN_16F = 2    # NOQA, complex as a half
     R_MIN_32F = 4    # NOQA, real as a float
@@ -123,7 +123,7 @@ cpdef enum:
     R_MIN_TF32 = 2048  # NOQA, real as a tensorfloat32
     C_MIN_TF32 = 4096  # NOQA, complex as a tensorfloat32
 
-    # cutensorComputeDescriptor_t altenatives
+    # cutensorComputeDescriptor_t alternatives
     COMPUTE_DESC_16F = 1
     COMPUTE_DESC_16BF = 1024
     COMPUTE_DESC_TF32 = 4096

--- a/cupyx/_runtime.py
+++ b/cupyx/_runtime.py
@@ -15,7 +15,7 @@ is_hip = cupy_backends.cuda.api.runtime.is_hip
 
 def _eval_or_error(func, errors):
     # Evaluates `func` and return the result.
-    # If an error specified by `errors` occured, it returns a string
+    # If an error specified by `errors` occurred, it returns a string
     # representing the error.
     try:
         return func()

--- a/cupyx/cusparse.py
+++ b/cupyx/cusparse.py
@@ -143,7 +143,7 @@ _available_hipsparse_version = {
     'dense2csc': (305, None),
     'dense2csr': (305, None),
     'csr2csr_compress': (305, None),
-    'csrsm2': (305, None),  # avaiable since 305 but seems buggy
+    'csrsm2': (305, None),  # available since 305 but seems buggy
     'csrilu02': (305, None),
     'denseToSparse': (402, None),
     'sparseToDense': (402, None),
@@ -1177,7 +1177,7 @@ def dense2csc(x):
         handle, m, n, descr.descriptor,
         x.data.ptr, m, nnz_per_col.data.ptr,
         data.data.ptr, indices.data.ptr, indptr.data.ptr)
-    # Note that a desciptor is recreated
+    # Note that a descriptor is recreated
     csc = cupyx.scipy.sparse.csc_matrix((data, indices, indptr), shape=x.shape)
     csc._has_canonical_format = True
     return csc
@@ -1223,7 +1223,7 @@ def dense2csr(x):
         handle, m, n, descr.descriptor,
         x.data.ptr, m, nnz_per_row.data.ptr,
         data.data.ptr, indptr.data.ptr, indices.data.ptr)
-    # Note that a desciptor is recreated
+    # Note that a descriptor is recreated
     csr = cupyx.scipy.sparse.csr_matrix((data, indices, indptr), shape=x.shape)
     csr._has_canonical_format = True
     return csr
@@ -1380,8 +1380,8 @@ def spmv(a, x, y=None, alpha=1, beta=0, transa=False):
             Sparse matrix A
         x (cupy.ndarray): Dense vector x
         y (cupy.ndarray or None): Dense vector y
-        alpha (scalar): Coefficent
-        beta (scalar): Coefficent
+        alpha (scalar): Coefficient
+        beta (scalar): Coefficient
         transa (bool): If ``True``, op(A) = transpose of A.
 
     Returns:
@@ -1447,8 +1447,8 @@ def spmm(a, b, c=None, alpha=1, beta=0, transa=False, transb=False):
             Sparse matrix A
         b (cupy.ndarray): Dense matrix B
         c (cupy.ndarray or None): Dense matrix C
-        alpha (scalar): Coefficent
-        beta (scalar): Coefficent
+        alpha (scalar): Coefficient
+        beta (scalar): Coefficient
         transa (bool): If ``True``, op(A) = transpose of A.
         transb (bool): If ``True``, op(B) = transpose of B.
 
@@ -1520,7 +1520,7 @@ def csrsm2(a, b, alpha=1.0, lower=True, unit_diag=False, transa=False,
             Sparse matrix with dimension ``(M, M)``.
         b (cupy.ndarray): Dense vector or matrix with dimension ``(M)`` or
             ``(M, K)``.
-        alpha (float or complex): Coefficent.
+        alpha (float or complex): Coefficient.
         lower (bool):
             True: ``a`` is lower triangle matrix.
             False: ``a`` is upper triangle matrix.
@@ -1535,7 +1535,7 @@ def csrsm2(a, b, alpha=1.0, lower=True, unit_diag=False, transa=False,
             True: blocking algorithm is used.
             False: non-blocking algorithm is used.
         level_info (bool):
-            True: solves it with level infromation.
+            True: solves it with level information.
             False: solves it without level information.
 
     Note: ``b`` will be overwritten.
@@ -1664,7 +1664,7 @@ def csrilu02(a, level_info=False):
         a (cupyx.scipy.sparse.csr_matrix):
             Sparse matrix with dimension ``(M, M)``.
         level_info (bool):
-            True: solves it with level infromation.
+            True: solves it with level information.
             False: solves it without level information.
 
     Note: ``a`` will be overwritten. This function does not support fill-in
@@ -1789,7 +1789,7 @@ def denseToSparse(x, format='csr'):
         row = _cupy.zeros(nnz, 'i')
         col = _cupy.zeros(nnz, 'i')
         # Note: I would like to use empty() here, but that might cause an
-        # exeption in the row/col number check when creating the coo_matrix,
+        # exception in the row/col number check when creating the coo_matrix,
         # so I used zeros() instead.
         data = _cupy.empty(nnz, x.dtype)
         y = cupyx.scipy.sparse.coo_matrix((data, (row, col)), shape=x.shape)
@@ -1941,7 +1941,7 @@ def spsm(a, b, alpha=1.0, lower=True, unit_diag=False, transa=False):
     if b._f_contiguous:
         op_b = _cusparse.CUSPARSE_OPERATION_NON_TRANSPOSE
     elif b._c_contiguous:
-        if _cusparse.get_build_version() < 11701:  # eariler than CUDA 11.6
+        if _cusparse.get_build_version() < 11701:  # earlier than CUDA 11.6
             raise ValueError('b must be F-contiguous.')
         b = b.T
         op_b = _cusparse.CUSPARSE_OPERATION_TRANSPOSE

--- a/cupyx/distributed/_nccl_comm.py
+++ b/cupyx/distributed/_nccl_comm.py
@@ -491,7 +491,7 @@ class _SparseNCCLCommunicator:
     @classmethod
     def _get_internal_arrays(cls, array):
         if sparse.isspmatrix_coo(array):
-            array.sum_duplicates()  # set it to cannonical form
+            array.sum_duplicates()  # set it to canonical form
             return (array.data, array.row, array.col)
         elif sparse.isspmatrix_csr(array) or sparse.isspmatrix_csc(array):
             return (array.data, array.indptr, array.indices)
@@ -667,7 +667,7 @@ class _SparseNCCLCommunicator:
         if comm.rank != root:
             arrays = [
                 cupy.empty(s, dtype=a.dtype) for s, a in zip(sizes, arrays)]
-        # TODO(ecastill): measure if its faster to just contatenate
+        # TODO(ecastill): measure if its faster to just concatenate
         # the arrays in a single one and send it
         nccl.groupStart()
         for a in arrays:

--- a/cupyx/distributed/_store.py
+++ b/cupyx/distributed/_store.py
@@ -44,7 +44,7 @@ class ExceptionAwareProcess(multiprocessing.Process):
 
 class TCPStore:
     # This is only used for initialization of nccl so we don't care
-    # too much about peformance
+    # too much about performance
     def __init__(self, world_size):
         self.storage = {}
         self._process = None

--- a/cupyx/distributed/array/_elementwise.py
+++ b/cupyx/distributed/array/_elementwise.py
@@ -155,7 +155,7 @@ def _execute_kernel(
     for chunk in chain.from_iterable(out_chunks_map.values()):
         if not isinstance(chunk.array, (ndarray, _chunk._ArrayPlaceholder)):
             raise RuntimeError(
-                'Kernels returning other than signle array are not supported')
+                'Kernels returning other than single array are not supported')
 
     shape = comms = None
     for arg in (args or kwargs.values()):
@@ -209,7 +209,7 @@ def _execute_peer_access(
     if len(out_types) != 1:
         print(out_types)
         raise RuntimeError(
-            'Kernels returning other than signle array are not supported')
+            'Kernels returning other than single array are not supported')
     dtype = out_types[0]
 
     shape = a.shape

--- a/cupyx/jit/_compile.py
+++ b/cupyx/jit/_compile.py
@@ -754,7 +754,7 @@ def _transpile_expr_internal(
             if not func._device:
                 raise TypeError(
                     f'Calling __global__ function {func._func.__name__} '
-                    'from __global__ funcion is not allowed.')
+                    'from __global__ function is not allowed.')
             args = [Data.init(x, env) for x in args]
             in_types = tuple([x.ctype for x in args])
             fname, return_type = _transpile_func_obj(

--- a/cupyx/jit/_interface.py
+++ b/cupyx/jit/_interface.py
@@ -43,7 +43,7 @@ class _JitRawKernel:
     """JIT CUDA kernel object.
 
     The decorator :func:``cupyx.jit.rawkernel`` converts the target function
-    to an object of this class. This class is not inteded to be instantiated
+    to an object of this class. This class is not intended to be instantiated
     by users.
     """
 
@@ -143,7 +143,7 @@ class _JitRawKernel:
     def cached_codes(self):
         """Returns a dict that has input types as keys and codes values.
 
-        This proprety method is for debugging purpose.
+        This property method is for debugging purpose.
         The return value is not guaranteed to keep backward compatibility.
         """
         if len(self._cached_codes) == 0:
@@ -156,7 +156,7 @@ class _JitRawKernel:
     def cached_code(self):
         """Returns `next(iter(self.cached_codes.values()))`.
 
-        This proprety method is for debugging purpose.
+        This property method is for debugging purpose.
         The return value is not guaranteed to keep backward compatibility.
         """
         codes = self.cached_codes

--- a/cupyx/jit/_internal_types.py
+++ b/cupyx/jit/_internal_types.py
@@ -30,7 +30,7 @@ class Data(Expr):
 
     @property
     def obj(self):
-        raise ValueError(f'Constant value is requried: {self.code}')
+        raise ValueError(f'Constant value is required: {self.code}')
 
     def __repr__(self) -> str:
         return f'<Data code = "{self.code}", type = {self.ctype}>'

--- a/cupyx/profiler/_time.py
+++ b/cupyx/profiler/_time.py
@@ -105,7 +105,7 @@ def benchmark(
 
     Args:
         func (callable): a callable object to be timed.
-        args (tuple): positional argumens to be passed to the callable.
+        args (tuple): positional arguments to be passed to the callable.
         kwargs (dict): keyword arguments to be passed to the callable.
         n_repeat (int): number of times the callable is called. Increasing
             this value would improve the collected statistics at the cost

--- a/cupyx/scipy/fftpack/_fft.py
+++ b/cupyx/scipy/fftpack/_fft.py
@@ -97,7 +97,7 @@ def get_fft_plan(a, shape=None, axes=None, value_type='C2C'):
         elif n > 3:
             raise ValueError('Only up to three axes is supported')
 
-    # Note that "shape" here refers to the shape along trasformed axes, not
+    # Note that "shape" here refers to the shape along transformed axes, not
     # the shape of the output array, and we need to convert it to the latter.
     # The result is as if "a=_cook_shape(a); return a.shape" is called.
     # Because of this, we need to use (possibly unsorted) axes.

--- a/cupyx/scipy/interpolate/_bspline.py
+++ b/cupyx/scipy/interpolate/_bspline.py
@@ -371,7 +371,7 @@ def splder(tck, n=1):
             # See e.g. Schumaker, Spline Functions: Basic Theory, Chapter 5
 
             # Compute the denominator in the differentiation formula.
-            # (and append traling dims, if necessary)
+            # (and append trailing dims, if necessary)
             dt = t[k+1:-1] - t[1:-k-1]
             dt = dt[sh]
             # Compute the new coefficients

--- a/cupyx/scipy/interpolate/_bspline2.py
+++ b/cupyx/scipy/interpolate/_bspline2.py
@@ -239,7 +239,7 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
         c = cupy.zeros((nt,) + y.shape[1:], dtype=float)
         return BSpline.construct_fast(t, c, k, axis=axis)
 
-    # Consruct the colocation matrix of b-splines + boundary conditions.
+    # Construct the colocation matrix of b-splines + boundary conditions.
     # The coefficients of the interpolating B-spline function are the solution
     # of the linear system `A @ c = rhs` where `A` is the colocation matrix
     # (i.e., each row of A corresponds to a data point in the `x` array and
@@ -383,7 +383,7 @@ def _make_interp_spline_full_matrix(x, y, k, t, bc_type):
     nt = t.size - k - 1
     assert nt - n == nleft + nright
 
-    # Consruct the colocation matrix of b-splines + boundary conditions.
+    # Construct the colocation matrix of b-splines + boundary conditions.
     # The coefficients of the interpolating B-spline function are the solution
     # of the linear system `A @ c = rhs` where `A` is the colocation matrix
     # (i.e., each row of A corresponds to a data point in the `x` array and
@@ -605,7 +605,7 @@ fprota(T c, T s, T f, T g, T *f_out, T *g_out) {
  *    0  x x x       0  x  x x      0 [x] x x      0 0 [x] x      0 0 0 x
  *
  *  The matrix A has a special structure: each row has at most (k+1)
- *  consequitive non-zeros, so we only store them.
+ *  consecutive non-zeros, so we only store them.
  *
  *  On exit, the return matrix, also of shape (m, k+1), contains
  *  elements of the upper triangular matrix `R[i, i: i + k + 1]`.
@@ -638,7 +638,7 @@ fprota(T c, T s, T f, T g, T *f_out, T *g_out) {
  *  sequential.
  *
  *  The `startrow` optional argument accounts for the scenatio with a two-step
- *  factorization. Namely, the preceding rows are assumend to be already
+ *  factorization. Namely, the preceding rows are assumed to be already
  *  processed and are skipped.
  *  This is to account for the scenario where we append new rows to an already
  *  triangularized matrix.

--- a/cupyx/scipy/interpolate/_fitpack_repro.py
+++ b/cupyx/scipy/interpolate/_fitpack_repro.py
@@ -718,7 +718,7 @@ def root_rati(f, p0, bracket, acc):
     https://github.com/scipy/scipy/blob/maintenance/1.11.x/scipy/interpolate/fitpack/fppara.f#L290
 
     Note that the latter is for parametric splines and the former is for 1D
-    spline functions. The minimization is indentical though [modulo a summation
+    spline functions. The minimization is identical though [modulo a summation
     over the dimensions in the computation of f(p)], so we reuse the minimizer
     for both d=1 and d>1.
     """

--- a/cupyx/scipy/interpolate/_interpnd.py
+++ b/cupyx/scipy/interpolate/_interpnd.py
@@ -727,7 +727,7 @@ class CloughTocher2DInterpolator(NDInterpolatorBase):
     continuously differentiable.
 
     The gradients of the interpolant are chosen so that the curvature
-    of the interpolating surface is approximatively minimized. The
+    of the interpolating surface is approximately minimized. The
     gradients necessary for this are estimated using the global
     algorithm described in [Nielson83]_ and [Renka84]_.
 

--- a/cupyx/scipy/interpolate/_ndbspline.py
+++ b/cupyx/scipy/interpolate/_ndbspline.py
@@ -738,7 +738,7 @@ def make_ndbspl(points, values, k=3):
 
     # Solve for the coefficients given `values`.
     # Trailing dimensions: first ndim dimensions are data, the rest are batch
-    # dimensions, so stack `values` into a 2D array for `spsolve` to undestand.
+    # dimensions, so stack `values` into a 2D array for `spsolve` to understand.
     v_shape = values.shape
     vals_shape = (prod(v_shape[:ndim]), prod(v_shape[ndim:]))
     vals = values.reshape(vals_shape)

--- a/cupyx/scipy/interpolate/_ndbspline.py
+++ b/cupyx/scipy/interpolate/_ndbspline.py
@@ -738,7 +738,8 @@ def make_ndbspl(points, values, k=3):
 
     # Solve for the coefficients given `values`.
     # Trailing dimensions: first ndim dimensions are data, the rest are batch
-    # dimensions, so stack `values` into a 2D array for `spsolve` to understand.
+    # dimensions, so stack `values` into a 2D array for `spsolve` to
+    # understand.
     v_shape = values.shape
     vals_shape = (prod(v_shape[:ndim]), prod(v_shape[ndim:]))
     vals = values.reshape(vals_shape)

--- a/cupyx/scipy/linalg/_array_utils.py
+++ b/cupyx/scipy/linalg/_array_utils.py
@@ -19,7 +19,7 @@ def bandwidth(a):
     Returns
     -------
     lu : tuple
-        2-tuple of ints indicating the lower and upper bandwith. A zero
+        2-tuple of ints indicating the lower and upper bandwidth. A zero
         denotes no sub- or super-diagonal on that side (triangular), and,
         say for M rows (M-1) means that side is full. Same example applies
         to the upper triangular part with (N-1).
@@ -44,7 +44,7 @@ def bandwidth(a):
     row_num, col_num = cupy.mgrid[0:m, 0:n]
     bandpts = _kernel_cupy_band_pos_c(A, row_num, col_num)
 
-    # If F contigious, transpose
+    # If F contiguous, transpose
     if a.flags['F_CONTIGUOUS']:
         upper_band = int(cupy.amax(bandpts))
         lower_band = -int(cupy.amin(bandpts))

--- a/cupyx/scipy/linalg/_special_matrices.py
+++ b/cupyx/scipy/linalg/_special_matrices.py
@@ -151,7 +151,7 @@ def hankel(c, r=None):
     Args:
         c (cupy.ndarray): First column of the matrix. Whatever the actual shape
             of ``c``, it will be converted to a 1-D array.
-        r (cupy.ndarray, optionnal): Last row of the matrix. If None,
+        r (cupy.ndarray, optional): Last row of the matrix. If None,
             ``r = zeros_like(c)`` is assumed. ``r[0]`` is ignored; the last row
             of the returned matrix is ``[c[-1], r[1:]]``. Whatever the actual
             shape of ``r``, it will be converted to a 1-D array.

--- a/cupyx/scipy/ndimage/_filters.py
+++ b/cupyx/scipy/ndimage/_filters.py
@@ -775,7 +775,7 @@ def _min_or_max_filter(input, size, ftprnt, structure, output, mode, cval,
         raise NotImplementedError("NaN cval is unsupported")
 
     if sizes is not None:
-        # Seperable filter, run as a series of 1D filters
+        # Separable filter, run as a series of 1D filters
         fltr = minimum_filter1d if func == 'min' else maximum_filter1d
         return _filters_core._run_1d_filters(
             [fltr if size > 1 else None for size in sizes],

--- a/cupyx/scipy/ndimage/_measurements.py
+++ b/cupyx/scipy/ndimage/_measurements.py
@@ -395,7 +395,7 @@ def sum_labels(input, labels=None, index=None):
                            cupy.float64, cupy.uint32, cupy.uint64,
                            cupy.ulonglong]:
         warnings.warn(
-            'Using the slower implmentation as '
+            'Using the slower implementation as '
             'cupyx.scipy.ndimage.sum supports int32, float16, '
             'float32, float64, uint32, uint64 as data types'
             'for the fast implmentation', _util.PerformanceWarning)
@@ -485,7 +485,7 @@ def mean(input, labels=None, index=None):
                            cupy.float64, cupy.uint32, cupy.uint64,
                            cupy.ulonglong]:
         warnings.warn(
-            'Using the slower implmentation as '
+            'Using the slower implementation as '
             'cupyx.scipy.ndimage.mean supports int32, float16, '
             'float32, float64, uint32, uint64 as data types '
             'for the fast implmentation', _util.PerformanceWarning)

--- a/cupyx/scipy/ndimage/_pba_2d.py
+++ b/cupyx/scipy/ndimage/_pba_2d.py
@@ -117,7 +117,7 @@ def _get_pack_kernel(int_type, marker=-32768):
 
 def _pack_int2(arr, marker=-32768, int_dtype=cupy.int16):
     if arr.ndim != 2:
-        raise ValueError("only 2d arr suppported")
+        raise ValueError("only 2d arr supported")
     int2_dtype = cupy.dtype({"names": ["x", "y"], "formats": [int_dtype] * 2})
     out = cupy.zeros(arr.shape + (2,), dtype=int_dtype)
     assert out.size == 2 * arr.size
@@ -433,7 +433,7 @@ def _pba_2d(arr, sampling=None, return_distances=True, return_indices=False,
         block,
         (input_arr, input_arr, size, bandSize2),
     )
-    # Repeatly merging two bands into one
+    # Repeatedly merging two bands into one
     noBand = m2
     while noBand > 1:
         grid = (math.ceil(size / block[0]), noBand // 2)

--- a/cupyx/scipy/ndimage/_pba_3d.py
+++ b/cupyx/scipy/ndimage/_pba_3d.py
@@ -121,7 +121,7 @@ def _get_encode3d_kernel(size_max, marker=-2147483648):
 
 def encode3d(arr, marker=-2147483648, bit_depth=32, size_max=1024):
     if arr.ndim != 3:
-        raise ValueError("only 3d arr suppported")
+        raise ValueError("only 3d arr supported")
     if bit_depth not in [32, 64]:
         raise ValueError("only bit_depth of 32 or 64 is supported")
     if size_max > 1024:

--- a/cupyx/scipy/signal/_bsplines.py
+++ b/cupyx/scipy/signal/_bsplines.py
@@ -523,7 +523,7 @@ def spline_filter(Iin, lmbda=5.0):
     Returns
     -------
     res : ndarray
-        filterd input data
+        filtered input data
 
     """
     intype = Iin.dtype.char

--- a/cupyx/scipy/signal/_fir_filter_design.py
+++ b/cupyx/scipy/signal/_fir_filter_design.py
@@ -118,7 +118,7 @@ def kaiserord(ripple, width):
     A = abs(ripple)  # in case somebody is confused as to what's meant
     if A < 8:
         # Formula for N is not valid in this range.
-        raise ValueError("Requested maximum ripple attentuation %f is too "
+        raise ValueError("Requested maximum ripple attenuation %f is too "
                          "small for the Kaiser formula." % A)
     beta = kaiser_beta(A)
 
@@ -706,7 +706,7 @@ def firls(numtaps, bands, desired, weight=None, fs=2):
 
     # We have that:
     #     q(n) = 1/π ∫W(ω)cos(nω)dω (over 0->π)
-    # Using our nomalization ω=πf and with a constant weight W over each
+    # Using our normalization ω=πf and with a constant weight W over each
     # interval f1->f2 we get:
     #     q(n) = W∫cos(πnf)df (0->1) = Wf sin(πnf)/πnf
     # integrated over each f1->f2 pair (i.e., value at f2 - value at f1).

--- a/cupyx/scipy/signal/_peak_finding.py
+++ b/cupyx/scipy/signal/_peak_finding.py
@@ -615,7 +615,7 @@ def _select_by_peak_threshold(x, peaks, tmin, tmax):
 
     """
     # Stack thresholds on both sides to make min / max operations easier:
-    # tmin is compared with the smaller, and tmax with the greater thresold to
+    # tmin is compared with the smaller, and tmax with the greater threshold to
     # each peak's side
     stacked_thresholds = cupy.vstack([x[peaks] - x[peaks - 1],
                                       x[peaks] - x[peaks + 1]])

--- a/cupyx/scipy/signal/_resample.py
+++ b/cupyx/scipy/signal/_resample.py
@@ -344,7 +344,7 @@ def resample(x, num, t=None, axis=0, window=None, domain="time"):
             X *= W.reshape(newshape_W)
 
     # Copy each half of the original spectrum to the output spectrum, either
-    # truncating high frequences (downsampling) or zero-padding them
+    # truncating high frequencies (downsampling) or zero-padding them
     # (upsampling)
 
     # Placeholder array for output spectrum
@@ -513,7 +513,7 @@ def resample_poly(x, up, down, axis=0, window=("kaiser", 5.0),
         raise ValueError("up and down must be >= 1")
 
     # Determine our up and down factors
-    # Use a rational approimation to save computation time on really long
+    # Use a rational approximation to save computation time on really long
     # signals
     g_ = gcd(up, down)
     up //= g_

--- a/cupyx/scipy/signal/windows/_windows.py
+++ b/cupyx/scipy/signal/windows/_windows.py
@@ -2003,7 +2003,7 @@ def taylor(M, nbar=4, sll=30, norm=True, sym=True):
     The Taylor window taper function approximates the Dolph-Chebyshev window's
     constant sidelobe level for a parameterized number of near-in sidelobes,
     but then allows a taper beyond [2]_.
-    The SAR (synthetic aperature radar) community commonly uses Taylor
+    The SAR (synthetic aperture radar) community commonly uses Taylor
     weighting for image formation processing because it provides strong,
     selectable sidelobe suppression with minimum broadening of the
     mainlobe [1]_.

--- a/cupyx/scipy/sparse/_base.py
+++ b/cupyx/scipy/sparse/_base.py
@@ -490,7 +490,7 @@ class spmatrix(object):
         """Sums the matrix elements over a given axis.
 
         Args:
-            axis (int or ``None``): Axis along which the sum is comuted.
+            axis (int or ``None``): Axis along which the sum is computed.
                 If it is ``None``, it computes the sum of all the elements.
                 Select from ``{None, 0, 1, -2, -1}``.
             dtype: The type of returned matrix. If it is not specified, type

--- a/cupyx/scipy/sparse/_compressed.py
+++ b/cupyx/scipy/sparse/_compressed.py
@@ -206,7 +206,7 @@ class _compressed_sparse_matrix(sparse_data._data_matrix,
             indptr = x.indptr
 
             if arg1.format != self.format:
-                # When formats are differnent, all arrays are already copied
+                # When formats are different, all arrays are already copied
                 copy = False
 
             if shape is None:

--- a/cupyx/scipy/sparse/_coo.py
+++ b/cupyx/scipy/sparse/_coo.py
@@ -71,7 +71,7 @@ class coo_matrix(sparse_data._data_matrix):
             col = x.col
 
             if arg1.format != self.format:
-                # When formats are differnent, all arrays are already copied
+                # When formats are different, all arrays are already copied
                 copy = False
 
             if shape is None:
@@ -472,7 +472,7 @@ class coo_matrix(sparse_data._data_matrix):
         return self.tocsr().toarray(order=order, out=out)
 
     def tocoo(self, copy=False):
-        """Converts the matrix to COOdinate format.
+        """Converts the matrix to coordinate format.
 
         Args:
             copy (bool): If ``False``, it shares data arrays as much as

--- a/cupyx/scipy/sparse/_coo.py
+++ b/cupyx/scipy/sparse/_coo.py
@@ -472,7 +472,7 @@ class coo_matrix(sparse_data._data_matrix):
         return self.tocsr().toarray(order=order, out=out)
 
     def tocoo(self, copy=False):
-        """Converts the matrix to coordinate format.
+        """Converts the matrix to COOrdinate format.
 
         Args:
             copy (bool): If ``False``, it shares data arrays as much as

--- a/cupyx/scipy/sparse/_csc.py
+++ b/cupyx/scipy/sparse/_csc.py
@@ -262,7 +262,7 @@ class csc_matrix(_compressed._compressed_sparse_matrix):
     # TODO(unno): Implement tobsr
 
     def tocoo(self, copy=False):
-        """Converts the matrix to coordinate format.
+        """Converts the matrix to COOrdinate format.
 
         Args:
             copy (bool): If ``False``, it shares data arrays as much as

--- a/cupyx/scipy/sparse/_csc.py
+++ b/cupyx/scipy/sparse/_csc.py
@@ -262,7 +262,7 @@ class csc_matrix(_compressed._compressed_sparse_matrix):
     # TODO(unno): Implement tobsr
 
     def tocoo(self, copy=False):
-        """Converts the matrix to COOdinate format.
+        """Converts the matrix to coordinate format.
 
         Args:
             copy (bool): If ``False``, it shares data arrays as much as

--- a/cupyx/scipy/sparse/_csr.py
+++ b/cupyx/scipy/sparse/_csr.py
@@ -438,7 +438,7 @@ class csr_matrix(_compressed._compressed_sparse_matrix):
         raise NotImplementedError
 
     def tocoo(self, copy=False):
-        """Converts the matrix to COOdinate format.
+        """Converts the matrix to coordinate format.
 
         Args:
             copy (bool): If ``False``, it shares data arrays as much as
@@ -774,7 +774,7 @@ def multiply_by_csr(a, b):
     d_data = cupy.empty(d_nnz, dtype=dtype)
     d_indices = cupy.empty(d_nnz, dtype=a.indices.dtype)
 
-    # remove zero elements in matric c
+    # remove zero elements in matrix c
     cupy_multiply_by_csr_step2()(c_data, c_indices, flags, d_data, d_indices)
 
     return csr_matrix((d_data, d_indices, d_indptr), shape=(m, n))

--- a/cupyx/scipy/sparse/_csr.py
+++ b/cupyx/scipy/sparse/_csr.py
@@ -438,7 +438,7 @@ class csr_matrix(_compressed._compressed_sparse_matrix):
         raise NotImplementedError
 
     def tocoo(self, copy=False):
-        """Converts the matrix to coordinate format.
+        """Converts the matrix to COOrdinate format.
 
         Args:
             copy (bool): If ``False``, it shares data arrays as much as

--- a/cupyx/scipy/sparse/_data.py
+++ b/cupyx/scipy/sparse/_data.py
@@ -28,7 +28,7 @@ class _data_matrix(_base.spmatrix):
         raise NotImplementedError
 
     def __abs__(self):
-        """Elementwise abosulte."""
+        """Elementwise absolute."""
         return self._with_data(abs(self.data))
 
     def __neg__(self):

--- a/cupyx/scipy/sparse/linalg/_iterative.py
+++ b/cupyx/scipy/sparse/linalg/_iterative.py
@@ -115,7 +115,7 @@ def gmres(A, b, x0=None, tol=1e-5, restart=None, maxiter=None, M=None,
             ``callback_type``.
         callback_type (str): 'x' or 'pr_norm'. If 'x', the current solution
             vector is used as an argument of callback function. if 'pr_norm',
-            relative (preconditioned) residual norm is used as an arugment.
+            relative (preconditioned) residual norm is used as an argument.
         atol (float): Tolerance for convergence.
 
     Returns:
@@ -188,7 +188,7 @@ def gmres(A, b, x0=None, tol=1e-5, restart=None, maxiter=None, M=None,
                 V[:, j+1] = v
 
         # Note: The least-square solution to equation Hy = e is computed on CPU
-        # because it is faster if tha matrix size is small.
+        # because it is faster if the matrix size is small.
         ret = numpy.linalg.lstsq(cupy.asnumpy(H), e)
         y = cupy.array(ret[0])
         x += V @ y

--- a/cupyx/scipy/sparse/linalg/_lobpcg.py
+++ b/cupyx/scipy/sparse/linalg/_lobpcg.py
@@ -477,7 +477,7 @@ def lobpcg(A, X,
             # Once explicitGramFlag, forever explicitGramFlag.
             explicitGramFlag = True
 
-        # Shared memory assingments to simplify the code
+        # Shared memory assignments to simplify the code
         if B is None:
             blockVectorBX = blockVectorX
             activeBlockVectorBR = activeBlockVectorR

--- a/cupyx/scipy/sparse/linalg/_solve.py
+++ b/cupyx/scipy/sparse/linalg/_solve.py
@@ -410,7 +410,7 @@ def spsolve_triangular(A, b, lower=True, overwrite_A=False, overwrite_b=False,
         b (cupy.ndarray):
             Dense vector or matrix with dimension ``(M)`` or ``(M, K)``.
         lower (bool):
-            Whether ``A`` is a lower or upper trinagular matrix.
+            Whether ``A`` is a lower or upper triangular matrix.
             If True, it is lower triangular, otherwise, upper triangular.
         overwrite_A (bool):
             (not supported)

--- a/cupyx/scipy/special/_logsumexp.py
+++ b/cupyx/scipy/special/_logsumexp.py
@@ -34,7 +34,7 @@ def logsumexp(a, axis=None, b=None, keepdims=False, return_sign=False):
     sgn : cupy.ndarray
         If return_sign is True, this will be an array of floating-point
         numbers matching res and +1, 0, or -1 depending on the sign of
-        the result. If False, only own result is returned
+        the result. If False, only one result is returned.
 
     See Also
     --------

--- a/cupyx/scipy/special/_logsumexp.py
+++ b/cupyx/scipy/special/_logsumexp.py
@@ -34,7 +34,7 @@ def logsumexp(a, axis=None, b=None, keepdims=False, return_sign=False):
     sgn : cupy.ndarray
         If return_sign is True, this will be an array of floating-point
         numbers matching res and +1, 0, or -1 depending on the sign of
-        the result. If False, only onw result is returned
+        the result. If False, only own result is returned
 
     See Also
     --------

--- a/cupyx/scipy/special/_stats_distributions.py
+++ b/cupyx/scipy/special/_stats_distributions.py
@@ -67,7 +67,7 @@ log_ndtr = _core.create_ufunc(
     preamble=log_ndtr_definition,
     doc="""Logarithm of Gaussian cumulative distribution function.
 
-    Returns the log of the area under the standard Gaussian propability
+    Returns the log of the area under the standard Gaussian probability
     density function.
 
     Parameters

--- a/cupyx/signal/_radartools/_radartools.py
+++ b/cupyx/signal/_radartools/_radartools.py
@@ -159,7 +159,7 @@ def ca_cfar(array, guard_cells, reference_cells, pfa=1e-3):
     reference_cells_x : int
         one-sided reference cell count in the first dimension.
     reference_cells_y : int
-        one-sided referenc cell count in the second dimension.
+        one-sided reference cell count in the second dimension.
     pfa : float
         Probability of false alarm.
     Returns

--- a/cupyx/time.py
+++ b/cupyx/time.py
@@ -34,7 +34,7 @@ def repeat(
 
     Args:
         func (callable): a callable object to be timed.
-        args (tuple): positional argumens to be passed to the callable.
+        args (tuple): positional arguments to be passed to the callable.
         kwargs (dict): keyword arguments to be passed to the callable.
         n_repeat (int): number of times the callable is called. Increasing
             this value would improve the collected statistics at the cost

--- a/cupyx/tools/_hipsparse_stub_mapper.py
+++ b/cupyx/tools/_hipsparse_stub_mapper.py
@@ -5,7 +5,7 @@ from typing import Tuple
 
 # Take cupy_backends/stub/cupy_cusparse.h and generate
 # cupy_backends/hip/cupy_hipsparse.h, with all return values replaced by an
-# error if not supprted. This script mainly focuses on getting the CUDA ->
+# error if not supported. This script mainly focuses on getting the CUDA ->
 # HIP API mapping done correctly; structs, enums, etc, are handled
 # automatically to the maximal extent.
 #

--- a/docs/source/_templates/autosummary/class.rst
+++ b/docs/source/_templates/autosummary/class.rst
@@ -41,7 +41,7 @@
 {% endblock %}
 
    ..
-      Atributes
+      Attributes
 
 {% block attributes %} {% if attributes %}
 

--- a/docs/source/contribution.rst
+++ b/docs/source/contribution.rst
@@ -214,7 +214,7 @@ Once you send a pull request, your coding style is automatically checked by `Git
 The reviewing process starts after the check passes.
 
 The CuPy is designed based on NumPy's API design. CuPy's source code and documents contain the original NumPy ones.
-Please note the followings when writing the document.
+Please note the following when writing the document.
 
 * In order to identify overlapping parts, it is preferable to add some remarks
   that this document is just copied or altered from the original one. It is

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -125,7 +125,7 @@ If you aim at minimizing the installation footprint, you can install the ``cupy-
     $ conda install -c conda-forge cupy-core
 
 which only depends on ``numpy``. None of the CUDA libraries will be installed this way, and it is your responsibility to install the needed
-dependencies youself, either from conda-forge or elsewhere. This is equivalent of the ``cupy-cudaXX`` wheel installation.
+dependencies yourself, either from conda-forge or elsewhere. This is equivalent of the ``cupy-cudaXX`` wheel installation.
 
 Conda has a built-in mechanism to determine and install the latest version of ``cudatoolkit`` or any other CUDA components supported by your driver.
 However, if for any reason you need to force-install a particular CUDA version (say 11.8), you can do::
@@ -330,7 +330,7 @@ CuPy always raises ``cupy.cuda.compiler.CompileException``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If CuPy raises a ``CompileException`` for almost everything, it is possible that CuPy cannot detect CUDA installed on your system correctly.
-The followings are error messages commonly observed in such cases.
+The following are error messages commonly observed in such cases.
 
 * ``nvrtc: error: failed to load builtins``
 * ``catastrophic error: cannot open source file "cuda_fp16.h"``

--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -13,7 +13,7 @@ API Reference
 
 ..
   For NumPy/SciPy-compatible APIs (ndarray, ufunc, routines, scipy),
-  omit the module name prefix in the API list, following the convension in
+  omit the module name prefix in the API list, following the convention in
   NumPy/SciPy documentation.
   For CuPy-specific APIs, use fully-qualified names.
 

--- a/docs/source/reference/scipy_fftpack.rst
+++ b/docs/source/reference/scipy_fftpack.rst
@@ -29,7 +29,7 @@ Fast Fourier Transforms (FFTs)
 
 Code compatibility features
 ---------------------------
-1. As with other FFT modules in CuPy, FFT functions in this module can take advantage of an existing cuFFT plan (returned by :func:`~cupyx.scipy.fftpack.get_fft_plan`) to accelarate the computation. The plan can be either passed in explicitly via the ``plan`` argument or used as a context manager. The argument ``plan`` is currently experimental and the interface may be changed in the future version. The :func:`~cupyx.scipy.fftpack.get_fft_plan` function has no counterpart in ``scipy.fftpack``.
+1. As with other FFT modules in CuPy, FFT functions in this module can take advantage of an existing cuFFT plan (returned by :func:`~cupyx.scipy.fftpack.get_fft_plan`) to accelerate the computation. The plan can be either passed in explicitly via the ``plan`` argument or used as a context manager. The argument ``plan`` is currently experimental and the interface may be changed in the future version. The :func:`~cupyx.scipy.fftpack.get_fft_plan` function has no counterpart in ``scipy.fftpack``.
 
 2. The boolean switch :data:`cupy.fft.config.enable_nd_planning` also affects the FFT functions in this module, see :doc:`./fft`. This switch is neglected when planning manually using :func:`~cupyx.scipy.fftpack.get_fft_plan`.
 

--- a/docs/source/upgrade.rst
+++ b/docs/source/upgrade.rst
@@ -350,7 +350,7 @@ Python 3.5 is no longer supported in CuPy v9.
 NCCL and cuDNN No Longer Included in Wheels
 -------------------------------------------
 
-NCCL and cuDNN shared libraires are no longer included in wheels (see `#4850 <https://github.com/cupy/cupy/issues/4850>`_ for discussions). 
+NCCL and cuDNN shared libraries are no longer included in wheels (see `#4850 <https://github.com/cupy/cupy/issues/4850>`_ for discussions). 
 You can manually install them after installing wheel if you don't have a previous installation; see :doc:`install` for details.
 
 cuTENSOR Enabled in Wheels

--- a/docs/source/user_guide/fft.rst
+++ b/docs/source/user_guide/fft.rst
@@ -260,7 +260,7 @@ The second kind of usage is to use the low-level, *private* CuPy APIs. You need 
     plan.fft(a, out_cp, cufft.CUFFT_FORWARD)
 
     out_np = numpy.fft.fft(a)  # use NumPy's fft
-    # np.fft.fft alway returns np.complex128
+    # np.fft.fft always returns np.complex128
     if dtype is numpy.complex64:
         out_np = out_np.astype(dtype)
 

--- a/docs/source/user_guide/kernel.rst
+++ b/docs/source/user_guide/kernel.rst
@@ -272,7 +272,7 @@ If your kernel relies on the C++ std library headers such as ``<type_traits>``, 
 .. note::
     In all of the examples above, we declare the kernels in an ``extern "C"`` block,
     indicating that the C linkage is used. This is to ensure the kernel names are not
-    mangled so that they can be retrived by name.
+    mangled so that they can be retrieved by name.
 
 Kernel arguments
 ----------------
@@ -568,7 +568,7 @@ See :doc:`../reference/kernel` for a full list of API.
 Basic Design
 ^^^^^^^^^^^^
 
-CuPy's JIT compiler generates CUDA code via Python AST. We decided not to use Python bytecode to analyze the target function to avoid perforamance degradation. The CUDA source code generated from the Python bytecode will not effectively optimized by CUDA compiler, because for-loops and other control statements of the target function are fully transformed to jump instruction when converting the target function to bytecode.
+CuPy's JIT compiler generates CUDA code via Python AST. We decided not to use Python bytecode to analyze the target function to avoid performance degradation. The CUDA source code generated from the Python bytecode will not effectively optimized by CUDA compiler, because for-loops and other control statements of the target function are fully transformed to jump instruction when converting the target function to bytecode.
 
 Typing rule
 ^^^^^^^^^^^

--- a/docs/source/user_guide/memory.rst
+++ b/docs/source/user_guide/memory.rst
@@ -145,7 +145,7 @@ which may or may not be desired.
 Stream Ordered Memory Allocator is a new feature added since CUDA 11.2. CuPy provides an *experimental* interface to it.
 Similar to CuPy's memory pool, Stream Ordered Memory Allocator also allocates/deallocates memory *asynchronously* from/to
 a memory pool in a stream-ordered fashion. The key difference is that it is a built-in feature implemented in the CUDA
-driver by NVIDIA, so other CUDA applications in the same processs can easily allocate memory from the same pool.
+driver by NVIDIA, so other CUDA applications in the same process can easily allocate memory from the same pool.
 
 To enable a memory pool that manages stream ordered memory, you can construct a new :class:`~cupy.cuda.MemoryAsyncPool`
 instance:

--- a/examples/interoperability/mpi4py_multiple_devices.py
+++ b/examples/interoperability/mpi4py_multiple_devices.py
@@ -20,7 +20,7 @@ if device_count < 2:
 
 # Select device based on local MPI rank.
 # Caveat: for simplicity we assume local_rank == rank here, which may or may
-# not be the case depending how MPI processes are lauched and how your code
+# not be the case depending how MPI processes are launched and how your code
 # is written. For more robust usage, you may need to consult the user manual
 # for your MPI library. For example:
 # local_rank = int(os.getenv("OMPI_COMM_WORLD_LOCAL_RANK"))  # Open MPI

--- a/install/cupy_builder/_features.py
+++ b/install/cupy_builder/_features.py
@@ -70,7 +70,7 @@ def _from_dict(d: Dict[str, Any], ctx: Context) -> Feature:
     f.libraries = d['libraries']
     f.static_libraries = d.get('static_libraries', [])
 
-    # Note: the followings are renamed
+    # Note: the following are renamed
     f.modules = d['file']
     f.includes = d['include']
     if 'check_method' in d:
@@ -82,7 +82,7 @@ def _from_dict(d: Dict[str, Any], ctx: Context) -> Feature:
 
 
 # The value of the key 'file' is a list that contains extension names
-# or tuples of an extension name and a list of other souces files
+# or tuples of an extension name and a list of other sources files
 # required to build the extension such as .cpp files and .cu files.
 #
 #   <extension name> | (<extension name>, a list of <other source>)

--- a/tests/cupy_tests/array_api_tests/test_array_object.py
+++ b/tests/cupy_tests/array_api_tests/test_array_object.py
@@ -355,7 +355,7 @@ def test_array_keys_use_private_array():
     in __getitem__(). This is achieved by passing array_api arrays with 0-sized
     dimensions, which NumPy-proper treats erroneously - not sure why!
 
-    TODO: Find and use appropiate __setitem__() case.
+    TODO: Find and use appropriate __setitem__() case.
     """
     a = ones((0, 0), dtype=bool_)
     assert a[a].shape == (0,)

--- a/tests/cupy_tests/core_tests/fusion_tests/test_kernel_cache.py
+++ b/tests/cupy_tests/core_tests/fusion_tests/test_kernel_cache.py
@@ -18,7 +18,7 @@ class CreateMock(object):
         return self.target(*args, **kwargs)
 
     def check_call_count(self, xp, count):
-        # TODO(asi1024): Uncomment after replace fusion implementaiton.
+        # TODO(asi1024): Uncomment after replace fusion implementation.
 
         # assert xp in (numpy, cupy)
         # assert isinstance(count, int)

--- a/tests/cupy_tests/core_tests/fusion_tests/test_misc.py
+++ b/tests/cupy_tests/core_tests/fusion_tests/test_misc.py
@@ -214,7 +214,7 @@ class TestFusionKernelName(unittest.TestCase):
 
             with mock.patch(target_full_name) as kernel:  # NOQA
                 func(a, b, c)
-                # TODO(asi1024): Uncomment after replace fusion implementaiton.
+                # TODO(asi1024): Uncomment after replace fusion implementation.
                 # kernel.assert_called_once()
                 # self.assertEqual(kernel.call_args.args[0], expected_name)
 

--- a/tests/cupy_tests/core_tests/fusion_tests/test_optimization.py
+++ b/tests/cupy_tests/core_tests/fusion_tests/test_optimization.py
@@ -19,7 +19,7 @@ class CreateMock(object):
 
     def check_number_of_ops(
             self, loops, memories, variables, lookup, mutate):
-        # TODO(asi1024): Uncomment after replace fusion implementaiton.
+        # TODO(asi1024): Uncomment after replace fusion implementation.
 
         # assert isinstance(loops, int)
         # assert isinstance(memories, int)

--- a/tests/cupy_tests/core_tests/fusion_tests/test_reduction.py
+++ b/tests/cupy_tests/core_tests/fusion_tests/test_reduction.py
@@ -120,7 +120,7 @@ class TestFusionReductionAndElementwise(unittest.TestCase):
     def test_premap_postmap(self, xp):
         return lambda x, y: xp.sum(xp.sqrt(x) + y, self.axis) * 2 + y
 
-    # TODO(asi1024): Uncomment after replace fusion implementaiton.
+    # TODO(asi1024): Uncomment after replace fusion implementation.
     # @fusion_utils.check_fusion()
     # def test_premap_inplace(self, xp):
     #     def impl(x, y):

--- a/tests/cupy_tests/core_tests/fusion_tests/test_routines.py
+++ b/tests/cupy_tests/core_tests/fusion_tests/test_routines.py
@@ -368,14 +368,14 @@ class TestFusionManipulation(unittest.TestCase):
     def test_where(self, xp, dtype1, dtype2):
         return lambda cond, x, y: xp.where(cond, x, y)
 
-    # TODO(imanishi): Supoort complex dtypes
+    # TODO(imanishi): Support complex dtypes
     @testing.for_all_dtypes_combination(
         names=('dtype1', 'dtype2'), no_complex=True)
     @fusion_utils.check_fusion(accept_error=(TypeError,))
     def test_copyto(self, xp, dtype1, dtype2):
         return lambda cond, x, y: xp.copyto(x, y)
 
-    # TODO(imanishi): Supoort complex dtypes
+    # TODO(imanishi): Support complex dtypes
     @pytest.mark.xfail(reason='Issue #5848')
     @testing.for_all_dtypes_combination(
         names=('dtype1', 'dtype2'), no_complex=True)
@@ -383,7 +383,7 @@ class TestFusionManipulation(unittest.TestCase):
     def test_copyto_compat_broadcast(self, xp, dtype1, dtype2):
         return lambda cond, x, y: xp.copyto(x, y[None])
 
-    # TODO(imanishi): Supoort complex dtypes
+    # TODO(imanishi): Support complex dtypes
     @testing.for_all_dtypes_combination(
         names=('dtype1', 'dtype2'), no_complex=True)
     @fusion_utils.check_fusion(accept_error=(TypeError,))

--- a/tests/cupy_tests/core_tests/fusion_tests/test_ufunc.py
+++ b/tests/cupy_tests/core_tests/fusion_tests/test_ufunc.py
@@ -61,7 +61,7 @@ class TestFusionBroadcast(unittest.TestCase):
     def test_broadcast(self, xp):
         return lambda x, y: x + y
 
-    # TODO(asi1024): Uncomment after replace fusion implementaiton.
+    # TODO(asi1024): Uncomment after replace fusion implementation.
 
     # @fusion_utils.check_fusion(accept_error=ValueError)
     # def test_broadcast_inplace(self, xp):

--- a/tests/cupy_tests/core_tests/test_ndarray_elementwise_op.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_elementwise_op.py
@@ -188,7 +188,7 @@ class TestArrayElementwiseOp:
         return operator.pow(a, b)
 
     def test_pow_array(self):
-        # There are some precission issues in HIP that prevent
+        # There are some precision issues in HIP that prevent
         # checking with atol=0
         if cupy.cuda.runtime.is_hip:
             self.check_pow_array()
@@ -292,7 +292,7 @@ class TestArrayElementwiseOp:
         return operator.pow(a, b)
 
     def test_broadcasted_pow(self):
-        # There are some precission issues in HIP that prevent
+        # There are some precision issues in HIP that prevent
         # checking with atol=0
         if cupy.cuda.runtime.is_hip:
             self.check_broadcasted_pow()

--- a/tests/cupy_tests/core_tests/test_raw.py
+++ b/tests/cupy_tests/core_tests/test_raw.py
@@ -1266,7 +1266,7 @@ class TestRawPicklable(unittest.TestCase):
         # run another process to check the pickle
         s = subprocess.run([sys.executable, 'TestRawPicklable.py'] + test_args,
                            cwd=self.temp_dir)
-        s.check_returncode()  # raise if unsuccess
+        s.check_returncode()  # raise if unsuccessful
 
 
 # a slightly more realistic kernel involving std utilities

--- a/tests/cupy_tests/cuda_tests/test_cufft.py
+++ b/tests/cupy_tests/cuda_tests/test_cufft.py
@@ -54,7 +54,7 @@ class TestMultiGpuPlan1dNumPy(unittest.TestCase):
         plan.fft(a, out_cp, cufft.CUFFT_FORWARD)
 
         out_np = numpy.fft.fft(a)
-        # np.fft.fft alway returns np.complex128
+        # np.fft.fft always returns np.complex128
         if dtype is numpy.complex64:
             out_np = out_np.astype(dtype)
 
@@ -88,7 +88,7 @@ class TestMultiGpuPlan1dNumPy(unittest.TestCase):
         out_cp /= nx
 
         out_np = numpy.fft.ifft(a)
-        # np.fft.fft alway returns np.complex128
+        # np.fft.fft always returns np.complex128
         if dtype is numpy.complex64:
             out_np = out_np.astype(dtype)
 

--- a/tests/cupy_tests/cuda_tests/test_driver.py
+++ b/tests/cupy_tests/cuda_tests/test_driver.py
@@ -7,7 +7,7 @@ from cupy import testing
 from cupy.cuda import driver
 
 
-@unittest.skipIf(cupy.cuda.runtime.is_hip, 'Context API is dperecated in HIP')
+@unittest.skipIf(cupy.cuda.runtime.is_hip, 'Context API is deprecated in HIP')
 class TestDriver(unittest.TestCase):
     def test_ctxGetCurrent(self):
         # Make sure to create context.

--- a/tests/cupy_tests/cuda_tests/test_memory.py
+++ b/tests/cupy_tests/cuda_tests/test_memory.py
@@ -485,7 +485,7 @@ class TestSingleDeviceMemoryPool(unittest.TestCase):
         del p2
 
     def test_free_all_blocks_split(self):
-        # do not free splitted blocks
+        # do not free split blocks
         p = self.pool.malloc(self.unit * 4)
         del p
         head = self.pool.malloc(self.unit * 2)
@@ -1049,7 +1049,7 @@ class TestMallocAsync(unittest.TestCase):
             assert memptr.mem.stream_ref().ptr == s.ptr
 
     def test_stream3(self):
-        # Check: destory stream does not affect memory deallocation
+        # Check: destroy stream does not affect memory deallocation
         s = cupy.cuda.Stream()
         with s:
             memptr = memory.alloc(100)

--- a/tests/cupy_tests/fft_tests/test_fft.py
+++ b/tests/cupy_tests/fft_tests/test_fft.py
@@ -19,7 +19,7 @@ def skip_forward_backward(request):
 
 
 def nd_planning_states(states=[True, False], name='enable_nd'):
-    """Decorator for parameterized tests with and wihout nd planning
+    """Decorator for parameterized tests with and without nd planning
 
     Tests are repeated with config.enable_nd_planning set to True and False
 

--- a/tests/cupy_tests/linalg_tests/test_eigenvalue.py
+++ b/tests/cupy_tests/linalg_tests/test_eigenvalue.py
@@ -63,7 +63,7 @@ class TestEigenvalue:
         # NumPy, cuSOLVER, rocSOLVER all sort in ascending order,
         # so w's should be directly comparable. However, both cuSOLVER
         # and rocSOLVER pick a different convention for constructing
-        # eigenvectors, so v's are not directly comparible and we verify
+        # eigenvectors, so v's are not directly comparable and we verify
         # them through the eigen equation A*v=w*v.
         A = _get_hermitian(xp, a, self.UPLO)
         for i in range(a.shape[0]):
@@ -81,7 +81,7 @@ class TestEigenvalue:
         # NumPy, cuSOLVER, rocSOLVER all sort in ascending order,
         # so w's should be directly comparable. However, both cuSOLVER
         # and rocSOLVER pick a different convention for constructing
-        # eigenvectors, so v's are not directly comparible and we verify
+        # eigenvectors, so v's are not directly comparable and we verify
         # them through the eigen equation A*v=w*v.
         A = _get_hermitian(xp, a, self.UPLO)
         for i in range(a.shape[0]):

--- a/tests/cupy_tests/linalg_tests/test_solve.py
+++ b/tests/cupy_tests/linalg_tests/test_solve.py
@@ -236,7 +236,7 @@ class TestLstsq:
             cupy.linalg.lstsq(a, b, rcond=None)
 
     def test_lstsq_solutions(self):
-        # Comapres numpy.linalg.lstsq and cupy.linalg.lstsq solutions for:
+        # Compares numpy.linalg.lstsq and cupy.linalg.lstsq solutions for:
         #   a shapes range from (3, 3) to (5, 3) and (3, 5)
         #   b shapes range from (i, 3) to (i, )
         #   sets a random seed for deterministic testing

--- a/tests/cupy_tests/random_tests/test_permutations.py
+++ b/tests/cupy_tests/random_tests/test_permutations.py
@@ -148,7 +148,7 @@ class TestPermutationRandomness(unittest.TestCase):
     # frequency of appearance of 0 and 1 at each bit position of
     # whole elements in the sub-array should become similar
     # when elements count of original array is 2^N.
-    # Note that this is not an establishd method to check randomness.
+    # Note that this is not an established method to check randomness.
     # TODO(anaruse): implement randomness check using some established methods.
     @_condition.repeat_with_success_at_least(5, 3)
     def test_permutation_randomness(self):

--- a/tests/cupy_tests/sorting_tests/test_search.py
+++ b/tests/cupy_tests/sorting_tests/test_search.py
@@ -709,7 +709,7 @@ class TestSearchSortedNanInf:
 
 class TestSearchSortedInvalid:
 
-    # Cant test unordered bins due to numpy undefined
+    # Can't test unordered bins due to numpy undefined
     # behavior for searchsorted
 
     def test_searchsorted_ndbins(self):

--- a/tests/cupyx_tests/jit_tests/test_cub.py
+++ b/tests/cupyx_tests/jit_tests/test_cub.py
@@ -16,8 +16,8 @@ class TestCubWarpReduce:
                 dtype=WarpReduce.TempStorage, size=1)
             i, j = jit.blockIdx.x, jit.threadIdx.x
             value = x[i, j]
-            aggregater = WarpReduce(temp_storage[0])
-            aggregate = aggregater.Sum(value)
+            aggregator = WarpReduce(temp_storage[0])
+            aggregate = aggregator.Sum(value)
             if j == 0:
                 y[i] = aggregate
 
@@ -40,8 +40,8 @@ class TestCubWarpReduce:
                 dtype=WarpReduce.TempStorage, size=1)
             i, j = jit.blockIdx.x, jit.threadIdx.x
             value = x[i, j]
-            aggregater = WarpReduce(temp_storage[0])
-            aggregate = aggregater.Reduce(value, jit.cub.Sum())
+            aggregator = WarpReduce(temp_storage[0])
+            aggregate = aggregator.Reduce(value, jit.cub.Sum())
             if j == 0:
                 y[i] = aggregate
 
@@ -64,8 +64,8 @@ class TestCubWarpReduce:
                 dtype=WarpReduce.TempStorage, size=1)
             i, j = jit.blockIdx.x, jit.threadIdx.x
             value = x[i, j]
-            aggregater = WarpReduce(temp_storage[0])
-            aggregate = aggregater.Reduce(value, jit.cub.Max())
+            aggregator = WarpReduce(temp_storage[0])
+            aggregate = aggregator.Reduce(value, jit.cub.Max())
             if j == 0:
                 y[i] = aggregate
 
@@ -91,8 +91,8 @@ class TestCubBlockReduce:
                 dtype=BlockReduce.TempStorage, size=1)
             i, j = jit.blockIdx.x, jit.threadIdx.x
             value = x[i, j]
-            aggregater = BlockReduce(temp_storage[0])
-            aggregate = aggregater.Sum(value)
+            aggregator = BlockReduce(temp_storage[0])
+            aggregate = aggregator.Sum(value)
             if j == 0:
                 y[i] = aggregate
 
@@ -114,8 +114,8 @@ class TestCubBlockReduce:
                 dtype=BlockReduce.TempStorage, size=1)
             i, j = jit.blockIdx.x, jit.threadIdx.x
             value = x[i, j]
-            aggregater = BlockReduce(temp_storage[0])
-            aggregate = aggregater.Reduce(value, jit.cub.Min())
+            aggregator = BlockReduce(temp_storage[0])
+            aggregate = aggregator.Reduce(value, jit.cub.Min())
             if j == 0:
                 y[i] = aggregate
 

--- a/tests/cupyx_tests/scipy_tests/interpolate_tests/test_polyint.py
+++ b/tests/cupyx_tests/scipy_tests/interpolate_tests/test_polyint.py
@@ -18,7 +18,7 @@ except ImportError:
 
 
 if cupy.cuda.runtime.runtimeGetVersion() < 11000:
-    # Workarounds precison issues in CUDA 10.2 + float16
+    # Workarounds precision issues in CUDA 10.2 + float16
     default_atol = 5e-2
     default_rtol = 1e-1
 else:

--- a/tests/cupyx_tests/scipy_tests/interpolate_tests/test_rbfinterp.py
+++ b/tests/cupyx_tests/scipy_tests/interpolate_tests/test_rbfinterp.py
@@ -77,7 +77,7 @@ def _is_conditionally_positive_definite(kernel, m, xp, scp):
     ntests = 100
     for ndim in [1, 2, 3, 4, 5]:
         # Generate sample points with a Halton sequence to avoid samples that
-        # are too close to eachother, which can make the matrix singular.
+        # are too close to each other, which can make the matrix singular.
         seq = Halton(ndim, scramble=False, seed=_np.random.RandomState())
         for _ in range(ntests):
             x = xp.asarray(2*seq.random(nx)) - 1

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
@@ -79,7 +79,7 @@ class FilterTestCaseBase:
             # w is actually a tuple of (None, footprint)
             wghts, kwargs['footprint'] = wghts
 
-        # Bulid the arguments
+        # Build the arguments
         args = [getattr(self, param)
                 for param in FilterTestCaseBase.ARGS_PARAMS
                 if hasattr(self, param)]

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
@@ -438,7 +438,7 @@ class TestLabeledComprehension():
             def func(x, pos):
                 return xp.sum(x + pos > 50)
         else:
-            # simple function to apply to each lable
+            # simple function to apply to each label
             func = xp.sum
 
         op = getattr(scp.ndimage, 'labeled_comprehension')

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_filter_design.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_filter_design.py
@@ -802,7 +802,7 @@ class TestGroupDelay:
 
 @testing.with_requires('scipy')
 class TestGammatone:
-    # Test erroneus input cases.
+    # Test erroneous input cases.
     def test_invalid_input(self):
         for scp in [cupyx.scipy, scipy]:
             # Cutoff frequency is <= 0 or >= fs / 2.

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_iir_filter_design.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_iir_filter_design.py
@@ -972,14 +972,14 @@ class TestIIRNotch:
 
     @testing.numpy_cupy_allclose(scipy_name="scp")
     def test_ba_output(self, xp, scp):
-        # Compare coeficients with Matlab ones
+        # Compare coefficients with Matlab ones
         # for the equivalent input:
         b, a = scp.signal.iirnotch(0.06, 30)
         return b, a
 
     @testing.numpy_cupy_allclose(scipy_name="scp")
     def test_frequency_response(self, xp, scp):
-        # Get filter coeficients
+        # Get filter coefficients
         b, a = scp.signal.iirnotch(0.3, 30)
         return b, a
 
@@ -995,7 +995,7 @@ class TestIIRNotch:
 
     @testing.numpy_cupy_allclose(scipy_name="scp")
     def test_fs_param(self, xp, scp):
-        # Get filter coeficients
+        # Get filter coefficients
         b, a = scp.signal.iirnotch(1500, 30, fs=10000)
         return b, a
 
@@ -1005,14 +1005,14 @@ class TestIIRPeak:
 
     @testing.numpy_cupy_allclose(scipy_name="scp")
     def test_ba_output(self, xp, scp):
-        # Compare coeficients with Matlab ones
+        # Compare coefficients with Matlab ones
         # for the equivalent input:
         b, a = scp.signal.iirpeak(0.06, 30)
         return b, a
 
     @testing.numpy_cupy_allclose(scipy_name="scp")
     def test_frequency_response(self, xp, scp):
-        # Get filter coeficients
+        # Get filter coefficients
         b, a = scp.signal.iirpeak(0.3, 30)
         return b, a
 
@@ -1028,7 +1028,7 @@ class TestIIRPeak:
 
     @testing.numpy_cupy_allclose(scipy_name="scp")
     def test_fs_param(self, xp, scp):
-        # Get filter coeficients
+        # Get filter coefficients
         b, a = scp.signal.iirpeak(1200, 30, fs=8000)
         return b, a
 

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_dia.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_dia.py
@@ -327,7 +327,7 @@ class TestDiaMatrixSum(unittest.TestCase):
             HIP_version = driver.get_build_version()
             if HIP_version < 5_00_00000:
                 # internally a temporary CSC matrix is generated and thus
-                # casues problems (see test_csc.py)
+                # causes problems (see test_csc.py)
                 pytest.xfail('spmv is buggy (trans=True)')
 
     @testing.numpy_cupy_allclose(sp_name='sp')

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
@@ -1308,7 +1308,7 @@ class TestLOBPCGForDiagInput:
         X = testing.shaped_random((n, m), xp=xp, dtype=xp.dtype(self.X_dtype),
                                   seed=1234)
 
-        # Require tht returned eigenvectors be in the orthogonal
+        # Require that returned eigenvectors be in the orthogonal
         # complement of the first few standard basis vectors
         # (Cannot be sparse array)
         m_excluded = 3

--- a/tests/cupyx_tests/test_cusparse.py
+++ b/tests/cupyx_tests/test_cusparse.py
@@ -1098,7 +1098,7 @@ class TestSpsm:
         if not cusparse.check_availability('spsm'):
             pytest.skip('spsm is not available')
         if not runtime.is_hip and _cusparse.get_build_version() < 11701:
-            # eariler than CUDA 11.6
+            # earlier than CUDA 11.6
             if b_order == 'c':
                 pytest.skip("Older CUDA has a bug")
         if runtime.is_hip:

--- a/tests/cupyx_tests/tools_tests/test_install_library.py
+++ b/tests/cupyx_tests/tools_tests/test_install_library.py
@@ -59,7 +59,7 @@ class TestInstallLibrary:
             for filename in filenames:
                 if filename in files:
                     return
-        pytest.fail('expected file cound not be found')
+        pytest.fail('expected file could not be found')
 
     @pytest.mark.parametrize('library', _libraries)
     def test_urls(self, library):


### PR DESCRIPTION
@kmaehashi As discussed elsewhere...
```
codespell --skip="./docs/source/spelling_wordlist.txt,*.pyx" --write-changes \
--ignore-words-list=alo,alow,ans,bu,ccompiler,clen,commun,coo,fro,fo,indext,mata,matc,mone,nd,nin,nomes,numer,ot,shat,te,twon,ue,wew
```
* https://pypi.org/project/codespell