### PR TITLE
add axes support in ndimage filters module

### DIFF
--- a/cupyx/scipy/ndimage/_filters.py
+++ b/cupyx/scipy/ndimage/_filters.py
@@ -332,13 +332,12 @@ def gaussian_filter1d(input, sigma, axis=-1, order=0, output=None,
 
     .. note::
         The Gaussian kernel will have size ``2*radius + 1`` along each axis. If
-       `radius` is None, a default ``radius = round(truncate * sigma)`` will be
-        used.
+        `radius` is None, a default ``radius = round(truncate * sigma)`` will
+        be used.
 
         When the output data type is integral (or when no output is provided
         and input is integral) the results may not perfectly match the results
         from SciPy due to floating-point rounding of intermediate results.
-
     """
     radius = int(float(truncate) * float(sigma) + 0.5)
     weights_dtype = _util._init_weights_dtype(input)
@@ -392,13 +391,12 @@ def gaussian_filter(input, sigma, order=0, output=None, mode="reflect",
 
     .. note::
         The Gaussian kernel will have size ``2*radius + 1`` along each axis. If
-       `radius` is None, a default ``radius = round(truncate * sigma)`` will be
-        used.
+        `radius` is None, a default ``radius = round(truncate * sigma)`` will
+        be used.
 
         When the output data type is integral (or when no output is provided
         and input is integral) the results may not perfectly match the results
         from SciPy due to floating-point rounding of intermediate results.
-
     """
     axes = _util._check_axes(axes, input.ndim)
     num_axes = len(axes)

--- a/cupyx/scipy/ndimage/_filters.py
+++ b/cupyx/scipy/ndimage/_filters.py
@@ -338,6 +338,7 @@ def gaussian_filter1d(input, sigma, axis=-1, order=0, output=None,
         When the output data type is integral (or when no output is provided
         and input is integral) the results may not perfectly match the results
         from SciPy due to floating-point rounding of intermediate results.
+
     """
     radius = int(float(truncate) * float(sigma) + 0.5)
     weights_dtype = _util._init_weights_dtype(input)
@@ -397,6 +398,7 @@ def gaussian_filter(input, sigma, order=0, output=None, mode="reflect",
         When the output data type is integral (or when no output is provided
         and input is integral) the results may not perfectly match the results
         from SciPy due to floating-point rounding of intermediate results.
+
     """
     axes = _util._check_axes(axes, input.ndim)
     num_axes = len(axes)

--- a/cupyx/scipy/ndimage/_filters.py
+++ b/cupyx/scipy/ndimage/_filters.py
@@ -858,7 +858,7 @@ def _min_or_max_filter(input, size, ftprnt, structure, output, mode, cval,
         fltr = minimum_filter1d if func == 'min' else maximum_filter1d
         return _filters_core._run_1d_filters(
             [fltr if size > 1 else None for size in sizes],
-            input, axes, sizes, output, modes, cval, origin)
+            input, axes, sizes, output, modes, cval, origins)
 
     if structure is not None and structure.ndim != input.ndim:
         raise RuntimeError('structure array has incorrect shape')

--- a/cupyx/scipy/ndimage/_filters.py
+++ b/cupyx/scipy/ndimage/_filters.py
@@ -401,6 +401,14 @@ def gaussian_filter(input, sigma, order=0, output=None, mode="reflect",
     axes = _util._check_axes(axes, input.ndim)
     num_axes = len(axes)
     sigmas = _util._fix_sequence_arg(sigma, num_axes, 'sigma', float)
+    sigma_threshold = 1e-15
+    if num_axes == 0 or all(s < sigma_threshold for s in sigmas):
+        if output is None:
+            return input.copy()
+        else:
+            output = _util._get_output(output, input)
+            output[:] = input
+            return output
     orders = _util._fix_sequence_arg(order, num_axes, 'order', int)
     modes = _util._fix_sequence_arg(mode, num_axes, 'mode', str)
     radiuses = _util._fix_sequence_arg(radius, num_axes, 'radius')

--- a/cupyx/scipy/ndimage/_filters.py
+++ b/cupyx/scipy/ndimage/_filters.py
@@ -410,6 +410,8 @@ def gaussian_filter(input, sigma, order=0, output=None, mode="reflect",
     # omit any axes with sigma ~= 0.0
     params = [(axes[ii], sigmas[ii], orders[ii], modes[ii], radiuses[ii])
               for ii in range(num_axes) if sigmas[ii] > 1e-15]
+    # update arguments in case any were filtered out due to sigma ~= 0.0
+    axes, sigmas, orders, modes, radiuses = zip(*params)
 
     def get(param):
         _, sigma, order, _, radius = param

--- a/cupyx/scipy/ndimage/_morphology.py
+++ b/cupyx/scipy/ndimage/_morphology.py
@@ -67,12 +67,13 @@ def _get_binary_erosion_kernel(
         name += '_invert'
     has_weights = not all_weights_nonzero
 
+    modes = ('constant',) * len(w_shape)
     return _filters_core._generate_nd_kernel(
         name,
         pre,
         found,
         '',
-        'constant', w_shape, int_type, offsets, 0, ctype='Y',
+        modes, w_shape, int_type, offsets, 0, ctype='Y',
         has_weights=has_weights, has_structure=False, has_mask=masked,
         binary_morphology=True)
 
@@ -681,7 +682,7 @@ def grey_erosion(input, size=None, footprint=None, structure=None, output=None,
         raise ValueError('size, footprint or structure must be specified')
 
     return _filters._min_or_max_filter(input, size, footprint, structure,
-                                       output, mode, cval, origin, 'min')
+                                       output, mode, cval, origin, 'min', None)
 
 
 def grey_dilation(input, size=None, footprint=None, structure=None,
@@ -741,7 +742,7 @@ def grey_dilation(input, size=None, footprint=None, structure=None,
             origin[i] -= 1
 
     return _filters._min_or_max_filter(input, size, footprint, structure,
-                                       output, mode, cval, origin, 'max')
+                                       output, mode, cval, origin, 'max', None)
 
 
 def grey_closing(input, size=None, footprint=None, structure=None,

--- a/cupyx/scipy/ndimage/_util.py
+++ b/cupyx/scipy/ndimage/_util.py
@@ -1,6 +1,9 @@
+import operator
 import warnings
+from collections.abc import Iterable
 
 import cupy
+from cupy import AxisError
 
 
 def _is_integer_output(output, input):
@@ -89,6 +92,25 @@ def _check_mode(mode):
         msg = f'boundary mode not supported (actual: {mode})'
         raise RuntimeError(msg)
     return mode
+
+
+def _check_axes(axes, ndim):
+    if axes is None:
+        return tuple(range(ndim))
+    elif cupy.isscalar(axes):
+        axes = (operator.index(axes),)
+    elif isinstance(axes, Iterable):
+        for ax in axes:
+            axes = tuple(operator.index(ax) for ax in axes)
+            if ax < -ndim or ax > ndim - 1:
+                raise AxisError(f"specified axis: {ax} is out of range")
+        axes = tuple(ax % ndim if ax < 0 else ax for ax in axes)
+    else:
+        message = "axes must be an integer, iterable of integers, or None"
+        raise ValueError(message)
+    if len(tuple(set(axes))) != len(axes):
+        raise ValueError("axes must be unique")
+    return axes
 
 
 def _get_inttype(input):

--- a/cupyx/scipy/signal/_bsplines.py
+++ b/cupyx/scipy/signal/_bsplines.py
@@ -69,8 +69,9 @@ def sepfir2d(input, hrow, hcol):
     hrow = hrow.astype(dtype, copy=False)
     hcol = hcol.astype(dtype, copy=False)
     filters = (hcol[::-1].conj(), hrow[::-1].conj())
+    axes = (0, 1)
     return cupyx.scipy.ndimage._filters._run_1d_correlates(
-        input, (0, 1), lambda i: filters[i], None, 'reflect', 0)
+        input, axes, (0, 1), lambda i: filters[i], None, 'reflect', 0)
 
 
 def _quadratic(x):

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
@@ -116,10 +116,8 @@ class FilterTestCaseBase:
 
         if self.filter in ('minimum_filter', 'maximum_filter', 'median_filter',
                            'rank_filter', 'percentile_filter'):
-            if not hasattr(self, "axes"):
-                self.axes = None
 
-            if self.axes is None:
+            if getattr(self, "axes", None) is None:
                 num_axes = len(self.shape)
             else:
                 if numpy.isscalar(self.axes):
@@ -130,7 +128,7 @@ class FilterTestCaseBase:
                     self.ksize = self.ksize[:num_axes]
                 return self.ksize
             # generate footprint with same number of dimensions as axes
-            if self.axes is None:
+            if getattr(self, "axes", None) is None:
                 kshape = self._kshape[:self._ndim]
             else:
                 kshape = [self._kshape[ax] for ax in self.axes]
@@ -157,13 +155,11 @@ class FilterTestCaseBase:
             return self.ksize
 
         if self.filter == 'uniform_filter':
-            if not hasattr(self, "axes"):
-                self.axes = None
-            elif numpy.isscalar(self.axes):
-                self.axes = (self.axes,)
-            if self.axes is None:
+            if getattr(self, "axes", None) is None:
                 kshape = self._kshape[:self._ndim]
             else:
+                if numpy.isscalar(self.axes):
+                    self.axes = (self.axes,)
                 kshape = [self._kshape[ax] for ax in self.axes]
             return kshape
 

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
@@ -441,11 +441,11 @@ class TestFilterFastAxes(FilterTestCaseBase):
             return
         if self.ksize != 3:
             return
-        invalids = [(25, (1, 3, 4, 5)),
-                    (50, (3, 4, 5)),
-                    (-25, (1, 3, 4, 5))]
-        if (self.percentile, self.shape) in invalids:
-            pytest.xfail('ROCm/HIP may have a bug')
+        # TODO: run on HIP to see if any specific cases need to be skipped
+        # (as done for TestFilterFast)
+        # invalids = [(15, (3, 4, 5, 6))]
+        # if (self.percentile, self.shape) in invalids:
+        #     pytest.xfail('ROCm/HIP may have a bug')
 
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
     def test_filter(self, xp, scp):

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
@@ -115,10 +115,37 @@ class FilterTestCaseBase:
             return testing.shaped_random((self.ksize,), xp, self._dtype)
 
         if self.filter in ('minimum_filter', 'maximum_filter', 'median_filter',
-                           'rank_filter', 'percentile_filter', 'generic_filter'
-                           ):
+                           'rank_filter', 'percentile_filter'):
+            if not hasattr(self, "axes"):
+                self.axes = None
+
+            if self.axes is None:
+                num_axes = len(self.shape)
+            else:
+                if numpy.isscalar(self.axes):
+                    self.axes = (self.axes,)
+                num_axes = len(self.axes)
+            if not self.footprint:
+                if isinstance(self.ksize, tuple):
+                    self.ksize = self.ksize[:num_axes]
+                return self.ksize
+            # generate footprint with same number of dimensions as axes
+            if self.axes is None:
+                kshape = self._kshape[:self._ndim]
+            else:
+                kshape = [self._kshape[ax] for ax in self.axes]
+            footprint = testing.shaped_random(kshape, xp, scale=1) > 0.5
+            if not footprint.any():
+                footprint = xp.ones(kshape)
+            if not isinstance(self.mode, str):
+                # need single mode, not sequence if footprint is non-separable
+                self.mode = self.mode[0]
+            return None, footprint
+
+        if self.filter in ('generic_filter',):
             if not self.footprint:
                 return self.ksize
+            # generate footprint with same number of dimensions as axes
             kshape = self._kshape
             footprint = testing.shaped_random(kshape, xp, scale=1) > 0.5
             if not footprint.any():
@@ -130,7 +157,15 @@ class FilterTestCaseBase:
             return self.ksize
 
         if self.filter == 'uniform_filter':
-            return self._kshape
+            if not hasattr(self, "axes"):
+                self.axes = None
+            elif numpy.isscalar(self.axes):
+                self.axes = (self.axes,)
+            if self.axes is None:
+                kshape = self._kshape[:self._ndim]
+            else:
+                kshape = [self._kshape[ax] for ax in self.axes]
+            return kshape
 
         # gaussian_filter*, prewitt, sobel, *laplace, and *_gradient_magnitude
         # all have no 'weights' or similar argument so return None
@@ -283,14 +318,8 @@ def dummy_deriv_func(input, axis, output, mode, cval, *args, **kwargs):
             'sigma': [1.5, 2],
             'truncate': [2.75, 4],
         }) + testing.product({
-            'filter': ['gaussian_filter'],
-            'sigma': [1.5, 2.25, (1.5, 2.25, 1.0, 3.0)],
-            'radius': [None, 2, (1, 2, 3, 4)],
-            'mode': [('reflect', 'nearest', 'mirror', 'wrap')],
-            'axes': [None, (0, -1)],
-            'truncate': [2.75, 4],
-        }) + testing.product({
-            'filter': ['gaussian_laplace', 'gaussian_gradient_magnitude'],
+            'filter': ['gaussian_filter', 'gaussian_laplace',
+                       'gaussian_gradient_magnitude'],
             'sigma': [1.5, 2.25, (1.5, 2.25, 1.0, 3.0)],
             'truncate': [2.75, 4],
         }) + testing.product({
@@ -337,6 +366,99 @@ class TestFilterFast(FilterTestCaseBase):
 
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
     def test_filter(self, xp, scp):
+        self._hip_skip_invalid_condition()
+        return self._filter(xp, scp)
+
+
+# Check cases with various axes and axis-specific args
+@testing.parameterize(*(
+    testing.product_dict(
+        testing.product({
+            'filter': ['gaussian_filter'],
+            'sigma': [1.5, 2.25, (1.5, 2.25, 1.0, 3.0)],
+            'radius': [None, 2, (1, 2, 3, 4)],
+            'mode': [('reflect', 'nearest', 'mirror', 'wrap')],
+            'truncate': [2.75],
+        }) +
+        testing.product({
+            'filter': ['rank_filter'],
+            'rank': [0, 2, -1],
+            'origin': [0, (0, 1, 1, 0)],
+            'footprint': [False, True],
+        }) +
+        testing.product({
+            'filter': ['percentile_filter'],
+            'percentile': [15],
+            'origin': [0, (0, 1, 1, 0)],
+            'footprint': [False, True],
+        }) +
+        testing.product({
+            'filter': ['median_filter'],
+            'origin': [0, (0, 1, 1, 0)],
+            'footprint': [False, True],
+        }) +
+        # min/max with ksize -> tests separable rectangular footprint
+        testing.product({
+            'filter': ['maximum_filter', 'minimum_filter'],
+            'origin': [0, (0, 1, 1, 0)],
+            'ksize': [(3, 3, 4, 5)],
+            'mode': [('reflect', 'nearest', 'mirror', 'wrap')],
+            'cval': [0, 2],
+            'footprint': [False],
+        }) +
+        # min/max with kshape -> tests non-separable footprint
+        testing.product({
+            'filter': ['maximum_filter', 'minimum_filter'],
+            'origin': [0, (0, 1, 1, 0)],
+            'kshape': [(3, 5, 3, 5)],
+            'mode': ['reflect'],
+            'cval': [0, 2],
+            'footprint': [True],
+        }) +
+        testing.product({
+            'filter': ['uniform_filter'],
+            'origin': [0, (0, 1, 1, 0)],
+            'kshape': [(3, 5, 3, 5)],
+            'mode': [('reflect', 'nearest', 'mirror', 'wrap')],
+            'cval': [0, 2],
+        }),
+        # common arguments for all filters to test axes
+        testing.product({
+            'shape': [(4, 5), (6, 4, 5), (3, 4, 5, 6)],
+            'dtype': [numpy.uint8, numpy.float64],
+            'output': [numpy.float64],
+            'axes': [None, (0, -1), (1,), 0],
+        })
+    )
+))
+@testing.with_requires('scipy>=1.11')
+class TestFilterFastAxes(FilterTestCaseBase):
+
+    def _hip_skip_invalid_condition(self):
+        if not runtime.is_hip:
+            return
+        if self.filter != 'percentile_filter':
+            return
+        if self.ksize != 3:
+            return
+        invalids = [(25, (1, 3, 4, 5)),
+                    (50, (3, 4, 5)),
+                    (-25, (1, 3, 4, 5))]
+        if (self.percentile, self.shape) in invalids:
+            pytest.xfail('ROCm/HIP may have a bug')
+
+    @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
+    def test_filter(self, xp, scp):
+        if (
+            self.filter in ('minimum_filter', 'maximum_filter')
+            and isinstance(self.origin, tuple)
+            and hasattr(self, "kshape")
+        ):
+            pytest.skip(
+                "SciPy bug in minimum_filter and maximum_filter for tuple "
+                "origin and nonseparable footprint "
+                "(https://github.com/scipy/scipy/issues/20652)."
+            )
         self._hip_skip_invalid_condition()
         return self._filter(xp, scp)
 
@@ -766,26 +888,6 @@ class TestSpecialCases1D(FilterTestCaseBase):
                                  accept_error=RuntimeError)
     def test_0_dim(self, xp, scp):
         self.ksize = 0
-        return self._filter(xp, scp)
-
-
-# Tests special weights (1D)
-@testing.parameterize(*testing.product({
-    'filter': ['uniform_filter'],
-    'shape': [(15, 13), (7, 8, 9)],
-    'kshape': [(3, 4, 5)],
-    'axes': [None, 1, (0,), (-2, -1)],
-    'dtype': [numpy.float64],
-    'mode': ['reflect', 'nearest', ('constant', 'wrap', 'mirror')],
-    'cval': [0, 2],
-}))
-@testing.with_requires('scipy')
-class TestUniformFilterAxes(FilterTestCaseBase):
-    @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp',
-                                 accept_error=RuntimeError)
-    def test_axes(self, xp, scp):
-        if isinstance(self.kshape, tuple):
-            self.kshape = self.kshape[:len(self.shape)]
         return self._filter(xp, scp)
 
 


### PR DESCRIPTION
This MR updates several `cupyx.scipy.ndimage` filters with support for the `axes` arguments that was added in SciPy 1.11.