### PR TITLE
Use f-strings in ndimage kernel generation code

### DIFF
--- a/cupyx/scipy/ndimage/_morphology.py
+++ b/cupyx/scipy/ndimage/_morphology.py
@@ -21,34 +21,33 @@ def _get_binary_erosion_kernel(
         true_val = 0
         false_val = 1
     else:
+        border_value = int(border_value)
         true_val = 1
         false_val = 0
 
     if masked:
-        pre = """
+        pre = f"""
             bool mv = (bool)mask[i];
             bool _in = (bool)x[i];
             if (!mv) {{
                 y = cast<Y>(_in);
                 return;
-            }} else if ({center_is_true} && _in == {false_val}) {{
+            }} else if ({int(center_is_true)} && _in == {false_val}) {{
                 y = cast<Y>(_in);
                 return;
-            }}""".format(center_is_true=int(center_is_true),
-                         false_val=false_val)
+            }}"""
     else:
-        pre = """
+        pre = f"""
             bool _in = (bool)x[i];
-            if ({center_is_true} && _in == {false_val}) {{
+            if ({int(center_is_true)} && _in == {false_val}) {{
                 y = cast<Y>(_in);
                 return;
-            }}""".format(center_is_true=int(center_is_true),
-                         false_val=false_val)
-    pre = pre + """
-            y = cast<Y>({true_val});""".format(true_val=true_val)
+            }}"""
+    pre = pre + f"""
+            y = cast<Y>({true_val});"""
 
     # {{{{ required because format is called again within _generate_nd_kernel
-    found = """
+    found = f"""
         if ({{cond}}) {{{{
             if (!{border_value}) {{{{
                 y = cast<Y>({false_val});
@@ -60,9 +59,7 @@ def _get_binary_erosion_kernel(
                 y = cast<Y>({false_val});
                 return;
             }}}}
-        }}}}""".format(true_val=int(true_val),
-                       false_val=int(false_val),
-                       border_value=int(border_value),)
+        }}}}"""
 
     name = 'binary_erosion'
     if false_val:


### PR DESCRIPTION
This MR backports a limited number of style changes made for cuCIM's vendored copy of ndimage code. It is intended to improve readability and ease maintenance of the CUDA kernels used by `cupyx.scipy.ndimage`.

This is split out from other formatting changes in #8126