### PR TITLE
Re-enable NVTX range coloring for NVTX3.

### DIFF
--- a/cupy_backends/cuda/libs/nvtx.pyx
+++ b/cupy_backends/cuda/libs/nvtx.pyx
@@ -104,7 +104,7 @@ cpdef MarkC(message, uint32_t color=0):
         color (uint32): Color code for a marker.
     """
     cdef bytes b_message = message.encode()
-    if NVTX_VERSION != 1 and NVTX_VERSION != 2:
+    if NVTX_VERSION < 1:
         nvtxMarkA(<const char*>b_message)
         return
 
@@ -132,7 +132,7 @@ cpdef Mark(message, int id_color=-1):
         id_color (int): ID of color for a marker.
     """
     cdef bytes b_message = message.encode()
-    if id_color < 0 or (NVTX_VERSION != 1 and NVTX_VERSION != 2):
+    if id_color < 0 or NVTX_VERSION < 1:
         nvtxMarkA(<const char*>b_message)
         return
 
@@ -166,7 +166,7 @@ cpdef RangePushC(message, uint32_t color=0):
         color (uint32): ARGB color for a range.
     """
     cdef bytes b_message = message.encode()
-    if NVTX_VERSION != 1 and NVTX_VERSION != 2:
+    if NVTX_VERSION < 1:
         nvtxRangePushA(<const char*>b_message)
         return
 
@@ -208,7 +208,7 @@ cpdef RangePush(message, int id_color=-1):
         id_color (int): ID of color for a range.
     """
     cdef bytes b_message = message.encode()
-    if id_color < 0 or (NVTX_VERSION != 1 and NVTX_VERSION != 2):
+    if id_color < 0 or NVTX_VERSION < 1:
         nvtxRangePushA(<const char*>b_message)
         return
 


### PR DESCRIPTION
I noticed that the color option for the `cupy.cuda.nvtx.RangePush` function is not currently working. When provided an `id_color` argument, the ranges show up in Nsight Systems with a gray (default) color.

I think this issue was introduced in #7304 where NVTX was bumped to version 3. There are `NVTX_VERSION` checks in `nvtx.py` that end up routing calls to a branch that drops the color information if `NVTX_VERSION` does not equal `1` or `2`, like the following code here: https://github.com/cupy/cupy/blob/a54b7abfed668e52de7f3eee7b3fe8ccaef34874/cupy_backends/cuda/libs/nvtx.pyx#L169-L171

These version checks are very old and I am not quite sure what they are guarding, unless there was support for NVTX version prior to 1 in the past. This PR updates these version checks to only call the alternative path if `NVTX_VERSION < 1`, which fixes the coloring issue with NVTX3. 