### PR TITLE
Match numpy sign semantics

### DIFF
--- a/cupy/_math/misc.py
+++ b/cupy/_math/misc.py
@@ -221,10 +221,12 @@ fabs = _core.create_ufunc(
 
 _unsigned_sign = 'out0 = in0 > 0'
 _complex_sign = '''
-if (in0.real() == 0) {
-  out0 = (in0.imag() > 0) - (in0.imag() < 0);
+if (isnan(in0)) {
+  out0 = nan("");
+} else if (in0.real() == 0) {
+  out0 = (in0.imag() > 0) ? 1 : (in0.imag() < 0) ? -1 : 0;
 } else {
-  out0 = (in0.real() > 0) - (in0.real() < 0);
+  out0 = (in0.real() > 0) ? 1 : (in0.real() < 0) ? -1 : 0;
 }
 '''
 sign = _core.create_ufunc(
@@ -233,10 +235,17 @@ sign = _core.create_ufunc(
      'i->i', ('I->I', _unsigned_sign), 'l->l', ('L->L', _unsigned_sign),
      'q->q', ('Q->Q', _unsigned_sign), 'e->e', 'f->f', 'd->d',
      ('F->F', _complex_sign), ('D->D', _complex_sign)),
-    'out0 = (in0 > 0) - (in0 < 0)',
+    '''
+    out0 = (in0 > 0) ? static_cast<out0_type>(1)
+         : (in0 < 0) ? static_cast<out0_type>(-1)
+         : (in0 == 0) ? static_cast<out0_type>(0)
+         : in0
+    ''',
     doc='''Elementwise sign function.
 
     It returns -1, 0, or 1 depending on the sign of the input.
+
+    nan is returned for nan inputs.
 
     .. seealso:: :data:`numpy.sign`
 

--- a/cupy/_math/misc.py
+++ b/cupy/_math/misc.py
@@ -224,9 +224,9 @@ _complex_sign = '''
 if (isnan(in0)) {
   out0 = nan("");
 } else if (in0.real() == 0) {
-  out0 = (in0.imag() > 0) ? 1 : (in0.imag() < 0) ? -1 : 0;
+  out0 = (in0.imag() > 0) - (in0.imag() < 0);
 } else {
-  out0 = (in0.real() > 0) ? 1 : (in0.real() < 0) ? -1 : 0;
+  out0 = (in0.real() > 0) - (in0.real() < 0);
 }
 '''
 sign = _core.create_ufunc(

--- a/tests/cupy_tests/math_tests/test_misc.py
+++ b/tests/cupy_tests/math_tests/test_misc.py
@@ -183,6 +183,9 @@ class TestMisc:
     def test_sign_negative(self):
         self.check_unary_negative('sign', no_bool=True)
 
+    def test_sign_inf_nan(self):
+        self.check_unary_inf_nan('sign')
+
     def test_maximum(self):
         self.check_binary('maximum')
 


### PR DESCRIPTION
Here is my first pass at modifying the `sign` function to match `numpy`'s NaN semantics. It includes a test case using `check_unary_inf_nan`. This is to fix  #8327

I've confirmed that the tests pass on v12, and have rebased to main, but am currently having build difficulties on main, so this is a draft for now.

The non-complex logic is based directly on numpy's logic. The static_casts are there to avoid a compiler error about ambiguous int casting for the ternary operator when the template is used with integer types.
