### PR TITLE
make CuPy import under NumPy 2.0

### DIFF
--- a/.github/workflows/pretest.yml
+++ b/.github/workflows/pretest.yml
@@ -41,6 +41,7 @@ jobs:
         # TODO: Test against various NumPy/SciPy versions.
         pip install 'numpy==1.25.*' 'scipy==1.10.*'
         pip install 'mypy==1.5.*' 'types-setuptools==57.4.14' 'pytest>=7.2'
+        sed -i s/error::cupy.exceptions./error::numpy./ setup.cfg  # Because no cupy here. See cupy#8346
         pytest -v tests/typing_tests/test_typing.py
 
   build-cuda:

--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -133,8 +133,6 @@ from numpy import uint64  # NOQA
 from numpy import half  # NOQA
 from numpy import single  # NOQA
 from numpy import double  # NOQA
-from numpy import float_  # NOQA
-from numpy import longfloat  # NOQA
 from numpy import float16  # NOQA
 from numpy import float32  # NOQA
 from numpy import float64  # NOQA
@@ -147,10 +145,7 @@ from numpy import float64  # NOQA
 # Complex floating-point numbers
 # -----------------------------------------------------------------------------
 from numpy import csingle  # NOQA
-from numpy import singlecomplex  # NOQA
 from numpy import cdouble  # NOQA
-from numpy import cfloat  # NOQA
-from numpy import complex_  # NOQA
 from numpy import complex64  # NOQA
 from numpy import complex128  # NOQA
 
@@ -361,23 +356,17 @@ def result_type(*arrays_and_dtypes):
 
 from cupy._core.core import min_scalar_type  # NOQA
 
-from numpy import obj2sctype  # NOQA
 from numpy import promote_types  # NOQA
 
 from numpy import dtype  # NOQA
-from numpy import format_parser  # NOQA
 
 from numpy import finfo  # NOQA
 from numpy import iinfo  # NOQA
 
-from numpy import find_common_type  # NOQA
-from numpy import issctype  # NOQA
-from numpy import issubclass_  # NOQA
 from numpy import issubdtype  # NOQA
-from numpy import issubsctype  # NOQA
 
 from numpy import mintypecode  # NOQA
-from numpy import sctype2char  # NOQA
+
 from numpy import typename  # NOQA
 
 # -----------------------------------------------------------------------------
@@ -423,7 +412,7 @@ from cupy._indexing.insert import diag_indices_from  # NOQA
 from cupy._indexing.iterate import flatiter  # NOQA
 
 # Borrowed from NumPy
-from numpy import get_array_wrap  # NOQA
+# from numpy import get_array_wrap  # NOQA
 from numpy import index_exp  # NOQA
 from numpy import ndindex  # NOQA
 from numpy import s_  # NOQA
@@ -454,11 +443,9 @@ def base_repr(number, base=2, padding=0):  # NOQA (needed to avoid redefinition 
 
 
 # Borrowed from NumPy
-from numpy import DataSource  # NOQA
 from numpy import get_printoptions  # NOQA
 from numpy import set_printoptions  # NOQA
 from numpy import printoptions  # NOQA
-from numpy import set_string_function  # NOQA
 
 
 # -----------------------------------------------------------------------------
@@ -545,8 +532,6 @@ from cupy.lib._routines_poly import polyfit  # NOQA
 from cupy.lib._routines_poly import polyval  # NOQA
 from cupy.lib._routines_poly import roots  # NOQA
 
-# Borrowed from NumPy
-from numpy import RankWarning  # NOQA
 
 # -----------------------------------------------------------------------------
 # Mathematical functions
@@ -673,10 +658,7 @@ from cupy._misc.memory_ranges import shares_memory  # NOQA
 from cupy._misc.who import who  # NOQA
 
 # Borrowed from NumPy
-from numpy import disp  # NOQA
 from numpy import iterable  # NOQA
-from numpy import safe_eval  # NOQA
-from numpy import AxisError  # NOQA
 
 
 # -----------------------------------------------------------------------------
@@ -740,14 +722,6 @@ from cupy._statistics.histogram import digitize  # NOQA
 from cupy._statistics.histogram import histogram  # NOQA
 from cupy._statistics.histogram import histogram2d  # NOQA
 from cupy._statistics.histogram import histogramdd  # NOQA
-
-# -----------------------------------------------------------------------------
-# Classes without their own docs
-# -----------------------------------------------------------------------------
-from numpy import ComplexWarning  # NOQA
-from numpy import ModuleDeprecationWarning  # NOQA
-from numpy import TooHardError  # NOQA
-from numpy import VisibleDeprecationWarning  # NOQA
 
 
 # -----------------------------------------------------------------------------
@@ -921,9 +895,36 @@ _deprecated_apis = [
 ]
 
 
+_np2_removed_names = {
+    'AxisError': 'exceptions.AxisError',
+    'ComplexWarning': 'exceptions.ComplexWarning',
+    'ModuleDeprecationWarning': 'exceptions.ModuleDeprecationWarning',
+    'TooHardError': 'TooHardError',
+    'VisibleDeprecationWarning': 'VisibleDeprecationWarning',
+    'float_': 'float64',
+    'longfloat': 'longdouble',
+    'singlecomplex': 'complex64',
+    'complex_': 'complex128',
+    'cfloat': 'complex128',
+
+    'format_parser': 'numpy.rec.format_parser',
+    'find_common_type': '`promote_types` or `result_type`',
+    'issubclass_': '`issubclass` builtin',
+    'issubsctype': 'issubdtype',
+    'sctype2char': '`np.dtype(obj).char`',
+    'DataSource': '`np.lib.npyio.DataSource`',
+    'set_string_function': 'set_printoptions',
+}
+
+
 def __getattr__(name):
     if name in _deprecated_apis:
         return getattr(_numpy, name)
+
+    if name in _np2_removed_names:
+        raise AttributeError(
+            f"{name =} was removed in the NumPy 2.0 release. Use "
+            f"{_np2_removed_names[name]} instead.")
 
     raise AttributeError(f"module 'cupy' has no attribute {name!r}")
 

--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -133,6 +133,8 @@ from numpy import uint64  # NOQA
 from numpy import half  # NOQA
 from numpy import single  # NOQA
 from numpy import double  # NOQA
+from numpy import float64 as float_  # NOQA
+# from numpy import longfloat  # NOQA   # XXX
 from numpy import float16  # NOQA
 from numpy import float32  # NOQA
 from numpy import float64  # NOQA
@@ -145,7 +147,10 @@ from numpy import float64  # NOQA
 # Complex floating-point numbers
 # -----------------------------------------------------------------------------
 from numpy import csingle  # NOQA
+from numpy import complex64 as singlecomplex  # NOQA
 from numpy import cdouble  # NOQA
+from numpy import complex128 as cfloat  # NOQA
+from numpy import complex128 as complex_  # NOQA
 from numpy import complex64  # NOQA
 from numpy import complex128  # NOQA
 
@@ -366,7 +371,6 @@ from numpy import iinfo  # NOQA
 from numpy import issubdtype  # NOQA
 
 from numpy import mintypecode  # NOQA
-
 from numpy import typename  # NOQA
 
 # -----------------------------------------------------------------------------
@@ -412,7 +416,6 @@ from cupy._indexing.insert import diag_indices_from  # NOQA
 from cupy._indexing.iterate import flatiter  # NOQA
 
 # Borrowed from NumPy
-# from numpy import get_array_wrap  # NOQA
 from numpy import index_exp  # NOQA
 from numpy import ndindex  # NOQA
 from numpy import s_  # NOQA
@@ -532,6 +535,8 @@ from cupy.lib._routines_poly import polyfit  # NOQA
 from cupy.lib._routines_poly import polyval  # NOQA
 from cupy.lib._routines_poly import roots  # NOQA
 
+# Borrowed from NumPy
+from cupy.exceptions import RankWarning  # NOQA
 
 # -----------------------------------------------------------------------------
 # Mathematical functions
@@ -659,6 +664,7 @@ from cupy._misc.who import who  # NOQA
 
 # Borrowed from NumPy
 from numpy import iterable  # NOQA
+from cupy.exceptions import AxisError  # NOQA
 
 
 # -----------------------------------------------------------------------------
@@ -722,6 +728,14 @@ from cupy._statistics.histogram import digitize  # NOQA
 from cupy._statistics.histogram import histogram  # NOQA
 from cupy._statistics.histogram import histogram2d  # NOQA
 from cupy._statistics.histogram import histogramdd  # NOQA
+
+# -----------------------------------------------------------------------------
+# Classes without their own docs
+# -----------------------------------------------------------------------------
+from cupy.exceptions import ComplexWarning  # NOQA
+from cupy.exceptions import ModuleDeprecationWarning  # NOQA
+from cupy.exceptions import TooHardError  # NOQA
+from cupy.exceptions import VisibleDeprecationWarning  # NOQA
 
 
 # -----------------------------------------------------------------------------
@@ -895,36 +909,179 @@ _deprecated_apis = [
 ]
 
 
-_np2_removed_names = {
-    'AxisError': 'exceptions.AxisError',
-    'ComplexWarning': 'exceptions.ComplexWarning',
-    'ModuleDeprecationWarning': 'exceptions.ModuleDeprecationWarning',
-    'TooHardError': 'TooHardError',
-    'VisibleDeprecationWarning': 'VisibleDeprecationWarning',
-    'float_': 'float64',
-    'longfloat': 'longdouble',
-    'singlecomplex': 'complex64',
-    'complex_': 'complex128',
-    'cfloat': 'complex128',
+# np 2.0: XXX shims for things removed in np 2.0
 
-    'format_parser': 'numpy.rec.format_parser',
-    'find_common_type': '`promote_types` or `result_type`',
-    'issubclass_': '`issubclass` builtin',
-    'issubsctype': 'issubdtype',
-    'sctype2char': '`np.dtype(obj).char`',
-    'DataSource': '`np.lib.npyio.DataSource`',
-    'set_string_function': 'set_printoptions',
-}
+# https://github.com/numpy/numpy/blob/v1.26.4/numpy/core/numerictypes.py#L283-L322   # NOQA
+def issubclass_(arg1, arg2):
+    try:
+        return issubclass(arg1, arg2)
+    except TypeError:
+        return False
+
+# https://github.com/numpy/numpy/blob/v1.26.0/numpy/core/numerictypes.py#L229-L280   # NOQA
+def obj2sctype(rep, default=None):
+    """
+    Return the scalar dtype or NumPy equivalent of Python type of an object.
+
+    Parameters
+    ----------
+    rep : any
+        The object of which the type is returned.
+    default : any, optional
+        If given, this is returned for objects whose types can not be
+        determined. If not given, None is returned for those objects.
+
+    Returns
+    -------
+    dtype : dtype or Python type
+        The data type of `rep`.
+
+    """
+    # prevent abstract classes being upcast
+    if isinstance(rep, type) and issubclass(rep, numpy.generic):
+        return rep
+    # extract dtype from arrays
+    if isinstance(rep, numpy.ndarray):
+        return rep.dtype.type
+    # fall back on dtype to convert
+    try:
+        res = numpy.dtype(rep)
+    except Exception:
+        return default
+    else:
+        return res.type
+
+
+# https://github.com/numpy/numpy/blob/v1.26.0/numpy/core/numerictypes.py#L326C1-L355C1  # NOQA
+def issubsctype(arg1, arg2):
+    """
+    Determine if the first argument is a subclass of the second argument.
+
+    Parameters
+    ----------
+    arg1, arg2 : dtype or dtype specifier
+        Data-types.
+
+    Returns
+    -------
+    out : bool
+        The result.
+
+    """
+    return issubclass(obj2sctype(arg1), obj2sctype(arg2))
+
+
+# https://github.com/numpy/numpy/blob/v1.26.0/numpy/core/numerictypes.py#L457  # NOQA
+def sctype2char(sctype):
+    """
+    Return the string representation of a scalar dtype.
+
+    Parameters
+    ----------
+    sctype : scalar dtype or object
+        If a scalar dtype, the corresponding string character is
+        returned. If an object, `sctype2char` tries to infer its scalar type
+        and then return the corresponding string character.
+
+    Returns
+    -------
+    typechar : str
+        The string character corresponding to the scalar type.
+
+    Raises
+    ------
+    ValueError
+        If `sctype` is an object for which the type can not be inferred.
+
+    """
+    sctype = obj2sctype(sctype)
+    if sctype is None:
+        raise ValueError("unrecognized type")
+    return numpy.dtype(sctype).char
+
+
+# https://github.com/numpy/numpy/blob/v1.26.0/numpy/core/numerictypes.py#L184  # NOQA
+def issctype(rep):
+    """
+    Determines whether the given object represents a scalar data-type.
+
+    Parameters
+    ----------
+    rep : any
+        If `rep` is an instance of a scalar dtype, True is returned. If not,
+        False is returned.
+
+    Returns
+    -------
+    out : bool
+        Boolean result of check whether `rep` is a scalar dtype.
+
+    """
+    if not isinstance(rep, (type, numpy.dtype)):
+        return False
+    try:
+        res = obj2sctype(rep)
+        if res and res != numpy.object_:
+            return True
+        return False
+    except Exception:
+        return False
+
+
+# np 2.0: XXX shims for things moved in np 2.0
+if numpy.__version__ < "2":
+    from numpy import format_parser  # NOQA
+    from numpy import DataSource     # NOQA
+else:
+    from numpy.rec import format_parser  # NOQA
+    from numpy.lib.npyio import DataSource  # NOQA
+
+
+# np 2.0: XXX shims for things removed without replacement
+if numpy.__version__ < "2":
+    from numpy import find_common_type   # NOQA
+    from numpy import set_string_function  # NOQA
+    from numpy import get_array_wrap  # NOQA
+    from numpy import disp  # NOQA
+    from numpy import safe_eval  # NOQA
+else:
+
+    _template = '''\
+''This function has been removed in NumPy v2.
+Use {recommendation} instead.
+
+CuPy has been providing this function as an alias to the NumPy
+implementation, so it cannot be used in environments with NumPy
+v2 installed. If you rely on this function and you cannot modify
+the code to use {recommendation}, please downgrade NumPy to v1.26
+or earlier.
+'''
+    def find_common_type(*args, **kwds):
+        mesg = _template.format(
+            recommendation='`promote_types` or `result_type`'
+        )
+        raise RuntimeError(mesg)
+
+    def set_string_function(*args, **kwds):
+        mesg = _template.format(recommendation='`np.set_printoptions`')
+        raise RuntimeError(mesg)
+
+    def get_array_wrap(*args, **kwds):
+        mesg = _template.format(recommendation="<no replacement>")
+        raise RuntimeError(mesg)
+
+    def disp(*args, **kwds):
+        mesg = _template.format(recommendation="your own print function")
+        raise RuntimeError(mesg)
+
+    def safe_eval(*args, **kwds):
+        mesg = _template.format(recommendation="`ast.literal_eval`")
+        raise RuntimeError(mesg)
 
 
 def __getattr__(name):
     if name in _deprecated_apis:
         return getattr(_numpy, name)
-
-    if name in _np2_removed_names:
-        raise AttributeError(
-            f"{name =} was removed in the NumPy 2.0 release. Use "
-            f"{_np2_removed_names[name]} instead.")
 
     raise AttributeError(f"module 'cupy' has no attribute {name!r}")
 

--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -919,6 +919,8 @@ def issubclass_(arg1, arg2):
         return False
 
 # https://github.com/numpy/numpy/blob/v1.26.0/numpy/core/numerictypes.py#L229-L280   # NOQA
+
+
 def obj2sctype(rep, default=None):
     """
     Return the scalar dtype or NumPy equivalent of Python type of an object.
@@ -938,14 +940,14 @@ def obj2sctype(rep, default=None):
 
     """
     # prevent abstract classes being upcast
-    if isinstance(rep, type) and issubclass(rep, numpy.generic):
+    if isinstance(rep, type) and issubclass(rep, _numpy.generic):
         return rep
     # extract dtype from arrays
-    if isinstance(rep, numpy.ndarray):
+    if isinstance(rep, _numpy.ndarray):
         return rep.dtype.type
     # fall back on dtype to convert
     try:
-        res = numpy.dtype(rep)
+        res = _numpy.dtype(rep)
     except Exception:
         return default
     else:
@@ -997,7 +999,7 @@ def sctype2char(sctype):
     sctype = obj2sctype(sctype)
     if sctype is None:
         raise ValueError("unrecognized type")
-    return numpy.dtype(sctype).char
+    return _numpy.dtype(sctype).char
 
 
 # https://github.com/numpy/numpy/blob/v1.26.0/numpy/core/numerictypes.py#L184  # NOQA
@@ -1017,11 +1019,11 @@ def issctype(rep):
         Boolean result of check whether `rep` is a scalar dtype.
 
     """
-    if not isinstance(rep, (type, numpy.dtype)):
+    if not isinstance(rep, (type, _numpy.dtype)):
         return False
     try:
         res = obj2sctype(rep)
-        if res and res != numpy.object_:
+        if res and res != _numpy.object_:
             return True
         return False
     except Exception:
@@ -1033,7 +1035,7 @@ if _numpy.__version__ < "2":
     from numpy import format_parser  # NOQA
     from numpy import DataSource     # NOQA
 else:
-    from numpy.rec import format_parser  # NOQA
+    from numpy.rec import format_parser   # type: ignore [no-redef]  # NOQA
     from numpy.lib.npyio import DataSource  # NOQA
 
 
@@ -1056,25 +1058,26 @@ v2 installed. If you rely on this function and you cannot modify
 the code to use {recommendation}, please downgrade NumPy to v1.26
 or earlier.
 '''
+
     def find_common_type(*args, **kwds):
         mesg = _template.format(
             recommendation='`promote_types` or `result_type`'
         )
         raise RuntimeError(mesg)
 
-    def set_string_function(*args, **kwds):
+    def set_string_function(*args, **kwds):   # type: ignore [misc]
         mesg = _template.format(recommendation='`np.set_printoptions`')
         raise RuntimeError(mesg)
 
-    def get_array_wrap(*args, **kwds):
+    def get_array_wrap(*args, **kwds):       # type: ignore [no-redef]
         mesg = _template.format(recommendation="<no replacement>")
         raise RuntimeError(mesg)
 
-    def disp(*args, **kwds):
+    def disp(*args, **kwds):   # type: ignore [misc]
         mesg = _template.format(recommendation="your own print function")
         raise RuntimeError(mesg)
 
-    def safe_eval(*args, **kwds):
+    def safe_eval(*args, **kwds):  # type: ignore [misc]
         mesg = _template.format(recommendation="`ast.literal_eval`")
         raise RuntimeError(mesg)
 

--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -1029,7 +1029,7 @@ def issctype(rep):
 
 
 # np 2.0: XXX shims for things moved in np 2.0
-if numpy.__version__ < "2":
+if _numpy.__version__ < "2":
     from numpy import format_parser  # NOQA
     from numpy import DataSource     # NOQA
 else:
@@ -1038,7 +1038,7 @@ else:
 
 
 # np 2.0: XXX shims for things removed without replacement
-if numpy.__version__ < "2":
+if _numpy.__version__ < "2":
     from numpy import find_common_type   # NOQA
     from numpy import set_string_function  # NOQA
     from numpy import get_array_wrap  # NOQA

--- a/cupy/_core/_routines_indexing.pyx
+++ b/cupy/_core/_routines_indexing.pyx
@@ -1054,7 +1054,7 @@ cdef _ndarray_base _diagonal(
         Py_ssize_t axis2=1):
     cdef Py_ssize_t ndim = a.ndim
     if not (-ndim <= axis1 < ndim and -ndim <= axis2 < ndim):
-        raise numpy.AxisError(
+        raise numpy.exceptions.AxisError(
             'axis1(={0}) and axis2(={1}) must be within range '
             '(ndim={2})'.format(axis1, axis2, ndim))
 

--- a/cupy/_core/_routines_indexing.pyx
+++ b/cupy/_core/_routines_indexing.pyx
@@ -6,6 +6,7 @@ import numpy
 
 import cupy
 import cupy._core.core as core
+from cupy.exceptions import AxisError
 from cupy._core._kernel import ElementwiseKernel, _get_warpsize
 from cupy._core._ufuncs import elementwise_copy
 
@@ -1054,7 +1055,7 @@ cdef _ndarray_base _diagonal(
         Py_ssize_t axis2=1):
     cdef Py_ssize_t ndim = a.ndim
     if not (-ndim <= axis1 < ndim and -ndim <= axis2 < ndim):
-        raise numpy.exceptions.AxisError(
+        raise AxisError(
             'axis1(={0}) and axis2(={1}) must be within range '
             '(ndim={2})'.format(axis1, axis2, ndim))
 

--- a/cupy/_core/_routines_manipulation.pyx
+++ b/cupy/_core/_routines_manipulation.pyx
@@ -390,7 +390,7 @@ cpdef _ndarray_base _transpose(
     for i in range(axes_size):
         axis = axes[i]
         if axis < -ndim or axis >= ndim:
-            raise numpy.AxisError(axis, ndim)
+            raise numpy.exceptions.AxisError(axis, ndim)
         axis %= ndim
         a_axes.push_back(axis)
         if axis_flags[axis]:

--- a/cupy/_core/_routines_manipulation.pyx
+++ b/cupy/_core/_routines_manipulation.pyx
@@ -6,6 +6,7 @@ import numpy
 from cupy._core._kernel import ElementwiseKernel
 from cupy._core._ufuncs import elementwise_copy
 import cupy._core.core as core
+from cupy.exceptions import AxisError
 
 cimport cpython  # NOQA
 cimport cython  # NOQA
@@ -390,7 +391,7 @@ cpdef _ndarray_base _transpose(
     for i in range(axes_size):
         axis = axes[i]
         if axis < -ndim or axis >= ndim:
-            raise numpy.exceptions.AxisError(axis, ndim)
+            raise AxisError(axis, ndim)
         axis %= ndim
         a_axes.push_back(axis)
         if axis_flags[axis]:

--- a/cupy/_core/_routines_sorting.pyx
+++ b/cupy/_core/_routines_sorting.pyx
@@ -3,6 +3,7 @@ import string
 import numpy
 
 import cupy
+from cupy.exceptions import AxisError
 from cupy._core._scalar import get_typename as _get_typename
 from cupy._core._ufuncs import elementwise_copy
 import cupy._core.core as core
@@ -25,7 +26,7 @@ cdef _ndarray_sort(_ndarray_base self, int axis):
                            'reinstall CuPy after uninstalling it.')
 
     if ndim == 0:
-        raise numpy.exceptions.AxisError('Sorting arrays with the rank of zero is not '
+        raise AxisError('Sorting arrays with the rank of zero is not '
                               'supported')  # as numpy.sort() raises
 
     # TODO(takagi): Support sorting views
@@ -128,7 +129,7 @@ cdef _ndarray_partition(_ndarray_base self, kth, int axis):
     cdef _ndarray_base data
 
     if ndim == 0:
-        raise numpy.exceptions.AxisError('Sorting arrays with the rank of zero is not '
+        raise AxisError('Sorting arrays with the rank of zero is not '
                               'supported')
 
     if not self._c_contiguous:

--- a/cupy/_core/_routines_sorting.pyx
+++ b/cupy/_core/_routines_sorting.pyx
@@ -25,7 +25,7 @@ cdef _ndarray_sort(_ndarray_base self, int axis):
                            'reinstall CuPy after uninstalling it.')
 
     if ndim == 0:
-        raise numpy.AxisError('Sorting arrays with the rank of zero is not '
+        raise numpy.exceptions.AxisError('Sorting arrays with the rank of zero is not '
                               'supported')  # as numpy.sort() raises
 
     # TODO(takagi): Support sorting views
@@ -128,7 +128,7 @@ cdef _ndarray_partition(_ndarray_base self, kth, int axis):
     cdef _ndarray_base data
 
     if ndim == 0:
-        raise numpy.AxisError('Sorting arrays with the rank of zero is not '
+        raise numpy.exceptions.AxisError('Sorting arrays with the rank of zero is not '
                               'supported')
 
     if not self._c_contiguous:

--- a/cupy/_core/_routines_sorting.pyx
+++ b/cupy/_core/_routines_sorting.pyx
@@ -27,7 +27,7 @@ cdef _ndarray_sort(_ndarray_base self, int axis):
 
     if ndim == 0:
         raise AxisError('Sorting arrays with the rank of zero is not '
-                              'supported')  # as numpy.sort() raises
+                        'supported')  # as numpy.sort() raises
 
     # TODO(takagi): Support sorting views
     if not self._c_contiguous:
@@ -130,7 +130,7 @@ cdef _ndarray_partition(_ndarray_base self, kth, int axis):
 
     if ndim == 0:
         raise AxisError('Sorting arrays with the rank of zero is not '
-                              'supported')
+                        'supported')
 
     if not self._c_contiguous:
         raise NotImplementedError('Sorting non-contiguous array is not '

--- a/cupy/_core/_routines_statistics.pyx
+++ b/cupy/_core/_routines_statistics.pyx
@@ -4,6 +4,7 @@ import numpy
 from numpy import nan
 
 import cupy
+from cupy.exceptions import AxisError
 from cupy._core import _reduction
 from cupy._core._reduction import create_reduction_func
 from cupy._core._reduction import ReductionKernel
@@ -412,7 +413,7 @@ cpdef _ndarray_base _median(
         sz = a.size
     else:
         if axis < -keep_ndim or axis >= keep_ndim:
-            raise numpy.exceptions.AxisError('Axis overrun')
+            raise AxisError('Axis overrun')
         sz = a.shape[axis]
     if sz % 2 == 0:
         szh = sz // 2

--- a/cupy/_core/_routines_statistics.pyx
+++ b/cupy/_core/_routines_statistics.pyx
@@ -412,7 +412,7 @@ cpdef _ndarray_base _median(
         sz = a.size
     else:
         if axis < -keep_ndim or axis >= keep_ndim:
-            raise numpy.AxisError('Axis overrun')
+            raise numpy.exceptions.AxisError('Axis overrun')
         sz = a.shape[axis]
     if sz % 2 == 0:
         szh = sz // 2

--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -2538,7 +2538,7 @@ cdef _ndarray_base _array_default(
             order = 'F'
         else:
             order = 'C'
-    a_cpu = numpy.array(obj, dtype=dtype, copy=False, order=order,
+    a_cpu = numpy.array(obj, dtype=dtype, copy=None, order=order,
                         ndmin=ndmin)
     if a_cpu.dtype.char not in '?bhilqBHILQefdFD':
         raise ValueError('Unsupported dtype %s' % a_cpu.dtype)

--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -52,6 +52,7 @@ from cupy_backends.cuda.api cimport runtime
 
 NUMPY_1x = numpy.__version__ < '2'
 
+
 # If rop of cupy.ndarray is called, cupy's op is the last chance.
 # If op of cupy.ndarray is called and the `other` is cupy.ndarray, too,
 # it is safe to call cupy's op.

--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -50,6 +50,8 @@ from cupy_backends.cuda cimport stream as _stream_module
 from cupy_backends.cuda.api cimport runtime
 
 
+NUMPY_1x = numpy.__version__ < '2'
+
 # If rop of cupy.ndarray is called, cupy's op is the last chance.
 # If op of cupy.ndarray is called and the `other` is cupy.ndarray, too,
 # it is safe to call cupy's op.
@@ -2538,7 +2540,8 @@ cdef _ndarray_base _array_default(
             order = 'F'
         else:
             order = 'C'
-    a_cpu = numpy.array(obj, dtype=dtype, copy=None, order=order,
+    copy = False if NUMPY_1x else None
+    a_cpu = numpy.array(obj, dtype=dtype, copy=copy, order=order,
                         ndmin=ndmin)
     if a_cpu.dtype.char not in '?bhilqBHILQefdFD':
         raise ValueError('Unsupported dtype %s' % a_cpu.dtype)

--- a/cupy/_core/fusion.pyx
+++ b/cupy/_core/fusion.pyx
@@ -975,7 +975,7 @@ def _call_reduction(fusion_op, *args, **kwargs):
     else:
         ndim = 0
     if ndim < 0:
-        raise numpy.AxisError(axis, src_ndim)
+        raise numpy.exceptions.AxisError(axis, src_ndim)
 
     _thread_local.history.ndim = ndim
     if ndim >= 1:

--- a/cupy/_core/fusion.pyx
+++ b/cupy/_core/fusion.pyx
@@ -14,7 +14,7 @@ from cupy._core import _fusion_thread_local
 from cupy._core import _reduction
 from cupy._core import core
 from cupy._core import new_fusion
-
+from cupy.exceptions import AxisError
 
 _is_fusing = _fusion_thread_local.is_fusing  # NOQA
 _thread_local = _fusion_thread_local.thread_local
@@ -975,7 +975,7 @@ def _call_reduction(fusion_op, *args, **kwargs):
     else:
         ndim = 0
     if ndim < 0:
-        raise numpy.exceptions.AxisError(axis, src_ndim)
+        raise AxisError(axis, src_ndim)
 
     _thread_local.history.ndim = ndim
     if ndim >= 1:

--- a/cupy/_core/internal.pyx
+++ b/cupy/_core/internal.pyx
@@ -434,7 +434,7 @@ cpdef Py_ssize_t _normalize_axis_index(
 
     """
     if not (-ndim <= axis < ndim):
-        raise numpy.AxisError(axis, ndim)
+        raise numpy.exceptions.AxisError(axis, ndim)
     if axis < 0:
         axis += ndim
     return axis

--- a/cupy/_core/internal.pyx
+++ b/cupy/_core/internal.pyx
@@ -8,6 +8,7 @@ from libc.stdint cimport uint32_t
 import warnings
 
 import numpy
+from cupy.exceptions import AxisError
 
 from cupy._core.core cimport _ndarray_base
 
@@ -434,7 +435,7 @@ cpdef Py_ssize_t _normalize_axis_index(
 
     """
     if not (-ndim <= axis < ndim):
-        raise numpy.exceptions.AxisError(axis, ndim)
+        raise AxisError(axis, ndim)
     if axis < 0:
         axis += ndim
     return axis

--- a/cupy/exceptions/__init__.py
+++ b/cupy/exceptions/__init__.py
@@ -1,0 +1,6 @@
+from numpy.exceptions import AxisError  # NOQA
+from numpy.exceptions import ComplexWarning  # NOQA
+from numpy.exceptions import ModuleDeprecationWarning  # NOQA
+from numpy.exceptions import TooHardError  # NOQA
+from numpy.exceptions import VisibleDeprecationWarning  # NOQA
+

--- a/cupy/exceptions/__init__.py
+++ b/cupy/exceptions/__init__.py
@@ -1,3 +1,4 @@
+# mypy: ignore-errors
 import numpy
 
 if numpy.__version__ < '2':

--- a/cupy/exceptions/__init__.py
+++ b/cupy/exceptions/__init__.py
@@ -6,10 +6,11 @@ if numpy.__version__ < '2':
     from numpy import ModuleDeprecationWarning  # NOQA
     from numpy import TooHardError  # NOQA
     from numpy import VisibleDeprecationWarning  # NOQA
+    from numpy import RankWarning   # NOQA
 else:
     from numpy.exceptions import AxisError  # NOQA
     from numpy.exceptions import ComplexWarning  # NOQA
     from numpy.exceptions import ModuleDeprecationWarning  # NOQA
     from numpy.exceptions import TooHardError  # NOQA
     from numpy.exceptions import VisibleDeprecationWarning  # NOQA
-
+    from numpy.exceptions import RankWarning   # NOQA

--- a/cupy/exceptions/__init__.py
+++ b/cupy/exceptions/__init__.py
@@ -1,6 +1,15 @@
-from numpy.exceptions import AxisError  # NOQA
-from numpy.exceptions import ComplexWarning  # NOQA
-from numpy.exceptions import ModuleDeprecationWarning  # NOQA
-from numpy.exceptions import TooHardError  # NOQA
-from numpy.exceptions import VisibleDeprecationWarning  # NOQA
+import numpy
+
+if numpy.__version__ < '2':
+    from numpy import AxisError  # NOQA
+    from numpy import ComplexWarning  # NOQA
+    from numpy import ModuleDeprecationWarning  # NOQA
+    from numpy import TooHardError  # NOQA
+    from numpy import VisibleDeprecationWarning  # NOQA
+else:
+    from numpy.exceptions import AxisError  # NOQA
+    from numpy.exceptions import ComplexWarning  # NOQA
+    from numpy.exceptions import ModuleDeprecationWarning  # NOQA
+    from numpy.exceptions import TooHardError  # NOQA
+    from numpy.exceptions import VisibleDeprecationWarning  # NOQA
 

--- a/cupy/lib/_routines_poly.py
+++ b/cupy/lib/_routines_poly.py
@@ -224,7 +224,7 @@ def polyfit(x, y, deg, rcond=None, full=False, w=None, cov=False):
 
     .. warning::
 
-        numpy.RankWarning: The rank of the coefficient matrix in the
+        numpy.exceptions.RankWarning: The rank of the coefficient matrix in the
         least-squares fit is deficient. It is raised if ``full=False``.
 
     .. seealso:: :func:`numpy.polyfit`
@@ -279,7 +279,7 @@ def polyfit(x, y, deg, rcond=None, full=False, w=None, cov=False):
     order = deg + 1
     if rank != order and not full:
         msg = 'Polyfit may be poorly conditioned'
-        warnings.warn(msg, numpy.RankWarning, stacklevel=4)
+        warnings.warn(msg, numpy.exceptions.RankWarning, stacklevel=4)
 
     if full:
         if resids.dtype.kind == 'c':

--- a/cupy/lib/_routines_poly.py
+++ b/cupy/lib/_routines_poly.py
@@ -4,6 +4,7 @@ import warnings
 import numpy
 
 import cupy
+from cupy.exceptions import RankWarning
 import cupyx.scipy.fft
 
 
@@ -224,7 +225,7 @@ def polyfit(x, y, deg, rcond=None, full=False, w=None, cov=False):
 
     .. warning::
 
-        numpy.exceptions.RankWarning: The rank of the coefficient matrix in the
+        cupy.exceptions.RankWarning: The rank of the coefficient matrix in the
         least-squares fit is deficient. It is raised if ``full=False``.
 
     .. seealso:: :func:`numpy.polyfit`
@@ -279,7 +280,7 @@ def polyfit(x, y, deg, rcond=None, full=False, w=None, cov=False):
     order = deg + 1
     if rank != order and not full:
         msg = 'Polyfit may be poorly conditioned'
-        warnings.warn(msg, numpy.exceptions.RankWarning, stacklevel=4)
+        warnings.warn(msg, RankWarning, stacklevel=4)
 
     if full:
         if resids.dtype.kind == 'c':

--- a/cupy/lib/_shape_base.py
+++ b/cupy/lib/_shape_base.py
@@ -1,4 +1,4 @@
-from numpy.lib import index_tricks
+import numpy.lib._index_tricks_impl as index_tricks
 
 import cupy
 from cupy._core import internal

--- a/cupy/lib/_shape_base.py
+++ b/cupy/lib/_shape_base.py
@@ -1,4 +1,8 @@
-import numpy.lib._index_tricks_impl as index_tricks
+import numpy
+if numpy.__version__ < '2':
+    from numpy.lib import index_tricks
+else:
+    import numpy.lib._index_tricks_impl as index_tricks
 
 import cupy
 from cupy._core import internal

--- a/cupy/lib/_shape_base.py
+++ b/cupy/lib/_shape_base.py
@@ -2,7 +2,7 @@ import numpy
 if numpy.__version__ < '2':
     from numpy.lib import index_tricks
 else:
-    import numpy.lib._index_tricks_impl as index_tricks
+    import numpy.lib._index_tricks_impl as index_tricks  # type: ignore[no-redef]  # NOQA
 
 import cupy
 from cupy._core import internal

--- a/cupy/testing/_loops.py
+++ b/cupy/testing/_loops.py
@@ -106,7 +106,7 @@ def _call_func_numpy_cupy(impl, args, kw, name, sp_name, scipy_name):
 _numpy_errors = [
     AttributeError, Exception, IndexError, TypeError, ValueError,
     NotImplementedError, DeprecationWarning,
-    numpy.AxisError, numpy.linalg.LinAlgError,
+    numpy.exceptions.AxisError, numpy.linalg.LinAlgError,
 ]
 
 

--- a/cupy/testing/_loops.py
+++ b/cupy/testing/_loops.py
@@ -10,6 +10,7 @@ import warnings
 import numpy
 
 import cupy
+from cupy.exceptions import AxisError
 from cupy.testing import _array
 from cupy.testing import _parameterized
 import cupyx
@@ -106,7 +107,7 @@ def _call_func_numpy_cupy(impl, args, kw, name, sp_name, scipy_name):
 _numpy_errors = [
     AttributeError, Exception, IndexError, TypeError, ValueError,
     NotImplementedError, DeprecationWarning,
-    numpy.exceptions.AxisError, numpy.linalg.LinAlgError,
+    AxisError, numpy.linalg.LinAlgError,
 ]
 
 

--- a/cupyx/jit/_compile.py
+++ b/cupyx/jit/_compile.py
@@ -11,6 +11,7 @@ import types
 
 import numpy
 
+from cupy.exceptions import ComplexWarning
 from cupy_backends.cuda.api import runtime
 from cupy._core._codeblock import CodeBlock, _CodeType
 from cupy._core import _kernel
@@ -1006,7 +1007,7 @@ def _astype_scalar(
         if to_t.kind != 'b':
             warnings.warn(
                 'Casting complex values to real discards the imaginary part',
-                numpy.ComplexWarning)
+                ComplexWarning)
         return Data(f'({ctype})({x.code}.real())', ctype)
     return Data(f'({ctype})({x.code})', ctype)
 

--- a/cupyx/scipy/fft/_realtransforms.py
+++ b/cupyx/scipy/fft/_realtransforms.py
@@ -41,7 +41,7 @@ import cupy
 from cupy import _core
 from cupy.fft._fft import _cook_shape
 from cupyx.scipy.fft import _fft
-
+from cupy.exceptions import AxisError
 
 __all__ = ['dct', 'dctn', 'dst', 'dstn', 'idct', 'idctn', 'idst', 'idstn']
 
@@ -163,7 +163,7 @@ def _dct_or_dst_type2(
         The transformed array.
     """
     if axis < -x.ndim or axis >= x.ndim:
-        raise numpy.AxisError('axis out of range')
+        raise AxisError('axis out of range')
     if axis < 0:
         axis += x.ndim
     if n is not None and n < 1:
@@ -284,7 +284,7 @@ def _dct_or_dst_type3(
 
     """
     if axis < -x.ndim or axis >= x.ndim:
-        raise numpy.AxisError('axis out of range')
+        raise AxisError('axis out of range')
     if axis < 0:
         axis += x.ndim
     if n is not None and n < 1:

--- a/cupyx/scipy/fft/_realtransforms.py
+++ b/cupyx/scipy/fft/_realtransforms.py
@@ -35,8 +35,6 @@ import math
 import numbers
 import operator
 
-import numpy
-
 import cupy
 from cupy import _core
 from cupy.fft._fft import _cook_shape

--- a/cupyx/scipy/interpolate/_bspline2.py
+++ b/cupyx/scipy/interpolate/_bspline2.py
@@ -1,7 +1,7 @@
 import operator
 from math import prod
 
-from numpy.core.multiarray import normalize_axis_index
+from numpy.lib.array_utils import normalize_axis_index
 
 import cupy
 from cupyx.scipy import sparse

--- a/cupyx/scipy/interpolate/_bspline2.py
+++ b/cupyx/scipy/interpolate/_bspline2.py
@@ -1,7 +1,11 @@
 import operator
 from math import prod
 
-from numpy.lib.array_utils import normalize_axis_index
+import numpy
+if numpy.__version__ < '2':
+    from numpy.core.multiarray import normalize_axis_index
+else:
+    from numpy.lib.array_utils import normalize_axis_index
 
 import cupy
 from cupyx.scipy import sparse

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,8 +26,8 @@ filterwarnings =
     ignore::UserWarning
     error::DeprecationWarning
     error::PendingDeprecationWarning
-    error::numpy.VisibleDeprecationWarning
-    error::numpy.ComplexWarning
+    error::numpy.exceptions.VisibleDeprecationWarning
+    error::numpy.exceptions.ComplexWarning
     # distutils (Python 3.10)
     ignore:The distutils(.+) is deprecated:DeprecationWarning
     ignore:dep_util is Deprecated:DeprecationWarning

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,11 +26,8 @@ filterwarnings =
     ignore::UserWarning
     error::DeprecationWarning
     error::PendingDeprecationWarning
-    # XXX: np 2.0 moved these two to numpy.exceptions
-    error::numpy.VisibleDeprecationWarning
-    error::numpy.ComplexWarning
-    error::numpy.exceptions.VisibleDeprecationWarning
-    error::numpy.exceptions.ComplexWarning
+    error::cupy.exceptions.VisibleDeprecationWarning
+    error::cupy.exceptions.ComplexWarning
     # distutils (Python 3.10)
     ignore:The distutils(.+) is deprecated:DeprecationWarning
     ignore:dep_util is Deprecated:DeprecationWarning

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,8 +26,9 @@ filterwarnings =
     ignore::UserWarning
     error::DeprecationWarning
     error::PendingDeprecationWarning
-    error::numpy.exceptions.VisibleDeprecationWarning
-    error::numpy.exceptions.ComplexWarning
+    # XXX: np 2.0
+    # error::numpy.exceptions.VisibleDeprecationWarning
+    # error::numpy.exceptions.ComplexWarning
     # distutils (Python 3.10)
     ignore:The distutils(.+) is deprecated:DeprecationWarning
     ignore:dep_util is Deprecated:DeprecationWarning

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,9 +26,11 @@ filterwarnings =
     ignore::UserWarning
     error::DeprecationWarning
     error::PendingDeprecationWarning
-    # XXX: np 2.0
-    # error::numpy.exceptions.VisibleDeprecationWarning
-    # error::numpy.exceptions.ComplexWarning
+    # XXX: np 2.0 moved these two to numpy.exceptions
+    error::numpy.VisibleDeprecationWarning
+    error::numpy.ComplexWarning
+    error::numpy.exceptions.VisibleDeprecationWarning
+    error::numpy.exceptions.ComplexWarning
     # distutils (Python 3.10)
     ignore:The distutils(.+) is deprecated:DeprecationWarning
     ignore:dep_util is Deprecated:DeprecationWarning

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup_requires = [
     'fastrlock>=0.5',
 ]
 install_requires = [
-    'numpy>=1.22,<1.29',  # see #4773
+    'numpy>=2.0.0rc1',
     'fastrlock>=0.5',
 ]
 extras_require = {

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup_requires = [
     'fastrlock>=0.5',
 ]
 install_requires = [
-    'numpy>=2.0.0rc1',
+    'numpy>=1.22,<2.3',
     'fastrlock>=0.5',
 ]
 extras_require = {

--- a/tests/cupy_tests/core_tests/fusion_tests/test_reduction.py
+++ b/tests/cupy_tests/core_tests/fusion_tests/test_reduction.py
@@ -17,11 +17,11 @@ class TestFusionReductionAxis(unittest.TestCase):
         x = testing.shaped_random(self.shape, xp, 'int64', scale=10, seed=0)
         return (x,), {}
 
-    @fusion_utils.check_fusion(accept_error=numpy.AxisError)
+    @fusion_utils.check_fusion(accept_error=numpy.exceptions.AxisError)
     def test_sum_axis(self, xp):
         return lambda x: cupy.sum(x, self.axis)
 
-    @fusion_utils.check_fusion(accept_error=numpy.AxisError)
+    @fusion_utils.check_fusion(accept_error=numpy.exceptions.AxisError)
     def test_sum_kwargs_axis(self, xp):
         return lambda x: cupy.sum(x, axis=self.axis)
 
@@ -40,11 +40,11 @@ class TestFusionReductionMultiAxis(unittest.TestCase):
         x = testing.shaped_random(self.shape, xp, 'int64', scale=10, seed=0)
         return (x,), {}
 
-    @fusion_utils.check_fusion(accept_error=(ValueError, numpy.AxisError))
+    @fusion_utils.check_fusion(accept_error=(ValueError, numpy.exceptions.AxisError))
     def test_sum_axis(self, xp):
         return lambda x: cupy.sum(x, self.axis)
 
-    @fusion_utils.check_fusion(accept_error=(ValueError, numpy.AxisError))
+    @fusion_utils.check_fusion(accept_error=(ValueError, numpy.exceptions.AxisError))
     def test_sum_kwargs_axis(self, xp):
         return lambda x: cupy.sum(x, axis=self.axis)
 

--- a/tests/cupy_tests/core_tests/fusion_tests/test_reduction.py
+++ b/tests/cupy_tests/core_tests/fusion_tests/test_reduction.py
@@ -1,8 +1,7 @@
 import unittest
 
-import numpy
-
 import cupy
+from cupy.exceptions import AxisError
 from cupy import testing
 from cupy_tests.core_tests.fusion_tests import fusion_utils
 
@@ -17,11 +16,11 @@ class TestFusionReductionAxis(unittest.TestCase):
         x = testing.shaped_random(self.shape, xp, 'int64', scale=10, seed=0)
         return (x,), {}
 
-    @fusion_utils.check_fusion(accept_error=numpy.exceptions.AxisError)
+    @fusion_utils.check_fusion(accept_error=AxisError)
     def test_sum_axis(self, xp):
         return lambda x: cupy.sum(x, self.axis)
 
-    @fusion_utils.check_fusion(accept_error=numpy.exceptions.AxisError)
+    @fusion_utils.check_fusion(accept_error=AxisError)
     def test_sum_kwargs_axis(self, xp):
         return lambda x: cupy.sum(x, axis=self.axis)
 
@@ -40,11 +39,11 @@ class TestFusionReductionMultiAxis(unittest.TestCase):
         x = testing.shaped_random(self.shape, xp, 'int64', scale=10, seed=0)
         return (x,), {}
 
-    @fusion_utils.check_fusion(accept_error=(ValueError, numpy.exceptions.AxisError))
+    @fusion_utils.check_fusion(accept_error=(ValueError, AxisError))
     def test_sum_axis(self, xp):
         return lambda x: cupy.sum(x, self.axis)
 
-    @fusion_utils.check_fusion(accept_error=(ValueError, numpy.exceptions.AxisError))
+    @fusion_utils.check_fusion(accept_error=(ValueError, AxisError))
     def test_sum_kwargs_axis(self, xp):
         return lambda x: cupy.sum(x, axis=self.axis)
 

--- a/tests/cupy_tests/core_tests/test_ndarray_copy_and_view.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_copy_and_view.py
@@ -2,6 +2,7 @@ import numpy
 import pytest
 
 import cupy
+from cupy.exceptions import ComplexWarning
 from cupy import testing
 from cupy import _util
 
@@ -9,7 +10,7 @@ from cupy import _util
 def astype_without_warning(x, dtype, *args, **kwargs):
     dtype = numpy.dtype(dtype)
     if x.dtype.kind == 'c' and dtype.kind not in ['b', 'c']:
-        with testing.assert_warns(numpy.exceptions.ComplexWarning):
+        with testing.assert_warns(ComplexWarning):
             return x.astype(dtype, *args, **kwargs)
     else:
         return x.astype(dtype, *args, **kwargs)
@@ -257,7 +258,7 @@ class TestArrayFill:
 
     @testing.with_requires('numpy>=1.24.0')
     @testing.for_all_dtypes_combination(('dtype1', 'dtype2'))
-    @testing.numpy_cupy_array_equal(accept_error=numpy.exceptions.ComplexWarning)
+    @testing.numpy_cupy_array_equal(accept_error=ComplexWarning)
     def test_fill_with_numpy_scalar_ndarray(self, xp, dtype1, dtype2):
         a = testing.shaped_arange((2, 3, 4), xp, dtype1)
         a.fill(numpy.ones((), dtype=dtype2))
@@ -265,7 +266,7 @@ class TestArrayFill:
 
     @testing.with_requires('numpy>=1.24.0')
     @testing.for_all_dtypes_combination(('dtype1', 'dtype2'))
-    @testing.numpy_cupy_array_equal(accept_error=numpy.exceptions.ComplexWarning)
+    @testing.numpy_cupy_array_equal(accept_error=ComplexWarning)
     def test_fill_with_cupy_scalar_ndarray(self, xp, dtype1, dtype2):
         a = testing.shaped_arange((2, 3, 4), xp, dtype1)
         b = xp.ones((), dtype=dtype2)

--- a/tests/cupy_tests/core_tests/test_ndarray_copy_and_view.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_copy_and_view.py
@@ -9,7 +9,7 @@ from cupy import _util
 def astype_without_warning(x, dtype, *args, **kwargs):
     dtype = numpy.dtype(dtype)
     if x.dtype.kind == 'c' and dtype.kind not in ['b', 'c']:
-        with testing.assert_warns(numpy.ComplexWarning):
+        with testing.assert_warns(numpy.exceptions.ComplexWarning):
             return x.astype(dtype, *args, **kwargs)
     else:
         return x.astype(dtype, *args, **kwargs)
@@ -257,7 +257,7 @@ class TestArrayFill:
 
     @testing.with_requires('numpy>=1.24.0')
     @testing.for_all_dtypes_combination(('dtype1', 'dtype2'))
-    @testing.numpy_cupy_array_equal(accept_error=numpy.ComplexWarning)
+    @testing.numpy_cupy_array_equal(accept_error=numpy.exceptions.ComplexWarning)
     def test_fill_with_numpy_scalar_ndarray(self, xp, dtype1, dtype2):
         a = testing.shaped_arange((2, 3, 4), xp, dtype1)
         a.fill(numpy.ones((), dtype=dtype2))
@@ -265,7 +265,7 @@ class TestArrayFill:
 
     @testing.with_requires('numpy>=1.24.0')
     @testing.for_all_dtypes_combination(('dtype1', 'dtype2'))
-    @testing.numpy_cupy_array_equal(accept_error=numpy.ComplexWarning)
+    @testing.numpy_cupy_array_equal(accept_error=numpy.exceptions.ComplexWarning)
     def test_fill_with_cupy_scalar_ndarray(self, xp, dtype1, dtype2):
         a = testing.shaped_arange((2, 3, 4), xp, dtype1)
         b = xp.ones((), dtype=dtype2)

--- a/tests/cupy_tests/functional_tests/test_vectorize.py
+++ b/tests/cupy_tests/functional_tests/test_vectorize.py
@@ -272,7 +272,7 @@ class TestVectorizeExprs(unittest.TestCase):
 
     @testing.for_all_dtypes_combination(names=('dtype1', 'dtype2'), full=True)
     @testing.numpy_cupy_array_equal(
-        accept_error=(TypeError, numpy.ComplexWarning))
+        accept_error=(TypeError, numpy.exceptions.ComplexWarning))
     def test_vectorize_typecast(self, xp, dtype1, dtype2):
         typecast = xp.dtype(dtype2).type
 

--- a/tests/cupy_tests/functional_tests/test_vectorize.py
+++ b/tests/cupy_tests/functional_tests/test_vectorize.py
@@ -272,7 +272,7 @@ class TestVectorizeExprs(unittest.TestCase):
 
     @testing.for_all_dtypes_combination(names=('dtype1', 'dtype2'), full=True)
     @testing.numpy_cupy_array_equal(
-        accept_error=(TypeError, numpy.exceptions.ComplexWarning))
+        accept_error=(TypeError, cupy.exceptions.ComplexWarning))
     def test_vectorize_typecast(self, xp, dtype1, dtype2):
         typecast = xp.dtype(dtype2).type
 

--- a/tests/cupy_tests/lib_tests/test_polynomial.py
+++ b/tests/cupy_tests/lib_tests/test_polynomial.py
@@ -7,6 +7,8 @@ from cupy.cuda import runtime
 import cupyx
 from cupy import testing
 
+from cupy.exceptions import RankWarning
+
 
 @testing.parameterize(
     {'variable': None},
@@ -584,7 +586,7 @@ class TestPolyfit:
         for xp in (numpy, cupy):
             x = testing.shaped_arange((5,), xp, dtype)
             y = testing.shaped_arange((5,), xp, dtype)
-            with pytest.warns(numpy.RankWarning):
+            with pytest.warns(RankWarning):
                 xp.polyfit(x, y, 6)
 
 

--- a/tests/cupy_tests/logic_tests/test_truth.py
+++ b/tests/cupy_tests/logic_tests/test_truth.py
@@ -300,6 +300,6 @@ class TestUnion1d:
 
     @testing.numpy_cupy_array_equal()
     def test_union1d_3(self, xp):
-        x = xp.zeros((2, 2), dtype=xp.complex_)
+        x = xp.zeros((2, 2), dtype=xp.complex128)
         y = xp.array([[1+1j, 2+3j], [4+1j, 0+7j]])
         return xp.union1d(x, y)

--- a/tests/cupy_tests/manipulation_tests/test_join.py
+++ b/tests/cupy_tests/manipulation_tests/test_join.py
@@ -230,7 +230,7 @@ class TestJoin:
                 xp.concatenate((a, b), out=out, dtype=xp.int64)
 
     @testing.with_requires('numpy>=1.20.0')
-    @pytest.mark.filterwarnings('error::numpy.ComplexWarning')
+    @pytest.mark.filterwarnings('error::numpy.exceptions.ComplexWarning')
     @pytest.mark.parametrize('casting', [
         'no',
         'equiv',
@@ -240,7 +240,7 @@ class TestJoin:
     ])
     @testing.for_all_dtypes_combination(names=['dtype1', 'dtype2'])
     @testing.numpy_cupy_array_equal(
-        accept_error=(TypeError, numpy.ComplexWarning))
+        accept_error=(TypeError, numpy.exceptions.ComplexWarning))
     def test_concatenate_casting(self, xp, dtype1, dtype2, casting):
         a = testing.shaped_arange((3, 4), xp, dtype1)
         b = testing.shaped_arange((3, 4), xp, dtype1)
@@ -308,7 +308,7 @@ class TestJoin:
     ])
     @testing.for_all_dtypes_combination(names=['dtype1', 'dtype2'])
     @testing.numpy_cupy_array_equal(
-        accept_error=(TypeError, numpy.ComplexWarning))
+        accept_error=(TypeError, numpy.exceptions.ComplexWarning))
     def test_hstack_casting(self, xp, dtype1, dtype2, casting):
         a = testing.shaped_arange((3, 4), xp, dtype1)
         b = testing.shaped_arange((3, 4), xp, dtype1)
@@ -351,7 +351,7 @@ class TestJoin:
     ])
     @testing.for_all_dtypes_combination(names=['dtype1', 'dtype2'])
     @testing.numpy_cupy_array_equal(
-        accept_error=(TypeError, numpy.ComplexWarning))
+        accept_error=(TypeError, numpy.exceptions.ComplexWarning))
     def test_vstack_casting(self, xp, dtype1, dtype2, casting):
         a = testing.shaped_arange((3, 4), xp, dtype1)
         b = testing.shaped_arange((3, 4), xp, dtype1)
@@ -495,7 +495,7 @@ class TestJoin:
     ])
     @testing.for_all_dtypes_combination(names=['dtype1', 'dtype2'])
     @testing.numpy_cupy_array_equal(
-        accept_error=(TypeError, numpy.ComplexWarning))
+        accept_error=(TypeError, numpy.exceptions.ComplexWarning))
     def test_stack_casting(self, xp, dtype1, dtype2, casting):
         a = testing.shaped_arange((3, 4), xp, dtype1)
         b = testing.shaped_arange((3, 4), xp, dtype1)

--- a/tests/cupy_tests/manipulation_tests/test_join.py
+++ b/tests/cupy_tests/manipulation_tests/test_join.py
@@ -230,7 +230,7 @@ class TestJoin:
                 xp.concatenate((a, b), out=out, dtype=xp.int64)
 
     @testing.with_requires('numpy>=1.20.0')
-    @pytest.mark.filterwarnings('error::numpy.exceptions.ComplexWarning')
+    @pytest.mark.filterwarnings('error::cupy.exceptions.ComplexWarning')
     @pytest.mark.parametrize('casting', [
         'no',
         'equiv',
@@ -240,7 +240,7 @@ class TestJoin:
     ])
     @testing.for_all_dtypes_combination(names=['dtype1', 'dtype2'])
     @testing.numpy_cupy_array_equal(
-        accept_error=(TypeError, numpy.exceptions.ComplexWarning))
+        accept_error=(TypeError, cupy.exceptions.ComplexWarning))
     def test_concatenate_casting(self, xp, dtype1, dtype2, casting):
         a = testing.shaped_arange((3, 4), xp, dtype1)
         b = testing.shaped_arange((3, 4), xp, dtype1)
@@ -308,7 +308,7 @@ class TestJoin:
     ])
     @testing.for_all_dtypes_combination(names=['dtype1', 'dtype2'])
     @testing.numpy_cupy_array_equal(
-        accept_error=(TypeError, numpy.exceptions.ComplexWarning))
+        accept_error=(TypeError, cupy.exceptions.ComplexWarning))
     def test_hstack_casting(self, xp, dtype1, dtype2, casting):
         a = testing.shaped_arange((3, 4), xp, dtype1)
         b = testing.shaped_arange((3, 4), xp, dtype1)
@@ -351,7 +351,7 @@ class TestJoin:
     ])
     @testing.for_all_dtypes_combination(names=['dtype1', 'dtype2'])
     @testing.numpy_cupy_array_equal(
-        accept_error=(TypeError, numpy.exceptions.ComplexWarning))
+        accept_error=(TypeError, cupy.exceptions.ComplexWarning))
     def test_vstack_casting(self, xp, dtype1, dtype2, casting):
         a = testing.shaped_arange((3, 4), xp, dtype1)
         b = testing.shaped_arange((3, 4), xp, dtype1)
@@ -495,7 +495,7 @@ class TestJoin:
     ])
     @testing.for_all_dtypes_combination(names=['dtype1', 'dtype2'])
     @testing.numpy_cupy_array_equal(
-        accept_error=(TypeError, numpy.exceptions.ComplexWarning))
+        accept_error=(TypeError, cupy.exceptions.ComplexWarning))
     def test_stack_casting(self, xp, dtype1, dtype2, casting):
         a = testing.shaped_arange((3, 4), xp, dtype1)
         b = testing.shaped_arange((3, 4), xp, dtype1)

--- a/tests/cupyx_tests/scipy_tests/interpolate_tests/test_bspline2.py
+++ b/tests/cupyx_tests/scipy_tests/interpolate_tests/test_bspline2.py
@@ -142,7 +142,7 @@ class TestInterp:
     @testing.numpy_cupy_allclose(scipy_name='scp', atol=1e-14)
     def test_quintic_derivs(self, xp, scp):
         k, n = 5, 7
-        x = xp.arange(n).astype(xp.float_)
+        x = xp.arange(n).astype(xp.float64)
         y = xp.sin(x)
         der_l = [(1, -12.), (2, 1)]
         der_r = [(1, 8.), (2, 3.)]

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
@@ -4,6 +4,7 @@ import pytest
 import cupy
 from cupy.cuda import runtime
 from cupy import testing
+from cupy.exceptions import AxisError
 import cupyx.scipy.ndimage  # NOQA
 
 try:
@@ -766,7 +767,7 @@ class TestInvalidAxis(FilterTestCaseBase):
         self.axis = len(self.shape)
         try:
             return self._filter(xp, scp)
-        except numpy.AxisError:
+        except AxisError:
             # numpy.AxisError is a subclass of ValueError
             # currently cupyx is raising numpy.AxisError but scipy is still
             # raising ValueError
@@ -778,7 +779,7 @@ class TestInvalidAxis(FilterTestCaseBase):
         self.axis = -len(self.shape) - 1
         try:
             return self._filter(xp, scp)
-        except numpy.AxisError:
+        except AxisError:
             raise ValueError('invalid axis')
 
 

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_fourier.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_fourier.py
@@ -3,6 +3,7 @@ import numpy
 import pytest
 
 from cupy import testing
+from cupy.exceptions import AxisError
 # TODO (grlee77): use fft instead of fftpack once min. supported scipy >= 1.4
 import cupyx.scipy.fft  # NOQA
 import cupyx.scipy.fftpack  # NOQA
@@ -384,7 +385,7 @@ class TestFourierEllipsoidInvalid():
     @testing.with_requires('scipy>=1.5.0')
     def test_0d_input(self):
         for xp, scp in zip((numpy, cupy), (scipy, cupyx.scipy)):
-            with pytest.raises(numpy.AxisError):
+            with pytest.raises(AxisError):
                 scp.ndimage.fourier_ellipsoid(xp.asarray(5.0), size=2)
         return
 
@@ -404,9 +405,9 @@ class TestFourierEllipsoidInvalid():
         # as of 1.5.4, it does not.
         shape = (6, 8)
         for xp, scp in zip((numpy, cupy), (scipy, cupyx.scipy)):
-            with pytest.raises(numpy.AxisError):
+            with pytest.raises(AxisError):
                 scp.ndimage.fourier_ellipsoid(xp.ones(shape), 2, axis=2)
-            with pytest.raises(numpy.AxisError):
+            with pytest.raises(AxisError):
                 scp.ndimage.fourier_ellipsoid(xp.ones(shape), 2, axis=-3)
         return
 


### PR DESCRIPTION
As suggested in https://github.com/cupy/cupy/issues/8306#issuecomment-2139695574: make CuPy import under numpy 2.0. 

- top-level names removed in numpy 2.0 are removed here as well. An alternative is to have, e.g. `cupy.float_` conditionally available depending on the numpy version. This feels a bit strange TBH.
- tests should pass with numpy 1.26.x 

If this is the way to go, the sequence is, I suppose:
- this PR: CuPy imports on 2.0, is inconsistent with either numpy 1.x or 2.x
- NEP50: https://github.com/cupy/cupy/pull/8323
- NEP52: https://github.com/cupy/cupy/pull/8314 (will need to be rebased on the two previous PRs)


