### PR TITLE
cupyx: cleanup use of deprecated NumPy functionality (NumPy 2.0 compatibility)

### DIFF
--- a/cupy/_manipulation/kind.py
+++ b/cupy/_manipulation/kind.py
@@ -27,7 +27,7 @@ def asarray_chkfinite(a, dtype=None, order=None):
     return a
 
 
-def asfarray(a, dtype=cupy.float_):
+def asfarray(a, dtype=cupy.float64):
     """Converts array elements to float type.
 
     Args:
@@ -41,7 +41,7 @@ def asfarray(a, dtype=cupy.float_):
 
     """
     if not cupy.issubdtype(dtype, cupy.inexact):
-        dtype = cupy.float_
+        dtype = cupy.float64
     return cupy.asarray(a, dtype=dtype)
 
 

--- a/cupyx/scipy/_lib/_util.py
+++ b/cupyx/scipy/_lib/_util.py
@@ -68,6 +68,6 @@ def _asarray_validated(a, check_finite=True,
 
     if as_inexact:
         if not cupy.issubdtype(a, cupy.inexact):
-            a = a.astype(dtype=cupy.float_)
+            a = a.astype(dtype=cupy.float64)
 
     return a

--- a/cupyx/scipy/interpolate/_bspline.py
+++ b/cupyx/scipy/interpolate/_bspline.py
@@ -319,7 +319,7 @@ def _make_design_matrix(x, t, k, extrapolate, indices):
                   (t, None, k, 0, x, intervals, None, bspline_basis, 0, 0,
                    x.shape[0]))
 
-    data = cupy.zeros(x.shape[0] * (k + 1), dtype=cupy.float_)
+    data = cupy.zeros(x.shape[0] * (k + 1), dtype=cupy.float64)
     design_mat_kernel = _get_module_func(
         DESIGN_MAT_MODULE, 'compute_design_matrix', indices)
     design_mat_kernel(((x.shape[0] + 128 - 1) // 128,), (128,),
@@ -733,7 +733,7 @@ class BSpline:
 
         x = cupy.asarray(x)
         x_shape, x_ndim = x.shape, x.ndim
-        x = cupy.ascontiguousarray(cupy.ravel(x), dtype=cupy.float_)
+        x = cupy.ascontiguousarray(cupy.ravel(x), dtype=cupy.float64)
 
         # With periodic extrapolation we map x to the segment
         # [self.t[k], self.t[n]].
@@ -903,7 +903,7 @@ class BSpline:
 
             if n_periods > 0:
                 # Evaluate the difference of antiderivatives.
-                x = cupy.asarray([ts, te], dtype=cupy.float_)
+                x = cupy.asarray([ts, te], dtype=cupy.float64)
                 _evaluate_spline(ta, ca.reshape(ca.shape[0], -1),
                                  ka, x, 0, False, out)
                 integral = out[1] - out[0]
@@ -919,23 +919,23 @@ class BSpline:
             # If b <= te then we need to integrate over [a, b], otherwise
             # over [a, te] and from xs to what is remained.
             if b <= te:
-                x = cupy.asarray([a, b], dtype=cupy.float_)
+                x = cupy.asarray([a, b], dtype=cupy.float64)
                 _evaluate_spline(ta, ca.reshape(ca.shape[0], -1),
                                  ka, x, 0, False, out)
                 integral += out[1] - out[0]
             else:
-                x = cupy.asarray([a, te], dtype=cupy.float_)
+                x = cupy.asarray([a, te], dtype=cupy.float64)
                 _evaluate_spline(ta, ca.reshape(ca.shape[0], -1),
                                  ka, x, 0, False, out)
                 integral += out[1] - out[0]
 
-                x = cupy.asarray([ts, ts + b - te], dtype=cupy.float_)
+                x = cupy.asarray([ts, ts + b - te], dtype=cupy.float64)
                 _evaluate_spline(ta, ca.reshape(ca.shape[0], -1),
                                  ka, x, 0, False, out)
                 integral += out[1] - out[0]
         else:
             # Evaluate the difference of antiderivatives.
-            x = cupy.asarray([a, b], dtype=cupy.float_)
+            x = cupy.asarray([a, b], dtype=cupy.float64)
             _evaluate_spline(ta, ca.reshape(ca.shape[0], -1),
                              ka, x, 0, extrapolate, out)
             integral = out[1] - out[0]

--- a/cupyx/scipy/interpolate/_interpolate.py
+++ b/cupyx/scipy/interpolate/_interpolate.py
@@ -868,9 +868,9 @@ class _PPolyBase:
     def _get_dtype(self, dtype):
         if (cupy.issubdtype(dtype, cupy.complexfloating)
                 or cupy.issubdtype(self.c.dtype, cupy.complexfloating)):
-            return cupy.complex_
+            return cupy.complex128
         else:
-            return cupy.float_
+            return cupy.float64
 
     @classmethod
     def construct_fast(cls, c, x, extrapolate=None, axis=0):
@@ -1014,7 +1014,7 @@ class _PPolyBase:
             extrapolate = self.extrapolate
         x = cupy.asarray(x)
         x_shape, x_ndim = x.shape, x.ndim
-        x = cupy.ascontiguousarray(x.ravel(), dtype=cupy.float_)
+        x = cupy.ascontiguousarray(x.ravel(), dtype=cupy.float64)
 
         # With periodic extrapolation we map x to the segment
         # [self.x[0], self.x[-1]].
@@ -1927,9 +1927,9 @@ class BPoly(_PPolyBase):
         dta, dtb = ya.dtype, yb.dtype
         if (cupy.issubdtype(dta, cupy.complexfloating) or
                 cupy.issubdtype(dtb, cupy.complexfloating)):
-            dt = cupy.complex_
+            dt = cupy.complex128
         else:
-            dt = cupy.float_
+            dt = cupy.float64
 
         na, nb = len(ya), len(yb)
         n = na + nb
@@ -2049,9 +2049,9 @@ class NdPPoly:
     def _get_dtype(self, dtype):
         if (cupy.issubdtype(dtype, cupy.complexfloating)
                 or cupy.issubdtype(self.c.dtype, cupy.complexfloating)):
-            return cupy.complex_
+            return cupy.complex128
         else:
-            return cupy.float_
+            return cupy.float64
 
     def _ensure_c_contiguous(self):
         if not self.c.flags.c_contiguous:

--- a/cupyx/scipy/interpolate/_polyint.py
+++ b/cupyx/scipy/interpolate/_polyint.py
@@ -128,10 +128,10 @@ class _Interpolator1D:
     def _set_dtype(self, dtype, union=False):
         if cupy.issubdtype(dtype, cupy.complexfloating) \
                 or cupy.issubdtype(self.dtype, cupy.complexfloating):
-            self.dtype = cupy.complex_
+            self.dtype = cupy.complex128
         else:
-            if not union or self.dtype != cupy.complex_:
-                self.dtype = cupy.float_
+            if not union or self.dtype != cupy.complex128:
+                self.dtype = cupy.float64
 
 
 class _Interpolator1DWithDerivatives(_Interpolator1D):
@@ -234,7 +234,7 @@ class BarycentricInterpolator(_Interpolator1D):
     def __init__(self, xi, yi=None, axis=0):
         _Interpolator1D.__init__(self, xi, yi, axis)
 
-        self.xi = xi.astype(cupy.float_)
+        self.xi = xi.astype(cupy.float64)
         self.set_yi(yi)
         self.n = len(self.xi)
 
@@ -423,7 +423,7 @@ class KroghInterpolator(_Interpolator1DWithDerivatives):
     def __init__(self, xi, yi, axis=0):
         _Interpolator1DWithDerivatives.__init__(self, xi, yi, axis)
 
-        self.xi = xi.astype(cupy.float_)
+        self.xi = xi.astype(cupy.float64)
         self.yi = self._reshape_yi(yi)
         self.n, self.r = self.yi.shape
 

--- a/cupyx/scipy/ndimage/_interpolation.py
+++ b/cupyx/scipy/ndimage/_interpolation.py
@@ -552,7 +552,8 @@ def rotate(input, angle, axes=(1, 0), reshape=True, output=None, order=3,
         out_bounds = rot_matrix @ [[0, 0, iy, iy],
                                    [0, ix, 0, ix]]
         # Compute the shape of the transformed input plane
-        out_plane_shape = (out_bounds.ptp(axis=1) + 0.5).astype(cupy.int64)
+        out_plane_shape = (numpy.ptp(out_bounds, axis=1) +
+                           0.5).astype(cupy.int64)
     else:
         out_plane_shape = img_shape[axes]
 

--- a/cupyx/scipy/ndimage/_util.py
+++ b/cupyx/scipy/ndimage/_util.py
@@ -1,7 +1,5 @@
 import warnings
 
-import numpy
-
 import cupy
 
 
@@ -53,8 +51,8 @@ def _get_output(output, input, shape=None, complex_output=False):
             output = cupy.promote_types(output, cupy.complex64)
         output = cupy.empty(shape, dtype=output)
     elif isinstance(output, str):
-        output = numpy.sctypeDict[output]
-        if complex_output and cupy.dtype(output).kind != 'c':
+        output = cupy.dtype(output)
+        if complex_output and output.kind != 'c':
             raise RuntimeError("output must have complex dtype")
         output = cupy.empty(shape, dtype=output)
     elif output.shape != shape:

--- a/cupyx/scipy/signal/_iir_filter_conversions.py
+++ b/cupyx/scipy/signal/_iir_filter_conversions.py
@@ -85,15 +85,15 @@ def _align_nums(nums):
 
 def _polycoeffs_from_zeros(zeros, tol=10):
     # a clone of numpy.poly, simplified
-    dtyp = (cupy.complex_
+    dtyp = (cupy.complex128
             if cupy.issubdtype(zeros.dtype, cupy.complexfloating)
-            else cupy.float_)
+            else cupy.float64)
     a = cupy.ones(1, dtype=dtyp)
     for z in zeros:
         a = cupy.convolve(a, cupy.r_[1, -z], mode='full')
 
     # Use real output if possible.
-    if dtyp == cupy.complex_:
+    if dtyp == cupy.complex128:
         mask = cupy.abs(a.imag) < tol * cupy.finfo(a.dtype).eps
         a.imag[mask] = 0.0
         if mask.shape[0] == a.shape[0]:

--- a/cupyx/scipy/signal/_waveforms.py
+++ b/cupyx/scipy/signal/_waveforms.py
@@ -532,7 +532,7 @@ def chirp(t, f0, t1, f1, method="linear", phi=0, vertex_zero=True):
     """
     t = cupy.asarray(t)
 
-    if cupy.issubdtype(t.dtype, cupy.int_):
+    if cupy.issubdtype(t.dtype, cupy.integer):
         t = t.astype(cupy.float64)
 
     phi *= np.pi / 180
@@ -542,9 +542,11 @@ def chirp(t, f0, t1, f1, method="linear", phi=0, vertex_zero=True):
         if type == "real":
             return _chirp_phase_lin_kernel_real(t, f0, t1, f1, phi)
         elif type == "complex":
-            phase = cupy.empty(t.shape, dtype=cupy.complex64)
-            if np.issubclass_(t.dtype, (np.float64)):
+            # type hard-coded to 'real' above, so this code path is never used
+            if t.real.dtype.kind == 'f' and t.dtype.itemsize == 8:
                 phase = cupy.empty(t.shape, dtype=cupy.complex128)
+            else:
+                phase = cupy.empty(t.shape, dtype=cupy.complex64)
             _chirp_phase_lin_kernel_cplx(t, f0, t1, f1, phi, phase)
             return phase
         else:


### PR DESCRIPTION
This MR has some minor housekeeping changes, mostly in `cupyx.scipy` modules so they are not using functionality deprecated for NumPy 2.0.

This should complement the changes being made by @ev-br in #8314

related to #8306
