### PR TITLE
Support ROCm 6

### DIFF
--- a/cupy_backends/cuda/api/_runtime_typedef.pxi
+++ b/cupy_backends/cuda/api/_runtime_typedef.pxi
@@ -138,9 +138,15 @@ cdef extern from *:
             int device
             void* devicePointer
             void* hostPointer
-    ELIF CUPY_HIP_VERSION > 0:
+    ELIF 0 < CUPY_HIP_VERSION < 600:
         ctypedef struct _PointerAttributes 'cudaPointerAttributes':
             int memoryType
+            int device
+            void* devicePointer
+            void* hostPointer
+    ELIF CUPY_HIP_VERSION >= 600:
+        ctypedef struct _PointerAttributes 'cudaPointerAttributes':
+            int type
             int device
             void* devicePointer
             void* hostPointer

--- a/cupy_backends/cuda/api/runtime.pyx
+++ b/cupy_backends/cuda/api/runtime.pyx
@@ -318,7 +318,6 @@ cpdef getDeviceProperties(int device):
         properties['clockInstructionRate'] = props.clockInstructionRate
         properties['maxSharedMemoryPerMultiProcessor'] = (
             props.maxSharedMemoryPerMultiProcessor)
-        properties['gcnArch'] = props.gcnArch
         properties['hdpMemFlushCntl'] = <intptr_t>(props.hdpMemFlushCntl)
         properties['hdpRegFlushCntl'] = <intptr_t>(props.hdpRegFlushCntl)
         properties['memPitch'] = props.memPitch
@@ -351,6 +350,8 @@ cpdef getDeviceProperties(int device):
         arch['has3dGrid'] = props.arch.has3dGrid
         arch['hasDynamicParallelism'] = props.arch.hasDynamicParallelism
         properties['arch'] = arch
+    IF CUPY_HIP_VERSION < 600: # removed in HIP 6.0.0
+        properties['gcnArch'] = props.gcnArch
     IF CUPY_HIP_VERSION >= 310:
         properties['gcnArchName'] = props.gcnArchName
         properties['asicRevision'] = props.asicRevision
@@ -720,12 +721,18 @@ cpdef PointerAttributes pointerGetAttributes(intptr_t ptr):
             <intptr_t>attrs.devicePointer,
             <intptr_t>attrs.hostPointer,
             attrs.type)
-    ELIF CUPY_HIP_VERSION > 0:
+    ELIF 0 < CUPY_HIP_VERSION < 600:
         return PointerAttributes(
             attrs.device,
             <intptr_t>attrs.devicePointer,
             <intptr_t>attrs.hostPointer,
             attrs.memoryType)
+    ELIF CUPY_HIP_VERSION >= 600:
+        return PointerAttributes(
+            attrs.device,
+            <intptr_t>attrs.devicePointer,
+            <intptr_t>attrs.hostPointer,
+            attrs.type)
     ELSE:  # for RTD
         return None
 

--- a/cupy_backends/hip/cupy_hip_runtime.h
+++ b/cupy_backends/hip/cupy_hip_runtime.h
@@ -270,6 +270,7 @@ cudaError_t cudaPointerGetAttributes(cudaPointerAttributes *attributes,
                                      const void* ptr) {
     cudaError_t status = hipPointerGetAttributes(attributes, ptr);
     if (status == cudaSuccess) {
+#if HIP_VERSION >= 600
         switch (attributes->type) {
             case 0 /* hipMemoryTypeHost */:
                 attributes->type = (hipMemoryType)1; /* cudaMemoryTypeHost */
@@ -277,6 +278,15 @@ cudaError_t cudaPointerGetAttributes(cudaPointerAttributes *attributes,
             case 1 /* hipMemoryTypeDevice */:
                 attributes->type = (hipMemoryType)2; /* cudaMemoryTypeDevice */
                 return status;
+#elif
+       switch (attributes->memoryType) {
+            case 0 /* hipMemoryTypeHost */:
+                attributes->memoryType = (hipMemoryType)1; /* cudaMemoryTypeHost */
+                return status;
+            case 1 /* hipMemoryTypeDevice */:
+                attributes->memoryType = (hipMemoryType)2; /* cudaMemoryTypeDevice */
+                return status;
+#endif
             default:
                 /* we don't care the rest of possibilities */
                 return status;

--- a/cupy_backends/hip/cupy_hip_runtime.h
+++ b/cupy_backends/hip/cupy_hip_runtime.h
@@ -270,12 +270,12 @@ cudaError_t cudaPointerGetAttributes(cudaPointerAttributes *attributes,
                                      const void* ptr) {
     cudaError_t status = hipPointerGetAttributes(attributes, ptr);
     if (status == cudaSuccess) {
-        switch (attributes->memoryType) {
+        switch (attributes->type) {
             case 0 /* hipMemoryTypeHost */:
-                attributes->memoryType = (hipMemoryType)1; /* cudaMemoryTypeHost */
+                attributes->type = (hipMemoryType)1; /* cudaMemoryTypeHost */
                 return status;
             case 1 /* hipMemoryTypeDevice */:
-                attributes->memoryType = (hipMemoryType)2; /* cudaMemoryTypeDevice */
+                attributes->type = (hipMemoryType)2; /* cudaMemoryTypeDevice */
                 return status;
             default:
                 /* we don't care the rest of possibilities */

--- a/install/cupy_builder/install_build.py
+++ b/install/cupy_builder/install_build.py
@@ -155,6 +155,11 @@ def get_compiler_setting(ctx: Context, use_hip):
         include_dirs.append(os.path.join(rocm_path, 'include', 'rocrand'))
         include_dirs.append(os.path.join(rocm_path, 'include', 'hiprand'))
         include_dirs.append(os.path.join(rocm_path, 'include', 'roctracer'))
+        include_dirs.append(os.path.join(rocm_path, 'include', 'hipblas'))
+        include_dirs.append(os.path.join(rocm_path, 'include', 'hipsparse'))
+        include_dirs.append(os.path.join(rocm_path, 'include', 'hipfft'))
+        include_dirs.append(os.path.join(rocm_path, 'include', 'rocsolver'))
+        include_dirs.append(os.path.join(rocm_path, 'include', 'rccl'))
         library_dirs.append(os.path.join(rocm_path, 'lib'))
 
     if use_hip:


### PR DESCRIPTION
ROCm 6 introduced various changes on its API. In particular,
* Removal of gcnarch from hipDeviceProp_t structure
* Renaming of ‘memoryType’ in hipPointerAttribute_t structure to ‘type’

This patch provides support on ROCm 6.0.0 and above.