### PR TITLE
Delaunay: Prevent checking neighboring triangles if nTri <= 1

### DIFF
--- a/cupyx/scipy/spatial/delaunay_2d/_kernels.py
+++ b/cupyx/scipy/spatial/delaunay_2d/_kernels.py
@@ -2895,7 +2895,7 @@ RealType*           coords
             }
         }
 
-        if(!isInTri) {
+        if(!isInTri && nTri > 1) {
             // Find the nearest opposite triangle to the query point from
             // the nearest center found.
             TriOpp nearest = triOpp[encIdx[startingPos]];
@@ -2954,7 +2954,6 @@ RealType*           coords
                 off++;
             }
         }
-
 
         /**if(debug != NULL) {
             debug[3 * idx] = pos;


### PR DESCRIPTION
See https://github.com/cupy/cupy/pull/8290#issuecomment-2146687693

This PR ensures that `kerFindClosestTri` doesn't segfault when the number of triangles in the grid is one.