### PR TITLE
Lazy-preload NCCL

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -10,7 +10,6 @@ from cupy import _version
 _environment._detect_duplicate_installation()  # NOQA
 _environment._setup_win32_dll_directory()  # NOQA
 _environment._preload_library('cutensor')  # NOQA
-_environment._preload_library('nccl')  # NOQA
 
 
 try:

--- a/cupy/cuda/nccl.py
+++ b/cupy/cuda/nccl.py
@@ -4,11 +4,14 @@ NCCL Wrapper
 Use `cupy_backends.cuda.libs.nccl` directly in CuPy codebase.
 """
 
+from cupy import _environment
+
+
 available = True
 
 try:
+    _environment._preload_library('nccl')
     from cupy_backends.cuda.libs.nccl import *  # NOQA
 except ImportError as e:
     available = False
-    from cupy._environment import _preload_warning
-    _preload_warning('nccl', e)
+    _environment._preload_warning('nccl', e)

--- a/cupyx/_runtime.py
+++ b/cupyx/_runtime.py
@@ -187,6 +187,13 @@ class _RuntimeInfo:
             pass
 
         # NCCL
+        if cupy._environment._can_attempt_preload('nccl'):
+            if full:
+                cupy._environment._preload_library('nccl')
+            else:
+                self.nccl_build_version = (
+                    '(not loaded; try `import cupy.cuda.nccl` first)')
+                self.nccl_runtime_version = self.nccl_build_version
         try:
             import cupy_backends.cuda.libs.nccl as nccl
             self.nccl_build_version = nccl.get_build_version()


### PR DESCRIPTION
Closes #8354 (part of #5641)

This PR changes CuPy to load NCCL shared library at the time of `import cupy.cuda.nccl` (which also runs when `import cupyx.distributed`), instead of `import cupy`.

xref: #5677 (which implements lazy-preload of cuDNN)

NCCL compatibility among the ecosystem libraries is becoming important now that everyone is using NCCL for large-scale model training with complicated mixed-library environments :)