### PR TITLE
ndimage: more efficient testing of binary morphology functions

### DIFF
--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_morphology.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_morphology.py
@@ -60,17 +60,33 @@ class TestIterateStructure:
 
 
 @testing.parameterize(*(
-    testing.product({
-        'x_dtype': [numpy.bool_, numpy.int8, numpy.uint8, numpy.float32,
-                    numpy.float64],
+    testing.product({  # cases with boolean input and output
+        'x_dtype': [bool],
         'border_value': [0, 1],
         'structure': [None, [1, 0, 1], [1, 1, 0]],
         'origin': [-1, 0, 1],
-        'data': [[], [1, 1, 0, 1, 1]],
+        'data': [[1, 1, 0, 1, 1]],
+        'filter': ['binary_erosion', 'binary_dilation'],
+        'output': [None]}
+    ) + testing.product({  # cases with empty data
+        'x_dtype': [bool],
+        'border_value': [0],
+        'structure': [None],
+        'origin': [0],
+        'data': [[]],
+        'filter': ['binary_erosion', 'binary_dilation'],
+        'output': [None]}
+    ) + testing.product({  # dtype and output combinations
+        'x_dtype': [numpy.bool_, numpy.int8, numpy.uint8, numpy.float32,
+                    numpy.float64],
+        'border_value': [0],
+        'structure': [[1, 1, 0]],
+        'origin': [0],
+        'data': [[1, 1, 0, 1, 1]],
         'filter': ['binary_erosion', 'binary_dilation'],
         'output': [None, numpy.float32, numpy.int8, 'array']}
-    ))
-)
+    )
+))
 @testing.with_requires('scipy')
 class TestBinaryErosionAndDilation1d:
     def _filter(self, xp, scp, x):
@@ -97,8 +113,8 @@ class TestBinaryErosionAndDilation1d:
 
 
 @testing.parameterize(*(
-    testing.product({
-        'x_dtype': [numpy.bool_, numpy.float64],
+    testing.product({  # cases with boolean input and output
+        'x_dtype': [bool],
         'border_value': [0, 1],
         'connectivity': [1, 2],
         'origin': [0, 1],
@@ -121,9 +137,25 @@ class TestBinaryErosionAndDilation1d:
                   [0, 0, 0, 0, 0, 0, 0, 0]],
                  ],
         'filter': ['binary_opening', 'binary_closing'],
+        'output': [None]}
+    ) + testing.product({  # dtype and output combinations
+        'x_dtype': [numpy.bool_, numpy.float64],
+        'border_value': [0],
+        'connectivity': [1],
+        'origin': [0],
+        'data': [[[0, 1, 0, 0, 0, 0, 0, 0],
+                  [1, 1, 1, 0, 0, 0, 0, 0],
+                  [0, 1, 0, 0, 0, 1, 0, 0],
+                  [0, 0, 0, 1, 1, 1, 1, 0],
+                  [0, 0, 1, 1, 0, 1, 0, 0],
+                  [0, 1, 1, 1, 1, 1, 1, 0],
+                  [0, 0, 1, 0, 0, 1, 0, 0],
+                  [0, 0, 0, 0, 0, 0, 0, 0]],
+                 ],
+        'filter': ['binary_opening', 'binary_closing'],
         'output': [None, numpy.float32, numpy.int8]}
-    ))
-)
+    )
+))
 @testing.with_requires('scipy>=1.1.0')
 class TestBinaryOpeningAndClosing:
     def _filter(self, xp, scp, x):
@@ -196,7 +228,7 @@ class TestBinaryMorphologyTupleFootprint:
 
 @testing.parameterize(*(
     testing.product({
-        'x_dtype': [numpy.bool_, numpy.float64],
+        'x_dtype': [bool],
         'connectivity': [1, 2],
         'origin': [-1, 0, 1],
         'data': [[[0, 0, 0, 0, 0, 0, 0, 0],
@@ -223,6 +255,19 @@ class TestBinaryMorphologyTupleFootprint:
                   [0, 0, 1, 0, 0, 1, 1, 1],
                   [0, 0, 0, 0, 0, 0, 0, 0]],
                  ],
+        'output': [None]}
+    ) + testing.product({  # dtype and output combinations
+        'x_dtype': [numpy.bool_, numpy.float64],
+        'connectivity': [1],
+        'origin': [0],
+        'data': [[[0, 0, 0, 0, 0, 0, 0, 0],
+                  [0, 0, 0, 1, 1, 0, 0, 0],
+                  [0, 0, 1, 0, 0, 1, 0, 0],
+                  [0, 0, 1, 0, 0, 1, 0, 0],
+                  [0, 0, 1, 0, 0, 1, 0, 0],
+                  [0, 0, 0, 1, 1, 0, 0, 0],
+                  [0, 0, 0, 0, 0, 0, 0, 0]],
+                 ],
         'output': [None, numpy.float32, numpy.int8]}
     ))
 )
@@ -243,8 +288,8 @@ class TestBinaryFillHoles:
 
 
 @testing.parameterize(*(
-    testing.product({
-        'x_dtype': [numpy.bool_, numpy.float64],
+    testing.product({  # cases with boolean input and output
+        'x_dtype': [bool],
         'struct': ['same', 'separate'],
         'origins': [((0, 0), (0, 0)),
                     ((0, 1), (-1, 0))],
@@ -271,9 +316,23 @@ class TestBinaryFillHoles:
                   [0, 1, 1, 1, 1, 1, 1, 0],
                   [0, 0, 0, 0, 0, 0, 0, 0]],
                  ],
+        'output': [None]}
+    ) + testing.product({  # dtype and output combinations
+        'x_dtype': [numpy.bool_, numpy.float64],
+        'struct': ['same', 'separate'],
+        'origins': [((0, 0), (0, 0))],
+        'data': [[[0, 1, 0, 0, 1, 1, 1, 0],
+                  [1, 1, 1, 0, 0, 0, 0, 0],
+                  [0, 1, 0, 1, 1, 1, 1, 0],
+                  [0, 0, 1, 1, 1, 1, 1, 0],
+                  [0, 1, 1, 1, 0, 1, 1, 0],
+                  [0, 0, 0, 0, 1, 1, 1, 0],
+                  [0, 1, 1, 1, 1, 1, 1, 0],
+                  [0, 0, 0, 0, 0, 0, 0, 0]],
+                 ],
         'output': [None, numpy.float32, numpy.int8]}
-    ))
-)
+    )
+))
 @testing.with_requires('scipy')
 class TestBinaryHitOrMiss:
     def _filter(self, xp, scp, x):
@@ -302,8 +361,8 @@ class TestBinaryHitOrMiss:
 
 
 @testing.parameterize(*(
-    testing.product({
-        'x_dtype': [numpy.bool_, numpy.float64],
+    testing.product({  # cases with boolean input and output
+        'x_dtype': [bool],
         'border_value': [0, 1],
         'connectivity': [1, 2],
         'origin': [0, 1],
@@ -343,9 +402,33 @@ class TestBinaryHitOrMiss:
                   [0, 0, 0, 0, 0, 0, 0, 0],
                   [0, 0, 0, 0, 0, 0, 0, 0]],
                  ],
+        'output': [None]}
+    ) + testing.product({  # dtype and output combinations
+        'x_dtype': [numpy.bool_, numpy.float64],
+        'border_value': [0],
+        'connectivity': [1],
+        'origin': [0],
+        'mask': [[[0, 1, 0, 0, 0, 0, 0, 0],
+                  [0, 1, 1, 0, 0, 0, 0, 0],
+                  [0, 0, 1, 0, 0, 0, 0, 0],
+                  [0, 0, 0, 0, 0, 1, 0, 0],
+                  [0, 0, 0, 1, 1, 0, 0, 0],
+                  [0, 0, 1, 0, 0, 1, 0, 0],
+                  [0, 0, 0, 0, 0, 0, 0, 0],
+                  [0, 0, 0, 0, 0, 0, 0, 0]],
+                 ],
+        'data': [[[0, 1, 0, 0, 0, 0, 0, 0],
+                  [0, 0, 0, 0, 0, 0, 0, 0],
+                  [0, 0, 0, 0, 0, 0, 0, 0],
+                  [0, 0, 0, 0, 0, 0, 0, 0],
+                  [0, 0, 0, 0, 0, 0, 0, 0],
+                  [0, 1, 0, 0, 0, 0, 0, 0],
+                  [0, 0, 0, 0, 0, 0, 0, 0],
+                  [0, 0, 0, 0, 0, 0, 0, 0]],
+                 ],
         'output': [None, numpy.float32, numpy.int8]}
-    ))
-)
+    )
+))
 @testing.with_requires('scipy')
 class TestBinaryPropagation:
     def _filter(self, xp, scp, x):
@@ -365,18 +448,28 @@ class TestBinaryPropagation:
 
 
 @testing.parameterize(*(
-    testing.product({
-        'x_dtype': [numpy.int8, numpy.float32],
+    testing.product({  # cases with boolean input and output
+        'x_dtype': [bool],
         'border_value': [0, 1],
         'connectivity': [1, 2],
         'origin': [0, -1],
         'shape': [(64,), (16, 15), (5, 7, 9)],
         'density': [0.1, 0.5, 0.9],
         'filter': ['binary_erosion', 'binary_dilation'],
+        'iterations': [1],
+        'output': [None]}
+    ) + testing.product({
+        'x_dtype': [numpy.int8, numpy.float32],
+        'border_value': [0],
+        'connectivity': [1],
+        'origin': [0],
+        'shape': [(18, 13)],
+        'density': [0.2],
+        'filter': ['binary_erosion', 'binary_dilation'],
         'iterations': [1, 2, 0],
         'output': [None, numpy.float32, 'array']}
-    ))
-)
+    )
+))
 @testing.with_requires('scipy')
 class TestBinaryErosionAndDilation:
     def _filter(self, xp, scp, x):


### PR DESCRIPTION
The purpose of this MR is to refactor existing binary morphology tests from a single dense product over all parameters to 2 or 3 products over a small subset of the parameters. The functionality tested should be equivalent while reducing the total number of test cases run by an order of magnitude.

When running the morphology tests with `pytest` flag `-k Binary`, the number of tests that run is reduced from 4054 (before) to 412 (after).