### PR TITLE
MAINT: interpolate: update RBF to scipy 1.13

### DIFF
--- a/cupyx/scipy/interpolate/_rbfinterp.py
+++ b/cupyx/scipy/interpolate/_rbfinterp.py
@@ -641,7 +641,7 @@ class RBFInterpolator:
             degree = int(degree)
             if degree < -1:
                 raise ValueError("`degree` must be at least -1.")
-            elif degree < min_degree:
+            elif -1 < degree < min_degree:
                 warnings.warn(
                     f"`degree` should not be below {min_degree} when `kernel` "
                     f"is '{kernel}'. The interpolant may not be uniquely "

--- a/tests/cupyx_tests/scipy_tests/interpolate_tests/test_rbfinterp.py
+++ b/tests/cupyx_tests/scipy_tests/interpolate_tests/test_rbfinterp.py
@@ -386,7 +386,8 @@ class _TestRBFInterpolator:
 
     @testing.numpy_cupy_allclose(scipy_name='scp', accept_error=UserWarning)
     @pytest.mark.parametrize('kernel',
-                             [kl for kl in _NAME_TO_MIN_DEGREE])
+                             [kl for kl in _NAME_TO_MIN_DEGREE
+                              if _NAME_TO_MIN_DEGREE[kl] >= 1])
     def test_degree_warning(self, xp, scp, kernel):
         y = xp.linspace(0, 1, 5)[:, None]
         d = xp.zeros(5)
@@ -394,6 +395,15 @@ class _TestRBFInterpolator:
         with warnings.catch_warnings():
             warnings.simplefilter("error")
             self.build(scp, y, d, epsilon=1.0, kernel=kernel, degree=deg-1)
+
+    @pytest.mark.parametrize('kernel', [kl for kl in _NAME_TO_MIN_DEGREE])
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_minus_one_degree(self, xp, scp, kernel):
+        # Make sure a degree of -1 is accepted without any warning.
+        y = xp.linspace(0, 1, 5)[:, None]
+        d = xp.zeros(5)
+        f = self.build(scp, y, d, epsilon=1.0, kernel=kernel, degree=-1)
+        return f(y)
 
     @testing.numpy_cupy_allclose(scipy_name='scp', accept_error=LinAlgError)
     def test_rank_error(self, xp, scp):


### PR DESCRIPTION
Sync the RBF implementation with scipy 1.13, which removed a spurious warning in a corner case. See https://github.com/scipy/scipy/pull/20364 for the discussion.